### PR TITLE
haproxy: fix PCREDIR

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -88,7 +88,7 @@ define Build/Compile
 		CFLAGS="$(TARGET_CFLAGS) -fno-align-jumps -fno-align-functions -fno-align-labels -fno-align-loops -pipe -fomit-frame-pointer -fhonour-copts" \
 		LD="$(TARGET_CC)" \
 		LDFLAGS="$(TARGET_LDFLAGS)" \
-		PCREDIR="$(STAGING_DIR)/usr/include" \
+		PCREDIR="$(STAGING_DIR)/usr" \
 		SMALL_OPTS="-DBUFSIZE=16384 -DMAXREWRITE=1030 -DSYSTEM_MAXCONN=165530 " \
 		USE_LINUX_TPROXY=1 USE_LINUX_SPLICE=1 USE_REGPARM=1 $(USE_OPENSSL) \
 		USE_ZLIB=yes USE_PCRE=1 \


### PR DESCRIPTION
`PCREDIR="$(STAGING_DIR)/usr/include"` should be changed to `PCREDIR="$(STAGING_DIR)/usr"`. Checkout haproxy Makefile for details:

```
$ cat build_dir/target-<target_name>/haproxy-1.5.11/Makefile
....
#   PCREDIR        : force the path to libpcre.
#   PCRE_LIB       : force the lib path to libpcre (defaults to $PCREDIR/lib).
#   PCRE_INC       : force the include path to libpcre ($PCREDIR/inc)
...
# PCREDIR is used to automatically construct the PCRE_INC and PCRE_LIB paths,
# same sub-directories, simply force these variables instead of PCREDIR. It is
# Forcing PCREDIR to an empty string will let the compiler use the default
PCREDIR         := $(shell pcre-config --prefix 2>/dev/null || echo /usr/local)
ifneq ($(PCREDIR),)
PCRE_INC        := $(PCREDIR)/include
PCRE_LIB        := $(PCREDIR)/lib
endif
...


```