### PR TITLE
mdnsresponder: Fixed IPv6 deprecated address handling

### DIFF
--- a/net/mdnsresponder/patches/100-linux_fixes.patch
+++ b/net/mdnsresponder/patches/100-linux_fixes.patch
@@ -1,3 +1,6 @@
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 0000000..920cdfc
 --- /dev/null
 +++ b/.gitignore
 @@ -0,0 +1,4 @@
@@ -5,6 +8,21 @@
 +mDNSPosix/build
 +mDNSPosix/objects
 +
+diff --git a/Clients/Makefile b/Clients/Makefile
+index 383af31..925c20e 100755
+--- a/Clients/Makefile
++++ b/Clients/Makefile
+@@ -34,7 +34,7 @@ TARGETS = build/dns-sd build/dns-sd64
+ LIBS =
+ else
+ TARGETS = build/dns-sd
+-LIBS = -L../mDNSPosix/build/prod/ -ldns_sd
++LIBS ?= -L../mDNSPosix/build/prod/ -ldns_sd
+ endif
+ 
+ all: $(TARGETS)
+diff --git a/mDNSPosix/PosixDaemon.c b/mDNSPosix/PosixDaemon.c
+index 88b3292..e86a6c7 100644
 --- a/mDNSPosix/PosixDaemon.c
 +++ b/mDNSPosix/PosixDaemon.c
 @@ -37,6 +37,11 @@
@@ -70,9 +88,11 @@
      if (mStatus_NoError == err)
          err = MainLoop(&mDNSStorage);
  
+diff --git a/mDNSPosix/Responder.c b/mDNSPosix/Responder.c
+index 3996b7b..e58d8eb 100755
 --- a/mDNSPosix/Responder.c
 +++ b/mDNSPosix/Responder.c
-@@ -603,7 +603,8 @@ static mStatus RegisterServicesInFile(co
+@@ -603,7 +603,8 @@ static mStatus RegisterServicesInFile(const char *filePath)
          status = mStatus_UnknownErr;
      }
  
@@ -82,9 +102,11 @@
  
      return status;
  }
+diff --git a/mDNSPosix/mDNSPosix.c b/mDNSPosix/mDNSPosix.c
+index 6effa12..d3acf99 100755
 --- a/mDNSPosix/mDNSPosix.c
 +++ b/mDNSPosix/mDNSPosix.c
-@@ -138,7 +138,7 @@ mDNSlocal void SockAddrTomDNSAddr(const
+@@ -138,7 +138,7 @@ mDNSlocal void SockAddrTomDNSAddr(const struct sockaddr *const sa, mDNSAddr *ipA
  
  // mDNS core calls this routine when it needs to send a packet.
  mDNSexport mStatus mDNSPlatformSendUDP(const mDNS *const m, const void *const msg, const mDNSu8 *const end,
@@ -93,7 +115,7 @@
                                         mDNSIPPort dstPort, mDNSBool useBackgroundTrafficClass)
  {
      int err = 0;
-@@ -583,9 +583,17 @@ mDNSlocal void FreePosixNetworkInterface
+@@ -583,9 +583,17 @@ mDNSlocal void FreePosixNetworkInterface(PosixNetworkInterface *intf)
  {
      assert(intf != NULL);
      if (intf->intfName != NULL) free((void *)intf->intfName);
@@ -113,7 +135,7 @@
  #endif
  
      // Move interface to the RecentInterfaces list for a minute
-@@ -724,6 +732,29 @@ mDNSlocal int SetupSocket(struct sockadd
+@@ -724,6 +732,29 @@ mDNSlocal int SetupSocket(struct sockaddr *intfAddr, mDNSIPPort port, int interf
              if (err < 0) { err = errno; perror("setsockopt - IP_MULTICAST_TTL"); }
          }
  
@@ -143,7 +165,7 @@
          // And start listening for packets
          if (err == 0)
          {
-@@ -805,6 +836,29 @@ mDNSlocal int SetupSocket(struct sockadd
+@@ -805,6 +836,29 @@ mDNSlocal int SetupSocket(struct sockaddr *intfAddr, mDNSIPPort port, int interf
              if (err < 0) { err = errno; perror("setsockopt - IPV6_MULTICAST_HOPS"); }
          }
  
@@ -173,7 +195,7 @@
          // And start listening for packets
          if (err == 0)
          {
-@@ -836,7 +890,12 @@ mDNSlocal int SetupSocket(struct sockadd
+@@ -836,7 +890,12 @@ mDNSlocal int SetupSocket(struct sockaddr *intfAddr, mDNSIPPort port, int interf
      }
  
      // Clean up
@@ -187,7 +209,7 @@
      assert((err == 0) == (*sktPtr != -1));
      return err;
  }
-@@ -1026,7 +1085,7 @@ mDNSlocal mStatus OpenIfNotifySocket(int
+@@ -1026,7 +1085,7 @@ mDNSlocal mStatus OpenIfNotifySocket(int *pFD)
      /* Subscribe the socket to Link & IP addr notifications. */
      mDNSPlatformMemZero(&snl, sizeof snl);
      snl.nl_family = AF_NETLINK;
@@ -196,7 +218,7 @@
      ret = bind(sock, (struct sockaddr *) &snl, sizeof snl);
      if (0 == ret)
          *pFD = sock;
-@@ -1104,11 +1163,18 @@ mDNSlocal mDNSu32       ProcessRoutingNo
+@@ -1104,11 +1163,18 @@ mDNSlocal mDNSu32       ProcessRoutingNotification(int sd)
          PrintNetLinkMsg(pNLMsg);
  #endif
  
@@ -217,7 +239,7 @@
  
          // Advance pNLMsg to the next message in the buffer
          if ((pNLMsg->nlmsg_flags & NLM_F_MULTI) != 0 && pNLMsg->nlmsg_type != NLMSG_DONE)
-@@ -1279,8 +1345,12 @@ mDNSexport mStatus mDNSPlatformInit(mDNS
+@@ -1279,8 +1345,12 @@ mDNSexport mStatus mDNSPlatformInit(mDNS *const m)
      if (err == mStatus_NoError) err = SetupSocket(&sa, zeroIPPort, 0, &m->p->unicastSocket6);
  #endif
  
@@ -230,7 +252,7 @@
  
      // Tell mDNS core about DNS Servers
      mDNS_Lock(m);
-@@ -1313,9 +1383,17 @@ mDNSexport void mDNSPlatformClose(mDNS *
+@@ -1313,9 +1383,17 @@ mDNSexport void mDNSPlatformClose(mDNS *const m)
  {
      assert(m != NULL);
      ClearInterfaceList(m);
@@ -250,7 +272,7 @@
  #endif
  }
  
-@@ -1571,14 +1649,14 @@ mDNSexport mStatus    mDNSPlatformClearS
+@@ -1571,14 +1649,14 @@ mDNSexport mStatus    mDNSPlatformClearSPSMACAddr(void)
  mDNSexport mDNSu16 mDNSPlatformGetUDPPort(UDPSocket *sock)
  {
      (void) sock; // unused
@@ -267,257 +289,63 @@
      return mDNSfalse;
  }
  
+diff --git a/mDNSPosix/mDNSUNP.c b/mDNSPosix/mDNSUNP.c
+index b392fc7..fe800af 100755
 --- a/mDNSPosix/mDNSUNP.c
 +++ b/mDNSPosix/mDNSUNP.c
-@@ -61,154 +61,86 @@
- #endif
- 
+@@ -63,6 +63,7 @@
  #if defined(AF_INET6) && HAVE_IPV6 && HAVE_LINUX
--#include <netdb.h>
--#include <arpa/inet.h>
-+#include <sys/types.h>
-+#include <ifaddrs.h>
+ #include <netdb.h>
+ #include <arpa/inet.h>
++#include <linux/if_addr.h>
  
--/* Converts a prefix length to IPv6 network mask */
--void plen_to_mask(int plen, char *addr) {
--    int i;
--    int colons=7; /* Number of colons in IPv6 address */
--    int bits_in_block=16; /* Bits per IPv6 block */
--    for(i=0; i<=colons; i++) {
--        int block, ones=0xffff, ones_in_block;
--        if (plen>bits_in_block) ones_in_block=bits_in_block;
--        else ones_in_block=plen;
--        block = ones & (ones << (bits_in_block-ones_in_block));
--        i==0 ? sprintf(addr, "%x", block) : sprintf(addr, "%s:%x", addr, block);
--        plen -= ones_in_block;
--    }
--}
- 
--/* Gets IPv6 interface information from the /proc filesystem in linux*/
--struct ifi_info *get_ifi_info_linuxv6(int family, int doaliases)
-+/* Correct way to deal with this is just to use getifaddrs (glibc
-+ * 2.3.3+ and various BSDs, but BSDs are 'slightly different' just to
-+ * make life interesting). We assume Linux getifaddrs is available,
-+ * and if not, please upgrade. */
-+struct ifi_info *get_ifi_info_linuxv6(int doaliases)
- {
--    struct ifi_info *ifi, *ifihead, **ifipnext, *ifipold, **ifiptr;
--    FILE *fp;
--    char addr[8][5];
--    int flags, myflags, index, plen, scope;
+ /* Converts a prefix length to IPv6 network mask */
+ void plen_to_mask(int plen, char *addr) {
+@@ -86,7 +87,7 @@ struct ifi_info *get_ifi_info_linuxv6(int family, int doaliases)
+     FILE *fp;
+     char addr[8][5];
+     int flags, myflags, index, plen, scope;
 -    char ifname[9], lastname[IFNAMSIZ];
--    char addr6[32+7+1]; /* don't forget the seven ':' */
--    struct addrinfo hints, *res0;
--    struct sockaddr_in6 *sin6;
--    struct in6_addr *addrptr;
--    int err;
--    int sockfd = -1;
--    struct ifreq ifr;
++    char ifname[IFNAMSIZ], lastname[IFNAMSIZ];
+     char addr6[32+7+1]; /* don't forget the seven ':' */
+     struct addrinfo hints, *res0;
+     struct sockaddr_in6 *sin6;
+@@ -94,7 +95,8 @@ struct ifi_info *get_ifi_info_linuxv6(int family, int doaliases)
+     int err;
+     int sockfd = -1;
+     struct ifreq ifr;
 -
--    res0=NULL;
--    ifihead = NULL;
--    ifipnext = &ifihead;
--    lastname[0] = 0;
--
--    if ((fp = fopen(PROC_IFINET6_PATH, "r")) != NULL) {
--        sockfd = socket(AF_INET6, SOCK_DGRAM, 0);
--        if (sockfd < 0) {
--            goto gotError;
--        }
--        while (fscanf(fp,
++    char mask[64] = "%4s%4s%4s%4s%4s%4s%4s%4s %02x %02x %02x %02x %";
++    sprintf(mask+strlen(mask), "%ds\n", IFNAMSIZ);
+     res0=NULL;
+     ifihead = NULL;
+     ifipnext = &ifihead;
+@@ -106,11 +108,12 @@ struct ifi_info *get_ifi_info_linuxv6(int family, int doaliases)
+             goto gotError;
+         }
+         while (fscanf(fp,
 -                      "%4s%4s%4s%4s%4s%4s%4s%4s %02x %02x %02x %02x %8s\n",
--                      addr[0],addr[1],addr[2],addr[3],
--                      addr[4],addr[5],addr[6],addr[7],
--                      &index, &plen, &scope, &flags, ifname) != EOF) {
--
--            myflags = 0;
--            if (strncmp(lastname, ifname, IFNAMSIZ) == 0) {
--                if (doaliases == 0)
--                    continue;   /* already processed this interface */
--                myflags = IFI_ALIAS;
--            }
--            memcpy(lastname, ifname, IFNAMSIZ);
--            ifi = (struct ifi_info*)calloc(1, sizeof(struct ifi_info));
--            if (ifi == NULL) {
--                goto gotError;
--            }
--
--            ifipold   = *ifipnext;       /* need this later */
--            ifiptr    = ifipnext;
--            *ifipnext = ifi;            /* prev points to this new one */
--            ifipnext = &ifi->ifi_next;  /* pointer to next one goes here */
--
--            sprintf(addr6, "%s:%s:%s:%s:%s:%s:%s:%s",
--                    addr[0],addr[1],addr[2],addr[3],
--                    addr[4],addr[5],addr[6],addr[7]);
--
--            /* Add address of the interface */
--            memset(&hints, 0, sizeof(hints));
--            hints.ai_family = AF_INET6;
--            hints.ai_flags = AI_NUMERICHOST;
--            err = getaddrinfo(addr6, NULL, &hints, &res0);
--            if (err) {
--                goto gotError;
--            }
--            ifi->ifi_addr = calloc(1, sizeof(struct sockaddr_in6));
--            if (ifi->ifi_addr == NULL) {
--                goto gotError;
--            }
--            memcpy(ifi->ifi_addr, res0->ai_addr, sizeof(struct sockaddr_in6));
--
--            /* Add netmask of the interface */
--            char ipv6addr[INET6_ADDRSTRLEN];
--            plen_to_mask(plen, ipv6addr);
--            ifi->ifi_netmask = calloc(1, sizeof(struct sockaddr_in6));
--            if (ifi->ifi_addr == NULL) {
--                goto gotError;
--            }
--            sin6=calloc(1, sizeof(struct sockaddr_in6));
--            addrptr=calloc(1, sizeof(struct in6_addr));
--            inet_pton(family, ipv6addr, addrptr);
--            sin6->sin6_family=family;
--            sin6->sin6_addr=*addrptr;
--            sin6->sin6_scope_id=scope;
--            memcpy(ifi->ifi_netmask, sin6, sizeof(struct sockaddr_in6));
--            free(sin6);
--
--
--            /* Add interface name */
--            memcpy(ifi->ifi_name, ifname, IFI_NAME);
--
--            /* Add interface index */
--            ifi->ifi_index = index;
--
--            /* Add interface flags*/
--            memcpy(ifr.ifr_name, ifname, IFNAMSIZ);
--            if (ioctl(sockfd, SIOCGIFFLAGS, &ifr) < 0) {
--                if (errno == EADDRNOTAVAIL) {
--                    /*
--                     * If the main interface is configured with no IP address but
--                     * an alias interface exists with an IP address, you get
--                     * EADDRNOTAVAIL for the main interface
--                     */
--                    free(ifi->ifi_addr);
--                    free(ifi);
--                    ifipnext  = ifiptr;
--                    *ifipnext = ifipold;
--                    continue;
--                } else {
--                    goto gotError;
--                }
--            }
--            ifi->ifi_flags = ifr.ifr_flags;
--            freeaddrinfo(res0);
--            res0=NULL;
--        }
--    }
--    goto done;
-+  struct ifaddrs *ifap, *ifa;
-+  struct ifi_info *ifi = NULL, *head = NULL;
++                      mask,
+                       addr[0],addr[1],addr[2],addr[3],
+                       addr[4],addr[5],addr[6],addr[7],
+                       &index, &plen, &scope, &flags, ifname) != EOF) {
  
--gotError:
--    if (ifihead != NULL) {
--        free_ifi_info(ifihead);
--        ifihead = NULL;
--    }
--    if (res0 != NULL) {
--        freeaddrinfo(res0);
--        res0=NULL;
-+  /* doaliases seems always true in the calls in current code */
-+  assert(doaliases);
-+
-+  if (getifaddrs(&ifap) < 0)
-+    {
-+      return NULL;
++            if (flags & IFA_F_DEPRECATED) continue;
+             myflags = 0;
+             if (strncmp(lastname, ifname, IFNAMSIZ) == 0) {
+                 if (doaliases == 0)
+@@ -205,7 +208,8 @@ gotError:
      }
--done:
--    if (sockfd != -1) {
+ done:
+     if (sockfd != -1) {
 -        assert(close(sockfd) == 0);
-+  for (ifa = ifap ; ifa ; ifa = ifa->ifa_next)
-+    {
-+      /* Care only about IPv6 addresses on non-point-to-point links. */
-+      if (!ifa->ifa_addr
-+          || ifa->ifa_addr->sa_family != AF_INET6)
-+        continue;
-+      ifi = calloc(1, sizeof(*ifi));
-+      if (!ifi)
-+        break;
-+      strncpy(ifi->ifi_name, ifa->ifa_name, IFI_NAME);
-+      /* We ignore ifi_{haddr,hlen}, everyone else does too */
-+      ifi->ifi_flags = ifa->ifa_flags;
-+      /* We ignore ifi_myflags; IFI_ALIAS isn't used anywhere */
-+      ifi->ifi_index = if_nametoindex(ifa->ifa_name);
-+      if (!(ifi->ifi_addr = malloc(sizeof(struct sockaddr_in6))))
-+        break;
-+      memcpy(ifi->ifi_addr, ifa->ifa_addr, sizeof(struct sockaddr_in6));
-+
-+      if (ifa->ifa_netmask)
-+        {
-+          if (!(ifi->ifi_netmask = malloc(sizeof(struct sockaddr_in6))))
-+            break;
-+          memcpy(ifi->ifi_netmask, ifa->ifa_netmask,
-+                 sizeof(struct sockaddr_in6));
-+        }
-+
-+      if (!(ifi->ifi_addr = malloc(sizeof(struct sockaddr_in6))))
-+        break;
-+      memcpy(ifi->ifi_addr, ifa->ifa_addr, sizeof(struct sockaddr_in6));
-+
-+
-+      if (ifa->ifa_flags & IFF_POINTOPOINT && ifa->ifa_dstaddr)
-+        {
-+          if (!(ifi->ifi_dstaddr = malloc(sizeof(struct sockaddr_in6))))
-+            break;
-+          memcpy(ifi->ifi_dstaddr, ifa->ifa_dstaddr,
-+                 sizeof(struct sockaddr_in6));
-+        }
-+      else if (ifa->ifa_broadaddr)
-+        {
-+          if (!(ifi->ifi_brdaddr = malloc(sizeof(struct sockaddr_in6))))
-+            break;
-+          memcpy(ifi->ifi_brdaddr, ifa->ifa_broadaddr,
-+                 sizeof(struct sockaddr_in6));
-+        }
-+      ifi->ifi_next = head;
-+      head = ifi;
-+      ifi = NULL;
-+    };
-+  if (ifi)
-+    {
-+      /* An error occurred. Let's bail out. */
-+      ifi->ifi_next = head;
-+      free_ifi_info(head);
-+      return NULL;
++      int rv = close(sockfd);
++      assert(rv == 0);
      }
--    return(ifihead);    /* pointer to first structure in linked list */
-+  freeifaddrs(ifap);
-+  return head;
+     return(ifihead);    /* pointer to first structure in linked list */
  }
-+
- #endif // defined(AF_INET6) && HAVE_IPV6 && HAVE_LINUX
- 
- struct ifi_info *get_ifi_info(int family, int doaliases)
-@@ -229,7 +161,7 @@ struct ifi_info *get_ifi_info(int family
- #endif
- 
- #if defined(AF_INET6) && HAVE_IPV6 && HAVE_LINUX
--    if (family == AF_INET6) return get_ifi_info_linuxv6(family, doaliases);
-+    if (family == AF_INET6) return get_ifi_info_linuxv6(doaliases);
- #endif
- 
-     sockfd = -1;
---- a/mDNSPosix/mDNSUNP.h
-+++ b/mDNSPosix/mDNSUNP.h
-@@ -97,8 +97,7 @@ struct ifi_info {
- };
- 
- #if defined(AF_INET6) && HAVE_IPV6 && HAVE_LINUX
--#define PROC_IFINET6_PATH "/proc/net/if_inet6"
--extern struct ifi_info  *get_ifi_info_linuxv6(int family, int doaliases);
-+extern struct ifi_info  *get_ifi_info_linuxv6(int doaliases);
- #endif
- 
- #if defined(AF_INET6) && HAVE_IPV6
+diff --git a/mDNSShared/dnsextd_parser.y b/mDNSShared/dnsextd_parser.y
+index 18c5990..d4b63ce 100644
 --- a/mDNSShared/dnsextd_parser.y
 +++ b/mDNSShared/dnsextd_parser.y
 @@ -15,6 +15,8 @@


### PR DESCRIPTION
Fixed deprecated address handling. The new getifaddr code in the patch that I wrote year ago was wrong; removed it and fixed old mDNSResponder code to work with correct sized interface names, and to handle deprecated flag.

(Diff produced by git diff upstream master in the fingon/mDNSResponder repository.)
