### PR TITLE
openocd: include nls.mk to fix build with full NLS support

### DIFF
--- a/utils/openocd/Makefile
+++ b/utils/openocd/Makefile
@@ -26,6 +26,7 @@ PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/openocd
   SECTION:=utils


### PR DESCRIPTION
Since openocd depends on hidapi it needs appropriate LD_FLAGS to link
against it as that library depends on libiconv.

Signed-off-by: Paul Fertser <fercerpav@gmail.com>