### PR TITLE
diffutils: fix fortify source compat

### DIFF
--- a/devel/diffutils/Makefile
+++ b/devel/diffutils/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2012 OpenWrt.org
+# Copyright (C) 2008-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=diffutils
 PKG_VERSION:=3.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/diffutils
@@ -36,7 +36,7 @@ endef
 
 CONFIGURE_VARS += \
 	ac_cv_func_mempcpy=n
-TARGET_CFLAGS += --std=c99
+TARGET_CFLAGS += --std=gnu99
 
 define Package/diffutils/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Compile with `-std=gnu99` instead of `-std=c99` to avoid redefining `__attribute__` in `src/system.h`.
    
Fixes the following error spotted by the buildbot:

    In file included from ../lib/stdio.h:43:0,
                     from cmp.c:22:
    .../staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-4.8-linaro_musl-1.1.10_eabi/include/fortify/stdio.h: In function 'snprintf':
    .../staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-4.8-linaro_musl-1.1.10_eabi/include/fortify/stdio.h:99:2: error: invalid use of '__builtin_va_arg_pack ()'
      return __orig_snprintf(__s, __n, __f, __builtin_va_arg_pack());
      ^

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>