### PR TITLE
nettle: enable mini-gmp by default to save space

### DIFF
--- a/libs/nettle/Config.in
+++ b/libs/nettle/Config.in
@@ -5,5 +5,6 @@ menu "Configuration"
 
 config LIBNETTLE_MINI
 	bool "use mini-gmp instead of gmp; the library will be much smaller at a 10x performance penalty. Note that this option may have side effects to programs that link to both nettle and gmp."
+	default y
 
 endmenu


### PR DESCRIPTION
Signed-off-by: Steven Barth steven@midlink.org
