### PR TITLE
python-ply: update host install path

### DIFF
--- a/lang/python-ply/Makefile
+++ b/lang/python-ply/Makefile
@@ -53,7 +53,7 @@ define Build/InstallDev
 endef
 
 define Host/Compile
-	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOST)")
+	$(call Build/Compile/HostPyMod,,install --prefix="/usr" --root="$(STAGING_DIR_HOST)")
 endef
 
 define Host/Install


### PR DESCRIPTION
Host installs should now go into $(STAGING_DIR_HOST)/usr to match
python-host.mk.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>