### PR TITLE
cryptodev: get rid of get_unused_fd()

### DIFF
--- a/utils/cryptodev-linux/Makefile
+++ b/utils/cryptodev-linux/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=cryptodev-linux
 PKG_VERSION:=1.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.gna.org/cryptodev-linux/

--- a/utils/cryptodev-linux/patches/001-no-get-unused-fd.patch
+++ b/utils/cryptodev-linux/patches/001-no-get-unused-fd.patch
@@ -1,0 +1,13 @@
+Index: cryptodev-linux-1.7/ioctl.c
+===================================================================
+--- cryptodev-linux-1.7.orig/ioctl.c
++++ cryptodev-linux-1.7/ioctl.c
+@@ -546,7 +546,7 @@ static int
+ clonefd(struct file *filp)
+ {
+ 	int ret;
+-	ret = get_unused_fd();
++	ret = get_unused_fd_flags(0);
+ 	if (ret >= 0) {
+ 			get_file(filp);
+ 			fd_install(ret, filp);


### PR DESCRIPTION
The get_unused_fd() macro was removed upstream by
https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=f938612dd97d481b8b5bf960c992ae577f081c17

Thus replace get_unused_fd() by get_unused_fd_flags(0) which used to
be the definition of the get_unused_fd() macro before it was removed.

This fixes cryptodev compilation on kernel 4.0.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>