### PR TITLE
crtmpserver: import from packages, add myself as the maintainer

### DIFF
--- a/multimedia/crtmpserver/Makefile
+++ b/multimedia/crtmpserver/Makefile
@@ -1,0 +1,95 @@
+# 
+# Copyright (C) 2010 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=crtmpserver
+PKG_REV:=811
+PKG_VERSION:=r$(PKG_REV)
+PKG_RELEASE:=1
+PKG_BUILD_PARALLEL:=2
+PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
+PKG_LICENSE:=GPL-3.0
+
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=--username=anonymous --password= https://svn.rtmpd.com/crtmpserver/branches/1.0
+PKG_SOURCE_SUBDIR:=crtmpserver-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=$(PKG_REV)
+PKG_SOURCE_PROTO:=svn
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/crtmpserver
+  SECTION:=multimedia
+  CATEGORY:=Multimedia
+  DEPENDS:=+libopenssl +libstdcpp +liblua
+  TITLE:=C++ RTMP Server
+  URL:=http://www.rtmpd.com/
+endef
+
+define Package/crtmpserver/description
+C++ RTMP Server it is a high performance streaming server able to
+stream (live or recorded) in the following technologies:
+ * To and from Flash (RTMP,RTMPE, RTMPS, RTMPT, RTMPTE)
+ * To and from embedded devices: iPhone, Android
+ * From surveillance cameras
+ * IP-TV using MPEG-TS and RTSP/RTCP/RTP protocols
+                
+Also, crtmpserver can be used as a high performance rendes-vous
+server. For example, it enables you to do:
+ * Audio/Video conferencing
+ * Online gaming
+ * Online collaboration
+ * Simple/complex chat applications
+endef
+
+define Package/crtmpserver/conffiles
+/etc/crtmpserver.lua
+endef
+
+# XXX: this hack handles the usr/bin vs bin difference of backfire and trunk
+TS_BASE:=$(wildcard $(TOOLCHAIN_DIR)/bin/$(TARGET_CC))
+TS_BASE:=$(dir $(if $(TS_BASE),$(TS_BASE),$(wildcard $(TOOLCHAIN_DIR)/usr/bin/$(TARGET_CC))))
+
+define Build/Configure
+	(cd $(PKG_BUILD_DIR)/builders/make; \
+		cp linux.mk linux-openwrt-uclibc.mk; \
+		$(SED) 's,^TOOLCHAIN_BASE[[:space:]]*=.*,TOOLCHAIN_BASE=$(TS_BASE),' \
+			-e 's,^TOOLCHAIN_PREFIX[[:space:]]*=.*,TOOLCHAIN_PREFIX=$(TARGET_CROSS),' \
+			-e 's,^CCOMPILER[[:space:]]*=.*,CCOMPILER=$(TARGET_CC),' \
+			-e 's,^CXXCOMPILER[[:space:]]*=.*,CXXCOMPILER=$(TARGET_CXX),' \
+			-e 's,^OPTIMIZATIONS[[:space:]]*=.*,OPTIMIZATIONS=-O2,' \
+			-e 's,^SSL_BASE[[:space:]]*=.*,SSL_BASE=$(STAGING_DIR)/usr,' \
+			linux-openwrt-uclibc.mk)
+endef
+
+define Build/Compile
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/builders/make \
+		PLATFORM=linux-openwrt-uclibc -Wno-error -j6
+endef
+
+define Package/crtmpserver/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/builders/make/output/dynamic/crtmpserver $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/lib/crtmpserver
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/builders/make/output/dynamic/*.so $(1)/usr/lib/crtmpserver/
+	$(foreach app,flvplayback samplefactory admin stresstest appselector vptests applestreamingclient proxypublish, \
+		$(INSTALL_DIR) $(1)/usr/lib/crtmpserver/$(app); \
+		$(INSTALL_BIN) $(PKG_BUILD_DIR)/builders/make/output/dynamic/applications/$(app)/lib$(app).so \
+			$(1)/usr/lib/crtmpserver/$(app)/; \
+	)
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/builders/make/output/dynamic/crtmpserver.lua $(1)/etc/
+	$(INSTALL_DIR) $(1)/usr/share/crtmpserver/appselector
+	$(INSTALL_DIR) $(1)/usr/share/crtmpserver/media
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/crtmpserver.init $(1)/etc/init.d/crtmpserver
+endef
+
+$(eval $(call BuildPackage,crtmpserver))
+

--- a/multimedia/crtmpserver/files/crtmpserver.init
+++ b/multimedia/crtmpserver/files/crtmpserver.init
@@ -1,0 +1,30 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2009-2010 OpenWrt.org
+
+START=99
+STOP=80
+
+SERVICE_USE_PID=1
+
+CRTMPSERVER_BIN="/usr/bin/crtmpserver"
+CRTMPSERVER_CONFIG="/etc/crtmpserver.lua"
+CRTMPSERVER_PID="/var/run/crtmpserver.pid"
+
+start()
+{
+        echo "start $CRTMPSERVER_BIN"
+        start-stop-daemon -S -x "$CRTMPSERVER_BIN" -- --daemon --pid="$CRTMPSERVER_PID" \
+                "$CRTMPSERVER_CONFIG"
+}
+stop() {
+
+        echo "stop $CRTMPSERVER_BIN"
+        start-stop-daemon  -K -x $CRTMPSERVER_BIN -p $CRTMPSERVER_PID
+}
+
+reload()
+{
+        stop
+        start
+}
+

--- a/multimedia/crtmpserver/patches/010-link-crypt-for-lua.patch
+++ b/multimedia/crtmpserver/patches/010-link-crypt-for-lua.patch
@@ -1,0 +1,11 @@
+--- a/builders/make/compile.mk
++++ b/builders/make/compile.mk
+@@ -67,7 +67,7 @@ TINYXML_OBJS = $(TINYXML_SRCS:.cpp=.tiny
+ 
+ #common
+ COMMON_INCLUDE=$(LUA_INCLUDE) $(TINYXML_INCLUDE) $(SSL_INCLUDE) -I$(PROJECT_BASE_PATH)/sources/common/include
+-COMMON_LIBS=$(SSL_LIB) -L$(OUTPUT_DYNAMIC) -llua -ltinyxml
++COMMON_LIBS=$(SSL_LIB) -L$(OUTPUT_DYNAMIC) -llua -ltinyxml -lcrypt
+ COMMON_SRCS = $(shell find $(PROJECT_BASE_PATH)/sources/common/src -type f -name "*.cpp")
+ COMMON_OBJS = $(COMMON_SRCS:.cpp=.common.o)
+ 

--- a/multimedia/crtmpserver/patches/020-add-rpath.patch
+++ b/multimedia/crtmpserver/patches/020-add-rpath.patch
@@ -1,0 +1,13 @@
+--- a/builders/make/linux.mk
++++ b/builders/make/linux.mk
+@@ -31,8 +31,8 @@ OPTIMIZATIONS = -O3
+ COMPILE_FLAGS = $(FPIC) $(OPTIMIZATIONS) $(CFLAGS)
+ 
+ #linking flags
+-dynamic_lib_flags = $(FPIC) $(OPTIMIZATIONS) -Wl,-soname,$(DYNAMIC_LIB_PREFIX)$(1)$(DYNAMIC_LIB_SUFIX) -Wl,-rpath,"\$$ORIGIN"
+-dynamic_exec_flags = $(FPIC) $(OPTIMIZATIONS) -Wl,-rpath,"\$$ORIGIN"
++dynamic_lib_flags = $(FPIC) $(OPTIMIZATIONS) -Wl,-soname,$(DYNAMIC_LIB_PREFIX)$(1)$(DYNAMIC_LIB_SUFIX) -Wl,-rpath,/usr/lib/crtmpserver
++dynamic_exec_flags = $(FPIC) $(OPTIMIZATIONS) -Wl,-rpath,/usr/lib/crtmpserver
+ 
+ #compile switches
+ PLATFORM_DEFINES = \

--- a/multimedia/crtmpserver/patches/030-default-config.patch
+++ b/multimedia/crtmpserver/patches/030-default-config.patch
@@ -1,0 +1,60 @@
+--- a/builders/cmake/crtmpserver/crtmpserver.lua
++++ b/builders/cmake/crtmpserver/crtmpserver.lua
+@@ -4,7 +4,7 @@ configuration=
+ {
+ 	-- if true, the server will run as a daemon.
+ 	-- NOTE: all console appenders will be ignored if this is a daemon
+-	daemon=false,
++	daemon=true,
+ 	-- the OS's path separator. Used in composing paths
+ 	pathSeparator="/",
+ 
+@@ -44,7 +44,7 @@ configuration=
+ 	{
+ 		-- this is the root directory of all applications
+ 		-- usually this is relative to the binary execuable
+-		rootDirectory="applications",
++		rootDirectory="/usr/lib/crtmpserver",
+ 		
+ 		
+ 		--this is where the applications array starts
+@@ -68,7 +68,7 @@ configuration=
+ 			-- this is the folder from where the current application gets it's content.
+ 			-- It is optional. If not specified, it will be defaulted to:
+ 			-- <rootDirectory>/<name>/mediaFolder
+-			-- mediaFolder="/some/directory/where/media/files/are/stored"
++			mediaFolder="/usr/share/crtmpserver/appselector",
+ 			-- the application will also be known by that names. It is optional
+ 			--aliases=
+ 			--{
+@@ -89,13 +89,6 @@ configuration=
+ 				},
+ 				{
+ 					ip="0.0.0.0",
+-					port=8081,
+-					protocol="inboundRtmps",
+-					sslKey="server.key",
+-					sslCert="server.crt"
+-				},
+-				{
+-					ip="0.0.0.0",
+ 					port=8080,
+ 					protocol="inboundRtmpt"
+                 },
+@@ -105,7 +98,7 @@ configuration=
+ 			description="FLV Playback Sample",
+ 			name="flvplayback",
+ 			protocol="dynamiclinklibrary",
+-			mediaFolder="/Volumes/android/backup/media/",
++			mediaFolder="/media/",
+ 			aliases=
+ 			{
+ 				"simpleLive",
+@@ -183,6 +176,7 @@ configuration=
+ 			name="samplefactory",
+ 			description="asdsadasdsa",
+ 			protocol="dynamiclinklibrary",
++			mediaFolder="/usr/share/ctmpserver/media",
+ 			aliases=
+ 			{
+ 				"httpOutboundTest"

--- a/multimedia/crtmpserver/patches/040-use-select.patch
+++ b/multimedia/crtmpserver/patches/040-use-select.patch
@@ -1,0 +1,13 @@
+Index: crtmpserver-r726/builders/make/linux.mk
+===================================================================
+--- crtmpserver-r726.orig/builders/make/linux.mk
++++ crtmpserver-r726/builders/make/linux.mk
+@@ -38,7 +38,7 @@ dynamic_exec_flags = $(FPIC) $(OPTIMIZAT
+ PLATFORM_DEFINES = \
+ 	-DLINUX \
+ 	-DLITTLE_ENDIAN_BYTE_ALIGNED \
+-	-DNET_EPOLL
++	-DNET_SELECT
+ 
+ SSL_BASE=/usr/local
+ 

--- a/multimedia/crtmpserver/patches/050-add-missing-make-defines.patch
+++ b/multimedia/crtmpserver/patches/050-add-missing-make-defines.patch
@@ -1,0 +1,57 @@
+--- a/builders/make/compile.mk
++++ b/builders/make/compile.mk
+@@ -43,17 +43,22 @@ FEATURES_DEFINES = \
+ 	-DHAS_PROTOCOL_RTP \
+ 	-DHAS_PROTOCOL_TS \
+ 	-DHAS_PROTOCOL_VAR \
++	-DHAS_PROTOCOL_CLI \
++	-DHAS_PROTOCOL_HLS \
++	-DHAS_PROTOCOL_RAWHTTPSTREAM \
+ 	-DHAS_LUA \
+ 	-DHAS_MEDIA_MP3 \
+ 	-DHAS_MEDIA_MP4 \
+-	-DHAS_MEDIA_FLV
++	-DHAS_MEDIA_FLV \
++	-DHAS_SYSLOG
++	
+ 
+ 
+ DEFINES = $(PLATFORM_DEFINES) $(FEATURES_DEFINES)
+ 
+ #library paths
+ SSL_INCLUDE=-I$(SSL_BASE)/include
+-SSL_LIB=-L$(SSL_BASE)/lib -lssl -lcrypto
++SSL_LIB=-L$(SSL_BASE)/lib -lssl -lcrypto -ldl
+ 
+ #lua
+ LUA_INCLUDE=-I$(PROJECT_BASE_PATH)/3rdparty/lua-dev
+@@ -67,25 +72,25 @@ TINYXML_OBJS = $(TINYXML_SRCS:.cpp=.tiny
+ 
+ #common
+ COMMON_INCLUDE=$(LUA_INCLUDE) $(TINYXML_INCLUDE) $(SSL_INCLUDE) -I$(PROJECT_BASE_PATH)/sources/common/include
+-COMMON_LIBS=$(SSL_LIB) -L$(OUTPUT_DYNAMIC) -llua -ltinyxml -lcrypt
++COMMON_LIBS=$(SSL_LIB) -L$(OUTPUT_DYNAMIC) $(PROJECT_BASE_PATH)/builders/make/output/dynamic/liblua.so -ltinyxml -lcrypt -ldl
+ COMMON_SRCS = $(shell find $(PROJECT_BASE_PATH)/sources/common/src -type f -name "*.cpp")
+ COMMON_OBJS = $(COMMON_SRCS:.cpp=.common.o)
+ 
+ #thelib
+ THELIB_INCLUDE=$(COMMON_INCLUDE) -I$(PROJECT_BASE_PATH)/sources/thelib/include
+-THELIB_LIBS=$(COMMON_LIBS) -L$(OUTPUT_DYNAMIC) -lcommon
++THELIB_LIBS=$(COMMON_LIBS) -L$(OUTPUT_DYNAMIC) -lcommon -ldl
+ THELIB_SRCS = $(shell find $(PROJECT_BASE_PATH)/sources/thelib/src -type f -name "*.cpp")
+ THELIB_OBJS = $(THELIB_SRCS:.cpp=.thelib.o)
+ 
+ #tests
+ TESTS_INCLUDE=$(THELIB_INCLUDE) -I$(PROJECT_BASE_PATH)/sources/tests/include
+-TESTS_LIBS=$(THELIB_LIBS) -L$(OUTPUT_DYNAMIC) -lthelib
++TESTS_LIBS=$(THELIB_LIBS) -L$(OUTPUT_DYNAMIC) -lthelib -ldl
+ TESTS_SRCS=$(shell find $(PROJECT_BASE_PATH)/sources/tests/src -type f -name "*.cpp")
+ TESTS_OBJS=$(TESTS_SRCS:.cpp=.tests.o)
+ 
+ #crtmpserver
+ CRTMPSERVER_INCLUDE=$(THELIB_INCLUDE) -I$(PROJECT_BASE_PATH)/sources/crtmpserver/include
+-CRTMPSERVER_LIBS=$(THELIB_LIBS) -L$(OUTPUT_DYNAMIC) -lthelib
++CRTMPSERVER_LIBS=$(THELIB_LIBS) -L$(OUTPUT_DYNAMIC) -lthelib -ldl
+ CRTMPSERVER_SRCS=$(shell find $(PROJECT_BASE_PATH)/sources/crtmpserver/src -type f -name "*.cpp")
+ CRTMPSERVER_OBJS_DYNAMIC=$(CRTMPSERVER_SRCS:.cpp=.crtmpserver_dynamic.o)
+ CRTMPSERVER_OBJS_STATIC=$(CRTMPSERVER_SRCS:.cpp=.crtmpserver_static.o)

--- a/multimedia/crtmpserver/patches/060-add-missing-includes.patch
+++ b/multimedia/crtmpserver/patches/060-add-missing-includes.patch
@@ -1,0 +1,26 @@
+--- a/sources/common/include/common.h
++++ b/sources/common/include/common.h
+@@ -20,6 +20,10 @@
+ #ifndef _COMMON_H
+ #define _COMMON_H
+ 
++#include <stdio.h>
++#include <unistd.h>
++#include <sys/types.h>
++
+ #include "defines.h"
+ #include "platform/platform.h"
+ #include "utils/utils.h"
+--- a/sources/common/src/utils/logging/fileloglocation.cpp
++++ b/sources/common/src/utils/logging/fileloglocation.cpp
+@@ -18,6 +18,10 @@
+  */
+ 
+ 
++#include <stdio.h>
++#include <unistd.h>
++#include <sys/types.h>
++
+ #include "utils/logging/fileloglocation.h"
+ #include "utils/lua/luautils.h"
+ 

--- a/multimedia/crtmpserver/patches/070-missing-include-gcc-47.patch
+++ b/multimedia/crtmpserver/patches/070-missing-include-gcc-47.patch
@@ -1,0 +1,10 @@
+--- a/3rdparty/tinyxml/tinyxml.h
++++ b/3rdparty/tinyxml/tinyxml.h
+@@ -39,6 +39,7 @@ distribution.
+ #include <string>
+ #include <iostream>
+ #include <sstream>
++#include "lstate.h"
+ 
+ // Help out windows:
+ #if defined( _DEBUG ) && !defined( DEBUG )


### PR DESCRIPTION
This adds the crtmpserver package from the old svn package tree. I adopt
the licensing information and will maintain the package in the future. I
also updated the package to the latest version and ensure that is
building on x86_64, ar71xx and avr32.

Signed-off-by: Thomas Heil heil@terminal-consulting.de
