### PR TITLE
bandwidthd: fix build with gcc5

### DIFF
--- a/utils/bandwidthd/Makefile
+++ b/utils/bandwidthd/Makefile
@@ -82,7 +82,7 @@ CONFIGURE_ARGS += \
         ac_cv_file__usr_local_pgsql_include=no
 endif
 
-EXTRA_CFLAGS+= $(TARGET_CPPFLAGS)
+EXTRA_CFLAGS+= $(TARGET_CPPFLAGS) -std=gnu89
 EXTRA_LDFLAGS+= $(TARGET_LDFLAGS) -Wl,-rpath-link,$(STAGING_DIR)/usr/lib
 
 define Package/bandwidthd/install

--- a/utils/bandwidthd/files/bandwidthd.init
+++ b/utils/bandwidthd/files/bandwidthd.init
@@ -1,5 +1,5 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2008-2011 OpenWrt.org
+# Copyright (C) 2008-2015 OpenWrt.org
 
 START=99
 


### PR DESCRIPTION
This is a small fix to allow the package to compile with gcc5
Addition of the -std=gnu89 CFLAGS.
Small correction of the copyright date of file bandwidthd.init

Signed-off-by: Jean-Michel Lacroix <lacroix@lepine-lacroix.info>