### PR TITLE
mpg123: simplify dependanciess, add more binaries

### DIFF
--- a/sound/mpg123/Makefile
+++ b/sound/mpg123/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpg123
 PKG_VERSION:=1.22.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.mpg123.de/download/
@@ -43,7 +43,7 @@ define Package/mpg123
   SECTION:=sound
   CATEGORY:=Sound
   TITLE:=fast console mpeg audio player
-  DEPENDS+=+libmpg123 +alsa-lib +libsdl +libpthread
+  DEPENDS+=+libmpg123 +alsa-lib
 endef
 
 define Build/Configure
@@ -51,6 +51,7 @@ define Build/Configure
 		--enable-shared \
 		--enable-static \
 		--with-cpu=generic_nofpu \
+		--with-default-audio=alsa \
 	)
 endef
 
@@ -86,7 +87,8 @@ endef
 define Package/mpg123/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) \
-		$(PKG_INSTALL_DIR)/usr/bin/mpg123 \
+		$(PKG_INSTALL_DIR)/usr/bin/mpg123{,-id3dump,-strip} \
+		$(PKG_INSTALL_DIR)/usr/bin/out123
 		$(1)/usr/bin
 
 	$(INSTALL_DIR) $(1)/usr/lib/mpg123


### PR DESCRIPTION
1. Dependencies. There is no `libsdl` in repo, `alsa-lib` [ already got](https://github.com/openwrt/packages/blob/master/libs/alsa-lib/Makefile) `libpthread` dependency.
2. Default audio output is set to alsa, I think we can do it as long as package depends on `alsa-lib`.
3. Please consider to pack additional binaries as a part of `mpg123` package:
     * [out123](http://rpm.pbone.net/index.php3/stat/45/idpl/30534747/numer/1/nazwa/out123) to play raw PCM audio to an output device,
     * mpg123-id3dump to extract meta data,
     * mpg123-strip to strip dirt out of MPEG streams including meta data.

This binaries becomes official part of mpg123 [since v1.16.0](http://upstream.rosalinux.ru/changelogs/mpg123/1.18.0/changelog.html).