### PR TITLE
ddns-scripts: Update to Version 2.1.0-5

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -2,8 +2,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.1.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_LICENSE:=GPL-2.0
+PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 
@@ -15,7 +16,6 @@ define Package/ddns-scripts
     SUBMENU:=IP Addresses and Names
     TITLE:=Dynamic DNS Scripts (with IPv6 support)
     PKGARCH:=all
-    MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
 endef
 
 define Package/ddns-scripts/description
@@ -28,7 +28,6 @@ A highly configurable set of scripts for doing dynamic dns updates.
 	- Proxy server support
 	- log file support
 	- support to run once
-Version: $(PKG_VERSION)-$(PKG_RELEASE)
 endef
 
 define Build/Prepare

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -23,7 +23,7 @@
 # variables in small chars are read from /etc/config/ddns
 # variables in big chars are defined inside these scripts as global vars
 # variables in big chars beginning with "__" are local defined inside functions only
-#set -vx  	#script debugger
+# set -vx  	#script debugger
 
 . /lib/functions.sh
 . /lib/functions/network.sh
@@ -32,12 +32,12 @@
 SECTION_ID=""		# hold config's section name
 VERBOSE_MODE=1		# default mode is log to console, but easily changed with parameter
 
-# allow NON-public IP's
+			# allow NON-public IP's
 ALLOW_LOCAL_IP=$(uci -q get ddns.global.allow_local_ip) || ALLOW_LOCAL_IP=0
-# directory to store run information to.
+			# directory to store run information to.
 RUNDIR=$(uci -q get ddns.global.run_dir) || RUNDIR="/var/run/ddns"
 [ -d $RUNDIR ] || mkdir -p -m755 $RUNDIR
-# directory to store log files
+			# directory to store log files
 LOGDIR=$(uci -q get ddns.global.log_dir) || LOGDIR="/var/log/ddns"
 [ -d $LOGDIR ] || mkdir -p -m755 $LOGDIR
 LOGFILE=""		# logfile - all files are set in dynamic_dns_updater.sh
@@ -47,7 +47,7 @@ DATFILE=""		# save stdout data of WGet and other external programs called
 ERRFILE=""		# save stderr output of WGet and other external programs called
 TLDFILE=/usr/lib/ddns/tld_names.dat	# TLD file used by split_FQDN
 
-# number of lines to before rotate logfile
+			# number of lines to before rotate logfile
 LOGLINES=$(uci -q get ddns.global.log_lines) || LOGLINES=250
 LOGLINES=$((LOGLINES + 1))	# correct sed handling
 
@@ -295,19 +295,19 @@ get_service_data() {
 	local __SCRIPT=""
 	local __OLD_IFS=$IFS
 	local __NEWLINE_IFS='
-' #__NEWLINE_IFS
+' # __NEWLINE_IFS
 	[ $# -ne 2 ] && write_log 12 "Error calling 'get_service_data()' - wrong number of parameters"
 
 	__FILE="/usr/lib/ddns/services"					# IPv4
 	[ $use_ipv6 -ne 0 ] && __FILE="/usr/lib/ddns/services_ipv6"	# IPv6
 
-	#remove any lines not containing data, and then make sure fields are enclosed in double quotes
+	# remove any lines not containing data, and then make sure fields are enclosed in double quotes
 	__SERVICES=$(cat $__FILE | grep "^[\t ]*[^#]" | \
 		awk ' gsub("\x27", "\"") { if ($1~/^[^\"]*$/) $1="\""$1"\"" }; { if ( $NF~/^[^\"]*$/) $NF="\""$NF"\""  }; { print $0 }')
 
 	IFS=$__NEWLINE_IFS
 	for __LINE in $__SERVICES; do
-		#grep out proper parts of data and use echo to remove quotes
+		# grep out proper parts of data and use echo to remove quotes
 		__NAME=$(echo $__LINE | grep -o "^[\t ]*\"[^\"]*\"" | xargs -r -n1 echo)
 		__DATA=$(echo $__LINE | grep -o "\"[^\"]*\"[\t ]*$" | xargs -r -n1 echo)
 
@@ -440,7 +440,7 @@ timeout() {
 	return $status
 }
 
-#verify given host and port is connectable
+# verify given host and port is connectable
 # $1	Host/IP to verify
 # $2	Port to verify
 verify_host_port() {
@@ -987,7 +987,7 @@ trap_handler() {
 	local __ERR=${2:-0}
 	local __OLD_IFS=$IFS
 	local __NEWLINE_IFS='
-' #__NEWLINE_IFS
+' # __NEWLINE_IFS
 
 	[ $PID_SLEEP -ne 0 ] && kill -$1 $PID_SLEEP 2>/dev/null	# kill pending sleep if exist
 

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_lucihelper.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_lucihelper.sh
@@ -17,8 +17,6 @@
 
 . /usr/lib/ddns/dynamic_dns_functions.sh	# global vars are also defined here
 
-# set -vx  	#script debugger
-
 # preset some variables, wrong or not set in dynamic_dns_functions.sh
 SECTION_ID="lucihelper"
 LOGFILE="$LOGDIR/$SECTION_ID.log"

--- a/net/ddns-scripts/files/usr/lib/ddns/getlocalip_sample.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/getlocalip_sample.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # sample script for detecting local IP
-# 2014 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+# 2014-2015 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 #
 # activated inside /etc/config/ddns by setting
 #
@@ -10,7 +10,7 @@
 #
 # the script is executed (not parsed) inside get_local_ip() function
 # of /usr/lib/ddns/dynamic_dns_functions.sh
-# 
+#
 # useful when this box is the only DDNS client in the network
 # IP adresses of "internal" boxes could be detected with this script
 # so no need to install ddns client on every "internal" box

--- a/net/ddns-scripts/files/usr/lib/ddns/services
+++ b/net/ddns-scripts/files/usr/lib/ddns/services
@@ -1,28 +1,28 @@
-#444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444
-#4
-#4 This file contains the update urls for various dynamic dns services.
-#4 Column one contains the service name, column two contains the update url.
-#4 within the update url there are 4 variables you can use: [USERNAME],
-#4 [PASSWORD], [DOMAIN] and [IP].  These are substituted for the username,
-#4 password, and domain name specified in the /etc/config/ddns file when an
-#4 update is performed.  The IP is substituted for the current ip address of the
-#4 router.  These variables are case sensitive, while urls generally are not, so
-#4 if you need to enter the same text in the url (which seems very unlikely) put
-#4 that text in lowercase, while the variables should remain in uppercase
-#4
-#4 There are TONS of dynamic dns services out there. There's a huge list of them at:
-#4 http://www.dmoz.org/Computers/Software/Internet/Servers/Address_Management/Dynamic_DNS_Services/
-#4 If anyone has time they could update this file to be compatible with a bunch of them
-#4
-#4 !!! Since ddns-scripts Version 2.x the update of IPv6 addresses is also supported
-#4 !!! This file is used for update of IPv4 adresses only. For IPv6 use services_ipv6
-#4
-#4 !!! Since ddns-scripts Version 2.x the update via provider specific update scripts is supported.
-#4 !!! This scripts must be located at /usr/lib/ddns directory if defined inside this file.
-#4 !!! Use only the script name (without path). Sample:
-#4 !!! "example.com"	"update_sample.sh"
-#4
-#444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444
+# 44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444
+#
+# This file contains the update urls for various dynamic dns services.
+# Column one contains the service name, column two contains the update url.
+# within the update url there are 4 variables you can use: [USERNAME],
+# [PASSWORD], [DOMAIN] and [IP].  These are substituted for the username,
+# password, and domain name specified in the /etc/config/ddns file when an
+# update is performed.  The IP is substituted for the current ip address of the
+# router.  These variables are case sensitive, while urls generally are not, so
+# if you need to enter the same text in the url (which seems very unlikely) put
+# that text in lowercase, while the variables should remain in uppercase
+#
+# There are TONS of dynamic dns services out there. There's a huge list of them at:
+# http://www.dmoz.org/Computers/Software/Internet/Servers/Address_Management/Dynamic_DNS_Services/
+# If anyone has time they could update this file to be compatible with a bunch of them
+#
+# !!! Since ddns-scripts Version 2.x the update of IPv6 addresses is also supported
+# !!! This file is used for update of IPv4 adresses only. For IPv6 use services_ipv6
+#
+# !!! Since ddns-scripts Version 2.x the update via provider specific update scripts is supported.
+# !!! This scripts must be located at /usr/lib/ddns directory if defined inside this file.
+# !!! Use only the script name (without path). Sample:
+# !!! "example.com"	"update_sample.sh"
+#
+# 44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444
 
 "dyndns.org"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"
 "changeip.com"		"http://[USERNAME]:[PASSWORD]@nic.changeip.com/nic/update?u=[USERNAME]&p=[PASSWORD]&cmd=update&hostname=[DOMAIN]&ip=[IP]"
@@ -34,7 +34,7 @@
 "no-ip.com"	"update_no-ip.sh"
 "noip.com"	"update_no-ip.sh"
 
-#freedns.afraid.org is weird, you just need an update code, for which we use the password variable
+# freedns.afraid.org is weird, you just need an update code, for which we use the password variable
 "freedns.afraid.org"	"http://freedns.afraid.org/dynamic/update.php?[PASSWORD]&address=[IP]"
 
 # DNS Max and resellers' update urls

--- a/net/ddns-scripts/files/usr/lib/ddns/services_ipv6
+++ b/net/ddns-scripts/files/usr/lib/ddns/services_ipv6
@@ -1,40 +1,43 @@
-#666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666
-#6
-#6 This file contains the update urls for various dynamic dns services.
-#6 Column one contains the service name, column two contains the update url.
-#6 within the update url there are 4 variables you can use: [USERNAME],
-#6 [PASSWORD], [DOMAIN] and [IP].  These are substituted for the username,
-#6 password, and domain name specified in the /etc/config/ddns file when an
-#6 update is performed.  The IP is substituted for the current ip address of the
-#6 router.  These variables are case sensitive, while urls generally are not, so
-#6 if you need to enter the same text in the url (which seems very unlikely) put
-#6 that text in lowercase, while the variables should remain in uppercase
-#6
-#6 There are TONS of dynamic dns services out there. There's a huge list of them at:
-#6 http://www.dmoz.org/Computers/Software/Internet/Servers/Address_Management/Dynamic_DNS_Services/
-#6 If anyone has time they could update this file to be compatible with a bunch of them
-#6
-#6 !!! Since ddns-scripts Version 2.x the update of IPv6 addresses is also supported
-#6 !!! This file is used for update of IPv6 adresses only. For IPv4 use services
-#6
-#6 !!! Since ddns-scripts Version 2.x the update via provider specific update scripts is supported.
-#6 !!! This scripts must be located at /usr/lib/ddns directory if defined inside this file.
-#6 !!! Use only the script name (without path). Sample:
-#6 !!! "example.com"	"update_sample.sh"
-#6
-#666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666
+# 66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666
+#
+# This file contains the update urls for various dynamic dns services.
+# Column one contains the service name, column two contains the update url.
+# within the update url there are 4 variables you can use: [USERNAME],
+# [PASSWORD], [DOMAIN] and [IP].  These are substituted for the username,
+# password, and domain name specified in the /etc/config/ddns file when an
+# update is performed.  The IP is substituted for the current ip address of the
+# router.  These variables are case sensitive, while urls generally are not, so
+# if you need to enter the same text in the url (which seems very unlikely) put
+# that text in lowercase, while the variables should remain in uppercase
+#
+# There are TONS of dynamic dns services out there. There's a huge list of them at:
+# http://www.dmoz.org/Computers/Software/Internet/Servers/Address_Management/Dynamic_DNS_Services/
+# If anyone has time they could update this file to be compatible with a bunch of them
+#
+# !!! Since ddns-scripts Version 2.x the update of IPv6 addresses is also supported
+# !!! This file is used for update of IPv6 adresses only. For IPv4 use services
+#
+# !!! Since ddns-scripts Version 2.x the update via provider specific update scripts is supported.
+# !!! This scripts must be located at /usr/lib/ddns directory if defined inside this file.
+# !!! Use only the script name (without path). Sample:
+# !!! "example.com"	"update_sample.sh"
+#
+# 66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666
 
-#IPv6 @ Securepoint Dynamic-DNS-Service
+# IPv6 @ Securepoint Dynamic-DNS-Service
 "spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"
 
-#IPv6 @ Hurricane Electric Dynamic DNS
+# IPv6 @ Hurricane Electric Dynamic DNS
 "he.net"	"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"
 
-#IPv6 @ MyDNS.JP
+# IPv6 @ MyDNS.JP
 "mydns.jp"	"http://www.mydns.jp/directip.html?MID=[USERNAME]&PWD=[PASSWORD]&IPV6ADDR=[IP]"
 
-#IPv6 @ Cloudflare
+# IPv6 @ Cloudflare
 "cloudflare.com"	"update_cloudflare.sh"
 
-#IPv6 @ no-ip.pl nothing to do with no-ip.com (domain registered to www.domeny.tv) (IP autodetected by provider)
+# IPv6 @ no-ip.pl nothing to do with no-ip.com (domain registered to www.domeny.tv) (IP autodetected by provider)
 "no-ip.pl"	"http://[USERNAME]:[PASSWORD]@update.no-ip.pl/?hostname=[DOMAIN]"
+
+# IPv6 @ freedns.afraid.org
+"freedns.afraid.org"	"http://freedns.afraid.org/dynamic/update.php?[PASSWORD]&address=[IP]"

--- a/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_cloudflare.sh
@@ -1,6 +1,6 @@
 #
 # script for sending updates to cloudflare.com
-# 2014 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+# 2014-2015 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 # many thanks to Paul for testing and feedback during development
 #
 # This script is parsed by dynamic_dns_functions.sh inside send_update() function
@@ -14,6 +14,8 @@
 # variable __IP already defined with the ip-address to use for update
 #
 [ $use_https -eq 0 ] && write_log 14 "Cloudflare only support updates via Secure HTTP (HTTPS). Please correct configuration!"
+[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
+[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"
 
 local __RECID __URL __KEY __KEYS __FOUND __SUBDOM __DOMAIN __TLD
 
@@ -46,7 +48,7 @@ grep -i "json_get_keys" /usr/share/libubox/jshn.sh >/dev/null 2>&1 || json_get_k
 
 # function to "sed" unwanted string parts from DATFILE
 cleanup() {
-	#based on the sample output on cloudflare.com homepage we need to do some cleanup
+	# based on the sample output on cloudflare.com homepage we need to do some cleanup
 	sed -i 's/^[ \t]*//;s/[ \t]*$//' $DATFILE	# remove invisible chars at beginning and end of lines
 	sed -i '/^-$/d' $DATFILE			# remove lines with "-" (dash)
 	sed -i '/^$/d' $DATFILE				# remove empty lines

--- a/net/ddns-scripts/files/usr/lib/ddns/update_no-ip.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_no-ip.sh
@@ -1,6 +1,6 @@
 #
 # script for sending updates to no-ip.com / noip.com
-# 2014 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+# 2014-2015 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 #
 # This script is parsed by dynamic_dns_functions.sh inside send_update() function
 #
@@ -9,6 +9,9 @@
 #
 local __DUMMY
 local __UPDURL="http://[USERNAME]:[PASSWORD]@dynupdate.no-ip.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
+# inside url we need username and password
+[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
+[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"
 
 # set IP version dependend dummy (localhost)
 [ $use_ipv6 -eq 0 ] && __DUMMY="127.0.0.1" || __DUMMY="::1"

--- a/net/ddns-scripts/files/usr/lib/ddns/update_sample.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/update_sample.sh
@@ -1,5 +1,5 @@
 # sample script for sending user defined updates
-# 2014 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+# 2014-2015 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 #
 # activated inside /etc/config/ddns by setting
 #
@@ -18,6 +18,9 @@
 #
 # tested with spdns.de
 local __URL="http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"
+# inside url we need username and password
+[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
+[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"
 
 # do replaces in URL
 __URL=$(echo $__URL | sed -e "s#\[USERNAME\]#$URL_USER#g" -e "s#\[PASSWORD\]#$URL_PASS#g" \


### PR DESCRIPTION
restructure startup of dnymaic_dns_updater.sh
 - first run load_all_config_options (it returns 1 if SECTION_ID not found) #779
 - verify if username and/or password if needed inside update_url #779
 - remove wait - will be done by retry_interval and retry_count if communication fails

provider specific update scripts
 - verify if username/password are given

services_ipv6
 - added freedns.afraid.org
 - IPv6 should work due to their documentation

minor fixes

Signed-off-by: Christian Schoenebeck <christian.schoenebeck@gmail.com>