### PR TITLE
keepalived: fix mips64

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=1.2.16
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= http://www.keepalived.org/software

--- a/net/keepalived/patches/101-update-struct-msghdr.patch
+++ b/net/keepalived/patches/101-update-struct-msghdr.patch
@@ -1,0 +1,43 @@
+From 0fc8dfa7ef479220b2a27901c5c69add6e13debd Mon Sep 17 00:00:00 2001
+From: Stijn Tintel <stijn@linux-ipv6.be>
+Date: Tue, 10 May 2016 04:26:31 +0300
+Subject: [PATCH] vrrp: update struct msghdr
+
+The vrrp netlink code assumes an order for the members of struct msghdr.
+This breaks recvmsg and sendmsg with musl libc on mips64. Fix this by
+using designated initializers instead.
+---
+ keepalived/vrrp/vrrp_netlink.c | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
+
+--- a/keepalived/vrrp/vrrp_netlink.c
++++ b/keepalived/vrrp/vrrp_netlink.c
+@@ -276,8 +276,12 @@ netlink_parse_info(int (*filter) (struct
+		char buf[4096];
+		struct iovec iov = { buf, sizeof buf };
+		struct sockaddr_nl snl;
+-		struct msghdr msg =
+-		    { (void *) &snl, sizeof snl, &iov, 1, NULL, 0, 0 };
++		struct msghdr msg = {
++			.msg_name = &snl,
++			.msg_namelen = sizeof(snl),
++			.msg_iov = &iov,
++			.msg_iovlen = 1,
++		};
+		struct nlmsghdr *h;
+
+		status = recvmsg(nl->fd, &msg, 0);
+@@ -386,7 +390,12 @@ netlink_talk(nl_handle_t *nl, struct nlm
+	int ret, flags;
+	struct sockaddr_nl snl;
+	struct iovec iov = { (void *) n, n->nlmsg_len };
+-	struct msghdr msg = { (void *) &snl, sizeof snl, &iov, 1, NULL, 0, 0 };
++	struct msghdr msg = {
++		.msg_name = &snl,
++		.msg_namelen = sizeof(snl),
++		.msg_iov = &iov,
++		.msg_iovlen = 1,
++	};
+
+	memset(&snl, 0, sizeof snl);
+	snl.nl_family = AF_NETLINK;


### PR DESCRIPTION
Fix recvmsg/sendmsg on mips64

The latest version of keepalived adds extra dependencies and seems to have a deadlock (seen on x86_64 and mips64), so I have not included that yet.