### PR TITLE
update cambozola-latest.tar.gz md5 signature

### DIFF
--- a/multimedia/mjpg-streamer/Makefile
+++ b/multimedia/mjpg-streamer/Makefile
@@ -54,7 +54,7 @@ CAMBOZOLA:=cambozola-latest.tar.gz
 define Download/cambozola
   URL:=http://www.andywilcock.com/code/cambozola
   FILE:=$(CAMBOZOLA)
-  MD5SUM:=6c48fd994685d4d72668850eeb613e24
+  MD5SUM:=c9b0da91f8e6e72efccd307e04e2b75b
 endef
 
 # Fetch latest cambozola that works with latest Java(s)


### PR DESCRIPTION
cambozola-latest.tar.gz has a new md5sum, which blocks building unless updated in the package defs.