### PR TITLE
Use compiled in defaults from wget or curl when cacert is empty

### DIFF
--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -668,7 +668,7 @@ do_transfer() {
 				__PROG="$__PROG --ca-certificate=${cacert}"
 			elif [ -d "$cacert" ]; then
 				__PROG="$__PROG --ca-directory=${cacert}"
-			elif [ -n "$cacert" ]	# exit here because it makes no sense to start loop
+			elif [ -n "$cacert" ]; then		# exit here because it makes no sense to start loop
 				write_log 14 "No valid certificate(s) found at '$cacert' for HTTPS communication"
 			fi
 		fi
@@ -702,7 +702,7 @@ do_transfer() {
 				__PROG="$__PROG --cacert $cacert"
 			elif [ -d "$cacert" ]; then
 				__PROG="$__PROG --capath $cacert"
-			elif [ -n "$cacert" ]	# exit here because it makes no sense to start loop
+			elif [ -n "$cacert" ]; then		# exit here because it makes no sense to start loop
 				write_log 14 "No valid certificate(s) found at '$cacert' for HTTPS communication"
 			fi
 		fi

--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -668,7 +668,7 @@ do_transfer() {
 				__PROG="$__PROG --ca-certificate=${cacert}"
 			elif [ -d "$cacert" ]; then
 				__PROG="$__PROG --ca-directory=${cacert}"
-			else	# exit here because it makes no sense to start loop
+			elif [ -n "$cacert" ]	# exit here because it makes no sense to start loop
 				write_log 14 "No valid certificate(s) found at '$cacert' for HTTPS communication"
 			fi
 		fi
@@ -702,7 +702,7 @@ do_transfer() {
 				__PROG="$__PROG --cacert $cacert"
 			elif [ -d "$cacert" ]; then
 				__PROG="$__PROG --capath $cacert"
-			else	# exit here because it makes no sense to start loop
+			elif [ -n "$cacert" ]	# exit here because it makes no sense to start loop
 				write_log 14 "No valid certificate(s) found at '$cacert' for HTTPS communication"
 			fi
 		fi


### PR DESCRIPTION
Only check/use the value of cacert if it is configured. When empty, default to the builtin location where wget/curl look for CA root certificates.