### PR TITLE
collectd: update to 5.5.0

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
-PKG_VERSION:=5.4.2
+PKG_VERSION:=5.5.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://collectd.org/files/
-PKG_MD5SUM:=feff9fd0ed89e956d7cf12ba18cfc248
+PKG_MD5SUM:=c39305ef5514b44238b0d31f77e29e6a
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libltdl/aclocal.m4
@@ -27,21 +27,27 @@ COLLECTD_PLUGINS_DISABLED:= \
 	amqp \
 	apple_sensors \
 	aquaero \
+	barometer \
 	battery \
+	ceph \
 	cgroups \
 	cpufreq \
 	curl_json \
 	curl_xml \
 	dbi \
+	drbd \
 	entropy \
 	ethstat \
+	fhcount \
 	genericjmx \
 	gmond \
 	hddtemp \
+	ipc \
 	ipmi \
 	ipvs \
 	java \
-	libvirt \
+	log_logstash \
+	lvm \
 	lpar \
 	mbmon \
 	md \
@@ -56,6 +62,7 @@ COLLECTD_PLUGINS_DISABLED:= \
 	notify_email \
 	numa \
 	nut \
+	openldap \
 	openvz \
 	oracle \
 	perl \
@@ -67,19 +74,26 @@ COLLECTD_PLUGINS_DISABLED:= \
 	rrdcached \
 	serial \
 	sigrok \
+	smart \
 	statsd \
 	swap \
 	tape \
 	tokyotyrant \
+	turbostat \
 	uuid \
 	varnish \
+	virt \
 	vserver \
-	write_graphite \
+	write_kafka \
+	write_log \
 	write_mongodb \
 	write_redis \
 	write_riemann \
+	write_sensu \
+	write_tsdb \
 	xmms \
 	zfs_arc \
+	zookeeper
 
 COLLECTD_PLUGINS_SELECTED:= \
 	apache \
@@ -135,6 +149,7 @@ COLLECTD_PLUGINS_SELECTED:= \
 	users \
 	vmem \
 	wireless \
+	write_graphite \
 	write_http \
 
 PKG_CONFIG_DEPENDS:= \
@@ -327,4 +342,5 @@ $(eval $(call BuildPlugin,uptime,uptime status input,uptime,))
 $(eval $(call BuildPlugin,users,user logged in status input,users,))
 $(eval $(call BuildPlugin,vmem,virtual memory usage input,vmem,))
 $(eval $(call BuildPlugin,wireless,wireless status input,wireless,))
+$(eval $(call BuildPlugin,write-graphite,Carbon/Graphite output,write_graphite,+PACKAGE_collectd-mod-write-graphite:libpthread))
 $(eval $(call BuildPlugin,write-http,HTTP POST output,write_http,+PACKAGE_collectd-mod-write-http:libcurl))

--- a/utils/collectd/patches/003-remove-werror.patch
+++ b/utils/collectd/patches/003-remove-werror.patch
@@ -1,14 +1,14 @@
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -4,7 +4,7 @@ SUBDIRS += liboconfig
- endif
+@@ -7,7 +7,7 @@ SUBDIRS += daemon
+ PLUGIN_LDFLAGS = -module -avoid-version -export-symbols-regex '\<module_register\>'
  
  if COMPILER_IS_GCC
 -AM_CFLAGS = -Wall -Werror
 +AM_CFLAGS = -Wall
  endif
  
- AM_CPPFLAGS = -DPREFIX='"${prefix}"'
+ AM_CPPFLAGS = -I$(srcdir)/daemon
 --- a/src/libcollectdclient/Makefile.am
 +++ b/src/libcollectdclient/Makefile.am
 @@ -1,7 +1,7 @@

--- a/utils/collectd/patches/100-rrdtool-add-rrasingle-option.patch
+++ b/utils/collectd/patches/100-rrdtool-add-rrasingle-option.patch
@@ -34,7 +34,7 @@
  		double tmp = atof (value);
 --- a/src/utils_rrdcreate.c
 +++ b/src/utils_rrdcreate.c
-@@ -212,6 +212,9 @@ static int rra_get (char ***ret, const v
+@@ -217,6 +217,9 @@ static int rra_get (char ***ret, const v
      rts_num = rra_timespans_num;
    }
  
@@ -46,7 +46,7 @@
    if ((rra_def = (char **) malloc ((rra_max + 1) * sizeof (char *))) == NULL)
 --- a/src/utils_rrdcreate.h
 +++ b/src/utils_rrdcreate.h
-@@ -36,6 +36,8 @@ struct rrdcreate_config_s
+@@ -41,6 +41,8 @@ struct rrdcreate_config_s
    int *timespans;
    size_t timespans_num;
  

--- a/utils/collectd/patches/140-fix-fqdnlookup.patch
+++ b/utils/collectd/patches/140-fix-fqdnlookup.patch
@@ -1,6 +1,6 @@
---- a/src/configfile.c
-+++ b/src/configfile.c
-@@ -105,7 +105,7 @@ static cf_global_option_t cf_global_opti
+--- a/src/daemon/configfile.c
++++ b/src/daemon/configfile.c
+@@ -109,7 +109,7 @@ static cf_global_option_t cf_global_opti
  	{"BaseDir",     NULL, PKGLOCALSTATEDIR},
  	{"PIDFile",     NULL, PIDFILE},
  	{"Hostname",    NULL, NULL},

--- a/utils/collectd/patches/200-fix-git-describe-error.patch
+++ b/utils/collectd/patches/200-fix-git-describe-error.patch
@@ -2,10 +2,10 @@
 +++ b/version-gen.sh
 @@ -2,7 +2,7 @@
  
- DEFAULT_VERSION="5.4.2.git"
+ DEFAULT_VERSION="5.5.0.git"
  
--VERSION="`git describe 2> /dev/null | sed -e 's/^collectd-//'`"
-+#VERSION="`git describe 2> /dev/null | sed -e 's/^collectd-//'`"
+-VERSION="`git describe 2> /dev/null | grep collectd | sed -e 's/^collectd-//'`"
++#VERSION="`git describe 2> /dev/null | grep collectd | sed -e 's/^collectd-//'`"
  
  if test -z "$VERSION"; then
  	VERSION="$DEFAULT_VERSION"

--- a/utils/collectd/patches/400-fix-olsrd-get-all.patch
+++ b/utils/collectd/patches/400-fix-olsrd-get-all.patch
@@ -1,6 +1,6 @@
 --- a/src/olsrd.c
 +++ b/src/olsrd.c
-@@ -653,7 +653,7 @@ static int olsrd_read (void) /* {{{ */
+@@ -658,7 +658,7 @@ static int olsrd_read (void) /* {{{ */
    if (fh == NULL)
      return (-1);
  

--- a/utils/collectd/patches/900-add-iwinfo-plugin.patch
+++ b/utils/collectd/patches/900-add-iwinfo-plugin.patch
@@ -1,58 +1,58 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -580,6 +580,9 @@ AC_CHECK_HEADERS(net/pfvar.h,
+@@ -589,6 +589,9 @@ AC_CHECK_HEADERS(net/pfvar.h,
  have_termios_h="no"
  AC_CHECK_HEADERS(termios.h, [have_termios_h="yes"])
  
 +# For the iwinfo plugin
 +AC_CHECK_LIB(iwinfo, iwinfo_backend, [with_iwinfo="yes"], [with_iwinfo="no (libiwinfo not found)"], [])
 +
- #
- # Checks for typedefs, structures, and compiler characteristics.
- #
-@@ -4841,6 +4844,7 @@ plugin_interface="no"
+ # For the turbostat plugin
+ have_asm_msrindex_h="no"
+ AC_CHECK_HEADERS(asm/msr-index.h, [have_asm_msrindex_h="yes"])
+@@ -5171,6 +5174,7 @@ plugin_interface="no"
  plugin_ipmi="no"
  plugin_ipvs="no"
  plugin_irq="no"
 +plugin_iwinfo="no"
- plugin_libvirt="no"
  plugin_load="no"
+ plugin_log_logstash="no"
  plugin_memory="no"
-@@ -5179,6 +5183,7 @@ AC_PLUGIN([ipmi],        [$plugin_ipmi],
+@@ -5562,6 +5566,7 @@ AC_PLUGIN([ipmi],        [$plugin_ipmi],
  AC_PLUGIN([iptables],    [$with_libiptc],      [IPTables rule counters])
  AC_PLUGIN([ipvs],        [$plugin_ipvs],       [IPVS connection statistics])
  AC_PLUGIN([irq],         [$plugin_irq],        [IRQ statistics])
 +AC_PLUGIN([iwinfo],      [$with_iwinfo],       [Common iwinfo wireless statistics])
  AC_PLUGIN([java],        [$with_java],         [Embed the Java Virtual Machine])
- AC_PLUGIN([libvirt],     [$plugin_libvirt],    [Virtual machine statistics])
  AC_PLUGIN([load],        [$plugin_load],       [System load])
-@@ -5480,6 +5485,7 @@ Configuration:
-     protobuf-c  . . . . . $have_protoc_c
+ AC_PLUGIN([logfile],     [yes],                [File logging plugin])
+@@ -5891,6 +5896,7 @@ Configuration:
      oracle  . . . . . . . $with_oracle
+     protobuf-c  . . . . . $have_protoc_c
      python  . . . . . . . $with_python
 +    iwinfo  . . . . . . . $with_iwinfo
  
    Features:
      daemon mode . . . . . $enable_daemon
-@@ -5524,6 +5530,7 @@ Configuration:
+@@ -5940,6 +5946,7 @@ Configuration:
      iptables  . . . . . . $enable_iptables
      ipvs  . . . . . . . . $enable_ipvs
      irq . . . . . . . . . $enable_irq
 +    iwinfo  . . . . . . . $enable_iwinfo
      java  . . . . . . . . $enable_java
-     libvirt . . . . . . . $enable_libvirt
      load  . . . . . . . . $enable_load
+     logfile . . . . . . . $enable_logfile
 --- a/src/collectd.conf.in
 +++ b/src/collectd.conf.in
-@@ -109,6 +109,7 @@
+@@ -128,6 +128,7 @@
  #@BUILD_PLUGIN_IPMI_TRUE@LoadPlugin ipmi
  #@BUILD_PLUGIN_IPVS_TRUE@LoadPlugin ipvs
  #@BUILD_PLUGIN_IRQ_TRUE@LoadPlugin irq
 +#@BUILD_PLUGIN_IWINFO_TRUE@LoadPlugin iwinfo
  #@BUILD_PLUGIN_JAVA_TRUE@LoadPlugin java
- #@BUILD_PLUGIN_LIBVIRT_TRUE@LoadPlugin libvirt
  @BUILD_PLUGIN_LOAD_TRUE@@BUILD_PLUGIN_LOAD_TRUE@LoadPlugin load
-@@ -502,6 +503,12 @@
+ #@BUILD_PLUGIN_LPAR_TRUE@LoadPlugin lpar
+@@ -582,6 +583,12 @@
  #	IgnoreSelected true
  #</Plugin>
  
@@ -62,12 +62,12 @@
 +#   Interface "wlan0"
 +#</Plugin>
 +
- #<Plugin "java">
+ #<Plugin java>
  #	JVMArg "-verbose:jni"
  #	JVMArg "-Djava.class.path=@prefix@/share/collectd/java/collectd-api.jar"
 --- a/src/collectd.conf.pod
 +++ b/src/collectd.conf.pod
-@@ -2077,6 +2077,27 @@ and all other interrupts are collected.
+@@ -2572,6 +2572,27 @@ and all other interrupts are collected.
  
  =back
  
@@ -250,17 +250,15 @@
 +}
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -530,6 +530,15 @@ collectd_LDADD += "-dlopen" irq.la
- collectd_DEPENDENCIES += irq.la
+@@ -459,6 +459,13 @@ irq_la_SOURCES = irq.c \
+ irq_la_LDFLAGS = $(PLUGIN_LDFLAGS)
  endif
  
 +if BUILD_PLUGIN_IWINFO
 +pkglib_LTLIBRARIES += iwinfo.la
-+iwinfo_la_SOURCES = iwinfo.c
++iwinfo_la_SOURCES = iwinfo.c utils_ignorelist.c utils_ignorelist.h
 +iwinfo_la_LDFLAGS = -module -avoid-version
 +iwinfo_la_LIBADD = -liwinfo
-+collectd_LDADD += "-dlopen" iwinfo.la
-+collectd_DEPENDENCIES += iwinfo.la
 +endif
 +
  if BUILD_PLUGIN_JAVA
@@ -268,12 +266,11 @@
  java_la_SOURCES = java.c
 --- a/src/types.db
 +++ b/src/types.db
-@@ -195,7 +195,7 @@ voltage			value:GAUGE:U:U
+@@ -227,6 +227,7 @@ voltage			value:GAUGE:U:U
  vs_memory		value:GAUGE:0:9223372036854775807
  vs_processes		value:GAUGE:0:65535
  vs_threads		value:GAUGE:0:65535
--
 +stations		value:GAUGE:0:256
+ 
  #
  # Legacy types
- # (required for the v5 upgrade target)

--- a/utils/collectd/patches/920-fix-ping-droprate.patch
+++ b/utils/collectd/patches/920-fix-ping-droprate.patch
@@ -1,6 +1,6 @@
 --- a/src/ping.c
 +++ b/src/ping.c
-@@ -651,7 +651,7 @@ static int ping_read (void) /* {{{ */
+@@ -656,7 +656,7 @@ static int ping_read (void) /* {{{ */
            / ((double) (pkg_recv * (pkg_recv - 1))));
  
      /* Calculate drop rate. */


### PR DESCRIPTION
Update collectd, base of Luci statistics, to 5.5.0.

Patches have been refreshed.
write-graphite plugin is enabled to be optionally built. (see #1351 )

I have compile-tested all plugins with ar71xx, and real-life tested the following plugins:
Conntrack, Processor (CPU), DNS, Interfaces, Wireless, System Load, Memory, Ping, Uptime