### PR TITLE
poco: add package for the Poco C++ library

### DIFF
--- a/libs/poco/Makefile
+++ b/libs/poco/Makefile
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2007-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=poco
+PKG_VERSION:=1.7.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://pocoproject.org/releases/poco-1.7.0
+PKG_MD5SUM:=dbbc98ab95910cc31bf4f1ffff9ac572
+
+PKG_LICENSE:=BSL-1.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/poco
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Poco C++ libraries
+  URL:=http://www.pocoproject.org/
+  DEPENDS:=+libstdcpp +libpthread +librt
+  MAINTAINER:=Jean-Michel Julien <jean-michel.julien@trilliantinc.com>
+endef
+
+define Package/poco/description
+  POrtable COmponents, a modern and powerful open source C++ class libraries
+  and frameworks for building network and internet-based applications that
+  run on desktop, server and embedded systems.
+endef
+
+CONFIGURE_ARGS += \
+	--config=Linux \
+	--no-tests \
+	--no-samples \
+	--no-fpenvironment \
+	--no-sharedmemory \
+	--no-wstring \
+	--poquito \
+	--minimal \
+	--shared
+
+define Package/poco/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libPoco{Foundation,XML,JSON,Net,Util}.so* $(1)/usr/lib/
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) -r $(PKG_INSTALL_DIR)/usr/include/Poco $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libPoco{Foundation,XML,JSON,Net,Util}.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,poco))

--- a/libs/poco/patches/100-configure.patch
+++ b/libs/poco/patches/100-configure.patch
@@ -1,0 +1,15 @@
+--- a/configure
++++ b/configure
+@@ -231,9 +231,9 @@
+		;;
+
+	*)
+-		showhelp
+-		exit 1
+-		;;
++#		showhelp
++#		exit 1
++#		;;
+	esac
+
+ 	shift

--- a/libs/poco/patches/200-strerror.patch
+++ b/libs/poco/patches/200-strerror.patch
@@ -1,0 +1,11 @@
+--- a/Foundation/src/Error.cpp
++++ b/Foundation/src/Error.cpp
+@@ -66,7 +66,7 @@
+		   without -D_GNU_SOURCE is needed, otherwise the GNU version is
+		   preferred.
+		*/
+-#if defined _GNU_SOURCE && !POCO_ANDROID
++#if (defined _GNU_SOURCE && (defined __GLIBC__ || defined __UCLIBC__)) && !POCO_ANDROID
+		char errmsg[256] = "";
+		return std::string(strerror_r(errorCode, errmsg, 256));
+ #elif (_XOPEN_SOURCE >= 600) || POCO_ANDROID


### PR DESCRIPTION
POrtable COmponents is a Modern, powerful open source C++ class libraries
for building network- and internet-based applications that run on desktop,
 server, mobile and embedded systems.

Original Makefile -->
https://dev.openwrt.org/browser/packages/libs/poco/Makefile

add license
add maintainer
update URL to latest github stable version (1.6.2)
change patch to the configure file

Signed-off-by: Jean-Michel Julien <jean-michel.julien@trilliantinc.com>