### PR TITLE
libtorrent: remove manual autoconf invocation

### DIFF
--- a/libs/libtorrent/Makefile
+++ b/libs/libtorrent/Makefile
@@ -51,11 +51,6 @@ CONFIGURE_ARGS+= \
 	--disable-instrumentation \
 	--with-zlib=$(STAGING_DIR)/usr
 
-define Build/Configure
-	( cd $(PKG_BUILD_DIR); ./autogen.sh );
-	$(call Build/Configure/Default)
-endef
-
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/torrent $(1)/usr/include/


### PR DESCRIPTION
The Makefile already uses the proper autoreconf fixup but leaves a manual
autoconf invocation in place.

The bad autoconf call leads to the following build error in the SDK:

	configure.ac:3: installing `./config.guess'
	configure.ac:3: installing `./config.sub'
	configure.ac:20: installing `./install-sh'
	configure.ac:20: installing `./missing'
	src/Makefile.am: installing `./depcomp'
	autoreconf: Leaving directory `.'
	aclocal...
	autoheader...
	libtoolize... libtoolize nor glibtoolize not found
	make[2]: *** [.../.configured_] Error 1

Remove the entire Build/Configure override to let libtorrent build correctly.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>