### PR TITLE
nginx: change start level to 80

### DIFF
--- a/net/nginx/files/nginx.init
+++ b/net/nginx/files/nginx.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2015 OpenWrt.org
 
-START=50
+START=80
 
 USE_PROCD=1
 


### PR DESCRIPTION
I consider nginx as somewhat lower priority so move it back in the startup sequence.
@heil: what's your view/experience? I couldn't find any guidelines on choosing start levels. For us the current value of 50 is a bit too early; my choice of 80 works for us but it's still a bit arbitrary.

Signed-off-by: Dirk Feytons <dirk.feytons@gmail.com>