### PR TITLE
libnet-1.2.x: fix musl compatiblity

### DIFF
--- a/libs/libnet-1.2.x/Makefile
+++ b/libs/libnet-1.2.x/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnet
 PKG_VERSION:=1.2-rc3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://sourceforge.net/projects/libnet-dev/files/

--- a/libs/libnet-1.2.x/patches/100-musl-compat.patch
+++ b/libs/libnet-1.2.x/patches/100-musl-compat.patch
@@ -1,0 +1,11 @@
+--- a/src/libnet_link_linux.c
++++ b/src/libnet_link_linux.c
+@@ -30,7 +30,7 @@
+ #include <sys/time.h>
+ 
+ #include <net/if.h>
+-#if (__GLIBC__)
++#if (!__UCLIBC__)
+ #include <netinet/if_ether.h>
+ #include <net/if_arp.h>
+ #else


### PR DESCRIPTION
The correct includes for musl are protected by an `__GLIBC__` check in the
upstream sources.

Since musl does not provide own defines to identify itself, simply invert
the condition to `!__UCLIBC__` in order to fix the build on allon all libc flavors
supported by OpenWrt.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>