### PR TITLE
python: add missing host build dependency on expat/host

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -29,7 +29,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/Python-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/Python-$(PKG_VERSION)
 
 PKG_BUILD_DEPENDS:=python/host
-HOST_BUILD_DEPENDS:=bzip2/host
+HOST_BUILD_DEPENDS:=bzip2/host expat/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Since 94f87dc1, host build of Python depends on expat installed in host staging directory. However, pyexpat extension fails to build if expat was not built and installed to staging dir before - adding host build dependency should fix this.

This is related to #1631 (as I've also had issues with glib2 host-build).