### PR TITLE
Adding support for libhttp-parser

### DIFF
--- a/libs/libhttp-parser/Makefile
+++ b/libs/libhttp-parser/Makefile
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2013 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libhttp-parser
+PKG_VERSION:=2.3.0
+PKG_RELEASE=1
+PKG_MAINTAINER:=Ramanathan Sivagurunathan <ramzthecoder@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILE:=LICENSE-MIT
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_URL:=git://github.com/joyent/http-parser.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=56f7ad0e2e5a80f79d214015c91e1f17d11d109f
+
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libhttp-parser
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=A library to parse http request and response
+  URL:=https://github.com/joyent/http-parser
+endef
+
+define Package/libhttp-parser/description
+  A parser for HTTP messages written in C. It parses both requests and responses. 
+  The parser is designed to be used in performance HTTP applications. 
+  It does not make any syscalls nor allocations, it does not buffer data, 
+  it can be interrupted at anytime. Depending on your architecture, 
+  it only requires about 40 bytes of data per message stream 
+  (in a web server that is per connection).
+endef
+
+define Build/Compile
+	$(call Build/Compile/Default, library) 
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/http_parser.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/libhttp_parser.so.* $(1)/usr/lib/
+	( cd $(1)/usr/lib ; ln -s libhttp_parser.so.* libhttp_parser.so )
+endef
+
+define Package/libhttp-parser/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/libhttp_parser.so.* $(1)/usr/lib/
+	( cd $(1)/usr/lib ; ln -s libhttp_parser.so.* libhttp_parser.so )
+endef
+
+$(eval $(call BuildPackage,libhttp-parser))


### PR DESCRIPTION
http-parser is a parser for HTTP messages written in C. It parses both requests and responses. The parser is designed to be used in performance HTTP applications. It does not make any syscalls nor allocations, it does not buffer data, it can be interrupted at anytime. Depending on your architecture, it only requires about 40 bytes of data per message stream (in a web server that is per connection).

http-parser is developed by joyent. 

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Ramanathan Sivagurunathan ramzthecoder@gmail.com
