### PR TITLE
aircrack-ng: split out airmon-ng as a separate package.

### DIFF
--- a/net/aircrack-ng/Makefile
+++ b/net/aircrack-ng/Makefile
@@ -10,7 +10,8 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=aircrack-ng
 PKG_VERSION:=1.2-rc1
 PKG_RELEASE:=1
-PKG_LICENSE:=GPLv2
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.aircrack-ng.org/ \
@@ -20,20 +21,34 @@ PKG_MD5SUM:=c2f8648c92f7e46051c86c618d4fb0d5
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
+PKG_MAINTAINER:=Rick Farina <zerochaos@gentoo.org>
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/aircrack-ng
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libpcap +libpthread +libopenssl +libnl-core +libnl-genl +wireless-tools +ethtool
-  TITLE:=WLAN tools for breaking 802.11 WEP/WPA keys
+  DEPENDS:=+libpcap +libpthread +libopenssl +libnl-core +libnl-genl
+  TITLE:=WLAN tools (without airmon-ng) for breaking 802.11 WEP/WPA keys
   URL:=http://www.aircrack-ng.org/
-  MAINTAINER:=Rick Farina <zerochaos@gentoo.org>
   SUBMENU:=wireless
 endef
 
 define Package/aircrack-ng/description
   WLAN tools for breaking 802.11 WEP/WPA keys
+endef
+
+define Package/airmon-ng
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+wireless-tools +ethtool +procps +CONFIG_PCI_SUPPORT:pciutils +CONFIG_USB_SUPPORT:usbutils
+  TITLE:=Bash script designed to turn wireless cards into monitor mode.
+  URL:=http://www.aircrack-ng.org/
+  SUBMENU:=wireless
+endef
+
+define Package/airmon-ng/description
+  Bash script designed to turn wireless cards into monitor mode.
 endef
 
 MAKE_FLAGS += prefix=/usr \
@@ -47,6 +62,13 @@ define Package/aircrack-ng/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/* $(1)/usr/sbin/
+	rm -f $(1)/usr/sbin/airmon-ng
+endef
+
+define Package/airmon-ng/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/airmon-ng $(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,aircrack-ng))
+$(eval $(call BuildPackage,airmon-ng))


### PR DESCRIPTION

NOTE: wireless-tools still required for airmon-ng in 1.2-rc1

As said in a related github discussion thread [1], OpenWrt is so small a
system that

 - "airmon-ng check kill" does not have much to check
 - airmon-ng takes up too much space for not that much benefit (bringing
   up monitor interface with just iw should be enough for at least b43
   and ath9k drivers)

Airmon-ng depends on a lot of utility binaries to run and these
dependencies increase the installation size.  With this commit we can
provide a working airmon-ng and a smaller aircrack-ng package.

Dependency spec of airmon-ng is also reworked to

 - select usbutils only if USB feature is available
 - select pciutils only if PCI feature is available

While doing the split, this commit also contains a few other minor
changes

 - Use SPDX identifier for license name.
 - Add PKG_LICENSE_FILES definition.
 - Set PKG_MAINTAINER (MAINTAINER variable will take value from it).

 [1] https://github.com/openwrt/packages/pull/1693

Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>