### PR TITLE
gst1-plugins-bad: add fragmented plugin

### DIFF
--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2015 OpenWrt.org
+# Copyright (C) 2011-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-bad
 PKG_VERSION:=1.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -147,7 +147,6 @@ CONFIGURE_ARGS += \
 	--disable-schro \
 	--disable-zbar \
 	--disable-srtp \
-	--disable-hls \
 	\
 	--without-libiconv-prefix \
 	--without-libintl-prefix \
@@ -198,8 +197,10 @@ define GstBuildLibrary
   $$(eval $$(call BuildPackage,libgst1$(1)))
 endef
 
+$(eval $(call GstBuildLibrary,adaptivedemux,adaptivedemux,app uridownloader,))
 $(eval $(call GstBuildLibrary,photography,photography,,))
 $(eval $(call GstBuildLibrary,basecamerabinsrc,basecamerabinsrc,app,))
+$(eval $(call GstBuildLibrary,uridownloader,uridownloader,,))
 
 # 1: short name
 # 2: description
@@ -248,6 +249,7 @@ $(eval $(call GstBuildPlugin,debugutilsbad,debugutils support,video,,))
 $(eval $(call GstBuildPlugin,dvdspu,dvdspu support,video,,))
 $(eval $(call GstBuildPlugin,fbdevsink,fbdev support,video,,))
 $(eval $(call GstBuildPlugin,festival,festival support,audio,,))
+$(eval $(call GstBuildPlugin,fragmented,HLS support,video pbutils adaptivedemux,multifile,+libnettle))
 $(eval $(call GstBuildPlugin,frei0r,frei0r support,controller video,,))
 $(eval $(call GstBuildPlugin,id3tag,id3tag support,tag,,))
 $(eval $(call GstBuildPlugin,jpegformat,jpegformat support,tag,,))


### PR DESCRIPTION
fragmented provides hlssink and hlsdemux.

Also added required gst libraries:
- adaptivedemux
- uridownloader

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

I tested with x86 and it streamed (slowly) both videotest and a real webcam:

`gst-launch-1.0 videotestsrc is-live=true ! vp8enc ! webmmux streamable=true ! hlssink max-files=5`

`gst-launch-1.0 v4l2src do-timestamp=1 ! videorate drop-only=true average-period=2 ! image/jpeg,width=320,height=240 ! jpegdec !  vp8enc ! webmmux streamable=true ! hlssink max-files=5`

@MikePetullo , is it ok for you?