### PR TITLE
atftp: fix invalid read in tftp_send_request.

### DIFF
--- a/net/atftp/patches/02-fix-invalid-read-in-tftp_send_request.patch
+++ b/net/atftp/patches/02-fix-invalid-read-in-tftp_send_request.patch
@@ -1,0 +1,13 @@
+diff --git a/tftp_io.c b/tftp_io.c
+index 605a9c2..6cce1f4 100644
+--- a/tftp_io.c
++++ b/tftp_io.c
+@@ -64,7 +64,7 @@ int tftp_send_request(int socket, struct sockaddr_storage *sa, short type,
+      buf_index += strlen(mode);
+      buf_index++;
+      
+-     for (i = 2; ; i++)
++     for (i = 2; i < OPT_NUMBER; i++)
+      {
+           if (strlen(tftp_options[i].option) == 0)
+                break;


### PR DESCRIPTION
This invalid read of 1 byte caused a segfault
on some arm platforms.