### PR TITLE
cyrus-sasl: fix typo in install section

### DIFF
--- a/libs/cyrus-sasl/Makefile
+++ b/libs/cyrus-sasl/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2008 OpenWrt.org
+# Copyright (C) 2006-2014 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cyrus-sasl
 PKG_VERSION:=2.1.26
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -104,9 +104,9 @@ endef
 
 define Package/libsasl2/install
 	$(INSTALL_DIR) $(1)/usr/lib/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsasl2.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsasl2.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/sasl2
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/sasl2/lib*.so.* $(1)/usr/lib/sasl2/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/sasl2/lib*.so* $(1)/usr/lib/sasl2/
 endef
 
 $(eval $(call BuildPackage,libsasl2))


### PR DESCRIPTION
An overly specific glob pattern in the package install sections prevents
the unversioned .so symlinks from getting copied into the .ipk.

This commit changes the pattern from xxx.so.\* to xxx.so\* in order to copy
those symlinks too. Fixes #382.

Also bump the copyright year in the Makefile while we're at it.

Signed-off-by: Jo-Philipp Wich jow@openwrt.org
