### PR TITLE
python-service-identity: new package

### DIFF
--- a/lang/python-service-identity/Makefile
+++ b/lang/python-service-identity/Makefile
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=service_identity
+PKG_VERSION:=16.0.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/s/service_identity
+PKG_MD5SUM:=d52392597b9c44a740abf322bfdb21e6
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/python-service-identity
+	SECTION:=lang
+	CATEGORY:=Languages
+	SUBMENU:=Python
+	TITLE:=python-service-identity
+	URL:=https://github.com/pyca/service_identity
+	DEPENDS:=+python-light +python-attrs +python-pyasn1 +python-pyasn1-modules +python-pyopenssl
+endef
+
+define Package/python-service-identity/description
+service_identity aspires to give you all the tools you need for
+verifying whether a certificate is valid for the intended purposes.
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
+endef
+
+$(eval $(call PyPackage,python-service-identity))
+$(eval $(call BuildPackage,python-service-identity))


### PR DESCRIPTION
From the README:

service_identity aspires to give you all the tools you need for
verifying whether a certificate is valid for the intended purposes.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>