### PR TITLE
aria2: update to 1.19.2, fix build issues with libuv

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
-PKG_VERSION:=1.18.7
+PKG_VERSION:=1.19.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=@SF/aria2
-PKG_MD5SUM:=36e92af92b4370817c577ed802546842
+PKG_SOURCE_URL:=https://github.com/tatsuhiro-t/aria2/releases/download/release-$(PKG_VERSION)/
+PKG_MD5SUM:=1b00ab22951880e07bb4db4d66312f91
 PKG_INSTALL:=1
 
 PKG_MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>


### PR DESCRIPTION
Update to latest version. This update also resolve issues when building aria2 when libuv is present (refs: #1011, #1019, #1880).