### PR TITLE
Update ncdu

### DIFF
--- a/utils/ncdu/Makefile
+++ b/utils/ncdu/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 OpenWrt.org
+# Copyright (C) 2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,14 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ncdu
-PKG_VERSION:=1.10
+PKG_VERSION:=1.11
 PKG_RELEASE=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://dev.yorhel.nl/download
-PKG_MD5SUM:=7535decc8d54eca811493e82d4bfab2d
+PKG_MD5SUM:=9e44240a5356b029f05f0e70a63c4d12
 
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
@@ -26,7 +27,7 @@ define Package/ncdu
   SUBMENU:=Filesystem
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libncursesw
+  DEPENDS:=+libncurses
   TITLE:=ncurses disk usage viewer
   MAINTAINER:=Charles Lehner <celehner1@gmail.com>
   URL:=http://dev.yorhel.nl/ncdu
@@ -37,6 +38,8 @@ define Package/ncdu/description
   interface through famous du utility. It allows one to browse through the
   directories and show percentages of disk usage with ncurses library.
 endef
+
+CONFIGURE_ARGS += --with-ncurses
 
 define Package/ncdu/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/utils/ncdu/patches/010-add_sys_wait.patch
+++ b/utils/ncdu/patches/010-add_sys_wait.patch
@@ -1,0 +1,10 @@
+--- a/src/shell.c
++++ b/src/shell.c
+@@ -33,6 +33,7 @@
+ #include <stdlib.h>
+ #include <unistd.h>
++#include <sys/wait.h>
+ 
+ void shell_draw() {
+   char *full_path;
+   int res;


### PR DESCRIPTION
- Update ncdu to 1.11 (2015-04-05)
- Add patch to make 1.11 compile (fixed in unreleased upstream rev so won't be needed in next release)
- Depend on libncurses instead of libncursesw (because libncurses is more commonly depended upon by other packages)
- Enable parallel build