### PR TITLE
hfsprogs: initial import

### DIFF
--- a/utils/hfsprogs/Makefile
+++ b/utils/hfsprogs/Makefile
@@ -1,0 +1,81 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=hfsprogs
+PKG_VERSION:=332.25
+PKG_RELEASE:=1
+
+PKG_LICENSE:=GPL-3.0+
+PKG_LICENSE_FILES:=COPYING
+
+PKG_MAINTAINER:=Florian Fainelli <florian@openwrt.org>
+
+PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
+PKG_SOURCE_URL:=http://archive.ubuntu.com/ubuntu/pool/universe/h/$(PKG_NAME)
+PKG_BUILD_DIR:=$(BUILD_DIR)/diskdev_cmds-$(PKG_VERSION)
+PKG_MD5SUM:=261c3de5ec0dcf5244e3f60d79c1d6f1
+PKG_LICENSE:=APSL 2.0
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/hfsprogs/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Filesystem
+  DEPENDS:=+libopenssl
+endef
+
+define Package/hfsfsck
+  $(call Package/hfsprogs/Default)
+  TITLE:=fsck (fsck.hfs) utility from hfsprogs
+endef
+
+define Package/mkhfs
+  $(call Package/hfsprogs/Default)
+  TITLE:=mkfs (mkfs.hfs) utility from hfsprogs
+endef
+
+define Package/hfsfsck/description
+	Utilities to create and check HFS/HFS+ filesystems.
+	(fsck.hfs and fsck.hfsplus for checking integrity of HFS/HFS+ volumes)
+endef
+
+define Package/mkhfs/description
+	Utilities to create and check HFS/HFS+ filesystems.
+	(mkfs.hfs and mkfs.hfsplus for creating HFS/HFS+ volumes)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		-f Makefile.lnx \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS+="$(TARGET_CFLAGS) -I$(PKG_BUILD_DIR)/include -DDEBUG_BUILD=0 -D_FILE_OFFSET_BITS=64 -D LINUX=1 -D BSD=1" \
+		all
+endef
+
+define Package/hfsfsck/install
+	$(INSTALL_DIR) $(1)/lib/functions/fsck
+	$(INSTALL_DATA) ./files/hfsfsck.sh $(1)/lib/functions/fsck/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/fsck_hfs.tproj/fsck_hfs	$(1)/usr/sbin/fsck.hfsplus
+	(cd $(1)/usr/sbin; ln -sf fsck.hfsplus fsck.hfs;)
+endef
+
+define Package/mkhfs/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/newfs_hfs.tproj/newfs_hfs $(1)/usr/sbin/mkfs.hfsplus
+	(cd $(1)/usr/sbin; ln -sf mkfs.hfsplus mkfs.hfs;)
+endef
+
+$(eval $(call BuildPackage,hfsfsck))
+$(eval $(call BuildPackage,mkhfs))

--- a/utils/hfsprogs/files/hfsfsck.sh
+++ b/utils/hfsprogs/files/hfsfsck.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Copyright 2015 OpenWrt.org
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+fsck_hfsfsck() {
+	hfsfsck "$device" 2>&1 | logger -t "fstab: hfsfsck ($device)"
+	local status="$?"
+	case "$status" in
+		0) ;; #success
+		4) reboot;;
+		8) echo "hfsfsck ($device): Warning! Uncorrected errors."| logger -t fstab
+			return 1
+			;;
+		*) echo "hfsfsck ($device): Error $status. Check not complete."| logger -t fstab;;
+	esac
+	return 0
+}
+
+fsck_hfs() {
+	fsck_hfsfsck "$@"
+}
+
+fsck_hfsplus() {
+	fsck_hfsfsck "$@"
+}
+
+append libmount_known_fsck "hfs"
+append libmount_known_fsck "hfsplus"

--- a/utils/hfsprogs/patches/0001-Create-short-Makefiles-for-Debian.patch
+++ b/utils/hfsprogs/patches/0001-Create-short-Makefiles-for-Debian.patch
@@ -1,0 +1,93 @@
+From: =?UTF-8?q?Rog=C3=A9rio=20Brito?= <rbrito@ime.usp.br>
+Date: Thu, 24 Oct 2013 01:11:21 -0200
+Subject: Create short Makefiles for Debian
+
+Create short Makefiles for compiling just the necessary parts for a
+Debian-based (and possibly other distributions) HFS+ filesystem
+utilities.
+---
+ Makefile.lnx                       |  8 ++++++++
+ fsck_hfs.tproj/Makefile.lnx        | 16 ++++++++++++++++
+ fsck_hfs.tproj/dfalib/Makefile.lnx | 15 +++++++++++++++
+ newfs_hfs.tproj/Makefile.lnx       | 12 ++++++++++++
+ 4 files changed, 51 insertions(+)
+ create mode 100644 Makefile.lnx
+ create mode 100644 fsck_hfs.tproj/Makefile.lnx
+ create mode 100644 fsck_hfs.tproj/dfalib/Makefile.lnx
+ create mode 100644 newfs_hfs.tproj/Makefile.lnx
+
+diff --git a/Makefile.lnx b/Makefile.lnx
+new file mode 100644
+index 0000000..687d1e7
+--- /dev/null
++++ b/Makefile.lnx
+@@ -0,0 +1,8 @@
++CC := gcc
++CFLAGS += -I$(PWD)/include -DDEBUG_BUILD=0 -D_FILE_OFFSET_BITS=64 -D LINUX=1 -D BSD=1
++SUBDIRS := newfs_hfs.tproj fsck_hfs.tproj
++
++all clean:
++	for d in $(SUBDIRS); do $(MAKE) -C $$d -f Makefile.lnx $@; done
++
++export CC CFLAGS
+diff --git a/fsck_hfs.tproj/Makefile.lnx b/fsck_hfs.tproj/Makefile.lnx
+new file mode 100644
+index 0000000..977d7e8
+--- /dev/null
++++ b/fsck_hfs.tproj/Makefile.lnx
+@@ -0,0 +1,16 @@
++CFILES = fsck_hfs.c strings.c utilities.c cache.c fsck_debug.c
++OFILES = $(CFILES:.c=.o)
++
++all: fsck_hfs
++
++fsck_hfs: $(OFILES) dfalib/libdfa.a
++	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OFILES) dfalib/libdfa.a
++
++dfalib/libdfa.a: FORCE
++	$(MAKE) -C dfalib -f Makefile.lnx CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" libdfa.a
++
++clean:
++	$(RM) fsck_hfs $(OFILES)
++	$(MAKE) -C dfalib -f Makefile.lnx clean
++
++.PHONY : FORCE clean
+diff --git a/fsck_hfs.tproj/dfalib/Makefile.lnx b/fsck_hfs.tproj/dfalib/Makefile.lnx
+new file mode 100644
+index 0000000..8c07196
+--- /dev/null
++++ b/fsck_hfs.tproj/dfalib/Makefile.lnx
+@@ -0,0 +1,15 @@
++CFILES = hfs_endian.c BlockCache.c\
++         BTree.c BTreeAllocate.c BTreeMiscOps.c \
++         BTreeNodeOps.c BTreeScanner.c BTreeTreeOps.c\
++         CatalogCheck.c HardLinkCheck.c\
++         SBTree.c SControl.c SVerify1.c SVerify2.c\
++         SRepair.c SRebuildCatalogBTree.c\
++         SUtils.c SKeyCompare.c SDevice.c SExtents.c SAllocate.c\
++         SCatalog.c SStubs.c VolumeBitmapCheck.c
++OFILES = $(CFILES:.c=.o)
++
++libdfa.a: $(OFILES)
++	ar rc $@ $?
++
++clean:
++	$(RM) $(OFILES) libdfa.a
+diff --git a/newfs_hfs.tproj/Makefile.lnx b/newfs_hfs.tproj/Makefile.lnx
+new file mode 100644
+index 0000000..58e6700
+--- /dev/null
++++ b/newfs_hfs.tproj/Makefile.lnx
+@@ -0,0 +1,12 @@
++CFILES = hfs_endian.c makehfs.c newfs_hfs.c
++OFILES = $(CFILES:.c=.o)
++
++all: newfs_hfs
++
++newfs_hfs: $(OFILES)
++	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OFILES) -lcrypto
++
++clean:
++	$(RM) newfs_hfs $(OFILES)
++
++.PHONY : FORCE clean

--- a/utils/hfsprogs/patches/0002-Add-exclude-Darwin-specific-code.patch
+++ b/utils/hfsprogs/patches/0002-Add-exclude-Darwin-specific-code.patch
@@ -1,0 +1,1407 @@
+From: =?UTF-8?q?Rog=C3=A9rio=20Brito?= <rbrito@ime.usp.br>
+Date: Thu, 24 Oct 2013 01:11:21 -0200
+Subject: Add/exclude Darwin-specific code
+
+Modify some of the files so that they can be compiled without the
+Apple owned frameworks in a Debian system (and possibly others).
+---
+ fsck_hfs.tproj/cache.c              |   4 ++
+ fsck_hfs.tproj/dfalib/BTree.c       |   2 +
+ fsck_hfs.tproj/dfalib/BlockCache.c  |   3 +
+ fsck_hfs.tproj/dfalib/SBTree.c      |   2 +
+ fsck_hfs.tproj/dfalib/SDevice.c     |  92 ++++++++++++++++++++---------
+ fsck_hfs.tproj/dfalib/SKeyCompare.c |   2 +
+ fsck_hfs.tproj/dfalib/SRepair.c     |   2 +
+ fsck_hfs.tproj/dfalib/SRuntime.h    |   7 ++-
+ fsck_hfs.tproj/dfalib/SUtils.c      |   5 +-
+ fsck_hfs.tproj/dfalib/SVerify2.c    |   7 +++
+ fsck_hfs.tproj/dfalib/Scavenger.h   |  11 +++-
+ fsck_hfs.tproj/dfalib/hfs_endian.c  |   4 ++
+ fsck_hfs.tproj/dfalib/hfs_endian.h  |   7 ++-
+ fsck_hfs.tproj/fsck_hfs.c           |  61 +++++++++++++++----
+ fsck_hfs.tproj/utilities.c          |   8 ++-
+ include/missing.h                   | 115 ++++++++++++++++++++++++++++++++++++
+ newfs_hfs.tproj/hfs_endian.c        |   5 ++
+ newfs_hfs.tproj/hfs_endian.h        |   5 ++
+ newfs_hfs.tproj/makehfs.c           |  72 ++++++++++++++++------
+ newfs_hfs.tproj/newfs_hfs.c         |  74 ++++++++++++++++++++---
+ newfs_hfs.tproj/newfs_hfs.h         |  26 ++++----
+ 21 files changed, 429 insertions(+), 85 deletions(-)
+ create mode 100644 include/missing.h
+
+diff --git a/fsck_hfs.tproj/cache.c b/fsck_hfs.tproj/cache.c
+index be46195..527088a 100644
+--- a/fsck_hfs.tproj/cache.c
++++ b/fsck_hfs.tproj/cache.c
+@@ -26,7 +26,11 @@
+ #include <stdlib.h>
+ #include <sys/mman.h>
+ #include <sys/stat.h>
++#if LINUX
++#include "missing.h"
++#else
+ #include <sys/types.h>
++#endif /* __LINUX__ */
+ #include <sys/uio.h>
+ #include <unistd.h>
+ #include <string.h>
+diff --git a/fsck_hfs.tproj/dfalib/BTree.c b/fsck_hfs.tproj/dfalib/BTree.c
+index edd8301..7ad9fe0 100644
+--- a/fsck_hfs.tproj/dfalib/BTree.c
++++ b/fsck_hfs.tproj/dfalib/BTree.c
+@@ -1705,7 +1705,9 @@ OSStatus	BTGetInformation	(SFCB					*filePtr,
+ 								 UInt16					 version,
+ 								 BTreeInfoRec			*info )
+ {
++#if !LINUX
+ #pragma unused (version)
++#endif
+ 
+ 	BTreeControlBlockPtr	btreePtr;
+ 
+diff --git a/fsck_hfs.tproj/dfalib/BlockCache.c b/fsck_hfs.tproj/dfalib/BlockCache.c
+index 1bb952f..e3a28a2 100644
+--- a/fsck_hfs.tproj/dfalib/BlockCache.c
++++ b/fsck_hfs.tproj/dfalib/BlockCache.c
+@@ -20,6 +20,9 @@
+  * @APPLE_LICENSE_HEADER_END@
+  */
+ 
++#if LINUX
++#include "missing.h"
++#endif
+ #include "SRuntime.h"
+ #include "Scavenger.h"
+ #include "../cache.h"
+diff --git a/fsck_hfs.tproj/dfalib/SBTree.c b/fsck_hfs.tproj/dfalib/SBTree.c
+index 2fbcd1d..cd81b13 100644
+--- a/fsck_hfs.tproj/dfalib/SBTree.c
++++ b/fsck_hfs.tproj/dfalib/SBTree.c
+@@ -322,7 +322,9 @@ ErrorExit:
+ OSStatus
+ SetEndOfForkProc ( SFCB *filePtr, FSSize minEOF, FSSize maxEOF )
+ {
++#if !LINUX
+ #pragma unused (maxEOF)
++#endif
+ 
+ 	OSStatus	result;
+ 	UInt32		actualSectorsAdded;
+diff --git a/fsck_hfs.tproj/dfalib/SDevice.c b/fsck_hfs.tproj/dfalib/SDevice.c
+index bf6f61c..9a46023 100644
+--- a/fsck_hfs.tproj/dfalib/SDevice.c
++++ b/fsck_hfs.tproj/dfalib/SDevice.c
+@@ -2,7 +2,7 @@
+  * Copyright (c) 1999 Apple Computer, Inc. All rights reserved.
+  *
+  * @APPLE_LICENSE_HEADER_START@
+- * 
++ *
+  * "Portions Copyright (c) 1999 Apple Computer, Inc.  All Rights
+  * Reserved.  This file contains Original Code and/or Modifications of
+  * Original Code as defined in and that are subject to the Apple Public
+@@ -10,7 +10,7 @@
+  * except in compliance with the License.  Please obtain a copy of the
+  * License at http://www.apple.com/publicsource and read it before using
+  * this file.
+- * 
++ *
+  * The Original Code and all software distributed under the License are
+  * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+  * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+@@ -18,7 +18,7 @@
+  * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT.  Please see the
+  * License for the specific language governing rights and limitations
+  * under the License."
+- * 
++ *
+  * @APPLE_LICENSE_HEADER_END@
+  */
+ #include "SRuntime.h"
+@@ -28,33 +28,71 @@
+ #include <unistd.h>
+ #include <errno.h>
+ #include <sys/ioctl.h>
+-
++#if LINUX
++#include <fcntl.h>
++#include <sys/stat.h>
++#else
+ #include <IOKit/storage/IOMediaBSDClient.h>
+-
++#endif /* LINUX */
+ #else
+-
+ #include <Files.h>
+ #include <Device.h>
+ #include <Disks.h>
+ 
+ #endif
+ 
+-
+ OSErr GetDeviceSize(int driveRefNum, UInt64 *numBlocks, UInt32 *blockSize)
+ {
+ #if BSD
+ 	UInt64 devBlockCount = 0;
+ 	int devBlockSize = 0;
++#if LINUX
++	struct stat stbuf;
++
++	devBlockSize = 512;
+ 
++#ifndef BLKGETSIZE
++#define BLKGETSIZE              _IO(0x12,96)
++#endif
++#ifndef BLKGETSIZE64
++#define BLKGETSIZE64            _IOR(0x12,114,size_t)
++#endif
++	if (fstat(driveRefNum, &stbuf) < 0){
++		printf("Error: %s\n", strerror(errno));
++		return(-1);
++	}
++
++        if (S_ISREG(stbuf.st_mode)) {
++                devBlockCount = stbuf.st_size / 512;
++        }
++        else if (S_ISBLK(stbuf.st_mode)) {
++                unsigned long size;
++                u_int64_t size64;
++                if (!ioctl(driveRefNum, BLKGETSIZE64, &size64))
++                        devBlockCount = size64 / 512;
++                else if (!ioctl(driveRefNum, BLKGETSIZE, &size))
++                        devBlockCount = size;
++                else{
++                        printf("Error: %s\n", strerror(errno));
++			return(-1);
++		}
++
++        }
++        else{
++                printf("Device is not a block device");
++		return(-1);
++	}
++#elif BSD
+ 	if (ioctl(driveRefNum, DKIOCGETBLOCKCOUNT, &devBlockCount) < 0) {
+ 		printf("ioctl(DKIOCGETBLOCKCOUNT) for fd %d: %s\n", driveRefNum, strerror(errno));
+ 		return (-1);
+ 	}
+-	
++
+ 	if (ioctl(driveRefNum, DKIOCGETBLOCKSIZE, &devBlockSize) < 0) {
+ 		printf("ioctl(DKIOCGETBLOCKSIZE) for fd %d: %s\n", driveRefNum, strerror(errno));
+ 		return (-1);
+ 	}
++#endif /* BSD */
+ 
+ 	if (devBlockSize != 512) {
+ 		*numBlocks = (devBlockCount * (UInt64)devBlockSize) / 512;
+@@ -70,24 +108,24 @@ OSErr GetDeviceSize(int driveRefNum, UInt64 *numBlocks, UInt32 *blockSize)
+ 	{
+ 		/* return format list status code */
+ 		kFmtLstCode = 6,
+-		
++
+ 		/* reference number of .SONY driver */
+ 		kSonyRefNum = 0xfffb,
+-		
++
+ 		/* values returned by DriveStatus in DrvSts.twoSideFmt */
+ 		kSingleSided = 0,
+ 		kDoubleSided = -1,
+ 		kSingleSidedSize = 800,		/* 400K */
+ 		kDoubleSidedSize = 1600,	/* 800K */
+-		
++
+ 		/* values in DrvQEl.qType */
+ 		kWordDrvSiz = 0,
+ 		kLongDrvSiz = 1,
+-		
++
+ 		/* more than enough formatListRecords */
+ 		kMaxFormatListRecs = 16
+ 	};
+-	
++
+ 	ParamBlockRec	pb;
+ 	FormatListRec	formatListRecords[kMaxFormatListRecs];
+ 	DrvSts			status;
+@@ -95,22 +133,22 @@ OSErr GetDeviceSize(int driveRefNum, UInt64 *numBlocks, UInt32 *blockSize)
+ 	OSErr			result;
+ 	unsigned long	blocks			= 0;
+ 
+-	
++
+ 	/* Attempt to get the drive's format list. */
+ 	/* (see the Technical Note "What Your Sony Drives For You") */
+-	
++
+ 	pb.cntrlParam.ioVRefNum = driveQElementPtr->dQDrive;
+ 	pb.cntrlParam.ioCRefNum = driveQElementPtr->dQRefNum;
+ 	pb.cntrlParam.csCode = kFmtLstCode;
+ 	pb.cntrlParam.csParam[0] = kMaxFormatListRecs;
+ 	*(long *)&pb.cntrlParam.csParam[1] = (long)&formatListRecords[0];
+-	
++
+ 	result = PBStatusSync(&pb);
+-	
++
+ 	if ( result == noErr )
+ 	{
+ 		/* The drive supports ReturnFormatList status call. */
+-		
++
+ 		/* Get the current disk's size. */
+ 		for( formatListRecIndex = 0;
+ 			 formatListRecIndex < pb.cntrlParam.csParam[0];
+@@ -131,7 +169,7 @@ OSErr GetDeviceSize(int driveRefNum, UInt64 *numBlocks, UInt32 *blockSize)
+ 	else if ( driveQElementPtr->dQRefNum == (short)kSonyRefNum )
+ 	{
+ 		/* The drive is a non-SuperDrive floppy which only supports 400K and 800K disks */
+-		
++
+ 		result = DriveStatus(driveQElementPtr->dQDrive, &status);
+ 		if ( result == noErr )
+ 		{
+@@ -140,11 +178,11 @@ OSErr GetDeviceSize(int driveRefNum, UInt64 *numBlocks, UInt32 *blockSize)
+ 				case kSingleSided:
+ 					blocks = kSingleSidedSize;
+ 					break;
+-					
++
+ 				case kDoubleSided:
+ 					blocks = kDoubleSidedSize;
+ 					break;
+-					
++
+ 				default:		//	This should never happen
+ 					result = paramErr;
+ 					break;
+@@ -155,20 +193,20 @@ OSErr GetDeviceSize(int driveRefNum, UInt64 *numBlocks, UInt32 *blockSize)
+ 	{
+ 		/* The drive is not a floppy and it doesn't support ReturnFormatList */
+ 		/* so use the dQDrvSz field(s) */
+-		
++
+ 		result = noErr;	/* reset result */
+-		
++
+ 		switch ( driveQElementPtr->qType )
+ 		{
+ 			case kWordDrvSiz:
+ 				blocks = driveQElementPtr->dQDrvSz;
+ 				break;
+-				
++
+ 			case kLongDrvSiz:
+ 				blocks = ((unsigned long)driveQElementPtr->dQDrvSz2 << 16) +
+ 						 driveQElementPtr->dQDrvSz;
+ 				break;
+-				
++
+ 			default:		//	This should never happen
+ 				result = paramErr;
+ 				break;
+@@ -177,7 +215,7 @@ OSErr GetDeviceSize(int driveRefNum, UInt64 *numBlocks, UInt32 *blockSize)
+ 
+ 	*numBlocks = blocks;
+ 	*blockSize = 512;
+-	
++
+ 	return( result );
+ #endif
+ }
+@@ -188,7 +226,7 @@ OSErr DeviceRead(int device, int drive, void* buffer, SInt64 offset, UInt32 reqB
+ #if BSD
+ 	off_t seek_off;
+ 	ssize_t	nbytes;
+-	
++
+ 	*actBytes = 0;
+ 
+ 	seek_off = lseek(device, offset, SEEK_SET);
+diff --git a/fsck_hfs.tproj/dfalib/SKeyCompare.c b/fsck_hfs.tproj/dfalib/SKeyCompare.c
+index 46e145f..18d99c5 100644
+--- a/fsck_hfs.tproj/dfalib/SKeyCompare.c
++++ b/fsck_hfs.tproj/dfalib/SKeyCompare.c
+@@ -454,7 +454,9 @@ SInt32 CompareExtentKeysPlus( const HFSPlusExtentKey *searchKey, const HFSPlusEx
+  * The name portion of the key is compared using a 16-bit binary comparison. 
+  * This is called from the b-tree code.
+  */
++#if !LINUX
+ __private_extern__
++#endif
+ SInt32
+ CompareAttributeKeys(const AttributeKey *searchKey, const AttributeKey *trialKey)
+ {
+diff --git a/fsck_hfs.tproj/dfalib/SRepair.c b/fsck_hfs.tproj/dfalib/SRepair.c
+index 01c1a10..8eb759c 100644
+--- a/fsck_hfs.tproj/dfalib/SRepair.c
++++ b/fsck_hfs.tproj/dfalib/SRepair.c
+@@ -1617,7 +1617,9 @@ Output:
+ 
+ static	OSErr	FixWrapperExtents( SGlobPtr GPtr, RepairOrderPtr p )
+ {
++#if !LINUX
+ #pragma unused (p)
++#endif
+ 
+ 	OSErr						err;
+ 	HFSMasterDirectoryBlock		*mdb;
+diff --git a/fsck_hfs.tproj/dfalib/SRuntime.h b/fsck_hfs.tproj/dfalib/SRuntime.h
+index 646917b..770e3ef 100644
+--- a/fsck_hfs.tproj/dfalib/SRuntime.h
++++ b/fsck_hfs.tproj/dfalib/SRuntime.h
+@@ -27,8 +27,11 @@
+ #define __SRUNTIME__
+ 
+ #if BSD
+-
++#if LINUX
++#include "missing.h"
++#else
+ #include <sys/types.h>
++#endif
+ #include <stdlib.h>
+ #include <string.h>
+ #include <stdio.h>
+@@ -91,10 +94,12 @@ typedef const unsigned char *	ConstStr255Param;
+ 
+ typedef u_int32_t	HFSCatalogNodeID;
+ 
++#if !LINUX
+ enum {
+ 	false		= 0,
+ 	true		= 1
+ };
++#endif
+ 
+ /* OS error codes */
+ enum {
+diff --git a/fsck_hfs.tproj/dfalib/SUtils.c b/fsck_hfs.tproj/dfalib/SUtils.c
+index 72035f0..6e9253e 100644
+--- a/fsck_hfs.tproj/dfalib/SUtils.c
++++ b/fsck_hfs.tproj/dfalib/SUtils.c
+@@ -380,7 +380,8 @@ void	InvalidateCalculatedVolumeBitMap( SGlobPtr GPtr )
+ //				GPtr->realVCB			Real in-memory vcb
+ //------------------------------------------------------------------------------
+ 
+-#if !BSD	
++#if BSD
++#if !LINUX
+ OSErr GetVolumeFeatures( SGlobPtr GPtr )
+ {
+ 	OSErr					err;
+@@ -418,7 +419,7 @@ OSErr GetVolumeFeatures( SGlobPtr GPtr )
+ 	return( noErr );
+ }
+ #endif
+-
++#endif
+ 
+ 
+ /*-------------------------------------------------------------------------------
+diff --git a/fsck_hfs.tproj/dfalib/SVerify2.c b/fsck_hfs.tproj/dfalib/SVerify2.c
+index 6a47935..c68f3d8 100644
+--- a/fsck_hfs.tproj/dfalib/SVerify2.c
++++ b/fsck_hfs.tproj/dfalib/SVerify2.c
+@@ -32,7 +32,9 @@
+ */
+ 
+ #include <sys/ioctl.h>
++#if !LINUX
+ #include <sys/disk.h>
++#endif
+ 
+ #include "BTree.h"
+ #include "BTreePrivate.h"
+@@ -1354,8 +1356,13 @@ OSErr CompareVolumeHeader( SGlobPtr GPtr, HFSPlusVolumeHeader *volumeHeader )
+ 	 * clump size for read-only media is irrelevant we skip the clump size 
+ 	 * check to avoid non useful warnings. 
+ 	 */
++#if LINUX
++	// FIXME
++	isWriteable = 1;
++#else
+ 	isWriteable = 0;
+ 	ioctl( GPtr->DrvNum, DKIOCISWRITABLE, &isWriteable );
++#endif
+ 	if ( isWriteable != 0 && 
+ 		 volumeHeader->catalogFile.clumpSize != vcb->vcbCatalogFile->fcbClumpSize ) {
+ 		PrintError(GPtr, E_InvalidClumpSize, 0);
+diff --git a/fsck_hfs.tproj/dfalib/Scavenger.h b/fsck_hfs.tproj/dfalib/Scavenger.h
+index cf53970..edb3a80 100644
+--- a/fsck_hfs.tproj/dfalib/Scavenger.h
++++ b/fsck_hfs.tproj/dfalib/Scavenger.h
+@@ -37,11 +37,16 @@
+ #include "../fsck_debug.h"
+ 
+ #include <assert.h>
++#if LINUX
++#define XATTR_MAXNAMELEN 127
++#include <limits.h>
++#else
+ #include <sys/xattr.h>
+ #include <sys/acl.h>
+ #include <sys/kauth.h>
+-#include <sys/errno.h>
+ #include <sys/syslimits.h>
++#endif
++#include <sys/errno.h>
+ 
+ #ifdef __cplusplus
+ extern	"C" {
+@@ -1465,4 +1470,8 @@ extern int 	AllocateContigBitmapBits (SVCB *vcb, UInt32 numBlocks, UInt32 *actua
+ };
+ #endif
+ 
++/* #if LINUX
++#undef XATTR_MAXNAMELEN
++#endif */
++
+ #endif /* __SCAVENGER__ */
+diff --git a/fsck_hfs.tproj/dfalib/hfs_endian.c b/fsck_hfs.tproj/dfalib/hfs_endian.c
+index 7fa5385..69500c1 100755
+--- a/fsck_hfs.tproj/dfalib/hfs_endian.c
++++ b/fsck_hfs.tproj/dfalib/hfs_endian.c
+@@ -31,7 +31,11 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ 
++#if LINUX
++#include "missing.h"
++#else
+ #include <architecture/byte_order.h>
++#endif
+ #include <hfs/hfs_format.h>
+ 
+ #include "Scavenger.h"
+diff --git a/fsck_hfs.tproj/dfalib/hfs_endian.h b/fsck_hfs.tproj/dfalib/hfs_endian.h
+index 52d0c3a..0763d9d 100755
+--- a/fsck_hfs.tproj/dfalib/hfs_endian.h
++++ b/fsck_hfs.tproj/dfalib/hfs_endian.h
+@@ -27,9 +27,14 @@
+  *
+  * This file prototypes endian swapping routines for the HFS/HFS Plus
+  * volume format.
+- */
++*/
+ #include <hfs/hfs_format.h>
++#if LINUX
++#include <endian.h>
++#include <byteswap.h>
++#else
+ #include <architecture/byte_order.h>
++#endif
+ #include "SRuntime.h"
+ 
+ /*********************/
+diff --git a/fsck_hfs.tproj/fsck_hfs.c b/fsck_hfs.tproj/fsck_hfs.c
+index 90532fd..f1a18bd 100644
+--- a/fsck_hfs.tproj/fsck_hfs.c
++++ b/fsck_hfs.tproj/fsck_hfs.c
+@@ -24,10 +24,14 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <sys/param.h>
++#if !LINUX
+ #include <sys/ucred.h>
++#endif
+ #include <sys/mount.h>
+ #include <sys/ioctl.h>
++#if !LINUX
+ #include <sys/disk.h>
++#endif
+ 
+ #include <hfs/hfs_mount.h>
+ 
+@@ -195,8 +199,12 @@ main(argc, argv)
+ 	if (guiControl)
+ 		debug = 0; /* debugging is for command line only */
+ 
++#if LINUX
++// FIXME
++#else
+ 	if (signal(SIGINT, SIG_IGN) != SIG_IGN)
+ 		(void)signal(SIGINT, catch);
++#endif
+ 
+ 	if (argc < 1) {
+ 		(void) fprintf(stderr, "%s: missing special-device\n", progname);
+@@ -218,7 +226,9 @@ checkfilesys(char * filesys)
+ 	int chkLev, repLev, logLev;
+ 	int blockDevice_fd, canWrite;
+ 	char *unraw, *mntonname;
++#if !LINUX
+ 	struct statfs *fsinfo;
++#endif
+ 	int fs_fd=-1;  // fd to the root-dir of the fs we're checking (only w/lfag == 1)
+ 
+ 	flags = 0;
+@@ -227,7 +237,9 @@ checkfilesys(char * filesys)
+ 	canWrite = 0;
+ 	unraw = NULL;
+ 	mntonname = NULL;
+-
++#if LINUX
++	// FIXME
++#else
+ 	if (lflag) {
+ 		result = getmntinfo(&fsinfo, MNT_NOWAIT);
+ 
+@@ -257,10 +269,10 @@ checkfilesys(char * filesys)
+ 		    }
+ 		}
+ 	}
+-
++#endif
+ 	if (debug && preen)
+ 		pwarn("starting\n");
+-	
++
+ 	if (setup( filesys, &blockDevice_fd, &canWrite ) == 0) {
+ 		if (preen)
+ 			pfatal("CAN'T CHECK FILE SYSTEM.");
+@@ -278,7 +290,7 @@ checkfilesys(char * filesys)
+ 	repLev = kMajorRepairs;
+ 	logLev = kVerboseLog;
+ 
+-	if (yflag)	
++	if (yflag)
+ 		repLev = kMajorRepairs;
+ 
+ 	if (quick) {
+@@ -298,16 +310,16 @@ checkfilesys(char * filesys)
+ 
+ 	if (nflag)
+ 		repLev = kNeverRepair;
+-		
++
+ 	if ( rebuildCatalogBtree ) {
+ 		chkLev = kPartialCheck;
+ 		repLev = kForceRepairs;  // this will force rebuild of catalog B-Tree file
+ 	}
+-		
++
+ 	/*
+ 	 * go check HFS volume...
+ 	 */
+-	result = CheckHFS(	fsreadfd, fswritefd, chkLev, repLev, logLev, 
++	result = CheckHFS(	fsreadfd, fswritefd, chkLev, repLev, logLev,
+ 						guiControl, lostAndFoundMode, canWrite, &fsmodified );
+ 	if (!hotroot) {
+ 		ckfini(1);
+@@ -330,6 +342,9 @@ checkfilesys(char * filesys)
+ 			}
+ 		}
+ 	} else {
++#if LINUX
++	// FIXME
++#else
+ 		struct statfs stfs_buf;
+ 		/*
+ 		 * Check to see if root is mounted read-write.
+@@ -339,19 +354,25 @@ checkfilesys(char * filesys)
+ 		else
+ 			flags = 0;
+ 		ckfini(flags & MNT_RDONLY);
++#endif
+ 	}
+ 
+ 	/* XXX free any allocated memory here */
+ 
+ 	if (hotroot && fsmodified) {
++#if !LINUX
+ 		struct hfs_mount_args args;
++#endif
+ 		/*
+ 		 * We modified the root.  Do a mount update on
+ 		 * it, unless it is read-write, so we can continue.
+ 		 */
+ 		if (!preen)
+ 			printf("\n***** FILE SYSTEM WAS MODIFIED *****\n");
+-		if (flags & MNT_RDONLY) {		
++#if LINUX
++		// FIXME
++#else
++		if (flags & MNT_RDONLY) {
+ 			bzero(&args, sizeof(args));
+ 			flags |= MNT_UPDATE | MNT_RELOAD;
+ 			if (mount("hfs", "/", flags, &args) == 0) {
+@@ -359,6 +380,7 @@ checkfilesys(char * filesys)
+ 				goto ExitThisRoutine;
+ 			}
+ 		}
++#endif
+ 		if (!preen)
+ 			printf("\n***** REBOOT NOW *****\n");
+ 		sync();
+@@ -367,7 +389,7 @@ checkfilesys(char * filesys)
+ 	}
+ 
+ 	result = (result == 0) ? 0 : EEXIT;
+-	
++
+ ExitThisRoutine:
+ 	if (lflag) {
+ 	    fcntl(fs_fd, F_THAW_FS, NULL);
+@@ -401,16 +423,18 @@ setup( char *dev, int *blockDevice_fdPtr, int *canWritePtr )
+ 	fswritefd = -1;
+ 	*blockDevice_fdPtr = -1;
+ 	*canWritePtr = 0;
+-	
++
+ 	if (stat(dev, &statb) < 0) {
+ 		printf("Can't stat %s: %s\n", dev, strerror(errno));
+ 		return (0);
+ 	}
++#if !LINUX
+ 	if ((statb.st_mode & S_IFMT) != S_IFCHR) {
+ 		pfatal("%s is not a character device", dev);
+ 		if (reply("CONTINUE") == 0)
+ 			return (0);
+ 	}
++#endif
+ 	if ((fsreadfd = open(dev, O_RDONLY)) < 0) {
+ 		printf("Can't open %s: %s\n", dev, strerror(errno));
+ 		return (0);
+@@ -419,7 +443,7 @@ setup( char *dev, int *blockDevice_fdPtr, int *canWritePtr )
+ 	/* attempt to get write access to the block device and if not check if volume is */
+ 	/* mounted read-only.  */
+ 	getWriteAccess( dev, blockDevice_fdPtr, canWritePtr );
+-	
++
+ 	if (preen == 0 && !guiControl)
+ 		printf("** %s", dev);
+ 	if (nflag || (fswritefd = open(dev, O_WRONLY)) < 0) {
+@@ -433,10 +457,14 @@ setup( char *dev, int *blockDevice_fdPtr, int *canWritePtr )
+ 		printf("\n");
+ 
+ 	/* Get device block size to initialize cache */
++#if LINUX
++	devBlockSize = 512;
++#else
+ 	if (ioctl(fsreadfd, DKIOCGETBLOCKSIZE, &devBlockSize) < 0) {
+ 		pfatal ("Can't get device block size\n");
+ 		return (0);
+ 	}
++#endif
+ 
+ 	 /* calculate the cache block size and total blocks */
+ 	if (CalculateCacheSize(userCacheSize, &cacheBlockSize, &cacheTotalBlocks, debug) != 0) {
+@@ -463,11 +491,15 @@ setup( char *dev, int *blockDevice_fdPtr, int *canWritePtr )
+ 
+ static void getWriteAccess( char *dev, int *blockDevice_fdPtr, int *canWritePtr )
+ {
++#if !LINUX
+ 	int					i;
+ 	int					myMountsCount;
++#endif
+ 	void *				myPtr;
+ 	char *				myCharPtr;
++#if !LINUX
+ 	struct statfs *		myBufPtr;
++#endif
+ 	void *				myNamePtr;
+ 
+ 	myPtr = NULL;
+@@ -490,6 +522,9 @@ static void getWriteAccess( char *dev, int *blockDevice_fdPtr, int *canWritePtr
+ 	}
+ 	
+ 	// get count of mounts then get the info for each 
++#if LINUX
++	// FIXME
++#else
+ 	myMountsCount = getfsstat( NULL, 0, MNT_NOWAIT );
+ 	if ( myMountsCount < 0 )
+ 		goto ExitThisRoutine;
+@@ -513,8 +548,8 @@ static void getWriteAccess( char *dev, int *blockDevice_fdPtr, int *canWritePtr
+ 		}
+ 		myBufPtr++;
+ 	}
+-	*canWritePtr = 1;  // single user will get us here, f_mntfromname is not /dev/diskXXXX 
+-	
++#endif
++	*canWritePtr = 1;  // single user will get us here, f_mntfromname is not /dev/diskXXXX
+ ExitThisRoutine:
+ 	if ( myPtr != NULL )
+ 		free( myPtr );
+diff --git a/fsck_hfs.tproj/utilities.c b/fsck_hfs.tproj/utilities.c
+index ee41bef..8e1cd77 100644
+--- a/fsck_hfs.tproj/utilities.c
++++ b/fsck_hfs.tproj/utilities.c
+@@ -183,12 +183,14 @@ retry:
+ 			printf("Can't stat %s\n", raw);
+ 			return (origname);
+ 		}
++#if !LINUX
+ 		if ((stchar.st_mode & S_IFMT) == S_IFCHR) {
+ 			return (raw);
+ 		} else {
+ 			printf("%s is not a character device\n", raw);
+ 			return (origname);
+ 		}
++#endif
+ 	} else if ((stblock.st_mode & S_IFMT) == S_IFCHR && !retried) {
+ 		newname = unrawname(newname);
+ 		retried++;
+@@ -214,7 +216,11 @@ rawname(char *name)
+ 	*dp = 0;
+ 	(void)strcpy(rawbuf, name);
+ 	*dp = '/';
+-	(void)strcat(rawbuf, "/r");
++#if LINUX
++	(void)strcat(rawbuf, "/");
++#else
++	(void)strcat(rawbuf,"/r");
++#endif
+ 	(void)strcat(rawbuf, &dp[1]);
+ 
+ 	return (rawbuf);
+diff --git a/include/missing.h b/include/missing.h
+new file mode 100644
+index 0000000..0a859c4
+--- /dev/null
++++ b/include/missing.h
+@@ -0,0 +1,114 @@
++#ifndef _MISSING_H_
++#define _MISSING_H_
++
++#include <endian.h>
++#include <byteswap.h>
++#include <errno.h>
++#include <stdint.h>
++#include <string.h>
++
++#define MAXBSIZE		(256 * 4096)
++
++#ifndef true
++#define true			1
++#endif
++#ifndef false
++#define false			0
++#endif
++
++/* Mac types */
++
++/* 8 Bit */
++#ifndef UInt8
++#define UInt8			uint8_t
++#endif
++#ifndef u_int8_t
++#define u_int8_t		UInt8
++#endif
++#ifndef SInt8
++#define SInt8			int8_t
++#endif
++
++/* 16 Bit */
++#ifndef UInt16
++#define UInt16			uint16_t
++#endif
++#ifndef u_int16_t
++#define u_int16_t		UInt16
++#endif
++#ifndef SInt16
++#define SInt16			int16_t
++#endif
++
++/* 32 Bit */
++#ifndef UInt32
++#define UInt32			uint32_t
++#endif
++#ifndef u_int32_t
++#define u_int32_t		UInt32
++#endif
++#ifndef SInt32
++#define SInt32			int32_t
++#endif
++
++/* 64 Bit */
++#ifndef UInt64
++#define UInt64			uint64_t
++#endif
++#ifndef u_int64_t
++#define u_int64_t		UInt64
++#endif
++#ifndef SInt64
++#define SInt64			int64_t
++#endif
++
++#define UniChar			u_int16_t
++#define Boolean			u_int8_t
++
++#define UF_NODUMP	0x00000001
++
++/* syslimits.h */
++#define NAME_MAX	255
++
++/* Byteswap stuff */
++#define NXSwapHostLongToBig(x)		cpu_to_be64(x)
++#define NXSwapBigShortToHost(x) 	be16_to_cpu(x)
++#define OSSwapBigToHostInt16(x)		be16_to_cpu(x)
++#define NXSwapBigLongToHost(x)		be32_to_cpu(x)
++#define OSSwapBigToHostInt32(x)		be32_to_cpu(x)
++#define NXSwapBigLongLongToHost(x) 	be64_to_cpu(x)
++#define OSSwapBigToHostInt64(x)		be64_to_cpu(x)
++
++#if __BYTE_ORDER == __LITTLE_ENDIAN
++/* Big Endian Swaps */
++#ifndef be16_to_cpu
++#define be16_to_cpu(x) bswap_16(x)
++#endif
++#ifndef be32_to_cpu
++#define be32_to_cpu(x) bswap_32(x)
++#endif
++#ifndef be64_to_cpu
++#define be64_to_cpu(x) bswap_64(x)
++#endif
++#ifndef cpu_to_be64
++#define cpu_to_be64(x) bswap_64(x)
++#endif
++#elif __BYTE_ORDER == __BIG_ENDIAN
++/* Big endian doesn't swap */
++#ifndef be16_to_cpu
++#define be16_to_cpu(x)	(x)
++#endif
++#ifndef be32_to_cpu
++#define be32_to_cpu(x)	(x)
++#endif
++#ifndef be64_to_cpu
++#define be64_to_cpu(x)	(x)
++#endif
++#ifndef cpu_to_be64
++#define cpu_to_be64(x) 	(x)
++#endif
++#endif
++
++#define KAUTH_FILESEC_XATTR "com.apple.system.Security"
++
++#endif
+diff --git a/newfs_hfs.tproj/hfs_endian.c b/newfs_hfs.tproj/hfs_endian.c
+index 117b7f8..fdf7353 100644
+--- a/newfs_hfs.tproj/hfs_endian.c
++++ b/newfs_hfs.tproj/hfs_endian.c
+@@ -30,7 +30,12 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ 
++#if LINUX
++#include "missing.h"
++#else
+ #include <architecture/byte_order.h>
++#endif
++
+ #include <hfs/hfs_format.h>
+ 
+ #include "hfs_endian.h"
+diff --git a/newfs_hfs.tproj/hfs_endian.h b/newfs_hfs.tproj/hfs_endian.h
+index 8d9d01d..5c7ff57 100644
+--- a/newfs_hfs.tproj/hfs_endian.h
++++ b/newfs_hfs.tproj/hfs_endian.h
+@@ -29,7 +29,12 @@
+  * volume format.
+  */
+ #include <hfs/hfs_format.h>
++#if LINUX
++#include <endian.h>
++#include <byteswap.h>
++#else
+ #include <architecture/byte_order.h>
++#endif
+ 
+ /*********************/
+ /* BIG ENDIAN Macros */
+diff --git a/newfs_hfs.tproj/makehfs.c b/newfs_hfs.tproj/makehfs.c
+index 085222f..7609779 100644
+--- a/newfs_hfs.tproj/makehfs.c
++++ b/newfs_hfs.tproj/makehfs.c
+@@ -31,10 +31,16 @@
+ #include <sys/param.h>
+ #include <sys/types.h>
+ #include <sys/time.h>
++#if LINUX
++#include <time.h>
++#include "missing.h"
++#endif
+ #include <sys/errno.h>
+ #include <sys/stat.h>
+ #include <sys/sysctl.h>
++#if !LINUX
+ #include <sys/vmmeter.h>
++#endif
+ 
+ #include <err.h>
+ #include <errno.h>
+@@ -47,13 +53,14 @@
+ 
+ #include <openssl/sha.h>
+ 
++#if !LINUX
+ #include <architecture/byte_order.h>
+ 
+ #include <CoreFoundation/CFString.h>
+ #include <CoreFoundation/CFStringEncodingExt.h>
+ 
+ extern Boolean _CFStringGetFileSystemRepresentation(CFStringRef string, UInt8 *buffer, CFIndex maxBufLen);
+-
++#endif
+ 
+ #include <hfs/hfs_format.h>
+ #include <hfs/hfs_mount.h>
+@@ -129,7 +136,9 @@ static UInt32 Largest __P((UInt32 a, UInt32 b, UInt32 c, UInt32 d ));
+ static void MarkBitInAllocationBuffer __P((HFSPlusVolumeHeader *header,
+ 		UInt32 allocationBlock, void* sectorBuffer, UInt32 *sector));
+ 
++#if !LINUX
+ static UInt32 GetDefaultEncoding();
++#endif
+ 
+ static UInt32 UTCToLocal __P((UInt32 utcTime));
+ 
+@@ -158,11 +167,14 @@ void SETOFFSET (void *buffer, UInt16 btNodeSize, SInt16 recOffset, SInt16 vecOff
+ 
+ #define ROUNDUP(x, u)	(((x) % (u) == 0) ? (x) : ((x)/(u) + 1) * (u))
+ 
+-#define ENCODING_TO_BIT(e)                               \
++#if LINUX
++#define ENCODING_TO_BIT(e)       (e)
++#else
++#define ENCODING_TO_BIT(e)
+           ((e) < 48 ? (e) :                              \
+           ((e) == kCFStringEncodingMacUkrainian ? 48 :   \
+           ((e) == kCFStringEncodingMacFarsi ? 49 : 0)))
+-
++#endif
+ /*
+  * make_hfs
+  *	
+@@ -528,6 +540,7 @@ InitMDB(hfsparams_t *defaults, UInt32 driveBlocks, HFS_MDB *mdbp)
+ 	 * Map UTF-8 input into a Mac encoding.
+ 	 * On conversion errors "untitled" is used as a fallback.
+ 	 */
++#if !LINUX
+ 	{
+ 		UniChar unibuf[kHFSMaxVolumeNameChars];
+ 		CFStringRef cfstr;
+@@ -553,7 +566,11 @@ InitMDB(hfsparams_t *defaults, UInt32 driveBlocks, HFS_MDB *mdbp)
+ 		bcopy(&mdbp->drVN[1], defaults->volumeName, mdbp->drVN[0]);
+ 		defaults->volumeName[mdbp->drVN[0]] = '\0';
+ 	}
++#endif
+ 	/* Save the encoding hint in the Finder Info (field 4). */
++	mdbp->drVN[0] = strlen(defaults->volumeName);
++	bcopy(defaults->volumeName,&mdbp->drVN[1],mdbp->drVN[0]);
++
+ 	mdbp->drFndrInfo[4] = SET_HFS_TEXT_ENCODING(defaults->encodingHint);
+ 
+ 	mdbp->drWrCnt = kWriteSeqNum;
+@@ -1100,9 +1117,11 @@ InitCatalogRoot_HFSPlus(const hfsparams_t *dp, const HFSPlusVolumeHeader *header
+ 	UInt16					nodeSize;
+ 	SInt16					offset;
+ 	UInt32					unicodeBytes;
++#if !LINUX
+ 	UInt8 canonicalName[256];
+ 	CFStringRef cfstr;
+ 	Boolean	cfOK;
++#endif
+ 	int index = 0;
+ 
+ 	nodeSize = dp->catalogNodeSize;
+@@ -1122,7 +1141,9 @@ InitCatalogRoot_HFSPlus(const hfsparams_t *dp, const HFSPlusVolumeHeader *header
+ 	 * First record is always the root directory...
+ 	 */
+ 	ckp = (HFSPlusCatalogKey *)((UInt8 *)buffer + offset);
+-	
++#if LINUX
++	ConvertUTF8toUnicode(dp->volumeName, sizeof(ckp->nodeName.unicode), ckp->nodeName.unicode, &ckp->nodeName.length);
++#else
+ 	/* Use CFString functions to get a HFSPlus Canonical name */
+ 	cfstr = CFStringCreateWithCString(kCFAllocatorDefault, (char *)dp->volumeName, kCFStringEncodingUTF8);
+ 	cfOK = _CFStringGetFileSystemRepresentation(cfstr, canonicalName, sizeof(canonicalName));
+@@ -1139,6 +1160,7 @@ InitCatalogRoot_HFSPlus(const hfsparams_t *dp, const HFSPlusVolumeHeader *header
+ 		      dp->volumeName, kDefaultVolumeNameStr);
+ 	}
+ 	CFRelease(cfstr);
++#endif
+ 	ckp->nodeName.length = SWAP_BE16 (ckp->nodeName.length);
+ 
+ 	unicodeBytes = sizeof(UniChar) * SWAP_BE16 (ckp->nodeName.length);
+@@ -1821,15 +1843,15 @@ WriteBuffer(const DriveInfo *driveInfo, UInt64 startingSector, UInt32 byteCount,
+ 	off_t sector;
+ 
+ 	if ((byteCount % driveInfo->sectorSize) != 0)
+-		errx(1, "WriteBuffer: byte count %ld is not sector size multiple", byteCount);
++		errx(1, "WriteBuffer: byte count %i is not sector size multiple", byteCount);
+ 
+ 	sector = driveInfo->sectorOffset + startingSector;
+ 
+ 	if (lseek(driveInfo->fd, sector * driveInfo->sectorSize, SEEK_SET) < 0)
+-		err(1, "seek (sector %qd)", sector);
++		err(1, "seek (sector %lld)", sector);
+ 
+ 	if (write(driveInfo->fd, buffer, byteCount) != byteCount)
+-		err(1, "write (sector %qd, %ld bytes)", sector, byteCount);
++		err(1, "write (sector %lld, %i bytes)", sector, byteCount);
+ }
+ 
+ 
+@@ -1913,7 +1935,7 @@ DivideAndRoundUp(UInt32 numerator, UInt32 denominator)
+ 	return quotient;
+ }
+ 
+-
++#if !LINUX
+ #define __kCFUserEncodingFileName ("/.CFUserTextEncoding")
+ 
+ static UInt32
+@@ -1939,7 +1961,7 @@ GetDefaultEncoding()
+     }
+     return 0;
+ }
+-
++#endif
+ 
+ static int
+ ConvertUTF8toUnicode(const UInt8* source, UInt32 bufsize, UniChar* unibuf,
+@@ -2006,6 +2028,9 @@ ConvertUTF8toUnicode(const UInt8* source, UInt32 bufsize, UniChar* unibuf,
+ static int
+ getencodinghint(unsigned char *name)
+ {
++#if LINUX
++	return(0);
++#else
+         int mib[3];
+         size_t buflen = sizeof(int);
+         struct vfsconf vfc;
+@@ -2023,7 +2048,8 @@ getencodinghint(unsigned char *name)
+ 	return (hint);
+ error:
+ 	hint = GetDefaultEncoding();
+-	return (hint);
++	return (0);
++#endif
+ }
+ 
+ 
+@@ -2034,12 +2060,14 @@ void GenerateVolumeUUID(VolumeUUID *newVolumeID) {
+ 	unsigned char digest[20];
+ 	time_t now;
+ 	clock_t uptime;
+-	int mib[2];
+-	int sysdata;
+-	char sysctlstring[128];
+ 	size_t datalen;
+ 	double sysloadavg[3];
++#if !LINUX
++	int sysdata;
++	int mib[2];
++	char sysctlstring[128];
+ 	struct vmtotal sysvmtotal;
++#endif
+ 	
+ 	do {
+ 		/* Initialize the SHA-1 context for processing: */
+@@ -2052,52 +2080,58 @@ void GenerateVolumeUUID(VolumeUUID *newVolumeID) {
+ 		SHA1_Update(&context, &uptime, sizeof(uptime));
+ 		
+ 		/* The kernel's boot time: */
++#if !LINUX
+ 		mib[0] = CTL_KERN;
+ 		mib[1] = KERN_BOOTTIME;
+ 		datalen = sizeof(sysdata);
+ 		sysctl(mib, 2, &sysdata, &datalen, NULL, 0);
+ 		SHA1_Update(&context, &sysdata, datalen);
+-		
++#endif
+ 		/* The system's host id: */
++#if !LINUX
+ 		mib[0] = CTL_KERN;
+ 		mib[1] = KERN_HOSTID;
+ 		datalen = sizeof(sysdata);
+ 		sysctl(mib, 2, &sysdata, &datalen, NULL, 0);
+ 		SHA1_Update(&context, &sysdata, datalen);
+-
++#endif
+ 		/* The system's host name: */
++#if !LINUX
+ 		mib[0] = CTL_KERN;
+ 		mib[1] = KERN_HOSTNAME;
+ 		datalen = sizeof(sysctlstring);
+ 		sysctl(mib, 2, sysctlstring, &datalen, NULL, 0);
+ 		SHA1_Update(&context, sysctlstring, datalen);
+-
++#endif
+ 		/* The running kernel's OS release string: */
++#if !LINUX
+ 		mib[0] = CTL_KERN;
+ 		mib[1] = KERN_OSRELEASE;
+ 		datalen = sizeof(sysctlstring);
+ 		sysctl(mib, 2, sysctlstring, &datalen, NULL, 0);
+ 		SHA1_Update(&context, sysctlstring, datalen);
+-
++#endif
+ 		/* The running kernel's version string: */
++#if !LINUX
+ 		mib[0] = CTL_KERN;
+ 		mib[1] = KERN_VERSION;
+ 		datalen = sizeof(sysctlstring);
+ 		sysctl(mib, 2, sysctlstring, &datalen, NULL, 0);
+ 		SHA1_Update(&context, sysctlstring, datalen);
+-
++#endif
+ 		/* The system's load average: */
+ 		datalen = sizeof(sysloadavg);
+ 		getloadavg(sysloadavg, 3);
+ 		SHA1_Update(&context, &sysloadavg, datalen);
+ 
+ 		/* The system's VM statistics: */
++#if !LINUX
+ 		mib[0] = CTL_VM;
+ 		mib[1] = VM_METER;
+ 		datalen = sizeof(sysvmtotal);
+ 		sysctl(mib, 2, &sysvmtotal, &datalen, NULL, 0);
+ 		SHA1_Update(&context, &sysvmtotal, datalen);
+-
++#endif
+ 		/* The current GMT (26 ASCII characters): */
+ 		time(&now);
+ 		strncpy(randomInputBuffer, asctime(gmtime(&now)), 26);	/* "Mon Mar 27 13:46:26 2000" */
+diff --git a/newfs_hfs.tproj/newfs_hfs.c b/newfs_hfs.tproj/newfs_hfs.c
+index c4176a9..bf2ed21 100644
+--- a/newfs_hfs.tproj/newfs_hfs.c
++++ b/newfs_hfs.tproj/newfs_hfs.c
+@@ -38,8 +38,13 @@
+ #include <sys/mount.h>
+ #include <sys/param.h>
+ #include <sys/stat.h>
++#if LINUX
++#include <time.h>
++#endif
+ 
++#if !LINUX
+ #include <IOKit/storage/IOMediaBSDClient.h>
++#endif
+ 
+ #include <hfs/hfs_format.h>
+ #include "newfs_hfs.h"
+@@ -73,7 +78,9 @@ static void usage __P((void));
+ 
+ char	*progname;
+ char	gVolumeName[kHFSPlusMaxFileNameChars + 1] = {kDefaultVolumeNameStr};
++#if !LINUX
+ char	rawdevice[MAXPATHLEN];
++#endif
+ char	blkdevice[MAXPATHLEN];
+ UInt32	gBlockSize = 0;
+ UInt32	gNextCNID = kHFSFirstUserCatalogNodeID;
+@@ -158,8 +165,10 @@ main(argc, argv)
+ 	extern int optind;
+ 	int ch;
+ 	int forceHFS;
++#if !LINUX
+ 	char *cp, *special;
+ 	struct statfs *mp;
++#endif
+ 	int n;
+ 	
+ 	if ((progname = strrchr(*argv, '/')))
+@@ -260,16 +269,19 @@ main(argc, argv)
+ 			usage();
+ 		}
+ 
+-	argc -= optind;
+-	argv += optind;
++		argc -= optind;
++		argv += optind;
+ 
+-	if (gPartitionSize != 0) {
+-		if (argc != 0)
+-			usage();
+-	} else {
+-		if (argc != 1)
+-			usage();
++		if (gPartitionSize != 0) {
++			if (argc != 0)
++				usage();
++		} else {
++			if (argc != 1)
++				usage();
+ 
++#if LINUX
++		(void) sprintf(blkdevice, "%s", argv[0]);
++#else
+ 		special = argv[0];
+ 		cp = strrchr(special, '/');
+ 		if (cp != 0)
+@@ -278,6 +290,7 @@ main(argc, argv)
+ 			special++;
+ 		(void) sprintf(rawdevice, "%sr%s", _PATH_DEV, special);
+ 		(void) sprintf(blkdevice, "%s%s", _PATH_DEV, special);
++#endif
+ 	}
+ 
+ 	if (forceHFS && gJournaled) {
+@@ -301,6 +314,9 @@ main(argc, argv)
+ 		/*
+ 		 * Check if target device is aready mounted
+ 		 */
++#if LINUX
++	// FIXME
++#else
+ 		n = getmntinfo(&mp, MNT_NOWAIT);
+ 		if (n == 0)
+ 			fatal("%s: getmntinfo: %s", blkdevice, strerror(errno));
+@@ -310,15 +326,20 @@ main(argc, argv)
+ 				fatal("%s is mounted on %s", blkdevice, mp->f_mntonname);
+ 			++mp;
+ 		}
++#endif
+ 	}
+ 
+-	if (hfs_newfs(rawdevice, forceHFS, true) < 0) {
++	if (hfs_newfs(blkdevice, forceHFS, true) < 0) {
++#if LINUX
++		err(1, NULL);
++#else
+ 		/* On ENXIO error use the block device (to get de-blocking) */
+ 		if (errno == ENXIO) {
+ 			if (hfs_newfs(blkdevice, forceHFS, false) < 0)
+ 				err(1, NULL);
+ 		} else
+ 			err(1, NULL);
++#endif
+ 	}
+ 
+ 	exit(0);
+@@ -506,7 +527,9 @@ hfs_newfs(char *device, int forceHFS, int isRaw)
+ 	int fso = 0;
+ 	int retval = 0;
+ 	hfsparams_t defaults = {0};
++#if !LINUX
+ 	u_int64_t maxSectorsPerIO;
++#endif
+ 
+ 	if (gPartitionSize) {
+ 			dip.sectorSize = kBytesPerSector;
+@@ -526,6 +549,34 @@ hfs_newfs(char *device, int forceHFS, int isRaw)
+ 	
+ 		if (fstat( fso, &stbuf) < 0)
+ 			fatal("%s: %s", device, strerror(errno));
++#if LINUX
++		dip.sectorSize = 512;
++		dip.sectorsPerIO = 256;
++
++#	ifndef	BLKGETSIZE
++#	define	BLKGETSIZE		_IO(0x12,96)
++#	endif
++
++#	ifndef	BLKGETSIZE64
++#	define BLKGETSIZE64		_IOR(0x12,114,size_t)
++#	endif
++
++		if (S_ISREG(stbuf.st_mode)) {
++		        dip.totalSectors = stbuf.st_size / 512;
++	        }
++		else if (S_ISBLK(stbuf.st_mode)) {
++	                unsigned long size;
++	                u_int64_t size64;
++			if (!ioctl(fso, BLKGETSIZE64, &size64))
++				dip.totalSectors = size64 / 512;
++			else if (!ioctl(fso, BLKGETSIZE, &size))
++				dip.totalSectors = size;
++			else
++				fatal("%s: %s", device, strerror(errno));
++		}
++		else
++			fatal("%s: is not a block device", device);
++#else
+ 	
+ 		if (ioctl(fso, DKIOCGETBLOCKCOUNT, &dip.totalSectors) < 0)
+ 			fatal("%s: %s", device, strerror(errno));
+@@ -537,11 +588,14 @@ hfs_newfs(char *device, int forceHFS, int isRaw)
+ 			dip.sectorsPerIO = (128 * 1024) / dip.sectorSize;  /* use 128K as default */
+ 		else
+ 			dip.sectorsPerIO = MIN(maxSectorsPerIO, (1024 * 1024) / dip.sectorSize);
++#endif
++
+ 		/*
+ 		 * The make_hfs code currentlydoes 512 byte sized I/O.
+ 		 * If the sector size is bigger than 512, start over
+ 		 * using the block device (to get de-blocking).
+ 		 */       
++#if !LINUX
+ 		if (dip.sectorSize != kBytesPerSector) {
+ 			if (isRaw) {
+ 				close(fso);
+@@ -556,7 +610,9 @@ hfs_newfs(char *device, int forceHFS, int isRaw)
+ 				dip.sectorSize = kBytesPerSector;
+ 			}
+ 		}
++#endif
+ 	}
++
+ 	dip.sectorOffset = 0;
+ 	time(&createtime);
+ 
+diff --git a/newfs_hfs.tproj/newfs_hfs.h b/newfs_hfs.tproj/newfs_hfs.h
+index 968ff10..5680a34 100644
+--- a/newfs_hfs.tproj/newfs_hfs.h
++++ b/newfs_hfs.tproj/newfs_hfs.h
+@@ -19,8 +19,12 @@
+  * 
+  * @APPLE_LICENSE_HEADER_END@
+  */
+- 
++
++#if LINUX
++#include "missing.h"
++#else
+ #include <CoreFoundation/CFBase.h>
++#endif
+ 
+ /*
+  * Mac OS Finder flags
+@@ -122,33 +126,33 @@ enum {
+ #define kDTDF_FileID	16
+ #define kDTDF_Name	"Desktop DF"
+ #define kDTDF_Chars	10
+-#define kDTDF_Type	'DTFL'
+-#define kDTDF_Creator	'DMGR'
++#define kDTDF_Type	0x4454464C /* 'DTFL' */
++#define kDTDF_Creator	0x444D4752 /* 'DMGR' */
+ 
+ #define kDTDB_FileID	17
+ #define kDTDB_Name	"Desktop DB"
+ #define kDTDB_Chars	10
+-#define kDTDB_Type	'BTFL'
+-#define kDTDB_Creator	'DMGR'
++#define kDTDB_Type	0x4254464C /* 'BTFL' */
++#define kDTDB_Creator	0x444D4752 /* 'DMGR' */
+ #define kDTDB_Size	1024
+ 
+ #define kReadMe_FileID	18
+ #define kReadMe_Name	"ReadMe"
+ #define kReadMe_Chars	6
+-#define kReadMe_Type	'ttro'
+-#define kReadMe_Creator	'ttxt'
++#define kReadMe_Type	0x7474726F /* 'ttro' */
++#define kReadMe_Creator	0x74747974 /* 'ttxt' */
+ 
+ #define kFinder_FileID	19
+ #define kFinder_Name	"Finder"
+ #define kFinder_Chars	6
+-#define kFinder_Type	'FNDR'
+-#define kFinder_Creator	'MACS'
++#define kFinder_Type	0x464E4452 /* 'FNDR' */
++#define kFinder_Creator	0x4D414353 /* 'MACS' */
+ 
+ #define kSystem_FileID	20
+ #define kSystem_Name	"System"
+ #define kSystem_Chars	6
+-#define kSystem_Type	'zsys'
+-#define kSystem_Creator	'MACS'
++#define kSystem_Type	0x7A737973 /* 'zsys' */
++#define kSystem_Creator	0x4D414353 /* 'MACS' */
+ 
+ 
+ 

--- a/utils/hfsprogs/patches/0003-Add-helper-include-files-absent-from-the-upstream-pa.patch
+++ b/utils/hfsprogs/patches/0003-Add-helper-include-files-absent-from-the-upstream-pa.patch
@@ -1,0 +1,1024 @@
+From: =?UTF-8?q?Rog=C3=A9rio=20Brito?= <rbrito@ime.usp.br>
+Date: Thu, 24 Oct 2013 01:11:21 -0200
+Subject: Add helper include files absent from the upstream package
+
+Add some include files from an Apple system that contain the definition of
+the data structures used by the programs that manipulate the filesystems.
+---
+ include/bitstring.h        | 164 +++++++++++
+ include/hfs/hfs_format.h   | 689 +++++++++++++++++++++++++++++++++++++++++++++
+ include/hfs/hfs_mount.h    |  78 +++++
+ include/sys/appleapiopts.h |  52 ++++
+ 4 files changed, 983 insertions(+)
+ create mode 100644 include/bitstring.h
+ create mode 100644 include/hfs/hfs_format.h
+ create mode 100644 include/hfs/hfs_mount.h
+ create mode 100644 include/sys/appleapiopts.h
+
+diff --git a/include/bitstring.h b/include/bitstring.h
+new file mode 100644
+index 0000000..fbecfbe
+--- /dev/null
++++ b/include/bitstring.h
+@@ -0,0 +1,164 @@
++/*
++ * Copyright (c) 2000 Apple Computer, Inc. All rights reserved.
++ *
++ * @APPLE_LICENSE_HEADER_START@
++ *
++ * The contents of this file constitute Original Code as defined in and
++ * are subject to the Apple Public Source License Version 1.1 (the
++ * "License").  You may not use this file except in compliance with the
++ * License.  Please obtain a copy of the License at
++ * http://www.apple.com/publicsource and read it before using this file.
++ *
++ * This Original Code and all software distributed under the License are
++ * distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER
++ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
++ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT.  Please see the
++ * License for the specific language governing rights and limitations
++ * under the License.
++ *
++ * @APPLE_LICENSE_HEADER_END@
++ */
++/*
++ * Copyright (c) 1989, 1993
++ *	The Regents of the University of California.  All rights reserved.
++ *
++ * This code is derived from software contributed to Berkeley by
++ * Paul Vixie.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. All advertising materials mentioning features or use of this software
++ *    must display the following acknowledgement:
++ *	This product includes software developed by the University of
++ *	California, Berkeley and its contributors.
++ * 4. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *	@(#)bitstring.h	8.1 (Berkeley) 7/19/93
++ */
++
++#ifndef _BITSTRING_H_
++#define	_BITSTRING_H_
++
++typedef	unsigned char bitstr_t;
++
++/* internal macros */
++				/* byte of the bitstring bit is in */
++#define	_bit_byte(bit) \
++	((bit) >> 3)
++
++				/* mask for the bit within its byte */
++#define	_bit_mask(bit) \
++	(1 << ((bit)&0x7))
++
++/* external macros */
++				/* bytes in a bitstring of nbits bits */
++#define	bitstr_size(nbits) \
++	((((nbits) - 1) >> 3) + 1)
++
++				/* allocate a bitstring */
++#define	bit_alloc(nbits) \
++	(bitstr_t *)calloc(1, \
++	    (unsigned int)bitstr_size(nbits) * sizeof(bitstr_t))
++
++				/* allocate a bitstring on the stack */
++#define	bit_decl(name, nbits) \
++	(name)[bitstr_size(nbits)]
++
++				/* is bit N of bitstring name set? */
++#define	bit_test(name, bit) \
++	((name)[_bit_byte(bit)] & _bit_mask(bit))
++
++				/* set bit N of bitstring name */
++#define	bit_set(name, bit) \
++	(name)[_bit_byte(bit)] |= _bit_mask(bit)
++
++				/* clear bit N of bitstring name */
++#define	bit_clear(name, bit) \
++	(name)[_bit_byte(bit)] &= ~_bit_mask(bit)
++
++				/* clear bits start ... stop in bitstring */
++#define	bit_nclear(name, start, stop) { \
++	register bitstr_t *_name = name; \
++	register int _start = start, _stop = stop; \
++	register int _startbyte = _bit_byte(_start); \
++	register int _stopbyte = _bit_byte(_stop); \
++	if (_startbyte == _stopbyte) { \
++		_name[_startbyte] &= ((0xff >> (8 - (_start&0x7))) | \
++				      (0xff << ((_stop&0x7) + 1))); \
++	} else { \
++		_name[_startbyte] &= 0xff >> (8 - (_start&0x7)); \
++		while (++_startbyte < _stopbyte) \
++			_name[_startbyte] = 0; \
++		_name[_stopbyte] &= 0xff << ((_stop&0x7) + 1); \
++	} \
++}
++
++				/* set bits start ... stop in bitstring */
++#define	bit_nset(name, start, stop) { \
++	register bitstr_t *_name = name; \
++	register int _start = start, _stop = stop; \
++	register int _startbyte = _bit_byte(_start); \
++	register int _stopbyte = _bit_byte(_stop); \
++	if (_startbyte == _stopbyte) { \
++		_name[_startbyte] |= ((0xff << (_start&0x7)) & \
++				    (0xff >> (7 - (_stop&0x7)))); \
++	} else { \
++		_name[_startbyte] |= 0xff << ((_start)&0x7); \
++		while (++_startbyte < _stopbyte) \
++	    		_name[_startbyte] = 0xff; \
++		_name[_stopbyte] |= 0xff >> (7 - (_stop&0x7)); \
++	} \
++}
++
++				/* find first bit clear in name */
++#define	bit_ffc(name, nbits, value) { \
++	register bitstr_t *_name = name; \
++	register int _byte, _nbits = nbits; \
++	register int _stopbyte = _bit_byte(_nbits), _value = -1; \
++	for (_byte = 0; _byte <= _stopbyte; ++_byte) \
++		if (_name[_byte] != 0xff) { \
++			_value = _byte << 3; \
++			for (_stopbyte = _name[_byte]; (_stopbyte&0x1); \
++			    ++_value, _stopbyte >>= 1); \
++			break; \
++		} \
++	*(value) = _value; \
++}
++
++				/* find first bit set in name */
++#define	bit_ffs(name, nbits, value) { \
++	register bitstr_t *_name = name; \
++	register int _byte, _nbits = nbits; \
++	register int _stopbyte = _bit_byte(_nbits), _value = -1; \
++	for (_byte = 0; _byte <= _stopbyte; ++_byte) \
++		if (_name[_byte]) { \
++			_value = _byte << 3; \
++			for (_stopbyte = _name[_byte]; !(_stopbyte&0x1); \
++			    ++_value, _stopbyte >>= 1); \
++			break; \
++		} \
++	*(value) = _value; \
++}
++
++#endif /* !_BITSTRING_H_ */
+diff --git a/include/hfs/hfs_format.h b/include/hfs/hfs_format.h
+new file mode 100644
+index 0000000..d820329
+--- /dev/null
++++ b/include/hfs/hfs_format.h
+@@ -0,0 +1,689 @@
++/*
++ * Copyright (c) 2000-2004 Apple Computer, Inc. All rights reserved.
++ *
++ * @APPLE_LICENSE_HEADER_START@
++ *
++ * The contents of this file constitute Original Code as defined in and
++ * are subject to the Apple Public Source License Version 1.1 (the
++ * "License").  You may not use this file except in compliance with the
++ * License.  Please obtain a copy of the License at
++ * http://www.apple.com/publicsource and read it before using this file.
++ *
++ * This Original Code and all software distributed under the License are
++ * distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER
++ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
++ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT.  Please see the
++ * License for the specific language governing rights and limitations
++ * under the License.
++ *
++ * @APPLE_LICENSE_HEADER_END@
++ */
++#ifndef __HFS_FORMAT__
++#define __HFS_FORMAT__
++
++#include "missing.h"
++
++#include <sys/appleapiopts.h>
++
++/*
++ * hfs_format.c
++ *
++ * This file describes the on-disk format for HFS and HFS Plus volumes.
++ * The HFS Plus volume format is desciibed in detail in Apple Technote 1150.
++ *
++ * http://developer.apple.com/technotes/tn/tn1150.html
++ *
++ */
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/* some on-disk hfs structures have 68K alignment (misaligned) */
++
++#define PACKED_S	__attribute__((packed))
++
++/* Signatures used to differentiate between HFS and HFS Plus volumes */
++enum {
++	kHFSSigWord		= 0x4244,	/* 'BD' in ASCII */
++	kHFSPlusSigWord		= 0x482B,	/* 'H+' in ASCII */
++	kHFSXSigWord		= 0x4858,	/* 'HX' in ASCII */
++
++	kHFSPlusVersion		= 0x0004,	/* 'H+' volumes are version 4 only */
++	kHFSXVersion		= 0x0005,	/* 'HX' volumes start with version 5 */
++
++	kHFSPlusMountVersion	= 0x31302E30,	/* '10.0' for Mac OS X */
++	kHFSJMountVersion	= 0x4846534a,	/* 'HFSJ' for journaled HFS+ on OS X */
++	kFSKMountVersion	= 0x46534b21	/* 'FSK!' for failed journal replay */
++}PACKED_S;
++
++
++#if 1
++/*
++ * Mac OS X has a special directory for linked and unlinked files (HFS Plus only).
++ * This directory and its contents are never exported from the filesystem under
++ * Mac OS X.
++ *
++ * To make this folder name sort last,  it has embedded null prefix.
++ * (0xC0, 0x80 in UTF-8)
++ */
++#define HFSPLUSMETADATAFOLDER  "\xC0\x80\xC0\x80\xC0\x80\xC0\x80HFS+ Private Data"
++
++/*
++ * Files in the HFS Private Data folder have one of the following prefixes
++ * followed by a decimal number (no leading zeros).  For indirect nodes this
++ * number is a 32 bit random number.  For unlinked (deleted) files that are
++ * still open, the number is the file ID for that file.
++ *
++ * e.g.  iNode7182000 and temp3296
++ */
++#define HFS_INODE_PREFIX	"iNode"
++#define HFS_DELETE_PREFIX	"temp"
++
++#endif /* __APPLE_API_PRIVATE */
++
++/*
++ * Indirect link files (hard links) have the following type/creator.
++ */
++enum {
++	kHardLinkFileType = 0x686C6E6B,  /* 'hlnk' */
++	kHFSPlusCreator   = 0x6866732B   /* 'hfs+' */
++}PACKED_S;
++
++
++#ifndef _HFSUNISTR255_DEFINED_
++#define _HFSUNISTR255_DEFINED_
++/* Unicode strings are used for HFS Plus file and folder names */
++struct HFSUniStr255 {
++	u_int16_t	length;		/* number of unicode characters */
++	u_int16_t	unicode[255];	/* unicode characters */
++} PACKED_S;
++typedef struct HFSUniStr255 HFSUniStr255;
++typedef const HFSUniStr255 *ConstHFSUniStr255Param;
++#endif /* _HFSUNISTR255_DEFINED_ */
++
++enum {
++	kHFSMaxVolumeNameChars		= 27,
++	kHFSMaxFileNameChars		= 31,
++	kHFSPlusMaxFileNameChars	= 255
++}PACKED_S;
++
++
++/* Extent overflow file data structures */
++
++/* HFS Extent key */
++struct HFSExtentKey {
++	u_int8_t 	keyLength;	/* length of key, excluding this field */
++	u_int8_t 	forkType;	/* 0 = data fork, FF = resource fork */
++	u_int32_t 	fileID;		/* file ID */
++	u_int16_t 	startBlock;	/* first file allocation block number in this extent */
++}PACKED_S;
++typedef struct HFSExtentKey HFSExtentKey;
++
++/* HFS Plus Extent key */
++struct HFSPlusExtentKey {
++	u_int16_t 	keyLength;		/* length of key, excluding this field */
++	u_int8_t 	forkType;		/* 0 = data fork, FF = resource fork */
++	u_int8_t 	pad;			/* make the other fields align on 32-bit boundary */
++	u_int32_t 	fileID;			/* file ID */
++	u_int32_t 	startBlock;		/* first file allocation block number in this extent */
++}PACKED_S;
++typedef struct HFSPlusExtentKey HFSPlusExtentKey;
++
++/* Number of extent descriptors per extent record */
++enum {
++	kHFSExtentDensity	= 3,
++	kHFSPlusExtentDensity	= 8
++}PACKED_S;
++
++/* HFS extent descriptor */
++struct HFSExtentDescriptor {
++	u_int16_t 	startBlock;		/* first allocation block */
++	u_int16_t 	blockCount;		/* number of allocation blocks */
++}PACKED_S;
++typedef struct HFSExtentDescriptor HFSExtentDescriptor;
++
++/* HFS Plus extent descriptor */
++struct HFSPlusExtentDescriptor {
++	u_int32_t 	startBlock;		/* first allocation block */
++	u_int32_t 	blockCount;		/* number of allocation blocks */
++}PACKED_S;
++typedef struct HFSPlusExtentDescriptor HFSPlusExtentDescriptor;
++
++/* HFS extent record */
++typedef HFSExtentDescriptor HFSExtentRecord[3];
++
++/* HFS Plus extent record */
++typedef HFSPlusExtentDescriptor HFSPlusExtentRecord[8];
++
++
++/* Finder information */
++struct FndrFileInfo {
++	u_int32_t 	fdType;		/* file type */
++	u_int32_t 	fdCreator;	/* file creator */
++	u_int16_t 	fdFlags;	/* Finder flags */
++	struct {
++	    int16_t	v;		/* file's location */
++	    int16_t	h;
++	} PACKED_S fdLocation;
++	int16_t 	opaque;
++}PACKED_S;
++typedef struct FndrFileInfo FndrFileInfo;
++
++struct FndrDirInfo {
++	struct {			/* folder's window rectangle */
++	    int16_t	top;
++	    int16_t	left;
++	    int16_t	bottom;
++	    int16_t	right;
++	}PACKED_S frRect;
++	unsigned short 	frFlags;	/* Finder flags */
++	struct {
++	    u_int16_t	v;		/* folder's location */
++	    u_int16_t	h;
++	}PACKED_S frLocation;
++	int16_t 	opaque;
++}PACKED_S;
++typedef struct FndrDirInfo FndrDirInfo;
++
++struct FndrOpaqueInfo {
++	int8_t opaque[16];
++}PACKED_S;
++typedef struct FndrOpaqueInfo FndrOpaqueInfo;
++
++
++/* HFS Plus Fork data info - 80 bytes */
++struct HFSPlusForkData {
++	u_int64_t 		logicalSize;	/* fork's logical size in bytes */
++	u_int32_t 		clumpSize;	/* fork's clump size in bytes */
++	u_int32_t 		totalBlocks;	/* total blocks used by this fork */
++	HFSPlusExtentRecord 	extents;	/* initial set of extents */
++}PACKED_S;
++typedef struct HFSPlusForkData HFSPlusForkData;
++
++
++/* Mac OS X has 16 bytes worth of "BSD" info.
++ *
++ * Note:  Mac OS 9 implementations and applications
++ * should preserve, but not change, this information.
++ */
++struct HFSPlusBSDInfo {
++	u_int32_t 	ownerID;	/* user or group ID of file/folder owner */
++	u_int32_t 	groupID;	/* additional user of group ID */
++	u_int8_t 	adminFlags;	/* super-user changeable flags */
++	u_int8_t 	ownerFlags;	/* owner changeable flags */
++	u_int16_t 	fileMode;	/* file type and permission bits */
++	union {
++	    u_int32_t	iNodeNum;	/* indirect node number (hard links only) */
++	    u_int32_t	linkCount;	/* links that refer to this indirect node */
++	    u_int32_t	rawDevice;	/* special file device (FBLK and FCHR only) */
++	}PACKED_S special;
++}PACKED_S;
++typedef struct HFSPlusBSDInfo HFSPlusBSDInfo;
++
++
++/* Catalog file data structures */
++
++enum {
++	kHFSRootParentID		= 1,	/* Parent ID of the root folder */
++	kHFSRootFolderID		= 2,	/* Folder ID of the root folder */
++	kHFSExtentsFileID		= 3,	/* File ID of the extents file */
++	kHFSCatalogFileID		= 4,	/* File ID of the catalog file */
++	kHFSBadBlockFileID		= 5,	/* File ID of the bad allocation block file */
++	kHFSAllocationFileID		= 6,	/* File ID of the allocation file (HFS Plus only) */
++	kHFSStartupFileID		= 7,	/* File ID of the startup file (HFS Plus only) */
++	kHFSAttributesFileID		= 8,	/* File ID of the attribute file (HFS Plus only) */
++	kHFSRepairCatalogFileID		= 14,	/* Used when rebuilding Catalog B-tree */
++	kHFSBogusExtentFileID		= 15,	/* Used for exchanging extents in extents file */
++	kHFSFirstUserCatalogNodeID	= 16
++}PACKED_S;
++
++/* HFS catalog key */
++struct HFSCatalogKey {
++	u_int8_t 	keyLength;		/* key length (in bytes) */
++	u_int8_t 	reserved;		/* reserved (set to zero) */
++	u_int32_t 	parentID;		/* parent folder ID */
++	u_int8_t 	nodeName[kHFSMaxFileNameChars + 1]; /* catalog node name */
++}PACKED_S;
++typedef struct HFSCatalogKey HFSCatalogKey;
++
++/* HFS Plus catalog key */
++struct HFSPlusCatalogKey {
++	u_int16_t 		keyLength;	/* key length (in bytes) */
++	u_int32_t 		parentID;	/* parent folder ID */
++	HFSUniStr255 		nodeName;	/* catalog node name */
++}PACKED_S;
++typedef struct HFSPlusCatalogKey HFSPlusCatalogKey;
++
++/* Catalog record types */
++enum {
++	/* HFS Catalog Records */
++	kHFSFolderRecord		= 0x0100,	/* Folder record */
++	kHFSFileRecord			= 0x0200,	/* File record */
++	kHFSFolderThreadRecord		= 0x0300,	/* Folder thread record */
++	kHFSFileThreadRecord		= 0x0400,	/* File thread record */
++
++	/* HFS Plus Catalog Records */
++	kHFSPlusFolderRecord		= 1,		/* Folder record */
++	kHFSPlusFileRecord		= 2,		/* File record */
++	kHFSPlusFolderThreadRecord	= 3,		/* Folder thread record */
++	kHFSPlusFileThreadRecord	= 4		/* File thread record */
++}PACKED_S;
++
++
++/* Catalog file record flags */
++enum {
++	kHFSFileLockedBit	= 0x0000,	/* file is locked and cannot be written to */
++	kHFSFileLockedMask	= 0x0001,
++
++	kHFSThreadExistsBit	= 0x0001,	/* a file thread record exists for this file */
++	kHFSThreadExistsMask	= 0x0002,
++
++	kHFSHasAttributesBit	= 0x0002,	/* object has extended attributes */
++	kHFSHasAttributesMask	= 0x0004,
++
++	kHFSHasSecurityBit	= 0x0003,	/* object has security data (ACLs) */
++	kHFSHasSecurityMask	= 0x0008
++}PACKED_S;
++
++
++/* HFS catalog folder record - 70 bytes */
++struct HFSCatalogFolder {
++	int16_t 		recordType;		/* == kHFSFolderRecord */
++	u_int16_t 		flags;			/* folder flags */
++	u_int16_t 		valence;		/* folder valence */
++	u_int32_t		folderID;		/* folder ID */
++	u_int32_t 		createDate;		/* date and time of creation */
++	u_int32_t 		modifyDate;		/* date and time of last modification */
++	u_int32_t 		backupDate;		/* date and time of last backup */
++	FndrDirInfo 		userInfo;		/* Finder information */
++	FndrOpaqueInfo		finderInfo;		/* additional Finder information */
++	u_int32_t 		reserved[4];		/* reserved - initialized as zero */
++}PACKED_S;
++typedef struct HFSCatalogFolder HFSCatalogFolder;
++
++/* HFS Plus catalog folder record - 88 bytes */
++struct HFSPlusCatalogFolder {
++	int16_t 		recordType;		/* == kHFSPlusFolderRecord */
++	u_int16_t 		flags;			/* file flags */
++	u_int32_t 		valence;		/* folder's valence (limited to 2^16 in Mac OS) */
++	u_int32_t 		folderID;		/* folder ID */
++	u_int32_t 		createDate;		/* date and time of creation */
++	u_int32_t 		contentModDate;		/* date and time of last content modification */
++	u_int32_t 		attributeModDate;	/* date and time of last attribute modification */
++	u_int32_t 		accessDate;		/* date and time of last access (MacOS X only) */
++	u_int32_t 		backupDate;		/* date and time of last backup */
++	HFSPlusBSDInfo		bsdInfo;		/* permissions (for MacOS X) */
++	FndrDirInfo 		userInfo;		/* Finder information */
++	FndrOpaqueInfo	 	finderInfo;		/* additional Finder information */
++	u_int32_t 		textEncoding;		/* hint for name conversions */
++	u_int32_t 		attrBlocks;		/* cached count of attribute data blocks */
++}PACKED_S;
++typedef struct HFSPlusCatalogFolder HFSPlusCatalogFolder;
++
++/* HFS catalog file record - 102 bytes */
++struct HFSCatalogFile {
++	int16_t 		recordType;		/* == kHFSFileRecord */
++	u_int8_t 		flags;			/* file flags */
++	int8_t 			fileType;		/* file type (unused ?) */
++	FndrFileInfo 		userInfo;		/* Finder information */
++	u_int32_t 		fileID;			/* file ID */
++	u_int16_t 		dataStartBlock;		/* not used - set to zero */
++	int32_t 		dataLogicalSize;	/* logical EOF of data fork */
++	int32_t 		dataPhysicalSize;	/* physical EOF of data fork */
++	u_int16_t		rsrcStartBlock;		/* not used - set to zero */
++	int32_t			rsrcLogicalSize;	/* logical EOF of resource fork */
++	int32_t			rsrcPhysicalSize;	/* physical EOF of resource fork */
++	u_int32_t		createDate;		/* date and time of creation */
++	u_int32_t		modifyDate;		/* date and time of last modification */
++	u_int32_t		backupDate;		/* date and time of last backup */
++	FndrOpaqueInfo		finderInfo;		/* additional Finder information */
++	u_int16_t		clumpSize;		/* file clump size (not used) */
++	HFSExtentRecord		dataExtents;		/* first data fork extent record */
++	HFSExtentRecord		rsrcExtents;		/* first resource fork extent record */
++	u_int32_t		reserved;		/* reserved - initialized as zero */
++}PACKED_S;
++typedef struct HFSCatalogFile HFSCatalogFile;
++
++/* HFS Plus catalog file record - 248 bytes */
++struct HFSPlusCatalogFile {
++	int16_t 		recordType;		/* == kHFSPlusFileRecord */
++	u_int16_t 		flags;			/* file flags */
++	u_int32_t 		reserved1;		/* reserved - initialized as zero */
++	u_int32_t 		fileID;			/* file ID */
++	u_int32_t 		createDate;		/* date and time of creation */
++	u_int32_t 		contentModDate;		/* date and time of last content modification */
++	u_int32_t 		attributeModDate;	/* date and time of last attribute modification */
++	u_int32_t 		accessDate;		/* date and time of last access (MacOS X only) */
++	u_int32_t 		backupDate;		/* date and time of last backup */
++	HFSPlusBSDInfo 		bsdInfo;		/* permissions (for MacOS X) */
++	FndrFileInfo 		userInfo;		/* Finder information */
++	FndrOpaqueInfo	 	finderInfo;		/* additional Finder information */
++	u_int32_t 		textEncoding;		/* hint for name conversions */
++	u_int32_t 		attrBlocks;		/* cached count of attribute data blocks */
++
++	/* Note: these start on double long (64 bit) boundry */
++	HFSPlusForkData 	dataFork;		/* size and block data for data fork */
++	HFSPlusForkData 	resourceFork;		/* size and block data for resource fork */
++}PACKED_S;
++typedef struct HFSPlusCatalogFile HFSPlusCatalogFile;
++
++/* HFS catalog thread record - 46 bytes */
++struct HFSCatalogThread {
++	int16_t 	recordType;		/* == kHFSFolderThreadRecord or kHFSFileThreadRecord */
++	int32_t 	reserved[2];		/* reserved - initialized as zero */
++	u_int32_t 	parentID;		/* parent ID for this catalog node */
++	u_int8_t 	nodeName[kHFSMaxFileNameChars + 1]; /* name of this catalog node */
++}PACKED_S;
++typedef struct HFSCatalogThread HFSCatalogThread;
++
++/* HFS Plus catalog thread record -- 264 bytes */
++struct HFSPlusCatalogThread {
++	int16_t 	recordType;		/* == kHFSPlusFolderThreadRecord or kHFSPlusFileThreadRecord */
++	int16_t 	reserved;		/* reserved - initialized as zero */
++	u_int32_t 	parentID;		/* parent ID for this catalog node */
++	HFSUniStr255 	nodeName;		/* name of this catalog node (variable length) */
++}PACKED_S;
++typedef struct HFSPlusCatalogThread HFSPlusCatalogThread;
++
++#ifdef __APPLE_API_UNSTABLE
++/*
++  	These are the types of records in the attribute B-tree.  The values were
++  	chosen so that they wouldn't conflict with the catalog record types.
++*/
++enum {
++	kHFSPlusAttrInlineData	= 0x10,    /* if size <  kAttrOverflowSize */
++	kHFSPlusAttrForkData	= 0x20,    /* if size >= kAttrOverflowSize */
++	kHFSPlusAttrExtents	= 0x30     /* overflow extents for large attributes */
++}PACKED_S;
++
++
++/*
++  	HFSPlusAttrForkData
++  	For larger attributes, whose value is stored in allocation blocks.
++  	If the attribute has more than 8 extents, there will be additonal
++  	records (of type HFSPlusAttrExtents) for this attribute.
++*/
++struct HFSPlusAttrForkData {
++	u_int32_t 	recordType;		/* == kHFSPlusAttrForkData*/
++	u_int32_t 	reserved;
++	HFSPlusForkData theFork;		/* size and first extents of value*/
++}PACKED_S;
++typedef struct HFSPlusAttrForkData HFSPlusAttrForkData;
++
++/*
++  	HFSPlusAttrExtents
++  	This record contains information about overflow extents for large,
++  	fragmented attributes.
++*/
++struct HFSPlusAttrExtents {
++	u_int32_t 		recordType;	/* == kHFSPlusAttrExtents*/
++	u_int32_t 		reserved;
++	HFSPlusExtentRecord	extents;	/* additional extents*/
++}PACKED_S;
++typedef struct HFSPlusAttrExtents HFSPlusAttrExtents;
++
++/*
++ * Atrributes B-tree Data Record
++ *
++ * For small attributes, whose entire value is stored
++ * within a single B-tree record.
++ */
++struct HFSPlusAttrData {
++	u_int32_t    recordType;   /* == kHFSPlusAttrInlineData */
++	u_int32_t    reserved[2];
++	u_int32_t    attrSize;     /* size of attribute data in bytes */
++	u_int8_t     attrData[2];  /* variable length */
++}PACKED_S;
++typedef struct HFSPlusAttrData HFSPlusAttrData;
++
++
++/* HFSPlusAttrInlineData is obsolete use HFSPlusAttrData instead */
++struct HFSPlusAttrInlineData {
++	u_int32_t 	recordType;
++	u_int32_t 	reserved;
++	u_int32_t 	logicalSize;
++	u_int8_t 	userData[2];
++}PACKED_S;
++typedef struct HFSPlusAttrInlineData HFSPlusAttrInlineData;
++
++
++/*	A generic Attribute Record*/
++union HFSPlusAttrRecord {
++	u_int32_t 		recordType;
++	HFSPlusAttrInlineData 	inlineData;   /* NOT USED */
++	HFSPlusAttrData 	attrData;
++	HFSPlusAttrForkData 	forkData;
++	HFSPlusAttrExtents 	overflowExtents;
++}PACKED_S;
++typedef union HFSPlusAttrRecord HFSPlusAttrRecord;
++
++/* Attribute key */
++enum { kHFSMaxAttrNameLen = 127 };
++struct HFSPlusAttrKey {
++	u_int16_t     keyLength;       /* key length (in bytes) */
++	u_int16_t     pad;	       /* set to zero */
++	u_int32_t     fileID;          /* file associated with attribute */
++	u_int32_t     startBlock;      /* first attribue allocation block number for extents */
++	u_int16_t     attrNameLen;     /* number of unicode characters */
++	u_int16_t     attrName[127];   /* attribute name (Unicode) */
++}PACKED_S;
++typedef struct HFSPlusAttrKey HFSPlusAttrKey;
++
++#define kHFSPlusAttrKeyMaximumLength   (sizeof(HFSPlusAttrKey) - sizeof(u_int16_t))
++#define kHFSPlusAttrKeyMinimumLength   (kHFSPlusAttrKeyMaximumLength - (127 * sizeof(u_int16_t)))
++
++#endif /* __APPLE_API_UNSTABLE */
++
++
++/* Key and node lengths */
++enum {
++	kHFSPlusExtentKeyMaximumLength = sizeof(HFSPlusExtentKey) - sizeof(u_int16_t),
++	kHFSExtentKeyMaximumLength	= sizeof(HFSExtentKey) - sizeof(u_int8_t),
++	kHFSPlusCatalogKeyMaximumLength = sizeof(HFSPlusCatalogKey) - sizeof(u_int16_t),
++	kHFSPlusCatalogKeyMinimumLength = kHFSPlusCatalogKeyMaximumLength - sizeof(HFSUniStr255) + sizeof(u_int16_t),
++	kHFSCatalogKeyMaximumLength	= sizeof(HFSCatalogKey) - sizeof(u_int8_t),
++	kHFSCatalogKeyMinimumLength	= kHFSCatalogKeyMaximumLength - (kHFSMaxFileNameChars + 1) + sizeof(u_int8_t),
++	kHFSPlusCatalogMinNodeSize	= 4096,
++	kHFSPlusExtentMinNodeSize	= 512,
++	kHFSPlusAttrMinNodeSize		= 4096
++}PACKED_S;
++
++/* HFS and HFS Plus volume attribute bits */
++enum {
++							/* Bits 0-6 are reserved (always cleared by MountVol call) */
++	kHFSVolumeHardwareLockBit	= 7,		/* volume is locked by hardware */
++	kHFSVolumeUnmountedBit		= 8,		/* volume was successfully unmounted */
++	kHFSVolumeSparedBlocksBit	= 9,		/* volume has bad blocks spared */
++	kHFSVolumeNoCacheRequiredBit = 10,		/* don't cache volume blocks (i.e. RAM or ROM disk) */
++	kHFSBootVolumeInconsistentBit = 11,		/* boot volume is inconsistent (System 7.6 and later) */
++	kHFSCatalogNodeIDsReusedBit = 12,
++	kHFSVolumeJournaledBit = 13,			/* this volume has a journal on it */
++	kHFSVolumeInconsistentBit = 14,			/* serious inconsistencies detected at runtime */
++	kHFSVolumeSoftwareLockBit	= 15,		/* volume is locked by software */
++
++	kHFSVolumeHardwareLockMask	= 1 << kHFSVolumeHardwareLockBit,
++	kHFSVolumeUnmountedMask		= 1 << kHFSVolumeUnmountedBit,
++	kHFSVolumeSparedBlocksMask	= 1 << kHFSVolumeSparedBlocksBit,
++	kHFSVolumeNoCacheRequiredMask = 1 << kHFSVolumeNoCacheRequiredBit,
++	kHFSBootVolumeInconsistentMask = 1 << kHFSBootVolumeInconsistentBit,
++	kHFSCatalogNodeIDsReusedMask = 1 << kHFSCatalogNodeIDsReusedBit,
++	kHFSVolumeJournaledMask	= 1 << kHFSVolumeJournaledBit,
++	kHFSVolumeInconsistentMask = 1 << kHFSVolumeInconsistentBit,
++	kHFSVolumeSoftwareLockMask	= 1 << kHFSVolumeSoftwareLockBit,
++	kHFSMDBAttributesMask		= 0x8380
++}PACKED_S;
++
++
++/* HFS Master Directory Block - 162 bytes */
++/* Stored at sector #2 (3rd sector) and second-to-last sector. */
++struct HFSMasterDirectoryBlock {
++	u_int16_t 		drSigWord;	/* == kHFSSigWord */
++	u_int32_t 		drCrDate;	/* date and time of volume creation */
++	u_int32_t 		drLsMod;	/* date and time of last modification */
++	u_int16_t 		drAtrb;		/* volume attributes */
++	u_int16_t 		drNmFls;	/* number of files in root folder */
++	u_int16_t 		drVBMSt;	/* first block of volume bitmap */
++	u_int16_t 		drAllocPtr;	/* start of next allocation search */
++	u_int16_t 		drNmAlBlks;	/* number of allocation blocks in volume */
++	u_int32_t 		drAlBlkSiz;	/* size (in bytes) of allocation blocks */
++	u_int32_t 		drClpSiz;	/* default clump size */
++	u_int16_t 		drAlBlSt;	/* first allocation block in volume */
++	u_int32_t 		drNxtCNID;	/* next unused catalog node ID */
++	u_int16_t 		drFreeBks;	/* number of unused allocation blocks */
++	u_int8_t 		drVN[kHFSMaxVolumeNameChars + 1];  /* volume name */
++	u_int32_t 		drVolBkUp;	/* date and time of last backup */
++	u_int16_t 		drVSeqNum;	/* volume backup sequence number */
++	u_int32_t 		drWrCnt;	/* volume write count */
++	u_int32_t 		drXTClpSiz;	/* clump size for extents overflow file */
++	u_int32_t 		drCTClpSiz;	/* clump size for catalog file */
++	u_int16_t 		drNmRtDirs;	/* number of directories in root folder */
++	u_int32_t 		drFilCnt;	/* number of files in volume */
++	u_int32_t 		drDirCnt;	/* number of directories in volume */
++	u_int32_t 		drFndrInfo[8];	/* information used by the Finder */
++	u_int16_t 		drEmbedSigWord;	/* embedded volume signature (formerly drVCSize) */
++	HFSExtentDescriptor	drEmbedExtent;	/* embedded volume location and size (formerly drVBMCSize and drCtlCSize) */
++	u_int32_t		drXTFlSize;	/* size of extents overflow file */
++	HFSExtentRecord		drXTExtRec;	/* extent record for extents overflow file */
++	u_int32_t 		drCTFlSize;	/* size of catalog file */
++	HFSExtentRecord 	drCTExtRec;	/* extent record for catalog file */
++}PACKED_S;
++typedef struct HFSMasterDirectoryBlock	HFSMasterDirectoryBlock;
++
++
++#ifdef __APPLE_API_UNSTABLE
++#define SET_HFS_TEXT_ENCODING(hint)  \
++	(0x656e6300 | ((hint) & 0xff))
++#define GET_HFS_TEXT_ENCODING(hint)  \
++	(((hint) & 0xffffff00) == 0x656e6300 ? (hint) & 0x000000ff : 0xffffffffU)
++#endif /* __APPLE_API_UNSTABLE */
++
++
++/* HFS Plus Volume Header - 512 bytes */
++/* Stored at sector #2 (3rd sector) and second-to-last sector. */
++struct HFSPlusVolumeHeader {
++	u_int16_t 	signature;		/* == kHFSPlusSigWord */
++	u_int16_t 	version;		/* == kHFSPlusVersion */
++	u_int32_t 	attributes;		/* volume attributes */
++	u_int32_t 	lastMountedVersion;	/* implementation version which last mounted volume */
++	u_int32_t 	journalInfoBlock;	/* block addr of journal info (if volume is journaled, zero otherwise) */
++
++	u_int32_t 	createDate;		/* date and time of volume creation */
++	u_int32_t 	modifyDate;		/* date and time of last modification */
++	u_int32_t 	backupDate;		/* date and time of last backup */
++	u_int32_t 	checkedDate;		/* date and time of last disk check */
++
++	u_int32_t 	fileCount;		/* number of files in volume */
++	u_int32_t 	folderCount;		/* number of directories in volume */
++
++	u_int32_t 	blockSize;		/* size (in bytes) of allocation blocks */
++	u_int32_t 	totalBlocks;		/* number of allocation blocks in volume (includes this header and VBM*/
++	u_int32_t 	freeBlocks;		/* number of unused allocation blocks */
++
++	u_int32_t 	nextAllocation;		/* start of next allocation search */
++	u_int32_t 	rsrcClumpSize;		/* default resource fork clump size */
++	u_int32_t 	dataClumpSize;		/* default data fork clump size */
++	u_int32_t 	nextCatalogID;		/* next unused catalog node ID */
++
++	u_int32_t 	writeCount;		/* volume write count */
++	u_int64_t 	encodingsBitmap;	/* which encodings have been use  on this volume */
++
++	u_int8_t 	finderInfo[32];		/* information used by the Finder */
++
++	HFSPlusForkData	 allocationFile;	/* allocation bitmap file */
++	HFSPlusForkData  extentsFile;		/* extents B-tree file */
++	HFSPlusForkData  catalogFile;		/* catalog B-tree file */
++	HFSPlusForkData  attributesFile;	/* extended attributes B-tree file */
++	HFSPlusForkData	 startupFile;		/* boot file (secondary loader) */
++}PACKED_S;
++typedef struct HFSPlusVolumeHeader HFSPlusVolumeHeader;
++
++
++/* B-tree structures */
++
++enum BTreeKeyLimits{
++	kMaxKeyLength	= 520
++}PACKED_S;
++
++union BTreeKey{
++	u_int8_t	length8;
++	u_int16_t	length16;
++	u_int8_t	rawData [kMaxKeyLength+2];
++}PACKED_S;
++typedef union BTreeKey BTreeKey;
++
++/* BTNodeDescriptor -- Every B-tree node starts with these fields. */
++struct BTNodeDescriptor {
++	u_int32_t	fLink;			/* next node at this level*/
++	u_int32_t 	bLink;			/* previous node at this level*/
++	int8_t 		kind;			/* kind of node (leaf, index, header, map)*/
++	u_int8_t 	height;			/* zero for header, map; child is one more than parent*/
++	u_int16_t 	numRecords;		/* number of records in this node*/
++	u_int16_t 	reserved;		/* reserved - initialized as zero */
++}PACKED_S;
++typedef struct BTNodeDescriptor BTNodeDescriptor;
++
++/* Constants for BTNodeDescriptor kind */
++enum {
++	kBTLeafNode	= -1,
++	kBTIndexNode	= 0,
++	kBTHeaderNode	= 1,
++	kBTMapNode	= 2
++}PACKED_S;
++
++/* BTHeaderRec -- The first record of a B-tree header node */
++struct BTHeaderRec {
++	u_int16_t	treeDepth;		/* maximum height (usually leaf nodes) */
++	u_int32_t 	rootNode;		/* node number of root node */
++	u_int32_t 	leafRecords;		/* number of leaf records in all leaf nodes */
++	u_int32_t 	firstLeafNode;		/* node number of first leaf node */
++	u_int32_t 	lastLeafNode;		/* node number of last leaf node */
++	u_int16_t 	nodeSize;		/* size of a node, in bytes */
++	u_int16_t 	maxKeyLength;		/* reserved */
++	u_int32_t 	totalNodes;		/* total number of nodes in tree */
++	u_int32_t 	freeNodes;		/* number of unused (free) nodes in tree */
++	u_int16_t 	reserved1;		/* unused */
++	u_int32_t 	clumpSize;		/* reserved */
++	u_int8_t 	btreeType;		/* reserved */
++	u_int8_t 	keyCompareType;		/* Key string Comparison Type */
++	u_int32_t 	attributes;		/* persistent attributes about the tree */
++	u_int32_t 	reserved3[16];		/* reserved */
++}PACKED_S;
++typedef struct BTHeaderRec BTHeaderRec;
++
++/* Constants for BTHeaderRec attributes */
++enum {
++	kBTBadCloseMask		 = 0x00000001,	/* reserved */
++	kBTBigKeysMask		 = 0x00000002,	/* key length field is 16 bits */
++	kBTVariableIndexKeysMask = 0x00000004	/* keys in index nodes are variable length */
++}PACKED_S;
++
++
++/* Catalog Key Name Comparison Type */
++enum {
++	kHFSCaseFolding   = 0xCF,  /* case folding (case-insensitive) */
++	kHFSBinaryCompare = 0xBC  /* binary compare (case-sensitive) */
++}PACKED_S;
++
++/* JournalInfoBlock - Structure that describes where our journal lives */
++struct JournalInfoBlock {
++	u_int32_t	flags;
++    	u_int32_t       device_signature[8];  // signature used to locate our device.
++	u_int64_t       offset;               // byte offset to the journal on the device
++	u_int64_t       size;                 // size in bytes of the journal
++	u_int32_t 	reserved[32];
++}PACKED_S;
++typedef struct JournalInfoBlock JournalInfoBlock;
++
++enum {
++    kJIJournalInFSMask          = 0x00000001,
++    kJIJournalOnOtherDeviceMask = 0x00000002,
++    kJIJournalNeedInitMask      = 0x00000004
++}PACKED_S;
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* __HFS_FORMAT__ */
+diff --git a/include/hfs/hfs_mount.h b/include/hfs/hfs_mount.h
+new file mode 100644
+index 0000000..ad729f2
+--- /dev/null
++++ b/include/hfs/hfs_mount.h
+@@ -0,0 +1,78 @@
++/*
++ * Copyright (c) 2000-2003 Apple Computer, Inc. All rights reserved.
++ *
++ * @APPLE_LICENSE_HEADER_START@
++ *
++ * The contents of this file constitute Original Code as defined in and
++ * are subject to the Apple Public Source License Version 1.1 (the
++ * "License").  You may not use this file except in compliance with the
++ * License.  Please obtain a copy of the License at
++ * http://www.apple.com/publicsource and read it before using this file.
++ *
++ * This Original Code and all software distributed under the License are
++ * distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER
++ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
++ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT.  Please see the
++ * License for the specific language governing rights and limitations
++ * under the License.
++ *
++ * @APPLE_LICENSE_HEADER_END@
++ */
++/*
++ * Copyright (c) 1997-2002 Apple Computer, Inc. All Rights Reserved
++ *
++ */
++
++#ifndef _HFS_MOUNT_H_
++#define _HFS_MOUNT_H_
++
++#include <sys/appleapiopts.h>
++
++#include <sys/mount.h>
++#include <sys/time.h>
++
++/*
++ * Arguments to mount HFS-based filesystems
++ */
++
++#define OVERRIDE_UNKNOWN_PERMISSIONS 0
++
++#define UNKNOWNUID ((uid_t)99)
++#define UNKNOWNGID ((gid_t)99)
++#define UNKNOWNPERMISSIONS (S_IRWXU | S_IROTH | S_IXOTH)		/* 705 */
++
++#ifdef __APPLE_API_UNSTABLE
++struct hfs_mount_args {
++#ifndef KERNEL
++	char	*fspec;			/* block special device to mount */
++#endif
++	uid_t	hfs_uid;		/* uid that owns hfs files (standard HFS only) */
++	gid_t	hfs_gid;		/* gid that owns hfs files (standard HFS only) */
++	mode_t	hfs_mask;		/* mask to be applied for hfs perms  (standard HFS only) */
++	u_int32_t hfs_encoding;		/* encoding for this volume (standard HFS only) */
++	struct	timezone hfs_timezone;	/* user time zone info (standard HFS only) */
++	int		flags;			/* mounting flags, see below */
++	int     journal_tbuffer_size;   /* size in bytes of the journal transaction buffer */
++	int		journal_flags;          /* flags to pass to journal_open/create */
++	int		journal_disable;        /* don't use journaling (potentially dangerous) */
++};
++
++#define HFSFSMNT_NOXONFILES	0x1	/* disable execute permissions for files */
++#define HFSFSMNT_WRAPPER	0x2	/* mount HFS wrapper (if it exists) */
++#define HFSFSMNT_EXTENDED_ARGS  0x4     /* indicates new fields after "flags" are valid */
++
++/*
++ * Sysctl values for HFS
++ */
++#define HFS_ENCODINGBIAS	1	    /* encoding matching CJK bias */
++#define HFS_EXTEND_FS		2
++#define HFS_ENCODINGHINT	3	    /* guess encoding for string */
++#define HFS_ENABLE_JOURNALING   0x082969
++#define HFS_DISABLE_JOURNALING  0x031272
++#define HFS_GET_JOURNAL_INFO    0x6a6e6c69
++#define HFS_SET_PKG_EXTENSIONS  0x121031
++
++#endif /* __APPLE_API_UNSTABLE */
++
++#endif /* ! _HFS_MOUNT_H_ */
+diff --git a/include/sys/appleapiopts.h b/include/sys/appleapiopts.h
+new file mode 100644
+index 0000000..4d2061f
+--- /dev/null
++++ b/include/sys/appleapiopts.h
+@@ -0,0 +1,52 @@
++/*
++ * Copyright (c) 2002 Apple Computer, Inc. All rights reserved.
++ *
++ * @APPLE_LICENSE_HEADER_START@
++ *
++ * The contents of this file constitute Original Code as defined in and
++ * are subject to the Apple Public Source License Version 1.1 (the
++ * "License").  You may not use this file except in compliance with the
++ * License.  Please obtain a copy of the License at
++ * http://www.apple.com/publicsource and read it before using this file.
++ *
++ * This Original Code and all software distributed under the License are
++ * distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER
++ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
++ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT.  Please see the
++ * License for the specific language governing rights and limitations
++ * under the License.
++ *
++ * @APPLE_LICENSE_HEADER_END@
++ */
++
++#ifndef __SYS_APPLEAPIOPTS_H__
++#define __SYS_APPLEAPIOPTS_H__
++
++
++#ifndef __APPLE_API_STANDARD
++#define __APPLE_API_STANDARD
++#endif /* __APPLE_API_STANDARD */
++
++#ifndef __APPLE_API_STABLE
++#define __APPLE_API_STABLE
++#endif /* __APPLE_API_STABLE */
++
++#ifndef __APPLE_API_STRICT_CONFORMANCE
++
++#ifndef __APPLE_API_EVOLVING
++#define __APPLE_API_EVOLVING
++#endif /* __APPLE_API_EVOLVING */
++
++#ifndef __APPLE_API_UNSTABLE
++#define __APPLE_API_UNSTABLE
++#endif /* __APPLE_API_UNSTABLE */
++
++#ifndef __APPLE_API_OBSOLETE
++#define __APPLE_API_OBSOLETE
++#endif /* __APPLE_API_OBSOLETE */
++
++#endif /* __APPLE_API_STRICT_CONFORMANCE */
++
++#endif /* __SYS_APPLEAPIOPTS_H__ */
++

--- a/utils/hfsprogs/patches/0004-Fix-compilation-on-64-bit-arches.patch
+++ b/utils/hfsprogs/patches/0004-Fix-compilation-on-64-bit-arches.patch
@@ -1,0 +1,131 @@
+From: =?UTF-8?q?Rog=C3=A9rio=20Brito?= <rbrito@ime.usp.br>
+Date: Thu, 24 Oct 2013 01:11:21 -0200
+Subject: Fix compilation on 64-bit arches
+
+---
+ fsck_hfs.tproj/dfalib/BTreePrivate.h |  5 ++++-
+ fsck_hfs.tproj/dfalib/SControl.c     |  8 ++++----
+ fsck_hfs.tproj/dfalib/SVerify1.c     | 14 +++++++-------
+ fsck_hfs.tproj/dfalib/hfs_endian.c   |  2 +-
+ 4 files changed, 16 insertions(+), 13 deletions(-)
+
+diff --git a/fsck_hfs.tproj/dfalib/BTreePrivate.h b/fsck_hfs.tproj/dfalib/BTreePrivate.h
+index 058c75b..2fc2f28 100644
+--- a/fsck_hfs.tproj/dfalib/BTreePrivate.h
++++ b/fsck_hfs.tproj/dfalib/BTreePrivate.h
+@@ -104,6 +104,9 @@ typedef enum {
+ 
+ ///////////////////////////////////// Types /////////////////////////////////////
+ 
++// Forward declaration from Scavenger.h
++struct BTreeExtensionsRec;
++
+ typedef struct BTreeControlBlock {					// fields specific to BTree CBs
+ 
+ 	UInt8		keyCompareType;   /* Key string Comparison Type */
+@@ -144,7 +147,7 @@ typedef struct BTreeControlBlock {					// fields specific to BTree CBs
+ 	UInt32						 numPossibleHints;	// Looks like a formated hint
+ 	UInt32						 numValidHints;		// Hint used to find correct record.
+ 	
+-	UInt32						 refCon;			//	Used by DFA to point to private data.
++	struct BTreeExtensionsRec			*refCon;			//	Used by DFA to point to private data.
+ 	SFCB						*fcbPtr;		// fcb of btree file
+ 	
+ } BTreeControlBlock, *BTreeControlBlockPtr;
+diff --git a/fsck_hfs.tproj/dfalib/SControl.c b/fsck_hfs.tproj/dfalib/SControl.c
+index 37eb242..4ce9e16 100644
+--- a/fsck_hfs.tproj/dfalib/SControl.c
++++ b/fsck_hfs.tproj/dfalib/SControl.c
+@@ -1034,7 +1034,7 @@ static int ScavTerm( SGlobPtr GPtr )
+ 		btcbP = (BTreeControlBlock*)fcbP->fcbBtree;
+ 		if ( btcbP != nil)
+ 		{
+-			if( btcbP->refCon != (UInt32)nil )
++			if( btcbP->refCon != nil )
+ 			{
+ 				if(((BTreeExtensionsRec*)btcbP->refCon)->BTCBMPtr != nil)
+ 				{
+@@ -1043,13 +1043,13 @@ static int ScavTerm( SGlobPtr GPtr )
+ 				}
+ 				DisposeMemory( (Ptr)btcbP->refCon );
+ 				err = MemError();
+-				btcbP->refCon = (UInt32)nil;
++				btcbP->refCon = nil;
+ 			}
+ 				
+ 			fcbP = GPtr->calculatedCatalogFCB;	//	release catalog BTree bit map
+ 			btcbP = (BTreeControlBlock*)fcbP->fcbBtree;
+ 				
+-			if( btcbP->refCon != (UInt32)nil )
++			if( btcbP->refCon != nil )
+ 			{
+ 				if(((BTreeExtensionsRec*)btcbP->refCon)->BTCBMPtr != nil)
+ 				{
+@@ -1058,7 +1058,7 @@ static int ScavTerm( SGlobPtr GPtr )
+ 				}
+ 				DisposeMemory( (Ptr)btcbP->refCon );
+ 				err = MemError();
+-				btcbP->refCon = (UInt32)nil;
++				btcbP->refCon = nil;
+ 			}
+ 		}
+ 	}
+diff --git a/fsck_hfs.tproj/dfalib/SVerify1.c b/fsck_hfs.tproj/dfalib/SVerify1.c
+index c272d4d..a273bf3 100644
+--- a/fsck_hfs.tproj/dfalib/SVerify1.c
++++ b/fsck_hfs.tproj/dfalib/SVerify1.c
+@@ -789,8 +789,8 @@ OSErr	CreateExtentsBTreeControlBlock( SGlobPtr GPtr )
+ 	//
+ 	//	set up our DFA extended BTCB area.  Will we have enough memory on all HFS+ volumes.
+ 	//
+-	btcb->refCon = (UInt32) AllocateClearMemory( sizeof(BTreeExtensionsRec) );			// allocate space for our BTCB extensions
+-	if ( btcb->refCon == (UInt32) nil ) {
++	btcb->refCon = AllocateClearMemory( sizeof(BTreeExtensionsRec) );			// allocate space for our BTCB extensions
++	if ( btcb->refCon == nil ) {
+ 		err = R_NoMem;
+ 		goto exit;
+ 	}
+@@ -1144,8 +1144,8 @@ OSErr	CreateCatalogBTreeControlBlock( SGlobPtr GPtr )
+ 	//	set up our DFA extended BTCB area.  Will we have enough memory on all HFS+ volumes.
+ 	//
+ 
+-	btcb->refCon = (UInt32) AllocateClearMemory( sizeof(BTreeExtensionsRec) );			// allocate space for our BTCB extensions
+-	if ( btcb->refCon == (UInt32)nil ) {
++	btcb->refCon = AllocateClearMemory( sizeof(BTreeExtensionsRec) );			// allocate space for our BTCB extensions
++	if ( btcb->refCon == nil ) {
+ 		err = R_NoMem;
+ 		goto exit;
+ 	}
+@@ -1779,8 +1779,8 @@ OSErr	CreateAttributesBTreeControlBlock( SGlobPtr GPtr )
+ 	//
+ 	//	set up our DFA extended BTCB area.  Will we have enough memory on all HFS+ volumes.
+ 	//
+-	btcb->refCon = (UInt32) AllocateClearMemory( sizeof(BTreeExtensionsRec) );			// allocate space for our BTCB extensions
+-	if ( btcb->refCon == (UInt32)nil ) {
++	btcb->refCon = AllocateClearMemory( sizeof(BTreeExtensionsRec) );			// allocate space for our BTCB extensions
++	if ( btcb->refCon == nil ) {
+ 		err = R_NoMem;
+ 		goto exit;
+ 	}
+@@ -1793,7 +1793,7 @@ OSErr	CreateAttributesBTreeControlBlock( SGlobPtr GPtr )
+ 	}
+ 	else
+ 	{
+-		if ( btcb->refCon == (UInt32)nil ) {
++		if ( btcb->refCon == nil ) {
+ 			err = R_NoMem;
+ 			goto exit;
+ 		}
+diff --git a/fsck_hfs.tproj/dfalib/hfs_endian.c b/fsck_hfs.tproj/dfalib/hfs_endian.c
+index 69500c1..3cc9eb4 100755
+--- a/fsck_hfs.tproj/dfalib/hfs_endian.c
++++ b/fsck_hfs.tproj/dfalib/hfs_endian.c
+@@ -437,7 +437,7 @@ hfs_swap_HFSPlusBTInternalNode (
+     BTNodeDescriptor *srcDesc = src->buffer;
+     UInt16 *srcOffs = (UInt16 *)((char *)src->buffer + (src->blockSize - (srcDesc->numRecords * sizeof (UInt16))));
+ 	char *nextRecord;	/*  Points to start of record following current one */
+-    UInt32 i;
++    int i;
+     UInt32 j;
+ 
+     if (fileID == kHFSExtentsFileID) {

--- a/utils/hfsprogs/patches/0005-Remove-Apple-specific-p-from-strings.patch
+++ b/utils/hfsprogs/patches/0005-Remove-Apple-specific-p-from-strings.patch
@@ -1,0 +1,291 @@
+From: =?UTF-8?q?Rog=C3=A9rio=20Brito?= <rbrito@ime.usp.br>
+Date: Thu, 24 Oct 2013 01:11:21 -0200
+Subject: Remove (Apple-specific?) \p from strings
+
+Modify the way that debug messages are sent to the user, by eliminating one
+character of them.
+---
+ fsck_hfs.tproj/dfalib/BTreeTreeOps.c | 48 ++++++++++++++++++------------------
+ fsck_hfs.tproj/dfalib/SBTree.c       | 14 +++++------
+ 2 files changed, 31 insertions(+), 31 deletions(-)
+
+diff --git a/fsck_hfs.tproj/dfalib/BTreeTreeOps.c b/fsck_hfs.tproj/dfalib/BTreeTreeOps.c
+index b812b14..37fb170 100644
+--- a/fsck_hfs.tproj/dfalib/BTreeTreeOps.c
++++ b/fsck_hfs.tproj/dfalib/BTreeTreeOps.c
+@@ -223,7 +223,7 @@ OSStatus	SearchTree	(BTreeControlBlockPtr	 btreePtr,
+         //
+         if (curNodeNum == 0)
+         {
+-//          Panic("\pSearchTree: curNodeNum is zero!");
++            Panic("SearchTree: curNodeNum is zero!");
+             err = fsBTInvalidNodeErr;
+             goto ErrorExit;
+         }
+@@ -433,7 +433,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+ 		M_ExitOnError (err);
+ 		
+ 		if ( DEBUG_BUILD && updateParent && newRoot )
+-			DebugStr("\p InsertLevel: New root from primary key, update from secondary key...");
++			DebugStr("InsertLevel: New root from primary key, update from secondary key...");
+ 	}
+ 
+ 	//////////////////////// Update Parent(s) ///////////////////////////////
+@@ -448,7 +448,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+ 		
+ 		secondaryKey = nil;
+ 		
+-		PanicIf ( (level == btreePtr->treeDepth), "\p InsertLevel: unfinished insert!?");
++		PanicIf ( (level == btreePtr->treeDepth), "InsertLevel: unfinished insert!?");
+ 
+ 		++level;
+ 
+@@ -456,7 +456,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+ 		index = treePathTable [level].index;
+ 		parentNodeNum = treePathTable [level].node;
+ 
+-		PanicIf ( parentNodeNum == 0, "\p InsertLevel: parent node is zero!?");
++		PanicIf ( parentNodeNum == 0, "InsertLevel: parent node is zero!?");
+ 
+ 		err = GetNode (btreePtr, parentNodeNum, &parentNode);	// released as target node in next level up
+ 		M_ExitOnError (err);
+@@ -470,7 +470,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+ 		{
+ 			//¥¥Êdebug: check if ptr == targetNodeNum
+ 			GetRecordByIndex (btreePtr, parentNode.buffer, index, &keyPtr, &recPtr, &recSize);
+-			PanicIf( (*(UInt32 *) recPtr) != targetNodeNum, "\p InsertLevel: parent ptr doesn't match target node!");
++			PanicIf( (*(UInt32 *) recPtr) != targetNodeNum, "InsertLevel: parent ptr doesn't match target node!");
+ 			
+ 			// need to delete and re-insert this parent key/ptr
+ 			// we delete it here and it gets re-inserted in the
+@@ -532,7 +532,7 @@ ErrorExit:
+ 	(void) ReleaseNode (btreePtr, targetNode);
+ 	(void) ReleaseNode (btreePtr, &siblingNode);
+ 
+-	Panic ("\p InsertLevel: an error occured!");
++	Panic ("InsertLevel: an error occured!");
+ 
+ 	return	err;
+ 
+@@ -566,7 +566,7 @@ static OSErr	InsertNode	(BTreeControlBlockPtr	 btreePtr,
+ 
+ 	*rootSplit = false;
+ 	
+-	PanicIf ( targetNode->buffer == siblingNode->buffer, "\p InsertNode: targetNode == siblingNode, huh?");
++	PanicIf ( targetNode->buffer == siblingNode->buffer, "InsertNode: targetNode == siblingNode, huh?");
+ 	
+ 	leftNodeNum = ((NodeDescPtr) targetNode->buffer)->bLink;
+ 	rightNodeNum = ((NodeDescPtr) targetNode->buffer)->fLink;
+@@ -606,7 +606,7 @@ static OSErr	InsertNode	(BTreeControlBlockPtr	 btreePtr,
+ 	
+ 	if ( leftNodeNum > 0 )
+ 	{
+-		PanicIf ( siblingNode->buffer != nil, "\p InsertNode: siblingNode already aquired!");
++		PanicIf ( siblingNode->buffer != nil, "InsertNode: siblingNode already aquired!");
+ 
+ 		if ( siblingNode->buffer == nil )
+ 		{
+@@ -614,7 +614,7 @@ static OSErr	InsertNode	(BTreeControlBlockPtr	 btreePtr,
+ 			M_ExitOnError (err);
+ 		}
+ 
+-		PanicIf ( ((NodeDescPtr) siblingNode->buffer)->fLink != nodeNum, "\p InsertNode, RotateLeft: invalid sibling link!" );
++		PanicIf ( ((NodeDescPtr) siblingNode->buffer)->fLink != nodeNum, "InsertNode, RotateLeft: invalid sibling link!" );
+ 
+ 		if ( !key->skipRotate )		// are rotates allowed?
+ 		{
+@@ -703,7 +703,7 @@ OSStatus	DeleteTree			(BTreeControlBlockPtr		 btreePtr,
+ 
+ 	targetNodeNum = treePathTable[level].node;
+ 	targetNodePtr = targetNode->buffer;
+-	PanicIf (targetNodePtr == nil, "\pDeleteTree: targetNode has nil buffer!");
++	PanicIf (targetNodePtr == nil, "DeleteTree: targetNode has nil buffer!");
+ 
+ 	DeleteRecord (btreePtr, targetNodePtr, index);
+ 		
+@@ -797,7 +797,7 @@ OSStatus	DeleteTree			(BTreeControlBlockPtr		 btreePtr,
+ 			 
+ 			//¥¥Êdebug: check if ptr == targetNodeNum
+ 			GetRecordByIndex (btreePtr, parentNode.buffer, index, &keyPtr, &recPtr, &recSize);
+-			PanicIf( (*(UInt32 *) recPtr) != targetNodeNum, "\p DeleteTree: parent ptr doesn't match targetNodeNum!!");
++			PanicIf( (*(UInt32 *) recPtr) != targetNodeNum, " DeleteTree: parent ptr doesn't match targetNodeNum!!");
+ 			
+ 			// need to delete and re-insert this parent key/ptr
+ 			DeleteRecord (btreePtr, parentNode.buffer, index);
+@@ -1018,7 +1018,7 @@ static OSStatus	RotateLeft		(BTreeControlBlockPtr		 btreePtr,
+ 										keyPtr, keyLength, recPtr, recSize);
+ 			if ( !didItFit )
+ 			{
+-				Panic ("\pRotateLeft: InsertKeyRecord (left) returned false!");
++				Panic ("RotateLeft: InsertKeyRecord (left) returned false!");
+ 				err = fsBTBadRotateErr;
+ 				goto ErrorExit;
+ 			}
+@@ -1031,7 +1031,7 @@ static OSStatus	RotateLeft		(BTreeControlBlockPtr		 btreePtr,
+ 			didItFit = RotateRecordLeft (btreePtr, leftNode, rightNode);
+ 			if ( !didItFit )
+ 			{
+-				Panic ("\pRotateLeft: RotateRecordLeft returned false!");
++				Panic ("RotateLeft: RotateRecordLeft returned false!");
+ 				err = fsBTBadRotateErr;
+ 				goto ErrorExit;
+ 			}
+@@ -1048,7 +1048,7 @@ static OSStatus	RotateLeft		(BTreeControlBlockPtr		 btreePtr,
+ 									keyPtr, keyLength, recPtr, recSize);
+ 		if ( !didItFit )
+ 		{
+-			Panic ("\pRotateLeft: InsertKeyRecord (right) returned false!");
++			Panic ("RotateLeft: InsertKeyRecord (right) returned false!");
+ 			err = fsBTBadRotateErr;
+ 			goto ErrorExit;
+ 		}
+@@ -1117,7 +1117,7 @@ static OSStatus	SplitLeft		(BTreeControlBlockPtr		 btreePtr,
+ 	right = rightNode->buffer;
+ 	left  = leftNode->buffer;
+ 	
+-	PanicIf ( right->bLink != 0 && left == 0, "\p SplitLeft: left sibling missing!?" );
++	PanicIf ( right->bLink != 0 && left == 0, " SplitLeft: left sibling missing!?" );
+ 	
+ 	//¥¥ type should be kLeafNode or kIndexNode
+ 	
+@@ -1240,8 +1240,8 @@ static OSStatus	AddNewRootNode	(BTreeControlBlockPtr	 btreePtr,
+ 	Boolean				didItFit;
+ 	UInt16				keyLength;	
+ 	
+-	PanicIf (leftNode == nil, "\pAddNewRootNode: leftNode == nil");
+-	PanicIf (rightNode == nil, "\pAddNewRootNode: rightNode == nil");
++	PanicIf (leftNode == nil, "AddNewRootNode: leftNode == nil");
++	PanicIf (rightNode == nil, "AddNewRootNode: rightNode == nil");
+ 	
+ 	
+ 	/////////////////////// Initialize New Root Node ////////////////////////////
+@@ -1264,7 +1264,7 @@ static OSStatus	AddNewRootNode	(BTreeControlBlockPtr	 btreePtr,
+ 	didItFit = InsertKeyRecord ( btreePtr, rootNode.buffer, 0, keyPtr, keyLength,
+ 								 (UInt8 *) &rightNode->bLink, 4 );
+ 
+-	PanicIf ( !didItFit, "\pAddNewRootNode:InsertKeyRecord failed for left index record");
++	PanicIf ( !didItFit, "AddNewRootNode:InsertKeyRecord failed for left index record");
+ 
+ 
+ 	//////////////////// Insert Right Node Index Record /////////////////////////
+@@ -1275,7 +1275,7 @@ static OSStatus	AddNewRootNode	(BTreeControlBlockPtr	 btreePtr,
+ 	didItFit = InsertKeyRecord ( btreePtr, rootNode.buffer, 1, keyPtr, keyLength,
+ 								 (UInt8 *) &leftNode->fLink, 4 );
+ 
+-	PanicIf ( !didItFit, "\pAddNewRootNode:InsertKeyRecord failed for right index record");
++	PanicIf ( !didItFit, "AddNewRootNode:InsertKeyRecord failed for right index record");
+ 
+ 
+ #if DEBUG_TREEOPS
+@@ -1355,7 +1355,7 @@ static OSStatus	SplitRight		(BTreeControlBlockPtr		 btreePtr,
+ 	}
+ 	rightPtr = rightNodePtr->buffer;
+ 	
+-	PanicIf ( leftPtr->fLink != 0 && rightPtr == 0, "\p SplitRight: right sibling missing!?" );
++	PanicIf ( leftPtr->fLink != 0 && rightPtr == 0, "SplitRight: right sibling missing!?" );
+ 	
+ 	//¥¥ type should be kLeafNode or kIndexNode
+ 	
+@@ -1557,7 +1557,7 @@ static OSStatus	RotateRight		(BTreeControlBlockPtr		 btreePtr,
+ 									keyPtr, keyLength, recPtr, recSize);
+ 		if ( !didItFit )
+ 		{
+-			Panic ("\pRotateRight: InsertKeyRecord (left) returned false!");
++			Panic ("RotateRight: InsertKeyRecord (left) returned false!");
+ 			err = fsBTBadRotateErr;
+ 			goto ErrorExit;
+ 		}
+@@ -1572,7 +1572,7 @@ static OSStatus	RotateRight		(BTreeControlBlockPtr		 btreePtr,
+ 		didItFit = RotateRecordRight( btreePtr, leftNodePtr, rightNodePtr );
+ 		if ( !didItFit )
+ 		{
+-			Panic ("\pRotateRight: RotateRecordRight returned false!");
++			Panic ("RotateRight: RotateRecordRight returned false!");
+ 			err = fsBTBadRotateErr;
+ 			goto ErrorExit;
+ 		}
+@@ -1583,7 +1583,7 @@ static OSStatus	RotateRight		(BTreeControlBlockPtr		 btreePtr,
+ 										keyPtr, keyLength, recPtr, recSize);
+ 			if ( !didItFit )
+ 			{
+-				Panic ("\pRotateRight: InsertKeyRecord (left) returned false!");
++				Panic ("RotateRight: InsertKeyRecord (left) returned false!");
+ 				err = fsBTBadRotateErr;
+ 				goto ErrorExit;
+ 			}
+@@ -1607,7 +1607,7 @@ static OSStatus	RotateRight		(BTreeControlBlockPtr		 btreePtr,
+ 									keyPtr, keyLength, recPtr, recSize);
+ 		if ( !didItFit )
+ 		{
+-			Panic ("\pRotateRight: InsertKeyRecord (right) returned false!");
++			Panic ("RotateRight: InsertKeyRecord (right) returned false!");
+ 			err = fsBTBadRotateErr;
+ 			goto ErrorExit;
+ 		}
+diff --git a/fsck_hfs.tproj/dfalib/SBTree.c b/fsck_hfs.tproj/dfalib/SBTree.c
+index cd81b13..eeb4e8c 100644
+--- a/fsck_hfs.tproj/dfalib/SBTree.c
++++ b/fsck_hfs.tproj/dfalib/SBTree.c
+@@ -103,7 +103,7 @@ OSErr SearchBTreeRecord(SFCB *fcb, const void* key, UInt32 hint, void* foundKey,
+ 			CopyMemory(&resultIterator->key, foundKey, CalcKeySize(btcb, &resultIterator->key));	//¥¥ warning, this could overflow user's buffer!!!
+ 
+ 		if ( DEBUG_BUILD && !ValidHFSRecord(data, btcb, *dataSize) )
+-			DebugStr("\pSearchBTreeRecord: bad record?");
++			DebugStr("SearchBTreeRecord: bad record?");
+ 	}
+ 
+ ErrorExit:
+@@ -211,7 +211,7 @@ OSErr GetBTreeRecord(SFCB *fcb, SInt16 selectionIndex, void* key, void* data, UI
+ 		CopyMemory(&iterator->key, key, CalcKeySize(btcb, &iterator->key));	//¥¥ warning, this could overflow user's buffer!!!
+ 		
+ 		if ( DEBUG_BUILD && !ValidHFSRecord(data, btcb, *dataSize) )
+-			DebugStr("\pGetBTreeRecord: bad record?");
++			DebugStr("GetBTreeRecord: bad record?");
+ 
+ 	}
+ 	
+@@ -243,7 +243,7 @@ OSErr InsertBTreeRecord(SFCB *fcb, const void* key, const void* data, UInt16 dat
+ 	CopyMemory(key, &iterator.key, CalcKeySize(btcb, (BTreeKey *) key));	//¥¥ should we range check against maxkeylen?
+ 
+ 	if ( DEBUG_BUILD && !ValidHFSRecord(data, btcb, dataSize) )
+-		DebugStr("\pInsertBTreeRecord: bad record?");
++		DebugStr("InsertBTreeRecord: bad record?");
+ 
+ 	result = BTInsertRecord( fcb, &iterator, &btRecord, dataSize );
+ 
+@@ -305,7 +305,7 @@ OSErr ReplaceBTreeRecord(SFCB *fcb, const void* key, UInt32 hint, void *newData,
+ 	CopyMemory(key, &iterator.key, CalcKeySize(btcb, (BTreeKey *) key));		//¥¥ should we range check against maxkeylen?
+ 
+ 	if ( DEBUG_BUILD && !ValidHFSRecord(newData, btcb, dataSize) )
+-		DebugStr("\pReplaceBTreeRecord: bad record?");
++		DebugStr("ReplaceBTreeRecord: bad record?");
+ 
+ 	result = BTReplaceRecord( fcb, &iterator, &btRecord, dataSize );
+ 
+@@ -344,7 +344,7 @@ SetEndOfForkProc ( SFCB *filePtr, FSSize minEOF, FSSize maxEOF )
+ 	else
+ 	{
+ 		if ( DEBUG_BUILD )
+-			DebugStr("\pSetEndOfForkProc: minEOF is smaller than current size!");
++			DebugStr("SetEndOfForkProc: minEOF is smaller than current size!");
+ 		return -1;
+ 	}
+ 
+@@ -370,7 +370,7 @@ SetEndOfForkProc ( SFCB *filePtr, FSSize minEOF, FSSize maxEOF )
+ 	//	Make sure we got at least as much space as we needed
+ 	//
+ 	if (filePtr->fcbLogicalSize < minEOF) {
+-		Panic("\pSetEndOfForkProc: disk too full to extend B-tree file");
++		Panic("SetEndOfForkProc: disk too full to extend B-tree file");
+ 		return dskFulErr;
+ 	}
+ 	
+@@ -442,7 +442,7 @@ static OSErr CheckBTreeKey(const BTreeKey *key, const BTreeControlBlock *btcb)
+ 	if ( (keyLen < 6) || (keyLen > btcb->maxKeyLength) )
+ 	{
+ 		if ( DEBUG_BUILD )
+-			DebugStr("\pCheckBTreeKey: bad key length!");
++			DebugStr("CheckBTreeKey: bad key length!");
+ 		return fsBTInvalidKeyLengthErr;
+ 	}
+ 	

--- a/utils/hfsprogs/patches/0006-Adjust-types-for-printing.patch
+++ b/utils/hfsprogs/patches/0006-Adjust-types-for-printing.patch
@@ -1,0 +1,37 @@
+From: =?UTF-8?q?Rog=C3=A9rio=20Brito?= <rbrito@ime.usp.br>
+Date: Thu, 24 Oct 2013 01:11:21 -0200
+Subject: Adjust types for printing
+
+Try to address the issues of a given integral type having different sizes
+in 32 and 64-bit architectures.
+---
+ fsck_hfs.tproj/dfalib/SControl.c   | 2 +-
+ fsck_hfs.tproj/dfalib/hfs_endian.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/fsck_hfs.tproj/dfalib/SControl.c b/fsck_hfs.tproj/dfalib/SControl.c
+index 4ce9e16..8b03ece 100644
+--- a/fsck_hfs.tproj/dfalib/SControl.c
++++ b/fsck_hfs.tproj/dfalib/SControl.c
+@@ -776,7 +776,7 @@ static int ScavSetUp( SGlob *GPtr)
+ 		pointer = (ScavStaticStructures *) AllocateClearMemory( sizeof(ScavStaticStructures) );
+ 		if ( pointer == nil ) {
+ 			if ( GPtr->logLevel >= kDebugLog ) {
+-				printf( "\t error %d - could not allocate %ld bytes of memory \n",
++				printf( "\t error %d - could not allocate %i bytes of memory \n",
+ 					R_NoMem, sizeof(ScavStaticStructures) );
+ 			}
+ 			return( R_NoMem );
+diff --git a/fsck_hfs.tproj/dfalib/hfs_endian.c b/fsck_hfs.tproj/dfalib/hfs_endian.c
+index 3cc9eb4..6ca2ac1 100755
+--- a/fsck_hfs.tproj/dfalib/hfs_endian.c
++++ b/fsck_hfs.tproj/dfalib/hfs_endian.c
+@@ -563,7 +563,7 @@ hfs_swap_HFSPlusBTInternalNode (
+             /* Make sure name length is consistent with key length */
+             if (keyLength < sizeof(srcKey->parentID) + sizeof(srcKey->nodeName.length) +
+                 srcKey->nodeName.length*sizeof(srcKey->nodeName.unicode[0])) {
+-				if (debug) printf("hfs_swap_HFSPlusBTInternalNode: catalog record #%d keyLength=%d expected=%lu\n",
++				if (debug) printf("hfs_swap_HFSPlusBTInternalNode: catalog record #%d keyLength=%d expected=%i\n",
+ 					srcDesc->numRecords-i, keyLength, sizeof(srcKey->parentID) + sizeof(srcKey->nodeName.length) +
+                     srcKey->nodeName.length*sizeof(srcKey->nodeName.unicode[0]));
+ 				WriteError(fcb->fcbVolume->vcbGPtr, E_KeyLen, fcb->fcbFileID, src->blockNum);

--- a/utils/hfsprogs/patches/0007-Fix-path-for-HFS-wrapper-block.patch
+++ b/utils/hfsprogs/patches/0007-Fix-path-for-HFS-wrapper-block.patch
@@ -1,0 +1,23 @@
+From: =?UTF-8?q?Rog=C3=A9rio=20Brito?= <rbrito@ime.usp.br>
+Date: Thu, 24 Oct 2013 01:11:21 -0200
+Subject: Fix path for HFS wrapper block
+
+Fix the installation of the HFS wrapper block to be compliant in Linux
+systems (since it is arch independent).
+---
+ newfs_hfs.tproj/makehfs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/newfs_hfs.tproj/makehfs.c b/newfs_hfs.tproj/makehfs.c
+index 7609779..2233ef7 100644
+--- a/newfs_hfs.tproj/makehfs.c
++++ b/newfs_hfs.tproj/makehfs.c
+@@ -70,7 +70,7 @@ extern Boolean _CFStringGetFileSystemRepresentation(CFStringRef string, UInt8 *b
+ #include "readme.h"
+ 
+ 
+-#define HFS_BOOT_DATA	"/usr/share/misc/hfsbootdata"
++#define HFS_BOOT_DATA	"/usr/share/hfsprogs/hfsbootdata"
+ 
+ #define HFS_JOURNAL_FILE	".journal"
+ #define HFS_JOURNAL_INFO	".journal_info_block"

--- a/utils/hfsprogs/patches/0008-Provide-command-line-option-a.patch
+++ b/utils/hfsprogs/patches/0008-Provide-command-line-option-a.patch
@@ -1,0 +1,40 @@
+From: =?UTF-8?q?Rog=C3=A9rio=20Brito?= <rbrito@ime.usp.br>
+Date: Thu, 24 Oct 2013 01:11:21 -0200
+Subject: Provide command line option -a
+
+Create a new command line option (-a) for the fsck.hfsplus that has the same
+behavior that the -p option has, for greater compatibility with other tools.
+---
+ fsck_hfs.tproj/fsck_hfs.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/fsck_hfs.tproj/fsck_hfs.c b/fsck_hfs.tproj/fsck_hfs.c
+index f1a18bd..6117698 100644
+--- a/fsck_hfs.tproj/fsck_hfs.c
++++ b/fsck_hfs.tproj/fsck_hfs.c
+@@ -104,7 +104,7 @@ main(argc, argv)
+ 	else
+ 		progname = *argv;
+ 
+-	while ((ch = getopt(argc, argv, "c:D:dfglm:npqruy")) != EOF) {
++	while ((ch = getopt(argc, argv, "c:D:dfglm:napqruy")) != EOF) {
+ 		switch (ch) {
+ 		case 'c':
+ 			/* Cache size to use in fsck_hfs */
+@@ -169,6 +169,7 @@ main(argc, argv)
+ 			yflag = 0;
+ 			break;
+ 
++		case 'a':
+ 		case 'p':
+ 			preen++;
+ 			break;
+@@ -572,7 +573,7 @@ usage()
+ 	(void) fprintf(stderr, "  l = live fsck (lock down and test-only)\n");
+ 	(void) fprintf(stderr, "  m arg = octal mode used when creating lost+found directory \n");
+ 	(void) fprintf(stderr, "  n = assume a no response \n");
+-	(void) fprintf(stderr, "  p = just fix normal inconsistencies \n");
++	(void) fprintf(stderr, "  p, a = just fix normal inconsistencies \n");
+ 	(void) fprintf(stderr, "  q = quick check returns clean, dirty, or failure \n");
+ 	(void) fprintf(stderr, "  r = rebuild catalog btree \n");
+ 	(void) fprintf(stderr, "  u = usage \n");

--- a/utils/hfsprogs/patches/0009-Rename-dprintf-to-dbg_printf.patch
+++ b/utils/hfsprogs/patches/0009-Rename-dprintf-to-dbg_printf.patch
@@ -1,0 +1,187 @@
+From: =?UTF-8?q?Rog=C3=A9rio=20Brito?= <rbrito@ime.usp.br>
+Date: Thu, 24 Oct 2013 01:11:21 -0200
+Subject: Rename dprintf to dbg_printf
+
+---
+ fsck_hfs.tproj/dfalib/SRepair.c  | 18 +++++++++---------
+ fsck_hfs.tproj/dfalib/SVerify1.c |  6 +++---
+ fsck_hfs.tproj/fsck_debug.c      | 10 +++++-----
+ fsck_hfs.tproj/fsck_debug.h      | 10 +++++-----
+ 4 files changed, 22 insertions(+), 22 deletions(-)
+
+diff --git a/fsck_hfs.tproj/dfalib/SRepair.c b/fsck_hfs.tproj/dfalib/SRepair.c
+index 8eb759c..89c12d6 100644
+--- a/fsck_hfs.tproj/dfalib/SRepair.c
++++ b/fsck_hfs.tproj/dfalib/SRepair.c
+@@ -1825,13 +1825,13 @@ static OSErr FixAttrSize(SGlobPtr GPtr, RepairOrderPtr p)
+ 	result = BTSearchRecord(GPtr->calculatedAttributesFCB, &iterator, 
+ 				kInvalidMRUCacheKey, &btRecord, &recSize, &iterator);
+ 	if (result) {
+-		dprintf (d_error|d_xattr, "%s: Cannot find attribute record (err = %d)\n", __FUNCTION__, result);
++		dbg_printf (d_error|d_xattr, "%s: Cannot find attribute record (err = %d)\n", __FUNCTION__, result);
+ 		goto out;
+ 	}
+ 
+ 	/* We should only get record of type kHFSPlusAttrForkData */
+ 	if (record.recordType != kHFSPlusAttrForkData) {
+-		dprintf (d_error|d_xattr, "%s: Record found is not attribute fork data\n", __FUNCTION__);
++		dbg_printf (d_error|d_xattr, "%s: Record found is not attribute fork data\n", __FUNCTION__);
+ 		result = btNotFound;
+ 		goto out;
+ 	}
+@@ -1862,7 +1862,7 @@ static OSErr FixAttrSize(SGlobPtr GPtr, RepairOrderPtr p)
+ 		result = BTReplaceRecord(GPtr->calculatedAttributesFCB, &iterator,
+ 					&btRecord, recSize);
+ 		if (result) {
+-			dprintf (d_error|d_xattr, "%s: Cannot replace attribute record (err=%d)\n", __FUNCTION__, result);
++			dbg_printf (d_error|d_xattr, "%s: Cannot replace attribute record (err=%d)\n", __FUNCTION__, result);
+ 			goto out;
+ 		}
+ 	}
+@@ -2058,7 +2058,7 @@ del_overflow_extents:
+ 
+ 		/* Delete the extent record */ 
+ 		err = DeleteBTreeRecord(GPtr->calculatedExtentsFCB, &extentKey);
+-		dprintf (d_info, "%s: Deleting extent overflow for fileID=%u, forkType=%u, startBlock=%u\n", __FUNCTION__, fileID, forkType, foundStartBlock);
++		dbg_printf (d_info, "%s: Deleting extent overflow for fileID=%u, forkType=%u, startBlock=%u\n", __FUNCTION__, fileID, forkType, foundStartBlock);
+ 		if (err) {
+ 			goto create_symlink;
+ 		}
+@@ -3227,12 +3227,12 @@ static OSErr MoveExtent(SGlobPtr GPtr, ExtentInfo *extentInfo)
+ 											  &extentData, &recordSize, &foundExtentIndex);
+ 				foundLocation = extentsBTree;
+ 				if (err != noErr) {
+-					dprintf (d_error|d_overlap, "%s: No matching extent record found in extents btree for fileID = %d (err=%d)\n", __FUNCTION__, extentInfo->fileID, err);
++					dbg_printf (d_error|d_overlap, "%s: No matching extent record found in extents btree for fileID = %d (err=%d)\n", __FUNCTION__, extentInfo->fileID, err);
+ 					goto out;
+ 				}
+ 			} else {
+ 				/* No more extents exist for this file */
+-				dprintf (d_error|d_overlap, "%s: No matching extent record found for fileID = %d\n", __FUNCTION__, extentInfo->fileID);
++				dbg_printf (d_error|d_overlap, "%s: No matching extent record found for fileID = %d\n", __FUNCTION__, extentInfo->fileID);
+ 				goto out;
+ 			}
+ 		}
+@@ -3241,7 +3241,7 @@ static OSErr MoveExtent(SGlobPtr GPtr, ExtentInfo *extentInfo)
+ 	err = CopyDiskBlocks(GPtr, extentInfo->startBlock, extentInfo->blockCount, 
+ 						 extentInfo->newStartBlock);
+ 	if (err != noErr) {
+-		dprintf (d_error|d_overlap, "%s: Error in copying disk blocks for fileID = %d (err=%d)\n", __FUNCTION__, extentInfo->fileID, err);
++		dbg_printf (d_error|d_overlap, "%s: Error in copying disk blocks for fileID = %d (err=%d)\n", __FUNCTION__, extentInfo->fileID, err);
+ 		goto out;
+ 	}
+ 	
+@@ -3260,7 +3260,7 @@ static OSErr MoveExtent(SGlobPtr GPtr, ExtentInfo *extentInfo)
+ 
+ 	}
+ 	if (err != noErr) {
+-		dprintf (d_error|d_overlap, "%s: Error in updating extent record for fileID = %d (err=%d)\n", __FUNCTION__, extentInfo->fileID, err);
++		dbg_printf (d_error|d_overlap, "%s: Error in updating extent record for fileID = %d (err=%d)\n", __FUNCTION__, extentInfo->fileID, err);
+ 		goto out;
+ 	}
+ 
+@@ -3491,7 +3491,7 @@ static OSErr SearchExtentInAttributeBT(SGlobPtr GPtr, ExtentInfo *extentInfo,
+ 	result = BTSearchRecord(GPtr->calculatedAttributesFCB, &iterator, 
+ 				kInvalidMRUCacheKey, &btRecord, recordSize, &iterator);
+ 	if (result) {
+-		dprintf (d_error|d_overlap, "%s: Error finding attribute record (err=%d) for fileID = %d, attrname = %d\n", __FUNCTION__, result, extentInfo->fileID, extentInfo->attrname);
++		dbg_printf (d_error|d_overlap, "%s: Error finding attribute record (err=%d) for fileID = %d, attrname = %d\n", __FUNCTION__, result, extentInfo->fileID, extentInfo->attrname);
+ 		goto out;	
+ 	}
+ 	
+diff --git a/fsck_hfs.tproj/dfalib/SVerify1.c b/fsck_hfs.tproj/dfalib/SVerify1.c
+index a273bf3..39bda5c 100644
+--- a/fsck_hfs.tproj/dfalib/SVerify1.c
++++ b/fsck_hfs.tproj/dfalib/SVerify1.c
+@@ -2157,9 +2157,9 @@ CheckAttributeRecord(SGlobPtr GPtr, const HFSPlusAttrKey *key, const HFSPlusAttr
+ 	
+ 	if (doDelete == true) {
+ 		result = DeleteBTreeRecord(GPtr->calculatedAttributesFCB, key);
+-		dprintf (d_info|d_xattr, "%s: Deleting attribute %s for fileID %d, type = %d\n", __FUNCTION__, attrname, key->fileID, rec->recordType);
++		dbg_printf (d_info|d_xattr, "%s: Deleting attribute %s for fileID %d, type = %d\n", __FUNCTION__, attrname, key->fileID, rec->recordType);
+ 		if (result) {
+-			dprintf (d_error|d_xattr, "%s: Error in deleting record for %s for fileID %d, type = %d\n", __FUNCTION__, attrname, key->fileID, rec->recordType);
++			dbg_printf (d_error|d_xattr, "%s: Error in deleting record for %s for fileID %d, type = %d\n", __FUNCTION__, attrname, key->fileID, rec->recordType);
+ 		}
+ 		
+ 		/* Set flags to mark header and map dirty */
+@@ -3034,7 +3034,7 @@ OSErr	CheckFileExtents( SGlobPtr GPtr, UInt32 fileNumber, UInt8 forkType,
+ 		//	checkout the extent record first
+ 		err = ChkExtRec( GPtr, extents, &lastExtentIndex );
+ 		if (err != noErr) {
+-			dprintf (d_info, "%s: Bad extent for fileID %u in extent %u for startblock %u\n", __FUNCTION__, fileNumber, lastExtentIndex, blockCount);
++			dbg_printf (d_info, "%s: Bad extent for fileID %u in extent %u for startblock %u\n", __FUNCTION__, fileNumber, lastExtentIndex, blockCount);
+ 
+ 			/* Stop verification if bad extent is found for system file or EA */
+ 			if ((fileNumber < kHFSFirstUserCatalogNodeID) ||
+diff --git a/fsck_hfs.tproj/fsck_debug.c b/fsck_hfs.tproj/fsck_debug.c
+index 1be3fc5..77e8e51 100644
+--- a/fsck_hfs.tproj/fsck_debug.c
++++ b/fsck_hfs.tproj/fsck_debug.c
+@@ -25,18 +25,18 @@
+ #include <stdio.h>
+ #include <stdarg.h>
+ 
+-/* Current debug level of fsck_hfs for printing messages via dprintf */
++/* Current debug level of fsck_hfs for printing messages via dbg_printf */
+ unsigned long cur_debug_level;
+ 
+-/* Function: dprintf
++/* Function: dbg_printf
+  *
+  * Description: Debug function similar to printf except the first parameter
+- * which indicates the type of message to be printed by dprintf. Based on 
++ * which indicates the type of message to be printed by dbg_printf. Based on
+  * current debug level and the type of message, the function decides 
+  * whether to print the message or not.
+  *
+  * Each unique message type has a bit assigned to it.  The message type 
+- * passed to dprintf can be one or combination (OR-ed value) of pre-defined 
++ * passed to dbg_printf can be one or combination (OR-ed value) of pre-defined
+  * debug message types.  Only the messages whose type have one or more similar
+  * bits set in comparison with current global debug level are printed. 
+  *
+@@ -56,7 +56,7 @@ unsigned long cur_debug_level;
+  * Output:
+  *	Nothing
+  */
+-void dprintf (unsigned long type, char *fmt, ...) 
++void dbg_printf (unsigned long type, char *fmt, ...)
+ {
+ 	if (cur_debug_level & type) {
+ 		va_list ap;
+diff --git a/fsck_hfs.tproj/fsck_debug.h b/fsck_hfs.tproj/fsck_debug.h
+index 81e3932..cb1b9be 100644
+--- a/fsck_hfs.tproj/fsck_debug.h
++++ b/fsck_hfs.tproj/fsck_debug.h
+@@ -36,18 +36,18 @@ enum debug_message_type {
+ 	d_overlap	=	0x0020 	/* Overlap extents related messages */
+ };
+ 
+-/* Current debug level of fsck_hfs for printing messages via dprintf */
++/* Current debug level of fsck_hfs for printing messages via dbg_printf */
+ extern unsigned long cur_debug_level;
+ 
+-/* Function: dprintf
++/* Function: dbg_printf
+  *
+  * Description: Debug function similar to printf except the first parameter
+- * which indicates the type of message to be printed by dprintf. Based on 
++ * which indicates the type of message to be printed by dbg_printf. Based on
+  * current debug level and the type of message, the function decides 
+  * whether to print the message or not.
+  *
+  * Each unique message type has a bit assigned to it.  The message type 
+- * passed to dprintf can be one or combination (OR-ed value) of pre-defined 
++ * passed to dbg_printf can be one or combination (OR-ed value) of pre-defined
+  * debug message types.  Only the messages whose type have one or more similar
+  * bits set in comparison with current global debug level are printed. 
+  *
+@@ -67,6 +67,6 @@ extern unsigned long cur_debug_level;
+  * Output:
+  *	Nothing
+  */
+-extern void dprintf (unsigned long message_type, char *format, ...);
++extern void dbg_printf (unsigned long message_type, char *format, ...);
+ 
+ #endif /* __FSCK_DEBUG__ */

--- a/utils/hfsprogs/patches/0010-Rename-custom-macro-nil-with-NULL.patch
+++ b/utils/hfsprogs/patches/0010-Rename-custom-macro-nil-with-NULL.patch
@@ -1,0 +1,1319 @@
+From: =?UTF-8?q?Rog=C3=A9rio=20Brito?= <rbrito@ime.usp.br>
+Date: Thu, 24 Oct 2013 01:11:21 -0200
+Subject: Rename custom macro nil with NULL
+
+---
+ fsck_hfs.tproj/dfalib/BTree.c         | 142 +++++++++++++++++-----------------
+ fsck_hfs.tproj/dfalib/BTreeAllocate.c |  14 ++--
+ fsck_hfs.tproj/dfalib/BTreeMiscOps.c  |  26 +++----
+ fsck_hfs.tproj/dfalib/BTreeNodeOps.c  |  30 +++----
+ fsck_hfs.tproj/dfalib/BTreeTreeOps.c  |  38 ++++-----
+ fsck_hfs.tproj/dfalib/SControl.c      |  56 +++++++-------
+ fsck_hfs.tproj/dfalib/SRepair.c       |   6 +-
+ fsck_hfs.tproj/dfalib/SUtils.c        |   6 +-
+ fsck_hfs.tproj/dfalib/SVerify1.c      |  32 ++++----
+ fsck_hfs.tproj/dfalib/SVerify2.c      |   4 +-
+ 10 files changed, 177 insertions(+), 177 deletions(-)
+
+diff --git a/fsck_hfs.tproj/dfalib/BTree.c b/fsck_hfs.tproj/dfalib/BTree.c
+index 7ad9fe0..c0c8744 100644
+--- a/fsck_hfs.tproj/dfalib/BTree.c
++++ b/fsck_hfs.tproj/dfalib/BTree.c
+@@ -163,21 +163,21 @@ OSStatus	BTInitialize		(FCB					*filePtr,
+ 
+ 	////////////////////// Preliminary Error Checking ///////////////////////////
+ 
+-	headerNode.buffer	= nil;
++	headerNode.buffer	= NULL;
+ 
+-	if (pathPtr										== nil)	return  paramErr;
++	if (pathPtr == NULL)	return  paramErr;
+ 
+ 	setEndOfForkProc	= pathPtr->agentPtr->agent.setEndOfForkProc;
+ 	setBlockSizeProc	= pathPtr->agentPtr->agent.setBlockSizeProc;
+ 
+-	if (pathPtr->agentPtr->agent.getBlockProc		== nil)	return  E_NoGetBlockProc;
+-	if (pathPtr->agentPtr->agent.releaseBlockProc	== nil)	return  E_NoReleaseBlockProc;
+-	if (setEndOfForkProc							== nil)	return  E_NoSetEndOfForkProc;
+-	if (setBlockSizeProc							== nil)	return  E_NoSetBlockSizeProc;
++	if (pathPtr->agentPtr->agent.getBlockProc == NULL)	return  E_NoGetBlockProc;
++	if (pathPtr->agentPtr->agent.releaseBlockProc == NULL)	return  E_NoReleaseBlockProc;
++	if (setEndOfForkProc == NULL)	return  E_NoSetEndOfForkProc;
++	if (setBlockSizeProc == NULL)	return  E_NoSetBlockSizeProc;
+ 
+ 	forkPtr = pathPtr->path.forkPtr;
+ 
+-	if (forkPtr->fork.btreePtr != nil)						return	fsBTrFileAlreadyOpenErr;
++	if (forkPtr->fork.btreePtr != NULL) return	fsBTrFileAlreadyOpenErr;
+ 
+ 	if ((maxKeyLength == 0) ||
+ 		(maxKeyLength >  kMaxKeyLength))					return	fsBTInvalidKeyLengthErr;
+@@ -209,7 +209,7 @@ OSStatus	BTInitialize		(FCB					*filePtr,
+ 	//////////////////////// Allocate Control Block /////////////////////////////
+ 
+ 	M_RESIDENT_ALLOCATE_FIXED_CLEAR( &btreePtr, sizeof( BTreeControlBlock ), kFSBTreeControlBlockType );
+-	if (btreePtr == nil)
++	if (btreePtr == NULL)
+ 	{
+ 		err = memFullErr;
+ 		goto ErrorExit;
+@@ -220,7 +220,7 @@ OSStatus	BTInitialize		(FCB					*filePtr,
+ 	btreePtr->flags				= 0;
+ 	btreePtr->attributes		= 0;
+ 	btreePtr->forkPtr			= forkPtr;
+-	btreePtr->keyCompareProc	= nil;
++	btreePtr->keyCompareProc	= NULL;
+ 	btreePtr->keyDescPtr		= keyDescPtr;
+ 	btreePtr->btreeType			= btreeType;
+ 	btreePtr->treeDepth			= 0;
+@@ -282,7 +282,7 @@ OSStatus	BTInitialize		(FCB					*filePtr,
+ 
+ 	///////////////////// Copy Key Descriptor To Header /////////////////////////
+ #if SupportsKeyDescriptors
+-	if (keyDescPtr != nil)
++	if (keyDescPtr != NULL)
+ 	{
+ 		err = CheckKeyDescriptor (keyDescPtr, maxKeyLength);
+ 		M_ExitOnError (err);
+@@ -309,7 +309,7 @@ OSStatus	BTInitialize		(FCB					*filePtr,
+ 	err = UpdateHeader (btreePtr);
+ 	M_ExitOnError (err);
+ 
+-	pathPtr->path.forkPtr->fork.btreePtr = nil;
++	pathPtr->path.forkPtr->fork.btreePtr = NULL;
+ 	M_RESIDENT_DEALLOCATE_FIXED( btreePtr, sizeof( BTreeControlBlock ), kFSBTreeControlBlockType );
+ 
+ 	return	noErr;
+@@ -320,7 +320,7 @@ OSStatus	BTInitialize		(FCB					*filePtr,
+ ErrorExit:
+ 
+ 	(void) ReleaseNode (btreePtr, &headerNode);
+-	if (btreePtr != nil)
++	if (btreePtr != NULL)
+ 		M_RESIDENT_DEALLOCATE_FIXED( btreePtr, sizeof( BTreeControlBlock ), kFSBTreeControlBlockType );
+ 
+ 	return	err;
+@@ -342,7 +342,7 @@ Input:		filePtr				- pointer to file to open as a B-tree
+ 			setEndOfForkProc	- pointer to client's SetEOF function
+ 
+ Result:		noErr				- success
+-			paramErr			- required ptr was nil
++			paramErr			- required ptr was NULL
+ 			fsBTInvalidFileErr				-
+ 			memFullErr			-
+ 			!= noErr			- failure
+@@ -364,16 +364,16 @@ OSStatus	BTOpenPath			(SFCB					*filePtr,
+ 
+ 	////////////////////// Preliminary Error Checking ///////////////////////////
+ 
+-	if ( filePtr == nil				||
+-		 getBlockProc == nil		||
+-		 releaseBlockProc == nil	||
+-		 setEndOfForkProc == nil	||
+-		 setBlockSizeProc == nil )
++	if (filePtr == NULL ||
++		 getBlockProc == NULL ||
++		 releaseBlockProc == NULL ||
++		 setEndOfForkProc == NULL ||
++		 setBlockSizeProc == NULL)
+ 	{
+ 		return  paramErr;
+ 	}
+ 
+-	if ( filePtr->fcbBtree != nil )			// already has a BTreeCB
++	if (filePtr->fcbBtree != NULL)			// already has a BTreeCB
+ 		return noErr;
+ 
+ 												// is file large enough to contain header node?
+@@ -384,7 +384,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr,
+ 	//////////////////////// Allocate Control Block /////////////////////////////
+ 
+ 	btreePtr = (BTreeControlBlock*) AllocateClearMemory( sizeof( BTreeControlBlock ) );
+-	if (btreePtr == nil)
++	if (btreePtr == NULL)
+ 	{
+ 		Panic ("\pBTOpen: no memory for btreePtr.");
+ 		return	memFullErr;
+@@ -397,7 +397,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr,
+ 
+ 	/////////////////////////// Read Header Node ////////////////////////////////
+ 
+-	nodeRec.buffer				= nil;				// so we can call ReleaseNode
++	nodeRec.buffer				= NULL;				// so we can call ReleaseNode
+ 	
+ 	btreePtr->fcbPtr			= filePtr;
+ 	filePtr->fcbBtree			= (void *) btreePtr;	// attach btree cb to file
+@@ -487,7 +487,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr,
+ 
+ 	////////////////////////// Get Key Descriptor ///////////////////////////////
+ #if SupportsKeyDescriptors
+-	if ( keyCompareProc == nil )		// 	if no key compare proc then get key descriptor
++	if (keyCompareProc == NULL)		// 	if no key compare proc then get key descriptor
+ 	{
+ 		err = GetKeyDescriptor (btreePtr, nodeRec.buffer);	//¥¥ it should check amount of memory allocated...
+ 		M_ExitOnError (err);
+@@ -499,7 +499,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr,
+ 	else
+ #endif
+ 	{
+-		btreePtr->keyDescPtr = nil;			// clear it so we don't dispose garbage later
++		btreePtr->keyDescPtr = NULL;			// clear it so we don't dispose garbage later
+ 	}
+ 
+ 	err = ReleaseNode (btreePtr, &nodeRec);
+@@ -528,7 +528,7 @@ OSStatus	BTOpenPath			(SFCB					*filePtr,
+ 
+ ErrorExit:
+ 
+-	filePtr->fcbBtree = nil;
++	filePtr->fcbBtree = NULL;
+ 	(void) ReleaseNode (btreePtr, &nodeRec);
+ 	DisposeMemory( btreePtr );
+ 
+@@ -567,7 +567,7 @@ OSStatus	BTClosePath			(SFCB					*filePtr)
+ 
+ 	btreePtr = (BTreeControlBlockPtr) filePtr->fcbBtree;
+ 
+-	if (btreePtr == nil)
++	if (btreePtr == NULL)
+ 		return fsBTInvalidFileErr;
+ 
+ 	////////////////////// Check for other BTree Paths //////////////////////////
+@@ -603,14 +603,14 @@ OSStatus	BTClosePath			(SFCB					*filePtr)
+ 	M_ExitOnError (err);
+ 
+ #if SupportsKeyDescriptors
+-	if (btreePtr->keyDescPtr != nil)			// deallocate keyDescriptor, if any
++	if (btreePtr->keyDescPtr != NULL)			// deallocate keyDescriptor, if any
+ 	{
+ 		DisposeMemory( btreePtr->keyDescPtr );
+ 	}
+ #endif
+ 
+ 	DisposeMemory( btreePtr );
+-	filePtr->fcbBtree = nil;
++	filePtr->fcbBtree = NULL;
+ 
+ //	LogEndTime(kTraceCloseBTree, noErr);
+ 
+@@ -643,7 +643,7 @@ Function:	Search for position in B*Tree indicated by searchKey. If a valid node
+ 
+ Input:		pathPtr			- pointer to path for BTree file.
+ 			searchKey		- pointer to search key to match.
+-			hintPtr			- pointer to hint (may be nil)
++			hintPtr			- pointer to hint (may be NULL)
+ 
+ Output:		record			- pointer to BufferDescriptor containing record
+ 			recordLen		- length of data at recordPtr
+@@ -678,14 +678,14 @@ OSStatus	BTSearchRecord		(SFCB						*filePtr,
+ 
+ //	LogStartTime(kTraceSearchBTree);
+ 
+-	if (filePtr == nil)									return	paramErr;
+-	if (searchIterator == nil)							return	paramErr;
++	if (filePtr == NULL)		return	paramErr;
++	if (searchIterator == NULL)	return	paramErr;
+ 
+ 	btreePtr = (BTreeControlBlockPtr) filePtr->fcbBtree;
+-	if (btreePtr == nil)								return	fsBTInvalidFileErr;
++	if (btreePtr == NULL)		return	fsBTInvalidFileErr;
+ 
+ #if SupportsKeyDescriptors
+-	if (btreePtr->keyCompareProc == nil)		// CheckKey if we using Key Descriptor
++	if (btreePtr->keyCompareProc == NULL)		// CheckKey if we using Key Descriptor
+ 	{
+ 		err = CheckKey (&searchIterator->key, btreePtr->keyDescPtr, btreePtr->maxKeyLength);
+ 		M_ExitOnError (err);
+@@ -775,9 +775,9 @@ OSStatus	BTSearchRecord		(SFCB						*filePtr,
+ 		//¥¥ Should check for errors! Or BlockMove could choke on recordPtr!!!
+ 		GetRecordByIndex (btreePtr, node.buffer, index, &keyPtr, &recordPtr, &len);
+ 
+-		if (recordLen != nil)			*recordLen = len;
++		if (recordLen != NULL)	*recordLen = len;
+ 
+-		if (record != nil)
++		if (record != NULL)
+ 		{
+ 			ByteCount recordSize;
+ 
+@@ -794,7 +794,7 @@ OSStatus	BTSearchRecord		(SFCB						*filePtr,
+ 
+ 	/////////////////////// Success - Update Iterator ///////////////////////////
+ 
+-	if (resultIterator != nil)
++	if (resultIterator != NULL)
+ 	{
+ 		resultIterator->hint.writeCount	= btreePtr->writeCount;
+ 		resultIterator->hint.nodeNum	= nodeNum;
+@@ -825,10 +825,10 @@ OSStatus	BTSearchRecord		(SFCB						*filePtr,
+ 
+ ErrorExit:
+ 
+-	if (recordLen != nil)
++	if (recordLen != NULL)
+ 		*recordLen = 0;
+ 
+-	if (resultIterator != nil)
++	if (resultIterator != NULL)
+ 	{
+ 		resultIterator->hint.writeCount	= 0;
+ 		resultIterator->hint.nodeNum	= 0;
+@@ -892,18 +892,18 @@ OSStatus	BTIterateRecord		(SFCB						*filePtr,
+ 
+ 	////////////////////////// Priliminary Checks ///////////////////////////////
+ 
+-	left.buffer		= nil;
+-	right.buffer	= nil;
+-	node.buffer		= nil;
++	left.buffer		= NULL;
++	right.buffer	= NULL;
++	node.buffer		= NULL;
+ 
+ 
+-	if (filePtr == nil)
++	if (filePtr == NULL)
+ 	{
+ 		return	paramErr;
+ 	}
+ 
+ 	btreePtr = (BTreeControlBlockPtr) filePtr->fcbBtree;
+-	if (btreePtr == nil)
++	if (btreePtr == NULL)
+ 	{
+ 		return	fsBTInvalidFileErr;			//¥¥ handle properly
+ 	}
+@@ -968,7 +968,7 @@ OSStatus	BTIterateRecord		(SFCB						*filePtr,
+ 		}
+ 		else
+ 		{
+-			if (left.buffer == nil)
++			if (left.buffer == NULL)
+ 			{
+ 				nodeNum = ((NodeDescPtr) node.buffer)->bLink;
+ 				if ( nodeNum > 0)
+@@ -981,13 +981,13 @@ OSStatus	BTIterateRecord		(SFCB						*filePtr,
+ 				}
+ 			}
+ 			//	Before we stomp on "right", we'd better release it if needed
+-			if (right.buffer != nil) {
++			if (right.buffer != NULL) {
+ 				err = ReleaseNode(btreePtr, &right);
+ 				M_ExitOnError(err);
+ 			}
+ 			right		= node;
+ 			node		= left;
+-			left.buffer	= nil;
++			left.buffer	= NULL;
+ 			index 		= ((NodeDescPtr) node.buffer)->numRecords -1;
+ 		}
+ 	}
+@@ -1012,7 +1012,7 @@ OSStatus	BTIterateRecord		(SFCB						*filePtr,
+ 		}
+ 		else
+ 		{
+-			if (right.buffer == nil)
++			if (right.buffer == NULL)
+ 			{
+ 				nodeNum = ((NodeDescPtr) node.buffer)->fLink;
+ 				if ( nodeNum > 0)
+@@ -1025,13 +1025,13 @@ OSStatus	BTIterateRecord		(SFCB						*filePtr,
+ 				}
+ 			}
+ 			//	Before we stomp on "left", we'd better release it if needed
+-			if (left.buffer != nil) {
++			if (left.buffer != NULL) {
+ 				err = ReleaseNode(btreePtr, &left);
+ 				M_ExitOnError(err);
+ 			}
+ 			left		 = node;
+ 			node		 = right;
+-			right.buffer = nil;
++			right.buffer = NULL;
+ 			index		 = 0;
+ 		}
+ 	}
+@@ -1054,9 +1054,9 @@ CopyData:
+ 	err = GetRecordByIndex (btreePtr, node.buffer, index, &keyPtr, &recordPtr, &len);
+ 	M_ExitOnError (err);
+ 
+-	if (recordLen != nil)			*recordLen = len;
++	if (recordLen != NULL)			*recordLen = len;
+ 
+-	if (record != nil)
++	if (record != NULL)
+ 	{
+ 		ByteCount recordSize;
+ 
+@@ -1069,7 +1069,7 @@ CopyData:
+ 		CopyMemory (recordPtr, record->bufferAddress, len);
+ 	}
+ 
+-	if (iterator != nil)						// first & last do not require iterator
++	if (iterator != NULL)						// first & last do not require iterator
+ 	{
+ 		iterator->hint.writeCount	= btreePtr->writeCount;
+ 		iterator->hint.nodeNum		= nodeNum;
+@@ -1089,13 +1089,13 @@ CopyData:
+ 	err = ReleaseNode (btreePtr, &node);
+ 	M_ExitOnError (err);
+ 
+-	if (left.buffer != nil)
++	if (left.buffer != NULL)
+ 	{
+ 		err = ReleaseNode (btreePtr, &left);
+ 		M_ExitOnError (err);
+ 	}
+ 
+-	if (right.buffer != nil)
++	if (right.buffer != NULL)
+ 	{
+ 		err = ReleaseNode (btreePtr, &right);
+ 		M_ExitOnError (err);
+@@ -1113,10 +1113,10 @@ ErrorExit:
+ 	(void)	ReleaseNode (btreePtr, &node);
+ 	(void)	ReleaseNode (btreePtr, &right);
+ 
+-	if (recordLen != nil)
++	if (recordLen != NULL)
+ 		*recordLen = 0;
+ 
+-	if (iterator != nil)
++	if (iterator != NULL)
+ 	{
+ 		iterator->hint.writeCount	= 0;
+ 		iterator->hint.nodeNum		= 0;
+@@ -1157,7 +1157,7 @@ OSStatus	BTInsertRecord		(SFCB						*filePtr,
+ 
+ 	////////////////////////// Priliminary Checks ///////////////////////////////
+ 
+-	nodeRec.buffer = nil;					// so we can call ReleaseNode
++	nodeRec.buffer = NULL;					// so we can call ReleaseNode
+ 
+ 	err = CheckInsertParams (filePtr, iterator, record, recordLen);
+ 	if (err != noErr)
+@@ -1317,7 +1317,7 @@ OSStatus	BTSetRecord			(SFCB						*filePtr,
+ 
+ 	////////////////////////// Priliminary Checks ///////////////////////////////
+ 
+-	nodeRec.buffer = nil;					// so we can call ReleaseNode
++	nodeRec.buffer = NULL;					// so we can call ReleaseNode
+ 
+ 	err = CheckInsertParams (filePtr, iterator, record, recordLen);
+ 	if (err != noErr)
+@@ -1506,7 +1506,7 @@ OSStatus	BTReplaceRecord		(SFCB						*filePtr,
+ 
+ 	////////////////////////// Priliminary Checks ///////////////////////////////
+ 
+-	nodeRec.buffer = nil;					// so we can call ReleaseNode
++	nodeRec.buffer = NULL;					// so we can call ReleaseNode
+ 
+ 	err = CheckInsertParams (filePtr, iterator, record, recordLen);
+ 	if (err != noErr)
+@@ -1645,20 +1645,20 @@ OSStatus	BTDeleteRecord		(SFCB						*filePtr,
+ 
+ 	////////////////////////// Priliminary Checks ///////////////////////////////
+ 
+-	nodeRec.buffer = nil;					// so we can call ReleaseNode
++	nodeRec.buffer = NULL;					// so we can call ReleaseNode
+ 
+-	M_ReturnErrorIf (filePtr == nil, 	paramErr);
+-	M_ReturnErrorIf (iterator == nil,	paramErr);
++	M_ReturnErrorIf (filePtr == NULL, 	paramErr);
++	M_ReturnErrorIf (iterator == NULL,	paramErr);
+ 
+ 	btreePtr = (BTreeControlBlockPtr) filePtr->fcbBtree;
+-	if (btreePtr == nil)
++	if (btreePtr == NULL)
+ 	{
+ 		err = fsBTInvalidFileErr;
+ 		goto ErrorExit;
+ 	}
+ 
+ #if SupportsKeyDescriptors
+-	if (btreePtr->keyDescPtr != nil)
++	if (btreePtr->keyDescPtr != NULL)
+ 	{
+ 		err = CheckKey (&iterator->key, btreePtr->keyDescPtr, btreePtr->maxKeyLength);
+ 		M_ExitOnError (err);
+@@ -1712,12 +1712,12 @@ OSStatus	BTGetInformation	(SFCB					*filePtr,
+ 	BTreeControlBlockPtr	btreePtr;
+ 
+ 
+-	M_ReturnErrorIf (filePtr == nil, 	paramErr);
++	M_ReturnErrorIf (filePtr == NULL, 	paramErr);
+ 
+ 	btreePtr = (BTreeControlBlockPtr) filePtr->fcbBtree;
+ 
+-	M_ReturnErrorIf (btreePtr == nil,	fsBTInvalidFileErr);
+-	M_ReturnErrorIf (info == nil,		paramErr);
++	M_ReturnErrorIf (btreePtr == NULL,	fsBTInvalidFileErr);
++	M_ReturnErrorIf (info == NULL,		paramErr);
+ 
+ 	//¥¥ check version?
+ 
+@@ -1730,7 +1730,7 @@ OSStatus	BTGetInformation	(SFCB					*filePtr,
+ 	info->keyDescriptor	= btreePtr->keyDescPtr;	//¥¥ this won't do at all...
+ 	info->reserved		= 0;
+ 
+-	if (btreePtr->keyDescPtr == nil)
++	if (btreePtr->keyDescPtr == NULL)
+ 		info->keyDescLength	= 0;
+ 	else
+ 		info->keyDescLength	= (UInt32) btreePtr->keyDescPtr->length;
+@@ -1762,11 +1762,11 @@ OSStatus	BTFlushPath				(SFCB					*filePtr)
+ 
+ //	LogStartTime(kTraceFlushBTree);
+ 
+-	M_ReturnErrorIf (filePtr == nil, 	paramErr);
++	M_ReturnErrorIf (filePtr == NULL, 	paramErr);
+ 
+ 	btreePtr = (BTreeControlBlockPtr) filePtr->fcbBtree;
+ 
+-	M_ReturnErrorIf (btreePtr == nil,	fsBTInvalidFileErr);
++	M_ReturnErrorIf (btreePtr == NULL,	fsBTInvalidFileErr);
+ 
+ 	err = UpdateHeader (btreePtr);
+ 
+@@ -1788,13 +1788,13 @@ Input:		iterator	- pointer to BTreeIterator
+ Output:		iterator	- iterator with the hint.nodeNum cleared
+ 
+ Result:		noErr			- success
+-			paramErr	- iterator == nil
++			paramErr	- iterator == NULL
+ -------------------------------------------------------------------------------*/
+ 
+ 
+ OSStatus	BTInvalidateHint	(BTreeIterator				*iterator )
+ {
+-	if (iterator == nil)
++	if (iterator == NULL)
+ 		return	paramErr;
+ 
+ 	iterator->hint.nodeNum = 0;
+diff --git a/fsck_hfs.tproj/dfalib/BTreeAllocate.c b/fsck_hfs.tproj/dfalib/BTreeAllocate.c
+index 485d867..02bdd8d 100644
+--- a/fsck_hfs.tproj/dfalib/BTreeAllocate.c
++++ b/fsck_hfs.tproj/dfalib/BTreeAllocate.c
+@@ -83,7 +83,7 @@ OSStatus	AllocateNode (BTreeControlBlockPtr		btreePtr, UInt32	*nodeNum)
+ 	
+ 	
+ 	nodeNumber		= 0;				// first node number of header map record
+-	node.buffer		= nil;				// clear node.buffer to get header node
++	node.buffer		= NULL;				// clear node.buffer to get header node
+ 										//	- and for ErrorExit
+ 	
+ 	while (true)
+@@ -192,7 +192,7 @@ OSStatus	FreeNode (BTreeControlBlockPtr		btreePtr, UInt32	nodeNum)
+ 
+ 	//////////////////////////// Find Map Record ////////////////////////////////
+ 	nodeIndex			= 0;				// first node number of header map record
+-	node.buffer			= nil;				// invalidate node.buffer to get header node
++	node.buffer			= NULL;				// invalidate node.buffer to get header node
+ 	
+ 	while (nodeNum >= nodeIndex)
+ 	{
+@@ -278,8 +278,8 @@ OSStatus	ExtendBTree	(BTreeControlBlockPtr	btreePtr,
+ 	nodeSize			= btreePtr->nodeSize;
+ 	filePtr				= btreePtr->fcbPtr;
+ 	
+-	mapNode.buffer		= nil;
+-	newNode.buffer		= nil;
++	mapNode.buffer		= NULL;
++	newNode.buffer		= NULL;
+ 
+ 	mapNodeRecSize	= nodeSize - sizeof(BTNodeDescriptor) - 6;	// 2 bytes of free space (see note)
+ 
+@@ -448,7 +448,7 @@ ErrorExit:
+ Routine:	GetMapNode	-	Get the next map node and pointer to the map record.
+ 
+ Function:	Given a BlockDescriptor to a map node in nodePtr, GetMapNode releases
+-			it and gets the next node. If nodePtr->buffer is nil, then the header
++			it and gets the next node. If nodePtr->buffer is NULL, then the header
+ 			node is retrieved.
+ 
+ 
+@@ -474,7 +474,7 @@ OSStatus	GetMapNode (BTreeControlBlockPtr	  btreePtr,
+ 	UInt16		mapIndex;
+ 	UInt32		nextNodeNum;
+ 	
+-	if (nodePtr->buffer != nil)		// if iterator is valid...
++	if (nodePtr->buffer != NULL)		// if iterator is valid...
+ 	{
+ 		nextNodeNum = ((NodeDescPtr)nodePtr->buffer)->fLink;
+ 		if (nextNodeNum == 0)
+@@ -521,7 +521,7 @@ ErrorExit:
+ 	
+ 	(void) ReleaseNode (btreePtr, nodePtr);
+ 	
+-	*mapPtr		= nil;
++	*mapPtr		= NULL;
+ 	*mapSize	= 0;
+ 	
+ 	return	err;
+diff --git a/fsck_hfs.tproj/dfalib/BTreeMiscOps.c b/fsck_hfs.tproj/dfalib/BTreeMiscOps.c
+index 7c9edca..997f34b 100644
+--- a/fsck_hfs.tproj/dfalib/BTreeMiscOps.c
++++ b/fsck_hfs.tproj/dfalib/BTreeMiscOps.c
+@@ -236,13 +236,13 @@ OSStatus	FindIteratorPosition	(BTreeControlBlockPtr	 btreePtr,
+ 	// assume index points to UInt16
+ 	// assume foundRecord points to Boolean
+ 	
+-	left->buffer		= nil;
+-	middle->buffer		= nil;
+-	right->buffer		= nil;
++	left->buffer		= NULL;
++	middle->buffer		= NULL;
++	right->buffer		= NULL;
+ 	
+ 	foundIt				= false;
+ 	
+-	if (iterator == nil)						// do we have an iterator?
++	if (iterator == NULL)						// do we have an iterator?
+ 	{
+ 		err = fsBTInvalidIteratorErr;
+ 		goto ErrorExit;
+@@ -250,7 +250,7 @@ OSStatus	FindIteratorPosition	(BTreeControlBlockPtr	 btreePtr,
+ 
+ #if SupportsKeyDescriptors
+ 	//¥¥ verify iterator key (change CheckKey to take btreePtr instead of keyDescPtr?)
+-	if (btreePtr->keyDescPtr != nil)
++	if (btreePtr->keyDescPtr != NULL)
+ 	{
+ 		err = CheckKey (&iterator->key, btreePtr->keyDescPtr, btreePtr->maxKeyLength );
+ 		M_ExitOnError (err);
+@@ -309,7 +309,7 @@ OSStatus	FindIteratorPosition	(BTreeControlBlockPtr	 btreePtr,
+ 		{
+ 			*right			= *middle;
+ 			*middle			= *left;
+-			left->buffer	= nil;
++			left->buffer	= NULL;
+ 			index			= leftIndex;
+ 			
+ 			goto SuccessfulExit;
+@@ -330,7 +330,7 @@ OSStatus	FindIteratorPosition	(BTreeControlBlockPtr	 btreePtr,
+ 		{
+ 			*right			= *middle;
+ 			*middle			= *left;
+-			left->buffer	= nil;
++			left->buffer	= NULL;
+ 			index			= leftIndex;
+ 			
+ 			goto SuccessfulExit;
+@@ -363,7 +363,7 @@ OSStatus	FindIteratorPosition	(BTreeControlBlockPtr	 btreePtr,
+ 		{
+ 			*left			= *middle;
+ 			*middle			= *right;
+-			right->buffer	= nil;
++			right->buffer	= NULL;
+ 			index			= rightIndex;
+ 			
+ 			goto SuccessfulExit;
+@@ -427,15 +427,15 @@ OSStatus	CheckInsertParams		(SFCB						*filePtr,
+ {
+ 	BTreeControlBlockPtr	btreePtr;
+ 	
+-	if (filePtr == nil)									return	paramErr;
++	if (filePtr == NULL)									return	paramErr;
+ 
+ 	btreePtr = (BTreeControlBlockPtr) filePtr->fcbBtree;
+-	if (btreePtr == nil)								return	fsBTInvalidFileErr;
+-	if (iterator == nil)								return	paramErr;
+-	if (record	 == nil)								return	paramErr;
++	if (btreePtr == NULL)								return	fsBTInvalidFileErr;
++	if (iterator == NULL)								return	paramErr;
++	if (record	 == NULL)								return	paramErr;
+ 	
+ #if SupportsKeyDescriptors
+-	if (btreePtr->keyDescPtr != nil)
++	if (btreePtr->keyDescPtr != NULL)
+ 	{
+ 		OSStatus	err;
+ 
+diff --git a/fsck_hfs.tproj/dfalib/BTreeNodeOps.c b/fsck_hfs.tproj/dfalib/BTreeNodeOps.c
+index da07cc7..ef2bd7b 100644
+--- a/fsck_hfs.tproj/dfalib/BTreeNodeOps.c
++++ b/fsck_hfs.tproj/dfalib/BTreeNodeOps.c
+@@ -105,7 +105,7 @@ Function:	Gets an existing BTree node from FS Agent and verifies it.
+ Input:		btreePtr	- pointer to BTree control block
+ 			nodeNum		- number of node to request
+ 			
+-Output:		nodePtr		- pointer to beginning of node (nil if error)
++Output:		nodePtr		- pointer to beginning of node (NULL if error)
+ 			
+ Result:
+ 			noErr		- success
+@@ -139,7 +139,7 @@ OSStatus	GetNode		(BTreeControlBlockPtr	 btreePtr,
+ 	if (err != noErr)
+ 	{
+ 		Panic ("\pGetNode: getNodeProc returned error.");
+-		nodePtr->buffer = nil;
++		nodePtr->buffer = NULL;
+ 		goto ErrorExit;
+ 	}
+ 	++btreePtr->numGetNodes;
+@@ -156,8 +156,8 @@ OSStatus	GetNode		(BTreeControlBlockPtr	 btreePtr,
+ 	return noErr;
+ 
+ ErrorExit:
+-	nodePtr->buffer			= nil;
+-	nodePtr->blockHeader	= nil;
++	nodePtr->buffer		= NULL;
++	nodePtr->blockHeader	= NULL;
+ 	
+ //	LogEndTime(kTraceGetNode, err);
+ 
+@@ -176,7 +176,7 @@ Function:	Gets a new BTree node from FS Agent and initializes it to an empty
+ Input:		btreePtr		- pointer to BTree control block
+ 			nodeNum			- number of node to request
+ 			
+-Output:		returnNodePtr	- pointer to beginning of node (nil if error)
++Output:		returnNodePtr	- pointer to beginning of node (NULL if error)
+ 			
+ Result:		noErr		- success
+ 			!= noErr	- failure
+@@ -203,7 +203,7 @@ OSStatus	GetNewNode	(BTreeControlBlockPtr	 btreePtr,
+ 	if (err != noErr)
+ 	{
+ 		Panic ("\pGetNewNode: getNodeProc returned error.");
+-		returnNodePtr->buffer = nil;
++		returnNodePtr->buffer = NULL;
+ 		return err;
+ 	}
+ 	++btreePtr->numGetNewNodes;
+@@ -248,7 +248,7 @@ OSStatus	ReleaseNode	(BTreeControlBlockPtr	 btreePtr,
+ 
+ 	err = noErr;
+ 	
+-	if (nodePtr->buffer != nil)
++	if (nodePtr->buffer != NULL)
+ 	{
+ 		/*
+ 		 * The nodes must remain in the cache as big endian!
+@@ -267,8 +267,8 @@ OSStatus	ReleaseNode	(BTreeControlBlockPtr	 btreePtr,
+ 		++btreePtr->numReleaseNodes;
+ 	}
+ 	
+-	nodePtr->buffer = nil;
+-	nodePtr->blockHeader = nil;
++	nodePtr->buffer = NULL;
++	nodePtr->blockHeader = NULL;
+ 	
+ //	LogEndTime(kTraceReleaseNode, err);
+ 
+@@ -299,7 +299,7 @@ OSStatus	TrashNode	(BTreeControlBlockPtr	 btreePtr,
+ 
+ 	err = noErr;
+ 	
+-	if (nodePtr->buffer != nil)
++	if (nodePtr->buffer != NULL)
+ 	{
+ 		releaseNodeProc = btreePtr->releaseBlockProc;
+ 		err = releaseNodeProc (btreePtr->fcbPtr,
+@@ -309,8 +309,8 @@ OSStatus	TrashNode	(BTreeControlBlockPtr	 btreePtr,
+ 		++btreePtr->numReleaseNodes;
+ 	}
+ 
+-	nodePtr->buffer			= nil;
+-	nodePtr->blockHeader	= nil;
++	nodePtr->buffer		= NULL;
++	nodePtr->blockHeader	= NULL;
+ 	
+ 	return err;
+ }
+@@ -338,7 +338,7 @@ OSStatus	UpdateNode	(BTreeControlBlockPtr	 btreePtr,
+ 	
+ 	err = noErr;
+ 		
+-	if (nodePtr->buffer != nil)			//¥¥ why call UpdateNode if nil ?!?
++	if (nodePtr->buffer != NULL)			//¥¥ why call UpdateNode if NULL ?!?
+ 	{
+ 	//	LogStartTime(kTraceReleaseNode);
+ 		err = hfs_swap_BTNode(nodePtr, btreePtr->fcbPtr, kSwapBTNodeHostToBig);
+@@ -358,8 +358,8 @@ OSStatus	UpdateNode	(BTreeControlBlockPtr	 btreePtr,
+ 		++btreePtr->numUpdateNodes;
+ 	}
+ 	
+-	nodePtr->buffer			= nil;
+-	nodePtr->blockHeader	= nil;
++	nodePtr->buffer		= NULL;
++	nodePtr->blockHeader	= NULL;
+ 
+ 	return	noErr;
+ 
+diff --git a/fsck_hfs.tproj/dfalib/BTreeTreeOps.c b/fsck_hfs.tproj/dfalib/BTreeTreeOps.c
+index 37fb170..73e1fda 100644
+--- a/fsck_hfs.tproj/dfalib/BTreeTreeOps.c
++++ b/fsck_hfs.tproj/dfalib/BTreeTreeOps.c
+@@ -177,7 +177,7 @@ Output:		nodeNum			- number of the node containing the key position
+ 			
+ Result:		noErr			- key found, index is record index
+ 			fsBTRecordNotFoundErr	- key not found, index is insert index
+-			fsBTEmptyErr		- key not found, return params are nil
++			fsBTEmptyErr		- key not found, return params are NULL
+ 			otherwise			- catastrophic failure (GetNode/ReleaseNode failed)
+ -------------------------------------------------------------------------------*/
+ 
+@@ -321,8 +321,8 @@ ReleaseAndExit:
+ ErrorExit:
+ 	
+ 	*nodeNum					= 0;
+-	nodePtr->buffer				= nil;
+-	nodePtr->blockHeader		= nil;
++	nodePtr->buffer				= NULL;
++	nodePtr->blockHeader		= NULL;
+ 	*returnIndex				= 0;
+ 
+ 	return	err;
+@@ -354,7 +354,7 @@ OSStatus	InsertTree ( BTreeControlBlockPtr		 btreePtr,
+ 	primaryKey.replacingKey	= replacingKey;
+ 	primaryKey.skipRotate	= false;
+ 
+-	err	= InsertLevel (btreePtr, treePathTable, &primaryKey, nil,
++	err	= InsertLevel (btreePtr, treePathTable, &primaryKey, NULL,
+ 					   targetNode, index, level, insertNode );
+ 						
+ 	return err;
+@@ -385,7 +385,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+ #if defined(applec) && !defined(__SC__)
+ 	PanicIf ((level == 1) && (((NodeDescPtr)targetNode->buffer)->kind != kBTLeafNode), "\P InsertLevel: non-leaf at level 1! ");
+ #endif
+-	siblingNode.buffer = nil;
++	siblingNode.buffer = NULL;
+ 	targetNodeNum = treePathTable [level].node;
+ 
+ 	insertParent = false;
+@@ -420,7 +420,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+ 	
+ 	////// process second insert (if any) //////
+ 
+-	if  ( secondaryKey != nil )
++	if (secondaryKey != NULL)
+ 	{
+ 		Boolean				temp;
+ 
+@@ -446,7 +446,7 @@ OSStatus	InsertLevel (BTreeControlBlockPtr		 btreePtr,
+ 		UInt8 *				recPtr;
+ 		UInt16				recSize;
+ 		
+-		secondaryKey = nil;
++		secondaryKey = NULL;
+ 		
+ 		PanicIf ( (level == btreePtr->treeDepth), "InsertLevel: unfinished insert!?");
+ 
+@@ -606,9 +606,9 @@ static OSErr	InsertNode	(BTreeControlBlockPtr	 btreePtr,
+ 	
+ 	if ( leftNodeNum > 0 )
+ 	{
+-		PanicIf ( siblingNode->buffer != nil, "InsertNode: siblingNode already aquired!");
++		PanicIf(siblingNode->buffer != NULL, "InsertNode: siblingNode already aquired!");
+ 
+-		if ( siblingNode->buffer == nil )
++		if (siblingNode->buffer == NULL)
+ 		{
+ 			err = GetNode (btreePtr, leftNodeNum, siblingNode);	// will be released by caller or a split below
+ 			M_ExitOnError (err);
+@@ -703,7 +703,7 @@ OSStatus	DeleteTree			(BTreeControlBlockPtr		 btreePtr,
+ 
+ 	targetNodeNum = treePathTable[level].node;
+ 	targetNodePtr = targetNode->buffer;
+-	PanicIf (targetNodePtr == nil, "DeleteTree: targetNode has nil buffer!");
++	PanicIf (targetNodePtr == NULL, "DeleteTree: targetNode has NULL buffer!");
+ 
+ 	DeleteRecord (btreePtr, targetNodePtr, index);
+ 		
+@@ -766,7 +766,7 @@ OSStatus	DeleteTree			(BTreeControlBlockPtr		 btreePtr,
+ 		deleteRequired = false;
+ 		updateRequired = false;
+ 		
+-		if ( targetNode->buffer == nil )	// then root was freed and the btree is empty
++		if (targetNode->buffer == NULL)	// then root was freed and the btree is empty
+ 		{
+ 			btreePtr->rootNode  = 0;
+ 			btreePtr->treeDepth = 0;
+@@ -1124,7 +1124,7 @@ static OSStatus	SplitLeft		(BTreeControlBlockPtr		 btreePtr,
+ 	if ( (right->height == 1) && (right->kind != kBTLeafNode) )
+ 		return	fsBTInvalidNodeErr;
+ 	
+-	if ( left != nil )
++	if (left != NULL)
+ 	{
+ 		if ( left->fLink != rightNodeNum )
+ 			return fsBTInvalidNodeErr;										//¥¥ E_BadSibling ?
+@@ -1145,7 +1145,7 @@ static OSStatus	SplitLeft		(BTreeControlBlockPtr		 btreePtr,
+ 
+ 	/////////////// Update Forward Link In Original Left Node ///////////////////
+ 
+-	if ( left != nil )
++	if (left != NULL)
+ 	{
+ 		left->fLink	= newNodeNum;
+ 		err = UpdateNode (btreePtr, leftNode);
+@@ -1240,8 +1240,8 @@ static OSStatus	AddNewRootNode	(BTreeControlBlockPtr	 btreePtr,
+ 	Boolean				didItFit;
+ 	UInt16				keyLength;	
+ 	
+-	PanicIf (leftNode == nil, "AddNewRootNode: leftNode == nil");
+-	PanicIf (rightNode == nil, "AddNewRootNode: rightNode == nil");
++	PanicIf (leftNode == NULL, "AddNewRootNode: leftNode == NULL");
++	PanicIf (rightNode == NULL, "AddNewRootNode: rightNode == NULL");
+ 	
+ 	
+ 	/////////////////////// Initialize New Root Node ////////////////////////////
+@@ -1362,7 +1362,7 @@ static OSStatus	SplitRight		(BTreeControlBlockPtr		 btreePtr,
+ 	if ( (leftPtr->height == 1) && (leftPtr->kind != kBTLeafNode) )
+ 		return	fsBTInvalidNodeErr;
+ 	
+-	if ( rightPtr != nil )
++	if (rightPtr != NULL)
+ 	{
+ 		if ( rightPtr->bLink != nodeNum )
+ 			return fsBTInvalidNodeErr;										//¥¥ E_BadSibling ?
+@@ -1382,7 +1382,7 @@ static OSStatus	SplitRight		(BTreeControlBlockPtr		 btreePtr,
+ 
+ 	/////////////// Update backward Link In Original Right Node ///////////////////
+ 
+-	if ( rightPtr != nil )
++	if (rightPtr != NULL)
+ 	{
+ 		rightPtr->bLink	= newNodeNum;
+ 		err = UpdateNode (btreePtr, rightNodePtr);
+@@ -1739,7 +1739,7 @@ static int DoKeyCheck( NodeDescPtr nodeP, BTreeControlBlock *btcb )
+ 	UInt16				keyLength;
+ 	KeyPtr 				keyPtr;
+ 	UInt8				*dataPtr;
+-	KeyPtr				prevkeyP	= nil;
++	KeyPtr				prevkeyP	= NULL;
+ 
+ 
+ 	if ( nodeP->numRecords == 0 )
+@@ -1766,7 +1766,7 @@ static int DoKeyCheck( NodeDescPtr nodeP, BTreeControlBlock *btcb )
+ 				return( -1 );
+ 			}
+ 	
+-			if ( prevkeyP != nil )
++			if (prevkeyP != NULL)
+ 			{
+ 				if ( CompareKeys( (BTreeControlBlockPtr)btcb, prevkeyP, keyPtr ) >= 0 )
+ 				{
+diff --git a/fsck_hfs.tproj/dfalib/SControl.c b/fsck_hfs.tproj/dfalib/SControl.c
+index 8b03ece..d3145e0 100644
+--- a/fsck_hfs.tproj/dfalib/SControl.c
++++ b/fsck_hfs.tproj/dfalib/SControl.c
+@@ -82,7 +82,7 @@ CheckHFS( 	int fsReadRef, int fsWriteRef, int checkLevel, int repairLevel,
+ {
+ 	SGlob				dataArea;	// Allocate the scav globals
+ 	short				temp; 	
+-	FileIdentifierTable	*fileIdentifierTable	= nil;
++	FileIdentifierTable	*fileIdentifierTable	= NULL;
+ 	OSErr				err = noErr;
+ 	OSErr				scavError = 0;
+ 	int					scanCount = 0;
+@@ -228,7 +228,7 @@ DoAgain:
+ 	}
+ 
+ 	//	Set up structures for post processing
+-	if ( (autoRepair == true) && (dataArea.fileIdentifierTable != nil) )
++	if ((autoRepair == true) && (dataArea.fileIdentifierTable != NULL))
+ 	{
+ 	//	*repairInfo = *repairInfo | kVolumeHadOverlappingExtents;	//	Report back that volume has overlapping extents
+ 		fileIdentifierTable	= (FileIdentifierTable *) AllocateMemory( GetHandleSize( (Handle) dataArea.fileIdentifierTable ) );
+@@ -239,7 +239,7 @@ DoAgain:
+ 	//
+ 	//	Post processing
+ 	//
+-	if ( fileIdentifierTable != nil )
++	if (fileIdentifierTable != NULL)
+ 	{
+ 		DisposeMemory( fileIdentifierTable );
+ 	}
+@@ -682,7 +682,7 @@ short CheckForStop( SGlob *GPtr )
+ 
+ 	//if ( ((ticks - 10) > GPtr->lastTickCount) || (dfaStage == kAboutToRepairStage) )			//	To reduce cursor flicker on fast machines, call through on a timed interval
+ 	//{
+-		if ( GPtr->userCancelProc != nil )
++		if (GPtr->userCancelProc != NULL)
+ 		{
+ 			UInt64	progress = 0;
+ 			Boolean	progressChanged;
+@@ -761,7 +761,7 @@ static int ScavSetUp( SGlob *GPtr)
+ 	short	ioRefNum;
+ #endif
+ 
+-	GPtr->MinorRepairsP = nil;
++	GPtr->MinorRepairsP = NULL;
+ 	
+ 	GPtr->itemsProcessed = 0;
+ 	GPtr->lastProgress = 0;
+@@ -774,7 +774,7 @@ static int ScavSetUp( SGlob *GPtr)
+ 		ScavStaticStructures	*pointer;
+ 		
+ 		pointer = (ScavStaticStructures *) AllocateClearMemory( sizeof(ScavStaticStructures) );
+-		if ( pointer == nil ) {
++		if (pointer == NULL) {
+ 			if ( GPtr->logLevel >= kDebugLog ) {
+ 				printf( "\t error %d - could not allocate %i bytes of memory \n",
+ 					R_NoMem, sizeof(ScavStaticStructures) );
+@@ -831,7 +831,7 @@ static int ScavSetUp( SGlob *GPtr)
+ 	//	Save current value of vcbWrCnt, to detect modifications to volume by other apps etc
+ 	if ( GPtr->volumeFeatures & volumeIsMountedMask )
+ 	{
+-		FlushVol( nil, GPtr->realVCB->vcbVRefNum );	//	Ask HFS to update all changes to disk
++		FlushVol(NULL, GPtr->realVCB->vcbVRefNum);	//	Ask HFS to update all changes to disk
+ 		GPtr->wrCnt = GPtr->realVCB->vcbWrCnt;		//	Remember write count after writing changes
+ 	}
+ #endif
+@@ -949,7 +949,7 @@ static int ScavSetUp( SGlob *GPtr)
+  	
+ 	// Keep a valid file id list for HFS volumes
+ 	GPtr->validFilesList = (UInt32**)NewHandle( 0 );
+-	if ( GPtr->validFilesList == nil ) {
++	if (GPtr->validFilesList == NULL) {
+ 		if ( GPtr->logLevel >= kDebugLog ) {
+ 			printf( "\t error %d - could not allocate file ID list \n", R_NoMem );
+ 		}
+@@ -995,17 +995,17 @@ static int ScavTerm( SGlobPtr GPtr )
+ 
+ 	(void) BitMapCheckEnd();
+ 
+-	while( (rP = GPtr->MinorRepairsP) != nil )		//	loop freeing leftover (undone) repair orders
++	while((rP = GPtr->MinorRepairsP) != NULL)		//	loop freeing leftover (undone) repair orders
+ 	{
+ 		GPtr->MinorRepairsP = rP->link;				//	(in case repairs were not made)
+ 		DisposeMemory(rP);
+ 		err = MemError();
+ 	}
+ 	
+-	if( GPtr->validFilesList != nil )
++	if (GPtr->validFilesList != NULL)
+ 		DisposeHandle( (Handle) GPtr->validFilesList );
+ 	
+-	if( GPtr->overlappedExtents != nil ) {
++	if (GPtr->overlappedExtents != NULL) {
+  		extentsTableH = GPtr->overlappedExtents;
+  	
+ 		/* Overlapped extents list also allocated memory for attribute name */
+@@ -1021,44 +1021,44 @@ static int ScavTerm( SGlobPtr GPtr )
+ 		DisposeHandle( (Handle) GPtr->overlappedExtents );
+ 	}
+ 	
+-	if( GPtr->fileIdentifierTable != nil )
++	if (GPtr->fileIdentifierTable != NULL)
+ 		DisposeHandle( (Handle) GPtr->fileIdentifierTable );
+ 	
+-	if( GPtr->calculatedVCB == nil )								//	already freed?
++	if (GPtr->calculatedVCB == NULL)								//	already freed?
+ 		return( noErr );
+ 
+ 	//	If the FCB's and BTCB's have been set up, dispose of them
+ 	fcbP = GPtr->calculatedExtentsFCB;	// release extent file BTree bit map
+-	if ( fcbP != nil )
++	if (fcbP != NULL)
+ 	{
+ 		btcbP = (BTreeControlBlock*)fcbP->fcbBtree;
+-		if ( btcbP != nil)
++		if (btcbP != NULL)
+ 		{
+-			if( btcbP->refCon != nil )
++			if (btcbP->refCon != NULL)
+ 			{
+-				if(((BTreeExtensionsRec*)btcbP->refCon)->BTCBMPtr != nil)
++				if (((BTreeExtensionsRec*)btcbP->refCon)->BTCBMPtr != NULL)
+ 				{
+ 					DisposeMemory(((BTreeExtensionsRec*)btcbP->refCon)->BTCBMPtr);
+ 					err = MemError();
+ 				}
+ 				DisposeMemory( (Ptr)btcbP->refCon );
+ 				err = MemError();
+-				btcbP->refCon = nil;
++				btcbP->refCon = NULL;
+ 			}
+ 				
+ 			fcbP = GPtr->calculatedCatalogFCB;	//	release catalog BTree bit map
+ 			btcbP = (BTreeControlBlock*)fcbP->fcbBtree;
+ 				
+-			if( btcbP->refCon != nil )
++			if (btcbP->refCon != NULL)
+ 			{
+-				if(((BTreeExtensionsRec*)btcbP->refCon)->BTCBMPtr != nil)
++				if (((BTreeExtensionsRec*)btcbP->refCon)->BTCBMPtr != NULL)
+ 				{
+ 					DisposeMemory(((BTreeExtensionsRec*)btcbP->refCon)->BTCBMPtr);
+ 					err = MemError();
+ 				}
+ 				DisposeMemory( (Ptr)btcbP->refCon );
+ 				err = MemError();
+-				btcbP->refCon = nil;
++				btcbP->refCon = NULL;
+ 			}
+ 		}
+ 	}
+@@ -1066,7 +1066,7 @@ static int ScavTerm( SGlobPtr GPtr )
+ 	DisposeMemory( GPtr->calculatedVCB );						//	Release our block of data structures	
+ 	err = MemError();
+ 
+-	GPtr->calculatedVCB = nil;
++	GPtr->calculatedVCB = NULL;
+ 
+ 	return( noErr );
+ }
+@@ -1113,7 +1113,7 @@ Boolean IsBlueBoxSharedDrive ( DrvQElPtr dqPtr )
+ 	// Now look at the name of the Driver name. If it is .BlueBoxShared keep it out of the list of available disks.
+ 	driverDCtlHandle = GetDCtlEntry(dqPtr->dQRefNum);
+ 	driverDCtlPtr = *driverDCtlHandle;
+-	if((((driverDCtlPtr->dCtlFlags) & Is_Native_Mask) == 0) && (driverDCtlPtr->dCtlDriver != nil))
++	if((((driverDCtlPtr->dCtlFlags) & Is_Native_Mask) == 0) && (driverDCtlPtr->dCtlDriver != NULL))
+ 	{
+ 		if (((driverDCtlPtr->dCtlFlags) & Is_Ram_Based_Mask) == 0)
+ 		{
+@@ -1127,19 +1127,19 @@ Boolean IsBlueBoxSharedDrive ( DrvQElPtr dqPtr )
+ 			
+ 		}
+ 		driverName = (StringPtr)&(drvrHeaderPtr->drvrName);
+-		if (!(IdenticalString(driverName,blueBoxSharedDriverName,nil)))
++		if (!(IdenticalString(driverName,blueBoxSharedDriverName,NULL)))
+ 		{
+ 			return( true );
+ 		}
+ 
+ 		// Special case for the ".Sony" floppy driver which might be accessed in Shared mode inside the Blue Box
+ 		// Test its "where" string instead of the driver name.
+-		if (!(IdenticalString(driverName,sonyDriverName,nil)))
++		if (!(IdenticalString(driverName,sonyDriverName,NULL)))
+ 		{
+ 			CntrlParam			paramBlock;
+ 		
+-			paramBlock.ioCompletion	= nil;
+-			paramBlock.ioNamePtr	= nil;
++			paramBlock.ioCompletion	= NULL;
++			paramBlock.ioNamePtr	= NULL;
+ 			paramBlock.ioVRefNum	= dqPtr->dQDrive;
+ 			paramBlock.ioCRefNum	= dqPtr->dQRefNum;
+ 			paramBlock.csCode		= kDriveIcon;						// return physical icon
+@@ -1152,7 +1152,7 @@ Boolean IsBlueBoxSharedDrive ( DrvQElPtr dqPtr )
+ 				
+ 				iconAndStringRecPtr = * (IconAndStringRecPtr*) & paramBlock.csParam;
+ 				whereStringPtr = (StringPtr) & iconAndStringRecPtr->string;
+-				if (!(IdenticalString(whereStringPtr,blueBoxFloppyWhereString,nil)))
++				if (!(IdenticalString(whereStringPtr,blueBoxFloppyWhereString,NULL)))
+ 				{
+ 					return( true );
+ 				}
+diff --git a/fsck_hfs.tproj/dfalib/SRepair.c b/fsck_hfs.tproj/dfalib/SRepair.c
+index 89c12d6..b261c37 100644
+--- a/fsck_hfs.tproj/dfalib/SRepair.c
++++ b/fsck_hfs.tproj/dfalib/SRepair.c
+@@ -844,7 +844,7 @@ static	int	DelFThd( SGlobPtr GPtr, UInt32 fid )				//	the file ID
+ 
+ 	isHFSPlus = VolumeObjectIsHFSPlus( );
+ 	
+-	BuildCatalogKey( fid, (const CatalogName*) nil, isHFSPlus, &key );
++	BuildCatalogKey(fid, NULL, isHFSPlus, &key);
+ 	result = SearchBTreeRecord( GPtr->calculatedCatalogFCB, &key, kNoHint, &foundKey, &record, &recSize, &hint );
+ 	
+ 	if ( result )	return ( IntError( GPtr, result ) );
+@@ -910,7 +910,7 @@ static	OSErr	FixDirThread( SGlobPtr GPtr, UInt32 did )	//	the dir ID
+ 
+ 	isHFSPlus = VolumeObjectIsHFSPlus( );
+ 
+-	BuildCatalogKey( did, (const CatalogName*) nil, isHFSPlus, &key );
++	BuildCatalogKey(did, NULL, isHFSPlus, &key);
+ 	result = SearchBTreeRecord( GPtr->calculatedCatalogFCB, &key, kNoHint, &foundKey, &record, &recSize, &hint );
+ 	
+ 	if ( result )
+@@ -2171,7 +2171,7 @@ static	OSErr	FixOrphanedFiles ( SGlobPtr GPtr )
+ 				}
+ 
+ 				//-- Build the key for the file thread
+-				BuildCatalogKey( cNodeID, nil, isHFSPlus, &key );
++				BuildCatalogKey(cNodeID, NULL, isHFSPlus, &key);
+ 
+ 				err = SearchBTreeRecord( GPtr->calculatedCatalogFCB, &key, kNoHint, 
+ 										 &tempKey, &threadRecord, &recordSize, &hint2 );
+diff --git a/fsck_hfs.tproj/dfalib/SUtils.c b/fsck_hfs.tproj/dfalib/SUtils.c
+index 6e9253e..491afbf 100644
+--- a/fsck_hfs.tproj/dfalib/SUtils.c
++++ b/fsck_hfs.tproj/dfalib/SUtils.c
+@@ -395,11 +395,11 @@ OSErr GetVolumeFeatures( SGlobPtr GPtr )
+ 	err = GetVCBDriveNum( &GPtr->realVCB, GPtr->DrvNum );
+ 	ReturnIfError( err );
+ 
+-	if ( GPtr->realVCB != nil )
++	if (GPtr->realVCB != NULL)
+ 	{
+ 		GPtr->volumeFeatures	|= volumeIsMountedMask;
+ 
+-		pb.ioParam.ioNamePtr	= nil;
++		pb.ioParam.ioNamePtr	= NULL;
+ 		pb.ioParam.ioVRefNum	= GPtr->realVCB->vcbVRefNum;
+ 		pb.ioParam.ioBuffer		= (Ptr) &buffer;
+ 		pb.ioParam.ioReqCount	= sizeof( buffer );
+@@ -2282,7 +2282,7 @@ void print_prime_buckets(PrimeBuckets *cur);
+  *     	   	4. btreetye - can be kHFSPlusCatalogRecord or kHFSPlusAttributeRecord
+  *                            indicates which btree prime number bucket should be incremented
+  *
+- * Output:	nil
++ * Output:	NULL
+  */
+ void RecordXAttrBits(SGlobPtr GPtr, UInt16 flags, HFSCatalogNodeID fileid, UInt16 btreetype) 
+ {
+diff --git a/fsck_hfs.tproj/dfalib/SVerify1.c b/fsck_hfs.tproj/dfalib/SVerify1.c
+index 39bda5c..c33155f 100644
+--- a/fsck_hfs.tproj/dfalib/SVerify1.c
++++ b/fsck_hfs.tproj/dfalib/SVerify1.c
+@@ -790,13 +790,13 @@ OSErr	CreateExtentsBTreeControlBlock( SGlobPtr GPtr )
+ 	//	set up our DFA extended BTCB area.  Will we have enough memory on all HFS+ volumes.
+ 	//
+ 	btcb->refCon = AllocateClearMemory( sizeof(BTreeExtensionsRec) );			// allocate space for our BTCB extensions
+-	if ( btcb->refCon == nil ) {
++	if (btcb->refCon == NULL) {
+ 		err = R_NoMem;
+ 		goto exit;
+ 	}
+ 	size = (btcb->totalNodes + 7) / 8;											//	size of BTree bit map
+ 	((BTreeExtensionsRec*)btcb->refCon)->BTCBMPtr = AllocateClearMemory(size);			//	get precleared bitmap
+-	if ( ((BTreeExtensionsRec*)btcb->refCon)->BTCBMPtr == nil )
++	if (((BTreeExtensionsRec*)btcb->refCon)->BTCBMPtr == NULL)
+ 	{
+ 		err = R_NoMem;
+ 		goto exit;
+@@ -1145,13 +1145,13 @@ OSErr	CreateCatalogBTreeControlBlock( SGlobPtr GPtr )
+ 	//
+ 
+ 	btcb->refCon = AllocateClearMemory( sizeof(BTreeExtensionsRec) );			// allocate space for our BTCB extensions
+-	if ( btcb->refCon == nil ) {
++	if (btcb->refCon == NULL) {
+ 		err = R_NoMem;
+ 		goto exit;
+ 	}
+ 	size = (btcb->totalNodes + 7) / 8;											//	size of BTree bit map
+ 	((BTreeExtensionsRec*)btcb->refCon)->BTCBMPtr = AllocateClearMemory(size);			//	get precleared bitmap
+-	if ( ((BTreeExtensionsRec*)btcb->refCon)->BTCBMPtr == nil )
++	if (((BTreeExtensionsRec*)btcb->refCon)->BTCBMPtr == NULL)
+ 	{
+ 		err = R_NoMem;
+ 		goto exit;
+@@ -1339,7 +1339,7 @@ OSErr CatHChk( SGlobPtr GPtr )
+ 	
+ 	//¥¥ Can we ignore this part by just taking advantage of setting the selCode = 0x8001;
+ 	{ 
+-		BuildCatalogKey( 1, (const CatalogName *)nil, isHFSPlus, &key );
++		BuildCatalogKey(1, NULL, isHFSPlus, &key);
+ 		result = SearchBTreeRecord( GPtr->calculatedCatalogFCB, &key, kNoHint, &foundKey, &threadRecord, &recSize, &hint );
+ 	
+ 		GPtr->TarBlock = hint;									/* set target block */
+@@ -1443,7 +1443,7 @@ OSErr CatHChk( SGlobPtr GPtr )
+ 				/* 
+ 				 * Find thread record
+ 				 */
+-				BuildCatalogKey( dprP->directoryID, (const CatalogName *) nil, isHFSPlus, &key );
++				BuildCatalogKey(dprP->directoryID, NULL, isHFSPlus, &key);
+ 				result = SearchBTreeRecord( GPtr->calculatedCatalogFCB, &key, kNoHint, &foundKey, &threadRecord, &recSize, &hint );
+ 				if ( result != noErr ) {
+ 					char idStr[16];
+@@ -1780,26 +1780,26 @@ OSErr	CreateAttributesBTreeControlBlock( SGlobPtr GPtr )
+ 	//	set up our DFA extended BTCB area.  Will we have enough memory on all HFS+ volumes.
+ 	//
+ 	btcb->refCon = AllocateClearMemory( sizeof(BTreeExtensionsRec) );			// allocate space for our BTCB extensions
+-	if ( btcb->refCon == nil ) {
++	if (btcb->refCon == NULL) {
+ 		err = R_NoMem;
+ 		goto exit;
+ 	}
+ 
+ 	if (btcb->totalNodes == 0)
+ 	{
+-		((BTreeExtensionsRec*)btcb->refCon)->BTCBMPtr			= nil;
++		((BTreeExtensionsRec*)btcb->refCon)->BTCBMPtr			= NULL;
+ 		((BTreeExtensionsRec*)btcb->refCon)->BTCBMSize			= 0;
+ 		((BTreeExtensionsRec*)btcb->refCon)->realFreeNodeCount	= 0;
+ 	}
+ 	else
+ 	{
+-		if ( btcb->refCon == nil ) {
++		if (btcb->refCon == NULL) {
+ 			err = R_NoMem;
+ 			goto exit;
+ 		}
+ 		size = (btcb->totalNodes + 7) / 8;											//	size of BTree bit map
+ 		((BTreeExtensionsRec*)btcb->refCon)->BTCBMPtr = AllocateClearMemory(size);			//	get precleared bitmap
+-		if ( ((BTreeExtensionsRec*)btcb->refCon)->BTCBMPtr == nil )
++		if (((BTreeExtensionsRec*)btcb->refCon)->BTCBMPtr == NULL)
+ 		{
+ 			err = R_NoMem;
+ 			goto exit;
+@@ -2358,7 +2358,7 @@ static	OSErr	RcdMDBEmbededVolDescriptionErr( SGlobPtr GPtr, OSErr type, HFSMaste
+ 	RcdError( GPtr, type );												//	first, record the error
+ 	
+ 	p = AllocMinorRepairOrder( GPtr, sizeof(EmbededVolDescription) );	//	get the node
+-	if ( p == nil )	return( R_NoMem );
++	if (p == NULL)	return( R_NoMem );
+ 	
+ 	p->type							=  type;							//	save error info
+ 	desc							=  (EmbededVolDescription *) &(p->name);
+@@ -2397,7 +2397,7 @@ static	OSErr	RcdInvalidWrapperExtents( SGlobPtr GPtr, OSErr type )
+ 	RcdError( GPtr, type );												//	first, record the error
+ 	
+ 	p = AllocMinorRepairOrder( GPtr, 0 );	//	get the node
+-	if ( p == nil )	return( R_NoMem );
++	if (p == NULL)	return( R_NoMem );
+ 	
+ 	p->type							=  type;							//	save error info
+ 	
+@@ -3029,7 +3029,7 @@ OSErr	CheckFileExtents( SGlobPtr GPtr, UInt32 fileNumber, UInt8 forkType,
+ 	foundBadExtent = false;
+ 	lastExtentIndex = GPtr->numExtents;
+ 	
+-	while ( (extents != nil) && (err == noErr) )
++	while ((extents != NULL) && (err == noErr))
+ 	{	
+ 		//	checkout the extent record first
+ 		err = ChkExtRec( GPtr, extents, &lastExtentIndex );
+@@ -3105,7 +3105,7 @@ OSErr	CheckFileExtents( SGlobPtr GPtr, UInt32 fileNumber, UInt8 forkType,
+ 			if ( err == btNotFound )
+ 			{
+ 				err = noErr;								//	 no more extent records
+-				extents = nil;
++				extents = NULL;
+ 				break;
+ 			}
+ 			else if ( err != noErr )
+@@ -3121,7 +3121,7 @@ OSErr	CheckFileExtents( SGlobPtr GPtr, UInt32 fileNumber, UInt8 forkType,
+ 			if ( err == btNotFound )
+ 			{
+ 				err = noErr;								//	 no more extent records
+-				extents = nil;
++				extents = NULL;
+ 				break;
+ 			}
+ 			else if ( err != noErr )
+@@ -3205,7 +3205,7 @@ static OSErr	AddExtentToOverlapList( SGlobPtr GPtr, HFSCatalogNodeID fileNumber,
+ 	}
+ 	
+ 	//	If it's uninitialized
+-	if ( GPtr->overlappedExtents == nil )
++	if (GPtr->overlappedExtents == NULL)
+ 	{
+ 		GPtr->overlappedExtents	= (ExtentsTable **) NewHandleClear( sizeof(ExtentsTable) );
+ 		extentsTableH	= GPtr->overlappedExtents;
+diff --git a/fsck_hfs.tproj/dfalib/SVerify2.c b/fsck_hfs.tproj/dfalib/SVerify2.c
+index c68f3d8..da1a982 100644
+--- a/fsck_hfs.tproj/dfalib/SVerify2.c
++++ b/fsck_hfs.tproj/dfalib/SVerify2.c
+@@ -1013,7 +1013,7 @@ static int BTKeyChk( SGlobPtr GPtr, NodeDescPtr nodeP, BTreeControlBlock *btcb )
+ 	UInt16				keyLength;
+ 	KeyPtr 				keyPtr;
+ 	UInt8				*dataPtr;
+-	KeyPtr				prevkeyP	= nil;
++	KeyPtr				prevkeyP	= NULL;
+ 
+ 
+ 	if ( nodeP->numRecords == 0 )
+@@ -1044,7 +1044,7 @@ static int BTKeyChk( SGlobPtr GPtr, NodeDescPtr nodeP, BTreeControlBlock *btcb )
+ 				return( E_KeyLen );
+ 			}
+ 	
+-			if ( prevkeyP != nil )
++			if (prevkeyP != NULL)
+ 			{
+ 				if ( CompareKeys( (BTreeControlBlockPtr)btcb, prevkeyP, keyPtr ) >= 0 )
+ 				{

--- a/utils/hfsprogs/patches/0011-Fix-types.patch
+++ b/utils/hfsprogs/patches/0011-Fix-types.patch
@@ -1,0 +1,71 @@
+From: =?UTF-8?q?Rog=C3=A9rio=20Brito?= <rbrito@ime.usp.br>
+Date: Thu, 24 Oct 2013 01:11:22 -0200
+Subject: Fix types
+
+---
+ fsck_hfs.tproj/cache.c | 30 ++++++++++++++++--------------
+ 1 file changed, 16 insertions(+), 14 deletions(-)
+
+diff --git a/fsck_hfs.tproj/cache.c b/fsck_hfs.tproj/cache.c
+index 527088a..540fa0b 100644
+--- a/fsck_hfs.tproj/cache.c
++++ b/fsck_hfs.tproj/cache.c
+@@ -961,20 +961,21 @@ int CacheLookup (Cache_t *cache, uint64_t off, Tag_t **tag)
+  */
+ int CacheRawRead (Cache_t *cache, uint64_t off, uint32_t len, void *buf)
+ {
+-	uint64_t	result;
++	off_t	result1;
++	ssize_t result2;
+ 		
+ 	/* Both offset and length must be multiples of the device block size */
+ 	if (off % cache->DevBlockSize) return (EINVAL);
+ 	if (len % cache->DevBlockSize) return (EINVAL);
+ 	
+ 	/* Seek to the position */
+-	result = lseek (cache->FD_R, off, SEEK_SET);
+-	if (result < 0) return (errno);
+-	if (result != off) return (ENXIO);
++	result1 = lseek(cache->FD_R, off, SEEK_SET);
++	if (result1 < 0) return (errno);
++	if (result1 != off) return (ENXIO);
+ 	/* Read into the buffer */
+-	result = read (cache->FD_R, buf, len);
+-	if (result < 0) return (errno);
+-	if (result == 0) return (ENXIO);
++	result2 = read(cache->FD_R, buf, len);
++	if (result2 < 0) return (errno);
++	if (result2 == 0) return (ENXIO);
+ 
+ 	/* Update counters */
+ 	cache->DiskRead++;
+@@ -989,21 +990,22 @@ int CacheRawRead (Cache_t *cache, uint64_t off, uint32_t len, void *buf)
+  */
+ int CacheRawWrite (Cache_t *cache, uint64_t off, uint32_t len, void *buf)
+ {
+-	uint64_t	result;
++	off_t	result1;
++	ssize_t result2;
+ 	
+ 	/* Both offset and length must be multiples of the device block size */
+ 	if (off % cache->DevBlockSize) return (EINVAL);
+ 	if (len % cache->DevBlockSize) return (EINVAL);
+ 	
+ 	/* Seek to the position */
+-	result = lseek (cache->FD_W, off, SEEK_SET);
+-	if (result < 0) return (errno);
+-	if (result != off) return (ENXIO);
++	result1 = lseek (cache->FD_W, off, SEEK_SET);
++	if (result1 < 0) return (errno);
++	if (result1 != off) return (ENXIO);
+ 	
+ 	/* Write into the buffer */
+-	result = write (cache->FD_W, buf, len);
+-	if (result < 0) return (errno);
+-	if (result == 0) return (ENXIO);
++	result2 = write (cache->FD_W, buf, len);
++	if (result2 < 0) return (errno);
++	if (result2 == 0) return (ENXIO);
+ 	
+ 	/* Update counters */
+ 	cache->DiskWrite++;

--- a/utils/hfsprogs/patches/0012-Fix-mkfs-not-creating-UUIDs-for-new-filesystems.patch
+++ b/utils/hfsprogs/patches/0012-Fix-mkfs-not-creating-UUIDs-for-new-filesystems.patch
@@ -1,0 +1,50 @@
+From: Matthew Garrett <mjg59@codon.org.uk>
+Date: Thu, 24 Oct 2013 01:11:22 -0200
+Subject: Fix mkfs not creating UUIDs for new filesystems.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fix mkfs not creating UUIDs for new filesystems.
+
+Thanks to Lars Noodén for reporting the bug at
+ <https://bugs.launchpad.net/bugs/737002>.
+
+This closes LP: #737002.
+---
+ include/missing.h | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/include/missing.h b/include/missing.h
+index 0a859c4..f50e8fb 100644
+--- a/include/missing.h
++++ b/include/missing.h
+@@ -72,7 +72,7 @@
+ #define NAME_MAX	255
+ 
+ /* Byteswap stuff */
+-#define NXSwapHostLongToBig(x)		cpu_to_be64(x)
++#define NXSwapHostLongToBig(x)		cpu_to_be32(x)
+ #define NXSwapBigShortToHost(x) 	be16_to_cpu(x)
+ #define OSSwapBigToHostInt16(x)		be16_to_cpu(x)
+ #define NXSwapBigLongToHost(x)		be32_to_cpu(x)
+@@ -88,6 +88,9 @@
+ #ifndef be32_to_cpu
+ #define be32_to_cpu(x) bswap_32(x)
+ #endif
++#ifndef cpu_to_be32
++#define cpu_to_be32(x) bswap_32(x)
++#endif
+ #ifndef be64_to_cpu
+ #define be64_to_cpu(x) bswap_64(x)
+ #endif
+@@ -102,6 +105,9 @@
+ #ifndef be32_to_cpu
+ #define be32_to_cpu(x)	(x)
+ #endif
++#ifndef cpu_to_be32
++#define cpu_to_be32(x)	(x)
++#endif
+ #ifndef be64_to_cpu
+ #define be64_to_cpu(x)	(x)
+ #endif

--- a/utils/hfsprogs/patches/0013-Fix-manpages.patch
+++ b/utils/hfsprogs/patches/0013-Fix-manpages.patch
@@ -1,0 +1,157 @@
+From: =?UTF-8?q?Rog=C3=A9rio=20Theodoro=20de=20Brito?= <rbrito@ime.usp.br>
+Date: Thu, 25 Nov 2010 00:00:00 -0200
+Subject: Fix manpages
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Remove typos, references in the "See also" sections of the manpages to
+commands that are not available in Debian systems (and, quite probably,
+other systems too) and non-Linux specific comments.
+
+Authored also by Christoph Hellwig <hch@lst.de> and  "A. Costa" <agcosta@gis.net>
+
+Bug-Debian: http://bugs.debian.org/598714
+Bug-Debian: http://bugs.debian.org/575201
+Forwarded: no
+Reviewed-by: Rogério Theodoro de Brito <rbrito@ime.usp.br>
+---
+ fsck_hfs.tproj/fsck_hfs.8   | 18 +++++++-----------
+ newfs_hfs.tproj/newfs_hfs.8 | 23 ++++++++---------------
+ 2 files changed, 15 insertions(+), 26 deletions(-)
+
+diff --git a/fsck_hfs.tproj/fsck_hfs.8 b/fsck_hfs.tproj/fsck_hfs.8
+index aec9949..0bc804d 100644
+--- a/fsck_hfs.tproj/fsck_hfs.8
++++ b/fsck_hfs.tproj/fsck_hfs.8
+@@ -19,18 +19,18 @@
+ .Dt FSCK_HFS 8
+ .Os "Mac OS X"
+ .Sh NAME
+-.Nm fsck_hfs
++.Nm fsck.hfs
+ .Nd HFS file system consistency check
+ .Sh SYNOPSIS
+-.Nm fsck_hfs
++.Nm fsck.hfs
+ .Fl q
+ .Op Fl df
+ .Ar special ...
+-.Nm fsck_hfs
++.Nm fsck.hfs
+ .Fl p
+ .Op Fl df
+ .Ar special ...
+-.Nm fsck_hfs
++.Nm fsck.hfs
+ .Op Fl n | y | r
+ .Op Fl dfgl
+ .Op Fl m Ar mode
+@@ -52,9 +52,7 @@ The second form of
+ preens the specified file systems.
+ It is normally started by
+ .Xr fsck 8
+-run from
+-.Pa /etc/rc.boot
+-during automatic reboot, when a HFS file system is detected.
++during systen boot, when a HFS file system is detected.
+ When preening file systems,
+ .Nm
+ will fix common inconsistencies for file systems that were not
+@@ -105,9 +103,9 @@ to check and repair journaled HFS+ file systems.
+ .It Fl g
+ Causes
+ .Nm
+-to generate it's output strings in GUI format.
++to generate its output strings in GUI format.
+ This option is used when another application with a graphical user interface
+-(like Mac OS X Disk Utility) is envoking the
++(like Mac OS X Disk Utility) is invoking the
+ .Nm
+ tool.
+ .It Fl l
+@@ -144,8 +142,6 @@ specified file system for a new catalog file and if there is no damage
+ to the leaf nodes in the existing catalog file.
+ .El
+ .Pp
+-Because of inconsistencies between the block device and the buffer cache,
+-the raw device should always be used.
+ .Sh SEE ALSO
+ .Xr fsck 8
+ .Sh BUGS
+diff --git a/newfs_hfs.tproj/newfs_hfs.8 b/newfs_hfs.tproj/newfs_hfs.8
+index d002cc9..fe91962 100644
+--- a/newfs_hfs.tproj/newfs_hfs.8
++++ b/newfs_hfs.tproj/newfs_hfs.8
+@@ -19,10 +19,10 @@
+ .Dt NEWFS_HFS 8
+ .Os "Mac OS X"
+ .Sh NAME
+-.Nm newfs_hfs
++.Nm mkfs.hfs
+ .Nd construct a new HFS Plus file system
+ .Sh SYNOPSIS
+-.Nm newfs_hfs
++.Nm mkfs.hfs
+ .Op Fl N Ar [partition-size]
+ .Op Fl U Ar uid
+ .Op Fl G Ar gid
+@@ -37,19 +37,13 @@
+ .Op Fl v Ar volume-name
+ .Ar special
+ .Sh DESCRIPTION
+-.Nm Newfs_hfs
++.Nm mkfs.hfs
+ builds an HFS Plus file system on the specified special device.
+-Before running 
+-.Nm newfs_hfs
+-the disk should be partitioned using the
+-.Em Disk Utility
+-application or
+-.Xr pdisk 8 .
+ .Pp
+ The file system default parameters are calculated based on
+ the size of the disk partition. Typically the defaults are
+ reasonable, however
+-.Nm newfs_hfs
++.Nm mkfs.hfs
+ has several options to allow the defaults to be selectively overridden.
+ The options are as follows:
+ .Bl -tag -width Fl
+@@ -66,7 +60,7 @@ Set the group of the file system's root directory to
+ Specify the access permissions mask for the file system's root directory.
+ .It Fl h
+ Creates a legacy HFS format filesystem. This option
+-is not recomended for file systems that will be
++is not recommended for file systems that will be
+ primarily used with Mac OS X or Darwin.
+ .It Fl s
+ Creates a case-sensitive HFS Plus filesystem. By
+@@ -93,7 +87,7 @@ sizes are specified with the
+ option followed by a comma
+ separated list of the form arg=blocks.
+ .Pp
+-Example:  -c c=5000,e=500
++Example:  \-c c=5000,e=500
+ .Bl -tag -width Fl
+ .It Em a=blocks
+ Set the attribute file clump size.
+@@ -126,7 +120,7 @@ the form arg=bytes. The
+ size must be a power of two and no larger than
+ 32768 bytes.
+ .Pp
+-Example:  -n c=8192,e=4096
++Example:  \-n c=8192,e=4096
+ .Bl -tag -width Fl
+ .It Em a=bytes
+ Set the attribute b-tree node size.
+@@ -139,8 +133,7 @@ Set the extent overflow b-tree node size.
+ Volume name (file system name) in ascii or UTF-8 format.
+ .El
+ .Sh SEE ALSO
+-.Xr mount 8 ,
+-.Xr pdisk 8
++.Xr mount 8
+ .Sh HISTORY
+ The
+ .Nm

--- a/utils/hfsprogs/patches/0014-uClibc_no_loadavg.patch
+++ b/utils/hfsprogs/patches/0014-uClibc_no_loadavg.patch
@@ -1,0 +1,15 @@
+--- diskdev_cmds-332.25/newfs_hfs.tproj/makehfs.c	2015-03-27 21:58:04.163171675 -0700
++++ hfsprogs-332.25/newfs_hfs.tproj/makehfs.c	2015-03-27 21:56:03.687175020 -0700
+@@ -2119,10 +2119,12 @@
+ 		sysctl(mib, 2, sysctlstring, &datalen, NULL, 0);
+ 		SHA1_Update(&context, sysctlstring, datalen);
+ #endif
++#ifndef __UCLIBC__
+ 		/* The system's load average: */
+ 		datalen = sizeof(sysloadavg);
+ 		getloadavg(sysloadavg, 3);
+ 		SHA1_Update(&context, &sysloadavg, datalen);
++#endif
+ 
+ 		/* The system's VM statistics: */
+ #if !LINUX


### PR DESCRIPTION
Adds supports for hfsprogs, allowing the creation and verification of
HFS/HFS+ filesystems.

This creates two selectable packages:
- hfsfsck
- mkhfs

A filesystem checking script is included with hfsfsck to allow OpenWrt
to check/repair filesystem errors.

Using Ubuntu's 332.25 sources plus their patches from debian/patches/.

Signed-off-by: Florian Fainelli <florian@openwrt.org>