### PR TITLE
db47: add option to turn off small build

### DIFF
--- a/libs/db47/Makefile
+++ b/libs/db47/Makefile
@@ -12,9 +12,9 @@ BASE_VERSION:=4.7.25
 
 PKG_NAME:=db47
 PKG_VERSION:=$(BASE_VERSION).4.NC
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/db-$(BASE_VERSION).NC
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/db-$(BASE_VERSION).NC
 PKG_SOURCE:=db-$(BASE_VERSION).NC.tar.gz
 PKG_SOURCE_URL:=http://download.oracle.com/berkeley-db/
 PKG_MD5SUM:=073ab7f20d24b3872a51ca762f5090e7
@@ -29,28 +29,71 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/libdb47
+define Package/libdb47/Default
   SECTION:=libs
   CATEGORY:=Libraries
   DEPENDS:=+libxml2
-  TITLE:=Berkeley DB library (4.7)
+  PROVIDES:=libdb47
   URL:=http://www.oracle.com/us/products/database/berkeley-db
 endef
 
-define Package/libdb47/description
+define Package/libdb47/Default/description
   Berkeley DB library (4.7).
 endef
 
-define Package/libdb47xx
+define Package/libdb47
+$(call Package/libdb47/Default)
+  VARIANT:=small
+  TITLE:=Berkeley DB library (4.7) (without statistics etc. support)
+endef
+
+define Package/libdb47/description
+$(call Package/libdb47/Default/description)
+ This package is not built with statistics etc. support.
+endef
+
+define Package/libdb47-full
+$(call Package/libdb47/Default)
+  VARIANT:=full
+  TITLE:=Berkeley DB library (4.7) (with statistics etc. support)
+endef
+
+define Package/libdb47-full/description
+$(call Package/libdb47/Default/description)
+ This package is built with statistics etc. support.
+endef
+
+define Package/libdb47xx/Default
   SECTION:=libs
   CATEGORY:=Libraries
   DEPENDS:=+libdb47 $(CXX_DEPENDS)
-  TITLE:=Berkeley DB library (4.7) for C++
   URL:=http://www.oracle.com/us/products/database/berkeley-db
 endef
 
-define Package/libdb47xx/description
+define Package/libdb47xx/Default/description
   Berkeley DB library (4.7).  C++ wrapper.
+endef
+
+define Package/libdb47xx
+$(call Package/libdb47xx/Default)
+  VARIANT:=small
+  TITLE:=Berkeley DB library (4.7) for C++ (without statistics etc. support)
+endef
+
+define Package/libdb47xx/description
+$(call Package/libdb47xx/Default/description)
+ This package is not built with statistics etc. support.
+endef
+
+define Package/libdb47xx-full
+$(call Package/libdb47xx/Default)
+  VARIANT:=full
+  TITLE:=Berkeley DB library (4.7) for C++ (with statistics etc. support)
+endef
+
+define Package/libdb47xx-full/description
+$(call Package/libdb47xx/Default/description)
+ This package is built with statistics etc. support.
 endef
 
 CONFIGURE_PATH = build_unix
@@ -64,10 +107,13 @@ CONFIGURE_ARGS += \
 	--disable-tcl \
 	--disable-rpc \
 	--enable-compat185 \
-	--enable-smallbuild \
 	--disable-debug \
 	--enable-cryptography \
 	$(if $(CONFIG_PACKAGE_libdb47xx),--enable-cxx,--disable-cxx)
+
+ifeq ($(BUILD_VARIANT),small)
+        CONFIGURE_ARGS += --enable-smallbuild
+endif
 
 TARGET_CFLAGS += $(FPIC)
 
@@ -83,7 +129,17 @@ define Package/libdb47/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdb-*.so $(1)/usr/lib/
 endef
 
+define Package/libdb47-full/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdb-*.so $(1)/usr/lib/
+endef
+
 define Package/libdb47xx/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdb_cxx-*.so $(1)/usr/lib/
+endef
+
+define Package/libdb47xx-full/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdb_cxx-*.so $(1)/usr/lib/
 endef
@@ -97,4 +153,6 @@ define Build/InstallDev
 endef
 
 $(eval $(call BuildPackage,libdb47))
+$(eval $(call BuildPackage,libdb47-full))
 $(eval $(call BuildPackage,libdb47xx))
+$(eval $(call BuildPackage,libdb47xx-full))


### PR DESCRIPTION
The new bogofilter package requires that db47 be built with statistics support, but this is incompatible with db47's --enable-smallbuild option. This modification adds an OpenWrt build option which turns off --enable-smallbuild.

Signed-off-by: W. Michael Petullo mike@flyn.org
