### PR TITLE
python: add patch to abort build on failed module build

### DIFF
--- a/lang/python/patches/170-abort-on-failed-modules.patch
+++ b/lang/python/patches/170-abort-on-failed-modules.patch
@@ -1,0 +1,21 @@
+Abort on failed module build
+
+When building a Python module fails, the setup.py script currently
+doesn't exit with an error, and simply continues. This is not a really
+nice behavior, so this patch changes setup.py to abort with an error,
+so that the build issue is clearly noticeable.
+
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+
+Index: b/setup.py
+===================================================================
+--- a/setup.py
++++ b/setup.py
+@@ -283,6 +283,7 @@
+             print "Failed to build these modules:"
+             print_three_column(failed)
+             print
++            sys.exit(1)
+ 
+     def build_extension(self, ext):
+ 


### PR DESCRIPTION
Taken from buildroot:
  http://git.buildroot.net/buildroot/plain/package/python/014-abort-on-failed-modules.patch

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>