### PR TITLE
davfs2: simplify dependencies

### DIFF
--- a/net/davfs2/Makefile
+++ b/net/davfs2/Makefile
@@ -23,7 +23,7 @@ define Package/davfs2
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Filesystem
-  DEPENDS=+libopenssl +libneon +libiconv +libintl +libexpat +kmod-fuse +libfuse
+  DEPENDS=+libneon +libiconv +libintl +kmod-fuse +libfuse
   TITLE:=Mount a WebDAV resource as a regular file system.
   URL:=http://savannah.nongnu.org/projects/davfs2/
   MAINTAINER:=Federico Di Marco <fededim@gmail.com>


### PR DESCRIPTION
`libopenssl` and `libexpat is a part of `libneon` dependencies. 

Also, please consider to add some other changes:
1) You've got `libiconv` and `libintl` deps without `include $(INCLUDE_DIR)/nls.mk`
2) Mine `davfs2` is not working for writing without `TARGET_CPPFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE` , it should be compiled with the same `CPPFLAGS` ad `libneon`.
3) Are you sure `libfuse` dep. is necessary?

https://github.com/Entware-ng/entware-packages/blob/master/net/davfs2/Makefile
