### PR TITLE
strongswan: make kmod-ipsec6 dependency conditional

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -115,7 +115,7 @@ define Package/strongswan
 $(call Package/strongswan/Default)
   DEPENDS:= +libpthread +ip \
 	+kmod-crypto-authenc \
-	+kmod-ipsec +kmod-ipsec4 +kmod-ipsec6 \
+	+kmod-ipsec +kmod-ipsec4 +IPV6:kmod-ipsec6 \
 	+kmod-ipt-ipsec +iptables-mod-ipsec
 endef
 


### PR DESCRIPTION
Makes kmod-ipsec6 requirement dependent on IPv6 support for packages.
This allows to disable unnecessary IPv6 kernel modules, saving
considerable amount of space.