### PR TITLE
sispmctl: import from oldpackages

### DIFF
--- a/utils/sispmctl/Makefile
+++ b/utils/sispmctl/Makefile
@@ -43,6 +43,7 @@ define Package/sispmctl/description
  multiple SIS-PM devices, too.
 endef
 
+TARGET_CFLAGS += -D_GNU_SOURCE
 CONFIGURE_ARGS += \
 	--enable-webless \
 	--disable-dependency-tracking

--- a/utils/sispmctl/patches/001-fix-includes.patch
+++ b/utils/sispmctl/patches/001-fix-includes.patch
@@ -1,0 +1,25 @@
+--- a/src/sispm_ctl.c
++++ b/src/sispm_ctl.c
+@@ -33,6 +33,7 @@
+ #include <stdlib.h>
+ #include <unistd.h>
+ #include <time.h>
++#include <sys/types.h>
+ #include <usb.h>
+ #include <assert.h>
+ #include "sispm_ctl.h"
+--- a/src/main.c
++++ b/src/main.c
+@@ -34,11 +34,11 @@
+ #define __USE_XOPEN
+ #include <time.h>
+ #include <signal.h>
+-#include <usb.h>
+ #include <assert.h>
+ #include <getopt.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
++#include <usb.h>
+ 
+ #include <fcntl.h>
+ 


### PR DESCRIPTION
- import from oldpackages
- use latest revision from git
- fix compile error for musl build

Unpatched compile against musl fails because &lt;sys/types.h&gt; is not included in &lt;usb.h&gt; (provided by "libusb-compat") and consequently the 'u_int*_t' types are not found.

This should probably better be fixed generically in the core "libusb-compat" package (by including &lt;sys/types.h&gt; in usb.h).
