### PR TITLE
chaosvpn: add new package

### DIFF
--- a/net/chaosvpn/Makefile
+++ b/net/chaosvpn/Makefile
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2010-2013 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=chaosvpn
+
+PKG_REV:=2eb24810b5aa0b2d56f21562e52927020dc3090a
+PKG_VERSION:=2014-01-24
+PKG_RELEASE=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/ryd/chaosvpn.git
+PKG_SOURCE_VERSION:=$(PKG_REV)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_REV).tar.gz
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:Norbert Summer <git@o-g.at>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/chaosvpn
+		TITLE:=Config generator for chaos vpn
+		SECTION:=net
+		CATEGORY:=Network
+		URL:=https://wiki.hamburg.ccc.de/index.php/ChaosVPN::DebianHowto
+		SUBMENU:=VPN
+		DEPENDS:=+tinc +ip +kmod-tun +libopenssl
+endef
+
+define Package/chaosvpn/description
+		Configure tincd for the chaosvpn network
+endef
+
+define Package/chaosvpn/conffiles
+/etc/tinc/chaosvpn.conf
+endef
+
+MAKE_FLAGS += \
+		COPT="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) $(TARGET_LDFLAGS)"
+
+define Package/chaosvpn/install
+		$(INSTALL_DIR) $(1)/etc/tinc/chaos/ $(1)/usr/sbin/ $(1)/etc/init.d/ $(1)/etc/hotplug.d/iface/
+		$(INSTALL_BIN) $(PKG_BUILD_DIR)/chaosvpn $(1)/usr/sbin/
+		$(INSTALL_BIN) ./files/chaosvpn.init $(1)/etc/init.d/chaosvpn
+		$(INSTALL_BIN) ./files/chaosvpn.hotplug $(1)/etc/hotplug.d/iface/40-chaosvpn
+		sed  -i -e 's/"\/sbin\/ip /"\/usr\/sbin\/ip /' $(PKG_BUILD_DIR)/chaosvpn.conf
+		$(INSTALL_CONF) $(PKG_BUILD_DIR)/chaosvpn.conf $(1)/etc/tinc/chaosvpn.conf
+endef
+
+$(eval $(call BuildPackage,chaosvpn))
+

--- a/net/chaosvpn/files/chaosvpn.hotplug
+++ b/net/chaosvpn/files/chaosvpn.hotplug
@@ -1,0 +1,3 @@
+[ "$INTERFACE" == "wan" ] || return
+[ "$ACTION" == "ifup" ] && /etc/init.d/chaosvpn restart
+

--- a/net/chaosvpn/files/chaosvpn.init
+++ b/net/chaosvpn/files/chaosvpn.init
@@ -1,0 +1,31 @@
+#!/bin/sh /etc/rc.common
+START=99
+
+USE_PROCD=1
+
+start_service()
+{
+  #check if chaosvpn is configured
+  if [ ! -f "/etc/tinc/chaos/rsa_key.pub" -o ! -f "/etc/tinc/chaos/rsa_key.priv" ]; then
+    logger -t chaosvpn "please generate rsa key pair"
+    logger -t chaosvpn "tincd -n chaos --generate-keys=2048"
+    exit 1
+  fi
+
+  if [ "`grep unique_name /etc/tinc/chaosvpn.conf  | wc -l`" != "0" ]; then
+    logger -t chaosvpn "/etc/tinc/chaosvpn.conf is not configured yet or contains 'unique_name'"
+    exit 1
+  fi
+
+  procd_open_instance
+  procd_set_param command /usr/sbin/chaosvpn -r -c /etc/tinc/chaosvpn.conf
+  procd_close_instance
+}
+
+stop_service()
+{
+  #force remove tinc pid
+  if [ -f "/var/run/tinc.chaos.pid" ]; then
+    rm "/var/run/tinc.chaos.pid"
+  fi
+}


### PR DESCRIPTION
Hello this is a pull request to readd chaosvpn because I missed it since the update.

I'm not sure that depend on `ip` is right because the also other packages `ip-*`
Is it possible to add this package to the stable branch, otherwise is it possible for the master branch?

This is my first package for openwrt so please check it.