### PR TITLE
dnscrypt-proxy: add support for -E/--ephemeral-keys option.

### DIFF
--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
 PKG_VERSION:=1.5.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy

--- a/net/dnscrypt-proxy/files/dnscrypt-proxy.config
+++ b/net/dnscrypt-proxy/files/dnscrypt-proxy.config
@@ -3,3 +3,4 @@ config dnscrypt-proxy
 	option port '5353'
 	# option resolver 'opendns'
 	# option resolvers_list '/usr/share/dnscrypt-proxy/dnscrypt-resolvers.csv'
+	# option ephemeral_keys '1'

--- a/net/dnscrypt-proxy/files/dnscrypt-proxy.init
+++ b/net/dnscrypt-proxy/files/dnscrypt-proxy.init
@@ -8,12 +8,14 @@ start_instance () {
 	config_get port            "$section" 'port'
 	config_get resolver        "$section" 'resolver'
 	config_get resolvers_list  "$section" 'resolvers_list'
+	config_get_bool ephemeral_keys "$section" 'ephemeral_keys'
 
 	service_start /usr/sbin/dnscrypt-proxy -d \
 		-a ${address}:${port} \
 		-u nobody \
 		-L ${resolvers_list:-'/usr/share/dnscrypt-proxy/dnscrypt-resolvers.csv'} \
-		-R ${resolver:-'opendns'}
+		-R ${resolver:-'opendns'} \
+		${ephemeral_keys:+'-E'}
 }
 
 start() {


### PR DESCRIPTION
Signed-off-by: Adam Gensler <openwrt@a.gnslr.us>