### PR TITLE
python-crypto: import pycrypto from old packages feed

### DIFF
--- a/lang/python-crypto/Makefile
+++ b/lang/python-crypto/Makefile
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2009-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pycrypto
+PKG_VERSION:=2.6.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://ftp.dlitz.net/pub/dlitz/crypto/pycrypto/
+PKG_MD5SUM:=55a61a054aa66812daf5161a0d5d7eda
+
+PKG_LICENSE:=Public Domain
+PKG_LICENSE_FILES:=COPYRIGHT
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/python-crypto
+	SECTION:=lang-python
+	CATEGORY:=Languages
+	SUBMENU:=Python
+	TITLE:=python-crypto
+	URL:=http://www.pycrypto.org/
+	DEPENDS:=+python +libgmp
+endef
+
+define Package/python-crypto/description
+A collection of both secure hash functions (such as MD5 and SHA),
+and various encryption algorithms (AES, DES, IDEA, RSA, ElGamal, etc.).
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+endef
+
+define Package/python-crypto/install
+	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)/
+	$(CP) \
+		$(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
+		$(1)$(PYTHON_PKG_DIR)/
+endef
+
+$(eval $(call PyPackage,python-crypto))
+$(eval $(call BuildPackage,python-crypto))

--- a/lang/python-crypto/Makefile
+++ b/lang/python-crypto/Makefile
@@ -37,7 +37,10 @@ and various encryption algorithms (AES, DES, IDEA, RSA, ElGamal, etc.).
 endef
 
 define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+	$(call Build/Compile/PyMod,,\
+		install --prefix=/usr --root=$(PKG_INSTALL_DIR),\
+		CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)" \
+	)
 endef
 
 define Package/python-crypto/install

--- a/lang/python-crypto/patches/001-no-host-paths.patch
+++ b/lang/python-crypto/patches/001-no-host-paths.patch
@@ -1,0 +1,11 @@
+--- a/setup.py
++++ b/setup.py
+@@ -370,7 +370,7 @@ kw = {'name':"pycrypto",
+       'ext_modules': plat_ext + [
+             # _fastmath (uses GNU mp library)
+             Extension("Crypto.PublicKey._fastmath",
+-                      include_dirs=['src/','/usr/include/'],
++                      include_dirs=['src/'],
+                       libraries=['gmp'],
+                       sources=["src/_fastmath.c"]),
+ 

--- a/lang/python-crypto/patches/002-fix-endianness-detect.patch
+++ b/lang/python-crypto/patches/002-fix-endianness-detect.patch
@@ -1,15 +1,13 @@
---- a/setup.py	2015-10-30 23:30:22.334127083 +0800
-+++ b/setup.py	2015-10-30 23:33:03.856098660 +0800
-@@ -100,6 +100,12 @@
+--- a/setup.py
++++ b/setup.py
+@@ -100,6 +100,10 @@
          w(kwd.get("end", "\n"))
  
  def endianness_macro():
-+    if "CONFIG_BIG_ENDIAN" in os.environ:
-+        if os.environ["CONFIG_BIG_ENDIAN"] == "y":
-+            return ('PCT_BIG_ENDIAN', 1)
-+        else:
-+            return ('PCT_LITTLE_ENDIAN', 1)
-+    raise AssertionError("CONFIG_BIG_ENDIAN environment variable missing")
++    if os.environ["CONFIG_BIG_ENDIAN"] == "y":
++        return ('PCT_BIG_ENDIAN', 1)
++    else:
++        return ('PCT_LITTLE_ENDIAN', 1)
      s = struct.pack("@I", 0x33221100)
      if s == "\x00\x11\x22\x33".encode():     # little endian
          return ('PCT_LITTLE_ENDIAN', 1)

--- a/lang/python-crypto/patches/002-fix-endianness-detect.patch
+++ b/lang/python-crypto/patches/002-fix-endianness-detect.patch
@@ -1,0 +1,15 @@
+--- a/setup.py	2015-10-30 23:30:22.334127083 +0800
++++ b/setup.py	2015-10-30 23:33:03.856098660 +0800
+@@ -100,6 +100,12 @@
+         w(kwd.get("end", "\n"))
+ 
+ def endianness_macro():
++    if "CONFIG_BIG_ENDIAN" in os.environ:
++        if os.environ["CONFIG_BIG_ENDIAN"] == "y":
++            return ('PCT_BIG_ENDIAN', 1)
++        else:
++            return ('PCT_LITTLE_ENDIAN', 1)
++    raise AssertionError("CONFIG_BIG_ENDIAN environment variable missing")
+     s = struct.pack("@I", 0x33221100)
+     if s == "\x00\x11\x22\x33".encode():     # little endian
+         return ('PCT_LITTLE_ENDIAN', 1)


### PR DESCRIPTION
- update to latest stable version (2.6.1)
- add PyPackage call
- add license info
- add myself as maintainer

Signed-off-by: Jeffery To <jeffery.to@gmail.com>