### PR TITLE
net/apache: use @APACHE download facility

### DIFF
--- a/net/apache/Makefile
+++ b/net/apache/Makefile
@@ -15,8 +15,7 @@ PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=Apache License
 
 PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=http://mirrors.ibiblio.org/apache/httpd/ \
-		http://apache.imsam.info/httpd/
+PKG_SOURCE_URL:=@APACHE/httpd/
 PKG_MD5SUM:=6c10e15835ab214464228a9beb7afba8
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_NAME)-$(PKG_VERSION)


### PR DESCRIPTION
Instead of explicitly specyfing an Apache mirror use the
@APACHE download facility.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>