### PR TITLE
libffi: fix host build

### DIFF
--- a/libs/libffi/Makefile
+++ b/libs/libffi/Makefile
@@ -66,7 +66,7 @@ define Build/InstallDev
 
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/libffi-$(PKG_VERSION)/include/*.h \
+		$(PKG_INSTALL_DIR)/usr/include/*.h \
 		$(1)/usr/include/
 endef
 

--- a/libs/libffi/patches/001-fix-includedir-pkg.patch
+++ b/libs/libffi/patches/001-fix-includedir-pkg.patch
@@ -1,11 +1,36 @@
 --- a/libffi.pc.in
 +++ b/libffi.pc.in
-@@ -1,7 +1,7 @@
+@@ -1,10 +1,10 @@
  prefix=@prefix@
  exec_prefix=@exec_prefix@
  libdir=@libdir@
 -includedir=${libdir}/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
-+includedir=${prefix}/include
++includedir=@includedir@
  
  Name: @PACKAGE_NAME@
  Description: Library supporting Foreign Function Interfaces
+ Version: @PACKAGE_VERSION@
+-Libs: -L${libdir} -lffi
+-Cflags: -I${includedir}
++Libs: -lffi
++Cflags:
+--- a/include/Makefile.am
++++ b/include/Makefile.am
+@@ -5,5 +5,5 @@ AUTOMAKE_OPTIONS=foreign
+ DISTCLEANFILES=ffitarget.h
+ EXTRA_DIST=ffi.h.in ffi_common.h
+ 
+-includesdir = $(libdir)/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includesdir = $(includedir)
+ nodist_includes_HEADERS = ffi.h ffitarget.h
+--- a/include/Makefile.in
++++ b/include/Makefile.in
+@@ -250,7 +250,7 @@ top_srcdir = @top_srcdir@
+ AUTOMAKE_OPTIONS = foreign
+ DISTCLEANFILES = ffitarget.h
+ EXTRA_DIST = ffi.h.in ffi_common.h
+-includesdir = $(libdir)/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includesdir = $(includedir)
+ nodist_includes_HEADERS = ffi.h ffitarget.h
+ all: all-am
+ 


### PR DESCRIPTION
My last commit c1137b6db7c461ddc3d2ddac674ba73bc1579918 "libffi: fix
libffi.pc file" broke the host build as that still placed the header
files to /usr/lib/libffi-3.0.13/include/ and the libffi.pc file pointed
to /usr/include/ . With this patch I took the patch from Debian and
also made the install process to put the header files to /usr/include
in all situations.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>