### PR TITLE
ffmpeg: switch to included opus support for libffmpeg-audio-dec and option to libffmpeg-custom

### DIFF
--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -60,11 +60,11 @@ config FFMPEG_CUSTOM_AUDIO_DEC_SUPPORT
 	select FFMPEG_CUSTOM_DECODER_ape
 	select FFMPEG_CUSTOM_DECODER_atrac3
 	select FFMPEG_CUSTOM_DECODER_flac
-	select FFMPEG_CUSTOM_SELECT_libopus
 	select FFMPEG_CUSTOM_DECODER_mp2
 	select FFMPEG_CUSTOM_DECODER_mp3
 	select FFMPEG_CUSTOM_DECODER_mpc7
 	select FFMPEG_CUSTOM_DECODER_mpc8
+	select FFMPEG_CUSTOM_DECODER_opus
 	select FFMPEG_CUSTOM_DECODER_pcm_s16be
 	select FFMPEG_CUSTOM_DECODER_pcm_s16le
 	select FFMPEG_CUSTOM_SELECT_speex
@@ -98,9 +98,10 @@ config FFMPEG_CUSTOM_AUDIO_DEC_SUPPORT
 	select FFMPEG_CUSTOM_DEMUXER_wv
 	select FFMPEG_CUSTOM_PARSER_aac
 	select FFMPEG_CUSTOM_PARSER_aac_latm
-	select FFMPEG_CUSTOM_PARSER_flac
 	select FFMPEG_CUSTOM_PARSER_ac3
+	select FFMPEG_CUSTOM_PARSER_flac
 	select FFMPEG_CUSTOM_PARSER_mpegaudio
+	select FFMPEG_CUSTOM_PARSER_opus
 	select FFMPEG_CUSTOM_PROTOCOL_file
 	select FFMPEG_CUSTOM_PROTOCOL_http
 	select FFMPEG_CUSTOM_PROTOCOL_rtp
@@ -228,6 +229,9 @@ config FFMPEG_CUSTOM_DECODER_mpc7
 config FFMPEG_CUSTOM_DECODER_mpc8
 	bool "Musepack 8"
 	select FFMPEG_CUSTOM_DEMUXER_mpc8
+
+config FFMPEG_CUSTOM_DECODER_opus
+	bool "Opus"
 
 config FFMPEG_CUSTOM_DECODER_pcm_s16be
 	bool "PCM signed 16-bit big-endian"
@@ -397,6 +401,9 @@ config FFMPEG_CUSTOM_PARSER_mpegvideo
 
 config FFMPEG_CUSTOM_PARSER_mpeg4video
 	bool "MPEG-4 Video"
+
+config FFMPEG_CUSTOM_PARSER_opus
+	bool "Opus"
 
 comment "Protocols ---"
 

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=2.6.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://ffmpeg.org/releases/
@@ -162,6 +162,7 @@ FFMPEG_AUDIO_DECODERS:= \
 	mp3* \
 	mpc7 \
 	mpc8 \
+	opus \
 	pcm_* \
 	vorbis \
 	wavpack \
@@ -197,9 +198,10 @@ FFMPEG_AUDIO_DEMUXERS:= \
 FFMPEG_AUDIO_PARSERS:= \
 	aac \
 	aac_latm \
-	flac \
 	ac3 \
+	flac \
 	mpegaudio \
+	opus \
 
 FFMPEG_AUDIO_PROTOCOLS:= \
 	file http icecast rtp tcp udp
@@ -308,7 +310,7 @@ endef
 define Package/libffmpeg-audio-dec
 $(call Package/libffmpeg/Default)
  TITLE+= (audio)
- DEPENDS+= @DEVEL +libopus +libspeex
+ DEPENDS+= @BUILD_PATENTED +libspeex
  VARIANT:=audio-dec
 endef
 
@@ -462,7 +464,6 @@ ifeq ($(BUILD_VARIANT),audio-dec)
 	$(call FFMPEG_ENABLE,demuxer,$(FFMPEG_AUDIO_DEMUXERS)) \
 	$(call FFMPEG_ENABLE,parser,$(FFMPEG_AUDIO_PARSERS)) \
 	$(call FFMPEG_ENABLE,protocol,$(FFMPEG_AUDIO_PROTOCOLS)) \
-	--enable-libopus --enable-decoder=libopus \
 	--enable-libspeex --enable-decoder=libspeex \
 	--disable-decoder=pcm_bluray,pcm_dvd \
 


### PR DESCRIPTION
These commits:

Remove the DEVEL flag for libffmpeg-audio-dec and add the BUILD_PATENTED flag.
Add the included Opus support in ffmpeg to libffmpeg-audio-dec and libffmpeg-custom. 
Remove the dependency on libopus from libffmpeg-audio-dec

Compile tested only.