### PR TITLE
pthsem: fix musl and fortify source compatibility

### DIFF
--- a/libs/pthsem/Makefile
+++ b/libs/pthsem/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pthsem
 PKG_VERSION:=2.0.8
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=LGPL-2.1+
@@ -21,6 +21,7 @@ PKG_MD5SUM:=9144b26dcc27e67498d63dd5456f934c
 
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1
+PKG_FORTIFY_SOURCE:=0
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -36,6 +37,13 @@ define Package/pthsem/description
   GNU pth is a user mode multi threading library.
   pthsem is an extend version, with support for semaphores added. It can be installed parallel to a normal pth.
 endef
+
+# The musl libc provides a proper implementation of sigaltstack() so
+# prevent configure from wrongly assuming a broken Linux platform
+ifeq ($(CONFIG_USE_MUSL),y)
+  CONFIGURE_VARS += \
+	ac_cv_check_sjlj=ssjlj
+endif
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
This commit addresses two issues encountered while building pthsem for
x86_64/musl:

1) Autoconf incorrectly assumes a broken Glibc and thus falls back
   to Linux compatibility code which runs into an unsupported
   platform error with musl libc. Since musl provides a proper
   implementation of `sigaltstack(2)`, force configure to use the
   POSIX compliant code when musl libc is used.

2) The `pth_syscall.c` file undefines various libc function names
   which breaks the indirection set up by fortify-source headers,
   therefore forcibly disable fortify source in the OpenWrt Makefile.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>