### PR TITLE
haproxy: add upstream bugfix, adapt Copyright

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2010-2013 OpenWrt.org
-# Copyright (C) 2009-2013 Thomas Heil <heil@terminal-consulting.de>
+# Copyright (C) 2009-2014 Thomas Heil <heil@terminal-consulting.de>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
 PKG_VERSION:=1.5.0
-PKG_RELEASE:=00
+PKG_RELEASE:=01
 PKG_SOURCE:=haproxy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://haproxy.1wt.eu/download/1.5/src/
 PKG_MD5SUM:=e33bb97e644e98af948090f1ecebbda9

--- a/net/haproxy/patches/0001-BUG-MEDIUM-Consistently-use-check-in-process_chk.patch
+++ b/net/haproxy/patches/0001-BUG-MEDIUM-Consistently-use-check-in-process_chk.patch
@@ -1,0 +1,31 @@
+From 9ac7cabaf9945fb92c96cb92f5ea85235f54f7d6 Mon Sep 17 00:00:00 2001
+From: Simon Horman <horms@verge.net.au>
+Date: Fri, 20 Jun 2014 12:29:47 +0900
+Subject: [PATCH] BUG/MEDIUM: Consistently use 'check' in process_chk
+
+I am not entirely sure that this is a bug, but it seems
+to me that it may cause a problem if there agent-check is
+configured and there is some kind of error making a connection for it.
+
+Signed-off-by: Simon Horman <horms@verge.net.au>
+(cherry picked from commit ccaabcdfca23851af6fd83f4f3265284d283e2ab)
+---
+ src/checks.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/checks.c b/src/checks.c
+index cba0018..f3b2b54 100644
+--- a/src/checks.c
++++ b/src/checks.c
+@@ -1541,7 +1541,7 @@ static struct task *process_chk(struct task *t)
+ 		 * First, let's check whether there was an uncaught error,
+ 		 * which can happen on connect timeout or error.
+ 		 */
+-		if (s->check.result == CHK_RES_UNKNOWN) {
++		if (check->result == CHK_RES_UNKNOWN) {
+ 			/* good connection is enough for pure TCP check */
+ 			if ((conn->flags & CO_FL_CONNECTED) && !check->type) {
+ 				if (check->use_ssl)
+-- 
+1.8.5.5
+


### PR DESCRIPTION
- [PATCH] BUG/MEDIUM: Consistently use 'check' in process_chk

Signed-off-by: Thomas Heil heil@terminal-consulting.de
