### PR TITLE
nut: Fix required dependencies.

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -55,6 +55,7 @@ define Package/nut
 	$(call Package/nut/Default)
 	TITLE:=Network UPS Tools
 	DEPENDS:= \
+		+libpthread \
 		+NUT_DRIVER_SNMP:libnetsnmp \
 		+NUT_DRIVER_USB:libusb-compat \
 		+NUT_SSL:libopenssl


### PR DESCRIPTION
Fixes the complaint about missing "libpthread.so" dependency during compilation.

Signed-off-by: Hanson Wong <me@hansonwong.com.au>