### PR TITLE
ssmtp: maintenance update

### DIFF
--- a/mail/ssmtp/Makefile
+++ b/mail/ssmtp/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2014 OpenWrt.org
+# Copyright (C) 2007-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,8 +9,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ssmtp
 PKG_VERSION:=2.64
-PKG_RELEASE:=1.1
-PKG_MAINTAINER:=Dirk Brenken <dibdot@gmail.com>
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Dirk Brenken <dirk@brenken.org>
 PKG_LICENSE:=GPL-2.0+
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.bz2
@@ -21,23 +21,24 @@ include $(INCLUDE_DIR)/package.mk
 
 TARGET_CFLAGS += $(TARGET_CPPFLAGS)
 
-define Package/ssmtp
-  SECTION:=mail
-  CATEGORY:=Mail
-  DEPENDS:=+libopenssl
-  TITLE:=A minimal and secure mail sender with ssl support
-  URL:=http://packages.debian.org/ssmtp
+define Package/$(PKG_NAME)
+	SECTION:=mail
+	CATEGORY:=Mail
+	DEPENDS:=+libopenssl
+	TITLE:=A minimal and secure mail sender with ssl support
+	URL:=http://packages.debian.org/ssmtp
 endef
 
-define Package/ssmtp/description
- A secure, effective and simple way of getting mail off a system to your
- mail hub. It contains no suid-binaries or other dangerous things - no
- mail spool to poke around in, and no daemons running in the background.
- Mail is simply forwarded to the configured mailhost. Extremely easy
- configuration.
+define Package/$(PKG_NAME)/description
+A secure, effective and simple way of getting mail off a system to your
+mail hub. It contains no suid-binaries or other dangerous things - no
+mail spool to poke around in, and no daemons running in the background.
+Mail is simply forwarded to the configured mailhost. Extremely easy
+configuration.
+
 endef
 
-define Package/ssmtp/conffiles
+define Package/$(PKG_NAME)/conffiles
 /etc/ssmtp/ssmtp.conf
 /etc/ssmtp/revaliases
 endef
@@ -48,7 +49,7 @@ CONFIGURE_VARS += \
 CONFIGURE_ARGS += \
 	--enable-ssl
 
-define Package/ssmtp/install
+define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/etc/ssmtp
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/ssmtp.conf $(1)/etc/ssmtp/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/revaliases $(1)/etc/ssmtp/
@@ -56,9 +57,9 @@ define Package/ssmtp/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ssmtp $(1)/usr/sbin/
 endef
 
-define Package/ssmtp/postinst
+define Package/$(PKG_NAME)/postinst
 #!/bin/sh
 ln -sf ssmtp $${IPKG_INSTROOT}/usr/sbin/sendmail
 endef
 
-$(eval $(call BuildPackage,ssmtp))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/mail/ssmtp/patches/004-remove_dead-letter.patch
+++ b/mail/ssmtp/patches/004-remove_dead-letter.patch
@@ -1,0 +1,94 @@
+--- a/ssmtp.c
++++ b/ssmtp.c
+@@ -138,71 +138,7 @@ int smtp_read_all(int fd, char *response
+ int smtp_okay(int fd, char *response);
+ 
+ /*
+-dead_letter() -- Save stdin to ~/dead.letter if possible
+-*/
+-void dead_letter(void)
+-{
+-	char *path;
+-	char buf[(BUF_SZ + 1)];
+-	struct passwd *pw;
+-	uid_t uid;
+-	FILE *fp;
+-
+-	uid = getuid();
+-	pw = getpwuid(uid);
+-
+-	if(isatty(fileno(stdin))) {
+-		if(log_level > 0) {
+-			log_event(LOG_ERR,
+-				"stdin is a TTY - not saving to %s/dead.letter", pw->pw_dir);
+-		}
+-		return;
+-	}
+-
+-	if(pw == (struct passwd *)NULL) {
+-		/* Far to early to save things */
+-		if(log_level > 0) {
+-			log_event(LOG_ERR, "No sender failing horribly!");
+-		}
+-		return;
+-	}
+-
+-#define DEAD_LETTER "/dead.letter"
+-	path = malloc (strlen (pw->pw_dir) + sizeof (DEAD_LETTER));
+-	if (!path) {
+-		/* Can't use die() here since dead_letter() is called from die() */
+-		exit(1);
+-	}
+-	memcpy (path, pw->pw_dir, strlen (pw->pw_dir));
+-	memcpy (path + strlen (pw->pw_dir), DEAD_LETTER, sizeof (DEAD_LETTER));
+-	
+-	if((fp = fopen(path, "a")) == (FILE *)NULL) {
+-		/* Perhaps the person doesn't have a homedir... */
+-		if(log_level > 0) {
+-			log_event(LOG_ERR, "Can't open %s failing horribly!", path);
+-		}
+-		free(path);
+-		return;
+-	}
+-
+-	/* We start on a new line with a blank line separating messages */
+-	(void)fprintf(fp, "\n\n");
+-
+-	while(fgets(buf, sizeof(buf), stdin)) {
+-		(void)fputs(buf, fp);
+-	}
+-
+-	if(fclose(fp) == -1) {
+-		if(log_level > 0) {
+-			log_event(LOG_ERR,
+-				"Can't close %s/dead.letter, possibly truncated", pw->pw_dir);
+-		}
+-	}
+-	free(path);
+-}
+-
+-/*
+-die() -- Write error message, dead.letter and exit
++die() -- Write error message and exit
+ */
+ void die(char *format, ...)
+ {
+@@ -216,9 +152,6 @@ void die(char *format, ...)
+ 	(void)fprintf(stderr, "%s: %s\n", prog, buf);
+ 	log_event(LOG_ERR, "%s", buf);
+ 
+-	/* Send message to dead.letter */
+-	(void)dead_letter();
+-
+ 	exit(1);
+ }
+ 
+@@ -1640,7 +1573,7 @@ int ssmtp(char *argv[])
+ 			sleep(1);
+ 			/* don't hang forever when reading from stdin */
+ 			if (++timeout >= MEDWAIT) {
+-				log_event(LOG_ERR, "killed: timeout on stdin while reading body -- message saved to dead.letter.");
++				log_event(LOG_ERR, "killed: timeout on stdin while reading body.");
+ 				die("Timeout on stdin while reading body");
+ 			}
+ 			continue;

--- a/mail/ssmtp/patches/006-add_ip-header.patch
+++ b/mail/ssmtp/patches/006-add_ip-header.patch
@@ -1,0 +1,21 @@
+--- a/ssmtp.c
++++ b/ssmtp.c
+@@ -1338,6 +1338,7 @@ ssmtp() -- send the message (exactly one
+ int ssmtp(char *argv[])
+ {
+ 	char b[(BUF_SZ + 2)], *buf = b+1, *p, *q;
++	char *remote_addr;
+ #ifdef MD5AUTH
+ 	char challenge[(BUF_SZ + 1)];
+ #endif
+@@ -1541,6 +1542,10 @@ int ssmtp(char *argv[])
+ 		outbytes += smtp_write(sock, "From: %s", from);
+ 	}
+ 
++	if(remote_addr=getenv("REMOTE_ADDR")) {
++		outbytes += smtp_write(sock, "X-Originating-IP: %s", remote_addr);
++	}
++
+ 	if(have_date == False) {
+ 		outbytes += smtp_write(sock, "Date: %s", arpadate);
+ 	}

--- a/mail/ssmtp/patches/008-remove_garbage.patch
+++ b/mail/ssmtp/patches/008-remove_garbage.patch
@@ -1,0 +1,18 @@
+--- a/ssmtp.c
++++ b/ssmtp.c
+@@ -1591,12 +1591,12 @@ int ssmtp(char *argv[])
+ 			outbytes += smtp_write(sock, "%s", leadingdot ? b : buf);
+ 		} else {
+ 			if (log_level > 0) {
+-				log_event(LOG_INFO, "Sent a very long line in chunks");
++				log_event(LOG_INFO, "Sending a partial line");
+ 			}
+ 			if (leadingdot) {
+-				outbytes += fd_puts(sock, b, sizeof(b));
++				outbytes += fd_puts(sock, b, strlen(b));
+ 			} else {
+-				outbytes += fd_puts(sock, buf, bufsize);
++				outbytes += fd_puts(sock, buf, strlen(buf));
+ 			}
+ 		}
+ 		(void)alarm((unsigned) MEDWAIT);

--- a/mail/ssmtp/patches/010-fix_message-header.patch
+++ b/mail/ssmtp/patches/010-fix_message-header.patch
@@ -1,0 +1,92 @@
+--- a/ssmtp.c
++++ b/ssmtp.c
+@@ -282,6 +282,7 @@ standardise() -- Trim off '\n's and doub
+ */
+ bool_t standardise(char *str, bool_t *linestart)
+ {
++	size_t sl;
+ 	char *p;
+ 	bool_t leadingdot = False;
+ 
+@@ -297,6 +298,12 @@ bool_t standardise(char *str, bool_t *li
+ 	if((p = strchr(str, '\n'))) {
+ 		*p = '\0';
+ 		*linestart = True;
++
++		/* If the line ended in "\r\n", then drop the '\r' too */
++		sl = strlen(str);
++		if(sl >= 1 && str[sl - 1] == '\r') {
++			str[sl - 1] = '\0';
++		}
+ 	}
+ 	return(leadingdot);
+ }
+@@ -690,6 +697,14 @@ void header_parse(FILE *stream)
+ 		}
+ 		len++;
+ 
++		if(l == '\r' && c == '\n') {
++			/* Properly handle input that already has "\r\n"
++			   line endings; see https://bugs.debian.org/584162 */
++			l = (len >= 2 ? *(q - 2) : '\n');
++			q--;
++			len--;
++		}
++
+ 		if(l == '\n') {
+ 			switch(c) {
+ 				case ' ':
+@@ -712,8 +727,9 @@ void header_parse(FILE *stream)
+ 						if((q = strrchr(p, '\n'))) {
+ 							*q = '\0';
+ 						}
+-						header_save(p);
+-
++						if(len > 0) {
++							header_save(p);
++						}
+ 						q = p;
+ 						len = 0;
+ 			}
+@@ -722,35 +738,12 @@ void header_parse(FILE *stream)
+ 
+ 		l = c;
+ 	}
+-	if(in_header) {
+-		if(l == '\n') {
+-			switch(c) {
+-				case ' ':
+-				case '\t':
+-						/* Must insert '\r' before '\n's embedded in header
+-						   fields otherwise qmail won't accept our mail
+-						   because a bare '\n' violates some RFC */
+-						
+-						*(q - 1) = '\r';	/* Replace previous \n with \r */
+-						*q++ = '\n';		/* Insert \n */
+-						len++;
+-						
+-						break;
+-
+-				case '\n':
+-						in_header = False;
+-
+-				default:
+-						*q = '\0';
+-						if((q = strrchr(p, '\n'))) {
+-							*q = '\0';
+-						}
+-						header_save(p);
+-
+-						q = p;
+-						len = 0;
+-			}
+-		}
++	if(in_header && l == '\n') {
++		/* Got EOF while reading the header */
++		if((q = strrchr(p, '\n'))) {
++			*q = '\0';
++ 		}
++		header_save(p);
+ 	}
+ 	(void)free(p);
+ }


### PR DESCRIPTION
remove needless dead.letter function (at least on embedded devices)
backport debian fixes (slightly modified)

compile tested. Please apply to upstream - thank you!

Signed-off-by: Dirk Brenken <dirk@brenken.org>