### PR TITLE
squid: fix musl compatibility

### DIFF
--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
 PKG_VERSION:=3.5.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>

--- a/net/squid/patches/200-musl-compat.patch
+++ b/net/squid/patches/200-musl-compat.patch
@@ -1,0 +1,15 @@
+--- a/lib/rfcnb/rfcnb-io.c
++++ b/lib/rfcnb/rfcnb-io.c
+@@ -36,11 +36,11 @@
+ #include "rfcnb/rfcnb-util.h"
+ #include "rfcnb/std-includes.h"
+ 
++#include <signal.h>
+ #if HAVE_STRING_H
+ #include <string.h>
+ #endif
+ #include <sys/uio.h>
+-#include <sys/signal.h>
+ 
+ int RFCNB_Timeout = 0;          /* Timeout in seconds ... */
+ 


### PR DESCRIPTION
Change `sys/signal.h` include to just `signal.h`. The build otherwise fails
due to `-Werror` with the following message:

    In file included from rfcnb-io.c:43:0:
    .../staging_dir/toolchain-mipsel_mips32_gcc-4.8-linaro_musl-1.1.10/include/sys/signal.h:1:2: error: #warning redirecting incorrect #include <sys/signal.h> to <signal.h> [-Werror=cpp]
     #warning redirecting incorrect #include <sys/signal.h> to <signal.h>
      ^
    cc1: all warnings being treated as errors

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>