### PR TITLE
node: add python/host to HOST_BUILD_DEPENDS as well

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -14,6 +14,7 @@ PKG_RELEASE:=1
 PKG_SOURCE:=node-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://nodejs.org/dist/${PKG_VERSION}
 
+HOST_BUILD_DEPENDS:=python/host
 PKG_BUILD_DEPENDS:=python/host
 PKG_INSTALL:=1
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>