### PR TITLE
haproxy: fix target avr32,

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
 PKG_VERSION:=1.5.0
-PKG_RELEASE:=02
+PKG_RELEASE:=03
 PKG_SOURCE:=haproxy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://haproxy.1wt.eu/download/1.5/src/
 PKG_MD5SUM:=e33bb97e644e98af948090f1ecebbda9


### PR DESCRIPTION
the avr32 target uses a old accept4 implementation, so i disabled it for this patform.
