### PR TITLE
horst: Add horst version 4.2

### DIFF
--- a/net/horst/Makefile
+++ b/net/horst/Makefile
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=horst
+PKG_VERSION:=4.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-git.tar.gz
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_URL:=git://br1.einfach.org/horst
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=version-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Bruno Randolf <br1@einfach.org>
+PKG_LICENSE:=GPL-2.0+
+PKG_LICENSE_FILE:=LICENSE
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+MAKE_FLAGS += DEBUG=1
+
+define Package/horst
+	SECTION:=net
+	CATEGORY:=Network
+	SUBMENU:=wireless
+	DEPENDS:=+libncurses
+	MAINTAINER:=Bruno Randolf <br1@einfach.org>
+	TITLE:=Highly Optimized 802.11 Radio Scanning Tool
+	URL:=http://br1.einfach.org/tech/horst/
+endef
+
+define Package/horst/description
+	[horst] is a scanning and analysis tool for 802.11 wireless networks
+	and especially IBSS (ad-hoc) mode and mesh networks (OLSR).
+endef
+
+define Package/horst/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/horst $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/horst.sh $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,horst))


### PR DESCRIPTION
I know, the merge window is officially closed, but I still see changes coming in...

horst 3.0 as from oldpackages, apart from being 3 years old, does not work well with the new mac80211 drivers of 14.07, so please consider to merge this again...
