### PR TITLE
xz: add xz-utils meta package

### DIFF
--- a/utils/xz/Makefile
+++ b/utils/xz/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xz
 PKG_VERSION:=5.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://tukaani.org/xz
@@ -92,6 +92,10 @@ define Build/InstallDev
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/liblzma.pc \
 		$(1)/usr/lib/pkgconfig/
+endef
+
+define Package/xz-utils/install
+	true
 endef
 
 define Package/liblzma/install


### PR DESCRIPTION
Looks like `xz` was blindly taken from oldpackages feed. Users will get a following error:

```
admin@RTN66U:/tmp/home/root# opkg install xz
Installing xz (5.2.1-1) to root...
Downloading http://entware.wl500g.info/binaries/entware/xz_5.2.1-1_entware.ipk.
Collected errors:
 * satisfy_dependencies_for: Cannot satisfy the following dependencies for xz:
 *      xz-utils *
 * opkg_install_cmd: Cannot install package xz.
```
This pull-request adds `zx-utils` dummy package.
Discovered by @zyxmon.