### PR TITLE
libev: Import from management, with path fixes

### DIFF
--- a/libs/libev/Makefile
+++ b/libs/libev/Makefile
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2014-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libev
+PKG_VERSION:=4.19
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://dist.schmorp.de/libev/Attic/
+PKG_MD5SUM:=01d1c672697f649b4f94abd0b70584ff
+PKG_LICENSE:=BSD-2-Clause
+PKG_MAINTAINER:=Karl Palsson <karlp@tweak.net.au>
+
+PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_USE_MIPS16:=0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libev
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=High-performance event loop
+  URL:=http://software.schmorp.de/pkg/libev.html
+endef
+
+define Package/libev/description
+ A full-featured and high-performance event loop that is loosely modelled after
+ libevent, but without its limitations and bugs.
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--enable-static \
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libev.{a,so*} $(1)/usr/lib/
+endef
+
+define Package/libev/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libev.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libev))


### PR DESCRIPTION
Imports the latest version from the management feed, and fixes the
install paths.  All example code, and desktop linux expects and installs
libev's headers to /usr/include/<ev.h> not under a subdirectory.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>

@lperkov Here's the modified version.  I've built and tested one app I have that was using this.  This should also go to for-15.05, and it can then be dropped from the management feed.