### PR TITLE
rtorrent: remove manual autoconf invocation

### DIFF
--- a/net/rtorrent/Makefile
+++ b/net/rtorrent/Makefile
@@ -80,11 +80,6 @@ ifeq ($(BUILD_VARIANT),rpc)
 endif
 
 
-define Build/Configure
-	( cd $(PKG_BUILD_DIR); ./autogen.sh );
-	$(call Build/Configure/Default)
-endef
-
 define Package/rtorrent/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/rtorrent $(1)/usr/bin/


### PR DESCRIPTION
The Makefile already uses the proper autoreconf fixup but leaves a manual
autoconf invocation in place.

The bad autoconf call leads to the following build error in the SDK:

	( cd .../rtorrent-0.9.4-git; ./autogen.sh );
	aclocal...
	autoheader...
	libtoolize... libtoolize nor glibtoolize not found
	make[2]: *** [.../rtorrent-0.9.4-git/.configured_] Error 1

Remove the entire Build/Configure override to let rtorrent build correctly.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>