### PR TITLE
pps-tools: remove kernel dependencies

### DIFF
--- a/utils/pps-tools/Makefile
+++ b/utils/pps-tools/Makefile
@@ -26,7 +26,6 @@ define Package/pps-tools
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=PPS-tools
-  DEPENDS:=@LINUX_3_10||@LINUX_3_13||@LINUX_3_14||@LINUX_3_18
 endef
 
 define Package/pps-tools/description


### PR DESCRIPTION
pps-tools builds on kernel 4.1, but instead of adding this kernel,
remove the check as all kernel versions currently supported by OpenWrt
are listed.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>