### PR TITLE
python3: override machine definition for i386 to build the decimal module

### DIFF
--- a/lang/python3/Makefile
+++ b/lang/python3/Makefile
@@ -111,6 +111,10 @@ MAKE_FLAGS+=\
 	LD="$(TARGET_CC)" \
 	PGEN=pgen3
 
+ifeq ($(ARCH),i386)
+MAKE_FLAGS+=PYTHON_DECIMAL_WITH_MACHINE=ansi32
+endif
+
 EXTRA_CFLAGS+= \
 	-DNDEBUG -fno-inline
 EXTRA_LDFLAGS+= \


### PR DESCRIPTION
Fixes https://github.com/openwrt/packages/issues/1077

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>