### PR TITLE
net/git: Add building of gitweb

### DIFF
--- a/net/git/Makefile
+++ b/net/git/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=git
 PKG_VERSION:=2.7.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/scm/git/
@@ -51,8 +51,17 @@ endef
 
 define Package/git-http/description
 $(call Package/git/description)
+endef
 
- This package allows git push/fetch over http(s) and ftp(s)
+define Package/git-gitweb
+$(call Package/git/Default)
+  TITLE:=Git repository web interface
+  DEPENDS:=git +perlbase-essential +perlbase-file +perlbase-fcntl +perlbase-encode +perlbase-digest +perlbase-time +perl-cgi
+endef
+
+define Package/git-gitweb/description
+$(call Package/git/description)
+ This package builds the gitweb web interface for git repositories
 endef
 
 MAKE_FLAGS := \
@@ -70,6 +79,11 @@ MAKE_FLAGS := \
 	NO_PYTHON="YesPlease" \
 	NO_TCLTK="YesPlease" \
 	NO_INSTALL_HARDLINKS="yes" \
+	gitwebdir="/www/cgi-bin" \
+	GITWEB_JS="/gitweb/gitweb.js" \
+	GITWEB_CSS="/gitweb/gitweb.css" \
+	GITWEB_LOGO="/gitweb/gitweb-logo.png" \
+	GITWEB_FAVICON="/gitweb/gitweb-favicon.png"
 
 CONFIGURE_ARGS += \
 	--without-iconv \
@@ -77,8 +91,12 @@ CONFIGURE_ARGS += \
 define Build/Configure
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		configure
-
 	$(call Build/Configure/Default,)
+endef
+
+define Build/Compile
+	mkdir -p $(PKG_INSTALL_DIR)/www/cgi-bin $(PKG_INSTALL_DIR)/www/gitweb
+	$(call Build/Compile/Default,DESTDIR=$(PKG_INSTALL_DIR) all install gitweb install-gitweb)
 endef
 
 define Package/git/install
@@ -111,5 +129,13 @@ define Package/git-http/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/git-core/git-remote-https $(1)/usr/lib/git-core
 endef
 
+define Package/git-gitweb/install
+	$(INSTALL_DIR) $(1)/www/cgi-bin $(1)/www/gitweb
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/www/cgi-bin/gitweb.cgi $(1)/www/cgi-bin/
+	$(CP) $(PKG_INSTALL_DIR)/www/cgi-bin/static/* $(1)/www/gitweb/
+endef
+
 $(eval $(call BuildPackage,git))
 $(eval $(call BuildPackage,git-http))
+$(eval $(call BuildPackage,git-gitweb))
+


### PR DESCRIPTION
gitweb is a handy git web interfaces; add building of it

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>

Note that this has only been lightly tested.  Also it depends on the perl-cgi fix pull request as without the perl CGI module will not work.