### PR TITLE
flashrom: fix gcc5 build

### DIFF
--- a/utils/flashrom/Makefile
+++ b/utils/flashrom/Makefile
@@ -46,6 +46,8 @@ define Package/flashrom/description
  /firmware images.
 endef
 
+TARGET_CFLAGS+=-std=gnu89
+
 MAKE_FLAGS += \
 	PREFIX="/usr"
 


### PR DESCRIPTION
default C dialect changed with gcc5
explicitly use old C dialect

Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>