### PR TITLE
ddns-scripts: add lowercase no-ip.com service_name

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -187,6 +187,8 @@ define Package/$(PKG_NAME)_no-ip_com/postinst
 	#!/bin/sh
 	echo -e '"No-IP.com"\t"update_No-IP.com.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services
 	echo -e '"NoIP.com"\t"update_No-IP.com.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services
+	echo -e '"no-ip.com"\t"update_No-IP.com.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services
+	echo -e '"noip.com"\t"update_No-IP.com.sh"' >> $${IPKG_INSTROOT}/usr/lib/ddns/services
 endef
 define Package/$(PKG_NAME)_no-ip_com/prerm
 	#!/bin/sh


### PR DESCRIPTION
When setting up a no-ip.com ddns configuration like described on
https://wiki.openwrt.org/doc/howto/ddns.client#noipcom
I got into trouble, as the documentation uses lowercase "no-ip.com"
service_name, but the ddns-scripts_no-ip_com expect mixed-case
"NoIP.com" and "No-IP.com" service_names.

This patch adds lower case service_name entries to be in line with
the documentation. Keep the mixed-case entries to don't break existing
configs.

Signed-off-by: Stefan Hellermann <stefan@the2masters.de>