### PR TITLE
collectd: Clarify config file example/placeholder

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.5.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://collectd.org/files/

--- a/utils/collectd/files/collectd.conf
+++ b/utils/collectd/files/collectd.conf
@@ -1,90 +1,39 @@
-#
-# OpenWrt Config file for collectd(1).
-# Please read collectd.conf(5) for a list of options.
-# http://collectd.org/
-#
+# Config file for collectd. More info: https://collectd.org/
+# Note: Luci statistics will generate a new config and overwrite this file.
 
 #Hostname   "localhost"
 #FQDNLookup  true
-BaseDir     "/var/lib/collectd"
-PIDFile     "/var/run/collectd.pid"
-#PluginDir  "/usr/lib/collectd"
-#TypesDB    "/usr/share/collectd/types.db"
+BaseDir "/var/run/collectd"
+Include "/etc/collectd/conf.d"
+PIDFile "/var/run/collectd.pid"
+PluginDir "/usr/lib/collectd"
+TypesDB "/usr/share/collectd/types.db"
 Interval    30
 ReadThreads 2
 
-#LoadPlugin syslog
-#LoadPlugin logfile
-
-#<Plugin syslog>
-#	LogLevel info
-#</Plugin>
-
-#<Plugin logfile>
-#	LogLevel info
-#	File STDOUT
-#	Timestamp true
-#</Plugin>
-
-LoadPlugin cpu
-LoadPlugin df
-LoadPlugin disk
 LoadPlugin interface
 LoadPlugin load
-LoadPlugin memory
-LoadPlugin network
 #LoadPlugin ping
-#LoadPlugin processes
-#LoadPlugin rrdtool
-#LoadPlugin serial
-LoadPlugin wireless
+LoadPlugin rrdtool
 
-#<Plugin df>
-#	FSType tmpfs
-#	IgnoreSelected true
-#	ReportByDevice false
-#	ReportReserved false
-#	ReportInodes false
-#</Plugin>
+<Plugin rrdtool>
+	DataDir "/tmp/rrd"
+	RRARows 100
+	RRASingle true
+	RRATimespan 3600
+	RRATimespan 86400
+	RRATimespan 604800
+	RRATimespan 2678400
+	RRATimespan 31622400
+</Plugin>
 
-#<Plugin disk>
-#	Disk "/^[hs]d[a-f][0-9]?$/"
-#	IgnoreSelected false
-#</Plugin>
-
-#<Plugin interface>
-#	Interface "eth0"
-#	Interface "br-lan"
-#	IgnoreSelected false
-#</Plugin>
-
-<Plugin network>
-#	Server "ff18::efc0:4a42" "25826"
-	Server "239.192.74.66" "25826"
-#	Listen "ff18::efc0:4a42" "25826"
-#	Listen "239.192.74.66" "25826"
-#	TimeToLive "128"
-#	Forward false
-#	CacheFlush 1800
-#	ReportStats false
+<Plugin interface>
+	IgnoreSelected false
+	Interface "br-lan"
 </Plugin>
 
 #<Plugin ping>
 #	Host "host.foo.bar"
-#	Interval 1.0
-#	Timeout 0.9
-#	TTL 255
-#	SourceAddress "1.2.3.4"
-#	Device "eth0"
-#	MaxMissed -1
-#</Plugin>
-
-#<Plugin processes>
-#	Process "name"
-#</Plugin>
-
-#<Plugin rrdtool>
-#	DataDir "/var/lib/collectd/rrd"
-#	CacheTimeout 120
-#	CacheFlush   900
+#	Interval 30
+#	TTL 127
 #</Plugin>


### PR DESCRIPTION
Sanitize and shorten the placeholder config file:
* Reference actively only the default plugins installed by luci statistics. (Removing extra option examples cuts the file size to half.)
* Match the placeholder config with the genuine config from luci statistics.

The config file shipped with collectd dates from 2010 ( http://git.openwrt.org/?p=packages.git;a=history;f=utils/collectd/files/collectd.conf ) and leads to error messages if luci statistics & collectd are installed, as it references several plugins not usually installed (by default by luci statistics), or such ones that have been renamed since then.
```
Configuring collectd.
plugin_load: Could not find plugin "cpu" in /usr/lib/collectd
plugin_load: Could not find plugin "df" in /usr/lib/collectd
plugin_load: Could not find plugin "disk" in /usr/lib/collectd
plugin_load: Could not find plugin "memory" in /usr/lib/collectd
plugin_load: Could not find plugin "wireless" in /usr/lib/collectd
```
(It also actively references to an IP address in the network plugin configuration.)

For most users, this file is just a placeholder during collectd installation, as /usr/bin/stat-genconfig from /etc/init.d/luci_statistics will overwrite it with a symlink to /var/etc/collectd.conf.
```
root@OpenWrt2:/tmp# ls -l /etc/col*
-rw-------    1 root     root           765 Aug 29 23:05 /etc/collectd.conf

root@OpenWrt2:/tmp# opkg install luci-app-statistics_git-15.242.21432-478bb37-1_
all.ipk
Installing luci-app-statistics (git-15.242.21432-478bb37-1) to root...
Configuring luci-app-statistics.

root@OpenWrt2:/tmp# ls -l /etc/col*
lrwxrwxrwx    1 root     root            22 Aug 30 10:46 /etc/collectd.conf -> /var/etc/collectd.conf
-rw-------    1 root     root           765 Aug 29 23:05 /etc/collectd.conf.bak
```

If somebody uses collectd separately from luci statistics, he will need to edit these settings anyway.

