### PR TITLE
libs/c-ares: Port from old packages, and update

### DIFF
--- a/libs/c-ares/Makefile
+++ b/libs/c-ares/Makefile
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2009-2010 OpenWrt.org
+# Copyright (C) 2009 Jakob Pfeiffer
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=c-ares
+PKG_VERSION:=1.10.0
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://c-ares.haxx.se/download
+PKG_MD5SUM:=1196067641411a75d3cbebe074fd36d8
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libcares
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Library for asyncronous DNS Requests (including name resolves)
+  URL:=http://c-ares.haxx.se/
+  MAINTAINER:=Karl Palsson <karlp@remake.is>
+endef
+
+define Package/libcares/description
+  c-ares is a C library for asynchronous DNS requests (including name resolves)
+
+C89 compatibility, MIT licensed, builds for and runs on POSIX, Windows,
+Netware, Android and many more operating systems.
+
+endef
+
+define Package/libcares/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so.* $(1)/usr/lib/
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)
+	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
+endef
+
+$(eval $(call BuildPackage,libcares))


### PR DESCRIPTION
libcares is a dependency of mosquitto, at least.

Imported existing packages makefile, updated from 1.7.4 to 1.10.0
Added License and Maintainer information

Signed-off-by: Karl Palsson karlp@remake.is
