### PR TITLE
mc: apply gettext version fixup

### DIFF
--- a/utils/mc/Makefile
+++ b/utils/mc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mc
 PKG_VERSION:=4.8.17
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 PKG_LICENSE:=GPL-3.0+
 
@@ -17,7 +17,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://ftp.midnight-commander.org/
 PKG_SHA256SUM:=0447bdddc0baa81866e66f50f9a545d29d6eebb68b0ab46c98d8fddd2bf4e44d
 PKG_BUILD_PARALLEL:=1
-PKG_FIXUP:=autoreconf
+PKG_FIXUP:=autoreconf gettext-version
 
 PKG_CONFIG_DEPENDS := \
 	CONFIG_PACKAGE_MC \


### PR DESCRIPTION
Apply the version fixup in order to solve the following build error on systems
not using exactly gettext version 0.18:

    make[6]: Entering directory '.../build_dir/target-mips_34kc_musl-1.1.14/mc-4.8.17/po'
    *** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version 0.18 but the autoconf macros are from gettext version 0.19

The fixup will ensure that embedded macro versions are replaced with the
version of the staged gettext executable in ./staging_dir/host/bin

Signed-off-by: Jo-Philipp Wich <jo@mein.io>