### PR TITLE
alsa-lib: do not include sys/poll.h in header

### DIFF
--- a/libs/alsa-lib/patches/005-include_fixes.patch
+++ b/libs/alsa-lib/patches/005-include_fixes.patch
@@ -1,0 +1,32 @@
+--- a/include/asoundlib.h
++++ b/include/asoundlib.h
+@@ -35,7 +35,7 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <assert.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <errno.h>
+ #include <stdarg.h>
+ #include <endian.h>
+--- a/include/local.h
++++ b/include/local.h
+@@ -47,7 +47,7 @@
+ #error Header defining endianness not defined
+ #endif
+ #include <stdarg.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <sys/types.h>
+ #include <errno.h>
+ #include <linux/types.h>
+--- a/include/asoundlib-head.h
++++ b/include/asoundlib-head.h
+@@ -35,6 +35,6 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <assert.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <errno.h>
+ #include <stdarg.h>


### PR DESCRIPTION
classpath did not build for me because it includes alsa/asoundlib.h
which includes sys/poll.h. classpath treats all warnings as errors and
then the warning from sys/poll.h causes the build to fail.

I got this error message:

In file included from /home/hauke/openwrt/git/staging_dir/target-mipsel_mips32_musl-1.1.10/usr/include/alsa/asoundlib.h:38:0,
                 from gnu_javax_sound_midi_alsa_AlsaPortDevice.c:45:
/home/hauke/openwrt/git/staging_dir/toolchain-mipsel_mips32_gcc-4.8-linaro_musl-1.1.10/include/sys/poll.h:1:2: error: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Werror=cpp]
 #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
  ^
cc1: all warnings being treated as errors
Makefile:541: recipe for target 'gnu_javax_sound_midi_alsa_AlsaPortDevice.lo' failed
make[7]: *** [gnu_javax_sound_midi_alsa_AlsaPortDevice.lo] Error 1
make[7]: Leaving directory '/home/hauke/openwrt/git/build_dir/target-mipsel_mips32_musl-1.1.10/classpath-0.99/native/jni/midi-alsa'
Makefile:470: recipe for target 'all-recursive' failed

This patch fixes this error message. alsa-lib still includes sys/poll.h
in some places, but not in any header file any more.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>