### PR TITLE
mmc-utils: don't set -D_FORTIFY_SOURCE in Makefile

### DIFF
--- a/utils/mmc-utils/Makefile
+++ b/utils/mmc-utils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mmc-utils
 PKG_VERSION=2015-03-06-$(PKG_SOURCE_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/linux/kernel/git/cjb/mmc-utils.git

--- a/utils/mmc-utils/patches/001-dont-set-fortify-source-in-makefile.patch
+++ b/utils/mmc-utils/patches/001-dont-set-fortify-source-in-makefile.patch
@@ -1,0 +1,11 @@
+Index: mmc-utils-f4eb241519f8d500ce6068a70d2389be39ac5189/Makefile
+===================================================================
+--- mmc-utils-f4eb241519f8d500ce6068a70d2389be39ac5189.orig/Makefile
++++ mmc-utils-f4eb241519f8d500ce6068a70d2389be39ac5189/Makefile
+@@ -1,5 +1,5 @@
+ CC ?= gcc
+-AM_CFLAGS = -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2
++AM_CFLAGS = -D_FILE_OFFSET_BITS=64
+ CFLAGS ?= -g -O2
+ objects = \
+ 	mmc.o \


### PR DESCRIPTION
Now that security features are set globally, having the
FORTIFY_SOURCE option set in Makefile breaks the build when
CONFIG_PKG_FORTIFY_SOURCE_{1,2} is enabled as well.

arm-openwrt-linux-uclibcgnueabi-gcc  -Wall -Werror -Wuninitialized -Wundef -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2 -Os -pipe -march=armv6k -mtune=mpcore -fno-caller-saves -fhonour-copts -Wno-error=unused-but-set-variable -mfloat-abi=soft -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -Wp,-MMD,./.mmc.o.d,-MT,mmc.o -c mmc.c -o mmc.o
<command-line>:0:0: error: "_FORTIFY_SOURCE" redefined [-Werror]
<command-line>:0:0: note: this is the location of the previous definition
cc1: all warnings being treated as errors
Makefile:35: recipe for target 'mmc.o' failed

Fix this by removing -D_FORTIFY_SOURCE=2 from Makefile.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>