### PR TITLE
mdnsresponder: No longer require IPv4 address to start.

### DIFF
--- a/net/mdnsresponder/patches/100-linux_fixes.patch
+++ b/net/mdnsresponder/patches/100-linux_fixes.patch
@@ -103,7 +103,7 @@ index 3996b7b..e58d8eb 100755
      return status;
  }
 diff --git a/mDNSPosix/mDNSPosix.c b/mDNSPosix/mDNSPosix.c
-index 6effa12..d3acf99 100755
+index 6effa12..7c1d6eb 100755
 --- a/mDNSPosix/mDNSPosix.c
 +++ b/mDNSPosix/mDNSPosix.c
 @@ -138,7 +138,7 @@ mDNSlocal void SockAddrTomDNSAddr(const struct sockaddr *const sa, mDNSAddr *ipA
@@ -209,7 +209,30 @@ index 6effa12..d3acf99 100755
      assert((err == 0) == (*sktPtr != -1));
      return err;
  }
-@@ -1026,7 +1085,7 @@ mDNSlocal mStatus OpenIfNotifySocket(int *pFD)
+@@ -938,19 +997,14 @@ mDNSlocal int SetupInterfaceList(mDNS *const m)
+     int err            = 0;
+     struct ifi_info *intfList      = get_ifi_info(AF_INET, mDNStrue);
+     struct ifi_info *firstLoopback = NULL;
++    struct ifi_info **p = &intfList;
+ 
+     assert(m != NULL);
+     debugf("SetupInterfaceList");
+ 
+-    if (intfList == NULL) err = ENOENT;
+-
+ #if HAVE_IPV6
+-    if (err == 0)       /* Link the IPv6 list to the end of the IPv4 list */
+-    {
+-        struct ifi_info **p = &intfList;
+-        while (*p) p = &(*p)->ifi_next;
+-        *p = get_ifi_info(AF_INET6, mDNStrue);
+-    }
++    while (*p) p = &(*p)->ifi_next;
++    *p = get_ifi_info(AF_INET6, mDNStrue);
+ #endif
+ 
+     if (err == 0)
+@@ -1026,7 +1080,7 @@ mDNSlocal mStatus OpenIfNotifySocket(int *pFD)
      /* Subscribe the socket to Link & IP addr notifications. */
      mDNSPlatformMemZero(&snl, sizeof snl);
      snl.nl_family = AF_NETLINK;
@@ -218,7 +241,7 @@ index 6effa12..d3acf99 100755
      ret = bind(sock, (struct sockaddr *) &snl, sizeof snl);
      if (0 == ret)
          *pFD = sock;
-@@ -1104,11 +1163,18 @@ mDNSlocal mDNSu32       ProcessRoutingNotification(int sd)
+@@ -1104,11 +1158,18 @@ mDNSlocal mDNSu32       ProcessRoutingNotification(int sd)
          PrintNetLinkMsg(pNLMsg);
  #endif
  
@@ -239,7 +262,7 @@ index 6effa12..d3acf99 100755
  
          // Advance pNLMsg to the next message in the buffer
          if ((pNLMsg->nlmsg_flags & NLM_F_MULTI) != 0 && pNLMsg->nlmsg_type != NLMSG_DONE)
-@@ -1279,8 +1345,12 @@ mDNSexport mStatus mDNSPlatformInit(mDNS *const m)
+@@ -1279,8 +1340,12 @@ mDNSexport mStatus mDNSPlatformInit(mDNS *const m)
      if (err == mStatus_NoError) err = SetupSocket(&sa, zeroIPPort, 0, &m->p->unicastSocket6);
  #endif
  
@@ -252,7 +275,7 @@ index 6effa12..d3acf99 100755
  
      // Tell mDNS core about DNS Servers
      mDNS_Lock(m);
-@@ -1313,9 +1383,17 @@ mDNSexport void mDNSPlatformClose(mDNS *const m)
+@@ -1313,9 +1378,17 @@ mDNSexport void mDNSPlatformClose(mDNS *const m)
  {
      assert(m != NULL);
      ClearInterfaceList(m);
@@ -272,7 +295,7 @@ index 6effa12..d3acf99 100755
  #endif
  }
  
-@@ -1571,14 +1649,14 @@ mDNSexport mStatus    mDNSPlatformClearSPSMACAddr(void)
+@@ -1571,14 +1644,14 @@ mDNSexport mStatus    mDNSPlatformClearSPSMACAddr(void)
  mDNSexport mDNSu16 mDNSPlatformGetUDPPort(UDPSocket *sock)
  {
      (void) sock; // unused


### PR DESCRIPTION
It used to require 1+ IPv4 addresses to start on Linux. Now it starts
up with 0 addresses (of any type), as netlink can provide us more
later. This way, no stupid restart loop with procd if it is racing
with netifd at startup.