### PR TITLE
Added Davfs2 1.5.2 package, copy and updated neon to version 0.3.0

### DIFF
--- a/libs/neon/Makefile
+++ b/libs/neon/Makefile
@@ -1,0 +1,80 @@
+#
+# Copyright (C) 2007-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=neon
+PKG_VERSION:=0.30.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.webdav.org/neon
+PKG_MD5SUM:=fb60b3a124eeec441937a812c456fd94
+	 
+#PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+#PKG_CAT :=zcat
+	
+include $(INCLUDE_DIR)/package.mk
+	
+define Package/neon
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+libopenssl +libexpat
+  TITLE:=HTTP and WebDAV client library.
+  URL:=http://www.webdav.org/neon/
+  MAINTAINER:=Federico Di Marco <fededim@gmail.com>
+endef
+	
+define Package/neon/description
+  neon is an HTTP and WebDAV client library, with a C interface. Features:
+
+  - High-level wrappers for common HTTP and WebDAV operations (GET, MOVE, DELETE, etc)
+  - Low-level interface to the HTTP request/response engine, allowing the use of arbitrary HTTP methods, headers, etc.
+  - Authentication support including Basic and Digest support, along with GSSAPI-based Negotiate on Unix, and 
+    SSPI-based Negotiate/NTLM on Win32
+  - SSL/TLS support using OpenSSL or GnuTLS; exposing an abstraction layer for verifying server certificates, handling client
+    certificates, and examining certificate properties. Smartcard-based client certificates are also supported via a 
+    PKCS11 wrapper interface.
+  - Abstract interface to parsing XML using libxml2 or expat, and wrappers for simplifying handling XML HTTP response bodies
+  - WebDAV metadata support; wrappers for PROPFIND and PROPPATCH to simplify property manipulation.
+endef
+
+
+TARGET_CFLAGS += $(FPIC)
+TARGET_CPPFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
+	
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--enable-static \
+	--with-expat \
+	--with-ssl="openssl" \
+	--without-egd \
+	--without-libproxy
+	
+CONFIGURE_VARS += \
+	LDFLAGS="$$$$LDFLAGS -lcrypto -lssl"
+	
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/neon-config $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/neon $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libneon.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/neon.pc $(1)/usr/lib/pkgconfig/
+	$(SED) 's,-I$$$${includedir}/,-I$(STAGING_DIR)/usr/include/,g' $(1)/usr/bin/neon-config
+	$(SED) 's,-L$$$${libdir},,g' $(1)/usr/bin/neon-config
+endef
+	
+define Package/neon/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libneon.so.* $(1)/usr/lib/
+endef
+	
+$(eval $(call BuildPackage,neon))

--- a/net/davfs2/Makefile
+++ b/net/davfs2/Makefile
@@ -1,0 +1,79 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=davfs2
+PKG_VERSION:=1.5.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://download.savannah.gnu.org/releases/davfs2/
+PKG_MD5SUM:=376bc9346454135cba78afacbcb23f86
+#PKG_INSTALL_DIR:=$(PKG_BUILD_DIR)/ipkg-install
+#PKG_BUILD_DIR :=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+#PKG_CAT :=zcat
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/davfs2
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Filesystem
+  DEPENDS=+libopenssl +neon +libiconv +libintl +libexpat +kmod-fuse +libfuse
+  TITLE:=Mount a WebDAV resource as a regular file system.
+  URL:=http://savannah.nongnu.org/projects/davfs2/
+  MAINTAINER:=Federico Di Marco <fededim@gmail.com>
+endef
+
+
+define Package/davfs2/description
+ Web Distributed Authoring and Versioning (WebDAV), an extension to the HTTP-protocol,
+ allows authoring of resources on a remote web server.davfs2 provides the ability to 
+ access such resources like a typical filesystem, allowing for use by standard 
+ applications with no built-in support for WebDAV. 
+
+ davfs2 is designed to fully integrate into the filesystem semantics of Unix-like 
+ systems (mount, umount, etc.). davfs2 makes mounting by unprivileged users as easy 
+ and secure as possible.
+ 
+ davfs2 does extensive caching to make the file system responsive, to avoid 
+ unnecessary network traffic and to prevent data loss, and to cope for slow or 
+ unreliable connections. 
+
+ davfs2 will work with most WebDAV servers needing little or no configuration. 
+
+endef
+
+
+define Package/davfs2/conffiles
+/etc/davfs2/davfs2.conf
+endef
+
+TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include
+
+CONFIGURE_VARS += \
+#        CXXFLAGS="-nostdinc++"  \
+       LDFLAGS="$(TARGET_LDFLAGS) -L$(TOOLCHAIN_DIR)/usr/lib -L$(TOOLCHAIN_DIR)/lib" \                                     
+#	LIBS="-lgcc -lc -luClibc++ -lgcc_s"
+
+
+define Build/Configure
+  $(call Build/Configure/Default,--with-neon="$(STAGING_DIR)/usr")
+endef
+	
+define Package/davfs2/install	
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/mount.davfs $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/umount.davfs $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DIR) $(1)/etc/davfs2
+	$(INSTALL_DATA) files/$(PKG_NAME).conf $(1)/etc/davfs2
+endef
+
+
+$(eval $(call BuildPackage,davfs2))

--- a/net/davfs2/files/davfs2.conf
+++ b/net/davfs2/files/davfs2.conf
@@ -1,0 +1,9 @@
+#
+# davfs2 configuration file
+# please see http://linux.die.net/man/5/davfs2.conf for details
+#
+
+dav_user nobody
+dav_group nogroup
+cache_dir /tmp/davfs2
+cache_size 4

--- a/net/davfs2/patches/010-main_code_fix.patch
+++ b/net/davfs2/patches/010-main_code_fix.patch
@@ -1,0 +1,35 @@
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -32,8 +32,8 @@ mount_davfs_SOURCES = cache.c dav_coda.c
+         kernel_interface.h mount_davfs.h webdav.h
+ umount_davfs_SOURCES = umount_davfs.c defaults.h
+ 
+-AM_CFLAGS = -Wall -Werror=format-security \
+-        -fstack-protector --param=ssp-buffer-size=4
++AM_CFLAGS = -Wall -Werror=format-security 
++#        -fstack-protector --param=ssp-buffer-size=4  -- removed ssp not supported in openwrt
+ DEFS = -DPROGRAM_NAME=\"mount.davfs\" \
+        -DDAV_SYS_CONF_DIR=\"$(pkgsysconfdir)\" \
+        -DDAV_LOCALSTATE_DIR=\"$(dav_localstatedir)\" \
+--- a/src/cache.c
++++ b/src/cache.c
+@@ -58,7 +58,7 @@
+ #ifdef HAVE_SYS_TYPES_H
+ #include <sys/types.h>
+ #endif
+-#include <sys/xattr.h>
++#include <linux/xattr.h>
+ 
+ #include <ne_alloc.h>
+ #include <ne_string.h>
+--- a/src/webdav.c
++++ b/src/webdav.c
+@@ -2033,7 +2033,7 @@ ssl_verify(void *userdata, int failures,
+             len = getline(&s, &n, stdin);
+             if (len < 0)
+                 abort();
+-            if (rpmatch(s) > 0)
++            if ((s[0]=='y' || s[0]=='Y') > 0)
+                 ret = 0;
+             free(s);
+     } 


### PR DESCRIPTION
As requested by Etienne Champetier champetier.etienne@gmail.com, please see (https://lists.openwrt.org/pipermail/openwrt-devel/2014-August/027269.html)

From: Federico Di Marco fededim@gmail.com

Body of explanation:
A new package has been added in packages feed under net/davfs2 directory, porting a simple tool to mount a WebDAV resource as a regular file system (please see https://savannah.nongnu.org/projects/davfs2/ ) to OpenWRT. There was also a previous ticket requesting the porting of this tool (https://dev.openwrt.org/ticket/12843). The neon library used by this tool has been ported as well.

The patch consists of the following files:

Makefile: standard makefile of OpenWRT packages which downloads from the source code and compiles it into a package using the uClibc.
files/davfs2.conf: configuration file for davfs2
patches/010-main_code_fix.patch: minor fixes to allow the source code to compile under uClibc (code replacement rpmatch function not present in uclibc, fix of an include path and removed libssp not supported under openwrt)

Signed-off-by: Federico Di Marco fededim@gmail.com
