### PR TITLE
glib2: host build needs --with-libiconv=native (not =gnu)

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -46,7 +46,7 @@ endef
 
 HOST_CONFIGURE_ARGS += \
 	--disable-selinux \
-	--with-libiconv=gnu
+	--with-libiconv=native
 
 CONFIGURE_ARGS += \
 	--enable-shared \


### PR DESCRIPTION
The libiconv in host build is actually native (i.e., it is static library, and uses funcs as 'iconv_open', 'iconv_close', etc). The gnu variant (where it is dynamic libiconv.so with 'libiconv_open', etc) is NOT the case and cause crash on building.
