### PR TITLE
libarchive: Reduce dependencies by disabling them using configure args

### DIFF
--- a/libs/libarchive/Makefile
+++ b/libs/libarchive/Makefile
@@ -30,13 +30,21 @@ endef
 
 define Package/libarchive
   $(call Package/libarchive/Default)
-  DEPENDS:=+libxml2 +libopenssl +zlib +libacl +libattr +libbz2 +liblzo +libnettle
+  DEPENDS:=+libopenssl +zlib
   TITLE:=Multi-format archive and compression library
 endef
 
 define Package/libarchive/description
  Multi-format archive and compression library.
 endef
+
+CONFIGURE_ARGS += \
+	--disable-acl \
+	--disable-xattr \
+	--without-bz2lib \
+	--without-lzo2 \
+	--without-nettle \
+	--without-xml2
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)


### PR DESCRIPTION
In order to reduce the dependencies, this patch disables following features:
- Extended Attributes
- ACL support
- bzip2 through bz2lib
- lzop through liblzo2
- crypto support from Nettle
- xar through libxml2

Signed-off-by: Johannes Morgenroth morgenroth@ibr.cs.tu-bs.de
