### PR TITLE
libxml2: add host compile

### DIFF
--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxml2
 PKG_VERSION:=2.9.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://gd.tuwien.ac.at/languages/libxml/ \
@@ -26,6 +26,7 @@ PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/libxml2
@@ -43,6 +44,38 @@ endef
 TARGET_CFLAGS += $(FPIC)
 
 CONFIGURE_ARGS += \
+	--enable-shared \
+	--enable-static \
+	--with-c14n \
+	--without-catalog \
+	--with-debug \
+	--without-docbook \
+	--with-html \
+	--without-ftp \
+	--without-http \
+	--without-iconv \
+	--without-iso8859x \
+	--without-legacy \
+	--with-output \
+	--without-pattern \
+	--without-push \
+	--without-python \
+	--with-reader \
+	--without-readline \
+	--without-regexps \
+	--with-sax1 \
+	--with-schemas \
+	--with-threads \
+	--with-tree \
+	--with-valid \
+	--with-writer \
+	--with-xinclude \
+	--with-xpath \
+	--with-xptr \
+	--with-zlib \
+	--without-lzma
+
+HOST_CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
 	--with-c14n \
@@ -97,4 +130,5 @@ define Package/libxml2/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libxml2.so* $(1)/usr/lib/
 endef
 
+$(eval $(call HostBuild))
 $(eval $(call BuildPackage,libxml2))


### PR DESCRIPTION
Several packages may depend on host compiled packages during
the build time (such as the new LTS versions of telephony packages).

This commit adds an option to build libxml2 as a host package. Usage 
would be following:

```
PKG_BUILD_DEPENDS:=libxml2/host
```

Signed-off-by: Jiri Slachta slachta@cesnet.cz
