### PR TITLE
Fwknop: Fix setting getting overwritten

### DIFF
--- a/net/fwknop/files/fwknopd.init
+++ b/net/fwknop/files/fwknopd.init
@@ -36,7 +36,7 @@ reload()
 gen_confs()
 {
 	[ -f /tmp/access.conf.tmp ] && rm /tmp/access.conf.tmp
-	if [`uci get fwknopd.@access[0].PCAP_INTF` = ""]
+	if [ "`uci get fwknopd.@config[0].PCAP_INTF`" = ""]
 	then
 		. /lib/functions/network.sh
 		network_get_physdev device wan


### PR DESCRIPTION
A typo in the init file was causing a certain setting to be overwritten on every daemon start.

Signed-off-by: Jonathan Bennett <JBennett@incomsystems.biz>
Fixes: 1771