### PR TITLE
python-setuptools: enforce __PYVENV_LAUNCHER__ env var use

### DIFF
--- a/lang/python-setuptools/patches/0002-fix-pyvenv-environment-get.patch
+++ b/lang/python-setuptools/patches/0002-fix-pyvenv-environment-get.patch
@@ -1,0 +1,13 @@
+diff --git a/setuptools/command/easy_install.py b/setuptools/command/easy_install.py
+index df1655b..24c34e5 100755
+--- a/setuptools/command/easy_install.py
++++ b/setuptools/command/easy_install.py
+@@ -1885,7 +1885,7 @@ class CommandSpec(list):
+             return param
+         if isinstance(param, list):
+             return cls(param)
+-        if param is None:
++        if param is None or os.environ.get('__PYVENV_LAUNCHER__'):
+             return cls.from_environment()
+         # otherwise, assume it's a string.
+         return cls.from_string(param)


### PR DESCRIPTION
Shoud fix issue:https://github.com/openwrt/packages/issues/1709
Seems it's python-setuptools' fault and not python-pip.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>