### PR TITLE
hfsprogs: fix build with musl

### DIFF
--- a/utils/hfsprogs/patches/0015-sysctl-only-on-glibc.patch
+++ b/utils/hfsprogs/patches/0015-sysctl-only-on-glibc.patch
@@ -1,0 +1,91 @@
+--- a/newfs_hfs.tproj/makehfs.c
++++ b/newfs_hfs.tproj/makehfs.c
+@@ -37,7 +37,9 @@
+ #endif
+ #include <sys/errno.h>
+ #include <sys/stat.h>
++#ifdef __GLIBC__
+ #include <sys/sysctl.h>
++#endif
+ #if !LINUX
+ #include <sys/vmmeter.h>
+ #endif
+@@ -2039,6 +2041,7 @@ getencodinghint(unsigned char *name)
+         if (getvfsbyname("hfs", &vfc) < 0)
+ 		goto error;
+ 
++#ifdef __GLIBC__
+         mib[0] = CTL_VFS;
+         mib[1] = vfc.vfc_typenum;
+         mib[2] = HFS_ENCODINGHINT;
+@@ -2046,6 +2049,7 @@ getencodinghint(unsigned char *name)
+ 	if (sysctl(mib, 3, &hint, &buflen, name, strlen((char *)name) + 1) < 0)
+  		goto error;
+ 	return (hint);
++#endif
+ error:
+ 	hint = GetDefaultEncoding();
+ 	return (0);
+@@ -2062,7 +2066,7 @@ void GenerateVolumeUUID(VolumeUUID *newV
+ 	clock_t uptime;
+ 	size_t datalen;
+ 	double sysloadavg[3];
+-#if !LINUX
++#if !LINUX && defined(__GLIBC__)
+ 	int sysdata;
+ 	int mib[2];
+ 	char sysctlstring[128];
+@@ -2080,7 +2084,7 @@ void GenerateVolumeUUID(VolumeUUID *newV
+ 		SHA1_Update(&context, &uptime, sizeof(uptime));
+ 		
+ 		/* The kernel's boot time: */
+-#if !LINUX
++#if !LINUX && defined(__GLIBC__)
+ 		mib[0] = CTL_KERN;
+ 		mib[1] = KERN_BOOTTIME;
+ 		datalen = sizeof(sysdata);
+@@ -2088,7 +2092,7 @@ void GenerateVolumeUUID(VolumeUUID *newV
+ 		SHA1_Update(&context, &sysdata, datalen);
+ #endif
+ 		/* The system's host id: */
+-#if !LINUX
++#if !LINUX && defined(__GLIBC__)
+ 		mib[0] = CTL_KERN;
+ 		mib[1] = KERN_HOSTID;
+ 		datalen = sizeof(sysdata);
+@@ -2096,7 +2100,7 @@ void GenerateVolumeUUID(VolumeUUID *newV
+ 		SHA1_Update(&context, &sysdata, datalen);
+ #endif
+ 		/* The system's host name: */
+-#if !LINUX
++#if !LINUX && defined(__GLIBC__)
+ 		mib[0] = CTL_KERN;
+ 		mib[1] = KERN_HOSTNAME;
+ 		datalen = sizeof(sysctlstring);
+@@ -2104,7 +2108,7 @@ void GenerateVolumeUUID(VolumeUUID *newV
+ 		SHA1_Update(&context, sysctlstring, datalen);
+ #endif
+ 		/* The running kernel's OS release string: */
+-#if !LINUX
++#if !LINUX && defined(__GLIBC__)
+ 		mib[0] = CTL_KERN;
+ 		mib[1] = KERN_OSRELEASE;
+ 		datalen = sizeof(sysctlstring);
+@@ -2112,7 +2116,7 @@ void GenerateVolumeUUID(VolumeUUID *newV
+ 		SHA1_Update(&context, sysctlstring, datalen);
+ #endif
+ 		/* The running kernel's version string: */
+-#if !LINUX
++#if !LINUX && defined(__GLIBC__)
+ 		mib[0] = CTL_KERN;
+ 		mib[1] = KERN_VERSION;
+ 		datalen = sizeof(sysctlstring);
+@@ -2127,7 +2131,7 @@ void GenerateVolumeUUID(VolumeUUID *newV
+ #endif
+ 
+ 		/* The system's VM statistics: */
+-#if !LINUX
++#if !LINUX && defined(__GLIBC__)
+ 		mib[0] = CTL_VM;
+ 		mib[1] = VM_METER;
+ 		datalen = sizeof(sysvmtotal);


### PR DESCRIPTION
Do not make use of sysctl in makehfs.c on non-glibc systems.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>