### PR TITLE
luasoap: bump luasoap from 2.x to 3.x.

### DIFF
--- a/lang/luasoap/Makefile
+++ b/lang/luasoap/Makefile
@@ -19,6 +19,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
 PKG_MIRROR_MD5SUM:=
 
 PKG_MAINTAINER:=Liu Peng <pengliu@credosemi.com>
+PKG_LICENSE:=MIT
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Hi, This the lastest stable version of luasoap. 

AND, I think the luasoap in **oldpackages** should be deleted.

Thanks.
