### PR TITLE
subversion: bring back from oldpackages and update to current version

### DIFF
--- a/net/subversion/Makefile
+++ b/net/subversion/Makefile
@@ -1,0 +1,141 @@
+#
+# Copyright (C) 2007-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=subversion
+PKG_RELEASE:=1
+PKG_VERSION:=1.9.4
+PKG_SOURCE_URL:=@APACHE/subversion
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_MD5SUM:=29121a038f87641055a8183f49e9739f
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Donald Rumata <donald.rumata@gmail.com>
+
+PKG_FIXUP:=autoreconf
+PKG_MACRO_PATHS:=build/ac-macros
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+
+define Package/subversion/Default
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Version Control Systems
+  TITLE:=A compelling replacement for CVS
+  DEPENDS:=+zlib +libsqlite3 +libapr +libaprutil +libmagic \
+  	$(ICONV_DEPENDS) $(INTL_DEPENDS)
+  URL:=http://subversion.apache.org/
+endef
+
+define Package/subversion/Default/description
+	Subversion is a free/open-source version control system. That is,
+	Subversion manages files and directories, and the changes made to them,
+	over time. This allows you to recover older versions of your data, or
+	examine the history of how your data changed. In this regard, many
+	people think of a version control system as a sort of time machine.
+endef
+
+define Package/subversion-libs
+  $(call Package/subversion/Default)
+  TITLE:=subversion libs
+endef
+
+define Package/subversion-libs/description
+  $(call Package/subversion/Default/description)
+  This package contains the Subversion libraries.
+endef
+
+define Package/subversion-client
+  $(call Package/subversion/Default)
+  DEPENDS:=+subversion-libs
+  TITLE:=subversion client tools
+endef
+
+define Package/subversion-client/description
+  $(call Package/subversion/Default/description)
+  This package contains the Subversion client tools.
+endef
+
+define Package/subversion-server
+  $(call Package/subversion/Default)
+  DEPENDS:=+subversion-libs
+  TITLE:=subversion server
+endef
+
+define Package/subversion-server/description
+  $(call Package/subversion/Default/description)
+  This package contains the Subversion server.
+endef
+
+define Package/subversion-server/conffiles
+/etc/config/subversion
+endef
+
+TARGET_CFLAGS += $(FPIC)
+TARGET_CPPFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
+
+CONFIGURE_ARGS += \
+	--with-apr="$(STAGING_DIR)/usr/bin/apr-1-config" \
+	--with-apr-util="$(STAGING_DIR)/usr/bin/apu-1-config" \
+	--with-libmagic="$(STAGING_DIR)/usr" \
+	--disable-mod-activation \
+	--without-ruby-sitedir \
+	--without-swig \
+	--without-jikes \
+	--without-junit \
+	--without-berkeley-db \
+	--without-apxs \
+	--without-sasl
+
+ifdef $(INTL_FULL)
+	CONFIGURE_ARGS += --enable-nls
+else
+	CONFIGURE_ARGS += --disable-nls
+endif
+
+CONFIGURE_VARS += \
+	LDFLAGS="$(TARGET_LDFLAGS) -lcrypt -lm \
+		-lz -lpthread $(if $(INTL_FULL),-lintl)"
+	CPPFLAGS="$(TARGET_CPPFLAGS)"
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		all local-install
+endef
+
+define Package/subversion-libs/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsvn_*.so.* $(1)/usr/lib/
+endef
+
+define Package/subversion-client/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{svn,svnversion,svnsync} $(1)/usr/bin/
+endef
+
+define Package/subversion-server/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/svn{look,admin,dumpfilter,serve} $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/subversion.config $(1)/etc/config/subversion
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/subversion.init $(1)/etc/init.d/subversion
+endef
+
+define Package/subversion-server/prerm
+#!/bin/sh
+ ps | grep '\(/svnserve$\| svnserve\)' | grep -cvq grep >/dev/null && /etc/init.d/subversion stop
+ /etc/init.d/subversion disable
+endef
+
+$(eval $(call BuildPackage,subversion-libs))
+$(eval $(call BuildPackage,subversion-client))
+$(eval $(call BuildPackage,subversion-server))

--- a/net/subversion/files/subversion.config
+++ b/net/subversion/files/subversion.config
@@ -1,0 +1,3 @@
+config subversion
+	option path	'/var/local/svn'
+	option port	'3690'

--- a/net/subversion/files/subversion.init
+++ b/net/subversion/files/subversion.init
@@ -1,0 +1,37 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2006-2016 OpenWrt.org
+
+START=50
+
+start_instance () {
+	local section="$1"
+	config_get path "$section" 'path'
+	config_get port "$section" 'port'
+
+	if [ ! -d "$path" ]; then
+		echo "The subversion repository (${path}) does not exist."
+		echo "Create a new repository and/or change the path in /etc/config/subversion"
+		echo
+		echo "Create a new subversion repository with:"
+		echo "        mkdir -p ${path}"
+		echo "        svnadmin create --fs-type fsfs ${path}"
+		echo
+		echo "Changing the path using UCI (default path is: /var/local/svn):"
+		echo "        uci set subversion.@[0].path="/srv/svn""
+		echo "        uci commit"
+		echo "        /etc/init.d/subversion restart"
+		return 1
+	fi
+
+	service_start /usr/bin/svnserve -d --listen-port ${port} -r ${path}
+}
+
+start() {
+	config_load 'subversion'
+	config_foreach start_instance 'subversion'
+}
+
+stop() {
+	SERVICE_SIG_STOP="INT" \
+	service_stop /usr/bin/svnserve
+}

--- a/net/subversion/patches/101-cross-compilation-macos.patch
+++ b/net/subversion/patches/101-cross-compilation-macos.patch
@@ -1,0 +1,97 @@
+--- a/build/ac-macros/macosx.m4	2016-02-09 01:24:13.181409245 -0500
++++ b/build/ac-macros/macosx.m4	2016-02-09 01:25:15.873408288 -0500
+@@ -17,94 +17,4 @@ dnl   specific language governing permis
+ dnl   under the License.
+ dnl ===================================================================
+ dnl
+-dnl  Mac OS X specific checks
+ 
+-dnl SVN_LIB_MACHO_ITERATE
+-dnl Check for _dyld_image_name and _dyld_image_header availability
+-AC_DEFUN(SVN_LIB_MACHO_ITERATE,
+-[
+-  AC_MSG_CHECKING([for Mach-O dynamic module iteration functions])
+-  AC_RUN_IFELSE([AC_LANG_PROGRAM([[
+-    #include <mach-o/dyld.h>
+-    #include <mach-o/loader.h>
+-  ]],[[
+-    const struct mach_header *header = _dyld_get_image_header(0);
+-    const char *name = _dyld_get_image_name(0);
+-    if (name && header) return 0;
+-    return 1;
+-  ]])],[
+-    AC_DEFINE([SVN_HAVE_MACHO_ITERATE], [1],
+-              [Is Mach-O low-level _dyld API available?])
+-    AC_MSG_RESULT([yes])
+-  ],[
+-    AC_MSG_RESULT([no])
+-  ])
+-])
+-
+-dnl SVN_LIB_MACOS_PLIST
+-dnl Assign variables for Mac OS property list support
+-AC_DEFUN(SVN_LIB_MACOS_PLIST,
+-[
+-  AC_MSG_CHECKING([for Mac OS property list utilities])
+-
+-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+-    #include <AvailabilityMacros.h>
+-    #if !defined(MAC_OS_X_VERSION_MAX_ALLOWED) \
+-     || !defined(MAC_OS_X_VERSION_10_0) \
+-     || (MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_0)
+-    #error ProperyList API unavailable.
+-    #endif
+-  ]],[[]])],[
+-    dnl ### Hack.  We should only need to pass the -framework options when
+-    dnl linking libsvn_subr, since it is the only library that uses Keychain.
+-    dnl
+-    dnl Unfortunately, libtool 1.5.x doesn't track transitive dependencies for
+-    dnl OS X frameworks like it does for normal libraries, so we need to
+-    dnl explicitly pass the option to all the users of libsvn_subr to allow
+-    dnl static builds to link successfully.
+-    dnl
+-    dnl This does mean that all executables we link will be linked directly
+-    dnl to these frameworks - even when building shared libraries - but that
+-    dnl shouldn't cause any problems.
+-
+-    LIBS="$LIBS -framework CoreFoundation"
+-    AC_DEFINE([SVN_HAVE_MACOS_PLIST], [1],
+-              [Is Mac OS property list API available?])
+-    AC_MSG_RESULT([yes])
+-  ],[
+-    AC_MSG_RESULT([no])
+-  ])
+-])
+-
+-dnl SVN_LIB_MACOS_KEYCHAIN
+-dnl Check configure options and assign variables related to Keychain support
+-
+-AC_DEFUN(SVN_LIB_MACOS_KEYCHAIN,
+-[
+-  AC_ARG_ENABLE(keychain,
+-    AS_HELP_STRING([--disable-keychain],
+-    [Disable use of Mac OS KeyChain for auth credentials]),
+-    [enable_keychain=$enableval],[enable_keychain=yes])
+-
+-  AC_MSG_CHECKING([for Mac OS KeyChain Services])
+-
+-  if test "$enable_keychain" = "yes"; then
+-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+-      #include <AvailabilityMacros.h>
+-      #if !defined(MAC_OS_X_VERSION_MAX_ALLOWED) \
+-       || !defined(MAC_OS_X_VERSION_10_2) \
+-       || (MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_2)
+-      #error KeyChain API unavailable.
+-      #endif
+-    ]],[[]])],[
+-      dnl ### Hack, see SVN_LIB_MACOS_PLIST
+-      LIBS="$LIBS -framework Security"
+-      LIBS="$LIBS -framework CoreServices"
+-      AC_DEFINE([SVN_HAVE_KEYCHAIN_SERVICES], [1], [Is Mac OS KeyChain support enabled?])
+-      AC_MSG_RESULT([yes])
+-    ],[
+-      enable_keychain=no
+-      AC_MSG_RESULT([no])
+-    ])
+-  fi
+-])


### PR DESCRIPTION
Bring back Subversion from oldpackages and update to version 1.9.3.
Create prerm script to stop subversion server and remove init script on uninstall.

Signed-off-by: Donald Rumata <donald.rumata@gmail.com>