### PR TITLE
git: Fix broken git symlink, add IPv6 support

### DIFF
--- a/net/git/Makefile
+++ b/net/git/Makefile
@@ -64,7 +64,6 @@ MAKE_FLAGS := \
 	NO_MKSTEMPS="YesPlease" \
 	NO_GETTEXT="YesPlease" \
 	NO_UNIX_SOCKETS="YesPlease" \
-	NO_IPV6="YesPlease" \
 	NO_ICONV="YesPlease" \
 	NO_NSEC="YesPlease" \
 	NO_PERL="YesPlease" \
@@ -88,6 +87,7 @@ define Package/git/install
 	$(RM) $(PKG_INSTALL_DIR)/usr/bin/git-cvsserver
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/git-* $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/usr/lib/git-core
+	$(LN) /usr/bin/git $(1)/usr/lib/git-core/git
 	( cd $(PKG_INSTALL_DIR); $(TAR) \
 		--exclude=usr/lib/git-core/git-http-backend \
 		--exclude=usr/lib/git-core/git-http-fetch \

--- a/net/git/patches/100-convert_builtin.patch
+++ b/net/git/patches/100-convert_builtin.patch
@@ -49,7 +49,7 @@
  git-http-fetch$X: http.o http-walker.o http-fetch.o GIT-LDFLAGS $(GITLIBS)
  	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) $(filter %.o,$^) \
  		$(LIBS) $(CURL_LIBCURL)
-@@ -2277,10 +2269,11 @@ endif
+@@ -2279,10 +2271,11 @@ endif
  	bindir=$$(cd '$(DESTDIR_SQ)$(bindir_SQ)' && pwd) && \
  	execdir=$$(cd '$(DESTDIR_SQ)$(gitexec_instdir_SQ)' && pwd) && \
  	{ test "$$bindir/" = "$$execdir/" || \


### PR DESCRIPTION
The issue [#10221](https://dev.openwrt.org/ticket/10221) has been fixed in the past but then reintroduced in the very next commit. This pull requests fixes it again. Hope this time it lasts longer. While in it, I've also enabled IPv6 support and bumped a new version.

@tripolar please review.

