### PR TITLE
rng-tools: musl compatibility

### DIFF
--- a/utils/rng-tools/Makefile
+++ b/utils/rng-tools/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2014 OpenWrt.org
+# Copyright (C) 2011-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rng-tools
 PKG_VERSION:=5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/gkernel/rng-tools/$(PKG_VERSION)/
@@ -19,7 +19,7 @@ PKG_MAINTAINER:=Hannu Nyman <hannu.nyman@iki.fi>
 
 PKG_FIXUP:=autoreconf
 
-PKG_BUILD_DEPENDS:=USE_UCLIBC:argp-standalone
+PKG_BUILD_DEPENDS:=USE_UCLIBC:argp-standalone USE_MUSL:argp-standalone
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -31,6 +31,11 @@ define Package/rng-tools
 endef
 
 ifdef CONFIG_USE_UCLIBC
+CONFIGURE_VARS += \
+    LIBS="-largp"
+endif
+
+ifdef CONFIG_USE_MUSL
 CONFIGURE_VARS += \
     LIBS="-largp"
 endif


### PR DESCRIPTION
Make rng-tools to compile with musl by adding similar argp dependencies as with uclibc.

This should fix #1396 
