### PR TITLE
tgt: fix musl compatibility

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012-2014 OpenWrt.org
+# Copyright (C) 2012-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=tgt
 PKG_VERSION:=1.0.53
 PKG_REV:=9764e0afd9a7115e356fc85569a780f9003c4eac
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE_PROTO:=git

--- a/net/tgt/patches/100-musl-compat.patch
+++ b/net/tgt/patches/100-musl-compat.patch
@@ -1,0 +1,36 @@
+--- a/usr/tgtd.h
++++ b/usr/tgtd.h
+@@ -9,6 +9,10 @@
+ #include <systemd/sd-daemon.h>
+ #endif
+ 
++#ifndef __WORDSIZE
++#include <sys/user.h>
++#endif
++
+ struct concat_buf;
+ 
+ #define NR_SCSI_OPCODES		256
+--- a/usr/util.h
++++ b/usr/util.h
+@@ -16,6 +16,10 @@
+ #include <limits.h>
+ #include <linux/types.h>
+ 
++#ifndef __WORDSIZE
++#include <sys/user.h>
++#endif
++
+ #include "be_byteshift.h"
+ 
+ #define roundup(x, y) ((((x) + ((y) - 1)) / (y)) * (y))
+--- a/usr/libssc.c
++++ b/usr/libssc.c
+@@ -23,6 +23,7 @@
+ #include <string.h>
+ #include <unistd.h>
+ #include <stdio.h>
++#include <fcntl.h>
+ #include "bs_ssc.h"
+ #include "ssc.h"
+ #include "be_byteshift.h"


### PR DESCRIPTION
 - Include `sys/user.h` if `__WORDSIZE` is undefined
 - Add `fcntl.h` to `libscc.c` in order to declare `loff_t`

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>