### PR TITLE
mpg123: fix installation by adding a missing backslash

### DIFF
--- a/sound/mpg123/Makefile
+++ b/sound/mpg123/Makefile
@@ -88,7 +88,7 @@ define Package/mpg123/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) \
 		$(PKG_INSTALL_DIR)/usr/bin/mpg123{,-id3dump,-strip} \
-		$(PKG_INSTALL_DIR)/usr/bin/out123
+		$(PKG_INSTALL_DIR)/usr/bin/out123 \
 		$(1)/usr/bin
 
 	$(INSTALL_DIR) $(1)/usr/lib/mpg123


### PR DESCRIPTION
Fix the installation command by adding a missing "\".

Commit https://github.com/ryzhovau/packages/commit/56939a2b0ed55ad0f4bf1c901588dc710e5f163e#diff-bf8cceb58c8e9da5ac3833f99120ecf3R91 in pull request #1808 added a new line to the installation command, but forgot to add the needed "\". That broke the logic as the last binary to be installed was interpreted to be the target directory (instead of the genuine target dir on the next line).

The installation error "...install/usr/bin/out123' is not a directory" is visible in buildbot:
http://buildbot.openwrt.org:8010/broken_packages/ar71xx/mpg123/compile.txt
```
install -m0755 /mnt/dl/slave/ar71xx/build/build_dir/target-mips_34kc_musl-1.1.11/mpg123-1.22.3/ipkg-install/usr/bin/mpg123{,-id3dump,-strip} /mnt/dl/slave/ar71xx/build/build_dir/target-mips_34kc_musl-1.1.11/mpg123-1.22.3/ipkg-install/usr/bin/out123
install: target `/mnt/dl/slave/ar71xx/build/build_dir/target-mips_34kc_musl-1.1.11/mpg123-1.22.3/ipkg-install/usr/bin/out123' is not a directory
```
