### PR TITLE
nginx: upstep to 1.10.0, add Lua module, footprint optimizations

### DIFF
--- a/net/nginx/Config.in
+++ b/net/nginx/Config.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2012 OpenWrt.org
+# Copyright (C) 2010-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -176,5 +176,10 @@ config NGINX_NAXSI
 	bool
 	prompt "Enable NAXSI module"
 	default y
+
+config NGINX_LUA
+	bool
+	prompt "Enable Lua module"
+	default n
 
 endmenu

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2012-2015 OpenWrt.org
+# Copyright (C) 2012-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
-PKG_VERSION:=1.9.13
+PKG_VERSION:=1.10.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://nginx.org/download/
-PKG_MD5SUM:=e7502dc170277597ca73eb53c359c771
+PKG_MD5SUM:=c184c873d2798c5ba92be95ed1209c02
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=2-clause BSD-like license
 
@@ -54,7 +54,9 @@ PKG_CONFIG_DEPENDS := \
 	CONFIG_NGINX_HTTP_UPSTREAM_KEEPALIVE \
 	CONFIG_NGINX_HTTP_UPSTREAM_ZONE \
 	CONFIG_NGINX_HTTP_CACHE \
-	CONFIG_NGINX_PCRE
+	CONFIG_NGINX_PCRE \
+	CONFIG_NGINX_NAXSI \
+	CONFIG_NGINX_LUA
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -64,7 +66,7 @@ define Package/nginx
   SUBMENU:=Web Servers/Proxies
   TITLE:=Nginx web server
   URL:=http://nginx.org/
-  DEPENDS:=+NGINX_PCRE:libpcre +(NGINX_SSL||NGINX_HTTP_CACHE||NGINX_HTTP_AUTH_BASIC):libopenssl +NGINX_HTTP_GZIP:zlib +libpthread
+  DEPENDS:=+NGINX_PCRE:libpcre +(NGINX_SSL||NGINX_HTTP_CACHE||NGINX_HTTP_AUTH_BASIC):libopenssl +NGINX_HTTP_GZIP:zlib +NGINX_LUA:liblua +libpthread
   MENU:=1
 endef
 
@@ -77,7 +79,7 @@ define Package/nginx/config
   source "$(SOURCE)/Config.in"
 endef
 
-config_files=nginx.conf mime.types fastcgi_params koi-utf koi-win win-utf
+config_files=nginx.conf mime.types
 
 define Package/nginx/conffiles
 /etc/nginx/
@@ -87,8 +89,9 @@ ADDITIONAL_MODULES:=
 ifeq ($(CONFIG_NGINX_NAXSI),y)
   ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-naxsi/naxsi_src
 endif
-
-ADDITIONAL_MODULES:=
+ifeq ($(CONFIG_NGINX_LUA),y)
+  ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/lua-nginx
+endif
 ifeq ($(CONFIG_IPV6),y)
   ADDITIONAL_MODULES += --with-ipv6
 endif
@@ -112,6 +115,8 @@ ifneq ($(CONFIG_NGINX_PCRE),y)
 endif
 ifneq ($(CONFIG_NGINX_HTTP_CHARSET),y)
   ADDITIONAL_MODULES += --without-http_charset_module
+else
+  config_files += koi-utf koi-win win-utf
 endif
 ifneq ($(CONFIG_NGINX_HTTP_GZIP),y)
   ADDITIONAL_MODULES += --without-http_gzip_module
@@ -151,6 +156,8 @@ ifneq ($(CONFIG_NGINX_HTTP_PROXY),y)
 endif
 ifneq ($(CONFIG_NGINX_HTTP_FASTCGI),y)
   ADDITIONAL_MODULES += --without-http_fastcgi_module
+else
+  config_files += fastcgi_params
 endif
 ifneq ($(CONFIG_NGINX_HTTP_UWSGI),y)
   ADDITIONAL_MODULES += --without-http_uwsgi_module
@@ -186,8 +193,12 @@ ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_KEEPALIVE),y)
   ADDITIONAL_MODULES += --without-http_upstream_keepalive_module
 endif
 
+TARGET_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -DNGX_LUA_NO_BY_LUA_BLOCK
+TARGET_LDFLAGS += -Wl,--gc-sections
+
 define Build/Configure
 	( cd $(PKG_BUILD_DIR) ; \
+		$(if $(CONFIG_NGINX_LUA),LUA_INC=$(STAGING_DIR)/usr/include LUA_LIB=$(STAGING_DIR)/usr/lib) \
 		./configure \
 			--crossbuild=Linux::$(ARCH) \
 			--prefix=/usr \
@@ -226,6 +237,7 @@ endef
 define Build/Prepare
 	$(call Build/Prepare/Default)
 	$(if $(CONFIG_NGINX_NAXSI),$(call Prepare/nginx-naxsi))
+	$(if $(CONFIG_NGINX_LUA),$(call Prepare/lua-nginx))
 endef
 
 define Download/nginx-naxsi
@@ -239,6 +251,20 @@ endef
 define  Prepare/nginx-naxsi
 	$(eval $(call Download,nginx-naxsi))
 	gzip -dc $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
+endef
+
+define Download/lua-nginx
+	VERSION:=df5bf1d6242eb5c11adf0dccb8e830dc6672e14b
+	SUBDIR:=lua-nginx
+	FILE:=lua-nginx-module-$(PKG_VERSION)-$$(VERSION).tar.gz
+	URL:=https://github.com/openresty/lua-nginx-module.git
+	PROTO:=git
+endef
+
+define  Prepare/lua-nginx
+	$(eval $(call Download,lua-nginx))
+	gzip -dc $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
+	$(call PatchDir,$(PKG_BUILD_DIR),./patches-lua-nginx)
 endef
 
 $(eval $(call BuildPackage,nginx))

--- a/net/nginx/patches-lua-nginx/100-by-lua-block.patch
+++ b/net/nginx/patches-lua-nginx/100-by-lua-block.patch
@@ -1,0 +1,195 @@
+--- a/lua-nginx/src/ngx_http_lua_module.c
++++ b/lua-nginx/src/ngx_http_lua_module.c
+@@ -150,14 +150,14 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       offsetof(ngx_http_lua_loc_conf_t, log_socket_errors),
+       NULL },
+-
++#ifndef NGX_LUA_NO_BY_LUA_BLOCK
+     { ngx_string("init_by_lua_block"),
+       NGX_HTTP_MAIN_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS,
+       ngx_http_lua_init_by_lua_block,
+       NGX_HTTP_MAIN_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_init_by_inline },
+-
++#endif
+     { ngx_string("init_by_lua"),
+       NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+       ngx_http_lua_init_by_lua,
+@@ -171,14 +171,14 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_MAIN_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_init_by_file },
+-
++#ifndef NGX_LUA_NO_BY_LUA_BLOCK
+     { ngx_string("init_worker_by_lua_block"),
+       NGX_HTTP_MAIN_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS,
+       ngx_http_lua_init_worker_by_lua_block,
+       NGX_HTTP_MAIN_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_init_worker_by_inline },
+-
++#endif
+     { ngx_string("init_worker_by_lua"),
+       NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+       ngx_http_lua_init_worker_by_lua,
+@@ -194,6 +194,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       (void *) ngx_http_lua_init_worker_by_file },
+ 
+ #if defined(NDK) && NDK
++#ifndef NGX_LUA_NO_BY_LUA_BLOCK
+     /* set_by_lua $res { inline Lua code } [$arg1 [$arg2 [...]]] */
+     { ngx_string("set_by_lua_block"),
+       NGX_HTTP_SRV_CONF|NGX_HTTP_SIF_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+@@ -202,7 +203,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_filter_set_by_lua_inline },
+-
++#endif
+     /* set_by_lua $res <inline script> [$arg1 [$arg2 [...]]] */
+     { ngx_string("set_by_lua"),
+       NGX_HTTP_SRV_CONF|NGX_HTTP_SIF_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+@@ -230,7 +231,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_rewrite_handler_inline },
+-
++#ifndef NGX_LUA_NO_BY_LUA_BLOCK
+     /* rewrite_by_lua_block { <inline script> } */
+     { ngx_string("rewrite_by_lua_block"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+@@ -239,7 +240,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_rewrite_handler_inline },
+-
++#endif
+     /* access_by_lua "<inline script>" */
+     { ngx_string("access_by_lua"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+@@ -248,7 +249,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_access_handler_inline },
+-
++#ifndef NGX_LUA_NO_BY_LUA_BLOCK
+     /* access_by_lua_block { <inline script> } */
+     { ngx_string("access_by_lua_block"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+@@ -257,7 +258,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_access_handler_inline },
+-
++#endif
+     /* content_by_lua "<inline script>" */
+     { ngx_string("content_by_lua"),
+       NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_TAKE1,
+@@ -265,7 +266,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_content_handler_inline },
+-
++#ifndef NGX_LUA_NO_BY_LUA_BLOCK
+     /* content_by_lua_block { <inline script> } */
+     { ngx_string("content_by_lua_block"),
+       NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS,
+@@ -273,7 +274,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_content_handler_inline },
+-
++#endif
+     /* log_by_lua <inline script> */
+     { ngx_string("log_by_lua"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+@@ -282,7 +283,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_log_handler_inline },
+-
++#ifndef NGX_LUA_NO_BY_LUA_BLOCK
+     /* log_by_lua_block { <inline script> } */
+     { ngx_string("log_by_lua_block"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+@@ -291,7 +292,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_log_handler_inline },
+-
++#endif
+     { ngx_string("rewrite_by_lua_file"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+                         |NGX_CONF_TAKE1,
+@@ -346,7 +347,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_header_filter_inline },
+-
++#ifndef NGX_LUA_NO_BY_LUA_BLOCK
+     /* header_filter_by_lua_block { <inline script> } */
+     { ngx_string("header_filter_by_lua_block"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+@@ -355,7 +356,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_header_filter_inline },
+-
++#endif
+     { ngx_string("header_filter_by_lua_file"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+                         |NGX_CONF_TAKE1,
+@@ -371,7 +372,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_body_filter_inline },
+-
++#ifndef NGX_LUA_NO_BY_LUA_BLOCK
+     /* body_filter_by_lua_block { <inline script> } */
+     { ngx_string("body_filter_by_lua_block"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+@@ -380,7 +381,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_body_filter_inline },
+-
++#endif
+     { ngx_string("body_filter_by_lua_file"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
+                         |NGX_CONF_TAKE1,
+@@ -388,14 +389,14 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_body_filter_file },
+-
++#ifndef NGX_LUA_NO_BY_LUA_BLOCK
+     { ngx_string("balancer_by_lua_block"),
+       NGX_HTTP_UPS_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS,
+       ngx_http_lua_balancer_by_lua_block,
+       NGX_HTTP_SRV_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_balancer_handler_inline },
+-
++#endif
+     { ngx_string("balancer_by_lua_file"),
+       NGX_HTTP_UPS_CONF|NGX_CONF_TAKE1,
+       ngx_http_lua_balancer_by_lua,
+@@ -502,14 +503,14 @@ static ngx_command_t ngx_http_lua_cmds[]
+       NGX_HTTP_LOC_CONF_OFFSET,
+       offsetof(ngx_http_lua_loc_conf_t, ssl_ciphers),
+       NULL },
+-
++#ifndef NGX_LUA_NO_BY_LUA_BLOCK
+     { ngx_string("ssl_certificate_by_lua_block"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS,
+       ngx_http_lua_ssl_cert_by_lua_block,
+       NGX_HTTP_SRV_CONF_OFFSET,
+       0,
+       (void *) ngx_http_lua_ssl_cert_handler_inline },
+-
++#endif
+     { ngx_string("ssl_certificate_by_lua_file"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
+       ngx_http_lua_ssl_cert_by_lua,

--- a/net/nginx/patches/101-feature_test_fix.patch
+++ b/net/nginx/patches/101-feature_test_fix.patch
@@ -11,7 +11,7 @@
      ngx_feature_libs=
 --- a/auto/cc/conf
 +++ b/auto/cc/conf
-@@ -178,7 +178,7 @@ if [ "$NGX_PLATFORM" != win32 ]; then
+@@ -200,7 +200,7 @@ if [ "$NGX_PLATFORM" != win32 ]; then
      else
          ngx_feature="C99 variadic macros"
          ngx_feature_name="NGX_HAVE_C99_VARIADIC_MACROS"
@@ -20,7 +20,7 @@
          ngx_feature_incs="#include <stdio.h>
  #define var(dummy, ...)  sprintf(__VA_ARGS__)"
          ngx_feature_path=
-@@ -192,7 +192,7 @@ if [ "$NGX_PLATFORM" != win32 ]; then
+@@ -214,7 +214,7 @@ if [ "$NGX_PLATFORM" != win32 ]; then
  
      ngx_feature="gcc variadic macros"
      ngx_feature_name="NGX_HAVE_GCC_VARIADIC_MACROS"
@@ -69,7 +69,7 @@
  ngx_feature_libs=
 --- a/auto/unix
 +++ b/auto/unix
-@@ -678,7 +678,7 @@ ngx_feature_test="void *p; p = memalign(
+@@ -735,7 +735,7 @@ ngx_feature_test="void *p; p = memalign(
  
  ngx_feature="mmap(MAP_ANON|MAP_SHARED)"
  ngx_feature_name="NGX_HAVE_MAP_ANON"
@@ -78,7 +78,7 @@
  ngx_feature_incs="#include <sys/mman.h>"
  ngx_feature_path=
  ngx_feature_libs=
-@@ -691,7 +691,7 @@ ngx_feature_test="void *p;
+@@ -748,7 +748,7 @@ ngx_feature_test="void *p;
  
  ngx_feature='mmap("/dev/zero", MAP_SHARED)'
  ngx_feature_name="NGX_HAVE_MAP_DEVZERO"
@@ -87,7 +87,7 @@
  ngx_feature_incs="#include <sys/mman.h>
                    #include <sys/stat.h>
                    #include <fcntl.h>"
-@@ -706,7 +706,7 @@ ngx_feature_test='void *p; int  fd;
+@@ -763,7 +763,7 @@ ngx_feature_test='void *p; int  fd;
  
  ngx_feature="System V shared memory"
  ngx_feature_name="NGX_HAVE_SYSVSHM"
@@ -96,7 +96,7 @@
  ngx_feature_incs="#include <sys/ipc.h>
                    #include <sys/shm.h>"
  ngx_feature_path=
-@@ -720,7 +720,7 @@ ngx_feature_test="int  id;
+@@ -777,7 +777,7 @@ ngx_feature_test="int  id;
  
  ngx_feature="POSIX semaphores"
  ngx_feature_name="NGX_HAVE_POSIX_SEM"

--- a/net/nginx/patches/102-sizeof_test_fix.patch
+++ b/net/nginx/patches/102-sizeof_test_fix.patch
@@ -1,6 +1,6 @@
 --- a/auto/types/sizeof
 +++ b/auto/types/sizeof
-@@ -25,8 +25,13 @@ $NGX_INCLUDE_UNISTD_H
+@@ -25,8 +25,14 @@ $NGX_INCLUDE_UNISTD_H
  $NGX_INCLUDE_INTTYPES_H
  $NGX_INCLUDE_AUTO_CONFIG_H
  
@@ -12,6 +12,7 @@
 +
  int main() {
 -    printf("%d", (int) sizeof($ngx_type));
++    printf("dummy use of object_code_block to avoid gc-section: %c", object_code_block[0]);
      return 0;
  }
  

--- a/net/nginx/patches/300-max-processes.patch
+++ b/net/nginx/patches/300-max-processes.patch
@@ -1,0 +1,11 @@
+--- a/src/os/unix/ngx_process.h
++++ b/src/os/unix/ngx_process.h
+@@ -44,7 +44,7 @@ typedef struct {
+ } ngx_exec_ctx_t;
+ 
+ 
+-#define NGX_MAX_PROCESSES         1024
++#define NGX_MAX_PROCESSES         8
+ 
+ #define NGX_PROCESS_NORESPAWN     -1
+ #define NGX_PROCESS_JUST_SPAWN    -2


### PR DESCRIPTION
This PR updates nginx to the recently released 1.10.0 (stable branch). It also adds the Lua module. Additionally some tweaks and patches are done to reduce the binary size.
This obsoletes #2101.

Signed-off-by: Dirk Feytons <dirk.feytons@gmail.com>