### PR TITLE
Add rsyslog package

### DIFF
--- a/libs/libestr/Makefile
+++ b/libs/libestr/Makefile
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libestr
+PKG_VERSION:=0.1.10
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=http://libestr.adiscon.com/files/download/
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_MD5SUM:=f4c9165a23587e77f7efe65d676d5e8e
+
+PKG_MAINTAINER:=Dov Murik <dmurik@us.ibm.com>
+PKG_LICENSE:=LGPL-2.1+
+PKG_LICENSE_FILE:=COPYING
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libestr
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=String handling library
+  URL:=http://libestr.adiscon.com/
+endef
+
+define Package/libestr/description
+  libestr - some essentials for string handling (and a bit more)
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
+endef
+
+define Package/libestr/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libestr.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libestr))

--- a/net/rsyslog/Makefile
+++ b/net/rsyslog/Makefile
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rsyslog
+PKG_VERSION:=8.14.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.rsyslog.com/files/download/rsyslog/
+PKG_MD5SUM:=9862b08fd8d13753c13d7f9d86ec8f4e
+
+PKG_MAINTAINER:=Dov Murik <dmurik@us.ibm.com>
+PKG_LICENSE:=GPL-3.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/rsyslog
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Enhanced system logging and kernel message trapping daemons
+  URL:=http://www.rsyslog.com/
+  DEPENDS:=+libestr +libjson-c +libuuid +zlib
+endef
+
+define Package/rsyslog/conffiles
+/etc/rsyslog.conf
+endef
+
+CONFIGURE_ARGS+= \
+	--disable-libgcrypt \
+	--disable-liblogging-stdlog
+
+TARGET_CFLAGS += \
+	-std=c99
+
+define Package/rsyslog/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/rsyslogd $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/lib/rsyslog
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/rsyslog/* $(1)/usr/lib/rsyslog/
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_CONF) ./files/rsyslog.conf $(1)/etc
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/rsyslog.init $(1)/etc/init.d/rsyslog
+endef
+
+$(eval $(call BuildPackage,rsyslog))

--- a/net/rsyslog/files/rsyslog.conf
+++ b/net/rsyslog/files/rsyslog.conf
@@ -1,0 +1,18 @@
+module(load="imuxsock")
+module(load="imklog")
+module(load="imudp")
+input(type="imudp" port="514")
+#module(load="imtcp")
+#input(type="imtcp" port="514")
+
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+*.info;mail.none;authpriv.none;cron.none  /var/log/messages
+
+authpriv.*                                /var/log/secure
+
+mail.*                                    /var/log/maillog
+
+cron.*                                    /var/log/cron
+
+local7.*                                  /var/log/boot.log

--- a/net/rsyslog/files/rsyslog.init
+++ b/net/rsyslog/files/rsyslog.init
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2014 OpenWrt.org
+
+START=20
+
+USE_PROCD=1
+
+start_service() {
+	procd_open_instance
+	procd_set_param command /usr/sbin/rsyslogd
+	procd_close_instance
+}


### PR DESCRIPTION
This patch series adds a `libestr` package (required by rsyslog) and an `rsyslog`
package. This allows to use an OpenWRT box as a central logger (or as proxy for
logging from clients).

Tested on realview (ARM) and x86.