### PR TITLE
python packages: update host install path

### DIFF
--- a/lang/python-cffi/Makefile
+++ b/lang/python-cffi/Makefile
@@ -45,7 +45,7 @@ define Build/Compile
 endef
 
 define Host/Compile
-	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOST)")
+	$(call Build/Compile/HostPyMod,,install --prefix="/usr" --root="$(STAGING_DIR_HOST)")
 endef
 
 define Host/Install

--- a/lang/python-ply/Makefile
+++ b/lang/python-ply/Makefile
@@ -53,7 +53,7 @@ define Build/InstallDev
 endef
 
 define Host/Compile
-	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOST)")
+	$(call Build/Compile/HostPyMod,,install --prefix="/usr" --root="$(STAGING_DIR_HOST)")
 endef
 
 define Host/Install

--- a/lang/python-pycparser/Makefile
+++ b/lang/python-pycparser/Makefile
@@ -47,7 +47,7 @@ define Build/Compile
 endef
 
 define Host/Compile
-	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOST)")
+	$(call Build/Compile/HostPyMod,,install --prefix="/usr" --root="$(STAGING_DIR_HOST)")
 endef
 
 define Host/Install

--- a/lang/python-setuptools/Makefile
+++ b/lang/python-setuptools/Makefile
@@ -60,7 +60,7 @@ endef
 
 define Host/Compile
 	$(call Build/Compile/HostPyMod,,\
-		install --root="$(STAGING_DIR_HOST)" --prefix="" \
+		install --root="$(STAGING_DIR_HOST)" --prefix="/usr" \
 		--single-version-externally-managed \
 	)
 endef


### PR DESCRIPTION
Host installs should now go into $(STAGING_DIR_HOST)/usr to match
python-host.mk.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>