### PR TITLE
seafile: build against libevhtp 1.1 instead of 1.2

### DIFF
--- a/net/seafile-server/Makefile
+++ b/net/seafile-server/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-server
 PKG_VERSION:=4.1.2
-PKG_RELEASE=$(PKG_SOURCE_VERSION)
+PKG_RELEASE=$(PKG_SOURCE_VERSION)-2
 PKG_LICENSE:=GPL-3.0
 
 PKG_SOURCE_PROTO:=git
@@ -31,7 +31,7 @@ define Package/seafile-server
     URL:=http://seafile.com/
     DEPENDS:=+shadow-useradd +libarchive +libopenssl +glib2 +libsearpc +seafile-ccnet +seafile-seahub \
 		+sqlite3-cli +python-mysql +jansson +libevent2 +libevent2-openssl +zlib +libzdb +libsqlite3 \
-		+libmysqlclient +libevhtp +libpthread +libuuid \
+		+libmysqlclient +libpthread +libuuid \
 		+bash +sudo +procps +procps-pkill $(ICONV_DEPENDS)
     EXTRA_DEPENDS:=seafile-ccnet (=4.1.2-a73109f09af4ecc49cdc4c57cdde51b38e15c31a), seafile-seahub (=4.1.2-3fb1288f920de03a4e2e6a06b60671ce98971742)
 endef
@@ -54,7 +54,8 @@ CONFIGURE_ARGS += --disable-riak \
 		    --disable-console
 
 PKG_BUILD_DEPENDS:=vala/host \
-		    libsearpc/host
+		    libsearpc/host \
+		    libevhtp-1.1
 
 TARGET_LDFLAGS += -Wl,-rpath-link=$(STAGING_DIR)/usr/lib -liconv \
 		    -L$(STAGING_DIR)/usr/lib/mysql -lmysqlclient -lz

--- a/net/seafile-server/patches/050-libevhtp-search-path-fix.patch
+++ b/net/seafile-server/patches/050-libevhtp-search-path-fix.patch
@@ -1,0 +1,17 @@
+diff -rupN seafile-server-4.1.2.orig/server/Makefile.am seafile-server-4.1.2/server/Makefile.am
+--- seafile-server-4.1.2.orig/server/Makefile.am	2015-05-02 11:04:11.000000000 +0200
++++ seafile-server-4.1.2/server/Makefile.am	2015-06-14 01:28:55.924834806 +0200
+@@ -4,6 +4,7 @@ AM_CFLAGS = -DPKGDATADIR=\"$(pkgdatadir)
+ 	-DPACKAGE_DATA_DIR=\""$(pkgdatadir)"\" \
+ 	-DSEAFILE_SERVER \
+ 	-DFULL_FEATURE \
++	-I$(STAGING_DIR)/usr/include/libevhtp-1.1 \
+ 	-I$(top_srcdir)/include \
+ 	-I$(top_srcdir)/lib \
+ 	-I$(top_builddir)/lib \
+@@ -122,4 +123,4 @@ seaf_server_LDADD = @CCNET_LIBS@ \
+ 	@SEARPC_LIBS@ @JANSSON_LIBS@ @ZDB_LIBS@ @CURL_LIBS@ ${LIB_WS32} @ZLIB_LIBS@ \
+ 	@LIBARCHIVE_LIBS@
+ 
+-seaf_server_LDFLAGS = @STATIC_COMPILE@ @SERVER_PKG_RPATH@
++seaf_server_LDFLAGS = @STATIC_COMPILE@ @SERVER_PKG_RPATH@ -L$(STAGING_DIR)/usr/lib/libevhtp-1.1


### PR DESCRIPTION
This fixes multiple issues like upload/download problems on seahub
and also makes it possible to use the new HTTP syncing feature
which doesn't work with libevhtp 1.2.10 at all.