### PR TITLE
tor: depend on libseccomp if KERNEL_SECCOMP is set

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -41,7 +41,7 @@ endef
 define Package/tor
 $(call Package/tor/Default)
   TITLE:=An anonymous Internet communication system
-  DEPENDS:=+libevent2 +libopenssl +libpthread +librt +SSP_SUPPORT:libssp
+  DEPENDS:=+libevent2 +libopenssl +libpthread +librt +SSP_SUPPORT:libssp +KERNEL_SECCOMP:libseccomp
 endef
 
 define Package/tor/description


### PR DESCRIPTION
Signed-off-by: Daniel Golle <daniel@makrotopia.org>