### PR TITLE
aiccu: enable GnuTLS support

### DIFF
--- a/ipv6/aiccu/Makefile
+++ b/ipv6/aiccu/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aiccu
 PKG_VERSION:=20070115
-PKG_RELEASE:=14
+PKG_RELEASE:=15
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.sixxs.net/archive/sixxs/aiccu/unix
@@ -24,7 +24,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/aiccu
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libpthread +ip +kmod-sit +kmod-tun
+  DEPENDS:=+libpthread +ip +kmod-sit +kmod-tun +libgnutls
   TITLE:=SixXS Automatic IPv6 Connectivity Client Utility
   URL:=http://www.sixxs.net/tools/aiccu/
   MAINTAINER:=Ondrej Caletka <ondrej@caletka.cz>
@@ -36,7 +36,7 @@ endef
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
-		CC="$(TARGET_CC)" OS_NAME="Linux" OS_VERSION="$(LINUX_VERSION)" \
+		CC="$(TARGET_CC)" OS_NAME="Linux" OS_VERSION="$(LINUX_VERSION)" HAVE_GNUTLS=1 \
 		EXTRA_CFLAGS="$(TARGET_CFLAGS)" \
 		EXTRA_LDFLAGS="$(TARGET_LDFLAGS) -pthread" \
 		DEBUG=0

--- a/ipv6/aiccu/patches/500-gnutls_3.4.patch
+++ b/ipv6/aiccu/patches/500-gnutls_3.4.patch
@@ -1,0 +1,22 @@
+--- aiccu/common/common.c
++++ aiccu/common/common.c
+@@ -271,8 +271,6 @@
+ TLSSOCKET sock_alloc(void)
+ {
+ #ifdef AICCU_GNUTLS
+-	/* Allow connections to servers that have OpenPGP keys as well */
+-	const int	cert_type_priority[3] = { GNUTLS_CRT_X509, GNUTLS_CRT_OPENPGP, 0 };
+ 	int		ret;
+ #endif /* AICCU_GNUTLS*/
+ 
+@@ -300,7 +298,8 @@
+ 	gnutls_set_default_priority(sock->session);
+ 	/* XXX: Return value is not documented in GNUTLS documentation! */
+ 
+-	gnutls_certificate_type_set_priority(sock->session, cert_type_priority);
++	/* Allow connections to servers that have OpenPGP keys as well */
++	gnutls_priority_set_direct(sock->session, "NORMAL:+CTYPE-OPENPGP", NULL);
+ 	/* XXX: Return value is not documented in GNUTLS documentation! */
+ 
+ 	/* Configure the x509 credentials for the current session */
+


### PR DESCRIPTION
GnuTLS support in aiccu has been available for years; transmitting plaintext credentials on the wire in 2015 is unacceptable.

Signed-off-by: Sébastien Noel <sebastien@twolife.be>