### PR TITLE
aiccu: fix musl compatibility

### DIFF
--- a/ipv6/aiccu/Makefile
+++ b/ipv6/aiccu/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2012 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aiccu
 PKG_VERSION:=20070115
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.sixxs.net/archive/sixxs/aiccu/unix

--- a/ipv6/aiccu/patches/100-cross_compile.patch
+++ b/ipv6/aiccu/patches/100-cross_compile.patch
@@ -1,6 +1,6 @@
---- aiccu/unix-console/Makefile.orig	2007-09-02 23:19:39.000000000 +0200
-+++ aiccu/unix-console/Makefile	2007-09-02 23:20:11.000000000 +0200
-@@ -25,7 +25,8 @@
+--- a/unix-console/Makefile
++++ b/unix-console/Makefile
+@@ -25,7 +25,8 @@ CWARNS += -W -Wall -Wshadow -Wpointer-ar
  # CWARNS += -Wpacked
  
  #CFLAGS	+= $(CWARNS) -D_GNU_SOURCE -D_DEBUG -g3 -O0
@@ -10,7 +10,7 @@
  CC      = @gcc
  RM      = rm
  
-@@ -40,25 +41,25 @@
+@@ -40,25 +41,25 @@ CFLAGS	+= -D AICCU_CONSOLE
  # GnuTLS Support ?
  # Used by TIC to secure that communication
  # Currently defaultly builds only on Linux, but other platforms might easily also support it
@@ -41,7 +41,7 @@
  CFLAGS	+= -D AICCU_TYPE="\"freebsd4\""
  SRCS	+= ../common/aiccu_freebsd4.c
  OBJS	+= ../common/aiccu_freebsd4.o
-@@ -71,7 +72,7 @@
+@@ -71,7 +72,7 @@ endif
  endif
  
  # DragonFlyBSD
@@ -50,7 +50,7 @@
  CFLAGS	+= -D_DFBSD -D NEED_IFHEAD -D AICCU_TYPE="\"dragonfly\""
  SRCS	+= ../common/aiccu_freebsd4.c
  OBJS	+= ../common/aiccu_freebsd4.o
-@@ -79,7 +80,7 @@
+@@ -79,7 +80,7 @@ CFLAGS	+= -pthread
  endif
  
  # NetBSD
@@ -59,7 +59,7 @@
  CFLAGS	+= -D_NETBSD -D AICCU_TYPE="\"kame\""
  
  # Check if net/if_tun.h has TUNSIFHEAD and enable support for it
-@@ -97,10 +98,10 @@
+@@ -97,10 +98,10 @@ CFLAGS	+= -pthread -D_NETBSD_SOURCE
  endif
  
  # OpenBSD
@@ -72,7 +72,7 @@
  CFLAGS	+= -D AICCU_TYPE="\"openbsd2\""
  SRCS	+= ../common/aiccu_openbsd2.c
  OBJS	+= ../common/aiccu_openbsd2.o
-@@ -114,7 +115,7 @@
+@@ -114,7 +115,7 @@ CFLAGS	+= -pthread
  endif
  
  # Darwin
@@ -81,7 +81,7 @@
  CFLAGS	+= -D_DARWIN -D NEED_IFHEAD -D AICCU_TYPE="\"darwin\""
  SRCS	+= ../common/aiccu_darwin.c
  OBJS	+= ../common/aiccu_darwin.o
-@@ -122,7 +123,7 @@
+@@ -122,7 +123,7 @@ LDFLAGS	+= -lresolv
  endif
  
  # SunOS / Solaris
@@ -90,7 +90,7 @@
  CFLAGS	+= -D_SUNOS -D AICCU_TYPE="\"sunos\""
  SRCS	+= ../common/aiccu_sunos.c
  OBJS	+= ../common/aiccu_sunos.o
-@@ -130,7 +131,7 @@
+@@ -130,7 +131,7 @@ LDFLAGS	+= -lsocket -lnsl -lresolv
  endif
  
  # AIX

--- a/ipv6/aiccu/patches/200-add_dn_skipname.patch
+++ b/ipv6/aiccu/patches/200-add_dn_skipname.patch
@@ -1,6 +1,5 @@
-diff -Nru aiccu.old/common/dn_skipname.c aiccu/common/dn_skipname.c
---- aiccu.old/common/dn_skipname.c	1970-01-01 02:00:00.000000000 +0200
-+++ aiccu/common/dn_skipname.c	2006-11-04 00:50:23.000000000 +0200
+--- /dev/null
++++ b/common/dn_skipname.c
 @@ -0,0 +1,51 @@
 +#include <errno.h>
 +#include <resolv.h>
@@ -53,11 +52,10 @@ diff -Nru aiccu.old/common/dn_skipname.c aiccu/common/dn_skipname.c
 +	return (ptr - saveptr);
 +}
 +
-diff -Nru aiccu.old/unix-console/Makefile aiccu/unix-console/Makefile
---- aiccu.old/unix-console/Makefile	2006-11-04 00:51:20.000000000 +0200
-+++ aiccu/unix-console/Makefile	2006-11-04 00:48:51.000000000 +0200
+--- a/unix-console/Makefile
++++ b/unix-console/Makefile
 @@ -10,9 +10,9 @@
- #  $Date: 2006-07-25 09:20:48 $
+ #  $Date: 2007-01-15 11:04:27 $
  # **********************************************************/
  
 -SRCS	= main.c ../common/tun.c ../common/aiccu.c ../common/hash_md5.c ../common/hash_sha1.c ../common/common.c ../common/heartbeat.c ../common/tic.c ../common/ayiya.c ../common/aiccu_test.c ../common/resolver.c

--- a/ipv6/aiccu/patches/300-resolver-uclibc.patch
+++ b/ipv6/aiccu/patches/300-resolver-uclibc.patch
@@ -1,29 +1,40 @@
---- aiccu/common/resolver.c.orig	2007-09-02 23:10:58.000000000 +0200
-+++ aiccu/common/resolver.c	2007-09-02 23:11:01.000000000 +0200
+--- a/common/resolver.c
++++ b/common/resolver.c
 @@ -26,7 +26,7 @@
  
  int getrrs(const char *label, int rrtype, void gotrec(unsigned int num, int type, const char *record))
  {
 -#ifdef _LINUX
-+#if defined(_LINUX) && !defined(__UCLIBC__)
++#if defined(_LINUX) && defined(__GLIBC__)
  	struct __res_state	res;
  #endif
  	unsigned char		answer[8192];
-@@ -38,7 +38,7 @@
+@@ -38,7 +38,7 @@ int getrrs(const char *label, int rrtype
  	uint16_t		type = 0, class = 0;
  	uint32_t		ttl = 0;
  
 -#ifdef _LINUX
-+#if defined(_LINUX) && !defined(__UCLIBC__)
++#if defined(_LINUX) && defined(__GLIBC__)
  	memset(&res, 0, sizeof(res));
  	res.options = RES_DEBUG;
  	res_ninit(&res);
-@@ -47,7 +47,7 @@
+@@ -47,7 +47,7 @@ int getrrs(const char *label, int rrtype
  #endif
  
  	memset(answer, 0, sizeof(answer));
 -#ifdef _LINUX
-+#if defined(_LINUX) && !defined(__UCLIBC__)
++#if defined(_LINUX) && defined(__GLIBC__)
  	ret = res_nquery(&res, label, C_IN, rrtype, answer, sizeof(answer));
  #else
  	ret = res_query(label, C_IN, rrtype, answer, sizeof(answer));
+--- a/common/dn_skipname.c
++++ b/common/dn_skipname.c
+@@ -9,7 +9,7 @@
+  * return:
+  *      0 on success, -1 (with errno set) on failure.
+  */
+-int ns_name_skip(const u_char **ptrptr, const u_char *eom)
++static int ns_name_skip(const u_char **ptrptr, const u_char *eom)
+ {
+ 	const u_char *cp;
+ 	u_int n;

--- a/ipv6/aiccu/patches/400-musl-compat.patch
+++ b/ipv6/aiccu/patches/400-musl-compat.patch
@@ -1,0 +1,29 @@
+--- a/common/common.h
++++ b/common/common.h
+@@ -50,6 +50,7 @@
+ #include <signal.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#include <sys/uio.h>
+ #include <fcntl.h>
+ 
+ #if defined(_SUNOS) || defined(_AIX) || defined(_DARWIN)
+@@ -91,7 +92,9 @@
+ 	#include <sys/select.h>
+ 
+ 	#include <net/if.h>
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+ 	#include <netinet/if_ether.h>
++#endif
+ #ifdef linux
+ 	#include <netpacket/packet.h>
+ 	#include <linux/if_tun.h>
+--- a/common/dn_skipname.c
++++ b/common/dn_skipname.c
+@@ -1,5 +1,6 @@
+ #include <errno.h>
+ #include <resolv.h>
++#include <sys/types.h>
+ 
+ /* Ripped from glibc 2.4 sources. */
+ 


### PR DESCRIPTION
- Fix redefinition of struct ethhdr
- Restrict the use of res_ninit() and res_nquery() to glibc
- Fix a warning in dn_skipname.c by declaring ns_name_skip() static
- Refresh patches

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>