### PR TITLE
sstp-client: fix musl compatibility

### DIFF
--- a/net/sstp-client/Makefile
+++ b/net/sstp-client/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -17,6 +17,8 @@ PKG_MD5SUM:=5f290355187e5ce0423fb7e388e65b9d
 PKG_LICENSE=GPLv2
 
 include $(INCLUDE_DIR)/package.mk
+
+TARGET_CPPFLAGS += -I$(PKG_BUILD_DIR)/include
 
 define Package/sstp-client
   SECTION:=net

--- a/net/sstp-client/patches/100-musl-compat.patch
+++ b/net/sstp-client/patches/100-musl-compat.patch
@@ -1,0 +1,33 @@
+--- /dev/null
++++ b/include/net/ppp_defs.h
+@@ -0,0 +1,10 @@
++#ifndef _NET_PPP_DEFS_H
++#define _NET_PPP_DEFS_H 1
++
++#define __need_time_t
++#include <time.h>
++
++#include <asm/types.h>
++#include <linux/ppp_defs.h>
++
++#endif /* net/ppp_defs.h */
+--- a/src/libsstp-log/sstp-log-syslog.c
++++ b/src/libsstp-log/sstp-log-syslog.c
+@@ -32,6 +32,7 @@
+ #include <sys/uio.h>
+ #include <sys/un.h>
+ #include <sys/socket.h>
++#include <sys/types.h>
+ #include <unistd.h>
+ 
+ #include <sstp-common.h>
+--- a/src/libsstp-log/sstp-log-std.c
++++ b/src/libsstp-log/sstp-log-std.c
+@@ -25,6 +25,7 @@
+ #include <stdio.h>
+ #include <stdint.h>
+ #include <string.h>
++#include <sys/types.h>
+ #include <sys/uio.h>
+ #include <unistd.h>
+ 


### PR DESCRIPTION
 - Ship a `net/ppp_defs.h` replacement header since musl does not provide one
   but `pppd/pppd.h` provided by pppd is needing it.
 - Add missing `sys/types.h` includes

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>