### PR TITLE
Drop the redundant -r option to $(CP)

### DIFF
--- a/lang/node-arduino-firmata/Makefile
+++ b/lang/node-arduino-firmata/Makefile
@@ -60,7 +60,7 @@ define Package/node-arduino-firmata/install
 	mkdir -p $(1)/usr/lib/node
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/* $(1)/usr/lib/node
 	rm -rf $(1)/usr/lib/node/arduino-firmata/node_modules/serialport/ 
-	$(CP) -r ./files/* $(1)/
+	$(CP) ./files/* $(1)/
 endef
 
 $(eval $(call BuildPackage,node-arduino-firmata))

--- a/lang/node-cylon/Makefile
+++ b/lang/node-cylon/Makefile
@@ -73,22 +73,22 @@ endef
 
 define Package/node-cylon/install
 	mkdir -p $(1)/usr/lib/node/cylon
-	$(CP) -r $(PKG_INSTALL_DIR)/usr/lib/node_modules/cylon-firmata/node_modules/cylon/* $(1)/usr/lib/node/cylon/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/cylon-firmata/node_modules/cylon/* $(1)/usr/lib/node/cylon/
 endef
 
 define Package/node-cylon-i2c/install
 	mkdir -p $(1)/usr/lib/node/cylon-i2c
-	$(CP) -r $(PKG_INSTALL_DIR)/usr/lib/node_modules/cylon-firmata/node_modules/cylon-i2c/* $(1)/usr/lib/node/cylon-i2c/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/cylon-firmata/node_modules/cylon-i2c/* $(1)/usr/lib/node/cylon-i2c/
 endef
 
 define Package/node-cylon-gpio/install
 	mkdir -p $(1)/usr/lib/node/cylon-gpio
-	$(CP) -r $(PKG_INSTALL_DIR)/usr/lib/node_modules/cylon-firmata/node_modules/cylon-gpio/* $(1)/usr/lib/node/cylon-gpio/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/cylon-firmata/node_modules/cylon-gpio/* $(1)/usr/lib/node/cylon-gpio/
 endef
 
 define Package/node-cylon-firmata/install
 	mkdir -p $(1)/usr/lib/node/cylon-firmata
-	$(CP) -r $(PKG_INSTALL_DIR)/usr/lib/node_modules/cylon-firmata/{index.js,lib,LICENSE,package.json,README.md,RELEASES.md,spec} $(1)/usr/lib/node/cylon-firmata/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/cylon-firmata/{index.js,lib,LICENSE,package.json,README.md,RELEASES.md,spec} $(1)/usr/lib/node/cylon-firmata/
 endef
 
 $(eval $(call BuildPackage,node-cylon))

--- a/libs/poco/Makefile
+++ b/libs/poco/Makefile
@@ -55,7 +55,7 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) -r $(PKG_INSTALL_DIR)/usr/include/Poco $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/Poco $(1)/usr/include/
 
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libPoco{Foundation,XML,JSON,Net,Util}.so* $(1)/usr/lib/

--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -207,13 +207,12 @@ define Package/pgsql-server/install
 
 	$(INSTALL_BIN) ./files/postgresql.init $(1)/etc/init.d/postgresql
 
-	$(CP) -r $(PKG_INSTALL_DIR)/usr/share/postgresql/* \
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/postgresql/* \
 		$(1)/usr/share/postgresql
 
 	$(INSTALL_DATA) ./files/postgresql.config $(1)/etc/config/postgresql
 
-	$(CP) -r \
-		$(PKG_INSTALL_DIR)/usr/lib/postgresql \
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/postgresql \
 		$(1)/usr/lib
 endef
 

--- a/net/znc/Makefile
+++ b/net/znc/Makefile
@@ -81,7 +81,7 @@ define module
 	# include webadmin page templates if existing
 	if [ -d $$(PKG_BUILD_DIR)/modules/data/$(subst -,_,$(strip $(1))) ]; then \
 		$(INSTALL_DIR) $$(1)/usr/share/znc/modules ;\
-		$(CP) -r $$(PKG_BUILD_DIR)/modules/data/$(subst -,_,$(strip $(1))) $$(1)/usr/share/znc/modules ;\
+		$(CP) $$(PKG_BUILD_DIR)/modules/data/$(subst -,_,$(strip $(1))) $$(1)/usr/share/znc/modules ;\
 	fi
   endef
 
@@ -104,9 +104,9 @@ define webadmin
 	$(INSTALL_DIR) $$(1)/usr/lib/znc/
 	$(INSTALL_BIN) $$(PKG_BUILD_DIR)/modules/webadmin.so $$(1)/usr/lib/znc/
 	$(INSTALL_DIR) $$(1)/usr/share/znc/modules
-	$(CP) -r $$(PKG_BUILD_DIR)/modules/data/webadmin $$(1)/usr/share/znc/modules
+	$(CP) $$(PKG_BUILD_DIR)/modules/data/webadmin $$(1)/usr/share/znc/modules
 	$(INSTALL_DIR) $$(1)/usr/share/znc/webskins/
-	$(CP) -r $$(PKG_BUILD_DIR)/webskins/_default_ $$(1)/usr/share/znc/webskins/
+	$(CP) $$(PKG_BUILD_DIR)/webskins/_default_ $$(1)/usr/share/znc/webskins/
   endef
 
   ZNC_MODULES += znc-mod-webadmin
@@ -126,7 +126,7 @@ define webskin
 
   define Package/znc-webskin-$(strip $(1))/install
 	$(INSTALL_DIR) $$(1)/usr/share/znc/webskins/
-	$(CP) -r $$(PKG_BUILD_DIR)/webskins/$(strip $(1)) $$(1)/usr/share/znc/webskins/
+	$(CP) $$(PKG_BUILD_DIR)/webskins/$(strip $(1)) $$(1)/usr/share/znc/webskins/
   endef
   ZNC_MODULES += znc-webskin-$(strip $(1))
 endef

--- a/sound/upmpdcli/Makefile
+++ b/sound/upmpdcli/Makefile
@@ -54,7 +54,7 @@ endif
 ifneq ($(CONFIG_PACKAGE_UPMPDCLI_SC_WEB_INTERFACE),y)
 	$(RM) -rf $(PKG_INSTALL_DIR)/usr/share/upmpdcli/web
 endif
-	$(CP) -r $(PKG_INSTALL_DIR)/usr/share/upmpdcli $(1)/usr/share/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/upmpdcli $(1)/usr/share/
 	$(INSTALL_DATA) ./files/upmpdcli.png $(1)/usr/share/upmpdcli/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/upmpdcli.init $(1)/etc/init.d/upmpdcli

--- a/utils/acl/Makefile
+++ b/utils/acl/Makefile
@@ -81,7 +81,7 @@ endef
 define Build/InstallDev
 	mkdir -p $(1)/usr/include
 	mkdir -p $(1)/usr/lib/pkgconfig
-	$(CP) -r $(PKG_INSTALL_DIR)/usr/{include,lib} $(1)/usr/
+	$(CP) $(PKG_INSTALL_DIR)/usr/{include,lib} $(1)/usr/
 endef
 
 $(eval $(call BuildPackage,acl))

--- a/utils/attr/Makefile
+++ b/utils/attr/Makefile
@@ -86,7 +86,7 @@ endef
 define Build/InstallDev
 	mkdir -p $(1)/usr/include
 	mkdir -p $(1)/usr/lib/pkgconfig
-	$(CP) -r $(PKG_INSTALL_DIR)/usr/{include,lib} $(1)/usr/
+	$(CP) $(PKG_INSTALL_DIR)/usr/{include,lib} $(1)/usr/
 endef
 
 $(eval $(call BuildPackage,attr))

--- a/utils/gammu/Makefile
+++ b/utils/gammu/Makefile
@@ -48,7 +48,7 @@ endif
 
 define Build/InstallDev
 	mkdir -p $(1)/usr/include
-	$(CP) -r $(PKG_INSTALL_DIR)/usr/include/gammu $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/gammu $(1)/usr/include/
 	mkdir -p $(1)/usr/lib
 	$(CP)    $(PKG_INSTALL_DIR)/usr/lib$(LIB_SUFFIX)/lib{Gammu*,gsmsd*} $(1)/usr/lib/
 endef


### PR DESCRIPTION
$(CP) was defined as `cp -fpR' since the very begining of OpenWrt build
system (2006-06-22).  The -R option should be enough and base packages
use only $(CP) for the same purposes just fine and BSD manual of cp also
discourages the use of `-r' option.  So let's just tidy up the usage now.

Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>

Well, this commit modifies a lot of packages here, I am fairly sure that the change won't break anything but I'd like to see this kind of change getting acks from you guys before making its way into the master branch.