### PR TITLE
Boost: Version Update -> 1.60

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -16,14 +16,14 @@ include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/target.mk 
 
 PKG_NAME:=boost
-PKG_VERSION:=1_59_0
-PKG_RELEASE:=8
+PKG_VERSION:=1_60_0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/boost
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)_$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)_$(PKG_VERSION)
-PKG_MD5SUM:=51528a0e3b33d9e10aaa311d9eb451e3
+PKG_MD5SUM:=28f58b9a33469388302110562bdf6188
 PKG_LICENSE:=Boost Software License <http://www.boost.org/users/license.html>
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>
 


### PR DESCRIPTION
Version Update:
 - Boost is updated to version 1.60
   - New library called Variadic Macro Data (VMD) [[1]]
   - Several libraries updates [[2]]

[1]: http://www.boost.org/libs/vmd/
[2]: http://www.boost.org/users/history/version_1_60_0.html

Signed-off-by: Carlos M. Ferreira <carlosmf.pt@gmail.com>