### PR TITLE
vim: Fix false broken package status (buildbot)

### DIFF
--- a/utils/vim/patches/002-remove_helptags_generation.patch
+++ b/utils/vim/patches/002-remove_helptags_generation.patch
@@ -1,0 +1,10 @@
+--- a/runtime/doc/Makefile
++++ b/runtime/doc/Makefile
+@@ -310,7 +310,6 @@ all: tags vim.man evim.man vimdiff.man v
+ # Use Vim to generate the tags file.  Can only be used when Vim has been
+ # compiled and installed.  Supports multiple languages.
+ vimtags: $(DOCS)
+-	$(VIMEXE) -u NONE -esX -c "helptags ++t ." -c quit
+ 
+ # Use "doctags" to generate the tags file.  Only works for English!
+ tags: doctags $(DOCS)


### PR DESCRIPTION
Vim shows up in broken packages on buildbot though it seems to build OK and produce packages without re-generating helptags. This patch removes the build error and nothing else changes.

Signed-off-by: Ted Hess <thess@kitschensync.net>