### PR TITLE
pptpd: Make mppe and logwtmp configurable as uci parameters

### DIFF
--- a/net/pptpd/Makefile
+++ b/net/pptpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pptpd
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/poptop

--- a/net/pptpd/files/options.pptpd
+++ b/net/pptpd/files/options.pptpd
@@ -11,7 +11,6 @@ nobsdcomp
 nodeflate
 #noproxyarp
 #nomppc
-mppe required,no40,no56,stateless
 require-mschap-v2
 refuse-chap
 refuse-mschap

--- a/net/pptpd/files/pptpd.conf
+++ b/net/pptpd/files/pptpd.conf
@@ -1,5 +1,4 @@
 #debug
-option /etc/ppp/options.pptpd
 speed 115200
 stimeout 10
 #localip & remoteip are not needed, ip management is done by pppd

--- a/net/pptpd/files/pptpd.init
+++ b/net/pptpd/files/pptpd.init
@@ -7,6 +7,7 @@ USE_PROCD=1
 BIN=/usr/sbin/pptpd
 CONFIG=/var/etc/pptpd.conf
 CHAP_SECRETS=/var/etc/chap-secrets
+OPTIONS_PPTP=/var/etc/options.pptpd
 
 validate_login_section() {
 	uci_validate_section pptpd login "${1}" \
@@ -18,7 +19,9 @@ validate_pptpd_section() {
 	uci_validate_section pptpd service "${1}" \
 		'enabled:uinteger' \
 		'localip:string' \
-		'remoteip:string'
+		'remoteip:string' \
+		'mppe:list(string):required no40 no56 stateless' \
+		'logwtmp:uinteger'
 }
 
 setup_login() {
@@ -34,6 +37,8 @@ setup_login() {
 }
 
 setup_config() {
+	local enabled localip remoteip mppe
+
 	validate_pptpd_section "${1}" || {
 		echo "validation failed"
 		return 1
@@ -43,9 +48,13 @@ setup_config() {
 
 	mkdir -p /var/etc
 	cp /etc/pptpd.conf $CONFIG
+	cp /etc/ppp/options.pptpd $OPTIONS_PPTP
 
 	[ -n "$localip" ] && echo "localip  $localip" >> $CONFIG
 	[ -n "$remoteip" ] && echo "remoteip  $remoteip" >> $CONFIG
+	[ "$logwtmp" -eq 1 ] && echo "logwtmp" >> $CONFIG
+
+	echo "mppe $(echo $mppe | sed -e 's/\s/,/g')" >> $OPTIONS_PPTP
 
 	return 0
 }
@@ -58,6 +67,6 @@ start_service() {
 	ln -sfn $CHAP_SECRETS /etc/ppp/chap-secrets
 
 	procd_open_instance
-	procd_set_param command $BIN -c $CONFIG
+	procd_set_param command $BIN -c $CONFIG -o $OPTIONS_PPTP
 	procd_close_instance
 }


### PR DESCRIPTION
Add uci option mppe which makes the mppe parameter configurable;
the default value is required,no40,no56,stateless as before.

Add uci option logwtmp; when enabled updates wtmp when users
connect and disconnect

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>