### PR TITLE
ffmpeg: Disable mips32r2 for mips32 CPUs

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -399,6 +399,10 @@ FFMPEG_CONFIGURE:= \
 	--disable-vdpau \
 	--disable-outdevs
 
+ifeq ($(CONFIG_CPU_TYPE),"mips32")
+	FFMPEG_CONFIGURE +=--disable-mips32r2
+endif
+
 ifeq ($(BUILD_VARIANT),custom)
 
   FFMPEG_ENABLE= \


### PR DESCRIPTION
Some CPUs, such as the au1500 are MIPS32 but not MIPS32r2 and we have to
explicitly disable mips32r2 in the ffmpeg configure script.

Signed-off-by: Bruno Randolf br1@einfach.org
