### PR TITLE
alpine: update to 2.20

### DIFF
--- a/mail/alpine/Makefile
+++ b/mail/alpine/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alpine
-PKG_VERSION:=2.11
+PKG_VERSION:=2.20
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://patches.freeiz.com/alpine/release/src/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MD5SUM:=a3bba218787691080d706b36215eec06
+PKG_MD5SUM:=043b67666af73b26f9627ad97e2aaf92
 
 PKG_MAINTAINER:=Antti Seppälä <a.seppala@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -101,14 +101,6 @@ ifeq ($(CONFIG_IPV6),y)
 else
   DISABLE_IPV6:=--without-ipv6
 endif
-
-define Build/Configure
-	$(call Build/Configure/Default)
-	( cd $(PKG_BUILD_DIR)/regex ; \
-		make ; \
-	)
-	$(call Build/Configure/Default)
-endef
 
 define Build/Compile
 	( cd $(PKG_BUILD_DIR)/pith ; \

--- a/mail/alpine/patches/100-no-openssl-check-cross-compile.patch
+++ b/mail/alpine/patches/100-no-openssl-check-cross-compile.patch
@@ -1,0 +1,29 @@
+diff -Nru alpine-2.20-orig/configure alpine-2.20/configure
+--- alpine-2.20-orig/configure	2015-01-18 09:00:42.100645053 +0200
++++ alpine-2.20/configure	2015-01-25 12:01:11.831015443 +0200
+@@ -17643,10 +17643,8 @@
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking Openssl library version >= 1.0.1c" >&5
+ $as_echo_n "checking Openssl library version >= 1.0.1c... " >&6; }
+   if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
++   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: cross compiling: not checking" >&5
++$as_echo "$as_me: WARNING: cross compiling: not checking" >&2;}
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+diff -Nru alpine-2.20-orig/configure.ac alpine-2.20/configure.ac
+--- alpine-2.20-orig/configure.ac	2015-01-18 08:38:08.893495949 +0200
++++ alpine-2.20/configure.ac	2015-01-25 12:01:02.773015236 +0200
+@@ -1370,7 +1370,8 @@
+ }
+ 	]])],
+ 	[ AC_MSG_RESULT(yes) ],
+-	[ alpine_SSLTYPE="none" ])
++	[ alpine_SSLTYPE="none" ],
++	[ AC_MSG_WARN([cross compiling: not checking])])
+ 
+     if test "x$alpine_SSLTYPE" = "xnone" ; then
+ 	AC_MSG_ERROR(Install openssl version >= 1.0.1c)


### PR DESCRIPTION
New version requires a patch to skip openssl runtime checking when cross-compiling.

Signed-off-by: Antti Seppälä <a.seppala@gmail.com>