### PR TITLE
libffi: do not append multilib suffix (eg. '../lib64') to toolexeclibdir

### DIFF
--- a/libs/libffi/Makefile
+++ b/libs/libffi/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2012 OpenWrt.org
+# Copyright (C) 2009-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libffi
 PKG_VERSION:=3.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://sourceware.org/pub/libffi/

--- a/libs/libffi/patches/002-fix-toolexeclibdir-path.patch
+++ b/libs/libffi/patches/002-fix-toolexeclibdir-path.patch
@@ -1,0 +1,31 @@
+diff -rupN libffi-3.2.1.orig/configure libffi-3.2.1/configure
+--- libffi-3.2.1.orig/configure	2014-11-12 12:59:57.000000000 +0100
++++ libffi-3.2.1/configure	2016-05-11 17:14:58.606625260 +0200
+@@ -18725,12 +18725,6 @@ if test "x$GCC" = "xyes"; then
+     toolexecdir="${libdir}"/gcc-lib/'$(target_alias)'
+     toolexeclibdir="${libdir}"
+   fi
+-  multi_os_directory=`$CC $CFLAGS -print-multi-os-directory`
+-  case $multi_os_directory in
+-    .) ;; # Avoid trailing /.
+-    ../*) toolexeclibdir=$toolexeclibdir/$multi_os_directory ;;
+-  esac
+-
+ else
+   toolexeclibdir="${libdir}"
+ fi
+diff -rupN libffi-3.2.1.orig/configure.ac libffi-3.2.1/configure.ac
+--- libffi-3.2.1.orig/configure.ac	2014-11-12 12:56:51.000000000 +0100
++++ libffi-3.2.1/configure.ac	2016-05-11 17:15:19.694626266 +0200
+@@ -601,11 +601,6 @@ if test "x$GCC" = "xyes"; then
+     toolexecdir="${libdir}"/gcc-lib/'$(target_alias)'
+     toolexeclibdir="${libdir}"
+   fi
+-  multi_os_directory=`$CC $CFLAGS -print-multi-os-directory`
+-  case $multi_os_directory in
+-    .) ;; # Avoid trailing /.
+-    ../*) toolexeclibdir=$toolexeclibdir/$multi_os_directory ;;
+-  esac
+   AC_SUBST(toolexecdir)
+ else
+   toolexeclibdir="${libdir}"


### PR DESCRIPTION
The configure script appends the multilib suffix to toolexeclibdir while doing a host build resulting in libraries installed to a location not exported by default.

Another approach would be to replace $(STAGING_DIR)/host/lib64 with a symlink but I'm unsure how to do that properly.