### PR TITLE
Strongswan: support for brcm47xx/atheros ar9331

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
 PKG_VERSION:=5.3.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.strongswan.org/ http://download2.strongswan.org/

--- a/net/strongswan/patches/101-musl-fixes.patch
+++ b/net/strongswan/patches/101-musl-fixes.patch
@@ -10,7 +10,7 @@
  
 --- /dev/null
 +++ b/src/libstrongswan/musl.h
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,48 @@
 +#include <sys/types.h>
 +
 +#define crypt x_crypt
@@ -32,6 +32,15 @@
 +#define timer_t x_timer_t
 +#define blkcnt_t x_blkcnt_t
 +#define __kernel_nlink_t void
++
++/*
++ * Support for brcm47xx/atheros ar9331
++ * In arch/mips/include/asm/posix_types.h __kernel_nlink_t will be defined as typedef unsigned long/int
++ * that is not compatible with void defined above
++ */
++#if ( (_MIPS_SZLONG == 32) || (_MIPS_SZLONG == 64) )
++#undef __kernel_nlink_t
++#endif
 +
 +#include <linux/types.h>
 +


### PR DESCRIPTION
 In arch/mips/include/asm/posix_types.h __kernel_nlink_t will be defined as typedef unsigned long/int 
 that is not compatible with void (#define __kernel_nlink_t void)
