### PR TITLE
mail/nullmailer:  Bring back, update, and improve nullmailer package

### DIFF
--- a/mail/nullmailer/Makefile
+++ b/mail/nullmailer/Makefile
@@ -1,0 +1,73 @@
+#
+# Copyright (C) 2007-2011 OpenWrt.org
+# Copyright (C) 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/uclibc++.mk
+
+PKG_NAME:=nullmailer
+PKG_VERSION:=1.13
+PKG_RELEASE:=4
+PKG_MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+PKG_LICENSE:=GPL-2.0+
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://untroubled.org/nullmailer/
+PKG_MD5SUM:=aaeb8746fbc082917b26d0827ccc9270
+PKG_USERID:=nullmailer=5236:nullmailer=5236
+
+PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+TARGET_CFLAGS += $(TARGET_CPPFLAGS)
+
+CONFIGURE_ARGS += \
+	--localstatedir=/var/spool
+
+ifeq ($(BUILD_VARIANT),ssl)
+CONFIGURE_ARGS+=--enable-tls
+endif
+
+define NullmailerPackageSet
+  define Package/nullmailer$(if $(filter-out plain,$(1)),-$(1))
+    SECTION:=mail
+    CATEGORY:=Mail
+    DEPENDS:=$(CXX_DEPENDS) $(if $(filter ssl,$(1)),+libgnutls)
+    TITLE:=A minimal MTA for hosts which relay to a fixed set of smart relays $(1) variant
+    URL:=http://untroubled.org/nullmailer/
+    VARIANT:=$(1)
+  endef
+
+  define Package/nullmailer$(if $(filter-out plain,$(1)),-$(1))/description
+   This is nullmailer, a sendmail/qmail/etc replacement MTA for hosts
+   which relay to a fixed set of smart relays.  It is designed to be
+   simple to configure, secure, and easily extendable.
+  endef
+
+  define Package/nullmailer$(if $(filter-out plain,$(1)),-$(1))/conffiles
+  /etc/nullmailer
+  /etc/config/nullmailer
+  endef
+
+  define Package/nullmailer$(if $(filter-out plain,$(1)),-$(1))/install
+	$(INSTALL_DIR) $$(1)/etc/init.d $$(1)/usr/bin $$(1)/usr/sbin $$(1)/usr/lib/nullmailer $$(1)/etc/config $$(1)/sbin
+	$(INSTALL_BIN) $$(PKG_INSTALL_DIR)/usr/bin/* $$(1)/usr/bin/
+	$(INSTALL_BIN) $$(PKG_INSTALL_DIR)/usr/sbin/* $$(1)/usr/sbin/
+	$(INSTALL_BIN) $$(PKG_INSTALL_DIR)/usr/lib/nullmailer/* $$(1)/usr/lib/nullmailer/
+	$(INSTALL_BIN) ./files/nullmailer.init $$(1)/etc/init.d/nullmailer
+	$(INSTALL_CONF) ./files/nullmailer.config $$(1)/etc/config/nullmailer
+	ln -sf /var/etc/nullmailer $$(1)/etc/nullmailer
+	ln -sf /usr/sbin/nullmailer-sendmail $$(1)/sbin/sendmail
+	ln -sf /sbin/sendmail $$(1)/usr/lib/sendmail
+  endef
+
+   $$(eval $$(call BuildPackage,nullmailer$(if $(filter-out plain,$(1)),-$(1))))
+endef
+$(eval $(call NullmailerPackageSet,plain))
+$(eval $(call NullmailerPackageSet,ssl))

--- a/mail/nullmailer/files/nullmailer.config
+++ b/mail/nullmailer/files/nullmailer.config
@@ -1,0 +1,14 @@
+# config nullmailer
+  # option localfqdnhostname 'helohostname' # required
+  # option adminaddr 'user@to.appear.as'
+  # option defaultdomain 'defaultdomain'
+  # option defaulthost 'defaulthost'
+  # option queuetime 60
+  # option sendtimeout 3600
+
+# config remote
+  # option smarthost 'remotemailserver' # required
+  # option port 25
+  # option authlogin 0 # whether to use LOGIN instead of PLAIN
+  # option username 'username'
+  # option password 'password'

--- a/mail/nullmailer/files/nullmailer.init
+++ b/mail/nullmailer/files/nullmailer.init
@@ -1,0 +1,129 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2006-2011 OpenWrt.org
+
+START=90
+STOP=10
+
+USE_PROCD=1
+PROG=/usr/sbin/nullmailer-send
+NAME=nullmailer
+
+validate_section_nullmailer()
+{
+    if ! uci_validate_section nullmailer nullmailer "${1}" \
+	'adminaddr:string' \
+	'defaultdomain:string' \
+	'defaulthost:string' \
+	'queuetime:uinteger:60' \
+	'sendtimeout:uinteger:3600' \
+	'localfqdnhostname:string' \
+	'runasuser:string:nullmailer' \
+	'nullmailergroup:string:nullmailer'
+    then
+	return 1
+    fi
+
+   [ -z "$localfqdnhostname" ] && return 1
+
+   return 0
+}
+
+validate_section_nullmailer_remote()
+{
+   if ! uci_validate_section nullmailer remote "${1}" \
+	'smarthost:string' \
+	'authlogin:bool:0' \
+	'username:string' \
+        'password:string' \
+        'port:port:25'
+    then
+	return 1
+    fi
+
+   if [ -n "$password" ] && [ -z "$username" ]; then
+       return 1
+   fi
+
+   [ -z "$smarthost" ] && return 1
+
+   return 0
+}
+
+nullmailer_global() {
+    local adminaddr defaultdomain defaulthost queuetime localfqdnhostname
+
+    validate_section_nullmailer "${1}" || {
+	echo "Validation failed"
+	return 1
+    }
+
+    if [ -n "$adminaddr" ]; then
+	echo "$adminaddr" >/var/etc/nullmailer/adminaddr
+    fi
+
+    if [ -n "$defaultdomain" ]; then
+	echo "$defaultdomain" >/var/etc/nullmailer/defaultdomain
+    fi
+
+    if [ -n "$defaulthost" ]; then
+	echo "$defaulthost" >/var/etc/nullmailer/defaulthost
+    fi
+
+    echo "${queuetime}" >/var/etc/nullmailer/pausetime
+
+    echo "${sendtimeout}" >/var/etc/nullmailer/sendtimeout
+
+    echo "${localfqdnhostname}" >/var/etc/nullmailer/helohost
+    
+    if [ -z "$defaulthost" ]; then
+	echo "${localfqdnhostname}" >/var/etc/nullmailer/defaulthost
+    fi
+}
+
+nullmailer_remote() {
+    local smarthost authlogin username password port
+
+    validate_section_nullmailer_remote "${1}" || {
+	echo "Validation failed"
+	return 1
+    }
+
+    echo "${smarthost} smtp --port=${port} ${authlogin:+--auth-login} ${username:+--user=$username} ${password:+--pass=$password}" >>/var/etc/nullmailer/remotes
+    chown $runasuser:$(id -g $runasuser) /var/etc/nullmailer/remotes
+    chmod 600 /var/etc/nullmailer/remotes
+}
+
+start_service() {
+    local runasuser nullmailergroup
+
+    rm -rf /var/etc/nullmailer
+    mkdir -p /var/etc/nullmailer
+
+    config_load "${NAME}"
+    config_foreach nullmailer_global nullmailer || exit 1
+    config_foreach nullmailer_remote remote || exit 1
+
+    chown $runasuser:$nullmailergroup /var/etc/nullmailer
+    chmod 700 /var/etc/nullmailer
+    
+    mkdir -p /var/spool/nullmailer/queue
+    mkdir -p /var/spool/nullmailer/tmp
+    rm -f /var/spool/nullmailer/trigger
+    mkfifo /var/spool/nullmailer/trigger
+    chown -R $runasuser:$nullmailergroup /var/spool/nullmailer
+    chmod 4770 /var/spool/nullmailer/queue
+    chmod 4770 /var/spool/nullmailer/tmp
+    procd_open_instance
+    procd_set_param command "$PROG" -s -u $runasuser
+    procd_add_jail nullmailer log
+    procd_add_jail_mount /var/etc/nullmailer /etc/nullmailer /usr/sbin/nullmailer-queue /usr/lib/nullmailer/smtp /etc/passwd /etc/group
+    procd_add_jail_mount_rw /var/spool/nullmailer /tmp/spool/nullmailer
+    procd_close_instance
+}
+
+service_triggers() {
+    procd_add_reload_trigger "nullmailer"
+    procd_add_validation validate_section_nullmailer
+    procd_add_validation validate_section_nullmailer_remote
+}
+

--- a/mail/nullmailer/patches/100_gentoo_manual.patch
+++ b/mail/nullmailer/patches/100_gentoo_manual.patch
@@ -1,0 +1,175 @@
+From eac41de59cf178ed346308cc54139fe9dcb9e0d7 Mon Sep 17 00:00:00 2001
+Message-Id: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+From: Justin Lecher <jlec@gentoo.org>
+Date: Wed, 8 Jan 2014 14:41:27 +0100
+Subject: [PATCH 1/9] 01_manual.diff
+
+Signed-off-by: Justin Lecher <jlec@gentoo.org>
+---
+ doc/nullmailer-inject.1 | 12 ++++++------
+ doc/nullmailer-queue.8  | 12 ++++++------
+ doc/nullmailer-send.8   | 12 ++++++------
+ doc/sendmail.1          | 14 ++++++++++----
+ 4 files changed, 28 insertions(+), 22 deletions(-)
+
+diff --git a/doc/nullmailer-inject.1 b/doc/nullmailer-inject.1
+index 58c7fcd..540f1c0 100644
+--- a/doc/nullmailer-inject.1
++++ b/doc/nullmailer-inject.1
+@@ -82,7 +82,7 @@ fields, the following line is appended to the message:
+ Address lists are expected to follow the syntax set out in RFC822.
+ The following is a simplified explanation of the syntax.
+ 
+-An address list is list of addresses seperated by commas.
++An address list is list of addresses separated by commas.
+ An individual address may have one of the following three forms:
+ .IR user@fqdn ,
+ .IR comment <user@fqdn> ,
+@@ -227,16 +227,16 @@ including
+ and
+ .BR idhost .
+ Defaults to the value of the
+-.I me
+-control file, if it exists, otherwise the literal name
++.I /etc/mailname
++system file, if it exists, otherwise the literal name
+ .IR defauldomain .
+ .TP
+ .B defaulthost
+ The content of this file is appended to any address that is missing a
+ host name.
+ Defaults to the value of the
+-.I me
+-control file, if it exists, otherwise the literal name
++.I /etc/mailname
++system file, if it exists, otherwise the literal name
+ .IR defaulthost .
+ .TP
+ .B idhost
+@@ -245,7 +245,7 @@ for the message.
+ Defaults to the canonicalized value of
+ .BR defaulthost .
+ .TP
+-.B me
++.B /etc/mailname
+ The fully-qualifiled host name of the computer running nullmailer.
+ Defaults to the literal name
+ .IR me .
+diff --git a/doc/nullmailer-queue.8 b/doc/nullmailer-queue.8
+index f51b068..50fa6f3 100644
+--- a/doc/nullmailer-queue.8
++++ b/doc/nullmailer-queue.8
+@@ -22,22 +22,22 @@ message to stdandard output.
+ .TP
+ .B adminaddr
+ If this file is not empty, all recipients to users at either
+-"localhost" (the literal string) or the canonical host name (from the
+-.I me
+-control file) are remapped to this address.
++"localhost" (the literal string) or the canonical host name (from
++.IR /etc/mailname )
++are remapped to this address.
+ This is provided to allow local daemons to be able to send email to
+ "somebody@localhost" and have it go somewhere sensible instead of
+ being bounced by your relay host. To send to multiple addresses, put
+ them all on one line separated by a comma.
+ .SH OTHER FILES
+ .TP
+-.B /var/nullmailer/queue
++.B /var/spool/nullmailer/queue
+ The directory into which the completed messages are moved.
+ .TP
+-.B /var/nullmailer/tmp
++.B /var/spool/nullmailer/tmp
+ The directory in which messages are formed temporarily.
+ .TP
+-.B /var/nullmailer/trigger
++.B /var/spool/nullmailer/trigger
+ A pipe used to trigger
+ .BR nullmailer-send
+ to immediately start sending the message from the queue.
+diff --git a/doc/nullmailer-send.8 b/doc/nullmailer-send.8
+index 014c2c4..38fb8aa 100644
+--- a/doc/nullmailer-send.8
++++ b/doc/nullmailer-send.8
+@@ -85,14 +85,14 @@ For example, to connect to port 2525 on your SMTP smart host,
+ which also requires SMTP authentication, use:
+ 
+ .EX
+-    smarthost.dom smtp --port=2525 --user=user --pass=pass
++    smarthost.dom smtp \-\-port=2525 \-\-user=user \-\-pass=pass
+ .EE
+ 
+ If your smarthost requires LOGIN authentication instead of the default
+ PLAIN method, use:
+ 
+ .EX
+-    smarthost.dom smtp --port=2525 --auth-login --user=user --pass=pass
++    smarthost.dom smtp \-\-port=2525 \-\-auth-login \-\-user=user \-\-pass=pass
+ .EE
+ 
+ Blank lines and lines starting with a pound are ignored. When called with
+@@ -115,16 +115,16 @@ If this is set to
+ will wait forever for messages to complete sending.
+ .SH FILES
+ .TP
+-.B /var/nullmailer/queue
++.B /var/spool/nullmailer/queue
+ The message queue.
+ .TP
+-.B /var/nullmailer/trigger
++.B /var/spool/nullmailer/trigger
+ A trigger file to cause immediate delivery.
+ .TP
+-.B /usr/local/etc/nullmailer
++.B /etc/nullmailer
+ The configuration directory.
+ .TP
+-.B /usr/local/libexec/nullmailer
++.B /usr/lib/nullmailer
+ The protocol program directory.
+ .SH SEE ALSO
+ nullmailer-queue(8),
+diff --git a/doc/sendmail.1 b/doc/sendmail.1
+index 28e1ca6..ada9447 100644
+--- a/doc/sendmail.1
++++ b/doc/sendmail.1
+@@ -17,8 +17,11 @@ It is used by programs that expect a
+ interface for sending email.
+ After parsing the command-line arguments, this program executes
+ .B nullmailer-inject
+-directly.
+-See the documentation for
++directly, unless the
++.I \-bs
++option is specified in which case this program executes
++.B nullmailer-smtpd
++to inject the mail.  See the documentation for
+ .B nullmailer-inject
+ for details on how messages are reformatted and queued.
+ .SH OPTIONS
+@@ -26,6 +29,9 @@ for details on how messages are reformatted and queued.
+ .B \-B TYPE
+ .TP
+ .B \-C FILE
++ \-bm        Read mail from standard input (default)
++ \-bp        List information about mail queue
++ \-bs        Handle SMTP commands on standard input
+ .TP
+ .B \-d DEBUG
+ .TP
+@@ -77,9 +83,9 @@ Sets the full name of the sender.
+ Sets the envelope sender address.
+ .TP
+ .B \-r ADDRESS
+-An alternate and obsolete form of the -f flag.
++An alternate and obsolete form of the \-f flag.
+ .TP
+ .B \-t
+ Read message for recipients and ignore the command-line arguments.
+ .SH SEE ALSO
+-nullmailer-inject(1)
++nullmailer-inject(1), nullmailer-smtpd(8)
+-- 
+1.8.5.2
+

--- a/mail/nullmailer/patches/110_gentoo_ipv6.patch
+++ b/mail/nullmailer/patches/110_gentoo_ipv6.patch
@@ -1,0 +1,119 @@
+From 4abcd3a69367983104dcdf99b7e497378b653556 Mon Sep 17 00:00:00 2001
+Message-Id: <4abcd3a69367983104dcdf99b7e497378b653556.1389188742.git.jlec@gentoo.org>
+In-Reply-To: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+References: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+From: Justin Lecher <jlec@gentoo.org>
+Date: Wed, 8 Jan 2014 14:41:45 +0100
+Subject: [PATCH 2/9] 02_ipv6.diff
+
+Signed-off-by: Justin Lecher <jlec@gentoo.org>
+---
+ configure.in      | 19 +++++++++++++++++++
+ lib/tcpconnect.cc | 40 ++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 59 insertions(+)
+
+diff --git a/configure.in b/configure.in
+index d439d5e..d824e0e 100644
+--- a/configure.in
++++ b/configure.in
+@@ -48,6 +48,25 @@ dnl Checks for library functions.
+ dnl AC_CHECK_FUNCS(gettimeofday mkdir putenv rmdir socket)
+ AC_CHECK_FUNCS(setenv srandom)
+ 
++AC_MSG_CHECKING(for getaddrinfo)
++AC_TRY_COMPILE([#include <sys/types.h>
++#include <sys/socket.h>
++#include <netdb.h>
++#include <stddef.h>], [getaddrinfo(NULL, NULL, NULL, NULL)], has_getaddrinfo=yes, has_getaddrinfo=no)
++if test "$has_getaddrinfo" = yes; then
++  AC_MSG_RESULT(yes)
++else
++  AC_MSG_RESULT(no)
++fi
++
++if test x-$has_getaddrinfo = "x-no" ; then
++  AC_MSG_RESULT(disabled: getaddrinfo missing)
++else
++  AC_DEFINE(HAVE_GETADDRINFO,,[getaddrinfo code enabled])
++fi
++
++AC_SUBST(HAVE_GETADDRINFO)
++
+ AC_DEFINE(BUFSIZE, 4096, [Generic buffer size])
+ AM_CONDITIONAL(FDBUF_NO_MYSTRING, false)
+ 
+diff --git a/lib/tcpconnect.cc b/lib/tcpconnect.cc
+index a140256..9bd3cc0 100644
+--- a/lib/tcpconnect.cc
++++ b/lib/tcpconnect.cc
+@@ -28,7 +28,11 @@
+ #include <netinet/in.h>
+ #include "errcodes.h"
+ #include "connect.h"
++#ifdef HAVE_GETADDRINFO
++#include "lib/itoa.h"
++#endif
+ 
++#ifndef HAVE_GETADDRINFO
+ static int sethostbyname(const mystring& hostname, struct sockaddr_in& sa)
+ {
+   struct hostent *he = gethostbyname(hostname.c_str());
+@@ -44,13 +48,48 @@ static int sethostbyname(const mystring& hostname, struct sockaddr_in& sa)
+   memcpy(&sa.sin_addr, he->h_addr, he->h_length);
+   return 0;
+ }
++#endif
+ 
+ int tcpconnect(const mystring& hostname, int port)
+ {
++#ifdef HAVE_GETADDRINFO
++  struct addrinfo req, *res, *orig_res;
++  const char *service = itoa(port, 6);
++
++  memset(&req, 0, sizeof(req));
++  req.ai_flags = AI_NUMERICSERV;
++  req.ai_socktype = SOCK_STREAM;
++  int e = getaddrinfo(hostname.c_str(), service, &req, &res);
++#else
+   struct sockaddr_in sa;
+   memset(&sa, 0, sizeof(sa));
+   int e = sethostbyname(hostname, sa);
++#endif
+   if(e) return e;
++#ifdef HAVE_GETADDRINFO
++  int s = -1;
++  orig_res = res;
++
++  for (; res; res = res->ai_next ) {
++    s = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
++
++    if(s < 0)
++	continue;
++
++    if(connect(s, res->ai_addr, res->ai_addrlen) != 0) {
++    	s = -1;
++	continue;
++    }
++
++    /* sucessful connection */
++    break;
++  }
++
++  freeaddrinfo(orig_res);
++
++  if(s < 0)
++    return -ERR_CONN_FAILED;
++#else
+   sa.sin_family = AF_INET;
+   sa.sin_port = htons(port);
+   int s = socket(PF_INET, SOCK_STREAM, 0);
+@@ -64,5 +103,6 @@ int tcpconnect(const mystring& hostname, int port)
+     default: return -ERR_CONN_FAILED;
+     }
+   }
++#endif
+   return s;
+ }
+-- 
+1.8.5.2
+

--- a/mail/nullmailer/patches/120_gentoo_syslog.patch
+++ b/mail/nullmailer/patches/120_gentoo_syslog.patch
@@ -1,0 +1,301 @@
+From 464dbd87ca2e1e09e59f44871a3caa50bdbd95f0 Mon Sep 17 00:00:00 2001
+Message-Id: <464dbd87ca2e1e09e59f44871a3caa50bdbd95f0.1389188742.git.jlec@gentoo.org>
+In-Reply-To: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+References: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+From: Justin Lecher <jlec@gentoo.org>
+Date: Wed, 8 Jan 2014 14:42:43 +0100
+Subject: [PATCH 3/9] 03_syslog.diff
+
+Signed-off-by: Justin Lecher <jlec@gentoo.org>
+---
+ protocols/protocol.cc |  20 +++++++++-
+ src/Makefile.in       |   6 +--
+ src/send.cc           | 101 +++++++++++++++++++++++++++++++++++++++++++-------
+ 3 files changed, 108 insertions(+), 19 deletions(-)
+
+diff --git a/protocols/protocol.cc b/protocols/protocol.cc
+index 9b0b834..603d891 100644
+--- a/protocols/protocol.cc
++++ b/protocols/protocol.cc
+@@ -22,11 +22,15 @@
+ #include <config.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <sys/syslog.h>
+ #include "connect.h"
+ #include "errcodes.h"
+ #include "protocol.h"
+ #include "cli++.h"
+ 
++static int use_syslog = 0;
++static int daemonize  = 0;
++
+ const char* user = 0;
+ const char* pass = 0;
+ int port = 0;
+@@ -44,6 +48,8 @@ cli_option cli_options[] = {
+     "Set the user name for authentication", 0 },
+   { 0, "pass", cli_option::string, 0, &pass,
+     "Set the password for authentication", 0 },
++  { 'd', "daemon", cli_option::flag, 1, &daemonize,  "use syslog exclusively ", 0 },
++  { 's', "syslog", cli_option::flag, 1, &use_syslog, "use syslog additionally", 0 },
+   { 0, "auth-login", cli_option::flag, AUTH_LOGIN, &auth_method,
+     "Use AUTH LOGIN instead of auto-detecting in SMTP", 0 },
+ #ifdef HAVE_TLS
+@@ -67,13 +73,19 @@ cli_option cli_options[] = {
+ 
+ void protocol_fail(int e, const char* msg)
+ {
+-  ferr << cli_program << ": Failed: " << msg << endl;
++  if (use_syslog)
++    syslog(LOG_ERR, "%s: Failed: %s", cli_program, msg);
++  if (!daemonize)
++    ferr << cli_program << ": Failed: " << msg << endl;
+   exit(e);
+ }
+ 
+ void protocol_succ(const char* msg)
+ {
+-  ferr << cli_program << ": Succeeded: " << msg << endl;
++  if (use_syslog)
++    syslog(LOG_INFO, "%s: Succeeded: %s", cli_program, msg);
++  if (!daemonize)
++    ferr << cli_program << ": Succeeded: " << msg << endl;
+   exit(0);
+ }
+ 
+@@ -93,6 +105,10 @@ static void plain_send(fdibuf& in, int fd)
+ 
+ int cli_main(int, char* argv[])
+ {
++  if (daemonize)
++    use_syslog = 1;
++  if (use_syslog)
++    openlog("nullmailer", LOG_CONS | LOG_PID, LOG_MAIL);
+   const char* remote = argv[0];
+   if (port == 0)
+     port = use_ssl ? default_ssl_port : default_port;
+diff --git a/src/Makefile.in b/src/Makefile.in
+index 45448ce..f2b879c 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -61,7 +61,7 @@ nullmailer_queue_OBJECTS = $(am_nullmailer_queue_OBJECTS)
+ nullmailer_queue_DEPENDENCIES = ../lib/libnullmailer.a
+ am_nullmailer_send_OBJECTS = send.$(OBJEXT)
+ nullmailer_send_OBJECTS = $(am_nullmailer_send_OBJECTS)
+-nullmailer_send_DEPENDENCIES = ../lib/libnullmailer.a
++nullmailer_send_DEPENDENCIES = ../lib/cli++/libcli++.a ../lib/libnullmailer.a
+ am_nullmailer_smtpd_OBJECTS = smtpd.$(OBJEXT)
+ nullmailer_smtpd_OBJECTS = $(am_nullmailer_smtpd_OBJECTS)
+ nullmailer_smtpd_DEPENDENCIES = ../lib/libnullmailer.a
+@@ -182,13 +182,13 @@ top_srcdir = @top_srcdir@
+ #noinst_PROGRAMS = address
+ INCLUDES = -I../lib -I../lib/cli++
+ mailq_SOURCES = mailq.cc
+-mailq_LDADD = ../lib/libnullmailer.a
++mailq_LDADD = ../lib/cli++/libcli++.a ../lib/libnullmailer.a
+ nullmailer_inject_SOURCES = inject.cc
+ nullmailer_inject_LDADD = ../lib/cli++/libcli++.a ../lib/libnullmailer.a
+ nullmailer_queue_SOURCES = queue.cc
+ nullmailer_queue_LDADD = ../lib/libnullmailer.a
+ nullmailer_send_SOURCES = send.cc
+-nullmailer_send_LDADD = ../lib/libnullmailer.a
++nullmailer_send_LDADD = ../lib/cli++/libcli++.a ../lib/libnullmailer.a
+ nullmailer_smtpd_SOURCES = smtpd.cc
+ nullmailer_smtpd_LDADD = ../lib/libnullmailer.a
+ sendmail_SOURCES = sendmail.cc
+diff --git a/src/send.cc b/src/send.cc
+index 1b854fc..71e0029 100644
+--- a/src/send.cc
++++ b/src/send.cc
+@@ -27,6 +27,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <sys/stat.h>
++#include <sys/syslog.h>
+ #include <sys/types.h>
+ #include <sys/wait.h>
+ #include <unistd.h>
+@@ -40,14 +41,30 @@
+ #include "list.h"
+ #include "selfpipe.h"
+ #include "setenv.h"
++#include "cli++/cli++.h"
+ 
+ selfpipe selfpipe;
+ 
+ typedef list<mystring> slist;
+ 
+-#define fail(MSG) do { fout << MSG << endl; return false; } while(0)
+-#define fail2(MSG1,MSG2) do{ fout << MSG1 << MSG2 << endl; return false; }while(0)
+-#define fail_sys(MSG) do{ fout << MSG << strerror(errno) << endl; return false; }while(0)
++static int use_syslog = 0;
++static int daemonize  = 0;
++
++const char* cli_program     = "nullmailer-send";
++const char* cli_help_prefix = "nullmailer daemon\n";
++const char* cli_help_suffix = "";
++const char* cli_args_usage  = "";
++const int cli_args_min = 0;
++const int cli_args_max = 0;
++cli_option cli_options[] = {
++  { 'd', "daemon", cli_option::flag, 1, &daemonize,  "daemonize , implies --syslog", 0 },
++  { 's', "syslog", cli_option::flag, 1, &use_syslog, "use syslog", 0 },
++  { 0, 0, cli_option::flag, 0, 0, 0, 0 }
++};
++
++#define fail(MSG) do { if (use_syslog) syslog(LOG_ERR, "%s", MSG); if (!daemonize) ferr << MSG << endl; return false; } while (0)
++#define fail2(MSG1,MSG2) do { if (use_syslog) syslog(LOG_ERR, "%s %s", MSG1, MSG2); if (!daemonize) fout << MSG1 << MSG2 << endl; return false; } while (0)
++#define fail_sys(MSG) do { if (use_syslog) syslog(LOG_ERR, "%s %s", MSG, strerror(errno)); if (!daemonize) ferr << MSG << strerror(errno) << endl; return false; } while (0)
+ 
+ struct remote
+ {
+@@ -162,7 +179,10 @@ void catch_alrm(int)
+ bool load_files()
+ {
+   reload_files = false;
+-  fout << "Rescanning queue." << endl;
++  if (use_syslog)
++    syslog(LOG_INFO, "Rescanning queue.");
++  if (!daemonize)
++    fout << "Rescanning queue." << endl;
+   DIR* dir = opendir(".");
+   if(!dir)
+     fail_sys("Cannot open queue directory: ");
+@@ -180,12 +200,19 @@ bool load_files()
+ 
+ void exec_protocol(int fd, remote& remote)
+ {
+-  if(close(0) == -1 || dup2(fd, 0) == -1 || close(fd) == -1)
++  if (!daemonize && close(STDIN_FILENO) < 0)
+     return;
++  if (fd != STDIN_FILENO)
++    if (dup2(fd, STDIN_FILENO) < 0 || close(fd) < 0)
++      return;
+   mystring program = PROTOCOL_DIR + remote.proto;
+-  const char* args[3+remote.options.count()];
++  const char* args[5+remote.options.count()];
+   unsigned i = 0;
+   args[i++] = program.c_str();
++  if (daemonize)
++    args[i++] = "-d";
++  if (use_syslog)
++    args[i++] = "-s";
+   for(slist::const_iter opt(remote.options); opt; opt++)
+     args[i++] = strdup((*opt).c_str());
+   args[i++] = remote.host.c_str();
+@@ -222,7 +249,10 @@ bool catchsender(pid_t pid)
+       if(status)
+ 	fail2("Sending failed: ", errorstr(status));
+       else {
+-	fout << "Sent file." << endl;
++        if (use_syslog)
++          syslog(LOG_INFO, "Sent file.");
++        if (!daemonize)
++             fout << "Sent file." << endl;
+ 	return true;
+       }
+     }
+@@ -235,10 +265,20 @@ bool send_one(mystring filename, remote& remote)
+ {
+   int fd = open(filename.c_str(), O_RDONLY);
+   if(fd == -1) {
+-    fout << "Can't open file '" << filename << "'" << endl;
++    if (use_syslog)
++      syslog(LOG_ERR, "Can't open file '%s'", filename.c_str());
++    if (!daemonize)
++      fout << "Can't open file '" << filename << "'" << endl;
+     return false;
+   }
+-  fout << "Starting delivery: protocol: " << remote.proto
++  if (use_syslog)
++    syslog(LOG_INFO, "Starting delivery: protocol: %s host: %s file: %s",
++      remote.proto.c_str(), remote.host.c_str(), filename.c_str());
++  if (!daemonize)
++  if (use_syslog)
++    syslog(LOG_INFO, "Starting delivery, %d message(s) in queue.", files.count());
++  if (!daemonize)
++    fout << "Starting delivery: protocol: " << remote.proto
+        << " host: " << remote.host
+        << " file: " << filename << endl;
+   pid_t pid = fork();
+@@ -277,7 +317,10 @@ bool send_all()
+ 	file++;
+     }
+   }
+-  fout << "Delivery complete, "
++  if (use_syslog)
++    syslog(LOG_INFO, "Delivery complete, %d message(s) remain.", files.count());
++  if (!daemonize)
++    fout << "Delivery complete, "
+        << itoa(files.count()) << " message(s) remain." << endl;
+   return true;
+ }
+@@ -329,7 +372,10 @@ bool do_select()
+ 
+   int s = select(trigger+1, &readfds, 0, 0, &timeout);
+   if(s == 1) {
+-    fout << "Trigger pulled." << endl;
++    if (use_syslog)
++      syslog(LOG_INFO, "Trigger pulled.");
++    if (!daemonize)
++      fout << "Trigger pulled." << endl;
+     read_trigger();
+     reload_files = true;
+     pausetime = minpause;
+@@ -343,8 +389,14 @@ bool do_select()
+   return true;
+ }
+ 
+-int main(int, char*[])
++int cli_main(int, char*[])
+ {
++  pid_t pid;
++
++  if (daemonize)
++    use_syslog = 1;
++  if (use_syslog)
++    openlog("nullmailer", LOG_CONS | LOG_PID, LOG_MAIL);
+   read_hostnames();
+ 
+   if(!selfpipe) {
+@@ -353,13 +405,34 @@ int main(int, char*[])
+   }
+   selfpipe.catchsig(SIGCHLD);
+   
+-  if(!open_trigger())
++  if(!open_trigger()) {
++    if (use_syslog)
++      syslog(LOG_CRIT, "Could not open trigger.");
++    if (!daemonize)
++      ferr << "Could not open trigger." << endl;
+     return 1;
++  }
+   if(chdir(QUEUE_MSG_DIR) == -1) {
+     fout << "Could not chdir to queue message directory." << endl;
++    if (use_syslog)
++      syslog(LOG_CRIT, "Could not chdir to queue message directory.");
++    if (!daemonize)
++      ferr << "Could not chdir to queue message directory." << endl;
+     return 1;
+   }
+-  
++
++  if (daemonize) {
++    if ((pid = fork()) < 0) {
++      syslog(LOG_CRIT, "Could not fork.");
++      return 1;
++    }
++    if (pid)
++      return 0;
++    close(STDIN_FILENO);
++    close(STDOUT_FILENO);
++    close(STDERR_FILENO);
++  }
++
+   signal(SIGALRM, catch_alrm);
+   signal(SIGHUP, SIG_IGN);
+   load_config();
+-- 
+1.8.5.2
+

--- a/mail/nullmailer/patches/130_gentoo_autoconf.patch
+++ b/mail/nullmailer/patches/130_gentoo_autoconf.patch
@@ -1,0 +1,29 @@
+From cfe58adac1d485ff49d2b69d5e35031c45c05132 Mon Sep 17 00:00:00 2001
+Message-Id: <cfe58adac1d485ff49d2b69d5e35031c45c05132.1389188742.git.jlec@gentoo.org>
+In-Reply-To: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+References: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+From: Justin Lecher <jlec@gentoo.org>
+Date: Wed, 8 Jan 2014 14:43:03 +0100
+Subject: [PATCH 4/9] 04_autoconf.diff
+
+Signed-off-by: Justin Lecher <jlec@gentoo.org>
+---
+ Makefile.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index ba5d9ce..9ed3e74 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -171,7 +171,7 @@ all: config.h
+ .SUFFIXES:
+ am--refresh:
+ 	@:
+-$(srcdir)/Makefile.in:  $(srcdir)/Makefile.am  $(am__configure_deps)
++$(srcdir)/Makefile.in:  $(srcdir)/Makefile.am
+ 	@for dep in $?; do \
+ 	  case '$(am__configure_deps)' in \
+ 	    *$$dep*) \
+-- 
+1.8.5.2
+

--- a/mail/nullmailer/patches/150_gentoo_errors_on_stderr.patch
+++ b/mail/nullmailer/patches/150_gentoo_errors_on_stderr.patch
@@ -1,0 +1,69 @@
+From 641d1db0652e9612042412bffc9a8094b2ac22a8 Mon Sep 17 00:00:00 2001
+Message-Id: <641d1db0652e9612042412bffc9a8094b2ac22a8.1389188742.git.jlec@gentoo.org>
+In-Reply-To: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+References: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+From: Justin Lecher <jlec@gentoo.org>
+Date: Wed, 8 Jan 2014 14:43:23 +0100
+Subject: [PATCH 5/9] 05_errors_on_stderr.diff
+
+Signed-off-by: Justin Lecher <jlec@gentoo.org>
+---
+ src/inject.cc | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/src/inject.cc b/src/inject.cc
+index 6bd5c80..fba7361 100644
+--- a/src/inject.cc
++++ b/src/inject.cc
+@@ -71,9 +71,9 @@ cli_option cli_options[] = {
+   {0, 0, cli_option::flag, 0, 0, 0, 0}
+ };
+ 
+-#define fail(MSG) do{ fout << "nullmailer-inject: " << MSG << endl; return false; }while(0)
+-#define fail_sys(MSG) do{ fout << "nullmailer-inject: " << MSG << ": " << strerror(errno) << endl; return false; }while(0)
+-#define bad_hdr(LINE,MSG) do{ header_has_errors = true; fout << "nullmailer-inject: Invalid header line:\n  " << LINE << "\n  " MSG << endl; }while(0)
++#define fail(MSG) do{ ferr << "nullmailer-inject: " << MSG << endl; return false; }while(0)
++#define fail_sys(MSG) do{ ferr << "nullmailer-inject: " << MSG << ": " << strerror(errno) << endl; return false; }while(0)
++#define bad_hdr(LINE,MSG) do{ header_has_errors = true; ferr << "nullmailer-inject: Invalid header line:\n  " << LINE << "\n  " MSG << endl; }while(0)
+ 
+ typedef list<mystring> slist;
+ // static bool do_debug = false;
+@@ -431,7 +431,7 @@ static pid_t pid = 0;
+ void exec_queue()
+ {
+   execl(nqueue.c_str(), nqueue.c_str(), NULL);
+-  fout << "nullmailer-inject: Could not exec " << nqueue << ": "
++  ferr << "nullmailer-inject: Could not exec " << nqueue << ": "
+        << strerror(errno) << endl;
+   exit(1);
+ }
+@@ -552,7 +552,7 @@ bool parse_args(int argc, char* argv[])
+     mystring tmp(o_from);
+     if(!parse_addresses(tmp, list) ||
+        !parse_sender(list)) {
+-      fout << "nullmailer-inject: Invalid sender address: " << o_from << endl;
++      ferr << "nullmailer-inject: Invalid sender address: " << o_from << endl;
+       return false;
+     }
+   }
+@@ -564,7 +564,7 @@ bool parse_args(int argc, char* argv[])
+   bool result = true;
+   for(int i = 0; i < argc; i++) {
+     if(!parse_recip_arg(argv[i])) {
+-      fout << "Invalid recipient: " << argv[i] << endl;
++      ferr << "Invalid recipient: " << argv[i] << endl;
+       result = false;
+     }
+   }
+@@ -579,7 +579,7 @@ int cli_main(int argc, char* argv[])
+      !fix_header())
+     return 1;
+   if(recipients.count() == 0) {
+-    fout << "No recipients were listed." << endl;
++    ferr << "No recipients were listed." << endl;
+     return 1;
+   }
+   if(!send_message())
+-- 
+1.8.5.2
+

--- a/mail/nullmailer/patches/160_gentoo_nullenvsender.patch
+++ b/mail/nullmailer/patches/160_gentoo_nullenvsender.patch
@@ -1,0 +1,125 @@
+From 030bc262a17e798d5eebd6601fd2330d32d5bda5 Mon Sep 17 00:00:00 2001
+Message-Id: <030bc262a17e798d5eebd6601fd2330d32d5bda5.1389188742.git.jlec@gentoo.org>
+In-Reply-To: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+References: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+From: Justin Lecher <jlec@gentoo.org>
+Date: Wed, 8 Jan 2014 14:43:57 +0100
+Subject: [PATCH 6/9] 06_nullenvsender.diff
+
+Signed-off-by: Justin Lecher <jlec@gentoo.org>
+---
+ lib/address.cc | 14 +++++++++++++-
+ src/inject.cc  | 12 +++++++++---
+ src/queue.cc   |  4 ++--
+ 3 files changed, 24 insertions(+), 6 deletions(-)
+
+diff --git a/lib/address.cc b/lib/address.cc
+index 606e1cf..16fea1c 100644
+--- a/lib/address.cc
++++ b/lib/address.cc
+@@ -523,6 +523,17 @@ RULE(route_addr)
+   RETURN(node, "<" + r2.str + ">" + comment, "", r2.addr);
+ }
+ 
++RULE(null_addr)
++{
++  ENTER("LABRACKET RABRACKET");
++  mystring comment;
++  node = skipcomment(node, comment);
++  MATCHTOKEN(LABRACKET);
++  node = skipcomment(node, comment);
++  MATCHTOKEN(RABRACKET);
++  RETURN(node, "<>" + comment, "", "");
++}
++
+ RULE(phrase)
+ {
+   ENTER("word *(word / PERIOD / CFWS)");
+@@ -660,7 +671,8 @@ bool parse_addresses(mystring& line, mystring& list)
+   anode* tokenlist = tokenize(line.c_str());
+   if(!tokenlist)
+     return false;
+-  result r = match_addresses(tokenlist);
++  result r = match_null_addr(tokenlist);
++  if (!r) r = match_addresses(tokenlist);
+   del_tokens(tokenlist);
+   if(r) {
+     line = r.str;
+diff --git a/src/inject.cc b/src/inject.cc
+index fba7361..2f0cf93 100644
+--- a/src/inject.cc
++++ b/src/inject.cc
+@@ -110,6 +110,7 @@ void read_config()
+ ///////////////////////////////////////////////////////////////////////////////
+ static slist recipients;
+ static mystring sender;
++static bool use_header_sender = true;
+ static bool use_header_recips = true;
+ 
+ void parse_recips(const mystring& list)
+@@ -136,6 +137,9 @@ bool parse_recip_arg(mystring str)
+ bool parse_sender(const mystring& list)
+ {
+   int end = list.find_first('\n');
++  if(end == -1) {
++    return true;	// null sender
++  }
+   if(end > 0 && list.find_first('\n', end+1) < 0) {
+     sender = list.sub(0, end);
+     return true;
+@@ -175,7 +179,6 @@ struct header_field
+ 	return true;
+       if(is_resent) {
+ 	if(!header_is_resent) {
+-	  sender = "";
+ 	  if(use_header_recips)
+ 	    recipients.empty();
+ 	}
+@@ -197,8 +200,10 @@ struct header_field
+ 	      parse_recips(list);
+ 	  }
+ 	  else if(is_sender) {
+-	    if(is_resent == header_is_resent && !sender)
++	    if(use_header_sender) {	// There is no Resent-Return-Path
+ 	      parse_sender(list);
++	      use_header_sender = 0;
++	    }
+ 	  }
+ 	}
+       }
+@@ -296,7 +301,7 @@ void setup_from()
+   if(!shost) shost = host;
+   canonicalize(shost);
+   
+-  if(!sender)
++  if(use_header_sender && !sender)
+     sender = suser + "@" + shost;
+ }
+ 
+@@ -555,6 +560,7 @@ bool parse_args(int argc, char* argv[])
+       ferr << "nullmailer-inject: Invalid sender address: " << o_from << endl;
+       return false;
+     }
++    use_header_sender = false;
+   }
+   use_header_recips = (use_recips != use_args);
+   if(use_recips == use_header)
+diff --git a/src/queue.cc b/src/queue.cc
+index 8db9c22..c5596b1 100644
+--- a/src/queue.cc
++++ b/src/queue.cc
+@@ -93,9 +93,9 @@ bool validate_addr(mystring& addr, bool doremap)
+ bool copyenv(fdobuf& out)
+ {
+   mystring str;
+-  if(!fin.getline(str) || !str)
++  if(!fin.getline(str))
+     fail("Could not read envelope sender.");
+-  if(!validate_addr(str, false))
++  if(!validate_addr(str, false) && str != "")
+     fail("Envelope sender address is invalid.");
+   if(!(out << str << endl))
+     fail("Could not write envelope sender.");
+-- 
+1.8.5.2
+

--- a/mail/nullmailer/patches/170_gentoo_sendquit.patch
+++ b/mail/nullmailer/patches/170_gentoo_sendquit.patch
@@ -1,0 +1,45 @@
+From 1c2257e6e3a747839aabc99b1b734fadf6e96d0d Mon Sep 17 00:00:00 2001
+Message-Id: <1c2257e6e3a747839aabc99b1b734fadf6e96d0d.1389188742.git.jlec@gentoo.org>
+In-Reply-To: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+References: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+From: Justin Lecher <jlec@gentoo.org>
+Date: Wed, 8 Jan 2014 14:44:28 +0100
+Subject: [PATCH 7/9] 07_sendquit.diff
+
+Signed-off-by: Justin Lecher <jlec@gentoo.org>
+---
+ protocols/smtp.cc | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/protocols/smtp.cc b/protocols/smtp.cc
+index 827bcf4..9d3eac9 100644
+--- a/protocols/smtp.cc
++++ b/protocols/smtp.cc
+@@ -53,6 +53,7 @@ public:
+   void auth_plain(void);
+   void send_data(fdibuf& msg);
+   void send_envelope(fdibuf& msg);
++  void send_quit();
+   void send(fdibuf& msg);
+ };
+ 
+@@ -204,10 +205,16 @@ void smtp::send_data(fdibuf& msg)
+   protocol_succ(tmp.c_str());
+ }
+ 
++void smtp::send_quit()
++{
++  docmd("QUIT", 200);
++}
++
+ void smtp::send(fdibuf& msg)
+ {
+   send_envelope(msg);
+   send_data(msg);
++  send_quit();
+ }
+ 
+ void protocol_prep(fdibuf&)
+-- 
+1.8.5.2
+

--- a/mail/nullmailer/patches/180_gentoo_manpages.patch
+++ b/mail/nullmailer/patches/180_gentoo_manpages.patch
@@ -1,0 +1,32 @@
+From c33c3d63b54235804db26ad208fe2218990cc1aa Mon Sep 17 00:00:00 2001
+Message-Id: <c33c3d63b54235804db26ad208fe2218990cc1aa.1389188742.git.jlec@gentoo.org>
+In-Reply-To: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+References: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+From: Justin Lecher <jlec@gentoo.org>
+Date: Wed, 8 Jan 2014 14:44:47 +0100
+Subject: [PATCH 8/9] 08_manpages.diff
+
+Signed-off-by: Justin Lecher <jlec@gentoo.org>
+---
+ doc/nullmailer.7 | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/doc/nullmailer.7 b/doc/nullmailer.7
+index bb13b1a..33e2c4a 100644
+--- a/doc/nullmailer.7
++++ b/doc/nullmailer.7
+@@ -23,9 +23,11 @@ control file	used by
+ .I adminaddr	\fBnullmailer-queue
+ .I defaultdomain	\fBnullmailer-inject
+ .I defaulthost	\fBnullmailer-inject
++.I helohost	\fBnullmailer-send
+ .I idhost	\fBnullmailer-inject
+ .I me		\fBnullmailer-inject
+ .I pausetime	\fBnullmailer-send
+ .I remotes	\fBnullmailer-send
++.I sendtimeout	\fBnullmailer-send
+ .fi
+ .RE
+-- 
+1.8.5.2
+

--- a/mail/nullmailer/patches/190_gentoo_allow_no_dots.patch
+++ b/mail/nullmailer/patches/190_gentoo_allow_no_dots.patch
@@ -1,0 +1,56 @@
+From b5c76a58e1a2387eb9851d47aabef6e42e3d3e29 Mon Sep 17 00:00:00 2001
+Message-Id: <b5c76a58e1a2387eb9851d47aabef6e42e3d3e29.1389188742.git.jlec@gentoo.org>
+In-Reply-To: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+References: <eac41de59cf178ed346308cc54139fe9dcb9e0d7.1389188742.git.jlec@gentoo.org>
+From: Justin Lecher <jlec@gentoo.org>
+Date: Wed, 8 Jan 2014 14:45:15 +0100
+Subject: [PATCH 9/9] 12_allow_no_dots.diff
+
+Signed-off-by: Justin Lecher <jlec@gentoo.org>
+---
+ lib/hostname.cc | 10 +++++++---
+ src/queue.cc    |  4 ++--
+ 2 files changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/lib/hostname.cc b/lib/hostname.cc
+index 9af34a2..06b72f7 100644
+--- a/lib/hostname.cc
++++ b/lib/hostname.cc
+@@ -33,12 +33,16 @@ void read_hostnames()
+ {
+   int nome;
+   nome = 0;
+-  if (!config_read("me", me)) {
++  // introduced as bufix for #120660, #157259, #158412 in 1.00RC5-17;
++  // still there since it's more appropriate for Debian systems
++  if (!config_read("../mailname", me)) {
+     nome = 1;
+     me = "me";
+   }
+-  if (!config_read("defaultdomain", defaultdomain))
+-    defaultdomain = nome ? "defaultdomain" : me.c_str();
++  // allow defaultdomain to be empty for Debian
++  config_read("defaultdomain", defaultdomain);
++  // if (!config_read("defaultdomain", defaultdomain))
++    // defaultdomain = nome ? "defaultdomain" : me.c_str();
+   if (!config_read("defaulthost", defaulthost))
+     defaulthost = nome ? "defaulthost" : me.c_str();
+   canonicalize(defaulthost);
+diff --git a/src/queue.cc b/src/queue.cc
+index c5596b1..5045020 100644
+--- a/src/queue.cc
++++ b/src/queue.cc
+@@ -85,8 +85,8 @@ bool validate_addr(mystring& addr, bool doremap)
+     if(hostname == me || hostname == "localhost")
+       addr = adminaddr;
+   }
+-  else if(hostname.find_first('.') < 0)
+-    return false;
++  // else if(hostname.find_first('.') < 0)
++    // return false;
+   return true;
+ }
+ 
+-- 
+1.8.5.2
+

--- a/mail/nullmailer/patches/200_drop_privileges.patch
+++ b/mail/nullmailer/patches/200_drop_privileges.patch
@@ -1,0 +1,128 @@
+Index: nullmailer-1.13/src/send.cc
+===================================================================
+--- nullmailer-1.13.orig/src/send.cc
++++ nullmailer-1.13/src/send.cc
+@@ -42,6 +42,9 @@
+ #include "selfpipe.h"
+ #include "setenv.h"
+ #include "cli++/cli++.h"
++#include <pwd.h>
++#include <grp.h>
++
+ 
+ selfpipe selfpipe;
+ 
+@@ -49,6 +52,7 @@ typedef list<mystring> slist;
+ 
+ static int use_syslog = 0;
+ static int daemonize  = 0;
++static char *user = NULL;
+ 
+ const char* cli_program     = "nullmailer-send";
+ const char* cli_help_prefix = "nullmailer daemon\n";
+@@ -59,6 +63,7 @@ const int cli_args_max = 0;
+ cli_option cli_options[] = {
+   { 'd', "daemon", cli_option::flag, 1, &daemonize,  "daemonize , implies --syslog", 0 },
+   { 's', "syslog", cli_option::flag, 1, &use_syslog, "use syslog", 0 },
++  { 'u', "user", cli_option::string, 1, &user, "run as user", 0 },
+   { 0, 0, cli_option::flag, 0, 0, 0, 0 }
+ };
+ 
+@@ -393,6 +398,97 @@ int cli_main(int, char*[])
+ {
+   pid_t pid;
+ 
++  /* Dropping privileges taken and merged from sane-backends */
++  uid_t runas_uid = 0;
++  gid_t runas_gid = 0;
++  struct passwd *pwent;
++  gid_t *grplist = NULL;
++  struct group *grp;
++  int ngroups = 0;
++  int ret = 0;
++  
++  if (user) {
++    pwent = getpwnam(user);
++
++    if (pwent == NULL) {
++      ferr << "FATAL ERROR: user " << user << "not found on system" << endl;
++      return 1;
++    }
++
++    runas_uid = pwent->pw_uid;
++    runas_gid = pwent->pw_gid;
++
++    grplist = (gid_t *)malloc(sizeof(gid_t));
++
++    if (grplist == NULL) {
++      ferr << "FATAL ERROR: cannot allocate memory for group list" << endl;
++      return 1;
++    }
++
++    ngroups = 1;
++    grplist[0] = runas_gid;
++
++    setgrent();
++
++    /* Get group list for runas_uid */
++    while ((grp = getgrent()) != NULL)
++    {
++    	int i = 0;
++	
++	/* Already added current group */
++        if (grp->gr_gid == runas_gid)
++        	continue;
++
++        while (grp->gr_mem[i])
++        {
++        	int need_to_add = 1, j;
++
++                /* Make sure its not already in list */
++                for (j = 0; j < ngroups; j++)
++                {
++                	if (grp->gr_gid == grplist[i])
++                            need_to_add = 0;
++		}
++                if (need_to_add)
++                {
++                	grplist = (gid_t *)realloc(grplist, 
++                        	sizeof(gid_t)*ngroups+1);
++                        if (grplist == NULL)
++			{
++				ferr << "FATAL ERROR: cannot reallocate memory for group list" << endl;
++			        exit (1);
++			}
++                        grplist[ngroups++] = grp->gr_gid;
++		}
++       	        i++;
++       }
++    }
++    endgrent();
++  }
++
++  /* Drop privileges if requested */
++  if (runas_uid > 0) {
++    ret = setgroups(ngroups, grplist);
++    if (ret < 0) {
++      ferr << "FATAL ERROR: could not set group list: " << strerror(errno) << endl;
++      return 1;
++    }
++
++    free(grplist);
++
++    ret = setegid (runas_gid);
++    if (ret < 0) {
++      ferr << "FATAL ERROR: setegid to gid " << runas_gid << " failed: " << strerror (errno) << endl;
++      return 1;
++    }
++
++    ret = seteuid (runas_uid);
++    if (ret < 0) {
++      ferr << "FATAL ERROR: seteuid to uid " << runas_uid << " failed: " << strerror (errno) << endl;
++      return 1;
++    }    
++  }
++
+   if (daemonize)
+     use_syslog = 1;
+   if (use_syslog)


### PR DESCRIPTION
Nullmailer is a send-only email queue that will retry sending emails
after some time, when sending fails, and/or the queue or upstream
server is too busy.  This should reduce the amount of lost mail compared
to solutions like msmtp or ssmtp that fire and forget.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>