### PR TITLE
smartmontools: remove stale dependency on rsync

### DIFF
--- a/utils/smartmontools/Makefile
+++ b/utils/smartmontools/Makefile
@@ -41,7 +41,6 @@ endef
 
 define Package/smartd
   $(call Package/smartmontools/Default)
-  DEPENDS+= +rsync
   TITLE+= Daemon
 endef
 


### PR DESCRIPTION
rsync is in no way related to smartmontools. Additionally rsync
is missing in the new github repo.

Signed-off-by: Stefan Hellermann stefan@the2masters.de
