### PR TITLE
Python update 5

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -64,7 +64,7 @@ endef
 
 define Package/python
 $(call Package/python/Default)
-  DEPENDS:=+python-base +libncursesw +libbz2 +libgdbm +libreadline +libsqlite3 +libexpat +libdb47
+  DEPENDS:=+python-base +libncursesw +libbz2 +libgdbm +libsqlite3 +libexpat +libdb47
 endef
 
 define Package/python/description
@@ -159,6 +159,7 @@ define PyPackage/python/filespec
 -|/usr/lib/python$(PYTHON_VERSION)/webbrowser.py
 -|/usr/lib/python$(PYTHON_VERSION)/*/test
 -|/usr/lib/python$(PYTHON_VERSION)/*/tests
+-|/usr/lib/python$(PYTHON_VERSION)/lib-dynload/readline.so
 endef
 
 define PyPackage/python-base/install


### PR DESCRIPTION
Fix builds. 
https://github.com/openwrt/packages/issues/518 & http://buildbot.openwrt.org:8010/broken_packages/ar71xx.mikrotik/python/compile.txt

Making `python` ==> `python-base` and `python-full` ==> `python`.
This is the final packaging/switch/etc.
From now it's just `python-base` and `python`.
Anything in-between is difficult to maintain for the main Python package.

Users that want to install Python should install the standard python installation (out-of-the-box).
If they cannot fit the full Python install, they should use `python-base` and install whatever libs they need.
I have a work-in-progress for adding `python-base` + whatever libs are needed.

Signed-off-by: Alexandru Ardelean ardeleanalex@gmail.com
