### PR TITLE
shadow: select all packages by default

### DIFF
--- a/utils/shadow/Makefile
+++ b/utils/shadow/Makefile
@@ -73,6 +73,7 @@ define Package/shadow-utils/config
     config shadow-all
       bool "Include all PLD shadow utilities"
       select PACKAGE_shadow
+      default y
 
     comment "Utilities"
 


### PR DESCRIPTION
This is related to #679 . Removing the "+ALL:shadow" dependency had a side-effect of not building all packages even if the "ALL" symbol is defined. This caused buildbot to omit building shadow-\* packages not selected by some other package.
