### PR TITLE
libpng: update to 1.2.56

### DIFF
--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpng
-PKG_VERSION:=1.2.54
+PKG_VERSION:=1.2.56
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/libpng
-PKG_MD5SUM:=bbb7a7264f1c7d9c444fd16bf6f89832
+PKG_MD5SUM:=868562bd1c58b76ed8703f135a2e439a
 PKG_MAINTAINER:=Jo-Philipp Wich <jow@openwrt.org>
 
 PKG_LICENSE:=Libpng GPL-2.0+ BSD-3-Clause


### PR DESCRIPTION
Fixes CVE-2015-8126 and CVE-2015-8540.