### PR TITLE
gpsd: don't enable by default

### DIFF
--- a/utils/gpsd/Makefile
+++ b/utils/gpsd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gpsd
 PKG_VERSION:=3.15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download-mirror.savannah.gnu.org/releases/gpsd/

--- a/utils/gpsd/files/gpsd.config
+++ b/utils/gpsd/files/gpsd.config
@@ -2,4 +2,4 @@ config gpsd core
     option device    "/dev/ttyUSB0"
     option port    "2947"
     option listen_globally    "false"
-    option enabled    "true"
+    option enabled    "false"


### PR DESCRIPTION
Because this selects ttyUSB0 (bad choice) by default, turn off enabling gps
by default until the user set's the tty manually and will stop gpsd from
stomping on another device's tty.

Signed-off-by: Pushpal Sidhu <psidhu@gateworks.com>