### PR TITLE
utils/collectd:  Really prevent perl bindings

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -185,7 +185,7 @@ CONFIGURE_ARGS+= \
 	--disable-debug \
 	--enable-daemon \
 	--with-nan-emulation \
-	--with-perl-bindings= \
+	--without-perl-bindings \
 	--without-libgcrypt
 
 CONFIGURE_VARS+= \


### PR DESCRIPTION
--with-perl-bindings= is insufficient, --without-perl-bindings is required
to actually prevent perl bindings when perl has been built for the target.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>