### PR TITLE
Gammu fixes

### DIFF
--- a/utils/gammu/Makefile
+++ b/utils/gammu/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gammu
 PKG_VERSION:=1.34.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://dl.cihar.com/gammu/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -18,8 +18,11 @@ PKG_MD5SUM:=5bc2508389d9b291ca0b8d4f210d0012
 PKG_MAINTAINER:=Vitaly Protsko <villy@sft.ru>
 PKG_LICENCE:=GPL-2.0
 
+PKG_INSTALL:=1
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/gammu
 	SECTION:=utils
@@ -32,30 +35,12 @@ define Package/gammu
 	DEPENDS+=+PACKAGE_libusb-1.0:libusb-1.0
 endef
 
-CONFIGURE_ARGS:= \
-	--prefix=/usr \
-	--cross-root="$(STAGING_DIR) $(TOOLCHAIN_DIR)" \
-	--enable-shared \
-	--without-libdbi
-
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		$(TARGET_CONFIGURE_OPTS) \
-		LDSHARED="$(TARGET_CROSS)ld -shared" \
-		CFLAGS="$(TARGET_CFLAGS) $(FPIC)"
-endef
-
-define Build/Install
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		install
-endef
 
 define Build/InstallDev
 	mkdir -p $(1)/usr/include
 	$(CP) -r $(PKG_INSTALL_DIR)/usr/include/gammu $(1)/usr/include/
 	mkdir -p $(1)/usr/lib
-	$(CP)    $(PKG_INSTALL_DIR)/usr/lib/lib{Gammu*,gsmsd*} $(1)/usr/lib/
+	$(CP)    $(PKG_INSTALL_DIR)/usr/lib$(LIB_SUFFIX)/lib{Gammu*,gsmsd*} $(1)/usr/lib/
 endef
 
 define Package/gammu/install
@@ -63,7 +48,7 @@ define Package/gammu/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gammu $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gammu-{smsd,smsd-inject,smsd-monitor} $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/lib{Gammu*,gsmsd*} $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib$(LIB_SUFFIX)/lib{Gammu*,gsmsd*} $(1)/usr/lib
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/gammu $(1)/etc/config/gammu

--- a/utils/gammu/Makefile
+++ b/utils/gammu/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gammu
 PKG_VERSION:=1.34.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=http://dl.cihar.com/gammu/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -31,9 +31,11 @@ define Package/gammu
 	URL:=http://dl.cihar.com/gammu/releases/
 	DEPENDS:=+libpthread +libcurl +glib2 $(ICONV_DEPENDS) $(INTL_DEPENDS)
 	DEPENDS+=+PACKAGE_python:python +PACKAGE_bluez-libs:bluez-libs
-	DEPENDS+=+PACKAGE_libmysqlclient:libmysqlclient +PACKAGE_unixodbc:unixodbc
+	DEPENDS+=+PACKAGE_libmysqlclient:libmysqlclient +PACKAGE_unixodbc:unixodbc +PACKAGE_libpq:libpq
 	DEPENDS+=+PACKAGE_libusb-1.0:libusb-1.0
 endef
+
+CMAKE_OPTIONS += -DWITH_LibDBI:BOOL=OFF
 
 
 define Build/InstallDev


### PR DESCRIPTION
Improvements (patch 1): 
gammu uses CMake build system so use the OpenWRT cmake.mk facilties
to build (and remove the old build 

Build fixes (patch 2):
- redisable libdbi via cmake
- libpq dependency (reported by http://buildbot.openwrt.org:8010/broken_packages/malta/gammu/compile.txt)

other notes:
- Patch 2 depends on patch 1 (CMake syntax) so thats why its 1 pull request
- /usr/lib$(LIB_SUFFIX)/ is because for x86_64 targets (mips64,aarch64 untested ) there can be a build failure when installing - maybe there need to be a change in cmake.mk to fix other packages where this might be an issue ?