### PR TITLE
sudo: use hardcoded /var/lib instead of getting from compiling host

### DIFF
--- a/admin/sudo/Makefile
+++ b/admin/sudo/Makefile
@@ -47,7 +47,9 @@ CONFIGURE_ARGS+= \
 	--disable-pam-session \
 	--with-editor=/bin/vi \
 	--without-lecture \
-	--disable-zlib
+	--disable-zlib \
+	--with-rundir=/var/lib/sudo \
+	--with-vardir=/var/lib/sudo
 
 CONFIGURE_VARS+= \
 	sudo_cv_uid_t_len=10 \


### PR DESCRIPTION
At least for me, sudo package is looking for /var/db/sudo, no /var/lib/sudo

Signed-off-by: Julen Landa Alustiza julen@zokormazo.info
