### PR TITLE
shairplay: use generic autoreconf fixup

### DIFF
--- a/sound/shairplay/Makefile
+++ b/sound/shairplay/Makefile
@@ -23,19 +23,13 @@ PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
 
-PKG_FIXUP:=libtool
+PKG_FIXUP:=autoreconf
 
 define Package/shairplay
   SECTION:=sound
   CATEGORY:=Sound
   DEPENDS:=+libao +libavahi-compat-libdnssd +libltdl +libpthread
   TITLE:=Shairplay
-endef
-
-define Build/Configure
-	(cd $(PKG_BUILD_DIR)/$(CONFIGURE_PATH); \
-	./autogen.sh;)
-	$(call Build/Configure/Default)
 endef
 
 define Package/shairplay/description


### PR DESCRIPTION
Use the generic autoreconf facility to pickup proper variants of
autoconf, automake and libtool.

Remove the unneeded Build/Configure override.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>