### PR TITLE
ruby: bump to 2.2.2

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -10,14 +10,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=2.2.1
+PKG_VERSION:=2.2.2
 PKG_RELEASE:=1
 
 PKG_LIBVER:=2.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://cache.ruby-lang.org/pub/ruby/$(PKG_LIBVER)/
-PKG_MD5SUM:=06973777736d8e6bdad8dcaa469a9da3
+PKG_MD5SUM:=af6eb4fa7247f1f7b2e19c8e6f3e3145
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING
@@ -803,6 +803,12 @@ HOST_CONFIGURE_ARGS += \
 	--disable-install-rdoc \
 	--disable-install-capi \
 	--with-static-linked-ext \
+
+# even not used, host build with restricted exts results in gems not being
+# compiling for target (probably some cross compiling problem like checking
+# host for selecting target features)
+#	--with-out-ext \
+#	--with-ext=thread,stringio \
 
 CONFIGURE_ARGS += \
 	--enable-shared \


### PR DESCRIPTION
This is a small ruby release, mainly to fix
CVE-2015-1855: Ruby OpenSSL Hostname Verification

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>