### PR TITLE
python3: fix build; getvar() was removed, expand it

### DIFF
--- a/lang/python3/files/python3-package.mk
+++ b/lang/python3/files/python3-package.mk
@@ -33,7 +33,7 @@ define Py3Package
 
   define Package/$(1)/install
 	find $(PKG_INSTALL_DIR) -name "*\.pyc" -o -name "*\.pyo" | xargs rm -f
-	@$(SH_FUNC) getvar $$(call shvar,Py3Package/$(1)/filespec) | ( \
+	@$(SH_FUNC) echo "$$$$$$$${$$(call shvar,Py3Package/$(1)/filespec)}" | ( \
 		IFS='|'; \
 		while read fop fspec fperm; do \
 		  if [ "$$$$$$$$fop" = "+" ]; then \


### PR DESCRIPTION
Signed-off-by: Alexandru Ardelean ardeleanalex@gmail.com
