### PR TITLE
net/bind: Update db.root

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.9.8-P4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER := Noah Meyerhans <frodo@morgul.net>

--- a/net/bind/files/bind/db.root
+++ b/net/bind/files/bind/db.root
@@ -1,45 +1,90 @@
-
-; <<>> DiG 9.2.3 <<>> ns . @a.root-servers.net.
-;; global options:  printcmd
-;; Got answer:
-;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 18944
-;; flags: qr aa rd; QUERY: 1, ANSWER: 13, AUTHORITY: 0, ADDITIONAL: 13
-
-;; QUESTION SECTION:
-;.				IN	NS
-
-;; ANSWER SECTION:
-.			518400	IN	NS	A.ROOT-SERVERS.NET.
-.			518400	IN	NS	B.ROOT-SERVERS.NET.
-.			518400	IN	NS	C.ROOT-SERVERS.NET.
-.			518400	IN	NS	D.ROOT-SERVERS.NET.
-.			518400	IN	NS	E.ROOT-SERVERS.NET.
-.			518400	IN	NS	F.ROOT-SERVERS.NET.
-.			518400	IN	NS	G.ROOT-SERVERS.NET.
-.			518400	IN	NS	H.ROOT-SERVERS.NET.
-.			518400	IN	NS	I.ROOT-SERVERS.NET.
-.			518400	IN	NS	J.ROOT-SERVERS.NET.
-.			518400	IN	NS	K.ROOT-SERVERS.NET.
-.			518400	IN	NS	L.ROOT-SERVERS.NET.
-.			518400	IN	NS	M.ROOT-SERVERS.NET.
-
-;; ADDITIONAL SECTION:
-A.ROOT-SERVERS.NET.	3600000	IN	A	198.41.0.4
-B.ROOT-SERVERS.NET.	3600000	IN	A	192.228.79.201
-C.ROOT-SERVERS.NET.	3600000	IN	A	192.33.4.12
-D.ROOT-SERVERS.NET.	3600000	IN	A	128.8.10.90
-E.ROOT-SERVERS.NET.	3600000	IN	A	192.203.230.10
-F.ROOT-SERVERS.NET.	3600000	IN	A	192.5.5.241
-G.ROOT-SERVERS.NET.	3600000	IN	A	192.112.36.4
-H.ROOT-SERVERS.NET.	3600000	IN	A	128.63.2.53
-I.ROOT-SERVERS.NET.	3600000	IN	A	192.36.148.17
-J.ROOT-SERVERS.NET.	3600000	IN	A	192.58.128.30
-K.ROOT-SERVERS.NET.	3600000	IN	A	193.0.14.129
-L.ROOT-SERVERS.NET.	3600000	IN	A	199.7.83.42
-M.ROOT-SERVERS.NET.	3600000	IN	A	202.12.27.33
-
-;; Query time: 81 msec
-;; SERVER: 198.41.0.4#53(a.root-servers.net.)
-;; WHEN: Sun Feb  1 11:27:14 2004
-;; MSG SIZE  rcvd: 436
-
+;       This file holds the information on root name servers needed to
+;       initialize cache of Internet domain name servers
+;       (e.g. reference this file in the "cache  .  <file>"
+;       configuration file of BIND domain name servers).
+;
+;       This file is made available by InterNIC 
+;       under anonymous FTP as
+;           file                /domain/named.cache
+;           on server           FTP.INTERNIC.NET
+;       -OR-                    RS.INTERNIC.NET
+;
+;       last update:    February 17, 2016
+;       related version of root zone:   2016021701
+;
+; formerly NS.INTERNIC.NET
+;
+.                        3600000      NS    A.ROOT-SERVERS.NET.
+A.ROOT-SERVERS.NET.      3600000      A     198.41.0.4
+A.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:ba3e::2:30
+;
+; FORMERLY NS1.ISI.EDU
+;
+.                        3600000      NS    B.ROOT-SERVERS.NET.
+B.ROOT-SERVERS.NET.      3600000      A     192.228.79.201
+B.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:84::b
+;
+; FORMERLY C.PSI.NET
+;
+.                        3600000      NS    C.ROOT-SERVERS.NET.
+C.ROOT-SERVERS.NET.      3600000      A     192.33.4.12
+C.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2::c
+;
+; FORMERLY TERP.UMD.EDU
+;
+.                        3600000      NS    D.ROOT-SERVERS.NET.
+D.ROOT-SERVERS.NET.      3600000      A     199.7.91.13
+D.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2d::d
+;
+; FORMERLY NS.NASA.GOV
+;
+.                        3600000      NS    E.ROOT-SERVERS.NET.
+E.ROOT-SERVERS.NET.      3600000      A     192.203.230.10
+;
+; FORMERLY NS.ISC.ORG
+;
+.                        3600000      NS    F.ROOT-SERVERS.NET.
+F.ROOT-SERVERS.NET.      3600000      A     192.5.5.241
+F.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2f::f
+;
+; FORMERLY NS.NIC.DDN.MIL
+;
+.                        3600000      NS    G.ROOT-SERVERS.NET.
+G.ROOT-SERVERS.NET.      3600000      A     192.112.36.4
+;
+; FORMERLY AOS.ARL.ARMY.MIL
+;
+.                        3600000      NS    H.ROOT-SERVERS.NET.
+H.ROOT-SERVERS.NET.      3600000      A     198.97.190.53
+H.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:1::53
+;
+; FORMERLY NIC.NORDU.NET
+;
+.                        3600000      NS    I.ROOT-SERVERS.NET.
+I.ROOT-SERVERS.NET.      3600000      A     192.36.148.17
+I.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fe::53
+;
+; OPERATED BY VERISIGN, INC.
+;
+.                        3600000      NS    J.ROOT-SERVERS.NET.
+J.ROOT-SERVERS.NET.      3600000      A     192.58.128.30
+J.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:c27::2:30
+;
+; OPERATED BY RIPE NCC
+;
+.                        3600000      NS    K.ROOT-SERVERS.NET.
+K.ROOT-SERVERS.NET.      3600000      A     193.0.14.129
+K.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fd::1
+;
+; OPERATED BY ICANN
+;
+.                        3600000      NS    L.ROOT-SERVERS.NET.
+L.ROOT-SERVERS.NET.      3600000      A     199.7.83.42
+L.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:3::42
+;
+; OPERATED BY WIDE
+;
+.                        3600000      NS    M.ROOT-SERVERS.NET.
+M.ROOT-SERVERS.NET.      3600000      A     202.12.27.33
+M.ROOT-SERVERS.NET.      3600000      AAAA  2001:dc3::35
+; End of file

--- a/net/bind/files/named.init
+++ b/net/bind/files/named.init
@@ -13,7 +13,6 @@ pid_file=/var/run/named/named.pid
 logdir=/var/log/named/
 cachedir=/var/cache/bind
 libdir=/var/lib/bind
-config_file=/etc/bind/named.conf
 
 fix_perms() {
     for dir in $libdir $logdir $cachedir; do


### PR DESCRIPTION
The contents of the file "db.root" is very old (12 years).
Here's a new version downloaded from ftp://ftp.internic.net/domain/

The variable "config_file" appears twice in "named.init"

Signed-off-by: DonkZZ <donk@evhr.net>