### PR TITLE
libwebsockets: Bump to version 1.6-stable

### DIFF
--- a/libs/libwebsockets/Makefile
+++ b/libs/libwebsockets/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libwebsockets
-PKG_VERSION:=1.5-chrome47-firefox41
+PKG_VERSION:=1.6-stable
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -74,7 +74,7 @@ ifeq ($(BUILD_VARIANT),cyassl)
 # for cyassl, edit package/libs/cyassl/Makefile to include --enable-opensslextra
 # NOTE: it will compile without it, untested whether it it's needed?!
     CMAKE_OPTIONS += -DLWS_USE_CYASSL=ON
-    CMAKE_OPTIONS += -DLWS_CYASSL_LIB=$(STAGING_DIR)/usr/lib/libcyassl.so
+    CMAKE_OPTIONS += -DLWS_CYASSL_LIBRARIES=$(STAGING_DIR)/usr/lib/libcyassl.so
     CMAKE_OPTIONS += -DLWS_CYASSL_INCLUDE_DIRS=$(STAGING_DIR)/usr/include
 endif
 


### PR DESCRIPTION
Note that at LWS_CYASSL_LIB has changed to LWS_CYASSL_LIBRARIES

Signed-off-by: John Clark <inindev@gmail.com>
