### PR TITLE
davfs2: fix musl compatibility

### DIFF
--- a/net/davfs2/Makefile
+++ b/net/davfs2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=davfs2
 PKG_VERSION:=1.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.savannah.gnu.org/releases/davfs2/

--- a/net/davfs2/patches/100-musl-compat.patch
+++ b/net/davfs2/patches/100-musl-compat.patch
@@ -1,0 +1,194 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -42,7 +42,7 @@ DAV_CHECK_NEON
+ # Checks for header files.
+ AC_HEADER_DIRENT
+ AC_HEADER_STDC
+-AC_CHECK_HEADERS([fcntl.h libintl.h langinfo.h limits.h locale.h mntent.h stddef.h stdint.h stdlib.h string.h sys/file.h sys/mount.h sys/time.h syslog.h termios.h unistd.h utime.h])
++AC_CHECK_HEADERS([error.h fcntl.h libintl.h langinfo.h limits.h locale.h mntent.h stddef.h stdint.h stdlib.h string.h sys/file.h sys/mount.h sys/time.h sys/select.h sys/types.h syslog.h termios.h unistd.h utime.h])
+ 
+ # Checks for typedefs, structures, and compiler characteristics.
+ AC_C_CONST
+@@ -78,7 +78,7 @@ AC_FUNC_SELECT_ARGTYPES
+ AC_FUNC_STRFTIME
+ AC_FUNC_STAT
+ AC_FUNC_UTIME_NULL
+-AC_CHECK_FUNCS([endpwent ftruncate getmntent memset mkdir nl_langinfo rpmatch select setlocale strcasecmp strchr strdup strerror strpbrk strrchr strstr strtol strtoull utime])
++AC_CHECK_FUNCS([endpwent ftruncate getmntent memset mkdir nl_langinfo rpmatch select setlocale strcasecmp strchr strdup strerror strpbrk strrchr strstr strtol strtoull utime canonicalize_file_name fopencookie])
+ 
+ # Misc.
+ DAV_DEFAULTS
+--- a/src/cache.c
++++ b/src/cache.c
+@@ -19,12 +19,12 @@
+ 
+ 
+ #include "config.h"
++#include "compat.h"
+ 
+ #ifdef HAVE_DIRENT_H
+ #include <dirent.h>
+ #endif
+ #include <errno.h>
+-#include <error.h>
+ #ifdef HAVE_FCNTL_H
+ #include <fcntl.h>
+ #endif
+--- a/src/dav_fuse.c
++++ b/src/dav_fuse.c
+@@ -47,6 +47,9 @@
+ #ifdef HAVE_SYS_STAT_H
+ #include <sys/stat.h>
+ #endif
++#ifdef HAVE_SYS_SELECT_H
++#include <sys/select.h>
++#endif
+ 
+ #include "defaults.h"
+ #include "mount_davfs.h"
+--- a/src/kernel_interface.c
++++ b/src/kernel_interface.c
+@@ -19,8 +19,8 @@
+ 
+ 
+ #include "config.h"
++#include "compat.h"
+ 
+-#include <error.h>
+ #ifdef HAVE_FCNTL_H
+ #include <fcntl.h>
+ #endif
+@@ -51,6 +51,9 @@
+ #ifdef HAVE_SYS_STAT_H
+ #include <sys/stat.h>
+ #endif
++#ifdef HAVE_SYS_TYPES_H
++#include <sys/types.h>
++#endif
+ #include <sys/wait.h>
+ 
+ #include "defaults.h"
+--- a/src/mount_davfs.c
++++ b/src/mount_davfs.c
+@@ -19,10 +19,10 @@
+ 
+ 
+ #include "config.h"
++#include "compat.h"
+ 
+ #include <ctype.h>
+ #include <errno.h>
+-#include <error.h>
+ #ifdef HAVE_FCNTL_H
+ #include <fcntl.h>
+ #endif
+--- a/src/umount_davfs.c
++++ b/src/umount_davfs.c
+@@ -19,8 +19,8 @@
+ 
+ 
+ #include "config.h"
++#include "compat.h"
+ 
+-#include <error.h>
+ #include <errno.h>
+ #include <getopt.h>
+ #ifdef HAVE_LIBINTL_H
+--- a/src/webdav.c
++++ b/src/webdav.c
+@@ -19,9 +19,9 @@
+ 
+ 
+ #include "config.h"
++#include "compat.h"
+ 
+ #include <errno.h>
+-#include <error.h>
+ #ifdef HAVE_FCNTL_H
+ #include <fcntl.h>
+ #endif
+@@ -368,6 +368,7 @@ dav_init_webdav(const dav_args *args)
+         error(EXIT_FAILURE, errno, _("socket library initialization failed"));
+ 
+     if (args->neon_debug & ~NE_DBG_HTTPPLAIN) {
++#ifdef HAVE_FOPENCOOKIE
+         char *buf = malloc(log_bufsize);
+         cookie_io_functions_t *log_func = malloc(sizeof(cookie_io_functions_t));
+         if (!log_func) abort();
+@@ -380,6 +381,9 @@ dav_init_webdav(const dav_args *args)
+             error(EXIT_FAILURE, errno,
+                   _("can't open stream to log neon-messages"));
+         ne_debug_init(log_stream, args->neon_debug);
++#else
++	error(EXIT_FAILURE, 0, "neon debugging unsupported");
++#endif
+     }
+ 
+     session = ne_session_create(args->scheme, args->host, args->port);
+--- /dev/null
++++ b/src/compat.h
+@@ -0,0 +1,64 @@
++#ifndef _COMPAT_H
++#define _COMPAT_H
++
++#ifndef _PATH_MOUNTED
++# define _PATH_MOUNTED "/proc/mounts"
++#endif
++
++#ifndef _PATH_MNTTAB
++# define _PATH_MNTTAB "/etc/fstab"
++#endif
++
++#ifdef HAVE_ERROR_H
++# include <error.h>
++#else
++# include <stdio.h>
++# include <stdarg.h>
++# include <stdlib.h>
++# include <string.h>
++static void error_at_line(int status, int errnum, const char *filename,
++                          unsigned int linenum, const char *format, ...)
++{
++	va_list ap;
++
++	fflush(stdout);
++
++	if (filename != NULL)
++		fprintf(stderr, "%s:%u: ", filename, linenum);
++
++	va_start(ap, format);
++	vfprintf(stderr, format, ap);
++	va_end(ap);
++
++	if (errnum != 0)
++		fprintf(stderr, ": %s", strerror(errnum));
++
++	fprintf(stderr, "\n");
++
++	if (status != 0)
++		exit(status);
++}
++
++#define error(status, errnum, format...) \
++	error_at_line(status, errnum, NULL, 0, format)
++
++#endif /* HAVE_ERROR_H */
++
++#ifndef HAVE_CANONICALIZE_FILE_NAME
++#include <limits.h>
++#include <string.h>
++#include <stdlib.h>
++static char * canonicalize_file_name(const char *path)
++{
++	char buf[PATH_MAX] = { };
++
++	snprintf(buf, sizeof(buf) - 1, "%s", path);
++
++	if (!realpath(path, buf))
++		return NULL;
++
++	return strdup(buf);
++}
++#endif
++
++#endif /* _COMPAT_H */


### PR DESCRIPTION
 - Add header tests for `error.h`, `sys/types.h` and `sys/select.h`
 - Add function tests for `canonicalize_file_name()` and `fopencookie()`
 - Add `compat.h` header to provide replacements for `error()`,
   `error_at_line()` and `canonicalize_file_name()` as well as the
   `_PATH_MOUNTED` and `_PATH_MNTTAB` defines
 - Add missing includes for `sys/select.h` and `sys/types.h`
 - Disable libneon debugging if no `fopencookie()` implementation is
   available

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>