### PR TITLE
Boost: Update 8

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -17,7 +17,7 @@ include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=boost
 PKG_VERSION:=1_59_0
-PKG_RELEASE:=6
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/boost
@@ -115,31 +115,75 @@ define Package/boost/config
     menu "Select Boost Options"
       depends on PACKAGE_boost
       	comment "Boost compilation options."
-	    config boost-static-libs
-	    	bool "Compile Static Libraries"
-	    	help 
-	    		Compile static version of all selected boost libraries.
-	    	default y
 
-	    config boost-shared-libs
-	    	bool "Compile Shared Libraries"
-	    	help 
-	    		Compile shared version of all selected boost libraries.
-	    	default y
-	    
-	    config boost-runtime-static
-	    	bool "Use static version of C and C++ runtimes for static libraries."	    	
-	    	help 
-	    		Determines if shared or static version of C and C++ runtimes should be used for static libraries.
-	    	default n
-	    	select boost-static-libs
+      	choice
+      		prompt "Compile Boost libraries."
+      			default boost-static-and-shared-libs
+      			help
+      				Choose which version to compile.
+      				 -> Shared:
+      				    - Only Shared libs will be compiled.
+      				 -> Static:
+      				    - Only Static libs will be compiled.
+      				 -> Both:
+      				    - Both Static and Shared libs will be compiled.		    
 
-	    config boost-runtime-shared
-	    	bool "Use shared version of C and C++ runtimes for shared libraries."
-	    	help 
-	    		Determines if shared or static version of C and C++ runtimes should be used for shared libraries.
-	    	default y
-	    	select boost-shared-libs
+		    config boost-shared-libs
+		    	bool "Shared"
+			
+			config boost-static-libs
+		    	bool "Static"		    	
+			
+			config boost-static-and-shared-libs
+		    	bool "Both"		    	
+	    endchoice
+
+      	choice
+      		prompt "Selects Boost Runtime linkage."
+      		default boost-runtime-shared
+      		help
+      			Choose which C and C++ runtimes to use:
+      			 -> Use Shared runtimes.
+      			 -> Use Static runtimes.
+      			    - Not available if Shared libs are to be built.
+      			 -> Use both runtimes.
+      			    - Not available if Shared libs are to be built.
+      			    - Two seperate versions of Boost are built, linking each to a different runtime. 
+      			    - This option requires "Use tagged names" option to be active.
+
+		    config boost-runtime-shared
+		    	bool "Shared"
+
+		    config boost-runtime-static
+		    	depends on @(!boost-shared-libs&&!boost-static-and-shared-libs)
+		    	bool "Static"		    	
+		    
+		    config boost-runtime-static-and-shared
+		    	depends on @(boost-use-name-tags&&!boost-shared-libs&&!boost-static-and-shared-libs)
+		    	bool "Both"
+	    endchoice
+
+      	choice
+      		prompt "Select a Variant."
+      		default boost-variant-release
+      		help
+      			Chooses which boost variant should be selected:
+      			-> Release: Optimizes Boost for release.
+      			   - Optimization: Speed;  Debug Symbols: Off; Inlining: Full; Runtime Debugging: Off.
+      			-> Debug: 
+      			   - Optimization: Off; Debug Symbols: On; Inlining: Off; Runtime Debugging: On.
+      			-> Profile:
+      			   - Profiling: On;  Debug Symbols: On.
+
+      		config boost-variant-release
+      			bool "Release"
+
+      		config boost-variant-debug
+      			bool "Debug"
+      				
+      		config boost-variant-profile
+      			bool "Profile"
+      	endchoice	    	
 
 	    config boost-use-name-tags
 	    	bool "Use tagged names."
@@ -153,16 +197,16 @@ define Package/boost/config
 
 	    config boost-single-thread
 	    	depends on @boost-use-name-tags
-	    	bool "Single thread Support"	    	
+	    	bool "Single thread Support."
 	    	help 
 	    		Compile Boost libraries in single-thread mode.
 	    	default n
-	    
-	    config boost-with-debug
+			    
+	    config boost-build-type-complete
 	    	depends on @boost-use-name-tags
-	    	bool "Boost Debug Support"	    	
+	    	bool "Complete Boost Build."
 	    	help 
-	    		Compile Boost libraries with debug support.
+	    		Builds both release and debug libs. It will take much longer to compile.
 	    	default n	    	
     endmenu
 
@@ -262,7 +306,7 @@ $(eval $(call DefineBoostLibrary,wave,date_time thread filesystem,))
 
 
 define Host/Compile
-	# bjam does not provide a configure-script nor a Makefile
+	# b2 does not provide a configure-script nor a Makefile
 	( cd $(HOST_BUILD_DIR)/tools/build/src/engine ; ./build.sh gcc )
 endef
 
@@ -287,6 +331,7 @@ else
     BOOST_ABI = sysv
 endif
 
+comma := ,
 
 define Build/Compile
 	$(info Selected Boost API $(BOOST_ABI) for architecture $(ARCH) and cpu $(CPU_TYPE) $(CPU_SUBTYPE))
@@ -300,20 +345,24 @@ define Build/Compile
 			echo "using python : 2.7 : $(STAGING_DIR_ROOT)/usr/bin/python :	$(STAGING_DIR)/usr/include/python2.7/ ;" >> \
 				tools/build/src/user-config.jam; \
 		) \
-		bjam \
-			'-sBUILD=release <optimization>space <inlining>on <debug-symbols>off' \
+		b2 \
+			$(CONFIGURE_ARGS) \
 			--ignore-site-config \
 			--toolset=gcc-$(ARCH) abi=$(BOOST_ABI) \
 			--disable-long-double \
+			$(if $(CONFIG_boost-variant-release), variant=release,) \
+			$(if $(CONFIG_boost-variant-debug), variant=debug,) \
+			$(if $(CONFIG_boost-variant-profile), variant=profile,) \
 			$(if $(CONFIG_boost-use-name-tags),--layout=tagged,--layout=system) \
-			$(if $(CONFIG_boost-with-debug),--build-type=complete,--build-type=minimal) \
-			$(if $(CONFIG_boost-static-libs),link=static,) \
-			$(if $(CONFIG_boost-runtime-static),runtime-link=static,runtime-link=shared) \
+			$(if $(CONFIG_boost-build-type-complete),--build-type=complete,--build-type=minimal) \
 			$(if $(CONFIG_boost-shared-libs),link=shared,) \
+			$(if $(CONFIG_boost-static-libs),link=static,) \
+			$(if $(CONFIG_boost-static-and-shared-libs),link=static$(comma)shared,) \
 			$(if $(CONFIG_boost-runtime-shared),runtime-link=shared,) \
+			$(if $(CONFIG_boost-runtime-static),runtime-link=static,) \
+			$(if $(CONFIG_boost-runtime-static-and-shared),runtime-link=shared$(comma)static,) \
 			$(if $(CONFIG_boost-single-thread),threading=single,) \
 			threading=multi \
-			$(CONFIGURE_ARGS) \
 			--without-mpi \
 			$(if $(CONFIG_boost-coroutine2),,--without-coroutine2) \
 			$(if $(CONFIG_boost-graph-parallel),,--without-graph_parallel) \
@@ -342,7 +391,7 @@ define Build/InstallDev
 		# copies _all_ header files - independent of <--with-library>-argument above
 
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) -v $(PKG_INSTALL_DIR)/lib/*.a $(1)/usr/lib/ # copies all compiled archive files 	
+	$(CP) -v $(PKG_INSTALL_DIR)/lib/*.a $(1)/usr/lib/ # copies all compiled archive files
 	$(FIND) $(PKG_INSTALL_DIR)/lib/ -name '*.so*' -exec $(CP) {} $(1)/usr/lib/ \; # copies all the shared objects files
 endef
 
@@ -351,7 +400,7 @@ define Host/Install
 		$(STAGING_DIR_HOST)/bin
 
 	$(CP) \
-		$(HOST_BUILD_DIR)/tools/build/src/engine/bin.*/bjam \
+		$(HOST_BUILD_DIR)/tools/build/src/engine/bin.*/b2 \
 		$(STAGING_DIR_HOST)/bin/
 endef
 


### PR DESCRIPTION
Major fixes:
 - The "Select Boost Options" was improved:
   - In previous versions, it was possible to unselect both Shared and Static
     options, so that there would be nothing to be built. This was solved by
     creating a choice menu "Compile Boost libraries".
   - A new choice menu was also created for Boost Run-time linkage called
     "Selects Boost Run-time linkage", which is used to select the C and C++
     runtime. This choice menu obeys to the required restrictions by boost
     options [1].

 - Fixed the invalid combination where boost shared version could be linked
   to C and C++ static runtime. This is not allowed by the boost builder.
 - Added new menu where a Boost building variant can be chosen from 3 options:
   - Release: The optimized version for daily use.
   - Debug: The debugging version, for testing purposes.
   - Profiling: The profiling version for evaluation purposes.
 - Improved options help descriptions.

Minor fixes:
 - Makefile Version was bumped from 6 to 8 because the previous update [2] did
   not bumped the value acordingly to the submission rules.
 - Removed stuff that was not doing anything: "-sBUILD=release"
 - Changed builder executable from "bjam" to "b2" which is the correct caller:
   - "bjam" is the old name and exists only for compatibility purposes.

[1]: http://www.boost.org/build/doc/html/bbv2/overview/builtins/features.html
[2]: https://github.com/openwrt/packages/pull/2084

Signed-off-by: Carlos M. Ferreira <carlosmf.pt@gmail.com>