### PR TITLE
libxml2: Fix zlib detection the right way

### DIFF
--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -42,7 +42,6 @@ define Package/libxml2/description
 endef
 
 TARGET_CFLAGS += $(FPIC)
-TARGET_LDFLAGS += -lz
 
 CONFIGURE_ARGS += \
 	--enable-shared \
@@ -73,7 +72,7 @@ CONFIGURE_ARGS += \
 	--with-xinclude \
 	--with-xpath \
 	--with-xptr \
-	--with-zlib \
+	--with-zlib=$(STAGING_DIR)/usr \
 	--without-lzma
 
 HOST_CONFIGURE_ARGS += \


### PR DESCRIPTION
The previous fix (#557) forced -lz into LDFLAGS instead of fixing the
real issue where configure was failing to detect zlib in the first
place. This was happening because it was looking in /lib, resulting in
conflicts with the host libraries.

Signed-off-by: James Le Cuirot james.le-cuirot@yakara.com
