### PR TITLE
libffi: fix libffi.pc file

### DIFF
--- a/libs/libffi/patches/001-fix-includedir-pkg.patch
+++ b/libs/libffi/patches/001-fix-includedir-pkg.patch
@@ -1,0 +1,11 @@
+--- a/libffi.pc.in
++++ b/libffi.pc.in
+@@ -1,7 +1,7 @@
+ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+-includedir=${libdir}/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includedir=${prefix}/include
+ 
+ Name: @PACKAGE_NAME@
+ Description: Library supporting Foreign Function Interfaces


### PR DESCRIPTION
The include dir pointed to staging_dir/target-mips_34kc+dsp_musl-1.1.11
/usr/lib/libffi-3.0.13/include which does not exists, this made glib2
fail to compile. The header files are copied to /usr/include so define
it in the libffi.pc file.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>