### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is the OpenWrt "packages"-feed containing community-maintained build scripts, options and patches for applications, modules and libraries used within OpenWrt.
 
-Installation of pre-built packages is handled directly by the **opkg** utility within your running OpenWrt system or by using the [OpenWrt SDK](http://doc/howto/obtain.firmware.sdk) on a build system.
+Installation of pre-built packages is handled directly by the **opkg** utility within your running OpenWrt system or by using the [OpenWrt SDK](http://wiki.openwrt.org/doc/howto/obtain.firmware.sdk) on a build system.
 
 ## Usage
 


### PR DESCRIPTION
I've fixed the obtain.firmware.sdk link.
Signed-off-by: Eric Schultz <eschultz@prplfoundation.org>