### PR TITLE
db47: Reorder packages/configuration

### DIFF
--- a/libs/db47/Makefile
+++ b/libs/db47/Makefile
@@ -35,65 +35,72 @@ define Package/libdb47/Default
   DEPENDS:=+libxml2
   PROVIDES:=libdb47
   URL:=http://www.oracle.com/us/products/database/berkeley-db
+  TITLE:=Berkeley DB library (4.7)
 endef
 
 define Package/libdb47/Default/description
   Berkeley DB library (4.7).
 endef
 
-define Package/libdb47
+define Package/libdb47-small
 $(call Package/libdb47/Default)
   VARIANT:=small
-  TITLE:=Berkeley DB library (4.7) (without statistics etc. support)
+  TITLE+= (small variant)
 endef
 
-define Package/libdb47/description
+define Package/libdb47-small/description
 $(call Package/libdb47/Default/description)
- This package is not built with statistics etc. support.
+ This package does not provide support for:
+ - Hashes/Queues
+ - Replication
+ - Statistics
+ - Database verification
+ which saves about 200 kilobytes combined.
 endef
 
 define Package/libdb47-full
 $(call Package/libdb47/Default)
+  CONFLICTS:=libdb47-small
   VARIANT:=full
-  TITLE:=Berkeley DB library (4.7) (with statistics etc. support)
 endef
 
 define Package/libdb47-full/description
 $(call Package/libdb47/Default/description)
- This package is built with statistics etc. support.
 endef
 
 define Package/libdb47xx/Default
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libdb47 $(CXX_DEPENDS)
+  PROVIDES:=libdb47xx
+  DEPENDS:=$(CXX_DEPENDS)
   URL:=http://www.oracle.com/us/products/database/berkeley-db
+  TITLE:=Berkeley DB library (4.7) for C++
 endef
 
 define Package/libdb47xx/Default/description
-  Berkeley DB library (4.7).  C++ wrapper.
+  Berkeley DB library (4.7). C++ wrapper.
 endef
 
-define Package/libdb47xx
+define Package/libdb47xx-small
 $(call Package/libdb47xx/Default)
+  DEPENDS+=+libdb47-small
   VARIANT:=small
-  TITLE:=Berkeley DB library (4.7) for C++ (without statistics etc. support)
+  TITLE+= (small variant)
 endef
 
-define Package/libdb47xx/description
+define Package/libdb47xx-small/description
 $(call Package/libdb47xx/Default/description)
- This package is not built with statistics etc. support.
 endef
 
 define Package/libdb47xx-full
 $(call Package/libdb47xx/Default)
+  DEPENDS+=+libdb47-full
+  CONFLICTS:=libdb47xx-small
   VARIANT:=full
-  TITLE:=Berkeley DB library (4.7) for C++ (with statistics etc. support)
 endef
 
 define Package/libdb47xx-full/description
 $(call Package/libdb47xx/Default/description)
- This package is built with statistics etc. support.
 endef
 
 CONFIGURE_PATH = build_unix
@@ -108,11 +115,15 @@ CONFIGURE_ARGS += \
 	--disable-rpc \
 	--enable-compat185 \
 	--disable-debug \
-	--enable-cryptography \
-	$(if $(CONFIG_PACKAGE_libdb47xx),--enable-cxx,--disable-cxx)
+	--enable-cryptography
 
 ifeq ($(BUILD_VARIANT),small)
-        CONFIGURE_ARGS += --enable-smallbuild
+	CONFIGURE_ARGS += --enable-smallbuild \
+		$(if $(CONFIG_PACKAGE_libdb47xx-small),--enable-cxx,--disable-cxx)
+endif
+
+ifeq ($(BUILD_VARIANT),full)
+	CONFIGURE_ARGS += $(if $(CONFIG_PACKAGE_libdb47xx-full),--enable-cxx,--disable-cxx)
 endif
 
 TARGET_CFLAGS += $(FPIC)
@@ -124,7 +135,7 @@ define Build/Compile
 		DESTDIR="$(PKG_INSTALL_DIR)" install
 endef
 
-define Package/libdb47/install
+define Package/libdb47-small/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdb-*.so $(1)/usr/lib/
 endef
@@ -134,7 +145,7 @@ define Package/libdb47-full/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdb-*.so $(1)/usr/lib/
 endef
 
-define Package/libdb47xx/install
+define Package/libdb47xx-small/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdb_cxx-*.so $(1)/usr/lib/
 endef
@@ -152,7 +163,7 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdb*.{a,so} $(1)/usr/lib
 endef
 
-$(eval $(call BuildPackage,libdb47))
+$(eval $(call BuildPackage,libdb47-small))
 $(eval $(call BuildPackage,libdb47-full))
-$(eval $(call BuildPackage,libdb47xx))
+$(eval $(call BuildPackage,libdb47xx-small))
 $(eval $(call BuildPackage,libdb47xx-full))


### PR DESCRIPTION
So the recent addition of libdb47-full broke things, see https://dev.openwrt.org/ticket/18184
This is caused by libdb47 providing itself. Making only libdb47-full provide libdb47 fixes that. However, it really confuses buildroot as it will make visibility of both libdb47xx and libdb47xx-full depend on libdb47-full.

I suggest renaming libdb47 to libdb47-small and making both libdb47-small and libdb47-full provide libdb47, the same with libdb47xx_. Also, make libdb47-small conflict with libdb47-full, again the same thing with libdb47xx_. libdb47xx-small and libdb47xx-full depend on their respective libdb47-\* counterparts directly.
This is made to allow packages to depend on libdb47 if they don't care about full functionality being present or not, or alternatively depend on libdb47-full in case they absolutely need it.

Sounds good. However this raises a problem: Which variant should be choosen if no package requests a specific one? I'd say libdb47-small, but there doesn't seem to be a way to express that. opkg will just choose libdb47-full(Alphabetic order? Random? I don't know), buildroot doesn't even try and hides every package that depends on libdb47 until the user chooses one of the two. ffmpeg currently has the same problem.

This means that, at the moment, nobody will be able to even see ruby-dbm, perlbase-db(-file), netatalk, dmapd or mocp in buildroot until they choose either libdb47-small or libdb47-full(or bogofilter, which depends on libdb47-full). Kinda cryptic. Also, installing any one of them on a running system might produce a less optimal result.

Any suggestions? I currently see 3 scenarios:
a) Implement some way to tell buildroot and opkg a default libdb47 choice(maybe there is already one?)
b) Screw it. Remove libdb47/libdb47-small and make libdb47-full the new libdb47. At least perl will only work with libdb47-full in the near feature, so it may not even be worth the hassle.
c) Live with it. ffmpeg also does so.
