### PR TITLE
Make /var/log/icecast directory

### DIFF
--- a/multimedia/icecast/files/icecast.init
+++ b/multimedia/icecast/files/icecast.init
@@ -5,8 +5,13 @@
 USE_PROCD=1
 START=99
 STOP=15
+LOG="/var/log/icecast"
 
 start_service() {
+	#create icecast log directories
+	if [ ! -d $LOG ]; then
+		mkdir -m 777 -p $LOG
+	fi
 	procd_open_instance
 	procd_set_param command /usr/bin/icecast -c /etc/icecast.xml
 	procd_set_param respawn


### PR DESCRIPTION
Probably could be done better by getting the directory from the config file, but this gets icecast working with the default log directory at least. Not sure if I am doing this right, first time I've made a suggestion on github, but the default init script was not working for my 14.07 build of OpenWRT.
