### PR TITLE
openssh: strip openssh-sftp-server dependencies, notably openssl

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -121,6 +121,7 @@ endef
 define Package/openssh-sftp-server
 	$(call Package/openssh/Default)
 	TITLE+= SFTP server
+	DEPENDS:=
 endef
 
 define Package/openssh-sftp-server/description


### PR DESCRIPTION
openssh-sftp-server is actually a tiny binary that has nearly no dependencies:

```
$ mips-openwrt-linux-objdump -x sftp-server | grep NEEDED
  NEEDED               libgcc_s.so.1
  NEEDED               libc.so.0
```

Stripping its DEPENDS allows building a system with SFTP support, without
pulling in OpenSSL.
