### PR TITLE
ruby: update to 2.1.4

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -10,14 +10,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=2.1.3
-PKG_RELEASE:=2
+PKG_VERSION:=2.1.4
+PKG_RELEASE:=1
 
 PKG_LIBVER:=2.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://cache.ruby-lang.org/pub/ruby/$(PKG_LIBVER)/
-PKG_MD5SUM:=02b7da3bb06037c777ca52e1194efccb
+PKG_MD5SUM:=f4136e781d261e3cc20748005e1740b7
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILE:=COPYING
@@ -86,7 +86,7 @@ endef
 
 define Package/ruby-bigdecimal
 $(call Package/ruby/Default)
-  TITLE:=Arbitrary-precision decimal floating-point library for Ruby
+  TITLE:=Arbitrary-precision decimal floating-point lib for Ruby
   DEPENDS:=ruby
 endef
 


### PR DESCRIPTION
This release includes security fixes for the following vulnerabilities:
- CVE-2014-8080: Denial of Service XML Expansion
- Changed default settings of ext/openssl related to CVE-2014-3566

And there are some bug-fixes.

Ref: https://www.ruby-lang.org/en/news/2014/10/27/ruby-2-1-4-released/

Signed-off-by: Luiz Angelo Daros de Luca luizluca@gmail.com
