### PR TITLE
seafile-server: fix dependency and postinst script

### DIFF
--- a/net/seafile-server/Makefile
+++ b/net/seafile-server/Makefile
@@ -5,11 +5,13 @@
 # See /LICENSE for more information.
 #
 
+# NOTE: make sure to update EXTRA_DEPENDS in case of version/release changes!
+
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-server
 PKG_VERSION:=4.1.2
-PKG_RELEASE=$(PKG_SOURCE_VERSION)-4
+PKG_RELEASE=$(PKG_SOURCE_VERSION)-5
 PKG_LICENSE:=GPL-3.0
 
 PKG_SOURCE_PROTO:=git
@@ -33,7 +35,7 @@ define Package/seafile-server
 		+sqlite3-cli +python-mysql +jansson +libevent2 +libevent2-openssl +zlib +libzdb +libsqlite3 \
 		+libmysqlclient +libpthread +libuuid \
 		+bash +sudo +procps-ng +procps-ng-pkill $(ICONV_DEPENDS)
-    EXTRA_DEPENDS:=seafile-ccnet (=4.1.2-a73109f09af4ecc49cdc4c57cdde51b38e15c31a), seafile-seahub (=4.1.2-3fb1288f920de03a4e2e6a06b60671ce98971742)
+    EXTRA_DEPENDS:=seafile-ccnet (=4.1.2-a73109f09af4ecc49cdc4c57cdde51b38e15c31a-2), seafile-seahub (=4.1.2-3fb1288f920de03a4e2e6a06b60671ce98971742)
 endef
 
 define Package/seafile-server/description

--- a/net/seafile-server/Makefile
+++ b/net/seafile-server/Makefile
@@ -31,7 +31,7 @@ define Package/seafile-server
     TITLE:=Seafile server
     MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
     URL:=http://seafile.com/
-    DEPENDS:=+shadow-useradd +libarchive +libopenssl +glib2 +libsearpc +seafile-ccnet +seafile-seahub \
+    DEPENDS:=+libarchive +libopenssl +glib2 +libsearpc +seafile-ccnet +seafile-seahub \
 		+sqlite3-cli +python-mysql +jansson +libevent2 +libevent2-openssl +zlib +libzdb +libsqlite3 \
 		+libmysqlclient +libpthread +libuuid \
 		+bash +sudo +procps-ng +procps-ng-pkill $(ICONV_DEPENDS)
@@ -93,43 +93,50 @@ endef
 define Package/seafile-server/postinst
 #!/bin/sh
 
-if ! id -u seafile >/dev/null 2>&1; then
-    useradd seafile -d "/usr/share/seafile" -s /bin/sh; fi
+if ! group_exists seafile; then
+   group_add_next seafile; fi
+
+SEAFILE_GID=$$(grep -s '^seafile:' "$${IPKG_INSTROOT}/etc/group" | cut -d: -f3)
+
+if ! user_exists seafile; then
+   user_add seafile "" "$${SEAFILE_GID}" seafile /usr/share/seafile /bin/sh; fi
+
+if [ -z "$${IPKG_INSTROOT}" ]
+then
+   chown -R seafile:seafile /usr/share/seafile/
+   chmod -R o-rwx /usr/share/seafile/
+
+   if [ ! -d /usr/share/seafile/seafile-data ]
+   then
+      echo "*** Installation completed, running configuration script..."
+      /etc/init.d/seafile setup
+
+      if [ $$? -ne 0 ]
+      then
+         echo
+         echo "*** ERROR: Configuration failed. Please fix the issues if any and re-run the script using the command below:"
+         echo "*** \"/etc/init.d/seafile setup\""
+      fi
+
+      echo
+      echo "*** NOTE: you need to create an admin account before using Seafile."
+      echo "*** Please run \"/etc/init.d/seafile create_admin\" to do so."
+   else
+      echo "*** It seems you are upgrading from an older version."
+      echo "*** If so, please run the appropriate upgrade scripts before using the new version of Seafile."
+      echo "*** Upgrade scripts are located at \"/usr/share/seafile/seafile-server/upgrade\""
+      echo
+      echo "*** For more information, please read http://manual.seafile.com/deploy/upgrade.html"
+   fi
+else
+   cat > "$${IPKG_INSTROOT}/etc/uci-defaults/99_seafile-server" << EOF
+#!/bin/sh
 
 chown -R seafile:seafile /usr/share/seafile/
 chmod -R o-rwx /usr/share/seafile/
-
-if [ ! -d "/usr/share/seafile/seafile-data" ]
-then
-   echo "*** Installation completed, running configuration script..."
-   /etc/init.d/seafile setup
-
-   if [ $$? -ne 0 ]
-   then
-      echo
-      echo "*** ERROR: Configuration failed. Please fix the issues if any and re-run the script using the command below:"
-      echo "*** \"/etc/init.d/seafile setup\""
-   fi
-
-   echo
-   echo "*** NOTE: you need to create an admin account before using Seafile."
-   echo "*** Please run \"/etc/init.d/seafile create_admin\" to do so."
-else
-   echo "*** WARNING: it seems you are upgrading from an older version."
-   echo "*** If so, please run the appropriate upgrade script before using the new version of Seafile."
-   echo "*** Upgrade scripts are located at \"/usr/share/seafile/seafile-server/upgrade\""
-   echo
-   echo "*** For more information, please read http://manual.seafile.com/deploy/upgrade.html"
-   exit
+exit 0
+EOF
 fi
-
-/etc/init.d/seafile enable
-/etc/init.d/seafile restart
-endef
-
-define Package/seafile-server/prerm
-#!/bin/sh
-/etc/init.d/seafile stop
 endef
 
 $(eval $(call BuildPackage,seafile-server))


### PR DESCRIPTION
seafile-server had an out-of-date dependency against seafile-ccnet making it impossible to properly install with opkg.

Also, I have sanitized the postinst script a bit, removed some unnecessary steps and improved it a bit to make it work with Image Generator.