### PR TITLE
Bring back the Tcl language (lang/tcl package)...

### DIFF
--- a/lang/tcl/Makefile
+++ b/lang/tcl/Makefile
@@ -1,0 +1,73 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tcl
+PKG_VERSION:=8.6.4
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)$(PKG_VERSION)-src.tar.gz
+PKG_SOURCE_URL:=@SF/$(PKG_NAME)
+PKG_MD5SUM:=d7cbb91f1ded1919370a30edd1534304
+
+PKG_LICENSE:=TCL
+PKG_LICENSE_FILES:=license.terms
+PKG_MAINTAINER:=Joe Mistachkin <joe@mistachkin.com>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)$(PKG_VERSION)
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/tcl
+  SUBMENU:=Tcl
+  SECTION:=lang
+  CATEGORY:=Languages
+  DEPENDS:=+libpthread
+  TITLE:=The Tcl language
+  URL:=http://www.tcl.tk/
+endef
+
+define Package/tcl/description
+  Tcl, or Tool Command Language, is a an elegant, versatile, feature-rich,
+  simple-to-learn yet very powerful industrial-strength open-source
+  programming language and development platform. It is renowned for its
+  stability and utility, and its emphasis on providing a cross-platform
+  programming API makes it an ideal choice for an enormous variety of
+  programming jobs.
+endef
+
+CONFIGURE_PATH := unix
+
+CONFIGURE_VARS += \
+	tcl_cv_strtod_unbroken=ok
+
+CONFIGURE_ARGS += \
+	--enable-threads
+
+MAKE_PATH := unix
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtcl*.{a,so*} $(1)/usr/lib/
+endef
+
+define Package/tcl/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so $(1)/usr/lib
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,tcl))

--- a/lang/tcl/patches/100-disable_tzdata_and_msgs_install.patch
+++ b/lang/tcl/patches/100-disable_tzdata_and_msgs_install.patch
@@ -1,0 +1,22 @@
+--- a/unix/Makefile.in
++++ b/unix/Makefile.in
+@@ -817,15 +817,15 @@ install-tzdata: tclsh
+ 	@echo "Installing time zone data"
+ 	@@LD_LIBRARY_PATH_VAR@="`pwd`:$${@LD_LIBRARY_PATH_VAR@}"; export @LD_LIBRARY_PATH_VAR@; \
+ 	TCL_LIBRARY="${TCL_BUILDTIME_LIBRARY}"; export TCL_LIBRARY; \
+-	./tclsh $(TOOL_DIR)/installData.tcl \
+-	    $(TOP_DIR)/library/tzdata "$(SCRIPT_INSTALL_DIR)"/tzdata
++	#./tclsh $(TOOL_DIR)/installData.tcl \
++	#    $(TOP_DIR)/library/tzdata "$(SCRIPT_INSTALL_DIR)"/tzdata
+ 
+ install-msgs: tclsh
+ 	@echo "Installing message catalogs"
+ 	@@LD_LIBRARY_PATH_VAR@="`pwd`:$${@LD_LIBRARY_PATH_VAR@}"; export @LD_LIBRARY_PATH_VAR@; \
+ 	TCL_LIBRARY="${TCL_BUILDTIME_LIBRARY}"; export TCL_LIBRARY; \
+-	./tclsh $(TOOL_DIR)/installData.tcl \
+-	    $(TOP_DIR)/library/msgs "$(SCRIPT_INSTALL_DIR)"/msgs
++	#./tclsh $(TOOL_DIR)/installData.tcl \
++	#    $(TOP_DIR)/library/msgs "$(SCRIPT_INSTALL_DIR)"/msgs
+ 
+ install-doc: doc
+ 	@for i in "$(MAN_INSTALL_DIR)" "$(MAN1_INSTALL_DIR)" "$(MAN3_INSTALL_DIR)" "$(MANN_INSTALL_DIR)" ; \

--- a/lang/tcl/patches/200-fix_mips_build.patch
+++ b/lang/tcl/patches/200-fix_mips_build.patch
@@ -1,0 +1,20 @@
+--- a/generic/tclStrToD.c
++++ b/generic/tclStrToD.c
+@@ -73,7 +73,7 @@ typedef unsigned int fpu_control_t __att
+  * MIPS floating-point units need special settings in control registers
+  * to use gradual underflow as we expect.
+  */
+-#if defined(__mips)
++#if defined(__sgi) && defined(_COMPILER_VERSION)
+ #include <sys/fpu.h>
+ #endif
+ /*
+@@ -2166,7 +2166,7 @@ TclInitDoubleConversion(void)
+     } bitwhack;
+ #endif
+ 
+-#if defined(__mips)
++#if defined(__sgi) && defined(_COMPILER_VERSION)
+     union fpc_csr mipsCR;
+ 
+     mipsCR.fc_word = get_fpc_csr();


### PR DESCRIPTION
These changes bring back the Tcl language, updating it to the latest stable version (8.6.4).