### PR TITLE
aria2: enable bittorrent and metalink by default

### DIFF
--- a/net/aria2/Config.in
+++ b/net/aria2/Config.in
@@ -19,10 +19,10 @@ endchoice
 config ARIA2_BITTORRENT
 	bool "Enable bittorrent support"
 	depends on ARIA2_OPENSSL
-	default n
+	default y
 
 config ARIA2_METALINK
 	bool "Enable metalink support"
-	default N
+	default y
 
 endmenu


### PR DESCRIPTION
Aria2 bittorrent and metalink support should be enabled by default
Signed-off-by: Gavin Ni gisngy@gmail.com
