### PR TITLE
gst1-plugins-base: add videorate and videoscale

### DIFF
--- a/multimedia/gst1-plugins-base/Makefile
+++ b/multimedia/gst1-plugins-base/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-base
 PKG_VERSION:=1.4.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -133,8 +133,8 @@ CONFIGURE_ARGS += \
 	--disable-subparse \
 	$(call GST_COND_SELECT,tcp) \
 	$(call GST_COND_SELECT,theora) \
-	--disable-videorate \
-	--disable-videoscale \
+	$(call GST_COND_SELECT,videorate) \
+	$(call GST_COND_SELECT,videoscale) \
 	$(call GST_COND_SELECT,videoconvert) \
 	$(call GST_COND_SELECT,videotestsrc) \
 	$(call GST_COND_SELECT,volume) \
@@ -279,6 +279,8 @@ $(eval $(call GstBuildPlugin,tcp,TCP,,,))
 $(eval $(call GstBuildPlugin,theora,Theora,tag video,,+libogg +libtheora))
 $(eval $(call GstBuildPlugin,typefindfunctions,'typefind' functions,audio pbutils tag video,,))
 $(eval $(call GstBuildPlugin,videoconvert,video format conversion,video,,))
+$(eval $(call GstBuildPlugin,videorate,Adjusts video frames,video,,))
+$(eval $(call GstBuildPlugin,videoscale,Resizes video,video,,))
 $(eval $(call GstBuildPlugin,videotestsrc,video test,video,,+liboil))
 $(eval $(call GstBuildPlugin,volume,volume,audio controller,,+liboil))
 $(eval $(call GstBuildPlugin,vorbis,Vorbis,audio tag,ogg,+libvorbis))


### PR DESCRIPTION
This adds videoscale and videorate plugins. They have no external dependencies.

Tested on x86.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>