### PR TITLE
fwknop: add optional dep on libssp

### DIFF
--- a/net/fwknop/Makefile
+++ b/net/fwknop/Makefile
@@ -42,7 +42,7 @@ define Package/fwknopd
   CATEGORY:=Network
   SUBMENU:=Firewall
   TITLE+= Daemon
-  DEPENDS:=+iptables +libfko +libpcap
+  DEPENDS:=+SSP_SUPPORT:libssp +iptables +libfko +libpcap
 endef
 
 define Package/fwknopd/description
@@ -61,7 +61,7 @@ define Package/fwknop
   CATEGORY:=Network
   SUBMENU:=Firewall
   TITLE+= Client
-  DEPENDS:=+libfko
+  DEPENDS:=+SSP_SUPPORT:libssp +libfko
 endef
 
 define Package/fwknop/description


### PR DESCRIPTION
When SSP is enabled, fwknop links to libssp

Signed-off-by: Rick Farina (Zero_Chaos) <zerochaos@gentoo.org>