### PR TITLE
knxd: Fix build dependencies w/argp-standalone, add libstdcpp

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -12,7 +12,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
 PKG_VERSION=2015-06-27-$(PKG_SOURCE_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/knxd/knxd.git
@@ -38,7 +38,7 @@ define Package/knxd
   SECTION:=net
   CATEGORY:=Network
   TITLE:=EIB KNX daemon
-  DEPENDS:=+pthsem +libusb-1.0
+  DEPENDS:=+pthsem +libusb-1.0 +libstdcpp
 endef
 
 define Package/knxd/description
@@ -86,7 +86,7 @@ CONFIGURE_ARGS+= \
 	--without-libstdc
 
 EXTRA_LDFLAGS+= \
-	-fno-builtin -nodefaultlibs -lc -lgcc
+       -fno-builtin -largp
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
Not sure if this is the right fix, but it does solve #1535 

Signed-off-by: Ted Hess <thess@kitschensync.net>