### PR TITLE
boost 1.58.0: patch added

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 ## Description
 
-This is the OpenWrt "packages"-feed containing community-maintained packages.
+This is the OpenWrt "packages"-feed containing community-maintained build scripts, options and patches for applications, modules and libraries used within OpenWrt.
+
+Installation of pre-built packages is handled directly by the **opkg** utility within your running OpenWrt system or by using the [OpenWrt SDK](http://doc/howto/obtain.firmware.sdk) on a build system.
 
 ## Usage
+
+This repository is intended to be layered on-top of an OpenWrt buildroot. If you do not have an OpenWrt buildroot installed, see the documentation at: [OpenWrt Buildroot – Installation](http://wiki.openwrt.org/doc/howto/buildroot.exigence) on the OpenWrt support site.
 
 This feed is enabled by default. To install all its package definitions, run:
 ```


### PR DESCRIPTION
This pull request solves the problem discussed in https://github.com/openwrt/packages/issues/1160

Unfortunately, due to changes in the boostcpp.jam described here https://github.com/boostorg/boost/commit/beb53b6b9574f95309384bfc5afffb40d467bc04 , for now, boost 1.58.0 will require a patch to fix the options being sent to the GCC compiler, when compiling for MIPS based targets.
gcc.jam is not taking into account the mips1 arch when deciding to send -m32 and -m64 options to the gcc compiler.
