### PR TITLE
check: fix fortify source compatibility

### DIFF
--- a/libs/check/Makefile
+++ b/libs/check/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=check
 PKG_VERSION:=0.9.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/check
@@ -40,6 +40,9 @@ define Package/check/description
 endef
 
 TARGET_CFLAGS += $(FPIC)
+CONFIGURE_VARS += \
+	hw_cv_func_snprintf_c99=yes \
+	hw_cv_func_vsnprintf_c99=yes \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
Let `./configure` assume C99 compliant `snprintf()` and `vsnprintf()` functions
by passing the required cache variables via `CONFIGURE_VARS`.

Fixes fortify-source related undeclared function errors when compiling the
`tests/` directory.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>