### PR TITLE
python-txsocksx: new package

### DIFF
--- a/lang/python-txsocksx/Makefile
+++ b/lang/python-txsocksx/Makefile
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2015-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=txsocksx
+PKG_VERSION:=1.15.0.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/t/txsocksx
+PKG_MD5SUM:=0266b9ae7b58f7550a49683afebf65ba
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/python-txsocksx
+	SECTION:=lang
+	CATEGORY:=Languages
+	SUBMENU:=Python
+	TITLE:=python-txsocksx
+	URL:=https://github.com/habnabit/txsocksx
+	DEPENDS:=+python-light +python-parsley +twisted
+endef
+
+define Package/python-txsocksx/description
+txsocksx is SOCKS4/4a and SOCKS5 client endpoints for Twisted 10.1 or
+greater.
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,, \
+		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)", \
+		PKG_VERSION="$(PKG_VERSION)" \
+	)
+endef
+
+$(eval $(call PyPackage,python-txsocksx))
+$(eval $(call BuildPackage,python-txsocksx))

--- a/lang/python-txsocksx/patches/001-omit-tests.patch
+++ b/lang/python-txsocksx/patches/001-omit-tests.patch
@@ -1,0 +1,11 @@
+diff --git a/setup.py b/setup.py
+index 7979f89..3873a1e 100644
+--- a/setup.py
++++ b/setup.py
+@@ -35,5 +35,5 @@ setup(
+         'version_module_paths': ['txsocksx/_version.py'],
+     },
+     install_requires=install_requires,
+-    packages=['txsocksx', 'txsocksx.test'],
++    packages=['txsocksx'],
+ )

--- a/lang/python-txsocksx/patches/002-do-not-use-vcversioner.patch
+++ b/lang/python-txsocksx/patches/002-do-not-use-vcversioner.patch
@@ -1,0 +1,29 @@
+diff --git a/setup.py b/setup.py
+index 7979f89..5e1abb3 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,6 +1,8 @@
+ # Copyright (c) Aaron Gallagher <_@habnab.it>
+ # See COPYING for details.
+ 
++import os
++
+ from setuptools import setup
+ 
+ 
+@@ -30,10 +32,11 @@ setup(
+     ],
+     license='ISC',
+ 
+-    setup_requires=['vcversioner>=1'],
+-    vcversioner={
+-        'version_module_paths': ['txsocksx/_version.py'],
+-    },
++    #setup_requires=['vcversioner>=1'],
++    #vcversioner={
++    #    'version_module_paths': ['txsocksx/_version.py'],
++    #},
++    version=os.environ.get('PKG_VERSION'),
+     install_requires=install_requires,
+     packages=['txsocksx', 'txsocksx.test'],
+ )


### PR DESCRIPTION
From the README:

txsocksx is SOCKS4/4a and SOCKS5 client endpoints for Twisted 10.1 or
greater.

This depends on:

- ~~python-vcversioner (#2057)~~
- python-parsley (#2056)
- twisted (#2052)

Signed-off-by: Jeffery To <jeffery.to@gmail.com>