### PR TITLE
perl: ensure File::Spec::canonpath() preserves taint [CVE-2015-8607]

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=5.22.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=ftp://ftp.cpan.org/pub/CPAN/src/5.0 \
 		http://www.cpan.org/src/5.0 \

--- a/lang/perl/patches/020-host-libc-dir-moved-debian+derivatives.patch
+++ b/lang/perl/patches/020-host-libc-dir-moved-debian+derivatives.patch
@@ -1,6 +1,6 @@
 --- a/hints/linux.sh
 +++ b/hints/linux.sh
-@@ -204,6 +204,24 @@ case "$libc" in
+@@ -221,6 +221,24 @@ case "$libc" in
      ;;
  esac
  

--- a/lang/perl/patches/110-always_use_miniperl.patch
+++ b/lang/perl/patches/110-always_use_miniperl.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.SH
 +++ b/Makefile.SH
-@@ -315,22 +315,11 @@ MINIPERL = \$(LDLIBPTH) ./miniperl\$(EXE
+@@ -316,22 +316,11 @@ MANIFEST_SRT = MANIFEST.srt
  
  !GROK!THIS!
  

--- a/lang/perl/patches/700-tie_fetch_count_t-handle_missing_crypt.patch
+++ b/lang/perl/patches/700-tie_fetch_count_t-handle_missing_crypt.patch
@@ -1,7 +1,5 @@
-Index: perl-5.22.0/t/op/tie_fetch_count.t
-===================================================================
---- perl-5.22.0.orig/t/op/tie_fetch_count.t
-+++ perl-5.22.0/t/op/tie_fetch_count.t
+--- a/t/op/tie_fetch_count.t
++++ b/t/op/tie_fetch_count.t
 @@ -250,12 +250,17 @@ for ([chdir=>''],[chmod=>'0,'],[chown=>'
      check_count "$op $args\\\$tied_glob$postargs";
  }

--- a/lang/perl/patches/710-threads_join-skip_ps_on_busybox.patch
+++ b/lang/perl/patches/710-threads_join-skip_ps_on_busybox.patch
@@ -5,10 +5,8 @@ We can't provide either with busybox. Just skip it for now.
 
 Signed-off-by: Marcel Denia <naoir@gmx.net>
 
-Index: perl-5.22.0/dist/threads/t/join.t
-===================================================================
---- perl-5.22.0.orig/dist/threads/t/join.t
-+++ perl-5.22.0/dist/threads/t/join.t
+--- a/dist/threads/t/join.t
++++ b/dist/threads/t/join.t
 @@ -110,36 +110,41 @@ sub skip {
  
  # We parse ps output so this is OS-dependent.

--- a/lang/perl/patches/900-CVE-2015-8607.patch
+++ b/lang/perl/patches/900-CVE-2015-8607.patch
@@ -1,0 +1,57 @@
+From b6307f728a4f842a54ea96959e386c7daa92ece1 Mon Sep 17 00:00:00 2001
+From: Tony Cook <tony@develop-help.com>
+Date: Tue, 15 Dec 2015 10:56:54 +1100
+Subject: [perl #126862] ensure File::Spec::canonpath() preserves taint
+
+Previously the unix specific XS implementation of canonpath() would
+return an untainted path when supplied a tainted path.
+
+For the empty string case, newSVpvs() already sets taint as needed on
+its result.
+---
+ dist/PathTools/Cwd.xs    |  1 +
+ dist/PathTools/t/taint.t | 19 ++++++++++++++++++-
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+--- a/dist/PathTools/Cwd.xs
++++ b/dist/PathTools/Cwd.xs
+@@ -535,6 +535,7 @@ THX_unix_canonpath(pTHX_ SV *path)
+     *o = 0;
+     SvPOK_on(retval);
+     SvCUR_set(retval, o - SvPVX(retval));
++    SvTAINT(retval);
+     return retval;
+ }
+ 
+--- a/dist/PathTools/t/taint.t
++++ b/dist/PathTools/t/taint.t
+@@ -12,7 +12,7 @@ use Test::More;
+ BEGIN {
+     plan(
+         ${^TAINT}
+-        ? (tests => 17)
++        ? (tests => 21)
+         : (skip_all => "A perl without taint support")
+     );
+ }
+@@ -34,3 +34,20 @@ foreach my $func (@Functions) {
+ 
+ # Previous versions of Cwd tainted $^O
+ is !tainted($^O), 1, "\$^O should not be tainted";
++
++{
++    # [perl #126862] canonpath() loses taint
++    my $tainted = substr($ENV{PATH}, 0, 0);
++    # yes, getcwd()'s result should be tainted, and is tested above
++    # but be sure
++    ok tainted(File::Spec->canonpath($tainted . Cwd::getcwd)),
++        "canonpath() keeps taint on non-empty string";
++    ok tainted(File::Spec->canonpath($tainted)),
++        "canonpath() keeps taint on empty string";
++
++    (Cwd::getcwd() =~ /^(.*)/);
++    my $untainted = $1;
++    ok !tainted($untainted), "make sure our untainted value is untainted";
++    ok !tainted(File::Spec->canonpath($untainted)),
++        "canonpath() doesn't add taint to untainted string";
++}


### PR DESCRIPTION
Beginning in PathTools 3.47 and/or perl 5.20.0, the File::Spec::canonpath()
routine returned untained strings even if passed tainted input. This defect
undermines the guarantee of taint propagation, which is sometimes used to
ensure that unvalidated user input does not reach sensitive code.

This defect was found and reported by David Golden of MongoDB, and a patch
was provided by Tony Cook.

References:

 * https://rt.perl.org/Public/Bug/Display.html?id=126862
 * https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8607

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>