### PR TITLE
Added patch for squid to address build error caused by warning of hea…

### DIFF
--- a/net/squid/patches/101-include-redirect-warning.patch
+++ b/net/squid/patches/101-include-redirect-warning.patch
@@ -1,0 +1,11 @@
+--- a/lib/rfcnb/rfcnb-io.c
++++ b/lib/rfcnb/rfcnb-io.c
+@@ -40,7 +40,7 @@
+ #include <string.h>
+ #endif
+ #include <sys/uio.h>
+-#include <sys/signal.h>
++#include <signal.h>
+ 
+ int RFCNB_Timeout = 0;          /* Timeout in seconds ... */
+ 


### PR DESCRIPTION
Added patch for squid to address build error caused by warning of header redirect when using  `<sys/signal.h>`. It needed to just specify `<signal.h>`.