### PR TITLE
tiff: fix wrong declaration of ftell() compat macro

### DIFF
--- a/libs/tiff/Makefile
+++ b/libs/tiff/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tiff
 PKG_VERSION:=4.0.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.osgeo.org/libtiff

--- a/libs/tiff/patches/005-fix-ftell-macro.patch
+++ b/libs/tiff/patches/005-fix-ftell-macro.patch
@@ -1,0 +1,11 @@
+--- a/libtiff/tiffiop.h
++++ b/libtiff/tiffiop.h
+@@ -284,7 +284,7 @@ struct tiff {
+ */
+ #if defined(HAVE_FSEEKO)
+ #  define fseek(stream,offset,whence)  fseeko(stream,offset,whence)
+-#  define ftell(stream,offset,whence)  ftello(stream,offset,whence)
++#  define ftell(stream)  ftello(stream)
+ #endif
+ #endif
+ #if defined(__WIN32__) && \


### PR DESCRIPTION
The libtiff library declares an `ftell()` compat macro redirecting calls
to `ftello()` if such an implementation exists. The compat macro however
is declared with a wrong number of arguments, leading to the following
error on our buildbots:

    In file included from .../usr/include/uClibc++/iostream:29:0,
                     from tif_stream.cxx:31:
    .../usr/include/uClibc++/fstream:422:22: error: macro "ftell" requires 3 arguments, but only 1 given
         retval = ftell(fp);

Add a patch to fix the macro definition in order to fix compilation of
the tiff package.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>