### PR TITLE
iotivity: add IoTivity

### DIFF
--- a/net/iotivity/Makefile
+++ b/net/iotivity/Makefile
@@ -1,0 +1,216 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=iotivity
+PKG_VERSION:=0.9.1
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://gerrit.iotivity.org/gerrit/iotivity
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=0.9.1
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_MIRROR_MD5SUM:=
+PKG_USE_MIPS16:=0
+
+PKG_MAINTAINER:=Hauke Mehrtens <hauke.mehrtens@lantiq.com>
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE.md
+
+PKG_BUILD_DEPENDS:= +boost +libexpat
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/scons.mk
+
+
+define Package/iotivity
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:= +libpthread +librt +libstdcpp +libuuid
+  TITLE:=IoTivity Library
+  URL:=https://www.iotivity.org
+endef
+
+define Package/iotivity/description
+    IoTivity is a framework for the Internet of Things based on the
+    Open Interconnect Consortium Specification.
+endef
+
+
+define Package/iotivity-things-manager-lib
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=iotivity
+  TITLE:=IoTivity things manager lib
+  URL:=https://www.iotivity.org
+endef
+
+define Package/iotivity-things-manager-lib/description
+    IoTivity things-manager lib
+endef
+
+
+define Package/iotivity-plugin-manager-lib
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=iotivity +libexpat
+  TITLE:=IoTivity plugin manager lib
+  URL:=https://www.iotivity.org
+endef
+
+define Package/iotivity-plugin-manager-lib/description
+    IoTivity plugin manager lib
+endef
+
+
+define Package/iotivity-mqttclient
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=iotivity +iotivity-plugin-manager-lib +boost +boost-system
+  TITLE:=IoTivity mqtt Client
+  URL:=https://www.iotivity.org
+endef
+
+define Package/iotivity-mqttclient/description
+    IoTivity mqtt Client
+endef
+
+
+define Package/iotivity-oic-middle
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=iotivity
+  TITLE:=IoTivity OIC Middle
+  URL:=https://www.iotivity.org
+endef
+
+define Package/iotivity-oic-middle/description
+    IoTivity OIC Middle
+endef
+
+
+define Package/iotivity-things-manager
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=iotivity +iotivity-things-manager-lib
+  TITLE:=IoTivity things manager
+  URL:=https://www.iotivity.org
+endef
+
+define Package/iotivity-things-manager/description
+    IoTivity things manager
+endef
+
+
+define Package/iotivity-example-garage
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=iotivity
+  TITLE:=IoTivity Garage example
+  URL:=https://www.iotivity.org
+endef
+
+define Package/iotivity-example-garage/description
+    An IoTivity example application
+endef
+
+
+PKG_CEREAL_NAME:=cereal
+PKG_CEREAL_VERSION:=7121e91e6ab8c3e6a6516d9d9c3e6804e6f65245
+PKG_CEREAL_SOURCE:=$(PKG_CEREAL_NAME)-$(PKG_CEREAL_VERSION).tar.bz2
+PKG_CEREAL_PROTO:=git
+PKG_CEREAL_SOURCE_URL:=https://github.com/USCiLab/cereal.git
+PKG_CEREAL_SUBDIR:=$(PKG_CEREAL_NAME)
+#PKG_CEREAL_MIRROR_MD5SUM:=?
+
+define Download/iotivity-cereal
+  FILE:=$(PKG_CEREAL_SOURCE)
+  URL:=$(PKG_CEREAL_SOURCE_URL)
+  PROTO:=$(PKG_CEREAL_PROTO)
+  VERSION:=$(PKG_CEREAL_VERSION)
+  SUBDIR:=$(PKG_CEREAL_SUBDIR)
+  #MIRROR_MD5SUM:=$(PKG_CEREAL_MIRROR_MD5SUM)
+endef
+$(eval $(call Download,iotivity-cereal))
+
+
+SCONS_OPTIONS += \
+	TARGET_OS=linux \
+	TARGET_TRANSPORT=ALL \
+	TARGET_ARCH=$(ARCH) \
+	STAGING_DIR=$(STAGING_DIR) \
+	mqttclient examples samples libTGMSDK ConServerApp ConClientApp BootstrapServerApp
+
+ifneq ($(findstring c,$(OPENWRT_VERBOSE)),)
+  SCONS_OPTIONS += VERBOSE=true
+endif
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(TAR) -C $(PKG_BUILD_DIR)/extlibs/cereal -xjf $(DL_DIR)/$(PKG_CEREAL_SOURCE)
+endef
+
+define Build/Configure
+	(cd $(PKG_BUILD_DIR); \
+		$(SCONS_VARS) \
+		scons \
+			$(SCONS_OPTIONS) \
+	)
+endef
+
+
+define Package/iotivity/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/out/linux/$(ARCH)/release/liboc.so $(1)/usr/lib/liboc.so
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/out/linux/$(ARCH)/release/liboc_logger.so $(1)/usr/lib/liboc_logger.so
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/out/linux/$(ARCH)/release/liboctbstack.so $(1)/usr/lib/liboctbstack.so
+endef
+
+define Package/iotivity-things-manager-lib/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/out/linux/$(ARCH)/release/libTGMSDKLibrary.so $(1)/usr/lib/libTGMSDKLibrary.so
+endef
+
+define Package/iotivity-plugin-manager-lib/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/out/linux/$(ARCH)/release/libpmimpl.so $(1)/usr/lib/libpmimpl.so
+endef
+
+define Package/iotivity-mqttclient/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/out/linux/$(ARCH)/release/service/protocol-plugin/sample-app/linux/mqtt/mqttclient $(1)/usr/bin/mqttclient
+endef
+
+define Package/iotivity-oic-middle/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/out/linux/$(ARCH)/release/examples/OICMiddle/OICMiddle $(1)/usr/bin/OICMiddle
+endef
+
+define Package/iotivity-things-manager/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/out/linux/$(ARCH)/release/service/things-manager/sampleapp/linux/configuration/bootstrapserver $(1)/usr/bin/bootstrapserver
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/out/linux/$(ARCH)/release/service/things-manager/sampleapp/linux/configuration/con-server $(1)/usr/bin/con-server
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/out/linux/$(ARCH)/release/service/things-manager/sampleapp/linux/configuration/con-client $(1)/usr/bin/con-client
+endef
+
+define Package/iotivity-example-garage/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/out/linux/$(ARCH)/release/resource/examples/garageclient $(1)/usr/bin/garageclient
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/out/linux/$(ARCH)/release/resource/examples/garageserver $(1)/usr/bin/garageserver
+endef
+
+
+$(eval $(call BuildPackage,iotivity))
+$(eval $(call BuildPackage,iotivity-things-manager-lib))
+$(eval $(call BuildPackage,iotivity-plugin-manager-lib))
+$(eval $(call BuildPackage,iotivity-mqttclient))
+$(eval $(call BuildPackage,iotivity-oic-middle))
+$(eval $(call BuildPackage,iotivity-things-manager))
+$(eval $(call BuildPackage,iotivity-example-garage))

--- a/net/iotivity/patches/001-no_unit_test.patch
+++ b/net/iotivity/patches/001-no_unit_test.patch
@@ -1,0 +1,11 @@
+--- a/resource/SConscript
++++ b/resource/SConscript
+@@ -61,7 +61,7 @@ if target_os == 'linux':
+ 	SConscript('csdk/stack/samples/linux/secure/SConscript')
+ 
+ 	# Build C/C++ unit tests
+-	SConscript('unit_tests.scons')
++	# SConscript('unit_tests.scons')
+ 
+ elif target_os == 'darwin':
+ 	# Build linux samples for now.

--- a/net/iotivity/patches/002-do-not-chck-for-boost.patch
+++ b/net/iotivity/patches/002-do-not-chck-for-boost.patch
@@ -1,0 +1,29 @@
+From 51e26e002aa043435f94ac0f071066090d5c2de8 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Mon, 22 Jun 2015 20:23:36 +0200
+Subject: [PATCH 5/5] do not chck for boost
+
+Boost is not needed for every package just for some.
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ service/third_party_libs.scons | 8 --------
+ 1 file changed, 8 deletions(-)
+
+--- a/service/third_party_libs.scons
++++ b/service/third_party_libs.scons
+@@ -49,14 +49,6 @@ if target_os in ['linux', 'tizen']:
+ 
+ 		conf = Configure(lib_env)
+ 
+-		if target_os not in ['tizen'] and not conf.CheckLib('boost_thread', language='C++'):
+-			print 'Did not find boost_thread, exiting!'
+-			Exit(1)
+-
+-		if target_os not in ['tizen'] and not conf.CheckLib('boost_system', language='C++'):
+-			print 'Did not find boost_system, exiting!'
+-			Exit(1)
+-
+ 		lib_env = conf.Finish()
+ 
+ ######################################################################

--- a/net/iotivity/patches/004-use-env.patch
+++ b/net/iotivity/patches/004-use-env.patch
@@ -1,0 +1,38 @@
+From 884e831ed07607097614276f6bbf192993228100 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke.mehrtens@lantiq.com>
+Date: Tue, 2 Jun 2015 11:08:17 +0200
+Subject: [PATCH 3/4] 004-use-env.patch
+
+---
+ build_common/SConscript | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+--- a/build_common/SConscript
++++ b/build_common/SConscript
+@@ -106,6 +106,26 @@ tc_set_msg = '''
+ * cause inexplicable errors.                                                  *
+ *******************************************************************************
+ '''
++env['ENV'] = os.environ
++if 'CC' in os.environ:
++	env['CC'] = Split(os.environ['CC'])
++	print "using CC from enviroment: %s" % env['CC']
++if 'CXX' in os.environ:
++	env['CXX'] = Split(os.environ['CXX'])
++	print "using CXX from enviroment: %s" % env['CXX']
++if 'CFLAGS' in os.environ:
++	env['CFLAGS'] = Split(os.environ['CFLAGS'])
++	print "using CFLAGS from enviroment: %s" % env['CFLAGS']
++if 'CXXFLAGS' in os.environ:
++	env['CXXFLAGS'] = Split(os.environ['CXXFLAGS'])
++	print "using CXXFLAGS from enviroment: %s" % env['CXXFLAGS']
++if 'CPPFLAGS' in os.environ:
++	env['CPPFLAGS'] = Split(os.environ['CPPFLAGS'])
++	print "using CPPFLAGS from enviroment: %s" % env['CPPFLAGS']
++if 'LDFLAGS' in os.environ:
++	env['LINKFLAGS'] = Split(os.environ['LDFLAGS'])
++	print "using LDFLAGS/LINKFLAGS from enviroment: %s" % env['LINKFLAGS']
++
+ if env.get('VERBOSE') == False:
+ 	env['CCCOMSTR'] = "Compiling $TARGET"
+ 	env['CXXCOMSTR'] = "Compiling $TARGET"

--- a/net/iotivity/patches/010-libcoap-fix-big-endian-problems.patch
+++ b/net/iotivity/patches/010-libcoap-fix-big-endian-problems.patch
@@ -1,0 +1,32 @@
+From 62c0a14ccd333d0e55fc431f151253a72a2836d0 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke.mehrtens@lantiq.com>
+Date: Mon, 8 Jun 2015 21:57:52 +0200
+Subject: [PATCH] libcoap: fix big endian problems
+
+When this is build for a big endian Linux system WORDS_BIGENDIAN was
+not be set. This patch sets it correctly so it will not generate broken
+code on big endian systems.
+This was tested on MIPS BE 32 Bit.
+
+Change-Id: I59dd07d8020c553318e2aa43894a2185fe9b9286
+Signed-off-by: Hauke Mehrtens <hauke.mehrtens@lantiq.com>
+Reviewed-on: https://gerrit.iotivity.org/gerrit/1219
+Tested-by: jenkins-iotivity <jenkins-iotivity@opendaylight.org>
+Reviewed-by: Erich Keane <erich.keane@intel.com>
+---
+ resource/csdk/connectivity/lib/libcoap-4.1.1/config.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/resource/csdk/connectivity/lib/libcoap-4.1.1/config.h
++++ b/resource/csdk/connectivity/lib/libcoap-4.1.1/config.h
+@@ -135,8 +135,8 @@
+ #  define WORDS_BIGENDIAN 1
+ # endif
+ #else
+-# ifndef WORDS_BIGENDIAN
+-/* #  undef WORDS_BIGENDIAN */
++# if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
++#  define WORDS_BIGENDIAN 1
+ # endif
+ #endif
+ 

--- a/net/iotivity/patches/011-cdsk-fix-big-endian-problem.patch
+++ b/net/iotivity/patches/011-cdsk-fix-big-endian-problem.patch
@@ -1,0 +1,35 @@
+From 7189bc088f558945972d82a9a3427001cb20000a Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke.mehrtens@lantiq.com>
+Date: Mon, 8 Jun 2015 22:03:19 +0200
+Subject: [PATCH] cdsk: fix big endian problem
+
+Without this patch the client will endianes swap the port number when
+sending the detailed request after it got the answer for his multicast
+get. Use the same method for storing the port number in the address
+array in ever part of the code and do not use memcpy and manual
+bytewise coping mixed over the code. memcpy was used once and byte wise
+copy was used twice so I choose the majority.
+This was tested on MIPS BE 32 Bit.
+
+Change-Id: Ib486171987004d10209d2bbf6b1d9ada75235651
+Signed-off-by: Hauke Mehrtens <hauke.mehrtens@lantiq.com>
+Reviewed-on: https://gerrit.iotivity.org/gerrit/1220
+Tested-by: jenkins-iotivity <jenkins-iotivity@opendaylight.org>
+Reviewed-by: Doug Hudson <douglas.hudson@intel.com>
+Reviewed-by: Erich Keane <erich.keane@intel.com>
+---
+ resource/csdk/stack/src/ocstack.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/resource/csdk/stack/src/ocstack.c
++++ b/resource/csdk/stack/src/ocstack.c
+@@ -723,7 +723,8 @@ OCStackResult UpdateResponseAddr(OCDevAd
+         address->addr[i] = atoi(tok);
+     }
+ 
+-    memcpy(&address->addr[4], &endPoint->addressInfo.IP.port, sizeof(uint16_t));
++    address->addr[4] = (uint8_t)endPoint->addressInfo.IP.port;
++    address->addr[5] = (uint8_t)(endPoint->addressInfo.IP.port >> 8);
+     ret = OC_STACK_OK;
+ 
+ exit:

--- a/net/iotivity/patches/020-Do-not-set-architecture-specific-flags.patch
+++ b/net/iotivity/patches/020-Do-not-set-architecture-specific-flags.patch
@@ -1,0 +1,60 @@
+From 980ef34a085f654e74c9896e8143e6f970049b6c Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Mon, 22 Jun 2015 19:39:58 +0200
+Subject: [PATCH 3/5] Do not set architecture specific flags
+
+Setting architecture specific flags causes problems when you want to
+build something which is not covered by these.
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ build_common/linux/SConscript                     | 20 --------------------
+ resource/csdk/connectivity/build/linux/SConscript | 20 --------------------
+ 2 files changed, 40 deletions(-)
+
+--- a/build_common/linux/SConscript
++++ b/build_common/linux/SConscript
+@@ -24,20 +24,3 @@ env.AppendUnique(LINKFLAGS = ['-ldl', '-
+ 
+ # Set arch flags
+ target_arch = env.get('TARGET_ARCH')
+-if target_arch in ['x86']:
+-	env.AppendUnique(CCFLAGS = ['-m32'])
+-	env.AppendUnique(LINKFLAGS = ['-m32'])
+-elif target_arch in ['x86_64']:
+-	env.AppendUnique(CCFLAGS = ['-m64'])
+-	env.AppendUnique(LINKFLAGS = ['-m64'])
+-elif target_arch.find('v7a-hard') > 0:
+-	env.AppendUnique(CPPFLAGS = ['-march=armv7-a'])
+-	env.AppendUnique(CPPFLAGS = ['-mfloat-abi=hard'])
+-	env.AppendUnique(CCFLAGS = ['-mfloat-abi=hard'])
+-	env.AppendUnique(LINKFLAGS = ['-mfloat-abi=hard'])
+-elif target_arch.find('v7a') > 0:
+-	env.AppendUnique(CPPFLAGS = ['-march=armv7-a'])
+-elif target_arch.find('arm64') >= 0:
+-	env.AppendUnique(CPPFLAGS = ['-march=armv8-a'])
+-else:
+-	env.AppendUnique(CPPFLAGS = ['-march=armv5te'])
+--- a/resource/csdk/connectivity/build/linux/SConscript
++++ b/resource/csdk/connectivity/build/linux/SConscript
+@@ -22,20 +22,3 @@ env.AppendUnique(LINKFLAGS = ['-ldl', '-
+ 
+ # Set arch flags
+ target_arch = env.get('TARGET_ARCH')
+-if target_arch in ['x86']:
+-	env.AppendUnique(CCFLAGS = ['-m32'])
+-	env.AppendUnique(LINKFLAGS = ['-m32'])
+-elif target_arch in ['x86_64']:
+-	env.AppendUnique(CCFLAGS = ['-m64'])
+-	env.AppendUnique(LINKFLAGS = ['-m64'])
+-elif target_arch.find('v7a-hard') > 0:
+-	env.AppendUnique(CPPFLAGS = ['-march=armv7-a'])
+-	env.AppendUnique(CPPFLAGS = ['-mfloat-abi=hard'])
+-	env.AppendUnique(CCFLAGS = ['-mfloat-abi=hard'])
+-	env.AppendUnique(LINKFLAGS = ['-mfloat-abi=hard'])
+-elif target_arch.find('v7a') > 0:
+-	env.AppendUnique(CPPFLAGS = ['-march=armv7-a'])
+-elif target_arch.find('arm64') > 0:
+-	env.AppendUnique(CPPFLAGS = ['-march=armv8-a'])
+-else:
+-	env.AppendUnique(CPPFLAGS = ['-march=armv5te'])

--- a/net/iotivity/patches/021-add-some-more-architectures.patch
+++ b/net/iotivity/patches/021-add-some-more-architectures.patch
@@ -1,0 +1,35 @@
+From f78ba209b14908bf2b6197293e1f9e3458ddba8e Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Mon, 22 Jun 2015 19:59:47 +0200
+Subject: [PATCH 4/5] add some more architectures
+
+This does not scale and this check should be removed.
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ build_common/SConscript                     | 2 +-
+ resource/csdk/connectivity/build/SConscript | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/build_common/SConscript
++++ b/build_common/SConscript
+@@ -14,7 +14,7 @@ host_target_map = {
+ 
+ # Map of os and allowed archs (os: allowed archs)
+ os_arch_map = {
+-		'linux': ['x86', 'x86_64', 'arm', 'arm64'],
++		'linux': ['x86', 'x86_64', 'arm', 'arm64', 'mips', 'mipsel', 'mips64', 'mips64el', 'i386', 'powerpc', 'sparc', 'aarch64'],
+ 		'tizen': ['x86', 'x86_64', 'arm', 'arm64', 'armeabi-v7a'],
+ 		'android': ['x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'armeabi-v7a-hard', 'arm64-v8a'],
+ 		'windows': ['x86', 'amd64', 'arm'],
+--- a/resource/csdk/connectivity/build/SConscript
++++ b/resource/csdk/connectivity/build/SConscript
+@@ -14,7 +14,7 @@ host_target_map = {
+ 
+ # Map of os and allowed archs (os: allowed archs)
+ os_arch_map = {
+-		'linux': ['x86', 'x86_64', 'arm', 'arm64'],
++		'linux': ['x86', 'x86_64', 'arm', 'arm64', 'mips', 'mipsel', 'mips64', 'mips64el', 'i386', 'powerpc', 'sparc', 'aarch64'],
+ 		'tizen': ['x86', 'x86_64', 'arm', 'arm64'],
+ 		'android': ['x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'armeabi-v7a-hard', 'arm64-v8a'],
+ 		'windows': ['x86', 'amd64', 'arm'],

--- a/net/iotivity/patches/030-fix-missing-lib.patch
+++ b/net/iotivity/patches/030-fix-missing-lib.patch
@@ -1,0 +1,11 @@
+--- a/service/protocol-plugin/sample-app/linux/SConscript
++++ b/service/protocol-plugin/sample-app/linux/SConscript
+@@ -41,7 +41,7 @@ if target_os not in ['windows', 'winrt']
+ 
+ sample_env.AppendUnique(LIBS = ['oc', 'oc_logger', 'octbstack',
+                                 'connectivity_abstraction', 'coap',
+-                                'ppm', 'pmimpl', 'dl'])
++                                'ppm', 'boost_system', 'pmimpl', 'dl'])
+ 
+ if env.get('SECURED') == '1':
+     sample_env.AppendUnique(LIBS = ['tinydtls'])

--- a/net/iotivity/patches/040-fix-things-manager.patch
+++ b/net/iotivity/patches/040-fix-things-manager.patch
@@ -1,0 +1,11 @@
+--- a/service/things-manager/sampleapp/linux/configuration/SConscript
++++ b/service/things-manager/sampleapp/linux/configuration/SConscript
+@@ -57,7 +57,7 @@ conserver = linux_sample_env.Program('co
+ conclient = linux_sample_env.Program('con-client', 'con-client.cpp')
+ bootstrapserver = linux_sample_env.Program('bootstrapserver', 'bootstrapserver.cpp')
+ Alias("ConServerApp", conserver)
+-Alias("ConCleintApp", conclient)
++Alias("ConClientApp", conclient)
+ Alias("BootstrapServerApp", bootstrapserver)
+ env.AppendTarget('ConServerApp')
+ env.AppendTarget('ConClientApp')

--- a/net/iotivity/patches/050-fix-OICMidle.patch
+++ b/net/iotivity/patches/050-fix-OICMidle.patch
@@ -1,0 +1,14 @@
+--- a/resource/csdk/stack/include/octypes.h
++++ b/resource/csdk/stack/include/octypes.h
+@@ -35,9 +35,9 @@ extern "C" {
+ //Don't want to expose to application layer that lower level stack is using CoAP.
+ 
+ /// Authority + URI string to prefix well known queries
+-#define OC_WELL_KNOWN_QUERY                  "224.0.1.187:5683/oc/core"
++#define OC_WELL_KNOWN_QUERY                  "/oc/core"
+ #define OC_MULTICAST_DISCOVERY_URI           "/oc/core"
+-#define OC_EXPLICIT_DEVICE_DISCOVERY_URI     "224.0.1.187:5683/oc/core/d?rt=core.led"
++#define OC_EXPLICIT_DEVICE_DISCOVERY_URI     "/oc/core/d?rt=core.led"
+ /// Multicast address and port string to prefix multicast queries
+ #define OC_MULTICAST_PREFIX                  "224.0.1.187:5683"
+ /// IP Multicast address to use for multicast requests


### PR DESCRIPTION
IoTivity is a Internet of Things framework implementing the Open
Interconnect Consortium Specification.

The current version of IoTivity is still in heavy development and does
not support all its intended features, but I still want to add it to
the packages feed to make it easier for others to extend the OpenWrt
support.

Signed-off-by: Hauke Mehrtens <hauke.mehrtens@lantiq.com>
---
I am still not sure if it is the right time to get it into the packages feed, as it is not really usable for an end user and all APIs will probably change soon. This is only interesting for people wanting to develop on this.