### PR TITLE
gcc: fix musl build (#1418)

### DIFF
--- a/devel/gcc/Makefile
+++ b/devel/gcc/Makefile
@@ -89,6 +89,9 @@ define Build/Configure
 			$(if $(CONFIG_mips64)$(CONFIG_mips64el),--with-arch=mips64 \
 			--with-abi=$(subst ",,$(CONFIG_MIPS64_ABI))) \
 	);
+	cp $(PKG_BUILD_DIR)/config.sub $(PKG_BUILD_DIR)/mpfr/
+	cp $(PKG_BUILD_DIR)/config.sub $(PKG_BUILD_DIR)/gmp/
+	cp $(PKG_BUILD_DIR)/config.sub $(PKG_BUILD_DIR)/mpc/
 endef
 
 define Build/Compile

--- a/devel/gcc/patches/930-fix_sanitizer_issue.patch
+++ b/devel/gcc/patches/930-fix_sanitizer_issue.patch
@@ -1,0 +1,20 @@
+--- a/libsanitizer/tsan/tsan_platform_linux.cc
++++ b/libsanitizer/tsan/tsan_platform_linux.cc
+@@ -291,6 +291,7 @@
+ 
+ #ifndef TSAN_GO
+ int ExtractResolvFDs(void *state, int *fds, int nfd) {
++#if SANITIZER_LINUX
+   int cnt = 0;
+   __res_state *statp = (__res_state*)state;
+   for (int i = 0; i < MAXNS && cnt < nfd; i++) {
+@@ -298,6 +299,9 @@
+       fds[cnt++] = statp->_u._ext.nssocks[i];
+   }
+   return cnt;
++#else
++  return 0;
++#endif
+ }
+ #endif
+ 


### PR DESCRIPTION
Fixes issue with "machine `none-openwrt-linux' not recognized" while compiling gcc.

Signed-off-by: Oskari Rauta <oskari.rauta@gmail.com>