### PR TITLE
python-pyopenssl: new package

### DIFF
--- a/lang/python-pyopenssl/Makefile
+++ b/lang/python-pyopenssl/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pyOpenSSL
+PKG_VERSION:=0.15.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pyOpenSSL
+PKG_MD5SUM:=f447644afcbd5f0a1f47350fec63a4c6
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/python-pyopenssl
+	SECTION:=lang
+	CATEGORY:=Languages
+	SUBMENU:=Python
+	TITLE:=python-pyopenssl
+	URL:=https://github.com/pyca/pyopenssl
+	DEPENDS:=+python-light +python-cryptography +python-six
+endef
+
+define Package/python-pyopenssl/description
+Python wrapper module around the OpenSSL library
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
+endef
+
+$(eval $(call PyPackage,python-pyopenssl))
+$(eval $(call BuildPackage,python-pyopenssl))

--- a/lang/python-pyopenssl/patches/001-omit-tests.patch
+++ b/lang/python-pyopenssl/patches/001-omit-tests.patch
@@ -1,0 +1,27 @@
+diff --git a/setup.py b/setup.py
+index c376f87..6444fac 100755
+--- a/setup.py
++++ b/setup.py
+@@ -22,14 +22,7 @@ setup(name='pyOpenSSL', version=__version__,
+                      'OpenSSL.rand',
+                      'OpenSSL.crypto',
+                      'OpenSSL.SSL',
+-                     'OpenSSL.version',
+-                     'OpenSSL.test.__init__',
+-                     'OpenSSL.test.util',
+-                     'OpenSSL.test.test_crypto',
+-                     'OpenSSL.test.test_rand',
+-                     'OpenSSL.test.test_ssl',
+-                     'OpenSSL.test.test_tsafe',
+-                     'OpenSSL.test.test_util',],
++                     'OpenSSL.version',],
+       description = 'Python wrapper module around the OpenSSL library',
+       author = 'Jean-Paul Calderone',
+       author_email = 'exarkun@twistedmatrix.com',
+@@ -74,5 +67,4 @@ High-level wrapper around a subset of the OpenSSL library, includes
+         'Topic :: Security :: Cryptography',
+         'Topic :: Software Development :: Libraries :: Python Modules',
+         'Topic :: System :: Networking',
+-        ],
+-      test_suite="OpenSSL")
++        ])


### PR DESCRIPTION
From the package description:

Python wrapper module around the OpenSSL library

This depends on python-cryptography (#2035)

Signed-off-by: Jeffery To <jeffery.to@gmail.com>