### PR TITLE
FFmpeg: space saving in the libffmpeg-mini variant 

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -512,7 +512,15 @@ define Build/InstallDev/full
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/lib{avcodec,avdevice,avfilter,avformat,avutil,postproc,swresample,swscale}.pc $(1)/usr/lib/pkgconfig/
 endef
 
-Build/InstallDev/mini = $(Build/InstallDev/custom)
+define Build/InstallDev/mini
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/lib{avcodec,avformat,avutil} $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avformat,avutil}.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/lib{avcodec,avformat,avutil}.pc $(1)/usr/lib/pkgconfig/
+endef
+
 Build/InstallDev/audio-dec = $(Build/InstallDev/custom)
 
 # XXX: attempt at installing "best" dev files available


### PR DESCRIPTION
The libffmpeg-mini variant is intended for DLNA usage, which only uses ffmpeg for media identification purposes. It does need libavdevices to do this, so remove it in order to save space.
