### PR TITLE
tcp_wrappers: don't set LIBS=-lnsl when building with musl

### DIFF
--- a/libs/tcp_wrappers/Makefile
+++ b/libs/tcp_wrappers/Makefile
@@ -32,11 +32,15 @@ endef
 
 TARGET_CFLAGS += $(FPIC)
 
+ifeq ($(CONFIG_USE_MUSL),)
+TARGET_EXTRA_LIBS:=LIBS=-lnsl
+endif
+
 define Build/Compile	
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		$(TARGET_CONFIGURE_OPTS) \
 		OPT_CFLAGS="$(TARGET_CFLAGS)" \
-		LIBS=-lnsl \
+		$(TARGET_EXTRA_LIBS) \
 		NETGROUP= \
 		VSYSLOG= \
 		BUGS= \

--- a/libs/tcp_wrappers/patches/005-no--lnsl-on-musl.patch
+++ b/libs/tcp_wrappers/patches/005-no--lnsl-on-musl.patch
@@ -1,0 +1,22 @@
+Index: tcp_wrappers_7.6/Makefile
+===================================================================
+--- tcp_wrappers_7.6.orig/Makefile
++++ tcp_wrappers_7.6/Makefile
+@@ -1,4 +1,4 @@
+-GLIBC=$(shell grep -s -c __GLIBC__ /usr/include/features.h)
++GLIBC=$(shell grep -s -c __GLIBC__ ${STAGING_DIR}/usr/include/features.h)
+ 
+ # @(#) Makefile 1.23 97/03/21 19:27:20
+ 
+@@ -146,9 +146,11 @@ freebsd:
+ 	LIBS= RANLIB=ranlib ARFLAGS=rv AUX_OBJ= NETGROUP= TLI= \
+ 	EXTRA_CFLAGS=-DSYS_ERRLIST_DEFINED VSYSLOG= all
+ 
++ifneq ($(GLIBC),)
+ ifneq ($(GLIBC),0)
+ MYLIB=-lnsl
+ endif
++endif
+ 
+ linux:
+ 	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \


### PR DESCRIPTION
Signed-off-by: Daniel Golle <daniel@makrotopia.org>