### PR TITLE
Make 2 variants for libshout. Update oggfwd to use full variant.

### DIFF
--- a/libs/libshout/Makefile
+++ b/libs/libshout/Makefile
@@ -9,8 +9,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libshout
 PKG_VERSION:=2.3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://downloads.us.xiph.org/releases/libshout/
 PKG_MD5SUM:=11765b2592e7ea623ccd93d3f8df172c
@@ -24,12 +25,25 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/libshout
+define Package/libshout/default
   SECTION:=libs
   CATEGORY:=Libraries
-  TITLE:=Library which can be used to write a source client like ices
+  TITLE:=Shoutcast client library
   URL:=http://www.icecast.org/download.php
-  DEPENDS:= +libspeex +libtheora +libvorbis +libvorbisidec +libpthread
+  DEPENDS:= +libvorbis +libvorbisidec +libpthread
+endef
+
+define Package/libshout
+  $(call Package/libshout/default)
+  TITLE+= (no speex & theora)
+  VARIANT:=nospeex
+endef
+
+define Package/libshout-full
+  $(call Package/libshout/default)
+  TITLE+= (all codecs)
+  DEPENDS+= +libspeex +libtheora
+  VARIANT:=full
 endef
 
 define Package/libshout/description
@@ -40,9 +54,15 @@ define Package/libshout/description
  details.
 endef
 
+Package/libshout-full/description=Package/libshout/description
+
 CONFIGURE_ARGS += \
 	--enable-shared \
-	--enable-static \
+	--enable-static
+
+ifeq ($(BUILD_VARIANT),full)
+  CONFIGURE_ARGS += --with-theora=no --with-speex=no
+endif
 
 CONFIGURE_VARS += \
 	VORBIS_CFLAGS="-I$(STAGING_DIR)/usr/include/tremor/" \
@@ -64,5 +84,7 @@ define Package/libshout/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libshout.so.* $(1)/usr/lib/
 endef
+Package/libshout-full/install=Package/libshout/install
 
 $(eval $(call BuildPackage,libshout))
+$(eval $(call BuildPackage,libshout-full))

--- a/multimedia/oggfwd/Makefile
+++ b/multimedia/oggfwd/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=oggfwd
 PKG_REV:=506088e5066abd086efc951670906187c120e9a3
 PKG_VERSION:=20150412
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=git://r-w-x.org/oggfwd.git
@@ -30,7 +30,7 @@ define Package/oggfwd
   SUBMENU:=Streaming
   TITLE:=Pipe media into icecast
   URL:=http://www.v2v.cc/~j/oggfwd
-  DEPENDS:=+libpthread +libshout
+  DEPENDS:=+libpthread +libshout-full
 endef
 
 define Package/oggfwd/description


### PR DESCRIPTION
Removed speex & theora for another project to cut down the size of libshout significantly. libshout-full has all codecs included.

Oggfwd looked like it wanted video support.  Maybe not so for ices app.

@psycho-nico - please review