### PR TITLE
c-ares: fix build with CONFIG_PKG_FORTIFY_SOURCE*

### DIFF
--- a/libs/c-ares/Makefile
+++ b/libs/c-ares/Makefile
@@ -22,6 +22,9 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
+TARGET_CPPFLAGS += $(filter -D%,$(TARGET_CFLAGS))
+TARGET_CFLAGS := $(filter-out -D%,$(TARGET_CFLAGS))
+
 define Package/libcares
   SECTION:=libs
   CATEGORY:=Libraries


### PR DESCRIPTION
When fortify source is enabled, the c-ares configure script will abort with:

    configure: CFLAGS error: CFLAGS may only be used to specify C compiler flags, not macro definitions. Use CPPFLAGS for: -D_FORTIFY_SOURCE=1

Change the OpenWrt Makefile to move any -D flags from TARGET_CFLAGS to
TARGET_CPPFLAGS in order to satisfy `configure`.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>