### PR TITLE
net/dnscrypt-proxy: Set default provider to cisco, add client key support in config

### DIFF
--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
 PKG_VERSION:=1.6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy

--- a/net/dnscrypt-proxy/files/dnscrypt-proxy.config
+++ b/net/dnscrypt-proxy/files/dnscrypt-proxy.config
@@ -1,6 +1,8 @@
 config dnscrypt-proxy
 	option address '127.0.0.1'
 	option port '5353'
-	# option resolver 'opendns'
+	# option resolver 'cisco'
 	# option resolvers_list '/usr/share/dnscrypt-proxy/dnscrypt-resolvers.csv'
 	# option ephemeral_keys '1'
+	# more details at https://github.com/jedisct1/dnscrypt-proxy#public-key-client-authentication
+	# option client_key ''

--- a/net/dnscrypt-proxy/files/dnscrypt-proxy.init
+++ b/net/dnscrypt-proxy/files/dnscrypt-proxy.init
@@ -8,14 +8,16 @@ start_instance () {
 	config_get port            "$section" 'port'
 	config_get resolver        "$section" 'resolver'
 	config_get resolvers_list  "$section" 'resolvers_list'
+	config_get client_key      "$section" 'client_key'
 	config_get_bool ephemeral_keys "$section" 'ephemeral_keys'
 
 	service_start /usr/sbin/dnscrypt-proxy -d \
 		-a ${address}:${port} \
 		-u nobody \
 		-L ${resolvers_list:-'/usr/share/dnscrypt-proxy/dnscrypt-resolvers.csv'} \
-		-R ${resolver:-'opendns'} \
-		${ephemeral_keys:+'-E'}
+		-R ${resolver:-'cisco'} \
+		${ephemeral_keys:+'-E'} \
+		${client_key:+'--client-key='$client_key}
 }
 
 start() {


### PR DESCRIPTION
Signed-off-by: Damiano Renfer damiano.renfer@gmail.com