### PR TITLE
Fixes bluez build on big endian archs

### DIFF
--- a/utils/bluez/patches/005-tools-avinfo-fix-build-for-big-endian.patch
+++ b/utils/bluez/patches/005-tools-avinfo-fix-build-for-big-endian.patch
@@ -1,0 +1,14 @@
+--- a/profiles/audio/a2dp-codecs.h
++++ b/profiles/audio/a2dp-codecs.h
+@@ -234,6 +234,11 @@ typedef struct {
+ 	uint8_t channel_mode:4;
+ } __attribute__ ((packed)) a2dp_aptx_t;
+ 
++typedef struct {
++	a2dp_vendor_codec_t info;
++	uint8_t unknown[2];
++} __attribute__ ((packed)) a2dp_ldac_t;
++
+ #else
+ #error "Unknown byte order"
+ #endif


### PR DESCRIPTION
A struct needed for avinfo is hidden in an #ifdef LITTLE_ENDIAN . This patch adds a copy of the struct to the #else block . It's identical to the buildroot problem/patch documented here: https://git.busybox.net/buildroot/commit/?id=8f65c4151b0ac796c9ec91ba38dd15d3b0076a9b