### PR TITLE
gst1-plugins-bad: add opus plugin

### DIFF
--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-bad
 PKG_VERSION:=1.4.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -257,6 +257,7 @@ $(eval $(call GstBuildPlugin,mpegpsmux,mpegpsmux support,,,))
 #$(eval $(call GstBuildPlugin,mpegtsdemux,mpegtsdemux support,mpegts pbutils tag,,))
 #$(eval $(call GstBuildPlugin,mpegtsmux,mpegtsmux support,video,,))
 $(eval $(call GstBuildPlugin,mxf,mxf support,audio video,,))
+$(eval $(call GstBuildPlugin,opus,OPUS plugin library,audio tag rtp,,+libopus))
 $(eval $(call GstBuildPlugin,pcapparse,pcapparse support,,,))
 $(eval $(call GstBuildPlugin,pnm,pnm support,video,,))
 $(eval $(call GstBuildPlugin,rawparse,rawparse support,audio video,,))


### PR DESCRIPTION
This add opus plugin providing opusenc, opusdec, opusparse, rtpopuspay, rtpopusdepay

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

I tested live opus encoding into a ogg container without problems on target x86.
BTW, even without this commit, whether libopus was selected, gst1-plugins-bad was already compiling opus support, but it was not packaged.

@MikePetullo , for your considerations. Maybe opus description is not coherent with others.