### PR TITLE
muninlite: added a patch for correctly parse ifname with - char

### DIFF
--- a/admin/muninlite/patches/220-modify-ifname-parser.patch
+++ b/admin/muninlite/patches/220-modify-ifname-parser.patch
@@ -1,0 +1,20 @@
+--- a/munin-node.in
++++ b/munin-node.in
+@@ -141,7 +141,7 @@
+   fi
+ }
+ fetch_if() {
+-  IINFO=$(grep "$1:" /proc/net/dev | cut -d: -f2 | sed -e 's/  / /g')
++  IINFO=$(cat /proc/net/dev | sed -e 's/-/_/g' | grep "$1:" | cut -d: -f2 | sed -e 's/  */ /g' -e 's/^[ \t]*//')
+   echo "down.value" $(echo $IINFO | cut -d\  -f1)
+   echo "up.value" $(echo $IINFO | cut -d\  -f9)
+ }
+@@ -162,7 +162,7 @@
+   echo "trans.warning 1"
+ }
+ fetch_if_err() {
+-  IINFO=$(grep "$1:" /proc/net/dev | cut -d: -f2 | sed -e 's/  / /g')
++  IINFO=$(cat /proc/net/dev | sed -e 's/-/_/g' | grep "$1:"| cut -d: -f2 | sed -e 's/  */ /g' -e 's/^[ \t]*//')
+   echo "rcvd.value" $(echo $IINFO | cut -d\  -f3)
+   echo "trans.value" $(echo $IINFO | cut -d\  -f11)
+ }

--- a/admin/muninlite/patches/220-modify-ifname-parser.patch
+++ b/admin/muninlite/patches/220-modify-ifname-parser.patch
@@ -5,7 +5,7 @@
  }
  fetch_if() {
 -  IINFO=$(grep "$1:" /proc/net/dev | cut -d: -f2 | sed -e 's/  / /g')
-+  IINFO=$(cat /proc/net/dev | sed -e 's/-/_/g' | grep "$1:" | cut -d: -f2 | sed -e 's/  */ /g' -e 's/^[ \t]*//')
++  IINFO=$(sed -ne "/^ *${1//_/-}: / { s/^.\+: \+//; s/[[:space:]]\+/ /gp }" /proc/net/dev)
    echo "down.value" $(echo $IINFO | cut -d\  -f1)
    echo "up.value" $(echo $IINFO | cut -d\  -f9)
  }
@@ -14,7 +14,7 @@
  }
  fetch_if_err() {
 -  IINFO=$(grep "$1:" /proc/net/dev | cut -d: -f2 | sed -e 's/  / /g')
-+  IINFO=$(cat /proc/net/dev | sed -e 's/-/_/g' | grep "$1:"| cut -d: -f2 | sed -e 's/  */ /g' -e 's/^[ \t]*//')
++  IINFO=$(sed -ne "/^ *${1//_/-}: / { s/^.\+: \+//; s/[[:space:]]\+/ /gp }" /proc/net/dev)
    echo "rcvd.value" $(echo $IINFO | cut -d\  -f3)
    echo "trans.value" $(echo $IINFO | cut -d\  -f11)
  }


### PR DESCRIPTION
Hi,
i found three problems:
1)  interface name with - char inside wasn't correctly parsed (for example pppoe-wan) because the script substitutes '-' with '_'. This patch substitute the same cher on /proc/net/dev before interface matching.
2) /proc/net/dev has more spaces as delimiter (variable), changing regexp   with "  *" instead of "  "
3)After two splitting matching row in /proc/net/dev, remaing an initial space that shift the correct column number. Removed initial space

