### PR TITLE
lua-cjson: remove the dependency of libzmq

### DIFF
--- a/lang/lua-cjson/Makefile
+++ b/lang/lua-cjson/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lua-cjson
 PKG_VERSION:=2.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Dirk Chang <dirk@kooiot.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -29,7 +29,7 @@ define Package/lua-cjson
   CATEGORY:=Languages
   TITLE:=Lua CJSON parser
   URL:=https://github.com/mpx/lua-cjson
-  DEPENDS:= +lua +libzmq
+  DEPENDS:= +lua
 endef
 
 define Package/lua-cjson/description


### PR DESCRIPTION
The libzmq is not required by lua-cjson, it was made by a mistake.