### PR TITLE
zabbix: Enable IPv6 support

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=2.4.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/zabbix
@@ -107,6 +107,7 @@ CONFIGURE_ARGS+= \
 	--enable-agent \
 	--enable-server \
 	--enable-proxy \
+	--enable-ipv6 \
 	--disable-java \
 	--with-sqlite3="$(STAGING_DIR)/usr"
 


### PR DESCRIPTION
As stated in the heading zabbix can be used with IPv6 now.

I have not tested this patch because I was unable to get the SDK working yet.

Signed-off-by: Thomas Bahn <thomas-bahn@gmx.net>