### PR TITLE
ddns-scripts: Update mythic-beasts URL so that fully qualified hostname can be passed

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.6.4
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -73,7 +73,7 @@
 "ddns.com.br"	"http://[DOMAIN]:[PASSWORD]@members.ddns.com.br/nic/update?hostname=[DOMAIN]&myip=[IP]"
 
 # Mythic Beasts (https://www.mythic-beasts.com) Dynamic DNS
-"mythic-beasts.com"	"http://dnsapi4.mythic-beasts.com/?domain=[USERNAME]&password=[PASSWORD]&command=REPLACE%20[DOMAIN]%2060%20A%20DYNAMIC_IP"
+"mythic-beasts.com"	"http://dnsapi4.mythic-beasts.com/?domain=[USERNAME]&password=[PASSWORD]&command=REPLACE%20[DOMAIN]%2060%20A%20DYNAMIC_IP&origin=."
 
 # Securepoint Dynamic-DNS-Service	(http://www.spdns.de)
 "spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"

--- a/net/ddns-scripts/files/services_ipv6
+++ b/net/ddns-scripts/files/services_ipv6
@@ -69,3 +69,5 @@
 # IPv6 @ regfish.de
 "regfish.de"	"http://dyndns.regfish.de/?fqdn=[DOMAIN]&forcehost=1&authtype=secure&token=[PASSWORD]&ipv6=[IP]"	"success|100|101"
 
+# Mythic Beasts (https://www.mythic-beasts.com) Dynamic DNS
+"mythic-beasts.com"	"http://dnsapi6.mythic-beasts.com/?domain=[USERNAME]&password=[PASSWORD]&command=REPLACE%20[DOMAIN]%2060%20AAAA%20DYNAMIC_IP&origin=."


### PR DESCRIPTION
Mythic beasts have updated their API so that a fully qualified host name can be passed in to update a DNS entry - details at https://www.mythic-beasts.com/support/api/primary and https://www.mythic-beasts.com/support/domains/dynamic/openwrt
This updates the config settings for mythic-beasts to reflect this