### PR TITLE
avrdude: fix musl compatibility

### DIFF
--- a/utils/avrdude/Makefile
+++ b/utils/avrdude/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avrdude
 PKG_VERSION:=6.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.savannah.gnu.org/releases/avrdude
@@ -39,6 +39,9 @@ endef
 CONFIGURE_ARGS+= \
 	--disable-doc \
 	--disable-parport \
+
+TARGET_CFLAGS+= \
+	-D_GNU_SOURCE \
 
 define Package/avrdude/conffiles
 /etc/avrdude.conf

--- a/utils/avrdude/patches/100-musl-compat.patch
+++ b/utils/avrdude/patches/100-musl-compat.patch
@@ -1,0 +1,60 @@
+--- a/dfu.h
++++ b/dfu.h
+@@ -25,6 +25,7 @@
+ 
+ #ifdef HAVE_LIBUSB
+ #if defined(HAVE_USB_H)
++#  include <sys/types.h>
+ #  include <usb.h>
+ #elif defined(HAVE_LUSB0_USB_H)
+ #  include <lusb0_usb.h>
+--- a/pickit2.c
++++ b/pickit2.c
+@@ -50,6 +50,7 @@
+ #include <string.h>
+ #include <inttypes.h>
+ #include <unistd.h>
++#include <sys/types.h>
+ 
+ #include "avrdude.h"
+ #include "avr.h"
+--- a/ser_avrdoper.c
++++ b/ser_avrdoper.c
+@@ -248,6 +248,7 @@ static int usbGetReport(union filedescri
+ /* ------------------------------------------------------------------------ */
+ 
+ #if defined(HAVE_USB_H)
++#  include <sys/types.h>
+ #  include <usb.h>
+ #elif defined(HAVE_LUSB0_USB_H)
+ #  include <lusb0_usb.h>
+--- a/usbtiny.c
++++ b/usbtiny.c
+@@ -41,6 +41,7 @@
+ 
+ #if defined(HAVE_LIBUSB)      // we use LIBUSB to talk to the board
+ #if defined(HAVE_USB_H)
++#  include <sys/types.h>
+ #  include <usb.h>
+ #elif defined(HAVE_LUSB0_USB_H)
+ #  include <lusb0_usb.h>
+--- a/usbasp.c
++++ b/usbasp.c
+@@ -54,6 +54,7 @@
+ # endif
+ #else
+ # if defined(HAVE_USB_H)
++#  include <sys/types.h>
+ #  include <usb.h>
+ # elif defined(HAVE_LUSB0_USB_H)
+ #  include <lusb0_usb.h>
+--- a/usb_libusb.c
++++ b/usb_libusb.c
+@@ -36,6 +36,7 @@
+ #include <sys/time.h>
+ 
+ #if defined(HAVE_USB_H)
++#  include <sys/types.h>
+ #  include <usb.h>
+ #elif defined(HAVE_LUSB0_USB_H)
+ #  include <lusb0_usb.h>


### PR DESCRIPTION
 - Build with -D_GNU_SOURCE to expose "loff_t" required for libelf.h
 - Include sys/types.h before usb.h to provide missing u_int*_t types

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>