### PR TITLE
macchanger: fix build with musl

### DIFF
--- a/utils/macchanger/Makefile
+++ b/utils/macchanger/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=macchanger
 PKG_VERSION:=1.7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/alobbs/macchanger/releases/download/$(PKG_VERSION)/

--- a/utils/macchanger/patches/0001-fix-build-with-musl.patch
+++ b/utils/macchanger/patches/0001-fix-build-with-musl.patch
@@ -1,0 +1,13 @@
+Index: macchanger-1.7.0/src/netinfo.c
+===================================================================
+--- macchanger-1.7.0.orig/src/netinfo.c
++++ macchanger-1.7.0/src/netinfo.c
+@@ -113,7 +113,7 @@ mc_net_info_get_permanent_mac (const net
+ 	epa->size = IFHWADDRLEN;
+ 
+ 	memcpy(&req, &(net->dev), sizeof(struct ifreq));
+-	req.ifr_data = (caddr_t)epa;
++	req.ifr_data = (char *)epa;
+ 
+ 	if (ioctl(net->sock, SIOCETHTOOL, &req) < 0) {
+ 		perror ("[ERROR] Could not read permanent MAC");


### PR DESCRIPTION
According to netdevice(7) ifr_data is a "char *", not caddr_t.

Signed-off-by: Paul Fertser <fercerpav@gmail.com>