### PR TITLE
Optional IPv6 support

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -814,11 +814,16 @@ CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
 	--disable-rpath \
-	--enable-ipv6 \
 	--disable-install-doc \
 	--disable-install-capi \
 	--with-ruby-version=minor \
 	--with-iconv-dir=$(ICONV_PREFIX) \
+
+
+ifeq ($(CONFIG_IPV6),y)
+CONFIGURE_ARGS+= \
+	--enable-ipv6
+endif
 
 ifndef CONFIG_RUBY_DIGEST_USE_OPENSSL
 CONFIGURE_ARGS += \

--- a/libs/apr/Makefile
+++ b/libs/apr/Makefile
@@ -37,8 +37,13 @@ TARGET_CPPFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
 
 CONFIGURE_ARGS += \
 	--with-devrandom=/dev/urandom \
-	--disable-dso \
+	--disable-dso
+
+ifeq ($(CONFIG_IPV6),y)
+CONFIGURE_ARGS+= \
 	--enable-ipv6
+endif
+
 
 # XXX: ac_cv_sizeof_struct_iovec=1 is just to trick configure
 CONFIGURE_VARS += \

--- a/libs/libtorrent/Makefile
+++ b/libs/libtorrent/Makefile
@@ -51,6 +51,11 @@ CONFIGURE_ARGS+= \
 	--disable-instrumentation \
 	--with-zlib=$(STAGING_DIR)/usr
 
+ifeq ($(CONFIG_IPV6),y)
+CONFIGURE_ARGS+= \
+	--enable-ipv6
+endif
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/torrent $(1)/usr/include/

--- a/net/mtr/Makefile
+++ b/net/mtr/Makefile
@@ -47,6 +47,11 @@ CONFIGURE_ARGS += \
 	--without-gtk \
 	--without-glib \
 
+ifeq ($(CONFIG_IPV6),n)
+CONFIGURE_ARGS+= \
+	--disable-ipv6
+endif
+
 define Build/Configure
 	(cd $(PKG_BUILD_DIR); touch \
 		configure.in \

--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -77,12 +77,16 @@ CONFIGURE_ARGS += \
 	--disable-gss \
 	--disable-nfsv4 \
 	--disable-nfsv41 \
-	--disable-ipv6 \
 	--enable-static \
 	--enable-shared \
 	--disable-caps \
 	--disable-tirpc \
 	--disable-nfsdcld
+
+ifeq ($(CONFIG_IPV6),n)
+CONFIGURE_ARGS+= \
+	--disable-ipv6
+endif
 
 CONFIGURE_VARS += \
 	libblkid_cv_is_recent=yes \
@@ -102,9 +106,13 @@ HOST_CONFIGURE_ARGS += \
 	--disable-gss \
 	--disable-nfsv4 \
 	--disable-nfsv41 \
-	--disable-ipv6 \
 	--disable-tirpc \
 	--without-tcp-wrappers
+
+ifeq ($(CONFIG_IPV6),n)
+HOST_CONFIGURE_ARGS+= \
+	--disable-ipv6
+endif
 
 HOST_CONFIGURE_VARS += \
 	ac_cv_lib_event_event_dispatch=yes \

--- a/net/rtorrent/Makefile
+++ b/net/rtorrent/Makefile
@@ -79,6 +79,10 @@ ifeq ($(BUILD_VARIANT),rpc)
 		--with-xmlrpc-c
 endif
 
+ifeq ($(CONFIG_IPV6),y)
+	CONFIGURE_ARGS+= \
+		--enable-ipv6
+endif
 
 define Package/rtorrent/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/utils/lsof/Makefile
+++ b/utils/lsof/Makefile
@@ -32,9 +32,15 @@ define Package/lsof
   URL:=http://people.freebsd.org/~abe/
 endef
 
+ifeq ($(CONFIG_IPV6),y)
+  LINUX_CLIB_IPV6="-DHASIPv6"
+else
+  LINUX_CLIB_IPV6=
+endif
+
 define Build/Configure
 	cd $(PKG_BUILD_DIR); \
-		LINUX_CLIB="-DGLIBCV=2" \
+		LINUX_CLIB="-DGLIBCV=2 $(LINUX_CLIB_IPV6)" \
 		LSOF_CC="$(TARGET_CC)" \
 		LSOF_INCLUDE="-I$(STAGING_DIR)/usr/include" \
 		LSOF_VSTR="$(LINUX_VERSION)" \


### PR DESCRIPTION
Turn on/off IPv6 support, according to global `ONFIG_IPV6` setting.