### PR TITLE
libevhtp-1.1: package added

### DIFF
--- a/libs/libevhtp-1.1/Makefile
+++ b/libs/libevhtp-1.1/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libevhtp-1.1
+PKG_VERSION:=1.1.7
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD-3-Clause
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/ellzey/libevhtp.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=f70c920d4d8d4146ff662867f47c4b5854045b3c
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libevhtp-1.1
+    SECTION:=libs
+    CATEGORY:=Libraries
+    TITLE:=A more flexible replacement for libevent's httpd API - compatibility package
+    MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
+    URL:=https://github.com/ellzey/libevhtp
+    DEPENDS:=+libevent2 +libevent2-pthreads +libpthread
+endef
+
+define Package/libevhtp-1.1/description
+   Libevhtp was created as a replacement API for Libevent's current HTTP API.
+
+   NOTE: This is an older version required for compatibility reasons. The latest version has its own package named "libevhtp".
+endef
+
+include $(INCLUDE_DIR)/cmake.mk
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/libevhtp-1.1/
+	$(INSTALL_DIR) $(1)/usr/lib/libevhtp-1.1/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libevhtp-1.1))

--- a/libs/libevhtp-1.1/patches/010-CMakeLists-fixes.patch
+++ b/libs/libevhtp-1.1/patches/010-CMakeLists-fixes.patch
@@ -1,0 +1,29 @@
+diff -rupN libevhtp-1.1-1.1.7-orig/CMakeLists.txt libevhtp-1.1-1.1.7/CMakeLists.txt
+--- libevhtp-1.1-1.1.7-orig/CMakeLists.txt	2015-06-14 00:15:28.000000000 +0200
++++ libevhtp-1.1-1.1.7/CMakeLists.txt	2015-06-14 00:21:17.441299942 +0200
+@@ -54,7 +54,7 @@ if (NOT HAVE_SYS_UN)
+ 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNO_SYS_UN")
+ endif(NOT HAVE_SYS_UN)
+ 
+-OPTION(EVHTP_DISABLE_SSL       "Disable ssl support"      OFF)
++OPTION(EVHTP_DISABLE_SSL       "Disable ssl support"      ON)
+ OPTION(EVHTP_DISABLE_EVTHR     "Disable evthread support" OFF)
+ OPTION(EVHTP_DIABLE_REGEX      "Disable regex support"    OFF)
+ 
+@@ -182,11 +182,11 @@ endif()
+ add_library(libevhtp STATIC ${LIBEVHTP_SOURCES} ${ONIG_SOURCES})
+ set_target_properties(libevhtp PROPERTIES OUTPUT_NAME "evhtp")
+ 
+-install (TARGETS libevhtp DESTINATION lib)
+-install (FILES evhtp.h DESTINATION include)
+-install (FILES htparse/htparse.h DESTINATION include)
+-install (FILES evthr/evthr.h DESTINATION include)
+-install (FILES oniguruma/onigposix.h DESTINATION include)
++install (TARGETS libevhtp DESTINATION lib/libevhtp-1.1)
++install (FILES evhtp.h DESTINATION include/libevhtp-1.1)
++install (FILES htparse/htparse.h DESTINATION include/libevhtp-1.1)
++install (FILES evthr/evthr.h DESTINATION include/libevhtp-1.1)
++install (FILES oniguruma/onigposix.h DESTINATION include/libevhtp-1.1)
+ 
+ find_library (LIB_DL dl)
+ set (SYS_LIBS ${LIB_DL})


### PR DESCRIPTION
seafile-server seems to have compatibility issues with the 1.2 branch of
libevtp. This package makes it possible to build seafile against a
supported version, 1.1.7.