### PR TITLE
knot: Split utils subpackage

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
 PKG_VERSION:=1.5.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
@@ -46,9 +46,27 @@ define Package/knot
 	DEPENDS+=+knot-libknot
 endef
 
-define Package/knot-utils
+define Package/knot-dig
 	$(call Package/knot/Default)
-	TITLE+= (utils)
+	TITLE+= lookup utility
+	DEPENDS+=+knot-libknot
+endef
+
+define Package/knot-host
+	$(call Package/knot/Default)
+	TITLE+= simple DNS lookup utility
+	DEPENDS+=+knot-libknot
+endef
+
+define Package/knot-nsec3hash
+	$(call Package/knot/Default)
+	TITLE+= simple NSEC3 hash utility
+	DEPENDS+=+knot-libknot
+endef
+
+define Package/knot-nsupdate
+	$(call Package/knot/Default)
+	TITLE+= dynamic DNS update utility
 	DEPENDS+=+knot-libknot
 endef
 
@@ -66,8 +84,20 @@ define Package/knot/description
 	High-performance authoritative-only DNS server.
 endef
 
-define Package/knot-utils/description
-	DNS utilities: kdig, khost, knsupdate and knsec3hash.
+define Package/knot-dig/description
+	Knot DNS lookup utility.
+endef
+
+define Package/knot-host/description
+	Knot DNS simple DNS lookup utility.
+endef
+
+define Package/knot-nsec3hash/description
+	Knot DNS simple utility to compute NSEC3 hash.
+endef
+
+define Package/knot-nsupdate/description
+	Knot DNS dynamic DNS update utility.
 endef
 
 define Package/knot-tests/description
@@ -114,12 +144,24 @@ define Package/knot/install
 	$(INSTALL_BIN) ./files/knotd.init	$(1)/etc/init.d/knotd
 endef
 
-define Package/knot-utils/install
+define Package/knot-dig/install
 	$(INSTALL_DIR)						$(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/kdig		$(1)/usr/bin/
+endef
+
+define Package/knot-host/install
+	$(INSTALL_DIR)						$(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/khost		$(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/knsupdate	$(1)/usr/bin/
+endef
+
+define Package/knot-nsec3hash/install
+	$(INSTALL_DIR)						$(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/knsec3hash	$(1)/usr/bin/
+endef
+
+define Package/knot-nsupdate/install
+	$(INSTALL_DIR)						$(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/knsupdate	$(1)/usr/bin/
 endef
 
 define Package/knot-tests/install
@@ -146,5 +188,8 @@ endef
 
 $(eval $(call BuildPackage,knot-libknot))
 $(eval $(call BuildPackage,knot))
-$(eval $(call BuildPackage,knot-utils))
+$(eval $(call BuildPackage,knot-dig))
+$(eval $(call BuildPackage,knot-host))
+$(eval $(call BuildPackage,knot-nsec3hash))
+$(eval $(call BuildPackage,knot-nsupdate))
 $(eval $(call BuildPackage,knot-tests))


### PR DESCRIPTION
knot-utils consists of kdig, khost, knsec3hash and knsupdate. In order
to reduce the size of software installed on a device it is useful to
include a minimal collection of software and thus it should be possible
to install the utilities individually. bind also creates a subpackage
for each utility.

Signed-off-by: Matthias-Christian Ott ott@mirix.org
