### PR TITLE
keepalived: fix musl compatibility

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=1.2.16
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= http://www.keepalived.org/software

--- a/net/keepalived/patches/100-musl-compat.patch
+++ b/net/keepalived/patches/100-musl-compat.patch
@@ -1,0 +1,10 @@
+--- a/lib/utils.h
++++ b/lib/utils.h
+@@ -31,6 +31,7 @@
+ #include <arpa/inet.h>
+ #include <arpa/nameser.h>
+ #include <sys/param.h>
++#include <sys/types.h>
+ #include <sys/utsname.h>
+ #include <netdb.h>
+ 


### PR DESCRIPTION
 - Add missing sys/types.h include to provide u_short type under musl

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>