### PR TITLE
glib2: fix missing gobject library when linking glib-compile-resources (#826)

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2012 OpenWrt.org
+# Copyright (C) 2007-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -20,6 +20,8 @@ PKG_BUILD_DEPENDS:=glib2/host libpthread zlib libintl libffi
 HOST_BUILD_DEPENDS:=libintl/host libiconv/host libffi/host
 PKG_INSTALL:=1
 PKG_USE_MIPS16:=0
+
+PKG_FIXUP:=autoreconf
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/glib-$(PKG_VERSION)
 

--- a/libs/glib2/patches/001-automake-compat.patch
+++ b/libs/glib2/patches/001-automake-compat.patch
@@ -1,0 +1,11 @@
+--- a/gtk-doc.make
++++ b/gtk-doc.make
+@@ -267,7 +267,7 @@ uninstall-local:
+ #
+ # Require gtk-doc when making dist
+ #
+-if HAVE_GTK_DOC
++if ENABLE_GTK_DOC
+ dist-check-gtkdoc: docs
+ else
+ dist-check-gtkdoc:

--- a/libs/glib2/patches/100-fix-gio-linking.patch
+++ b/libs/glib2/patches/100-fix-gio-linking.patch
@@ -1,0 +1,10 @@
+--- a/gio/Makefile.am
++++ b/gio/Makefile.am
+@@ -695,6 +695,7 @@ bin_PROGRAMS = gio-querymodules glib-com
+ 
+ glib_compile_resources_LDADD = libgio-2.0.la 		\
+ 	$(top_builddir)/gobject/libgobject-2.0.la	\
++	$(top_builddir)/gmodule/libgmodule-2.0.la	\
+ 	$(top_builddir)/glib/libglib-2.0.la 		\
+ 	$(NULL)
+ 


### PR DESCRIPTION
The automake template does not specify libgobject-2.0.la as _LDADD dependency
for glib-compile-resources, leading to the following linker error:

    .../ld: warning: libgmodule-2.0.so.0, needed by ./.libs/libgio-2.0.so, not found (try using -rpath or -rpath-link)
    ./.libs/libgio-2.0.so: undefined reference to `g_module_supported'
    ./.libs/libgio-2.0.so: undefined reference to `g_module_symbol'
    ./.libs/libgio-2.0.so: undefined reference to `g_module_close'
    ./.libs/libgio-2.0.so: undefined reference to `g_module_error'
    ./.libs/libgio-2.0.so: undefined reference to `g_module_open'
    collect2: error: ld returned 1 exit status

This commit introduces a patch to add the missing libtool archive to the list
of libraries to link.

Due to the update of the .am file, a full autoreconf is required to update
configure and Makefile, leading to the following error:

  error: HAVE_GTK_DOC does not appear in AM_CONDITIONAL

Therfore another patch is added to properly fix the conditional when using
automake-1.15.

Finally extend the copyright year in the Makefile and enable the generic
autoreconf fixup to properly build and link glib2.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>