### PR TITLE
vim: Fix editing crontabs with crontab -e

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vim
 PKG_VERSION:=7.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 VIMVER:=74
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/utils/vim/files/vimrc
+++ b/utils/vim/files/vimrc
@@ -9,3 +9,4 @@ set linebreak		" don't wrap words by default
 set textwidth=0		" don't wrap lines by default
 set ruler			" show the cursor position all the time
 
+set backupskip+=/etc/crontabs.*	" fix crontab -e

--- a/utils/vim/files/vimrc.full
+++ b/utils/vim/files/vimrc.full
@@ -9,6 +9,8 @@ set linebreak			" don't wrap words by default
 set textwidth=0			" don't wrap lines by default
 set ruler			" show the cursor position all the time
 
+set backupskip+=/etc/crontabs.*	" fix crontab -e
+
 if filereadable(expand("$VIMRUNTIME/syntax/synload.vim"))
 	syntax on
 endif


### PR DESCRIPTION
Per default, vim creates a new file and keeps the original file as backup.
This leads to crontab checking the backup file for changes instead of the
one actually being edited, resulting in any changes being silently dropped.
Since busybox's crontab saves temporary crontab files in `/etc/crontabs.*`
vim's default of `backupskip=/tmp/*` doesn't circumvent this.

This commit fixes this issue by appending `/etc/crontabs.*` to `backupskip`.

Signed-off-by: Florian Fieber <florian@florianfieber.de>