### PR TITLE
bluez: add btmgmt tool

### DIFF
--- a/utils/bluez/Makefile
+++ b/utils/bluez/Makefile
@@ -120,6 +120,7 @@ define Package/bluez-utils/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/bccmd $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/bluemoon $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/btmon $(1)/usr/bin/
+	$(CP) $(PKG_BUILD_DIR)/tools/btmgmt $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ciptool $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/hciattach $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/hciconfig $(1)/usr/bin/


### PR DESCRIPTION
The btmgmt tool is needed to activate BL LE support.
Currently it is not installed.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>