### PR TITLE
mwan3: update to version 2.0-2

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Jeroen Louwes <jeroen.louwes@gmail.com>
 PKG_LICENSE:=GPLv2
 


### PR DESCRIPTION
Fix iptables issue where a needed ipset was not created if first wan that came online was not a member of policy.

Signed-off-by: Jeroen Louwes <jeroen.louwes@gmail.com>