### PR TITLE
add dansguardian version 2.12.0.3

### DIFF
--- a/net/dansguardian/Makefile
+++ b/net/dansguardian/Makefile
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2008-2009 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dansguardian
+PKG_VERSION:=2.12.0.3
+PKG_RELEASE:=3
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=http://sourceforge.net/projects/dansguardian/files
+PKG_MD5SUM:=2a88d0392cd28eaec02b7ee727b2e253
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/uclibc++.mk
+include $(INCLUDE_DIR)/package.mk
+
+define Package/dansguardian
+  SECTION:=net
+  DEPENDS:=+libpthread $(CXX_DEPENDS) +zlib
+  CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
+  TITLE:=DansGuardian
+  URL:=http://dansguardian.org
+endef
+
+define Package/dansguardian/conffiles
+/etc/dansguardian/dansguardian.conf
+endef
+
+CONFIGURE_VARS += \
+	INCLUDES="" \
+	CXXFLAGS="$$$$CXXFLAGS -fno-rtti"  \
+	LIBS="-lpthread" \
+
+define Build/Configure
+	$(call Build/Configure/Default,\
+		--disable-clamav \
+		--with-sysconfsubdir=dansguardian \
+		--with-proxyuser=root \
+		--with-proxygroup=root \
+		--disable-pcre \
+	)
+endef
+
+define Package/dansguardian/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/dansguardian $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc
+	$(CP) $(PKG_INSTALL_DIR)/etc/dansguardian $(1)/etc/
+	$(INSTALL_DIR) $(1)/usr/share/dansguardian
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/dansguardian/transparent1x1.gif $(1)/usr/share/dansguardian/
+	$(INSTALL_DIR) $(1)/usr/share/dansguardian/languages/ukenglish
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/dansguardian/languages/ukenglish/* $(1)/usr/share/dansguardian/languages/ukenglish/
+endef
+
+$(eval $(call BuildPackage,dansguardian))

--- a/net/dansguardian/patches/001-include_dir.patch
+++ b/net/dansguardian/patches/001-include_dir.patch
@@ -1,0 +1,29 @@
+--- a/configure
++++ b/configure
+@@ -827,7 +827,7 @@ sysconfdir='${prefix}/etc'
+ sharedstatedir='${prefix}/com'
+ localstatedir='${prefix}/var'
+ includedir='${prefix}/include'
+-oldincludedir='/usr/include'
++oldincludedir='${prefix}/usr/include'
+ docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
+ infodir='${datarootdir}/info'
+ htmldir='${docdir}'
+@@ -5265,7 +5265,7 @@ $as_echo_n "checking for zlib... " >&6;
+ # Check whether --with-zlib was given.
+ if test "${with_zlib+set}" = set; then :
+   withval=$with_zlib;  # check for header & func (in library) in given prefix
+-	CPPFLAGS="${CPPFLAGS} -I${withval}/include"
++	CPPFLAGS="${CPPFLAGS}"
+ 	if test "x$staticzlib" = "xtrue"; then
+ 		LIBS="-Bstatic -L${withval} -lz -Bdynamic ${LIBS}"
+ 	else
+@@ -7095,7 +7095,7 @@ $as_echo "#define ENABLE_NTLM /**/" >>co
+ if test "${with_libiconv+set}" = set; then :
+   withval=$with_libiconv;  # check for header & func (in library) in given prefix
+ 			if test "x$withval" != "x"; then
+-				CPPFLAGS="${CPPFLAGS} -I${withval}/include"
++				CPPFLAGS="${CPPFLAGS}"
+ 				LIBS="-L${withval}/lib -liconv ${LIBS}"
+ 			else
+ 				LIBS="-liconv ${LIBS}"


### PR DESCRIPTION
dansguardian: add latest version 2.12.0.3

Comparison with the old dansguardian package from openwrt oldpackages:

1) Bumb Makefile from version 2.10.X to version 2.12.0.3.
2) New sourceforge location of the latest GPL software.
3) Applies the same configure patch that was needed for version 2.10 to make it work with openwrt.

Unchanged: DG needs more "power" than many embedded devices can provide (CPU / RAM / IO).

---

Signed-off-by: Renato Mercurio mercurio.renato@gmail.com
