### PR TITLE
Fwknopd: Fix a typo in the init file

### DIFF
--- a/net/fwknop/files/fwknopd.init
+++ b/net/fwknop/files/fwknopd.init
@@ -5,7 +5,6 @@
 # list of contributors, see the file 'CREDITS'.
 #
 . /lib/functions.sh
-UCI_ENABLED=0
 START=60
 
 FWKNOPD_BIN=/usr/sbin/fwknopd


### PR DESCRIPTION
Signed-off-by: Jonathan Bennett <jbennett@incomsystems.biz>