### PR TITLE
Optional IPv6 support 

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
 PKG_VERSION:=2.2.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LIBVER:=2.2
 
@@ -815,7 +815,7 @@ CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
 	--disable-rpath \
-	--enable-ipv6 \
+	$(call autoconf_bool,CONFIG_IPV6,ipv6) \
 	--disable-install-doc \
 	--disable-install-capi \
 	--with-ruby-version=minor \

--- a/libs/apr/Makefile
+++ b/libs/apr/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apr
 PKG_VERSION:=1.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://mirrors.ibiblio.org/apache/apr/
@@ -38,7 +38,7 @@ TARGET_CPPFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
 CONFIGURE_ARGS += \
 	--with-devrandom=/dev/urandom \
 	--disable-dso \
-	--enable-ipv6
+	$(call autoconf_bool,CONFIG_IPV6,ipv6)
 
 # XXX: ac_cv_sizeof_struct_iovec=1 is just to trick configure
 CONFIGURE_VARS += \

--- a/libs/libtorrent/Makefile
+++ b/libs/libtorrent/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtorrent
-PKG_VERSION:=0.13.4-git-0
+PKG_VERSION:=0.13.4-git-1
 PKG_RELEASE=$(PKG_SOURCE_VERSION)
 
 PKG_SOURCE_PROTO:=git
@@ -49,7 +49,8 @@ CONFIGURE_ARGS+= \
 	--disable-debug \
 	--enable-openssl \
 	--disable-instrumentation \
-	--with-zlib=$(STAGING_DIR)/usr
+	--with-zlib=$(STAGING_DIR)/usr \
+	$(call autoconf_bool,CONFIG_IPV6,ipv6)
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include

--- a/net/mtr/Makefile
+++ b/net/mtr/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mtr
 PKG_VERSION:=0.86
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.bitwizard.nl/mtr
@@ -46,6 +46,7 @@ endef
 CONFIGURE_ARGS += \
 	--without-gtk \
 	--without-glib \
+	$(call autoconf_bool,CONFIG_IPV6,ipv6)
 
 define Build/Configure
 	(cd $(PKG_BUILD_DIR); touch \

--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=1.3.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MD5SUM:=1e2f3c1ed468dee02d00c534c002ea10
 
 PKG_SOURCE_URL:=@SF/nfs
@@ -77,12 +77,12 @@ CONFIGURE_ARGS += \
 	--disable-gss \
 	--disable-nfsv4 \
 	--disable-nfsv41 \
-	--disable-ipv6 \
 	--enable-static \
 	--enable-shared \
 	--disable-caps \
 	--disable-tirpc \
-	--disable-nfsdcld
+	--disable-nfsdcld \
+	$(call autoconf_bool,CONFIG_IPV6,ipv6)
 
 CONFIGURE_VARS += \
 	libblkid_cv_is_recent=yes \

--- a/net/rtorrent/Makefile
+++ b/net/rtorrent/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtorrent
-PKG_VERSION:=0.9.4-git-0
+PKG_VERSION:=0.9.4-git-1
 PKG_RELEASE=$(PKG_SOURCE_VERSION)
 
 PKG_SOURCE_PROTO:=git
@@ -72,7 +72,8 @@ TARGET_LDFLAGS += -lz -lpthread -Wl,-rpath-link=$(STAGING_DIR)/usr/lib
 CONFIGURE_ARGS+= \
 	--enable-shared \
 	--disable-static \
-	--disable-debug
+	--disable-debug \
+	$(call autoconf_bool,CONFIG_IPV6,ipv6)
 
 ifeq ($(BUILD_VARIANT),rpc)
 	CONFIGURE_ARGS += \

--- a/utils/lsof/Makefile
+++ b/utils/lsof/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=lsof
 PKG_VERSION:=4.86
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION)+dfsg.orig.tar.gz
 PKG_SOURCE_URL:=http://ftp2.de.debian.org/debian/pool/main/l/lsof
@@ -32,9 +32,15 @@ define Package/lsof
   URL:=http://people.freebsd.org/~abe/
 endef
 
+ifeq ($(CONFIG_IPV6),y)
+  LINUX_CLIB_IPV6="-DHASIPv6"
+else
+  LINUX_CLIB_IPV6=
+endif
+
 define Build/Configure
 	cd $(PKG_BUILD_DIR); \
-		LINUX_CLIB="-DGLIBCV=2" \
+		LINUX_CLIB="-DGLIBCV=2 $(LINUX_CLIB_IPV6)" \
 		LSOF_CC="$(TARGET_CC)" \
 		LSOF_INCLUDE="-I$(STAGING_DIR)/usr/include" \
 		LSOF_VSTR="$(LINUX_VERSION)" \


### PR DESCRIPTION
Turn on/off IPv6 support, according to global `CONFIG_IPV6` setting.
Replacement of https://github.com/openwrt/packages/pull/1177