### PR TITLE
collectd: add $(INSTALL_DIR) $(1)/etc/collectd/conf.d

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -255,6 +255,7 @@ define Package/collectd/install
 	$(INSTALL_CONF) ./files/collectd.conf $(1)/etc/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/collectd.init $(1)/etc/init.d/collectd
+	$(INSTALL_DIR) $(1)/etc/collectd/conf.d
 endef
 
 # 1: plugin name


### PR DESCRIPTION
/etc/collectd/conf.d is referenced in the default config so should be installed to prevent the following in syslog every boot:
Fri Oct  9 02:09:38 2015 user.emerg : configfile: stat (/etc/collectd/conf.d) failed: No such file or directory