### PR TITLE
python: add __PYENV_LAUNCHER__ env var

### DIFF
--- a/lang/python/files/python-package.mk
+++ b/lang/python/files/python-package.mk
@@ -89,6 +89,7 @@ define Build/Compile/PyMod
 		CPPFLAGS="$(TARGET_CPPFLAGS) -I$(PYTHON_INC_DIR)" \
 		LDFLAGS="$(TARGET_LDFLAGS) -lpython$(PYTHON_VERSION)" \
 		_PYTHON_HOST_PLATFORM="linux-$(ARCH)" \
+		__PYVENV_LAUNCHER__="/usr/bin/$(PYTHON)" \
 		$(3) \
 		, \
 		./setup.py $(2) \


### PR DESCRIPTION
Mostly useful for setuptools and pip during build.

Signed-off-by: Alexandru Ardelean ardeleanalex@gmail.com
