### PR TITLE
ddns-scripts: Fix check for musl library

### DIFF
--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -950,7 +950,7 @@ get_registered_ip() {
 	local __CNT=0	# error counter
 	local __ERR=255
 	local __REGEX  __PROG  __RUNPROG  __DATA  __IP
-	local __MUSL=$(/usr/bin/nslookup 127.0.0.1 0 >/dev/null 2>&1; echo $?) # 0 == busybox compiled with musl
+	local __MUSL=$(/usr/bin/nslookup 127.0.0.1 * >/dev/null 2>&1; echo $?) # 0 == busybox compiled with musl
 	# return codes
 	# 1	no IP detected
 


### PR DESCRIPTION
Checking whether or not the second argument is actually used by 'nslookup' should not use a valid IP address. When compiled with the 'musl' library, this argument is ignored (no matter what it is). But when it *is* used, using '0' will result in Busybox nslookup to attempt to query the IP_ANYADDR '0.0.0.0'. This may typically take up to 15 seconds to timeout. It is better to provide an illegal argument, which will immediately return with an error.

Signed-off-by: Arjen M de Korte \<build+openwrt@de-korte.org\>