### PR TITLE
ddns-scripts: allow setting CloudFlare 'rec_id' in the config

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.5.0
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>


### PR DESCRIPTION
This is necessary when there are multiple records for the same domain,
otherwise the script will overwrite the first one returned by the API.
It has the secondary benefit of allowing faster updates by performing
only one API call instead of two.

In case 'rec_id' is not set the script behaves exactly as before.

Signed-off-by: Leonardo Brondani Schenkel <leonardo@schenkel.net>