### PR TITLE
bind: build fix: remove autoconf AR cruft

### DIFF
--- a/net/bind/patches/002-autoconf-ar-fix.patch
+++ b/net/bind/patches/002-autoconf-ar-fix.patch
@@ -1,0 +1,29 @@
+--- a/configure.in
++++ b/configure.in
+@@ -93,26 +93,11 @@ esac
+ #
+ AC_CONFIG_FILES([make/rules make/includes])
+ 
+-AC_PATH_PROG(AR, ar)
+-ARFLAGS="cruv"
+-AC_SUBST(AR)
+-AC_SUBST(ARFLAGS)
+-
+ # The POSIX ln(1) program.  Non-POSIX systems may substitute
+ # "copy" or something.
+ LN=ln
+ AC_SUBST(LN)
+ 
+-case "$AR" in
+-	"")
+-		AC_MSG_ERROR([
+-ar program not found.  Please fix your PATH to include the directory in
+-which ar resides, or set AR in the environment with the full path to ar.
+-])
+-
+-		;;
+-esac
+-
+ #
+ # Etags.
+ #


### PR DESCRIPTION
This patch removes some autoconf goo which is causing bind to use the host's ar
instead the ar from the toolchain.  If they're both elf platforms this is fine,
but it's no good if host is darwin.

Signed-off-by: Lawrence D'Anna <larry@elder-gods.org>