### PR TITLE
vsftpd: fix musl compatibility

### DIFF
--- a/net/vsftpd/Makefile
+++ b/net/vsftpd/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vsftpd
 PKG_VERSION:=3.0.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://security.appspot.com/downloads/
@@ -49,8 +49,15 @@ endef
 
 Package/vsftpd-tls/conffiles=$(Package/vsftpd/conffiles)
 
+ifneq ($(CONFIG_USE_MUSL),)
+  NLSSTRING:=-lcrypt
+else
+  NLSSTRING:=-lcrypt -lnsl
+endif
+
 ifeq ($(BUILD_VARIANT),notls)
  define Build/Compile
+	$(SED) 's/-lcrypt -lnsl/$(NLSSTRING)/' $(PKG_BUILD_DIR)/Makefile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		CC="$(TARGET_CC)" \
 		CFLAGS="$(TARGET_CFLAGS)" \
@@ -63,6 +70,7 @@ ifeq ($(BUILD_VARIANT),tls)
  define Build/Compile
 	$(SED) 's/#undef VSF_BUILD_SSL/#define VSF_BUILD_SSL/' $(PKG_BUILD_DIR)/builddefs.h
 	$(SED) 's/-lcrypt -lnsl/-lcrypt -lnsl -lssl -lcrypto/' $(PKG_BUILD_DIR)/Makefile
+	$(SED) 's/-lcrypt -lnsl/$(NLSSTRING)/' $(PKG_BUILD_DIR)/Makefile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		CC="$(TARGET_CC)" \
 		CFLAGS="$(TARGET_CFLAGS)" \

--- a/net/vsftpd/patches/006-musl-compatibility.patch
+++ b/net/vsftpd/patches/006-musl-compatibility.patch
@@ -1,0 +1,13 @@
+--- a/sysdeputil.c
++++ b/sysdeputil.c
+@@ -58,7 +58,9 @@
+ #define VSF_SYSDEP_HAVE_SHADOW
+ #define VSF_SYSDEP_HAVE_USERSHELL
+ #define VSF_SYSDEP_HAVE_LIBCAP
+-#define VSF_SYSDEP_HAVE_UTMPX
++#if defined(__GLIBC__) || defined(__UCLIBC__)
++  #define VSF_SYSDEP_HAVE_UTMPX
++#endif
+ 
+ #define __USE_GNU
+ #include <utmpx.h>


### PR DESCRIPTION
Make vsftpd to compile with musl, while preserving uclibc compatibility.

When using musl:
* disable UTMPX functionality. A new patch disabling it if necessary.
* disable -lnsl option in upstream Makefile. This is done with a 'sed' command in the Openwrt Makefile, as it touches the same line that may be edited via 'sed' during make to set the tls/notls option.

Background info:
lnsl: #456  and https://dev.openwrt.org/ticket/19310
UTMPX: https://patchwork.ozlabs.org/patch/390057/


@obsy 
