### PR TITLE
fix download-url for tmux

### DIFF
--- a/utils/tmux/Makefile
+++ b/utils/tmux/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.9a
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/tmux
+PKG_SOURCE_URL:=https://github.com/tmux/tmux/releases/download/$(PKG_VERSION)
 PKG_MD5SUM:=b07601711f96f1d260b390513b509a2d
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=ISC


### PR DESCRIPTION
tmux is not avail on Sourceforge anymore, so change to Github as in trunk

Signed-off-by: Sven Roederer <devel-sven@geroedel.de>