### PR TITLE
shairport-sync: important bug fix and enhancements

### DIFF
--- a/sound/shairport-sync/Makefile
+++ b/sound/shairport-sync/Makefile
@@ -3,8 +3,7 @@
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
-# updated to work with latest source from abrasive
-#
+
 
 include $(TOPDIR)/rules.mk
 

--- a/sound/shairport-sync/Makefile
+++ b/sound/shairport-sync/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shairport-sync
-PKG_VERSION:=2.4.1
-PKG_RELEASE:=2
+PKG_VERSION:=2.4.2
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=git://github.com/mikebrady/shairport-sync.git

--- a/sound/shairport-sync/Makefile
+++ b/sound/shairport-sync/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shairport-sync
-PKG_VERSION:=2.4.2
+PKG_VERSION:=2.6
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git

--- a/sound/shairport-sync/files/shairport-sync.config
+++ b/sound/shairport-sync/files/shairport-sync.config
@@ -23,6 +23,7 @@ config shairport-sync 'shairport_sync'
 	option resync_threshold '' # 2205
 	option log_verbosity '' # 0/1/2/3
 	option ignore_volume_control '' # no/yes
+	option volume_range_db '' # 30 to 150
 	# Latencies
 	option latencies_default '' # 88200
 	option latencies_itunes '' # 99400

--- a/sound/shairport-sync/files/shairport-sync.config
+++ b/sound/shairport-sync/files/shairport-sync.config
@@ -1,13 +1,13 @@
 # Use your own config file
 config shairport-sync 'shairport_sync_file'
-	option disabled '1'
+	option disabled '1' # delete this line to use your own config file
 	option respawn '1'
 	option conf_custom '1'
 	option conf_file '/etc/shairport-sync.conf'
 
 # Use OpenWrt UCI config
 config shairport-sync 'shairport_sync'
-	option disabled '1'
+	option disabled '1' # delete this line to use an OpenWRT UCI config file
 	option respawn '1'
 	# General
 	option name 'Shairport-Sync'

--- a/sound/shairport-sync/files/shairport-sync.init
+++ b/sound/shairport-sync/files/shairport-sync.init
@@ -58,7 +58,7 @@ start_instance() {
 		append_num "$cfg" "$conf_file" resync_threshold "resync_threshold"
 		append_num "$cfg" "$conf_file" log_verbosity "log_verbosity"
 		append_str "$cfg" "$conf_file" ignore_volume_control "ignore_volume_control"
-		append_str "$cfg" "$conf_file" volume_range_db "volume_range_db"
+		append_num "$cfg" "$conf_file" volume_range_db "volume_range_db"
 		echo -e "};\n" >> $conf_file
 
 		# Latencies

--- a/sound/shairport-sync/files/shairport-sync.init
+++ b/sound/shairport-sync/files/shairport-sync.init
@@ -58,6 +58,7 @@ start_instance() {
 		append_num "$cfg" "$conf_file" resync_threshold "resync_threshold"
 		append_num "$cfg" "$conf_file" log_verbosity "log_verbosity"
 		append_str "$cfg" "$conf_file" ignore_volume_control "ignore_volume_control"
+		append_str "$cfg" "$conf_file" volume_range_db "volume_range_db"
 		echo -e "};\n" >> $conf_file
 
 		# Latencies

--- a/sound/shairport-sync/files/shairport-sync.init
+++ b/sound/shairport-sync/files/shairport-sync.init
@@ -1,5 +1,6 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2015 OpenWrt.org
+# Shairport Sync startup file
 
 START=99
 USE_PROCD=1


### PR DESCRIPTION
Shairport Sync 2.6 brings an important bug fix and some enhancements:

1. A long-standing bug has been fixed which should make Shairport Sync more reliable and also compatible with Synology devices.

2. Shairport Sync now sets latencies automatically, like it always should have, making it easier to integrate with, for example, audio|acacia and Synology devices.

3. An extra setting allows you to use just part of the full level-control range of the mixer -- useful with the built-in DAC of the Raspberry Pi.

Signed-off-by: Mike Brady <mikebrady@eircom.net>