### PR TITLE
Canfestival library: add new package

### DIFF
--- a/libs/libcanfestival/Makefile
+++ b/libs/libcanfestival/Makefile
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libcanfestival
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=hg
+PKG_SOURCE_URL:=http://dev.automforge.net/CanFestival-3
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)
+PKG_SOURCE_VERSION:=8bfe0ac00cdb
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.bz2
+
+PKG_MAINTAINER:=Anton Glukhov <anton.a.glukhov@gmail.com>
+PKG_LICENSE:=LGPL-2.1+
+PKG_LICENSE_FILE:=LICENCE
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libcanfestival
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Free software CANopen library
+  URL:=http://canfestival.org
+  DEPENDS:=+libpthread +librt
+endef
+
+define Package/libcanfestival/description
+  CanFestival library
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+CONFIGURE_ARGS := \
+	--cc=$(TARGET_CC) \
+	--cxx=$(TARGET_CXX) \
+	--ld=$(TARGET_CC) \
+	--arch=$(ARCH) \
+	--os=Linux \
+	--kerneldir=$(LINUX_DIR) \
+	--prefix=/usr \
+	--target=unix \
+	--can=socket \
+	--timers=unix \
+	--debug=ERR \
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
+endef
+
+define Package/libcanfestival/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcanfestival_can_socket.so $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libcanfestival))

--- a/libs/libcanfestival/patches/001-sigval-ref-fix.patch
+++ b/libs/libcanfestival/patches/001-sigval-ref-fix.patch
@@ -1,0 +1,11 @@
+--- a/drivers/timers_unix/timers_unix.c
++++ b/drivers/timers_unix/timers_unix.c
+@@ -33,7 +33,7 @@
+ 	}
+ }
+ 
+-void timer_notify(sigval_t val)
++void timer_notify(void)
+ {
+ 	if(gettimeofday(&last_sig,NULL)) {
+ 		perror("gettimeofday()");

--- a/libs/libcanfestival/patches/002-makefile-gcc-linker.patch
+++ b/libs/libcanfestival/patches/002-makefile-gcc-linker.patch
@@ -1,0 +1,33 @@
+--- a/examples/TestMasterMicroMod/Makefile.in
++++ b/examples/TestMasterMicroMod/Makefile.in
+@@ -56,7 +56,7 @@
+ 
+ 
+ $(TESTMASTERMICROMOD): $(OBJS)
+-	$(LD) $(CFLAGS) $(PROG_CFLAGS) ${PROGDEFINES} $(INCLUDES) -o $@ $(OBJS) $(EXE_CFLAGS)
++	$(CC) $(CFLAGS) $(PROG_CFLAGS) ${PROGDEFINES} $(INCLUDES) -o $@ $(OBJS) $(EXE_CFLAGS)
+ 
+ 	
+ TestMaster.c: TestMaster.od
+--- a/examples/TestMasterSlave/Makefile.in
++++ b/examples/TestMasterSlave/Makefile.in
+@@ -65,7 +65,7 @@
+ 
+ 
+ $(TESTMASTERSLAVE): $(OBJS)
+-	$(LD) $(CFLAGS) $(PROG_CFLAGS) ${PROGDEFINES} $(INCLUDES) -o $@ $(OBJS) $(EXE_CFLAGS)
++	$(CC) $(CFLAGS) $(PROG_CFLAGS) ${PROGDEFINES} $(INCLUDES) -o $@ $(OBJS) $(EXE_CFLAGS)
+ 	
+ TestSlave.c: TestSlave.od
+ 	$(MAKE) -C ../../objdictgen gnosis
+--- a/examples/CANOpenShell/Makefile.in
++++ b/examples/CANOpenShell/Makefile.in
+@@ -64,7 +64,7 @@
+ 	$(MAKE) -C ../../drivers/$(TARGET) libcanfestival_$(TARGET).a
+ 
+ $(CANOPENSHELL): $(OBJS)
+-	$(LD) $(CFLAGS) $(PROG_CFLAGS) ${PROGDEFINES} $(INCLUDES) -o $@ $(OBJS) $(EXE_CFLAGS)
++	$(CC) $(CFLAGS) $(PROG_CFLAGS) ${PROGDEFINES} $(INCLUDES) -o $@ $(OBJS) $(EXE_CFLAGS)
+ 	mkdir -p Debug; cp $(CANOPENSHELL) Debug
+ 	
+ CANOpenShellMasterOD.c: CANOpenShellMasterOD.od


### PR DESCRIPTION
Canfestival is a library, which implement CANOpen protocol.
http://canfestival.org/

Signed-off-by: Anton Glukhov <anton.a.glukhov@gmail.com>