### PR TITLE
php5: upgrade to 5.4.35

### DIFF
--- a/lang/php5/Makefile
+++ b/lang/php5/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=5.4.34
+PKG_VERSION:=5.4.35
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILE=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_MD5SUM:=1afe3a10cefec9618acb785ef5064bf9
+PKG_MD5SUM:=489cc8336488fb2e722ffa3c08f9c864
 
 PKG_FIXUP:=libtool no-autoreconf
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
This fixes CVE-2014-3710.

Signed-off-by: Michael Heimpold mhei@heimpold.de
