### PR TITLE
libimobiledevice, usbmuxd, libplist, libusbmuxd: move to github

### DIFF
--- a/libs/libimobiledevice/Makefile
+++ b/libs/libimobiledevice/Makefile
@@ -1,0 +1,96 @@
+#
+# Copyright (C) 2012-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libimobiledevice
+PKG_VERSION:=1.1.6
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Lukasz Baj <l.baj@radytek.com>
+PKG_LICENSE:=LGPL-2.1+
+PKG_LICENSE_FILE:=COPYING.LESSER
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/libimobiledevice/libimobiledevice.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=9732d275d00bb1200d2b6180d94814a1a7fb7696
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+$(call include_mk, python-package.mk)
+
+define Package/libimobiledevice/Default
+  TITLE:=A library that talks to Apple devices.
+  URL:=http://www.libimobiledevice.org/
+endef
+
+define Package/libimobiledevice/Default/description
+  libimobiledevice is a software library that talks the protocols to support
+  iPhone®, iPod Touch®, iPad® and Apple TV® devices.
+endef
+
+define Package/libimobiledevice
+  $(call Package/libimobiledevice/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=$(ICONV_DEPENDS) +libplist +libusbmuxd +libopenssl +libcrypto
+endef
+
+define Package/libimobiledevice/description
+  $(call Package/libimobiledevice/Default/description)
+endef
+
+define Package/libimobiledevice-utils
+  $(call Package/libimobiledevice/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libimobiledevice
+endef
+
+define Package/libimobiledevice-utils/description
+  $(call Package/libimobiledevice/Default/description)
+  This package contains the libimobiledevice utilities.
+endef
+
+CONFIGURE_VARS += \
+	libusbmuxd_CFLAGS="-I$(STAGING_DIR)/usr/include" \
+	libusbmuxd_LIBS="-L$(STAGING_DIR)/usr/lib -lusbmuxd" \
+	openssl_CFLAGS=" " \
+	openssl_LIBS="-L$(STAGING_DIR)/usr/lib -lssl -lcrypto"
+
+CONFIGURE_ARGS += \
+	--without-cython \
+	--disable-largefile
+
+TARGET_LDFLAGS += -Wl,-rpath-link=$(STAGING_DIR)/usr/lib
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libimobiledevice $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libimobiledevice.{a,la,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libimobiledevice-*.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libimobiledevice/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libimobiledevice.so.* $(1)/usr/lib/
+endef
+
+define Package/libimobiledevice-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/idevice* $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,libimobiledevice))
+$(eval $(call BuildPackage,libimobiledevice-utils))

--- a/libs/libplist/Makefile
+++ b/libs/libplist/Makefile
@@ -1,0 +1,105 @@
+#
+# Copyright (C) 2012-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libplist
+PKG_VERSION:=1.11
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Lukasz Baj <l.baj@radytek.com>
+PKG_LICENSE:=LGPL-2.1+
+PKG_LICENSE_FILE:=COPYING.LESSER
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/libimobiledevice/libplist.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=063c629baef6028e84838f77fd1401b05e41dc58
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libplist/Default
+  TITLE:=Apple property list
+  URL:=http://www.libimobiledevice.org/
+endef
+
+define Package/libplist/Default/description
+  A library to handle Apple Property List format whereas it's binary or XML
+endef
+
+define Package/libplist
+  $(call Package/libplist/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+libxml2
+  TITLE+= library
+endef
+
+define Package/libplist/description
+  $(call Package/libplist/Default/description)
+endef
+
+define Package/libplistcxx
+  $(call Package/libplist/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+libplist +libstdcpp
+  TITLE+= C++ library
+endef
+
+define Package/libplistcxx/description
+  $(call Package/libplist/Default/description)
+  This package contains the libplist C++ shared library.
+endef
+
+define Package/libplist-utils
+  $(call Package/libplist/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libplist
+  TITLE+= converter
+endef
+
+define Package/libplist-utils/description
+  $(call Package/libplist/Default/description)
+  This package contains the libplist utilities.
+endef
+
+CONFIGURE_ARGS += \
+	--without-cython
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/plist $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libplist*.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libplist*.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libplist/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libplist.so.* $(1)/usr/lib/
+endef
+
+define Package/libplistcxx/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libplist++.so.* $(1)/usr/lib/
+endef
+
+define Package/libplist-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/plistutil $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,libplist))
+$(eval $(call BuildPackage,libplistcxx))
+$(eval $(call BuildPackage,libplist-utils))

--- a/libs/libusbmuxd/Makefile
+++ b/libs/libusbmuxd/Makefile
@@ -1,0 +1,90 @@
+#
+# Copyright (C) 2012-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libusbmuxd
+PKG_VERSION:=1.0.9
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Lukasz Baj <l.baj@radytek.com>
+PKG_LICENSE:=LGPL-2.1+
+PKG_LICENSE_FILE:=COPYING.LGPLv2.1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/libimobiledevice/libusbmuxd.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=ca68e3c287a8410fbef5280948a6d1d2255e0a89
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libusbmuxd/Default
+  TITLE:=USB multiplexing daemon
+  URL:=http://www.libimobiledevice.org/
+endef
+
+define Package/libusbmuxd/Default/description
+  This daemon is in charge of multiplexing connections over USB to an iPhone or
+  iPod touch. To users, it means you can sync your music, contacts, photos, etc.
+  over USB. To developers, it means you can connect to any listening localhost
+  socket on the device. usbmuxd is not used for tethering data transfer, which
+  uses a dedicated USB interface as a virtual network device.
+endef
+
+define Package/libusbmuxd
+  $(call Package/libusbmuxd/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE+= library
+  DEPENDS:=+libplist +libpthread +libxml2 +zlib
+endef
+
+define Package/libusbmuxd/description
+  $(call Package/libusbmuxd/Default/description)
+  This package contains the libusbmuxd shared library.
+endef
+
+define Package/libusbmuxd-utils
+  $(call Package/libusbmuxd/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE+= utilies
+  DEPENDS:=+libusbmuxd
+endef
+
+define Package/libusbmuxd-utils/description
+  $(call Package/libusbmuxd/Default/description)
+  This package contains the libusbmuxd utilities.
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libusbmuxd.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libusbmuxd.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libusbmuxd/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libusbmuxd.so.* $(1)/usr/lib/
+endef
+
+define Package/libusbmuxd-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/iproxy $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,libusbmuxd))
+$(eval $(call BuildPackage,libusbmuxd-utils))

--- a/utils/usbmuxd/Makefile
+++ b/utils/usbmuxd/Makefile
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2012-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=usbmuxd
+PKG_VERSION:=1.0.8
+PKG_RELEASE:=2
+PKG_SOURCE_PROTO:=git
+
+PKG_MAINTAINER:=Lukasz Baj <l.baj@radytek.com>
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILE:=COPYING.GPLv2
+
+PKG_SOURCE_URL:=https://github.com/libimobiledevice/usbmuxd.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=2f6d9d5f7047d4dd5ea9970721ba902301621ab2
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/usbmuxd
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=USB multiplexing daemon
+  URL:=http://www.libimobiledevice.org/
+  DEPENDS:=+librt +libusb-1.0 +libusbmuxd +libcrypto +libopenssl +libimobiledevice
+endef
+
+define Package/usbmuxd/description
+  This daemon is in charge of multiplexing connections over USB to an iPhone or
+  iPod touch. To users, it means you can sync your music, contacts, photos, etc.
+  over USB. To developers, it means you can connect to any listening localhost
+  socket on the device. usbmuxd is not used for tethering data transfer, which
+  uses a dedicated USB interface as a virtual network device.
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+define Package/usbmuxd/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/usbmuxd $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,usbmuxd))


### PR DESCRIPTION
This libraries and util are necessary to connect and use Apple devices with OpenWrt software.
