### PR TITLE
shine: fix mips64 (octeon) build error

### DIFF
--- a/sound/shine/patches/001-fix_mips64_bswap.patch
+++ b/sound/shine/patches/001-fix_mips64_bswap.patch
@@ -1,0 +1,11 @@
+--- a/src/bin/wave.c
++++ b/src/bin/wave.c
+@@ -168,7 +168,7 @@ unsigned char wave_open(const char *fnam
+ }
+ 
+ #ifdef SHINE_BIG_ENDIAN
+-#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))
++#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8))
+ #define bswap_16(x) __builtin_bswap16(x)
+ #else
+ #define bswap_16(x) ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8))


### PR DESCRIPTION
error reported by buildbot, replicated locally:
wave.c:(.text+0x8e4): undefined reference to `__builtin_bswap16'

It seems that gcc builtin function is not working for mips64

according to
https://gcc.gnu.org/ml/gcc-patches/2014-01/msg00551.html
bswap patterns only work in >4.8 so the compiler
check in wave.c seems inconsistent across different archs
as octeon has gcc 4.6

make it require gcc >=4.8
compile tested only

Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>