### PR TITLE
python: fix upgrade 2.7.11 goof

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -148,9 +148,9 @@ define Build/InstallDev
 		$(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON_VERSION).so* \
 		$(1)/usr/lib/
 	$(CP) \
-		$(STAGING_DIR_HOST)/usr/lib/pkgconfig/python.pc \
-		$(STAGING_DIR_HOST)/usr/lib/pkgconfig/python2.pc \
-		$(STAGING_DIR_HOST)/usr/lib/pkgconfig/python-$(PYTHON_VERSION).pc \
+		$(STAGING_DIR_HOST)/lib/pkgconfig/python.pc \
+		$(STAGING_DIR_HOST)/lib/pkgconfig/python2.pc \
+		$(STAGING_DIR_HOST)/lib/pkgconfig/python-$(PYTHON_VERSION).pc \
 		$(1)/usr/lib/pkgconfig
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/config \


### PR DESCRIPTION
Seems those pkgconfig file paths were revealed to be incorrect
after doing a full clean build.
And I only had to inspiration to do one after doing the initial PR.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>