### PR TITLE
sshtunnel: do not honor invalid config sections

### DIFF
--- a/net/sshtunnel/Makefile
+++ b/net/sshtunnel/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sshtunnel
 PKG_VERSION:=4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0+
 
 PKG_MAINTAINER:=Nuno Goncalves <nunojpg@gmail.com>

--- a/net/sshtunnel/files/sshtunnel.init
+++ b/net/sshtunnel/files/sshtunnel.init
@@ -53,6 +53,7 @@ validate_server_section() {
 		'StrictHostKeyChecking:or("yes", "no")' \
 		'TCPKeepAlive:or("yes", "no")' \
 		'VerifyHostKeyDNS:or("yes", "no")'
+	return $?
 }
 
 validate_tunnelR_section() {
@@ -61,6 +62,7 @@ validate_tunnelR_section() {
 		'remoteport:port' \
 		'localaddress:host' \
 		'localport:port'
+	return $?
 }
 
 validate_tunnelL_section() {
@@ -69,12 +71,14 @@ validate_tunnelL_section() {
 		'remoteport:port' \
 		'localaddress:or(host, "*"):*' \
 		'localport:port'
+	return $?
 }
 
 validate_tunnelD_section() {
 	uci_validate_section sshtunnel tunnelD "$1" \
 		'localaddress:or(host, "*"):*' \
 		'localport:port'
+	return $?
 }
 
 validate_tunnelW_section() {
@@ -82,6 +86,7 @@ validate_tunnelW_section() {
 		'vpntype:or("ethernet", "point-to-point"):point-to-point' \
 		'localdev:or("any", min(1))' \
 		'remotedev:or("any", min(1))'
+	return $?
 }
 
 load_tunnelR() {


### PR DESCRIPTION
The various validate* functions now return an error code when
validation fails, and will not be appended to the `ssh` command
for the server in question.

This was a part of the original pull request, but those lines got dropped out, probably because the same pattern is seen in other packages.

Without the patch an invalid tunnelL/tunnelR/... section will cause ssh to complain and exit, and get restarted infinitely by procd.