### PR TITLE
Remove optional dependency on libssp from packages

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -56,7 +56,7 @@ define Package/libavahi/Default
   SECTION:=libs
   CATEGORY:=Libraries
   PROVIDES:=libavahi
-  DEPENDS:=+libpthread +SSP_SUPPORT:libssp
+  DEPENDS:=+libpthread
 endef
 
 define Package/libavahi/description
@@ -70,7 +70,7 @@ endef
 define Package/avahi-autoipd
   $(call Package/avahi/Default)
   SUBMENU:=IP Addresses and Names
-  DEPENDS:=+libdaemon +SSP_SUPPORT:libssp
+  DEPENDS:=+libdaemon
   TITLE:=IPv4LL network address configuration daemon
 endef
 
@@ -155,7 +155,7 @@ endef
 define Package/avahi-dnsconfd
   $(call Package/avahi/Default)
   SUBMENU:=IP Addresses and Names
-  DEPENDS:=+libavahi +libdaemon +libpthread +SSP_SUPPORT:libssp
+  DEPENDS:=+libavahi +libdaemon +libpthread
   TITLE:=A Unicast DNS server using avahi-daemon
 endef
 

--- a/net/ethtool/Makefile
+++ b/net/ethtool/Makefile
@@ -29,7 +29,6 @@ define Package/ethtool
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Display or change ethernet card settings
-  DEPENDS:=+SSP_SUPPORT:libssp
   URL:=http://www.kernel.org/pub/software/network/ethtool/
 endef
 

--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -29,7 +29,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/openssh/Default
 	SECTION:=net
 	CATEGORY:=Network
-	DEPENDS:=+libopenssl +zlib +SSP_SUPPORT:libssp
+	DEPENDS:=+libopenssl +zlib
 	TITLE:=OpenSSH
 	MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 	URL:=http://www.openssh.com/
@@ -124,7 +124,6 @@ endef
 define Package/openssh-sftp-server
 	$(call Package/openssh/Default)
 	TITLE+= SFTP server
-	DEPENDS:=+SSP_SUPPORT:libssp
 endef
 
 define Package/openssh-sftp-server/description

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -41,7 +41,7 @@ endef
 define Package/tor
 $(call Package/tor/Default)
   TITLE:=An anonymous Internet communication system
-  DEPENDS:=+libevent2 +libopenssl +libpthread +librt +SSP_SUPPORT:libssp
+  DEPENDS:=+libevent2 +libopenssl +libpthread +librt
 endef
 
 define Package/tor/description


### PR DESCRIPTION
They are no longer needed as of trunk r44911.