### PR TITLE
python: fix source folder for libpython

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -176,7 +176,7 @@ define Build/InstallDev
 		$(1)/usr/include/
 	$(CP) \
 		$(STAGING_DIR_HOST)/lib/python$(PYTHON_VERSION) \
-		$(PKG_BUILD_DIR)/libpython$(PYTHON_VERSION).so* \
+		$(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON_VERSION).so* \
 		$(1)/usr/lib/
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/config \
@@ -389,7 +389,7 @@ endef
 define PyPackage/python/install
 	$(LN) python$(PYTHON_VERSION) $(1)/usr/bin/python
 	$(LN) python$(PYTHON_VERSION) $(1)/usr/bin/python2
-	$(CP) $(PKG_BUILD_DIR)/libpython$(PYTHON_VERSION).so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON_VERSION).so* $(1)/usr/lib/
 endef
 
 define PyPackage/python-doc/filespec


### PR DESCRIPTION
This fix is quite critical since it fixes copying the libpython shared lib.
The previous source folder we've used is ok, it has the shared lib,
but libpython2.7.so is not a symlink of libpython2.7.so.1.0, but
rather a copy of it.
Which means that libpython2.7.so takes twice as much space
on the target's flash.

Signed-off-by: Alexandru Ardelean ardeleanalex@gmail.com
