### PR TITLE
postfix: broken mynetworks parameter default value

### DIFF
--- a/mail/postfix/files/postfix.init
+++ b/mail/postfix/files/postfix.init
@@ -16,7 +16,7 @@ upgrade() {
 
 		echo "myhostname = $(uci get system.@system[0].hostname)" >> "$config_directory"/main.cf.default
 		echo "mydomain = $(uci get system.@system[0].hostname|sed -e "s/[^\.]*\.\(.*\)/\1/")" >> "$config_directory"/main.cf.default
-		for net in $(uci show network|grep ipaddr|sed -e "s/network\.\([^\.]*\).*/\1/"); do eval "$(ipcalc.sh $(uci get network.$net.ipaddr) $(uci get network.$net.netmask))"; echo "$IP/$PREFIX"; done | xargs echo "mynetworks =" >> "$config_directory"/main.cf.default
+		ifconfig | grep "inet addr" | sed -e "s/.*inet addr:\([0-9.]*\).*Mask:/\1 /" | while read IP NETMASK; do eval "$(ipcalc.sh $IP $NETMASK)"; echo "$NETWORK/$PREFIX"; done | xargs echo "mynetworks =" >> "$config_directory"/main.cf.default
 
 		grep -qc "^sendmail_path" "$config_directory"/main.cf >/dev/null || postconf -e "$(grep "^sendmail_path =" "$config_directory"/main.cf.default)"
 		grep -qc "^newaliases_path" "$config_directory"/main.cf >/dev/null || postconf -e "$(grep "^newaliases_path =" "$config_directory"/main.cf.default)"


### PR DESCRIPTION
Fixed an issue with the default parameter value.
1. By default, the init script set ip address instead of network address in the parameter value (i.e. 192.168.1.1/24 instead of 192.168.1.0/24)
2. Dynamic address were not caught by the init script

As a result, if the mynetworks parameter was left default, Postfix would have rejected the mails with the following message in the logs:

Sat Dec  6 23:26:45 2014 mail.info postfix/smtpd[22806]: NOQUEUE: reject: RCPT from unknown[104.167.106.30]: 451 4.3.0 ds_gitcommit@shulyaka.org.ru: Temporary lookup failure; from=delivery@mx.sailthru.com to=ds_gitcommit@shulyaka.org.ru proto=ESMTP helo=<mx-indiegogo-b.sailthru.com>
Sat Dec  6 23:26:45 2014 mail.warn postfix/smtpd[22806]: warning: non-null host address bits in "127.0.0.1/8", perhaps you should use "127.0.0.0/8" instead

This commit fixes that behavior for the new installations.

Signed-off-by: Denis Shulyaka Shulyaka@gmail.com
