### PR TITLE
lxc: use generic autoreconf fixup

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -19,7 +19,9 @@ PKG_MD5SUM:=4aad3aee84b42faa194e44091d723a3b
 
 PKG_BUILD_DEPENDS:=lua
 PKG_BUILD_PARALLEL:=1
+
 PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -117,11 +119,6 @@ CONFIGURE_ARGS += \
 MAKE_FLAGS += \
 	LUA_INSTALL_CMOD="/usr/lib/lua" \
 	LUA_INSTALL_LMOD="/usr/lib/lua"
-
-define Build/Configure
-	( cd $(PKG_BUILD_DIR); ./autogen.sh );
-	$(call Build/Configure/Default)
-endef
 
 
 define Build/InstallDev


### PR DESCRIPTION
Use the generic autoreconf facility to pickup proper variants of
autoconf, automake and libtool.

Remove the unneeded Build/Configure override.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>