### PR TITLE
libxml2: disable parallel build

### DIFF
--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -24,7 +24,7 @@ PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
+PKG_BUILD_PARALLEL:=0
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
libxml2 fails to build in one of three runs.

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>