### PR TITLE
openldap: update to 2.4.41

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
-PKG_VERSION:=2.4.39
-PKG_RELEASE:=2
+PKG_VERSION:=2.4.41
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/ \
 	ftp://sunsite.cnlab-switch.ch/mirror/OpenLDAP/openldap-release/ \
 	ftp://ftp.nl.uu.net/pub/unix/db/openldap/openldap-release/ \
 	ftp://ftp.plig.org/pub/OpenLDAP/openldap-release/
-PKG_MD5SUM:=b0d5ee4b252c841dec6b332d679cf943
+PKG_MD5SUM:=3f1a4cea52827e18feaedfdc1634b5d0
 
 PKG_FIXUP:=autoreconf
 

--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2012 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.


### PR DESCRIPTION
Version 2.4.41 of OpenLDAP addresses CVE-2015-1545 and CVE-2015-1546, and it also provides other updates.

Signed-off-by: W. Michael Petullo <mike@flyn.org>