### PR TITLE
[zoneinfo] Updated to a most recent version.

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2014j
-PKG_VERSION_CODE:=2014j
+PKG_VERSION:=2015a
+PKG_VERSION_CODE:=2015a
 PKG_RELEASE:=2
 
 #As i couldn't find real license used "Puplic Domain"


### PR DESCRIPTION
From mail list:
The 2015a release of the tz code and data is available.  It reflects the
following changes, which were either circulated on the tz mailing list
or are relatively minor technical or administrative changes:

   Changes affecting future time stamps

     The Mexican state of Quintana Roo, represented by America/Cancun,
     will shift from Central Time with DST to Eastern Time without DST
     on 2015-02-01 at 02:00.  (Thanks to Steffen Thorsen and Gwillim Law.)

     Chile will not change clocks in April or thereafter; its new
standard time
     will be its old daylight saving time.  This affects America/Santiago,
     Pacific/Easter, and Antarctica/Palmer.  (Thanks to Juan Correa.)

     New leap second 2015-06-30 23:59:60 UTC as per IERS Bulletin C 49.
     (Thanks to Tim Parenti.)

   Changes affecting past time stamps

     Iceland observed DST in 1919 and 1921, and its 1939 fallback
     transition was Oct. 29, not Nov. 29.  Remove incorrect data from
     Shanks about time in Iceland between 1837 and 1908.

     Some more zones have been turned into links, when they differed
     from existing zones only for older time stamps.  As usual,
     these changes affect UTC offsets in pre-1970 time stamps only.
     Their old contents have been moved to the 'backzone' file.
     The affected zones are: Asia/Aden, Asia/Bahrain, Asia/Kuwait,
     and Asia/Muscat.

   Changes affecting code

     tzalloc now scrubs time zone abbreviations compatibly with the way
     that tzset always has, by replacing invalid bytes with '_' and by
     shortening too-long abbreviations.

     tzselect ports to POSIX awk implementations, no longer mishandles
     POSIX TZ settings when GNU awk is used, and reports POSIX TZ
     settings to the user.  (Thanks to Stefan Kuhn.)

   Changes affecting build procedure

     'make check' now checks for links to links in the data.
     One such link (for Africa/Asmera) has been fixed.
     (Thanks to Stephen Colebourne for pointing out the problem.)

   Changes affecting commentary

     The leapseconds file commentary now mentions the expiration date.
     (Problem reported by Martin Burnicki.)

     Update Mexican Library of Congress URL.