### PR TITLE
davfs2: fix inconsistency with HAVE_ICONV and HAVE_ICONV_H

### DIFF
--- a/net/davfs2/Makefile
+++ b/net/davfs2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=davfs2
 PKG_VERSION:=1.5.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.savannah.gnu.org/releases/davfs2/
@@ -23,7 +23,7 @@ define Package/davfs2
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Filesystem
-  DEPENDS=+libneon +kmod-fuse +libfuse
+  DEPENDS=+libneon +kmod-fuse +libfuse $(ICONV_DEPENDS)
   TITLE:=Mount a WebDAV resource as a regular file system.
   URL:=http://savannah.nongnu.org/projects/davfs2/
   MAINTAINER:=Federico Di Marco <fededim@gmail.com>

--- a/net/davfs2/patches/001-replace-have-iconv-h-with-have-iconv.patch
+++ b/net/davfs2/patches/001-replace-have-iconv-h-with-have-iconv.patch
@@ -1,0 +1,40 @@
+diff --git a/src/webdav.c b/src/webdav.c
+index 1ff7c7f..74cd957 100644
+--- a/src/webdav.c
++++ b/src/webdav.c
+@@ -25,7 +25,7 @@
+ #ifdef HAVE_FCNTL_H
+ #include <fcntl.h>
+ #endif
+-#ifdef HAVE_ICONV_H
++#ifdef HAVE_ICONV
+ #include <iconv.h>
+ #endif
+ #ifdef HAVE_LANGINFO_H
+@@ -231,7 +231,7 @@ static int initialized;
+    Needed by  ssl_verify() which may be called at any time. */
+ static int have_terminal;
+ 
+-#ifdef HAVE_ICONV_H
++#ifdef HAVE_ICONV
+ /* Handle to convert character encoding from utf-8 to LC_CTYPE.
+    If NULL no conversion is done. */
+ static iconv_t from_utf_8;
+@@ -264,7 +264,7 @@ static char **cookie_list;
+ /* Private function prototypes and inline functions */
+ /*==================================================*/
+ 
+-#ifdef HAVE_ICONV_H
++#ifdef HAVE_ICONV
+ static void
+ convert(char **s, iconv_t conv);
+ #endif
+@@ -337,7 +337,7 @@ dav_init_webdav(const dav_args *args)
+     if (args->neon_debug & ~NE_DBG_HTTPPLAIN)
+         syslog(LOG_MAKEPRI(LOG_DAEMON, LOG_DEBUG), "Initializing webdav");
+ 
+-#ifdef HAVE_ICONV_H
++#ifdef HAVE_ICONV
+     char *lc_charset = nl_langinfo(CODESET);
+     if (lc_charset && strcasecmp(lc_charset, "UTF-8") != 0) {
+         from_utf_8 = iconv_open(lc_charset, "UTF-8");


### PR DESCRIPTION
Fixes: https://github.com/openwrt/packages/issues/1327

Seems that HAVE_ICONV was 1 and HAVE_ICONV_H undefined.
Resulting in build errors like this:
  webdav.c: In function 'dav_conv_from_utf_8':
  webdav.c:587:9: error: 'from_utf_8' undeclared (first use in this function)
       if (from_utf_8)

Also, we're adding $(ICONV_DEPENDS) to the DEPENDS of this package.
Just adding the DEPENDS does not fix.
Seems the patch is still necessary.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>