### PR TITLE
atftp: fix invalid read in tftp_send_request.

### DIFF
--- a/net/atftp/Makefile
+++ b/net/atftp/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=atftp
 PKG_VERSION:=0.7.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
 PKG_LICENSE:=GPL-2.0
 

--- a/net/atftp/patches/02-fix-invalid-read-in-tftp_send_request.patch
+++ b/net/atftp/patches/02-fix-invalid-read-in-tftp_send_request.patch
@@ -1,0 +1,13 @@
+diff --git a/tftp_io.c b/tftp_io.c
+index 605a9c2..6cce1f4 100644
+--- a/tftp_io.c
++++ b/tftp_io.c
+@@ -64,7 +64,7 @@ int tftp_send_request(int socket, struct sockaddr_storage *sa, short type,
+      buf_index += strlen(mode);
+      buf_index++;
+      
+-     for (i = 2; ; i++)
++     for (i = 2; i < OPT_NUMBER; i++)
+      {
+           if (strlen(tftp_options[i].option) == 0)
+                break;


### PR DESCRIPTION
This invalid read of 1 byte caused a segfault
on some arm platforms.

Signed-off-by: Daniel Danzberger <daniel@dd-wrt.com>