### PR TITLE
bmon: Fix libncursesw dependency

### DIFF
--- a/net/bmon/Makefile
+++ b/net/bmon/Makefile
@@ -36,9 +36,6 @@ endef
 
 CONFIGURE_ARGS += \
 	--disable-cnt-workaround \
-	--disable-dbi \
-	--disable-rrd \
-	--disable-asound \
 
 CONFIGURE_VARS += \
 	ac_cv_lib_nl_nl_connect=no \


### PR DESCRIPTION
bmon tries to use libncursesw if it is available, which makes the dependency of the OpenWRT package incorrect.  This patch borrows from `sound/mocp`, which conditionally depends on either libncurses or libncursesw, depending on which one is available.

This fixes issue #509.
