### PR TITLE
ddns-scripts: update to 2.6.1-1 with several fixes

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ddns-scripts
 # Version == major.minor.patch
 # increase on new functionality (minor) or patches (patch)
-PKG_VERSION:=2.6.0
+PKG_VERSION:=2.6.1
 # Release == build
 # increase on changes of services files or tld_names.dat
 PKG_RELEASE:=1

--- a/net/ddns-scripts/files/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/dynamic_dns_updater.sh
@@ -272,6 +272,12 @@ while : ; do
 
 	get_local_ip LOCAL_IP		# read local IP
 
+	# on IPv6 we use expanded version to be shure when comparing
+	[ $use_ipv6 -eq 1 ] && {
+		expand_ipv6 "$LOCAL_IP" LOCAL_IP
+		expand_ipv6 "$REGISTERED_IP" REGISTERED_IP
+	}
+
 	# prepare update
 	# never updated or forced immediate then NEXT_TIME = 0
 	[ $FORCE_SECONDS -eq 0 -o $LAST_TIME -eq 0 ] \


### PR DESCRIPTION
- new function expand_ipv6()
- expand IPv6 before compare https://dev.openwrt.org/ticket/21725
- Fix split_FQDN() to return host.subdomain correctly  #2334
- modified check for musl library used by nslookup #2341 #2346 thanks to Arjen de Korte

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>