### PR TITLE
libs: libwebsockets: add latest released version

### DIFF
--- a/libs/libwebsockets/Makefile
+++ b/libs/libwebsockets/Makefile
@@ -1,0 +1,83 @@
+#
+# Copyright (C) 2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libwebsockets
+
+PKG_VERSION:=1.3-chrome37-firefox30
+PKG_RELEASE:=1
+PKG_SOURCE:=v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/warmcat/$(PKG_NAME)/archive/
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_SOURCE_SUBDIR)
+PKG_LICENSE:=LGPL-2.1+exception
+PKG_LICENSE_FILES:=LICENSE
+
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+CMAKE_OPTIONS += $(if $(CONFIG_PACKAGE_kmod-ipv6),,-DLWS_IPV6=)
+
+CMAKE_OPTIONS += -DLWS_WITHOUT_TESTAPPS=ON
+
+# other options worth noting
+# CMAKE_OPTIONS += -DLWS_WITHOUT_EXTENSIONS=ON
+# CMAKE_OPTIONS += -DLWS_WITHOUT_DAEMONIZE=ON
+# CMAKE_OPTIONS += -DLWS_WITHOUT_SERVER=ON
+# CMAKE_OPTIONS += -DLWS_WITHOUT_DEBUG=ON
+
+
+define Package/$(PKG_NAME)/Default
+	SECTION:=libs
+	CATEGORY:=Libraries
+	TITLE:=libwebsockets
+	DEPENDS:=+zlib
+endef
+
+define Package/libwebsockets-openssl
+	$(call Package/$(PKG_NAME)/Default)
+	TITLE += (OpenSSL)
+	DEPENDS += +libopenssl
+	VARIANT:=openssl
+endef
+
+define Package/libwebsockets-cyassl
+	$(call Package/$(PKG_NAME)/Default)
+	TITLE += (CyaSSL)
+	DEPENDS += +libcyassl
+	VARIANT:=cyassl
+endef
+
+ifeq ($(BUILD_VARIANT),openssl)
+    CMAKE_OPTIONS += -DLWS_OPENSSL_CLIENT_CERTS=/etc/ssl/certs
+    CMAKE_OPTIONS += -DLWS_OPENSSL_SUPPORT=ON
+    CMAKE_OPTIONS += -DLWS_WITH_SSL=ON
+endif
+
+ifeq ($(BUILD_VARIANT),cyassl)
+    CMAKE_OPTIONS += -DLWS_OPENSSL_CLIENT_CERTS=/etc/ssl/certs
+    CMAKE_OPTIONS += -DLWS_OPENSSL_SUPPORT=ON
+    CMAKE_OPTIONS += -DLWS_WITH_SSL=ON
+# for cyassl, edit package/libs/cyassl/Makefile to include --enable-opensslextra
+# NOTE: it will compile without it, untested whether it it's needed?!
+    CMAKE_OPTIONS += -DLWS_USE_CYASSL=ON
+    CMAKE_OPTIONS += -DLWS_CYASSL_LIB=$(STAGING_DIR)/usr/lib/libcyassl.so
+    CMAKE_OPTIONS += -DLWS_CYASSL_INCLUDE_DIRS=$(STAGING_DIR)/usr/include
+endif
+
+define Package/libwebsockets/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libwebsockets.so* $(1)/usr/lib/
+endef
+
+Package/$(PKG_NAME)-cyassl/install = $(Package/$(PKG_NAME)/install)
+Package/$(PKG_NAME)-openssl/install = $(Package/$(PKG_NAME)/install)
+
+$(eval $(call BuildPackage,libwebsockets-openssl))
+$(eval $(call BuildPackage,libwebsockets-cyassl))

--- a/libs/libwebsockets/patches/0001-cyassl-correct-include-path-for-3.1.x.patch
+++ b/libs/libwebsockets/patches/0001-cyassl-correct-include-path-for-3.1.x.patch
@@ -1,0 +1,25 @@
+From 4fb4a2353db521667d1ec61480bf8179bf585d5f Mon Sep 17 00:00:00 2001
+From: Karl Palsson <karlp@remake.is>
+Date: Thu, 14 Aug 2014 16:30:48 +0000
+Subject: [PATCH] cyassl: correct include path for 3.1.x
+
+---
+ lib/private-libwebsockets.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/private-libwebsockets.h b/lib/private-libwebsockets.h
+index 4194498..fbd22b5 100755
+--- a/lib/private-libwebsockets.h
++++ b/lib/private-libwebsockets.h
+@@ -155,7 +155,7 @@
+ #ifdef LWS_OPENSSL_SUPPORT
+ #ifdef USE_CYASSL
+ #include <cyassl/openssl/ssl.h>
+-#include <cyassl/error.h>
++#include <cyassl/error-ssl.h>
+ unsigned char *
+ SHA1(const unsigned char *d, size_t n, unsigned char *md);
+ #else
+-- 
+1.8.3.1
+


### PR DESCRIPTION
This includes a patch for cyassl building that has been committed
upstream, but not released.

No SPDX license identifier is used, as this is LGPL+linking exception,
which doesn't seem to be covered by SPDX.

See also: https://github.com/warmcat/libwebsockets/issues/170

Signed-off-by: Karl Palsson karlp@remake.is
