### PR TITLE
aiccu: Fix typo tunnelid

### DIFF
--- a/ipv6/aiccu/files/aiccu.sh
+++ b/ipv6/aiccu/files/aiccu.sh
@@ -34,7 +34,7 @@ proto_aiccu_setup() {
 	echo "ipv6_interface $link"   >> "$CFGFILE"
 	[ -n "$server" ] && echo "server $server" >> "$CFGFILE"
 	[ -n "$protocol" ] && echo "protocol $protocol" >> "$CFGFILE"
-	[ -n "$tunnel_id" ] && echo "tunnel_id $tunnel_id"	  >> "$CFGFILE"
+	[ -n "$tunnelid" ] && echo "tunnel_id $tunnelid"	  >> "$CFGFILE"
 	[ -n "$requiretls" ] && echo "requiretls $requiretls"	   >> "$CFGFILE"
 	[ "$nat" == 1 ] && echo "behindnat true"     >> "$CFGFILE"
 	[ "$heartbeat"	== 1 ] && echo "makebeats true" >> "$CFGFILE"


### PR DESCRIPTION
The option 'tunnel_id' from aiccu is called 'tunnelid' in the UCI config file. The content of $tunnelid should be checked and written to the $CFGFILE instead of the undeclared $tunnel_id.

This change was tested locally with OpenWrt Barrier Breaker 14.07-rc1.

Signed-off-by: Thomas Bahn thomas@thomas-bahn.net
