### PR TITLE
Adds YAJL

### DIFF
--- a/libs/yajl/Makefile
+++ b/libs/yajl/Makefile
@@ -1,0 +1,59 @@
+# 
+# Copyright (C) 2014, 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=yajl
+PKG_VERSION:=2.1.0
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Charles Southerland <charlie@stuphlabs.com>
+PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=COPYING
+PKG_REV:=66cb08ca2ad8581080b626a75dfca266a890afb2
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=$(PKG_REV)
+PKG_SOURCE_URL:=git://github.com/lloyd/yajl.git
+PKG_SOURCE_PROTO:=git
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/yajl
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Yet Another JSON Library
+  URL:=http://lloyd.github.io/yajl
+endef
+
+define Package/yajl/description
+  Yet Another JSON Library. YAJL is a small event-driven (SAX-style)
+JSON parser written in ANSI C, and a small validating JSON generator.
+YAJL is released under the ISC license.
+
+  YAJL was created by Lloyd Hilaiel.
+endef
+
+PKG_INSTALL:=1
+
+CMAKE_OPTIONS += \
+	-DCMAKE_BUILD_TYPE:String="Release" 
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/yajl $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libyajl.so* $(1)/usr/lib/
+endef
+
+define Package/yajl/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libyajl.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,yajl))

--- a/libs/yajl/patches/100-link-reformatter-uclibc-libm.patch
+++ b/libs/yajl/patches/100-link-reformatter-uclibc-libm.patch
@@ -1,0 +1,11 @@
+--- a/reformatter/CMakeLists.txt
++++ b/reformatter/CMakeLists.txt
+@@ -26,7 +26,7 @@
+ 
+ ADD_EXECUTABLE(json_reformat ${SRCS})
+ 
+-TARGET_LINK_LIBRARIES(json_reformat yajl_s)
++TARGET_LINK_LIBRARIES(json_reformat yajl_s m)
+ 
+ # copy the binary into the output directory
+ GET_TARGET_PROPERTY(binPath json_reformat LOCATION)

--- a/libs/yajl/patches/101-link-perf-uclibc-libm.patch
+++ b/libs/yajl/patches/101-link-perf-uclibc-libm.patch
@@ -1,0 +1,8 @@
+--- a/perf/CMakeLists.txt
++++ b/perf/CMakeLists.txt
+@@ -20,4 +20,4 @@
+ 
+ ADD_EXECUTABLE(perftest ${SRCS})
+ 
+-TARGET_LINK_LIBRARIES(perftest yajl_s)
++TARGET_LINK_LIBRARIES(perftest yajl_s m)


### PR DESCRIPTION
[YAJL](https://github.com/lloyd/yajl) is a small C library used for parsing JSON.

Given its small size, this package is sometimes included in its entirety by other packages and statically linked to the resulting binaries. However, it seems like having multiple copies of even such a small library is bad practice, especially on certain older routers where every kilobyte counts.

We've been using an older version I wrote for internal testing purposes at Who's On My WiFi for almost a year and a half, but maybe someone else would like to use it as well.

Signed-off-by: Charles Southerland <charlie@stuphlabs.com>