### PR TITLE
openssh: remove dsa and add ecdsa + ed25519 to initial keygen.

### DIFF
--- a/net/openssh/files/sshd.init
+++ b/net/openssh/files/sshd.init
@@ -8,7 +8,7 @@ USE_PROCD=1
 PROG=/usr/sbin/sshd
 
 start_service() {
-	for type in rsa dsa; do {
+	for type in rsa ecdsa ed25519; do {
 		# check for keys
 		key=/etc/ssh/ssh_host_${type}_key
 		[ ! -f $key ] && {


### PR DESCRIPTION
OpenSSH 5.7 introduced ECDSA 
OpenSSH 6.5 introduced ed25519
OpenSSH 7.0 disabled DSA keys at runtime by default.

This change reflects all of that.