### PR TITLE
openconnect: allow specifying os, csd-wrapper and no-cert-check

### DIFF
--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -13,6 +13,7 @@ proto_openconnect_init_config() {
 	proto_config_add_string "token_mode"
 	proto_config_add_string "token_secret"
 	proto_config_add_string "interface"
+	proto_config_add_string "os"
 	no_device=1
 	available=1
 }
@@ -20,7 +21,7 @@ proto_openconnect_init_config() {
 proto_openconnect_setup() {
 	local config="$1"
 
-	json_get_vars server port username serverhash authgroup password interface token_mode token_secret
+	json_get_vars server port username serverhash authgroup password interface token_mode token_secret os
 
 	grep -q tun /proc/modules || insmod tun
 
@@ -68,6 +69,7 @@ proto_openconnect_setup() {
 
 	[ -n "$token_mode" ] && append cmdline "--token-mode=$token_mode"
 	[ -n "$token_secret" ] && append cmdline "--token-secret=$token_secret"
+	[ -n "$os" ] && append cmdline "--os=$os"
 
 	proto_export INTERFACE="$config"
 	logger -t openconnect "executing 'openconnect $cmdline'"

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -14,6 +14,7 @@ proto_openconnect_init_config() {
 	proto_config_add_string "token_secret"
 	proto_config_add_string "interface"
 	proto_config_add_string "os"
+	proto_config_add_string "csd_wrapper"
 	no_device=1
 	available=1
 }
@@ -21,7 +22,7 @@ proto_openconnect_init_config() {
 proto_openconnect_setup() {
 	local config="$1"
 
-	json_get_vars server port username serverhash authgroup password interface token_mode token_secret os
+	json_get_vars server port username serverhash authgroup password interface token_mode token_secret os csd_wrapper
 
 	grep -q tun /proc/modules || insmod tun
 
@@ -70,6 +71,7 @@ proto_openconnect_setup() {
 	[ -n "$token_mode" ] && append cmdline "--token-mode=$token_mode"
 	[ -n "$token_secret" ] && append cmdline "--token-secret=$token_secret"
 	[ -n "$os" ] && append cmdline "--os=$os"
+	[ -n "$csd_wrapper" ] && [ -x "$csd_wrapper" ] && append cmdline "--csd-wrapper=$csd_wrapper"
 
 	proto_export INTERFACE="$config"
 	logger -t openconnect "executing 'openconnect $cmdline'"


### PR DESCRIPTION
Some VPN servers might require the use of a special csd-wrapper script,
using custom self-signed certificates that we don't want to
validate/verify, and might be doing ACLs based on the OS reported by
openconnect.

Signed-off-by: Florian Fainelli <florian@openwrt.org>