### PR TITLE
libsodium: fix _FORTIFY_SOURCE redefined issue

### DIFF
--- a/libs/libsodium/patches/001-fix-_FORTIFY_SOURCE-redefined.patch
+++ b/libs/libsodium/patches/001-fix-_FORTIFY_SOURCE-redefined.patch
@@ -1,0 +1,120 @@
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -1207,6 +1207,7 @@ AC_SUBST([am__untar])
+ ]) # _AM_PROG_TAR
+ 
+ m4_include([m4/ax_check_compile_flag.m4])
++m4_include([m4/ax_check_define.m4])
+ m4_include([m4/ax_check_link_flag.m4])
+ m4_include([m4/ld-output-def.m4])
+ m4_include([m4/libtool.m4])
+--- a/configure.ac
++++ b/configure.ac
+@@ -143,8 +143,10 @@ AC_PROG_CC_C99
+ AM_PROG_AS
+ AC_USE_SYSTEM_EXTENSIONS
+ 
+-AX_CHECK_COMPILE_FLAG([-D_FORTIFY_SOURCE=2],
+-  [CPPFLAGS="$CPPFLAGS -D_FORTIFY_SOURCE=2"])
++AC_CHECK_DEFINE([_FORTIFY_SOURCE], [], [
++  AX_CHECK_COMPILE_FLAG([-D_FORTIFY_SOURCE=2],
++    [CPPFLAGS="$CPPFLAGS -D_FORTIFY_SOURCE=2"])
++])
+ 
+ AX_CHECK_COMPILE_FLAG([-fvisibility=hidden],
+   [CFLAGS="$CFLAGS -fvisibility=hidden"])
+--- /dev/null
++++ b/m4/ax_check_define.m4
+@@ -0,0 +1,92 @@
++# ===========================================================================
++#      http://www.gnu.org/software/autoconf-archive/ax_check_define.html
++# ===========================================================================
++#
++# SYNOPSIS
++#
++#   AC_CHECK_DEFINE([symbol], [ACTION-IF-FOUND], [ACTION-IF-NOT])
++#   AX_CHECK_DEFINE([includes],[symbol], [ACTION-IF-FOUND], [ACTION-IF-NOT])
++#
++# DESCRIPTION
++#
++#   Complements AC_CHECK_FUNC but it does not check for a function but for a
++#   define to exist. Consider a usage like:
++#
++#    AC_CHECK_DEFINE(__STRICT_ANSI__, CFLAGS="$CFLAGS -D_XOPEN_SOURCE=500")
++#
++# LICENSE
++#
++#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
++#
++#   This program is free software; you can redistribute it and/or modify it
++#   under the terms of the GNU General Public License as published by the
++#   Free Software Foundation; either version 3 of the License, or (at your
++#   option) any later version.
++#
++#   This program is distributed in the hope that it will be useful, but
++#   WITHOUT ANY WARRANTY; without even the implied warranty of
++#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
++#   Public License for more details.
++#
++#   You should have received a copy of the GNU General Public License along
++#   with this program. If not, see <http://www.gnu.org/licenses/>.
++#
++#   As a special exception, the respective Autoconf Macro's copyright owner
++#   gives unlimited permission to copy, distribute and modify the configure
++#   scripts that are the output of Autoconf when processing the Macro. You
++#   need not follow the terms of the GNU General Public License when using
++#   or distributing such scripts, even though portions of the text of the
++#   Macro appear in them. The GNU General Public License (GPL) does govern
++#   all other use of the material that constitutes the Autoconf Macro.
++#
++#   This special exception to the GPL applies to versions of the Autoconf
++#   Macro released by the Autoconf Archive. When you make and distribute a
++#   modified version of the Autoconf Macro, you may extend this special
++#   exception to the GPL to apply to your modified version as well.
++
++#serial 8
++
++AU_ALIAS([AC_CHECK_DEFINED], [AC_CHECK_DEFINE])
++AC_DEFUN([AC_CHECK_DEFINE],[
++AS_VAR_PUSHDEF([ac_var],[ac_cv_defined_$1])dnl
++AC_CACHE_CHECK([for $1 defined], ac_var,
++AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
++  #ifdef $1
++  int ok;
++  #else
++  choke me
++  #endif
++]])],[AS_VAR_SET(ac_var, yes)],[AS_VAR_SET(ac_var, no)]))
++AS_IF([test AS_VAR_GET(ac_var) != "no"], [$2], [$3])dnl
++AS_VAR_POPDEF([ac_var])dnl
++])
++
++AU_ALIAS([AX_CHECK_DEFINED], [AX_CHECK_DEFINE])
++AC_DEFUN([AX_CHECK_DEFINE],[
++AS_VAR_PUSHDEF([ac_var],[ac_cv_defined_$2_$1])dnl
++AC_CACHE_CHECK([for $2 defined in $1], ac_var,
++AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <$1>]], [[
++  #ifdef $2
++  int ok;
++  #else
++  choke me
++  #endif
++]])],[AS_VAR_SET(ac_var, yes)],[AS_VAR_SET(ac_var, no)]))
++AS_IF([test AS_VAR_GET(ac_var) != "no"], [$3], [$4])dnl
++AS_VAR_POPDEF([ac_var])dnl
++])
++
++AC_DEFUN([AX_CHECK_FUNC],
++[AS_VAR_PUSHDEF([ac_var], [ac_cv_func_$2])dnl
++AC_CACHE_CHECK([for $2], ac_var,
++dnl AC_LANG_FUNC_LINK_TRY
++[AC_LINK_IFELSE([AC_LANG_PROGRAM([$1
++                #undef $2
++                char $2 ();],[
++                char (*f) () = $2;
++                return f != $2; ])],
++                [AS_VAR_SET(ac_var, yes)],
++                [AS_VAR_SET(ac_var, no)])])
++AS_IF([test AS_VAR_GET(ac_var) = yes], [$3], [$4])dnl
++AS_VAR_POPDEF([ac_var])dnl
++])# AC_CHECK_FUNC


### PR DESCRIPTION
If we already defined `CFLAGS=-D_FORTIFY_SOURCE=1`, it will still check `-D_FORTIFY_SOURCE=2` and add it to CPPFLAGS. In this case, we redefine `_FORTIFY_SOURCE` to both 1 and 2 if compiler accepts `-D_FORTIFY_SOURCE=2`.

Fix this issue by checking whether `_FORTIFY_SOURCE` was defined or not. If defined, do nothing. If not, then check `-D_FORTIFY_SOURCE=2`.

BTW, OpenWrt's buildroot uses `-D_FORTIFY_SOURCE=1` for most targets by default.

You can refer to: https://github.com/jedisct1/libsodium/pull/287

Signed-off-by: Shuoyao Wang <wong.syrone@gmail.com>