### PR TITLE
libseccomp: work-around prctl.h mess

### DIFF
--- a/libs/libseccomp/patches/100-dont-use-linux-prctl.h-with-musl.patch
+++ b/libs/libseccomp/patches/100-dont-use-linux-prctl.h-with-musl.patch
@@ -1,0 +1,14 @@
+Index: libseccomp-2.2.1/src/system.h
+===================================================================
+--- libseccomp-2.2.1.orig/src/system.h
++++ libseccomp-2.2.1/src/system.h
+@@ -23,7 +23,9 @@
+ #define _SYSTEM_H
+ 
+ #include <linux/filter.h>
++#ifdef __GLIBC__
+ #include <linux/prctl.h>
++#endef
+ 
+ #include "configure.h"
+ 


### PR DESCRIPTION
musl doesn't allow including both, sys/prctl.h and linux/prctl.h.
Thus include linux/prctl.h only on GLIBC systems (that includes
uClibc which defines ```__GLIBC__```)

Signed-off-by: Daniel Golle <daniel@makrotopia.org>