### PR TITLE
lftp: added mirror directory old to avoid build disruption on new version releases

### DIFF
--- a/net/lftp/Makefile
+++ b/net/lftp/Makefile
@@ -11,7 +11,10 @@ PKG_NAME:=lftp
 PKG_VERSION:=4.6.2
 PKG_RELEASE:=1
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://lftp.yar.ru/ftp \ http://lftp.cybermirror.org \ http://lftp.cybermirror.org/old
+PKG_SOURCE_URL:=http://lftp.yar.ru/ftp \
+		http://lftp.yar.ru/ftp/old \
+		http://lftp.cybermirror.org \
+		http://lftp.cybermirror.org/old
 PKG_MD5SUM:=487c064ee1bd732e5f95928e530435a8
 
 


### PR DESCRIPTION
As proposed by tolbkni ( http://github.com/openwrt/packages/pull/1225 ) 

Signed-off-by: Federico Di Marco fededim@gmail.com