### PR TITLE
multimedia/motion: pthread not found because motion doesn't use CPPFLAGS

### DIFF
--- a/multimedia/motion/Makefile
+++ b/multimedia/motion/Makefile
@@ -38,6 +38,8 @@ define Package/motion/conffiles
   /etc/motion.conf
 endef
 
+TARGET_CFLAGS+=$(TARGET_CPPFLAGS)
+
 CONFIGURE_ARGS+= \
 	--without-optimizecpu \
 	--without-ffmpeg \


### PR DESCRIPTION
pthread.h is in $(TOOLCHAIN_DIR)/include which by default
is included in CPPFLAGS, however motion doesn't use CPPFLAGS
so doesn't find pthread.h (and therefore fails to build).
We fix this by adding CPPFLAGS to TARGET_CFLAGS.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>