### PR TITLE
e2guardian : typo into procd init script

### DIFF
--- a/net/e2guardian/files/e2guardian.init
+++ b/net/e2guardian/files/e2guardian.init
@@ -15,7 +15,7 @@ validate_e2guardian_section() {
 		'accessdeniedaddress:string' \
 		'bannediplist:string' \
 		'contentscanexceptions:string' \
-		'contentscanner:string'
+		'contentscanner:string' \
 		'contentscannertimeout:uinteger' \
 		'createlistcachefiles:string' \
 		'custombannedflashfile:string' \


### PR DESCRIPTION
Without this, produces an error :
<code>/etc/rc.common: line 1: contentscannertimeout:uinteger: not found
validation failed
/etc/rc.common: line 1: contentscannertimeout:uinteger: not found</code>

Signed-off-by: Julien Paquit julien@databeille.com