### PR TITLE
rtorrent: reenable rtorrent-rpc in Barrier Breaker

### DIFF
--- a/net/rtorrent/Makefile
+++ b/net/rtorrent/Makefile
@@ -90,4 +90,4 @@ endef
 Package/rtorrent-rpc/install = $(Package/rtorrent/install)
 
 $(eval $(call BuildPackage,rtorrent))
-#$(eval $(call BuildPackage,rtorrent-rpc))
+$(eval $(call BuildPackage,rtorrent-rpc))


### PR DESCRIPTION
The xmlrpc-c-server packages that are required are available for barrier breaker.

I just compiled this for 14.07 without any problems. This is enabled in master, but since 14.07 was just recently released this should be available for that release as well.