### PR TITLE
python-setuptools: update host install path

### DIFF
--- a/lang/python-setuptools/Makefile
+++ b/lang/python-setuptools/Makefile
@@ -60,7 +60,7 @@ endef
 
 define Host/Compile
 	$(call Build/Compile/HostPyMod,,\
-		install --root="$(STAGING_DIR_HOST)" --prefix="" \
+		install --root="$(STAGING_DIR_HOST)" --prefix="/usr" \
 		--single-version-externally-managed \
 	)
 endef


### PR DESCRIPTION
Host installs should now go into $(STAGING_DIR_HOST)/usr to match
python-host.mk.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>