### PR TITLE
[PATCH] lighttpd: errorlog failed as non root user

### DIFF
--- a/net/lighttpd/files/lighttpd.init
+++ b/net/lighttpd/files/lighttpd.init
@@ -6,7 +6,8 @@ SERVICE_USE_PID=1
 START=50
 
 start() {
-	mkdir -m 0755 -p /var/log/lighttpd
+	[ -d /var/log/lighttpd ] || mkdir -p /var/log/lighttpd
+	chmod 0777 /var/log/lighttpd
 	service_start /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf
 }
 


### PR DESCRIPTION
if running as non root user (what's should be the default on web-servers) you get:
(log.c.118) opening errorlog '/var/log/lighttpd/server.log' failed: Permission denied

Fix: create log directory only if not exist and chmod 777 to allow anyone 
to write and create files inside default log directory

Signed-off-by: Christian Schoenebeck christian.schoenebeck@gmail.com
