### PR TITLE
libmms: remove useless autogen call

### DIFF
--- a/libs/libmms/Makefile
+++ b/libs/libmms/Makefile
@@ -44,11 +44,6 @@ endef
 TARGET_CFLAGS += $(FPIC)
 TARGET_LDFLAGS += $(if $(ICONV_FULL),-liconv)
 
-define Build/Configure
-	(cd $(PKG_BUILD_DIR); ./autogen.sh );
-	$(call Build/Configure/Default)
-endef
-
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libmms $(1)/usr/include/


### PR DESCRIPTION
The package already uses the generic autoreconf fixup so the additional call
to autogen.sh is unneeded and might even introduce wrong versions of the
required autotools into the build.

Remove the unneeded Build/Configure override to simplify the Makefile.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>