### PR TITLE
btrfs-progs: Fix init script

### DIFF
--- a/utils/btrfs-progs/files/btrfs-scan.init
+++ b/utils/btrfs-progs/files/btrfs-scan.init
@@ -4,6 +4,6 @@
 START=19
 
 start() {
-	grep -q btrfs /proc/modules && /usr/bin/btrfsctl -a
+	grep -q btrfs /proc/modules && /usr/bin/btrfs device scan
 }
 


### PR DESCRIPTION
The init script calls the old btrfsctl util, which is not included in
btrfs-progs anymore. Update the init script to call "btrfs device scan"
which assembles multi device btrfs filesystems.

Signed-off-by: Stefan Hellermann stefan@the2masters.de
