### PR TITLE
ntpd: fix fortify source compatibility

### DIFF
--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntp
 PKG_VERSION:=4.2.8p2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/
@@ -93,7 +93,9 @@ endef
 CONFIGURE_VARS += \
 	ac_cv_header_md5_h=no \
 	ac_cv_lib_rt_sched_setscheduler=no \
-	ac_cv_header_dns_sd_h=no
+	ac_cv_header_dns_sd_h=no \
+	hw_cv_func_snprintf_c99=yes \
+	hw_cv_func_vsnprintf_c99=yes \
 
 CONFIGURE_ARGS += \
 	--disable-all-clocks \


### PR DESCRIPTION
The ntpd package ships autoconf macros which attempt to test for the C99
compliance of `snprintf()` and `vsnprintf()`.

Those macros unconditionally consider the functions not compliant in a cross
compile setting and therfore break all subsequent configure tests because
the `snprintf` and `vsnprintf` symbols are shadowed with `#define` directives
redirecting them to their respectiv gnulib replacements.

The fortify source headers in turn will `#undef` those defines when wrapping
the associated functions and therfore cause all `conftest` programs to emit
a failure.

Pass the required magic autoconf cache variables via `CONFIGURE_VARS` to let
`./configure` assume C99 compliance of the affected functions, thus fixing
the build.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>