### PR TITLE
libesmtp: add Makefile for new package

### DIFF
--- a/libs/libesmtp/Makefile
+++ b/libs/libesmtp/Makefile
@@ -1,0 +1,71 @@
+#
+# Copyright (C) 2008-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libesmtp
+PKG_VERSION:=1.0.6
+PKG_RELEASE:=1
+PKG_MD5SUM:=c4fedc999b6c3820296b0eb92cc2e252
+
+PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
+PKG_LICENSE:=LGPL-2.0+
+PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE_URL:=http://www.stafford.uklinux.net/libesmtp
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_CAT:=zcat
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_INSTALL_DIR:=$(PKG_BUILD_DIR)/ipkg-install
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libesmtp
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=A Library for Posting Electronic Mail
+  URL:=http://www.stafford.uklinux.net/libesmtp/
+  DEPENDS:=+libpthread
+endef
+
+define Build/Configure
+	$(call Build/Configure/Default,--without-openssl)
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		all install
+endef
+
+define Build/InstallDev
+	mkdir -p $(STAGING_DIR)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libesmtp.h $(STAGING_DIR)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/auth-client.h $(STAGING_DIR)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/auth-plugin.h $(STAGING_DIR)/usr/include/
+	mkdir -p $(STAGING_DIR)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libesmtp.{a,so*} $(STAGING_DIR)/usr/lib/
+	$(INSTALL_DIR) $(2)/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/libesmtp-config $(2)/bin/
+	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' $(2)/bin/libesmtp-config
+endef
+
+define Build/UninstallDev
+	rm -rf \
+		$(STAGING_DIR)/usr/include/libesmtp.h \
+		$(STAGING_DIR)/usr/include/auth-client.h \
+		$(STAGING_DIR)/usr/include/auth-plugin.h \
+		$(STAGING_DIR)/usr/lib/libesmtp.{a,so*}
+endef
+
+define Package/libesmtp/install
+	mkdir -p $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libesmtp.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libesmtp))


### PR DESCRIPTION
libESMTP is an SMTP client which manages posting (or submission of) electronic mail via a preconfigured Mail Transport Agent (MTA). It may be used as part of a Mail User Agent (MUA) or other program that must be able to post electronic mail where mail functionality may not be that program's primary purpose.

The availability of a reliable, lightweight and thread-safe SMTP client eases the task of coding for software authors thus improving the quality of the resulting code.

Hosted on: http://www.stafford.uklinux.net/libesmtp/

Signed-off-by: Othmar Truniger <github@truniger.ch>