### PR TITLE
nano: fix ncurses issue

### DIFF
--- a/utils/nano/Makefile
+++ b/utils/nano/Makefile
@@ -43,6 +43,7 @@ CONFIGURE_ARGS += \
 	--disable-utf8 \
         --without-slang \
         --disable-color \
+	LIBS="-lncurses -ltinfo" \
 
 CONFIGURE_VARS += \
 	ac_cv_header_regex_h=no \


### PR DESCRIPTION
fix nano compile error.

`bin/ld: nano.o: undefined reference to symbol 'keypad'`

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>