### PR TITLE
bogofilter: remove host includes

### DIFF
--- a/mail/bogofilter/Makefile
+++ b/mail/bogofilter/Makefile
@@ -35,7 +35,10 @@ define Package/bogofilter/description
 	Bogofilter is a fast Bayesian spam filter
 endef
 
-CONFIGURE_ARGS += --disable-unicode
+CONFIGURE_ARGS += \
+	--disable-unicode \
+	--with-libdb-prefix=$(STAGING_DIR) \
+	--with-included-gsl
 
 define Package/bogofilter/install
 	$(INSTALL_DIR)  $(1)/etc/ \


### PR DESCRIPTION
- host GSL libs are sometimes found leading to errors
reported by buildbot, replicated locally (Arch Linux)

Error:
configure: GSL_LIBS=-L/usr/lib -lgsl -lgslcblas -lm
leading to
/usr/include/features.h:398:23: fatal error: gnu/stubs.h: No such file or directory

- explicit libdb location to prevent host includes

Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>