### PR TITLE
python: revert previous patch and add a filespec

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -209,8 +209,8 @@ define PyPackage/python-base/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON_VERSION).so* $(1)/usr/lib/
 endef
 
-# Dummy rule so that the package gets picked up
-define Package/python/install
+define PyPackage/python/filespec
+-|$(PYTHON_PKG_DIR)
 endef
 
 HOST_CFLAGS+= \
@@ -241,7 +241,7 @@ $(foreach package, $(PYTHON_PACKAGES),  \
 
 $(eval $(call PyPackage,python-base))
 $(eval $(call PyPackage,python-light))
-#$(eval $(call PyPackage,python))
+$(eval $(call PyPackage,python))
 
 $(eval $(call BuildPackage,python-base))
 $(eval $(call BuildPackage,python-light))


### PR DESCRIPTION
Seems removing the PyPackage rule and/or adding dummy install rule
causes some issues inside the build-system, where the libpython2.7.so.1.0
is not seen by packages that depend on python.
Even though that libpython2.7.so.1.0 file is installed properly by `python-base`.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>