### PR TITLE
knot: update to 1.5.3.

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,13 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=1.5.0
+PKG_VERSION:=1.5.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_MD5SUM:=d677de99c19afea3b1e8ef075a9d5a8b
+PKG_MD5SUM:=bab73ec83ad7f1d64bb765bf0c72caae
+
+PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
+PKG_LICENSE:=GPL-2.0+
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_BUILD_PARALLEL:=1
@@ -28,7 +31,6 @@ define Package/knot/Default
 	CATEGORY:=Network
 	TITLE:=Knot DNS
 	URL:=https://www.knot-dns.cz
-	MAINTAINER:=daniel.salzman@nic.cz
 	SUBMENU:=IP Addresses and Names
 	DEPENDS:=+libopenssl +liburcu
 endef

--- a/net/knot/patches/03_zscanner_tests.patch
+++ b/net/knot/patches/03_zscanner_tests.patch
@@ -34,8 +34,8 @@ index 846f351..272856c 100644
  TESTS_DIR="$SOURCE"/data
  ZSCANNER_TOOL="$BUILD"/zscanner-tool
  
--plan 68
-+plan 66
+-plan 69
++plan 67
  
  mkdir -p "$TMPDIR"/includes/
  for a in 1 2 3 4 5 6; do


### PR DESCRIPTION
As Knot DNS 1.5.0 contains some security issues, it would be better to update this package to the latest stable version 1.5.3.

Signed-off-by: Daniel Salzman daniel.salzman@nic.cz
