### PR TITLE
lxc: allow building with seccomp

### DIFF
--- a/utils/lxc/Config.in
+++ b/utils/lxc/Config.in
@@ -27,4 +27,11 @@ config LXC_BUSYBOX_OPTIONS
 	  Select needed busybox options for lxc-create utility. This include XZ tar
 	  compression, long option support for tar and built-in getopt support.
 
+config LXC_SECCOMP
+	bool "Enable support for seccomp in LXC"
+	default KERNEL_SECCOMP
+	help
+	  Build LXC with support for seccomp filters.
+	  Select libseccomp which also pulls-in the needed kernel features.
+
 endmenu

--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=1.1.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=LGPL-2.1+ BSD-2-Clause GPL-2.0
 PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>
@@ -94,7 +94,7 @@ define Package/liblxc
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=LXC userspace library
-  DEPENDS:= lxc +libcap +libpthread
+  DEPENDS:= lxc +libcap +libpthread +LXC_SECCOMP:libseccomp
 endef
 
 define Package/lxc-lua
@@ -113,9 +113,14 @@ CONFIGURE_ARGS += \
 	--disable-apparmor \
 	--disable-doc \
 	--disable-examples \
-	--disable-seccomp
 	--enable-lua=yes \
-	--with-lua-pc="$(STAGING_DIR)/usr/lib/pkgconfig/lua.pc" \
+	--with-lua-pc="$(STAGING_DIR)/usr/lib/pkgconfig/lua.pc"
+
+ifeq ($(CONFIG_LXC_SECCOMP),y)
+CONFIGURE_ARGS += --enable-seccomp
+else
+CONFIGURE_ARGS += --disable-seccomp
+endif
 
 MAKE_FLAGS += \
 	LUA_INSTALL_CMOD="/usr/lib/lua" \


### PR DESCRIPTION
seccomp was unconditionally disabled before.
Also a non-escaped newline in a place where it should be escaped
made the build process skip some CONFIGURE_ARGS.
Fix CONFIGURE_ARGS and add an option to allow building with seccomp.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>