### PR TITLE
boost: patch update

### DIFF
--- a/libs/boost/patches/001-mips-options-fix.patch
+++ b/libs/boost/patches/001-mips-options-fix.patch
@@ -5,7 +5,7 @@
          {
              local arch = [ feature.get-values architecture : $(properties) ] ;
 -            if $(arch) != arm
-+            if $(arch) != arm && $(arch) != mips1
++            if $(arch) = power || $(arch) = sparc || $(arch) = x86
              {
                  if $(model) = 32
                  {


### PR DESCRIPTION
  This update follows after the previous update[[1]]
  Due to the Boost Dev patch submitted in [[2]], this commit also updates
    the boost patch in order to, instead of excluding all architectures
    that do not support -m32 and -m64 options, it now includes only the
    architectures that do support it.

 [1]: https://github.com/openwrt/packages/pull/1186
 [2]: https://github.com/boostorg/build/pull/76

 Signed-off-by: Carlos M. Ferreira carlosmf.pt@gmail.com