### PR TITLE
ddns-scripts: fix problem during startup

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.0.1
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 PKG_LICENSE:=GPL-2.0
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -247,7 +247,7 @@ get_service_data() {
 	IFS=$__OLD_IFS
 
 	# check is URL or SCRIPT is given
-	__URL=$(echo "$__URL" | grep "^http:")
+	__URL=$(echo "$__DATA" | grep "^http:")
 	[ -z "$__URL" ] && __SCRIPT="/usr/lib/ddns/$__DATA"
 	
 	eval "$1='$__URL'"

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -117,7 +117,6 @@ load_all_config_options "ddns" "$SECTION_ID"
 
 verbose_echo "\n ************** =: ************** ************** **************"
 verbose_echo "       STARTED =: PID '$$' at $(eval $DATE_PROG)"
-syslog_info "Started"
 case $VERBOSE_MODE in
 	0) verbose_echo "  verbose mode =: '0' - run normal, NO console output";;
 	1) verbose_echo "  verbose mode =: '1' - run normal, console mode";;


### PR DESCRIPTION
fixes problem CRITICAL ERROR - custom update_script not found
when extracting url and script from services / services_ipv6 file

Signed-off-by: Christian Schoenebeck christian.schoenebeck@gmail.com
