### PR TITLE
wifitoggle: Fix empty led_sysfs option

### DIFF
--- a/utils/wifitoggle/Makefile
+++ b/utils/wifitoggle/Makefile
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2010-2014 OpenWrt.org
 # Copyright (C) 2010 segal.di.ubi.pt
+# Copyright (C) 2016 Karol Babioch <karol@babioch.de>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifitoggle
 PKG_VERSION:=1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_LICENSE:=GPL-2.0+
 
 PKG_MAINTAINER:=Nuno Goncalves <nunojpg@gmail.com>

--- a/utils/wifitoggle/files/wifitoggle.config
+++ b/utils/wifitoggle/files/wifitoggle.config
@@ -4,7 +4,9 @@ config wifitoggle
 	option persistent	'0' 
 	option timer		'600'
 
-	option led_sysfs		'wrt160nl:amber:wps'
+	#option led_sysfs		'wrt160nl:amber:wps'
+	# Leaving this option empty, makes sure that no LED is touched
+	option led_sysfs		''
 	option led_enable_trigger	'timer' 
 	option led_enable_delayon	'500'
 	option led_enable_delayoff	'500'

--- a/utils/wifitoggle/files/wifitoggle.hotplug
+++ b/utils/wifitoggle/files/wifitoggle.hotplug
@@ -1,7 +1,9 @@
 # /bin/sh
 
 setled() {
-        if [ -e /sys/class/leds/${led_sysfs}/brightness ]
+        if [ -z "${led_sysfs}" ]; then
+            return
+        elif [ -e /sys/class/leds/${led_sysfs}/brightness ]
 	then
                 [ $led_default -eq 1 ] && echo 1 >/sys/class/leds/${led_sysfs}/brightness
                 [ $led_default -eq 1 ] || echo 0 >/sys/class/leds/${led_sysfs}/brightness


### PR DESCRIPTION
While an empty led_sysfs definition works as intended (no LED state is
touched), an error message is generated, since the appropriate sysfs
interface does not exist:

     Sat Feb 27 16:42:55 2016 user.err wifitoggle: led:  not found

This patch makes sure that no such error message will be generated,
which fixes #2431.

Signed-off-by: Karol Babioch <karol@babioch.de>