### PR TITLE
squid: disable krb5

### DIFF
--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -21,9 +21,6 @@ PKG_MD5SUM:=50016bf6e2d3a3a186a6c7236d251f63
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
-# uses libcom_err.la
-PKG_BUILD_DEP:=libext2fs
-
 include $(INCLUDE_DIR)/package.mk
 
 define Package/squid/Default
@@ -88,6 +85,7 @@ CONFIGURE_ARGS += \
 	--disable-auth-basic \
 	--disable-arch-native \
 	--with-krb5-config=no \
+	--without-mit-krb5 \
 	--without-libcap \
 	--without-netfilter-conntrack
 


### PR DESCRIPTION
- fix build error reported by buildbot by disabling krb5
- libcom_err from krb5 is used - configure output:
configure: WARNING: library 'com_err' is required for Heimdal Kerberos
- krb5 has its own libcom_err (see krb5 package) with its own symbols

- linking with wrong libcom_err from libext2fs produces errors during
libgssapi_krb5.so: undefined reference to `error_message@com_err_3_MIT'
libgssapi_krb5.so: undefined reference to `remove_error_table@com_err_3_MIT'
libgssapi_krb5.so: undefined reference to `add_error_table@com_err_3_MIT'
-> remove libext2fs dependency (wasnt working anyway - no PKG_BUILD_DEP)

Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>