### PR TITLE
[privoxy] back to old-style initscript not using procd

### DIFF
--- a/net/privoxy/Makefile
+++ b/net/privoxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=privoxy
 PKG_VERSION:=3.0.22
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-stable-src.tar.gz
 PKG_SOURCE_URL:=@SF/ijbswa
@@ -47,7 +47,7 @@ Version: $(PKG_VERSION)-$(PKG_RELEASE)
 endef
 
 CONFIGURE_ARGS += \
-	--sysconfdir=/etc/privoxy \
+	--sysconfdir=/etc/privoxy
 
 # needed otherwise errors during compile
 MAKE_FLAGS:=
@@ -67,9 +67,8 @@ define Package/privoxy/preinst
 	#!/bin/sh
 	# if run within buildroot exit
 	[ -n "$${IPKG_INSTROOT}" ] && exit 0
-	# stop service # if PKG_UPGRADE NOT WORKING
-	# [ "$${PKG_UPGRADE}" = "1" ] && /etc/init.d/privoxy stop
-	/etc/init.d/privoxy stop >/dev/null 2>&1
+	# stop service if PKG_UPGRADE
+	[ "$${PKG_UPGRADE}" = "1" ] && /etc/init.d/privoxy stop >/dev/null 2>&1
 	exit 0	# supress errors from stop command
 endef
 
@@ -78,9 +77,8 @@ define Package/privoxy/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/privoxy $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/privoxy.init $(1)/etc/init.d/privoxy
-	# no longer needed because running with procd
-	# $(INSTALL_DIR) $(1)/etc/hotplug.d/iface
-	# $(INSTALL_BIN) ./files/privoxy.hotplug $(1)/etc/hotplug.d/iface/80-privoxy
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
+	$(INSTALL_BIN) ./files/privoxy.hotplug $(1)/etc/hotplug.d/iface/80-privoxy
 
 	$(INSTALL_DIR) $(1)/etc/privoxy
 	$(CP) $(PKG_INSTALL_DIR)/etc/privoxy/* $(1)/etc/privoxy/
@@ -89,7 +87,7 @@ define Package/privoxy/install
 	$(INSTALL_CONF) ./files/privoxy.oldconfig $(1)/etc/privoxy/config
 	# create .old file to be removed with next pacakge builds during update
 	$(INSTALL_CONF) ./files/privoxy.oldconfig $(1)/etc/privoxy/config.old
-
+	# copy NEW config
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/privoxy.config $(1)/etc/config/privoxy
 endef

--- a/net/privoxy/files/privoxy.hotplug
+++ b/net/privoxy/files/privoxy.hotplug
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# only (re-)start on ifup
+[ "$ACTION" = "ifup" ] || exit 0
+
+PIDFILE=/var/run/privoxy.pid
+
+_PID=$(cat $PIDFILE 2>/dev/null)
+kill -1 $_PID 2>/dev/null
+if [ $? -eq 0 ]; then
+	# only restart if already running
+	logger -p daemon.info -t "privoxy[$_PID]" \
+		"Restart request due to '$ACTION' of interface '$INTERFACE'"
+	/etc/init.d/privoxy restart
+else
+	# only start if enabled
+	/etc/init.d/privoxy enabled && /etc/init.d/privoxy start
+fi

--- a/net/privoxy/files/privoxy.init
+++ b/net/privoxy/files/privoxy.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 
 START=80
-USE_PROCD=1
+STOP=20
 
 PIDFILE=/var/run/privoxy.pid
 CFGFILE=/var/etc/privoxy.conf
@@ -68,57 +68,52 @@ _uci2conf() {
 	mv -f $CFGTEMP $CFGFILE
 }
 
-# privoxy should auto-reload it's configuration
-# but it only reload on next connect to one of the listen_address
-# if we create a new listen_address privoxy never reload
-reload_service() {
-	# so we restart here because rc.common reload_service only start without stopping
-	restart "$@"
-
-	# the following should normally work but see above
-#	_uci2conf	# convert uci config
+boot() {
+	return 0	# will be started by "iface" hotplug events
 }
 
-service_triggers() {
-	procd_add_reload_trigger "privoxy"
+start() {
+	# if already running do nothing
+	local _PID=$(cat $PIDFILE 2>/dev/null)
+	kill -1 $_PID 2>/dev/null && return 0
+
+	_uci2conf
+	/usr/sbin/privoxy --pidfile $PIDFILE --user privoxy.privoxy $CFGFILE
+
+	# verify startup
+	_PID=$(cat $PIDFILE 2>/dev/null)
+	kill -1 $_PID 2>/dev/null
+	local _ERR=$?
+	[ $_ERR -eq 0 ] \
+		&& logger -p daemon.notice -t "privoxy[$_PID]" "Started successfully"\
+		|| logger -p daemon.warn -t "privoxy[-----]" "Failed to start"
+	return $_ERR
 }
 
-start_service() {
-	# redefined callback for sections when calling config_load
-	config_cb() {
-		# $1	type of config section
-		# $2	name of section
-		[ "$1" = "interface" ] && \
-			procd_add_interface_trigger interface.* $2 /etc/init.d/privoxy restart
-	}
-
-	_uci2conf	# convert uci config
-
-	procd_open_instance
-
-	procd_set_param command /usr/sbin/privoxy
-	procd_append_param command --no-daemon			# for procd run in foreground
-	procd_append_param command --pidfile $PIDFILE		# set pid file
-	procd_append_param command --user privoxy.privoxy	# set user
-	procd_append_param command $CFGFILE			# config file
-
-	procd_set_param file $CFGFILE	# set configration file
-
-        procd_open_trigger	# we need a restart on interface events not a reload
-	config_load network	# load network configuration and set trigger(s) in config_cb() above
-        procd_close_trigger
-
-	procd_close_instance
+reload() {
+	# reload is also used by luci-app-privoxy
+	local _PID=$(cat $PIDFILE 2>/dev/null)
+	kill -1 $_PID 2>/dev/null
+	if [ $? -eq 0 ]; then
+		# only restart if already running
+		restart
+	else
+		# only start if enabled
+		enabled && start
+	fi
+	return 0
 }
 
-service_running() {
-	logger_trick() {
-		sleep 1		# give privoxy time to completely come up
-		logger -p daemon.notice -t "privoxy[$(cat $PIDFILE)]" "Service started successfully"
-	}
-	logger_trick &
-}
-
-stop_service() {
-	logger -p daemon.notice -t "privoxy[$(cat $PIDFILE)]" "Service shutdown"
+stop() {
+	local _PID=$(cat $PIDFILE 2>/dev/null)
+	kill -15 $_PID 2>/dev/null
+	sleep 1			# give time to shutdown
+	local _tmp=$(pgrep privoxy)
+	if [ -z "$_tmp" ]; then
+		logger -p daemon.notice -t "privoxy[$_PID]" "Shutdown successfully"
+	else
+		killall -9 privoxy
+		logger -p daemon.warn -t "privoxy[-----]" "Shutdown forced by KILL"
+	fi
+	return 0
 }


### PR DESCRIPTION
because:
- privoxy running --no-daemon only logging to STDERR
- procd do not support redirection of STDOUT/STDERR, '2>file' as a command parameter does not work

Signed-off-by: Christian Schoenebeck christian.schoenebeck@gmail.com
