### PR TITLE
seafile-ccnet: use correct libevent2 includes

### DIFF
--- a/net/seafile-ccnet/patches/010-libevent-include-path.patch
+++ b/net/seafile-ccnet/patches/010-libevent-include-path.patch
@@ -1,0 +1,239 @@
+diff -rupN seafile-ccnet-4.1.2.orig/include/ccnet/ccnet-client.h seafile-ccnet-4.1.2/include/ccnet/ccnet-client.h
+--- seafile-ccnet-4.1.2.orig/include/ccnet/ccnet-client.h	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/include/ccnet/ccnet-client.h	2015-09-04 10:21:05.578937942 +0200
+@@ -10,11 +10,7 @@
+ #include <glib.h>
+ #include <glib-object.h>
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/util.h>
+-#else
+-#include <evutil.h>
+-#endif
+ 
+ #include "ccnet-session-base.h"
+ 
+diff -rupN seafile-ccnet-4.1.2.orig/include/ccnet/cevent.h seafile-ccnet-4.1.2/include/ccnet/cevent.h
+--- seafile-ccnet-4.1.2.orig/include/ccnet/cevent.h	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/include/ccnet/cevent.h	2015-09-04 10:21:10.498933107 +0200
+@@ -6,13 +6,9 @@
+ #ifndef CEVENT_H
+ #define CEVENT_H
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/event.h>
+ #include <event2/event_compat.h>
+ #include <event2/event_struct.h>
+-#else
+-#include <event.h>
+-#endif
+ 
+ #include <glib.h>
+ 
+diff -rupN seafile-ccnet-4.1.2.orig/lib/job-mgr.c seafile-ccnet-4.1.2/lib/job-mgr.c
+--- seafile-ccnet-4.1.2.orig/lib/job-mgr.c	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/job-mgr.c	2015-09-04 10:19:49.323012920 +0200
+@@ -1,11 +1,7 @@
+ /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/event.h>
+ #include <event2/event_compat.h>
+-#else
+-#include <event.h>
+-#endif
+ 
+ #include <string.h>
+ #include <stdlib.h>
+diff -rupN seafile-ccnet-4.1.2.orig/lib/libccnet_utils.h seafile-ccnet-4.1.2/lib/libccnet_utils.h
+--- seafile-ccnet-4.1.2.orig/lib/libccnet_utils.h	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/libccnet_utils.h	2015-09-04 10:20:00.003002414 +0200
+@@ -15,11 +15,7 @@
+ #include <glib-object.h>
+ #include <stdlib.h>
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/util.h>
+-#else
+-#include <evutil.h>
+-#endif
+ 
+ #ifdef WIN32
+     #include <errno.h>
+diff -rupN seafile-ccnet-4.1.2.orig/lib/mainloop.c seafile-ccnet-4.1.2/lib/mainloop.c
+--- seafile-ccnet-4.1.2.orig/lib/mainloop.c	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/mainloop.c	2015-09-04 10:20:10.355992232 +0200
+@@ -3,13 +3,9 @@
+ #include "include.h"
+ #include <ccnet.h>
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/event.h>
+ #include <event2/event_compat.h>
+ #include <event2/event_struct.h>
+-#else
+-#include <event.h>
+-#endif
+ 
+ static int
+ cmdrsp_cb (const char *code, char *content, int clen, void *data)
+diff -rupN seafile-ccnet-4.1.2.orig/lib/net.h seafile-ccnet-4.1.2/lib/net.h
+--- seafile-ccnet-4.1.2.orig/lib/net.h	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/net.h	2015-09-04 10:20:22.951979845 +0200
+@@ -19,11 +19,7 @@
+     #include <netinet/tcp.h>
+ #endif
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/util.h>
+-#else
+-#include <evutil.h>
+-#endif
+ 
+ #ifdef WIN32
+     #define ECONNREFUSED WSAECONNREFUSED
+diff -rupN seafile-ccnet-4.1.2.orig/lib/packet-io.h seafile-ccnet-4.1.2/lib/packet-io.h
+--- seafile-ccnet-4.1.2.orig/lib/packet-io.h	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/packet-io.h	2015-09-04 10:20:31.827971118 +0200
+@@ -5,11 +5,7 @@
+ 
+ #include <packet.h>
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/util.h>
+-#else
+-#include <evutil.h>
+-#endif
+ 
+ struct buffer;
+ 
+diff -rupN seafile-ccnet-4.1.2.orig/lib/processor.c seafile-ccnet-4.1.2/lib/processor.c
+--- seafile-ccnet-4.1.2.orig/lib/processor.c	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/processor.c	2015-09-04 10:20:53.395949916 +0200
+@@ -4,11 +4,7 @@
+ 
+ #include <pthread.h>
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/event.h>
+-#else
+-#include <event.h>
+-#endif
+ 
+ #include "ccnet-client.h"
+ #include "processor.h"
+diff -rupN seafile-ccnet-4.1.2.orig/lib/timer.c seafile-ccnet-4.1.2/lib/timer.c
+--- seafile-ccnet-4.1.2.orig/lib/timer.c	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/timer.c	2015-09-04 10:20:38.571964488 +0200
+@@ -1,12 +1,8 @@
+ /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/event.h>
+ #include <event2/event_compat.h>
+ #include <event2/event_struct.h>
+-#else
+-#include <event.h>
+-#endif
+ 
+ #include <sys/time.h>
+ 
+diff -rupN seafile-ccnet-4.1.2.orig/lib/utils.h seafile-ccnet-4.1.2/lib/utils.h
+--- seafile-ccnet-4.1.2.orig/lib/utils.h	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/utils.h	2015-09-04 10:20:45.578957600 +0200
+@@ -11,11 +11,7 @@
+ #include <glib-object.h>
+ #include <stdlib.h>
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/util.h>
+-#else
+-#include <evutil.h>
+-#endif
+ 
+ #ifdef WIN32
+ #include <errno.h>
+diff -rupN seafile-ccnet-4.1.2.orig/net/common/connect-mgr.h seafile-ccnet-4.1.2/net/common/connect-mgr.h
+--- seafile-ccnet-4.1.2.orig/net/common/connect-mgr.h	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/net/common/connect-mgr.h	2015-09-04 10:21:20.266923508 +0200
+@@ -3,11 +3,7 @@
+ #ifndef CCNET_CONNECTION_MANAGER
+ #define CCNET_CONNECTION_MANAGER
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/event.h>
+-#else
+-#include <event.h>
+-#endif
+ 
+ #include "timer.h"
+ 
+diff -rupN seafile-ccnet-4.1.2.orig/net/common/packet-io.c seafile-ccnet-4.1.2/net/common/packet-io.c
+--- seafile-ccnet-4.1.2.orig/net/common/packet-io.c	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/net/common/packet-io.c	2015-09-04 10:21:28.691915231 +0200
+@@ -13,13 +13,9 @@
+ 
+ #include <unistd.h>
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/event.h>
+ #include <event2/bufferevent.h>
+ #include <event2/bufferevent_struct.h>
+-#else
+-#include <event.h>
+-#endif
+ 
+ #include <glib.h>
+ #include <errno.h>
+diff -rupN seafile-ccnet-4.1.2.orig/net/common/packet-io.h seafile-ccnet-4.1.2/net/common/packet-io.h
+--- seafile-ccnet-4.1.2.orig/net/common/packet-io.h	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/net/common/packet-io.h	2015-09-04 10:21:51.130893188 +0200
+@@ -5,13 +5,9 @@
+ 
+ #include "packet.h"
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/util.h>
+ #include <event2/buffer.h>
+ #include <event2/buffer_compat.h>
+-#else
+-#include <evutil.h>
+-#endif
+ 
+ /* struct evbuffer; */
+ /* for libevent2 */
+diff -rupN seafile-ccnet-4.1.2.orig/net/common/peer.c seafile-ccnet-4.1.2/net/common/peer.c
+--- seafile-ccnet-4.1.2.orig/net/common/peer.c	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/net/common/peer.c	2015-09-04 10:22:00.506883980 +0200
+@@ -2,14 +2,10 @@
+ 
+ #include "common.h"
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/event.h>
+ #include <event2/bufferevent.h>
+ #include <event2/bufferevent_compat.h>
+ #include <event2/bufferevent_struct.h>
+-#else
+-#include <event.h>
+-#endif
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
+diff -rupN seafile-ccnet-4.1.2.orig/net/common/session.h seafile-ccnet-4.1.2/net/common/session.h
+--- seafile-ccnet-4.1.2.orig/net/common/session.h	2015-09-03 21:43:37.000000000 +0200
++++ seafile-ccnet-4.1.2/net/common/session.h	2015-09-04 10:22:13.114871598 +0200
+@@ -3,13 +3,9 @@
+ #ifndef CCNET_SESSION_H
+ #define CCNET_SESSION_H
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/event.h>
+ #include <event2/event_compat.h>
+ #include <event2/event_struct.h>
+-#else
+-#include <event.h>
+-#endif
+ 
+ #include <glib.h>
+ #include <glib/gstdio.h>


### PR DESCRIPTION
Hopefully this would fix #1324.

Including `<event.h>` and `<evutil.h>` directly might not work as expected as those are deprecated header files in libevent2:

`The <event.h> header is deprecated in Libevent 2.0 and later; please use <event2/event.h> instead.`