### PR TITLE
shadow: Add libiconv to PKG_BUILD_DEPENDS

### DIFF
--- a/utils/shadow/Makefile
+++ b/utils/shadow/Makefile
@@ -21,7 +21,7 @@ PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
-PKG_BUILD_DEPENDS:=libintl
+PKG_BUILD_DEPENDS:=libintl libiconv
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Signed-off-by: Ted Hess thess@kitschensync.net
