### PR TITLE
motion: move configuration file to default path expected by program

### DIFF
--- a/multimedia/motion/Makefile
+++ b/multimedia/motion/Makefile
@@ -49,7 +49,8 @@ CONFIGURE_ARGS+= \
 
 define Package/motion/install
 	$(INSTALL_DIR) $(1)/etc
-	$(CP) $(PKG_BUILD_DIR)/motion-dist.conf $(1)/etc/motion.conf
+	mkdir -p $(1)/etc/motion/
+	$(CP) $(PKG_BUILD_DIR)/motion-dist.conf $(1)/etc/motion/motion.conf
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/motion $(1)/usr/bin/
 


### PR DESCRIPTION
By default, motion process tries to load configuration from /etc/motion/motion.conf.