### PR TITLE
opencv: fix musl compatibility

### DIFF
--- a/libs/opencv/Makefile
+++ b/libs/opencv/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opencv
 PKG_VERSION:=2.4.11
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=http://sourceforge.net/projects/opencvlibrary/files/opencv-unix/$(PKG_VERSION)/
@@ -54,6 +54,7 @@ CMAKE_OPTIONS += -DBUILD_opencv_gpu:BOOL=OFF \
 	-DWITH_LIBV4L:BOOL=OFF \
 	-DWITH_PNG:BOOL=OFF \
 	-DWITH_TIFF:BOOL=OFF \
+	-DENABLE_PRECOMPILED_HEADERS=OFF \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include

--- a/libs/opencv/patches/100-musl-compat.patch
+++ b/libs/opencv/patches/100-musl-compat.patch
@@ -1,0 +1,33 @@
+--- a/modules/core/src/system.cpp
++++ b/modules/core/src/system.cpp
+@@ -164,7 +164,7 @@ std::wstring GetTempFileNameWinRT(std::w
+ #if defined ANDROID
+ #include <sys/sysconf.h>
+ #else
+-#include <sys/sysctl.h>
++#include <linux/sysctl.h>
+ #endif
+ #endif
+ 
+--- a/modules/highgui/src/cap_ffmpeg_impl.hpp
++++ b/modules/highgui/src/cap_ffmpeg_impl.hpp
+@@ -131,7 +131,7 @@ extern "C" {
+     #include <unistd.h>
+     #include <stdio.h>
+     #include <sys/types.h>
+-    #include <sys/sysctl.h>
++    #include <linux/sysctl.h>
+ #endif
+ 
+ #ifndef MIN
+--- a/modules/core/src/parallel.cpp
++++ b/modules/core/src/parallel.cpp
+@@ -57,7 +57,7 @@
+     #if defined ANDROID
+         #include <sys/sysconf.h>
+     #else
+-        #include <sys/sysctl.h>
++        #include <linux/sysctl.h>
+     #endif
+ #endif
+ 


### PR DESCRIPTION
 - Turn off precompiled header support since it leads to following
   linking failure:

    .../staging_dir/toolchain-mips_34kc+dsp_gcc-4.8-linaro_musl-1.1.10/mips-openwrt-linux-musl/lib/crt1.o: In function `__start':
    (.text+0xc): undefined reference to `main'
    collect2: error: ld returned 1 exit status

 - Replace `sys/sysctl.h` includes with `linux/sysctl.h` ones as the musl libc
   does not provide this nonstandard header. This has also been fixed upstream
   in the OpenCV 3.x releases

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>