### PR TITLE
open-plc-utils: backport of update on master branch

### DIFF
--- a/utils/open-plc-utils/Makefile
+++ b/utils/open-plc-utils/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2014 OpenWrt.org
+# Copyright (C) 2013-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=open-plc-utils
-PKG_VERSION:=2015-02-23
+PKG_VERSION:=2015-07-06
 PKG_RELEASE:=$(PKG_SOURCE_VERSION)
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=git://github.com/qca/open-plc-utils.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=1f6e7e372b313cf570aa63314037588ed01ec0de
+PKG_SOURCE_VERSION:=885a1b7e2e663b5ab8797db6d40a0318131fdf18
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
 
 PKG_MAINTAINER:=Florian Fainelli <florian@openwrt.org>


### PR DESCRIPTION
This particularly fixes unusable amphost utility on big endian targets.

Signed-off-by: Günther Kelleter <guenther.kelleter@devolo.de>