### PR TITLE
openssh: strip openssh-sftp-server dependencies again

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -124,6 +124,8 @@ endef
 define Package/openssh-sftp-server
 	$(call Package/openssh/Default)
 	TITLE+= SFTP server
+	# Strip dependencies to avoid pulling in OpenSSL etc.
+	DEPENDS:=
 endef
 
 define Package/openssh-sftp-server/description


### PR DESCRIPTION
Reapply 99c6c3d830156ce13f415c698343353c477cd9f9 which was removed by e996c1cc369620272cdb760fcc836289cfe5df39