### PR TITLE
mdnsresponder: (fix build) use TARGET_CC as LD

### DIFF
--- a/net/mdnsresponder/Makefile
+++ b/net/mdnsresponder/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mDNSResponder
 PKG_VERSION:=567
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=mDNSResponder-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://opensource.apple.com/tarballs/mDNSResponder/
@@ -85,6 +85,7 @@ endef
 # I have no idea why -lc is required, but without it, C library symbols are
 # not found:
 MAKE_FLAGS += \
+	LD="$(TARGET_CC)"  \
 	CFLAGS_DEBUG="$(TARGET_CFLAGS)" \
 	LINKOPTS=-lc \
 	LDCONFIG= \


### PR DESCRIPTION
Probably related to -fstack-protector being used.
Got the idea from:
  http://ubuntuforums.org/showthread.php?t=352642&p=10100263#post10100263
  Regarding the missing __stack_check_fail_local, using gcc as the linker instead of ld fixes the issue without disabling stack protection as with -fno-stack-protector.

Fixes linker errs on some targets:
  objects/prod/dnssd_clientstub.c.so.o: In function `handle_resolve_response':
  dnssd_clientstub.c:(.text+0x395): undefined reference to `__stack_chk_fail_local'
  objects/prod/dnssd_clientstub.c.so.o: In function `handle_query_response':
  dnssd_clientstub.c:(.text+0x4bd): undefined reference to `__stack_chk_fail_local'

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>