### PR TITLE
smartmontools: use generic autoreconf fixup

### DIFF
--- a/utils/smartmontools/Makefile
+++ b/utils/smartmontools/Makefile
@@ -18,6 +18,8 @@ PKG_MD5SUM:=2ea0c62206e110192a97b59291b17f54
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0+
 
+PKG_FIXUP:=autoreconf
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/smartmontools/Default
@@ -59,13 +61,6 @@ CONFIGURE_VARS += \
 	CPPFLAGS="$$$$CPPFLAGS -I$(STAGING_DIR)/usr/include/uClibc++ -I$(LINUX_DIR)/include" \
 	LDFLAGS="$$$$LDFLAGS" \
 	LIBS="-nodefaultlibs -lc -luClibc++ -lm $(LIBGCC_S) -lc" \
-
-define Build/Configure
-	(cd $(PKG_BUILD_DIR); rm -rf config.{cache,status} ; \
-		./autogen.sh \
-	);
-	$(call Build/Configure/Default)
-endef
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \


### PR DESCRIPTION
Instead of using the broken upstream autogen.sh, utilize then generic
autoreconf PKG_FIXUP.

This fixes the following configure error after the recent automake
update in trunk:

-- 8< --
You must have at least GNU Automake 1.7 (up to 1.14) installed
in order to bootstrap smartmontools from SVN. Download the
appropriate package for your distribution, or the source tarball
from ftp://ftp.gnu.org/gnu/automake/ .

Also note that support for new Automake series (anything newer
than 1.14) is only added after extensive tests. If you live in
the bleeding edge, you should know what you're doing, mainly how
to test it before the developers. Be patient.
make[2]: *** [.../.configured_] Error 1
-- >8 --

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>