### PR TITLE
libs: file: fix typo in default call

### DIFF
--- a/libs/file/Makefile
+++ b/libs/file/Makefile
@@ -31,7 +31,7 @@ define Package/file/Default
 endef
 
 define Package/file
-$(call package/file/Default)
+$(call Package/file/Default)
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE+= utility
@@ -39,7 +39,7 @@ $(call package/file/Default)
 endef
 
 define Package/libmagic
-$(call package/file/Default)
+$(call Package/file/Default)
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE+= library


### PR DESCRIPTION
Corrects the display and help text for file and libmagic in menuconfig.

Signed-off-by: Karl Palsson <karlp@remake.is>