### PR TITLE
unbound: bump to 1.5.1 and update named.cache

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.4.22
+PKG_VERSION:=1.5.1
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
@@ -17,7 +17,7 @@ PKG_MAINTAINER:=Michael Hanselmann <public@hansmi.ch>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unbound.net/downloads
-PKG_MD5SUM:=59728c74fef8783f8bad1d7451eba97f
+PKG_MD5SUM:=ed4c46476dcfb8a507cc08b1ba12a8f1
 
 PKG_BUILD_DEPENDS:=libexpat
 PKG_BUILD_PARALLEL:=1

--- a/net/unbound/files/named.cache
+++ b/net/unbound/files/named.cache
@@ -9,31 +9,32 @@
 ;           on server           FTP.INTERNIC.NET
 ;       -OR-                    RS.INTERNIC.NET
 ;
-;       last update:    Mar 26, 2014
-;       related version of root zone:   2014032601
+;       last update:    November 05, 2014
+;       related version of root zone:   2014110501
 ;
 ; formerly NS.INTERNIC.NET
 ;
-.                        3600000  IN  NS    A.ROOT-SERVERS.NET.
+.                        3600000      NS    A.ROOT-SERVERS.NET.
 A.ROOT-SERVERS.NET.      3600000      A     198.41.0.4
-A.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:BA3E::2:30
+A.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:ba3e::2:30
 ;
 ; FORMERLY NS1.ISI.EDU
 ;
 .                        3600000      NS    B.ROOT-SERVERS.NET.
 B.ROOT-SERVERS.NET.      3600000      A     192.228.79.201
+B.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:84::b
 ;
 ; FORMERLY C.PSI.NET
 ;
 .                        3600000      NS    C.ROOT-SERVERS.NET.
 C.ROOT-SERVERS.NET.      3600000      A     192.33.4.12
-C.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2::C
+C.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2::c
 ;
 ; FORMERLY TERP.UMD.EDU
 ;
 .                        3600000      NS    D.ROOT-SERVERS.NET.
 D.ROOT-SERVERS.NET.      3600000      A     199.7.91.13
-D.ROOT-SERVERS.NET.	 3600000      AAAA  2001:500:2D::D
+D.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2d::d
 ;
 ; FORMERLY NS.NASA.GOV
 ;
@@ -44,7 +45,7 @@ E.ROOT-SERVERS.NET.      3600000      A     192.203.230.10
 ;
 .                        3600000      NS    F.ROOT-SERVERS.NET.
 F.ROOT-SERVERS.NET.      3600000      A     192.5.5.241
-F.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2F::F
+F.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2f::f
 ;
 ; FORMERLY NS.NIC.DDN.MIL
 ;
@@ -55,25 +56,25 @@ G.ROOT-SERVERS.NET.      3600000      A     192.112.36.4
 ;
 .                        3600000      NS    H.ROOT-SERVERS.NET.
 H.ROOT-SERVERS.NET.      3600000      A     128.63.2.53
-H.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:1::803F:235
+H.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:1::803f:235
 ;
 ; FORMERLY NIC.NORDU.NET
 ;
 .                        3600000      NS    I.ROOT-SERVERS.NET.
 I.ROOT-SERVERS.NET.      3600000      A     192.36.148.17
-I.ROOT-SERVERS.NET.      3600000      AAAA  2001:7FE::53
+I.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fe::53
 ;
 ; OPERATED BY VERISIGN, INC.
 ;
 .                        3600000      NS    J.ROOT-SERVERS.NET.
 J.ROOT-SERVERS.NET.      3600000      A     192.58.128.30
-J.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:C27::2:30
+J.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:c27::2:30
 ;
 ; OPERATED BY RIPE NCC
 ;
 .                        3600000      NS    K.ROOT-SERVERS.NET.
 K.ROOT-SERVERS.NET.      3600000      A     193.0.14.129
-K.ROOT-SERVERS.NET.      3600000      AAAA  2001:7FD::1
+K.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fd::1
 ;
 ; OPERATED BY ICANN
 ;
@@ -85,5 +86,5 @@ L.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:3::42
 ;
 .                        3600000      NS    M.ROOT-SERVERS.NET.
 M.ROOT-SERVERS.NET.      3600000      A     202.12.27.33
-M.ROOT-SERVERS.NET.      3600000      AAAA  2001:DC3::35
-; End of File
+M.ROOT-SERVERS.NET.      3600000      AAAA  2001:dc3::35
+; End of file

--- a/net/unbound/patches/001-conf.patch
+++ b/net/unbound/patches/001-conf.patch
@@ -149,6 +149,6 @@
  	# plain value in bytes or you can append k, m or G. default is "1Mb". 
  	# neg-cache-size: 1m
 +	neg-cache-size: 10k
- 
+ 	
  	# By default, for a number of zones a small default 'nothing here'
  	# reply is built-in.  Query traffic is thus blocked.  If you


### PR DESCRIPTION
unbound: bump named.cache to latest version from Nov 2014
unbound: bump to version 1.5.1

 net/unbound/Makefile               |  4 ++--
 net/unbound/files/named.cache      | 27 ++++++++++++++-------------
 net/unbound/patches/001-conf.patch |  2 +-
 3 files changed, 17 insertions(+), 16 deletions(-)

Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
