### PR TITLE
openvswitch: fix build for gcc versions below 4.9

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -119,6 +119,11 @@ define Build/Configure
 	$(call Build/Configure/Default,$(CONFIGURE_ARGS))
 endef
 
+KCFLAGS=
+ifeq ($(CONFIG_GCC_VERSION_4_9),y)
+KCFLAGS:=-Wno-error=date-time
+endif
+
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		$(TARGET_CONFIGURE_OPTS) \
@@ -131,7 +136,7 @@ define Build/Compile
 		ARCH="$(LINUX_KARCH)" \
 		SUBDIRS="$(PKG_BUILD_DIR)/datapath/linux" \
 		PATH="$(TARGET_PATH)" \
-		KCFLAGS="-Wno-error=date-time" \
+		KCFLAGS="$(KCFLAGS)" \
 		KCC="$(KERNEL_CC)"
 endef
 


### PR DESCRIPTION
Seems that while fixing the build for GCC 4.9
I broke the build for GCC 4.8, because that KCFLAG I added
causes a build error (since it's not recognized).

The fix is to add KCFLAG only when GCC 4.9 is used.

OpenVSwitch now builds successfully with GCC 4.8 and 4.9.

Signed-off-by: Alexandru Ardelean ardeleanalex@gmail.com
