### PR TITLE
mdnsresponder: Replace whitespace to hyphen for DNS conformant.

### DIFF
--- a/net/mdnsresponder/patches/101-replace_whitespace_to_hyphen_for_dns_comformant.patch
+++ b/net/mdnsresponder/patches/101-replace_whitespace_to_hyphen_for_dns_comformant.patch
@@ -1,0 +1,16 @@
+--- a/mDNSPosix/mDNSPosix.c
++++ b/mDNSPosix/mDNSPosix.c
+@@ -477,8 +477,13 @@
+ mDNSlocal void GetUserSpecifiedRFC1034ComputerName(domainlabel *const namelabel)
+ {
+     int len = 0;
++    int idx = 0;
+     gethostname((char *)(&namelabel->c[1]), MAX_DOMAIN_LABEL);
+     while (len < MAX_DOMAIN_LABEL && namelabel->c[len+1] && namelabel->c[len+1] != '.') len++;
++
++    idx = len;
++    do { if (namelabel->c[idx+1] == ' ') namelabel->c[idx+1] = '-'; } while (idx-- >= 1);
++
+     namelabel->c[0] = len;
+ }
+ 


### PR DESCRIPTION
mdnsresponder: mdnsresponder: Replace whitespace to hyphen for DNS conformant

Since POSIX implementation take `gethostname` as default namelable,
however white space is not acceptable as domain name.

Signed-off-by: Kent Chen <chenkaie@gmail.com>