### PR TITLE
squashfs-tools: bring back package

### DIFF
--- a/utils/squashfs-tools/Config.in
+++ b/utils/squashfs-tools/Config.in
@@ -1,0 +1,17 @@
+config SQUASHFS_TOOLS_LZO_SUPPORT
+	depends on PACKAGE_squashfs-tools-mksquashfs || PACKAGE_squashfs-tools-unsquashfs
+	bool "Enable LZO support"
+	select PACKAGE_liblzo
+	default y
+
+config SQUASHFS_TOOLS_LZ4_SUPPORT
+	depends on PACKAGE_squashfs-tools-mksquashfs || PACKAGE_squashfs-tools-unsquashfs
+	bool "Enable LZ4 support"
+	select PACKAGE_liblz4
+	default y
+
+config SQUASHFS_TOOLS_XZ_SUPPORT
+	depends on PACKAGE_squashfs-tools-mksquashfs || PACKAGE_squashfs-tools-unsquashfs
+	bool "Enable XZ support"
+	select PACKAGE_liblzma
+	default y

--- a/utils/squashfs-tools/Makefile
+++ b/utils/squashfs-tools/Makefile
@@ -1,0 +1,86 @@
+# 
+# Copyright (C) 2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=squashfs-tools
+PKG_VERSION:=4.3
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/plougher/squashfs-tools
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=9c1db6d13a51a2e009f0027ef336ce03624eac0d
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+
+PKG_BUILD_PARALLEL:=1
+include $(INCLUDE_DIR)/package.mk
+
+define Package/squashfs-tools/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=squashfs-tools
+  URL:=https://github.com/plougher/squashfs-tools
+  DEPENDS += +libpthread +zlib \
+	+SQUASHFS_TOOLS_LZO_SUPPORT:liblzo \
+	+SQUASHFS_TOOLS_LZ4_SUPPORT:liblz4 \
+	+SQUASHFS_TOOLS_XZ_SUPPORT:liblzma
+  MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+endef
+
+define Package/squashfs-tools-mksquashfs
+  $(call Package/squashfs-tools/Default)
+  TITLE+= mksquashfs
+endef
+
+define Package/squashfs-tools-unsquashfs
+  $(call Package/squashfs-tools/Default)
+  TITLE+= unsquashfs
+endef
+
+define Package/squashfs-tools-unsquashfs/config
+	source "$(SOURCE)/Config.in"
+endef
+
+Build/Configure:=
+
+MAKE_FLAGS += \
+	XATTR_SUPPORT=
+
+ifneq ($(CONFIG_SQUASHFS_TOOLS_XZ_SUPPORT),)
+MAKE_FLAGS += XZ_SUPPORT=1
+endif
+
+ifneq ($(CONFIG_SQUASHFS_TOOLS_LZO_SUPPORT),)
+MAKE_FLAGS += LZO_SUPPORT=1
+endif
+
+ifneq ($(CONFIG_SQUASHFS_TOOLS_LZ4_SUPPORT),)
+MAKE_FLAGS += LZ4_SUPPORT=1
+endif
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR)/squashfs-tools \
+		CC="$(TARGET_CC)" \
+		$(MAKE_FLAGS) \
+		mksquashfs unsquashfs
+endef
+
+define Package/squashfs-tools-mksquashfs/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/squashfs-tools/mksquashfs $(1)/usr/sbin/mksquashfs
+endef
+
+define Package/squashfs-tools-unsquashfs/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/squashfs-tools/unsquashfs $(1)/usr/sbin/unsquashfs
+endef
+
+$(eval $(call BuildPackage,squashfs-tools-mksquashfs))
+$(eval $(call BuildPackage,squashfs-tools-unsquashfs))

--- a/utils/squashfs-tools/patches/0001-squashfs-tools-fix-fnmatch.h-compatibility-with-musl.patch
+++ b/utils/squashfs-tools/patches/0001-squashfs-tools-fix-fnmatch.h-compatibility-with-musl.patch
@@ -1,0 +1,120 @@
+From a0c129760ca9bdc7e564ae2a508fac3799f9d39b Mon Sep 17 00:00:00 2001
+From: Alexandru Ardelean <aa@ocedo.com>
+Date: Wed, 6 Jan 2016 15:33:43 +0200
+Subject: [PATCH 1/2] squashfs-tools: with fnmatch.h compatibility with musl
+
+Signed-off-by: Alexandru Ardelean <aa@ocedo.com>
+---
+ squashfs-tools/action.c         |  2 +-
+ squashfs-tools/fnmatch_compat.h | 32 ++++++++++++++++++++++++++++++++
+ squashfs-tools/mksquashfs.c     |  2 +-
+ squashfs-tools/unsquashfs.c     |  1 +
+ squashfs-tools/unsquashfs.h     |  1 -
+ 5 files changed, 35 insertions(+), 3 deletions(-)
+ create mode 100644 squashfs-tools/fnmatch_compat.h
+
+diff --git a/squashfs-tools/action.c b/squashfs-tools/action.c
+index 35889a4..4b06ccb 100644
+--- a/squashfs-tools/action.c
++++ b/squashfs-tools/action.c
+@@ -31,7 +31,6 @@
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <unistd.h>
+-#include <fnmatch.h>
+ #include <pwd.h>
+ #include <grp.h>
+ #include <sys/wait.h>
+@@ -43,6 +42,7 @@
+ #include "mksquashfs.h"
+ #include "action.h"
+ #include "error.h"
++#include "fnmatch_compat.h"
+ 
+ /*
+  * code to parse actions
+diff --git a/squashfs-tools/fnmatch_compat.h b/squashfs-tools/fnmatch_compat.h
+new file mode 100644
+index 0000000..7b4afd8
+--- /dev/null
++++ b/squashfs-tools/fnmatch_compat.h
+@@ -0,0 +1,32 @@
++#ifndef FNMATCH_COMPAT
++#define FNMATCH_COMPAT
++/*
++ * Squashfs
++ *
++ * Copyright (c) 2015
++ * Phillip Lougher <phillip@squashfs.org.uk>
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License
++ * as published by the Free Software Foundation; either version 2,
++ * or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
++ *
++ * fnmatch_compat.h
++ */
++
++#include <fnmatch.h>
++
++#ifndef FNM_EXTMATCH
++#define FNM_EXTMATCH	0
++#endif
++
++#endif
+diff --git a/squashfs-tools/mksquashfs.c b/squashfs-tools/mksquashfs.c
+index d221c35..4e7cbdd 100644
+--- a/squashfs-tools/mksquashfs.c
++++ b/squashfs-tools/mksquashfs.c
+@@ -46,7 +46,6 @@
+ #include <sys/mman.h>
+ #include <pthread.h>
+ #include <regex.h>
+-#include <fnmatch.h>
+ #include <sys/wait.h>
+ #include <limits.h>
+ #include <ctype.h>
+@@ -76,6 +75,7 @@
+ #include "read_fs.h"
+ #include "restore.h"
+ #include "process_fragments.h"
++#include "fnmatch_compat.h"
+ 
+ int delete = FALSE;
+ int fd;
+diff --git a/squashfs-tools/unsquashfs.c b/squashfs-tools/unsquashfs.c
+index 1323dd6..2428baa 100644
+--- a/squashfs-tools/unsquashfs.c
++++ b/squashfs-tools/unsquashfs.c
+@@ -30,6 +30,7 @@
+ #include "xattr.h"
+ #include "unsquashfs_info.h"
+ #include "stdarg.h"
++#include "fnmatch_compat.h"
+ 
+ #include <sys/sysinfo.h>
+ #include <sys/types.h>
+diff --git a/squashfs-tools/unsquashfs.h b/squashfs-tools/unsquashfs.h
+index ecd0bb4..0edbd25 100644
+--- a/squashfs-tools/unsquashfs.h
++++ b/squashfs-tools/unsquashfs.h
+@@ -40,7 +40,6 @@
+ #include <grp.h>
+ #include <time.h>
+ #include <regex.h>
+-#include <fnmatch.h>
+ #include <signal.h>
+ #include <pthread.h>
+ #include <math.h>
+-- 
+2.1.4
+

--- a/utils/squashfs-tools/patches/0002-pseudo.c-add-explicit-stat.h-include.patch
+++ b/utils/squashfs-tools/patches/0002-pseudo.c-add-explicit-stat.h-include.patch
@@ -1,0 +1,25 @@
+From 0ea07a1b5ddb2f2fa1358b2c1b42bcf34bbf5ee2 Mon Sep 17 00:00:00 2001
+From: Alexandru Ardelean <aa@ocedo.com>
+Date: Wed, 6 Jan 2016 15:36:48 +0200
+Subject: [PATCH 2/2] pseudo.c: add explicit <stat.h> include
+
+Signed-off-by: Alexandru Ardelean <aa@ocedo.com>
+---
+ squashfs-tools/pseudo.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/squashfs-tools/pseudo.c b/squashfs-tools/pseudo.c
+index f85fe60..7a26bca 100644
+--- a/squashfs-tools/pseudo.c
++++ b/squashfs-tools/pseudo.c
+@@ -32,6 +32,7 @@
+ #include <stdlib.h>
+ #include <sys/types.h>
+ #include <sys/wait.h>
++#include <sys/stat.h>
+ #include <ctype.h>
+ 
+ #include "pseudo.h"
+-- 
+2.1.4
+


### PR DESCRIPTION
Picked up the old Makefile at 4.2.
Upgraded at 4.3 (repo move to github now: https://github.com/plougher/squashfs-tools/)
Added musl compatibility.
Enabled LZ4 compression support by default

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>