### PR TITLE
openconnect: avoid possible implicit dependency on liblz4

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=7.06
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -50,7 +50,8 @@ CONFIGURE_ARGS += \
 	--disable-shared \
 	--with-vpnc-script=/lib/netifd/vpnc-script \
 	--without-libpcsclite \
-	--without-stoken
+	--without-stoken \
+	--without-lz4
 
 ifeq ($(CONFIG_OPENCONNECT_OPENSSL),y)
 CONFIGURE_ARGS += \


### PR DESCRIPTION
If the liblz4 library exists within the build environment, the openconnect
configure will pick it up and start depending on it, leading to the following
build error:

    Package openconnect is missing dependencies for the following libraries:
    liblz4.so.1

Disable LZ4 support in configure in order to avoid this implicit,
nondeterministic dependency.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>