### PR TITLE
jansson: import version 2.7

### DIFF
--- a/libs/jansson/Makefile
+++ b/libs/jansson/Makefile
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2011-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=jansson
+PKG_VERSION:=2.7
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.digip.org/jansson/releases/
+PKG_MD5SUM:=3a106a465bbb77637550b422f5b262ef
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/jansson
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Jansson library
+  URL:=http://www.digip.org/jansson/
+  MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
+endef
+
+define Package/jansson/description
+  Jansson is a C library for encoding, decoding and manipulating JSON data
+endef
+
+TARGET_CFLAGS += $(FPIC)
+TARGET_LDFLAGS += -Wl,-rpath-link=$(STAGING_DIR)/usr/lib -lm
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/{lib,include}
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libjansson* $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/* $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+endef
+
+define Package/jansson/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libjansson*so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,jansson))


### PR DESCRIPTION
Adds package definition for the jansson library version 2.7.

Signed-off-by: Gergely Kiss &lt;mail.gery@gmail.com&gt;
Tested-by: Gergely Kiss &lt;mail.gery@gmail.com&gt;
