### PR TITLE
fastd: fix musl compatibility

### DIFF
--- a/net/fastd/Makefile
+++ b/net/fastd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fastd
 PKG_VERSION:=17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Matthias Schiffer <mschiffer@universe-factory.net>
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/net/fastd/patches/100-musl-compat.patch
+++ b/net/fastd/patches/100-musl-compat.patch
@@ -1,0 +1,67 @@
+--- a/cmake/checks.cmake
++++ b/cmake/checks.cmake
+@@ -54,9 +54,13 @@ if(NOT DARWIN)
+ endif(NOT DARWIN)
+ 
+ 
++set(CMAKE_EXTRA_INCLUDE_FILES "linux/if_ether.h")
++check_type_size("struct ethhdr" SIZEOF_ETHHDR)
++string(COMPARE NOTEQUAL "${SIZEOF_ETHHDR}" "" HAVE_LINUX_ETHHDR)
++
+ set(CMAKE_EXTRA_INCLUDE_FILES "netinet/if_ether.h")
+ check_type_size("struct ethhdr" SIZEOF_ETHHDR)
+-string(COMPARE NOTEQUAL "${SIZEOF_ETHHDR}" "" HAVE_ETHHDR)
++string(COMPARE NOTEQUAL "${SIZEOF_ETHHDR}" "" HAVE_NETINET_ETHHDR)
+ 
+ 
+ set(CMAKE_REQUIRED_INCLUDES "sys/types.h")
+--- a/src/compat.h
++++ b/src/compat.h
+@@ -45,7 +45,12 @@
+ #include <net/if.h>
+ #include <net/if_arp.h>
+ #include <netinet/in.h>
++
++#if defined(HAVE_LINUX_ETHHDR)
++#include <linux/if_ether.h>
++#elif defined(HAVE_NETINET_ETHHDR)
+ #include <netinet/if_ether.h>
++#endif
+ 
+ #ifndef ETH_ALEN
+ /** The length of a MAC address */
+@@ -55,9 +60,8 @@
+ #ifndef ETH_HLEN
+ /** The length of the standard ethernet header */
+ #define ETH_HLEN 14
+-#endif
+ 
+-#ifndef HAVE_ETHHDR
++#if !defined(HAVE_LINUX_ETHHDR) && !defined(HAVE_NETINET_ETHHDR)
+ /** An ethernet header */
+ struct ethhdr {
+ 	uint8_t h_dest[ETH_ALEN];			/**< The destination MAC address field */
+@@ -65,6 +69,7 @@ struct ethhdr {
+ 	uint16_t h_proto;				/**< The EtherType/length field */
+ } __attribute__((packed));
+ #endif
++#endif
+ 
+ #if defined(USE_FREEBIND) && !defined(IP_FREEBIND)
+ /** Compatiblity define for systems supporting, but not defining IP_FREEBIND */
+--- a/src/fastd_config.h.in
++++ b/src/fastd_config.h.in
+@@ -35,8 +35,11 @@
+ /** Defined if the platform supports the AI_ADDRCONFIG flag to getaddrinfo() */
+ #cmakedefine HAVE_AI_ADDRCONFIG
+ 
+-/** Defined if the platform defines the \e ethhdr struct */
+-#cmakedefine HAVE_ETHHDR
++/** Defined if the platform defines the \e ethhdr struct through linux/if_ether.h */
++#cmakedefine HAVE_LINUX_ETHHDR
++
++/** Defined if the platform defines the \e ethhdr struct through netinet/if_ether.h */
++#cmakedefine HAVE_LINUX_ETHHDR
+ 
+ /** Defined if the platform defines get_current_dir_name() */
+ #cmakedefine HAVE_GET_CURRENT_DIR_NAME


### PR DESCRIPTION
Prefer linux/if_ether.h over netinet/if_ether.h if available since the
musl libc if_ether.h header does not allow mixing with kernel headers,
it will result in a struct ethhdr redefinition error.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>