### PR TITLE
ulogd: fix musl compatibility

### DIFF
--- a/net/ulogd/Makefile
+++ b/net/ulogd/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ulogd
 PKG_VERSION:=2.0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=ftp://ftp.netfilter.org/pub/ulogd/ \
@@ -123,6 +123,9 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_ulogd-mod-mysql \
 	CONFIG_PACKAGE_ulogd-mod-pgsql \
 	CONFIG_PACKAGE_ulogd-mod-sqlite \
+
+TARGET_CFLAGS += \
+	-D_GNU_SOURCE \
 
 CONFIGURE_ARGS += \
 	--enable-nfacct \

--- a/net/ulogd/patches/100-musl-compat.patch
+++ b/net/ulogd/patches/100-musl-compat.patch
@@ -1,0 +1,57 @@
+--- a/src/ulogd.c
++++ b/src/ulogd.c
+@@ -83,7 +83,7 @@ static char *ulogd_logfile = NULL;
+ static const char *ulogd_configfile = ULOGD_CONFIGFILE;
+ static const char *ulogd_pidfile = NULL;
+ static int ulogd_pidfile_fd = -1;
+-static FILE syslog_dummy;
++static int ulogd_use_syslog = 0;
+ 
+ static int info_mode = 0;
+ 
+@@ -427,7 +427,7 @@ void __ulogd_log(int level, char *file,
+ 	if (level < loglevel_ce.u.value)
+ 		return;
+ 
+-	if (logfile == &syslog_dummy) {
++	if (ulogd_use_syslog) {
+ 		/* FIXME: this omits the 'file' string */
+ 		va_start(ap, format);
+ 		vsyslog(ulogd2syslog_level(level), format, ap);
+@@ -950,7 +950,7 @@ static int logfile_open(const char *name
+ 		logfile = stdout;
+ 	} else if (!strcmp(name, "syslog")) {
+ 		openlog("ulogd", LOG_PID, LOG_DAEMON);
+-		logfile = &syslog_dummy;
++		ulogd_use_syslog = 1;
+ 	} else {
+ 		logfile = fopen(ulogd_logfile, "a");
+ 		if (!logfile) {
+@@ -1240,7 +1240,7 @@ static void sigterm_handler(int signal)
+ 	unload_plugins();
+ #endif
+ 
+-	if (logfile != NULL  && logfile != stdout && logfile != &syslog_dummy) {
++	if (logfile != NULL  && logfile != stdout) {
+ 		fclose(logfile);
+ 		logfile = NULL;
+ 	}
+@@ -1262,7 +1262,7 @@ static void signal_handler(int signal)
+ 	switch (signal) {
+ 	case SIGHUP:
+ 		/* reopen logfile */
+-		if (logfile != stdout && logfile != &syslog_dummy) {
++		if (logfile != NULL && logfile != stdout) {
+ 			fclose(logfile);
+ 			logfile = fopen(ulogd_logfile, "a");
+  			if (!logfile) {
+--- a/filter/raw2packet/ulogd_raw2packet_BASE.c
++++ b/filter/raw2packet/ulogd_raw2packet_BASE.c
+@@ -42,6 +42,7 @@
+ #include <ulogd/ulogd.h>
+ #include <ulogd/ipfix_protocol.h>
+ #include <netinet/if_ether.h>
++#include <linux/types.h>
+ #include <string.h>
+ 
+ enum input_keys {


### PR DESCRIPTION
 - Avoid non-pointer use of `FILE` type since its just a forward declaration
 - Build with -D_GNU_SOURCE to expose required `struct tcphdr` members

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>