### PR TITLE
privoxy: bump to version 3.0.24

### DIFF
--- a/net/privoxy/Config.in
+++ b/net/privoxy/Config.in
@@ -1,0 +1,115 @@
+if PACKAGE_privoxy
+
+	comment "Shared libraries settings"
+
+	config PRIVOXY_disable-pthread
+		bool "Don't use POSIX libpthread (-5489b)"
+		default n
+
+	config PRIVOXY_disable-dynamic-pcre
+		bool "Use the built-in, static pcre, even if libpcre is available (+25669b)"
+		default n
+
+	config PRIVOXY_disable-zlib
+		bool "Don't use zlib to decompress data before filtering. (-1336b)"
+		default n
+
+	comment "Config options. Overwrites/ignore configuration file settings"
+
+	config PRIVOXY_disable-toggle
+		bool "Don't support temporary disable (+2797b)"
+		default n
+
+	config PRIVOXY_disable-force
+		bool "Don't allow single-page disable (-434b)"
+		default n
+
+	config PRIVOXY_disable-fast-redirects
+		bool "Don't support fast redirects (-1393b)"
+		default n
+
+	config PRIVOXY_disable-stats
+		bool "Don't keep statistics (+2870b)"
+		default n
+
+	config PRIVOXY_enable-ie-images
+		bool "Enable MS IE image handling. !Read help! (+2694b)"
+		help
+			Enable a quick but not always reliable auto-detect whether
+			requests from MS Internet Explorer are for an image or not.
+		default n
+
+	config PRIVOXY_disable-image-blocking
+		bool "Don't check for image request - assume HTML (-655b)"
+		help
+			Don't try to figure out whether a request is
+			for an image or HTML - assume HTML.
+		default n
+
+	config PRIVOXY_disable-acl-support
+		bool "Disable ACL access control (-3496b)"
+		help
+			Prevents the use of ACLs to control access to Privoxy by IP address.
+		default n
+
+	config PRIVOXY_disable-trust-files
+		bool "Prevents the use of trust files. (-1302b)"
+		default n
+
+	config PRIVOXY_disable-editor
+		bool "Disable web-based editor. !Read help! (-44979b)"
+		help
+			Prevents the use of the web-based actions file
+			editor and web-based temporary disable setting.
+		default n
+
+	config PRIVOXY_enable-no-gifs
+		bool "Use politically correct PNG format. !Read help! (+112b)"
+		help
+			Use politically correct PNG format instead of GIF
+			for built-in images. May not work with all browsers.
+		default n
+
+	config PRIVOXY_enable-graceful-termination
+		bool "Allow to shutdown Privoxy through the webinterface. (+1685b)"
+		default n
+
+	config PRIVOXY_enable-extended-host-patterns
+		bool "Enable and require PCRE syntax in host patterns. !Read help! (-1329b)"
+		help
+			Enable and require PCRE syntax in host patterns. This feature hasn't
+			been announced yet and it's not clear if it's a good idea. It's expected
+			to work, but undocumented. You should only enable it if you know what
+			PCRE is and are sure that you need it for your host patterns. You can
+			use tools/url-pattern-translator.pl to convert existing action files to
+			use PCRE host patterns. Please don't enable this option when creating
+			packages for others that may not be expecting it.
+		default n
+
+	config PRIVOXY_enable-external-filters
+		bool "Allow to filter content with scripts and programs. Experimental. (+4821b)"
+		default n
+
+	config PRIVOXY_enable-accept-filter
+		bool "Try to use accf_http(9) if supported. (+-0b)"
+		default n
+
+	config PRIVOXY_enable-strptime-sanity-checks
+		bool "Only trust strptime() results if ... !Read help! (+407b)"
+		help
+			Only trust strptime() results if an additional strftime()/strptime()
+			conversion doesn't change the result. Can be useful if strptime() is
+			known or suspected to be broken.
+		default n
+
+	config PRIVOXY_enable-compression
+		bool "Allow Privoxy to compress buffered content. (+1275b)"
+		help
+			Allow Privoxy to compress buffered content 
+			if the client supports it. Requires zlib support.
+		depends on !PRIVOXY_no_zlib
+		default n
+
+
+endif
+                

--- a/net/privoxy/Makefile
+++ b/net/privoxy/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2015 OpenWrt.org
+# Copyright (C) 2006-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=privoxy
-PKG_VERSION:=3.0.23
-PKG_RELEASE:=4
+PKG_VERSION:=3.0.24
+PKG_RELEASE:=1
 
 PKG_SOURCE:=privoxy-$(PKG_VERSION)-stable-src.tar.gz
 PKG_SOURCE_URL:=@SF/ijbswa
-PKG_MD5SUM:=bbe47d5ff1a54d9f9fc93a160532697f
+PKG_MD5SUM:=44a47d1a5000db8cccd61ace0e25e7f7
 PKG_BUILD_DIR:=$(BUILD_DIR)/privoxy-$(PKG_VERSION)-stable
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -21,7 +21,31 @@ PKG_INSTALL:=1
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_MAINTAINER:=christian.schoenebeck@gmail.com
+PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
+
+PKG_CONFIG_DEPENDS:= \
+  CONFIG_IPV6 \
+  \
+  CONFIG_PRIVOXY_disable-pthread \
+  CONFIG_PRIVOXY_disable-dynamic-pcre \
+  CONFIG_PRIVOXY_disable-zlib \
+  \
+  CONFIG_PRIVOXY_disable-toggle \
+  CONFIG_PRIVOXY_disable-force \
+  CONFIG_PRIVOXY_disable-fast-redirects \
+  CONFIG_PRIVOXY_disable-stats \
+  CONFIG_PRIVOXY_enable-ie-images \
+  CONFIG_PRIVOXY_disable-image-blocking \
+  CONFIG_PRIVOXY_disable-acl-support \
+  CONFIG_PRIVOXY_disable-trust-files \
+  CONFIG_PRIVOXY_disable-editor \
+  CONFIG_PRIVOXY_enable-no-gifs \
+  CONFIG_PRIVOXY_enable-graceful-termination \
+  CONFIG_PRIVOXY_enable-extended-host-patterns \
+  CONFIG_PRIVOXY_enable-external-filters \
+  CONFIG_PRIVOXY_enable-accept-filter \
+  CONFIG_PRIVOXY_enable-strptime-sanity-checks \
+  CONFIG_PRIVOXY_enable-compression
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -29,10 +53,11 @@ define Package/$(PKG_NAME)
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
-  DEPENDS:=+libpcre +libpthread +zlib
   TITLE:=Privoxy WEB Proxy
   URL:=http://www.privoxy.org/
   USERID:=privoxy=8118:privoxy=8118
+  MENU:=1
+  DEPENDS:=+!PRIVOXY_no_pcre:libpcre +!PRIVOXY_no_pthread:libpthread +!PRIVOXY_no_zlib:zlib
 endef
 
 # shown in LuCI package description
@@ -42,23 +67,45 @@ endef
 
 # shown in make menuconfig <Help>
 define Package/$(PKG_NAME)/config
-help
-	Privoxy is a web proxy with advanced filtering capabilities for protecting
-	privacy, modifying web page content, managing cookies, controlling access,
-	and removing ads, banners, pop-ups and other obnoxious Internet junk. 
-	Privoxy has a very flexible configuration and can be customized to suit
-	individual needs and tastes. 
-	Privoxy has application for both stand-alone systems and multi-user networks.
+	help
+		Privoxy is a web proxy with advanced filtering capabilities for protecting
+		privacy, modifying web page content, managing cookies, controlling access,
+		and removing ads, banners, pop-ups and other obnoxious Internet junk. 
+		Privoxy has a very flexible configuration and can be customized to suit
+		individual needs and tastes. 
+		Privoxy has application for both stand-alone systems and multi-user networks.
+		Run as : $(USERID)
+		Version: $(PKG_VERSION)-$(PKG_RELEASE)
+		Home   : $(URL)
+		$(PKG_MAINTAINER)
 
-	Run as : $(USERID)
-	Version: $(PKG_VERSION)-$(PKG_RELEASE)
-	Home   : $(URL)
-
-	$(PKG_MAINTAINER)
+	source "$(SOURCE)/Config.in"
 endef
 
 CONFIGURE_ARGS += \
-	--sysconfdir=/etc/privoxy
+	--sysconfdir=/etc/privoxy \
+	$(if $(CONFIG_IPV6),,--disable-ipv6-support) \
+	\
+	$(if $(CONFIG_PRIVOXY_disable-pthread),--disable-pthread) \
+	$(if $(CONFIG_PRIVOXY_disable-dynamic-pcre),--disable-dynamic-pcre) \
+	$(if $(CONFIG_PRIVOXY_disable-zlib),--disable-zlib) \
+	\
+	$(if $(CONFIG_PRIVOXY_disable-toggle),--disable-toggle) \
+	$(if $(CONFIG_PRIVOXY_disable-force),--disable-force) \
+	$(if $(CONFIG_PRIVOXY_disable-fast-redirects),--disable-fast-redirects) \
+	$(if $(CONFIG_PRIVOXY_disable-stats),--disable-stats) \
+	$(if $(CONFIG_PRIVOXY_enable-ie-images),--enable-ie-images) \
+	$(if $(CONFIG_PRIVOXY_disable-image-blocking),--disable-image-blocking) \
+	$(if $(CONFIG_PRIVOXY_disable-acl-support),--disable-acl-support) \
+	$(if $(CONFIG_PRIVOXY_disable-trust-files),--disable-trust-files) \
+	$(if $(CONFIG_PRIVOXY_disable-editor),--disable-editor) \
+	$(if $(CONFIG_PRIVOXY_enable-no-gifs),--enable-no-gifs) \
+	$(if $(CONFIG_PRIVOXY_enable-graceful-termination),--enable-graceful-termination) \
+	$(if $(CONFIG_PRIVOXY_enable-extended-host-patterns),--enable-extended-host-patterns) \
+	$(if $(CONFIG_PRIVOXY_enable-external-filters),--enable-external-filters) \
+	$(if $(CONFIG_PRIVOXY_enable-accept-filter),--enable-accept-filter) \
+	$(if $(CONFIG_PRIVOXY_enable-strptime-sanity-checks),--enable-strptime-sanity-checks) \
+	$(if $(CONFIG_PRIVOXY_enable-compression),--enable-compression)
 
 # needed otherwise errors during compile
 MAKE_FLAGS:=
@@ -98,12 +145,20 @@ define Package/$(PKG_NAME)/install
 		-exec install -m0664 -t $(1)/etc/privoxy {} \;
 
 	$(INSTALL_DIR) \
+		$(1)/lib/upgrade/keep.d \
 		$(1)/etc/init.d \
 		$(1)/etc/hotplug.d/iface \
 		$(1)/etc/config
+	$(INSTALL_DATA) ./files/privoxy.upgrade $(1)/lib/upgrade/keep.d/privoxy
 	$(INSTALL_BIN)  ./files/privoxy.init $(1)/etc/init.d/privoxy
 	$(INSTALL_BIN)  ./files/privoxy.hotplug $(1)/etc/hotplug.d/iface/80-privoxy
 	$(INSTALL_CONF) ./files/privoxy.config $(1)/etc/config/privoxy
+endef
+
+define Package/$(PKG_NAME)/postinst
+	#!/bin/sh
+	grep -i privoxy $${IPKG_INSTROOT}/etc/services >/dev/null 2>&1 || \
+		echo -e "privoxy\t8118" >> $${IPKG_INSTROOT}/etc/services
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/net/privoxy/files/privoxy.hotplug
+++ b/net/privoxy/files/privoxy.hotplug
@@ -2,6 +2,8 @@
 
 # only (re-)start on ifup
 [ "$ACTION" = "ifup" ] || exit 0
+# only start if boot_delay is done
+[ -f /tmp/privoxy.hotplug ] || exit 0
 
 PIDFILE=/var/run/privoxy.pid
 

--- a/net/privoxy/files/privoxy.init
+++ b/net/privoxy/files/privoxy.init
@@ -50,6 +50,17 @@ _uci2conf() {
 	echo '### SEE /etc/config/privoxy INSTEAD' >> $CFGTEMP
 	echo ''					   >> $CFGTEMP
 
+	# logdir and logfile
+	# privoxy needs read/write access
+	_LOGDIR=$(uci -q get privoxy.privoxy.logdir)   || _LOGDIR="/var/log"
+	_LOGFILE=$(uci -q get privoxy.privoxy.logfile) || _LOGFILE="privoxy.log"
+	mkdir -m0755 -p $_LOGDIR
+	touch $_LOGDIR/$_LOGFILE
+	chmod 664 $_LOGDIR/$_LOGFILE
+	chown privoxy:privoxy $_LOGDIR/$_LOGFILE
+	echo -e "logdir\t$_LOGDIR" >> $CFGTEMP
+	echo -e "logfile\t$_LOGFILE" >> $CFGTEMP
+
 	# confdir
 	# privoxy needs read access (possibly write access)
 	_CONFDIR=$(uci -q get privoxy.privoxy.confdir) || _CONFDIR="/etc/privoxy"
@@ -72,17 +83,6 @@ _uci2conf() {
 		echo -e "templdir\t$_TEMPLDIR" >> $CFGTEMP
 	fi
 
-	# logdir and logfile
-	# privoxy needs read/write access
-	_LOGDIR=$(uci -q get privoxy.privoxy.logdir)   || _LOGDIR="/var/log"
-	_LOGFILE=$(uci -q get privoxy.privoxy.logfile) || _LOGFILE="privoxy.log"
-	mkdir -m0755 -p $_LOGDIR
-	touch $_LOGDIR/$_LOGFILE
-	chmod 664 $_LOGDIR/$_LOGFILE
-	chown privoxy:privoxy $_LOGDIR/$_LOGFILE
-	echo -e "logdir\t$_LOGDIR" >> $CFGTEMP
-	echo -e "logfile\t$_LOGFILE" >> $CFGTEMP
-
 	# temporary-directory
 	# privoxy needs read/write access
 	_TMP_DIR=$(uci -q get privoxy.privoxy.temporary_directory)	# no default needed
@@ -100,7 +100,25 @@ _uci2conf() {
 }
 
 boot() {
-	return 0	# will be started by "iface" hotplug events
+	# wait a given time (default 10 seconds) before startup
+	# to wait for interfaces to come up / not using hotplug events during boot
+	_start() {
+		[ $1 -gt 0 ] && {
+			logger -p daemon.info -t "privoxy[]" "Scheduled startup in $1 seconds"
+			sleep $1
+		}
+		start
+	}
+
+	local _DELAY
+	_DELAY=$(uci_get "privoxy" "system" "boot_delay" "10")
+	_start $_DELAY &
+	return 0
+}
+
+shutdown() {
+	rm -f /tmp/privoxy.hotplug
+	stop
 }
 
 start() {
@@ -110,6 +128,7 @@ start() {
 
 	_uci2conf
 	/usr/sbin/privoxy --pidfile $PIDFILE --user privoxy.privoxy $CFGFILE
+	touch /tmp/privoxy.hotplug
 
 	# verify startup
 	_PID=$(cat $PIDFILE 2>/dev/null)
@@ -117,7 +136,7 @@ start() {
 	local _ERR=$?
 	[ $_ERR -eq 0 ] \
 		&& logger -p daemon.notice -t "privoxy[$_PID]" "Started successfully"\
-		|| logger -p daemon.warn -t "privoxy[-----]" "Failed to start"
+		|| logger -p daemon.warn -t "privoxy[]" "Failed to start"
 	return $_ERR
 }
 
@@ -144,7 +163,7 @@ stop() {
 		logger -p daemon.notice -t "privoxy[$_PID]" "Shutdown successfully"
 	else
 		kill -9 $_tmp	# Normally never come here
-		logger -p daemon.warn -t "privoxy[-----]" "Shutdown forced by KILL"
+		logger -p daemon.warn -t "privoxy[$_tmp]" "Shutdown forced by KILL"
 	fi
 	return 0
 }

--- a/net/privoxy/files/privoxy.upgrade
+++ b/net/privoxy/files/privoxy.upgrade
@@ -1,0 +1,4 @@
+/etc/config/privoxy
+/etc/privoxy/user.action
+/etc/privoxy/user.filter
+/etc/privoxy/user.trust


### PR DESCRIPTION
* upstream to Privoxy 3.0.24
* add facility to set compile options
* add file list to be saved on sysupgrade
* fixed PKG_MAINTAINER string
* add port 8118 used by privoxy to /etc/services
* new "boot_delay" option (default 10 seconds) to wait for interfaces to come up before hotplug restarts are enabled

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>