### PR TITLE
fdm: fix missing quote mark in Makefile

### DIFF
--- a/mail/fdm/Makefile
+++ b/mail/fdm/Makefile
@@ -48,7 +48,7 @@ define Build/Prepare
 endef
 
 define Package/fdm/config
-	source "$(SOURCE)/Config.in
+	source "$(SOURCE)/Config.in"
 endef
 
 define Package/fdm/conffiles


### PR DESCRIPTION
source "$(SOURCE)/Config.in
change to
source "$(SOURCE)/Config.in"

BTW,this will cause a "tmp/.config-package.in:22096:_warning: multi-line strings not supported" issue
