### PR TITLE
Fix emailrelay init script

### DIFF
--- a/net/emailrelay/Makefile
+++ b/net/emailrelay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=emailrelay
 PKG_VERSION:=1.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=@SF/emailrelay/$(PKG_VERSION)

--- a/net/emailrelay/files/emailrelay.init
+++ b/net/emailrelay/files/emailrelay.init
@@ -6,10 +6,10 @@ START=90
 
 start() {
         logger -t 'emailrelay' "Starting emailrelay service."
-        service_start emailrelay --as-server --poll 60 --forward-to smtpserver:smtpport --spool-dir /tmp --client-tls --client-auth /etc/emailrelay.auth --server-auth /etc/emailrelay.auth --log
+        service_start /usr/bin/emailrelay --as-server --poll 60 --forward-to smtpserver:smtpport --spool-dir /tmp --client-tls --client-auth /etc/emailrelay.auth --server-auth /etc/emailrelay.auth --log
 }
 
 stop() {
         logger -t 'emailrelay' "Stopping emailrelay service."
-        killall -9 emailrelay
+        service_stop /usr/bin/emailrelay
 }


### PR DESCRIPTION
I was seeing this error when trying to use `/etc/init.d/emailrelay start`:
```
service: file 'emailrelay' is not executable
```
This patch fixes this issue by using the full path to the emailrelay binary, and allows us to use service_stop instead of killall in the stop function.