### PR TITLE
openvswitch: Run with nice -10 (#1765)

### DIFF
--- a/net/openvswitch/files/etc/init.d/openvswitch.init
+++ b/net/openvswitch/files/etc/init.d/openvswitch.init
@@ -21,6 +21,8 @@ start_service() {
 	procd_append_param respawn 3600
 	procd_append_param respawn 5
 	procd_append_param respawn -1
+	procd_set_param nice
+	procd_append_param nice -10
 	procd_close_instance
 
 	# ovs-vswitchd
@@ -31,6 +33,8 @@ start_service() {
 	procd_append_param respawn 3600
 	procd_append_param respawn 5
 	procd_append_param respawn -1
+	procd_set_param nice
+	procd_append_param nice -10
 	procd_close_instance
 
 }


### PR DESCRIPTION
This is default if ovs is started through ovs-ctl but we start it directly, hence
tell procd to use nice -10 for ovs.

Signed-off-by: Helmut Schaa helmut.schaa@googlemail.com
