### PR TITLE
openvswitch: cleanup and updates

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -56,17 +56,6 @@ define Package/openvswitch/description
   Provides the main userspace components required for Open vSwitch to function.
 endef
 
-define Package/openvswitch-ipsec
-  $(call Package/openvswitch/Default)
-  TITLE:=Open vSwitch Userspace Package
-  DEPENDS:=@PACKAGE_openvswitch +PACKAGE_openvswitch:openvswitch
-endef
-
-define Package/openvswitch-ipsec/description
-  The ovs-monitor-ipsec script provides support for encrypting GRE tunnels with 
-  IPsec.
-endef
-
 define Package/openvswitch-benchmark
   $(call Package/openvswitch/Default)
   TITLE:=Open vSwitch Userspace Package
@@ -152,11 +141,6 @@ define Package/openvswitch/install
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/vswitchd/vswitch.ovsschema $(1)/usr/share/openvswitch/
 endef
 
-define Package/openvswitch-ipsec/install
-	$(INSTALL_DIR) $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/debian/ovs-monitor-ipsec $(1)/usr/sbin/
-endef
-
 define Package/openvswitch-benchmark/install
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utilities/.libs/ovs-benchmark $(1)/usr/bin/
@@ -168,7 +152,6 @@ define Package/openvswitch/postinst
 endef
 
 $(eval $(call BuildPackage,openvswitch))
-$(eval $(call BuildPackage,openvswitch-ipsec))
 $(eval $(call BuildPackage,openvswitch-benchmark))
 $(eval $(call KernelPackage,openvswitch))
 


### PR DESCRIPTION
After the [last reported build failure](https://dev.openwrt.org/ticket/17893), I figured I should do a brushing in the package feed.

The fact that we've been using this package for some time now, has made me careless with respect to it's neatness.
At least, this way, there's now a bit of history about it, that can be traced to the original author.

Major things to note:
- fixed URL to main site
- the openswitch-ipsec package has been removed due to python not being in the current package feeds; will be re-added when python is re-added; [currently it's parked here](https://github.com/commodo/packages/commits/openvswitch-ipsec-parked)
- there is now a openvswitch package (which is openvswitch-common and openvswitch-switch merged into one), which is a top-level package, and openswitch-benchmark (and others that will be further added), are now subpackages; it's better to rename now, since it's early

All's been tested on x86_64, MIPS and PowerPC.

Thanks
