### PR TITLE
dosfstools: bump to new upstream version 3.0.27

### DIFF
--- a/utils/dosfstools/Makefile
+++ b/utils/dosfstools/Makefile
@@ -1,0 +1,109 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dosfstools
+PKG_VERSION:=3.0.27
+PKG_RELEASE:=1
+
+PKG_LICENSE:=GPL-3.0+
+PKG_LICENSE_FILES:=COPYING
+
+PKG_MAINTAINER:=David Bonnes <david.bonnes@gmail.com>
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://daniel-baumann.ch/files/software/dosfstools \
+		http://fossies.org/linux/misc
+PKG_MD5SUM:=2e31e7bdf92998e41ed17de505a4a552
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/dosfstools/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  URL:=http://www.daniel-baumann.ch/software/dosfstools/
+  SUBMENU:=Filesystem
+  DEPENDS:=$(ICONV_DEPENDS)
+endef
+
+define Package/dosfsck
+  $(call Package/dosfstools/Default)
+  TITLE:=fsck (fsck.fat) utility from dosfstools
+endef
+
+define Package/dosfslabel
+  $(call Package/dosfstools/Default)
+  TITLE:=fslabel (fatlabel) utility from dosfstools
+endef
+
+define Package/mkdosfs
+  $(call Package/dosfstools/Default)
+  TITLE:=mkfs (mkfs.fat) utility from dosfstools
+endef
+
+define Package/dosfsck/description
+	Utilities to create and check MS-DOS FAT filesystems.
+	(fsck.vfat and fsck.fat for checking integrity of FAT volumes)
+endef
+
+define Package/dosfslabel/description
+	Utilities to create and check MS-DOS FAT filesystems.
+	(fatlabel for reading and writing labels of FAT volumes)
+endef
+
+define Package/mkdosfs/description
+	Utilities to create and check MS-DOS FAT filesystems.
+	(mkfs.vfat and mkfs.fat for creating FAT volumes)
+endef
+
+LDFLAGS+=$(ICONV_LDFLAGS)
+LDLIBS+=-liconv
+
+define Build/Configure
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		$(TARGET_CONFIGURE_OPTS) \
+		OPTFLAGS="$(TARGET_CFLAGS) -D_FILE_OFFSET_BITS=64" \
+		PREFIX="/usr" \
+		SBINDIR="/usr/sbin" \
+		LDFLAGS="$(LDFLAGS)" \
+		LDLIBS="$(LDLIBS)" \
+		all
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		$(TARGET_CONFIGURE_OPTS) \
+		OPTFLAGS="$(TARGET_CFLAGS) -D_FILE_OFFSET_BITS=64" \
+		PREFIX="$(PKG_INSTALL_DIR)/usr" \
+		SBINDIR="$(PKG_INSTALL_DIR)/usr/sbin" \
+		install-bin
+endef
+
+define Package/dosfsck/install
+	$(INSTALL_DIR) $(1)/lib/functions/fsck
+	$(INSTALL_DATA) ./files/dosfsck.sh $(1)/lib/functions/fsck/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/fsck.fat $(1)/usr/sbin/
+	(cd $(1)/usr/sbin; ln -sf fsck.fat fsck.msdos; ln -sf fsck.fat fsck.vfat; ln -sf fsck.fat dosfsck)
+endef
+
+define Package/dosfslabel/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/fatlabel $(1)/usr/sbin/
+endef
+
+define Package/mkdosfs/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/mkfs.fat $(1)/usr/sbin/
+	(cd $(1)/usr/sbin; ln -sf mkfs.fat mkfs.msdos; ln -sf mkfs.fat mkfs.vfat)
+endef
+
+$(eval $(call BuildPackage,dosfsck))
+$(eval $(call BuildPackage,dosfslabel))
+$(eval $(call BuildPackage,mkdosfs))

--- a/utils/dosfstools/files/dosfsck.sh
+++ b/utils/dosfstools/files/dosfsck.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Copyright 2010 Vertical Communications
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+fsck_dosfsck() {
+	dosfsck -p "$device" 2>&1 | logger -t "fstab: dosfsck ($device)"
+	local status="$?"
+	case "$status" in
+		0|1) ;; #success
+		2) reboot;;
+		4) echo "dosfsck ($device): Warning! Uncorrected errors."| logger -t fstab
+			return 1
+			;;
+		*) echo "dosfsck ($device): Error $status. Check not complete."| logger -t fstab;;
+	esac
+	return 0
+}
+
+fsck_dos() {
+	fsck_dosfsck "$@"
+}
+
+fsck_vfat() {
+	fsck_dosfsck "$@"
+}
+
+append libmount_known_fsck "dos"
+append libmount_known_fsck "vfat"


### PR DESCRIPTION
Bump to v3.0.27 & add ICONV support
 - move over from oldpackages
 - with thanks to Dirk Neukirchen

Signed-off-by: David Bonnes <david.bonnes@gmail.com>