### PR TITLE
libinput: fix and optimize build

### DIFF
--- a/libs/libinput/Makefile
+++ b/libs/libinput/Makefile
@@ -26,7 +26,7 @@ include $(INCLUDE_DIR)/package.mk
 
 TARGET_CFLAGS+= -std=gnu99
 
-CONFIGURE_ARGS += --disable-libwacom
+CONFIGURE_ARGS += --disable-libwacom --disable-tests --disable-documentation
 
 define Package/libinput
   SECTION:=libs

--- a/libs/libinput/patches/002-static_assert.patch
+++ b/libs/libinput/patches/002-static_assert.patch
@@ -1,0 +1,14 @@
+--- a/src/evdev-tablet.c
++++ b/src/evdev-tablet.c
+@@ -1155,9 +1155,11 @@ static void
+ tablet_mark_all_axes_changed(struct tablet_dispatch *tablet,
+ 			     struct libinput_tablet_tool *tool)
+ {
++#if 0
+ 	static_assert(sizeof(tablet->changed_axes) ==
+ 			      sizeof(tool->axis_caps),
+ 		      "Mismatching array sizes");
++#endif
+ 
+ 	memcpy(tablet->changed_axes,
+ 	       tool->axis_caps,


### PR DESCRIPTION
Buildbots are reporting the following build failure:

-snip-
  CCLD     test-build-linker
../src/.libs/libinput.so: undefined reference to `static_assert'
-snap-

Since this is the only call to static_assert within the library,
removing this assertion seems to be reasonable.

While at, speed up the build by not building tests and documentation.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>