### PR TITLE
libdaq: fix musl compatibility

### DIFF
--- a/libs/libdaq/Makefile
+++ b/libs/libdaq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdaq
 PKG_VERSION:=2.0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://www.snort.org/downloads/snort/ \
 	@SF/snort

--- a/libs/libdaq/patches/001-compile.patch
+++ b/libs/libdaq/patches/001-compile.patch
@@ -1,8 +1,8 @@
---- daq-1.1.1/configure	2012-07-10 21:32:51.000000000 +0200
-+++ daq-new/configure	2012-08-03 15:47:07.654945651 +0200
-@@ -12717,10 +12717,11 @@
-     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libpcap version >= \"1.0.0\"" >&5
- $as_echo_n "checking for libpcap version >= \"1.0.0\"... " >&6; }
+--- a/configure
++++ b/configure
+@@ -12967,10 +12967,11 @@ if ${daq_cv_libpcap_version_1x+:} false;
+ else
+ 
      if test "$cross_compiling" = yes; then :
 -  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 -$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}

--- a/libs/libdaq/patches/100-musl-compat.patch
+++ b/libs/libdaq/patches/100-musl-compat.patch
@@ -1,0 +1,42 @@
+--- a/os-daq-modules/daq_ipfw.c
++++ b/os-daq-modules/daq_ipfw.c
+@@ -23,10 +23,10 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <stdio.h>
++#include <unistd.h>
+ 
+ #include <sys/types.h>
+ #include <sys/time.h>
+-#include <sys/unistd.h>
+ 
+ #include <netinet/in.h>
+ #include <sys/socket.h>
+--- a/os-daq-modules/daq_ipq.c
++++ b/os-daq-modules/daq_ipq.c
+@@ -24,10 +24,10 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ #include <sys/types.h>
+ #include <sys/time.h>
+-#include <sys/unistd.h>
+ 
+ #include <netinet/ip.h>
+ 
+--- a/os-daq-modules/daq_nfq.c
++++ b/os-daq-modules/daq_nfq.c
+@@ -24,10 +24,10 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ #include <sys/types.h>
+ #include <sys/time.h>
+-#include <sys/unistd.h>
+ 
+ #include <netinet/ip.h>
+ 


### PR DESCRIPTION
Change occurences of `sys/unistd.h` to the standard `unistd.h` include.
Fixes build against musl.

Also refresh existing patch since it applied with fuzz.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>