### PR TITLE
Add netcat package from old 14.07 package repository.

### DIFF
--- a/net/netcat/Makefile
+++ b/net/netcat/Makefile
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=netcat
+PKG_VERSION:=0.7.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=@SF/$(PKG_NAME)
+PKG_MD5SUM:=0a29eff1736ddb5effd0b1ec1f6fe0ef
+PKG_MAINTAINER:=Adam Gensler <openwrt@a.gnslr.us>
+PKG_LICENSE:=GPL-2.0
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/netcat
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=A feature-rich network debugging and exploration tool.
+  URL:=http://netcat.sourceforge.net/
+endef
+
+define Package/netcat/description
+		Netcat is a featured networking utility which reads and writes data across network connections, using the TCP/IP protocol.
+	It is designed to be a reliable "back-end" tool that can be used directly or easily driven by other programs and scripts. At the same time, it is a feature-rich network debugging and exploration tool, since it can create almost any kind of connection you would need and has several interesting built-in capabilities.
+endef
+
+define Build/Configure
+	$(call Build/Configure/Default, \
+		--disable-rpath \
+		--with-included-getopt \
+	)
+endef
+
+define Package/netcat/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/netcat \
+		$(1)/usr/bin
+endef
+
+define Package/netcat/postinst
+#!/bin/sh
+if [ -e $${IPKG_INSTROOT}/usr/bin/nc ]; then
+  rm -rf $${IPKG_INSTROOT}/usr/bin/nc;
+fi
+ln -s ./netcat $${IPKG_INSTROOT}/usr/bin/nc
+endef
+
+define Package/netcat/postrm
+#!/bin/sh
+rm $${IPKG_INSTROOT}/usr/bin/nc
+ln -s ../../bin/busybox $${IPKG_INSTROOT}/usr/bin/nc
+$${IPKG_INSTROOT}/usr/bin/nc 2>&1 | grep 'applet not found' > /dev/null 2>&1 && rm $${IPKG_INSTROOT}/usr/bin/nc
+exit 0
+endef
+
+
+$(eval $(call BuildPackage,netcat))

--- a/net/netcat/patches/001-netcat_flag_count.patch
+++ b/net/netcat/patches/001-netcat_flag_count.patch
@@ -1,0 +1,22 @@
+Index: netcat-0.7.1/src/flagset.c
+===================================================================
+--- netcat-0.7.1.orig/src/flagset.c	2009-02-06 19:56:01.000000000 +0100
++++ netcat-0.7.1/src/flagset.c	2009-02-06 19:56:13.000000000 +0100
+@@ -134,7 +134,7 @@
+ 
+ int netcat_flag_count(void)
+ {
+-  register char c;
++  register unsigned char c;
+   register int i;
+   int ret = 0;
+ 
+@@ -154,7 +154,7 @@
+ 	Assumed that the bit number 1 is the sign, and that we will shift the
+ 	bit 1 (or the bit that takes its place later) until the the most right,
+ 	WHY it has to keep the wrong sign? */
+-      ret -= (c >> 7);
++      ret += (c >> 7);
+       c <<= 1;
+     }
+   }


### PR DESCRIPTION
Bring over full-blown GNU netcat from the old 14.07 package repo. Compile and runtime tested on Netgear WNDR3800:

root@bunson:/tmp# cat /etc/banner ; netcat --help

| |.-----.-----.-----.| | | |.----.| |_
| - || _ | -| || | | || || |
|___|| |___||||________||| |__|
|__| W I R E L E S S F R E E D O M

CHAOS CALMER (Bleeding Edge, r43800)

1 1/2 oz Gin Shake with a glassful
1/4 oz Triple Sec of broken ice and pour
3/4 oz Lime Juice unstrained into a goblet.
1 1/2 oz Orange Juice
1 tsp. Grenadine Syrup ----------------------------------------------------- GNU netcat 0.7.1, a rewrite of the famous networking tool. Basic usages: connect to somewhere: netcat [options] hostname port [port] ... listen for inbound: netcat -l -p port [options] [hostname] [port] ... tunnel to somewhere: netcat -L hostname:port -p port [options]
Mandatory arguments to long options are mandatory for short options too.
Options:
-c, --close close connection on EOF from stdin
-e, --exec=PROGRAM program to exec after connect
-g, --gateway=LIST source-routing hop point[s], up to 8
-G, --pointer=NUM source-routing pointer: 4, 8, 12, ...
-h, --help display this help and exit
-i, --interval=SECS delay interval for lines sent, ports scanned
-l, --listen listen mode, for inbound connects
-L, --tunnel=ADDRESS:PORT forward local port to remote address
-n, --dont-resolve numeric-only IP addresses, no DNS
-o, --output=FILE output hexdump traffic to FILE (implies -x)
-p, --local-port=NUM local port number
-r, --randomize randomize local and remote ports
-s, --source=ADDRESS local source address (ip or hostname)
-t, --tcp TCP mode (default)
-T, --telnet answer using TELNET negotiation
-u, --udp UDP mode
-v, --verbose verbose (use twice to be more verbose)
-V, --version output version information and exit
-x, --hexdump hexdump incoming and outgoing traffic
-w, --wait=SECS timeout for connects and final net reads
-z, --zero zero-I/O mode (used for scanning)

Remote port number can also be specified as range. Example: '1-1024'

root@bunson:/tmp#

Signed-off-by: Adam Gensler openwrt@a.gnslr.us