### PR TITLE
ntpd: add libcap to default dependencies of the ntpd package

### DIFF
--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntp
 PKG_VERSION:=4.2.8p4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/
@@ -31,7 +31,7 @@ define Package/ntpd/Default
   TITLE:=ISC ntp
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
   URL:=http://www.ntp.org/
-  DEPENDS:=+libopenssl +libpthread
+  DEPENDS:=+libopenssl +libpthread +libcap
 endef
 
 define Package/ntpd/Default/description
@@ -43,7 +43,6 @@ endef
 define Package/ntpd
 $(call Package/ntpd/Default)
   TITLE+= server
-  DEPENDS+= +libcap
   USERID:=ntp=123:ntp=123
 endef
 
@@ -67,7 +66,6 @@ endef
 define Package/ntp-utils
 $(call Package/ntpd/Default)
   TITLE+= utilities
-  DEPENDS+= +libcap
 endef
 
 define Package/ntp-utils/description
@@ -79,7 +77,7 @@ endef
 define Package/ntp-keygen
 $(call Package/ntpd/Default)
   TITLE+=keygen
-  DEPENDS+= +libcap +libevent2-core
+  DEPENDS+= +libevent2-core
 endef
 
 define Package/ntp-keygen/description


### PR DESCRIPTION
Fixes https://github.com/openwrt/packages/issues/2054

Seems ntpdate also requires this lib:
```
Package ntpdate is missing dependencies for the following libraries:
libcap.so.2
make[2]: *** [/store/buildbot/slave/ar71xx/build/bin/ar71xx/packages/packages/ntpdate_4.2.8p4-1_ar71xx.ipk] Error 1
make[2]: Leaving directory `/store/buildbot/slave/ar71xx/build/feeds/packages/net/ntpd'
```

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>