### PR TITLE
mwan3: update to version 1.5-6

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=1.5
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_MAINTAINER:=Jeroen Louwes <jeroen.louwes@gmail.com>
 PKG_LICENSE:=GPLv2
 

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -69,26 +69,26 @@ mwan3_set_iface_iptables()
 {
 	local local_net local_nets
 
-	local_nets=$($IP route list dev $DEVICE scope link | awk '{print $1}' | egrep '[0-9]{1,3}(\.[0-9]{1,3}){3}')
-
 	if ! $IPT -S mwan3_iface_$INTERFACE &> /dev/null; then
 		$IPT -N mwan3_iface_$INTERFACE
 	fi
 
 	$IPT -F mwan3_iface_$INTERFACE
-	$IPT -D mwan3_ifaces -i $DEVICE -m mark --mark 0x0/0xff00 -j mwan3_iface_$INTERFACE &> /dev/null
+	$IPT -D mwan3_ifaces -m mark --mark 0x0/0xff00 -j mwan3_iface_$INTERFACE &> /dev/null
 
 	if [ $ACTION == "ifup" ]; then
+		local_nets=$($IP route list dev $DEVICE scope link | awk '{print $1}' | egrep '[0-9]{1,3}(\.[0-9]{1,3}){3}')
+
 		if [ -n "$local_nets" ]; then
 			for local_net in $local_nets ; do
 				if [ $ACTION == "ifup" ]; then
-					$IPT -I mwan3_iface_$INTERFACE -s $local_net -m mark --mark 0x0/0xff00 -m comment --comment "default" -j MARK --set-xmark 0xff00/0xff00
+					$IPT -I mwan3_iface_$INTERFACE -i $DEVICE -s $local_net -m mark --mark 0x0/0xff00 -m comment --comment "default" -j MARK --set-xmark 0xff00/0xff00
 				fi
 			done
 		fi
 
-		$IPT -A mwan3_iface_$INTERFACE -m mark --mark 0x0/0xff00 -m comment --comment "$INTERFACE" -j MARK --set-xmark $(($iface_id*256))/0xff00
-		$IPT -A mwan3_ifaces -i $DEVICE -m mark --mark 0x0/0xff00 -j mwan3_iface_$INTERFACE
+		$IPT -A mwan3_iface_$INTERFACE -i $DEVICE -m mark --mark 0x0/0xff00 -m comment --comment "$INTERFACE" -j MARK --set-xmark $(($iface_id*256))/0xff00
+		$IPT -A mwan3_ifaces -m mark --mark 0x0/0xff00 -j mwan3_iface_$INTERFACE
 	fi
 
 	if [ $ACTION == "ifdown" ]; then
@@ -112,13 +112,18 @@ mwan3_set_iface_rules()
 		$IP rule del pref $(($iface_id+2000))
 	done
 
+	while [ -n "$($IP rule list | awk '$1 == "2253:"')" ]; do
+		$IP rule del pref 2253
+	done
+
 	while [ -n "$($IP rule list | awk '$1 == "2254:"')" ]; do
 		$IP rule del pref 2254
 	done
 
 	[ $ACTION == "ifup" ] && $IP rule add pref $(($iface_id+1000)) iif $DEVICE lookup main
 	[ $ACTION == "ifup" ] && $IP rule add pref $(($iface_id+2000)) fwmark $(($iface_id*256))/0xff00 lookup $iface_id
-        $IP rule add pref 2254 fwmark 0xfe00/0xff00 unreachable                                   
+        $IP rule add pref 2253 fwmark 0xfd00/0xff00 blackhole
+        $IP rule add pref 2254 fwmark 0xfe00/0xff00 unreachable
 }
 
 mwan3_track()
@@ -205,9 +210,11 @@ mwan3_set_policy()
 
 mwan3_set_policies_iptables()
 {
-	local lowest_metric policy total_weight
+	local last_resort lowest_metric policy total_weight
 
 	policy=$1
+
+	config_get last_resort $1 last_resort unreachable
 
 	if [ "$policy" != $(echo "$policy" | cut -c1-15) ]; then
 		$LOG warn "Policy $policy exceeds max of 15 chars. Not setting policy" && return 0
@@ -218,7 +225,18 @@ mwan3_set_policies_iptables()
 	fi
 
 	$IPT -F mwan3_policy_$policy
-	$IPT -A mwan3_policy_$policy -m mark --mark 0x0/0xff00 -m comment --comment "unreachable" -j MARK --set-xmark 0xfe00/0xff00
+
+	case "$last_resort" in
+		blackhole)
+			$IPT -A mwan3_policy_$policy -m mark --mark 0x0/0xff00 -m comment --comment "blackhole" -j MARK --set-xmark 0xfd00/0xff00
+		;;
+		default)
+			$IPT -A mwan3_policy_$policy -m mark --mark 0x0/0xff00 -m comment --comment "default" -j MARK --set-xmark 0xff00/0xff00
+		;;
+		*)
+			$IPT -A mwan3_policy_$policy -m mark --mark 0x0/0xff00 -m comment --comment "unreachable" -j MARK --set-xmark 0xfe00/0xff00
+		;;
+	esac
 
 	lowest_metric=256
 	total_weight=0
@@ -242,6 +260,8 @@ mwan3_set_user_rules_iptables()
 			use_policy="MARK --set-xmark 0xff00/0xff00"
 		elif [ "$use_policy" == "unreachable" ]; then
 			use_policy="MARK --set-xmark 0xfe00/0xff00"
+		elif [ "$use_policy" == "blackhole" ]; then
+			use_policy="MARK --set-xmark 0xfd00/0xff00"
 		else
 			use_policy="mwan3_policy_$use_policy"
 		fi
@@ -279,7 +299,7 @@ mwan3_ifupdown()
 			sleep 1
 			let counter++
 			if [ "$counter" -ge 10 ]; then
-				$LOG warn "Could not find gateway for interface $INTERFACE ($DEVICE)" && return 0
+				$LOG warn "Could not find gateway for interface $INTERFACE (${DEVICE:-unknown})" && return 0
 			fi
 		done
 
@@ -291,11 +311,11 @@ mwan3_ifupdown()
 		sleep 1
 		let counter++
 		if [ "$counter" -ge 60 ]; then
-			$LOG warn "Timeout waiting for older hotplug processes to finish. $ACTION interface $INTERFACE ($DEVICE) aborted" && return 0
+			$LOG warn "Timeout waiting for older hotplug processes to finish. $ACTION interface $INTERFACE (${DEVICE:-unknown}) aborted" && return 0
 		fi
 	done
 
-	$LOG notice "$ACTION interface $INTERFACE ($DEVICE)"
+	$LOG notice "$ACTION interface $INTERFACE (${DEVICE:-unknown})"
 
 	mwan3_set_general_iptables
 	mwan3_set_iface_iptables
@@ -308,10 +328,13 @@ mwan3_ifupdown()
 	config_foreach mwan3_set_user_rules_iptables rule
 }
 
-[ -n "$DEVICE" ] || exit 0
+local IP IPT LOG
+
 [ -n "$INTERFACE" ] || exit 0
 
-local IP IPT LOG
+if [ $ACTION == "ifup" ]; then
+	[ -n "$DEVICE" ] || exit 0
+fi
 
 IP="/usr/sbin/ip -4"
 IPT="/usr/sbin/iptables -t mangle -w"

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -21,8 +21,6 @@ IPT="/usr/sbin/iptables -t mangle -w"
 
 ifdown()
 {
-	local device
-
 	if [ -z "$1" ]; then
 		echo "Error: Expecting interface. Usage: mwan3 ifdown <interface>" && exit 0
 	fi
@@ -31,16 +29,12 @@ ifdown()
 		echo "Error: Too many arguments. Usage: mwan3 ifdown <interface>" && exit 0
 	fi
 
-	device=$(uci get -p /var/state network.$1.ifname) &> /dev/null
-	
 	if [ -e /var/run/mwan3track-$1.pid ] ; then
 		kill $(cat /var/run/mwan3track-$1.pid)
 		rm /var/run/mwan3track-$1.pid
 	fi
 
-	if [ -n "$device" ] ; then
-		ACTION=ifdown INTERFACE=$1 DEVICE=$device /sbin/hotplug-call iface
-	fi
+	ACTION=ifdown INTERFACE=$1 /sbin/hotplug-call iface
 }
 
 ifup()
@@ -121,7 +115,7 @@ policies()
 	local percent policy share total_weight weight iface
 
 	for policy in $($IPT -S | awk '{print $2}' | grep mwan3_policy_ | sort -u); do
-		echo "Policy $policy:" | sed 's/mwan3_policy_//g'
+		echo "Policy $policy:" | sed 's/mwan3_policy_//'
 
 		[ -n "$total_weight" ] || total_weight=$($IPT -S $policy | cut -s -d'"' -f2 | head -1 | awk '{print $3}')
 


### PR DESCRIPTION
Fixed issue where mwan3 would not immediately set interface down on link-loss event
Added feature to define last-resort action on policies with no members

Signed-off-by: Jeroen Louwes jeroen.louwes@gmail.com
