### PR TITLE
openvswitch: work-around kernel architecture detection

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -116,6 +116,9 @@ CONFIGURE_ARGS += --enable-shared
 
 TARGET_CFLAGS += -flto -std=gnu99
 
+CONFIGURE_VARS += KARCH=$(LINUX_KARCH)
+MAKE_FLAGS += ARCH="$(LINUX_KARCH)"
+
 define Package/openvswitch/install
 	$(INSTALL_DIR) $(1)/etc/openvswitch
 


### PR DESCRIPTION
caught on build-bot:
make -C /store/buildbot/slave/ramips/build/build_dir/target-mipsel_24kec+dsp_musl-1.1.11/linux-ramips_rt305x/linux-3.18.21 M=/store/buildbot/slave/ramips/build/build_dir/target-mipsel_24kec+dsp_musl-1.1.11/openvswitch-2.4.0/datapath/linux modules
make[7]: Entering directory `/store/buildbot/slave/ramips/build/build_dir/target-mipsel_24kec+dsp_musl-1.1.11/linux-ramips_rt305x/linux-3.18.21'
Makefile:610: arch/mipsel/Makefile: No such file or directory

Declare LINUX_KARCH to package's build-system to resolv this.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>