### PR TITLE
ruby: update to 2.1.5

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -10,14 +10,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=2.1.4
+PKG_VERSION:=2.1.5
 PKG_RELEASE:=1
 
 PKG_LIBVER:=2.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://cache.ruby-lang.org/pub/ruby/$(PKG_LIBVER)/
-PKG_MD5SUM:=f4136e781d261e3cc20748005e1740b7
+PKG_MD5SUM:=a7c3e5fec47eff23091b566e9e1dac1b
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Ruby 2.1.5 has been released.

This release includes a security fix for a DoS vulnerability of REXML.
It is similar to the fixed vulnerability in the previous release, but
new and different from it.

CVE-2014-8090: Another Denial of Service XML Expansion
And, some bug fixes are also included. See tickets and ChangeLog for details.

Fixes #645 

Signed-off-by: Luiz Angelo Daros de Luca luizluca@gmail.com
