### PR TITLE
shadowsocks-client: fix fortify source compatibility

### DIFF
--- a/net/shadowsocks-client/patches/100-fortify-source-compat.patch
+++ b/net/shadowsocks-client/patches/100-fortify-source-compat.patch
@@ -1,0 +1,72 @@
+--- a/client.c
++++ b/client.c
+@@ -111,7 +111,7 @@ int client_do_local_read(int sockfd, str
+ 			goto out;
+ 	}
+ 
+-	if (encrypt(sockfd, ln) == -1)
++	if (crypto_encrypt(sockfd, ln) == -1)
+ 		goto out;
+ 
+ 	ret = do_send(ln->server_sockfd, ln, "cipher", 0);
+@@ -172,7 +172,7 @@ int client_do_server_read(int sockfd, st
+ 		}
+ 	}
+ 
+-	if (decrypt(sockfd, ln) == -1)
++	if (crypto_decrypt(sockfd, ln) == -1)
+ 		goto out;
+ 
+ 	if (ln->state & SS_UDP) {
+--- a/crypto.c
++++ b/crypto.c
+@@ -185,7 +185,7 @@ err:
+ 	return -1;
+ }
+ 
+-int encrypt(int sockfd, struct link *ln)
++int crypto_encrypt(int sockfd, struct link *ln)
+ {
+ 	int len, cipher_len;
+ 	EVP_CIPHER_CTX *ctx_p;
+@@ -223,7 +223,7 @@ err:
+ 	return -1;
+ }
+ 
+-int decrypt(int sockfd, struct link *ln)
++int crypto_decrypt(int sockfd, struct link *ln)
+ {
+ 	int len, text_len;
+ 	EVP_CIPHER_CTX *ctx_p;
+--- a/crypto.h
++++ b/crypto.h
+@@ -15,7 +15,7 @@ extern int iv_len;
+ 
+ int crypto_init(char *key, char *method);
+ void crypto_exit(void);
+-int encrypt(int sockfd, struct link *ln);
+-int decrypt(int sockfd, struct link *ln);
++int crypto_encrypt(int sockfd, struct link *ln);
++int crypto_decrypt(int sockfd, struct link *ln);
+ 
+ #endif
+--- a/server.c
++++ b/server.c
+@@ -36,7 +36,7 @@ int server_do_remote_read(int sockfd, st
+ 			goto out;
+ 	}
+ 
+-	if (encrypt(sockfd, ln) == -1)
++	if (crypto_encrypt(sockfd, ln) == -1)
+ 		goto out;
+ 
+ 	ret = do_send(ln->local_sockfd, ln, "cipher", 0);
+@@ -91,7 +91,7 @@ int server_do_local_read(int sockfd, str
+ 		}
+ 	}
+ 
+-	if (decrypt(sockfd, ln) == -1)
++	if (crypto_decrypt(sockfd, ln) == -1)
+ 		goto out;
+ 
+ 	if (ln->state & SS_UDP) {


### PR DESCRIPTION
The shadowsocks source uses the name `encrypt` which is already reserved by
the `unistd.h` header. Rename the local `encrypt` and `decrypt` functions to
`crypto_encrypt` and `crypto_decrypt` in order to prevent clashes with the
standard headers.

Fixes the following build error oberserved on the buildbot:

    In file included from client.c:19:0:
    crypto.h:18:5: error: conflicting types for 'encrypt'
     int encrypt(int sockfd, struct link *ln);
         ^
    In file included from .../staging_dir/toolchain-mipsel_mips32_gcc-4.8-linaro_musl-1.1.10/include/fortify/unistd.h:20:0,
                     from client.c:12:
    .../staging_dir/toolchain-mipsel_mips32_gcc-4.8-linaro_musl-1.1.10/include/unistd.h:145:6: note: previous declaration of 'encrypt' was here
     void encrypt(char *, int);
          ^
    make[3]: *** [sslocal] Error 1

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>