### PR TITLE
dbus host building

### DIFF
--- a/utils/dbus/Makefile
+++ b/utils/dbus/Makefile
@@ -21,6 +21,7 @@ PKG_LICENSE:=AFL-2.1
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 
 TARGET_LDFLAGS+= \
@@ -107,6 +108,29 @@ CONFIGURE_VARS+= \
 	ac_cv_have_abstract_sockets="yes" \
 	ac_cv_lib_expat_XML_ParserCreate_MM="yes" \
 
+HOST_CONFIGURE_ARGS+= \
+	--enable-shared \
+	--enable-static \
+	--disable-abstract-sockets \
+	--disable-ansi \
+	--disable-asserts \
+	--disable-console-owner-file \
+	--disable-docygen-docs \
+	--disable-compiler_coverage \
+	--disable-selinux \
+	--disable-tests \
+	--disable-verbose-mode \
+	--disable-xml-docs \
+	--with-dbus-user=root \
+	--with-dbus-daemondir="$(STAGIND_DIR_HOST)/bin" \
+	--with-system-socket="$(STAGING_DIR_HOST)/var/run/dbus/system_bus_socket" \
+	--with-system-pid-file="$(STAGING_DIR_HOST)/var/run/dbus.pid" \
+	--without-x \
+	--libexecdir="$(STAGING_DIR_HOST)/lib/dbus-1"
+
+HOST_CONFIGURE_VARS+= \
+	ac_cv_have_abstract_sockets="yes" \
+	ac_cv_lib_expat_XML_ParserCreate_MM="yes" \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
@@ -184,6 +208,7 @@ define Package/dbus-utils/install
 		$(1)/usr/bin/
 endef
 
+$(eval $(call HostBuild))
 $(eval $(call BuildPackage,libdbus))
 $(eval $(call BuildPackage,dbus))
 $(eval $(call BuildPackage,dbus-utils))


### PR DESCRIPTION
Enable dbus host building ( some packages on other feed(s) need dbus on
host side, since packages need to be compiled natively before cross
compiling)

I maintain (or try to maintain) feed rip-packages, which has various packages designed for raspberry pi running OpenWrt (can be used on others as well, but some packages are useless on headless units) and for elementary and efl (enlightenment libraries) - dbus needs to be host compiled as well, since these libraries _must_ be compiled natively first, since they have utility that needs to be used before end-user code can be generated. This utility does not compile without dbus. This patch enabled host building of dbus. This isn't a huge improvement to packages, but helps some of us - and does not hurt anyone or cause any problems, as dbus is only compiled for host if another package requires so. Please merge, thank you.
