### PR TITLE
coreutils: install libstdbuf.so if coreutils-stdbuf is built

### DIFF
--- a/utils/coreutils/Makefile
+++ b/utils/coreutils/Makefile
@@ -106,6 +106,12 @@ define BuildPlugin
   define Package/$(1)/install
 	$(INSTALL_DIR) $$(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$(2) $$(1)/usr/bin/
+	
+ifeq ($(2),stdbuf)
+	$(INSTALL_DIR) $$(1)/usr/lib/coreutils
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/coreutils/libstdbuf.so $$(1)/usr/lib/coreutils/
+endif
+
   endef
 
   $$(eval $$(call BuildPackage,$(1)))


### PR DESCRIPTION
Signed-off-by: maz-1 ohmygod19993@gmail.com
libstdbuf.so is required by coreutils-stdbuf. Otherwise stdbuf will exit with " stdbuf: failed to find 'libstdbuf.so' "