### PR TITLE
move mksh to github; update it

### DIFF
--- a/utils/mksh/Makefile
+++ b/utils/mksh/Makefile
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2007-2011 OpenWrt.org
-# Copyright (c) 2009-2013 Thorsten Glaser <tg@mirbsd.org>
+# Copyright (c) 2009-2014 Thorsten Glaser <tg@mirbsd.org>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,12 +9,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mksh
-PKG_VERSION:=47
+PKG_VERSION:=50d
 PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Thorsten Glaser <tg@mirbsd.org>
+PKG_LICENSE:=MirOS
 
 PKG_SOURCE:=$(PKG_NAME)-R$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=http://www.mirbsd.org/MirOS/dist/mir/mksh
-PKG_MD5SUM:=71c7cbcd78306897801b8b6691091e66
+PKG_MD5SUM:=1c3882c07a760b23df1ad94ad0b4ed2e
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -36,7 +39,7 @@ derivate currently being actively developed.  It includes bug
 fixes and feature improvements, in order to produce a modern,
 robust shell good for interactive and especially script use.
 mksh has UTF-8 support (in substring operations and the Emacs
-editing mode) and - while R47 corresponds to OpenBSD 5.1-cur-
+editing mode) and - while R50 corresponds to OpenBSD 5.5-cur-
 rent ksh (without GNU bash-like PS1 and fancy character clas-
 ses) - adheres to SUSv4 and is much more robust. The code has
 been cleaned up and simplified, bugs fixed, standards compli-
@@ -50,13 +53,18 @@ define Build/Compile
 	# -DMKSH_ASSUME_UTF8=0 ⇒ never automatically enable
 	#	UTF-8 mode, neither use setlocale/nl_langinfo
 	#	nor look at $LC_* and $LANG (not recommended)
+	# -DMKSH_BINSHPOSIX ⇒ enable POSIX mode if called as sh
+	#XXX maybe change to -DMKSH_ASSUME_UTF8=1 now (which
+	#XXX is always assume UTF-8 mode)
 	# HAVE_CAN_FSTACKPROTECTORALL=0 ⇒ nuke libssp dependency
+	# HAVE_CAN_FSTACKPROTECTORSTRONG=0 ⇒ same, for gcc 4.9+
 	cd $(PKG_BUILD_DIR); \
 		CC="$(TARGET_CC)" \
 		TARGET_OS="$(shell uname -s)" \
 		CFLAGS="$(TARGET_CFLAGS)" \
-		CPPFLAGS="-DMKSH_SMALL=1 -DMKSH_ASSUME_UTF8=0" \
+		CPPFLAGS="-DMKSH_SMALL=1 -DMKSH_ASSUME_UTF8=0 -DMKSH_BINSHPOSIX" \
 		HAVE_CAN_FSTACKPROTECTORALL=0 \
+		HAVE_CAN_FSTACKPROTECTORSTRONG=0 \
 		LDFLAGS="$(TARGET_LDFLAGS)" \
 			$(BASH) Build.sh -Q -r -c lto
 endef

--- a/utils/mksh/patches/100-dot_mkshrc
+++ b/utils/mksh/patches/100-dot_mkshrc
@@ -1,5 +1,5 @@
-From 2bee59bb9e6b142a78c94f5e77a54e4e2366c1b8 Mon Sep 17 00:00:00 2001
-From: Thorsten Glaser <tg@freewrt.org>
+From 23712cea8e2a623fd952eb781df0011c501703d0 Mon Sep 17 00:00:00 2001
+From: Thorsten Glaser <tg@mirbsd.org>
 Date: Thu, 25 Jul 2013 22:07:33 +0200
 Subject: [PATCH] Make default mkshrc file suitable for OpenWrt environment:
 
@@ -13,7 +13,7 @@ Subject: [PATCH] Make default mkshrc file suitable for OpenWrt environment:
  1 file changed, 7 insertions(+), 3 deletions(-)
 
 diff --git a/dot.mkshrc b/dot.mkshrc
-index c10b8fd..3a389b2 100644
+index 233a10c..caf482c 100644
 --- a/dot.mkshrc
 +++ b/dot.mkshrc
 @@ -28,8 +28,8 @@ case $KSH_VERSION in
@@ -33,10 +33,10 @@ index c10b8fd..3a389b2 100644
  alias ll='l -l'
 -alias lo='l -alo'
 +alias lo='l -al'
- alias doch='fc -ln -1 | sudo mksh -s'
+ alias doch='sudo mksh -c "$(fc -ln -1)"'
  whence -p rot13 >/dev/null || alias rot13='tr \
      abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ \
-@@ -413,4 +413,8 @@ alias cls='print -n \\033c'
+@@ -402,4 +402,8 @@ alias cls='print -n \\033c'
  
  unset p
  
@@ -46,5 +46,5 @@ index c10b8fd..3a389b2 100644
 +
  : place customisations above this line
 -- 
-1.8.3.2
+2.1.1
 


### PR DESCRIPTION
This series of commits moves utils/mksh from oldpackages to github (retaining complete history) and updates it to the SECURITY and bugfix versioin R50d (current upstream).

It has been tested (including full testsuite run, except for the missing /bin/ed on OpenWrt) successfully on MIPS Malta in Qemu (without MIPS16).
