### PR TITLE
python: patch distutils adjusting path in scripts' shebang

### DIFF
--- a/lang/python/patches/170-distutils-do-not-adjust-path.patch
+++ b/lang/python/patches/170-distutils-do-not-adjust-path.patch
@@ -1,0 +1,10 @@
+--- a/Lib/distutils/command/build_scripts.py
++++ b/Lib/distutils/command/build_scripts.py
+@@ -89,6 +89,7 @@ class build_scripts (Command):
+                     adjust = 1
+                     post_interp = match.group(1) or ''
+ 
++            adjust = 0
+             if adjust:
+                 log.info("copying and adjusting %s -> %s", script,
+                          self.build_dir)


### PR DESCRIPTION
When distutils are copying scripts, path to Python interpreter is adjusted. This does not work well in OpenWrt buildroot, because the path is adjusted to absolute path to host Python then. This patch simply disables the adjusting of the path.

Signed-off-by: Jan Čermák <jan.cermak@nic.cz>