### PR TITLE
libexpat: do not install soname symlink

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
 PKG_VERSION:=2.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_MD5SUM:=dd7dab7a5fea97d2a6a43f511449b7cd
@@ -62,7 +62,7 @@ endef
 
 define Package/libexpat/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libexpat.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libexpat.so.* $(1)/usr/lib/
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
The .so symlinks (without any suffix) are only used by compiler/linker and
not needed on the target system.
See https://github.com/openwrt/packages/pull/274 for a short discussion.

Signed-off-by: Michael Heimpold mhei@heimpold.de
