### PR TITLE
net/nut: Fix '/var/run' world readable warning

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -330,7 +330,7 @@ CONFIGURE_ARGS += \
 	--$(if $(CONFIG_NUT_SSL),with,without)-ssl $(if $(CONFIG_NUT_SSL),--with-openssl) \
 	--without-libltdl \
 	--$(if $(CONFIG_PACKAGE_nut-web-cgi),with,without)-cgi \
-	--with-statepath=/var/run \
+	--with-statepath=/var/run/nut \
 	--with-drvpath=/lib/nut \
 	--with-cgipath=/usr/share/www/cgi-bin/nut \
 	--with-htmlpath=/usr/share/www/nut \

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -9,6 +9,10 @@ restart() {
 }
 
 start_service() {
+	mkdir -p /var/run/nut
+	chown root:root /var/run/nut
+	chmod 700 /var/run/nut
+
 	upsmon -p
 }
 

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -9,6 +9,10 @@ restart() {
 }
 
 start_service() {
+	mkdir -p /var/run/nut
+	chown root:root /var/run/nut
+	chmod 0700 /var/run/nut
+
 	upsdrvctl start
 	upsd
 }


### PR DESCRIPTION
Use /var/run/nut as statepath and set appropriate owner
and permissions on /var/run/nut in order to avoid pidfile
for nut being world-readable.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>

Conflicts:
	net/nut/Makefile
	net/nut/files/nut-monitor.init
	net/nut/files/nut-server.init