### PR TITLE
net/udp-broadcast-relay: Bring back, update, and improve

### DIFF
--- a/net/udp-broadcast-relay/Makefile
+++ b/net/udp-broadcast-relay/Makefile
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=udp-broadcast-relay
+PKG_VERSION:=0.3
+PKG_RELEASE:=5
+PKG_MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+PKG_LICENSE:=GPL-2.0
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.joachim-breitner.de/udp-broadcast-relay/files/
+PKG_MD5SUM:=a32f983b7063d6ac670e6b22be9b9d24
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/udp-broadcast-relay
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  TITLE:=listens for packets on a specified UDP broadcast port
+  URL:=http://www.joachim-breitner.de/udp-broadcast-relay/
+endef
+
+define Package/udp-broadcast-relay/description
+	This program listens for packets on a specified UDP broadcast port.
+	When a packet is received, it sends that packet to all specified interfaces but
+	the one it came from as though it originated from the original sender.
+	The primary purpose of this is to allow games on machines on separated
+	local networks (Ethernet, WLAN) that use udp broadcasts to find each other to do so.
+	It also works on ppp links, so you can log in from windows boxes (e.g. using pptp)
+	and play LAN-based games together. Currently, you have to care about upcoming or
+	downgoing interfaces yourself.
+endef
+
+define Package/udp-broadcast-relay/conffiles
+/etc/config/udp_broadcast_relay
+endef
+
+define Build/Compile
+	$(TARGET_CC) $(TARGET_CFLAGS) $(PKG_BUILD_DIR)/main.c -o $(PKG_BUILD_DIR)/$(PKG_NAME)
+endef
+
+define Package/udp-broadcast-relay/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/config $(1)/etc/init.d
+	$(CP) $(PKG_BUILD_DIR)/$(PKG_NAME) $(1)/usr/sbin/
+	$(INSTALL_CONF) ./files/udp_broadcast_relay.config $(1)/etc/config/udp_broadcast_relay
+	$(INSTALL_BIN) ./files/udp-broadcast-relay.init $(1)/etc/init.d/udp-broadcast-relay
+endef
+
+$(eval $(call BuildPackage,udp-broadcast-relay))

--- a/net/udp-broadcast-relay/files/udp-broadcast-relay.init
+++ b/net/udp-broadcast-relay/files/udp-broadcast-relay.init
@@ -1,0 +1,62 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2006-2011 OpenWrt.org
+
+START=90
+STOP=10
+
+USE_PROCD=1
+PROG=/usr/sbin/udp-broadcast-relay
+NAME=udp-broadcast-relay
+PIDCOUNT=0
+
+validate_section_udp_broadcast_relay()
+{
+    uci_validate_section udp_broadcast_relay udp_broadcast_relay "${1}" \
+	'port:port' \
+	'network:list(string)'
+
+    [ -z "$network" ] && return 1
+
+    [ -z "$port" ] && return 1
+
+    return 0
+}
+
+udp_broadcast_relay_instance() {
+    local net network ifname port
+
+    validate_section_udp_broadcast_relay "${1}" || {
+	echo "Validation failed"
+	return 1
+    }
+
+    PIDCOUNT="$((  ${PIDCOUNT} + 1))"
+
+    procd_open_instance
+    procd_set_param command "$PROG" $(printf "%03d" "${PIDCOUNT}") "${port}"
+
+    for net in $network; do
+	network_get_device ifname "$net"
+	if [ -n "$ifname" ]; then
+	    procd_append_param command "$ifname"
+	    procd_append_param netdev "$ifname"
+	fi
+    done
+
+    procd_add_jail ubr-${PIDCOUNT}
+    procd_close_instance
+}
+
+start_service() {
+    . /lib/functions.sh
+    . /lib/functions/network.sh
+
+    config_load udp_broadcast_relay
+    config_foreach udp_broadcast_relay_instance udp_broadcast_relay
+}
+
+service_triggers()
+ {
+    procd_add_reload_trigger "udp-broadcast-relay"
+    procd_add_validation validate_section_udp_broadcast_relay
+}

--- a/net/udp-broadcast-relay/files/udp_broadcast_relay.config
+++ b/net/udp-broadcast-relay/files/udp_broadcast_relay.config
@@ -1,0 +1,4 @@
+#config udp_broadcast_relay
+       #option port 137
+       #list network lan
+       #list network lan_wifi

--- a/net/udp-broadcast-relay/patches/100-fix-bind-to-specific-address.patch
+++ b/net/udp-broadcast-relay/patches/100-fix-bind-to-specific-address.patch
@@ -1,0 +1,169 @@
+Index: udp-broadcast-relay-0.3/main.c
+===================================================================
+--- udp-broadcast-relay-0.3.orig/main.c
++++ udp-broadcast-relay-0.3/main.c
+@@ -51,6 +51,7 @@ http://www.netfor2.com/ip.htm
+ #include <stdio.h>
+ #include <linux/if.h>
+ #include <sys/ioctl.h>
++#include <stdlib.h>
+ 
+ main(int argc,char **argv)
+ {
+@@ -74,6 +75,7 @@ main(int argc,char **argv)
+ 	struct {
+ 		struct sockaddr_in dstaddr;
+ 		int ifindex;
++		int sockfd;
+ 	} ifs[MAXIFS];
+ 	
+ 	/* Address broadcast packet was sent from */
+@@ -239,68 +241,76 @@ main(int argc,char **argv)
+ 	/* Free our allocated buffer and close the socket */
+ 	close(fd);
+ 
+-	/* Create our broadcast receiving socket */
+-	if((rcv=socket(AF_INET,SOCK_DGRAM,IPPROTO_UDP)) < 0)
+-  	{
++        int maxfd = -1;
++
++	int curif;
++	for (curif = 0; curif <= maxifs; curif++) {
++	  /* Create our broadcast receiving socket */
++	  if((rcv=socket(AF_INET,SOCK_DGRAM,IPPROTO_UDP)) < 0)
++	  {
+   		perror("socket");
+   		exit(1);
+-  	};
++	  };
++	  ifs[curif].sockfd = rcv;
++	  if (rcv > maxfd) {
++	    maxfd = rcv;
++          }
+ 
+-	x = 1;
+-	if(setsockopt(rcv, SOL_SOCKET, SO_BROADCAST, (char*) &x, sizeof(int))<0){
++	  x = 1;
++	  if(setsockopt(rcv, SOL_SOCKET, SO_BROADCAST, (char*) &x, sizeof(int))<0){
+ 		perror("SO_BROADCAST on rcv");
+ 		exit(1);
+-	};
+-	if(setsockopt(rcv, SOL_IP, IP_RECVTTL, (char*) &x, sizeof(int))<0){
++	  };
++	  if(setsockopt(rcv, SOL_IP, IP_RECVTTL, (char*) &x, sizeof(int))<0){
+ 		perror("IP_RECVTTL on rcv");
+ 		exit(1);
+-	};
+-	if(setsockopt(rcv, SOL_IP, IP_PKTINFO, (char*) &x, sizeof(int))<0){
++	  };
++	  if(setsockopt(rcv, SOL_IP, IP_PKTINFO, (char*) &x, sizeof(int))<0){
+ 		perror("IP_PKTINFO on rcv");
+ 		exit(1);
+ 	};
+ 
+-	/* We bind it to broadcast addr on the given port */
+-	rcv_addr.sin_family = AF_INET;
+-	rcv_addr.sin_port = htons(port);
+-	rcv_addr.sin_addr.s_addr = INADDR_ANY;
++	  /* We bind it to broadcast addr on the given port */
++	  rcv_addr.sin_family = AF_INET;
++	  rcv_addr.sin_port = htons(port);
++	  rcv_addr.sin_addr.s_addr = ifs[curif].dstaddr.sin_addr.s_addr;
+ 
+-	if ( bind (rcv, (struct sockaddr *)&rcv_addr, sizeof(struct sockaddr_in) ) < 0 )
+-	{
++	  if ( bind (rcv, (struct sockaddr *)&rcv_addr, sizeof(struct sockaddr_in) ) < 0 )
++	  {
+ 		perror("bind");
+ 		fprintf(stderr,"A program is already bound to the broadcast address for the given port\n");
+ 		exit(1);
+-	}
++	  }
+ 	
+-	/* Set up a raw socket for sending our packets through */
+-	if((fd=socket(AF_INET,SOCK_RAW,IPPROTO_RAW)) < 0)
+-  	{
++	  /* Set up a raw socket for sending our packets through */
++	  if((fd=socket(AF_INET,SOCK_RAW,IPPROTO_RAW)) < 0)
++	  {
+   		perror("socket");
+   		exit(1);
+-  	};
++	  };
+ 
+-	/* Set dest port to that was provided on command line */
+-	*(u_short*)(gram+22)=(u_short)htons(port);
++	  /* Set dest port to that was provided on command line */
++	  *(u_short*)(gram+22)=(u_short)htons(port);
+ 	
+-	x=1;
+-	if (setsockopt(fd,SOL_SOCKET,SO_BROADCAST,(char*)&x,sizeof(x))<0)
+-	{
++	  x=1;
++	  if (setsockopt(fd,SOL_SOCKET,SO_BROADCAST,(char*)&x,sizeof(x))<0)
++	    {
+ 		perror("setsockopt SO_BROADCAST");
+ 		exit(1);
+-  	};
++	    };
+ 
+-	/* Enable IP header stuff on the raw socket */
+-	#ifdef IP_HDRINCL
+-	x=1;
+-	if (setsockopt(fd,IPPROTO_IP,IP_HDRINCL,(char*)&x,sizeof(x))<0)
+-	{
++	  /* Enable IP header stuff on the raw socket */
++          #ifdef IP_HDRINCL
++	  x=1;
++	  if (setsockopt(fd,IPPROTO_IP,IP_HDRINCL,(char*)&x,sizeof(x))<0)
++	    {
+ 		perror("setsockopt IP_HDRINCL");
+ 		exit(1);
+-  	};
+-	#else
+-	#error IP_HDRINCL support is required
+-	#endif
+-
++	    };
++	  #else
++	  #error IP_HDRINCL support is required
++	  #endif
++	}
+  	/* Fork to background */
+   if (! debug) {
+     if (forking && fork())
+@@ -315,6 +325,25 @@ main(int argc,char **argv)
+ 
+ 	for (;;) /* endless loop */
+ 	{
++          fd_set rfds;
++          FD_ZERO(&rfds);
++          for (curif = 0; curif <= maxifs; curif++) {
++            FD_SET(ifs[curif].sockfd, &rfds);
++          }
++          struct timeval tv;
++          int selretval;
++          tv.tv_sec = 30;
++          tv.tv_usec = 0;
++
++          selretval = select(maxfd + 1, &rfds, NULL, NULL, &tv);
++
++          if (selretval == -1) {
++            perror("Error detecting broadcast packet");
++	    continue;
++          } else if (selretval > 0) {
++            for (curif = 0; curif <= maxifs; curif++) {
++              if (FD_ISSET(ifs[curif].sockfd, &rfds)) {
++                rcv = ifs[curif].sockfd;
+ 		/* Receive a broadcast packet */
+ 		len = recvmsg(rcv,&rcv_msg,0);
+ 		if (len <= 0) continue;	/* ignore broken packets */
+@@ -378,5 +407,8 @@ main(int argc,char **argv)
+ 				perror("sendto");
+ 		}
+ 		DPRINT ("\n");
++              }
++            }
++          }
+ 	}
+ }


### PR DESCRIPTION
udp-broadcast-relay receives ipv4 broadcasts on a select set
of interfaces (for a specific port) and rebroadcasts them to
every other interfaces in the set of interfaces.  This allows
ipv4 udp broadcasts to cross subnets/interfaces (that the
primary subnets associated with each interface).  Ordinarily
broadcast packets are limited to a single layer-2 broadcast
domain.

Note that this version of udp-broadcast-relay does not handle
the universal broadcast to everyone address (255.255.255.255).

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>