### PR TITLE
obfsproxy: new package

### DIFF
--- a/net/obfsproxy/Makefile
+++ b/net/obfsproxy/Makefile
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2006-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=obfsproxy
+PKG_VERSION:=0.2.13
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/o/obfsproxy
+PKG_MD5SUM:=f596aeeda7bf03cdf0e78e68e6e7ac9f
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/obfsproxy
+	SECTION:=net
+	CATEGORY:=Network
+	TITLE:=A pluggable transport proxy written in Python
+	URL:=https://www.torproject.org/projects/obfsproxy.html.en
+	DEPENDS:=+python-light +python-crypto +python-pyptlib +python-setuptools +python-yaml +twisted
+endef
+
+define Package/obfsproxy/description
+obfsproxy is a tool that attempts to circumvent censorship, by
+transforming the Tor traffic between the client and the bridge. This
+way, censors, who usually monitor traffic between the client and the
+bridge, will see innocent-looking transformed traffic instead of the
+actual Tor traffic.
+endef
+
+define Package/obfsproxy/conffiles
+/etc/config/obfsproxy
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
+endef
+
+define PyPackage/obfsproxy/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/obfsproxy $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/obfsproxy.conf $(1)/etc/config/obfsproxy
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/obfsproxy.init $(1)/etc/init.d/obfsproxy
+endef
+
+$(eval $(call PyPackage,obfsproxy))
+$(eval $(call BuildPackage,obfsproxy))

--- a/net/obfsproxy/files/obfsproxy.conf
+++ b/net/obfsproxy/files/obfsproxy.conf
@@ -1,0 +1,57 @@
+# To use Obfsproxy with Tor, follow the instructions at:
+#
+# https://www.torproject.org/projects/obfsproxy-instructions.html.en
+#
+# instead of setting up a separate instance of Obfsproxy.
+
+config obfsproxy 'obfsproxy'
+	# Set to 1 to enable this instance
+	option enabled 0
+
+	# One of: managed, dummy, b64, obfs2, obfs3, scramblesuit
+	option transport 'scramblesuit'
+
+	# Shared secret / password
+	# For obfs2 (as the shared secret parameter) and scramblesuit only
+	option password 'EXAMPLEPASSWORDNOTREAL'
+
+	# One of: server, ext_server, client, socks
+	option mode 'socks'
+
+	# Destination address
+	# Required for all modes except 'socks'
+	#option dest_host '0.0.0.0'
+	#option dest_port '80'
+
+	# Extended ORPort authentication cookie file location
+	# Required for 'ext_server' mode
+	#option ext_cookie_file ''
+
+	# Listener address
+	option listen_host '127.0.0.1'
+	option listen_port '8080'
+
+	# Set to log to a file instead of syslog
+	#option log_file '/var/log/obfsproxy.log'
+
+	# Minimum logging severity
+	# One of: error, warning, info, debug
+	#option log_min_severity 'info'
+
+	# Set to 1 to disable logging
+	#option no_log 0
+
+	# Set to 1 to disable safe (scrubbed address) logging
+	#option no_safe_logging 0
+
+	# Run as a different user
+	#option user 'nobody'
+
+	# Outgoing proxy
+	# proxy_scheme is one of: socks4a, socks5, http
+	# txsocksx is required for socks4a or socks5
+	#option proxy_scheme ''
+	#option proxy_username ''
+	#option proxy_password ''
+	#option proxy_host ''
+	#option proxy_port ''

--- a/net/obfsproxy/files/obfsproxy.init
+++ b/net/obfsproxy/files/obfsproxy.init
@@ -1,0 +1,158 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2016 OpenWrt.org
+
+START=80
+STOP=20
+USE_PROCD=1
+
+PROG=/usr/bin/obfsproxy
+
+append_arg() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
+
+	config_get val "$cfg" "$var"
+	[ -n "$val" -o -n "$def" ] && procd_append_param command "$opt" "${val:-$def}"
+}
+
+append_bool() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
+
+	config_get_bool val "$cfg" "$var" "$def"
+	[ "$val" = 1 ] && procd_append_param command "$opt"
+}
+
+append_plain() {
+	procd_append_param command "$1"
+}
+
+append_param() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
+
+	config_get val "$cfg" "$var"
+	[ -n "$val" -o -n "$def" ] && procd_append_param "$opt" "${val:-$def}"
+}
+
+append_proxy_spec() {
+	local cfg="$1"
+	local scheme_var="$2"
+	local username_var="$3"
+	local password_var="$4"
+	local host_var="$5"
+	local port_var="$6"
+	local opt="$7"
+	local def="$8"
+	local scheme
+	local username
+	local password
+	local host
+	local port
+	local login
+	local val
+
+	config_get scheme "$cfg" "$scheme_var"
+	config_get username "$cfg" "$username_var"
+	config_get password "$cfg" "$password_var"
+	config_get host "$cfg" "$host_var"
+	config_get port "$cfg" "$port_var"
+	[ "$username" ] && login="$username${password:+:$password}@"
+	[ -n "$scheme" -a -n "$host" -a -n "$port" ] && val="$scheme://$login$host:$port"
+	[ -n "$val" -o -n "$def" ] && procd_append_param command "$opt" "${val:-$def}"
+}
+
+append_host_port() {
+	local cfg="$1"
+	local host_var="$2"
+	local port_var="$3"
+	local opt="$4"
+	local def="$5"
+	local host
+	local port
+	local val
+
+	config_get host "$cfg" "$host_var"
+	config_get port "$cfg" "$port_var"
+	[ -n "$host" -a -n "$port" ] && val="$host:$port"
+	[ -n "$val" -o -n "$def" ] && {
+		[ "$opt" ] && procd_append_param command "$opt"
+		procd_append_param command "${val:-$def}"
+	}
+}
+
+start_instance() {
+	local cfg="$1"
+	local lib_dir="/var/lib/obfsproxy/$cfg"
+	local redirect=0
+	local enabled
+	local user
+	local transport
+	local password
+	local log_min_severity
+
+	config_get_bool enabled "$cfg" 'enabled' '0'
+	[ "$enabled" = 0 ] && return 1
+
+	config_get user "$cfg" 'user' 'root'
+	config_get transport "$cfg" 'transport'
+	[ "$transport" = "scramblesuit" ] && config_get password "$cfg" 'password'
+
+	[ -d "$lib_dir" ] || {
+		mkdir -m 0755 -p "$lib_dir/data"
+		chmod -R 0700 "$lib_dir"
+	}
+	[ "$password" ] && {
+		echo "$password" > "$lib_dir/secret"
+		chmod 0600 "$lib_dir/secret"
+	}
+	chown -R "$user:" "$lib_dir"
+
+	config_get log_min_severity "$cfg" 'log_min_severity'
+	[ "$log_min_severity" = "debug" ] && redirect=1
+
+	procd_open_instance
+
+	procd_set_param command "$PROG" --data-dir "$lib_dir/data" --syslog "obfsproxy($cfg)"
+
+	append_arg "$cfg" log_file "--log-file"
+	append_arg "$cfg" log_min_severity "--log-min-severity"
+	append_bool "$cfg" no_log "--no-log"
+	append_bool "$cfg" no_safe_logging "--no-safe-logging"
+	append_proxy_spec "$cfg" proxy_scheme proxy_username proxy_password proxy_host proxy_port "--proxy"
+
+	append_param "$cfg" transport command
+	[ "$transport" = "obfs2" ] && append_arg "$cfg" password "--shared-secret"
+	[ "$password" ] && procd_append_param command "--password-file" "$lib_dir/secret"
+
+	append_param "$cfg" mode command
+	append_host_port "$cfg" dest_host dest_port "--dest"
+	append_arg "$cfg" ext_cookie_file "--ext-cookie-file"
+
+	append_host_port "$cfg" listen_host listen_port
+
+	procd_set_param respawn
+	procd_set_param stdout $redirect
+	procd_set_param stderr $redirect
+	append_param "$cfg" user user
+
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger obfsproxy
+}
+
+start_service() {
+	config_load obfsproxy
+	config_foreach start_instance obfsproxy
+}

--- a/net/obfsproxy/patches/001-exclude-tests.patch
+++ b/net/obfsproxy/patches/001-exclude-tests.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 2353a29..9d2a9a9 100644
+--- a/setup.py
++++ b/setup.py
+@@ -21,7 +21,7 @@ setup(
+     version=versioneer.get_version(),
+     cmdclass=versioneer.get_cmdclass(),
+ 
+-    packages = find_packages(),
++    packages = find_packages(exclude=['*.test', '*.test.*']),
+     entry_points = {
+         'console_scripts': [
+             'obfsproxy = obfsproxy.pyobfsproxy:run'

--- a/net/obfsproxy/patches/002-fix-python-path.patch
+++ b/net/obfsproxy/patches/002-fix-python-path.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.py b/setup.py
+index 2353a29..8d3d56d 100644
+--- a/setup.py
++++ b/setup.py
+@@ -27,6 +27,11 @@ setup(
+             'obfsproxy = obfsproxy.pyobfsproxy:run'
+             ]
+         },
++    options = {
++        'build_scripts': {
++            'executable': '/usr/bin/python'
++            },
++        },
+ 
+     install_requires = [
+         'setuptools',

--- a/net/obfsproxy/patches/003-remove-argparse-dependency-test.patch
+++ b/net/obfsproxy/patches/003-remove-argparse-dependency-test.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index 2353a29..e04c5f5 100644
+--- a/setup.py
++++ b/setup.py
+@@ -32,7 +32,6 @@ setup(
+         'setuptools',
+         'PyCrypto',
+         'Twisted',
+-        'argparse',
+         'pyptlib >= 0.0.6',
+         'pyyaml'
+         ],

--- a/net/obfsproxy/patches/004-add-syslog-support.patch
+++ b/net/obfsproxy/patches/004-add-syslog-support.patch
@@ -1,0 +1,51 @@
+diff --git a/obfsproxy/common/log.py b/obfsproxy/common/log.py
+index bb30296..79193d2 100644
+--- a/obfsproxy/common/log.py
++++ b/obfsproxy/common/log.py
+@@ -1,5 +1,6 @@
+ """obfsproxy logging code"""
+ import logging
++import logging.handlers
+ import sys
+ 
+ from twisted.python import log
+@@ -50,6 +51,18 @@ class ObfsLogger(object):
+ 
+         self.obfslogger.addHandler(log_handler)
+ 
++    def set_syslog(self, progname):
++        """Set up our logger so that it starts logging to syslog instead."""
++
++        # remove the default handler, and add the SysLogHandler:
++        self.obfslogger.removeHandler(self.default_handler)
++
++        log_handler = logging.handlers.SysLogHandler(address='/dev/log')
++        formatter = logging.Formatter(progname + "[%(process)d]: %(message)s")
++        log_handler.setFormatter(formatter)
++
++        self.obfslogger.addHandler(log_handler)
++
+ 
+     def set_log_severity(self, sev_string):
+         """Update our minimum logging severity to 'sev_string'."""
+diff --git a/obfsproxy/pyobfsproxy.py b/obfsproxy/pyobfsproxy.py
+index 4a2faf6..eaf8a44 100755
+--- a/obfsproxy/pyobfsproxy.py
++++ b/obfsproxy/pyobfsproxy.py
+@@ -42,6 +42,7 @@ def set_up_cli_parsing():
+ 
+     parser.add_argument('-v', '--version', action='version', version=__version__)
+     parser.add_argument('--log-file', help='set logfile')
++    parser.add_argument('--syslog', metavar='PROGNAME', help='use syslog')
+     parser.add_argument('--log-min-severity',
+                         choices=['error', 'warning', 'info', 'debug'],
+                         help='set minimum logging severity (default: %(default)s)')
+@@ -110,6 +111,8 @@ def consider_cli_args(args):
+ 
+     if args.log_file:
+         log.set_log_file(args.log_file)
++    elif args.syslog:
++        log.set_syslog(args.syslog)
+     if args.log_min_severity:
+         log.set_log_severity(args.log_min_severity)
+     if args.no_log:


### PR DESCRIPTION
From the [Tor project page](https://www.torproject.org/projects/obfsproxy.html.en):

obfsproxy is a tool that attempts to circumvent censorship, by
transforming the Tor traffic between the client and the bridge. This
way, censors, who usually monitor traffic between the client and the
bridge, will see innocent-looking transformed traffic instead of the
actual Tor traffic.

This depends on:

- pyptlib (#2053)
- twisted (#2052)

Also, txsocksx (#2058) is necessary to use an outgoing SOCKS proxy,
and having either gmpy2 (#2067) or gmpy (#2051) installed will help
speed up calculations.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>