### PR TITLE
liblz4: update to r131

### DIFF
--- a/libs/liblz4/Makefile
+++ b/libs/liblz4/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 # Although liblz4 exports a major.minor.patch version, it isn't always
 # incremented for new releases, so use the release tag instead.
 PKG_NAME:=liblz4
-PKG_VERSION:=r129
+PKG_VERSION:=r131
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
From the upstream NEWS file:

  r131
  New    : Dos/DJGPP target, thanks to Louis Santillan (#114)
  Added  : Example using lz4frame library, by Zbigniew Jędrzejewski-Szmek (#118)
  Changed: xxhash symbols are modified (namespace emulation) within liblz4

  r130:
  Fixed  : incompatibility sparse mode vs console, reported by Yongwoon Cho (#105)
  Fixed  : LZ4IO exits too early when frame crc not present, reported by Yongwoon Cho (#106)
  Fixed  : incompatibility sparse mode vs append mode, reported by Takayuki Matsuoka (#110)
  Performance fix : big compression speed boost for clang (+30%)
  New    : cross-version test, by Takayuki Matsuoka

Signed-off-by: Darik Horn <dajhorn@vanadac.com>