### PR TITLE
screen: fix musl compatibility

### DIFF
--- a/utils/screen/Makefile
+++ b/utils/screen/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=screen
 PKG_VERSION:=4.2.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/screen

--- a/utils/screen/patches/200-musl-compat.patch
+++ b/utils/screen/patches/200-musl-compat.patch
@@ -1,0 +1,10 @@
+--- a/utmp.c
++++ b/utmp.c
+@@ -33,6 +33,7 @@
+ #include "config.h"
+ #include "screen.h"
+ #include "extern.h"
++#include "os.h"
+ 
+ #ifdef HAVE_UTEMPTER
+ #include <utempter.h>


### PR DESCRIPTION
Add missing `os.h` include to `utmp.c` to pull in the required `utmp.h` header.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>