### PR TITLE
boost 1.58.0: added mips fix patch

### DIFF
--- a/libs/boost/patches/001-mips-options-fix.patch
+++ b/libs/boost/patches/001-mips-options-fix.patch
@@ -1,0 +1,11 @@
+--- boost_1_58_0/tools/build/src/tools/gcc.jam 2015-04-23 12:01:37.723438995 +0200
++++ boost_1_58_0/tools/build/src/tools/gcc.jam 2015-04-23 12:00:21.427441384 +0200
+@@ -451,7 +451,7 @@
+         else
+         {
+             local arch = [ feature.get-values architecture : $(properties) ] ;
+-            if $(arch) != arm
++            if $(arch) != arm && $(arch) != mips1
+             {
+                 if $(model) = 32
+                 {


### PR DESCRIPTION
This pull request solves the problem discussed in #1160

Unfortunately, due to changes in the boostcpp.jam described here boostorg/boost@beb53b6 , for now, boost 1.58.0 will require a patch to fix the options being sent to the GCC compiler, when compiling for MIPS based targets.
gcc.jam is not taking into account the mips1 arch when deciding to send -m32 and -m64 options to the gcc compiler.

I have also submitted a pull-request to fix the problem upstream (https://github.com/boostorg/build/pull/71)
