### PR TITLE
luasec: update to 0.5 to fix memory leak hit by prosody

### DIFF
--- a/lang/luasec/Makefile
+++ b/lang/luasec/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2010 OpenWrt.org
+# Copyright (C) 2009-2014 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luasec
-PKG_VERSION:=0.4
+PKG_VERSION:=0.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://files.luaforge.net/releases/luasec/LuaSec/LuaSec0.4/
-PKG_MD5SUM:=712158d60207bdbb6215fc7e07d8db24
+PKG_SOURCE_URL:=https://github.com/brunoos/luasec/archive/
+PKG_MD5SUM:=0518f4524f399f33424c6f450e1d06db
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION)
+
+MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_INSTALL:=1
 
@@ -24,8 +29,7 @@ define Package/luasec
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=LuaSec
-  URL:=http://luasec.luaforge.net/
-  MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+  URL:=https://github.com/brunoos/luasec
   DEPENDS:=+lua +libopenssl +luasocket
 endef
 
@@ -36,16 +40,15 @@ endef
 define Build/Configure
 endef
 
-MAKE_PATH = ./src
-
 MAKE_FLAGS += \
-	INCDIR="$(TARGET_CPPFLAGS)" \
-	LIBDIR="$(TARGET_LDFLAGS)" \
-	CC="$(TARGET_CC) $(TARGET_CFLAGS) -std=gnu99" \
-	LD="$(TARGET_CROSS)ld -shared" \
-	LUACPATH="$(PKG_INSTALL_DIR)/usr/lib/lua" \
-	LUAPATH="$(PKG_INSTALL_DIR)/usr/lib/lua" \
-	linux \
+	INCDIR="$(TARGET_CPPFLAGS) -I." \
+	LIBDIR="$(TARGET_LDFLAGS) -L./luasocket" \
+	LUACPATH="/usr/lib/lua" \
+	LUAPATH="/usr/lib/lua"
+
+define Build/Compile
+$(call Build/Compile/Default,linux)
+endef
 
 define Package/luasec/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua

--- a/lang/luasec/patches/100-luasocket-Makefile.patch
+++ b/lang/luasec/patches/100-luasocket-Makefile.patch
@@ -1,0 +1,20 @@
+--- luasec-luasec-0.5-old/src/luasocket/Makefile	2014-01-29 21:43:33.000000000 +0100
++++ luasec-luasec-0.5/src/luasocket/Makefile	2014-11-30 13:07:44.850051000 +0100
+@@ -6,7 +6,7 @@
+ 
+ CC	?= cc
+ CFLAGS	+= $(MYCFLAGS) -DLUASOCKET_DEBUG
+-AR	:= ar rcu
++AR	?= ar
+ RANLIB	?= ranlib
+ 
+ .PHONY: all clean
+@@ -14,7 +14,7 @@
+ all: libluasocket.a
+ 
+ libluasocket.a: $(OBJS)
+-	$(AR) $@ $(OBJS)
++	$(AR) rcu $@ $(OBJS)
+ 	$(RANLIB) $@
+ 
+ clean:


### PR DESCRIPTION
Noted in luasec 0.4.1 Changelog:
Activate SSL_MODE_RELEASE_BUFFERS by default if it is available (thanks Prosody project)

Update to latest 0.5 to fix a few other leaks.
luasec moved to github, so update URL and license info.
Move package maintainer to correct place in Makefile, hope he is okay with it.

Signed-off-by: Stefan Hellermann <stefan@the2masters.de>