### PR TITLE
bzip2: respect LDFLAGS

### DIFF
--- a/utils/bzip2/Makefile
+++ b/utils/bzip2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bzip2
 PKG_VERSION:=1.0.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.bzip.org/$(PKG_VERSION)
@@ -52,13 +52,15 @@ define Package/bzip2/description
 	data compressor. This package provides the binary.
 endef
 
-TARGET_CFLAGS += $(FPIC)
+TARGET_CFLAGS += \
+	$(FPIC) \
+	$(TARGET_LDFLAGS)
+
 CONFIGURE_ARGS += --prefix=/usr
 
 MAKE_FLAGS += \
 	-f Makefile-libbz2_so \
 	CFLAGS="$(TARGET_CFLAGS)" \
-	LDFLAGS="$(TARGET_LDLAGS)" \
 	all
 
 define Build/InstallDev


### PR DESCRIPTION
`LDFLAGS` are not used in `Makefile-libbz2_so`. The simplest way is to add `LDFLAGS` to `CFLAGS`.