### PR TITLE
Remove unnecessary libiconv dependencies

### DIFF
--- a/libs/apr-util/Makefile
+++ b/libs/apr-util/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2014 OpenWrt.org
+# Copyright (C) 2007-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apr-util
 PKG_VERSION:=1.5.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@APACHE/apr/
@@ -41,16 +41,21 @@ CONFIGURE_ARGS += \
 	--with-apr="$(STAGING_DIR)/usr/bin/apr-1-config" \
 	--with-expat="$(STAGING_DIR)/usr" \
 	--without-sqlite2 \
-	--with-sqlite3="$(STAGING_DIR)/usr" \
-	--with-iconv="$(ICONV_PREFIX)" \
+	--with-sqlite3="$(STAGING_DIR)/usr"
+
+ifdef $(CONFIG_BUILD_NLS)
+	CONFIGURE_ARGS += --with-iconv="$(ICONV_PREFIX)"
+else
+	CONFIGURE_ARGS += --without-iconv
+endif
 
 CONFIGURE_VARS += \
 	ac_cv_file_dbd_apr_dbd_mysql_c=no \
 	ac_cv_path_ODBC_CONFIG= \
-	APR_BUILD_DIR="$(STAGING_DIR)/usr/share/build-1" \
+	APR_BUILD_DIR="$(STAGING_DIR)/usr/share/build-1"
 
 MAKE_FLAGS += \
-	APRUTIL_LIBS="-lsqlite3 $(TARGET_LDFLAGS) -lexpat $(if $(ICONV_FULL),-liconv) -lapr-1 -luuid -lm -lcrypt" \
+	APRUTIL_LIBS="-lsqlite3 $(TARGET_LDFLAGS) -lexpat $(if $(ICONV_FULL),-liconv) -lapr-1 -luuid -lm -lcrypt"
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/include/apr-1/ $(1)/usr/lib  $(1)/usr/lib/pkgconfig/


### PR DESCRIPTION
Attention @heil : please consider this fix to the dependencies issue.

The compiled libaprutil library contains references to libiconv, libiconv_open and libiconv_close functions from the full gettext package even when the full gettext support is disabled (i.e. the CONFIG_BUILD_NLS configuration parameter is not set). The dependency on these ICONV functions breaks compilation of some packages that depend on libaprutil, such as subversion, when the full gettext support is disabled:

```
.../<targetdir>/usr/lib/libaprutil-1.so: undefined reference to `libiconv'
.../<targetdir>/usr/lib/libaprutil-1.so: undefined reference to `libiconv_open'
.../<targetdir>/usr/lib/libaprutil-1.so: undefined reference to `libiconv_close'
```
The proposed changes to libaprutil's Makefile resolve the issue.

Signed-off-by: Don Rumata <don.rumata.vk@gmail.com>