### PR TITLE
ola: fix build (linking issue TCPSocket::ReadDescriptor() const)

### DIFF
--- a/net/ola/patches/002-remove-visibility-inlines-hidden-flag.patch
+++ b/net/ola/patches/002-remove-visibility-inlines-hidden-flag.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.am b/Makefile.am
+index 22647be..7dcf0de 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -32,7 +32,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS = --enable-python-libs
+ COMMON_CXXFLAGS_ONLY_WARNINGS = \
+     -I$(top_srcdir)/include \
+     -I$(top_builddir)/include \
+-    -Wall -Wformat -W -fvisibility-inlines-hidden \
++    -Wall -Wformat -W \
+     $(libprotobuf_CFLAGS)
+ 
+ COMMON_CXXFLAGS = $(COMMON_CXXFLAGS_ONLY_WARNINGS)


### PR DESCRIPTION
Reported buildbot issue is:
/store/buildbot/slave/ar71xx/build/build_dir/target-mips_34kc_musl-1.1.11/ola-0.9.7/plugins/openpixelcontrol/.libs/libolaopenpixelcontrol.so: undefined reference to `ola::network::TCPSocket::ReadDescriptor() const'
collect2: error: ld returned 1 exit status

There's also a discussion (attempt) to fix this on the buildroot project:
  https://patchwork.ozlabs.org/patch/503884/

This bug has been reported (from the buildroot project), here:
  https://github.com/OpenLightingProject/ola/issues/880

This commit introduced the issue:
  https://github.com/OpenLightingProject/ola/commit/bfc1d99055980dfac5c959a7210257d1939803ec
specifically the `-fvisibility-inlines-hidden` switch.

So, until, the upstream project (ola) fixes this, this fix
looks like the quickest/simplest workaround to have this package build.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>