### PR TITLE
mwan3: update to version 1.5-10

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=1.5
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 PKG_MAINTAINER:=Jeroen Louwes <jeroen.louwes@gmail.com>
 PKG_LICENSE:=GPLv2
 

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -314,7 +314,7 @@ mwan3_ifupdown()
 		done
 
 		route_args=$($IP route list dev $DEVICE default | head -1 | sed '/.*via \([^ ]*\) .*$/!d;s//via \1/;q' | egrep '[0-9]{1,3}(\.[0-9]{1,3}){3}')
-		route_args="nexthop $route_args dev $DEVICE"
+		route_args="$route_args dev $DEVICE"
 	fi
 
 	while [ "$(pgrep -f -o hotplug-call)" -ne $$ -a "$counter" -lt 60 ]; do

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -74,6 +74,7 @@ interfaces()
 	
 	check_iface_status()
 	{
+		let iface_id++
 		device=$(uci get -p /var/state network.$1.ifname) &> /dev/null
 
 		if [ -z "$device" ]; then
@@ -82,7 +83,6 @@ interfaces()
 		fi
 
 		config_get enabled "$1" enabled 0
-		let iface_id++
 
 		if [ -n "$(ps -w | grep mwan3track | grep -v grep | sed '/.*\/usr\/sbin\/mwan3track \([^ ]*\) .*$/!d;s//\1/' | awk '$1 == "'$1'"')" ]; then
 			tracking="active"


### PR DESCRIPTION
Fixed issue in mwan3 status output with mwan3 interfaces not yet configuerd in network config
Removed nexthop argument as it is no longer used

Signed-off-by: Jeroen Louwes <jeroen.louwes@gmail.com>