### PR TITLE
memcached: import from packages, add myself as the maintainer

### DIFF
--- a/net/memcached/Makefile
+++ b/net/memcached/Makefile
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2009-2012 OpenWrt.org
+# Copyright (C) 2009-2014 Thomas Heil <heil@terminal-consulting.de>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=memcached
+PKG_VERSION:=1.4.20
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://memcached.org/files
+PKG_MD5SUM:=92f702bcb28d7bec8fdf9418360fc062
+PKG_INSTALL:=1
+PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
+PKG_LICENSE:=permissive free software license
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/memcached
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libevent +libpthread
+  TITLE:=The high-performance, distributed memory object caching system
+  URL:=http://memcached.org/
+endef
+
+define Package/memcached/description
+  Free and open source, high-performance, distributed memory object caching system
+endef
+
+define Package/memcached/conffiles
+/etc/config/memcached
+endef
+
+ifeq ($(CONFIG_BIG_ENDIAN),y)
+CONFIGURE_VARS += ac_cv_c_endian=big
+else
+CONFIGURE_VARS += ac_cv_c_endian=little
+endif
+
+CONFIGURE_ARGS += \
+	--with-libevent=$(STAGING_DIR)/usr/include/libevent \
+	--disable-docs \
+	--disable-dtrace \
+	--disable-coverage \
+	--disable-sasl
+
+TARGET_CFLAGS += \
+	-std=gnu99
+
+TARGET_LDFLAGS = \
+	-L$(STAGING_DIR)/usr/lib/libevent -L$(STAGING_DIR)/usr/lib -L$(STAGING_DIR)/lib
+
+define Package/memcached/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/memcached $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/memcached.config $(1)/etc/config/memcached
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/memcached.init $(1)/etc/init.d/memcached
+endef
+
+$(eval $(call BuildPackage,memcached))

--- a/net/memcached/files/memcached.config
+++ b/net/memcached/files/memcached.config
@@ -1,0 +1,6 @@
+config memcached
+	option user 'nobody'
+	option maxconn '1024'
+	option listen '0.0.0.0'
+	option port '11211'
+	option memory '64'

--- a/net/memcached/files/memcached.init
+++ b/net/memcached/files/memcached.init
@@ -1,0 +1,27 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2010-2011 OpenWrt.org
+
+START=80
+
+start_instance () {
+	local section="$1"
+
+	config_get user "$section" user
+	config_get maxconn "$section" maxconn
+	config_get listen "$section" listen
+	config_get port "$section" port
+	config_get memory "$section" memory
+
+	service_start /usr/bin/memcached -d -u ${user:-nobody} \
+		-c ${maxconn:-1024} -l ${listen:-0.0.0.0} \
+		-p ${port:-11211} -U ${port:-11211} -m ${memory:-64}
+}
+
+start() {
+	config_load 'memcached'
+	config_foreach start_instance 'memcached'
+}
+
+stop() {
+	service_stop /usr/bin/memcached
+}

--- a/net/memcached/patches/100-fix_iov_max.patch
+++ b/net/memcached/patches/100-fix_iov_max.patch
@@ -1,0 +1,23 @@
+--- a/memcached.c
++++ b/memcached.c
+@@ -13,6 +13,10 @@
+  *      Anatoly Vorobey <mellon@pobox.com>
+  *      Brad Fitzpatrick <brad@danga.com>
+  */
++#ifndef __need_IOV_MAX
++#define __need_IOV_MAX
++#endif
++
+ #include "memcached.h"
+ #include <sys/stat.h>
+ #include <sys/socket.h>
+@@ -29,9 +33,6 @@
+ #define _P1003_1B_VISIBLE
+ #endif
+ /* need this to get IOV_MAX on some platforms. */
+-#ifndef __need_IOV_MAX
+-#define __need_IOV_MAX
+-#endif
+ #include <pwd.h>
+ #include <sys/mman.h>
+ #include <fcntl.h>


### PR DESCRIPTION
This adds the memcached package from the old svn package fee. I adopt
the licensing information and will maintain the package in the future.
This request also updates memcached to the last stable version 1.4.20.
Building was tested with target x86_64, ar71xx and avr32

Signed-off-by: Thomas Heil heil@terminal-consulting.de
