### PR TITLE
horst: update to version 4.1

### DIFF
--- a/net/horst/Makefile
+++ b/net/horst/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=horst
-PKG_VERSION:=4.0
+PKG_VERSION:=4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-git.tar.gz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_URL:=git://br1.einfach.org/horst
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=version-4.0
+PKG_SOURCE_VERSION:=version-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Bruno Randolf <br1@einfach.org>
 PKG_LICENSE:=GPL-2.0+
@@ -24,6 +24,8 @@ PKG_LICENSE_FILE:=LICENSE
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
+
+MAKE_FLAGS += DEBUG=1
 
 define Package/horst
 	SECTION:=net


### PR DESCRIPTION
4.1 has an important bugfix for platforms (such as ARM cns3xxx) where "char"
does not default to "signed char" and other bugfixes.

Also build with debugging enabled (-D flag) to enable debugging, the size
increase is just +336B (on platform au1000).
