### PR TITLE
sane-backends: add missing config file

### DIFF
--- a/utils/sane-backends/Makefile
+++ b/utils/sane-backends/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sane-backends
 PKG_VERSION:=1.0.25
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://fossies.org/linux/misc \
     https://alioth.debian.org/frs/download.php/file/4146/
@@ -203,6 +203,7 @@ endef
 
 define Package/sane-daemon/conffiles
 /etc/sane.d/saned.conf
+/etc/xinetd.d/sane-port
 endef
 
 define Package/sane-frontends/install


### PR DESCRIPTION
/etc/xinetd.d/sane-port is a config file.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>