### PR TITLE
openocd: Fix build when BUILD_NLS=y (full language support)

### DIFF
--- a/utils/openocd/Makefile
+++ b/utils/openocd/Makefile
@@ -26,6 +26,7 @@ PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/openocd
   SECTION:=utils
@@ -62,6 +63,8 @@ CONFIGURE_ARGS += \
 	--enable-usb_blaster_libftdi \
         --enable-openjtag_ftdi \
         --enable-presto_libftdi
+
+TARGET_LDFLAGS+= $(if $(ICONV_FULL),-liconv)
 
 define Build/Compile
         +$(MAKE_VARS) \


### PR DESCRIPTION
Linking with hidapi which is dependent on libiconv fails when libiconv-full is selected. I am not sure this is the best fix, but it works. I have tried building hidapi differently but always ended up with undefined symbols when linking this utility and 'crelay' (same issue). .

Signed-off-by: Ted Hess <thess@kitschensync.net>