### PR TITLE
privoxy: modified initscript (remove killall)

### DIFF
--- a/net/privoxy/Makefile
+++ b/net/privoxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=privoxy
 PKG_VERSION:=3.0.23
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-stable-src.tar.gz
 PKG_SOURCE_URL:=@SF/ijbswa

--- a/net/privoxy/files/privoxy.init
+++ b/net/privoxy/files/privoxy.init
@@ -108,11 +108,11 @@ stop() {
 	local _PID=$(cat $PIDFILE 2>/dev/null)
 	kill -15 $_PID 2>/dev/null
 	sleep 1			# give time to shutdown
-	local _tmp=$(pgrep privoxy)
+	local _tmp=$(pgrep privoxy | tr "\n" " ")
 	if [ -z "$_tmp" ]; then
 		logger -p daemon.notice -t "privoxy[$_PID]" "Shutdown successfully"
 	else
-		killall -9 privoxy
+		kill -9 $_tmp	# Normally never come here
 		logger -p daemon.warn -t "privoxy[-----]" "Shutdown forced by KILL"
 	fi
 	return 0


### PR DESCRIPTION
remove "killall" from initscript because it kills itself #867

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>