### PR TITLE
adblock: 0.80.1

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=0.80.0
+PKG_VERSION:=0.80.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <openwrt@brenken.org>
@@ -48,6 +48,9 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) ./files/adblock-update.sh $(1)/usr/bin/
 	$(INSTALL_DATA) ./files/adblock-helper.sh $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
+	$(INSTALL_BIN) ./files/adblock.hotplug $(1)/etc/hotplug.d/iface/99-adblock
 
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/adblock.init $(1)/etc/init.d/adblock

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -51,6 +51,7 @@ When the dns server on your router receives dns requests, you will sort out quer
 * status & error logging to stdout and syslog
 * use of dynamic uhttpd instance as adblock pixel server
 * openwrt init system support (start/stop/restart/reload)
+* hotplug support, adblock start will be triggered by wan 'ifup' event
 * optional features (disabled by default):
     * adblock list backup/restore
     * debug logging to separate file
@@ -62,8 +63,8 @@ When the dns server on your router receives dns requests, you will sort out quer
     * optional: 'kmod-ipt-nat6' for IPv6 support
 * the above dependencies and requirements will be checked during package installation & script runtime
 
-## Usage
-* install the adblock package (*opkg install adblock*)
+## Installation & Usage
+* install the adblock package (*opkg update & opkg install adblock*)
 * start the adblock service with */etc/init.d/adblock start* and check *logread -e "adblock"* for adblock related information
 * optional: enable/disable your required adblock list sources in */etc/config/adblock* - 'adaway', 'disconnect' and 'yoyo' are enabled by default
 * optional: maintain the adblock service in luci under 'System => Startup'
@@ -72,6 +73,11 @@ When the dns server on your router receives dns requests, you will sort out quer
 For easy management of the various blocklist sources and and the adblock options there is also a nice & efficient LuCI frontend available.  
 Please install the package 'luci-app-adblock'. Then you will find the application in LuCI located under 'Services' menu.  
 Thanks to Hannu Nyman for this great adblock LuCI frontend!  
+
+## CC installation notes
+* currently the adblock package is *not* part of the CC package repository
+* download the latest adblock package *adblock_x.xx.x-1_all.ipk* from a DD snapshot [package directory](https://downloads.openwrt.org/snapshots/trunk/ar71xx/generic/packages/packages)
+* manual transfer the package to your router and install the opkg package as usual
 
 ## Tweaks
 * there is no need to enable all blacklist sites at once, for normal use one to three adblock list sources should be sufficient
@@ -90,10 +96,6 @@ Thanks to Hannu Nyman for this great adblock LuCI frontend!
     * adb\_port => port of the adblock uhttpd instance (default: '65535')
     * adb\_nullipv4 => IPv4 blackhole ip address (default: '192.0.2.1')
     * adb\_nullipv6 => IPv6 blackhole ip address (default: '::ffff:c000:0201')
-    * adb\_probeipv4 => IPv4 address used for uplink online check (default: '8.8.8.8')
-    * adb\_probeipv6 => IPv6 address used for uplink online check (default: '2001:4860:4860::8888')
-    * adb\_maxtime => download timeout limit in seconds (default: '60')
-    * adb\_maxloop => startup timeout limit in seconds to wait for an active wan interface (default: '20')
 
 ## Background
 This adblock package is a dns/dnsmasq based adblock solution for openwrt.  

--- a/net/adblock/files/adblock-update.sh
+++ b/net/adblock/files/adblock-update.sh
@@ -45,7 +45,7 @@ fi
 # get current directory, script- and openwrt version
 #
 adb_scriptdir="${0%/*}"
-adb_scriptver="0.80.0"
+adb_scriptver="0.80.1"
 openwrt_version="$(cat /etc/openwrt_version 2>/dev/null)"
 
 # source in adblock function library
@@ -100,7 +100,7 @@ then
     # only process shallalist archive with updated timestamp,
     # extract and merge only domains of selected shallalist categories
     #
-    shalla_time="$(${adb_fetch} ${wget_parm} --timeout=5 --server-response --spider "${adb_arc_shalla}" 2>&1 | grep -F "Last-Modified: " 2>/dev/null | tr -d '\r' 2>/dev/null)"
+    shalla_time="$(${adb_fetch} ${wget_parm} --server-response --spider "${adb_arc_shalla}" 2>&1 | grep -F "Last-Modified: " 2>/dev/null | tr -d '\r' 2>/dev/null)"
     shalla_time="${shalla_time/*: /}"
     if [ -z "${shalla_time}" ]
     then
@@ -109,7 +109,7 @@ then
     fi
     if [ -z "${list_time}" ] || [ "${list_time}" != "${shalla_time}" ]
     then
-        ${adb_fetch} ${wget_parm} --timeout="${adb_maxtime}" --output-document="${shalla_archive}" "${adb_arc_shalla}" 2>/dev/null
+        ${adb_fetch} ${wget_parm} --output-document="${shalla_archive}" "${adb_arc_shalla}" 2>/dev/null
         rc=${?}
         if [ $((rc)) -eq 0 ]
         then
@@ -184,7 +184,7 @@ do
     then
         url_time="${shalla_time}"
     else
-        url_time="$(${adb_fetch} ${wget_parm} --timeout=5 --server-response --spider "${url}" 2>&1 | grep -F "Last-Modified: " 2>/dev/null | tr -d '\r' 2>/dev/null)"
+        url_time="$(${adb_fetch} ${wget_parm} --server-response --spider "${url}" 2>&1 | grep -F "Last-Modified: " 2>/dev/null | tr -d '\r' 2>/dev/null)"
         url_time="${url_time/*: /}"
     fi
     if [ -z "${url_time}" ]
@@ -203,7 +203,7 @@ do
             tmp_domains="$(cat "${shalla_file}" 2>/dev/null)"
             rc=${?}
         else
-            tmp_domains="$(${adb_fetch} ${wget_parm} --timeout="${adb_maxtime}" --output-document=- "${url}" 2>/dev/null)"
+            tmp_domains="$(${adb_fetch} ${wget_parm} --output-document=- "${url}" 2>/dev/null)"
             rc=${?}
         fi
     else
@@ -413,7 +413,7 @@ fi
 # restart dnsmasq with newly generated or deleted adblock lists,
 # check dnsmasq startup afterwards
 #
-if [ -n "${adb_revsrclist}" ] || [ -n "${rm_done}" ]
+if [ -n "${adb_revsrclist}" ] || [ -n "${rm_done}" ] || [ -n "${restore_done}" ]
 then
     /etc/init.d/dnsmasq restart >/dev/null 2>&1
     sleep 2

--- a/net/adblock/files/adblock.hotplug
+++ b/net/adblock/files/adblock.hotplug
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+
+if [ -f "/var/run/adblock.pid" ] || [ "${ACTION}" != "ifup" ]
+then
+    exit 0
+fi
+
+. /lib/functions/network.sh
+adb_pid="${$}"
+adb_logger="/usr/bin/logger"
+network_find_wan adb_wanif4
+network_find_wan6 adb_wanif6
+
+if [ "${INTERFACE}" = "${adb_wanif4}" ] || [ "${INTERFACE}" = "${adb_wanif6}" ]
+then
+    /etc/init.d/adblock start
+    "${adb_logger}" -t "adblock[${adb_pid}] info " "adblock service started due to '${ACTION}' of '${INTERFACE}' interface"
+fi

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -23,6 +23,11 @@ then
     exit 255
 fi
 
+boot()
+{
+    return 0
+}
+
 start()
 {
     eval "${adb_script}" ${bg_parm}


### PR DESCRIPTION
* fix ip6tables reject types and statistics
* simplified firewall ruleset for IPv4/IPv6
* fix memory detection (swap was always 0)
* fix dnsmasq restart after partial restore
* ad hotplug support, adblock will be started when wan interface comes up
* change adblock init script accordingly, do nothing on 'boot'
* optimize wget parameters for faster download results (in case of an error)
* added CC installation notes to readme
* removed needless external online check
* removed needless optional parms 'adb_maxtime', 'adb_maxloop', 'adb_probeipv4' and 'adb_probeipv6'

Signed-off-by: Dirk Brenken <openwrt@brenken.org>