### PR TITLE
[packages] tinyproxy: logging problems

### DIFF
--- a/net/tinyproxy/files/tinyproxy.init
+++ b/net/tinyproxy/files/tinyproxy.init
@@ -46,7 +46,7 @@ start_proxy() {
 	proxy_string "$1" StatFile >> $CFGFILE
 	proxy_string "$1" LogFile >> $CFGFILE
 
-	proxy_flag "$1" SysLog >> $CFGFILE
+	proxy_flag "$1" Syslog >> $CFGFILE
 
 	proxy_atom "$1" LogLevel >> $CFGFILE
 
@@ -111,6 +111,10 @@ proxy_string() {
 	config_get _value "$SECTION" "$OPTION"
 	[ -z "$_value" ] && _value="$DEFAULT"
 	[ -n "$_value" ] && echo "${ALIAS:-${OPTION}} "'"'"$_value"'"'
+	[ -n "$_value" -a "$OPTION" = "LogFile" ] && {
+		touch $_value
+		chmod 666 $_value
+	}
 }
 
 proxy_flag() {


### PR DESCRIPTION
1.) No SysLog possible because keyword misspelled
In tinyproxy.conf and tinyproxy.config the parameter is correct spelled
with small "l"
2.) No logging as non root user
The default is that tinyproxy deamon run as nobody:nogroup, but they have no permission to /var/log/ or any other location.
So touch and change permission of logfile during startup

Signed-off-by: Christian Schoenebeck christian.schoenebeck@gmail.com
