### PR TITLE
python-dns: remove PyPackage filespec

### DIFF
--- a/lang/python-dns/Makefile
+++ b/lang/python-dns/Makefile
@@ -40,9 +40,5 @@ define Build/Compile
 	)
 endef
 
-define PyPackage/python-dns/filespec
-+|/usr/lib/python$(PYTHON_VERSION)/site-packages
-endef
-
 $(eval $(call PyPackage,python-dns))
 $(eval $(call BuildPackage,python-dns))


### PR DESCRIPTION
Default will be used.

Note: please merge this after PR https://github.com/openwrt/packages/pull/740

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>