### PR TITLE
seafile-server: fix fastcgi mode settings in seafile-admin script

### DIFF
--- a/net/seafile-server/patches/040-seafile-admin.patch
+++ b/net/seafile-server/patches/040-seafile-admin.patch
@@ -1,7 +1,7 @@
 diff -rupN seafile-3.1.7-server.orig/tools/seafile-admin seafile-3.1.7-server/tools/seafile-admin
 --- seafile-3.1.7-server.orig/tools/seafile-admin	2014-10-16 05:30:04.000000000 +0200
-+++ seafile-3.1.7-server/tools/seafile-admin	2014-12-12 12:09:00.703175935 +0100
-@@ -416,13 +416,15 @@ def create_gunicorn_conf():
++++ seafile-3.1.7-server/tools/seafile-admin	2014-12-22 21:52:25.929781054 +0100
+@@ -416,13 +416,13 @@ def create_gunicorn_conf():
      content = '''\
  import os
  daemon = True
@@ -15,12 +15,10 @@ diff -rupN seafile-3.1.7-server.orig/tools/seafile-admin seafile-3.1.7-server/to
 +pidfile = '/var/run/seafile/seahub.pid'
  errorlog = os.path.join(runtime_dir, 'error.log')
 -accesslog = os.path.join(runtime_dir, 'access.log')
-+# uncomment if you need access logging (works only in fastcgi mode)
-+#accesslog = os.path.join(runtime_dir, 'access.log')
  '''
      try:
          with open(confpath, 'w') as fp:
-@@ -607,6 +609,7 @@ def start_seahub_gunicorn():
+@@ -607,6 +607,7 @@ def start_seahub_gunicorn():
          'gunicorn_django',
          '-c', conf[CONF_SEAHUB_CONF],
          '-b', '0.0.0.0:%s' % conf[CONF_SEAHUB_PORT],
@@ -28,7 +26,24 @@ diff -rupN seafile-3.1.7-server.orig/tools/seafile-admin seafile-3.1.7-server/to
      ]
  
      info('Starting seahub...')
-@@ -738,10 +741,9 @@ def setup_seafile(args):
+@@ -625,6 +626,7 @@ def start_seahub_fastcgi():
+         'pidfile=%(pidfile)s',
+         'outlog=%(outlog)s',
+         'errlog=%(errlog)s',
++        'method=threaded',
+     ]
+ 
+     cmdline = ' '.join(argv) % \
+@@ -693,7 +695,7 @@ def check_layout(args):
+     conf[CONF_SEAFILE_DIR]      = seafile_data_dir
+     conf[CONF_SEAHUB_DIR]       = seahub_dir
+     conf[CONF_SEAHUB_CONF]      = seahub_conf
+-    conf[CONF_SEAHUB_PIDFILE]   = os.path.join(runtime_dir, 'seahub.pid')
++    conf[CONF_SEAHUB_PIDFILE]   = '/var/run/seafile/seahub.pid'
+     conf[CONF_SEAHUB_OUTLOG]    = os.path.join(runtime_dir, 'access.log')
+     conf[CONF_SEAHUB_ERRLOG]    = os.path.join(runtime_dir, 'error.log')
+ 
+@@ -738,10 +740,9 @@ def setup_seafile(args):
      print '-----------------------------------------------------------------'
      print '-----------------------------------------------------------------'
      print
@@ -41,7 +56,7 @@ diff -rupN seafile-3.1.7-server.orig/tools/seafile-admin seafile-3.1.7-server/to
      print
      print 'If you have any problem, refer to\n'
      print
-@@ -802,8 +804,7 @@ def start_seafile(args):
+@@ -802,8 +803,7 @@ def start_seafile(args):
  def stop_seafile(dummy):
      info('Stopping seafile server')
      pkill('seafile-controller')


### PR DESCRIPTION
- Use the correct path for the pidfile
- Start a multithreaded daemon instead of pre-forking worker processes.
  This avoids consuming too much memory and makes context switches faster

Signed-off-by: Gergely Kiss mail.gery@gmail.com
