### PR TITLE
gnutls: fix compilation with external toolchain

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -127,7 +127,7 @@ CONFIGURE_ARGS+= \
 	--enable-openssl-compatibility \
 	--with-default-trust-store-dir=/etc/ssl/certs/ \
 	--disable-crywrap \
-	--with-librt-prefix="$(STAGING_DIR)/"
+	--with-librt-prefix="$(LIBRT_ROOT_DIR)/"
 
 ifneq ($(CONFIG_GNUTLS_EXT_LIBTASN1),y)
 CONFIGURE_ARGS += --with-included-libtasn1


### PR DESCRIPTION
Using `$(LIBRT_ROOT_DIR)` fixes compilation with external toolchain.