### PR TITLE
libmicrohttpd: don't use PROVIDES for non-virtual package

### DIFF
--- a/libs/libmicrohttpd/Makefile
+++ b/libs/libmicrohttpd/Makefile
@@ -45,7 +45,6 @@ $(call Package/libmicrohttpd/Default)
    TITLE+=(no-ssl)
    DEPENDS:=+libpthread
    VARIANT:=no-ssl
-   PROVIDES:=libmicrohttpd
    CONFLICTS:=libmicrohttpd
 endef
 


### PR DESCRIPTION
Using PROVIDES for packages actually existing breaks dependency resolution due to the PROVIDES feature being somehow broken in OpenWrt.
Maybe there should be 3 variants of libmicrohttpd:
libmicrohttp-nossl
libmicrohttp-openssl
libmicrohttp-gnutls
All 3 should provide libmicrohttpd.
However, for now the use of PROVIDES just makes all packages originally depending on libmicrohttpd depend on libmicrohttpd-no-ssl instead which is not the intended outcome. Until a proper fix is found, remove PROVIDES package variable to unbreak stuff for now.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>