### PR TITLE
pppossh: new package for network proto "pppossh"

### DIFF
--- a/net/pppossh/Makefile
+++ b/net/pppossh/Makefile
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pppossh
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
+PKG_LICENSE:=GPLv2
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/pppossh
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=PPPoSSH (Point-to-Point Protocol over SSH)
+  URL:=https://github.com/yousong/waller
+  DEPENDS:=+ppp +resolveip @(PACKAGE_dropbear||PACKAGE_openssh-client)
+endef
+
+define Package/pppossh/description
+This package adds protocol support for PPP over SSH.  The protocol name is
+'pppossh' as in netifd interface config option 'proto'.
+endef
+
+define Build/Compile
+endef
+
+define Package/pppossh/install
+	$(INSTALL_DIR) $(1)/lib/netifd/proto
+	$(INSTALL_BIN) ./files/pppossh.sh $(1)/lib/netifd/proto
+endef
+
+$(eval $(call BuildPackage,pppossh))

--- a/net/pppossh/README.md
+++ b/net/pppossh/README.md
@@ -1,0 +1,68 @@
+This package will add the so-called `pppossh` protocol support to OpenWrt.  The idea is mainly from [`pvpn` project](https://github.com/halhen/pvpn) (poor man's VPN over SSH).
+
+PPPoSSH is generally not considered a network setup for production use mainly due to the TCP-over-TCP styles of traffic transport, but it can be quite handy for personal use.  And with what's already in OpenWrt, it is really easy and takes little extra space to configure it up running.
+
+## Prerequisites and dependency.
+
+`pppossh` depends on either `dropbear` or `openssh-client`; `dropbear` is normally enabled in OpenWrt by default.
+
+The following requirements need to be fulfilled for it to work.
+
+- A SSH account on the remote machine with `CAP_NET_ADMIN` capability is required.
+- Public key authentication must be enabled and setup properly.
+
+	Public key of the one generated automatially by dropbear can be induced by the following command.  But you can always use your own (dropbear can work with OpenSSH public key).
+
+		dropbearkey -y -f /etc/dropbear/dropbear_rsa_host_key
+
+- SSH server's fingerprint has to be present in `~/.ssh/known_hosts` for the authentication to proceed in an unattended way.
+
+	Manually logging in at least once to the remote server from OpenWrt should do this for you.
+
+## How to use it.
+
+The protocol name to use in `/etc/config/network` is `pppossh`.  Options are as described below.
+
+- `server`, SSH server name
+- `port`, SSH server port (defaults to `22`).
+- `sshuser`, SSH login username
+- `identity`, list of client private key files.  `~/.ssh/id_{rsa,dsa}` will
+   be used if no identity file was specified and at least one of them must be
+   valid for the public key authentication to proceed.
+- `ipaddr`, local ip address to be assigned.
+- `peeraddr`, peer ip address to be assigned.
+- `ssh_options`, extra options for the ssh client.
+- `use_hostdep`, set it to `0` to disable the use of `proto_add_host_dependency`.  This is mainly for the case that the appropriate route to `server` is not registered to `netifd` and thus causing a incorrect route being setup.
+
+## Tips
+
+An `uci batch` command template for your reference.  Modify it to suite your situation.
+
+	uci batch <<EOF
+	delete network.fs
+	set network.fs=interface
+	set network.fs.proto=pppossh
+	set network.fs.sshuser=root
+	set network.fs.server=ssh.example.cn
+	set network.fs.port=30244
+	add_list network.fs.identity=/etc/dropbear/dropbear_rsa_host_key
+	set network.fs.ipaddr=192.168.177.2
+	set network.fs.peeraddr=192.168.177.1
+	commit
+	EOF
+
+Allow forward and NAT on the remote side (`ppp0` is the peer interface on the remote side.  `eth0` is the interface for Internet access).
+
+	sysctl -w net.ipv4.ip_forward=1
+	iptables -t filter -A FORWARD -i ppp0 -j ACCEPT
+	iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+
+It's possible that pppd may output protocol negotiation incompatibilities issues to syslog, such as something like the following which did not hurt the connectivity and was annoying only because we thought it can do better.
+
+	Sun Oct 25 09:45:14 2015 daemon.err pppd[22188]: Received bad configure-rej:  12 06 00 00 00 00
+
+To debug such problems, we can try adding `option pppd_optinos debug` to the interface config.  In the above case, it's a LCP CCP configure rej (the CCP options struct is exactly 6 octets in size as indicated in source code `pppd/ccp.h`) and since the internet fee is not charged on the bytes transfered, I will just use `noccp` to disable the negotiation altogether.
+
+Also to optimize bulk transfer performance, you can try tweaking the ciphers.  OpenSSH client does not support `none` cipher by default and you have to patch and install it for by yourself.  Another option is to try ciphers like `arcfour` and `blowfish-cbc`.  In my case, `arcfour` has the best throughput.
+
+	option ssh_options '-o "Ciphers arcfour"'

--- a/net/pppossh/files/pppossh.sh
+++ b/net/pppossh/files/pppossh.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+SSH=/usr/bin/ssh
+[ -x "$SSH" ] || {
+	echo "Cannot find executable $SSH." >&2
+	exit 1
+}
+
+. /lib/functions.sh
+. ../netifd-proto.sh
+init_proto "$@"
+
+INCLUDE_ONLY=1
+
+. ./ppp.sh
+
+proto_pppossh_init_config() {
+	ppp_generic_init_config
+	config_add_string server sshuser ipaddr peeraddr ssh_options
+	config_add_array 'identity:list(string)'
+	config_add_int port use_hostdep
+	available=1
+	no_device=1
+}
+
+proto_pppossh_setup() {
+	local config="$1"
+	local iface="$2"
+	local user="$(id -nu)"
+	local home=$(sh -c "echo ~$user")
+	local server port sshuser ipaddr peeraddr ssh_options identity use_hostdep
+	local ip fn errmsg opts pty
+
+	json_get_vars port sshuser ipaddr peeraddr ssh_options use_hostdep
+	json_get_var server server && {
+		[ -z "$use_hostdep" ] && use_hostdep=1
+		for ip in $(resolveip -t 5 "$server"); do
+			if [ "$use_hostdep" -gt 0 ]; then
+				( proto_add_host_dependency "$config" "$ip" )
+			else
+				break
+			fi
+		done
+	}
+	[ -n "$ip" ] || errmsg="${errmsg}Could not resolve $server\n"
+	[ -n "$sshuser" ] || errmsg="${errmsg}Missing sshuser option\n"
+
+	json_get_values identity identity
+	[ -z "$identity" ] && identity="'$home/.ssh/id_rsa' '$home/.ssh/id_dsa'"
+	for fn in $identity; do
+		[ -f "$fn" ] && opts="$opts -i $fn"
+	done
+	[ -n "$opts" ] || errmsg="${errmsg}Cannot find valid identity file\n"
+
+	[ -n "$errmsg" ] && {
+		echo -ne "$errmsg" >&2
+		proto_setup_failed "$config"
+		exit 1
+	}
+	opts="$opts ${port:+-p $port}"
+	opts="$opts ${ssh_options}"
+	opts="$opts $sshuser@$server"
+	pty="env 'HOME=$home' "$SSH" $opts pppd nodetach notty noauth"
+
+	ppp_generic_setup "$config" noauth pty "$pty" "$ipaddr:$peeraddr"
+}
+
+proto_pppossh_teardown() {
+	ppp_generic_teardown "$@"
+}
+
+add_protocol pppossh


### PR DESCRIPTION
Previously I proposed several revisions of this pppossh protocol support to the openwrt-devel list [1,2], unfortunately it seemed then that there was not enough interests in such a connectivity hack and they all ended up getting lost in the patchwork queue.

I archived it in my little `waller` repo [3] and happily set it up again just several days ago because it's so easy and provides enough bandwidth for the few suddenly unreachable sites I need to access.

I even wrote LuCI protocol support files for it today.  The plan is to first get the approval of merging this package into packages feed, then the LuCI protocol support to luci repo (@jow-).  So please provide your opinions on this.

[1] https://lists.openwrt.org/pipermail/openwrt-devel/2014-May/025532.html
[2] [OpenWrt-Devel] [PATCH v6] ppp: add new protocol PPPoSSH. https://lists.openwrt.org/pipermail/openwrt-devel/2014-September/028062.html
[3] https://github.com/yousong/waller