### PR TITLE
mpd: Update to 0.18.23, fix ALSA support in mpd-mini, refresh patches (for 15.05)

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpd
-PKG_VERSION:=0.18.21
+PKG_VERSION:=0.18.23
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.musicpd.org/download/mpd/0.18/
-PKG_MD5SUM:=945879f55acc256d30a5f69787338ceb
+PKG_MD5SUM:=fcdfe8b3a7a21a87b6776204e6eb7814
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
 PKG_LICENSE:=GPL-2.0
@@ -161,7 +161,6 @@ ifeq ($(BUILD_VARIANT),full)
 
   CONFIGURE_ARGS += \
 	$(call autoconf_bool,CONFIG_BUILD_PATENTED,aac) \
-	$(call autoconf_bool,CONFIG_AUDIO_SUPPORT,alsa) \
 	--enable-audiofile \
 	--enable-fifo \
 	--enable-ffmpeg \
@@ -185,7 +184,6 @@ ifeq ($(BUILD_VARIANT),mini)
   # oggflac is not compatible with tremor
   CONFIGURE_ARGS += \
 	--disable-aac \
-	--disable-alsa \
 	--disable-audiofile \
 	--disable-fifo \
 	--disable-ffmpeg \

--- a/sound/mpd/patches/210-support_raw_pcm_streams.patch
+++ b/sound/mpd/patches/210-support_raw_pcm_streams.patch
@@ -1,6 +1,6 @@
 --- a/src/decoder/FfmpegDecoderPlugin.cxx
 +++ b/src/decoder/FfmpegDecoderPlugin.cxx
-@@ -634,6 +634,7 @@ static const char *const ffmpeg_mime_typ
+@@ -666,6 +666,7 @@ static const char *const ffmpeg_mime_typ
  	"audio/qcelp",
  	"audio/vorbis",
  	"audio/vorbis+ogg",

--- a/sound/mpd/patches/220-handle_slow_server_stream_startup.patch
+++ b/sound/mpd/patches/220-handle_slow_server_stream_startup.patch
@@ -1,6 +1,6 @@
 --- a/src/decoder/FfmpegDecoderPlugin.cxx
 +++ b/src/decoder/FfmpegDecoderPlugin.cxx
-@@ -373,6 +373,13 @@ ffmpeg_probe(Decoder *decoder, InputStre
+@@ -376,6 +376,13 @@ ffmpeg_probe(Decoder *decoder, InputStre
  
  	unsigned char buffer[BUFFER_SIZE];
  	size_t nbytes = decoder_read(decoder, is, buffer, BUFFER_SIZE);


### PR DESCRIPTION
Signed-off-by: Ted Hess <thess@kitschensync.net>

@sbyx - I'd like to cap off MPD for CC with this version. Several bug-fixes and one build config issue resolved. I am also submitting a PR for the latest libmpdclient as well.

My plans for MPD is to start migrating the trunk version to 0.19 (a major re-write) in the following weeks.