### PR TITLE
netatalk: fix dependency: libattr instead of attr

### DIFF
--- a/net/netatalk/Makefile
+++ b/net/netatalk/Makefile
@@ -25,7 +25,7 @@ define Package/netatalk
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Filesystem
-  DEPENDS:=+attr +libdb47 +libgcrypt +libopenssl $(LIBRPC_DEPENDS)
+  DEPENDS:=+libattr +libdb47 +libgcrypt +libopenssl $(LIBRPC_DEPENDS)
   TITLE:=netatalk
   URL:=http://netatalk.sourceforge.net
   MAINTAINER:=W. Michael Petullo <mike@flyn.org>


### PR DESCRIPTION
Signed-off-by: Maxim Storchak <m.storchak@gmail.com>