### PR TITLE
coova-chilli: Adding Menu option for enabling chilli proxy.

### DIFF
--- a/net/coova-chilli/Config.in
+++ b/net/coova-chilli/Config.in
@@ -3,6 +3,10 @@
 menu "Configuration"
 	depends on PACKAGE_coova-chilli
 
+config COOVACHILLI_PROXY
+        bool "Enable support for chilli proxy. Required for AAA Proxy through http"
+        default n
+
 config COOVACHILLI_REDIR
 	bool "Enable support for redir server. Required for uamregex"
 	default n

--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -72,6 +72,7 @@ endef
 
 define Build/Configure
 	$(call Build/Configure/Default, \
+	$(if $(CONFIG_COOVACHILLI_PROXY),--enable,--disable)-chilliproxy \
 	$(if $(CONFIG_COOVACHILLI_REDIR),--enable,--disable)-chilliredir \
 	$(if $(CONFIG_COOVACHILLI_DNSLOG),--enable,--disable)-dnslog \
 	$(if $(CONFIG_COOVACHILLI_MINIPORTAL),--enable,--disable)-miniportal \


### PR DESCRIPTION
Chilli proxy is used when one does not want to setup AAA server
but want to handle AAA through http.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

Signed-off-by: Ramanathan Sivagurunathan ramzthecoder@gmail.com
