### PR TITLE
luaposix: suppress docs compilation errors

### DIFF
--- a/lang/luaposix/Makefile
+++ b/lang/luaposix/Makefile
@@ -38,7 +38,7 @@ define Package/luaposix/description
   to various low level libc functions.
 endef
 
-CONFIGURE_VARS += ac_cv_path_LDOC=""
+CONFIGURE_VARS += ac_cv_path_LDOC="true"
 
 TARGET_CFLAGS += -DLUA_USE_LINUX $(FPIC) -std=gnu99
 ifeq ($(CONFIG_USE_MUSL),y)


### PR DESCRIPTION
Suppress 51 errors while 'compiling' docs.
* before:
```
make[3]: Entering directory '/home/ryzhovau/Entware-ng/build_dir/target-mipsel_mips32r2_uClibc-1.0.9/luaposix-release-v33.2.1'
make  all-am
make[4]: Entering directory '/home/ryzhovau/Entware-ng/build_dir/target-mipsel_mips32r2_uClibc-1.0.9/luaposix-release-v33.2.1'
  CC       ext/posix/posix.lo
  CCLD     ext/posix/posix.la
test -d ./doc || mkdir ./doc
c build-aux/config.ld -d /home/ryzhovau/Entware-ng/build_dir/target-mipsel_mips32r2_uClibc-1.0.9/luaposix-release-v33.2.1/doc .
/bin/bash: c: command not found
Makefile:2044: recipe for target 'doc/classes/posix.curses.chstr.html' failed
make[4]: [doc/classes/posix.curses.chstr.html] Error 127 (ignored)
test -d ./doc || mkdir ./doc
c build-aux/config.ld -d /home/ryzhovau/Entware-ng/build_dir/target-mipsel_mips32r2_uClibc-1.0.9/luaposix-release-v33.2.1/doc .
/bin/bash: c: command not found
Makefile:2044: recipe for target 'doc/classes/posix.curses.window.html' failed
make[4]: [doc/classes/posix.curses.window.html] Error 127 (ignored)
...
```
* after:
```
make[4]: Entering directory '/home/ryzhovau/Entware-ng/build_dir/target-mipsel_mips32r2_uClibc-1.0.9/luaposix-release-v33.2.1'
  CC       ext/posix/posix.lo
  CCLD     ext/posix/posix.la
test -d ./doc || mkdir ./doc
true -c build-aux/config.ld -d /home/ryzhovau/Entware-ng/build_dir/target-mipsel_mips32r2_uClibc-1.0.9/luaposix-release-v33.2.1/doc .
test -d ./doc || mkdir ./doc
true -c build-aux/config.ld -d /home/ryzhovau/Entware-ng/build_dir/target-mipsel_mips32r2_uClibc-1.0.9/luaposix-release-v33.2.1/doc .
test -d ./doc || mkdir ./doc
true -c build-aux/config.ld -d /home/ryzhovau/Entware-ng/build_dir/target-mipsel_mips32r2_uClibc-1.0.9/luaposix-release-v33.2.1/doc .
test -d ./doc || mkdir ./doc
true -c build-aux/config.ld -d /home/ryzhovau/Entware-ng/build_dir/target-mipsel_mips32r2_uClibc-1.0.9/luaposix-release-v33.2.1/doc .
test -d ./doc || mkdir ./doc
...
```