### PR TITLE
libzdb: import version 3.0

### DIFF
--- a/libs/libzdb/Makefile
+++ b/libs/libzdb/Makefile
@@ -1,0 +1,90 @@
+#
+# Copyright (C) 2007-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libzdb
+PKG_VERSION:=3.0
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-3.0
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.tildeslash.com/libzdb/dist/
+PKG_MD5SUM:=3bb9efff10a1f3ebc5b76c1055c48635
+PKG_CAT:=zcat
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+PKG_BUILD_DEPENDS:=libzdb/host
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libzdb
+    SECTION:=libs
+    CATEGORY:=Libraries
+    TITLE:=A thread-safe multi database connection pool library
+    MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
+    URL:=http://www.tildeslash.com/libzdb/
+    DEPENDS:=+libsqlite3 +libpq +libmysqlclient +zlib +libpthread +libopenssl
+endef
+
+define Package/libzdb/description
+   zdb is a database library with thread-safe connection pooling. The library can connect
+   transparently to multiple database systems. It has zero runtime configuration and connections
+   are specified via a URL scheme. A modern object-oriented API is provided.
+   zdb supports MySQL, PostgreSQL, SQLite, and Oracle.
+   NOTE: This package does not include Oracle support.
+endef
+
+CONFIGURE_ARGS += --disable-profiling \
+		    --enable-optimized \
+		    --with-mysql \
+		    --with-postgresql \
+		    --with-sqlite \
+		    --enable-sqliteunlock \
+		    --enable-openssl
+
+TARGET_CPPFLAGS += -std=c99
+
+include $(INCLUDE_DIR)/host-build.mk
+
+define Hooks/HostConfigure/Pre
+endef
+
+define Host/Configure
+endef
+
+define Host/Compile
+	$(HOSTCC) $(HOST_BUILD_DIR)/tools/filterh/lex.yy.c -o $(HOST_BUILD_DIR)/tools/bin/filterh
+endef
+
+define Host/Install
+	$(INSTALL_DIR) $(STAGING_DIR_HOST)/bin
+	$(CP) $(HOST_BUILD_DIR)/tools/bin/filterh $(STAGING_DIR_HOST)/bin/
+endef
+
+$(eval $(call HostBuild))
+
+define Build/Compile
+	$(call Build/Compile/Default)
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/zdb
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/zdb/ $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libzdb* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/zdb.pc $(1)/usr/lib/pkgconfig
+endef
+
+define Package/libzdb/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libzdb.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libzdb))

--- a/libs/libzdb/patches/010-cross-compile-fixes.patch
+++ b/libs/libzdb/patches/010-cross-compile-fixes.patch
@@ -1,0 +1,186 @@
+diff -rupN libzdb-3.0.orig/configure.ac libzdb-3.0/configure.ac
+--- libzdb-3.0.orig/configure.ac	2014-01-06 22:17:57.000000000 +0100
++++ libzdb-3.0/configure.ac	2014-11-20 13:59:27.456957651 +0100
+@@ -196,15 +196,6 @@ AC_SEARCH_LIBS([pthread_create], [pthrea
+ # Database Libraries 
+ 
+ mysql="yes"
+-check_mysql_config() 
+-{
+-        AC_PATH_PROG([MYSQLCONFIG], [mysql_config], [no], [$PATH:/usr/local/bin:/usr/local/mysql/bin])
+-        if test "x$MYSQLCONFIG" = "xno" 
+-        then
+-                AC_MSG_WARN([mysql_config is required to build libzdb with mysql])
+-                mysql="no"
+-        fi
+-}
+ AC_MSG_CHECKING(for mysql)
+ AC_ARG_WITH([mysql], 
+         AS_HELP_STRING([--with-mysql(=<path>)], 
+@@ -216,22 +207,20 @@ AC_ARG_WITH([mysql],
+                         mysql="no"
+                 else
+                         AC_MSG_RESULT([yes])
+-                        AC_CHECK_FILE([$with_mysql], [MYSQLCONFIG=$with_mysql], [check_mysql_config])        
+                 fi
+         ],
+         [
+                 AC_MSG_RESULT([yes])
+-                check_mysql_config
+         ])
+ if test "xyes" = "x$mysql"; then
+         svd_CPPFLAGS=$CPPFLAGS
+         svd_LDFLAGS=$LDFLAGS
+-        CPPFLAGS="`$MYSQLCONFIG --include` $CPPFLAGS"
+-        LDFLAGS="`$MYSQLCONFIG --libs` $LDFLAGS"
++        CPPFLAGS="-I$STAGING_DIR/usr/include/mysql $CPPFLAGS"
++        LDFLAGS="-L$STAGING_DIR/usr/lib/mysql -L$STAGING_DIR/usr/lib $LDFLAGS"
+         AC_CHECK_HEADERS([mysql.h], [], [mysql="no"])
+         if test "xyes" = "x$mysql"; then
+-                DBCPPFLAGS="$DBCPPFLAGS `$MYSQLCONFIG --include`"
+-                DBLDFLAGS="$DBLDFLAGS `$MYSQLCONFIG --libs`"
++                DBCPPFLAGS="$DBCPPFLAGS -I$STAGING_DIR/usr/include/mysql"
++                DBLDFLAGS="$DBLDFLAGS -L$STAGING_DIR/usr/lib/mysql -L$STAGING_DIR/usr/lib -lmysqlclient -lz -lcrypt -lnsl -lm"
+                 AC_DEFINE([HAVE_LIBMYSQLCLIENT], 1, [Define to 1 to enable mysql])
+         else
+                 CPPFLAGS=$svd_CPPFLAGS
+@@ -241,15 +230,6 @@ fi
+ AM_CONDITIONAL([WITH_MYSQL], test "xyes" = "x$mysql")
+ 
+ postgresql="yes"
+-check_postgres_config() 
+-{
+-        AC_PATH_PROG([PGCONFIG], [pg_config], [no], [$PATH:/usr/local/bin:/usr/local/pgsql/bin])
+-        if test "x$PGCONFIG" = "xno"
+-        then
+-                AC_MSG_WARN([pg_config is required to build libzdb with postgresql])
+-                postgresql="no"
+-        fi
+-}
+ AC_MSG_CHECKING(for postgresql)
+ AC_ARG_WITH([postgresql], 
+         AS_HELP_STRING([--with-postgresql(=<path>)], 
+@@ -261,22 +241,20 @@ AC_ARG_WITH([postgresql],
+                         postgresql="no"
+                 else
+                         AC_MSG_RESULT([yes])
+-                        AC_CHECK_FILE([$with_postgresql], [PGCONFIG=$with_postgresql],[check_postgres_config])
+                 fi
+         ],
+         [
+                 AC_MSG_RESULT([yes])
+-                check_postgres_config
+         ])
+ if test "xyes" = "x$postgresql"; then
+         svd_CPPFLAGS=$CPPFLAGS
+         svd_LDFLAGS=$LDFLAGS
+-        CPPFLAGS="-I`$PGCONFIG --includedir` $CPPFLAGS"
+-        LDFLAGS="-L`$PGCONFIG --libdir` $LDFLAGS"
++        CPPFLAGS="-I$STAGING_DIR/usr/include/postgresql -I$STAGING_DIR/usr/include $CPPFLAGS"
++        LDFLAGS="-L$STAGING_DIR/usr/lib $LDFLAGS"
+         AC_CHECK_HEADERS([libpq-fe.h], [], [postgresql="no"])
+         if test "xyes" = "x$postgresql"; then
+-                DBCPPFLAGS="$DBCPPFLAGS -I`$PGCONFIG --includedir`"
+-                DBLDFLAGS="$DBLDFLAGS -L`$PGCONFIG --libdir` -lpq"
++                DBCPPFLAGS="$DBCPPFLAGS -I$STAGING_DIR/usr/include/postgresql -I$STAGING_DIR/usr/include"
++                DBLDFLAGS="$DBLDFLAGS -L$STAGING_DIR/usr/lib -lpq"
+                 AC_DEFINE([HAVE_LIBPQ], 1, [Define to 1 to enable postgresql])
+         else
+                 CPPFLAGS=$svd_CPPFLAGS
+@@ -298,22 +276,7 @@ AC_ARG_WITH([sqlite],
+                         sqlite="no"
+                 else
+                         AC_MSG_RESULT([yes])
+-                        AC_CHECK_FILE([$with_sqlite],
+-                        [
+-                                svd_LDFLAGS=$LDFLAGS
+-                                svd_CPPFLAGS=$CPPFLAGS
+-                                LDFLAGS="-L$with_sqlite/lib $LDFLAGS -lsqlite3"
+-                                CPPFLAGS="-I$with_sqlite/include $CPPFLAGS"
+-                                AC_SEARCH_LIBS([sqlite3_open], [sqlite3],
+-                                [
+-                                        DBCPPFLAGS="$DBCPPFLAGS -I$with_sqlite/include"
+-                                        DBLDFLAGS="$DBLDFLAGS -L$with_sqlite/lib/ -lsqlite3"
+-                                ],[sqlite="no"])
+-                                LDFLAGS=$svd_LDFLAGS
+-                                CPPFLAGS=$svd_CPPFLAGS
+-   
+-                        ],
+-                        AC_SEARCH_LIBS([sqlite3_open], [sqlite3], [], [sqlite="no"]))
++                        AC_SEARCH_LIBS([sqlite3_open], [sqlite3], [], [sqlite="no"])
+                 fi
+         ], 
+         [
+@@ -328,20 +291,8 @@ if test "xyes" = "x$sqlite"; then
+ fi
+ AM_CONDITIONAL([WITH_SQLITE], test "xyes" = "x$sqlite")
+ 
+-oracle="yes"
+-AC_MSG_CHECKING(for oracle)
+-AX_LIB_ORACLE_OCI
+-if test -n "$ORACLE_OCI_CFLAGS" -a -n "$ORACLE_OCI_LDFLAGS"; then
+-        DBCPPFLAGS="$DBCPPFLAGS $ORACLE_OCI_CFLAGS"
+-        DBLDFLAGS="$DBLDFLAGS $ORACLE_OCI_LDFLAGS"
+-        AC_DEFINE([HAVE_ORACLE], 1, [Define to 1 to enable oracle])
+-else
+-        oracle="no"
+-fi
+-AM_CONDITIONAL([WITH_ORACLE], test "xyes" = "x$oracle")
+-
+ # Test if any database system was found
+-if test "xno" = "x$postgresql" -a "xno" = "x$mysql" -a "xno" = "x$sqlite" -a "xno" = "x$oracle"; then
++if test "xno" = "x$postgresql" -a "xno" = "x$mysql" -a "xno" = "x$sqlite"; then
+         AC_MSG_ERROR([No available database found or selected. Try configure --help])
+ fi
+ 
+@@ -358,23 +309,6 @@ AC_HEADER_STDC
+ # Functions 
+ # ------------------------------------------------------------------------
+ 
+-# Require a working setjmp
+-AC_RUN_IFELSE([AC_LANG_PROGRAM([[
+-        #include <setjmp.h>
+-        ]],
+-        [[jmp_buf env; setjmp(env);]])], 
+-        [], [AC_MSG_FAILURE([setjmp is required])]
+-)
+-
+-# Require that we have vsnprintf that conforms to c99. I.e. does bounds check
+-AC_RUN_IFELSE([AC_LANG_PROGRAM([[
+-        #include <stdarg.h> 
+-        #include <stdio.h>
+-        ]],
+-        [[char t[1]; va_list ap; int n = vsnprintf(t, 1, "hello", ap); if(n == 5) return 0;return 1;]])], 
+-        [], [AC_MSG_FAILURE([vsnprintf does not conform to c99])]
+-)
+-
+ AC_CHECK_FUNCS([timegm])
+ 
+ 
+@@ -487,11 +421,6 @@ echo "|   PostgreSQL:
+ else
+ echo "|   PostgreSQL:                                   DISABLED   |"
+ fi
+-if test "xyes" = "x$oracle"; then
+-echo "|   Oracle:                                       ENABLED    |"
+-else
+-echo "|   Oracle:                                       DISABLED   |"
+-fi
+ echo "+------------------------------------------------------------+"
+ 
+ 
+diff -rupN libzdb-3.0.orig/Makefile.am libzdb-3.0/Makefile.am
+--- libzdb-3.0.orig/Makefile.am	2014-01-06 22:34:08.000000000 +0100
++++ libzdb-3.0/Makefile.am	2014-11-20 13:51:22.508204689 +0100
+@@ -45,11 +45,6 @@ libzdb_la_SOURCES += src/db/sqlite/SQLit
+                      src/db/sqlite/SQLiteResultSet.c \
+                      src/db/sqlite/SQLitePreparedStatement.c
+ endif
+-if WITH_ORACLE
+-libzdb_la_SOURCES += src/db/oracle/OracleConnection.c \
+-                     src/db/oracle/OracleResultSet.c \
+-                     src/db/oracle/OraclePreparedStatement.c
+-endif
+ 
+ API_INTERFACES  = src/zdb.h src/db/ConnectionPool.h src/db/Connection.h \
+                   src/db/ResultSet.h src/net/URL.h src/db/PreparedStatement.h \

--- a/libs/libzdb/patches/020-filterh-use-host-built-version.patch
+++ b/libs/libzdb/patches/020-filterh-use-host-built-version.patch
@@ -1,0 +1,20 @@
+diff -rupN libzdb-3.0.orig/Makefile.am libzdb-3.0/Makefile.am
+--- libzdb-3.0.orig/Makefile.am	2014-01-06 22:34:08.000000000 +0100
++++ libzdb-3.0/Makefile.am	2014-11-19 20:26:20.588547729 +0100
+@@ -1,5 +1,7 @@
+ # Copyright (C) Tildeslash Ltd. All rights reserved.
+ 
++include $(TOPDIR)/rules.mk
++
+ AUTOMAKE_OPTIONS = foreign no-dependencies subdir-objects
+ ACLOCAL_AMFLAGS  = -I m4
+ 
+@@ -12,7 +14,7 @@ LIBRARY_NAME    = zdb
+ 
+ RE2C		= @RE2C@
+ RE2CFLAGS       = -b
+-FILTERH         = ./tools/bin/filterh
++FILTERH         = $(STAGING_DIR_HOST)/bin/filterh
+ 
+ AM_CPPFLAGS     = $(CPPFLAGS) $(DBCPPFLAGS)
+ AM_CPPFLAGS     += -Isrc -Isrc/util -Isrc/net -Isrc/db -Isrc/exceptions


### PR DESCRIPTION
Imports the libzdb library (without Oracle support).

Signed-off-by: Gergely Kiss &lt;mail.gery@gmail.com&gt;
Tested-by: Gergely Kiss &lt;mail.gery@gmail.com&gt;
