### PR TITLE
glib2: fix host build

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -19,7 +19,7 @@ PKG_MD5SUM:=83efba4722a9674b97437d1d99af79db
 PKG_BUILD_PARALLEL:=1
 HOST_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=glib2/host libpthread zlib libintl libffi
-HOST_BUILD_DEPENDS:=libintl/host libiconv/host libffi/host
+HOST_BUILD_DEPENDS:=gettext-full/host libiconv/host libffi/host
 PKG_INSTALL:=1
 PKG_USE_MIPS16:=0
 


### PR DESCRIPTION
Replace libintl/host with gettext-full/host.
Fixes this build error (on a clean build):
```
*** You must have either have gettext support in your C library, or use the
*** GNU gettext library. (http://www.gnu.org/software/gettext/gettext.html
```

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>