### PR TITLE
vpnc: dirty hack for musl compatibility

### DIFF
--- a/net/vpnc/Makefile
+++ b/net/vpnc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=vpnc
 PKG_REV:=550
 PKG_VERSION:=0.5.3.r$(PKG_REV)
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://svn.unix-ag.uni-kl.de/vpnc/trunk/

--- a/net/vpnc/patches/100-musl-compat.patch
+++ b/net/vpnc/patches/100-musl-compat.patch
@@ -19,17 +19,17 @@
  #endif
 --- a/sysdep.c
 +++ b/sysdep.c
-@@ -59,7 +59,9 @@
+@@ -59,6 +59,10 @@
  #if defined(__DragonFly__)
  #include <net/tun/if_tun.h>
  #elif defined(__linux__)
--#include <linux/if_tun.h>
-+# if defined(__GLIBC__) || defined(__UCLIBC__)
-+#  include <linux/if_tun.h>
++# if !defined(__GLIBC__) && !defined(__UCLIBC__)
++#  define _LINUX_IF_ETHER_H
++#  include <net/ethernet.h>
 +# endif
+ #include <linux/if_tun.h>
  #elif defined(__APPLE__)
  /* no header for tun */
- #elif defined(__CYGWIN__)
 --- a/config.c
 +++ b/config.c
 @@ -28,6 +28,7 @@


### PR DESCRIPTION
So far, this is only compile-tested but should address https://github.com/openwrt/packages/issues/1679