### PR TITLE
glib2: fix host build

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -46,7 +46,7 @@ endef
 
 HOST_CONFIGURE_ARGS += \
 	--disable-selinux \
-	--with-libiconv=gnu
+	--with-libiconv=no
 
 CONFIGURE_ARGS += \
 	--enable-shared \


### PR DESCRIPTION
build glib2/host without iconv to avoid build dependencies