### PR TITLE
[URFC] Prefer full versions of commands to busybox replacements

### DIFF
--- a/devel/diffutils/Makefile
+++ b/devel/diffutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=diffutils
 PKG_VERSION:=3.3
-PKG_RELEASE:=2
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/diffutils
@@ -21,7 +21,7 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/diffutils
+define Package/diffutils/Default
   SECTION:=devel
   CATEGORY:=Development
   DEPENDS:=+USE_GLIBC:librt
@@ -29,7 +29,7 @@ define Package/diffutils
   URL:=http://www.gnu.org/software/diffutils/
 endef
 
-define Package/diffutils/description
+define Package/diffutils/description/Default
   The Diffutils package contains programs that show the differences between
   files or directories.
 endef
@@ -38,25 +38,23 @@ CONFIGURE_VARS += \
 	ac_cv_func_mempcpy=n
 TARGET_CFLAGS += --std=gnu99
 
-define Package/diffutils/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{sdiff,diff3,diff,cmp} $(1)/usr/bin/
+define GenTool
+  define Package/diffutils-$(1)
+  $(call Package/diffutils/Default)
+    TITLE+= ($1)
+  endef
+
+  define Package/diffutils-$(1)/description
+  $(call Package/diffutils/description/Default)
+  This package contains the $1 tool
+  endef
+
+  define Package/diffutils-$(1)/install
+	$(INSTALL_DIR) $$(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$(1) $$(1)/usr/bin/
+  endef
+
+  $$(eval $$(call BuildPackage,diffutils-$(1)))
 endef
 
-define Package/diffutils/preinst
-#!/bin/sh
-for x in sdiff diff3 diff cmp; do
-  [ -L "$${IPKG_INSTROOT}/usr/bin/$$x" ] && rm -f "$${IPKG_INSTROOT}/usr/bin/$$x"
-done
-exit 0
-endef
-
-define Package/diffutils/postrm
-#!/bin/sh
-for x in sdiff diff3 diff cmp; do
-  /bin/busybox $$x -h 2>&1 | grep -q BusyBox && ln -sf ../../bin/busybox /usr/bin/$$x
-done
-exit 0
-endef
-
-$(eval $(call BuildPackage,diffutils))
+$(foreach x,sdiff diff3 diff cmp,$(eval $(call GenTool,$(x))))

--- a/utils/coreutils/Makefile
+++ b/utils/coreutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coreutils
 PKG_VERSION:=8.23
-PKG_RELEASE:=1
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/coreutils
@@ -62,6 +62,65 @@ define Package/coreutils/description
  smaller.
 endef
 
+define Package/coreutils-busybox
+  $(call Package/coreutils/Default)
+  TITLE:=Select full GNU core utilities normally from busybox
+  DEPENDS:= \
++coreutils-basename \
++coreutils-cat \
++coreutils-chgrp \
++coreutils-chmod \
++coreutils-chown \
++coreutils-chroot \
++coreutils-cp \
++coreutils-cut \
++coreutils-date \
++coreutils-dd \
++coreutils-dirname \
++coreutils-du \
++coreutils-echo \
++coreutils-expr \
++coreutils-false \
++coreutils-head \
++coreutils-id \
++coreutils-ln \
++coreutils-ls \
++coreutils-md5sum \
++coreutils-mkdir \
++coreutils-mkfifo \
++coreutils-mknod \
++coreutils-mktemp \
++coreutils-mv \
++coreutils-nice \
++coreutils-printf \
++coreutils-pwd \
++coreutils-readlink \
++coreutils-rm \
++coreutils-rmdir \
++coreutils-seq \
++coreutils-sleep \
++coreutils-sort \
++coreutils-sync \
++coreutils-tail \
++coreutils-tee \
++coreutils-test \
++coreutils-touch \
++coreutils-tr \
++coreutils-true \
++coreutils-uname \
++coreutils-uniq \
++coreutils-uptime \
++coreutils-wc \
++coreutils-yes
+endef
+
+define Package/coreutils-busybox/description
+This package selects the full versions of the GNU core utilities
+for which the busybox replacments are normally used.  This may
+be useful if you want a system more compatible with a typical
+GNU/Linux system than a busybox-based system.
+endef
+
 define GenPlugin
  define Package/$(1)
    $(call Package/coreutils/Default)
@@ -112,5 +171,6 @@ define BuildPlugin
 endef
 
 $(eval $(call BuildPackage,coreutils))
+$(eval $(call BuildPackage,coreutils-busybox))
 
 $(foreach a,$(COREUTILS_APPLETS),$(eval $(call BuildPlugin,coreutils-$(a),$(a))))

--- a/utils/findutils/Makefile
+++ b/utils/findutils/Makefile
@@ -1,0 +1,83 @@
+# 
+# Copyright (C) 2006-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=findutils
+PKG_VERSION:=4.6.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
+PKG_MD5SUM:=9936aa8009438ce185bea2694a997fc1
+PKG_MAINTAINER:=Daniel Dickinson <lede@daniel.thecshore.com>
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/findutils/Default
+	TITLE:=GNU findutils
+	SECTION:=utils
+	CATEGORY:=Utilities
+endef
+
+define Package/findutils/description/Default
+Replace busybox versions of findutils with full GNU versions.
+This is normally not needed as busybox is smaller and provides
+sufficient functionality, but some users may want or need
+the full functionality of the GNU tools.
+endef
+
+define Package/findutils-find
+	$(call Package/findutils/Default)
+	TITLE+= (find)
+endef
+
+define Package/findutils-find/description
+$(call Package/findutils/description/Default)
+This package contains the find utility
+endef
+
+define Package/findutils-xargs
+	$(call Package/findutils/Default)
+	TITLE := (xargs)
+endef
+
+define Package/findutils-xargs/description
+$(call Package/findutils/description/Default)
+This package contains the xargs utility
+endef
+
+define Package/findutils-locate
+	$(call Package/findutils/Default)
+	TITLE := (locate)
+endef
+
+define Package/findutils-locate/description
+$(call Package/findutils/description/Default)
+This package contains the locate and related updatedb utility
+endef
+
+define Package/findutils-find/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/find $(1)/usr/bin/	
+endef
+
+define Package/findutils-xargs/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/xargs $(1)/usr/bin/	
+endef
+
+define Package/findutils-locate/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/locate $(1)/usr/bin/	
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/updatedb $(1)/usr/bin/	
+endef
+
+$(eval $(call BuildPackage,findutils-find))
+$(eval $(call BuildPackage,findutils-xargs))
+$(eval $(call BuildPackage,findutils-locate))

--- a/utils/findutils/Makefile
+++ b/utils/findutils/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=findutils
 PKG_VERSION:=4.6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -30,6 +30,21 @@ Replace busybox versions of findutils with full GNU versions.
 This is normally not needed as busybox is smaller and provides
 sufficient functionality, but some users may want or need
 the full functionality of the GNU tools.
+endef
+
+define Package/findutils-busybox
+	$(call Package/findutils/Default)
+	TITLE+= (replace busybox versions)
+	DEPENDS:= +findutils-find +findutils-xargs
+endef
+
+define Package/findutils-busybox/description
+$(call Package/findutils/description/Default)
+
+This package selects the findutils for which
+busybox versions are normally included, as
+convenience for those who want to replace
+busybox version with full versions.
 endef
 
 define Package/findutils-find
@@ -62,6 +77,10 @@ $(call Package/findutils/description/Default)
 This package contains the locate and related updatedb utility
 endef
 
+define Package/findutils-busybox/install
+	true
+endef
+
 define Package/findutils-find/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/find $(1)/usr/bin/	
@@ -78,6 +97,7 @@ define Package/findutils-locate/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/updatedb $(1)/usr/bin/	
 endef
 
+$(eval $(call BuildPackage,findutils-busybox)
 $(eval $(call BuildPackage,findutils-find))
 $(eval $(call BuildPackage,findutils-xargs))
 $(eval $(call BuildPackage,findutils-locate))

--- a/utils/less/Makefile
+++ b/utils/less/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=less
 PKG_VERSION:=481
-PKG_RELEASE:=1
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.greenwoodsoftware.com/less
@@ -38,12 +38,25 @@ endef
 
 define Package/less
   $(call Package/less/Default)
-  DEPENDS:=+libncurses
-  VARIANT:=narrow
+  DEPENDS:=+less-bin
 endef
 
 define Package/less/description
   $(call Package/less/Default/description)
+  This is a metapackage that depends on either full version of less.
+endef
+
+
+define Package/less-narrow
+  $(call Package/less/Default)
+  DEPENDS:=+libncurses
+  VARIANT:=narrow
+  PROVIDES:=less-bin
+endef
+
+define Package/less-narrow/description
+  $(call Package/less/Default/description)
+  This installs the non-Unicode version of less.
 endef
 
 define Package/less-wide
@@ -51,6 +64,7 @@ define Package/less-wide
   TITLE+= (Unicode)
   DEPENDS:=+libncursesw
   VARIANT:=wide
+  PROVIDES:=less-bin
 endef
 
 define Package/less-wide/description
@@ -69,25 +83,16 @@ ifeq ($(BUILD_VARIANT),wide)
 endif
 
 define Package/less/install
-	$(INSTALL_DIR) $(1)/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/less $(1)/bin/less
+	true
 endef
 
-define Package/less/postinst
-#!/bin/sh
-[ -L "$${IPKG_INSTROOT}/usr/bin/less" ] && rm -f "$${IPKG_INSTROOT}/usr/bin/less"
-exit 0
+define Package/less-narrow/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/less $(1)/usr/bin/
 endef
 
-define Package/less/postrm
-#!/bin/sh
-/bin/busybox less -h 2>&1 | grep -q BusyBox && ln -sf ../../bin/busybox /usr/bin/less
-exit 0
-endef
-
-Package/less-wide/install = $(Package/less/install)
-Package/less-wide/postinst = $(Package/less/postinst)
-Package/less-wide/postrm = $(Package/less/postrm)
+Package/less-wide/install = $(Package/less-narrow/install)
 
 $(eval $(call BuildPackage,less))
+$(eval $(call BuildPackage,less-narrow))
 $(eval $(call BuildPackage,less-wide))

--- a/utils/procps-ng/Makefile
+++ b/utils/procps-ng/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=procps-ng
 PKG_VERSION:=3.3.11
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING COPYING.LIB
 
@@ -58,6 +58,19 @@ define Package/procps-ng/description
   Conflicting applets should be removed from the build to avoid file conflicts.
 endef
 
+define Package/procps-ng-busybox
+  $(call Package/procps-ng/Default)
+  TITLE:=Prefer full versions of procps-ng commands vs busybox
+  DEPENDS:=procps-ng +procps-ng-free +procps-ng-kill +procps-ng-pgrep +procps-ng-ps +procps-ng-top
+endef
+
+define Package/procps-ng-busybox/description
+This package depends on the full versions of commands available
+from the procps-ng package for which the busybox replacements are
+normally use.  This is useful when you want to prefer or replace
+with full versions vs. busybox versions.
+endef
+
 define GenPlugin
  define Package/$(1)
    $(call Package/procps-ng/Default)
@@ -84,6 +97,10 @@ define Package/procps-ng/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libprocps.so* $(1)/usr/lib/
 endef
 
+define Package/procps-ng-busybox/install
+	true
+endef
+
 define BuildPlugin
   define Package/$(1)/install
 	$(INSTALL_DIR) $$(1)/usr/bin
@@ -95,3 +112,4 @@ endef
 
 $(foreach a,$(PROCPS_APPLETS),$(eval $(call BuildPlugin,procps-ng-$(a),$(a))))
 $(eval $(call BuildPackage,procps-ng))
+$(eval $(call BuildPackage,procps-ng-busybox))

--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vim
 PKG_VERSION:=7.4
-PKG_RELEASE:=3
+PKG_RELEASE:=5
 VIMVER:=74
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -32,13 +32,21 @@ define Package/vim/Default
 endef
 
 define Package/vim
+  $(call Pacakge/vim/Default)
+  TITLE:=Vim metapackage to select either version
+  DEPENDS:=+vim-bin
+endef
+
+define Package/vim-tiny
   $(call Package/vim/Default)
   TITLE+= (Tiny)
+  PROVIDES:=vim-bin
 endef
 
 define Package/vim-full
   $(call Package/vim/Default)
   TITLE+= (Normal)
+  PROVIDES:=vim-bin
 endef
 
 define Package/vim-runtime
@@ -69,6 +77,15 @@ define Package/vim/conffiles
 endef
 
 define Package/vim/description
+ Vim is an almost compatible version of the UNIX editor Vi.
+
+ This metapackage allows the new infrastructure for
+ completely replacing busybox versions of commands
+ with full versions to select either version of
+ vim.
+endef
+
+define Package/vim-tiny/description
  Vim is an almost compatible version of the UNIX editor Vi.
  (Tiny build)
 endef
@@ -114,8 +131,8 @@ CONFIGURE_VARS += \
 	vim_cv_tty_group=root \
 	vim_cv_tty_mode=0620
 
-ifneq ($(CONFIG_PACKAGE_vim),)
-define Build/Compile/vim
+ifneq ($(CONFIG_PACKAGE_vim-tiny),)
+define Build/Compile/vim-tiny
 	$(call Build/Configure/Default, \
 		--with-features=tiny \
 		--disable-multibyte \
@@ -153,17 +170,22 @@ define Build/Compile/vim-runtime
 endef
 
 define Build/Compile
-$(call Build/Compile/vim)
+$(call Build/Compile/vim-tiny)
 $(call Build/Compile/vim-full)
 $(call Build/Compile/vim-runtime)
 $(call Build/Compile/xxd)
 endef
 
 define Package/vim/install
+	true
+endef
+
+define Package/vim-tiny/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/vim_tiny $(1)/usr/bin/vim
 	$(INSTALL_DIR) $(1)/usr/share/vim
 	$(INSTALL_CONF) ./files/vimrc $(1)/usr/share/vim/
+	ln -sf vim $(1)/usr/bin/vi
 endef
 
 define Package/vim-full/install
@@ -171,6 +193,7 @@ define Package/vim-full/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/vim_normal $(1)/usr/bin/vim
 	$(INSTALL_DIR) $(1)/usr/share/vim
 	$(INSTALL_CONF) ./files/vimrc.full $(1)/usr/share/vim/vimrc
+	ln -sf vim $(1)/usr/bin/vi
 endef
 
 define Package/vim-runtime/install
@@ -188,6 +211,7 @@ define Package/xxd/install
 endef
 
 $(eval $(call BuildPackage,vim))
+$(eval $(call BuildPackage,vim-tiny))
 $(eval $(call BuildPackage,vim-full))
 $(eval $(call BuildPackage,vim-runtime))
 $(eval $(call BuildPackage,vim-help))


### PR DESCRIPTION
This is an Untested Request For Comments.  It is being issued so that I can reference it in the corresponding trunk PR (https://github.com/lede-project/source/pull/37), for advancing the discussion of that patch series. 

The goal of that patch series is to allow the user to build a version the firmware/rootfs (e.g. for LXC) which does not have the busybox applets compiled in, but rather uses full versions of the commands.

This patch series takes care of the applicable packages for that purpose that are in the packages feed.