### PR TITLE
python-gmpy2: new package

### DIFF
--- a/lang/python-gmpy2/Makefile
+++ b/lang/python-gmpy2/Makefile
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gmpy2
+PKG_VERSION:=2.0.7
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/g/gmpy2
+PKG_MD5SUM:=b5aada3ee5afb316ea94604f45192054
+
+PKG_LICENSE:=LGPL-3.0+
+PKG_LICENSE_FILES:=COPYING.LESSER
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/python-gmpy2
+	SECTION:=lang
+	CATEGORY:=Languages
+	SUBMENU:=Python
+	TITLE:=python-gmpy2
+	URL:=http://code.google.com/p/gmpy/
+	DEPENDS:=+libgmp +python-light
+endef
+
+define Package/python-gmpy2/description
+gmpy2 is a C-coded Python extension module that supports multiple-precision
+arithmetic. gmpy2 is the successor to the original gmpy module. The gmpy module
+only supported the GMP multiple-precision library. gmpy2 adds support for the
+MPFR (correctly rounded real floating-point arithmetic) and MPC (correctly
+rounded complex floating-point arithmetic) libraries. gmpy2 also updates the
+API and naming conventions to be more consistent and support the additional
+functionality.
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" --nompfr)
+endef
+
+$(eval $(call PyPackage,python-gmpy2))
+$(eval $(call BuildPackage,python-gmpy2))


### PR DESCRIPTION
From the documentation:

gmpy2 is a C-coded Python extension module that supports multiple-precision
arithmetic. gmpy2 is the successor to the original gmpy module. The gmpy module
only supported the GMP multiple-precision library. gmpy2 adds support for the
MPFR (correctly rounded real floating-point arithmetic) and MPC (correctly
rounded complex floating-point arithmetic) libraries. gmpy2 also updates the
API and naming conventions to be more consistent and support the additional
functionality.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>