### PR TITLE
gst1-libav: Import gstreamer libary based on bundled libav

### DIFF
--- a/multimedia/gst1-libav/Config.in
+++ b/multimedia/gst1-libav/Config.in
@@ -1,0 +1,279 @@
+menu "Select GStreamer libav configuration options"
+	depends on PACKAGE_gst1-libav
+
+config GST1_LIBAV_IPV6
+	bool "Enable IPv6"
+	default IPV6
+
+config GST1_LIBAV_PATENTED
+	bool "Include patented codecs and technologies"
+	default BUILD_PATENTED
+
+config GET_LIBAV_COMMON_AV_SUPPORT
+	bool "Include support for common audio/video decoders"
+	default y
+	select GST1_LIBAV_DECODER_aac if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DECODER_ac3 if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DECODER_h264 if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DECODER_atrac3 if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DECODER_jpegls
+	select GST1_LIBAV_DECODER_mp3 if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DECODER_mpeg1video
+	select GST1_LIBAV_DECODER_mpeg2video if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DECODER_mpeg4 if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DECODER_mpeg4aac if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DECODER_mpegvideo
+	select GST1_LIBAV_DECODER_pcm_s16be
+	select GST1_LIBAV_DECODER_pcm_s16le
+	select GST1_LIBAV_DECODER_vorbis
+	select GST1_LIBAV_DECODER_wmav1 if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DECODER_wmav2 if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DECODER_png
+	select GST1_LIBAV_PARSER_aac if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_PARSER_h264 if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_PARSER_mpegaudio
+	select GST1_LIBAV_PARSER_mpegvideo
+	select GST1_LIBAV_PARSER_mpeg4video
+	select GST1_LIBAV_DEMUXER_ac3
+	select GST1_LIBAV_DEMUXER_h264 if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DEMUXER_mp3 if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DEMUXER_mpegvideo if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DEMUXER_ogg
+
+comment "Encoders ---"
+
+config GST1_LIBAV_ENCODER_ac3
+	bool "AC3"
+	depends on GST1_LIBAV_PATENTED
+	select GST1_LIBAV_PARSER_ac3
+
+config GST1_LIBAV_ENCODER_jpegls
+	bool "JPEG-LS"
+
+config GST1_LIBAV_ENCODER_mpeg1video
+	bool "MPEG-1 Video"
+
+config GST1_LIBAV_ENCODER_mpeg2video
+	bool "MPEG-2 Video"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_ENCODER_mpeg4
+	bool "MPEG-4"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_ENCODER_pcm_s16be
+	bool "PCM signed 16-bit big-endian"
+
+config GST1_LIBAV_ENCODER_pcm_s16le
+	bool "PCM signed 16-bit little-endian"
+
+config GST1_LIBAV_ENCODER_png
+	bool "PNG"
+	select GST1_LIBAV_ENCODER_zlib
+
+config GST1_LIBAV_ENCODER_vorbis
+	bool "Vorbis"
+
+config GST1_LIBAV_ENCODER_zlib
+	bool "Zlib"
+
+comment "Decoders ---"
+
+config GST1_LIBAV_DECODER_aac
+	bool "AAC (Advanced Audio Coding)"
+	depends on GST1_LIBAV_PATENTED
+	select GST1_LIBAV_PARSER_aac
+
+config GST1_LIBAV_DECODER_ac3
+	bool "AC3"
+	depends on GST1_LIBAV_PATENTED
+	select GST1_LIBAV_PARSER_ac3
+
+config GST1_LIBAV_DECODER_atrac3
+	bool "ATRAC3"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_DECODER_gif
+	bool "GIF"
+
+config GST1_LIBAV_DECODER_h264
+	bool "H.264"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_DECODER_jpegls
+	bool "JPEG-LS"
+
+config GST1_LIBAV_DECODER_mp2
+	bool "MP2 (MPEG Audio Layer 2)"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_DECODER_mp3
+	bool "MP3 (MPEG Audio Layer 2)"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_DECODER_mpegvideo
+	bool "MPEG Video"
+
+config GST1_LIBAV_DECODER_mpeg1video
+	bool "MPEG-1 Video"
+
+config GST1_LIBAV_DECODER_mpeg2video
+	bool "MPEG-2 Video"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_DECODER_mpeg4
+	bool "MPEG-4"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_DECODER_mpeg4aac
+	bool "MPEG-4 (AAC)"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_DECODER_pcm_s16be
+	bool "PCM signed 16-bit big-endian"
+
+config GST1_LIBAV_DECODER_pcm_s16le
+	bool "PCM signed 16-bit little-endian"
+
+config GST1_LIBAV_DECODER_png
+	bool "PNG"
+	select GST1_LIBAV_DECODER_zlib
+
+config GST1_LIBAV_DECODER_vorbis
+	bool "Vorbis"
+
+config GST1_LIBAV_DECODER_wmav1
+	bool "WMAv1"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_DECODER_wmav2
+	bool "WMAv2"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_DECODER_zlib
+	bool "Zlib"
+
+comment "Muxers ---"
+
+config GST1_LIBAV_MUXER_ac3
+	bool "AC3"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_MUXER_ffm
+	bool "FFM (ffserver live feed)"
+
+config GST1_LIBAV_MUXER_h264
+	bool "H.264"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_MUXER_mp3
+	bool "MP3 (MPEG Audio Layer 3)"
+
+config GST1_LIBAV_MUXER_mp4
+	bool "MP4"
+
+config GST1_LIBAV_MUXER_mpeg1video
+	bool "MPEG-1 Video"
+
+config GST1_LIBAV_MUXER_mpeg2video
+	bool "MPEG-2 Video"
+
+config GST1_LIBAV_MUXER_mpegts
+	bool "MPEG-2 (TS)"
+
+config GST1_LIBAV_MUXER_ogg
+	bool "Ogg"
+
+config GST1_LIBAV_MUXER_oss
+	bool "OSS (Open Sound System playback)"
+
+config GST1_LIBAV_MUXER_rtp
+	bool "RTP"
+
+comment "Demuxers ---"
+
+config GST1_LIBAV_DEMUXER_ac3
+	bool "AC3"
+
+config GST1_LIBAV_DEMUXER_ffm
+	bool "FFM (ffserver live feed)"
+
+config GST1_LIBAV_DEMUXER_h264
+	bool "H.264"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_DEMUXER_mp3
+	bool "MP3 (MPEG Audio Layer 3)"
+
+config GST1_LIBAV_DEMUXER_mpegvideo
+	bool "MPEG Video"
+
+config GST1_LIBAV_DEMUXER_mpegps
+	bool "MPEG-2 (PS)"
+
+config GST1_LIBAV_DEMUXER_mpegts
+	bool "MPEG-2 (TS)"
+
+config GST1_LIBAV_DEMUXER_ogg
+	bool "Ogg"
+
+config GST1_LIBAV_DEMUXER_rm
+	bool "RM"
+	help
+	  RealMedia format demuxer
+
+config GST1_LIBAV_DEMUXER_rtsp
+	bool "RTSP"
+	select GST1_LIBAV_DEMUXER_rm
+	select GST1_LIBAV_DEMUXER_sdp
+
+config GST1_LIBAV_DEMUXER_sdp
+	bool "SDP"
+	select GST1_LIBAV_DEMUXER_mpegts
+
+comment "Parsers ---"
+
+config GST1_LIBAV_PARSER_aac
+	bool "AAC (Advanced Audio Coding)"
+	depends on GST1_LIBAV_PATENTED
+
+config GST1_LIBAV_PARSER_ac3
+	bool "AC3"
+
+config GST1_LIBAV_PARSER_h264
+	bool "H.264"
+	depends on GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DECODER_h264
+
+config GST1_LIBAV_PARSER_mpegaudio
+	bool "MPEG Audio"
+
+config GST1_LIBAV_PARSER_mpegvideo
+	bool "MPEG Video"
+
+config GST1_LIBAV_PARSER_mpeg4video
+	bool "MPEG-4 Video"
+
+comment "Protocols ---"
+
+config GST1_LIBAV_PROTOCOL_file
+	bool "file:"
+
+config GST1_LIBAV_PROTOCOL_http
+	bool "http:"
+
+config GST1_LIBAV_PROTOCOL_pipe
+	bool "pipe:"
+
+config GST1_LIBAV_PROTOCOL_rtp
+	bool "rtp:"
+	select GST1_LIBAV_PROTOCOL_udp
+
+config GST1_LIBAV_PROTOCOL_tcp
+	bool "tcp:"
+
+config GST1_LIBAV_PROTOCOL_udp
+	bool "udp:"
+
+endmenu
+

--- a/multimedia/gst1-libav/Makefile
+++ b/multimedia/gst1-libav/Makefile
@@ -1,0 +1,183 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gst1-libav
+PKG_VERSION:=1.2.3
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+
+PKG_SOURCE:=gst-libav-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-libav
+PKG_MD5SUM:=58c7998a054d8d8ca041fa35738f72b6
+
+PKG_LICENSE:=GPL-2.0 LGPL-2.0
+PKG_LICENSE_FILE:=COPYING COPYING.LIB
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/gst-libav-$(PKG_VERSION)
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+PKG_USE_MIPS16:=0
+
+GST_VERSION:=1.0
+
+LIBAV_ENCODERS:= \
+	ac3 \
+	jpegls \
+	mpeg1video \
+	mpeg2video \
+	mpeg4 \
+	pcm_s16be \
+	pcm_s16le \
+	png \
+	vorbis \
+	zlib \
+
+LIBAV_DECODERS:= \
+	aac \
+	ac3 \
+	atrac3 \
+	gif \
+	h264 \
+	jpegls \
+	mp2 \
+	mp3 \
+	mpeg1video \
+	mpeg2video \
+	mpeg4 \
+	mpeg4aac \
+	mpegvideo \
+	pcm_s16be \
+	pcm_s16le \
+	png \
+	vorbis \
+	wmav1 \
+	wmav2 \
+	zlib \
+
+LIBAV_MUXERS:= \
+	ac3 \
+	ffm \
+	h264 \
+	mp3 \
+	mp4 \
+	mpeg1video \
+	mpeg2video \
+	mpegts \
+	ogg \
+	oss \
+	rtp \
+
+LIBAV_DEMUXERS:= \
+	ac3 \
+	ffm \
+	h264 \
+	mp3 \
+	mpegps \
+	mpegts \
+	mpegvideo \
+	ogg \
+	rm \
+	rtsp \
+	sdp \
+	v4l2 \
+
+LIBAV_PARSERS:= \
+	aac \
+	ac3 \
+	h264 \
+	mpegaudio \
+	mpegvideo \
+	mpeg4video \
+
+LIBAV_PROTOCOLS:= \
+	file http pipe rtp tcp udp
+
+PKG_CONFIG_DEPENDS:= \
+	$(patsubst %,CONFIG_GST1_LIBAV_ENCODER_%,$(LIBAV_ENCODERS)) \
+	$(patsubst %,CONFIG_GST1_LIBAV_DECODER_%,$(LIBAV_DECODERS)) \
+	$(patsubst %,CONFIG_GST1_LIBAV_MUXER_%,$(LIBAV_DEMUXERS)) \
+	$(patsubst %,CONFIG_GST1_LIBAV_DEMUXER_%,$(LIBAV_DEMUXERS)) \
+	$(patsubst %,CONFIG_GST1_LIBAV_PARSER_%,$(LIBAV_PARSERS)) \
+	$(patsubst %,CONFIG_GST1_LIBAV_PROTOCOL_%,$(LIBAV_PROTOCOLS))
+
+PKG_BUILD_DEPENDS:= libstreamer1 gstreamer1-plugins-base
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/gst1-libav
+  SECTION:=multimedia
+  CATEGORY:=Multimedia
+  TITLE:=GStreamer Libav plugin
+  URL:=http://www.gstreamer.net/modules/gst-libav.html
+  DEPENDS:= +libgstreamer1 +gstreamer1-plugins-base \
+	    +gst1-mod-alsa +libgst1audio +libgst1pbutils +libgst1video \
+	    +libbz2
+endef
+
+define Package/gst1-libav/description
+  GStreamer with libav bindings using internal Libav
+endef
+
+define Package/gst1-libav/config
+  source "$(SOURCE)/Config.in"
+endef
+
+FILTER_CONFIG= \
+	$(foreach c, $(3), \
+		$(if $(CONFIG_GST1_LIBAV_$(1)_$(c)),--enable-$(2)='$(c)') \
+	)
+
+LIBAV_CONFIGURE_ENCODERS:=$(call FILTER_CONFIG,ENCODER,encoder,$(LIBAV_ENCODERS))
+LIBAV_CONFIGURE_DECODERS:=$(call FILTER_CONFIG,DECODER,decoder,$(LIBAV_DECODERS))
+LIBAV_CONFIGURE_MUXERS:=$(call FILTER_CONFIG,MUXER,muxer,$(LIBAV_MUXERS))
+LIBAV_CONFIGURE_DEMUXERS:=$(call FILTER_CONFIG,DEMUXER,demuxer,$(LIBAV_DEMUXERS))
+LIBAV_CONFIGURE_PARSERS:=$(call FILTER_CONFIG,PARSER,parser,$(LIBAV_PARSERS))
+LIBAV_CONFIGURE_PROTOCOLS:=$(call FILTER_CONFIG,PROTOCOL,protocol,$(LIBAV_PROTOCOLS))
+
+CONFIGURE_ARGS += \
+	--with-libav-extra-configure="--target-os=linux \
+	--without-system-libav \
+	--disable-bsfs \
+	--disable-devices \
+	--disable-encoders \
+	$(LIBAV_CONFIGURE_ENCODERS) \
+	--disable-decoders \
+	$(LIBAV_CONFIGURE_DECODERS) \
+	--disable-muxers \
+	$(LIBAV_CONFIGURE_MUXERS) \
+	--disable-demuxers \
+	$(LIBAV_CONFIGURE_DEMUXERS) \
+	--disable-parsers \
+	$(LIBAV_CONFIGURE_PARSERS) \
+	--disable-protocols \
+	$(LIBAV_CONFIGURE_PROTOCOLS)"
+
+# XXX: trick to force use of embedded Libav headers
+TARGET_CFLAGS += $(TARGET_CPPFLAGS)
+TARGET_CPPFLAGS :=
+
+TARGET_LDFLAGS += $(FPIC)
+
+define Build/Prepare
+$(call Build/Prepare/Default)
+endef
+
+define Package/gst1-libav/install
+	$(INSTALL_DIR) $(1)/usr/lib/gstreamer-$(GST_VERSION)
+	( cd $(PKG_INSTALL_DIR); $(CP) \
+                ./usr/lib/gstreamer-$(GST_VERSION)/libgstlibav.so* \
+                $(1)/usr/lib/gstreamer-$(GST_VERSION)/ \
+        )
+endef
+
+$(eval $(call BuildPackage,gst1-libav))


### PR DESCRIPTION
GStreamer 1.x no longer uses ffmpeg (for now). This packages uses a bundled version of libav included in the sources.

Signed-off-by: Ted Hess thess@kitschensync.net
