### PR TITLE
usbip: mark as nonshared

### DIFF
--- a/net/usbip/Makefile
+++ b/net/usbip/Makefile
@@ -33,6 +33,7 @@ Hooks/Prepare/Pre += prepare_source_directory
 PKG_BUILD_DEPENDS:=eudev
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_FLAGS:=nonshared
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk


### PR DESCRIPTION
Mark the usbip package nonshared so that is built along with the target
specific binaries and not within the SDK environment.

This is needed since the usbip package draws its source files directly
from the kernel tree which is unavailable within the SDK.

Fixes the following build error encountered by the LEDE buildbots:
http://downloads.lede-project.org/snapshots/faillogs/mipsel_1004kc_dsp/packages/usbip/compile.txt

Signed-off-by: Jo-Philipp Wich <jo@mein.io>