### PR TITLE
generic userid: use the new USERID api

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -32,6 +32,7 @@ define Package/zabbix/Default
   URL:=http://www.zabbix.com/
   SUBMENU:=zabbix
   MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
+  USERID:=zabbix=53:zabbix=53
 endef
 
 define Package/zabbix-agent

--- a/admin/zabbix/files/zabbix_agentd.init
+++ b/admin/zabbix/files/zabbix_agentd.init
@@ -19,8 +19,6 @@ start() {
 	}
 
 	grep -q "^AllowRoot=1" ${CONFIG} || {
-		user_exists zabbix 53 || user_add zabbix 53
-		group_exists zabbix 53 || group_add zabbix 53
 		touch ${SERVICE_PID_FILE}
 		chown zabbix:zabbix ${SERVICE_PID_FILE}
 	}

--- a/mail/dovecot/Makefile
+++ b/mail/dovecot/Makefile
@@ -31,6 +31,7 @@ define Package/dovecot
   TITLE:=An IMAP and POP3 daemon
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
   URL:=http://www.dovecot.org/
+  USERID:=dovecot=59:dovecot=59
 endef
 
 define Package/dovecot/description

--- a/mail/dovecot/files/dovecot.init
+++ b/mail/dovecot/files/dovecot.init
@@ -7,8 +7,6 @@ STOP=75
 USE_PROCD=1
 
 start_service() {
-	user_exists dovecot 59 || user_add dovecot 59
-	group_exists dovecot 59 || group_add dovecot 59
 	mkdir -p -m 0755 /var/lib/dovecot
 	mkdir -p -m 0755 /var/run/dovecot
 	chmod 0750 /var/lib/dovecot

--- a/net/dmapd/Makefile
+++ b/net/dmapd/Makefile
@@ -32,6 +32,7 @@ define Package/dmapd
   DEPENDS:=+libdmapsharing +libdb47 +vips
   TITLE:= dmapd
   URL:=http://www.flyn.org/projects/dmapd/
+  USERID:=dmapd=56:dmapd=56
 endef
 
 define Package/dmapd/decription

--- a/net/dmapd/files/dmapd.init
+++ b/net/dmapd/files/dmapd.init
@@ -4,8 +4,6 @@
 START=60
 
 start() {
-	user_exists dmapd 56 || user_add dmapd 56
-	group_exists dmapd 56 || group_add dmapd 56
 	[ -d /var/run/dmapd ] || {
 		mkdir -m 0755 -p /var/run/dmapd
 		chown dmapd:dmapd /var/run/dmapd

--- a/net/mosquitto/Makefile
+++ b/net/mosquitto/Makefile
@@ -30,6 +30,7 @@ define Package/$(PKG_NAME)/default
   URL:=http://www.mosquitto.org/
   MAINTAINER:=Karl Palsson <karlp@remake.is>
   DEPENDS:= +librt
+  USERID:=mosquitto=200:mosquitto=200
 endef
 
 define Package/$(PKG_NAME)

--- a/net/mosquitto/files/mosquitto.init
+++ b/net/mosquitto/files/mosquitto.init
@@ -14,7 +14,6 @@ SERVICE_DAEMONIZE=1
 SERVICE_WRITE_PID=1
 
 start() {
-        user_exists mosquitto 200 || user_add mosquitto 200
         if [ "$USE_UCI_CONFIG" -eq 1 ]; then
             CONF=/tmp/mosquitto.converted.$$.conf
             mosquitto.uci.convert -f $CONF

--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -31,6 +31,7 @@ define Package/ntpd/Default
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
   URL:=http://www.ntp.org/
   DEPENDS:=+libcap
+  USERID:=ntp=123:ntp=123
 endef
 
 define Package/ntpd/Default/description

--- a/net/ntpd/files/ntpd.init
+++ b/net/ntpd/files/ntpd.init
@@ -9,8 +9,6 @@ USE_PROCD=1
 start_service() {
 #	ln -sf /dev/ttyS0 /dev/gps0
 #	/usr/sbin/setgarmin -d /dev/gps -c /etc/setgarmin.conf
-	user_exists ntp 123 || user_add ntp 123 123 ntp /var/lib/ntp
-	group_exists ntp 123 || group_add ntp 123
 	mkdir -p /var/lib/ntp
 	chown -R ntp:ntp /var/lib/ntp
 

--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -34,6 +34,7 @@ define Package/ocserv
   URL:=http://www.infradead.org/ocserv/
   MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
   DEPENDS:= +libgnutls +certtool +libncurses +libreadline +OCSERV_PAM:libpam +OCSERV_PROTOBUF:libprotobuf-c
+  USERID:=ocserv=72:ocserv=72
 endef
 
 define Package/ocserv/description

--- a/net/ocserv/files/ocserv.init
+++ b/net/ocserv/files/ocserv.init
@@ -86,9 +86,6 @@ setup_dns() {
 start() {
 	local hostname iface
 
-	user_exists ocserv 72 || user_add ocserv 72 72 /var/lib/ocserv
-	group_exists ocserv 72 || group_add ocserv 72
-
 	hostname=`uci get ddns.myddns.domain`
 	[ -z "$hostname" ] && hostname=`uci get system.@system[0].hostname`
 

--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -35,6 +35,7 @@ define Package/openssh/Default
 	URL:=http://www.openssh.com/
 	SUBMENU:=SSH
 	VARIANT:=without-pam
+	USERID:=sshd=22:sshd=22
 endef
 
 define Package/openssh-moduli

--- a/net/openssh/files/sshd.init
+++ b/net/openssh/files/sshd.init
@@ -18,8 +18,6 @@ start_service() {
 			}
 		}
 	}; done
-	user_exists sshd 22 || user_add sshd 22 22 sshd /var/empty
-	group_exists sshd 22 || group_add sshd 22 
 	mkdir -m 0700 -p /var/empty
 
 	procd_open_instance

--- a/net/portmap/Makefile
+++ b/net/portmap/Makefile
@@ -29,6 +29,7 @@ define Package/portmap
   TITLE:=The RPC Portmapper
   URL:=http://neil.brown.name/portmap/
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
+  USERID:=rpc=65533:rpc=65533
 endef
 
 define Package/portmap/description

--- a/net/portmap/files/portmap.init
+++ b/net/portmap/files/portmap.init
@@ -7,9 +7,6 @@ STOP=19
 USE_PROCD=1
 
 start_service() {
-	user_exists rpc 65533 || user_add rpc 65533 65533 rpc /var/empty
-	group_exists rpc 65533 || group_add rpc 65533
-	
 	procd_open_instance
 	procd_set_param command /usr/sbin/portmap -f
 	procd_close_instance

--- a/net/prosody/Makefile
+++ b/net/prosody/Makefile
@@ -28,6 +28,7 @@ define Package/prosody
   DEPENDS:=+luafilesystem +libidn +luaexpat +luasec +libopenssl +libidn +liblua 
   TITLE:=XMPP server
   URL:=http://prosody.im/
+  USERID:=prosody=54:prosody=54
 endef
 
 define Package/prosody/description

--- a/net/prosody/files/prosody.init
+++ b/net/prosody/files/prosody.init
@@ -14,8 +14,6 @@ RUN_USER=prosody
 RUN_GROUP=prosody
 
 start() {
-	user_exists prosody 54 || user_add prosody 54
-	group_exists prosody 54 || group_add prosody 54
 	[ -d /var/run/prosody ] || {
 		mkdir -m 0755 -p /var/run/prosody
 		chown prosody:prosody /var/run/prosody

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -27,6 +27,7 @@ define Package/tor/Default
   SECTION:=net
   CATEGORY:=Network
   URL:=https://www.torproject.org/
+  USERID:=tor=52:tor=52
 endef
 
 define Package/tor/Default/description

--- a/net/tor/files/tor.init
+++ b/net/tor/files/tor.init
@@ -7,8 +7,6 @@ STOP=50
 USE_PROCD=1
 
 start_service() {
-	user_exists tor 52 || user_add tor 52 52 /var/lib/tor
-	group_exists tor 52 || group_add tor 52
 	[ -f /var/run/tor.pid ] || {
 		touch /var/run/tor.pid
 		chown tor:tor /var/run/tor.pid

--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -38,6 +38,7 @@ define Package/pulseaudio/Default
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
   URL:=http://www.pulseaudio.org
   PROVIDES:=pulseaudio
+  USERID:=pulse=51:pulse=51
 endef
 
 define Package/pulseaudio-daemon

--- a/sound/pulseaudio/files/pulseaudio.init
+++ b/sound/pulseaudio/files/pulseaudio.init
@@ -8,8 +8,6 @@ USE_PROCD=1
 PROG=/usr/bin/pulseaudio
 
 start_service() {
-	user_exists pulse 51 || user_add pulse 51
-	group_exists pulse 51 || group_add pulse 51
 	[ -d /var/run/pulse ] || {
 		mkdir -m 0755 -p /var/run/pulse
 		chmod 0750 /var/run/pulse


### PR DESCRIPTION
recent changes in trunk allow us to specify the userid inside the openwrt makefile.
the info is stored int he meta data of the IPK control file and users are generated
by the new generic postinst trigger.

Signed-off-by: John Crispin blogic@openwrt.org
