### PR TITLE
netperf: fix gcc5

### DIFF
--- a/net/netperf/Makefile
+++ b/net/netperf/Makefile
@@ -26,6 +26,8 @@ define Package/netperf
   MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 endef
 
+TARGET_CFLAGS+=-std=gnu89
+
 CONFIGURE_ARGS += --enable-demo
 
 define Package/netperf/install


### PR DESCRIPTION
default C standard changed in gcc5 so set old variant

Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>