### PR TITLE
bluez: fix build with libiconv-full

### DIFF
--- a/utils/bluez/Makefile
+++ b/utils/bluez/Makefile
@@ -96,6 +96,8 @@ CONFIGURE_ARGS += \
 TARGET_CPPFLAGS += \
 	-D_GNU_SOURCE
 
+TARGET_LDFLAGS += -Wl,-rpath-link,$(ICONV_PREFIX)/lib
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/bluetooth $(1)/usr/include/


### PR DESCRIPTION
This fixes the following build warning and its resulting build error by
adding the path to the libiconv-full directory manually.

ld: warning: libiconv.so.2, needed by staging_dir/target-mipsel_mips32_musl-1.1.10/usr/lib/libgthread-2.0.so, not found (try using -rpath or -rpath-link)

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>