### PR TITLE
Remove libcrypto dependency

### DIFF
--- a/libs/libimobiledevice/Makefile
+++ b/libs/libimobiledevice/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libimobiledevice
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Lukasz Baj <l.baj@radytek.com>
 PKG_LICENSE:=LGPL-2.1+
@@ -42,7 +42,7 @@ define Package/libimobiledevice
   $(call Package/libimobiledevice/Default)
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=$(ICONV_DEPENDS) +libplist +libusbmuxd +libopenssl +libcrypto
+  DEPENDS:=$(ICONV_DEPENDS) +libplist +libusbmuxd +libopenssl
 endef
 
 define Package/libimobiledevice/description

--- a/libs/libmicrohttpd/Makefile
+++ b/libs/libmicrohttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmicrohttpd
 PKG_VERSION:=0.9.38
-PKG_RELEASE:=1.1
+PKG_RELEASE:=1.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/libmicrohttpd
@@ -29,7 +29,7 @@ define Package/libmicrohttpd
 	CATEGORY:=Libraries
 	TITLE:=GNU libmicrohttpd is a library that runs an HTTP server.
 	URL:=http://www.gnu.org/software/libmicrohttpd/
-	DEPENDS:=+libpthread +libgcrypt +libgnutls +libgpg-error +libcrypto +libopenssl
+	DEPENDS:=+libpthread +libgcrypt +libgnutls +libgpg-error +libopenssl
 endef
 
 define Package/libmicrohttpd/description

--- a/mail/alpine/Makefile
+++ b/mail/alpine/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alpine
 PKG_VERSION:=2.20
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://patches.freeiz.com/alpine/release/src/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -44,7 +44,7 @@ endef
 define Package/alpine
 $(call Package/alpine/Default)
   TITLE+= (with OpenSSL support)
-  DEPENDS+= +libcrypto +libopenssl
+  DEPENDS+= +libopenssl
   VARIANT:=ssl
 endef
 

--- a/utils/usbmuxd/Makefile
+++ b/utils/usbmuxd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=usbmuxd
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_SOURCE_PROTO:=git
 
 PKG_MAINTAINER:=Lukasz Baj <l.baj@radytek.com>
@@ -31,7 +31,7 @@ define Package/usbmuxd
   CATEGORY:=Utilities
   TITLE:=USB multiplexing daemon
   URL:=http://www.libimobiledevice.org/
-  DEPENDS:=+librt +libusb-1.0 +libusbmuxd +libcrypto +libopenssl +libimobiledevice
+  DEPENDS:=+librt +libusb-1.0 +libusbmuxd +libopenssl +libimobiledevice
 endef
 
 define Package/usbmuxd/description


### PR DESCRIPTION
There is no separate `libcrypto` package. libcrypro.so is a part of `libopenssl` package for 3+ years.