### PR TITLE
collectd: Delay first data read cycle by 1s

### DIFF
--- a/utils/collectd/patches/300-delay-first-read-cycle.patch
+++ b/utils/collectd/patches/300-delay-first-read-cycle.patch
@@ -1,0 +1,12 @@
+--- a/src/daemon/plugin.c
++++ b/src/daemon/plugin.c
+@@ -1149,7 +1149,7 @@ static int plugin_insert_read (read_func
+ 	int status;
+ 	llentry_t *le;
+ 
+-	rf->rf_next_read = cdtime ();
++	rf->rf_next_read = cdtime () + (cdtime_t) 1073741824; //delay first read 1s
+ 	rf->rf_effective_interval = rf->rf_interval;
+ 
+ 	pthread_mutex_lock (&read_lock);
+


### PR DESCRIPTION
Some collectd plugins launch third-party plugins that have variation in initialisation time (like libpcap). Recently (since kernel bump to 4.1) the DNS plugin has been causing collectd to crash semi-randomly at startup on MIPS based WNDR3700.

Debugging led to realisation that the DNS plugin seems to require at least 0.1s time to start, before the first data reading attempt starts.

By default, the first data read cycle starts immediately, while apparently some of the plugins may still be asyncronously initialising. To make things safe, this patch adds 1 second delay before the first data read cycle.

This patch fixes https://github.com/openwrt/packages/issues/1660
Debugging efforts documented at: https://github.com/collectd/collectd/issues/1227
Inspiration for the patch: https://github.com/collectd/collectd/pull/1197

@jow- 
