### PR TITLE
libev: Fix compatibility with libevent2 includes

### DIFF
--- a/libs/libev/Makefile
+++ b/libs/libev/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libev
 PKG_VERSION:=4.20
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://dist.schmorp.de/libev/Attic/
@@ -44,7 +44,9 @@ CONFIGURE_ARGS += \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/event.h $(1)/usr/include/ev_event_compat.h
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/ev.h $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/ev++.h $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libev.{a,so*} $(1)/usr/lib/
 endef


### PR DESCRIPTION
Packages building with libev and want to include event.h from libev
need to be modified to include ev_event_compat.h instead.

The are no known packages which need to be fixed at this time. The
normal include is ev.h for this package.

Does not break Kamailio4 and also fixes #1338

Signed-off-by: Ted Hess <thess@kitschensync.net>