### PR TITLE
fwknop: respect SSP settings

### DIFF
--- a/net/fwknop/Makefile
+++ b/net/fwknop/Makefile
@@ -86,6 +86,11 @@ CONFIGURE_ARGS += \
 	--without-gpgme \
 	--with-iptables=/usr/sbin/iptables
 
+ifneq ($(CONFIG_SSP_SUPPORT),y)
+CONFIGURE_ARGS+= \
+	--disable-stack-protector
+endif
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/fko.h $(1)/usr/include/


### PR DESCRIPTION
Makes SSP protection optional.