### PR TITLE
ddns-scripts: duiadns.net service support added

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/services
+++ b/net/ddns-scripts/files/usr/lib/ddns/services
@@ -66,3 +66,6 @@
 
 # Securepoint Dynamic-DNS-Service	(http://www.spdns.de)
 "spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"
+
+# duiadns.net
+"duiadns.net"     "http://ipv4.duia.ro/dynamic.duia?host=[DOMAIN]&password=[PASSWORD]&ip4=[IP]"


### PR DESCRIPTION
https://www.duiadns.net is a free dynamic dns provider. with this patch, it was included in dynamic dns providers list.
Signed-off-by: Liviu Pislaru liviu@duiadns.net
