### PR TITLE
mwan3: supress hotplug on reconnect

### DIFF
--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -9,6 +9,8 @@ config_load mwan3
 config_get enabled $INTERFACE enabled 0
 [ "$enabled" == "1" ] || exit 0
 
+[ -f "/var/run/mwan3track-${INTERFACE}-downed" ] && exit 0:q
+
 [ "$ACTION" == "ifup" -o "$ACTION" == "ifdown" ] || exit 1
 [ -n "$INTERFACE" ] || exit 2
 

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -9,7 +9,7 @@ config_load mwan3
 config_get enabled $INTERFACE enabled 0
 [ "$enabled" == "1" ] || exit 0
 
-[ -f "/var/run/mwan3track-${INTERFACE}-downed" ] && exit 0:q
+[ -f "/var/run/mwan3track-${INTERFACE}-downed" ] && exit 0
 
 [ "$ACTION" == "ifup" -o "$ACTION" == "ifdown" ] || exit 1
 [ -n "$INTERFACE" ] || exit 2

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -5,6 +5,7 @@
 if [ -e /var/run/mwan3track-$1.pid ] ; then
 	kill $(cat /var/run/mwan3track-$1.pid) &> /dev/null
 	rm /var/run/mwan3track-$1.pid &> /dev/null
+	rm /var/run/mwan3track-$1-downed &> /dev/null
 fi
 
 echo "$$" > /var/run/mwan3track-$1.pid
@@ -32,6 +33,7 @@ while true; do
 		if [ $score -eq $8 ]; then
 
 			logger -t mwan3track -p notice "Interface $1 ($2) is offline"
+			touch /var/run/mwan3track-$1-downed
 			env -i ACTION=ifdown INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
 			score=0
 
@@ -52,6 +54,7 @@ while true; do
 		if [ $score -eq $8 ]; then
 
 			logger -t mwan3track -p notice "Interface $1 ($2) is online"
+			rm /var/run/mwan3track-$1-downed &> /dev/null
 			env -i ACTION=ifup INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
 			rm /var/run/mwan3track-$1.pid
 			exit 0


### PR DESCRIPTION
I am working with a 2 wan system that requires a delayed fail-back. Everything works great when an outage is on another network segment. However if the breakage is layer 2, the hotplug event is fired by the system even though mwan3track has not hit the fail-back rule threshold.

This commit checks to see if mwan3track downed the interface and disregards it if it receives an hotplug ifup call not originating from mwan3track if mwan3track ifdowned the interface.

So in instances where where the CPE switch or router layer 2 is flapping, it will hold the failover as designed.