### PR TITLE
python: add patches to disable runtime lib dirs

### DIFF
--- a/lang/python/patches/009-do-not-use-dblib_dir-when-cross-compiling.patch
+++ b/lang/python/patches/009-do-not-use-dblib_dir-when-cross-compiling.patch
@@ -1,0 +1,34 @@
+diff --git a/setup.py b/setup.py
+index 7868b7b..10ec68f 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1067,6 +1067,7 @@ class PyBuildExt(build_ext):
+                         if db_setup_debug: print "db lib: ", dblib, "not found"
+ 
+         except db_found:
++            rt_dblib_dir = None if cross_compiling else dblib_dir
+             if db_setup_debug:
+                 print "bsddb using BerkeleyDB lib:", db_ver, dblib
+                 print "bsddb lib dir:", dblib_dir, " inc dir:", db_incdir
+@@ -1081,7 +1082,7 @@ class PyBuildExt(build_ext):
+             exts.append(Extension('_bsddb', ['_bsddb.c'],
+                                   depends = ['bsddb.h'],
+                                   library_dirs=dblib_dir,
+-                                  runtime_library_dirs=dblib_dir,
++                                  runtime_library_dirs=rt_dblib_dir,
+                                   include_dirs=db_incs,
+                                   libraries=dblibs))
+         else:
+@@ -1292,10 +1293,11 @@ class PyBuildExt(build_ext):
+                             break
+                 elif cand == "bdb":
+                     if db_incs is not None:
++                        rt_dblib_dir = None if cross_compiling else dblib_dir
+                         print "building dbm using bdb"
+                         dbmext = Extension('dbm', ['dbmmodule.c'],
+                                            library_dirs=dblib_dir,
+-                                           runtime_library_dirs=dblib_dir,
++                                           runtime_library_dirs=rt_dblib_dir,
+                                            include_dirs=db_incs,
+                                            define_macros=[
+                                                ('HAVE_BERKDB_H', None),

--- a/lang/python/patches/010-do-not-add-rt-lib-dirs-when-cross-compiling.patch
+++ b/lang/python/patches/010-do-not-add-rt-lib-dirs-when-cross-compiling.patch
@@ -1,0 +1,15 @@
+diff --git a/setup.py b/setup.py
+index 7868b7b..544fa7e 100644
+--- a/setup.py
++++ b/setup.py
+@@ -452,8 +452,9 @@ class PyBuildExt(build_ext):
+         # directly since an inconsistently reproducible issue comes up where
+         # the environment variable is not set even though the value were passed
+         # into configure and stored in the Makefile (issue found on OS X 10.3).
++        rt_lib_dirs = [] if cross_compiling else self.compiler.runtime_library_dirs
+         for env_var, arg_name, dir_list in (
+-                ('LDFLAGS', '-R', self.compiler.runtime_library_dirs),
++                ('LDFLAGS', '-R', rt_lib_dirs),
+                 ('LDFLAGS', '-L', self.compiler.library_dirs),
+                 ('CPPFLAGS', '-I', self.compiler.include_dirs)):
+             env_val = sysconfig.get_config_var(env_var)


### PR DESCRIPTION
When cross-compiling, we do not need to add runtime lib dirs.
Also, the cross compilers that are used on OpenWRT do not support
the '-R' option, which causes build failures.

These build failures existed before, but were not noticed,
because it fails only on some setups.
This is because Python's `setup.py` does a lot of voo-doo
automagic that needs handling for some cross-compilation cases.

Fixes issue: https://github.com/openwrt/packages/issues/996

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>