### PR TITLE
python-pycparser: add host compile/install

### DIFF
--- a/lang/python-pycparser/Makefile
+++ b/lang/python-pycparser/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pycparser
 PKG_VERSION:=2.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pycparser

--- a/lang/python-pycparser/Makefile
+++ b/lang/python-pycparser/Makefile
@@ -42,11 +42,6 @@ module designed to be easily integrated into applications that need to parse
 C source code.
 endef
 
-define PyPackage/python-pycparser/filespec
-+|$(PYTHON_PKG_DIR)
--|$(PYTHON_PKG_DIR)/pycparser/ply
-endef
-
 define Build/Compile
 	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
 endef

--- a/lang/python-pycparser/Makefile
+++ b/lang/python-pycparser/Makefile
@@ -16,13 +16,16 @@ PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pycparser
 PKG_MD5SUM:=a2bc8d28c923b4fe2b2c3b4b51a4f935
 
 PKG_BUILD_DEPENDS:=python python-setuptools
+HOST_BUILD_DEPENDS:=python/host python-setuptools/host python-ply/host
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
+$(call include_mk, python-host.mk)
 
 define Package/python-pycparser
 	SECTION:=lang
@@ -45,8 +48,17 @@ define PyPackage/python-pycparser/filespec
 endef
 
 define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
 endef
+
+define Host/Compile
+	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOST)")
+endef
+
+define Host/Install
+endef
+
+$(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-pycparser))
 $(eval $(call BuildPackage,python-pycparser))


### PR DESCRIPTION
This depends on:

- python-setuptools host install (#1985)
- python-ply host install (#2032)

Signed-off-by: Jeffery To <jeffery.to@gmail.com>