### PR TITLE
tgt: iSCSI target support

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2012-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tgt
+PKG_VERSION:=1.0.46
+PKG_REV:=601a44d6c833f59d9d2472ad11d421481a25b2e7
+PKG_RELEASE:=2
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/fujita/tgt.git
+
+PKG_SOURCE_VERSION:=$(PKG_REV)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_REV).tar.gz
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/tgt
+  SECTION:=net
+  CATEGORY:=Network
+  URL:=http://stgt.sourceforge.net/
+  TITLE:=userspace iSCSI target
+  DEPENDS:=+libpthread +libaio +@KERNEL_AIO +@KERNEL_DIRECT_IO
+endef
+
+define Package/tgt/description
+Linux SCSI target framework (tgt) aims to simplify various SCSI target driver (iSCSI, Fibre Channel, SRP, etc) creation and maintenance.
+Key goals of the project are the clean integration into the scsi-mid layer and implementing a great portion of tgt in user space.
+Tgt consists of kernel-space and user-space code. The kernel-space component is included in upstream as of 2.6.20.
+Note that if you are interested in only iSCSI (probably you are), you need only the user-space code (any kernel version is fine).
+endef
+
+define Build/Compile
+	CC=$(TARGET_CC) CFLAGS="$(TARGET_CFLAGS)" $(MAKE) -C $(PKG_BUILD_DIR) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		LD="$(TARGET_CC)" \
+		install-programs
+endef
+
+define Package/tgt/conffiles
+/etc/config/tgt
+endef
+
+define Package/tgt/install
+	$(INSTALL_DIR) $(1)/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) ./files/* $(1)/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/tgtd $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/tgtadm $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,tgt))

--- a/net/tgt/files/etc/config/tgt
+++ b/net/tgt/files/etc/config/tgt
@@ -1,0 +1,38 @@
+config target 1
+	option name 'iqn.2012-06.org.openwrt:target1'
+	option allow ALL
+
+#config target 2
+#	option name 'iqn.2012-06.org.openwrt:t2'
+#	option allow 192.168.1.0/24
+
+
+# all options are set to default, except for the device
+# for all type and bstype values see tgtd(8)
+# lun "name" is constructed as TGTID_LUN
+#config lun                        1_1
+#	option readonly 0
+#	option device /dev/sda
+#	option type disk
+#	option bstype rdwr
+#	option sync 0
+#	option direct 0
+
+
+#config lun 2_1
+#	option readonly 0
+#	option device /mnt/iscsi.img
+
+#config lun 2_2
+#	option device /dev/sdc
+
+#config account
+#	option target 1
+#	option user "username1"
+#	option password "pass1"
+
+#config account
+#	option target 2
+#	option user "user2"
+#	option password "pwd2"
+#	option outgoing 1

--- a/net/tgt/files/etc/init.d/tgt
+++ b/net/tgt/files/etc/init.d/tgt
@@ -1,0 +1,107 @@
+#!/bin/sh /etc/rc.common
+START=91
+STOP=10
+
+EXTRA_COMMANDS="show"
+EXTRA_HELP="	show	Show current configuration of tgtd"
+
+NAME=tgt
+PROG=/usr/sbin/tgtd
+USE_PROCD=1
+
+tgtadm="/usr/sbin/tgtadm --lld iscsi"
+
+handle_lun() {
+	local tgt_lun=$1
+	local tgtid=$2
+	local ro device type bstype sync direct
+	local my_tgtid=${tgt_lun%_*}
+	local lun=${tgt_lun#*_}
+	[ $my_tgtid -eq $tgtid ] || return 0
+
+	config_get device $1 device ""
+	[ "$device" ] || return 1
+
+	config_get type $1 type disk
+	config_get bstype $1 bstype rdwr
+	config_get_bool readonly $1 readonly 0
+	config_get_bool sync $1 sync 0
+	config_get_bool direct $1 direct 0
+	if [ $sync -ne 0 -o $direct -ne 0 ]; then
+		local bsoflags
+		[ $sync -ne 0 ] && bsoflags="sync"
+		[ $direct -ne 0 ] && bsoflags="direct"
+		[ $sync -ne 0 -a $direct -ne 0 ] && bsoflags="sync:direct"
+		bsoflags="--bsoflags $bsoflags"
+	fi
+
+	local _tgtadm="$tgtadm --mode logicalunit --tid $tgtid --lun $lun"
+	$_tgtadm --op new --backing-store $device --device-type $type --bstype $bstype --bstype $bstype $bsoflags || return 1
+	$_tgtadm --op update --param readonly=$readonly || return 1
+}
+
+handle_account() {
+	local tgtid=$2
+	local _tgtadm="$tgtadm --mode account"
+	local target user password outgoing
+
+	config_get target $1 target ""
+	[ "$target" ] || return 1
+	[ $target -eq $tgtid ] || return 0
+
+	config_get user $1 user ""
+	[ "$user" ] || return 1
+
+	config_get password $1 password ""
+	config_get_bool outgoing $1 outgoing 0
+	[ "$outgoing" -ne 0 ] && outgoing=--outgoing || outgoing=""
+
+	$_tgtadm --op new --user "$user" --password "$password" || return 1
+	$_tgtadm --op bind --tid $tgtid --user "$user" $outgoing || return 1
+}
+
+handle_target() {
+	local tgtid=$1
+	local tgtname allow
+	local _tgtadm="$tgtadm --mode target"
+
+	[ $tgtid -ge 0 ] || return 1
+
+	config_get tgtname $1 name iqn.2012-06.org.openwrt
+	config_get allow $1 allow ALL
+
+	$_tgtadm --op new --tid $tgtid --targetname $tgtname || return 1
+	$_tgtadm --op bind --tid $tgtid -I $allow || return 1
+
+	config_foreach handle_lun lun $tgtid || return 1
+	config_foreach handle_account account $tgtid || return 1
+}
+
+configure() {
+	config_load $NAME
+	$tgtadm --mode sys --op update --name State -v offline || return 1
+	config_foreach handle_target target || return 1
+	$tgtadm --mode sys --op update --name State -v ready || return 1
+	return 0
+}
+
+start_service() {
+	procd_open_instance
+	procd_set_param command $PROG -f
+	procd_set_param respawn
+	procd_close_instance
+	logger -t $NAME -s "Configuration will be loaded in seconds"
+	( sleep 5; configure || { stop_service; exit 1; } ) &
+}
+
+stop_service() {
+	$tgtadm --mode sys --op update --name State -v offline
+	$tgtadm --mode target  --op show \
+		| awk  '$1 == "Target" {sub(/:/,"",$2); print $2}' \
+		| xargs -n1 $tgtadm --mode target --op delete --force --tid
+	$tgtadm --mode sys --op delete
+}
+
+show() {
+	$tgtadm --mode target --op show
+}

--- a/net/tgt/patches/010-fallocate.patch
+++ b/net/tgt/patches/010-fallocate.patch
@@ -1,0 +1,14 @@
+--- tgt-1.0.42/usr/util.h.orig	2013-12-26 16:18:54.000000000 +0200
++++ tgt-1.0.42/usr/util.h	2013-12-26 16:19:10.000000000 +0200
+@@ -212,11 +212,6 @@
+  */
+ static inline int unmap_file_region(int fd, off_t offset, off_t length)
+ {
+-#ifdef FALLOC_FL_PUNCH_HOLE
+-	if (fallocate(fd, FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE,
+-			offset, length) == 0)
+-		return 0;
+-#endif
+ 	return -1;
+ }
+ 

--- a/net/tgt/patches/020-usr_Makefile.patch
+++ b/net/tgt/patches/020-usr_Makefile.patch
@@ -1,0 +1,56 @@
+--- tgt-1.0.46.orig/usr/Makefile	2014-04-06 09:55:49.000000000 +0300
++++ tgt-1.0.46/usr/Makefile	2014-04-06 09:57:04.000000000 +0300
+@@ -1,13 +1,13 @@
+ sbindir ?= $(PREFIX)/sbin
+ libdir ?= $(PREFIX)/lib/tgt
+ 
+-ifneq ($(shell test -e /usr/include/linux/signalfd.h && echo 1),)
++#ifneq ($(shell test -e /usr/include/linux/signalfd.h && echo 1),)
+ CFLAGS += -DUSE_SIGNALFD
+-endif
++#endif
+ 
+-ifneq ($(shell test -e /usr/include/sys/timerfd.h && echo 1),)
++#ifneq ($(shell test -e /usr/include/sys/timerfd.h && echo 1),)
+ CFLAGS += -DUSE_TIMERFD
+-endif
++#endif
+ 
+ TGTD_OBJS += $(addprefix iscsi/, conn.o param.o session.o \
+ 		iscsid.o target.o chap.o sha1.o md5.o transport.o iscsi_tcp.o \
+@@ -21,8 +21,9 @@
+ MODULES += bs_glfs.so
+ endif
+ 
+-ifneq ($(shell test -e /usr/include/sys/eventfd.h && test -e /usr/include/libaio.h && echo 1),)
+-CFLAGS += -DUSE_EVENTFD
++#ifneq ($(shell test -e /usr/include/sys/eventfd.h && test -e $(STAGING_DIR)/usr/include/libaio.h && echo 1),)
++ifneq ((test -e $(STAGING_DIR)/usr/include/libaio.h && echo 1),)
++CFLAGS += -DUSE_EVENTFD -I$(STAGING_DIR)/usr/include/
+ TGTD_OBJS += bs_aio.o
+ LIBS += -laio
+ endif
+@@ -47,7 +48,7 @@
+ 
+ LIBS += -lpthread -ldl
+ 
+-PROGRAMS += tgtd tgtadm tgtimg
++PROGRAMS += tgtd tgtadm
+ TGTD_OBJS += tgtd.o mgmt.o target.o scsi.o log.o driver.o util.o work.o \
+ 		concat_buf.o parser.o spc.o sbc.o mmc.o osd.o scc.o smc.o \
+ 		ssc.o libssc.o bs_rdwr.o bs_ssc.o \
+@@ -74,14 +75,8 @@
+ 
+ -include $(TGTADM_DEP)
+ 
+-TGTIMG_OBJS = tgtimg.o libssc.o libcrc32c.o
+ TGTIMG_DEP = $(TGTIMG_OBJS:.o=.d)
+ 
+-tgtimg: $(TGTIMG_OBJS)
+-	$(CC) $^ -o $@
+-
+--include $(TGTIMG_DEP)
+-
+ %.o: %.c
+ 	$(CC) -c $(CFLAGS) $*.c -o $*.o
+ 	@$(CC) -MM $(CFLAGS) -MF $*.d -MT $*.o $*.c

--- a/net/tgt/patches/030-Makefile.patch
+++ b/net/tgt/patches/030-Makefile.patch
@@ -1,0 +1,11 @@
+--- tgt-1.0.46.orig/Makefile	2014-04-06 09:55:49.000000000 +0300
++++ tgt-1.0.46/Makefile	2014-04-06 09:57:04.000000000 +0300
+@@ -63,7 +63,7 @@
+ 	$(MAKE) -C conf clean
+ 
+ .PHONY: install
+-install: install-programs install-doc install-conf install-scripts
++install: install-programs
+ 
+ .PHONY: rpm
+ rpm:


### PR DESCRIPTION
This is a port from old packages repo with the following improvements:
- allow to select multiple addresses and ports to listent to
- support both address- and name-based ACLs
  (note: config option has been changed from "allow" to "allow_address", "allow_name")
- support more optionf for LUNs
- support various device types (disk, cd, sg passthrough)
- bind accounts to multiple targets
- use uci_validate_section in the init script
- improve error reporting, use logger instead of echo
- set number of IO threads to 2 by default (affects memory footprint)
- configure keepalive
- update to 1.0.48

Signed-off-by: Maxim Storchak m.storchak@gmail.com
