### PR TITLE
wifitoggle: Support toggling specific wireless interface

### DIFF
--- a/utils/wifitoggle/files/wifitoggle.hotplug
+++ b/utils/wifitoggle/files/wifitoggle.hotplug
@@ -36,7 +36,7 @@ setwifi() {
         setled
 
         config_load wireless
-        config_foreach save_wireless wifi-device
+        config_foreach save_wireless wifi-$wifi_type
 
         if ubus list network.wireless >/dev/null 2>/dev/null; then
                 ubus call network reload
@@ -146,6 +146,8 @@ load_wifitoggle() {
 	config_get led_disable_delayon $1 led_disable_delayon
 	config_get led_disable_delayoff $1 led_disable_delayoff
 
+	config_get wifi_type $1 wifi_type "device"
+
         [ "$ACTION" = "$action" -a "$BUTTON" = "$button" ] && {
 
 		[ -f /tmp/run/wirelesstoggle_${1}.pid ] && read PID < /tmp/run/wirelesstoggle_${1}.pid && kill $PID && rm /tmp/run/wirelesstoggle_${1}.pid
@@ -153,7 +155,7 @@ load_wifitoggle() {
 		if [ "$device" = "all" ]
 		then
 			config_load wireless
-        		config_foreach load_wireless wifi-device
+			config_foreach load_wireless wifi-$wifi_type
 		else
 			disabled="$(uci get wireless."$device".disabled)"
 		fi


### PR DESCRIPTION
Add new `wifi_type` setting which can be configured to `device` (default) or `iface`. Specifying `iface` switches only specific wireless interface, not the complete radio.
 
Also `config wifi-iface` entries on `/etc/config/wireless` need to have a name, e.g. `config wifi-iface 'ap-network'`.

The default behavior stays the same — toggles the whole radio completely.

Config example to toggle only 'ap-network' interface:
```
config wifitoggle
    option button 'wps'
    option persistent '1'
    option timer '0'
    option led_sysfs 'tp-link:green:qss'
    option led_enable_trigger 'netdev'
    option led_enable_mode 'link tx rx'
    option led_enable_dev 'wlan0'
    option device 'ap-network'
    option wifi_type 'iface'
```