### PR TITLE
uMurmur: Update to 0.2.16. 

### DIFF
--- a/net/umurmur/Makefile
+++ b/net/umurmur/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2014 OpenWrt.org
+# Copyright (C) 2009-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -7,14 +7,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=umurmur
-PKG_VERSION:=0.2.15
+PKG_VERSION:=0.2.16
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=git://github.com/fatbob313/umurmur.git
+PKG_SOURCE_URL:=git://github.com/umurmur/umurmur.git
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=f66c0c3d630aaff1c4d589bc4d884067f00b6529
+PKG_SOURCE_VERSION:=0.2.16
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf

--- a/net/umurmur/patches/10-Add-compile-time-check-for-POLARSSL_VERSION_FEATURES.patch
+++ b/net/umurmur/patches/10-Add-compile-time-check-for-POLARSSL_VERSION_FEATURES.patch
@@ -1,0 +1,17 @@
+diff --git a/src/ssli_polarssl.c b/src/ssli_polarssl.c
+index a36ccb6..167637b 100644
+--- a/src/ssli_polarssl.c
++++ b/src/ssli_polarssl.c
+@@ -225,8 +225,12 @@ void SSLi_init(void)
+ 	    Log_fatal("Cannot open /dev/urandom");
+ #endif
+ 
++#ifdef POLARSSL_VERSION_FEATURES
+     version_get_string(verstring);
+     Log_info("PolarSSL library version %s initialized", verstring);
++#else
++    Log_info("PolarSSL library initialized");
++#endif
+ }
+ 
+ void SSLi_deinit(void)


### PR DESCRIPTION
Also fix MbedTLS (PolarSSL) compilation which broke when its version module was disabled a while back.
Signed-off-by: Martin Johansson <martin@fatbob.nu>