### PR TITLE
vim: add libacl deps

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vim
 PKG_VERSION:=7.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 VIMVER:=74
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/vim/Default
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libncurses
+  DEPENDS:=+libncurses +libacl
   TITLE:=Vi IMproved - enhanced vi editor
   URL:=http://www.vim.org/
   SUBMENU:=Editors


### PR DESCRIPTION
vim was failing to compile when libacl was selected (as in buildbot)
http://buildbot.openwrt.org:8010/broken_packages/x86/vim/compile.txt

I could also use something like +PACKAGE_libacl:libacl but I guess a static dep is better.
As vim is already for those who have spare space, libacl will not make too much difference.

Another option is to patch vim in order to get acl out of configure, as in:
http://git.openembedded.org/meta-openembedded/tree/meta-oe/recipes-support/vim/files
from issue #990. There, there is also another patch about elfutils, but it currently
does not affect openwrt.

I tested with x86.