### PR TITLE
libevent: update to 1.4.15 (fixes CVE-2014-6272)

### DIFF
--- a/libs/libevent/Makefile
+++ b/libs/libevent/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libevent
-PKG_VERSION:=1.4.14b
-PKG_RELEASE:=2
+PKG_VERSION:=1.4.15
+PKG_RELEASE:=1
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)-stable
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-stable.tar.gz
-PKG_SOURCE_URL:=https://github.com/downloads/libevent/libevent/
-PKG_MD5SUM:=a00e037e4d3f9e4fe9893e8a2d27918c
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-release-$(PKG_VERSION)-stable
+PKG_SOURCE:=release-$(PKG_VERSION)-stable.tar.gz
+PKG_SOURCE_URL:=https://github.com/libevent/libevent/archive/
+PKG_MD5SUM:=6dce6fe39f133c09ffe63de895805f7f
 PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
 
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
This update fixes CVE-2014-6272. Change of source URL was needed, because the older location does not contain the latest version.

Signed-off-by: Jan Čermák <jan.cermak@nic.cz>