### PR TITLE
adblock: busybox "tr" does not support character classes by default

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=0.20.0
+PKG_VERSION:=0.20.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dirk@brenken.org>

--- a/net/adblock/files/adblock-update.sh
+++ b/net/adblock/files/adblock-update.sh
@@ -25,7 +25,7 @@
 
 # set script version
 #
-adb_version="0.20.0"
+adb_version="0.20.1"
 
 # get current pid and script directory
 #
@@ -164,7 +164,7 @@ do
     if [ $((rc)) -eq 0 ] && [ -n "${tmp_var}" ]
     then
         eval "$(printf "${src}" | sed 's/\(.*\&ruleset=\)/ruleset=\$/g')"
-        tmp_var="$(printf "%s\n" "${tmp_var}" |  tr '[[:upper:]]' '[[:lower:]]')"
+        tmp_var="$(printf "%s\n" "${tmp_var}" | tr '[A-Z]' '[a-z]')"
         adb_count="$(printf "%s\n" "${tmp_var}" | eval "${ruleset}" | tee -a "${adb_tmpfile}" | wc -l)"
         /usr/bin/logger -t "adblock[${pid}]" "info: source download finished (${url}, ${adb_count} entries)"
     elif [ $((rc)) -eq 0 ] && [ -z "${tmp_var}" ]


### PR DESCRIPTION
bugfix: busybox "tr" does not support character classes by default and
generates (partly) odd domain names.

Signed-off-by: Dirk Brenken <dirk@brenken.org>