### PR TITLE
lang/perl-cgi: Missing copy of CGI.pm

### DIFF
--- a/lang/perl-cgi/Makefile
+++ b/lang/perl-cgi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-cgi
 PKG_VERSION:=4.28
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://www.cpan.org/authors/id/L/LE/LEEJO
 PKG_SOURCE:=CGI-$(PKG_VERSION).tar.gz
@@ -41,7 +41,7 @@ define Build/Compile
 endef
 
 define Package/perl-cgi/install
-        $(call perlmod/Install,$(1),CGI auto/CGI)
+        $(call perlmod/Install,$(1),CGI.pm CGI auto/CGI)
 endef
 
 


### PR DESCRIPTION
Perl CGI requires CGI.pm file, but this file was missing from module
creation.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>

Accidentally removed pull-request branch, bringing back pull request