### PR TITLE
xz: remove call to default package

### DIFF
--- a/utils/xz/Makefile
+++ b/utils/xz/Makefile
@@ -38,7 +38,6 @@ $(call Package/xz/Default)
 endef
 
 define Package/liblzma
-$(call Package/xz/Default)
   SECTION:=libs
   CATEGORY:=Libraries
   DEPENDS:=+libpthread


### PR DESCRIPTION
Seems to help with some dependency workings.
Package liblzma shows up in the Libraries section.
Python3 seems to find it and link against it.

Requires package maintainer approval.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>