### PR TITLE
net-snmp: reload snmpd on interface events

### DIFF
--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -230,5 +230,12 @@ stop_service() {
 }
 
 service_triggers(){
+	local script=$(readlink "$initscript")
+	local name=$(basename ${script:-$initscript})
+
+	procd_open_trigger
+	procd_add_raw_trigger "interface.*" 2000 /etc/init.d/$name reload
+	procd_close_trigger
+
 	procd_add_reload_trigger 'snmpd'
 }


### PR DESCRIPTION
When applying wireless configuration changes, the ifindex of the
wireless interface(s) change. While snmpd picks up the new interfaces
with the correct index, it does not remove the old ones:

IF-MIB::ifName.23 = STRING: wlan0
IF-MIB::ifName.24 = STRING: wlan1
IF-MIB::ifName.25 = STRING: wlan0
IF-MIB::ifName.26 = STRING: wlan1

This causes problems for monitoring tools that use ifName (or ifDesc) as
interface reference. Add a trigger that reloads snmpd on interface
up/down events so that it will no longer have the old interfaces.

Based on example by Felix: http://permalink.gmane.org/gmane.comp.embedded.openwrt.devel/38072