### PR TITLE
tcsh: fix musl compatibility

### DIFF
--- a/utils/tcsh/Makefile
+++ b/utils/tcsh/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2014 OpenWrt.org
+# Copyright (C) 2011-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcsh
 PKG_VERSION:=6.19.00
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/

--- a/utils/tcsh/patches/100-musl-compat.patch
+++ b/utils/tcsh/patches/100-musl-compat.patch
@@ -1,0 +1,11 @@
+--- a/sh.proc.c
++++ b/sh.proc.c
+@@ -48,7 +48,7 @@ RCSID("$tcsh: sh.proc.c,v 3.127 2015/02/
+ #endif /* aiws */
+ 
+ #if defined(_BSD) || (defined(IRIS4D) && __STDC__) || defined(__lucid) || defined(__linux__) || defined(__GNU__) || defined(__GLIBC__)
+-# if !defined(__ANDROID__)
++# if !(defined(__ANDROID__) || (defined(__linux__) && !defined(__GLIBC__)))
+ #  define BSDWAIT
+ # endif
+ #endif /* _BSD || (IRIS4D && __STDC__) || __lucid || glibc */


### PR DESCRIPTION
Avoid using `union wait` under musl as it does not provide this definition.
Implement solution suggested by http://www.openwall.com/lists/musl/2013/06/21/4

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>