### PR TITLE
xinetd: fix musl compatibility

### DIFF
--- a/net/xinetd/Makefile
+++ b/net/xinetd/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xinetd
 PKG_VERSION:=2.3.15
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.xinetd.org
@@ -42,6 +42,7 @@ define Package/xinetd/conffiles
 endef
 
 TARGET_CFLAGS += -DNO_RPC
+TARGET_CPPFLAGS += -DHAVE_RLIM_T
 
 CONFIGURE_ARGS += \
 	--without-libwrap \

--- a/net/xinetd/patches/004-ident-bind.patch
+++ b/net/xinetd/patches/004-ident-bind.patch
@@ -10,7 +10,7 @@ Reviewed-By: Adam Tkac <atkac@redhat.com>
 #diff -up xinetd-2.3.14/xinetd/ident.c.orig xinetd-2.3.14/xinetd/ident.c
 --- a/xinetd/ident.c
 +++ b/xinetd/ident.c
-@@ -97,7 +98,13 @@ idresult_e log_remote_user( const struct
+@@ -97,7 +97,13 @@ idresult_e log_remote_user( const struct
     }
  
     CLEAR( sin_contact );
@@ -25,7 +25,7 @@ Reviewed-By: Adam Tkac <atkac@redhat.com>
     sin_contact = sin_remote;
     memcpy( &sin_bind, &sin_local, sizeof(sin_bind) ) ;
     local_port = 0;
-@@ -121,7 +128,13 @@ idresult_e log_remote_user( const struct
+@@ -127,7 +133,13 @@ idresult_e log_remote_user( const struct
        msg( LOG_ERR, func, "socket creation: %m" ) ;
        return( IDR_ERROR ) ;
     }


### PR DESCRIPTION
Pass HAVE_RLIM_T via TARGET_CPPFLAGS since configure uses that define
but never actually declares it.

Without doing that, `config.h` tries to declare `rlim_t` itself which
leads to `config.h:126:16: error: 'long long long' is too long for GCC`
with musl on at least x86_64.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>