### PR TITLE
python: remove PyPackage rules for python package

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -241,7 +241,7 @@ $(foreach package, $(PYTHON_PACKAGES),  \
 
 $(eval $(call PyPackage,python-base))
 $(eval $(call PyPackage,python-light))
-$(eval $(call PyPackage,python))
+#$(eval $(call PyPackage,python))
 
 $(eval $(call BuildPackage,python-base))
 $(eval $(call BuildPackage,python-light))


### PR DESCRIPTION
Calling `PyPackage` will install some default install rules for
python packages that are not required for the `python` package specifically
are not required.
That will lead to some conflicts with `python-light` because the
`/usr/lib/python2.7/site-packages` folder (+contents) will be
available in both packages.
There is a default `Package/python/install` rule already in place, and that would mean that the python package will get picked up.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>