### PR TITLE
python: removed ensurepip module

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -153,6 +153,7 @@ define PyPackage/python/filespec
 -|/usr/lib/python$(PYTHON_VERSION)/config
 -|/usr/lib/python$(PYTHON_VERSION)/distutils/cygwinccompiler.py
 -|/usr/lib/python$(PYTHON_VERSION)/distutils/command/wininst*
+-|/usr/lib/python$(PYTHON_VERSION)/ensurepip
 -|/usr/lib/python$(PYTHON_VERSION)/idlelib
 -|/usr/lib/python$(PYTHON_VERSION)/lib2to3
 -|/usr/lib/python$(PYTHON_VERSION)/lib-tk


### PR DESCRIPTION
This module is not necessary in OpenWrt because the functionality it provides (i.e. installation of setuptools and PIP) is ensured by python-pip and python-setuptools packages.

See: https://docs.python.org/2.7/library/ensurepip.html

Signed-off-by: Jan Čermák <jan.cermak@nic.cz>