### PR TITLE
ddns-scripts: Ver.2.6.0 - support hostip and uclient-fetch

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2015 OpenWrt.org
+# Copyright (C) 2008-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 #
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ddns-scripts
 # Version == major.minor.patch
 # increase on new functionality (minor) or patches (patch)
-PKG_VERSION:=2.5.0
+PKG_VERSION:=2.6.0
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=5
+PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/ddns.config
+++ b/net/ddns-scripts/files/ddns.config
@@ -10,7 +10,7 @@ config ddns "global"
 
 
 config service "myddns_ipv4"
-	option service_name	"dyndns.com"
+	option service_name	"dyndns.org"
 	option lookup_host	"yourhost.example.com"
 	option domain		"yourhost.example.com"
 	option username		"your_username"

--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -1,20 +1,12 @@
 #!/bin/sh
 # /usr/lib/ddns/dynamic_dns_functions.sh
 #
-# Original written by Eric Paul Bishop, January 2008
 #.Distributed under the terms of the GNU General Public License (GPL) version 2.0
+# Original written by Eric Paul Bishop, January 2008
 # (Loosely) based on the script on the one posted by exobyte in the forums here:
 # http://forum.openwrt.org/viewtopic.php?id=14040
-#
-# extended and partial rewritten in August 2014 by
-#.Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
-# to support:
-# - IPv6 DDNS services
-# - setting DNS Server to retrieve current IP including TCP transport
-# - Proxy Server to send out updates or retrieving WEB based IP detection
-# - force_interval=0 to run once (useful for cron jobs etc.)
-# - the usage of BIND's host instead of BusyBox's nslookup if installed (DNS via TCP)
-# - extended Verbose Mode and log file support for better error detection
+# extended and partial rewritten
+#.2014-2016 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 #
 # function timeout
 # copied from http://www.ict.griffith.edu.au/anthony/software/timeout.sh
@@ -29,7 +21,7 @@
 . /lib/functions/network.sh
 
 # GLOBAL VARIABLES #
-VERSION="2.5.0-1"
+VERSION="2.6.0-1"
 SECTION_ID=""		# hold config's section name
 VERBOSE_MODE=1		# default mode is log to console, but easily changed with parameter
 
@@ -467,12 +459,12 @@ verify_host_port() {
 	__IPV6=$(echo $__HOST | grep -m 1 -o "$IPV6_REGEX")
 	# if FQDN given get IP address
 	[ -z "$__IPV4" -a -z "$__IPV6" ] && {
-		if [ -x /usr/bin/host ]; then	# use BIND host if installed
+		if [ -n "$(which host)" ]; then	# use BIND host if installed
 			__PROG="BIND host"
-			__RUNPROG="/usr/bin/host -t ANY $__HOST >$DATFILE 2>$ERRFILE"
+			__RUNPROG="$(which host) -t ANY $__HOST >$DATFILE 2>$ERRFILE"
 		else	# use BusyBox nslookup
 			__PROG="BusyBox nslookup"
-			__RUNPROG="/usr/bin/nslookup $__HOST >$DATFILE 2>$ERRFILE"
+			__RUNPROG="$(which nslookup) $__HOST >$DATFILE 2>$ERRFILE"
 		fi
 		write_log 7 "#> $__RUNPROG"
 		eval $__RUNPROG
@@ -643,9 +635,8 @@ do_transfer() {
 	[ $# -ne 1 ] && write_log 12 "Error in 'do_transfer()' - wrong number of parameters"
 
 	# lets prefer GNU Wget because it does all for us - IPv4/IPv6/HTTPS/PROXY/force IP version
-	grep -i "\+ssl" /usr/bin/wget >/dev/null 2>&1	# check for Wget with SSL support
-	if [ $? -eq 0 -a $USE_CURL -eq 0 ]; then 	# except global option use_curl is set to "1"
-		__PROG="/usr/bin/wget -nv -t 1 -O $DATFILE -o $ERRFILE"	# non_verbose no_retry outfile errfile
+	if [ -n "$(which wget-ssl)" -a $USE_CURL -eq 0 ]; then 			# except global option use_curl is set to "1"
+		__PROG="$(which wget-ssl) -nv -t 1 -O $DATFILE -o $ERRFILE"	# non_verbose no_retry outfile errfile
 		# force network/ip to use for communication
 		if [ -n "$bind_network" ]; then
 			local __BINDIP
@@ -668,7 +659,7 @@ do_transfer() {
 				__PROG="$__PROG --ca-certificate=${cacert}"
 			elif [ -d "$cacert" ]; then
 				__PROG="$__PROG --ca-directory=${cacert}"
-			else	# exit here because it makes no sense to start loop
+			elif [ -n "$cacert" ]; then		# it's not a file and not a directory but given
 				write_log 14 "No valid certificate(s) found at '$cacert' for HTTPS communication"
 			fi
 		fi
@@ -679,9 +670,13 @@ do_transfer() {
 		__PROG="GNU Wget"		# reuse for error logging
 
 	# 2nd choice is cURL IPv4/IPv6/HTTPS
-	# libcurl might be compiled without Proxy Support (default in trunk)
-	elif [ -x /usr/bin/curl ]; then
-		__PROG="/usr/bin/curl -RsS -o $DATFILE --stderr $ERRFILE"
+	# libcurl might be compiled without Proxy or HTTPS Support
+	elif [ -n "$(which curl)" ]; then
+		__PROG="$(which curl) -RsS -o $DATFILE --stderr $ERRFILE"
+		# check HTTPS support
+		/usr/bin/curl -V | grep "Protocols:" | grep -F "https" >/dev/null 2>&1
+		[ $? -eq 1 -a $use_https -eq 1 ] && \
+			write_log 13 "cURL: libcurl compiled without https support"
 		# force network/interface-device to use for communication
 		if [ -n "$bind_network" ]; then
 			local __DEVICE
@@ -702,7 +697,7 @@ do_transfer() {
 				__PROG="$__PROG --cacert $cacert"
 			elif [ -d "$cacert" ]; then
 				__PROG="$__PROG --capath $cacert"
-			else	# exit here because it makes no sense to start loop
+			elif [ -n "$cacert" ]; then		# it's not a file and not a directory but given
 				write_log 14 "No valid certificate(s) found at '$cacert' for HTTPS communication"
 			fi
 		fi
@@ -720,9 +715,36 @@ do_transfer() {
 		__RUNPROG="$__PROG '$__URL'"	# build final command
 		__PROG="cURL"			# reuse for error logging
 
-	# busybox Wget (did not support neither IPv6 nor HTTPS)
-	elif [ -x /usr/bin/wget ]; then
-		__PROG="/usr/bin/wget -q -O $DATFILE"
+	# uclient-fetch possibly with ssl support if /lib/libustream-ssl.so installed
+	elif [ -n "$(which uclient-fetch)" ]; then
+		__PROG="$(which uclient-fetch) -q -O $DATFILE"
+		# force network/ip not supported
+		[ -n "$__BINDIP" ] && \
+			write_log 14 "uclient-fetch: FORCE binding to specific address not supported"
+		# force ip version not supported
+		[ $force_ipversion -eq 1 ] && \
+			write_log 14 "uclient-fetch: Force connecting to IPv4 or IPv6 addresses not supported"
+		# https possibly not supported
+		[ $use_https -eq 1 -a ! -f /lib/libustream-ssl.so ] && \
+			write_log 14 "uclient-fetch: no HTTPS support! Additional install one of ustream-ssl packages"
+		# proxy support
+		[ -z "$proxy" ] && __PROG="$__PROG -Y off" || __PROG="$__PROG -Y on"
+		# https & certificates
+		if [ $use_https -eq 1 ]; then
+			if [ "$cacert" = "IGNORE" ]; then
+				__PROG="$__PROG --no-check-certificate"
+			elif [ -f "$cacert" ]; then
+				__PROG="$__PROG --ca-certificate=$cacert"
+			elif [ -n "$cacert" ]; then		# it's not a file; nothing else supported
+				write_log 14 "No valid certificate file '$cacert' for HTTPS communication"
+			fi
+		fi
+		__RUNPROG="$__PROG '$__URL' 2>$ERRFILE"		# build final command
+		__PROG="uclient-fetch"				# reuse for error logging
+
+	# Busybox Wget or any other wget in search $PATH (did not support neither IPv6 nor HTTPS)
+	elif [ -n "$(which wget)" ]; then
+		__PROG="$(which wget) -q -O $DATFILE"
 		# force network/ip not supported
 		[ -n "$__BINDIP" ] && \
 			write_log 14 "BusyBox Wget: FORCE binding to specific address not supported"
@@ -739,7 +761,7 @@ do_transfer() {
 		__PROG="Busybox Wget"				# reuse for error logging
 
 	else
-		write_log 13 "Neither 'Wget' nor 'cURL' installed or executable"
+		write_log 13 "Neither 'Wget' nor 'cURL' nor 'uclient-fetch' installed or executable"
 	fi
 
 	while : ; do
@@ -851,7 +873,7 @@ get_local_ip () {
 						)
 					else
 						__DATA=$(awk '
-							/inet6/ && /: [0-9a-eA-E]/ && !/\/128/ {	# Filter IPv6 exclude fxxx and /128 prefix
+							/inet6/ && /: [0-9a-eA-E]/ {	# Filter IPv6 exclude fxxx
 							#   inet6 addr: 2001:db8::xxxx:xxxx/32 Scope:Global
 							FS="/";		# separator "/"
 							$0=$0;		# reread to activate separator
@@ -927,7 +949,8 @@ get_registered_ip() {
 	# $2	(optional) if set, do not retry on error
 	local __CNT=0	# error counter
 	local __ERR=255
-	local __REGEX  __PROG  __RUNPROG  __DATA
+	local __REGEX  __PROG  __RUNPROG  __DATA  __IP
+	local __MUSL=$(/usr/bin/nslookup 127.0.0.1 0 >/dev/null 2>&1; echo $?) # 0 == busybox compiled with musl
 	# return codes
 	# 1	no IP detected
 
@@ -937,8 +960,8 @@ get_registered_ip() {
 	# set correct regular expression
 	[ $use_ipv6 -eq 0 ] && __REGEX="$IPV4_REGEX" || __REGEX="$IPV6_REGEX"
 
-	if [ -x /usr/bin/host ]; then
-		__PROG="/usr/bin/host"
+	if [ -n "$(which host)" ]; then
+		__PROG="$(which host)"
 		[ $use_ipv6 -eq 0 ] && __PROG="$__PROG -t A"  || __PROG="$__PROG -t AAAA"
 		if [ $force_ipversion -eq 1 ]; then			# force IP version
 			[ $use_ipv6 -eq 0 ] && __PROG="$__PROG -4"  || __PROG="$__PROG -6"
@@ -947,11 +970,37 @@ get_registered_ip() {
 
 		__RUNPROG="$__PROG $lookup_host $dns_server >$DATFILE 2>$ERRFILE"
 		__PROG="BIND host"
-	elif [ -x /usr/bin/nslookup ]; then	# last use BusyBox nslookup
+	elif [ -n "$(which hostip)" ]; then	# hostip package installed
+		__PROG="$(which hostip)"
+		[ $force_dnstcp -ne 0 ] && \
+			write_log 14 "hostip - no support for 'DNS over TCP'"
+
+		# is IP given as dns_server ?
+		__IP=$(echo $dns_server | grep -m 1 -o "$IPV4_REGEX")
+		[ -z "$__IP" ] && __IP=$(echo $dns_server | grep -m 1 -o "$IPV6_REGEX")
+
+		# we got NO ip for dns_server, so build command
+		[ -z "$__IP" -a -n "$dns_server" ] && {
+			__IP="\`/usr/bin/hostip"
+			[ $use_ipv6 -eq 1 -a $force_ipversion -eq 1 ] && __IP="$__IP -6"
+			__IP="$__IP $dns_server | grep -m 1 -o"
+			[ $use_ipv6 -eq 1 -a $force_ipversion -eq 1 ] \
+				&& __IP="$__IP '$IPV6_REGEX'" \
+				|| __IP="$__IP '$IPV4_REGEX'"
+			__IP="$__IP \`"
+		}
+
+		[ $use_ipv6 -eq 1 ] && __PROG="$__PROG -6"
+		[ -n "$dns_server" ] && __PROG="$__PROG -r $__IP"
+		__RUNPROG="$__PROG $lookup_host >$DATFILE 2>$ERRFILE"
+		__PROG="hostip"
+	elif [ -n "$(which nslookup)" ]; then	# last use BusyBox nslookup
 		[ $force_ipversion -ne 0 -o $force_dnstcp -ne 0 ] && \
 			write_log 14 "Busybox nslookup - no support to 'force IP Version' or 'DNS over TCP'"
+		[ $__MUSL -eq 0 -a -n "$dns_server" ] && \
+			write_log 14 "Busybox compiled with musl - nslookup - no support to set/use DNS Server"
 
-		__RUNPROG="/usr/bin/nslookup $lookup_host $dns_server >$DATFILE 2>$ERRFILE"
+		__RUNPROG="$(which nslookup) $lookup_host $dns_server >$DATFILE 2>$ERRFILE"
 		__PROG="BusyBox nslookup"
 	else	# there must be an error
 		write_log 12 "Error in 'get_registered_ip()' - no supported Name Server lookup software accessible"
@@ -967,6 +1016,8 @@ get_registered_ip() {
 		else
 			if [ "$__PROG" = "BIND host" ]; then
 				__DATA=$(cat $DATFILE | awk -F "address " '/has/ {print $2; exit}' )
+			elif [ "$__PROG" = "hostip" ]; then
+				__DATA=$(cat $DATFILE | grep -m 1 -o "$__REGEX")
 			else
 				__DATA=$(cat $DATFILE | sed -ne "/^Name:/,\$ { s/^Address[0-9 ]\{0,\}: \($__REGEX\).*$/\\1/p }" )
 			fi

--- a/net/ddns-scripts/files/dynamic_dns_lucihelper.sh
+++ b/net/ddns-scripts/files/dynamic_dns_lucihelper.sh
@@ -2,13 +2,8 @@
 # /usr/lib/ddns/luci_dns_helper.sh
 #
 #.Distributed under the terms of the GNU General Public License (GPL) version 2.0
-#
-# Written in August 2014 by
-#.Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+#.2014-2016 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 # This script is used by luci-app-ddns
-# - getting registered IP
-# - check if possible to get local IP
-# - verifing given DNS- or Proxy-Server
 #
 # variables in small chars are read from /etc/config/ddns as parameter given here
 # variables in big chars are defined inside these scripts as gloval vars

--- a/net/ddns-scripts/files/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/dynamic_dns_updater.sh
@@ -1,21 +1,12 @@
 #!/bin/sh
 # /usr/lib/ddns/dynamic_dns_updater.sh
 #
-# Original written by Eric Paul Bishop, January 2008
 #.Distributed under the terms of the GNU General Public License (GPL) version 2.0
+# Original written by Eric Paul Bishop, January 2008
 # (Loosely) based on the script on the one posted by exobyte in the forums here:
 # http://forum.openwrt.org/viewtopic.php?id=14040
-#
-# extended and partial rewritten in August 2014 by
-#.Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
-# to support:
-# - IPv6 DDNS services
-# - DNS Server to retrieve registered IP including TCP transport (Ticket 7820)
-# - Proxy Server to send out updates
-# - force_interval=0 to run once (Luci Ticket 538)
-# - the usage of BIND's host command instead of BusyBox's nslookup if installed
-# - extended Verbose Mode and log file support for better error detection
-# - wait for interface to fully come up, before the first update is done
+# extended and partial rewritten
+#.2014-2016 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 #
 # variables in small chars are read from /etc/config/ddns
 # variables in big chars are defined inside these scripts as global vars

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -22,6 +22,15 @@
 # !!! Use only the script name (without path). Sample:
 # !!! "example.com"	"update_sample.sh"
 #
+# !!! Since ddns-scripts Version 2.5.x additional parameters are supported
+# !!! and a given answer on success is checked (ignored by earlier versions)
+# !!! Additional parameters: [PARAMOPT] and [PARAMENC]; [PARAMENC] is send urlencoded
+#
+# Line syntax: "service" [TAB] "update_url" [TAB] "answer"
+# "service"	name used as "option service_name" inside /etc/config/ddns
+# "update_url"	update url as given by the provider; custom urls should not saved here
+# "answer"	single words inside providers answer string; use "|" to combine "or"
+#
 # 44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444
 
 "dyndns.org"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"
@@ -37,7 +46,7 @@
 "thatip.com"	"http://update.dnsmax.com/update/?username=[USERNAME]&password=[PASSWORD]&resellerid=2&clientname=openwrt&clientversion=8.09&protocolversion=2.0&updatehostname=[DOMAIN]&ip=[IP]"
 
 # Hurricane Electric Dynamic DNS
-"he.net"	"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"
+"he.net"	"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 # DNSdynamic.org
 "dnsdynamic.org"	"http://[USERNAME]:[PASSWORD]@www.dnsdynamic.org/api/?hostname=[DOMAIN]&myip=[IP]"
@@ -48,10 +57,8 @@
 # OVH
 "ovh.com"	"http://[USERNAME]:[PASSWORD]@www.ovh.com/nic/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]"
 
-# dns-o-matic is a free service by opendns.com for updating multiple hosts and
-# dynamic dns services in one api call. To update all your configured services
-# at once, use "all.dnsomatic.com as the hostname.
-"dnsomatic.com"	"http://[USERNAME]:[PASSWORD]@updates.dnsomatic.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
+# dns-o-matic is a free service by opendns.com for updating multiple hosts
+"dnsomatic.com"	"http://[USERNAME]:[PASSWORD]@updates.dnsomatic.com/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 # 3322.org
 "3322.org"	"http://[USERNAME]:[PASSWORD]@members.3322.org/dyndns/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]"
@@ -69,7 +76,7 @@
 "mythic-beasts.com"	"http://dnsapi4.mythic-beasts.com/?domain=[USERNAME]&password=[PASSWORD]&command=REPLACE%20[DOMAIN]%2060%20A%20DYNAMIC_IP"
 
 # Securepoint Dynamic-DNS-Service	(http://www.spdns.de)
-"spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	    "good|nochg"
+"spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 # duiadns.net - free dynamic DNS
 "duiadns.net"	"http://ipv4.duia.ro/dynamic.duia?host=[DOMAIN]&password=[PASSWORD]&ip4=[IP]"
@@ -84,7 +91,7 @@
 "loopia.se"	"http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"
 
 # SelfHost.de
-"selfhost.de"	"http://carol.selfhost.de/update?username=[USERNAME]&password=[PASSWORD]&myip=[IP]&hostname=1"	    "good|nochg"
+"selfhost.de"	"http://carol.selfhost.de/update?username=[USERNAME]&password=[PASSWORD]&myip=[IP]&hostname=1"	"good|nochg"
 
 # no-ip.pl nothing to do with no-ip.com (domain registered to www.domeny.tv) (IP autodetected by provider)
 "no-ip.pl"	"http://[USERNAME]:[PASSWORD]@update.no-ip.pl/?hostname=[DOMAIN]"
@@ -93,19 +100,22 @@
 "domains.google.com"	"http://[USERNAME]:[PASSWORD]@domains.google.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
 
 # Schokokeks Hosting, schokokeks.org
-"schokokeks.org"	"http://[USERNAME]:[PASSWORD]@dyndns.schokokeks.org/nic/update?myip=[IP]"
+"schokokeks.org"	"http://[USERNAME]:[PASSWORD]@dyndns.schokokeks.org/nic/update?myip=[IP]"	"good|nochg"
 
 # STRATO AG
 "strato.de"		"http://[USERNAME]:[PASSWORD]@dyndns.strato.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
 
 # Variomedia AG
-"variomedia.de" 	"http://[USERNAME]:[PASSWORD]@dyndns.variomedia.de/nic/update?hostname=[DOMAIN]&myip=[IP]"
+"variomedia.de" 	"http://[USERNAME]:[PASSWORD]@dyndns.variomedia.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
  #DtDNS
 "dtdns.com"	"http://www.dtdns.com/api/autodns.cfm?id=[DOMAIN]&pw=[PASSWORD]&ip=[IP]"
 
-# dy.fi Dynamic DNS for finnish users
-"dy.fi"      "http://[USERNAME]:[PASSWORD]@www.dy.fi/nic/update?hostname=[DOMAIN]"
+# dy.fi Dynamic DNS for finnish users (IP autodetected by provider)
+"dy.fi"		"http://[USERNAME]:[PASSWORD]@www.dy.fi/nic/update?hostname=[DOMAIN]"	"good|nochg"
 
-# duckdns.org as in https://www.duckdns.org/install.jsp#openwrt and https://wiki.openwrt.org/doc/howto/ddns.client/duckdns
-"duckdns.org"    "http://www.duckdns.org/update?domains=[USERNAME]&token=[PASSWORD]&ip=[IP]"    "OK"
+# duckdns.org
+"duckdns.org"	"http://www.duckdns.org/update?domains=[USERNAME]&token=[PASSWORD]&ip=[IP]"	"OK"
+
+# zzzz.io Free Dynamic DNS
+"zzzz.io"	"https://zzzz.io/api/v1/update/[DOMAIN]/?token=[PASSWORD]&ip=[IP]"	"Updated|No change"

--- a/net/ddns-scripts/files/services_ipv6
+++ b/net/ddns-scripts/files/services_ipv6
@@ -22,13 +22,22 @@
 # !!! Use only the script name (without path). Sample:
 # !!! "example.com"	"update_sample.sh"
 #
+# !!! Since ddns-scripts Version 2.5.x additional parameters are supported
+# !!! and a given answer on success is checked (ignored by earlier versions)
+# !!! Additional parameters: [PARAMOPT] and [PARAMENC]; [PARAMENC] is send urlencoded
+#
+# Line syntax: "service" [TAB] "update_url" [TAB] "answer"
+# "service"	name used as "option service_name" inside /etc/config/ddns
+# "update_url"	update url as given by the provider; custom urls should not saved here
+# "answer"	words inside providers answer string; use "|" to combine "or"
+#
 # 66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666
 
 # IPv6 @ Securepoint Dynamic-DNS-Service
-"spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	    "good|nochg"
+"spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 # IPv6 @ Hurricane Electric Dynamic DNS
-"he.net"	"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"
+"he.net"	"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 # IPv6 @ MyDNS.JP
 "mydns.jp"	"http://www.mydns.jp/directip.html?MID=[USERNAME]&PWD=[PASSWORD]&IPV6ADDR=[IP]"
@@ -40,8 +49,13 @@
 "freedns.afraid.org"	"http://freedns.afraid.org/dynamic/update.php?[PASSWORD]&address=[IP]"
 
 # IPv6 @ LoopiaDNS
-"loopia.se" "http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"
+"loopia.se"	"http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"
 
 # Variomedia AG
-"variomedia.de" 	"http://[USERNAME]:[PASSWORD]@dyndns.variomedia.de/nic/update?hostname=[DOMAIN]&myip=[IP]"
+"variomedia.de"		"http://[USERNAME]:[PASSWORD]@dyndns.variomedia.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
+# IPv6 @ Dyn.com
+"dyndns.org"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"
+
+# zzzz.io Free Dynamic DNS
+"zzzz.io"	"https://zzzz.io/api/v1/update/[DOMAIN]/?token=[PASSWORD]&type=aaaa&ip=[IP]"	"Updated|No change"

--- a/net/ddns-scripts/files/tld_names.dat
+++ b/net/ddns-scripts/files/tld_names.dat
@@ -89,7 +89,6 @@ leasing.aero
 logistics.aero
 magazine.aero
 maintenance.aero
-marketplace.aero
 media.aero
 microlight.aero
 modelling.aero
@@ -112,7 +111,6 @@ show.aero
 skydiving.aero
 software.aero
 student.aero
-taxi.aero
 trader.aero
 trading.aero
 trainer.aero
@@ -154,13 +152,6 @@ org.al
 
 // am : http://en.wikipedia.org/wiki/.am
 am
-
-// an : http://www.una.an/an_domreg/default.asp
-an
-com.an
-net.an
-org.an
-edu.an
 
 // ao : http://en.wikipedia.org/wiki/.ao
 // http://www.dns.ao/REGISTR.DOC
@@ -1016,7 +1007,10 @@ gw
 gy
 co.gy
 com.gy
+edu.gy
+gov.gy
 net.gy
+org.gy
 
 // hk : https://www.hkdnr.hk
 // Submitted by registry <hk.tech@hkirc.hk> 2008-06-11
@@ -1176,7 +1170,7 @@ tv.im
 
 // in : http://en.wikipedia.org/wiki/.in
 // see also: https://registry.in/Policies
-// Please note, that nic.in is not an offical eTLD, but used by most
+// Please note, that nic.in is not an official eTLD, but used by most
 // government institutions.
 in
 co.in
@@ -4510,8 +4504,21 @@ gov.ng
 mil.ng
 mobi.ng
 
-// ni : http://www.nic.ni/dominios.htm
-*.ni
+// ni : http://www.nic.ni/
+com.ni
+gob.ni
+edu.ni
+org.ni
+nom.ni
+net.ni
+mil.ni
+co.ni
+biz.ni
+web.ni
+int.ni
+ac.ni
+in.ni
+info.ni
 
 // nl : http://en.wikipedia.org/wiki/.nl
 // https://www.sidn.nl/
@@ -6030,7 +6037,6 @@ kms.ru
 k-uralsk.ru
 kustanai.ru
 kuzbass.ru
-magnitka.ru
 mytis.ru
 nakhodka.ru
 nkz.ru
@@ -6379,10 +6385,6 @@ net.to
 org.to
 edu.to
 mil.to
-
-// tp : No registrations at this time.
-// Submitted by Ryan Sleevi <ryan.sleevi@gmail.com> 2014-01-03
-tp
 
 // subTLDs: https://www.nic.tr/forms/eng/policies.pdf
 // and: https://www.nic.tr/forms/politikalar.pdf
@@ -6822,8 +6824,8 @@ lib.wi.us
 // lib.wv.us Bug 941670 - Removed at request of Larry W Arnold <arnold@wvlc.lib.wv.us>
 lib.wy.us
 // k12.ma.us contains school districts in Massachusetts. The 4LDs are
-// managed indepedently except for private (PVT), charter (CHTR) and
-// parochial (PAROCH) schools. Those are delegated dorectly to the
+// managed independently except for private (PVT), charter (CHTR) and
+// parochial (PAROCH) schools. Those are delegated directly to the
 // 5LD operators. <k12-ma-hostmaster _ at _ rsuc.gweep.net>
 pvt.k12.ma.us
 chtr.k12.ma.us
@@ -7214,7 +7216,7 @@ xxx
 
 // za : http://www.zadna.org.za/content/page/domain-information
 ac.za
-agrica.za
+agric.za
 alt.za
 co.za
 edu.za
@@ -7238,7 +7240,7 @@ web.za
 *.zw
 
 
-// List of new gTLDs imported from https://newgtlds.icann.org/newgtlds.csv on 2015-10-11T22:21:58Z
+// List of new gTLDs imported from https://newgtlds.icann.org/newgtlds.csv on 2016-01-04T22:39:54Z
 
 // aaa : 2015-02-26 American Automobile Association, Inc.
 aaa
@@ -7411,6 +7413,9 @@ apple
 // aquarelle : 2014-07-24 Aquarelle.com
 aquarelle
 
+// arab : 2015-11-12 League of Arab States
+arab
+
 // aramco : 2014-11-20 Aramco Services Company
 aramco
 
@@ -7507,6 +7512,9 @@ barefoot
 // bargains : 2013-11-14 Half Hallow, LLC
 bargains
 
+// baseball : 2015-10-29 MLB Advanced Media DH, LLC
+baseball
+
 // basketball : 2015-08-20 Fédération Internationale de Basketball (FIBA)
 basketball
 
@@ -7533,6 +7541,9 @@ bcn
 
 // beats : 2015-05-14 Beats Electronics, LLC
 beats
+
+// beauty : 2015-12-03 L'Oréal
+beauty
 
 // beer : 2014-01-09 Top Level Domain Holdings Limited
 beer
@@ -7639,11 +7650,17 @@ bosch
 // bostik : 2015-05-28 Bostik SA
 bostik
 
+// boston : 2015-12-10 Boston Globe Media Partners, LLC
+boston
+
 // bot : 2014-12-18 Amazon EU S.à r.l.
 bot
 
 // boutique : 2013-11-14 Over Galley, LLC
 boutique
+
+// box : 2015-11-12 NS1 Limited
+box
 
 // bradesco : 2014-12-18 Banco Bradesco S.A.
 bradesco
@@ -7764,6 +7781,9 @@ casino
 
 // catering : 2013-12-05 New Falls. LLC
 catering
+
+// catholic : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
+catholic
 
 // cba : 2014-06-26 COMMONWEALTH BANK OF AUSTRALIA
 cba
@@ -7972,6 +7992,9 @@ crown
 // crs : 2014-04-03 Federated Co-operatives Limited
 crs
 
+// cruise : 2015-12-10 Viking River Cruises (Bermuda) Ltd.
+cruise
+
 // cruises : 2013-12-05 Spring Way, LLC
 cruises
 
@@ -8082,6 +8105,9 @@ discover
 
 // dish : 2015-07-30 Dish DBS Corporation
 dish
+
+// diy : 2015-11-05 Lifestyle Domain Holdings, Inc.
+diy
 
 // dnp : 2013-12-13 Dai Nippon Printing Co., Ltd.
 dnp
@@ -8365,6 +8391,9 @@ foundation
 // fox : 2015-09-11 FOX Registry, LLC
 fox
 
+// free : 2015-12-10 Amazon EU S.à r.l.
+free
+
 // fresenius : 2015-07-30 Fresenius Immobilien-Verwaltungs-GmbH
 fresenius
 
@@ -8554,6 +8583,9 @@ guitars
 // guru : 2013-08-27 Pioneer Cypress, LLC
 guru
 
+// hair : 2015-12-03 L'Oréal
+hair
+
 // hamburg : 2014-02-20 Hamburg Top-Level-Domain GmbH
 hamburg
 
@@ -8602,7 +8634,7 @@ hisamitsu
 // hitachi : 2014-10-31 Hitachi, Ltd.
 hitachi
 
-// hiv : 2014-03-13 dotHIV gemeinnuetziger e.V.
+// hiv : 2014-03-13
 hiv
 
 // hkt : 2015-05-14 PCCW-HKT DataCom Services Limited
@@ -9349,6 +9381,9 @@ ninja
 // nissan : 2014-03-27 NISSAN MOTOR CO., LTD.
 nissan
 
+// nissay : 2015-10-29 Nippon Life Insurance Company
+nissay
+
 // nokia : 2015-01-08 Nokia Corporation
 nokia
 
@@ -9604,7 +9639,7 @@ prof
 // progressive : 2015-07-23 Progressive Casualty Insurance Company
 progressive
 
-// promo : 2014-12-18 Play.PROMO Oy
+// promo : 2014-12-18
 promo
 
 // properties : 2013-12-05 Big Pass, LLC
@@ -9624,6 +9659,9 @@ prudential
 
 // pub : 2013-12-12 United TLD Holdco Ltd.
 pub
+
+// pwc : 2015-10-29 PricewaterhouseCoopers LLP
+pwc
 
 // qpon : 2013-11-14 dotCOOL, Inc.
 qpon
@@ -9735,6 +9773,9 @@ rio
 
 // rip : 2014-07-10 United TLD Holdco Ltd.
 rip
+
+// rmit : 2015-11-19 Royal Melbourne Institute of Technology
+rmit
 
 // rocher : 2014-12-18 Ferrero Trading Lux S.A.
 rocher
@@ -10288,6 +10329,9 @@ ubs
 // uconnect : 2015-07-30 FCA US LLC.
 uconnect
 
+// unicom : 2015-10-15 China United Network Communications Corporation Limited
+unicom
+
 // university : 2014-03-06 Little Station, LLC
 university
 
@@ -10374,6 +10418,9 @@ vodka
 
 // volkswagen : 2015-05-14 Volkswagen Group of America Inc.
 volkswagen
+
+// volvo : 2015-11-12 Volvo Holding Sverige Aktiebolag
+volvo
 
 // vote : 2013-11-21 Monolith Registry LLC
 vote
@@ -10583,6 +10630,10 @@ xn--6qq986b3xl
 москва
 xn--80adxhks
 
+// xn--80aqecdr1a : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
+католик
+xn--80aqecdr1a
+
 // xn--80asehdb : 2013-07-14 CORE Association
 онлайн
 xn--80asehdb
@@ -10763,6 +10814,10 @@ xn--mgbb9fbpob
 ابوظبي
 xn--mgbca7dzdo
 
+// xn--mgbi4ecexp : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
+كاثوليك
+xn--mgbi4ecexp
+
 // xn--mgbt3dhd : 2014-09-04 Asia Green IT System Bilgisayar San. ve Tic. Ltd. Sti.
 همراه
 xn--mgbt3dhd
@@ -10782,6 +10837,10 @@ xn--ngbc5azd
 // xn--ngbe9e0a : 2014-12-04 Kuwait Finance House
 بيتك
 xn--ngbe9e0a
+
+// xn--ngbrx : 2015-11-12 League of Arab States
+عرب
+xn--ngbrx
 
 // xn--nqv7f : 2013-11-14 Public Interest Registry
 机构
@@ -10834,6 +10893,10 @@ xn--t60b56a
 // xn--tckwe : 2015-01-15 VeriSign Sarl
 コム
 xn--tckwe
+
+// xn--tiq49xqyj : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
+天主教
+xn--tiq49xqyj
 
 // xn--unup4y : 2013-07-14 Spring Fields, LLC
 游戏
@@ -11071,6 +11134,10 @@ cupcake.is
 // DreamHost : http://www.dreamhost.com/
 // Submitted by Andrew Farmer <andrew.farmer@dreamhost.com> 2012-10-02
 dreamhosters.com
+
+// Drobo : http://www.drobo.com/
+// Submitted by Ricardo Padilha <rpadilha@drobo.com> 2015-12-17
+mydrobo.com
 
 // DuckDNS : http://www.duckdns.org/
 // Submitted by Richard Harper <richard@duckdns.org> 2015-05-17
@@ -11523,12 +11590,16 @@ blogspot.td
 blogspot.tw
 blogspot.ug
 blogspot.vn
+cloudfunctions.net
 codespot.com
 googleapis.com
 googlecode.com
 pagespeedmobilizer.com
 withgoogle.com
 withyoutube.com
+
+// Hashbang : https://hashbang.sh
+hashbang.sh
 
 // Heroku : https://www.heroku.com/
 // Submitted by Tom Maher <tmaher@heroku.com> 2013-05-02
@@ -11560,6 +11631,10 @@ bmoattachments.org
 // Submitted by Trung Tran <Trung.Tran@neustar.biz> 2015-04-23
 4u.com
 
+// ngrok : https://ngrok.com/
+// Submitted by Alan Shreve <alan@ngrok.com> 2015-11-10
+ngrok.io
+
 // NFSN, Inc. : https://www.NearlyFreeSpeech.NET/
 // Submitted by Jeff Wheelhouse <support@nearlyfreespeech.net> 2014-02-02
 nfshost.com
@@ -11579,6 +11654,10 @@ operaunite.com
 // OutSystems
 // Submitted by Duarte Santos <domain-admin@outsystemscloud.com> 2014-03-11
 outsystemscloud.com
+
+// Pagefront : https://www.pagefronthq.com/
+// Submitted by Jason Kriss <jason@pagefronthq.com> 2015-12-02
+pagefrontapp.com
 
 // .pl domains (grandfathered)
 art.pl
@@ -11601,6 +11680,11 @@ priv.at
 // Submitted by Daniel Dent (https://www.danieldent.com/) 2015-07-16
 qa2.com
 
+// Rackmaze LLC : https://www.rackmaze.com
+// Submitted by Kirill Pertsev <kika@rackmaze.com> 2015-12-02
+rackmaze.com
+rackmaze.net
+
 // Red Hat, Inc. OpenShift : https://openshift.redhat.com/
 // Submitted by Tim Kramer <tkramer@rhcloud.com> 2012-10-24
 rhcloud.com
@@ -11620,6 +11704,22 @@ pp.ua
 sinaapp.com
 vipsinaapp.com
 1kapp.com
+
+// Synology, Inc. : https://www.synology.com/
+// Submitted by Rony Weng <ronyweng@synology.com> 2015-12-02
+diskstation.me
+dscloud.biz
+dscloud.me
+dscloud.mobi
+dsmynas.com
+dsmynas.net
+dsmynas.org
+familyds.com
+familyds.net
+familyds.org
+i234.me
+myds.me
+synology.me
 
 // TASK geographical domains (www.task.gda.pl/uslugi/dns)
 gda.pl


### PR DESCRIPTION
- add support for "hostip" to get_registered_ip() as alternative to "Bind host" package https://dev.openwrt.org/ticket/20893#comment:5
- allow to send updates using compiled-in certificate file/path of curl/wget #2242 #2243 #2245
- add support for uclient-fetch
- remove /128 prefix-filter in get_local_ip() via interface #2268
- add dyndns.org to services_ipv6 https://forum.openwrt.org/viewtopic.php?id=62103
- readd duckdns.org to services #2251 (lost somewhere in data heaven)
- add zzzz.io service #2302
- updated tld_names.dat

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>