### PR TITLE
sysstat: fix musl compatibility

### DIFF
--- a/utils/sysstat/Makefile
+++ b/utils/sysstat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sysstat
 PKG_VERSION:=11.0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>

--- a/utils/sysstat/patches/100-musl-compat.patch
+++ b/utils/sysstat/patches/100-musl-compat.patch
@@ -1,0 +1,30 @@
+--- a/sa_common.c
++++ b/sa_common.c
+@@ -28,6 +28,7 @@
+ #include <dirent.h>
+ #include <fcntl.h>
+ #include <libgen.h>
++#include <limits.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ 
+--- a/common.c
++++ b/common.c
+@@ -30,6 +30,7 @@
+ #include <dirent.h>
+ #include <ctype.h>
+ #include <libgen.h>
++#include <limits.h>
+ 
+ #include "version.h"
+ #include "common.h"
+--- a/ioconf.c
++++ b/ioconf.c
+@@ -27,6 +27,7 @@
+ #include <errno.h>
+ #include <dirent.h>
+ #include <sys/stat.h>
++#include <sys/types.h>
+ 
+ #include "ioconf.h"
+ #include "common.h"


### PR DESCRIPTION
Add missing `limits.h` and `sys/types.h` includes to the appropriate
source files.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>