### PR TITLE
utils/collectd: Disable libudev linking

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.5.1
-PKG_RELEASE:=4
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://collectd.org/files/
@@ -193,7 +193,8 @@ CONFIGURE_ARGS+= \
 	--disable-debug \
 	--enable-daemon \
 	--with-nan-emulation \
-	--without-perl-bindings
+	--without-perl-bindings \
+	--without-libudev
 
 ifneq ($(CONFIG_PACKAGE_COLLECTD_ENCRYPTED_NETWORK),)
 CONFIGURE_ARGS+= \


### PR DESCRIPTION
At least when building with OpenWrt SDK, if libudev is present
(even if not actually used by the system), then at least the
disk plugin attempts to link against udev, which results in
packages failure due to lack of dependencies, and it's not
desirable to add a dependency on udev just because udev
was built for the SDK, so we disable libudev support
explicity.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>