### PR TITLE
utils/findutils: Add GNU findutils

### DIFF
--- a/utils/findutils/Makefile
+++ b/utils/findutils/Makefile
@@ -1,0 +1,88 @@
+# 
+# Copyright (C) 2006-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=findutils
+PKG_VERSION:=4.6.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
+PKG_MD5SUM:=9936aa8009438ce185bea2694a997fc1
+PKG_MAINTAINER:=Daniel Dickinson <lede@daniel.thecshore.com>
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/findutils/Default
+	TITLE:=GNU findutils
+	SECTION:=utils
+	CATEGORY:=Utilities
+endef
+
+define Package/findutils/description/Default
+Replace busybox versions of findutils with full GNU versions.
+This is normally not needed as busybox is smaller and provides
+sufficient functionality, but some users may want or need
+the full functionality of the GNU tools.
+endef
+
+define Package/findutils-find
+	$(call Package/findutils/Default)
+	TITLE+= (find)
+endef
+
+define Package/findutils-find/description
+$(call Package/findutils/description/Default)
+This package contains the find utility
+endef
+
+define Package/findutils-xargs
+	$(call Package/findutils/Default)
+	TITLE := (xargs)
+endef
+
+define Package/findutils-xargs/description
+$(call Package/findutils/description/Default)
+This package contains the xargs utility
+endef
+
+define Package/findutils-locate
+	$(call Package/findutils/Default)
+	TITLE := (locate)
+endef
+
+define Package/findutils-locate/description
+$(call Package/findutils/description/Default)
+This package contains the locate and related updatedb utility
+endef
+
+CONFIGURE_ARGS += --localstatedir=/srv/var
+CONFIGURE_VARS += ac_cv_path_SORT=sort
+
+define Package/findutils-find/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/find $(1)/usr/bin/	
+endef
+
+define Package/findutils-xargs/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/xargs $(1)/usr/bin/	
+endef
+
+define Package/findutils-locate/install
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/srv/var
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/locate $(1)/usr/bin/	
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/updatedb $(1)/usr/bin/	
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib $(1)/usr/
+endef
+
+$(eval $(call BuildPackage,findutils-find))
+$(eval $(call BuildPackage,findutils-xargs))
+$(eval $(call BuildPackage,findutils-locate))


### PR DESCRIPTION
While normally busybox version of findutils is enough, sometimes you want the full deal.

Here it is.

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>

This is marked as Untested Request For Comments as I have so far only compile-tested this patch, and present only for the off chance that someone with a more urgent interest wants to test it and report back before I can.