### PR TITLE
ibrdtnd: Add patch to exclude build of documentation using pdflatex

### DIFF
--- a/net/ibrdtnd/patches/110-add_configure_options_docs.patch
+++ b/net/ibrdtnd/patches/110-add_configure_options_docs.patch
@@ -1,0 +1,26 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -138,11 +138,17 @@ AS_IF([test "x$enable_android" = "xyes"], [
+ 	# Checks for library functions.
+ 	AC_CHECK_FUNCS([gethostname socket])
+ 
+-	# Check for presence of pdfLaTeX
+-	AC_CHECK_PROG(PDFLATEX, pdflatex, pdflatex)
+-	if test -z "$PDFLATEX"; then
+-	AC_MSG_WARN([Unable to create PDF version of the documentation.])
+-	fi
++	AC_ARG_ENABLE([docs],
++		AS_HELP_STRING([--enable-docs], [Build documentation using PDFLaTeX]),
++	[
++		# Check for presence of pdfLaTeX
++		AC_CHECK_PROG(PDFLATEX, pdflatex, pdflatex)
++		if test -z "$PDFLATEX"; then
++			AC_MSG_WARN([Unable to create PDF version of the documentation.])
++		fi
++	], [
++		PDFLATEX="no"
++	])
+ 
+ 	AC_ARG_ENABLE([libdaemon],
+ 		AS_HELP_STRING([--disable-libdaemon], [Build without libdaemon support]),
+-- 


### PR DESCRIPTION
This patch fixes #284.

By default the package detects the presence of pdflatex and builds documentation automatically.
During the OpenWrt build this behavior is not acceptable. The added patch introduces a configure
option to explicitly enable the build of the documentation on request.
