### PR TITLE
utils/zip: fix broken build by adding missing libbz2 dependency

### DIFF
--- a/utils/zip/Makefile
+++ b/utils/zip/Makefile
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/zip
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=
+  DEPENDS:=libbz2
   TITLE:=Archiver for .zip files
   URL:=http://infozip.sourceforge.net/Zip.html
   SUBMENU:=Compression


### PR DESCRIPTION
Signed-off-by: Russell Senior russell@personaltelco.net
