### PR TITLE
fix apr-util URL

### DIFF
--- a/libs/apr-util/Makefile
+++ b/libs/apr-util/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.5.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=http://mirrors.ibiblio.org/apache/apr/
+PKG_SOURCE_URL:=https://archive.apache.org/dist/apr/
 PKG_MD5SUM:=6f3417691c7a27090f36e7cf4d94b36e
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=Apache License


### PR DESCRIPTION
apr-util 1.5.3 is no longer hosted on biblio.org.  Get it from archive.apache.org.
