### PR TITLE
Build with shadow password support if the system is being built with shadow support

### DIFF
--- a/net/ipsec-tools/Makefile
+++ b/net/ipsec-tools/Makefile
@@ -70,7 +70,9 @@ define Build/Configure
 		configure \
 	);
 	$(call Build/Configure/Default)
+ifndef CONFIG_SHADOW_PASSWORDS
 	echo "#undef HAVE_SHADOW_H" >> $(PKG_BUILD_DIR)/config.h
+endif
 endef
 
 define Package/ipsec-tools/install


### PR DESCRIPTION
Racoon requires shadow password support when built for a system with shadow passwords enabled.  This is controlled by the `CONFIG_SHADOW_PASSWORDS` definition in the 'General build options'.

Without this change, racoon's system authentication against user accounts fails.
