### PR TITLE
ddns-scripts: update to version 2.6.0-1

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2015 OpenWrt.org
+# Copyright (C) 2008-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 #
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ddns-scripts
 # Version == major.minor.patch
 # increase on new functionality (minor) or patches (patch)
-PKG_VERSION:=2.5.0
+PKG_VERSION:=2.6.0
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=5
+PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/ddns.config
+++ b/net/ddns-scripts/files/ddns.config
@@ -10,7 +10,7 @@ config ddns "global"
 
 
 config service "myddns_ipv4"
-	option service_name	"dyndns.com"
+	option service_name	"dyndns.org"
 	option lookup_host	"yourhost.example.com"
 	option domain		"yourhost.example.com"
 	option username		"your_username"

--- a/net/ddns-scripts/files/dynamic_dns_lucihelper.sh
+++ b/net/ddns-scripts/files/dynamic_dns_lucihelper.sh
@@ -2,13 +2,8 @@
 # /usr/lib/ddns/luci_dns_helper.sh
 #
 #.Distributed under the terms of the GNU General Public License (GPL) version 2.0
-#
-# Written in August 2014 by
-#.Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+#.2014-2016 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 # This script is used by luci-app-ddns
-# - getting registered IP
-# - check if possible to get local IP
-# - verifing given DNS- or Proxy-Server
 #
 # variables in small chars are read from /etc/config/ddns as parameter given here
 # variables in big chars are defined inside these scripts as gloval vars

--- a/net/ddns-scripts/files/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/dynamic_dns_updater.sh
@@ -1,21 +1,12 @@
 #!/bin/sh
 # /usr/lib/ddns/dynamic_dns_updater.sh
 #
-# Original written by Eric Paul Bishop, January 2008
 #.Distributed under the terms of the GNU General Public License (GPL) version 2.0
+# Original written by Eric Paul Bishop, January 2008
 # (Loosely) based on the script on the one posted by exobyte in the forums here:
 # http://forum.openwrt.org/viewtopic.php?id=14040
-#
-# extended and partial rewritten in August 2014 by
-#.Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
-# to support:
-# - IPv6 DDNS services
-# - DNS Server to retrieve registered IP including TCP transport (Ticket 7820)
-# - Proxy Server to send out updates
-# - force_interval=0 to run once (Luci Ticket 538)
-# - the usage of BIND's host command instead of BusyBox's nslookup if installed
-# - extended Verbose Mode and log file support for better error detection
-# - wait for interface to fully come up, before the first update is done
+# extended and partial rewritten
+#.2014-2016 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 #
 # variables in small chars are read from /etc/config/ddns
 # variables in big chars are defined inside these scripts as global vars

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -22,6 +22,15 @@
 # !!! Use only the script name (without path). Sample:
 # !!! "example.com"	"update_sample.sh"
 #
+# !!! Since ddns-scripts Version 2.5.x additional parameters are supported
+# !!! and a given answer on success is checked (ignored by earlier versions)
+# !!! Additional parameters: [PARAMOPT] and [PARAMENC]; [PARAMENC] is send urlencoded
+#
+# Line syntax: "service" [TAB] "update_url" [TAB] "answer"
+# "service"	name used as "option service_name" inside /etc/config/ddns
+# "update_url"	update url as given by the provider; custom urls should not saved here
+# "answer"	single words inside providers answer string; use "|" to combine "or"
+#
 # 44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444
 
 "dyndns.org"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"
@@ -37,7 +46,7 @@
 "thatip.com"	"http://update.dnsmax.com/update/?username=[USERNAME]&password=[PASSWORD]&resellerid=2&clientname=openwrt&clientversion=8.09&protocolversion=2.0&updatehostname=[DOMAIN]&ip=[IP]"
 
 # Hurricane Electric Dynamic DNS
-"he.net"	"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"
+"he.net"	"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 # DNSdynamic.org
 "dnsdynamic.org"	"http://[USERNAME]:[PASSWORD]@www.dnsdynamic.org/api/?hostname=[DOMAIN]&myip=[IP]"
@@ -48,10 +57,8 @@
 # OVH
 "ovh.com"	"http://[USERNAME]:[PASSWORD]@www.ovh.com/nic/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]"
 
-# dns-o-matic is a free service by opendns.com for updating multiple hosts and
-# dynamic dns services in one api call. To update all your configured services
-# at once, use "all.dnsomatic.com as the hostname.
-"dnsomatic.com"	"http://[USERNAME]:[PASSWORD]@updates.dnsomatic.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
+# dns-o-matic is a free service by opendns.com for updating multiple hosts
+"dnsomatic.com"	"http://[USERNAME]:[PASSWORD]@updates.dnsomatic.com/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 # 3322.org
 "3322.org"	"http://[USERNAME]:[PASSWORD]@members.3322.org/dyndns/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]"
@@ -69,7 +76,7 @@
 "mythic-beasts.com"	"http://dnsapi4.mythic-beasts.com/?domain=[USERNAME]&password=[PASSWORD]&command=REPLACE%20[DOMAIN]%2060%20A%20DYNAMIC_IP"
 
 # Securepoint Dynamic-DNS-Service	(http://www.spdns.de)
-"spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	    "good|nochg"
+"spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 # duiadns.net - free dynamic DNS
 "duiadns.net"	"http://ipv4.duia.ro/dynamic.duia?host=[DOMAIN]&password=[PASSWORD]&ip4=[IP]"
@@ -84,7 +91,7 @@
 "loopia.se"	"http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"
 
 # SelfHost.de
-"selfhost.de"	"http://carol.selfhost.de/update?username=[USERNAME]&password=[PASSWORD]&myip=[IP]&hostname=1"	    "good|nochg"
+"selfhost.de"	"http://carol.selfhost.de/update?username=[USERNAME]&password=[PASSWORD]&myip=[IP]&hostname=1"	"good|nochg"
 
 # no-ip.pl nothing to do with no-ip.com (domain registered to www.domeny.tv) (IP autodetected by provider)
 "no-ip.pl"	"http://[USERNAME]:[PASSWORD]@update.no-ip.pl/?hostname=[DOMAIN]"
@@ -93,19 +100,19 @@
 "domains.google.com"	"http://[USERNAME]:[PASSWORD]@domains.google.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
 
 # Schokokeks Hosting, schokokeks.org
-"schokokeks.org"	"http://[USERNAME]:[PASSWORD]@dyndns.schokokeks.org/nic/update?myip=[IP]"
+"schokokeks.org"	"http://[USERNAME]:[PASSWORD]@dyndns.schokokeks.org/nic/update?myip=[IP]"	"good|nochg"
 
 # STRATO AG
 "strato.de"		"http://[USERNAME]:[PASSWORD]@dyndns.strato.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
 
 # Variomedia AG
-"variomedia.de" 	"http://[USERNAME]:[PASSWORD]@dyndns.variomedia.de/nic/update?hostname=[DOMAIN]&myip=[IP]"
+"variomedia.de" 	"http://[USERNAME]:[PASSWORD]@dyndns.variomedia.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
  #DtDNS
 "dtdns.com"	"http://www.dtdns.com/api/autodns.cfm?id=[DOMAIN]&pw=[PASSWORD]&ip=[IP]"
 
-# dy.fi Dynamic DNS for finnish users
-"dy.fi"      "http://[USERNAME]:[PASSWORD]@www.dy.fi/nic/update?hostname=[DOMAIN]"
+# dy.fi Dynamic DNS for finnish users (IP autodetected by provider)
+"dy.fi"		"http://[USERNAME]:[PASSWORD]@www.dy.fi/nic/update?hostname=[DOMAIN]"	"good|nochg"
 
-# duckdns.org as in https://www.duckdns.org/install.jsp#openwrt and https://wiki.openwrt.org/doc/howto/ddns.client/duckdns
-"duckdns.org"    "http://www.duckdns.org/update?domains=[USERNAME]&token=[PASSWORD]&ip=[IP]"    "OK"
+# duckdns.org
+"duckdns.org"	"http://www.duckdns.org/update?domains=[USERNAME]&token=[PASSWORD]&ip=[IP]"	"OK"

--- a/net/ddns-scripts/files/services_ipv6
+++ b/net/ddns-scripts/files/services_ipv6
@@ -22,13 +22,22 @@
 # !!! Use only the script name (without path). Sample:
 # !!! "example.com"	"update_sample.sh"
 #
+# !!! Since ddns-scripts Version 2.5.x additional parameters are supported
+# !!! and a given answer on success is checked (ignored by earlier versions)
+# !!! Additional parameters: [PARAMOPT] and [PARAMENC]; [PARAMENC] is send urlencoded
+#
+# Line syntax: "service" [TAB] "update_url" [TAB] "answer"
+# "service"	name used as "option service_name" inside /etc/config/ddns
+# "update_url"	update url as given by the provider; custom urls should not saved here
+# "answer"	words inside providers answer string; use "|" to combine "or"
+#
 # 66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666
 
 # IPv6 @ Securepoint Dynamic-DNS-Service
-"spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	    "good|nochg"
+"spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 # IPv6 @ Hurricane Electric Dynamic DNS
-"he.net"	"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"
+"he.net"	"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 # IPv6 @ MyDNS.JP
 "mydns.jp"	"http://www.mydns.jp/directip.html?MID=[USERNAME]&PWD=[PASSWORD]&IPV6ADDR=[IP]"
@@ -40,8 +49,10 @@
 "freedns.afraid.org"	"http://freedns.afraid.org/dynamic/update.php?[PASSWORD]&address=[IP]"
 
 # IPv6 @ LoopiaDNS
-"loopia.se" "http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"
+"loopia.se"	"http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"
 
 # Variomedia AG
-"variomedia.de" 	"http://[USERNAME]:[PASSWORD]@dyndns.variomedia.de/nic/update?hostname=[DOMAIN]&myip=[IP]"
+"variomedia.de"		"http://[USERNAME]:[PASSWORD]@dyndns.variomedia.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
+# IPv6 @ Dyn.com
+"dyndns.org"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"


### PR DESCRIPTION
- add support for "hostip" to get_registered_ip() as "small" alternative to "Bind host" package https://dev.openwrt.org/ticket/20893#comment:5
- allow to send updates using compiled-in certificate file/path of curl/wget #2242 #2243 #2245
- add dyndns.org to services_ipv6 https://forum.openwrt.org/viewtopic.php?id=62103
- readd duckdns.org to services #2251 (lost somewhere in data heaven)
- some cosmetics

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>