### PR TITLE
ddns-scripts: Added update DNS script via nsupdate

### DIFF
--- a/net/ddns-scripts/files/update_nsupdate.sh
+++ b/net/ddns-scripts/files/update_nsupdate.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+[ $use_ipv6 -eq 1 ] && rrtype="AAAA" || rrtype="A"
+cat <<EOF  | /usr/bin/nsupdate -y $username:$password
+server $dns_server
+update del $domain $rrtype 
+update add $domain 60 $rrtype $__IP
+send
+EOF


### PR DESCRIPTION
The script directly updates a PowerDNS (or maybe bind server) via nsupdate from bind-client package. It requires dns_server to be set to the server to be used by nsupdate. Username should be set to the key name and password to the base64 encoded shared secret.
Signed-off-by: Jan Riechers <de@r-jan.de>