### PR TITLE
openvswitch: a bit of cleanup + fix musl compatibility

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -24,13 +24,15 @@ PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=58be9c9fd732b5bdd3d4c2e9b8cc2313f570094d
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
 
+PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
 SUPPORTED_KERNELS:=LINUX_3_8||LINUX_3_10||LINUX_3_13||LINUX_3_14||LINUX_3_18||LINUX_4_0
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/kernel.mk
 $(call include_mk, python-package.mk)
-
-PKG_FIXUP=libtool
 
 define Package/openvswitch/Default
   SECTION:=net
@@ -112,35 +114,7 @@ CONFIGURE_ARGS += --enable-ndebug
 CONFIGURE_ARGS += --disable-ssl
 CONFIGURE_ARGS += --enable-shared
 
-TARGET_CFLAGS += -flto
-
-define Build/Configure
-	(cd $(PKG_BUILD_DIR); \
-		autoreconf -v --install --force || exit 1 \
-	);
-	$(call Build/Configure/Default,$(CONFIGURE_ARGS))
-endef
-
-KCFLAGS=
-ifeq ($(CONFIG_GCC_VERSION_4_9),y)
-KCFLAGS:=-Wno-error=date-time
-endif
-
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		$(TARGET_CONFIGURE_OPTS) \
-		CFLAGS="-I$(PKG_BUILD_DIR)/lib $(TARGET_CFLAGS) -std=gnu99" \
-		LDFLAGS="-L$(PKG_BUILD_DIR)/lib $(TARGET_LDFLAGS)" \
-		LDFLAGS_MODULES="$(TARGET_LDFLAGS) -L$(PKG_BUILD_DIR)/lib" \
-		STAGING_DIR="$(STAGING_DIR)" \
-		DESTDIR="$(PKG_INSTALL_DIR)/usr" \
-		CROSS_COMPILE="$(TARGET_CROSS)" \
-		ARCH="$(LINUX_KARCH)" \
-		SUBDIRS="$(PKG_BUILD_DIR)/datapath/linux" \
-		PATH="$(TARGET_PATH)" \
-		EXTRA_CFLAGS="$(KCFLAGS)" \
-		KCC="$(KERNEL_CC)"
-endef
+TARGET_CFLAGS += -flto -std=gnu99
 
 define Package/openvswitch/install
 	$(INSTALL_DIR) $(1)/etc/openvswitch

--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openvswitch
 
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_VERSION:=2.3.90
 PKG_RELEASE=$(PKG_SOURCE_VERSION)
 PKG_LICENSE:=Apache-2.0
@@ -54,7 +54,7 @@ endef
 define Package/openvswitch
   $(call Package/openvswitch/Default)
   TITLE:=Open vSwitch Userspace Package
-  DEPENDS:=+libpcap +libopenssl +librt +libatomic +kmod-openvswitch @($(SUPPORTED_KERNELS))
+  DEPENDS:=+libpcap +libopenssl +librt +kmod-openvswitch @($(SUPPORTED_KERNELS))
 endef
 
 define Package/openvswitch/description

--- a/net/openvswitch/patches/0004-musl-compatibility.patch
+++ b/net/openvswitch/patches/0004-musl-compatibility.patch
@@ -1,0 +1,39 @@
+diff --git a/configure.ac b/configure.ac
+index 8d47eb9..69eeed8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -117,7 +117,6 @@ OVS_CHECK_XENSERVER_VERSION
+ OVS_CHECK_GROFF
+ OVS_CHECK_GNU_MAKE
+ OVS_CHECK_TLS
+-OVS_CHECK_ATOMIC_LIBS
+ OVS_CHECK_GCC4_ATOMICS
+ OVS_CHECK_ATOMIC_ALWAYS_LOCK_FREE(1)
+ OVS_CHECK_ATOMIC_ALWAYS_LOCK_FREE(2)
+diff --git a/lib/netdev-linux.c b/lib/netdev-linux.c
+index 9b2e74f..70126bb 100644
+--- a/lib/netdev-linux.c
++++ b/lib/netdev-linux.c
+@@ -40,7 +40,9 @@
+ #include <netpacket/packet.h>
+ #include <net/if.h>
+ #include <net/if_arp.h>
++#if defined(__UCLIBC__) || defined(__GLIBC__)
+ #include <net/if_packet.h>
++#endif
+ #include <net/route.h>
+ #include <netinet/in.h>
+ #include <poll.h>
+diff --git a/lib/ovs-atomic.h b/lib/ovs-atomic.h
+index 9ead907..86d3341 100644
+--- a/lib/ovs-atomic.h
++++ b/lib/ovs-atomic.h
+@@ -325,8 +325,6 @@
+         #include "ovs-atomic-clang.h"
+     #elif HAVE_STDATOMIC_H
+         #include "ovs-atomic-c11.h"
+-    #elif __GNUC__ >= 4 && __GNUC_MINOR__ >= 7
+-        #include "ovs-atomic-gcc4.7+.h"
+     #elif __GNUC__ && defined(__x86_64__)
+         #include "ovs-atomic-x86_64.h"
+     #elif __GNUC__ && defined(__i386__)


### PR DESCRIPTION
Cleanup: remove explicit build rules in favor of the default ones/
For the musl compatibility:
- conditionally compile out <net/if_packet.h> for musl ; this helps build the package, but won't run yet
- remove libatomic support ; seems that musl's libatomic is not complete; some functions do not exist and only cause a fail when running on a target.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>