### PR TITLE
protobuf-c: use generic autoreconf fixup

### DIFF
--- a/libs/protobuf-c/Makefile
+++ b/libs/protobuf-c/Makefile
@@ -18,6 +18,7 @@ PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
 
 PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
 
 PKG_LICENSE:=BSD-2c
 
@@ -43,11 +44,6 @@ CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
 	--disable-protoc
-
-define Build/Configure
-	cd $(PKG_BUILD_DIR) && ./autogen.sh
-	$(call Build/Configure/Default)
-endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/


### PR DESCRIPTION
Invoke the generic autoreconf fixup instead of calling the shipped autogen.sh.

This ensures that proper variants of libtoolize, autoconf, automake etc. are
used, otherwise it is not possible to rebuild protobuf-c in the SDK env.

The change requires backport to BB as it currently blocks the rebuild of ocerv.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>