### PR TITLE
vpnc: fix musl compatibility

### DIFF
--- a/net/vpnc/Makefile
+++ b/net/vpnc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=vpnc
 PKG_REV:=550
 PKG_VERSION:=0.5.3.r$(PKG_REV)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://svn.unix-ag.uni-kl.de/vpnc/trunk/

--- a/net/vpnc/patches/001-cross.patch
+++ b/net/vpnc/patches/001-cross.patch
@@ -1,7 +1,7 @@
 --- a/Makefile
 +++ b/Makefile
 @@ -20,7 +20,7 @@
- # $Id$
+ # $Id: Makefile 539 2013-12-04 13:41:04Z Antonio Borneo $
  
  DESTDIR=
 -PREFIX=/usr/local
@@ -9,7 +9,7 @@
  ETCDIR=/etc/vpnc
  BINDIR=$(PREFIX)/bin
  SBINDIR=$(PREFIX)/sbin
-@@ -57,18 +57,15 @@
+@@ -57,18 +57,15 @@ OBJS = $(addsuffix .o,$(basename $(SRCS)
  CRYPTO_OBJS = $(addsuffix .o,$(basename $(CRYPTO_SRCS)))
  BINOBJS = $(addsuffix .o,$(BINS))
  BINSRCS = $(addsuffix .c,$(BINS))
@@ -31,7 +31,7 @@
  LIBS += -lnsl -lresolv -lsocket
  endif
  ifneq (,$(findstring Apple,$(shell $(CC) --version)))
-@@ -82,7 +79,7 @@
+@@ -82,7 +79,7 @@ vpnc : $(OBJS) vpnc.o
  	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
  
  vpnc.8 : vpnc.8.template makeman.pl vpnc

--- a/net/vpnc/patches/100-musl-compat.patch
+++ b/net/vpnc/patches/100-musl-compat.patch
@@ -1,0 +1,42 @@
+--- a/sysdep.h
++++ b/sysdep.h
+@@ -37,12 +37,14 @@ int tun_read(int fd, unsigned char *buf,
+ int tun_get_hwaddr(int fd, char *dev, uint8_t *hwaddr);
+ 
+ /***************************************************************************/
+-#if defined(__linux__) || defined(__GLIBC__)
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+ #include <error.h>
++#define HAVE_ERROR     1
++#endif
+ 
++#if defined(__linux__) || defined(__GLIBC__)
+ #define HAVE_VASPRINTF 1
+ #define HAVE_ASPRINTF  1
+-#define HAVE_ERROR     1
+ #define HAVE_UNSETENV  1
+ #define HAVE_SETENV    1
+ #endif
+--- a/sysdep.c
++++ b/sysdep.c
+@@ -59,7 +59,9 @@
+ #if defined(__DragonFly__)
+ #include <net/tun/if_tun.h>
+ #elif defined(__linux__)
+-#include <linux/if_tun.h>
++# if defined(__GLIBC__) || defined(__UCLIBC__)
++#  include <linux/if_tun.h>
++# endif
+ #elif defined(__APPLE__)
+ /* no header for tun */
+ #elif defined(__CYGWIN__)
+--- a/config.c
++++ b/config.c
+@@ -28,6 +28,7 @@
+ #include <unistd.h>
+ #include <string.h>
+ #include <errno.h>
++#include <sys/ttydefaults.h>
+ #include <sys/types.h>
+ #include <sys/utsname.h>
+ #include <sys/wait.h>


### PR DESCRIPTION
 - Add missing `sys/ttydefaults.h` include to `config.c`
 - Restrict usage of `error.h` to glibc and uclibc only
 - Avoid including `linux/if_tun.h` on non-glibc/uclibc to prevent
   musl kernel/libc header conflicts

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>