### PR TITLE
[Radicale] upstream to Radicale 1.1

### DIFF
--- a/net/radicale/Makefile
+++ b/net/radicale/Makefile
@@ -7,8 +7,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale
-PKG_VERSION:=0.10
-PKG_RELEASE:=2
+PKG_VERSION:=1.1
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
 
 PKG_LICENSE:=GPL-3.0
@@ -16,7 +16,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=Radicale-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://pypi.python.org/packages/source/R/Radicale/
-PKG_MD5SUM:=32655d8893962956ead0ad690cca6044
+PKG_MD5SUM:=2e3f11d05d7a21ee412dfd7bd5c38961
 
 # needed for "r"adicale <-> "R"adicale
 PKG_BUILD_DIR:=$(BUILD_DIR)/Radicale-$(PKG_VERSION)

--- a/net/radicale/files/radicale.config
+++ b/net/radicale/files/radicale.config
@@ -11,6 +11,16 @@
 #
 
 ####################################################
+# OpenWrt specific settings
+# not part of radicale package
+#
+config	system 'radicale'
+	# delayed startup at boot (default 10 seconds)
+	# to wait for netifd to bring up interfaces
+	# during this time iface hotplug events are ignored
+#	option	boot_delay	'10'
+
+####################################################
 # Server options
 #
 config setting 'server'
@@ -65,7 +75,7 @@ config	setting	'encoding'
 ####################################################
 # Authentication options
 #
-config setting 'auth'
+config	setting	'auth'
 
 	# Authentication method
 	# Value: None | htpasswd | IMAP | LDAP | PAM | courier | http | remote_user | custom

--- a/net/radicale/files/radicale.hotplug
+++ b/net/radicale/files/radicale.hotplug
@@ -2,6 +2,8 @@
 
 # only (re-)start on ifup
 [ "$ACTION" = "ifup" ] || exit 0
+# only start if boot_delay is done
+[ -f /tmp/radicale.hotplug ] || exit 0
 
 _PID=$(ps | grep '[p]ython.*[r]adicale' 2>/dev/null | awk '{print $1}')
 kill -1 $_PID 2>/dev/null

--- a/net/radicale/files/radicale.init
+++ b/net/radicale/files/radicale.init
@@ -163,7 +163,22 @@ _set_permission() {
 }
 
 boot() {
-	return 0	# will be started by "iface" hotplug events
+	# wait a given time (default 10 seconds) before startup
+	# to wait for interfaces to come up / not using hotplug events during boot
+	_start() {
+		[ $1 -gt 0 ] && sleep $1
+		start
+	}
+
+	local _DELAY
+	_DELAY=$(uci_get "radicale" "system" "boot_delay" "10")
+	_start $_DELAY &
+	return 0
+}
+
+shutdown() {
+	rm -f /tmp/radicale.hotplug
+	stop
 }
 
 start() {
@@ -184,6 +199,7 @@ start() {
 	_set_permission
 
 	radicale --daemon --config=$SYSCFG
+	touch /tmp/radicale.hotplug
 
 	_running &	# check if running and syslog
 


### PR DESCRIPTION
* upstream to Radicale 1.1
* new "boot_delay" option (default 10 seconds) to wait for interfaces to come up before hotplug restarts are enabled.

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>