### PR TITLE
ddns-scripts: Add domains.google.com

### DIFF
--- a/net/ddns-scripts/files/usr/lib/ddns/services
+++ b/net/ddns-scripts/files/usr/lib/ddns/services
@@ -25,6 +25,7 @@
 # 44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444
 
 "dyndns.org"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"
+"domains.google.com"	"http://[USERNAME]:[PASSWORD]@domains.google.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
 "changeip.com"		"http://[USERNAME]:[PASSWORD]@nic.changeip.com/nic/update?u=[USERNAME]&p=[PASSWORD]&cmd=update&hostname=[DOMAIN]&ip=[IP]"
 "zoneedit.com"		"http://[USERNAME]:[PASSWORD]@dynamic.zoneedit.com/auth/dynamic.html?host=[DOMAIN]&dnsto=[IP]"
 "free.editdns.net"	"http://dyndns-free.editdns.net/api/dynLinux.php?p=[PASSWORD]&r=[DOMAIN]"


### PR DESCRIPTION
@chris5560: This PR add DDNS support for [Google Domains](https://domains.google.com).

Reference: https://support.google.com/domains/answer/6147083

Signed-off-by: なつき <i@ntk.me>