### PR TITLE
lxc: fix build on mpc85xx

### DIFF
--- a/utils/lxc/patches/016-uninitialized-ret-in-monitor.patch
+++ b/utils/lxc/patches/016-uninitialized-ret-in-monitor.patch
@@ -1,0 +1,11 @@
+--- a/src/lxc/monitor.c
++++ b/src/lxc/monitor.c
+@@ -181,7 +181,7 @@ int lxc_monitor_sock_name(const char *lx
+ int lxc_monitor_open(const char *lxcpath)
+ {
+ 	struct sockaddr_un addr;
+-	int fd,ret;
++	int fd,ret = 0;
+ 	int retry,backoff_ms[] = {10, 50, 100};
+ 	size_t len;
+ 


### PR DESCRIPTION
Initialize ret to 0 so compiler no longer complains about
monitor.c: In function 'lxc_monitor_open':
monitor.c:212:5: error: 'ret' may be used uninitialized in this function [-Werror=maybe-uninitialized]

Signed-off-by: Daniel Golle <daniel@makrotopia.org>