### PR TITLE
madplay: fix missing binary in madplay-oss package

### DIFF
--- a/sound/madplay/Makefile
+++ b/sound/madplay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=madplay
 PKG_VERSION:=0.15.2b
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/mad \
@@ -73,7 +73,7 @@ endif
 
 define Package/madplay/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/madplay $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/madplay $(1)/usr/bin/
 endef
 
 define Package/madplay-alsa/install


### PR DESCRIPTION
Fixes #1896 

@probonopd - OK?

Signed-off-by: Ted Hess <thess@kitschensync.net>