### PR TITLE
add aircrack-ng

### DIFF
--- a/net/aircrack-ng/Makefile
+++ b/net/aircrack-ng/Makefile
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=aircrack-ng
+PKG_VERSION:=1.2-rc1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://download.aircrack-ng.org/$(PKG_SOURCE)/
+PKG_MD5SUM:=c2f8648c92f7e46051c86c618d4fb0d5
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/aircrack-ng
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpcap +libpthread +libopenssl +libnl +wireless-tools +ethtool
+  BUILD_DEPENDS:=+pkg-config
+  TITLE:=WLAN tools for breaking 802.11 WEP/WPA keys
+  URL:=http://www.aircrack-ng.org/
+  MAINTAINER:=Zero_Chaos <zerochaos@gentoo.org>
+  SUBMENU:=wireless
+endef
+
+define Package/aircrack-ng/description
+  WLAN tools for breaking 802.11 WEP/WPA keys
+endef
+
+MAKE_FLAGS += prefix=/usr \
+	libnl=true \
+	sqlite=false \
+	unstable=false
+
+define Package/aircrack-ng/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/* $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,aircrack-ng))

--- a/net/aircrack-ng/Makefile
+++ b/net/aircrack-ng/Makefile
@@ -10,9 +10,10 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=aircrack-ng
 PKG_VERSION:=1.2-rc1
 PKG_RELEASE:=1
+PKG_LICENSE:=GPLv2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://download.aircrack-ng.org/$(PKG_SOURCE)/
+PKG_SOURCE_URL:=http://download.aircrack-ng.org/
 PKG_MD5SUM:=c2f8648c92f7e46051c86c618d4fb0d5
 
 PKG_BUILD_PARALLEL:=1
@@ -24,7 +25,6 @@ define Package/aircrack-ng
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+libpcap +libpthread +libopenssl +libnl +wireless-tools +ethtool
-  BUILD_DEPENDS:=+pkg-config
   TITLE:=WLAN tools for breaking 802.11 WEP/WPA keys
   URL:=http://www.aircrack-ng.org/
   MAINTAINER:=Zero_Chaos <zerochaos@gentoo.org>
@@ -38,7 +38,8 @@ endef
 MAKE_FLAGS += prefix=/usr \
 	libnl=true \
 	sqlite=false \
-	unstable=false
+	unstable=false \
+	OSNAME=Linux
 
 define Package/aircrack-ng/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/net/aircrack-ng/Makefile
+++ b/net/aircrack-ng/Makefile
@@ -13,7 +13,8 @@ PKG_RELEASE:=1
 PKG_LICENSE:=GPLv2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://download.aircrack-ng.org/
+PKG_SOURCE_URL:=http://download.aircrack-ng.org/ \
+		http://archive.aircrack-ng.org/aircrack-ng/$(PKG_VERSION)/
 PKG_MD5SUM:=c2f8648c92f7e46051c86c618d4fb0d5
 
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
add aircrack-ng, imported from oldpackages, fixed up, updated to latest version, fixed based on comments from Nico.  Please accept this package and remove the same package from oldpackages repo for continuity.