### PR TITLE
madplay: Fix various build issues

### DIFF
--- a/sound/madplay/Makefile
+++ b/sound/madplay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=madplay
 PKG_VERSION:=0.15.2b
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/mad \
@@ -20,14 +20,14 @@ PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Simon Peter <probono@puredarwin.org>
 
 PKG_FIXUP:=autoreconf
-PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/madplay
   SECTION:=sound
   CATEGORY:=Sound
-  DEPENDS:=+libid3tag +libmad
+  DEPENDS:=+libid3tag +libmad $(INTL_DEPENDS)
   TITLE:=MPEG audio player in fixed point
   URL:=http://sourceforge.net/projects/mad
 endef
@@ -57,7 +57,7 @@ endef
 
 define Package/madplay/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/madplay $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/madplay $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,madplay))

--- a/sound/madplay/patches/010-use_correct_shell.patch
+++ b/sound/madplay/patches/010-use_correct_shell.patch
@@ -1,0 +1,30 @@
+--- a/intl/Makefile.in
++++ b/intl/Makefile.in
+@@ -19,7 +19,7 @@
+ PACKAGE = @PACKAGE@
+ VERSION = @VERSION@
+ 
+-SHELL = /bin/sh
++SHELL = @SHELL@
+ 
+ srcdir = @srcdir@
+ top_srcdir = @top_srcdir@
+@@ -56,6 +56,7 @@ DEFS = -DLOCALEDIR=\"$(localedir)\" -DLO
+ -DENABLE_RELOCATABLE=1 -DIN_LIBRARY -DINSTALLDIR=\"$(libdir)\" -DNO_XMALLOC \
+ -Dset_relocation_prefix=libintl_set_relocation_prefix \
+ -Drelocate=libintl_relocate \
++-DINSTALLPREFIX=\"$(prefix)\" \
+ -DDEPENDS_ON_LIBICONV=1 @DEFS@
+ CPPFLAGS = @CPPFLAGS@
+ CFLAGS = @CFLAGS@
+--- a/po/Makefile.in.in
++++ b/po/Makefile.in.in
+@@ -13,7 +13,7 @@
+ PACKAGE = @PACKAGE@
+ VERSION = @VERSION@
+ 
+-SHELL = /bin/sh
++SHELL = @SHELL@
+ @SET_MAKE@
+ 
+ srcdir = @srcdir@


### PR DESCRIPTION
- Needs iconv dependency (pkg error)
- Wrong shell (/bin/sh) invoked explicitly to launch libtool (platform issue)
- Missing symbol definition building intl options (INSTALLPREFIX)

@probonopd  - please review

Signed-off-by: Ted Hess <thess@kitschensync.net>