### PR TITLE
mjpg-streamer: update to latest version

### DIFF
--- a/multimedia/mjpg-streamer/Makefile
+++ b/multimedia/mjpg-streamer/Makefile
@@ -8,17 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mjpg-streamer
-PKG_REV:=181
+PKG_REV:=182
 PKG_VERSION:=r$(PKG_REV)
 PKG_RELEASE:=2
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=https://svn.code.sf.net/p/mjpg-streamer/code/mjpg-streamer
+PKG_SOURCE_URL:=https://svn.code.sf.net/p/mjpg-streamer/code/mjpg-streamer-experimental
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=$(PKG_REV)
 PKG_SOURCE_PROTO:=svn
-PKG_MD5SUM:=b2bc22665733319e647ace236e283684
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILE:=LICENSE


### PR DESCRIPTION
use r182 from experimental branch
remove unused MD5SUM

Signed-off-by: Roger D rogerdammit@gmail.com
