### PR TITLE
lispmob: fix build with musl

### DIFF
--- a/net/lispmob/patches/001-fix-musl-build.patch
+++ b/net/lispmob/patches/001-fix-musl-build.patch
@@ -1,0 +1,31 @@
+--- a/lispd/lispd_output.c
++++ b/lispd/lispd_output.c
+@@ -26,6 +26,7 @@
+  *    Alberto Rodriguez Natal <arnatal@ac.upc.edu>
+  */
+ 
++#define _GNU_SOURCE 1
+ 
+ 
+ #include <assert.h>
+--- a/lispd/lispd_input.c
++++ b/lispd/lispd_input.c
+@@ -26,6 +26,7 @@
+  *    Alberto Rodriguez Natal <arnatal@ac.upc.edu>
+  */
+ 
++#define _GNU_SOURCE 1
+ 
+ #include "lispd_input.h"
+ #include "lispd_map_notify.h"
+--- a/lispd/lispd_pkt_lib.c
++++ b/lispd/lispd_pkt_lib.c
+@@ -28,6 +28,8 @@
+  *
+  */
+ 
++#define _GNU_SOURCE 1
++
+ #include "lispd_afi.h"
+ #include "lispd_pkt_lib.h"
+ #include "lispd_lib.h"


### PR DESCRIPTION
lispmob accesses the gnu members of struct udphdr like source and dest
and does not use the posix member names. Instead of using the correct
names just define this as _GNU_SOURCE.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>