### PR TITLE
motion: fix segmentation fault under musl libc

### DIFF
--- a/multimedia/motion/Makefile
+++ b/multimedia/motion/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2011 OpenWrt.org
+# Copyright (C) 2008-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=motion
 PKG_VERSION=3.4.0-20141018-$(PKG_SOURCE_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPLv2

--- a/multimedia/motion/patches/100-musl-compat.patch
+++ b/multimedia/motion/patches/100-musl-compat.patch
@@ -1,0 +1,49 @@
+--- a/motion.c
++++ b/motion.c
+@@ -2630,6 +2630,17 @@ int main (int argc, char **argv)
+     struct sigaction sigchild_action;
+     setup_signals(&sig_handler_action, &sigchild_action);
+ 
++    /*
++     * Create and a thread attribute for the threads we spawn later on.
++     * PTHREAD_CREATE_DETACHED means to create threads detached, i.e.
++     * their termination cannot be synchronized through 'pthread_join'.
++     */
++    pthread_attr_init(&thread_attr);
++    pthread_attr_setdetachstate(&thread_attr, PTHREAD_CREATE_DETACHED);
++
++    /* Create the TLS key for thread number. */
++    pthread_key_create(&tls_key_threadnr, NULL);
++
+     motion_startup(1, argc, argv);
+ 
+ #ifdef HAVE_FFMPEG
+@@ -2648,17 +2659,6 @@ int main (int argc, char **argv)
+     if (cnt_list[0]->conf.setup_mode)
+         MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO, "%s: Motion running in setup mode.");
+ 
+-    /*
+-     * Create and a thread attribute for the threads we spawn later on.
+-     * PTHREAD_CREATE_DETACHED means to create threads detached, i.e.
+-     * their termination cannot be synchronized through 'pthread_join'.
+-     */
+-    pthread_attr_init(&thread_attr);
+-    pthread_attr_setdetachstate(&thread_attr, PTHREAD_CREATE_DETACHED);
+-
+-    /* Create the TLS key for thread number. */
+-    pthread_key_create(&tls_key_threadnr, NULL);
+-
+     do {
+         if (restart) {
+             /*
+--- a/motion.h
++++ b/motion.h
+@@ -84,7 +84,7 @@
+ #endif
+ 
+ /* strerror_r() XSI vs GNU */
+-#if (defined(BSD)) || ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE)
++#if (defined(BSD)) || ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE) || (!defined(__GLIBC__))
+ #define XSI_STRERROR_R
+ #endif
+ 


### PR DESCRIPTION
During startup, motion calls pthread_getspecific() through motion_log()
before pthread_key_create() has been called yet. This works on glibc and
uclibc but segfaults on musl because motion is relying on undefined
behaviour here.

Move the pthread initialization before motion_startup() so that
tls_key_threadnr is initialized when motion_log() is called.

Also enforce the use of strerror_r() on musl by defining XSI_STRERROR_R
on all non-glibc systems because the supposed replacement code is broken
and crashes on musl.

References:
http://www.lavrsen.dk/foswiki/bin/view/Motion/BugReport2015x09x30x203633

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>