### PR TITLE
rar2fs: new package

### DIFF
--- a/utils/rar2fs/Makefile
+++ b/utils/rar2fs/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 OpenWrt.org
+# Copyright (C) 2015-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.

--- a/utils/rar2fs/Makefile
+++ b/utils/rar2fs/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rar2fs
-PKG_VERSION:=1.21.0
+PKG_VERSION:=1.22.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=rar2fs-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/hasse69/rar2fs/releases/download/v$(PKG_VERSION)
-PKG_MD5SUM:=afe744740f9ca71986a798bba1fe8b44
+PKG_MD5SUM:=56b374b95d6d56dc94f24997749294fe
 PKG_MAINTAINER:=Nikolay Podoprigora <volzhanin@gmail.com>
 
 PKG_LICENSE:=GPL-3.0

--- a/utils/rar2fs/Makefile
+++ b/utils/rar2fs/Makefile
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rar2fs
+PKG_VERSION:=1.21.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=rar2fs-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/hasse69/rar2fs/releases/download/v$(PKG_VERSION)
+PKG_MD5SUM:=afe744740f9ca71986a798bba1fe8b44
+PKG_MAINTAINER:=Nikolay Podoprigora <volzhanin@gmail.com>
+
+PKG_LICENSE:=GPL-3.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+CONFIGURE_ARGS += \
+	--with-unrar=$(STAGING_DIR)/usr/include/unrar
+
+define Package/rar2fs
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Filesystem
+  TITLE:=rar2fs
+  URL:=https://github.com/hasse69/rar2fs
+  DEPENDS:=+libstdcpp +libfuse +libunrar
+endef
+
+define Package/rar2fs/description
+	FUSE file system for reading RAR archives
+endef
+
+define Package/rar2fs/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{rar2fs,mkr2i} $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(LN) /usr/bin/rar2fs $(1)/usr/sbin/mount.rar2fs
+endef
+
+$(eval $(call BuildPackage,rar2fs))


### PR DESCRIPTION
An excerpt from rar2fs [README](https://github.com/hasse69/rar2fs/blob/master/README):
```
rar2fs is a FUSE based file system that can mount a source RAR archive/volume
or a directory containing any number of RAR archives and read the contents as
regular files on-the-fly. Non-archived files located in the source directory
are handled transparently. Both compressed and non-compressed 
archives/volumes are supported but full media seek support (aka. indexing) is
only available for non-compressed plaintext archives. In general support for
compressed and/or encrypted archives is "best effort", highly depending on
what type of information the archive contains and by what method it is 
accessed.
```

Signed-off-by: Nikolay Podoprigora <volzhanin@gmail.com>