### PR TITLE
Add ncdu

### DIFF
--- a/utils/ncdu/Makefile
+++ b/utils/ncdu/Makefile
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ncdu
+PKG_VERSION:=1.10
+PKG_RELEASE=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://dev.yorhel.nl/download
+PKG_MD5SUM:=7535decc8d54eca811493e82d4bfab2d
+
+PKG_INSTALL:=1
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ncdu
+  SUBMENU:=Filesystem
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libncursesw
+  TITLE:=ncurses disk usage viewer
+  MAINTAINER:=Charles Lehner <celehner1@gmail.com>
+  URL:=http://dev.yorhel.nl/ncdu
+endef
+
+define Package/ncdu/description
+  Ncdu is a ncurses-based du viewer. It provides a fast and easy-to-use
+  interface through famous du utility. It allows one to browse through the
+  directories and show percentages of disk usage with ncurses library.
+endef
+
+define Package/ncdu/install
+  $(INSTALL_DIR) $(1)/usr/bin
+  $(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ncdu $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,ncdu))


### PR DESCRIPTION
[ncdu](dev.yorhel.nl/ncdu/) is a disk usage visualizer with a ncurses interface. It's useful for managing file space on a NAS. It builds for me in latest openwrt.
