### PR TITLE
configuration fix: enable ipv6 for avahi-daemon

### DIFF
--- a/libs/avahi/files/avahi-daemon.conf
+++ b/libs/avahi/files/avahi-daemon.conf
@@ -2,7 +2,7 @@
 #host-name=foo
 #domain-name=local
 use-ipv4=yes
-use-ipv6=no
+use-ipv6=yes
 check-response-ttl=no
 use-iff-running=no
 


### PR DESCRIPTION
MDNS service discovery does not work without a link-local address.  IPv4 link
local addressing is an optional feature and requires manual configuration.  With
ipv6 enabled, avahi service discovery will work out of the box.

Signed-off-by: Lawrence D'Anna <larry@elder-gods.org>