### PR TITLE
collectd: backport the entropy plugin and changes to example config file

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.4.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://collectd.org/files/
@@ -33,7 +33,6 @@ COLLECTD_PLUGINS_DISABLED:= \
 	curl_json \
 	curl_xml \
 	dbi \
-	entropy \
 	ethstat \
 	genericjmx \
 	gmond \
@@ -95,6 +94,7 @@ COLLECTD_PLUGINS_SELECTED:= \
 	disk \
 	dns \
 	email \
+	entropy \
 	exec \
 	filecount \
 	fscache \
@@ -286,6 +286,7 @@ $(eval $(call BuildPlugin,df,disk space input,df,))
 $(eval $(call BuildPlugin,disk,disk usage/timing input,disk,))
 $(eval $(call BuildPlugin,dns,DNS traffic input,dns,+PACKAGE_collectd-mod-dns:libpcap))
 $(eval $(call BuildPlugin,email,email output,email,))
+$(eval $(call BuildPlugin,entropy,Entropy amount input,entropy,))
 $(eval $(call BuildPlugin,exec,process exec input,exec,))
 $(eval $(call BuildPlugin,filecount,file count input,filecount,))
 $(eval $(call BuildPlugin,fscache,file-system based caching framework input,fscache,))

--- a/utils/collectd/files/collectd.conf
+++ b/utils/collectd/files/collectd.conf
@@ -1,90 +1,39 @@
-#
-# OpenWrt Config file for collectd(1).
-# Please read collectd.conf(5) for a list of options.
-# http://collectd.org/
-#
+# Config file for collectd. More info: https://collectd.org/
+# Note: Luci statistics will generate a new config and overwrite this file.
 
 #Hostname   "localhost"
 #FQDNLookup  true
-BaseDir     "/var/lib/collectd"
-PIDFile     "/var/run/collectd.pid"
-#PluginDir  "/usr/lib/collectd"
-#TypesDB    "/usr/share/collectd/types.db"
+BaseDir "/var/run/collectd"
+Include "/etc/collectd/conf.d"
+PIDFile "/var/run/collectd.pid"
+PluginDir "/usr/lib/collectd"
+TypesDB "/usr/share/collectd/types.db"
 Interval    30
 ReadThreads 2
 
-#LoadPlugin syslog
-#LoadPlugin logfile
-
-#<Plugin syslog>
-#	LogLevel info
-#</Plugin>
-
-#<Plugin logfile>
-#	LogLevel info
-#	File STDOUT
-#	Timestamp true
-#</Plugin>
-
-LoadPlugin cpu
-LoadPlugin df
-LoadPlugin disk
 LoadPlugin interface
 LoadPlugin load
-LoadPlugin memory
-LoadPlugin network
 #LoadPlugin ping
-#LoadPlugin processes
-#LoadPlugin rrdtool
-#LoadPlugin serial
-LoadPlugin wireless
+LoadPlugin rrdtool
 
-#<Plugin df>
-#	FSType tmpfs
-#	IgnoreSelected true
-#	ReportByDevice false
-#	ReportReserved false
-#	ReportInodes false
-#</Plugin>
+<Plugin rrdtool>
+	DataDir "/tmp/rrd"
+	RRARows 100
+	RRASingle true
+	RRATimespan 3600
+	RRATimespan 86400
+	RRATimespan 604800
+	RRATimespan 2678400
+	RRATimespan 31622400
+</Plugin>
 
-#<Plugin disk>
-#	Disk "/^[hs]d[a-f][0-9]?$/"
-#	IgnoreSelected false
-#</Plugin>
-
-#<Plugin interface>
-#	Interface "eth0"
-#	Interface "br-lan"
-#	IgnoreSelected false
-#</Plugin>
-
-<Plugin network>
-#	Server "ff18::efc0:4a42" "25826"
-	Server "239.192.74.66" "25826"
-#	Listen "ff18::efc0:4a42" "25826"
-#	Listen "239.192.74.66" "25826"
-#	TimeToLive "128"
-#	Forward false
-#	CacheFlush 1800
-#	ReportStats false
+<Plugin interface>
+	IgnoreSelected false
+	Interface "br-lan"
 </Plugin>
 
 #<Plugin ping>
 #	Host "host.foo.bar"
-#	Interval 1.0
-#	Timeout 0.9
-#	TTL 255
-#	SourceAddress "1.2.3.4"
-#	Device "eth0"
-#	MaxMissed -1
-#</Plugin>
-
-#<Plugin processes>
-#	Process "name"
-#</Plugin>
-
-#<Plugin rrdtool>
-#	DataDir "/var/lib/collectd/rrd"
-#	CacheTimeout 120
-#	CacheFlush   900
+#	Interval 30
+#	TTL 127
 #</Plugin>


### PR DESCRIPTION
Enable 'entropy' plugin also for collectd 5.4.2.
Works ok.

( backport of https://github.com/openwrt/packages/commit/35552db4ee8162b5c85f2a9e370177681a70431c )

@jow- 
