### PR TITLE
haveged: fix CONFIGURE_ARGS

### DIFF
--- a/utils/haveged/Makefile
+++ b/utils/haveged/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haveged
 PKG_VERSION:=1.9.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.issihosts.com/$(PKG_NAME) \
@@ -43,7 +43,7 @@ define Package/libhavege
 endef
 
 CONFIGURE_ARGS+= \
-      --enable-daemon=yes
+      --enable-daemon=yes \
       --enable-threads=no
 
 define Build/InstallDev


### PR DESCRIPTION
Add backslash to the CONFIGURE_ARGS definition to remove thread support as originally intended.
The error has been there since the bump to 1.7c in October 2013.

The change is rather minor and decreases the size of the uncompressed haveged binary by ~100 bytes, so I see no real need to backport this to 14.07.

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
