### PR TITLE
bmon: depend only on libnl-route

### DIFF
--- a/net/bmon/Makefile
+++ b/net/bmon/Makefile
@@ -22,7 +22,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/bmon
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+PACKAGE_libncursesw:libncursesw +!PACKAGE_libncursesw:libncurses +libnl +confuse +terminfo
+  DEPENDS:=+PACKAGE_libncursesw:libncursesw +!PACKAGE_libncursesw:libncurses +libnl-route +confuse +terminfo
   TITLE:=bmon is a portable bandwidth monitor
   URL:=https://github.com/tgraf/bmon/
 endef


### PR DESCRIPTION
bmon only seems to require libnl-route.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>