### PR TITLE
avahi-daemon: don't install service files automatically (fixes #757)

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -18,7 +18,7 @@ endif
 
 PKG_NAME:=avahi
 PKG_VERSION:=0.6.31
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -348,9 +348,9 @@ define Package/avahi-daemon/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/avahi-daemon $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/avahi
 	$(INSTALL_DATA) ./files/avahi-daemon.conf $(1)/etc/avahi/
+	# install empty service directory so that user knows where
+	# to place custom service files
 	$(INSTALL_DIR) $(1)/etc/avahi/services
-	$(INSTALL_DATA) ./files/service-http $(1)/etc/avahi/services/http.service
-	$(INSTALL_DATA) ./files/service-ssh $(1)/etc/avahi/services/ssh.service
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/avahi-daemon.init $(1)/etc/init.d/avahi-daemon
 endef


### PR DESCRIPTION
Signed-off-by: Michael Heimpold <mhei@heimpold.de>
