### PR TITLE
sslh: fix musl compatibility

### DIFF
--- a/net/sslh/Makefile
+++ b/net/sslh/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2014 OpenWrt.org
+# Copyright (C) 2009-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sslh
 PKG_VERSION:=v1.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://rutschle.net/tech/

--- a/net/sslh/patches/100-musl-compat.patch
+++ b/net/sslh/patches/100-musl-compat.patch
@@ -1,0 +1,12 @@
+--- a/probe.c
++++ b/probe.c
+@@ -25,6 +25,9 @@
+ #include <ctype.h>
+ #include "probe.h"
+ 
++#ifndef REG_STARTEND
++#define REG_STARTEND 0
++#endif
+ 
+ 
+ static int is_ssh_protocol(const char *p, int len, struct proto*);


### PR DESCRIPTION
Musl libc does not provide the `REG_STARTEND` regex flag, so declare it as `0`
in case it is not defined.

This will break regex probes against buffer data containing embedded NULL bytes,
but regex operations on such binary data are simply not supported by musl.

Other standard protocol matches are unaffected.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>