### PR TITLE
boost: Fix building without hard float (fenv.h)

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -17,7 +17,7 @@ include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=boost
 PKG_VERSION:=1_59_0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/boost
@@ -177,6 +177,7 @@ endef
 CONFIGURE_PREFIX:=$(PKG_INSTALL_DIR)
 TARGET_LDFLAGS += -pthread -lrt
 
+TARGET_CFLAGS += $(if $(CONFIG_SOFT_FLOAT),-DBOOST_NO_FENV_H)
 
 ifneq ($(findstring mips,$(ARCH)),)
     BOOST_ABI = o32


### PR DESCRIPTION
Current builds of boost 'test' packages are failing due to lack of FE_xxx defintions from 'include/bits/fenv.h'. On platforms with soft FP these symbols are not defined (due to conditional in fenv.h) 

This fix directs boost to build without fenv.h if CONFIG_SOFT_FLOAT is defined.

Signed-off-by: Ted Hess <thess@kitschensync.net>