### PR TITLE
ocserv: fix libcrypt location

### DIFF
--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ocserv
 PKG_VERSION:=0.9.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR :=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -58,6 +58,7 @@ CONFIGURE_ARGS+= \
 	--enable-local-libopts \
 	--with-libreadline-prefix="$(STAGING_DIR)/" \
 	--without-libnl \
+	--with-libcrypt-prefix="$(STAGING_DIR)/" \
 
 ifneq ($(CONFIG_OCSERV_PAM),y)
 CONFIGURE_ARGS += --without-pam


### PR DESCRIPTION
fix build errors on Arch Linux/Fedora 20

config.log trying to link with /usr/lib/libcrypt.so
/usr/lib/libcrypt.so: undefined reference to `memset@GLIBC_2.2.5'
resulting in
ac_cv_libcrypt=no
and failed build later
  CCLD     ocpasswd
ocpasswd.o: In function `main':
ocpasswd.c:(.text.startup+0x70e): undefined reference to `crypt'
ocpasswd.c:(.text.startup+0x728): undefined reference to `crypt'
collect2: error: ld returned 1 exit status

linkage is AC_LIB_HAVE_LINKFLAGS macro behaviour
see http://marc.info/?l=gnulib-bug&m=129660262901148

Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>