### PR TITLE
twisted: import from old packages feed

### DIFF
--- a/lang/twisted/Makefile
+++ b/lang/twisted/Makefile
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2006-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=twisted
+PKG_VERSION:=16.0.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=Twisted-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/T/Twisted \
+		http://twistedmatrix.com/Releases/Twisted/16.0
+PKG_MD5SUM:=c6aa35e9a1e40fce6797247f39647d2a
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/Twisted-$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=python python-setuptools USE_MUSL:librpc
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/twisted
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Python networking engine
+  URL:=http://twistedmatrix.com/
+  DEPENDS:=+python-light +zope-interface
+endef
+
+define Package/twisted/description
+ Twisted is a networking engine written in Python, supporting numerous
+ protocols. It contains a web server, numerous chat clients, chat servers,
+ mail servers, and more.
+endef
+
+define PyPackage/twisted/filespec
++|/usr/bin
+-|/usr/bin/manhole
+-|/usr/bin/tap2deb
+-|/usr/bin/tap2rpm
+-|/usr/bin/tkconch
++|$(PYTHON_PKG_DIR)
+-|$(PYTHON_PKG_DIR)/twisted/conch/scripts/tkconch.py
+-|$(PYTHON_PKG_DIR)/twisted/scripts/manhole.py
+-|$(PYTHON_PKG_DIR)/twisted/scripts/tap2deb.py
+-|$(PYTHON_PKG_DIR)/twisted/scripts/tap2rpm.py
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,, \
+		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" --no-compile, \
+	)
+endef
+
+$(eval $(call PyPackage,twisted))
+$(eval $(call BuildPackage,twisted))

--- a/lang/twisted/patches/001-fix-zsh-completion.patch
+++ b/lang/twisted/patches/001-fix-zsh-completion.patch
@@ -1,0 +1,9 @@
+diff -Nur a/twisted/python/twisted-completion.zsh b/twisted/python/twisted-completion.zsh
+--- a/twisted/python/twisted-completion.zsh	2015-11-29 11:30:47.000000000 +0800
++++ b/twisted/python/twisted-completion.zsh	2015-11-30 20:05:59.755695237 +0800
+@@ -1,4 +1,4 @@
+-#compdef twistd trial conch cftp ckeygen pyhtmlizer tap2deb tkconch manhole tap2rpm
++#compdef twistd trial conch cftp ckeygen pyhtmlizer
+ #
+ # This is the ZSH completion file for Twisted commands. It calls the current
+ # command-line with the special "--_shell-completion" option which is handled

--- a/lang/twisted/patches/002-omit-tests.patch
+++ b/lang/twisted/patches/002-omit-tests.patch
@@ -1,0 +1,32 @@
+diff -Nur a/setup.py b/setup.py
+--- a/setup.py	2015-11-29 11:30:46.000000000 +0800
++++ b/setup.py	2015-12-02 18:22:10.251268303 +0800
+@@ -49,11 +49,11 @@
+     scripts = getScripts()
+ 
+     setup_args.update(dict(
+-        packages=getPackages('twisted'),
++        packages=getPackages('twisted', ignore=['test']),
+         conditionalExtensions=getExtensions(),
+         scripts=scripts,
+         extras_require=_EXTRAS_REQUIRE,
+-        data_files=getDataFiles('twisted'),
++        data_files=getDataFiles('twisted', ignore=['test']),
+         **STATIC_PACKAGE_METADATA))
+ 
+     setup(**setup_args)
+diff -Nur a/twisted/python/dist.py b/twisted/python/dist.py
+--- a/twisted/python/dist.py	2015-11-29 11:30:47.000000000 +0800
++++ b/twisted/python/dist.py	2015-12-02 19:21:20.076370379 +0800
+@@ -268,11 +268,6 @@
+     """
+     extensions = [
+         ConditionalExtension(
+-            "twisted.test.raiser",
+-            ["twisted/test/raiser.c"],
+-            condition=lambda _: _isCPython),
+-
+-        ConditionalExtension(
+             "twisted.internet.iocpreactor.iocpsupport",
+             ["twisted/internet/iocpreactor/iocpsupport/iocpsupport.c",
+              "twisted/internet/iocpreactor/iocpsupport/winsock_pointers.c"],


### PR DESCRIPTION
- update to latest version (~~15.5.0~~ 16.0.0)
- change to one package containing all plugins/subprojects
- add license info
- add myself as maintainer

This builds one main package, instead of multiple packages like the old
packages feed, to match upstream. (Debian and Fedora are moving to a
single-package model as well.) The obvious downside is a larger install
size, but one main package should be easier to maintain in the future.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>