### PR TITLE
pulseaudio: fix libjson-c dep

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pulseaudio
 PKG_VERSION:=6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://freedesktop.org/software/pulseaudio/releases/
@@ -32,7 +32,7 @@ define Package/pulseaudio/Default
   SECTION:=sound
   CATEGORY:=Sound
   DEPENDS:=+libspeexdsp +libsndfile +libltdl +libpthread \
-	+librt +alsa-lib +libjson +libopenssl +libwrap +libcap $(ICONV_DEPENDS) $(INTL_DEPENDS)
+	+librt +alsa-lib +libjson-c +libopenssl +libwrap +libcap $(ICONV_DEPENDS) $(INTL_DEPENDS)
   TITLE:=Network sound server
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
   URL:=http://www.pulseaudio.org


### PR DESCRIPTION
libjson package [was removed](https://dev.openwrt.org/changeset?mail_addr=&mail_addr_confirm=&reponame=&new=44826%40trunk%2Fpackage%2Flibs%2Flibjson-c&old=39228%40trunk%2Fpackage%2Flibs%2Flibjson-c) from OpenWrt trunk, and, BTW, pulseaudio was always depended on `libjson-c`, not `libjson`:
```
$ ldd ./pulseaudio
...
        libpulsecore-6.0.so => ...
        libpulse.so.0 => ...
        libspeexdsp.so.1 => ...
        libpulsecommon-6.0.so => ...
        libjson-c.so.2 => ...
        libwrap.so.0 => ...
        libsndfile.so.1 => ...
        libltdl.so.7 => ...
        libcap.so.2 => ...
        libpthread.so.0 => ...
        librt.so.0 => ...
        libdl.so.0 => ...
        libm.so.0 => ...
        libc.so.0 => ...
```