### PR TITLE
owfs: add startup scripts, make features configurable and fix w1 adapter bugs

### DIFF
--- a/utils/owfs/Config.in
+++ b/utils/owfs/Config.in
@@ -1,0 +1,49 @@
+  menu "Customize libow"
+    depends on PACKAGE_libow
+
+    menu "Bus master and adapter support"
+      config LIBOW_MASTER_USB
+      bool "USB bus master support (requires libusb)"
+      help
+        Include support for USB adapters (NOT usb-serial adapters, which use
+        kernel driver and are supported anyway).
+        Turning this off will save ~13kB (and ~50kB weighting libusb dependency).
+      default y
+
+      config LIBOW_MASTER_I2C
+      bool "I2C bus master (DS2482) support"
+      default y
+      help
+        Include support for I2C adapters.
+        Turning this feature off will save ~6kB.
+
+      config LIBOW_MASTER_W1
+      bool "Kernel W1 bus master support (requires kmod-w1)"
+      help
+        Support kernel 1-Wire bus masters (requires KConfig CONFIG_CONNECTOR=y
+        and CONFIG_W1_CON=y).
+        Turning this on will increase libow size by about 10kB.
+      default n
+    endmenu
+
+    config LIBOW_ZEROCONF
+    bool "Zeroconf/bonjour support"
+    default y
+    help
+      Enable server process announcement using Zeroconf (Bonjour) protocol.
+      Turning this feature on will increase owlib size by about 12kB.
+
+    config LIBOW_DEBUG
+    bool "Enable debug output (100+ kB)"
+    default y
+    help
+      If you don't need to debug your 1-wire network, you can save as much as
+      137kB disabling debug output.
+
+    config LIBOW_OWTRAFFIC
+    bool "Enable bus traffic reports"
+    default n
+    help
+      Enable owfs traffic monitor. It's here purely for debugging purposes.
+      Turning this on will increase libow size by about 3kB.
+  endmenu

--- a/utils/owfs/Makefile
+++ b/utils/owfs/Makefile
@@ -198,6 +198,15 @@ endef
 define Package/owfs/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/owfs $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/owfs.conf $(1)/etc/config/owfs
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/owfs.init $(1)/etc/init.d/owfs
+	mkdir -p $(1)/mnt/owfs
+endef
+
+define Package/owfs/conffiles
+/etc/config/owfs
 endef
 
 define Package/owshell/install
@@ -213,18 +222,41 @@ endef
 define Package/owserver/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/owserver $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/owserver.conf $(1)/etc/config/owserver
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/owserver.init $(1)/etc/init.d/owserver
+endef
+
+define Package/owserver/conffiles
+/etc/config/owserver
 endef
 
 define Package/owhttpd/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/owhttpd $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/owhttpd.conf $(1)/etc/config/owhttpd
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/owhttpd.init $(1)/etc/init.d/owhttpd
+endef
+
+define Package/owhttpd/conffiles
+/etc/config/owhttpd
 endef
 
 define Package/owftpd/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/owftpd $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/owftpd.conf $(1)/etc/config/owftpd
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/owftpd.init $(1)/etc/init.d/owftpd
 endef
 
+define Package/owftpd/conffiles
+/etc/config/owftpd
+endef
 
 define Package/libow/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/utils/owfs/Makefile
+++ b/utils/owfs/Makefile
@@ -20,6 +20,14 @@ PKG_LICENSE:=GPL-2.0
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
+PKG_CONFIG_DEPENDS:= \
+  CONFIG_LIBOW_MASTER_USB \
+  CONFIG_LIBOW_MASTER_I2C \
+  CONFIG_LIBOW_MASTER_W1 \
+  CONFIG_LIBOW_ZEROCONF \
+  CONFIG_LIBOW_DEBUG \
+  CONFIG_LIBOW_OWTRAFFIC
+
 include $(INCLUDE_DIR)/package.mk
 
 #
@@ -74,8 +82,15 @@ endef
 
 define Package/libow
   $(call Package/owfs/Library)
-  DEPENDS:=+libusb-compat +libpthread
+  DEPENDS:= \
+    +libpthread \
+    +LIBOW_MASTER_USB:libusb-compat \
+    +LIBOW_MASTER_W1:kmod-w1
   TITLE:=OWFS - common shared library
+endef
+
+define Package/libow/config
+  source "$(SOURCE)/Config.in"
 endef
 
 define Package/libow/description
@@ -170,13 +185,18 @@ CONFIGURE_ARGS += \
 	--with-fuseinclude="$(STAGING_DIR)/usr/include" \
 	--with-fuselib="$(STAGING_DIR)/usr/lib" \
 	--enable-shared \
-	--enable-zero \
 	--disable-parport \
 	--disable-ownet \
 	--disable-owpython \
 	--disable-owphp \
 	--disable-owtcl \
 	--disable-swig \
+	$(if $(CONFIG_LIBOW_MASTER_USB),--enable-usb,--disable-usb) \
+	$(if $(CONFIG_LIBOW_MASTER_W1),--enable-w1,--disable-w1) \
+	$(if $(CONFIG_LIBOW_MASTER_I2C),--enable-i2c,--disable-i2c) \
+	$(if $(CONFIG_LIBOW_ZEROCONF),--enable-zero,--disable-zero) \
+	$(if $(CONFIG_LIBOW_DEBUG),--enable-debug,--disable-debug) \
+	$(if $(CONFIG_LIBOW_OWTRAFFIC),--enable-owtraffic,--disable-owtraffic)
 
 CONFIGURE_VARS += \
 	LDFLAGS="$(TARGET_LDFLAGS) -Wl,-rpath-link=$(STAGING_DIR)/usr/lib -Wl,-rpath-link=$(TOOLCHAIN_DIR)/usr/lib" \

--- a/utils/owfs/files/owfs.conf
+++ b/utils/owfs/files/owfs.conf
@@ -1,0 +1,11 @@
+config owfs 'owfs'
+	option enabled 0
+	option uid 0
+	option gid 0
+	option readonly 0
+	option mountpoint '/mnt/owfs'
+	option fuse_allow_other 0
+	option fuse_open_opt ''
+	option error_level 0
+	option options ''
+	list devices '-s localhost:4304'

--- a/utils/owfs/files/owfs.conf
+++ b/utils/owfs/files/owfs.conf
@@ -1,11 +1,10 @@
 config owfs 'owfs'
 	option enabled 0
-	option uid 0
-	option gid 0
+	option user root
 	option readonly 0
 	option mountpoint '/mnt/owfs'
 	option fuse_allow_other 0
 	option fuse_open_opt ''
 	option error_level 0
-	option options ''
-	list devices '-s localhost:4304'
+	list devices '-s'
+	list devices 'localhost:4304'

--- a/utils/owfs/files/owfs.init
+++ b/utils/owfs/files/owfs.init
@@ -1,75 +1,82 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2009-2012 OpenWrt.org
+# Copyright (C) 2009-2015 OpenWrt.org
 
-START=99
+START=95
+USE_PROCD=1
 
-SERVICE_WRITE_PID=1
-SERVICE_DAEMONIZE=1
+PROG=/usr/bin/owfs
 
-# Workaround insufficient /dev/fuse permissions and the lack of /etc/fuse.conf
-DEFAULT_SERVICE_UID=0
-DEFAULT_SERVICE_GID=0
+append_arg() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
 
-append_device() {
-	append devices "$1"
+	config_get val "$cfg" "$var"
+	[ -n "$val" -o -n "$def" ] && procd_append_param command $opt "${val:-$def}"
 }
 
+append_bool() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
 
-start_owfs_daemon() {
-	local program="$1"
-	local config="$1"
-	local args="--foreground --error_print=1 $2"
+	config_get_bool val "$cfg" "$var" "$def"
+	[ "$val" = 1 ] && procd_append_param command "$opt"
+}
 
+append_plain() {
+	procd_append_param command "$1"
+}
 
+append_param() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
+
+	config_get val "$cfg" "$var"
+	[ -n "$val" -o -n "$def" ] && procd_append_param "$opt" "${val:-$def}"
+}
+
+start_instance() {
+	local cfg="$1"
 	local enabled
-	config_get_bool enabled "$config" enabled 0
-	[ "${enabled}" -eq 0 ] && return 1
 
-	local readonly
-	config_get_bool readonly "$config" readonly 0
-	[ "${readonly}" -eq 1 ] && append args "--readonly"
+	config_get_bool enabled "$cfg" 'enabled' '0'
+	[ "$enabled" = 0 ] && return 1
 
-	local error_level
-	config_get error_level "$config" error_level
-	[ -n "${error_level}" ] && append args "--error_level=${error_level}"
+	procd_open_instance
 
-	local options
-	config_get options "$config" options
+	procd_set_param command "$PROG" --foreground --error_print=1
 
-	devices=""
-	config_list_foreach "$config" devices append_device
+	# common parameters
+	append_bool "$cfg" readonly "--readonly"
+	append_arg "$cfg" error_level "--error_level"
+	config_list_foreach "$cfg" options append_plain
+	config_list_foreach "$cfg" devices append_plain
+	append_param "$cfg" user user
 
-	config_get SERVICE_UID "$config" uid "$DEFAULT_SERVICE_UID"
-	config_get SERVICE_GID "$config" gid "$DEFAULT_SERVICE_GID"
+	# owfs-specific
+	append_arg "$cfg" mountpoint "--mountpoint" /mnt/owfs
+	append_bool "$cfg" fuse_allow_other "--allow_other"
+	append_arg "$cfg" fuse_open_opt "--fuse_open_opt"
 
-	service_start "/usr/bin/$program" $args $options $devices
+	# don't respawn fuse
+
+	procd_close_instance
+
 }
 
-start_owfs() {
-	local config="owfs"
-	local args=""
-
-	config_load "$config"
-
-	local mountpoint
-	config_get mountpoint "$config" mountpoint /mnt/owfs
-	append args "--mountpoint=${mountpoint}"
-
-	local fuse_allow_other
-	config_get_bool fuse_allow_other "$config" fuse_allow_other 0
-	[ "${fuse_allow_other}" -eq 1 ] && append args "--allow_other"
-
-	local fuse_open_opt
-	config_get fuse_open_opt "$config" fuse_open_opt
-	[ -n "${fuse_open_opt}" ] && append args "--fuse_open_opt=\"${fuse_open_opt}\""
-
-	start_owfs_daemon "$config" "$args"
+service_triggers() {
+	procd_add_reload_trigger owfs
 }
 
-start() {
-	start_owfs
-}
-
-stop() {
-	service_stop /usr/bin/owfs
+start_service() {
+	config_load owfs
+	config_foreach start_instance owfs
 }

--- a/utils/owfs/files/owfs.init
+++ b/utils/owfs/files/owfs.init
@@ -1,0 +1,75 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2009-2012 OpenWrt.org
+
+START=99
+
+SERVICE_WRITE_PID=1
+SERVICE_DAEMONIZE=1
+
+# Workaround insufficient /dev/fuse permissions and the lack of /etc/fuse.conf
+DEFAULT_SERVICE_UID=0
+DEFAULT_SERVICE_GID=0
+
+append_device() {
+	append devices "$1"
+}
+
+
+start_owfs_daemon() {
+	local program="$1"
+	local config="$1"
+	local args="--foreground --error_print=1 $2"
+
+
+	local enabled
+	config_get_bool enabled "$config" enabled 0
+	[ "${enabled}" -eq 0 ] && return 1
+
+	local readonly
+	config_get_bool readonly "$config" readonly 0
+	[ "${readonly}" -eq 1 ] && append args "--readonly"
+
+	local error_level
+	config_get error_level "$config" error_level
+	[ -n "${error_level}" ] && append args "--error_level=${error_level}"
+
+	local options
+	config_get options "$config" options
+
+	devices=""
+	config_list_foreach "$config" devices append_device
+
+	config_get SERVICE_UID "$config" uid "$DEFAULT_SERVICE_UID"
+	config_get SERVICE_GID "$config" gid "$DEFAULT_SERVICE_GID"
+
+	service_start "/usr/bin/$program" $args $options $devices
+}
+
+start_owfs() {
+	local config="owfs"
+	local args=""
+
+	config_load "$config"
+
+	local mountpoint
+	config_get mountpoint "$config" mountpoint /mnt/owfs
+	append args "--mountpoint=${mountpoint}"
+
+	local fuse_allow_other
+	config_get_bool fuse_allow_other "$config" fuse_allow_other 0
+	[ "${fuse_allow_other}" -eq 1 ] && append args "--allow_other"
+
+	local fuse_open_opt
+	config_get fuse_open_opt "$config" fuse_open_opt
+	[ -n "${fuse_open_opt}" ] && append args "--fuse_open_opt=\"${fuse_open_opt}\""
+
+	start_owfs_daemon "$config" "$args"
+}
+
+start() {
+	start_owfs
+}
+
+stop() {
+	service_stop /usr/bin/owfs
+}

--- a/utils/owfs/files/owftpd.conf
+++ b/utils/owfs/files/owftpd.conf
@@ -1,9 +1,8 @@
 config owftpd 'owftpd'
 	option enabled 0
-	option uid 0
-	option gid 0
+	option user root
 	option readonly 0
 	option port 21
 	option error_level 0
-	option options ''
-	list devices '-s localhost:4304'
+	list devices '-s'
+	list devices 'localhost:4304'

--- a/utils/owfs/files/owftpd.conf
+++ b/utils/owfs/files/owftpd.conf
@@ -1,0 +1,9 @@
+config owftpd 'owftpd'
+	option enabled 0
+	option uid 0
+	option gid 0
+	option readonly 0
+	option port 21
+	option error_level 0
+	option options ''
+	list devices '-s localhost:4304'

--- a/utils/owfs/files/owftpd.init
+++ b/utils/owfs/files/owftpd.init
@@ -1,72 +1,81 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2009-2012 OpenWrt.org
+# Copyright (C) 2009-2015 OpenWrt.org
 
-START=99
+START=95
+USE_PROCD=1
 
-SERVICE_WRITE_PID=1
-SERVICE_DAEMONIZE=1
+PROG=/usr/bin/owftpd
 
-# Needed for restricted TCP port 21
-DEFAULT_SERVICE_UID=0
-DEFAULT_SERVICE_GID=0
+append_arg() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
 
-append_device() {
-	append devices "$1"
+	config_get val "$cfg" "$var"
+	[ -n "$val" -o -n "$def" ] && procd_append_param command $opt "${val:-$def}"
 }
 
+append_bool() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
 
-start_owfs_daemon() {
-	local program="$1"
-	local config="$1"
-	local args="--foreground --error_print=1 $2"
+	config_get_bool val "$cfg" "$var" "$def"
+	[ "$val" = 1 ] && procd_append_param command "$opt"
+}
 
+append_plain() {
+	procd_append_param command "$1"
+}
 
+append_param() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
+
+	config_get val "$cfg" "$var"
+	[ -n "$val" -o -n "$def" ] && procd_append_param "$opt" "${val:-$def}"
+}
+
+start_instance() {
+	local cfg="$1"
 	local enabled
-	config_get_bool enabled "$config" enabled 0
-	[ "${enabled}" -eq 0 ] && return 1
 
-	local readonly
-	config_get_bool readonly "$config" readonly 0
-	[ "${readonly}" -eq 1 ] && append args "--readonly"
+	config_get_bool enabled "$cfg" 'enabled' '0'
+	[ "$enabled" = 0 ] && return 1
 
-	local error_level
-	config_get error_level "$config" error_level
-	[ -n "${error_level}" ] && append args "--error_level=${error_level}"
+	procd_open_instance
 
-	local options
-	config_get options "$config" options
+	procd_set_param command "$PROG" --foreground --error_print=1
 
-	devices=""
-	config_list_foreach "$config" devices append_device
+	# common parameters
+	append_bool "$cfg" readonly "--readonly"
+	append_arg "$cfg" error_level "--error_level"
+	config_list_foreach "$cfg" options append_plain
+	config_list_foreach "$cfg" devices append_plain
+	append_param "$cfg" user user
 
-	config_get SERVICE_UID "$config" uid "$DEFAULT_SERVICE_UID"
-	config_get SERVICE_GID "$config" gid "$DEFAULT_SERVICE_GID"
+	# owftpd-specific
+	append_arg "$cfg" port "--port"
+	append_arg "$cfg" max_connections "--max_connections"
 
-	service_start "/usr/bin/$program" $args $options $devices
+	procd_set_param respawn
+
+	procd_close_instance
+
 }
 
-start_owftpd() {
-	local config="owftpd"
-	local args=""
-
-	config_load "$config"
-
-	local port
-	config_get port "$config" port
-	[ -n "${port}" ] && append args "--port=${port}"
-
-	local max_connections
-	config_get max_connections "$config" max_connections
-	[ -n "${max_connections}" ] && append args "--max_connections=${max_connections}"
-
-	start_owfs_daemon "$config" "$args"
+service_triggers() {
+	procd_add_reload_trigger owftpd
 }
 
-
-start() {
-	start_owftpd
-}
-
-stop() {
-	service_stop /usr/bin/owftpd
+start_service() {
+	config_load owftpd
+	config_foreach start_instance owftpd
 }

--- a/utils/owfs/files/owftpd.init
+++ b/utils/owfs/files/owftpd.init
@@ -1,0 +1,72 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2009-2012 OpenWrt.org
+
+START=99
+
+SERVICE_WRITE_PID=1
+SERVICE_DAEMONIZE=1
+
+# Needed for restricted TCP port 21
+DEFAULT_SERVICE_UID=0
+DEFAULT_SERVICE_GID=0
+
+append_device() {
+	append devices "$1"
+}
+
+
+start_owfs_daemon() {
+	local program="$1"
+	local config="$1"
+	local args="--foreground --error_print=1 $2"
+
+
+	local enabled
+	config_get_bool enabled "$config" enabled 0
+	[ "${enabled}" -eq 0 ] && return 1
+
+	local readonly
+	config_get_bool readonly "$config" readonly 0
+	[ "${readonly}" -eq 1 ] && append args "--readonly"
+
+	local error_level
+	config_get error_level "$config" error_level
+	[ -n "${error_level}" ] && append args "--error_level=${error_level}"
+
+	local options
+	config_get options "$config" options
+
+	devices=""
+	config_list_foreach "$config" devices append_device
+
+	config_get SERVICE_UID "$config" uid "$DEFAULT_SERVICE_UID"
+	config_get SERVICE_GID "$config" gid "$DEFAULT_SERVICE_GID"
+
+	service_start "/usr/bin/$program" $args $options $devices
+}
+
+start_owftpd() {
+	local config="owftpd"
+	local args=""
+
+	config_load "$config"
+
+	local port
+	config_get port "$config" port
+	[ -n "${port}" ] && append args "--port=${port}"
+
+	local max_connections
+	config_get max_connections "$config" max_connections
+	[ -n "${max_connections}" ] && append args "--max_connections=${max_connections}"
+
+	start_owfs_daemon "$config" "$args"
+}
+
+
+start() {
+	start_owftpd
+}
+
+stop() {
+	service_stop /usr/bin/owftpd
+}

--- a/utils/owfs/files/owhttpd.conf
+++ b/utils/owfs/files/owhttpd.conf
@@ -1,0 +1,9 @@
+config owhttpd 'owhttpd'
+	option enabled 0
+	option uid 65534
+	option gid 65534
+	option readonly 0
+	option port 3001
+	option error_level 0
+	option options ''
+	list devices '-s localhost:4304'

--- a/utils/owfs/files/owhttpd.conf
+++ b/utils/owfs/files/owhttpd.conf
@@ -1,9 +1,8 @@
 config owhttpd 'owhttpd'
 	option enabled 0
-	option uid 65534
-	option gid 65534
+	option user root
 	option readonly 0
 	option port 3001
 	option error_level 0
-	option options ''
-	list devices '-s localhost:4304'
+	list devices '-s'
+	list devices 'localhost:4304'

--- a/utils/owfs/files/owhttpd.init
+++ b/utils/owfs/files/owhttpd.init
@@ -1,71 +1,81 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2009-2012 OpenWrt.org
+# Copyright (C) 2009-2015 OpenWrt.org
 
-START=99
+START=95
+USE_PROCD=1
 
-SERVICE_WRITE_PID=1
-SERVICE_DAEMONIZE=1
+PROG=/usr/bin/owhttpd
 
-DEFAULT_SERVICE_UID=65534
-DEFAULT_SERVICE_GID=65534
+append_arg() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
 
-append_device() {
-	append devices "$1"
+	config_get val "$cfg" "$var"
+	[ -n "$val" -o -n "$def" ] && procd_append_param command $opt "${val:-$def}"
 }
 
+append_bool() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
 
-start_owfs_daemon() {
-	local program="$1"
-	local config="$1"
-	local args="--foreground --error_print=1 $2"
+	config_get_bool val "$cfg" "$var" "$def"
+	[ "$val" = 1 ] && procd_append_param command "$opt"
+}
 
+append_plain() {
+	procd_append_param command "$1"
+}
 
+append_param() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
+
+	config_get val "$cfg" "$var"
+	[ -n "$val" -o -n "$def" ] && procd_append_param "$opt" "${val:-$def}"
+}
+
+start_instance() {
+	local cfg="$1"
 	local enabled
-	config_get_bool enabled "$config" enabled 0
-	[ "${enabled}" -eq 0 ] && return 1
 
-	local readonly
-	config_get_bool readonly "$config" readonly 0
-	[ "${readonly}" -eq 1 ] && append args "--readonly"
+	config_get_bool enabled "$cfg" 'enabled' '0'
+	[ "$enabled" = 0 ] && return 1
 
-	local error_level
-	config_get error_level "$config" error_level
-	[ -n "${error_level}" ] && append args "--error_level=${error_level}"
+	procd_open_instance
 
-	local options
-	config_get options "$config" options
+	procd_set_param command "$PROG" --foreground --error_print=1
 
-	devices=""
-	config_list_foreach "$config" devices append_device
+	# common parameters
+	append_bool "$cfg" readonly "--readonly"
+	append_arg "$cfg" error_level "--error_level"
+	config_list_foreach "$cfg" options append_plain
+	config_list_foreach "$cfg" devices append_plain
+	append_param "$cfg" user user
 
-	config_get SERVICE_UID "$config" uid "$DEFAULT_SERVICE_UID"
-	config_get SERVICE_GID "$config" gid "$DEFAULT_SERVICE_GID"
+	# owhttpd-specific
+	append_arg "$cfg" port "--port"
+	append_arg "$cfg" max_connections "--max_connections"
 
-	service_start "/usr/bin/$program" $args $options $devices
+	procd_set_param respawn
+
+	procd_close_instance
+
 }
 
-start_owhttpd() {
-	local config="owhttpd"
-	local args=""
-
-	config_load "$config"
-
-	local port
-	config_get port "$config" port
-	[ -n "${port}" ] && append args "--port=${port}"
-
-	local max_connections
-	config_get max_connections "$config" max_connections
-	[ -n "${max_connections}" ] && append args "--max_connections=${max_connections}"
-
-	start_owfs_daemon "$config" "$args"
+service_triggers() {
+	procd_add_reload_trigger owhttpd
 }
 
-
-start() {
-	start_owhttpd
-}
-
-stop() {
-	service_stop /usr/bin/owhttpd
+start_service() {
+	config_load owhttpd
+	config_foreach start_instance owhttpd
 }

--- a/utils/owfs/files/owhttpd.init
+++ b/utils/owfs/files/owhttpd.init
@@ -1,0 +1,71 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2009-2012 OpenWrt.org
+
+START=99
+
+SERVICE_WRITE_PID=1
+SERVICE_DAEMONIZE=1
+
+DEFAULT_SERVICE_UID=65534
+DEFAULT_SERVICE_GID=65534
+
+append_device() {
+	append devices "$1"
+}
+
+
+start_owfs_daemon() {
+	local program="$1"
+	local config="$1"
+	local args="--foreground --error_print=1 $2"
+
+
+	local enabled
+	config_get_bool enabled "$config" enabled 0
+	[ "${enabled}" -eq 0 ] && return 1
+
+	local readonly
+	config_get_bool readonly "$config" readonly 0
+	[ "${readonly}" -eq 1 ] && append args "--readonly"
+
+	local error_level
+	config_get error_level "$config" error_level
+	[ -n "${error_level}" ] && append args "--error_level=${error_level}"
+
+	local options
+	config_get options "$config" options
+
+	devices=""
+	config_list_foreach "$config" devices append_device
+
+	config_get SERVICE_UID "$config" uid "$DEFAULT_SERVICE_UID"
+	config_get SERVICE_GID "$config" gid "$DEFAULT_SERVICE_GID"
+
+	service_start "/usr/bin/$program" $args $options $devices
+}
+
+start_owhttpd() {
+	local config="owhttpd"
+	local args=""
+
+	config_load "$config"
+
+	local port
+	config_get port "$config" port
+	[ -n "${port}" ] && append args "--port=${port}"
+
+	local max_connections
+	config_get max_connections "$config" max_connections
+	[ -n "${max_connections}" ] && append args "--max_connections=${max_connections}"
+
+	start_owfs_daemon "$config" "$args"
+}
+
+
+start() {
+	start_owhttpd
+}
+
+stop() {
+	service_stop /usr/bin/owhttpd
+}

--- a/utils/owfs/files/owserver.conf
+++ b/utils/owfs/files/owserver.conf
@@ -1,9 +1,8 @@
 config owserver 'owserver'
 	option enabled 0
-	option uid 65534
-	option gid 65534
+	option user root
 	option readonly 0
 	option port 4304
 	option error_level 0
-	option options ''
-	list devices '-d /dev/ttyUSB0'
+	list devices '-d'
+	list devices '/dev/ttyUSB0'

--- a/utils/owfs/files/owserver.conf
+++ b/utils/owfs/files/owserver.conf
@@ -1,0 +1,9 @@
+config owserver 'owserver'
+	option enabled 0
+	option uid 65534
+	option gid 65534
+	option readonly 0
+	option port 4304
+	option error_level 0
+	option options ''
+	list devices '-d /dev/ttyUSB0'

--- a/utils/owfs/files/owserver.init
+++ b/utils/owfs/files/owserver.init
@@ -1,70 +1,81 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2009-2012 OpenWrt.org
+# Copyright (C) 2009-2015 OpenWrt.org
 
-START=98
+START=90
+USE_PROCD=1
 
-SERVICE_WRITE_PID=1
-SERVICE_DAEMONIZE=1
+PROG=/usr/bin/owserver
 
-DEFAULT_SERVICE_UID=65534
-DEFAULT_SERVICE_GID=65534
+append_arg() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
 
-append_device() {
-	append devices "$1"
+	config_get val "$cfg" "$var"
+	[ -n "$val" -o -n "$def" ] && procd_append_param command $opt "${val:-$def}"
 }
 
+append_bool() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
 
-start_owfs_daemon() {
-	local program="$1"
-	local config="$1"
-	local args="--foreground --error_print=1 $2"
+	config_get_bool val "$cfg" "$var" "$def"
+	[ "$val" = 1 ] && procd_append_param command "$opt"
+}
 
+append_plain() {
+	procd_append_param command "$1"
+}
 
+append_param() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
+
+	config_get val "$cfg" "$var"
+	[ -n "$val" -o -n "$def" ] && procd_append_param "$opt" "${val:-$def}"
+}
+
+start_instance() {
+	local cfg="$1"
 	local enabled
-	config_get_bool enabled "$config" enabled 0
-	[ "${enabled}" -eq 0 ] && return 1
 
-	local readonly
-	config_get_bool readonly "$config" readonly 0
-	[ "${readonly}" -eq 1 ] && append args "--readonly"
+	config_get_bool enabled "$cfg" 'enabled' '0'
+	[ "$enabled" = 0 ] && return 1
 
-	local error_level
-	config_get error_level "$config" error_level
-	[ -n "${error_level}" ] && append args "--error_level=${error_level}"
+	procd_open_instance
 
-	local options
-	config_get options "$config" options
+	procd_set_param command "$PROG" --foreground --error_print=1
 
-	devices=""
-	config_list_foreach "$config" devices append_device
+	# common parameters
+	append_bool "$cfg" readonly "--readonly"
+	append_arg "$cfg" error_level "--error_level"
+	config_list_foreach "$cfg" options append_plain
+	config_list_foreach "$cfg" devices append_plain
+	append_param "$cfg" user user
 
-	config_get SERVICE_UID "$config" uid "$DEFAULT_SERVICE_UID"
-	config_get SERVICE_GID "$config" gid "$DEFAULT_SERVICE_GID"
+	# owserver-specific
+	append_arg "$cfg" port "--port"
+	append_arg "$cfg" max_connections "--max_connections"
 
-	service_start "/usr/bin/$program" $args $options $devices
+	procd_set_param respawn
+
+	procd_close_instance
+
 }
 
-start_owserver() {
-	local config="owserver"
-	local args=""
-
-	config_load "$config"
-
-	local port
-	config_get port "$config" port
-	[ -n "${port}" ] && append args "--port=${port}"
-
-	local max_connections
-	config_get max_connections "$config" max_connections
-	[ -n "${max_connections}" ] && append args "--max_connections=${max_connections}"
-
-	start_owfs_daemon "$config" "$args"
+service_triggers() {
+	procd_add_reload_trigger owserver
 }
 
-start() {
-	start_owserver
-}
-
-stop() {
-	service_stop /usr/bin/owserver
+start_service() {
+	config_load owserver
+	config_foreach start_instance owserver
 }

--- a/utils/owfs/files/owserver.init
+++ b/utils/owfs/files/owserver.init
@@ -1,0 +1,70 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2009-2012 OpenWrt.org
+
+START=98
+
+SERVICE_WRITE_PID=1
+SERVICE_DAEMONIZE=1
+
+DEFAULT_SERVICE_UID=65534
+DEFAULT_SERVICE_GID=65534
+
+append_device() {
+	append devices "$1"
+}
+
+
+start_owfs_daemon() {
+	local program="$1"
+	local config="$1"
+	local args="--foreground --error_print=1 $2"
+
+
+	local enabled
+	config_get_bool enabled "$config" enabled 0
+	[ "${enabled}" -eq 0 ] && return 1
+
+	local readonly
+	config_get_bool readonly "$config" readonly 0
+	[ "${readonly}" -eq 1 ] && append args "--readonly"
+
+	local error_level
+	config_get error_level "$config" error_level
+	[ -n "${error_level}" ] && append args "--error_level=${error_level}"
+
+	local options
+	config_get options "$config" options
+
+	devices=""
+	config_list_foreach "$config" devices append_device
+
+	config_get SERVICE_UID "$config" uid "$DEFAULT_SERVICE_UID"
+	config_get SERVICE_GID "$config" gid "$DEFAULT_SERVICE_GID"
+
+	service_start "/usr/bin/$program" $args $options $devices
+}
+
+start_owserver() {
+	local config="owserver"
+	local args=""
+
+	config_load "$config"
+
+	local port
+	config_get port "$config" port
+	[ -n "${port}" ] && append args "--port=${port}"
+
+	local max_connections
+	config_get max_connections "$config" max_connections
+	[ -n "${max_connections}" ] && append args "--max_connections=${max_connections}"
+
+	start_owfs_daemon "$config" "$args"
+}
+
+start() {
+	start_owserver
+}
+
+stop() {
+	service_stop /usr/bin/owserver
+}

--- a/utils/owfs/patches/100-fix-netlink-w1-status-message-detection.patch
+++ b/utils/owfs/patches/100-fix-netlink-w1-status-message-detection.patch
@@ -1,0 +1,30 @@
+AaAA
+--- a/module/owlib/src/c/ow_w1_parse.c
++++ b/module/owlib/src/c/ow_w1_parse.c
+@@ -237,7 +237,7 @@ enum Netlink_Read_Status W1_Process_Resp
+ 			owfree(nlp.nlm) ;
+ 			return nrs_nodev ;
+ 		}
+-		if ( nrs_callback == NULL ) { // status message
++		if ( nrs_callback == NULL ) { // bus reset
+ 			owfree(nlp.nlm) ;
+ 			return nrs_complete ;
+ 		}
+@@ -246,7 +246,7 @@ enum Netlink_Read_Status W1_Process_Resp
+ 		nrs_callback( &nlp, v, pn ) ;
+ 		LEVEL_DEBUG("Called nrs_callback");
+ 		owfree(nlp.nlm) ;
+-		if ( nlp.cn->ack != 0 ) {
++		if ( nlp.cn->seq != nlp.cn->ack ) {
+ 			if ( nlp.w1m->type == W1_LIST_MASTERS ) {
+ 				continue ; // look for more data
+ 			}
+@@ -254,7 +254,7 @@ enum Netlink_Read_Status W1_Process_Resp
+ 				continue ; // look for more data
+ 			}
+ 		}
+-		nrs_callback = NULL ; // now look for status message
++		return nrs_complete ; // status message
+ 	}
+ 	return nrs_timeout ;
+ }

--- a/utils/owfs/patches/101-fix-no-reset-routine-segfault.patch
+++ b/utils/owfs/patches/101-fix-no-reset-routine-segfault.patch
@@ -1,0 +1,13 @@
+--- a/module/owlib/src/c/ow_reset.c
++++ b/module/owlib/src/c/ow_reset.c
+@@ -21,6 +21,10 @@ RESET_TYPE BUS_reset(const struct parsed
+ 	struct connection_in * in = pn->selected_connection ;
+ 	STAT_ADD1_BUS(e_bus_resets, in);
+ 
++	if ( in->iroutines.reset == NO_RESET_ROUTINE ) {
++		return BUS_RESET_OK;
++	}
++
+ 	switch ( (in->iroutines.reset) (pn) ) {
+ 	case BUS_RESET_OK:
+ 		in->reconnect_state = reconnect_ok;	// Flag as good!


### PR DESCRIPTION
Add init.d/config files for owfs/owserver/owhttpd/owftpd daemons, make libow features configurable and fix bugs in w1 netlink connector adapter. 
Refer to individual commits for details.