### PR TITLE
kismet: fix build with musl

### DIFF
--- a/net/kismet/patches/010-dont-add-host-include-paths.patch
+++ b/net/kismet/patches/010-dont-add-host-include-paths.patch
@@ -1,9 +1,7 @@
-diff --git a/configure b/configure
-index 6936a47..9a85269 100755
 --- a/configure
 +++ b/configure
-@@ -6980,9 +6980,6 @@ else
- fi
+@@ -5456,9 +5456,6 @@ fi
+ 
  
  
 -# Add additional cflags since some distros bury panel.h

--- a/net/kismet/patches/020-musl-include-fixes.patch
+++ b/net/kismet/patches/020-musl-include-fixes.patch
@@ -1,0 +1,22 @@
+--- a/configfile.cc
++++ b/configfile.cc
+@@ -24,6 +24,7 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <errno.h>
++#include <time.h>
+ #include "configfile.h"
+ #include "util.h"
+ 
+--- a/dumpfile_tuntap.cc
++++ b/dumpfile_tuntap.cc
+@@ -20,8 +20,8 @@
+ 
+ #include <errno.h>
+ 
+-#include "dumpfile_tuntap.h"
+ #include "ifcontrol.h"
++#include "dumpfile_tuntap.h"
+ #include "ipc_remote.h"
+ 
+ #ifndef SYS_CYGWIN


### PR DESCRIPTION
Without these patches kismet does not build with musl.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>