### PR TITLE
glib2: make libiconv dependent on ICONV_FULL variable

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -46,7 +46,7 @@ endef
 
 HOST_CONFIGURE_ARGS += \
 	--disable-selinux \
-	--with-libiconv=gnu \
+	$(if $(ICONV_FULL),--with-libiconv=gnu)
 	--with-pcre=internal
 
 CONFIGURE_ARGS += \
@@ -55,7 +55,7 @@ CONFIGURE_ARGS += \
 	--enable-debug=no \
 	--disable-selinux \
 	--disable-fam \
-	--with-libiconv=gnu \
+	$(if $(ICONV_FULL),--with-libiconv=gnu)
 	--with-pcre=internal
 
 CONFIGURE_VARS += \


### PR DESCRIPTION
glib2 does not compile because it assumes that full language support is enabled by default. 
This fix ensures that glib2 compiles if full language is disabled. 
