### PR TITLE
lang: lua-mosquitto: import new package

### DIFF
--- a/lang/lua-mosquitto/Makefile
+++ b/lang/lua-mosquitto/Makefile
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2013 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=lua-mosquitto
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=v$(PKG_VERSION).tar.gz
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/flukso/$(PKG_NAME)/archive/
+PKG_MD5SUM:=fd26fa08fc855ba4a66ce521fe5aae13
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+    SUBMENU:=Lua
+    SECTION:=lang
+    CATEGORY:=Languages
+    TITLE:=Lua-mosquitto
+    DEPENDS:=+libmosquitto +lua
+    MAINTAINER:=Karl Palsson <karlp@remake.is>
+endef
+
+define Package/$(PKG_NAME)/description
+	Lua bindings to libmosquitto
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/mosquitto.so $(1)/usr/lib/lua
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
Based on released version of lua binding to libmosquitto.
Advantages compared to lua-mqtt:
- qos 1/2 support
- substantially faster

Signed-off-by: Karl Palsson karlp@remake.is
