### PR TITLE
bash: Update to 4.3.39 [for-15.05]

### DIFF
--- a/utils/bash/Makefile
+++ b/utils/bash/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2014 OpenWrt.org
+# Copyright (C) 2007-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 BASE_VERSION:=4.3
 
 PKG_NAME:=bash
-PKG_VERSION:=$(BASE_VERSION).33
+PKG_VERSION:=$(BASE_VERSION).39
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(BASE_VERSION).tar.gz

--- a/utils/bash/patches/122-upstream-bash43-022.patch
+++ b/utils/bash/patches/122-upstream-bash43-022.patch
@@ -17,7 +17,7 @@ Patch (apply with `patch -p0'):
 
 --- a/execute_cmd.c
 +++ b/execute_cmd.c
-@@ -2409,7 +2409,16 @@ execute_pipeline (command, asynchronous,
+@@ -2413,7 +2413,16 @@ execute_pipeline (command, asynchronous,
  #endif
        lstdin = wait_for (lastpid);
  #if defined (JOB_CONTROL)

--- a/utils/bash/patches/134-upstream-bash43-034.patch
+++ b/utils/bash/patches/134-upstream-bash43-034.patch
@@ -1,0 +1,74 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.3
+Patch-ID:	bash43-034
+
+Bug-Reported-by:	Dreamcat4 <dreamcat4@gmail.com>
+Bug-Reference-ID:	<CAN39uTpAEs2GFu4ebC_SfSVMRTh-DJ9YanrY4BZZ3OO+CCHjng@mail.gmail.com>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2015-05/msg00001.html
+
+Bug-Description:
+
+If neither the -f nor -v options is supplied to unset, and a name argument is
+found to be a function and unset, subsequent name arguments are not treated as
+variables before attempting to unset a function by that name.
+
+Patch (apply with `patch -p0'):
+
+--- a/builtins/set.def
++++ b/builtins/set.def
+@@ -751,9 +751,11 @@ unset_builtin (list)
+   WORD_LIST *list;
+ {
+   int unset_function, unset_variable, unset_array, opt, nameref, any_failed;
++  int global_unset_func, global_unset_var;
+   char *name;
+ 
+   unset_function = unset_variable = unset_array = nameref = any_failed = 0;
++  global_unset_func = global_unset_var = 0;
+ 
+   reset_internal_getopt ();
+   while ((opt = internal_getopt (list, "fnv")) != -1)
+@@ -761,10 +763,10 @@ unset_builtin (list)
+       switch (opt)
+ 	{
+ 	case 'f':
+-	  unset_function = 1;
++	  global_unset_func = 1;
+ 	  break;
+ 	case 'v':
+-	  unset_variable = 1;
++	  global_unset_var = 1;
+ 	  break;
+ 	case 'n':
+ 	  nameref = 1;
+@@ -777,7 +779,7 @@ unset_builtin (list)
+ 
+   list = loptend;
+ 
+-  if (unset_function && unset_variable)
++  if (global_unset_func && global_unset_var)
+     {
+       builtin_error (_("cannot simultaneously unset a function and a variable"));
+       return (EXECUTION_FAILURE);
+@@ -795,6 +797,9 @@ unset_builtin (list)
+ 
+       name = list->word->word;
+ 
++      unset_function = global_unset_func;
++      unset_variable = global_unset_var;
++
+ #if defined (ARRAY_VARS)
+       unset_array = 0;
+       if (!unset_function && valid_array_reference (name))
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -25,6 +25,6 @@
+    regexp `^#define[ 	]*PATCHLEVEL', since that's what support/mkversion.sh
+    looks for to find the patch level (for the sccs version string). */
+ 
+-#define PATCHLEVEL 33
++#define PATCHLEVEL 34
+ 
+ #endif /* _PATCHLEVEL_H_ */

--- a/utils/bash/patches/135-upstream-bash43-035.patch
+++ b/utils/bash/patches/135-upstream-bash43-035.patch
@@ -1,0 +1,48 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.3
+Patch-ID:	bash43-035
+
+Bug-Reported-by:	<romerox.adrian@gmail.com>
+Bug-Reference-ID:	<CABV5r3zhPXmSKUe9uedeGc5YFBM2njJ1iVmY2h5neWdQpDBQug@mail.gmail.com>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2014-08/msg00045.html
+
+Bug-Description:
+
+A locale with a long name can trigger a buffer overflow and core dump.  This
+applies on systems that do not have locale_charset in libc, are not using
+GNU libiconv, and are not using the libintl that ships with bash in lib/intl.
+
+Patch (apply with `patch -p0'):
+
+--- a/lib/sh/unicode.c
++++ b/lib/sh/unicode.c
+@@ -78,13 +78,15 @@ stub_charset ()
+   s = strrchr (locale, '.');
+   if (s)
+     {
+-      strcpy (charsetbuf, s+1);
++      strncpy (charsetbuf, s+1, sizeof (charsetbuf) - 1);
++      charsetbuf[sizeof (charsetbuf) - 1] = '\0';
+       t = strchr (charsetbuf, '@');
+       if (t)
+ 	*t = 0;
+       return charsetbuf;
+     }
+-  strcpy (charsetbuf, locale);
++  strncpy (charsetbuf, locale, sizeof (charsetbuf) - 1);
++  charsetbuf[sizeof (charsetbuf) - 1] = '\0';
+   return charsetbuf;
+ }
+ #endif
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -25,6 +25,6 @@
+    regexp `^#define[ 	]*PATCHLEVEL', since that's what support/mkversion.sh
+    looks for to find the patch level (for the sccs version string). */
+ 
+-#define PATCHLEVEL 34
++#define PATCHLEVEL 35
+ 
+ #endif /* _PATCHLEVEL_H_ */

--- a/utils/bash/patches/136-upstream-bash43-036.patch
+++ b/utils/bash/patches/136-upstream-bash43-036.patch
@@ -1,0 +1,48 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.3
+Patch-ID:	bash43-036
+
+Bug-Reported-by:	emanuelczirai@cryptolab.net
+Bug-Reference-ID:	<f962e4f556da5ebfadaf7afe9c78a8cb@cryptolab.net>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2015-02/msg00071.html
+
+Bug-Description:
+
+When evaluating and setting integer variables, and the assignment fails to
+create a variable (for example, when performing an operation on an array
+variable with an invalid subscript), bash attempts to dereference a null
+pointer, causing a segmentation violation.
+
+Patch (apply with `patch -p0'):
+
+--- a/variables.c
++++ b/variables.c
+@@ -2833,10 +2833,12 @@ bind_int_variable (lhs, rhs)
+ #endif
+     v = bind_variable (lhs, rhs, 0);
+ 
+-  if (v && isint)
+-    VSETATTR (v, att_integer);
+-
+-  VUNSETATTR (v, att_invisible);
++  if (v)
++    {
++      if (isint)
++	VSETATTR (v, att_integer);
++      VUNSETATTR (v, att_invisible);
++    }
+ 
+   return (v);
+ }
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -25,6 +25,6 @@
+    regexp `^#define[ 	]*PATCHLEVEL', since that's what support/mkversion.sh
+    looks for to find the patch level (for the sccs version string). */
+ 
+-#define PATCHLEVEL 35
++#define PATCHLEVEL 36
+ 
+ #endif /* _PATCHLEVEL_H_ */

--- a/utils/bash/patches/137-upstream-bash43-037.patch
+++ b/utils/bash/patches/137-upstream-bash43-037.patch
@@ -1,0 +1,38 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.3
+Patch-ID:	bash43-037
+
+Bug-Reported-by:	Greg Wooledge <wooledg@eeg.ccf.org>
+Bug-Reference-ID:	<20150204144240.GN13956@eeg.ccf.org>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2015-02/msg00007.html
+
+Bug-Description:
+
+If an associative array uses `@' or `*' as a subscript, `declare -p' produces
+output that cannot be reused as input.
+
+Patch (apply with `patch -p0'):
+
+--- a/assoc.c
++++ b/assoc.c
+@@ -436,6 +436,8 @@ assoc_to_assign (hash, quoted)
+ #if 1
+ 	if (sh_contains_shell_metas (tlist->key))
+ 	  istr = sh_double_quote (tlist->key);
++	else if (ALL_ELEMENT_SUB (tlist->key[0]) && tlist->key[1] == '\0')
++	  istr = sh_double_quote (tlist->key);	
+ 	else
+ 	  istr = tlist->key;	
+ #else
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -25,6 +25,6 @@
+    regexp `^#define[ 	]*PATCHLEVEL', since that's what support/mkversion.sh
+    looks for to find the patch level (for the sccs version string). */
+ 
+-#define PATCHLEVEL 36
++#define PATCHLEVEL 37
+ 
+ #endif /* _PATCHLEVEL_H_ */

--- a/utils/bash/patches/138-upstream-bash43-038.patch
+++ b/utils/bash/patches/138-upstream-bash43-038.patch
@@ -1,0 +1,67 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.3
+Patch-ID:	bash43-038
+
+Bug-Reported-by:	worley@alum.mit.edu (Dale R. Worley)
+Bug-Reference-ID:	<201406100051.s5A0pCeB014978@hobgoblin.ariadne.com>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2014-06/msg00028.html
+
+Bug-Description:
+
+There are a number of instances where `time' is not recognized as a reserved
+word when the shell grammar says it should be.
+
+Patch (apply with `patch -p0'):
+
+--- a/parse.y
++++ b/parse.y
+@@ -2818,11 +2818,16 @@ time_command_acceptable ()
+     case AND_AND:
+     case OR_OR:
+     case '&':
++    case WHILE:
+     case DO:
++    case UNTIL:
++    case IF:
+     case THEN:
++    case ELIF:
+     case ELSE:
+     case '{':		/* } */
+-    case '(':		/* ) */
++    case '(':		/* )( */
++    case ')':		/* only valid in case statement */
+     case BANG:		/* ! time pipeline */
+     case TIME:		/* time time pipeline */
+     case TIMEOPT:	/* time -p time pipeline */
+--- a/y.tab.c
++++ b/y.tab.c
+@@ -5130,11 +5130,16 @@ time_command_acceptable ()
+     case AND_AND:
+     case OR_OR:
+     case '&':
++    case WHILE:
+     case DO:
++    case UNTIL:
++    case IF:
+     case THEN:
++    case ELIF:
+     case ELSE:
+     case '{':		/* } */
+-    case '(':		/* ) */
++    case '(':		/* )( */
++    case ')':		/* only valid in case statement */
+     case BANG:		/* ! time pipeline */
+     case TIME:		/* time time pipeline */
+     case TIMEOPT:	/* time -p time pipeline */
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -25,6 +25,6 @@
+    regexp `^#define[ 	]*PATCHLEVEL', since that's what support/mkversion.sh
+    looks for to find the patch level (for the sccs version string). */
+ 
+-#define PATCHLEVEL 37
++#define PATCHLEVEL 38
+ 
+ #endif /* _PATCHLEVEL_H_ */

--- a/utils/bash/patches/139-upstream-bash43-039.patch
+++ b/utils/bash/patches/139-upstream-bash43-039.patch
@@ -1,0 +1,52 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	4.3
+Patch-ID:	bash43-039
+
+Bug-Reported-by:	SN <poczta-sn@gazeta.pl>
+Bug-Reference-ID:	<54E2554C.205@gazeta.pl>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2015-02/msg00060.html
+
+Bug-Description:
+
+Using the output of `declare -p' when run in a function can result in variables
+that are invisible to `declare -p'.  This problem occurs when an assignment
+builtin such as `declare' receives a quoted compound array assignment as one of
+its arguments.
+
+Patch (apply with `patch -p0'):
+
+--- a/arrayfunc.c
++++ b/arrayfunc.c
+@@ -404,6 +404,9 @@ assign_array_var_from_word_list (var, li
+       (*var->assign_func) (var, l->word->word, i, 0);
+     else
+       array_insert (a, i, l->word->word);
++
++  VUNSETATTR (var, att_invisible);	/* no longer invisible */
++
+   return var;
+ }
+ 
+@@ -634,6 +637,10 @@ assign_array_var_from_string (var, value
+ 
+   if (nlist)
+     dispose_words (nlist);
++
++  if (var)
++    VUNSETATTR (var, att_invisible);	/* no longer invisible */
++
+   return (var);
+ }
+ 
+--- a/patchlevel.h
++++ b/patchlevel.h
+@@ -25,6 +25,6 @@
+    regexp `^#define[ 	]*PATCHLEVEL', since that's what support/mkversion.sh
+    looks for to find the patch level (for the sccs version string). */
+ 
+-#define PATCHLEVEL 38
++#define PATCHLEVEL 39
+ 
+ #endif /* _PATCHLEVEL_H_ */


### PR DESCRIPTION
This is the same update as the one that got into master a few days ago.
Nothing huge in this one, just bugfixes. A quick look didn't reveal anything security-relevant. I figured we might as well include it in CC tough.