### PR TITLE
rng-tools: remove libgcrypt dependency

### DIFF
--- a/utils/rng-tools/Makefile
+++ b/utils/rng-tools/Makefile
@@ -34,6 +34,9 @@ CONFIGURE_VARS += \
     LIBS="-largp"
 endif
 
+CONFIGURE_ARGS += \
+	--without-libgcrypt
+
 define Package/rng-tools/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/rngd.init $(1)/etc/init.d/rngd


### PR DESCRIPTION
Remove libgcrypt dependency that was spotted by buildbot.
It seems to be related to x86-only functionality, so it makes no sense to burden all platforms with it.

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
