### PR TITLE
node: fix build on x86 & x86.64 targets

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
 PKG_VERSION:=v0.12.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=node-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://nodejs.org/dist/${PKG_VERSION}
@@ -40,8 +40,13 @@ define Package/node/description
    package ecosystem, npm, is the largest ecosystem of open source libraries in the world.
 endef
 
+CPU:=$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))
+
+MAKE_VARS += \
+	DESTCPU=$(CPU)
+
 CONFIGURE_ARGS= \
-	--dest-cpu=$(CONFIG_ARCH) \
+	--dest-cpu=$(CPU) \
 	--dest-os=linux \
 	--without-snapshot \
 	--shared-zlib \


### PR DESCRIPTION
[ Tested on both x86 and x86_64 ]
Fixes https://github.com/openwrt/packages/issues/2068

For x86 and x86_64, nodejs has some special CPU
code that needs to be selected by specifying
the correct CPU name (correct for nodejs).

On OpenWRT x86 is i386 ; node wants ia32 for this.
And x86_64 is x64 on nodejs.

So, we just need to do the proper substitutions.

Note: the ARCH env-var is obtained from CONFIG_ARCH, after
some subtitutions are applied.
So, it shouldn't affect other target archs.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>