### PR TITLE
luabitop: correct dependency

### DIFF
--- a/lang/luabitop/Makefile
+++ b/lang/luabitop/Makefile
@@ -28,7 +28,7 @@ define Package/luabitop
   CATEGORY:=Languages
   TITLE:=luabitop
   URL:=http://bitop.luajit.org/
-  DEPENDS:=+lua
+  DEPENDS:=+liblua
 endef
 
 define Package/luabitop/description


### PR DESCRIPTION
Just a small correction: the package should depend on `liblua`, not `lua` (which is the interpreter).

Signed-off-by: Dirk Feytons <dirk.feytons@gmail.com>