### PR TITLE
aircrack-ng: update from 1.2-rc1 to 1.2-rc2.

### DIFF
--- a/net/aircrack-ng/Makefile
+++ b/net/aircrack-ng/Makefile
@@ -8,17 +8,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aircrack-ng
-PKG_VERSION:=1.2-rc1
+PKG_VERSION:=1.2-rc2
 PKG_RELEASE:=1
-PKG_LICENSE:=GPLv2
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.aircrack-ng.org/ \
 		http://archive.aircrack-ng.org/aircrack-ng/$(PKG_VERSION)/
-PKG_MD5SUM:=c2f8648c92f7e46051c86c618d4fb0d5
+PKG_MD5SUM:=ebe9d537f06f4d6956213af09c4476da
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
+
+PKG_MAINTAINER:=Rick Farina <zerochaos@gentoo.org>
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -28,7 +31,6 @@ define Package/aircrack-ng
   DEPENDS:=+libpcap +libpthread +libopenssl +libnl +wireless-tools +ethtool
   TITLE:=WLAN tools for breaking 802.11 WEP/WPA keys
   URL:=http://www.aircrack-ng.org/
-  MAINTAINER:=Rick Farina <zerochaos@gentoo.org>
   SUBMENU:=wireless
 endef
 


### PR DESCRIPTION
Hi, @ZeroChaos- 

 - Use SPDX identifier for license name.
 - Add PKG_LICENSE_FILES definition.
 - Set PKG_MAINTAINER (MAINTAINER variable will take value from it).

Release notice from aircrack-ng.org:

  Here is the second release candidate. Along with a LOT of fixes, it
  improves the support for the Airodump-ng scan visualizer. Airmon-zc is
  mature and is now renamed to Airmon-ng. Also, Airtun-ng is now able to
  encrypt and decrypt WPA on top of WEP. Another big change is recent
  version of GPSd now work very well with Airodump-ng.

Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>