### PR TITLE
gnutls: revert libgnutls-openssl

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -182,7 +182,7 @@ TARGET_CFLAGS += $(FPIC)
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib/pkgconfig
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/libgnutls.so* \
+		$(PKG_INSTALL_DIR)/usr/lib/libgnutls{,-openssl}.so* \
 		$(1)/usr/lib/
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/include/gnutls \


### PR DESCRIPTION
`--enable-openssl-compatibility` is enabled by default now, but `libgnutls-openssl` is forgotten to be installed to staging directory.