### PR TITLE
lsof: use original tarballs, update to 4.89

### DIFF
--- a/utils/lsof/Makefile
+++ b/utils/lsof/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2014 OpenWrt.org
+# Copyright (C) 2007-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,13 +9,13 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=lsof
-PKG_VERSION:=4.86
-PKG_RELEASE:=3
+PKG_VERSION:=4.89
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION)+dfsg.orig.tar.gz
-PKG_SOURCE_URL:=http://ftp2.de.debian.org/debian/pool/main/l/lsof
-PKG_MD5SUM:=23420509564a897b76055f9d84d19068
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)+dfsg.orig
+PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://www.mirrorservice.org/sites/lsof.itap.purdue.edu/pub/tools/unix/lsof/ ftp://sunsite.ualberta.ca/pub/Mirror/lsof/ ftp://ftp.fu-berlin.de/pub/unix/tools/lsof
+PKG_MD5SUM:=1b9cd34f3fb86856a125abbf2be3a386
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)_$(PKG_VERSION)
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=Unique
 PKG_LICENSE_FILES:=00README
@@ -37,6 +37,12 @@ ifeq ($(CONFIG_IPV6),y)
 else
   LINUX_CLIB_IPV6=
 endif
+
+define Build/Prepare
+	$(PKG_UNPACK)
+	(cd $(PKG_BUILD_DIR) && tar -xf $(PKG_NAME)_$(PKG_VERSION)_src.tar && mv $(PKG_NAME)_$(PKG_VERSION)_src/* .)
+	$(Build/Patch)
+endef
 
 define Build/Configure
 	cd $(PKG_BUILD_DIR); \

--- a/utils/lsof/patches/003-lsof_selinux.patch
+++ b/utils/lsof/patches/003-lsof_selinux.patch
@@ -1,6 +1,8 @@
+diff --git a/Configure b/Configure
+index e4a25a2..3a6e78b 100755
 --- a/Configure
 +++ b/Configure
-@@ -2806,7 +2806,7 @@ return(0); }
+@@ -2923,7 +2923,7 @@ return(0); }
  	LSOF_TMP1=1
        fi	# }
      fi	# }

--- a/utils/lsof/patches/004-lsof_ccv.patch
+++ b/utils/lsof/patches/004-lsof_ccv.patch
@@ -1,6 +1,8 @@
+diff --git a/Configure b/Configure
+index 3a6e78b..a2946c6 100755
 --- a/Configure
 +++ b/Configure
-@@ -2682,6 +2682,9 @@ LOCKF_OWNER4
+@@ -2788,6 +2788,9 @@ LOCKF_OWNER4
      if test "X$LSOF_CC" = "X"	# {
      then
        LSOF_CC=cc


### PR DESCRIPTION
Signed-off-by: Maxim Storchak <m.storchak@gmail.com>