### PR TITLE
exfat-nofuse: Depend on BUILD_PATENTED

### DIFF
--- a/kernel/exfat-nofuse/Makefile
+++ b/kernel/exfat-nofuse/Makefile
@@ -29,7 +29,7 @@ define KernelPackage/fs-exfat
 	TITLE:=ExFAT Kernel driver
 	FILES:=$(PKG_BUILD_DIR)/exfat.ko
 	AUTOLOAD:=$(call AutoLoad,30,exfat,1)
-	DEPENDS:=+kmod-nls-base
+	DEPENDS:=+kmod-nls-base @BUILD_PATENTED
 endef
 
 define KernelPackage/fs-exfat/description


### PR DESCRIPTION
ExFAT is patented by Microsoft.

Signed-off-by: Bruno Randolf <br1@einfach.org>