### PR TITLE
elfutils: import from old packages

### DIFF
--- a/libs/elfutils/Makefile
+++ b/libs/elfutils/Makefile
@@ -1,0 +1,79 @@
+#
+# Copyright (C) 2010-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=elfutils
+PKG_VERSION:=0.155
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=http://fedorahosted.org/releases/e/l/$(PKG_NAME)/$(PKG_VERSION)
+PKG_MD5SUM:=163a5712b86f6bdfebdf233cc6e2192d
+
+PKG_INSTALL:=1
+PKG_USE_MIPS16:=0
+PKG_LICENSE:=GPLv3
+PKG_LICENSE_FILES:=COPYING COPYING-GPLV2 COPYING-LGPLV3
+PKG_MAINTAINER:=Florian Fainelli <florian@openwrt.org>
+
+PKG_BUILD_DEPENDS:=USE_UCLIBC:argp-standalone
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/elfutils/Default
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=$(INTL_DEPENDS)
+  TITLE:=ELF manipulation libraries
+  URL:=https://fedorahosted.org/elfutils/
+endef
+
+define Package/libdw
+  $(call Package/elfutils/Default)
+  DEPENDS:=libelf1 +zlib +libbz2
+  TITLE+= (libdw)
+endef
+
+define Package/libelf1
+  $(call Package/elfutils/Default)
+  TITLE+= (libelf)
+endef
+
+ifeq ($(CONFIG_BUILD_NLS),y)
+TARGET_LDFLAGS += "-lintl"
+endif
+
+ifdef CONFIG_USE_UCLIBC
+CONFIGURE_VARS += \
+	LIBS="-largp"
+endif
+
+CONFIGURE_ARGS += \
+	--disable-werror \
+	--without-lzma
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/libdw/libdw.{a,so*} $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/libelf/libelf.{a,so*} $(1)/usr/lib/
+endef
+
+define Package/libdw/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/libdw/libdw.so* $(1)/usr/lib/
+endef
+
+define Package/libelf1/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/libelf/libelf.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libdw))
+$(eval $(call BuildPackage,libelf1))

--- a/libs/elfutils/patches/001-elfutils-portability.patch
+++ b/libs/elfutils/patches/001-elfutils-portability.patch
@@ -1,0 +1,1684 @@
+--- elfutils/backends/ChangeLog
++++ elfutils/backends/ChangeLog
+@@ -135,6 +135,10 @@
+ 	* ppc_attrs.c (ppc_check_object_attribute): Handle tag
+ 	GNU_Power_ABI_Struct_Return.
+ 
++2009-01-23  Roland McGrath  <roland@redhat.com>
++
++	* Makefile.am (libebl_%.so): Use $(LD_AS_NEEDED).
++
+ 2008-10-04  Ulrich Drepper  <drepper@redhat.com>
+ 
+ 	* i386_reloc.def: Fix entries for TLS_GOTDESC, TLS_DESC_CALL, and
+@@ -462,6 +466,11 @@
+ 	* sparc_init.c: Likewise.
+ 	* x86_64_init.c: Likewise.
+ 
++2005-11-22  Roland McGrath  <roland@redhat.com>
++
++	* Makefile.am (LD_AS_NEEDED): New variable, substituted by configure.
++	(libebl_%.so rule): Use it in place of -Wl,--as-needed.
++
+ 2005-11-19  Roland McGrath  <roland@redhat.com>
+ 
+ 	* ppc64_reloc.def: REL30 -> ADDR30.
+@@ -484,6 +493,9 @@
+ 	* Makefile.am (uninstall): Don't try to remove $(pkgincludedir).
+ 	(CLEANFILES): Add libebl_$(m).so.
+ 
++	* Makefile.am (WEXTRA): New variable, substituted by configure.
++	(AM_CFLAGS): Use it in place of -Wextra.
++
+ 	* ppc_reloc.def: Update bits per Alan Modra <amodra@bigpond.net.au>.
+ 	* ppc64_reloc.def: Likewise.
+ 
+--- elfutils/backends/Makefile.am
++++ elfutils/backends/Makefile.am
+@@ -111,7 +111,7 @@ libebl_%.so libebl_%.map: libebl_%_pic.a
+ 	$(LINK) -shared -o $(@:.map=.so) \
+ 		-Wl,--whole-archive $< $(cpu_$*) -Wl,--no-whole-archive \
+ 		-Wl,--version-script,$(@:.so=.map) \
+-		-Wl,-z,defs -Wl,--as-needed $(libelf) $(libdw) $(libmudflap)
++		-Wl,-z,defs $(LD_AS_NEEDED) $(libelf) $(libdw) $(libmudflap)
+ 	$(textrel_check)
+ 
+ libebl_i386.so: $(cpu_i386)
+--- elfutils/backends/Makefile.in
++++ elfutils/backends/Makefile.in
+@@ -38,7 +38,8 @@ build_triplet = @build@
+ host_triplet = @host@
+ DIST_COMMON = $(noinst_HEADERS) $(srcdir)/Makefile.am \
+ 	$(srcdir)/Makefile.in $(top_srcdir)/config/eu.am ChangeLog
+-@MUDFLAP_TRUE@am__append_1 = -fmudflap
++@BUILD_WERROR_TRUE@am__append_1 = $(if $($(*F)_no_Werror),,-Werror)
++@MUDFLAP_TRUE@am__append_2 = -fmudflap
+ subdir = backends
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/nls.m4 $(top_srcdir)/m4/po.m4 \
+@@ -172,6 +173,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@
+ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
+ LDFLAGS = @LDFLAGS@
++LD_AS_NEEDED = @LD_AS_NEEDED@
+ LEX = @LEX@
+ LEXLIB = @LEXLIB@
+ LEX_OUTPUT_ROOT = @LEX_OUTPUT_ROOT@
+@@ -201,6 +203,7 @@ SHELL = @SHELL@
+ STRIP = @STRIP@
+ USE_NLS = @USE_NLS@
+ VERSION = @VERSION@
++WEXTRA = @WEXTRA@
+ XGETTEXT = @XGETTEXT@
+ XGETTEXT_015 = @XGETTEXT_015@
+ XGETTEXT_EXTRA_OPTIONS = @XGETTEXT_EXTRA_OPTIONS@
+@@ -263,10 +266,9 @@ INCLUDES = -I. -I$(srcdir) -I$(top_srcdi
+ 	-I$(top_srcdir)/libebl -I$(top_srcdir)/libasm \
+ 	-I$(top_srcdir)/libelf -I$(top_srcdir)/libdw
+ AM_CFLAGS = -std=gnu99 -Wall -Wshadow $(if \
+-	$($(*F)_no_Werror),,-Werror) $(if \
+-	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
++	$($(*F)_no_Wunused),,-Wunused $(WEXTRA)) $(if \
+ 	$($(*F)_no_Wformat),-Wno-format,-Wformat=2) $($(*F)_CFLAGS) \
+-	$(am__append_1)
++	$(am__append_1) $(am__append_2)
+ @MUDFLAP_FALSE@libmudflap = 
+ @MUDFLAP_TRUE@libmudflap = -lmudflap
+ COMPILE.os = $(filter-out -fprofile-arcs -ftest-coverage $(no_mudflap.os),\
+@@ -725,7 +727,7 @@ libebl_%.so libebl_%.map: libebl_%_pic.a
+ 	$(LINK) -shared -o $(@:.map=.so) \
+ 		-Wl,--whole-archive $< $(cpu_$*) -Wl,--no-whole-archive \
+ 		-Wl,--version-script,$(@:.so=.map) \
+-		-Wl,-z,defs -Wl,--as-needed $(libelf) $(libdw) $(libmudflap)
++		-Wl,-z,defs $(LD_AS_NEEDED) $(libelf) $(libdw) $(libmudflap)
+ 	$(textrel_check)
+ 
+ libebl_i386.so: $(cpu_i386)
+--- elfutils/ChangeLog
++++ elfutils/ChangeLog
+@@ -16,6 +16,8 @@
+ 
+ 2012-01-24  Mark Wielaard  <mjw@redhat.com>
+ 
++	* configure.ac: Wrap AC_COMPILE_IFELSE sources in AC_LANG_SOURCE.
++
+ 	* COPYING: Fix address. Updated version from gnulib.
+ 
+ 2012-01-23  Mark Wielaard  <mjw@redhat.com>
+@@ -34,6 +36,9 @@
+ 
+ 2011-10-08  Mike Frysinger  <vapier@gentoo.org>
+ 
++	* configure.ac (--disable-werror): Handle it, controlling BUILD_WERROR
++	automake option.
++
+ 	* configure.ac: Fix use of AC_ARG_ENABLE to handle $enableval correctly.
+ 
+ 2011-10-02  Ulrich Drepper  <drepper@gmail.com>
+@@ -55,6 +60,10 @@
+ 
+ 	* configure.ac (LOCALEDIR, DATADIRNAME): Removed.
+ 
++2009-11-22  Roland McGrath  <roland@redhat.com>
++
++	* configure.ac: Use sed and expr instead of modern bash extensions.
++
+ 2009-09-21  Ulrich Drepper  <drepper@redhat.com>
+ 
+ 	* configure.ac: Update for more modern autoconf.
+@@ -63,6 +72,10 @@
+ 
+ 	* configure.ac (zip_LIBS): Check for liblzma too.
+ 
++2009-08-17  Roland McGrath  <roland@redhat.com>
++
++	* configure.ac: Check for -fgnu89-inline; add it to WEXTRA if it works.
++
+ 2009-04-19  Roland McGrath  <roland@redhat.com>
+ 
+ 	* configure.ac (eu_version): Round down here, not in version.h macros.
+@@ -74,6 +87,8 @@
+ 
+ 2009-01-23  Roland McGrath  <roland@redhat.com>
+ 
++	* configure.ac: Check for __builtin_popcount.
++
+ 	* configure.ac (zlib check): Check for gzdirect, need zlib >= 1.2.2.3.
+ 
+ 	* configure.ac (__thread check): Use AC_LINK_IFELSE, in case of
+@@ -154,6 +169,10 @@
+ 	* configure.ac: Add dummy automake conditional to get dependencies
+ 	for non-generic linker right.  See src/Makefile.am.
+ 
++2005-11-22  Roland McGrath  <roland@redhat.com>
++
++	* configure.ac: Check for --as-needed linker option.
++
+ 2005-11-18  Roland McGrath  <roland@redhat.com>
+ 
+ 	* Makefile.am (DISTCHECK_CONFIGURE_FLAGS): New variable.
+@@ -201,6 +220,17 @@
+ 	* Makefile.am (all_SUBDIRS): Add libdwfl.
+ 	* configure.ac: Write libdwfl/Makefile.
+ 
++2005-05-31  Roland McGrath  <roland@redhat.com>
++
++	* configure.ac (WEXTRA): Check for -Wextra and set this substitution.
++
++	* configure.ac: Check for struct stat st_?tim members.
++	* src/strip.c (process_file): Use st_?time if st_?tim are not there.
++
++	* configure.ac: Check for futimes function.
++	* src/strip.c (handle_elf) [! HAVE_FUTIMES]: Use utimes instead.
++	(handle_ar) [! HAVE_FUTIMES]: Likewise.
++
+ 2005-05-19  Roland McGrath  <roland@redhat.com>
+ 
+ 	* configure.ac [AH_BOTTOM] (INTDECL, _INTDECL): New macros.
+--- elfutils/config/ChangeLog
++++ elfutils/config/ChangeLog
+@@ -19,6 +19,10 @@
+ 
+ 	* known-dwarf.awk: Use gawk.
+ 
++2011-10-08  Mike Frysinger  <vapier@gentoo.org>
++
++	* eu.am [BUILD_WERROR]: Conditionalize -Werror use on this.
++
+ 2010-07-02  Ulrich Drepper  <drepper@redhat.com>
+ 
+ 	* elfutils.spec.in: Add more BuildRequires.
+--- elfutils/config/eu.am
++++ elfutils/config/eu.am
+@@ -1,6 +1,6 @@
+ ## Common automake fragments for elfutils subdirectory makefiles.
+ ##
+-## Copyright (C) 2010 Red Hat, Inc.
++## Copyright (C) 2010-2011 Red Hat, Inc.
+ ##
+ ## This file is part of elfutils.
+ ##
+@@ -29,14 +29,20 @@
+ ## not, see <http://www.gnu.org/licenses/>.
+ ##
+ 
++WEXTRA = @WEXTRA@
++LD_AS_NEEDED = @LD_AS_NEEDED@
++
+ DEFS = -D_GNU_SOURCE -DHAVE_CONFIG_H -DLOCALEDIR='"${localedir}"'
+ INCLUDES = -I. -I$(srcdir) -I$(top_srcdir)/lib -I..
+ AM_CFLAGS = -std=gnu99 -Wall -Wshadow \
+-	    $(if $($(*F)_no_Werror),,-Werror) \
+-	    $(if $($(*F)_no_Wunused),,-Wunused -Wextra) \
++	    $(if $($(*F)_no_Wunused),,-Wunused $(WEXTRA)) \
+ 	    $(if $($(*F)_no_Wformat),-Wno-format,-Wformat=2) \
+ 	    $($(*F)_CFLAGS)
+ 
++if BUILD_WERROR
++AM_CFLAGS += $(if $($(*F)_no_Werror),,-Werror)
++endif
++
+ if MUDFLAP
+ AM_CFLAGS += -fmudflap
+ libmudflap = -lmudflap
+--- elfutils/config/Makefile.in
++++ elfutils/config/Makefile.in
+@@ -76,6 +76,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@
+ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
+ LDFLAGS = @LDFLAGS@
++LD_AS_NEEDED = @LD_AS_NEEDED@
+ LEX = @LEX@
+ LEXLIB = @LEXLIB@
+ LEX_OUTPUT_ROOT = @LEX_OUTPUT_ROOT@
+@@ -105,6 +106,7 @@ SHELL = @SHELL@
+ STRIP = @STRIP@
+ USE_NLS = @USE_NLS@
+ VERSION = @VERSION@
++WEXTRA = @WEXTRA@
+ XGETTEXT = @XGETTEXT@
+ XGETTEXT_015 = @XGETTEXT_015@
+ XGETTEXT_EXTRA_OPTIONS = @XGETTEXT_EXTRA_OPTIONS@
+--- elfutils/config.h.in
++++ elfutils/config.h.in
+@@ -6,6 +6,9 @@
+ /* Defined if libdw should support GNU ref_alt FORM, dwz multi files. */
+ #undef ENABLE_DWZ
+ 
++/* Have __builtin_popcount. */
++#undef HAVE_BUILTIN_POPCOUNT
++
+ /* $libdir subdirectory containing libebl modules. */
+ #undef LIBEBL_SUBDIR
+ 
+@@ -64,4 +67,7 @@
+ /* Define for large files, on AIX-style hosts. */
+ #undef _LARGE_FILES
+ 
++/* Stubbed out if missing compiler support. */
++#undef __thread
++
+ #include <eu-config.h>
+--- elfutils/configure
++++ elfutils/configure
+@@ -598,6 +598,8 @@ ZLIB_TRUE
+ LIBEBL_SUBDIR
+ TESTS_RPATH_FALSE
+ TESTS_RPATH_TRUE
++BUILD_WERROR_FALSE
++BUILD_WERROR_TRUE
+ BUILD_STATIC_FALSE
+ BUILD_STATIC_TRUE
+ GCOV_FALSE
+@@ -612,6 +614,8 @@ NEVER_TRUE
+ base_cpu
+ NATIVE_LD_FALSE
+ NATIVE_LD_TRUE
++LD_AS_NEEDED
++WEXTRA
+ LEXLIB
+ LEX_OUTPUT_ROOT
+ LEX
+@@ -726,6 +730,7 @@ enable_mudflap
+ enable_debugpred
+ enable_gprof
+ enable_gcov
++enable_werror
+ enable_tests_rpath
+ enable_libebl_subdir
+ with_zlib
+@@ -1379,6 +1384,7 @@ Optional Features:
+                           prediction
+   --enable-gprof          build binaries with gprof support
+   --enable-gcov           build binaries with gcov support
++  --disable-werror        do not build with -Werror
+   --enable-tests-rpath    build $ORIGIN-using rpath into tests
+   --enable-libebl-subdir=DIR
+                           install libebl_CPU modules in $(libdir)/DIR
+@@ -3920,6 +3926,130 @@ if test "x$ac_cv_c99" != xyes; then :
+   as_fn_error $? "gcc with C99 support required" "$LINENO" 5
+ fi
+ 
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for -Wextra option to $CC" >&5
++$as_echo_n "checking for -Wextra option to $CC... " >&6; }
++if ${ac_cv_cc_wextra+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  old_CFLAGS="$CFLAGS"
++CFLAGS="$CFLAGS -Wextra"
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++void foo (void) { }
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++  ac_cv_cc_wextra=yes
++else
++  ac_cv_cc_wextra=no
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++CFLAGS="$old_CFLAGS"
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cc_wextra" >&5
++$as_echo "$ac_cv_cc_wextra" >&6; }
++
++if test "x$ac_cv_cc_wextra" = xyes; then :
++  WEXTRA=-Wextra
++else
++  WEXTRA=-W
++fi
++
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for -fgnu89-inline option to $CC" >&5
++$as_echo_n "checking for -fgnu89-inline option to $CC... " >&6; }
++if ${ac_cv_cc_gnu89_inline+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  old_CFLAGS="$CFLAGS"
++CFLAGS="$CFLAGS -fgnu89-inline -Werror"
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++void foo (void)
++{
++  inline void bar (void) {}
++  bar ();
++}
++extern inline void baz (void) {}
++
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++  ac_cv_cc_gnu89_inline=yes
++else
++  ac_cv_cc_gnu89_inline=no
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++CFLAGS="$old_CFLAGS"
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_cc_gnu89_inline" >&5
++$as_echo "$ac_cv_cc_gnu89_inline" >&6; }
++if test "x$ac_cv_cc_gnu89_inline" = xyes; then :
++  WEXTRA="${WEXTRA:+$WEXTRA }-fgnu89-inline"
++fi
++
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for --as-needed linker option" >&5
++$as_echo_n "checking for --as-needed linker option... " >&6; }
++if ${ac_cv_as_needed+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  cat > conftest.c <<EOF
++int main (void) { return 0; }
++EOF
++if { ac_try='${CC-cc} $CFLAGS $CPPFLAGS $LDFLAGS
++			    -fPIC -shared -o conftest.so conftest.c
++			    -Wl,--as-needed 1>&5'
++  { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_try\""; } >&5
++  (eval $ac_try) 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; }
++then
++  ac_cv_as_needed=yes
++else
++  ac_cv_as_needed=no
++fi
++rm -f conftest*
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_as_needed" >&5
++$as_echo "$ac_cv_as_needed" >&6; }
++if test "x$ac_cv_as_needed" = xyes; then :
++  LD_AS_NEEDED=-Wl,--as-needed
++else
++  LD_AS_NEEDED=
++fi
++
++
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for __builtin_popcount" >&5
++$as_echo_n "checking for __builtin_popcount... " >&6; }
++if ${ac_cv_popcount+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++int
++main ()
++{
++exit (__builtin_popcount (127));
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"; then :
++  ac_cv_popcount=yes
++else
++  ac_cv_popcount=no
++fi
++rm -f core conftest.err conftest.$ac_objext \
++    conftest$ac_exeext conftest.$ac_ext
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_popcount" >&5
++$as_echo "$ac_cv_popcount" >&6; }
++if test "x$ac_cv_popcount" = xyes; then :
++
++$as_echo "#define HAVE_BUILTIN_POPCOUNT 1" >>confdefs.h
++
++fi
++
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for __thread support" >&5
+ $as_echo_n "checking for __thread support... " >&6; }
+ if ${ac_cv_tls+:} false; then :
+@@ -3956,7 +4086,13 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_tls" >&5
+ $as_echo "$ac_cv_tls" >&6; }
+ if test "x$ac_cv_tls" != xyes; then :
+-  as_fn_error $? "__thread support required" "$LINENO" 5
++  if test "$use_locks" = yes; then :
++  as_fn_error $? "--enable-thread-safety requires __thread support" "$LINENO" 5
++else
++
++$as_echo "#define __thread /* empty: no multi-thread support */" >>confdefs.h
++
++fi
+ fi
+ 
+ # Check whether --enable-largefile was given.
+@@ -4305,6 +4441,22 @@ else
+ fi
+ 
+ 
++# Check whether --enable-werror was given.
++if test "${enable_werror+set}" = set; then :
++  enableval=$enable_werror; enable_werror=$enableval
++else
++  enable_werror=yes
++fi
++
++ if test "$enable_werror" = yes; then
++  BUILD_WERROR_TRUE=
++  BUILD_WERROR_FALSE='#'
++else
++  BUILD_WERROR_TRUE='#'
++  BUILD_WERROR_FALSE=
++fi
++
++
+ # Check whether --enable-tests-rpath was given.
+ if test "${enable_tests_rpath+set}" = set; then :
+   enableval=$enable_tests_rpath; tests_use_rpath=$enableval
+@@ -5025,7 +5177,7 @@ case "$eu_version" in
+ esac
+ 
+ # Round up to the next release API (x.y) version.
+-eu_version=$(( (eu_version + 999) / 1000 ))
++eu_version=`expr \( $eu_version + 999 \) / 1000`
+ 
+ cat >confcache <<\_ACEOF
+ # This file is a shell script that caches the results of configure
+@@ -5188,6 +5340,10 @@ if test -z "${BUILD_STATIC_TRUE}" && tes
+   as_fn_error $? "conditional \"BUILD_STATIC\" was never defined.
+ Usually this means the macro was only invoked conditionally." "$LINENO" 5
+ fi
++if test -z "${BUILD_WERROR_TRUE}" && test -z "${BUILD_WERROR_FALSE}"; then
++  as_fn_error $? "conditional \"BUILD_WERROR\" was never defined.
++Usually this means the macro was only invoked conditionally." "$LINENO" 5
++fi
+ if test -z "${TESTS_RPATH_TRUE}" && test -z "${TESTS_RPATH_FALSE}"; then
+   as_fn_error $? "conditional \"TESTS_RPATH\" was never defined.
+ Usually this means the macro was only invoked conditionally." "$LINENO" 5
+--- elfutils/configure.ac
++++ elfutils/configure.ac
+@@ -90,6 +90,54 @@ CFLAGS="$old_CFLAGS"])
+ AS_IF([test "x$ac_cv_c99" != xyes],
+       AC_MSG_ERROR([gcc with C99 support required]))
+ 
++AC_CACHE_CHECK([for -Wextra option to $CC], ac_cv_cc_wextra, [dnl
++old_CFLAGS="$CFLAGS"
++CFLAGS="$CFLAGS -Wextra"
++AC_COMPILE_IFELSE([AC_LANG_SOURCE([void foo (void) { }])],
++		  ac_cv_cc_wextra=yes, ac_cv_cc_wextra=no)
++CFLAGS="$old_CFLAGS"])
++AC_SUBST(WEXTRA)
++AS_IF([test "x$ac_cv_cc_wextra" = xyes], [WEXTRA=-Wextra], [WEXTRA=-W])
++
++AC_CACHE_CHECK([for -fgnu89-inline option to $CC], ac_cv_cc_gnu89_inline, [dnl
++old_CFLAGS="$CFLAGS"
++CFLAGS="$CFLAGS -fgnu89-inline -Werror"
++AC_COMPILE_IFELSE([AC_LANG_SOURCE([
++void foo (void)
++{
++  inline void bar (void) {}
++  bar ();
++}
++extern inline void baz (void) {}
++])], ac_cv_cc_gnu89_inline=yes, ac_cv_cc_gnu89_inline=no)
++CFLAGS="$old_CFLAGS"])
++AS_IF([test "x$ac_cv_cc_gnu89_inline" = xyes],
++      [WEXTRA="${WEXTRA:+$WEXTRA }-fgnu89-inline"])
++
++AC_CACHE_CHECK([for --as-needed linker option],
++	       ac_cv_as_needed, [dnl
++cat > conftest.c <<EOF
++int main (void) { return 0; }
++EOF
++if AC_TRY_COMMAND([${CC-cc} $CFLAGS $CPPFLAGS $LDFLAGS
++			    -fPIC -shared -o conftest.so conftest.c
++			    -Wl,--as-needed 1>&AS_MESSAGE_LOG_FD])
++then
++  ac_cv_as_needed=yes
++else
++  ac_cv_as_needed=no
++fi
++rm -f conftest*])
++AS_IF([test "x$ac_cv_as_needed" = xyes],
++      [LD_AS_NEEDED=-Wl,--as-needed], [LD_AS_NEEDED=])
++AC_SUBST(LD_AS_NEEDED)
++
++AC_CACHE_CHECK([for __builtin_popcount], ac_cv_popcount, [dnl
++AC_LINK_IFELSE([AC_LANG_PROGRAM([], [[exit (__builtin_popcount (127));]])],
++	       ac_cv_popcount=yes, ac_cv_popcount=no)])
++AS_IF([test "x$ac_cv_popcount" = xyes],
++      [AC_DEFINE([HAVE_BUILTIN_POPCOUNT], [1], [Have __builtin_popcount.])])
++
+ AC_CACHE_CHECK([for __thread support], ac_cv_tls, [dnl
+ # Use the same flags that we use for our DSOs, so the test is representative.
+ # Some old compiler/linker/libc combinations fail some ways and not others.
+@@ -105,7 +153,10 @@ static __thread int a; int foo (int b) {
+ CFLAGS="$save_CFLAGS"
+ LDFLAGS="$save_LDFLAGS"])
+ AS_IF([test "x$ac_cv_tls" != xyes],
+-      AC_MSG_ERROR([__thread support required]))
++      [AS_IF([test "$use_locks" = yes],
++	     [AC_MSG_ERROR([--enable-thread-safety requires __thread support])],
++	     [AC_DEFINE([__thread], [/* empty: no multi-thread support */],
++			[Stubbed out if missing compiler support.])])])
+ 
+ dnl This test must come as early as possible after the compiler configuration
+ dnl tests, because the choice of the file model can (in principle) affect
+@@ -193,6 +244,11 @@ AM_CONDITIONAL(GCOV, test "$use_gcov" =
+ AM_CONDITIONAL(BUILD_STATIC, [dnl
+ test "$use_mudflap" = yes -o "$use_gprof" = yes -o "$use_gcov" = yes])
+ 
++AC_ARG_ENABLE([werror],
++AS_HELP_STRING([--disable-werror],[do not build with -Werror]),
++	       [enable_werror=$enableval], [enable_werror=yes])
++AM_CONDITIONAL(BUILD_WERROR, test "$enable_werror" = yes)
++
+ AC_ARG_ENABLE([tests-rpath],
+ AS_HELP_STRING([--enable-tests-rpath],[build $ORIGIN-using rpath into tests]),
+ 	       [tests_use_rpath=$enableval], [tests_use_rpath=no])
+@@ -304,6 +360,6 @@ case "$eu_version" in
+ esac
+ 
+ # Round up to the next release API (x.y) version.
+-eu_version=$(( (eu_version + 999) / 1000 ))
++eu_version=`expr \( $eu_version + 999 \) / 1000`
+ 
+ AC_OUTPUT
+--- elfutils/lib/ChangeLog
++++ elfutils/lib/ChangeLog
+@@ -35,6 +35,9 @@
+ 
+ 2009-01-23  Roland McGrath  <roland@redhat.com>
+ 
++	* eu-config.h [! HAVE_BUILTIN_POPCOUNT]
++	(__builtin_popcount): New inline function.
++
+ 	* eu-config.h: Add multiple inclusion protection.
+ 
+ 2009-01-17  Ulrich Drepper  <drepper@redhat.com>
+@@ -91,6 +94,11 @@
+ 	* Makefile.am (libeu_a_SOURCES): Add it.
+ 	* system.h: Declare crc32_file.
+ 
++2005-02-07  Roland McGrath  <roland@redhat.com>
++
++	* Makefile.am (WEXTRA): New variable, substituted by configure.
++	(AM_CFLAGS): Use it in place of -Wextra.
++
+ 2005-04-30  Ulrich Drepper  <drepper@redhat.com>
+ 
+ 	* Makefile.am: Use -ffunction-sections for xmalloc.c.
+--- elfutils/lib/eu-config.h
++++ elfutils/lib/eu-config.h
+@@ -162,6 +162,17 @@ asm (".section predict_data, \"aw\"; .pr
+ /* This macro is used by the tests conditionalize for standalone building.  */
+ #define ELFUTILS_HEADER(name) <lib##name.h>
+ 
++#ifndef HAVE_BUILTIN_POPCOUNT
++# define __builtin_popcount hakmem_popcount
++static inline unsigned int __attribute__ ((unused))
++hakmem_popcount (unsigned int x)
++{
++  /* HAKMEM 169 */
++  unsigned int n = x - ((x >> 1) & 033333333333) - ((x >> 2) & 011111111111);
++  return ((n + (n >> 3)) & 030707070707) % 63;
++}
++#endif	/* HAVE_BUILTIN_POPCOUNT */
++
+ 
+ #ifdef SHARED
+ # define OLD_VERSION(name, version) \
+--- elfutils/lib/Makefile.in
++++ elfutils/lib/Makefile.in
+@@ -37,7 +37,8 @@ build_triplet = @build@
+ host_triplet = @host@
+ DIST_COMMON = $(noinst_HEADERS) $(srcdir)/Makefile.am \
+ 	$(srcdir)/Makefile.in $(top_srcdir)/config/eu.am ChangeLog
+-@MUDFLAP_TRUE@am__append_1 = -fmudflap
++@BUILD_WERROR_TRUE@am__append_1 = $(if $($(*F)_no_Werror),,-Werror)
++@MUDFLAP_TRUE@am__append_2 = -fmudflap
+ subdir = lib
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/nls.m4 $(top_srcdir)/m4/po.m4 \
+@@ -100,6 +101,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@
+ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
+ LDFLAGS = @LDFLAGS@
++LD_AS_NEEDED = @LD_AS_NEEDED@
+ LEX = @LEX@
+ LEXLIB = @LEXLIB@
+ LEX_OUTPUT_ROOT = @LEX_OUTPUT_ROOT@
+@@ -129,6 +131,7 @@ SHELL = @SHELL@
+ STRIP = @STRIP@
+ USE_NLS = @USE_NLS@
+ VERSION = @VERSION@
++WEXTRA = @WEXTRA@
+ XGETTEXT = @XGETTEXT@
+ XGETTEXT_015 = @XGETTEXT_015@
+ XGETTEXT_EXTRA_OPTIONS = @XGETTEXT_EXTRA_OPTIONS@
+@@ -190,10 +193,9 @@ zip_LIBS = @zip_LIBS@
+ INCLUDES = -I. -I$(srcdir) -I$(top_srcdir)/lib -I.. \
+ 	-I$(srcdir)/../libelf
+ AM_CFLAGS = -std=gnu99 -Wall -Wshadow $(if \
+-	$($(*F)_no_Werror),,-Werror) $(if \
+-	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
++	$($(*F)_no_Wunused),,-Wunused $(WEXTRA)) $(if \
+ 	$($(*F)_no_Wformat),-Wno-format,-Wformat=2) $($(*F)_CFLAGS) \
+-	$(am__append_1) -fpic
++	$(am__append_1) $(am__append_2) -fpic
+ @MUDFLAP_FALSE@libmudflap = 
+ @MUDFLAP_TRUE@libmudflap = -lmudflap
+ COMPILE.os = $(filter-out -fprofile-arcs -ftest-coverage $(no_mudflap.os),\
+--- elfutils/libasm/ChangeLog
++++ elfutils/libasm/ChangeLog
+@@ -71,6 +71,11 @@
+ 	* asm_error.c: Add new error ASM_E_IOERROR.
+ 	* libasmP.h: Add ASM_E_IOERROR definition.
+ 
++2005-05-31  Roland McGrath  <roland@redhat.com>
++
++	* Makefile.am (WEXTRA): New variable, substituted by configure.
++	(AM_CFLAGS): Use it in place of -Wextra.
++
+ 2005-02-15  Ulrich Drepper  <drepper@redhat.com>
+ 
+ 	* Makefile.am (AM_CFLAGS): Add -Wunused -Wextra -Wformat=2.
+--- elfutils/libasm/Makefile.in
++++ elfutils/libasm/Makefile.in
+@@ -39,10 +39,11 @@ host_triplet = @host@
+ DIST_COMMON = $(noinst_HEADERS) $(pkginclude_HEADERS) \
+ 	$(srcdir)/Makefile.am $(srcdir)/Makefile.in \
+ 	$(top_srcdir)/config/eu.am ChangeLog
+-@MUDFLAP_TRUE@am__append_1 = -fmudflap
++@BUILD_WERROR_TRUE@am__append_1 = $(if $($(*F)_no_Werror),,-Werror)
++@MUDFLAP_TRUE@am__append_2 = -fmudflap
+ @MUDFLAP_FALSE@noinst_PROGRAMS = $(am__EXEEXT_1)
+ @MUDFLAP_TRUE@am_libasm_pic_a_OBJECTS =
+-@MUDFLAP_FALSE@@USE_LOCKS_TRUE@am__append_2 = -lpthread
++@MUDFLAP_FALSE@@USE_LOCKS_TRUE@am__append_3 = -lpthread
+ subdir = libasm
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/nls.m4 $(top_srcdir)/m4/po.m4 \
+@@ -153,6 +154,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@
+ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
+ LDFLAGS = @LDFLAGS@
++LD_AS_NEEDED = @LD_AS_NEEDED@
+ LEX = @LEX@
+ LEXLIB = @LEXLIB@
+ LEX_OUTPUT_ROOT = @LEX_OUTPUT_ROOT@
+@@ -182,6 +184,7 @@ SHELL = @SHELL@
+ STRIP = @STRIP@
+ USE_NLS = @USE_NLS@
+ VERSION = 1
++WEXTRA = @WEXTRA@
+ XGETTEXT = @XGETTEXT@
+ XGETTEXT_015 = @XGETTEXT_015@
+ XGETTEXT_EXTRA_OPTIONS = @XGETTEXT_EXTRA_OPTIONS@
+@@ -244,10 +247,9 @@ INCLUDES = -I. -I$(srcdir) -I$(top_srcdi
+ 	-I$(top_srcdir)/libelf -I$(top_srcdir)/libebl \
+ 	-I$(top_srcdir)/libdw
+ AM_CFLAGS = -std=gnu99 -Wall -Wshadow $(if \
+-	$($(*F)_no_Werror),,-Werror) $(if \
+-	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
++	$($(*F)_no_Wunused),,-Wunused $(WEXTRA)) $(if \
+ 	$($(*F)_no_Wformat),-Wno-format,-Wformat=2) $($(*F)_CFLAGS) \
+-	$(am__append_1)
++	$(am__append_1) $(am__append_2)
+ @MUDFLAP_FALSE@libmudflap = 
+ @MUDFLAP_TRUE@libmudflap = -lmudflap
+ COMPILE.os = $(filter-out -fprofile-arcs -ftest-coverage $(no_mudflap.os),\
+@@ -276,7 +278,7 @@ libasm_a_SOURCES = asm_begin.c asm_abort
+ 
+ @MUDFLAP_FALSE@libasm_pic_a_SOURCES = 
+ @MUDFLAP_FALSE@am_libasm_pic_a_OBJECTS = $(libasm_a_SOURCES:.c=.os)
+-@MUDFLAP_FALSE@libasm_so_LDLIBS = $(am__append_2)
++@MUDFLAP_FALSE@libasm_so_LDLIBS = $(am__append_3)
+ @MUDFLAP_FALSE@libasm_so_SOURCES = 
+ noinst_HEADERS = libasmP.h symbolhash.h
+ EXTRA_DIST = libasm.map
+--- elfutils/libcpu/ChangeLog
++++ elfutils/libcpu/ChangeLog
+@@ -38,6 +38,9 @@
+ 
+ 2009-01-23  Roland McGrath  <roland@redhat.com>
+ 
++	* i386_disasm.c (i386_disasm): Add abort after assert-constant for old
++	compilers that don't realize it's noreturn.
++
+ 	* Makefile.am (i386_parse_CFLAGS): Use quotes around command
+ 	substitution that can produce leading whitespace.
+ 
+@@ -367,6 +370,11 @@
+ 	* defs/i386.doc: New file.
+ 	* defs/x86_64: New file.
+ 
++2005-04-04  Roland McGrath  <roland@redhat.com>
++
++	* Makefile.am (WEXTRA): New variable, substituted by configure.
++	(AM_CFLAGS): Use it instead of -Wextra.
++
+ 2005-02-15  Ulrich Drepper  <drepper@redhat.com>
+ 
+ 	* Makefile (AM_CFLAGS): Add -Wunused -Wextra -Wformat=2.
+--- elfutils/libcpu/i386_disasm.c
++++ elfutils/libcpu/i386_disasm.c
+@@ -822,6 +822,7 @@ i386_disasm (const uint8_t **startp, con
+ 
+ 			default:
+ 			  assert (! "INVALID not handled");
++			  abort ();
+ 			}
+ 		    }
+ 		  else
+--- elfutils/libcpu/Makefile.in
++++ elfutils/libcpu/Makefile.in
+@@ -39,7 +39,8 @@ host_triplet = @host@
+ DIST_COMMON = $(am__noinst_HEADERS_DIST) $(srcdir)/Makefile.am \
+ 	$(srcdir)/Makefile.in $(top_srcdir)/config/eu.am ChangeLog \
+ 	i386_lex.c i386_parse.c
+-@MUDFLAP_TRUE@am__append_1 = -fmudflap
++@BUILD_WERROR_TRUE@am__append_1 = $(if $($(*F)_no_Werror),,-Werror)
++@MUDFLAP_TRUE@am__append_2 = -fmudflap
+ @MAINTAINER_MODE_TRUE@noinst_PROGRAMS = i386_gendis$(EXEEXT)
+ subdir = libcpu
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+@@ -117,6 +118,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@
+ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
+ LDFLAGS = @LDFLAGS@
++LD_AS_NEEDED = @LD_AS_NEEDED@
+ LEX = @LEX@
+ LEXLIB = @LEXLIB@
+ LEX_OUTPUT_ROOT = lex.$(<F:lex.l=)
+@@ -146,6 +148,7 @@ SHELL = @SHELL@
+ STRIP = @STRIP@
+ USE_NLS = @USE_NLS@
+ VERSION = @VERSION@
++WEXTRA = @WEXTRA@
+ XGETTEXT = @XGETTEXT@
+ XGETTEXT_015 = @XGETTEXT_015@
+ XGETTEXT_EXTRA_OPTIONS = @XGETTEXT_EXTRA_OPTIONS@
+@@ -208,10 +211,9 @@ INCLUDES = -I. -I$(srcdir) -I$(top_srcdi
+ 	-I$(srcdir)/../libelf -I$(srcdir)/../libebl \
+ 	-I$(srcdir)/../libdw -I$(srcdir)/../libasm
+ AM_CFLAGS = -std=gnu99 -Wall -Wshadow $(if \
+-	$($(*F)_no_Werror),,-Werror) $(if \
+-	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
++	$($(*F)_no_Wunused),,-Wunused $(WEXTRA)) $(if \
+ 	$($(*F)_no_Wformat),-Wno-format,-Wformat=2) $($(*F)_CFLAGS) \
+-	$(am__append_1) -fpic -fdollars-in-identifiers
++	$(am__append_1) $(am__append_2) -fpic -fdollars-in-identifiers
+ @MUDFLAP_FALSE@libmudflap = 
+ @MUDFLAP_TRUE@libmudflap = -lmudflap
+ COMPILE.os = $(filter-out -fprofile-arcs -ftest-coverage $(no_mudflap.os),\
+--- elfutils/libdw/ChangeLog
++++ elfutils/libdw/ChangeLog
+@@ -82,6 +82,10 @@
+ 
+ 	* Makefile.am (known-dwarf.h): Run gawk on config/known-dwarf.awk.
+ 
++2011-07-20  Mark Wielaard  <mjw@redhat.com>
++
++	* dwarf_begin_elf.c: Add fallback for be64toh if not defined.
++
+ 2011-07-14  Mark Wielaard  <mjw@redhat.com>
+ 
+ 	* libdw.h (dwarf_offdie): Fix documentation to mention .debug_info.
+@@ -441,6 +445,10 @@
+ 
+ 	* dwarf_hasattr_integrate.c: Integrate DW_AT_specification too.
+ 
++2009-08-17  Roland McGrath  <roland@redhat.com>
++
++	* libdw.h: Disable extern inlines for GCC 4.2.
++
+ 2009-08-10  Roland McGrath  <roland@redhat.com>
+ 
+ 	* dwarf_getscopevar.c: Use dwarf_diename.
+@@ -1209,6 +1217,11 @@
+ 
+ 2005-05-31  Roland McGrath  <roland@redhat.com>
+ 
++	* Makefile.am (WEXTRA): New variable, substituted by configure.
++	(AM_CFLAGS): Use it in place of -Wextra.
++
++2005-05-31  Roland McGrath  <roland@redhat.com>
++
+ 	* dwarf_formref_die.c (dwarf_formref_die): Add CU header offset to
+ 	formref offset.
+ 
+--- elfutils/libdw/dwarf_begin_elf.c
++++ elfutils/libdw/dwarf_begin_elf.c
+@@ -48,6 +48,14 @@
+ #if USE_ZLIB
+ # include <endian.h>
+ # define crc32		loser_crc32
++# ifndef be64toh
++#  include <byteswap.h>
++#  if __BYTE_ORDER == __LITTLE_ENDIAN
++#   define be64toh(x) bswap_64 (x)
++#  else
++#   define be64toh(x) (x)
++#  endif
++# endif
+ # include <zlib.h>
+ # undef crc32
+ #endif
+--- elfutils/libdw/libdw.h
++++ elfutils/libdw/libdw.h
+@@ -831,7 +831,7 @@ extern Dwarf_OOM dwarf_new_oom_handler (
+ 
+ 
+ /* Inline optimizations.  */
+-#ifdef __OPTIMIZE__
++#if defined __OPTIMIZE__ && !(__GNUC__ == 4 && __GNUC_MINOR__ == 2)
+ /* Return attribute code of given attribute.  */
+ __libdw_extern_inline unsigned int
+ dwarf_whatattr (Dwarf_Attribute *attr)
+--- elfutils/libdw/Makefile.in
++++ elfutils/libdw/Makefile.in
+@@ -39,8 +39,9 @@ host_triplet = @host@
+ DIST_COMMON = $(include_HEADERS) $(noinst_HEADERS) \
+ 	$(pkginclude_HEADERS) $(srcdir)/Makefile.am \
+ 	$(srcdir)/Makefile.in $(top_srcdir)/config/eu.am ChangeLog
+-@MUDFLAP_TRUE@am__append_1 = -fmudflap
+-@BUILD_STATIC_TRUE@am__append_2 = -fpic
++@BUILD_WERROR_TRUE@am__append_1 = $(if $($(*F)_no_Werror),,-Werror)
++@MUDFLAP_TRUE@am__append_2 = -fmudflap
++@BUILD_STATIC_TRUE@am__append_3 = -fpic
+ @MUDFLAP_FALSE@noinst_PROGRAMS = $(am__EXEEXT_1)
+ @MUDFLAP_TRUE@am_libdw_pic_a_OBJECTS =
+ subdir = libdw
+@@ -198,6 +199,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@
+ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
+ LDFLAGS = @LDFLAGS@
++LD_AS_NEEDED = @LD_AS_NEEDED@
+ LEX = @LEX@
+ LEXLIB = @LEXLIB@
+ LEX_OUTPUT_ROOT = @LEX_OUTPUT_ROOT@
+@@ -227,6 +229,7 @@ SHELL = @SHELL@
+ STRIP = @STRIP@
+ USE_NLS = @USE_NLS@
+ VERSION = 1
++WEXTRA = @WEXTRA@
+ XGETTEXT = @XGETTEXT@
+ XGETTEXT_015 = @XGETTEXT_015@
+ XGETTEXT_EXTRA_OPTIONS = @XGETTEXT_EXTRA_OPTIONS@
+@@ -288,10 +291,9 @@ zip_LIBS = @zip_LIBS@
+ INCLUDES = -I. -I$(srcdir) -I$(top_srcdir)/lib -I.. \
+ 	-I$(srcdir)/../libelf
+ AM_CFLAGS = -std=gnu99 -Wall -Wshadow $(if \
+-	$($(*F)_no_Werror),,-Werror) $(if \
+-	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
++	$($(*F)_no_Wunused),,-Wunused $(WEXTRA)) $(if \
+ 	$($(*F)_no_Wformat),-Wno-format,-Wformat=2) $($(*F)_CFLAGS) \
+-	$(am__append_1) $(am__append_2)
++	$(am__append_1) $(am__append_2) $(am__append_3)
+ @MUDFLAP_FALSE@libmudflap = 
+ @MUDFLAP_TRUE@libmudflap = -lmudflap
+ COMPILE.os = $(filter-out -fprofile-arcs -ftest-coverage $(no_mudflap.os),\
+--- elfutils/libdwfl/ChangeLog
++++ elfutils/libdwfl/ChangeLog
+@@ -1420,6 +1420,11 @@
+ 
+ 2005-07-21  Roland McGrath  <roland@redhat.com>
+ 
++	* Makefile.am (WEXTRA): New variable, substituted by configure.
++	(AM_CFLAGS): Use it in place of -Wextra.
++
++2005-07-21  Roland McGrath  <roland@redhat.com>
++
+ 	* Makefile.am (noinst_HEADERS): Add loc2c.c.
+ 
+ 	* test2.c (main): Check sscanf result to quiet warning.
+--- elfutils/libdwfl/Makefile.in
++++ elfutils/libdwfl/Makefile.in
+@@ -38,11 +38,12 @@ host_triplet = @host@
+ DIST_COMMON = $(noinst_HEADERS) $(pkginclude_HEADERS) \
+ 	$(srcdir)/Makefile.am $(srcdir)/Makefile.in \
+ 	$(top_srcdir)/config/eu.am ChangeLog
+-@MUDFLAP_TRUE@am__append_1 = -fmudflap
+-@MUDFLAP_FALSE@am__append_2 = libdwfl_pic.a
+-@ZLIB_TRUE@am__append_3 = gzip.c
+-@BZLIB_TRUE@am__append_4 = bzip2.c
+-@LZMA_TRUE@am__append_5 = lzma.c
++@BUILD_WERROR_TRUE@am__append_1 = $(if $($(*F)_no_Werror),,-Werror)
++@MUDFLAP_TRUE@am__append_2 = -fmudflap
++@MUDFLAP_FALSE@am__append_3 = libdwfl_pic.a
++@ZLIB_TRUE@am__append_4 = gzip.c
++@BZLIB_TRUE@am__append_5 = bzip2.c
++@LZMA_TRUE@am__append_6 = lzma.c
+ @MUDFLAP_TRUE@am_libdwfl_pic_a_OBJECTS =
+ subdir = libdwfl
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+@@ -188,6 +189,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@
+ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
+ LDFLAGS = @LDFLAGS@
++LD_AS_NEEDED = @LD_AS_NEEDED@
+ LEX = @LEX@
+ LEXLIB = @LEXLIB@
+ LEX_OUTPUT_ROOT = @LEX_OUTPUT_ROOT@
+@@ -217,6 +219,7 @@ SHELL = @SHELL@
+ STRIP = @STRIP@
+ USE_NLS = @USE_NLS@
+ VERSION = 1
++WEXTRA = @WEXTRA@
+ XGETTEXT = @XGETTEXT@
+ XGETTEXT_015 = @XGETTEXT_015@
+ XGETTEXT_EXTRA_OPTIONS = @XGETTEXT_EXTRA_OPTIONS@
+@@ -279,10 +282,9 @@ INCLUDES = -I. -I$(srcdir) -I$(top_srcdi
+ 	-I$(srcdir)/../libelf -I$(srcdir)/../libebl \
+ 	-I$(srcdir)/../libdw
+ AM_CFLAGS = -std=gnu99 -Wall -Wshadow $(if \
+-	$($(*F)_no_Werror),,-Werror) $(if \
+-	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
++	$($(*F)_no_Wunused),,-Wunused $(WEXTRA)) $(if \
+ 	$($(*F)_no_Wformat),-Wno-format,-Wformat=2) $($(*F)_CFLAGS) \
+-	$(am__append_1)
++	$(am__append_1) $(am__append_2)
+ @MUDFLAP_FALSE@libmudflap = 
+ @MUDFLAP_TRUE@libmudflap = -lmudflap
+ COMPILE.os = $(filter-out -fprofile-arcs -ftest-coverage $(no_mudflap.os),\
+@@ -290,7 +292,7 @@ COMPILE.os = $(filter-out -fprofile-arcs
+ 
+ CLEANFILES = *.gcno *.gcda $(am_libdwfl_pic_a_OBJECTS)
+ textrel_check = if readelf -d $@ | fgrep -q TEXTREL; then exit 1; fi
+-noinst_LIBRARIES = libdwfl.a $(am__append_2)
++noinst_LIBRARIES = libdwfl.a $(am__append_3)
+ pkginclude_HEADERS = libdwfl.h
+ libdwfl_a_SOURCES = dwfl_begin.c dwfl_end.c dwfl_error.c \
+ 	dwfl_version.c dwfl_module.c dwfl_report_elf.c relocate.c \
+@@ -311,8 +313,8 @@ libdwfl_a_SOURCES = dwfl_begin.c dwfl_en
+ 	dwfl_module_getsym.c dwfl_module_addrname.c \
+ 	dwfl_module_addrsym.c dwfl_module_return_value_location.c \
+ 	dwfl_module_register_names.c dwfl_segment_report_module.c \
+-	link_map.c core-file.c open.c image-header.c $(am__append_3) \
+-	$(am__append_4) $(am__append_5)
++	link_map.c core-file.c open.c image-header.c $(am__append_4) \
++	$(am__append_5) $(am__append_6)
+ @MUDFLAP_FALSE@libdwfl = $(libdw)
+ @MUDFLAP_TRUE@libdwfl = libdwfl.a $(libdw) $(libebl) $(libelf) $(libeu)
+ @MUDFLAP_FALSE@libdw = ../libdw/libdw.so
+--- elfutils/libebl/ChangeLog
++++ elfutils/libebl/ChangeLog
+@@ -658,6 +658,11 @@
+ 	* Makefile.am (libebl_*_so_SOURCES): Set to $(*_SRCS) so dependency
+ 	tracking works right.
+ 
++2005-05-31  Roland McGrath  <roland@redhat.com>
++
++	* Makefile.am (WEXTRA): New variable, substituted by configure.
++	(AM_CFLAGS): Use it in place of -Wextra.
++
+ 2005-05-21  Ulrich Drepper  <drepper@redhat.com>
+ 
+ 	* libebl_x86_64.map: Add x86_64_core_note.
+--- elfutils/libebl/Makefile.in
++++ elfutils/libebl/Makefile.in
+@@ -38,7 +38,8 @@ host_triplet = @host@
+ DIST_COMMON = $(noinst_HEADERS) $(pkginclude_HEADERS) \
+ 	$(srcdir)/Makefile.am $(srcdir)/Makefile.in \
+ 	$(top_srcdir)/config/eu.am ChangeLog
+-@MUDFLAP_TRUE@am__append_1 = -fmudflap
++@BUILD_WERROR_TRUE@am__append_1 = $(if $($(*F)_no_Werror),,-Werror)
++@MUDFLAP_TRUE@am__append_2 = -fmudflap
+ subdir = libebl
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/nls.m4 $(top_srcdir)/m4/po.m4 \
+@@ -150,6 +151,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@
+ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
+ LDFLAGS = @LDFLAGS@
++LD_AS_NEEDED = @LD_AS_NEEDED@
+ LEX = @LEX@
+ LEXLIB = @LEXLIB@
+ LEX_OUTPUT_ROOT = @LEX_OUTPUT_ROOT@
+@@ -179,6 +181,7 @@ SHELL = @SHELL@
+ STRIP = @STRIP@
+ USE_NLS = @USE_NLS@
+ VERSION = 1
++WEXTRA = @WEXTRA@
+ XGETTEXT = @XGETTEXT@
+ XGETTEXT_015 = @XGETTEXT_015@
+ XGETTEXT_EXTRA_OPTIONS = @XGETTEXT_EXTRA_OPTIONS@
+@@ -241,10 +244,9 @@ INCLUDES = -I. -I$(srcdir) -I$(top_srcdi
+ 	-I$(srcdir)/../libelf -I$(srcdir)/../libdw \
+ 	-I$(srcdir)/../libasm
+ AM_CFLAGS = -std=gnu99 -Wall -Wshadow $(if \
+-	$($(*F)_no_Werror),,-Werror) $(if \
+-	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
++	$($(*F)_no_Wunused),,-Wunused $(WEXTRA)) $(if \
+ 	$($(*F)_no_Wformat),-Wno-format,-Wformat=2) $($(*F)_CFLAGS) \
+-	$(am__append_1) -fpic
++	$(am__append_1) $(am__append_2) -fpic
+ @MUDFLAP_FALSE@libmudflap = 
+ @MUDFLAP_TRUE@libmudflap = -lmudflap
+ COMPILE.os = $(filter-out -fprofile-arcs -ftest-coverage $(no_mudflap.os),\
+--- elfutils/libelf/ChangeLog
++++ elfutils/libelf/ChangeLog
+@@ -34,6 +34,11 @@
+ 
+ 	* elf-knowledge.h (SECTION_STRIP_P): Remove < SHT_NUM check.
+ 
++2011-03-10  Roland McGrath  <roland@redhat.com>
++
++	* gnuhash_xlate.h (elf_cvt_gnuhash): Avoid post-increment in bswap_32
++	argument, since some implementations are buggy macros.
++
+ 2011-02-26  Mark Wielaard  <mjw@redhat.com>
+ 
+ 	* elf_end.c (elf_end): Call rwlock_unlock before rwlock_fini.
+@@ -711,6 +716,11 @@
+ 
+ 	* elf.h: Update from glibc.
+ 
++2005-05-31  Roland McGrath  <roland@redhat.com>
++
++	* Makefile.am (WEXTRA): New variable, substituted by configure.
++	(AM_CFLAGS): Use it in place of -Wextra.
++
+ 2005-05-08  Roland McGrath  <roland@redhat.com>
+ 
+ 	* elf_begin.c (read_file) [_MUDFLAP]: Don't use mmap for now.
+--- elfutils/libelf/common.h
++++ elfutils/libelf/common.h
+@@ -139,7 +139,7 @@ libelf_release_all (Elf *elf)
+   (Var) = (sizeof (Var) == 1						      \
+ 	   ? (unsigned char) (Var)					      \
+ 	   : (sizeof (Var) == 2						      \
+-	      ? bswap_16 (Var)						      \
++	      ? (unsigned short int) bswap_16 (Var)			      \
+ 	      : (sizeof (Var) == 4					      \
+ 		 ? bswap_32 (Var)					      \
+ 		 : bswap_64 (Var))))
+@@ -148,7 +148,7 @@ libelf_release_all (Elf *elf)
+   (Dst) = (sizeof (Var) == 1						      \
+ 	   ? (unsigned char) (Var)					      \
+ 	   : (sizeof (Var) == 2						      \
+-	      ? bswap_16 (Var)						      \
++	      ? (unsigned short int) bswap_16 (Var)			      \
+ 	      : (sizeof (Var) == 4					      \
+ 		 ? bswap_32 (Var)					      \
+ 		 : bswap_64 (Var))))
+--- elfutils/libelf/gnuhash_xlate.h
++++ elfutils/libelf/gnuhash_xlate.h
+@@ -1,5 +1,5 @@
+ /* Conversion functions for versioning information.
+-   Copyright (C) 2006, 2007 Red Hat, Inc.
++   Copyright (C) 2006-2011 Red Hat, Inc.
+    This file is part of elfutils.
+    Written by Ulrich Drepper <drepper@redhat.com>, 2006.
+ 
+@@ -68,7 +68,9 @@ elf_cvt_gnuhash (void *dest, const void
+   dest32 = (Elf32_Word *) &dest64[bitmask_words];
+   while (len >= 4)
+     {
+-      *dest32++ = bswap_32 (*src32++);
++      *dest32 = bswap_32 (*src32);
++      ++dest32;
++      ++src32;
+       len -= 4;
+     }
+ }
+--- elfutils/libelf/Makefile.in
++++ elfutils/libelf/Makefile.in
+@@ -39,11 +39,12 @@ host_triplet = @host@
+ DIST_COMMON = $(include_HEADERS) $(noinst_HEADERS) \
+ 	$(pkginclude_HEADERS) $(srcdir)/Makefile.am \
+ 	$(srcdir)/Makefile.in $(top_srcdir)/config/eu.am ChangeLog
+-@MUDFLAP_TRUE@am__append_1 = -fmudflap
+-@BUILD_STATIC_TRUE@am__append_2 = -fpic
++@BUILD_WERROR_TRUE@am__append_1 = $(if $($(*F)_no_Werror),,-Werror)
++@MUDFLAP_TRUE@am__append_2 = -fmudflap
++@BUILD_STATIC_TRUE@am__append_3 = -fpic
+ @MUDFLAP_FALSE@noinst_PROGRAMS = $(am__EXEEXT_1)
+ @MUDFLAP_TRUE@am_libelf_pic_a_OBJECTS =
+-@MUDFLAP_FALSE@@USE_LOCKS_TRUE@am__append_3 = -lpthread
++@MUDFLAP_FALSE@@USE_LOCKS_TRUE@am__append_4 = -lpthread
+ subdir = libelf
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/nls.m4 $(top_srcdir)/m4/po.m4 \
+@@ -195,6 +196,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@
+ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
+ LDFLAGS = @LDFLAGS@
++LD_AS_NEEDED = @LD_AS_NEEDED@
+ LEX = @LEX@
+ LEXLIB = @LEXLIB@
+ LEX_OUTPUT_ROOT = @LEX_OUTPUT_ROOT@
+@@ -224,6 +226,7 @@ SHELL = @SHELL@
+ STRIP = @STRIP@
+ USE_NLS = @USE_NLS@
+ VERSION = 1
++WEXTRA = @WEXTRA@
+ XGETTEXT = @XGETTEXT@
+ XGETTEXT_015 = @XGETTEXT_015@
+ XGETTEXT_EXTRA_OPTIONS = @XGETTEXT_EXTRA_OPTIONS@
+@@ -284,10 +287,9 @@ top_srcdir = @top_srcdir@
+ zip_LIBS = @zip_LIBS@
+ INCLUDES = -I. -I$(srcdir) -I$(top_srcdir)/lib -I..
+ AM_CFLAGS = -std=gnu99 -Wall -Wshadow $(if \
+-	$($(*F)_no_Werror),,-Werror) $(if \
+-	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
++	$($(*F)_no_Wunused),,-Wunused $(WEXTRA)) $(if \
+ 	$($(*F)_no_Wformat),-Wno-format,-Wformat=2) $($(*F)_CFLAGS) \
+-	$(am__append_1) $(am__append_2)
++	$(am__append_1) $(am__append_2) $(am__append_3)
+ @MUDFLAP_FALSE@libmudflap = 
+ @MUDFLAP_TRUE@libmudflap = -lmudflap
+ COMPILE.os = $(filter-out -fprofile-arcs -ftest-coverage $(no_mudflap.os),\
+@@ -352,7 +354,7 @@ libelf_a_SOURCES = elf_version.c elf_has
+ 
+ @MUDFLAP_FALSE@libelf_pic_a_SOURCES = 
+ @MUDFLAP_FALSE@am_libelf_pic_a_OBJECTS = $(libelf_a_SOURCES:.c=.os)
+-@MUDFLAP_FALSE@libelf_so_LDLIBS = $(am__append_3)
++@MUDFLAP_FALSE@libelf_so_LDLIBS = $(am__append_4)
+ @MUDFLAP_FALSE@libelf_so_SOURCES = 
+ noinst_HEADERS = elf.h abstract.h common.h exttypes.h gelf_xlate.h libelfP.h \
+ 		 version_xlate.h gnuhash_xlate.h note_xlate.h dl-hash.h
+--- elfutils/m4/Makefile.in
++++ elfutils/m4/Makefile.in
+@@ -75,6 +75,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@
+ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
+ LDFLAGS = @LDFLAGS@
++LD_AS_NEEDED = @LD_AS_NEEDED@
+ LEX = @LEX@
+ LEXLIB = @LEXLIB@
+ LEX_OUTPUT_ROOT = @LEX_OUTPUT_ROOT@
+@@ -104,6 +105,7 @@ SHELL = @SHELL@
+ STRIP = @STRIP@
+ USE_NLS = @USE_NLS@
+ VERSION = @VERSION@
++WEXTRA = @WEXTRA@
+ XGETTEXT = @XGETTEXT@
+ XGETTEXT_015 = @XGETTEXT_015@
+ XGETTEXT_EXTRA_OPTIONS = @XGETTEXT_EXTRA_OPTIONS@
+--- elfutils/Makefile.in
++++ elfutils/Makefile.in
+@@ -165,6 +165,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@
+ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
+ LDFLAGS = @LDFLAGS@
++LD_AS_NEEDED = @LD_AS_NEEDED@
+ LEX = @LEX@
+ LEXLIB = @LEXLIB@
+ LEX_OUTPUT_ROOT = @LEX_OUTPUT_ROOT@
+@@ -194,6 +195,7 @@ SHELL = @SHELL@
+ STRIP = @STRIP@
+ USE_NLS = @USE_NLS@
+ VERSION = @VERSION@
++WEXTRA = @WEXTRA@
+ XGETTEXT = @XGETTEXT@
+ XGETTEXT_015 = @XGETTEXT_015@
+ XGETTEXT_EXTRA_OPTIONS = @XGETTEXT_EXTRA_OPTIONS@
+--- elfutils/src/addr2line.c
++++ elfutils/src/addr2line.c
+@@ -447,10 +447,10 @@ handle_address (const char *string, Dwfl
+       bool parsed = false;
+       int i, j;
+       char *name = NULL;
+-      if (sscanf (string, "(%m[^)])%" PRIiMAX "%n", &name, &addr, &i) == 2
++      if (sscanf (string, "(%a[^)])%" PRIiMAX "%n", &name, &addr, &i) == 2
+ 	  && string[i] == '\0')
+ 	parsed = adjust_to_section (name, &addr, dwfl);
+-      switch (sscanf (string, "%m[^-+]%n%" PRIiMAX "%n", &name, &i, &addr, &j))
++      switch (sscanf (string, "%a[^-+]%n%" PRIiMAX "%n", &name, &i, &addr, &j))
+ 	{
+ 	default:
+ 	  break;
+--- elfutils/src/ChangeLog
++++ elfutils/src/ChangeLog
+@@ -606,8 +606,16 @@
+ 	* readelf.c (attr_callback): Use print_block only when we don't use
+ 	print_ops.
+ 
++2009-08-17  Roland McGrath  <roland@redhat.com>
++
++	* ld.h: Disable extern inlines for GCC 4.2.
++
+ 2009-08-14  Roland McGrath  <roland@redhat.com>
+ 
++	* strings.c (read_block): Conditionalize posix_fadvise use
++	on [POSIX_FADV_SEQUENTIAL].
++	From Petr Salinger <Petr.Salinger@seznam.cz>.
++
+ 	* ar.c (do_oper_extract): Use pathconf instead of statfs.
+ 
+ 2009-08-01  Ulrich Drepper  <drepper@redhat.com>
+@@ -771,6 +779,8 @@
+ 	* readelf.c (print_debug_frame_section): Use t instead of j formats
+ 	for ptrdiff_t OFFSET.
+ 
++	* addr2line.c (handle_address): Use %a instead of %m for compatibility.
++
+ 2009-01-21  Ulrich Drepper  <drepper@redhat.com>
+ 
+ 	* elflint.c (check_program_header): Fix typo in .eh_frame_hdr section
+@@ -954,6 +964,11 @@
+ 	that matches its PT_LOAD's p_flags &~ PF_W.  On sparc, PF_X really
+ 	is valid in RELRO.
+ 
++2008-03-01  Roland McGrath  <roland@redhat.com>
++
++	* readelf.c (dump_archive_index): Tweak portability hack
++	to match [__GNUC__ < 4] too.
++
+ 2008-02-29  Roland McGrath  <roland@redhat.com>
+ 
+ 	* readelf.c (print_attributes): Add a cast.
+@@ -1205,6 +1220,8 @@
+ 
+ 	* readelf.c (hex_dump): Fix rounding error in whitespace calculation.
+ 
++	* Makefile.am (readelf_no_Werror): New variable.
++
+ 2007-10-15  Roland McGrath  <roland@redhat.com>
+ 
+ 	* make-debug-archive.in: New file.
+@@ -1644,6 +1661,10 @@
+ 	* elflint.c (valid_e_machine): Add EM_ALPHA.
+ 	Reported by Christian Aichinger <Greek0@gmx.net>.
+ 
++	* strings.c (map_file): Define POSIX_MADV_SEQUENTIAL to
++	MADV_SEQUENTIAL if undefined.  	Don't call posix_madvise
++	if neither is defined.
++
+ 2006-08-08  Ulrich Drepper  <drepper@redhat.com>
+ 
+ 	* elflint.c (check_dynamic): Don't require DT_HASH for DT_SYMTAB.
+@@ -1720,6 +1741,10 @@
+ 	* Makefile.am: Add hacks to create dependency files for non-generic
+ 	linker.
+ 
++2006-04-05  Roland McGrath  <roland@redhat.com>
++
++	* strings.c (MAP_POPULATE): Define to 0 if undefined.
++
+ 2006-06-12  Ulrich Drepper  <drepper@redhat.com>
+ 
+ 	* ldgeneric.c (ld_generic_generate_sections): Don't create .interp
+@@ -2068,6 +2093,11 @@
+ 	* readelf.c (print_debug_loc_section): Fix indentation for larger
+ 	address size.
+ 
++2005-05-31  Roland McGrath  <roland@redhat.com>
++
++	* Makefile.am (WEXTRA): New variable, substituted by configure.
++	(AM_CFLAGS): Use it in place of -Wextra.
++
+ 2005-05-30  Roland McGrath  <roland@redhat.com>
+ 
+ 	* readelf.c (print_debug_line_section): Print section offset of each
+--- elfutils/src/findtextrel.c
++++ elfutils/src/findtextrel.c
+@@ -496,7 +496,11 @@ ptrcompare (const void *p1, const void *
+ 
+ 
+ static void
+-check_rel (size_t nsegments, struct segments segments[nsegments],
++check_rel (size_t nsegments, struct segments segments[
++#if __GNUC__ >= 4
++						      nsegments
++#endif
++	   ],
+ 	   GElf_Addr addr, Elf *elf, Elf_Scn *symscn, Dwarf *dw,
+ 	   const char *fname, bool more_than_one, void **knownsrcs)
+ {
+--- elfutils/src/ld.h
++++ elfutils/src/ld.h
+@@ -1114,6 +1114,7 @@ extern bool dynamically_linked_p (void);
+ 
+ /* Checked whether the symbol is undefined and referenced from a DSO.  */
+ extern bool linked_from_dso_p (struct scninfo *scninfo, size_t symidx);
++#if defined __OPTIMIZE__ && !(__GNUC__ == 4 && __GNUC_MINOR__ == 2)
+ #ifdef __GNUC_STDC_INLINE__
+ __attribute__ ((__gnu_inline__))
+ #endif
+@@ -1131,5 +1132,6 @@ linked_from_dso_p (struct scninfo *scnin
+ 
+   return sym->defined && sym->in_dso;
+ }
++#endif	/* Optimizing and not GCC 4.2.  */
+ 
+ #endif	/* ld.h */
+--- elfutils/src/Makefile.am
++++ elfutils/src/Makefile.am
+@@ -95,6 +95,9 @@ addr2line_no_Wformat = yes
+ # XXX While the file is not finished, don't warn about this
+ ldgeneric_no_Wunused = yes
+ 
++# Buggy old compilers.
++readelf_no_Werror = yes
++
+ readelf_LDADD = $(libdw) $(libebl) $(libelf) $(libeu) $(libmudflap) -ldl
+ nm_LDADD = $(libdw) $(libebl) $(libelf) $(libeu) $(libmudflap) -ldl \
+ 	   $(demanglelib)
+--- elfutils/src/Makefile.in
++++ elfutils/src/Makefile.in
+@@ -40,7 +40,8 @@ host_triplet = @host@
+ DIST_COMMON = $(noinst_HEADERS) $(srcdir)/Makefile.am \
+ 	$(srcdir)/Makefile.in $(top_srcdir)/config/eu.am ChangeLog \
+ 	ldlex.c ldscript.c
+-@MUDFLAP_TRUE@am__append_1 = -fmudflap
++@BUILD_WERROR_TRUE@am__append_1 = $(if $($(*F)_no_Werror),,-Werror)
++@MUDFLAP_TRUE@am__append_2 = -fmudflap
+ bin_PROGRAMS = readelf$(EXEEXT) nm$(EXEEXT) size$(EXEEXT) \
+ 	strip$(EXEEXT) ld$(EXEEXT) elflint$(EXEEXT) \
+ 	findtextrel$(EXEEXT) addr2line$(EXEEXT) elfcmp$(EXEEXT) \
+@@ -49,9 +50,9 @@ bin_PROGRAMS = readelf$(EXEEXT) nm$(EXEE
+ @NATIVE_LD_FALSE@noinst_PROGRAMS = $(am__EXEEXT_1)
+ # We never build this library but we need to get the dependency files
+ # of all the linker backends that might be used in a non-generic linker.
+-@NEVER_TRUE@am__append_2 = libdummy.a
++@NEVER_TRUE@am__append_3 = libdummy.a
+ # -ldl is always needed for libebl.
+-@NATIVE_LD_TRUE@am__append_3 = libld_elf.a
++@NATIVE_LD_TRUE@am__append_4 = libld_elf.a
+ @NATIVE_LD_TRUE@am_libld_elf_i386_pic_a_OBJECTS =
+ subdir = src
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+@@ -115,7 +116,7 @@ am_ld_OBJECTS = ld.$(OBJEXT) ldgeneric.$
+ 	versionhash.$(OBJEXT)
+ ld_OBJECTS = $(am_ld_OBJECTS)
+ ld_DEPENDENCIES = $(libebl) $(libelf) $(libeu) $(am__DEPENDENCIES_1) \
+-	$(am__append_3)
++	$(am__append_4)
+ ld_LINK = $(CCLD) $(AM_CFLAGS) $(CFLAGS) $(ld_LDFLAGS) $(LDFLAGS) -o \
+ 	$@
+ am_libld_elf_i386_so_OBJECTS =
+@@ -235,6 +236,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@
+ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
+ LDFLAGS = @LDFLAGS@
++LD_AS_NEEDED = @LD_AS_NEEDED@
+ LEX = @LEX@
+ LEXLIB = @LEXLIB@
+ LEX_OUTPUT_ROOT = @LEX_OUTPUT_ROOT@
+@@ -264,6 +266,7 @@ SHELL = @SHELL@
+ STRIP = @STRIP@
+ USE_NLS = @USE_NLS@
+ VERSION = @VERSION@
++WEXTRA = @WEXTRA@
+ XGETTEXT = @XGETTEXT@
+ XGETTEXT_015 = @XGETTEXT_015@
+ XGETTEXT_EXTRA_OPTIONS = @XGETTEXT_EXTRA_OPTIONS@
+@@ -327,10 +330,9 @@ INCLUDES = -I. -I$(srcdir) -I$(top_srcdi
+ 	-I$(srcdir)/../libdw -I$(srcdir)/../libdwfl \
+ 	-I$(srcdir)/../libasm
+ AM_CFLAGS = -std=gnu99 -Wall -Wshadow $(if \
+-	$($(*F)_no_Werror),,-Werror) $(if \
+-	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
++	$($(*F)_no_Wunused),,-Wunused $(WEXTRA)) $(if \
+ 	$($(*F)_no_Wformat),-Wno-format,-Wformat=2) $($(*F)_CFLAGS) \
+-	$(am__append_1)
++	$(am__append_1) $(am__append_2)
+ @MUDFLAP_FALSE@libmudflap = 
+ @MUDFLAP_TRUE@libmudflap = -lmudflap
+ COMPILE.os = $(filter-out -fprofile-arcs -ftest-coverage $(no_mudflap.os),\
+@@ -346,8 +348,8 @@ AM_LFLAGS = -Pld -olex.yy.c
+ native_ld = @native_ld@
+ ld_dsos = libld_elf_i386_pic.a
+ @NATIVE_LD_FALSE@noinst_LIBRARIES = libld_elf.a libar.a $(ld_dsos) \
+-@NATIVE_LD_FALSE@	$(am__append_2)
+-@NATIVE_LD_TRUE@noinst_LIBRARIES = libld_elf.a libar.a $(am__append_2)
++@NATIVE_LD_FALSE@	$(am__append_3)
++@NATIVE_LD_TRUE@noinst_LIBRARIES = libld_elf.a libar.a $(am__append_3)
+ @NATIVE_LD_TRUE@native_ld_cflags = -DBASE_ELF_NAME=elf_$(base_cpu)
+ @NEVER_TRUE@libdummy_a_SOURCES = i386_ld.c
+ ld_SOURCES = ld.c ldgeneric.c ldlex.l ldscript.y symbolhash.c sectionhash.c \
+@@ -376,6 +378,9 @@ strings_no_Wformat = yes
+ addr2line_no_Wformat = yes
+ # XXX While the file is not finished, don't warn about this
+ ldgeneric_no_Wunused = yes
++
++# Buggy old compilers.
++readelf_no_Werror = yes
+ readelf_LDADD = $(libdw) $(libebl) $(libelf) $(libeu) $(libmudflap) -ldl
+ nm_LDADD = $(libdw) $(libebl) $(libelf) $(libeu) $(libmudflap) -ldl \
+ 	   $(demanglelib)
+@@ -383,7 +388,7 @@ nm_LDADD = $(libdw) $(libebl) $(libelf)
+ size_LDADD = $(libelf) $(libeu) $(libmudflap)
+ strip_LDADD = $(libebl) $(libelf) $(libeu) $(libmudflap) -ldl
+ ld_LDADD = $(libebl) $(libelf) $(libeu) $(libmudflap) -ldl \
+-	$(am__append_3)
++	$(am__append_4)
+ ld_LDFLAGS = -rdynamic
+ elflint_LDADD = $(libebl) $(libelf) $(libeu) $(libmudflap) -ldl
+ findtextrel_LDADD = $(libdw) $(libelf) $(libmudflap)
+--- elfutils/src/readelf.c
++++ elfutils/src/readelf.c
+@@ -3949,10 +3949,11 @@ struct listptr
+ #define listptr_offset_size(p)	((p)->dwarf64 ? 8 : 4)
+ #define listptr_address_size(p)	((p)->addr64 ? 8 : 4)
+ 
++static const char *listptr_name;
+ static int
+-compare_listptr (const void *a, const void *b, void *arg)
++compare_listptr (const void *a, const void *b)
+ {
+-  const char *name = arg;
++  const char *const name = listptr_name;
+   struct listptr *p1 = (void *) a;
+   struct listptr *p2 = (void *) b;
+ 
+@@ -4033,8 +4034,11 @@ static void
+ sort_listptr (struct listptr_table *table, const char *name)
+ {
+   if (table->n > 0)
+-    qsort_r (table->table, table->n, sizeof table->table[0],
+-	     &compare_listptr, (void *) name);
++    {
++      listptr_name = name;
++      qsort (table->table, table->n, sizeof table->table[0],
++	     &compare_listptr);
++    }
+ }
+ 
+ static bool
+@@ -8442,7 +8446,7 @@ dump_archive_index (Elf *elf, const char
+ 	  if (unlikely (elf_rand (elf, as_off) == 0)
+ 	      || unlikely ((subelf = elf_begin (-1, ELF_C_READ_MMAP, elf))
+ 			   == NULL))
+-#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 7)
++#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 7) || __GNUC__ < 4
+ 	    while (1)
+ #endif
+ 	      error (EXIT_FAILURE, 0,
+--- elfutils/src/strings.c
++++ elfutils/src/strings.c
+@@ -43,6 +43,10 @@
+ 
+ #include <system.h>
+ 
++#ifndef MAP_POPULATE
++# define MAP_POPULATE 0
++#endif
++
+ 
+ /* Prototypes of local functions.  */
+ static int read_fd (int fd, const char *fname, off64_t fdlen);
+@@ -483,8 +487,13 @@ map_file (int fd, off64_t start_off, off
+ 		    fd, start_off);
+       if (mem != MAP_FAILED)
+ 	{
++#if !defined POSIX_MADV_SEQUENTIAL && defined MADV_SEQUENTIAL
++# define POSIX_MADV_SEQUENTIAL MADV_SEQUENTIAL
++#endif
++#ifdef POSIX_MADV_SEQUENTIAL
+ 	  /* We will go through the mapping sequentially.  */
+ 	  (void) posix_madvise (mem, map_size, POSIX_MADV_SEQUENTIAL);
++#endif
+ 	  break;
+ 	}
+       if (errno != EINVAL && errno != ENOMEM)
+@@ -576,9 +585,11 @@ read_block (int fd, const char *fname, o
+       elfmap_off = from & ~(ps - 1);
+       elfmap_base = elfmap = map_file (fd, elfmap_off, fdlen, &elfmap_size);
+ 
++#ifdef POSIX_FADV_SEQUENTIAL
+       if (unlikely (elfmap == MAP_FAILED))
+ 	/* Let the kernel know we are going to read everything in sequence.  */
+ 	(void) posix_fadvise (fd, 0, 0, POSIX_FADV_SEQUENTIAL);
++#endif
+     }
+ 
+   if (unlikely (elfmap == MAP_FAILED))
+--- elfutils/src/strip.c
++++ elfutils/src/strip.c
+@@ -45,6 +45,12 @@
+ #include <libebl.h>
+ #include <system.h>
+ 
++#ifdef HAVE_FUTIMES
++# define FUTIMES(fd, fname, tvp) futimes (fd, tvp)
++#else
++# define FUTIMES(fd, fname, tvp) utimes (fname, tvp)
++#endif
++
+ typedef uint8_t GElf_Byte;
+ 
+ /* Name and version of program.  */
+@@ -318,8 +324,18 @@ process_file (const char *fname)
+ 
+       /* If we have to preserve the timestamp, we need it in the
+ 	 format utimes() understands.  */
++#ifdef HAVE_STRUCT_STAT_ST_ATIM
+       TIMESPEC_TO_TIMEVAL (&tv[0], &pre_st.st_atim);
++#else
++      tv[0].tv_sec = pre_st.st_atime;
++      tv[0].tv_usec = 0;
++#endif
++#ifdef HAVE_STRUCT_STAT_ST_MTIM
+       TIMESPEC_TO_TIMEVAL (&tv[1], &pre_st.st_mtim);
++#else
++      tv[1].tv_sec = pre_st.st_atime;
++      tv[1].tv_usec = 0;
++#endif
+     }
+ 
+   /* Open the file.  */
+@@ -2055,7 +2071,7 @@ while computing checksum for debug infor
+   /* If requested, preserve the timestamp.  */
+   if (tvp != NULL)
+     {
+-      if (futimes (fd, tvp) != 0)
++      if (FUTIMES (fd, output_fname, tvp) != 0)
+ 	{
+ 	  error (0, errno, gettext ("\
+ cannot set access and modification date of '%s'"),
+@@ -2112,7 +2128,7 @@ handle_ar (int fd, Elf *elf, const char
+ 
+   if (tvp != NULL)
+     {
+-      if (unlikely (futimes (fd, tvp) != 0))
++      if (unlikely (FUTIMES (fd, fname, tvp) != 0))
+ 	{
+ 	  error (0, errno, gettext ("\
+ cannot set access and modification date of '%s'"), fname);
+--- elfutils/tests/ChangeLog
++++ elfutils/tests/ChangeLog
+@@ -439,6 +439,8 @@
+ 
+ 2008-01-21  Roland McGrath  <roland@redhat.com>
+ 
++	* line2addr.c (main): Revert last change.
++
+ 	* testfile45.S.bz2: Add tests for cltq, cqto.
+ 	* testfile45.expect.bz2: Adjust.
+ 
+@@ -1147,6 +1149,11 @@
+ 	* Makefile.am (TESTS): Add run-elflint-test.sh.
+ 	(EXTRA_DIST): Add run-elflint-test.sh and testfile18.bz2.
+ 
++2005-05-31  Roland McGrath  <roland@redhat.com>
++
++	* Makefile.am (WEXTRA): New variable, substituted by configure.
++	(AM_CFLAGS): Use it in place of -Wextra.
++
+ 2005-05-24  Ulrich Drepper  <drepper@redhat.com>
+ 
+ 	* get-files.c (main): Use correct format specifier.
+--- elfutils/tests/line2addr.c
++++ elfutils/tests/line2addr.c
+@@ -124,7 +124,7 @@ main (int argc, char *argv[])
+     {
+       struct args a = { .arg = argv[cnt] };
+ 
+-      switch (sscanf (a.arg, "%m[^:]:%d", &a.file, &a.line))
++      switch (sscanf (a.arg, "%a[^:]:%d", &a.file, &a.line))
+ 	{
+ 	default:
+ 	case 0:
+--- elfutils/tests/Makefile.in
++++ elfutils/tests/Makefile.in
+@@ -35,14 +35,15 @@ build_triplet = @build@
+ host_triplet = @host@
+ DIST_COMMON = $(srcdir)/Makefile.am $(srcdir)/Makefile.in \
+ 	$(top_srcdir)/config/eu.am ChangeLog
+-@MUDFLAP_TRUE@am__append_1 = -fmudflap
+-@STANDALONE_FALSE@am__append_2 = -I$(top_srcdir)/libasm -I$(top_srcdir)/libdw \
++@BUILD_WERROR_TRUE@am__append_1 = $(if $($(*F)_no_Werror),,-Werror)
++@MUDFLAP_TRUE@am__append_2 = -fmudflap
++@STANDALONE_FALSE@am__append_3 = -I$(top_srcdir)/libasm -I$(top_srcdir)/libdw \
+ @STANDALONE_FALSE@	    -I$(top_srcdir)/libdwfl \
+ @STANDALONE_FALSE@	    -I$(top_srcdir)/libebl -I$(top_srcdir)/libelf \
+ @STANDALONE_FALSE@	    -I$(top_srcdir)/lib -I..
+ 
+-@STANDALONE_FALSE@am__append_3 = -Wl,-rpath-link,../libasm:../libdw:../libelf
+-@TESTS_RPATH_TRUE@am__append_4 = -Wl,-rpath,$(BUILD_RPATH)
++@STANDALONE_FALSE@am__append_4 = -Wl,-rpath-link,../libasm:../libdw:../libelf
++@TESTS_RPATH_TRUE@am__append_5 = -Wl,-rpath,$(BUILD_RPATH)
+ check_PROGRAMS = arextract$(EXEEXT) arsymtest$(EXEEXT) \
+ 	newfile$(EXEEXT) saridx$(EXEEXT) scnnames$(EXEEXT) \
+ 	sectiondump$(EXEEXT) showptable$(EXEEXT) update1$(EXEEXT) \
+@@ -92,12 +93,12 @@ TESTS = run-arextract.sh run-arsymtest.s
+ 	run-readelf-gdb_index.sh run-unstrip-n.sh run-low_high_pc.sh \
+ 	run-macro-test.sh run-elf_cntl_gelf_getshdr.sh \
+ 	run-test-archive64.sh $(am__EXEEXT_1) $(am__EXEEXT_3) \
+-	$(am__append_9)
+-@STANDALONE_FALSE@am__append_5 = msg_tst md5-sha1-test
++	$(am__append_10)
+ @STANDALONE_FALSE@am__append_6 = msg_tst md5-sha1-test
+-@HAVE_LIBASM_TRUE@am__append_7 = $(asm_TESTS)
++@STANDALONE_FALSE@am__append_7 = msg_tst md5-sha1-test
+ @HAVE_LIBASM_TRUE@am__append_8 = $(asm_TESTS)
+-@ENABLE_DWZ_TRUE@am__append_9 = run-readelf-dwz-multi.sh
++@HAVE_LIBASM_TRUE@am__append_9 = $(asm_TESTS)
++@ENABLE_DWZ_TRUE@am__append_10 = run-readelf-dwz-multi.sh
+ subdir = tests
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/nls.m4 $(top_srcdir)/m4/po.m4 \
+@@ -412,6 +413,7 @@ INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ INSTALL_SCRIPT = @INSTALL_SCRIPT@
+ INSTALL_STRIP_PROGRAM = @INSTALL_STRIP_PROGRAM@
+ LDFLAGS = @LDFLAGS@
++LD_AS_NEEDED = @LD_AS_NEEDED@
+ LEX = @LEX@
+ LEXLIB = @LEXLIB@
+ LEX_OUTPUT_ROOT = @LEX_OUTPUT_ROOT@
+@@ -441,6 +443,7 @@ SHELL = @SHELL@
+ STRIP = @STRIP@
+ USE_NLS = @USE_NLS@
+ VERSION = @VERSION@
++WEXTRA = @WEXTRA@
+ XGETTEXT = @XGETTEXT@
+ XGETTEXT_015 = @XGETTEXT_015@
+ XGETTEXT_EXTRA_OPTIONS = @XGETTEXT_EXTRA_OPTIONS@
+@@ -499,12 +502,11 @@ top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+ zip_LIBS = @zip_LIBS@
+-INCLUDES = -I. -I$(srcdir) -I$(top_srcdir)/lib -I.. $(am__append_2)
++INCLUDES = -I. -I$(srcdir) -I$(top_srcdir)/lib -I.. $(am__append_3)
+ AM_CFLAGS = -std=gnu99 -Wall -Wshadow $(if \
+-	$($(*F)_no_Werror),,-Werror) $(if \
+-	$($(*F)_no_Wunused),,-Wunused -Wextra) $(if \
++	$($(*F)_no_Wunused),,-Wunused $(WEXTRA)) $(if \
+ 	$($(*F)_no_Wformat),-Wno-format,-Wformat=2) $($(*F)_CFLAGS) \
+-	$(am__append_1)
++	$(am__append_1) $(am__append_2)
+ @MUDFLAP_FALSE@libmudflap = 
+ @MUDFLAP_TRUE@libmudflap = -lmudflap
+ COMPILE.os = $(filter-out -fprofile-arcs -ftest-coverage $(no_mudflap.os),\
+@@ -514,7 +516,7 @@ CLEANFILES = *.gcno *.gcda
+ textrel_check = if readelf -d $@ | fgrep -q TEXTREL; then exit 1; fi
+ @MUDFLAP_FALSE@BUILD_RPATH = \$$ORIGIN/../libasm:\$$ORIGIN/../libdw:\$$ORIGIN/../backends:\$$ORIGIN/../libelf
+ @MUDFLAP_TRUE@BUILD_RPATH = \$$ORIGIN/../backends
+-AM_LDFLAGS = $(am__append_3) $(am__append_4)
++AM_LDFLAGS = $(am__append_4) $(am__append_5)
+ @TESTS_RPATH_FALSE@tests_rpath = no
+ @TESTS_RPATH_TRUE@tests_rpath = yes
+ asm_TESTS = asm-tst1 asm-tst2 asm-tst3 asm-tst4 asm-tst5 \

--- a/libs/elfutils/patches/002-no_tests.patch
+++ b/libs/elfutils/patches/002-no_tests.patch
@@ -1,0 +1,22 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -31,7 +31,7 @@ pkginclude_HEADERS = version.h
+ 
+ # Add doc back when we have some real content.
+ SUBDIRS = config m4 lib libelf libebl libdwfl libdw libcpu libasm backends \
+-	  src po tests
++	  src po
+ 
+ EXTRA_DIST = elfutils.spec GPG-KEY NOTES EXCEPTION
+ 
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -249,7 +249,7 @@ pkginclude_HEADERS = version.h
+ 
+ # Add doc back when we have some real content.
+ SUBDIRS = config m4 lib libelf libebl libdwfl libdw libcpu libasm backends \
+-	  src po tests
++	  src po
+ 
+ EXTRA_DIST = elfutils.spec GPG-KEY NOTES EXCEPTION
+ 

--- a/libs/elfutils/patches/004-memcpy_def.patch
+++ b/libs/elfutils/patches/004-memcpy_def.patch
@@ -1,0 +1,14 @@
+--- a/libelf/libelf.h
++++ b/libelf/libelf.h
+@@ -34,6 +34,11 @@
+ /* Get the ELF types.  */
+ #include <elf.h>
+ 
++#ifndef _LIBC
++#ifndef __mempcpy
++#define __mempcpy mempcpy
++#endif
++#endif
+ 
+ /* Known translation types.  */
+ typedef enum

--- a/libs/elfutils/patches/005-only_libdw_libelf.patch
+++ b/libs/elfutils/patches/005-only_libdw_libelf.patch
@@ -1,0 +1,24 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -23,8 +23,7 @@ ACLOCAL_AMFLAGS = -I m4
+ pkginclude_HEADERS = version.h
+ 
+ # Add doc back when we have some real content.
+-SUBDIRS = config m4 lib libelf libebl libdwfl libdw libcpu libasm backends \
+-	  src po
++SUBDIRS = config m4 lib libelf libebl libdwfl libdw
+ 
+ EXTRA_DIST = elfutils.spec GPG-KEY NOTES CONTRIBUTING \
+ 	     COPYING COPYING-GPLV2 COPYING-LGPLV3
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -258,8 +258,7 @@ ACLOCAL_AMFLAGS = -I m4
+ pkginclude_HEADERS = version.h
+ 
+ # Add doc back when we have some real content.
+-SUBDIRS = config m4 lib libelf libebl libdwfl libdw libcpu libasm backends \
+-	  src po
++SUBDIRS = config m4 lib libelf libebl libdwfl libdw
+ 
+ EXTRA_DIST = elfutils.spec GPG-KEY NOTES CONTRIBUTING \
+ 	     COPYING COPYING-GPLV2 COPYING-LGPLV3

--- a/libs/elfutils/patches/006-libdw_LIBS.patch
+++ b/libs/elfutils/patches/006-libdw_LIBS.patch
@@ -1,0 +1,22 @@
+--- a/libdw/Makefile.am
++++ b/libdw/Makefile.am
+@@ -111,7 +111,7 @@ libdw.so: $(srcdir)/libdw.map libdw_pic.
+ 		-Wl,--enable-new-dtags,-rpath,$(pkglibdir) \
+ 		-Wl,--version-script,$<,--no-undefined \
+ 		-Wl,--whole-archive $(filter-out $<,$^) -Wl,--no-whole-archive\
+-		-ldl $(zip_LIBS)
++		-ldl $(zip_LIBS) $(LIBS)
+ 	if readelf -d $@ | fgrep -q TEXTREL; then exit 1; fi
+ 	ln -fs $@ $@.$(VERSION)
+ 
+--- a/libdw/Makefile.in
++++ b/libdw/Makefile.in
+@@ -845,7 +845,7 @@ uninstall-am: uninstall-includeHEADERS u
+ @MUDFLAP_FALSE@		-Wl,--enable-new-dtags,-rpath,$(pkglibdir) \
+ @MUDFLAP_FALSE@		-Wl,--version-script,$<,--no-undefined \
+ @MUDFLAP_FALSE@		-Wl,--whole-archive $(filter-out $<,$^) -Wl,--no-whole-archive\
+-@MUDFLAP_FALSE@		-ldl $(zip_LIBS)
++@MUDFLAP_FALSE@		-ldl $(zip_LIBS) $(LIBS)
+ @MUDFLAP_FALSE@	if readelf -d $@ | fgrep -q TEXTREL; then exit 1; fi
+ @MUDFLAP_FALSE@	ln -fs $@ $@.$(VERSION)
+ 

--- a/libs/elfutils/patches/007-no_textrel_checks.patch
+++ b/libs/elfutils/patches/007-no_textrel_checks.patch
@@ -1,0 +1,60 @@
+--- a/libasm/Makefile.am
++++ b/libasm/Makefile.am
+@@ -69,7 +69,6 @@ libasm.so: libasm_pic.a libasm.map
+ 		-Wl,--version-script,$(srcdir)/libasm.map,--no-undefined \
+ 		-Wl,--soname,$@.$(VERSION) \
+ 		../libebl/libebl.a ../libelf/libelf.so  $(libasm_so_LDLIBS)
+-	if readelf -d $@ | fgrep -q TEXTREL; then exit 1; fi
+ 	ln -fs $@ $@.$(VERSION)
+ 
+ install: install-am libasm.so
+--- a/libasm/Makefile.in
++++ b/libasm/Makefile.in
+@@ -656,7 +656,6 @@ uninstall-am: uninstall-libLIBRARIES uni
+ @MUDFLAP_FALSE@		-Wl,--version-script,$(srcdir)/libasm.map,--no-undefined \
+ @MUDFLAP_FALSE@		-Wl,--soname,$@.$(VERSION) \
+ @MUDFLAP_FALSE@		../libebl/libebl.a ../libelf/libelf.so  $(libasm_so_LDLIBS)
+-@MUDFLAP_FALSE@	if readelf -d $@ | fgrep -q TEXTREL; then exit 1; fi
+ @MUDFLAP_FALSE@	ln -fs $@ $@.$(VERSION)
+ 
+ @MUDFLAP_FALSE@install: install-am libasm.so
+--- a/libdw/Makefile.am
++++ b/libdw/Makefile.am
+@@ -112,7 +112,6 @@ libdw.so: $(srcdir)/libdw.map libdw_pic.
+ 		-Wl,--version-script,$<,--no-undefined \
+ 		-Wl,--whole-archive $(filter-out $<,$^) -Wl,--no-whole-archive\
+ 		-ldl $(zip_LIBS) $(LIBS)
+-	if readelf -d $@ | fgrep -q TEXTREL; then exit 1; fi
+ 	ln -fs $@ $@.$(VERSION)
+ 
+ install: install-am libdw.so
+--- a/libdw/Makefile.in
++++ b/libdw/Makefile.in
+@@ -846,7 +846,6 @@ uninstall-am: uninstall-includeHEADERS u
+ @MUDFLAP_FALSE@		-Wl,--version-script,$<,--no-undefined \
+ @MUDFLAP_FALSE@		-Wl,--whole-archive $(filter-out $<,$^) -Wl,--no-whole-archive\
+ @MUDFLAP_FALSE@		-ldl $(zip_LIBS) $(LIBS)
+-@MUDFLAP_FALSE@	if readelf -d $@ | fgrep -q TEXTREL; then exit 1; fi
+ @MUDFLAP_FALSE@	ln -fs $@ $@.$(VERSION)
+ 
+ @MUDFLAP_FALSE@install: install-am libdw.so
+--- a/libelf/Makefile.am
++++ b/libelf/Makefile.am
+@@ -106,7 +106,6 @@ libelf.so: libelf_pic.a libelf.map
+ 	$(LINK) -shared -o $@ -Wl,--whole-archive,$<,--no-whole-archive \
+ 		-Wl,--version-script,$(srcdir)/libelf.map,--no-undefined \
+ 		-Wl,--soname,$@.$(VERSION),-z,defs,-z,relro $(libelf_so_LDLIBS)
+-	if readelf -d $@ | fgrep -q TEXTREL; then exit 1; fi
+ 	ln -fs $@ $@.$(VERSION)
+ 
+ install: install-am libelf.so
+--- a/libelf/Makefile.in
++++ b/libelf/Makefile.in
+@@ -832,7 +832,6 @@ uninstall-am: uninstall-includeHEADERS u
+ @MUDFLAP_FALSE@	$(LINK) -shared -o $@ -Wl,--whole-archive,$<,--no-whole-archive \
+ @MUDFLAP_FALSE@		-Wl,--version-script,$(srcdir)/libelf.map,--no-undefined \
+ @MUDFLAP_FALSE@		-Wl,--soname,$@.$(VERSION),-z,defs,-z,relro $(libelf_so_LDLIBS)
+-@MUDFLAP_FALSE@	if readelf -d $@ | fgrep -q TEXTREL; then exit 1; fi
+ @MUDFLAP_FALSE@	ln -fs $@ $@.$(VERSION)
+ 
+ @MUDFLAP_FALSE@install: install-am libelf.so


### PR DESCRIPTION
Import elfutils: libelf1 and libdw from the old packages repository.

Signed-off-by: Florian Fainelli florian@openwrt.org
