### PR TITLE
minidlna: Add path to correct PID file for start-stop-daemon

### DIFF
--- a/multimedia/minidlna/Makefile
+++ b/multimedia/minidlna/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=minidlna
 PKG_VERSION:=1.1.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/minidlna

--- a/multimedia/minidlna/files/minidlna.init
+++ b/multimedia/minidlna/files/minidlna.init
@@ -4,6 +4,7 @@
 START=50
 
 SERVICE_USE_PID=1
+SERVICE_PID_FILE=/var/run/minidlna/minidlna.pid
 
 MINIDLNA_CONFIG_FILE="/tmp/minidlna.conf"
 


### PR DESCRIPTION
Signed-off-by: Ted Hess thess@kitschensync.net
