### PR TITLE
[utils/zoneinfo] Updated to the latest release version

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2016c
-PKG_VERSION_CODE:=2016c
+PKG_VERSION:=2016d
+PKG_VERSION_CODE:=2016d
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -20,14 +20,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION_CODE).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_MD5SUM:=0330ccd16140d3b6438a18dae9b34b93
+PKG_MD5SUM:=14bf84b6c2cdab0a9428991e0150ebe6
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   MD5SUM:=ffb82ab0b588138759902b4627a6a80d
+   MD5SUM:=06fc6fc111cd8dd681abdc5326529afd
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
  Changes affecting future time stamps

     America/Caracas switches from -0430 to -04 on 2016-05-01 at 02:30.
     (Thanks to Alexander Krivenyshev for the heads-up.)

     Asia/Magadan switches from +10 to +11 on 2016-04-24 at 02:00.
     (Thanks to Alexander Krivenyshev and Matt Johnson.)

     New zone Asia/Tomsk, split off from Asia/Novosibirsk. It covers
     Tomsk Oblast, Russia, which switches from +06 to +07 on 2016-05-29
     at 02:00.  (Thanks to Stepan Golosunov.)

   Changes affecting past time stamps

     New zone Europe/Kirov, split off from Europe/Volgograd.  It covers
     Kirov Oblast, Russia, which switched from +04/+05 to +03/+04 on
     1989-03-26 at 02:00, roughly a year after Europe/Volgograd made
     the same change.  (Thanks to Stepan Golosunov.)

     Russia and nearby locations had daylight-saving transitions on
     1992-03-29 at 02:00 and 1992-09-27 at 03:00, instead of on
     1992-03-28 at 23:00 and 1992-09-26 at 23:00.  (Thanks to Stepan
     Golosunov.)

     Many corrections to historical time in Kazakhstan from 1991
     through 2005.  (Thanks to Stepan Golosunov.)  Replace Kazakhstan's
     invented time zone abbreviations with numeric abbreviations.
