### PR TITLE
gdbm: Import from packages, update to latest upstream, fix build, add myself as maintainer

### DIFF
--- a/libs/gdbm/Makefile
+++ b/libs/gdbm/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2013 OpenWrt.org
+# Copyright (C) 2006-2014 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.


### PR DESCRIPTION
This is the old gdbm package, updated and fixed.
gdbm 1.11 comes with pre-generated Makefiles for some reason, so this packages removes them to make things work.
Also added a package description, bumped copyright notice and made me the package maintainer.
