### PR TITLE
python: fix patch removing multiarch support for host python

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -12,7 +12,7 @@ include ./files/python-package.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.python.org/ftp/python/$(PKG_VERSION)

--- a/lang/python/patches/006-remove-debian-multiarch-support.patch
+++ b/lang/python/patches/006-remove-debian-multiarch-support.patch
@@ -1,12 +1,14 @@
 diff --git a/setup.py b/setup.py
-index 7868b7b..9ae0ef2 100644
+index 1d1ae72..511aed5 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -444,7 +444,6 @@ class PyBuildExt(build_ext):
+@@ -444,7 +444,8 @@ class PyBuildExt(build_ext):
              add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
          if cross_compiling:
              self.add_gcc_paths()
 -        self.add_multiarch_paths()
++        else:
++            self.add_multiarch_paths()
  
          # Add paths specified in the environment variables LDFLAGS and
          # CPPFLAGS for header and library files.


### PR DESCRIPTION
Patch removing multiarch paths from build should be applied only when Python is built for target, but not for host. When the paths are removed during host build, host python throws some ugly errors when importing some hashlib modules. Also it reports that modules crypt and nis failed to build (tested on Ubuntu 14.04 host).

This patch fixes #1525. It should not affect target build (tested on mpc85xx device), but maybe @enigmagroup should review it whether it does not introduce regression of #756 for them?

Signed-off-by: Jan Čermák <jan.cermak@nic.cz>