### PR TITLE
devel/pkg-config: fix build when CONFIG_BUILD_NLS is set

### DIFF
--- a/devel/pkg-config/Makefile
+++ b/devel/pkg-config/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 OpenWrt.org
+# Copyright (C) 2015-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pkg-config
 PKG_VERSION:=0.29
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://pkgconfig.freedesktop.org/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -20,13 +20,14 @@ PKG_LICENSE:=GPL-2+
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/pkg-config
   SECTION:=devel
   CATEGORY:=Development
   TITLE:=pkg-config
   URL:=http://www.freedesktop.org/wiki/Software/pkg-config/
-  DEPENDS:=+glib2
+  DEPENDS:=+glib2 $(INTL_DEPENDS)
 endef
 
 define Package/pkg-config/description


### PR DESCRIPTION
Buildbots reported build failures when full NLS is enabled:

http://buildbot.openwrt.org:8010/broken_packages/ar71xx/pkg-config/compile.txt

So add NLS awareness and the conditional dependency.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>