### PR TITLE
openconnect: cmdline parameter for CA not moved

### DIFF
--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -47,7 +47,7 @@ proto_openconnect_setup() {
 	[ -f /etc/config/openconnect-user-cert-vpn-$config.pem ] && append cmdline "-c /etc/config/openconnect-user-cert-vpn-$config.pem"
 	[ -f /etc/config/openconnect-user-key-vpn-$config.pem ] && append cmdline "--sslkey /etc/config/openconnect-user-key-vpn-$config.pem"
 	[ -f /etc/config/openconnect-ca-vpn-$config.pem ] && {
-		append cmdline "--cafile /etc/openconnect/ca-vpn-$config.pem"
+		append cmdline "--cafile /etc/config/openconnect-ca-vpn-$config.pem"
 		append cmdline "--no-system-trust"
 	}
 


### PR DESCRIPTION
The location for the server CA file was moved in b53e5bfe875d673fc8a57a4766d7af6fc1b3e074, but the corresponding command line option for opeconnect not updated.

Signed-off-by: Jan Jasper Salathe <jaspersalathe@gmail.com>