### PR TITLE
Pull request lxc auto

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=1.1.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=LGPL-2.1+ BSD-2-Clause GPL-2.0
 PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>
@@ -39,7 +39,8 @@ LXC_SCRIPTS += \
 
 DEPENDS_APPLETS = +libpthread +libcap +liblxc
 
-DEPENDS_create = +lxc-configs +lxc-hooks +lxc-templates
+DEPENDS_create = +lxc-configs +lxc-hooks +lxc-templates +flock
+
 DEPENDS_ls = +lxc-config
 DEPENDS_top = +lxc-lua +luafilesystem @BROKEN
 
@@ -54,6 +55,23 @@ endef
 define Package/lxc
   $(call Package/lxc/Default)
   MENU:=1
+endef
+
+define Package/lxc-auto
+  $(call Package/lxc/Default)
+  TITLE:= (initscript)
+  DEPENDS:=+lxc-start +lxc-stop
+endef
+
+define Package/lxc-auto/description
+ LXC is the userspace control package for Linux Containers, a lightweight
+ virtual system mechanism sometimes described as "chroot on steroids".
+ This package adds and initscript for starting and stopping the containers
+ on boot and shutdown.
+endef
+
+define Package/lxc-auto/conffiles
+/etc/config/lxc-auto
 endef
 
 define Package/lxc/config
@@ -147,6 +165,12 @@ endef
 
 define Package/lxc/install
 	true
+endef
+
+define Package/lxc-auto/install
+	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/init.d
+	$(INSTALL_CONF) ./files/lxc-auto.config $(1)/etc/config/lxc-auto
+	$(INSTALL_BIN) ./files/lxc-auto.init $(1)/etc/init.d/lxc-auto
 endef
 
 define Package/lxc-common/conffiles
@@ -250,6 +274,7 @@ $(eval $(call BuildPackage,lxc-templates))
 $(eval $(call BuildPackage,liblxc))
 $(eval $(call BuildPackage,lxc-lua))
 $(eval $(call BuildPackage,lxc-init))
+$(eval $(call BuildPackage,lxc-auto))
 $(foreach u,$(LXC_APPLETS_BIN),$(eval $(call GenPlugin,$(u),$(DEPENDS_APPLETS),"/usr/bin")))
 $(foreach u,$(LXC_APPLETS_LIB),$(eval $(call GenPlugin,$(u),$(DEPENDS_APPLETS),"/usr/lib/lxc")))
 $(foreach u,$(LXC_SCRIPTS),$(eval $(call GenPlugin,$(u),,"/usr/bin")))

--- a/utils/lxc/files/lxc-auto.config
+++ b/utils/lxc/files/lxc-auto.config
@@ -1,0 +1,5 @@
+#config container
+	#option name container1
+	#option timeout 300
+	#list command '/bin/command --option'
+

--- a/utils/lxc/files/lxc-auto.init
+++ b/utils/lxc/files/lxc-auto.init
@@ -1,0 +1,60 @@
+#!/bin/sh /etc/rc.common
+
+. /lib/functions.sh
+
+START=99
+STOP=00
+
+run_command() {
+	local command="$1"
+	$command
+}
+
+start_container() {
+	local cfg="$1"
+	local name
+
+	config_get name "$cfg" name
+	config_list_foreach "$cfg" command run_command
+	if [ -n "$name" ]; then
+		/usr/bin/lxc-start -n "$name"
+	fi
+}
+
+max_timeout=0
+
+stop_container() {
+	local cfg="$1"
+	local name timeout
+
+	config_get name "$cfg" name
+	config_get timeout "$cfg" timeout 300
+
+	if [ "$max_timeout" -lt "$timeout" ]; then
+		max_timeout=$timeout
+	fi
+
+	if [ -n "$name" ]; then
+		if [ "$timeout" = "0" ]; then
+			/usr/bin/lxc-stop -n "$name" &
+		else
+			/usr/bin/lxc-stop -n "$name" -t $timeout &
+		fi
+	fi
+}
+
+start() {
+	config_load lxc-auto
+	config_foreach start_container container
+}
+
+stop() {
+	config_load lxc-auto
+	config_foreach stop_container container
+	# ensure e.g. shutdown doesn't occur before maximum timeout on
+	# containers that are shutting down
+	if [ $max_timeout -gt 0 ]; then
+		sleep $max_timeout
+	fi
+}
+


### PR DESCRIPTION
Autostart mechanism from upstream LXC currently doesn't work in OpenWrt.  Implement a workaround for now.