### PR TITLE
ctorrent-svn: fix musl compatibility

### DIFF
--- a/net/ctorrent-svn/Makefile
+++ b/net/ctorrent-svn/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2008 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ctorrent-svn
 PKG_REV:=322
 PKG_VERSION:=r$(PKG_REV)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://svn.code.sf.net/p/dtorrent/code/dtorrent/trunk

--- a/net/ctorrent-svn/patches/400-musl-compat.patch
+++ b/net/ctorrent-svn/patches/400-musl-compat.patch
@@ -1,0 +1,10 @@
+--- a/compat.c
++++ b/compat.c
+@@ -51,6 +51,7 @@ int snprintf(char *str, size_t size, con
+ 
+ #ifndef HAVE_STRNSTR
+ #include <string.h>
++#include <sys/types.h>
+ /* FUNCTION PROGRAMER: Siberiaic Sang */
+ char *strnstr(const char *haystack, const char *needle, size_t haystacklen)
+ {


### PR DESCRIPTION
Add missing `sys/types.h` include to `strnstr()` replacement code in
`compat.c` in order to declare `ssize_t` type under musl.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>