### PR TITLE
python-pycparser: new package

### DIFF
--- a/lang/python-pycparser/Makefile
+++ b/lang/python-pycparser/Makefile
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pycparser
+PKG_VERSION:=2.14
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pycparser
+PKG_MD5SUM:=a2bc8d28c923b4fe2b2c3b4b51a4f935
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/python-pycparser
+	SECTION:=lang
+	CATEGORY:=Languages
+	SUBMENU:=Python
+	TITLE:=python-pycparser
+	URL:=https://github.com/eliben/pycparser
+	DEPENDS:=+python-light +python-ply
+endef
+
+define Package/python-pycparser/description
+pycparser is a parser for the C language, written in pure Python. It is a
+module designed to be easily integrated into applications that need to parse
+C source code.
+endef
+
+define PyPackage/python-pycparser/filespec
++|$(PYTHON_PKG_DIR)
+-|$(PYTHON_PKG_DIR)/pycparser/ply
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+endef
+
+$(eval $(call PyPackage,python-pycparser))
+$(eval $(call BuildPackage,python-pycparser))

--- a/lang/python-pycparser/patches/001-use-external-ply.patch
+++ b/lang/python-pycparser/patches/001-use-external-ply.patch
@@ -1,0 +1,41 @@
+diff --git a/pycparser/c_lexer.py b/pycparser/c_lexer.py
+index cbb9d26..cbd7742 100644
+--- a/pycparser/c_lexer.py
++++ b/pycparser/c_lexer.py
+@@ -9,8 +9,8 @@
+ import re
+ import sys
+ 
+-from .ply import lex
+-from .ply.lex import TOKEN
++from ply import lex
++from ply.lex import TOKEN
+ 
+ 
+ class CLexer(object):
+diff --git a/pycparser/c_parser.py b/pycparser/c_parser.py
+index f4f7453..5c0ca88 100644
+--- a/pycparser/c_parser.py
++++ b/pycparser/c_parser.py
+@@ -8,7 +8,7 @@
+ #------------------------------------------------------------------------------
+ import re
+ 
+-from .ply import yacc
++from ply import yacc
+ 
+ from . import c_ast
+ from .c_lexer import CLexer
+diff --git a/setup.py b/setup.py
+index fdccbb3..036a10b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -49,7 +49,7 @@ setup(
+     classifiers = [
+         'Programming Language :: Python :: 2',
+         'Programming Language :: Python :: 3',],
+-    packages=['pycparser', 'pycparser.ply'],
++    packages=['pycparser'],
+     package_data={'pycparser': ['*.cfg']},
+     cmdclass={'install': install, 'sdist': sdist},
+ )


### PR DESCRIPTION
From the README:

pycparser is a parser for the C language, written in pure Python. It is a
module designed to be easily integrated into applications that need to parse
C source code.

This depends on python-ply, which is in PR #1956

Signed-off-by: Jeffery To <jeffery.to@gmail.com>