### PR TITLE
Build nut plugin for collectd

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -270,6 +270,7 @@ $(eval $(call DriverDescription,usb,nutdrv_qx,\
 	Driver for Q* protocol serial and USB based UPS equipment))
 
 CONFIGURE_ARGS += \
+	--with-dev \
 	--$(if $(CONFIG_NUT_DRIVER_SERIAL),with,without)-serial \
 	--$(if $(CONFIG_NUT_DRIVER_USB),with,without)-usb \
 	--$(if $(CONFIG_NUT_DRIVER_SNMP),with,without)-snmp \
@@ -286,6 +287,19 @@ CONFIGURE_ARGS += \
 	--with-drvpath=/lib/nut \
 	--with-statepath=/var/run \
 	--datadir=/usr/share/nut
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib/pkgconfig
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/lib*.so* \
+		$(1)/usr/lib/
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/include/*.h \
+		$(1)/usr/include/
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc \
+		$(1)/usr/lib/pkgconfig/
+endef
 
 $(eval $(call BuildPackage,nut))
 $(foreach d,$(filter-out $(SERIAL_DRIVERLIST_IGNORE),$(SERIAL_DRIVERLIST)),$(eval $(call BuildPackage,nut-driver-$(d))))

--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -60,7 +60,6 @@ COLLECTD_PLUGINS_DISABLED:= \
 	notify_desktop \
 	notify_email \
 	numa \
-	nut \
 	openldap \
 	openvz \
 	oracle \
@@ -126,6 +125,7 @@ COLLECTD_PLUGINS_SELECTED:= \
 	network \
 	nginx \
 	ntpd \
+	nut \
 	olsrd \
 	onewire \
 	openvpn \
@@ -318,7 +318,7 @@ $(eval $(call BuildPlugin,netlink,netlink input,netlink,+PACKAGE_collectd-mod-ne
 $(eval $(call BuildPlugin,network,network input/output,network))
 $(eval $(call BuildPlugin,nginx,nginx status input,nginx,+PACKAGE_collectd-mod-nginx:libcurl))
 $(eval $(call BuildPlugin,ntpd,NTP daemon status input,ntpd,))
-#$(eval $(call BuildPlugin,nut,UPS monitoring input,nut,+PACKAGE_collectd-mod-nut:nut))
+$(eval $(call BuildPlugin,nut,UPS monitoring input,nut,+PACKAGE_collectd-mod-nut:nut))
 $(eval $(call BuildPlugin,olsrd,OLSRd status input,olsrd,))
 $(eval $(call BuildPlugin,onewire,onewire sensor input,onewire,+PACKAGE_collectd-mod-onewire:libow-capi @BROKEN))
 $(eval $(call BuildPlugin,openvpn,OpenVPN traffic/compression input,openvpn,))


### PR DESCRIPTION
These patches enable the development headers for nut to be installed, and then re-enable the nut plugin for collectd. I like my pretty UPS graphs.

cf. https://dev.openwrt.org/ticket/20515