### PR TITLE
    Add nano to packages, update to newest unstable, add myself as maintainer

### DIFF
--- a/utils/nano/Makefile
+++ b/utils/nano/Makefile
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2007-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nano
+PKG_VERSION:=2.3.4
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.nano-editor.org/dist/v2.3
+PKG_MD5SUM:=9cd0a974c7edfdf0f4cb92d1f79d6510
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/nano
+  SUBMENU:=Editors
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=An enhanced clone of the Pico text editor
+  URL:=http://www.nano-editor.org/
+  MAINTAINER:=Jonathan Bennett <JBennett@incomsystems.biz>
+  DEPENDS:=+libncurses
+endef
+
+define Package/nano/description
+  GNU nano (Nano's ANOther editor, or Not ANOther editor) is an enhanced clone
+  of the Pico text editor.
+endef
+
+CONFIGURE_ARGS += \
+	--enable-tiny \
+	--disable-glibtest \
+	--disable-utf8 \
+        --without-slang \
+        --disable-color \
+
+CONFIGURE_VARS += \
+	ac_cv_header_regex_h=no \
+
+define Package/nano/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/$(PKG_NAME) $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,nano))
+


### PR DESCRIPTION
There is one quirk that I've found. When SSHing from my Fedora box, the TERM variable is set to "xterm-256color", and that term is not installed by ncurses. I don't think this is a nano bug, and I'm about to submit a patch to the main project to include that terminfo file with ncurses.

Also, this updates nano to the latest unstable release as the latest "stable" version is years and years old.
