### PR TITLE
horst: Add horst version 4.0

### DIFF
--- a/net/horst/Makefile
+++ b/net/horst/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006 OpenWrt.org
+# Copyright (C) 2006-2014 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -16,6 +16,10 @@ PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_URL:=git://br1.einfach.org/horst
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=version-4.0
+
+PKG_MAINTAINER:=Bruno Randolf <br1@einfach.org>
+PKG_LICENSE:=GPL-2.0+
+PKG_LICENSE_FILE:=LICENSE
 
 PKG_BUILD_PARALLEL:=1
 


### PR DESCRIPTION
Please merge as horst 3.0 from oldpackages can not show RSSI values from newer mac80211 and does not yet know about 802.11N...

Signed-off-by: Bruno Randolf br1@einfach.org
