### PR TITLE
fdm: fix musl compile

### DIFF
--- a/mail/fdm/patches/010-musl_WAIT_ANY.patch
+++ b/mail/fdm/patches/010-musl_WAIT_ANY.patch
@@ -1,0 +1,13 @@
+--- a/fdm.c
++++ b/fdm.c
+@@ -22,6 +22,10 @@
+ #include <sys/utsname.h>
+ #include <sys/wait.h>
+ 
++#ifndef WAIT_ANY
++#define WAIT_ANY (-1)
++#endif
++
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <fnmatch.h>

--- a/mail/fdm/patches/020-musl_GLOB_BRACE.patch
+++ b/mail/fdm/patches/020-musl_GLOB_BRACE.patch
@@ -1,0 +1,22 @@
+--- a/fetch-maildir.c
++++ b/fetch-maildir.c
+@@ -31,6 +31,8 @@
+ #include "fdm.h"
+ #include "fetch.h"
+ 
++#define GLOB_BRACE 0
++
+ int	fetch_maildir_commit(struct account *, struct mail *);
+ void	fetch_maildir_abort(struct account *);
+ u_int	fetch_maildir_total(struct account *);
+--- a/fetch-mbox.c
++++ b/fetch-mbox.c
+@@ -32,6 +32,8 @@
+ #include "fdm.h"
+ #include "fetch.h"
+ 
++#define GLOB_BRACE 0
++
+ int	fetch_mbox_commit(struct account *, struct mail *);
+ void	fetch_mbox_abort(struct account *);
+ u_int	fetch_mbox_total(struct account *);

--- a/mail/fdm/patches/030-musl_ACCESSPERMS.patch
+++ b/mail/fdm/patches/030-musl_ACCESSPERMS.patch
@@ -1,0 +1,11 @@
+--- a/file.c
++++ b/file.c
+@@ -26,6 +26,8 @@
+ 
+ #include "fdm.h"
+ 
++#define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO)
++
+ int	mklock(u_int, const char *);
+ void	rmlock(u_int, const char *);
+ int	lockfd(u_int, int);


### PR DESCRIPTION
musl does not define some macros so define them ourselves

Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>