### PR TITLE
Pull request python package collection

### DIFF
--- a/lang/python-package-argparse/Makefile
+++ b/lang/python-package-argparse/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=argparse
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=1.4.0
+PKG_RELEASE:=1
+PKG_LICENSE:=LGPL-2.1
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/a/$(SRC_PKG_NAME)
+PKG_MD5SUM:=08062d2ceb6596fcbc5a7e725b53746f
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Command-line parsing library
+	URL:=https://github.com/ThomasWaldmann/argparse
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+endef
+
+define Package/$(PKG_NAME)/description
+  argparse is a python library for parsing command line arguments
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-chardet/Makefile
+++ b/lang/python-package-chardet/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=chardet
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=2.3.0
+PKG_RELEASE:=1
+PKG_LICENSE:=LGPL-2.1
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/c/$(SRC_PKG_NAME)
+PKG_MD5SUM:=25274d664ccb5130adae08047416e1a8
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Universal character encoding detector for Python
+	URL:=https://github.com/chardet/chardet
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+endef
+
+define Package/$(PKG_NAME)/description
+ chardet is a python module detects character encodings
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-django-1.5/Makefile
+++ b/lang/python-package-django-1.5/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-package-django-1.5
+SRC_PKG_NAME:=Django
+PKG_VERSION:=1.5.8
+PKG_RELEASE=1
+PKG_LICENSE:=BSD-3-Clause
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/D/$(SRC_PKG_NAME)
+PKG_MD5SUM:=675fc736e2c29090f005e217ccf90b5b
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Django web application framework for Python
+	URL:=https://www.djangoproject.com
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+	PROVIDES:=python-package-django
+endef
+
+define Package/$(PKG_NAME)/description
+ Django is a web application framework written in Python
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-django-1.8/Makefile
+++ b/lang/python-package-django-1.8/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-package-django-1.8
+SRC_PKG_NAME:=Django
+PKG_VERSION:=1.8.4
+PKG_RELEASE=1
+PKG_LICENSE:=BSD-3-Clause
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/D/$(SRC_PKG_NAME)
+PKG_MD5SUM:=8eb569a5b9d984d9f3366fda67fb0bb8
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Django web application framework for Python
+	URL:=https://www.djangoproject.com
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+	PROVIDES:=python-package-django
+endef
+
+define Package/$(PKG_NAME)/description
+ Django is a web application framework written in Python
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-django-appconf/Makefile
+++ b/lang/python-package-django-appconf/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=django-appconf
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=1.0.1
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD-3-Clause
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/d/$(SRC_PKG_NAME)
+PKG_MD5SUM:=29c87a00f0d098b90f3ac6113ae6e52d
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Helper for handling Django app configuration defaults
+	URL:=http://django-appconf.readthedocs.org/
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python +python-package-six +python-package-django-1.5
+endef
+
+define Package/$(PKG_NAME)/description
+ django-appconf is a helper for handling Django app configuration defaults
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-django-compressor-1.4/Makefile
+++ b/lang/python-package-django-compressor-1.4/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-package-django-compressor-1.4
+SRC_PKG_NAME:=django-compressor
+PKG_VERSION:=1.4
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/django-compressor/django-compressor
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=e747dce3d7e04fe595bbfed54f9554c2725eb757
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Asset compression for Django
+	URL:=http://django-compressor.readthedocs.org/en/latest/
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python +python-package-django-1.5 +python-package-django-appconf
+	PROVIDES:=django-compressor
+endef
+
+define Package/$(PKG_NAME)/description
+ django-compressor is a python module for compressing web assets when
+ using Django web application framework.
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-django-pipeline/Makefile
+++ b/lang/python-package-django-pipeline/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-package-django-pipeline
+SRC_PKG_NAME:=django-pipeline
+PKG_VERSION:=1.5.4
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/d/$(SRC_PKG_NAME)
+PKG_MD5SUM:=dc7ef8d0b1e872011de29ce74c884e39
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Asset packaging for Django
+	URL:=https://github.com/cyberdelia/django-pipeline
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python +python-package-django +python-package-futures
+endef
+
+define Package/$(PKG_NAME)/description
+ django-pipeline is a python module for packaging web assets when
+ using Django web application framework.
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-django-static/Makefile
+++ b/lang/python-package-django-static/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=django-static
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=1.5.5
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD-3-Clause
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/d/$(SRC_PKG_NAME)
+PKG_MD5SUM:=2db80302ace2ea3bbec30c111a68d3ca
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Template tags for static content in Django
+	URL:=http://github.com/peterbe/django-static
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+endef
+
+define Package/$(PKG_NAME)/description
+ django-static enables template tags for better serving static content
+ in Django apps (e.g. for serving the static content outside Django).
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-django-statici18n/Makefile
+++ b/lang/python-package-django-statici18n/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=django-statici18n
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=1.1.5
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD-3-Clause
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/d/$(SRC_PKG_NAME)
+PKG_MD5SUM:=ad9941818f54428508fece4a463ea1cc
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Django helper for Javascript i18n
+	URL:=http://django-statici18n.readthedocs.org/
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python +python-package-django-1.5 +python-package-django-appconf
+endef
+
+define Package/$(PKG_NAME)/description
+ django-statici18n is a Django helper for Javascript i18n
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-djblets-0.6/Makefile
+++ b/lang/python-package-djblets-0.6/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-package-djblets-0.6
+SRC_PKG_NAME:=Djblets
+PKG_VERSION:=0.6.14
+PKG_RELEASE=1
+PKG_LICENSE:=MIT
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://downloads.reviewboard.org/releases/$(SRC_PKG_NAME)/0.6
+PKG_MD5SUM:=e4337111e9cc0a04db38eac5c2ad1383
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Utility module for Django-base web applications
+	URL:=https://github.com/djblets
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python +python-package-django-1.5 +python-package-pil
+	PROVIDES:=python-package-djblets
+endef
+
+define Package/$(PKG_NAME)/description
+ djblets is a collection of utilities functions for Django-based
+ web applications
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-djblets-0.8/Makefile
+++ b/lang/python-package-djblets-0.8/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-package-djblets
+SRC_PKG_NAME:=Djblets
+PKG_VERSION:=0.8.22
+PKG_RELEASE=1
+PKG_LICENSE:=MIT
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://downloads.reviewboard.org/releases/$(SRC_PKG_NAME)/0.8/
+PKG_MD5SUM:=25274d664ccb5130adae08047416e1a8
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Utility module for Django-base web applications
+	URL:=https://github.com/djblets
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python +python-package-django-1.8 +python-package-feedparser +python-package-pillowfight +python-package-pytz +python-package-django-pipeline
+	PROVIDES:=python-package-djblets
+endef
+
+define Package/$(PKG_NAME)/description
+ djblets is a collection of utilities functions for Django-based
+ web applications
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-docutils/Makefile
+++ b/lang/python-package-docutils/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=docutils
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=0.12
+PKG_RELEASE:=1
+PKG_LICENSE_FILE:=COPYING
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/d/$(SRC_PKG_NAME)
+PKG_MD5SUM:=4622263b62c5c771c03502afa3157768
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=System for processing documentation for Python
+	URL:=http://docutils.sourceforge.net
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+endef
+
+define Package/$(PKG_NAME)/description
+ docutils is a system for processing for documentation for Python
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-feedparser/Makefile
+++ b/lang/python-package-feedparser/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-package-feedparser
+SRC_PKG_NAME:=feedparser
+PKG_VERSION:=5.2.1
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD-2-Clause
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/f/$(SRC_PKG_NAME)
+PKG_MD5SUM:=d552f7a2a55e8e33b2a3fe1082505b42
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Universal feed parser for Python
+	URL:=https://github.com/kurtmckee/feedparser
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+endef
+
+define Package/$(PKG_NAME)/description
+ feedparser - Parse Atom and RSS feeds in Python.
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-flup/Makefile
+++ b/lang/python-package-flup/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=flup
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=1.0.2
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD-2-Clause
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/f/$(SRC_PKG_NAME)
+PKG_MD5SUM:=24dad7edc5ada31dddd49456ee8d5254
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=WSGI servers for Python
+	URL:=http://www.saddi.com/software/flup/
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+endef
+
+define Package/$(PKG_NAME)/description
+ A random assortment of WGSI servers
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-futures/Makefile
+++ b/lang/python-package-futures/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-package-futures
+SRC_PKG_NAME:=futures
+PKG_VERSION:=3.0.3
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD-2-Clause
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/f/$(SRC_PKG_NAME)
+PKG_MD5SUM:=32171f72af7e80c266310794adc4db46
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Asynchronous execution for Pyton
+	URL:=https://github.com/agronholm/pythonfutures
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python +python-package-django
+endef
+
+define Package/$(PKG_NAME)/description
+ futures is a python module for performing asycnhronous exection of tasks
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-gunicorn/Makefile
+++ b/lang/python-package-gunicorn/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=gunicorn
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=19.3.0
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/g/$(SRC_PKG_NAME)
+PKG_MD5SUM:=faa3e80661efd67e5e06bba32699af20
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=WSGI HTTP server for Unix
+	URL:=http://gunicorn.org
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+endef
+
+define Package/$(PKG_NAME)/description
+ gunicorn is a WGSI HTTP server for Python on Unix
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-lockfile/Makefile
+++ b/lang/python-package-lockfile/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=lockfile
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=0.10.2
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/l/$(SRC_PKG_NAME)
+PKG_MD5SUM:=1aa6175a6d57f082cd12e7ac6102ab15
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Platform-independent locking module for Python
+	URL:=http://launchpad.net/pylockfile
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+endef
+
+define Package/$(PKG_NAME)/description
+ lockfile is a platform-independent locking module for Python
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-pil/Makefile
+++ b/lang/python-package-pil/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=PIL
+PKG_NAME:=python-package-pil
+PKG_VERSION:=1.1.7
+PKG_RELEASE:=1
+PKG_LICENSE_FILE:=README
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://effbot.org/media/downloads
+PKG_MD5SUM:=a4f6ff4fe9490171910ad1585aef85b5
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Python Imaging Library
+	URL:=http://www.pythonware.com/products/pil
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python +zlib +libjpeg +libfreetype
+endef
+
+define Package/$(PKG_NAME)/description
+ PIL is an imaging library for Python
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-pil/patches/100-fix-using-libraries-from-host.patch
+++ b/lang/python-package-pil/patches/100-fix-using-libraries-from-host.patch
@@ -1,0 +1,221 @@
+Index: PIL-1.1.7/setup.py
+===================================================================
+--- PIL-1.1.7.orig/setup.py
++++ PIL-1.1.7/setup.py
+@@ -33,12 +33,22 @@ def libinclude(root):
+ #
+ # TIFF_ROOT = libinclude("/opt/tiff")
+ 
+-TCL_ROOT = None
+-JPEG_ROOT = None
+-ZLIB_ROOT = None
+-TIFF_ROOT = None
+-FREETYPE_ROOT = None
+-LCMS_ROOT = None
++JPEG_ROOT = os.environ.get('JPEG_ROOT')
++ZLIB_ROOT = os.environ.get('ZLIB_ROOT')
++TIFF_ROOT = os.environ.get('TIFF_ROOT')
++FREETYPE_ROOT = os.environ.get('FREETYPE_ROOT')
++
++if JPEG_ROOT is not None:
++    JPEG_ROOT = libinclude(JPEG_ROOT)
++
++if ZLIB_ROOT is not None:
++    ZLIB_ROOT = libinclude(ZLIB_ROOT)
++
++if TIFF_ROOT is not None:
++    TIFF_ROOT = libinclude(TIFF_ROOT)
++
++if FREETYPE_ROOT is not None:
++    FREETYPE_ROOT = libinclude(FREETYPE_ROOT)
+ 
+ # FIXME: add mechanism to explicitly *disable* the use of a library
+ 
+@@ -86,11 +96,6 @@ from distutils import sysconfig
+ from distutils.core import Extension, setup
+ from distutils.command.build_ext import build_ext
+ 
+-try:
+-    import _tkinter
+-except ImportError:
+-    _tkinter = None
+-
+ def add_directory(path, dir, where=None):
+     if dir and os.path.isdir(dir) and dir not in path:
+         if where is None:
+@@ -120,8 +125,6 @@ class pil_build_ext(build_ext):
+ 
+     def build_extensions(self):
+ 
+-        global TCL_ROOT
+-
+         library_dirs = []
+         include_dirs = []
+ 
+@@ -155,42 +158,8 @@ class pil_build_ext(build_ext):
+             add_directory(library_dirs, os.path.join(prefix, "lib"))
+             add_directory(include_dirs, os.path.join(prefix, "include"))
+ 
+-        #
+-        # locate tkinter libraries
+-
+-        if _tkinter:
+-            TCL_VERSION = _tkinter.TCL_VERSION[:3]
+-
+-        if _tkinter and not TCL_ROOT:
+-            # we have Tkinter but the TCL_ROOT variable was not set;
+-            # try to locate appropriate Tcl/Tk libraries
+-            PYVERSION = sys.version[0] + sys.version[2]
+-            TCLVERSION = TCL_VERSION[0] + TCL_VERSION[2]
+-            roots = [
+-                # common installation directories, mostly for Windows
+-                # (for Unix-style platforms, we'll check in well-known
+-                # locations later)
+-                os.path.join("/py" + PYVERSION, "Tcl"),
+-                os.path.join("/python" + PYVERSION, "Tcl"),
+-                "/Tcl", "/Tcl" + TCLVERSION, "/Tcl" + TCL_VERSION,
+-                os.path.join(os.environ.get("ProgramFiles", ""), "Tcl"),
+-                ]
+-            for TCL_ROOT in roots:
+-                TCL_ROOT = os.path.abspath(TCL_ROOT)
+-                if os.path.isfile(os.path.join(TCL_ROOT, "include", "tk.h")):
+-                    # FIXME: use distutils logging (?)
+-                    print "--- using Tcl/Tk libraries at", TCL_ROOT
+-                    print "--- using Tcl/Tk version", TCL_VERSION
+-                    TCL_ROOT = libinclude(TCL_ROOT)
+-                    break
+-            else:
+-                TCL_ROOT = None
+-
+-        #
+-        # add configured kits
+-
+-        for root in (TCL_ROOT, JPEG_ROOT, TCL_ROOT, TIFF_ROOT, ZLIB_ROOT,
+-                     FREETYPE_ROOT, LCMS_ROOT):
++        for root in (JPEG_ROOT, TIFF_ROOT, ZLIB_ROOT,
++                     FREETYPE_ROOT):
+             if isinstance(root, type(())):
+                 lib_root, include_root = root
+             else:
+@@ -201,18 +170,12 @@ class pil_build_ext(build_ext):
+         #
+         # add standard directories
+ 
+-        # look for tcl specific subdirectory (e.g debian)
+-        if _tkinter:
+-            tcl_dir = "/usr/include/tcl" + TCL_VERSION
+-            if os.path.isfile(os.path.join(tcl_dir, "tk.h")):
+-                add_directory(include_dirs, tcl_dir)
+-
+         # standard locations
+-        add_directory(library_dirs, "/usr/local/lib")
+-        add_directory(include_dirs, "/usr/local/include")
++        #add_directory(library_dirs, "/usr/local/lib")
++        #add_directory(include_dirs, "/usr/local/include")
+ 
+-        add_directory(library_dirs, "/usr/lib")
+-        add_directory(include_dirs, "/usr/include")
++        #add_directory(library_dirs, "/usr/lib")
++        #add_directory(include_dirs, "/usr/include")
+ 
+         #
+         # insert new dirs *before* default libs, to avoid conflicts
+@@ -225,7 +188,7 @@ class pil_build_ext(build_ext):
+         # look for available libraries
+ 
+         class feature:
+-            zlib = jpeg = tiff = freetype = tcl = tk = lcms = None
++            zlib = jpeg = tiff = freetype = None
+         feature = feature()
+ 
+         if find_include_file(self, "zlib.h"):
+@@ -264,22 +227,6 @@ class pil_build_ext(build_ext):
+                 if dir:
+                     add_directory(self.compiler.include_dirs, dir, 0)
+ 
+-        if find_include_file(self, "lcms.h"):
+-            if find_library_file(self, "lcms"):
+-                feature.lcms = "lcms"
+-
+-        if _tkinter and find_include_file(self, "tk.h"):
+-            # the library names may vary somewhat (e.g. tcl84 or tcl8.4)
+-            version = TCL_VERSION[0] + TCL_VERSION[2]
+-            if find_library_file(self, "tcl" + version):
+-                feature.tcl = "tcl" + version
+-            elif find_library_file(self, "tcl" + TCL_VERSION):
+-                feature.tcl = "tcl" + TCL_VERSION
+-            if find_library_file(self, "tk" + version):
+-                feature.tk = "tk" + version
+-            elif find_library_file(self, "tk" + TCL_VERSION):
+-                feature.tk = "tk" + TCL_VERSION
+-
+         #
+         # core library
+ 
+@@ -323,43 +270,6 @@ class pil_build_ext(build_ext):
+                 "_imagingtiff", ["_imagingtiff.c"], libraries=["tiff"]
+                 ))
+ 
+-        if os.path.isfile("_imagingcms.c") and feature.lcms:
+-            extra = []
+-            if sys.platform == "win32":
+-                extra.extend(["user32", "gdi32"])
+-            exts.append(Extension(
+-                "_imagingcms", ["_imagingcms.c"], libraries=["lcms"] + extra
+-                ))
+-
+-        if sys.platform == "darwin":
+-            # locate Tcl/Tk frameworks
+-            frameworks = []
+-            framework_roots = [
+-                "/Library/Frameworks",
+-                "/System/Library/Frameworks"
+-                ]
+-            for root in framework_roots:
+-                if (os.path.exists(os.path.join(root, "Tcl.framework")) and
+-                    os.path.exists(os.path.join(root, "Tk.framework"))):
+-                    print "--- using frameworks at", root
+-                    frameworks = ["-framework", "Tcl", "-framework", "Tk"]
+-                    dir = os.path.join(root, "Tcl.framework", "Headers")
+-                    add_directory(self.compiler.include_dirs, dir, 0)
+-                    dir = os.path.join(root, "Tk.framework", "Headers")
+-                    add_directory(self.compiler.include_dirs, dir, 1)
+-                    break
+-            if frameworks:
+-                exts.append(Extension(
+-                    "_imagingtk", ["_imagingtk.c", "Tk/tkImaging.c"],
+-                    extra_compile_args=frameworks, extra_link_args=frameworks
+-                    ))
+-                feature.tcl = feature.tk = 1 # mark as present
+-        elif feature.tcl and feature.tk:
+-            exts.append(Extension(
+-                "_imagingtk", ["_imagingtk.c", "Tk/tkImaging.c"],
+-                libraries=[feature.tcl, feature.tk]
+-                ))
+-
+         if os.path.isfile("_imagingmath.c"):
+             exts.append(Extension("_imagingmath", ["_imagingmath.c"]))
+ 
+@@ -390,12 +300,10 @@ class pil_build_ext(build_ext):
+         print "-" * 68
+ 
+         options = [
+-            (feature.tcl and feature.tk, "TKINTER"),
+             (feature.jpeg, "JPEG"),
+             (feature.zlib, "ZLIB (PNG/ZIP)"),
+             # (feature.tiff, "experimental TIFF G3/G4 read"),
+             (feature.freetype, "FREETYPE2"),
+-            (feature.lcms, "LITTLECMS"),
+             ]
+ 
+         all = 1
+@@ -404,9 +312,6 @@ class pil_build_ext(build_ext):
+                 print "---", option[1], "support available"
+             else:
+                 print "***", option[1], "support not available",
+-                if option[1] == "TKINTER" and _tkinter:
+-                    version = _tkinter.TCL_VERSION
+-                    print "(Tcl/Tk %s libraries needed)" % version,
+                 print
+                 all = 0
+ 

--- a/lang/python-package-pil/patches/110-fix-wrong-dir-for-freetype.patch
+++ b/lang/python-package-pil/patches/110-fix-wrong-dir-for-freetype.patch
@@ -1,0 +1,22 @@
+Index: PIL-1.1.7/_imagingft.c
+===================================================================
+--- PIL-1.1.7.orig/_imagingft.c
++++ PIL-1.1.7/_imagingft.c
+@@ -32,7 +32,7 @@
+ #include FT_FREETYPE_H
+ #else
+ /* freetype 2.0 */
+-#include <freetype/freetype.h>
++#include <freetype2/freetype.h>
+ #endif
+ 
+ #if PY_VERSION_HEX < 0x01060000
+@@ -70,7 +70,7 @@ struct {
+     const char* message;
+ } ft_errors[] =
+ 
+-#include <freetype/fterrors.h>
++#include <freetype2/fterrors.h>
+ 
+ /* -------------------------------------------------------------------- */
+ /* font objects */

--- a/lang/python-package-pillow/Makefile
+++ b/lang/python-package-pillow/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=Pillow
+PKG_NAME:=python-package-pillow
+PKG_VERSION:=2.9.0
+PKG_RELEASE:=1
+PKG_LICENSE_FILE:=LICENSE
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/P/$(SRC_PKG_NAME)
+PKG_MD5SUM:=46f1729ece27981d54ec543ad5b37d14
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Fork of Python Imaging Library
+	URL:=http://python-pillow.github.io
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python +zlib +libjpeg +libfreetype +libtiff
+endef
+
+define Package/$(PKG_NAME)/description
+ Pillow is a for of PIL - an imaging library for Python
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),PIL))
+
+define Build/Compile
+	$(CP) ./files/setup.cfg $(PKG_BUILD_DIR)/
+	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR),INCLUDE=$(STAGING_DIR)/usr/include LD_RUN_PATH=$(STAGING_DIR)/usr/lib)
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-pillow/files/setup.cfg
+++ b/lang/python-package-pillow/files/setup.cfg
@@ -1,0 +1,13 @@
+[egg_info]
+tag_build = 
+tag_date = 0
+tag_svn_revision = 0
+
+[build_ext]
+disable_jpeg2000 = True
+disable_lcms = True
+disable_webp = True
+disable_webpmux = True
+disable_tk = True
+disable_tcl = True
+

--- a/lang/python-package-pillow/patches/010-fix-using-host-includes.patch
+++ b/lang/python-package-pillow/patches/010-fix-using-host-includes.patch
@@ -1,0 +1,30 @@
+Index: Pillow-2.9.0/setup.py
+===================================================================
+--- Pillow-2.9.0.orig/setup.py
++++ Pillow-2.9.0/setup.py
+@@ -340,17 +340,17 @@ class pil_build_ext(build_ext):
+         # add standard directories
+ 
+         # look for tcl specific subdirectory (e.g debian)
+-        if _tkinter:
+-            tcl_dir = "/usr/include/tcl" + TCL_VERSION
+-            if os.path.isfile(os.path.join(tcl_dir, "tk.h")):
+-                _add_directory(include_dirs, tcl_dir)
++        #if _tkinter:
++        #    tcl_dir = "/usr/include/tcl" + TCL_VERSION
++        #    if os.path.isfile(os.path.join(tcl_dir, "tk.h")):
++        #        _add_directory(include_dirs, tcl_dir)
+ 
+         # standard locations
+-        _add_directory(library_dirs, "/usr/local/lib")
+-        _add_directory(include_dirs, "/usr/local/include")
++        #_add_directory(library_dirs, "/usr/local/lib")
++        #_add_directory(include_dirs, "/usr/local/include")
+ 
+-        _add_directory(library_dirs, "/usr/lib")
+-        _add_directory(include_dirs, "/usr/include")
++        #_add_directory(library_dirs, "/usr/lib")
++        #_add_directory(include_dirs, "/usr/include")
+ 
+         # on Windows, look for the OpenJPEG libraries in the location that
+         # the official installer puts them

--- a/lang/python-package-pillowfight/Makefile
+++ b/lang/python-package-pillowfight/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=pillowfight
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=0.2
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/$(SRC_PKG_NAME)
+PKG_MD5SUM:=5f5df64de2e2bf7599460da08dfca08d
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Ease transition from PIL to Pillow (Python)
+	URL:=https://github.com/beanbaginc/pillowfight
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+endef
+
+define Package/$(PKG_NAME)/description
+ pillowfight eases transition from PIL to Pillow
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-python-daemon/Makefile
+++ b/lang/python-package-python-daemon/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=python-daemon
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=2.0.6
+PKG_RELEASE:=1
+PKG_LICENSE:=Apache-2.0
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/$(SRC_PKG_NAME)
+PKG_MD5SUM:=049508c47c8fa054e91ec9a3c572f939
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools python-package-docutils
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=PEP 3143 well-behaved daemon library for Python
+	URL:=https://alioth.debian.org/projects/python-daemon
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python +python-package-docutils +python-package-lockfile
+endef
+
+define Package/$(PKG_NAME)/description
+ python-daemon implements PEP 3143 well-behaved daemon library for Python
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-python-dateutil/Makefile
+++ b/lang/python-package-python-dateutil/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=python-dateutil
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=2.4.2
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD-3-Clause
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/$(SRC_PKG_NAME)
+PKG_MD5SUM:=4ef68e1c485b09e9f034e10473e5add2
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Extension to datetime module for Python
+	URL:=https://github.com/chardet/chardet
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python +python-package-six
+endef
+
+define Package/$(PKG_NAME)/description
+ python-dateutil is a power extension to datetime module for Python
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),dateutil))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-pytz/Makefile
+++ b/lang/python-package-pytz/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=pytz
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=2015.6
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/$(SRC_PKG_NAME)
+PKG_MD5SUM:=ff047a16dafeaa895bedef80a74c3728
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=World timezone definitions for Python
+	URL:=http://pythonhosted.org/pytz
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+endef
+
+define Package/$(PKG_NAME)/description
+ pytz brings the Olson tz database into Python.
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python-package-six/Makefile
+++ b/lang/python-package-six/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+SRC_PKG_NAME:=six
+PKG_NAME:=python-package-$(SRC_PKG_NAME)
+PKG_VERSION:=1.9.0
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/s/$(SRC_PKG_NAME)
+PKG_MD5SUM:=476881ef4012262dfc8adc645ee786c4
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Python 2 and 3 compatibility library for Python
+	URL:=http://pypi.python.org/pypi/six
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+endef
+
+define Package/$(PKG_NAME)/description
+ six is a Python 2 and 3 compatibility library for Python
+endef
+
+$(eval $(call PyMod/Default,$(SRC_PKG_NAME),))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/python/files/python-package.mk
+++ b/lang/python/files/python-package.mk
@@ -109,3 +109,23 @@ define Build/Compile/PyMod
 	find $(PKG_INSTALL_DIR) -name "*\.pyc" -o -name "*\.pyo" | xargs rm -f
 endef
 
+define PyMod/Default
+  define Build/Compile
+	$$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+  endef
+
+  define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $$(1)$(PYTHON_PKG_DIR) $$(1)/usr/bin
+	if [ -d $(PKG_INSTALL_DIR)/usr/bin ]; then find $(PKG_INSTALL_DIR)/usr/bin -mindepth 1 -maxdepth 1 -type f -exec $(CP) \{\} $$(1)/usr/bin/ \; ; fi
+	find $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/$(subst -,_,$(1))* -maxdepth 0 \( -type f -o -type d \) -exec $(CP) \{\} $$(1)$(PYTHON_PKG_DIR)/ \;
+	if [ -n "$(2)" ]; then find $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/$(2)* -maxdepth 0 \( -type f -o -type d \) -exec $(CP) \{\} $$(1)$(PYTHON_PKG_DIR)/ \; ; fi
+  endef
+
+  define Build/InstallDev
+	$(INSTALL_DIR) $$(1)/usr/bin $(PYTHON_LIB_DIR)
+	if [ -d $(PKG_INSTALL_DIR)/usr/bin ]; then find $(PKG_INSTALL_DIR)/usr/bin -mindepth 1 -maxdepth 1 -type f -exec $(CP) \{\} $$(1)/usr/bin/ \; ; fi
+	find $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/$(subst -,_,$(1))* -maxdepth 0 \( -type f -o -type d \) -exec $(CP) \{\} $(PYTHON_LIB_DIR)/ \;
+	if [ -n "$(2)" ]; then find $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/$(2) -maxdepth 0 \( -type f -o -type d \) -exec $(CP) \{\} $(PYTHON_LIB_DIR)/ \; ; fi
+  endef
+endef
+


### PR DESCRIPTION
This pull request adds some makefile magic to the python packaging makefile and uses it to build a substantial collection of third party python packages.

Of particular note is the correct cross-compilation of PIL and Pillow, which the current Seahub python dependency stuff gets wrong, resulting in failures when dealing with cross-compilation (target arch != host arch).

This was primarily initiated in order to get proper packaging and dependencies for seahub, but is more generally useful that just that.