### PR TITLE
python-pyasn1: new package

### DIFF
--- a/lang/python-pyasn1/Makefile
+++ b/lang/python-pyasn1/Makefile
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pyasn1
+PKG_VERSION:=0.1.9
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pyasn1
+PKG_MD5SUM:=f00a02a631d4016818659d1cc38d229a
+
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE.txt
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/python-pyasn1
+	SECTION:=lang
+	CATEGORY:=Languages
+	SUBMENU:=Python
+	TITLE:=python-pyasn1
+	URL:=http://pyasn1.sourceforge.net/
+	DEPENDS:=+python-light
+endef
+
+define Package/python-pyasn1/description
+This is an implementation of ASN.1 types and codecs in Python programming
+language. It has been first written to support particular protocol (SNMP)
+but then generalized to be suitable for a wide range of protocols
+based on ASN.1 specification.
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+endef
+
+$(eval $(call PyPackage,python-pyasn1))
+$(eval $(call BuildPackage,python-pyasn1))

--- a/lang/python-pyasn1/Makefile
+++ b/lang/python-pyasn1/Makefile
@@ -15,6 +15,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pyasn1
 PKG_MD5SUM:=f00a02a631d4016818659d1cc38d229a
 
+PKG_BUILD_DEPENDS:=python python-setuptools
+
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>


### PR DESCRIPTION
From the README:

This is an implementation of ASN.1 types and codecs in Python programming
language. It has been first written to support particular protocol (SNMP)
but then generalized to be suitable for a wide range of protocols
based on ASN.1 specification.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>