### PR TITLE
python: added configure args for distutils path detection

### DIFF
--- a/lang/python/files/python-package.mk
+++ b/lang/python/files/python-package.mk
@@ -33,6 +33,13 @@ define HostPython
 	)
 endef
 
+# These configure args are needed in detection of path to Python header files
+# using autotools.
+CONFIGURE_ARGS += \
+	_python_sysroot="$(STAGING_DIR)" \
+	_python_prefix="/usr" \
+	_python_exec_prefix="/usr"
+
 PKG_USE_MIPS16:=0
 # This is required in addition to PKG_USE_MIPS16:=0 because otherwise MIPS16
 # flags are inherited from the Python base package (via sysconfig module)


### PR DESCRIPTION
python-package.mk now defines (extends) CONFIGURE_ARGS that are adjusting PREFIX and EXEC_PREFIX in distutils.sysconfig during compilation. These variables are sometimes used by autotools to detect path to Python header files. Adding these variables to python-package.mk fixes compilation of legacy autotools-configured packages that already include python-package.mk and do not overwrite CONFIGURE_ARGS.

Signed-off-by: Jan Čermák <jan.cermak@nic.cz>
Cc: Alexandru Ardelean <ardeleanalex@gmail.com>