### PR TITLE
mwan3: add chnroute support

### DIFF
--- a/net/mwan3-luci/files/usr/lib/lua/luci/model/cbi/mwan/rule.lua
+++ b/net/mwan3-luci/files/usr/lib/lua/luci/model/cbi/mwan/rule.lua
@@ -88,6 +88,12 @@ proto = mwan_rule:option(DummyValue, "proto", translate("Protocol"))
 		return self.map:get(s, "proto") or "all"
 	end
 
+mark = mwan_rule:option(DummyValue, "mark", translate("Mark"))
+	mark.rawhtml = true
+	function mark.cfgvalue(self, s)
+		return self.map:get(s, "mark") or "&#8212;"
+	end
+
 use_policy = mwan_rule:option(DummyValue, "use_policy", translate("Policy assigned"))
 	use_policy.rawhtml = true
 	function use_policy.cfgvalue(self, s)

--- a/net/mwan3-luci/files/usr/lib/lua/luci/model/cbi/mwan/ruleconfig.lua
+++ b/net/mwan3-luci/files/usr/lib/lua/luci/model/cbi/mwan/ruleconfig.lua
@@ -81,6 +81,9 @@ proto = mwan_rule:option(Value, "proto", translate("Protocol"),
 	proto:value("esp")
 	cbiAddProtocol(proto)
 
+mark = mwan_rule:option(Value, "mark", translate("Mark"),
+	translate("May be entered as a single number 0x00 or 0x00/0xff00"))
+
 use_policy = mwan_rule:option(Value, "use_policy", translate("Policy assigned"))
 	cbiAddPolicy(use_policy)
 	use_policy:value("unreachable", translate("unreachable (reject)"))

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -256,13 +256,14 @@ mwan3_set_policies_iptables()
 
 mwan3_set_user_rules_iptables()
 {
-	local proto src_ip src_port dest_ip dest_port use_policy
+	local proto src_ip src_port dest_ip dest_port mark use_policy
 
 	config_get proto $1 proto all
 	config_get src_ip $1 src_ip 0.0.0.0/0
 	config_get src_port $1 src_port 0:65535
 	config_get dest_ip $1 dest_ip 0.0.0.0/0
 	config_get dest_port $1 dest_port 0:65535
+    config_get mark $1 mark 0/0xff00
 	config_get use_policy $1 use_policy
 
 	if [ -n "$use_policy" ]; then
@@ -278,10 +279,11 @@ mwan3_set_user_rules_iptables()
 
 		case $proto in
 			tcp|udp)
-			$IPT -A mwan3_rules -p $proto -s $src_ip -d $dest_ip -m multiport --sports $src_port -m multiport --dports $dest_port -m mark --mark 0/0xff00 -m comment --comment "$1" -j $use_policy &> /dev/null
+			$IPT -A mwan3_rules -p $proto -s $src_ip -d $dest_ip -m multiport --sports $src_port -m multiport --dports $dest_port -m mark --mark $mark -m comment --comment "$1" -j $use_policy &> /dev/null
 			;;
 			*)
-			$IPT -A mwan3_rules -p $proto -s $src_ip -d $dest_ip -m mark --mark 0/0xff00 -m comment --comment "$1" -j $use_policy &> /dev/null
+			$IPT -A mwan3_rules -p $proto -s $src_ip -d $dest_ip -m mark --mark $mark -m comment --comment "$1" -j $use_policy &> /dev/null
+
 			;;
 		esac
 	fi

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -192,6 +192,7 @@ mwan3_set_policy()
 
 			total_weight=$weight
 			$IPT -F mwan3_policy_$policy
+            $IPT -A mwan3_policy_$policy -j MARK --and-mark 0xff00
 			$IPT -A mwan3_policy_$policy -m mark --mark 0x0/0xff00 -m comment --comment "$INTERFACE $weight $weight" -j MARK --set-xmark $(($iface_id*256))/0xff00
 
 			lowest_metric=$metric

--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
@@ -1,0 +1,88 @@
+#!/bin/sh
+
+# to enable this script uncomment the case loop at the bottom
+# to report mwan status on interface hotplug ifup/ifdown events modify the lines in the send_alert function
+
+send_alert()
+{
+# variable "$1" stores the MWAN status information
+# insert your code here to send the contents of "$1"
+echo "$1"
+}
+
+gather_event_info()
+{
+# create event information message
+local EVENT_INFO="Interface [ "$INTERFACE" ($DEVICE) ] on router [ "$(uci get -p /var/state system.@system[0].hostname)" ] has triggered a hotplug [ "$ACTION" ] event on "$(date +"%a %b %d %Y %T %Z")""
+
+# get current interface, policy and rule status
+local CURRENT_STATUS="$(/usr/sbin/mwan3 status)"
+
+# get last 50 MWAN systemlog messages
+local MWAN_LOG="$(echo -e "Last 50 MWAN systemlog entries. Newest entries sorted at the top:\n$(logread | grep mwan3 | tail -n 50 | sed 'x;1!H;$!d;x')")"
+
+# pass event info to send_alert function
+send_alert "$(echo -e "$EVENT_INFO\n\n$CURRENT_STATUS\n\n$MWAN_LOG")"
+}
+
+#case "$ACTION" in
+#	ifup)
+#		gather_event_info
+#	;;
+#
+#	ifdown)
+#		gather_event_info
+#	;;
+#esac
+
+mwan3_set_chnroute_iptables()
+{
+    local chnroutef
+
+    chnroutef="/etc/chinadns_chnroute.txt"
+
+    if ! $IPT -S mwan3_chnroute_target &> /dev/null; then
+        $IPT -N mwan3_chnroute_target
+        $IPT -A mwan3_chnroute_target -j MARK --set-xmark 0xff0000/0xff0000
+        $IPT -A mwan3_chnroute_target -j mwan3_rules
+    fi
+
+    if ! $IPT -S mwan3_chnroute &> /dev/null; then
+        $IPT -N mwan3_chnroute
+        if [ -f "$chnroutef" ]; then
+            for LINE in `cat $chnroutef`
+            do
+                $IPT -A mwan3_chnroute -d $LINE -j mwan3_chnroute_target
+            done
+        fi
+        $IPT -A mwan3_chnroute -j mwan3_rules
+    fi
+    if $IPT -S mwan3_chnroute &> /dev/null; then
+        if ! $IPT -S mwan3_chnroute | grep mwan3_rules &> /dev/null; then
+            $IPT -A mwan3_chnroute -j mwan3_rules
+        fi
+    fi
+    if $IPT -S mwan3_hook &> /dev/null; then
+        if ! $IPT -S mwan3_hook | grep mwan3_chnroute &> /dev/null; then
+            $IPT -I mwan3_hook 4 -m mark --mark 0x0/0xff00 -j mwan3_chnroute
+        fi
+    fi
+    $LOG notice "mwan3 set chnroute iptables"
+}
+
+local IP IPT LOG
+
+IP="/usr/sbin/ip -4"
+IPT="/usr/sbin/iptables -t mangle -w"
+LOG="/usr/bin/logger -t mwan3 -p"
+
+case "$ACTION" in
+    ifup|ifdown)
+    mwan3_set_chnroute_iptables
+    ;;
+esac
+
+
+
+exit 0
+

--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
@@ -41,34 +41,19 @@ mwan3_set_chnroute_iptables()
         $IPT -N mwan3_rules
     fi
 
-    if ! $IPT -S mwan3_chnroute_target &> /dev/null; then
-        $IPT -N mwan3_chnroute_target
-        $IPT -A mwan3_chnroute_target -j MARK --set-xmark 0xfc00/0xff00
-        $IPT -A mwan3_chnroute_target -j mwan3_rules
-    fi
-
     if ! $IPT -S mwan3_chnroute &> /dev/null; then
         $IPT -N mwan3_chnroute
-        $IPT -t mangle -A mwan3_chnroute -m set --match-set chnip dst -j mwan3_chnroute_target
-    fi
-    if $IPT -S mwan3_chnroute &> /dev/null; then
-        if ! $IPT -S mwan3_chnroute | grep mwan3_rules &> /dev/null; then
-            $IPT -A mwan3_chnroute -j mwan3_rules
-        fi
+        $IPT -t mangle -A mwan3_chnroute -m set --match-set chnip dst -j MARK --set-xmark 0xfc/0x00ff
     fi
     if $IPT -S mwan3_hook &> /dev/null; then
         if ! $IPT -S mwan3_hook | grep mwan3_chnroute &> /dev/null; then
             $IPT -I mwan3_hook 4 -m mark --mark 0x0/0xff00 -j mwan3_chnroute
         fi
     fi
-    if ! $IPT -S mwan3_vpnroute_target &> /dev/null; then
-        $IPT -N mwan3_vpnroute_target
-        $IPT -A mwan3_vpnroute_target -j MARK --set-xmark 0xfb00/0xff00
-        $IPT -A mwan3_vpnroute_target -j mwan3_rules
-    fi
+
     if ! $IPT -S mwan3_vpnroute &> /dev/null; then
         $IPT -N mwan3_vpnroute
-        $IPT -t mangle -A mwan3_vpnroute -m set --match-set redir dst -j mwan3_vpnroute_target
+        $IPT -t mangle -A mwan3_vpnroute -m set --match-set redir dst -j MARK --set-xmark 0xfb/0x00ff
     fi
     if $IPT -S mwan3_hook &> /dev/null; then
         if ! $IPT -S mwan3_hook | grep mwan3_vpnroute &> /dev/null; then

--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
@@ -37,9 +37,9 @@ send_alert "$(echo -e "$EVENT_INFO\n\n$CURRENT_STATUS\n\n$MWAN_LOG")"
 
 mwan3_set_chnroute_iptables()
 {
-    local chnroutef
-
-    chnroutef="/etc/chinadns_chnroute.txt"
+    if ! $IPT -S mwan3_rules &> /dev/null; then
+        $IPT -N mwan3_rules
+    fi
 
     if ! $IPT -S mwan3_chnroute_target &> /dev/null; then
         $IPT -N mwan3_chnroute_target
@@ -49,13 +49,7 @@ mwan3_set_chnroute_iptables()
 
     if ! $IPT -S mwan3_chnroute &> /dev/null; then
         $IPT -N mwan3_chnroute
-        if [ -f "$chnroutef" ]; then
-            for LINE in `cat $chnroutef`
-            do
-                $IPT -A mwan3_chnroute -d $LINE -j mwan3_chnroute_target
-            done
-        fi
-        $IPT -A mwan3_chnroute -j mwan3_rules
+        $IPT -t mangle -A mwan3_chnroute -m set --match-set chnip dst -j mwan3_chnroute_target
     fi
     if $IPT -S mwan3_chnroute &> /dev/null; then
         if ! $IPT -S mwan3_chnroute | grep mwan3_rules &> /dev/null; then
@@ -67,6 +61,21 @@ mwan3_set_chnroute_iptables()
             $IPT -I mwan3_hook 4 -m mark --mark 0x0/0xff00 -j mwan3_chnroute
         fi
     fi
+    if ! $IPT -S mwan3_vpnroute_target &> /dev/null; then
+        $IPT -N mwan3_vpnroute_target
+        $IPT -A mwan3_vpnroute_target -j MARK --set-xmark 0xfb00/0xff00
+        $IPT -A mwan3_vpnroute_target -j mwan3_rules
+    fi
+    if ! $IPT -S mwan3_vpnroute &> /dev/null; then
+        $IPT -N mwan3_vpnroute
+        $IPT -t mangle -A mwan3_vpnroute -m set --match-set redir dst -j mwan3_vpnroute_target
+    fi
+    if $IPT -S mwan3_hook &> /dev/null; then
+        if ! $IPT -S mwan3_hook | grep mwan3_vpnroute &> /dev/null; then
+            $IPT -I mwan3_hook 4 -m mark --mark 0x0/0xff00 -j mwan3_vpnroute
+        fi
+    fi
+
     $LOG notice "mwan3 set chnroute iptables"
 }
 

--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
@@ -43,7 +43,7 @@ mwan3_set_chnroute_iptables()
 
     if ! $IPT -S mwan3_chnroute_target &> /dev/null; then
         $IPT -N mwan3_chnroute_target
-        $IPT -A mwan3_chnroute_target -j MARK --set-xmark 0xff0000/0xff0000
+        $IPT -A mwan3_chnroute_target -j MARK --set-xmark 0xfc00/0xff00
         $IPT -A mwan3_chnroute_target -j mwan3_rules
     fi
 


### PR DESCRIPTION
two steps to config chnroute support
first step:
goto mwan3 load balancing page->advanced->Hotplug Script, using the new
16-mwancustom script , copy and paste , click submit.
note:you need to upload /etc/chinadns_chnroute.txt youselft or install
ChinaDNS which include installing the file.
second step:
goto mwan3 load balancing page->config->rules, add a mark type rules
for chnroute balancing Policy. add the default full to vpn Policy.
note:you need to install vpn and configure mwan3
interface/members/policies. suggest using ShadowVPN.
reboot router and enjoy chnroute with mwan3.