### PR TITLE
haproxy: fix halog linkage

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
 PKG_VERSION:=1.5.11
-PKG_RELEASE:=09
+PKG_RELEASE:=10
 PKG_SOURCE:=haproxy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://haproxy.1wt.eu/download/1.5/src/
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
@@ -96,12 +96,8 @@ define Build/Compile
 		install
 
 	$(MAKE) -C $(PKG_BUILD_DIR)/contrib/halog \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		CC="$(TARGET_CC)" \
-		CFLAGS="$(TARGET_CFLAGS) -fno-align-jumps -fno-align-functions -fno-align-labels -fno-align-loops -pipe -fomit-frame-pointer -fhonour-copts" \
-		LD="$(TARGET_CC)" \
-		LDFLAGS="$(TARGET_LDFLAGS)" \
-		VERSION="$(PKG_VERSION)-patch$(PKG_RELEASE)" \
+		CC="$(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_LDFLAGS)" \
+		OPTIMIZE="" \
 		halog
 endef
 


### PR DESCRIPTION
`contrib/halog/Makefile` ignores most of variables, including `LDFLAGS`. 

Bug discovered by @zyxmon.