### PR TITLE
unrar: add Build/InstallDev define

### DIFF
--- a/utils/unrar/Makefile
+++ b/utils/unrar/Makefile
@@ -61,6 +61,13 @@ define Build/Compile
 	$(call Build/Compile/Default,lib)
 endef
 
+define Build/InstallDev
+        $(INSTALL_DIR) $(STAGING_DIR)/include/unrar
+        $(CP) $(PKG_BUILD_DIR)/*.hpp $(STAGING_DIR)/include/unrar
+        $(INSTALL_DIR) $(STAGING_DIR)/lib
+        $(CP) $(PKG_BUILD_DIR)/libunrar.so $(STAGING_DIR)/lib
+endef
+
 define Package/unrar/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/unrar $(1)/usr/bin/

--- a/utils/unrar/Makefile
+++ b/utils/unrar/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unrar
 PKG_VERSION:=5.3.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=unrarsrc-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.rarlab.com/rar
@@ -62,10 +62,10 @@ define Build/Compile
 endef
 
 define Build/InstallDev
-        $(INSTALL_DIR) $(STAGING_DIR)/include/unrar
-        $(CP) $(PKG_BUILD_DIR)/*.hpp $(STAGING_DIR)/include/unrar
-        $(INSTALL_DIR) $(STAGING_DIR)/lib
-        $(CP) $(PKG_BUILD_DIR)/libunrar.so $(STAGING_DIR)/lib
+	$(INSTALL_DIR) $(1)/usr/include/unrar
+	$(CP) $(PKG_BUILD_DIR)/*.hpp $(1)/usr/include/unrar
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/libunrar.so $(1)/usr/lib
 endef
 
 define Package/unrar/install


### PR DESCRIPTION
Copy headers and compiled library into STAGING_DIR to make available to other packages that may depend on them.

Signed-off-by: Nikolay Podoprigora <volzhanin@gmail.com>