### PR TITLE
nut: add dev headers, nut-web-cgi and nut-avahi-service, bugfix

### DIFF
--- a/net/nut/Config.in
+++ b/net/nut/Config.in
@@ -84,13 +84,6 @@
 			some space and build NUT without SSL support.
 		default n
 	
-	config NUT_DRIVER_SERIAL
-		depends on PACKAGE_nut
-		bool "Build with support for serial drivers"
-		help
-			If you have a UPS connected via serial, select this.
-		default n
-	
 	config NUT_DRIVER_USB
 		depends on PACKAGE_nut
 		bool "Build with support for USB drivers"

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/
@@ -28,11 +28,10 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_NUT_CLIENTS_UPSMON \
 	CONFIG_NUT_CLIENTS_UPSRW \
 	CONFIG_NUT_CLIENTS_UPSSCHED \
-	CONFIG_NUT_DRIVER_SERIAL \
 	CONFIG_NUT_DRIVER_SNMP \
 	CONFIG_NUT_DRIVER_USB \
 	CONFIG_NUT_SERVER \
-	CONFIG_NUT_SSL \
+	CONFIG_NUT_SSL
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -78,7 +77,6 @@ endef
 define Package/nut/install
 	$(INSTALL_DIR) $(1)/etc/nut
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/nut.conf.sample $(1)/etc/nut/nut.conf
@@ -102,7 +100,7 @@ define Package/nut/install
 	$(if $(CONFIG_NUT_SERVER),$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/upsd.users.sample $(1)/etc/nut/upsd.users)
 	$(if $(CONFIG_NUT_CLIENTS_UPSC),$(CP) $(PKG_INSTALL_DIR)/usr/bin/upsc $(1)/usr/bin/)
 	$(if $(CONFIG_NUT_CLIENTS_UPSCMD),$(CP) $(PKG_INSTALL_DIR)/usr/bin/upscmd $(1)/usr/bin/)
-	$(if $(CONFIG_NUT_CLIENTS_LOG),$(CP) $(PKG_INSTALL_DIR)/usr/bin/upslog $(1)/usr/bin/)
+	$(if $(CONFIG_NUT_CLIENTS_UPSLOG),$(CP) $(PKG_INSTALL_DIR)/usr/bin/upslog $(1)/usr/bin/)
 	$(if $(CONFIG_NUT_CLIENTS_UPSRW),$(CP) $(PKG_INSTALL_DIR)/usr/bin/upsrw $(1)/usr/bin/)
 	$(if $(CONFIG_NUT_CLIENTS_UPSMON),$(CP) ./files/nut-monitor.init $(1)/etc/init.d/)
 	$(if $(CONFIG_NUT_CLIENTS_UPSMON),$(CP) $(PKG_INSTALL_DIR)/usr/sbin/upsmon $(1)/usr/sbin/)
@@ -112,13 +110,62 @@ define Package/nut/install
 	$(if $(CONFIG_NUT_CLIENTS_UPSSCHED),$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/upssched.conf.sample $(1)/etc/nut/upssched.conf)
 endef
 
+define Package/nut-web-cgi
+	$(call Package/nut/Default)
+	TITLE+= Web CGI interface
+	DEPENDS+=+libgd
+endef
+
+define Package/nut-web-cgi/description
+The CGI programs are clients that run through your web server.
+They allow you to see UPS status and perform certain administrative
+commands from any web browser. Javascript and cookies are not required.
+endef
+
+define Package/nut-web-cgi/conffiles
+	/etc/nut/hosts.conf
+	/etc/nut/upsset.conf
+	/etc/nut/upsstats.html
+	/etc/nut/upsstats-single.html
+endef
+
+define Package/nut-web-cgi/install
+	$(INSTALL_DIR) $(1)/etc/nut
+	$(INSTALL_DIR) $(1)/usr/share/www/cgi-bin
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/hosts.conf.sample $(1)/etc/nut/hosts.conf
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/upsset.conf.sample $(1)/etc/nut/upsset.conf
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/upsstats.html.sample $(1)/etc/nut/upsstats.html
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/upsstats-single.html.sample $(1)/etc/nut/upsstats-single.html
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/www/nut $(1)/usr/share/www/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/www/cgi-bin/nut $(1)/usr/share/www/cgi-bin/
+endef
+
+define Package/nut-avahi-service
+	$(call Package/nut/Default)
+	TITLE+= (Avahi service)
+	DEPENDS+=+avahi-daemon
+endef
+
+define Package/nut-avahi-service/description
+This package contains the service definition for announcing the
+attached UPS via mDNS/DNS-SD.
+endef
+
+define Package/nut-avahi-service/conffiles
+	/etc/avahi/services/nut.service
+endef
+
+define Package/nut-avahi-service/install
+	$(INSTALL_DIR) $(1)/etc/avahi/services
+	$(INSTALL_CONF) ./files/nut.service $(1)/etc/avahi/services/
+endef
+
 # Dealing with all of the drivers is very repetitive, but the previous
 # maintainer had a neat solution which just needed some tweaking.
 define DriverPackage
         define Package/nut-driver-$(2)
 		$(call Package/nut/Default)
 		TITLE:=$(2) (NUT $(1) driver)
-		$(if $(filter $(1),serial),DEPENDS+= @NUT_DRIVER_SERIAL)
 		$(if $(filter $(1),snmp),DEPENDS+= @NUT_DRIVER_SNMP)
 		$(if $(filter $(1),usb),DEPENDS+= @NUT_DRIVER_USB)
         endef
@@ -270,24 +317,36 @@ $(eval $(call DriverDescription,usb,nutdrv_qx,\
 	Driver for Q* protocol serial and USB based UPS equipment))
 
 CONFIGURE_ARGS += \
-	--$(if $(CONFIG_NUT_DRIVER_SERIAL),with,without)-serial \
+	--sysconfdir=/etc/nut \
+	--datadir=/usr/share/nut \
+	--with-dev \
 	--$(if $(CONFIG_NUT_DRIVER_USB),with,without)-usb \
+	--without-avahi \
 	--$(if $(CONFIG_NUT_DRIVER_SNMP),with,without)-snmp \
 	--without-neon \
 	--without-powerman \
 	--without-ipmi \
 	--without-freeipmi \
 	--$(if $(CONFIG_NUT_SSL),with,without)-ssl $(if $(CONFIG_NUT_SSL),--with-openssl) \
-	--without-avahi \
 	--without-libltdl \
-	--with-user=root \
-	--with-group=root \
-	--sysconfdir=/etc/nut \
-	--with-drvpath=/lib/nut \
+	--$(if $(CONFIG_PACKAGE_nut-web-cgi),with,without)-cgi \
 	--with-statepath=/var/run \
-	--datadir=/usr/share/nut
+	--with-drvpath=/lib/nut \
+	--with-cgipath=/usr/share/www/cgi-bin/nut \
+	--with-htmlpath=/usr/share/www/nut \
+	--with-user=root \
+	--with-group=root
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc $(1)/usr/lib/pkgconfig/
+endef
 
 $(eval $(call BuildPackage,nut))
+$(eval $(call BuildPackage,nut-web-cgi))
+$(eval $(call BuildPackage,nut-avahi-service))
 $(foreach d,$(filter-out $(SERIAL_DRIVERLIST_IGNORE),$(SERIAL_DRIVERLIST)),$(eval $(call BuildPackage,nut-driver-$(d))))
 $(foreach d,$(SNMP_DRIVERLIST),$(eval $(call BuildPackage,nut-driver-$(d))))
 $(foreach d,$(USB_LIBUSB_DRIVERLIST),$(eval $(call BuildPackage,nut-driver-$(d))))

--- a/net/nut/files/nut.service
+++ b/net/nut/files/nut.service
@@ -1,0 +1,34 @@
+<?xml version="1.0" standalone='no'?><!--*-nxml-*-->
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+
+<!--
+  This file is part of NUT - Network UPS Tools
+
+  NUT is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2 of the
+  License, or (at your option) any later version.
+
+  NUT is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with NUT; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+  02111-1307 USA.
+-->
+
+<!-- See avahi.service(5) for more information about this configuration file -->
+
+<service-group>
+
+  <name replace-wildcards="yes">%h</name>
+
+  <service>
+    <type>_nut._tcp</type>
+    <port>3493</port>
+  </service>
+
+</service-group>


### PR DESCRIPTION
Headers are required by collectd as mentioned in #1801. This is the nut portion based on dwmw2@d636841cd1d1dfab04cb509520c082738ddfb2ea
Happy to merge with 15.05 as per #1803.
Signed-off-by: David Woodhouse <David.Woodhouse@intel.com>
[martin.p.rowe@gmail.com: condensed InstallDev lines]

Added package nut-web-cgi based on demorfi@7e340f47944ff4a9c49d3b1dc6c1d9d965cd344c
Closes #1614.
Pending signoff by @demorfi
[martin.p.rowe@gmail.com: simplified implementation, no changes to Config.in]

Added package nut-avahi-service similar to other implementations in #618
Bugfix to remove redundant NUT_DRIVER_SERIAL config
Bugfix to make UPSLOG config actually install (requires PKG_RELEASE bump)
Some code tidy-ups
Signed-off-by: Martin Rowe <martin.p.rowe@gmail.com>