### PR TITLE
grep: Fix CVE-2015-1345 heap buffer overrun

### DIFF
--- a/utils/grep/Makefile
+++ b/utils/grep/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grep
 PKG_VERSION:=2.21
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/grep

--- a/utils/grep/patches/0001-grep-F-fix-a-heap-buffer-read-overrun.patch
+++ b/utils/grep/patches/0001-grep-F-fix-a-heap-buffer-read-overrun.patch
@@ -1,0 +1,15 @@
+diff --git a/src/kwset.c b/src/kwset.c
+index 4003c8d..376f7c3 100644
+--- a/src/kwset.c
++++ b/src/kwset.c
+@@ -643,6 +643,8 @@ bmexec_trans (kwset_t kwset, char const *text, size_t size)
+                     if (! tp)
+                       return -1;
+                     tp++;
++                    if (ep <= tp)
++                      break;
+                   }
+               }
+           }
+--
+cgit v0.9.0.2


### PR DESCRIPTION
grep: Fix CVE-2015-1345 heap buffer overrun
Signed-off-by: Julen Landa Alustiza <julen@zokormazo.info>