### PR TITLE
net: Import cifs-utils

### DIFF
--- a/net/cifs-utils/Makefile
+++ b/net/cifs-utils/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2007-2012 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cifs-utils
+PKG_VERSION:=6.4
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=http://ftp.samba.org/pub/linux-cifs/cifs-utils
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_MD5SUM:=b7d75b67fd3987952896d27256c7293d
+
+PKG_MAINTAINER:=Florian Fainelli <florian@openwrt.org>
+PKG_LICENSE:=GPL-3.0
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/cifsmount
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=CIFS mount utilities
+  URL:=http://wiki.samba.org/index.php/LinuxCIFS_utils
+endef
+
+TARGET_CFLAGS += -Wno-error
+
+CONFIGURE_ARGS += \
+	--exec-prefix=/usr \
+	--prefix=/ \
+	--with-libcap-ng=no \
+	--with-libcap=no
+
+define Package/cifsmount/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/mount.cifs $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,cifsmount))

--- a/net/cifs-utils/patches/001-fix-musl-build.patch
+++ b/net/cifs-utils/patches/001-fix-musl-build.patch
@@ -1,0 +1,30 @@
+From 6603cef0f06c450196a1bca06bb143d8fcda5651 Mon Sep 17 00:00:00 2001
+From: Felix Janda <felix.janda@posteo.de>
+Date: Fri, 5 Dec 2014 23:19:29 +0100
+Subject: [PATCH 1/1] mtab.c: include <paths.h> for _PATH_MOUNTED
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Backported from: 6603cef0f06c450196a1bca06bb143d8fcda5651
+
+Signed-off-by: Felix Janda <felix.janda@posteo.de>
+Signed-off-by: Jörg Krause <joerg.krause@embedded.rocks>
+---
+ mtab.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/mtab.c b/mtab.c
+index 7b365b3..a662a3c 100644
+--- a/mtab.c
++++ b/mtab.c
+@@ -38,6 +38,7 @@
+ #include <mntent.h>
+ #include <stdlib.h>
+ #include <signal.h>
++#include <paths.h>
+ #include "mount.h"
+ #include "config.h"
+ 
+-- 
+2.5.0


### PR DESCRIPTION
Import cifs-utils from old packages:

* update to 6.4
* add upstream patch to fix builds with musl
* add license information
* add myself as maintainer

Follow-up from https://github.com/openwrt/packages/issues/795

Signed-off-by: Florian Fainelli <florian@openwrt.org>