### PR TITLE
boost: Update 5

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -17,7 +17,7 @@ include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=boost
 PKG_VERSION:=1_59_0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/boost
@@ -112,17 +112,32 @@ define Package/boost/config
       depends on PACKAGE_boost
 		comment "Libraries"
 	    config boost-libs-all
-	    	bool "Include all Boost libraries"
+	    	bool "Include all Boost libraries."
 	    	select PACKAGE_boost-libs	    	
 
 		config boost-test-pkg
-	    	bool "Boost test package"
+	    	bool "Boost test package."
 	    	select PACKAGE_boost-test
 	    
     	$(foreach lib,$(BOOST_LIBS), \
         	config PACKAGE_boost-$(lib)
-        	prompt "Boost $(lib) library"
+        	prompt "Boost $(lib) library."
    		)
+   		config PACKAGE_boost-python
+   			prompt "Boost python 2.7 library."
+
+		config PACKAGE_boost-python3
+   			prompt "Boost python 3.5 library."
+		
+		config boost-coroutine2
+   			bool "Boost couroutine2 support."
+			select PACKAGE_boost-coroutine
+			default n
+   		
+   		config boost-graph-parallel
+   			bool "Boost parallel graph support."
+   			select PACKAGE_boost-graph
+   			default n
   	endmenu
 
 endef
@@ -163,6 +178,7 @@ define DefineBoostLibrary
   endef
 endef
 
+
 $(eval $(call DefineBoostLibrary,atomic,system,))
 $(eval $(call DefineBoostLibrary,chrono,system,))
 $(eval $(call DefineBoostLibrary,container,,))
@@ -180,8 +196,6 @@ $(eval $(call DefineBoostLibrary,math,,))
 #$(eval $(call DefineBoostLibrary,mpi,,)) # OpenMPI does no exist in OpenWRT at this time.
 $(eval $(call DefineBoostLibrary,program_options,,))
 $(eval $(call DefineBoostLibrary,random,system,))
-$(eval $(call DefineBoostLibrary,python,,+PACKAGE_boost-python:python))
-$(eval $(call DefineBoostLibrary,python3,,+PACKAGE_boost-python3:python3))
 $(eval $(call DefineBoostLibrary,regex,,))
 $(eval $(call DefineBoostLibrary,serialization,,))
 $(eval $(call DefineBoostLibrary,signals,,))
@@ -189,6 +203,45 @@ $(eval $(call DefineBoostLibrary,system,,+@boost-multi-threading))
 $(eval $(call DefineBoostLibrary,thread,system chrono atomic,))
 $(eval $(call DefineBoostLibrary,timer,chrono))
 $(eval $(call DefineBoostLibrary,wave,date_time thread filesystem,))
+
+
+# Boost.python package configuration for Python 2.7
+BOOST_DEPENDS+= +boost-python
+PKG_CONFIG_DEPENDS+= CONFIG_PACKAGE_boost-python
+
+define Package/boost-python
+$(call Package/boost/Default)
+TITLE+= (python2)
+DEPENDS+= +PACKAGE_python
+HIDDEN:=1
+endef
+
+define Package/boost-python/description
+$(call Package/boost/description/Default)
+.
+This package contains the boost.python for Python 2.7 library.
+endef
+##
+
+
+# Boost.python package configuration for Python 3.5
+BOOST_DEPENDS+= +boost-python3
+PKG_CONFIG_DEPENDS+= CONFIG_PACKAGE_boost-python3
+
+define Package/boost-python3
+$(call Package/boost/Default)
+TITLE+= (python3)
+DEPENDS+= +PACKAGE_python3
+HIDDEN:=1
+endef
+
+define Package/boost-python3/description
+$(call Package/boost/description/Default)
+.
+This package contains the boost.python for Python 3.5 library.
+endef
+##
+
 
 define Host/Compile
 	# bjam does not provide a configure-script nor a Makefile
@@ -223,7 +276,7 @@ define Build/Compile
 				tools/build/src/user-config.jam; \
 		) \
 		$(if $(CONFIG_PACKAGE_boost-python), \
-			echo "using python : 2.7 : $(STAGING_DIR_ROOT)/usr/bin/python2 :	$(STAGING_DIR)/usr/include/python2.7/ ;" >> \
+			echo "using python : 2.7 : $(STAGING_DIR_ROOT)/usr/bin/python :	$(STAGING_DIR)/usr/include/python2.7/ ;" >> \
 				tools/build/src/user-config.jam; \
 		) \
 		bjam \
@@ -236,6 +289,9 @@ define Build/Compile
 			$(if $(CONFIG_boost-multi-threading),threading=multi,threading=single) \
 			$(CONFIGURE_ARGS) \
 			--without-mpi \
+			$(if $(CONFIG_boost-coroutine2),,--without-coroutine2) \
+			$(if $(CONFIG_boost-graph-parallel),,--without-graph_parallel) \
+			$(if $(CONFIG_PACKAGE_boost-python),,$(if $(CONFIG_PACKAGE_boost-python3),,--without-python)) \
 			$(if $(CONFIG_PACKAGE_boost-test),,--without-test) \
 			$(foreach lib,$(BOOST_LIBS), \
 				$(if $(CONFIG_PACKAGE_boost-$(lib)),,--without-$(lib)) \
@@ -302,6 +358,8 @@ endef
 $(eval $(call HostBuild))
 
 $(foreach lib,$(BOOST_LIBS),$(eval $(call BuildBoostLibrary,$(lib))))
+$(eval $(call BuildBoostLibrary,python))
+$(eval $(call BuildBoostLibrary,python3))
 $(eval $(call BuildPackage,boost-test))
 
 $(eval $(call BuildPackage,boost-libs))


### PR DESCRIPTION
Minor Fixes:
 - Fixed bug related to Python 3.5 support. [1]
   - "--without-python3" was being issued when it should only be
     "--without-python".
   - "--without-python" is only issued in the event of neither Python 3.5
     support neither Python 2.7 support is requested.
 - Fixed an old bug related to coroutine2 support (added selector).
   - "--without-coroutin2" was not being issued, even when boost-coroutine was
     not selected. Because of that, the boost building system was compiling
     boost- coroutine and all of its dependencies.
 - Added selector for boost-graph-parallel.

 References:
 [1] - https://github.com/openwrt/packages/commit/8f7e09026d9a2edd25c87e66fb0f53035a42f3e3#commitcomment-14542816

Signed-off-by: Carlos M. Ferreira <carlosmf.pt@gmail.com>