### PR TITLE
ctorrent: fix musl compatibility

### DIFF
--- a/net/ctorrent/Makefile
+++ b/net/ctorrent/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2008 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ctorrent
 PKG_VERSION:=dnh3.3.2
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/dtorrent \

--- a/net/ctorrent/patches/200-musl-compat.patch
+++ b/net/ctorrent/patches/200-musl-compat.patch
@@ -1,0 +1,10 @@
+--- a/compat.c
++++ b/compat.c
+@@ -63,6 +63,7 @@ int snprintf(char *str, size_t size, con
+ 
+ #ifndef HAVE_STRNSTR
+ #include <string.h>
++#include <sys/types.h>
+ /* FUNCTION PROGRAMER: Siberiaic Sang */
+ char *strnstr(const char *haystack, const char *needle, size_t haystacklen)
+ {


### PR DESCRIPTION
Add missing `sys/types.h` include to `strnstr()` replacement code in
`compat.c` in order to declare `ssize_t` type under musl.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>