### PR TITLE
fossil: fix Makefile for GNU Make < 3.82

### DIFF
--- a/net/fossil/Makefile
+++ b/net/fossil/Makefile
@@ -44,7 +44,8 @@ MAKE_FLAGS := \
 	CFLAGS="$(TARGET_CFLAGS) -I$(STAGING_DIR)/usr/include -DFOSSIL_ENABLE_JSON" \
 	LDFLAGS="$(TARGET_LDFLAGS) -Wl,-rpath=$(TOOLCHAIN_DIR)/lib -L$(STAGING_DIR)/lib -L$(STAGING_DIR)/usr/lib" \
 
-undefine Build/Configure
+define Build/Configure
+endef
 
 define Build/Compile
 	$(call Build/Compile/Default, \
@@ -52,7 +53,8 @@ define Build/Compile
 	)
 endef
 
-undefine Build/Install
+define Build/Install
+endef
 
 define Package/fossil/conffiles
 /etc/config/fossil


### PR DESCRIPTION
make defconfig (or feeds update) raised following error for fossil package on Ubuntu 14.04 LTS with GNU Make 3.81:
`Makefile:47: *** missing separator.  Stop.`

To fix this, empty blocks are now defined instead of using undefine directive which was added in GNU Make 3.82.

@lperkov, can you review it, please?
