### PR TITLE
bridge-utils: fix musl compatibility

### DIFF
--- a/net/bridge-utils/Makefile
+++ b/net/bridge-utils/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=bridge-utils
 PKG_VERSION:=1.5
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/bridge-utils.git

--- a/net/bridge-utils/patches/100-musl-compat.patch
+++ b/net/bridge-utils/patches/100-musl-compat.patch
@@ -1,0 +1,11 @@
+--- a/libbridge/libbridge.h
++++ b/libbridge/libbridge.h
+@@ -19,6 +19,8 @@
+ #ifndef _LIBBRIDGE_H
+ #define _LIBBRIDGE_H
+ 
++#include <sys/types.h>
++#include <sys/select.h>
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+ #include <linux/if.h>


### PR DESCRIPTION
Add missing includes to libbridge.h to define struct timeval and the
required u_int*_t types under musl.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>