### PR TITLE
perl: fix musl compatibility

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=5.20.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=ftp://ftp.cpan.org/pub/CPAN/src/5.0 \
 		http://www.cpan.org/src/5.0/perl-5.20.0.tar.gz \
@@ -128,6 +128,26 @@ define Build/Configure
 		-e 's!%%HOSTGENERATE%%!$(HOST_PERL_PREFIX)/bin/generate_uudmap!g' \
 		files/config.sh-$(patsubst i386,i486,$(ARCH))$(PERL_CONFIG_SUFFIX).in \
 		> $(PKG_BUILD_DIR)/config.sh
+  ifeq ($(CONFIG_USE_MUSL),y)
+	sed -i \
+		-e "s,\(d_stdio_ptr_lval=\)'define',\1'undef',g" \
+		-e "s,\(d_stdio_ptr_lval_sets_cnt=\)'define',\1'undef',g" \
+		-e "s,\(d_stdiobase=\)'define',\1'undef',g" \
+		-e "s,\(d_stdstdio=\)'define',\1'undef',g" \
+		-e "s,\(d_getnetbyname_r=\)'define',\1'undef',g" \
+		-e "s,\(getprotobyname_r=\)'define',\1'undef',g" \
+		-e "s,\(getpwent_r=\)'define',\1'undef',g" \
+		-e "s,\(getservent_r=\)'define',\1'undef',g" \
+		-e "s,\(gethostent_r=\)'define',\1'undef',g" \
+		-e "s,\(getnetent_r=\)'define',\1'undef',g" \
+		-e "s,\(getnetbyaddr_r=\)'define',\1'undef',g" \
+		-e "s,\(getprotoent_r=\)'define',\1'undef',g" \
+		-e "s,\(getprotobynumber_r=\)'define',\1'undef',g" \
+		-e "s,\(getgrent_r=\)'define',\1'undef',g" \
+		-e "s,\(i_fcntl=\)'undef',\1'define',g" \
+		-e "s,\(h_fcntl=\)'false',\1'true',g" \
+		$(PKG_BUILD_DIR)/config.sh
+  endif
 	(cd $(PKG_BUILD_DIR) && ./Configure -S)
 	install -m 0644 $(PKG_BUILD_DIR)/config.h $(PKG_BUILD_DIR)/xconfig.h
 endef

--- a/lang/perl/patches/100-musl-compat.patch
+++ b/lang/perl/patches/100-musl-compat.patch
@@ -1,0 +1,11 @@
+--- a/pp.c
++++ b/pp.c
+@@ -43,7 +43,7 @@ extern Pid_t getpid (void);
+  * Some BSDs and Cygwin default to POSIX math instead of IEEE.
+  * This switches them over to IEEE.
+  */
+-#if defined(LIBM_LIB_VERSION)
++#if defined(LIBM_LIB_VERSION) && (defined(__GLIBC__) || defined(__UCLIBC__))
+     _LIB_VERSION_TYPE _LIB_VERSION = _IEEE_;
+ #endif
+ 


### PR DESCRIPTION
 - Add patch to inhibit the libm IEEE math switch on musl
 - Add postprocessing for config.sh to the Makefile to fixup
   defines for musl, idea taken
   from http://patchwork.openembedded.org/patch/91707/

This is the least invasive approach I could come up to fix the build
failure asap. Another possibility is maintaining yet another set of
musl specific architecture config files, but I think that this introduces
a lot of maintenance overhead.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>