### PR TITLE
mwan3: update to version 1.5-8

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=1.5
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 PKG_MAINTAINER:=Jeroen Louwes <jeroen.louwes@gmail.com>
 PKG_LICENSE:=GPLv2
 

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -202,5 +202,13 @@ restart() {
 	start
 }
 
-action=${1:-help}
-$action
+case "$1" in
+	ifup|ifdown|interfaces|policies|rules|status|start|stop|restart)
+		$*
+	;;
+	*)
+		help
+	;;
+esac
+
+exit 0


### PR DESCRIPTION
Fix bug introduced in version 1.5-7; args were not parsed to script.

Signed-off-by: Jeroen Louwes jeroen.louwes@gmail.com
