### PR TITLE
avahi: avahi-autoipd uses libssp if SSP_SUPPORT is enabled

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -70,7 +70,7 @@ endef
 define Package/avahi-autoipd
   $(call Package/avahi/Default)
   SUBMENU:=IP Addresses and Names
-  DEPENDS:=+libdaemon
+  DEPENDS:=+libdaemon +SSP_SUPPORT:libssp
   TITLE:=IPv4LL network address configuration daemon
 endef
 


### PR DESCRIPTION
Found on an all-y build with SSP enabled:
Package avahi-autoipd is missing dependencies for the following libraries:
libssp.so.0

Adding the missing dependency to address that.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>