### PR TITLE
knxd: streamline makefile

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -11,25 +11,25 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
-PKG_REV:=a63bc660d305e26ce3ed038607d387758fad8413
-PKG_VERSION:=2015-03-06
+PKG_VERSION=2015-03-06-$(PKG_SOURCE_VERSION)
 PKG_RELEASE:=1
 
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/knxd/knxd.git
+PKG_SOURCE_VERSION:=a63bc660d305e26ce3ed038607d387758fad8413
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_SOURCE_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz
+
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
+
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=LICENSE
 
-
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=git://github.com/knxd/knxd.git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)
-PKG_SOURCE_VERSION:=$(PKG_REV)
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
-PKG_BUILD_DEPENDS:=pthsem argp-standalone
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
 
 PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -37,8 +37,7 @@ define Package/knxd
   SECTION:=net
   CATEGORY:=Network
   TITLE:=EIB KNX daemon
-  URL:=https://github.com/knxd/knxd
-  DEPENDS:=pthsem libusb-1.0
+  DEPENDS:=+pthsem +libusb-1.0
 endef
 
 define Package/knxd/description
@@ -49,105 +48,105 @@ define Package/knxd/conffiles
 /etc/config/knxd
 endef
 
+define Package/libeibclient
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Library for EIB clients
+  DEPENDS:=+pthsem
+endef
+
+define Package/knxd-tools/description
+EIB KNX client library
+endef
+
 define Package/knxd-tools
   SECTION:=net
   CATEGORY:=Network
   TITLE:=EIB KNX Utils
-  URL:=https://github.com/knxd/knxd
-  DEPENDS:=pthsem libusb-1.0
+  DEPENDS:=+libeibclient
 endef
 
 define Package/knxd-tools/description
 EIB KNX Tools
 endef
 
-define Build/Prepare
-	$(call Build/Prepare/Default)
-endef
+CONFIGURE_ARGS+= \
+	--disable-ft12 \
+	--enable-eibnetip \
+	--enable-eibnetiptunnel \
+	--enable-eibnetipserver \
+	--enable-usb \
+	--enable-tpuart \
+	--enable-tpuarts \
+	--disable-pei16 \
+	--disable-pei16s \
+	--enable-groupcache \
+	--without-pth-test \
+	--without-libstdc
 
-define Build/Configure
-	$(call Build/Configure/Default,\
-		--disable-ft12 \
-		--enable-eibnetip \
-		--enable-eibnetiptunnel \
-		--enable-eibnetipserver \
-		--enable-usb \
-		--enable-tpuart \
-		--enable-tpuarts \
-		--disable-pei16 \
-		--disable-pei16s \
-		--enable-groupcache \
-		--without-pth-test \
-		--without-libstdc )
-endef
+TARGET_CFLAGS+= \
+	$(FPIC) \
+	-fno-builtin -nodefaultlibs -lc -lm -lgcc -largp -lpthsem
 
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		CC=$(TARGET_CC) \
-		LIBS="-L$(STAGING_DIR)/lib -L$(STAGING_DIR)/usr/lib -fno-builtin -nodefaultlibs -lc -lm -lgcc -largp -lpthsem" \
-		CPPFLAGS="-I$(STAGING_DIR)/include -I$(STAGING_DIR)/usr/include"
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/eib*.h $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libeibclient.{a,so*} $(1)/usr/lib/
 endef
 
 define Package/knxd/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/server/knxd $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/tools/bcu/bcuaddrtab $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/tools/bcu/bcuread $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/tools/eibnet/eibnetsearch $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/tools/eibnet/eibnetdescribe $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/usb/findknxusb $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/knxd.init $(1)/etc/init.d/knxd
+
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) ./files/knxd.config $(1)/etc/config/knxd
 endef
 
-define Package/knxd-tools/install
+define Package/libeibclient/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/src/client/c/.libs/libeibclient.so.0.0.0 $(1)/usr/lib/
-	ln -s libeibclient.so.0.0.0 $(1)/usr/lib/libeibclient.so
-	ln -s libeibclient.so.0.0.0 $(1)/usr/lib/libeibclient.so.0
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libeibclient.so* $(1)/usr/lib/
+endef
+
+define Package/knxd-tools/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	-rm -f $(1)/usr/bin/knxread
-	-rm -f $(1)/usr/bin/knxreadtemp
-	-rm -f $(1)/usr/bin/knxwrite
-	-rm -f $(1)/usr/bin/knxlog
-	-rm -f $(1)/usr/bin/knxon
-	-rm -f $(1)/usr/bin/knxoff
-	-rm -f $(1)/usr/bin/knxif
-	-rm -f $(1)/usr/bin/knxswrite
-	-rm -f $(1)/usr/bin/knxbool
-	-rm -f $(1)/usr/bin/knxdimup
-	ln -s knxtool $(1)/usr/bin/knxread
-	ln -s knxtool $(1)/usr/bin/knxreadtemp
-	ln -s knxtool $(1)/usr/bin/knxwrite
-	ln -s knxtool $(1)/usr/bin/knxlog
-	ln -s knxtool $(1)/usr/bin/knxon
-	ln -s knxtool $(1)/usr/bin/knxoff
-	ln -s knxtool $(1)/usr/bin/knxif
-	ln -s knxtool $(1)/usr/bin/knxswrite
-	ln -s knxtool $(1)/usr/bin/knxbool
-	ln -s knxtool $(1)/usr/bin/knxdimup
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/knxtool $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/busmonitor1 $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/busmonitor2 $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/busmonitor3 $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/eibread-cgi $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/eibwrite-cgi $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/vbusmonitor1 $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/vbusmonitor2 $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/vbusmonitor3 $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/groupwrite $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/groupswrite $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/grouplisten $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/groupread $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/groupresponse $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/groupreadresponse $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/groupsocketlisten $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/groupsocketread $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/groupsocketwrite $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/examples/.libs/groupsocketswrite $(1)/usr/bin/
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/knxtool $(1)/usr/bin/
+	ln -sf knxtool $(1)/usr/bin/knxread
+	ln -sf knxtool $(1)/usr/bin/knxreadtemp
+	ln -sf knxtool $(1)/usr/bin/knxwrite
+	ln -sf knxtool $(1)/usr/bin/knxlog
+	ln -sf knxtool $(1)/usr/bin/knxon
+	ln -sf knxtool $(1)/usr/bin/knxoff
+	ln -sf knxtool $(1)/usr/bin/knxif
+	ln -sf knxtool $(1)/usr/bin/knxswrite
+	ln -sf knxtool $(1)/usr/bin/knxbool
+	ln -sf knxtool $(1)/usr/bin/knxdimup
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/busmonitor1 $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/busmonitor2 $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/busmonitor3 $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/eibread-cgi $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/eibwrite-cgi $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/vbusmonitor1 $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/vbusmonitor2 $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/vbusmonitor3 $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/groupwrite $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/groupswrite $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/grouplisten $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/groupread $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/groupresponse $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/groupreadresponse $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/groupsocketlisten $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/groupsocketread $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/groupsocketwrite $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/knxd/examples/bin/groupsocketswrite $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,knxd))
+$(eval $(call BuildPackage,libeibclient))
 $(eval $(call BuildPackage,knxd-tools))

--- a/net/knxd/files/knxd.init
+++ b/net/knxd/files/knxd.init
@@ -6,8 +6,6 @@ STOP=20
 NAME=knxd
 PROG=/usr/bin/$NAME
 
-. /lib/functions.sh
-
 start() {
         local options url
         config_load "$NAME"
@@ -19,4 +17,3 @@ start() {
 stop() {
         service_stop $PROG
 }
-


### PR DESCRIPTION
- use https URL for fetching sources from GitHub, otherwise cloning
  sources could stall buildbots by asking to accept a/the SSH host key
- do not _depend_ on DEPENDS but _select_ them, so the package(s) always
  appear in menuconfig, not only when all dependencies are already
  selected --> dependencies are automatically pulled in when package
  is selected by user
- use PKG_INSTALL
- factor out the libeibclient library as own package
- use CONFIGURE_ARGS instead of dedicated Build/Configure
- same for TARGET_CFLAGS and Build/Compile
- do not include /etc/functions, already included by /etc/rc.common

Signed-off-by: Michael Heimpold <mhei@heimpold.de>