### PR TITLE
Https dns proxy

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -1,0 +1,32 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=https_dns_proxy
+PKG_VERSION:=2016-06-19
+PKG_RELEASE=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_URL=https://github.com/aarond10/https_dns_proxy/
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=d50f78c7c2e9d7016ad5297e4cb0ab9e7d223a0d
+PKG_MAINTAINER:=Aaron Drew <aarond10@gmail.com>
+PKG_LICENSE:=MIT
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/https_dns_proxy
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=DNS over HTTPS proxy server
+  DEPENDS:=+libcares +libcurl +libev
+endef
+
+define Package/https_dns_proxy/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/init.d ${1}/etc/config
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/https_dns_proxy $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/https_dns_proxy.init $(1)/etc/init.d/https_dns_proxy
+	$(INSTALL_CONF) ./files/https_dns_proxy.config $(1)/etc/config/https_dns_proxy
+endef
+
+$(eval $(call BuildPackage,https_dns_proxy))

--- a/net/https-dns-proxy/files/https_dns_proxy.config
+++ b/net/https-dns-proxy/files/https_dns_proxy.config
@@ -1,0 +1,5 @@
+config https_dns_proxy
+	option listen_addr '127.0.0.1'
+	option listen_port '5053'
+	option user 'nobody'
+	option group 'nogroup'

--- a/net/https-dns-proxy/files/https_dns_proxy.init
+++ b/net/https-dns-proxy/files/https_dns_proxy.init
@@ -1,0 +1,32 @@
+#!/bin/sh /etc/rc.common
+
+START=80
+
+USE_PROCD=1
+PROG=/usr/sbin/https_dns_proxy
+
+start_instance() {
+	local cfg="$1"
+	local listen_addr listen_port user group
+
+	config_get listen_addr "$cfg" listen_addr
+	config_get listen_port "$cfg" listen_port
+	config_get user "$cfg" user
+	config_get group "$cfg" group
+
+	procd_open_instance
+	procd_set_param command ${PROG} \
+		-l "$listen_addr" -p "$listen_port" \
+		-u "$user" -g "$group"
+	procd_set_param respawn
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger "https_dns_proxy"
+}
+
+start_service() {
+	config_load 'https_dns_proxy'
+	config_foreach start_instance 'https_dns_proxy'
+}


### PR DESCRIPTION
Add a package for a proxy that lets you use Google's DNS over HTTPS (I'm the author).

Signed-off-by: Aaron Drew <aarond10@gmail.com>