### PR TITLE
ntfs-3g: fix build with musl when using internal libfuse

### DIFF
--- a/utils/ntfs-3g/patches/001-fuseint-fix-path-mounted-on-musl.patch
+++ b/utils/ntfs-3g/patches/001-fuseint-fix-path-mounted-on-musl.patch
@@ -1,0 +1,30 @@
+Index: ntfs-3g-2014.2.15-1-fuseint/libfuse-lite/fusermount.c
+===================================================================
+--- ntfs-3g-2014.2.15-1-fuseint.orig/libfuse-lite/fusermount.c
++++ ntfs-3g-2014.2.15-1-fuseint/libfuse-lite/fusermount.c
+@@ -36,6 +36,10 @@
+ 
+ #define FUSE_DEV_NEW "/dev/fuse"
+ 
++#ifndef _PATH_MOUNTED
++#define _PATH_MOUNTED "/proc/mounts"
++#endif
++
+ #ifndef MS_DIRSYNC
+ #define MS_DIRSYNC 128
+ #endif
+Index: ntfs-3g-2014.2.15-1-fuseint/libfuse-lite/mount_util.c
+===================================================================
+--- ntfs-3g-2014.2.15-1-fuseint.orig/libfuse-lite/mount_util.c
++++ ntfs-3g-2014.2.15-1-fuseint/libfuse-lite/mount_util.c
+@@ -255,6 +255,10 @@ int fuse_mnt_check_fuseblk(void)
+ 
+ #else /* __SOLARIS__ */
+ 
++#ifndef _PATH_MOUNTED
++#define _PATH_MOUNTED "/proc/mounts"
++#endif /* _PATH_MOUNTED */
++
+ static int mtab_needs_update(const char *mnt)
+ {
+ 	int res;


### PR DESCRIPTION
Signed-off-by: Daniel Golle <daniel@makrotopia.org>