### PR TITLE
python: fix build; getvar() was removed, expand it

### DIFF
--- a/lang/python/files/python-package.mk
+++ b/lang/python/files/python-package.mk
@@ -33,7 +33,7 @@ define PyPackage
 
   define Package/$(1)/install
 	find $(PKG_INSTALL_DIR) -name "*\.pyc" -o -name "*\.pyo" | xargs rm -f
-	@$(SH_FUNC) getvar $$(call shvar,PyPackage/$(1)/filespec) | ( \
+	@$(SH_FUNC) echo "$$$$$$$${$$(call shvar,PyPackage/$(1)/filespec)}" | ( \
 		IFS='|'; \
 		while read fop fspec fperm; do \
 		  if [ "$$$$$$$$fop" = "+" ]; then \


### PR DESCRIPTION
Signed-off-by: Alexandru Ardelean ardeleanalex@gmail.com
