### PR TITLE
python-imglib: import version 1.1.7 of Python Imaging Library

### DIFF
--- a/lang/python-imglib/Makefile
+++ b/lang/python-imglib/Makefile
@@ -1,0 +1,62 @@
+#
+# Copyright (c) 1997-2009 by Secret Labs AB
+# Copyright (c) 1995-2009 by Fredrik Lundh
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-imglib
+PKG_VERSION:=1.1.7
+PKG_RELEASE:=1
+PKG_LICENSE:=CUSTOM
+PKG_LICENSE_FILES:=README
+
+PKG_SOURCE:=Imaging-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://effbot.org/downloads
+PKG_MD5SUM:=fc14a54e1ce02a0225be8854bfba478e
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/Imaging-$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/python-imglib
+  SECTION:=language-python
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Python Imaging Library (PIL)
+  MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
+  URL:=http://www.pythonware.com/products/pil/
+  DEPENDS:=+python +libfreetype +libjpeg +zlib
+endef
+
+define Package/python-imglib/description
+ The Python Imaging Library adds image processing capabilities to your
+ Python interpreter.
+
+ This library provides extensive file format support, an efficient
+ internal representation, and fairly powerful image processing
+ capabilities.
+
+ The core image library is designed for fast access to data stored in a
+ few basic pixel formats. It should provide a solid foundation for a
+ general image processing tool.
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,., \
+		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)", \
+	)
+endef
+
+define Package/python-imglib/install
+	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) \
+		$(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
+		$(1)$(PYTHON_PKG_DIR)/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,python-imglib))

--- a/lang/python-imglib/patches/010-cross-compile.patch
+++ b/lang/python-imglib/patches/010-cross-compile.patch
@@ -1,0 +1,48 @@
+diff -rupN Imaging-1.1.7.orig/setup.py Imaging-1.1.7/setup.py
+--- Imaging-1.1.7.orig/setup.py	2009-11-15 17:06:10.000000000 +0100
++++ Imaging-1.1.7/setup.py	2014-12-11 01:01:10.857100877 +0100
+@@ -34,10 +34,10 @@ def libinclude(root):
+ # TIFF_ROOT = libinclude("/opt/tiff")
+ 
+ TCL_ROOT = None
+-JPEG_ROOT = None
+-ZLIB_ROOT = None
++JPEG_ROOT = os.environ['STAGING_DIR'] + "/usr/lib", os.environ['STAGING_DIR'] + "/usr/include"
++ZLIB_ROOT = os.environ['STAGING_DIR'] + "/usr/lib", os.environ['STAGING_DIR'] + "/usr/include"
+ TIFF_ROOT = None
+-FREETYPE_ROOT = None
++FREETYPE_ROOT = os.environ['STAGING_DIR'] + "/usr/lib", os.environ['STAGING_DIR'] + "/usr/include"
+ LCMS_ROOT = None
+ 
+ # FIXME: add mechanism to explicitly *disable* the use of a library
+@@ -147,7 +147,6 @@ class pil_build_ext(build_ext):
+             add_directory(library_dirs, "/opt/local/lib")
+             add_directory(include_dirs, "/opt/local/include")
+ 
+-        add_directory(library_dirs, "/usr/local/lib")
+         # FIXME: check /opt/stuff directories here?
+ 
+         prefix = sysconfig.get_config_var("prefix")
+@@ -199,22 +198,6 @@ class pil_build_ext(build_ext):
+             add_directory(include_dirs, include_root)
+ 
+         #
+-        # add standard directories
+-
+-        # look for tcl specific subdirectory (e.g debian)
+-        if _tkinter:
+-            tcl_dir = "/usr/include/tcl" + TCL_VERSION
+-            if os.path.isfile(os.path.join(tcl_dir, "tk.h")):
+-                add_directory(include_dirs, tcl_dir)
+-
+-        # standard locations
+-        add_directory(library_dirs, "/usr/local/lib")
+-        add_directory(include_dirs, "/usr/local/include")
+-
+-        add_directory(library_dirs, "/usr/lib")
+-        add_directory(include_dirs, "/usr/include")
+-
+-        #
+         # insert new dirs *before* default libs, to avoid conflicts
+         # between Python PYD stub libs and real libraries
+ 

--- a/lang/python-imglib/patches/020-freetype-header-include.patch
+++ b/lang/python-imglib/patches/020-freetype-header-include.patch
@@ -1,0 +1,21 @@
+diff -rupN Imaging-1.1.7.orig/_imagingft.c Imaging-1.1.7/_imagingft.c
+--- Imaging-1.1.7.orig/_imagingft.c	2009-11-01 01:44:12.000000000 +0100
++++ Imaging-1.1.7/_imagingft.c	2014-12-11 01:05:21.290135484 +0100
+@@ -32,7 +32,7 @@
+ #include FT_FREETYPE_H
+ #else
+ /* freetype 2.0 */
+-#include <freetype/freetype.h>
++#include <freetype2/freetype.h>
+ #endif
+ 
+ #if PY_VERSION_HEX < 0x01060000
+@@ -70,7 +70,7 @@ struct {
+     const char* message;
+ } ft_errors[] =
+ 
+-#include <freetype/fterrors.h>
++#include <freetype2/fterrors.h>
+ 
+ /* -------------------------------------------------------------------- */
+ /* font objects */


### PR DESCRIPTION
Imports the Python Imaging Library version 1.1.7.

Signed-off-by: Gergely Kiss &lt;mail.gery@gmail.com&gt;
Tested-by: Gergely Kiss &lt;mail.gery@gmail.com&gt;
