### PR TITLE
python: fixed _python_sysroot paths

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -12,7 +12,7 @@ include ./files/python-package.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)

--- a/lang/python/files/python-host.mk
+++ b/lang/python/files/python-host.mk
@@ -13,10 +13,10 @@ HOST_PYTHONPATH:=$(HOST_PYTHON_LIB_DIR):$(STAGING_DIR_HOST)/$(HOST_PYTHON_PKG_DI
 define HostPython
 	if [ "$(strip $(3))" == "HOST" ]; then \
 		export PYTHONPATH="$(HOST_PYTHONPATH)"; \
-		export _python_sysroot="$(STAGING_DIR_HOST)/usr"; \
+		export _python_sysroot="$(STAGING_DIR_HOST)"; \
 	else \
 		export PYTHONPATH="$(PYTHONPATH)"; \
-		export _python_sysroot="$(STAGING_DIR)/usr"; \
+		export _python_sysroot="$(STAGING_DIR)"; \
 	fi; \
 	export PYTHONOPTIMIZE=""; \
 	export PYTHONDONTWRITEBYTECODE=1; \
@@ -29,7 +29,7 @@ endef
 # These configure args are needed in detection of path to Python header files
 # using autotools.
 HOST_CONFIGURE_ARGS += \
-	_python_sysroot="$(STAGING_DIR_HOST)/usr" \
+	_python_sysroot="$(STAGING_DIR_HOST)" \
 	_python_prefix="/usr" \
 	_python_exec_prefix="/usr"
 


### PR DESCRIPTION
AFAIK sysroot is combined with prefix/exec_prefix, so sysroot shouldn't
include "/usr". (cf. the HostPython function in older versions of
python-package.mk)

Signed-off-by: Jeffery To <jeffery.to@gmail.com>