### PR TITLE
Draft a system to automatically test package compile with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+
+install:
+    - sudo apt-get update
+    - sudo apt-get install git-core build-essential libssl-dev libncurses5-dev unzip subversion
+
+before_script:
+    - wget https://raw.githubusercontent.com/claudyus/owrt-package-test/master/owrt-pkgtest
+    - sudo mv owrt-pkgtest /usr/local/bin
+    - sudo chmod a+x /usr/local/bin/owrt-pkgtest
+
+script:
+    - export PACKAGE_TEST=`git show HEAD | grep "+++ b" | grep Makefile | cut -d / -f 3 | uniq | head -n 1` #bad
+    - owrt-pkgtest $PACKAGE_TEST  # move this part in a script?


### PR DESCRIPTION
This feature will improve the total quality of the project and will help
contributors and maintainers with the tests also on the provided pull-requests.

You can see the result of this work on the travis-test branch, on my repo fork, where I revert a commit just to trigger the travis build. The compile results are available here:
https://travis-ci.org/claudyus/packages/builds/67392198
