### PR TITLE
apcupsd: move from old-packages and update to new version

### DIFF
--- a/utils/apcupsd/Makefile
+++ b/utils/apcupsd/Makefile
@@ -1,0 +1,78 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=apcupsd
+PKG_VERSION:=3.14.13
+PKG_RELEASE:=2
+
+PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@SF/apcupsd
+PKG_MD5SUM:=c291d9d3923b4d9c0e600b755ad4f489
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/apcupsd
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libpthread +libusb-compat
+  TITLE:=UPS control software
+  URL:=http://www.apcupsd.org/
+endef
+
+define Build/Configure
+	$(CP) $(SCRIPT_DIR)/config.* $(PKG_BUILD_DIR)/autoconf/
+	$(call Build/Configure/Default, \
+		--with-distname=unknown \
+	--sysconfdir=/etc/apcupsd \
+		--enable-usb \
+		--without-x \
+	)
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		LD="$(TARGET_CC)" \
+		all install
+endef
+
+define Package/apcupsd/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/apcupsd $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/smtp $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/apctest $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/apcaccess $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/apcupsd
+	$(INSTALL_CONF) ./files/apcupsd.conf $(1)/etc/apcupsd/
+	$(INSTALL_CONF) ./files/apcupsd_mail.conf $(1)/etc/apcupsd/
+	$(INSTALL_BIN) ./files/changeme $(1)/etc/apcupsd/
+	$(INSTALL_BIN) ./files/commfailure $(1)/etc/apcupsd/
+	$(INSTALL_BIN) ./files/commok $(1)/etc/apcupsd/
+	$(INSTALL_BIN) ./files/offbattery $(1)/etc/apcupsd/
+	$(INSTALL_BIN) ./files/onbattery $(1)/etc/apcupsd/
+	$(INSTALL_BIN) ./files/apccontrol $(1)/etc/apcupsd/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN)  ./files/apcupsd.init $(1)/etc/init.d/apcupsd
+endef
+
+define Package/apcupsd/conffiles
+/etc/apcupsd/apcupsd.conf
+/etc/apcupsd/apcupsd_mail.conf
+/etc/apcupsd/changeme
+/etc/apcupsd/commfailure
+/etc/apcupsd/commok
+/etc/apcupsd/offbattery
+/etc/apcupsd/onbattery
+endef
+
+$(eval $(call BuildPackage,apcupsd))

--- a/utils/apcupsd/files/apccontrol
+++ b/utils/apcupsd/files/apccontrol
@@ -1,0 +1,146 @@
+#!/bin/sh
+#
+# Copyright (C) 1999-2002 Riccardo Facchetti <riccardo@master.oasi.gpa.it>
+#
+#  for apcupsd release 3.14.1 (04 May 2007) - unknown
+#
+# platforms/apccontrol.  Generated from apccontrol.in by configure.
+#
+#  Note, this is a generic file that can be used by most
+#   systems. If a particular system needs to have something
+#   special, start with this file, and put a copy in the
+#   platform subdirectory.
+#
+
+#
+# These variables are needed for set up the autoconf other variables.
+#
+prefix=/usr
+exec_prefix=/usr
+
+APCPID=/var/run/apcupsd.pid
+APCUPSD=/usr/sbin/apcupsd
+SHUTDOWN=/sbin/shutdown
+SCRIPTSHELL=/bin/sh
+SCRIPTDIR=/etc/apcupsd
+WALL=true
+
+#
+# Concatenate all output from this script to the events file
+#  Note, the following kills the script in a power fail situation
+#   where the disks are mounted read-only.
+# exec >>/var/log/apcupsd.events 2>&1
+
+#
+# This piece is to substitute the default behaviour with your own script,
+# perl, or C program.
+# You can customize every single command creating an executable file (may be a
+# script or a compiled program) and calling it the same as the $1 parameter
+# passed by apcupsd to this script.
+#
+# After executing your script, apccontrol continues with the default action.
+# If you do not want apccontrol to continue, exit your script with exit
+# code 99. E.g. "exit 99".
+#
+# WARNING: the apccontrol file will be overwritten every time you update your
+# apcupsd, doing `make install'. Your own customized scripts will _not_ be
+# overwritten. If you wish to make changes to this file (discouraged), you
+# should change apccontrol.sh.in and then rerun the configure process.
+#
+if [ -f ${SCRIPTDIR}/${1} -a -x ${SCRIPTDIR}/${1} ]
+then
+    ${SCRIPTDIR}/${1} ${2} ${3} ${4}
+    # exit code 99 means he does not want us to do default action
+    if [ $? = 99 ] ; then
+        exit 0
+    fi
+fi
+
+case "$1" in
+    killpower)
+        echo "Apccontrol doing: ${APCUPSD} --killpower on UPS ${2}"
+        sleep 10
+        ${APCUPSD} --killpower
+        echo "Apccontrol has done: ${APCUPSD} --killpower on UPS ${2}" | ${WALL}
+    ;;
+    commfailure)
+        echo "Warning communications lost with UPS ${2}" | ${WALL}
+    ;;
+    commok)
+        echo "Communications restored with UPS ${2}" | ${WALL}
+    ;;
+#
+# powerout, onbattery, offbattery, mainsback events occur
+#   in that order.
+#
+    powerout)
+        echo "Warning power loss detected on UPS ${2}" | ${WALL}
+    ;;
+    onbattery)
+        echo "Power failure on UPS ${2}. Running on batteries." | ${WALL}
+    ;;
+    offbattery)
+    ;;
+    mainsback)
+        echo "Power has returned on UPS ${2}..." | ${WALL}
+        if [ -f /etc/powerfail ] ; then
+           printf "Continuing with shutdown."  | ${WALL}
+        fi
+    ;;
+    failing)
+        echo "Battery power exhaused on UPS ${2}. Doing shutdown." | ${WALL}
+    ;;
+    timeout)
+        echo "Battery time limit exceeded on UPS ${2}. Doing shutdown." | ${WALL}
+    ;;
+    loadlimit)
+        echo "Remaining battery charge below limit on UPS ${2}. Doing shutdown." | ${WALL}
+    ;;
+    runlimit)
+        echo "Remaining battery runtime below limit on UPS ${2}. Doing shutdown." | ${WALL}
+    ;;
+    doreboot)
+        echo "UPS ${2} initiating Reboot Sequence" | ${WALL}
+        ${SHUTDOWN} -r now "apcupsd UPS ${2} initiated reboot"
+    ;;
+    doshutdown)
+        echo "UPS ${2} initiated Shutdown Sequence" | ${WALL}
+        ${SHUTDOWN} -h now "apcupsd UPS ${2} initiated shutdown"
+    ;;
+    annoyme)
+        echo "Power problems with UPS ${2}. Please logoff." | ${WALL}
+    ;;
+    emergency)
+        echo "Emergency Shutdown. Possible battery failure on UPS ${2}." | ${WALL}
+    ;;
+    changeme)
+        echo "Emergency! Batteries have failed on UPS ${2}. Change them NOW" | ${WALL}
+    ;;
+    remotedown)
+        echo "Remote Shutdown. Beginning Shutdown Sequence." | ${WALL}
+    ;;
+    restartme)
+        echo -n "Restarting APCUPSD Power Management: "
+        THEPID=`cat ${APCPID}`
+        kill ${THEPID}
+        rm -f ${APCPID}
+        rm -f /etc/powerfail
+        rm -f /etc/nologin
+        sleep 5
+        `${APCUPSD}`
+        echo "apcupsd"
+    ;;
+    startselftest)
+    ;;
+    endselftest)
+    ;;
+    battdetach)
+    ;;
+    battattach)
+    ;;
+    *)  echo "Usage: ${0##*/} command"
+        echo "       warning: this script is intended to be launched by"
+        echo "       apcupsd and should never be launched by users."
+        exit 1
+    ;;
+esac

--- a/utils/apcupsd/files/apcupsd.conf
+++ b/utils/apcupsd/files/apcupsd.conf
@@ -1,0 +1,322 @@
+## apcupsd.conf v1.1 ##
+#
+#  for apcupsd release 3.14.1 (04 May 2007) - unknown
+#
+# "apcupsd" POSIX config file
+
+#
+# ========= General configuration parameters ============
+#
+
+# UPSNAME xxx
+#   Use this to give your UPS a name in log files and such. This
+#   is particulary useful if you have multiple UPSes. This does not
+#   set the EEPROM. It should be 8 characters or less.
+UPSNAME ups1
+
+# UPSCABLE <cable>
+#   Defines the type of cable connecting the UPS to your computer.
+#
+#   Possible generic choices for <cable> are:
+#     simple, smart, ether, usb
+#
+#   Or a specific cable model number may be used:
+#     940-0119A, 940-0127A, 940-0128A, 940-0020B,
+#     940-0020C, 940-0023A, 940-0024B, 940-0024C,
+#     940-1524C, 940-0024G, 940-0095A, 940-0095B,
+#     940-0095C, M-04-02-2000
+#
+UPSCABLE smart
+
+# To get apcupsd to work, in addition to defining the cable
+# above, you must also define a UPSTYPE, which corresponds to
+# the type of UPS you have (see the Description for more details).
+# You must also specify a DEVICE, sometimes referred to as a port.
+# For USB UPSes, please leave the DEVICE directive blank. For
+# other UPS types, you must specify an appropriate port or address.
+#
+# UPSTYPE   DEVICE           Description
+# apcsmart  /dev/tty**       Newer serial character device,
+#                            appropriate for SmartUPS models using
+#                            a serial cable (not USB).
+#
+# usb       <BLANK>          Most new UPSes are USB. A blank DEVICE
+#                            setting enables autodetection, which is
+#                            the best choice for most installations.
+#
+# net       hostname:port    Network link to a master apcupsd
+#                            through apcupsd's Network Information
+#                            Server. This is used if you don't have
+#                            a UPS directly connected to your computer.
+#
+# snmp      hostname:port:vendor:community
+#                            SNMP Network link to an SNMP-enabled
+#                            UPS device. Vendor is the MIB used by
+#                            the UPS device: can be "APC", "APC_NOTRAP"
+#                            or "RFC" where APC is the powernet MIB,
+#                            "APC_NOTRAP" is powernet with SNMP trap
+#                            catching disabled, and RFC is the IETF's
+#                            rfc1628 UPS-MIB. You usually want "APC".
+#                            Port is usually 161. Community is usually
+#                            "private".
+#
+# dumb      /dev/tty**       Old serial character device for use
+#                            with simple-signaling UPSes.
+#
+# pcnet    ipaddr:username:passphrase
+#                            PowerChute Network Shutdown protocol
+#                            which can be used as an alternative to SNMP
+#                            with AP9617 family of smart slot cards.
+#                            ipaddr is the IP address of the UPS mgmt
+#                            card. username and passphrase are the
+#                            credentials for which the card has been
+#                            configured.
+#
+UPSTYPE apcsmart
+DEVICE /dev/ttyS0
+
+
+# LOCKFILE <path to lockfile>
+#   Path for device lock file. Not used on Win32.
+LOCKFILE /var/lock
+
+# SCRIPTDIR <path to script directory>
+#   Directory in which apccontrol and event scripts are located.
+SCRIPTDIR /etc/apcupsd
+
+# PWRFAILDIR <path to powerfail directory>
+#   Directory in which to write the powerfail flag file. This file
+#   is created when apcupsd initiates a system shutdown and is
+#   checked in the OS halt scripts to determine if a killpower
+#   (turning off UPS output power) is required.
+PWRFAILDIR /etc
+
+# NOLOGINDIR <path to nologin directory>
+#   Directory in which to write the nologin file. The existence
+#   of this flag file tells the OS to disallow new logins.
+NOLOGINDIR /etc
+
+
+#
+# ======== Configuration parameters used during power failures ==========
+#
+
+# The ONBATTERYDELAY is the time in seconds from when a power failure
+#   is detected until we react to it with an onbattery event.
+#
+#   This means that, apccontrol will be called with the powerout argument
+#   immediately when a power failure is detected.  However, the
+#   onbattery argument is passed to apccontrol only after the
+#   ONBATTERYDELAY time.  If you don't want to be annoyed by short
+#   powerfailures, make sure that apccontrol powerout does nothing
+#   i.e. comment out the wall.
+#ONBATTERYDELAY 6
+
+#
+# Note: BATTERYLEVEL, MINUTES, and TIMEOUT work in conjunction, so
+# the first that occurs will cause the initation of a shutdown.
+#
+
+# If during a power failure, the remaining battery percentage
+# (as reported by the UPS) is below or equal to BATTERYLEVEL,
+# apcupsd will initiate a system shutdown.
+BATTERYLEVEL 5
+
+# If during a power failure, the remaining runtime in minutes
+# (as calculated internally by the UPS) is below or equal to MINUTES,
+# apcupsd, will initiate a system shutdown.
+MINUTES 3
+
+# If during a power failure, the UPS has run on batteries for TIMEOUT
+# many seconds or longer, apcupsd will initiate a system shutdown.
+# A value of 0 disables this timer.
+#
+#  Note, if you have a Smart UPS, you will most likely want to disable
+#    this timer by setting it to zero. That way, you UPS will continue
+#    on batteries until either the % charge remaing drops to or below BATTERYLEVEL,
+#    or the remaining battery runtime drops to or below MINUTES.  Of course,
+#    if you are testing, setting this to 60 causes a quick system shutdown
+#    if you pull the power plug.
+#  If you have an older dumb UPS, you will want to set this to less than
+#    the time you know you can run on batteries.
+TIMEOUT 0
+
+#  Time in seconds between annoying users to signoff prior to
+#  system shutdown. 0 disables.
+ANNOY 300
+
+# Initial delay after power failure before warning users to get
+# off the system.
+ANNOYDELAY 60
+
+# The condition which determines when users are prevented from
+# logging in during a power failure.
+# NOLOGON <string> [ disable | timeout | percent | minutes | always ]
+NOLOGON disable
+
+# If KILLDELAY is non-zero, apcupsd will continue running after a
+# shutdown has been requested, and after the specified time in
+# seconds attempt to kill the power. This is for use on systems
+# where apcupsd cannot regain control after a shutdown.
+# KILLDELAY <seconds>  0 disables
+KILLDELAY 0
+
+#
+# ==== Configuration statements for Network Information Server ====
+#
+
+# NETSERVER [ on | off ] on enables, off disables the network
+#  information server. If netstatus is on, a network information
+#  server process will be started for serving the STATUS and
+#  EVENT data over the network (used by CGI programs).
+NETSERVER on
+
+# NISIP <dotted notation ip address>
+#  IP address on which NIS server will listen for incoming connections.
+#  This is useful if your server is multi-homed (has more than one
+#  network interface and IP address). Default value is 0.0.0.0 which
+#  means any incoming request will be serviced. Alternatively, you can
+#  configure this setting to any specific IP address of your server and
+#  NIS will listen for connections only on that interface. Use the
+#  loopback address (127.0.0.1) to accept connections only from the
+#  local machine.
+NISIP 0.0.0.0
+
+# NISPORT <port> default is 3551 as registered with the IANA
+#  port to use for sending STATUS and EVENTS data over the network.
+#  It is not used unless NETSERVER is on. If you change this port,
+#  you will need to change the corresponding value in the cgi directory
+#  and rebuild the cgi programs.
+NISPORT 3551
+
+# If you want the last few EVENTS to be available over the network
+# by the network information server, you must define an EVENTSFILE.
+EVENTSFILE /var/log/apcupsd.events
+
+# EVENTSFILEMAX <kilobytes>
+#  By default, the size of the EVENTSFILE will be not be allowed to exceed
+#  10 kilobytes.  When the file grows beyond this limit, older EVENTS will
+#  be removed from the beginning of the file (first in first out).  The
+#  parameter EVENTSFILEMAX can be set to a different kilobyte value, or set
+#  to zero to allow the EVENTSFILE to grow without limit.
+EVENTSFILEMAX 10
+
+#
+# ========== Configuration statements used if sharing =============
+#            a UPS with more than one machine
+
+# NETTIME <int>
+#   Interval (in seconds) at which the NIS client polls the server.
+#   Used only when this apcupsd is a network client (UPSTYPE net).
+#NETTIME 60
+
+#
+# Remaining items are for ShareUPS (APC expansion card) ONLY
+#
+
+# UPSCLASS [ standalone | shareslave | sharemaster ]
+#   Normally standalone unless you share an UPS using an APC ShareUPS
+#   card.
+UPSCLASS standalone
+
+# UPSMODE [ disable | share ]
+#   Normally disable unless you share an UPS using an APC ShareUPS card.
+UPSMODE disable
+
+#
+# ===== Configuration statements to control apcupsd system logging ========
+#
+
+# Time interval in seconds between writing the STATUS file; 0 disables
+STATTIME 0
+
+# Location of STATUS file (written to only if STATTIME is non-zero)
+STATFILE /var/log/apcupsd.status
+
+# LOGSTATS [ on | off ] on enables, off disables
+# Note! This generates a lot of output, so if
+#       you turn this on, be sure that the
+#       file defined in syslog.conf for LOG_NOTICE is a named pipe.
+#  You probably do not want this on.
+LOGSTATS off
+
+# Time interval in seconds between writing the DATA records to
+#   the log file. 0 disables.
+DATATIME 0
+
+# FACILITY defines the logging facility (class) for logging to syslog.
+#          If not specified, it defaults to "daemon". This is useful
+#          if you want to separate the data logged by apcupsd from other
+#          programs.
+#FACILITY DAEMON
+
+#
+# ========== Configuration statements used in updating the UPS EPROM =========
+#
+
+#
+# These statements are used only by apctest when choosing "Set EEPROM with conf
+# file values" from the EEPROM menu. THESE STATEMENTS HAVE NO EFFECT ON APCUPSD.
+#
+
+# UPS name, max 8 characters
+#UPSNAME UPS_IDEN
+
+# Battery date - 8 characters
+#BATTDATE mm/dd/yy
+
+# Sensitivity to line voltage quality (H cause faster transfer to batteries)
+# SENSITIVITY H M L        (default = H)
+#SENSITIVITY H
+
+# UPS delay after power return (seconds)
+# WAKEUP 000 060 180 300   (default = 0)
+#WAKEUP 60
+
+# UPS Grace period after request to power off (seconds)
+# SLEEP 020 180 300 600    (default = 20)
+#SLEEP 180
+
+# Low line voltage causing transfer to batteries
+# The permitted values depend on your model as defined by last letter
+#  of FIRMWARE or APCMODEL. Some representative values are:
+#    D 106 103 100 097
+#    M 177 172 168 182
+#    A 092 090 088 086
+#    I 208 204 200 196     (default = 0 => not valid)
+#LOTRANSFER  208
+
+# High line voltage causing transfer to batteries
+# The permitted values depend on your model as defined by last letter
+#  of FIRMWARE or APCMODEL. Some representative values are:
+#    D 127 130 133 136
+#    M 229 234 239 224
+#    A 108 110 112 114
+#    I 253 257 261 265     (default = 0 => not valid)
+#HITRANSFER 253
+
+# Battery charge needed to restore power
+# RETURNCHARGE 00 15 50 90 (default = 15)
+#RETURNCHARGE 15
+
+# Alarm delay
+# 0 = zero delay after pwr fail, T = power fail + 30 sec, L = low battery, N = never
+# BEEPSTATE 0 T L N        (default = 0)
+#BEEPSTATE T
+
+# Low battery warning delay in minutes
+# LOWBATT 02 05 07 10      (default = 02)
+#LOWBATT 2
+
+# UPS Output voltage when running on batteries
+# The permitted values depend on your model as defined by last letter
+#  of FIRMWARE or APCMODEL. Some representative values are:
+#    D 115
+#    M 208
+#    A 100
+#    I 230 240 220 225     (default = 0 => not valid)
+#OUTPUTVOLTS 230
+
+# Self test interval in hours 336=2 weeks, 168=1 week, ON=at power on
+# SELFTEST 336 168 ON OFF  (default = 336)
+#SELFTEST 336

--- a/utils/apcupsd/files/apcupsd.init
+++ b/utils/apcupsd/files/apcupsd.init
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2006 OpenWrt.org
+START=50
+STOP=50
+
+start() {
+	/usr/sbin/apcupsd -f /etc/apcupsd/apcupsd.conf
+}
+
+stop() {
+	kill $(cat /var/run/apcupsd.pid)
+}

--- a/utils/apcupsd/files/apcupsd_mail.conf
+++ b/utils/apcupsd/files/apcupsd_mail.conf
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+MAILPROG="/usr/sbin/smtp"
+MAILHOST="mail:25"
+FROM="OpenWrt"
+TO="apcups@example.com"
+HOSTNAME="OpenWrt"

--- a/utils/apcupsd/files/changeme
+++ b/utils/apcupsd/files/changeme
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd
+# will be called by /etc/apcupsd/apccontrol when apcupsd
+# detects that the battery should be replaced.
+# We send an email message to root to notify him.
+#
+. /etc/apcupsd/apcupsd_mail.conf
+
+MSG="$HOSTNAME UPS battery needs changing NOW."
+#
+(
+   echo "$MSG"
+   echo " "
+   /usr/sbin/apcaccess status
+) | $MAILPROG -h $MAILHOST -f $FROM -s "$MSG" $TO
+exit 0

--- a/utils/apcupsd/files/commfailure
+++ b/utils/apcupsd/files/commfailure
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd
+# will be called by /etc/apcupsd/apccontrol when apcupsd
+# loses contact with the UPS (i.e. the serial connection is not responding).
+# We send an email message to root to notify him.
+#
+. /etc/apcupsd/apcupsd_mail.conf
+
+MSG="$HOSTNAME Communications with UPS lost"
+#
+(
+   echo "$MSG"
+   echo " "
+   /usr/sbin/apcaccess status
+) | $MAILPROG -h $MAILHOST -f $FROM -s "$MSG" $TO
+exit 0

--- a/utils/apcupsd/files/commok
+++ b/utils/apcupsd/files/commok
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd
+# will be called by /etc/apcupsd/apccontrol when apcupsd
+# restores contact with the UPS (i.e. the serial connection is restored).
+# We send an email message to root to notify him.
+#
+. /etc/apcupsd/apcupsd_mail.conf
+
+MSG="$HOSTNAME Communications with UPS restored"
+#
+(
+   echo "$MSG"
+   echo " "
+   /usr/sbin/apcaccess status
+) | $MAILPROG -h $MAILHOST -f $FROM -s "$MSG" $TO
+exit 0

--- a/utils/apcupsd/files/offbattery
+++ b/utils/apcupsd/files/offbattery
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd
+# will be called by /etc/apcupsd/apccontrol when apcupsd
+# restores contact with the UPS (i.e. the serial connection is restored).
+# We send an email message to root to notify him.
+#
+. /etc/apcupsd/apcupsd_mail.conf
+
+MSG="$HOSTNAME Communications with UPS restored"
+#
+(
+   echo "$MSG"
+   echo " "
+   /usr/sbin/apcaccess status
+) | $MAILPROG -h $MAILHOST -f $FROM -s "$MSG" $TO
+exit 0

--- a/utils/apcupsd/files/onbattery
+++ b/utils/apcupsd/files/onbattery
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd
+# will be called by /etc/apcupsd/apccontrol when the UPS
+# goes on batteries.
+# We send an email message to root to notify him.
+#
+. /etc/apcupsd/apcupsd_mail.conf
+
+MSG="$HOSTNAME Power Failure !!!"
+#
+(
+   echo "$MSG"
+   echo " "
+   /usr/sbin/apcaccess status
+) | $MAILPROG -h $MAILHOST -f $FROM -s "$MSG" $TO
+exit 0

--- a/utils/apcupsd/patches/010-fix-include-paths.patch
+++ b/utils/apcupsd/patches/010-fix-include-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/autoconf/variables.mak.in b/autoconf/variables.mak.in
+index b67e467..6022434 100644
+--- a/autoconf/variables.mak.in
++++ b/autoconf/variables.mak.in
+@@ -65,7 +65,7 @@ DRVLIBS = @PTHREAD_LFLAGS@ @DRVLIBS@
+ X_LIBS = @X_LIBS@
+ X_EXTRA_LIBS = @X_EXTRA_LIBS@
+
+-CPPFLAGS = @CPPFLAGS@ -I$(topdir)/include $(EXTRAINCS)
++CPPFLAGS = -I$(topdir)/include @CPPFLAGS@ $(EXTRAINCS)
+ CFLAGS = $(CPPFLAGS) @CFLAGS@ @PTHREAD_CFLAGS@
+ CXXFLAGS = $(CPPFLAGS) @CXXFLAGS@ @PTHREAD_CFLAGS@
+ LDFLAGS = @LDFLAGS@


### PR DESCRIPTION
This creates the feed for package apcupsd as copy from old-packages with updated Makefile.
apcupsd in old-packages should be deleted afterwards.