### PR TITLE
alsa-lib: disable TLS for musl compatibility

### DIFF
--- a/libs/alsa-lib/Makefile
+++ b/libs/alsa-lib/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alsa-lib
 PKG_VERSION:=1.0.28
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=ftp://ftp.alsa-project.org/pub/lib/ \

--- a/libs/alsa-lib/patches/003-Remove_TLS_for_musl.patch
+++ b/libs/alsa-lib/patches/003-Remove_TLS_for_musl.patch
@@ -1,0 +1,11 @@
+--- a/src/error.c
++++ b/src/error.c
+@@ -61,7 +61,7 @@ const char *snd_strerror(int errnum)
+ }
+ 
+ #ifndef DOC_HIDDEN
+-#ifdef HAVE___THREAD
++#if defined(HAVE___THREAD) && (defined(__GLIBC__) || defined(__UCLIBC__))
+ #define TLS_PFX		__thread
+ #else
+ #define TLS_PFX		/* NOP */


### PR DESCRIPTION
Temporary work-around until MUSL TLS issue resolved.

alsa-lib has a static TLS declaration w/initializer. Any attempt to reference the variable causes a segfault. Does anybody have any insight about this problem and what in MUSL (or GCC) needs to be fixed.

Signed-off-by: Ted Hess <thess@kitschensync.net>