### PR TITLE
adblock: 0.90.0

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=0.80.1
+PKG_VERSION:=0.90.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <openwrt@brenken.org>
@@ -25,7 +25,7 @@ endef
 define Package/$(PKG_NAME)/description
 Powerful adblock script to block ad/abuse domains.
 Currently the script supports 15 domain blacklist sites plus manual black- and whitelist overrides.
-Please see README.md in /etc/adblock for further information.
+Please see https://github.com/openwrt/packages/blob/master/net/adblock/files/README.md for further information.
 
 endef
 
@@ -62,7 +62,6 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_CONF) ./files/adblock.conf $(1)/etc/adblock/adblock.conf.default
 	$(INSTALL_CONF) ./files/adblock.blacklist $(1)/etc/adblock/
 	$(INSTALL_CONF) ./files/adblock.whitelist $(1)/etc/adblock/
-	$(INSTALL_CONF) ./files/README.md $(1)/etc/adblock/
 
 	$(INSTALL_DIR) $(1)/www/adblock
 	$(INSTALL_DATA) ./files/www/adblock/* $(1)/www/adblock/

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -46,15 +46,13 @@ When the dns server on your router receives dns requests, you will sort out quer
 * adblock source list parsing by fast & flexible regex rulesets
 * additional white- and blacklist support for manual overrides
 * quality checks during & after update of adblock lists to ensure a reliable dnsmasq service
-* wan update check, to wait for an active wan uplink before update
 * basic adblock statistics via iptables packet counters for each chain
 * status & error logging to stdout and syslog
 * use of dynamic uhttpd instance as adblock pixel server
+* use of dynamic iptables ruleset for adblock related redirects/rejects
 * openwrt init system support (start/stop/restart/reload)
 * hotplug support, adblock start will be triggered by wan 'ifup' event
-* optional features (disabled by default):
-    * adblock list backup/restore
-    * debug logging to separate file
+* optional: adblock list backup/restore (disabled by default)
 
 ## Prerequisites
 * [openwrt](https://openwrt.org), tested with latest stable release (Chaos Calmer 15.05) and with current trunk (Designated Driver > r47025)
@@ -81,28 +79,29 @@ Thanks to Hannu Nyman for this great adblock LuCI frontend!
 
 ## Tweaks
 * there is no need to enable all blacklist sites at once, for normal use one to three adblock list sources should be sufficient
-* if you really need to handle all blacklists at once add an usb stick or any other storage device to supersize your temp directory with a swap partition => see [openwrt wiki](https://wiki.openwrt.org/doc/uci/fstab) for further details
-* add static, personal domain white- or blacklist entries, one domain per line (wildcards & regex are not allowed!), by default both lists are located in */etc/adblock*
-* enable the backup/restore feature, to restore automatically the latest, stable backup of your adblock lists in case of any processing error
-* enable the logging feature for continuous logfile writing to monitor the adblock runs over a longer period
+* if you really need to handle all blacklists at once add an usb stick or any other storage device to enlarge your temp directory with a swap partition => see [openwrt wiki](https://wiki.openwrt.org/doc/uci/fstab) for further details
+* add personal domain white- or blacklist entries as an additional blocklist source, one domain per line (wildcards & regex are not allowed!), by default both empty lists are located in */etc/adblock*
+* enable the backup/restore feature, to restore automatically the latest stable backup of your adblock lists in case of any (partial) processing error (i.e. a single blocklist source server is down). Please use an (external) solid partition and *not* your volatile router temp directory for this
 * for a scheduled call of the adblock service via */etc/init.d/adblock start* add an appropriate crontab entry
 
 ## Further adblock config options
 * usually the adblock autodetection works quite well and no manual config overrides are needed, all options apply to 'global' adblock config section:
-    * adb\_enabled => main switch to enable/disable adblock service (default: '1' (enabled))
+    * adb\_enabled => main switch to enable/disable adblock service (default: '1', enabled)
     * adb\_cfgver => config version string (do not change!) - adblock checks this entry and automatically applies the current config, if none or an older revision was found.
     * adb\_wanif => name of the logical wan interface (default: 'wan')
     * adb\_lanif => name of the logical lan interface (default: 'lan')
     * adb\_port => port of the adblock uhttpd instance (default: '65535')
     * adb\_nullipv4 => IPv4 blackhole ip address (default: '192.0.2.1')
     * adb\_nullipv6 => IPv6 blackhole ip address (default: '::ffff:c000:0201')
+    * adb\_forcedns => redirect all DNS queries to local dnsmasq resolver (default: '1', enabled)
 
 ## Background
 This adblock package is a dns/dnsmasq based adblock solution for openwrt.  
 Queries to ad/abuse domains are never forwarded and always replied with a local IP address which may be IPv4 or IPv6.  
 For that purpose adblock uses an ip address from the private 'TEST-NET-1' subnet (192.0.2.1 / ::ffff:c000:0201) by default.  
 Furthermore all ad/abuse queries will be filtered by ip(6)tables and redirected to internal adblock pixel server (in PREROUTING chain) or rejected (in FORWARD or OUTPUT chain).  
-All iptables and uhttpd related adblock additions are non-destructive, no hard-coded changes in 'firewall.user', 'uhttpd' config or any other openwrt related config files. There is *no* adblock background daemon running, the (scheduled) start of the adblock service keeps only the adblock lists up-to-date.
+All iptables and uhttpd related adblock additions are non-destructive, no hard-coded changes in 'firewall.user', 'uhttpd' config or any other openwrt related config files.  
+There is *no* adblock background daemon running, the (scheduled) start of the adblock service keeps only the adblock lists up-to-date.
 
 ## Support
 Please join the adblock discussion in this [openwrt forum thread](https://forum.openwrt.org/viewtopic.php?id=59803) or contact me by mail <openwrt@brenken.org>

--- a/net/adblock/files/adblock.conf
+++ b/net/adblock/files/adblock.conf
@@ -1,19 +1,16 @@
 # adblock configuration, for further information
-# see '/etc/adblock/README.md'
+# see 'https://github.com/openwrt/packages/blob/master/net/adblock/files/README.md'
 
 config adblock 'global'
 	option adb_enabled '1'
-	option adb_cfgver '0.80'
+	option adb_cfgver '0.90'
 	option adb_blacklist '/etc/adblock/adblock.blacklist'
 	option adb_whitelist '/etc/adblock/adblock.whitelist'
+	option adb_forcedns '1'
 
 config service 'backup'
 	option enabled '0'
-	option adb_backupdir '/tmp'
-
-config service 'log'
-	option enabled '0'
-	option adb_logfile '/tmp/adb_debug.log'
+	option adb_backupdir '/mnt'
 
 config source 'adaway'
 	option enabled '1'

--- a/net/adblock/files/adblock.hotplug
+++ b/net/adblock/files/adblock.hotplug
@@ -1,14 +1,16 @@
 #!/bin/sh
 #
 
-if [ -f "/var/run/adblock.pid" ] || [ "${ACTION}" != "ifup" ]
+adb_pid="${$}"
+adb_pidfile="/var/run/adblock.pid"
+adb_logger="/usr/bin/logger"
+
+if [ -f "${adb_pidfile}" ] || [ "${ACTION}" != "ifup" ]
 then
     exit 0
 fi
 
 . /lib/functions/network.sh
-adb_pid="${$}"
-adb_logger="/usr/bin/logger"
 network_find_wan adb_wanif4
 network_find_wan6 adb_wanif6
 

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -36,6 +36,7 @@ start()
 
 restart()
 {
+    stop
     start
 }
 

--- a/net/adblock/files/www/adblock/adblock.html
+++ b/net/adblock/files/www/adblock/adblock.html
@@ -1,6 +1,0 @@
-<html>
-    <head><meta charset="utf-8"></head>
-    <body>
-        <img src="/adblock.png" border="0" alt=""></img>
-    </body>
-</html>


### PR DESCRIPTION
* all relevant adblock events will be properly written to syslog/stdout
* removed needless 'debug log' option
* add optional parm 'adb_forcedns' to redirect all queries to local resolver (default: '1', enabled)
* revised space check
* various code cosmetics & cleanups

Signed-off-by: Dirk Brenken <openwrt@brenken.org>