### PR TITLE
tvheadend: add new package

### DIFF
--- a/multimedia/tvheadend/Config.in
+++ b/multimedia/tvheadend/Config.in
@@ -1,0 +1,17 @@
+config TVHEADEND_CWC_SUPPORT
+	bool "NewCamd support"
+	default y
+
+config TVHEADEND_LINUXDVB_SUPPORT
+	bool "Linux DVB support"
+	default y
+
+config TVHEADEND_DVBSCAN_SUPPORT
+	bool "Fetch DVB-scan data"
+	depends on TVHEADEND_LINUXDVB_SUPPORT
+	default TVHEADEND_LINUXDVB_SUPPORT
+
+config TVHEADEND_AVAHI_SUPPORT
+	bool "Avahi client support"
+	select PACKAGE_libavahi-client
+	default n

--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -1,0 +1,97 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tvheadend
+PKG_VERSION:=4.0.5
+PKG_RELEASE:=1
+
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/tvheadend/tvheadend.git
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+
+PKG_LICENSE:=GPL-3.0
+PKG_LICENSE_FILES:=LICENSE.md
+
+PKG_FIXUP:=autoreconf
+
+PKG_USE_MIPS16:=0
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/tvheadend
+  SECTION:=multimedia
+  CATEGORY:=Multimedia
+  TITLE:=Tvheadend is a TV streaming server for Linux
+  DEPENDS:=+libopenssl +librt +zlib +TVHEADEND_AVAHI_SUPPORT:libavahi-client
+  URL:=https://tvheadend.org
+  MAINTAINER:=Jan Čermák <jan.cermak@nic.cz>
+endef
+
+define Package/tvheadend/description
+  Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android
+  supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, IPTV, SAT>IP and HDHomeRun as input sources.
+
+  Tvheadend offers the HTTP (VLC, MPlayer), HTSP (Kodi, Movian) and SAT>IP streaming.
+endef
+
+define Package/tvheadend/config
+  menu "Configuration"
+  depends on PACKAGE_tvheadend
+  source "$(SOURCE)/Config.in"
+  endmenu
+endef
+
+ifeq ($(CONFIG_TVHEADEND_CWC_SUPPORT),)
+  CONFIGURE_ARGS += --disable-cwc
+endif
+
+ifeq ($(CONFIG_TVHEADEND_LINUXDVB_SUPPORT),)
+  CONFIGURE_ARGS += --disable-linuxdvb
+endif
+
+ifeq ($(CONFIG_TVHEADEND_DVBSCAN_SUPPORT),)
+  CONFIGURE_ARGS += --disable-dvbscan
+endif
+
+ifeq ($(CONFIG_TVHEADEND_AVAHI_SUPPORT),)
+  CONFIGURE_ARGS += --disable-avahi
+else
+  CONFIGURE_ARGS += --enable-avahi
+endif
+
+CONFIGURE_ARGS += \
+	--arch=$(ARCH) \
+	--disable-dbus_1 \
+	--disable-libav \
+	--enable-bundle
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	echo 'Tvheadend $(shell echo $(PKG_SOURCE_VERSION) | sed "s/^v//")~openwrt$(PKG_RELEASE)' \
+		> $(PKG_BUILD_DIR)/debian/changelog
+endef
+
+define Package/conffiles
+/etc/config/tvheadend
+endef
+
+define Package/tvheadend/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/tvheadend.init $(1)/etc/init.d/tvheadend
+	$(INSTALL_DIR) $(1)/etc/config
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build.linux/tvheadend $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,tvheadend))

--- a/multimedia/tvheadend/files/tvheadend.config
+++ b/multimedia/tvheadend/files/tvheadend.config
@@ -1,0 +1,13 @@
+#config tvheadend service
+#	 option nosyslog '0'
+#	 option use_temp_epgdb '0'
+#	 option config_path '/etc/tvheadend'
+
+config tvheadend server
+	option ipv6 '1'
+#	 option bindaddr '0.0.0.0'
+#	 option http_port '9981'
+#	 option http_root '/tvheadend'
+#	 option htsp_port '9982'
+#	 option htsp_port2 '9983'
+#	 option xspf '0'

--- a/multimedia/tvheadend/files/tvheadend.init
+++ b/multimedia/tvheadend/files/tvheadend.init
@@ -1,0 +1,71 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=00
+
+USE_PROCD=1
+PROG=/usr/bin/tvheadend
+
+TEMP_CONFIG=/tmp/tvheadend
+PERSISTENT_CONFIG=/etc/tvheadend
+
+execute_first_run() {
+	"$PROG" -c "$1" -B -C -A >/dev/null 2>&1
+}
+
+ensure_config_exists() {
+	local config_path
+
+	config_load tvheadend
+	config_get config_path service config_path
+
+	if [ -z "$config_path" ]; then
+		[ -d "$PERSISTENT_CONFIG" ] || execute_first_run "$PERSISTENT_CONFIG"
+	else
+		# if the configuration directory is empty, empty config with grant-all ACL is created
+		[ -d "$config_path" ] && [ "$(ls -A $config_path)" ] || execute_first_run "$config_path"
+	fi
+
+	# if use_temp_epgdb is enabled (default), most of the config is put to config_path
+	# (or /etc/config), except for epgdb.v2, which grows quite large and is write-heavy,
+	# so it's put into volatile tmpfs
+	# epgdb.v2 is created and symlinked to main config dir upon each start (if it doesn't exist)
+	config_get_bool use_temp_epgdb service use_temp_epgdb 1
+	if [ "$use_temp_epgdb" == "1" ]; then
+		TEMP_EPG="${TEMP_CONFIG}/epgdb.v2"
+		[ ! -f "$TEMP_EPG" ] && mkdir -p "$TEMP_CONFIG" && touch "$TEMP_EPG" && chmod 700 "$TEMP_EPG"
+		[ -z "$config_path" ] && config_path="$PERSISTENT_CONFIG"
+		ln -sf "$TEMP_EPG" "${config_path}/epgdb.v2"
+	fi
+}
+
+load_uci_config() {
+	config_load tvheadend
+	config_get config_path service config_path "$PERSISTENT_CONFIG"
+	[ -n "$config_path" ] && procd_append_param command -c "$config_path"
+	config_get_bool nosyslog service nosyslog 0
+	[ "$nosyslog" -eq 1 ] && procd_append_param command --nosyslog
+	config_get_bool ipv6 server ipv6 0
+	[ "$ipv6" -eq 1 ] && procd_append_param command --ipv6
+	config_get bindaddr server bindaddr
+	[ -n "$bindaddr" ] && procd_append_param command --bindaddr "$bindaddr"
+	config_get http_port server http_port
+	[ -n "$http_port" ] && procd_append_param command --http_port "$http_port"
+	config_get http_root server http_root
+	[ -n "$http_root" ] && procd_append_param command --http_root "$http_root"
+	config_get htsp_port server htsp_port
+	[ -n "$htsp_port" ] && procd_append_param command --htsp_port "$htsp_port"
+	config_get htsp_port2 server htsp_port2
+	[ -n "$htsp_port2" ] && procd_append_param command --htsp_port "$htsp_port2"
+	config_get xspf server xspf 0
+	[ "$xspf" -eq 1 ] && procd_append_param command --xspf
+}
+
+start_service() {
+	ensure_config_exists
+	procd_open_instance
+	procd_set_param file /etc/config/tvheadend
+	procd_set_param command "$PROG" -B
+	load_uci_config
+	procd_close_instance
+}


### PR DESCRIPTION
Tvheadend is a TV streaming server and recorder for Linux. Legacy Makefile for tvheadend was used  as a skeleton, but most of its parts were rewritten or updated later.

Procd init script allows to set some configuration options (these are commented out in default Uci config for documentation purposes) and is written in a way that it puts only configuration that needs to be persistent to main memory. EPG database which is large and updated regularly is put to tmpfs (this can be disabled in config).

Signed-off-by: Jan Čermák <jan.cermak@nic.cz>