### PR TITLE
htpdate: add htpdate package based on AA feed

### DIFF
--- a/net/htpdate/Makefile
+++ b/net/htpdate/Makefile
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2006 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=htpdate
+PKG_VERSION:=1.1.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=http://www.vervest.org/htp/archive/c/
+PKG_MD5SUM:=c612f63282e3f23b709f37a5c81d4739
+
+PKG_LICENSE:=GPL-2.0+
+PKG_LICENSE_FILES:=
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/htpdate
+  SUBMENU:=Time Synchronization
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=an HTP (Hypertext Time Protocol) implementation
+  URL:=http://www.vervest.com/htp/
+  MAINTAINER:=Tijs Van Buggenhout <tvbuggen@netzerk.be>
+endef
+
+define Package/htpdate/description
+	The HTTP Time Protocol (HTP) is used to synchronize a computer's time
+	with web servers as reference time source. Htpdate will synchronize your
+	computer's time by extracting timestamps from HTTP headers found
+	in web server responses. Htpdate can be used as a daemon, to keep your
+	computer synchronized.
+endef
+
+define Package/htpdate/conffiles
+/etc/default/htpdate
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS="$(TARGET_CFLAGS)"
+endef
+
+define Package/htpdate/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/htpdate $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/default/
+	$(INSTALL_CONF) ./files/htpdate.default $(1)/etc/default/htpdate
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/htpdate.init $(1)/etc/init.d/htpdate
+endef
+
+$(eval $(call BuildPackage,htpdate))
+

--- a/net/htpdate/files/htpdate.default
+++ b/net/htpdate/files/htpdate.default
@@ -1,0 +1,1 @@
+OPTIONS="www.google.com www.yahoo.com www.linux.org www.freebsd.org"

--- a/net/htpdate/files/htpdate.init
+++ b/net/htpdate/files/htpdate.init
@@ -1,0 +1,19 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2006 OpenWrt.org
+
+START=49
+BIN=htpdate
+DEFAULT=/etc/default/$BIN
+RUN_D=/var/run
+PID_F=$RUN_D/$BIN.pid
+
+start() {
+	[ -f $DEFAULT ] && . $DEFAULT
+	mkdir -p $RUN_D
+	$BIN -l -s -t $OPTIONS && $BIN -D $OPTIONS
+}
+
+stop() {
+	[ -f $PID_F ] && kill $(cat $PID_F)
+}
+

--- a/net/htpdate/patches/100-adjtimex.patch
+++ b/net/htpdate/patches/100-adjtimex.patch
@@ -1,0 +1,20 @@
+--- a/htpdate.c
++++ b/htpdate.c
+@@ -359,7 +359,7 @@ static int htpdate_adjtimex( double drif
+ 
+ 	/* Read current kernel frequency */
+ 	tmx.modes = 0;
+-	ntp_adjtime(&tmx);
++	adjtimex(&tmx);
+ 
+ 	/* Calculate new frequency */
+ 	freq = (long)(65536e6 * drift);
+@@ -377,7 +377,7 @@ static int htpdate_adjtimex( double drif
+ 		printlog( 1, "seteuid()" );
+ 		exit(1);
+ 	} else {
+-		return( ntp_adjtime(&tmx) );
++		return( adjtimex(&tmx) );
+ 	}
+ 
+ }


### PR DESCRIPTION
Source homepage has changed, and sources are updated to version 1.1.1
released 25 August 2015.

Patch adjtimex still applies.

Changes in version 1.1.1:

- Fixed out of bound issue and a missing null-terminated string (thanks
  to Tobias Stöckmann)

Signed-off-by: Tijs Van Buggenhout <tvbuggen@netzerk.be>