### PR TITLE
p910nd: convert p910nd init script to procd

### DIFF
--- a/net/p910nd/files/p910nd.init
+++ b/net/p910nd/files/p910nd.init
@@ -1,6 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2007 OpenWrt.org
 START=50
+USE_PROCD=1
 
 append_bool() {
 	local section="$1"
@@ -21,31 +22,24 @@ append_string() {
 }
 
 start_service() {
-	local section="$1"
-	args=""
+	config_load "p910nd"
+	config_foreach start_p910nd p910nd
+}
 
-	append_bool "$section" bidirectional "-b"
-	append_string "$section" device "-f "
-	append_string "$section" bind "-i "
-	append_string "$section" port ""
+
+start_p910nd() {
+	local section="$1"
 	config_get_bool "enabled" "$section" "enabled" '1'
-	[ "$enabled" -gt 0 ] && /usr/sbin/p910nd $args
-}
-
-stop_service() {
-	local section="$1"
-	config_get port "$section" port
-
-	PID_F=/var/run/p910${port}d.pid
-	[ -f $PID_F ] && kill $(cat $PID_F)
-}
-
-start() {
-	config_load "p910nd"
-	config_foreach start_service p910nd
-}
-
-stop() {
-	config_load "p910nd"
-	config_foreach stop_service p910nd
+	if [ "$enabled" -gt 0 ]; then
+		args="-d "
+		config_get port "$section" port
+		name=p910${port}d
+		append_bool "$section" bidirectional "-b"
+		append_string "$section" device "-f "
+		append_string "$section" bind "-i "
+		append_string "$section" port ""
+		procd_open_instance $name
+		procd_set_param command /usr/sbin/p910nd $args
+		procd_close_instance
+	fi
 }


### PR DESCRIPTION
I created a hotplug.d script that (re)starts the p910nd daemon in case I plug in my usb printer because it did not start automatically if the printer was off during the start of the openwrt device.
Somehow I ended up with two instances of the daemon - even though I used the "restart" option.
One of them was not stoppable via the init script since the pid file was overwritten by the second instance.

Anyway. Those three lines prevent starting the daemon for the same device twice.