### PR TITLE
snort: fix build with CONFIG_PKG_CHECK_FORMAT_SECURITY

### DIFF
--- a/net/snort/Makefile
+++ b/net/snort/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort
 PKG_VERSION:=2.9.7.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.snort.org/downloads/snort/ \

--- a/net/snort/patches/100-autoconf-fixes.patch
+++ b/net/snort/patches/100-autoconf-fixes.patch
@@ -1,0 +1,17 @@
+--- a/configure.in
++++ b/configure.in
+@@ -11,14 +11,6 @@ AM_INIT_AUTOMAKE(snort,2.9.7.2)
+ NO_OPTIMIZE="no"
+ ADD_WERROR="no"
+ 
+-# Test for -Werror and sed it out for now since some of the auto tests,
+-# for example AC_CHECK_LIB, will fail because of
+-# warning: conflicting types for built-in function <func>
+-if eval "echo $CFLAGS | grep -e -Werror"; then
+-    CFLAGS=`echo $CFLAGS | sed -e "s/-Werror//g"`
+-    ADD_WERROR="yes"
+-fi
+-
+ # Disable annoying practice of recursively re-running the autotools
+ AM_MAINTAINER_MODE
+ AC_PROG_CC_STDC


### PR DESCRIPTION
The configure script incorrectly mangles `CFLAGS` by attempting to remove
`-Werror` from it, thus turning `-Werror=format-security` into just
`=format-security` which will cause subsequent autoconf tests to fail.

Patch out the custom `CFLAGS` mangling to fix the build.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>