### PR TITLE
node-hid: fix git submodule issue

### DIFF
--- a/lang/node-hid/Makefile
+++ b/lang/node-hid/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=hid
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=0.5.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/node-hid/node-hid.git
@@ -46,6 +46,7 @@ CPU:=$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))
 EXTRA_CFLAGS+=-I$(STAGING_DIR)/usr/include/libusb-1.0
 
 define Build/Compile
+	git init $(PKG_BUILD_DIR)
 	$(MAKE_VARS) \
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(CONFIG_ARCH) \


### PR DESCRIPTION
```
> node-hid@0.5.1 prepublish /data/bowl-builder/mips_34kc/build/sdk/build_dir/target-mips_34kc_musl-1.1.14/node-hid-0.5.1
> git submodule update --init

fatal: Not a git repository (or any parent up to mount point /data)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```
this issue

https://github.com/openwrt/packages/pull/2707

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>