### PR TITLE
zmq: Make 2 variants, refresh patches, fix C++ build issues

### DIFF
--- a/libs/zmq/Makefile
+++ b/libs/zmq/Makefile
@@ -18,9 +18,9 @@ PKG_LICENSE_FILES:=LICENCE.txt
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= http://download.zeromq.org
-PKG_MD5SUM:=73c39f5eb01b9d7eaf74a5d899f1d03d
+PKG_MD5SUM:=0a4b44aa085644f25c177f79dc13f253
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=libuuid
 
 PKG_FIXUP:=autoreconf
@@ -31,26 +31,34 @@ PKG_INSTALL:=1
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
-define Package/libzmq
+define Package/libzmq/default
   TITLE:=ZeroMQ - Message Queue engine
   URL:=http://www.zeromq.org/
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libuuid +libpthread +librt +PACKAGE_libsodium:libsodium $(CXX_DEPENDS)
-  MENU:=1
+  DEPENDS:=+libuuid +libpthread +librt $(CXX_DEPENDS)
+  PROVIDES:=libzmq
 endef
 
-define Package/libzmq/config
- config LIBZMQ_CURVEZMQ
-	bool "Include support for CurveZMQ security"
-	depends on PACKAGE_libzmq
-	default y
-	select PACKAGE_libsodium
+define Package/libzmq-nc
+  $(call Package/libzmq/default)
+  VARIANT:=nc
 endef
 
-define Package/libzmq/description
+define Package/libzmq-curve
+  $(call Package/libzmq/default)
+  VARIANT:=curve
+  TITLE+= (CurveZMQ)
+  DEPENDS+=+libsodium 
+endef
+
+define Package/libzmq-nc/description
  This package contains the ZeroMQ messaging engine shared library.
- CurveZMQ security protocols are optional using libsodium.
+endef
+
+define Package/libzmq-curve/description
+ $(call Package/libzmq-nc/description)
+ Includes CurveZMQ security by libsodium.
 endef
 
 # add extra configure flags here
@@ -58,14 +66,11 @@ CONFIGURE_ARGS += \
 	--enable-static \
 	--enable-shared
 
-ifneq ($(CONFIG_PACKAGE_libsodium),)
+ifeq ($(BUILD_VARIANT),curve)
   CONFIGURE_ARGS+= --with-libsodium
 else
   CONFIGURE_ARGS+= --without-libsodium
 endif
-
-# add make variable overrides here
-MAKE_FLAGS +=
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
@@ -77,9 +82,12 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libzmq.pc $(1)/usr/lib/pkgconfig/
 endef
 
-define Package/libzmq/install
+define Package/libzmq-nc/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libzmq.so.* $(1)/usr/lib/
 endef
 
-$(eval $(call BuildPackage,libzmq))
+Package/libzmq-curve/install=$(Package/libzmq-nc/install)
+
+$(eval $(call BuildPackage,libzmq-nc))
+$(eval $(call BuildPackage,libzmq-curve))

--- a/libs/zmq/patches/010-disable_pedantic_on_linux_with_ulibc++.patch
+++ b/libs/zmq/patches/010-disable_pedantic_on_linux_with_ulibc++.patch
@@ -1,6 +1,6 @@
---- a/configure.ac	2014-06-04 10:19:35.140061796 +0800
-+++ b/configure.ac	2014-06-04 11:08:17.231997926 +0800
-@@ -127,8 +127,10 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -147,8 +147,10 @@ case "${host_os}" in
      *linux*)
          # Define on Linux to enable all library features. Define if using a gnu compiler
          if test "x$GXX" = "xyes"; then

--- a/libs/zmq/patches/020-map_with_const_string_with_ublic++.patch
+++ b/libs/zmq/patches/020-map_with_const_string_with_ublic++.patch
@@ -1,6 +1,6 @@
---- a/src/metadata.hpp	2015-06-17 21:39:33.629934688 +0800
-+++ b/src/metadata.hpp	2014-10-14 22:07:36.000000000 +0800
-@@ -31,7 +31,7 @@
+--- a/src/metadata.hpp
++++ b/src/metadata.hpp
+@@ -31,7 +31,7 @@ namespace zmq
      {
          public:
  
@@ -9,8 +9,8 @@
  
              metadata_t (const dict_t &dict);
              virtual ~metadata_t ();
---- a/src/socket_base.cpp	2015-06-17 21:42:26.289413233 +0800
-+++ b/src/socket_base.cpp	2015-06-02 18:31:00.000000000 +0800
+--- a/src/socket_base.cpp
++++ b/src/socket_base.cpp
 @@ -20,6 +20,7 @@
  #include <new>
  #include <string>
@@ -19,9 +19,9 @@
  
  #include "platform.hpp"
  
---- a/src/stream_engine.cpp	2015-06-17 21:57:29.599443517 +0800
-+++ b/src/stream_engine.cpp	2015-06-02 18:31:00.000000000 +0800
-@@ -198,7 +198,7 @@
+--- a/src/stream_engine.cpp
++++ b/src/stream_engine.cpp
+@@ -198,7 +198,7 @@ void zmq::stream_engine_t::plug (io_thre
              //  Compile metadata.
              typedef metadata_t::dict_t properties_t;
              properties_t properties;
@@ -30,7 +30,7 @@
              zmq_assert (metadata == NULL);
              metadata = new (std::nothrow) metadata_t (properties);
          }
-@@ -805,7 +805,7 @@
+@@ -805,7 +805,7 @@ void zmq::stream_engine_t::mechanism_rea
  
      //  If we have a peer_address, add it to metadata
      if (!peer_address.empty()) {

--- a/libs/zmq/patches/030-streamoff_missing_with_ulibc++.patch
+++ b/libs/zmq/patches/030-streamoff_missing_with_ulibc++.patch
@@ -1,5 +1,5 @@
---- a/src/blob.hpp	2014-06-04 10:19:12.680062287 +0800
-+++ b/src/blob.hpp	2014-06-04 10:30:31.168047457 +0800
+--- a/src/blob.hpp
++++ b/src/blob.hpp
 @@ -21,6 +21,7 @@
  #define __ZMQ_BLOB_HPP_INCLUDED__
  

--- a/libs/zmq/patches/100-fix-cxx-include-order.patch
+++ b/libs/zmq/patches/100-fix-cxx-include-order.patch
@@ -1,0 +1,84 @@
+--- a/src/mtrie.cpp
++++ b/src/mtrie.cpp
+@@ -17,11 +17,11 @@
+     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+-#include <stdlib.h>
+-
+ #include <new>
+ #include <algorithm>
+ 
++#include <stdlib.h>
++
+ #include "platform.hpp"
+ #if defined ZMQ_HAVE_WINDOWS
+ #include "windows.hpp"
+--- a/src/raw_encoder.cpp
++++ b/src/raw_encoder.cpp
+@@ -17,6 +17,11 @@
+     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#include <basic_definitions>
++#include <exception>
++#include <cstddef>
++#include <algorithm>
++
+ #include "encoder.hpp"
+ #include "raw_encoder.hpp"
+ #include "likely.hpp"
+--- a/src/trie.cpp
++++ b/src/trie.cpp
+@@ -17,11 +17,11 @@
+     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+-#include <stdlib.h>
+-
+ #include <new>
+ #include <algorithm>
+ 
++#include <stdlib.h>
++
+ #include "platform.hpp"
+ #if defined ZMQ_HAVE_WINDOWS
+ #include "windows.hpp"
+--- a/src/encoder.hpp
++++ b/src/encoder.hpp
+@@ -29,7 +29,6 @@
+ #include <stddef.h>
+ #include <string.h>
+ #include <stdlib.h>
+-#include <algorithm>
+ 
+ #include "err.hpp"
+ #include "msg.hpp"
+--- a/src/v1_encoder.cpp
++++ b/src/v1_encoder.cpp
+@@ -17,6 +17,11 @@
+     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#include <basic_definitions>
++#include <exception>
++#include <cstddef>
++#include <algorithm>
++
+ #include "encoder.hpp"
+ #include "v1_encoder.hpp"
+ #include "likely.hpp"
+--- a/src/v2_encoder.cpp
++++ b/src/v2_encoder.cpp
+@@ -17,6 +17,11 @@
+     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#include <basic_definitions>
++#include <exception>
++#include <cstddef>
++#include <algorithm>
++
+ #include "v2_protocol.hpp"
+ #include "v2_encoder.hpp"
+ #include "likely.hpp"


### PR DESCRIPTION
* Correct package md5sum
* Create 2 variants of libzmq (libzmq-nc without CurveZMQ/libsodium; libzmq-curve with CurveZMQ)
* Re-number/refresh patches
* Add patch to correct C++ include file order errors

Signed-off-by: Ted Hess <thess@kitschensync.net>