### PR TITLE
boost: Dependencies, architectures updates and lib additions

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -45,7 +45,12 @@ PKG_CONFIG_DEPENDS := \
 	CONFIG_PACKAGE_boost-test \
 	CONFIG_PACKAGE_boost-thread \
 	CONFIG_PACKAGE_boost-wave \
-        CONFIG_PACKAGE_boost-atomic \
+	CONFIG_PACKAGE_boost-atomic \
+	CONFIG_PACKAGE_boost-context \
+	CONFIG_PACKAGE_boost-container \
+	CONFIG_PACKAGE_boost-coroutine \
+	CONFIG_PACKAGE_boost-log \
+
 
 
 include $(INCLUDE_DIR)/package.mk
@@ -111,6 +116,7 @@ endef
 define Package/boost-locale
   $(call Package/boost/Default)
   TITLE+= (locale)
+  DEPENDS+= +iconv
 endef
 
 define Package/boost-math
@@ -183,6 +189,28 @@ define Package/boost-wave
   DEPENDS+= +boost-date_time +boost-thread +boost-filesystem
 endef
 
+define Package/boost-context
+  $(call Package/boost/Default)
+  TITLE+= (context)
+endef
+
+define Package/boost-container
+  $(call Package/boost/Default)
+  TITLE+= (container)
+endef
+
+define Package/boost-coroutine
+  $(call Package/boost/Default)
+  TITLE+= (coroutine)
+  DEPENDS+= +boost-system +boost-chrono +boost-context +boost-thread
+endef
+
+define Package/boost-log
+  $(call Package/boost/Default)
+  TITLE+= (log)
+  DEPENDS+= +boost-system +boost-chrono +boost-date_time +boost-thread +boost-filesystem +boost-regex
+endef
+
 define Package/boost
   $(call Package/boost/Default)
   TITLE+= (header-only)
@@ -200,6 +228,14 @@ endef
 CONFIGURE_PREFIX:=$(PKG_INSTALL_DIR)
 TARGET_LDFLAGS += -pthread -lrt
 
+ifeq ($(ARCH),mips)
+	BOOST_ABI = o32
+else ifeq ($(ARCH),arm)
+	BOOST_ABI = aapcs
+else
+	BOOST_ABI = sysv
+endif
+
 define Build/Compile
 	( cd $(PKG_BUILD_DIR) ; \
 		echo "using gcc : $(ARCH) : $(GNU_TARGET_NAME)-gcc : <compileflags>\"$(TARGET_CFLAGS)\" <cxxflags>\"$(TARGET_CXXFLAGS)\" <linkflags>\"$(TARGET_LDFLAGS)\" ;" > tools/build/src/user-config.jam ; \
@@ -209,7 +245,7 @@ define Build/Compile
 		) \
 		bjam \
 			'-sBUILD=release <optimization>space <inlining>on <debug-symbols>off' \
-			--toolset=gcc-$(ARCH) --build-type=minimal --layout=system \
+			--toolset=gcc-$(ARCH) --build-type=minimal --layout=system abi=$(BOOST_ABI) \
 			--disable-long-double \
 			$(CONFIGURE_ARGS) \
 			$(if $(CONFIG_PACKAGE_boost-atomic),,--without-atomic) \
@@ -234,6 +270,10 @@ define Build/Compile
 			$(if $(CONFIG_PACKAGE_boost-thread),,--without-thread) \
 			$(if $(CONFIG_PACKAGE_boost-timer),,--without-timer) \
 			$(if $(CONFIG_PACKAGE_boost-wave),,--without-wave) \
+			$(if $(CONFIG_PACKAGE_boost-context),,--without-context) \
+			$(if $(CONFIG_PACKAGE_boost-container),,--without-container) \
+			$(if $(CONFIG_PACKAGE_boost-coroutine),,--without-coroutine) \
+			$(if $(CONFIG_PACKAGE_boost-log),,--without-log) \
 			\
 			$(if $(CONFIG_PACKAGE_boost-iostreams),-sNO_BZIP2=1 -sZLIB_INCLUDE=$(STAGING_DIR)/usr/include \
 				-sZLIB_LIBPATH=$(STAGING_DIR)/usr/lib) \
@@ -373,6 +413,24 @@ define Package/boost-wave/install
   $(call Package/boost/Default/install,$(1),wave)
 endef
 
+define Package/boost-context/install
+  $(call Package/boost/Default/install,$(1),context)
+endef
+
+define Package/boost-container/install
+  $(call Package/boost/Default/install,$(1),container)
+endef
+
+define Package/boost-coroutine/install
+  $(call Package/boost/Default/install,$(1),coroutine)
+endef
+
+define Package/boost-log/install
+  $(call Package/boost/Default/install,$(1),log)
+endef
+
+
+
 $(eval $(call HostBuild))
 $(eval $(call BuildPackage,boost))
 $(eval $(call BuildPackage,boost-atomic))
@@ -397,3 +455,7 @@ $(eval $(call BuildPackage,boost-test))
 $(eval $(call BuildPackage,boost-thread))
 $(eval $(call BuildPackage,boost-timer))
 $(eval $(call BuildPackage,boost-wave))
+$(eval $(call BuildPackage,boost-context))
+$(eval $(call BuildPackage,boost-container))
+$(eval $(call BuildPackage,boost-coroutine))
+$(eval $(call BuildPackage,boost-log))


### PR DESCRIPTION
Added MIPS (o32 abi) and Arm (aapcs abi) support. Everything else defaults to sysv.
Added Boost.Locale iconv dependency
Added Boost.Context, Boost.Container, Boost.Coroutine and Boost.Log

Signed-off-by: Carlos M. Ferreira carlosmf.pt@gmail.com