### PR TITLE
nfs-kernel-server: use libevent2

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -1,4 +1,4 @@
-# Copyright (C) 2009-2015 OpenWrt.org
+# Copyright (C) 2009-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=1.3.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MD5SUM:=9b87d890669eaaec8e97a2b0a35b2665
 
 PKG_SOURCE_URL:=@SF/nfs

--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -60,7 +60,7 @@ define Package/nfs-utils
   $(call Package/nfs-kernel-server/Default)
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS+= +libevent +USE_UCLIBC:librpc
+  DEPENDS+= +libevent2 +USE_UCLIBC:librpc
   TITLE:=updated mount utility (includes nfs4)
 endef
 


### PR DESCRIPTION
Use libevent2 instead of libevent

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>