### PR TITLE
muninlite: Fix muninlite network if parsing

### DIFF
--- a/admin/muninlite/patches/220-modify-ifname-parser.patch
+++ b/admin/muninlite/patches/220-modify-ifname-parser.patch
@@ -5,7 +5,7 @@
  }
  fetch_if() {
 -  IINFO=$(grep "$1:" /proc/net/dev | cut -d: -f2 | sed -e 's/  / /g')
-+  IINFO=$(cat /proc/net/dev | sed -e 's/-/_/g' | grep "$1:" | cut -d: -f2 | sed -e 's/  */ /g' -e 's/^[ \t]*//')
++  IINFO=$(grep "$1:" /proc/net/dev | cut -d: -f2 | sed -e 's/  */ /g' -e 's/^[ \t]*//')
    echo "down.value" $(echo $IINFO | cut -d\  -f1)
    echo "up.value" $(echo $IINFO | cut -d\  -f9)
  }
@@ -16,7 +16,7 @@
  }
  fetch_if_err() {
 -  IINFO=$(grep "$1:" /proc/net/dev | cut -d: -f2 | sed -e 's/  / /g')
-+  IINFO=$(cat /proc/net/dev | sed -e 's/-/_/g' | grep "$1:" | cut -d: -f2 | sed -e 's/  */ /g' -e 's/^[ \t]*//')
++  IINFO=$(grep "$1:" /proc/net/dev | cut -d: -f2 | sed -e 's/  */ /g' -e 's/^[ \t]*//')
    echo "rcvd.value" $(echo $IINFO | cut -d\  -f3)
    echo "trans.value" $(echo $IINFO | cut -d\  -f11)
  }

--- a/admin/muninlite/patches/230-fix-available-interface-parsing.patch
+++ b/admin/muninlite/patches/230-fix-available-interface-parsing.patch
@@ -1,0 +1,20 @@
+--- a/munin-node.in	2015-11-07 17:52:54.000000000 +0100
++++ b/munin-node.in	2015-11-07 18:09:06.117200499 +0100
+@@ -72,7 +72,7 @@
+ for PLUG in $PLUGINS
+ do 
+   if [ "$PLUG" = "if_" ]; then  
+-    for INTER in $(grep '^ *\(ppp\|eth\|wlan\|ath\|ra\|ipsec\|tap\|br-\)\([^:]\)\{1,\}:' /proc/net/dev | cut -f1 -d: | sed 's/ //g');
++    for INTER in $(grep -E '^ *(ppp|eth|wlan|ath|ra|ipsec|tap|br-)[^:]{1,}:' /proc/net/dev | cut -f1 -d: | sed 's/ //g');
+     do
+       INTERRES=$(echo $INTER | sed -e 's/\./VLAN/' -e 's/\-/_/')
+       RES="$RES if_$INTERRES"
+@@ -80,7 +80,7 @@
+       eval "config_if_${INTERRES}() { config_if $INTER $@; };"
+     done
+   elif [ "$PLUG" = "if_err_" ]; then
+-    for INTER in $(grep '^ *\(ppp\|eth\|wlan\|ath\|ra\|ipsec\|tap\|br-\)\([^:]\)\{1,\}:' /proc/net/dev | cut -f1 -d: | sed 's/ //g');
++    for INTER in $(grep -E '^ *(ppp|eth|wlan|ath|ra|ipsec|tap|br-)[^:]{1,}:' /proc/net/dev | cut -f1 -d: | sed 's/ //g');
+     do
+       INTERRES=$(echo $INTER | sed -e 's/\./VLAN/' -e 's/\-/_/')
+       RES="$RES if_err_$INTERRES"


### PR DESCRIPTION
These two commits fix the interface parsing in muninlite for me (in OpenWrt trunk).

old grep command:
```
# grep '^ *\(ppp\|eth\|wlan\|ath\|ra\|ipsec\|tap\|br-\)\([^:]\)\{1,\}:' /proc/net/dev | cut -f1 -d: | sed 's/ //g'
#
```

new grep command:
```
# grep -E '^ *(ppp|eth|wlan|ath|ra|ipsec|tap|br-)[^:]{1,}:' /proc/net/dev | cut -f1 -d: | sed 's/ //g'
tap0
eth0.1
wlan1
eth1
wlan0
eth0
pppoe-wan
br-lan
#
```

After muninlite detected the interfaces correctly again I still could not retrieve data for pppoe-wan and br-lan.
This is what the second patch fixes.

CC: @jmccrohan 

Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>