### PR TITLE
libdmapsharing: update to 2.9.32

### DIFF
--- a/libs/libdmapsharing/Makefile
+++ b/libs/libdmapsharing/Makefile
@@ -10,7 +10,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdmapsharing
-PKG_VERSION:=2.9.30
+PKG_VERSION:=2.9.32
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -20,7 +20,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=libdmapsharing-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.flyn.org/projects/libdmapsharing/
-PKG_MD5SUM:=25de55d128d432d82f2a1ec010d7069a
+PKG_MD5SUM:=b0bb27525c92233bd76e5f7b7b6cfe6d
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>