### PR TITLE
libzdb: musl compatibility fix

### DIFF
--- a/libs/libzdb/Makefile
+++ b/libs/libzdb/Makefile
@@ -23,6 +23,10 @@ PKG_BUILD_DEPENDS:=libzdb/host
 
 include $(INCLUDE_DIR)/package.mk
 
+ifeq ($(CONFIG_USE_MUSL),n)
+    LDFLAGS += -lnsl
+endif
+
 define Package/libzdb
     SECTION:=libs
     CATEGORY:=Libraries

--- a/libs/libzdb/patches/010-cross-compile-fixes.patch
+++ b/libs/libzdb/patches/010-cross-compile-fixes.patch
@@ -40,7 +40,7 @@ diff -rupN libzdb-3.0.orig/configure.ac libzdb-3.0/configure.ac
 -                DBCPPFLAGS="$DBCPPFLAGS `$MYSQLCONFIG --include`"
 -                DBLDFLAGS="$DBLDFLAGS `$MYSQLCONFIG --libs`"
 +                DBCPPFLAGS="$DBCPPFLAGS -I$STAGING_DIR/usr/include/mysql"
-+                DBLDFLAGS="$DBLDFLAGS -L$STAGING_DIR/usr/lib/mysql -L$STAGING_DIR/usr/lib -lmysqlclient -lz -lcrypt -lnsl -lm"
++                DBLDFLAGS="$DBLDFLAGS -L$STAGING_DIR/usr/lib/mysql -L$STAGING_DIR/usr/lib -lmysqlclient -lz -lcrypt -lm $LDFLAGS"
                  AC_DEFINE([HAVE_LIBMYSQLCLIENT], 1, [Define to 1 to enable mysql])
          else
                  CPPFLAGS=$svd_CPPFLAGS


### PR DESCRIPTION
Add -lnsl linker flag only when not building against musl (typo fixed).