### PR TITLE
simplejson: import version 3.6.5

### DIFF
--- a/lang/simplejson/Makefile
+++ b/lang/simplejson/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=simplejson
+PKG_VERSION:=3.6.5
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://pypi.python.org/packages/source/s/simplejson/
+PKG_MD5SUM:=b65dc21c7aaad14c6b4ad0d9179e437d
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/simplejson
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
+  TITLE:=Simple, fast, extensible JSON encoder/decoder for Python
+  URL:=http://simplejson.readthedocs.org/
+  DEPENDS:=+python
+endef
+
+define Package/simplejson/description
+  Simple, fast, extensible JSON encoder/decoder for Python
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+endef
+
+define Package/simplejson/install
+	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
+	$(CP) \
+	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
+	    $(1)$(PYTHON_PKG_DIR)
+endef
+
+$(eval $(call BuildPackage,simplejson))


### PR DESCRIPTION
Pulls version 3.6.5 of the simplejson Python package

Signed-off-by: Gergely Kiss &lt;mail.gery@gmail.com&gt;
Tested-by: Gergely Kiss &lt;mail.gery@gmail.com&gt;
