### PR TITLE
net/dnscrypt-proxy: update to 1.4.1

### DIFF
--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
-PKG_VERSION:=1.4.0
+PKG_VERSION:=1.4.1
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy
-PKG_MD5SUM:=c31d14d8de2123e9f2ddf26216577841
+PKG_MD5SUM:=f2bf4195b7264813138e3c6c8da86190
 PKG_CAT:=zcat
 
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Signed-off-by: Damiano Renfer damiano.renfer@gmail.com
