### PR TITLE
[utils/zoneinfo] Updated to the latest release.

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2015f
-PKG_VERSION_CODE:=2015f
+PKG_VERSION:=2015g
+PKG_VERSION_CODE:=2015g
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -20,14 +20,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION_CODE).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_MD5SUM:=e3b82732d20e973e48af1c6f13df9a1d
+PKG_MD5SUM:=8d46e8b225b9a04c75f5c39636435ad6
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   MD5SUM:=19578d432ba8b92f73406a17a9bc268d
+   MD5SUM:=a2c47d908a6426f530efb1393cf1cd06
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
The 2015g release of the tz code and data is available.  It reflects the
following changes, which were either circulated on the tz mailing list
or are relatively minor technical or administrative changes:

   Changes affecting future time stamps

     Turkey's 2015 fall-back transition is scheduled for Nov. 8, not
Oct. 25.
     (Thanks to Fatih.)

     Norfolk moves from +1130 to +1100 on 2015-10-04 at 02:00 local time.
     (Thanks to Alexander Krivenyshev.)

     Fiji's 2016 fall-back transition is scheduled for January 17, not 24.
     (Thanks to Ken Rylander.)

     Fort Nelson, British Columbia will not fall back on 2015-11-01. It has
     effectively been on MST (-0700) since it advanced its clocks on
2015-03-08.
     New zone America/Fort_Nelson.  (Thanks to Matt Johnson.)

   Changes affecting past time stamps

     Norfolk observed DST from 1974-10-27 02:00 to 1975-03-02 02:00.

   Changes affecting code

     localtime no longer mishandles America/Anchorage after 2037.
     (Thanks to Bradley White for reporting the bug.)

     On hosts with signed 32-bit time_t, localtime no longer mishandles
     Pacific/Fiji after 2038-01-16 14:00 UTC.

     The localtime module allows the variables 'timezone', 'daylight',
     and 'altzone' to be in common storage shared with other modules,
     and declares them in case the system <time.h> does not.
     (Problems reported by Kees Dekker.)

     On platforms with tm_zone, strftime.c now assumes it is not NULL.
     This simplifies the code and is consistent with zdump.c.
     (Problem reported by Christos Zoulas.)

   Changes affecting documentation

    The tzfile man page now documents that transition times denote the
    starts (not the ends) of the corresponding time periods.
    (Ambiguity reported by Bill Seymour.)

