### PR TITLE
ibrcommon: fix build on musl

### DIFF
--- a/libs/ibrcommon/Makefile
+++ b/libs/ibrcommon/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ibrcommon
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.ibr.cs.tu-bs.de/projects/ibr-dtn/releases

--- a/libs/ibrcommon/patches/001-fix-build-with-musl.patch
+++ b/libs/ibrcommon/patches/001-fix-build-with-musl.patch
@@ -1,0 +1,23 @@
+diff --git a/ibrcommon/data/File.cpp b/ibrcommon/data/File.cpp
+index 31af4ae..9b49890 100644
+--- a/ibrcommon/data/File.cpp
++++ b/ibrcommon/data/File.cpp
+@@ -35,9 +35,7 @@
+ #include <cerrno>
+ #include <fstream>
+ 
+-#if !defined(HAVE_FEATURES_H) || defined(ANDROID)
+ #include <libgen.h>
+-#endif
+ 
+ #ifdef __WIN32__
+ #include <io.h>
+@@ -226,7 +224,7 @@ namespace ibrcommon
+ 	std::string File::getBasename() const
+ 	{
+ #if !defined(ANDROID) && defined(HAVE_FEATURES_H)
+-		return std::string(basename(_path.c_str()));
++		return std::string(basename((char *)_path.c_str()));
+ #else
+ 		char path[_path.length()+1];
+ 		::memcpy(&path, _path.c_str(), _path.length()+1);


### PR DESCRIPTION
Build error:
```
make[6]: Entering directory `/home/sandu/work/openwrt/build_dir/target-mips_34kc_musl-1.1.11/ibrcommon-1.0.1/ibrcommon/data'
  CXX      BLOB.lo
  CXX      ConfigFile.lo
  CXX      File.lo
File.cpp: In member function 'std::__cxx11::string ibrcommon::File::getBasename() const':
File.cpp:229:44: error: 'basename' was not declared in this scope
   return std::string(basename(_path.c_str()));
                                            ^
make[6]: *** [File.lo] Error 1
```

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>