### PR TITLE
python: backport some patches from trunk to 15.05

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -12,7 +12,7 @@ include ./files/python-package.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.python.org/ftp/python/$(PKG_VERSION)

--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -29,7 +29,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/Python-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/Python-$(PKG_VERSION)
 
 PKG_BUILD_DEPENDS:=python/host
-HOST_BUILD_DEPENDS:=bzip2/host
+HOST_BUILD_DEPENDS:=bzip2/host expat/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk

--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -222,6 +222,7 @@ HOST_CONFIGURE_ARGS+= \
 	--without-cxx-main \
 	--without-pymalloc \
 	--with-threads \
+	--with-system-expat=$(STAGING_DIR_HOST) \
 	--prefix=$(STAGING_DIR_HOST) \
 	--with-ensurepip=upgrade \
 	CONFIG_SITE= \

--- a/lang/python/files/python-package.mk
+++ b/lang/python/files/python-package.mk
@@ -103,6 +103,7 @@ define Build/Compile/PyMod
 		cd $(PKG_BUILD_DIR)/$(strip $(1)); \
 		CC="$(TARGET_CC)" \
 		CCSHARED="$(TARGET_CC) $(FPIC)" \
+		CXX="$(TARGET_CXX)" \
 		LD="$(TARGET_CC)" \
 		LDSHARED="$(TARGET_CC) -shared" \
 		CFLAGS="$(TARGET_CFLAGS)" \

--- a/lang/python/patches/006-remove-debian-multiarch-support.patch
+++ b/lang/python/patches/006-remove-debian-multiarch-support.patch
@@ -1,12 +1,14 @@
 diff --git a/setup.py b/setup.py
-index 7868b7b..9ae0ef2 100644
+index 1d1ae72..511aed5 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -444,7 +444,6 @@ class PyBuildExt(build_ext):
+@@ -444,7 +444,8 @@ class PyBuildExt(build_ext):
              add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
          if cross_compiling:
              self.add_gcc_paths()
 -        self.add_multiarch_paths()
++        else:
++            self.add_multiarch_paths()
  
          # Add paths specified in the environment variables LDFLAGS and
          # CPPFLAGS for header and library files.


### PR DESCRIPTION
Build tested with python, python-setuptools, python-pip, seafile-seahub.
Fixes https://github.com/openwrt/packages/issues/1784

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>