### PR TITLE
ddns-scripts: update to version 2.2.0-1

### DIFF
--- a/net/ddns-scripts/Config.in
+++ b/net/ddns-scripts/Config.in
@@ -1,0 +1,59 @@
+if PACKAGE_ddns-scripts
+
+	comment "Options to reduce the size of installed package"
+
+	config DDNS-SCRIPTS_small
+		bool "Remove sample files and comments"
+		help
+			Remove comments from files an do not install sample files
+		default n
+
+	comment "Install Sample files"
+		depends on !DDNS-SCRIPTS_small
+
+	config  DDNS-SCRIPTS_sample-config
+		depends on !DDNS-SCRIPTS_small
+		bool "Install sample configuration"
+		help
+			Install /etc/config/ddns.sample
+			full commented ddns configuration
+		default y
+
+	config  DDNS-SCRIPTS_sample-update
+		depends on !DDNS-SCRIPTS_small
+		bool "Install provider update sample script"
+		help
+			Sample how to write a provider specific update script
+			Install /usr/lib/ddns/update_sample.sh
+		default n
+
+	config  DDNS-SCRIPTS_sample-getlocalip
+		depends on !DDNS-SCRIPTS_small
+		bool "Install 'get local ip' sample script"
+		help
+			Sample how to write a script to detect an IP address 
+			and return data to the main scripts.
+			Install /usr/lib/ddns/getlocalip_sample.sh
+		default n
+
+	comment "Install Provider specific scripts"
+
+	config  DDNS-SCRIPTS_provider-cloudflare-com
+		bool "Install support for cloudflare.com"
+		help
+			Script to fulfill specific API requirements to
+			update DDNS at cloudflare.com 
+			Install /usr/lib/ddns/update_cloudflare.sh
+			and     /usr/lib/ddns/tld_names.dat
+		default y
+
+	config  DDNS-SCRIPTS_provider-noip-com
+		bool "Install support for no-ip.com"
+		help
+			Script as workaround to let no-ip.com think that
+			the client IP has changed since last update.
+			Install /usr/lib/ddns/update_no-ip.sh
+		default y
+
+
+endif

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -1,8 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ddns-scripts
-PKG_VERSION:=2.1.0
-PKG_RELEASE:=5
+# Version == major.minor.patch
+# increase on new functionality (minor) or patches (patch)
+PKG_VERSION:=2.2.0
+# Release == build
+# increase on changes of services files or tld_names.dat
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
 
@@ -10,55 +14,111 @@ PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/ddns-scripts
+define Package/$(PKG_NAME)
     SECTION:=net
     CATEGORY:=Network
     SUBMENU:=IP Addresses and Names
-    TITLE:=Dynamic DNS Scripts (with IPv6 support)
+    TITLE:=Dynamic DNS Client scripts (with IPv6 support)
+    URL:=http://wiki.openwrt.org/doc/howto/ddns.client
+    DEPENDS:=
     PKGARCH:=all
+    MENU:=1
 endef
 
-define Package/ddns-scripts/description
-A highly configurable set of scripts for doing dynamic dns updates.
-	- IPv6 support
-	- force communication to IPv4 or IPv6 only
-	- DNS server support
-	- using BIND host if installed
-	- DNS requests via TCP
-	- Proxy server support
-	- log file support
-	- support to run once
+# shown in LuCI package description
+define Package/$(PKG_NAME)/description
+    $(TITLE) - Info: http://wiki.openwrt.org/doc/howto/ddns.client
+endef
+
+define Package/$(PKG_NAME)/config
+	# shown in menuconfig <Help>
+	help
+		A highly configurable set of scripts for doing dynamic dns updates.
+		  - IPv6 support
+		  - force communication to IPv4 or IPv6 only
+		  - DNS server support
+		  - using BIND host if installed
+		  - DNS requests via TCP
+		  - Proxy server support
+		  - log file support
+		  - support to run once
+
+		Version: $(PKG_VERSION)-$(PKG_RELEASE)
+		Info   : $(URL)
+
+		$(PKG_MAINTAINER)
+
+	source "$(SOURCE)/Config.in"
 endef
 
 define Build/Prepare
+	$(CP) ./files/* $(PKG_BUILD_DIR)
 endef
 
 define Build/Configure
 endef
 
 define Build/Compile
+	if [ "$(CONFIG_DDNS-SCRIPTS_small)" = "y" ]; then \
+		rm -f $(PKG_BUILD_DIR)/etc/config/ddns.sample; \
+		rm -f $(PKG_BUILD_DIR)/usr/lib/ddns/update_sample.sh; \
+		rm -f $(PKG_BUILD_DIR)/usr/lib/ddns/getlocalip_sample.sh; \
+		DIRS="usr etc/hotplug.d etc/init.d"; \
+		for DIR in $$$$DIRS; do \
+			for FILE in `find $(PKG_BUILD_DIR)/$$$$DIR -type f`; do \
+				$(SED) '/^\s*$$$$/ d' $$$$FILE; \
+				$(SED) '/^\/\/\s/ d' $$$$FILE; \
+				$(SED) 's/^\s*#/#/' $$$$FILE; \
+				$(SED) '/^#\s/ d' $$$$FILE; \
+				$(SED) '/^#*$$$$/ d' $$$$FILE; \
+				$(SED) 's/\s#\s.*$$$$//' $$$$FILE; \
+				$(SED) 's/\s*$$$$//' $$$$FILE; \
+			done; \
+		done; \
+	fi
+
+	[ "$(CONFIG_DDNS-SCRIPTS_sample-config)" = "y" ] || \
+		rm -f $(PKG_BUILD_DIR)/etc/config/ddns.sample
+
+	[ "$(CONFIG_DDNS-SCRIPTS_sample-update)" = "y" ] || \
+		rm -f $(PKG_BUILD_DIR)/usr/lib/ddns/update_sample.sh
+
+	[ "$(CONFIG_DDNS-SCRIPTS_sample-getlocalip)" = "y" ] || \
+		rm -f $(PKG_BUILD_DIR)/usr/lib/ddns/getlocalip_sample.sh
+
+	[ "$(CONFIG_DDNS-SCRIPTS_provider-cloudflare-com)" = "y" ] || { \
+		rm -f $(PKG_BUILD_DIR)/usr/lib/ddns/update_cloudflare.sh; \
+		rm -f $(PKG_BUILD_DIR)/usr/lib/ddns/tld_names.dat; \
+		$(SED) '/update_cloudflare\.sh/ d' $(PKG_BUILD_DIR)/usr/lib/ddns/services; \
+		$(SED) '/update_cloudflare\.sh/ d' $(PKG_BUILD_DIR)/usr/lib/ddns/services_ipv6; \
+	}
+	[ "$(CONFIG_DDNS-SCRIPTS_provider-noip-com)" = "y" ] || { \
+		rm -f $(PKG_BUILD_DIR)/usr/lib/ddns/update_no-ip.sh; \
+		$(SED) '/update_no-ip\.sh/ d' $(PKG_BUILD_DIR)/usr/lib/ddns/services; \
+		$(SED) '/update_no-ip\.sh/ d' $(PKG_BUILD_DIR)/usr/lib/ddns/services_ipv6; \
+	}
 endef
 
-define Package/ddns-scripts/conffiles
+define Package/$(PKG_NAME)/conffiles
 /etc/config/ddns
 endef
 
-define Package/ddns-scripts/install
+define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_CONF) ./files/etc/config/* $(1)/etc/config
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/etc/config/* $(1)/etc/config
 
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
-	$(INSTALL_BIN) ./files/etc/hotplug.d/iface/* $(1)/etc/hotplug.d/iface
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/etc/hotplug.d/iface/* $(1)/etc/hotplug.d/iface
 
 	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) ./files/etc/init.d/* $(1)/etc/init.d/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/etc/init.d/* $(1)/etc/init.d/
 
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
-	$(INSTALL_DATA) ./files/usr/lib/ddns/* $(1)/usr/lib/ddns
-	$(INSTALL_BIN)  ./files/usr/lib/ddns/*.sh $(1)/usr/lib/ddns
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/usr/lib/ddns/* $(1)/usr/lib/ddns
+	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/usr/lib/ddns/*.sh $(1)/usr/lib/ddns
 endef
 
-define Package/ddns-scripts/postinst
+define Package/$(PKG_NAME)/postinst
 	#!/bin/sh
 	# if run within buildroot exit
 	[ -n "$${IPKG_INSTROOT}" ] && exit 0
@@ -76,7 +136,7 @@ define Package/ddns-scripts/postinst
 	exit 0
 endef
 
-define Package/ddns-scripts/prerm
+define Package/$(PKG_NAME)/prerm
 	#!/bin/sh
 	# if run within buildroot exit
 	[ -n "$${IPKG_INSTROOT}" ] && exit 0
@@ -91,4 +151,4 @@ define Package/ddns-scripts/prerm
 	exit 0
 endef
 
-$(eval $(call BuildPackage,ddns-scripts))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/net/ddns-scripts/files/etc/config/ddns.sample
+++ b/net/ddns-scripts/files/etc/config/ddns.sample
@@ -245,6 +245,17 @@ config service "myddns"
 	# default: none
 #	option proxy ''
 
+	###########
+	# In some very special configurations i.e. Multi WAN environment
+	# in a NAT cascade it might be necessary to define
+	# a network to use for communication.
+	# should use option ip_source "web" (see above)
+	# Needs GNU Wget (with SSL support) or cURL to be installed.
+	# GNU Wget will use IP address and cURL the physical device 
+	# of the given network
+	# default: none
+#	option bind_network "wan7"
+
 	########### Timer settings ########################
 
 	###########

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -638,6 +638,16 @@ do_transfer() {
 	# lets prefer GNU Wget because it does all for us - IPv4/IPv6/HTTPS/PROXY/force IP version
 	if /usr/bin/wget --version 2>&1 | grep "\+ssl" >/dev/null 2>&1 ; then
 		__PROG="/usr/bin/wget -nv -t 1 -O $DATFILE -o $ERRFILE"	# non_verbose no_retry outfile errfile
+		# force network/ip to use for communication
+		if [ -n "$bind_network" ]; then
+			local __BINDIP
+			# set correct program to detect IP
+			[ $use_ipv6 -eq 0 ] && __RUNPROG="network_get_ipaddr" || __RUNPROG="network_get_ipaddr6"
+			eval "$__RUNPROG __BINDIP $bind_network" || \
+				write_log 13 "Can not detect local IP using '$__RUNPROG $bind_network' - Error: '$?'"
+			write_log 7 "Force communication via IP '$__BINDIP'"
+			__PROG="$__PROG --bind-address=$__BINDIP"
+		fi
 		# force ip version to use
 		if [ $force_ipversion -eq 1 ]; then
 			[ $use_ipv6 -eq 0 ] && __PROG="$__PROG -4" || __PROG="$__PROG -6"	# force IPv4/IPv6
@@ -664,6 +674,14 @@ do_transfer() {
 	# libcurl might be compiled without Proxy Support (default in trunk)
 	elif [ -x /usr/bin/curl ]; then
 		__PROG="/usr/bin/curl -RsS -o $DATFILE --stderr $ERRFILE"
+		# force network/interface-device to use for communication
+		if [ -n "$bind_network" ]; then
+			local __DEVICE
+			network_get_physdev __DEVICE $bind_network || \
+				write_log 13 "Can not detect local device using 'network_get_physdev $bind_network' - Error: '$?'"
+			write_log 7 "Force communication via device '$__DEVICE'"
+			__PROG="$__PROG --interface $__DEVICE"
+		fi
 		# force ip version to use
 		if [ $force_ipversion -eq 1 ]; then
 			[ $use_ipv6 -eq 0 ] && __PROG="$__PROG -4" || __PROG="$__PROG -6"	# force IPv4/IPv6
@@ -697,9 +715,12 @@ do_transfer() {
 	# busybox Wget (did not support neither IPv6 nor HTTPS)
 	elif [ -x /usr/bin/wget ]; then
 		__PROG="/usr/bin/wget -q -O $DATFILE"
+		# force network/ip not supported
+		[ -n "$__BINDIP" ] && \
+			write_log 14 "BusyBox Wget: FORCE binding to specific address not supported"
 		# force ip version not supported
 		[ $force_ipversion -eq 1 ] && \
-			write_log 14 "BusyBox Wget: can not force IP version to use"
+			write_log 14 "BusyBox Wget: Force connecting to IPv4 or IPv6 addresses not supported"
 		# https not supported
 		[ $use_https -eq 1 ] && \
 			write_log 14 "BusyBox Wget: no HTTPS support"
@@ -752,7 +773,7 @@ send_update() {
 
 	if [ $ALLOW_LOCAL_IP -eq 0 ]; then
 		# verify given IP / no private IPv4's / no IPv6 addr starting with fxxx of with ":"
-		[ $use_ipv6 -eq 0 ] && __IP=$(echo $1 | grep -v -E "(^0|^10\.|^127|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168)")
+		[ $use_ipv6 -eq 0 ] && __IP=$(echo $1 | grep -v -E "(^0|^10\.|^100\.6[4-9]\.|^100\.[7-9][0-9]\.|^100\.1[0-1][0-9]\.|^100\.12[0-7]\.|^127|^169\.254|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168)")
 		[ $use_ipv6 -eq 1 ] && __IP=$(echo $1 | grep "^[0-9a-eA-E]")
 		[ -z "$__IP" ] && write_log 14 "Private or invalid or no IP '$1' given! Please check your configuration"
 	else
@@ -788,7 +809,7 @@ get_local_ip () {
 	local __RUNPROG __DATA __URL __ERR
 
 	[ $# -ne 1 ] && write_log 12 "Error calling 'get_local_ip()' - wrong number of parameters"
-	write_log 7 "Detect local IP"
+	write_log 7 "Detect local IP on '$ip_source'"
 
 	while : ; do
 		case $ip_source in
@@ -796,8 +817,8 @@ get_local_ip () {
 				# set correct program
 				[ $use_ipv6 -eq 0 ] && __RUNPROG="network_get_ipaddr" \
 						    || __RUNPROG="network_get_ipaddr6"
-				write_log 7 "#> $__RUNPROG __DATA '$ip_network'"
-				eval "$__RUNPROG __DATA $ip_network" || write_log 3 "$__RUNPROG Error: '$?'"
+				eval "$__RUNPROG __DATA $ip_network" || \
+					write_log 13 "Can not detect local IP using $__RUNPROG '$ip_network' - Error: '$?'"
 				[ -n "$__DATA" ] && write_log 7 "Local IP '$__DATA' detected on network '$ip_network'"
 				;;
 			interface)
@@ -857,7 +878,7 @@ get_local_ip () {
 				[ $use_ipv6 -eq 0 ] \
 					&& __DATA=$(grep -m 1 -o "$IPV4_REGEX" $DATFILE) \
 					|| __DATA=$(grep -m 1 -o "$IPV6_REGEX" $DATFILE)
-				[ -n "$__DATA" ] && write_log 7 "Local IP '$__DATA' detected on web at '$__URL'"
+				[ -n "$__DATA" ] && write_log 7 "Local IP '$__DATA' detected on web at '$ip_url'"
 				;;
 			*)
 				write_log 12 "Error in 'get_local_ip()' - unhandled ip_source '$ip_source'"

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_functions.sh
@@ -235,6 +235,7 @@ write_log() {
 	fi
 	[ $LUCI_HELPER ]   && return	# nothing else todo when running LuCI helper script
 	[ $__LEVEL -eq 7 ] && return	# no syslog for debug messages
+	__CMD=$(echo -e "$__CMD" | tr -d '\n' | tr '\t' '     ')        # remove \n \t chars
 	[ $__EXIT  -eq 1 ] && {
 		$__CMD		# force syslog before exit
 		exit 1

--- a/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/usr/lib/ddns/dynamic_dns_updater.sh
@@ -147,7 +147,7 @@ ERR_LAST=$?	# save return code - equal 0 if SECTION_ID found
 write_log 7 "************ ************** ************** **************"
 write_log 5 "PID '$$' started at $(eval $DATE_PROG)"
 write_log 7 "uci configuration:\n$(uci -q show ddns.$SECTION_ID | sort)"
-write_log 7 "ddns version  : $(opkg list-installed ddns-scripts | awk '{print $3}')"
+write_log 7 "ddns version  : $(opkg list-installed ddns-scripts | cut -d ' ' -f 3)"
 case $VERBOSE_MODE in
 	0) write_log  7 "verbose mode  : 0 - run normal, NO console output";;
 	1) write_log  7 "verbose mode  : 1 - run normal, console mode";;

--- a/net/ddns-scripts/files/usr/lib/ddns/services
+++ b/net/ddns-scripts/files/usr/lib/ddns/services
@@ -96,3 +96,6 @@
 
 # no-ip.pl nothing to do with no-ip.com (domain registered to www.domeny.tv) (IP autodetected by provider)
 "no-ip.pl"	"http://[USERNAME]:[PASSWORD]@update.no-ip.pl/?hostname=[DOMAIN]"
+
+# domains.google.com	non free service - require HTTPS communication
+"domains.google.com"	"https://[USERNAME]:[PASSWORD]@domains.google.com/nic/update?hostname=[DOMAIN]&myip=[IP]"


### PR DESCRIPTION
- added IPv4 100.64/10 (RFC 6598) and 169.254/16 (RFC 5735) to the range of default blocked IP's.
- added option "bind_network" to force GNU Wget or cURL to use specific network/interface for communication
- modified Makefile/Config.in to support to minimize package size
- added "domains.google.com" as IPv4 DDNS provider #822

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>