### PR TITLE
packages: gnutls fix build with librt

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
 PKG_VERSION:=3.3.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -123,7 +123,8 @@ CONFIGURE_ARGS+= \
 	--disable-tests \
 	--disable-rsa-export \
 	--with-default-trust-store-dir=/etc/ssl/certs/ \
-	--disable-crywrap
+	--disable-crywrap \
+	--with-librt-prefix="$(STAGING_DIR)/"
 
 ifneq ($(CONFIG_GNUTLS_EXT_LIBTASN1),y)
 CONFIGURE_ARGS += --with-included-libtasn1


### PR DESCRIPTION
compile errors in config phase with ArchLinux and Fedora 20

config.log trying to link with -I/usr/lib/librt.so:
/usr/lib/librt.so: undefined reference to `gettimeofday@GLIBC_2.2.5'

or Fedora20:
/usr/lib/librt.so: error adding symbols: File in wrong format

linkage is AC_LIB_HAVE_LINKFLAGS macro behaviour
see http://marc.info/?l=gnulib-bug&m=129660262901148

Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>