### PR TITLE
Fix bug in git-daemon

### DIFF
--- a/net/git/Makefile
+++ b/net/git/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=git
 PKG_VERSION:=2.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/scm/git/

--- a/net/git/patches/100-convert_builtin.patch
+++ b/net/git/patches/100-convert_builtin.patch
@@ -127,6 +127,25 @@
  {
  	int listen_port = 0;
  	struct string_list listen_addr = STRING_LIST_INIT_NODUP;
+@@ -1315,12 +1315,13 @@
+ 		store_pid(pid_file);
+ 
+ 	/* prepare argv for serving-processes */
+-	cld_argv = xmalloc(sizeof (char *) * (argc + 2));
+-	cld_argv[0] = argv[0];	/* git-daemon */
+-	cld_argv[1] = "--serve";
++	cld_argv = xmalloc(sizeof (char *) * (argc + 3));
++	cld_argv[0] = "git";
++	cld_argv[1] = argv[0];	/* daemon */
++	cld_argv[2] = "--serve";
+ 	for (i = 1; i < argc; ++i)
+-		cld_argv[i+1] = argv[i];
+-	cld_argv[argc+1] = NULL;
++		cld_argv[i+2] = argv[i];
++	cld_argv[argc+2] = NULL;
+ 
+ 	return serve(&listen_addr, listen_port, cred);
+ }
 --- a/fast-import.c
 +++ b/fast-import.c
 @@ -3343,7 +3343,7 @@ static void parse_argv(void)


### PR DESCRIPTION
The git-daemon command currently doesn't work and displays the following
error whenever a repository is cloned:

```
error: cannot run daemon: No such file or directory
[10920] unable to fork
```

On the client side the connection is simply terminated. The problem is,
that git-daemon tries to start a new instance of itself for every
new client that is connecting. It expects `argv[0]` to contain
`"git-daemon"`, but since it is converted into a builtin command, `argv[0]`
only contains `"daemon"`, which does not exist and causes the above error.
The fix simply prepends `"git"` to the list of arguments, so that the
resulting call looks something like `git daemon --serve ...`

Signed-off-by: Andreas Rohner andreas.rohner@gmx.net
