### PR TITLE
python: add patch to remove Debian/Ubuntu multiarch support

### DIFF
--- a/lang/python/patches/160-remove-debian-multiarch-support.patch
+++ b/lang/python/patches/160-remove-debian-multiarch-support.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index 7868b7b..9ae0ef2 100644
+--- a/setup.py
++++ b/setup.py
+@@ -444,7 +444,6 @@ class PyBuildExt(build_ext):
+             add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
+         if cross_compiling:
+             self.add_gcc_paths()
+-        self.add_multiarch_paths()
+ 
+         # Add paths specified in the environment variables LDFLAGS and
+         # CPPFLAGS for header and library files.


### PR DESCRIPTION
Seems when cross compiling on x86_64 Debian (most likely Ubuntu too) the host's paths will be added too causing build failures for some extensions.

Fixes: https://github.com/openwrt/packages/issues/756

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>