### PR TITLE
ethtool: Add option to enable/disable pretty-printing

### DIFF
--- a/net/ethtool/Config.in
+++ b/net/ethtool/Config.in
@@ -1,0 +1,7 @@
+menu "Configuration"
+	depends on PACKAGE_ethtool
+
+	config ETHTOOL_PRETTY_DUMP
+		bool "Enable pretty printing"
+
+endmenu

--- a/net/ethtool/Makefile
+++ b/net/ethtool/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ethtool
 PKG_VERSION:=3.18
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Matthias Schiffer <mschiffer@universe-factory.net>
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -22,6 +22,8 @@ PKG_LICENSE_FILES:=COPYING
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+
+PKG_CONFIG_DEPENDS:=ETHTOOL_PRETTY_DUMP
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -36,6 +38,16 @@ define Package/ethtool/description
  ethtool is a small utility for examining and tuning your ethernet-based
  network interface
 endef
+
+define Package/ethtool/config
+	source "$(SOURCE)/Config.in
+endef
+
+ifeq ($(CONFIG_ETHTOOL_PRETTY_DUMP),y)
+CONFIGURE_ARGS += --enable-pretty-dump
+else
+CONFIGURE_ARGS += --disable-pretty-dump
+endif
 
 define Package/ethtool/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
With upstream commit
https://git.kernel.org/cgit/network/ethtool/ethtool.git/commit/?id=875616dfcbe57ea0f639a20d85fcbad2172ad744

there is now an option to produce a smaller ethtool build which will
disable pretty printing (Ethernet drivers, SFP diagnostics...) for
platforms that do not need it.

Hook a menu configuration option to control that option. Build size
differences on ar71xx:

With:
-rw-r--r-- 1 florian florian 79K mai   23 10:43
bin/ar71xx/packages/packages/ethtool_3.18-1_ar71xx.ipk

Without:
-rw-r--r-- 1 florian florian 23K mai   23 10:43
bin/ar71xx/packages/packages/ethtool_3.18-1_ar71xx.ipk

Signed-off-by: Florian Fainelli <florian@openwrt.org>