### PR TITLE
python-setuptools: revamp installation procedure, update to 18.1

### DIFF
--- a/lang/python-setuptools/Makefile
+++ b/lang/python-setuptools/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-setuptools
-PKG_VERSION:=18.0.1
+PKG_VERSION:=18.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=setuptools-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/source/s/setuptools/
-PKG_MD5SUM:=cecd172c9ff7fd5f2e16b2fcc88bba51
+PKG_MD5SUM:=f72e87f34fbf07f299f6cb46256a0b06
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/setuptools-$(PKG_VERSION)
 
@@ -35,7 +35,8 @@ endef
 
 define Build/Compile
 	$(call Build/Compile/PyMod,,\
-		install --prefix="$(PKG_INSTALL_DIR)/usr" \
+		install --root="$(PKG_INSTALL_DIR)" --prefix="/usr" \
+		--single-version-externally-managed \
 	)
 endef
 


### PR DESCRIPTION
It's better to install setuptools-enabled Python packages with a special flag that makes a flatter structure of the egg and does not create site.py file. Already done for python-pip recently. Also, version was bumped to 18.1.

Signed-off-by: Jan Čermák <jan.cermak@nic.cz>