### PR TITLE
opencv: Update to 3.1 to fix compilation problems

### DIFF
--- a/libs/opencv/Makefile
+++ b/libs/opencv/Makefile
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2013-2014 wrtnode.com
-# Copyright (C) 2015 OpenWrt.org
+# Copyright (C) 2015-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opencv
-PKG_VERSION:=3.0.0
+PKG_VERSION:=3.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=http://sourceforge.net/projects/opencvlibrary/files/opencv-unix/$(PKG_VERSION)/
-PKG_MD5SUM:=09004c275d8092cbdf5b61675cecd399
+PKG_MD5SUM:=6082ee2124d4066581a7386972bfd52a
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
This patch is a backport from a recent fix in upstream commit 78376c0f63834642b8133ab5d3b5f658d65a0bb2:
"pthreads: replace usage of non-POSIX PTHREAD_RECURSIVE_MUTEX_INITIALIZER* defines".

It also includes the changes made to the file "modules/core/src/precomp.hpp" in upstream commit: 53fc5440d78fd9ebe727c51243528e1eac3b5e35: "implement singleton lazy initialization".