### PR TITLE
seafile-ccnet: fix patch file to work correctly with libevent2 headers

### DIFF
--- a/net/seafile-ccnet/patches/010-libevent-include-path.patch
+++ b/net/seafile-ccnet/patches/010-libevent-include-path.patch
@@ -1,6 +1,6 @@
 diff -rupN seafile-ccnet-4.1.2.orig/include/ccnet/ccnet-client.h seafile-ccnet-4.1.2/include/ccnet/ccnet-client.h
---- seafile-ccnet-4.1.2.orig/include/ccnet/ccnet-client.h	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/include/ccnet/ccnet-client.h	2015-09-04 10:21:05.578937942 +0200
+--- seafile-ccnet-4.1.2.orig/include/ccnet/ccnet-client.h	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/include/ccnet/ccnet-client.h	2015-09-09 19:22:23.515461892 +0200
 @@ -10,11 +10,7 @@
  #include <glib.h>
  #include <glib-object.h>
@@ -14,8 +14,8 @@ diff -rupN seafile-ccnet-4.1.2.orig/include/ccnet/ccnet-client.h seafile-ccnet-4
  #include "ccnet-session-base.h"
  
 diff -rupN seafile-ccnet-4.1.2.orig/include/ccnet/cevent.h seafile-ccnet-4.1.2/include/ccnet/cevent.h
---- seafile-ccnet-4.1.2.orig/include/ccnet/cevent.h	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/include/ccnet/cevent.h	2015-09-04 10:21:10.498933107 +0200
+--- seafile-ccnet-4.1.2.orig/include/ccnet/cevent.h	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/include/ccnet/cevent.h	2015-09-09 19:22:23.516461920 +0200
 @@ -6,13 +6,9 @@
  #ifndef CEVENT_H
  #define CEVENT_H
@@ -31,8 +31,8 @@ diff -rupN seafile-ccnet-4.1.2.orig/include/ccnet/cevent.h seafile-ccnet-4.1.2/i
  #include <glib.h>
  
 diff -rupN seafile-ccnet-4.1.2.orig/lib/job-mgr.c seafile-ccnet-4.1.2/lib/job-mgr.c
---- seafile-ccnet-4.1.2.orig/lib/job-mgr.c	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/lib/job-mgr.c	2015-09-04 10:19:49.323012920 +0200
+--- seafile-ccnet-4.1.2.orig/lib/job-mgr.c	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/job-mgr.c	2015-09-09 19:22:23.516461920 +0200
 @@ -1,11 +1,7 @@
  /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
  
@@ -46,8 +46,8 @@ diff -rupN seafile-ccnet-4.1.2.orig/lib/job-mgr.c seafile-ccnet-4.1.2/lib/job-mg
  #include <string.h>
  #include <stdlib.h>
 diff -rupN seafile-ccnet-4.1.2.orig/lib/libccnet_utils.h seafile-ccnet-4.1.2/lib/libccnet_utils.h
---- seafile-ccnet-4.1.2.orig/lib/libccnet_utils.h	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/lib/libccnet_utils.h	2015-09-04 10:20:00.003002414 +0200
+--- seafile-ccnet-4.1.2.orig/lib/libccnet_utils.h	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/libccnet_utils.h	2015-09-09 19:22:23.517461948 +0200
 @@ -15,11 +15,7 @@
  #include <glib-object.h>
  #include <stdlib.h>
@@ -61,8 +61,8 @@ diff -rupN seafile-ccnet-4.1.2.orig/lib/libccnet_utils.h seafile-ccnet-4.1.2/lib
  #ifdef WIN32
      #include <errno.h>
 diff -rupN seafile-ccnet-4.1.2.orig/lib/mainloop.c seafile-ccnet-4.1.2/lib/mainloop.c
---- seafile-ccnet-4.1.2.orig/lib/mainloop.c	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/lib/mainloop.c	2015-09-04 10:20:10.355992232 +0200
+--- seafile-ccnet-4.1.2.orig/lib/mainloop.c	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/mainloop.c	2015-09-09 19:22:23.517461948 +0200
 @@ -3,13 +3,9 @@
  #include "include.h"
  #include <ccnet.h>
@@ -78,8 +78,8 @@ diff -rupN seafile-ccnet-4.1.2.orig/lib/mainloop.c seafile-ccnet-4.1.2/lib/mainl
  static int
  cmdrsp_cb (const char *code, char *content, int clen, void *data)
 diff -rupN seafile-ccnet-4.1.2.orig/lib/net.h seafile-ccnet-4.1.2/lib/net.h
---- seafile-ccnet-4.1.2.orig/lib/net.h	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/lib/net.h	2015-09-04 10:20:22.951979845 +0200
+--- seafile-ccnet-4.1.2.orig/lib/net.h	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/net.h	2015-09-09 19:22:23.517461948 +0200
 @@ -19,11 +19,7 @@
      #include <netinet/tcp.h>
  #endif
@@ -93,8 +93,8 @@ diff -rupN seafile-ccnet-4.1.2.orig/lib/net.h seafile-ccnet-4.1.2/lib/net.h
  #ifdef WIN32
      #define ECONNREFUSED WSAECONNREFUSED
 diff -rupN seafile-ccnet-4.1.2.orig/lib/packet-io.h seafile-ccnet-4.1.2/lib/packet-io.h
---- seafile-ccnet-4.1.2.orig/lib/packet-io.h	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/lib/packet-io.h	2015-09-04 10:20:31.827971118 +0200
+--- seafile-ccnet-4.1.2.orig/lib/packet-io.h	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/packet-io.h	2015-09-09 19:22:23.518461976 +0200
 @@ -5,11 +5,7 @@
  
  #include <packet.h>
@@ -108,8 +108,8 @@ diff -rupN seafile-ccnet-4.1.2.orig/lib/packet-io.h seafile-ccnet-4.1.2/lib/pack
  struct buffer;
  
 diff -rupN seafile-ccnet-4.1.2.orig/lib/processor.c seafile-ccnet-4.1.2/lib/processor.c
---- seafile-ccnet-4.1.2.orig/lib/processor.c	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/lib/processor.c	2015-09-04 10:20:53.395949916 +0200
+--- seafile-ccnet-4.1.2.orig/lib/processor.c	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/processor.c	2015-09-09 19:22:23.518461976 +0200
 @@ -4,11 +4,7 @@
  
  #include <pthread.h>
@@ -123,8 +123,8 @@ diff -rupN seafile-ccnet-4.1.2.orig/lib/processor.c seafile-ccnet-4.1.2/lib/proc
  #include "ccnet-client.h"
  #include "processor.h"
 diff -rupN seafile-ccnet-4.1.2.orig/lib/timer.c seafile-ccnet-4.1.2/lib/timer.c
---- seafile-ccnet-4.1.2.orig/lib/timer.c	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/lib/timer.c	2015-09-04 10:20:38.571964488 +0200
+--- seafile-ccnet-4.1.2.orig/lib/timer.c	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/timer.c	2015-09-09 19:22:23.519462004 +0200
 @@ -1,12 +1,8 @@
  /* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
  
@@ -139,8 +139,8 @@ diff -rupN seafile-ccnet-4.1.2.orig/lib/timer.c seafile-ccnet-4.1.2/lib/timer.c
  #include <sys/time.h>
  
 diff -rupN seafile-ccnet-4.1.2.orig/lib/utils.h seafile-ccnet-4.1.2/lib/utils.h
---- seafile-ccnet-4.1.2.orig/lib/utils.h	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/lib/utils.h	2015-09-04 10:20:45.578957600 +0200
+--- seafile-ccnet-4.1.2.orig/lib/utils.h	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/lib/utils.h	2015-09-09 19:22:23.519462004 +0200
 @@ -11,11 +11,7 @@
  #include <glib-object.h>
  #include <stdlib.h>
@@ -153,9 +153,24 @@ diff -rupN seafile-ccnet-4.1.2.orig/lib/utils.h seafile-ccnet-4.1.2/lib/utils.h
  
  #ifdef WIN32
  #include <errno.h>
+diff -rupN seafile-ccnet-4.1.2.orig/net/cluster/server.c seafile-ccnet-4.1.2/net/cluster/server.c
+--- seafile-ccnet-4.1.2.orig/net/cluster/server.c	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/net/cluster/server.c	2015-09-09 19:24:33.800125741 +0200
+@@ -6,11 +6,7 @@
+ #include <stdio.h>
+ #include <getopt.h>
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/dns.h>
+-#else
+-#include <evdns.h>
+-#endif
+ 
+ #include "inner-session.h"
+ #include "outer-session.h"
 diff -rupN seafile-ccnet-4.1.2.orig/net/common/connect-mgr.h seafile-ccnet-4.1.2/net/common/connect-mgr.h
---- seafile-ccnet-4.1.2.orig/net/common/connect-mgr.h	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/net/common/connect-mgr.h	2015-09-04 10:21:20.266923508 +0200
+--- seafile-ccnet-4.1.2.orig/net/common/connect-mgr.h	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/net/common/connect-mgr.h	2015-09-09 19:22:23.520462032 +0200
 @@ -3,11 +3,7 @@
  #ifndef CCNET_CONNECTION_MANAGER
  #define CCNET_CONNECTION_MANAGER
@@ -169,8 +184,8 @@ diff -rupN seafile-ccnet-4.1.2.orig/net/common/connect-mgr.h seafile-ccnet-4.1.2
  #include "timer.h"
  
 diff -rupN seafile-ccnet-4.1.2.orig/net/common/packet-io.c seafile-ccnet-4.1.2/net/common/packet-io.c
---- seafile-ccnet-4.1.2.orig/net/common/packet-io.c	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/net/common/packet-io.c	2015-09-04 10:21:28.691915231 +0200
+--- seafile-ccnet-4.1.2.orig/net/common/packet-io.c	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/net/common/packet-io.c	2015-09-09 19:22:23.521462060 +0200
 @@ -13,13 +13,9 @@
  
  #include <unistd.h>
@@ -186,8 +201,8 @@ diff -rupN seafile-ccnet-4.1.2.orig/net/common/packet-io.c seafile-ccnet-4.1.2/n
  #include <glib.h>
  #include <errno.h>
 diff -rupN seafile-ccnet-4.1.2.orig/net/common/packet-io.h seafile-ccnet-4.1.2/net/common/packet-io.h
---- seafile-ccnet-4.1.2.orig/net/common/packet-io.h	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/net/common/packet-io.h	2015-09-04 10:21:51.130893188 +0200
+--- seafile-ccnet-4.1.2.orig/net/common/packet-io.h	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/net/common/packet-io.h	2015-09-09 19:22:23.521462060 +0200
 @@ -5,13 +5,9 @@
  
  #include "packet.h"
@@ -203,8 +218,8 @@ diff -rupN seafile-ccnet-4.1.2.orig/net/common/packet-io.h seafile-ccnet-4.1.2/n
  /* struct evbuffer; */
  /* for libevent2 */
 diff -rupN seafile-ccnet-4.1.2.orig/net/common/peer.c seafile-ccnet-4.1.2/net/common/peer.c
---- seafile-ccnet-4.1.2.orig/net/common/peer.c	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/net/common/peer.c	2015-09-04 10:22:00.506883980 +0200
+--- seafile-ccnet-4.1.2.orig/net/common/peer.c	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/net/common/peer.c	2015-09-09 19:22:23.522462088 +0200
 @@ -2,14 +2,10 @@
  
  #include "common.h"
@@ -221,8 +236,8 @@ diff -rupN seafile-ccnet-4.1.2.orig/net/common/peer.c seafile-ccnet-4.1.2/net/co
  #include <stdio.h>
  #include <stdlib.h>
 diff -rupN seafile-ccnet-4.1.2.orig/net/common/session.h seafile-ccnet-4.1.2/net/common/session.h
---- seafile-ccnet-4.1.2.orig/net/common/session.h	2015-09-03 21:43:37.000000000 +0200
-+++ seafile-ccnet-4.1.2/net/common/session.h	2015-09-04 10:22:13.114871598 +0200
+--- seafile-ccnet-4.1.2.orig/net/common/session.h	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/net/common/session.h	2015-09-09 19:22:23.523462116 +0200
 @@ -3,13 +3,9 @@
  #ifndef CCNET_SESSION_H
  #define CCNET_SESSION_H
@@ -237,3 +252,49 @@ diff -rupN seafile-ccnet-4.1.2.orig/net/common/session.h seafile-ccnet-4.1.2/net
  
  #include <glib.h>
  #include <glib/gstdio.h>
+diff -rupN seafile-ccnet-4.1.2.orig/net/daemon/ccnet-daemon.c seafile-ccnet-4.1.2/net/daemon/ccnet-daemon.c
+--- seafile-ccnet-4.1.2.orig/net/daemon/ccnet-daemon.c	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/net/daemon/ccnet-daemon.c	2015-09-09 19:24:59.313846178 +0200
+@@ -6,12 +6,8 @@
+ #include <stdio.h>
+ #include <getopt.h>
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/dns.h>
+ #include <event2/dns_compat.h>
+-#else
+-#include <evdns.h>
+-#endif
+ 
+ #include "daemon-session.h"
+ #include "rpc-service.h"
+diff -rupN seafile-ccnet-4.1.2.orig/net/daemon/ccnet-test.c seafile-ccnet-4.1.2/net/daemon/ccnet-test.c
+--- seafile-ccnet-4.1.2.orig/net/daemon/ccnet-test.c	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/net/daemon/ccnet-test.c	2015-09-09 19:24:45.089444412 +0200
+@@ -5,11 +5,7 @@
+ 
+ #include <stdio.h>
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/dns.h>
+-#else
+-#include <evdns.h>
+-#endif
+ 
+ #include "utils.h"
+ 
+diff -rupN seafile-ccnet-4.1.2.orig/net/server/ccnet-server.c seafile-ccnet-4.1.2/net/server/ccnet-server.c
+--- seafile-ccnet-4.1.2.orig/net/server/ccnet-server.c	2015-09-09 18:49:35.000000000 +0200
++++ seafile-ccnet-4.1.2/net/server/ccnet-server.c	2015-09-09 19:25:53.967392265 +0200
+@@ -6,11 +6,7 @@
+ #include <stdio.h>
+ #include <getopt.h>
+ 
+-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+ #include <event2/dns.h>
+-#else
+-#include <evdns.h>
+-#endif
+ 
+ #include "server-session.h"
+ #include "user-mgr.h"


### PR DESCRIPTION
Related to #1754 .

This should fix build errors regarding conflicting types (include `<event2/dns.h>` instead of `<evdns.h>`).