### PR TITLE
Add git HTTP(s) support (and FTP)

### DIFF
--- a/net/git/Makefile
+++ b/net/git/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=git
 PKG_VERSION:=2.3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/scm/git/
@@ -21,7 +21,7 @@ PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/git
+define Package/git/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Version Control Systems
@@ -31,10 +31,28 @@ define Package/git
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 endef
 
+define Package/git
+$(call Package/git/Default)
+  DEPENDS:=+libopenssl +libpthread +librt
+  TITLE:=The fast version control system
+endef
+
 define Package/git/description
  Git is a free & open source, distributed version control system
  designed to handle everything from small to very large projects
  with speed and efficiency.
+endef
+
+define Package/git-http
+$(call Package/git/Default)
+  DEPENDS:=git +libcurl +ca-certificates
+  TITLE:=Git HTTP commands
+endef
+
+define Package/git-http/description
+$(call Package/git/description)
+
+ This package allows git push/fetch over http(s) and ftp(s)
 endef
 
 MAKE_FLAGS := \
@@ -42,7 +60,6 @@ MAKE_FLAGS := \
 	CFLAGS="$(TARGET_CFLAGS)" \
 	CPPFLAGS="$(TARGET_CPPFLAGS)" \
 	LDFLAGS="$(TARGET_LDFLAGS)" \
-	NO_CURL="YesPlease" \
 	NO_EXPAT="YesPlease" \
 	NO_MKSTEMPS="YesPlease" \
 	NO_GETTEXT="YesPlease" \
@@ -52,7 +69,11 @@ MAKE_FLAGS := \
 	NO_NSEC="YesPlease" \
 	NO_PERL="YesPlease" \
 	NO_PYTHON="YesPlease" \
-	NO_TCLTK="YesPlease"
+	NO_TCLTK="YesPlease" \
+	NO_INSTALL_HARDLINKS="yes" \
+
+CONFIGURE_ARGS += \
+	--without-iconv \
 
 define Build/Configure
 	$(MAKE) -C $(PKG_BUILD_DIR) \
@@ -62,9 +83,32 @@ define Build/Configure
 endef
 
 define Package/git/install
-	$(INSTALL_DIR) $(1)
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/git   $(1)/usr/bin
 	$(RM) $(PKG_INSTALL_DIR)/usr/bin/git-cvsserver
-	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/git-* $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/usr/lib/git-core
+	( cd $(PKG_INSTALL_DIR); $(TAR) \
+		--exclude=usr/lib/git-core/git-http-backend \
+		--exclude=usr/lib/git-core/git-http-fetch \
+		--exclude=usr/lib/git-core/git-remote-ftp \
+		--exclude=usr/lib/git-core/git-remote-ftps \
+		--exclude=usr/lib/git-core/git-remote-http \
+		--exclude=usr/lib/git-core/git-remote-https \
+		-cf - \
+		usr/lib/git-core \
+	) | ( cd $(1); $(TAR) -xf - )
+endef
+
+define Package/git-http/install
+	$(INSTALL_DIR) $(1)/usr/lib/git-core
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/git-core/git-http-backend $(1)/usr/lib/git-core
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/git-core/git-http-fetch $(1)/usr/lib/git-core
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/git-core/git-remote-ftp $(1)/usr/lib/git-core
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/git-core/git-remote-ftps $(1)/usr/lib/git-core
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/git-core/git-remote-http $(1)/usr/lib/git-core
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/git-core/git-remote-https $(1)/usr/lib/git-core
 endef
 
 $(eval $(call BuildPackage,git))
+$(eval $(call BuildPackage,git-http))

--- a/net/git/Makefile
+++ b/net/git/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2014 OpenWrt.org
+# Copyright (C) 2009-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=git
 PKG_VERSION:=2.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/scm/git/
@@ -17,6 +17,7 @@ PKG_MD5SUM:=e5880760d1f43f4f49b3bf94b9046eee
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -57,9 +58,7 @@ define Build/Configure
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		configure
 
-	( cd $(PKG_BUILD_DIR); \
-		./configure --prefix=/usr \
-	);
+	$(call Build/Configure/Default,)
 endef
 
 define Package/git/install

--- a/net/git/patches/100-convert_builtin.patch
+++ b/net/git/patches/100-convert_builtin.patch
@@ -14,17 +14,16 @@
 -PROGRAM_OBJS += show-index.o
 -PROGRAM_OBJS += upload-pack.o
 -PROGRAM_OBJS += remote-testsvn.o
-+PROGRAM_OBJS =
++PROGRAM_OBJS += http-backend.o
  
  # Binary suffix, set to .exe for Windows builds
  X =
-@@ -896,6 +887,12 @@ BUILTIN_OBJS += builtin/verify-commit.o
+@@ -896,6 +887,11 @@ BUILTIN_OBJS += builtin/verify-commit.o
  BUILTIN_OBJS += builtin/verify-pack.o
  BUILTIN_OBJS += builtin/verify-tag.o
  BUILTIN_OBJS += builtin/write-tree.o
 +BUILTIN_OBJS += builtin/daemon.o
 +BUILTIN_OBJS += builtin/fast-import.o
-+BUILTIN_OBJS += builtin/http-backend.o
 +BUILTIN_OBJS += builtin/imap-send.o
 +BUILTIN_OBJS += builtin/shell.o
 +BUILTIN_OBJS += builtin/upload-pack.o
@@ -51,7 +50,7 @@
  git-http-fetch$X: http.o http-walker.o http-fetch.o GIT-LDFLAGS $(GITLIBS)
  	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) $(filter %.o,$^) \
  		$(LIBS) $(CURL_LIBCURL)
-@@ -2254,24 +2247,22 @@ endif
+@@ -2254,10 +2247,11 @@ endif
  	bindir=$$(cd '$(DESTDIR_SQ)$(bindir_SQ)' && pwd) && \
  	execdir=$$(cd '$(DESTDIR_SQ)$(gitexec_instdir_SQ)' && pwd) && \
  	{ test "$$bindir/" = "$$execdir/" || \
@@ -59,34 +58,19 @@
 +	  for p in $(filter $(install_bindir_programs),$(ALL_PROGRAMS)); do \
  		$(RM) "$$execdir/$$p" && \
  		test -z "$(NO_INSTALL_HARDLINKS)$(NO_CROSS_DIRECTORY_HARDLINKS)" && \
--		ln "$$bindir/$$p" "$$execdir/$$p" 2>/dev/null || \
+ 		ln "$$bindir/$$p" "$$execdir/$$p" 2>/dev/null || \
 +		ln -s git "$$execdir/$$p" 2>/dev/null || \
  		cp "$$bindir/$$p" "$$execdir/$$p" || exit; \
  	  done; \
  	} && \
- 	for p in $(filter $(install_bindir_programs),$(BUILT_INS)); do \
- 		$(RM) "$$bindir/$$p" && \
- 		test -z "$(NO_INSTALL_HARDLINKS)" && \
--		ln "$$bindir/git$X" "$$bindir/$$p" 2>/dev/null || \
- 		ln -s "git$X" "$$bindir/$$p" 2>/dev/null || \
- 		cp "$$bindir/git$X" "$$bindir/$$p" || exit; \
- 	done && \
- 	for p in $(BUILT_INS); do \
- 		$(RM) "$$execdir/$$p" && \
- 		test -z "$(NO_INSTALL_HARDLINKS)" && \
--		ln "$$execdir/git$X" "$$execdir/$$p" 2>/dev/null || \
- 		ln -s "git$X" "$$execdir/$$p" 2>/dev/null || \
- 		cp "$$execdir/git$X" "$$execdir/$$p" || exit; \
- 	done && \
 --- a/builtin.h
 +++ b/builtin.h
-@@ -138,5 +138,11 @@ extern int cmd_verify_pack(int argc, con
+@@ -138,5 +138,10 @@ extern int cmd_verify_pack(int argc, con
  extern int cmd_show_ref(int argc, const char **argv, const char *prefix);
  extern int cmd_pack_refs(int argc, const char **argv, const char *prefix);
  extern int cmd_replace(int argc, const char **argv, const char *prefix);
 +extern int cmd_daemon(int argc, char **argv, const char *prefix);
 +extern int cmd_fast_import(int argc, char **argv, const char *prefix);
-+extern int cmd_http_backend(int argc, char **argv, const char *prefix);
 +extern int cmd_imap_send(int argc, char **argv, const char *prefix);
 +extern int cmd_shell(int argc, char **argv, const char *prefix);
 +extern int cmd_upload_pack(int argc, char **argv, const char *prefix);
@@ -100,10 +84,6 @@
 +++ b/builtin/fast-import.c
 @@ -0,0 +1 @@
 +#include "../fast-import.c"
---- /dev/null
-+++ b/builtin/http-backend.c
-@@ -0,0 +1 @@
-+#include "../http-backend.c"
 --- /dev/null
 +++ b/builtin/imap-send.c
 @@ -0,0 +1 @@
@@ -181,11 +161,10 @@
  	{ "describe", cmd_describe, RUN_SETUP },
  	{ "diff", cmd_diff },
  	{ "diff-files", cmd_diff_files, RUN_SETUP | NEED_WORK_TREE },
-@@ -411,6 +412,8 @@ static struct cmd_struct commands[] = {
+@@ -411,6 +412,7 @@ static struct cmd_struct commands[] = {
  	{ "grep", cmd_grep, RUN_SETUP_GENTLY },
  	{ "hash-object", cmd_hash_object },
  	{ "help", cmd_help },
-+	{ "http-backend", cmd_http_backend },
 +	{ "imap-send", cmd_imap_send },
  	{ "index-pack", cmd_index_pack, RUN_SETUP_GENTLY },
  	{ "init", cmd_init_db, NO_SETUP },
@@ -206,17 +185,6 @@
  	{ "var", cmd_var, RUN_SETUP_GENTLY },
  	{ "verify-commit", cmd_verify_commit, RUN_SETUP },
  	{ "verify-pack", cmd_verify_pack },
---- a/http-backend.c
-+++ b/http-backend.c
-@@ -557,7 +557,7 @@ static struct service_cmd {
- 	{"POST", "/git-receive-pack$", service_rpc}
- };
- 
--int main(int argc, char **argv)
-+int cmd_http_backend(int argc, char **argv, const char *prefix)
- {
- 	char *method = getenv("REQUEST_METHOD");
- 	char *dir;
 --- a/imap-send.c
 +++ b/imap-send.c
 @@ -1484,7 +1484,7 @@ static int curl_append_msgs_to_imap(stru

--- a/net/git/patches/300-configure_for_crosscompiling
+++ b/net/git/patches/300-configure_for_crosscompiling
@@ -1,0 +1,32 @@
+--- git-2.3.0/configure.ac.old	2015-03-08 01:19:33.675810197 -0300
++++ git-2.3.0/configure.ac	2015-03-08 01:27:10.688033125 -0300
+@@ -844,7 +844,8 @@
+ 		FILE *f = fopen(".", "r");
+ 		return f && fread(&c, 1, 1, f)]])],
+ 	[ac_cv_fread_reads_directories=no],
+-	[ac_cv_fread_reads_directories=yes])
++	[ac_cv_fread_reads_directories=yes],
++	[ac_cv_fread_reads_directories=no])
+ ])
+ if test $ac_cv_fread_reads_directories = yes; then
+ 	FREAD_READS_DIRECTORIES=UnfortunatelyYes
+@@ -878,7 +879,8 @@
+ 		  if (snprintf(buf, 3, "%s", "12345") != 5
+ 		      || strcmp(buf, "12")) return 1]])],
+ 	[ac_cv_snprintf_returns_bogus=no],
+-	[ac_cv_snprintf_returns_bogus=yes])
++	[ac_cv_snprintf_returns_bogus=yes],
++	[ac_cv_snprintf_returns_bogus=no])
+ ])
+ if test $ac_cv_snprintf_returns_bogus = yes; then
+ 	SNPRINTF_RETURNS_BOGUS=UnfortunatelyYes
+@@ -901,7 +903,8 @@
+ #endif
+ ]),
+ 	[ac_cv_sane_mode_bits=yes],
+-	[ac_cv_sane_mode_bits=no])
++	[ac_cv_sane_mode_bits=no],
++	[ac_cv_sane_mode_bits=yes])
+ ])
+ if test $ac_cv_sane_mode_bits = yes; then
+ 	NEEDS_MODE_TRANSLATION=

--- a/net/git/patches/400-imapsend_without_curl.patch
+++ b/net/git/patches/400-imapsend_without_curl.patch
@@ -1,0 +1,11 @@
+--- git-2.3.0/Makefile.old	2015-03-08 02:14:42.857845824 -0300
++++ git-2.3.0/Makefile	2015-03-08 02:15:06.697451372 -0300
+@@ -1039,7 +1039,7 @@
+ 	endif
+ 	curl_check := $(shell (echo 072200; curl-config --vernum) 2>/dev/null | sort -r | sed -ne 2p)
+ 	ifeq "$(curl_check)" "072200"
+-		USE_CURL_FOR_IMAP_SEND = YesPlease
++#		USE_CURL_FOR_IMAP_SEND = YesPlease
+ 	endif
+ 	ifdef USE_CURL_FOR_IMAP_SEND
+ 		BASIC_CFLAGS += -DUSE_CURL_FOR_IMAP_SEND


### PR DESCRIPTION
This is a two part PR.

The first one, I deal with ./configure problem in order to use OpenWRT
env. This is required if one wants to link git with another library. It might
solve cases like this:

https://dev.openwrt.org/ticket/19017

The second one reverts the http-backend back from builtin commands
and enables curl. http/ftp comnmands went into a new package: git-http.
Maybe this name is not correct as it includes ftp stuff (although only symlink).
Another name suggestion would be git-curl.

Even with this modifications, git pkg size was reduced (as http-backend
was removed) and gained no new runtime deps. git-http depends on libcurl
but SSL requirements is treated nicely at runtime.

The new git-http package is large (even bigger than git) but it is optional.
Maybe git-*http* could be linked together in order to save some kbytes.

git-imap-send was kept independent of curl. If desired its curl features, it
should go into a new subpackage (or even together git-http, or git-curl)

@tripolar , could you check this?

Also, I guess the maintanance info in pkg is not correct.
There is no PKG_MAINTAINER and @tripolar is as git maintainer (the software,
not the package).