### PR TITLE
usb: fix musl compatibility

### DIFF
--- a/net/usbip/Makefile
+++ b/net/usbip/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=usbip
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_LICENSE:=GPL-2.0
 
 # Since kernel 2.6.39.1 userspace tools are inside the kernel tree

--- a/net/usbip/patches-2.0/100-musl-compat.patch
+++ b/net/usbip/patches-2.0/100-musl-compat.patch
@@ -1,0 +1,11 @@
+--- a/src/usbipd.c
++++ b/src/usbipd.c
+@@ -453,7 +453,7 @@ static void set_signal(void)
+ 	sigaction(SIGTERM, &act, NULL);
+ 	sigaction(SIGINT, &act, NULL);
+ 	act.sa_handler = SIG_IGN;
+-	sigaction(SIGCLD, &act, NULL);
++	sigaction(SIGCHLD, &act, NULL);
+ }
+ 
+ static const char *pid_file;


### PR DESCRIPTION
Replace the nonstandard `SIGCLD` signal name with the proper `SIGCHLD` spelling
as the `SIGCLD` alias is not provided by musl.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>