### PR TITLE
net/arpwatch:  Bring back, update, and improve arpwatch

### DIFF
--- a/net/arpwatch/Makefile
+++ b/net/arpwatch/Makefile
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2006-2011 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=arpwatch
+PKG_VERSION:=2.1a15
+PKG_RELEASE:=5
+PKG_MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+PKG_LICENSE:=BSD-4-Clause
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=ftp://ftp.free.fr/.mirrors1/ftp.gentoo.org/distfiles/
+PKG_MD5SUM:=cebfeb99c4a7c2a6cee2564770415fe7
+PKG_USERID:=arpwatch:nullmailer
+
+# use a subdirectory to prevent configure for finding libpcap build dir
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/$(PKG_NAME)-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/arpwatch
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpcap
+  TITLE:=Ethernet station activity monitor
+  URL:=http://www-nrg.ee.lbl.gov/
+endef
+
+define Package/arpwatch/description
+	Ethernet monitor program for keeping track of ethernet/ip address
+	pairings.
+endef
+
+define Package/arpwatch/conffiles
+/etc/arpwatch/arp.dat
+/etc/config/arpwatch
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	chmod -R u+w $(PKG_BUILD_DIR)
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		ARPDIR=/etc/arpwatch \
+		CCOPT="$(TARGET_CFLAGS)" \
+		INCLS="-I. $(TARGET_CPPFLAGS)" \
+		LIBS="$(TARGET_LDFLAGS) -lpcap" \
+		all
+endef
+
+define Package/arpwatch/install
+	$(INSTALL_DIR) $(1)/etc/arpwatch $(1)/usr/sbin $(1)/etc/init.d $(1)/etc/config
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/arp{watch,snmp} $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/arpwatch.init $(1)/etc/init.d/arpwatch
+	$(INSTALL_CONF) ./files/arpwatch $(1)/etc/config/arpwatch
+endef
+
+$(eval $(call BuildPackage,arpwatch))

--- a/net/arpwatch/files/arpwatch
+++ b/net/arpwatch/files/arpwatch
@@ -1,0 +1,13 @@
+config arpwatch
+	option enable 1
+	option network lan
+	option emailaddress root
+	option disablepromiscuous 1
+	option bogonsalladdresses 1
+	option nobogons 0
+	option nonewstations 0
+	option restartinterfacegone 30
+	option noemails 0
+	option noreversedns 1
+	option runasuser arpwatch
+

--- a/net/arpwatch/files/arpwatch.init
+++ b/net/arpwatch/files/arpwatch.init
@@ -1,0 +1,95 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2006-2011 OpenWrt.org
+
+START=90
+STOP=10
+
+USE_PROCD=1
+PROG=/usr/sbin/arpwatch
+NAME=arpwatch
+PIDCOUNT=0
+
+validate_section_arpwatch()
+{
+	if ! uci_validate_section arpwatch arpwatch "${1}" \
+		'network:string' \
+	        'emailaddress:string' \
+		'disablepromiscuous:bool:1' \
+		'bogonsalladdresses:bool:1' \
+		'nobogons:0' \
+		'nonewstations:0' \
+		'restartinterfacegone:uinteger:0' \
+		'noemails:bool:0' \
+		'noreversedns:bool:1' \
+		'enable:bool:1' \
+		'sendmailpath:string:/usr/sbin/sendmail' \
+		'runasuser:string:arpwatch'
+        then
+		return 1
+        fi
+
+	[ "$nobogons" = "1" ] && [ "$bogonsalladdresses" = "1" ] && return 1
+
+	[ -n "$emailaddress"  ] && [ "$noemails" = "1" ] && return 1
+
+	[ -z "$emailaddress" ] && [ "$noemails" = "0" ] && return 1
+
+	[ -n "$network" ] || return 1
+	
+	return 0
+}
+
+arpwatch_instance() {
+	local network emailaddress disablepromiscuous bogonsalladdresses nobogon nonewstations restartinterfacegone noemails noreversedns enable sendmailpath runasuser
+
+	validate_section_arpwatch "${1}" || {
+		echo "Validation failed"
+		return 1
+	}
+
+	[ "${enable}" = "0" ] && return 1
+	PIDCOUNT="$(( ${PIDCOUNT} + 1))"
+	local pid_file="/var/run/${NAME}.${PIDCOUNT}.pid"
+
+	touch /etc/arpwatch/arp.dat
+	chown -R $runasuser:$(id -g $runasuser) /etc/arpwatch
+	chmod 700 /etc/arpwatch
+
+	procd_open_instance
+	procd_set_param command "$PROG" -F -P "$pid_file"
+	[ -n "$emailaddress" ] && procd_append_param command -m "$emailaddress"
+	[ "$disablepromiscuous" = "1" ] && procd_append_param command -p
+	[ "$bogonsalladdresses" = "1" ] && procd_append_param command -a
+	[ "$nobogons" = "1" ] && procd_append_param command -N
+	[ "$nonewstations" = "1" ] && procd_append_param command -S
+	[ "$restartinterfacegone" != "0" ] && procd_append_param command -R "$restartinterfacegone"
+	[ "$restartinterfacegone" = "0" ] && procd_append_param command -u "$runasuser"
+	[ "$noemails" = "1" ] && procd_append_param command -Q
+	[ "$noemails" != "1" ] && procd_append_param command -s "$sendmailpath"
+	[ "$noreversedns" = "1" ] && procd_append_param command -D
+	local ifname
+	network_get_device ifname "$network"	
+	if [ -n "$ifname" ]; then
+		procd_append_param command -i "$ifname"
+		procd_append_param netdev "$ifname"
+	else
+		echo "Unable to find interface"
+		return 1
+	fi
+	procd_close_instance
+
+        return 0
+}
+
+start_service() {
+	. /lib/functions.sh
+	. /lib/functions/network.sh
+
+	config_load "${NAME}"
+	config_foreach arpwatch_instance arpwatch
+}
+
+service_triggers() {
+	procd_add_reload_trigger "arpwatch"
+	procd_add_validation validate_section_arpwatch
+}

--- a/net/arpwatch/patches/010_gentoo_arpwatch-2.1a15-getopt.patch
+++ b/net/arpwatch/patches/010_gentoo_arpwatch-2.1a15-getopt.patch
@@ -1,0 +1,150 @@
+Patch from debian. Just reorders usage output and getopt options to ease adding new features.
+
+
+diff -Naru arpwatch-2.1a15.orig/arpsnmp.8 arpwatch-2.1a15/arpsnmp.8
+--- arpwatch-2.1a15.orig/arpsnmp.8	2006-09-22 17:18:02.000000000 +0400
++++ arpwatch-2.1a15/arpsnmp.8	2006-09-22 18:17:44.000000000 +0400
+@@ -27,10 +27,15 @@
+ .B arpsnmp
+ [
+ .B -d
+-] [
++]
++.br
++.ti +8
++[
+ .B -f
+ .I datafile
+ ]
++.br
++.ti +8
+ .I file
+ [
+ .I ...
+diff -Naru arpwatch-2.1a15.orig/arpsnmp.c arpwatch-2.1a15/arpsnmp.c
+--- arpwatch-2.1a15.orig/arpsnmp.c	2004-01-23 01:25:17.000000000 +0300
++++ arpwatch-2.1a15/arpsnmp.c	2006-09-22 18:17:15.000000000 +0400
+@@ -78,6 +78,10 @@
+ 	register char *cp;
+ 	register int op, i;
+ 	char errbuf[256];
++	char options[] =
++		"d"
++		"f:"
++	;
+ 
+ 	if ((cp = strrchr(argv[0], '/')) != NULL)
+ 		prog = cp + 1;
+@@ -90,7 +94,7 @@
+ 	}
+ 
+ 	opterr = 0;
+-	while ((op = getopt(argc, argv, "df:")) != EOF)
++	while ((op = getopt(argc, argv, options)) != EOF)
+ 		switch (op) {
+ 
+ 		case 'd':
+@@ -182,9 +186,14 @@
+ usage(void)
+ {
+ 	extern char version[];
++	char usage[] =
++		"[-d] "
++		"[-f datafile] "
++		"file [...]\n"
++	;
+ 
+ 	(void)fprintf(stderr, "Version %s\n", version);
+ 	(void)fprintf(stderr,
+-	    "usage: %s [-d] [-f datafile] file [...]\n", prog);
++	    "usage: %s %s", prog, usage);
+ 	exit(1);
+ }
+diff -Naru arpwatch-2.1a15.orig/arpwatch.8 arpwatch-2.1a15/arpwatch.8
+--- arpwatch-2.1a15.orig/arpwatch.8	2006-09-22 17:18:02.000000000 +0400
++++ arpwatch-2.1a15/arpwatch.8	2006-09-22 18:19:20.000000000 +0400
+@@ -28,10 +28,16 @@
+ .B arpwatch
+ [
+ .B -dN
+-] [
++]
++.br
++.ti +8
++[
+ .B -f
+ .I datafile
+-] [
++]
++.br
++.ti +8
++[
+ .B -i
+ .I interface
+ ]
+@@ -40,7 +46,10 @@
+ [
+ .B -n
+ .IR net [/ width
+-]] [
++]]
++.br
++.ti +8
++[
+ .B -r
+ .I file
+ ]
+diff -Naru arpwatch-2.1a15.orig/arpwatch.c arpwatch-2.1a15/arpwatch.c
+--- arpwatch-2.1a15.orig/arpwatch.c	2004-01-23 01:18:20.000000000 +0300
++++ arpwatch-2.1a15/arpwatch.c	2006-09-22 18:22:35.000000000 +0400
+@@ -153,6 +153,14 @@
+ 	register char *interface, *rfilename;
+ 	struct bpf_program code;
+ 	char errbuf[PCAP_ERRBUF_SIZE];
++	char options[] =
++		"d"
++		"f:"
++		"i:"
++		"n:"
++		"N"
++		"r:"
++	;
+ 
+ 	if (argv[0] == NULL)
+ 		prog = "arpwatch";
+@@ -170,7 +178,7 @@
+ 	interface = NULL;
+ 	rfilename = NULL;
+ 	pd = NULL;
+-	while ((op = getopt(argc, argv, "df:i:n:Nr:")) != EOF)
++	while ((op = getopt(argc, argv, options)) != EOF)
+ 		switch (op) {
+ 
+ 		case 'd':
+@@ -201,7 +209,6 @@
+ 		case 'r':
+ 			rfilename = optarg;
+ 			break;
+-
+ 		default:
+ 			usage();
+ 		}
+@@ -748,9 +755,16 @@
+ usage(void)
+ {
+ 	extern char version[];
++	char usage[] =
++		"[-dN] "
++		"[-f datafile] "
++		"[-i interface] "
++		"[-n net[/width]] "
++		"[-r file] "
++		"\n"
++	;
+ 
+ 	(void)fprintf(stderr, "Version %s\n", version);
+-	(void)fprintf(stderr, "usage: %s [-dN] [-f datafile] [-i interface]"
+-	    " [-n net[/width]] [-r file]\n", prog);
++	(void)fprintf(stderr, "usage: %s %s", prog, usage);
+ 	exit(1);
+ }

--- a/net/arpwatch/patches/100_gentoo_arpwatch-2.1a15-sendmail-cmdline-opt.patch
+++ b/net/arpwatch/patches/100_gentoo_arpwatch-2.1a15-sendmail-cmdline-opt.patch
@@ -1,0 +1,159 @@
+This patch from debian adds possibility to specify sendmail program.
+
+diff -Naru arpwatch-2.1a15.orig/arpsnmp.8 arpwatch-2.1a15/arpsnmp.8
+--- arpwatch-2.1a15.orig/arpsnmp.8	2006-09-22 19:26:53.000000000 +0400
++++ arpwatch-2.1a15/arpsnmp.8	2006-09-22 19:31:59.000000000 +0400
+@@ -36,6 +36,12 @@
+ ]
+ .br
+ .ti +8
++[
++.B -s
++.I sendmail_path
++]
++.br
++.ti +8
+ .I file
+ [
+ .I ...
+@@ -60,6 +66,13 @@
+ The default is
+ .IR arp.dat .
+ .LP
++The
++.B -s
++flag is used to specify the path to the sendmail program. Any program that
++takes the option -odi and then text from stdin can be substituted. This is
++useful for redirecting reports to log files instead of mail. (This feature
++comes from Debian).
++.LP
+ Note that an empty
+ .I arp.dat
+ file must be created before the first time you run
+diff -Naru arpwatch-2.1a15.orig/arpsnmp.c arpwatch-2.1a15/arpsnmp.c
+--- arpwatch-2.1a15.orig/arpsnmp.c	2006-09-22 19:26:53.000000000 +0400
++++ arpwatch-2.1a15/arpsnmp.c	2006-09-22 19:26:23.000000000 +0400
+@@ -67,6 +67,7 @@
+ __dead	void usage(void) __attribute__((volatile));
+ 
+ char *prog;
++char *path_sendmail = PATH_SENDMAIL;
+ 
+ extern int optind;
+ extern int opterr;
+@@ -81,6 +82,7 @@
+ 	char options[] =
+ 		"d"
+ 		"f:"
++		"s:"
+ 	;
+ 
+ 	if ((cp = strrchr(argv[0], '/')) != NULL)
+@@ -109,6 +111,10 @@
+ 			arpfile = optarg;
+ 			break;
+ 
++		case 's':
++			path_sendmail = optarg;
++			break;
++
+ 		default:
+ 			usage();
+ 		}
+@@ -189,6 +195,7 @@
+ 	char usage[] =
+ 		"[-d] "
+ 		"[-f datafile] "
++		"[-s sendmail_path] "
+ 		"file [...]\n"
+ 	;
+ 
+diff -Naru arpwatch-2.1a15.orig/arpwatch.8 arpwatch-2.1a15/arpwatch.8
+--- arpwatch-2.1a15.orig/arpwatch.8	2006-09-22 19:26:53.000000000 +0400
++++ arpwatch-2.1a15/arpwatch.8	2006-09-22 19:28:02.000000000 +0400
+@@ -53,6 +53,12 @@
+ .B -r
+ .I file
+ ]
++.br
++.ti +8
++[
++.B -s
++.I sendmail_path
++]
+ .ad
+ .SH DESCRIPTION
+ .B Arpwatch
+@@ -103,6 +109,13 @@
+ .B arpwatch
+ does not fork.
+ .LP
++The
++.B -s
++flag is used to specify the path to the sendmail program. Any program that
++takes the option -odi and then text from stdin can be substituted. This is
++useful for redirecting reports to log files instead of mail. (This feature
++comes from Debian).
++.LP
+ Note that an empty
+ .I arp.dat
+ file must be created before the first time you run
+diff -Naru arpwatch-2.1a15.orig/arpwatch.c arpwatch-2.1a15/arpwatch.c
+--- arpwatch-2.1a15.orig/arpwatch.c	2006-09-22 19:26:53.000000000 +0400
++++ arpwatch-2.1a15/arpwatch.c	2006-09-22 19:26:23.000000000 +0400
+@@ -106,6 +106,7 @@
+ #endif
+ 
+ char *prog;
++char *path_sendmail = PATH_SENDMAIL;
+ 
+ int can_checkpoint;
+ int swapped;
+@@ -160,6 +161,7 @@
+ 		"n:"
+ 		"N"
+ 		"r:"
++		"s:"
+ 	;
+ 
+ 	if (argv[0] == NULL)
+@@ -209,6 +211,11 @@
+ 		case 'r':
+ 			rfilename = optarg;
+ 			break;
++
++		case 's':
++			path_sendmail = optarg;
++			break;
++
+ 		default:
+ 			usage();
+ 		}
+@@ -761,6 +768,7 @@
+ 		"[-i interface] "
+ 		"[-n net[/width]] "
+ 		"[-r file] "
++		"[-s sendmail_path] "
+ 		"\n"
+ 	;
+ 
+diff -Naru arpwatch-2.1a15.orig/report.c arpwatch-2.1a15/report.c
+--- arpwatch-2.1a15.orig/report.c	2000-10-01 03:41:10.000000000 +0400
++++ arpwatch-2.1a15/report.c	2006-09-22 19:26:23.000000000 +0400
+@@ -235,6 +235,7 @@
+ report(register char *title, register u_int32_t a, register u_char *e1,
+     register u_char *e2, register time_t *t1p, register time_t *t2p)
+ {
++	extern char *path_sendmail;
+ 	register char *cp, *hn;
+ 	register int fd, pid;
+ 	register FILE *f;
+@@ -242,7 +243,7 @@
+ 	char *fmt = "%20s: %s\n";
+ 	char *watcher = WATCHER;
+ 	char *watchee = WATCHEE;
+-	char *sendmail = PATH_SENDMAIL;
++	char *sendmail = path_sendmail;
+ 	char *unknown = "<unknown>";
+ 	char buf[132];
+ 	static int init = 0;

--- a/net/arpwatch/patches/110_gentoo_arpwatch-2.1a15-promiscuous-mode.patch
+++ b/net/arpwatch/patches/110_gentoo_arpwatch-2.1a15-promiscuous-mode.patch
@@ -1,0 +1,89 @@
+diff -Naru arpwatch-2.1a15.orig/arpwatch.8 arpwatch-2.1a15/arpwatch.8
+--- arpwatch-2.1a15.orig/arpwatch.8	2006-09-22 19:33:49.000000000 +0400
++++ arpwatch-2.1a15/arpwatch.8	2006-09-22 19:34:52.000000000 +0400
+@@ -59,6 +59,11 @@
+ .B -s
+ .I sendmail_path
+ ]
++.br
++.ti +8
++[
++.B -p
++]
+ .ad
+ .SH DESCRIPTION
+ .B Arpwatch
+@@ -116,6 +121,15 @@
+ useful for redirecting reports to log files instead of mail. (This feature
+ comes from Debian).
+ .LP
++The
++.B -p
++flag disables promiscuous operation. ARP broadcasts get through hubs without
++having the interface in promiscuous mode, while saving considerable resources
++that would be wasted on processing gigabytes of non-broadcast traffic. OTOH,
++setting promiscuous mode does not mean getting 100% traffic that would concern
++.B arpwatch.
++YMMV. (This feature comes from Debian).
++.LP
+ Note that an empty
+ .I arp.dat
+ file must be created before the first time you run
+diff -Naru arpwatch-2.1a15.orig/arpwatch.c arpwatch-2.1a15/arpwatch.c
+--- arpwatch-2.1a15.orig/arpwatch.c	2006-09-22 19:33:49.000000000 +0400
++++ arpwatch-2.1a15/arpwatch.c	2006-09-22 19:34:07.000000000 +0400
+@@ -162,6 +162,7 @@
+ 		"N"
+ 		"r:"
+ 		"s:"
++		"p"
+ 	;
+ 
+ 	if (argv[0] == NULL)
+@@ -216,6 +217,10 @@
+ 			path_sendmail = optarg;
+ 			break;
+ 
++		case 'p':
++			++nopromisc;
++			break;
++
+ 		default:
+ 			usage();
+ 		}
+@@ -283,7 +288,7 @@
+ 		snaplen = max(sizeof(struct ether_header),
+ 		    sizeof(struct fddi_header)) + sizeof(struct ether_arp);
+ 		timeout = 1000;
+-		pd = pcap_open_live(interface, snaplen, 1, timeout, errbuf);
++		pd = pcap_open_live(interface, snaplen, !nopromisc, timeout, errbuf);
+ 		if (pd == NULL) {
+ 			syslog(LOG_ERR, "pcap open %s: %s", interface, errbuf);
+ 			exit(1);
+@@ -769,6 +774,7 @@
+ 		"[-n net[/width]] "
+ 		"[-r file] "
+ 		"[-s sendmail_path] "
++		"[-p] "
+ 		"\n"
+ 	;
+ 
+diff -Naru arpwatch-2.1a15.orig/util.c arpwatch-2.1a15/util.c
+--- arpwatch-2.1a15.orig/util.c	2004-01-23 01:25:39.000000000 +0300
++++ arpwatch-2.1a15/util.c	2006-09-22 19:35:15.000000000 +0400
+@@ -61,6 +61,7 @@
+ 
+ int debug = 0;
+ int initializing = 1;			/* true if initializing */
++int nopromisc = 0;			/* don't activate promisc mode by default */
+ 
+ /* syslog() helper routine */
+ void
+diff -Naru arpwatch-2.1a15.orig/util.h arpwatch-2.1a15/util.h
+--- arpwatch-2.1a15.orig/util.h	1996-10-06 14:22:14.000000000 +0400
++++ arpwatch-2.1a15/util.h	2006-09-22 19:34:07.000000000 +0400
+@@ -17,3 +17,4 @@
+ 
+ extern int debug;
+ extern int initializing;
++extern int nopromisc;

--- a/net/arpwatch/patches/120_gentoo_arpwatch-2.1a15-bogons-report.patch
+++ b/net/arpwatch/patches/120_gentoo_arpwatch-2.1a15-bogons-report.patch
@@ -1,0 +1,507 @@
+diff -Naru arpwatch-2.1a15.orig/arpsnmp.c arpwatch-2.1a15/arpsnmp.c
+--- arpwatch-2.1a15.orig/arpsnmp.c	2006-09-22 19:44:44.000000000 +0400
++++ arpwatch-2.1a15/arpsnmp.c	2006-09-22 19:41:19.000000000 +0400
+@@ -63,7 +63,7 @@
+ /* Forwards */
+ int	main(int, char **);
+ int	readsnmp(char *);
+-int	snmp_add(u_int32_t, u_char *, time_t, char *);
++int	snmp_add(u_int32_t, u_char *, time_t, char *, char *);
+ __dead	void usage(void) __attribute__((volatile));
+ 
+ char *prog;
+@@ -149,22 +149,24 @@
+ static time_t now;
+ 
+ int
+-snmp_add(register u_int32_t a, register u_char *e, time_t t, register char *h)
++snmp_add(register u_int32_t a, register u_char *e, time_t t, register char *h,
++	 char *interface)
+ {
+ 	/* Watch for ethernet broadcast */
+ 	if (MEMCMP(e, zero, 6) == 0 || MEMCMP(e, allones, 6) == 0) {
+-		dosyslog(LOG_INFO, "ethernet broadcast", a, e, NULL);
++		dosyslog(LOG_INFO, "ethernet broadcast", a, e, NULL,
++			 interface);
+ 		return (1);
+ 	}
+ 
+ 	/* Watch for some ip broadcast addresses */
+ 	if (a == 0 || a == 1) {
+-		dosyslog(LOG_INFO, "ip broadcast", a, e, NULL);
++		dosyslog(LOG_INFO, "ip broadcast", a, e, NULL, interface);
+ 		return (1);
+ 	}
+ 
+ 	/* Use current time (although it would be nice to subtract idle time) */
+-	return (ent_add(a, e, now, h));
++	return (ent_add(a, e, now, h, interface));
+ }
+ 
+ /* Process an snmp file */
+diff -Naru arpwatch-2.1a15.orig/arpwatch.8 arpwatch-2.1a15/arpwatch.8
+--- arpwatch-2.1a15.orig/arpwatch.8	2006-09-22 19:44:53.000000000 +0400
++++ arpwatch-2.1a15/arpwatch.8	2006-09-22 19:41:19.000000000 +0400
+@@ -64,6 +64,11 @@
+ [
+ .B -p
+ ]
++.br
++.ti +8
++[
++.B -a
++]
+ .ad
+ .SH DESCRIPTION
+ .B Arpwatch
+@@ -130,6 +135,17 @@
+ .B arpwatch.
+ YMMV. (This feature comes from Debian).
+ .LP
++The
++.B -a
++flag tells
++.B arpwatch
++to report bogons about every IP address. By default,
++.B arpwatch
++reports bogons for IP addresses that are in the same subnet with the first IP
++address of the default interface (unless
++.B -N
++is given). (This feature comes from Debian).
++.LP
+ Note that an empty
+ .I arp.dat
+ file must be created before the first time you run
+diff -Naru arpwatch-2.1a15.orig/arpwatch.c arpwatch-2.1a15/arpwatch.c
+--- arpwatch-2.1a15.orig/arpwatch.c	2006-09-22 19:44:53.000000000 +0400
++++ arpwatch-2.1a15/arpwatch.c	2006-09-22 19:41:19.000000000 +0400
+@@ -142,6 +142,8 @@
+ int	sanity_fddi(struct fddi_header *, struct ether_arp *, int);
+ __dead	void usage(void) __attribute__((volatile));
+ 
++static char *interface;
++
+ int
+ main(int argc, char **argv)
+ {
+@@ -151,7 +153,7 @@
+ 	register int fd;
+ #endif
+ 	register pcap_t *pd;
+-	register char *interface, *rfilename;
++	register char *rfilename;
+ 	struct bpf_program code;
+ 	char errbuf[PCAP_ERRBUF_SIZE];
+ 	char options[] =
+@@ -163,6 +165,7 @@
+ 		"r:"
+ 		"s:"
+ 		"p"
++		"a"
+ 	;
+ 
+ 	if (argv[0] == NULL)
+@@ -221,6 +224,10 @@
+ 			++nopromisc;
+ 			break;
+ 
++		case 'a':
++			++allsubnets;
++			break;
++
+ 		default:
+ 			usage();
+ 		}
+@@ -399,29 +406,31 @@
+ 
+ 	/* Watch for bogons */
+ 	if (isbogon(sia)) {
+-		dosyslog(LOG_INFO, "bogon", sia, sea, sha);
+-		return;
++		dosyslog(LOG_INFO, "bogon", sia, sea, sha, interface);
++		if (!allsubnets) return;
+ 	}
+ 
+ 	/* Watch for ethernet broadcast */
+ 	if (MEMCMP(sea, zero, 6) == 0 || MEMCMP(sea, allones, 6) == 0 ||
+ 	    MEMCMP(sha, zero, 6) == 0 || MEMCMP(sha, allones, 6) == 0) {
+-		dosyslog(LOG_INFO, "ethernet broadcast", sia, sea, sha);
++		dosyslog(LOG_INFO, "ethernet broadcast", sia, sea, sha,
++			 interface);
+ 		return;
+ 	}
+ 
+ 	/* Double check ethernet addresses */
+ 	if (MEMCMP(sea, sha, 6) != 0) {
+-		dosyslog(LOG_INFO, "ethernet mismatch", sia, sea, sha);
++		dosyslog(LOG_INFO, "ethernet mismatch", sia, sea, sha,
++			 interface);
+ 		return;
+ 	}
+ 
+ 	/* Got a live one */
+ 	t = h->ts.tv_sec;
+ 	can_checkpoint = 0;
+-	if (!ent_add(sia, sea, t, NULL))
+-		syslog(LOG_ERR, "ent_add(%s, %s, %ld) failed",
+-		    intoa(sia), e2str(sea), t);
++	if (!ent_add(sia, sea, t, NULL, interface))
++		syslog(LOG_ERR, "ent_add(%s, %s, %ld, %s) failed",
++		    intoa(sia), e2str(sea), t, interface);
+ 	can_checkpoint = 1;
+ }
+ 
+@@ -548,29 +557,31 @@
+ 
+ 	/* Watch for bogons */
+ 	if (isbogon(sia)) {
+-		dosyslog(LOG_INFO, "bogon", sia, sea, sha);
+-		return;
++		dosyslog(LOG_INFO, "bogon", sia, sea, sha, interface);
++		if (!allsubnets) return;
+ 	}
+ 
+ 	/* Watch for ethernet broadcast */
+ 	if (MEMCMP(sea, zero, 6) == 0 || MEMCMP(sea, allones, 6) == 0 ||
+ 	    MEMCMP(sha, zero, 6) == 0 || MEMCMP(sha, allones, 6) == 0) {
+-		dosyslog(LOG_INFO, "ethernet broadcast", sia, sea, sha);
++		dosyslog(LOG_INFO, "ethernet broadcast", sia, sea, sha,
++			 interface);
+ 		return;
+ 	}
+ 
+ 	/* Double check ethernet addresses */
+ 	if (MEMCMP(sea, sha, 6) != 0) {
+-		dosyslog(LOG_INFO, "ethernet mismatch", sia, sea, sha);
++		dosyslog(LOG_INFO, "ethernet mismatch", sia, sea, sha,
++			 interface);
+ 		return;
+ 	}
+ 
+ 	/* Got a live one */
+ 	t = h->ts.tv_sec;
+ 	can_checkpoint = 0;
+-	if (!ent_add(sia, sea, t, NULL))
+-		syslog(LOG_ERR, "ent_add(%s, %s, %ld) failed",
+-		    intoa(sia), e2str(sea), t);
++	if (!ent_add(sia, sea, t, NULL, interface))
++		syslog(LOG_ERR, "ent_add(%s, %s, %ld, %s) failed",
++		    intoa(sia), e2str(sea), t, interface);
+ 	can_checkpoint = 1;
+ }
+ 
+@@ -775,6 +786,7 @@
+ 		"[-r file] "
+ 		"[-s sendmail_path] "
+ 		"[-p] "
++		"[-a] "
+ 		"\n"
+ 	;
+ 
+diff -Naru arpwatch-2.1a15.orig/db.c arpwatch-2.1a15/db.c
+--- arpwatch-2.1a15.orig/db.c	2000-10-01 03:39:58.000000000 +0400
++++ arpwatch-2.1a15/db.c	2006-09-22 19:43:35.000000000 +0400
+@@ -64,6 +64,7 @@
+ 	u_char e[6];		/* ether address */
+ 	char h[34];		/* simple hostname */
+ 	time_t t;		/* timestamp */
++	char i[16];		/* interface */
+ };
+ 
+ /* Address info */
+@@ -80,13 +81,14 @@
+ 
+ static void alist_alloc(struct ainfo *);
+ int cmpeinfo(const void *, const void *);
+-static struct einfo *elist_alloc(u_int32_t, u_char *, time_t, char *);
++static struct einfo *elist_alloc(u_int32_t, u_char *, time_t, char *, char *);
+ static struct ainfo *ainfo_find(u_int32_t);
+ static void check_hname(struct ainfo *);
+ struct ainfo *newainfo(void);
+ 
+ int
+-ent_add(register u_int32_t a, register u_char *e, time_t t, register char *h)
++ent_add(register u_int32_t a, register u_char *e, time_t t, register char *h,
++	char *interface)
+ {
+ 	register struct ainfo *ap;
+ 	register struct einfo *ep;
+@@ -103,7 +105,8 @@
+ 		ep = ap->elist[0];
+ 		if (MEMCMP(e, ep->e, 6) == 0) {
+ 			if (t - ep->t > NEWACTIVITY_DELTA) {
+-				report("new activity", a, e, NULL, &t, &ep->t);
++				report("new activity", a, e, NULL, &t, &ep->t,
++					interface);
+ 				check_hname(ap);
+ 			}
+ 			ep->t = t;
+@@ -114,8 +117,8 @@
+ 	/* Check for a virgin ainfo record */
+ 	if (ap->ecount == 0) {
+ 		ap->ecount = 1;
+-		ap->elist[0] = elist_alloc(a, e, t, h);
+-		report("new station", a, e, NULL, &t, NULL);
++		ap->elist[0] = elist_alloc(a, e, t, h, interface);
++		report("new station", a, e, NULL, &t, NULL, interface);
+ 		return (1);
+ 	}
+ 
+@@ -133,9 +136,11 @@
+ 			if (t - t2 < FLIPFLIP_DELTA &&
+ 			    (isdecnet(e) || isdecnet(e2)))
+ 				dosyslog(LOG_INFO,
+-				    "suppressed DECnet flip flop", a, e, e2);
++				    "suppressed DECnet flip flop", a, e, e2,
++				    interface);
+ 			else
+-				report("flip flop", a, e, e2, &t, &t2);
++				report("flip flop", a, e, e2, &t, &t2,
++					interface);
+ 			ap->elist[1] = ap->elist[0];
+ 			ap->elist[0] = ep;
+ 			ep->t = t;
+@@ -151,7 +156,7 @@
+ 			e2 = ap->elist[0]->e;
+ 			t2 = ap->elist[0]->t;
+ 			dosyslog(LOG_NOTICE, "reused old ethernet address",
+-			    a, e, e2);
++			    a, e, e2, interface);
+ 			/* Shift entries down */
+ 			len = i * sizeof(ap->elist[0]);
+ 			BCOPY(&ap->elist[0], &ap->elist[1], len);
+@@ -165,12 +170,12 @@
+ 	/* New ether address */
+ 	e2 = ap->elist[0]->e;
+ 	t2 = ap->elist[0]->t;
+-	report("changed ethernet address", a, e, e2, &t, &t2);
++	report("changed ethernet address", a, e, e2, &t, &t2, interface);
+ 	/* Make room at head of list */
+ 	alist_alloc(ap);
+ 	len = ap->ecount * sizeof(ap->elist[0]);
+ 	BCOPY(&ap->elist[0], &ap->elist[1], len);
+-	ap->elist[0] = elist_alloc(a, e, t, h);
++	ap->elist[0] = elist_alloc(a, e, t, h, interface);
+ 	++ap->ecount;
+ 	return (1);
+ }
+@@ -227,7 +232,7 @@
+ 		for (ap = &ainfo_table[i]; ap != NULL; ap = ap->next)
+ 			for (j = 0; j < ap->ecount; ++j) {
+ 				ep = ap->elist[j];
+-				(*fn)(ap->a, ep->e, ep->t, ep->h);
++				(*fn)(ap->a, ep->e, ep->t, ep->h, ep->i);
+ 				++n;
+ 			}
+ 	return (n);
+@@ -259,7 +264,7 @@
+ /* Allocate and initialize a elist struct */
+ static struct einfo *
+ elist_alloc(register u_int32_t a, register u_char *e, register time_t t,
+-    register char *h)
++    register char *h, char *interface)
+ {
+ 	register struct einfo *ep;
+ 	register u_int size;
+@@ -286,6 +291,8 @@
+ 	if (h != NULL && !isdigit((int)*h))
+ 		strcpy(ep->h, h);
+ 	ep->t = t;
++	if (interface != NULL)
++		strncpy(ep->i, interface, 16);
+ 	return (ep);
+ }
+ 
+diff -Naru arpwatch-2.1a15.orig/db.h arpwatch-2.1a15/db.h
+--- arpwatch-2.1a15.orig/db.h	1996-06-05 09:39:30.000000000 +0400
++++ arpwatch-2.1a15/db.h	2006-09-22 19:41:19.000000000 +0400
+@@ -1,10 +1,10 @@
+ /* @(#) $Header: db.h,v 1.8 96/06/04 22:39:29 leres Exp $ (LBL) */
+ 
+-typedef void (*ent_process)(u_int32_t, u_char *, time_t, char *);
++typedef void (*ent_process)(u_int32_t, u_char *, time_t, char *, char *);
+ 
+ #ifdef	DEBUG
+ void	debugdump(void);
+ #endif
+-int	ent_add(u_int32_t, u_char *, time_t, char *);
++int	ent_add(u_int32_t, u_char *, time_t, char *, char *);
+ int	ent_loop(ent_process);
+ void	sorteinfo(void);
+diff -Naru arpwatch-2.1a15.orig/file.c arpwatch-2.1a15/file.c
+--- arpwatch-2.1a15.orig/file.c	2000-10-14 02:29:43.000000000 +0400
++++ arpwatch-2.1a15/file.c	2006-09-22 19:41:19.000000000 +0400
+@@ -69,6 +69,7 @@
+ 	u_int32_t a;
+ 	register time_t t;
+ 	register struct hostent *hp;
++	char *interface;
+ 	char line[1024];
+ 	u_char e[6];
+ 
+@@ -117,6 +118,7 @@
+ 		if (cp2 == NULL) {
+ 			t = 0;
+ 			h = NULL;
++			interface = NULL;
+ 		} else {
+ 			t = atoi(cp2);
+ 			h = strchr(cp2, '\t');
+@@ -126,11 +128,18 @@
+ 				while (*cp2 != '\n' && *cp2 != '\t' &&
+ 				    *cp2 != '\0')
+ 					++cp2;
++				if (*cp2 == '\t') {
++				    *cp2++ = '\0';
++				    while (*cp2 != '\n' && *cp2 != '\t' &&
++					   *cp2 != '\0') ++cp2;
++				} else {
++				    interface = NULL;
++				}
+ 				*cp2 = '\0';
+ 			}
+ 		}
+ 
+-		if (!(*fn)(a, e, t, h))
++		if (!(*fn)(a, e, t, h, interface))
+ 			return(0);
+ 	}
+ 
+diff -Naru arpwatch-2.1a15.orig/file.h arpwatch-2.1a15/file.h
+--- arpwatch-2.1a15.orig/file.h	1999-01-18 04:46:04.000000000 +0300
++++ arpwatch-2.1a15/file.h	2006-09-22 19:41:19.000000000 +0400
+@@ -1,5 +1,5 @@
+ /* @(#) $Header: file.h,v 1.4 99/01/17 17:46:03 leres Exp $ (LBL) */
+ 
+-typedef int (*file_process)(u_int32_t, u_char *, time_t, char *);
++typedef int (*file_process)(u_int32_t, u_char *, time_t, char *, char *);
+ 
+ int file_loop(FILE *, file_process, const char *);
+diff -Naru arpwatch-2.1a15.orig/report.c arpwatch-2.1a15/report.c
+--- arpwatch-2.1a15.orig/report.c	2006-09-22 19:44:44.000000000 +0400
++++ arpwatch-2.1a15/report.c	2006-09-22 19:41:19.000000000 +0400
+@@ -233,7 +233,8 @@
+ 
+ void
+ report(register char *title, register u_int32_t a, register u_char *e1,
+-    register u_char *e2, register time_t *t1p, register time_t *t2p)
++    register u_char *e2, register time_t *t1p, register time_t *t2p,
++    char *interface)
+ {
+ 	extern char *path_sendmail;
+ 	register char *cp, *hn;
+@@ -254,7 +255,7 @@
+ 
+ 	if (debug) {
+ 		if (debug > 1) {
+-			dosyslog(LOG_NOTICE, title, a, e1, e2);
++			dosyslog(LOG_NOTICE, title, a, e1, e2, interface);
+ 			return;
+ 		}
+ 		f = stdout;
+@@ -271,7 +272,7 @@
+ 		}
+ 
+ 		/* Syslog this event too */
+-		dosyslog(LOG_NOTICE, title, a, e1, e2);
++		dosyslog(LOG_NOTICE, title, a, e1, e2, interface);
+ 
+ 		/* Update child depth */
+ 		++cdepth;
+@@ -303,16 +304,19 @@
+ 
+ 	(void)fprintf(f, "From: %s\n", watchee);
+ 	(void)fprintf(f, "To: %s\n", watcher);
++	if (interface == NULL) interface = ""; /* shouldn't happen */
+ 	hn = gethname(a);
+ 	if (!isdigit(*hn))
+-		(void)fprintf(f, "Subject: %s (%s)\n", title, hn);
++		(void)fprintf(f, "Subject: %s (%s) %s\n", title, hn,
++			      interface);
+ 	else {
+-		(void)fprintf(f, "Subject: %s\n", title);
++		(void)fprintf(f, "Subject: %s %s\n", title, interface);
+ 		hn = unknown;
+ 	}
+ 	(void)putc('\n', f);
+ 	(void)fprintf(f, fmt, "hostname", hn);
+ 	(void)fprintf(f, fmt, "ip address", intoa(a));
++	(void)fprintf(f, fmt, "interface", interface);
+ 	(void)fprintf(f, fmt, "ethernet address", e2str(e1));
+ 	if ((cp = ec_find(e1)) == NULL)
+ 		cp = unknown;
+diff -Naru arpwatch-2.1a15.orig/report.h arpwatch-2.1a15/report.h
+--- arpwatch-2.1a15.orig/report.h	1996-06-05 09:40:54.000000000 +0400
++++ arpwatch-2.1a15/report.h	2006-09-22 19:41:19.000000000 +0400
+@@ -1,3 +1,3 @@
+ /* @(#) $Header: report.h,v 1.3 96/06/04 22:40:53 leres Exp $ (LBL) */
+ 
+-void report(char *, u_int32_t, u_char *, u_char *, time_t *, time_t *);
++void report(char *, u_int32_t, u_char *, u_char *, time_t *, time_t *, char *);
+diff -Naru arpwatch-2.1a15.orig/util.c arpwatch-2.1a15/util.c
+--- arpwatch-2.1a15.orig/util.c	2006-09-22 19:44:53.000000000 +0400
++++ arpwatch-2.1a15/util.c	2006-09-22 19:41:19.000000000 +0400
+@@ -62,11 +62,12 @@
+ int debug = 0;
+ int initializing = 1;			/* true if initializing */
+ int nopromisc = 0;			/* don't activate promisc mode by default */
++int allsubnets = 0;			/* watch all attached subnets */
+ 
+ /* syslog() helper routine */
+ void
+ dosyslog(register int p, register char *s, register u_int32_t a,
+-    register u_char *ea, register u_char *ha)
++    register u_char *ea, register u_char *ha, char *interface)
+ {
+ 	char xbuf[64];
+ 
+@@ -83,23 +84,21 @@
+ 	}
+ 
+ 	if (debug)
+-		fprintf(stderr, "%s: %s %s %s\n", prog, s, intoa(a), xbuf);
++		fprintf(stderr, "%s: %s %s %s %s\n", prog, s, intoa(a),
++			xbuf, interface);
+ 	else
+-		syslog(p, "%s %s %s", s, intoa(a), xbuf);
++		syslog(p, "%s %s %s %s", s, intoa(a), xbuf, interface);
+ }
+ 
+ static FILE *dumpf;
+ 
+ void
+ dumpone(register u_int32_t a, register u_char *e, register time_t t,
+-    register char *h)
++    register char *h, char *interface)
+ {
+-	(void)fprintf(dumpf, "%s\t%s", e2str(e), intoa(a));
+-	if (t != 0 || h != NULL)
+-		(void)fprintf(dumpf, "\t%u", (u_int32_t)t);
+-	if (h != NULL && *h != '\0')
+-		(void)fprintf(dumpf, "\t%s", h);
+-	(void)putc('\n', dumpf);
++	(void)fprintf(dumpf, "%s\t%s\t%u\t%s\t%s\n", e2str(e), intoa(a),
++		      (u_int32_t)t, ((h != NULL)?h:""),
++		      ((interface != NULL)?interface:""));
+ }
+ 
+ int
+diff -Naru arpwatch-2.1a15.orig/util.h arpwatch-2.1a15/util.h
+--- arpwatch-2.1a15.orig/util.h	2006-09-22 19:44:53.000000000 +0400
++++ arpwatch-2.1a15/util.h	2006-09-22 19:41:19.000000000 +0400
+@@ -1,8 +1,8 @@
+ /* @(#) $Header: util.h,v 1.2 96/10/06 03:22:13 leres Exp $ (LBL) */
+ 
+-void	dosyslog(int, char *, u_int32_t, u_char *, u_char *);
++void	dosyslog(int, char *, u_int32_t, u_char *, u_char *, char *);
+ int	dump(void);
+-void	dumpone(u_int32_t, u_char *, time_t, char *);
++void	dumpone(u_int32_t, u_char *, time_t, char *, char *);
+ int	readdata(void);
+ char	*savestr(const char *);
+ 
+@@ -18,3 +18,4 @@
+ extern int debug;
+ extern int initializing;
+ extern int nopromisc;
++extern int allsubnets;

--- a/net/arpwatch/patches/130_gentoo_arpwatch-2.1a15-specify-mail.patch
+++ b/net/arpwatch/patches/130_gentoo_arpwatch-2.1a15-specify-mail.patch
@@ -1,0 +1,175 @@
+Index: arpwatch-2.1a15/arpsnmp.8
+===================================================================
+--- arpwatch-2.1a15.orig/arpsnmp.8
++++ arpwatch-2.1a15/arpsnmp.8
+@@ -42,6 +42,12 @@ arpsnmp - keep track of ethernet/ip addr
+ ]
+ .br
+ .ti +8
++[
++.B -m
++.I addr
++]
++.br
++.ti +8
+ .I file
+ [
+ .I ...
+@@ -55,6 +61,13 @@ reads information from a file (usually g
+ .BR snmpwalk (8)).
+ .LP
+ The
++.B -m
++option is used to specify the e-mail address to which reports will be
++sent. By default, reports are sent to
++.I root
++on the local machine. (This feature comes from Debian).
++.LP
++The
+ .B -d
+ flag is used enable debugging. This also inhibits mailing the reports.
+ Instead, they are sent to
+Index: arpwatch-2.1a15/arpsnmp.c
+===================================================================
+--- arpwatch-2.1a15.orig/arpsnmp.c
++++ arpwatch-2.1a15/arpsnmp.c
+@@ -82,6 +82,7 @@ main(int argc, char **argv)
+ 	char options[] =
+ 		"d"
+ 		"f:"
++		"m:"
+ 		"s:"
+ 	;
+ 
+@@ -111,6 +112,10 @@ main(int argc, char **argv)
+ 			arpfile = optarg;
+ 			break;
+ 
++		case 'm':
++			mailaddress = optarg;
++			break;
++
+ 		case 's':
+ 			path_sendmail = optarg;
+ 			break;
+@@ -197,6 +202,7 @@ usage(void)
+ 	char usage[] =
+ 		"[-d] "
+ 		"[-f datafile] "
++		"[-m e-mail ] "
+ 		"[-s sendmail_path] "
+ 		"file [...]\n"
+ 	;
+Index: arpwatch-2.1a15/arpwatch.8
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.8
++++ arpwatch-2.1a15/arpwatch.8
+@@ -46,7 +46,7 @@ arpwatch - keep track of ethernet/ip add
+ [
+ .B -n
+ .IR net [/ width
+-]]
++] ]
+ .br
+ .ti +8
+ [
+@@ -56,6 +56,12 @@ arpwatch - keep track of ethernet/ip add
+ .br
+ .ti +8
+ [
++.B -m
++.I e-mail
++]
++.br
++.ti +8
++[
+ .B -s
+ .I sendmail_path
+ ]
+@@ -120,6 +126,13 @@ of reading from the network. In this cas
+ does not fork.
+ .LP
+ The
++.B -m
++option is used to specify the e-mail address to which reports will be
++sent. By default, reports are sent to
++.I root
++on the local machine. (This feature comes from Debian).
++.LP
++The
+ .B -s
+ flag is used to specify the path to the sendmail program. Any program that
+ takes the option -odi and then text from stdin can be substituted. This is
+Index: arpwatch-2.1a15/arpwatch.c
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.c
++++ arpwatch-2.1a15/arpwatch.c
+@@ -163,6 +163,7 @@ main(int argc, char **argv)
+ 		"n:"
+ 		"N"
+ 		"r:"
++		"m:"
+ 		"s:"
+ 		"p"
+ 		"a"
+@@ -216,6 +217,10 @@ main(int argc, char **argv)
+ 			rfilename = optarg;
+ 			break;
+ 
++		case 'm':
++			mailaddress = optarg;
++			break;
++
+ 		case 's':
+ 			path_sendmail = optarg;
+ 			break;
+@@ -784,6 +789,7 @@ usage(void)
+ 		"[-i interface] "
+ 		"[-n net[/width]] "
+ 		"[-r file] "
++		"[-m e-mail] "
+ 		"[-s sendmail_path] "
+ 		"[-p] "
+ 		"[-a] "
+Index: arpwatch-2.1a15/report.c
+===================================================================
+--- arpwatch-2.1a15.orig/report.c
++++ arpwatch-2.1a15/report.c
+@@ -242,7 +242,7 @@ report(register char *title, register u_
+ 	register FILE *f;
+ 	char tempfile[64], cpu[64], os[64];
+ 	char *fmt = "%20s: %s\n";
+-	char *watcher = WATCHER;
++	char *watcher = mailaddress;
+ 	char *watchee = WATCHEE;
+ 	char *sendmail = path_sendmail;
+ 	char *unknown = "<unknown>";
+Index: arpwatch-2.1a15/util.c
+===================================================================
+--- arpwatch-2.1a15.orig/util.c
++++ arpwatch-2.1a15/util.c
+@@ -50,6 +50,7 @@ static const char rcsid[] =
+ #include "ec.h"
+ #include "file.h"
+ #include "util.h"
++#include "addresses.h"
+ 
+ char *arpdir = ARPDIR;
+ char *arpfile = ARPFILE;
+@@ -63,6 +64,7 @@ int debug = 0;
+ int initializing = 1;			/* true if initializing */
+ int nopromisc = 0;			/* don't activate promisc mode by default */
+ int allsubnets = 0;			/* watch all attached subnets */
++char *mailaddress = WATCHER;
+ 
+ /* syslog() helper routine */
+ void
+Index: arpwatch-2.1a15/util.h
+===================================================================
+--- arpwatch-2.1a15.orig/util.h
++++ arpwatch-2.1a15/util.h
+@@ -19,3 +19,4 @@ extern int debug;
+ extern int initializing;
+ extern int nopromisc;
+ extern int allsubnets;
++extern char *mailaddress;

--- a/net/arpwatch/patches/140_gentoo_arpwatch-2.1a15-drop-privileges.patch
+++ b/net/arpwatch/patches/140_gentoo_arpwatch-2.1a15-drop-privileges.patch
@@ -1,0 +1,207 @@
+Index: arpwatch-2.1a15/arpwatch.8
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.8
++++ arpwatch-2.1a15/arpwatch.8
+@@ -75,6 +75,18 @@ arpwatch - keep track of ethernet/ip add
+ [
+ .B -a
+ ]
++.br
++.ti +8
++[
++.B -u
++.I username
++]
++.br
++.ti +8
++[
++.B -R
++.I seconds
++]
+ .ad
+ .SH DESCRIPTION
+ .B Arpwatch
+@@ -159,6 +171,32 @@ address of the default interface (unless
+ .B -N
+ is given). (This feature comes from Debian).
+ .LP
++The
++.B -u
++flag instructs
++.B arpwatch
++to drop root privileges and change the UID to
++.I username
++and GID to the primary group of
++.IR username .
++This is recommended for security reasons, but
++.I username
++has to have write access to the default directory. (This feature comes from Debian).
++.LP
++The
++.B -R
++flag instructs
++.B arpwatch
++to restart in
++.I seconds
++seconds after the interface went down. By default, in such cases
++arpwatch would print an error message and exit. This option is
++ignored if either the
++.B -r
++or
++.B -u
++flags are used. (This feature comes from Debian).
++.LP
+ Note that an empty
+ .I arp.dat
+ file must be created before the first time you run
+Index: arpwatch-2.1a15/arpwatch.c
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.c
++++ arpwatch-2.1a15/arpwatch.c
+@@ -62,7 +62,8 @@ struct rtentry;
+ #include <string.h>
+ #include <syslog.h>
+ #include <unistd.h>
+-
++#include <pwd.h>
++#include <grp.h>
+ #include <pcap.h>
+ 
+ #include "gnuc.h"
+@@ -144,6 +145,82 @@ __dead	void usage(void) __attribute__((v
+ 
+ static char *interface;
+ 
++void dropprivileges(const char* user)
++{
++	struct passwd* pw;
++	gid_t *grplist = NULL;
++	struct group *grp;
++        gid_t runas_grp = 0;
++	int ngroups = 0;
++	pw = getpwnam( user );
++	if ( pw ) {
++		/* Using supplementary groups of user we drop to comes from SANE project GPL */
++        	/* Get group list for runas_uid */
++          	grplist = (gid_t *)malloc(sizeof(gid_t));
++
++		runas_grp = pw->pw_gid;
++
++	  	if (grplist == NULL)
++	    	{
++	      		syslog(LOG_ERR, "FATAL ERROR: cannot allocate memory for group list\n");
++			exit (1);
++		}
++
++		ngroups = 1;
++		grplist[0] = runas_grp;
++
++          	setgrent();
++          	while ((grp = getgrent()) != NULL)
++	    	{
++              		int i = 0;
++
++              		/* Already added current group */
++	              	if (grp->gr_gid == runas_grp)
++	                continue;
++
++        		while (grp->gr_mem[i])
++			{
++                      		int need_to_add = 1, j;
++
++                      		/* Make sure its not already in list */
++                      		for (j = 0; j < ngroups; j++)
++                        	{
++                          		if (grp->gr_gid == grplist[i])
++                            			need_to_add = 0;
++				}
++                      		if (need_to_add)
++                        	{
++                          		grplist = (gid_t *)realloc(grplist, 
++                                               	sizeof(gid_t)*ngroups+1);
++			                       if (grplist == NULL)
++					{
++						syslog(LOG_ERR, "FATAL ERROR: cannot reallocate memory for group list\n");
++
++						exit (1);
++		    			}
++                       			grplist[ngroups++] = grp->gr_gid;
++                       		}
++               			i++;
++               		}
++	    	}
++          	endgrent();	
++		if (setgroups(ngroups, grplist) != 0) {
++	      		syslog(LOG_ERR, "FATAL ERROR: cannot set group list: %s\n", strerror(errno));
++			exit (1);
++		}
++		if ( setgid(pw->pw_gid) != 0 ||
++			setuid(pw->pw_uid) != 0 ) {
++			syslog(LOG_ERR, "Couldn't change to '%.32s' uid=%d gid=%d", user,pw->pw_uid, pw->pw_gid);
++			exit(1);
++		}
++	}
++	else {
++		syslog(LOG_ERR, "Couldn't find user '%.32s' in /etc/passwd", user);
++		exit(1);
++	}
++	syslog(LOG_INFO, "Running as uid=%d gid=%d", getuid(), getgid());
++}
++
+ int
+ main(int argc, char **argv)
+ {
+@@ -156,6 +233,7 @@ main(int argc, char **argv)
+ 	register char *rfilename;
+ 	struct bpf_program code;
+ 	char errbuf[PCAP_ERRBUF_SIZE];
++	char* username = NULL;
+ 	char options[] =
+ 		"d"
+ 		"f:"
+@@ -167,6 +245,7 @@ main(int argc, char **argv)
+ 		"s:"
+ 		"p"
+ 		"a"
++		"u:"
+ 	;
+ 
+ 	if (argv[0] == NULL)
+@@ -233,6 +312,10 @@ main(int argc, char **argv)
+ 			++allsubnets;
+ 			break;
+ 
++		case 'u':
++			username = optarg;
++			break;
++
+ 		default:
+ 			usage();
+ 		}
+@@ -310,12 +393,16 @@ main(int argc, char **argv)
+ #endif
+ 	}
+ 
++	if ( username ) {
++		dropprivileges( username );
++	} else {
+ 	/*
+ 	 * Revert to non-privileged user after opening sockets
+ 	 * (not needed on most systems).
+ 	 */
+-	setgid(getgid());
+-	setuid(getuid());
++		setgid(getgid());
++		setuid(getuid());
++	}
+ 
+ 	/* Must be ethernet or fddi */
+ 	linktype = pcap_datalink(pd);
+@@ -793,6 +880,7 @@ usage(void)
+ 		"[-s sendmail_path] "
+ 		"[-p] "
+ 		"[-a] "
++		"[-u username] "
+ 		"\n"
+ 	;
+ 

--- a/net/arpwatch/patches/150_gentoo_arpwatch-2.1a15-quiet-mail.patch
+++ b/net/arpwatch/patches/150_gentoo_arpwatch-2.1a15-quiet-mail.patch
@@ -1,0 +1,95 @@
+Index: arpwatch-2.1a15/arpwatch.8
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.8
++++ arpwatch-2.1a15/arpwatch.8
+@@ -87,6 +87,11 @@ arpwatch - keep track of ethernet/ip add
+ .B -R
+ .I seconds
+ ]
++.br
++.ti +8
++[
++.B -Q
++]
+ .ad
+ .SH DESCRIPTION
+ .B Arpwatch
+@@ -197,6 +202,10 @@ or
+ .B -u
+ flags are used. (This feature comes from Debian).
+ .LP
++The
++.B -Q
++flags prevents arpwatch from sending reports by mail. (This feature comes from Debian).
++.LP
+ Note that an empty
+ .I arp.dat
+ file must be created before the first time you run
+Index: arpwatch-2.1a15/arpwatch.c
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.c
++++ arpwatch-2.1a15/arpwatch.c
+@@ -246,6 +246,7 @@ main(int argc, char **argv)
+ 		"p"
+ 		"a"
+ 		"u:"
++		"Q"
+ 	;
+ 
+ 	if (argv[0] == NULL)
+@@ -316,6 +317,11 @@ main(int argc, char **argv)
+ 			username = optarg;
+ 			break;
+ 
++		case 'Q':
++			++quiet;
++			break;
++
++
+ 		default:
+ 			usage();
+ 		}
+@@ -881,6 +887,7 @@ usage(void)
+ 		"[-p] "
+ 		"[-a] "
+ 		"[-u username] "
++		"[-Q ] "
+ 		"\n"
+ 	;
+ 
+Index: arpwatch-2.1a15/report.c
+===================================================================
+--- arpwatch-2.1a15.orig/report.c
++++ arpwatch-2.1a15/report.c
+@@ -274,6 +274,10 @@ report(register char *title, register u_
+ 		/* Syslog this event too */
+ 		dosyslog(LOG_NOTICE, title, a, e1, e2, interface);
+ 
++		/* return if watcher is an empty string */
++		if ( quiet )
++			return;
++
+ 		/* Update child depth */
+ 		++cdepth;
+ 
+Index: arpwatch-2.1a15/util.c
+===================================================================
+--- arpwatch-2.1a15.orig/util.c
++++ arpwatch-2.1a15/util.c
+@@ -65,6 +65,7 @@ int initializing = 1;			/* true if initi
+ int nopromisc = 0;			/* don't activate promisc mode by default */
+ int allsubnets = 0;			/* watch all attached subnets */
+ char *mailaddress = WATCHER;
++int quiet = 0;				/* send mail by default */
+ 
+ /* syslog() helper routine */
+ void
+Index: arpwatch-2.1a15/util.h
+===================================================================
+--- arpwatch-2.1a15.orig/util.h
++++ arpwatch-2.1a15/util.h
+@@ -20,3 +20,4 @@ extern int initializing;
+ extern int nopromisc;
+ extern int allsubnets;
+ extern char *mailaddress;
++extern int quiet;

--- a/net/arpwatch/patches/160_gentoo_arpwatch-2.1a15-ignore-net.patch
+++ b/net/arpwatch/patches/160_gentoo_arpwatch-2.1a15-ignore-net.patch
@@ -1,0 +1,99 @@
+Index: arpwatch-2.1a15/arpwatch.8
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.8
++++ arpwatch-2.1a15/arpwatch.8
+@@ -92,6 +92,12 @@ arpwatch - keep track of ethernet/ip add
+ [
+ .B -Q
+ ]
++.br
++.ti +8
++[
++.B -z
++.I ignorenet/ignoremask
++]
+ .ad
+ .SH DESCRIPTION
+ .B Arpwatch
+@@ -206,6 +212,11 @@ The
+ .B -Q
+ flags prevents arpwatch from sending reports by mail. (This feature comes from Debian).
+ .LP
++The
++.B -z
++flag is used to set a range of ip addresses to ignore (such as a DHCP
++range). Netmask is specified as 255.255.128.0. (This feature comes from Debian).
++.LP
+ Note that an empty
+ .I arp.dat
+ file must be created before the first time you run
+Index: arpwatch-2.1a15/arpwatch.c
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.c
++++ arpwatch-2.1a15/arpwatch.c
+@@ -125,6 +125,9 @@ static struct nets *nets;
+ static int nets_ind;
+ static int nets_size;
+ 
++static struct in_addr ignore_net;
++static struct in_addr ignore_netmask;
++
+ extern int optind;
+ extern int opterr;
+ extern char *optarg;
+@@ -247,7 +250,9 @@ main(int argc, char **argv)
+ 		"a"
+ 		"u:"
+ 		"Q"
++		"z:"
+ 	;
++	char *tmpptr;
+ 
+ 	if (argv[0] == NULL)
+ 		prog = "arpwatch";
+@@ -265,6 +270,9 @@ main(int argc, char **argv)
+ 	interface = NULL;
+ 	rfilename = NULL;
+ 	pd = NULL;
++	
++	inet_aton("0.0.0.0", &ignore_netmask);
++	inet_aton("255.255.255.255", &ignore_netmask);
+ 	while ((op = getopt(argc, argv, options)) != EOF)
+ 		switch (op) {
+ 
+@@ -321,6 +329,12 @@ main(int argc, char **argv)
+ 			++quiet;
+ 			break;
+ 
++		case 'z':
++			tmpptr = strtok(optarg, "/");
++			inet_aton(tmpptr, &ignore_net);
++			tmpptr = strtok(NULL, "/");
++			inet_aton(tmpptr, &ignore_netmask);
++			break;
+ 
+ 		default:
+ 			usage();
+@@ -523,6 +537,14 @@ process_ether(register u_char *u, regist
+ 		return;
+ 	}
+ 
++	/* Ignores the specified netmask/metwork */
++	if ((sia & ignore_netmask.s_addr) == ignore_net.s_addr) {
++		if (debug) {
++			dosyslog(LOG_INFO, "ignored", sia, sea, sha, interface);
++		}
++		return;
++	}
++
+ 	/* Got a live one */
+ 	t = h->ts.tv_sec;
+ 	can_checkpoint = 0;
+@@ -888,6 +910,7 @@ usage(void)
+ 		"[-a] "
+ 		"[-u username] "
+ 		"[-Q ] "
++		"[-z ignorenet/ignoremask] "
+ 		"\n"
+ 	;
+ 

--- a/net/arpwatch/patches/170_gentoo_arpwatch-2.1a15-secure-tmp.patch
+++ b/net/arpwatch/patches/170_gentoo_arpwatch-2.1a15-secure-tmp.patch
@@ -1,0 +1,28 @@
+Index: arpwatch-2.1a15/bihourly.sh
+===================================================================
+--- arpwatch-2.1a15.orig/bihourly.sh
++++ arpwatch-2.1a15/bihourly.sh
+@@ -10,8 +10,8 @@ cd /usr/operator/arpwatch
+ #
+ list="`cat list`"
+ cname="`cat cname`"
+-temp1=/tmp/bihourly.1.$$
+-temp2=/tmp/bihourly.2.$$
++temp1=`tempfile -p arpbh -s .tmp`
++temp2=`tempfile -p arpbh -s .tmp`
+ d=/tmp/errs
+ 
+ # imperfect hack
+Index: arpwatch-2.1a15/mkdep
+===================================================================
+--- arpwatch-2.1a15.orig/mkdep
++++ arpwatch-2.1a15/mkdep
+@@ -51,7 +51,7 @@ if [ ! -w $MAKE ]; then
+ 	exit 1
+ fi
+ 
+-TMP=/tmp/mkdep$$
++TMP=`tempfile -p mkdep -s .tmp`
+ 
+ trap 'rm -f $TMP ; exit 1' 1 2 3 13 15
+ 

--- a/net/arpwatch/patches/180_gentoo_arpwatch-2.1a15-scripts-awk.patch
+++ b/net/arpwatch/patches/180_gentoo_arpwatch-2.1a15-scripts-awk.patch
@@ -1,0 +1,33 @@
+Index: arpwatch-2.1a15/arp2ethers
+===================================================================
+--- arpwatch-2.1a15.orig/arp2ethers
++++ arpwatch-2.1a15/arp2ethers
+@@ -13,11 +13,10 @@
+ #	- sort
+ #
+ 
+-sort +2rn arp.dat | \
+-    awk 'NF == 4 { print }' | \
++export AWKPATH="$AWKPATH:/usr/share/arpwatch/awk"
++
++sort -k 3rn ${1:-/var/lib/arpwatch/arp.dat} | \
+     awk -f p.awk | \
+-    egrep -v '\.[0-9][0-9]*$' | \
+-    sed -e 's/	.*	/	/' | \
+     awk -f d.awk | \
+     awk -f e.awk | \
+     sort
+Index: arpwatch-2.1a15/massagevendor
+===================================================================
+--- arpwatch-2.1a15.orig/massagevendor
++++ arpwatch-2.1a15/massagevendor
+@@ -9,6 +9,9 @@
+ #
+ # - Deal with duplicates in oui.txt (concatenate company names)
+ #
++
++export AWKPATH="$AWKPATH:/usr/share/arpwatch/awk"
++
+ (sed -n \
+     -e 's/^\([0-9A-F][0-9A-F]\)-\([0-9A-F][0-9A-F]\)-\([0-9A-F][0-9A-F]\)  *(hex)[ 	]*\(..*\)/\1\2\3	\4/p' \
+     $* | \

--- a/net/arpwatch/patches/190_gentoo_arpwatch-2.1a15-paths-fix.patch
+++ b/net/arpwatch/patches/190_gentoo_arpwatch-2.1a15-paths-fix.patch
@@ -1,0 +1,35 @@
+diff -Naru arpwatch-2.1a15.orig/arpwatch.h arpwatch-2.1a15/arpwatch.h
+--- arpwatch-2.1a15.orig/arpwatch.h	2000-10-01 03:40:55.000000000 +0400
++++ arpwatch-2.1a15/arpwatch.h	2006-09-22 22:48:13.000000000 +0400
+@@ -1,7 +1,7 @@
+ /* @(#) $Id: arpwatch.h,v 1.29 2000/09/30 23:40:49 leres Exp $ (LBL) */
+ 
+ #define ARPFILE "arp.dat"
+-#define ETHERCODES "ethercodes.dat"
++/*#define ETHERCODES "ethercodes.dat" */
+ #define CHECKPOINT (15*60)		/* Checkpoint time in seconds */
+ 
+ #define MEMCMP(a, b, n) memcmp((char *)a, (char *)b, n)
+diff -Naru arpwatch-2.1a15.orig/Makefile.in arpwatch-2.1a15/Makefile.in
+--- arpwatch-2.1a15.orig/Makefile.in	2006-09-22 22:48:59.000000000 +0400
++++ arpwatch-2.1a15/Makefile.in	2006-09-22 22:49:23.000000000 +0400
+@@ -31,7 +31,8 @@
+ # Pathname of directory to install the man page
+ MANDEST = @mandir@
+ # Pathname of directory to install database file
+-ARPDIR = $(prefix)/arpwatch
++ARPDIR = /var/lib/arpwatch
++ETHERCODES = /usr/share/arpwatch/ethercodes.dat
+ 
+ # VPATH
+ srcdir = @srcdir@
+@@ -45,7 +46,8 @@
+ PROG = arpwatch
+ CCOPT = @V_CCOPT@
+ INCLS = -I. @V_INCLS@
+-DEFS = -DDEBUG @DEFS@ -DARPDIR=\"$(ARPDIR)\" -DPATH_SENDMAIL=\"$(SENDMAIL)\"
++DEFS = -DDEBUG @DEFS@ -DARPDIR=\"$(ARPDIR)\" -DPATH_SENDMAIL=\"$(SENDMAIL)\" \
++       -DETHERCODES=\"$(ETHERCODES)\"
+ 
+ # Standard CFLAGS
+ CFLAGS = $(CCOPT) $(DEFS) $(INCLS)

--- a/net/arpwatch/patches/200_gentoo_arpwatch-2.1a15-fix-dead-lock.patch
+++ b/net/arpwatch/patches/200_gentoo_arpwatch-2.1a15-fix-dead-lock.patch
@@ -1,0 +1,32 @@
+diff -Naru arpwatch-2.1a15.orig/report.c arpwatch-2.1a15/report.c
+--- arpwatch-2.1a15.orig/report.c	2006-09-23 19:31:47.000000000 +0400
++++ arpwatch-2.1a15/report.c	2006-09-23 19:38:54.000000000 +0400
+@@ -217,7 +217,12 @@
+ 				continue;
+ 			/* ECHILD means no one left */
+ 			if (errno != ECHILD)
+-				syslog(LOG_ERR, "reaper: %m");
++				/* It is dangerous to call non reentrant */
++				/* functions from callback (POSIX) */
++				/* Next line effectively disables this as */
++				/* we never get here in debug */
++				if (debug)
++					syslog(LOG_ERR, "reaper: %m");
+ 			break;
+ 		}
+ 		/* Already got everyone who was done */
+@@ -225,8 +230,13 @@
+ 			break;
+ 		--cdepth;
+ 		if (WEXITSTATUS(status))
++			/* It is dangerous to call non-reentrant */
++			/* functions from callback (POSIX) */
++			/* Next line effectively disables this as */
++			/* we never get here in debug */
++			if (debug)
+ 			syslog(LOG_DEBUG, "reaper: pid %d, exit status %d",
+-			    pid, WEXITSTATUS(status));
++				    pid, WEXITSTATUS(status));
+ 	}
+ 	return RETSIGVAL;
+ }

--- a/net/arpwatch/patches/210_gentoo_arpwatch-2.1a15-restart.patch
+++ b/net/arpwatch/patches/210_gentoo_arpwatch-2.1a15-restart.patch
@@ -1,0 +1,163 @@
+Index: arpwatch-2.1a15/arpwatch.c
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.c
++++ arpwatch-2.1a15/arpwatch.c
+@@ -237,6 +237,8 @@ main(int argc, char **argv)
+ 	struct bpf_program code;
+ 	char errbuf[PCAP_ERRBUF_SIZE];
+ 	char* username = NULL;
++	int restart = 0;
++	int restarting_loop = 0;
+ 	char options[] =
+ 		"d"
+ 		"f:"
+@@ -249,6 +251,7 @@ main(int argc, char **argv)
+ 		"p"
+ 		"a"
+ 		"u:"
++		"R:"
+ 		"Q"
+ 		"z:"
+ 	;
+@@ -325,6 +328,10 @@ main(int argc, char **argv)
+ 			username = optarg;
+ 			break;
+ 
++		case 'R':
++			restart = atoi(optarg);
++			break;
++
+ 		case 'Q':
+ 			++quiet;
+ 			break;
+@@ -343,6 +350,12 @@ main(int argc, char **argv)
+ 	if (optind != argc)
+ 		usage();
+ 
++	if ( username && restart ) {
++		syslog(LOG_ERR, "Please, specify either -u or -R");		
++		(void)fprintf(stderr,"Please, specify either -u or -R. See arpwatch.8\n");
++		exit(1);
++	}
++
+ 	if (rfilename != NULL) {
+ 		net = 0;
+ 		netmask = 0;
+@@ -392,6 +405,7 @@ main(int argc, char **argv)
+ 		syslog(LOG_ERR, "(using current working directory)");
+ 	}
+ 
++label_restart:
+ 	if (rfilename != NULL) {
+ 		pd = pcap_open_offline(rfilename, errbuf);
+ 		if (pd == NULL) {
+@@ -406,22 +420,30 @@ main(int argc, char **argv)
+ 		pd = pcap_open_live(interface, snaplen, !nopromisc, timeout, errbuf);
+ 		if (pd == NULL) {
+ 			syslog(LOG_ERR, "pcap open %s: %s", interface, errbuf);
+-			exit(1);
++			if (restart) {
++				syslog(LOG_ERR, "restart in %d secs", restart);
++			} else {
++				exit(1);
++			}
++			sleep(restart);
++			goto label_restart;
+ 		}
+ #ifdef WORDS_BIGENDIAN
+ 		swapped = 1;
+ #endif
+ 	}
+ 
+-	if ( username ) {
+-		dropprivileges( username );
+-	} else {
+-	/*
+-	 * Revert to non-privileged user after opening sockets
+-	 * (not needed on most systems).
+-	 */
+-		setgid(getgid());
+-		setuid(getuid());
++	if (!restarting_loop) {
++		if ( username && !restart ) {
++			dropprivileges( username );
++		} else {
++			/*
++			 * Revert to non-privileged user after opening sockets
++			 * (not needed on most systems).
++			 */
++			setgid(getgid());
++			setuid(getuid());
++		}
+ 	}
+ 
+ 	/* Must be ethernet or fddi */
+@@ -444,26 +466,30 @@ main(int argc, char **argv)
+ 	if (rfilename == NULL)
+ 		syslog(LOG_INFO, "listening on %s", interface);
+ 
+-	/* Read in database */
+-	initializing = 1;
+-	if (!readdata())
+-		exit(1);
+-	sorteinfo();
++	if (!restarting_loop) {
++		/* Read in database */
++		initializing = 1;
++		if (!readdata())
++			exit(1);
++		sorteinfo();
++	}
+ #ifdef DEBUG
+ 	if (debug > 2) {
+ 		debugdump();
+ 		exit(0);
+ 	}
+ #endif
+-	initializing = 0;
++	if (!restarting_loop) {
++		initializing = 0;
+ 
+-	(void)setsignal(SIGINT, die);
+-	(void)setsignal(SIGTERM, die);
+-	(void)setsignal(SIGHUP, die);
+-	if (rfilename == NULL) {
+-		(void)setsignal(SIGQUIT, checkpoint);
+-		(void)setsignal(SIGALRM, checkpoint);
+-		(void)alarm(CHECKPOINT);
++		(void)setsignal(SIGINT, die);
++		(void)setsignal(SIGTERM, die);
++		(void)setsignal(SIGHUP, die);
++		if (rfilename == NULL) {
++			(void)setsignal(SIGQUIT, checkpoint);
++			(void)setsignal(SIGALRM, checkpoint);
++			(void)alarm(CHECKPOINT);
++		}
+ 	}
+ 
+ 	switch (linktype) {
+@@ -482,7 +508,15 @@ main(int argc, char **argv)
+ 	}
+ 	if (status < 0) {
+ 		syslog(LOG_ERR, "pcap_loop: %s", pcap_geterr(pd));
+-		exit(1);
++		if (restart && rfilename == NULL) {
++			syslog(LOG_ERR, "restart in %d secs", restart);
++			++restarting_loop;
++			pcap_close(pd);
++		} else {
++			exit(1);
++		}
++		sleep(restart);
++		goto label_restart;
+ 	}
+ 	pcap_close(pd);
+ 	if (!dump())
+@@ -909,6 +943,7 @@ usage(void)
+ 		"[-p] "
+ 		"[-a] "
+ 		"[-u username] "
++		"[-R seconds ] "
+ 		"[-Q ] "
+ 		"[-z ignorenet/ignoremask] "
+ 		"\n"

--- a/net/arpwatch/patches/220_gentoo_arpwatch-2.1a15-nofork.patch
+++ b/net/arpwatch/patches/220_gentoo_arpwatch-2.1a15-nofork.patch
@@ -1,0 +1,96 @@
+Origianl idea comes from Matthias Andree.
+
+Index: arpwatch-2.1a15/arpwatch.8
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.8
++++ arpwatch-2.1a15/arpwatch.8
+@@ -27,7 +27,12 @@ arpwatch - keep track of ethernet/ip add
+ .na
+ .B arpwatch
+ [
+-.B -dN
++.B -d
++]
++.br
++.ti +9
++[
++.B -F
+ ]
+ .br
+ .ti +8
+@@ -50,6 +55,11 @@ arpwatch - keep track of ethernet/ip add
+ .br
+ .ti +8
+ [
++.B -N
++]
++.br
++.ti +9
++[
+ .B -r
+ .I file
+ ]
+@@ -115,6 +125,14 @@ background and emailing the reports. Ins
+ .IR stderr .
+ .LP
+ The
++.B -F
++flag is used to prevent 
++.I arpwatch
++from forking. This is allows to run
++.I arpwatch
++from daemon tools.
++.LP
++The
+ .B -f
+ flag is used to set the ethernet/ip address database filename.
+ The default is
+Index: arpwatch-2.1a15/arpwatch.c
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.c
++++ arpwatch-2.1a15/arpwatch.c
+@@ -237,10 +237,12 @@ main(int argc, char **argv)
+ 	struct bpf_program code;
+ 	char errbuf[PCAP_ERRBUF_SIZE];
+ 	char* username = NULL;
++	int nofork = 0;
+ 	int restart = 0;
+ 	int restarting_loop = 0;
+ 	char options[] =
+ 		"d"
++		"F"
+ 		"f:"
+ 		"i:"
+ 		"n:"
+@@ -287,6 +289,10 @@ main(int argc, char **argv)
+ #endif
+ 			break;
+ 
++		case 'F':
++			++nofork;
++			break;
++
+ 		case 'f':
+ 			arpfile = optarg;
+ 			break;
+@@ -377,12 +383,14 @@ main(int argc, char **argv)
+ 
+ 		/* Drop into the background if not debugging */
+ 		if (!debug) {
+-			pid = fork();
+-			if (pid < 0) {
+-				syslog(LOG_ERR, "main fork(): %m");
+-				exit(1);
+-			} else if (pid != 0)
+-				exit(0);
++			if (!nofork) {
++				pid = fork();
++				if (pid < 0) {
++					syslog(LOG_ERR, "main fork(): %m");
++					exit(1);
++				} else if (pid != 0)
++					exit(0);
++			}
+ 			(void)close(fileno(stdin));
+ 			(void)close(fileno(stdout));
+ 			(void)close(fileno(stderr));

--- a/net/arpwatch/patches/230_gentoo_arpwatch-2.1a15-nonewstation.patch
+++ b/net/arpwatch/patches/230_gentoo_arpwatch-2.1a15-nonewstation.patch
@@ -1,0 +1,104 @@
+Index: arpwatch-2.1a15/arpwatch.8
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.8
++++ arpwatch-2.1a15/arpwatch.8
+@@ -60,6 +60,11 @@ arpwatch - keep track of ethernet/ip add
+ .br
+ .ti +9
+ [
++.B -S
++]
++.br
++.ti +9
++[
+ .B -r
+ .I file
+ ]
+@@ -155,6 +160,10 @@ The
+ flag disables reporting any bogons.
+ .LP
+ The
++.B -S
++flag disables reporting of new stations.
++.LP
++The
+ .B -r
+ flag is used to specify a savefile
+ (perhaps created by
+Index: arpwatch-2.1a15/arpwatch.c
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.c
++++ arpwatch-2.1a15/arpwatch.c
+@@ -247,6 +247,7 @@ main(int argc, char **argv)
+ 		"i:"
+ 		"n:"
+ 		"N"
++		"S"
+ 		"r:"
+ 		"m:"
+ 		"s:"
+@@ -310,6 +311,10 @@ main(int argc, char **argv)
+ 			++nobogons;
+ 			break;
+ 
++		case 'S':
++			++nonewstations;
++			break;
++
+ 		case 'r':
+ 			rfilename = optarg;
+ 			break;
+@@ -941,7 +946,7 @@ usage(void)
+ {
+ 	extern char version[];
+ 	char usage[] =
+-		"[-dN] "
++		"[-dNS] "
+ 		"[-f datafile] "
+ 		"[-i interface] "
+ 		"[-n net[/width]] "
+@@ -952,7 +957,7 @@ usage(void)
+ 		"[-a] "
+ 		"[-u username] "
+ 		"[-R seconds ] "
+-		"[-Q ] "
++		"[-Q] "
+ 		"[-z ignorenet/ignoremask] "
+ 		"\n"
+ 	;
+Index: arpwatch-2.1a15/arpwatch.h
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.h
++++ arpwatch-2.1a15/arpwatch.h
+@@ -16,6 +16,8 @@ void bcopy(const void *, void *, size_t)
+ 
+ extern char *prog;
+ 
++extern int nonewstations; /* Turns off new-station reporting. */
++
+ #ifdef ETHER_HEADER_HAS_EA
+ #define ESRC(ep) ((ep)->ether_shost.ether_addr_octet)
+ #define EDST(ep) ((ep)->ether_dhost.ether_addr_octet)
+Index: arpwatch-2.1a15/db.c
+===================================================================
+--- arpwatch-2.1a15.orig/db.c
++++ arpwatch-2.1a15/db.c
+@@ -86,6 +86,8 @@ static struct ainfo *ainfo_find(u_int32_
+ static void check_hname(struct ainfo *);
+ struct ainfo *newainfo(void);
+ 
++int nonewstations = 0;
++
+ int
+ ent_add(register u_int32_t a, register u_char *e, time_t t, register char *h,
+ 	char *interface)
+@@ -118,7 +120,8 @@ ent_add(register u_int32_t a, register u
+ 	if (ap->ecount == 0) {
+ 		ap->ecount = 1;
+ 		ap->elist[0] = elist_alloc(a, e, t, h, interface);
+-		report("new station", a, e, NULL, &t, NULL, interface);
++		if (!nonewstations)
++			report("new station", a, e, NULL, &t, NULL, interface);
+ 		return (1);
+ 	}
+ 

--- a/net/arpwatch/patches/240_gentoo_arpwatch-2.1a15-noreversedns-resolve.patch
+++ b/net/arpwatch/patches/240_gentoo_arpwatch-2.1a15-noreversedns-resolve.patch
@@ -1,0 +1,103 @@
+Index: arpwatch-2.1a15/arpwatch.8
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.8
++++ arpwatch-2.1a15/arpwatch.8
+@@ -110,6 +110,11 @@ arpwatch - keep track of ethernet/ip add
+ .br
+ .ti +8
+ [
++.B -D
++]
++.br
++.ti +9
++[
+ .B -z
+ .I ignorenet/ignoremask
+ ]
+@@ -240,6 +245,10 @@ The
+ flags prevents arpwatch from sending reports by mail. (This feature comes from Debian).
+ .LP
+ The
++.B -D
++flag turns off reverse-DNS queries. This can speed up operations significantly.
++.LP
++The
+ .B -z
+ flag is used to set a range of ip addresses to ignore (such as a DHCP
+ range). Netmask is specified as 255.255.128.0. (This feature comes from Debian).
+Index: arpwatch-2.1a15/arpwatch.c
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.c
++++ arpwatch-2.1a15/arpwatch.c
+@@ -256,6 +256,7 @@ main(int argc, char **argv)
+ 		"u:"
+ 		"R:"
+ 		"Q"
++		"D"
+ 		"z:"
+ 	;
+ 	char *tmpptr;
+@@ -347,6 +348,10 @@ main(int argc, char **argv)
+ 			++quiet;
+ 			break;
+ 
++		case 'D':
++			++noreversedns;
++			break;
++
+ 		case 'z':
+ 			tmpptr = strtok(optarg, "/");
+ 			inet_aton(tmpptr, &ignore_net);
+@@ -958,6 +963,7 @@ usage(void)
+ 		"[-u username] "
+ 		"[-R seconds ] "
+ 		"[-Q] "
++		"[-D] "
+ 		"[-z ignorenet/ignoremask] "
+ 		"\n"
+ 	;
+Index: arpwatch-2.1a15/arpwatch.h
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.h
++++ arpwatch-2.1a15/arpwatch.h
+@@ -17,6 +17,7 @@ void bcopy(const void *, void *, size_t)
+ extern char *prog;
+ 
+ extern int nonewstations; /* Turns off new-station reporting. */
++extern int noreversedns; /* Turns off reverse-dns. */
+ 
+ #ifdef ETHER_HEADER_HAS_EA
+ #define ESRC(ep) ((ep)->ether_shost.ether_addr_octet)
+Index: arpwatch-2.1a15/dns.c
+===================================================================
+--- arpwatch-2.1a15.orig/dns.c
++++ arpwatch-2.1a15/dns.c
+@@ -71,6 +71,8 @@ typedef union {
+ } querybuf;
+ #endif
+ 
++int noreversedns = 0;
++
+ int
+ gethinfo(register char *hostname, register char *cpu, register int cpulen,
+     register char *os, register int oslen)
+@@ -84,6 +86,9 @@ gethinfo(register char *hostname, regist
+ 	register int type, class, buflen, ancount, qdcount;
+ 	querybuf qbuf;
+ 
++	if (noreversedns)
++		return (0);
++
+ 	qb = &qbuf;
+ 	n = res_query(hostname, C_IN, T_HINFO, qb->buf, sizeof(qb->buf));
+ 	if (n < 0)
+@@ -144,6 +149,9 @@ gethname(u_int32_t a)
+ 	register int32_t options;
+ 	register struct hostent *hp;
+ 
++	if (noreversedns)
++		return (intoa(a));
++
+ 	options = _res.options;
+ 	_res.options |= RES_AAONLY;
+ 	_res.options &= ~(RES_DEFNAMES | RES_DNSRCH);

--- a/net/arpwatch/patches/250_gentoo_arpwatch-2.1a15-pid-filename.patch
+++ b/net/arpwatch/patches/250_gentoo_arpwatch-2.1a15-pid-filename.patch
@@ -1,0 +1,114 @@
+Index: arpwatch-2.1a15/arpwatch.8
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.8
++++ arpwatch-2.1a15/arpwatch.8
+@@ -88,6 +88,12 @@ arpwatch - keep track of ethernet/ip add
+ .br
+ .ti +8
+ [
++.B -P
++.I pid_path
++]
++.br
++.ti +9
++[
+ .B -a
+ ]
+ .br
+@@ -204,6 +210,10 @@ setting promiscuous mode does not mean g
+ YMMV. (This feature comes from Debian).
+ .LP
+ The
++.B -P
++flag is used to specify pid filename. Default is set to /var/run/arpwatch.pid.
++.LP
++The
+ .B -a
+ flag tells
+ .B arpwatch
+Index: arpwatch-2.1a15/arpwatch.h
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.h
++++ arpwatch-2.1a15/arpwatch.h
+@@ -1,6 +1,7 @@
+ /* @(#) $Id: arpwatch.h,v 1.29 2000/09/30 23:40:49 leres Exp $ (LBL) */
+ 
+ #define ARPFILE "arp.dat"
++#define PIDFILENAME "/var/run/arpwatch.pid"
+ /*#define ETHERCODES "ethercodes.dat" */
+ #define CHECKPOINT (15*60)		/* Checkpoint time in seconds */
+ 
+Index: arpwatch-2.1a15/arpwatch.c
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.c
++++ arpwatch-2.1a15/arpwatch.c
+@@ -108,6 +108,8 @@ struct rtentry;
+ 
+ char *prog;
+ char *path_sendmail = PATH_SENDMAIL;
++char *pidname = PIDFILENAME;
++int nofork = 0;
+ 
+ int can_checkpoint;
+ int swapped;
+@@ -237,7 +239,6 @@ main(int argc, char **argv)
+ 	struct bpf_program code;
+ 	char errbuf[PCAP_ERRBUF_SIZE];
+ 	char* username = NULL;
+-	int nofork = 0;
+ 	int restart = 0;
+ 	int restarting_loop = 0;
+ 	char options[] =
+@@ -252,6 +253,7 @@ main(int argc, char **argv)
+ 		"m:"
+ 		"s:"
+ 		"p"
++		"P:"
+ 		"a"
+ 		"u:"
+ 		"R:"
+@@ -260,6 +262,7 @@ main(int argc, char **argv)
+ 		"z:"
+ 	;
+ 	char *tmpptr;
++	FILE *pidfile;
+ 
+ 	if (argv[0] == NULL)
+ 		prog = "arpwatch";
+@@ -332,6 +335,10 @@ main(int argc, char **argv)
+ 			++nopromisc;
+ 			break;
+ 
++		case 'P':
++			pidname = optarg;
++			break;
++
+ 		case 'a':
+ 			++allsubnets;
+ 			break;
+@@ -400,6 +407,15 @@ main(int argc, char **argv)
+ 					exit(1);
+ 				} else if (pid != 0)
+ 					exit(0);
++				pidfile = fopen(pidname, "w");
++				if(pidfile) {
++					int pid = (int)getpid();
++					fprintf(pidfile, "%d\n", pid);
++					fclose(pidfile);
++					syslog(LOG_INFO, "Wrote pid %d to %s", pid, pidname);
++				}
++				else
++					fprintf(stderr, "Couldn't write pid file\n");
+ 			}
+ 			(void)close(fileno(stdin));
+ 			(void)close(fileno(stdout));
+@@ -928,6 +944,9 @@ die(int signo)
+ {
+ 
+ 	syslog(LOG_DEBUG, "exiting");
++	if (!debug && !nofork)
++		if(!unlink(pidname))
++			syslog(LOG_DEBUG, "unable to remove pid file %s", pidname);
+ 	checkpoint(0);
+ 	exit(1);
+ }

--- a/net/arpwatch/patches/260_gentoo_arpwatch-2.1a15-respect-ldflags.patch
+++ b/net/arpwatch/patches/260_gentoo_arpwatch-2.1a15-respect-ldflags.patch
@@ -1,0 +1,28 @@
+=== modified file 'Makefile.in'
+Index: arpwatch-2.1a15/Makefile.in
+===================================================================
+--- arpwatch-2.1a15.orig/Makefile.in
++++ arpwatch-2.1a15/Makefile.in
+@@ -97,11 +97,11 @@ all: $(ALL)
+ 
+ arpwatch: $(WOBJ) @V_PCAPDEP@
+ 	@rm -f $@
+-	$(CC) $(CFLAGS) -o $@ $(WOBJ) $(LIBS)
++	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(WOBJ) $(LIBS)
+ 
+ arpsnmp: $(SOBJ)
+ 	@rm -f $@
+-	$(CC) $(CFLAGS) -o $@ $(SOBJ) $(SLIBS)
++	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(SOBJ) $(SLIBS)
+ 
+ version.o: version.c
+ version.c: $(srcdir)/VERSION
+@@ -109,7 +109,7 @@ version.c: $(srcdir)/VERSION
+ 	sed -e 's/.*/char version[] = "&";/' $(srcdir)/VERSION > $@
+ 
+ zap: zap.o intoa.o
+-	$(CC) $(CFLAGS) -o $@ zap.o intoa.o -lutil
++	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ zap.o intoa.o -lutil
+ 
+ install: force
+ 	$(INSTALL) -m 555 -o bin -g bin arpwatch $(DESTDIR)$(BINDEST)

--- a/net/arpwatch/patches/270_gentoo_arpwatch-2.1a15-ignore-802.1Q-packets.patch
+++ b/net/arpwatch/patches/270_gentoo_arpwatch-2.1a15-ignore-802.1Q-packets.patch
@@ -1,0 +1,48 @@
+From 5d852d6f81d4022d500ccfea3e9b84a1d3b07dd0 Mon Sep 17 00:00:00 2001
+From: Rob Leslie <rob@mars.org>
+Date: Sun, 10 Jun 2012 12:35:02 -0700
+Subject: [PATCH] Ignore 802.1Q frames
+
+Due to the way Linux packet filtering works, the pcap library will
+return ARP/RARP packets belonging to other VLANs when listening on the
+corresponding physical interface. This confuses arpwatch as it is not
+expecting such packets; the symptom is many "... sent bad hardware
+format ..." syslog messages.
+
+Since VLAN packets can be accessed via another interface and a separate
+arpwatch instance could be run there (if desired), we simply ignore all
+802.1Q frames.
+---
+ arpwatch.c |   12 ++++++++++++
+ 1 files changed, 12 insertions(+), 0 deletions(-)
+
+Index: arpwatch-2.1a15/arpwatch.c
+===================================================================
+--- arpwatch-2.1a15.orig/arpwatch.c
++++ arpwatch-2.1a15/arpwatch.c
+@@ -98,6 +98,10 @@ struct rtentry;
+ #define ETHERTYPE_APOLLO	0x8019
+ #endif
+ 
++#ifndef ETHERTYPE_VLAN
++#define	ETHERTYPE_VLAN		0x8100
++#endif
++
+ #ifndef IN_CLASSD_NET
+ #define IN_CLASSD_NET		0xf0000000
+ #endif
+@@ -645,6 +649,14 @@ sanity_ether(register struct ether_heade
+ 		return(0);
+ 	}
+ 
++	/* ignore 802.1Q (VLAN) frames */
++	if (eh->ether_type == ETHERTYPE_VLAN) {
++		if (debug)
++			syslog(LOG_INFO, "ignoring 802.1Q frame from %s\n",
++			    e2str(shost));
++		return(0);
++	}
++
+ 	/* XXX sysv r4 seems to use hardware format 6 */
+ 	if (ea->arp_hrd != ARPHRD_ETHER && ea->arp_hrd != 6) {
+ 		syslog(LOG_ERR, "%s sent bad hardware format 0x%x\n",

--- a/net/arpwatch/patches/990_gentoo_arpwatch-2.1a15-ethercodes.dat-20100918.patch
+++ b/net/arpwatch/patches/990_gentoo_arpwatch-2.1a15-ethercodes.dat-20100918.patch
@@ -1,0 +1,12923 @@
+=== modified file 'ethercodes.dat'
+Index: arpwatch-2.1a15/ethercodes.dat
+===================================================================
+--- arpwatch-2.1a15.orig/ethercodes.dat
++++ arpwatch-2.1a15/ethercodes.dat
+@@ -1,5 +1,4 @@
+ 0:0:0	XEROX CORPORATION
+-0:0:1	XEROX CORPORATION
+ 0:0:10	SYTEK INC.
+ 0:0:11	NORMEREL SYSTEMES
+ 0:0:12	INFORMATION TECHNOLOGY LIMITED
+@@ -16,7 +15,7 @@
+ 0:0:1d	CABLETRON SYSTEMS, INC.
+ 0:0:1e	TELSIST INDUSTRIA ELECTRONICA
+ 0:0:1f	Telco Systems, Inc.
+-0:0:2	XEROX CORPORATION
++0:0:1	XEROX CORPORATION
+ 0:0:20	DATAINDUSTRIER DIAB AB
+ 0:0:21	SUREMAN COMP. & COMMUN. CORP.
+ 0:0:22	VISUAL TECHNOLOGY INC.
+@@ -33,7 +32,7 @@
+ 0:0:2d	CHROMATICS INC
+ 0:0:2e	SOCIETE EVIRA
+ 0:0:2f	TIMEPLEX INC.
+-0:0:3	XEROX CORPORATION
++0:0:2	XEROX CORPORATION
+ 0:0:30	VG LABORATORY SYSTEMS LTD
+ 0:0:31	QPSX COMMUNICATIONS PTY LTD
+ 0:0:32	Marconi plc
+@@ -50,7 +49,7 @@
+ 0:0:3d	UNISYS
+ 0:0:3e	SIMPACT
+ 0:0:3f	SYNTREX, INC.
+-0:0:4	XEROX CORPORATION
++0:0:3	XEROX CORPORATION
+ 0:0:40	APPLICON, INC.
+ 0:0:41	ICE CORPORATION
+ 0:0:42	METIER MANAGEMENT SYSTEMS LTD.
+@@ -67,7 +66,7 @@
+ 0:0:4d	DCI CORPORATION
+ 0:0:4e	AMPEX CORPORATION
+ 0:0:4f	LOGICRAFT, INC.
+-0:0:5	XEROX CORPORATION
++0:0:4	XEROX CORPORATION
+ 0:0:50	RADISYS CORPORATION
+ 0:0:51	HOB ELECTRONIC GMBH & CO. KG
+ 0:0:52	Intrusion.com, Inc.
+@@ -84,7 +83,7 @@
+ 0:0:5d	CS TELECOM
+ 0:0:5e	USC INFORMATION SCIENCES INST
+ 0:0:5f	SUMITOMO ELECTRIC IND., LTD.
+-0:0:6	XEROX CORPORATION
++0:0:5	XEROX CORPORATION
+ 0:0:60	KONTRON ELEKTRONIK GMBH
+ 0:0:61	GATEWAY COMMUNICATIONS
+ 0:0:62	BULL HN INFORMATION SYSTEMS
+@@ -101,7 +100,7 @@
+ 0:0:6d	CRAY COMMUNICATIONS, LTD.
+ 0:0:6e	ARTISOFT, INC.
+ 0:0:6f	Madge Ltd.
+-0:0:7	XEROX CORPORATION
++0:0:6	XEROX CORPORATION
+ 0:0:70	HCL LIMITED
+ 0:0:71	ADRA SYSTEMS INC.
+ 0:0:72	MINIWARE TECHNOLOGY
+@@ -115,10 +114,10 @@
+ 0:0:7a	DANA COMPUTER INC.
+ 0:0:7b	RESEARCH MACHINES
+ 0:0:7c	AMPERE INCORPORATED
+-0:0:7d	SUN MICROSYSTEMS, INC.
++0:0:7d	Oracle Corporation
+ 0:0:7e	CLUSTRIX CORPORATION
+ 0:0:7f	LINOTYPE-HELL AG
+-0:0:8	XEROX CORPORATION
++0:0:7	XEROX CORPORATION
+ 0:0:80	CRAY COMMUNICATIONS A/S
+ 0:0:81	BAY NETWORKS
+ 0:0:82	LECTRA SYSTEMES SA
+@@ -127,15 +126,15 @@
+ 0:0:85	CANON INC.
+ 0:0:86	MEGAHERTZ CORPORATION
+ 0:0:87	HITACHI, LTD.
+-0:0:88	COMPUTER NETWORK TECH. CORP.
++0:0:88	Brocade Communications Systems, Inc.
+ 0:0:89	CAYMAN SYSTEMS INC.
+ 0:0:8a	DATAHOUSE INFORMATION SYSTEMS
+ 0:0:8b	INFOTRON
+ 0:0:8c	Alloy Computer Products (Australia) Pty Ltd
+-0:0:8d	VERDIX CORPORATION
++0:0:8d	Cryptek Inc.
+ 0:0:8e	SOLBOURNE COMPUTER, INC.
+-0:0:8f	RAYTHEON COMPANY
+-0:0:9	XEROX CORPORATION
++0:0:8f	Raytheon
++0:0:8	XEROX CORPORATION
+ 0:0:90	MICROCOM
+ 0:0:91	ANRITSU CORPORATION
+ 0:0:92	COGENT DATA TECHNOLOGIES
+@@ -143,7 +142,7 @@
+ 0:0:94	ASANTE TECHNOLOGIES
+ 0:0:95	SONY TEKTRONIX CORP.
+ 0:0:96	MARCONI ELECTRONICS LTD.
+-0:0:97	EPOCH SYSTEMS
++0:0:97	EMC Corporation
+ 0:0:98	CROSSCOMM CORPORATION
+ 0:0:99	MTX, INC.
+ 0:0:9a	RC COMPUTER A/S
+@@ -152,7 +151,7 @@
+ 0:0:9d	LOCUS COMPUTING CORPORATION
+ 0:0:9e	MARLI S.A.
+ 0:0:9f	AMERISTAR TECHNOLOGIES INC.
+-0:0:a	OMRON TATEISI ELECTRONICS CO.
++0:0:9	XEROX CORPORATION
+ 0:0:a0	SANYO Electric Co., Ltd.
+ 0:0:a1	MARQUETTE ELECTRIC CO.
+ 0:0:a2	BAY NETWORKS
+@@ -169,7 +168,7 @@
+ 0:0:ad	BRUKER INSTRUMENTS INC.
+ 0:0:ae	DASSAULT ELECTRONIQUE
+ 0:0:af	NUCLEAR DATA INSTRUMENTATION
+-0:0:b	MATRIX CORPORATION
++0:0:a	OMRON TATEISI ELECTRONICS CO.
+ 0:0:b0	RND-RAD NETWORK DEVICES
+ 0:0:b1	ALPHA MICROSYSTEMS INC.
+ 0:0:b2	TELEVIDEO SYSTEMS, INC.
+@@ -182,11 +181,11 @@
+ 0:0:b9	MCDONNELL DOUGLAS COMPUTER SYS
+ 0:0:ba	SIIG, INC.
+ 0:0:bb	TRI-DATA
+-0:0:bc	ALLEN-BRADLEY CO. INC.
++0:0:bc	Rockwell Automation
+ 0:0:bd	MITSUBISHI CABLE COMPANY
+ 0:0:be	THE NTI GROUP
+ 0:0:bf	SYMMETRIC COMPUTER SYSTEMS
+-0:0:c	CISCO SYSTEMS, INC.
++0:0:b	MATRIX CORPORATION
+ 0:0:c0	WESTERN DIGITAL CORPORATION
+ 0:0:c1	Madge Ltd.
+ 0:0:c2	INFORMATION PRESENTATION TECH.
+@@ -196,14 +195,14 @@
+ 0:0:c6	EON SYSTEMS
+ 0:0:c7	ARIX CORPORATION
+ 0:0:c8	ALTOS COMPUTER SYSTEMS
+-0:0:c9	EMULEX CORPORATION
++0:0:c9	Emulex Corporation
+ 0:0:ca	ARRIS International
+ 0:0:cb	COMPU-SHACK ELECTRONIC GMBH
+ 0:0:cc	DENSAN CO., LTD.
+-0:0:cd	Allied Telesyn Research Ltd.
++0:0:c	CISCO SYSTEMS, INC.
++0:0:cd	Allied Telesis Labs Ltd
+ 0:0:ce	MEGADATA CORP.
+ 0:0:cf	HAYES MICROCOMPUTER PRODUCTS
+-0:0:d	FIBRONICS LTD.
+ 0:0:d0	DEVELCON ELECTRONICS LTD.
+ 0:0:d1	ADAPTEC INCORPORATED
+ 0:0:d2	SBE, INC.
+@@ -220,7 +219,7 @@
+ 0:0:dd	TCL INCORPORATED
+ 0:0:de	CETIA
+ 0:0:df	BELL & HOWELL PUB SYS DIV
+-0:0:e	FUJITSU LIMITED
++0:0:d	FIBRONICS LTD.
+ 0:0:e0	QUADRAM CORP.
+ 0:0:e1	GRID SYSTEMS
+ 0:0:e2	ACER TECHNOLOGIES CORP.
+@@ -237,12 +236,12 @@
+ 0:0:ed	APRIL
+ 0:0:ee	NETWORK DESIGNERS, LTD.
+ 0:0:ef	KTI
+-0:0:f	NEXT, INC.
++0:0:e	FUJITSU LIMITED
+ 0:0:f0	SAMSUNG ELECTRONICS CO., LTD.
+ 0:0:f1	MAGNA COMPUTER CORPORATION
+ 0:0:f2	SPIDER COMMUNICATIONS
+ 0:0:f3	GANDALF DATA LIMITED
+-0:0:f4	ALLIED TELESYN INTERNATIONAL
++0:0:f4	Allied Telesis
+ 0:0:f5	DIAMOND SALES LIMITED
+ 0:0:f6	APPLIED MICROSYSTEMS CORP.
+ 0:0:f7	YOUTH KEEP ENTERPRISE CO LTD
+@@ -254,42 +253,42 @@
+ 0:0:fd	HIGH LEVEL HARDWARE
+ 0:0:fe	ANNAPOLIS MICRO SYSTEMS
+ 0:0:ff	CAMTEC ELECTRONICS LTD.
++0:0:f	NEXT, INC.
+ 0:10:0	CABLE TELEVISION LABORATORIES, INC.
+-0:10:1	MCK COMMUNICATIONS
+ 0:10:10	INITIO CORPORATION
+ 0:10:11	CISCO SYSTEMS, INC.
+ 0:10:12	PROCESSOR SYSTEMS (I) PVT LTD
+-0:10:13	Kontron
++0:10:13	Kontron America, Inc.
+ 0:10:14	CISCO SYSTEMS, INC.
+ 0:10:15	OOmon Inc.
+ 0:10:16	T.SQWARE
+-0:10:17	MICOS GmbH
++0:10:17	Bosch Access Systems GmbH
+ 0:10:18	BROADCOM CORPORATION
+ 0:10:19	SIRONA DENTAL SYSTEMS GmbH & Co. KG
+ 0:10:1a	PictureTel Corp.
+ 0:10:1b	CORNET TECHNOLOGY, INC.
++0:10:1	Citel
+ 0:10:1c	OHM TECHNOLOGIES INTL, LLC
+ 0:10:1d	WINBOND ELECTRONICS CORP.
+ 0:10:1e	MATSUSHITA ELECTRONIC INSTRUMENTS CORP.
+ 0:10:1f	CISCO SYSTEMS, INC.
+-0:10:2	ACTIA
+-0:10:20	WELCH ALLYN, DATA COLLECTION
++0:10:20	Hand Held Products Inc
+ 0:10:21	ENCANTO NETWORKS, INC.
+ 0:10:22	SatCom Media Corporation
+-0:10:23	FLOWWISE NETWORKS, INC.
++0:10:23	Network Equipment Technologies
+ 0:10:24	NAGOYA ELECTRIC WORKS CO., LTD
+-0:10:25	GRAYHILL INC.
++0:10:25	Grayhill, Inc
+ 0:10:26	ACCELERATED NETWORKS, INC.
+ 0:10:27	L-3 COMMUNICATIONS EAST
+ 0:10:28	COMPUTER TECHNICA, INC.
+ 0:10:29	CISCO SYSTEMS, INC.
++0:10:2	ACTIA
+ 0:10:2a	ZF MICROSYSTEMS, INC.
+ 0:10:2b	UMAX DATA SYSTEMS, INC.
+ 0:10:2c	Lasat Networks A/S
+ 0:10:2d	HITACHI SOFTWARE ENGINEERING
+ 0:10:2e	NETWORK SYSTEMS & TECHNOLOGIES PVT. LTD.
+ 0:10:2f	CISCO SYSTEMS, INC.
+-0:10:3	IMATRON, INC.
+ 0:10:30	EION Inc.
+ 0:10:31	OBJECTIVE COMMUNICATIONS, INC.
+ 0:10:32	ALTA TECHNOLOGY
+@@ -306,24 +305,24 @@
+ 0:10:3d	PHASECOM, LTD.
+ 0:10:3e	NETSCHOOLS CORPORATION
+ 0:10:3f	TOLLGRADE COMMUNICATIONS, INC.
+-0:10:4	THE BRANTLEY COILE COMPANY,INC
++0:10:3	IMATRON, INC.
+ 0:10:40	INTERMEC CORPORATION
+ 0:10:41	BRISTOL BABCOCK, INC.
+-0:10:42	AlacriTech
++0:10:42	Alacritech, Inc.
+ 0:10:43	A2 CORPORATION
+ 0:10:44	InnoLabs Corporation
+ 0:10:45	Nortel Networks
+ 0:10:46	ALCORN MCBRIDE INC.
+ 0:10:47	ECHO ELETRIC CO. LTD.
+ 0:10:48	HTRC AUTOMATION, INC.
+-0:10:49	SHORELINE TELEWORKS, INC.
+-0:10:4a	THE PARVUC CORPORATION
++0:10:49	ShoreTel, Inc
++0:10:4a	The Parvus Corporation
+ 0:10:4b	3COM CORPORATION
+-0:10:4c	COMPUTER ACCESS TECHNOLOGY
++0:10:4c	LeCroy Corporation
+ 0:10:4d	SURTEC INDUSTRIES, INC.
+ 0:10:4e	CEOLOGIC
+-0:10:4f	STORAGE TECHNOLOGY CORPORATION
+-0:10:5	UEC COMMERCIAL
++0:10:4f	Oracle Corporation
++0:10:4	THE BRANTLEY COILE COMPANY,INC
+ 0:10:50	RION CO., LTD.
+ 0:10:51	CMICRO CORPORATION
+ 0:10:52	METTLER-TOLEDO (ALBSTADT) GMBH
+@@ -340,7 +339,7 @@
+ 0:10:5d	Draeger Medical
+ 0:10:5e	HEKIMIAN LABORATORIES, INC.
+ 0:10:5f	IN-SNEC
+-0:10:6	Thales Contact Solutions Ltd.
++0:10:5	UEC COMMERCIAL
+ 0:10:60	BILLIONTON SYSTEMS, INC.
+ 0:10:61	HOSTLINK CORP.
+ 0:10:62	NX SERVER, ILNC.
+@@ -353,15 +352,15 @@
+ 0:10:69	HELIOSS COMMUNICATIONS, INC.
+ 0:10:6a	DIGITAL MICROWAVE CORPORATION
+ 0:10:6b	SONUS NETWORKS, INC.
+-0:10:6c	INFRATEC PLUS GmbH
+-0:10:6d	INTEGRITY COMMUNICATIONS, INC.
++0:10:6c	Infratec AG
++0:10:6d	Axxcelera Broadband Wireless
+ 0:10:6e	TADIRAN COM. LTD.
+ 0:10:6f	TRENTON TECHNOLOGY INC.
+-0:10:7	CISCO SYSTEMS, INC.
++0:10:6	Thales Contact Solutions Ltd.
+ 0:10:70	CARADON TREND LTD.
+ 0:10:71	ADVANET INC.
+ 0:10:72	GVN TECHNOLOGIES, INC.
+-0:10:73	TECHNOBOX, INC.
++0:10:73	Technobox, Inc.
+ 0:10:74	ATEN INTERNATIONAL CO., LTD.
+ 0:10:75	Maxtor Corporation
+ 0:10:76	EUREM GmbH
+@@ -370,28 +369,28 @@
+ 0:10:79	CISCO SYSTEMS, INC.
+ 0:10:7a	AmbiCom, Inc.
+ 0:10:7b	CISCO SYSTEMS, INC.
++0:10:7	CISCO SYSTEMS, INC.
+ 0:10:7c	P-COM, INC.
+ 0:10:7d	AURORA COMMUNICATIONS, LTD.
+ 0:10:7e	BACHMANN ELECTRONIC GmbH
+ 0:10:7f	CRESTRON ELECTRONICS, INC.
+-0:10:8	VIENNA SYSTEMS CORPORATION
+ 0:10:80	METAWAVE COMMUNICATIONS
+ 0:10:81	DPS, INC.
+ 0:10:82	JNA TELECOMMUNICATIONS LIMITED
+ 0:10:83	HEWLETT-PACKARD COMPANY
+ 0:10:84	K-BOT COMMUNICATIONS
+ 0:10:85	POLARIS COMMUNICATIONS, INC.
+-0:10:86	ATTO TECHNOLOGY, INC.
++0:10:86	ATTO Technology, Inc.
+ 0:10:87	Xstreamis PLC
+ 0:10:88	AMERICAN NETWORKS INC.
+ 0:10:89	WebSonic
+ 0:10:8a	TeraLogic, Inc.
+ 0:10:8b	LASERANIMATION SOLLINGER GmbH
+ 0:10:8c	FUJITSU TELECOMMUNICATIONS EUROPE, LTD.
+-0:10:8d	JOHNSON CONTROLS, INC.
++0:10:8d	Johnson Controls, Inc.
+ 0:10:8e	HUGH SYMONS CONCEPT Technologies Ltd.
+ 0:10:8f	RAPTOR SYSTEMS
+-0:10:9	HORO QUARTZ
++0:10:8	VIENNA SYSTEMS CORPORATION
+ 0:10:90	CIMETRICS, INC.
+ 0:10:91	NO WIRES NEEDED BV
+ 0:10:92	NETCORE INC.
+@@ -408,7 +407,7 @@
+ 0:10:9d	CLARINET SYSTEMS, INC.
+ 0:10:9e	AWARE, INC.
+ 0:10:9f	PAVO, INC.
+-0:10:a	WILLIAMS COMMUNICATIONS GROUP
++0:10:9	HORO QUARTZ
+ 0:10:a0	INNOVEX TECHNOLOGIES, INC.
+ 0:10:a1	KENDIN SEMICONDUCTOR, INC.
+ 0:10:a2	TNS
+@@ -425,7 +424,7 @@
+ 0:10:ad	SOFTRONICS USB, INC.
+ 0:10:ae	SHINKO ELECTRIC INDUSTRIES CO.
+ 0:10:af	TAC SYSTEMS, INC.
+-0:10:b	CISCO SYSTEMS, INC.
++0:10:a	WILLIAMS COMMUNICATIONS GROUP
+ 0:10:b0	MERIDIAN TECHNOLOGY CORP.
+ 0:10:b1	FOR-A CO., LTD.
+ 0:10:b2	COACTIVE AESTHETICS
+@@ -439,11 +438,11 @@
+ 0:10:ba	MARTINHO-DAVIS SYSTEMS, INC.
+ 0:10:bb	DATA & INFORMATION TECHNOLOGY
+ 0:10:bc	Aastra Telecom
+-0:10:bd	THE TELECOMMUNICATION TECHNOLOGY COMMITTEE
+-0:10:be	TELEXIS CORP.
++0:10:b	CISCO SYSTEMS, INC.
++0:10:bd	THE TELECOMMUNICATION TECHNOLOGY COMMITTEE (TTC)
++0:10:be	MARCH NETWORKS CORPORATION
+ 0:10:bf	InterAir Wireless
+-0:10:c	ITO CO., LTD.
+-0:10:c0	ARMA, INC.
++0:10:c0	ARMA, Inc.
+ 0:10:c1	OI ELECTRIC CO., LTD.
+ 0:10:c2	WILLNET, INC.
+ 0:10:c3	CSI-CONTROL SYSTEMS
+@@ -459,7 +458,7 @@
+ 0:10:cd	INTERFACE CONCEPT
+ 0:10:ce	VOLAMP, LTD.
+ 0:10:cf	FIBERLANE COMMUNICATIONS
+-0:10:d	CISCO SYSTEMS, INC.
++0:10:c	ITO CO., LTD.
+ 0:10:d0	WITCOM, LTD.
+ 0:10:d1	Top Layer Networks, Inc.
+ 0:10:d2	NITTO TSUSHINKI CO., LTD
+@@ -472,15 +471,15 @@
+ 0:10:d9	IBM JAPAN, FUJISAWA MT+D
+ 0:10:da	MOTION ENGINEERING, INC.
+ 0:10:db	Juniper Networks, Inc.
++0:10:d	CISCO SYSTEMS, INC.
+ 0:10:dc	MICRO-STAR INTERNATIONAL CO., LTD.
+ 0:10:dd	ENABLE SEMICONDUCTOR, INC.
+ 0:10:de	INTERNATIONAL DATACASTING CORPORATION
+ 0:10:df	RISE COMPUTER INC.
+-0:10:e	MICRO LINEAR COPORATION
+-0:10:e0	COBALT MICROSERVER, INC.
++0:10:e0	Oracle Corporation
+ 0:10:e1	S.I. TECH, INC.
+ 0:10:e2	ArrayComm, Inc.
+-0:10:e3	COMPAQ COMPUTER CORPORATION
++0:10:e3	Hewlett Packard
+ 0:10:e4	NSI CORPORATION
+ 0:10:e5	SOLECTRON TEXAS
+ 0:10:e6	APPLIED INTELLIGENT SYSTEMS, INC.
+@@ -493,24 +492,26 @@
+ 0:10:ed	SUNDANCE TECHNOLOGY, INC.
+ 0:10:ee	CTI PRODUCTS, INC.
+ 0:10:ef	DBTEL INCORPORATED
+-0:10:f	INDUSTRIAL CPU SYSTEMS
++0:10:e	MICRO LINEAR COPORATION
++0:1:0	EQUIP'TRANS
+ 0:10:f1	I-O CORPORATION
+ 0:10:f2	ANTEC
+ 0:10:f3	Nexcom International Co., Ltd.
+-0:10:f4	VERTICAL NETWORKS, INC.
++0:10:f4	Vertical Communications
+ 0:10:f5	AMHERST SYSTEMS, INC.
+ 0:10:f6	CISCO SYSTEMS, INC.
+ 0:10:f7	IRIICHI TECHNOLOGIES Inc.
+-0:10:f8	KENWOOD TMI CORPORATION
++0:10:f8	Niikke Techno System Co. Ltd
+ 0:10:f9	UNIQUE SYSTEMS, INC.
+-0:10:fa	ZAYANTE, INC.
++0:10:fa	Apple Inc
+ 0:10:fb	ZIDA TECHNOLOGIES LIMITED
+ 0:10:fc	BROADBAND NETWORKS, INC.
+ 0:10:fd	COCOM A/S
+ 0:10:fe	DIGITAL EQUIPMENT CORPORATION
+ 0:10:ff	CISCO SYSTEMS, INC.
+-0:11:0	RAM Industries, LLC
+-0:11:1	CET Technologies Pte Ltd
++0:10:f	INDUSTRIAL CPU SYSTEMS
++0:1:10	Gotham Networks
++0:11:0	Schneider Electric
+ 0:11:10	Maxanna Technology Co., Ltd.
+ 0:11:11	Intel Corporation
+ 0:11:12	Honeywell CMSS
+@@ -523,11 +524,12 @@
+ 0:11:19	Solteras, Inc.
+ 0:11:1a	Motorola BCS
+ 0:11:1b	Targa Systems Div L-3 Communications Canada
++0:11:1	CET Technologies Pte Ltd
+ 0:11:1c	Pleora Technologies Inc.
+ 0:11:1d	Hectrix Limited
+ 0:11:1e	EPSG (Ethernet Powerlink Standardization Group)
+ 0:11:1f	Doremi Labs, Inc.
+-0:11:2	Aurora Multimedia Corp.
++0:1:11	iDigm Inc.
+ 0:11:20	Cisco Systems
+ 0:11:21	Cisco Systems
+ 0:11:22	CIMSYS Inc
+@@ -539,12 +541,13 @@
+ 0:11:28	Streamit
+ 0:11:29	Paradise Datacom Ltd.
+ 0:11:2a	Niko NV
+-0:11:2b	NetModule
++0:11:2	Aurora Multimedia Corp.
++0:11:2b	NetModule AG
+ 0:11:2c	IZT GmbH
+-0:11:2d	Guys Without Ties
++0:11:2d	iPulse Systems
+ 0:11:2e	CEICOM
+ 0:11:2f	ASUSTek Computer Inc.
+-0:11:3	kawamura electric inc.
++0:1:12	Shark Multimedia Inc.
+ 0:11:30	Allied Telesis (Hong Kong) Ltd.
+ 0:11:31	UNATECH. CO.,LTD
+ 0:11:32	Synology Incorporated
+@@ -561,7 +564,8 @@
+ 0:11:3d	KN SOLTEC CO.,LTD.
+ 0:11:3e	JL Corporation
+ 0:11:3f	Alcatel DI
+-0:11:4	TELEXY
++0:11:3	kawamura electric inc.
++0:1:13	OLYMPUS CORPORATION
+ 0:11:40	Nanometrics Inc.
+ 0:11:41	GoodMan Corporation
+ 0:11:42	e-SMARTCOM  INC.
+@@ -571,14 +575,15 @@
+ 0:11:46	Telecard-Pribor Ltd
+ 0:11:47	Secom-Industry co.LTD.
+ 0:11:48	Prolon Control Systems
+-0:11:49	Proliphix LLC
++0:11:49	Proliphix Inc.
+ 0:11:4a	KAYABA INDUSTRY Co,.Ltd.
+-0:11:4b	Francotyp-Postalia AG & Co. KG
++0:11:4b	Francotyp-Postalia GmbH
+ 0:11:4c	caffeina applied research ltd.
+ 0:11:4d	Atsumi Electric Co.,LTD.
+ 0:11:4e	690885 Ontario Inc.
+ 0:11:4f	US Digital Television, Inc
+-0:11:5	Sunplus Technology Co., Ltd.
++0:1:14	KANDA TSUSHIN KOGYO CO., LTD.
++0:11:4	TELEXY
+ 0:11:50	Belkin Corporation
+ 0:11:51	Mykotronx
+ 0:11:52	Eidsvoll Electronics AS
+@@ -594,8 +599,9 @@
+ 0:11:5c	Cisco
+ 0:11:5d	Cisco
+ 0:11:5e	ProMinent Dosiertechnik GmbH
+-0:11:5f	Intellix Co., Ltd.
+-0:11:6	Siemens NV (Belgium)
++0:1:15	EXTRATECH CORPORATION
++0:11:5f	ITX Security Co., Ltd.
++0:11:5	Sunplus Technology Co., Ltd.
+ 0:11:60	ARTDIO Company Co., LTD
+ 0:11:61	NetStreams, LLC
+ 0:11:62	STAR MICRONICS CO.,LTD.
+@@ -612,28 +618,30 @@
+ 0:11:6d	American Time and Signal
+ 0:11:6e	PePLink Ltd.
+ 0:11:6f	Netforyou Co., LTD.
+-0:11:7	RGB Networks Inc.
++0:1:16	Netspect Technologies, Inc.
++0:11:6	Siemens NV (Belgium)
+ 0:11:70	GSC SRL
+ 0:11:71	DEXTER Communications, Inc.
+ 0:11:72	COTRON CORPORATION
+-0:11:73	Adtron Corporation
++0:11:73	SMART Modular Technologies
+ 0:11:74	Wibhu Technologies, Inc.
+ 0:11:75	PathScale, Inc.
+ 0:11:76	Intellambda Systems, Inc.
+-0:11:77	COAXIAL NETWORKS, INC.
++0:11:77	Coaxial Networks, Inc.
+ 0:11:78	Chiron Technology Ltd
+ 0:11:79	Singular Technology Co. Ltd.
+ 0:11:7a	Singim International Corp.
+-0:11:7b	Büchi Labortechnik AG
++0:11:7b	B
++0:1:17	CANAL +
+ 0:11:7c	e-zy.net
+ 0:11:7d	ZMD America, Inc.
+ 0:11:7e	Progeny Inc.
+ 0:11:7f	Neotune Information Technology Corporation,.LTD
+-0:11:8	Orbital Data Corporation
++0:11:7	RGB Networks Inc.
+ 0:11:80	Motorola BCS
+ 0:11:81	InterEnergy Co.Ltd,
+ 0:11:82	IMI Norgren Ltd
+-0:11:83	PSC Scanning, Inc
++0:11:83	Datalogic Mobile, Inc.
+ 0:11:84	Humo Laboratory,Ltd.
+ 0:11:85	Hewlett Packard
+ 0:11:86	Prime Systems, Inc.
+@@ -641,12 +649,13 @@
+ 0:11:88	Enterasys
+ 0:11:89	Aerotech Inc
+ 0:11:8a	Viewtran Technology Limited
+-0:11:8b	NetDevices Inc.
++0:11:8b	Alcatel-Lucent, Enterprise Business Group
+ 0:11:8c	Missouri Department of Transportation
+ 0:11:8d	Hanchang System Corp.
+ 0:11:8e	Halytech Mace
++0:1:18	EZ Digital Co., Ltd.
+ 0:11:8f	EUTECH INSTRUMENTS PTE. LTD.
+-0:11:9	Micro-Star International
++0:11:8	Orbital Data Corporation
+ 0:11:90	Digital Design Corporation
+ 0:11:91	CTS-Clima Temperatur Systeme GmbH
+ 0:11:92	Cisco Systems
+@@ -663,7 +672,8 @@
+ 0:11:9d	Diginfo Technology Corporation
+ 0:11:9e	Solectron Brazil
+ 0:11:9f	Nokia Danmark A/S
+-0:11:a	Hewlett Packard
++0:11:9	Micro-Star International
++0:1:19	RTUnet (Australia)
+ 0:11:a0	Vtech Engineering Canada Ltd
+ 0:11:a1	VISION NETWARE CO.,LTD
+ 0:11:a2	Manufacturing Technology Inc
+@@ -678,9 +688,10 @@
+ 0:11:ab	TRUSTABLE TECHNOLOGY CO.,LTD.
+ 0:11:ac	Simtec Electronics
+ 0:11:ad	Shanghai Ruijie Technology
++0:1:1a	EEH DataLink GmbH
+ 0:11:ae	Motorola BCS
+ 0:11:af	Medialink-i,Inc
+-0:11:b	Franklin Technology Systems
++0:11:a	Hewlett Packard
+ 0:11:b0	Fortelink Inc.
+ 0:11:b1	BlueExpert Technology Corp.
+ 0:11:b2	2001 Technology Inc.
+@@ -688,7 +699,7 @@
+ 0:11:b4	Westermo Teleindustri AB
+ 0:11:b5	Shenzhen Powercom Co.,Ltd
+ 0:11:b6	Open Systems International
+-0:11:b7	Melexis Nederland B.V.
++0:11:b7	Octalix B.V.
+ 0:11:b8	Liebherr - Elektronik GmbH
+ 0:11:b9	Inner Range Pty. Ltd.
+ 0:11:ba	Elexol Pty Ltd
+@@ -697,7 +708,8 @@
+ 0:11:bd	Bombardier Transportation
+ 0:11:be	AGP Telecom Co. Ltd
+ 0:11:bf	AESYS S.p.A.
+-0:11:c	Atmark Techno, Inc.
++0:11:b	Franklin Technology Systems
++0:1:1b	Unizone Technologies, Inc.
+ 0:11:c0	Aday Technology Inc
+ 0:11:c1	4P MOBILE DATA PROCESSING
+ 0:11:c2	United Fiber Optic Communication
+@@ -705,16 +717,17 @@
+ 0:11:c4	Terminales de Telecomunicacion Terrestre, S.L.
+ 0:11:c5	TEN Technology
+ 0:11:c6	Seagate Technology LLC
+-0:11:c7	RAYMARINE Group Ltd.
++0:11:c7	Raymarine UK Ltd
+ 0:11:c8	Powercom Co., Ltd.
+ 0:11:c9	MTT Corporation
+ 0:11:ca	Long Range Systems, Inc.
+-0:11:cb	Jacobsons RKH AB
++0:11:c	Atmark Techno, Inc.
++0:11:cb	Jacobsons AB
+ 0:11:cc	Guangzhou Jinpeng Group Co.,Ltd.
+ 0:11:cd	Axsun Technologies
+ 0:11:ce	Ubisense Limited
+ 0:11:cf	Thrane & Thrane A/S
+-0:11:d	SANBlaze Technology, Inc.
++0:1:1c	Universal Talkware Corporation
+ 0:11:d0	Tandberg Data ASA
+ 0:11:d1	Soft Imaging System GmbH
+ 0:11:d2	Perception Digital Ltd
+@@ -727,11 +740,12 @@
+ 0:11:d9	TiVo
+ 0:11:da	Vivaas Technology Inc.
+ 0:11:db	Land-Cellular Corporation
++0:1:1d	Centillium Communications
+ 0:11:dc	Glunz & Jensen
+ 0:11:dd	FROMUS TEC. Co., Ltd.
+ 0:11:de	EURILOGIC
+-0:11:df	Arecont Systems
+-0:11:e	Tsurusaki Sealand Transportation Co. Ltd.
++0:11:df	Current Energy
++0:11:d	SANBlaze Technology, Inc.
+ 0:11:e0	U-MEDIA Communications, Inc.
+ 0:11:e1	BEKO Electronics Co.
+ 0:11:e2	Hua Jung Components Co., Ltd.
+@@ -748,11 +762,12 @@
+ 0:11:ed	802 Global
+ 0:11:ee	Estari, Inc.
+ 0:11:ef	Conitec Datensysteme GmbH
+-0:11:f	netplat,Inc.
++0:1:1e	Precidia Technologies, Inc.
++0:11:e	Tsurusaki Sealand Transportation Co. Ltd.
+ 0:11:f0	Wideful Limited
+ 0:11:f1	QinetiQ Ltd
+ 0:11:f2	Institute of Network Technologies
+-0:11:f3	Gavitec AG- mobile digit
++0:11:f3	NeoMedia Europe AG
+ 0:11:f4	woori-net
+ 0:11:f5	ASKEY COMPUTER CORP.
+ 0:11:f6	Asia Pacific Microsystems , Inc.
+@@ -765,11 +780,14 @@
+ 0:11:fd	KORG INC.
+ 0:11:fe	Keiyo System Research, Inc.
+ 0:11:ff	Digitro Tecnologia Ltda
++0:11:f	netplat,Inc.
++0:1:1f	RC Networks, Inc.
++0:1:1	PRIVATE
+ 0:12:0	Cisco
+-0:12:1	Cisco
++0:1:20	OSCILLOQUARTZ S.A.
+ 0:12:10	WideRay Corp
+ 0:12:11	Protechna Herbst GmbH & Co. KG
+-0:12:12	PLUS Vision Corporation
++0:12:12	PLUS  Corporation
+ 0:12:13	Metrohm AG
+ 0:12:14	Koenig & Bauer AG
+ 0:12:15	iStor Networks, Inc.
+@@ -779,11 +797,12 @@
+ 0:12:19	Ahead Communication Systems Inc
+ 0:12:1a	Techno Soft Systemnics Inc.
+ 0:12:1b	Sound Devices, LLC
++0:12:1	Cisco
+ 0:12:1c	PARROT S.A.
+ 0:12:1d	Netfabric Corporation
+ 0:12:1e	Juniper Networks, Inc.
+ 0:12:1f	Harding Intruments
+-0:12:2	Audio International Inc.
++0:1:21	Watchguard Technologies, Inc.
+ 0:12:20	Cadco Systems
+ 0:12:21	B.Braun Melsungen AG
+ 0:12:22	Skardin (UK) Ltd
+@@ -797,27 +816,30 @@
+ 0:12:2a	VTech Telecommunications Ltd.
+ 0:12:2b	Virbiage Pty Ltd
+ 0:12:2c	Soenen Controls N.V.
++0:12:2	Decrane Aerospace - Audio International Inc.
+ 0:12:2d	SiNett Corporation
+ 0:12:2e	Signal Technology - AISD
+ 0:12:2f	Sanei Electric Inc.
+-0:12:3	Activ Networks
++0:1:22	Trend Communications, Ltd.
+ 0:12:30	Picaso Infocommunication CO., LTD.
+ 0:12:31	Motion Control Systems, Inc.
+ 0:12:32	LeWiz Communications Inc.
+ 0:12:33	JRC TOKKI Co.,Ltd.
+ 0:12:34	Camille Bauer
+ 0:12:35	Andrew Corporation
+-0:12:36	Tidal Networks
++0:12:36	ConSentry Networks
+ 0:12:37	Texas Instruments
+ 0:12:38	SetaBox Technology Co., Ltd.
+ 0:12:39	S Net Systems Inc.
++0:12:3	Activ Networks
+ 0:12:3a	Posystech Inc., Co.
+ 0:12:3b	KeRo Systems ApS
+-0:12:3c	IP3 Networks, Inc.
++0:1:2	3COM CORPORATION
++0:12:3c	Second Rule LLC
+ 0:12:3d	GES
++0:1:23	DIGITAL ELECTRONICS CORP.
+ 0:12:3e	ERUNE technology Co., Ltd.
+ 0:12:3f	Dell Inc
+-0:12:4	u10 Networks, Inc.
+ 0:12:40	AMOI ELECTRONICS CO.,LTD
+ 0:12:41	a2i marketing center
+ 0:12:42	Millennial Net
+@@ -826,15 +848,16 @@
+ 0:12:45	Zellweger Analytics, Inc.
+ 0:12:46	T.O.M TECHNOLOGY INC..
+ 0:12:47	Samsung Electronics Co., Ltd.
+-0:12:48	Kashya Inc.
++0:12:48	EMC Corporation (Kashya)
+ 0:12:49	Delta Elettronica S.p.A.
++0:1:24	Acer Incorporated
+ 0:12:4a	Dedicated Devices, Inc.
+-0:12:4b	Chipcon AS
++0:12:4b	Texas Instruments
+ 0:12:4c	BBWM Corporation
+ 0:12:4d	Inducon BV
+ 0:12:4e	XAC AUTOMATION CORP.
+ 0:12:4f	Tyco Thermal Controls LLC.
+-0:12:5	Terrasat Communications, Inc.
++0:12:4	u10 Networks, Inc.
+ 0:12:50	Tokyo Aircaft Instrument Co., Ltd.
+ 0:12:51	SILINK
+ 0:12:52	Citronix, LLC
+@@ -851,14 +874,15 @@
+ 0:12:5d	CyberNet Inc.
+ 0:12:5e	CAEN
+ 0:12:5f	AWIND Inc.
+-0:12:6	iQuest (NZ) Ltd
++0:12:5	Terrasat Communications, Inc.
++0:1:25	YAESU MUSEN CO., LTD.
+ 0:12:60	Stanton Magnetics,inc.
+ 0:12:61	Adaptix, Inc
+ 0:12:62	Nokia Danmark A/S
+ 0:12:63	Data Voice Technologies GmbH
+ 0:12:64	daum electronic gmbh
+ 0:12:65	Enerdyne Technologies, Inc.
+-0:12:66	PRIVATE
++0:12:66	Swisscom Hospitality Services SA
+ 0:12:67	Matsushita Electronic Components Co., Ltd.
+ 0:12:68	IPS d.o.o.
+ 0:12:69	Value Electronics
+@@ -868,13 +892,14 @@
+ 0:12:6d	University of California, Berkeley
+ 0:12:6e	Seidel Elektronik GmbH Nfg.KG
+ 0:12:6f	Rayson Technology Co., Ltd.
+-0:12:7	Head Strong International Limited
++0:12:6	iQuest (NZ) Ltd
++0:1:26	PAC Labs
+ 0:12:70	NGES Denro Systems
+ 0:12:71	Measurement Computing Corp
+ 0:12:72	Redux Communications Ltd.
+ 0:12:73	Stoke Inc
+ 0:12:74	NIT lab
+-0:12:75	Moteiv Corporation
++0:12:75	Sentilla Corporation
+ 0:12:76	Microsol Holdings Ltd.
+ 0:12:77	Korenix Technologies Co., Ltd.
+ 0:12:78	International Bar Code
+@@ -885,7 +910,8 @@
+ 0:12:7d	MobileAria
+ 0:12:7e	Digital Lifestyles Group, Inc.
+ 0:12:7f	Cisco
+-0:12:8	Gantner Electronic GmbH
++0:12:7	Head Strong International Limited
++0:1:27	OPEN Networks Pty Ltd
+ 0:12:80	Cisco
+ 0:12:81	CIEFFE srl
+ 0:12:82	Qovia
+@@ -900,14 +926,15 @@
+ 0:12:8b	Sensory Networks Inc
+ 0:12:8c	Woodward Governor
+ 0:12:8d	STB Datenservice GmbH
++0:1:28	EnjoyWeb, Inc.
+ 0:12:8e	Q-Free ASA
+ 0:12:8f	Montilio
+-0:12:9	Fastrax Ltd
++0:12:8	Gantner Instruments GmbH
+ 0:12:90	KYOWA Electric & Machinery Corp.
+ 0:12:91	KWS Computersysteme GmbH
+ 0:12:92	Griffin Technology
+ 0:12:93	GE Energy
+-0:12:94	Eudyna Devices Inc.
++0:12:94	SUMITOMO ELECTRIC DEVICE INNOVATIONS, INC
+ 0:12:95	Aiware Inc.
+ 0:12:96	Addlogix
+ 0:12:97	O2Micro, Inc.
+@@ -916,32 +943,34 @@
+ 0:12:9a	IRT Electronics Pty Ltd
+ 0:12:9b	E2S Electronic Engineering Solutions, S.L.
+ 0:12:9c	Yulinet
+-0:12:9d	FIRST INTERNATIONAL COMPUTER DO BRASIL LTDA
++0:1:29	DFI Inc.
++0:12:9d	First International Computer do Brasil
+ 0:12:9e	Surf Communications Inc.
++0:12:9	Fastrax Ltd
+ 0:12:9f	RAE Systems, Inc.
+-0:12:a	Emerson Electric GmbH & Co. OHG
+ 0:12:a0	NeoMeridian Sdn Bhd
+ 0:12:a1	BluePacket Communications Co., Ltd.
+ 0:12:a2	VITA
+ 0:12:a3	Trust International B.V.
+ 0:12:a4	ThingMagic, LLC
+ 0:12:a5	Stargen, Inc.
+-0:12:a6	Lake Technology Ltd
++0:12:a6	Dolby Australia
+ 0:12:a7	ISR TECHNOLOGIES Inc
+ 0:12:a8	intec GmbH
+-0:12:a9	3COM EUROPE LTD
++0:12:a9	3Com Ltd
+ 0:12:aa	IEE, Inc.
+ 0:12:ab	WiLife, Inc.
+ 0:12:ac	ONTIMETEK INC.
+ 0:12:ad	IDS GmbH
+ 0:12:ae	HLS HARD-LINE Solutions Inc.
++0:12:a	Emerson Electric GmbH & Co. OHG
+ 0:12:af	ELPRO Technologies
+-0:12:b	Chinasys Technologies Limited
++0:1:2a	Telematica Sistems Inteligente
+ 0:12:b0	Efore Oyj   (Plc)
+ 0:12:b1	Dai Nippon Printing Co., Ltd
+ 0:12:b2	AVOLITES LTD.
+ 0:12:b3	Advance Wireless Technology Corp.
+-0:12:b4	Work GmbH
++0:12:b4	Work Microwave GmbH
+ 0:12:b5	Vialta, Inc.
+ 0:12:b6	Santa Barbara Infrared, Inc.
+ 0:12:b7	PTW Freiburg
+@@ -950,27 +979,29 @@
+ 0:12:ba	FSI Systems, Inc.
+ 0:12:bb	Telecommunications Industry Association TR-41 Committee
+ 0:12:bc	Echolab LLC
++0:12:b	Chinasys Technologies Limited
+ 0:12:bd	Avantec Manufacturing Limited
+ 0:12:be	Astek Corporation
+ 0:12:bf	Arcadyan Technology Corporation
+-0:12:c	CE-Infosys Pte Ltd
++0:1:2b	TELENET Co., Ltd.
+ 0:12:c0	HotLava Systems, Inc.
+ 0:12:c1	Check Point Software Technologies
+ 0:12:c2	Apex Electronics Factory
+ 0:12:c3	WIT S.A.
+ 0:12:c4	Viseon, Inc.
+-0:12:c5	V-Show Technology Co.Ltd
++0:12:c5	V-Show  Technology (China) Co.,Ltd
+ 0:12:c6	TGC America, Inc
+ 0:12:c7	SECURAY Technologies Ltd.Co.
+ 0:12:c8	Perfect tech
+ 0:12:c9	Motorola BCS
+-0:12:ca	Hansen Telecom
++0:12:ca	Mechatronic Brick Aps
++0:1:2c	Aravox Technologies, Inc.
+ 0:12:cb	CSS Inc.
+ 0:12:cc	Bitatek CO., LTD
++0:12:c	CE-Infosys Pte Ltd
+ 0:12:cd	ASEM SpA
+ 0:12:ce	Advanced Cybernetics Group
+ 0:12:cf	Accton Technology Corporation
+-0:12:d	Advanced Telecommunication Technologies, Inc.
+ 0:12:d0	Gossen-Metrawatt-GmbH
+ 0:12:d1	Texas Instruments Inc
+ 0:12:d2	Texas Instruments
+@@ -982,12 +1013,13 @@
+ 0:12:d8	International Games System Co., Ltd.
+ 0:12:d9	Cisco Systems
+ 0:12:da	Cisco Systems
++0:12:d	Advanced Telecommunication Technologies, Inc.
+ 0:12:db	ZIEHL industrie-elektronik GmbH + Co KG
+ 0:12:dc	SunCorp Industrial Limited
+ 0:12:dd	Shengqu Information Technology (Shanghai) Co., Ltd.
+ 0:12:de	Radio Components Sweden AB
+ 0:12:df	Novomatic AG
+-0:12:e	AboCom
++0:1:2d	Komodo Technology
+ 0:12:e0	Codan Limited
+ 0:12:e1	Alliant Networks, Inc
+ 0:12:e2	ALAXALA Networks Corporation
+@@ -998,19 +1030,20 @@
+ 0:12:e7	Projectek Networking Electronics Corp.
+ 0:12:e8	Fraunhofer IMS
+ 0:12:e9	Abbey Systems Ltd
++0:12:e	AboCom
+ 0:12:ea	Trane
+ 0:12:eb	R2DI, LLC
+ 0:12:ec	Movacolor b.v.
+ 0:12:ed	AVG Advanced Technologies
+ 0:12:ee	Sony Ericsson Mobile Communications AB
+ 0:12:ef	OneAccess SA
+-0:12:f	IEEE 802.3
++0:1:2e	PC Partner Ltd.
+ 0:12:f0	Intel Corporate
+ 0:12:f1	IFOTEC
+-0:12:f2	Foundry Networks
++0:12:f2	Brocade Communications Systems, Inc
+ 0:12:f3	connectBlue AB
+ 0:12:f4	Belco International Co.,Ltd.
+-0:12:f5	Prolificx Ltd
++0:12:f5	Imarda New Zealand Limited
+ 0:12:f6	MDK CO.,LTD.
+ 0:12:f7	Xiamen Xinglian Electronics Co., Ltd.
+ 0:12:f8	WNI Resources, LLC
+@@ -1021,46 +1054,50 @@
+ 0:12:fd	OPTIMUS IC S.A.
+ 0:12:fe	Lenovo Mobile Communication Technology Ltd.
+ 0:12:ff	Lely Industries N.V.
++0:12:f	IEEE 802.3
++0:1:2f	Twinhead International Corp
++0:1:30	Extreme Networks
+ 0:13:0	IT-FACTORY, INC.
+-0:13:1	IronGate S.L.
+ 0:13:10	Cisco-Linksys, LLC
+ 0:13:11	ARRIS International
+ 0:13:12	Amedia Networks Inc.
+ 0:13:13	GuangZhou Post & Telecom Equipment ltd
+ 0:13:14	Asiamajor Inc.
+ 0:13:15	SONY Computer Entertainment inc,
+-0:13:16	L-S-B GmbH
++0:13:16	L-S-B Broadcast Technologies GmbH
+ 0:13:17	GN Netcom as
+ 0:13:18	DGSTATION Co., Ltd.
+ 0:13:19	Cisco Systems
+ 0:13:1a	Cisco Systems
+ 0:13:1b	BeCell Innovations Corp.
+ 0:13:1c	LiteTouch, Inc.
++0:1:31	Detection Systems, Inc.
+ 0:13:1d	Scanvaegt International A/S
+ 0:13:1e	Peiker acustic GmbH & Co. KG
+ 0:13:1f	NxtPhase T&D, Corp.
+-0:13:2	Intel Corporate
++0:13:1	IronGate S.L.
+ 0:13:20	Intel Corporate
+ 0:13:21	Hewlett Packard
+ 0:13:22	DAQ Electronics, Inc.
+ 0:13:23	Cap Co., Ltd.
+ 0:13:24	Schneider Electric Ultra Terminal
+-0:13:25	ImmenStar Inc.
++0:13:25	Cortina Systems Inc
+ 0:13:26	ECM Systems Ltd
+ 0:13:27	Data Acquisitions limited
+ 0:13:28	Westech Korea Inc.,
+ 0:13:29	VSST Co., LTD
+-0:13:2a	STROM telecom, s. r. o.
++0:13:2a	Sitronics Telecom Solutions
+ 0:13:2b	Phoenix Digital
+ 0:13:2c	MAZ Brandenburg GmbH
+-0:13:2d	iWise Communications Pty Ltd
++0:13:2d	iWise Communications
++0:1:32	Dranetz - BMI
+ 0:13:2e	ITian Coporation
+ 0:13:2f	Interactek
+-0:13:3	GateConnect Technologies GmbH
++0:13:2	Intel Corporate
+ 0:13:30	EURO PROTECTION SURVEILLANCE
+ 0:13:31	CellPoint Connect
+ 0:13:32	Beijing Topsec Network Security Technology Co., Ltd.
+-0:13:33	Baud Technology Inc.
++0:13:33	BaudTec Corporation
+ 0:13:34	Arkados, Inc.
+ 0:13:35	VS Industry Berhad
+ 0:13:36	Tianjin 712 Communication Broadcasting co., ltd.
+@@ -1069,11 +1106,13 @@
+ 0:13:39	EL-ME AG
+ 0:13:3a	VadaTech Inc.
+ 0:13:3b	Speed Dragon Multimedia Limited
++0:1:3	3COM CORPORATION
+ 0:13:3c	QUINTRON SYSTEMS INC.
+-0:13:3d	Micro Memory LLC
++0:13:3d	Micro Memory Curtiss Wright Co
+ 0:13:3e	MetaSwitch
+ 0:13:3f	Eppendorf Instrumente GmbH
+-0:13:4	Flaircomm Technologies Co. LTD
++0:13:3	GateConnect Technologies GmbH
++0:1:33	KYOWA Electronic Instruments C
+ 0:13:40	AD.EL s.r.l.
+ 0:13:41	Shandong New Beiyang Information Technology Co.,Ltd
+ 0:13:42	Vision Research, Inc.
+@@ -1089,8 +1128,9 @@
+ 0:13:4c	YDT Technology International
+ 0:13:4d	IPC systems
+ 0:13:4e	Valox Systems, Inc.
++0:13:4	Flaircomm Technologies Co. LTD
+ 0:13:4f	Tranzeo Wireless Technologies Inc.
+-0:13:5	Epicom, Inc.
++0:1:34	Selectron Systems AG
+ 0:13:50	Silver Spring Networks, Inc
+ 0:13:51	Niles Audio Corporation
+ 0:13:52	Naztec, Inc.
+@@ -1106,8 +1146,9 @@
+ 0:13:5c	OnSite Systems, Inc.
+ 0:13:5d	NTTPC Communications, Inc.
+ 0:13:5e	EAB/RWI/K
++0:13:5	Epicom, Inc.
+ 0:13:5f	Cisco Systems
+-0:13:6	Always On Wireless
++0:1:35	KDC Corp.
+ 0:13:60	Cisco Systems
+ 0:13:61	Biospace Co., Ltd.
+ 0:13:62	ShinHeung Precision Co., Ltd.
+@@ -1118,18 +1159,19 @@
+ 0:13:67	Narayon. Co., Ltd.
+ 0:13:68	Maersk Data Defence
+ 0:13:69	Honda Electron Co., LED.
+-0:13:6a	Hach Ultra Analytics
++0:13:6a	Hach Lange SA
++0:13:6	Always On Wireless
+ 0:13:6b	E-TEC
+-0:13:6c	PRIVATE
++0:13:6c	TomTom
++0:1:36	CyberTAN Technology, Inc.
+ 0:13:6d	Tentaculus AB
+ 0:13:6e	Techmetro Corp.
+ 0:13:6f	PacketMotion, Inc.
+-0:13:7	Paravirtual Corporation
+ 0:13:70	Nokia Danmark A/S
+ 0:13:71	Motorola CHS
+ 0:13:72	Dell Inc.
+ 0:13:73	BLwave Electronics Co., Ltd
+-0:13:74	Attansic Technology Corp.
++0:13:74	Atheros Communications, Inc.
+ 0:13:75	American Security Products Co.
+ 0:13:76	Tabor Electronics Ltd.
+ 0:13:77	Samsung Electronics CO., LTD
+@@ -1141,7 +1183,8 @@
+ 0:13:7d	Dynalab, Inc.
+ 0:13:7e	CorEdge Networks, Inc.
+ 0:13:7f	Cisco Systems
+-0:13:8	Nuvera Fuel Cells
++0:1:37	IT Farm Corporation
++0:13:7	Paravirtual Corporation
+ 0:13:80	Cisco Systems
+ 0:13:81	CHIPS & Systems, Inc.
+ 0:13:82	Cetacea Networks Corporation
+@@ -1151,17 +1194,18 @@
+ 0:13:86	ABB Inc./Totalflow
+ 0:13:87	27M Technologies AB
+ 0:13:88	WiMedia Alliance
+-0:13:89	Redes de Telefonía Móvil S.A.
++0:13:89	Redes de Telefon
+ 0:13:8a	QINGDAO GOERTEK ELECTRONICS CO.,LTD.
+ 0:13:8b	Phantom Technologies LLC
+ 0:13:8c	Kumyoung.Co.Ltd
+ 0:13:8d	Kinghold
+ 0:13:8e	FOAB Elektronik AB
+ 0:13:8f	Asiarock Incorporation
+-0:13:9	Ocean Broadband Networks
++0:13:8	Nuvera Fuel Cells
++0:1:38	XAVi Technologies Corp.
+ 0:13:90	Termtek Computer Co., Ltd
+ 0:13:91	OUEN CO.,LTD.
+-0:13:92	Video54 Technologies, Inc
++0:13:92	Ruckus Wireless
+ 0:13:93	Panta Systems, Inc.
+ 0:13:94	Infohand Co.,Ltd
+ 0:13:95	congatec AG
+@@ -1175,7 +1219,8 @@
+ 0:13:9d	Design of Systems on Silicon S.A.
+ 0:13:9e	Ciara Technologies Inc.
+ 0:13:9f	Electronics Design Services, Co., Ltd.
+-0:13:a	Nortel
++0:13:9	Ocean Broadband Networks
++0:1:39	Point Multimedia Systems
+ 0:13:a0	ALGOSYSTEM Co., Ltd.
+ 0:13:a1	Crow Electronic Engeneering
+ 0:13:a2	MaxStream, Inc
+@@ -1190,13 +1235,14 @@
+ 0:13:ab	Telemotive AG
+ 0:13:ac	Sunmyung Electronics Co., LTD
+ 0:13:ad	Sendo Ltd
+-0:13:ae	Radiance Technologies
++0:13:ae	Radiance Technologies, Inc.
+ 0:13:af	NUMA Technology,Inc.
+-0:13:b	Mextal B.V.
++0:13:a	Nortel
++0:1:3a	SHELCAD COMMUNICATIONS, LTD.
+ 0:13:b0	Jablotron
+ 0:13:b1	Intelligent Control Systems (Asia) Pte Ltd
+ 0:13:b2	Carallon Limited
+-0:13:b3	Beijing Ecom Communications Technology Co., Ltd.
++0:13:b3	Ecom Communications Technology Co., Ltd.
+ 0:13:b4	Appear TV
+ 0:13:b5	Wavesat
+ 0:13:b6	Sling Media, Inc.
+@@ -1204,12 +1250,13 @@
+ 0:13:b8	RyCo Electronic Systems Limited
+ 0:13:b9	BM SPA
+ 0:13:ba	ReadyLinks Inc
+-0:13:bb	PRIVATE
++0:1:3b	BNA SYSTEMS
++0:13:bb	Smartvue Corporation
+ 0:13:bc	Artimi Ltd
+ 0:13:bd	HYMATOM SA
+ 0:13:be	Virtual Conexions
+ 0:13:bf	Media System Planning Corp.
+-0:13:c	HF System Corporation
++0:13:b	Mextal B.V.
+ 0:13:c0	Trix Tecnologia Ltda.
+ 0:13:c1	Asoka USA Corporation
+ 0:13:c2	WACOM Co.,Ltd
+@@ -1226,8 +1273,9 @@
+ 0:13:cd	MTI co. LTD
+ 0:13:ce	Intel Corporate
+ 0:13:cf	4Access Communications
+-0:13:d	GALILEO AVIONICA
+-0:13:d0	e-San Limited
++0:13:c	HF System Corporation
++0:1:3c	TIW SYSTEMS
++0:13:d0	t+ Medical Ltd
+ 0:13:d1	KIRK telecom A/S
+ 0:13:d2	PAGE IBERICA, S.A.
+ 0:13:d3	MICRO-STAR INTERNATIONAL CO., LTD.
+@@ -1241,26 +1289,28 @@
+ 0:13:db	SHOEI Electric Co.,Ltd
+ 0:13:dc	IBTEK INC.
+ 0:13:dd	Abbott Diagnostics
+-0:13:de	Adapt4
++0:13:de	Adapt4, LLC
+ 0:13:df	Ryvor Corp.
+-0:13:e	Focusrite Audio Engineering Limited
++0:13:d	GALILEO AVIONICA
++0:1:3d	RiscStation Ltd.
+ 0:13:e0	Murata Manufacturing Co., Ltd.
+-0:13:e1	Iprobe
++0:13:e1	Iprobe AB
+ 0:13:e2	GeoVision Inc.
+ 0:13:e3	CoVi Technologies, Inc.
+ 0:13:e4	YANGJAE SYSTEMS CORP.
+ 0:13:e5	TENOSYS, INC.
+ 0:13:e6	Technolution
+-0:13:e7	Minelab Electronics Pty Limited
++0:13:e7	Halcro
+ 0:13:e8	Intel Corporate
+ 0:13:e9	VeriWave, Inc.
+ 0:13:ea	Kamstrup A/S
++0:1:3e	Ascom Tateco AB
+ 0:13:eb	Sysmaster Corporation
+ 0:13:ec	Sunbay Software AG
+ 0:13:ed	PSIA
+ 0:13:ee	JBX Designs Inc.
+ 0:13:ef	Kingjon Digital Technology Co.,Ltd
+-0:13:f	EGEMEN Bilgisayar Muh San ve Tic LTD STI
++0:13:e	Focusrite Audio Engineering Limited
+ 0:13:f0	Wavefront Semiconductor
+ 0:13:f1	AMOD Technology Co., Ltd.
+ 0:13:f2	Klas Ltd
+@@ -1275,10 +1325,12 @@
+ 0:13:fb	RKC INSTRUMENT INC.
+ 0:13:fc	SiCortex, Inc
+ 0:13:fd	Nokia Danmark A/S
++0:13:f	EGEMEN Bilgisayar Muh San ve Tic LTD STI
+ 0:13:fe	GRANDTEC ELECTRONIC CORP.
+ 0:13:ff	Dage-MTI of MC, Inc.
++0:1:3f	Neighbor World Co., Ltd.
+ 0:14:0	MINERVA KOREA CO., LTD
+-0:14:1	Rivertree Networks Corp.
++0:1:40	Sendtek Corporation
+ 0:14:10	Suzhou Keda Technology CO.,Ltd
+ 0:14:11	Deutschmann Automation GmbH & Co. KG
+ 0:14:12	S-TEC electronics AG
+@@ -1291,11 +1343,12 @@
+ 0:14:19	SIDSA
+ 0:14:1a	DEICY CORPORATION
+ 0:14:1b	Cisco Systems
++0:1:41	CABLE PRINT
+ 0:14:1c	Cisco Systems
+ 0:14:1d	Lust Antriebstechnik GmbH
+ 0:14:1e	P.A. Semi, Inc.
+ 0:14:1f	SunKwang Electronics Co., Ltd
+-0:14:2	kk-electronic a/s
++0:14:1	Rivertree Networks Corp.
+ 0:14:20	G-Links networking company
+ 0:14:21	Total Wireless Technologies Pte. Ltd.
+ 0:14:22	Dell Inc.
+@@ -1307,12 +1360,13 @@
+ 0:14:28	Vocollect, Inc
+ 0:14:29	V Center Technologies Co., Ltd.
+ 0:14:2a	Elitegroup Computer System Co., Ltd
+-0:14:2b	Edata Technologies Inc.
++0:14:2b	Edata Communication Inc.
++0:1:42	Cisco Systems, Inc.
+ 0:14:2c	Koncept International, Inc.
+ 0:14:2d	Toradex AG
+ 0:14:2e	77 Elektronika Kft.
+ 0:14:2f	WildPackets
+-0:14:3	Renasis, LLC
++0:14:2	kk-electronic a/s
+ 0:14:30	ViPowER, Inc
+ 0:14:31	PDL Electronics Ltd
+ 0:14:32	Tarallax Wireless, Inc.
+@@ -1325,18 +1379,19 @@
+ 0:14:39	Blonder Tongue Laboratories, Inc.
+ 0:14:3a	RAYTALK INTERNATIONAL SRL
+ 0:14:3b	Sensovation AG
+-0:14:3c	Oerlikon Contraves Inc.
++0:1:43	Cisco Systems, Inc.
++0:14:3c	Rheinmetall Canada Inc.
+ 0:14:3d	Aevoe Inc.
+ 0:14:3e	AirLink Communications, Inc.
+ 0:14:3f	Hotway Technology Corporation
+-0:14:4	Motorola CHS
++0:14:3	Renasis, LLC
+ 0:14:40	ATOMIC Corporation
+ 0:14:41	Innovation Sound Technology Co., LTD.
+ 0:14:42	ATTO CORPORATION
+ 0:14:43	Consultronics Europe Ltd
+ 0:14:44	Grundfos Electronics
+ 0:14:45	Telefon-Gradnja d.o.o.
+-0:14:46	KidMapper, Inc.
++0:14:46	SuperVision Solutions LLC
+ 0:14:47	BOAZ Inc.
+ 0:14:48	Inventec Multimedia & Telecom Corporation
+ 0:14:49	Sichuan Changhong Electric Ltd.
+@@ -1344,9 +1399,10 @@
+ 0:14:4b	Hifn, Inc.
+ 0:14:4c	General Meters Corp.
+ 0:14:4d	Intelligent Systems
++0:1:44	EMC Corporation
+ 0:14:4e	SRISA
+-0:14:4f	Sun Microsystems, Inc.
+-0:14:5	OpenIB, Inc.
++0:14:4f	Oracle Corporation
++0:14:4	Motorola CHS
+ 0:14:50	Heim Systems GmbH
+ 0:14:51	Apple Computer Inc.
+ 0:14:52	CALCULEX,INC.
+@@ -1357,13 +1413,14 @@
+ 0:14:57	T-VIPS AS
+ 0:14:58	HS Automatic ApS
+ 0:14:59	Moram Co., Ltd.
+-0:14:5a	Elektrobit AG
++0:14:5a	Neratec AG
+ 0:14:5b	SeekerNet Inc.
+ 0:14:5c	Intronics B.V.
+ 0:14:5d	WJ Communications, Inc.
+ 0:14:5e	IBM
+ 0:14:5f	ADITEC CO. LTD
+-0:14:6	Go Networks
++0:14:5	OpenIB, Inc.
++0:1:45	WINSYSTEMS, INC.
+ 0:14:60	Kyocera Wireless Corp.
+ 0:14:61	CORONA CORPORATION
+ 0:14:62	Digiwell Technology, inc
+@@ -1380,7 +1437,8 @@
+ 0:14:6d	RF Technologies
+ 0:14:6e	H. Stoll GmbH & Co. KG
+ 0:14:6f	Kohler Co
+-0:14:7	Biosystems
++0:14:6	Go Networks
++0:1:46	Tesco Controls, Inc.
+ 0:14:70	Prokom Software SA
+ 0:14:71	Eastern Asia Technology Limited
+ 0:14:72	China Broadband Wireless IP Standard Group
+@@ -1393,28 +1451,30 @@
+ 0:14:79	NEC Magnus Communications,Ltd.
+ 0:14:7a	Eubus GmbH
+ 0:14:7b	Iteris, Inc.
+-0:14:7c	3Com Europe Ltd
++0:14:7c	3Com Ltd
+ 0:14:7d	Aeon Digital International
+-0:14:7e	PanGo Networks, Inc.
++0:14:7e	InnerWireless
+ 0:14:7f	Thomson Telecom Belgium
+-0:14:8	Eka Systems Inc.
++0:14:7	Sperian Protection Instrumentation
++0:1:47	Zhone Technologies
+ 0:14:80	Hitachi-LG Data Storage Korea, Inc
+ 0:14:81	Multilink Inc
+ 0:14:82	GoBackTV, Inc
+ 0:14:83	eXS Inc.
+-0:14:84	CERMATE TECHNOLOGIES INC
++0:14:84	Cermate Technologies Inc.
+ 0:14:85	Giga-Byte
+ 0:14:86	Echo Digital Audio Corporation
+ 0:14:87	American Technology Integrators
+-0:14:88	Akorri Networks
++0:14:88	Akorri
+ 0:14:89	B15402100 - JANDEI, S.L.
+ 0:14:8a	Elin Ebg Traction Gmbh
+ 0:14:8b	Globo Electronic GmbH & Co. KG
+ 0:14:8c	Fortress Technologies
+ 0:14:8d	Cubic Defense Simulation Systems
++0:14:8	Eka Systems Inc.
+ 0:14:8e	Tele Power Inc.
+ 0:14:8f	Protronic (Far East) Ltd.
+-0:14:9	MAGNETI MARELLI   S.E. S.p.A.
++0:1:48	X-traWeb Inc.
+ 0:14:90	ASP Corporation
+ 0:14:91	Daniels Electronics Ltd.
+ 0:14:92	Liteon, Mobile Media Solution SBU
+@@ -1431,8 +1491,9 @@
+ 0:14:9d	Sound ID Inc.
+ 0:14:9e	UbONE Co., Ltd
+ 0:14:9f	System and Chips, Inc.
+-0:14:a	WEPIO Co., Ltd.
+-0:14:a0	RFID Asset Track, Inc.
++0:14:9	MAGNETI MARELLI   S.E. S.p.A.
++0:1:49	T.D.T. Transfer Data Test GmbH
++0:14:a0	Accsense, Inc.
+ 0:14:a1	Synchronous Communication Corp
+ 0:14:a2	Core Micro Systems Inc.
+ 0:14:a3	Vitelec BV
+@@ -1445,27 +1506,29 @@
+ 0:14:aa	Ashly Audio, Inc.
+ 0:14:ab	Senhai Electronic Technology Co., Ltd.
+ 0:14:ac	Bountiful WiFi
+-0:14:ad	Gassner Wiege- u. Meßtechnik GmbH
++0:14:ad	Gassner Wiege- u. MeÃŸtechnik GmbH
+ 0:14:ae	Wizlogics Co., Ltd.
+ 0:14:af	Datasym Inc.
+-0:14:b	FIRST INTERNATIONAL COMPUTER, INC.
++0:1:4a	Sony Corporation
++0:14:a	WEPIO Co., Ltd.
+ 0:14:b0	Naeil Community
+ 0:14:b1	Avitec AB
+ 0:14:b2	mCubelogics Corporation
+ 0:14:b3	CoreStar International Corp
+ 0:14:b4	General Dynamics United Kingdom Ltd
+-0:14:b5	PRIVATE
++0:14:b5	PHYSIOMETRIX,INC
+ 0:14:b6	Enswer Technology Inc.
+ 0:14:b7	AR Infotek Inc.
+ 0:14:b8	Hill-Rom
+-0:14:b9	STEPMIND
++0:14:b9	MSTAR SEMICONDUCTOR
+ 0:14:ba	Carvers SA de CV
+ 0:14:bb	Open Interface North America
+ 0:14:bc	SYNECTIC TELECOM EXPORTS PVT. LTD.
+ 0:14:bd	incNETWORKS, Inc
++0:1:4b	Ennovate Networks, Inc.
+ 0:14:be	Wink communication technology CO.LTD
+ 0:14:bf	Cisco-Linksys LLC
+-0:14:c	GKB CCTV CO., LTD.
++0:14:b	FIRST INTERNATIONAL COMPUTER, INC.
+ 0:14:c0	Symstream Technology Group Ltd
+ 0:14:c1	U.S. Robotics Corporation
+ 0:14:c2	Hewlett Packard
+@@ -1475,31 +1538,34 @@
+ 0:14:c6	Quixant Ltd
+ 0:14:c7	Nortel
+ 0:14:c8	Contemporary Research Corp
+-0:14:c9	Silverback Systems, Inc.
++0:14:c9	Brocade Communications Systems, Inc.
+ 0:14:ca	Key Radio Systems Limited
+-0:14:cb	GMP|Wireless Medicine,Inc.
++0:1:4c	Berkeley Process Control
++0:14:cb	LifeSync Corporation
+ 0:14:cc	Zetec, Inc.
+ 0:14:cd	DigitalZone Co., Ltd.
+ 0:14:ce	NF CORPORATION
+-0:14:cf	Nextlink.to A/S
+-0:14:d	Nortel
+-0:14:d0	BTI Photonics
+-0:14:d1	TRENDware International, Inc.
++0:14:cf	INVISIO Communications
++0:14:c	GKB CCTV CO., LTD.
++0:14:d0	BTI Systems Inc.
++0:14:d1	TRENDnet
+ 0:14:d2	KYUKI CORPORATION
+ 0:14:d3	SEPSA
+ 0:14:d4	K Technology Corporation
+ 0:14:d5	Datang Telecom Technology CO. , LCD,Optical Communication Br
+ 0:14:d6	Jeongmin Electronics Co.,Ltd.
+-0:14:d7	DataStor Technology Inc.
++0:14:d7	Datastore Technology Corp
+ 0:14:d8	bio-logic SA
+ 0:14:d9	IP Fabrics, Inc.
+-0:14:da	Sonicaid
++0:14:da	Huntleigh Healthcare
+ 0:14:db	Elma Trenew Electronic GmbH
+ 0:14:dc	Communication System Design & Manufacturing (CSDM)
+ 0:14:dd	Covergence Inc.
+ 0:14:de	Sage Instruments Inc.
+ 0:14:df	HI-P Tech Corporation
+-0:14:e	Nortel
++0:14:d	Nortel
++0:1:4d	Shin Kin Enterprises Co., Ltd
++0:1:4	DVICO Co., Ltd.
+ 0:14:e0	LET'S Corporation
+ 0:14:e1	Data Display AG
+ 0:14:e2	datacom systems inc.
+@@ -1516,7 +1582,8 @@
+ 0:14:ed	Airak, Inc.
+ 0:14:ee	Western Digital Technologies, Inc.
+ 0:14:ef	TZero Technologies, Inc.
+-0:14:f	Federal State Unitary Enterprise Leningrad R&D Institute of
++0:14:e	Nortel
++0:1:4e	WIN Enterprises, Inc.
+ 0:14:f0	Business Security OL AB
+ 0:14:f1	Cisco Systems
+ 0:14:f2	Cisco Systems
+@@ -1528,13 +1595,15 @@
+ 0:14:f8	Scientific Atlanta
+ 0:14:f9	Vantage Controls
+ 0:14:fa	AsGa S.A.
++0:1:4f	ADTRAN INC
+ 0:14:fb	Technical Solutions Inc.
+ 0:14:fc	Extandon, Inc.
+ 0:14:fd	Thecus Technology Corp.
+ 0:14:fe	Artech Electronics
+-0:14:ff	Precise Automation, LLC
++0:14:f	Federal State Unitary Enterprise Leningrad R&D Institute of
++0:14:ff	Precise Automation, Inc.
++0:1:50	GILAT COMMUNICATIONS, LTD.
+ 0:15:0	Intel Corporate
+-0:15:1	LexBox
+ 0:15:10	Techsphere Co., Ltd
+ 0:15:11	Data Center Systems
+ 0:15:12	Zurich University of Applied Sciences
+@@ -1549,43 +1618,46 @@
+ 0:15:1b	Isilon Systems Inc.
+ 0:15:1c	LENECO
+ 0:15:1d	M2I CORPORATION
+-0:15:1e	Metaware Co., Ltd.
++0:15:1e	Ethernet Powerlink Standardization Group (EPSG)
++0:1:51	Ensemble Communications
+ 0:15:1f	Multivision Intelligent Surveillance (Hong Kong) Ltd
+-0:15:2	BETA tech
++0:15:1	LexBox
+ 0:15:20	Radiocrafts AS
+ 0:15:21	Horoquartz
+ 0:15:22	Dea Security
+ 0:15:23	Meteor Communications Corporation
+ 0:15:24	Numatics, Inc.
+-0:15:25	PTI Integrated Systems, Inc.
++0:15:25	Chamberlain Access Solutions
+ 0:15:26	Remote Technologies Inc
+ 0:15:27	Balboa Instruments
+ 0:15:28	Beacon Medical Products LLC d.b.a. BeaconMedaes
+ 0:15:29	N3 Corporation
+ 0:15:2a	Nokia GmbH
+ 0:15:2b	Cisco Systems
++0:15:2	BETA tech
+ 0:15:2c	Cisco Systems
++0:1:52	CHROMATEK INC.
+ 0:15:2d	TenX Networks, LLC
+ 0:15:2e	PacketHop, Inc.
+ 0:15:2f	Motorola CHS
+-0:15:3	PROFIcomms s.r.o.
+ 0:15:30	Bus-Tech, Inc.
+ 0:15:31	KOCOM
+ 0:15:32	Consumer Technologies Group, LLC
+ 0:15:33	NADAM.CO.,LTD
+-0:15:34	A BELTRÓNICA, Companhia de Comunicações, Lda
++0:15:34	A BELTR
+ 0:15:35	OTE Spa
+ 0:15:36	Powertech co.,Ltd
+ 0:15:37	Ventus Networks
+ 0:15:38	RFID, Inc.
+ 0:15:39	Technodrive SRL
++0:1:53	ARCHTEK TELECOM CORPORATION
+ 0:15:3a	Shenzhen Syscan Technology Co.,Ltd.
+-0:15:3b	EMH Elektrizitätszähler GmbH & CoKG
++0:15:3b	EMH Elektrizit
+ 0:15:3c	Kprotech Co., Ltd.
+ 0:15:3d	ELIM PRODUCT CO.
+ 0:15:3e	Q-Matic Sweden AB
+-0:15:3f	Alenia Spazio S.p.A.
+-0:15:4	GAME PLUS CO., LTD.
++0:15:3f	Alcatel Alenia Space Italia
++0:15:3	PROFIcomms s.r.o.
+ 0:15:40	Nortel
+ 0:15:41	StrataLight Communications, Inc.
+ 0:15:42	MICROHARD S.R.L.
+@@ -1600,26 +1672,28 @@
+ 0:15:4b	Wonde Proud Technology Co., Ltd
+ 0:15:4c	Saunders Electronics
+ 0:15:4d	Netronome Systems, Inc.
+-0:15:4e	Hirschmann Automation and Control GmbH
++0:15:4e	IEC
+ 0:15:4f	one RF Technology
+-0:15:5	Actiontec Electronics, Inc
++0:1:54	G3M Corporation
++0:15:4	GAME PLUS CO., LTD.
+ 0:15:50	Nits Technology Inc
+ 0:15:51	RadioPulse Inc.
+ 0:15:52	Wi-Gear Inc.
+ 0:15:53	Cytyc Corporation
+ 0:15:54	Atalum Wireless S.A.
+ 0:15:55	DFM GmbH
+-0:15:56	SAGEM SA
++0:15:56	SAGEM COMMUNICATION
+ 0:15:57	Olivetti
+ 0:15:58	FOXCONN
+ 0:15:59	Securaplane Technologies, Inc.
++0:15:5	Actiontec Electronics, Inc
+ 0:15:5a	DAINIPPON PHARMACEUTICAL CO., LTD.
+ 0:15:5b	Sampo Corporation
+ 0:15:5c	Dresser Wayne
+ 0:15:5d	Microsoft Corporation
+ 0:15:5e	Morgan Stanley
+-0:15:5f	Ubiwave
+-0:15:6	BeamExpress, Inc
++0:15:5f	GreenPeak Technologies
++0:1:55	Promise Technology, Inc.
+ 0:15:60	Hewlett Packard
+ 0:15:61	JJPlus Corporation
+ 0:15:62	Cisco Systems
+@@ -1633,27 +1707,29 @@
+ 0:15:6a	DG2L Technologies Pvt. Ltd.
+ 0:15:6b	Perfisans Networks Corp.
+ 0:15:6c	SANE SYSTEM CO., LTD
+-0:15:6d	Ubiquiti Networks
++0:15:6d	Ubiquiti Networks Inc.
+ 0:15:6e	A. W. Communication Systems Ltd
++0:1:56	FIREWIREDIRECT.COM, INC.
+ 0:15:6f	Xiranet Communications GmbH
+-0:15:7	Renaissance Learning Inc
+-0:15:70	Symbol Technologies
++0:15:6	Neo Photonics
++0:15:70	Symbol TechnologiesWholly owned Subsidiary of Motorola
+ 0:15:71	Nolan Systems
+ 0:15:72	Red-Lemon
+ 0:15:73	NewSoft  Technology Corporation
+ 0:15:74	Horizon Semiconductors Ltd.
+ 0:15:75	Nevis Networks Inc.
+ 0:15:76	scil animal care company GmbH
+-0:15:77	Allied Telesyn, Inc.
++0:15:77	Allied Telesis
+ 0:15:78	Audio / Video Innovations
+ 0:15:79	Lunatone Industrielle Elektronik GmbH
+ 0:15:7a	Telefin S.p.A.
+ 0:15:7b	Leuze electronic GmbH + Co. KG
+ 0:15:7c	Dave Networks, Inc.
+ 0:15:7d	POSDATA CO., LTD.
+-0:15:7e	HEYFRA ELECTRONIC gmbH
++0:15:7e	Weidmï¿½ller Interface GmbH & Co. KG   
+ 0:15:7f	ChuanG International Holding CO.,LTD.
+-0:15:8	Global Target Enterprise Inc
++0:15:7	Renaissance Learning Inc
++0:1:57	SYSWAVE CO., LTD
+ 0:15:80	U-WAY CORPORATION
+ 0:15:81	MAKUS Inc.
+ 0:15:82	TVonics Ltd
+@@ -1662,15 +1738,16 @@
+ 0:15:85	Aonvision Technolopy Corp.
+ 0:15:86	Xiamen Overseas Chinese Electronic Co., Ltd.
+ 0:15:87	Takenaka Seisakusho Co.,Ltd
+-0:15:88	Balda-Thong Fook Solutions Sdn. Bhd.
++0:15:88	Balda Solution Malaysia Sdn Bhd
+ 0:15:89	D-MAX Technology Co.,Ltd
+ 0:15:8a	SURECOM Technology Corp.
+ 0:15:8b	Park Air Systems Ltd
+ 0:15:8c	Liab ApS
+ 0:15:8d	Jennic Ltd
++0:1:58	Electro Industries/Gauge Tech
+ 0:15:8e	Plustek.INC
+ 0:15:8f	NTT Advanced Technology Corporation
+-0:15:9	Plus Technology Co., Ltd
++0:15:8	Global Target Enterprise Inc
+ 0:15:90	Hectronic GmbH
+ 0:15:91	RLW Inc.
+ 0:15:92	Facom UK Ltd (Melksham)
+@@ -1685,11 +1762,12 @@
+ 0:15:9b	Nortel
+ 0:15:9c	B-KYUNG SYSTEM Co.,Ltd.
+ 0:15:9d	Minicom Advanced Systems ltd
+-0:15:9e	Saitek plc
++0:15:9e	Mad Catz Interactive Inc
+ 0:15:9f	Terascala, Inc.
+-0:15:a	Sonoa Systems, Inc
++0:15:9	Plus Technology Co., Ltd
++0:1:59	S1 Corporation
+ 0:15:a0	Nokia Danmark A/S
+-0:15:a1	SINTERS SAS
++0:15:a1	ECA-SINTERS
+ 0:15:a2	ARRIS International
+ 0:15:a3	ARRIS International
+ 0:15:a4	ARRIS International
+@@ -1702,9 +1780,10 @@
+ 0:15:ab	PRO CO SOUND INC
+ 0:15:ac	Capelon AB
+ 0:15:ad	Accedian Networks
++0:1:5a	Digital Video Broadcasting
+ 0:15:ae	kyung il
+ 0:15:af	AzureWave Technologies, Inc.
+-0:15:b	SAGE INFOTECH LTD.
++0:15:a	Sonoa Systems, Inc
+ 0:15:b0	AUTOTELENET CO.,LTD
+ 0:15:b1	Ambient Corporation
+ 0:15:b2	Advanced Industrial Computer, Inc.
+@@ -1716,12 +1795,14 @@
+ 0:15:b8	Tahoe
+ 0:15:b9	Samsung Electronics Co., Ltd.
+ 0:15:ba	iba AG
+-0:15:bb	SMA Technologie AG
++0:15:bb	SMA Solar Technology AG
+ 0:15:bc	Develco
+ 0:15:bd	Group 4 Technology Ltd
++0:1:5	Beckhoff Automation GmbH
+ 0:15:be	Iqua Ltd.
+ 0:15:bf	technicob
+-0:15:c	AVM GmbH
++0:1:5b	ITALTEL S.p.A/RF-UP-I
++0:15:b	SAGE INFOTECH LTD.
+ 0:15:c0	DIGITAL TELEMEDIA CO.,LTD.
+ 0:15:c1	SONY Computer Entertainment inc,
+ 0:15:c2	3M Germany
+@@ -1733,14 +1814,15 @@
+ 0:15:c8	FlexiPanel Ltd
+ 0:15:c9	Gumstix, Inc
+ 0:15:ca	TeraRecon, Inc.
++0:15:c	AVM GmbH
+ 0:15:cb	Surf Communication Solutions Ltd.
++0:1:5c	CADANT INC.
+ 0:15:cc	TEPCO UQUEST, LTD.
+ 0:15:cd	Exartech International Corp.
+ 0:15:ce	ARRIS International
+ 0:15:cf	ARRIS International
+-0:15:d	Hoana Medical, Inc.
+ 0:15:d0	ARRIS International
+-0:15:d1	ARRIS International
++0:15:d1	ARRIS Group, Inc.
+ 0:15:d2	Xantech Corporation
+ 0:15:d3	Pantech&Curitel Communications, Inc.
+ 0:15:d4	Emitor AB
+@@ -1755,10 +1837,11 @@
+ 0:15:dd	IP Control Systems Ltd.
+ 0:15:de	Nokia Danmark A/S
+ 0:15:df	Clivet S.p.A.
+-0:15:e	OPENBRAIN TECHNOLOGIES CO., LTD.
+-0:15:e0	Ericsson Mobile Platforms
++0:15:d	Hoana Medical, Inc.
++0:1:5d	Oracle Corporation
++0:15:e0	ST-Ericsson
+ 0:15:e1	picoChip Designs Ltd
+-0:15:e2	Wissenschaftliche Geraetebau Dr. Ing. H. Knauer GmbH
++0:15:e2	Dr.Ing. Herbert Knauer GmbH
+ 0:15:e3	Dream Technologies Corporation
+ 0:15:e4	Zimmer Elektromedizin
+ 0:15:e5	Cheertek Inc.
+@@ -1767,12 +1850,13 @@
+ 0:15:e8	Nortel
+ 0:15:e9	D-Link Corporation
+ 0:15:ea	Tellumat (Pty) Ltd
++0:1:5e	BEST TECHNOLOGY CO., LTD.
+ 0:15:eb	ZTE CORPORATION
+ 0:15:ec	Boca Devices LLC
+ 0:15:ed	Fulcrum Microsystems, Inc.
+ 0:15:ee	Omnex Control Systems
+ 0:15:ef	NEC TOKIN Corporation
+-0:15:f	mingjong
++0:15:e	OPENBRAIN TECHNOLOGIES CO., LTD.
+ 0:15:f0	EGO BV
+ 0:15:f1	KYLINK Communications Corp.
+ 0:15:f2	ASUSTek COMPUTER INC.
+@@ -1785,12 +1869,14 @@
+ 0:15:f9	Cisco Systems
+ 0:15:fa	Cisco Systems
+ 0:15:fb	setex schermuly textile computer gmbh
+-0:15:fc	Startco Engineering Ltd.
++0:15:fc	Littelfuse Startco
+ 0:15:fd	Complete Media Systems
++0:1:5f	DIGITAL DESIGN GmbH
+ 0:15:fe	SCHILLING ROBOTICS LLC
+ 0:15:ff	Novatel Wireless, Inc.
++0:15:f	mingjong
+ 0:16:0	CelleBrite Mobile Synchronization
+-0:16:1	Buffalo Inc.
++0:1:60	ELMEX Co., LTD.
+ 0:16:10	Carina Technology
+ 0:16:11	Altecon Srl
+ 0:16:12	Otsuka Electronics Co., Ltd.
+@@ -1800,19 +1886,20 @@
+ 0:16:16	BROWAN COMMUNICATION INC.
+ 0:16:17	MSI
+ 0:16:18	HIVION Co., Ltd.
+-0:16:19	La Factoría de Comunicaciones Aplicadas,S.L.
++0:16:19	La Factor
+ 0:16:1a	Dametric AB
+ 0:16:1b	Micronet Corporation
++0:16:1	Buffalo Inc.
+ 0:16:1c	e:cue
+ 0:16:1d	Innovative Wireless Technologies, Inc.
+ 0:16:1e	Woojinnet
+ 0:16:1f	SUNWAVETEC Co., Ltd.
+-0:16:2	CEYON TECHNOLOGY CO.,LTD.
++0:1:61	Meta Machine Technology
+ 0:16:20	Sony Ericsson Mobile Communications AB
+ 0:16:21	Colorado Vnet
+ 0:16:22	BBH SYSTEMS GMBH
+ 0:16:23	Interval Media
+-0:16:24	PRIVATE
++0:16:24	Teneros, Inc.
+ 0:16:25	Impinj, Inc.
+ 0:16:26	Motorola CHS
+ 0:16:27	embedded-logic DESIGN AND MORE GmbH
+@@ -1820,11 +1907,12 @@
+ 0:16:29	Nivus GmbH
+ 0:16:2a	Antik computers & communications s.r.o.
+ 0:16:2b	Togami Electric Mfg.co.,Ltd.
++0:16:2	CEYON TECHNOLOGY CO.,LTD.
+ 0:16:2c	Xanboo
++0:1:62	Cygnet Technologies, Inc.
+ 0:16:2d	STNet Co., Ltd.
+ 0:16:2e	Space Shuttle Hi-Tech Co., Ltd.
+-0:16:2f	Geutebrück GmbH
+-0:16:3	PRIVATE
++0:16:2f	Geutebr
+ 0:16:30	Vativ Technologies
+ 0:16:31	Xteam
+ 0:16:32	SAMSUNG ELECTRONICS CO., LTD.
+@@ -1837,15 +1925,16 @@
+ 0:16:39	UBIQUAM Co.,Ltd
+ 0:16:3a	YVES TECHNOLOGY CO., LTD.
+ 0:16:3b	VertexRSI/General Dynamics
++0:1:63	Cisco Systems, Inc.
++0:16:3	COOLKSKY Co., LTD
+ 0:16:3c	Rebox B.V.
+ 0:16:3d	Tsinghua Tongfang Legend Silicon Tech. Co., Ltd.
+ 0:16:3e	Xensource, Inc.
+ 0:16:3f	CReTE SYSTEMS Inc.
+-0:16:4	Sigpro
+ 0:16:40	Asmobile Communication Inc.
+ 0:16:41	USI
+ 0:16:42	Pangolin
+-0:16:43	Sunhillo Corproation
++0:16:43	Sunhillo Corporation
+ 0:16:44	LITE-ON Technology Corp.
+ 0:16:45	Power Distribution, Inc.
+ 0:16:46	Cisco Systems
+@@ -1854,13 +1943,14 @@
+ 0:16:49	SetOne GmbH
+ 0:16:4a	Vibration Technology Limited
+ 0:16:4b	Quorion Data Systems GmbH
++0:1:64	Cisco Systems, Inc.
+ 0:16:4c	PLANET INT Co., Ltd
+ 0:16:4d	Alcatel North America IP Division
+ 0:16:4e	Nokia Danmark A/S
+ 0:16:4f	World Ethnic Broadcastin Inc.
+-0:16:5	YORKVILLE SOUND INC.
+-0:16:50	EYAL MICROWAVE
+-0:16:51	PRIVATE
++0:16:4	Sigpro
++0:16:50	Herley General Microwave Israel. 
++0:16:51	Exeo Systems
+ 0:16:52	Hoatech Technologies, Inc.
+ 0:16:53	LEGO System A/S IE Electronics Division
+ 0:16:54	Flex-P Industries Sdn. Bhd.
+@@ -1870,12 +1960,13 @@
+ 0:16:58	Fusiontech Technologies Inc.
+ 0:16:59	Z.M.P. RADWAG
+ 0:16:5a	Harman Specialty Group
++0:1:65	AirSwitch Corporation
+ 0:16:5b	Grip Audio
+ 0:16:5c	Trackflow Ltd
+ 0:16:5d	AirDefense, Inc.
+ 0:16:5e	Precision I/O
+ 0:16:5f	Fairmount Automation
+-0:16:6	Ideal Industries
++0:16:5	YORKVILLE SOUND INC.
+ 0:16:60	Nortel
+ 0:16:61	Novatium Solutions (P) Ltd
+ 0:16:62	Liyuh Technology Ltd.
+@@ -1892,11 +1983,12 @@
+ 0:16:6d	Yulong Computer Telecommunication Scientific(shenzhen)Co.,Lt
+ 0:16:6e	Arbitron Inc.
+ 0:16:6f	Intel Corporation
+-0:16:7	Curves International Inc.
++0:16:6	Ideal Industries
++0:1:66	TC GROUP A/S
+ 0:16:70	SKNET Corporation
+ 0:16:71	Symphox Information Co.
+ 0:16:72	Zenway enterprise ltd
+-0:16:73	PRIVATE
++0:16:73	Bury GmbH & Co. KG
+ 0:16:74	EuroCB (Phils.), Inc.
+ 0:16:75	Motorola MDb
+ 0:16:76	Intel Corporation
+@@ -1906,16 +1998,17 @@
+ 0:16:7a	Skyworth Overseas Dvelopment Ltd.
+ 0:16:7b	Haver&Boecker
+ 0:16:7c	iRex Technologies BV
+-0:16:7d	Sky-Line
++0:16:7	Curves International Inc.
++0:16:7d	Sky-Line Information Co., Ltd.
+ 0:16:7e	DIBOSS.CO.,LTD
+ 0:16:7f	Bluebird Soft Inc.
+-0:16:8	Sequans Communications
++0:1:67	HIOKI E.E. CORPORATION
+ 0:16:80	Bally Gaming + Systems
+ 0:16:81	Vector Informatik GmbH
+ 0:16:82	Pro Dex, Inc
+ 0:16:83	WEBIO International Co.,.Ltd.
+ 0:16:84	Donjin Co.,Ltd.
+-0:16:85	FRWD Technologies Ltd.
++0:16:85	Elisa Oyj
+ 0:16:86	Karl Storz Imaging
+ 0:16:87	Chubb CSC-Vendor AP
+ 0:16:88	ServerEngines LLC
+@@ -1926,7 +2019,8 @@
+ 0:16:8d	KORWIN CO., Ltd.
+ 0:16:8e	Vimicro corporation
+ 0:16:8f	GN Netcom as
+-0:16:9	Unitech electronics co., ltd.
++0:16:8	Sequans Communications
++0:1:68	VITANA CORPORATION
+ 0:16:90	J-TEK INCORPORATION
+ 0:16:91	Moser-Baer AG
+ 0:16:92	Scientific-Atlanta, Inc.
+@@ -1935,19 +2029,20 @@
+ 0:16:95	AVC Technology Limited
+ 0:16:96	QDI Technology (H.K.) Limited
+ 0:16:97	NEC Corporation
+-0:16:98	T&A Mobile Phones SAS
+-0:16:99	PRIVATE
++0:16:98	T&A Mobile Phones
++0:16:99	Tonic DVB Marketing Ltd
+ 0:16:9a	Quadrics Ltd
+ 0:16:9b	Alstom Transport
+ 0:16:9c	Cisco Systems
++0:1:69	Celestix Networks Pte Ltd.
+ 0:16:9d	Cisco Systems
+ 0:16:9e	TV One Ltd
+ 0:16:9f	Vimtron Electronics Co., Ltd.
+-0:16:a	SWEEX Europe BV
++0:16:9	Unitech electronics co., ltd.
+ 0:16:a0	Auto-Maskin
+ 0:16:a1	3Leaf Networks
+ 0:16:a2	CentraLite Systems, Inc.
+-0:16:a3	TEAM ARTECHE, S.A.
++0:16:a3	Ingeteam Transmission&Distribution, S.A.
+ 0:16:a4	Ezurio Ltd
+ 0:16:a5	Tandberg Storage ASA
+ 0:16:a6	Dovado FZ-LLC
+@@ -1955,12 +2050,13 @@
+ 0:16:a8	CWT CO., LTD.
+ 0:16:a9	2EI
+ 0:16:aa	Kei Communication Technology Inc.
++0:1:6a	ALITEC
+ 0:16:ab	PBI-Dansensor A/S
+ 0:16:ac	Toho Technology Corp.
+ 0:16:ad	BT-Links Company Limited
+ 0:16:ae	INVENTEL
+ 0:16:af	Shenzhen Union Networks Equipment Co.,Ltd.
+-0:16:b	TVWorks LLC
++0:16:a	SWEEX Europe BV
+ 0:16:b0	VK Corporation
+ 0:16:b1	KBS
+ 0:16:b2	DriveCam Inc
+@@ -1977,7 +2073,8 @@
+ 0:16:bd	ATI Industrial Automation
+ 0:16:be	INFRANET, Inc.
+ 0:16:bf	PaloDEx Group Oy
+-0:16:c	LPL  DEVELOPMENT S.A. DE C.V
++0:1:6b	LightChip, Inc.
++0:16:b	TVWorks LLC
+ 0:16:c0	Semtech Corporation
+ 0:16:c1	Eleksen Ltd
+ 0:16:c2	Avtec Systems Inc
+@@ -1994,7 +2091,8 @@
+ 0:16:cd	HIJI HIGH-TECH CO., LTD.
+ 0:16:ce	Hon Hai Precision Ind. Co., Ltd.
+ 0:16:cf	Hon Hai Precision Ind. Co., Ltd.
+-0:16:d	Be Here Corporation
++0:1:6c	FOXCONN
++0:16:c	LPL  DEVELOPMENT S.A. DE C.V
+ 0:16:d0	ATech elektronika d.o.o.
+ 0:16:d1	ZAT a.s.
+ 0:16:d2	Caspian
+@@ -2006,13 +2104,14 @@
+ 0:16:d8	Senea AB
+ 0:16:d9	NINGBO BIRD CO.,LTD.
+ 0:16:da	Futronic Technology Co. Ltd.
++0:16:d	Be Here Corporation
+ 0:16:db	Samsung Electronics Co., Ltd.
+ 0:16:dc	ARCHOS
++0:1:6d	CarrierComm Inc.
+ 0:16:dd	Gigabeam Corporation
+ 0:16:de	FAST Inc
+ 0:16:df	Lundinova AB
+-0:16:e	Optica Technologies Inc.
+-0:16:e0	3Com Europe Ltd
++0:16:e0	3Com Ltd
+ 0:16:e1	SiliconStor, Inc.
+ 0:16:e2	American Fibertek, Inc.
+ 0:16:e3	ASKEY COMPUTER CORP.
+@@ -2025,11 +2124,12 @@
+ 0:16:ea	Intel Corporation
+ 0:16:eb	Intel Corporation
+ 0:16:ec	Elitegroup Computer Systems Co., Ltd.
+-0:16:ed	Integrian, Inc.
++0:1:6e	Conklin Corporation
++0:16:ed	Digital Safety Technologies, Inc
+ 0:16:ee	RoyalDigital Inc.
+ 0:16:ef	Koko Fitness, Inc.
+-0:16:f	BADGER METER INC
+-0:16:f0	Zermatt Systems, Inc
++0:16:e	Optica Technologies Inc.
++0:16:f0	Dell
+ 0:16:f1	OmniSense, LLC
+ 0:16:f2	Dmobile System Co., Ltd.
+ 0:16:f3	CAST Information Co., Ltd
+@@ -2037,16 +2137,19 @@
+ 0:16:f5	Dalian Golden Hualu Digital Technology Co.,Ltd
+ 0:16:f6	Video Products Group
+ 0:16:f7	L-3 Communications, Electrodynamics, Inc.
+-0:16:f8	PRIVATE
++0:16:f8	AVIQTECH TECHNOLOGY CO., LTD.
+ 0:16:f9	CETRTA POT, d.o.o., Kranj
+ 0:16:fa	ECI Telecom Ltd.
++0:16:f	BADGER METER INC
+ 0:16:fb	SHENZHEN MTC CO.,LTD.
+ 0:16:fc	TOHKEN CO.,LTD.
+ 0:16:fd	Jaty Electronics
+ 0:16:fe	Alps Electric Co., Ltd
+ 0:16:ff	Wamin Optocomm Mfg Corp
++0:1:6f	Inkel Corp.
++0:1:6	Tews Datentechnik GmbH
++0:1:70	ESE Embedded System Engineer'g
+ 0:17:0	Motorola MDb
+-0:17:1	KDE, Inc.
+ 0:17:10	Casa Systems Inc.
+ 0:17:11	GE Healthcare Bio-Sciences AB
+ 0:17:12	ISCO International
+@@ -2057,13 +2160,14 @@
+ 0:17:17	Leica Geosystems AG
+ 0:17:18	Vansco Electronics Oy
+ 0:17:19	AudioCodes USA, Inc
++0:1:71	Allied Data Technologies
+ 0:17:1a	Winegard Company
+ 0:17:1b	Innovation Lab Corp.
+ 0:17:1c	NT MicroSystems, Inc.
+ 0:17:1d	DIGIT
+ 0:17:1e	Theo Benning GmbH & Co. KG
+ 0:17:1f	IMV Corporation
+-0:17:2	Osung Midicom Co., Ltd
++0:17:1	KDE, Inc.
+ 0:17:20	Image Sensing Systems, Inc.
+ 0:17:21	FITRE S.p.A.
+ 0:17:22	Hanazeder Electronic GmbH
+@@ -2080,28 +2184,30 @@
+ 0:17:2d	Axcen Photonics Corporation
+ 0:17:2e	FXC Inc.
+ 0:17:2f	NeuLion Incorporated
+-0:17:3	MOSDAN Internation Co.,Ltd
++0:17:2	Osung Midicom Co., Ltd
++0:1:72	TechnoLand Co., LTD.
+ 0:17:30	Automation Electronics
+ 0:17:31	ASUSTek COMPUTER INC.
+ 0:17:32	Science-Technical Center "RISSA"
+-0:17:33	neuf cegetel
+-0:17:34	LGC Wireless Inc.
++0:17:33	SFR
++0:17:34	ADC Telecommunications
+ 0:17:35	PRIVATE
+ 0:17:36	iiTron Inc.
+ 0:17:37	Industrie Dial Face S.p.A.
+-0:17:38	XIV
++0:17:38	International Business Machines
+ 0:17:39	Bright Headphone Electronics Company
+-0:17:3a	Edge Integration Systems Inc.
++0:1:73	AMCC
++0:17:3a	Reach Systems Inc.
+ 0:17:3b	Arched Rock Corporation
+ 0:17:3c	Extreme Engineering Solutions
+ 0:17:3d	Neology
+ 0:17:3e	LeucotronEquipamentos Ltda.
+ 0:17:3f	Belkin Corporation
+-0:17:4	Shinco Electronics Group Co.,Ltd
+-0:17:40	Technologies Labtronix
++0:17:3	MOSDAN Internation Co.,Ltd
++0:17:40	Bluberi Gaming Technologies Inc
+ 0:17:41	DEFIDEV
+ 0:17:42	FUJITSU LIMITED
+-0:17:43	PRIVATE
++0:17:43	Deck Srl
+ 0:17:44	Araneo Ltd.
+ 0:17:45	INNOTZ CO., Ltd
+ 0:17:46	Freedom9 Inc.
+@@ -2111,10 +2217,11 @@
+ 0:17:4a	SOCOMEC
+ 0:17:4b	Nokia Danmark A/S
+ 0:17:4c	Millipore
++0:1:74	CyberOptics Corporation
+ 0:17:4d	DYNAMIC NETWORK FACTORY, INC.
+ 0:17:4e	Parama-tech Co.,Ltd.
+ 0:17:4f	iCatch Inc.
+-0:17:5	Methode Electronics
++0:17:4	Shinco Electronics Group Co.,Ltd
+ 0:17:50	GSI Group, MicroE Systems
+ 0:17:51	Online Corporation
+ 0:17:52	DAGS, Inc
+@@ -2129,9 +2236,10 @@
+ 0:17:5b	ACS Solutions Switzerland Ltd.
+ 0:17:5c	SHARP CORPORATION
+ 0:17:5d	Dongseo system.
+-0:17:5e	Anta Systems, Inc.
++0:17:5e	Zed-3
+ 0:17:5f	XENOLINK Communications Co., Ltd.
+-0:17:6	Techfaithwireless Communication Technology Limited.
++0:17:5	Methode Electronics
++0:1:75	Radiant Communications Corp.
+ 0:17:60	Naito Densei Machida MFG.CO.,LTD
+ 0:17:61	ZKSoftware Inc.
+ 0:17:62	Solar Technology, Inc.
+@@ -2148,7 +2256,8 @@
+ 0:17:6d	CORE CORPORATION
+ 0:17:6e	DUCATI SISTEMI
+ 0:17:6f	PAX Computer Technology(Shenzhen) Ltd.
+-0:17:7	InGrid, Inc
++0:1:76	Orient Silver Enterprises
++0:17:6	Techfaith Wireless Communication Technology Limited.
+ 0:17:70	Arti Industrial Electronics Ltd.
+ 0:17:71	APD Communications Ltd
+ 0:17:72	ASTRO Strobel Kommunikationssysteme GmbH
+@@ -2161,11 +2270,12 @@
+ 0:17:79	QuickTel
+ 0:17:7a	ASSA ABLOY AB
+ 0:17:7b	Azalea Networks inc
+-0:17:7c	D-Link India Ltd
++0:17:7c	Smartlink Network Systems Limited
+ 0:17:7d	IDT International Limited
++0:1:77	EDSL
+ 0:17:7e	Meshcom Technologies Inc.
+ 0:17:7f	Worldsmart Retech
+-0:17:8	Hewlett Packard
++0:17:7	InGrid, Inc
+ 0:17:80	Applera Holding B.V. Singapore Operations
+ 0:17:81	Greystone Data System, Inc.
+ 0:17:82	LoBenn Inc.
+@@ -2182,7 +2292,8 @@
+ 0:17:8d	Checkpoint Systems, Inc.
+ 0:17:8e	Gunnebo Cash Automation AB
+ 0:17:8f	NINGBO YIDONG ELECTRONIC CO.,LTD.
+-0:17:9	Exalt Communications
++0:17:8	Hewlett Packard
++0:1:78	MARGI Systems, Inc.
+ 0:17:90	HYUNDAI DIGITECH Co, Ltd.
+ 0:17:91	LinTech GmbH
+ 0:17:92	Falcom Wireless Comunications Gmbh
+@@ -2198,13 +2309,14 @@
+ 0:17:9c	DEPRAG SCHULZ GMBH u. CO.
+ 0:17:9d	Kelman Limited
+ 0:17:9e	Sirit Inc
++0:17:9	Exalt Communications
+ 0:17:9f	Apricorn
+-0:17:a	INEW DIGITAL COMPANY
++0:1:79	WIRELESS TECHNOLOGY, INC.
+ 0:17:a0	RoboTech srl
+ 0:17:a1	3soft inc.
+ 0:17:a2	Camrivox Ltd.
+ 0:17:a3	MIX s.r.l.
+-0:17:a4	Global Data Services
++0:17:a4	Hewlett Packard
+ 0:17:a5	TrendChip Technologies Corp.
+ 0:17:a6	YOSIN ELECTRONICS CO., LTD.
+ 0:17:a7	Mobile Computing Promotion Consortium
+@@ -2212,11 +2324,12 @@
+ 0:17:a9	Sentivision
+ 0:17:aa	elab-experience inc.
+ 0:17:ab	Nintendo Co., Ltd.
++0:1:7a	Chengdu Maipu Electric Industrial Co., Ltd.
+ 0:17:ac	O'Neil Product Development Inc.
+ 0:17:ad	AceNet Corporation
+ 0:17:ae	GAI-Tronics
+ 0:17:af	Enermet
+-0:17:b	Contela, Inc.
++0:17:a	INEW DIGITAL COMPANY
+ 0:17:b0	Nokia Danmark A/S
+ 0:17:b1	ACIST Medical Systems, Inc.
+ 0:17:b2	SK Telesys
+@@ -2229,28 +2342,30 @@
+ 0:17:b9	Gambro Lundia AB
+ 0:17:ba	SEDO CO., LTD.
+ 0:17:bb	Syrinx Industrial Electronics
++0:17:b	Contela, Inc.
+ 0:17:bc	Touchtunes Music Corporation
+ 0:17:bd	Tibetsystem
+ 0:17:be	Tratec Telecom B.V.
+ 0:17:bf	Coherent Research Limited
+-0:17:c	Benefon Oyj
++0:1:7b	Heidelberger Druckmaschinen AG
+ 0:17:c0	PureTech Systems, Inc.
+ 0:17:c1	CM Precision Technology LTD.
+ 0:17:c2	Pirelli Broadband Solutions
+ 0:17:c3	KTF Technologies Inc.
+ 0:17:c4	Quanta Microsystems, INC.
+ 0:17:c5	SonicWALL
+-0:17:c6	Labcal Technologies
++0:17:c6	Cross Match Technologies Inc
+ 0:17:c7	MARA Systems Consulting AB
+ 0:17:c8	Kyocera Mita Corporation
+ 0:17:c9	Samsung Electronics Co., Ltd.
+-0:17:ca	BenQ Corporation
++0:1:7c	AG-E GmbH
++0:17:ca	Qisda Corporation
+ 0:17:cb	Juniper Networks
+-0:17:cc	Alcatel USA Sourcing LP
++0:17:cc	Alcatel-Lucent
+ 0:17:cd	CEC Wireless R&D Ltd.
+ 0:17:ce	MB International Telecom Labs srl
+ 0:17:cf	iMCA-GmbH
+-0:17:d	Dust Networks Inc.
++0:17:c	GeoSentric OYj
+ 0:17:d0	Opticom Communications, LLC
+ 0:17:d1	Nortel
+ 0:17:d2	THINLINX PTY LTD
+@@ -2258,16 +2373,17 @@
+ 0:17:d4	Monsoon Multimedia, Inc
+ 0:17:d5	Samsung Electronics Co., Ltd.
+ 0:17:d6	Bluechips Microhouse Co.,Ltd.
+-0:17:d7	Input/Output Inc.
++0:17:d7	ION Geophysical Corporation Inc.
+ 0:17:d8	Magnum Semiconductor, Inc.
+ 0:17:d9	AAI Corporation
+ 0:17:da	Spans Logic
+-0:17:db	PRIVATE
++0:17:db	CANKO TECHNOLOGIES INC.
+ 0:17:dc	DAEMYUNG ZERO1
+ 0:17:dd	Clipsal Australia
++0:17:d	Dust Networks Inc.
+ 0:17:de	Advantage Six Ltd
+ 0:17:df	Cisco Systems
+-0:17:e	Cisco Systems
++0:1:7d	ThermoQuest
+ 0:17:e0	Cisco Systems
+ 0:17:e1	DACOS Technologies Co., Ltd.
+ 0:17:e2	Motorola Mobile Devices
+@@ -2278,31 +2394,35 @@
+ 0:17:e7	Texas Instruments
+ 0:17:e8	Texas Instruments
+ 0:17:e9	Texas Instruments
++0:1:7e	ADTEK System Science Co., Ltd.
+ 0:17:ea	Texas Instruments
+ 0:17:eb	Texas Instruments
++0:17:e	Cisco Systems
+ 0:17:ec	Texas Instruments
+ 0:17:ed	WooJooIT Ltd.
+ 0:17:ee	Motorola CHS
+ 0:17:ef	Blade Network Technologies, Inc.
+-0:17:f	Cisco Systems
+ 0:17:f0	SZCOM Broadband Network Technology Co.,Ltd
+ 0:17:f1	Renu Electronics Pvt Ltd
+ 0:17:f2	Apple Computer
+-0:17:f3	M/A-COM Wireless Systems
++0:17:f3	Harris Corparation
+ 0:17:f4	ZERON ALLIANCE
+-0:17:f5	NEOPTEK
++0:17:f5	LIG NEOPTEK
+ 0:17:f6	Pyramid Meriden Inc.
+ 0:17:f7	CEM Solutions Pvt Ltd
+ 0:17:f8	Motech Industries Inc.
+ 0:17:f9	Forcom Sp. z o.o.
+ 0:17:fa	Microsoft Corporation
+ 0:17:fb	FA
++0:17:f	Cisco Systems
+ 0:17:fc	Suprema Inc.
+ 0:17:fd	Amulet Hotkey
+ 0:17:fe	TALOS SYSTEM INC.
++0:1:7f	Experience Music Project
+ 0:17:ff	PLAYLINE Co.,Ltd.
++0:1:7	Leiser GmbH
++0:1:80	AOpen, Inc.
+ 0:18:0	UNIGRAND LTD
+-0:18:1	Actiontec Electronics, Inc
+ 0:18:10	IPTrade S.A.
+ 0:18:11	Neuros Technology International, LLC.
+ 0:18:12	Beijing Xinwei Telecom Technology Co., Ltd.
+@@ -2313,13 +2433,14 @@
+ 0:18:17	D. E. Shaw Research, LLC
+ 0:18:18	Cisco Systems
+ 0:18:19	Cisco Systems
+-0:18:1a	AVerMedia Technologies Inc.
++0:18:1a	AVerMedia Information Inc.
++0:18:1	Actiontec Electronics, Inc
+ 0:18:1b	TaiJin Metal Co., Ltd.
+ 0:18:1c	Exterity Limited
+ 0:18:1d	ASIA ELECTRONICS CO.,LTD
+ 0:18:1e	GDX Technologies Ltd.
+ 0:18:1f	Palmmicro Communications
+-0:18:2	Alpha Networks Inc.
++0:1:81	Nortel Networks
+ 0:18:20	w5networks
+ 0:18:21	SINDORICOH
+ 0:18:22	CEC TELECOM CO.,LTD.
+@@ -2327,33 +2448,35 @@
+ 0:18:24	Kimaldi Electronics, S.L.
+ 0:18:25	Wavion LTD
+ 0:18:26	Cale Access AB
+-0:18:27	NEC PHILIPS UNIFIED SOLUTIONS NEDERLAND BV
++0:18:27	NEC UNIFIED SOLUTIONS NEDERLAND B.V.
+ 0:18:28	e2v technologies (UK) ltd.
+ 0:18:29	Gatsometer
++0:18:2	Alpha Networks Inc.
+ 0:18:2a	Taiwan Video & Monitor
+ 0:18:2b	Softier
+ 0:18:2c	Ascend Networks, Inc.
+-0:18:2d	Artec Group OÜ
+-0:18:2e	Wireless Ventures USA
++0:18:2d	Artec Group O
++0:1:82	DICA TECHNOLOGIES AG
++0:18:2e	XStreamHD, LLC
+ 0:18:2f	Texas Instruments
+-0:18:3	ArcSoft Shanghai Co. LTD
+ 0:18:30	Texas Instruments
+ 0:18:31	Texas Instruments
+ 0:18:32	Texas Instruments
+ 0:18:33	Texas Instruments
+ 0:18:34	Texas Instruments
+-0:18:35	ITC
++0:18:35	Thoratec / ITC
+ 0:18:36	Reliance Electric Limited
+ 0:18:37	Universal ABIT Co., Ltd.
+ 0:18:38	PanAccess Communications,Inc.
+ 0:18:39	Cisco-Linksys LLC
++0:1:83	ANITE TELECOMS
++0:18:3	ArcSoft Shanghai Co. LTD
+ 0:18:3a	Westell Technologies
+ 0:18:3b	CENITS Co., Ltd.
+ 0:18:3c	Encore Software Limited
+ 0:18:3d	Vertex Link Corporation
+ 0:18:3e	Digilent, Inc
+ 0:18:3f	2Wire, Inc
+-0:18:4	E-TEK DIGITAL TECHNOLOGY LIMITED
+ 0:18:40	3 Phoenix, Inc.
+ 0:18:41	High Tech Computer Corp
+ 0:18:42	Nokia Danmark A/S
+@@ -2362,15 +2485,16 @@
+ 0:18:45	NPL Pulsar Ltd.
+ 0:18:46	Crypto S.A.
+ 0:18:47	AceNet Technology Inc.
+-0:18:48	Vcom Inc.
++0:18:48	Vecima Networks Inc.
+ 0:18:49	Pigeon Point Systems
+ 0:18:4a	Catcher, Inc.
+ 0:18:4b	Las Vegas Gaming, Inc.
+ 0:18:4c	Bogen Communications
+ 0:18:4d	Netgear Inc.
+ 0:18:4e	Lianhe Technologies, Inc.
++0:18:4	E-TEK DIGITAL TECHNOLOGY LIMITED
+ 0:18:4f	8 Ways Technology Corp.
+-0:18:5	Beijing InHand Networking
++0:1:84	SIEB & MEYER AG
+ 0:18:50	Secfone Kft
+ 0:18:51	SWsoft
+ 0:18:52	StorLink Semiconductors, Inc.
+@@ -2381,19 +2505,20 @@
+ 0:18:57	Unilever R&D
+ 0:18:58	TagMaster AB
+ 0:18:59	Strawberry Linux Co.,Ltd.
++0:1:85	Aloka Co., Ltd.
+ 0:18:5a	uControl, Inc.
++0:18:5	Beijing InHand Networking Technology Co.,Ltd.
+ 0:18:5b	Network Chemistry, Inc
+ 0:18:5c	EDS Lab Pte Ltd
+ 0:18:5d	TAIGUEN TECHNOLOGY (SHEN-ZHEN) CO., LTD.
+ 0:18:5e	Nexterm Inc.
+ 0:18:5f	TAC Inc.
+-0:18:6	Hokkei Industries Co., Ltd.
+ 0:18:60	SIM Technology Group Shanghai Simcom Ltd.,
+ 0:18:61	Ooma, Inc.
+ 0:18:62	Seagate Technology
+ 0:18:63	Veritech Electronics Limited
+ 0:18:64	Cybectec Inc.
+-0:18:65	Bayer Diagnostics Sudbury Ltd
++0:18:65	Siemens Healthcare Diagnostics Manufacturing Ltd
+ 0:18:66	Leutron Vision
+ 0:18:67	Evolution Robotics Retail
+ 0:18:68	Scientific Atlanta, A Cisco Company
+@@ -2402,11 +2527,12 @@
+ 0:18:6b	Sambu Communics CO., LTD.
+ 0:18:6c	Neonode AB
+ 0:18:6d	Zhenjiang Sapphire Electronic Industry CO.
+-0:18:6e	3COM Europe Ltd
++0:18:6e	3Com Ltd
+ 0:18:6f	Setha Industria Eletronica LTDA
+-0:18:7	Fanstel Corp.
++0:18:6	Hokkei Industries Co., Ltd.
++0:1:86	Uwe Disch
+ 0:18:70	E28 Shanghai Limited
+-0:18:71	Global Data Services
++0:18:71	Hewlett Packard
+ 0:18:72	Expertise Engineering
+ 0:18:73	Cisco Systems
+ 0:18:74	Cisco Systems
+@@ -2420,9 +2546,10 @@
+ 0:18:7c	INTERCROSS, LLC
+ 0:18:7d	Armorlink shanghai Co. Ltd
+ 0:18:7e	RGB Spectrum
++0:18:7	Fanstel Corp.
+ 0:18:7f	ZODIANET
+-0:18:8	SightLogix, Inc.
+-0:18:80	Mobilygen
++0:1:87	i2SE GmbH
++0:18:80	Maxim Integrated Circuits
+ 0:18:81	Buyang Electronics Industrial Co., Ltd
+ 0:18:82	Huawei Technologies Co., Ltd.
+ 0:18:83	FORMOSA21 INC.
+@@ -2438,7 +2565,8 @@
+ 0:18:8d	Nokia Danmark A/S
+ 0:18:8e	Ekahau, Inc.
+ 0:18:8f	Montgomery Technology, Inc.
+-0:18:9	CRESYN
++0:1:88	LXCO Technologies ag
++0:18:8	SightLogix, Inc.
+ 0:18:90	RadioCOM, s.r.o.
+ 0:18:91	Zhongshan General K-mate Electronics Co., Ltd
+ 0:18:92	ads-tec GmbH
+@@ -2451,11 +2579,12 @@
+ 0:18:99	ShenZhen jieshun Science&Technology Industry CO,LTD.
+ 0:18:9a	HANA Micron Inc.
+ 0:18:9b	Thomson Inc.
++0:18:9	CRESYN
+ 0:18:9c	Weldex Corporation
+ 0:18:9d	Navcast Inc.
+ 0:18:9e	OMNIKEY GmbH.
+ 0:18:9f	Lenntek Corporation
+-0:18:a	Meraki Networks, Inc.
++0:1:89	Refraction Technology, Inc.
+ 0:18:a0	Cierma Ascenseurs
+ 0:18:a1	Tiqit Computers, Inc.
+ 0:18:a2	XIP Technology AB
+@@ -2466,13 +2595,15 @@
+ 0:18:a7	Yoggie Security Systems LTD.
+ 0:18:a8	AnNeal Technology Inc.
+ 0:18:a9	Ethernet Direct Corporation
+-0:18:aa	PRIVATE
++0:18:aa	Protec Fire Detection plc
+ 0:18:ab	BEIJING LHWT MICROELECTRONICS INC.
+ 0:18:ac	Shanghai Jiao Da HISYS Technology Co. Ltd.
+ 0:18:ad	NIDEC SANKYO CORPORATION
+-0:18:ae	Tongwei Video Technology CO.,LTD
++0:18:ae	TVT CO.,LTD
+ 0:18:af	Samsung Electronics Co., Ltd.
+-0:18:b	Brilliant Telecommunications
++0:18:a	Meraki, Inc.
++0:1:8a	ROI COMPUTER AG
++0:1:8	AVLAB Technology, Inc.
+ 0:18:b0	Nortel
+ 0:18:b1	Blade Network Technologies
+ 0:18:b2	ADEUNIS RF
+@@ -2485,13 +2616,14 @@
+ 0:18:b9	Cisco Systems
+ 0:18:ba	Cisco Systems
+ 0:18:bb	Eliwell Controls srl
++0:18:b	Brilliant Telecommunications
+ 0:18:bc	ZAO NVP Bolid
+ 0:18:bd	SHENZHEN DVBWORLD TECHNOLOGY CO., LTD.
+ 0:18:be	ANSA Corporation
+ 0:18:bf	Essence Technology Solution, Inc.
+-0:18:c	Optelian Access Networks Corporation
++0:1:8b	NetLinks Co., Ltd.
+ 0:18:c0	Motorola CHS
+-0:18:c1	Almitec Informática e Comércio Ltda.
++0:18:c1	Almitec Inform
+ 0:18:c2	Firetide, Inc
+ 0:18:c3	C&S Microwave
+ 0:18:c4	Raba Technologies LLC
+@@ -2506,8 +2638,9 @@
+ 0:18:cd	Erae Electronics Industry Co., Ltd
+ 0:18:ce	Dreamtech Co., Ltd
+ 0:18:cf	Baldor Electric Company
+-0:18:d	Terabytes Server Storage Tech Corp
+-0:18:d0	@ROAD Inc
++0:1:8c	Mega Vision
++0:18:c	Optelian Access Networks
++0:18:d0	AtRoad,  A Trimble Company
+ 0:18:d1	Siemens Home & Office Comm. Devices
+ 0:18:d2	High-Gain Antennas LLC
+ 0:18:d3	TEAMCAST
+@@ -2518,12 +2651,13 @@
+ 0:18:d8	ARCH METER Corporation
+ 0:18:d9	Santosha Internatonal, Inc
+ 0:18:da	AMBER wireless GmbH
++0:1:8d	AudeSi Technologies
+ 0:18:db	EPL Technology Ltd
+ 0:18:dc	Prostar Co., Ltd.
+ 0:18:dd	Silicondust Engineering Ltd
+ 0:18:de	Intel Corporation
+ 0:18:df	The Morey Corporation
+-0:18:e	Avega Systems
++0:18:d	Terabytes Server Storage Tech Corp
+ 0:18:e0	ANAVEO
+ 0:18:e1	Verkerk Service Systemen
+ 0:18:e2	Topdata Sistemas de Automacao Ltda
+@@ -2535,12 +2669,13 @@
+ 0:18:e8	Hacetron Corporation
+ 0:18:e9	Numata Corporation
+ 0:18:ea	Alltec GmbH
++0:18:e	Avega Systems
+ 0:18:eb	BroVis Wireless Networks
+ 0:18:ec	Welding Technology Corporation
+-0:18:ed	ACCUTECH INTERNATIONAL CO., LTD.
++0:18:ed	Accutech Ultrasystems Co., Ltd.
+ 0:18:ee	Videology Imaging Solutions, Inc.
+ 0:18:ef	Escape Communications, Inc.
+-0:18:f	Nokia Danmark A/S
++0:1:8e	Logitec Corporation
+ 0:18:f0	JOYTOTO Co., Ltd.
+ 0:18:f1	Chunichi Denshi Co.,LTD.
+ 0:18:f2	Beijing Tianyu Communication Equipment Co., Ltd
+@@ -2557,8 +2692,10 @@
+ 0:18:fd	Optimal Technologies International Inc.
+ 0:18:fe	Hewlett Packard
+ 0:18:ff	PowerQuattro Co.
++0:1:8f	Kenetec, Inc.
++0:18:f	Nokia Danmark A/S
+ 0:19:0	Intelliverese - DBA Voicecom
+-0:19:1	F1MEDIA
++0:1:90	SMK-M
+ 0:19:10	Knick Elektronische Messgeraete GmbH & Co. KG
+ 0:19:11	Just In Mobile Information Technologies (Shanghai) Co., Ltd.
+ 0:19:12	Welcat Inc
+@@ -2571,279 +2708,1904 @@
+ 0:19:19	ASTEL Inc.
+ 0:19:1a	IRLINK
+ 0:19:1b	Sputnik Engineering AG
+-0:19:2	Cambridge Consultants Ltd
+-0:19:3	Bigfoot Networks Inc
+-0:19:4	WB Electronics Sp. z o.o.
+-0:19:5	SCHRACK Seconet AG
+-0:19:6	Cisco Systems
+-0:19:7	Cisco Systems
+-0:19:8	Duaxes Corporation
+-0:19:9	Devi A/S
+-0:19:a	HASWARE INC.
+-0:19:b	Southern Vision Systems, Inc.
+-0:19:c	Encore Electronics, Inc.
+-0:19:d	IEEE 1394c
+-0:19:e	Atech Technology Co., Ltd.
+-0:19:f	Advansus Corp.
+-0:1:0	EQUIP'TRANS
+-0:1:1	PRIVATE
+-0:1:10	Gotham Networks
+-0:1:11	iDigm Inc.
+-0:1:12	Shark Multimedia Inc.
+-0:1:13	OLYMPUS CORPORATION
+-0:1:14	KANDA TSUSHIN KOGYO CO., LTD.
+-0:1:15	EXTRATECH CORPORATION
+-0:1:16	Netspect Technologies, Inc.
+-0:1:17	CANAL +
+-0:1:18	EZ Digital Co., Ltd.
+-0:1:19	RTUnet (Australia)
+-0:1:1a	EEH DataLink GmbH
+-0:1:1b	Unizone Technologies, Inc.
+-0:1:1c	Universal Talkware Corporation
+-0:1:1d	Centillium Communications
+-0:1:1e	Precidia Technologies, Inc.
+-0:1:1f	RC Networks, Inc.
+-0:1:2	3COM CORPORATION
+-0:1:20	OSCILLOQUARTZ S.A.
+-0:1:21	Watchguard Technologies, Inc.
+-0:1:22	Trend Communications, Ltd.
+-0:1:23	DIGITAL ELECTRONICS CORP.
+-0:1:24	Acer Incorporated
+-0:1:25	YAESU MUSEN CO., LTD.
+-0:1:26	PAC Labs
+-0:1:27	OPEN Networks Pty Ltd
+-0:1:28	EnjoyWeb, Inc.
+-0:1:29	DFI Inc.
+-0:1:2a	Telematica Sistems Inteligente
+-0:1:2b	TELENET Co., Ltd.
+-0:1:2c	Aravox Technologies, Inc.
+-0:1:2d	Komodo Technology
+-0:1:2e	PC Partner Ltd.
+-0:1:2f	Twinhead International Corp
+-0:1:3	3COM CORPORATION
+-0:1:30	Extreme Networks
+-0:1:31	Detection Systems, Inc.
+-0:1:32	Dranetz - BMI
+-0:1:33	KYOWA Electronic Instruments C
+-0:1:34	SIG Positec Systems AG
+-0:1:35	KDC Corp.
+-0:1:36	CyberTAN Technology, Inc.
+-0:1:37	IT Farm Corporation
+-0:1:38	XAVi Technologies Corp.
+-0:1:39	Point Multimedia Systems
+-0:1:3a	SHELCAD COMMUNICATIONS, LTD.
+-0:1:3b	BNA SYSTEMS
+-0:1:3c	TIW SYSTEMS
+-0:1:3d	RiscStation Ltd.
+-0:1:3e	Ascom Tateco AB
+-0:1:3f	Neighbor World Co., Ltd.
+-0:1:4	DVICO Co., Ltd.
+-0:1:40	Sendtek Corporation
+-0:1:41	CABLE PRINT
+-0:1:42	Cisco Systems, Inc.
+-0:1:43	Cisco Systems, Inc.
+-0:1:44	EMC Corporation
+-0:1:45	WINSYSTEMS, INC.
+-0:1:46	Tesco Controls, Inc.
+-0:1:47	Zhone Technologies
+-0:1:48	X-traWeb Inc.
+-0:1:49	T.D.T. Transfer Data Test GmbH
+-0:1:4a	Sony Corporation
+-0:1:4b	Ennovate Networks, Inc.
+-0:1:4c	Berkeley Process Control
+-0:1:4d	Shin Kin Enterprises Co., Ltd
+-0:1:4e	WIN Enterprises, Inc.
+-0:1:4f	ADTRAN INC
+-0:1:5	BECKHOFF GmbH
+-0:1:50	GILAT COMMUNICATIONS, LTD.
+-0:1:51	Ensemble Communications
+-0:1:52	CHROMATEK INC.
+-0:1:53	ARCHTEK TELECOM CORPORATION
+-0:1:54	G3M Corporation
+-0:1:55	Promise Technology, Inc.
+-0:1:56	FIREWIREDIRECT.COM, INC.
+-0:1:57	SYSWAVE CO., LTD
+-0:1:58	Electro Industries/Gauge Tech
+-0:1:59	S1 Corporation
+-0:1:5a	Digital Video Broadcasting
+-0:1:5b	ITALTEL S.p.A/RF-UP-I
+-0:1:5c	CADANT INC.
+-0:1:5d	Sun Microsystems, Inc
+-0:1:5e	BEST TECHNOLOGY CO., LTD.
+-0:1:5f	DIGITAL DESIGN GmbH
+-0:1:6	Tews Datentechnik GmbH
+-0:1:60	ELMEX Co., LTD.
+-0:1:61	Meta Machine Technology
+-0:1:62	Cygnet Technologies, Inc.
+-0:1:63	Cisco Systems, Inc.
+-0:1:64	Cisco Systems, Inc.
+-0:1:65	AirSwitch Corporation
+-0:1:66	TC GROUP A/S
+-0:1:67	HIOKI E.E. CORPORATION
+-0:1:68	VITANA CORPORATION
+-0:1:69	Celestix Networks Pte Ltd.
+-0:1:6a	ALITEC
+-0:1:6b	LightChip, Inc.
+-0:1:6c	FOXCONN
+-0:1:6d	CarrierComm Inc.
+-0:1:6e	Conklin Corporation
+-0:1:6f	HAITAI ELECTRONICS CO., LTD.
+-0:1:7	Leiser GmbH
+-0:1:70	ESE Embedded System Engineer'g
+-0:1:71	Allied Data Technologies
+-0:1:72	TechnoLand Co., LTD.
+-0:1:73	AMCC
+-0:1:74	CyberOptics Corporation
+-0:1:75	Radiant Communications Corp.
+-0:1:76	Orient Silver Enterprises
+-0:1:77	EDSL
+-0:1:78	MARGI Systems, Inc.
+-0:1:79	WIRELESS TECHNOLOGY, INC.
+-0:1:7a	Chengdu Maipu Electric Industrial Co., Ltd.
+-0:1:7b	Heidelberger Druckmaschinen AG
+-0:1:7c	AG-E GmbH
+-0:1:7d	ThermoQuest
+-0:1:7e	ADTEK System Science Co., Ltd.
+-0:1:7f	Experience Music Project
+-0:1:8	AVLAB Technology, Inc.
+-0:1:80	AOpen, Inc.
+-0:1:81	Nortel Networks
+-0:1:82	DICA TECHNOLOGIES AG
+-0:1:83	ANITE TELECOMS
+-0:1:84	SIEB & MEYER AG
+-0:1:85	Aloka Co., Ltd.
+-0:1:86	Uwe Disch
+-0:1:87	i2SE GmbH
+-0:1:88	LXCO Technologies ag
+-0:1:89	Refraction Technology, Inc.
+-0:1:8a	ROI COMPUTER AG
+-0:1:8b	NetLinks Co., Ltd.
+-0:1:8c	Mega Vision
+-0:1:8d	AudeSi Technologies
+-0:1:8e	Logitec Corporation
+-0:1:8f	Kenetec, Inc.
+-0:1:9	Nagano Japan Radio Co., Ltd.
+-0:1:90	SMK-M
++0:19:1c	Sensicast Systems
++0:19:1d	Nintendo Co.,Ltd.
++0:19:1e	Beyondwiz Co., Ltd.
++0:19:1	F1MEDIA
++0:19:1f	Microlink communications Inc.
+ 0:1:91	SYRED Data Systems
++0:19:20	KUME electric Co.,Ltd.
++0:19:21	Elitegroup Computer System Co.
++0:19:22	CM Comandos Lineares
++0:19:23	Phonex Korea Co., LTD.
++0:19:24	LBNL  Engineering
++0:19:25	Intelicis Corporation
++0:19:26	BitsGen Co., Ltd.
++0:19:27	ImCoSys Ltd
++0:19:28	Siemens AG, Transportation Systems
++0:19:29	2M2B Montadora de Maquinas Bahia Brasil LTDA
++0:19:2a	Antiope Associates
++0:19:2b	Aclara RF Systems Inc.
++0:19:2	Cambridge Consultants Ltd
++0:19:2c	Motorola Mobile Devices
++0:19:2d	Nokia Corporation
++0:19:2e	Spectral Instruments, Inc.
++0:19:2f	Cisco Systems
+ 0:1:92	Texas Digital Systems
++0:19:30	Cisco Systems
++0:19:31	Balluff GmbH
++0:19:32	Gude Analog- und Digialsysteme GmbH
++0:19:33	Strix Systems, Inc.
++0:19:34	TRENDON TOUCH TECHNOLOGY CORP.
++0:19:35	Duerr Dental GmbH & Co. KG
++0:19:36	STERLITE OPTICAL TECHNOLOGIES LIMITED
++0:19:37	CommerceGuard AB
++0:19:38	UMB Communications Co., Ltd.
++0:19:39	Gigamips
++0:19:3a	OESOLUTIONS
++0:19:3	Bigfoot Networks Inc
++0:19:3b	Wilibox Deliberant Group LLC
++0:19:3c	HighPoint Technologies Incorporated
++0:19:3d	GMC Guardian Mobility Corp.
++0:19:3e	PIRELLI BROADBAND SOLUTIONS
++0:19:3f	RDI technology(Shenzhen) Co.,LTD
+ 0:1:93	Hanbyul Telecom Co., Ltd.
++0:19:40	Rackable Systems
++0:19:41	Pitney Bowes, Inc
++0:19:42	ON SOFTWARE INTERNATIONAL LIMITED
++0:19:43	Belden
++0:19:44	Fossil Partners, L.P.
++0:19:45	Ten-Tec Inc.
++0:19:46	Cianet Industria e Comercio S/A
++0:19:47	Scientific Atlanta, A Cisco Company
++0:19:48	AireSpider Networks
++0:19:49	TENTEL  COMTECH CO., LTD.
++0:19:4a	TESTO AG
++0:19:4b	SAGEM COMMUNICATION
+ 0:1:94	Capital Equipment Corporation
++0:19:4c	Fujian Stelcom information & Technology CO.,Ltd
++0:19:4d	Avago Technologies Sdn Bhd
++0:19:4e	Ultra Electronics - TCS (Tactical Communication Systems)
++0:19:4f	Nokia Danmark A/S
++0:19:4	WB Electronics Sp. z o.o.
++0:19:50	Harman Multimedia
++0:19:51	NETCONS, s.r.o.
++0:19:52	ACOGITO Co., Ltd
++0:19:53	Chainleader Communications Corp.
++0:19:54	Leaf Corporation.
++0:19:55	Cisco Systems
++0:19:56	Cisco Systems
++0:19:57	Saafnet Canada Inc.
++0:19:58	Bluetooth SIG, Inc.
++0:19:59	Staccato Communications Inc.
++0:19:5a	Jenaer Antriebstechnik GmbH
++0:19:5b	D-Link Corporation
++0:19:5c	Innotech Corporation
++0:19:5d	ShenZhen XinHuaTong Opto Electronics Co.,Ltd
++0:19:5e	Motorola CHS
++0:19:5f	Valemount Networks Corporation
++0:19:5	SCHRACK Seconet AG
+ 0:1:95	Sena Technologies, Inc.
++0:19:60	DoCoMo Systems, Inc.
++0:19:61	Blaupunkt GmbH
++0:19:62	Commerciant, LP
++0:19:63	Sony Ericsson Mobile Communications AB
++0:19:64	Doorking Inc.
++0:19:65	YuHua TelTech (ShangHai) Co., Ltd.
++0:19:66	Asiarock Technology Limited
++0:19:67	TELDAT Sp.J.
++0:19:68	Digital Video Networks(Shanghai) CO. LTD.
++0:19:69	Nortel
++0:19:6a	MikroM GmbH
++0:19:6b	Danpex Corporation
++0:19:6c	ETROVISION TECHNOLOGY
++0:19:6	Cisco Systems
+ 0:1:96	Cisco Systems, Inc.
++0:19:6d	Raybit Systems Korea, Inc
++0:19:6e	Metacom (Pty) Ltd.
++0:19:6f	SensoPart GmbH
++0:19:70	Z-Com, Inc.
++0:19:71	Guangzhou Unicomp Technology Co.,Ltd
++0:19:72	Plexus (Xiamen) Co.,ltd
++0:19:73	Zeugma Systems
++0:19:74	AboCom Systems, Inc.
++0:19:75	Beijing Huisen networks technology Inc
++0:19:76	Xipher Technologies, LLC
++0:19:77	Aerohive Networks, Inc.
++0:19:78	Datum Systems, Inc.
++0:19:79	Nokia Danmark A/S
++0:19:7a	MAZeT GmbH
++0:19:7b	Picotest Corp.
++0:19:7	Cisco Systems
+ 0:1:97	Cisco Systems, Inc.
++0:19:7c	Riedel Communications GmbH
++0:19:7d	Hon Hai Precision Ind. Co., Ltd
++0:19:7e	Hon Hai Precision Ind. Co., Ltd
++0:19:7f	PLANTRONICS, INC.
++0:19:80	Gridpoint Systems
++0:19:81	Vivox Inc
++0:19:82	SmarDTV
++0:19:83	CCT R&D Limited
++0:19:84	ESTIC Corporation
++0:19:85	IT Watchdogs, Inc
++0:19:86	Cheng Hongjian
++0:19:87	Panasonic Mobile Communications Co., Ltd.
++0:19:88	Wi2Wi, Inc
++0:19:89	Sonitrol Corporation
++0:19:8a	Northrop Grumman Systems Corp.
++0:19:8b	Novera Optics Korea, Inc.
++0:19:8c	iXSea
+ 0:1:98	Darim Vision
++0:19:8d	Ocean Optics, Inc.
++0:19:8	Duaxes Corporation
++0:19:8e	Oticon A/S
++0:19:8f	Alcatel Bell N.V.
++0:19:90	ELM DATA Co., Ltd.
++0:19:91	avinfo
++0:19:92	Bluesocket, Inc
++0:19:93	Changshu Switchgear MFG. Co.,Ltd. (Former Changshu Switchgea
++0:19:94	Jorjin Technologies Inc.
++0:19:95	Jurong Hi-Tech (Suzhou)Co.ltd
++0:19:96	TurboChef Technologies Inc.
++0:19:97	Soft Device Sdn Bhd
++0:19:98	SATO CORPORATION
++0:19:99	Fujitsu Technology Solutions
++0:19:9a	EDO-EVI
++0:19:9b	Diversified Technical Systems, Inc.
++0:19:9c	CTRING
++0:19:9	Devi A/S
++0:19:9d	VIZIO, Inc.
++0:19:9e	SHOWADENSHI ELECTRONICS,INC.
++0:19:9f	DKT A/S
+ 0:1:99	HeiSei Electronics
++0:19:a0	NIHON DATA SYSTENS, INC.
++0:19:a1	LG INFORMATION & COMM.
++0:19:a2	ORDYN TECHNOLOGIES
++0:19:a3	asteel electronique atlantique
++0:19:a4	Austar Technology (hang zhou) Co.,Ltd
++0:19:a5	RadarFind Corporation
++0:19:a6	Motorola CHS
++0:19:a7	ITU-T
++0:19:a8	WiQuest Communications
++0:19:a9	Cisco Systems
++0:19:aa	Cisco Systems
++0:19:ab	Raycom CO ., LTD
++0:19:ac	GSP SYSTEMS Inc.
++0:19:ad	BOBST SA
++0:19:ae	Hopling Technologies b.v.
++0:19:af	Rigol Technologies, Inc.
++0:19:a	HASWARE INC.
+ 0:1:9a	LEUNIG GmbH
++0:19:b0	HanYang System
++0:19:b1	Arrow7 Corporation
++0:19:b2	XYnetsoft Co.,Ltd
++0:19:b3	Stanford Research Systems
++0:19:b4	VideoCast Ltd.
++0:19:b5	Famar Fueguina S.A.
++0:19:b6	Euro Emme s.r.l.
++0:19:b7	Nokia Danmark A/S
++0:19:b8	Boundary Devices
++0:19:b9	Dell Inc.
++0:19:ba	Paradox Security Systems Ltd
++0:19:bb	Hewlett Packard
++0:19:bc	ELECTRO CHANCE SRL
++0:19:bd	New Media Life
++0:19:be	Altai Technologies Limited
++0:19:bf	Citiway technology Co.,ltd
+ 0:1:9b	Kyoto Microcomputer Co., Ltd.
++0:19:b	Southern Vision Systems, Inc.
++0:19:c0	Motorola Mobile Devices
++0:19:c1	Alps Electric Co., Ltd
++0:19:c2	Equustek Solutions, Inc.
++0:19:c3	Qualitrol
++0:19:c4	Infocrypt Inc.
++0:19:c5	SONY Computer Entertainment inc,
++0:19:c6	ZTE Corporation
++0:19:c7	Cambridge Industries(Group) Co.,Ltd.
++0:19:c8	AnyDATA Corporation
++0:19:c9	S&C ELECTRIC COMPANY
++0:19:ca	Broadata Communications, Inc
++0:19:cb	ZyXEL Communications Corporation
++0:19:cc	RCG (HK) Ltd
++0:19:cd	Chengdu ethercom information technology Ltd.
++0:19:c	Encore Electronics, Inc.
++0:19:ce	Progressive Gaming International
++0:19:cf	SALICRU, S.A.
+ 0:1:9c	JDS Uniphase Inc.
++0:19:d0	Cathexis
++0:19:d1	Intel Corporation
++0:19:d2	Intel Corporation
++0:19:d3	TRAK Microwave
++0:19:d4	ICX Technologies
++0:19:d5	IP Innovations, Inc.
++0:19:d6	LS Cable Ltd.
++0:19:d7	FORTUNETEK CO., LTD
++0:19:d8	MAXFOR
++0:19:d9	Zeutschel GmbH
++0:19:da	Welltrans O&E Technology Co. , Ltd.
++0:19:db	MICRO-STAR INTERNATIONAL CO., LTD.
++0:19:dc	ENENSYS Technologies
++0:19:dd	FEI-Zyfer, Inc.
+ 0:1:9d	E-Control Systems, Inc.
++0:19:de	MOBITEK
++0:19:df	Thomson Inc.
++0:19:d	IEEE 1394c
++0:19:e0	TP-LINK Technologies Co., Ltd.
++0:19:e1	Nortel
++0:19:e2	Juniper Networks
++0:19:e3	Apple Computer Inc.
++0:19:e4	2Wire, Inc
++0:19:e5	Lynx Studio Technology, Inc.
++0:19:e6	TOYO MEDIC CO.,LTD.
++0:19:e7	Cisco Systems
++0:19:e8	Cisco Systems
++0:19:e9	S-Information Technolgy, Co., Ltd.
++0:19:e	Atech Technology Co., Ltd.
++0:19:ea	TeraMage Technologies Co., Ltd.
++0:19:eb	Pyronix Ltd
++0:19:ec	Sagamore Systems, Inc.
++0:19:ed	Axesstel Inc.
++0:19:ee	CARLO GAVAZZI CONTROLS SPA-Controls Division
+ 0:1:9e	ESS Technology, Inc.
++0:19:ef	SHENZHEN LINNKING ELECTRONICS CO.,LTD
++0:19:f0	UNIONMAN TECHNOLOGY CO.,LTD
++0:19:f1	Star Communication Network Technology Co.,Ltd
++0:19:f2	Teradyne K.K.
++0:19:f3	Telematrix, Inc
++0:19:f4	Convergens Oy Ltd
++0:19:f5	Imagination Technologies Ltd
++0:19:f6	Acconet (PTE) Ltd
++0:19:f7	Onset Computer Corporation
++0:19:f8	Embedded Systems Design, Inc.
++0:19:f9	TDK-Lambda
++0:19:fa	Cable Vision Electronics CO., LTD.
++0:19:f	Advansus Corp.
++0:19:fb	AMSTRAD PLC
++0:19:fc	PT. Ufoakses Sukses Luarbiasa
++0:19:fd	Nintendo Co., Ltd.
++0:19:fe	SHENZHEN SEECOMM TECHNOLOGY CO.,LTD.
++0:19:ff	Finnzymes
+ 0:1:9f	Phonex Broadband
+-0:1:a	CIS TECHNOLOGY INC.
++0:1:9	Nagano Japan Radio Co., Ltd.
+ 0:1:a0	Infinilink Corporation
++0:1a:0	MATRIX INC.
++0:1a:10	LUCENT TRANS ELECTRONICS CO.,LTD
++0:1a:11	Google Inc.
++0:1a:12	Essilor
++0:1a:13	Wanlida Group Co., LTD
++0:1a:14	Xin Hua Control Engineering Co.,Ltd.
++0:1a:15	gemalto e-Payment
++0:1a:16	Nokia Danmark A/S
++0:1a:17	Teak Technologies, Inc.
++0:1a:18	Advanced Simulation Technology inc.
++0:1a:19	Computer Engineering Limited
++0:1a:1a	Gentex Corporation/Electro-Acoustic Products
++0:1a:1b	Motorola Mobile Devices
++0:1a:1c	GT&T Engineering Pte Ltd
++0:1a:1d	PChome Online Inc.
++0:1a:1e	Aruba Networks
++0:1a:1f	Coastal Environmental Systems
+ 0:1:a1	Mag-Tek, Inc.
++0:1a:1	Smiths Medical
++0:1a:20	CMOTECH Co. Ltd.
++0:1a:21	Indac B.V.
++0:1a:22	eq-3 GmbH
++0:1a:23	Ice Qube, Inc
++0:1a:24	Galaxy Telecom Technologies Ltd
++0:1a:25	DELTA DORE
++0:1a:26	Deltanode Solutions AB
++0:1a:27	Ubistar
++0:1a:28	ASWT Co., LTD. Taiwan Branch H.K.
++0:1a:29	Techsonic Industries d/b/a Humminbird
++0:1a:2a	Arcadyan Technology Corporation
++0:1a:2b	Ayecom Technology Co., Ltd.
++0:1a:2c	SATEC Co.,LTD
++0:1a:2d	The Navvo Group
++0:1a:2e	Ziova Coporation
++0:1a:2f	Cisco Systems
+ 0:1:a2	Logical Co., Ltd.
++0:1a:2	SECURE CARE PRODUCTS, INC
++0:1a:30	Cisco Systems
++0:1a:31	SCAN COIN Industries AB
++0:1a:32	ACTIVA MULTIMEDIA
++0:1a:33	ASI Communications, Inc.
++0:1a:34	Konka Group Co., Ltd.
++0:1a:35	BARTEC GmbH
++0:1a:36	Aipermon GmbH & Co. KG
++0:1a:37	Lear Corporation
++0:1a:38	Sanmina-SCI
++0:1a:39	Merten GmbH&CoKG
++0:1a:3a	Dongahelecomm
++0:1a:3	Angel Electronics Co., Ltd.
++0:1a:3b	Doah Elecom Inc.
++0:1a:3c	Technowave Ltd.
++0:1a:3d	Ajin Vision Co.,Ltd
++0:1a:3e	Faster Technology LLC
++0:1a:3f	intelbras
+ 0:1:a3	GENESYS LOGIC, INC.
++0:1a:40	A-FOUR TECH CO., LTD.
++0:1a:41	INOCOVA Co.,Ltd
++0:1a:42	Techcity Technology co., Ltd.
++0:1a:43	Logical Link Communications
++0:1a:44	JWTrading Co., Ltd
++0:1a:45	GN Netcom as
++0:1a:46	Digital Multimedia Technology Co., Ltd
++0:1a:47	Agami Systems, Inc.
++0:1a:48	Takacom Corporation
++0:1a:49	Micro Vision Co.,LTD
++0:1a:4a	Qumranet Inc.
++0:1a:4b	Hewlett Packard
++0:1a:4c	Crossbow Technology, Inc
++0:1a:4d	GIGA-BYTE TECHNOLOGY CO.,LTD.
++0:1a:4e	NTI AG / LinMot
++0:1a:4f	AVM GmbH
++0:1a:4	Interay Solutions BV
+ 0:1:a4	Microlink Corporation
++0:1a:50	PheeNet Technology Corp.
++0:1a:51	Alfred Mann Foundation
++0:1a:52	Meshlinx Wireless Inc.
++0:1a:53	Zylaya
++0:1a:54	Hip Shing Electronics Ltd.
++0:1a:55	ACA-Digital Corporation
++0:1a:56	ViewTel Co,. Ltd.
++0:1a:57	Matrix Design Group, LLC
++0:1a:58	CCV Deutschland GmbH - Celectronic eHealth Div.
++0:1a:59	Ircona
++0:1a:5a	Korea Electric Power Data Network  (KDN) Co., Ltd
++0:1a:5b	NetCare Service Co., Ltd.
++0:1a:5c	Euchner GmbH+Co. KG
++0:1a:5d	Mobinnova Corp.
++0:1a:5e	Thincom Technology Co.,Ltd
++0:1a:5f	KitWorks.fi Ltd.
+ 0:1:a5	Nextcomm, Inc.
++0:1a:5	OPTIBASE LTD
++0:1a:60	Wave Electronics Co.,Ltd.
++0:1a:61	PacStar Corp.
++0:1a:62	Data Robotics, Incorporated
++0:1a:63	Elster Solutions, LLC,
++0:1a:64	IBM Corp.
++0:1a:65	Seluxit
++0:1a:66	Motorola CHS
++0:1a:67	Infinite QL Sdn Bhd
++0:1a:68	Weltec Enterprise Co., Ltd.
++0:1a:69	Wuhan Yangtze Optical Technology CO.,Ltd.
++0:1a:6a	Tranzas, Inc.
++0:1a:6b	USI
++0:1a:6c	Cisco Systems
++0:1a:6d	Cisco Systems
++0:1a:6e	Impro Technologies
++0:1a:6f	MI.TEL s.r.l.
++0:1a:6	OpVista, Inc.
+ 0:1:a6	Scientific-Atlanta Arcodan A/S
++0:1a:70	Cisco-Linksys, LLC
++0:1a:71	Diostech Co., Ltd.
++0:1a:72	Mosart Semiconductor Corp.
++0:1a:73	Gemtek Technology Co., Ltd.
++0:1a:74	Procare International Co
++0:1a:75	Sony Ericsson Mobile Communications
++0:1a:76	SDT information Technology Co.,LTD.
++0:1a:77	Motorola Mobile Devices
++0:1a:78	ubtos
++0:1a:79	TELECOMUNICATION TECHNOLOGIES LTD.
++0:1a:7a	Lismore Instruments Limited
++0:1a:7	Arecont Vision
++0:1a:7b	Teleco, Inc.
++0:1a:7c	Hirschmann Automation and Control B.V.
++0:1a:7d	cyber-blue(HK)Ltd
++0:1a:7e	LN Srithai Comm Ltd.
++0:1a:7f	GCI Science&Technology Co.,Ltd.
+ 0:1:a7	UNEX TECHNOLOGY CORPORATION
++0:1a:80	Sony Corporation
++0:1a:81	Zelax
++0:1a:82	PROBA Building Automation Co.,LTD
++0:1a:83	Pegasus Technologies Inc.
++0:1a:84	V One Multimedia Pte Ltd
++0:1a:85	NV Michel Van de Wiele
++0:1a:86	AdvancedIO Systems Inc
++0:1a:87	Canhold International Limited
++0:1a:88	Venergy,Co,Ltd
++0:1a:89	Nokia Danmark A/S
++0:1a:8a	Samsung Electronics Co., Ltd.
++0:1a:8b	CHUNIL ELECTRIC IND., CO.
++0:1a:8c	Astaro AG
++0:1a:8	Dalman Technical Services
++0:1a:8d	AVECS Bergen GmbH
++0:1a:8e	3Way Networks Ltd
++0:1a:8f	Nortel
+ 0:1:a8	Welltech Computer Co., Ltd.
++0:1a:90	Tr
++0:1a:91	FusionDynamic Ltd.
++0:1a:92	ASUSTek COMPUTER INC.
++0:1a:93	ERCO Leuchten GmbH
++0:1a:94	Votronic GmbH
++0:1a:95	Hisense Mobile Communications Technoligy Co.,Ltd.
++0:1a:96	ECLER S.A.
++0:1a:97	fitivision technology Inc.
++0:1a:98	Asotel Communication Limited Taiwan Branch
++0:1a:99	Smarty (HZ) Information Electronics Co., Ltd
++0:1a:9a	Skyworth Digital technology(shenzhen)co.ltd.
++0:1a:9b	ADEC & Parter AG
+ 0:1:a9	BMW AG
++0:1a:9c	RightHand Technologies, Inc.
++0:1a:9d	Skipper Wireless, Inc.
++0:1a:9e	ICON Digital International Limited
++0:1a:9f	A-Link Europe Ltd
++0:1a:9	Wayfarer Transit Systems Ltd
++0:1a:a0	Dell Inc
++0:1a:a1	Cisco Systems
++0:1a:a2	Cisco Systems
++0:1a:a3	DELORME
++0:1a:a4	Future University-Hakodate
++0:1a:a5	BRN Phoenix
++0:1a:a6	Telefunken Radio Communication Systems GmbH &CO.KG
++0:1a:a7	Torian Wireless
++0:1a:a8	Mamiya Digital Imaging Co., Ltd.
++0:1a:a9	FUJIAN STAR-NET COMMUNICATION CO.,LTD
++0:1a:aa	Analogic Corp.
++0:1a:a	Adaptive Micro-Ware Inc.
+ 0:1:aa	Airspan Communications, Ltd.
++0:1a:ab	eWings s.r.l.
++0:1a:ac	Corelatus AB
++0:1a:ad	Motorola CHS
++0:1a:ae	Savant Systems LLC
++0:1a:af	BLUSENS TECHNOLOGY
++0:1a:b0	Signal Networks Pvt. Ltd.,
++0:1a:b1	Asia Pacific Satellite Industries Co., Ltd.
++0:1a:b2	Cyber Solutions Inc.
++0:1a:b3	VISIONITE INC.
++0:1a:b4	FFEI Ltd.
++0:1a:b5	Home Network System
++0:1a:b6	Texas Instruments
++0:1a:b7	Ethos Networks LTD.
++0:1a:b8	Anseri Corporation
++0:1a:b9	PMC
++0:1a:ba	Caton Overseas Limited
++0:1a:bb	Fontal Technology Incorporation
++0:1a:b	BONA TECHNOLOGY INC.
++0:1a:bc	U4EA Technologies Ltd
++0:1a:bd	Impatica Inc.
++0:1a:be	COMPUTER HI-TECH INC.
++0:1a:bf	TRUMPF Laser Marking Systems AG
+ 0:1:ab	Main Street Networks
++0:1a:c0	JOYBIEN TECHNOLOGIES CO., LTD.
++0:1a:c1	3Com Ltd
++0:1a:c2	YEC Co.,Ltd.
++0:1a:c3	Scientific-Atlanta, Inc
++0:1a:c4	2Wire, Inc
++0:1a:c5	BreakingPoint Systems, Inc.
++0:1a:c6	Micro Control Designs
++0:1a:c7	UNIPOINT
++0:1a:c8	ISL (Instrumentation Scientifique de Laboratoire)
++0:1a:c9	SUZUKEN CO.,LTD
++0:1a:ca	Tilera Corporation
++0:1a:cb	Autocom Products Ltd
++0:1a:cc	Celestial Semiconductor, Ltd
++0:1a:cd	Tidel Engineering LP
++0:1a:ce	YUPITERU CORPORATION
++0:1a:cf	C.T. ELETTRONICA
++0:1:a	CIS TECHNOLOGY INC.
+ 0:1:ac	Sitara Networks, Inc.
++0:1a:c	Swe-Dish Satellite Systems AB
++0:1a:d0	Albis Technologies AG
++0:1a:d1	FARGO CO., LTD.
++0:1a:d2	Eletronica Nitron Ltda
++0:1a:d3	Vamp Ltd.
++0:1a:d4	iPOX Technology Co., Ltd.
++0:1a:d5	KMC CHAIN INDUSTRIAL CO., LTD.
++0:1a:d6	JIAGNSU AETNA ELECTRIC CO.,LTD
++0:1a:d7	Christie Digital Systems, Inc.
++0:1a:d8	AlsterAero GmbH
++0:1a:d9	International Broadband Electric Communications, Inc.
++0:1a:da	Biz-2-Me Inc.
++0:1a:db	Motorola Mobile Devices
++0:1a:dc	Nokia Danmark A/S
+ 0:1:ad	Coach Master International  d.b.a. CMI Worldwide, Inc.
++0:1a:dd	PePWave Ltd
++0:1a:de	Motorola CHS
++0:1a:df	Interactivetv Pty Limited
++0:1a:d	HandHeld entertainment, Inc.
++0:1a:e0	Mythology Tech Express Inc.
++0:1a:e1	EDGE ACCESS INC
++0:1a:e2	Cisco Systems
++0:1a:e3	Cisco Systems
++0:1a:e4	Medicis Technologies Corporation
++0:1a:e5	Mvox Technologies Inc.
++0:1a:e6	Atlanta Advanced Communications Holdings Limited
++0:1a:e7	Aztek Networks, Inc.
++0:1a:e8	Siemens Enterprise Communications GmbH & Co. KG
++0:1a:e9	Nintendo Co., Ltd.
++0:1a:ea	Radio Terminal Systems Pty Ltd
++0:1a:eb	Allied Telesis K.K.
++0:1a:e	Cheng Uei Precision Industry Co.,Ltd
++0:1a:ec	Keumbee Electronics Co.,Ltd.
++0:1a:ed	INCOTEC GmbH
++0:1a:ee	Shenztech Ltd
++0:1a:ef	Loopcomm Technology, Inc.
+ 0:1:ae	Trex Enterprises
+-0:1:af	Motorola Computer Group
+-0:1:b	Space CyberLink, Inc.
++0:1a:f0	Alcatel - IPD
++0:1a:f1	Embedded Artists AB
++0:1a:f2	Dynavisions Schweiz AG
++0:1a:f3	Samyoung Electronics
++0:1a:f4	Handreamnet
++0:1a:f5	PENTAONE. CO., LTD.
++0:1a:f6	Woven Systems, Inc.
++0:1a:f7	dataschalt e+a GmbH
++0:1a:f8	Copley Controls Corporation
++0:1a:f9	AeroVIronment (AV Inc)
++0:1a:fa	Welch Allyn, Inc.
++0:1a:fb	Joby Inc.
++0:1a:fc	ModusLink Corporation
++0:1a:fd	EVOLIS
++0:1:af	Emerson Network Power
++0:1a:fe	SOFACREAL
++0:1a:ff	Wizyoung Tech.
++0:1a:f	Sistemas Avanzados de Control, S.A.
+ 0:1:b0	Fulltek Technology Co., Ltd.
++0:1b:0	Neopost Technologies
++0:1b:10	ShenZhen Kang Hui Technology Co.,ltd
++0:1b:11	D-Link Corporation
++0:1b:12	Apprion
++0:1b:13	Icron Technologies Corporation
++0:1b:14	Carex Lighting Equipment Factory
++0:1b:15	Voxtel, Inc.
++0:1b:16	Celtro Ltd.
++0:1b:17	Palo Alto Networks
++0:1b:18	Tsuken Electric Ind. Co.,Ltd
++0:1b:19	IEEE 1588 Standard
++0:1b:1a	e-trees Japan, Inc.
++0:1b:1	Applied Radio Technologies
++0:1b:1b	Siemens AG,
++0:1b:1c	Coherent
++0:1b:1d	Phoenix International Co., Ltd
++0:1b:1e	HART Communication Foundation
++0:1b:1f	DELTA - Danish Electronics, Light & Acoustics
+ 0:1:b1	General Bandwidth
++0:1b:20	TPine Technology
++0:1b:21	Intel Corporate
++0:1b:22	Palit Microsystems ( H.K.) Ltd.
++0:1b:23	SimpleComTools
++0:1b:24	Quanta Computer Inc.
++0:1b:25	Nortel
++0:1b:26	RON-Telecom ZAO
++0:1b:27	Merlin CSI
++0:1b:28	POLYGON, JSC
++0:1b:29	Avantis.Co.,Ltd
++0:1b:2a	Cisco Systems
++0:1b:2b	Cisco Systems
++0:1b:2c	ATRON electronic GmbH
+ 0:1:b2	Digital Processing Systems, Inc.
++0:1b:2d	Med-Eng Systems Inc.
++0:1b:2	ED Co.Ltd
++0:1b:2e	Sinkyo Electron Inc
++0:1b:2f	NETGEAR Inc.
++0:1b:30	Solitech Inc.
++0:1b:31	Neural Image. Co. Ltd.
++0:1b:32	QLogic Corporation
++0:1b:33	Nokia Danmark A/S
++0:1b:34	Focus System Inc.
++0:1b:35	ChongQing JINOU Science & Technology Development CO.,Ltd
++0:1b:36	Tsubata Engineering Co.,Ltd. (Head Office)
++0:1b:37	Computec Oy
++0:1b:38	COMPAL INFORMATION (KUNSHAN) CO., LTD.
++0:1b:39	Proxicast
++0:1b:3	Action Technology (SZ) Co., Ltd
++0:1b:3a	SIMS Corp.
++0:1b:3b	Yi-Qing CO., LTD
++0:1b:3c	Software Technologies Group,Inc.
++0:1b:3d	EuroTel Spa
++0:1b:3e	Curtis, Inc.
++0:1b:3f	ProCurve Networking by HP
+ 0:1:b3	Precision Electronic Manufacturing
++0:1b:40	Network Automation mxc AB
++0:1b:41	General Infinity Co.,Ltd.
++0:1b:42	Wise & Blue
++0:1b:43	Beijing DG Telecommunications equipment Co.,Ltd
++0:1b:44	SanDisk Corporation
++0:1b:45	ABB AS, Division Automation Products
++0:1b:46	Blueone Technology Co.,Ltd
++0:1b:47	Futarque A/S
++0:1b:48	Shenzhen Lantech Electronics Co., Ltd.
++0:1b:49	Roberts Radio limited
++0:1b:4	Affinity International S.p.a
++0:1b:4a	W&W Communications, Inc.
++0:1b:4b	SANION Co., Ltd.
++0:1b:4c	Signtech
++0:1b:4d	Areca Technology Corporation
++0:1b:4e	Navman New Zealand
++0:1b:4f	Avaya Inc.
+ 0:1:b4	Wayport, Inc.
++0:1b:50	Nizhny Novgorod Factory named after M.Frunze, FSUE (NZiF)
++0:1b:51	Vector Technology Corp.
++0:1b:52	Motorola Mobile Devices
++0:1b:53	Cisco Systems
++0:1b:54	Cisco Systems
++0:1b:55	Hurco Automation Ltd.
++0:1b:56	Tehuti Networks Ltd.
++0:1b:57	SEMINDIA SYSTEMS PRIVATE LIMITED
++0:1b:58	ACE CAD Enterprise Co., Ltd.
++0:1b:59	Sony Ericsson Mobile Communications AB
++0:1b:5a	Apollo Imaging Technologies, Inc.
++0:1b:5b	2Wire, Inc.
++0:1b:5c	Azuretec Co., Ltd.
++0:1b:5d	Vololink Pty Ltd
++0:1b:5e	BPL Limited
++0:1b:5f	Alien Technology
+ 0:1:b5	Turin Networks, Inc.
++0:1b:5	YMC AG
++0:1b:60	NAVIGON AG
++0:1b:61	Digital Acoustics, LLC
++0:1b:62	JHT Optoelectronics Co.,Ltd.
++0:1b:63	Apple Computer Inc.
++0:1b:64	IsaacLandKorea Co., Ltd,
++0:1b:65	China Gridcom Co., Ltd
++0:1b:66	Sennheiser electronic GmbH & Co. KG
++0:1b:67	Ubiquisys Ltd
++0:1b:68	Modnnet Co., Ltd
++0:1b:69	Equaline Corporation
++0:1b:6a	Powerwave Technologies Sweden AB
++0:1b:6	Ateliers R. LAUMONIER
++0:1b:6b	Swyx Solutions AG
++0:1b:6c	LookX Digital Media BV
++0:1b:6d	Midtronics, Inc.
++0:1b:6e	Anue Systems, Inc.
++0:1b:6f	Teletrak Ltd
+ 0:1:b6	SAEJIN T&M Co., Ltd.
++0:1b:70	IRI Ubiteq, INC.
++0:1b:71	Telular Corp.
++0:1b:72	Sicep s.p.a.
++0:1b:73	DTL Broadcast Ltd
++0:1b:74	MiraLink Corporation
++0:1b:75	Hypermedia Systems
++0:1b:76	Ripcode, Inc.
++0:1b:77	Intel Corporate
++0:1b:78	Hewlett Packard
++0:1b:79	FAIVELEY TRANSPORT
++0:1b:7a	Nintendo Co., Ltd.
++0:1b:7b	The Tintometer Ltd
++0:1b:7c	A & R Cambridge
+ 0:1:b7	Centos, Inc.
++0:1b:7d	CXR Anderson Jacobson
++0:1b:7e	Beckmann GmbH
++0:1b:7f	TMN Technologies Telecomunicacoes Ltda
++0:1b:7	Mendocino Software
++0:1b:80	LORD Corporation
++0:1b:81	DATAQ Instruments, Inc.
++0:1b:82	Taiwan Semiconductor Co., Ltd.
++0:1b:83	Finsoft Ltd
++0:1b:84	Scan Engineering Telecom
++0:1b:85	MAN Diesel SE
++0:1b:86	Bosch Access Systems GmbH
++0:1b:87	Deepsound Tech. Co., Ltd
++0:1b:88	Divinet Access Technologies Ltd
++0:1b:89	EMZA Visual Sense Ltd.
++0:1b:8a	2M Electronic A/S
++0:1b:8b	NEC AccessTechnica,Ltd.
++0:1b:8c	JMicron Technology Corp.
++0:1b:8	Danfoss Drives A/S
++0:1b:8d	Electronic Computer Systems, Inc.
++0:1b:8e	Hulu Sweden AB
++0:1b:8f	Cisco Systems
+ 0:1:b8	Netsensity, Inc.
++0:1b:90	Cisco Systems
++0:1b:91	EFKON AG
++0:1b:92	l-acoustics
++0:1b:93	JC Decaux SA DNT
++0:1b:94	T.E.M.A. S.p.A.
++0:1b:95	VIDEO SYSTEMS SRL
++0:1b:96	General Sensing
++0:1b:97	Violin Technologies
++0:1b:98	Samsung Electronics Co., Ltd.
++0:1b:99	KS System GmbH
++0:1b:9a	Apollo Fire Detectors Ltd
++0:1b:9b	Hose-McCann Communications
++0:1b:9c	SATEL sp. z o.o.
++0:1b:9d	Novus Security Sp. z o.o.
++0:1b:9e	ASKEY  COMPUTER  CORP
++0:1b:9f	Calyptech Pty Ltd
++0:1b:9	Matrix Telecom Pvt. Ltd.
+ 0:1:b9	SKF Condition Monitoring
++0:1b:a0	Awox
++0:1b:a1		
++0:1b:a2	IDS Imaging Development Systems GmbH
++0:1b:a3	Flexit Group GmbH
++0:1b:a4	S.A.E Afikim
++0:1b:a5	MyungMin Systems, Inc.
++0:1b:a6	intotech inc.
++0:1b:a7	Lorica Solutions
++0:1b:a8	UBI&MOBI,.Inc
++0:1b:a9	BROTHER INDUSTRIES, LTD.
++0:1b:aa	XenICs nv
++0:1b:ab	Telchemy, Incorporated
++0:1b:ac	Curtiss Wright Controls Embedded Computing
++0:1b:ad	iControl Incorporated
++0:1b:ae	Micro Control Systems, Inc
++0:1b:af	Nokia Danmark A/S
+ 0:1:ba	IC-Net, Inc.
++0:1b:a	Intelligent Distributed Controls Ltd
++0:1b:b0	BHARAT ELECTRONICS
++0:1b:b1	Wistron Neweb Corp.
++0:1b:b2	Intellect International NV
++0:1b:b3	Condalo GmbH
++0:1b:b4	Airvod Limited
++0:1b:b5	ZF Electronics GmbH
++0:1b:b6	Bird Electronic Corp.
++0:1b:b7	Alta Heights Technology Corp.
++0:1b:b8	BLUEWAY ELECTRONIC CO;LTD
++0:1b:b9	Elitegroup Computer System Co.
++0:1b:ba	Nortel
++0:1b:bb	RFTech Co.,Ltd
++0:1b:bc	Silver Peak Systems, Inc.
++0:1b:bd	FMC Kongsberg Subsea AS
++0:1b:be	ICOP Digital
+ 0:1:bb	Frequentis
++0:1b:bf	SAGEM COMMUNICATION
++0:1b:b	Phidgets Inc.
++0:1b:c0	Juniper Networks
++0:1b:c1	HOLUX Technology, Inc.
++0:1b:c2	Integrated Control Technology Limitied
++0:1b:c3	Mobisolution Co.,Ltd
++0:1b:c4	Ultratec, Inc.
++0:1b:c5	IEEE Registration Authority
++0:1b:c6	Strato Rechenzentrum AG
++0:1b:c7	StarVedia Technology Inc.
++0:1b:c8	MIURA CO.,LTD
++0:1b:c9	FSN DISPLAY INC
++0:1b:ca	Beijing Run Technology LTD. Company
++0:1b:cb	PEMPEK SYSTEMS PTY LTD
+ 0:1:bc	Brains Corporation
++0:1b:c	Cisco Systems
++0:1b:cc	KINGTEK CCTV ALLIANCE CO., LTD.
++0:1b:cd	DAVISCOMMS (S) PTE LTD
++0:1b:ce	Measurement Devices Ltd
++0:1b:cf	Dataupia Corporation
++0:1b:d0	IDENTEC SOLUTIONS
++0:1b:d1	SOGESTMATIC
++0:1b:d2	ULTRA-X ASIA PACIFIC Inc.
++0:1b:d3	Matsushita Electric Panasonic AVC
++0:1b:d4	Cisco Systems
++0:1b:d5	Cisco Systems
++0:1b:d6	Kelvin Hughes Ltd
++0:1b:d7	Scientific Atlanta, A Cisco Company
++0:1b:d8	DVTel LTD
++0:1b:d9	Edgewater Computer Systems
++0:1b:da	UTStarcom Inc
++0:1b:db	Valeo VECS
++0:1b:d	Cisco Systems
++0:1b:dc	Vencer Co., Ltd.
++0:1b:dd	Motorola CHS
++0:1b:de	Renkus-Heinz, Inc.
++0:1b:df	Iskra MIS
+ 0:1:bd	Peterson Electro-Musical Products, Inc.
++0:1b:e0	TELENOT ELECTRONIC GmbH
++0:1b:e1	ViaLogy
++0:1b:e2	AhnLab,Inc.
++0:1b:e3	Health Hero Network, Inc.
++0:1b:e4	TOWNET SRL
++0:1b:e5	802automation Limited
++0:1b:e6	VR AG
++0:1b:e7	Postek Electronics Co., Ltd.
++0:1b:e8	Ultratronik GmbH
++0:1b:e9	Broadcom Corporation
++0:1b:ea	Nintendo Co., Ltd.
++0:1b:eb	DMP Electronics INC.
++0:1b:ec	Netio Technologies Co., Ltd
++0:1b:ed	Brocade Communications Systems, Inc
++0:1b:ee	Nokia Danmark A/S
++0:1b:ef	Blossoms Digital Technology Co.,Ltd.
+ 0:1:be	Gigalink Co., Ltd.
++0:1b:e	InoTec GmbH Organisationssysteme
++0:1b:f0	Value Platforms Limited
++0:1b:f1	Nanjing SilverNet Software Co., Ltd.
++0:1b:f2	KWORLD COMPUTER CO., LTD
++0:1b:f3	TRANSRADIO SenderSysteme Berlin AG
++0:1b:f4	KENWIN INDUSTRIAL(HK) LTD.
++0:1b:f5	Tellink Sistemas de Telecomunicaci
++0:1b:f6	CONWISE Technology Corporation Ltd.
++0:1b:f7	Lund IP Products AB
++0:1b:f8	Digitrax Inc.
++0:1b:f9	Intellitect Water Ltd
++0:1b:fa	G.i.N. mbH
++0:1b:fb	Alps Electric Co., Ltd
++0:1b:fc	ASUSTek COMPUTER INC.
++0:1b:fd	Dignsys Inc.
++0:1b:fe	Zavio Inc.
++0:1b:ff	Millennia Media inc.
++0:1b:f	Petratec
+ 0:1:bf	Teleforce Co., Ltd.
+-0:1:c	System Talks Inc.
++0:1:b	Space CyberLink, Inc.
+ 0:1:c0	CompuLab, Ltd.
++0:1c:0	Entry Point, LLC
++0:1c:10	Cisco-Linksys, LLC
++0:1c:11	Motorola CHS
++0:1c:12	Motorola Mobile Devices
++0:1c:13	OPTSYS TECHNOLOGY CO., LTD.
++0:1c:14	VMware, Inc
++0:1c:15	TXP Corporation
++0:1c:16	ThyssenKrupp Elevator
++0:1c:17	Nortel
++0:1c:18	Sicert S.r.L.
++0:1c:19	secunet Security Networks AG
++0:1c:1	ABB Oy Drives
++0:1c:1a	Thomas Instrumentation, Inc
++0:1c:1b	Hyperstone GmbH
++0:1c:1c	Center Communication Systems GmbH
++0:1c:1d	CHENZHOU GOSPELL DIGITAL TECHNOLOGY CO.,LTD
++0:1c:1e	emtrion GmbH
++0:1c:1f	Quest Retail Technology Pty Ltd
+ 0:1:c1	Vitesse Semiconductor Corporation
++0:1c:20	CLB Benelux
++0:1c:21	Nucsafe Inc.
++0:1c:22	Aeris Elettronica s.r.l.
++0:1c:23	Dell Inc
++0:1c:24	Formosa Wireless Systems Corp.
++0:1c:25	Hon Hai Precision Ind. Co.,Ltd.
++0:1c:26	Hon Hai Precision Ind. Co.,Ltd.
++0:1c:27	Sunell Electronics Co.
++0:1c:28	Sphairon Technologies GmbH 
++0:1c:29	CORE DIGITAL ELECTRONICS CO., LTD
++0:1c:2a	Envisacor Technologies Inc.
+ 0:1:c2	ARK Research Corp.
++0:1c:2b	Alertme.com Limited
++0:1c:2c	Synapse
++0:1c:2d	FlexRadio Systems
++0:1c:2e	ProCurve Networking by HP
++0:1c:2f	Pfister GmbH
++0:1c:2	Pano Logic
++0:1c:30	Mode Lighting (UK ) Ltd.
++0:1c:31	Mobile XP Technology Co., LTD
++0:1c:32	Telian Corporation
++0:1c:33	Sutron
++0:1c:34	HUEY CHIAO INTERNATIONAL CO., LTD.
++0:1c:35	Nokia Danmark A/S
++0:1c:36	iNEWiT NV
++0:1c:37	Callpod, Inc.
++0:1c:38	Bio-Rad Laboratories, Inc.
++0:1c:39	S Netsystems Inc.
+ 0:1:c3	Acromag, Inc.
++0:1c:3a	Element Labs, Inc.
++0:1c:3b	AmRoad Technology Inc.
++0:1c:3	Betty TV Technology AG
++0:1c:3c	Seon Design Inc.
++0:1c:3d	WaveStorm
++0:1c:3e	ECKey Limited
++0:1c:3f	International Police Technologies, Inc.
++0:1c:40	VDG-Security bv
++0:1c:41	scemtec Transponder Technology GmbH
++0:1c:42	Parallels, Inc.
++0:1c:43	Samsung Electronics Co.,Ltd
++0:1c:44	Bosch Security Systems BV
++0:1c:45	Chenbro Micom Co., Ltd.
++0:1c:46	QTUM
++0:1c:47	Hangzhou Hollysys Automation Co., Ltd
++0:1c:48	WiDeFi, Inc.
++0:1c:49	Zoltan Technology Inc.
++0:1c:4a	AVM GmbH
++0:1c:4	Airgain, Inc.
++0:1c:4b	Gener8, Inc.
++0:1c:4c	Petrotest Instruments
++0:1c:4d	Zeetoo, Inc.
++0:1c:4e	TASA International Limited
++0:1c:4f	MACAB AB
+ 0:1:c4	NeoWave, Inc.
++0:1c:50	TCL Technoly Electronics(Huizhou)Co.,Ltd
++0:1c:51	Celeno Communications
++0:1c:52	VISIONEE SRL
++0:1c:53	Synergy Lighting Controls
++0:1c:54	Hillstone Networks Inc
++0:1c:55	Shenzhen Kaifa Technology Co.
++0:1c:56	Pado Systems, Inc.
++0:1c:57	Cisco Systems
++0:1c:58	Cisco Systems
++0:1c:59	DEVON IT
++0:1c:5a	Advanced Relay Corporation
++0:1c:5b	Chubb Electronic Security Systems Ltd
++0:1c:5c	Integrated Medical Systems, Inc.
++0:1c:5d	Leica Microsystems
++0:1c:5e	ASTON France
++0:1c:5f	Winland Electronics, Inc.
++0:1c:5	Nonin Medical Inc.
+ 0:1:c5	Simpler Networks
++0:1c:60	CSP Frontier Technologies,Inc.
++0:1c:61	Galaxy Technology (HK) Ltd.
++0:1c:62	LG Electronics Inc
++0:1c:63	TRUEN
++0:1c:64	Cellnet+Hunt
++0:1c:65	JoeScan, Inc.
++0:1c:66	UCAMP CO.,LTD
++0:1c:67	Pumpkin Networks, Inc.
++0:1c:68	Anhui Sun Create Electronics Co., Ltd
++0:1c:69	Packet Vision Ltd
++0:1c:6a	Weiss Engineering Ltd.
++0:1c:6b	COVAX  Co. Ltd
++0:1c:6c	Jabil Circuit (Guangzhou) Limited
++0:1c:6d	KYOHRITSU ELECTRONIC INDUSTRY CO., LTD.
++0:1c:6e	Newbury Networks, Inc.
++0:1c:6f	Emfit Ltd
+ 0:1:c6	Quarry Technologies
++0:1c:6	Siemens Numerical Control Ltd., Nanjing
++0:1c:70	NOVACOMM LTDA
++0:1c:71	Emergent Electronics
++0:1c:72	Mayer & Cie GmbH & Co KG
++0:1c:73	Arista Networks, Inc.
++0:1c:74	Syswan Technologies Inc.
++0:1c:75	RF Systems GmbH
++0:1c:76	The Wandsworth Group Ltd
++0:1c:77	Prodys
++0:1c:78	WYPLAY SAS
++0:1c:79	Cohesive Financial Technologies LLC
++0:1c:7a	Perfectone Netware Company Ltd
++0:1c:7b	Castlenet Technology Inc.
+ 0:1:c7	Cisco Systems, Inc.
+-0:1:c8	CONRAD CORP. *also* THOMAS CONRAD CORP.
++0:1c:7c	PERQ SYSTEMS CORPORATION
++0:1c:7	Cwlinux Limited
++0:1c:7d	Excelpoint Manufacturing Pte Ltd
++0:1c:7e	Toshiba
++0:1c:7f	Check Point Software Technologies
++0:1c:80	New Business Division/Rhea-Information CO., LTD.
++0:1c:81	NextGen Venturi LTD
++0:1c:82	Genew Technologies
++0:1c:83	New Level Telecom Co., Ltd.
++0:1c:84	STL Solution Co.,Ltd.
++0:1c:85	Eunicorn
++0:1c:86	Cranite Systems, Inc.
++0:1c:87	Uriver Inc.
++0:1c:88	TRANSYSTEM INC.
++0:1c:89	Force Communications, Inc.
++0:1c:8a	Cirrascale Corporation
++0:1c:8b	MJ Innovations Ltd.
++0:1c:8c	DIAL TECHNOLOGY LTD.
++0:1:c8	CONRAD CORP.
++0:1c:8d	Mesa Imaging
++0:1c:8e	Alcatel-Lucent IPD
++0:1c:8	Echo360, Inc.
++0:1c:8f	Advanced Electronic Design, Inc.
++0:1c:90	Empacket Corporation
++0:1c:91	Gefen Inc.
++0:1c:92	Tervela
++0:1c:93	ExaDigm Inc
++0:1c:94	LI-COR Biosciences
++0:1c:95	Opticomm Corporation
++0:1c:96	Linkwise Technology Pte Ltd
++0:1c:97	Enzytek Technology Inc.,
++0:1c:98	LUCKY TECHNOLOGY (HK) COMPANY LIMITED
++0:1c:99	Shunra Software Ltd.
++0:1c:9a	Nokia Danmark A/S
++0:1c:9b	FEIG ELECTRONIC GmbH
+ 0:1:c9	Cisco Systems, Inc.
++0:1c:9c	Nortel
++0:1c:9d	Liecthi AG
++0:1c:9e	Dualtech IT AB
++0:1c:9f	Razorstream, LLC
++0:1c:9	SAE Electronic Co.,Ltd.
++0:1c:a0	Production Resource Group, LLC
++0:1c:a1	AKAMAI TECHNOLOGIES, INC.
++0:1c:a2	PIRELLI BROADBAND SOLUTIONS
++0:1c:a3	Terra
++0:1c:a4	Sony Ericsson Mobile Communications
++0:1c:a5	Zygo Corporation
++0:1c:a6	Win4NET
++0:1c:a7	International Quartz Limited
++0:1c:a8	AirTies Wireless Networks
++0:1c:a9	Audiomatica Srl
++0:1c:aa	Bellon Pty Ltd
++0:1c:ab	Meyer Sound Laboratories, Inc.
++0:1c:ac	Qniq Technology Corp.
++0:1c:ad	Wuhan Telecommunication Devices Co.,Ltd
++0:1c:ae	WiChorus, Inc.
++0:1c:af	Plato Networks Inc.
+ 0:1:ca	Geocast Network Systems, Inc.
++0:1c:a	Shenzhen AEE Technology Co.,Ltd.
++0:1c:b0	Cisco Systems
++0:1c:b1	Cisco Systems
++0:1c:b2	BPT SPA
++0:1c:b3	APPLE, INC
++0:1c:b4	Iridium Satellite LLC
++0:1c:b5	Neihua Network Technology Co.,LTD.(NHN)
++0:1c:b6	Duzon CNT Co., Ltd.
++0:1c:b7	USC DigiArk Corporation
++0:1c:b8	CBC Co., Ltd
++0:1c:b9	KWANG SUNG ELECTRONICS CO., LTD.
++0:1c:ba	VerScient, Inc.
++0:1c:bb	MusicianLink
++0:1c:bc	CastGrabber, LLC
++0:1c:bd	Ezze Mobile Tech., Inc.
++0:1c:be	Nintendo Co., Ltd.
+ 0:1:cb	EVR
++0:1c:bf	Intel Corporate
++0:1c:b	SmartAnt Telecom
++0:1c:c0	Intel Corporate
++0:1c:c1	Motorola Mobile Devices
++0:1c:c2	Part II Research, Inc.
++0:1c:c3	Pace Micro Technology plc
++0:1c:c4	Hewlett Packard
++0:1c:c5	3COM LTD
++0:1c:c6	ProStor Systems
++0:1c:c7	Rembrandt Technologies, LLC d/b/a REMSTREAM
++0:1c:c8	INDUSTRONIC Industrie-Electronic GmbH & Co. KG
++0:1c:c9	Kaise Electronic Technology Co., Ltd.
++0:1c:ca	Shanghai Gaozhi Science & Technology Development Co.
++0:1c:cb	Forth Corporation Public Company Limited
++0:1c:cc	Research In Motion Limited
++0:1c:cd	Alektrona Corporation
++0:1c:ce	By Techdesign
++0:1c:cf	LIMETEK
+ 0:1:cc	Japan Total Design Communication Co., Ltd.
++0:1c:c	TANITA Corporation
++0:1c:d0	Circleone Co.,Ltd.
++0:1c:d1	Waves Audio LTD
++0:1c:d2	King Champion (Hong Kong) Limited
++0:1c:d3	ZP Engineering SEL
++0:1c:d4	Nokia Danmark A/S
++0:1c:d5	ZeeVee, Inc.
++0:1c:d6	Nokia Danmark A/S
++0:1c:d7	Harman/Becker Automotive Systems GmbH
++0:1c:d8	BlueAnt Wireless
++0:1c:d9	GlobalTop Technology Inc.
++0:1c:da	Exegin Technologies Limited
+ 0:1:cd	ARtem
++0:1c:db	CARPOINT CO.,LTD
++0:1c:dc	Custom Computer Services, Inc.
++0:1c:dd	COWBELL ENGINEERING CO., LTD.
++0:1c:de	Interactive Multimedia eXchange Inc.
++0:1c:df	Belkin International Inc.
++0:1c:d	G-Technology, Inc.
++0:1c:e0	DASAN TPS
++0:1c:e1	INDRA SISTEMAS, S.A.
++0:1c:e2	Attero Tech, LLC.
++0:1c:e3	Optimedical Systems
++0:1c:e4	EleSy JSC
++0:1c:e5	MBS Electronic Systems GmbH
++0:1c:e6	INNES
++0:1c:e7	Rocon PLC Research Centre
++0:1c:e8	Cummins Inc
++0:1c:e9	Galaxy Technology Limited
++0:1c:ea	Scientific-Atlanta, Inc
++0:1c:eb	Nortel
++0:1c:e	Cisco Systems
++0:1c:ec	Mobilesoft (Aust.) Pty Ltd
+ 0:1:ce	Custom Micro Products, Ltd.
++0:1c:ed	ENVIRONNEMENT SA
++0:1c:ee	SHARP Corporation
++0:1c:ef	Primax Electronics LTD
++0:1c:f0	D-Link Corporation
++0:1c:f1	SUPoX Technology Co. , LTD.
++0:1c:f2	Tenlon Technology Co.,Ltd.
++0:1c:f3	EVS BROADCAST EQUIPMENT
++0:1c:f4	Media Technology Systems Inc
++0:1c:f5	Wiseblue Technology Limited
++0:1c:f6	Cisco Systems
++0:1c:f7	AudioScience
++0:1c:f8	Parade Technologies, Ltd.
++0:1c:f9	Cisco Systems
++0:1c:fa	Alarm.com
+ 0:1:cf	Alpha Data Parallel Systems, Ltd.
+-0:1:d	CORECO, INC.
++0:1c:fb	Motorola CHS
++0:1c:f	Cisco Systems
++0:1c:fc	Suminet Communication Technologies (Shanghai) Co., Ltd.
++0:1c:fd	Universal Electronics
++0:1c:fe	Quartics Inc
++0:1c:ff	Napera Networks Inc
++0:1:c	System Talks Inc.
++0:1d:0	Brivo Systems, LLC
+ 0:1:d0	VitalPoint, Inc.
++0:1d:10	LightHaus Logic, Inc.
++0:1d:11	Analogue & Micro Ltd
++0:1d:12	ROHM CO., LTD.
++0:1d:13	NextGTV
++0:1d:14	SPERADTONE INFORMATION TECHNOLOGY LIMITED
++0:1d:15	Shenzhen Dolphin Electronic Co., Ltd
++0:1d:16	Efixo
++0:1d:17	Digital Sky Corporation
++0:1d:18	Power Innovation GmbH
++0:1d:19	Arcadyan Technology Corporation
++0:1d:1a	OvisLink S.A.
++0:1d:1b	Sangean Electronics Inc.
++0:1d:1c	Gennet s.a.
+ 0:1:d1	CoNet Communications, Inc.
++0:1d:1d	Inter-M Corporation
++0:1d:1e	KYUSHU TEN CO.,LTD
++0:1d:1f	Siauliu Tauro Televizoriai, JSC
++0:1d:1	Neptune Digital
++0:1d:20	COMTREND CO.
++0:1d:21	Alcad SL
++0:1d:22	Foss Analytical A/S
++0:1d:23	SENSUS 
++0:1d:24	Aclara Power-Line Systems Inc.
++0:1d:25	Samsung Electronics Co.,Ltd
++0:1d:26	Rockridgesound Technology Co.
++0:1d:27	NAC-INTERCOM
++0:1d:28	Sony Ericsson Mobile Communications AB
++0:1d:29	Doro AB
++0:1d:2a	Tideway Electronic LTD
++0:1d:2b	Wuhan Pont Technology CO. , LTD
++0:1d:2c	Wavetrend Technologies (Pty) Limited
++0:1d:2	Cybertech Telecom Development
++0:1d:2d	Pylone, Inc.
++0:1d:2e	Ruckus Wireless
++0:1d:2f	QuantumVision Corporation
+ 0:1:d2	MacPower Peripherals, Ltd.
++0:1d:30	YX Wireless S.A.
++0:1d:31	HIGHPRO INTERNATIONAL R&D CO,.LTD.
++0:1d:32	Longkay Communication & Technology (Shanghai) Co. Ltd
++0:1d:33	Maverick Systems Inc.
++0:1d:34	SYRIS Technology Corp
++0:1d:35	Viconics Electronics Inc.
++0:1d:36	ELECTRONICS CORPORATION OF INDIA LIMITED
++0:1d:37	Thales-Panda Transportation System
++0:1d:38	Seagate Technology
++0:1d:39	MOOHADIGITAL CO., LTD
++0:1d:3a	mh acoustics LLC
++0:1d:3b	Nokia Danmark A/S
++0:1d:3c	Muscle Corporation
++0:1d:3d	Avidyne Corporation
++0:1d:3	Design Solutions Inc.
++0:1d:3e	SAKA TECHNO SCIENCE CO.,LTD
++0:1d:3f	Mitron Pty Ltd
+ 0:1:d3	PAXCOMM, Inc.
++0:1d:40	Living Independently Group, Inc.
++0:1d:41	Hardy Instruments
++0:1d:42	Nortel
++0:1d:43	Shenzhen G-link Digital Technology Co., Ltd.
++0:1d:44	Krohne
++0:1d:45	Cisco Systems
++0:1d:46	Cisco Systems
++0:1d:47	Covote GmbH & Co KG
++0:1d:48	Sensor-Technik Wiedemann GmbH
++0:1d:49	Innovation Wireless Inc.
++0:1d:4a	Carestream Health, Inc.
++0:1d:4b	Grid Connect Inc.
++0:1d:4c	Alcatel-Lucent
++0:1d:4d	Adaptive Recognition Hungary, Inc
++0:1d:4e	TCM Mobile LLC
++0:1d:4f	Apple Computer Inc.
+ 0:1:d4	Leisure Time, Inc.
++0:1d:4	Zipit Wireless, Inc.
++0:1d:50	SPINETIX SA
++0:1d:51	GE Energy
++0:1d:52	Defzone B.V.
++0:1d:53	S&O Electronics (Malaysia) Sdn. Bhd.
++0:1d:54	Sunnic Technology & Merchandise INC.
++0:1d:55	ZANTAZ, Inc
++0:1d:56	Kramer Electronics Ltd.
++0:1d:57	CAETEC Messtechnik
++0:1d:58	CQ Inc
++0:1d:59	Mitra Energy & Infrastructure
++0:1d:5a	2Wire Inc.
++0:1d:5b	Tecvan Informatica Ltda
++0:1d:5c	Tom Communication Industrial Co.,Ltd.
++0:1d:5d	Control Dynamics Pty. Ltd.
++0:1d:5e	COMING MEDIA CORP.
++0:1d:5f	OverSpeed SARL
+ 0:1:d5	HAEDONG INFO & COMM CO., LTD
+-0:1:d6	MAN Roland Druckmaschinen AG
++0:1d:5	iLight
++0:1d:60	ASUSTek COMPUTER INC.
++0:1d:61	BIJ Corporation
++0:1d:62	InPhase Technologies
++0:1d:63	Miele & Cie. KG
++0:1d:64	Adam Communications Systems Int Ltd
++0:1d:65	Microwave Radio Communications
++0:1d:66	Hyundai Telecom
++0:1d:67	AMEC
++0:1d:68	Thomson Telecom Belgium
++0:1d:69	Knorr-Bremse AG
++0:1d:6a	Alpha Networks Inc.
++0:1d:6b	Motorola (formerly Netopia, Inc
++0:1d:6c	ClariPhy Communications, Inc.
++0:1d:6d	Confidant International LLC
++0:1d:6e	Nokia Danmark A/S
++0:1d:6f	Chainzone Technology Co., Ltd
++0:1d:6	HM Electronics, Inc.
++0:1:d6	manroland AG
++0:1d:70	Cisco Systems
++0:1d:71	Cisco Systems
++0:1d:72	Wistron Corporation
++0:1d:73	Buffalo Inc.
++0:1d:74	Tianjin China-Silicon Microelectronics Co., Ltd.
++0:1d:75	Radioscape PLC
++0:1d:76	Eyeheight Ltd.
++0:1d:77	NSGate
++0:1d:78	Invengo Information Technology Co.,Ltd
++0:1d:79	SIGNAMAX LLC
++0:1d:7a	Wideband Semiconductor, Inc.
++0:1d:7b	Ice Energy, Inc.
++0:1d:7c	ABE Elettronica S.p.A.
++0:1d:7d	GIGA-BYTE TECHNOLOGY CO.,LTD.
++0:1d:7e	Cisco-Linksys, LLC
+ 0:1:d7	F5 Networks, Inc.
++0:1d:7f	Tekron International Ltd
++0:1d:7	Shenzhen Sang Fei Consumer Communications Co.,Ltd
++0:1d:80	Beijing Huahuan Eletronics Co.,Ltd
++0:1d:81	GUANGZHOU GATEWAY ELECTRONICS CO., LTD
++0:1d:82	GN A/S (GN Netcom A/S)
++0:1d:83	Emitech Corporation
++0:1d:84	Gateway, Inc.
++0:1d:85	Call Direct Cellular Solutions
++0:1d:86	Shinwa Industries(China) Ltd.
++0:1d:87	VigTech Labs Sdn Bhd
++0:1d:88	Clearwire
++0:1d:89	VaultStor Corporation
++0:1d:8a	TechTrex Inc
++0:1d:8b	PIRELLI BROADBAND SOLUTIONS
++0:1d:8c	La Crosse Technology LTD
++0:1d:8d	Raytek GmbH
++0:1d:8e	Alereon, Inc.
++0:1d:8f	PureWave Networks
++0:1d:8	JIANGSU YINHE ELECTRONICS CO., LTD
+ 0:1:d8	Teltronics, Inc.
++0:1d:90	EMCO Flow Systems
++0:1d:91	Digitize, Inc
++0:1d:92	MICRO-STAR INT'L CO.,LTD.
++0:1d:93	Modacom
++0:1d:94	Climax Technology Co., Ltd
++0:1d:95	Flash, Inc.
++0:1d:96	WatchGuard Video
++0:1d:97	Alertus Technologies LLC
++0:1d:98	Nokia Danmark A/S
++0:1d:99	Cyan Optic, Inc.
++0:1d:9a	GODEX INTERNATIONAL CO., LTD
++0:1d:9b	Hokuyo Automatic Co., Ltd.
++0:1d:9c	Rockwell Automation
++0:1d:9d	ARTJOY INTERNATIONAL LIMITED
++0:1d:9	Dell Inc
++0:1d:9e	AXION TECHNOLOGIES
++0:1d:9f	MATT   R.P.Traczynscy Sp.J.
+ 0:1:d9	Sigma, Inc.
++0:1d:a0	Heng Yu Electronic Manufacturing Company Limited
++0:1d:a1	Cisco Systems
++0:1d:a2	Cisco Systems
++0:1d:a3	SabiOso
++0:1d:a4	Hangzhou System Technology CO., LTD
++0:1d:a5	WB Electronics
++0:1d:a6	Media Numerics Limited
++0:1d:a7	Seamless Internet
++0:1d:a8	Takahata Electronics Co.,Ltd
++0:1d:a9	Castles Technology, Co., LTD
++0:1d:aa	DrayTek Corp.
++0:1d:ab	SwissQual License AG
++0:1d:ac	Gigamon Systems LLC
++0:1d:a	Davis Instruments, Inc.
++0:1d:ad	Sinotech Engineering Consultants, Inc.  Geotechnical Enginee
++0:1d:ae	CHANG TSENG TECHNOLOGY CO., LTD
++0:1d:af	Nortel
+ 0:1:da	WINCOMM Corporation
++0:1d:b0	FuJian HengTong Information Technology Co.,Ltd
++0:1d:b1	Crescendo Networks
++0:1d:b2	HOKKAIDO ELECTRIC ENGINEERING CO.,LTD.
++0:1d:b3	ProCurve Networking by HP
++0:1d:b4	KUMHO ENG CO.,LTD
++0:1d:b5	Juniper networks
++0:1d:b6	BestComm Networks, Inc.
++0:1d:b7	Tendril Networks, Inc.
++0:1d:b8	Intoto Inc.
++0:1d:b9	Wellspring Wireless
++0:1d:ba	Sony Corporation
++0:1d:bb	Dynamic System Electronics Corp.
++0:1d:bc	Nintendo Co., Ltd.
++0:1d:bd	Versamed Inc.
++0:1d:be	Motorola Mobile Devices
++0:1d:bf	Radiient Technologies, Inc.
+ 0:1:db	Freecom Technologies GmbH
++0:1d:b	Power Standards Lab
++0:1d:c0	Enphase Energy
++0:1d:c1	Audinate Pty L
++0:1d:c2	XORTEC OY
++0:1d:c3	RIKOR TV, Ltd
++0:1d:c4	AIOI Systems Co., Ltd.
++0:1d:c5	Beijing Jiaxun Feihong Electricial Co., Ltd.
++0:1d:c6	SNR Inc.
++0:1d:c7	L-3 Communications Geneva Aerospace
++0:1d:c8	ScadaMetrcs, LLC.
++0:1d:c9	GainSpan Corp.
+ 0:1:dc	Activetelco
++0:1d:ca	PAV Electronics Limited
++0:1d:cb	Ex
++0:1d:cc	Hetra Secure Solutions
++0:1d:cd	ARRIS Group, Inc.
++0:1d:ce	ARRIS Group, Inc.
++0:1d:cf	ARRIS Group, Inc.
++0:1d:c	MobileCompia
++0:1:d	CORECO, INC.
++0:1d:d0	ARRIS Group, Inc.
++0:1d:d1	ARRIS Group, Inc.
++0:1d:d2	ARRIS Group, Inc.
++0:1d:d3	ARRIS Group, Inc.
++0:1d:d4	ARRIS Group, Inc.
++0:1d:d5	ARRIS Group, Inc.
++0:1d:d6	ARRIS Group, Inc.
++0:1d:d7	Algolith
++0:1d:d8	Microsoft Corporation
++0:1d:d9	Hon Hai Precision Ind.Co.,Ltd.
++0:1d:da	Mikroelektronika spol. s r. o.
+ 0:1:dd	Avail Networks
++0:1d:db	C-BEL Corporation
++0:1d:dc	HangZhou DeChangLong Tech&Info Co.,Ltd
++0:1d:dd	DAT H.K. LIMITED
++0:1d:de	Zhejiang Broadcast&Television Technology Co.,Ltd.
++0:1d:df	Sunitec Enterprise Co., Ltd.
++0:1d:d	Sony Computer Entertainment inc.
++0:1d:e0	Intel Corporate
++0:1d:e1	Intel Corporate
++0:1d:e2	Radionor Communications
++0:1d:e3	Intuicom
++0:1d:e4	Visioneered Image Systems
++0:1d:e5	Cisco Systems
++0:1d:e6	Cisco Systems
++0:1d:e7	Marine Sonic Technology, Ltd.
++0:1d:e8	Nikko Denki Tsushin Company(NDTC)
++0:1d:e9	Nokia Danmark A/S
++0:1d:ea	Commtest Instruments Ltd
++0:1d:e	Agapha Technology co., Ltd.
++0:1d:eb	DINEC International
++0:1d:ec	Marusys
++0:1d:ed	Grid Net, Inc.
++0:1d:ee	NEXTVISION SISTEMAS DIGITAIS DE TELEVIS
++0:1d:ef	TRIMM, INC.
+ 0:1:de	Trango Systems, Inc.
++0:1d:f0	Vidient Systems, Inc.
++0:1d:f1	Intego Systems, Inc.
++0:1d:f2	Netflix, Inc.
++0:1d:f3	SBS Science & Technology Co., Ltd
++0:1d:f4	Magellan Technology Pty Limited
++0:1d:f5	Sunshine Co,LTD
++0:1d:f6	Samsung Electronics Co.,Ltd
++0:1d:f7	R. STAHL Schaltger
++0:1d:f8	Webpro Vision Technology Corporation
++0:1d:f9	Cybiotronics (Far East) Limited
++0:1d:fa	Fujian LANDI Commercial Equipment Co.,Ltd
++0:1d:fb	NETCLEUS Systems Corporation
++0:1d:fc	KSIC
++0:1d:fd	Nokia Danmark A/S
++0:1d:fe	Palm, Inc
++0:1d:ff	Network Critical Solutions Ltd
+ 0:1:df	ISDN Communications, Ltd.
+-0:1:e	Bri-Link Technologies Co., Ltd
++0:1d:f	TP-LINK Technologies Co., Ltd.
+ 0:1:e0	Fast Systems, Inc.
++0:1e:0	Shantou Institute of Ultrasonic Instruments
++0:1e:10	ShenZhen Huawei Communication Technologies Co.,Ltd.
++0:1e:11	ELELUX INTERNATIONAL LTD
++0:1e:12	Ecolab
++0:1e:13	Cisco Systems
++0:1e:14	Cisco Systems
++0:1e:15	Beech Hill Electronics
++0:1e:16	Keytronix
++0:1e:17	STN BV
++0:1e:18	Radio Activity srl
++0:1e:19	GTRI
++0:1e:1a	Best Source Taiwan Inc.
++0:1e:1b	Digital Stream Technology, Inc.
++0:1e:1c	SWS Australia Pty Limited
++0:1e:1d	East Coast Datacom, Inc.
++0:1e:1e	Honeywell Life Safety
++0:1e:1f	Nortel
+ 0:1:e1	Kinpo Electronics, Inc.
++0:1e:1	Renesas Technology Sales Co., Ltd.
++0:1e:20	Intertain Inc.
++0:1e:21	Qisda Co.
++0:1e:22	ARVOO Imaging Products BV
++0:1e:23	Electronic Educational Devices, Inc
++0:1e:24	Zhejiang Bell Technology Co.,ltd
++0:1e:25	Intek Digital Inc
++0:1e:26	Digifriends Co. Ltd
++0:1e:27	SBN TECH Co.,Ltd.
++0:1e:28	Lumexis Corporation
++0:1e:29	Hypertherm Inc
+ 0:1:e2	Ando Electric Corporation
++0:1e:2a	Netgear Inc.
++0:1e:2b	Radio Systems Design, Inc.
++0:1e:2c	CyVerse Corporation
++0:1e:2d	STIM
++0:1e:2e	SIRTI S.p.A.
++0:1e:2f	DiMoto Pty Ltd
++0:1e:2	Sougou Keikaku Kougyou Co.,Ltd.
++0:1e:30	Shireen Inc
++0:1e:31	INFOMARK CO.,LTD.
++0:1e:32	Zensys
++0:1e:33	Inventec Corporation
++0:1e:34	CryptoMetrics
++0:1e:35	Nintendo Co., Ltd.
++0:1e:36	IPTE
++0:1e:37	USI
++0:1e:38	Bluecard Software Technology Co., Ltd.
++0:1e:39	Comsys Communication Ltd.
++0:1e:3a	Nokia Danmark A/S
++0:1e:3b	Nokia Danmark A/S
++0:1e:3c	Lyngbox Media AB
++0:1e:3d	Alps Electric Co., Ltd
++0:1e:3e	KMW Inc.
++0:1e:3f	TrellisWare Technologies, Inc.
++0:1e:3	LiComm Co., Ltd.
+ 0:1:e3	Siemens AG
++0:1e:40	Shanghai DareGlobal Technologies  Co.,Ltd.
++0:1e:41	Microwave Communication & Component, Inc.
++0:1e:42	Teltonika
++0:1e:43	AISIN AW CO.,LTD.
++0:1e:44	SANTEC
++0:1e:45	Sony Ericsson Mobile Communications AB
++0:1e:46	Motorola CHS
++0:1e:47	PT. Hariff Daya Tunggal Engineering
++0:1e:48	Wi-Links
++0:1e:49	Cisco Systems
++0:1e:4a	Cisco Systems
++0:1e:4b	City Theatrical
++0:1e:4c	Hon Hai Precision Ind.Co., Ltd.
++0:1e:4d	Welkin Sciences, LLC
++0:1e:4e	DAKO EDV-Ingenieur- und Systemhaus GmbH
++0:1e:4f	Dell Inc.
++0:1e:4	Hanson Research Corporation
+ 0:1:e4	Sitera, Inc.
++0:1e:50	BATTISTONI RESEARCH
++0:1e:51	Converter Industry Srl
++0:1e:52	Apple Computer Inc
++0:1e:53	Further Tech Co., LTD
++0:1e:54	TOYO ELECTRIC Corporation
++0:1e:55	COWON SYSTEMS,Inc.
++0:1e:56	Bally Wulff Entertainment GmbH
++0:1e:57	ALCOMA, spol. s r.o.
++0:1e:58	D-Link Corporation
++0:1e:59	Silicon Turnkey Express, LLC
++0:1e:5a	Motorola CHS
++0:1e:5b	Unitron Company, Inc.
++0:1e:5c	RB GeneralEkonomik
++0:1e:5d	Holosys d.o.o.
++0:1e:5e	COmputime Ltd.
++0:1e:5f	KwikByte, LLC
+ 0:1:e5	Supernet, Inc.
++0:1e:5	Xseed Technologies & Computing
++0:1e:60	Digital Lighting Systems, Inc
++0:1e:61	ITEC GmbH
++0:1e:62	Siemon
++0:1e:63	Vibro-Meter SA
++0:1e:64	Intel Corporate
++0:1e:65	Intel Corporate
++0:1e:66	RESOL Elektronische Regelungen GmbH
++0:1e:67	Intel Corporate
++0:1e:68	Quanta Computer
++0:1e:69	Thomson Inc.
++0:1e:6a	Beijing Bluexon Technology Co.,Ltd
++0:1e:6b	Scientific Atlanta, A Cisco Company
++0:1e:6c	Carbon Mountain LLC
++0:1e:6d	IT R&D Center
++0:1e:6e	Shenzhen First Mile Communications Ltd
++0:1e:6f	Magna-Power Electronics, Inc.
+ 0:1:e6	Hewlett-Packard Company
++0:1e:6	WIBRAIN
++0:1e:70	Cobham Defence Communications Ltd
++0:1e:71	IgeaCare Systems Inc.
++0:1e:72	PCS
++0:1e:73	ZTE CORPORATION
++0:1e:74	SAGEM COMMUNICATION
++0:1e:75	LG Electronics
++0:1e:76	Thermo Fisher Scientific
++0:1e:77	Air2App
++0:1e:78	Owitek Technology Ltd.,
++0:1e:79	Cisco Systems
++0:1e:7a	Cisco Systems
++0:1e:7b	R.I.CO. S.r.l.
++0:1e:7c	Taiwick Limited
++0:1e:7d	Samsung Electronics Co.,Ltd
++0:1e:7e	Nortel
++0:1e:7f	CBM of America
+ 0:1:e7	Hewlett-Packard Company
++0:1e:7	Winy Technology Co., Ltd.
++0:1e:80	Last Mile Ltd.
++0:1e:81	CNB Technology Inc.
++0:1e:82	Pliant Technology, Inc.
++0:1e:83	LAN/MAN Standards Association (LMSC)
++0:1e:84	Pika Technologies Inc.
++0:1e:85	Lagotek Corporation
++0:1e:86	MEL Co.,Ltd.
++0:1e:87	Realease Limited
++0:1e:88	ANDOR SYSTEM SUPPORT CO., LTD.
++0:1e:89	CRFS Limited
++0:1e:8a	eCopy, Inc
++0:1e:8b	Infra Access Korea Co., Ltd.
++0:1e:8c	ASUSTek COMPUTER INC.
++0:1e:8	Centec Networks Inc
++0:1e:8d	Motorola Mobile Devices
++0:1e:8e	Hunkeler AG
++0:1e:8f	CANON INC.
+ 0:1:e8	Force10 Networks, Inc.
++0:1e:90	Elitegroup Computer Systems Co
++0:1e:91	KIMIN Electronic Co., Ltd.
++0:1e:92	JEULIN S.A.
++0:1e:93	CiriTech Systems Inc
++0:1e:94	SUPERCOM TECHNOLOGY CORPORATION
++0:1e:95	SIGMALINK
++0:1e:96	Sepura Plc
++0:1e:97	Medium Link System Technology CO., LTD,
++0:1e:98	GreenLine Communications
++0:1e:99	Vantanol Industrial Corporation
++0:1e:9a	HAMILTON Bonaduz AG
++0:1e:9b	San-Eisha, Ltd.
++0:1e:9c	Fidustron INC
++0:1e:9d	Recall Technologies, Inc.
++0:1e:9e	ddm hopt + schuler Gmbh + Co. KG
++0:1e:9f	Visioneering Systems, Inc.
+ 0:1:e9	Litton Marine Systems B.V.
++0:1e:9	ZEFATEK Co.,LTD
++0:1e:a0	XLN-t
++0:1e:a1	Brunata a/s
++0:1e:a2	Symx Systems, Inc.
++0:1e:a3	Nokia Danmark A/S
++0:1e:a4	Nokia Danmark A/S
++0:1e:a5	ROBOTOUS, Inc.
++0:1e:a6	Best IT World (India) Pvt. Ltd.
++0:1e:a7	ActionTec Electronics, Inc
++0:1e:a8	Datang Mobile Communications Equipment CO.,LTD
++0:1e:a9	Nintendo Co., Ltd.
++0:1e:aa	E-Senza Technologies GmbH
++0:1e:ab	TeleWell Oy
++0:1e:ac	Armadeus Systems
+ 0:1:ea	Cirilium Corp.
++0:1e:ad	Wingtech Group Limited
++0:1e:ae	Continental Automotive Systems
++0:1e:af	Ophir Optronics Ltd
++0:1e:a	Syba Tech Limited
++0:1e:b0	ImesD Electronica S.L.
++0:1e:b1	Cryptsoft Pty Ltd
++0:1e:b2	LG innotek
++0:1e:b3	Primex Wireless
++0:1e:b4	UNIFAT TECHNOLOGY LTD.
++0:1e:b5	Ever Sparkle Technologies Ltd
++0:1e:b6	TAG Heuer SA
++0:1e:b7	TBTech, Co., Ltd.
++0:1e:b8	Fortis, Inc.
++0:1e:b9	Sing Fai Technology Limited
++0:1e:ba	High Density Devices AS
++0:1e:bb	BLUELIGHT TECHNOLOGY INC.
+ 0:1:eb	C-COM Corporation
++0:1e:bc	WINTECH AUTOMATION CO.,LTD.
++0:1e:bd	Cisco Systems
++0:1e:be	Cisco Systems
++0:1e:bf	Haas Automation Inc.
++0:1e:b	Hewlett Packard
++0:1:e	Bri-Link Technologies Co., Ltd
++0:1e:c0	ZeroG Wireless Inc.
++0:1e:c1	3COM EUROPE LTD
++0:1e:c2	Apple, Inc
++0:1e:c3	Kozio, Inc.
++0:1e:c4	Celio Corp
++0:1e:c5	Middle Atlantic Products Inc
++0:1e:c6	Obvius Holdings LLC
++0:1e:c7	2Wire
++0:1e:c8	Rapid Mobile (Pty) Ltd
++0:1e:c9	Dell Inc
++0:1e:ca	Nortel
++0:1e:cb	"RPC "Energoautomatika" Ltd
++0:1e:cc	CDVI
++0:1e:cd	KYLAND
++0:1e:ce	BISA Technologies (Hong Kong) Limited
+ 0:1:ec	Ericsson Group
++0:1e:cf	PHILIPS ELECTRONICS UK LTD
++0:1e:c	Sherwood Information Partners, Inc.
++0:1e:d0	CONNEXIUM
++0:1e:d1	Keyprocessor B.V.
++0:1e:d2	Ray Shine Video Technology Inc
++0:1e:d3	Dot Technology Int'l Co., Ltd.
++0:1e:d4	Doble Engineering
++0:1e:d5	Tekon-Automatics
++0:1e:d6	Alentec & Orion AB
++0:1e:d7	H-Stream Wireless, Inc.
++0:1e:d8	Digital United Inc.
++0:1e:d9	Mitsubishi Precision Co.,LTd.
++0:1e:da	Wesemann Elektrotechniek B.V.
++0:1e:db	Giken Trastem Co., Ltd.
++0:1e:dc	Sony Ericsson Mobile Communications AB
++0:1e:dd	WASKO S.A.
++0:1e:de	BYD COMPANY LIMITED
++0:1e:df	Master Industrialization Center Kista
++0:1e:d	Micran Ltd.
+ 0:1:ed	SETA Corp.
++0:1e:e0	Urmet Domus SpA
++0:1e:e1	Samsung Electronics Co.,Ltd
++0:1e:e2	Samsung Electronics Co.,Ltd
++0:1e:e3	T&W Electronics (ShenZhen) Co.,Ltd
++0:1e:e4	ACS Solutions France
++0:1e:e5	Cisco-Linksys, LLC
++0:1e:e6	Shenzhen Advanced Video Info-Tech Co., Ltd.
++0:1e:e7	Epic Systems Inc
++0:1e:e8	Mytek
++0:1e:e9	Stoneridge Electronics AB
++0:1e:ea	Sensor Switch, Inc.
++0:1e:eb	Talk-A-Phone Co.
++0:1e:ec	COMPAL INFORMATION (KUNSHAN) CO., LTD.
+ 0:1:ee	Comtrol Europe, Ltd.
++0:1e:ed	Adventiq Ltd.
++0:1e:ee	ETL Systems Ltd
++0:1e:ef	Cantronic International Limited
++0:1e:e	MAXI VIEW HOLDINGS LIMITED
++0:1e:f0	Gigafin Networks
++0:1e:f1	Servimat
++0:1e:f2	Micro Motion Inc
++0:1e:f3	From2
++0:1e:f4	L-3 Communications Display Systems
++0:1e:f5	Hitek Automated Inc.
++0:1e:f6	Cisco Systems
++0:1e:f7	Cisco Systems
++0:1e:f8	Emfinity Inc.
++0:1e:f9	Pascom Kommunikations systeme GmbH.
++0:1e:fa	PROTEI Ltd.
++0:1e:f	Briot International
++0:1e:fb	Trio Motion Technology Ltd
+ 0:1:ef	Camtel Technology Corp.
+-0:1:f	McDATA Corporation
++0:1e:fc	JSC "MASSA-K"
++0:1e:fd	Microbit 2.0 AB
++0:1e:fe	LEVEL s.r.o.
++0:1e:ff	Mueller-Elektronik GmbH & Co. KG
++0:1f:0	Nokia Danmark A/S
+ 0:1:f0	Tridium, Inc.
++0:1f:10	TOLEDO DO BRASIL INDUSTRIA DE BALANCAS  LTDA
++0:1f:11	OPENMOKO, INC.
++0:1f:12	Juniper Networks
++0:1f:13	S.& A.S. Ltd.
++0:1f:14	NexG
++0:1f:15	Bioscrypt Inc
++0:1f:16	Wistron Corporation
++0:1f:17	IDX Company, Ltd.
++0:1f:18	Hakusan.Mfg.Co,.Ltd
++0:1f:19	BEN-RI ELECTRONICA S.A.
++0:1f:1a	Prominvest
++0:1f:1b	RoyalTek Company Ltd.
++0:1f:1c	KOBISHI ELECTRIC Co.,Ltd.
++0:1f:1d	Atlas Material Testing Technology LLC
++0:1f:1e	Astec Technology Co., Ltd
++0:1f:1f	Edimax Technology Co. Ltd.
+ 0:1:f1	Innovative Concepts, Inc.
++0:1f:1	Nokia Danmark A/S
++0:1f:20	Logitech Europe SA
++0:1f:21	Inner Mongolia Yin An Science & Technology Development Co.,L
++0:1f:22	Fiberxon, Inc.
++0:1f:23	Interacoustics
++0:1f:24	DIGITVIEW TECHNOLOGY CO., LTD.
++0:1f:25	MBS GmbH
++0:1f:26	Cisco Systems
++0:1f:27	Cisco Systems
++0:1f:28	ProCurve Networking by HP
++0:1f:29	Hewlett Packard
++0:1f:2a	ACCM
++0:1f:2b	Orange Logic
++0:1f:2c	Starbridge Networks
++0:1f:2d	Electro-Optical Imaging, Inc.
++0:1f:2e	Triangle Research Int'l Pte Ltd
++0:1f:2f	Berker GmbH & Co. KG
+ 0:1:f2	Mark of the Unicorn, Inc.
++0:1f:2	Pixelmetrix Corporation Pte Ltd
++0:1f:30	Travelping
++0:1f:31	Radiocomp
++0:1f:32	Nintendo Co., Ltd.
++0:1f:33	Netgear Inc.
++0:1f:34	Lung Hwa Electronics Co., Ltd.
++0:1f:35	AIR802 LLC
++0:1f:36	Bellwin Information Co. Ltd.,
++0:1f:37	Genesis I&C
++0:1f:38	POSITRON
++0:1f:39	Construcciones y Auxiliar de Ferrocarriles, S.A.
++0:1f:3a	Hon Hai Precision Ind.Co., Ltd.
++0:1f:3b	Intel Corporate
++0:1f:3c	Intel Corporate
++0:1f:3d	Qbit GmbH
++0:1f:3e	RP-Technik e.K.
++0:1f:3f	AVM GmbH
++0:1f:3	NUM AG
+ 0:1:f3	QPS, Inc.
++0:1f:40	Speakercraft Inc.
++0:1f:41	Ruckus Wireless
++0:1f:42	Etherstack Pty Ltd
++0:1f:43	ENTES ELEKTRONIK
++0:1f:44	GE Transportation Systems
++0:1f:45	Enterasys
++0:1f:46	Nortel
++0:1f:47	MCS Logic Inc.
++0:1f:48	Mojix Inc.
++0:1f:49	Eurosat Distribution Ltd
++0:1f:4a	Albentia Systems S.A.
++0:1f:4b	Lineage Power
++0:1f:4c	Roseman Engineering Ltd
++0:1f:4d	Segnetics LLC
++0:1f:4e	ConMed Linvatec
+ 0:1:f4	Enterasys Networks
++0:1f:4f	Thinkware Co. Ltd.
++0:1f:4	Granch Ltd.
++0:1f:50	Swissdis AG
++0:1f:51	HD Communications Corp
++0:1f:52	UVT Unternehmensberatung f
++0:1f:53	GEMAC Gesellschaft f
++0:1f:54	Lorex Technology Inc.
++0:1f:55	Honeywell Security (China) Co., Ltd.
++0:1f:56	DIGITAL FORECAST
++0:1f:57	Phonik Innovation Co.,LTD
++0:1f:58	EMH Energiemesstechnik GmbH
++0:1f:59	Kronback Tracers
++0:1f:5a	Beckwith Electric Co.
++0:1f:5b	Apple, Inc.
++0:1f:5c	Nokia Danmark A/S
++0:1f:5d	Nokia Danmark A/S
++0:1f:5e	Dyna Technology Co.,Ltd.
+ 0:1:f5	ERIM S.A.
++0:1f:5f	Blatand GmbH
++0:1f:5	iTAS Technology Corp.
++0:1f:60	COMPASS SYSTEMS CORP.
++0:1f:61	Talent Communication Networks Inc.
++0:1f:62	JSC "Stilsoft"
++0:1f:63	JSC Goodwin-Europa
++0:1f:64	Beijing Autelan Technology Inc.
++0:1f:65	KOREA ELECTRIC TERMINAL CO., LTD.
++0:1f:66	PLANAR LLC
++0:1f:67	Hitachi,Ltd.
++0:1f:68	Martinsson Elektronik AB
++0:1f:69	Pingood Technology Co., Ltd.
++0:1f:6a	PacketFlux Technologies, Inc.
+ 0:1:f6	Association of Musical Electronics Industry
++0:1f:6b	LG Electronics
++0:1f:6c	Cisco Systems
++0:1f:6d	Cisco Systems
++0:1f:6e	Vtech Engineering Corporation
++0:1f:6f	Fujian Sunnada Communication Co.,Ltd.
++0:1f:6	Integrated Dispatch Solutions
++0:1f:70	Botik Technologies LTD
++0:1f:71	xG Technology, Inc.
++0:1f:72	QingDao Hiphone Technology Co,.Ltd
++0:1f:73	Teraview Technology Co., Ltd.
++0:1f:74	Eigen Development
++0:1f:75	GiBahn Media
++0:1f:76	AirLogic Systems Inc.
++0:1f:77	HEOL DESIGN
++0:1f:78	Blue Fox Porini Textile
++0:1f:79	Lodam Electronics A/S
++0:1f:7a	WiWide Inc.
++0:1f:7	AZTEQ Mobile
++0:1f:7b	TechNexion Ltd.
++0:1f:7c	Witelcom AS
++0:1f:7d	embedded wireless GmbH
++0:1f:7e	Motorola Mobile Devices
++0:1f:7f	Phabrix Limited
+ 0:1:f7	Image Display Systems, Inc.
++0:1f:80	Lucas Holding bv
++0:1f:81	Accel Semiconductor Corp
++0:1f:82	Cal-Comp Electronics & Communications Co., Ltd
++0:1f:83	Teleplan Technology Services Sdn Bhd
++0:1f:84	Gigle Semiconductor
++0:1f:85	Apriva ISS, LLC
++0:1f:86	digEcor
++0:1f:87	Skydigital Inc.
++0:1f:88	FMS Force Measuring Systems AG
++0:1f:89	Signalion GmbH
+ 0:1:f8	Adherent Systems, Ltd.
++0:1f:8a	Ellion Digital Inc.
++0:1f:8b	Storspeed, Inc.
++0:1f:8c	CCS Inc.
++0:1f:8d	Ingenieurbuero Stark GmbH und Ko. KG
++0:1f:8e	Metris USA Inc.
++0:1f:8f	Shanghai Bellmann Digital Source Co.,Ltd.
++0:1f:8	RISCO LTD
++0:1f:90	Actiontec Electronics, Inc
++0:1f:91	DBS Lodging Technologies, LLC
++0:1f:92	VideoIQ, Inc.
++0:1f:93	Xiotech Corporation
++0:1f:94	Lascar Electronics Ltd
++0:1f:95	SAGEM COMMUNICATION
++0:1f:96	APROTECH CO.LTD
++0:1f:97	BERTANA SRL
++0:1f:98	DAIICHI-DENTSU LTD.
++0:1f:99	SERONICS co.ltd
++0:1f:9a	Nortel Networks
++0:1f:9b	POSBRO
++0:1f:9c	LEDCO
++0:1f:9d	Cisco Systems
++0:1f:9e	Cisco Systems
++0:1f:9f	Thomson Telecom Belgium
++0:1f:9	JASTEC CO., LTD.
+ 0:1:f9	TeraGlobal Communications Corp.
++0:1f:a0	A10 Networks
++0:1f:a1	Gtran Inc
++0:1f:a2	Datron World Communications, Inc.
++0:1f:a3	T&W Electronics(Shenzhen)Co.,Ltd.
++0:1f:a4	ShenZhen Gongjin Electronics Co.,Ltd
++0:1f:a5	Blue-White Industries
++0:1f:a6	Stilo srl
++0:1f:a7	Sony Computer Entertainment Inc.
++0:1f:a8	ANI Technologies Corp.
++0:1f:a9	Atlanta DTH, Inc.
++0:1f:aa	Taseon, Inc.
++0:1f:ab	I.S HIGH TECH.INC
++0:1f:ac	Goodmill Systems Ltd
++0:1f:ad	Brown Innovations, Inc
++0:1f:ae	Blick South Africa (Pty) Ltd
++0:1f:af	NextIO, Inc.
+ 0:1:fa	HOROSCAS
++0:1f:a	Nortel
++0:1f:b0	TimeIPS, Inc.
++0:1f:b1	Cybertech Inc.
++0:1f:b2	Sontheim Industrie Elektronik GmbH
++0:1f:b3	2Wire
++0:1f:b4	SmartShare Systems
++0:1f:b5	I/O Interconnect Inc.
++0:1f:b6	Chi Lin Technology Co., Ltd.
++0:1f:b7	WiMate Technologies Corp.
++0:1f:b8	Universal Remote Control, Inc.
++0:1f:b9	Paltronics
++0:1f:ba	BoYoung Tech. & Marketing, Inc.
++0:1f:bb	Xenatech Co.,LTD
++0:1f:bc	EVGA Corporation
++0:1f:bd	Kyocera Wireless Corp.
+ 0:1:fb	DoTop Technology, Inc.
++0:1f:be	Shenzhen Mopnet Industrial Co.,Ltd
++0:1f:b	Federal State Unitary Enterprise Industrial Union"Electropribor"
++0:1f:bf	Fulhua Microelectronics Corp. Taiwan Branch
++0:1:f	Brocade Communications Systems, Inc.
++0:1f:c0	Control Express Finland Oy
++0:1f:c1	Hanlong Technology Co.,LTD
++0:1f:c2	Jow Tong Technology Co Ltd
++0:1f:c3	SmartSynch, Inc
++0:1f:c4	Motorola CHS
++0:1f:c5	Nintendo Co., Ltd.
++0:1f:c6	ASUSTek COMPUTER INC.
++0:1f:c7	Casio Hitachi Mobile Comunications Co., Ltd.
++0:1f:c8	Up-Today Industrial Co., Ltd.
++0:1f:c9	Cisco Systems
++0:1f:ca	Cisco Systems
++0:1f:cb	NIW Solutions
++0:1f:cc	Samsung Electronics Co.,Ltd
++0:1f:cd	Samsung Electronics
++0:1f:ce	QTECH LLC
++0:1f:cf	MSI Technology GmbH
++0:1f:c	Intelligent Digital Services GmbH
+ 0:1:fc	Keyence Corporation
++0:1f:d0	GIGA-BYTE TECHNOLOGY CO.,LTD.
++0:1f:d1	OPTEX CO.,LTD.
++0:1f:d2	COMMTECH TECHNOLOGY MACAO COMMERCIAL OFFSHORE LTD.
++0:1f:d3	RIVA Networks Inc.
++0:1f:d4	4IPNET, INC.
++0:1f:d5	MICRORISC s.r.o.
++0:1f:d6	Shenzhen Allywll
++0:1f:d7	TELERAD SA
++0:1f:d8	A-TRUST COMPUTER CORPORATION
++0:1f:d9	RSD Communications Ltd
++0:1f:da	Nortel Networks
++0:1f:db	Network Supply Corp.,
++0:1f:dc	Mobile Safe Track Ltd
++0:1f:dd	GDI LLC
+ 0:1:fd	Digital Voice Systems, Inc.
++0:1f:de	Nokia Danmark A/S
++0:1f:df	Nokia Danmark A/S
++0:1f:d	L3 Communications - Telemetry West
++0:1f:e0	EdgeVelocity Corp
++0:1f:e1	Hon Hai Precision Ind. Co., Ltd.
++0:1f:e2	Hon Hai Precision Ind. Co., Ltd.
++0:1f:e3	LG Electronics
++0:1f:e4	Sony Ericsson Mobile Communications
++0:1f:e5	In-Circuit GmbH
++0:1f:e6	Alphion Corporation
++0:1f:e7	Simet
++0:1f:e8	KURUSUGAWA Electronics Industry Inc,.
++0:1f:e9	Printrex, Inc.
++0:1f:ea	Applied Media Technologies Corporation
++0:1f:eb	Trio Datacom Pty Ltd
++0:1f:ec	Synapse 
+ 0:1:fe	DIGITAL EQUIPMENT CORPORATION
++0:1f:ed	Tecan Systems Inc.
++0:1f:ee	ubisys technologies GmbH
++0:1f:ef	SHINSEI INDUSTRIES CO.,LTD
++0:1f:e	Japan Kyastem Co., Ltd
++0:1f:f0	Audio Partnership
++0:1f:f1	Paradox Hellas S.A.
++0:1f:f2	VIA Technologies, Inc.
++0:1f:f3	Apple, Inc
++0:1f:f4	Power Monitors, Inc.
++0:1f:f5	Kongsberg Defence & Aerospace
++0:1f:f6	PS Audio International
++0:1f:f7	Nakajima All Precision Co., Ltd.
++0:1f:f8	Siemens AG, Sector Industry, Drive Technologies, Motion Control Systems
++0:1f:f9	Advanced Knowledge Associates
++0:1f:fa	Coretree, Co, Ltd
++0:1f:fb	Green Packet Bhd
++0:1f:fc	Riccius+Sohn GmbH
+ 0:1:ff	Data Direct Networks, Inc.
+-0:1c:7c	PERQ SYSTEMS CORPORATION
++0:1f:fd	Indigo Mobile Technologies Corp.
++0:1f:fe	ProCurve Networking by HP
++0:1f:ff	Respironics, Inc.
++0:1f:f	Select Engineered Systems
+ 0:20:0	LEXMARK INTERNATIONAL, INC.
+-0:20:1	DSP SOLUTIONS, INC.
+ 0:20:10	JEOL SYSTEM TECHNOLOGY CO. LTD
+ 0:20:11	CANOPUS CO., LTD.
+ 0:20:12	CAMTRONICS MEDICAL SYSTEMS
+@@ -2858,9 +4620,9 @@
+ 0:20:1b	NORTHERN TELECOM/NETWORK
+ 0:20:1c	EXCEL, INC.
+ 0:20:1d	KATANA PRODUCTS
++0:20:1	DSP SOLUTIONS, INC.
+ 0:20:1e	NETQUEST CORPORATION
+ 0:20:1f	BEST POWER TECHNOLOGY, INC.
+-0:20:2	SERITECH ENTERPRISE CO., LTD.
+ 0:20:20	MEGATRON COMPUTER INDUSTRIES PTY, LTD.
+ 0:20:21	ALGORITHMS SOFTWARE PVT. LTD.
+ 0:20:22	NMS Communications
+@@ -2877,7 +4639,7 @@
+ 0:20:2d	TAIYO CORPORATION
+ 0:20:2e	DAYSTAR DIGITAL
+ 0:20:2f	ZETA COMMUNICATIONS, LTD.
+-0:20:3	PIXEL POWER LTD.
++0:20:2	SERITECH ENTERPRISE CO., LTD.
+ 0:20:30	ANALOG & DIGITAL SYSTEMS
+ 0:20:31	ERTEC GmbH
+ 0:20:32	ALCATEL TAISEL
+@@ -2891,10 +4653,10 @@
+ 0:20:3a	DIGITAL BI0METRICS INC.
+ 0:20:3b	WISDM LTD.
+ 0:20:3c	EUROTIME AB
+-0:20:3d	NOVAR ELECTRONICS CORPORATION
++0:20:3d	Honeywell ECC
+ 0:20:3e	LogiCan Technologies, Inc.
+ 0:20:3f	JUKI CORPORATION
+-0:20:4	YAMATAKE-HONEYWELL CO., LTD.
++0:20:3	PIXEL POWER LTD.
+ 0:20:40	Motorola Broadband Communications Sector
+ 0:20:41	DATA NET
+ 0:20:42	DATAMETRICS CORP.
+@@ -2911,12 +4673,12 @@
+ 0:20:4d	INOVIS GMBH
+ 0:20:4e	NETWORK SECURITY SYSTEMS, INC.
+ 0:20:4f	DEUTSCHE AEROSPACE AG
+-0:20:5	SIMPLE TECHNOLOGY
++0:20:4	YAMATAKE-HONEYWELL CO., LTD.
+ 0:20:50	KOREA COMPUTER INC.
+ 0:20:51	Verilink Corporation
+ 0:20:52	RAGULA SYSTEMS
+ 0:20:53	HUNTSVILLE MICROSYSTEMS, INC.
+-0:20:54	EASTERN RESEARCH, INC.
++0:20:54	Sycamore Networks
+ 0:20:55	ALTECH CO., LTD.
+ 0:20:56	NEOPRODUCTS
+ 0:20:57	TITZE DATENTECHNIK GmbH
+@@ -2928,9 +4690,9 @@
+ 0:20:5d	NANOMATIC OY
+ 0:20:5e	CASTLE ROCK, INC.
+ 0:20:5f	GAMMADATA COMPUTER GMBH
+-0:20:6	GARRETT COMMUNICATIONS, INC.
++0:20:5	SIMPLE TECHNOLOGY
+ 0:20:60	ALCATEL ITALIA S.p.A.
+-0:20:61	DYNATECH COMMUNICATIONS, INC.
++0:20:61	GarrettCom, Inc.
+ 0:20:62	SCORPION LOGIC, LTD.
+ 0:20:63	WIPRO INFOTECH LTD.
+ 0:20:64	PROTEC MICROSYSTEMS, INC.
+@@ -2945,7 +4707,7 @@
+ 0:20:6d	DATA RACE, INC.
+ 0:20:6e	XACT, INC.
+ 0:20:6f	FLOWPOINT CORPORATION
+-0:20:7	SFA, INC.
++0:20:6	GARRETT COMMUNICATIONS, INC.
+ 0:20:70	HYNET, LTD.
+ 0:20:71	IBR GMBH
+ 0:20:72	WORKLINK INNOVATIONS
+@@ -2962,7 +4724,7 @@
+ 0:20:7d	ADVANCED COMPUTER APPLICATIONS
+ 0:20:7e	FINECOM Co., Ltd.
+ 0:20:7f	KYOEI SANGYO CO., LTD.
+-0:20:8	CABLE & COMPUTER TECHNOLOGY
++0:20:7	SFA, INC.
+ 0:20:80	SYNERGY (UK) LTD.
+ 0:20:81	TITAN ELECTRONICS
+ 0:20:82	ONEAC CORPORATION
+@@ -2970,16 +4732,16 @@
+ 0:20:84	OCE PRINTING SYSTEMS, GMBH
+ 0:20:85	EXIDE ELECTRONICS
+ 0:20:86	MICROTECH ELECTRONICS LIMITED
+-0:20:87	MEMOTEC COMMUNICATIONS CORP.
++0:20:87	MEMOTEC, INC.
+ 0:20:88	GLOBAL VILLAGE COMMUNICATION
+ 0:20:89	T3PLUS NETWORKING, INC.
+ 0:20:8a	SONIX COMMUNICATIONS, LTD.
+ 0:20:8b	LAPIS TECHNOLOGIES, INC.
++0:20:8	CABLE & COMPUTER TECHNOLOGY
+ 0:20:8c	GALAXY NETWORKS, INC.
+ 0:20:8d	CMD TECHNOLOGY
+ 0:20:8e	CHEVIN SOFTWARE ENG. LTD.
+ 0:20:8f	ECI TELECOM LTD.
+-0:20:9	PACKARD BELL ELEC., INC.
+ 0:20:90	ADVANCED COMPRESSION TECHNOLOGY, INC.
+ 0:20:91	J125, NATIONAL SECURITY AGENCY
+ 0:20:92	CHESS ENGINEERING B.V.
+@@ -2996,14 +4758,14 @@
+ 0:20:9d	LIPPERT AUTOMATIONSTECHNIK
+ 0:20:9e	BROWN'S OPERATING SYSTEM SERVICES, LTD.
+ 0:20:9f	MERCURY COMPUTER SYSTEMS, INC.
+-0:20:a	SOURCE-COMM CORP.
++0:20:9	PACKARD BELL ELEC., INC.
+ 0:20:a0	OA LABORATORY CO., LTD.
+ 0:20:a1	DOVATRON
+ 0:20:a2	GALCOM NETWORKING LTD.
+ 0:20:a3	DIVICOM INC.
+ 0:20:a4	MULTIPOINT NETWORKS
+ 0:20:a5	API ENGINEERING
+-0:20:a6	PROXIM, INC.
++0:20:a6	Proxim Wireless
+ 0:20:a7	PAIRGAIN TECHNOLOGIES, INC.
+ 0:20:a8	SAST TECHNOLOGY CORP.
+ 0:20:a9	WHITE HORSE INDUSTRIAL
+@@ -3013,7 +4775,7 @@
+ 0:20:ad	LINQ SYSTEMS
+ 0:20:ae	ORNET DATA COMMUNICATION TECH.
+ 0:20:af	3COM CORPORATION
+-0:20:b	OCTAGON SYSTEMS CORP.
++0:20:a	SOURCE-COMM CORP.
+ 0:20:b0	GATEWAY DEVICES, INC.
+ 0:20:b1	COMTECH RESEARCH INC.
+ 0:20:b2	GKD Gesellschaft Fur Kommunikation Und Datentechnik
+@@ -3030,7 +4792,7 @@
+ 0:20:bd	NIOBRARA R & D CORPORATION
+ 0:20:be	LAN ACCESS CORP.
+ 0:20:bf	AEHR TEST SYSTEMS
+-0:20:c	ADASTRA SYSTEMS CORP.
++0:20:b	OCTAGON SYSTEMS CORP.
+ 0:20:c0	PULSE ELECTRONICS, INC.
+ 0:20:c1	SAXA, Inc.
+ 0:20:c2	TEXAS MEMORY SYSTEMS, INC.
+@@ -3041,13 +4803,13 @@
+ 0:20:c7	AKAI Professional M.I. Corp.
+ 0:20:c8	LARSCOM INCORPORATED
+ 0:20:c9	VICTRON BV
++0:20:c	ADASTRA SYSTEMS CORP.
+ 0:20:ca	DIGITAL OCEAN
+ 0:20:cb	PRETEC ELECTRONICS CORP.
+ 0:20:cc	DIGITAL SERVICES, LTD.
+ 0:20:cd	HYBRID NETWORKS, INC.
+ 0:20:ce	LOGICAL DESIGN GROUP, INC.
+ 0:20:cf	TEST & MEASUREMENT SYSTEMS INC
+-0:20:d	CARL ZEISS
+ 0:20:d0	VERSALYNX CORPORATION
+ 0:20:d1	MICROCOMPUTER SYSTEMS (M) SDN.
+ 0:20:d2	RAD DATA COMMUNICATIONS, LTD.
+@@ -3060,11 +4822,11 @@
+ 0:20:d9	PANASONIC TECHNOLOGIES, INC./MIECO-US
+ 0:20:da	Alcatel North America ESD
+ 0:20:db	XNET TECHNOLOGY, INC.
++0:20:d	CARL ZEISS
+ 0:20:dc	DENSITRON TAIWAN LTD.
+ 0:20:dd	Cybertec Pty Ltd
+ 0:20:de	JAPAN DIGITAL LABORAT'Y CO.LTD
+ 0:20:df	KYOSAN ELECTRIC MFG. CO., LTD.
+-0:20:e	SATELLITE TECHNOLOGY MGMT, INC
+ 0:20:e0	Actiontec Electronics, Inc.
+ 0:20:e1	ALAMAR ELECTRONICS
+ 0:20:e2	INFORMATION RESOURCE ENGINEERING
+@@ -3081,10 +4843,10 @@
+ 0:20:ed	GIGA-BYTE TECHNOLOGY CO., LTD.
+ 0:20:ee	GTECH CORPORATION
+ 0:20:ef	USC CORPORATION
+-0:20:f	TANBAC CO., LTD.
++0:20:e	SATELLITE TECHNOLOGY MGMT, INC
+ 0:20:f0	UNIVERSAL MICROELECTRONICS CO.
+ 0:20:f1	ALTOS INDIA LIMITED
+-0:20:f2	SUN MICROSYSTEMS, INC.
++0:20:f2	Oracle Corporation 
+ 0:20:f3	RAYNET CORPORATION
+ 0:20:f4	SPECTRIX CORPORATION
+ 0:20:f5	PANDATEL AG
+@@ -3098,128 +4860,1691 @@
+ 0:20:fd	ITV TECHNOLOGIES, INC.
+ 0:20:fe	TOPWARE INC. / GRAND COMPUTER
+ 0:20:ff	SYMMETRICAL TECHNOLOGIES
+-0:26:54	3Com Corporation
++0:20:f	TANBAC CO., LTD.
+ 0:2:0	Net & Sys Co., Ltd.
+-0:2:1	IFM Electronic gmbh
+ 0:2:10	Fenecom
++0:21:0	GemTek Technology Co., Ltd.
++0:21:10	Clearbox Systems
++0:21:11	Uniphone Inc.
++0:21:12	WISCOM SYSTEM CO.,LTD
++0:21:13	Padtec S/A
++0:21:14	Hylab Technology Inc.
++0:21:15	PHYWE Systeme GmbH & Co. KG
++0:21:16	Transcon Electronic Systems, spol. s r. o.
++0:21:17	Tellord
++0:21:18	Athena Tech, Inc.
++0:21:19	Samsung Electro-Mechanics
++0:21:1a	LInTech Corporation
++0:21:1	Aplicaciones Electronicas Quasar (AEQ)
++0:21:1b	Cisco Systems
++0:21:1c	Cisco Systems
++0:21:1d	Dataline AB
++0:21:1e	Motorola CHS
++0:21:1f	SHINSUNG DELTATECH CO.,LTD.
+ 0:2:11	Nature Worldwide Technology Corp.
++0:21:20	Sequel Technologies, LLC
++0:21:21	VRmagic GmbH
++0:21:22	Chip-pro Ltd.
++0:21:23	Aerosat Avionics
++0:21:24	Optos Plc
++0:21:25	KUK JE TONG SHIN Co.,LTD
++0:21:26	Shenzhen Torch Equipment Co., Ltd.
++0:21:27	TP-LINK Technology Co., Ltd.
++0:21:28	Oracle Corporation
++0:21:29	Cisco-Linksys, LLC
++0:21:2a	Audiovox Corporation
++0:21:2b	MSA Auer
++0:21:2c	SemIndia System Private Limited
++0:21:2d	SCIMOLEX CORPORATION
++0:21:2e	dresden-elektronik
++0:21:2f	Phoebe Micro Inc.
+ 0:2:12	SierraCom
++0:21:2	UpdateLogic Inc.
++0:21:30	Keico Hightech Inc.
++0:21:31	Blynke Inc.
++0:21:32	Masterclock, Inc.
++0:21:33	Building B, Inc
++0:21:34	Brandywine Communications
++0:21:35	ALCATEL-LUCENT
++0:21:36	Motorola Mobile Devices business (MDb)
++0:21:37	Bay Controls, LLC
++0:21:38	Cepheid
++0:21:39	Escherlogic Inc.
++0:21:3a	Winchester Systems Inc.
++0:21:3b	Berkshire Products, Inc
++0:21:3c	AliphCom
++0:21:3d	Cermetek Microelectronics, Inc.
++0:21:3e	TomTom
++0:21:3f	A-Team Technology Ltd.
++0:21:3	GHI Electronics, LLC
+ 0:2:13	S.D.E.L.
++0:21:40	EN Technologies Inc.
++0:21:41	RADLIVE
++0:21:42	Advanced Control Systems doo
++0:21:43	Motorola CHS
++0:21:44	SS Telecoms
++0:21:45	Semptian Technologies Ltd.
++0:21:46	SCI Technology
++0:21:47	Nintendo Co., Ltd.
++0:21:48	Kaco Solar Korea
++0:21:49	China Daheng Group ,Inc.
++0:21:4a	Pixel Velocity, Inc
++0:21:4b	Shenzhen HAMP Science & Technology Co.,Ltd
++0:21:4c	SAMSUNG ELECTRONICS CO., LTD.
++0:21:4d	Guangzhou Skytone Transmission Technology Com. Ltd.
+ 0:2:14	DTVRO
++0:21:4e	GS Yuasa Power Supply Ltd.
++0:21:4f	ALPS Electric Co., Ltd
++0:21:4	Gigaset Communications GmbH
++0:21:50	EYEVIEW ELECTRONICS
++0:21:51	Millinet Co., Ltd.
++0:21:52	General Satellite Trading Limited
++0:21:53	SeaMicro Inc.
++0:21:54	D-TACQ Solutions Ltd
++0:21:55	Cisco Systems
++0:21:56	Cisco Systems
++0:21:57	National Datacast, Inc.
++0:21:58	Style Flying Technology Co.
++0:21:59	Juniper Networks
++0:21:5a	Hewlett Packard
++0:21:5	Alcatel-Lucent
++0:21:5b	Inotive
++0:21:5c	Intel Corporate
+ 0:2:15	Cotas Computer Technology A/B
++0:21:5d	Intel Corporate
++0:21:5e	IBM
++0:21:5f	IHSE GmbH
++0:21:60	Hidea Solutions Co. Ltd.
++0:21:61	Yournet Inc.
++0:21:62	Nortel
++0:21:63	ASKEY COMPUTER CORP
++0:21:64	Special Design Bureau for Seismic Instrumentation
++0:21:65	Presstek Inc.
++0:21:66	NovAtel Inc.
++0:21:67	HWA JIN T&I Corp.
++0:21:68	iVeia, LLC
++0:21:69	Prologix, LLC.
++0:21:6a	Intel Corporate
++0:21:6b	Intel Corporate
+ 0:2:16	Cisco Systems, Inc.
++0:21:6c	ODVA
++0:21:6d	Soltech Co., Ltd.
++0:21:6e	Function ATI (Huizhou) Telecommunications Co., Ltd.
++0:21:6f	SymCom, Inc.
++0:21:6	RIM Testing Services
++0:21:70	Dell Inc
++0:21:71	Wesung TNC Co., Ltd.
++0:21:72	Seoultek Valley
++0:21:73	Ion Torrent Systems, Inc.
++0:21:74	AvaLAN Wireless
++0:21:75	Pacific Satellite International Ltd.
++0:21:76	YMax Telecom Ltd.
++0:21:77	W. L. Gore & Associates
++0:21:78	Matuschek Messtechnik GmbH
++0:21:79	IOGEAR, Inc.
++0:21:7a	Sejin Electron, Inc.
++0:21:7b	Bastec AB
++0:21:7c	2Wire
+ 0:2:17	Cisco Systems, Inc.
++0:21:7d	PYXIS S.R.L.
++0:21:7e	Telit Communication s.p.a
++0:21:7f	Intraco Technology Pte Ltd
++0:21:7	Seowonintech Co Ltd.
++0:21:80	Motorola CHS
++0:21:81	Si2 Microsystems Limited
++0:21:82	SandLinks Systems, Ltd.
++0:21:83	VATECH HYDRO
++0:21:84	POWERSOFT SRL
++0:21:85	MICRO-STAR INT'L CO.,LTD.
++0:21:86	USI
++0:21:87	Imacs GmbH
++0:21:88	Data Domain, Inc.
++0:21:89	AppTech, Inc.
+ 0:2:18	Advanced Scientific Corp
++0:21:8a	Electronic Design and Manufacturing Company
++0:21:8b	Wescon Technology, Inc.
++0:21:8c	TopControl GMBH
++0:21:8d	AP Router Ind. Eletronica LTDA
++0:21:8e	MEKICS CO., LTD.
++0:21:8f	Avantgarde Acoustic Lautsprechersysteme GmbH
++0:21:8	Nokia Danmark A/S
++0:21:90	Goliath Solutions
++0:21:91	D-Link Corporation
++0:21:92	Baoding Galaxy Electronic Technology  Co.,Ltd
++0:21:93	Videofon MV
++0:21:94	Ping Communication
++0:21:95	GWD Media Limited
++0:21:96	Telsey  S.p.A.
++0:21:97	ELITEGROUP COMPUTER SYSTEM
++0:21:98	Thai Radio Co, LTD
++0:21:99	Vacon Plc
++0:21:9a	Cambridge Visual Networks Ltd
++0:21:9b	Dell Inc
++0:21:9c	Honeywld Technology Corp.
++0:21:9d	Adesys BV
++0:21:9e	Sony Ericsson Mobile Communications
++0:21:9f	SATEL OY
++0:21:9	Nokia Danmark A/S
+ 0:2:19	Paralon Technologies
++0:21:a0	Cisco Systems
++0:21:a1	Cisco Systems
++0:21:a2	EKE-Electronics Ltd.
++0:21:a3	Micromint
++0:21:a4	Dbii Networks
++0:21:a5	ERLPhase Power Technologies Ltd.
++0:21:a6	Videotec Spa
++0:21:a7	Hantle System Co., Ltd.
++0:21:a8	Telephonics Corporation
++0:21:a9	Mobilink Telecom Co.,Ltd
++0:21:aa	Nokia Danmark A/S
++0:21:ab	Nokia Danmark A/S
++0:21:a	byd:sign Corporation
++0:21:ac	Infrared Integrated Systems Ltd
++0:21:ad	Nordic ID Oy
++0:21:ae	ALCATEL-LUCENT FRANCE - WTD
++0:21:af	Radio Frequency Systems
+ 0:2:1a	Zuma Networks
++0:21:b0	Tyco Telecommunications
++0:21:b1	DIGITAL SOLUTIONS LTD
++0:21:b2	Fiberblaze A/S
++0:21:b3	Ross Controls
++0:21:b4	APRO MEDIA CO., LTD
++0:21:b5	Vyro Games Limited
++0:21:b6	Triacta Power Technologies Inc.
++0:21:b7	Lexmark International Inc.
++0:21:b8	Inphi Corporation
++0:21:b9	Universal Devices Inc.
++0:21:ba	Texas Instruments
++0:21:bb	Riken Keiki Co., Ltd.
++0:21:bc	ZALA COMPUTER
++0:21:bd	Nintendo Co., Ltd.
++0:21:be	Cisco, Service Provider Video Technology Group
++0:21:bf	Hitachi High-Tech Control Systems Corporation
++0:21:b	GEMINI TRAZE RFID PVT. LTD.
+ 0:2:1b	Kollmorgen-Servotronix
++0:21:c0	Mobile Appliance, Inc.
++0:21:c1	ABB Oy / Distribution Automation
++0:21:c2	GL Communications Inc
++0:21:c3	CORNELL Communications, Inc.
++0:21:c4	Consilium AB
++0:21:c5	3DSP Corp
++0:21:c6	CSJ Global, Inc.
++0:21:c7	Russound
++0:21:c8	LOHUIS Networks
++0:21:c9	Wavecom Asia Pacific Limited
++0:21:ca	ART System Co., Ltd.
++0:21:cb	SMS TECNOLOGIA ELETRONICA LTDA
++0:21:cc	Flextronics International
++0:21:c	Cymtec Systems, Inc.
++0:21:cd	LiveTV
++0:21:ce	NTC-Metrotek
++0:21:cf	The Crypto Group
+ 0:2:1c	Network Elements, Inc.
++0:21:d0	Global Display Solutions Spa
++0:21:d1	Samsung Electronics Co.,Ltd
++0:21:d2	Samsung Electronics Co.,Ltd
++0:21:d3	BOCOM SECURITY(ASIA PACIFIC) LIMITED
++0:21:d4	Vollmer Werke GmbH
++0:21:d5	X2E GmbH
++0:21:d6	LXI Consortium
++0:21:d7	Cisco Systems
++0:21:d8	Cisco Systems
++0:21:d9	SEKONIC CORPORATION
++0:21:da	Automation Products Group Inc.
++0:21:db	Santachi Video Technology (Shenzhen) Co., Ltd.
++0:21:dc	TECNOALARM S.r.l.
+ 0:2:1d	Data General Communication Ltd.
++0:21:dd	Northstar Systems Corp
++0:21:de	Firepro Wireless
++0:21:df	Martin Christ GmbH
++0:21:d	SAMSIN INNOTEC
++0:21:e0	CommAgility Ltd
++0:21:e1	Nortel Networks
++0:21:e2	Creative Electronic GmbH
++0:21:e3	SerialTek LLC
++0:21:e4	I-WIN
++0:21:e5	Display Solution AG
++0:21:e6	Starlight Video Limited
++0:21:e7	Informatics Services Corporation
++0:21:e8	Murata Manufacturing Co., Ltd.
++0:21:e9	Apple, Inc
++0:21:ea	Bystronic Laser AG
++0:21:eb	ESP SYSTEMS, LLC
++0:21:ec	Solutronic GmbH
++0:21:ed	Telegesis
++0:21:ee	Full Spectrum Inc.
++0:21:ef	Kapsys
++0:21:e	Orpak Systems L.T.D.
+ 0:2:1e	SIMTEL S.R.L.
++0:21:f0	EW3 Technologies LLC
++0:21:f1	Tutus Data AB
++0:21:f2	EASY3CALL Technology Limited
++0:21:f3	Si14 SpA
++0:21:f4	INRange Systems, Inc
++0:21:f5	Western Engravers Supply, Inc.
++0:21:f6	Virtual Iron Software
++0:21:f7	ProCurve Networking by HP
++0:21:f8	Enseo, Inc.
++0:21:f9	WIRECOM Technologies
++0:21:fa	A4SP Technologies Ltd.
+ 0:2:1f	Aculab PLC
+-0:2:2	Amino Communications, Ltd.
++0:21:fb	LG Electronics
++0:21:f	Cernium Corp
++0:21:fc	Nokia Danmark A/S
++0:21:fd	DSTA S.L.
++0:21:fe	Nokia Danmark A/S
++0:21:ff	Cyfrowy Polsat SA
++0:2:1	IFM Electronic gmbh
++0:22:0	BLADE Network Technology
+ 0:2:20	Canon Aptex, Inc.
++0:22:10	Motorola CHS
++0:22:11	Rohati Systems
++0:22:12	CAI Networks, Inc.
++0:22:13	PCI CORPORATION
++0:22:14	RINNAI KOREA
++0:22:15	ASUSTek COMPUTER INC.
++0:22:16	SHIBAURA VENDING MACHINE CORPORATION
++0:22:17	Neat Electronics
++0:22:18	Verivue Inc.
++0:22:19	Dell Inc
++0:22:1a	Audio Precision
++0:22:1	Aksys Networks Inc
++0:22:1b	Morega Systems
++0:22:1c	PRIVATE
++0:22:1d	Freegene Technology LTD
+ 0:2:21	DSP Application, Ltd.
++0:22:1e	Media Devices Co., Ltd.
++0:22:1f	eSang Technologies Co., Ltd.
++0:22:20	Mitac Technology Corp
++0:22:21	ITOH DENKI CO,LTD.
++0:22:22	Schaffner Deutschland GmbH 
++0:22:23	TimeKeeping Systems, Inc.
++0:22:24	Good Will Instrument Co., Ltd.
++0:22:25	Thales Avionics Ltd
++0:22:26	Avaak, Inc.
++0:22:27	uv-electronic GmbH
++0:22:28	Breeze Innovations Ltd.
++0:22:29	Compumedics Ltd
++0:22:2a	SoundEar A/S
++0:22:2b	Nucomm, Inc.
++0:22:2c	Ceton Corp
+ 0:2:22	Chromisys, Inc.
++0:22:2d	SMC Networks Inc.
++0:22:2e	maintech GmbH
++0:22:2	Excito Elektronik i Sk
++0:22:2f	Open Grid Computing, Inc.
++0:22:30	FutureLogic Inc.
++0:22:31	SMT&C Co., Ltd.
++0:22:32	Design Design Technology Ltd
++0:22:33	Pirelli Broadband Solutions
++0:22:34	Corventis Inc.
++0:22:35	Strukton Systems bv
++0:22:36	VECTOR SP. Z O.O.
++0:22:37	Shinhint Group
++0:22:38	LOGIPLUS
++0:22:39	Indiana Life Sciences Incorporated
++0:22:3a	Scientific Atlanta, Cisco SPVT Group
++0:22:3b	Communication Networks, LLC
+ 0:2:23	ClickTV
++0:22:3c	RATIO Entwicklungen GmbH
++0:22:3d	JumpGen Systems, LLC
++0:22:3e	IRTrans GmbH
++0:22:3f	Netgear Inc.
++0:22:3	Glensound Electronics Ltd
++0:22:40	Universal Telecom S/A
++0:22:41	Apple, Inc
++0:22:42	Alacron Inc.
++0:22:43	AzureWave Technologies, Inc.
++0:22:44	Chengdu Linkon Communications Device Co., Ltd
++0:22:45	Leine & Linde AB
++0:22:46	Evoc Intelligent Technology Co.,Ltd.
++0:22:47	DAC ENGINEERING CO., LTD.
++0:22:48	Microsoft Corporation
++0:22:49	HOME MULTIENERGY SL
++0:22:4a	RAYLASE AG
++0:22:4b	AIRTECH TECHNOLOGIES, INC.
+ 0:2:24	C-COR
+-0:2:25	Certus Technology, Inc.
++0:22:4c	Nintendo Co., Ltd.
++0:22:4d	MITAC INTERNATIONAL CORP.
++0:22:4e	SEEnergy Corp.
++0:22:4f	Byzoro Networks Ltd.
++0:22:4	KORATEK
++0:22:50	Point Six Wireless, LLC
++0:22:51	Lumasense Technologies
++0:22:52	ZOLL Lifecor Corporation
++0:22:53	Entorian Technologies
++0:22:54	Bigelow Aerospace
++0:22:55	Cisco Systems
++0:22:56	Cisco Systems
++0:22:57	3Com Europe Ltd
++0:22:58	Taiyo Yuden Co., Ltd.
++0:22:59	Guangzhou New Postcom Equipment Co.,Ltd.
++0:22:5a	Garde Security AB
++0:22:5b	Teradici Corporation
++0:22:5c	Multimedia & Communication Technology
++0:22:5d	Digicable Network India Pvt. Ltd.
++0:22:5e	Uwin Technologies Co.,LTD
++0:22:5f	Liteon Technology Corporation
++0:2:25	One Stop Systems
++0:22:5	WeLink Solutions, Inc.
++0:22:60	AFREEY Inc.
++0:22:61	Frontier Silicon Ltd
++0:22:62	BEP Marine
++0:22:63	Koos Technical Services, Inc.
++0:22:64	Hewlett Packard
++0:22:65	Nokia Danmark A/S
++0:22:66	Nokia Danmark A/S
++0:22:67	Nortel Networks
++0:22:68	Hon Hai Precision Ind. Co., Ltd.
++0:22:69	Hon Hai Precision Ind. Co., Ltd.
++0:22:6a	Honeywell
++0:22:6b	Cisco-Linksys, LLC
++0:22:6c	LinkSprite Technologies, Inc.
++0:22:6	Cyberdyne Inc.
++0:22:6d	Shenzhen GIEC Electronics Co., Ltd.
++0:22:6e	Gowell Electronic Limited
++0:22:6f	3onedata Technology Co. Ltd.
+ 0:2:26	XESystems, Inc.
+-0:2:27	ESD GmbH
++0:22:70	ABK North America, LLC
++0:22:71	J
++0:22:72	American Micro-Fuel Device Corp.
++0:22:73	Techway
++0:22:74	FamilyPhone AB
++0:22:75	Belkin International, Inc.
++0:22:76	Triple EYE B.V.
++0:22:77	NEC Australia Pty Ltd
++0:22:78	Shenzhen  Tongfang Multimedia  Technology Co.,Ltd.
++0:22:79	Nippon Conlux Co., Ltd.
++0:22:7a	Telecom Design
++0:22:7b	Apogee Labs, Inc.
++0:22:7c	Woori SMT Co.,ltd
++0:22:7d	YE DATA INC.
++0:22:7e	Chengdu 30Kaitian Communication Industry Co.Ltd
++0:2:27	ESD Electronic System Design GmbH
++0:22:7f	Ruckus Wireless
++0:22:7	Inteno Broadband Technology AB
++0:22:80	A2B Electronics AB
++0:22:81	Daintree Networks Inc
++0:22:82	8086 Limited
++0:22:83	Juniper Networks
++0:22:84	DESAY A&V SCIENCE AND TECHNOLOGY CO.,LTD
++0:22:85	NOMUS COMM SYSTEMS
++0:22:86	ASTRON
++0:22:87	Titan Wireless LLC
++0:22:88	Sagrad, Inc.
++0:22:89	Optosecurity Inc.
++0:22:8a	Teratronik elektronische systeme gmbh
++0:22:8b	Kensington Computer Products Group
++0:22:8	Certicom Corp
++0:22:8c	Photon Europe GmbH
++0:22:8d	GBS Laboratories LLC
++0:22:8e	TV-NUMERIC
++0:22:8f	CNRS
+ 0:2:28	Necsom, Ltd.
++0:22:90	Cisco Systems
++0:22:91	Cisco Systems
++0:22:92	Cinetal
++0:22:93	ZTE Corporation
++0:22:94	Kyocera Corporation
++0:22:95	SGM Technology for lighting spa
++0:22:96	LinoWave Corporation
++0:22:97	XMOS Semiconductor
++0:22:98	Sony Ericsson Mobile Communications
++0:22:99	SeaMicro Inc.
+ 0:2:29	Adtec Corporation
++0:22:9a	Lastar, Inc.
++0:22:9b	AverLogic Technologies, Inc.
++0:22:9c	Verismo Networks Inc
++0:22:9d	PYUNG-HWA IND.CO.,LTD
++0:22:9e	Social Aid Research Co., Ltd.
++0:22:9f	Sensys Traffic AB
++0:22:9	Omron Healthcare Co., Ltd
++0:22:a0	Delphi Corporation
++0:22:a1	Huawei Symantec Technologies Co.,Ltd.
++0:22:a2	Xtramus Technologies
++0:22:a3	California Eastern Laboratories
++0:22:a4	2Wire
++0:22:a5	Texas Instruments
++0:22:a6	Sony Computer Entertainment America
++0:22:a7	Tyco Electronics AMP GmbH
++0:22:a8	Ouman Finland Oy
++0:22:a9	LG Electronics Inc
++0:22:aa	Nintendo Co., Ltd.
+ 0:2:2a	Asound Electronic
++0:22:ab	Shenzhen Turbosight Technology Ltd
++0:22:ac	Hangzhou Siyuan Tech. Co., Ltd
++0:22:ad	TELESIS TECHNOLOGIES, INC.
++0:22:ae	Mattel Inc.
++0:22:af	Safety Vision
++0:2:2	Amino Communications, Ltd.
++0:22:a	OnLive, Inc
++0:22:b0	D-Link Corporation
++0:22:b1	Elbit Systems
++0:22:b2	4RF Communications Ltd
++0:22:b3	Sei S.p.A.
++0:22:b4	Motorola Mobile Devices
++0:22:b5	NOVITA
++0:22:b6	Superflow Technologies Group
++0:22:b7	GSS Grundig SAT-Systems GmbH
++0:22:b8	Norcott
++0:22:b9	Analogix Seminconductor, Inc
++0:22:ba	HUTH Elektronik Systeme GmbH
++0:22:bb	beyerdynamic GmbH & Co. KG
++0:22:bc	JDSU France SAS
++0:22:bd	Cisco Systems
++0:22:be	Cisco Systems
++0:22:bf	SieAmp Group of Companies
++0:22:b	National Source Coding Center
+ 0:2:2b	SAXA, Inc.
++0:22:c0	Shenzhen Forcelink Electronic Co, Ltd
++0:22:c1	Active Storage Inc.
++0:22:c2	Proview Eletronica do Brasil LTDA
++0:22:c3	Zeeport Technology Inc.
++0:22:c4	epro GmbH
++0:22:c5	INFORSON Co,Ltd.
++0:22:c6	Sutus Inc
++0:22:c7	SEGGER Microcontroller GmbH & Co. KG
++0:22:c8	Applied Instruments
++0:22:c9	Lenord, Bauer & Co GmbH
++0:22:ca	Anviz Biometric Tech. Co., Ltd.
+ 0:2:2c	ABB Bomem, Inc.
++0:22:cb	IONODES Inc.
++0:22:c	Cisco Systems
++0:22:cc	SciLog, Inc.
++0:22:cd	Ared Technology Co., Ltd.
++0:22:ce	Cisco, Service Provider Video Technology Group
++0:22:cf	PLANEX Communications INC
++0:22:d0	Polar Electro Oy
++0:22:d1	Albrecht Jung GmbH & Co. KG
++0:22:d2	All Earth Com
++0:22:d3	Hub-Tech
++0:22:d4	ComWorth Co., Ltd.
++0:22:d5	Eaton Corp. Electrical Group Data Center Solutions - Pulizzi
++0:22:d6	Cypak AB
++0:22:d7	Nintendo Co., Ltd.
++0:22:d8	Shenzhen GST Security and Safety Technology Limited
++0:22:d9	Fortex Industrial Ltd.
++0:22:da	ANATEK, LLC
+ 0:2:2d	Agere Systems
++0:22:db	Translogic Corporation
++0:22:d	Cisco Systems
++0:22:dc	Vigil Health Solutions Inc.
++0:22:dd	Protecta Electronics Ltd
++0:22:de	OPPO Digital, Inc.
++0:22:df	TAMUZ Monitors
++0:22:e0	Atlantic Software Technologies S.r.L.
++0:22:e1	ZORT Labs, LLC.
++0:22:e2	WABTEC Transit Division
++0:22:e3	Amerigon
++0:22:e4	APASS TECHNOLOGY CO., LTD.
++0:22:e5	Fisher-Rosemount Systems Inc.
++0:22:e6	Intelligent Data
++0:22:e7	WPS Parking Systems
++0:22:e8	Applition Co., Ltd.
++0:22:e9	ProVision Communications
++0:22:ea	Rustelcom Inc.
++0:22:eb	Data Respons A/S
++0:22:ec	IDEALBT TECHNOLOGY CORPORATION
++0:22:ed	TSI Power Corporation
++0:22:ee	Algo Communication Products Ltd
++0:22:ef	Ibis Tek, LLC
++0:22:e	Indigo Security Co., Ltd.
+ 0:2:2e	TEAC Corp. R& D
++0:22:f0	3 Greens Aviation Limited
++0:22:f1	PRIVATE
++0:22:f2	SunPower Corp
++0:22:f3	SHARP CORPORATION
++0:22:f4	AMPAK Technology, Inc.
++0:22:f5	Advanced Realtime Tracking GmbH
++0:22:f6	Syracuse Research Corporation
++0:22:f7	Conceptronic
++0:22:f8	PIMA Electronic Systems Ltd.
++0:22:f9	Pollin Electronic GmbH
++0:22:fa	Intel Corporate
++0:22:fb	Intel Corporate
++0:22:fc	Nokia Danmark A/S
++0:22:fd	Nokia Danmark A/S
++0:22:fe	Microprocessor Designs Inc
++0:22:ff	NIVIS LLC
++0:22:f	MoCA (Multimedia over Coax Alliance)
+ 0:2:2f	P-Cube, Ltd.
+-0:2:3	Woonsang Telecom, Inc.
++0:23:0	Cayee Computer Ltd.
+ 0:2:30	Intersoft Electronics
++0:23:10	LNC Technology Co., Ltd.
++0:23:11	Gloscom Co., Ltd.
++0:23:12	Apple, Inc
++0:23:13	Qool Technologies Ltd.
++0:23:14	Intel Corporate
++0:23:15	Intel Corporate
++0:23:16	KISAN ELECTRONICS CO
++0:23:17	Lasercraft Inc
++0:23:18	Toshiba
++0:23:19	Sielox LLC
++0:23:1a	ITF Co., Ltd.
++0:23:1b	Danaher Motion - Kollmorgen
++0:23:1c	Fourier Systems Ltd.
++0:23:1d	Deltacom Electronics Ltd
++0:23:1e	Cezzer Multimedia Technologies
++0:23:1f	Guangda Electronic & Telecommunication Technology Development Co., Ltd.
+ 0:2:31	Ingersoll-Rand
++0:23:1	Witron Technology Limited
++0:23:20	Nicira Networks
++0:23:21	Avitech International Corp
++0:23:22	KISS Teknical Solutions, Inc.
++0:23:23	Zylin AS
++0:23:24	G-PRO COMPUTER
++0:23:25	IOLAN Holding
++0:23:26	Fujitsu Limited
++0:23:27	Shouyo Electronics CO., LTD
++0:23:28	ALCON TELECOMMUNICATIONS CO., LTD.
++0:23:29	DDRdrive LLC
++0:23:2a	eonas IT-Beratung und -Entwicklung GmbH
+ 0:2:32	Avision, Inc.
++0:23:2b	IRD A/S
++0:23:2	Cobalt Digital, Inc.
++0:23:2c	Senticare
++0:23:2d	SandForce
++0:23:2e	Kedah Electronics Engineering, LLC
++0:23:2f	Advanced Card Systems Ltd.
++0:23:30	DIZIPIA, INC.
++0:23:31	Nintendo Co., Ltd.
++0:23:32	Apple, Inc
++0:23:33	Cisco Systems
++0:23:34	Cisco Systems
++0:23:35	Linkflex Co.,Ltd
++0:23:36	METEL s.r.o.
++0:23:37	Global Star Solutions ULC
++0:23:38	OJ-Electronics A/S
++0:23:39	Samsung Electronics
++0:23:3a	Samsung Electronics Co.,Ltd
++0:23:3b	C-Matic Systems Ltd
++0:23:3c	Alflex
++0:23:3d	novero GmbH
++0:23:3e	Alcatel-Lucent-IPD
++0:23:3f	Purechoice Inc
++0:23:3	LITE-ON IT Corporation
+ 0:2:33	Mantra Communications, Inc.
++0:23:40	MiX Telematics
++0:23:41	Siemens Building Technologies Fire & Security Products GmbH & Co. oHG
++0:23:42	Coffee Equipment Company
++0:23:43	TEM AG
++0:23:44	Objective Interface Systems
++0:23:45	Sony Ericsson Mobile Communications
++0:23:46	Vestac
++0:23:47	ProCurve Networking by HP
++0:23:48	SAGEM COMMUNICATION
++0:23:49	Helmholtz Centre Berlin for Material and Energy
++0:23:4a	PRIVATE
++0:23:4b	Inyuan Technology Inc.
++0:23:4	Cisco Systems
++0:23:4c	KTC AB
++0:23:4d	Hon Hai Precision Ind. Co., Ltd.
++0:23:4e	Hon Hai Precision Ind. Co., Ltd.
++0:23:4f	Luminous Power Technologies Pvt. Ltd.
+ 0:2:34	Imperial Technology, Inc.
++0:23:50	LynTec
++0:23:51	2Wire
++0:23:52	DATASENSOR S.p.A.
++0:23:53	F E T Elettronica snc
++0:23:54	ASUSTek COMPUTER INC.
++0:23:55	Kinco Automation(Shanghai) Ltd.
++0:23:56	Packet Forensics LLC
++0:23:57	Pitronot Technologies and Engineering P.T.E. Ltd.
++0:23:58	SYSTEL SA
++0:23:59	Benchmark Electronics ( Thailand ) Public Company Limited
++0:23:5a	COMPAL INFORMATION (KUNSHAN) CO., Ltd.
++0:23:5b	Gulfstream
++0:23:5c	Aprius, Inc.
++0:23:5	Cisco Systems
++0:23:5d	Cisco Systems
++0:23:5e	Cisco Systems
++0:23:5f	Silicon Micro Sensors GmbH
+ 0:2:35	Paragon Networks International
++0:23:60	Lookit Technology Co., Ltd
++0:23:61	Unigen Corporation
++0:23:62	Goldline Controls
++0:23:63	Zhuhai RaySharp Technology Co., Ltd.
++0:23:64	Power Instruments Pte Ltd
++0:23:65	ELKA-Elektronik GmbH
++0:23:66	Beijing Siasun Electronic System Co.,Ltd.
++0:23:67	UniControls a.s.
++0:23:68	Motorola
++0:23:69	Cisco-Linksys, LLC
++0:23:6a	ClearAccess, Inc.
++0:23:6	ALPS Electric Co., Ltd
++0:23:6b	Xembedded, Inc.
++0:23:6c	Apple, Inc
++0:23:6d	ResMed Ltd
++0:23:6e	Burster GmbH & Co KG
++0:23:6f	DAQ System
+ 0:2:36	INIT GmbH
++0:23:70	PRO-BEL LIMITED
++0:23:71	SOAM Systel
++0:23:72	MORE STAR INDUSTRIAL GROUP LIMITED
++0:23:73	GridIron Systems, Inc.
++0:23:74	Motorola CHS
++0:23:75	Motorola CHS
++0:23:76	HTC Corporation
++0:23:77	Isotek Electronics Ltd
++0:23:78	GN Netcom A/S
++0:23:79	Union Business Machines Co. Ltd.
++0:23:7a	RIM
++0:23:7b	WHDI LLC
++0:23:7c	NEOTION
+ 0:2:37	Cosmo Research Corp.
++0:23:7d	Hewlett Packard
++0:23:7e	ELSTER GMBH
++0:23:7f	PLANTRONICS
++0:23:7	FUTURE INNOVATION TECH CO.,LTD
++0:23:80	Nanoteq
++0:23:81	Lengda Technology(Xiamen) Co.,Ltd.
++0:23:82	Lih Rong Electronic Enterprise Co., Ltd.
++0:23:83	InMage Systems Inc
++0:23:84	GGH Engineering s.r.l.
++0:23:85	ANTIPODE
++0:23:86	Tour & Andersson AB
++0:23:87	ThinkFlood, Inc.
++0:23:88	V.T. Telematica S.p.a.
++0:23:89	HANGZHOU H3C Technologies Co., Ltd.
++0:23:8a	Ciena Corporation
++0:23:8	Arcadyan Technology Corporation
++0:23:8b	Quanta Computer Inc.
++0:23:8c	PRIVATE
++0:23:8d	Techno Design Co., Ltd.
++0:23:8e	PIRELLI BROADBAND SOLUTIONS
++0:23:8f	NIDEC COPAL CORPORATION
+ 0:2:38	Serome Technology, Inc.
++0:23:90	Algolware Corporation
++0:23:91	Maxian
++0:23:92	Proteus Industries Inc.
++0:23:93	AJINEXTEK
++0:23:94	Samjeon
++0:23:95	Motorola CHS
++0:23:96	ANDES TECHNOLOGY CORPORATION
++0:23:97	Westell Technologies Inc.
++0:23:98	Sky Control
++0:23:99	VD Division, Samsung Electronics Co.
++0:23:9a	EasyData Software GmbH
++0:23:9b	Elster Solutions, LLC
++0:23:9c	Juniper Networks
++0:23:9d	Mapower Electronics Co., Ltd
++0:23:9e	Jiangsu Lemote Technology Corporation Limited
++0:23:9f	Institut f
++0:23:9	Janam Technologies LLC
+ 0:2:39	Visicom
++0:23:a0	Hana CNS Co., LTD.
++0:23:a1	Trend Electronics Ltd
++0:23:a2	Motorola CHS
++0:23:a3	Motorola CHS
++0:23:a4	New Concepts Development Corp.
++0:23:a5	SageTV, LLC
++0:23:a6	E-Mon
++0:23:a7	Redpine Signals, Inc.
++0:23:a8	Marshall Electronics
++0:23:a9	Beijing Detianquan Electromechanical Equipment Co., Ltd
++0:23:aa	HFR, Inc.
++0:23:a	ARBURG GmbH & Co KG
++0:23:ab	Cisco Systems
++0:23:ac	Cisco Systems
++0:23:ad	Xmark Corporation
++0:23:ae	Dell Inc.
++0:23:af	Motorola Mobile Devices
+ 0:2:3a	ZSK Stickmaschinen GmbH
++0:23:b0	COMXION Technology Inc.
++0:23:b1	Longcheer Technology (Singapore) Pte Ltd
++0:23:b2	Intelligent Mechatronic Systems Inc
++0:23:b3	Lyyn AB
++0:23:b4	Nokia Danmark A/S
++0:23:b5	ORTANA LTD
++0:23:b6	SECURITE COMMUNICATIONS / HONEYWELL
++0:23:b7	Q-Light Co., Ltd.
++0:23:b8	Sichuan Jiuzhou Electronic Technology Co.,Ltd
++0:23:b9	EADS Deutschland GmbH
++0:23:ba	Chroma
++0:23:bb	Schmitt Industries
++0:23:bc	EQ-SYS GmbH
++0:23:bd	Digital Ally, Inc.
++0:23:be	Cisco SPVTG
++0:23:bf	Mainpine, Inc.
++0:23:b	Motorola CHS
+ 0:2:3b	Redback Networks
++0:23:c0	Broadway Networks
++0:23:c1	Securitas Direct AB
++0:23:c2	SAMSUNG Electronics. Co. LTD
++0:23:c3	LogMeIn, Inc.
++0:23:c4	Lux Lumen
++0:23:c5	Radiation Safety and Control Services Inc
++0:23:c6	SMC Corporation
++0:23:c7	AVSystem
++0:23:c8	TEAM-R
++0:23:c9	Sichuan Tianyi Information Science & Technology Stock CO.,LTD
++0:23:ca	Behind The Set, LLC
++0:23:cb	Shenzhen Full-join Technology Co.,Ltd
++0:23:c	CLOVER ELECTRONICS CO.,LTD.
++0:23:cc	Nintendo Co., Ltd.
+ 0:2:3c	Creative Technology, Ltd.
+-0:2:3d	NuSpeed, Inc.
++0:23:cd	TP-LINK TECHNOLOGIES CO., LTD.
++0:23:ce	KITA DENSHI CORPORATION
++0:23:cf	CUMMINS-ALLISON CORP.
++0:23:d0	Uniloc USA Inc.
++0:23:d1	TRG
++0:23:d2	Inhand Electronics, Inc.
++0:23:d3	AirLink WiFi Networking Corp.
++0:23:d4	Texas Instruments
++0:23:d5	WAREMA electronic GmbH
++0:23:d6	Samsung Electronics Co.,LTD
++0:23:d7	Samsung Electronics
++0:23:d8	Ball-It Oy
++0:23:d9	Banner Engineering
++0:23:da	Industrial Computer Source (Deutschland)GmbH
++0:23:db	saxnet gmbh
++0:23:dc	Benein, Inc
++0:2:3d	Cisco Systems, Inc.
++0:23:dd	ELGIN S.A.
++0:23:de	Ansync Inc.
++0:23:df	Apple, Inc
++0:23:d	Nortel Networks
++0:23:e0	INO Therapeutics LLC
++0:23:e1	Cavena Image Products AB
++0:23:e2	SEA Signalisation
++0:23:e3	Microtronic AG
++0:23:e4	IPnect co. ltd.
++0:23:e5	IPaXiom Networks
++0:23:e6	Pirkus, Inc.
++0:23:e7	Hinke A/S
++0:23:e8	Demco Corp.
++0:23:e9	F5 Networks, Inc.
++0:23:ea	Cisco Systems
++0:23:eb	Cisco Systems
++0:23:ec	Algorithmix GmbH
++0:23:ed	Motorola CHS
++0:23:ee	Motorola CHS
++0:23:ef	Zuend Systemtechnik AG
++0:23:e	Gorba AG
+ 0:2:3e	Selta Telematica S.p.a
++0:23:f0	Shanghai Jinghan Weighing Apparatus Co. Ltd.
++0:23:f1	Sony Ericsson Mobile Communications
++0:23:f2	TVLogic
++0:23:f3	Glocom, Inc.
++0:23:f4	Masternaut
++0:23:f5	WILO SE
++0:23:f6	Softwell Technology Co., Ltd.
++0:23:f7	PRIVATE
++0:23:f8	ZyXEL Communications Corporation
++0:23:f9	Double-Take Software, INC.
++0:23:fa	RG Nets, Inc.
++0:23:fb	IP Datatel, Inc.
+ 0:2:3f	Compal Electronics, Inc.
+-0:2:4	Bodmann Industries Elektronik GmbH
++0:23:fc	Ultra Stereo Labs, Inc
++0:23:fd	AFT Atlas Fahrzeugtechnik GmbH
++0:23:fe	Biodevices, SA
++0:23:ff	Beijing HTTC Technology Ltd.
++0:23:f	Hirsch Electronics Corporation
++0:2:3	Woonsang Telecom, Inc.
++0:24:0	Nortel Networks
+ 0:2:40	Seedek Co., Ltd.
++0:24:10	NUETEQ Technology,Inc.
++0:24:11	PharmaSmart LLC
++0:24:12	Benign Technologies Co, Ltd.
++0:24:13	Cisco Systems
++0:24:14	Cisco Systems
++0:24:15	Magnetic Autocontrol GmbH
++0:24:16	Any Use
++0:24:17	Thomson Telecom Belgium
++0:24:18	Nextwave Semiconductor
++0:24:19	PRIVATE
+ 0:2:41	Amer.com
++0:24:1a	Red Beetle Inc.
++0:24:1b	iWOW Communications Pte Ltd
++0:24:1c	FuGang Electronic (DG) Co.,Ltd
++0:24:1d	GIGA-BYTE TECHNOLOGY CO.,LTD.
++0:24:1	D-Link Corporation
++0:24:1e	Nintendo Co., Ltd.
++0:24:1f	DCT-Delta GmbH
++0:24:20	NetUP Inc.
++0:24:21	MICRO-STAR INT'L CO., LTD.
++0:24:22	Knapp Logistik Automation GmbH
++0:24:23	AzureWave Technologies (Shanghai) Inc.
++0:24:24	Axis Network Technology
++0:24:25	Shenzhenshi chuangzhicheng Technology Co.,Ltd
++0:24:26	NOHMI BOSAI LTD.
++0:24:27	SSI COMPUTER CORP
++0:24:28	EnergyICT
++0:24:29	MK MASTER INC.
++0:24:2a	Hittite Microwave Corporation
++0:24:2b	Hon Hai Precision Ind.Co.,Ltd.
++0:24:2c	Hon Hai Precision Ind. Co., Ltd.
++0:24:2e	Datastrip Inc.
++0:24:2f	VirtenSys Inc
++0:24:2	Op-Tection GmbH
+ 0:2:42	Videoframe Systems
++0:24:30	Ruby Tech Corp.
++0:24:31	Uni-v co.,ltd
++0:24:32	Neostar Technology Co.,LTD
++0:24:33	Alps Electric Co., Ltd
++0:24:34	Lectrosonics, Inc.
++0:24:35	WIDE CORPORATION
++0:24:36	Apple, Inc
++0:24:37	Motorola - BSG
++0:24:38	Brocade Communications Systems, Inc
++0:24:39	Essential Viewing Systems Limited
++0:24:3a	Ludl Electronic Products
++0:24:3b	CSSI (S) Pte Ltd
++0:24:3c	S.A.A.A.
++0:24:3d	Emerson Appliance Motors and Controls
++0:24:3f	Storwize, Inc.
++0:24:3	Nokia Danmark A/S
+ 0:2:43	Raysis Co., Ltd.
++0:24:40	Halo Monitoring, Inc.
++0:24:41	Wanzl Metallwarenfabrik GmbH
++0:24:42	Axona Limited
++0:24:43	Nortel Networks
++0:24:44	Nintendo Co., Ltd.
++0:24:45	LiquidxStream Systems Inc.
++0:24:46	MMB Research Inc.
++0:24:47	Kaztek Systems
++0:24:48	SpiderCloud Wireless, Inc
++0:24:49	Shen Zhen Lite Star Electronics Technology Co., Ltd
++0:24:4a	Voyant International
++0:24:4b	PERCEPTRON INC
++0:24:4c	Solartron Metrology Ltd
++0:24:4d	Hokkaido Electronics Corporation
++0:24:4e	RadChips, Inc.
++0:24:4f	Asantron Technologies Ltd.
++0:24:4	Nokia Danmark A/S
+ 0:2:44	SURECOM Technology Co.
++0:24:50	Cisco Systems
++0:24:51	Cisco Systems
++0:24:52	Silicon Software GmbH
++0:24:53	Initra d.o.o.
++0:24:54	Samsung Electronics Co., LTD
++0:24:55	MuLogic BV
++0:24:56	2Wire
++0:24:58	PA Bastion CC
++0:24:59	ABB STOTZ-KONTAKT GmbH
++0:24:5a	Nanjing Panda Electronics Company Limited
++0:24:5b	RAIDON TECHNOLOGY, INC.
++0:24:5c	Design-Com Technologies Pty. Ltd.
++0:24:5	Dilog Nordic AB
++0:24:5d	Terberg besturingstechniek B.V.
++0:24:5e	Hivision Co.,ltd
++0:24:5f	Vine Telecom CO.,Ltd.
+ 0:2:45	Lampus Co, Ltd.
++0:24:60	Giaval Science Development Co. Ltd.
++0:24:61	Shin Wang Tech.
++0:24:62	Rayzone Corporation
++0:24:63	Phybridge Inc
++0:24:64	Bridge Technologies Co AS
++0:24:65	Elentec
++0:24:66	Unitron nv
++0:24:67	AOC International (Europe) GmbH
++0:24:68	Sumavision Technologies Co.,Ltd
++0:24:69	Smart Doorphones
+ 0:2:46	All-Win Tech Co., Ltd.
++0:24:6a	Solid Year Co., Ltd.
++0:24:6b	Coventive
++0:24:6c	ARUBA NETWORKS, INC.
++0:24:6d	Weinzierl Engineering GmbH
++0:24:6e	Phihong USA Corp.
++0:24:6f	Onda Communication spa
++0:24:6	Pointmobile
++0:24:70	AUROTECH ultrasound AS.
++0:24:71	Fusion MultiSystems dba Fusion-io
++0:24:72	ReDriven Power Inc.
++0:24:73	3Com Europe Ltd
++0:24:74	Autronica Fire And Securirty
++0:24:75	Compass System(Embedded Dept.)
++0:24:76	TAP.tv
++0:24:77	Tibbo Technology
++0:24:78	Mag Tech Electronics Co Limited
++0:24:79	Optec Displays, Inc.
++0:24:7a	FU YI CHENG Technology Co., Ltd.
++0:24:7b	Actiontec Electronics, Inc
++0:24:7c	Nokia Danmark A/S
++0:24:7d	Nokia Danmark A/S
++0:24:7e	USI
++0:24:7f	Nortel Networks
+ 0:2:47	Great Dragon Information Technology (Group) Co., Ltd.
++0:24:7	TELEM SAS
++0:24:80	Meteocontrol GmbH
++0:24:81	Hewlett Packard
++0:24:82	Ruckus Wireless
++0:24:83	LG Electronics
++0:24:84	Bang and Olufsen Medicom a/s
++0:24:85	ConteXtream Ltd
++0:24:86	DesignArt Networks
++0:24:87	Blackboard Inc.
++0:24:88	Centre For Development Of Telematics
++0:24:89	Vodafone Omnitel N.V.
++0:24:8a	Kaga Electronics Co., Ltd.
++0:24:8b	HYBUS CO., LTD.
++0:24:8c	ASUSTek COMPUTER INC.
++0:24:8d	Sony Computer Entertainment Inc.
++0:24:8e	Infoware ZRt.
++0:24:8f	DO-MONIX
++0:24:8	Pacific Biosciences
+ 0:2:48	Pilz GmbH & Co.
++0:24:90	Samsung Electronics Co.,LTD
++0:24:91	Samsung Electronics
++0:24:92	Motorola, Broadband Solutions Group
++0:24:93	Motorola, Inc
++0:24:94	Shenzhen Baoxin Tech CO., Ltd.
++0:24:95	Motorola Mobile Devices
++0:24:96	Ginzinger electronic systems
++0:24:97	Cisco Systems
++0:24:98	Cisco Systems
++0:24:99	Aquila Technologies
++0:24:9a	Beijing Zhongchuang Telecommunication Test Co., Ltd.
+ 0:2:49	Aviv Infocom Co, Ltd.
++0:24:9b	Action Star Enterprise Co., Ltd.
++0:24:9c	Bimeng Comunication System Co. Ltd
++0:24:9d	NES Technology Inc.
++0:24:9e	ADC-Elektronik GmbH
++0:24:9f	RIM Testing Services
++0:24:9	The Toro Company
++0:24:a0	Motorola CHS
++0:24:a1	Motorola CHS
++0:24:a2	Hong Kong Middleware Technology Limited
++0:24:a3	Sonim Technologies Inc
++0:24:a4	Siklu Communication
++0:24:a5	Buffalo Inc.
++0:24:a6	TELESTAR DIGITAL GmbH
++0:24:a7	Advanced Video Communications Inc.
++0:24:a8	ProCurve Networking by HP
++0:24:a9	Ag Leader Technology
++0:24:aa	Dycor Technologies Ltd.
++0:24:ab	A7 Engineering, Inc.
++0:24:ac	Hangzhou DPtech Technologies Co., Ltd.
+ 0:2:4a	Cisco Systems, Inc.
++0:24:ad	Adolf Thies Gmbh & Co. KG
++0:24:ae	SAGEM SECURITE
++0:24:af	EchoStar Technologies
++0:24:a	US Beverage Net
++0:24:b0	ESAB AB
++0:24:b1	Coulomb Technologies
++0:24:b2	Netgear
++0:24:b3	Graf-Syteco GmbH & Co. KG
++0:24:b4	ESCATRONIC GmbH
++0:24:b5	Nortel Networks
++0:24:b6	Seagate Technology
++0:24:b7	GridPoint, Inc.
++0:24:b8	free alliance sdn bhd
++0:24:b9	Wuhan Higheasy Electronic Technology Development Co.Ltd
++0:24:ba	Texas Instruments
++0:24:bb	CENTRAL Corporation
++0:24:bc	HuRob Co.,Ltd
+ 0:2:4b	Cisco Systems, Inc.
++0:24:bd	Hainzl Industriesysteme GmbH
++0:24:be	Sony Corporation
++0:24:bf	CIAT
++0:2:4	Bodmann Industries Elektronik GmbH
++0:24:b	Virtual Computer Inc.
++0:24:c0	NTI COMODO INC
++0:24:c1	Hangzhou Motorola Technologies LTD.
++0:24:c2	Asumo Co.,Ltd.
++0:24:c3	Cisco Systems
++0:24:c4	Cisco Systems
++0:24:c5	Meridian Audio Limited
++0:24:c6	Hager Electro SAS
++0:24:c7	Mobilarm Ltd
++0:24:c8	Broadband Solutions Group
++0:24:c9	Broadband Solutions Group
++0:24:ca	Tobii Technology AB
++0:24:cb	Autonet Mobile
++0:24:cc	Fascinations Toys and Gifts, Inc.
++0:24:c	DELEC GmbH
++0:24:cd	Willow Garage, Inc.
++0:24:ce	Exeltech Inc
++0:24:cf	Inscape Data Corporation
+ 0:2:4c	SiByte, Inc.
++0:24:d0	Shenzhen SOGOOD Industry CO.,LTD.
++0:24:d1	Thomson Inc.
++0:24:d2	Askey Computer
++0:24:d3	QUALICA Inc.
++0:24:d4	FREEBOX SA
++0:24:d5	Winward Industrial Limited
++0:24:d6	Intel Corporate
++0:24:d7	Intel Corporate
++0:24:d8	IlSung Precision
++0:24:d9	BICOM, Inc.
++0:24:da	Innovar Systems Limited
++0:24:db	Alcohol Monitoring Systems
++0:24:dc	Juniper Networks
++0:24:dd	Centrak, Inc.
++0:24:de	GLOBAL Technology Inc.
++0:24:df	Digitalbox Europe GmbH
+ 0:2:4d	Mannesman Dematic Colby Pty. Ltd.
++0:24:d	OnePath Networks LTD.
++0:24:e0	DS Tech, LLC
++0:24:e1	Convey Computer Corp.
++0:24:e2	HASEGAWA ELECTRIC CO.,LTD.
++0:24:e3	CAO Group
++0:24:e4	Withings
++0:24:e5	Seer Technology, Inc
++0:24:e6	In Motion Technology Inc.
++0:24:e7	Plaster Networks
++0:24:e8	Dell Inc.
++0:24:e9	Samsung Electronics Co., Ltd., Storage System Division
++0:24:ea	iris-GmbH infrared & intelligent sensors
++0:24:eb	ClearPath Networks, Inc.
++0:24:ec	United Information Technology Co.,Ltd.
+ 0:2:4e	Datacard Group
++0:24:ed	YT Elec. Co,.Ltd.
++0:24:ee	Wynmax Inc.
++0:24:ef	Sony Ericsson Mobile Communications
++0:24:e	Inventec Besta Co., Ltd.
++0:24:f0	Seanodes
++0:24:f1	Shenzhen Fanhai Sanjiang Electronics Co., Ltd.
++0:24:f2	Uniphone Telecommunication Co., Ltd.
++0:24:f3	Nintendo Co., Ltd.
++0:24:f4	Kaminario Technologies Ltd.
++0:24:f5	NDS Surgical Imaging
++0:24:f6	MIYOSHI ELECTRONICS CORPORATION
++0:24:f7	Cisco Systems
++0:24:f8	Technical Solutions Company Ltd.
++0:24:f9	Cisco Systems
++0:24:fa	Hilger u. Kern GMBH
++0:24:fb	PRIVATE
++0:24:fc	QuoPin Co., Ltd.
++0:24:fd	Prosilient Technologies AB
++0:24:fe	AVM GmbH
++0:24:ff	QLogic Corporation
+ 0:2:4f	IPM Datacom S.R.L.
+-0:2:5	Hitachi Denshi, Ltd.
++0:24:f	Ishii Tool & Engineering Corporation
++0:25:0	Apple, Inc
+ 0:2:50	Geyser Networks, Inc.
++0:25:10	Pico-Tesla Magnetic Therapies
++0:25:11	ELITEGROUP COMPUTER SYSTEM CO., LTD.
++0:25:12	ZTE Corporation
++0:25:13	CXP DIGITAL BV
++0:25:14	PC Worth Int'l Co., Ltd.
++0:25:15	SFR
++0:25:16	Integrated Design Tools, Inc.
++0:25:17	Venntis, LLC
++0:25:18	Power PLUS Communications AG
++0:25:19	Viaas Inc
++0:25:1a	Psiber Data Systems Inc.
++0:25:1b	Philips CareServant
++0:25:1c	EDT
++0:25:1d	DSA Encore, LLC
++0:25:1e	ROTEL TECHNOLOGIES
++0:25:1f	ZYNUS VISION INC.
++0:25:1	JSC "Supertel"
+ 0:2:51	Soma Networks, Inc.
++0:25:20	SMA Railway Technology GmbH
++0:25:21	Logitek Electronic Systems, Inc.
++0:25:22	ASRock Incorporation
++0:25:23	OCP Inc.
++0:25:24	Lightcomm Technology Co., Ltd
++0:25:25	CTERA Networks Ltd.
++0:25:26	Genuine Technologies Co., Ltd.
++0:25:27	Bitrode Corp.
++0:25:28	Daido Signal Co., Ltd.
++0:25:29	COMELIT GROUP S.P.A
++0:25:2a	Chengdu GeeYa Technology Co.,LTD
++0:25:2b	Stirling Energy Systems
+ 0:2:52	Carrier Corporation
++0:25:2c	Entourage Systems, Inc.
++0:25:2d	Kiryung Electronics
++0:25:2e	Cisco SPVTG
++0:25:2f	Energy, Inc.
++0:25:2	NaturalPoint
++0:25:30	Aetas Systems Inc.
++0:25:31	Cloud Engines, Inc.
++0:25:32	Digital Recorders
++0:25:33	WITTENSTEIN AG
++0:25:35	Minimax GmbH & Co KG
++0:25:36	Oki Electric Industry Co., Ltd.
++0:25:37	Runcom Technologies Ltd.
++0:25:38	Samsung Electronics Co., Ltd., Memory Division
++0:25:39	IfTA GmbH
++0:25:3a	CEVA, Ltd.
++0:25:3b	din Dietmar Nocker Facilitymanagement GmbH
++0:25:3	BLADE Network Technology
++0:25:3c	2Wire
++0:25:3d	DRS Consolidated Controls
++0:25:3e	Sensus Metering Systems
+ 0:2:53	Televideo, Inc.
++0:25:40	Quasar Technologies, Inc.
++0:25:41	Maquet Critical Care AB
++0:25:42	Pittasoft
++0:25:43	MONEYTECH
++0:25:44	LoJack Corporation
++0:25:45	Cisco Systems
++0:25:46	Cisco Systems
++0:25:47	Nokia Danmark A/S
++0:25:48	Nokia Danmark A/S
++0:25:49	Jeorich Tech. Co.,Ltd.
++0:25:4a	RingCube Technologies, Inc.
++0:25:4b	Apple, Inc
++0:25:4c	Videon Central, Inc.
++0:25:4d	Singapore Technologies Electronics Limited
++0:25:4e	Vertex Wireless Co., Ltd.
++0:25:4f	ELETTROLAB Srl
++0:25:4	Valiant Communications Limited
+ 0:2:54	WorldGate
++0:25:50	Riverbed Technology
++0:25:51	SE-Elektronic GmbH
++0:25:52	VXI CORPORATION
++0:25:53	PIRELLI BROADBAND SOLUTIONS
++0:25:54	Pixel8 Networks
++0:25:55	Visonic Technologies 1993 Ltd
++0:25:56	Hon Hai Precision Ind. Co., Ltd.
++0:25:57	Research In Motion
++0:25:58	MPEDIA
++0:25:59	Syphan Technologies Ltd
++0:25:5a	Tantalus Systems Corp.
++0:25:5b	CoachComm, LLC
++0:25:5c	NEC Corporation
++0:25:5d	Morningstar Corporation
++0:25:5	eks Engel GmbH & Co. KG
++0:25:5e	Shanghai Dare Technologies Co.,Ltd.
++0:25:5f	SenTec AG
+ 0:2:55	IBM Corporation
++0:25:60	Ibridge Networks & Communications Ltd.
++0:25:61	ProCurve Networking by HP
++0:25:62	interbro Co. Ltd.
++0:25:63	Luxtera Inc
++0:25:64	Dell Inc.
++0:25:65	Vizimax Inc.
++0:25:66	Samsung Electronics Co.,Ltd
++0:25:67	Samsung Electronics
++0:25:68	Shenzhen Huawei Communication Technologies Co., Ltd
++0:25:69	SAGEM COMMUNICATION
++0:25:6	A.I. ANTITACCHEGGIO ITALIA SRL
++0:25:6a	inIT - Institut Industrial IT
+ 0:2:56	Alpha Processor, Inc.
++0:25:6b	ATENIX E.E. s.r.l.
++0:25:6c	"Azimut" Production Association JSC
++0:25:6d	Broadband Forum
++0:25:6e	Van Breda B.V.
++0:25:6f	Dantherm Power
++0:25:70	Eastern Communications Company Limited
++0:25:71	Zhejiang Tianle Digital Electric Co.,Ltd
++0:25:72	Nemo-Q International AB
++0:25:73	ST Electronics (Info-Security) Pte Ltd
++0:25:74	KUNIMI MEDIA DEVICE Co., Ltd.
++0:25:75	FiberPlex Inc
++0:25:76	NELI TECHNOLOGIES
++0:25:77	D-BOX Technologies
++0:25:78	JSC "Concern "Sozvezdie"
++0:25:79	J & F Labs
++0:25:7a	CAMCO Produktions- und Vertriebs-GmbH f
++0:25:7	ASTAK Inc.
++0:25:7b	STJ  ELECTRONICS  PVT  LTD
++0:25:7c	Huachentel Technology Development Co., Ltd
++0:25:7d	PointRed Telecom Private Ltd.
++0:25:7e	NEW POS Technology Limited
++0:25:7f	CallTechSolution Co.,Ltd
+ 0:2:57	Microcom Corp.
++0:25:80	Equipson S.A.
++0:25:81	x-star networks Inc.
++0:25:82	Maksat Technologies (P) Ltd
++0:25:83	Cisco Systems
++0:25:84	Cisco Systems
++0:25:85	KOKUYO S&T Co., Ltd.
++0:25:86	TP-LINK Technologies Co., Ltd.
++0:25:87	Vitality, Inc.
++0:25:88	Genie Industries, Inc.
++0:25:89	Hills Industries Limited
++0:25:8a	Pole/Zero Corporation
++0:25:8b	Mellanox Technologies Ltd
++0:25:8c	ESUS ELEKTRONIK SAN. VE DIS. TIC. LTD. STI.
++0:25:8d	Haier
++0:25:8e	The Weather Channel
+ 0:2:58	Flying Packets Communications
++0:25:8f	Trident Microsystems, Inc.
++0:25:8	Maquet Cardiopulmonary AG
++0:25:90	Super Micro Computer, Inc.
++0:25:91	NEXTEK, Inc.
++0:25:92	Guangzhou Shirui Electronic Co., Ltd
++0:25:93	DatNet Informatikai Kft.
++0:25:94	Eurodesign BG LTD
++0:25:95	Northwest Signal Supply, Inc
++0:25:96	GIGAVISION srl
++0:25:97	Kalki Communication Technologies
++0:25:98	Zhong Shan City Litai Electronic Industrial Co. Ltd
++0:25:99	Hedon e.d. B.V.
++0:25:9a	CEStronics GmbH
++0:25:9b	Beijing PKUNITY Microsystems Technology Co., Ltd
++0:25:9c	Cisco-Linksys, LLC
++0:25:9d	PRIVATE
++0:25:9e	Huawei Technologies Co., Ltd.
++0:25:9f	TechnoDigital Technologies GmbH
++0:25:9	SHARETRONIC Group LTD
+ 0:2:59	Tsann Kuen China (Shanghai)Enterprise Co., Ltd. IT Group
++0:25:a0	Nintendo Co., Ltd.
++0:25:a1	Enalasys
++0:25:a2	Alta Definicion LINCEO S.L.
++0:25:a3	Trimax Wireless, Inc.
++0:25:a4	EuroDesign embedded technologies GmbH
++0:25:a5	Walnut Media Network
++0:25:a6	Central Network Solution Co., Ltd.
++0:25:a7	Comverge, Inc.
++0:25:a8	Kontron (BeiJing) Technology Co.,Ltd
++0:25:a9	Shanghai Embedway Information Technologies Co.,Ltd
++0:25:aa	Beijing Soul Technology Co.,Ltd.
++0:25:ab	AIO LCD PC BU / TPV
+ 0:2:5a	Catena Networks
++0:25:ac	I-Tech corporation
++0:25:ad	Manufacturing Resources International
++0:25:ae	Microsoft Corporation
++0:25:af	COMFILE Technology
++0:25:a	Security Expert Co. Ltd
++0:25:b0	Schmartz Inc
++0:25:b1	Maya-Creation Corporation
++0:25:b2	LFK-Lenkflugk
++0:25:b3	Hewlett Packard
++0:25:b4	Cisco Systems
++0:25:b5	Cisco Systems
++0:25:b6	Telecom FM
++0:25:b7	Costar  electronics, inc.,
++0:25:b8	Agile Communications, Inc.
++0:25:b9	Agilink Systems Corp.
++0:25:ba	Alcatel-Lucent IPD
++0:25:bb	INNERINT Co., Ltd.
+ 0:2:5b	Cambridge Silicon Radio
++0:25:bc	Apple, Inc
++0:25:b	CENTROFACTOR  INC
++0:25:bd	Italdata Ingegneria dell'Idea S.p.A.
++0:25:be	Tektrap Systems Inc.
++0:25:bf	Wireless Cables Inc.
++0:25:c0	ZillionTV Corporation
++0:25:c1	Nawoo Korea Corp.
++0:25:c2	RingBell Co.,Ltd.
++0:25:c3	Nortel Networks
++0:25:c4	Ruckus Wireless
++0:25:c5	Star Link Communication Pvt. Ltd.
++0:25:c6	kasercorp, ltd
++0:25:c7	altek Corporation
++0:25:c8	S-Access GmbH
++0:25:c9	SHENZHEN HUAPU DIGITAL CO., LTD
++0:25:ca	LS Research, LLC
++0:25:cb	Reiner SCT
++0:25:cc	Mobile Communications Korea Incorporated
++0:25:cd	Skylane Optics
++0:25:ce	InnerSpace
++0:25:c	Enertrac
++0:25:cf	Nokia Danmark A/S
+ 0:2:5c	SCI Systems (Kunshan) Co., Ltd.
++0:25:d0	Nokia Danmark A/S
++0:25:d1	Eastech Electronics (Taiwan) Inc.
++0:25:d2	InpegVision Co., Ltd
++0:25:d3	AzureWave Technologies, Inc
++0:25:d4	Fortress Technologies
++0:25:d5	Robonica (Pty) Ltd
++0:25:d6	The Kroger Co.
++0:25:d7	CEDO
++0:25:d8	KOREA MAINTENANCE
++0:25:d9	DataFab Systems Inc.
++0:25:da	Secura Key
++0:25:db	ATI Electronics(Shenzhen) Co., LTD
+ 0:2:5d	Calix Networks
++0:25:dc	Sumitomo Electric Networks, Inc
++0:25:dd	SUNNYTEK INFORMATION CO., LTD.
++0:25:de	Probits Co., LTD.
++0:25:df	PRIVATE
++0:25:d	GZT Telkom-Telmor sp. z o.o.
++0:25:e0	CeedTec Sdn Bhd
++0:25:e1	SHANGHAI SEEYOO ELECTRONIC & TECHNOLOGY CO., LTD
++0:25:e2	Everspring Industry Co., Ltd.
++0:25:e3	Hanshinit Inc.
++0:25:e4	OMNI-WiFi, LLC
++0:25:e5	LG Electronics Inc
++0:25:e6	Belgian Monitoring Systems bvba
++0:25:e7	Sony Ericsson Mobile Communications
++0:25:e8	Idaho Technology
++0:25:e9	i-mate Development, Inc.
++0:25:ea	Iphion BV
++0:25:eb	Reutech Radar Systems (PTY) Ltd
++0:25:ec	Humanware
++0:25:ed	NuVo Technologies LLC
++0:25:ee	Avtex Ltd
++0:25:ef	I-TEC Co., Ltd.
++0:25:e	gt german telematics gmbh
+ 0:2:5e	High Technology Ltd
++0:25:f0	Suga Electronics Limited
++0:25:f1	Motorola CHS
++0:25:f2	Motorola CHS
++0:25:f3	Nordwestdeutsche Z
++0:25:f4	KoCo Connector AG
++0:25:f5	DVS Korea, Co., Ltd
++0:25:f6	netTALK.com, Inc.
++0:25:f7	Ansaldo STS USA
++0:25:f9	GMK electronic design GmbH
++0:25:fa	J&M Analytik AG
++0:25:fb	Tunstall Healthcare A/S
++0:25:fc	ENDA ENDUSTRIYEL ELEKTRONIK LTD. STI.
++0:25:fd	OBR Centrum Techniki Morskiej S.A.
++0:25:fe	Pilot Electronics Corporation
++0:25:ff	CreNova Technology GmbH
+ 0:2:5f	Nortel Networks
+-0:2:6	Telital R&D Denmark A/S
++0:25:f	On-Ramp Wireless, Inc.
++0:2:5	Hitachi Denshi, Ltd.
+ 0:2:60	Accordion Networks, Inc.
+-0:2:61	i3 Micro Technology AB
++0:26:0	TEAC Australia Pty Ltd.
++0:26:10	Apacewave Technologies
++0:26:11	Licera AB
++0:26:12	Space Exploration Technologies
++0:26:13	Engel Axil S.L.
++0:26:14	KTNF
++0:26:15	Teracom Limited
++0:26:16	Rosemount Inc.
++0:26:17	OEM Worldwide
++0:26:18	ASUSTek COMPUTER INC.
++0:26:19	FRC
++0:26:1a	Femtocomm System Technology Corp.
++0:26:1b	LAUREL BANK MACHINES CO., LTD.
++0:26:1c	NEOVIA INC.
++0:26:1d	COP SECURITY SYSTEM CORP.
++0:26:1e	QINGBANG ELEC(SZ) CO., LTD
++0:26:1f	SAE Magnetics (H.K.) Ltd.
++0:26:1	PRIVATE
++0:2:61	Tilgin AB
++0:26:20	ISGUS GmbH
++0:26:21	InteliCloud Technology Inc.
++0:26:22	COMPAL INFORMATION (KUNSHAN) CO., LTD.
++0:26:23	JRD Communication Inc
++0:26:24	Thomson Inc.
++0:26:25	MediaSputnik
++0:26:26	Geophysical Survey Systems, Inc.
++0:26:27	Truesell
++0:26:28	companytec automa
++0:26:29	Juphoon System Software Inc.
++0:26:2a	Proxense, LLC
++0:26:2b	Wongs Electronics Co. Ltd.
++0:26:2c	IKT Advanced Technologies s.r.o.
++0:26:2d	Wistron Corporation
++0:26:2e	Chengdu Jiuzhou Electronic Technology Inc
++0:26:2f	HAMAMATSU TOA ELECTRONICS
++0:26:2	SMART Temps LLC
+ 0:2:62	Soyo Group Soyo Com Tech Co., Ltd
++0:26:30	ACOREL S.A.S
++0:26:31	COMMTACT LTD
++0:26:32	Instrumentation Technologies d.d.
++0:26:33	MIR - Medical International Research
++0:26:34	Infineta Systems, Inc
++0:26:35	Bluetechnix GmbH
++0:26:36	Motorola Mobile Devices
++0:26:37	Samsung Electro-Mechanics
++0:26:38	Xia Men Joyatech Co., Ltd.
++0:26:39	T.M. Electronics, Inc.
++0:26:3a	Digitec Systems
++0:26:3b	Onbnetech
++0:26:3c	Bachmann GmbH & Co. KG
++0:26:3d	MIA Corporation
++0:26:3e	Trapeze Networks
++0:26:3f	LIOS Technology GmbH
++0:26:3	Shenzhen Wistar Technology Co., Ltd
+ 0:2:63	UPS Manufacturing SRL
++0:26:40	Baustem Broadband Technologies, Ltd.
++0:26:41	Motorola, Inc
++0:26:42	Motorola, Inc
++0:26:43	Alps Electric Co., Ltd
++0:26:44	Thomson Telecom Belgium
++0:26:45	Circontrol S.A.
++0:26:46	SHENYANG TONGFANG MULTIMEDIA TECHNOLOGY COMPANY LIMITED
++0:26:47	WFE TECHNOLOGY CORP.
++0:26:48	Emitech Corp.
++0:26:4a	Apple, Inc
++0:26:4	Audio Processing Technology Ltd
+ 0:2:64	AudioRamp.com
++0:26:4c	Shanghai DigiVision Technology Co., Ltd.
++0:26:4d	Arcadyan Technology Corporation
++0:26:4e	Rail & Road Protec GmbH
++0:26:4f	Kr
++0:26:50	2Wire
++0:26:51	Cisco Systems
++0:26:52	Cisco Systems
++0:26:53	DaySequerra Corporation
++0:26:54	3Com Corporation
++0:26:55	Hewlett Packard
++0:26:56	Sansonic Electronics USA
++0:26:57	OOO NPP EKRA
++0:26:58	T-Platforms (Cyprus) Limited
++0:26:59	Nintendo Co., Ltd.
++0:26:5a	D-Link Corporation
++0:26:5b	Hitron Technologies. Inc
++0:26:5	CC Systems AB
++0:26:5c	Hon Hai Precision Ind. Co.,Ltd.
++0:26:5d	Samsung Electronics
++0:26:5e	Hon Hai Precision Ind. Co.,Ltd.
++0:26:5f	Samsung Electronics Co.,Ltd
+ 0:2:65	Virditech Co. Ltd.
++0:26:60	Logiways
++0:26:61	Irumtek Co., Ltd.
++0:26:62	Actiontec Electronics, Inc
++0:26:63	Shenzhen Huitaiwei Tech. Ltd, co.
++0:26:64	Core System Japan
++0:26:65	ProtectedLogic Corporation
++0:26:66	EFM Networks
++0:26:67	CARECOM CO.,LTD.
++0:26:68	Nokia Danmark A/S
++0:26:69	Nokia Danmark A/S
++0:26:6a	ESSENSIUM NV
++0:26:6b	SHINE UNION ENTERPRISE LIMITED
++0:26:6c	Inventec
++0:26:6d	MobileAccess Networks
++0:26:6e	Nissho-denki Co.,LTD.
++0:26:6f	Coordiwise Technology Corp.
++0:26:6	RAUMFELD GmbH
+ 0:2:66	Thermalogic Corporation
++0:26:70	Cinch Connectors
++0:26:71	AUTOVISION Co., Ltd
++0:26:72	AAMP of America
++0:26:73	RICOH COMPANY LTD.
++0:26:74	Electronic Solutions, Inc.
++0:26:75	Aztech Electronics Pte Ltd
++0:26:76	COMMidt AS
++0:26:77	DEIF A/S
++0:26:78	Logic Instrument SA
++0:26:79	Euphonic Technologies, Inc.
++0:26:7a	wuhan hongxin telecommunication technologies co.,ltd
++0:26:7b	GSI Helmholtzzentrum f
++0:26:7c	Metz-Werke GmbH & Co KG
++0:26:7d	A-Max Technology Macao Commercial Offshore Company Limited
++0:26:7	Enabling Technology Pty Ltd
++0:26:7e	Parrot SA
++0:26:7f	Zenterio AB
+ 0:2:67	NODE RUNNER, INC.
++0:26:80	Lockie Innovation Pty Ltd
++0:26:81	Interspiro AB
++0:26:82	Gemtek Technology Co., Ltd.
++0:26:83	Ajoho Enterprise Co., Ltd.
++0:26:84	KISAN SYSTEM
++0:26:85	Digital Innovation
++0:26:86	Quantenna Communcations, Inc.
++0:26:87	ALLIED TELESIS, K.K corega division.
++0:26:88	Juniper Networks
++0:26:89	General Dynamics Robotic Systems
++0:26:8	Apple, Inc
++0:26:8a	Terrier SC Ltd
++0:26:8b	Guangzhou Escene Computer Technology Limited
++0:26:8c	StarLeaf Ltd.
++0:26:8d	CellTel S.p.A.
++0:26:8e	Alta Solutions, Inc.
++0:26:8f	MTA SpA
+ 0:2:68	Harris Government Communications
++0:26:90	I DO IT
++0:26:91	SAGEM COMMUNICATION
++0:26:92	Mitsubishi Electric Co.
++0:26:93	QVidium Technologies, Inc.
++0:26:94	Senscient Ltd
++0:26:95	ZT Group Int'l Inc
++0:26:96	NOOLIX Co., Ltd
++0:26:97	Cheetah Technologies, L.P.
++0:26:98	Cisco Systems
++0:26:99	Cisco Systems
++0:26:9a	carina system co., ltd.
++0:26:9b	SOKRAT Ltd.
++0:26:9c	ITUS JAPAN CO. LTD
++0:26:9d	M2Mnet Co., Ltd.
++0:26:9e	Quanta Computer Inc
++0:26:9f	PRIVATE
+ 0:2:69	Nadatel Co., Ltd
++0:26:9	Phyllis Co., Ltd.
++0:26:a0	moblic
++0:26:a1	Megger
++0:26:a2	Instrumentation Technology Systems
++0:26:a3	FQ Ingenieria Electronica S.A.
++0:26:a4	Novus Produtos Eletronicos Ltda
++0:26:a5	MICROROBOT.CO.,LTD
++0:26:a6	TRIXELL
++0:26:a7	CONNECT SRL
++0:26:a8	DAEHAP HYPER-TECH
++0:26:a9	Strong Technologies Pty Ltd
++0:26:aa	Kenmec Mechanical Engineering Co., Ltd.
++0:26:ab	SEIKO EPSON CORPORATION
++0:26:a	Cisco Systems
+ 0:2:6a	Cocess Telecom Co., Ltd.
++0:26:ac	Shanghai LUSTER Teraband photonic Co., Ltd.
++0:26:ad	Arada Systems, Inc.
++0:26:ae	Wireless Measurement Ltd
++0:26:af	Duelco A/S
++0:26:b0	Apple, Inc
++0:26:b1	Harman/Navis
++0:26:b2	Setrix AG
++0:26:b3	Thales Communications Inc
++0:26:b4	Ford Motor Company
++0:26:b5	ICOMM Tele Ltd
++0:26:b6	Askey Computer
++0:26:b7	Kingston Technology Company, Inc.
++0:26:b8	Actiontec Electronics, Inc
++0:26:b9	Dell Inc
++0:26:ba	Motorola Mobile Devices
++0:26:bb	Apple, Inc
+ 0:2:6b	BCM Computers Co., Ltd.
++0:26:bc	General Jack Technology Ltd.
++0:26:b	Cisco Systems
++0:26:bd	JTEC Card & Communication Co., Ltd.
++0:26:be	Schoonderbeek Elektronica Systemen B.V.
++0:26:bf	ShenZhen Temobi Science&Tech Development Co.,Ltd
++0:26:c0	EnergyHub
++0:26:c1	ARTRAY CO., LTD.
++0:26:c2	SCDI Co. LTD
++0:26:c3	Insightek Corp.
++0:26:c4	Cadmos microsystems S.r.l.
++0:26:c5	Guangdong Gosun Telecommunications Co.,Ltd
++0:26:c6	Intel Corporate
++0:26:c7	Intel Corporate
++0:26:c8	System Sensor
++0:26:c9	Proventix Systems, Inc.
++0:26:ca	Cisco Systems
++0:26:cb	Cisco Systems
++0:26:cc	Nokia Danmark A/S
++0:26:c	Dataram
++0:26:cd	PurpleComm, Inc.
++0:26:ce	Kozumi USA Corp.
++0:26:cf	DEKA R&D
+ 0:2:6c	Philips CFT
++0:26:d0	Semihalf
++0:26:d1	S Squared Innovations Inc.
++0:26:d2	Pcube Systems, Inc.
++0:26:d3	Zeno Information System
++0:26:d4	IRCA SpA
++0:26:d5	Ory Solucoes em Comercio de Informatica Ltda.
++0:26:d6	Ningbo Andy Optoelectronic Co., Ltd.
++0:26:d7	Xiamen BB Electron & Technology Co., Ltd.
++0:26:d8	Magic Point Inc.
++0:26:d9	Pace Micro Technology plc
+ 0:2:6d	Adept Telecom
++0:26:da	Universal Media Corporation /Slovakia/ s.r.o.
++0:26:db	Ionics EMS Inc.
++0:26:dc	Optical Systems Design
++0:26:dd	Fival Corporation
++0:26:de	FDI MATELEC
++0:26:df	TaiDoc Technology Corp.
++0:26:d	Micronetics, Inc.
++0:26:e0	ASITEQ
++0:26:e1	Stanford University, OpenFlow Group
++0:26:e2	LG Electronics
++0:26:e3	DTI
++0:26:e4	CANAL OVERSEAS
++0:26:e5	AEG Power Solutions
++0:26:e6	Visionhitech Co., Ltd.
++0:26:e7	Shanghai ONLAN Communication Tech. Co., Ltd.
++0:26:e8	Murata Manufacturing Co., Ltd.
++0:26:e9	SP Corp
++0:26:e	Ablaze Systems, LLC
++0:26:ea	Cheerchip Electronic Technology (ShangHai) Co., Ltd.
++0:26:eb	Advanced Spectrum Technology Co., Ltd.
++0:26:ec	Legrand Home Systems, Inc
++0:26:ed	zte corporation
++0:26:ee	TKM GmbH
++0:26:ef	Technology Advancement Group, Inc.
+ 0:2:6e	NeGeN Access, Inc.
++0:26:f0	cTrixs International GmbH.
++0:26:f1	ProCurve Networking by HP
++0:26:f2	Netgear
++0:26:f3	SMC Networks
++0:26:f4	Nesslab
++0:26:f5	XRPLUS Inc.
++0:26:f6	Military Communication Institute
++0:26:f7	Infosys Technologies Ltd.
++0:26:f8	Golden Highway Industry Development Co., Ltd.
++0:26:f9	S.E.M. srl
++0:26:fa	BandRich Inc.
++0:26:fb	AirDio Wireless, Inc.
++0:26:fc	AcSiP Technology Corp.
++0:26:fd	Interactive Intelligence
++0:26:fe	MKD Technology Inc.
++0:26:ff	Research In Motion
++0:26:f	Linn Products Ltd
+ 0:2:6f	Senao International Co., Ltd.
+-0:2:7	VisionGlobal Network Corp.
++0:2:6	Telital R&D Denmark A/S
+ 0:2:70	Crewave Co., Ltd.
+-0:2:71	Vpacket Communications
++0:27:0	Shenzhen Siglent Technology Co., Ltd.
++0:27:10	Intel Corporate
++0:27:11	LanPro Inc
++0:27:12	MaxVision LLC
++0:27:13	USI
++0:27:14	Grainmustards, Co,ltd.
++0:27:15	Rebound Telecom. Co., Ltd
++0:27:16	Adachi-Syokai Co., Ltd.
++0:27:17	CE Digital(Zhenjiang)Co.,Ltd
++0:27:18	Suzhou NEW SEAUNION Video Technology Co.,Ltd
++0:27:19	TP-LINK TECHNOLOGIES CO., LTD.
++0:27:1a	Geenovo Technology Ltd.
++0:27:1b	Alec Sicherheitssysteme GmbH
++0:27:1c	MERCURY CORPORATION
++0:27:1d	Comba Telecom Systems (China) Ltd.
++0:27:1e	Xagyl Communications
++0:27:1f	MIPRO Electronics Co., Ltd
++0:27:1	INCOstartec GmbH
++0:2:71	Zhone Technologies
++0:27:20	NEW-SOL COM
++0:27:21	Shenzhen Baoan Fenda Industrial Co., Ltd
++0:27:22	Ubiquiti Networks
+ 0:2:72	CC&C Technologies, Inc.
++0:27:2	SolarEdge Technologies
+ 0:2:73	Coriolis Networks
++0:27:3	Testech Electronics Pte Ltd
++0:27:4	Accelerated Concepts, LLC
+ 0:2:74	Tommy Technologies Corp.
++0:27:5	Sectronic
+ 0:2:75	SMART Technologies, Inc.
+ 0:2:76	Primax Electronics Ltd.
++0:27:6	YOISYS
+ 0:2:77	Cash Systemes Industrie
++0:27:7	Lift Complex DS, JSC
++0:27:8	Nordiag ASA
+ 0:2:78	Samsung Electro-Mechanics Co., Ltd.
+ 0:2:79	Control Applications, Ltd.
++0:27:9	Nintendo Co., Ltd.
++0:27:a	IEE S.A.
+ 0:2:7a	IOI Technology Corporation
++0:27:b	Adura Technologies
+ 0:2:7b	Amplify Net, Inc.
++0:27:c	Cisco Systems
+ 0:2:7c	Trilithic, Inc.
++0:27:d	Cisco Systems
+ 0:2:7d	Cisco Systems, Inc.
+ 0:2:7e	Cisco Systems, Inc.
++0:27:e	Intel Corporate
++0:27:f8	Brocade Communications Systems, Inc
+ 0:2:7f	ask-technologies.com
+-0:2:8	Unify Networks, Inc.
++0:27:f	Envisionnovation Inc
++0:2:7	VisionGlobal Network Corp.
+ 0:2:80	Mu Net, Inc.
+ 0:2:81	Madge Ltd.
+ 0:2:82	ViaClix, Inc.
+@@ -3236,7 +6561,7 @@
+ 0:2:8d	Movita Technologies, Inc.
+ 0:2:8e	Rapid 5 Networks, Inc.
+ 0:2:8f	Globetek, Inc.
+-0:2:9	Shenzhen SED Information Technology Co., Ltd.
++0:2:8	Unify Networks, Inc.
+ 0:2:90	Woorigisool, Inc.
+ 0:2:91	Open Network Co., Ltd.
+ 0:2:92	Logic Innovations, Inc.
+@@ -3253,13 +6578,13 @@
+ 0:2:9d	Merix Corp.
+ 0:2:9e	Information Equipment Co., Ltd.
+ 0:2:9f	L-3 Communication Aviation Recorders
+-0:2:a	Gefran Spa
++0:2:9	Shenzhen SED Information Technology Co., Ltd.
+ 0:2:a0	Flatstack Ltd.
+ 0:2:a1	World Wide Packets
+ 0:2:a2	Hilscher GmbH
+-0:2:a3	ABB Power Automation
++0:2:a3	ABB Switzerland Ltd, Power Systems
+ 0:2:a4	AddPac Technology Co., Ltd.
+-0:2:a5	Compaq Computer Corporation
++0:2:a5	Hewlett Packard
+ 0:2:a6	Effinet Systems Co., Ltd.
+ 0:2:a7	Vivace Networks
+ 0:2:a8	Air Link Technology
+@@ -3267,10 +6592,10 @@
+ 0:2:aa	PLcom Co., Ltd.
+ 0:2:ab	CTC Union Technologies Co., Ltd.
+ 0:2:ac	3PAR data
+-0:2:ad	Pentax Corpotation
++0:2:ad	HOYA Corporation
+ 0:2:ae	Scannex Electronics Ltd.
+ 0:2:af	TeleCruz Technology, Inc.
+-0:2:b	Native Networks, Inc.
++0:2:a	Gefran Spa
+ 0:2:b0	Hokubu Communication & Industrial Co., Ltd.
+ 0:2:b1	Anritsu, Ltd.
+ 0:2:b2	Cablevision
+@@ -3282,17 +6607,17 @@
+ 0:2:b8	WHI KONSULT AB
+ 0:2:b9	Cisco Systems, Inc.
+ 0:2:ba	Cisco Systems, Inc.
+-0:2:bb	Continuous Computing
++0:2:bb	Continuous Computing Corp
+ 0:2:bc	LVL 7 Systems, Inc.
+ 0:2:bd	Bionet Co., Ltd.
+ 0:2:be	Totsu Engineering, Inc.
+ 0:2:bf	dotRocket, Inc.
+-0:2:c	Metro-Optix
++0:2:b	Native Networks, Inc.
+ 0:2:c0	Bencent Tzeng Industry Co., Ltd.
+ 0:2:c1	Innovative Electronic Designs, Inc.
+ 0:2:c2	Net Vision Telecom
+ 0:2:c3	Arelnet Ltd.
+-0:2:c4	Vector International BUBA
++0:2:c4	Vector International BVBA
+ 0:2:c5	Evertz Microsystems Ltd.
+ 0:2:c6	Data Track Technology PLC
+ 0:2:c7	ALPS ELECTRIC Co., Ltd.
+@@ -3304,7 +6629,7 @@
+ 0:2:cd	TeleDream, Inc.
+ 0:2:ce	FoxJet, Inc.
+ 0:2:cf	ZyGate Communications, Inc.
+-0:2:d	Micronpc.com
++0:2:c	Metro-Optix
+ 0:2:d0	Comdial Corporation
+ 0:2:d1	Vivotek, Inc.
+ 0:2:d2	Workstation AG
+@@ -3321,7 +6646,7 @@
+ 0:2:dd	Bromax Communications, Ltd.
+ 0:2:de	Astrodesign, Inc.
+ 0:2:df	Net Com Systems, Inc.
+-0:2:e	Laurel Networks, Inc.
++0:2:d	Micronpc.com
+ 0:2:e0	ETAS GmbH
+ 0:2:e1	Integrated Network Corporation
+ 0:2:e2	NDC Infared Engineering
+@@ -3336,9 +6661,9 @@
+ 0:2:eb	Pico Communications
+ 0:2:ec	Maschoff Design Engineering
+ 0:2:ed	DXO Telecom Co., Ltd.
++0:2:e	ECI Telecom, Ltd., NSD-US
+ 0:2:ee	Nokia Danmark A/S
+ 0:2:ef	CCC Network Systems Group Ltd.
+-0:2:f	AATR
+ 0:2:f0	AME Optimedia Technology Co., Ltd.
+ 0:2:f1	Pinetron Co., Ltd.
+ 0:2:f2	eDevice, Inc.
+@@ -3349,6 +6674,7 @@
+ 0:2:f7	ARM
+ 0:2:f8	SEAKR Engineering, Inc.
+ 0:2:f9	Mimos Semiconductor SDN BHD
++0:2:f	AATR
+ 0:2:fa	DX Antenna Co., Ltd.
+ 0:2:fb	Baumuller Aulugen-Systemtechnik GmbH
+ 0:2:fc	Cisco Systems, Inc.
+@@ -3356,7 +6682,6 @@
+ 0:2:fe	Viditec, Inc.
+ 0:2:ff	Handan BroadInfoCom
+ 0:30:0	ALLWELL TECHNOLOGY CORP.
+-0:30:1	SMP
+ 0:30:10	VISIONETICS INTERNATIONAL
+ 0:30:11	HMS FIELDBUS SYSTEMS AB
+ 0:30:12	DIGITAL ENGINEERING LTD.
+@@ -3373,7 +6698,7 @@
+ 0:30:1d	SKYSTREAM, INC.
+ 0:30:1e	3COM Europe Ltd.
+ 0:30:1f	OPTICAL NETWORKS, INC.
+-0:30:2	Expand Networks
++0:30:1	SMP
+ 0:30:20	TSI, Inc..
+ 0:30:21	HSING TECH. ENTERPRISE CO.,LTD
+ 0:30:22	Fong Kai Industrial Co., Ltd.
+@@ -3389,8 +6714,8 @@
+ 0:30:2c	SYLANTRO SYSTEMS CORPORATION
+ 0:30:2d	QUANTUM BRIDGE COMMUNICATIONS
+ 0:30:2e	Hoft & Wessel AG
+-0:30:2f	Smiths Industries
+-0:30:3	Phasys Ltd.
++0:30:2	Expand Networks
++0:30:2f	GE Aviation System
+ 0:30:30	HARMONIX CORPORATION
+ 0:30:31	LIGHTWAVE COMMUNICATIONS, INC.
+ 0:30:32	MagicRam, Inc.
+@@ -3407,7 +6732,7 @@
+ 0:30:3d	IVA CORPORATION
+ 0:30:3e	Radcom Ltd.
+ 0:30:3f	TurboComm Tech Inc.
+-0:30:4	LEADTEK RESEARCH INC.
++0:30:3	Phasys Ltd.
+ 0:30:40	CISCO SYSTEMS, INC.
+ 0:30:41	SAEJIN T & M CO., LTD.
+ 0:30:42	DeTeWe-Deutsche Telephonwerke
+@@ -3424,31 +6749,31 @@
+ 0:30:4d	ESI
+ 0:30:4e	BUSTEC PRODUCTION LTD.
+ 0:30:4f	PLANET Technology Corporation
+-0:30:5	Fujitsu Siemens Computers
++0:30:4	LEADTEK RESEARCH INC.
+ 0:30:50	Versa Technology
+ 0:30:51	ORBIT AVIONIC & COMMUNICATION
+ 0:30:52	ELASTIC NETWORKS
+ 0:30:53	Basler AG
+ 0:30:54	CASTLENET TECHNOLOGY, INC.
+-0:30:55	Hitachi Semiconductor America,
++0:30:55	Renesas Technology America, Inc.
+ 0:30:56	Beck IPC GmbH
+ 0:30:57	QTelNet, Inc.
+ 0:30:58	API MOTION
+-0:30:59	DIGITAL-LOGIC AG
++0:30:59	KONTRON COMPACT COMPUTERS AG
+ 0:30:5a	TELGEN CORPORATION
+-0:30:5b	MODULE DEPARTMENT
++0:30:5b	Toko Inc.
+ 0:30:5c	SMAR Laboratories Corp.
+ 0:30:5d	DIGITRA SYSTEMS, INC.
+ 0:30:5e	Abelko Innovation
+-0:30:5f	IMACON APS
+-0:30:6	SUPERPOWER COMPUTER
++0:30:5f	Hasselblad
++0:30:5	Fujitsu Siemens Computers
+ 0:30:60	Powerfile, Inc.
+ 0:30:61	MobyTEL
+ 0:30:62	PATH 1 NETWORK TECHNOL'S INC.
+ 0:30:63	SANTERA SYSTEMS, INC.
+ 0:30:64	ADLINK TECHNOLOGY, INC.
+ 0:30:65	APPLE COMPUTER, INC.
+-0:30:66	DIGITAL WIRELESS CORPORATION
++0:30:66	RFM
+ 0:30:67	BIOSTAR MICROTECH INT'L CORP.
+ 0:30:68	CYBERNETICS TECH. CO., LTD.
+ 0:30:69	IMPACCT TECHNOLOGY CORP.
+@@ -3458,10 +6783,10 @@
+ 0:30:6d	LUCENT TECHNOLOGIES
+ 0:30:6e	HEWLETT PACKARD
+ 0:30:6f	SEYEON TECH. CO., LTD.
+-0:30:7	OPTI, INC.
++0:30:6	SUPERPOWER COMPUTER
+ 0:30:70	1Net Corporation
+ 0:30:71	Cisco Systems, Inc.
+-0:30:72	INTELLIBYTE INC.
++0:30:72	Intellibyte Inc.
+ 0:30:73	International Microsystems, In
+ 0:30:74	EQUIINET LTD.
+ 0:30:75	ADTECH
+@@ -3475,7 +6800,7 @@
+ 0:30:7d	GRE AMERICA, INC.
+ 0:30:7e	Redflex Communication Systems
+ 0:30:7f	IRLAN LTD.
+-0:30:8	AVIO DIGITAL, INC.
++0:30:7	OPTI, INC.
+ 0:30:80	CISCO SYSTEMS, INC.
+ 0:30:81	ALTOS C&C
+ 0:30:82	TAIHAN ELECTRIC WIRE CO., LTD.
+@@ -3487,20 +6812,20 @@
+ 0:30:88	Siara Systems, Inc.
+ 0:30:89	Spectrapoint Wireless, LLC
+ 0:30:8a	NICOTRA SISTEMI S.P.A
++0:30:8	AVIO DIGITAL, INC.
+ 0:30:8b	Brix Networks
+-0:30:8c	ADVANCED DIGITAL INFORMATION
+-0:30:8d	PINNACLE SYSTEMS, INC.
++0:30:8c	Quantum Corporation
++0:30:8d	Pinnacle Systems, Inc.
+ 0:30:8e	CROSS MATCH TECHNOLOGIES, INC.
+ 0:30:8f	MICRILOR, Inc.
+-0:30:9	Tachion Networks, Inc.
+ 0:30:90	CYRA TECHNOLOGIES, INC.
+ 0:30:91	TAIWAN FIRST LINE ELEC. CORP.
+ 0:30:92	ModuNORM GmbH
+-0:30:93	SONNET TECHNOLOGIES, INC.
++0:30:93	Sonnet Technologies, Inc
+ 0:30:94	Cisco Systems, Inc.
+ 0:30:95	Procomp Informatics, Ltd.
+ 0:30:96	CISCO SYSTEMS, INC.
+-0:30:97	EXOMATIC AB
++0:30:97	AB Regin
+ 0:30:98	Global Converging Technologies
+ 0:30:99	BOENIG UND KALLENBACH OHG
+ 0:30:9a	ASTRO TERRA CORP.
+@@ -3509,7 +6834,7 @@
+ 0:30:9d	Nimble Microsystems, Inc.
+ 0:30:9e	WORKBIT CORPORATION.
+ 0:30:9f	AMBER NETWORKS
+-0:30:a	AZTECH SYSTEMS LTD.
++0:30:9	Tachion Networks, Inc.
+ 0:30:a0	TYCO SUBMARINE SYSTEMS, LTD.
+ 0:30:a1	WEBGATE Inc.
+ 0:30:a2	Lightner Engineering
+@@ -3521,12 +6846,12 @@
+ 0:30:a8	OL'E COMMUNICATIONS, INC.
+ 0:30:a9	Netiverse, Inc.
+ 0:30:aa	AXUS MICROSYSTEMS, INC.
++0:30:a	AZTECH Electronics Pte Ltd
+ 0:30:ab	DELTA NETWORKS, INC.
+ 0:30:ac	Systeme Lauer GmbH & Co., Ltd.
+ 0:30:ad	SHANGHAI COMMUNICATION
+ 0:30:ae	Times N System, Inc.
+ 0:30:af	Honeywell GmbH
+-0:30:b	mPHASE Technologies, Inc.
+ 0:30:b0	Convergenet Technologies
+ 0:30:b1	aXess-pro networks GmbH
+ 0:30:b2	L-3 Sonoma EO
+@@ -3543,24 +6868,24 @@
+ 0:30:bd	BELKIN COMPONENTS
+ 0:30:be	City-Net Technology, Inc.
+ 0:30:bf	MULTIDATA GMBH
+-0:30:c	CONGRUENCY, LTD.
++0:30:b	mPHASE Technologies, Inc.
+ 0:30:c0	Lara Technology, Inc.
+ 0:30:c1	HEWLETT-PACKARD
+ 0:30:c2	COMONE
+ 0:30:c3	FLUECKIGER ELEKTRONIK AG
+-0:30:c4	Canon Imaging System Technologies, Inc.
++0:30:c4	Canon Imaging Systems Inc.
+ 0:30:c5	CADENCE DESIGN SYSTEMS
+ 0:30:c6	CONTROL SOLUTIONS, INC.
+-0:30:c7	MACROMATE CORP.
++0:30:c7	Macromate Corp.
+ 0:30:c8	GAD LINE, LTD.
+ 0:30:c9	LuxN, N
+ 0:30:ca	Discovery Com
+ 0:30:cb	OMNI FLOW COMPUTERS, INC.
++0:30:c	CONGRUENCY, LTD.
+ 0:30:cc	Tenor Networks, Inc.
+ 0:30:cd	CONEXANT SYSTEMS, INC.
+ 0:30:ce	Zaffire
+ 0:30:cf	TWO TECHNOLOGIES, INC.
+-0:30:d	MMC Technology, Inc.
+ 0:30:d0	Tellabs
+ 0:30:d1	INOVA CORPORATION
+ 0:30:d2	WIN TECHNOLOGIES, CO., LTD.
+@@ -3577,14 +6902,14 @@
+ 0:30:dd	INDIGITA CORPORATION
+ 0:30:de	WAGO Kontakttechnik GmbH
+ 0:30:df	KB/TEL TELECOMUNICACIONES
+-0:30:e	Klotz Digital AG
++0:30:d	MMC Technology, Inc.
+ 0:30:e0	OXFORD SEMICONDUCTOR LTD.
+ 0:30:e1	ACROTRON SYSTEMS, INC.
+ 0:30:e2	GARNET SYSTEMS CO., LTD.
+ 0:30:e3	SEDONA NETWORKS CORP.
+ 0:30:e4	CHIYODA SYSTEM RIKEN
+ 0:30:e5	Amper Datos S.A.
+-0:30:e6	SIEMENS MEDICAL SYSTEMS
++0:30:e6	Draeger Medical Systems, Inc.
+ 0:30:e7	CNF MOBILE SOLUTIONS, INC.
+ 0:30:e8	ENSIM CORP.
+ 0:30:e9	GMA COMMUNICATION MANUFACT'G
+@@ -3594,7 +6919,7 @@
+ 0:30:ed	Expert Magnetics Corp.
+ 0:30:ee	DSG Technology, Inc.
+ 0:30:ef	NEON TECHNOLOGY, INC.
+-0:30:f	IMT - Information Management T
++0:30:e	Klotz Digital AG
+ 0:30:f0	Uniform Industrial Corp.
+ 0:30:f1	Accton Technology Corp.
+ 0:30:f2	CISCO SYSTEMS, INC.
+@@ -3611,9 +6936,9 @@
+ 0:30:fd	INTEGRATED SYSTEMS DESIGN
+ 0:30:fe	DSA GmbH
+ 0:30:ff	DATAFAB SYSTEMS, INC.
++0:30:f	IMT - Information Management T
+ 0:3:0	NetContinuum, Inc.
+-0:3:1	Avantas Networks Corporation
+-0:3:10	Link Evolution Corp.
++0:3:10	ITX E-Globaledge Corporation
+ 0:3:11	Micro Technology Co., Ltd.
+ 0:3:12	TR-Systemtechnik GmbH
+ 0:3:13	Access Media SPA
+@@ -3624,17 +6949,17 @@
+ 0:3:18	Cyras Systems, Inc.
+ 0:3:19	Infineon AG
+ 0:3:1a	Beijing Broad Telecom Ltd., China
++0:3:1	Avantas Networks Corporation
+ 0:3:1b	Cellvision Systems, Inc.
+ 0:3:1c	Svenska Hardvarufabriken AB
+ 0:3:1d	Taiwan Commate Computer, Inc.
+ 0:3:1e	Optranet, Inc.
+ 0:3:1f	Condev Ltd.
+-0:3:2	Charles Industries, Ltd.
+ 0:3:20	Xpeed, Inc.
+ 0:3:21	Reco Research Co., Ltd.
+ 0:3:22	IDIS Co., Ltd.
+ 0:3:23	Cornet Technology, Inc.
+-0:3:24	SANYO Multimedia Tottori Co., Ltd.
++0:3:24	SANYO Consumer Electronics Co., Ltd.
+ 0:3:25	Arima Computer Corp.
+ 0:3:26	Iwasaki Information Systems Co., Ltd.
+ 0:3:27	ACT'L
+@@ -3642,17 +6967,18 @@
+ 0:3:29	F3, Inc.
+ 0:3:2a	UniData Communication Systems, Inc.
+ 0:3:2b	GAI Datenfunksysteme GmbH
+-0:3:2c	ABB Industrie AG
++0:3:2c	ABB Switzerland Ltd
++0:3:2	Charles Industries, Ltd.
+ 0:3:2d	IBASE Technology, Inc.
+ 0:3:2e	Scope Information Management, Ltd.
+ 0:3:2f	Global Sun Technology, Inc.
+-0:3:3	JAMA Electronics Co., Ltd.
+ 0:3:30	Imagenics, Co., Ltd.
+ 0:3:31	Cisco Systems, Inc.
+ 0:3:32	Cisco Systems, Inc.
+ 0:3:33	Digitel Co., Ltd.
+ 0:3:34	Newport Electronics
+ 0:3:35	Mirae Technology
++0:33:6c	SynapSense Corporation
+ 0:3:36	Zetes Technologies
+ 0:3:37	Vaone, Inc.
+ 0:3:38	Oak Technology
+@@ -3663,7 +6989,7 @@
+ 0:3:3d	ILSHin Lab
+ 0:3:3e	Tateyama System Laboratory Co., Ltd.
+ 0:3:3f	BigBand Networks, Ltd.
+-0:3:4	Pacific Broadband Communications
++0:3:3	JAMA Electronics Co., Ltd.
+ 0:3:40	Floware Wireless Systems, Ltd.
+ 0:3:41	Axon Digital Design
+ 0:3:42	Nortel Networks
+@@ -3679,15 +7005,17 @@
+ 0:3:4c	Shanghai DigiVision Technology Co., Ltd.
+ 0:3:4d	Chiaro Networks, Ltd.
+ 0:3:4e	Pos Data Company, Ltd.
++0:34:f1	Radicom Research, Inc.
+ 0:3:4f	Sur-Gard Security
+-0:3:5	Smart Network Devices GmbH
++0:3:4	Pacific Broadband Communications
+ 0:3:50	BTICINO SPA
+ 0:3:51	Diebold, Inc.
+ 0:3:52	Colubris Networks
++0:35:32	Electro-Metrics Corporation
+ 0:3:53	Mitac, Inc.
+ 0:3:54	Fiber Logic Communications
+ 0:3:55	TeraBeam Internet Systems
+-0:3:56	Wincor Nixdorf GmbH & Co KG
++0:3:56	Wincor Nixdorf International GmbH
+ 0:3:57	Intervoice-Brite, Inc.
+ 0:3:58	Hanyang Digitech Co., Ltd.
+ 0:3:59	DigitalSis
+@@ -3697,7 +7025,7 @@
+ 0:3:5d	Bosung Hi-Net Co., Ltd.
+ 0:3:5e	Metropolitan Area Networks, Inc.
+ 0:3:5f	Prueftechnik Condition Monitoring GmbH & Co. KG
+-0:3:6	Fusion In Tech Co., Ltd.
++0:3:5	MSC Vertriebs GmbH
+ 0:3:60	PAC Interactive Technology, Inc.
+ 0:3:61	Widcomm, Inc.
+ 0:3:62	Vodtel Communications, Inc.
+@@ -3714,12 +7042,12 @@
+ 0:3:6d	Runtop, Inc.
+ 0:3:6e	Nicon Systems (Pty) Limited
+ 0:3:6f	Telsey SPA
+-0:3:7	Secure Works, Inc.
++0:3:6	Fusion In Tech Co., Ltd.
+ 0:3:70	NXTV, Inc.
+ 0:3:71	Acomz Networks Corp.
+ 0:3:72	ULAN
+ 0:3:73	Aselsan A.S
+-0:3:74	Hunter Watertech
++0:3:74	Control Microsystems
+ 0:3:75	NetMedia, Inc.
+ 0:3:76	Graphtec Technology, Inc.
+ 0:3:77	Gigabit Wireless
+@@ -3731,7 +7059,7 @@
+ 0:3:7d	Stellcom
+ 0:3:7e	PORTech Communications, Inc.
+ 0:3:7f	Atheros Communications, Inc.
+-0:3:8	AM Communications, Inc.
++0:3:7	Secure Works, Inc.
+ 0:3:80	SSH Communications Security Corp.
+ 0:3:81	Ingenico International
+ 0:3:82	A-One Co., Ltd.
+@@ -3743,12 +7071,12 @@
+ 0:3:88	Fastfame Technology Co., Ltd.
+ 0:3:89	Plantronics
+ 0:3:8a	America Online, Inc.
++0:3:8	AM Communications, Inc.
+ 0:3:8b	PLUS-ONE I&T, Inc.
+ 0:3:8c	Total Impact
+ 0:3:8d	PCS Revenue Control Systems, Inc.
+ 0:3:8e	Atoga Systems, Inc.
+ 0:3:8f	Weinschel Corporation
+-0:3:9	Texcel Technology PLC
+ 0:3:90	Digital Video Communications, Inc.
+ 0:3:91	Advanced Digital Broadcast, Ltd.
+ 0:3:92	Hyundai Teletek Co., Ltd.
+@@ -3756,33 +7084,40 @@
+ 0:3:94	Connect One
+ 0:3:95	California Amplifier
+ 0:3:96	EZ Cast Co., Ltd.
+-0:3:97	Watchfront Electronics
++0:3:97	Watchfront Limited
+ 0:3:98	WISI
+ 0:3:99	Dongju Informations & Communications Co., Ltd.
+-0:3:9a	nSine, Ltd.
++0:3:9a	SiConnect
+ 0:3:9b	NetChip Technology, Inc.
+ 0:3:9c	OptiMight Communications, Inc.
+-0:3:9d	BENQ CORPORATION
++0:3:9d	Qisda Corporation
+ 0:3:9e	Tera System Co., Ltd.
+ 0:3:9f	Cisco Systems, Inc.
+-0:3:a	Argus Technologies
++0:3:9	Texcel Technology PLC
+ 0:3:a0	Cisco Systems, Inc.
+ 0:3:a1	HIPER Information & Communication, Inc.
+ 0:3:a2	Catapult Communications
+ 0:3:a3	MAVIX, Ltd.
+-0:3:a4	Data Storage and Information Management
++0:3:a4	Imation Corp.
+ 0:3:a5	Medea Corporation
+ 0:3:a6	Traxit Technology, Inc.
+ 0:3:a7	Unixtar Technology, Inc.
+ 0:3:a8	IDOT Computers, Inc.
++0:3a:98	Cisco Systems
++0:3a:99	Cisco Systems
++0:3a:9a	Cisco Systems
+ 0:3:a9	AXCENT Media AG
++0:3a:9b	Cisco Systems
++0:3a:9c	Cisco Systems
++0:3a:9d	NEC AccessTechnica, Ltd.
++0:3a:af	BlueBit Ltd.
++0:3:a	Argus Technologies
+ 0:3:aa	Watlow
+ 0:3:ab	Bridge Information Systems
+ 0:3:ac	Fronius Schweissmaschinen
+ 0:3:ad	Emerson Energy Systems AB
+ 0:3:ae	Allied Advanced Manufacturing Pte, Ltd.
+ 0:3:af	Paragea Communications
+-0:3:b	Hunter Technology, Inc.
+ 0:3:b0	Xsense Technology Corp.
+ 0:3:b1	Hospira Inc.
+ 0:3:b2	Radware
+@@ -3793,13 +7128,13 @@
+ 0:3:b7	ZACCESS Systems
+ 0:3:b8	NetKit Solutions, LLC
+ 0:3:b9	Hualong Telecom Co., Ltd.
+-0:3:ba	Sun Microsystems
++0:3:ba	Oracle Corporation
+ 0:3:bb	Signal Communications Limited
+ 0:3:bc	COT GmbH
+ 0:3:bd	OmniCluster Technologies, Inc.
+ 0:3:be	Netility
+ 0:3:bf	Centerpoint Broadband Technologies, Inc.
+-0:3:c	Telesoft Technologies Ltd.
++0:3:b	Hunter Technology, Inc.
+ 0:3:c0	RFTNC Co., Ltd.
+ 0:3:c1	Packet Dynamics Ltd
+ 0:3:c2	Solphone K.K.
+@@ -3812,15 +7147,17 @@
+ 0:3:c9	TECOM Co., Ltd.
+ 0:3:ca	MTS Systems Corp.
+ 0:3:cb	Nippon Systems Development Co., Ltd.
++0:3c:c5	WONWOO Engineering Co., Ltd
+ 0:3:cc	Momentum Computer, Inc.
+ 0:3:cd	Clovertech, Inc.
+ 0:3:ce	ETEN Technologies, Inc.
+ 0:3:cf	Muxcom, Inc.
+-0:3:d	Uniwill Computer Corp.
++0:3:c	Telesoft Technologies Ltd.
+ 0:3:d0	KOANKEISO Co., Ltd.
+ 0:3:d1	Takaya Corporation
+ 0:3:d2	Crossbeam Systems, Inc.
+ 0:3:d3	Internet Energy Systems, Inc.
++0:3d:41	Hatteland Computer AS
+ 0:3:d4	Alloptic, Inc.
+ 0:3:d5	Advanced Communications Co., Ltd.
+ 0:3:d6	RADVision, Ltd.
+@@ -3833,24 +7170,24 @@
+ 0:3:dd	Comark Corp.
+ 0:3:de	OTC Wireless
+ 0:3:df	Desana Systems
+-0:3:e	Core Communications Co., Ltd.
+-0:3:e0	RadioFrame Networks, Inc.
++0:3:d	Uniwill Computer Corp.
++0:3:e0	Motorola, Inc.
+ 0:3:e1	Winmate Communication, Inc.
+ 0:3:e2	Comspace Corporation
+ 0:3:e3	Cisco Systems, Inc.
+ 0:3:e4	Cisco Systems, Inc.
+ 0:3:e5	Hermstedt SG
+-0:3:e6	Entone Technologies, Inc.
++0:3:e6	Entone, Inc.
+ 0:3:e7	Logostek Co. Ltd.
+ 0:3:e8	Wavelength Digital Limited
+ 0:3:e9	Akara Canada, Inc.
+ 0:3:ea	Mega System Technologies, Inc.
+ 0:3:eb	Atrica
+ 0:3:ec	ICG Research, Inc.
++0:3:e	Core Communications Co., Ltd.
+ 0:3:ed	Shinkawa Electric Co., Ltd.
+ 0:3:ee	MKNet Corporation
+ 0:3:ef	Oneline AG
+-0:3:f	Digital China (Shanghai) Networks Ltd.
+ 0:3:f0	Redfern Broadband Networks
+ 0:3:f1	Cicada Semiconductor, Inc.
+ 0:3:f2	Seneca Networks
+@@ -3862,20 +7199,20 @@
+ 0:3:f8	SanCastle Technologies, Inc.
+ 0:3:f9	Pleiades Communications, Inc.
+ 0:3:fa	TiMetra Networks
+-0:3:fb	Toko Seiki Company, Ltd.
++0:3:fb	ENEGATE Co.,Ltd.
+ 0:3:fc	Intertex Data AB
+ 0:3:fd	Cisco Systems, Inc.
++0:3:f	Digital China (Shanghai) Networks Ltd.
+ 0:3:fe	Cisco Systems, Inc.
+ 0:3:ff	Microsoft Corporation
+ 0:40:0	PCI COMPONENTES DA AMZONIA LTD
+-0:40:1	ZYXEL COMMUNICATIONS, INC.
+ 0:40:10	SONIC SYSTEMS, INC.
+ 0:40:11	ANDOVER CONTROLS CORPORATION
+ 0:40:12	WINDATA, INC.
+ 0:40:13	NTT DATA COMM. SYSTEMS CORP.
+ 0:40:14	COMSOFT GMBH
+ 0:40:15	ASCOM INFRASYS AG
+-0:40:16	HADAX ELECTRONICS, INC.
++0:40:16	ADC - Global Connectivity Solutions Division
+ 0:40:17	Silex Technology America
+ 0:40:18	ADOBE SYSTEMS, INC.
+ 0:40:19	AEON SYSTEMS, INC.
+@@ -3885,14 +7222,14 @@
+ 0:40:1d	INVISIBLE SOFTWARE, INC.
+ 0:40:1e	ICC
+ 0:40:1f	COLORGRAPH LTD
+-0:40:2	PERLE SYSTEMS LIMITED
+-0:40:20	PINACL COMMUNICATION
++0:40:1	ZYXEL COMMUNICATIONS, INC.
++0:40:20	Tyco Electronics (UK) Ltd
+ 0:40:21	RASTER GRAPHICS
+ 0:40:22	KLEVER COMPUTERS, INC.
+ 0:40:23	LOGIC CORPORATION
+ 0:40:24	COMPAC INC.
+ 0:40:25	MOLECULAR DYNAMICS
+-0:40:26	MELCO, INC.
++0:40:26	Buffalo, Inc
+ 0:40:27	SMC MASSACHUSETTS, INC.
+ 0:40:28	NETCOMM LIMITED
+ 0:40:29	COMPEX
+@@ -3902,7 +7239,7 @@
+ 0:40:2d	HARRIS ADACOM CORPORATION
+ 0:40:2e	PRECISION SOFTWARE, INC.
+ 0:40:2f	XLNT DESIGNS INC.
+-0:40:3	Emerson Process Management Power & Water Solutions, Inc.
++0:40:2	PERLE SYSTEMS LIMITED
+ 0:40:30	GK COMPUTER
+ 0:40:31	KOKUSAI ELECTRIC CO., LTD
+ 0:40:32	DIGITAL COMMUNICATIONS
+@@ -3917,13 +7254,13 @@
+ 0:40:3b	SYNERJET INTERNATIONAL CORP.
+ 0:40:3c	FORKS, INC.
+ 0:40:3d	TERADATA
++0:40:3	Emerson Process Management Power & Water Solutions, Inc.
+ 0:40:3e	RASTER OPS CORPORATION
+ 0:40:3f	SSANGYONG COMPUTER SYSTEMS
+-0:40:4	ICM CO. LTD.
+ 0:40:40	RING ACCESS, INC.
+ 0:40:41	FUJIKURA LTD.
+ 0:40:42	N.A.T. GMBH
+-0:40:43	NOKIA TELECOMMUNICATIONS
++0:40:43	Nokia Siemens Networks GmbH & Co. KG.
+ 0:40:44	QNIX COMPUTER CO., LTD.
+ 0:40:45	TWINHEAD CORPORATION
+ 0:40:46	UDC RESEARCH LIMITED
+@@ -3936,7 +7273,7 @@
+ 0:40:4d	TELECOMMUNICATIONS TECHNIQUES
+ 0:40:4e	FLUENT, INC.
+ 0:40:4f	SPACE & NAVAL WARFARE SYSTEMS
+-0:40:5	ANI COMMUNICATIONS INC.
++0:40:4	ICM CO. LTD.
+ 0:40:50	IRONICS, INCORPORATED
+ 0:40:51	GRACILIS, INC.
+ 0:40:52	STAR TECHNOLOGIES, INC.
+@@ -3948,12 +7285,12 @@
+ 0:40:58	KRONOS, INC.
+ 0:40:59	YOSHIDA KOGYO K. K.
+ 0:40:5a	GOLDSTAR INFORMATION & COMM.
++0:40:5	ANI COMMUNICATIONS INC.
+ 0:40:5b	FUNASSET LIMITED
+ 0:40:5c	FUTURE SYSTEMS, INC.
+ 0:40:5d	STAR-TEK, INC.
+ 0:40:5e	NORTH HILLS ISRAEL
+ 0:40:5f	AFE COMPUTERS LTD.
+-0:40:6	SAMPO TECHNOLOGY CORPORATION
+ 0:40:60	COMENDEC LTD
+ 0:40:61	DATATECH ENTERPRISES CO., LTD.
+ 0:40:62	E-SYSTEMS, INC./GARLAND DIV.
+@@ -3970,7 +7307,7 @@
+ 0:40:6d	LANCO, INC.
+ 0:40:6e	COROLLARY, INC.
+ 0:40:6f	SYNC RESEARCH INC.
+-0:40:7	TELMAT INFORMATIQUE
++0:40:6	SAMPO TECHNOLOGY CORPORATION
+ 0:40:70	INTERWARE CO., LTD.
+ 0:40:71	ATM COMPUTER GMBH
+ 0:40:72	Applied Innovation Inc.
+@@ -3987,24 +7324,24 @@
+ 0:40:7d	EXTENSION TECHNOLOGY CORP.
+ 0:40:7e	EVERGREEN SYSTEMS, INC.
+ 0:40:7f	FLIR Systems
+-0:40:8	A PLUS INFO CORPORATION
++0:40:7	TELMAT INFORMATIQUE
+ 0:40:80	ATHENIX CORPORATION
+ 0:40:81	MANNESMANN SCANGRAPHIC GMBH
+ 0:40:82	LABORATORY EQUIPMENT CORP.
+ 0:40:83	TDA INDUSTRIA DE PRODUTOS
+-0:40:84	HONEYWELL INC.
++0:40:84	HONEYWELL ACS
+ 0:40:85	SAAB INSTRUMENTS AB
+ 0:40:86	MICHELS & KLEBERHOFF COMPUTER
+ 0:40:87	UBITREX CORPORATION
+ 0:40:88	MOBIUS TECHNOLOGIES, INC.
+ 0:40:89	MEIDENSHA CORPORATION
++0:40:8	A PLUS INFO CORPORATION
+ 0:40:8a	TPS TELEPROCESSING SYS. GMBH
+ 0:40:8b	RAYLAN CORPORATION
+ 0:40:8c	AXIS COMMUNICATIONS AB
+ 0:40:8d	THE GOODYEAR TIRE & RUBBER CO.
+ 0:40:8e	DIGILOG, INC.
+ 0:40:8f	WM-DATA MINFO AB
+-0:40:9	TACHIBANA TECTRON CO., LTD.
+ 0:40:90	ANSEL COMMUNICATIONS
+ 0:40:91	PROCOMP INDUSTRIA ELETRONICA
+ 0:40:92	ASP COMPUTER PRODUCTS, INC.
+@@ -4021,7 +7358,7 @@
+ 0:40:9d	DIGIBOARD, INC.
+ 0:40:9e	CONCURRENT TECHNOLOGIES  LTD.
+ 0:40:9f	LANCAST/CASAT TECHNOLOGY, INC.
+-0:40:a	PIVOTAL TECHNOLOGIES, INC.
++0:40:9	TACHIBANA TECTRON CO., LTD.
+ 0:40:a0	GOLDSTAR CO., LTD.
+ 0:40:a1	ERGO COMPUTING
+ 0:40:a2	KINGSTAR TECHNOLOGY INC.
+@@ -4038,7 +7375,7 @@
+ 0:40:ad	SMA REGELSYSTEME GMBH
+ 0:40:ae	DELTA CONTROLS, INC.
+ 0:40:af	DIGITAL PRODUCTS, INC.
+-0:40:b	CISCO SYSTEMS, INC.
++0:40:a	PIVOTAL TECHNOLOGIES, INC.
+ 0:40:b0	BYTEX CORPORATION, ENGINEERING
+ 0:40:b1	CODONICS INC.
+ 0:40:b2	SYSTEMFORSCHUNG
+@@ -4052,10 +7389,10 @@
+ 0:40:ba	ALLIANT COMPUTER SYSTEMS CORP.
+ 0:40:bb	GOLDSTAR CABLE CO., LTD.
+ 0:40:bc	ALGORITHMICS LTD.
++0:40:b	CISCO SYSTEMS, INC.
+ 0:40:bd	STARLIGHT NETWORKS, INC.
+ 0:40:be	BOEING DEFENSE & SPACE
+ 0:40:bf	CHANNEL SYSTEMS INTERN'L INC.
+-0:40:c	GENERAL MICRO SYSTEMS, INC.
+ 0:40:c0	VISTA CONTROLS CORPORATION
+ 0:40:c1	BIZERBA-WERKE WILHEIM KRAUT
+ 0:40:c2	APPLIED COMPUTING DEVICES
+@@ -4072,13 +7409,13 @@
+ 0:40:cd	TERA MICROSYSTEMS, INC.
+ 0:40:ce	NET-SOURCE, INC.
+ 0:40:cf	STRAWBERRY TREE, INC.
+-0:40:d	LANNET DATA COMMUNICATIONS,LTD
++0:40:c	GENERAL MICRO SYSTEMS, INC.
+ 0:40:d0	MITAC INTERNATIONAL CORP.
+ 0:40:d1	FUKUDA DENSHI CO., LTD.
+ 0:40:d2	PAGINE CORPORATION
+ 0:40:d3	KIMPSION INTERNATIONAL CORP.
+ 0:40:d4	GAGE TALKER CORP.
+-0:40:d5	SARTORIUS AG
++0:40:d5	Sartorius Mechatronics T&H GmbH 
+ 0:40:d6	LOCAMATION B.V.
+ 0:40:d7	STUDIO GEN INC.
+ 0:40:d8	OCEAN OFFICE AUTOMATION LTD.
+@@ -4087,9 +7424,9 @@
+ 0:40:db	ADVANCED TECHNICAL SOLUTIONS
+ 0:40:dc	TRITEC ELECTRONIC GMBH
+ 0:40:dd	HONG TECHNOLOGIES
+-0:40:de	ELETTRONICA SAN GIORGIO
++0:40:de	Elsag Datamat spa
+ 0:40:df	DIGALOG SYSTEMS, INC.
+-0:40:e	MEMOTEC COMMUNICATIONS, INC.
++0:40:d	LANNET DATA COMMUNICATIONS,LTD
+ 0:40:e0	ATOMWIDE LTD.
+ 0:40:e1	MARNER INTERNATIONAL, INC.
+ 0:40:e2	MESA RIDGE TECHNOLOGIES, INC.
+@@ -4106,7 +7443,7 @@
+ 0:40:ed	NETWORK CONTROLS INT'NATL INC.
+ 0:40:ee	OPTIMEM
+ 0:40:ef	HYPERCOM, INC.
+-0:40:f	DATACOM TECHNOLOGIES
++0:40:e	MEMOTEC, INC.
+ 0:40:f0	MICRO SYSTEMS, INC.
+ 0:40:f1	CHUO ELECTRONICS CO., LTD.
+ 0:40:f2	JANICH & KLASS COMPUTERTECHNIK
+@@ -4114,19 +7451,17 @@
+ 0:40:f4	CAMEO COMMUNICATIONS, INC.
+ 0:40:f5	OEM ENGINES
+ 0:40:f6	KATRON COMPUTERS INC.
+-0:40:f7	POLAROID MEDICAL IMAGING SYS.
++0:40:f7	Polaroid Corporation
+ 0:40:f8	SYSTEMHAUS DISCOM
+ 0:40:f9	COMBINET
+ 0:40:fa	MICROBOARDS, INC.
+ 0:40:fb	CASCADE COMMUNICATIONS CORP.
+ 0:40:fc	IBR COMPUTER TECHNIK GMBH
++0:40:f	DATACOM TECHNOLOGIES
+ 0:40:fd	LXE
+ 0:40:fe	SYMPLEX COMMUNICATIONS
+ 0:40:ff	TELEBIT CORPORATION
+-0:42:52	RLX Technologies
+-0:45:1	Versus Technology, Inc.
+ 0:4:0	LEXMARK INTERNATIONAL, INC.
+-0:4:1	Osaki Electric Co., Ltd.
+ 0:4:10	Spinnaker Networks, Inc.
+ 0:4:11	Inkra Networks, Inc.
+ 0:4:12	WaveSmith Networks, Inc.
+@@ -4137,18 +7472,19 @@
+ 0:4:17	ELAU AG
+ 0:4:18	Teltronic S.A.U.
+ 0:4:19	Fibercycle Networks, Inc.
+-0:4:1a	ines GmbH
+-0:4:1b	Digital Interfaces Ltd.
++0:4:1a	Ines Test and Measurement GmbH & CoKG
++0:4:1b	Bridgeworks Ltd.
+ 0:4:1c	ipDialog, Inc.
+ 0:4:1d	Corega of America
+ 0:4:1e	Shikoku Instrumentation Co., Ltd.
+ 0:4:1f	Sony Computer Entertainment, Inc.
+-0:4:2	Nexsan Technologies, Ltd.
++0:4:1	Osaki Electric Co., Ltd.
+ 0:4:20	Slim Devices, Inc.
+ 0:4:21	Ocular Networks
+ 0:4:22	Gordon Kapes, Inc.
+ 0:4:23	Intel Corporation
+ 0:4:24	TMC s.r.l.
++0:42:52	RLX Technologies
+ 0:4:25	Atmel Corporation
+ 0:4:26	Autosys
+ 0:4:27	Cisco Systems, Inc.
+@@ -4160,7 +7496,7 @@
+ 0:4:2d	Sarian Systems, Ltd.
+ 0:4:2e	Netous Technologies, Ltd.
+ 0:4:2f	International Communications Products, Inc.
+-0:4:3	Nexsi Corporation
++0:4:2	Nexsan Technologies, Ltd.
+ 0:4:30	Netgem
+ 0:4:31	GlobalStreams, Inc.
+ 0:4:32	Voyetra Turtle Beach, Inc.
+@@ -4176,8 +7512,8 @@
+ 0:4:3c	SONOS Co., Ltd.
+ 0:4:3d	INDEL AG
+ 0:4:3e	Telencomm
+-0:4:3f	Electronic Systems Technology, Inc.
+-0:4:4	Makino Milling Machine Co., Ltd.
++0:4:3f	ESTeem Wireless Modems, Inc
++0:4:3	Nexsi Corporation
+ 0:4:40	cyberPIXIE, Inc.
+ 0:4:41	Half Dome Systems, Inc.
+ 0:4:42	NACT
+@@ -4186,7 +7522,7 @@
+ 0:4:45	LMS Skalar Instruments GmbH
+ 0:4:46	CYZENTECH Co., Ltd.
+ 0:4:47	Acrowave Systems Co., Ltd.
+-0:4:48	Polaroid Professional Imaging
++0:4:48	Polaroid Corporation
+ 0:4:49	Mapletree Networks
+ 0:4:4a	iPolicy Networks, Inc.
+ 0:4:4b	NVIDIA
+@@ -4194,24 +7530,25 @@
+ 0:4:4d	Cisco Systems, Inc.
+ 0:4:4e	Cisco Systems, Inc.
+ 0:4:4f	Leukhardt Systemelektronik GmbH
+-0:4:5	ACN Technologies
++0:4:4	Makino Milling Machine Co., Ltd.
+ 0:4:50	DMD Computers SRL
+ 0:4:51	Medrad, Inc.
++0:45:1	Versus Technology, Inc.
+ 0:4:52	RocketLogix, Inc.
+ 0:4:53	YottaYotta, Inc.
+ 0:4:54	Quadriga UK
+ 0:4:55	ANTARA.net
+-0:4:56	PipingHot Networks
++0:4:56	Motorola PTP Inc
+ 0:4:57	Universal Access Technology, Inc.
+ 0:4:58	Fusion X Co., Ltd.
+ 0:4:59	Veristar Corporation
++0:4:5	ACN Technologies
+ 0:4:5a	The Linksys Group, Inc.
+ 0:4:5b	Techsan Electronics Co., Ltd.
+ 0:4:5c	Mobiwave Pte Ltd
+ 0:4:5d	BEKA Elektronik
+ 0:4:5e	PolyTrax Information Technology AG
+ 0:4:5f	Evalue Technology, Inc.
+-0:4:6	Fa. Metabox AG
+ 0:4:60	Knilink Technology, Inc.
+ 0:4:61	EPOX Computer Co., Ltd.
+ 0:4:62	DAKOS Data & Communication Co., Ltd.
+@@ -4227,8 +7564,8 @@
+ 0:4:6c	Cyber Technology Co., Ltd.
+ 0:4:6d	Cisco Systems, Inc.
+ 0:4:6e	Cisco Systems, Inc.
++0:4:6	Fa. Metabox AG
+ 0:4:6f	Digitel S/A Industria Eletronica
+-0:4:7	Topcon Positioning Systems, Inc.
+ 0:4:70	ipUnplugged AB
+ 0:4:71	IPrad
+ 0:4:72	Telelynx, Inc.
+@@ -4245,8 +7582,8 @@
+ 0:4:7d	Pelco
+ 0:4:7e	Optelecom=NKF
+ 0:4:7f	Chr. Mayr GmbH & Co. KG
+-0:4:8	Sanko Electronics Co., Ltd.
+-0:4:80	Foundry Networks, Inc.
++0:4:7	Topcon Positioning Systems, Inc.
++0:4:80	Brocade Communications Systems, Inc
+ 0:4:81	Econolite Control Products, Inc.
+ 0:4:82	Medialogic Corp.
+ 0:4:83	Deltron Technology, Inc.
+@@ -4261,25 +7598,25 @@
+ 0:4:8c	Nayna Networks, Inc.
+ 0:4:8d	Tone Commander Systems, Inc.
+ 0:4:8e	Ohm Tech Labs, Inc.
+-0:4:8f	TD Systems Corp.
+-0:4:9	Cratos Networks
++0:4:8f	TD Systems Corporation
++0:4:8	Sanko Electronics Co., Ltd.
+ 0:4:90	Optical Access
+ 0:4:91	Technovision, Inc.
+ 0:4:92	Hive Internet, Ltd.
+ 0:4:93	Tsinghua Unisplendour Co., Ltd.
+ 0:4:94	Breezecom, Ltd.
+-0:4:95	Tejas Networks
++0:4:95	Tejas Networks India Limited
+ 0:4:96	Extreme Networks
+ 0:4:97	MacroSystem Digital Video AG
+ 0:4:98	Mahi Networks
+ 0:4:99	Chino Corporation
+ 0:4:9a	Cisco Systems, Inc.
+ 0:4:9b	Cisco Systems, Inc.
++0:4:9	Cratos Networks
+ 0:4:9c	Surgient Networks, Inc.
+ 0:4:9d	Ipanema Technologies
+ 0:4:9e	Wirelink Co., Ltd.
+ 0:4:9f	Freescale Semiconductor
+-0:4:a	Sage Systems
+ 0:4:a0	Verity Instruments, Inc.
+ 0:4:a1	Pathway Connectivity
+ 0:4:a2	L.S.I. Japan Co., Ltd.
+@@ -4294,12 +7631,13 @@
+ 0:4:ab	Comverse Network Systems, Inc.
+ 0:4:ac	IBM CORP.
+ 0:4:ad	Malibu Networks
+-0:4:ae	Liquid Metronics
++0:4:ae	Sullair Corporation
+ 0:4:af	Digital Fountain, Inc.
+-0:4:b	3com Europe Ltd.
++0:4:a	Sage Systems
+ 0:4:b0	ELESIGN Co., Ltd.
+ 0:4:b1	Signal Technology, Inc.
+ 0:4:b2	ESSEGI SRL
++0:4:b	3com Europe Ltd.
+ 0:4:b3	Videotek, Inc.
+ 0:4:b4	CIAC
+ 0:4:b5	Equitrac Corporation
+@@ -4313,7 +7651,6 @@
+ 0:4:bd	Motorola BCS
+ 0:4:be	OptXCon, Inc.
+ 0:4:bf	VersaLogic Corp.
+-0:4:c	KANNO Work's Ltd.
+ 0:4:c0	Cisco Systems, Inc.
+ 0:4:c1	Cisco Systems, Inc.
+ 0:4:c2	Magnipix, Inc.
+@@ -4330,24 +7667,24 @@
+ 0:4:cd	Informedia Research Group
+ 0:4:ce	Patria Ailon
+ 0:4:cf	Seagate Technology
+-0:4:d	Avaya, Inc.
++0:4:c	KANNO Work's Ltd.
+ 0:4:d0	Softlink s.r.o.
+ 0:4:d1	Drew Technologies, Inc.
+ 0:4:d2	Adcon Telemetry GmbH
+ 0:4:d3	Toyokeiki Co., Ltd.
+ 0:4:d4	Proview Electronics Co., Ltd.
+-0:4:d5	Hitachi Communication Systems, Inc.
++0:4:d5	Hitachi Information & Communication Engineering, Ltd.
+ 0:4:d6	Takagi Industrial Co., Ltd.
+ 0:4:d7	Omitec Instrumentation Ltd.
+ 0:4:d8	IPWireless, Inc.
+ 0:4:d9	Titan Electronics, Inc.
+ 0:4:da	Relax Technology, Inc.
++0:4:d	Avaya, Inc.
+ 0:4:db	Tellus Group Corp.
+ 0:4:dc	Nortel Networks
+ 0:4:dd	Cisco Systems, Inc.
+ 0:4:de	Cisco Systems, Inc.
+ 0:4:df	Teracom Telematica Ltda.
+-0:4:e	AVM GmbH
+ 0:4:e0	Procket Networks
+ 0:4:e1	Infinior Microsystems
+ 0:4:e2	SMC Networks, Inc.
+@@ -4359,12 +7696,12 @@
+ 0:4:e8	IER, Inc.
+ 0:4:e9	Infiniswitch Corporation
+ 0:4:ea	Hewlett-Packard Company
++0:4:e	AVM GmbH
+ 0:4:eb	Paxonet Communications, Inc.
+ 0:4:ec	Memobox SA
+ 0:4:ed	Billion Electric Co., Ltd.
+ 0:4:ee	Lincoln Electric Company
+ 0:4:ef	Polestar Corp.
+-0:4:f	Asus Network Technologies, Inc.
+ 0:4:f0	International Computers, Ltd
+ 0:4:f1	WhereNet
+ 0:4:f2	Polycom
+@@ -4376,13 +7713,13 @@
+ 0:4:f8	QUALICABLE TV Industria E Com., Ltda
+ 0:4:f9	Xtera Communications, Inc.
+ 0:4:fa	NBS Technologies Inc.
++0:4:f	Asus Network Technologies, Inc.
+ 0:4:fb	Commtech, Inc.
+ 0:4:fc	Stratus Computer (DE), Inc.
+ 0:4:fd	Japan Control Engineering Co., Ltd.
+ 0:4:fe	Pelago Networks
+ 0:4:ff	Acronet Co., Ltd.
+ 0:50:0	NEXO COMMUNICATIONS, INC.
+-0:50:1	YAMASHITA SYSTEMS CORP.
+ 0:50:10	NovaNET Learning, Inc.
+ 0:50:12	CBL - GMBH
+ 0:50:13	Chaparral Network Storage
+@@ -4392,12 +7729,12 @@
+ 0:50:17	RSR S.R.L.
+ 0:50:18	AMIT, Inc.
+ 0:50:19	SPRING TIDE NETWORKS, INC.
+-0:50:1a	UISIQN
++0:50:1a	IQinVision
+ 0:50:1b	ABL CANADA, INC.
+ 0:50:1c	JATOM SYSTEMS, INC.
+ 0:50:1e	Miranda Technologies, Inc.
+ 0:50:1f	MRG SYSTEMS, LTD.
+-0:50:2	OMNISEC AG
++0:50:1	YAMASHITA SYSTEMS CORP.
+ 0:50:20	MEDIASTAR CO., LTD.
+ 0:50:21	EIS INTERNATIONAL, INC.
+ 0:50:22	ZONET TECHNOLOGY, INC.
+@@ -4413,7 +7750,7 @@
+ 0:50:2d	ACCEL, INC.
+ 0:50:2e	CAMBEX CORPORATION
+ 0:50:2f	TollBridge Technologies, Inc.
+-0:50:3	GRETAG MACBETH AG
++0:50:2	OMNISEC AG
+ 0:50:30	FUTURE PLUS SYSTEMS
+ 0:50:31	AEROFLEX LABORATORIES, INC.
+ 0:50:32	PICAZO COMMUNICATIONS, INC.
+@@ -4427,21 +7764,22 @@
+ 0:50:3c	TSINGHUA NOVEL ELECTRONICS
+ 0:50:3e	CISCO SYSTEMS, INC.
+ 0:50:3f	ANCHOR GAMES
+-0:50:4	3COM CORPORATION
+-0:50:40	Panasonic Electric Works Laboratory of America, Inc./SLC Lab
+-0:50:41	CTX OPTO ELECTRONIC CORP.
++0:50:3	GRETAG MACBETH AG
++0:50:40	Panasonic Electric Works Co., Ltd.
++0:50:41	Coretronic Corporation
+ 0:50:42	SCI MANUFACTURING SINGAPORE PTE, LTD.
++0:50:4	3COM CORPORATION
+ 0:50:43	MARVELL SEMICONDUCTOR, INC.
+ 0:50:44	ASACA CORPORATION
+ 0:50:45	RIOWORKS SOLUTIONS, INC.
+ 0:50:46	MENICX INTERNATIONAL CO., LTD.
+ 0:50:47	PRIVATE
+ 0:50:48	INFOLIBRIA
+-0:50:49	ELLACOYA NETWORKS, INC.
++0:50:49	Arbor Networks Inc
+ 0:50:4a	ELTECO A.S.
+ 0:50:4b	BARCONET N.V.
+-0:50:4c	GALIL MOTION CONTROL, INC.
+-0:50:4d	TOKYO ELECTRON DEVICE LTD.
++0:50:4c	Galil Motion Control
++0:50:4d	Tokyo Electron Device Limited
+ 0:50:4e	SIERRA MONITOR CORP.
+ 0:50:4f	OLENCOM ELECTRONICS
+ 0:50:50	CISCO SYSTEMS, INC.
+@@ -4450,32 +7788,31 @@
+ 0:50:53	CISCO SYSTEMS, INC.
+ 0:50:54	CISCO SYSTEMS, INC.
+ 0:50:55	DOMS A/S
+-0:50:56	VMWare, Inc.
++0:50:56	VMware, Inc.
+ 0:50:57	BROADBAND ACCESS SYSTEMS
+-0:50:58	VegaStream Limted
++0:50:58	VegaStream Group Limted
+ 0:50:59	iBAHN
+ 0:50:5a	NETWORK ALCHEMY, INC.
+ 0:50:5b	KAWASAKI LSI U.S.A., INC.
+ 0:50:5c	TUNDO CORPORATION
+ 0:50:5e	DIGITEK MICROLOGIC S.A.
+ 0:50:5f	BRAND INNOVATORS
+-0:50:6	TAC AB
+ 0:50:60	TANDBERG TELECOM AS
+ 0:50:62	KOUWELL ELECTRONICS CORP.  **
+ 0:50:63	OY COMSEL SYSTEM AB
+ 0:50:64	CAE ELECTRONICS
+-0:50:65	DENSEI-LAMBAD Co., Ltd.
++0:50:65	TDK-Lambda Corporation
+ 0:50:66	AtecoM GmbH advanced telecomunication modules
+ 0:50:67	AEROCOMM, INC.
+ 0:50:68	ELECTRONIC INDUSTRIES ASSOCIATION
+ 0:50:69	PixStream Incorporated
+ 0:50:6a	EDEVA, INC.
+ 0:50:6b	SPX-ATEG
+-0:50:6c	G & L BEIJER ELECTRONICS AB
++0:50:6c	Beijer Electronics Products AB
+ 0:50:6d	VIDEOJET SYSTEMS
+ 0:50:6e	CORDER ENGINEERING CORPORATION
+ 0:50:6f	G-CONNECT
+-0:50:7	SIEMENS TELECOMMUNICATION SYSTEMS LIMITED
++0:50:6	TAC AB
+ 0:50:70	CHAINTECH COMPUTER CO., LTD.
+ 0:50:71	AIWA CO., LTD.
+ 0:50:72	CORVIS CORPORATION
+@@ -4492,7 +7829,7 @@
+ 0:50:7d	IFP
+ 0:50:7e	NEWER TECHNOLOGY
+ 0:50:7f	DrayTek Corp.
+-0:50:8	TIVA MICROCOMPUTER CORP. (TMC)
++0:50:7	SIEMENS TELECOMMUNICATION SYSTEMS LIMITED
+ 0:50:80	CISCO SYSTEMS, INC.
+ 0:50:81	MURATA MACHINERY, LTD.
+ 0:50:82	FORESSON CORPORATION
+@@ -4502,12 +7839,12 @@
+ 0:50:87	TERASAKI ELECTRIC CO., LTD.
+ 0:50:88	AMANO CORPORATION
+ 0:50:89	SAFETY MANAGEMENT SYSTEMS
+-0:50:8b	COMPAQ COMPUTER CORPORATION
++0:50:8b	Hewlett Packard
+ 0:50:8c	RSI SYSTEMS
+ 0:50:8d	ABIT COMPUTER CORPORATION
+ 0:50:8e	OPTIMATION, INC.
+ 0:50:8f	ASITA TECHNOLOGIES INT'L LTD.
+-0:50:9	PHILIPS BROADBAND NETWORKS
++0:50:8	TIVA MICROCOMPUTER CORP. (TMC)
+ 0:50:90	DCTRI
+ 0:50:91	NETACCESS, INC.
+ 0:50:92	RIGAKU INDUSTRIAL CORPORATION
+@@ -4524,7 +7861,7 @@
+ 0:50:9d	THE INDUSTREE B.V.
+ 0:50:9e	Les Technologies SoftAcoustik Inc.
+ 0:50:9f	HORIZON COMPUTER
+-0:50:a	IRIS TECHNOLOGIES, INC.
++0:50:9	PHILIPS BROADBAND NETWORKS
+ 0:50:a0	DELTA COMPUTER SYSTEMS, INC.
+ 0:50:a1	CARLO GAVAZZI, INC.
+ 0:50:a2	CISCO SYSTEMS, INC.
+@@ -4536,12 +7873,12 @@
+ 0:50:a8	OpenCon Systems, Inc.
+ 0:50:a9	MOLDAT WIRELESS TECHNOLGIES
+ 0:50:aa	KONICA MINOLTA HOLDINGS, INC.
+-0:50:ab	NALTEC, INC.
++0:50:ab	NALTEC, Inc.
+ 0:50:ac	MAPLE COMPUTER CORPORATION
+ 0:50:ad	CommUnique Wireless Corp.
+ 0:50:ae	IWAKI ELECTRONICS CO., LTD.
+ 0:50:af	INTERGON, INC.
+-0:50:b	CISCO SYSTEMS, INC.
++0:50:a	IRIS TECHNOLOGIES, INC.
+ 0:50:b0	TECHNOLOGY ATLANTA CORPORATION
+ 0:50:b1	GIDDINGS & LEWIS
+ 0:50:b2	BRODEL AUTOMATION
+@@ -4555,15 +7892,15 @@
+ 0:50:ba	D-LINK
+ 0:50:bb	CMS TECHNOLOGIES
+ 0:50:bc	HAMMER STORAGE SOLUTIONS
++0:50:b	CISCO SYSTEMS, INC.
+ 0:50:bd	CISCO SYSTEMS, INC.
+ 0:50:be	FAST MULTIMEDIA AG
+-0:50:bf	MOTOTECH INC.
+-0:50:c	e-Tek Labs, Inc.
++0:50:bf	Metalligence Technology Corp.
+ 0:50:c0	GATAN, INC.
+ 0:50:c1	GEMFLEX NETWORKS, LTD.
+ 0:50:c2	IEEE REGISTRATION AUTHORITY
+ 0:50:c4	IMD
+-0:50:c5	ADS TECHNOLOGIES, INC.
++0:50:c5	ADS Technologies, Inc
+ 0:50:c6	LOOP TELECOMMUNICATION INTERNATIONAL, INC.
+ 0:50:c8	ADDONICS COMMUNICATIONS, INC.
+ 0:50:c9	MASPRO DENKOH CORP.
+@@ -4572,8 +7909,9 @@
+ 0:50:cc	XYRATEX
+ 0:50:cd	DIGIANSWER A/S
+ 0:50:ce	LG INTERNATIONAL CORP.
++0:50:c	e-Tek Labs, Inc.
+ 0:50:cf	VANLINK COMMUNICATION TECHNOLOGY RESEARCH INSTITUTE
+-0:50:d	SATORI ELECTORIC CO., LTD.
++0:5:0	Cisco Systems, Inc.
+ 0:50:d0	MINERVA SYSTEMS
+ 0:50:d1	CISCO SYSTEMS, INC.
+ 0:50:d2	CMC Electronics Inc
+@@ -4590,21 +7928,21 @@
+ 0:50:dd	SERRA SOLDADURA, S.A.
+ 0:50:de	SIGNUM SYSTEMS CORP.
+ 0:50:df	AirFiber, Inc.
+-0:50:e	CHROMATIS NETWORKS, INC.
++0:50:d	SATORI ELECTORIC CO., LTD.
+ 0:50:e1	NS TECH ELECTRONICS SDN BHD
+ 0:50:e2	CISCO SYSTEMS, INC.
+-0:50:e3	Terayon Communications Systems
++0:50:e3	Motorola, Inc.
+ 0:50:e4	APPLE COMPUTER, INC.
+ 0:50:e6	HAKUSAN CORPORATION
+ 0:50:e7	PARADISE INNOVATIONS (ASIA)
+ 0:50:e8	NOMADIX INC.
+ 0:50:ea	XEL COMMUNICATIONS, INC.
+ 0:50:eb	ALPHA-TOP CORPORATION
++0:50:e	CHROMATIS NETWORKS, INC.
+ 0:50:ec	OLICOM A/S
+ 0:50:ed	ANDA NETWORKS
+ 0:50:ee	TEK DIGITEL CORPORATION
+ 0:50:ef	SPE Systemhaus GmbH
+-0:50:f	CISCO SYSTEMS, INC.
+ 0:50:f0	CISCO SYSTEMS, INC.
+ 0:50:f1	LIBIT SIGNAL PROCESSING, LTD.
+ 0:50:f2	MICROSOFT CORP.
+@@ -4617,11 +7955,10 @@
+ 0:50:fa	OXTEL, LTD.
+ 0:50:fb	VSK ELECTRONICS
+ 0:50:fc	EDIMAX TECHNOLOGY CO., LTD.
++0:50:f	CISCO SYSTEMS, INC.
+ 0:50:fd	VISIONCOMM CO., LTD.
+ 0:50:fe	PCTVnet ASA
+ 0:50:ff	HAKKO ELECTRONICS CO., LTD.
+-0:5:0	Cisco Systems, Inc.
+-0:5:1	Cisco Systems, Inc.
+ 0:5:10	Infinite Shanghai Communication Terminals Ltd.
+ 0:5:11	Complementary Technologies Ltd
+ 0:5:12	MeshNetworks, Inc.
+@@ -4634,12 +7971,13 @@
+ 0:5:19	Siemens Building Technologies AG,
+ 0:5:1a	3Com Europe Ltd.
+ 0:5:1b	Magic Control Technology Corporation
++0:5:1	Cisco Systems, Inc.
+ 0:5:1c	Xnet Technology Corp.
+ 0:5:1d	Airocon, Inc.
+ 0:5:1e	Brocade Communications Systems, Inc.
+ 0:5:1f	Taijin Media Co., Ltd.
+-0:5:2	APPLE COMPUTER
+ 0:5:20	Smartronix, Inc.
++0:52:18	Wuxi Keboda Electron Co.Ltd
+ 0:5:21	Control Microsystems
+ 0:5:22	LEA*D Corporation, Inc.
+ 0:5:23	AVL List GmbH
+@@ -4650,16 +7988,16 @@
+ 0:5:28	New Focus, Inc.
+ 0:5:29	Shanghai Broadan Communication Technology Co., Ltd
+ 0:5:2a	Ikegami Tsushinki Co., Ltd.
++0:5:2	APPLE COMPUTER
+ 0:5:2b	HORIBA, Ltd.
+ 0:5:2c	Supreme Magic Corporation
+ 0:5:2d	Zoltrix International Limited
+ 0:5:2e	Cinta Networks
+-0:5:2f	Leviton Voice and Data
+-0:5:3	ICONAG
++0:5:2f	Leviton Network Solutions
+ 0:5:30	Andiamo Systems, Inc.
+ 0:5:31	Cisco Systems, Inc.
+ 0:5:32	Cisco Systems, Inc.
+-0:5:33	Sanera Systems, Inc.
++0:5:33	Brocade Communications Systems, Inc.
+ 0:5:34	Northstar Engineering Ltd.
+ 0:5:35	Chip PC Ltd.
+ 0:5:36	Danam Communications, Inc.
+@@ -4672,7 +8010,7 @@
+ 0:5:3d	Agere Systems
+ 0:5:3e	KID Systeme GmbH
+ 0:5:3f	VisionTek, Inc.
+-0:5:4	Naray Information & Communication Enterprise
++0:5:3	ICONAG
+ 0:5:40	FAST Corporation
+ 0:5:41	Advanced Systems Co., Ltd.
+ 0:5:42	Otari, Inc.
+@@ -4684,13 +8022,13 @@
+ 0:5:48	Disco Corporation
+ 0:5:49	Salira Optical Network Systems
+ 0:5:4a	Ario Data Networks, Inc.
+-0:5:4b	Micro Innovation AG
++0:5:4b	Eaton Automation AG
+ 0:5:4c	RF Innovations Pty Ltd
+ 0:5:4d	Brans Technologies, Inc.
+-0:5:4e	Philips Components
++0:5:4e	Philips
+ 0:5:4f	PRIVATE
+-0:5:5	Systems Integration Solutions, Inc.
+-0:5:50	Vcomms Limited
++0:5:4	Naray Information & Communication Enterprise
++0:5:50	Vcomms Connect Limited
+ 0:5:51	F & S Elektronik Systeme GmbH
+ 0:5:52	Xycotec Computer GmbH
+ 0:5:53	DVC Company, Inc.
+@@ -4706,7 +8044,7 @@
+ 0:5:5d	D-Link Systems, Inc.
+ 0:5:5e	Cisco Systems, Inc.
+ 0:5:5f	Cisco Systems, Inc.
+-0:5:6	Reddo Networks AB
++0:5:5	Systems Integration Solutions, Inc.
+ 0:5:60	LEADER COMM.CO., LTD
+ 0:5:61	nac Image Technology, Inc.
+ 0:5:62	Digital View Limited
+@@ -4716,14 +8054,14 @@
+ 0:5:66	Secui.com Corporation
+ 0:5:67	Etymonic Design, Inc.
+ 0:5:68	Piltofish Networks AB
+-0:5:69	VMWARE, Inc.
++0:5:69	VMware, Inc.
+ 0:5:6a	Heuft Systemtechnik GmbH
+ 0:5:6b	C.P. Technology Co., Ltd.
+ 0:5:6c	Hung Chang Co., Ltd.
+ 0:5:6d	Pacific Corporation
+ 0:5:6e	National Enhance Technology, Inc.
+ 0:5:6f	Innomedia Technologies Pvt. Ltd.
+-0:5:7	Fine Appliance Corp.
++0:5:6	Reddo Networks AB
+ 0:5:70	Baydel Ltd.
+ 0:5:71	Seiwa Electronics Co.
+ 0:5:72	Deonet Co., Ltd.
+@@ -4740,7 +8078,7 @@
+ 0:5:7d	Sun Communications, Inc.
+ 0:5:7e	Eckelmann Steuerungstechnik GmbH
+ 0:5:7f	Acqis Technology
+-0:5:8	Inetcam, Inc.
++0:5:7	Fine Appliance Corp.
+ 0:5:80	Fibrolan Ltd.
+ 0:5:81	Snell & Wilcox Ltd.
+ 0:5:82	ClearCube Technology
+@@ -4757,7 +8095,7 @@
+ 0:5:8d	Lynx Photonic Networks, Inc.
+ 0:5:8e	Flextronics International GmbH & Co. Nfg. KG
+ 0:5:8f	CLCsoft co.
+-0:5:9	AVOC Nishimura Ltd.
++0:5:8	Inetcam, Inc.
+ 0:5:90	Swissvoice Ltd.
+ 0:5:91	Active Silicon Ltd.
+ 0:5:92	Pultek Corp.
+@@ -4769,12 +8107,12 @@
+ 0:5:98	CRONOS S.r.l.
+ 0:5:99	DRS Test and Energy Management or DRS-TEM
+ 0:5:9a	Cisco Systems, Inc.
++0:5:9	AVOC Nishimura Ltd.
+ 0:5:9b	Cisco Systems, Inc.
+ 0:5:9c	Kleinknecht GmbH, Ing. Buero
+ 0:5:9d	Daniel Computing Systems, Inc.
+ 0:5:9e	Zinwell Corporation
+ 0:5:9f	Yotta Networks, Inc.
+-0:5:a	ICS Spa
+ 0:5:a0	MOBILINE Kft.
+ 0:5:a1	Zenocom
+ 0:5:a2	CELOX Networks
+@@ -4791,7 +8129,7 @@
+ 0:5:ad	Topspin Communications, Inc.
+ 0:5:ae	Mediaport USA
+ 0:5:af	InnoScan Computing A/S
+-0:5:b	SICOM Systems, Inc.
++0:5:a	ICS Spa
+ 0:5:b0	Korea Computer Technology Co., Ltd.
+ 0:5:b1	ASB Technology BV
+ 0:5:b2	Medison Co., Ltd.
+@@ -4808,7 +8146,7 @@
+ 0:5:bd	ROAX BV
+ 0:5:be	Kongsberg Seatex AS
+ 0:5:bf	JustEzy Technology, Inc.
+-0:5:c	Network Photonics, Inc.
++0:5:b	SICOM Systems, Inc.
+ 0:5:c0	Digital Network Alacarte Co., Ltd.
+ 0:5:c1	A-Kyung Motion, Inc.
+ 0:5:c2	Soronti, Inc.
+@@ -4818,14 +8156,14 @@
+ 0:5:c6	Triz Communications
+ 0:5:c7	I/F-COM A/S
+ 0:5:c8	VERYTECH
+-0:5:c9	LG Innotek
++0:5:c9	LG Innotek Co., Ltd.
+ 0:5:ca	Hitron Technology, Inc.
+ 0:5:cb	ROIS Technologies, Inc.
+ 0:5:cc	Sumtel Communications, Inc.
+ 0:5:cd	Denon, Ltd.
+ 0:5:ce	Prolink Microsystems Corporation
+ 0:5:cf	Thunder River Technologies, Inc.
+-0:5:d	Midstream Technologies, Inc.
++0:5:c	Network Photonics, Inc.
+ 0:5:d0	Solinet Systems
+ 0:5:d1	Metavector Technologies
+ 0:5:d2	DAP Technologies
+@@ -4837,20 +8175,21 @@
+ 0:5:d8	Arescom, Inc.
+ 0:5:d9	Techno Valley, Inc.
+ 0:5:da	Apex Automationstechnik
+-0:5:db	Nentec GmbH
++0:5:db	PSI Nentec GmbH
+ 0:5:dc	Cisco Systems, Inc.
+ 0:5:dd	Cisco Systems, Inc.
+ 0:5:de	Gi Fone Korea, Inc.
+ 0:5:df	Electronic Innovation, Inc.
+-0:5:e	3ware, Inc.
++0:5:d	Midstream Technologies, Inc.
+ 0:5:e0	Empirix Corp.
+ 0:5:e1	Trellis Photonics, Ltd.
+ 0:5:e2	Creativ Network Technologies
+ 0:5:e3	LightSand Communications, Inc.
+-0:5:e4	Red Lion Controls L.P.
++0:5:e	3ware, Inc.
++0:5:e4	Red Lion Controls Inc.
+ 0:5:e5	Renishaw PLC
+ 0:5:e6	Egenera, Inc.
+-0:5:e7	Netrake Corp.
++0:5:e7	Netrake an AudioCodes Company
+ 0:5:e8	TurboWave, Inc.
+ 0:5:e9	Unicess Network, Inc.
+ 0:5:ea	Rednix
+@@ -4859,13 +8198,12 @@
+ 0:5:ed	Technikum Joanneum GmbH
+ 0:5:ee	BEWATOR Group
+ 0:5:ef	ADOIR Digital Technology
+-0:5:f	Tanaka S/S Ltd.
+ 0:5:f0	SATEC
+ 0:5:f1	Vrcom, Inc.
+ 0:5:f2	Power R, Inc.
+ 0:5:f3	Weboyn
+ 0:5:f4	System Base Co., Ltd.
+-0:5:f5	OYO Geospace Corp.
++0:5:f5	OYO Geospace
+ 0:5:f6	Young Chang Co. Ltd.
+ 0:5:f7	Analog Devices, Inc.
+ 0:5:f8	Real Time Access, Inc.
+@@ -4876,8 +8214,8 @@
+ 0:5:fd	PacketLight Networks Ltd.
+ 0:5:fe	Traficon N.V.
+ 0:5:ff	SNS Solutions, Inc.
++0:5:f	Tanaka S/S Ltd.
+ 0:60:0	XYCOM INC.
+-0:60:1	InnoSys, Inc.
+ 0:60:10	NETWORK MACHINES, INC.
+ 0:60:11	CRYSTAL SEMICONDUCTOR CORP.
+ 0:60:12	POWER COMPUTING CORPORATION
+@@ -4894,14 +8232,14 @@
+ 0:60:1d	LUCENT TECHNOLOGIES
+ 0:60:1e	SOFTLAB, INC.
+ 0:60:1f	STALLION TECHNOLOGIES
+-0:60:2	SCREEN SUBTITLING SYSTEMS, LTD
++0:60:1	InnoSys, Inc.
+ 0:60:20	PIVOTAL NETWORKING, INC.
+ 0:60:21	DSC CORPORATION
+ 0:60:22	VICOM SYSTEMS, INC.
+ 0:60:23	PERICOM SEMICONDUCTOR CORP.
+ 0:60:24	GRADIENT TECHNOLOGIES, INC.
+ 0:60:25	ACTIVE IMAGING PLC
+-0:60:26	VIKING COMPONENTS, INC.
++0:60:26	VIKING Modular Solutions
+ 0:60:27	Superior Modular Products
+ 0:60:28	MACROVISION CORPORATION
+ 0:60:29	CARY PERIPHERALS INC.
+@@ -4911,15 +8249,15 @@
+ 0:60:2d	ALERTON TECHNOLOGIES, INC.
+ 0:60:2e	CYCLADES CORPORATION
+ 0:60:2f	CISCO SYSTEMS, INC.
+-0:60:3	TERAOKA WEIGH SYSTEM PTE, LTD.
++0:60:2	SCREEN SUBTITLING SYSTEMS, LTD
+ 0:60:30	VILLAGE TRONIC ENTWICKLUNG
+ 0:60:31	HRK SYSTEMS
+ 0:60:32	I-CUBE, INC.
+ 0:60:33	ACUITY IMAGING, INC.
+ 0:60:34	ROBERT BOSCH GmbH
+ 0:60:35	DALLAS SEMICONDUCTOR, INC.
+-0:60:36	AUSTRIAN RESEARCH CENTER SEIBERSDORF
+-0:60:37	PHILIPS SEMICONDUCTORS
++0:60:36	AIT Austrian Institute of Technology GmbH
++0:60:37	NXP Semiconductors
+ 0:60:38	Nortel Networks
+ 0:60:39	SanCom Technology, Inc.
+ 0:60:3a	QUICK CONTROLS LTD.
+@@ -4928,11 +8266,11 @@
+ 0:60:3d	3CX
+ 0:60:3e	CISCO SYSTEMS, INC.
+ 0:60:3f	PATAPSCO DESIGNS
+-0:60:4	COMPUTADORES MODULARES SA
++0:60:3	TERAOKA WEIGH SYSTEM PTE, LTD.
+ 0:60:40	NETRO CORP.
+ 0:60:41	Yokogawa Electric Corporation
+ 0:60:42	TKS (USA), INC.
+-0:60:43	ComSoft Systems, Inc.
++0:60:43	iDirect, INC.
+ 0:60:44	LITTON/POLY-SCIENTIFIC
+ 0:60:45	PATHLIGHT TECHNOLOGIES
+ 0:60:46	VMETRO, INC.
+@@ -4941,11 +8279,11 @@
+ 0:60:49	VINA TECHNOLOGIES
+ 0:60:4a	SAIC IDEAS GROUP
+ 0:60:4b	Safe-com GmbH & Co. KG
+-0:60:4c	SAGEM SA
++0:60:4	COMPUTADORES MODULARES SA
++0:60:4c	SAGEM COMMUNICATION
+ 0:60:4d	MMC NETWORKS, INC.
+ 0:60:4e	CYCLE COMPUTER CORPORATION, INC.
+ 0:60:4f	SUZUKI MFG. CO., LTD.
+-0:60:5	FEEDBACK DATA LTD.
+ 0:60:50	INTERNIX INC.
+ 0:60:51	QUALITY SEMICONDUCTOR
+ 0:60:52	PERIPHERALS ENTERPRISE CO., Ltd.
+@@ -4961,25 +8299,25 @@
+ 0:60:5c	CISCO SYSTEMS, INC.
+ 0:60:5d	SCANIVALVE CORP.
+ 0:60:5e	LIBERTY TECHNOLOGY NETWORKING
++0:60:5	FEEDBACK DATA LTD.
+ 0:60:5f	NIPPON UNISOFT CORPORATION
+-0:60:6	SOTEC CO., LTD
+ 0:60:60	DAWNING TECHNOLOGIES, INC.
+ 0:60:61	WHISTLE COMMUNICATIONS CORP.
+ 0:60:62	TELESYNC, INC.
+ 0:60:63	PSION DACOM PLC.
+ 0:60:64	NETCOMM LIMITED
+ 0:60:65	BERNECKER & RAINER INDUSTRIE-ELEKTRONIC GmbH
+-0:60:66	LACROIX TECHNOLGIE
++0:60:66	LACROIX Trafic
+ 0:60:67	ACER NETXUS INC.
+-0:60:68	EICON TECHNOLOGY CORPORATION
+-0:60:69	BROCADE COMMUNICATIONS SYSTEMS, Inc.
++0:60:68	Dialogic Corporation
++0:60:69	Brocade Communications Systems, Inc.
+ 0:60:6a	MITSUBISHI WIRELESS COMMUNICATIONS. INC.
+ 0:60:6b	Synclayer Inc.
+ 0:60:6c	ARESCOM
+ 0:60:6d	DIGITAL EQUIPMENT CORP.
+ 0:60:6e	DAVICOM SEMICONDUCTOR, INC.
+ 0:60:6f	CLARION CORPORATION OF AMERICA
+-0:60:7	ACRES GAMING, INC.
++0:60:6	SOTEC CO., LTD
+ 0:60:70	CISCO SYSTEMS, INC.
+ 0:60:71	MIDAS LAB, INC.
+ 0:60:72	VXL INSTRUMENTS, LIMITED
+@@ -4990,17 +8328,18 @@
+ 0:60:77	PRISA NETWORKS
+ 0:60:78	POWER MEASUREMENT LTD.
+ 0:60:79	Mainstream Data, Inc.
++0:60:7	ACRES GAMING, INC.
+ 0:60:7a	DVS GmbH
+ 0:60:7b	FORE SYSTEMS, INC.
+ 0:60:7c	WaveAccess, Ltd.
+ 0:60:7d	SENTIENT NETWORKS INC.
+ 0:60:7e	GIGALABS, INC.
+ 0:60:7f	AURORA TECHNOLOGIES, INC.
+-0:60:8	3COM CORPORATION
+ 0:60:80	MICROTRONIX DATACOM LTD.
+ 0:60:81	TV/COM INTERNATIONAL
+ 0:60:82	NOVALINK TECHNOLOGIES, INC.
+ 0:60:83	CISCO SYSTEMS, INC.
++0:60:8	3COM CORPORATION
+ 0:60:84	DIGITAL VIDEO
+ 0:60:85	Storage Concepts
+ 0:60:86	LOGIC REPLACEMENT TECH. LTD.
+@@ -5013,7 +8352,6 @@
+ 0:60:8d	UNIPULSE CORP.
+ 0:60:8e	HE ELECTRONICS, TECHNOLOGIE & SYSTEMTECHNIK GmbH
+ 0:60:8f	TEKRAM TECHNOLOGY CO., LTD.
+-0:60:9	CISCO SYSTEMS, INC.
+ 0:60:90	ABLE COMMUNICATIONS, INC.
+ 0:60:91	FIRST PACIFIC NETWORKS, INC.
+ 0:60:92	MICRO/SYS, INC.
+@@ -5026,11 +8364,11 @@
+ 0:60:99	SBE, Inc.
+ 0:60:9a	NJK TECHNO CO.
+ 0:60:9b	ASTRO-MED, INC.
++0:60:9	CISCO SYSTEMS, INC.
+ 0:60:9c	Perkin-Elmer Incorporated
+ 0:60:9d	PMI FOOD EQUIPMENT GROUP
+ 0:60:9e	ASC X3 - INFORMATION TECHNOLOGY STANDARDS SECRETARIATS
+ 0:60:9f	PHAST CORPORATION
+-0:60:a	SORD COMPUTER CORPORATION
+ 0:60:a0	SWITCHED NETWORK TECHNOLOGIES, INC.
+ 0:60:a1	VPNet, Inc.
+ 0:60:a2	NIHON UNISYS LIMITED CO.
+@@ -5047,7 +8385,7 @@
+ 0:60:ad	MegaChips Corporation
+ 0:60:ae	TRIO INFORMATION SYSTEMS AB
+ 0:60:af	PACIFIC MICRO DATA, INC.
+-0:60:b	LOGWARE GmbH
++0:60:a	SORD COMPUTER CORPORATION
+ 0:60:b0	HEWLETT-PACKARD CO.
+ 0:60:b1	INPUT/OUTPUT, INC.
+ 0:60:b2	PROCESS CONTROL CORP.
+@@ -5056,16 +8394,16 @@
+ 0:60:b5	KEBA GmbH
+ 0:60:b6	LAND COMPUTER CO., LTD.
+ 0:60:b7	CHANNELMATIC, INC.
+-0:60:b8	CORELIS INC.
+-0:60:b9	NITSUKO CORPORATION
++0:60:b8	CORELIS Inc.
++0:60:b9	NEC Infrontia Corporation
+ 0:60:ba	SAHARA NETWORKS, INC.
+ 0:60:bb	CABLETRON - NETLINK, INC.
+ 0:60:bc	KeunYoung Electronics & Communication Co., Ltd.
+ 0:60:bd	HUBBELL-PULSECOM
+ 0:60:be	WEBTRONICS
+ 0:60:bf	MACRAIGOR SYSTEMS, INC.
+-0:60:c	APPLIED DATA SYSTEMS, INC.
+-0:60:c0	NERA AS
++0:60:b	LOGWARE GmbH
++0:60:c0	Nera Networks AS
+ 0:60:c1	WaveSpan Corporation
+ 0:60:c2	MPL AG
+ 0:60:c3	NETVISION CORPORATION
+@@ -5076,12 +8414,12 @@
+ 0:60:c8	KUKA WELDING SYSTEMS & ROBOTS
+ 0:60:c9	ControlNet, Inc.
+ 0:60:ca	HARMONIC SYSTEMS INCORPORATED
++0:60:c	APPLIED DATA SYSTEMS, INC.
+ 0:60:cb	HITACHI ZOSEN CORPORATION
+ 0:60:cc	EMTRAK, INCORPORATED
+ 0:60:cd	VideoServer, Inc.
+ 0:60:ce	ACCLAIM COMMUNICATIONS
+ 0:60:cf	ALTEON NETWORKS, INC.
+-0:60:d	Digital Logic GmbH
+ 0:60:d0	SNMP RESEARCH INCORPORATED
+ 0:60:d1	CASCADE COMMUNICATIONS
+ 0:60:d2	LUCENT TECHNOLOGIES TAIWAN TELECOMMUNICATIONS CO., LTD.
+@@ -5094,11 +8432,11 @@
+ 0:60:d9	TRANSYS NETWORKS INC.
+ 0:60:da	JBM ELECTRONICS CO.
+ 0:60:db	NTP ELEKTRONIK A/S
+-0:60:dc	Toyo Network Systems Co, Ltd.
++0:60:dc	Toyo Network Systems  & System Integration Co. LTD
++0:60:d	Digital Logic GmbH
+ 0:60:dd	MYRICOM, INC.
+-0:60:de	KAYSER-THREDE GmbH
+-0:60:df	CNT Corporation
+-0:60:e	WAVENET INTERNATIONAL, INC.
++0:60:de	Kayser-Threde GmbH
++0:60:df	Brocade Communications Systems, Inc.
+ 0:60:e0	AXIOM TECHNOLOGY CO., LTD.
+ 0:60:e1	ORCKIT COMMUNICATIONS LTD.
+ 0:60:e2	QUEST ENGINEERING & DEVELOPMENT
+@@ -5115,7 +8453,7 @@
+ 0:60:ed	RICARDO TEST AUTOMATION LTD.
+ 0:60:ee	APOLLO
+ 0:60:ef	FLYTECH TECHNOLOGY CO., LTD.
+-0:60:f	WESTELL, INC.
++0:60:e	WAVENET INTERNATIONAL, INC.
+ 0:60:f0	JOHNSON & JOHNSON MEDICAL, INC
+ 0:60:f1	EXP COMPUTER, INC.
+ 0:60:f2	LASERGRAPHICS, INC.
+@@ -5132,8 +8470,8 @@
+ 0:60:fd	NetICs, Inc.
+ 0:60:fe	LYNX SYSTEM DEVELOPERS, INC.
+ 0:60:ff	QuVis, Inc.
++0:60:f	WESTELL, INC.
+ 0:6:0	Toshiba Teli Corporation
+-0:6:1	Otanikeiki Co., Ltd.
+ 0:6:10	Abeona Networks Inc
+ 0:6:11	Zeus Wireless, Inc.
+ 0:6:12	Accusys, Inc.
+@@ -5145,12 +8483,12 @@
+ 0:6:18	DigiPower Manufacturing Inc.
+ 0:6:19	Connection Technology Systems
+ 0:6:1a	Zetari Inc.
+-0:6:1b	Portable Systems, IBM Japan Co, Ltd
++0:6:1b	Notebook Development Lab.  Lenovo Japan Ltd.
+ 0:6:1c	Hoshino Metal Industries, Ltd.
+ 0:6:1d	MIP Telecom, Inc.
+ 0:6:1e	Maxan Systems
+ 0:6:1f	Vision Components GmbH
+-0:6:2	Cirkitech Electronics Co.
++0:6:1	Otanikeiki Co., Ltd.
+ 0:6:20	Serial System Ltd.
+ 0:6:21	Hinox, Co., Ltd.
+ 0:6:22	Chung Fu Chen Yeh Enterprise Corp.
+@@ -5163,15 +8501,15 @@
+ 0:6:29	IBM CORPORATION
+ 0:6:2a	Cisco Systems, Inc.
+ 0:6:2b	INTRASERVER TECHNOLOGY
+-0:6:2c	Network Robots, Inc.
++0:6:2c	Bivio Networks
++0:6:2	Cirkitech Electronics Co.
+ 0:6:2d	TouchStar Technologies, L.L.C.
+ 0:6:2e	Aristos Logic Corp.
+ 0:6:2f	Pivotech Systems Inc.
+-0:6:3	Baker Hughes Inc.
+ 0:6:30	Adtranz Sweden
+ 0:6:31	Optical Solutions, Inc.
+ 0:6:32	Mesco Engineering GmbH
+-0:6:33	Smiths Heimann Biometric Systems
++0:6:33	Cross Match Technologies GmbH
+ 0:6:34	GTE Airfone Inc.
+ 0:6:35	PacketAir Networks, Inc.
+ 0:6:36	Jedai Broadband Networks
+@@ -5179,38 +8517,39 @@
+ 0:6:38	Sungjin C&C Co., Ltd.
+ 0:6:39	Newtec
+ 0:6:3a	Dura Micro, Inc.
++0:6:3	Baker Hughes Inc.
+ 0:6:3b	Arcturus Networks, Inc.
+-0:6:3c	NMI Electronics Ltd
++0:6:3c	Intrinsyc Europe Ltd
+ 0:6:3d	Microwave Data Systems Inc.
+ 0:6:3e	Opthos Inc.
+ 0:6:3f	Everex Communications Inc.
+-0:6:4	@Track Communications, Inc.
+ 0:6:40	White Rock Networks
+ 0:6:41	ITCN
+ 0:6:42	Genetel Systems Inc.
+ 0:6:43	SONO Computer Co., Ltd.
+-0:6:44	NEIX Inc.
++0:64:40	Cisco Systems
++0:6:44	Neix,Inc
+ 0:6:45	Meisei Electric Co. Ltd.
+ 0:6:46	ShenZhen XunBao Network Technology Co Ltd
+ 0:6:47	Etrali S.A.
+ 0:6:48	Seedsware, Inc.
+-0:6:49	Quante
++0:6:49	3M Deutschland GmbH
+ 0:6:4a	Honeywell Co., Ltd. (KOREA)
+ 0:6:4b	Alexon Co., Ltd.
+ 0:6:4c	Invicta Networks, Inc.
+ 0:6:4d	Sencore
+ 0:6:4e	Broad Net Technology Inc.
+ 0:6:4f	PRO-NETS Technology Corporation
+-0:6:5	Inncom International, Inc.
++0:6:4	@Track Communications, Inc.
+ 0:6:50	Tiburon Networks, Inc.
+ 0:6:51	Aspen Networks Inc.
+ 0:6:52	Cisco Systems, Inc.
+ 0:6:53	Cisco Systems, Inc.
+-0:6:54	Maxxio Technologies
++0:6:54	Winpresa Building Automation Technologies GmbH
+ 0:6:55	Yipee, Inc.
+ 0:6:56	Tactel AB
+ 0:6:57	Market Central, Inc.
+-0:6:58	Helmut Fischer GmbH & Co. KG
++0:6:58	Helmut Fischer GmbH Institut f
+ 0:6:59	EAL (Apeldoorn) B.V.
+ 0:6:5a	Strix Systems
+ 0:6:5b	Dell Computer Corp.
+@@ -5218,7 +8557,7 @@
+ 0:6:5d	Heidelberg Web Systems
+ 0:6:5e	Photuris, Inc.
+ 0:6:5f	ECI Telecom - NGTS Ltd.
+-0:6:6	RapidWAN, Inc.
++0:6:5	Inncom International, Inc.
+ 0:6:60	NADEX Co., Ltd.
+ 0:6:61	NIA Home Technologies Corp.
+ 0:6:62	MBM Technology Ltd.
+@@ -5235,7 +8574,7 @@
+ 0:6:6d	Compuprint S.P.A.
+ 0:6:6e	Delta Electronics, Inc.
+ 0:6:6f	Korea Data Systems
+-0:6:7	Omni Directional Control Technology Inc.
++0:6:6	RapidWAN, Inc.
+ 0:6:70	Upponetti Oy
+ 0:6:71	Softing AG
+ 0:6:72	Netezza
+@@ -5244,15 +8583,15 @@
+ 0:6:75	Banderacom, Inc.
+ 0:6:76	Novra Technologies Inc.
+ 0:6:77	SICK AG
+-0:6:78	Marantz Japan, Inc.
++0:6:78	Marantz Brand Company
+ 0:6:79	Konami Corporation
+ 0:6:7a	JMP Systems
+ 0:6:7b	Toplink C&C Corporation
+ 0:6:7c	CISCO SYSTEMS, INC.
+ 0:6:7d	Takasago Ltd.
+ 0:6:7e	WinCom Systems, Inc.
+-0:6:7f	Rearden Steel Technologies
+-0:6:8	At-Sky SAS
++0:6:7f	Digeo, Inc.
++0:6:7	Omni Directional Control Technology Inc.
+ 0:6:80	Card Access, Inc.
+ 0:6:81	Goepel Electronic GmbH
+ 0:6:82	Convedia
+@@ -5264,12 +8603,12 @@
+ 0:6:88	Telways Communication Co., Ltd.
+ 0:6:89	yLez Technologies Pte Ltd
+ 0:6:8a	NeuronNet Co. Ltd. R&D Center
++0:6:8	At-Sky SAS
+ 0:6:8b	AirRunner Technologies, Inc.
+ 0:6:8c	3Com Corporation
+ 0:6:8d	SEPATON, Inc.
+ 0:6:8e	HID Corporation
+ 0:6:8f	Telemonitor, Inc.
+-0:6:9	Crossport Systems
+ 0:6:90	Euracom Communication GmbH
+ 0:6:91	PT Inovacao
+ 0:6:92	Intruvert Networks, Inc.
+@@ -5282,11 +8621,11 @@
+ 0:6:99	Vida Design Co.
+ 0:6:9a	e & Tel
+ 0:6:9b	AVT Audio Video Technologies GmbH
++0:6:9	Crossport Systems
+ 0:6:9c	Transmode Systems AB
+-0:6:9d	Petards Mobile Intelligence
++0:6:9d	Petards Ltd
+ 0:6:9e	UNIQA, Inc.
+ 0:6:9f	Kuokoa Networks
+-0:6:a	Blue2space
+ 0:6:a0	Mx Imaging
+ 0:6:a1	Celsian Technologies, Inc.
+ 0:6:a2	Microtune, Inc.
+@@ -5297,13 +8636,13 @@
+ 0:6:a7	Primarion
+ 0:6:a8	KC Technology, Inc.
+ 0:6:a9	Universal Instruments Corp.
+-0:6:aa	Miltope Corporation
++0:6:aa	VT Miltope
++0:6:a	Blue2space
+ 0:6:ab	W-Link Systems, Inc.
+ 0:6:ac	Intersoft Co.
+ 0:6:ad	KB Electronics Ltd.
+ 0:6:ae	Himachal Futuristic Communications Ltd
+-0:6:af	PRIVATE
+-0:6:b	Paceline Systems Corporation
++0:6:af	Xalted Networks
+ 0:6:b0	Comtech EF Data Corp.
+ 0:6:b1	Sonicwall
+ 0:6:b2	Linxtek Co.
+@@ -5319,12 +8658,12 @@
+ 0:6:bc	Macrolink, Inc.
+ 0:6:bd	BNTECHNOLOGY Co., Ltd.
+ 0:6:be	Baumer Optronic GmbH
++0:6:b	Emerson Network Power
+ 0:6:bf	Accella Technologies Co., Ltd.
+-0:6:c	Melco Industries, Inc.
+ 0:6:c0	United Internetworks, Inc.
+ 0:6:c1	CISCO SYSTEMS, INC.
+ 0:6:c2	Smartmatic Corporation
+-0:6:c3	Schindler Elevators Ltd.
++0:6:c3	Schindler Elevator Ltd.
+ 0:6:c4	Piolink Inc.
+ 0:6:c5	INNOVI Technologies Limited
+ 0:6:c6	lesswire AG
+@@ -5334,10 +8673,10 @@
+ 0:6:ca	American Computer & Digital Components, Inc. (ACDC)
+ 0:6:cb	Jotron Electronics A/S
+ 0:6:cc	JMI Electronics Co., Ltd.
+-0:6:cd	Creo IL. Ltd.
++0:6:cd	Leaf Imaging Ltd.
+ 0:6:ce	DATENO
+ 0:6:cf	Thales Avionics In-Flight Systems, LLC
+-0:6:d	Wave7 Optics
++0:6:c	Melco Industries, Inc.
+ 0:6:d0	Elgar Electronics Corp.
+ 0:6:d1	Tahoe Networks, Inc.
+ 0:6:d2	Tundra Semiconductor Corp.
+@@ -5354,7 +8693,7 @@
+ 0:6:dd	AT & T Laboratories - Cambridge Ltd
+ 0:6:de	Flash Technology
+ 0:6:df	AIDONIC Corporation
+-0:6:e	IGYS Systems, Inc.
++0:6:d	Wave7 Optics
+ 0:6:e0	MAT Co., Ltd.
+ 0:6:e1	Techno Trade s.a
+ 0:6:e2	Ceemax Technology Co., Ltd.
+@@ -5367,28 +8706,30 @@
+ 0:6:e9	Intime Corp.
+ 0:6:ea	ELZET80 Mikrocomputer GmbH&Co. KG
+ 0:6:eb	Global Data
+-0:6:ec	M/A COM Private Radio System Inc.
++0:6:ec	Harris Corporation
+ 0:6:ed	Inara Networks
+ 0:6:ee	Shenyang Neu-era Information & Technology Stock Co., Ltd
+ 0:6:ef	Maxxan Systems, Inc.
+-0:6:f	Narad Networks Inc
++0:6:e	IGYS Systems, Inc.
+ 0:6:f0	Digeo, Inc.
+ 0:6:f1	Optillion
+ 0:6:f2	Platys Communications
+ 0:6:f3	AcceLight Networks
+ 0:6:f4	Prime Electronics & Satellitics Inc.
++0:6:f5	ALPS Co,. Ltd.
++0:6:f6	Cisco Systems
+ 0:6:f8	CPU Technology, Inc.
+ 0:6:f9	Mitsui Zosen Systems Research Inc.
+ 0:6:fa	IP SQUARE Co, Ltd.
+ 0:6:fb	Hitachi Printing Solutions, Ltd.
+ 0:6:fc	Fnet Co., Ltd.
+ 0:6:fd	Comjet Information Systems Corp.
+-0:6:fe	Celion Networks, Inc.
++0:6:fe	Ambrado, Inc
+ 0:6:ff	Sheba Systems Co., Ltd.
++0:6:f	Narad Networks Inc
+ 0:70:b0	M/A-COM INC. COMPANIES
+ 0:70:b3	DATA RECALL LTD.
+ 0:7:0	Zettamedia Korea
+-0:7:1	RACAL-DATACOM
+ 0:7:10	Adax, Inc.
+ 0:7:11	Acterna
+ 0:7:12	JAL Information Technology
+@@ -5400,15 +8741,15 @@
+ 0:7:18	iCanTek Co., Ltd.
+ 0:7:19	Mobiis Co., Ltd.
+ 0:7:1a	Finedigital Inc.
+-0:7:1b	Position Technology Inc.
++0:7:1b	CDV Americas Ltd
+ 0:7:1c	AT&T Fixed Wireless Services
+ 0:7:1d	Satelsa Sistemas Y Aplicaciones De Telecomunicaciones, S.A.
+ 0:7:1e	Tri-M Engineering / Nupak Dev. Corp.
+ 0:7:1f	European Systems Integration
+-0:7:2	Varian Medical Systems
++0:7:1	RACAL-DATACOM
+ 0:7:20	Trutzschler GmbH & Co. KG
+ 0:7:21	Formac Elektronik GmbH
+-0:7:22	Nielsen Media Research
++0:7:22	The Nielsen Company
+ 0:7:23	ELCON Systemtechnik GmbH
+ 0:7:24	Telemax Co., Ltd.
+ 0:7:25	Bematech International Corp.
+@@ -5421,9 +8762,9 @@
+ 0:7:2d	CNSystems
+ 0:7:2e	North Node AB
+ 0:7:2f	Intransa, Inc.
+-0:7:3	CSEE Transport
++0:7:2	Varian Medical Systems
+ 0:7:30	Hutchison OPTEL Telecom Technology Co., Ltd.
+-0:7:31	Spiricon, Inc.
++0:7:31	Ophir-Spiricon Inc
+ 0:7:32	AAEON Technology Inc.
+ 0:7:33	DANCONTROL Engineering
+ 0:7:34	ONStor, Inc.
+@@ -5431,20 +8772,21 @@
+ 0:7:36	Data Video Technologies Co., Ltd.
+ 0:7:37	Soriya Co. Ltd.
+ 0:7:38	Young Technology Co., Ltd.
+-0:7:39	Motion Media Technology Ltd.
++0:7:39	Scotty Group Austria Gmbh
+ 0:7:3a	Inventel Systemes
+ 0:7:3b	Tenovis GmbH & Co KG
++0:7:3	CSEE Transport
+ 0:7:3c	Telecom Design
+ 0:7:3d	Nanjing Postel Telecommunications Co., Ltd.
+ 0:7:3e	China Great-Wall Computer Shenzhen Co., Ltd.
+ 0:7:3f	Woojyun Systec Co., Ltd.
+-0:7:40	Melco Inc.
++0:7:40	Buffalo, Inc
+ 0:7:41	Sierra Automated Systems
+-0:7:42	Current Technologies
++0:7:42	Current Technologies, LLC
+ 0:7:43	Chelsio Communications
+ 0:7:44	Unico, Inc.
+ 0:7:45	Radlan Computer Communications Ltd.
+-0:7:46	Interlink BT, LLC
++0:7:46	TURCK, Inc.
+ 0:7:47	Mecalc
+ 0:7:48	The Imaging Source Europe
+ 0:7:49	CENiX Inc.
+@@ -5454,9 +8796,8 @@
+ 0:7:4d	Zebra Technologies Corp.
+ 0:7:4e	Naughty boy co., Ltd.
+ 0:7:4f	Cisco Systems, Inc.
+-0:7:5	Endress & Hauser GmbH & Co
+ 0:7:50	Cisco Systems, Inc.
+-0:7:51	m.u.t. - GmbH
++0:7:51	m
+ 0:7:52	Rhythm Watch Co., Ltd.
+ 0:7:53	Beijing Qxcomm Technology Co., Ltd.
+ 0:7:54	Xyterra Computing, Inc.
+@@ -5469,9 +8810,9 @@
+ 0:7:5b	Gibson Guitars
+ 0:7:5c	Eastman Kodak Company
+ 0:7:5d	Celleritas Inc.
+-0:7:5e	Pulsar Technologies, Inc.
++0:7:5e	Ametek Power Instruments
++0:7:5	Endress & Hauser GmbH & Co
+ 0:7:5f	VCS Video Communication Systems AG
+-0:7:6	Sanritz Corporation
+ 0:7:60	TOMIS Information & Telecom Corp.
+ 0:7:61	Logitech SA
+ 0:7:62	Group Sense Limited
+@@ -5488,7 +8829,7 @@
+ 0:7:6d	Flexlight Networks
+ 0:7:6e	Sinetica Corporation Limited
+ 0:7:6f	Synoptics Limited
+-0:7:7	Interalia Inc.
++0:7:6	Sanritz Corporation
+ 0:7:70	Locusnetworks Corporation
+ 0:7:71	Embedded System Corporation
+ 0:7:72	Alcatel Shanghai Bell Co., Ltd.
+@@ -5501,13 +8842,13 @@
+ 0:7:79	Sungil Telecom Co., Ltd.
+ 0:7:7a	Infoware System Co., Ltd.
+ 0:7:7b	Millimetrix Broadband Networks
+-0:7:7c	OnTime Networks
++0:7:7c	Westermo Teleindustri AB
+ 0:7:7e	Elrest GmbH
+ 0:7:7f	J Communications Co., Ltd.
+-0:7:8	Bitrage Inc.
++0:7:7	Interalia Inc.
+ 0:7:80	Bluegiga Technologies OY
+ 0:7:81	Itron Inc.
+-0:7:82	Nauticus Networks, Inc.
++0:7:82	Oracle Corporation
+ 0:7:83	SynCom Network, Inc.
+ 0:7:84	Cisco Systems Inc.
+ 0:7:85	Cisco Systems Inc.
+@@ -5516,12 +8857,12 @@
+ 0:7:88	Clipcomm, Inc.
+ 0:7:89	Eastel Systems Corporation
+ 0:7:8a	Mentor Data System Inc.
++0:7:8	Bitrage Inc.
+ 0:7:8b	Wegener Communications, Inc.
+ 0:7:8c	Elektronikspecialisten i Borlange AB
+ 0:7:8d	NetEngines Ltd.
+ 0:7:8e	Garz & Friche GmbH
+ 0:7:8f	Emkay Innovative Products
+-0:7:9	Westerstrand Urfabrik AB
+ 0:7:90	Tri-M Technologies (s) Limited
+ 0:7:91	International Data Communications, Inc.
+ 0:7:92	Suetron Electronic GmbH
+@@ -5532,13 +8873,13 @@
+ 0:7:97	Netpower Co., Ltd.
+ 0:7:98	Selea SRL
+ 0:7:99	Tipping Point Technologies, Inc.
+-0:7:9a	SmartSight Networks Inc.
++0:7:9a	Verint Systems Inc
+ 0:7:9b	Aurora Networks
+ 0:7:9c	Golden Electronics Technology Co., Ltd.
+ 0:7:9d	Musashi Co., Ltd.
+ 0:7:9e	Ilinx Co., Ltd.
+ 0:7:9f	Action Digital Inc.
+-0:7:a	Unicom Automation Co., Ltd.
++0:7:9	Westerstrand Urfabrik AB
+ 0:7:a0	e-Watch Inc.
+ 0:7:a1	VIASYS Healthcare GmbH
+ 0:7:a2	Opteon Corporation
+@@ -5554,7 +8895,7 @@
+ 0:7:ad	Pentacon GmbH Foto-und Feinwerktechnik
+ 0:7:ae	Britestream Networks, Inc.
+ 0:7:af	N-Tron Corp.
+-0:7:b	Octal, SA
++0:7:a	Unicom Automation Co., Ltd.
+ 0:7:b0	Office Details, Inc.
+ 0:7:b1	Equator Technologies
+ 0:7:b2	Transaccess S.A.
+@@ -5563,7 +8904,7 @@
+ 0:7:b5	Any One Wireless Ltd.
+ 0:7:b6	Telecom Technology Ltd.
+ 0:7:b7	Samurai Ind. Prods Eletronicos Ltda
+-0:7:b8	American Predator Corp.
++0:7:b8	Corvalent Corporation
+ 0:7:b9	Ginganet Corporation
+ 0:7:ba	UTStarcom, Inc.
+ 0:7:bb	Candera Inc.
+@@ -5571,11 +8912,11 @@
+ 0:7:bd	Radionet Ltd.
+ 0:7:be	DataLogic SpA
+ 0:7:bf	Armillaire Technologies, Inc.
+-0:7:c	SVA-Intrusion.com Co. Ltd.
++0:7:b	Novabase SGPS, SA
+ 0:7:c0	NetZerver Inc.
+ 0:7:c1	Overture Networks, Inc.
+ 0:7:c2	Netsys Telecom
+-0:7:c3	Cirpack
++0:7:c3	Thomson
+ 0:7:c4	JEAN Co. Ltd.
+ 0:7:c5	Gcom, Inc.
+ 0:7:c6	VDS Vosskuhler GmbH
+@@ -5588,7 +8929,7 @@
+ 0:7:cd	NMTEL Co., Ltd.
+ 0:7:ce	Cabletime Limited
+ 0:7:cf	Anoto AB
+-0:7:d	Cisco Systems Inc.
++0:7:c	SVA-Intrusion.com Co. Ltd.
+ 0:7:d0	Automat Engenharia de Automaoa Ltda.
+ 0:7:d1	Spectrum Signal Processing Inc.
+ 0:7:d2	Logopak Systeme
+@@ -5602,10 +8943,10 @@
+ 0:7:da	Neuro Telecom Co., Ltd.
+ 0:7:db	Kirana Networks, Inc.
+ 0:7:dc	Atek Co, Ltd.
++0:7:d	Cisco Systems Inc.
+ 0:7:dd	Cradle Technologies
+ 0:7:de	eCopilt AB
+ 0:7:df	Vbrick Systems Inc.
+-0:7:e	Cisco Systems Inc.
+ 0:7:e0	Palm Inc.
+ 0:7:e1	WIS Communications Co. Ltd.
+ 0:7:e2	Bitworks, Inc.
+@@ -5619,11 +8960,11 @@
+ 0:7:ea	Massana, Inc.
+ 0:7:eb	Cisco Systems Inc.
+ 0:7:ec	Cisco Systems Inc.
++0:7:e	Cisco Systems Inc.
+ 0:7:ed	Altera Corporation
+ 0:7:ee	telco Informationssysteme GmbH
+ 0:7:ef	Lockheed Martin Tactical Systems
+-0:7:f	Fujant, Inc.
+-0:7:f0	LogiSync Corporation
++0:7:f0	Beckett LogiSync LLC
+ 0:7:f1	TeraBurst Networks Inc.
+ 0:7:f2	IOA Corporation
+ 0:7:f3	Thinkengine Networks
+@@ -5639,8 +8980,8 @@
+ 0:7:fd	LANergy Ltd.
+ 0:7:fe	Rigaku Corporation
+ 0:7:ff	Gluon Networks
++0:7:f	Fujant, Inc.
+ 0:80:0	MULTITECH SYSTEMS, INC.
+-0:80:1	PERIPHONICS CORPORATION
+ 0:80:10	COMMODORE INTERNATIONAL
+ 0:80:11	DIGITAL SYSTEMS INT'L. INC.
+ 0:80:12	INTEGRATED MEASUREMENT SYSTEMS
+@@ -5657,7 +8998,7 @@
+ 0:80:1d	INTEGRATED INFERENCE MACHINES
+ 0:80:1e	XINETRON, INC.
+ 0:80:1f	KRUPP ATLAS ELECTRONIK GMBH
+-0:80:2	SATELCOM (UK) LTD
++0:80:1	PERIPHONICS CORPORATION
+ 0:80:20	NETWORK PRODUCTS
+ 0:80:21	Alcatel Canada Inc.
+ 0:80:22	SCAN-OPTICS
+@@ -5674,7 +9015,7 @@
+ 0:80:2d	XYLOGICS INC
+ 0:80:2e	CASTLE ROCK COMPUTING
+ 0:80:2f	NATIONAL INSTRUMENTS CORP.
+-0:80:3	HYTEC ELECTRONICS LTD.
++0:80:2	SATELCOM (UK) LTD
+ 0:80:30	NEXUS ELECTRONICS
+ 0:80:31	BASYS, CORP.
+ 0:80:32	ACCESS CO., LTD.
+@@ -5691,10 +9032,10 @@
+ 0:80:3d	SURIGIKEN CO.,  LTD.
+ 0:80:3e	SYNERNETICS
+ 0:80:3f	TATUNG COMPANY
+-0:80:4	ANTLOW COMMUNICATIONS, LTD.
++0:80:3	HYTEC ELECTRONICS LTD.
+ 0:80:40	JOHN FLUKE MANUFACTURING CO.
+ 0:80:41	VEB KOMBINAT ROBOTRON
+-0:80:42	FORCE COMPUTERS
++0:80:42	Emerson Network Power
+ 0:80:43	NETWORLD, INC.
+ 0:80:44	SYSTECH COMPUTER CORP.
+ 0:80:45	MATSUSHITA ELECTRIC IND. CO
+@@ -5702,13 +9043,13 @@
+ 0:80:47	IN-NET CORP.
+ 0:80:48	COMPEX INCORPORATED
+ 0:80:49	NISSIN ELECTRIC CO., LTD.
++0:80:4	ANTLOW COMMUNICATIONS, LTD.
+ 0:80:4a	PRO-LOG
+ 0:80:4b	EAGLE TECHNOLOGIES PTY.LTD.
+ 0:80:4c	CONTEC CO., LTD.
+ 0:80:4d	CYCLONE MICROSYSTEMS, INC.
+ 0:80:4e	APEX COMPUTER COMPANY
+ 0:80:4f	DAIKIN INDUSTRIES, LTD.
+-0:80:5	CACTUS COMPUTER INC.
+ 0:80:50	ZIATECH CORPORATION
+ 0:80:51	FIBERMUX
+ 0:80:52	TECHNICALLY ELITE CONCEPTS
+@@ -5721,11 +9062,11 @@
+ 0:80:59	STANLEY ELECTRIC CO., LTD
+ 0:80:5a	TULIP COMPUTERS INTERNAT'L B.V
+ 0:80:5b	CONDOR SYSTEMS, INC.
++0:80:5	CACTUS COMPUTER INC.
+ 0:80:5c	AGILIS CORPORATION
+ 0:80:5d	CANSTAR
+ 0:80:5e	LSI LOGIC CORPORATION
+-0:80:5f	COMPAQ COMPUTER CORPORATION
+-0:80:6	COMPUADD CORPORATION
++0:80:5f	Hewlett Packard
+ 0:80:60	NETWORK INTERFACE CORPORATION
+ 0:80:61	LITTON SYSTEMS, INC.
+ 0:80:62	INTERFACE  CO.
+@@ -5739,10 +9080,10 @@
+ 0:80:6a	ERI (EMPAC RESEARCH INC.)
+ 0:80:6b	SCHMID TELECOMMUNICATION
+ 0:80:6c	CEGELEC PROJECTS LTD
++0:80:6	COMPUADD CORPORATION
+ 0:80:6d	CENTURY SYSTEMS CORP.
+ 0:80:6e	NIPPON STEEL CORPORATION
+ 0:80:6f	ONELAN LTD.
+-0:80:7	DLOG NC-SYSTEME
+ 0:80:70	COMPUTADORAS MICRON
+ 0:80:71	SAI TECHNOLOGY
+ 0:80:72	MICROPLEX SYSTEMS LTD.
+@@ -5757,9 +9098,9 @@
+ 0:80:7b	ARTEL COMMUNICATIONS CORP.
+ 0:80:7c	FIBERCOM, INC.
+ 0:80:7d	EQUINOX SYSTEMS INC.
++0:80:7	DLOG NC-SYSTEME
+ 0:80:7e	SOUTHERN PACIFIC LTD.
+ 0:80:7f	DY-4 INCORPORATED
+-0:80:8	DYNATECH COMPUTER SYSTEMS
+ 0:80:80	DATAMEDIA CORPORATION
+ 0:80:81	KENDALL SQUARE RESEARCH CORP.
+ 0:80:82	PEP MODULAR COMPUTERS GMBH
+@@ -5774,12 +9115,12 @@
+ 0:80:8b	DACOLL LIMITED
+ 0:80:8c	NetScout Systems, Inc.
+ 0:80:8d	WESTCOAST TECHNOLOGY B.V.
++0:80:8	DYNATECH COMPUTER SYSTEMS
+ 0:80:8e	RADSTONE TECHNOLOGY
+ 0:80:8f	C. ITOH ELECTRONICS, INC.
+-0:80:9	JUPITER SYSTEMS, INC.
+ 0:80:90	MICROTEK INTERNATIONAL, INC.
+ 0:80:91	TOKYO ELECTRIC CO.,LTD
+-0:80:92	JAPAN COMPUTER INDUSTRY, INC.
++0:80:92	Silex Technology, Inc.
+ 0:80:93	XYRON CORPORATION
+ 0:80:94	ALFA LAVAL AUTOMATION AB
+ 0:80:95	BASIC MERTON HANDELSGES.M.B.H.
+@@ -5793,15 +9134,15 @@
+ 0:80:9d	Commscraft Ltd.
+ 0:80:9e	DATUS GMBH
+ 0:80:9f	ALCATEL BUSINESS SYSTEMS
+-0:80:a	JAPAN COMPUTER CORP.
++0:80:9	JUPITER SYSTEMS, INC.
+ 0:80:a0	EDISA HEWLETT PACKARD S/A
+ 0:80:a1	MICROTEST, INC.
+ 0:80:a2	CREATIVE ELECTRONIC SYSTEMS
+-0:80:a3	LANTRONIX
++0:80:a3	Lantronix
+ 0:80:a4	LIBERTY ELECTRONICS
+ 0:80:a5	SPEED INTERNATIONAL
+ 0:80:a6	REPUBLIC TECHNOLOGY, INC.
+-0:80:a7	MEASUREX CORP.
++0:80:a7	Honeywell International Inc
+ 0:80:a8	VITACOM CORPORATION
+ 0:80:a9	CLEARPOINT RESEARCH
+ 0:80:aa	MAXPEED
+@@ -5810,7 +9151,7 @@
+ 0:80:ad	CNET TECHNOLOGY, INC.
+ 0:80:ae	HUGHES NETWORK SYSTEMS
+ 0:80:af	ALLUMER CO., LTD.
+-0:80:b	CSK CORPORATION
++0:80:a	JAPAN COMPUTER CORP.
+ 0:80:b0	ADVANCED INFORMATION
+ 0:80:b1	SOFTCOM A/S
+ 0:80:b2	NETWORK EQUIPMENT TECHNOLOGIES
+@@ -5824,10 +9165,10 @@
+ 0:80:ba	SPECIALIX (ASIA) PTE, LTD
+ 0:80:bb	HUGHES LAN SYSTEMS
+ 0:80:bc	HITACHI ENGINEERING CO., LTD
++0:80:b	CSK CORPORATION
+ 0:80:bd	THE FURUKAWA ELECTRIC CO., LTD
+ 0:80:be	ARIES RESEARCH
+ 0:80:bf	TAKAOKA ELECTRIC MFG. CO. LTD.
+-0:80:c	VIDECOM LIMITED
+ 0:80:c0	PENRIL DATACOMM
+ 0:80:c1	LANEX CORPORATION
+ 0:80:c2	IEEE 802.1 COMMITTEE
+@@ -5844,7 +9185,7 @@
+ 0:80:cd	MICRONICS COMPUTER, INC.
+ 0:80:ce	BROADCAST TELEVISION SYSTEMS
+ 0:80:cf	EMBEDDED PERFORMANCE INC.
+-0:80:d	VOSSWINKEL F.U.
++0:80:c	VIDECOM LIMITED
+ 0:80:d0	COMPUTER PERIPHERALS, INC.
+ 0:80:d1	KIMTRON CORPORATION
+ 0:80:d2	SHINNIHONDENKO CO., LTD.
+@@ -5854,14 +9195,14 @@
+ 0:80:d6	NUVOTECH, INC.
+ 0:80:d7	Fantum Engineering
+ 0:80:d8	NETWORK PERIPHERALS INC.
+-0:80:d9	EMK ELEKTRONIK
++0:80:d9	EMK Elektronik GmbH & Co. KG
+ 0:80:da	BRUEL & KJAER
+ 0:80:db	GRAPHON CORPORATION
+ 0:80:dc	PICKER INTERNATIONAL
+ 0:80:dd	GMX INC/GIMIX
+ 0:80:de	GIPSI S.A.
+ 0:80:df	ADC CODENOLL TECHNOLOGY CORP.
+-0:80:e	ATLANTIX CORPORATION
++0:80:d	VOSSWINKEL F.U.
+ 0:80:e0	XTP SYSTEMS, INC.
+ 0:80:e1	STMICROELECTRONICS
+ 0:80:e2	T.D.I. CO., LTD.
+@@ -5873,18 +9214,18 @@
+ 0:80:e8	CUMULUS CORPORATIION
+ 0:80:e9	Madge Ltd.
+ 0:80:ea	ADVA Optical Networking Ltd.
++0:80:e	ATLANTIX CORPORATION
+ 0:80:eb	COMPCONTROL B.V.
+ 0:80:ec	SUPERCOMPUTING SOLUTIONS, INC.
+ 0:80:ed	IQ TECHNOLOGIES, INC.
+ 0:80:ee	THOMSON CSF
+ 0:80:ef	RATIONAL
+-0:80:f	STANDARD MICROSYSTEMS
+ 0:80:f0	Panasonic Communications Co., Ltd.
+ 0:80:f1	OPUS SYSTEMS
+ 0:80:f2	RAYCOM SYSTEMS INC
+ 0:80:f3	SUN ELECTRONICS CORP.
+ 0:80:f4	TELEMECANIQUE ELECTRIQUE
+-0:80:f5	QUANTEL LTD
++0:80:f5	Quantel Ltd
+ 0:80:f6	SYNERGY MICROSYSTEMS
+ 0:80:f7	ZENITH ELECTRONICS
+ 0:80:f8	MIZAR, INC.
+@@ -5895,8 +9236,8 @@
+ 0:80:fd	EXSCEED CORPRATION
+ 0:80:fe	AZURE TECHNOLOGIES, INC.
+ 0:80:ff	SOC. DE TELEINFORMATIQUE RTC
++0:80:f	STANDARD MICROSYSTEMS
+ 0:8:0	MULTITECH SYSTEMS, INC.
+-0:8:1	HighSpeed Surfing Inc.
+ 0:8:10	Key Technology, Inc.
+ 0:8:11	VOIX Corporation
+ 0:8:12	GM-2 Corporation
+@@ -5913,12 +9254,12 @@
+ 0:8:1d	Ipsil, Incorporated
+ 0:8:1e	Repeatit AB
+ 0:8:1f	Pou Yuen Tech Corp. Ltd.
+-0:8:2	Compaq Computer Corporation
++0:8:1	HighSpeed Surfing Inc.
+ 0:8:20	Cisco Systems Inc.
+ 0:8:21	Cisco Systems Inc.
+ 0:8:22	InPro Comm
+ 0:8:23	Texa Corp.
+-0:8:24	Promatek Industries Ltd.
++0:8:24	Copitrak Inc
+ 0:8:25	Acme Packet
+ 0:8:26	Colorado Med Tech
+ 0:8:27	Pirelli Broadband Solutions
+@@ -5929,11 +9270,11 @@
+ 0:8:2c	Homag AG
+ 0:8:2d	Indus Teqsite Private Limited
+ 0:8:2e	Multitone Electronics PLC
++0:8:2	Hewlett Packard
+ 0:8:3	Cos Tron
+-0:8:4	ICA Inc.
+ 0:8:4e	DivergeNet, Inc.
+ 0:8:4f	Qualstar Corporation
+-0:8:5	Techno-Holon Corporation
++0:8:4	ICA Inc.
+ 0:8:50	Arizona Instrument Corp.
+ 0:8:51	Canadian Bank Note Company, Ltd.
+ 0:8:52	Davolink Co. Inc.
+@@ -5950,7 +9291,7 @@
+ 0:8:5d	Aastra
+ 0:8:5e	PCO AG
+ 0:8:5f	Picanol N.V.
+-0:8:6	Raonet Systems, Inc.
++0:8:5	Techno-Holon Corporation
+ 0:8:60	LodgeNet Entertainment Corp.
+ 0:8:61	SoftEnergy Co., Ltd.
+ 0:8:62	NEC Eluminant Technologies, Inc.
+@@ -5967,24 +9308,24 @@
+ 0:8:6d	Missouri FreeNet
+ 0:8:6e	Hyglo AB
+ 0:8:6f	Resources Computer Network Ltd.
+-0:8:7	Access Devices Limited
++0:8:6	Raonet Systems, Inc.
+ 0:8:70	Rasvia Systems, Inc.
+ 0:8:71	NORTHDATA Co., Ltd.
+-0:8:72	Sorenson Technologies, Inc.
+-0:8:73	DAP Design B.V.
++0:8:72	Sorenson Communications
++0:8:73	DapTechnology B.V.
+ 0:8:74	Dell Computer Corp.
+ 0:8:75	Acorp Electronics Corp.
+ 0:8:76	SDSystem
+-0:8:77	Liebert HIROSS S.p.A.
++0:8:77	Liebert-Hiross Spa
+ 0:8:78	Benchmark Storage Innovations
+ 0:8:79	CEM Corporation
++0:8:7	Access Devices Limited
+ 0:8:7a	Wipotec GmbH
+ 0:8:7b	RTX Telecom A/S
+ 0:8:7c	Cisco Systems, Inc.
+ 0:8:7d	Cisco Systems Inc.
+ 0:8:7e	Bon Electro-Telecom Inc.
+ 0:8:7f	SPAUN electronic GmbH & Co. KG
+-0:8:8	PPT Vision, Inc.
+ 0:8:80	BroadTel Canada Communications inc.
+ 0:8:81	DIGITAL HANDS CO.,LTD.
+ 0:8:82	SIGMA CORPORATION
+@@ -6001,7 +9342,7 @@
+ 0:8:8d	Sigma-Links Inc.
+ 0:8:8e	Nihon Computer Co., Ltd.
+ 0:8:8f	ADVANCED DIGITAL TECHNOLOGY
+-0:8:9	Systemonic AG
++0:8:8	PPT Vision, Inc.
+ 0:8:90	AVILINKS SA
+ 0:8:91	Lyan Inc.
+ 0:8:92	EM Solutions
+@@ -6018,7 +9359,7 @@
+ 0:8:9d	UHD-Elektronik
+ 0:8:9e	Beijing Enter-Net co.LTD
+ 0:8:9f	EFM Networks
+-0:8:a	Espera-Werke GmbH
++0:8:9	Systemonic AG
+ 0:8:a0	Stotz Feinmesstechnik GmbH
+ 0:8:a1	CNet Technology Inc.
+ 0:8:a2	ADI Engineering, Inc.
+@@ -6031,11 +9372,11 @@
+ 0:8:a9	SangSang Technology, Inc.
+ 0:8:aa	KARAM
+ 0:8:ab	EnerLinx.com, Inc.
+-0:8:ac	PRIVATE
++0:8:ac	Eltromat GmbH
+ 0:8:ad	Toyo-Linx Co., Ltd.
+ 0:8:ae	PacketFront Sweden AB
++0:8:a	Espera-Werke GmbH
+ 0:8:af	Novatec Corporation
+-0:8:b	Birka BPA Informationssystem AB
+ 0:8:b0	BKtel communications GmbH
+ 0:8:b1	ProQuent Systems
+ 0:8:b2	SHENZHEN COMPASS TECHNOLOGY DEVELOPMENT CO.,LTD
+@@ -6047,20 +9388,21 @@
+ 0:8:b8	E.F. Johnson
+ 0:8:b9	KAON MEDIA Co., Ltd.
+ 0:8:ba	Erskine Systems Ltd
++0:8:b	Birka BPA Informationssystem AB
+ 0:8:bb	NetExcell
+ 0:8:bc	Ilevo AB
+ 0:8:bd	TEPG-US
+ 0:8:be	XENPAK MSA Group
+ 0:8:bf	Aptus Elektronik AB
+-0:8:c	VDA elettronica SrL
+ 0:8:c0	ASA SYSTEMS
++0:8c:10	Black Box Corp.
+ 0:8:c1	Avistar Communications Corporation
+ 0:8:c2	Cisco Systems
+ 0:8:c3	Contex A/S
+ 0:8:c4	Hikari Co.,Ltd.
+ 0:8:c5	Liontech Co., Ltd.
+ 0:8:c6	Philips Consumer Communications
+-0:8:c7	COMPAQ COMPUTER CORPORATION
++0:8:c7	Hewlett Packard
+ 0:8:c8	Soneticom, Inc.
+ 0:8:c9	TechniSat Digital GmbH
+ 0:8:ca	TwinHan Technology Co.,Ltd
+@@ -6068,14 +9410,15 @@
+ 0:8:cc	Remotec, Inc.
+ 0:8:cd	With-Net Inc
+ 0:8:ce	IPMobileNet Inc.
++0:8c:fa	Inventec Corporation
+ 0:8:cf	Nippon Koei Power Systems Co., Ltd.
+-0:8:d	Toshiba
++0:8:c	VDA Elettronica spa
+ 0:8:d0	Musashi Engineering Co., LTD.
+ 0:8:d1	KAREL INC.
+ 0:8:d2	ZOOM Networks Inc.
+ 0:8:d3	Hercules Technologies S.A.
+ 0:8:d4	IneoQuest Technologies, Inc
+-0:8:d5	Vanguard Managed Solutions
++0:8:d5	Vanguard Networks Solutions, LLC
+ 0:8:d6	HASSNET Inc.
+ 0:8:d7	HOW CORPORATION
+ 0:8:d8	Dowkey Microwave
+@@ -6086,7 +9429,7 @@
+ 0:8:dd	Telena Communications, Inc.
+ 0:8:de	3UP Systems
+ 0:8:df	Alistel Inc.
+-0:8:e	Motorola, BCS
++0:8:d	Toshiba
+ 0:8:e0	ATO Technology Ltd.
+ 0:8:e1	Barix AG
+ 0:8:e2	Cisco Systems
+@@ -6099,29 +9442,29 @@
+ 0:8:e9	NextGig
+ 0:8:ea	Motion Control Engineering, Inc
+ 0:8:eb	ROMWin Co.,Ltd.
+-0:8:ec	Zonu, Inc.
++0:8:ec	Optical Zonu Corporation
+ 0:8:ed	ST&T Instrument Corp.
+ 0:8:ee	Logic Product Development
+ 0:8:ef	DIBAL,S.A.
+-0:8:f	Proximion Fiber Optics AB
++0:8:e	Motorola, BCS
+ 0:8:f0	Next Generation Systems, Inc.
+ 0:8:f1	Voltaire
+ 0:8:f2	C&S Technology
+ 0:8:f3	WANY
+ 0:8:f4	Bluetake Technology Co., Ltd.
+ 0:8:f5	YESTECHNOLOGY Co.,Ltd.
+-0:8:f6	SUMITOMO ELECTRIC HIGHTECHS.co.,ltd.
++0:8:f6	Sumitomo Electric System Solutions Co.,Ltd.
+ 0:8:f7	Hitachi Ltd, Semiconductor &amp; Integrated Circuits Gr
+ 0:8:f8	Guardall Ltd
+-0:8:f9	Padcom, Inc.
++0:8:f9	Emerson Network Power
+ 0:8:fa	Karl E.Brinkmann GmbH
+ 0:8:fb	SonoSite, Inc.
+ 0:8:fc	Gigaphoton Inc.
+ 0:8:fd	BlueKorea Co., Ltd.
+ 0:8:fe	UNIK C&C Co.,Ltd.
+-0:8:ff	Trilogy Broadcast (Holdings) Ltd
++0:8:ff	Trilogy Communications Ltd
++0:8:f	Proximion Fiber Optics AB
+ 0:90:0	DIAMOND MULTIMEDIA
+-0:90:1	NISHIMU ELECTRONICS INDUSTRIES CO., LTD.
+ 0:90:10	SIMULATION LABORATORIES, INC.
+ 0:90:11	WAVTrace, Inc.
+ 0:90:12	GLOBESPAN SEMICONDUCTOR, INC.
+@@ -6129,33 +9472,33 @@
+ 0:90:14	ROTORK INSTRUMENTS, LTD.
+ 0:90:15	CENTIGRAM COMMUNICATIONS CORP.
+ 0:90:16	ZAC
+-0:90:17	ZYPCOM, INC.
++0:90:17	Zypcom, Inc
+ 0:90:18	ITO ELECTRIC INDUSTRY CO, LTD.
+ 0:90:19	HERMES ELECTRONICS CO., LTD.
+ 0:90:1a	UNISPHERE SOLUTIONS
+ 0:90:1b	DIGITAL CONTROLS
+ 0:90:1c	mps Software Gmbh
+ 0:90:1d	PEC (NZ) LTD.
+-0:90:1e	SELESTA INGEGNE RIA S.P.A.
++0:90:1e	Selesta Ingegneria S.p.A.
+ 0:90:1f	ADTEC PRODUCTIONS, INC.
+-0:90:2	ALLGON AB
++0:90:1	NISHIMU ELECTRONICS INDUSTRIES CO., LTD.
+ 0:90:20	PHILIPS ANALYTICAL X-RAY B.V.
+ 0:90:21	CISCO SYSTEMS, INC.
+ 0:90:22	IVEX
+ 0:90:23	ZILOG INC.
+ 0:90:24	PIPELINKS, INC.
+-0:90:25	VISION SYSTEMS LTD. PTY
++0:90:25	BAE Systems Australia (Electronic Systems) Pty Ltd
+ 0:90:26	ADVANCED SWITCHING COMMUNICATIONS, INC.
+ 0:90:27	INTEL CORPORATION
+ 0:90:28	NIPPON SIGNAL CO., LTD.
+ 0:90:29	CRYPTO AG
+ 0:90:2a	COMMUNICATION DEVICES, INC.
++0:90:2	ALLGON AB
+ 0:90:2b	CISCO SYSTEMS, INC.
+ 0:90:2c	DATA & CONTROL EQUIPMENT LTD.
+ 0:90:2d	DATA ELECTRONICS (AUST.) PTY, LTD.
+ 0:90:2e	NAMCO LIMITED
+ 0:90:2f	NETCORE SYSTEMS, INC.
+-0:90:3	APLIO
+ 0:90:30	HONEYWELL-DATING
+ 0:90:31	MYSTICOM, LTD.
+ 0:90:32	PELCOMBE GROUP LTD.
+@@ -6167,15 +9510,16 @@
+ 0:90:38	FOUNTAIN TECHNOLOGIES, INC.
+ 0:90:39	SHASTA NETWORKS
+ 0:90:3a	NIHON MEDIA TOOL INC.
++0:90:3	APLIO
+ 0:90:3b	TriEMS Research Lab, Inc.
+ 0:90:3c	ATLANTIC NETWORK SYSTEMS
+ 0:90:3d	BIOPAC SYSTEMS, INC.
+ 0:90:3e	N.V. PHILIPS INDUSTRIAL ACTIVITIES
+ 0:90:3f	AZTEC RADIOMEDIA
+-0:90:4	3COM EUROPE LTD.
+ 0:90:40	Siemens Network Convergence LLC
+ 0:90:41	APPLIED DIGITAL ACCESS
+ 0:90:42	ECCS, Inc.
++0:90:4	3COM EUROPE LTD.
+ 0:90:43	NICHIBEI DENSHI CO., LTD.
+ 0:90:44	ASSURED DIGITAL, INC.
+ 0:90:45	Marconi Communications
+@@ -6189,7 +9533,6 @@
+ 0:90:4d	SPEC S.A.
+ 0:90:4e	DELEM BV
+ 0:90:4f	ABB POWER T&D COMPANY, INC.
+-0:90:5	PROTECH SYSTEMS CO., LTD.
+ 0:90:50	TELESTE OY
+ 0:90:51	ULTIMATE TECHNOLOGY CORP.
+ 0:90:52	SELCOM ELETTRONICA S.R.L.
+@@ -6206,12 +9549,12 @@
+ 0:90:5d	NETCOM SICHERHEITSTECHNIK GmbH
+ 0:90:5e	RAULAND-BORG CORPORATION
+ 0:90:5f	CISCO SYSTEMS, INC.
+-0:90:6	HAMAMATSU PHOTONICS K.K.
++0:90:5	PROTECH SYSTEMS CO., LTD.
+ 0:90:60	SYSTEM CREATE CORP.
+ 0:90:61	PACIFIC RESEARCH & ENGINEERING CORPORATION
+ 0:90:62	ICP VORTEX COMPUTERSYSTEME GmbH
+ 0:90:63	COHERENT COMMUNICATIONS SYSTEMS CORPORATION
+-0:90:64	THOMSON BROADCAST SYSTEMS
++0:90:64	Thomson Inc.
+ 0:90:65	FINISAR CORPORATION
+ 0:90:66	Troika Networks, Inc.
+ 0:90:67	WalkAbout Computers, Inc.
+@@ -6223,7 +9566,7 @@
+ 0:90:6d	CISCO SYSTEMS, INC.
+ 0:90:6e	PRAXON, INC.
+ 0:90:6f	CISCO SYSTEMS, INC.
+-0:90:7	DOMEX TECHNOLOGY CORP.
++0:90:6	HAMAMATSU PHOTONICS K.K.
+ 0:90:70	NEO NETWORKS, INC.
+ 0:90:71	Applied Innovation Inc.
+ 0:90:72	SIMRAD AS
+@@ -6234,13 +9577,13 @@
+ 0:90:77	ADVANCED FIBRE COMMUNICATIONS
+ 0:90:78	MER TELEMANAGEMENT SOLUTIONS, LTD.
+ 0:90:79	ClearOne, Inc.
+-0:90:7a	SPECTRALINK CORP.
++0:90:7a	Polycom, Inc.
+ 0:90:7b	E-TECH, INC.
+ 0:90:7c	DIGITALCAST, INC.
+ 0:90:7d	Lake Communications
++0:90:7	DOMEX TECHNOLOGY CORP.
+ 0:90:7e	VETRONIX CORP.
+ 0:90:7f	WatchGuard Technologies, Inc.
+-0:90:8	HanA Systems Inc.
+ 0:90:80	NOT LIMITED, INC.
+ 0:90:81	ALOHA NETWORKS, INC.
+ 0:90:82	FORCE INSTITUTE
+@@ -6257,7 +9600,7 @@
+ 0:90:8d	VICKERS ELECTRONICS SYSTEMS
+ 0:90:8e	Nortel Networks Broadband Access
+ 0:90:8f	AUDIO CODES LTD.
+-0:90:9	i Controls, Inc.
++0:90:8	HanA Systems Inc.
+ 0:90:90	I-BUS
+ 0:90:91	DigitalScape, Inc.
+ 0:90:92	CISCO SYSTEMS, INC.
+@@ -6265,18 +9608,18 @@
+ 0:90:94	OSPREY TECHNOLOGIES, INC.
+ 0:90:95	UNIVERSAL AVIONICS
+ 0:90:96	ASKEY COMPUTER CORP.
+-0:90:97	SYCAMORE NETWORKS
++0:90:97	Sycamore Networks
+ 0:90:98	SBC DESIGNS, INC.
+ 0:90:99	ALLIED TELESIS, K.K.
+ 0:90:9a	ONE WORLD SYSTEMS, INC.
+-0:90:9b	MARKPOINT AB
+-0:90:9c	Terayon Communications Systems
++0:90:9b	IMAJE
++0:90:9c	Motorola, Inc.
+ 0:90:9d	NovaTech Process Solutions, LLC
+ 0:90:9e	Critical IO, LLC
+ 0:90:9f	DIGI-DATA CORPORATION
+-0:90:a	PROTON ELECTRONIC INDUSTRIAL CO., LTD.
++0:90:9	i Controls, Inc.
+ 0:90:a0	8X8 INC.
+-0:90:a1	FLYING PIG SYSTEMS, LTD.
++0:90:a1	Flying Pig Systems/High End Systems Inc.
+ 0:90:a2	CYBERTAN TECHNOLOGY, INC.
+ 0:90:a3	Corecess Inc.
+ 0:90:a4	ALTIGA NETWORKS
+@@ -6291,7 +9634,7 @@
+ 0:90:ad	ASPECT ELECTRONICS, INC.
+ 0:90:ae	ITALTEL S.p.A.
+ 0:90:af	J. MORITA MFG. CORP.
+-0:90:b	LANNER ELECTRONICS, INC.
++0:90:a	PROTON ELECTRONIC INDUSTRIAL CO., LTD.
+ 0:90:b0	VADEM
+ 0:90:b1	CISCO SYSTEMS, INC.
+ 0:90:b2	AVICI SYSTEMS INC.
+@@ -6308,7 +9651,7 @@
+ 0:90:bd	OMNIA COMMUNICATIONS, INC.
+ 0:90:be	IBC/INTEGRATED BUSINESS COMPUTERS
+ 0:90:bf	CISCO SYSTEMS, INC.
+-0:90:c	CISCO SYSTEMS, INC.
++0:90:b	LANNER ELECTRONICS, INC.
+ 0:90:c0	K.J. LAW ENGINEERS, INC.
+ 0:90:c1	Peco II, Inc.
+ 0:90:c2	JK microsystems, Inc.
+@@ -6321,11 +9664,11 @@
+ 0:90:c9	DPAC Technologies
+ 0:90:ca	ACCORD VIDEO TELECOMMUNICATIONS, LTD.
+ 0:90:cb	Wireless OnLine, Inc.
+-0:90:cc	PLANET COMMUNICATIONS, INC.
++0:90:c	CISCO SYSTEMS, INC.
++0:90:cc	Planex Communications
+ 0:90:cd	ENT-EMPRESA NACIONAL DE TELECOMMUNICACOES, S.A.
+ 0:90:ce	TETRA GmbH
+ 0:90:cf	NORTEL
+-0:90:d	OVERLAND DATA INC.
+ 0:90:d0	Thomson Telecom Belgium
+ 0:90:d1	LEICHU ENTERPRISE CO., LTD.
+ 0:90:d2	ARTEL VIDEO SYSTEMS
+@@ -6342,14 +9685,14 @@
+ 0:90:dd	THE MIHARU COMMUNICATIONS CO., LTD.
+ 0:90:de	CARDKEY SYSTEMS, INC.
+ 0:90:df	MITSUBISHI CHEMICAL AMERICA, INC.
+-0:90:e	HANDLINK TECHNOLOGIES, INC.
++0:90:d	Overland Storage Inc.
+ 0:90:e0	SYSTRAN CORP.
+ 0:90:e1	TELENA S.P.A.
+ 0:90:e2	DISTRIBUTED PROCESSING TECHNOLOGY
+ 0:90:e3	AVEX ELECTRONICS INC.
+ 0:90:e4	NEC AMERICA, INC.
+ 0:90:e5	TEKNEMA, INC.
+-0:90:e6	ACER LABORATORIES, INC.
++0:90:e6	ALi Corporation
+ 0:90:e7	HORSCH ELEKTRONIK AG
+ 0:90:e8	MOXA TECHNOLOGIES CORP., LTD.
+ 0:90:e9	JANZ COMPUTER AG
+@@ -6359,7 +9702,7 @@
+ 0:90:ed	CENTRAL SYSTEM RESEARCH CO., LTD.
+ 0:90:ee	PERSONAL COMMUNICATIONS TECHNOLOGIES
+ 0:90:ef	INTEGRIX, INC.
+-0:90:f	KAWASAKI HEAVY INDUSTRIES, LTD
++0:90:e	HANDLINK TECHNOLOGIES, INC.
+ 0:90:f0	Harmonic Video Systems Ltd.
+ 0:90:f1	DOT HILL SYSTEMS CORPORATION
+ 0:90:f2	CISCO SYSTEMS, INC.
+@@ -6376,9 +9719,8 @@
+ 0:90:fd	CopperCom, Inc.
+ 0:90:fe	ELECOM CO., LTD.  (LANEED DIV.)
+ 0:90:ff	TELLUS TECHNOLOGY INC.
+-0:91:d6	Crystal Group, Inc.
++0:90:f	KAWASAKI HEAVY INDUSTRIES, LTD
+ 0:9:0	TMT
+-0:9:1	Shenzhen Shixuntong Information & Technoligy Co
+ 0:9:10	Simple Access Inc.
+ 0:9:11	Cisco Systems
+ 0:9:12	Cisco Systems
+@@ -6392,33 +9734,35 @@
+ 0:9:1a	Macat Optics & Electronics Co., Ltd.
+ 0:9:1b	Digital Generation Inc.
+ 0:9:1c	CacheVision, Inc
++0:91:d6	Crystal Group, Inc.
+ 0:9:1d	Proteam Computer Corporation
+ 0:9:1e	Firstech Technology Corp.
+ 0:9:1f	A&amp;D Co., Ltd.
+-0:9:2	Redline Communications Inc.
++0:9:1	Shenzhen Shixuntong Information & Technoligy Co
+ 0:9:20	EpoX COMPUTER CO.,LTD.
+ 0:9:21	Planmeca Oy
+-0:9:22	Touchless Sensor Technology AG
++0:9:22	TST Biometrics GmbH
+ 0:9:23	Heaman System Co., Ltd
+ 0:9:24	Telebau GmbH
+ 0:9:25	VSN Systemen BV
+ 0:9:26	YODA COMMUNICATIONS, INC.
+ 0:9:27	TOYOKEIKI CO.,LTD.
+-0:9:28	Telecore Inc
++0:9:28	Telecore
+ 0:9:29	Sanyo Industries (UK) Limited
+ 0:9:2a	MYTECS Co.,Ltd.
+ 0:9:2b	iQstor Networks, Inc.
+ 0:9:2c	Hitpoint Inc.
+-0:9:2d	High Tech Computer, Corp.
++0:9:2d	HTC Corporation
+ 0:9:2e	B&Tech System Inc.
+ 0:9:2f	Akom Technology Corporation
+-0:9:3	Panasas, Inc
++0:9:2	Redline Communications Inc.
+ 0:9:30	AeroConcierge Inc.
+ 0:9:31	Future Internet, Inc.
+ 0:9:32	Omnilux
+-0:9:33	OPTOVALLEY Co. Ltd.
++0:9:33	Ophit Co.Ltd.
+ 0:9:34	Dream-Multimedia-Tv GmbH
+ 0:9:35	Sandvine Incorporated
++0:93:63	Uni-Link Technology Co., Ltd.
+ 0:9:36	Ipetronik GmbH & Co.KG
+ 0:9:37	Inventec Appliance Corp
+ 0:9:38	Allot Communications
+@@ -6429,7 +9773,7 @@
+ 0:9:3d	Newisys,Inc.
+ 0:9:3e	C&I Technologies
+ 0:9:3f	Double-Win Enterpirse CO., LTD
+-0:9:4	MONDIAL electronic
++0:9:3	Panasas, Inc
+ 0:9:40	AGFEO GmbH & Co. KG
+ 0:9:41	Allied Telesis K.K.
+ 0:9:42	CRESCO, LTD.
+@@ -6446,9 +9790,9 @@
+ 0:9:4d	Braintree Communications Pty Ltd
+ 0:9:4e	BARTECH SYSTEMS INTERNATIONAL, INC
+ 0:9:4f	elmegt GmbH & Co. KG
+-0:9:5	iTEC Technologies Ltd.
++0:9:4	MONDIAL electronic
+ 0:9:50	Independent Storage Corporation
+-0:9:51	Apogee Instruments, Inc
++0:9:51	Apogee Imaging Systems
+ 0:9:52	Auerswald GmbH & Co. KG
+ 0:9:53	Linkage System Integration Co.Ltd.
+ 0:9:54	AMiT spol. s. r. o.
+@@ -6463,13 +9807,13 @@
+ 0:9:5d	Dialogue Technology Corp.
+ 0:9:5e	Masstech Group Inc.
+ 0:9:5f	Telebyte, Inc.
+-0:9:6	Esteem Networks
++0:9:5	iTEC Technologies Ltd.
+ 0:9:60	YOZAN Inc.
+ 0:9:61	Switchgear and Instrumentation Ltd
+-0:9:62	Filetrac AS
++0:9:62	Sonitor Technologies AS
+ 0:9:63	Dominion Lasercom Inc.
+-0:9:64	Hi-Techniques
+-0:9:65	PRIVATE
++0:9:64	Hi-Techniques, Inc.
++0:9:65	HyunJu Computer Co., Ltd.
+ 0:9:66	Thales Navigation
+ 0:9:67	Tachyon, Inc
+ 0:9:68	TECHNOVENTURE, INC.
+@@ -6479,8 +9823,8 @@
+ 0:9:6c	Imedia Semiconductor Corp.
+ 0:9:6d	Powernet Technologies Corp.
+ 0:9:6e	GIANT ELECTRONICS LTD.
++0:9:6	Esteem Networks
+ 0:9:6f	Beijing Zhongqing Elegant Tech. Corp.,Limited
+-0:9:7	Chrysalis Development
+ 0:9:70	Vibration Research Corporation
+ 0:9:71	Time Management, Inc.
+ 0:9:72	Securebase,Inc
+@@ -6494,10 +9838,11 @@
+ 0:9:7a	Louis Design Labs.
+ 0:9:7b	Cisco Systems
+ 0:9:7c	Cisco Systems
++0:9:7	Chrysalis Development
+ 0:9:7d	SecWell Networks Oy
+ 0:9:7e	IMI TECHNOLOGY CO., LTD
++0:97:ff	Heimann Sensor GmbH
+ 0:9:7f	Vsecure 2000 LTD.
+-0:9:8	VTech Technology Corp.
+ 0:9:80	Power Zenith Inc.
+ 0:9:81	Newport Networks
+ 0:9:82	Loewe Opta GmbH
+@@ -6511,10 +9856,10 @@
+ 0:9:8a	EqualLogic Inc
+ 0:9:8b	Entropic Communications, Inc.
+ 0:9:8c	Option Wireless Sweden
+-0:9:8d	DCT Ltd (Digital Communication Technologies Ltd)
++0:9:8d	Velocity Semiconductor
+ 0:9:8e	ipcas GmbH
+ 0:9:8f	Cetacean Networks
+-0:9:9	Telenor Connect A/S
++0:9:8	VTech Technology Corp.
+ 0:9:90	ACKSYS Communications & systems
+ 0:9:91	GE Fanuc Automation Manufacturing, Inc.
+ 0:9:92	InterEpoch Technology,INC.
+@@ -6531,7 +9876,7 @@
+ 0:9:9d	Haliplex Communications
+ 0:9:9e	Testech, Inc.
+ 0:9:9f	VIDEX INC.
+-0:9:a	SnedFar Technology Co., Ltd.
++0:9:9	Telenor Connect A/S
+ 0:9:a0	Microtechno Corporation
+ 0:9:a1	Telewise Communications, Inc.
+ 0:9:a2	Interface Co., Ltd.
+@@ -6548,7 +9893,7 @@
+ 0:9:ad	HYUNDAI SYSCOMM, INC.
+ 0:9:ae	OKANO ELECTRIC CO.,LTD
+ 0:9:af	e-generis
+-0:9:b	MTL  Instruments PLC
++0:9:a	SnedFar Technology Co., Ltd.
+ 0:9:b0	Onkyo Corporation
+ 0:9:b1	Kanematsu Electronics, Ltd.
+ 0:9:b2	L&F Inc.
+@@ -6561,14 +9906,14 @@
+ 0:9:b9	Action Imaging Solutions
+ 0:9:ba	MAKU Informationstechik GmbH
+ 0:9:bb	MathStar, Inc.
+-0:9:bc	Integrian, Inc.
++0:9:bc	Digital Safety Technologies, Inc
+ 0:9:bd	Epygi Technologies, Ltd.
+ 0:9:be	Mamiya-OP Co.,Ltd.
+ 0:9:bf	Nintendo Co.,Ltd.
+-0:9:c	Mayekawa Mfg. Co. Ltd.
++0:9:b	MTL  Instruments PLC
+ 0:9:c0	6WIND
+ 0:9:c1	PROCES-DATA A/S
+-0:9:c2	PRIVATE
++0:9:c2	Onity, Inc.
+ 0:9:c3	NETAS
+ 0:9:c4	Medicore Co., Ltd
+ 0:9:c5	KINGENE Technology Corporation
+@@ -6582,8 +9927,8 @@
+ 0:9:cd	HUDSON SOFT CO.,LTD.
+ 0:9:ce	SpaceBridge Semiconductor Corp.
+ 0:9:cf	iAd GmbH
+-0:9:d	LEADER ELECTRONICS CORP.
+-0:9:d0	Versatel Networks
++0:9:c	Mayekawa Mfg. Co. Ltd.
++0:9:d0	Solacom Technologies Inc.
+ 0:9:d1	SERANOA NETWORKS INC
+ 0:9:d2	Mai Logic Inc.
+ 0:9:d3	Western DataCom Co., Inc.
+@@ -6591,7 +9936,8 @@
+ 0:9:d5	Signal Communication, Inc.
+ 0:9:d6	KNC One GmbH
+ 0:9:d7	DC Security Products
+-0:9:d8	PRIVATE
++0:9d:8e	CARDIAC RECORDERS, INC.
++0:9:d8	F
+ 0:9:d9	Neoscale Systems, Inc
+ 0:9:da	Control Module Inc.
+ 0:9:db	eSpace
+@@ -6599,7 +9945,7 @@
+ 0:9:dd	Mavin Technology Inc.
+ 0:9:de	Samjin Information & Communications Co., Ltd.
+ 0:9:df	Vestel Komunikasyon Sanayi ve Ticaret A.S.
+-0:9:e	Helix Technology Inc.
++0:9:d	LEADER ELECTRONICS CORP.
+ 0:9:e0	XEMICS S.A.
+ 0:9:e1	Gemtek Technology Co., Ltd.
+ 0:9:e2	Sinbon Electronics Co., Ltd.
+@@ -6616,7 +9962,7 @@
+ 0:9:ed	CipherOptics
+ 0:9:ee	MEIKYO ELECTRIC CO.,LTD
+ 0:9:ef	Vocera Communications
+-0:9:f	Fortinet Inc.
++0:9:e	Helix Technology Inc.
+ 0:9:f0	Shimizu Technology Inc.
+ 0:9:f1	Yamaki Electric Corporation
+ 0:9:f2	Cohu, Inc., Electronics Division
+@@ -6627,14 +9973,13 @@
+ 0:9:f7	SED, a division of Calian
+ 0:9:f8	UNIMO TECHNOLOGY CO., LTD.
+ 0:9:f9	ART JAPAN CO., LTD.
+-0:9:fb	Philips Medizinsysteme Boeblingen GmbH
++0:9:fb	Philips Patient Monitoring
+ 0:9:fc	IPFLEX Inc.
+ 0:9:fd	Ubinetics Limited
+ 0:9:fe	Daisy Technologies, Inc.
++0:9:f	Fortinet Inc.
+ 0:9:ff	X.net 2000 GmbH
+-0:9d:8e	CARDIAC RECORDERS, INC.
+ 0:a0:0	CENTILLION NETWORKS, INC.
+-0:a0:1	DRS Signal Solutions
+ 0:a0:10	SYSLOGIC DATENTECHNIK AG
+ 0:a0:11	MUTOH INDUSTRIES LTD.
+ 0:a0:12	B.A.T.M. ADVANCED TECHNOLOGIES
+@@ -6648,10 +9993,10 @@
+ 0:a0:1a	BINAR ELEKTRONIK AB
+ 0:a0:1b	PREMISYS COMMUNICATIONS, INC.
+ 0:a0:1c	NASCENT NETWORKS CORPORATION
++0:a0:1	DRS Signal Solutions
+ 0:a0:1d	SIXNET
+ 0:a0:1e	EST CORPORATION
+ 0:a0:1f	TRICORD SYSTEMS, INC.
+-0:a0:2	LEEDS & NORTHRUP AUSTRALIA PTY LTD
+ 0:a0:20	CITICORP/TTI
+ 0:a0:21	General Dynamics
+ 0:a0:22	CENTRE FOR DEVELOPMENT OF ADVANCED COMPUTING
+@@ -6668,7 +10013,7 @@
+ 0:a0:2d	1394 Trade Association
+ 0:a0:2e	BRAND COMMUNICATIONS, LTD.
+ 0:a0:2f	PIRELLI CAVI
+-0:a0:3	STAEFA CONTROL SYSTEM
++0:a0:2	LEEDS & NORTHRUP AUSTRALIA PTY LTD
+ 0:a0:30	CAPTOR NV/SA
+ 0:a0:31	HAZELTINE CORPORATION, MS 1-17
+ 0:a0:32	GES SINGAPORE PTE. LTD.
+@@ -6676,7 +10021,7 @@
+ 0:a0:34	AXEL
+ 0:a0:35	CYLINK CORPORATION
+ 0:a0:36	APPLIED NETWORK TECHNOLOGY
+-0:a0:37	DATASCOPE CORPORATION
++0:a0:37	Mindray DS USA, Inc.
+ 0:a0:38	EMAIL ELECTRONICS
+ 0:a0:39	ROSS TECHNOLOGY, INC.
+ 0:a0:3a	KUBOTEK CORPORATION
+@@ -6685,7 +10030,7 @@
+ 0:a0:3d	OPTO-22
+ 0:a0:3e	ATM FORUM
+ 0:a0:3f	COMPUTER SOCIETY MICROPROCESSOR & MICROPROCESSOR STANDARDS C
+-0:a0:4	NETPOWER, INC.
++0:a0:3	Siemens Switzerland Ltd., I B T HVP
+ 0:a0:40	APPLE COMPUTER
+ 0:a0:41	INFICON
+ 0:a0:42	SPUR PRODUCTS CORP.
+@@ -6702,7 +10047,7 @@
+ 0:a0:4d	EDA INSTRUMENTS, INC.
+ 0:a0:4e	VOELKER TECHNOLOGIES, INC.
+ 0:a0:4f	AMERITEC CORP.
+-0:a0:5	DANIEL INSTRUMENTS, LTD.
++0:a0:4	NETPOWER, INC.
+ 0:a0:50	CYPRESS SEMICONDUCTOR
+ 0:a0:51	ANGIA COMMUNICATIONS. INC.
+ 0:a0:52	STANILITE ELECTRONICS PTY. LTD
+@@ -6716,10 +10061,10 @@
+ 0:a0:5a	KOFAX IMAGE PRODUCTS
+ 0:a0:5b	MARQUIP, INC.
+ 0:a0:5c	INVENTORY CONVERSION, INC./
++0:a0:5	DANIEL INSTRUMENTS, LTD.
+ 0:a0:5d	CS COMPUTER SYSTEME GmbH
+ 0:a0:5e	MYRIAD LOGIC INC.
+-0:a0:5f	BTG ENGINEERING BV
+-0:a0:6	IMAGE DATA PROCESSING SYSTEM GROUP
++0:a0:5f	BTG Electronics Design BV
+ 0:a0:60	ACER PERIPHERALS, INC.
+ 0:a0:61	PURITAN BENNETT
+ 0:a0:62	AES PRODATA
+@@ -6736,7 +10081,7 @@
+ 0:a0:6d	MANNESMANN TALLY CORPORATION
+ 0:a0:6e	AUSTRON, INC.
+ 0:a0:6f	THE APPCON GROUP, INC.
+-0:a0:7	APEXX TECHNOLOGY, INC.
++0:a0:6	IMAGE DATA PROCESSING SYSTEM GROUP
+ 0:a0:70	COASTCOM
+ 0:a0:71	VIDEO LOTTERY TECHNOLOGIES,INC
+ 0:a0:72	OVATION SYSTEMS LTD.
+@@ -6748,17 +10093,17 @@
+ 0:a0:78	Marconi Communications
+ 0:a0:79	ALPS ELECTRIC (USA), INC.
+ 0:a0:7a	ADVANCED PERIPHERALS TECHNOLOGIES, INC.
++0:a0:7	APEXX TECHNOLOGY, INC.
+ 0:a0:7b	DAWN COMPUTER INCORPORATION
+ 0:a0:7c	TONYANG NYLON CO., LTD.
+ 0:a0:7d	SEEQ TECHNOLOGY, INC.
+ 0:a0:7e	AVID TECHNOLOGY, INC.
+ 0:a0:7f	GSM-SYNTEL, LTD.
+-0:a0:8	NETCORP
+ 0:a0:80	SBE, Inc.
+ 0:a0:81	ALCATEL DATA NETWORKS
+ 0:a0:82	NKT ELEKTRONIK A/S
+ 0:a0:83	ASIMMPHONY TURKEY
+-0:a0:84	DATAPLEX PTY. LTD.
++0:a0:84	Dataplex Pty Ltd
+ 0:a0:85	PRIVATE
+ 0:a0:86	AMBER WAVE SYSTEMS, INC.
+ 0:a0:87	Zarlink Semiconductor Ltd.
+@@ -6770,7 +10115,7 @@
+ 0:a0:8d	JACOMO CORPORATION
+ 0:a0:8e	Nokia Internet Communications
+ 0:a0:8f	DESKNET SYSTEMS, INC.
+-0:a0:9	WHITETREE NETWORK
++0:a0:8	NETCORP
+ 0:a0:90	TimeStep Corporation
+ 0:a0:91	APPLICOM INTERNATIONAL
+ 0:a0:92	H. BOLLMANN MANUFACTURERS, LTD
+@@ -6779,7 +10124,7 @@
+ 0:a0:95	ACACIA NETWORKS, INC.
+ 0:a0:96	MITUMI ELECTRIC CO., LTD.
+ 0:a0:97	JC INFORMATION SYSTEMS
+-0:a0:98	NETWORK APPLIANCE CORP.
++0:a0:98	NetApp
+ 0:a0:99	K-NET LTD.
+ 0:a0:9a	NIHON KOHDEN AMERICA
+ 0:a0:9b	QPSX COMMUNICATIONS, LTD.
+@@ -6787,7 +10132,7 @@
+ 0:a0:9d	JOHNATHON FREEMAN TECHNOLOGIES
+ 0:a0:9e	ICTV
+ 0:a0:9f	COMMVISION CORP.
+-0:a0:a	R.D.C. COMMUNICATION
++0:a0:9	WHITETREE NETWORK
+ 0:a0:a0	COMPACT DATA, LTD.
+ 0:a0:a1	EPIC DATA INC.
+ 0:a0:a2	DIGICOM S.P.A.
+@@ -6798,13 +10143,13 @@
+ 0:a0:a7	VORAX CORPORATION
+ 0:a0:a8	RENEX CORPORATION
+ 0:a0:a9	NAVTEL COMMUNICATIONS INC.
++0:a0:a	Airspan
+ 0:a0:aa	SPACELABS MEDICAL
+ 0:a0:ab	NETCS INFORMATIONSTECHNIK GMBH
+ 0:a0:ac	GILAT SATELLITE NETWORKS, LTD.
+ 0:a0:ad	MARCONI SPA
+ 0:a0:ae	NUCOM SYSTEMS, INC.
+ 0:a0:af	WMS INDUSTRIES
+-0:a0:b	COMPUTEX CO., LTD.
+ 0:a0:b0	I-O DATA DEVICE, INC.
+ 0:a0:b1	FIRST VIRTUAL CORPORATION
+ 0:a0:b2	SHIMA SEIKI
+@@ -6817,11 +10162,11 @@
+ 0:a0:b9	EAGLE TECHNOLOGY, INC.
+ 0:a0:ba	PATTON ELECTRONICS CO.
+ 0:a0:bb	HILAN GMBH
++0:a0:b	COMPUTEX CO., LTD.
+ 0:a0:bc	VIASAT, INCORPORATED
+ 0:a0:bd	I-TECH CORP.
+ 0:a0:be	INTEGRATED CIRCUIT SYSTEMS, INC. COMMUNICATIONS GROUP
+ 0:a0:bf	WIRELESS DATA GROUP MOTOROLA
+-0:a0:c	KINGMAX TECHNOLOGY, INC.
+ 0:a0:c0	DIGITAL LINK CORP.
+ 0:a0:c1	ORTIVUS MEDICAL AB
+ 0:a0:c2	R.A. SYSTEMS CO., LTD.
+@@ -6838,7 +10183,7 @@
+ 0:a0:cd	DR. JOHANNES HEIDENHAIN GmbH
+ 0:a0:ce	ASTROCOM CORPORATION
+ 0:a0:cf	SOTAS, INC.
+-0:a0:d	THE PANDA PROJECT
++0:a0:c	KINGMAX TECHNOLOGY, INC.
+ 0:a0:d0	TEN X TECHNOLOGY, INC.
+ 0:a0:d1	INVENTEC CORPORATION
+ 0:a0:d2	ALLIED TELESIS INTERNATIONAL CORPORATION
+@@ -6855,10 +10200,10 @@
+ 0:a0:dd	AZONIX CORPORATION
+ 0:a0:de	YAMAHA CORPORATION
+ 0:a0:df	STS TECHNOLOGIES, INC.
+-0:a0:e	VISUAL NETWORKS, INC.
++0:a0:d	THE PANDA PROJECT
+ 0:a0:e0	TENNYSON TECHNOLOGIES PTY LTD
+ 0:a0:e1	WESTPORT RESEARCH ASSOCIATES, INC.
+-0:a0:e2	KEISOKU GIKEN CORP.
++0:a0:e2	Keisokugiken Corporation
+ 0:a0:e3	XKL SYSTEMS CORP.
+ 0:a0:e4	OPTIQUEST
+ 0:a0:e5	NHC COMMUNICATIONS
+@@ -6867,12 +10212,12 @@
+ 0:a0:e8	REUTERS HOLDINGS PLC
+ 0:a0:e9	ELECTRONIC RETAILING SYSTEMS INTERNATIONAL
+ 0:a0:ea	ETHERCOM CORP.
+-0:a0:eb	Encore Networks
++0:a0:eb	Encore Networks, Inc.
+ 0:a0:ec	TRANSMITTON LTD.
+ 0:a0:ed	Brooks Automation, Inc.
+ 0:a0:ee	NASHOBA NETWORKS
+ 0:a0:ef	LUCIDATA LTD.
+-0:a0:f	Broadband Technologies
++0:a0:e	VISUAL NETWORKS, INC.
+ 0:a0:f0	TORONTO MICROELECTRONICS INC.
+ 0:a0:f1	MTI
+ 0:a0:f2	INFOTEK COMMUNICATIONS, INC.
+@@ -6884,17 +10229,17 @@
+ 0:a0:f8	SYMBOL TECHNOLOGIES, INC.
+ 0:a0:f9	BINTEC COMMUNICATIONS GMBH
+ 0:a0:fa	Marconi Communication GmbH
++0:a0:f	Broadband Technologies
+ 0:a0:fb	TORAY ENGINEERING CO., LTD.
+ 0:a0:fc	IMAGE SCIENCES, INC.
+ 0:a0:fd	SCITEX DIGITAL PRINTING, INC.
+ 0:a0:fe	BOSTON TECHNOLOGY, INC.
+ 0:a0:ff	TELLABS OPERATIONS, INC.
+ 0:a:0	Mediatek Corp.
+-0:a:1	SOHOware, Inc.
+ 0:a:10	FAST media integrations AG
+ 0:a:11	ExPet Technologies, Inc
+ 0:a:12	Azylex Technology, Inc
+-0:a:13	Silent Witness
++0:a:13	Honeywell Video Systems
+ 0:a:14	TECO a.s.
+ 0:a:15	Silicon Data, Inc
+ 0:a:16	Lassen Research
+@@ -6907,7 +10252,7 @@
+ 0:a:1d	Optical Communications Products Inc.
+ 0:a:1e	Red-M Products Limited
+ 0:a:1f	ART WARE Telecommunication Co., Ltd.
+-0:a:2	ANNSO CO., LTD.
++0:a:1	SOHOware, Inc.
+ 0:a:20	SVA Networks, Inc.
+ 0:a:21	Integra Telecom Co. Ltd
+ 0:a:22	Amperion Inc
+@@ -6918,47 +10263,48 @@
+ 0:a:27	Apple Computer, Inc.
+ 0:a:28	Motorola
+ 0:a:29	Pan Dacom Networking AG
++0:a:2	ANNSO CO., LTD.
+ 0:a:2a	QSI Systems Inc.
+ 0:a:2b	Etherstuff
+ 0:a:2c	Active Tchnology Corporation
+-0:a:2d	PRIVATE
++0:a2:da	INAT GmbH
++0:a:2d	Cabot Communications Limited
+ 0:a:2e	MAPLE NETWORKS CO., LTD
+ 0:a:2f	Artnix Inc.
+-0:a:3	ENDESA SERVICIOS, S.L.
+ 0:a:30	Johnson Controls-ASG
+-0:a:31	HCV Wireless
++0:a:31	HCV Consulting
+ 0:a:32	Xsido Corporation
+-0:a:33	Sierra Logic, Inc.
++0:a:33	Emulex Corporation
+ 0:a:34	Identicard Systems Incorporated
+ 0:a:35	Xilinx
+ 0:a:36	Synelec Telecom Multimedia
+ 0:a:37	Procera Networks, Inc.
+-0:a:38	Netlock Technologies, Inc.
++0:a:38	Apani Networks
+ 0:a:39	LoPA Information Technology
+ 0:a:3a	J-THREE INTERNATIONAL Holding Co., Ltd.
+ 0:a:3b	GCT Semiconductor, Inc
+ 0:a:3c	Enerpoint Ltd.
+ 0:a:3d	Elo Sistemas Eletronicos S.A.
+ 0:a:3e	EADS Telecom
++0:a:3	ENDESA SERVICIOS, S.L.
+ 0:a:3f	Data East Corporation
+-0:a:4	3Com Europe Ltd
+-0:a:40	Crown Audio
++0:a:40	Crown Audio -- Harmanm International
+ 0:a:41	Cisco Systems
+ 0:a:42	Cisco Systems
+ 0:a:43	Chunghwa Telecom Co., Ltd.
++0:a:4	3Com Ltd
+ 0:a:44	Avery Dennison Deutschland GmbH
+ 0:a:45	Audio-Technica Corp.
+-0:a:46	ARO Controls SAS
++0:a:46	ARO WELDING TECHNOLOGIES SAS
+ 0:a:47	Allied Vision Technologies
+ 0:a:48	Albatron Technology
+-0:a:49	Acopia Networks
++0:a:49	F5 Networks, Inc.
+ 0:a:4a	Targa Systems Ltd.
+ 0:a:4b	DataPower Technology, Inc.
+ 0:a:4c	Molecular Devices Corporation
+ 0:a:4d	Noritz Corporation
+ 0:a:4e	UNITEK Electronics INC.
+ 0:a:4f	Brain Boxes Limited
+-0:a:5	Widax Corp.
+ 0:a:50	REMOTEK CORPORATION
+ 0:a:51	GyroSignal Technology Co., Ltd.
+ 0:a:52	AsiaRF Ltd.
+@@ -6975,7 +10321,7 @@
+ 0:a:5d	PUC Founder (MSC) Berhad
+ 0:a:5e	3COM Corporation
+ 0:a:5f	almedio inc.
+-0:a:6	Teledex LLC
++0:a:5	Widax Corp.
+ 0:a:60	Autostar Technology Pte Ltd
+ 0:a:61	Cellinx Systems Inc.
+ 0:a:62	Crinis Networks, Inc.
+@@ -6992,24 +10338,24 @@
+ 0:a:6d	EKS Elektronikservice GmbH
+ 0:a:6e	Broadcast Technology Limited
+ 0:a:6f	ZyFLEX Technologies Inc
+-0:a:7	WebWayOne Ltd
++0:a:6	Teledex LLC
+ 0:a:70	MPLS Forum
+ 0:a:71	Avrio Technologies, Inc
+-0:a:72	SimpleTech, Inc.
++0:a:72	STEC, INC.
+ 0:a:73	Scientific Atlanta
+ 0:a:74	Manticom Networks Inc.
+-0:a:75	Cat Electronics
++0:a:75	Caterpillar, Inc
+ 0:a:76	Beida Jade Bird Huaguang Technology Co.,Ltd
+ 0:a:77	Bluewire Technologies LLC
+ 0:a:78	OLITEC
+-0:a:79	corega K.K.
++0:a:79	Allied Telesis K.K. corega division
+ 0:a:7a	Kyoritsu Electric Co., Ltd.
+ 0:a:7b	Cornelius Consult
+ 0:a:7c	Tecton Ltd
+ 0:a:7d	Valo, Inc.
+ 0:a:7e	The Advantage Group
+ 0:a:7f	Teradon Industries, Inc
+-0:a:8	ALPINE ELECTRONICS, INC.
++0:a:7	WebWayOne Ltd
+ 0:a:80	Telkonet Inc.
+ 0:a:81	TEIMA Audiotex S.L.
+ 0:a:82	TATSUTA SYSTEM ELECTRONICS CO.,LTD.
+@@ -7021,12 +10367,12 @@
+ 0:a:88	InCypher S.A.
+ 0:a:89	Creval Systems, Inc.
+ 0:a:8a	Cisco Systems
++0:a:8	ALPINE ELECTRONICS, INC.
+ 0:a:8b	Cisco Systems
+ 0:a:8c	Guardware Systems Ltd.
+ 0:a:8d	EUROTHERM LIMITED
+ 0:a:8e	Invacom Ltd
+ 0:a:8f	Aska International Inc.
+-0:a:9	TaraCom Integrated Products, Inc.
+ 0:a:90	Bayside Interactive, Inc.
+ 0:a:91	HemoCue AB
+ 0:a:92	Presonus Corporation
+@@ -7036,31 +10382,35 @@
+ 0:a:96	MEWTEL TECHNOLOGY INC.
+ 0:a:97	SONICblue, Inc.
+ 0:a:98	M+F Gwinner GmbH & Co
+-0:a:99	Dataradio Inc.
++0:a:99	Calamp Wireless Networks Inc
+ 0:a:9a	Aiptek International Inc
+ 0:a:9b	Towa Meccs Corporation
+ 0:a:9c	Server Technology, Inc.
+ 0:a:9d	King Young Technology Co. Ltd.
+ 0:a:9e	BroadWeb Corportation
+ 0:a:9f	Pannaway Technologies, Inc.
+-0:a:a	SUNIX Co., Ltd.
++0:a:9	TaraCom Integrated Products, Inc.
+ 0:a:a0	Cedar Point Communications
++0:aa:0	INTEL CORPORATION
++0:aa:1	INTEL CORPORATION
+ 0:a:a1	V V S Limited
++0:aa:2	INTEL CORPORATION
+ 0:a:a2	SYSTEK INC.
++0:aa:3c	OLIVETTI TELECOM SPA (OLTECO)
+ 0:a:a3	SHIMAFUJI ELECTRIC CO.,LTD.
+ 0:a:a4	SHANGHAI SURVEILLANCE TECHNOLOGY CO,LTD
+ 0:a:a5	MAXLINK INDUSTRIES LIMITED
+ 0:a:a6	Hochiki Corporation
+-0:a:a7	FEI Company
++0:a:a7	FEI Electron Optics
+ 0:a:a8	ePipe Pty. Ltd.
+ 0:a:a9	Brooks Automation GmbH
+ 0:a:aa	AltiGen Communications Inc.
+-0:a:ab	TOYOTA MACS, INC.
++0:a:ab	Toyota Technical Development Corporation
+ 0:a:ac	TerraTec Electronic GmbH
+ 0:a:ad	Stargames Corporation
+ 0:a:ae	Rosemount Process Analytical
+ 0:a:af	Pipal Systems
+-0:a:b	Sealevel Systems, Inc.
++0:a:a	SUNIX Co., Ltd.
+ 0:a:b0	LOYTEC electronics GmbH
+ 0:a:b1	GENETEC Corporation
+ 0:a:b2	Fresnel Wireless Systems
+@@ -7077,7 +10427,7 @@
+ 0:a:bd	Rupprecht & Patashnick Co.
+ 0:a:be	OPNET Technologies CO., LTD.
+ 0:a:bf	HIROTA SS
+-0:a:c	Scientific Research Corporation
++0:a:b	Sealevel Systems, Inc.
+ 0:a:c0	Fuyoh Video Industry CO., LTD.
+ 0:a:c1	Futuretel
+ 0:a:c2	FiberHome Telecommunication Technologies CO.,LTD
+@@ -7094,7 +10444,7 @@
+ 0:a:cd	Sunrich Technology Limited
+ 0:a:ce	RADIANTECH, INC.
+ 0:a:cf	PROVIDEO Multimedia Co. Ltd.
+-0:a:d	MergeOptics GmbH
++0:a:c	Scientific Research Corporation
+ 0:a:d0	Niigata Develoment Center,  F.I.T. Co., Ltd.
+ 0:a:d1	MWS
+ 0:a:d2	JEPICO Corporation
+@@ -7105,13 +10455,13 @@
+ 0:a:d7	Origin ELECTRIC CO.,LTD.
+ 0:a:d8	IPCserv Technology Corp.
+ 0:a:d9	Sony Ericsson Mobile Communications AB
+-0:a:da	PRIVATE
++0:a:da	Vindicator Technologies
+ 0:a:db	SkyPilot Network, Inc
+ 0:a:dc	RuggedCom Inc.
+-0:a:dd	InSciTek Microsystems, Inc.
++0:a:dd	Allworx Corp.
+ 0:a:de	Happy Communication Co., Ltd.
++0:a:d	FCI Deutschland GmbH
+ 0:a:df	Gennum Corporation
+-0:a:e	Invivo Research Inc.
+ 0:a:e0	Fujitsu Softek
+ 0:a:e1	EG Technology
+ 0:a:e2	Binatone Electronics International, Ltd
+@@ -7125,17 +10475,17 @@
+ 0:a:ea	ADAM ELEKTRONIK LTD.STI.
+ 0:a:eb	Shenzhen Tp-Link Technology Co; Ltd.
+ 0:a:ec	Koatsu Gas Kogyo Co., Ltd.
+-0:a:ed	HARTING Vending G.m.b.H. & CO KG
++0:a:ed	HARTING Systems GmbH & Co KG
+ 0:a:ee	GCD Hard- & Software GmbH
+ 0:a:ef	OTRUM ASA
+-0:a:f	Ilryung Telesys, Inc
++0:a:e	Invivo Research Inc.
+ 0:a:f0	SHIN-OH ELECTRONICS CO., LTD. R&D
+ 0:a:f1	Clarity Design, Inc.
+ 0:a:f2	NeoAxiom Corp.
+ 0:a:f3	Cisco Systems
+ 0:a:f4	Cisco Systems
+ 0:a:f5	Airgo Networks, Inc.
+-0:a:f6	Computer Process Controls
++0:a:f6	Emerson Climate Technologies Retail Solutions, Inc.
+ 0:a:f7	Broadcom Corp.
+ 0:a:f8	American Telecare Inc.
+ 0:a:f9	HiConnect, Inc.
+@@ -7145,10 +10495,7 @@
+ 0:a:fd	Viking Electronic Services
+ 0:a:fe	NovaPal Ltd
+ 0:a:ff	Kilchherr Elektronik AG
+-0:aa:0	INTEL CORPORATION
+-0:aa:1	INTEL CORPORATION
+-0:aa:2	INTEL CORPORATION
+-0:aa:3c	OLIVETTI TELECOM SPA (OLTECO)
++0:a:f	Ilryung Telesys, Inc
+ 0:b0:17	InfoGear Technology Corp.
+ 0:b0:19	Casi-Rusco
+ 0:b0:1c	Westport Technologies
+@@ -7158,18 +10505,18 @@
+ 0:b0:3b	HiQ Networks
+ 0:b0:48	Marconi Communications Inc.
+ 0:b0:4a	Cisco Systems, Inc.
+-0:b0:52	Intellon Corporation
++0:b0:52	Atheros Communications
+ 0:b0:64	Cisco Systems, Inc.
+ 0:b0:69	Honewell Oy
+ 0:b0:6d	Jones Futurex Inc.
+ 0:b0:80	Mannesmann Ipulsys B.V.
+ 0:b0:86	LocSoft Limited
+ 0:b0:8e	Cisco Systems, Inc.
+-0:b0:9	Grass Valley Group
+ 0:b0:91	Transmeta Corp.
+ 0:b0:94	Alaris, Inc.
+ 0:b0:9a	Morrow Technologies Corp.
+ 0:b0:9d	Point Grey Research Inc.
++0:b0:9	Grass Valley Group
+ 0:b0:ac	SIAE-Microelettronica S.p.A.
+ 0:b0:ae	Symmetricom
+ 0:b0:b3	Xstreamis PLC
+@@ -7178,14 +10525,13 @@
+ 0:b0:ce	TECHNOLOGY RESCUE
+ 0:b0:d0	Dell Computer Corp.
+ 0:b0:db	Nextcell, Inc.
+-0:b0:df	Reliable Data Technology, Inc.
++0:b0:df	RELDATA Inc
+ 0:b0:e7	British Federal Ltd.
+ 0:b0:ec	EACEM
+ 0:b0:ee	Ajile Systems, Inc.
+ 0:b0:f0	CALY NETWORKS
+ 0:b0:f5	NetWorth Technologies, Inc.
+ 0:b:0	FUJIAN START COMPUTER EQUIPMENT CO.,LTD
+-0:b:1	DAIICHI ELECTRONICS CO., LTD.
+ 0:b:10	11wave Technonlogy Co.,Ltd
+ 0:b:11	HIMEJI ABC TRADING CO.,LTD.
+ 0:b:12	NURI Telecom Co., Ltd.
+@@ -7196,13 +10542,13 @@
+ 0:b:17	MKS Instruments
+ 0:b:18	PRIVATE
+ 0:b:19	Vernier Networks, Inc.
+-0:b:1a	Teltone Corporation
++0:b:1a	Industrial Defender, Inc.
+ 0:b:1b	Systronix, Inc.
+ 0:b:1c	SIBCO bv
++0:b:1	DAIICHI ELECTRONICS CO., LTD.
+ 0:b:1d	LayerZero Power Systems, Inc.
+ 0:b:1e	KAPPA opto-electronics GmbH
+ 0:b:1f	I CON Computer Co.
+-0:b:2	Dallmeier electronic
+ 0:b:20	Hirata corporation
+ 0:b:21	G-Star Communications Inc.
+ 0:b:22	Environmental Systems and Services
+@@ -7212,14 +10558,14 @@
+ 0:b:26	Wetek Corporation
+ 0:b:27	Scion Corporation
+ 0:b:28	Quatech Inc.
+-0:b:29	LG Industrial Systems Co.,Ltd.
++0:b:29	LS(LG) Industrial Systems co.,Ltd
+ 0:b:2a	HOWTEL Co., Ltd.
+ 0:b:2b	HOSTNET CORPORATION
+ 0:b:2c	Eiki Industrial Co. Ltd.
++0:b:2	Dallmeier electronic
+ 0:b:2d	Danfoss Inc.
+ 0:b:2e	Cal-Comp Electronics (Thailand) Public Company Limited Taipe
+ 0:b:2f	bplan GmbH
+-0:b:3	Taekwang Industrial Co., Ltd
+ 0:b:30	Beijing Gongye Science & Technology Co.,Ltd
+ 0:b:31	Yantai ZhiYang Scientific and technology industry CO., LTD
+ 0:b:32	VORMETRIC, INC.
+@@ -7230,13 +10576,13 @@
+ 0:b:37	MANUFACTURE DES MONTRES ROLEX SA
+ 0:b:38	Knuerr AG
+ 0:b:39	Keisoku Giken Co.,Ltd.
+-0:b:3a	Fortel DTV, Inc.
++0:b:3a	QuStream Corporation
+ 0:b:3b	devolo AG
+ 0:b:3c	Cygnal Integrated Products, Inc.
+ 0:b:3d	CONTAL OK Ltd.
+ 0:b:3e	BittWare, Inc
+ 0:b:3f	Anthology Solutions Inc.
+-0:b:4	Volktek Corporation
++0:b:3	Taekwang Industrial Co., Ltd
+ 0:b:40	OpNext Inc.
+ 0:b:41	Ing. Buero Dr. Beutlhauser
+ 0:b:42	commax Co., Ltd.
+@@ -7251,9 +10597,9 @@
+ 0:b:4b	VISIOWAVE SA
+ 0:b:4c	Clarion (M) Sdn Bhd
+ 0:b:4d	Emuzed
+-0:b:4e	VertexRSI Antenna Products Division
++0:b:4e	VertexRSI, General Dynamics SatCOM Technologies, Inc.
+ 0:b:4f	Verifone, INC.
+-0:b:5	Pacific Broadband Networks
++0:b:4	Volktek Corporation
+ 0:b:50	Oxygnet
+ 0:b:51	Micetek International Inc.
+ 0:b:52	JOYMAX ELECTRONICS CORP.
+@@ -7267,13 +10613,14 @@
+ 0:b:5a	HyperEdge
+ 0:b:5b	Rincon Research Corporation
+ 0:b:5c	Newtech Co.,Ltd
++0:b5:d6	Omnibit Inc.
+ 0:b:5d	FUJITSU LIMITED
+ 0:b:5e	Audio Engineering Society Inc.
+ 0:b:5f	Cisco Systems
+-0:b:6	Motorola BCS
++0:b:5	Pacific Broadband Networks
+ 0:b:60	Cisco Systems
+-0:b:61	Friedrich Lütze GmbH &Co.
+-0:b:62	Ingenieurbüro Ingo Mohnen
++0:b:61	Friedrich L
++0:b:62	Ingenieurbuero fuer Elektronikdesign Ingo Mohnen
+ 0:b:63	Kaleidescape
+ 0:b:64	Kieback & Peter GmbH & Co KG
+ 0:b:65	Sy.A.C. srl
+@@ -7287,14 +10634,14 @@
+ 0:b:6d	SOLECTRON JAPAN NAKANIIDA
+ 0:b:6e	Neff Instrument Corp.
+ 0:b:6f	Media Streaming Networks Inc
+-0:b:7	Voxpath Networks
++0:b:6	Motorola BCS
+ 0:b:70	Load Technology, Inc.
+ 0:b:71	Litchfield Communications Inc.
+ 0:b:72	Lawo AG
+ 0:b:73	Kodeos Communications
+ 0:b:74	Kingwave Technology Co., Ltd.
+ 0:b:75	Iosoft Ltd.
+-0:b:76	ET&T Co. Ltd.
++0:b:76	ET&T Technology Co. Ltd.
+ 0:b:77	Cogent Systems, Inc.
+ 0:b:78	TAIFATECH INC.
+ 0:b:79	X-COM, Inc.
+@@ -7304,28 +10651,28 @@
+ 0:b:7d	SOLOMON EXTREME INTERNATIONAL LTD.
+ 0:b:7e	SAGINOMIYA Seisakusho Inc.
+ 0:b:7f	OmniWerks
+-0:b:8	Pillar Data Systems
++0:b:7	Voxpath Networks
+ 0:b:80	Lycium Networks
+ 0:b:81	Kaparel Corporation
+ 0:b:82	Grandstream Networks, Inc.
+ 0:b:83	DATAWATT B.V.
+ 0:b:84	BODET
+-0:b:85	Airespace, Inc.
++0:b:85	Cisco Systems
+ 0:b:86	Aruba Networks
+ 0:b:87	American Reliance Inc.
+ 0:b:88	Vidisco ltd.
+ 0:b:89	Top Global Technology, Ltd.
+ 0:b:8a	MITEQ Inc.
+ 0:b:8b	KERAJET, S.A.
+-0:b:8c	flextronics israel
++0:b:8c	Flextronics
+ 0:b:8d	Avvio Networks
+ 0:b:8e	Ascent Corporation
+ 0:b:8f	AKITA ELECTRONICS SYSTEMS CO.,LTD.
+-0:b:9	Ifoundry Systems Singapore
+-0:b:90	Covaro Networks, Inc.
+-0:b:91	Aglaia Gesellschaft für Bildverarbeitung und Kommunikation m
++0:b:8	Pillar Data Systems
++0:b:90	Adva Optical Networking Inc.
++0:b:91	Aglaia Gesellschaft f
+ 0:b:92	Ascom Danmark A/S
+-0:b:93	Barmag Electronic
++0:b:93	Ritter Elektronik
+ 0:b:94	Digital Monitoring Products, Inc.
+ 0:b:95	eBet Gaming Systems Pty Ltd
+ 0:b:96	Innotrac Diagnostics Oy
+@@ -7338,7 +10685,7 @@
+ 0:b:9d	TwinMOS Technologies Inc.
+ 0:b:9e	Yasing Technology Corp.
+ 0:b:9f	Neue ELSA GmbH
+-0:b:a	dBm Optics
++0:b:9	Ifoundry Systems Singapore
+ 0:b:a0	T&L Information Inc.
+ 0:b:a1	SYSCOM Ltd.
+ 0:b:a2	Sumitomo Electric Networks, Inc
+@@ -7351,12 +10698,14 @@
+ 0:b:a9	CloudShield Technologies, Inc.
+ 0:b:aa	Aiphone co.,Ltd
+ 0:b:ab	Advantech Technology (CHINA) Co., Ltd.
+-0:b:ac	3Com Europe Ltd.
++0:ba:c0	Biometric Access Company
++0:b:ac	3Com Ltd
++0:b:a	dBm Optics
+ 0:b:ad	PC-PoS Inc.
+ 0:b:ae	Vitals System Inc.
+ 0:b:af	WOOJU COMMUNICATIONS Co,.Ltd
+-0:b:b	Corrent Corporation
+ 0:b:b0	Sysnet Telematica srl
++0:bb:1	OCTOTHORPE CORP.
+ 0:b:b1	Super Star Technology Co., Ltd.
+ 0:b:b2	SMALLBIG TECHNOLOGY
+ 0:b:b3	RiT technologies Ltd.
+@@ -7369,10 +10718,11 @@
+ 0:b:ba	Harmonic Broadband Access Networks
+ 0:b:bb	Etin Systems Co., Ltd
+ 0:b:bc	En Garde Systems, Inc.
++0:b:b	Corrent Corporation
+ 0:b:bd	Connexionz Limited
+ 0:b:be	Cisco Systems
++0:bb:f0	UNGERMANN-BASS INC.
+ 0:b:bf	Cisco Systems
+-0:b:c	Agile Systems Inc.
+ 0:b:c0	China IWNComm Co., Ltd.
+ 0:b:c1	Bay Microsystems, Inc.
+ 0:b:c2	Corinex Communication Corp.
+@@ -7384,29 +10734,31 @@
+ 0:b:c8	AirFlow Networks
+ 0:b:c9	Electroline Equipment
+ 0:b:ca	DATAVAN International Corporation
++0:b:c	Agile Systems Inc.
+ 0:b:cb	Fagor Automation , S. Coop
+ 0:b:cc	JUSAN, S.A.
+-0:b:cd	Compaq (HP)
++0:b:cd	Hewlett Packard
+ 0:b:ce	Free2move AB
+ 0:b:cf	AGFA NDT INC.
+-0:b:d	Air2U, Inc.
+ 0:b:d0	XiMeta Technology Americas Inc.
+ 0:b:d1	Aeronix, Inc.
++0:bd:27	Exar Corp.
+ 0:b:d2	Remopro Technology Inc.
++0:bd:3a	Nokia Corporation
+ 0:b:d3	cd3o
+ 0:b:d4	Beijing Wise Technology & Science Development Co.Ltd
+ 0:b:d5	Nvergence, Inc.
+ 0:b:d6	Paxton Access Ltd
+-0:b:d7	MBB Gelma GmbH
++0:b:d7	DORMA Time + Access GmbH
+ 0:b:d8	Industrial Scientific Corp.
+ 0:b:d9	General Hydrogen
+ 0:b:da	EyeCross Co.,Inc.
++0:b:d	Air2U, Inc.
+ 0:b:db	Dell ESG PCBA Test
+ 0:b:dc	AKCP
+ 0:b:dd	TOHOKU RICOH Co., LTD.
+ 0:b:de	TELDIX GmbH
+ 0:b:df	Shenzhen RouterD Networks Limited
+-0:b:e	Trapeze Networks
+ 0:b:e0	SercoNet Ltd.
+ 0:b:e1	Nokia NET Product Operations
+ 0:b:e2	Lumenera Corporation
+@@ -7423,7 +10775,7 @@
+ 0:b:ed	ELM Inc.
+ 0:b:ee	inc.jet, Incorporated
+ 0:b:ef	Code Corporation
+-0:b:f	Nyquist Industrial Control BV
++0:b:e	Trapeze Networks
+ 0:b:f0	MoTEX Products Co., Ltd.
+ 0:b:f1	LAP Laser Applikations
+ 0:b:f2	Chih-Kan Technology Co., Ltd.
+@@ -7440,11 +10792,8 @@
+ 0:b:fd	Cisco Systems
+ 0:b:fe	CASTEL Broadband Limited
+ 0:b:ff	Berkeley Camera Engineering
+-0:ba:c0	Biometric Access Company
+-0:bb:1	OCTOTHORPE CORP.
+-0:bb:f0	UNGERMANN-BASS INC.
++0:b:f	Nyquist Industrial Control BV
+ 0:c0:0	LANOPTICS, LTD.
+-0:c0:1	DIATEK PATIENT MANAGMENT
+ 0:c0:10	HIRAKAWA HEWTECH CORP.
+ 0:c0:11	INTERACTIVE COMPUTING DEVICES
+ 0:c0:12	NETSPAN CORPORATION
+@@ -7452,16 +10801,16 @@
+ 0:c0:14	TELEMATICS CALABASAS INT'L,INC
+ 0:c0:15	NEW MEDIA CORPORATION
+ 0:c0:16	ELECTRONIC THEATRE CONTROLS
+-0:c0:17	FORTE NETWORKS
++0:c0:17	Fluke Corporation
+ 0:c0:18	LANART CORPORATION
+ 0:c0:19	LEAP TECHNOLOGY, INC.
+ 0:c0:1a	COROMETRICS MEDICAL SYSTEMS
+ 0:c0:1b	SOCKET COMMUNICATIONS, INC.
+ 0:c0:1c	INTERLINK COMMUNICATIONS LTD.
+ 0:c0:1d	GRAND JUNCTION NETWORKS, INC.
++0:c0:1	DIATEK PATIENT MANAGMENT
+ 0:c0:1e	LA FRANCAISE DES JEUX
+ 0:c0:1f	S.E.R.C.E.L.
+-0:c0:2	SERCOMM CORPORATION
+ 0:c0:20	ARCO ELECTRONIC, CONTROL LTD.
+ 0:c0:21	NETEXPRESS
+ 0:c0:22	LASERMASTER TECHNOLOGIES, INC.
+@@ -7471,14 +10820,14 @@
+ 0:c0:26	LANS TECHNOLOGY CO., LTD.
+ 0:c0:27	CIPHER SYSTEMS, INC.
+ 0:c0:28	JASCO CORPORATION
+-0:c0:29	Nexans Deutschland AG - ANS
++0:c0:29	Nexans Deutschland GmbH - ANS
+ 0:c0:2a	OHKURA ELECTRIC CO., LTD.
+ 0:c0:2b	GERLOFF GESELLSCHAFT FUR
+ 0:c0:2c	CENTRUM COMMUNICATIONS, INC.
+ 0:c0:2d	FUJI PHOTO FILM CO., LTD.
+ 0:c0:2e	NETWIZ
+ 0:c0:2f	OKUMA CORPORATION
+-0:c0:3	GLOBALNET COMMUNICATIONS
++0:c0:2	SERCOMM CORPORATION
+ 0:c0:30	INTEGRATED ENGINEERING B. V.
+ 0:c0:31	DESIGN RESEARCH SYSTEMS, INC.
+ 0:c0:32	I-CUBED LIMITED
+@@ -7495,14 +10844,14 @@
+ 0:c0:3d	WIESEMANN & THEIS GMBH
+ 0:c0:3e	FA. GEBR. HELLER GMBH
+ 0:c0:3f	STORES AUTOMATED SYSTEMS, INC.
+-0:c0:4	JAPAN BUSINESS COMPUTER CO.LTD
++0:c0:3	GLOBALNET COMMUNICATIONS
+ 0:c0:40	ECCI
+ 0:c0:41	DIGITAL TRANSMISSION SYSTEMS
+ 0:c0:42	DATALUX CORP.
+ 0:c0:43	STRATACOM
+ 0:c0:44	EMCOM CORPORATION
+ 0:c0:45	ISOLATION SYSTEMS, LTD.
+-0:c0:46	KEMITRON LTD.
++0:c0:46	Blue Chip Technology Ltd
+ 0:c0:47	UNIMICRO SYSTEMS, INC.
+ 0:c0:48	BAY TECHNICAL ASSOCIATES
+ 0:c0:49	U.S. ROBOTICS, INC.
+@@ -7512,24 +10861,24 @@
+ 0:c0:4d	MITEC, INC.
+ 0:c0:4e	COMTROL CORPORATION
+ 0:c0:4f	DELL COMPUTER CORPORATION
+-0:c0:5	LIVINGSTON ENTERPRISES, INC.
++0:c0:4	JAPAN BUSINESS COMPUTER CO.LTD
+ 0:c0:50	TOYO DENKI SEIZO K.K.
+ 0:c0:51	ADVANCED INTEGRATION RESEARCH
+ 0:c0:52	BURR-BROWN
+-0:c0:53	Concerto Software
++0:c0:53	Aspect Software Inc.
+ 0:c0:54	NETWORK PERIPHERALS, LTD.
+ 0:c0:55	MODULAR COMPUTING TECHNOLOGIES
+ 0:c0:56	SOMELEC
+ 0:c0:57	MYCO ELECTRONICS
+ 0:c0:58	DATAEXPERT CORP.
+-0:c0:59	NIPPON DENSO CO., LTD.
++0:c0:59	DENSO CORPORATION
+ 0:c0:5a	SEMAPHORE COMMUNICATIONS CORP.
+ 0:c0:5b	NETWORKS NORTHWEST, INC.
+ 0:c0:5c	ELONEX PLC
+ 0:c0:5d	L&N TECHNOLOGIES
+ 0:c0:5e	VARI-LITE, INC.
+ 0:c0:5f	FINE-PAL COMPANY LIMITED
+-0:c0:6	NIPPON AVIONICS CO., LTD.
++0:c0:5	LIVINGSTON ENTERPRISES, INC.
+ 0:c0:60	ID SCANDINAVIA AS
+ 0:c0:61	SOLECTEK CORPORATION
+ 0:c0:62	IMPULSE TECHNOLOGY
+@@ -7546,7 +10895,7 @@
+ 0:c0:6d	BOCA RESEARCH, INC.
+ 0:c0:6e	HAFT TECHNOLOGY, INC.
+ 0:c0:6f	KOMATSU LTD.
+-0:c0:7	PINNACLE DATA SYSTEMS, INC.
++0:c0:6	NIPPON AVIONICS CO., LTD.
+ 0:c0:70	SECTRA SECURE-TRANSMISSION AB
+ 0:c0:71	AREANEX COMMUNICATIONS, INC.
+ 0:c0:72	KNX LTD.
+@@ -7563,7 +10912,7 @@
+ 0:c0:7d	RISC DEVELOPMENTS LTD.
+ 0:c0:7e	KUBOTA CORPORATION ELECTRONIC
+ 0:c0:7f	NUPON COMPUTING CORP.
+-0:c0:8	SECO SRL
++0:c0:7	PINNACLE DATA SYSTEMS, INC.
+ 0:c0:80	NETSTAR, INC.
+ 0:c0:81	METRODATA LTD.
+ 0:c0:82	MOORE PRODUCTS CO.
+@@ -7574,13 +10923,13 @@
+ 0:c0:87	UUNET TECHNOLOGIES, INC.
+ 0:c0:88	EKF ELEKTRONIK GMBH
+ 0:c0:89	TELINDUS DISTRIBUTION
+-0:c0:8a	LAUTERBACH DATENTECHNIK GMBH
++0:c0:8a	Lauterbach GmbH
+ 0:c0:8b	RISQ MODULAR SYSTEMS, INC.
+ 0:c0:8c	PERFORMANCE TECHNOLOGIES, INC.
+ 0:c0:8d	TRONIX PRODUCT DEVELOPMENT
+ 0:c0:8e	NETWORK INFORMATION TECHNOLOGY
+-0:c0:8f	MATSUSHITA ELECTRIC WORKS, LTD
+-0:c0:9	KT TECHNOLOGY (S) PTE LTD
++0:c0:8f	Panasonic Electric Works Co., Ltd.
++0:c0:8	SECO SRL
+ 0:c0:90	PRAIM S.R.L.
+ 0:c0:91	JABIL CIRCUIT, INC.
+ 0:c0:92	MENNEN MEDICAL INC.
+@@ -7593,11 +10942,11 @@
+ 0:c0:99	YOSHIKI INDUSTRIAL CO.,LTD.
+ 0:c0:9a	PHOTONICS CORPORATION
+ 0:c0:9b	RELIANCE COMM/TEC, R-TEC
+-0:c0:9c	TOA ELECTRONIC LTD.
++0:c0:9c	HIOKI E.E. CORPORATION
+ 0:c0:9d	DISTRIBUTED SYSTEMS INT'L, INC
+ 0:c0:9e	CACHE COMPUTERS, INC.
+ 0:c0:9f	QUANTA COMPUTER, INC.
+-0:c0:a	MICRO CRAFT
++0:c0:9	KT TECHNOLOGY (S) PTE LTD
+ 0:c0:a0	ADVANCE MICRO RESEARCH, INC.
+ 0:c0:a1	TOKYO DENSHI SEKEI CO.
+ 0:c0:a2	INTERMEDIUM A/S
+@@ -7614,14 +10963,14 @@
+ 0:c0:ad	MARBEN COMMUNICATION SYSTEMS
+ 0:c0:ae	TOWERCOM CO. INC. DBA PC HOUSE
+ 0:c0:af	TEKLOGIX INC.
+-0:c0:b	NORCONTROL A.S.
++0:c0:a	MICRO CRAFT
+ 0:c0:b0	GCC TECHNOLOGIES,INC.
+ 0:c0:b1	GENIUS NET CO.
+ 0:c0:b2	NORAND CORPORATION
+ 0:c0:b3	COMSTAT DATACOMM CORPORATION
+ 0:c0:b4	MYSON TECHNOLOGY, INC.
+ 0:c0:b5	CORPORATE NETWORK SYSTEMS,INC.
+-0:c0:b6	Snap Appliance, Inc.
++0:c0:b6	Overland Storage, Inc.
+ 0:c0:b7	AMERICAN POWER CONVERSION CORP
+ 0:c0:b8	FRASER'S HILL LTD.
+ 0:c0:b9	FUNK SOFTWARE, INC.
+@@ -7630,8 +10979,9 @@
+ 0:c0:bc	TELECOM AUSTRALIA/CSSC
+ 0:c0:bd	INEX TECHNOLOGIES, INC.
+ 0:c0:be	ALCATEL - SEL
++0:c:0	BEB Industrie-Elektronik AG
+ 0:c0:bf	TECHNOLOGY CONCEPTS, LTD.
+-0:c0:c	RELIA TECHNOLGIES
++0:c0:b	NORCONTROL A.S.
+ 0:c0:c0	SHORE MICROSYSTEMS, INC.
+ 0:c0:c1	QUAD/GRAPHICS, INC.
+ 0:c0:c2	INFINITE NETWORKS LTD.
+@@ -7648,24 +10998,24 @@
+ 0:c0:cd	COMELTA, S.A.
+ 0:c0:ce	CEI SYSTEMS & ENGINEERING PTE
+ 0:c0:cf	IMATRAN VOIMA OY
+-0:c0:d	ADVANCED LOGIC RESEARCH, INC.
++0:c0:c	RELIA TECHNOLGIES
+ 0:c0:d0	RATOC SYSTEM INC.
+ 0:c0:d1	COMTREE TECHNOLOGY CORPORATION
+ 0:c0:d2	SYNTELLECT, INC.
+ 0:c0:d3	OLYMPUS IMAGE SYSTEMS, INC.
+ 0:c0:d4	AXON NETWORKS, INC.
+-0:c0:d5	QUANCOM ELECTRONIC GMBH
++0:c0:d5	Werbeagentur J
+ 0:c0:d6	J1 SYSTEMS, INC.
+ 0:c0:d7	TAIWAN TRADING CENTER DBA
+ 0:c0:d8	UNIVERSAL DATA SYSTEMS
+ 0:c0:d9	QUINTE NETWORK CONFIDENTIALITY
++0:c0:d	ADVANCED LOGIC RESEARCH, INC.
+ 0:c0:da	NICE SYSTEMS LTD.
+ 0:c0:db	IPC CORPORATION (PTE) LTD.
+ 0:c0:dc	EOS TECHNOLOGIES, INC.
+ 0:c0:dd	QLogic Corporation
+ 0:c0:de	ZCOMM, INC.
+ 0:c0:df	KYE Systems Corp.
+-0:c0:e	PSITECH, INC.
+ 0:c0:e0	DSC COMMUNICATION CORP.
+ 0:c0:e1	SONIC SOLUTIONS
+ 0:c0:e2	CALCOMP, INC.
+@@ -7682,7 +11032,7 @@
+ 0:c0:ed	US ARMY ELECTRONIC
+ 0:c0:ee	KYOCERA CORPORATION
+ 0:c0:ef	ABIT CORPORATION
+-0:c0:f	QUANTUM SOFTWARE SYSTEMS LTD.
++0:c0:e	PSITECH, INC.
+ 0:c0:f0	KINGSTON TECHNOLOGY CORP.
+ 0:c0:f1	SHINKO ELECTRIC CO., LTD.
+ 0:c0:f2	TRANSITION NETWORKS
+@@ -7692,15 +11042,14 @@
+ 0:c0:f6	CELAN TECHNOLOGY INC.
+ 0:c0:f7	ENGAGE COMMUNICATION, INC.
+ 0:c0:f8	ABOUT COMPUTING INC.
+-0:c0:f9	Motorola Embedded Computing Group
++0:c0:f9	Emerson Network Power
+ 0:c0:fa	CANARY COMMUNICATIONS, INC.
+ 0:c0:fb	ADVANCED TECHNOLOGY LABS
+ 0:c0:fc	ELASTIC REALITY, INC.
+ 0:c0:fd	PROSUM
+ 0:c0:fe	APTEC COMPUTER SYSTEMS, INC.
+ 0:c0:ff	DOT HILL SYSTEMS CORPORATION
+-0:c:0	BEB Industrie-Elektronik AG
+-0:c:1	Abatron AG
++0:c0:f	QUANTUM SOFTWARE SYSTEMS LTD.
+ 0:c:10	PNI Corporation
+ 0:c:11	NIPPON DEMPA CO.,LTD.
+ 0:c:12	Micro-Optronic-Messtechnik GmbH
+@@ -7711,13 +11060,13 @@
+ 0:c:17	AJA Video Systems Inc
+ 0:c:18	Zenisu Keisoku Inc.
+ 0:c:19	Telio Communications GmbH
++0:c:1	Abatron AG
+ 0:c:1a	Quest Technical Solutions Inc.
+ 0:c:1b	ORACOM Co, Ltd.
+ 0:c:1c	MicroWeb Co., Ltd.
+ 0:c:1d	Mettler & Fuchs AG
+ 0:c:1e	Global Cache
+ 0:c:1f	Glimmerglass Networks
+-0:c:2	ABB Oy
+ 0:c:20	Fi WIn, Inc.
+ 0:c:21	Faculty of Science and Technology, Keio University
+ 0:c:22	Double D Electronics Ltd
+@@ -7728,13 +11077,13 @@
+ 0:c:27	Sammy Corporation
+ 0:c:28	RIFATRON
+ 0:c:29	VMware, Inc.
++0:c:2	ABB Oy
+ 0:c:2a	OCTTEL Communication Co., Ltd.
+ 0:c:2b	ELIAS Technology, Inc.
+ 0:c:2c	Enwiser Inc.
+ 0:c:2d	FullWave Technology Co., Ltd.
+ 0:c:2e	Openet information technology(shenzhen) Co., Ltd.
+ 0:c:2f	SeorimTechnology Co.,Ltd.
+-0:c:3	HDMI Licensing, LLC
+ 0:c:30	Cisco
+ 0:c:31	Cisco
+ 0:c:32	Avionic Design Development GmbH
+@@ -7751,9 +11100,9 @@
+ 0:c:3d	Glsystech Co., Ltd.
+ 0:c:3e	Crest Audio
+ 0:c:3f	Cogent Defence & Security Networks,
+-0:c:4	Tecnova
++0:c:3	HDMI Licensing, LLC
+ 0:c:40	Altech Controls
+-0:c:41	The Linksys Group, Inc.
++0:c:41	Cisco-Linksys
+ 0:c:42	Routerboard.com
+ 0:c:43	Ralink Technology, Corp.
+ 0:c:44	Automated Interfaces, Inc.
+@@ -7762,13 +11111,13 @@
+ 0:c:47	SK Teletech(R&D Planning Team)
+ 0:c:48	QoStek Corporation
+ 0:c:49	Dangaard Telecom RTC Division A/S
+-0:c:4a	Cygnus Microsystems Private Limited
++0:c:4a	Cygnus Microsystems (P) Limited
+ 0:c:4b	Cheops Elektronik
+ 0:c:4c	Arcor AG&Co.
+ 0:c:4d	ACRA CONTROL
+ 0:c:4e	Winbest Technology CO,LT
+ 0:c:4f	UDTech Japan Corporation
+-0:c:5	RPA Reserch Co., Ltd.
++0:c:4	Tecnova
+ 0:c:50	Seagate Technology
+ 0:c:51	Scientific Technologies Inc.
+ 0:c:52	Roll Systems Inc.
+@@ -7785,7 +11134,7 @@
+ 0:c:5d	CHIC TECHNOLOGY (CHINA) CORP.
+ 0:c:5e	Calypso Medical
+ 0:c:5f	Avtec, Inc.
+-0:c:6	Nixvue Systems  Pte Ltd
++0:c:5	RPA Reserch Co., Ltd.
+ 0:c:60	ACM Systems
+ 0:c:61	AC Tech corporation DBA Advanced Digital
+ 0:c:62	ABB Automation Technology Products AB, Control
+@@ -7794,15 +11143,15 @@
+ 0:c:65	Sunin Telecom
+ 0:c:66	Pronto Networks Inc
+ 0:c:67	OYO ELECTRIC CO.,LTD
+-0:c:68	Oasis Semiconductor, Inc.
++0:c:68	SigmaTel, Inc.
+ 0:c:69	National Radio Astronomy Observatory
+ 0:c:6a	MBARI
+ 0:c:6b	Kurz Industrie-Elektronik GmbH
+ 0:c:6c	Elgato Systems LLC
+-0:c:6d	BOC Edwards
++0:c:6d	Edwards Ltd.
+ 0:c:6e	ASUSTEK COMPUTER INC.
+ 0:c:6f	Amtek system co.,LTD.
+-0:c:7	Iftest AG
++0:c:6	Nixvue Systems  Pte Ltd
+ 0:c:70	ACC GmbH
+ 0:c:71	Wybron, Inc
+ 0:c:72	Tempearl Industrial Co., Ltd.
+@@ -7819,7 +11168,7 @@
+ 0:c:7d	TEIKOKU ELECTRIC MFG. CO., LTD
+ 0:c:7e	Tellium Incorporated
+ 0:c:7f	synertronixx GmbH
+-0:c:8	HUMEX Technologies Corp.
++0:c:7	Iftest AG
+ 0:c:80	Opelcomm Inc.
+ 0:c:81	Nulec Industries Pty Ltd
+ 0:c:82	NETWORK TECHNOLOGIES INC
+@@ -7827,7 +11176,7 @@
+ 0:c:84	Eazix, Inc.
+ 0:c:85	Cisco Systems
+ 0:c:86	Cisco Systems
+-0:c:87	ATI
++0:c:87	AMD
+ 0:c:88	Apache Micro Peripherals, Inc.
+ 0:c:89	AC Electric Vehicles, Ltd.
+ 0:c:8a	Bose Corporation
+@@ -7836,12 +11185,12 @@
+ 0:c:8d	MATRIX VISION GmbH
+ 0:c:8e	Mentor Engineering Inc
+ 0:c:8f	Nergal s.r.l.
+-0:c:9	Hitachi IE Systems Co., Ltd
++0:c:8	HUMEX Technologies Corp.
+ 0:c:90	Octasic Inc.
+ 0:c:91	Riverhead Networks Inc.
+ 0:c:92	WolfVision Gmbh
+ 0:c:93	Xeline Co., Ltd.
+-0:c:94	United Electronic Industries, Inc.
++0:c:94	United Electronic Industries, Inc. (EUI)
+ 0:c:95	PrimeNet
+ 0:c:96	OQO, Inc.
+ 0:c:97	NV ADB TTV Technologies SA
+@@ -7853,7 +11202,7 @@
+ 0:c:9d	AirWalk Communications, Inc.
+ 0:c:9e	MemoryLink Corp.
+ 0:c:9f	NKE Corporation
+-0:c:a	Guangdong Province Electronic Technology Research Institute
++0:c:9	Hitachi IE Systems Co., Ltd
+ 0:c:a0	StorCase Technology, Inc.
+ 0:c:a1	SIGMACOM Co., LTD.
+ 0:c:a2	Scopus Network Technologies Ltd
+@@ -7870,10 +11219,10 @@
+ 0:c:ad	BTU International
+ 0:c:ae	Ailocom Oy
+ 0:c:af	TRI TERM CO.,LTD.
+-0:c:b	Broadbus Technologies
++0:c:a	Guangdong Province Electronic Technology Research Institute
+ 0:c:b0	Star Semiconductor Corporation
+ 0:c:b1	Salland Engineering (Europe) BV
+-0:c:b2	safei Co., Ltd.
++0:c:b2	Comstar Co., Ltd.
+ 0:c:b3	ROUND Co.,Ltd.
+ 0:c:b4	AutoCell Laboratories, Inc.
+ 0:c:b5	Premier Technolgies, Inc
+@@ -7881,16 +11230,17 @@
+ 0:c:b7	Nanjing Huazhuo Electronics Co., Ltd.
+ 0:c:b8	MEDION AG
+ 0:c:b9	LEA
+-0:c:ba	Jamex
++0:c:ba	Jamex, Inc.
++0:cb:bd	Cambridge Broadband Networks Ltd.
+ 0:c:bb	ISKRAEMECO
++0:c:b	Broadbus Technologies
+ 0:c:bc	Iscutum
+ 0:c:bd	Interface Masters, Inc
+-0:c:be	PRIVATE
++0:c:be	Innominate Security Technologies AG
+ 0:c:bf	Holy Stone Ent. Co., Ltd.
+-0:c:c	APPRO TECHNOLOGY INC.
+ 0:c:c0	Genera Oy
+ 0:c:c1	Cooper Industries Inc.
+-0:c:c2	PRIVATE
++0:c:c2	ControlNet (India) Private Limited
+ 0:c:c3	BeWAN systems
+ 0:c:c4	Tiptel AG
+ 0:c:c5	Nextlink Co., Ltd.
+@@ -7899,12 +11249,12 @@
+ 0:c:c8	Xytronix Research & Design, Inc.
+ 0:c:c9	ILWOO DATA & TECHNOLOGY CO.,LTD
+ 0:c:ca	Hitachi Global Storage Technologies
++0:c:c	APPRO TECHNOLOGY INC.
+ 0:c:cb	Design Combus Ltd
+ 0:c:cc	Aeroscout Ltd.
+ 0:c:cd	IEC - TC57
+ 0:c:ce	Cisco Systems
+ 0:c:cf	Cisco Systems
+-0:c:d	Communications & Power Industries / Satcom Division
+ 0:c:d0	Symetrix
+ 0:c:d1	SFOM Technology Corp.
+ 0:c:d2	Schaffner EMV AG
+@@ -7916,12 +11266,12 @@
+ 0:c:d8	M. K. Juchheim GmbH & Co
+ 0:c:d9	Itcare Co., Ltd
+ 0:c:da	FreeHand Systems, Inc.
+-0:c:db	Foundry Networks
++0:c:db	Brocade Communications Systems, Inc
+ 0:c:dc	BECS Technology, Inc
++0:c:d	Communications & Power Industries / Satcom Division
+ 0:c:dd	AOS Technologies AG
+ 0:c:de	ABB STOTZ-KONTAKT GmbH
+ 0:c:df	PULNiX America, Inc
+-0:c:e	XtremeSpectrum, Inc.
+ 0:c:e0	Trek Diagnostics Inc.
+ 0:c:e1	The Open Group
+ 0:c:e2	Rolls-Royce
+@@ -7938,10 +11288,11 @@
+ 0:c:ed	Real Digital Media
+ 0:c:ee	jp-embedded
+ 0:c:ef	Open Networks Engineering Ltd
+-0:c:f	Techno-One Co., Ltd
++0:c:e	XtremeSpectrum, Inc.
+ 0:c:f0	M & N GmbH
++0:cf:1c	COMMUNICATION MACHINERY CORP.
+ 0:c:f1	Intel Corporation
+-0:c:f2	GAMESA EÓLICA
++0:c:f2	GAMESA E
+ 0:c:f3	CALL IMAGE SA
+ 0:c:f4	AKATSUKI ELECTRIC MFG.CO.,LTD.
+ 0:c:f5	InfoExpress
+@@ -7952,13 +11303,11 @@
+ 0:c:fa	Digital Systems Corp
+ 0:c:fb	Korea Network Systems
+ 0:c:fc	S2io Technologies Corp
+-0:c:fd	PRIVATE
++0:c:fd	Hyundai ImageQuest Co.,Ltd.
+ 0:c:fe	Grand Electronic Co., Ltd
+ 0:c:ff	MRO-TEK LIMITED
+-0:cb:bd	Cambridge Broadband Ltd.
+-0:cf:1c	COMMUNICATION MACHINERY CORP.
++0:c:f	Techno-One Co., Ltd
+ 0:d0:0	FERRAN SCIENTIFIC, INC.
+-0:d0:1	VST TECHNOLOGIES, INC.
+ 0:d0:10	CONVERGENT NETWORKS, INC.
+ 0:d0:11	PRISM VIDEO, INC.
+ 0:d0:12	GATEWORKS CORP.
+@@ -7975,7 +11324,7 @@
+ 0:d0:1d	FURUNO ELECTRIC CO., LTD.
+ 0:d0:1e	PINGTEL CORP.
+ 0:d0:1f	CTAM PTY. LTD.
+-0:d0:2	DITECH CORPORATION
++0:d0:1	VST TECHNOLOGIES, INC.
+ 0:d0:20	AIM SYSTEM, INC.
+ 0:d0:21	REGENT ELECTRONICS CORP.
+ 0:d0:22	INCREDIBLE TECHNOLOGIES, INC.
+@@ -7990,26 +11339,26 @@
+ 0:d0:2b	JETCELL, INC.
+ 0:d0:2c	CAMPBELL SCIENTIFIC, INC.
+ 0:d0:2d	ADEMCO
++0:d0:2	DITECH CORPORATION
+ 0:d0:2e	COMMUNICATION AUTOMATION CORP.
+ 0:d0:2f	VLSI TECHNOLOGY INC.
+-0:d0:3	COMDA ENTERPRISES CORP.
+-0:d0:30	SAFETRAN SYSTEMS CORP.
++0:d0:30	Safetran Systems Corp
+ 0:d0:31	INDUSTRIAL LOGIC CORPORATION
+ 0:d0:32	YANO ELECTRIC CO., LTD.
+ 0:d0:33	DALIAN DAXIAN NETWORK
+ 0:d0:34	ORMEC SYSTEMS CORP.
+ 0:d0:35	BEHAVIOR TECH. COMPUTER CORP.
+ 0:d0:36	TECHNOLOGY ATLANTA CORP.
+-0:d0:37	PHILIPS-DVS-LO BDR
++0:d0:37	Pace France
+ 0:d0:38	FIVEMERE, LTD.
+ 0:d0:39	UTILICOM, INC.
+ 0:d0:3a	ZONEWORX, INC.
+ 0:d0:3b	VISION PRODUCTS PTY. LTD.
++0:d0:3	COMDA ENTERPRISES CORP.
+ 0:d0:3c	Vieo, Inc.
+ 0:d0:3d	GALILEO TECHNOLOGY, LTD.
+ 0:d0:3e	ROCKETCHIPS, INC.
+ 0:d0:3f	AMERICAN COMMUNICATION
+-0:d0:4	PENTACOM LTD.
+ 0:d0:40	SYSMATE CO., LTD.
+ 0:d0:41	AMIGO TECHNOLOGY CO., LTD.
+ 0:d0:42	MAHLO GMBH & CO. UG
+@@ -8026,7 +11375,7 @@
+ 0:d0:4d	DIV OF RESEARCH & STATISTICS
+ 0:d0:4e	LOGIBAG
+ 0:d0:4f	BITRONICS, INC.
+-0:d0:5	ZHS ZEITMANAGEMENTSYSTEME
++0:d0:4	PENTACOM LTD.
+ 0:d0:50	ISKRATEL
+ 0:d0:51	O2 MICRO, INC.
+ 0:d0:52	ASCEND COMMUNICATIONS, INC.
+@@ -8043,8 +11392,8 @@
+ 0:d0:5d	INTELLIWORXX, INC.
+ 0:d0:5e	STRATABEAM TECHNOLOGY, INC.
+ 0:d0:5f	VALCOM, INC.
+-0:d0:6	CISCO SYSTEMS, INC.
+-0:d0:60	PANASONIC EUROPEAN
++0:d0:5	ZHS ZEITMANAGEMENTSYSTEME
++0:d0:60	Panasonic Europe Ltd.
+ 0:d0:61	TREMON ENTERPRISES CO., LTD.
+ 0:d0:62	DIGIGRAM
+ 0:d0:63	CISCO SYSTEMS, INC.
+@@ -8056,51 +11405,51 @@
+ 0:d0:69	TECHNOLOGIC SYSTEMS
+ 0:d0:6a	LINKUP SYSTEMS CORPORATION
+ 0:d0:6b	SR TELECOM INC.
++0:d0:6	CISCO SYSTEMS, INC.
+ 0:d0:6c	SHAREWAVE, INC.
+ 0:d0:6d	ACRISON, INC.
+ 0:d0:6e	TRENDVIEW RECORDERS LTD.
+ 0:d0:6f	KMC CONTROLS
+-0:d0:7	MIC ASSOCIATES, INC.
+ 0:d0:70	LONG WELL ELECTRONICS CORP.
+ 0:d0:71	ECHELON CORP.
+ 0:d0:72	BROADLOGIC
+ 0:d0:73	ACN ADVANCED COMMUNICATIONS
+ 0:d0:74	TAQUA SYSTEMS, INC.
+ 0:d0:75	ALARIS MEDICAL SYSTEMS, INC.
+-0:d0:76	MERRILL LYNCH & CO., INC.
++0:d0:76	Bank of America
+ 0:d0:77	LUCENT TECHNOLOGIES
+-0:d0:78	ELTEX OF SWEDEN AB
++0:d0:78	Eltex of Sweden AB
+ 0:d0:79	CISCO SYSTEMS, INC.
+ 0:d0:7a	AMAQUEST COMPUTER CORP.
+-0:d0:7b	COMCAM INTERNATIONAL LTD.
++0:d0:7b	COMCAM INTERNATIONAL INC
+ 0:d0:7c	KOYO ELECTRONICS INC. CO.,LTD.
+ 0:d0:7d	COSINE COMMUNICATIONS
+ 0:d0:7e	KEYCORP LTD.
+ 0:d0:7f	STRATEGY & TECHNOLOGY, LIMITED
+-0:d0:8	MACTELL CORPORATION
++0:d0:7	MIC ASSOCIATES, INC.
+ 0:d0:80	EXABYTE CORPORATION
+-0:d0:81	REAL TIME DEVICES USA, INC.
++0:d0:81	RTD Embedded Technologies, Inc.
+ 0:d0:82	IOWAVE INC.
+ 0:d0:83	INVERTEX, INC.
+ 0:d0:84	NEXCOMM SYSTEMS, INC.
+ 0:d0:85	OTIS ELEVATOR COMPANY
+ 0:d0:86	FOVEON, INC.
+ 0:d0:87	MICROFIRST INC.
+-0:d0:88	Terayon Communications Systems
++0:d0:88	Motorola, Inc.
+ 0:d0:89	DYNACOLOR, INC.
+ 0:d0:8a	PHOTRON USA
+-0:d0:8b	ADVA Limited
++0:d0:8b	ADVA Optical Networking Ltd
+ 0:d0:8c	GENOA TECHNOLOGY, INC.
+ 0:d0:8d	PHOENIX GROUP, INC.
+ 0:d0:8e	NVISION INC.
+ 0:d0:8f	ARDENT TECHNOLOGIES, INC.
+-0:d0:9	HSING TECH. ENTERPRISE CO. LTD
++0:d0:8	MACTELL CORPORATION
+ 0:d0:90	CISCO SYSTEMS, INC.
+ 0:d0:91	SMARTSAN SYSTEMS, INC.
+ 0:d0:92	GLENAYRE WESTERN MULTIPLEX
+ 0:d0:93	TQ - COMPONENTS GMBH
+ 0:d0:94	TIMELINE VISTA, INC.
+-0:d0:95	Alcatel North America ESD
++0:d0:95	Alcatel-Lucent, Enterprise Business Group
+ 0:d0:96	3COM EUROPE LTD.
+ 0:d0:97	CISCO SYSTEMS, INC.
+ 0:d0:98	Photon Dynamics Canada Inc.
+@@ -8111,7 +11460,7 @@
+ 0:d0:9d	VERIS INDUSTRIES
+ 0:d0:9e	2WIRE, INC.
+ 0:d0:9f	NOVTEK TEST SYSTEMS
+-0:d0:a	LANACCESS TELECOM S.A.
++0:d0:9	HSING TECH. ENTERPRISE CO. LTD
+ 0:d0:a0	MIPS DENMARK
+ 0:d0:a1	OSKAR VIERLING GMBH + CO. KG
+ 0:d0:a2	INTEGRATED DEVICE
+@@ -8128,7 +11477,7 @@
+ 0:d0:ad	TL INDUSTRIES
+ 0:d0:ae	ORESIS COMMUNICATIONS, INC.
+ 0:d0:af	CUTLER-HAMMER, INC.
+-0:d0:b	RHK TECHNOLOGY, INC.
++0:d0:a	LANACCESS TELECOM S.A.
+ 0:d0:b0	BITSWITCH LTD.
+ 0:d0:b1	OMEGA ELECTRONICS SA
+ 0:d0:b2	XIOTECH CORPORATION
+@@ -8142,10 +11491,10 @@
+ 0:d0:ba	CISCO SYSTEMS, INC.
+ 0:d0:bb	CISCO SYSTEMS, INC.
+ 0:d0:bc	CISCO SYSTEMS, INC.
+-0:d0:bd	SICAN GMBH
++0:d0:bd	Silicon Image GmbH
+ 0:d0:be	EMUTEC INC.
+ 0:d0:bf	PIVOTAL TECHNOLOGIES
+-0:d0:c	SNIJDER MICRO SYSTEMS
++0:d0:b	RHK TECHNOLOGY, INC.
+ 0:d0:c0	CISCO SYSTEMS, INC.
+ 0:d0:c1	HARMONIC DATA SYSTEMS, LTD.
+ 0:d0:c2	BALTHAZAR TECHNOLOGY AB
+@@ -8154,17 +11503,17 @@
+ 0:d0:c5	COMPUTATIONAL SYSTEMS, INC.
+ 0:d0:c6	THOMAS & BETTS CORP.
+ 0:d0:c7	PATHWAY, INC.
+-0:d0:c8	I/O CONSULTING A/S
++0:d0:c8	Prevas A/S
+ 0:d0:c9	ADVANTECH CO., LTD.
+-0:d0:ca	INTRINSYC SOFTWARE INC.
++0:d0:ca	Intrinsyc Software International Inc.
+ 0:d0:cb	DASAN CO., LTD.
+ 0:d0:cc	TECHNOLOGIES LYRE INC.
+ 0:d0:cd	ATAN TECHNOLOGY INC.
+ 0:d0:ce	ASYST ELECTRONIC
+ 0:d0:cf	MORETON BAY
+-0:d0:d	MICROMERITICS INSTRUMENT
++0:d0:c	SNIJDER MICRO SYSTEMS
+ 0:d0:d0	ZHONGXING TELECOM LTD.
+-0:d0:d1	SIROCCO SYSTEMS, INC.
++0:d0:d1	Sycamore Networks
+ 0:d0:d2	EPILOG CORPORATION
+ 0:d0:d3	CISCO SYSTEMS, INC.
+ 0:d0:d4	V-BITS, INC.
+@@ -8179,7 +11528,7 @@
+ 0:d0:dd	SUNRISE TELECOM, INC.
+ 0:d0:de	PHILIPS MULTIMEDIA NETWORK
+ 0:d0:df	KUZUMI ELECTRONICS, INC.
+-0:d0:e	PLURIS, INC.
++0:d0:d	MICROMERITICS INSTRUMENT
+ 0:d0:e0	DOOIN ELECTRONICS CO.
+ 0:d0:e1	AVIONITEK ISRAEL INC.
+ 0:d0:e2	MRT MICRO, INC.
+@@ -8189,14 +11538,14 @@
+ 0:d0:e6	IBOND INC.
+ 0:d0:e7	VCON TELECOMMUNICATION LTD.
+ 0:d0:e8	MAC SYSTEM CO., LTD.
+-0:d0:e9	ADVANTAGE CENTURY
++0:d0:e9	Advantage Century Telecommunication Corp.
+ 0:d0:ea	NEXTONE COMMUNICATIONS, INC.
+ 0:d0:eb	LIGHTERA NETWORKS, INC.
+ 0:d0:ec	NAKAYO TELECOMMUNICATIONS, INC
+ 0:d0:ed	XIOX
+ 0:d0:ee	DICTAPHONE CORPORATION
+ 0:d0:ef	IGT
+-0:d0:f	SPEECH DESIGN GMBH
++0:d0:e	PLURIS, INC.
+ 0:d0:f0	CONVISION TECHNOLOGY GMBH
+ 0:d0:f1	SEGA ENTERPRISES, LTD.
+ 0:d0:f2	MONTEREY NETWORKS
+@@ -8207,15 +11556,16 @@
+ 0:d0:f7	NEXT NETS CORPORATION
+ 0:d0:f8	FUJIAN STAR TERMINAL
+ 0:d0:f9	ACUTE COMMUNICATIONS CORP.
+-0:d0:fa	RACAL GUARDATA
++0:d0:fa	Thales e-Security Ltd.
+ 0:d0:fb	TEK MICROSYSTEMS, INCORPORATED
+ 0:d0:fc	GRANITE MICROSYSTEMS
+ 0:d0:fd	OPTIMA TELE.COM, INC.
+ 0:d0:fe	ASTRAL POINT
+ 0:d0:ff	CISCO SYSTEMS, INC.
++0:d0:f	SPEECH DESIGN GMBH
+ 0:d:0	Seaway Networks Inc.
+-0:d:1	P&E Microcomputer Systems, Inc.
+ 0:d:10	Embedtronics Oy
++0:d1:1c	ACETEL
+ 0:d:11	DENTSPLY - Gendex
+ 0:d:12	AXELL Corporation
+ 0:d:13	Wilhelm Rutenbeck GmbH&Co.
+@@ -8223,18 +11573,18 @@
+ 0:d:15	Voipac s.r.o.
+ 0:d:16	UHS Systems Pty Ltd
+ 0:d:17	Turbo Networks Co.Ltd
+-0:d:18	Sunitec Enterprise Co., Ltd.
++0:d:18	Mega-Trend Electronics CO., LTD.
+ 0:d:19	ROBE Show lighting
+ 0:d:1a	Mustek System Inc.
+ 0:d:1b	Kyoto Electronics Manufacturing Co., Ltd.
+-0:d:1c	I2E TELECOM
++0:d:1c	Amesys Defense
+ 0:d:1d	HIGH-TEK HARNESS ENT. CO., LTD.
+ 0:d:1e	Control Techniques
+ 0:d:1f	AV Digital
+-0:d:2	NEC Access Technica,Ltd
++0:d:1	P&E Microcomputer Systems, Inc.
+ 0:d:20	ASAHIKASEI TECHNOSYSTEM CO.,LTD.
+ 0:d:21	WISCORE Inc.
+-0:d:22	Unitronics
++0:d:22	Unitronics LTD
+ 0:d:23	Smart Solution, Inc
+ 0:d:24	SENTEC E&E CO., LTD.
+ 0:d:25	SANDEN CORPORATION
+@@ -8248,7 +11598,7 @@
+ 0:d:2d	NCT Deutschland GmbH
+ 0:d:2e	Matsushita Avionics Systems Corporation
+ 0:d:2f	AIN Comm.Tech.Co., LTD
+-0:d:3	Matrics, Inc.
++0:d:2	NEC AccessTechnica,Ltd
+ 0:d:30	IceFyre Semiconductor
+ 0:d:31	Compellent Technologies, Inc.
+ 0:d:32	DispenseSource, Inc.
+@@ -8257,6 +11607,7 @@
+ 0:d:35	PAC International Ltd
+ 0:d:36	Wu Han Routon Electronic Co., Ltd
+ 0:d:37	WIPLUG
++0:d3:8d	Hotel Technology Next Generation
+ 0:d:38	NISSIN INC.
+ 0:d:39	Network Electronics
+ 0:d:3a	Microsoft Corp.
+@@ -8264,15 +11615,15 @@
+ 0:d:3c	i.Tech Dynamic Ltd
+ 0:d:3d	Hammerhead Systems, Inc.
+ 0:d:3e	APLUX Communications Ltd.
+-0:d:3f	VXI Technology
+-0:d:4	Foxboro Eckardt Development GmbH
++0:d:3f	VTI Instruments Corporation
++0:d:3	Matrics, Inc.
+ 0:d:40	Verint Loronix Video Solutions
+ 0:d:41	Siemens AG ICM MP UC RD IT KLF1
+ 0:d:42	Newbest Development Limited
+ 0:d:43	DRS Tactical Systems Inc.
+-0:d:44	PRIVATE
++0:d:44	Audio BU - Logitech
+ 0:d:45	Tottori SANYO Electric Co., Ltd.
+-0:d:46	SSD Drives, Inc.
++0:d:46	Parker SSD Drives
+ 0:d:47	Collex
+ 0:d:48	AEWIN Technologies Co., Ltd.
+ 0:d:49	Triton Systems of Delaware, Inc.
+@@ -8282,12 +11633,12 @@
+ 0:d:4d	Ninelanes
+ 0:d:4e	NDR Co.,LTD.
+ 0:d:4f	Kenwood Corporation
+-0:d:5	cybernet manufacturing inc.
++0:d:4	Foxboro Eckardt Development GmbH
+ 0:d:50	Galazar Networks
+ 0:d:51	DIVR Systems, Inc.
+ 0:d:52	Comart system
+ 0:d:53	Beijing 5w Communication Corp.
+-0:d:54	3Com Europe Ltd
++0:d:54	3Com Ltd
+ 0:d:55	SANYCOM Technology Co.,Ltd
+ 0:d:56	Dell PCBA Test
+ 0:d:57	Fujitsu I-Network Systems Limited.
+@@ -8296,10 +11647,10 @@
+ 0:d:5a	Tiesse SpA
+ 0:d:5b	Smart Empire Investments Limited
+ 0:d:5c	Robert Bosch GmbH, VT-ATMO
++0:d:5	cybernet manufacturing inc.
+ 0:d:5d	Raritan Computer, Inc
+-0:d:5e	NEC CustomTechnica, Ltd.
++0:d:5e	NEC Personal Products
+ 0:d:5f	Minds Inc
+-0:d:6	Compulogic Limited
+ 0:d:60	IBM Corporation
+ 0:d:61	Giga-Byte Technology Co., Ltd.
+ 0:d:62	Funkwerk Dabendorf GmbH
+@@ -8313,10 +11664,10 @@
+ 0:d:6a	Redwood Technologies LTD
+ 0:d:6b	Mita-Teknik A/S
+ 0:d:6c	M-Audio
++0:d:6	Compulogic Limited
+ 0:d:6d	K-Tech Devices Corp.
+ 0:d:6e	K-Patents Oy
+ 0:d:6f	Ember Corporation
+-0:d:7	Calrec Audio Ltd
+ 0:d:70	Datamax Corporation
+ 0:d:71	boca systems
+ 0:d:72	2Wire, Inc
+@@ -8329,11 +11680,11 @@
+ 0:d:79	Dynamic Solutions Co,.Ltd.
+ 0:d:7a	DiGATTO Asia Pacific Pte Ltd
+ 0:d:7b	Consensys Computers Inc.
++0:d:7	Calrec Audio Ltd
+ 0:d:7c	Codian Ltd
+ 0:d:7d	Afco Systems
+ 0:d:7e	Axiowave Networks, Inc.
+ 0:d:7f	MIDAS  COMMUNICATION TECHNOLOGIES PTE LTD ( Foreign Branch)
+-0:d:8	AboveCable, Inc.
+ 0:d:80	Online Development Inc
+ 0:d:81	Pepperl+Fuchs GmbH
+ 0:d:82	PHS srl
+@@ -8344,13 +11695,13 @@
+ 0:d:87	Elitegroup Computer System Co. (ECS)
+ 0:d:88	D-Link Corporation
+ 0:d:89	Bils Technology Inc
++0:d:8	AboveCable, Inc.
+ 0:d:8a	Winners Electronics Co., Ltd.
+ 0:d:8b	T&D Corporation
+ 0:d:8c	Shanghai Wedone Digital Ltd. CO.
+ 0:d:8d	ProLinx Communication Gateways, Inc.
+ 0:d:8e	Koden Electronics Co., Ltd.
+ 0:d:8f	King Tsushin Kogyo Co., LTD.
+-0:d:9	Yuehua(Zhuhai) Electronic CO. LTD
+ 0:d:90	Factum Electronics AB
+ 0:d:91	Eclipse (HQ Espana) S.L.
+ 0:d:92	Arima Communication Corporation
+@@ -8367,7 +11718,7 @@
+ 0:d:9d	Hewlett Packard
+ 0:d:9e	TOKUDEN OHIZUMI SEISAKUSYO Co.,Ltd.
+ 0:d:9f	RF Micro Devices
+-0:d:a	Projectiondesign as
++0:d:9	Yuehua(Zhuhai) Electronic CO. LTD
+ 0:d:a0	NEDAP N.V.
+ 0:d:a1	MIRAE ITS Co.,LTD.
+ 0:d:a2	Infrant Technologies, Inc.
+@@ -8384,24 +11735,25 @@
+ 0:d:ad	Dataprobe Inc
+ 0:d:ae	SAMSUNG HEAVY INDUSTRIES CO., LTD.
+ 0:d:af	Plexus Corp (UK) Ltd
+-0:d:b	Buffalo Inc.
++0:d:a	Projectiondesign as
+ 0:d:b0	Olym-tech Co.,Ltd.
+ 0:d:b1	Japan Network Service Co., Ltd.
+ 0:d:b2	Ammasso, Inc.
+ 0:d:b3	SDO Communication Corperation
++0:db:45	THAMWAY CO.,LTD.
+ 0:d:b4	NETASQ
+ 0:d:b5	GLOBALSAT TECHNOLOGY CORPORATION
+ 0:d:b6	Teknovus, Inc.
+ 0:d:b7	SANKO ELECTRIC CO,.LTD
+ 0:d:b8	SCHILLER AG
+ 0:d:b9	PC Engines GmbH
+-0:d:ba	Océ Document Technologies GmbH
++0:d:ba	Oc
+ 0:d:bb	Nippon Dentsu Co.,Ltd.
++0:d:b	Buffalo Inc.
+ 0:d:bc	Cisco Systems
+ 0:d:bd	Cisco Systems
+ 0:d:be	Bel Fuse Europe Ltd.,UK
+ 0:d:bf	TekTone Sound & Signal Mfg., Inc.
+-0:d:c	MDI Security Systems
+ 0:d:c0	Spagat AS
+ 0:d:c1	SafeWeb Inc
+ 0:d:c2	PRIVATE
+@@ -8418,24 +11770,40 @@
+ 0:d:cd	GROUPE TXCOM
+ 0:d:ce	Dynavac Technology Pte Ltd
+ 0:d:cf	Cidra Corp.
+-0:d:d	ITSupported, LLC
++0:d:c	MDI Security Systems
+ 0:d:d0	TetraTec Instruments GmbH
++0:dd:0	UNGERMANN-BASS INC.
+ 0:d:d1	Stryker Corporation
++0:dd:1	UNGERMANN-BASS INC.
+ 0:d:d2	Simrad Optronics ASA
++0:dd:2	UNGERMANN-BASS INC.
+ 0:d:d3	SAMWOO Telecommunication Co.,Ltd.
+-0:d:d4	Revivio Inc.
++0:dd:3	UNGERMANN-BASS INC.
++0:d:d4	Symantec Corporation
++0:dd:4	UNGERMANN-BASS INC.
+ 0:d:d5	O'RITE TECHNOLOGY CO.,LTD
++0:dd:5	UNGERMANN-BASS INC.
+ 0:d:d6	ITI    LTD
++0:dd:6	UNGERMANN-BASS INC.
+ 0:d:d7	Bright
++0:dd:7	UNGERMANN-BASS INC.
+ 0:d:d8	BBN
++0:dd:8	UNGERMANN-BASS INC.
+ 0:d:d9	Anton Paar GmbH
++0:dd:9	UNGERMANN-BASS INC.
+ 0:d:da	ALLIED TELESIS K.K.
++0:dd:a	UNGERMANN-BASS INC.
+ 0:d:db	AIRWAVE TECHNOLOGIES INC.
++0:dd:b	UNGERMANN-BASS INC.
++0:dd:c	UNGERMANN-BASS INC.
+ 0:d:dc	VAC
+-0:d:dd	PROFÝLO TELRA ELEKTRONÝK SANAYÝ VE TÝCARET A.Þ.
++0:d:dd	PROF
++0:dd:d	UNGERMANN-BASS INC.
+ 0:d:de	Joyteck Co., Ltd.
++0:dd:e	UNGERMANN-BASS INC.
+ 0:d:df	Japan Image & Network Inc.
+-0:d:e	Inqnet Systems, Inc.
++0:dd:f	UNGERMANN-BASS INC.
++0:d:d	ITSupported, LLC
+ 0:d:e0	ICPDAS Co.,LTD
+ 0:d:e1	Control Products, Inc.
+ 0:d:e2	CMZ Sistemi Elettronici
+@@ -8452,7 +11820,7 @@
+ 0:d:ed	Cisco Systems
+ 0:d:ee	Andrew RF Power Amplifier Group
+ 0:d:ef	Soc. Coop. Bilanciai
+-0:d:f	Finlux Ltd
++0:d:e	Inqnet Systems, Inc.
+ 0:d:f0	QCOM TECHNOLOGY INC.
+ 0:d:f1	IONIX INC.
+ 0:d:f2	PRIVATE
+@@ -8465,30 +11833,14 @@
+ 0:d:f9	NDS Limited
+ 0:d:fa	Micro Control Systems Ltd.
+ 0:d:fb	Komax AG
+-0:d:fc	ITFOR Inc. resarch and development
++0:d:fc	ITFOR Inc.
+ 0:d:fd	Huges Hi-Tech Inc.,
+ 0:d:fe	Hauppauge Computer Works, Inc.
+ 0:d:ff	CHENMING MOLD INDUSTRY CORP.
+-0:dd:0	UNGERMANN-BASS INC.
+-0:dd:1	UNGERMANN-BASS INC.
+-0:dd:2	UNGERMANN-BASS INC.
+-0:dd:3	UNGERMANN-BASS INC.
+-0:dd:4	UNGERMANN-BASS INC.
+-0:dd:5	UNGERMANN-BASS INC.
+-0:dd:6	UNGERMANN-BASS INC.
+-0:dd:7	UNGERMANN-BASS INC.
+-0:dd:8	UNGERMANN-BASS INC.
+-0:dd:9	UNGERMANN-BASS INC.
+-0:dd:a	UNGERMANN-BASS INC.
+-0:dd:b	UNGERMANN-BASS INC.
+-0:dd:c	UNGERMANN-BASS INC.
+-0:dd:d	UNGERMANN-BASS INC.
+-0:dd:e	UNGERMANN-BASS INC.
+-0:dd:f	UNGERMANN-BASS INC.
+-0:e0:0	FUJITSU, LTD
+-0:e0:1	STRAND LIGHTING LIMITED
++0:d:f	Finlux Ltd
++0:e0:0	Fujitsu Limited
+ 0:e0:10	HESS SB-AUTOMATENBAU GmbH
+-0:e0:11	UNIDEN SAN DIEGO R&D CENTER, INC.
++0:e0:11	Uniden Corporation
+ 0:e0:12	PLUTO TECHNOLOGIES INTERNATIONAL INC.
+ 0:e0:13	EASTERN ELECTRONIC CO., LTD.
+ 0:e0:14	CISCO SYSTEMS, INC.
+@@ -8499,17 +11851,17 @@
+ 0:e0:19	ING. GIORDANO ELETTRONICA
+ 0:e0:1a	COMTEC SYSTEMS. CO., LTD.
+ 0:e0:1b	SPHERE COMMUNICATIONS, INC.
+-0:e0:1c	MOBILITY ELECTRONICSY
++0:e0:1c	Cradlepoint, Inc
+ 0:e0:1d	WebTV NETWORKS, INC.
+ 0:e0:1e	CISCO SYSTEMS, INC.
+ 0:e0:1f	AVIDIA Systems, Inc.
+-0:e0:2	CROSSROADS SYSTEMS, INC.
++0:e0:1	STRAND LIGHTING LIMITED
+ 0:e0:20	TECNOMEN OY
+ 0:e0:21	FREEGATE CORP.
+ 0:e0:22	Analog Devices Inc.
+ 0:e0:23	TELRAD
+ 0:e0:24	GADZOOX NETWORKS
+-0:e0:25	dit CO., LTD.
++0:e0:25	dit Co., Ltd.
+ 0:e0:26	Redlake MASD LLC
+ 0:e0:27	DUX, INC.
+ 0:e0:28	APTIX CORPORATION
+@@ -8517,16 +11869,16 @@
+ 0:e0:2a	TANDBERG TELEVISION AS
+ 0:e0:2b	EXTREME NETWORKS
+ 0:e0:2c	AST COMPUTER
++0:e0:2	CROSSROADS SYSTEMS, INC.
+ 0:e0:2d	InnoMediaLogic, Inc.
+ 0:e0:2e	SPC ELECTRONICS CORPORATION
+ 0:e0:2f	MCNS HOLDINGS, L.P.
+-0:e0:3	NOKIA WIRELESS BUSINESS COMMUN
+ 0:e0:30	MELITA INTERNATIONAL CORP.
+ 0:e0:31	HAGIWARA ELECTRIC CO., LTD.
+ 0:e0:32	MISYS FINANCIAL SYSTEMS, LTD.
+ 0:e0:33	E.E.P.D. GmbH
+ 0:e0:34	CISCO SYSTEMS, INC.
+-0:e0:35	LOUGHBOROUGH SOUND IMAGES, PLC
++0:e0:35	Emerson Network Power
+ 0:e0:36	PIONEER CORPORATION
+ 0:e0:37	CENTURY CORPORATION
+ 0:e0:38	PROXIMA CORPORATION
+@@ -8537,7 +11889,7 @@
+ 0:e0:3d	FOCON ELECTRONIC SYSTEMS A/S
+ 0:e0:3e	ALFATECH, INC.
+ 0:e0:3f	JATON CORPORATION
+-0:e0:4	PMC-SIERRA, INC.
++0:e0:3	NOKIA WIRELESS BUSINESS COMMUN
+ 0:e0:40	DeskStation Technology, Inc.
+ 0:e0:41	CSPI
+ 0:e0:42	Pacom Systems Ltd.
+@@ -8545,7 +11897,7 @@
+ 0:e0:44	LSICS CORPORATION
+ 0:e0:45	TOUCHWAVE, INC.
+ 0:e0:46	BENTLY NEVADA CORP.
+-0:e0:47	INFOCUS SYSTEMS
++0:e0:47	InFocus Corporation
+ 0:e0:48	SDL COMMUNICATIONS, INC.
+ 0:e0:49	MICROWI ELECTRONIC GmbH
+ 0:e0:4a	ENHANCED MESSAGING SYSTEMS, INC
+@@ -8554,10 +11906,10 @@
+ 0:e0:4d	INTERNET INITIATIVE JAPAN, INC
+ 0:e0:4e	SANYO DENKI CO., LTD.
+ 0:e0:4f	CISCO SYSTEMS, INC.
+-0:e0:5	TECHNICAL CORP.
++0:e0:4	PMC-SIERRA, INC.
+ 0:e0:50	EXECUTONE INFORMATION SYSTEMS, INC.
+ 0:e0:51	TALX CORPORATION
+-0:e0:52	FOUNDRY NETWORKS, INC.
++0:e0:52	Brocade Communications Systems, Inc
+ 0:e0:53	CELLPORT LABS, INC.
+ 0:e0:54	KODAI HITEC CO., LTD.
+ 0:e0:55	INGENIERIA ELECTRONICA COMERCIAL INELCOM S.A.
+@@ -8571,7 +11923,7 @@
+ 0:e0:5d	UNITEC CO., LTD.
+ 0:e0:5e	JAPAN AVIATION ELECTRONICS INDUSTRY, LTD.
+ 0:e0:5f	e-Net, Inc.
+-0:e0:6	SILICON INTEGRATED SYS. CORP.
++0:e0:5	TECHNICAL CORP.
+ 0:e0:60	SHERWOOD
+ 0:e0:61	EdgePoint Networks, Inc.
+ 0:e0:62	HOST ENGINEERING
+@@ -8587,8 +11939,8 @@
+ 0:e0:6c	AEP Systems International Ltd
+ 0:e0:6d	COMPUWARE CORPORATION
+ 0:e0:6e	FAR SYSTEMS S.p.A.
+-0:e0:6f	Terayon Communications Systems
+-0:e0:7	NETWORK ALCHEMY LTD.
++0:e0:6f	Motorola, Inc.
++0:e0:6	SILICON INTEGRATED SYS. CORP.
+ 0:e0:70	DH TECHNOLOGY
+ 0:e0:71	EPIS MICROCOMPUTER
+ 0:e0:72	LYNK
+@@ -8600,12 +11952,12 @@
+ 0:e0:78	BERKELEY NETWORKS
+ 0:e0:79	A.T.N.R.
+ 0:e0:7a	MIKRODIDAKT AB
++0:e0:7	Avaya ECS Ltd
+ 0:e0:7b	BAY NETWORKS
+ 0:e0:7c	METTLER-TOLEDO, INC.
+ 0:e0:7d	NETRONIX, INC.
+ 0:e0:7e	WALT DISNEY IMAGINEERING
+ 0:e0:7f	LOGISTISTEM s.r.l.
+-0:e0:8	AMAZING CONTROLS! INC.
+ 0:e0:80	CONTROL RESOURCES CORPORATION
+ 0:e0:81	TYAN COMPUTER CORP.
+ 0:e0:82	ANERMA
+@@ -8617,12 +11969,12 @@
+ 0:e0:88	LTX CORPORATION
+ 0:e0:89	ION Networks, Inc.
+ 0:e0:8a	GEC AVERY, LTD.
++0:e0:8	AMAZING CONTROLS! INC.
+ 0:e0:8b	QLogic Corp.
+ 0:e0:8c	NEOPARADIGM LABS, INC.
+ 0:e0:8d	PRESSURE SYSTEMS, INC.
+ 0:e0:8e	UTSTARCOM
+ 0:e0:8f	CISCO SYSTEMS, INC.
+-0:e0:9	MARATHON TECHNOLOGIES CORP.
+ 0:e0:90	BECKMAN LAB. AUTOMATION DIV.
+ 0:e0:91	LG ELECTRONICS, INC.
+ 0:e0:92	ADMTEK INCORPORATED
+@@ -8633,13 +11985,13 @@
+ 0:e0:97	CARRIER ACCESS CORPORATION
+ 0:e0:98	AboCom Systems, Inc.
+ 0:e0:99	SAMSON AG
+-0:e0:9a	POSITRON INDUSTRIES, INC.
++0:e0:9a	Positron Inc.
+ 0:e0:9b	ENGAGE NETWORKS, INC.
+ 0:e0:9c	MII
+ 0:e0:9d	SARNOFF CORPORATION
+ 0:e0:9e	QUANTUM CORPORATION
+ 0:e0:9f	PIXEL VISION
+-0:e0:a	DIBA, INC.
++0:e0:9	MARATHON TECHNOLOGIES CORP.
+ 0:e0:a0	WILTRON CO.
+ 0:e0:a1	HIMA PAUL HILDEBRANDT GmbH Co. KG
+ 0:e0:a2	MICROSLATE INC.
+@@ -8654,11 +12006,12 @@
+ 0:e0:ab	DIMAT S.A.
+ 0:e0:ac	MIDSCO, INC.
+ 0:e0:ad	EES TECHNOLOGY, LTD.
++0:e0:a	DIBA, INC.
+ 0:e0:ae	XAQTI CORPORATION
+ 0:e0:af	GENERAL DYNAMICS INFORMATION SYSTEMS
+-0:e0:b	ROOFTOP COMMUNICATIONS CORP.
++0:e:0	Atrie
+ 0:e0:b0	CISCO SYSTEMS, INC.
+-0:e0:b1	Alcatel North America ESD
++0:e0:b1	Alcatel-Lucent, Enterprise Business Group
+ 0:e0:b2	TELMAX COMMUNICATIONS CORP.
+ 0:e0:b3	EtherWAN Systems, Inc.
+ 0:e0:b4	TECHNO SCOPE CO., LTD.
+@@ -8673,7 +12026,7 @@
+ 0:e0:bd	INTERFACE SYSTEMS, INC.
+ 0:e0:be	GENROCO INTERNATIONAL, INC.
+ 0:e0:bf	TORRENT NETWORKING TECHNOLOGIES CORP.
+-0:e0:c	MOTOROLA
++0:e0:b	ROOFTOP COMMUNICATIONS CORP.
+ 0:e0:c0	SEIWA ELECTRIC MFG. CO., LTD.
+ 0:e0:c1	MEMOREX TELEX JAPAN, LTD.
+ 0:e0:c2	NECSY S.p.A.
+@@ -8690,13 +12043,13 @@
+ 0:e0:cd	SENSIS CORPORATION
+ 0:e0:ce	ARN
+ 0:e0:cf	INTEGRATED DEVICE TECHNOLOGY, INC.
+-0:e0:d	RADIANT SYSTEMS
++0:e0:c	MOTOROLA
+ 0:e0:d0	NETSPEED, INC.
+ 0:e0:d1	TELSIS LIMITED
+ 0:e0:d2	VERSANET COMMUNICATIONS, INC.
+ 0:e0:d3	DATENTECHNIK GmbH
+ 0:e0:d4	EXCELLENT COMPUTER
+-0:e0:d5	ARCXEL TECHNOLOGIES, INC.
++0:e0:d5	Emulex Corporation
+ 0:e0:d6	COMPUTER & COMMUNICATION RESEARCH LAB.
+ 0:e0:d7	SUNSHINE ELECTRONICS, INC.
+ 0:e0:d8	LANBit Computer, Inc.
+@@ -8706,8 +12059,8 @@
+ 0:e0:dc	NEXWARE CORP.
+ 0:e0:dd	ZENITH ELECTRONICS CORPORATION
+ 0:e0:de	DATAX NV
+-0:e0:df	KE KOMMUNIKATIONS-ELECTRONIK
+-0:e0:e	AVALON IMAGING SYSTEMS, INC.
++0:e0:df	KEYMILE GmbH
++0:e0:d	RADIANT SYSTEMS
+ 0:e0:e0	SI ELECTRONICS, LTD.
+ 0:e0:e1	G2 NETWORKS, INC.
+ 0:e0:e2	INNOVA CORP.
+@@ -8719,12 +12072,12 @@
+ 0:e0:e8	GRETACODER Data Systems AG
+ 0:e0:e9	DATA LABS, INC.
+ 0:e0:ea	INNOVAT COMMUNICATIONS, INC.
++0:e0:e	AVALON IMAGING SYSTEMS, INC.
+ 0:e0:eb	DIGICOM SYSTEMS, INCORPORATED
+ 0:e0:ec	CELESTICA INC.
+ 0:e0:ed	SILICOM, LTD.
+ 0:e0:ee	MAREL HF
+ 0:e0:ef	DIONEX
+-0:e0:f	SHANGHAI BAUD DATA
+ 0:e0:f0	ABLER TECHNOLOGY, INC.
+ 0:e0:f1	THAT CORPORATION
+ 0:e0:f2	ARLOTTO COMNET, INC.
+@@ -8741,27 +12094,25 @@
+ 0:e0:fd	A-TREND TECHNOLOGY CO., LTD.
+ 0:e0:fe	CISCO SYSTEMS, INC.
+ 0:e0:ff	SECURITY DYNAMICS TECHNOLOGIES, Inc.
+-0:e6:d3	NIXDORF COMPUTER CORP.
+-0:e:0	Atrie
+-0:e:1	ASIP Technologies Inc.
+-0:e:10	PRIVATE
+-0:e:11	BDT Büro- und Datentechnik GmbH & Co. KG
++0:e0:f	SHANGHAI BAUD DATA
++0:e:10	C-guys, Inc.
++0:e:11	BDT B
+ 0:e:12	Adaptive Micro Systems Inc.
+ 0:e:13	Accu-Sort Systems inc.
+ 0:e:14	Visionary Solutions, Inc.
+ 0:e:15	Tadlys LTD
+-0:e:16	SouthWing
++0:e:16	SouthWing S.L.
+ 0:e:17	PRIVATE
+ 0:e:18	MyA Technology
+ 0:e:19	LogicaCMG Pty Ltd
+ 0:e:1a	JPS Communications
++0:e:1	ASIP Technologies Inc.
+ 0:e:1b	IAV GmbH
+ 0:e:1c	Hach Company
+ 0:e:1d	ARION Technology Inc.
+-0:e:1e	PRIVATE
++0:e:1e	NetXen, Inc.
+ 0:e:1f	TCL Networks Equipment Co., Ltd.
+-0:e:2	Advantech AMT Inc.
+-0:e:20	PalmSource, Inc.
++0:e:20	ACCESS Systems Americas, Inc.
+ 0:e:21	MTU Friedrichshafen GmbH
+ 0:e:22	PRIVATE
+ 0:e:23	Incipient, Inc.
+@@ -8771,15 +12122,15 @@
+ 0:e:27	Crere Networks, Inc.
+ 0:e:28	Dynamic Ratings P/L
+ 0:e:29	Shester Communications Inc
++0:e:2	Advantech AMT Inc.
+ 0:e:2a	PRIVATE
+ 0:e:2b	Safari Technologies
+ 0:e:2c	Netcodec co.
+ 0:e:2d	Hyundai Digital Technology Co.,Ltd.
+ 0:e:2e	Edimax Technology Co., Ltd.
+ 0:e:2f	Disetronic Medical Systems AG
+-0:e:3	Aarohi Communications, Inc.
+ 0:e:30	AERAS Networks, Inc.
+-0:e:31	Olympus BioSystems GmbH
++0:e:31	Olympus Soft Imaging Solutions GmbH
+ 0:e:32	Kontron Medical
+ 0:e:33	Shuko Electronics Co.,Ltd
+ 0:e:34	NexGen City, LP
+@@ -8790,11 +12141,11 @@
+ 0:e:39	Cisco Systems
+ 0:e:3a	Cirrus Logic
+ 0:e:3b	Hawking Technologies, Inc.
+-0:e:3c	TransAct Technoloiges Inc.
++0:e:3c	Transact Technologies Inc
+ 0:e:3d	Televic N.V.
++0:e:3	Emulex
+ 0:e:3e	Sun Optronics Inc
+ 0:e:3f	Soronti, Inc.
+-0:e:4	CMA/Microdialysis AB
+ 0:e:40	Nortel Networks
+ 0:e:41	NIHON MECHATRONICS CO.,LTD.
+ 0:e:42	Motic Incoporation Ltd.
+@@ -8808,17 +12159,17 @@
+ 0:e:4a	Changchun Huayu WEBPAD Co.,LTD
+ 0:e:4b	atrium c and i
+ 0:e:4c	Bermai Inc.
++0:e:4	CMA/Microdialysis AB
+ 0:e:4d	Numesa Inc.
+ 0:e:4e	Waveplus Technology Co., Ltd.
+ 0:e:4f	Trajet GmbH
+-0:e:5	WIRELESS MATRIX CORP.
+ 0:e:50	Thomson Telecom Belgium
+ 0:e:51	tecna elettronica srl
+ 0:e:52	Optium Corporation
+ 0:e:53	AV TECH CORPORATION
+ 0:e:54	AlphaCell Wireless Ltd.
+ 0:e:55	AUVITRAN
+-0:e:56	4G Systems GmbH
++0:e:56	4G Systems GmbH & Co. KG
+ 0:e:57	Iworld Networking, Inc.
+ 0:e:58	Sonos, Inc.
+ 0:e:59	SAGEM SA
+@@ -8826,9 +12177,9 @@
+ 0:e:5b	ParkerVision - Direct2Data
+ 0:e:5c	Motorola BCS
+ 0:e:5d	Triple Play Technologies A/S
+-0:e:5e	Beijing Raisecom Science & Technology Development Co.,Ltd
++0:e:5e	Raisecom Technology
+ 0:e:5f	activ-net GmbH & Co. KG
+-0:e:6	Team Simoco Ltd
++0:e:5	WIRELESS MATRIX CORP.
+ 0:e:60	360SUN Digital Broadband Corporation
+ 0:e:61	MICROTROL LIMITED
+ 0:e:62	Nortel Networks
+@@ -8839,13 +12190,14 @@
+ 0:e:67	Eltis Microelectronics Ltd.
+ 0:e:68	E-TOP Network Technology Inc.
+ 0:e:69	China Electric Power Research Institute
+-0:e:6a	3COM EUROPE LTD
++0:e:6a	3Com Ltd
+ 0:e:6b	Janitza electronics GmbH
+ 0:e:6c	Device Drivers Limited
++0:e6:d3	NIXDORF COMPUTER CORP.
+ 0:e:6d	Murata Manufacturing Co., Ltd.
+ 0:e:6e	MICRELEC  ELECTRONICS S.A
+ 0:e:6f	IRIS Corporation Berhad
+-0:e:7	Sony Ericsson Mobile Communications AB
++0:e:6	Team Simoco Ltd
+ 0:e:70	in2 Networks
+ 0:e:71	Gemstar Technology Development Ltd.
+ 0:e:72	CTS electronics
+@@ -8860,9 +12212,9 @@
+ 0:e:7b	Toshiba
+ 0:e:7c	Televes S.A.
+ 0:e:7d	Electronics Line 3000 Ltd.
+-0:e:7e	Comprog Oy
++0:e:7e	ionSign Oy
+ 0:e:7f	Hewlett Packard
+-0:e:8	Sipura Technology, Inc.
++0:e:7	Sony Ericsson Mobile Communications AB
+ 0:e:80	Thomson Technology Inc
+ 0:e:81	Devicescape Software, Inc.
+ 0:e:82	Commtech Wireless
+@@ -8875,15 +12227,15 @@
+ 0:e:89	CLEMATIC
+ 0:e:8a	Avara Technologies Pty. Ltd.
+ 0:e:8b	Astarte Technology Co, Ltd.
++0:e:8	Cisco Linksys LLC
+ 0:e:8c	Siemens AG A&D ET
+ 0:e:8d	Systems in Progress Holding GmbH
+ 0:e:8e	SparkLAN Communications, Inc.
+ 0:e:8f	Sercomm Corp.
+-0:e:9	Shenzhen Coship Software Co.,LTD.
+ 0:e:90	PONICO CORP.
+-0:e:91	Northstar Technologies
++0:e:91	Navico Auckland Ltd
+ 0:e:92	Millinet Co., Ltd.
+-0:e:93	Milénio 3 Sistemas Electrónicos, Lda.
++0:e:93	Mil
+ 0:e:94	Maas International BV
+ 0:e:95	Fujiya Denki Seisakusho Co.,Ltd.
+ 0:e:96	Cubic Defense Applications, Inc.
+@@ -8893,31 +12245,31 @@
+ 0:e:9a	BOE TECHNOLOGY GROUP CO.,LTD
+ 0:e:9b	Ambit Microsystems Corporation
+ 0:e:9c	Pemstar
+-0:e:9d	Video Networks Ltd
++0:e:9d	Tiscali UK Ltd
+ 0:e:9e	Topfield Co., Ltd
+ 0:e:9f	TEMIC SDS GmbH
+-0:e:a	SAKUMA DESIGN OFFICE
++0:e:9	Shenzhen Coship Software Co.,LTD.
+ 0:e:a0	NetKlass Technology Inc.
+ 0:e:a1	Formosa Teletek Corporation
+-0:e:a2	CyberGuard Corporation
++0:e:a2	McAfee, Inc
+ 0:e:a3	CNCR-IT CO.,LTD,HangZhou P.R.CHINA
+ 0:e:a4	Certance Inc.
+ 0:e:a5	BLIP Systems
+ 0:e:a6	ASUSTEK COMPUTER INC.
+-0:e:a7	Endace Inc Ltd.
++0:e:a7	Endace Technology
+ 0:e:a8	United Technologists Europe Limited
+ 0:e:a9	Shanghai Xun Shi Communications Equipment Ltd. Co.
+ 0:e:aa	Scalent Systems, Inc.
+-0:e:ab	OctigaBay Systems Corporation
++0:e:ab	Cray Inc
+ 0:e:ac	MINTRON ENTERPRISE CO., LTD.
+ 0:e:ad	Metanoia Technologies, Inc.
+ 0:e:ae	GAWELL TECHNOLOGIES CORP.
+ 0:e:af	CASTEL
+-0:e:b	Netac Technology Co., Ltd.
++0:e:a	SAKUMA DESIGN OFFICE
+ 0:e:b0	Solutions Radio BV
+ 0:e:b1	Newcotech,Ltd
+ 0:e:b2	Micro-Research Finland Oy
+-0:e:b3	LeftHand Networks
++0:e:b3	Hewlett-Packard
+ 0:e:b4	GUANGZHOU GAOKE COMMUNICATIONS TECHNOLOGY CO.LTD.
+ 0:e:b5	Ecastle Electronics Co., Ltd.
+ 0:e:b6	Riverbed Technology, Inc.
+@@ -8926,11 +12278,11 @@
+ 0:e:b9	HASHIMOTO Electronics Industry Co.,Ltd.
+ 0:e:ba	HANMI SEMICONDUCTOR CO., LTD.
+ 0:e:bb	Everbee Networks
+-0:e:bc	Cullmann GmbH
++0:e:bc	Paragon Fidelity GmbH
+ 0:e:bd	Burdick, a Quinton Compny
+ 0:e:be	B&B Electronics Manufacturing Co.
+ 0:e:bf	Remsdaq Limited
+-0:e:c	Intel Corporation
++0:e:b	Netac Technology Co., Ltd.
+ 0:e:c0	Nortel Networks
+ 0:e:c1	MYNAH Technologies
+ 0:e:c2	Lowrance Electronics, Inc.
+@@ -8943,11 +12295,11 @@
+ 0:e:c9	YOKO Technology Corp.
+ 0:e:ca	WTSS Inc
+ 0:e:cb	VineSys Technology
+-0:e:cc	Tableau
++0:e:cc	Tableau, LLC
+ 0:e:cd	SKOV A/S
+ 0:e:ce	S.I.T.T.I. S.p.A.
+ 0:e:cf	PROFIBUS Nutzerorganisation e.V.
+-0:e:d	HESCH Schröder GmbH
++0:e:c	Intel Corporation
+ 0:e:d0	Privaris, Inc.
+ 0:e:d1	Osaka Micro Computer.
+ 0:e:d2	Filtronic plc
+@@ -8964,7 +12316,7 @@
+ 0:e:dd	SHURE INCORPORATED
+ 0:e:de	REMEC, Inc.
+ 0:e:df	PLX Technology
+-0:e:e	ESA elettronica S.P.A.
++0:e:d	HESCH Schr
+ 0:e:e0	Mcharge
+ 0:e:e1	ExtremeSpeed Inc.
+ 0:e:e2	Custom Engineering S.p.A.
+@@ -8980,13 +12332,13 @@
+ 0:e:ec	Orban
+ 0:e:ed	Nokia Danmark A/S
+ 0:e:ee	Muco Industrie BV
++0:e:e	ESA elettronica S.P.A.
+ 0:e:ef	PRIVATE
+-0:e:f	ERMME
+ 0:e:f0	Festo AG & Co. KG
+ 0:e:f1	EZQUEST INC.
+ 0:e:f2	Infinico Corporation
+ 0:e:f3	Smarthome
+-0:e:f4	Shenzhen Kasda Digital Technology Co.,Ltd
++0:e:f4	Kasda Digital Technology Co.,Ltd
+ 0:e:f5	iPAC Technology Co., Ltd.
+ 0:e:f6	E-TEN Information Systems Co., Ltd.
+ 0:e:f7	Vulcan Portals Inc
+@@ -8995,28 +12347,28 @@
+ 0:e:fa	Optoway Technology Incorporation
+ 0:e:fb	Macey Enterprises
+ 0:e:fc	JTAG Technologies B.V.
+-0:e:fd	FUJI PHOTO OPTICAL CO., LTD.
++0:e:fd	FUJINON CORPORATION
+ 0:e:fe	EndRun Technologies LLC
++0:e:f	ERMME
+ 0:e:ff	Megasolution,Inc.
+ 0:f:0	Legra Systems, Inc.
+-0:f:1	DIGITALKS INC
+ 0:f:10	RDM Corporation
+ 0:f:11	Prodrive B.V.
+-0:f:12	Panasonic AVC Networks Germany GmbH
++0:f:12	Panasonic Europe Ltd.
+ 0:f:13	Nisca corporation
+ 0:f:14	Mindray Co., Ltd.
+ 0:f:15	Kjaerulff1 A/S
+ 0:f:16	JAY HOW TECHNOLOGY CO.,
+ 0:f:17	Insta Elektro GmbH
+ 0:f:18	Industrial Control Systems
+-0:f:19	Guidant Corporation
++0:f:19	Boston Scientific
+ 0:f:1a	Gaming Support B.V.
+ 0:f:1b	Ego Systems Inc.
+ 0:f:1c	DigitAll World Co., Ltd
+ 0:f:1d	Cosmo Techs Co., Ltd.
++0:f:1	DIGITALKS INC
+ 0:f:1e	Chengdu KT Electric Co.of High & New Technology
+ 0:f:1f	WW PCBA Test
+-0:f:2	Digicube Technology Co., Ltd
+ 0:f:20	Hewlett Packard
+ 0:f:21	Scientific Atlanta, Inc
+ 0:f:22	Helius, Inc.
+@@ -9031,11 +12383,11 @@
+ 0:f:2b	GREENBELL SYSTEMS
+ 0:f:2c	Uplogix, Inc.
+ 0:f:2d	CHUNG-HSIN ELECTRIC & MACHINERY MFG.CORP.
++0:f:2	Digicube Technology Co., Ltd
+ 0:f:2e	Megapower International Corp.
+ 0:f:2f	W-LINX TECHNOLOGY CO., LTD.
+-0:f:3	COM&C CO., LTD
+ 0:f:30	Raza Microelectronics Inc
+-0:f:31	Prosilica
++0:f:31	Allied Vision Technologies Canada Inc
+ 0:f:32	LuTong Electronic Technology Co.,Ltd
+ 0:f:33	DUALi Inc.
+ 0:f:34	Cisco Systems
+@@ -9047,10 +12399,10 @@
+ 0:f:3a	HISHARP
+ 0:f:3b	Fuji System Machines Co., Ltd.
+ 0:f:3c	Endeleo Limited
++0:f:3	COM&C CO., LTD
+ 0:f:3d	D-Link Corporation
+ 0:f:3e	CardioNet, Inc
+ 0:f:3f	Big Bear Networks
+-0:f:4	cim-usa inc
+ 0:f:40	Optical Internetworking Forum
+ 0:f:41	Zipher Ltd
+ 0:f:42	Xalyo Systems
+@@ -9062,16 +12414,17 @@
+ 0:f:48	Polypix Inc.
+ 0:f:49	Northover Solutions Limited
+ 0:f:4a	Kyushu-kyohan co.,ltd
+-0:f:4b	Katana Technology
++0:f:4b	Virtual Iron Software, Inc.
+ 0:f:4c	Elextech INC
+-0:f:4d	Centrepoint Technologies Inc.
++0:f:4	cim-usa inc
++0:f:4d	TalkSwitch
+ 0:f:4e	Cellink
+ 0:f:4f	Cadmus Technology Ltd
+-0:f:5	3B SYSTEM INC.
+-0:f:50	Baxall Limited
++0:f:50	StreamScale Limited
+ 0:f:51	Azul Systems, Inc.
+ 0:f:52	YORK Refrigeration, Marine & Controls
+-0:f:53	Level 5 Networks, Inc.
++0:f:5	3B SYSTEM INC.
++0:f:53	Solarflare Communications Inc
+ 0:f:54	Entrelogic Corporation
+ 0:f:55	Datawire Communication Networks Inc.
+ 0:f:56	Continuum Photonics Inc
+@@ -9084,9 +12437,8 @@
+ 0:f:5d	42Networks AB
+ 0:f:5e	Veo
+ 0:f:5f	Nicety Technologies Inc. (NTS)
+-0:f:6	Nortel Networks
+ 0:f:60	Lifetron Co.,Ltd
+-0:f:61	Kiwi Networks
++0:f:61	Hewlett Packard
+ 0:f:62	Alcatel Bell Space N.V.
+ 0:f:63	Obzerv Technologies
+ 0:f:64	D&R Electronica Weesp BV
+@@ -9101,11 +12453,11 @@
+ 0:f:6d	Midas Engineering
+ 0:f:6e	BBox
+ 0:f:6f	FTA Communication Technologies
+-0:f:7	Mangrove Systems, Inc.
++0:f:6	Nortel Networks
+ 0:f:70	Wintec Industries, inc.
+ 0:f:71	Sanmei Electronics Co.,Ltd
+ 0:f:72	Sandburst
+-0:f:73	Rockwell Samsung Automation
++0:f:73	RS Automation Co., Ltd
+ 0:f:74	Qamcom Technology AB
+ 0:f:75	First Silicon Solutions
+ 0:f:76	Digital Keystone, Inc.
+@@ -9116,15 +12468,16 @@
+ 0:f:7b	Arce Sistemas, S.A.
+ 0:f:7c	ACTi Corporation
+ 0:f:7d	Xirrus
+-0:f:7e	UIS Abler Electronics Co.,Ltd.
++0:f:7e	Ablerex Electronics Co., LTD
+ 0:f:7f	UBSTORAGE Co.,Ltd.
+-0:f:8	Indagon Oy
++0:f:7	Mangrove Systems, Inc.
+ 0:f:80	Trinity Security Systems,Inc.
+ 0:f:81	Secure Info Imaging
+ 0:f:82	Mortara Instrument, Inc.
+ 0:f:83	Brainium Technologies Inc.
+ 0:f:84	Astute Networks, Inc.
+ 0:f:85	ADDO-Japan Corporation
++0:f8:60	PT. Panggung Electric Citrabuana
+ 0:f:86	Research In Motion Limited
+ 0:f:87	Maxcess International
+ 0:f:88	AMETEK, Inc.
+@@ -9135,7 +12488,7 @@
+ 0:f:8d	FAST TV-Server AG
+ 0:f:8e	DONGYANG TELECOM CO.,LTD.
+ 0:f:8f	Cisco Systems
+-0:f:9	PRIVATE
++0:f:8	Indagon Oy
+ 0:f:90	Cisco Systems
+ 0:f:91	Aerotelecom Co.,Ltd.
+ 0:f:92	Microhard Systems Inc.
+@@ -9149,10 +12502,10 @@
+ 0:f:9a	Synchrony, Inc.
+ 0:f:9b	Ross Video Limited
+ 0:f:9c	Panduit Corp
+-0:f:9d	Newnham Research Ltd
++0:f:9d	DisplayLink (UK) Ltd
+ 0:f:9e	Murrelektronik GmbH
+ 0:f:9f	Motorola BCS
+-0:f:a	Clear Edge Networks
++0:f:9	PRIVATE
+ 0:f:a0	CANON KOREA BUSINESS SOLUTIONS INC.
+ 0:f:a1	Gigabit Systems Inc.
+ 0:f:a2	Digital Path Networks
+@@ -9166,10 +12519,10 @@
+ 0:f:aa	Nexus Technologies
+ 0:f:ab	Kyushu Electronics Systems Inc.
+ 0:f:ac	IEEE 802.11
++0:f:a	Clear Edge Networks
+ 0:f:ad	FMN communications GmbH
+ 0:f:ae	E2O Communications
+ 0:f:af	Dialog Inc.
+-0:f:b	Kentima Technologies AB
+ 0:f:b0	Compal Electronics,INC.
+ 0:f:b1	Cognio Inc.
+ 0:f:b2	Broadband Pacenet (India) Pvt. Ltd.
+@@ -9181,12 +12534,12 @@
+ 0:f:b8	CallURL Inc.
+ 0:f:b9	Adaptive Instruments
+ 0:f:ba	Tevebox AB
+-0:f:bb	Siemens AG, ICN M&L TDC EP
++0:f:bb	Nokia Siemens Networks GmbH & Co. KG
+ 0:f:bc	Onkey Technologies, Inc.
+ 0:f:bd	MRV Communications (Networks) LTD
+ 0:f:be	e-w/you Inc.
+ 0:f:bf	DGT Sp. z o.o.
+-0:f:c	SYNCHRONIC ENGINEERING
++0:f:b	Kentima Technologies AB
+ 0:f:c0	DELCOMp
+ 0:f:c1	WAVE Corporation
+ 0:f:c2	Uniwell Corporation
+@@ -9198,12 +12551,12 @@
+ 0:f:c8	Chantry Networks
+ 0:f:c9	Allnet GmbH
+ 0:f:ca	A-JIN TECHLINE CO, LTD
+-0:f:cb	3COM EUROPE LTD
++0:f:cb	3Com Ltd
+ 0:f:cc	Netopia, Inc.
+ 0:f:cd	Nortel Networks
+ 0:f:ce	Kikusui Electronics Corp.
+ 0:f:cf	Datawind Research
+-0:f:d	Hunt Electronic Co., Ltd.
++0:f:c	SYNCHRONIC ENGINEERING
+ 0:f:d0	ASTRI
+ 0:f:d1	Applied Wireless Identifications Group, Inc.
+ 0:f:d2	EWA Technologies, Inc.
+@@ -9220,10 +12573,10 @@
+ 0:f:dd	SORDIN AB
+ 0:f:de	Sony Ericsson Mobile Communications AB
+ 0:f:df	SOLOMON Technology Corp.
+-0:f:e	WaveSplitter Technologies, Inc.
++0:f:d	Hunt Electronic Co., Ltd.
+ 0:f:e0	NComputing Co.,Ltd.
+ 0:f:e1	ID DIGITAL CORPORATION
+-0:f:e2	Hangzhou Huawei-3Com Tech. Co., Ltd.
++0:f:e2	Hangzhou H3C Technologies Co., Ltd.
+ 0:f:e3	Damm Cellular Systems A/S
+ 0:f:e4	Pantech Co.,Ltd
+ 0:f:e5	MERCURY SECURITY CORPORATION
+@@ -9237,8 +12590,8 @@
+ 0:f:ed	Anam Electronics Co., Ltd
+ 0:f:ee	XTec, Incorporated
+ 0:f:ef	Thales e-Transactions GmbH
+-0:f:f	Real ID Technology Co., Ltd.
+-0:f:f0	Sunray Enterprise
++0:f:e	WaveSplitter Technologies, Inc.
++0:f:f0	Sunray Co. Ltd.
+ 0:f:f1	nex-G Systems Pte.Ltd
+ 0:f:f2	Loud Technologies Inc.
+ 0:f:f3	Jung Myoung Communications&Technology
+@@ -9254,44 +12607,653 @@
+ 0:f:fd	Glorytek Network Inc.
+ 0:f:fe	G-PRO COMPUTER
+ 0:f:ff	Control4
++0:f:f	Real ID Technology Co., Ltd.
+ 10:0:0	PRIVATE
+ 10:0:5a	IBM CORPORATION
+ 10:0:e8	NATIONAL SEMICONDUCTOR
++10:10:b6	McCain Inc
++10:18:9e	Elmo Motion Control
++10:1d:c0	Samsung Electronics Co.,Ltd
++10:2d:96	Looxcie Inc.
++10:2e:af	Texas Instruments
++10:43:69	Soundmax Electronic Limited 
++10:44:5a	Shaanxi Hitech Electronic Co., LTD
++10:45:f8	LNT-Automation GmbH
++10:56:ca	Peplink International Ltd.
++10:62:c9	Adatis GmbH & Co. KG
++10:65:a3	Panamax Inc.
++10:78:d2	ELITEGROUP COMPUTER SYSTEM CO., LTD.
++10:88:f	DARUMA TELECOMUNICA
++10:9:c	Janome Sewing Machine Co., Ltd.
++10:a1:3b	FUJIKURA RUBBER LTD.
++10:b7:f6	Plastoform Industries Ltd.
++10:ba:a5	GANA I&C CO., LTD
++10:c:24	pomdevices, LLC
++10:c7:3f	Midas Klark Teknik Ltd
++10:ca:81	PRECIA
++10:cc:db	AXIMUM PRODUITS ELECTRONIQUES
++10:d:32	Embedian, Inc.
++10:e:2b	NEC CASIO Mobile Communications
++10:e6:ae	Source Technologies, LLC
++10:e8:ee	PhaseSpace
+ 11:0:aa	PRIVATE
++14:1b:bd	Volex, Inc.
++14:54:12	Entis Co., Ltd.
++14:6e:a	PRIVATE
++14:73:73	TUBITAK UEKAE
++14:a6:2c	S.M. Dezac S.A.
++14:a8:6b	ShenZhen Telacom Science&Technology Co., Ltd
++14:d7:6e	CONCH ELECTRONIC Co.,Ltd
++14:ee:9d	AirNav Systems LLC
++14:fe:af	SAGITTAR LIMITED
++18:14:56	Nokia Corporation
++18:17:14	DAEWOOIS
++18:1:e3	Elektrobit Wireless Communications Ltd
++18:3b:d2	BYD Precision Manufacture Company Ltd.
++18:3d:a2	Intel Corporate
++18:42:2f	Alcatel Lucent
++18:6:75	DILAX Intelcom GmbH
++18:80:ce	Barberry Solutions Ltd
++18:80:f5	Alcatel-Lucent Shanghai Bell Co., Ltd 
++18:86:ac	Nokia Danmark A/S
++18:8e:d5	Philips Innovative Application NV 
++18:92:2c	Virtual Instruments
++18:a9:5	Hewlett Packard
++18:b2:9	Torrey Pines Logic, Inc
++18:c0:86	Broadcom Corporation
++18:c:77	Westinghouse Electric Company, LLC
++18:e7:f4	Apple
++18:ef:63	Cisco Systems
++18:f4:6a	Hon Hai Precision Ind. Co.,Ltd.
++18:fc:9f	Changhe Electronics Co., Ltd.
++1c:12:9d	IEEE PES PSRC/SUB     
++1c:17:d3	Cisco Systems
++1c:3a:4f	AccuSpec Electronics, LLC
++1c:3d:e7	Sigma Koki Co.,Ltd.
++1c:4b:d6	AzureWave
++1c:6:56	IDY Corporation
++1c:65:9d	Liteon Technology Corporation
++1c:6f:65	GIGA-BYTE TECHNOLOGY CO.,LTD.
++1c:75:8	COMPAL INFORMATION (KUNSHAN) CO., LTD. 
++1c:7c:11	EID 
++1c:83:b0	Linked IP GmbH
++1c:8f:8a	Phase Motion Control SpA
++1c:af:f7	D-LINK INTERNATIONAL PTE LIMITED
++1c:bd:b9	D-LINK INTERNATIONAL PTE LIMITED
++1c:bd:e	Amplified Engineering Pty Ltd
++1c:c1:de	Hewlett Packard
++1c:df:f	Cisco Systems
++1c:f0:61	SCAPS GmbH
++1c:f:cf	Sypro Optics GmbH
++20:12:57	Most Lucky Trading Ltd
++20:21:a5	LG Electronics Inc
++20:2c:b7	Kong Yue Electronics & Information Industry (Xinhui) Ltd.
++20:41:5a	Smarteh d.o.o.
++20:46:f9	Advanced Network Devices (dba:AND)
++20:4e:6b	Axxana(israel) ltd
++20:59:a0	Paragon Technologies Inc.
++20:5:e8	OOO "InProMedia"
++20:6a:8a	Wistron InfoComm Manufacturing(Kunshan)Co.,Ltd.
++20:6a:ff	Atlas Elektronik UK Limited
++20:6f:ec	Braemac CA LLC
++20:7c:8f	Quanta Microsystems,Inc.
++20:a2:e7	Lee-Dickens Ltd
++20:aa:25	IP-NET LLC
++20:b0:f7	Enclustra GmbH
++20:bf:db	DVL
++20:cf:30	ASUSTek COMPUTER INC.
++20:d6:7	Nokia Corporation
++20:d9:6	Iota, Inc.
++20:fd:f1	3COM EUROPE LTD
++20:fe:db	M2M Solution S.A.S.
+ 2:1c:7c	PERQ SYSTEMS CORPORATION
++24:1f:2c	Calsys, Inc.
++24:21:ab	Sony Ericsson Mobile Communications
++24:3c:20	Dynamode Group
++24:45:97	GEMUE Gebr. Mueller Apparatebau
++24:82:8a	Prowave Technologies Ltd.
++24:a4:2c	KOUKAAM a.s.
++24:a9:37	PURE Storage
++24:af:4a	Alcatel-Lucent-IPD
++24:af:54	NEXGEN Mediatech Inc.
++24:b:2a	Viettel Group
++24:b6:b8	FRIEM SPA
++24:ba:30	Technical Consumer Products, Inc.
++24:bf:74	PRIVATE
++24:cf:21	Shenzhen State Micro Technology Co., Ltd
++24:d2:cc	SmartDrive Systems Inc.
++24:db:ad	ShopperTrak RCT Corporation
+ 2:60:86	LOGIC REPLACEMENT TECH. LTD.
+ 2:60:8c	3COM CORPORATION
+ 2:70:1	RACAL-DATACOM
+ 2:70:b0	M/A-COM INC. COMPANIES
+ 2:70:b3	DATA RECALL LTD
+ 2:7:1	RACAL-DATACOM
++28:48:46	GridCentric Inc.
++28:4c:53	Intune Networks
++28:6:1e	NINGBO GLOBAL USEFUL ELECTRIC CO.,LTD
++28:6:8d	ITL, LLC
++28:6e:d4	HUAWEI TECHNOLOGIES CO.,LTD
++28:72:c5	Smartmatic Corp
++28:89:15	CashGuard Sverige AB
++28:93:fe	Cisco Systems
++28:c0:da	Juniper Networks
++28:cd:4c	Individual Computers GmbH
++28:e7:94	Microtime Computer Inc.
++28:ed:58	JAG Jakob AG
++28:ef:1	PRIVATE
++28:fb:d3	Shanghai RagenTek Communication Technology Co.,Ltd.
+ 2:9d:8e	CARDIAC RECORDERS INC.
+ 2:aa:3c	OLIVETTI TELECOMM SPA (OLTECO)
+ 2:bb:1	OCTOTHORPE CORP.
+ 2:c0:8c	3COM CORPORATION
++2c:19:84	IDN Telecom, Inc.
++2c:30:68	Pantech Co.,Ltd
++2c:34:27	ERCO &amp; GENER
++2c:3a:28	Fagor Electrï¿½nica
++2c:3f:3e	Alge-Timing GmbH
++2c:6:23	Win Leader Inc.
++2c:6b:f5	Juniper networks
++2c:7a:fe	IEE&E "Black" ops
++2c:81:58	Hon Hai Precision Ind. Co.,Ltd
++2c:91:27	Eintechno Corporation
++2c:9e:5f	Motorola, Inc.
++2c:a7:80	True Technologies Inc.
++2c:a8:35	RIM
++2c:cd:27	Precor Inc
++2c:cd:43	Summit Technology Group
++2c:d1:da	Sanjole, Inc.
++2c:d2:e7	Nokia Corporation
++2c:dd:c	Discovergy GmbH
+ 2:cf:1c	COMMUNICATION MACHINERY CORP.
+ 2:e6:d3	NIXDORF COMPUTER CORPORATION
++30:18:cf	DEOS control systems GmbH
++30:32:d4	Hanilstm Co., Ltd.
++30:37:a6	Cisco Systems
++30:38:55	Nokia Corporation
++30:41:74	ALTEC LANSING LLC
++30:46:9a	NETGEAR
++30:49:3b	Nanjing Z-Com Wireless Co.,Ltd
++30:52:5a	NST Co., LTD
++30:69:4b	RIM
++30:7c:30	RIM
++30:87:30	Huawei Device Co., Ltd
++30:e4:8e	Vodafone UK
++30:ef:d1	Alstom Strongwish (Shenzhen) Co., Ltd.
++34:15:9e	Apple, Inc
++34:21:9	Jensen Scandinavia AS
++34:78:77	O-NET Communications(Shenzhen) Limited
++34:7e:39	Nokia Danmark A/S
++34:83:2	iForcom Co., Ltd
++34:86:2a	Heinz Lackmann GmbH & Co KG
++34:9a:d	ZBD Displays Ltd
++34:a1:83	AWare, Inc
++34:aa:ee	Mikrovisatos Servisas UAB
++34:ba:51	Se-Kure Controls, Inc.
++34:c3:ac	Samsung Electronics
++34:c6:9a	Enecsys Ltd
++34:ce:94	Parsec (Pty) Ltd
++34:d2:c4	RENA GmbH Print Systeme
++34:df:2a	Fujikon Industrial Co.,Limited
++34:e0:d7	DONGGUAN QISHENG ELECTRONICS INDUSTRIAL CO., LTD
++34:ef:44	2Wire
++34:ef:8b	NTT Communications Corporation
++34:f3:9b	WizLAN Ltd.
++34:f9:68	ATEK Products, LLC
++38:1:97	Toshiba Samsung Storage Technolgoy Korea Corporation
++38:22:9d	PIRELLI BROADBAND SOLUTIONS 
++38:52:1a	Alcatel-Lucent 7705
++38:58:c	Panaccess Systems GmbH
++38:5f:c3	Yu Jeong System, Co.Ltd
++38:63:f6	3NOD MULTIMEDIA(SHENZHEN)CO.,LTD
++38:95:92	Beijing Tendyron Corporation
++38:9f:83	OTN Systems N.V.
++38:a9:5f	Actifio Inc
++38:a:a	Sky-City Communication and Electronics Limited Company
++38:bb:23	OzVision America LLC
++38:c7:ba	CS Services Co.,Ltd.
++38:c8:5c	Cisco SPVTG
++38:d:d4	Primax Electronics LTD.
++38:e7:d8	HTC Corporation
++38:e8:df	b gmbh medien + datenbanken
++38:e9:8c	Reco S.p.A.
++3c:10:6f	ALBAHITH TECHNOLOGIES 
++3c:19:15	GFI Chrono Time
++3c:1a:79	Huayuan Technology CO.,LTD
++3c:1c:be	JADAK LLC
++3c:2d:b7	Texas Instruments
++3c:2f:3a	SFORZATO Corp.
++3c:39:c3	JW Electronics Co., Ltd.
++3c:4:bf	PRAVIS SYSTEMS Co.Ltd., 
++3c:4c:69	Infinity System S.L.
++3c:5:ab	Product Creation Studio
++3c:5f:1	Synerchip Co., Ltd.
++3c:62:78	SHENZHEN JETNET TECHNOLOGY CO.,LTD.
++3c:75:4a	Motorola CHS
++3c:99:f7	Lansentechnology AB
++3c:b1:7f	Wattwatchers Pty Ld
++3c:df:1e	Cisco Systems
++3c:e5:a6	Hangzhou H3C Technologies Co., Ltd.
++3c:ea:4f	2Wire
++3c:f5:2c	DSPECIALISTS GmbH
++3c:f7:2a	Nokia Corporation
++40:12:e4	Compass-EOS
++40:13:d9	Global ES
++40:15:97	Protect America, Inc.
++40:18:d7	Wyle Telemetry and Data Systems
++40:1:c6	3COM EUROPE LTD
++40:1d:59	Biometric Associates, LP
++40:25:c2	Intel Corporate
++40:2b:a1	Sony Ericsson Mobile Communications AB
++40:37:ad	Macro Image Technology, Inc.
++40:40:22	ZIV
++40:40:6b	Icomera
++40:4a:3	ZyXEL Communications Corporation
++40:52:d	Pico Technology
++40:5f:be	RIM
++40:61:86	MICRO-STAR INT'L CO.,LTD
++40:61:8e	Hort-Plan
++40:83:de	Motorola
++40:84:93	Clavister AB
++40:8a:9a	TITENG CO., Ltd.
++40:95:58	Aisino Corporation
++40:97:d1	BK Electronics cc
++40:a6:a4	PassivSystems Ltd
++40:b2:c8	Nortel Networks
++40:c2:45	Shenzhen Hexicom Technology Co., Ltd.
++40:c7:c9	Naviit Inc.
++40:cd:3a	Z3 Technology
++40:d3:2d	Apple, Inc
++40:d4:e	Biodata Ltd
++40:ec:f8	Siemens AG
++40:ef:4c	Fihonest communication co.,Ltd
++40:f5:2e	Leica Microsystems (Schweiz) AG
++4:1e:64	Apple, Inc
++4:22:34	Wireless Standard Extensions
++4:2b:bb	PicoCELA, Inc.
++4:2f:56	ATOCS (Shenzhen) LTD
++4:36:4	Gyeyoung I&T
++44:37:6f	Young Electric Sign Co
++44:37:e6	Hon Hai Precision Ind.Co.Ltd
++44:3d:21	Nuvolt
++44:4e:1a	Samsung Electronics Co.,Ltd
++44:51:db	Raytheon BBN Technologies
++44:54:c0	Thompson Aerospace
++44:56:8d	PNC Technologies  Co., Ltd.
++44:56:b7	Spawn Labs, Inc
++44:58:29	Cisco SPVTG
++44:59:9f	Criticare Systems, Inc
++44:5e:f3	Tonalite Holding B.V.
++44:61:32	ecobee inc
++44:6c:24	Reallin Electronic Co.,Ltd
++44:7c:7f	Innolight Technology Corporation
++44:83:12	Star-Net
++44:85:0	Intel Corporation
++44:87:fc	ELITEGROUP COMPUTER SYSTEM CO., LTD.
++44:8c:52	KTIS CO., Ltd
++44:8e:81	VIG
++44:91:db	Shanghai Huaqin Telecom Technology Co.,Ltd
++44:a4:2d	TCT Mobile Limited
++44:a6:89	PROMAX ELECTRONICA SA
++44:a8:c2	SEWOO TECH CO., LTD
++44:c2:33	Guangzhou Comet Technology Development Co.Ltd
++44:c9:a2	Greenwald Industries
++44:d6:3d	Talari Networks
++44:e4:9a	OMNITRONICS PTY LTD
++44:ed:57	Longicorn, inc.
++44:f4:59	Samsung Electronics
++4:4f:aa	Ruckus Wireless
++4:5d:56	camtron industrial inc.
++4:75:f5	CSST
++4:76:6e	ALPS Co,. Ltd.
++48:12:49	Luxcom Technologies Inc.
++48:17:4c	MicroPower technologies
++48:1b:d2	Intron Scientific co., ltd.
++48:2c:ea	Motorola Inc Business Light Radios
++48:34:3d	IEP GmbH
++48:44:87	Cisco SPVTG
++48:5b:39	ASUSTek COMPUTER INC.
++48:5d:60	Azurewave Technologies, Inc.
++48:6b:91	Fleetwood Group Inc.
++48:6f:d2	StorSimple Inc
++48:71:19	SGB GROUP LTD.
++48:91:f6	Shenzhen Reach software technology CO.,LTD
++4:8a:15	Avaya, Inc
++48:aa:5d	Store Electronic Systems
++48:c8:b6	SysTec GmbH
++48:eb:30	ETERNA TECHNOLOGY, INC.
++48:f8:e1	Alcatel Lucent WT
++48:fc:b8	Woodstream Corporation
++4:94:a1	CATCH THE WIND INC
++4:9f:81	Simena, LLC
++4:a3:f3	Emicon
+ 4:a:e0	XMIT AG COMPUTER NETWORKS
++4:b3:b6	Seamap (UK) Ltd
++4:b4:66	BSP Co., Ltd.
++4:c0:5b	Tigo Energy
++4c:2:2e	CMR KOREA CO., LTD
++4c:2c:80	Beijing Skyway Technologies Co.,Ltd 
++4c:30:89	Thales Rail Signalling Solutions GmbH
++4c:32:2d	TELEDATA NETWORKS
++4c:4b:68	Mobile Device, Inc. 
++4c:54:99	Huawei Device Co., Ltd
++4c:5d:cd	Oy Finnish Electric Vehicle Technologies Ltd
++4c:60:d5	airPointe of New Hampshire
++4c:63:eb	Application Solutions (Electronics and Vision) Ltd
++4:c8:80	Samtec Inc
++4c:8b:55	Grupo Digicon
++4c:9e:e4	Hanyang Navicom Co.,Ltd.
++4c:ba:a3	Bison Electronics Inc.
++4c:c4:52	Shang Hai Tyd. Electon Technology Ltd.
++4c:c6:2	Radios, Inc.
++4c:e6:76	BUFFALO INC.
++4c:f:6e	Hon Hai Precision Ind. Co.,Ltd. 
++4c:f7:37	SamJi Electronics Co., Ltd
++4:dd:4c	IPBlaze
+ 4:e0:c4	TRIUMPH-ADLER AG
++4:e5:48	Cohda Wireless Pty Ltd
++4:e:c2	ViewSonic Mobile China Limited
++4:fe:7f	Cisco Systems
++50:25:2b	Nethra Imaging Incorporated
++50:2a:7e	Smart electronic GmbH
++50:2a:8b	Telekom Research and Development Sdn Bhd
++50:2d:a2	Intel Corporate
++50:2d:f4	Phytec Messtechnik GmbH
++50:63:13	Hon Hai Precision Ind. Co.,Ltd. 
++50:67:f0	ZyXEL Communications Corporation
++50:6f:9a	Wi-Fi Alliance
++50:7d:2	BIODIT
++50:93:4f	Gradual Tecnologia Ltda.
++50:a6:e3	David Clark Company
++50:c5:8d	Juniper Networks
++50:ce:75	Measy Electronics Ltd
++50:eb:1a	Brocade Communications Systems, Inc
++50:f0:3	Open Stack, Inc.
++54:31:31	Raster Vision Ltd
++54:3:f5	EBN Technology Corp.
++54:42:49	Sony Corporation
++54:4a:5	wenglor sensoric gmbh
++54:5f:a9	Teracom Limited
++54:75:d0	Cisco Systems
++54:7f:ee	Cisco Systems
++54:89:22	Zelfy Inc
++54:92:be	Samsung Electronics Co.,Ltd
++54:9a:16	Uzushio Electric Co.,Ltd.
++54:b6:20	SUHDOL E&C Co.Ltd.
++54:d4:6f	Cisco SPVTG
++54:fd:bf	Scheidt & Bachmann GmbH
++58:17:c	Sony Ericsson Mobile Communications AB
++58:3c:c6	Omneality Ltd.
++58:42:e4	Sigma International General Medical Apparatus, LLC.
++58:49:ba	Chitai Electronic Corp.
++58:4c:ee	Digital One Technologies, Limited
++58:50:76	Linear Equipamentos Eletronicos SA
++58:50:e6	Best Buy Corporation
++58:5:56	Elettronica GF S.r.L.
++58:55:ca	Apple
++58:57:d	Danfoss Solar Inverters
++58:67:1a	BARNES&NOBLE.COM
++58:6e:d6	PRIVATE
++58:8d:9	Cisco Systems
++58:94:6b	Intel Corporate
++58:a7:6f	iD corporation
++58:b0:35	Apple, Inc
++58:b9:e1	Crystalfontz America, Inc.
++58:bc:27	Cisco Systems
++58:d0:8f	IEEE 1904.1 Working Group
++58:db:8d	Fast Co., Ltd.
++58:e7:47	Deltanet AG
++58:f6:7b	Xia Men UnionCore Technology LTD.
++58:f6:bf	Kyoto University
++58:fd:20	Bravida Sakerhet AB
++5c:14:37	Thyssenkrupp Aufzugswerke GmbH
++5c:17:d3	LGE 
++5c:26:a	Dell Inc.
++5c:33:8e	Alpha Networkc Inc.
++5c:35:3b	Compal Broadband Networks Inc.
++5c:35:da	There Corporation Oy
++5c:40:58	Jefferson Audio Video Systems, Inc.
++5c:57:c8	Nokia Corporation
++5c:59:48	Apple
++5c:6d:20	Hon Hai Precision Ind. Co.,Ltd.
++5c:86:4a	Secret Labs LLC
++5c:87:78	Cybertelbridge co.,ltd
++5c:ac:4c	Hon Hai Precision Ind. Co.,Ltd.
++5c:ca:32	Theben AG
++5c:d1:35	Xtreme Power Systems
++5c:d9:98	D-Link Corporation
++5c:da:d4	Murata Manufacturing Co., Ltd.
++5c:e2:23	Delphin Technology AG
++5c:e2:86	Nortel Networks
++5c:e:8b	Motorola
++5c:ff:35	Wistron Corporation
++60:12:83	Soluciones Tecnologicas para la Salud y el Bienestar SA
++60:15:c7	IdaTech
++60:1d:f	Midnite Solar
++60:2a:54	CardioTek B.V.
++60:33:4b	Apple
++60:38:e	Alps Electric Co.,
++60:39:1f	ABB Ltd
++60:63:fd	Transcend Communication Beijing Co.,Ltd.
++60:83:b2	GkWare e.K.
++60:89:3c	Thermo Fisher Scientific P.O.A.
++60:89:b7	KAEL Mï¿½HENDISLIK ELEKTRONIK TICARET SANAYI Limited ï¿½irketi
++60:8d:17	Sentrus Government Systems Division, Inc
++60:9a:a4	GVI SECURITY INC.
++60:9f:9d	CloudSwitch
++60:b3:c4	Elber Srl
++60:d0:a9	Samsung Electronics Co.,Ltd
++60:d3:a	Quatius Limited
++60:eb:69	Quanta computer Inc.
++60:f1:3d	JABLOCOM s.r.o.
++60:fb:42	Apple, Inc
++64:10:84	HEXIUM Technical Development Co., Ltd.
++64:16:8d	Cisco Systems
++64:16:f0	Shehzhen Huawei Communication Technologies Co., Ltd.
++64:1e:81	Dowslake Microsystems
++64:31:50	Hewlett Packard
++64:31:7e	Dexin Corporation
++64:34:9	BITwave Pte Ltd
++64:4b:c3	Shanghai WOASiS Telecommunications Ltd., Co.
++64:4f:74	LENUS Co., Ltd.
++64:65:c0	Nuvon, Inc
++64:67:7	Beijing Omnific Technology, Ltd.
++64:68:c	COMTREND
++64:6e:6c	Radio Datacom LLC
++64:7b:d4	Texas Instruments
++64:7d:81	YOKOTA INDUSTRIAL CO,.LTD
++64:80:99	Intel Corporation
++64:87:d7	PIRELLI BROADBAND SOLUTIONS 
++64:99:5d	LGE 
++64:9b:24	V Technology Co., Ltd.
++64:9c:8e	Texas Instruments
++64:a2:32	OOO Samlight
++64:a8:37	Juni Korea Co., Ltd
++64:b9:e8	Apple, Inc
++64:bc:11	CombiQ AB
++64:c6:af	AXERRA Networks Ltd
++64:d0:2d	DRAYTEK FRANCE
++64:d4:da	Intel Corporate
++64:db:18	OpenPattern
++64:e8:e6	global moisture management system
++64:ed:57	Motorola MDb/Broadband
++64:f9:70	Kenade Electronics Technology Co.,LTD.
++64:fc:8c	Zonar Systems
++68:12:2d	Special Instrument Development Co., Ltd.
++68:1f:d8	Advanced Telemetry
++68:23:4b	Nihon Dengyo Kousaku
++68:4b:88	Galtronics Telemetry Inc.
++68:54:f5	enLighted Inc
++68:59:7f	Alcatel Lucent
++68:63:59	Advanced Digital Broadcast SA
++68:78:4c	Nortel Networks
++68:79:24	ELS-GmbH & Co. KG
++68:7f:74	Cisco-Linksys, LLC
++68:85:40	IGI Mobile, Inc.
++68:92:34	Ruckus Wireless
++68:a1:b7	Honghao Mingchuan Technology (Beijing) CO.,Ltd.
++68:aa:d2	DATECS LTD.,
++68:b5:99	Hewlett Packard
++68:bd:ab	Cisco Systems
++68:ca:0	Octopus Systems Limited
++68:cc:9c	Mine Site Technologies
++68:db:96	OPWILL Technologies CO .,LTD
++68:e4:1f	Unglaube Identech GmbH
++68:eb:ae	Samsung Electronics Co.,Ltd
++68:eb:c5	Angstrem Telecom
++68:ef:bd	Cisco Systems
++6c:18:11	Decatur Electronics
++6c:22:ab	Ainsworth Game Technology
++6c:23:b9	Sony Ericsson Mobile Communications AB
++6c:32:de	Indieon Technologies Pvt. Ltd.
++6c:3e:9c	KE Knestel Elektronik GmbH
++6c:4:60	RBH Access Technologies Inc.
++6c:50:4d	Cisco Systems
++6c:5c:de	SunReports, Inc.
++6c:5e:7a	Ubiquitous Internet Telecom Co., Ltd
++6c:62:6d	Micro-Star INT'L CO., LTD
++6c:6f:18	Stereotaxis, Inc.
++6c:70:39	Novar GmbH 
++6c:8c:db	Otus Technologies Ltd
++6c:8d:65	Wireless Glue Networks, Inc.
++6c:92:bf	Inspur Electronic Information Industry Co.,Ltd.
++6c:9b:2	Nokia Corporation
++6c:9c:e9	Nimble Storage
++6c:ac:60	Venetex Corp
++6c:be:e9	Alcatel-Lucent-IPD
++6c:d6:8a	LG Electronics Inc
++6c:dc:6a	Promethean Limited
++6c:e0:b0	SOUND4
++6c:e:d	Sony Ericsson Mobile Communications AB
++6c:f0:49	GIGA-BYTE TECHNOLOGY CO.,LTD.
++6c:f:6a	JDC Tech Co., Ltd.
++6c:fd:b9	Proware Technologies Co Ltd.
++6c:ff:be	MPB Communications Inc.
++70:1a:4	Liteon Tech Corp.
++70:1a:ed	ADVAS CO., LTD.
++70:2:58	01DB-METRAVIB
++70:2b:1d	E-Domus International Limited
++70:2f:97	Aava Mobile Oy
++70:3c:39	SEAWING Kft
++70:58:12	Panasonic AVC Networks Company
++70:5a:b6	COMPAL INFORMATION (KUNSHAN) CO., LTD. 
++70:5e:aa	Action Target, Inc.
++70:64:17	ORBIS TECNOLOGIA ELECTRICA S.A.
++70:65:82	Suzhou Hanming Technologies Co., Ltd.
++70:71:bc	PEGATRON CORPORATION
++70:72:cf	EdgeCore Networks
++70:76:f0	LevelOne Communications (India) Private Limited
++70:82:8e	OleumTech Corporation
++70:8b:78	citygrow technology co., ltd
++70:a1:91	Trendsetter Medical, LLC
++70:b0:8c	Shenou Communication Equipment Co.,Ltd
++70:d5:7e	Scalar Corporation
++70:d5:e7	Wellcore Corporation
++70:d8:80	Upos System sp. z o.o.
++70:e1:39	3view Ltd
++70:f1:a1	Liteon Technology Corporation
++70:f3:95	USI
++74:15:e2	Tri-Sen Systems Corporation
++74:32:56	NT-ware Systemprg GmbH
++74:6b:82	MOVEK 
++74:72:f2	Chipsip Technology Co., Ltd.
++74:7d:b6	Aliwei Communications, Inc
++74:7e:1a	Red Embedded Design Limited
++74:8e:f8	Brocade Communications Systems, Inc.
++74:90:50	Renesas Electronics Corporation
++74:91:1a	Ruckus Wireless
++74:a4:a7	QRS Music Technologies, Inc.
++74:a:bc	JSJS Designs (Europe) Limited
++74:b9:eb	Fujian Goldcat Electronic Technology Co.,Ltd.
++74:be:8	PRIVATE
++74:cd:c	Smith Myers Communications Ltd.
++74:ce:56	PRIVATE
++74:d6:75	WYMA Tecnologia
++74:d8:50	Evrisko Systems
++74:e5:37	RADSPIN
++74:e5:b	Intel Corporate
++74:ea:3a	TP-LINK Technologies Co.,Ltd.
++74:f0:6d	AzureWave Technologies, Inc.
++74:f0:7d	BnCOM Co.,Ltd
++74:f6:12	Motorola, Inc.
++74:f7:26	Neuron Robotics
++78:11:85	NBS Payment Solutions Inc.
++78:12:b8	ORANTEK LIMITED
++78:19:2e	NASCENT Technology
++78:1d:ba	HUAWEI TECHNOLOGIES CO.,LTD
++78:25:ad	SAMSUNG ELECTRONICS CO., LTD.
++78:30:e1	UltraClenz, LLC
++78:44:76	Zioncom technology co.,ltd
++78:57:12	Mobile Integration Workgroup
++78:5c:72	Hioso Technology Co., Ltd.
++78:66:ae	ZTEC Instruments, Inc.
++78:7f:62	GiK mbH
++78:81:8f	Server Racks Australia Pty Ltd
++78:84:3c	Sony Corporation
++78:84:ee	INDRA ESPACIO S.A.
++78:8c:54	Enkom Technologies Ltd.
++78:92:9c	Intel Corporate
++78:99:8f	MEDILINE ITALIA SRL
++78:a0:51	iiNet Labs Pty Ltd 
++78:a2:a0	Nintendo Co., Ltd.
++78:a6:bd	DAEYEON Control&Instrument Co,.Ltd
++78:a7:14	Amphenol
++78:b8:1a	INTER SALES A/S
++78:c4:e	H&D Wireless 
++78:c6:bb	Innovasic, Inc.
++78:ca:39	Apple
++78:d0:4	Neousys Technology Inc.
++78:dd:8	Hon Hai Precision Ind. Co.,Ltd. 
++78:e4:0	Hon Hai Precision Ind. Co.,Ltd. 
++78:e7:d1	Hewlett Packard
++78:ec:22	Shanghai Qihui Telecom Technology Co., LTD
++7c:14:76	AE Partners S.a.s
++7c:1e:b3	2N TELEKOMUNIKACE a.s.
++7c:20:64	Alcatel Lucent IPD
++7c:2c:f3	Secure Electrans Ltd
++7c:2e:d	Blackmagic Design
++7c:2f:80	Gigaset Communications GmbH
++7c:39:20	SSOMA SECURITY
++7c:3b:d5	Imago Group
++7c:3e:9d	PATECH
++7c:5:1e	RAFAEL LTD.
++7c:55:e7	YSI, Inc.
++7c:6c:8f	AMS NEVE LTD
++7c:6d:62	Apple, Inc
++7c:6f:6	Caterpillar Trimble Control Technologies
++7c:76:73	ENMAS GmbH
++7c:7b:e4	Z&#39;SEDAI KENKYUSHO CORPORATION
++7c:8:d9	Shanghai Engineering Research Center for Broadband Technologies and Applications
++7c:8e:e4	Texas Instruments
++7c:a2:9b	D.SignT GmbH &amp; Co. KG
++7c:b5:42	ACES Technology
++7c:bb:6f	Cosco Electronics Co., Ltd.
++7c:c5:37	Apple
++7c:cb:d	Aaxeon Technologies Inc.
++7c:cf:cf	Shanghai SEARI Intelligent System Co., Ltd
++7c:e0:44	NEON Inc
++7c:ed:8d	MICROSOFT
++7c:ef:18	Creative Product Design Pty. Ltd.
++7c:f0:98	Bee Beans Technologies, Inc.
+ 80:0:10	ATT BELL LABORATORIES
+-8:0:1	COMPUTERVISION CORPORATION
+ 8:0:11	TEKTRONIX INC.
+ 8:0:12	BELL ATLANTIC INTEGRATED SYST.
+ 8:0:13	EXXON
+ 8:0:14	EXCELAN
+ 8:0:15	STC BUSINESS SYSTEMS
+ 8:0:16	BARRISTER INFO SYS CORP
++80:17:7d	Nortel Networks
+ 8:0:17	NATIONAL SEMICONDUCTOR
+ 8:0:18	PIRELLI FOCOM NETWORKS
+ 8:0:19	GENERAL ELECTRIC CORPORATION
+ 8:0:1a	TIARA/ 10NET
+-8:0:1b	DATA GENERAL
++8:0:1b	EMC Corporation
+ 8:0:1c	KDD-KOKUSAI DEBNSIN DENWA CO.
++8:0:1	COMPUTERVISION CORPORATION
+ 8:0:1d	ABLE COMMUNICATIONS INC.
+ 8:0:1e	APOLLO COMPUTER INC.
+ 8:0:1f	SHARP CORPORATION
+-8:0:2	BRIDGE COMMUNICATIONS INC.
+-8:0:20	SUN MICROSYSTEMS INC.
++8:0:20	Oracle Corporation
+ 8:0:21	3M COMPANY
+ 8:0:22	NBI INC.
+ 8:0:23	Panasonic Communications Co., Ltd.
+@@ -9303,11 +13265,11 @@
+ 8:0:29	MEGATEK CORPORATION
+ 8:0:2a	MOSAIC TECHNOLOGIES INC.
+ 8:0:2b	DIGITAL EQUIPMENT CORPORATION
++8:0:2	BRIDGE COMMUNICATIONS INC.
+ 8:0:2c	BRITTON LEE INC.
+ 8:0:2d	LAN-TEC INC.
+ 8:0:2e	METAPHOR COMPUTER SYSTEMS
+ 8:0:2f	PRIME COMPUTER INC.
+-8:0:3	ADVANCED COMPUTER COMM.
+ 8:0:30	CERN *also* NETWORK RESEARCH CORPORATION *also* ROYAL MELBOURNE INST OF TECH
+ 8:0:31	LITTLE MACHINES INC.
+ 8:0:32	TIGAN INCORPORATED
+@@ -9316,32 +13278,37 @@
+ 8:0:35	MICROFIVE CORPORATION
+ 8:0:36	INTERGRAPH CORPORATION
+ 8:0:37	FUJI-XEROX CO. LTD.
+-8:0:38	CII HONEYWELL BULL
++8:0:38	BULL S.A.S.
++80:38:fd	LeapFrog Enterprises, Inc.
++80:39:e5	PATLITE CORPORATION
+ 8:0:39	SPIDER SYSTEMS LIMITED
++8:0:3	ADVANCED COMPUTER COMM.
+ 8:0:3a	ORCATECH INC.
++80:3b:9a	ghe-ces electronic ag
+ 8:0:3b	TORUS SYSTEMS LIMITED
+ 8:0:3c	SCHLUMBERGER WELL SERVICES
+ 8:0:3d	CADNETIX CORPORATIONS
+ 8:0:3e	CODEX CORPORATION
+ 8:0:3f	FRED KOSCHARA ENTERPRISES
+-8:0:4	CROMEMCO INCORPORATED
+ 8:0:40	FERRANTI COMPUTER SYS. LIMITED
+ 8:0:41	RACAL-MILGO INFORMATION SYS..
+ 8:0:42	JAPAN MACNICS CORP.
+ 8:0:43	PIXEL COMPUTER INC.
+ 8:0:44	DAVID SYSTEMS INC.
+ 8:0:45	CONCURRENT COMPUTER CORP.
+-8:0:46	SONY CORPORATION LTD.
++8:0:46	Sony Corporation
+ 8:0:47	SEQUENT COMPUTER SYSTEMS INC.
+ 8:0:48	EUROTHERM GAUGING SYSTEMS
+ 8:0:49	UNIVATION
+ 8:0:4a	BANYAN SYSTEMS INC.
+ 8:0:4b	PLANNING RESEARCH CORP.
+ 8:0:4c	HYDRA COMPUTER SYSTEMS INC.
++8:0:4	CROMEMCO INCORPORATED
+ 8:0:4d	CORVUS SYSTEMS INC.
+ 8:0:4e	3COM EUROPE LTD.
++80:4f:58	ThinkEco, Inc.
+ 8:0:4f	CYGNET SYSTEMS
+-8:0:5	SYMBOLICS INC.
++80:50:1b	Nokia Corporation
+ 8:0:50	DAISY SYSTEMS CORP.
+ 8:0:51	EXPERDATA
+ 8:0:52	INSYSTEC
+@@ -9357,13 +13324,14 @@
+ 8:0:5d	GOULD INC.
+ 8:0:5e	COUNTERPOINT COMPUTER INC.
+ 8:0:5f	SABER TECHNOLOGY CORP.
+-8:0:6	SIEMENS AG
++8:0:5	SYMBOLICS INC.
+ 8:0:60	INDUSTRIAL NETWORKING INC.
+ 8:0:61	JAROGATE LTD.
+ 8:0:62	GENERAL DYNAMICS
+ 8:0:63	PLESSEY
+ 8:0:64	AUTOPHON AG
+ 8:0:65	GENRAD INC.
++80:66:29	Prescope Technologies CO.,LTD.
+ 8:0:66	AGFA CORPORATION
+ 8:0:67	COMDESIGN
+ 8:0:68	RIDGE COMPUTERS
+@@ -9374,8 +13342,9 @@
+ 8:0:6d	WHITECHAPEL COMPUTER WORKS
+ 8:0:6e	MASSCOMP
+ 8:0:6f	PHILIPS APELDOORN B.V.
+-8:0:7	APPLE COMPUTER INC.
++8:0:6	SIEMENS AG
+ 8:0:70	MITSUBISHI ELECTRIC CORP.
++80:71:1f	Juniper Networks
+ 8:0:71	MATRA (DSIE)
+ 8:0:72	XEROX CORP UNIV GRANT PROGRAM
+ 8:0:73	TECMAR INC.
+@@ -9386,12 +13355,14 @@
+ 8:0:78	ACCELL CORPORATION
+ 8:0:79	THE DROID WORKS
+ 8:0:7a	INDATA
++8:0:7	APPLE COMPUTER INC.
+ 8:0:7b	SANYO ELECTRIC CO. LTD.
+ 8:0:7c	VITALINK COMMUNICATIONS CORP.
++80:7d:1b	Neosystem Co. Ltd.
+ 8:0:7e	AMALGAMATED WIRELESS(AUS) LTD
+ 8:0:7f	CARNEGIE-MELLON UNIVERSITY
+-8:0:8	BOLT BERANEK AND NEWMAN INC.
+ 8:0:80	AES DATA INC.
++80:81:a5	TONGQING COMMUNICATION EQUIPMENT (SHENZHEN) Co.,Ltd
+ 8:0:81	,ASTECH INC.
+ 8:0:82	VERITAS SOFTWARE
+ 8:0:83	Seiko Instruments Inc.
+@@ -9399,28 +13370,709 @@
+ 8:0:85	ELXSI
+ 8:0:86	KONICA MINOLTA HOLDINGS, INC.
+ 8:0:87	XYPLEX
+-8:0:88	MCDATA CORPORATION
++8:0:88	Brocade Communications Systems, Inc.
+ 8:0:89	KINETICS
+ 8:0:8a	PERFORMANCE TECHNOLOGY
++8:0:8	BOLT BERANEK AND NEWMAN INC.
+ 8:0:8b	PYRAMID TECHNOLOGY CORP.
+ 8:0:8c	NETWORK RESEARCH CORPORATION
+ 8:0:8d	XYVISION INC.
+ 8:0:8e	TANDEM COMPUTERS
+ 8:0:8f	CHIPCOM CORPORATION
+-8:0:9	HEWLETT PACKARD
+ 8:0:90	SONOMA SYSTEMS
++80:91:2a	Lih Rong electronic Enterprise Co., Ltd.
++8:0:9	HEWLETT PACKARD
++80:a1:d7	Shanghai DareGlobal Technologies Co.,Ltd 
+ 8:0:a	NESTAR SYSTEMS INCORPORATED
++80:b2:89	Forworld Electronics Ltd.
++80:ba:ac	TeleAdapt Ltd
+ 8:0:b	UNISYS CORPORATION
++80:c6:3f	Remec Broadband Wireless , LLC
++80:c6:ca	Endian s.r.l.
++80:c8:62	Openpeak, Inc
+ 8:0:c	MIKLYN DEVELOPMENT CO.
++80:d0:19	Embed, Inc
+ 8:0:d	INTERNATIONAL COMPUTERS LTD.
++80:ee:73	Shuttle Inc.
+ 8:0:e	NCR CORPORATION
++80:f5:93	IRCO Sistemas de Telecomunicaciï¿½n S.A.
+ 8:0:f	MITEL CORPORATION
+ 8:14:43	UNIBRAIN S.A.
++8:16:51	Shenzhen Sea Star Technology Co.,Ltd
++8:17:f4	BLADE Network Technology
++8:18:1a	zte corporation
++8:18:4c	A. S. Thomas, Inc.
++8:1f:f3	Cisco Systems
++8:2a:d0	SRD Innovations Inc.
++84:21:41	Shenzhen Ginwave Technologies Ltd.
++84:29:14	EMPORIA TELECOM Produktions- und VertriebsgesmbH & Co KG
++84:2b:2b	Dell Inc.
++84:48:23	WOXTER TECHNOLOGY Co. Ltd
++84:6e:b1	Park Assist LLC
++84:90:0	Arnold &amp; Richter Cine Technik
++84:97:b8	Memjet Inc.
++84:a9:91	Cyber Trans Japan Co.,Ltd.
++84:c7:27	Gnodal Ltd
++84:c7:a9	C3PO S.A.
++84:db:2f	Sierra Wireless Inc
++8:4e:1c	H2A Systems, LLC
++84:f6:4c	Cross Point BV
++8:51:2e	Orion Diagnostica Oy
++8:76:18	ViE Technologies Sdn. Bhd.
++8:76:95	Auto Industrial Co., Ltd.
++8:76:ff	Thomson Telecom Belgium
++88:18:ae	Tamron Co., Ltd
++88:25:2c	Arcadyan Technology Corporation
++88:41:c1	ORBISAT DA AMAZONIA IND E AEROL SA
++88:43:e1	Cisco Systems
++88:4b:39	Siemens AG, Healthcare Sector
++88:53:2e	Intel Corporate
++88:86:a0	Simton Technologies, Ltd.
++88:87:17	CANON INC.
++88:8b:5d	Storage Appliance Corporation 
++88:8c:19	Brady Corp Asia Pacific Ltd
++88:91:dd	Racktivity
++88:94:f9	Gemicom Technology, Inc.
++88:95:b9	Unified Packet Systems Crop
++88:97:df	Entrypass Corporation Sdn. Bhd.
++88:98:21	TERAON
++88:a5:bd	QPCOM INC.
++88:ac:c1	Generiton Co., Ltd. 
++88:ae:1d	COMPAL INFORMATION(KUNSHAN)CO.,LTD
++88:b6:27	Gembird Europe BV
++88:ba:7f	Qfiednet Co., Ltd.
++8:8d:c8	Ryowa Electronics Co.,Ltd
++88:ed:1c	Cudo Communication Co., Ltd.
++88:fd:15	LINEEYE CO., LTD
++8:9f:97	LEROY AUTOMATION
+ 8:bb:cc	AK-NORD EDV VERTRIEBSGES. mbH
++8c:1f:94	RF Surgical System Inc. 
++8c:4d:ea	Cerio Corporation
++8c:53:f7	A&D ENGINEERING CO., LTD.
++8c:54:1d	LGE 
++8c:56:c5	Nintendo Co., Ltd.
++8c:59:8b	C Technologies AB
++8c:64:b	BS Storitve d.o.o.
++8c:73:6e	Fujitsu Limited
++8c:7c:b5	Hon Hai Precision Ind. Co.,Ltd.
++8c:84:1	PRIVATE
++8c:90:d3	Alcatel Lucent
++8c:92:36	Aus.Linx Technology Co., Ltd.
++8c:a0:48	Beijing NeTopChip Technology Co.,LTD
++8c:a9:82	Intel Corporate
++8c:d6:28	Ikor Metering
++8c:dd:8d	Wifly-City System Inc.
++8c:e7:b3	Sonardyne International Ltd
++8:d2:9a	Proformatique
++8:f2:f4	Net One Partners Co.,Ltd.
++8:f6:f8	GET Engineering
++8:fa:e0	Fohhn Audio AG
++90:18:ae	Shanghai Meridian Technologies, Co. Ltd.
++90:21:55	HTC Corporation
++90:27:e4	Apple
++90:3d:5a	Shenzhen Wision Technology Holding Limited
++90:3d:6b	Zicon Technology Corp.
++90:47:16	RORZE CORPORATION
++90:4c:e5	Hon Hai Precision Ind. Co.,Ltd.
++90:50:7b	Advanced PANMOBIL Systems GmbH & Co. KG
++90:51:3f	Elettronica Santerno
++90:54:46	TES ELECTRONIC SOLUTIONS
++90:55:ae	Ericsson, EAB/RWI/K
++90:61:c	Fida International (S) Pte Ltd
++90:6d:c8	DLG Automa
++90:7f:61	Chicony Electronics Co., Ltd.
++90:84:d	Apple, Inc
++90:88:a2	IONICS TECHNOLOGY ME LTDA
++90:90:3c	TRISON TECHNOLOGY CORPORATION
++90:a2:da	GHEO SA
++90:a7:c1	Pakedge Device and Software Inc.
++90:d8:52	Comtec Co., Ltd.
++90:e0:f0	IEEE P1722 
++90:e6:ba	ASUSTek COMPUTER INC.
++90:f2:78	Radius Gateway
++90:fb:a6	Hon Hai Precision Ind.Co.Ltd
++94:11:da	ITF Froschl GmbH
++94:23:6e	Shenzhen Junlan Electronic Ltd
++94:2e:63	Fins
++94:33:dd	Taco Electronic Solutions, Inc.
++94:44:52	Belkin International, Inc.
++94:59:2d	EKE Building Technology Systems Ltd
++94:5b:7e	TRILOBIT LTDA.
++94:85:7a	Evantage Industries Corp
++94:9c:55	Alta Data Technologies
++94:a7:bc	BodyMedia, Inc.
++94:ba:31	Visiontec da Amaz
++94:c4:e9	PowerLayer Microsystems HongKong Limited
++94:c:6d	TP-LINK Technologies Co.,Ltd.
++94:c7:af	Raylios Technology
++94:dd:3f	A+V Link Technologies, Corp.
++94:e7:11	Xirka Dama Persada PT
++94:f6:92	Geminico co.,Ltd.
++94:f7:20	Tianjin Deviser Electronics Instrument Co., Ltd
++94:fe:f4	SAGEMCOM
++98:2d:56	Resolution Audio
++98:35:b8	Assembled Products Corporation
++98:3:a0	ABB n.v. Power Quality Products
++98:6d:c8	TOSHIBA MITSUBISHI-ELECTRIC INDUSTRIAL SYSTEMS CORPORATION
++98:73:c4	Sage Electronic Engineering LLC
++98:89:ed	Anadem Information Inc.
++98:8b:5d	SAGEM COMMUNICATION
++98:8e:dd	Raychem International
++98:bc:99	Edeltech Co.,Ltd.
++98:d8:8c	Nortel Networks
++98:dc:d9	UNITEC Co., Ltd.
++98:e1:65	Accutome
++98:fc:11	Cisco-Linksys, LLC
++9c:18:74	Nokia Danmark A/S
++9c:28:bf	Continental Automotive Czech Republic s.r.o.
++9c:45:63	DIMEP Sistemas
++9c:4e:20	Cisco Systems
++9c:4e:8e	ALT Systems Ltd
++9c:55:b4	I.S.E. S.r.l.
++9c:5b:96	NMR Corporation
++9c:5e:73	Calibre UK Ltd
++9c:75:14	Wildix srl
++9c:77:aa	NADASNV
++9c:ad:ef	Obihai Technology, Inc.
++9c:af:ca	Cisco Systems
++9c:b2:6	PROCENTEC
++9c:c0:77	PrintCounts, LLC
++9c:cd:82	CHENG UEI PRECISION INDUSTRY CO.,LTD
++9c:eb:e8	BizLink (Kunshan) Co.,Ltd
++9c:f6:1a	UTC Fire and Security
++9c:ff:be	OTSL Inc.
++a0:18:59	Shenzhen Yidashi Electronics Co Ltd
++a0:23:1b	TeleComp R&amp;D Corp.
++a0:2e:f3	United Integrated Services Co., Led.
++a0:3a:75	PSS Belgium N.V.
++a0:40:25	Actioncable, Inc.
++a0:40:41	SAMWONFA Co.,Ltd.
++a0:4e:4	Nokia Corporation
++a0:55:de	Pace Micro Technology plc
++a0:59:3a	V.D.S. Video Display Systems srl
++a0:5d:c1	TMCT Co., LTD.
++a0:5d:e7	DIRECTV, Inc.
++a0:69:86	Wellav Technologies Ltd
+ a0:6a:0	Verilink Corporation
++a0:73:32	Cashmaster International Limited
++a0:7:98	Samsung Electronics
++a0:82:c7	P.T.I Co.,LTD
++a0:88:b4	Intel Corporate
++a0:98:5	OpenVox Communication Co Ltd
++a0:98:ed	Shandong Intelligent Optical Communication Development Co., Ltd.
++a0:9a:5a	Time Domain
++a0:a7:63	Polytron Vertrieb GmbH
++a0:b5:da	HongKong THTF Co., Ltd
++a0:b9:ed	Skytap
++a0:b:ba	SAMSUNG ELECTRO-MECHANICS
++a0:bf:a5	CORESYS
++a0:dd:e5	SHARP CORPORATION
++a0:f2:17	GE Medical System(China) Co., Ltd. 
++a4:21:8a	Nortel Networks
++a4:38:fc	Plastic Logic
++a4:50:55	busware.de
++a4:56:1b	MCOT Corporation
++a4:5c:27	Nintendo Co., Ltd.
++a4:79:e4	KLINFO Corp
++a4:7c:1f	Global Microwave Systems Inc.
++a4:9b:13	Burroughs Payment Systems, Inc.
++a4:a8:f	Shenzhen Coship Electronics Co., Ltd.
++a4:ad:0	Ragsdale Technology
++a4:ad:b8	Vitec Group, Camera Dynamics Ltd
++a4:ae:9a	Maestro Wireless Solutions ltd.
++a4:b1:21	Arantia 2010 S.L.
++a4:b1:ee	H. ZANDER GmbH & Co. KG
++a4:b2:a7	Adaxys Solutions AG
++a4:ba:db	Dell Inc.
++a4:be:61	EutroVision System, Inc.
++a4:c2:ab	Hangzhou LEAD-IT Information & Technology Co.,Ltd
++a4:c:c3	Cisco Systems
++a4:d1:d1	ECOtality North America
++a4:da:3f	Bionics Corp.
++a4:de:50	Total Walther GmbH
++a4:e7:e4	Connex GmbH
++a4:ed:4e	Motorola Mobile Devices
++a8:55:6a	Pocketnet Technology Inc.
++a8:5b:b0	Shenzhen Dehoo Technology Co.,Ltd
++a8:63:df	DISPLï¿½AIRE CORPORATION
++a8:70:a5	UniComm Inc.
++a8:7b:39	Nokia Corporation
++a8:7e:33	Nokia Danmark A/S
++a8:93:e6	JIANGXI JINGGANGSHAN CKING COMMUNICATION TECHNOLOGY CO.,LTD
++a8:99:5c	aizo ag
++a8:9b:10	inMotion Ltd.
++a8:b0:ae	LEONI 
++a8:b1:d4	Cisco Systems
++a8:c2:22	TM-Research Inc.
++a8:cb:95	EAST BEST CO., LTD.
++a8:ce:90	CVC
++a8:d3:c8	Wachendorff Elektronik  GmbH &amp; Co. KG
++a8:e3:ee	Sony Computer Entertainment Inc.
++a8:f2:74	Samsung Electronics
++a8:f4:70	Fujian Newland Communication Science Technologies Co.,Ltd.
++a8:f9:4b	Eltex Enterprise Ltd.
+ aa:0:0	DIGITAL EQUIPMENT CORPORATION
+ aa:0:1	DIGITAL EQUIPMENT CORPORATION
+ aa:0:2	DIGITAL EQUIPMENT CORPORATION
+ aa:0:3	DIGITAL EQUIPMENT CORPORATION
+ aa:0:4	DIGITAL EQUIPMENT CORPORATION
++ac:34:cb	Shanhai GBCOM Communication Technology Co. Ltd
++ac:44:f2	Revolabs Inc
++ac:4f:fc	SVS-VISTEK GmbH
++ac:51:35	MPI TECH
++ac:58:3b	Human Assembler, Inc.
++ac:61:23	Drivven, Inc.
++ac:67:6	Ruckus Wireless
++ac:6f:4f	Enspert Inc
++ac:81:12	Gemtek Technology Co., Ltd.
++ac:83:17	Shenzhen Furtunetel Communication Co., Ltd
++ac:83:f0	Magenta Video Networks
++ac:86:7e	Create New Technology (HK) Limited Company
++ac:9a:96	Lantiq Deutschland GmbH
++ac:9b:84	Smak Tecnologia e Automacao
++ac:a0:16	Cisco Systems
++ac:ab:8d	Lyngso Marine A/S
++ac:be:75	Ufine Technologies Co.,Ltd.
++ac:be:b6	Visualedge Technology Co., Ltd.
++ac:ce:8f	HWA YAO TECHNOLOGIES CO., LTD
++ac:d1:80	Crexendo Business Solutions, Inc.
+ ac:de:48	PRIVATE
++ac:e3:48	MadgeTech, Inc
++ac:e9:aa	Hay Systems Ltd
++ac:ea:6a	GENIX INFOCOMM CO., LTD.
++b0:5b:1f	THERMO FISHER SCIENTIFIC S.P.A.
++b0:65:63	Shanghai Railway Communication Factory
++b0:81:d8	I-sys Corp
++b0:90:74	Fulan Electronics Limited
++b0:91:34	Taleo
++b0:97:3a	E-Fuel Corporation
++b0:9a:e2	STEMMER IMAGING GmbH
++b0:aa:36	GUANGDONG OPPO MOBILE TELECOMMUNICATIONS CORP.,LTD.
++b0:b3:2b	Slican Sp. z o.o.
++b0:b8:d5	Nanjing Nengrui Auto Equipment CO.,Ltd
++b0:c6:9a	Juniper Networks
++b0:c8:ad	People Power Company
++b0:e3:9d	CAT SYSTEM CO.,LTD.
++b0:e7:54	2Wire
++b0:e9:7e	Advanced Micro Peripherals
++b4:1:42	GCI Science & Technology Co.,LTD
++b4:14:89	Cisco Systems
++b4:2c:be	Direct Payment Solutions Limited
++b4:37:41	Consert, Inc.
++b4:39:d6	ProCurve Networking by HP
++b4:3d:b2	Degreane Horizon
++b4:41:7a	ShenZhen Gongjin Electronics Co.,Ltd
++b4:52:53	Seagate Technology
++b4:58:61	CRemote, LLC
++b4:7:f9	SAMSUNG ELECTRO-MECHANICS
++b4:82:fe	Askey Computer Corp
++b4:8:32	TC Communications
++b4:a4:e3	Cisco Systems
++b4:b5:af	Minsung Electronics
++b4:c8:10	UMPI Elettronica
++b4:ed:19	Pie Digital, Inc.
++b4:ed:54	Wohler Technologies
++b4:e:dc	LG-Ericsson Co.,Ltd.
++b4:ee:d4	Texas Instruments
++b8:61:6f	Accton Wireless Broadband(AWB), Corp.
++b8:64:91	CK Telecom Ltd
++b8:65:3b	Bolymin, Inc.
++b8:79:7e	Secure Meters (UK) Limited
++b8:8e:3a	Infinite Technologies JLT
++b8:92:1d	BG T&amp;A
++b8:94:d2	Retail Innovation HTT AB
++b8:a3:e0	BenRui Technology Co.,Ltd
++b8:ac:6f	Dell Inc
++b8:b1:c7	BT&COM CO.,LTD
++b8:ba:68	Xi'an Jizhong Digital Communication Co.,Ltd
++b8:ba:72	Cynove
++b8:d0:6f	GUANGZHOU HKUST FOK YING TUNG RESEARCH INSTITUTE
++b8:e7:79	PRIVATE
++b8:ee:79	YWire Technologies, Inc.
++b8:f7:32	Aryaka Networks Inc
++b8:f9:34	Sony Ericsson Mobile Communications AB
++b8:ff:61	Apple
++b8:ff:6f	Shanghai Typrotech Technology Co.Ltd
++bc:30:5b	Dell Inc.
++bc:38:d2	Pandachip Limited
++bc:47:60	Samsung Electronics Co.,Ltd
++bc:4e:3c	CORE STAFF CO., LTD.
++bc:5:43	AVM GmbH
++bc:6a:16	tdvine
++bc:77:37	Intel Corporate
++bc:7d:d1	Radio Data Comms
++bc:9d:a5	DASCOM Europe GmbH
++bc:a9:d6	Cyber-Rain, Inc.
++bc:b1:81	SHARP CORPORATION
++bc:d5:b6	d2d technologies
++bc:d:a5	Texas Instruments
++bc:f2:af	devolo AG
++bc:ff:ac	TOPCON CORPORATION
++c0:1e:9b	Pixavi AS
++c0:22:50	PRIVATE
++c0:2b:fc	iNES. applied informatics GmbH
++c0:38:f9	Nokia Danmark A/S
++c0:3b:8f	Minicom Digital Signage
++c0:3f:e	NETGEAR
++c0:6c:f	Dobbs Stanford
++c0:83:a	2Wire
++c0:8b:6f	S I Sistemas Inteligentes Eletronicos Ltda
++c0:91:34	ProCurve Networking by HP
++c0:9c:92	COBY
++c0:ba:e6	Application Solutions (Safety and Security) Ltd
++c0:c1:c0	Cisco-Linksys, LLC
++c0:c5:20	Ruckus Wireless
++c0:cb:38	Hon Hai Precision Ind. Co.,Ltd. 
++c0:cf:a3	Creative Electronics &amp; Software, Inc.
++c0:d0:44	SAGEMCOM
++c0:d:7e	Additech, Inc.
++c0:e4:22	Texas Instruments
++c:15:c5	SDTEC Co., Ltd.
++c:17:f1	TELECSYS
++c:1d:c2	SeAH Networks
++c:27:55	Valuable Techologies Limited
++c4:16:fa	Prysm Inc
++c4:17:fe	Hon Hai Precision Ind. Co.,Ltd.
++c4:19:8b	Dominion Voting Systems Corporation
++c4:1e:ce	HMI Sources Ltd.
++c4:2c:3	Apple
++c4:3d:c7	NETGEAR
++c4:46:19	Hon Hai Precision Ind. Co.,Ltd. 
++c4:4b:44	Omniprint Inc.
++c4:59:76	Fugoo
++c4:63:54	U-Raku, Inc.
++c4:7d:4f	Cisco Systems
++c4:82:3f	Fujian Newland Auto-ID Tech. Co,.Ltd.
++c4:93:13	100fio networks technology llc
++c4:aa:a1	SUMMIT DEVELOPMENT, spol.s r.o.
++c4:b5:12	General Electric Digital Energy
++c4:cd:45	Beijing Boomsense Technology CO.,LTD.
++c4:d4:89	JiangSu Joyque Information Industry Co.,Ltd
++c4:e1:7c	U2S co.
++c4:ee:f5	Oclaro, Inc.
++c4:f4:64	Spica international
++c4:fc:e4	DishTV NZ Ltd
++c:60:76	Hon Hai Precision Ind. Co.,Ltd.
++c:7d:7c	Kexiang Information Technology Co, Ltd.
++c:82:30	SHENZHEN MAGNUS TECHNOLOGIES CO.,LTD
++c:82:6a	Wuhan Huagong Genuine Optics Technology Co., Ltd
++c8:2:a6	Beijing Newmine Technology
++c8:2e:94	Halfa Enterprise Co., Ltd.
++c8:35:b8	Ericsson, EAB/RWI/K
++c8:3a:35	Tenda Technology Co., Ltd.
++c8:3e:a7	KUNBUS GmbH
++c:84:11	A.O. Smith Water Products
++c8:48:f5	MEDISON Xray Co., Ltd
++c8:4c:75	Cisco Systems
++c8:6c:1e	Display Systems Ltd
++c8:6c:b6	Optcom Co., Ltd.
++c8:72:48	Aplicom Oy
++c8:7e:75	Samsung Electronics Co.,Ltd
++c8:84:47	Beautiful Enterprise Co., Ltd
++c8:87:3b	Net Optics
++c8:8b:47	Opticos s.r.l.
++c8:93:83	Embedded Automation, Inc.
++c8:97:9f	Nokia Corporation
++c8:a1:b6	Shenzhen Longway Technologies Co., Ltd
++c8:a7:29	SYStronics Co., Ltd.
++c8:a:a9	Quanta Computer Inc.
++c8:aa:cc	PRIVATE
++c8:bc:c8	Apple
++c8:c1:3c	RuggedTek Hangzhou Co., Ltd
++c8:cd:72	SAGEMCOM
++c8:d1:d1	AGAiT Technology Corporation
++c8:d2:c1	Jetlun (Shenzhen) Corporation
++c8:d5:fe	Shenzhen Zowee Technology Co., Ltd
++c:8d:98	TOP EIGHT IND CORP
++c8:ee:8	TANGTOP TECHNOLOGY CO.,LTD
++c8:ef:2e	Beijing Gefei Tech. Co., Ltd 
++c:a4:2	Alcatel Lucent IPD
++c:a4:2a	OB Telecom Electronic Technology Co., Ltd
++cc:0:80	TRUST SYSTEM Co.,
++cc:22:18	InnoDigital Co., Ltd.
++c:c3:a7	Meritec
++cc:43:e3	Trump s.a.
++cc:50:76	Ocom Communications, Inc.
++cc:54:59	OnTime Networks AS
++cc:55:ad	RIM
++cc:5c:75	Weightech Com. Imp. Exp. Equip. Pesagem Ltda
++cc:69:b0	Global Traffic Technologies, LLC
++cc:6b:98	Minetec Wireless Technologies
++cc:7a:30	CMAX Wireless Co., Ltd.
++cc:8c:e3	Texas Instruments
++cc:8:e0	Apple
++c:c9:c6	Samwin Hong Kong Limited
++cc:9:c8	IMAQLIQ LTD
++cc:9e:0	Nintendo Co., Ltd.
++cc:b8:88	AnB Securite s.a.
++cc:cc:4e	Sun Fountainhead USA. Corp 
++cc:cd:64	SM-Electronic GmbH
++cc:ce:40	Janteq Corp
++cc:d8:11	Aiconn Technology Corporation
++cc:ea:1c	DCONWORKS  Co., Ltd
++cc:fc:b1	Wireless Technology, Inc.
++c:d5:2	Westell
++c:d6:96	Amimon Ltd
++c:d7:c2	Axium Technologies, Inc.
++c:dd:ef	Nokia Corporation
++c:e7:9	Fox Crypto B.V.
++c:e9:36	ELIMOS srl
++c:ee:e6	Hon Hai Precision Ind. Co.,Ltd.
++c:ef:7c	AnaCom Inc
++d0:15:4a	zte corporation
++d0:27:88	Hon Hai Precision Ind.Co.Ltd
++d0:37:61	Texas Instruments
++d0:57:4c	Cisco Systems
++d0:58:75	Active Control Technology Inc.
++d0:7d:e5	Forward Pay Systems, Inc.
++d0:89:99	APCON, Inc.
++d0:b3:3f	SHENZHEN TINNO MOBILE TECHNOLOGY CO.,LTD.
++d0:bb:80	SHL Telemedicine International Ltd.
++d0:d0:fd	Cisco Systems
++d0:d2:86	Beckman Coulter Biomedical K.K.
++d0:e3:47	Yoga
++d0:e4:b	Wearable Inc.
++d0:f0:db	Ericsson
++d4:0:d	Phoenix Broadband Technologies, LLC.
++d4:11:d6	ShotSpotter, Inc.
++d4:12:96	Anobit Technologies Ltd.
++d4:1f:c	TVI Vision Oy
++d4:3d:67	Carma Industries Inc.
++d4:4c:a7	Informtekhnika & Communication, LLC
++d4:52:97	nSTREAMS Technologies, Inc.
++d4:66:a8	Riedo Networks GmbH
++d4:6c:bf	Goodrich ISR
++d4:6c:da	CSM GmbH
++d4:79:c3	Cameronet GmbH &amp; Co. KG
++d4:82:3e	Argosy Technologies, Ltd.
++d4:85:64	Hewlett Packard
++d4:88:90	Samsung Electronics Co.,Ltd
++d4:8f:aa	Sogecam Industrial, S.A.
++d4:91:af	Electroacustica General Iberica, S.A.
++d4:96:df	SUNGJIN C&T CO.,LTD
++d4:9a:20	Apple, Inc
++d4:9c:28	JayBird Gear LLC
++d4:9e:6d	Wuhan Zhongyuan Huadian Science & Technology Co.,
++d4:a9:28	GreenWave Reality Inc
++d4:aa:ff	MICRO WORLD 
++d4:c7:66	Acentic GmbH
++d4:cb:af	Nokia Corporation
++d4:e8:b2	Samsung Electronics
++d4:f1:43	IPROAD.,Inc
++d8:1b:fe	TWINLINX CORPORATION
++d8:1c:14	Compacta International, Ltd.
++d8:28:c9	General Electric Consumer and Industrial
++d8:29:86	Best Wish Technology LTD
++d8:30:62	Apple, Inc
++d8:42:ac	FreeComm Data Communication Co.,Ltd.
++d8:46:6	Silicon Valley Global Marketing
++d8:4b:2a	Cognitas Technologies, Inc.
++d8:54:3a	Texas Instruments
++d8:5d:4c	TP-LINK Technologies Co.,Ltd.
++d8:6b:f7	Nintendo Co., Ltd.
++d8:71:57	Lenovo Mobile Communication Technology Ltd.
++d8:75:33	Nokia Corporation
++d8:76:a	Escort, Inc.
++d8:79:88	Hon Hai Precision Ind. Co., Ltd.
++d8:a2:5e	Apple
++d8:ae:90	Itibia Technologies
++d8:b6:c1	NetworkAccountant, Inc.
++d8:c3:fb	DETRACOM
++d8:c7:c8	Aruba Networks
++d8:d3:85	Hewlett Packard
++d8:d6:7e	GSK CNC EQUIPMENT CO.,LTD
++d8:e7:2b	OnPATH Technologies
++d8:fe:8f	IDFone Co., Ltd.
++dc:1d:9f	U & B tech
++dc:20:8	ASD Electronics Ltd 
++dc:2:65	Meditech Kft
++dc:2b:61	Apple
++dc:2c:26	Iton Technology Limited
++dc:33:50	TechSAT GmbH
++dc:49:c9	CASCO SIGNAL LTD
++dc:4e:de	SHINYEI TECHNOLOGY CO., LTD.
++dc:7b:94	Cisco Systems
++dc:9c:52	Sapphire Technology Limited.
++dc:a9:71	Intel Corporate
++dc:d0:f7	Bentek Systems Ltd.
++dc:e2:ac	Lumens Digital Optics Inc.
++dc:e7:1c	AUG Elektronik GmbH
++dc:fa:d5	STRONG Ges.m.b.H.
++e0:1c:ee	Bravo Tech, Inc.
++e0:25:38	Titan Pet Products
++e0:26:30	Intrigue Technologies, Inc.
++e0:26:36	Nortel Networks
++e0:27:1a	TTC Next-generation Home Network System WG
++e0:2a:82	USI
++e0:58:9e	Laerdal Medical
++e0:5b:70	Innovid, Co., Ltd.
++e0:5:c5	TP-LINK Technologies Co.,Ltd.
++e0:61:b2	HANGZHOU ZENOINTEL TECHNOLOGY CO., LTD
++e0:62:90	Jinan Jovision Science & Technology Co., Ltd.
++e0:64:bb	DigiView S.r.l.
++e0:87:b1	Nata-Info Ltd.
++e0:8a:7e	Exponent
++e0:8f:ec	REPOTEC CO., LTD.
++e0:91:53	XAVi Technologies Corp.
++e0:91:f5	NETGEAR
++e0:a6:70	Nokia Corporation
++e0:ab:fe	Orb Networks, Inc.
++e0:bc:43	C2 Microsystems, Inc.
++e0:c2:86	Aisai Communication Technology Co., Ltd.
++e0:ca:4d	Shenzhen Unistar Communication Co.,LTD
++e0:cb:4e	ASUSTek COMPUTER INC.
++e0:cf:2d	Gemintek Corporation
++e0:d1:a	Katoudenkikougyousyo co ltd
++e0:e7:51	Nintendo Co., Ltd.
++e0:ee:1b	Panasonic Automotive Systems Company of America
++e4:1f:13	IBM
++e4:27:71	Smartlabs
++e4:35:93	Hangzhou GoTo technology Co.Ltd
++e4:46:bd	C&C TECHNIC TAIWAN CO., LTD.
++e4:75:1e	Getinge Sterilization AB
++e4:7c:f9	Samsung Electronics Co., LTD
++e4:83:99	Motorola CHS
++e4:97:f0	Shanghai VLC Technologies Ltd. Co.
++e4:ab:46	UAB Selteka
++e4:ad:7d	SCL Elements
++e4:ec:10	Nokia Corporation
++e4:ff:dd	ELECTRON INDIA
++e8:11:32	Samsung Electronics Co.,LTD
++e8:28:77	TMY Co., Ltd.
++e8:39:df	Askey Computer
++e8:3a:97	OCZ Technology Group
++e8:4:62	Cisco Systems
++e8:4e:ce	Nintendo Co., Ltd.
++e8:5:6d	Nortel Networks
++e8:5b:5b	LG ELECTRONICS INC
++e8:5e:53	Infratec Datentechnik GmbH
++e8:6:88	Apple Inc. 
++e8:6c:da	Supercomputers and Neurocomputers Research Center
++e8:75:7f	FIRS Technologies(Shenzhen) Co., Ltd
++e8:7a:f3	S5 Tech S.r.l.
++e8:99:5a	PiiGAB, Processinformation i Goteborg AB
++e8:9d:87	Toshiba
++e8:a4:c1	Deep Sea Electronics PLC
++e8:b:13	Akib Systems Taiwan, INC
++e8:be:81	SAGEMCOM
++e8:c:38	DAEYOUNG INFORMATION SYSTEM CO., LTD
++e8:da:aa	VideoHome Technology Corp.
++e8:df:f2	PRF Co., Ltd.
++e8:e0:b7	Toshiba
++e8:e1:e2	Energotest
++e8:e5:d6	Samsung Electronics Co.,Ltd 
++e8:e7:76	Shenzhen Kootion Technology Co., Ltd
++ec:14:f6	BioControl AS
++ec:23:68	IntelliVoice Co.,Ltd.
++ec:30:91	Cisco Systems
++ec:43:e6	AWCER Ltd.
++ec:44:76	Cisco Systems
++ec:54:2e	Shanghai XiMei Electronic Technology Co. Ltd
++ec:5c:69	MITSUBISHI HEAVY INDUSTRIES MECHATRONICS SYSTEMS,LTD.
++ec:66:d1	B&amp;W Group LTD
++ec:6c:9f	Chengdu Volans Technology CO.,LTD
++ec:7c:74	Justone Technologies Co., Ltd.
++ec:8e:ad	DLX
++ec:98:c1	Beijing Risbo Network Technology Co.,Ltd
++ec:9b:5b	Nokia Corporation
++ec:b1:6	Acuro Networks, Inc
++ec:bb:ae	Digivoice Tecnologia em Eletronica Ltda
++ec:c3:8a	Accuenergy (CANADA) Inc
++ec:c8:82	Cisco Systems
++ec:cd:6d	Allied Telesis, Inc.
++ec:d0:e	MiraeRecognition Co., Ltd.
++ec:de:3d	Lamprey Networks, Inc.
++ec:e0:9b	Samsung electronics CO., LTD
++ec:e9:f8	Guang Zhou TRI-SUN Electronics Technology  Co., Ltd
++ec:fa:aa	The IMS Company
++ec:fe:7e	BlueRadios, Inc.
++f0:2:48	SmarteBuilding
++f0:24:8	Talaris (Sweden) AB
++f0:26:4c	Dr. Sigrist AG
++f0:2f:d8	Bi2-Vision
++f0:43:35	DVN(Shanghai)Ltd.
++f0:4b:f2	JTECH Communications, Inc.
++f0:4d:a2	Dell Inc.
++f0:62:81	ProCurve Networking by HP
++f0:65:dd	Primax Electronics Ltd.
++f0:68:53	Integrated Corporation
++f0:77:d0	Xcellen
++f0:7b:cb	Hon Hai Precision Ind. Co.,Ltd. 
++f0:7d:68	D-Link Corporation
++f0:9c:bb	RaonThink Inc.
++f0:a7:64	GST Co., Ltd.
++f0:ad:4e	Globalscale Technologies, Inc.
++f0:b4:79	Apple
++f0:b6:eb	Poslab Technology Co., Ltd.
++f0:bc:c8	MaxID (Pty) Ltd
++f0:bd:f1	Sipod Inc.
++f0:c2:4c	Zhejiang FeiYue Digital Technology Co., Ltd
++f0:c8:8c	LeddarTech Inc.
++f0:d7:67	Axema Passagekontroll AB
++f0:de:71	Shanghai EDO Technologies Co.,Ltd.
++f0:de:f1	Wistron InfoComm (Kunshan)Co
++f0:e5:c3	Draegerwerk AG &amp;amp; Co. KG aA
++f0:ec:39	Essec
++f0:ed:1e	Bilkon Bilgisayar Kontrollu Cih. Im.Ltd.
++f0:f7:b3	Phorm
++f0:f8:42	KEEBOX, Inc.
++f0:f9:f7	IES GmbH &amp; Co. KG
++f4:1f:b	YAMABISHI Corporation
++f4:38:14	Shanghai Howell Electronic Co.,Ltd
++f4:3e:61	Shenzhen Gongjin Electronics Co., Ltd
++f4:42:27	S & S Research Inc.
++f4:45:ed	Portable Innovation Technology Ltd.
++f4:50:eb	Telechips Inc
++f4:55:95	HENGBAO Corporation LTD.
++f4:55:e0	Niceway CNC Technology Co.,Ltd.Hunan Province
++f4:5f:f7	DQ Technology Inc.
++f4:63:49	Diffon Corporation
++f4:76:26	Viltechmeda UAB 
++f4:9f:54	Samsung Electronics
++f4:ac:c1	Cisco Systems
++f4:b:93	Research In Motion
++f4:c7:95	WEY Elektronik AG
++f4:ce:46	Hewlett Packard
++f4:dc:4d	Beijing CCD Digital Technology Co., Ltd
++f4:dc:da	Zhuhai Jiahe Communication Technology Co., limited
++f4:e1:42	Delta Elektronika BV
++f4:fc:32	Texas Instruments
++f8:1e:df	Apple, Inc
++f8:47:2d	X2gen Digital Corp. Ltd
++f8:52:df	VNL Europe AB
++f8:66:f2	Cisco Systems
++f8:6e:cf	Arcx Inc
++f8:71:fe	The Goldman Sachs Group, Inc.
++f8:7b:7a	Motorola Mobile Devices
++f8:81:1a	OVERKIZ
++f8:8d:ef	Tenebraex
++f8:91:2a	GLP German Light Products GmbH
++f8:93:f3	VOLANS
++f8:9d:d	Control Technology Inc.
++f8:ac:6d	Deltenna Ltd
++f8:b5:99	Guangzhou CHNAVS Digital Technology Co.,Ltd
++f8:c0:91	Highgates Technology
++f8:d7:56	Simm Tronic Limited 
++f8:da:e2	Beta LaserMike
++f8:dc:7a	Variscite LTD
++f8:e9:68	Egker Kft.
++f8:f:41	Wistron InfoComm(ZhongShan) Corporation
++f8:f:84	Natural Security SAS
++f8:fb:2f	Santur Corporation
++fc:44:63	Universal Audio
++fc:61:98	NEC Personal Products, Ltd
++fc:68:3e	Directed Perception, Inc
++fc:75:e6	Handreamnet
++fc:7c:e7	FCI USA LLC
++fc:8:77	Prentke Romich Company
++fc:a1:3e	Samsung Electronics
++fc:a8:41	Nortel Networks
++fc:cc:e4	Ascon Ltd.
++fc:cf:62	BLADE Network Technology
++fc:d4:f6	Messana Air.Ray Conditioning s.r.l.
++fc:e1:92	Sichuan Jinwangtong Electronic Science&Technology Co,.Ltd
++fc:e2:3f	CLAY PAKY SPA
++fc:ed:b9	Arrayent
++fc:fa:f7	Shanghai Baud Data Communication Co.,Ltd.
++fc:fb:fb	Cisco Systems
++fc:f:e6	Sony Computer Entertainment Inc. 


### PR DESCRIPTION
Arpwatch detects new stations (mac address associated
with a given ip), changed stations, and stations with
ip on a subnet other than the one on the interface on
which the station was detected (bogon).  It can log
and/or mail detections using any mailer with a sendmail
compatible command.

I've created the package assuming nullmailer will be used (i.e. adding arpwatch to the nullmailer group if it exists in order for nullmailer's sendmail command to succeed).  This has no effect if nullmailer is not installed.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>