### PR TITLE
python-cffi: add host compile/install, upgrade to 1.3.1

### DIFF
--- a/lang/python-cffi/Makefile
+++ b/lang/python-cffi/Makefile
@@ -8,21 +8,24 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cffi
-PKG_VERSION:=1.3.0
+PKG_VERSION:=1.3.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/source/c/cffi
-PKG_MD5SUM:=a40ed8c8ac653c8fc7d5603711b06eaf
+PKG_MD5SUM:=deeba7c1fd32a66f1db587988d760c11
 
 PKG_BUILD_DEPENDS:=python python-setuptools
+HOST_BUILD_DEPENDS:=libffi/host python/host python-setuptools/host python-pycparser/host
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
+$(call include_mk, python-host.mk)
 
 define Package/python-cffi
 	SECTION:=lang
@@ -38,8 +41,17 @@ Foreign Function Interface for Python calling C code.
 endef
 
 define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
 endef
+
+define Host/Compile
+	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOST)")
+endef
+
+define Host/Install
+endef
+
+$(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-cffi))
 $(eval $(call BuildPackage,python-cffi))


### PR DESCRIPTION
This depends on:

- python-setuptools host install (#1985)
- python-pycparser host install (#2033)

Signed-off-by: Jeffery To <jeffery.to@gmail.com>