### PR TITLE
transmission: use procd

### DIFF
--- a/net/transmission/files/transmission.config
+++ b/net/transmission/files/transmission.config
@@ -2,6 +2,7 @@ config transmission
 	option enabled 0
 	option config_dir '/tmp/transmission'
 	#option user 'nobody'
+	option mem_percentage 50
 	option alt_speed_down 50
 	option alt_speed_enabled false
 	option alt_speed_time_begin  540

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -57,7 +57,7 @@ transmission() {
 	config_get download_dir "$cfg" 'download_dir' '/var/etc/transmission'
 	config_get mem_percentage "$cfg" 'mem_percentage' '50'
 
-	local MEM=$(grep MemTotal /proc/meminfo|sed 's/ \+/ /g'|cut -d ' ' -f 2)
+	local MEM=$(sed -ne 's!^MemTotal:[[:space:]]*\([0-9]*\) kB$!\1!p' /proc/meminfo)
 	if test "$MEM" -gt 1;then
 		USE=$(expr $MEM \* $mem_percentage \* 10)
 	fi

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -1,7 +1,9 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2010-2012 OpenWrt.org
+# Copyright (C) 2010-2015 OpenWrt.org
 
 START=99
+USE_PROCD=1
+
 
 LIST_SEP="
 "
@@ -40,14 +42,23 @@ section_enabled() {
 	[ $enabled -gt 0 ]
 }
 
-start_instance() {
-	local s="$1"
+transmission() {
+	local cfg="$1"
+	#give transmission 3/5 of the memory of the system
+	local USE
+	local MEM=`grep MemTotal /proc/meminfo|sed 's/ \+/ /g'|cut -d ' ' -f 2`
+	if test "$MEM" -gt 1;then
+		USE=`expr $MEM \* 3000 / 5`
+	fi
+
 	local user
+	local download_dir
 
 	section_enabled "$section" || return 1
 
-	config_get config_dir "$s" 'config_dir' '/var/etc/transmission'
-	config_get user "$s" 'user'
+	config_get config_dir "$cfg" 'config_dir' '/var/etc/transmission'
+	config_get user "$cfg" 'user'
+	config_get download_dir "$cfg" 'download_dir' '/var/etc/transmission'
 
 	config_file="$config_dir/settings.json"
 	[ -d $config_dir ] || {
@@ -58,7 +69,7 @@ start_instance() {
 
 	echo "{" > $config_file
 
-	append_params "$s" \
+	append_params "$cfg" \
 		alt_speed_down alt_speed_enabled alt_speed_time_begin alt_speed_time_day \
 		alt_speed_time_enabled alt_speed_time_end alt_speed_up blocklist_enabled \
 		cache_size_mb download_queue_enabled download_queue_size \
@@ -76,7 +87,7 @@ start_instance() {
 		umask upload_slots_per_torrent utp_enabled scrape_paused_torrents \
 		watch_dir_enabled
 
-	append_params_quotes "$s" \
+	append_params_quotes "$cfg" \
 		blocklist_url bind_address_ipv4 bind_address_ipv6 download_dir incomplete_dir \
 		peer_congestion_algorithm peer_socket_tos rpc_bind_address rpc_password rpc_url \
 		rpc_username rpc_whitelist script_torrent_done_filename watch_dir
@@ -84,28 +95,25 @@ start_instance() {
 	echo "\""invalid-key"\": false" >> $config_file
 	echo "}" >> $config_file
 
-	SERVICE_UID="$user" \
-	service_start /usr/bin/transmission-daemon -g $config_dir
+	procd_open_instance
+	procd_set_param command /usr/bin/transmission-daemon -g $config_dir -f
+	procd_set_param respawn
+	procd_set_param user "$user"
+	if test -z "$USE";then
+		procd_set_param limits core="0 0"
+	else
+		procd_set_param limits core="0 0" as="$USE $USE"
+		logger -t transmission "Starting with $USE virt mem"
+	fi
+
+	procd_add_jail transmission log
+	procd_add_jail_mount $config_file
+	procd_add_jail_mount_rw $download_dir
+	procd_close_instance
 }
 
-stop_instance() {
-	local s="$1"
-	local user
-
-	section_enabled "$section" || return 1
-
-	config_get user "$s" 'user'
-
-	SERVICE_UID="$user" \
-	service_stop /usr/bin/transmission-daemon
-}
-
-start() {
+start_service() {
 	config_load 'transmission'
-	config_foreach start_instance 'transmission'
+	config_foreach transmission 'transmission'
 }
 
-stop() {
-	config_load 'transmission'
-	config_foreach stop_instance 'transmission'
-}

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -44,21 +44,23 @@ section_enabled() {
 
 transmission() {
 	local cfg="$1"
-	#give transmission 3/5 of the memory of the system
 	local USE
-	local MEM=`grep MemTotal /proc/meminfo|sed 's/ \+/ /g'|cut -d ' ' -f 2`
-	if test "$MEM" -gt 1;then
-		USE=`expr $MEM \* 3000 / 5`
-	fi
 
 	local user
 	local download_dir
+	local mem_percentage
 
 	section_enabled "$section" || return 1
 
 	config_get config_dir "$cfg" 'config_dir' '/var/etc/transmission'
 	config_get user "$cfg" 'user'
 	config_get download_dir "$cfg" 'download_dir' '/var/etc/transmission'
+	config_get mem_percentage "$cfg" 'mem_percentage' '50'
+
+	local MEM=$(grep MemTotal /proc/meminfo|sed 's/ \+/ /g'|cut -d ' ' -f 2)
+	if test "$MEM" -gt 1;then
+		USE=$(expr $MEM \* $mem_percentage \* 10)
+	fi
 
 	config_file="$config_dir/settings.json"
 	[ -d $config_dir ] || {


### PR DESCRIPTION
That allows to restart transmission when it crashes, to limit the memory used by it, as well as be jailed in the directories it is supposed to access.

Signed-off-by: Nikos Mavrogiannopoulos <nmav@gnutls.org>