### PR TITLE
net/wget: Remove use broken use of postrm/postinst symlinks

### DIFF
--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.18
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -87,47 +87,13 @@ endif
 define Package/wget/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/wget $(1)/usr/bin/wget-ssl
+	ln -sf wget-ssl $(1)/usr/bin/wget
 endef
 
 define Package/wget-nossl/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/wget $(1)/usr/bin/wget-nossl
-endef
-
-define Package/wget/postinst
-#!/bin/sh
-if [ -e $${IPKG_INSTROOT}/usr/bin/wget ]; then
-  rm -rf $${IPKG_INSTROOT}/usr/bin/wget;
-fi
-ln -sf ./wget-ssl $${IPKG_INSTROOT}/usr/bin/wget
-endef
-
-define Package/wget/postrm
-#!/bin/sh
-rm $${IPKG_INSTROOT}/usr/bin/wget
-[ -x $${IPKG_INSTROOT}/usr/bin/wget-nossl ] && ln -s ./wget-nossl $${IPKG_INSTROOT}/usr/bin/wget || {
-  ln -s ../../bin/busybox $${IPKG_INSTROOT}/usr/bin/wget
-  $${IPKG_INSTROOT}/usr/bin/wget 2>&1 | grep 'applet not found' > /dev/null 2>&1 && rm $${IPKG_INSTROOT}/usr/bin/wget
-}
-exit 0
-endef
-
-define Package/wget-nossl/postinst
-#!/bin/sh
-if [ -e $${IPKG_INSTROOT}/usr/bin/wget ]; then
-  rm -rf $${IPKG_INSTROOT}/usr/bin/wget;
-fi
-ln -s ./wget-nossl $${IPKG_INSTROOT}/usr/bin/wget
-endef
-
-define Package/wget-nossl/postrm
-#!/bin/sh
-rm $${IPKG_INSTROOT}/usr/bin/wget
-[ -x $${IPKG_INSTROOT}/usr/bin/wget-ssl ] && ln -s ./wget-ssl $${IPKG_INSTROOT}/usr/bin/wget || {
-  ln -s ../../bin/busybox $${IPKG_INSTROOT}/usr/bin/wget
-  $${IPKG_INSTROOT}/usr/bin/wget 2>&1 | grep 'applet not found' > /dev/null 2>&1 && rm $${IPKG_INSTROOT}/usr/bin/wget
-}
-exit 0
+	ln -sf wget-nossl $(1)/usr/bin/wget
 endef
 
 $(eval $(call BuildPackage,wget))


### PR DESCRIPTION
Symlinks in order to use full version of command vs
default version are frowned upon by openwrt/lede,
and further results in wget-ssl failing to conflict
with wget-nossl.  As mentioned in the github issue
regarding this (https://github.com/openwrt/packages/issues/2728)
it is also unnessary in current openwrt/lede.

This patch therefore fixes the wget packages to
both install to /usr/bin/wget where they will
correctly conflict with each other and be
earlier in the PATH (and therefore preferred)
compared to the uclient-fetch symlink in /bin.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>

This is labelled as an URFC (Untested Request For Comments) because I have not yet tested, but submit the PR in case someone feels the changes are straightforward enough to do their own testing and merge the PR before I get to the testing.