### PR TITLE
iotivity: deactivate it on uclibc

### DIFF
--- a/net/iotivity/Makefile
+++ b/net/iotivity/Makefile
@@ -33,7 +33,7 @@ include $(INCLUDE_DIR)/scons.mk
 define Package/iotivity
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:= +libpthread +librt +libstdcpp +libuuid
+  DEPENDS:=@!USE_UCLIBC +libpthread +librt +libstdcpp +libuuid
   TITLE:=IoTivity Library
   URL:=https://www.iotivity.org
 endef


### PR DESCRIPTION
IoTivity makes use of std::sto* and this is deactivated because GCC
things uClibc does not support C11, but it supports this part, not C11
completely. To make IoTivity work with uClibc a patch for this bug is
needed:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58393

An option would be this patch:
https://github.com/maximeh/buildroot/blob/master/package/gcc/4.9.1/850-libstdcxx-uclibc-c99.patch

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>