### PR TITLE
dmx_usb_module: new package added

### DIFF
--- a/libs/dmx_usb_module/Makefile
+++ b/libs/dmx_usb_module/Makefile
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=dmx_usb_module
+PKG_VERSION:=0.1.20130818
+PKG_RELEASE:=0.1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_URL:=git://github.com/lowlander/dmx_usb_module.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=ee99ca7edbd9e093480ad63341ac007394047bde
+PKG_MAINTAINER:=Martijn Zilverschoon <martijn@friedzombie.com>
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/usb-serial-dmx_usb_module
+	SECTION:=kernel
+	CATEGORY:=Kernel modules
+	SUBMENU:=USB Support
+	TITLE:=Support for FTDI RS485 based DMX modules
+	URL:=http://www.erwinrol.com/open-dmx-usb-linux-driver/
+	FILES:=$(PKG_BUILD_DIR)/dmx_usb.$(LINUX_KMOD_SUFFIX)
+	AUTOLOAD:=$(call AutoProbe,dmx_usb)
+	DEPENDS+=kmod-usb-serial
+endef
+
+define KernelPackage/usb-serial-dmx_usb_module/description
+	Open DMX USB is an open USB to DMX dongle hardware design developed by Enttec.
+	The Open in Open DMX USB refers to the fact that everybody is free to use the
+	design and produce its own USB DMX Dongle without paying any licenses.
+endef
+
+DMX_MAKE_OPTS:= -C $(PKG_BUILD_DIR) \
+	PATH="$(TARGET_PATH)" \
+	ARCH="$(LINUX_KARCH)" \
+	CROSS_COMPILE="$(TARGET_CROSS)" \
+	TARGET="$(HAL_TARGET)" \
+	TOOLPREFIX="$(KERNEL_CROSS)" \
+	TOOLPATH="$(KERNEL_CROSS)" \
+	KERNELPATH="$(LINUX_DIR)" \
+	LDOPTS=" "
+
+define Build/Compile
+  $(MAKE) $(DMX_MAKE_OPTS) M=$(PKG_BUILD_DIR)
+endef
+
+$(eval $(call KernelPackage,usb-serial-dmx_usb_module))

--- a/libs/dmx_usb_module/patches/001-dmx_usb_Makefile.patch
+++ b/libs/dmx_usb_module/patches/001-dmx_usb_Makefile.patch
@@ -1,0 +1,13 @@
+--- a/Makefile
++++ b/Makefile
+@@ -12,8 +12,7 @@ KDIR	:= /lib/modules/$(shell uname -r)/build
+ PWD	:= $(shell pwd)
+ 
+ default:
+-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
+-	gcc -O2 -pipe -Wall dmx_usb_test.c -o dmx_usb_test
++	$(MAKE) -C $(KERNELPATH) SUBDIRS=$(PWD) modules
+ 
+ endif
+ 
+


### PR DESCRIPTION
dmx_usb_module is a kernel module that is needed to controll FTDI485 based DMX modules.

Signed-off-by: Martijn Zilverschoon martijn@friedzombie.com
