### PR TITLE
lang/python: Depend on system expat

### DIFF
--- a/lang/python/files/python-package-xml.mk
+++ b/lang/python/files/python-package-xml.mk
@@ -8,7 +8,7 @@
 define Package/python-xml
 $(call Package/python/Default)
   TITLE:=Python $(PYTHON_VERSION) xml libs
-  DEPENDS:=+python-light
+  DEPENDS:=+python-light +libexpat
 endef
 
 $(eval $(call PyBasePackage,python-xml, \


### PR DESCRIPTION
When expat has already been built by another package Python links to it causing an error that the python package is missing a dependency, therefore always depend on external expat so that builds always work.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>