### PR TITLE
devel/pkg-config: new package

### DIFF
--- a/devel/pkg-config/Makefile
+++ b/devel/pkg-config/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pkg-config
+PKG_VERSION:=0.29
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=http://pkgconfig.freedesktop.org/releases/
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_MD5SUM:=77f27dce7ef88d0634d0d6f90e03a77f
+PKG_MAINTAINER:=Heinrich Schuchardt <xypron.glpk@gmx.de>
+PKG_LICENSE:=GPL-2+
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/pkg-config
+  SECTION:=devel
+  CATEGORY:=Development
+  TITLE:=pkg-config
+  URL:=http://www.freedesktop.org/wiki/Software/pkg-config/
+  DEPENDS:=+glib2
+endef
+
+define Package/pkg-config/description
+  pkg-config is a helper tool used when compiling applications and libraries.
+  It helps you insert the correct compiler options on the command line so an
+  application can use gcc -o test test.cpkg-config --libs --cflags glib-2.0
+  for instance, rather than hard-coding values on where to find glib (or
+  other libraries). 
+endef
+
+define Package/pkg-config/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/pkg-config $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/share/aclocal/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/aclocal/pkg.m4 \
+	  $(1)/usr/share/aclocal/
+endef
+
+$(eval $(call BuildPackage,pkg-config))


### PR DESCRIPTION
pkg-config is a helper tool used when compiling applications and libraries.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>