### PR TITLE
ddns-scripts: implements usage of nsupdate to direct update DNS servers

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -3,16 +3,18 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ddns-scripts
 # Version == major.minor.patch
 # increase on new functionality (minor) or patches (patch)
-PKG_VERSION:=2.3.0
+PKG_VERSION:=2.4.0
 # Release == build
 # increase on changes of services files or tld_names.dat
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
-PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 
 include $(INCLUDE_DIR)/package.mk
+
+# no default dependencies
+PKG_DEFAULT_DEPENDS=
 
 define Package/$(PKG_NAME)/Default
     SECTION:=net
@@ -21,6 +23,7 @@ define Package/$(PKG_NAME)/Default
     PKGARCH:=all
 endef
 
+##### **********************************
 define Package/$(PKG_NAME)
     $(call Package/$(PKG_NAME)/Default)
     TITLE:=Dynamic DNS Client scripts (with IPv6 support)
@@ -41,31 +44,53 @@ define Package/$(PKG_NAME)/config
 		  - Proxy server support
 		  - log file support
 		  - support to run once
-
+		.
 		Version: $(PKG_VERSION)-$(PKG_RELEASE)
 		Info   : http://wiki.openwrt.org/doc/howto/ddns.client
-
+		.
 		$(PKG_MAINTAINER)
 endef
 
-define Package/$(PKG_NAME)_CloudFlare
+##### **********************************
+define Package/$(PKG_NAME)_cloudflare
     $(call Package/$(PKG_NAME)/Default)
     TITLE:=DDNS extension for CloudFlare
     DEPENDS:=$(PKG_NAME)
 endef
-define Package/$(PKG_NAME)_CloudFlare/description
+define Package/$(PKG_NAME)_cloudflare/description
     Dynamic DNS Client scripts extension for CloudFlare
 endef
 
-define Package/$(PKG_NAME)_No-IP_com
+##### **********************************
+define Package/$(PKG_NAME)_no-ip_com
     $(call Package/$(PKG_NAME)/Default)
     TITLE:=DDNS extension for No-IP.com
     DEPENDS:=$(PKG_NAME)
 endef
-define Package/$(PKG_NAME)_No-IP_com/description
+define Package/$(PKG_NAME)_no-ip_com/description
     Dynamic DNS Client scripts extension for No-IP.com
 endef
 
+##### **********************************
+define Package/$(PKG_NAME)_nsupdate
+    $(call Package/$(PKG_NAME)/Default)
+    TITLE:=DDNS extension using Bind nsupdate
+    DEPENDS:=$(PKG_NAME) +bind-client
+endef
+define Package/$(PKG_NAME)_nsupdate/description
+    Dynamic DNS Client scripts extension for direct updates using Bind nsupdate
+endef
+define Package/$(PKG_NAME)_nsupdate/config
+    help
+	The script directly updates a PowerDNS (or maybe bind server) via nsupdate 
+	from bind-client package. It requires 
+	"option dns_server" to be set to the server to be used by nsupdate.
+	"option username" should be set to the key name and 
+	"option password" to the base64 encoded shared secret.
+
+endef
+
+##### **********************************
 define Build/Configure
 endef
 define Build/Compile
@@ -84,6 +109,7 @@ define Package/$(PKG_NAME)/conffiles
 /etc/config/ddns
 endef
 
+##### **********************************
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.hotplug $(1)/etc/hotplug.d/iface/95-ddns
@@ -96,16 +122,6 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/services* $(1)/usr/lib/ddns
 	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/dynamic_*.sh $(1)/usr/lib/ddns
 endef
-define Package/$(PKG_NAME)_CloudFlare/install
-	$(INSTALL_DIR) $(1)/usr/lib/ddns
-	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/update_CloudFlare.sh $(1)/usr/lib/ddns
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/tld_names.dat $(1)/usr/lib/ddns
-endef
-define Package/$(PKG_NAME)_No-IP_com/install
-	$(INSTALL_DIR) $(1)/usr/lib/ddns
-	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/update_No-IP.com.sh $(1)/usr/lib/ddns
-endef
-
 define Package/$(PKG_NAME)/postinst
 	#!/bin/sh
 	# if run within buildroot exit
@@ -123,17 +139,6 @@ define Package/$(PKG_NAME)/postinst
 
 	exit 0
 endef
-define Package/$(PKG_NAME)_CloudFlare/postinst
-	#!/bin/sh
-	echo -e '"CloudFlare"\t"update_CloudFlare.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services
-	echo -e '"CloudFlare"\t"update_CloudFlare.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services_ipv6
-endef
-define Package/$(PKG_NAME)_No-IP_com/postinst
-	#!/bin/sh
-	echo -e '"No-IP.com"\t"update_No-IP.com.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services
-	echo -e '"NoIP.com"\t"update_No-IP.com.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services
-endef
-
 define Package/$(PKG_NAME)/prerm
 	#!/bin/sh
 	# if run within buildroot exit
@@ -148,16 +153,57 @@ define Package/$(PKG_NAME)/prerm
 
 	exit 0
 endef
-define Package/$(PKG_NAME)_CloudFlare/prerm
+
+##### **********************************
+define Package/$(PKG_NAME)_cloudflare/install
+	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/update_CloudFlare.sh $(1)/usr/lib/ddns
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/tld_names.dat $(1)/usr/lib/ddns
+endef
+define Package/$(PKG_NAME)_cloudflare/postinst
+	#!/bin/sh
+	echo -e '"CloudFlare"\t"update_CloudFlare.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services
+	echo -e '"CloudFlare"\t"update_CloudFlare.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services_ipv6
+endef
+define Package/$(PKG_NAME)_cloudflare/prerm
 	#!/bin/sh
 	/bin/sed -i '/update_CloudFlare\.sh/ d' $${IPKG_INSTROOT}/usr/lib/ddns/services
 	/bin/sed -i '/update_CloudFlare\.sh/ d' $${IPKG_INSTROOT}/usr/lib/ddns/services_ipv6
 endef
-define Package/$(PKG_NAME)_No-IP_com/prerm
+
+##### **********************************
+define Package/$(PKG_NAME)_no-ip_com/install
+	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/update_No-IP.com.sh $(1)/usr/lib/ddns
+endef
+define Package/$(PKG_NAME)_no-ip_com/postinst
+	#!/bin/sh
+	echo -e '"No-IP.com"\t"update_No-IP.com.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services
+	echo -e '"NoIP.com"\t"update_No-IP.com.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services
+endef
+define Package/$(PKG_NAME)_no-ip_com/prerm
 	#!/bin/sh
 	/bin/sed -i '/update_No-IP\.com\.sh/ d' $${IPKG_INSTROOT}/usr/lib/ddns/services
 endef
 
+##### **********************************
+define Package/$(PKG_NAME)_nsupdate/install
+	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/update_nsupdate.sh $(1)/usr/lib/ddns
+endef
+define Package/$(PKG_NAME)_nsupdate/postinst
+	#!/bin/sh
+	echo -e '"Bind-nsupdate"\t"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services
+	echo -e '"Bind-nsupdate"\t"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services_ipv6
+endef
+define Package/$(PKG_NAME)_nsupdate/prerm
+	#!/bin/sh
+	/bin/sed -i '/update_nsupdate\.sh/ d' $${IPKG_INSTROOT}/usr/lib/ddns/services
+	/bin/sed -i '/update_nsupdate\.sh/ d' $${IPKG_INSTROOT}/usr/lib/ddns/services_ipv6
+endef
+
+##### **********************************
 $(eval $(call BuildPackage,$(PKG_NAME)))
-$(eval $(call BuildPackage,$(PKG_NAME)_CloudFlare))
-$(eval $(call BuildPackage,$(PKG_NAME)_No-IP_com))
+$(eval $(call BuildPackage,$(PKG_NAME)_cloudflare))
+$(eval $(call BuildPackage,$(PKG_NAME)_no-ip_com))
+$(eval $(call BuildPackage,$(PKG_NAME)_nsupdate))

--- a/net/ddns-scripts/files/tld_names.dat
+++ b/net/ddns-scripts/files/tld_names.dat
@@ -6153,6 +6153,38 @@ store.st
 
 // su : http://en.wikipedia.org/wiki/.su
 su
+adygeya.su
+arkhangelsk.su
+balashov.su
+bashkiria.su
+bryansk.su
+dagestan.su
+grozny.su
+ivanovo.su
+kalmykia.su
+kaluga.su
+karelia.su
+khakassia.su
+krasnodar.su
+kurgan.su
+lenug.su
+mordovia.su
+msk.su
+murmansk.su
+nalchik.su
+nov.su
+obninsk.su
+penza.su
+pokrovsk.su
+sochi.su
+spb.su
+togliatti.su
+troitsk.su
+tula.su
+tuva.su
+vladikavkaz.su
+vladimir.su
+vologda.su
 
 // sv : http://www.svnet.org.sv/niveldos.pdf
 sv
@@ -9508,6 +9540,7 @@ zuerich
 
 // ===END ICANN DOMAINS===
 // ===BEGIN PRIVATE DOMAINS===
+// (Note: these are in alphabetical order by company name)
 
 // Amazon CloudFront : https://aws.amazon.com/cloudfront/
 // Submitted by Donavan Miller <donavanm@amazon.com> 2013-03-22
@@ -9941,6 +9974,10 @@ firebaseapp.com
 // Submitted by Jonathan Rudenberg <jonathan@flynn.io> 2014-07-12
 flynnhub.com
 
+// GDS : https://www.gov.uk/service-manual/operations/operating-servicegovuk-subdomains
+// Submitted by David Illsley <david.illsley@digital.cabinet-office.gov.uk> 2014-08-28
+service.gov.uk
+
 // GitHub, Inc.
 // Submitted by Ben Toews <btoews@github.com> 2014-02-06
 github.io
@@ -10052,17 +10089,19 @@ poznan.pl
 wroc.pl
 zakopane.pl
 
+// priv.at : http://www.nic.priv.at/
+// Submitted by registry <lendl@nic.at> 2008-06-09
+priv.at
+
 // Red Hat, Inc. OpenShift : https://openshift.redhat.com/
 // Submitted by Tim Kramer <tkramer@rhcloud.com> 2012-10-24
 rhcloud.com
 
-// GDS : https://www.gov.uk/service-manual/operations/operating-servicegovuk-subdomains
-// Submitted by David Illsley <david.illsley@digital.cabinet-office.gov.uk> 2014-08-28
-service.gov.uk
-
-// priv.at : http://www.nic.priv.at/
-// Submitted by registry <lendl@nic.at> 2008-06-09
-priv.at
+// SinaAppEngine : http://sae.sina.com.cn/
+// Submitted by SinaAppEngine <saesupport@sinacloud.com> 2015-02-02
+sinaapp.com
+vipsinaapp.com
+1kapp.com
 
 // TASK geographical domains (www.task.gda.pl/uslugi/dns)
 gda.pl

--- a/net/ddns-scripts/files/update_nsupdate.sh
+++ b/net/ddns-scripts/files/update_nsupdate.sh
@@ -1,0 +1,46 @@
+#
+#.Distributed under the terms of the GNU General Public License (GPL) version 2.0
+#
+# The script directly updates a PowerDNS (or maybe bind server) via nsupdate from bind-client package.
+#.based on github request #957 by Jan Riechers <de at r-jan dot de>
+#.2015 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+#
+# This script is parsed by dynamic_dns_functions.sh inside send_update() function
+#
+# using following options from /etc/config/ddns
+# option username   - keyname 
+# option password   - shared secret (base64 encoded)
+# option domain     - full qualified domain to update
+# option dns_server - DNS server to update
+#
+# variable __IP already defined with the ip-address to use for update
+#
+local __TTL=600		#.preset DNS TTL (in seconds)
+local __RRTYPE __PW __TCP
+
+[ -x /usr/bin/nsupdate ] || write_log 14 "'nsupdate' not installed or not executable !"
+
+[ -z "$username" ]   && write_log 14 "Service section not configured correctly! Missing 'username'"
+[ -z "$password" ]   && write_log 14 "Service section not configured correctly! Missing 'password'"
+[ -z "$dns_server" ] && write_log 14 "Service section not configured correctly! Missing 'dns_server'"
+
+[ $use_ipv6 -ne 0 ] && __RRTYPE="AAAA" || __RRTYPE="A"
+[ $force_dnstcp -ne 0 ] && __TCP="-v" || __TCP=""
+
+# create command file
+cat >$DATFILE <<-EOF
+server $dns_server
+key $username $password
+update del $domain $__RRTYPE
+update add $domain $__TTL $__RRTYPE $__IP
+show
+send
+quit
+EOF
+
+/usr/bin/nsupdate -d $__TCP $DATFILE >$ERRFILE 2>&1
+
+# nsupdate always return success
+write_log 7 "nsupdate reports:\n$(cat $ERRFILE)"
+
+return 0


### PR DESCRIPTION
* new service "bind-nsupdate" using nsupdate to directly updates a PowerDNS or Bind server via nsupdate.
  suggested by Jan Riechers (Pull #957) many thanks!
* updated tld-names.dat

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>