### PR TITLE
sane-backends: select all backends when CONFIG_ALL

### DIFF
--- a/utils/sane-backends/Makefile
+++ b/utils/sane-backends/Makefile
@@ -41,6 +41,7 @@ $(call Package/sane-backends/Default)
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE+= (drivers)
+  DEPENDS:=+ALL:sane-backends-all
 endef
 
 define Package/sane-backends/description

--- a/utils/sane-backends/patches/030-musl.patch
+++ b/utils/sane-backends/patches/030-musl.patch
@@ -1,61 +1,73 @@
 --- a/include/sane/sanei_udp.h
 +++ b/include/sane/sanei_udp.h
-@@ -27,6 +27,7 @@
+@@ -27,6 +27,9 @@
  #include <netinet/in.h>
  #include <netdb.h>
  #endif
++#ifdef HAVE_SYS_TYPES_H
 +#include <sys/types.h>
++#endif
  
  extern SANE_Status sanei_udp_open(const char *host, int port, int *fdp);
  extern SANE_Status sanei_udp_open_broadcast(int *fdp);
 --- a/backend/kvs20xx_cmd.h
 +++ b/backend/kvs20xx_cmd.h
-@@ -9,6 +9,8 @@
+@@ -9,6 +9,10 @@
     Panasonic KV-S20xx USB-SCSI scanners.
  */
  
++#ifdef HAVE_SYS_TYPES_H
 +#include <sys/types.h>
++#endif
 +
  #define COMMAND_BLOCK	1
  #define DATA_BLOCK	2
  #define RESPONSE_BLOCK	3
 --- a/backend/kvs40xx.h
 +++ b/backend/kvs40xx.h
-@@ -10,6 +10,7 @@
+@@ -10,6 +10,9 @@
  
  #include "../include/sane/config.h"
  #include <semaphore.h>
++#ifdef HAVE_SYS_TYPES_H
 +#include <sys/types.h>
++#endif
  
  #undef  BACKEND_NAME
  #define BACKEND_NAME kvs40xx
 --- a/backend/hp5400.c
 +++ b/backend/hp5400.c
-@@ -67,6 +67,7 @@
+@@ -67,6 +67,9 @@
  #include <stdlib.h>		/* malloc, free */
  #include <string.h>		/* memcpy */
  #include <stdio.h>
++#ifdef HAVE_SYS_TYPES_H
 +#include <sys/types.h>
++#endif
  
  
  #define HP5400_CONFIG_FILE "hp5400.conf"
 --- a/backend/hp5590.c
 +++ b/backend/hp5590.c
-@@ -48,6 +48,7 @@
+@@ -48,6 +48,9 @@
  #include <stdio.h>
  #include <string.h>
  #include <unistd.h>
++#ifdef HAVE_SYS_TYPES_H
 +#include <sys/types.h>
++#endif
  
  #include "../include/sane/sane.h"
  #define BACKEND_NAME hp5590
 --- a/backend/epsonds-io.c
 +++ b/backend/epsonds-io.c
-@@ -16,6 +16,7 @@
+@@ -16,6 +16,9 @@
  #include "sane/config.h"
  #include <ctype.h>
  #include <unistd.h>     /* sleep */
++#ifdef HAVE_SYS_TYPES_H
 +#include <sys/types.h>
++#endif
  
  #include "epsonds.h"
  #include "epsonds-io.h"


### PR DESCRIPTION
I did not change the PKG_RELEASE as no package binary or dependency changed.
The added dependency is only for a "virtual" package that does not generate a final ipk.

The other changed file, 030-musl.patch, was only updated to use "ifdef include" to
be upstreamed.

--

sane-xxx backend packages are hidden packages with custom
config and CONFIG_ALL does not select them alone. Now
sane-backends depends on +ALL:sane-backends-all.

No existing ipk is affected as the changed package/sane-backends
does not exist as an ipk.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>