### PR TITLE
muninlite: uptime should report days, not seconds.

### DIFF
--- a/admin/muninlite/patches/110-fix-uptime-days.patch
+++ b/admin/muninlite/patches/110-fix-uptime-days.patch
@@ -1,0 +1,9 @@
+--- a/plugins/uptime
++++ b/plugins/uptime
+@@ -7,5 +7,5 @@
+   echo "uptime.cdef uptime,86400,/"
+ }
+ fetch_uptime() {
+-  echo "uptime.value" $(cut -d\  -f1 /proc/uptime)
++  awk '{printf "uptime.value %.2f",$1/86400; print ""}' /proc/uptime
+ }


### PR DESCRIPTION
upstream bug: https://sourceforge.net/p/muninlite/patches/8/

Signed-off-by: Craig Gallek <cgallek@gmail.com>