### PR TITLE
libevhtp: add version 1.2.9

### DIFF
--- a/libs/libevhtp/Makefile
+++ b/libs/libevhtp/Makefile
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2007-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libevhtp
+PKG_VERSION:=1.2.9
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD-3-Clause
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/ellzey/libevhtp/archive/
+PKG_MD5SUM:=428a8d179fcc0cadedd914ed6456e08f
+PKG_CAT:=zcat
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libevhtp
+    SECTION:=libs
+    CATEGORY:=Libraries
+    TITLE:=A more flexible replacement for libevent's httpd API
+    MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
+    URL:=https://github.com/ellzey/libevhtp
+    DEPENDS:=+libevent2 +libevent2-openssl +libevent2-pthreads +libopenssl +libpthread
+endef
+
+define Package/libevhtp/description
+   Libevhtp was created as a replacement API for Libevent's current HTTP API.
+   The reality of libevent's http interface is that it was created as a JIT server,
+   meaning the developer never thought of it being used for creating a full-fledged HTTP service.
+endef
+
+include $(INCLUDE_DIR)/cmake.mk
+
+Hooks/Prepare/Post += delete_source_package
+
+define delete_source_package
+	# deleting source package as its filename is ambiguous
+	rm -f $(DL_DIR)/$(PKG_SOURCE)
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/{include,lib}
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevhtp.so* $(1)/usr/lib/
+
+endef
+
+define Package/libevhtp/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevhtp.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libevhtp))

--- a/libs/libevhtp/patches/010-enable-shared-object-building.patch
+++ b/libs/libevhtp/patches/010-enable-shared-object-building.patch
@@ -1,0 +1,12 @@
+diff -rupN libevhtp-1.2.9.orig/CMakeLists.txt libevhtp-1.2.9/CMakeLists.txt
+--- libevhtp-1.2.9.orig/CMakeLists.txt	2014-03-23 12:50:50.000000000 +0100
++++ libevhtp-1.2.9/CMakeLists.txt	2014-11-21 11:46:58.644575813 +0100
+@@ -64,7 +64,7 @@ OPTION(EVHTP_DISABLE_EVTHR     "Disable
+ OPTION(EVHTP_DISABLE_REGEX     "Disable regex support"    OFF)
+ 
+ # -DEVHTP_BUILD_SHARED:STRING=ON
+-OPTION(EVHTP_BUILD_SHARED      "Build shared library too" OFF)
++OPTION(EVHTP_BUILD_SHARED      "Build shared library too" ON)
+ 
+ # -DEVHTP_USE_DEFER_ACCEPT:STRING=ON
+ OPTION(EVHTP_USE_DEFER_ACCEPT  "Enable TCP_DEFER_ACCEPT"  OFF)

--- a/libs/libevhtp/patches/020-strcmp-endianness-fix.patch
+++ b/libs/libevhtp/patches/020-strcmp-endianness-fix.patch
@@ -1,0 +1,49 @@
+diff -rupN libevhtp-1.2.9.orig/htparse/htparse.c libevhtp-1.2.9/htparse/htparse.c
+--- libevhtp-1.2.9.orig/htparse/htparse.c	2014-03-23 12:50:50.000000000 +0100
++++ libevhtp-1.2.9/htparse/htparse.c	2014-12-09 01:12:22.242001241 +0100
+@@ -197,6 +197,7 @@ static const char * method_strmap[] = {
+ 
+ #define _MIN_READ(a, b) ((a) < (b) ? (a) : (b))
+ 
++#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+ #define _str3_cmp(m, c0, c1, c2, c3) \
+     *(uint32_t *)m == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)
+ 
+@@ -226,6 +227,37 @@ static const char * method_strmap[] = {
+     *(uint32_t *)m == ((c3 << 24) | (c2 << 16) | (c1 << 8) | c0)        \
+     && ((uint32_t *)m)[1] == ((c7 << 24) | (c6 << 16) | (c5 << 8) | c4) \
+     && m[8] == c8
++#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
++#define _str3_cmp(m, c0, c1, c2, c3) \
++    *(uint32_t *)m == ((c0 << 24) | (c1 << 16) | (c2 << 8) | c3)
++
++#define _str3Ocmp(m, c0, c1, c2, c3) \
++    *(uint32_t *)m == ((c0 << 24) | (c1 << 16) | (c2 << 8) | c3)
++
++#define _str4cmp(m, c0, c1, c2, c3) \
++    *(uint32_t *)m == ((c0 << 24) | (c1 << 16) | (c2 << 8) | c3)
++
++#define _str5cmp(m, c0, c1, c2, c3, c4)                          \
++    *(uint32_t *)m == ((c0 << 24) | (c1 << 16) | (c2 << 8) | c3) \
++    && m[4] == c4
++
++#define _str6cmp(m, c0, c1, c2, c3, c4, c5)                      \
++    *(uint32_t *)m == ((c0 << 24) | (c1 << 16) | (c2 << 8) | c3) \
++    && (((uint32_t *)m)[1] & 0xffff0000) == ((c4 << 24) | c5 << 16)
++
++#define _str7_cmp(m, c0, c1, c2, c3, c4, c5, c6, c7)             \
++    *(uint32_t *)m == ((c0 << 24) | (c1 << 16) | (c2 << 8) | c3) \
++    && ((uint32_t *)m)[1] == ((c4 << 24) | (c5 << 16) | (c6 << 8) | c7)
++
++#define _str8cmp(m, c0, c1, c2, c3, c4, c5, c6, c7)              \
++    *(uint32_t *)m == ((c0 << 24) | (c1 << 16) | (c2 << 8) | c3) \
++    && ((uint32_t *)m)[1] == ((c4 << 24) | (c5 << 16) | (c6 << 8) | c7)
++
++#define _str9cmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8)                 \
++    *(uint32_t *)m == ((c0 << 24) | (c1 << 16) | (c2 << 8) | c3)        \
++    && ((uint32_t *)m)[1] == ((c4 << 24) | (c5 << 16) | (c6 << 8) | c7) \
++    && m[8] == c8
++#endif
+ 
+ #define __HTPARSE_GENHOOK(__n)                                                    \
+     static inline int hook_ ## __n ## _run(htparser * p, htparse_hooks * hooks) { \


### PR DESCRIPTION
Imports version 1.2.9 of the libevhtp library.

Signed-off-by: Gergely Kiss &lt;mail.gery@gmail.com&gt;
Tested-by: Gergely Kiss &lt;mail.gery@gmail.com&gt;
