### PR TITLE
transmission: add nice and ionice support, store config persistently

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=2.84
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://download-origin.transmissionbt.com/files/ http://mirrors.m0k.org/transmission/files
@@ -34,6 +34,7 @@ define Package/transmission-daemon
   $(call Package/transmission/template)
   DEPENDS:=+libcurl +libopenssl +libpthread +libevent2 +librt
   MENU:=1
+  USERID:=transmission=224:transmission=224
 endef
 
 define Package/transmission-cli

--- a/net/transmission/files/transmission.config
+++ b/net/transmission/files/transmission.config
@@ -3,6 +3,8 @@ config transmission
 	option config_dir '/tmp/transmission'
 	#option user 'nobody'
 	option mem_percentage 50
+	option nice 10
+	option ionice_flags '-c 3'
 	option alt_speed_down 50
 	option alt_speed_enabled false
 	option alt_speed_time_begin  540

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -47,8 +47,10 @@ transmission() {
 	local USE
 
 	local user
-	local download_dir
+	local download_dir config_dir
 	local mem_percentage
+	local config_overwrite nice ionice_flags
+	local cmdline
 
 	section_enabled "$section" || return 1
 
@@ -56,6 +58,10 @@ transmission() {
 	config_get user "$cfg" 'user'
 	config_get download_dir "$cfg" 'download_dir' '/var/etc/transmission'
 	config_get mem_percentage "$cfg" 'mem_percentage' '50'
+	config_get config_overwrite "$cfg" config_overwrite 1
+	config_get nice "$cfg" nice 0
+	config_get ionice_flags "$cfg" ionice_flags ''
+	which ionice > /dev/null || ionice_flags=''
 
 	local MEM=$(sed -ne 's!^MemTotal:[[:space:]]*\([0-9]*\) kB$!\1!p' /proc/meminfo)
 	if test "$MEM" -gt 1;then
@@ -69,38 +75,45 @@ transmission() {
 		[ -z "$user" ] || chown -R $user $config_dir
 	}
 
-	echo "{" > $config_file
+	[ "$config_overwrite" == 0 ] || {
 
-	append_params "$cfg" \
-		alt_speed_down alt_speed_enabled alt_speed_time_begin alt_speed_time_day \
-		alt_speed_time_enabled alt_speed_time_end alt_speed_up blocklist_enabled \
-		cache_size_mb download_queue_enabled download_queue_size \
-		dht_enabled encryption idle_seeding_limit idle_seeding_limit_enabled \
-		incomplete_dir_enabled lazy_bitfield_enabled lpd_enabled message_level \
-		peer_limit_global peer_limit_per_torrent peer_port \
-		peer_port_random_high peer_port_random_low peer_port_random_on_start \
-		pex_enabled port_forwarding_enabled preallocation prefetch_enabled \
-		ratio_limit ratio_limit_enabled rename_partial_files rpc_authentication_required \
-		rpc_enabled rpc_port rpc_whitelist_enabled queue_stalled_enabled \
-		queue_stalled_minutes scrape_paused_torrents_enabled script_torrent_done_enabled \
-		seed_queue_enabled seed_queue_size \
-		speed_limit_down speed_limit_down_enabled speed_limit_up \
-		speed_limit_up_enabled start_added_torrents trash_original_torrent_files \
-		umask upload_slots_per_torrent utp_enabled scrape_paused_torrents \
-		watch_dir_enabled
+		echo "{" > $config_file
 
-	append_params_quotes "$cfg" \
-		blocklist_url bind_address_ipv4 bind_address_ipv6 download_dir incomplete_dir \
-		peer_congestion_algorithm peer_socket_tos rpc_bind_address rpc_password rpc_url \
-		rpc_username rpc_whitelist script_torrent_done_filename watch_dir
+		append_params "$cfg" \
+			alt_speed_down alt_speed_enabled alt_speed_time_begin alt_speed_time_day \
+			alt_speed_time_enabled alt_speed_time_end alt_speed_up blocklist_enabled \
+			cache_size_mb download_queue_enabled download_queue_size \
+			dht_enabled encryption idle_seeding_limit idle_seeding_limit_enabled \
+			incomplete_dir_enabled lazy_bitfield_enabled lpd_enabled message_level \
+			peer_limit_global peer_limit_per_torrent peer_port \
+			peer_port_random_high peer_port_random_low peer_port_random_on_start \
+			pex_enabled port_forwarding_enabled preallocation prefetch_enabled \
+			ratio_limit ratio_limit_enabled rename_partial_files rpc_authentication_required \
+			rpc_enabled rpc_port rpc_whitelist_enabled queue_stalled_enabled \
+			queue_stalled_minutes scrape_paused_torrents_enabled script_torrent_done_enabled \
+			seed_queue_enabled seed_queue_size \
+			speed_limit_down speed_limit_down_enabled speed_limit_up \
+			speed_limit_up_enabled start_added_torrents trash_original_torrent_files \
+			umask upload_slots_per_torrent utp_enabled scrape_paused_torrents \
+			watch_dir_enabled
 
-	echo "\""invalid-key"\": false" >> $config_file
-	echo "}" >> $config_file
+		append_params_quotes "$cfg" \
+			blocklist_url bind_address_ipv4 bind_address_ipv6 download_dir incomplete_dir \
+			peer_congestion_algorithm peer_socket_tos rpc_bind_address rpc_password rpc_url \
+			rpc_username rpc_whitelist script_torrent_done_filename watch_dir
 
+		echo "\""invalid-key"\": false" >> $config_file
+		echo "}" >> $config_file
+
+	}
+
+	cmdline="/usr/bin/transmission-daemon -g $config_dir -f"
+	[ "$ionice_flags" ] && cmdline="ionice $ionice_flags $cmdline"
 	procd_open_instance
-	procd_set_param command /usr/bin/transmission-daemon -g $config_dir -f
+	procd_set_param command $cmdline
 	procd_set_param respawn retry=60
 	procd_set_param user "$user"
+	procd_set_param nice "$nice"
 	if test -z "$USE";then
 		procd_set_param limits core="0 0"
 	else


### PR DESCRIPTION
The reason behind this change is that transmission can manage [most of] its settings internally, and if you run transmission, you usually have large enough storage where config may be stored.

@obsy , please review this PR. If you ACK it, I'll merge both changes for config persistence into a single one. They are separate at the moment to make change review easier.