### PR TITLE
gpsd: initial add to packages

### DIFF
--- a/package/utils/gpsd/Makefile
+++ b/package/utils/gpsd/Makefile
@@ -1,0 +1,144 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gpsd
+PKG_VERSION:=3.15
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://download-mirror.savannah.gnu.org/releases/gpsd/
+PKG_MD5SUM:=afd79b87337fadf38ee2a7c4314dac79
+
+PKG_MAINTAINER:=Pushpal Sidhu <psidhu@gateworks.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=COPYING
+
+PKG_BUILD_DEPENDS:=libncurses libusb-1.0
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/scons.mk
+
+define Package/gpsd/Default
+  DEPENDS:=+librt +libncurses
+  URL:=http://catb.org/gpsd/
+endef
+
+define Package/gpsd/Default/description
+  gpsd is a userland daemon acting as a translator between GPS and AIS receivers
+  and their clients. gpsd listens on port 2947 for clients requesting
+  position/time/velocity information.  The receivers are expected to generate
+  position information in a well-known format -- as NMEA-0183 sentences, SiRF
+  binary, Rockwell binary, Garmin binary format, or other vendor binary
+  protocols.  gpsd takes this information from the GPS and translates it into
+  something uniform and easier to understand for clients.
+endef
+
+define Package/gpsd
+  $(call Package/gpsd/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS+= +libgps +libusb-1.0
+  TITLE:=An interface daemon for GPS receivers
+endef
+
+define Package/gpsd/conffiles
+/etc/config/gpsd
+endef
+
+define Package/gpsd/description
+  $(call Package/gpsd/Default/description)
+  This package contains the GPS daemon.
+endef
+
+define Package/gpsd-clients
+  $(call Package/gpsd/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS+= +libgps +libncurses +libusb-1.0
+  TITLE:=GPS tools and clients
+endef
+
+define Package/gpsd-clients/description
+  $(call Package/gpsd/Default/description)
+  This package contains auxiliary tools and example clients for monitoring and
+  testing the GPS daemon.
+endef
+
+define Package/libgps
+  $(call Package/gpsd/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS+= +libcap
+  TITLE:=C service library for communicating with the GPS daemon
+endef
+
+define Package/libgps/description
+  $(call Package/gpsd/Default/description)
+  This package contains the libgps library.
+endef
+
+SCONS_OPTIONS += \
+	dbus_export=no \
+	tsip=no \
+	fv18=no \
+	tripmate=no \
+	earthmate=no \
+	itrax=no \
+	navcom=no \
+	ubx=no \
+	evermore=no \
+	ntrip=no \
+	libgpsmm=no \
+	libQgpsmm=no \
+	bluez=no \
+	strip=no \
+	python=no \
+	implicit_link=no \
+	chrpath=no
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/gps.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgps*.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libgps*.pc \
+		$(1)/usr/lib/pkgconfig/
+endef
+
+define Package/gpsd/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/gpsd.config $(1)/etc/config/gpsd
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/gpsd.init $(1)/etc/init.d/gpsd
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/usb
+	$(INSTALL_DATA) ./files/gpsd.hotplug $(1)/etc/hotplug.d/usb/20-gpsd
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/gpsd $(1)/usr/sbin/
+endef
+
+define Package/gpsd-clients/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/bin/cgps \
+		$(PKG_INSTALL_DIR)/usr/bin/gps{ctl,decode,mon,pipe} \
+		$(PKG_INSTALL_DIR)/usr/bin/gpxlogger \
+		$(PKG_INSTALL_DIR)/usr/bin/lcdgps \
+		$(1)/usr/bin/
+endef
+
+define Package/libgps/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgps.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,gpsd))
+$(eval $(call BuildPackage,gpsd-clients))
+$(eval $(call BuildPackage,libgps))

--- a/package/utils/gpsd/files/gpsd.config
+++ b/package/utils/gpsd/files/gpsd.config
@@ -1,0 +1,5 @@
+config gpsd core
+    option device    "/dev/ttyUSB0"
+    option port    "2947"
+    option listen_globally    "false"
+    option enabled    "true"

--- a/package/utils/gpsd/files/gpsd.hotplug
+++ b/package/utils/gpsd/files/gpsd.hotplug
@@ -1,0 +1,16 @@
+case "$ACTION" in
+    add)
+        # start process
+        # only pl2303 devices are handled
+        if [ "$PRODUCT" = "67b/2303/300" ] && [ "$TYPE" = "0/0/0" ] && [ "$INTERFACE" = "255/0/0" ]; then
+            sleep 3 && /etc/init.d/gpsd start
+        fi
+        ;;
+    remove)
+        # stop process
+        # only pl2303 devices are handled
+        if [ "$PRODUCT" = "67b/2303/300" ] && [ "$TYPE" = "0/0/0" ] && [ "$INTERFACE" = "255/0/0" ]; then
+            /etc/init.d/gpsd stop
+        fi
+        ;;
+esac

--- a/package/utils/gpsd/files/gpsd.init
+++ b/package/utils/gpsd/files/gpsd.init
@@ -1,0 +1,32 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2009-2011 OpenWrt.org
+START=50
+
+NAME=gpsd
+PIDF=/var/run/$NAME.pid
+PROG=/usr/sbin/$NAME
+
+start() {
+    config_load gpsd
+    config_get device core device
+    config_get port core port
+    config_get_bool listen_globally core listen_globally
+    config_get_bool enabled core enabled
+    [ "$enabled" != "1" ] && exit
+    logger -t "$NAME" "Starting..."
+    [ ! -c "$device" ] && {
+        logger -t "$NAME" "Unable to find device $device. Exiting."
+        exit 1
+    }
+    [ "$listen_globally" != "0" ] && append args "-G"
+    $PROG -n -P $PIDF -S $port $args $device
+}
+
+stop() {
+    logger -t "$NAME" "Stopping..."
+    [ -f "$PIDF" ] && {
+        read PID < "$PIDF"
+        kill -9 $PID
+        rm $PIDF
+    }
+}

--- a/package/utils/gpsd/patches/0001-Remove-a-BSD-ism.patch
+++ b/package/utils/gpsd/patches/0001-Remove-a-BSD-ism.patch
@@ -1,0 +1,42 @@
+From 95c99f69e026e8c57aecba545e51c97f3b284e75 Mon Sep 17 00:00:00 2001
+From: "Gary E. Miller" <gem@rellim.com>
+Date: Tue, 23 Jun 2015 14:36:26 -0700
+Subject: [PATCH] Remove a BSD-ism.
+
+CTRL('L') is a BSD-ism.  CTRL() is defined in sys/ttydefaults.h
+which does not always exist.  Instead of adding scons tests for
+needing CTRL() and its include files just replace with a simple
+constant.
+
+Needed for musl and found by Baruch Siach <baruch@tkos.co.il>
+---
+ gpsmon.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/gpsmon.c b/gpsmon.c
+index c3001c8..58c8300 100644
+--- a/gpsmon.c
++++ b/gpsmon.c
+@@ -583,6 +583,9 @@ static void select_packet_monitor(struct gps_device_t *device)
+ 	(void)wnoutrefresh(devicewin);
+ }
+ 
++/* Control-L character */
++#define CTRL_L 0x0C
++
+ static char *curses_get_command(void)
+ /* char-by-char nonblocking input, return accumulated command line on \n */
+ {
+@@ -591,7 +594,8 @@ static char *curses_get_command(void)
+     int c;
+ 
+     c = wgetch(cmdwin);
+-    if (c == CTRL('L')) {
++    if (CTRL_L == c) {
++        /* ^L is to repaint the screen */
+ 	(void)clearok(stdscr, true);
+ 	if (active != NULL && (*active)->initialize != NULL)
+ 	    (void)(*active)->initialize();
+-- 
+2.6.0
+


### PR DESCRIPTION
This package is currently in oldpackages. Add here to keep support for gpsd.

From oldpackages, this was bumped from 3.10 -> 3.15 and includes an upstream
patch to allow building with musl.

Signed-off-by: Pushpal Sidhu <psidhu@gateworks.com>