### PR TITLE
python-cffi: new package

### DIFF
--- a/lang/python-cffi/Makefile
+++ b/lang/python-cffi/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cffi
+PKG_VERSION:=1.3.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/c/cffi
+PKG_MD5SUM:=a40ed8c8ac653c8fc7d5603711b06eaf
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/python-cffi
+	SECTION:=lang
+	CATEGORY:=Languages
+	SUBMENU:=Python
+	TITLE:=python-cffi
+	URL:=http://cffi.readthedocs.org/
+	DEPENDS:=+libffi +python-light +python-pycparser
+endef
+
+define Package/python-cffi/description
+Foreign Function Interface for Python calling C code.
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+endef
+
+$(eval $(call PyPackage,python-cffi))
+$(eval $(call BuildPackage,python-cffi))


### PR DESCRIPTION
From PyPI:

Foreign Function Interface for Python calling C code.

This depends on python-pycparser, which is in PR #1970

Signed-off-by: Jeffery To <jeffery.to@gmail.com>