### PR TITLE
smstools3: remove unnecessary build deps

### DIFF
--- a/utils/smstools3/Makefile
+++ b/utils/smstools3/Makefile
@@ -22,7 +22,7 @@ PKG_SOURCE_URL:=http://smstools3.kekekasvi.com/packages/
 PKG_MD5SUM:=0241ef60e646fac1a06254a848e61ed7
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
-PKG_BUILD_DEPENDS:=libiconv-full iconv socket nsl
+PKG_BUILD_DEPENDS:=libiconv-full iconv
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
There is no `socket` and `nsl` packages, this build dependencies was blindly taken from `oldpackages` feed.

Not sure it's worth of `PKG_REV` increasing.