### PR TITLE
ddns-scripts: Added dy.fi service

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ddns-scripts
 # Version == major.minor.patch
 # increase on new functionality (minor) or patches (patch)
-PKG_VERSION:=2.5.0
+PKG_VERSION:=2.5.1
 # Release == build
 # increase on changes of services files or tld_names.dat
 PKG_RELEASE:=2

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ddns-scripts
 # Version == major.minor.patch
 # increase on new functionality (minor) or patches (patch)
-PKG_VERSION:=2.5.1
+PKG_VERSION:=2.5.0
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -103,3 +103,6 @@
 
  #DtDNS
 "dtdns.com"	"http://www.dtdns.com/api/autodns.cfm?id=[DOMAIN]&pw=[PASSWORD]&ip=[IP]"
+
+# dy.fi Dynamic DNS for finnish users
+"dy.fi"      "http://[USERNAME]:[PASSWORD]@www.dy.fi/nic/update?hostname=[DOMAIN]"


### PR DESCRIPTION
Added dy.fi dynamic dns provider into ddns-scripts (ipv4) services file.

Tested-by: Vaasa Hacklab ry <info@vaasa.hacklab.fi>
Signed-off-by: Sami Olmari <sami@olmari.fi>