### PR TITLE
libpng: update to 1.2.54

### DIFF
--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpng
-PKG_VERSION:=1.2.52
+PKG_VERSION:=1.2.54
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/libpng
-PKG_MD5SUM:=49d5c71929bf69a172147c47b9309fbe
+PKG_MD5SUM:=bbb7a7264f1c7d9c444fd16bf6f89832
 PKG_MAINTAINER:=Jo-Philipp Wich <jow@openwrt.org>
 
 PKG_LICENSE:=Libpng GPL-2.0+ BSD-3-Clause


### PR DESCRIPTION
Includes fixes for CVE-2015-7981 and CVE-2015-8126.

As this contains security fixes should it be cherry-picked into for-15.05 as well?