### PR TITLE
sqm-scripts: use masks with markings

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqm-scripts
 PKG_VERSION:=7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPLv2
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)

--- a/net/sqm-scripts/files/usr/lib/sqm/functions.sh
+++ b/net/sqm-scripts/files/usr/lib/sqm/functions.sh
@@ -29,6 +29,7 @@ ipt() {
 }
 
 do_modules() {
+#sm TODO: check first whether the modules exist and only load then
 	insmod act_ipt
 	insmod sch_$QDISC
 	insmod sch_ingress
@@ -59,15 +60,18 @@ do_modules() {
 [ -z "$IECN" ] && IECN="ECN"
 [ -z "$EECN" ] && EECN="NOECN"
 [ -z "$SQUASH_DSCP" ] && SQUASH_DSCP="1"
-[ -z "SQUASH_INGRESS" ] && SQUASH_INGRESS="1"
+[ -z "$SQUASH_INGRESS" ] && SQUASH_INGRESS="1"
 [ -z "$IQDISC_OPTS" ] && IQDISC_OPTS=""
 [ -z "$EQDISC_OPTS" ] && EQDISC_OPTS=""
 [ -z "$TC" ] && TC=`which tc`
 #[ -z "$TC" ] && TC="sqm_logger tc"# this redirects all tc calls into the log
 [ -z "$IP" ] && IP=$( which ip )
 [ -z "$INSMOD" ] && INSMOD=`which insmod`
-[ -z "TARGET" ] && TARGET="5ms"
+[ -z "$TARGET" ] && TARGET="5ms"
+[ -z "$IPT_MASK" ] && IPT_MASK="0xff"
+[ -z "$IPT_MASK_STRING" ] && IPT_MASK_STRING="/${IPT_MASK}"	# for set-mark
 
+#sqm_logger "${0} IPT_MASK: ${IPT_MASK_STRING}"
 
 
 

--- a/net/sqm-scripts/files/usr/lib/sqm/simple.qos
+++ b/net/sqm-scripts/files/usr/lib/sqm/simple.qos
@@ -25,13 +25,13 @@ ipt_setup() {
 
 ipt -t mangle -N QOS_MARK_${IFACE}
 
-ipt -t mangle -A QOS_MARK_${IFACE} -j MARK --set-mark 0x2
+ipt -t mangle -A QOS_MARK_${IFACE} -j MARK --set-mark 0x2${IPT_MASK_STRING}
 # You can go further with classification but...
-ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class CS1 -j MARK --set-mark 0x3
-ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class CS6 -j MARK --set-mark 0x1
-ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class EF -j MARK --set-mark 0x1
-ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class AF42 -j MARK --set-mark 0x1
-ipt -t mangle -A QOS_MARK_${IFACE} -m tos  --tos Minimize-Delay -j MARK --set-mark 0x1
+ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class CS1 -j MARK --set-mark 0x3${IPT_MASK_STRING}
+ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class CS6 -j MARK --set-mark 0x1${IPT_MASK_STRING}
+ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class EF -j MARK --set-mark 0x1${IPT_MASK_STRING}
+ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class AF42 -j MARK --set-mark 0x1${IPT_MASK_STRING}
+ipt -t mangle -A QOS_MARK_${IFACE} -m tos  --tos Minimize-Delay -j MARK --set-mark 0x1${IPT_MASK_STRING}
 
 # and it might be a good idea to do it for udp tunnels too
 
@@ -43,16 +43,16 @@ sqm_logger "Squashing differentiated services code points (DSCP) from ingress."
 ipt -t mangle -I PREROUTING -i $IFACE -m dscp ! --dscp 0 -j DSCP --set-dscp-class be
 else
 sqm_logger "Keeping differentiated services code points (DSCP) from ingress."
-ipt -t mangle -A PREROUTING -i $IFACE -m mark --mark 0x00 -g QOS_MARK_${IFACE} 
+ipt -t mangle -A PREROUTING -i $IFACE -m mark --mark 0x00${IPT_MASK_STRING} -g QOS_MARK_${IFACE} 
 fi
 
-ipt -t mangle -A POSTROUTING -o $IFACE -m mark --mark 0x00 -g QOS_MARK_${IFACE} 
+ipt -t mangle -A POSTROUTING -o $IFACE -m mark --mark 0x00${IPT_MASK_STRING} -g QOS_MARK_${IFACE} 
 
 # The Syn optimization was nice but fq_codel does it for us
 # ipt -t mangle -A PREROUTING -i s+ -p tcp -m tcp --tcp-flags SYN,RST,ACK SYN -j MARK --set-mark 0x01
 # Not sure if this will work. Encapsulation is a problem period
 
-ipt -t mangle -I PREROUTING -i vtun+ -p tcp -j MARK --set-mark 0x2 # tcp tunnels need ordering
+ipt -t mangle -I PREROUTING -i vtun+ -p tcp -j MARK --set-mark 0x2${IPT_MASK_STRING} # tcp tunnels need ordering
 
 # Emanating from router, do a little more optimization
 # but don't bother with it too much. 

--- a/net/sqm-scripts/files/usr/lib/sqm/simple_pppoe.qos
+++ b/net/sqm-scripts/files/usr/lib/sqm/simple_pppoe.qos
@@ -19,19 +19,24 @@
 
 # You need to jiggle these parameters. Note limits are tuned towards a <10Mbit uplink <60Mbup down
 
-. /usr/lib/sqm/functions.sh
+#sm: Goal to create a set of tc filters that also apply on pppoe encapsulated packets
+#	but having multiple filters run in succession is slow, so look at tc filter hashing 
+#	(this should help cut down the number of OPs per packet considerably)
 
+
+. /usr/lib/sqm/functions.sh
+#sqm_logger IPT_MASK: ${IPT_MASK_STRING}
 ipt_setup() {
 
 ipt -t mangle -N QOS_MARK_${IFACE}
 
-ipt -t mangle -A QOS_MARK_${IFACE} -j MARK --set-mark 0x2
+ipt -t mangle -A QOS_MARK_${IFACE} -j MARK --set-mark 0x2${IPT_MASK_STRING}
 # You can go further with classification but...
-ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class CS1 -j MARK --set-mark 0x3
-ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class CS6 -j MARK --set-mark 0x1
-ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class EF -j MARK --set-mark 0x1
-ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class AF42 -j MARK --set-mark 0x1
-ipt -t mangle -A QOS_MARK_${IFACE} -m tos  --tos Minimize-Delay -j MARK --set-mark 0x1
+ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class CS1 -j MARK --set-mark 0x3${IPT_MASK_STRING}
+ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class CS6 -j MARK --set-mark 0x1${IPT_MASK_STRING}
+ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class EF -j MARK --set-mark 0x1${IPT_MASK_STRING}
+ipt -t mangle -A QOS_MARK_${IFACE} -m dscp --dscp-class AF42 -j MARK --set-mark 0x1${IPT_MASK_STRING}
+ipt -t mangle -A QOS_MARK_${IFACE} -m tos  --tos Minimize-Delay -j MARK --set-mark 0x1${IPT_MASK_STRING}
 
 # and it might be a good idea to do it for udp tunnels too
 
@@ -39,20 +44,20 @@ ipt -t mangle -A QOS_MARK_${IFACE} -m tos  --tos Minimize-Delay -j MARK --set-ma
 
 if [ "$SQUASH_DSCP" = "1" ]
 then
-sqm_logger "Squashing differentiad services code points (DSCP) from ingress."
+sqm_logger "Squashing differentiated services code points (DSCP) from ingress."
 ipt -t mangle -I PREROUTING -i $IFACE -m dscp ! --dscp 0 -j DSCP --set-dscp-class be
 else
 sqm_logger "Keeping differentiad services code points (DSCP) from ingress."
-ipt -t mangle -A PREROUTING -i $IFACE -m mark --mark 0x00 -g QOS_MARK_${IFACE} 
+ipt -t mangle -A PREROUTING -i $IFACE -m mark --mark 0x00${IPT_MASK_STRING} -g QOS_MARK_${IFACE} 
 fi
 
-ipt -t mangle -A POSTROUTING -o $IFACE -m mark --mark 0x00 -g QOS_MARK_${IFACE} 
+ipt -t mangle -A POSTROUTING -o $IFACE -m mark --mark 0x00${IPT_MASK_STRING} -g QOS_MARK_${IFACE} 
 
 # The Syn optimization was nice but fq_codel does it for us
 # ipt -t mangle -A PREROUTING -i s+ -p tcp -m tcp --tcp-flags SYN,RST,ACK SYN -j MARK --set-mark 0x01
 # Not sure if this will work. Encapsulation is a problem period
 
-ipt -t mangle -I PREROUTING -i vtun+ -p tcp -j MARK --set-mark 0x2 # tcp tunnels need ordering
+ipt -t mangle -I PREROUTING -i vtun+ -p tcp -j MARK --set-mark 0x2${IPT_MASK_STRING} # tcp tunnels need ordering
 
 # Emanating from router, do a little more optimization
 # but don't bother with it too much. 
@@ -65,25 +70,27 @@ ipt -t mangle -A OUTPUT -p udp -m multiport --ports 123,53 -j DSCP --set-dscp-cl
 }
 
 
+MYBURST=1600	#sm: make burst and cburst as well as quantum configurable for ingress and egress in the GUI
 # TC rules
 
 egress() {
 
 CEIL=${UPLINK}
-PRIO_RATE=`expr $CEIL / 3` # Ceiling for prioirty
+PRIO_RATE=`expr $CEIL / 3` # Ceiling for priority
 BE_RATE=`expr $CEIL / 6`   # Min for best effort
 BK_RATE=`expr $CEIL / 6`   # Min for background
 BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
 LQ="quantum `get_mtu $IFACE $CEIL`"
+HTB_BURSTS="burst ${MYBURST} cburst ${MYBURST}"
 
 $TC qdisc del dev $IFACE root 2> /dev/null
 $TC qdisc add dev $IFACE root handle 1: `get_stab_string` htb default 12
-$TC class add dev $IFACE parent 1: classid 1:1 htb $LQ rate ${CEIL}kbit ceil ${CEIL}kbit `get_htb_adsll_string`
-$TC class add dev $IFACE parent 1:1 classid 1:10 htb $LQ rate ${CEIL}kbit ceil ${CEIL}kbit prio 0 `get_htb_adsll_string`
-$TC class add dev $IFACE parent 1:1 classid 1:11 htb $LQ rate 128kbit ceil ${PRIO_RATE}kbit prio 1 `get_htb_adsll_string`
-$TC class add dev $IFACE parent 1:1 classid 1:12 htb $LQ rate ${BE_RATE}kbit ceil ${BE_CEIL}kbit prio 2 `get_htb_adsll_string`
-$TC class add dev $IFACE parent 1:1 classid 1:13 htb $LQ rate ${BK_RATE}kbit ceil ${BE_CEIL}kbit prio 3 `get_htb_adsll_string`
+$TC class add dev $IFACE parent 1: classid 1:1 htb $LQ ${HTB_BURSTS} rate ${CEIL}kbit ceil ${CEIL}kbit `get_htb_adsll_string`
+$TC class add dev $IFACE parent 1:1 classid 1:10 htb $LQ ${HTB_BURSTS} rate ${CEIL}kbit ceil ${CEIL}kbit prio 0 `get_htb_adsll_string`
+$TC class add dev $IFACE parent 1:1 classid 1:11 htb $LQ ${HTB_BURSTS} rate 128kbit ceil ${PRIO_RATE}kbit prio 1 `get_htb_adsll_string`
+$TC class add dev $IFACE parent 1:1 classid 1:12 htb $LQ ${HTB_BURSTS} rate ${BE_RATE}kbit ceil ${BE_CEIL}kbit prio 2 `get_htb_adsll_string`
+$TC class add dev $IFACE parent 1:1 classid 1:13 htb $LQ ${HTB_BURSTS} rate ${BK_RATE}kbit ceil ${BE_CEIL}kbit prio 3 `get_htb_adsll_string`
 
 $TC qdisc add dev $IFACE parent 1:11 handle 110: $QDISC `get_limit ${ELIMIT}` `get_target "${ETARGET}" ${UPLINK}` `get_ecn ${EECN}` `get_quantum 300` `get_flows ${PRIO_RATE}` ${EQDISC_OPTS}
 $TC qdisc add dev $IFACE parent 1:12 handle 120: $QDISC `get_limit ${ELIMIT}` `get_target "${ETARGET}" ${UPLINK}` `get_ecn ${EECN}` `get_quantum 300` `get_flows ${BE_RATE}` ${EQDISC_OPTS}
@@ -301,6 +308,7 @@ BK_RATE=`expr $CEIL / 6`   # Min for background
 BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
 LQ="quantum `get_mtu $IFACE $CEIL`"
+HTB_BURSTS="burst ${MYBURST} cburst ${MYBURST}"
 
 $TC qdisc del dev $IFACE handle ffff: ingress 2> /dev/null
 $TC qdisc add dev $IFACE handle ffff: ingress
@@ -313,18 +321,18 @@ sqm_logger "Do not perform DSCP based filtering on ingress. (1-tier classificati
 # Revert to no dscp based filtering
 $TC qdisc del dev $DEV root 2>/dev/null
 $TC qdisc add dev $DEV root handle 1: `get_stab_string` htb default 10
-$TC class add dev $DEV parent 1: classid 1:1 htb $LQ rate ${DOWNLINK}kbit ceil ${DOWNLINK}kbit `get_htb_adsll_string`
-$TC class add dev $DEV parent 1:1 classid 1:10 htb $LQ rate ${DOWNLINK}kbit ceil ${DOWNLINK}kbit prio 0 `get_htb_adsll_string`
+$TC class add dev $DEV parent 1: classid 1:1 htb $LQ ${HTB_BURSTS} rate ${DOWNLINK}kbit ceil ${DOWNLINK}kbit `get_htb_adsll_string`
+$TC class add dev $DEV parent 1:1 classid 1:10 htb $LQ ${HTB_BURSTS} rate ${DOWNLINK}kbit ceil ${DOWNLINK}kbit prio 0 `get_htb_adsll_string`
 $TC qdisc add dev $DEV parent 1:10 handle 110: $QDISC `get_limit ${ILIMIT}` `get_target "${ITARGET}" ${DOWNLINK}` `get_ecn ${IECN}` `get_flows ${DOWNLINK}` ${IQDISC_OPTS}
 
 else
 sqm_logger "Perform DSCP based filtering on ingress. (3-tier classification)"
 $TC qdisc add dev $DEV root handle 1: `get_stab_string` htb default 12
-$TC class add dev $DEV parent 1: classid 1:1 htb $LQ rate ${CEIL}kbit ceil ${CEIL}kbit `get_htb_adsll_string`
-$TC class add dev $DEV parent 1:1 classid 1:10 htb $LQ rate ${CEIL}kbit ceil ${CEIL}kbit prio 0 `get_htb_adsll_string`
-$TC class add dev $DEV parent 1:1 classid 1:11 htb $LQ rate 32kbit ceil ${PRIO_RATE}kbit prio 1 `get_htb_adsll_string`
-$TC class add dev $DEV parent 1:1 classid 1:12 htb $LQ rate ${BE_RATE}kbit ceil ${BE_CEIL}kbit prio 2 `get_htb_adsll_string`
-$TC class add dev $DEV parent 1:1 classid 1:13 htb $LQ rate ${BK_RATE}kbit ceil ${BE_CEIL}kbit prio 3 `get_htb_adsll_string`
+$TC class add dev $DEV parent 1: classid 1:1 htb $LQ ${HTB_BURSTS} rate ${CEIL}kbit ceil ${CEIL}kbit `get_htb_adsll_string`
+$TC class add dev $DEV parent 1:1 classid 1:10 htb $LQ ${HTB_BURSTS} rate ${CEIL}kbit ceil ${CEIL}kbit prio 0 `get_htb_adsll_string`
+$TC class add dev $DEV parent 1:1 classid 1:11 htb $LQ ${HTB_BURSTS} rate 32kbit ceil ${PRIO_RATE}kbit prio 1 `get_htb_adsll_string`
+$TC class add dev $DEV parent 1:1 classid 1:12 htb $LQ ${HTB_BURSTS} rate ${BE_RATE}kbit ceil ${BE_CEIL}kbit prio 2 `get_htb_adsll_string`
+$TC class add dev $DEV parent 1:1 classid 1:13 htb $LQ ${HTB_BURSTS} rate ${BK_RATE}kbit ceil ${BE_CEIL}kbit prio 3 `get_htb_adsll_string`
 
 # I'd prefer to use a pre-nat filter but that causes permutation...
 


### PR DESCRIPTION
Apply mask for markings to enable co-existence with multiwan, mwan3 etc.

Matches source tree at https://github.com/dtaht/ceropackages-3.10/tree/d82ef2a81cb71fc4749ab4a353e6d9307c37dc4b

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
