### PR TITLE
Add cups & radvd from old packages and fix compile error.

### DIFF
--- a/ipv6/radvd/Makefile
+++ b/ipv6/radvd/Makefile
@@ -1,0 +1,81 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=radvd
+PKG_VERSION:=1.15
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://v6web.litech.org/radvd/dist \
+		http://download.sourcemage.org/mirror
+PKG_MD5SUM:=97cd606000b8dd929b5f5449d5e7cea2
+PKG_MAINTAINER:=QshenX <q@xd8.cn>
+PKG_LICENSE:=GPL-2.0
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/radvd/Default
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=IPv6 Routing Advertisement
+  URL:=http://v6web.litech.org/radvd/
+  DEPENDS:=+kmod-ipv6 +libdaemon
+endef
+
+define Package/radvd
+  $(call Package/radvd/Default)
+  TITLE+= Daemon
+endef
+
+define Package/radvd/description
+radvd is the router advertisement daemon for IPv6. It listens to router
+solicitations and sends router advertisements as described in "Neighbor
+Discovery for IP Version 6 (IPv6)" (RFC 4861).  With these advertisements hosts
+can automatically configure their addresses and some other parameters. They also
+can choose a default router based on these advertisements.
+endef
+
+define Package/radvdump
+  $(call Package/radvd/Default)
+  TITLE+= Dumper
+endef
+
+define Package/radvdump/description
+radvdump prints out the contents of incoming router advertisements sent by radvd
+or some other software implementing (parts of) "Neighbor Discovery for IP
+Version 6 (IPv6)" (RFC 4861).
+endef
+
+CONFIGURE_ARGS += \
+	--with-configfile=/etc/radvd.conf \
+	--with-logfile=/var/log/radvd.log \
+	--with-pidfile=/var/run/radvd.pid
+
+define Package/radvd/conffiles
+/etc/config/radvd
+endef
+
+define Package/radvd/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/radvd.config $(1)/etc/config/radvd
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/radvd.init $(1)/etc/init.d/radvd
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/radvd $(1)/usr/sbin/
+endef
+
+define Package/radvdump/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/radvdump $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,radvd))
+$(eval $(call BuildPackage,radvdump))

--- a/ipv6/radvd/files/radvd.config
+++ b/ipv6/radvd/files/radvd.config
@@ -1,0 +1,32 @@
+config interface
+	option interface	'lan'
+	option AdvSendAdvert	1
+	option AdvManagedFlag	0
+	option AdvOtherConfigFlag 0
+	list client		''
+	option ignore		1
+
+config prefix
+	option interface	'lan'
+	# If not specified, a non-link-local prefix of the interface is used
+	list prefix		''
+	option AdvOnLink	1
+	option AdvAutonomous	1
+	option AdvRouterAddr	0
+	option ignore		1
+
+config route
+	option interface	'lan'
+	list prefix		''
+	option ignore		1
+
+config rdnss
+	option interface	'lan'
+	# If not specified, the link-local address of the interface is used
+	list addr		''
+	option ignore		1
+
+config dnssl
+	option interface	'lan'
+	list suffix		''
+	option ignore		1

--- a/ipv6/radvd/files/radvd.init
+++ b/ipv6/radvd/files/radvd.init
@@ -1,0 +1,416 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2008-2011 OpenWrt.org
+# Copyright (C) 2008  Alina Friedrichsen <x-alina@gmx.net>
+
+START=50
+
+SERVICE_USE_PID=1
+
+RADVD_INTERFACE_STRING_OPTIONS='MaxRtrAdvInterval MinRtrAdvInterval MinDelayBetweenRAs AdvLinkMTU AdvReachableTime AdvRetransTimer AdvCurHopLimit AdvDefaultLifetime AdvDefaultPreference HomeAgentLifetime HomeAgentPreference'
+RADVD_INTERFACE_BOOLEAN_OPTIONS='IgnoreIfMissing AdvSendAdvert UnicastOnly AdvManagedFlag AdvOtherConfigFlag AdvSourceLLAddress AdvHomeAgentFlag AdvHomeAgentInfo AdvMobRtrSupportFlag AdvIntervalOpt'
+
+RADVD_PREFIX_STRING_OPTIONS='AdvValidLifetime AdvPreferredLifetime'
+RADVD_PREFIX_BOOLEAN_OPTIONS='AdvOnLink AdvAutonomous AdvRouterAddr DeprecatePrefix DecrementLifetimes'
+
+RADVD_ROUTE_STRING_OPTIONS='AdvRouteLifetime AdvRoutePreference'
+RADVD_ROUTE_BOOLEAN_OPTIONS='RemoveRoute'
+
+RADVD_RDNSS_STRING_OPTIONS='AdvRDNSSLifetime FlushRDNSS'
+
+RADVD_DNSSL_STRING_OPTIONS='AdvDNSSLLifetime FlushDNSSL'
+
+validate_varname() {
+	local varname=$1
+	[ -z "$varname" -o "$varname" != "${varname%%[!A-Za-z0-9_]*}" ] && return 1
+	return 0
+}
+
+validate_ip6addr() {
+	local ip6addr=$1
+	[ -z "$ip6addr" -o "$ip6addr" != "${ip6addr%%[!A-Fa-f0-9.:]*}" ] && return 1
+	return 0
+}
+
+validate_ip6prefix() {
+	local ip6prefix=$1
+	[ -z "$ip6prefix" -o "$ip6prefix" != "${ip6prefix%%[!A-Fa-f0-9./:]*}" ] && return 1
+	return 0
+}
+
+validate_radvd_string() {
+	local radvd_string=$1
+	[ -z "$radvd_string" -o "$radvd_string" != "${radvd_string%%[!A-Za-z0-9.:_-]*}" ] && return 1
+	return 0
+}
+
+get_ip6addr() {
+	local ifname=$1
+	local scope=$2
+	local iproute2_scope
+	local ifconfig_scope
+	local ip6addr
+
+	case "$scope" in
+		host) iproute2_scope=host ifconfig_scope=Host;;
+		link) iproute2_scope=link ifconfig_scope=Link;;
+		site) iproute2_scope=site ifconfig_scope=Site;;
+		global) iproute2_scope=global ifconfig_scope=Global;;
+		"") get_ip6addr "$ifname" global || get_ip6addr "$ifname" site; return;;
+		*) return 1;;
+	esac
+
+	ip6addr=$(LANG=C ip -f inet6 -- addr show dev "$ifname" 2> /dev/null | sed -n -e 's/^  *inet6 \([A-Fa-f0-9.:]*[/][0-9]*\) scope '"$iproute2_scope"' $/\1/p' | head -n 1)
+	if [ -z "$ip6addr" ]; then
+		ip6addr=$(LANG=C ifconfig "$ifname" 2> /dev/null | sed -n -e 's/^  *inet6 addr: \([A-Fa-f0-9.:]*[/][0-9]*\) Scope:'"$ifconfig_scope"'$/\1/p' | tail -n 1)
+		[ -z "$ip6addr" ] && return 1
+	fi
+
+	printf '%s\n' "$ip6addr"
+
+	return 0
+}
+
+radvd_find_config_file() {
+	local cfg=$1
+	validate_varname "$cfg" || return 0
+
+	config_get_bool ignore "$cfg" ignore 0
+	[ "$ignore" -ne 0 ] && return 0
+	config_get RADVD_CONFIG_FILE "$cfg" config_file
+
+	return 0
+}
+
+radvd_add_interface() {
+	local cfg=$1
+	validate_varname "$cfg" || return 0
+	local ignore
+	local interfaces
+	local interface
+	local list_interface
+	local exist
+
+	config_get_bool ignore "$cfg" ignore 0
+	[ "$ignore" -ne 0 ] && return 0
+
+	config_get interfaces "$cfg" interface
+	for interface in $interfaces; do
+		validate_varname "$interface" || continue
+		exist=0
+		for list_interface in $RADVD_INTERFACES; do
+			[ "$interface" = "$list_interface" ] && exist=1
+		done
+		[ "$exist" -eq 0 ] && RADVD_INTERFACES="$RADVD_INTERFACES $interface"
+	done
+
+	return 0
+}
+
+radvd_write_interface() {
+	local cfg=$1
+	validate_varname "$cfg" || return 0
+	local ignore
+	local interfaces
+	local interface
+	local name
+	local value
+
+	config_get_bool ignore "$cfg" ignore 0
+	[ "$ignore" -ne 0 ] && return 0
+
+	config_get interfaces "$cfg" interface
+	exist=0
+	for interface in $interfaces; do
+		[ "$INTERFACE" = "$interface" ] && exist=1
+	done
+	[ "$exist" -eq 0 ] && return 0
+
+	for name in $RADVD_INTERFACE_STRING_OPTIONS; do
+		config_get value "$cfg" "$name"
+		validate_radvd_string "$value" || continue
+		printf '\t%s %s;\n' "$name" "$value"
+	done
+
+	for name in $RADVD_INTERFACE_BOOLEAN_OPTIONS; do
+		config_get value "$cfg" "$name"
+		[ -z "$value" ] && continue
+		config_get_bool value "$cfg" "$name" 0
+		if [ "$value" -ne 0 ]; then 
+			printf '\t%s on;\n' "$name"
+		else
+			printf '\t%s off;\n' "$name"
+		fi
+	done
+
+	config_get clients "$cfg" client
+	if [ -n "$clients" ]; then
+	        printf '\n\tclients\n\t{\n'
+
+	        for client in $clients; do
+        	        validate_ip6addr "$client" || continue
+                	printf '\t\t%s;\n' "$client"
+	        done
+
+	        printf '\t};\n'
+	fi
+
+	return 0
+}
+
+radvd_write_prefix() {
+	local cfg=$1
+	validate_varname "$cfg" || return 0
+	local ignore
+	local interfaces
+	local interface
+	local device
+	local prefixes
+	local prefix
+	local name
+	local value
+	local cfgt
+
+	config_get_bool ignore "$cfg" ignore 0
+	[ "$ignore" -ne 0 ] && return 0
+
+	config_get interfaces "$cfg" interface
+	exist=0
+	for interface in $interfaces; do
+		[ "$INTERFACE" = "$interface" ] && exist=1
+	done
+	[ "$exist" -eq 0 ] && return 0
+
+	config_get prefixes "$cfg" prefix
+	if [ -z "$prefixes" ]; then
+		prefixes=$(get_ip6addr "$IFNAME") || return 0
+	fi
+
+	for prefix in $prefixes; do
+		validate_ip6prefix "$prefix" || continue
+		printf '\n\tprefix %s\n\t{\n' "$prefix"
+
+		for name in $RADVD_PREFIX_STRING_OPTIONS; do
+			config_get value "$cfg" "$name"
+			validate_radvd_string "$value" || continue
+			printf '\t\t%s %s;\n' "$name" "$value"
+		done
+
+		for name in $RADVD_PREFIX_BOOLEAN_OPTIONS; do
+			config_get value "$cfg" "$name"
+			[ -z "$value" ] && continue
+			config_get_bool value "$cfg" "$name" 0
+			if [ "$value" -ne 0 ]; then 
+				printf '\t\t%s on;\n' "$name"
+			else
+				printf '\t\t%s off;\n' "$name"
+			fi
+		done
+
+		config_get value "$cfg" Base6Interface
+		if [ -n "$value" ]; then
+			if network_get_device device "$value"; then
+				printf '\t\t%s %s;\n' "Base6Interface" "$device"
+			fi
+		fi
+
+		config_get value "$cfg" Base6to4Interface
+		if [ -n "$value" ]; then
+			if network_get_device device "$value"; then
+				printf '\t\t%s %s;\n' "Base6to4Interface" "$device"
+			fi
+		fi
+
+		printf '\t};\n'
+	done
+
+	return 0
+}
+
+radvd_write_route() {
+	local cfg=$1
+	validate_varname "$cfg" || return 0
+	local ignore
+	local interfaces
+	local interface
+	local prefixes
+	local prefix
+	local name
+	local value
+
+	config_get_bool ignore "$cfg" ignore 0
+	[ "$ignore" -ne 0 ] && return 0
+
+	config_get interfaces "$cfg" interface
+	exist=0
+	for interface in $interfaces; do
+		[ "$INTERFACE" = "$interface" ] && exist=1
+	done
+	[ "$exist" -eq 0 ] && return 0
+
+	config_get prefixes "$cfg" prefix
+	for prefix in $prefixes; do
+		validate_ip6prefix "$prefix" || continue
+		printf '\n\troute %s\n\t{\n' "$prefix"
+
+		for name in $RADVD_ROUTE_STRING_OPTIONS; do
+			config_get value "$cfg" "$name"
+			validate_radvd_string "$value" || continue
+			printf '\t\t%s %s;\n' "$name" "$value"
+		done
+
+		for name in $RADVD_ROUTE_BOOLEAN_OPTIONS; do
+			config_get value "$cfg" "$name"
+			[ -z "$value" ] && continue
+			config_get_bool value "$cfg" "$name" 0
+			if [ "$value" -ne 0 ]; then 
+				printf '\t\t%s on;\n' "$name"
+			else
+				printf '\t\t%s off;\n' "$name"
+			fi
+		done
+
+		printf '\t};\n'
+	done
+
+	return 0
+}
+
+radvd_write_rdnss() {
+	local cfg=$1
+	validate_varname "$cfg" || return 0
+	local ignore
+	local interfaces
+	local interface
+	local addrs
+	local addr
+	local addr_list
+	local name
+	local value
+	local i
+
+	config_get_bool ignore "$cfg" ignore 0
+	[ "$ignore" -ne 0 ] && return 0
+
+	config_get interfaces "$cfg" interface
+	exist=0
+	for interface in $interfaces; do
+		[ "$INTERFACE" = "$interface" ] && exist=1
+	done
+	[ "$exist" -eq 0 ] && return 0
+
+	config_get addrs "$cfg" addr
+	i=0
+	for addr in $addrs; do
+		[ "$i" -ge 3 ] && break
+		validate_ip6addr "$addr" || continue
+		addr_list="$addr_list $addr"
+		i=$(($i+1))
+	done
+
+	if [ -z "$addr_list" ]; then
+		addr=$(get_ip6addr "$IFNAME" link) || return 0
+		addr_list=" ${addr%%[/]*}"
+	fi
+
+	printf '\n\tRDNSS%s\n\t{\n' "$addr_list"
+
+	for name in $RADVD_RDNSS_STRING_OPTIONS; do
+		config_get value "$cfg" "$name"
+		validate_radvd_string "$value" || continue
+		printf '\t\t%s %s;\n' "$name" "$value"
+	done
+
+	printf '\t};\n'
+
+	return 0
+}
+
+radvd_write_dnssl() {
+	local cfg=$1
+	validate_varname "$cfg" || return 0
+	local ignore
+	local interfaces
+	local interface
+	local suffixes
+	local suffix
+	local suffix_list
+	local name
+	local value
+
+	config_get_bool ignore "$cfg" ignore 0
+	[ "$ignore" -ne 0 ] && return 0
+
+	config_get interfaces "$cfg" interface
+	exist=0
+	for interface in $interfaces; do
+		[ "$INTERFACE" = "$interface" ] && exist=1
+	done
+	[ "$exist" -eq 0 ] && return 0
+
+	config_get suffixes "$cfg" suffix
+	for suffix in $suffixes; do
+		validate_radvd_string "$suffix" || continue
+		suffix_list="$suffix_list $suffix"
+	done
+
+	printf '\n\tDNSSL%s\n\t{\n' "$suffix_list"
+
+	for name in $RADVD_DNSSL_STRING_OPTIONS; do
+		config_get value "$cfg" "$name"
+		validate_radvd_string "$value" || continue
+		printf '\t\t%s %s;\n' "$name" "$value"
+	done
+
+	printf '\t};\n'
+
+	return 0
+}
+
+radvd_write_config() {
+	. /lib/functions/network.sh
+
+	RADVD_INTERFACES=
+	config_foreach radvd_add_interface interface
+	config_foreach radvd_add_interface prefix
+	config_foreach radvd_add_interface route
+	config_foreach radvd_add_interface RDNSS
+	config_foreach radvd_add_interface DNSSL
+
+	for INTERFACE in $RADVD_INTERFACES; do
+		network_get_device IFNAME "$INTERFACE" || continue
+		printf 'interface %s\n{\n' "$IFNAME"
+		config_foreach radvd_write_interface interface
+		config_foreach radvd_write_prefix prefix
+		config_foreach radvd_write_route route
+		config_foreach radvd_write_rdnss rdnss
+		config_foreach radvd_write_dnssl dnssl
+		printf '};\n\n'
+	done
+
+	return 0
+}
+
+start() {
+	config_load radvd
+
+	RADVD_CONFIG_FILE=
+	config_foreach radvd_find_config_file radvd
+
+	if [ -z "$RADVD_CONFIG_FILE" ]; then
+		mkdir -p -- /var/etc/
+		radvd_write_config > /var/etc/radvd.conf
+		if [ -s "/var/etc/radvd.conf" ]; then
+			RADVD_CONFIG_FILE=/var/etc/radvd.conf
+		fi
+	fi
+
+	[ -z "$RADVD_CONFIG_FILE" ] && return 1
+
+	sysctl -w net.ipv6.conf.all.forwarding=1 > /dev/null 2> /dev/null
+
+	service_start /usr/sbin/radvd -C "$RADVD_CONFIG_FILE" -m stderr_syslog -p /var/run/radvd.pid
+}
+
+stop() {
+	service_stop /usr/sbin/radvd
+}

--- a/ipv6/radvd/patches/100-silent-netlink-config-reload.patch
+++ b/ipv6/radvd/patches/100-silent-netlink-config-reload.patch
@@ -1,0 +1,67 @@
+--- a/netlink.c
++++ b/netlink.c
+@@ -75,7 +75,7 @@
+ 						dlog(LOG_DEBUG, 3, "%s, ifindex %d, flags is *NOT* running", ifname, ifinfo->ifi_index);
+ 					}
+ 					if (!reloaded) {
+-						reload_config();
++						reload_config(LOG_DEBUG);
+ 						reloaded = 1;
+ 					}
+ 				}
+--- a/radvd.c
++++ b/radvd.c
+@@ -439,7 +439,7 @@
+ 
+ 		if (sighup_received) {
+ 			dlog(LOG_INFO, 3, "sig hup received.\n");
+-			reload_config();
++			reload_config(LOG_INFO);
+ 			sighup_received = 0;
+ 		}
+ 
+@@ -541,11 +541,11 @@
+ 	}
+ }
+ 
+-void reload_config(void)
++void reload_config(int loglevel)
+ {
+ 	struct Interface *iface;
+ 
+-	flog(LOG_INFO, "attempting to reread config file");
++	flog(loglevel, "attempting to reread config file");
+ 
+ 	iface = IfaceList;
+ 	while (iface) {
+@@ -610,7 +610,7 @@
+ 	config_interface();
+ 	kickoff_adverts();
+ 
+-	flog(LOG_INFO, "resuming normal operation");
++	flog(loglevel, "resuming normal operation");
+ }
+ 
+ void sighup_handler(int sig)
+--- a/radvd.h
++++ b/radvd.h
+@@ -208,7 +208,7 @@
+ 
+ /* radvd.c */
+ int check_ip6_forwarding(void);
+-void reload_config(void);
++void reload_config(int);
+ void reset_prefix_lifetimes(void);
+ 
+ /* timer.c */
+--- a/send.c
++++ b/send.c
+@@ -137,7 +137,7 @@
+ 			 * reload_config() will kick off new timers anyway.  This avoids
+ 			 * timer list corruption.
+ 			 */
+-			reload_config();
++			reload_config(LOG_INFO);
+ 			return -1;
+ 		}
+ 	}

--- a/net/cups-bjnp/Makefile
+++ b/net/cups-bjnp/Makefile
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2010-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cups-bjnp
+PKG_VERSION:=1.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@SF/cups-bjnp
+PKG_MD5SUM:=8672b4585b71dee6dcefa00fbbbe7698
+PKG_MAINTAINER:=QshenX <q@xd8.cn>
+PKG_LICENSE:=GPL-2.0
+
+PKG_BUILD_DEPENDS:=cups
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/cups-bjnp
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Printing
+  TITLE:=BJNP protocol backend for CUPS
+  URL:=http://sourceforge.net/projects/cups-bjnp/
+  DEPENDS:=cups
+endef
+
+define Package/cups-bjnp/description
+CUPS backend for the canon printers using the proprietary USB over
+IP BJNP protocol. This backend allows Cups to print over the network
+to a Canon printer. It currently supports Cups 1.2 and Cups 1.3 and
+is designed by reverse engineering.
+endef
+
+CONFIGURE_ARGS += --with-cupsbackenddir=$(STAGING_DIR)/usr/include/cups
+
+TARGET_CFLAGS+=-Wl,-rpath-link=$(STAGING_DIR)/usr/lib
+
+define Package/cups-bjnp/install
+	$(INSTALL_DIR) $(1)/usr/lib/cups/backend
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bjnp $(1)/usr/lib/cups/backend
+endef
+
+
+$(eval $(call BuildPackage,cups-bjnp))

--- a/net/cups/Makefile
+++ b/net/cups/Makefile
@@ -1,0 +1,703 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cups
+PKG_VERSION:=1.5.4
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-source.tar.bz2
+PKG_SOURCE_URL:= http://www.cups.org/software/$(PKG_VERSION)
+PKG_MD5SUM:=de3006e5cf1ee78a9c6145ce62c4e982
+PKG_MAINTAINER:=QshenX <q@xd8.cn>
+PKG_LICENSE:=GPL-2.0
+
+TARGET_LDFLAGS+=-Wl,-rpath-link=$(STAGING_DIR)/usr/lib
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/cups/Default
+  URL:=http://www.cups.org/
+  SUBMENU:=Printing
+endef
+
+define Package/cups
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libcups +libcupsmime +libcupscgi +libcupsppdc +libusb-1.0
+  TITLE:=Common UNIX Printing System (daemon)
+endef
+
+define Package/cups/description
+	Common UNIX Printing System (daemon)
+endef
+
+define Package/cups/conffiles
+/etc/cups/classes.conf
+/etc/cups/cupsd.conf
+/etc/cups/printers.conf
+endef
+
+define Package/cups-bsd
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libcups
+  TITLE:=Common UNIX Printing System - BSD commands (old)
+endef
+
+define Package/cups-bsd/description
+	Common UNIX Printing System - BSD commands (old)
+endef
+
+define Package/cups-client
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libcups +libcupsimage +libcupsmime
+  TITLE:=Common UNIX Printing System - Client commands
+endef
+
+define Package/cups-client/conffiles
+/etc/cups/client.conf
+endef
+
+define Package/cups-client/description
+	Common UNIX Printing System - Client commands
+endef
+
+define Package/cups-filters
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libcupsimage +libcupsdriver
+  TITLE:=Common UNIX Printing System - Filter
+endef
+
+define Package/cups-filters/description
+	Common UNIX Printing System - Filter
+endef
+
+define Package/cups-ppdc
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libcupsppdc
+  TITLE:=Common UNIX Printing System - PPDC utils
+endef
+
+define Package/cups-ppdc/description
+	Common UNIX Printing System - PPDC utils
+endef
+
+define Package/libcups
+$(call Package/cups/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+zlib +libpthread +libpng +libjpeg
+  TITLE:=Common UNIX Printing System - Core library
+endef
+
+define Package/libcups/description
+	Common UNIX Printing System - Core library
+endef
+
+define Package/libcupscgi
+$(call Package/cups/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+libcups
+  TITLE:=Common UNIX Printing System - CGI library
+endef
+
+define Package/libcupscgi/description
+	Common UNIX Printing System - CGI library
+endef
+
+define Package/libcupsdriver
+$(call Package/cups/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+libcups
+  TITLE:=Common UNIX Printing System - Driver library
+endef
+
+define Package/libcupsdriver/description
+	Common UNIX Printing System - Driver library
+endef
+
+define Package/libcupsimage
+$(call Package/cups/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+libcups +libpng +libjpeg
+  TITLE:=Common UNIX Printing System - Image library
+endef
+
+define Package/libcupsimage/description
+	Common UNIX Printing System - Image library
+endef
+
+define Package/libcupsmime
+$(call Package/cups/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+libcups
+  TITLE:=Common UNIX Printing System - MIME library
+endef
+
+define Package/libcupsmime/description
+	Common UNIX Printing System - MIME library
+endef
+
+define Package/libcupsppdc
+$(call Package/cups/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+libcups +libstdcpp
+  TITLE:=Common UNIX Printing System - PPDC library
+endef
+
+define Package/libcupsppdc/description
+	Common UNIX Printing System - PPDC library
+endef
+
+define Package/cups-locale-de
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale de
+endef
+
+define Package/cups-locale-de/description
+	Common UNIX Printing System - Locale de
+endef
+
+define Package/cups-locale-nl
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale nl
+endef
+
+define Package/cups-locale-nl/description
+	Common UNIX Printing System - Locale nl
+endef
+
+define Package/cups-locale-hu
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale hu
+endef
+
+define Package/cups-locale-hu/description
+	Common UNIX Printing System - Locale hu
+endef
+
+define Package/cups-locale-pt
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale pt
+endef
+
+define Package/cups-locale-pt/description
+	Common UNIX Printing System - Locale pt
+endef
+
+define Package/cups-locale-pt_BR
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale pt_BR
+endef
+
+define Package/cups-locale-pt_BR/description
+	Common UNIX Printing System - Locale pt_BR
+endef
+
+define Package/cups-locale-fi
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale fi
+endef
+
+define Package/cups-locale-fi/description
+	Common UNIX Printing System - Locale fi
+endef
+
+define Package/cups-locale-sv
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale sv
+endef
+
+define Package/cups-locale-sv/description
+	Common UNIX Printing System - Locale sv
+endef
+
+define Package/cups-locale-da
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale da
+endef
+
+define Package/cups-locale-da/description
+	Common UNIX Printing System - Locale da
+endef
+
+define Package/cups-locale-ko
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale ko
+endef
+
+define Package/cups-locale-ko/description
+	Common UNIX Printing System - Locale ko
+endef
+
+define Package/cups-locale-zh
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale zh
+endef
+
+define Package/cups-locale-zh/description
+	Common UNIX Printing System - Locale zh
+endef
+
+define Package/cups-locale-ja
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale ja
+endef
+
+define Package/cups-locale-ja/description
+	Common UNIX Printing System - Locale ja
+endef
+
+define Package/cups-locale-es
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale es
+endef
+
+define Package/cups-locale-es/description
+	Common UNIX Printing System - Locale es
+endef
+
+define Package/cups-locale-zh_TW
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale zh_TW
+endef
+
+define Package/cups-locale-zh_TW/description
+	Common UNIX Printing System - Locale zh_TW
+endef
+
+define Package/cups-locale-pl
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale pl
+endef
+
+define Package/cups-locale-pl/description
+	Common UNIX Printing System - Locale pl
+endef
+
+define Package/cups-locale-no
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale no
+endef
+
+define Package/cups-locale-no/description
+	Common UNIX Printing System - Locale no
+endef
+
+define Package/cups-locale-ru
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale ru
+endef
+
+define Package/cups-locale-ru/description
+	Common UNIX Printing System - Locale ru
+endef
+
+define Package/cups-locale-eu
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale eu
+endef
+
+define Package/cups-locale-eu/description
+	Common UNIX Printing System - Locale eu
+endef
+
+define Package/cups-locale-fr
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale fr
+endef
+
+define Package/cups-locale-fr/description
+	Common UNIX Printing System - Locale fr
+endef
+
+define Package/cups-locale-it
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale it
+endef
+
+define Package/cups-locale-it/description
+	Common UNIX Printing System - Locale it
+endef
+
+define Package/cups-locale-id
+$(call Package/cups/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common UNIX Printing System - Locale id
+endef
+
+define Package/cups-locale-id/description
+	Common UNIX Printing System - Locale id
+endef
+
+define Build/Configure
+	$(call Build/Configure/Default, \
+		--with-cups-user="nobody" \
+		--with-cups-group="nogroup" \
+		--with-components="embedded" \
+		--with-pdftops="none" \
+		--without-perl \
+		--without-python \
+		--without-php \
+		--enable-shared \
+		--enable-image \
+		--enable-libusb \
+		--disable-acl \
+		--disable-dbus \
+		--disable-dnssd \
+		--disable-launchd \
+		--disable-ldap \
+		--disable-pam \
+		--disable-slp \
+		--disable-gnutls \
+		--disable-openssl \
+		--disable-cdsassl \
+		--disable-ssl \
+		--disable-gssapi \
+		--disable-tiff, \
+		UNAME="Linux" \
+		LIBS="$(TARGET_LDFLAGS) -lz -lpng -ljpeg" \
+	)
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		$(TARGET_CONFIGURE_OPTS) \
+		DSTROOT="$(PKG_INSTALL_DIR)" \
+		STRIP="/bin/true" \
+		all install
+endef
+
+define Package/cups/install
+	rm -rf $(1)/etc/cups
+	$(INSTALL_DIR) $(1)/etc/cups
+	$(CP) $(PKG_INSTALL_DIR)/etc/cups/* $(1)/etc/cups/
+	rm -rf $(1)/etc/cups/certs
+	ln -sf /tmp $(1)/etc/cups/certs
+	rm -f $(1)/usr/bin/cups-config
+	$(INSTALL_DIR) $(1)/usr/lib/cups
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/cups/backend $(1)/usr/lib/cups
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/cups/cgi-bin $(1)/usr/lib/cups
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/cups/daemon $(1)/usr/lib/cups
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/cups/driver $(1)/usr/lib/cups
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/cups/monitor $(1)/usr/lib/cups
+	$(INSTALL_DIR) $(1)/usr/lib/cups/filter
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/cups/filter/{commandtops,pstops} \
+		$(PKG_INSTALL_DIR)/usr/lib/cups/filter/gziptoany \
+		$(1)/usr/lib/cups/filter
+	$(INSTALL_DIR) $(1)/usr/share/cups/templates
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/cups/templates/*.tmpl \
+		$(1)/usr/share/cups/templates/
+	$(INSTALL_DIR) $(1)/usr/share/cups/mime
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/cups/mime/* $(1)/usr/share/cups/mime/
+	$(INSTALL_DIR) $(1)/usr/share/doc/cups
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/doc/cups/index.html \
+		$(1)/usr/share/doc/cups/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/doc/cups/*.css \
+		$(1)/usr/share/doc/cups/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/doc/cups/images \
+		$(1)/usr/share/doc/cups/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	# overwrite default config with our own
+	$(CP) ./files/etc/cups/* $(1)/etc/cups/
+	# install initscript with priority 60
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/cupsd.init $(1)/etc/init.d/cupsd
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/sbin/{cupsctl,cupsd} \
+		$(1)/usr/sbin/
+endef
+
+define Package/cups-bsd/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{lprm,lpq,lpr} $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/lpc $(1)/usr/sbin/
+endef
+
+define Package/cups-client/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/bin/{lp,cancel,cupstestppd,cupstestdsc} \
+		$(PKG_INSTALL_DIR)/usr/bin/{ipptool,lpoptions,lpstat,lppasswd} \
+		$(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/sbin/{cupsaccept,cupsaddsmb,cupsfilter} \
+		$(PKG_INSTALL_DIR)/usr/sbin/{lpadmin,lpinfo,lpmove} \
+		$(1)/usr/sbin/
+	(cd $(1)/usr/sbin; ln -sf cupsaccept accept; ln -sf cupsaccept cupsenable; ln -sf cupsaccept cupsdisable; ln -sf cupsaccept reject; ln -sf cupsaccept cupsreject;)
+endef
+
+define Package/cups-filters/install
+	$(INSTALL_DIR) $(1)/usr/lib/cups/filter
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/cups/filter/{bannertops,commandtoescpx,commandtopclx,imagetops,imagetoraster,rastertoepson,rastertopwg,rastertohp,rastertoescpx,rastertopclx,rastertolabel,texttops} \
+		$(1)/usr/lib/cups/filter
+	(cd $(1)/usr/lib/cups/filter; ln -sf rastertolabel rastertodymo;)
+endef
+
+define Package/cups-ppdc/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/bin/{ppdc,ppdhtml,ppdi,ppdmerge,ppdpo} \
+		$(1)/usr/bin/
+endef
+
+define Package/libcups/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcups.so* $(1)/usr/lib/
+endef
+
+define Package/libcupscgi/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcupscgi.so* $(1)/usr/lib/
+endef
+
+define Package/libcupsdriver/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcupsdriver.so* $(1)/usr/lib/
+endef
+
+define Package/libcupsimage/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcupsimage.so* $(1)/usr/lib/
+endef
+
+define Package/libcupsmime/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcupsmime.so* $(1)/usr/lib/
+endef
+
+define Package/libcupsppdc/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcupsppdc.so* $(1)/usr/lib/
+endef
+
+define Package/cups-locale-de/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(INSTALL_DIR) $(1)/usr/share/cups/templates
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/de $(1)/usr/share/locale/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/cups/templates/de \
+		$(1)/usr/share/cups/templates/
+endef
+
+define Package/cups-locale-nl/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/nl $(1)/usr/share/locale/
+endef
+
+define Package/cups-locale-hu/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(INSTALL_DIR) $(1)/usr/share/cups/templates
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/hu $(1)/usr/share/locale/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/cups/templates/hu \
+		$(1)/usr/share/cups/templates/
+endef
+
+define Package/cups-locale-pt/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/pt $(1)/usr/share/locale/
+endef
+
+define Package/cups-locale-pt_BR/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/pt_BR $(1)/usr/share/locale/
+endef
+
+define Package/cups-locale-fi/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/fi $(1)/usr/share/locale/
+endef
+
+define Package/cups-locale-sv/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/sv $(1)/usr/share/locale/
+endef
+
+define Package/cups-locale-da/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/da $(1)/usr/share/locale/
+endef
+
+define Package/cups-locale-ko/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/ko $(1)/usr/share/locale/
+endef
+
+define Package/cups-locale-zh/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/zh $(1)/usr/share/locale/
+endef
+
+define Package/cups-locale-ja/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(INSTALL_DIR) $(1)/usr/share/cups/templates
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/ja $(1)/usr/share/locale/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/cups/templates/ja \
+		$(1)/usr/share/cups/templates/
+endef
+
+define Package/cups-locale-es/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(INSTALL_DIR) $(1)/usr/share/cups/templates
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/es $(1)/usr/share/locale/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/cups/templates/es \
+		$(1)/usr/share/cups/templates/
+endef
+
+define Package/cups-locale-zh_TW/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/zh_TW $(1)/usr/share/locale/
+endef
+
+define Package/cups-locale-pl/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(INSTALL_DIR) $(1)/usr/share/cups/templates
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/pl $(1)/usr/share/locale/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/cups/templates/pl \
+		$(1)/usr/share/cups/templates/
+endef
+
+define Package/cups-locale-no/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/no $(1)/usr/share/locale/
+endef
+
+define Package/cups-locale-ru/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(INSTALL_DIR) $(1)/usr/share/cups/templates
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/ru $(1)/usr/share/locale/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/cups/templates/ru \
+		$(1)/usr/share/cups/templates/
+endef
+
+define Package/cups-locale-eu/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(INSTALL_DIR) $(1)/usr/share/cups/templates
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/eu $(1)/usr/share/locale/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/cups/templates/eu \
+		$(1)/usr/share/cups/templates/
+endef
+
+define Package/cups-locale-fr/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(INSTALL_DIR) $(1)/usr/share/cups/templates
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/fr $(1)/usr/share/locale/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/cups/templates/fr \
+		$(1)/usr/share/cups/templates/
+endef
+
+define Package/cups-locale-it/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(INSTALL_DIR) $(1)/usr/share/cups/templates
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/it $(1)/usr/share/locale/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/cups/templates/it \
+		$(1)/usr/share/cups/templates/
+endef
+
+define Package/cups-locale-id/install
+	$(INSTALL_DIR) $(1)/usr/share/locale
+	$(INSTALL_DIR) $(1)/usr/share/cups/templates
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/locale/id $(1)/usr/share/locale/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/cups/templates/id \
+		$(1)/usr/share/cups/templates/
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(2)/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/cups-config $(2)/bin/
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/cups $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcups*.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,cups))
+$(eval $(call BuildPackage,libcups))
+$(eval $(call BuildPackage,libcupscgi))
+$(eval $(call BuildPackage,libcupsdriver))
+$(eval $(call BuildPackage,libcupsimage))
+$(eval $(call BuildPackage,libcupsmime))
+$(eval $(call BuildPackage,libcupsppdc))
+$(eval $(call BuildPackage,cups-bsd))
+$(eval $(call BuildPackage,cups-client))
+$(eval $(call BuildPackage,cups-filters))
+$(eval $(call BuildPackage,cups-ppdc))
+$(eval $(call BuildPackage,cups-locale-de))
+$(eval $(call BuildPackage,cups-locale-nl))
+$(eval $(call BuildPackage,cups-locale-hu))
+$(eval $(call BuildPackage,cups-locale-pt))
+$(eval $(call BuildPackage,cups-locale-pt_BR))
+$(eval $(call BuildPackage,cups-locale-fi))
+$(eval $(call BuildPackage,cups-locale-sv))
+$(eval $(call BuildPackage,cups-locale-da))
+$(eval $(call BuildPackage,cups-locale-ko))
+$(eval $(call BuildPackage,cups-locale-zh))
+$(eval $(call BuildPackage,cups-locale-ja))
+$(eval $(call BuildPackage,cups-locale-es))
+$(eval $(call BuildPackage,cups-locale-zh_TW))
+$(eval $(call BuildPackage,cups-locale-pl))
+$(eval $(call BuildPackage,cups-locale-no))
+$(eval $(call BuildPackage,cups-locale-ru))
+$(eval $(call BuildPackage,cups-locale-eu))
+$(eval $(call BuildPackage,cups-locale-fr))
+$(eval $(call BuildPackage,cups-locale-it))
+$(eval $(call BuildPackage,cups-locale-id))

--- a/net/cups/files/cupsd.init
+++ b/net/cups/files/cupsd.init
@@ -1,0 +1,19 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2006-2011 OpenWrt.org
+
+START=50
+
+start() {
+	mkdir -m 0755 -p /var/cache/cups
+	mkdir -m 0755 -p /var/cups
+	mkdir -m 0755 -p /var/spool/cups/tmp
+	service_start /usr/sbin/cupsd
+}
+
+stop() {
+	service_stop /usr/sbin/cupsd
+}
+
+reload() {
+	service_reload /usr/sbin/cupsd
+}

--- a/net/cups/files/etc/cups/classes.conf
+++ b/net/cups/files/etc/cups/classes.conf
@@ -1,0 +1,7 @@
+########################################################################
+#                                                                      #
+# This is a sample class configuration file.  This file is included    #
+# from the main configuration file (cups.conf) and lists all of the    #
+# printer classes known to the system.                                 #
+#                                                                      #
+########################################################################

--- a/net/cups/files/etc/cups/client.conf
+++ b/net/cups/files/etc/cups/client.conf
@@ -1,0 +1,9 @@
+########################################################################
+#                                                                      #
+# This is the CUPS client configuration file.  This file is used to    #
+# define client-specific parameters, such as the default server or     #
+# default encryption settings.                                         #
+#                                                                      #
+########################################################################
+
+Encryption Never

--- a/net/cups/files/etc/cups/cupsd.conf
+++ b/net/cups/files/etc/cups/cupsd.conf
@@ -1,0 +1,47 @@
+########################################################################
+#                                                                      #
+# This is the CUPS configuration file.  If you are familiar with       #
+# Apache or any of the other popular web servers, we've followed the   #
+# same format.  Any configuration variable used here has the same      #
+# semantics as the corresponding variable in Apache.  If we need       #
+# different functionality then a different name is used to avoid       #
+# confusion...                                                         #
+#                                                                      #
+########################################################################
+
+
+AccessLog syslog
+ErrorLog syslog
+LogLevel info
+PageLog syslog
+PreserveJobHistory No
+PreserveJobFiles No
+AutoPurgeJobs Yes
+MaxJobs 25
+MaxPrinterHistory 10
+#Printcap /etc/printcap
+#PrintcapFormat BSD
+RequestRoot /var/cups
+#RemoteRoot remroot
+User nobody
+Group nogroup
+RIPCache 512k
+TempDir /var/cups
+Port 631
+HostNameLookups Off
+KeepAlive On
+Browsing On
+BrowseProtocols cups
+
+<Location />
+Order Deny,Allow
+Allow From 127.0.0.1
+Allow From 192.168.1.0/24
+</Location>
+
+<Location /admin>
+AuthType Basic
+AuthClass System
+Order Allow,Deny
+Allow From All
+</Location>

--- a/net/cups/files/etc/cups/printers.conf
+++ b/net/cups/files/etc/cups/printers.conf
@@ -1,0 +1,23 @@
+<DefaultPrinter USB>
+Info USB Printer
+Location
+DeviceURI usb:/dev/usb/lp0
+State Idle
+Accepting Yes
+JobSheets none none
+QuotaPeriod 0
+PageLimit 0
+KLimit 0
+</Printer>
+
+<Printer LP>
+Info Parallel Port Printer
+Location
+DeviceURI parallel:/dev/printers/0
+State Idle
+Accepting Yes
+JobSheets none none
+QuotaPeriod 0
+PageLimit 0
+KLimit 0
+</Printer>

--- a/net/cups/patches/100-components.patch
+++ b/net/cups/patches/100-components.patch
@@ -1,0 +1,42 @@
+--- cups-1.5.4/configure	2012-10-09 09:22:45.000000000 +0200
++++ cups-1.5.4/configure	2012-10-09 09:24:30.000000000 +0200
+@@ -1619,6 +1619,7 @@
+   --with-operkey          set the default operator @AUTHKEY value
+   --with-components       set components to build:
+ 			    - "all" (default) builds everything
++			    - "embedded" builds everything except man and notifier
+ 			    - "core" builds libcups and ipptool
+   --with-privateinclude   set path for private include files, default=none
+   --with-rcdir            set path for rc scripts
+@@ -5861,6 +5862,10 @@
+ 		BUILDDIRS="filter backend berkeley cgi-bin driver monitor notifier ppdc scheduler systemv conf data desktop locale man doc examples templates"
+ 		;;
+
++	embedded)
++		BUILDDIRS="filter backend berkeley cgi-bin driver monitor ppdc scheduler systemv conf data locale doc examples templates"
++		;;
++
+ 	core)
+ 		BUILDDIRS="data locale"
+ 		;;
+--- cups-1.5.4/config-scripts/cups-common.m4.orig	2012-10-09 09:17:08.000000000 +0200
++++ cups-1.5.4/config-scripts/cups-common.m4	2012-10-09 09:24:42.000000000 +0200
+@@ -414,6 +414,7 @@
+
+ AC_ARG_WITH(components, [  --with-components       set components to build:
+ 			    - "all" (default) builds everything
++			    - "embedded" builds everything except locale, man and notifier
+ 			    - "core" builds libcups and ipptool],
+ 	COMPONENTS="$withval")
+
+@@ -422,6 +423,10 @@
+ 		BUILDDIRS="filter backend berkeley cgi-bin driver monitor notifier ppdc scheduler systemv conf data desktop locale man doc examples templates"
+ 		;;
+
++	embedded)
++		BUILDDIRS="filter backend berkeley cgi-bin driver monitor ppdc scheduler systemv conf data locale doc examples templates"
++		;;
++
+ 	core)
+ 		BUILDDIRS="data locale"
+ 		;;

--- a/net/cups/patches/140-uname.patch
+++ b/net/cups/patches/140-uname.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -1966,7 +1966,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+ 
+ 
+-uname=`uname`
++uname=${UNAME:-`uname`}
+ uversion=`uname -r | sed -e '1,$s/^[^0-9]*\([0-9]*\)\.\([0-9]*\).*/\1\2/'`
+ uarch=`uname -m`
+ 

--- a/net/cups/patches/150-64bit_host_fix.patch
+++ b/net/cups/patches/150-64bit_host_fix.patch
@@ -1,0 +1,64 @@
+--- a/cups-config.in
++++ b/cups-config.in
+@@ -54,7 +54,7 @@ else
+ 	CFLAGS="$CFLAGS -I$includedir"
+     fi
+ 
+-    if test $libdir != /usr/lib -a $libdir != /usr/lib32 -a $libdir != /usr/lib64; then
++    if test $libdir != /usr/lib -a $libdir != /usr/lib -a $libdir != /usr/lib; then
+ 	LDFLAGS="$LDFLAGS -L$libdir"
+     fi
+ fi
+--- a/config-scripts/cups-3264.m4
++++ b/config-scripts/cups-3264.m4
+@@ -108,7 +108,7 @@ case "$uname" in
+ 			LIB64CUPSIMAGE="64bit/libcupsimage.so.2"
+ 			LIB64DIR="$exec_prefix/lib"
+ 			if test -d /usr/lib64; then
+-				LIB64DIR="${LIB64DIR}64"
++				LIB64DIR="${LIB64DIR}"
+ 			fi
+ 			UNINSTALL64="uninstall64bit"
+ 		fi
+--- a/config-scripts/cups-directories.m4
++++ b/config-scripts/cups-directories.m4
+@@ -107,7 +107,7 @@ if test "$libdir" = "\${exec_prefix}/lib
+ 			;;
+ 		Linux*)
+ 			if test -d /usr/lib64; then
+-				libdir="$exec_prefix/lib64"
++				libdir="$exec_prefix/lib"
+ 			fi
+ 			;;
+ 		HP-UX*)
+--- a/configure
++++ b/configure
+@@ -10003,7 +10003,7 @@ if test "$libdir" = "\${exec_prefix}/lib
+ 			;;
+ 		Linux*)
+ 			if test -d /usr/lib64; then
+-				libdir="$exec_prefix/lib64"
++				libdir="$exec_prefix/lib"
+ 			fi
+ 			;;
+ 		HP-UX*)
+@@ -10626,9 +10626,6 @@ case "$uname" in
+ 			LIB32CUPS="32bit/libcups.so.2"
+ 			LIB32CUPSIMAGE="32bit/libcupsimage.so.2"
+ 			LIB32DIR="$exec_prefix/lib"
+-			if test -d /usr/lib32; then
+-				LIB32DIR="${LIB32DIR}32"
+-			fi
+ 			UNINSTALL32="uninstall32bit"
+ 		fi
+ 
+@@ -10638,9 +10635,6 @@ case "$uname" in
+ 			LIB64CUPS="64bit/libcups.so.2"
+ 			LIB64CUPSIMAGE="64bit/libcupsimage.so.2"
+ 			LIB64DIR="$exec_prefix/lib"
+-			if test -d /usr/lib64; then
+-				LIB64DIR="${LIB64DIR}64"
+-			fi
+ 			UNINSTALL64="uninstall64bit"
+ 		fi
+ 		;;

--- a/net/cups/patches/160-ppdc.patch
+++ b/net/cups/patches/160-ppdc.patch
@@ -1,0 +1,16 @@
+--- cups-1.5.4/ppdc/Makefile	2012-10-09 09:36:00.000000000 +0200
++++ cups-1.5.4/ppdc/Makefile	2012-10-09 09:36:34.000000000 +0200
+@@ -239,12 +239,7 @@
+ 
+ genstrings:		genstrings.o libcupsppdc.a ../cups/$(LIBCUPSSTATIC) \
+ 			sample.drv ../data/media.defs
+-	echo Linking $@...
+-	$(CXX) $(ARCHFLAGS) $(LDFLAGS) -o genstrings genstrings.o \
+-		libcupsppdc.a ../cups/$(LIBCUPSSTATIC) $(LIBGSSAPI) $(SSLLIBS) \
+-		$(DNSSDLIBS) $(COMMONLIBS) $(LIBZ)
+-	echo Generating localization strings...
+-	./genstrings >sample.c
++	echo Not Linking $@...
+ 
+ 
+ #

--- a/net/cups/patches/200-str4181.patch
+++ b/net/cups/patches/200-str4181.patch
@@ -1,0 +1,13 @@
+--- cups-1.5.4/backend/ipp.c	(revision 10596)
++++ cups-1.5.4/backend/ipp.c	(working copy)
+@@ -1578,6 +1578,10 @@
+ 	  ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_MIMETYPE,
+ 		       "document-format", NULL, document_format);
+
++        if (compression)
++	  ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD,
++		       "compression", NULL, compression);
++
+ 	fprintf(stderr, "DEBUG: Sending file %d using chunking...\n", i + 1);
+ 	http_status = cupsSendRequest(http, request, resource, 0);
+ 	if (http_status == HTTP_CONTINUE && request->state == IPP_DATA)

--- a/net/cups/patches/210-str4194.patch
+++ b/net/cups/patches/210-str4194.patch
@@ -1,0 +1,11 @@
+--- cups-1.5.4/backend/ipp.c	(revision 10619)
++++ cups-1.5.4/backend/ipp.c	(working copy)
+@@ -952,6 +952,8 @@
+ 	_cupsLangPrintFilter(stderr, "ERROR",
+ 	                     _("Unable to get printer status."));
+         sleep(10);
++
++	httpReconnect(http);
+       }
+
+       ippDelete(supported);


### PR DESCRIPTION
Add cups from old packages.
Add radvd from old packages.

Update radvd to version 1.15 to fix compile error. Ticket 19948 ( https://dev.openwrt.org/ticket/19948 )

Package tested with WD N750、TPLINK WR703N&MR3420、Huawei HG556a revC、HIWIFI 1S(MT7620A no USB, radvd only)