### PR TITLE
python-setuptools cleanup

### DIFF
--- a/lang/python-setuptools/Makefile
+++ b/lang/python-setuptools/Makefile
@@ -39,10 +39,6 @@ define Build/Compile
 	)
 endef
 
-define PyPackage/python-setuptools/filespec
-+|/usr/lib/python$(PYTHON_VERSION)/site-packages
-endef
-
 define Build/InstallDev
 	$(INSTALL_DIR) $(2)$(PYTHON_PKG_DIR)
 	$(CP) \

--- a/lang/python-setuptools/Makefile
+++ b/lang/python-setuptools/Makefile
@@ -44,10 +44,10 @@ define PyPackage/python-setuptools/filespec
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(2)/lib/python$(PYTHON_VERSION)/site-packages
+	$(INSTALL_DIR) $(2)$(PYTHON_PKG_DIR)
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/site-packages/* \
-		$(HOST_PYTHON_LIB_DIR)/site-packages
+		$(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR) \
+		$(2)$(PYTHON_PKG_DIR)
 endef
 
 define PyPackage/python-setuptools/install


### PR DESCRIPTION
Remove PyPackage filespec since default will be used.
Use shorthand vars.

Note: please merge this after PR https://github.com/openwrt/packages/pull/740

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>