### PR TITLE
socat: fix musl compatibility

### DIFF
--- a/net/socat/Makefile
+++ b/net/socat/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=socat
 PKG_VERSION:=1.7.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.dest-unreach.org/socat/download

--- a/net/socat/patches/100-musl-compat.patch
+++ b/net/socat/patches/100-musl-compat.patch
@@ -1,0 +1,23 @@
+--- a/sysincludes.h
++++ b/sysincludes.h
+@@ -79,6 +79,9 @@
+ #endif
+ #if HAVE_NETDB_H && (_WITH_IP4 || _WITH_IP6)
+ #include <netdb.h>	/* struct hostent, gethostbyname() */
++#if !(__UCLIBC__ || __GLIBC__)
++#define NETDB_INTERNAL -1
++#endif
+ #endif
+ #if HAVE_SYS_UN_H && WITH_UNIX
+ #include <sys/un.h>	/* struct sockaddr_un, unix domain sockets */
+@@ -139,8 +142,10 @@
+ #include <netpacket/packet.h>
+ #endif
+ #if HAVE_NETINET_IF_ETHER_H
++#if defined(__UCLIBC__) || defined(__GLIBC__)
+ #include <netinet/if_ether.h>
+ #endif
++#endif
+ #if HAVE_LINUX_IF_TUN_H
+ #include <linux/if_tun.h>
+ #endif


### PR DESCRIPTION
Do not include netinet/if_ether.h for musl to prevent struct ethhdr
redeclarations.

Also define NETDB_INTERNAL if needed to fix compilation of the network
backends.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>