### PR TITLE
davfs2: fix build error

### DIFF
--- a/net/davfs2/Makefile
+++ b/net/davfs2/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,11 +9,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=davfs2
 PKG_VERSION:=1.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.savannah.gnu.org/releases/davfs2/
 PKG_MD5SUM:=376bc9346454135cba78afacbcb23f86
+
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
fix issue #769

error:
../mips-openwrt-linux-uclibc/bin/ld: cannot find -lssp_nonshared
../mips-openwrt-linux-uclibc/bin/ld: cannot find -lssp

The patch for Makefile.am had no effect because the
Makefiles were not regenerated by automake and
the "-fstack-protector" was still enabled
so use autoreconf to rebuild all of them

Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>