### PR TITLE
postgresql: update source to 9.5.1 and refresh patches

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
-PKG_VERSION:=9.4.4
+PKG_VERSION:=9.5.1
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Jo-Philipp Wich <jow@openwrt.org>
 PKG_LICENSE:=PostgreSQL
@@ -18,7 +18,7 @@ PKG_SOURCE_URL:=\
 	http://ftp9.us.postgresql.org/pub/mirrors/postgresql/source/v$(PKG_VERSION) \
 	http://ftp.be.postgresql.org/postgresql/source/v$(PKG_VERSION) \
 	ftp://ftp-archives.postgresql.org/pub/source/v$(PKG_VERSION)
-PKG_MD5SUM:=1fe952c44ed26d7e6a335cf991a9c1c6
+PKG_MD5SUM:=11e037afaa4bd0c90bb3c3d955e2b401
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 PKG_FIXUP:=autoreconf
@@ -29,7 +29,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/libpq
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+zlib +libreadline +libpthread +libncurses +shadow-utils +shadow-su
+  DEPENDS:=+zlib +libreadline +libpthread +libncurses
   TITLE:=PostgreSQL client library
   URL:=http://www.postgresql.org/
   SUBMENU:=database
@@ -42,7 +42,7 @@ endef
 define Package/pgsql-cli
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libpq +USE_UCLIBC:librt
+  DEPENDS:=+libpq +USE_UCLIBC:librt +shadow-utils +shadow-su
   TITLE:=Command Line Interface (CLI) to PostgreSQL databases
   URL:=http://www.postgresql.org/
   SUBMENU:=database
@@ -116,7 +116,7 @@ define Build/Configure
 			--enable-depend \
 			--with-system-timezone=/tmp \
 	);
-	$(MAKE) -C $(PKG_BUILD_DIR)/src/interfaces/ecpg/preproc CC="$(HOSTCC)" CFLAGS+="-I../../libpq"
+	$(MAKE) -C $(PKG_BUILD_DIR)/src/interfaces/ecpg/preproc CC="$(HOSTCC)"
 	mv $(PKG_BUILD_DIR)/src/interfaces/ecpg/preproc/ecpg \
 		$(PKG_BUILD_DIR)/src/interfaces/ecpg/preproc/ecpg.host
 	$(MAKE) -C $(PKG_BUILD_DIR)/src/timezone CC="$(HOSTCC)"

--- a/libs/postgresql/patches/001-configure_fixes.patch
+++ b/libs/postgresql/patches/001-configure_fixes.patch
@@ -2,7 +2,7 @@
 +++ b/configure.in
 @@ -25,7 +25,7 @@ recommended.  You can remove the check f
  your responsibility whether the result works or not.])])
- AC_COPYRIGHT([Copyright (c) 1996-2014, PostgreSQL Global Development Group])
+ AC_COPYRIGHT([Copyright (c) 1996-2015, PostgreSQL Global Development Group])
  AC_CONFIG_SRCDIR([src/backend/access/common/heaptuple.c])
 -AC_CONFIG_AUX_DIR(config)
 +AC_CONFIG_AUX_DIR([config])

--- a/libs/postgresql/patches/200-ranlib.patch
+++ b/libs/postgresql/patches/200-ranlib.patch
@@ -1,8 +1,8 @@
 --- a/src/port/Makefile
 +++ b/src/port/Makefile
-@@ -52,6 +52,7 @@ uninstall:
- 
+@@ -53,6 +53,7 @@ uninstall:
  libpgport.a: $(OBJS)
+ 	rm -f $@
  	$(AR) $(AROPT) $@ $^
 +	$(RANLIB) libpgport.a
  

--- a/libs/postgresql/patches/800-busybox-default-pager.patch
+++ b/libs/postgresql/patches/800-busybox-default-pager.patch
@@ -1,8 +1,8 @@
 --- a/src/bin/psql/print.h
 +++ b/src/bin/psql/print.h
-@@ -179,10 +179,6 @@ extern void printQuery(const PGresult *r
- extern void setDecimalLocale(void);
+@@ -197,10 +197,6 @@ extern void setDecimalLocale(void);
  extern const printTextFormat *get_line_style(const printTableOpt *opt);
+ extern void refresh_utf8format(const printTableOpt *opt);
  
 -#ifndef __CYGWIN__
 -#define DEFAULT_PAGER "more"


### PR DESCRIPTION
Setting the additional include path for host-build of ecpg is no
longer required and started breaking the build (PostgeSQL BUG-14033),
remove it.
Also, pgsql-server no longer requires shadow-su since procd can take
care of starting it running under the appropriate user.
Moving the dependency to pgsql-cli makes sense as the 'su' command is
still needed to boot-strap a new data directory and also commonly used
for other administration tasks. However, in that way the CLI and
shadow-su can be removed during production once pgsql-server has been
setup.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>