### PR TITLE
Python3: Add python3-pip, python3-setuptools and their dependencies

### DIFF
--- a/lang/python3-pip/Makefile
+++ b/lang/python3-pip/Makefile
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2014-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-pip
+PKG_VERSION:=7.1.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=pip-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pip/
+PKG_MD5SUM:=3823d2343d9f3aaab21cf9c917710196
+
+PKG_LICENSE:=MIT
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/pip-$(PKG_VERSION)
+PKG_USE_MIPS16:=0
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python3-package.mk)
+
+define Package/python3-pip
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Tool for installing Python $(PYTHON3_VERSION) packages.
+	URL:=https://pip.pypa.io
+	DEPENDS:=+python3 +python3-dev +python3-lib2to3 +python3-setuptools
+	MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+endef
+
+define Package/python3-pip/description
+	A tool for installing and managing Python $(PYTHON3_VERSION) packages.
+endef
+
+define Build/Compile
+	$(call Build/Compile/Py3Mod,,\
+		install --root="$(PKG_INSTALL_DIR)" --prefix="/usr" \
+		--single-version-externally-managed \
+	)
+endef
+
+define Py3Package/python3-pip/filespec
++|$(PYTHON3_PKG_DIR)
+-|$(PYTHON3_PKG_DIR)/_vendor/distlib/*.exe
+-|$(PYTHON3_PKG_DIR)/utils/outdated.py
+endef
+
+define Py3Package/python3-pip/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/pip$(PYTHON3_VERSION) $(1)/usr/bin
+	$(LN) pip$(PYTHON3_VERSION) $(1)/usr/bin/pip3
+endef
+
+$(eval $(call Py3Package,python3-pip))
+$(eval $(call BuildPackage,python3-pip))

--- a/lang/python3-pip/patches/0001-remove-self-version-checking.patch
+++ b/lang/python3-pip/patches/0001-remove-self-version-checking.patch
@@ -1,0 +1,70 @@
+From 771a1407b15538697a7f38209e40dbbf58828d33 Mon Sep 17 00:00:00 2001
+From: Florian Fieber <florian@florianfieber.de>
+Date: Tue, 9 Jun 2015 15:59:04 +0200
+Subject: [PATCH] Remove self version checking
+
+Signed-off-by: Florian Fieber <florian@florianfieber.de>
+---
+ pip/basecommand.py | 10 ----------
+ pip/cmdoptions.py  | 10 ----------
+ 2 files changed, 20 deletions(-)
+
+diff --git a/pip/basecommand.py b/pip/basecommand.py
+index 854d113..c2337a4 100644
+--- a/pip/basecommand.py
++++ b/pip/basecommand.py
+@@ -22,7 +22,6 @@ from pip.status_codes import (
+ from pip.utils import get_prog, normalize_path
+ from pip.utils.deprecation import RemovedInPip8Warning
+ from pip.utils.logging import IndentingFormatter
+-from pip.utils.outdated import pip_version_check
+ 
+ 
+ __all__ = ['Command']
+@@ -237,15 +236,6 @@ class Command(object):
+             logger.critical('Exception:', exc_info=True)
+ 
+             return UNKNOWN_ERROR
+-        finally:
+-            # Check if we're using the latest version of pip available
+-            if (not options.disable_pip_version_check and not
+-                    getattr(options, "no_index", False)):
+-                with self._build_session(
+-                        options,
+-                        retries=0,
+-                        timeout=min(5, options.timeout)) as session:
+-                    pip_version_check(session)
+ 
+         return SUCCESS
+ 
+diff --git a/pip/cmdoptions.py b/pip/cmdoptions.py
+index 9a0446a..4fa29d3 100644
+--- a/pip/cmdoptions.py
++++ b/pip/cmdoptions.py
+@@ -514,15 +514,6 @@ no_clean = partial(
+     default=False,
+     help="Don't clean up build directories.")
+ 
+-disable_pip_version_check = partial(
+-    Option,
+-    "--disable-pip-version-check",
+-    dest="disable_pip_version_check",
+-    action="store_true",
+-    default=False,
+-    help="Don't periodically check PyPI to determine whether a new version "
+-         "of pip is available for download. Implied with --no-index.")
+-
+ # Deprecated, Remove later
+ always_unzip = partial(
+     Option,
+@@ -560,7 +551,6 @@ general_group = {
+         client_cert,
+         cache_dir,
+         no_cache,
+-        disable_pip_version_check,
+     ]
+ }
+ 
+-- 
+2.6.2
+

--- a/lang/python3-setuptools/Makefile
+++ b/lang/python3-setuptools/Makefile
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2014-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-setuptools
+PKG_VERSION:=18.5
+PKG_RELEASE:=1
+
+PKG_SOURCE:=setuptools-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/s/setuptools/
+PKG_MD5SUM:=533c868f01169a3085177dffe5e768bb
+
+PKG_LICENSE:=PSF
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/setuptools-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python3-package.mk)
+
+define Package/python3-setuptools
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Tool for installing Python $(PYTHON3_VERSION) packages.
+	URL:=https://bitbucket.org/pypa/setuptools
+	DEPENDS:=+python3 +python3-dev +python3-lib2to3
+	MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+endef
+
+define Package/python3-setuptools/description
+	Easily download, build, install, upgrade, and uninstall Python $(PYTHON3_VERSION) packages
+endef
+
+define Build/Compile
+	$(call Build/Compile/Py3Mod,,\
+		install --root="$(PKG_INSTALL_DIR)" --prefix="/usr" \
+		--single-version-externally-managed \
+	)
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(PYTHON3_LIB_DIR)
+	$(CP) \
+		$(PKG_INSTALL_DIR)$(PYTHON3_PKG_DIR)/* \
+		$(PYTHON3_LIB_DIR)
+endef
+
+define Py3Package/python3-setuptools/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/easy_install-$(PYTHON3_VERSION) $(1)/usr/bin/
+	$(LN) easy_install-$(PYTHON3_VERSION) $(1)/usr/bin/easy_install3
+endef
+
+$(eval $(call Py3Package,python3-setuptools))
+$(eval $(call BuildPackage,python3-setuptools))

--- a/lang/python3-setuptools/patches/0001-remove-windows-support.patch
+++ b/lang/python3-setuptools/patches/0001-remove-windows-support.patch
@@ -1,0 +1,20 @@
+diff --git a/setuptools/dist.py b/setuptools/dist.py
+index 6b9d350..1350e8a 100644
+--- a/setuptools/dist.py
++++ b/setuptools/dist.py
+@@ -15,7 +15,6 @@ from distutils.errors import (DistutilsOptionError, DistutilsPlatformError,
+ 
+ from setuptools.depends import Require
+ from setuptools.compat import basestring, PY2
+-from setuptools import windows_support
+ import pkg_resources
+ 
+ def _get_unpatched(cls):
+@@ -310,7 +309,6 @@ class Distribution(_Distribution):
+         egg_cache_dir = os.path.join(os.curdir, '.eggs')
+         if not os.path.exists(egg_cache_dir):
+             os.mkdir(egg_cache_dir)
+-            windows_support.hide_file(egg_cache_dir)
+             readme_txt_filename = os.path.join(egg_cache_dir, 'README.txt')
+             with open(readme_txt_filename, 'w') as f:
+                 f.write('This directory contains eggs that were downloaded '

--- a/lang/python3-setuptools/patches/0002-fix-pyvenv-environment-get.patch
+++ b/lang/python3-setuptools/patches/0002-fix-pyvenv-environment-get.patch
@@ -1,0 +1,13 @@
+diff --git a/setuptools/command/easy_install.py b/setuptools/command/easy_install.py
+index df1655b..24c34e5 100755
+--- a/setuptools/command/easy_install.py
++++ b/setuptools/command/easy_install.py
+@@ -1885,7 +1885,7 @@ class CommandSpec(list):
+             return param
+         if isinstance(param, list):
+             return cls(param)
+-        if param is None:
++        if param is None or os.environ.get('__PYVENV_LAUNCHER__'):
+             return cls.from_environment()
+         # otherwise, assume it's a string.
+         return cls.from_string(param)

--- a/lang/python3/Makefile
+++ b/lang/python3/Makefile
@@ -14,7 +14,7 @@ PYTHON_VERSION:=$(PYTHON3_VERSION)
 PYTHON_VERSION_MICRO:=$(PYTHON3_VERSION_MICRO)
 
 PKG_NAME:=python3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -92,7 +92,7 @@ include ./files/python3-package-*.mk
 
 define Package/python3
 $(call Package/python3/Default)
-  DEPENDS:=+python3-light $(foreach package,$(PYTHON3_PACKAGES),+$(package))
+  DEPENDS:=+python3-light $(foreach package,$(filter-out python3-dev python3-lib2to3,$(PYTHON3_PACKAGES)),+$(package))
 endef
 
 define Package/python3/description
@@ -179,12 +179,10 @@ endef
 
 define Py3Package/python3-light/filespec
 +|/usr/lib/python$(PYTHON_VERSION)
--|/usr/lib/python$(PYTHON_VERSION)/config-$(PYTHON_VERSION)
 -|/usr/lib/python$(PYTHON_VERSION)/distutils/cygwinccompiler.py
 -|/usr/lib/python$(PYTHON_VERSION)/distutils/command/wininst*
 -|/usr/lib/python$(PYTHON_VERSION)/ensurepip
 -|/usr/lib/python$(PYTHON_VERSION)/idlelib
--|/usr/lib/python$(PYTHON_VERSION)/lib2to3
 -|/usr/lib/python$(PYTHON_VERSION)/tkinter
 -|/usr/lib/python$(PYTHON_VERSION)/turtledemo
 -|/usr/lib/python$(PYTHON_VERSION)/lib-dynload/_test*.so

--- a/lang/python3/Makefile
+++ b/lang/python3/Makefile
@@ -14,11 +14,11 @@ PYTHON_VERSION:=$(PYTHON3_VERSION)
 PYTHON_VERSION_MICRO:=$(PYTHON3_VERSION_MICRO)
 
 PKG_NAME:=python3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://www.python.org/ftp/python/$(PKG_VERSION)
+PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)
 PKG_MD5SUM:=d149d2812f10cbe04c042232e7964171
 
 PKG_LICENSE:=PSF
@@ -41,7 +41,7 @@ define Package/python3/Default
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Python $(PYTHON_VERSION) programming language
-  URL:=http://www.python.org/
+  URL:=https://www.python.org/
   MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 endef
 

--- a/lang/python3/files/python3-package-dev.mk
+++ b/lang/python3/files/python3-package-dev.mk
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Package/python3-dev
+$(call Package/python3/Default)
+  TITLE:=Python $(PYTHON3_VERSION) development files
+  DEPENDS:=+python3
+endef
+
+define Py3Package/python3-dev/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/python$(PYTHON3_VERSION)-config $(1)/usr/bin
+	$(LN) python$(PYTHON3_VERSION)-config $(1)/usr/bin/python3-config
+	$(LN) python$(PYTHON_VERSION)/config-$(PYTHON_VERSION)/libpython$(PYTHON3_VERSION).a $(1)/usr/lib/libpython$(PYTHON3_VERSION).a
+endef
+
+$(eval $(call Py3BasePackage,python3-dev, \
+    /usr/lib/python$(PYTHON_VERSION)/config-$(PYTHON_VERSION) \
+    /usr/include/python$(PYTHON_VERSION) \
+    /usr/lib/pkgconfig \
+))

--- a/lang/python3/files/python3-package-lib2to3.mk
+++ b/lang/python3/files/python3-package-lib2to3.mk
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Package/python3-lib2to3
+$(call Package/python3/Default)
+  TITLE:=Python $(PYTHON3_VERSION) lib2to3 module
+  DEPENDS:=+python3
+endef
+
+$(eval $(call Py3BasePackage,python3-lib2to3, \
+	/usr/lib/python$(PYTHON3_VERSION)/lib2to3 \
+))

--- a/lang/python3/files/python3-package.mk
+++ b/lang/python3/files/python3-package.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2014 OpenWrt.org
+# Copyright (C) 2007-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -28,10 +28,20 @@ define HostPython3
 	(	export PYTHONPATH="$(PYTHON3PATH)"; \
 		export PYTHONOPTIMIZE=""; \
 		export PYTHONDONTWRITEBYTECODE=1; \
+		export _python_sysroot="$(STAGING_DIR)"; \
+		export _python_prefix="/usr"; \
+		export _python_exec_prefix="/usr"; \
 		$(1) \
 		$(HOST_PYTHON3_BIN) $(2); \
 	)
 endef
+
+# These configure args are needed in detection of path to Python header files
+# using autotools.
+CONFIGURE_ARGS += \
+	_python_sysroot="$(STAGING_DIR)" \
+	_python_prefix="/usr" \
+	_python_exec_prefix="/usr"
 
 PKG_USE_MIPS16:=0
 # This is required in addition to PKG_USE_MIPS16:=0 because otherwise MIPS16


### PR DESCRIPTION
I wrote these a while ago and just rebased them on the current master branch. 

I'm not using them myself any longer, so I don't think I'll maintain them. Nevertheless, someone might need them, thus this pull request. I left the maintainer for python3-pip and python3-setuptools empty; if someone is willing to adopt these packages, I'll fill them in.