### PR TITLE
[RFC] prosody: update to 0.9.10, switch to procd init script

### DIFF
--- a/net/prosody/Makefile
+++ b/net/prosody/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prosody
-PKG_VERSION:=0.9.9
+PKG_VERSION:=0.9.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://prosody.im/downloads/source
-PKG_MD5SUM:=8f7c529b072e78ab9e82ecbedfee7145
+PKG_MD5SUM:=ef6d4a9e6dcae577eb52f7277d7beac5
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=MIT/X11
 

--- a/net/prosody/files/prosody.init
+++ b/net/prosody/files/prosody.init
@@ -1,10 +1,9 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2010-2011 OpenWrt.org
+# Copyright (C) 2011-2016 OpenWrt.org
 
 START=99
 
-EXTRA_COMMANDS="status"
-EXTRA_HELP="	status	Print the status of the service"
+USE_PROCD=1
 
 BIN=/usr/bin/prosodyctl
 LOG_D=/var/log/prosody
@@ -13,7 +12,7 @@ PID_F=$RUN_D/prosody.pid
 RUN_USER=prosody
 RUN_GROUP=prosody
 
-start() {
+start_service() {
 	[ -d /var/run/prosody ] || {
 		mkdir -m 0755 -p /var/run/prosody
 		chown prosody:prosody /var/run/prosody
@@ -36,18 +35,12 @@ start() {
 		}
 	}
 
-	
-	$BIN start
+	procd_open_instance
+	procd_set_param command "$BIN" start
+	procd_set_param file /etc/prosody/prosody.cfg.lua
+	procd_close_instance
 }
 
-stop() {
-	$BIN stop
-}
-
-reload() {
-	[ -f $PID_F ] && kill -HUP $(cat $PID_F)
-}
-
-status() {
-	$BIN status
+stop_service() {
+	${BIN} stop
 }


### PR DESCRIPTION
Update to 0.9.10 due to https://prosody.im/issues/issue/585
The init script seems to block, as "prosodyctl start" started to block
at least on my configuration. I switched to a procd init script, which
deals with blocking processes.

Fixes issues #2342 

Signed-off-by: Stefan Hellermann <stefan@the2masters.de>