### PR TITLE
python-package.mk: fix cross-compiling C++ modules.

### DIFF
--- a/lang/python/files/python-package.mk
+++ b/lang/python/files/python-package.mk
@@ -103,6 +103,7 @@ define Build/Compile/PyMod
 		cd $(PKG_BUILD_DIR)/$(strip $(1)); \
 		CC="$(TARGET_CC)" \
 		CCSHARED="$(TARGET_CC) $(FPIC)" \
+		CXX="$(TARGET_CXX)" \
 		LD="$(TARGET_CC)" \
 		LDSHARED="$(TARGET_CC) -shared" \
 		CFLAGS="$(TARGET_CFLAGS)" \


### PR DESCRIPTION
Signed-off-by: Attila Lendvai <attila@lendvai.name>