### PR TITLE
libpam: fix compilation with musl.

### DIFF
--- a/libs/libpam/Makefile
+++ b/libs/libpam/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpam
 PKG_VERSION:=1.1.8
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=Linux-PAM-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.linux-pam.org/library/

--- a/libs/libpam/patches/008-LIBCRYPT-fix.patch
+++ b/libs/libpam/patches/008-LIBCRYPT-fix.patch
@@ -1,0 +1,11 @@
+--- a/configure.in.orig	2015-06-16 20:40:02.938216001 +0800
++++ b/configure.in	2015-06-16 20:40:16.198216001 +0800
+@@ -399,7 +399,7 @@ AS_IF([test "x$ac_cv_header_xcrypt_h" =
+   [crypt_libs="crypt"])
+ 
+ BACKUP_LIBS=$LIBS
+-AC_SEARCH_LIBS([crypt],[$crypt_libs], LIBCRYPT="-l$ac_lib", LIBCRYPT="")
++AC_SEARCH_LIBS([crypt],[$crypt_libs], LIBCRYPT="${ac_lib:+-l$ac_lib}", LIBCRYPT="")
+ AC_CHECK_FUNCS(crypt_r crypt_gensalt_r)
+ LIBS=$BACKUP_LIBS
+ AC_SUBST(LIBCRYPT)

--- a/libs/libpam/patches/009-pam_rhosts-fix.patch
+++ b/libs/libpam/patches/009-pam_rhosts-fix.patch
@@ -1,0 +1,51 @@
+--- a/configure.in.orig	2015-06-16 21:05:09.938216001 +0800
++++ b/configure.in	2015-06-16 21:05:29.374216001 +0800
+@@ -525,7 +525,8 @@ AC_CHECK_FUNCS(fseeko getdomainname geth
+ AC_CHECK_FUNCS(strcspn strdup strspn strstr strtol uname)
+ AC_CHECK_FUNCS(getutent_r getpwnam_r getpwuid_r getgrnam_r getgrgid_r getspnam_r)
+ AC_CHECK_FUNCS(getgrouplist getline getdelim)
+-AC_CHECK_FUNCS(inet_ntop inet_pton innetgr ruserok_af)
++AC_CHECK_FUNCS(inet_ntop inet_pton innetgr)
++AC_CHECK_FUNCS(ruserok ruserok_af)
+ 
+ AC_CHECK_FUNCS(unshare, [UNSHARE=yes], [UNSHARE=no])
+ AM_CONDITIONAL([HAVE_UNSHARE], [test "$UNSHARE" = yes])
+--- a/modules/pam_rhosts/pam_rhosts.c.orig	2015-06-16 20:58:20.002216001 +0800
++++ b/modules/pam_rhosts/pam_rhosts.c	2015-06-16 21:10:10.026216001 +0800
+@@ -35,6 +35,7 @@
+ #include <pwd.h>
+ #include <netdb.h>
+ #include <string.h>
++#include <stdlib.h>
+ #include <syslog.h>
+ 
+ #define PAM_SM_AUTH  /* only defines this management group */
+@@ -43,7 +43,7 @@
+ #include <security/pam_modutil.h>
+ #include <security/pam_ext.h>
+ 
+-#ifdef __UCLIBC__
++#if defined(__UCLIBC__) || (!defined(HAVE_RUSEROK) && !defined(HAVE_RUSEROK_AF))
+ 
+ #include <stdio.h>
+ #include <sys/stat.h>
+@@ -293,8 +294,10 @@ iruserok2 (u_int32_t raddr, int superuse
+ 	FILE *hostf = NULL;
+ 	int isbad = -1;
+ 
++#ifdef _PATH_HEQUIV
+ 	if (!superuser)
+ 		hostf = iruserfopen (_PATH_HEQUIV, 0);
++#endif
+ 
+ 	if (hostf) {
+ 		isbad = __ivaliduser2 (hostf, raddr, luser, ruser, rhost);
+@@ -396,7 +396,7 @@ int ruserok(const char *rhost, int super
+ 	return -1;
+ }
+ 
+-#endif /* __UCLIBC__ */
++#endif /* __UCLIBC__ || (!defined(HAVE_RUSEROK) && !defined(HAVE_RUSEROK_AF)) */
+ 
+ PAM_EXTERN
+ int pam_sm_authenticate (pam_handle_t *pamh, int flags, int argc,


### PR DESCRIPTION
There is also another patch [1] required of musl for compiling the pam_lastlog module.  

[1] https://lists.openwrt.org/pipermail/openwrt-devel/2015-June/033713.html