### PR TITLE
postfix: fix musl compatibility

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -1,5 +1,5 @@
 # 
-# Copyright (C) 2014 OpenWrt.org
+# Copyright (C) 2014-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postfix
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE_URL:=ftp://ftp.porcupine.org/mirrors/postfix-release/official/
 PKG_VERSION:=3.0.1
 PKG_MD5SUM:=3ec1416e7d4fba9566297c8fcf7a348c

--- a/mail/postfix/patches/500-crosscompile.patch
+++ b/mail/postfix/patches/500-crosscompile.patch
@@ -1,6 +1,6 @@
---- postfix-2.10.2/makedefs	2013-02-04 05:33:13.000000000 +0400
-+++ postfix-2.10.2_patched/makedefs	2013-11-19 22:48:50.528560454 +0400
-@@ -190,9 +190,9 @@
+--- a/makedefs
++++ b/makedefs
+@@ -190,9 +190,9 @@ error() {
  
  case $# in
   # Officially supported usage.
@@ -13,7 +13,7 @@
      case "$VERSION" in
       dcosx*) SYSTEM=$VERSION;;
      esac;;
-@@ -522,9 +522,9 @@
+@@ -522,9 +522,9 @@ EOF
  		esac
  		for name in nsl resolv
  		do
@@ -21,7 +21,7 @@
 +		    for lib in /usr/lib64 /usr/lib64/* /usr/lib /usr/lib/* /lib /lib/*
  		    do
 -			test -e $lib/lib$name.a -o -e $lib/lib$name.so && {
-+			test -e $PKG_BUILD_DIR/$lib/lib$name.a -o -e $PKG_BUILD_DIR/$lib/lib$name.so && {
++			test -e $STAGING_DIR/$lib/lib$name.a -o -e $STAGING_DIR/$lib/lib$name.so && {
  			    SYSLIBS="$SYSLIBS -l$name"
  			    break
  			}


### PR DESCRIPTION
The current package patches `makedefs` to probe for the existance
of the `nsl` and `resolv` libraries but uses the wrong variables
for the prefix, leading to `makedefs` probing the host directories,
not the staging dir ones.

Replace `$PKG_BUILD_DIR` with `$STAGING_DIR` to perform the library
tests in the correct directory.

Fixes the following error spotted by doing test builds against musl
which does not provide a `libnsl`:

    .../mips-openwrt-linux-musl/bin/ld: cannot find -lnsl
    collect2: error: ld returned 1 exit status
    make: *** [master] Error 1

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>