### PR TITLE
sqm-scripts: Fix a minor bug, add copyrights, improve logging

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqm-scripts
-PKG_VERSION:=6
+PKG_VERSION:=7
 PKG_RELEASE:=1
 PKG_LICENSE:=GPLv2
 

--- a/net/sqm-scripts/files/usr/lib/sqm/run.sh
+++ b/net/sqm-scripts/files/usr/lib/sqm/run.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+#       Copyright (C) 2012-4 Michael D. Taht, Toke Høiland-Jørgensen, Sebastian Moeller
+
+
 . /lib/functions.sh
 
 STOP=$1
@@ -17,7 +24,7 @@ for STATE_FILE in ${PROTO_STATE_FILE_LIST} ; do
     then
 	STATE_FILE_BASE_NAME=$( basename ${STATE_FILE} )
 	CURRENT_INTERFACE=${STATE_FILE_BASE_NAME:${#ACTIVE_STATE_PREFIX}:$(( ${#STATE_FILE_BASE_NAME} - ${#ACTIVE_STATE_PREFIX} ))}        
-	logger -t SQM -s "Stopping SQM on interface: ${CURRENT_INTERFACE}"
+	logger -t SQM -s "${0} Stopping SQM on interface: ${CURRENT_INTERFACE}"
 	/usr/lib/sqm/stop.sh ${CURRENT_INTERFACE}
 	rm ${STATE_FILE}	# well, we stop it so it is not running anymore and hence no active state file needed...
     fi
@@ -38,7 +45,7 @@ run_simple_qos() {
 		# this should not be possible, delete after testing
 		local SECTION_STOP="stop"	# it seems the user just de-selected enable, so stop the active SQM
 	    else
-		logger -t SQM -s "SQM for interface ${IFACE} is not enabled, skipping over..."
+		logger -t SQM -s "${0} SQM for interface ${IFACE} is not enabled, skipping over..."
 		return 0	# since SQM is not active on the current interface nothing to do here
 	    fi
 	fi
@@ -72,10 +79,10 @@ run_simple_qos() {
 #	     /usr/lib/sqm/stop.sh
 #	     [ -f ${ACTIVE_STATE_FILE_FQN} ] && rm ${ACTIVE_STATE_FILE_FQN}	# conditional to avoid errors ACTIVE_STATE_FILE_FQN does not exist anymore
 #	     $(config_set "$section" enabled 0)	# this does not save to the config file only to the loaded memory representation
-#	     logger -t SQM -s "SQM qdiscs on ${IFACE} removed"
+	     logger -t SQM -s "${0} SQM qdiscs on ${IFACE} removed"
 	     return 0
 	fi
-	logger -t SQM -s "Queue Setup Script: ${SCRIPT}"
+	logger -t SQM -s "${0} Queue Setup Script: ${SCRIPT}"
 	[ -x "$SCRIPT" ] && { $SCRIPT ; touch ${ACTIVE_STATE_FILE_FQN}; }
 }
 

--- a/net/sqm-scripts/files/usr/lib/sqm/simple.qos
+++ b/net/sqm-scripts/files/usr/lib/sqm/simple.qos
@@ -3,8 +3,11 @@
 # A 3 bin tc_codel and ipv6 enabled shaping script for
 # ethernet gateways
 
-# Copyright (C) 2012 Michael D Taht
-# GPLv2
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+#       Copyright (C) 2012-4 Michael D. Taht, Toke Høiland-Jørgensen, Sebastian Moeller
 
 # Compared to the complexity that debloat had become
 # this cleanly shows a means of going from diffserv marking
@@ -36,10 +39,10 @@ ipt -t mangle -A QOS_MARK_${IFACE} -m tos  --tos Minimize-Delay -j MARK --set-ma
 
 if [ "$SQUASH_DSCP" = "1" ]
 then
-sqm_logger "Squashing differentiad services code points (DSCP) from ingress."
+sqm_logger "Squashing differentiated services code points (DSCP) from ingress."
 ipt -t mangle -I PREROUTING -i $IFACE -m dscp ! --dscp 0 -j DSCP --set-dscp-class be
 else
-sqm_logger "Keeping differentiad services code points (DSCP) from ingress."
+sqm_logger "Keeping differentiated services code points (DSCP) from ingress."
 ipt -t mangle -A PREROUTING -i $IFACE -m mark --mark 0x00 -g QOS_MARK_${IFACE} 
 fi
 

--- a/net/sqm-scripts/files/usr/lib/sqm/simple_pppoe.qos
+++ b/net/sqm-scripts/files/usr/lib/sqm/simple_pppoe.qos
@@ -3,8 +3,11 @@
 # A 3 bin tc_codel and ipv6 enabled shaping script for
 # ethernet gateways
 
-# Copyright (C) 2012 Michael D Taht
-# GPLv2
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+#       Copyright (C) 2012-4 Michael D. Taht, Toke Høiland-Jørgensen, Sebastian Moeller
 
 # Compared to the complexity that debloat had become
 # this cleanly shows a means of going from diffserv marking

--- a/net/sqm-scripts/files/usr/lib/sqm/simplest.qos
+++ b/net/sqm-scripts/files/usr/lib/sqm/simplest.qos
@@ -3,8 +3,11 @@
 # A 1 bin tc_codel and ipv6 enabled shaping script for
 # ethernet gateways. This is nearly the simplest possible
 
-# Copyright (C) 2013 Michael D Taht
-# GPLv2
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+#       Copyright (C) 2012-4 Michael D. Taht, Toke Høiland-Jørgensen, Sebastian Moeller
 
 . /usr/lib/sqm/functions.sh
 sqm_logger "Starting simplest.qos"

--- a/net/sqm-scripts/files/usr/lib/sqm/stop.sh
+++ b/net/sqm-scripts/files/usr/lib/sqm/stop.sh
@@ -1,10 +1,17 @@
 #!/bin/sh
 
-. /usr/lib/sqm/functions.sh
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+#       Copyright (C) 2012-4 Michael D. Taht, Toke Høiland-Jørgensen, Sebastian Moeller
 
 # allow passing in the IFACE as first command line argument
 [ ! -z ${1} ] && IFACE=${1}
-sqm_logger "${0} Stopping ${IFACE}"
+# now IFACE is defined so we can source functions.sh without creating a spurious ifb4ge00
+. /usr/lib/sqm/functions.sh
+# sqm_logger is defined in functions.sh...
+sqm_logger "${0}: Stopping ${IFACE}"
 
 # make sure to only delete the ifb associated with the current interface
 CUR_IFB=$( get_ifb_associated_with_if ${IFACE} )
@@ -13,7 +20,7 @@ sqm_stop() {
 	tc qdisc del dev $IFACE ingress 2> /dev/null
 	tc qdisc del dev $IFACE root 2> /dev/null
 	[ ! -z "$CUR_IFB" ] && tc qdisc del dev $CUR_IFB root 2> /dev/null
-        [ ! -z "$CUR_IFB" ] && sqm_logger "${CUR_IFB} shaper deleted"
+        [ ! -z "$CUR_IFB" ] && sqm_logger "${0}: ${CUR_IFB} shaper deleted"
 }
 
 ipt_stop() {
@@ -30,6 +37,6 @@ sqm_stop
 ipt_stop
 [ ! -z "$CUR_IFB" ] && ifconfig ${CUR_IFB} down
 [ ! -z "$CUR_IFB" ] && ip link delete ${CUR_IFB} type ifb
-[ ! -z "$CUR_IFB" ] && sqm_logger "${CUR_IFB} interface deleted"
+[ ! -z "$CUR_IFB" ] && sqm_logger "${0}: ${CUR_IFB} interface deleted"
 
 exit 0


### PR DESCRIPTION
Changes committed to the cerowrt original repo after the initial import here:
- Better license & copyright statements, as requested
- Fixed a minor bug in stopping sqm
- Logging improvements
- Dead code removed
- Typos corrected

Matches original version https://github.com/dtaht/ceropackages-3.10/commit/caf457283865fc894a7699dbcea89be4611d2e81 except that I bumped the version number.

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
