### PR TITLE
avrdude: simplify dependencies

### DIFF
--- a/utils/avrdude/Makefile
+++ b/utils/avrdude/Makefile
@@ -29,7 +29,7 @@ define Package/avrdude
   CATEGORY:=Utilities
   TITLE:=AVR Downloader/UploaDEr
   URL:=http://www.nongnu.org/avrdude/
-  DEPENDS:=+libncurses +libreadline +libusb-compat +libftdi1 +libelf1
+  DEPENDS:=+libncurses +libreadline +libusb-compat +libftdi1
 endef
 
 define Package/avrdude/description


### PR DESCRIPTION
Checked on RT-N66U (Entware-ng repo), there is no `libelf1` dependency:
```
admin@RT-N66U:/tmp/home/root# ldd /opt/bin/avrdude
        libusb-1.0.so.0 => /opt/lib/libusb-1.0.so.0 (0x2aac0000)
        libusb-0.1.so.4 => /opt/lib/libusb-0.1.so.4 (0x2aae0000)
        libftdi1.so.2 => /opt/lib/libftdi1.so.2 (0x2aaf4000)
        libpthread.so.1 => /opt/lib/libpthread.so.1 (0x2ab10000)
        libm.so.1 => /opt/lib/libm.so.1 (0x2ab36000)
        libreadline.so.6 => /opt/lib/libreadline.so.6 (0x2ab5d000)
        libncurses.so.6 => /opt/lib/libncurses.so.6 (0x2aba9000)
        libgcc_s.so.1 => /opt/lib/libgcc_s.so.1 (0x2ac06000)
        libc.so.1 => /opt/lib/libc.so.1 (0x2ac2c000)
        ld-uClibc.so.1 => /opt/lib/ld-uClibc.so.0 (0x2aaa8000)
        libdl.so.1 => /opt/lib/libdl.so.1 (0x2ace2000)
```
Also, there is no `libelf1` in OpenWrt repo, it was replaced by `libelf` long time ago.