### PR TITLE
protobuf: Update version to 2.6.1

### DIFF
--- a/libs/protobuf/Makefile
+++ b/libs/protobuf/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007 OpenWrt.org
+# Copyright (C) 2007-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -14,6 +14,9 @@ PKG_RELEASE:=1
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/google/protobuf/releases/download/v$(PKG_VERSION)
 PKG_MD5SUM:=11aaac2d704eef8efd1867a807865d85
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_DEPENDS:=protobuf/host
 PKG_USE_MIPS16:=0# MIPS16 prevents protobuf's usage of the 'sync' asm-opcode

--- a/libs/protobuf/Makefile
+++ b/libs/protobuf/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=protobuf
-PKG_VERSION:=2.5.0
+PKG_VERSION:=2.6.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=http://protobuf.googlecode.com/files
-PKG_MD5SUM:=a72001a9067a4c2c4e0e836d0f92ece4
+PKG_SOURCE_URL:=https://github.com/google/protobuf/releases/download/v$(PKG_VERSION)
+PKG_MD5SUM:=11aaac2d704eef8efd1867a807865d85
 
 PKG_BUILD_DEPENDS:=protobuf/host
-PKG_USE_MIPS16:=0
+PKG_USE_MIPS16:=0# MIPS16 prevents protobuf's usage of the 'sync' asm-opcode
 
 PKG_INSTALL:=1
 
@@ -38,15 +38,7 @@ define Package/protobuf/description
  of its internal RPC protocols and file formats.
 endef
 
-define Host/Compile
-	$(MAKE) -C $(HOST_BUILD_DIR)
-endef
-
-define Host/Install
-	$(MAKE) -C $(HOST_BUILD_DIR) install
-endef
-
-CONFIGURE_ARGS += --with-protoc=$(HOST_BUILD_DIR)/src/protoc
+CONFIGURE_ARGS += --with-protoc=$(STAGING_DIR_HOST)/bin/protoc
 
 define Build/InstallDev
 	$(INSTALL_DIR) \

--- a/libs/protobuf/patches/001-mipseb-compile.patch
+++ b/libs/protobuf/patches/001-mipseb-compile.patch
@@ -1,11 +1,11 @@
---- a/src/google/protobuf/stubs/platform_macros.h
-+++ b/src/google/protobuf/stubs/platform_macros.h
-@@ -49,7 +49,7 @@
- #elif defined(__ARMEL__)
- #define GOOGLE_PROTOBUF_ARCH_ARM 1
- #define GOOGLE_PROTOBUF_ARCH_32_BIT 1
+--- -	2015-05-19 16:27:29.770936016 +0200
++++ protobuf-2.6.1/src/google/protobuf/stubs/platform_macros.h	2015-05-19 13:49:52.115444643 +0200
+@@ -55,7 +55,7 @@
+ #elif defined(__aarch64__)
+ #define GOOGLE_PROTOBUF_ARCH_AARCH64 1
+ #define GOOGLE_PROTOBUF_ARCH_64_BIT 1
 -#elif defined(__MIPSEL__)
 +#elif defined(__MIPSEL__) || defined(__MIPSEB__)
- #define GOOGLE_PROTOBUF_ARCH_MIPS 1
- #define GOOGLE_PROTOBUF_ARCH_32_BIT 1
- #elif defined(__pnacl__)
+ #if defined(__LP64__)
+ #define GOOGLE_PROTOBUF_ARCH_MIPS64 1
+ #define GOOGLE_PROTOBUF_ARCH_64_BIT 1

--- a/libs/protobuf/patches/003-mips2andHigher-compile.patch
+++ b/libs/protobuf/patches/003-mips2andHigher-compile.patch
@@ -1,0 +1,11 @@
+--- -	2015-05-19 16:29:09.614344473 +0200
++++ protobuf-2.6.1/src/google/protobuf/stubs/atomicops_internals_mips_gcc.h	2015-05-19 13:49:52.127442746 +0200
+@@ -150,7 +150,7 @@
+ }
+ 
+ inline void MemoryBarrier() {
+-  __asm__ __volatile__("sync" : : : "memory");
++  __asm__ __volatile__(".set mips2; sync; .set mips0" : : : "memory");
+ }
+ 
+ inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value) {


### PR DESCRIPTION
- Unbroke MIPS support which got entirely lost since the upgrade from 2.4.1:
  now all ISAs should work (MIPS1 would need kernel emulation though, untested)
- Fixed host installation which was broken on all targets
- Updated source origin to github and related variables
- Kept mipseb patch exception and MIPS16:=0 exclusion (needed for BB and CC compilation)

For rationale and earlier patch history please refer to OpenWrt-Devel's "protobuf broken in BB" thread starting at: https://lists.openwrt.org/pipermail/openwrt-devel/2014-November/thread.html#29108 and continued in Mai 2015.

Only tested on a ZyXEL NBG6716 router which is MIPS32 (MIPS74Kc), ar71xx target.

Signed-off-by: Guillaume Déflache <guillaume.deflache@ibwag.com>