### PR TITLE
fdm: add missing quote mark in Makefile

### DIFF
--- a/mail/fdm/Makefile
+++ b/mail/fdm/Makefile
@@ -48,7 +48,7 @@ define Build/Prepare
 endef
 
 define Package/fdm/config
-	source "$(SOURCE)/Config.in
+	source "$(SOURCE)/Config.in"
 endef
 
 define Package/fdm/conffiles


### PR DESCRIPTION
This commit will fix compile warning as below

tmp/.config-package.in:22096:warning: multi-line strings not supported

Signed-off-by: Shuoyao Wang wong.syrone@gmail.com
