### PR TITLE
libs/gnutls: Fix selecting cryptodev support fails to depend on kmod-…

### DIFF
--- a/libs/gnutls/Config.in
+++ b/libs/gnutls/Config.in
@@ -17,7 +17,6 @@ config GNUTLS_OCSP
 
 config GNUTLS_CRYPTODEV
 	bool "enable /dev/crypto support"
-	select PACKAGE_kmod-cryptodev
 	default n
 
 config GNUTLS_HEARTBEAT

--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -93,7 +93,7 @@ endef
 define Package/libgnutls
 $(call Package/gnutls/Default)
   TITLE+= (library)
-  DEPENDS+= +libnettle +!LIBNETTLE_MINI:libgmp +GNUTLS_EXT_LIBTASN1:libtasn1 +GNUTLS_PKCS11:p11-kit
+  DEPENDS+= +libnettle +!LIBNETTLE_MINI:libgmp +GNUTLS_EXT_LIBTASN1:libtasn1 +GNUTLS_PKCS11:p11-kit +GNUTLS_CRYPTODEV:kmod-cryptodev
 endef
 
 define Package/libgnutls/description


### PR DESCRIPTION
…cryptodev

It is not enough to select package kmod-cryptodev to avoid
build failure; there must be a Makefile dependency on
kmod-cryptodev in order for the build system to ensure
kmod-cryptodev (and it's headers) are present during build.
Thits is required so that kmod is treated as a prerequisite

Therefore drop the select and add a conditional dependency.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>