### PR TITLE
boost: Update 4

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -17,7 +17,7 @@ include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=boost
 PKG_VERSION:=1_59_0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/boost
@@ -34,17 +34,22 @@ PKG_USE_MIPS16:=0
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 
-# For now, the combination TARGET_mpc85xx&&USE_UCLIBC disables boost due to incompatibility
+
 define Package/boost/Default
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Boost C++ source library
   URL:=http://www.boost.org
-  DEPENDS:=@(!(TARGET_mpc85xx&&USE_UCLIBC)) +libstdcpp +libpthread +librt
+  DEPENDS:=+libstdcpp +libpthread +librt
 endef
 
 define Package/boost/description/Default
-  Boost provides free peer-reviewed portable C++ source libraries
+  true
+endef
+
+define Package/boost/description
+This package provides the Boost v1.59 libraries.
+Boost is a set of free, peer-reviewed, portable C++ source libraries.
 endef
 
 BOOST_LIBS =
@@ -72,34 +77,53 @@ define Package/boost/install
   true
 endef
 
-# For now, the combination TARGET_mpc85xx&&USE_UCLIBC disables boost due to incompatibility
+
 define Package/boost
   $(call Package/boost/Default)
   TITLE+= packages
-  DEPENDS:=@(!(TARGET_mpc85xx&&USE_UCLIBC)) +ALL:boost-libs +ALL:boost-test
+  DEPENDS:=+ALL:boost-libs +ALL:boost-test
 endef
 
 define Package/boost/config
+    menu "Select Boost Options"
+      depends on PACKAGE_boost
+      	comment "Boost compilation options."
+	    config boost-static-libs
+	    	bool "Static Libraries Only"	    	
+	    	help 
+	    		Static compile of all selected boost libraries.
+	    	default n
+	    
+	    config boost-runtime-static
+	    	bool "Use static version of C and C++ runtimes."	    	
+	    	help 
+	    		Determines if shared or static version of C and C++ runtimes should be used.
+	    	default n
+	    	select boost-static-libs
+
+	    config boost-multi-threading
+	    	bool "Multithread Support"	    	
+	    	help 
+	    		Compile Boost libraries with multithread support.
+	    	default y
+    endmenu
+
     menu "Select Boost libraries"
       depends on PACKAGE_boost
+		comment "Libraries"
+	    config boost-libs-all
+	    	bool "Include all Boost libraries"
+	    	select PACKAGE_boost-libs	    	
 
-    config boost-libs-all
-      bool "Include all Boost libraries"
-      select PACKAGE_boost-libs
-
-   config boost-test-pkg
-     bool "Boost test package"
-     select PACKAGE_boost-test
-
-    comment "Libraries"
-
-    $(foreach lib,$(BOOST_LIBS), \
-        config PACKAGE_boost-$(lib)
-           prompt "Boost $(lib) library"
-
-   )
-
-  endmenu
+		config boost-test-pkg
+	    	bool "Boost test package"
+	    	select PACKAGE_boost-test
+	    
+    	$(foreach lib,$(BOOST_LIBS), \
+        	config PACKAGE_boost-$(lib)
+        	prompt "Boost $(lib) library"
+   		)
+  	endmenu
 
 endef
 
@@ -153,18 +177,15 @@ $(eval $(call DefineBoostLibrary,iostreams,,+zlib))
 $(eval $(call DefineBoostLibrary,locale,system,$(ICONV_DEPENDS) +@BUILD_NLS))
 $(eval $(call DefineBoostLibrary,log,system chrono date_time thread filesystem regex,))
 $(eval $(call DefineBoostLibrary,math,,))
-#$(eval $(call DefineBoostLibrary,mpi,,))
+#$(eval $(call DefineBoostLibrary,mpi,,)) # OpenMPI does no exist in OpenWRT at this time.
 $(eval $(call DefineBoostLibrary,program_options,,))
 $(eval $(call DefineBoostLibrary,random,system,))
-
-# We need a beter way to provide this package, information regarding the Python packages
-#  such as Python version and directories locations. 
-# Python 2.7 version is for now hard-coded. Python 3 is (until this date) broken in the trunk tree.
 $(eval $(call DefineBoostLibrary,python,,+PACKAGE_boost-python:python))
+$(eval $(call DefineBoostLibrary,python3,,+PACKAGE_boost-python3:python3))
 $(eval $(call DefineBoostLibrary,regex,,))
 $(eval $(call DefineBoostLibrary,serialization,,))
 $(eval $(call DefineBoostLibrary,signals,,))
-$(eval $(call DefineBoostLibrary,system,,))
+$(eval $(call DefineBoostLibrary,system,,+@boost-multi-threading))
 $(eval $(call DefineBoostLibrary,thread,system chrono atomic,))
 $(eval $(call DefineBoostLibrary,timer,chrono))
 $(eval $(call DefineBoostLibrary,wave,date_time thread filesystem,))
@@ -177,7 +198,7 @@ endef
 CONFIGURE_PREFIX:=$(PKG_INSTALL_DIR)
 TARGET_LDFLAGS += -pthread -lrt
 
-TARGET_CFLAGS += $(if $(CONFIG_SOFT_FLOAT),-DBOOST_NO_FENV_H)
+TARGET_CFLAGS += $(if $(CONFIG_SOFT_FLOAT),-DBOOST_NO_FENV_H) -fPIC
 
 ifneq ($(findstring mips,$(ARCH)),)
     BOOST_ABI = o32
@@ -197,8 +218,12 @@ define Build/Compile
 	$(info Selected Boost API $(BOOST_ABI) for architecture $(ARCH) and cpu $(CPU_TYPE) $(CPU_SUBTYPE))
 	( cd $(PKG_BUILD_DIR) ; \
 		echo "using gcc : $(ARCH) : $(GNU_TARGET_NAME)-gcc : <compileflags>\"$(TARGET_CFLAGS)\" <cxxflags>\"$(TARGET_CXXFLAGS)\" <linkflags>\"$(TARGET_LDFLAGS)\" ;" > tools/build/src/user-config.jam ; \
+		$(if $(CONFIG_PACKAGE_boost-python3), \
+			echo "using python : 3.5 : $(STAGING_DIR_ROOT)/usr/bin/python3 : $(STAGING_DIR)/usr/include/python3.5/ ;" >> \
+				tools/build/src/user-config.jam; \
+		) \
 		$(if $(CONFIG_PACKAGE_boost-python), \
-			echo "using python : : $(STAGING_DIR_ROOT)/usr/bin/python :	$(STAGING_DIR)/usr/include/python2.7/ ;" >> \
+			echo "using python : 2.7 : $(STAGING_DIR_ROOT)/usr/bin/python2 :	$(STAGING_DIR)/usr/include/python2.7/ ;" >> \
 				tools/build/src/user-config.jam; \
 		) \
 		bjam \
@@ -206,13 +231,16 @@ define Build/Compile
 			--ignore-site-config \
 			--toolset=gcc-$(ARCH) --build-type=minimal --layout=system abi=$(BOOST_ABI) \
 			--disable-long-double \
+			$(if $(CONFIG_boost-static-libs),link=static,link=shared) \
+			$(if $(CONFIG_boost-runtime-static),runtime-link=static,runtime-link=shared) \
+			$(if $(CONFIG_boost-multi-threading),threading=multi,threading=single) \
 			$(CONFIGURE_ARGS) \
 			--without-mpi \
 			$(if $(CONFIG_PACKAGE_boost-test),,--without-test) \
 			$(foreach lib,$(BOOST_LIBS), \
 				$(if $(CONFIG_PACKAGE_boost-$(lib)),,--without-$(lib)) \
 			) \
-			$(if $(CONFIG_PACKAGE_boost-locale),boost.locale.iconv=on -sICONV_PATH=$(ICONV_PREFIX) boost.locale.posix=$(if $(USE_UCLIBC),on,off), \
+			$(if $(CONFIG_PACKAGE_boost-locale),boost.locale.iconv=on -sICONV_PATH=$(ICONV_PREFIX) boost.locale.posix=$(if $(USE_MUSL),on,off), \
 				boost.locale.iconv=off) \
 			\
 			$(if $(CONFIG_PACKAGE_boost-iostreams),-sNO_BZIP2=1 -sZLIB_INCLUDE=$(STAGING_DIR)/usr/include \
@@ -231,8 +259,8 @@ define Build/InstallDev
 		# copies _all_ header files - independent of <--with-library>-argument above
 
 	$(INSTALL_DIR) $(1)/usr/lib
-	-$(CP) $(PKG_INSTALL_DIR)/lib/*.a $(1)/usr/lib/
-	-$(CP) $(PKG_INSTALL_DIR)/lib/*.so* $(1)/usr/lib/
+	$(CP) -v $(PKG_INSTALL_DIR)/lib/*.a $(1)/usr/lib/ # copies all compiled archive files 	
+	$(FIND) $(PKG_INSTALL_DIR)/lib/ -name '*.so*' -exec $(CP) {} $(1)/usr/lib/ \; # copies all the shared objects files
 endef
 
 define Host/Install
@@ -248,22 +276,19 @@ define Package/boost/Default/install
 	$(INSTALL_DIR) \
 		$(1)/usr/lib
 
-	$(CP) \
-		$(PKG_INSTALL_DIR)/lib/libboost_$(2)*.so* \
-		$(1)/usr/lib/
+	$(FIND) \
+		$(PKG_INSTALL_DIR)/lib/ -name 'libboost_$(2)*.so*' -exec $(CP) {} $(1)/usr/lib/ \;
 endef
 
-define Package/boost-test/install
-	$(INSTALL_DIR) \
-		$(1)/usr/lib
+define Package/boost-test/install	
+		$(INSTALL_DIR) \
+			$(1)/usr/lib
 
-	$(CP) \
-		$(PKG_INSTALL_DIR)/lib/libboost_unit_test_framework*.so* \
-		$(1)/usr/lib/
-
-	$(CP) \
-		$(PKG_INSTALL_DIR)/lib/libboost_prg_exec_monitor*.so* \
-		$(1)/usr/lib/
+		$(FIND) \
+			$(PKG_INSTALL_DIR)/lib/ -name 'libboost_unit_test_framework*.so*' -exec $(CP) {} $(1)/usr/lib/ \;
+		
+		$(FIND) \
+			$(PKG_INSTALL_DIR)/lib/ -name 'libboost_prg_exec_monitor*.so*' -exec $(CP) {} $(1)/usr/lib/ \;	
 endef
 
 define BuildBoostLibrary


### PR DESCRIPTION
Major Updates
- Added support for Python 3.5.
- Removed the restriction for the target MPC85xx when using uclibc [1].
  - No longer required since uclibc was removed from trunk.
- Added option to force static compilation.
- Added option to force linking statically to the C++ standard library and compiler runtime support libraries.
- Added option to disable multithreading support. It can be helpfull for those who wish to fully optimise their code.
  - Some boost libraries will require multithreading to be active. For those, this option is active as a requirement.

Minor Updates
- Added -fPIC to CFLags [2].
  - python requires independent position code for static linking.

  References:
  [1] - https://github.com/openwrt/packages/issues/1621
  [2] - https://github.com/openwrt/packages/issues/1938

Signed-off-by: Carlos M. Ferreira <carlosmf.pt@gmail.com>