### PR TITLE
[Unbound] Update to 1.5.4

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.5.3
-PKG_RELEASE:=2
+PKG_VERSION:=1.5.4
+PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -17,7 +17,7 @@ PKG_MAINTAINER:=Michael Hanselmann <public@hansmi.ch>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unbound.net/downloads
-PKG_MD5SUM:=1e95fdcbaaf5dc87432d898006a5eb13
+PKG_MD5SUM:=f85854baad15adc7ce8acefe6cda4cf8
 
 PKG_BUILD_DEPENDS:=libexpat
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Bumped to latest upstream release - 1.5.4. Run-tested on ar71xx.

Signed-off by Stijn Segers <francesco.borromini@inventati.org>