### PR TITLE
net/ocserv: fix broken build by adding missing libnl dependency

### DIFF
--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -33,7 +33,7 @@ define Package/ocserv
   TITLE:=OpenConnect VPN server
   URL:=http://www.infradead.org/ocserv/
   MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
-  DEPENDS:= +libgnutls +certtool +libncurses +libreadline +OCSERV_PAM:libpam +OCSERV_PROTOBUF:libprotobuf-c
+  DEPENDS:= +libgnutls +certtool +libncurses +libreadline +OCSERV_PAM:libpam +OCSERV_PROTOBUF:libprotobuf-c +libnl
 endef
 
 define Package/ocserv/description


### PR DESCRIPTION
Signed-off-by: Russell Senior russell@personaltelco.net
