### PR TITLE
aiccu: Use the defaultroute option

### DIFF
--- a/ipv6/aiccu/files/aiccu.sh
+++ b/ipv6/aiccu/files/aiccu.sh
@@ -39,7 +39,7 @@ proto_aiccu_setup() {
 	[ "$nat" == 1 ] && echo "behindnat true"     >> "$CFGFILE"
 	[ "$heartbeat"	== 1 ] && echo "makebeats true" >> "$CFGFILE"
 	[ "$verbose" == 1 ] && echo "verbose true" >> "$CFGFILE"
-	echo "defaultroute false" >> "$CFGFILE"
+	[ "$defaultroute" == 1 ] && echo "defaultroute true" >> "$CFGFILE" 
 	echo "daemonize true"	  >> "$CFGFILE"
 	echo "pidfile $PIDFILE"   >> "$CFGFILE"
 


### PR DESCRIPTION
After the rework, the aiccu script no longer obeys the "defaultroute" option. This commit fixes that problem.

Originally reported at https://dev.openwrt.org/ticket/17131
