### PR TITLE
Davfs2: fixed issue with automake

### DIFF
--- a/net/davfs2/Makefile
+++ b/net/davfs2/Makefile
@@ -15,6 +15,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.savannah.gnu.org/releases/davfs2/
 PKG_MD5SUM:=376bc9346454135cba78afacbcb23f86
 
+PKG_FIXUP:=autoreconf
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/davfs2


### PR DESCRIPTION
Fixes build error 785 (https://github.com/openwrt/packages/pull/785)
Signed-off-by: Federico Di Marco fededim@gmail.com