### PR TITLE
collectd: Enable entropy plugin

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.5.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://collectd.org/files/
@@ -36,7 +36,6 @@ COLLECTD_PLUGINS_DISABLED:= \
 	curl_xml \
 	dbi \
 	drbd \
-	entropy \
 	ethstat \
 	fhcount \
 	genericjmx \
@@ -109,6 +108,7 @@ COLLECTD_PLUGINS_SELECTED:= \
 	disk \
 	dns \
 	email \
+	entropy \
 	exec \
 	filecount \
 	fscache \
@@ -300,6 +300,7 @@ $(eval $(call BuildPlugin,df,disk space input,df,))
 $(eval $(call BuildPlugin,disk,disk usage/timing input,disk,))
 $(eval $(call BuildPlugin,dns,DNS traffic input,dns,+PACKAGE_collectd-mod-dns:libpcap))
 $(eval $(call BuildPlugin,email,email output,email,))
+$(eval $(call BuildPlugin,entropy,Entropy amount input,entropy,))
 $(eval $(call BuildPlugin,exec,process exec input,exec,))
 $(eval $(call BuildPlugin,filecount,file count input,filecount,))
 $(eval $(call BuildPlugin,fscache,file-system based caching framework input,fscache,))


### PR DESCRIPTION
Enable compilation of the "entropy" plugin that monitors the available entropy in a Linux system.
(Data is read from /proc/sys/kernel/random/entropy_avail)

Works ok and has no library dependencies. Tested on ar71xx/WNDR3700.

Link to source: https://github.com/collectd/collectd/blob/collectd-5.5/src/entropy.c

Ps. I have created also the corresponding Luci statistics plugin (below), but this support in collectd needs to be committed first.
![entropy-plugin](https://cloud.githubusercontent.com/assets/7926856/9503052/6890c79c-4c3d-11e5-8af1-9046bc0ecf5c.png)
