### PR TITLE
Add fwknop to packages feed at most recently released version

### DIFF
--- a/net/fwknop/Makefile
+++ b/net/fwknop/Makefile
@@ -1,0 +1,118 @@
+#
+# Copyright (C) 2011-2012 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fwknop
+PKG_VERSION:=2.6.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=http://www.cipherdyne.org/fwknop/download
+PKG_MD5SUM:=4c68128297f76ee536a446fcdd496435
+PKG_MAINTAINER:=Jonathan Bennett <JBennett@incomsystems.biz>
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/fwknop/Default
+  TITLE:=FireWall KNock OPerator
+  URL:=http://www.cipherdyne.org/fwknop/
+endef
+
+define Package/fwknop/Default/description
+  Fwknop implements an authorization scheme known as Single Packet Authorization
+  (SPA) for Linux systems running iptables.  This mechanism requires only a
+  single encrypted and non-replayed packet to communicate various pieces of
+  information including desired access through an iptables policy. The main
+  application of this program is to use iptables in a default-drop stance to
+  protect services such as SSH with an additional layer of security in order to
+  make the exploitation of vulnerabilities (both 0-day and unpatched code) much
+  more difficult.
+endef
+
+define Package/fwknopd
+  $(call Package/fwknop/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Firewall
+  TITLE+= Daemon
+  DEPENDS:=+iptables +libfko +libpcap
+endef
+
+define Package/fwknopd/description
+  $(call Package/fwknop/Default/description)
+  This package contains the fwknop daemon.
+endef
+
+define Package/fwknopd/conffiles
+/etc/fwknop/access.conf
+/etc/fwknop/fwknopd.conf
+endef
+
+define Package/fwknop
+  $(call Package/fwknop/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Firewall
+  TITLE+= Client
+  DEPENDS:=+libfko
+endef
+
+define Package/fwknop/description
+  $(call Package/fwknop/Default/description)
+  This package contains the fwknop client.
+endef
+
+define Package/libfko
+  $(call Package/fwknop/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  SUBMENU:=Firewall
+  TITLE+= Library
+endef
+
+define Package/libfko/description
+  $(call Package/fwknop/Default/description)
+  This package contains the libfko shared library.
+endef
+
+CONFIGURE_ARGS += \
+	--without-gpgme \
+	--with-iptables=/usr/sbin/iptables
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/fko.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfko.{a,la,so*} $(1)/usr/lib/
+endef
+
+define Package/fwknopd/install
+	$(INSTALL_DIR) $(1)/etc/fwknop
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/fwknop/{access,fwknopd}.conf \
+		$(1)/etc/fwknop/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/extras/fwknop.init.openwrt \
+		$(1)/etc/init.d/fwknopd
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/fwknopd $(1)/usr/sbin/
+endef
+
+define Package/fwknop/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fwknop $(1)/usr/bin/
+endef
+
+define Package/libfko/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfko.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,fwknopd))
+$(eval $(call BuildPackage,fwknop))
+$(eval $(call BuildPackage,libfko))

--- a/net/fwknop/patches/001-fix_config.patch
+++ b/net/fwknop/patches/001-fix_config.patch
@@ -1,0 +1,18 @@
+--- a/server/fwknopd.conf.inst
++++ b/server/fwknopd.conf.inst
+@@ -284,8 +284,13 @@
+ # The IPT_FORWARD_ACCESS variable is only used if ENABLE_IPT_FORWARDING is
+ # enabled.
+ #
+-#IPT_FORWARD_ACCESS      ACCEPT, filter, FORWARD, 1, FWKNOP_FORWARD, 1;
+-#IPT_DNAT_ACCESS         DNAT, nat, PREROUTING, 1, FWKNOP_PREROUTING, 1;
++
++# These two lines are changed specifically for Openwrt, due to
++# different naming conventions. IPT_FORWARD is still disabled
++# by default, and must be enabled earlier in this file to be used.
++
++IPT_FORWARD_ACCESS      ACCEPT, filter, zone_wan_forward, 1, FWKNOP_FORWARD, 1;
++IPT_DNAT_ACCESS         DNAT, nat, zone_wan_prerouting, 1, FWKNOP_PREROUTING, 1;
+ 
+ # The IPT_SNAT_ACCESS variable is not used unless both ENABLE_IPT_SNAT and
+ # ENABLE_IPT_FORWARDING are enabled.  Also, the external static IP must be

--- a/net/fwknop/patches/002-fix_init.patch
+++ b/net/fwknop/patches/002-fix_init.patch
@@ -1,0 +1,17 @@
+--- a/extras/openwrt/package/fwknop/files/fwknopd.init
++++ b/extras/openwrt/package/fwknop/files/fwknopd.init
+@@ -11,12 +11,12 @@ FWKNOPD_BIN=/usr/sbin/fwknopd
+ 
+ start()
+ {
+-	$FWKNOPD_BIN
++	service_start $FWKNOPD_BIN
+ }
+ 
+ stop()
+ {
+-	$FWKNOPD_BIN -K
++	service_stop $FWKNOPD_BIN -K
+ }
+ 
+ restart()


### PR DESCRIPTION
I've updated the version to 2.6.2 and removed a an unnecessary config change from one of the patches. 
