### PR TITLE
prosody: update to 0.9.7

### DIFF
--- a/net/prosody/Makefile
+++ b/net/prosody/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prosody
-PKG_VERSION:=0.9.4
-PKG_RELEASE:=2
+PKG_VERSION:=0.9.7
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://prosody.im/downloads/source
-PKG_MD5SUM:=94f9a613c834c276352ac5b142fb72e0
+PKG_MD5SUM:=47de7f593279e327792df78cfa93e8a7
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=MIT/X11
 


### PR DESCRIPTION
update prosody to 0.9.7 to get the latest fixes. Changelogs:
http://blog.prosody.im/prosody-0-9-5-released/
http://blog.prosody.im/prosody-0-9-6-released/
http://blog.prosody.im/prosody-0-9-7-released/

Tested for a few days with a dozen clients

Signed-off-by: Stefan Hellermann stefan@the2masters.de
