### PR TITLE
net/netdiscover: Download from SourceForge not unreliable site

### DIFF
--- a/net/netdiscover/Makefile
+++ b/net/netdiscover/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=0.3-pre-beta7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-LINUXONLY.tar.gz
-PKG_SOURCE_URL:=http://nixgeneration.com/~jaime/netdiscover/releases/
+PKG_SOURCE_URL:=@SF/netdiscover
 PKG_MD5SUM:=8780e66d00496e933b4064cfe9ae61da
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 PKG_LICENSE:=GPL-2.0
@@ -27,7 +27,7 @@ define Package/netdiscover
   CATEGORY:=Network
   DEPENDS:=+libpcap +libnet-1.2.x +libpthread
   TITLE:=An active/passive address reconnaissance tool
-  URL:=http://nixgeneration.com/~jaime/netdiscover/
+  URL:=https://sourceforge.net/projects/netdiscover
 endef
 
 CONFIGURE_VARS+= \


### PR DESCRIPTION
The most recent developer of netdiscover had self-hosted downloads
but also put the project on SourceForge.  The self-hosted site went
down but SourceForge is much more reliable so I have moved the
download URI to SourceForge (md5sum is the same).

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>