### PR TITLE
move classpath to new repo; add Makefile for classpath-0.99; add patch for double memory-leak

### DIFF
--- a/libs/classpath/Makefile
+++ b/libs/classpath/Makefile
@@ -1,0 +1,89 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=classpath
+PKG_VERSION:=0.99
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+PKG_MAINTAINER:=Dana H. Myers <k6jq@comcast.net>
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@GNU/classpath
+PKG_MD5SUM:=0ae1571249172acd82488724a3b8acb4
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/classpath
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=GNU Classpath
+  URL:=http://www.gnu.org/software/classpath/
+  DEPENDS:=+alsa-lib +libgmp +libmagic
+endef
+
+define Package/classpath/Description
+	GNU Classpath, Essential Libraries for Java, is a GNU project
+	to create free core class libraries for use with virtual
+	machines and compilers for the java programming language.
+endef
+
+define Package/classpath-tools
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=GNU Classpath tools
+  URL:=http://www.gnu.org/software/classpath/
+endef
+
+define Download/antlr
+  URL:=http://www.antlr.org/download
+  FILE:=antlr-3.4-complete.jar
+  MD5SUM:=1b91dea1c7d480b3223f7c8a9aa0e172
+endef
+$(eval $(call Download,antlr))
+
+CONFIGURE_ARGS += \
+	--without-x \
+	--disable-gtk-peer \
+	--disable-qt-peer \
+	--disable-dssi \
+	--disable-plugin \
+	--disable-gconf-peer \
+	--disable-gjdoc \
+	--disable-examples \
+	--with-antlr-jar=$(DL_DIR)/antlr-3.4-complete.jar
+
+define Package/classpath/install
+	$(INSTALL_DIR) \
+		$(1)/usr/lib/classpath \
+		$(1)/usr/share/classpath
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/security \
+		$(PKG_INSTALL_DIR)/usr/lib/logging.properties \
+		$(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/classpath/*.so* $(1)/usr/lib/classpath/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/classpath/glibj.zip $(1)/usr/share/classpath/
+endef
+
+define Package/classpath-tools/install
+	$(INSTALL_DIR) \
+		$(1)/usr/bin \
+		$(1)/usr/share/classpath
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/classpath/tools.zip $(1)/usr/share/classpath/
+endef
+
+define Build/InstallDev
+	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
+endef
+
+$(eval $(call BuildPackage,classpath))
+$(eval $(call BuildPackage,classpath-tools))

--- a/libs/classpath/patches/010-double-memleak.patch
+++ b/libs/classpath/patches/010-double-memleak.patch
@@ -1,0 +1,91 @@
+--- classpath-0.99.orig/native/fdlibm/dtoa.c	2007-09-27 05:33:38.000000000 -0700
++++ classpath-0.99/native/fdlibm/dtoa.c	2014-12-21 14:22:42.451713851 -0800
+@@ -883,6 +883,16 @@ ret1:
+   return s0;
+ }
+ 
++void free_Bigints(struct _Jv_Bigint *p)
++{
++    struct _Jv_Bigint *l = p;
++    while (l)
++	{
++	  struct _Jv_Bigint *next = l->_next;
++	  free (l);
++	  l = next;
++	}
++}
+ 
+ _VOID
+ _DEFUN (_dtoa,
+@@ -905,16 +915,15 @@ _DEFUN (_dtoa,
+   p = _dtoa_r (&reent, _d, mode, ndigits, decpt, sign, rve, float_type);
+   strcpy (buf, p);
+ 
+-  for (i = 0; i < reent._result_k; ++i)
++  for (i = 0; i < reent._max_k; ++i)
+     {
+-      struct _Jv_Bigint *l = reent._freelist[i];
+-      while (l)
+-	{
+-	  struct _Jv_Bigint *next = l->_next;
+-	  free (l);
+-	  l = next;
+-	}
++        free_Bigints(reent._freelist[i]);
+     }
+   if (reent._freelist)
+     free (reent._freelist);
++
++  if (reent._result)
++    free(reent._result);
++
++  free_Bigints(reent._p5s);
+ }
+--- classpath-0.99.orig/native/jni/java-lang/java_lang_VMDouble.c	2008-02-08 09:42:57.000000000 -0800
++++ classpath-0.99/native/jni/java-lang/java_lang_VMDouble.c	2014-12-21 14:35:50.733800626 -0800
+@@ -158,6 +158,17 @@ Java_java_lang_VMDouble_longBitsToDouble
+   return val.d;
+ }
+ 
++static void free_Bigints(struct _Jv_Bigint *p)
++{
++     struct _Jv_Bigint *l = p;
++     while (l)
++     {
++         struct _Jv_Bigint *next = l->_next;
++         free (l);
++         l = next;
++     }
++}
++ 
+ /**
+  * Parse a double from a char array.
+  */
+@@ -167,7 +178,7 @@ parseDoubleFromChars(JNIEnv * env, const
+   char *endptr;
+   jdouble val = 0.0;
+   const char *p = buf, *end, *last_non_ws, *temp;
+-  int ok = 1;
++  int i, ok = 1;
+ 
+ #ifdef DEBUG
+   fprintf (stderr, "java.lang.VMDouble.parseDouble (%s)\n", buf);
+@@ -224,6 +235,18 @@ parseDoubleFromChars(JNIEnv * env, const
+ 
+       val = _strtod_r (&reent, p, &endptr);
+ 
++      for (i = 0; i < reent._max_k; ++i)
++      {
++          free_Bigints(reent._freelist[i]);
++      }
++      if (reent._freelist)
++          free (reent._freelist);
++
++      if (reent._result)
++          free (reent._result);
++
++      free_Bigints(reent._p5s);
++
+ #ifdef DEBUG
+       fprintf (stderr, "java.lang.VMDouble.parseDouble val = %g\n", val);
+       fprintf (stderr, "java.lang.VMDouble.parseDouble %p != %p ???\n",


### PR DESCRIPTION
This moves classpath to new packages as described in the subject.

Also included is patch for:

http://gcc.gnu.org/bugzilla/show_bug.cgi?id=29263

Tested with JamVM 2.0.0 on ar71xx/Carambola2, built on ARM (oxnas) as well.

I believe I have this correct this time; single commit for the PR.

Dana
Signed-off-by: Dana H. Myers k6jq@comcast.net