### PR TITLE
chrony: update to 2.2

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
-PKG_VERSION:=2.1.1
+PKG_VERSION:=2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.tuxfamily.org/chrony/
-PKG_MD5SUM:=15e470a51ab6e09e65bc0a2fbc5299af
+PKG_MD5SUM:=17bc77d3d2ce942675f9600b60452717
 
 PKG_MAINTAINER:=Miroslav Lichvar <mlichvar0@gmail.com>
 PKG_LICENSE:=GPL-2.0
@@ -41,7 +41,6 @@ endef
 
 define Package/chrony/conffiles
 /etc/chrony/chrony.conf
-/etc/chrony/chrony.keys
 /etc/config/chrony
 endef
 
@@ -51,6 +50,7 @@ CONFIGURE_ARGS+= \
 	--host-system=Linux \
 	--sysconfdir=/etc/chrony \
 	--prefix=/usr \
+	--chronysockdir=/var/run/chrony \
 	--disable-readline \
 	--disable-rtc \
 	--disable-asyncdns \
@@ -71,7 +71,6 @@ define Package/chrony/install
 	$(INSTALL_BIN) ./files/chronyd.init $(1)/etc/init.d/chronyd
 	$(INSTALL_CONF) ./files/chrony.config $(1)/etc/config/chrony
 	$(INSTALL_CONF) ./files/chrony.conf $(1)/etc/chrony/chrony.conf
-	$(INSTALL_CONF) ./files/chrony.keys $(1)/etc/chrony/chrony.keys
 endef
 
 $(eval $(call BuildPackage,chrony))

--- a/net/chrony/files/chrony.conf
+++ b/net/chrony/files/chrony.conf
@@ -5,8 +5,3 @@ logchange 0.5
 
 # Don't log client accesses
 noclientlog
-
-# Password config for chronyc
-keyfile /etc/chrony/chrony.keys
-commandkey 1
-generatecommandkey

--- a/net/chrony/files/chrony.hotplug
+++ b/net/chrony/files/chrony.hotplug
@@ -2,5 +2,5 @@ COMMAND=/usr/bin/chronyc
 
 [ -x $COMMAND ] || exit 0
 
-[ "$ACTION" = "ifup" -a "$INTERFACE" = "wan" ] && $COMMAND -a online
-[ "$ACTION" = "ifdown" -a "$INTERFACE" = "wan" ] && $COMMAND -a offline
+[ "$ACTION" = "ifup" -a "$INTERFACE" = "wan" ] && $COMMAND online
+[ "$ACTION" = "ifdown" -a "$INTERFACE" = "wan" ] && $COMMAND offline

--- a/net/chrony/files/chrony.keys
+++ b/net/chrony/files/chrony.keys
@@ -1,1 +1,0 @@
-# Keys for NTP authentication and chronyc commands


### PR DESCRIPTION
Support for authentication with command key was replaced with
communication over Unix domain socket.