### PR TITLE
gstreamer1: reorganize options selection menus

### DIFF
--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-bad
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -21,7 +21,7 @@ PKG_SOURCE:=gst-plugins-bad-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-plugins-bad/
 PKG_MD5SUM:=cfd6f303c8df2740b27cc63b945decef
 
-PKG_BUILD_DEPENDS:= gstreamer1 gst1-plugins-base liboil
+PKG_BUILD_DEPENDS:= libgstreamer1 gstreamer1-plugins-base liboil
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -29,32 +29,70 @@ PKG_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
-define Package/gstreamer1/Default
+GST_BAD_LIBS:=
+GST_BAD_MODULES:=
+
+define Package/gstreamer1-bad/Default
   CATEGORY:=Multimedia
   SECTION:=multimedia
   TITLE:=GStreamer
   URL:=http://gstreamer.freedesktop.org/
-  DEPENDS:= $(ICONV_DEPENDS)
+  DEPENDS:= +libgstreamer1 $(ICONV_DEPENDS)
 endef
 
-define Package/gstreamer1/description/Default
+define Package/gstreamer1-bad/description/Default
  GStreamer open source multimedia framework
 endef
 
 
 define Package/gst1-plugins-bad
-$(call Package/gstreamer1/Default)
+$(call Package/gstreamer1-bad/Default)
   TITLE+= plugins collection (bad)
   DEPENDS+= $(GST_DEPENDS)
+  HIDDEN:=1
 endef
 
 define Package/gts1-plugins-bad/description
-$(call Package/gstreamer1/description/Default)
+$(call Package/gstreamer1-bad/description/Default)
  .
  This meta package contains only dependencies to the other plugins from
  the bad plugins collection.
 endef
 
+define Package/gstreamer1-plugins-bad
+  $(call Package/gstreamer1-bad/Default)
+  TITLE+= plugins collection (bad)
+  DEPENDS:=+ALL:gst1-plugins-bad +gstreamer1-plugins-base
+endef
+
+define Package/gstreamer1-plugins-bad/config
+    menu "Select GStreamer bad modules and libraries"
+      depends on PACKAGE_gstreamer1-plugins-bad
+
+
+    config gst1-plugins-bad-all
+      bool "Include all GStreamer bad plugins"
+      select PACKAGE_gst1-plugins-bad
+
+    comment "Modules"
+
+   $(foreach mod,$(GST_BAD_MODULES), \
+    config PACKAGE_gst1-mod-$(mod)
+      prompt "GStreamer $(mod) module"
+
+   )
+
+    comment "Libraries"
+
+   $(foreach lib,$(GST_BAD_LIBS), \
+    config PACKAGE_libgst1$(lib)
+      prompt "GStreamer $(lib) library"
+
+   )
+
+  endmenu
+
+endef
 
 GST_VERSION:=1.0
 
@@ -135,7 +173,7 @@ EXTRA_LDFLAGS+= \
 	$(if $(ICONV_FULL),-liconv) \
 
 
-define Package/gst1-plugins-ugly/install
+define Package/gst1-plugins-bad/install
 	/bin/true
 endef
 
@@ -147,14 +185,16 @@ define GstBuildLibrary
 
   GST_DEPENDS += +libgst1$(1)
 
+  GST_BAD_LIBS+= $(1)
   define Package/libgst1$(1)
-    $(call Package/gstreamer1/Default)
+    $(call Package/gstreamer1-bad/Default)
     TITLE+= $(2) library (base)
-    DEPENDS+= +libgstreamer1 $$(foreach p,$(3),+libgst1$$(p)) $(4)
+    DEPENDS+= $$(foreach p,$(3),+libgst1$$(p)) $(4)
+    HIDDEN:=1
   endef
 
   define Package/libgst1$(1)/description
-   $(call Package/gstreamer1/description/Default)
+   $(call Package/gstreamer1-bad/description/Default)
    .
    This package contains the GStreamer $(2) library.
   endef
@@ -182,14 +222,17 @@ define GstBuildPlugin
 
   GST_DEPENDS += +gst1-mod-$(1)
 
+  GST_BAD_MODULES+= $(1)
+
   define Package/gst1-mod-$(1)
-    $(call Package/gstreamer1/Default)
+    $(call Package/gstreamer1-bad/Default)
     TITLE+= $(2) plugin (bad)
-    DEPENDS+= +libgstreamer1 $$(foreach p,$(3),+libgst1$$(p)) $$(foreach p,$(4),+gst1-mod-$$(p)) $(5)
+    DEPENDS+= $$(foreach p,$(3),+libgst1$$(p)) $$(foreach p,$(4),+gst1-mod-$$(p)) $(5)
+    HIDDEN:=1
   endef
 
   define Package/gst1-mod-$(1)/description
-   $(call Package/gstreamer1/description/Default)
+   $(call Package/gstreamer1-bad/description/Default)
    .
    This package contains the GStreamer $(2) plugin.
   endef
@@ -235,4 +278,5 @@ $(eval $(call GstBuildPlugin,siren,siren support,audio rtp,,))
 $(eval $(call GstBuildPlugin,speed,speed support,audio,,))
 $(eval $(call GstBuildPlugin,subenc,subenc support,controller,,))
 
+$(eval $(call BuildPackage,gstreamer1-plugins-bad))
 $(eval $(call BuildPackage,gst1-plugins-bad))

--- a/multimedia/gst1-plugins-base/Makefile
+++ b/multimedia/gst1-plugins-base/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-base
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -21,7 +21,7 @@ PKG_SOURCE:=gst-plugins-base-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-plugins-base/
 PKG_MD5SUM:=17aeabfbcd232526f50c9bee375f1b97
 
-PKG_BUILD_DEPENDS:= gstreamer1 liboil
+PKG_BUILD_DEPENDS:= libgstreamer1 liboil
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_gst1-mod-alsa \
 	CONFIG_PACKAGE_gst1-mod-app \
@@ -36,6 +36,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_gst1-mod-videotestsrc \
 	CONFIG_PACKAGE_gst1-mod-volume \
 	CONFIG_PACKAGE_gst1-mod-vorbis \
+	CONFIG_PACKAGE_libgst1app \
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -43,32 +44,70 @@ PKG_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
-define Package/gstreamer1/Default
+GST_BASE_LIBS:=
+GST_BASE_MODULES:=
+
+define Package/gstreamer1-base/Default
   CATEGORY:=Multimedia
   SECTION:=multimedia
   TITLE:=GStreamer
   URL:=http://gstreamer.freedesktop.org/
-  DEPENDS:= $(ICONV_DEPENDS)
+  DEPENDS:= +libgstreamer1 $(ICONV_DEPENDS)
 endef
 
-define Package/gstreamer1/description/Default
+define Package/gstreamer1-base/description/Default
  GStreamer open source multimedia framework
 endef
 
 
 define Package/gst1-plugins-base
-$(call Package/gstreamer1/Default)
+$(call Package/gstreamer1-base/Default)
   TITLE+= plugins collection (base)
   DEPENDS+= $(GST_DEPENDS)
+  HIDDEN:=1
 endef
 
 define Package/gts1-plugins-base/description
-$(call Package/gstreamer1/description/Default)
+$(call Package/gstreamer1-base/description/Default)
  .
  This meta package contains only dependencies to the other libraries and
  plugins from the base plugins collection.
 endef
 
+define Package/gstreamer1-plugins-base
+  $(call Package/gstreamer1-base/Default)
+  TITLE+= plugins collection (base)
+  DEPENDS:=+ALL:gst1-plugins-base +gstreamer1-libs
+endef
+
+define Package/gstreamer1-plugins-base/config
+    menu "Select GStreamer base modules and libraries"
+      depends on PACKAGE_gstreamer1-plugins-base
+
+
+    config gst1-plugins-base-all
+      bool "Include all GStreamer base plugins"
+      select PACKAGE_gst1-plugins-base
+
+    comment "Modules"
+
+   $(foreach mod,$(GST_BASE_MODULES), \
+    config PACKAGE_gst1-mod-$(mod)
+      prompt "GStreamer $(mod) module"
+
+   )
+
+    comment "Libraries"
+
+   $(foreach lib,$(GST_BASE_LIBS), \
+    config PACKAGE_libgst1$(lib)
+      prompt "GStreamer $(lib) library"
+
+   )
+
+  endmenu
+
+endef
 
 GST_COND_SELECT = $(patsubst %,$(if $(CONFIG_PACKAGE_gst1-mod-$(1)),--enable,--disable)-%,$(1))
 
@@ -156,14 +195,17 @@ define GstBuildLibrary
 
   GST_DEPENDS += +libgst1$(1)
 
+  GST_BASE_LIBS+= $(1)
+
   define Package/libgst1$(1)
-    $(call Package/gstreamer1/Default)
+    $(call Package/gstreamer1-base/Default)
     TITLE+= $(2) library (base)
-    DEPENDS+= +libgstreamer1 $$(foreach p,$(3),+libgst1$$(p)) $(4)
+    DEPENDS+= $$(foreach p,$(3),+libgst1$$(p)) $(4)
+    HIDDEN:=1
   endef
 
   define Package/libgst1$(1)/description
-   $(call Package/gstreamer1/description/Default)
+   $(call Package/gstreamer1-base/description/Default)
    .
    This package contains the GStreamer $(2) library.
   endef
@@ -190,7 +232,6 @@ $(eval $(call GstBuildLibrary,sdp,SDP,,))
 $(eval $(call GstBuildLibrary,tag,tag support,,))
 $(eval $(call GstBuildLibrary,video,video,,))
 
-
 # 1: short name
 # 2: description
 # 3: dependencies on other gstreamer libraries (short name)
@@ -200,14 +241,17 @@ define GstBuildPlugin
 
   GST_DEPENDS += +gst1-mod-$(1)
 
+  GST_BASE_MODULES+= $(1)
+
   define Package/gst1-mod-$(1)
-    $(call Package/gstreamer1/Default)
+    $(call Package/gstreamer1-base/Default)
     TITLE+= $(2) plugin (base)
-    DEPENDS+= +libgstreamer1 $$(foreach p,$(3),+libgst1$$(p)) $$(foreach p,$(4),+gst1-mod-$$(p)) $(5)
+    DEPENDS+= $$(foreach p,$(3),+libgst1$$(p)) $$(foreach p,$(4),+gst1-mod-$$(p)) $(5)
+    HIDDEN:=1
   endef
 
   define Package/gst1-mod-$(1)/description
-   $(call Package/gstreamer1/description/Default)
+   $(call Package/gstreamer1-base/description/Default)
    .
    This package contains the GStreamer $(2) plugin.
   endef
@@ -239,4 +283,5 @@ $(eval $(call GstBuildPlugin,videotestsrc,video test,video,,+liboil))
 $(eval $(call GstBuildPlugin,volume,volume,audio controller,,+liboil))
 $(eval $(call GstBuildPlugin,vorbis,Vorbis,audio tag,ogg,+libvorbis))
 
+$(eval $(call BuildPackage,gstreamer1-plugins-base))
 $(eval $(call BuildPackage,gst1-plugins-base))

--- a/multimedia/gst1-plugins-good/Makefile
+++ b/multimedia/gst1-plugins-good/Makefile
@@ -1,4 +1,5 @@
-## Copyright (C) 2009-2014 OpenWrt.org
+#
+# Copyright (C) 2009-2014 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-good
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -20,7 +21,7 @@ PKG_SOURCE:=gst-plugins-good-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-plugins-good/
 PKG_MD5SUM:=1a1f96bc27ad446e559474299160a9a8
 
-PKG_BUILD_DEPENDS:= gstreamer1 gst1-plugins-base liboil
+PKG_BUILD_DEPENDS:= libgstreamer1 gstreamer1-plugins-base liboil
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -28,32 +29,62 @@ PKG_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
-define Package/gstreamer1/Default
+GST_GOOD_MODULES:=
+
+define Package/gstreamer1-good/Default
   CATEGORY:=Multimedia
   SECTION:=multimedia
   TITLE:=GStreamer
   URL:=http://gstreamer.freedesktop.org/
-  DEPENDS:= $(ICONV_DEPENDS)
+  DEPENDS:= +libgstreamer1 $(ICONV_DEPENDS)
 endef
 
-define Package/gstreamer1/description/Default
+define Package/gstreamer1-good/description/Default
  GStreamer open source multimedia framework
 endef
 
 
 define Package/gst1-plugins-good
-$(call Package/gstreamer1/Default)
+$(call Package/gstreamer1-good/Default)
   TITLE+= plugins collection (good)
   DEPENDS+= $(GST_DEPENDS)
+  HIDDEN:=1
 endef
 
-define Package/gts-plugins-good/description
-$(call Package/gstreamer1/description/Default)
+define Package/gst1-plugins-good/description
+$(call Package/gstreamer1-good/description/Default)
  .
  This meta package contains only dependencies to the other plugins from
  the good plugins collection.
 endef
 
+
+define Package/gstreamer1-plugins-good
+  $(call Package/gstreamer1-good/Default)
+  TITLE+= plugins collection (good)
+  DEPENDS:=+ALL:gst1-plugins-good +gstreamer1-plugins-base
+endef
+
+define Package/gstreamer1-plugins-good/config
+    menu "Select GStreamer good modules"
+      depends on PACKAGE_gstreamer1-plugins-good
+
+
+    config gst1-plugins-good-all
+      bool "Include all GStreamer good plugins"
+      select PACKAGE_gst1-plugins-good
+
+    comment "Modules"
+
+   $(foreach mod,$(GST_GOOD_MODULES), \
+    config PACKAGE_gst1-mod-$(mod)
+      prompt "GStreamer $(mod) module"
+
+   )
+
+  endmenu
+
+endef
 
 GST_VERSION:=1.0
 
@@ -112,14 +143,17 @@ define GstBuildPlugin
 
   GST_DEPENDS += +gst1-mod-$(1)
 
+  GST_GOOD_MODULES+= $(1)
+
   define Package/gst1-mod-$(1)
-    $(call Package/gstreamer1/Default)
+    $(call Package/gstreamer1-good/Default)
     TITLE+= $(2) plugin (good)
-    DEPENDS+= +libgstreamer1 $$(foreach p,$(3),+libgst1$$(p)) $$(foreach p,$(4),+gst1-mod-$$(p)) $(5)
+    DEPENDS+= $$(foreach p,$(3),+libgst1$$(p)) $$(foreach p,$(4),+gst1-mod-$$(p)) $(5)
+    HIDDEN:=1
   endef
 
   define Package/gst1-mod-$(1)/description
-   $(call Package/gstreamer1/description/Default)
+   $(call Package/gstreamer1-good/description/Default)
    .
    This package contains the GStreamer $(2) plugin.
   endef
@@ -199,4 +233,5 @@ $(eval $(call GstBuildPlugin,wavenc,Wav encoder,riff,,))
 $(eval $(call GstBuildPlugin,wavparse,Wav parser,audio riff tag,,))
 #$(eval $(call GstBuildPlugin,ximagesrc,ximagesrc support,video,,))
 
+$(eval $(call BuildPackage,gstreamer1-plugins-good))
 $(eval $(call BuildPackage,gst1-plugins-good))

--- a/multimedia/gst1-plugins-ugly/Makefile
+++ b/multimedia/gst1-plugins-ugly/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-ugly
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -21,7 +21,7 @@ PKG_SOURCE:=gst-plugins-ugly-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-plugins-ugly/
 PKG_MD5SUM:=7ae60e2f759f58f32af5fcdc3c9193c4
 
-PKG_BUILD_DEPENDS:= gstreamer1 gst1-plugins-base liboil
+PKG_BUILD_DEPENDS:= libgstreamer1 gstreamer1-plugins-base liboil
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_gst1-mod-asf \
 	CONFIG_PACKAGE_gst1-mod-lame \
@@ -34,32 +34,62 @@ PKG_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
-define Package/gstreamer1/Default
+GST_UGLY_MODULES:=
+
+define Package/gstreamer1-ugly/Default
   CATEGORY:=Multimedia
   SECTION:=multimedia
   TITLE:=GStreamer
   URL:=http://gstreamer.freedesktop.org/
-  DEPENDS:= $(ICONV_DEPENDS)
+  DEPENDS:= +libgstreamer1 $(ICONV_DEPENDS)
 endef
 
-define Package/gstreamer1/description/Default
+define Package/gstreamer1-ugly/description/Default
  GStreamer open source multimedia framework
 endef
 
 
 define Package/gst1-plugins-ugly
-$(call Package/gstreamer1/Default)
+$(call Package/gstreamer1-ugly/Default)
   TITLE+= plugins collection (ugly)
   DEPENDS+= $(GST_DEPENDS)
+  HIDDEN:=1
 endef
 
 define Package/gts-plugins-ugly/description
-$(call Package/gstreamer1/description/Default)
+$(call Package/gstreamer1-ugly/description/Default)
  .
  This meta package contains only dependencies to the other plugins from
  the ugly plugins collection.
 endef
 
+
+define Package/gstreamer1-plugins-ugly
+  $(call Package/gstreamer1-ugly/Default)
+  TITLE+= plugins collection (ugly)
+  DEPENDS:=+ALL:gst1-plugins-ugly +gstreamer1-plugins-base
+endef
+
+define Package/gstreamer1-plugins-ugly/config
+    menu "Select GStreamer ugly modules"
+      depends on PACKAGE_gstreamer1-plugins-ugly
+
+
+    config gst1-plugins-ugly-all
+      bool "Include all GStreamer ugly plugins"
+      select PACKAGE_gst1-plugins-ugly
+
+    comment "Modules"
+
+   $(foreach mod,$(GST_UGLY_MODULES), \
+    config PACKAGE_gst1-mod-$(mod)
+      prompt "GStreamer $(mod) module"
+
+   )
+
+  endmenu
+
+endef
 
 GST_COND_SELECT = $(patsubst %,$(if $(CONFIG_PACKAGE_gst1-mod-$(1)),--enable,--disable)-%,$(1))
 
@@ -111,14 +141,17 @@ define GstBuildPlugin
 
   GST_DEPENDS += +gst1-mod-$(1)
 
+  GST_UGLY_MODULES+= $(1)
+
   define Package/gst1-mod-$(1)
-    $(call Package/gstreamer1/Default)
+    $(call Package/gstreamer1-ugly/Default)
     TITLE+= $(2) plugin (ugly)
     DEPENDS+= +libgstreamer1 $$(foreach p,$(3),+libgst1$$(p)) $$(foreach p,$(4),+gst1-mod-$$(p)) $(5)
+    HIDDEN:=1
   endef
 
   define Package/gst1-mod-$(1)/description
-   $(call Package/gstreamer1/description/Default)
+   $(call Package/gstreamer1-ugly/description/Default)
    .
    This package contains the GStreamer $(2) plugin.
   endef
@@ -139,4 +172,5 @@ $(eval $(call GstBuildPlugin,lame,MP3 encoder (using LAME),audio,,+lame-lib))
 $(eval $(call GstBuildPlugin,mad,MP3 decoder (using MAD),audio tag,,+libid3tag +libmad))
 $(eval $(call GstBuildPlugin,mpeg2dec,MPEG decoder,video,,+libmpeg2))
 
+$(eval $(call BuildPackage,gstreamer1-plugins-ugly))
 $(eval $(call BuildPackage,gst1-plugins-ugly))

--- a/multimedia/gstreamer1/Makefile
+++ b/multimedia/gstreamer1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gstreamer1
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -41,45 +41,73 @@ define Package/gstreamer1/description/Default
  GStreamer open source multimedia framework
 endef
 
+GSTREAMER_CORE_LIBS:= \
+	libgstreamer1 \
+	libgst1check \
+	libgst1controller \
+	libgst1net
 
 define Package/gstreamer1
-$(call Package/gstreamer1/Default)
-  TITLE+= framework
-  DEPENDS+= +libgstreamer1 \
-	+libgst1check \
-	+libgst1controller \
-	+libgst1net
+  $(call Package/gstreamer1/Default)
+  TITLE+= (All libraries)
+  DEPENDS:= $(foreach lib,$(GSTREAMER_CORE_LIBS),+$(lib))
+  HIDDEN:=1
 endef
 
-define Package/gstreamer1/description
-$(call Package/gstreamer1/description/Default)
+define Package/gstreamer1-libs/description
+ $(call Package/gstreamer1/description/Default)
  .
  This meta package contains only dependencies on the other GStreamer
  componenents.
 endef
 
+define Package/gstreamer1-libs
+  $(call Package/gstreamer1/Default)
+  TITLE+= core libraries
+  DEPENDS+=+ALL:gstreamer1
+endef
+
+define Package/gstreamer1-libs/config
+    menu "Select GStreamer libraries"
+      depends on PACKAGE_gstreamer1-libs
+
+    config gstreamer1-all
+      bool "Include all GStreamer1 core libraries"
+      select PACKAGE_gstreamer1
+
+    comment "Libraries"
+
+   $(foreach lib,$(GSTREAMER_CORE_LIBS), \
+    config PACKAGE_$(lib)
+      prompt "GStreamer core library $(lib)"
+
+   )
+
+  endmenu
+
+endef
 
 define Package/gstreamer1-utils
-$(call Package/gstreamer1/Default)
+  $(call Package/gstreamer1/Default)
   TITLE+= utilities
-  DEPENDS+= +libgstreamer1
+  DEPENDS+= +libgstreamer1 +gstreamer1-libs
 endef
 
 define Package/gstreamer1-utils/description
-$(call Package/gstreamer1/description/Default)
+ $(call Package/gstreamer1/description/Default)
  .
  This package contains the GStreamer utilities.
 endef
 
-
 define Package/libgstreamer1
-$(call Package/gstreamer1/Default)
+  $(call Package/gstreamer1/Default)
   TITLE+= library (core)
   DEPENDS+= +glib2 +libpthread +libxml2
+  HIDDEN:=1
 endef
 
 define Package/libgstreamer1/description
-$(call Package/gstreamer1/description/Default)
+ $(call Package/gstreamer1/description/Default)
  .
  This package contains the GStreamer core library.
 endef
@@ -129,7 +157,10 @@ define Build/InstallDev
 endef
 
 define Package/gstreamer1/install
-	/bin/true
+  true
+endef
+
+define Package/gstreamer1-libs/install
 endef
 
 define Package/gstreamer1-utils/install
@@ -167,6 +198,7 @@ define GstBuildLibrary
     $(call Package/gstreamer1/Default)
     TITLE+= $(2) library (core)
     DEPENDS+= +libgstreamer1 $$(foreach p,$(3),+libgst1$$(p)) $(4)
+    HIDDEN:=1
   endef
 
   define Package/libgst1$(1)/description
@@ -191,5 +223,6 @@ $(eval $(call GstBuildLibrary,controller,dynamic parameter control))
 $(eval $(call GstBuildLibrary,net,network classes))
 
 $(eval $(call BuildPackage,libgstreamer1))
-$(eval $(call BuildPackage,gstreamer1))
+$(eval $(call BuildPackage,gstreamer1-libs))
 $(eval $(call BuildPackage,gstreamer1-utils))
+$(eval $(call BuildPackage,gstreamer1))


### PR DESCRIPTION
gstreamer adds many module and library options to the top-level multimedia menu. These changes push the individual plugin modules and libraries to a secondary selection page depending on the main package choosen (libs, base, good, bad, ugly). Utils remains a top level package. Options to select ALL have been added rather than implied.

Signed-off-by: Ted Hess thess@kitschensync.net
