### PR TITLE
protobuf: Fixed protobuf host installation

### DIFF
--- a/libs/protobuf/Makefile
+++ b/libs/protobuf/Makefile
@@ -43,6 +43,7 @@ define Host/Compile
 endef
 
 define Host/Install
+	$(MAKE) -C $(HOST_BUILD_DIR) install
 endef
 
 CONFIGURE_ARGS += --with-protoc=$(HOST_BUILD_DIR)/src/protoc


### PR DESCRIPTION
Fixed the host install, because some packages need the host binary to build properly
Signed-off-by: Martijn Zilverschoon martijn@friedzombie.com
