### PR TITLE
flashrom: include io.h to fix compile error

### DIFF
--- a/utils/flashrom/Makefile
+++ b/utils/flashrom/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=flashrom
 PKG_VERSION:=0.9.8
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.flashrom.org/releases

--- a/utils/flashrom/patches/0003-fix-io-h-include.patch
+++ b/utils/flashrom/patches/0003-fix-io-h-include.patch
@@ -1,0 +1,12 @@
+diff -uprN a/linux_spi.c b/linux_spi.c
+--- a/flash.h     2015-02-08 16:57:52.000000000 -0500
++++ b/flash.h     2016-01-08 20:09:51.599387507 -0500
+@@ -30,6 +30,7 @@
+ #include <stdio.h>
+ #include <stdint.h>
+ #include <stddef.h>
++#include <sys/io.h>
+ #include <stdbool.h>
+ #if IS_WINDOWS
+ #include <windows.h>
+


### PR DESCRIPTION
This patch includes sys/io.h from flash.h to fix compile errors

Signed-off-by: Rob Mosher <nyt-openwrt@countercultured.net>