### PR TITLE
libnet-1.2.x: enable HAVE_PACKET_SOCKET

### DIFF
--- a/libs/libnet-1.2.x/Makefile
+++ b/libs/libnet-1.2.x/Makefile
@@ -39,7 +39,6 @@ CONFIGURE_ARGS += \
 CONFIGURE_VARS += \
 	ac_cv_libnet_endianess=$(ENDIANESS) \
 	ac_libnet_have_pf_packet=yes \
-	libnet_cv_have_packet_socket=yes \
 	LL_INT_TYPE=libnet_link_linux
 
 define Build/Configure

--- a/libs/libnet-1.2.x/Makefile
+++ b/libs/libnet-1.2.x/Makefile
@@ -39,6 +39,7 @@ CONFIGURE_ARGS += \
 CONFIGURE_VARS += \
 	ac_cv_libnet_endianess=$(ENDIANESS) \
 	ac_libnet_have_pf_packet=yes \
+	libnet_cv_have_packet_socket=yes \
 	LL_INT_TYPE=libnet_link_linux
 
 define Build/Configure


### PR DESCRIPTION
There is already a CONFIGURE_VAR set in here that seem
to have the same purpose, but it doesn't do the trick
in my case (libnet-1.2-rc3 and autoconf 2.69).