### PR TITLE
python: fix two build depend issues

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -28,7 +28,8 @@ HOST_BUILD_PARALLEL:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/Python-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/Python-$(PKG_VERSION)
 
-PKG_BUILD_DEPENDS:=libbz2/host python/host
+PKG_BUILD_DEPENDS:=python/host
+HOST_BUILD_DEPENDS:=bzip2/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Build depends must refer to the source package name, not the binary one,
therefore we need to use `bzip2` in order to enforce a build of libbz2.so.

Also make the host python build depend on the bzip2 host build in order to
ensure that host python is built with bzip2 support. We don't need a build
dependency for the target python as this already depends on +libbz2 through
python-light. That package dependency in turn implies a build dependency.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>