### PR TITLE
upmpdcli: Add upmpdcli-0.9.0 to the packages repository

### DIFF
--- a/multimedia/upmpdcli/Makefile
+++ b/multimedia/upmpdcli/Makefile
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=upmpdcli
+PKG_VERSION:=0.9.0
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.lesbonscomptes.com/upmpdcli/downloads
+PKG_MD5SUM:=0e7b86037f19ea3a08067409af6f6902
+PKG_MAINTAINER:=Petko Bordjukov <bordjukov@gmail.com>
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/upmpdcli
+  SECTION:=multimedia
+  CATEGORY:=Multimedia
+  URL:=http://www.lesbonscomptes.com/upmpdcli
+  DEPENDS+= +libupnpp +libmpdclient
+  TITLE:=A UPnP front-end to MPD, the Music Player Daemon
+  USERID:=upmpdcli=89:upmpdcli=89
+endef
+
+define Package/upmpdcli/description
+upmpdcli implements an UPnP Media Renderer, using MPD to perform the real work.
+endef
+
+define Package/upmpdcli/install
+       $(INSTALL_DIR) $(1)/etc
+       $(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/upmpdcli.conf $(1)/etc/
+       $(INSTALL_DIR) $(1)/usr/bin
+       $(CP) $(PKG_INSTALL_DIR)/usr/bin/upmpdcli $(1)/usr/bin/
+       $(INSTALL_DIR) $(1)/usr/share
+       $(CP) $(PKG_INSTALL_DIR)/usr/share/upmpdcli $(1)/usr/share/
+       $(INSTALL_DIR) $(1)/etc/init.d
+       $(INSTALL_BIN) ./files/upmpdcli.init $(1)/etc/init.d/upmpdcli
+endef
+
+$(eval $(call BuildPackage,upmpdcli))

--- a/multimedia/upmpdcli/files/upmpdcli.init
+++ b/multimedia/upmpdcli/files/upmpdcli.init
@@ -1,0 +1,18 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2014 OpenWrt.org
+
+START=95
+
+create_user() {
+       group_exists upmpdcli || group_add upmpdcli 89
+       user_exists upmpdcli || user_add upmpdcli 89
+}
+
+start() {
+       create_user
+       service_start /usr/bin/upmpdcli -D
+}
+
+stop() {
+       service_stop /usr/bin/upmpdcli
+}


### PR DESCRIPTION
upmpdcli is a DLNA renderer that forwards the commands it receives to an MPD
server.

Depends on libupnpp (https://github.com/openwrt/packages/pull/624)
More info here: http://www.lesbonscomptes.com/upmpdcli/
