### PR TITLE
glib2: Upgrade to 2.42.1

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
-PKG_VERSION:=2.41.1
-PKG_RELEASE:=2
+PKG_VERSION:=2.42.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_BUILD_DIR:=$(BUILD_DIR)/glib-$(PKG_VERSION)
-PKG_SOURCE_URL:=@GNOME/glib/2.41
-PKG_MD5SUM:=bae557c87323e8df7ac30fb484b5cba9
+PKG_SOURCE_URL:=@GNOME/glib/2.42
+PKG_MD5SUM:=89c4119e50e767d3532158605ee9121a
 
 PKG_BUILD_DEPENDS:=glib2/host libpthread zlib libintl libffi
 HOST_BUILD_DEPENDS:=libintl/host libiconv/host libffi/host


### PR DESCRIPTION
Signed-off-by: Ted Hess thess@kitschensync.net
