### PR TITLE
python-setuptools: upgrade to version 20.7.0

### DIFF
--- a/lang/python-setuptools/Makefile
+++ b/lang/python-setuptools/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-setuptools
-PKG_VERSION:=20.2.2
+PKG_VERSION:=20.7.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=setuptools-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/source/s/setuptools/
-PKG_MD5SUM:=bf37191cb4c1472fb61e6f933d2006b1
+PKG_MD5SUM:=5d12b39bf3e75e80fdce54e44b255615
 
 HOST_BUILD_DEPENDS:=python python/host
 


### PR DESCRIPTION
python-setuptools releases more often than my preference.
Every once in a while I sync up with the latest released.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>