### PR TITLE
net/rsyslog: upgrade to 8.17.0

### DIFF
--- a/libs/libfastjson/Makefile
+++ b/libs/libfastjson/Makefile
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libfastjson
+PKG_VERSION:=0.99.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/rsyslog/libfastjson.git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+
+PKG_MAINTAINER:=Dov Murik <dmurik@us.ibm.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILE:=COPYING
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libfastjson
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=A fast JSON library for C
+  URL:=https://github.com/rsyslog/libfastjson
+endef
+
+define Package/libfastjson/description
+  libfastjson - A fast JSON library for C
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
+endef
+
+define Package/libfastjson/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfastjson.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libfastjson))

--- a/net/rsyslog/Makefile
+++ b/net/rsyslog/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsyslog
-PKG_VERSION:=8.16.0
+PKG_VERSION:=8.17.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.rsyslog.com/files/download/rsyslog/
-PKG_MD5SUM:=52916045c07ebbd3ee77c39e8465bc4d
+PKG_MD5SUM:=fadc26576a783afdf11f64beca278bc9
 
 PKG_MAINTAINER:=Dov Murik <dmurik@us.ibm.com>
 PKG_LICENSE:=GPL-3.0
@@ -29,7 +29,7 @@ define Package/rsyslog
   CATEGORY:=Network
   TITLE:=Enhanced system logging and kernel message trapping daemons
   URL:=http://www.rsyslog.com/
-  DEPENDS:=+libestr +libjson-c +libuuid +zlib
+  DEPENDS:=+libestr +libfastjson +libuuid +zlib
 endef
 
 define Package/rsyslog/conffiles


### PR DESCRIPTION
Add `libs/libfastjson` which is now a dependency for rsyslog (since 8.17.0).

Upgrade rsyslog to 8.17.0.

Signed-off-by: Dov Murik \<dmurik@us.ibm.com>