### PR TITLE
unbound: Support for validating ECDSA DNSSEC signatures

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.5.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -109,7 +109,6 @@ define Package/libunbound/description
 endef
 
 CONFIGURE_ARGS += \
-	--disable-ecdsa \
 	--disable-gost \
 	--enable-allsymbols \
 	--with-libexpat="$(STAGING_DIR)/usr" \


### PR DESCRIPTION
This patch enables support for validating ECDSA signatures, which
are being deployed more and more in DNSSEC.

Proper validating can be tested by observing the AD flag in following
query (courtesy of Olafur Gudmundsson, CloudFlare):
 $ dig ds-4.alg-14-nsec.dnssec-test.org

Signed-off-by: Ondřej Caletka <ondrej@caletka.cz>