### PR TITLE
zmq dependency should not be there

### DIFF
--- a/lang/lua-cjson/Makefile
+++ b/lang/lua-cjson/Makefile
@@ -29,7 +29,7 @@ define Package/lua-cjson
   CATEGORY:=Languages
   TITLE:=Lua CJSON parser
   URL:=https://github.com/mpx/lua-cjson
-  DEPENDS:= +lua +libzmq
+  DEPENDS:= +lua
 endef
 
 define Package/lua-cjson/description


### PR DESCRIPTION
this is fixed in master branch, but it is important also for chaos calmer users since zmq is not in main download repository