### PR TITLE
collectd: backport parallel build fix from upstream

### DIFF
--- a/utils/collectd/patches/500-upstream-parallel-build-fix.patch
+++ b/utils/collectd/patches/500-upstream-parallel-build-fix.patch
@@ -1,0 +1,17 @@
+Backport of 780e6a76021a240e95007a04b723d827120afa95
+Subject: [PATCH] build: add libavltree, libcommon & libheap dependencies
+
+Otherwise it can break on very parallel builds since collectd link time
+arrives before one or more of these were built.
+
+--- a/src/daemon/Makefile.am
++++ b/src/daemon/Makefile.am
+@@ -49,7 +49,7 @@ collectd_CPPFLAGS =  $(AM_CPPFLAGS) $(LT
+ collectd_CFLAGS = $(AM_CFLAGS)
+ collectd_LDFLAGS = -export-dynamic
+ collectd_LDADD = libavltree.la libcommon.la libheap.la -lm
+-collectd_DEPENDENCIES =
++collectd_DEPENDENCIES = libavltree.la libcommon.la libheap.la
+ 
+ # Link to these libraries..
+ if BUILD_WITH_LIBRT


### PR DESCRIPTION
Backport a fix for parallel build from collectd upstream, where it has been commited to both trunk and 5.5 branch.

I have run a few times into a collectd build failure after make clean (log excerpt below).
```
OpenWrt-libtool: link: cannot find the library `libcommon.la' or unhandled argument `libcommon.la'
Makefile:873: recipe for target 'collectd' failed
make[7]: *** [collectd] Error 1
make[7]: *** Waiting for unfinished jobs....
```
Today I investigated the error and found that it has been already fixed upstream.

Upstream issue report: https://github.com/collectd/collectd/issues/1146
Upstream patch: https://github.com/collectd/collectd/commit/780e6a76021a240e95007a04b723d827120afa95

(we miss one additional commit before this patch, so I had to adapt the patch context a bit.)

@jow- 
Please commit this upstream fix.
