### PR TITLE
open-plc-utils: upgrade to latest git revision and fix compilation

### DIFF
--- a/utils/open-plc-utils/Makefile
+++ b/utils/open-plc-utils/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=open-plc-utils
-PKG_VERSION:=2015-07-06
+PKG_VERSION:=2015-09-21
 PKG_RELEASE:=$(PKG_SOURCE_VERSION)
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=git://github.com/qca/open-plc-utils.git
+PKG_SOURCE_URL:=https://github.com/qca/open-plc-utils.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=885a1b7e2e663b5ab8797db6d40a0318131fdf18
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
@@ -74,6 +74,10 @@ OPEN_PLC_UTILS_APPS:=efbu efeu efru efsu edru edsu nics \
 		     ttyrecv ttycat int6kdetect
 
 $(foreach a,$(OPEN_PLC_UTILS_APPS),$(eval $(call GenPlugin,$(a))))
+
+ifdef CONFIG_USE_MUSL
+  TARGET_CFLAGS += -D__UCLIBC__
+endif
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \


### PR DESCRIPTION
Buildbots are reporting the following error:
../mme/ARPCPrint.c: In function 'ARPCPrint':
../mme/ARPCPrint.c:123:2: error: incompatible type for argument 3 of 'vfprintf'
  vfprintf (fp, (char *)(&data->LIST [LE16TOH (data->STROFFSET)]), (void *)(&data->LIST [LE16TOH (data->ARGOFFSET)]));
  ^
In file included from /store/buildbot/slave/mxs/build/staging_dir/toolchain-arm_arm926ej-s_gcc-4.8-linaro_musl-1.1.11_eabi/include/fortify/stdio.h:20:0,
                 from ../mme/ARPCPrint.c:68:
/store/buildbot/slave/mxs/build/staging_dir/toolchain-arm_arm926ej-s_gcc-4.8-linaro_musl-1.1.11_eabi/include/stdio.h:108:5: note: expected '__isoc_va_list' but argument is of type 'void *'

Fix this by definition __UCLIBC__ to enable a workaround for this
issue.

While at, switch to HTTPS URL for cloning the git repo.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>