### PR TITLE
rtl-sdr: Add start script file for rtl-tcp

### DIFF
--- a/utils/rtl-sdr/Makefile
+++ b/utils/rtl-sdr/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtl-sdr
 PKG_VERSION:=0.5.3-20150608-$(PKG_SOURCE_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=git://git.osmocom.org/rtl-sdr.git
@@ -81,6 +81,10 @@ endef
 define Package/rtl-sdr/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/rtl_* $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) files/rtl_tcp.init $(1)/etc/init.d/rtl_tcp
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) files/rtl_tcp.config $(1)/etc/config/rtl_tcp
 endef
 
 define Package/librtlsdr/install

--- a/utils/rtl-sdr/files/rtl_tcp.config
+++ b/utils/rtl-sdr/files/rtl_tcp.config
@@ -1,0 +1,12 @@
+config rtl_tcp main
+	option disabled '1'
+	option respawn '1'
+	option device_index ''
+	option address '0.0.0.0'
+	option port ''
+	option frequency ''
+	option gain ''
+	option samplerate ''
+	option buffers '8'
+	option num_linked_lists '8'
+	option ppm_error ''

--- a/utils/rtl-sdr/files/rtl_tcp.init
+++ b/utils/rtl-sdr/files/rtl_tcp.init
@@ -1,0 +1,64 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2016 OpenWrt.org
+
+START=90
+STOP=10
+USE_PROCD=1
+
+append_arg() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
+
+	config_get val "$cfg" "$var"
+	[ -n "$val" -o -n "$def" ] && procd_append_param command $opt "${val:-$def}"
+}
+
+append_bool() {
+	local cfg="$1"
+	local var="$2"
+	local opt="$3"
+	local def="$4"
+	local val
+
+	config_get_bool val "$cfg" "$var" "$def"
+	[ "$val" = 1 ] && procd_append_param command "$opt"
+}
+
+
+start_instance() {
+	local cfg="$1"
+	local aux
+
+	config_get_bool aux "$cfg" 'disabled' '0'
+	[ "$aux" = 1 ] && return 1
+
+	procd_open_instance
+
+	procd_set_param command /usr/bin/rtl_tcp
+	append_arg "$cfg" device_index "-d"
+	append_arg "$cfg" address "-a"
+	append_arg "$cfg" port "-p"
+	append_arg "$cfg" frequency "-f"
+	append_arg "$cfg" gain "-g"
+	append_arg "$cfg" samplerate "-s"
+	append_arg "$cfg" buffers "-b"
+	append_arg "$cfg" num_linked_lists "-n"
+	append_arg "$cfg" ppm_error "-P"
+
+	config_get_bool aux "$cfg" 'respawn' '0'
+	[ "$aux" = 1 ] && procd_set_param respawn
+
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger "rtl_tcp"
+}
+
+start_service() {
+	config_load rtl_tcp
+	config_foreach start_instance rtl_tcp
+}


### PR DESCRIPTION
One of the most common uses of the rtl-sdr suite on OpenWrt is to stream
data to a remote analyzer. This commit creates a /etc/init.d/ and
/etc/config entry for rtl-tcp, so that it can automatically launch on
startup.

Signed-off-by: Mike Miller <github@mikeage.net>