### PR TITLE
ibrdtnd: Fix configure args

### DIFF
--- a/net/ibrdtnd/Makefile
+++ b/net/ibrdtnd/Makefile
@@ -38,7 +38,11 @@ define Package/ibrdtnd/description
 endef
 
 CONFIGURE_ARGS += \
-        --with-tls --with-sqlite --with-dht --without-wifip2p --without-vmime
+	--with-tls \
+	--with-sqlite \
+	--without-wifip2p \
+	--without-vmime \
+	--disable-libdaemon
 
 define Package/ibrdtnd/install
 	$(INSTALL_DIR) $(1)/usr/sbin/


### PR DESCRIPTION
The option --disable-libdaemon was missing and --with-dht is invalid.

Signed-off-by: Johannes Morgenroth morgenroth@ibr.cs.tu-bs.de
