### PR TITLE
gammu: disable libdbi support explicitly

### DIFF
--- a/utils/gammu/Makefile
+++ b/utils/gammu/Makefile
@@ -35,7 +35,8 @@ endef
 CONFIGURE_ARGS:= \
 	--prefix=/usr \
 	--cross-root="$(STAGING_DIR) $(TOOLCHAIN_DIR)" \
-	--enable-shared
+	--enable-shared \
+	--without-libdbi \
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \

--- a/utils/gammu/patches/004-cmake_libdbi_optional.patch
+++ b/utils/gammu/patches/004-cmake_libdbi_optional.patch
@@ -1,0 +1,34 @@
+--- a/configure
++++ b/configure
+@@ -36,6 +36,7 @@ Usage: ./configure [options]
+ --with-python=<path> path to Python interpreter
+ --without-gnapplet  disable installation of gnapplet
+ --without-completion disable installation of bash completion script
++--without-libdbi	disable libdbi support
+ 
+ All enable params have their disable counterparts.
+ 
+@@ -61,6 +62,7 @@ CMAKE_PYTHON=
+ CMAKE_GNAP=
+ CMAKE_COMPLETE=
+ CMAKE_ICONV=
++CMAKE_LIBDBI=
+ 
+ # process command line
+ while [ "$#" -gt 0 ] ; do
+@@ -120,6 +122,9 @@ while [ "$#" -gt 0 ] ; do
+         --without-completion)
+             CMAKE_COMPLETE="-DINSTALL_BASH_COMPLETION=OFF"
+             ;;
++        --without-libdbi)
++            CMAKE_LIBDBI="-DWITH_LibDBI=OFF"
++            ;;
+         --build=*)
+             ;;
+         --disable-dependency-tracking)
+@@ -156,4 +161,4 @@ fi
+ cd "$BUILD_DIR"
+ 
+ # invoke cmake to do configuration
+-cmake $SOURCE_DIR $CMAKE_ROOT $CMAKE_PREFIX $CMAKE_SHARED $CMAKE_DEBUG $CMAKE_BACKUP $CMAKE_CROSS $CMAKE_PROTECTION $CMAKE_PYTHON $CMAKE_GNAP $CMAKE_COMPLETE $CMAKE_ICONV
++cmake $SOURCE_DIR $CMAKE_ROOT $CMAKE_PREFIX $CMAKE_SHARED $CMAKE_DEBUG $CMAKE_BACKUP $CMAKE_CROSS $CMAKE_PROTECTION $CMAKE_PYTHON $CMAKE_GNAP $CMAKE_COMPLETE $CMAKE_ICONV $CMAKE_LIBDBI


### PR DESCRIPTION
This change fixes a dependency error that would occur if libdbi was built before gammu.