### PR TITLE
perlbase-data: Add dependency on perlbase-bytes

### DIFF
--- a/lang/perl/perlbase.mk
+++ b/lang/perl/perlbase.mk
@@ -329,7 +329,7 @@ $(eval $(call BuildPackage,perlbase-cwd))
 define Package/perlbase-data
 $(call Package/perlbase-template)
 TITLE:=Data perl module
-DEPENDS+=+perlbase-essential
+DEPENDS+=+perlbase-bytes +perlbase-essential
 endef
 
 define Package/perlbase-data/install


### PR DESCRIPTION
Dumper.pm, included in perlbase-data, uses module bytes, so add dependency
on openwrt package perlbase-bytes.

Signed-off-by: Robert Högberg <robert.hogberg@gmail.com>