### PR TITLE
python3: sync build rules with python's

### DIFF
--- a/lang/python3/Makefile
+++ b/lang/python3/Makefile
@@ -31,7 +31,7 @@ HOST_BUILD_PARALLEL:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/Python-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/Python-$(PKG_VERSION)
 
-PKG_BUILD_DEPENDS:=python3/host
+PKG_BUILD_DEPENDS:=libffi/host python3/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -54,69 +54,62 @@ define Package/python3/Default/description
  the development of higher quality, more maintainable code.
 endef
 
-define Package/python3
+define Package/python3-base
 $(call Package/python3/Default)
+  TITLE:=Python $(PYTHON_VERSION) interpreter
   DEPENDS:=+libpthread +zlib +libffi
 endef
 
-define Package/python3/description
-$(call Package/python3/Default/description)
-  .
-  This package contains only the interpreter and the bare minimum for the interpreter to start.
+define Package/python3-base/description
+  This package contains only the interpreter and the bare minimum
+  for the interpreter to start.
 endef
 
-MAKE_FLAGS:=\
-	$(TARGET_CONFIGURE_OPTS) \
-	DESTDIR="$(PKG_INSTALL_DIR)" \
+define Package/python3
+$(call Package/python3/Default)
+  DEPENDS:=+python3-base +libncursesw +libbz2 +libgdbm +libsqlite3 +libdb47 +libopenssl
+endef
+
+define Package/python3/description
+  This package contains the (almost) full Python install.
+endef
+
+MAKE_FLAGS+=\
 	CROSS_COMPILE=yes \
-	CFLAGS="$(TARGET_CFLAGS) -DNDEBUG -fno-inline" \
-	LDFLAGS="$(TARGET_LDFLAGS) -L$(PKG_BUILD_DIR)" \
-	LD="$(TARGET_CC)"
+	LD="$(TARGET_CC)" \
+	PGEN=pgen3
+
+EXTRA_CFLAGS+= \
+	-DNDEBUG -fno-inline
+EXTRA_LDFLAGS+= \
+	-L$(PKG_BUILD_DIR)
 
 ENABLE_IPV6:=
 ifeq ($(CONFIG_IPV6),y)
 	ENABLE_IPV6 += --enable-ipv6
 endif
 
-#=======================================================================
-# Notes: adding these so that I don't forget, and can track why stuff
-#        was did as was did
-# - Arguments below were moved to ./files/config.site file, and disabled
-#          ac_cv_have_chflags=no \
-#          ac_cv_have_lchflags=no \
-#          ac_cv_py_format_size_t=no \
-#          ac_cv_have_long_long_format=yes \
-#          ac_cv_buggy_getaddrinfo=no \
-# - --without-ensurepip added, because the build wants to ensure that
-#   it works; that's a good idea, but for now, it requires special 
-#   setup, and we can do that later
-# - --without-pymalloc added, becase in Python 3, modules are suffixed
-#   with m; e.g. so some paths are python3.4m instead of python3.4 
-#   all this is detailed here:
-#     http://legacy.python.org/dev/peps/pep-3149/
-#=======================================================================
+CONFIGURE_ARGS+= \
+	--sysconfdir=/etc \
+	--enable-shared \
+	--without-cxx-main \
+	--with-threads \
+	--with-system-ffi="$(STAGING_DIR)/usr" \
+	--without-pymalloc \
+	--without-ensurepip \
+	$(ENABLE_IPV6) \
+	CONFIG_SITE="$(PKG_BUILD_DIR)/config.site" \
+	OPT="$(TARGET_CFLAGS)"
 
-define Build/Configure
-	-$(MAKE) -C $(PKG_BUILD_DIR) distclean
-	(cd $(PKG_BUILD_DIR); autoreconf --force --install || exit 0)
-	$(CP) ./files/config.site $(PKG_BUILD_DIR)
-	$(call Build/Configure/Default, \
-		--sysconfdir=/etc \
-		--enable-shared \
-		--without-cxx-main \
-		--with-threads \
-		--with-system-ffi="$(STAGING_DIR)/usr" \
-		--without-ensurepip \
-		--without-pymalloc \
-		$(ENABLE_IPV6) \
-		CONFIG_SITE="$(PKG_BUILD_DIR)/config.site" \
-		OPT="$(TARGET_CFLAGS)" \
-	)
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(CP) ./files/config.site $(PKG_BUILD_DIR)/config.site
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(2)/bin $(1)/usr/bin $(1)/usr/include $(1)/usr/lib
 	$(INSTALL_DIR) $(STAGING_DIR)/mk/
+	$(INSTALL_DIR) $(1)/usr/include/ $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON_VERSION)/
 	$(INSTALL_DATA) ./files/python3-package.mk $(STAGING_DIR)/mk/
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/include/python$(PYTHON_VERSION) \
@@ -128,14 +121,9 @@ define Build/InstallDev
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/config-$(PYTHON_VERSION) \
 		$(1)/usr/lib/python$(PYTHON_VERSION)/
-
-	$(CP) \
-		$(STAGING_DIR_HOST)/bin/python$(PYTHON_VERSION)-config \
-		$(2)/bin/
-	$(SED) 's,^#!.*,#!/usr/bin/env python$(PYTHON_VERSION),g' $(2)/bin/python$(PYTHON_VERSION)-config
 endef
 
-define Py3Package/python3/filespec
+define Py3Package/python3-base/filespec
 +|/usr/bin/python$(PYTHON_VERSION)
 +|/usr/lib/python$(PYTHON_VERSION)/encodings
 +|/usr/lib/python$(PYTHON_VERSION)/_collections_abc.py
@@ -153,7 +141,25 @@ define Py3Package/python3/filespec
 +|/usr/lib/python$(PYTHON_VERSION)/stat.py
 endef
 
-define Py3Package/python3/install
+define Py3Package/python3/filespec
++|/usr/lib/python$(PYTHON_VERSION)
+-|/usr/lib/python$(PYTHON_VERSION)/config-$(PYTHON_VERSION)
+-|/usr/lib/python$(PYTHON_VERSION)/distutils/cygwinccompiler.py
+-|/usr/lib/python$(PYTHON_VERSION)/distutils/command/wininst*
+-|/usr/lib/python$(PYTHON_VERSION)/idlelib
+-|/usr/lib/python$(PYTHON_VERSION)/lib2to3
+-|/usr/lib/python$(PYTHON_VERSION)/tkinter
+-|/usr/lib/python$(PYTHON_VERSION)/turtledemo
+-|/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_test*.so
+-|/usr/lib/python$(PYTHON_VERSION)/lib-dynload/readline*.so
+-|/usr/lib/python$(PYTHON_VERSION)/pdb.doc
+-|/usr/lib/python$(PYTHON_VERSION)/test
+-|/usr/lib/python$(PYTHON_VERSION)/webbrowser.py
+-|/usr/lib/python$(PYTHON_VERSION)/*/test
+-|/usr/lib/python$(PYTHON_VERSION)/*/tests
+endef
+
+define Py3Package/python3-base/install
 	# Adding the lib-dynload folder (even just empty) suppresses 2 warnings when starting Python
 	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON_VERSION)/lib-dynload/
 	$(INSTALL_DIR) $(1)/usr/bin
@@ -161,39 +167,30 @@ define Py3Package/python3/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON_VERSION).so* $(1)/usr/lib/
 endef
 
-define Host/Configure
-	-$(MAKE) -C $(HOST_BUILD_DIR) distclean
-	(cd $(HOST_BUILD_DIR); autoreconf --force --install || exit 0)
-	(cd $(HOST_BUILD_DIR); \
-		rm -rf config.cache; \
-		CONFIG_SITE= \
-		OPT="$(HOST_CFLAGS)" \
-		./configure \
-			--without-cxx-main \
-			--without-ensurepip \
-			--without-pymalloc \
-			--with-threads \
-			--prefix=$(STAGING_DIR_HOST); \
-	)
-endef
+HOST_CONFIGURE_ARGS+= \
+	--without-cxx-main \
+	--without-pymalloc \
+	--without-ensurepip \
+	--with-threads \
+	--prefix=$(STAGING_DIR_HOST) \
+	CONFIG_SITE= \
+	OPT="$(HOST_CFLAGS)"
 
 define Host/Compile
-	+$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) \
-		python Parser/pgen
-	+$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) \
-		sharedmods
+	+$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) python Parser/pgen
+	+$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) sharedmods
 endef
 
 define Host/Install
 	$(INSTALL_DIR) $(STAGING_DIR_HOST)/bin/
-	$(MAKE) -C $(HOST_BUILD_DIR) \
-		install
-	$(INSTALL_BIN) $(HOST_BUILD_DIR)/Parser/pgen $(STAGING_DIR_HOST)/bin/
+	$(MAKE) -C $(HOST_BUILD_DIR) install
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/Parser/pgen $(STAGING_DIR_HOST)/bin/pgen3
 endef
-
 
 $(eval $(call HostBuild))
 
+$(eval $(call Py3Package,python3-base))
 $(eval $(call Py3Package,python3))
 
+$(eval $(call BuildPackage,python3-base))
 $(eval $(call BuildPackage,python3))


### PR DESCRIPTION
This patch is a mess [to say the least].
I created a diff of the python and python3 folders and copied and updated the build rules from python to python3.

After some tests I validated that it works.

Signed-off-by: Alexandru Ardelean ardeleanalex@gmail.com
