### PR TITLE
add klish-2.1.1 package

### DIFF
--- a/utils/klish/Makefile
+++ b/utils/klish/Makefile
@@ -1,0 +1,88 @@
+
+#
+# Copyright (C) 2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=klish
+PKG_VERSION:=2.1.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=http://libcode.org/attachments/download/61/
+PKG_MAINTAINER:=Takashi Umeno <umeno.takashi@gmail.com>
+PKG_MD5SUM:=4913259794d85585de0f8791c54ac633
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/klish/default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Kommand Line Interface SHell ($(1))
+  URL:=http://libcode.org/projects/klish/
+endef
+
+define Package/klish
+$(call Package/klish/default,main tool)
+  DEPENDS:=+libstdcpp +libxml2
+endef
+
+define Package/klish/description
+ The klish is a framework for implementing a CISCO-like CLI on a UNIX
+ systems. It is configurable by XML files. The KLISH stands for Kommand
+ Line Interface Shell.
+ The klish is a fork of clish 0.7.3 developed by Graeme McKerrell.
+ It defines new features but it's compatible (as much as possible) with
+ clish's XML configuration files.
+ klish is able to run using clish XML configuration files although
+ current clish users may expect some changes in behavior.
+ Konf and konfd are klish utilities that are used to store configuration
+ informations in a way which is similar to what's found on CISCO devices.
+ More information about these tools is to be found on the klish web site.
+endef
+
+define Build/Configure
+	$(call Build/Configure/Default, \
+		--with-libxml2 \
+	)
+endef
+
+define Package/klish/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/clish $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/konf $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/konfd $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sigexec $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,klish))
+
+define Package/klish-xml-files
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=klish
+  TITLE:=klish sample XML files
+  URL:=http://code.google.com/p/klish/
+endef
+
+define Package/klish-xml-files/description
+  This is a set of sample XML files for klish. 
+endef
+
+define Package/klish-xml-files/install
+	$(INSTALL_DIR) $(1)/etc/clish
+	$(CP) $(PKG_BUILD_DIR)/xml-examples/clish $(1)/etc/clish/
+	$(CP) $(PKG_BUILD_DIR)/xml-examples/klish $(1)/etc/clish/
+	$(CP) $(PKG_BUILD_DIR)/xml-examples/lua $(1)/etc/clish/
+	$(CP) $(PKG_BUILD_DIR)/xml-examples/test $(1)/etc/clish/
+endef
+
+$(eval $(call BuildPackage,klish-xml-files))

--- a/utils/klish/Makefile
+++ b/utils/klish/Makefile
@@ -14,6 +14,8 @@ PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://libcode.org/attachments/download/61/
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENCE
 PKG_MAINTAINER:=Takashi Umeno <umeno.takashi@gmail.com>
 PKG_MD5SUM:=4913259794d85585de0f8791c54ac633
 

--- a/utils/klish/patches/010-shell_execute_fix.patch
+++ b/utils/klish/patches/010-shell_execute_fix.patch
@@ -1,0 +1,18 @@
+Index: klish-2.1.1/clish/shell/shell_execute.c
+===================================================================
+--- klish-2.1.1.orig/clish/shell/shell_execute.c	2015-10-06 23:51:41.000000000 +0900
++++ klish-2.1.1/clish/shell/shell_execute.c	2016-01-19 23:42:13.066357933 +0900
+@@ -19,13 +19,6 @@
+ #include <signal.h>
+ #include <fcntl.h>
+ 
+-/* Empty signal handler to ignore signal but don't use SIG_IGN. */
+-static void sigignore(int signo)
+-{
+-	signo = signo; /* Happy compiler */
+-	return;
+-}
+-
+ /*-------------------------------------------------------- */
+ static int clish_shell_lock(const char *lock_path)
+ {

--- a/utils/klish/patches/010-shell_execute_fix.patch
+++ b/utils/klish/patches/010-shell_execute_fix.patch
@@ -1,7 +1,5 @@
-Index: klish-2.1.1/clish/shell/shell_execute.c
-===================================================================
---- klish-2.1.1.orig/clish/shell/shell_execute.c	2015-10-06 23:51:41.000000000 +0900
-+++ klish-2.1.1/clish/shell/shell_execute.c	2016-01-19 23:42:13.066357933 +0900
+--- a/clish/shell/shell_execute.c
++++ b/clish/shell/shell_execute.c
 @@ -19,13 +19,6 @@
  #include <signal.h>
  #include <fcntl.h>


### PR DESCRIPTION
 The klish is a framework for implementing a CISCO-like CLI on a UNIX
systems. It is configurable by XML files. The KLISH stands for Kommand
Line Interface Shell.

klish is an active fork of the clish program created by Graeme
McKerrell.

Makefile from https://dev.openwrt.org/browser/packages/utils/klish/Makefile?rev=31310

Review from
https://github.com/openwrt/packages/pull/2280#issuecomment-172517753

add SOB.
add Maintainer.
change URL http://libcode.org/projects/klish/files
update to 2.1.1 (newest version).
merge klish and konf package.

Signed-off-by: Takashi Umeno <umeno.takashi@gmail.com>