### PR TITLE
apr: version bump to 1.5.2

### DIFF
--- a/libs/apr/Makefile
+++ b/libs/apr/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apr
-PKG_VERSION:=1.5.1
+PKG_VERSION:=1.5.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://mirrors.ibiblio.org/apache/apr/
-PKG_MD5SUM:=5486180ec5a23efb5cae6d4292b300ab
+PKG_MD5SUM:=4e9769f3349fe11fc0a5e1b224c236aa
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=Apache License
 


### PR DESCRIPTION
apr 1.5.1 is outdated, and cannot download from mirror sites.