### PR TITLE
zabbix: fix musl compatibility

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=2.4.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/zabbix

--- a/admin/zabbix/patches/100-musl-compat.patch
+++ b/admin/zabbix/patches/100-musl-compat.patch
@@ -1,0 +1,23 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -51,7 +51,7 @@ AC_CHECK_HEADERS(stdio.h stdlib.h string
+   syslog.h time.h errno.h sys/types.h sys/stat.h netinet/in.h \
+   math.h sys/socket.h dirent.h ctype.h \
+   mtent.h fcntl.h sys/param.h arpa/inet.h \
+-  sys/vfs.h sys/pstat.h sys/sysinfo.h sys/statvfs.h sys/statfs.h \
++  sys/vfs.h sys/pstat.h sys/statvfs.h sys/statfs.h \
+   sys/socket.h sys/loadavg.h arpa/inet.h \
+   sys/vmmeter.h strings.h vm/vm_param.h \
+   sys/time.h kstat.h sys/syscall.h sys/sysmacros.h \
+@@ -63,6 +63,11 @@ AC_CHECK_HEADERS(stdio.h stdlib.h string
+   sys/timeb.h Winber.h lber.h ws2tcpip.h inttypes.h sys/file.h grp.h \
+   execinfo.h libperfstat.h sys/systemcfg.h sys/mnttab.h mntent.h sys/times.h \
+   dlfcn.h sys/utsname.h)
++AC_CHECK_HEADERS(sys/sysinfo.h, [], [], [
++#ifdef HAVE_LINUX_KERNEL_H
++#  include <linux/kernel.h>
++#endif
++])
+ AC_CHECK_HEADERS(resolv.h, [], [], [
+ #ifdef HAVE_SYS_TYPES_H
+ #  include <sys/types.h>


### PR DESCRIPTION
Under musl a compilation unit cannot include both linux/kernel.h
and sys/sysinfo.h at the same time since that leads to a redefinition
of `struct sysinfo`.

Change the autoconf template to include linux/kernel.h while testing
for sys/sysinfo.h to test for that conflict.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>