### PR TITLE
open-plc-utils: fix musl and fortify source compatibility

### DIFF
--- a/utils/open-plc-utils/Makefile
+++ b/utils/open-plc-utils/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2014 OpenWrt.org
+# Copyright (C) 2013-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=open-plc-utils
-PKG_VERSION:=2015-02-23
+PKG_VERSION:=2015-06-26
 PKG_RELEASE:=$(PKG_SOURCE_VERSION)
 
 PKG_SOURCE_PROTO:=git

--- a/utils/open-plc-utils/patches/100-musl-compat.patch
+++ b/utils/open-plc-utils/patches/100-musl-compat.patch
@@ -1,0 +1,33 @@
+--- a/ether/readpacket.c
++++ b/ether/readpacket.c
+@@ -70,6 +70,10 @@
+ #include <memory.h>
+ #include <errno.h>
+ 
++#if defined (__linux__)
++#include <poll.h>
++#endif
++
+ #include "../ether/channel.h"
+ #include "../tools/memory.h"
+ #include "../tools/error.h"
+@@ -95,8 +99,6 @@ ssize_t readpacket (struct channel const
+ 
+ #elif defined (__linux__)
+ 
+-#include <sys/poll.h>
+-
+ 	struct pollfd pollfd =
+ 	{
+ 		channel->fd,
+--- a/serial/serial.c
++++ b/serial/serial.c
+@@ -69,6 +69,8 @@
+ 
+ #if defined (WIN32)
+ #include <Windows.h>
++#else
++#include <sys/select.h>
+ #endif
+ 
+ /*====================================================================*


### PR DESCRIPTION
 - Include `poll.h` at the top of `ether/readpacket.c` to avoid nested
   declaration errors caused by fortify source headers
 - Add missing `sys/select.h` include to `serial/serial.c`

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>