### PR TITLE
openvswitch: add +kmod-vxlan dependency for kernels >= 3.12

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -94,7 +94,7 @@ define KernelPackage/openvswitch
   SUBMENU:=Network Support
   TITLE:=Open vSwitch Kernel Package
   KCONFIG:=CONFIG_BRIDGE
-  DEPENDS:=+kmod-stp +kmod-ipv6 +kmod-gre +kmod-lib-crc32c
+  DEPENDS:=+kmod-stp +kmod-ipv6 +kmod-gre +kmod-lib-crc32c +kmod-vxlan
   FILES:= \
 	$(PKG_BUILD_DIR)/datapath/linux/openvswitch.$(LINUX_KMOD_SUFFIX)
   AUTOLOAD:=$(call AutoLoad,21,openvswitch)


### PR DESCRIPTION
When OVS detects a kernel version >= 3.12 it does not build
it's own vxlan module and tries to use the kernel's, when building
the OVS kernel module.

I also pushed a patch to the OpenWRT trunk to add a +kmod-vxlan package.
The patch got it at r43126

This will add the kernel's vxlan.ko kernel module if it exists.
So, for kernel >= 3.12, this package should exist and be installed
when installing OVS.

Tested on OpenWRT trunk with kernel 3.14.18.

Signed-off-by: Alexandru Ardelean ardeleanalex@gmail.com
