### PR TITLE
dump1090: fix typo preventing daemon startup

### DIFF
--- a/utils/dump1090/files/dump1090.config
+++ b/utils/dump1090/files/dump1090.config
@@ -28,7 +28,7 @@ config dump1090 main
 	option no_fix '0'
 	option no_crc_check '0'
 	option phase_enhance '0'
-	option agressive '0'
+	option aggressive '0'
 	option mlat '0'
 	option stats '0'
 	option stats_every ''

--- a/utils/dump1090/files/dump1090.init
+++ b/utils/dump1090/files/dump1090.init
@@ -66,7 +66,7 @@ start_instance() {
 	append_bool "$cfg" no_fix "--no-fix"
 	append_bool "$cfg" no_crc_check "--no-crc-check"
 	append_bool "$cfg" phase_enhance "--phase-enhance"
-	append_bool "$cfg" agressive "--agressive"
+	append_bool "$cfg" aggressive "--aggressive"
 	append_bool "$cfg" mlat "--mlat"
 	append_bool "$cfg" stats "--stats"
 	append_arg "$cfg" stats_every "--stats-every"


### PR DESCRIPTION
This fix is already in master, but based on the switch to the
mutability fork.

Signed-off-by: Mike Miller <github@mikeage.net>