### PR TITLE
mail/msmtp: Add option to use msmtp/msmtpq as sendmail

### DIFF
--- a/mail/msmtp/Makefile
+++ b/mail/msmtp/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=msmtp
 PKG_VERSION:=1.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/msmtp
@@ -69,15 +69,82 @@ $(call Package/msmtp/Default/description)
  This package is built without SSL support.
 endef
 
+define Package/msmtp-mta
+$(call Package/msmtp/Default)
+  TITLE+= (with SSL support)
+  DEPENDS+= +msmtp
+  VARIANT:=ssl
+endef
+
+define Package/msmtp-mta/description
+$(call Package/msmtp/Default/description)
+ This package add a link from sendmail to msmtp
+ and is built with SSL support.
+endef
+
+define Package/msmtp-nossl-mta
+$(call Package/msmtp/Default)
+  TITLE+= (without SSL support)
+  DEPENDS+= +msmtp-nossl
+  VARIANT:=nossl
+endef
+
+define Package/msmtp-nossl-mta/description
+$(call Package/msmtp/Default/description)
+ This package add a link from sendmail to msmtp
+ and is built without SSL support.
+endef
+
 define Package/msmtp-queue
 $(call Package/msmtp/Default)
-  DEPENDS+= +bash
+  DEPENDS+= +bash +msmtp
   TITLE+= (queue scripts)
+  VARIANT:=ssl
 endef
 
 define Package/msmtp-queue/description
 $(call Package/msmtp/Default/description)
  This package contains the msmtp queue scripts.
+ uses msmtp with SSL.
+endef
+
+define Package/msmtp-queue-nossl
+$(call Package/msmtp/Default)
+  DEPENDS+= +bash +msmtp-nossl
+  TITLE+= (queue scripts)
+  VARIANT:=nossl
+endef
+
+define Package/msmtp-queue-nossl/description
+$(call Package/msmtp/Default/description)
+ This package contains the msmtp queue scripts and
+ uses msmtp without SSL.
+endef
+
+define Package/msmtp-queue-mta
+$(call Package/msmtp/Default)
+  DEPENDS+= +bash +msmtp-queue
+  TITLE+= (queue scripts)
+  VARIANT:=ssl
+endef
+
+define Package/msmtp-queue-mta/description
+$(call Package/msmtp/Default/description)
+ This package add a link from sendmail to msmtpq
+ and is built with SSL support.
+endef
+
+define Package/msmtp-queue-nossl-mta
+$(call Package/msmtp/Default)
+  DEPENDS+= +bash +msmtp-queue-nossl
+  TITLE+= (queue scripts)
+  VARIANT:=nossl
+endef
+
+define Package/msmtp-queue-nossl-mta/description
+$(call Package/msmtp/Default/description)
+ This package add a link from sendmail to msmtpq
+ and is built without SSL support.
 endef
 
 CONFIGURE_ARGS += \
@@ -112,23 +179,22 @@ define Package/msmtp/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/msmtp $(1)/usr/bin/
 endef
 
-define Package/msmtp/postinst
+define Package/msmtp-mta/install
+	true
+endef
+
+define Package/msmtp-mta/postinst
 	[ -e $${IPKG_INSTROOT}/usr/sbin/sendmail ] || {
 		mkdir -p $${IPKG_INSTROOT}/usr/sbin
 		ln -sf ../bin/msmtp $${IPKG_INSTROOT}/usr/sbin/sendmail
 	}
 endef
 
-define Package/msmtp/prerm
+define Package/msmtp-mta/prerm
 	[ "../bin/msmtp" = "$(readlink -qs $${IPKG_INSTROOT}/usr/sbin/sendmail)" ] && {
 		rm -f $${IPKG_INSTROOT}/usr/sbin/sendmail
 	}
 endef
-
-Package/msmtp-nossl/conffiles = $(Package/msmtp/conffiles)
-Package/msmtp-nossl/install = $(Package/msmtp/install)
-Package/msmtp-nossl/postinst = $(Package/msmtp/postinst)
-Package/msmtp-nossl/prerm = $(Package/msmtp/prerm)
 
 define Package/msmtp-queue/install
 	$(INSTALL_DIR) $(1)/usr/bin
@@ -136,6 +202,35 @@ define Package/msmtp-queue/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/scripts/msmtpqueue/msmtp-{en,list,run}queue.sh $(1)/usr/bin/
 endef
 
+define Package/msmtp-queue-mta/install
+	$(INSTALL_DIR) $(1)/etc/init.d $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/msmtp-queue-mta.init $(1)/etc/init.d/msmtp-queue-mta
+endef
+
+define Package/msmtp-queue-mta/postinst
+	sed -i -e 's,^Q=.*,Q=/var/spool/msmtp,' $${IPKG_INSTROOT}/usr/bin/msmtpq
+	sed -i -e 's,^LOG=.*,LOG=/var/log/msmtp,' $${IPKG_INSTROOT}/usr/bin/msmtpq
+	sed -i -e 's/^EMAIL_CONN_TEST=n/EMAIL_CONN_TEST=p/' $${IPKG_INSTROOT}/usr/bin/msmtpq
+	[ -e $${IPKG_INSTROOT}/usr/sbin/sendmail ] || {
+		mkdir -p $${IPKG_INSTROOT}/usr/sbin
+		ln -sf ../bin/msmtpq $${IPKG_INSTROOT}/usr/sbin/sendmail
+	}
+endef
+
+Package/msmtp-nossl/conffiles = $(Package/msmtp/conffiles)
+Package/msmtp-nossl/install = $(Package/msmtp/install)
+Package/msmtp-queue-nossl/install = $(Package/msmtp-queue/install)
+Package/msmtp-nossl-mta/install = $(Package/msmtp-mta/install)
+Package/msmtp-nossl-mta/postinst = $(Package/msmtp-mta/postinst)
+Package/msmtp-nossl-mta/postrm = $(Package/msmtp-mta/postrm)
+Package/msmtp-queue-nossl-mta/install = $(Package/msmtp-queue-mta/install)
+Package/msmtp-queue-nossl-mta/postinst = $(Package/msmtp-queue-mta/postinst)
+Package/msmtp-queue-nossl-mta/postrm = $(Package/msmtp-queue-mta/postrm)
+
 $(eval $(call BuildPackage,msmtp))
 $(eval $(call BuildPackage,msmtp-nossl))
 $(eval $(call BuildPackage,msmtp-queue))
+$(eval $(call BuildPackage,msmtp-mta))
+$(eval $(call BuildPackage,msmtp-nossl-mta))
+$(eval $(call BuildPackage,msmtp-queue-mta))
+$(eval $(call BuildPackage,msmtp-queue-nossl-mta))

--- a/mail/msmtp/files/msmtp-queue-mta.init
+++ b/mail/msmtp/files/msmtp-queue-mta.init
@@ -1,0 +1,11 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2016 Daniel Dickinson <openwrt@daniel.thecshore.com>
+
+START=99
+
+start() {
+	mkdir -p /var/spool/msmtp
+	chmod 0733 /var/spool/msmtp
+	mkdir -p /var/log/msmtp
+	chmod 0733 /var/log/msmtp
+}


### PR DESCRIPTION
Using msmtp-queue as a sendmail replacement is particularly handy
because it allows the mail to be stored for retry in the event
mail delivery fails.

We also improve the use of straight msmtp as an mta (and make
that a separate package from plain msmtp).

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>