### PR TITLE
GCC: include libgcc.a

### DIFF
--- a/devel/gcc/Makefile
+++ b/devel/gcc/Makefile
@@ -110,6 +110,7 @@ define Package/gcc/install
 	cp -ar $(TOOLCHAIN_DIR)/include $(1)/usr/lib/$(PKG_NAME)/$(REAL_GNU_TARGET_NAME)/$(PKG_VERSION)
 	cp -a $(TOOLCHAIN_DIR)/lib/*.{o,so*} $(1)/usr/lib/$(PKG_NAME)/$(REAL_GNU_TARGET_NAME)/$(PKG_VERSION)
 	cp -a $(TOOLCHAIN_DIR)/lib/*nonshared*.a  $(1)/usr/lib/$(PKG_NAME)/$(REAL_GNU_TARGET_NAME)/$(PKG_VERSION)
+	grep "GROUP.*-lgcc" $(1)/usr/lib/$(PKG_NAME)/$(REAL_GNU_TARGET_NAME)/$(PKG_VERSION)/libgcc_s.so && cp -a $(PKG_INSTALL_DIR)/usr/lib/gcc/$(REAL_GNU_TARGET_NAME)/$(PKG_VERSION)/libgcc.a $(1)/usr/lib/$(PKG_NAME)/$(REAL_GNU_TARGET_NAME)/$(PKG_VERSION)/ ; true
 endef
 
 $(eval $(call BuildPackage,gcc))

--- a/devel/gcc/README
+++ b/devel/gcc/README
@@ -1,7 +1,8 @@
 Native GCC that runs on target.
 
 To save disk space, this GCC only supports dynamic linking on the target box,
-there are no static libraries shipped.
+there are no static libraries shipped except libgcc.a on those architectures
+that need it.
 
 For now, this was only tested on a mips target. Others to be done...
 

--- a/devel/gcc/README
+++ b/devel/gcc/README
@@ -4,6 +4,7 @@ To save disk space, this GCC only supports dynamic linking on the target box,
 there are no static libraries shipped except libgcc.a on those architectures
 that need it.
 
-For now, this was only tested on a mips target. Others to be done...
+For now, this was only tested on arm (EABI) and mips targets. Others to be
+done...
 
    Christian Beier <cb@shoutrlabs.com>


### PR DESCRIPTION
Two patches to gcc package by Harald Geyer to ship libgcc.a on archs where it's needed.