### PR TITLE
pptpd: fix musl compatibility

### DIFF
--- a/net/pptpd/Makefile
+++ b/net/pptpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pptpd
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/poptop

--- a/net/pptpd/patches/100-musl-compat.patch
+++ b/net/pptpd/patches/100-musl-compat.patch
@@ -1,0 +1,38 @@
+--- a/bcrelay.c
++++ b/bcrelay.c
+@@ -667,7 +667,7 @@ static void mainloop(int argc, char **ar
+                  * there is no need to concern about the physical/link layer header because it is
+                  * filled in automatically (based on the contents of sa).
+                  */
+-                if ((nrsent = sendto(cur_ifsnr[j].sock_nr, ipp_p, rlen, MSG_DONTWAIT|MSG_TRYHARD, (struct sockaddr *)&sa, salen)) < 0)
++                if ((nrsent = sendto(cur_ifsnr[j].sock_nr, ipp_p, rlen, MSG_DONTWAIT|MSG_DONTROUTE, (struct sockaddr *)&sa, salen)) < 0)
+                 {
+                   if (errno == ENETDOWN) {
+                     syslog(LOG_NOTICE, "ignored ENETDOWN from sendto(), a network interface was going down?");
+--- a/compat.c
++++ b/compat.c
+@@ -11,10 +11,10 @@
+ #include "compat.h"
+ #include "our_syslog.h"
+ 
+-#ifndef HAVE_STRLCPY
+ #include <string.h>
+ #include <stdio.h>
+ 
++#ifndef HAVE_STRLCPY
+ void strlcpy(char *dst, const char *src, size_t size)
+ {
+         strncpy(dst, src, size - 1);
+--- /dev/null
++++ b/net/ppp_defs.h
+@@ -0,0 +1,10 @@
++#ifndef _NET_PPP_DEFS_H
++#define _NET_PPP_DEFS_H 1
++
++#define __need_time_t
++#include <time.h>
++
++#include <asm/types.h>
++#include <linux/ppp_defs.h>
++
++#endif /* net/ppp_defs.h */


### PR DESCRIPTION
 - Ship a net/ppp_defs.h replacement header since musl does not provide one
   but pppd/pppd.h provided by pppd is needing it.
 - Replace deprecated MSG_TRYHARD flag with the proper MSG_DONTROUTE one
 - Unconditionally include string.h in bcrelay to avoid undeclared memset()
   and strcpy() warnings.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>