### PR TITLE
dtndht: fix musl build

### DIFF
--- a/libs/dtndht/patches/001-musl_header.patch
+++ b/libs/dtndht/patches/001-musl_header.patch
@@ -1,0 +1,30 @@
+--- a/dtndht/dtndht.h
++++ b/dtndht/dtndht.h
+@@ -7,6 +7,7 @@ extern "C" {
+ 
+ #include <stdio.h>
+ #include <sys/socket.h>
++#include <time.h>
+ 
+ enum dtn_dht_bind_type {
+ 	BINDNONE = 0, IPV4ONLY = 1, IPV6ONLY = 2, BINDBOTH = 3
+--- a/dtndht/blacklist.c
++++ b/dtndht/blacklist.c
+@@ -6,6 +6,7 @@
+ #include <string.h>
+ #include <stdio.h>
+ #include <arpa/inet.h>
++#include <sys/types.h>
+ #ifdef HAVE_OPENSSL_SHA_H
+ #include <openssl/sha.h>
+ #else
+--- a/dtndht/rating.h
++++ b/dtndht/rating.h
+@@ -12,6 +12,7 @@
+ #include <sys/socket.h>
+ #include <arpa/inet.h>
+ #include <string.h>
++#include <time.h>
+ #ifdef HAVE_OPENSSL_SHA_H
+ #include <openssl/sha.h>
+ #else


### PR DESCRIPTION
add missing headers on musl

only compile tested

Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>