### PR TITLE
openvswitch: fix build with kernel >= 3.18.13

### DIFF
--- a/net/openvswitch/patches/0003-datapath-do-not-add-vlan_hwaccel_push_inside-for-ker.patch
+++ b/net/openvswitch/patches/0003-datapath-do-not-add-vlan_hwaccel_push_inside-for-ker.patch
@@ -1,0 +1,35 @@
+From 5919cb26c631b1dd77a745a3c546f9d117ed34b3 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sat, 23 May 2015 18:12:09 +0200
+Subject: [PATCH] datapath: do not add vlan_hwaccel_push_inside() for kernel >=
+ 3.18.13
+
+The vlan_hwaccel_push_inside() function was backported in this commit
+to kernel 3.18.13:
+
+commit a67e2e88342accd49587d9bad72f6dabd7673f7c
+Author: Jiri Pirko <jiri@resnulli.us>
+Date:   Wed Nov 19 14:04:59 2014 +0100
+
+    vlan: introduce *vlan_hwaccel_push_inside helpers
+
+    [ Upstream commit 5968250c868ceee680aa77395b24e6ddcae17d36 ]
+
+Without this patch compilation breaks on kernel >= 3.18.13
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ datapath/linux/compat/include/linux/if_vlan.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/datapath/linux/compat/include/linux/if_vlan.h
++++ b/datapath/linux/compat/include/linux/if_vlan.h
+@@ -52,7 +52,7 @@ static inline struct sk_buff *rpl_vlan_i
+ }
+ #endif
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,19,0)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(3,18,13)
+ /*
+  * __vlan_hwaccel_push_inside - pushes vlan tag to the payload
+  * @skb: skbuff to tag


### PR DESCRIPTION
This fixes a build problem with kernel >= 3.18.13.
This should close #1283.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>