### PR TITLE
net/vnstat: Make data directory an uci option

### DIFF
--- a/net/vnstat/Makefile
+++ b/net/vnstat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vnstat
 PKG_VERSION:=1.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://humdi.net/vnstat
@@ -86,13 +86,14 @@ define Package/vnstat/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/vnstatd $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc
-	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/vnstat.conf $(1)/etc/
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/vnstat.conf $(1)/etc/vnstat.conf.template
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/vnstat.config $(1)/etc/config/vnstat
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/vnstat.init $(1)/etc/init.d/vnstat
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/vnstat.defaults $(1)/etc/uci-defaults/vnstat
+	ln -sf /var/etc/vnstat.conf $(1)/etc/vnstat.conf
 endef
 
 define Package/vnstati/install

--- a/net/vnstat/files/vnstat.conf.template
+++ b/net/vnstat/files/vnstat.conf.template
@@ -1,0 +1,141 @@
+# vnStat 1.12 config file
+##
+
+# default interface
+Interface "eth0"
+
+# location of the database directory
+DatabaseDir "/tmp/vnstat"
+
+# locale (LC_ALL) ("-" = use system locale)
+Locale "-"
+
+# on which day should months change
+MonthRotate 1
+
+# date output formats for -d, -m, -t and -w
+# see 'man date' for control codes
+DayFormat    "%x"
+MonthFormat  "%b '%y"
+TopFormat    "%x"
+
+# characters used for visuals
+RXCharacter       "%"
+TXCharacter       ":"
+RXHourCharacter   "r"
+TXHourCharacter   "t"
+
+# how units are prefixed when traffic is shown
+# 0 = IEC standard prefixes (KiB/MiB/GiB/TiB)
+# 1 = old style binary prefixes (KB/MB/GB/TB)
+UnitMode 0
+
+# output style
+# 0 = minimal & narrow, 1 = bar column visible
+# 2 = same as 1 except rate in summary and weekly
+# 3 = rate column visible
+OutputStyle 3
+
+# used rate unit (0 = bytes, 1 = bits)
+RateUnit 1
+
+# maximum bandwidth (Mbit) for all interfaces, 0 = disable feature
+# (unless interface specific limit is given)
+MaxBandwidth 100
+
+# interface specific limits
+#  example 8Mbit limit for 'ethnone':
+MaxBWethnone 8
+
+# how many seconds should sampling for -tr take by default
+Sampletime 5
+
+# default query mode
+# 0 = normal, 1 = days, 2 = months, 3 = top10
+# 4 = exportdb, 5 = short, 6 = weeks, 7 = hours
+QueryMode 0
+
+# filesystem disk space check (1 = enabled, 0 = disabled)
+CheckDiskSpace 1
+
+# database file locking (1 = enabled, 0 = disabled)
+UseFileLocking 1
+
+# how much the boot time can variate between updates (seconds)
+BootVariation 15
+
+# log days without traffic to daily list (1 = enabled, 0 = disabled)
+TrafficlessDays 1
+
+
+# vnstatd
+##
+
+# switch to given user when started as root (leave empty to disable)
+DaemonUser ""
+
+# switch to given user when started as root (leave empty to disable)
+DaemonGroup ""
+
+# how often (in seconds) interface data is updated
+UpdateInterval 60
+
+# how often (in seconds) interface status changes are checked
+PollInterval 30
+
+# how often (in minutes) data is saved to file
+SaveInterval 30
+
+# how often (in minutes) data is saved when all interface are offline
+OfflineSaveInterval 30
+
+# force data save when interface status changes (1 = enabled, 0 = disabled)
+SaveOnStatusChange 1
+
+# enable / disable logging (0 = disabled, 1 = logfile, 2 = syslog)
+UseLogging 2
+
+# create dirs if needed (1 = enabled, 0 = disabled)
+CreateDirs 1
+
+# update ownership of files if needed (1 = enabled, 0 = disabled)
+UpdateFileOwner 1
+
+# file used for logging if UseLogging is set to 1
+LogFile "/var/log/vnstat/vnstat.log"
+
+# file used as daemon pid / lock file
+PidFile "/var/run/vnstat/vnstat.pid"
+
+
+# vnstati
+##
+
+# title timestamp format
+HeaderFormat "%x %H:%M"
+
+# show hours with rate (1 = enabled, 0 = disabled)
+HourlyRate 1
+
+# show rate in summary (1 = enabled, 0 = disabled)
+SummaryRate 1
+
+# layout of summary (1 = with monthly, 0 = without monthly)
+SummaryLayout 1
+
+# transparent background (1 = enabled, 0 = disabled)
+TransparentBg 0
+
+# image colors
+CBackground     "FFFFFF"
+CEdge           "AEAEAE"
+CHeader         "606060"
+CHeaderTitle    "FFFFFF"
+CHeaderDate     "FFFFFF"
+CText           "000000"
+CLine           "B0B0B0"
+CLineL          "-"
+CRx             "92CF00"
+CTx             "606060"
+CRxD            "-"
+CTxD            "-"

--- a/net/vnstat/files/vnstat.init
+++ b/net/vnstat/files/vnstat.init
@@ -5,7 +5,12 @@ START=99
 
 vnstat_option() {
 	sed -ne "s/^[[:space:]]*$1[[:space:]]*['\"]\([^'\"]*\)['\"].*/\1/p" \
-		/etc/vnstat.conf
+		/var/etc/vnstat.conf
+}
+
+vnstat_set_option() {
+	sed -i -e "s,^[[:space:]]*$1[[:space:]]*['\"][^'\"]*['\"]\(.*\)$,$1 \"$2\"\1," \
+		/var/etc/vnstat.conf
 }
 
 start() {
@@ -22,11 +27,21 @@ start() {
 		exit 1
 	}
 
-	mkdir -p "$lib"
 
 	init_ifaces() {
 		local cfg="$1"
-		local url lnk
+		local url lnk datadir
+
+		config_get datadir "$cfg" datadir
+
+		if [ -n "$datadir" ]; then
+			if [ "$lib" != "$datadir" ]; then
+				vnstat_set_option DatabaseDir $datadir
+				lib=$datadir
+			fi
+		fi
+
+		mkdir -p "$lib"
 
 		init_iface() {
 			local ifn="$1"
@@ -61,6 +76,9 @@ start() {
 
 		return 1
 	}
+
+	mkdir -p /var/etc
+	/bin/cp /etc/vnstat.conf.template /var/etc/vnstat.conf
 
 	config_load vnstat
 	config_foreach init_ifaces vnstat


### PR DESCRIPTION
Being able to alter the config for the data directory via LuCI
would be useful, therefore add UCI option to data set datadir

Signed-off-by: Daniel Dickinson openwrt@daniel.thecshore.com
