### PR TITLE
update l2tp.sh

### DIFF
--- a/net/xl2tpd/files/l2tp.sh
+++ b/net/xl2tpd/files/l2tp.sh
@@ -14,6 +14,7 @@ proto_l2tp_init_config() {
 	proto_config_add_string "keepalive"
 	proto_config_add_string "pppd_options"
 	proto_config_add_boolean "ipv6"
+	proto_config_add_int "demand"
 	proto_config_add_int "mtu"
 	proto_config_add_string "server"
 	available=1


### PR DESCRIPTION
this change is for considering demand option in l2tp.sh, demand option is not getting initialized

json_get_vars ipv6 demand keepalive username password pppd_options 

the above line in l2tp.sh fails to read demand option and whenever user changes only demand option (idle time value) xl2tp dameon is not notified.