### PR TITLE
tinc: fix musl compatibility

### DIFF
--- a/net/tinc/Makefile
+++ b/net/tinc/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2014 OpenWrt.org
+# Copyright (C) 2007-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinc
 PKG_VERSION:=1.0.25
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.tinc-vpn.org/packages

--- a/net/tinc/patches/100-musl-compat.patch
+++ b/net/tinc/patches/100-musl-compat.patch
@@ -1,0 +1,11 @@
+--- a/src/have.h
++++ b/src/have.h
+@@ -196,4 +196,8 @@
+ #include <netinet/if_ether.h>
+ #endif
+ 
++#ifdef HAVE_LINUX_IF_TUN_H
++#include <linux/if_tun.h>
++#endif
++
+ #endif /* __TINC_SYSTEM_H__ */


### PR DESCRIPTION
Let configure include `sys/if_tun.h` when testing for `netinet/if_ether.h`
to detect the Kernel/libc header conflict on musl.

After this patch, configure will correctly detect `netinet/if_ether.h` as
unusable and the subsequent compilation will not attempt to use it.

Fixes the following compatibility error:

	In file included from .../staging_dir/toolchain-mips_mips32_gcc-4.8-linaro_musl-1.1.9/include/linux/if_tun.h:20:0,
	                 from linux/device.c:24:
	.../staging_dir/toolchain-mips_mips32_gcc-4.8-linaro_musl-1.1.9/include/linux/if_ether.h:137:8: error: redefinition of 'struct ethhdr'
	 struct ethhdr {
	        ^
	In file included from .../staging_dir/toolchain-mips_mips32_gcc-4.8-linaro_musl-1.1.9/include/net/ethernet.h:10:0,
	                 from linux/../have.h:180,
	                 from linux/../system.h:26,
	                 from linux/device.c:21:
	.../staging_dir/toolchain-mips_mips32_gcc-4.8-linaro_musl-1.1.9/include/netinet/if_ether.h:96:8: note: originally defined here
	 struct ethhdr {
	        ^
	make[5]: *** [linux/device.o] Error 1

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>