### PR TITLE
collectd: perl INSTALL_BASE fix in 15.05

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.4.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://collectd.org/files/
@@ -171,6 +171,7 @@ CONFIGURE_ARGS+= \
 	--enable-daemon \
 	--enable-getifaddrs \
 	--with-nan-emulation \
+	--without-perl-bindings \
 	--without-libgcrypt
 
 CONFIGURE_VARS+= \


### PR DESCRIPTION
Fix for compile error in collectd 5.4.2 , cc15.05


cd buildperl && /openwrt/chaos_calmer/chaos_calmer/staging_dir/host/bin/perl Makefile.PL PREFIX=/usr
Only one of PREFIX or INSTALL_BASE can be given.  Not both.

Check whether you have set $PERL_MM_OPT in your environment and try using ./configure --with-perl-bindings=""

cd buildperl && make
make[7]: Entering directory `/openwrt/chaos_calmer/chaos_calmer/build_dir/target-mips_34kc+dsp_uClibc-0.9.33.2/collectd-5.4.2/bindings/buildperl'
make[7]: *** No targets specified and no makefile found.  Stop.
make[7]: Leaving directory `/openwrt/chaos_calmer/chaos_calmer/build_dir/target-mips_34kc+dsp_uClibc-0.9.33.2/collectd-5.4.2/bindings/buildperl'
make[6]: *** [perl] Error 2