### PR TITLE
chrony: improve hotplug and init scripts

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
 PKG_VERSION:=2.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.tuxfamily.org/chrony/

--- a/net/chrony/files/chrony.config
+++ b/net/chrony/files/chrony.config
@@ -3,6 +3,9 @@ config pool
 	option maxpoll '12'
 	option iburst 'yes'
 
+config dhcp_ntp_server
+	option iburst 'yes'
+
 config allow
 	option interface 'lan'
 

--- a/net/chrony/files/chrony.hotplug
+++ b/net/chrony/files/chrony.hotplug
@@ -1,6 +1,44 @@
-COMMAND=/usr/bin/chronyc
+#!/bin/sh
+# Set chronyd online/offline status, allow NTP access and add servers from DHCP
 
-[ -x $COMMAND ] || exit 0
+[ "$ACTION" = ifup -o "$ACTION" = ifdown ] || exit 0
 
-[ "$ACTION" = "ifup" -a "$INTERFACE" = "wan" ] && $COMMAND online
-[ "$ACTION" = "ifdown" -a "$INTERFACE" = "wan" ] && $COMMAND offline
+run_command() {
+	/usr/bin/chronyc -n "$*" > /dev/null 2>&1
+}
+
+run_command tracking || exit 0
+
+. /lib/functions/network.sh
+
+network_find_wan iface4
+network_find_wan6 iface6
+run_command $([ -n "$iface4" ] && echo online || echo offline) 0.0.0.0/0.0.0.0
+run_command $([ -n "$iface6" ] && echo online || echo offline) ::/0
+
+[ "$ACTION" = ifup ] || exit 0
+
+. /lib/functions.sh
+. /etc/init.d/chronyd
+
+config_load chrony
+
+config_foreach handle_allow allow | while read command; do
+	run_command "$command"
+done
+
+# Add servers from DHCP only if the config has a dhcp_ntp_server section
+[ -z "$(config_foreach echo dhcp_ntp_server)" ] && exit 0
+
+. /usr/share/libubox/jshn.sh
+
+for iface in $iface4 $iface6; do
+	json_load "$(ifstatus $iface)"
+	json_select data
+	json_get_var dhcp_ntp_servers ntpserver
+
+	for server in $dhcp_ntp_servers; do
+		run_command add $(NTP_SOURCE_HOSTNAME=$server config_foreach \
+				handle_source dhcp_ntp_server server)
+	done
+done

--- a/net/chrony/files/chronyd.init
+++ b/net/chrony/files/chronyd.init
@@ -1,15 +1,17 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2006 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 
-START=60
+START=15
 USE_PROCD=1
 PROG=/usr/sbin/chronyd
 CONFIGFILE=/var/etc/chrony.conf
+INCLUDEFILE=/etc/chrony/chrony.conf
 
 handle_source() {
 	local cfg=$1 sourcetype=$2 hostname minpoll maxpoll iburst
 
-	config_get hostname "$cfg" hostname
+	hostname=$NTP_SOURCE_HOSTNAME
+	[ -z "$hostname" ] && config_get hostname "$cfg" hostname
 	[ -z "$hostname" ] && return
 	config_get minpoll "$cfg" minpoll
 	config_get maxpoll "$cfg" maxpoll
@@ -19,7 +21,7 @@ handle_source() {
 		[ -n "$minpoll" ] && echo minpoll $minpoll
 		[ -n "$maxpoll" ] && echo maxpoll $maxpoll
 		[ "$iburst" = "1" ] && echo iburst
-	) >> $CONFIGFILE
+	)
 }
 
 handle_allow() {
@@ -30,12 +32,14 @@ handle_allow() {
 	config_get iface "$cfg" interface
 
 	if [ "$wan_iface" = "$iface" ]; then
-		echo allow >> $CONFIGFILE
+		echo allow 0/0
+	elif [ "$wan6_iface" = "$iface" ]; then
+		echo allow ::/0
 	else
 		network_get_subnets subnets $iface || \
 			network_get_subnets subnets6 $iface || continue
 		for subnet in $subnets $subnets6; do
-			echo allow $subnet >> $CONFIGFILE
+			echo allow $subnet
 		done
 	fi
 }
@@ -46,7 +50,7 @@ handle_makestep() {
 	config_get threshold "$cfg" threshold
 	config_get limit "$cfg" limit
 	[ -z "$threshold" -o -z "$limit" ] && return
-	echo makestep $threshold $limit >> $CONFIGFILE
+	echo makestep $threshold $limit
 }
 
 start_service() {
@@ -55,15 +59,18 @@ start_service() {
 	procd_open_instance
 	procd_set_param command $PROG -n -f $CONFIGFILE
 	procd_set_param file $CONFIGFILE
-	procd_set_param file /etc/chrony/chrony.conf
+	procd_set_param file $INCLUDEFILE
 	procd_close_instance
 
-	echo include /etc/chrony/chrony.conf > $CONFIGFILE
+	config_load chrony
+	mkdir -p $(dirname $CONFIGFILE)
 
-	config_load ntpd
-	config_foreach handle_source server server
-	config_foreach handle_source pool pool
-	config_foreach handle_source peer peer
-	config_foreach handle_allow allow
-	config_foreach handle_makestep makestep
+	(
+		echo include $INCLUDEFILE
+		config_foreach handle_source server server
+		config_foreach handle_source pool pool
+		config_foreach handle_source peer peer
+		config_foreach handle_allow allow
+		config_foreach handle_makestep makestep
+	) > $CONFIGFILE
 }

--- a/net/chrony/patches/001-freebind_uclibc.patch
+++ b/net/chrony/patches/001-freebind_uclibc.patch
@@ -1,0 +1,13 @@
+diff --git a/sysincl.h b/sysincl.h
+index 30e9b48..8fe16c0 100644
+--- a/sysincl.h
++++ b/sysincl.h
+@@ -70,4 +70,8 @@
+ #include <arpa/inet.h>
+ #endif
+ 
++#if defined(LINUX) && !defined(IP_FREEBIND)
++#define IP_FREEBIND 15
++#endif
++
+ #endif /* GOT_SYSINCL_H */


### PR DESCRIPTION
This patch adds various improvements to the chrony hotplug script and the init script. NTP access is allowed for interfaces that go up after chronyd starts and NTP servers obtained from DHCP are now used automatically.