### PR TITLE
ddns: Added schokokeks.org to ddns services

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.4.3
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -91,3 +91,6 @@
 
 # domains.google.com	non free service - require HTTPS communication
 "domains.google.com"	"https://[USERNAME]:[PASSWORD]@domains.google.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
+
+# Schokokeks Hosting, schokokeks.org
+"schokokeks.org" "http://[USERNAME]:[PASSWORD]@dyndns.schokokeks.org/nic/update?myip=[IP]"


### PR DESCRIPTION
Just added another service config. I already tested this to make sure it works with the schokokeks.org DynDNS service.

See more details in the schokokeks.org wiki for their DNS service: https://wiki.schokokeks.org/DynDNS#per_HTTPS (German only, unfortunately)

Let me know if I have to fix s.th. else before this can be merged...