### PR TITLE
Remove dependency on kmod-ipv6

### DIFF
--- a/ipv6/tayga/Makefile
+++ b/ipv6/tayga/Makefile
@@ -19,7 +19,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/tayga
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+ip +kmod-ipv6 +kmod-tun
+  DEPENDS:=+ip @IPV6 +kmod-tun
   TITLE:=Out-of-kernel stateless NAT64 implementation for Linux
   URL:=http://www.litech.org/tayga/
   MAINTAINER:=Ondrej Caletka <ondrej@caletka.cz>


### PR DESCRIPTION
IPv6 support is builtin if selected. Therefor, dependencies on kmod-ipv6 can no longer be fulfilled.