### PR TITLE
tmux: update source URL

### DIFF
--- a/utils/tmux/Makefile
+++ b/utils/tmux/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/tmux
+PKG_SOURCE_URL:=https://github.com/tmux/tmux/releases/download/$(PKG_VERSION)
 PKG_MD5SUM:=9fb6b443392c3978da5d599f1e814eaa
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 


### PR DESCRIPTION
There is [no more tmux 2.0](http://sourceforge.net/projects/tmux/files/tmux/) at sf.net, better to switch to Github sources.