### PR TITLE
dump1090: Support cross-compiling (from OS X)

### DIFF
--- a/utils/dump1090/Makefile
+++ b/utils/dump1090/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dump1090
 PKG_VERSION:=2015-11-22
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=git://github.com/mutability/dump1090.git
@@ -53,7 +53,8 @@ define Package/view1090/description
 endef
 
 MAKE_FLAGS += \
-	CFLAGS="$(TARGET_CFLAGS)"
+	CFLAGS="$(TARGET_CFLAGS)" \
+	UNAME=Linux
 
 define Package/dump1090/install
 	$(INSTALL_DIR) $(1)/etc/init.d


### PR DESCRIPTION
Ideally this should be fixed in dump1090 itself, but I didn't see an
easy way to detect cross compilation (they're not using autoconf).
Instead, just skip the target check based on the host's uname.

Signed-off-by: Mike Miller <github@mikeage.net>