### PR TITLE
utils/watchcat: Fix some typos (mostly found by codespell)

### DIFF
--- a/utils/watchcat/files/initd_watchcat
+++ b/utils/watchcat/files/initd_watchcat
@@ -25,10 +25,13 @@ timetoseconds() {
 
 load_watchcat() {
 	config_get period	$1 period
-	config_get mode		$1 mode		"allways"
+	config_get mode		$1 mode		"always"
 	config_get pinghosts	$1 pinghosts	"8.8.8.8"
 	config_get pingperiod	$1 pingperiod
 	config_get forcedelay	$1 forcedelay	"0"
+
+	# Fix potential typo in mode (backward compatibility).
+	[ "$mode" = "allways" ] && mode="always"
 
 	error=""
 
@@ -36,9 +39,9 @@ load_watchcat() {
 	period="$seconds"
 	[ "$period" -ge 1 ] \
 		|| append_string "error" 'period is not a valid time value (ex: "30"; "4m"; "6h"; "2d")' "; "
-	[ "$mode" = "allways" -o "$mode" = "ping" ] \
-		|| append_string "error" "mode must be 'allways' or 'ping'" "; "
-	[ -n "$pinghosts" -o "$mode" = "allways" ] \
+	[ "$mode" = "always" -o "$mode" = "ping" ] \
+		|| append_string "error" "mode must be 'always' or 'ping'" "; "
+	[ -n "$pinghosts" -o "$mode" = "always" ] \
 		|| append_string "error" "pinghosts must be set when in 'ping' mode" "; "
 	[ "$mode" = "ping" ] && {
 		if [ -n "$pingperiod" ]
@@ -56,20 +59,20 @@ load_watchcat() {
 			pingperiod="$((period/20))"
 		fi
 	}
-	[ "$pingperiod" -lt "$period" -o "$mode" = "allways" ] \
+	[ "$pingperiod" -lt "$period" -o "$mode" = "always" ] \
 		|| append_string "error" "pingperiod is not recognized" "; "
 	[ "$forcedelay" -ge 0 ] \
 		|| append_string "error" "forcedelay must be a integer greater or equal than 0, where 0 means disabled" "; "
 
 	[ -n "$error" ] && { logger -p user.err -t "watchcat" "reboot program $1 not started - $error"; return; }
 
-	if [ "$mode" = "allways" ]
+	if [ "$mode" = "always" ]
 	then
-		/usr/bin/watchcat.sh "allways" "$period" "$forcedelay" &
-		logger -p user.info -t "wathchat" "started task (mode=$mode;period=$period;forcedelay=$forcedelay)" 
+		/usr/bin/watchcat.sh "always" "$period" "$forcedelay" &
+		logger -p user.info -t "watchcat" "started task (mode=$mode;period=$period;forcedelay=$forcedelay)"
 	else
 		/usr/bin/watchcat.sh "period" "$period" "$forcedelay" "$pinghosts" "$pingperiod" &
-		logger -p user.info -t "wathchat" "started task (mode=$mode;period=$period;pinghosts=$pinghosts;pingperiod=$pingperiod;forcedelay=$forcedelay)" 
+		logger -p user.info -t "watchcat" "started task (mode=$mode;period=$period;pinghosts=$pinghosts;pingperiod=$pingperiod;forcedelay=$forcedelay)"
 	fi
 
 	echo $! >> "${PIDFILE}.pids"

--- a/utils/watchcat/files/watchcat.sh
+++ b/utils/watchcat/files/watchcat.sh
@@ -7,6 +7,9 @@
 
 mode="$1"
 
+# Fix potential typo in mode (backward compatibility).
+[ "$mode" = "allways" ] && mode="always"
+
 shutdown_now() {
 	local forcedelay="$1"
 
@@ -19,7 +22,7 @@ shutdown_now() {
 	}
 }
 
-watchcat_allways() {
+watchcat_always() {
 	local period="$1"; local forcedelay="$2"
 
 	sleep "$period" && shutdown_now "$forcedelay"
@@ -66,9 +69,9 @@ watchcat_ping() {
 	done
 }
 
-	if [ "$mode" = "allways" ]
+	if [ "$mode" = "always" ]
 	then
-		watchcat_allways "$2" "$3"
+		watchcat_always "$2" "$3"
 	else
 		watchcat_ping "$2" "$3" "$4" "$5"
 	fi


### PR DESCRIPTION
Note that this implies an API change (allways -> always).
The wrong spelling "allways" is still accepted for backward compatibility.

Signed-off-by: Stefan Weil <sw@weilnetz.de>