### PR TITLE
strongswan: gmpdh plugin, package and strongswan-isakmp metapackage

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.3.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.strongswan.org/ http://download2.strongswan.org/
@@ -45,6 +45,7 @@ PKG_MOD_AVAILABLE:= \
 	gcm \
 	gcrypt \
 	gmp \
+	gmpdh \
 	ha \
 	hmac \
 	kernel-libipsec \
@@ -254,6 +255,37 @@ $(call Package/strongswan/description/Default)
  This meta-package contains only dependencies to match upstream defaults.
 endef
 
+
+define Package/strongswan-isakmp
+$(call Package/strongswan/Default)
+  TITLE+= (isakmp)
+  DEPENDS:= +strongswan \
+	+strongswan-charon \
+	+strongswan-mod-aes \
+	+strongswan-mod-des \
+	+strongswan-mod-gmpdh \
+	+strongswan-mod-hmac \
+	+strongswan-mod-kernel-netlink \
+	+strongswan-mod-md5 \
+	+strongswan-mod-nonce \
+	+strongswan-mod-pubkey \
+	+strongswan-mod-random \
+	+strongswan-mod-sha1 \
+	+strongswan-mod-socket-default \
+	+strongswan-mod-stroke \
+	+strongswan-mod-uci \
+	+strongswan-mod-updown \
+	+strongswan-utils
+endef
+
+define Package/strongswan-isakmp/description
+$(call Package/strongswan/description/Default)
+ This meta-package contains only dependencies to establish  ISAKMP /
+ IKE PSK connections, dropping other capabilities in favor of small size 
+ Can fit most routers even with 4Mb flash (after removing IPv6 support).
+endef
+
+
 define Package/strongswan-minimal
 $(call Package/strongswan/Default)
   TITLE+= (minimal)
@@ -376,6 +408,10 @@ define Package/strongswan-full/install
 	true
 endef
 
+define Package/strongswan-isakmp/install
+	true
+endef
+
 define Package/strongswan-minimal/install
 	true
 endef
@@ -454,6 +490,7 @@ $(eval $(call BuildPackage,strongswan))
 $(eval $(call BuildPackage,strongswan-default))
 $(eval $(call BuildPackage,strongswan-full))
 $(eval $(call BuildPackage,strongswan-minimal))
+$(eval $(call BuildPackage,strongswan-isakmp))
 $(eval $(call BuildPackage,strongswan-charon))
 $(eval $(call BuildPackage,strongswan-utils))
 $(eval $(call BuildPackage,strongswan-libtls))
@@ -484,6 +521,7 @@ $(eval $(call BuildPlugin,fips-prf,FIPS PRF crypto,+strongswan-mod-sha1))
 $(eval $(call BuildPlugin,gcm,GCM AEAD wrapper crypto,))
 $(eval $(call BuildPlugin,gcrypt,libgcrypt,+PACKAGE_strongswan-mod-gcrypt:libgcrypt))
 $(eval $(call BuildPlugin,gmp,libgmp,+PACKAGE_strongswan-mod-gmp:libgmp))
+$(eval $(call BuildPlugin,gmpdh,DH-Groups; no libgmp dep,))
 $(eval $(call BuildPlugin,ha,high availability cluster,))
 $(eval $(call BuildPlugin,hmac,HMAC crypto,))
 $(eval $(call BuildPlugin,kernel-libipsec,libipsec kernel interface,))

--- a/net/strongswan/patches/305-minimal_dh_plugin.patch
+++ b/net/strongswan/patches/305-minimal_dh_plugin.patch
@@ -1,0 +1,221 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -135,6 +135,7 @@ ARG_DISBL_SET([fips-prf],       [disable
+ ARG_ENABL_SET([gcm],            [enables the GCM AEAD wrapper crypto plugin.])
+ ARG_ENABL_SET([gcrypt],         [enables the libgcrypt plugin.])
+ ARG_DISBL_SET([gmp],            [disable GNU MP (libgmp) based crypto implementation plugin.])
++ARG_DISBL_SET([gmpdh],          [disable GNU MP (libgmp) based static-linked crypto DH minimal implementation plugin.])
+ ARG_DISBL_SET([hmac],           [disable HMAC crypto implementation plugin.])
+ ARG_ENABL_SET([md4],            [enable MD4 software implementation plugin.])
+ ARG_DISBL_SET([md5],            [disable MD5 software implementation plugin.])
+@@ -1310,6 +1311,7 @@ ADD_PLUGIN([gcrypt],               [s ch
+ ADD_PLUGIN([af-alg],               [s charon scepclient pki scripts medsrv attest nm cmd aikgen])
+ ADD_PLUGIN([fips-prf],             [s charon nm cmd])
+ ADD_PLUGIN([gmp],                  [s charon scepclient pki scripts manager medsrv attest nm cmd aikgen])
++ADD_PLUGIN([gmpdh],                [s charon scepclient pki scripts manager medsrv attest nm cmd aikgen])
+ ADD_PLUGIN([agent],                [s charon nm cmd])
+ ADD_PLUGIN([keychain],             [s charon cmd])
+ ADD_PLUGIN([chapoly],              [s charon scripts nm cmd])
+@@ -1441,6 +1443,7 @@ AM_CONDITIONAL(USE_SHA1, test x$sha1 = x
+ AM_CONDITIONAL(USE_SHA2, test x$sha2 = xtrue)
+ AM_CONDITIONAL(USE_FIPS_PRF, test x$fips_prf = xtrue)
+ AM_CONDITIONAL(USE_GMP, test x$gmp = xtrue)
++AM_CONDITIONAL(USE_GMPDH, test x$gmpdh = xtrue)
+ AM_CONDITIONAL(USE_RDRAND, test x$rdrand = xtrue)
+ AM_CONDITIONAL(USE_AESNI, test x$aesni = xtrue)
+ AM_CONDITIONAL(USE_RANDOM, test x$random = xtrue)
+@@ -1688,6 +1691,7 @@ AC_CONFIG_FILES([
+ 	src/libstrongswan/plugins/sha2/Makefile
+ 	src/libstrongswan/plugins/fips_prf/Makefile
+ 	src/libstrongswan/plugins/gmp/Makefile
++	src/libstrongswan/plugins/gmpdh/Makefile
+ 	src/libstrongswan/plugins/rdrand/Makefile
+ 	src/libstrongswan/plugins/aesni/Makefile
+ 	src/libstrongswan/plugins/random/Makefile
+--- a/src/libstrongswan/Makefile.am
++++ b/src/libstrongswan/Makefile.am
+@@ -295,6 +295,13 @@ if MONOLITHIC
+ endif
+ endif
+ 
++if USE_GMPDH
++  SUBDIRS += plugins/gmpdh
++if MONOLITHIC
++  libstrongswan_la_LIBADD += plugins/gmpdh/libstrongswan-gmpdh.la
++endif
++endif
++
+ if USE_RDRAND
+   SUBDIRS += plugins/rdrand
+ if MONOLITHIC
+--- /dev/null
++++ b/src/libstrongswan/plugins/gmpdh/Makefile.am
+@@ -0,0 +1,19 @@
++AM_CPPFLAGS = \
++	-I$(top_srcdir)/src/libstrongswan
++
++AM_CFLAGS = \
++	$(PLUGIN_CFLAGS)
++
++if MONOLITHIC
++noinst_LTLIBRARIES = libstrongswan-gmpdh.la
++else
++plugin_LTLIBRARIES = libstrongswan-gmpdh.la
++endif
++
++libstrongswan_gmpdh_la_SOURCES = \
++	gmpdh_plugin.h gmpdh_plugin.c \
++	../gmp/gmp_diffie_hellman.c ../gmp/gmp_diffie_hellman.h 
++
++	
++libstrongswan_gmpdh_la_LDFLAGS = -module -avoid-version -Wl,-Bstatic -Wl,-lgmp -Wl,-Bdynamic -Wl,--as-needed
++libstrongswan_gmpdh_la_LIBADD  =
+--- /dev/null
++++ b/src/libstrongswan/plugins/gmpdh/gmpdh_plugin.c
+@@ -0,0 +1,101 @@
++/*
++ * Copyright (C) 2008-2009 Martin Willi
++ * Hochschule fuer Technik Rapperswil
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License as published by the
++ * Free Software Foundation; either version 2 of the License, or (at your
++ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
++ *
++ * This program is distributed in the hope that it will be useful, but
++ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
++ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * for more details.
++ */
++
++#include "gmpdh_plugin.h"
++
++#include <library.h>
++#include "../gmp/gmp_diffie_hellman.h"
++
++typedef struct private_gmpdh_plugin_t private_gmpdh_plugin_t;
++
++/**
++ * private data of gmp_plugin
++ */
++struct private_gmpdh_plugin_t {
++
++	/**
++	 * public functions
++	 */
++	gmpdh_plugin_t public;
++};
++
++METHOD(plugin_t, get_name, char*,
++	private_gmpdh_plugin_t *this)
++{
++	return "gmpdh";
++}
++
++METHOD(plugin_t, get_features, int,
++	private_gmpdh_plugin_t *this, plugin_feature_t *features[])
++{
++	static plugin_feature_t f[] = {
++		/* DH groups */
++		PLUGIN_REGISTER(DH, gmp_diffie_hellman_create),
++			PLUGIN_PROVIDE(DH, MODP_2048_BIT),
++				PLUGIN_DEPENDS(RNG, RNG_STRONG),
++			PLUGIN_PROVIDE(DH, MODP_2048_224),
++				PLUGIN_DEPENDS(RNG, RNG_STRONG),
++			PLUGIN_PROVIDE(DH, MODP_2048_256),
++				PLUGIN_DEPENDS(RNG, RNG_STRONG),
++			PLUGIN_PROVIDE(DH, MODP_1536_BIT),
++				PLUGIN_DEPENDS(RNG, RNG_STRONG),
++			PLUGIN_PROVIDE(DH, MODP_3072_BIT),
++				PLUGIN_DEPENDS(RNG, RNG_STRONG),
++			PLUGIN_PROVIDE(DH, MODP_4096_BIT),
++				PLUGIN_DEPENDS(RNG, RNG_STRONG),
++			PLUGIN_PROVIDE(DH, MODP_6144_BIT),
++				PLUGIN_DEPENDS(RNG, RNG_STRONG),
++			PLUGIN_PROVIDE(DH, MODP_8192_BIT),
++				PLUGIN_DEPENDS(RNG, RNG_STRONG),
++			PLUGIN_PROVIDE(DH, MODP_1024_BIT),
++				PLUGIN_DEPENDS(RNG, RNG_STRONG),
++			PLUGIN_PROVIDE(DH, MODP_1024_160),
++				PLUGIN_DEPENDS(RNG, RNG_STRONG),
++			PLUGIN_PROVIDE(DH, MODP_768_BIT),
++				PLUGIN_DEPENDS(RNG, RNG_STRONG),
++		PLUGIN_REGISTER(DH, gmp_diffie_hellman_create_custom),
++			PLUGIN_PROVIDE(DH, MODP_CUSTOM),
++				PLUGIN_DEPENDS(RNG, RNG_STRONG),
++	};
++	*features = f;
++	return countof(f);
++}
++
++METHOD(plugin_t, destroy, void,
++	private_gmpdh_plugin_t *this)
++{
++	free(this);
++}
++
++/*
++ * see header file
++ */
++plugin_t *gmpdh_plugin_create()
++{
++	private_gmpdh_plugin_t *this;
++
++	INIT(this,
++		.public = {
++			.plugin = {
++				.get_name = _get_name,
++				.get_features = _get_features,
++				.destroy = _destroy,
++			},
++		},
++	);
++
++	return &this->public.plugin;
++}
++
+--- /dev/null
++++ b/src/libstrongswan/plugins/gmpdh/gmpdh_plugin.h
+@@ -0,0 +1,42 @@
++/*
++ * Copyright (C) 2008 Martin Willi
++ * Hochschule fuer Technik Rapperswil
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License as published by the
++ * Free Software Foundation; either version 2 of the License, or (at your
++ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
++ *
++ * This program is distributed in the hope that it will be useful, but
++ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
++ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * for more details.
++ */
++
++/**
++ * @defgroup gmpdh_p gmpdh
++ * @ingroup plugins
++ *
++ * @defgroup gmpdh_plugin gmpdh_plugin
++ * @{ @ingroup gmpdh_p
++ */
++
++#ifndef GMPDH_PLUGIN_H_
++#define GMPDH_PLUGIN_H_
++
++#include <plugins/plugin.h>
++
++typedef struct gmpdh_plugin_t gmpdh_plugin_t;
++
++/**
++ * Plugin implementing asymmetric crypto algorithms using the GNU MP library.
++ */
++struct gmpdh_plugin_t {
++
++	/**
++	 * implements plugin interface
++	 */
++	plugin_t plugin;
++};
++
++#endif /** GMPDH_PLUGIN_H_ @}*/


### PR DESCRIPTION
gmpdh plugin implements DH Groups (same as normal GMP plugin), but links to GMP statically and is stripped of all RSA based stuff. Binary size for plugin is ~20kbytes with no dependency on libgmp (200+ kbytes after squash), easilly fitting into flash space restricted devices.

strongswan-isakmp metapackage defines a minimal set of strongswan plugins (including gmpdh) for ISAKMP / IKEv1 PSK tunnels. Will fit even 4mb routers (like tplink wr841n) with disabled IPv6 support and packages (so its a trade - IPv6 or ipsec tunnels).

Signed-of-by: Mikalai Miadzvedz <brainsucker.na@gmail.com>