### PR TITLE
python: use external libffi for host python

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -29,7 +29,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/Python-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/Python-$(PKG_VERSION)
 
 PKG_BUILD_DEPENDS:=python/host
-HOST_BUILD_DEPENDS:=bzip2/host expat/host
+HOST_BUILD_DEPENDS:=bzip2/host expat/host libffi/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -223,6 +223,7 @@ HOST_CONFIGURE_ARGS+= \
 	--with-threads \
 	--prefix=$(STAGING_DIR)/host/usr \
 	--with-system-expat=$(STAGING_DIR)/host \
+	--with-system-ffi="$(STAGING_DIR)/host" \
 	--with-ensurepip=upgrade \
 	CONFIG_SITE= \
 	CFLAGS="$(HOST_CFLAGS)"


### PR DESCRIPTION
This will ensure that ctypes will use the same version of libffi as
other packages, e.g. python-cffi.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>