### PR TITLE
openconnect: Restore support for vpnc-script hooks

### DIFF
--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -40,14 +40,14 @@ proto_openconnect_setup() {
 
 	[ -f /etc/openconnect/user-cert-vpn-$config.pem ] && append cmdline "-c /etc/openconnect/user-cert-vpn-$config.pem"
 	[ -f /etc/openconnect/user-key-vpn-$config.pem ] && append cmdline "--sslkey /etc/openconnect/user-key-vpn-$config.pem"
-	if test -f /etc/openconnect/ca-vpn-$config.pem;then
+	[ -f /etc/openconnect/ca-vpn-$config.pem ] && {
 		append cmdline "--cafile /etc/openconnect/ca-vpn-$config.pem"
 		append cmdline "--no-system-trust"
-	fi
-	if test -n "$serverhash";then
+	}
+	[ -n "$serverhash" ] && {
 		append cmdline " --servercert=$serverhash"
 		append cmdline "--no-system-trust"
-	fi
+	}
 	[ -n "$authgroup" ] && append cmdline "--authgroup $authgroup"
 	[ -n "$username" ] && append cmdline "-u $username"
 	[ -n "$password" ] && {
@@ -63,7 +63,7 @@ proto_openconnect_setup() {
 	proto_export INTERFACE="$config"
 	logger -t openconnect "executing 'openconnect $cmdline'"
 
-	if [ -f "$pwfile" ];then
+	if [ -f "$pwfile" ]; then
 		proto_run_command "$config" /usr/sbin/openconnect-wrapper $pwfile $cmdline
 	else
 		proto_run_command "$config" /usr/sbin/openconnect $cmdline

--- a/net/openconnect/files/vpnc-script
+++ b/net/openconnect/files/vpnc-script
@@ -26,6 +26,8 @@
 #* CISCO_IPV6_SPLIT_INC_%d_ADDR -- IPv6 network address
 #* CISCO_IPV6_SPLIT_INC_$%d_MASKLEN -- IPv6 subnet masklen
 
+HOOKS_DIR=/etc/openconnect
+
 # FIXMEs:
 
 # Section A: route handling
@@ -50,7 +52,7 @@
 do_connect() {
 	if [ -n "$CISCO_BANNER" ]; then
 		logger -t openconnect "Connect Banner:"
-		logger -t openconnect "$CISCO_BANNER" | while read LINE ; do logger -t openconnect "|" "$LINE" ; done
+		echo "$CISCO_BANNER" | while read LINE ; do logger -t openconnect "|" "$LINE" ; done
 	fi
 
 	proto_init_update "$TUNDEV" 1
@@ -122,6 +124,17 @@ do_disconnect() {
 	proto_send_update "$INTERFACE"
 }
 
+#### Hooks
+run_hooks() {
+	HOOK="$1"
+
+	if [ -d ${HOOKS_DIR}/${HOOK}.d ]; then
+		for script in ${HOOKS_DIR}/${HOOK}.d/* ; do
+			[ -f $script ] && . $script
+		done
+	fi
+}
+
 #### Main
 
 if [ -z "$reason" ]; then
@@ -137,14 +150,20 @@ fi
 
 case "$reason" in
 	pre-init)
+		run_hooks pre-init
 		;;
 	connect)
+		run_hooks connect
 		do_connect
+		run_hooks post-connect
 		;;
 	disconnect)
+		run_hooks disconnect
 		do_disconnect
+		run_hooks post-disconnect
 		;;
 	reconnect)
+		run_hooks reconnect
 		;;
 	*)
 		logger -t openconnect "unknown reason '$reason'. Maybe vpnc-script is out of date" 1>&2


### PR DESCRIPTION
- Restore hooks support from vpnc-script
- Use consistent style for tests and blocks in openconnect.sh
- Cleanup code that writes banner to syslog

Signed-off-by: Matthew Sykes matthew.sykes@gmail.com
