### PR TITLE
coova-chilli: Import from oldpackages

### DIFF
--- a/net/coova-chilli/Config.in
+++ b/net/coova-chilli/Config.in
@@ -1,0 +1,48 @@
+# CoovaChilli avanced configuration
+
+menu "Configuration"
+	depends on PACKAGE_coova-chilli
+
+config COOVACHILLI_REDIR
+	bool "Enable support for redir server. Required for uamregex"
+	default n
+
+config COOVACHILLI_MINIPORTAL
+	bool "Enable support Coova miniportal"
+	default n
+
+config COOVACHILLI_USERAGENT
+	bool "Enable recording user-agent"
+	default n
+
+config COOVACHILLI_DNSLOG
+	bool "Enable support to log DNS name queries"
+	default n
+
+config COOVACHILLI_UAMDOMAINFILE
+	bool "Enable loading of mass uamdomains from file"
+	default n
+
+config COOVACHILLI_LARGELIMITS
+	bool "Enable larger limits for use with non-embedded systems"
+	default n
+
+choice
+	prompt "SSL library"
+	default COOVACHILLI_NOSSL
+
+config COOVACHILLI_NOSSL
+	bool "No SSL support"
+
+config COOVACHILLI_MATRIXSSL
+	bool "MatrixSSL"
+
+config COOVACHILLI_CYASSL
+	bool "CyaSSL"
+
+config COOVACHILLI_OPENSSL
+	bool "OpenSSL"
+
+endchoice
+
+endmenu

--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -1,0 +1,101 @@
+#
+# Copyright (C) 2007-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=coova-chilli
+PKG_VERSION:=1.3.0
+PKG_RELEASE:=5
+PKG_MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>
+PKG_LICENSE:=GPL-3.0+
+PKG_LICENSE_FILE:=COPYING
+PKG_REV:= 492
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://dev.coova.org/svn/coova-chilli
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=$(PKG_REV)
+PKG_SOURCE_PROTO:=svn
+PKG_INSTALL:=1
+
+
+PKG_CONFIG_DEPENDS := \
+  COOVACHILLI_MINIPORTAL \
+  COOVACHILLI_REDIR \
+  COOVACHILLI_USERAGENT \
+  COOVACHILLI_DNSLOG \
+  COOVACHILLI_UAMDOMAINFILE \
+  COOVACHILLI_LARGELIMITS \
+  COOVACHILLI_NOSSL \
+  COOVACHILLI_MATRIXSSL \
+  COOVACHILLI_CYASSL \
+  COOVACHILLI_OPENSSL
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/coova-chilli
+  SUBMENU:=Captive Portals
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+kmod-tun +librt +COOVACHILLI_MATRIXSSL:libmatrixssl +COOVACHILLI_CYASSL:libcyassl +COOVACHILLI_OPENSSL:libopenssl
+  TITLE:=Wireless LAN HotSpot controller (Coova Chilli Version)
+  URL:=http://www.coova.org/CoovaChilli
+  MENU:=1
+endef
+
+define Package/coova-chilli/description
+	CoovaChilli is an open source access controller for wireless LAN
+	access points and is based on ChilliSpot. It is used for authenticating
+	users of a wireless (or wired) LAN. It supports web based login (UAM)
+	which is today's standard for public HotSpots and it supports Wireless
+	Protected Access (WPA) which is the standard of the future.
+	Authentication,	authorization and accounting (AAA) is handled by your
+	favorite radius server.
+endef
+
+define Package/coova-chilli/config
+  source "$(SOURCE)/Config.in"
+endef
+
+define Build/Configure
+	$(call Build/Configure/Default, \
+	$(if $(CONFIG_COOVACHILLI_REDIR),--enable,--disable)-chilliredir \
+	$(if $(CONFIG_COOVACHILLI_DNSLOG),--enable,--disable)-dnslog \
+	$(if $(CONFIG_COOVACHILLI_MINIPORTAL),--enable,--disable)-miniportal \
+	$(if $(CONFIG_COOVACHILLI_USERAGENT),--enable,--disable)-useragent \
+	$(if $(CONFIG_COOVACHILLI_LARGELIMITS),--enable,--disable)-largelimits \
+	$(if $(CONFIG_COOVACHILLI_UAMDOMAINFILE),--enable,--disable)-uamdomainfile \
+	$(if $(CONFIG_COOVACHILLI_MATRIXSSL),--with,--without)-matrixssl \
+	$(if $(CONFIG_COOVACHILLI_CYASSL),--with,--without)-cyaxssl \
+	$(if $(CONFIG_COOVACHILLI_OPENSSL),--with,--without)-openssl \
+	)
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	(cd $(PKG_BUILD_DIR) && $(BASH) -x ./bootstrap)
+endef
+
+define Package/coova-chilli/conffiles
+/etc/chilli.conf
+endef
+
+
+define Package/coova-chilli/install
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/chilli.conf $(1)/etc/
+	$(INSTALL_DIR) $(1)/etc/chilli
+	$(CP) $(PKG_INSTALL_DIR)/etc/chilli/* $(1)/etc/chilli/
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
+	$(INSTALL_DATA) ./files/chilli.hotplug $(1)/etc/hotplug.d/iface/30-chilli
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/chilli* $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,coova-chilli))

--- a/net/coova-chilli/files/chilli.hotplug
+++ b/net/coova-chilli/files/chilli.hotplug
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+[ "$ACTION" == "ifup" ] || exit 0
+
+[ "$INTERFACE" = "wan" ] && {
+	/etc/init.d/chilli restart
+}

--- a/net/coova-chilli/patches/100-fix-sysinfo-redeclaration.patch
+++ b/net/coova-chilli/patches/100-fix-sysinfo-redeclaration.patch
@@ -1,0 +1,24 @@
+--- a/src/system.h
++++ b/src/system.h
+@@ -76,10 +76,6 @@
+ #include <sys/stat.h>
+ #endif
+ 
+-#ifdef HAVE_SYS_SYSINFO_H
+-#include <sys/sysinfo.h>
+-#endif
+-
+ #ifdef HAVE_TIME_H
+ #include <time.h>
+ #endif
+@@ -132,6 +128,10 @@
+ #include <linux/un.h>
+ #endif
+ 
++#ifdef HAVE_SYS_SYSINFO_H
++#include <sys/sysinfo.h>
++#endif
++
+ #elif defined (__FreeBSD__)  || defined (__APPLE__) || defined (__OpenBSD__) || defined (__NetBSD__) 
+ #include <net/if.h>
+ #include <net/bpf.h>


### PR DESCRIPTION
Changes
1. Moved coova-chilli package from oldpackages
2. Using the svn version rather than a tar.gz download. 
3. Execute the bootstrap command before the configure and make 

Signed-off-by: Ramanathan Sivagurunathan ramzthecoder@gmail.com
