### PR TITLE
bluez: add support for Raspberry Pi 3.

### DIFF
--- a/utils/bluez/Makefile
+++ b/utils/bluez/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bluez
 PKG_VERSION:=5.37
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/bluetooth/

--- a/utils/bluez/Makefile
+++ b/utils/bluez/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2015 OpenWrt.org
+# Copyright (C) 2006-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bluez
-PKG_VERSION:=5.33
+PKG_VERSION:=5.37
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/bluetooth/
-PKG_MD5SUM:=78782dc33d9a8b6344c4cc1af70c8a98
+PKG_MD5SUM:=33177e5743e24b2b3738f72be64e3ffb
 
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING

--- a/utils/bluez/patches/001-bcm43xx-Add-bcm43xx-3wire-variant.patch
+++ b/utils/bluez/patches/001-bcm43xx-Add-bcm43xx-3wire-variant.patch
@@ -1,0 +1,21 @@
+From b4f2b77472aeb967d3a7595e8a965785c7a37c87 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Tue, 16 Feb 2016 16:40:46 +0000
+Subject: [PATCH 1/4] bcm43xx: Add bcm43xx-3wire variant
+
+---
+ tools/hciattach.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/tools/hciattach.c
++++ b/tools/hciattach.c
+@@ -1144,6 +1144,9 @@ struct uart_t uart[] = {
+ 	{ "bcm43xx",    0x0000, 0x0000, HCI_UART_H4,   115200, 3000000,
+ 				FLOW_CTL, DISABLE_PM, NULL, bcm43xx, NULL  },
+ 
++	{ "bcm43xx-3wire",    0x0000, 0x0000, HCI_UART_3WIRE, 115200, 3000000,
++				0, DISABLE_PM, NULL, bcm43xx, NULL  },
++
+ 	{ "ath3k",    0x0000, 0x0000, HCI_UART_ATH3K, 115200, 115200,
+ 			FLOW_CTL, DISABLE_PM, NULL, ath3k_ps, ath3k_pm  },
+ 

--- a/utils/bluez/patches/002-bcm43xx-The-UART-speed-must-be-reset-after-the-firmw.patch
+++ b/utils/bluez/patches/002-bcm43xx-The-UART-speed-must-be-reset-after-the-firmw.patch
@@ -1,0 +1,33 @@
+From e145c9621f976063e5c573db1f2053d906f63427 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Tue, 16 Feb 2016 16:39:09 +0000
+Subject: [PATCH 2/4] bcm43xx: The UART speed must be reset after the firmware
+ download
+
+---
+ tools/hciattach_bcm43xx.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+--- a/tools/hciattach_bcm43xx.c
++++ b/tools/hciattach_bcm43xx.c
+@@ -366,11 +366,8 @@ int bcm43xx_init(int fd, int def_speed,
+ 		return -1;
+ 
+ 	if (bcm43xx_locate_patch(FIRMWARE_DIR, chip_name, fw_path)) {
+-		fprintf(stderr, "Patch not found, continue anyway\n");
++		fprintf(stderr, "Patch not found for %s, continue anyway\n", chip_name);
+ 	} else {
+-		if (bcm43xx_set_speed(fd, ti, speed))
+-			return -1;
+-
+ 		if (bcm43xx_load_firmware(fd, fw_path))
+ 			return -1;
+ 
+@@ -380,6 +377,7 @@ int bcm43xx_init(int fd, int def_speed,
+ 			return -1;
+ 		}
+ 
++		sleep(1);
+ 		if (bcm43xx_reset(fd))
+ 			return -1;
+ 	}

--- a/utils/bluez/patches/003-Increase-firmware-load-timeout-to-30s.patch
+++ b/utils/bluez/patches/003-Increase-firmware-load-timeout-to-30s.patch
@@ -1,0 +1,20 @@
+From d41dc2046dd08d8c95197f677e224506f5b39bdd Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Wed, 20 Jan 2016 16:00:37 +0000
+Subject: [PATCH 3/4] Increase firmware load timeout to 30s
+
+---
+ tools/hciattach.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/tools/hciattach.c
++++ b/tools/hciattach.c
+@@ -1293,7 +1293,7 @@ int main(int argc, char *argv[])
+ {
+ 	struct uart_t *u = NULL;
+ 	int detach, printpid, raw, opt, i, n, ld, err;
+-	int to = 10;
++	int to = 30;
+ 	int init_speed = 0;
+ 	int send_break = 0;
+ 	pid_t pid;

--- a/utils/bluez/patches/004-Move-the-43xx-firmware-into-lib-firmware.patch
+++ b/utils/bluez/patches/004-Move-the-43xx-firmware-into-lib-firmware.patch
@@ -1,0 +1,20 @@
+From 76681284b0ea49852041fdb97a35175089a08781 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.org>
+Date: Tue, 23 Feb 2016 17:52:29 +0000
+Subject: [PATCH 4/4] Move the 43xx firmware into /lib/firmware
+
+---
+ tools/hciattach_bcm43xx.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/tools/hciattach_bcm43xx.c
++++ b/tools/hciattach_bcm43xx.c
+@@ -43,7 +43,7 @@
+ #include "hciattach.h"
+ 
+ #ifndef FIRMWARE_DIR
+-#define FIRMWARE_DIR "/etc/firmware"
++#define FIRMWARE_DIR "/lib/firmware/brcm"
+ #endif
+ 
+ #define FW_EXT ".hcd"

--- a/utils/bluez/patches/201-readline.patch
+++ b/utils/bluez/patches/201-readline.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -2405,7 +2405,7 @@ unit_tests = $(am__append_32) unit/test-
+@@ -2441,7 +2441,7 @@ unit_tests = $(am__append_35) unit/test-
  @CLIENT_TRUE@					monitor/uuid.h monitor/uuid.c
  
  @CLIENT_TRUE@client_bluetoothctl_LDADD = gdbus/libgdbus-internal.la @GLIB_LIBS@ @DBUS_LIBS@ \
@@ -9,7 +9,7 @@
  
  @MONITOR_TRUE@monitor_btmon_SOURCES = monitor/main.c monitor/bt.h \
  @MONITOR_TRUE@				monitor/display.h monitor/display.c \
-@@ -2651,13 +2651,13 @@ unit_tests = $(am__append_32) unit/test-
+@@ -2691,13 +2691,13 @@ unit_tests = $(am__append_35) unit/test-
  @READLINE_TRUE@				client/display.h
  
  @READLINE_TRUE@attrib_gatttool_LDADD = lib/libbluetooth-internal.la \
@@ -25,7 +25,7 @@
  
  @READLINE_TRUE@tools_obex_server_tool_SOURCES = $(gobex_sources) $(btio_sources) \
  @READLINE_TRUE@						tools/obex-server-tool.c
-@@ -2667,17 +2667,17 @@ unit_tests = $(am__append_32) unit/test-
+@@ -2707,17 +2707,17 @@ unit_tests = $(am__append_35) unit/test-
  @READLINE_TRUE@				client/display.h client/display.c
  
  @READLINE_TRUE@tools_bluetooth_player_LDADD = gdbus/libgdbus-internal.la \


### PR DESCRIPTION
Update bluez to v5.37 and add support for Raspberry Pi 3