### PR TITLE
python-characteristic: add new package

### DIFF
--- a/lang/python-characteristic/Makefile
+++ b/lang/python-characteristic/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=characteristic
+PKG_VERSION:=14.3.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/c/characteristic
+PKG_MD5SUM:=b249368dd021fde1c06b4802867c0913
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/python-characteristic
+	SECTION:=lang
+	CATEGORY:=Languages
+	SUBMENU:=Python
+	TITLE:=python-characteristic
+	URL:=https://characteristic.readthedocs.org/
+	DEPENDS:=+python-light
+endef
+
+define Package/python-characteristic/description
+characteristic is an MIT-licensed Python package with class decorators
+that ease the chores of implementing the most common attribute-related
+object protocols.
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
+endef
+
+$(eval $(call PyPackage,python-characteristic))
+$(eval $(call BuildPackage,python-characteristic))

--- a/lang/python-characteristic/patches/001-omit-tests.patch
+++ b/lang/python-characteristic/patches/001-omit-tests.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 46ce3da..1760cd7 100644
+--- a/setup.py
++++ b/setup.py
+@@ -61,7 +61,7 @@ if __name__ == "__main__":
+         license="MIT",
+         author="Hynek Schlawack",
+         author_email="hs@ox.cx",
+-        py_modules=["characteristic", "test_characteristic"],
++        py_modules=["characteristic"],
+         classifiers=[
+             "Development Status :: 5 - Production/Stable",
+             "Intended Audience :: Developers",


### PR DESCRIPTION
From the README:

characteristic is an MIT-licensed Python package with class decorators
that ease the chores of implementing the most common attribute-related
object protocols.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>