### PR TITLE
linknx: fix Makefile to use TABs instead of spaces

### DIFF
--- a/net/linknx/Makefile
+++ b/net/linknx/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=0.0.1.32
 PKG_RELEASE:=1
 PKG_MD5SUM:=7ecc1208f59bceb05068c752b2250b63
 
-PKG_MAINTAINER:=Othmar Truniger <tru7@users.noreply.github.com>
+PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0+
 
 PKG_SOURCE_URL:=@SF/linknx
@@ -32,31 +32,31 @@ define Package/linknx
 endef
 
 define Build/Configure
-        (cd $(PKG_BUILD_DIR); touch aclocal.m4 Makefile.in config.h.in configure; \
-        $(SED) 's,\"2.0.4\",\"2.0.4\"\n_pth_version=\"2.0.8\",g' $(PKG_BUILD_DIR)/configure )
-        $(call Build/Configure/Default,--verbose --without-pth-test --with-pth=$(STAGING_DIR) --without-log4cpp --with-lua --with-libcurl --without-mysql, \
-        CXXFLAGS="$(TARGET_CFLAGS) -fno-builtin -lcrypt" \
-        )
+	(cd $(PKG_BUILD_DIR); touch aclocal.m4 Makefile.in config.h.in configure; \
+	$(SED) 's,\"2.0.4\",\"2.0.4\"\n_pth_version=\"2.0.8\",g' $(PKG_BUILD_DIR)/configure )
+	$(call Build/Configure/Default,--verbose --without-pth-test --with-pth=$(STAGING_DIR) --without-log4cpp --with-lua --with-libcurl --without-mysql, \
+	CXXFLAGS="$(TARGET_CFLAGS) -fno-builtin -lcrypt" \
+	)
 endef
 
 define Build/Compile
-        $(MAKE) -C $(PKG_BUILD_DIR)/ \
-                LIBDIR="$(TARGET_LDFLAGS)" \
-                CC="$(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_CPPFLAGS) " \
-                LD="$(TARGET_CROSS)ld -shared" \
-                LUA="$(STAGING_DIR_HOST)/bin/lua" \
-                LUAC="$(STAGING_DIR_HOST)/bin/luac" \
-                CFLAGS="$(TARGET_CFLAGS) -nodefaultlibs" all
+	$(MAKE) -C $(PKG_BUILD_DIR)/ \
+		LIBDIR="$(TARGET_LDFLAGS)" \
+		CC="$(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_CPPFLAGS) " \
+		LD="$(TARGET_CROSS)ld -shared" \
+		LUA="$(STAGING_DIR_HOST)/bin/lua" \
+		LUAC="$(STAGING_DIR_HOST)/bin/luac" \
+		CFLAGS="$(TARGET_CFLAGS) -nodefaultlibs" all
 endef
 
 define Package/linknx/install
-        mkdir -p $(1)/usr/bin
-        $(CP) $(PKG_BUILD_DIR)/src/linknx $(1)/usr/bin/
-        mkdir -p $(1)/etc/init.d
-        $(CP) ./files/linknx.init $(1)/etc/init.d/linknx
-        mkdir -p $(1)/etc/config
-        $(CP) ./files/linknx.config $(1)/etc/config/linknx
-        $(CP) ./files/linknx.xml.dist $(1)/etc/linknx.xml.dist
+	mkdir -p $(1)/usr/bin
+	$(CP) $(PKG_BUILD_DIR)/src/linknx $(1)/usr/bin/
+	mkdir -p $(1)/etc/init.d
+	$(CP) ./files/linknx.init $(1)/etc/init.d/linknx
+	mkdir -p $(1)/etc/config
+	$(CP) ./files/linknx.config $(1)/etc/config/linknx
+	$(CP) ./files/linknx.xml.dist $(1)/etc/linknx.xml.dist
 endef
 
 $(eval $(call BuildPackage,linknx))


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>