### PR TITLE
Fixed split_FQDN() in dynamic_dns_functions.sh to properly split hostname/subdomain

### DIFF
--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -1158,7 +1158,7 @@ split_FQDN() {
 
 	# the leftover parameters are the HOST/SUBDOMAIN
 	while [ -n "$1" ]; do
-		_HOST="$1 $HOST"		# remember we need to invert
+		_HOST="$1 $_HOST"		# remember we need to invert
 		shift
 	done
 	_HOST=$(echo $_HOST | tr " " ".")	# insert DOT


### PR DESCRIPTION
I was trying to configure a ddns update for a domain like "one.two.domain.ext".

The split_FQDN function kept returning only "one" instead of "one.two".

I suspect the issue lies in the line I fixed in my pull request.

I have tested this new script and I get the proper splitting of domain names.

Signed off by: Yann <yakemema@gmail.com>