### PR TITLE
for-14.07: xinetd: socket bind: Invalid argument (errno = 22) when using USERID on ...

### DIFF
--- a/net/xinetd/patches/004-ident-bind.patch
+++ b/net/xinetd/patches/004-ident-bind.patch
@@ -1,0 +1,42 @@
+xinetd: socket bind: Invalid argument (errno = 22) when using USERID on ipv6
+
+Use right size of addresses in bind() call. Also use getpeername addresses when
+connecting to ident service to prevent address family mismatch between socket(),
+bind() and connect() calls.
+
+Author: Jan Safranek <jsafrane@redhat.com>
+Reviewed-By: Adam Tkac <atkac@redhat.com>
+
+#diff -up xinetd-2.3.14/xinetd/ident.c.orig xinetd-2.3.14/xinetd/ident.c
+--- a/xinetd/ident.c
++++ b/xinetd/ident.c
+@@ -97,7 +98,13 @@ idresult_e log_remote_user( const struct
+    }
+ 
+    CLEAR( sin_contact );
+-   sin_remote = *CONN_XADDRESS( SERVER_CONNECTION( serp ) ) ;
++
++   sin_len = sizeof( sin_remote );
++   if ( getpeername( SERVER_FD( serp ), &sin_remote.sa, &sin_len ) == -1 )
++   {
++      msg( LOG_ERR, func, "(%d) getpeername: %m", getpid() ) ;
++      return( IDR_ERROR ) ;
++   }
+    sin_contact = sin_remote;
+    memcpy( &sin_bind, &sin_local, sizeof(sin_bind) ) ;
+    local_port = 0;
+@@ -121,7 +128,13 @@ idresult_e log_remote_user( const struct
+       msg( LOG_ERR, func, "socket creation: %m" ) ;
+       return( IDR_ERROR ) ;
+    }
+-   if ( bind(sd, &sin_bind.sa, sizeof(sin_bind.sa)) == -1 )
++
++   if ( sin_bind.sa.sa_family == AF_INET ) 
++      sin_len = sizeof( sin_bind.sa_in ) ;
++   else
++      sin_len = sizeof( sin_bind.sa_in6 ) ;
++
++   if ( bind(sd, &sin_bind.sa, sin_len) == -1 )
+    { 
+       msg( LOG_ERR, func, "socket bind: %m" ) ;
+       (void) Sclose( sd ) ;


### PR DESCRIPTION
copied from trunk

Signed-off-by: Christian Schoenebeck christian.schoenebeck@gmail.com
