### PR TITLE
libv4l: Fix musl compatibility, update to 1.6.3

### DIFF
--- a/libs/libv4l/Makefile
+++ b/libs/libv4l/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v4l-utils
-PKG_VERSION:=1.6.2
+PKG_VERSION:=1.6.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.linuxtv.org/downloads/v4l-utils
-PKG_MD5SUM:=9cb3c178f937954e65bf30920af433ef
+PKG_MD5SUM:=307858616be6374f63bf946307f15a7f
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
@@ -22,6 +22,7 @@ PKG_LICENSE:=GPL-2.0 LGPL-2.1
 PKG_LICENSE_FILES:=COPYING COPYING.libv4l
 
 PKG_USE_MIPS16:=0
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
 PKG_BUILD_DEPENDS:=argp-standalone

--- a/libs/libv4l/patches/005-test_for_posix_ioctl.patch
+++ b/libs/libv4l/patches/005-test_for_posix_ioctl.patch
@@ -1,0 +1,23 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -80,6 +80,20 @@ gl_VISIBILITY
+ AC_CHECK_HEADERS([sys/klog.h])
+ AC_CHECK_FUNCS([klogctl])
+ 
++AC_CACHE_CHECK([for ioctl with POSIX signature],
++  [gl_cv_func_ioctl_posix_signature],
++  [AC_COMPILE_IFELSE(
++     [AC_LANG_PROGRAM(
++        [[#include <sys/ioctl.h>]],
++        [[int ioctl (int, int, ...);]])
++     ],
++     [gl_cv_func_ioctl_posix_signature=yes],
++     [gl_cv_func_ioctl_posix_signature=no])
++  ])
++if test "x$gl_cv_func_ioctl_posix_signature" = xyes; then
++  AC_DEFINE([HAVE_POSIX_IOCTL], [1], [Have ioctl with POSIX signature])
++fi
++
+ # Check host os
+ case "$host_os" in
+   linux*)

--- a/libs/libv4l/patches/020-add-missing-includes.patch
+++ b/libs/libv4l/patches/020-add-missing-includes.patch
@@ -8,3 +8,21 @@
  #include <fcntl.h>
  #include <errno.h>
  #include <sys/ioctl.h>
+@@ -36,6 +37,7 @@
+ #include <dirent.h>
+ #include <config.h>
+ #include <signal.h>
++#include <time.h>
+ 
+ #include <linux/videodev2.h>
+ #include <libv4l2.h>
+--- a/utils/v4l2-ctl/v4l2-ctl-streaming.cpp
++++ b/utils/v4l2-ctl/v4l2-ctl-streaming.cpp
+@@ -14,6 +14,7 @@
+ #include <sys/mman.h>
+ #include <dirent.h>
+ #include <math.h>
++#include <time.h>
+ 
+ #include "v4l2-ctl.h"
+ 

--- a/libs/libv4l/patches/030-musl_compatibility.patch
+++ b/libs/libv4l/patches/030-musl_compatibility.patch
@@ -1,0 +1,92 @@
+--- a/lib/libv4lconvert/libv4lsyscall-priv.h
++++ b/lib/libv4lconvert/libv4lsyscall-priv.h
+@@ -35,14 +35,19 @@
+    which is broken on some systems and doesn't include them itself :( */
+ 
+ #ifdef linux
++#define __NEED_off_t
+ #include <sys/time.h>
+ #include <syscall.h>
+ #include <linux/types.h>
+ #include <linux/ioctl.h>
+ /* On 32 bits archs we always use mmap2, on 64 bits archs there is no mmap2 */
+ #ifdef __NR_mmap2
++#undef SYS_mmap2
+ #define	SYS_mmap2 __NR_mmap2
+ #define	MMAP2_PAGE_SHIFT 12
++#if !(defined(__UCLIBC__) || defined(__GLIBC__))
++typedef off_t __off_t;
++#endif
+ #else
+ #define	SYS_mmap2 SYS_mmap
+ #define	MMAP2_PAGE_SHIFT 0
+--- a/lib/libv4l1/v4l1compat.c
++++ b/lib/libv4l1/v4l1compat.c
+@@ -62,7 +62,7 @@ LIBV4L_PUBLIC int open(const char *file,
+ 	return fd;
+ }
+ 
+-#ifdef linux
++#if defined(linux) && (defined(__GLIBC__) || defined(__UCLIBC__))
+ LIBV4L_PUBLIC int open64(const char *file, int oflag, ...)
+ {
+ 	int fd;
+@@ -94,7 +94,11 @@ LIBV4L_PUBLIC int dup(int fd)
+ 	return v4l1_dup(fd);
+ }
+ 
++#ifdef HAVE_POSIX_IOCTL
++LIBV4L_PUBLIC int ioctl(int fd, int request, ...)
++#else
+ LIBV4L_PUBLIC int ioctl(int fd, unsigned long int request, ...)
++#endif
+ {
+ 	void *arg;
+ 	va_list ap;
+@@ -112,12 +116,12 @@ LIBV4L_PUBLIC ssize_t read(int fd, void
+ }
+ 
+ LIBV4L_PUBLIC void *mmap(void *start, size_t length, int prot, int flags, int fd,
+-		__off_t offset)
++		off_t offset)
+ {
+ 	return v4l1_mmap(start, length, prot, flags, fd, offset);
+ }
+ 
+-#ifdef linux
++#if defined(linux) && (defined(__GLIBC__) || defined(__UCLIBC__))
+ LIBV4L_PUBLIC void *mmap64(void *start, size_t length, int prot, int flags, int fd,
+ 		__off64_t offset)
+ {
+--- a/lib/libv4l2/v4l2convert.c
++++ b/lib/libv4l2/v4l2convert.c
+@@ -86,7 +86,7 @@ LIBV4L_PUBLIC int open(const char *file,
+ 	return fd;
+ }
+ 
+-#ifdef linux
++#if defined(linux) && (defined(__GLIBC__) || defined(__UCLIBC__))
+ LIBV4L_PUBLIC int open64(const char *file, int oflag, ...)
+ {
+ 	int fd;
+@@ -121,7 +121,11 @@ LIBV4L_PUBLIC int dup(int fd)
+ 	return v4l2_dup(fd);
+ }
+ 
++#ifdef HAVE_POSIX_IOCTL
++LIBV4L_PUBLIC int ioctl(int fd, int request, ...)
++#else
+ LIBV4L_PUBLIC int ioctl(int fd, unsigned long int request, ...)
++#endif
+ {
+ 	void *arg;
+ 	va_list ap;
+@@ -144,7 +148,7 @@ LIBV4L_PUBLIC void *mmap(void *start, si
+ 	return v4l2_mmap(start, length, prot, flags, fd, offset);
+ }
+ 
+-#ifdef linux
++#if defined(linux) && (defined(__GLIBC__) || defined(__UCLIBC__))
+ LIBV4L_PUBLIC void *mmap64(void *start, size_t length, int prot, int flags, int fd,
+ 		__off64_t offset)
+ {


### PR DESCRIPTION
Most of this is in the upstream repo but not release yet.

Signed-off-by: Ted Hess <thess@kitschensync.net>