### PR TITLE
[RFC] eudev: add new package

### DIFF
--- a/utils/eudev/Config.in
+++ b/utils/eudev/Config.in
@@ -1,0 +1,68 @@
+# udev package config
+
+menu "Configuration"
+	depends on PACKAGE_eudev
+
+config EUDEV_EXTRA_ata_id
+	bool "Install eudev ata_id callout"
+	default y
+	help
+	  ata_id - udev callout to read product/serial number
+	  from ATA drives
+
+config EUDEV_EXTRA_blkid
+	bool "Use blkid to identify block devices"
+	default y
+	help
+	  blkid - make use of libblkid to identify block devices
+
+config EUDEV_EXTRA_cdrom_id
+	bool "Install eudev cdrom_id callout"
+	default y
+	help
+	  cdrom_id - udev callout to determine the capabilities
+	  of optical drives and media
+
+config EUDEV_EXTRA_collect
+	bool "Install eudev collect"
+	default n
+	help
+	  Adds ID to the list governed by <checkpoint>
+
+config EUDEV_EXTRA_input_id
+	bool "Install input_id callout"
+	default y
+	help
+	 input_id - udev callout to classify input devices
+
+config EUDEV_EXTRA_kmod
+	bool "Use kmod for loading kernel modules"
+	default n
+	help
+	  kmod - make use of kmod to load kernel modules on demand
+
+config EUDEV_EXTRA_mtd_probe
+	bool "Install mtd_probe callout"
+	default y
+	help
+	  mtd_probe - udev callout to probe mtd devices
+
+config EUDEV_EXTRA_rule_generator
+	bool "Install (legacy) eudev rule_generator"
+	default n
+	help
+
+config EUDEV_EXTRA_scsi_id
+	bool "Install eudev scsi_id callout"
+	default y
+	help
+	  scsi_id - retrieve and generate a unique SCSI identifier
+
+config EUDEV_EXTRA_v4l_id
+	bool "Install eudev v4l_id callout"
+	default y
+	help
+	  v4l_id - udev callout to identify Video4Linux devices
+
+
+endmenu

--- a/utils/eudev/Makefile
+++ b/utils/eudev/Makefile
@@ -1,0 +1,140 @@
+#
+# Copyright (C) 2006-2008 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=eudev
+PKG_VERSION:=3.1.5
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://dev.gentoo.org/~blueness/eudev/
+PKG_MD5SUM:=c4dace42deecede102b6c01904042acc
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+PKG_BUILD_DEPENDS:=gperf/host
+PKG_FIXUP:=autoreconf
+PKG_INSTALL=1
+
+define Package/eudev
+  SECTION:=base
+  CATEGORY:=Base system
+  TITLE:=Dynamic device management subsystem
+  URL:=https://wiki.gentoo.org/wiki/Project:Eudev
+  MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+  MENU:=1
+  DEPENDS:=+librt +EUDEV_EXTRA_blkid:libblkid +EUDEV_EXTRA_kmod:libkmod
+  PROVIDES:=udev
+  CONFLICTS:=udev
+endef
+
+define Package/eudev/description
+udev allows Linux users to have a dynamic /dev directory and it
+provides the ability to have persistent device names.
+eudev is a fork of systemd-udev with the goal of obtaining better
+compatibility with existing software such as OpenRC and Upstart, older
+kernels, various toolchains and anything else required by users and
+various distributions.
+endef
+
+define Package/eudev/conffiles
+/etc/udev/udev.conf
+endef
+
+define Package/eudev/config
+	source "$(SOURCE)/Config.in"
+endef
+
+CONFIGURE_ARGS += \
+	--prefix=/usr --exec-prefix= --sysconfdir=/etc \
+	--libexecdir=/lib/udev --sbindir=/sbin \
+	--disable-hwdb --disable-introspection --disable-manpages \
+	--disable-selinux \
+	$(if $(CONFIG_EUDEV_EXTRA_blkid),--enable-blkid,--disable-blkid) \
+	$(if $(CONFIG_EUDEV_EXTRA_kmod),--enable-kmod,--disable-kmod)
+
+
+eudev-extra-lib-bin-$(CONFIG_EUDEV_EXTRA_ata_id) += ata_id
+
+eudev-extra-rules-$(CONFIG_EUDEV_EXTRA_blkid) += 60-persistent-storage.rules
+
+eudev-extra-lib-bin-$(CONFIG_EUDEV_EXTRA_cdrom_id) += cdrom_id
+eudev-extra-rules-$(CONFIG_EUDEV_EXTRA_cdrom_id) += 60-cdrom_id.rules
+
+eudev-extra-lib-bin-$(CONFIG_EUDEV_EXTRA_collect) += collect
+
+eudev-extra-rules-$(CONFIG_EUDEV_EXTRA_input_id) += 60-persistent-input.rules
+
+eudev-extra-lib-bin-$(CONFIG_EUDEV_EXTRA_mtd_probe) += mtd_probe
+eudev-extra-rules-$(CONFIG_EUDEV_EXTRA_mtd_probe) += 75-probe_mtd.rules
+
+eudev-extra-lib-bin-$(CONFIG_EUDEV_EXTRA_scsi_id) += scsi_id
+
+eudev-extra-lib-bin-$(CONFIG_EUDEV_EXTRA_v4l_id) += v4l_id
+eudev-extra-rules-$(CONFIG_EUDEV_EXTRA_v4l_id) += 60-persistent-v4l.rules
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libudev.h $(1)/usr/include
+	$(INSTALL_DIR) $(1)/usr/share/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/pkgconfig/udev.pc $(1)/usr/share/pkgconfig
+	$(INSTALL_DIR) $(1)/lib
+	$(CP) $(PKG_INSTALL_DIR)/lib/libudev.so* $(1)/lib
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/lib/pkgconfig/libudev.pc $(1)/usr/lib/pkgconfig
+endef
+
+define Package/eudev/install
+	$(INSTALL_DIR) $(1)/etc/udev/rules.d
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/udev/udev.conf $(1)/etc/udev
+
+	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/bin/udevadm \
+		$(PKG_INSTALL_DIR)/sbin/udevd \
+		$(1)/sbin
+
+	$(INSTALL_DIR) $(1)/lib/udev/rules.d
+	$(INSTALL_DATA) \
+		$(addprefix $(PKG_INSTALL_DIR)/lib/udev/rules.d/, \
+			$(eudev-extra-rules-y)) \
+		$(addprefix $(PKG_INSTALL_DIR)/lib/udev/rules.d/, \
+			50-udev-default.rules \
+			60-block.rules \
+			60-drm.rules \
+			60-evdev.rules \
+			60-persistent-alsa.rules \
+			60-persistent-storage-tape.rules \
+			60-serial.rules \
+			64-btrfs.rules \
+			70-mouse.rules \
+			75-net-description.rules \
+			78-sound-card.rules \
+			80-net-name-slot.rules) \
+		$(1)/lib/udev/rules.d
+
+	$(INSTALL_DIR) $(1)/lib
+	$(CP) $(PKG_INSTALL_DIR)/lib/libudev.so* $(1)/lib
+
+	$(INSTALL_DIR) $(1)/lib/udev
+ifneq ($(eudev-extra-lib-bin-y),)
+		$(INSTALL_BIN) \
+			$(addprefix $(PKG_INSTALL_DIR)/lib/udev/, \
+				$(eudev-extra-lib-bin-y)) \
+			$(1)/lib/udev/
+endif
+ifneq ($(eudev-extra-lib-data-y),)
+		$(INSTALL_DATA) \
+			$(addprefix $(PKG_INSTALL_DIR)/lib/udev/, \
+				$(eudev-extra-lib-data-y)) \
+			$(1)/lib/udev/
+endif
+endef
+
+$(eval $(call BuildPackage,eudev))

--- a/utils/eudev/patches/0003-add_btn_trigger_happy_define.patch
+++ b/utils/eudev/patches/0003-add_btn_trigger_happy_define.patch
@@ -1,0 +1,15 @@
+Index: eudev-3.1.5/src/udev/udev-builtin-input_id.c
+===================================================================
+--- eudev-3.1.5.orig/src/udev/udev-builtin-input_id.c
++++ eudev-3.1.5/src/udev/udev-builtin-input_id.c
+@@ -33,6 +33,10 @@
+ #include "udev.h"
+ #include "util.h"
+ 
++#ifndef BTN_TRIGGER_HAPPY
++#define BTN_TRIGGER_HAPPY 0x2c0
++#endif
++
+ /* we must use this kernel-compatible implementation */
+ #define BITS_PER_LONG (sizeof(unsigned long) * 8)
+ #define NBITS(x) ((((x)-1)/BITS_PER_LONG)+1)

--- a/utils/eudev/patches/0004-mtd_probe-uses-stdint_h.patch
+++ b/utils/eudev/patches/0004-mtd_probe-uses-stdint_h.patch
@@ -1,0 +1,12 @@
+Index: eudev-3.1.5/src/mtd_probe/mtd_probe.h
+===================================================================
+--- eudev-3.1.5.orig/src/mtd_probe/mtd_probe.h
++++ eudev-3.1.5/src/mtd_probe/mtd_probe.h
+@@ -18,6 +18,7 @@
+  */
+ 
+ #include <mtd/mtd-user.h>
++#include <stdint.h>
+ 
+ #include "macro.h"
+ 


### PR DESCRIPTION
eudev is a fork of systemd-udev which doesn't require all the
rest of systemd. It's suitable for running along with OpenWrt's procd,
eplacing the very outdated version of pre-systemd udev.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>