### PR TITLE
libffi: override default Host/Install rule

### DIFF
--- a/libs/libffi/Makefile
+++ b/libs/libffi/Makefile
@@ -77,5 +77,12 @@ define Package/libffi/install
 		$(1)/usr/lib/
 endef
 
+define Host/Install
+	$(call Host/Install/Default)
+	$(CP) \
+		$(STAGING_DIR_HOST)/lib/libffi-$(PKG_VERSION)/include/*.h \
+		$(STAGING_DIR_HOST)/include/
+endef
+
 $(eval $(call HostBuild))
 $(eval $(call BuildPackage,libffi))


### PR DESCRIPTION
Copy libffi headers to a default include location so they're easier to find.
Default install location is `$(STAGING_DIR_HOST)/lib/lib-$(PKG_VERSION)/include/`

Obviously, this PR needs the blessing & review of the maintainer.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>