### PR TITLE
lang/perl-cgi: Fix missing file for perl-cgi

### DIFF
--- a/lang/perl-cgi/Makefile
+++ b/lang/perl-cgi/Makefile
@@ -41,7 +41,7 @@ define Build/Compile
 endef
 
 define Package/perl-cgi/install
-        $(call perlmod/Install,$(1),CGI auto/CGI)
+        $(call perlmod/Install,$(1),CGI CGI.pm auto/CGI)
 endef
 
 


### PR DESCRIPTION
Perl CGI fails to copy CGI.pm to package and therefore
perl programs and modules depend on CGI module fail.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>