### PR TITLE
krb5: bump to version 1.13.3 and fix uninitialized warning/error

### DIFF
--- a/net/krb5/Makefile
+++ b/net/krb5/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=krb5
-PKG_VERSION:=1.13.2
+PKG_VERSION:=1.13.3
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -16,9 +16,9 @@ PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=NOTICE
 
-PKG_SOURCE:=krb5-$(PKG_VERSION)-signed.tar
+PKG_SOURCE:=krb5-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://web.mit.edu/kerberos/dist/krb5/1.13/
-PKG_MD5SUM:=f7ebfa6c99c10b16979ebf9a98343189
+PKG_MD5SUM:=f99fb414932a4d8b1925e00ef31e7680
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -58,14 +58,6 @@ endef
 
 define Package/krb5/description
 	Kerberos
-endef
-
-define Build/Prepare
-	# Krb5 tarball contains signature and a second tarball
-	# containing source code.
-	tar xf "$(DL_DIR)/$(PKG_SOURCE)" -C "$(BUILD_DIR)"
-	tar xzf "$(BUILD_DIR)/krb5-$(PKG_VERSION).tar.gz" -C "$(BUILD_DIR)"
-	patch -p1 -d "$(PKG_BUILD_DIR)" < "$(PATCH_DIR)/001-fix-build.patch"
 endef
 
 CONFIGURE_PATH = ./src

--- a/net/krb5/patches/002-fix-uninitialized-warning-error.patch
+++ b/net/krb5/patches/002-fix-uninitialized-warning-error.patch
@@ -1,0 +1,13 @@
+diff --git a/src/kadmin/ktutil/ktutil_funcs.c b/src/kadmin/ktutil/ktutil_funcs.c
+index 20a348c..97baff0 100644
+--- a/src/kadmin/ktutil/ktutil_funcs.c
++++ b/src/kadmin/ktutil/ktutil_funcs.c
+@@ -67,7 +67,7 @@ krb5_error_code ktutil_delete(context, list, idx)
+     krb5_kt_list lp, prev;
+     int i;
+ 
+-    for (lp = *list, i = 1; lp; prev = lp, lp = lp->next, i++) {
++    for (prev = NULL, lp = *list, i = 1; lp; prev = lp, lp = lp->next, i++) {
+         if (i == idx) {
+             if (i == 1)
+                 *list = lp->next;


### PR DESCRIPTION
Version 1.13.3 has a tar.gz so the OpenWRT default Build/Prepare
rule can be used with MD5 checksum.

Add patch to fix build:
ktutil_funcs.c: In function 'ktutil_delete':
ktutil_funcs.c:75:28: error: 'prev' may be used uninitialized in this function [-Werror=maybe-uninitialized]
                 prev->next = lp->next;

There does not seem to be a way for 'prev' being uninitialized
(logically), however the compiler does not see that, because
'prev' is dependent on i >= 1.
So, we just need to initialize it to NULL.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>