### PR TITLE
python: add patch to disable python byte codes by default 

### DIFF
--- a/lang/python/patches/140-do-not-write-bytes-codes.patch
+++ b/lang/python/patches/140-do-not-write-bytes-codes.patch
@@ -1,0 +1,22 @@
+diff --git a/Python/pythonrun.c b/Python/pythonrun.c
+index 748a63b..cb6e291 100644
+--- a/Python/pythonrun.c
++++ b/Python/pythonrun.c
+@@ -79,7 +79,7 @@ int Py_InteractiveFlag; /* Needed by Py_FdIsInteractive() below */
+ int Py_InspectFlag; /* Needed to determine whether to exit at SystemExit */
+ int Py_NoSiteFlag; /* Suppress 'import site' */
+ int Py_BytesWarningFlag; /* Warn on str(bytes) and str(buffer) */
+-int Py_DontWriteBytecodeFlag; /* Suppress writing bytecode files (*.py[co]) */
++int Py_DontWriteBytecodeFlag = 1; /* Suppress writing bytecode files (*.py[co]) */
+ int Py_UseClassExceptionsFlag = 1; /* Needed by bltinmodule.c: deprecated */
+ int Py_FrozenFlag; /* Needed by getpath.c */
+ int Py_UnicodeFlag = 0; /* Needed by compile.c */
+@@ -174,7 +174,7 @@ Py_InitializeEx(int install_sigs)
+     if ((p = Py_GETENV("PYTHONOPTIMIZE")) && *p != '\0')
+         Py_OptimizeFlag = add_flag(Py_OptimizeFlag, p);
+     if ((p = Py_GETENV("PYTHONDONTWRITEBYTECODE")) && *p != '\0')
+-        Py_DontWriteBytecodeFlag = add_flag(Py_DontWriteBytecodeFlag, p);
++        Py_DontWriteBytecodeFlag = atoi(p);
+     /* The variable is only tested for existence here; _PyRandom_Init will
+        check its value further. */
+     if ((p = Py_GETENV("PYTHONHASHSEED")) && *p != '\0')


### PR DESCRIPTION
This gets added only if python is installed on the target, via build or via opkg command.

Signed-off-by: Alexandru Ardelean ardeleanalex@gmail.com
