### PR TITLE
apinger: add apinger package

### DIFF
--- a/net/apinger/Makefile
+++ b/net/apinger/Makefile
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=apinger
+PKG_VERSION:=0.6.1
+PKG_RELEASE=$(PKG_SOURCE_VERSION)
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/Jajcus/apinger.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=c7da72f7ec26eedd7fd8d224c0e10787b204f94e
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+
+PKG_MAINTAINER:=Alex Samorukov <samm@os2.kiev.ua>
+PKG_LICENSE:= GPL-2.0
+
+PKG_FIXUP:=autoreconf
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/apinger
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Tool which monitors various IP devices by simple ICMP echo requests
+  URL:=https://github.com/Jajcus/apinger
+  PKG_MAINTAINER:=Alex Samorukov <samm@os2.kiev.ua>
+endef
+
+define Package/apinger/description
+	Alarm Pinger (apinger) is a little tool which monitors various IP devices by
+	simple ICMP echo requests. There are various other tools, that can do this,
+	but most of them are shell or perl scripts, spawning many processes, thus much
+	CPU-expensive, especially when one wants continuous monitoring and fast
+	response on target failure.  Alarm Pinger is a single program written in C, so
+	it doesn't need much CPU power even when monitoring many targets with frequent
+	probes.  Alarm Pinger supports both IPv4 and IPv6. The code have been tested
+	on Linux and FreeBSD.
+endef
+
+define Package/apinger/conffiles
+/etc/apinger.conf
+endef
+
+define Build/Configure
+	$(call Build/Configure/Default)
+endef
+
+define Package/apinger/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/apinger $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/src/apinger.conf $(1)/etc/apinger.conf
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/apinger.init $(1)/etc/init.d/apinger
+endef
+
+$(eval $(call BuildPackage,apinger))
+

--- a/net/apinger/files/apinger.init
+++ b/net/apinger/files/apinger.init
@@ -1,0 +1,18 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2006-2011 OpenWrt.org
+
+START=80
+
+SERVICE_USE_PID=1
+
+start() {
+	service_start /usr/sbin/apinger
+}
+
+stop() {
+	service_stop /usr/sbin/apinger
+}
+
+reload() {
+	service_reload /usr/sbin/apinger
+}

--- a/net/apinger/patches/001-autoreconf.patch
+++ b/net/apinger/patches/001-autoreconf.patch
@@ -1,0 +1,13 @@
+--- apinger-0.6.1/acinclude.m4	2003-10-21 12:44:48.000000000 +0000
++++ apinger-0.6.1/acinclude.m4	2015-04-08 15:27:37.451903960 +0000
+@@ -39,9 +39,7 @@
+ 		[$jk_inet_includes
+ $jk_icmp_includes])
+ 
+-AC_CHECK_MEMBERS([struct icmp.icmp_type, struct icmp.icmp_code,\
+-struct icmp.icmp_cksum, struct icmp.icmp_seq,\
+-struct icmp.icmp_id],[],
++AC_CHECK_MEMBERS([struct icmp.icmp_type, struct icmp.icmp_code,struct icmp.icmp_cksum, struct icmp.icmp_seq,struct icmp.icmp_id],[],
+ 		AC_MSG_ERROR(struct icmp not defined or not compatible),
+ 		[$jk_inet_includes
+ $jk_icmp_includes])

--- a/net/apinger/patches/002-run_as_user.patch
+++ b/net/apinger/patches/002-run_as_user.patch
@@ -1,0 +1,11 @@
+--- apinger-0.6.1/src/apinger.conf.orig	2015-04-08 16:05:24.558919722 +0000
++++ apinger-0.6.1/src/apinger.conf	2015-04-08 16:07:47.089170236 +0000
+@@ -9,7 +9,7 @@
+ 
+ ## User and group the pinger should run as
+ user "nobody"
+-group "nobody"
++group "nogroup"
+ 
+ ## Mailer to use (default: "/usr/lib/sendmail -t")
+ #mailer "/var/qmail/bin/qmail-inject" 

--- a/net/apinger/patches/003-no_docs.patch
+++ b/net/apinger/patches/003-no_docs.patch
@@ -1,0 +1,11 @@
+--- apinger-0.6.1/Makefile.am.orig	2015-04-08 16:47:40.999990050 +0000
++++ apinger-0.6.1/Makefile.am	2015-04-08 16:48:07.565220137 +0000
+@@ -1,7 +1,7 @@
+ 
+ EXTRA_DIST = autogen.sh TODO BUGS
+ 
+-SUBDIRS = src doc
++SUBDIRS = src
+ 
+ .PHONY: ChangeLog
+ 


### PR DESCRIPTION
Alarm Pinger (apinger) is a little tool which monitors various IP devices by
simple ICMP echo requests. There are various other tools, that can do this,
but most of them are shell or perl scripts, spawning many processes, thus much
CPU-expensive, especially when one wants continuous monitoring and fast
response on target failure.

Signed-off-by: Alex Samorukov <samm@os2.kiev.ua>