### PR TITLE
opennhrp: fix musl compatibility

### DIFF
--- a/net/opennhrp/Makefile
+++ b/net/opennhrp/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2011 OpenWrt.org
+# Copyright (C) 2009-2015 OpenWrt.org
 # Copyright (C) 2009 Jakob Pfeiffer
 # Copyright (C) 2014 Artem Makhutov
 #
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennhrp
 PKG_VERSION:=0.14.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Artem Makhutov <artem@makhutov.org>
 PKG_LICENSE:=MIT License
 

--- a/net/opennhrp/patches/100-musl-compat.patch
+++ b/net/opennhrp/patches/100-musl-compat.patch
@@ -1,0 +1,20 @@
+--- a/nhrp/opennhrp.c
++++ b/nhrp/opennhrp.c
+@@ -9,6 +9,7 @@
+ #include <ctype.h>
+ #include <stdio.h>
+ #include <errno.h>
++#include <fcntl.h>
+ #include <malloc.h>
+ #include <stddef.h>
+ #include <string.h>
+--- a/nhrp/nhrp_common.h
++++ b/nhrp/nhrp_common.h
+@@ -12,6 +12,7 @@
+ #include <stdint.h>
+ #include <stdlib.h>
+ #include <sys/time.h>
++#include <sys/types.h>
+ #include <linux/if_ether.h>
+ 
+ struct nhrp_interface;


### PR DESCRIPTION
 - Add `fcntl.h` to `nrhp/opennhrp.c` for `open()`, `O_WRONLY` etc.
 - Add missing `sys/types.h` include to `nrhp/nrhp_common.h` to provide
   required `u_int*_t` types under musl

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>