### PR TITLE
etherwake: fix musl compatibility

### DIFF
--- a/net/etherwake/Makefile
+++ b/net/etherwake/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2011 OpenWrt.org
+# Copyright (C) 2007-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=etherwake
 PKG_VERSION:=1.09
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
 PKG_SOURCE_URL:=http://ftp.debian.org/debian/pool/main/e/etherwake

--- a/net/etherwake/patches/120-musl-compat.patch
+++ b/net/etherwake/patches/120-musl-compat.patch
@@ -1,0 +1,17 @@
+--- a/ether-wake.c
++++ b/ether-wake.c
+@@ -82,14 +82,8 @@ static char usage_msg[] =
+ #include <linux/if.h>
+ 
+ #include <features.h>
+-#if __GLIBC__ >= 2 && __GLIBC_MINOR >= 1
+ #include <netpacket/packet.h>
+ #include <net/ethernet.h>
+-#else
+-#include <asm/types.h>
+-#include <linux/if_packet.h>
+-#include <linux/if_ether.h>
+-#endif
+ #include <netdb.h>
+ #include <netinet/ether.h>
+ 


### PR DESCRIPTION
Always include net/ethernet.h instead linux specific headers,
fixes compilation with musl libc.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>