### PR TITLE
libpq: Fix missing dependency (shadow-utils)

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -28,7 +28,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/libpq
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+zlib +libreadline +libpthread +libncurses +shadow-su
+  DEPENDS:=+zlib +libreadline +libpthread +libncurses +shadow-utils +shadow-su
   TITLE:=PostgreSQL client library
   URL:=http://www.postgresql.org/
   SUBMENU:=database


### PR DESCRIPTION
Accidently introduced when compressing packages with lots of sub-items.

Signed-off-by: Ted Hess thess@kitschensync.net
