### PR TITLE
libdaemon: fix build with musl libc (fixes #453)

### DIFF
--- a/libs/libdaemon/Makefile
+++ b/libs/libdaemon/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdaemon
 PKG_VERSION:=0.14
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://0pointer.de/lennart/projects/libdaemon/

--- a/libs/libdaemon/patches/002-testd-use-unistd.h-instead-of-sys-unistd.h.patch
+++ b/libs/libdaemon/patches/002-testd-use-unistd.h-instead-of-sys-unistd.h.patch
@@ -1,0 +1,28 @@
+From 8cc1a70b8f65c8fc4f944cad5e9e642394ddbd2f Mon Sep 17 00:00:00 2001
+From: Michael Heimpold <mhei@heimpold.de>
+Date: Mon, 5 Jan 2015 23:55:21 +0100
+Subject: [PATCH] testd: use unistd.h instead of sys/unistd.h
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+examples/testd.c: As the C POSIX library recommends include the <unistd.h>
+instead of <sys/unistd.h>. This removes an error when building libdaemon
+against the musl C library.
+
+Signed-off-by: Jörg Krause <jkrause@posteo.de>
+---
+ examples/testd.c |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/examples/testd.c
++++ b/examples/testd.c
+@@ -23,7 +23,7 @@
+ #include <string.h>
+ #include <sys/types.h>
+ #include <sys/time.h>
+-#include <sys/unistd.h>
++#include <unistd.h>
+ #include <sys/select.h>
+ 
+ #include <libdaemon/dfork.h>


### PR DESCRIPTION
I extracted the mentioned patch for buildroot in the ticket and
compile-tested this for x86, mxs and atheros using musl, but also
cross-checked against uClibc.
Since the example daemon is not deployed into an OpenWrt package,
I think this simple test is sufficient.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>