### PR TITLE
ddns-scripts: update to version 2.3.0-1

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ddns-scripts
 # Version == major.minor.patch
 # increase on new functionality (minor) or patches (patch)
-PKG_VERSION:=2.2.0
+PKG_VERSION:=2.3.0
 # Release == build
 # increase on changes of services files or tld_names.dat
 PKG_RELEASE:=1
@@ -51,7 +51,7 @@ endef
 define Package/$(PKG_NAME)_CloudFlare
     $(call Package/$(PKG_NAME)/Default)
     TITLE:=DDNS extension for CloudFlare
-    DEPENDS:=+$(PKG_NAME)
+    DEPENDS:=$(PKG_NAME)
 endef
 define Package/$(PKG_NAME)_CloudFlare/description
     Dynamic DNS Client scripts extension for CloudFlare
@@ -60,7 +60,7 @@ endef
 define Package/$(PKG_NAME)_No-IP_com
     $(call Package/$(PKG_NAME)/Default)
     TITLE:=DDNS extension for No-IP.com
-    DEPENDS:=+$(PKG_NAME)
+    DEPENDS:=$(PKG_NAME)
 endef
 define Package/$(PKG_NAME)_No-IP_com/description
     Dynamic DNS Client scripts extension for No-IP.com

--- a/net/ddns-scripts/files/ddns.init
+++ b/net/ddns-scripts/files/ddns.init
@@ -8,6 +8,7 @@ boot() {
 
 reload() {
 	killall -1 dynamic_dns_updater.sh 2>/dev/null	# send SIGHUP
+	return 0
 }
 
 restart() {

--- a/net/ddns-scripts/files/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/dynamic_dns_updater.sh
@@ -201,7 +201,7 @@ write_log 7 "retry counter : $retry_count times"
 
 # kill old process if it exists & set new pid file
 stop_section_processes "$SECTION_ID"
-[ $? -gt 0 ] && write_log 7 "Send 'SIGTERM' was send to old process" || write_log 7 "No old process"
+[ $? -gt 0 ] && write_log 7 "'SIGTERM' was send to old process" || write_log 7 "No old process"
 echo $$ > $PIDFILE
 
 # determine when the last update was


### PR DESCRIPTION
new option "use_curl" to force the use of curl if GNU Wget and curl are installed
fix initscript reload(): reload and not restart if killall -1 fails
BusyBox nc not support -v in every compiled version

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>