### PR TITLE
adblock: reduce memory consumption

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=0.21.0
+PKG_VERSION:=0.22.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dirk@brenken.org>
@@ -23,7 +23,7 @@ define Package/$(PKG_NAME)
 endef
 
 define Package/$(PKG_NAME)/description
-powerful adblock script to block ad/abuse domains
+Powerful adblock script to block ad/abuse domains
 When the dns server on your router receives dns requests, we will sort out queries that ask for the [A]
 resource records of ad servers and return the local ip address of your router and the internal web server
 delivers a transparent pixel instead.
@@ -37,6 +37,8 @@ The script supports the following domain blacklist sites:
   http://www.shallalist.de
   http://www.spam404.com
   http://winhelp2002.mvps.org
+
+Please read README.md in /etc/adblock for further information.
 
 endef
 

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -10,15 +10,15 @@ and return the local ip address of your router and the internal web server deliv
 
 ## Main Features
 * support of the following domain blacklist sites (free for private usage, for commercial use please check their individual licenses):
-    * [pgl.yoyo.org](http://pgl.yoyo.org/adservers)
-    * [malwaredomains.com](http://malwaredomains.com)
-    * [zeustracker.abuse.ch](https://zeustracker.abuse.ch)
-    * [feodotracker.abuse.ch](https://feodotracker.abuse.ch)
-    * [palevotracker.abuse.ch](https://palevotracker.abuse.ch)
-    * [dshield.org](http://dshield.org)
-    * [shallalist.de](http://www.shallalist.de) (tested with the categories "adv" "costtraps" "downloads" "spyware" "tracker" "warez")
-    * [spam404.com](http://www.spam404.com)
-    * [winhelp2002.mvps.org](http://winhelp2002.mvps.org)
+    * [pgl.yoyo.org](http://pgl.yoyo.org/adservers), approx. 2.500 entries
+    * [malwaredomains.com](http://malwaredomains.com), approx. 16.000 entries
+    * [zeustracker.abuse.ch](https://zeustracker.abuse.ch), currently down
+    * [feodotracker.abuse.ch](https://feodotracker.abuse.ch), approx. 10 entries
+    * [palevotracker.abuse.ch](https://palevotracker.abuse.ch), approx. 10 entries
+    * [dshield.org](http://dshield.org), approx. 4.500 entries
+    * [shallalist.de](http://www.shallalist.de) (tested with the categories "adv" "costtraps" "downloads" "spyware" "tracker" "warez"), approx. 37.000 entries
+    * [spam404.com](http://www.spam404.com), approx. 5.000 entries
+    * [winhelp2002.mvps.org](http://winhelp2002.mvps.org), approx. 15.000 entries
 * blocklist parsing by fast & flexible regex rulesets
 * additional white- and blacklist support for manual overrides
 * separate dynamic adblock network interface
@@ -34,24 +34,26 @@ and return the local ip address of your router and the internal web server deliv
 * additional software packages:
     * curl
     * wget (due to an openwrt bug still needed for certain https requests - see ticket #19621)
-    * busybox find with *-mtime* support for logfile housekeeping (enabled by default with r47362, will be disabled if not found)
-* optional: mounted usb stick or any other storage device to overcome limited memory resources on embedded router devices
-* the above dependencies will be checked during package installation & script startup, please check console output or *logread -e "adblock"* for errors
+    * optional: busybox find with *-mtime* support for logfile housekeeping (enabled by default with r47362, will be disabled if not found)
+    * optional: coreutils-sort for reliable sort results, even on low memory systems
+* recommended: add an usb stick or any other storage device to supersize your /tmp directory with a swap partition (see [openwrt wiki](https://wiki.openwrt.org/doc/uci/fstab))
+* the above dependencies and requirements will be checked during package installation & script startup, please check console output or *logread -e "adblock"* for errors
 
 ## Usage
 * select & install adblock package (*opkg install adblock*)
 * configure /etc/config/adblock to your needs, see additional comments in *adblock.conf.sample*
-* by default openwrt uhttpd config is bind to 0.0.0.0 (to all ports of your router). For a working adblock configuration you have to bind uHTTPd to the standard LAN port only, please change *listen_http* and *listen_https* accordingly
+* at least configure the ip address of the local adblock interface/uhttpd instance, needs to be a different subnet from the normal LAN
+* by default openwrts main uhttpd instance is bind to all ports of your router. For a working adblock setup you have to bind uhttpd to the standard LAN port only, please change listen_http accordingly
 * start /usr/bin/adblock-update.sh and check console output or *logread -e "adblock"* for errors
 
 ## Distributed samples
-* all sample configuration files stored in */etc/adblock/samples*.
-* to enable/disable additional domain query logging set the dnsmasq option *logqueries* accordingly, see *dhcp.config.sample*.
+* all sample configuration files stored in */etc/adblock/samples*
+* to enable/disable additional domain query logging set the dnsmasq option *logqueries* accordingly, see *dhcp.config.sample*
 * to bind uhttpd to standard LAN port only, see *uhttpd.config.sample*
-* for script autostart by rc.local and /tmp resizing on the fly see *rc.local.sample*.
-* for scheduled call of *adblock-update.sh* see *root.crontab.sample*.
-* to redirect/force all dns queries to your router see *firwall.user.sample*.
-* for further dnsmasq tweaks see *dnsmasq.conf.sample*.
+* for script autostart by rc.local and /tmp resizing on the fly see *rc.local.sample*
+* for scheduled call of *adblock-update.sh* see *root.crontab.sample*
+* to redirect/force all dns queries to your router see *firwall.user.sample*
+* for further dnsmasq tweaks see *dnsmasq.conf.sample*
 
 ## Examples
 

--- a/net/adblock/files/adblock.conf
+++ b/net/adblock/files/adblock.conf
@@ -2,12 +2,7 @@
 #
 config adblock "global"
 	option adb_ip "192.168.2.1"
-	option adb_dev "eth0"
-	option adb_if "adblock"
 	option adb_domain "heise.de"
-	option adb_minspace "20000"
-	option adb_maxloop "5"
-	option adb_maxtime "60"
 	option adb_blacklist "/etc/adblock/adblock.blacklist"
 	option adb_whitelist "/etc/adblock/adblock.whitelist"
 
@@ -17,10 +12,6 @@ config service "wancheck"
 
 config service "ntpcheck"
 	option enabled "0"
-	list adb_ntplist "0.pool.ntp.org"
-	list adb_ntplist "1.pool.ntp.org"
-	list adb_ntplist "2.pool.ntp.org"
-	list adb_ntplist "3.pool.ntp.org"
 
 config service "backup"
 	option enabled "0"

--- a/net/adblock/files/samples/adblock.conf.sample
+++ b/net/adblock/files/samples/adblock.conf.sample
@@ -8,26 +8,9 @@ config adblock "global"
 	# needs to be a different subnet from the normal LAN
 	option adb_ip "192.168.2.1"
 	
-	# name of the physical adblock network device (check /sys/class/net/<dev>),
-	# should point to the default lan interface
-	option adb_dev "eth0"
-	
-	# name of the adblock network interface and uhttpd instance
-	option adb_if "adblock"
-	
 	# name of an "always accessible" domain,
 	# this domain will be used for the final nslookup check
 	option adb_domain "heise.de"
-	
-	# minimum required space for adlist, backups & logfiles (in kbyte)
-	# if you don't use all adblock sources, you can reduce this value accordingly
-	option adb_minspace "20000"
-	
-	# number of retries for wancheck and ntpcheck (see below)
-	option adb_maxloop "5"
-	
-	# download timeout for every adblock source (in seconds)
-	option adb_maxtime "60"
 	
 	# full path to static domain blacklist file (one domain per line)
 	option adb_blacklist "/etc/adblock/adblock.blacklist"
@@ -35,24 +18,19 @@ config adblock "global"
 	# full path to static domain whitelist file (one domain per line)
 	option adb_whitelist "/etc/adblock/adblock.whitelist"
 
-# list of devices that are allowed for adblock updates (check /sys/class/net/<dev>),
-# if no one found the last adlist backup will be used,
-# useful for (mobile) multiwan setups
+# list of wan devices that are allowed for adblock updates (check /sys/class/net/<dev>),
+# if no one found the last adlist backup will be restored,
+# useful only for (mobile) multiwan setups
 # disabled by default
 config service "wancheck"
 	option enabled "0"
 	list adb_wanlist "wan"
 
-# list of ntp time server pools,
 # check that ntp has adjusted the system time on this device,
 # will be used for logfile writing and logfile housekeeping
 # disabled by default
 config service "ntpcheck"
 	option enabled "0"
-	list adb_ntplist "0.pool.ntp.org"
-	list adb_ntplist "1.pool.ntp.org"
-	list adb_ntplist "2.pool.ntp.org"
-	list adb_ntplist "3.pool.ntp.org"
 
 # full path to backup file for adlist backups
 # disabled by default

--- a/net/adblock/files/samples/uhttpd.config.sample
+++ b/net/adblock/files/samples/uhttpd.config.sample
@@ -1,3 +1,4 @@
+# main uhttpd instance listens only to internal LAN
+#
     config uhttpd 'main'
             list listen_http '192.168.1.1:80'
-            list listen_https '192.168.1.1:443'


### PR DESCRIPTION
* rework shallalist processing: significantly reduce memory consumption during archive extraction and merging.
* considerable reduce memory consumption during adblock source processing.
* considerable reduce memory consumption of sort (sorts only the domain list and not the bigger dnsmasq file)

other changes:
* auto detection/defaults for adb_if, adb_dev, adb_ntpsrv, adb_maxloop, adb_maxtime and adb_minspace - these options can be safely removed from previous adblock configuration file
* check total memory and main uhttpd configuration on startup
* documentation update

Signed-off-by: Dirk Brenken <dirk@brenken.org>