### PR TITLE
libvpx: updated to 1.4.0

### DIFF
--- a/libs/libvpx/Makefile
+++ b/libs/libvpx/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2014 OpenWrt.org
+# Copyright (C) 2008-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libvpx
-PKG_VERSION:=1.3.0
+PKG_VERSION:=1.4.0
 PKG_RELEASE:=1
 
 PKG_REV:=v$(PKG_VERSION)

--- a/multimedia/gst1-plugins-good/Makefile
+++ b/multimedia/gst1-plugins-good/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-good
 PKG_VERSION:=1.4.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 


### PR DESCRIPTION
This update brings some fixes for VP9.
https://chromium.googlesource.com/webm/libvpx/+/v1.4.0

Also, it is ABI incompatible but the only known user of libvpx
is gst1-plugins-good, which is already compatile:
https://bugzilla.gnome.org/show_bug.cgi?id=739476

This change demands that gst1-plugin-good to be recompiled in order to rebuild package gst1-mod-vpx linking to the new library. However, the compiled plugin is still compatible with all the rest of gst1 plugins compiled before libvpx update.

Runtime tested on x86 target. It still encodes nicely.

@thess , what is the best way to deal with library upgrade? Look for dependents and bump its release? Or just let it go?

@MikePetullo , this affects you but might not demand any action.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>