### PR TITLE
python-pyserial: new package

### DIFF
--- a/lang/python-pyserial/Makefile
+++ b/lang/python-pyserial/Makefile
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pyserial
+PKG_VERSION:=2.7
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Micke Prag <micke.prag@telldus.se>
+
+PKG_SOURCE:=pyserial-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://pypi.python.org/packages/source/p/pyserial/
+PKG_MD5SUM:=794506184df83ef2290de0d18803dd11
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/pyserial-$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=python
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/python-pyserial
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=python-pyserial
+  URL:=http://pyserial.sourceforge.net
+  DEPENDS:=+python-light
+endef
+
+define Package/python-pyserial/description
+	serial port python bindings
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,,install --prefix="$(PKG_INSTALL_DIR)/usr")
+endef
+
+define Package/python-pyserial/install
+	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
+	$(CP) \
+	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
+	    $(1)$(PYTHON_PKG_DIR)
+endef
+
+$(eval $(call BuildPackage,python-pyserial))

--- a/lang/python-pyserial/Makefile
+++ b/lang/python-pyserial/Makefile
@@ -11,6 +11,7 @@ PKG_NAME:=python-pyserial
 PKG_VERSION:=2.7
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Micke Prag <micke.prag@telldus.se>
+PKG_LICENSE:=Python-2.0
 
 PKG_SOURCE:=pyserial-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://pypi.python.org/packages/source/p/pyserial/


### PR DESCRIPTION
This is the pyserial package ported from oldpackages. It is a
bumped version and depends on python-light instead of python-mini

Signed-off-by: Micke Prag <micke.prag@telldus.se>