### PR TITLE
python: packetize some python modules

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -12,7 +12,7 @@ include ./files/python-package.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.python.org/ftp/python/$(PKG_VERSION)
@@ -54,7 +54,7 @@ endef
 define Package/python-base
 $(call Package/python/Default)
   TITLE:=Python $(PYTHON_VERSION) interpreter
-  DEPENDS:=+libpthread +zlib +libffi +libopenssl
+  DEPENDS:=+libpthread +zlib
 endef
 
 define Package/python-base/description
@@ -62,13 +62,44 @@ define Package/python-base/description
   for the interpreter to start.
 endef
 
+define Package/python-light
+$(call Package/python/Default)
+  TITLE:=Python $(PYTHON_VERSION) light installation
+  DEPENDS:=+python-base +libffi +libbz2
+endef
+
+define Package/python-light/description
+  This package is essentially the python-base package plus
+  a few of the rarely used (and big) libraries stripped out
+  into separate packages.
+endef
+
+# Define newline here, since it's not defined in OpenWRT
+define newline
+
+
+endef
+
+PYTHON_LIB_FILES_DEL:=
+PYTHON_PACKAGES:=
+define PyBasePackage
+  PYTHON_PACKAGES+=$(1)
+  PYTHON_LIB_FILES_DEL+=$(2)
+  define PyPackage/$(1)/filespec
+    $(subst $(space),$(newline),$(foreach lib_file,$(2),+|$(lib_file)))
+  endef
+endef
+
+include ./files/python-package-*.mk
+
 define Package/python
 $(call Package/python/Default)
-  DEPENDS:=+python-base +libncursesw +libbz2 +libgdbm +libsqlite3 +libexpat +libdb47
+  DEPENDS:=+python-light $(foreach package,$(PYTHON_PACKAGES),+$(package))
 endef
 
 define Package/python/description
   This package contains the (almost) full Python install.
+  It's python-light + all other packages.
 endef
 
 MAKE_FLAGS+=\
@@ -124,31 +155,36 @@ define Build/InstallDev
 		$(1)/usr/lib/python$(PYTHON_VERSION)/
 endef
 
+PYTHON_BASE_LIB_FILES:= \
+	/usr/lib/python$(PYTHON_VERSION)/_abcoll.py \
+	/usr/lib/python$(PYTHON_VERSION)/_sysconfigdata.py \
+	/usr/lib/python$(PYTHON_VERSION)/_weakrefset.py \
+	/usr/lib/python$(PYTHON_VERSION)/abc.py \
+	/usr/lib/python$(PYTHON_VERSION)/copy_reg.py \
+	/usr/lib/python$(PYTHON_VERSION)/genericpath.py \
+	/usr/lib/python$(PYTHON_VERSION)/linecache.py \
+	/usr/lib/python$(PYTHON_VERSION)/posixpath.py \
+	/usr/lib/python$(PYTHON_VERSION)/os.py \
+	/usr/lib/python$(PYTHON_VERSION)/re.py \
+	/usr/lib/python$(PYTHON_VERSION)/site.py \
+	/usr/lib/python$(PYTHON_VERSION)/sre_compile.py \
+	/usr/lib/python$(PYTHON_VERSION)/sre_constants.py \
+	/usr/lib/python$(PYTHON_VERSION)/sre_parse.py \
+	/usr/lib/python$(PYTHON_VERSION)/sysconfig.py \
+	/usr/lib/python$(PYTHON_VERSION)/stat.py \
+	/usr/lib/python$(PYTHON_VERSION)/traceback.py \
+	/usr/lib/python$(PYTHON_VERSION)/types.py \
+	/usr/lib/python$(PYTHON_VERSION)/UserDict.py \
+	/usr/lib/python$(PYTHON_VERSION)/warnings.py
+
+PYTHON_BASE_LIB_FILES+=$(PYTHON_BASE_LIB_FILES)
+
 define PyPackage/python-base/filespec
 +|/usr/bin/python$(PYTHON_VERSION)
-+|/usr/lib/python$(PYTHON_VERSION)/_abcoll.py
-+|/usr/lib/python$(PYTHON_VERSION)/_sysconfigdata.py
-+|/usr/lib/python$(PYTHON_VERSION)/_weakrefset.py
-+|/usr/lib/python$(PYTHON_VERSION)/abc.py
-+|/usr/lib/python$(PYTHON_VERSION)/copy_reg.py
-+|/usr/lib/python$(PYTHON_VERSION)/genericpath.py
-+|/usr/lib/python$(PYTHON_VERSION)/linecache.py
-+|/usr/lib/python$(PYTHON_VERSION)/posixpath.py
-+|/usr/lib/python$(PYTHON_VERSION)/os.py
-+|/usr/lib/python$(PYTHON_VERSION)/re.py
-+|/usr/lib/python$(PYTHON_VERSION)/site.py
-+|/usr/lib/python$(PYTHON_VERSION)/sre_compile.py
-+|/usr/lib/python$(PYTHON_VERSION)/sre_constants.py
-+|/usr/lib/python$(PYTHON_VERSION)/sre_parse.py
-+|/usr/lib/python$(PYTHON_VERSION)/sysconfig.py
-+|/usr/lib/python$(PYTHON_VERSION)/stat.py
-+|/usr/lib/python$(PYTHON_VERSION)/traceback.py
-+|/usr/lib/python$(PYTHON_VERSION)/types.py
-+|/usr/lib/python$(PYTHON_VERSION)/UserDict.py
-+|/usr/lib/python$(PYTHON_VERSION)/warnings.py
+$(subst $(space),$(newline),$(foreach lib_file,$(PYTHON_BASE_LIB_FILES),+|$(lib_file)))
 endef
 
-define PyPackage/python/filespec
+define PyPackage/python-light/filespec
 +|/usr/lib/python$(PYTHON_VERSION)
 -|/usr/lib/python$(PYTHON_VERSION)/config
 -|/usr/lib/python$(PYTHON_VERSION)/distutils/cygwinccompiler.py
@@ -164,32 +200,17 @@ define PyPackage/python/filespec
 -|/usr/lib/python$(PYTHON_VERSION)/*/test
 -|/usr/lib/python$(PYTHON_VERSION)/*/tests
 -|/usr/lib/python$(PYTHON_VERSION)/lib-dynload/readline.so
--|/usr/lib/python$(PYTHON_VERSION)/_abcoll.py
--|/usr/lib/python$(PYTHON_VERSION)/_sysconfigdata.py
--|/usr/lib/python$(PYTHON_VERSION)/_weakrefset.py
--|/usr/lib/python$(PYTHON_VERSION)/abc.py
--|/usr/lib/python$(PYTHON_VERSION)/copy_reg.py
--|/usr/lib/python$(PYTHON_VERSION)/genericpath.py
--|/usr/lib/python$(PYTHON_VERSION)/linecache.py
--|/usr/lib/python$(PYTHON_VERSION)/posixpath.py
--|/usr/lib/python$(PYTHON_VERSION)/os.py
--|/usr/lib/python$(PYTHON_VERSION)/re.py
--|/usr/lib/python$(PYTHON_VERSION)/site.py
--|/usr/lib/python$(PYTHON_VERSION)/sre_compile.py
--|/usr/lib/python$(PYTHON_VERSION)/sre_constants.py
--|/usr/lib/python$(PYTHON_VERSION)/sre_parse.py
--|/usr/lib/python$(PYTHON_VERSION)/sysconfig.py
--|/usr/lib/python$(PYTHON_VERSION)/stat.py
--|/usr/lib/python$(PYTHON_VERSION)/traceback.py
--|/usr/lib/python$(PYTHON_VERSION)/types.py
--|/usr/lib/python$(PYTHON_VERSION)/UserDict.py
--|/usr/lib/python$(PYTHON_VERSION)/warnings.py
+$(subst $(space),$(newline),$(foreach lib_file,$(PYTHON_LIB_FILES_DEL),-|$(lib_file)))
 endef
 
 define PyPackage/python-base/install
 	$(LN) python$(PYTHON_VERSION) $(1)/usr/bin/python
 	$(LN) python$(PYTHON_VERSION) $(1)/usr/bin/python2
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON_VERSION).so* $(1)/usr/lib/
+endef
+
+# Dummy rule so that the package gets picked up
+define Package/python/install
 endef
 
 HOST_CFLAGS+= \
@@ -213,8 +234,15 @@ endef
 
 $(eval $(call HostBuild))
 
+$(foreach package, $(PYTHON_PACKAGES),  \
+	$(eval $(call PyPackage,$(package))) \
+	$(eval $(call BuildPackage,$(package))) \
+)
+
 $(eval $(call PyPackage,python-base))
+$(eval $(call PyPackage,python-light))
 $(eval $(call PyPackage,python))
 
 $(eval $(call BuildPackage,python-base))
+$(eval $(call BuildPackage,python-light))
 $(eval $(call BuildPackage,python))

--- a/lang/python/files/python-package-bsddb.mk
+++ b/lang/python/files/python-package-bsddb.mk
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Package/python-bsddb
+$(call Package/python/Default)
+  TITLE:=Python $(PYTHON_VERSION) bsddb module
+  DEPENDS:=+python-light +libdb47
+endef
+
+$(eval $(call PyBasePackage,python-bsddb, \
+	/usr/lib/python$(PYTHON_VERSION)/bsddb \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_bsddb.so \
+))

--- a/lang/python/files/python-package-codecs.mk
+++ b/lang/python/files/python-package-codecs.mk
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Package/python-codecs
+$(call Package/python/Default)
+  TITLE:=Python $(PYTHON_VERSION) codecs + unicode support
+  DEPENDS:=+python-light
+endef
+
+$(eval $(call PyBasePackage,python-codecs, \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_codecs_cn.so \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_codecs_hk.so \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_codecs_iso2022.so \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_codecs_jp.so \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_codecs_kr.so \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_codecs_tw.so \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/unicodedata.so \
+))

--- a/lang/python/files/python-package-dbm.mk
+++ b/lang/python/files/python-package-dbm.mk
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Package/python-dbm
+$(call Package/python/Default)
+  TITLE:=Python $(PYTHON_VERSION) dbm module
+  DEPENDS:=+python-light +libdb47
+endef
+
+$(eval $(call PyBasePackage,python-dbm, \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/dbm.so \
+))

--- a/lang/python/files/python-package-gdbm.mk
+++ b/lang/python/files/python-package-gdbm.mk
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Package/python-gdbm
+$(call Package/python/Default)
+  TITLE:=Python $(PYTHON_VERSION) gdbm module
+  DEPENDS:=+python-light +libgdbm
+endef
+
+$(eval $(call PyBasePackage,python-gdbm, \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/gdbm.so \
+))

--- a/lang/python/files/python-package-ncurses.mk
+++ b/lang/python/files/python-package-ncurses.mk
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Package/python-ncurses
+$(call Package/python/Default)
+  TITLE:=Python $(PYTHON_VERSION) ncurses module
+  DEPENDS:=+python-light +libncursesw
+endef
+
+$(eval $(call PyBasePackage,python-ncurses, \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_curses.so \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_curses_panel.so \
+))

--- a/lang/python/files/python-package-openssl.mk
+++ b/lang/python/files/python-package-openssl.mk
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Package/python-openssl
+$(call Package/python/Default)
+  TITLE:=Python $(PYTHON_VERSION) SSL module
+  DEPENDS:=+python-light +libopenssl
+endef
+
+$(eval $(call PyBasePackage,python-openssl, \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_hashlib.so \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_ssl.so \
+))

--- a/lang/python/files/python-package-pydoc.mk
+++ b/lang/python/files/python-package-pydoc.mk
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Package/python-pydoc
+$(call Package/python/Default)
+  TITLE:=Python $(PYTHON_VERSION) pydoc module
+  DEPENDS:=+python-light
+endef
+
+$(eval $(call PyBasePackage,python-pydoc, \
+	/usr/lib/python$(PYTHON_VERSION)/pydoc.py \
+	/usr/lib/python$(PYTHON_VERSION)/pydoc_data \
+))

--- a/lang/python/files/python-package-sqlite3.mk
+++ b/lang/python/files/python-package-sqlite3.mk
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Package/python-sqlite3
+$(call Package/python/Default)
+  TITLE:=Python $(PYTHON_VERSION) sqlite3 module
+  DEPENDS:=+python-light +libsqlite3
+endef
+
+$(eval $(call PyBasePackage,python-sqlite3, \
+	/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_sqlite3.so \
+	/usr/lib/python$(PYTHON_VERSION)/sqlite3 \
+))

--- a/lang/python/files/python-package.mk
+++ b/lang/python/files/python-package.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.


### PR DESCRIPTION
Packetize some Python modules to reduce size of the overall Python package.
Basically, a new package is introduced, call `python-light`,
and everything that's extra (or big) is put in other packages.

The `python` package becomes a metapackage that installs `python-light`
along with the rest of the packages.

Base work started by Jan Čermák.

The packetization is dynamic.
A `PyBasePackage` function has been created.
Each package must be put in a `./files/python-package-<package-name>.mk`
file, and it must call the `PyBasePackage` function.

The first parameter of the function is the package name,
and the second one, is the files (from the /usr/lib/python2.7 folder)
which the package needs.

The files will be removed from the `python-light` and put in the
the new package, making the `python-light` package lighter.

Signed-off-by: Jan Čermák <jan.cermak@nic.cz>
Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>