### PR TITLE
libgee, grilo, grilo-plugins: use GNOME alias to fix downloads in buildbot

### DIFF
--- a/libs/libgee/Makefile
+++ b/libs/libgee/Makefile
@@ -17,7 +17,7 @@ PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://download.gnome.org/sources/libgee/0.18/
+PKG_SOURCE_URL:=@GNOME/libgee/0.18/
 PKG_MD5SUM:=29ea6125e653d7e60b49a9a9544abc96
 
 PKG_FIXUP:=autoreconf

--- a/multimedia/grilo-plugins/Makefile
+++ b/multimedia/grilo-plugins/Makefile
@@ -17,7 +17,7 @@ PKG_LICENSE:=LGPLv2.1
 PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://download.gnome.org/sources/grilo-plugins/0.2/
+PKG_SOURCE_URL:=@GNOME/grilo-plugins/0.2/
 PKG_MD5SUM:=62ecaad877b485a950259eef1ef38c18
 
 PKG_BUILD_DEPENDS:=glib2 grilo

--- a/multimedia/grilo/Makefile
+++ b/multimedia/grilo/Makefile
@@ -17,7 +17,7 @@ PKG_LICENSE:=LGPLv2.1
 PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://download.gnome.org/sources/grilo/0.2/
+PKG_SOURCE_URL:=@GNOME/grilo/0.2/
 PKG_MD5SUM:=7eba405ada20fefcb877d534d9d4f
 
 PKG_BUILD_DEPENDS:=glib2 libsoup libxml2


### PR DESCRIPTION
Switch grilo, grilo-plugins and libgee to use the @ GNOME alias for source download in order to fix download problems in buildbot.

Buildbot is continuously failing to download the sources for these three packages due to TLS problem with download.gnome.org.
E.g.
http://buildbot.openwrt.org:8010/broken_packages/ar71xx/
http://buildbot.openwrt.org:8010/broken_packages/ar71xx/libgee/compile.txt
```
/mnt/dl/slave/ar71xx/build/scripts/download.pl "/mnt/dl/slave/ar71xx/build/dl" "libgee-0.18.0.tar.xz" "29ea6125e653d7e60b49a9a9544abc96" "https://download.gnome.org/sources/libgee/0.18/"
--2015-11-14 05:57:50--  https://download.gnome.org/sources/libgee/0.18/libgee-0.18.0.tar.xz
Resolving download.gnome.org (download.gnome.org)... 209.132.180.168, 209.132.180.180
Connecting to download.gnome.org (download.gnome.org)|209.132.180.168|:443... connected.
GnuTLS: A TLS warning alert has been received.
Unable to establish SSL connection.
Download failed.
```
The dependent packages like lcdgrilo naturally fail to build, too.

All other packages in this feed already use the @ GNOME download location alias, so switch also these three packages to use that. The alias also provides several fallback download locations in case there is problems with the first.

CCing the maintainer of all three packages: @MikePetullo 
