### PR TITLE
mpg123: build with alsa only

### DIFF
--- a/sound/mpg123/Makefile
+++ b/sound/mpg123/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpg123
 PKG_VERSION:=1.22.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.mpg123.de/download/
@@ -51,6 +51,7 @@ define Build/Configure
 		--enable-shared \
 		--enable-static \
 		--with-cpu=generic_nofpu \
+		--with-audio=alsa \
 		--with-default-audio=alsa \
 	)
 endef


### PR DESCRIPTION
This was the minimal work to fix build errors (missing dependencies) when either or both pulseaudio and portaudio are compiled before mpg123. If it is desired to have additional audio sub-systems supported they will need to be added as either options or, at the least, additional dependencies.

@wigyori - please review

Signed-off-by: Ted Hess <thess@kitschensync.net>