### PR TITLE
gcc: work around wrongly detected sys/sdt.h header.

### DIFF
--- a/devel/gcc/patches/020-disable-check-for-sys-sdt-h.patch
+++ b/devel/gcc/patches/020-disable-check-for-sys-sdt-h.patch
@@ -1,0 +1,45 @@
+diff --git a/gcc/configure b/gcc/configure
+index 3793681..bcda752 100755
+--- a/gcc/configure
++++ b/gcc/configure
+@@ -26876,19 +26876,6 @@ $as_echo "#define TARGET_LIBC_PROVIDES_SSP 1" >>confdefs.h
+ 
+ fi
+ 
+-# Test for <sys/sdt.h> on the target.
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking sys/sdt.h in the target C library" >&5
+-$as_echo_n "checking sys/sdt.h in the target C library... " >&6; }
+-have_sys_sdt_h=no
+-if test -f $target_header_dir/sys/sdt.h; then
+-  have_sys_sdt_h=yes
+-
+-$as_echo "#define HAVE_SYS_SDT_H 1" >>confdefs.h
+-
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_sys_sdt_h" >&5
+-$as_echo "$have_sys_sdt_h" >&6; }
+ 
+ # Check if TFmode long double should be used by default or not.
+ # Some glibc targets used DFmode long double, but with glibc 2.4
+diff --git a/gcc/configure.ac b/gcc/configure.ac
+index 3ee1d67..e321218 100644
+--- a/gcc/configure.ac
++++ b/gcc/configure.ac
+@@ -4796,16 +4796,6 @@ if test x$gcc_cv_libc_provides_ssp = xyes; then
+ 	    [Define if your target C library provides stack protector support])
+ fi
+ 
+-# Test for <sys/sdt.h> on the target.
+-GCC_TARGET_TEMPLATE([HAVE_SYS_SDT_H])
+-AC_MSG_CHECKING(sys/sdt.h in the target C library)
+-have_sys_sdt_h=no
+-if test -f $target_header_dir/sys/sdt.h; then
+-  have_sys_sdt_h=yes
+-  AC_DEFINE(HAVE_SYS_SDT_H, 1,
+-            [Define if your target C library provides sys/sdt.h])
+-fi
+-AC_MSG_RESULT($have_sys_sdt_h)
+ 
+ # Check if TFmode long double should be used by default or not.
+ # Some glibc targets used DFmode long double, but with glibc 2.4


### PR DESCRIPTION
The build system somehow detects /usr/include/sys/sdt.h, which is part of systemtap-sdt-devel
package in the host environment but not present in the SDK.

This patch simply disables the check for sys/sdt.h, enabling building of this package when
systemtap-sdt-devel is installed in the host environment.

Fixes https://github.com/openwrt/packages/issues/296

Signed-off-by: Christian Beier dontmind@freeshell.org
