### PR TITLE
lang/python-six: Use PyMod so that other modules can find six

### DIFF
--- a/lang/python-six/Makefile
+++ b/lang/python-six/Makefile
@@ -14,6 +14,8 @@ PKG_RELEASE:=1
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/source/s/six
 PKG_MD5SUM:=34eed507548117b2ab523ab14b2f8b55
+PKG_SOURCE_DIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
 
 PKG_BUILD_DEPENDS:=python python-setuptools
 
@@ -40,9 +42,5 @@ writing Python code that is compatible on both Python versions.  See the
 documentation for more information on what is provided.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-$(eval $(call PyPackage,python-six))
+$(eval $(call PyMod/Default))
 $(eval $(call BuildPackage,python-six))


### PR DESCRIPTION
PyMod includes InstallDev which is necessary for other modules
to find this module and not attempt to download and build it
as part of their easy_install

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>