### PR TITLE
ddns-scripts: Set PKG_LICENSE

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -3,6 +3,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=1.0.0
 PKG_RELEASE:=23
+PKG_LICENSE:=GPL-2.0
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 


### PR DESCRIPTION
Set PKG_LICENSE as written inside dynamic_dns_updater.sh and dynamic_dns_functions.sh.

Signed-off-by: Christian Schoenebeck christian.schoenebeck@gmail.com
