### PR TITLE
lvm2: fix libdevmapper deps

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=LVM2
 PKG_VERSION:=2.02.141
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0 LGPL-2.1
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
@@ -26,7 +26,7 @@ define Package/libdevmapper
   CATEGORY:=Libraries
   TITLE:=The Linux Kernel Device Mapper userspace library
   URL:=http://sourceware.org/dm/
-  DEPENDS:=+kmod-dm +libpthread
+  DEPENDS:=+kmod-dm +libpthread +libuuid
 endef
 
 define Package/libdevmapper/description


### PR DESCRIPTION
This PR fixes following error:
```
...
Package libdevmapper is missing dependencies for the following libraries:
libuuid.so.1
...
make[1]: *** [package/feeds/packages/lvm2/compile] Error 2
```