### PR TITLE
wifidog: fix musl compatibility

### DIFF
--- a/net/wifidog/Makefile
+++ b/net/wifidog/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifidog
 PKG_VERSION:=1.2.1
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 
 PKG_LICENSE:=GPL-2.0

--- a/net/wifidog/patches/100-musl-compat.patch
+++ b/net/wifidog/patches/100-musl-compat.patch
@@ -1,0 +1,47 @@
+--- a/libhttpd/protocol.c
++++ b/libhttpd/protocol.c
+@@ -28,6 +28,7 @@
+ 
+ #if defined(_WIN32)
+ #else
++#include <fcntl.h>
+ #include <unistd.h>
+ #include <sys/file.h>
+ #endif
+--- a/src/firewall.c
++++ b/src/firewall.c
+@@ -35,7 +35,6 @@
+ #include <pthread.h>
+ #include <sys/wait.h>
+ #include <sys/types.h>
+-#include <sys/unistd.h>
+ 
+ #include <string.h>
+ 
+--- a/src/client_list.c
++++ b/src/client_list.c
+@@ -31,9 +31,9 @@
+ #include <syslog.h>
+ #include <errno.h>
+ #include <pthread.h>
++#include <unistd.h>
+ #include <sys/wait.h>
+ #include <sys/types.h>
+-#include <sys/unistd.h>
+ 
+ #include <string.h>
+ 
+--- a/src/util.c
++++ b/src/util.c
+@@ -33,10 +33,10 @@
+ #include <syslog.h>
+ #include <errno.h>
+ #include <pthread.h>
++#include <unistd.h>
+ #include <sys/wait.h>
+ #include <sys/types.h>
+ #include <sys/time.h>
+-#include <sys/unistd.h>
+ #include <netinet/in.h>
+ #include <sys/ioctl.h>
+ #include <arpa/inet.h>


### PR DESCRIPTION
 - Fix missing `fcntl.h` in `protocol.c`
 - Replace nonstandard `sys/unistd.h` includes with `unistd.h` ones

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>