### PR TITLE
boost: do not fail when no shared libs were build

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -226,16 +226,9 @@ define Build/InstallDev
 		$(1)/usr/include/boost/ \
 		# copies _all_ header files - independent of <--with-library>-argument above
 
-	if [ -d $(PKG_INSTALL_DIR)/lib ]; then \
-		$(INSTALL_DIR) \
-			$(1)/usr/lib; \
-		$(CP) \
-			$(PKG_INSTALL_DIR)/lib/*.a \
-			$(1)/usr/lib/; \
-		$(CP) \
-			$(PKG_INSTALL_DIR)/lib/*.so* \
-			$(1)/usr/lib/; \
-	fi
+	$(INSTALL_DIR) $(1)/usr/lib
+	-$(CP) $(PKG_INSTALL_DIR)/lib/*.a $(1)/usr/lib/
+	-$(CP) $(PKG_INSTALL_DIR)/lib/*.so* $(1)/usr/lib/
 endef
 
 define Host/Install


### PR DESCRIPTION
When only boost is selected without any specific boost library no *.so
file will be build and the InstallDev part is failing. Instead of
checking if there is a lib directory just try to copy the libs and do
not fail in case of an error.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>