### PR TITLE
lang/python-feedparser: Parse Atom and RSS feeds

### DIFF
--- a/lang/python-feedparser/Makefile
+++ b/lang/python-feedparser/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-feedparser
+SRC_PKG_NAME:=feedparser
+PKG_VERSION:=5.2.1
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD-2-Clause
+
+PKG_SOURCE:=$(SRC_PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/f/$(SRC_PKG_NAME)
+PKG_MD5SUM:=d552f7a2a55e8e33b2a3fe1082505b42
+PKG_SOURCE_DIR:=$(SRC_PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+define Package/$(PKG_NAME)
+	SUBMENU:=Python
+	SECTION:=lang
+	CATEGORY:=Languages
+	TITLE:=Universal feed parser for Python
+	URL:=https://github.com/kurtmckee/feedparser
+	MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+	DEPENDS:=+python
+endef
+
+define Package/$(PKG_NAME)/description
+ feedparser - Parse Atom and RSS feeds in Python.
+endef
+
+$(eval $(call PyMod/Default))
+$(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
Third party module for parsing Atom and RSS feeds

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>