### PR TITLE
utils/config-backup: Add convenience script for backing up config

### DIFF
--- a/utils/config-backup/Makefile
+++ b/utils/config-backup/Makefile
@@ -1,0 +1,51 @@
+# Copyright 2013-2016 Daniel Dickinson <lede@daniel.thecshore.com>
+#
+# MIT License
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=config-backup
+PKG_VERSION:=1
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Daniel Dickinson <lede@daniel.thecshore.com>
+PKG_LICENSE:=MIT
+
+PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PGK_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+   SECTION:=utils
+   CATEGORY:=Utilities
+   TITLE:=Configuration backup scripts
+endef
+
+define Package/$(PKG_NAME)/description
+A small script to make backing up router configuration
+over SSH easy.  One would use a command such as
+ssh root@router "/usr/sbin/config+data-backup" >router-backup.tar.gz
+to backup the same configs as sysupgrade, plus the overlay
+and the /data directory if it exists.  One can also use
+ssh root@router "/usr/sbin/config-backup" >config-backup.tar.gz
+to backup the same things as sysupgrade or LuCI backup.
+HINT: To get a list packages try
+ssh root@router "opkg list_installed" >packages.lst
+endef
+
+define Build/Prepare
+	true
+endef
+
+define Build/Compile
+	true
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/usr/libexec/config-backup $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/usr/libexec/config-backup/* $(1)/usr/libexec/config-backup
+	$(INSTALL_BIN) ./files/usr/sbin/config-backup $(1)/usr/sbin/
+	ln -sf config-backup $(1)/usr/sbin/config+data-backup
+endef
+
+$(eval $(call BuildPackage,config-backup))
+

--- a/utils/config-backup/files/usr/libexec/config-backup/config_paths
+++ b/utils/config-backup/files/usr/libexec/config-backup/config_paths
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+filelist="$1"
+databackup="$2"
+
+sysupgrade_backup_files="$(mktemp)"
+
+# opkg stderr sent to /dev/null due to spurious warnings about
+# opkg lock
+
+( find $(sed -ne '/^[[:space:]]*$/d; /^#/d; p' \
+      /etc/sysupgrade.conf /lib/upgrade/keep.d/* 2>/dev/null) \
+      -type f 2>/dev/null;
+  opkg list-changed-conffiles 2>/dev/null ) | sort -u >>"$sysupgrade_backup_files"
+
+cat $sysupgrade_backup_files >>"$filelist"
+
+if [ "$databackup" = "true" ]; then
+	cp $sysupgrade_backup_files /tmp/sysupgrade_backup_files
+	echo /tmp/sysupgrade_backup_files >>"$filelist"
+fi
+
+rm -f "$sysupgrade_backup_files"

--- a/utils/config-backup/files/usr/libexec/config-backup/data
+++ b/utils/config-backup/files/usr/libexec/config-backup/data
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+filelist="$1"
+databackup="$2"
+
+# /rootdata is intended to store data that is
+# kept on the rootfs rather external storage
+# (for example in a typical squashfs+jffs2
+# setup).
+
+if [ "$databackup" = "true" ]; then
+	if [ -d /rootdata ]; then
+		echo "/rootdata" >>"$filelist"
+	fi
+fi
+

--- a/utils/config-backup/files/usr/libexec/config-backup/overlay
+++ b/utils/config-backup/files/usr/libexec/config-backup/overlay
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+filelist="$1"
+databackup="$2"
+
+if [ "$databackup" = "true" ]; then
+	echo "/overlay" >>"$filelist"
+fi
+

--- a/utils/config-backup/files/usr/sbin/config-backup
+++ b/utils/config-backup/files/usr/sbin/config-backup
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Copyright 2013-2016 Daniel Dickinson <lede@daniel.thecshore.com>
+#
+# MIT License
+#
+
+if [ "$(basename "${0}")" = "config+data-backup" ]; then
+	databackup=true
+else
+	databackup=false
+fi
+
+filelist="$(mktemp)"
+
+cd /
+
+for file in /usr/libexec/config-backup/*; do
+	nice -n 5 $file $filelist $databackup
+done
+
+cat $filelist | sed -e 's,^/,,' | sort -u >"${filelist}.tmp"
+rm -f $filelist
+
+nice -n 5 tar -T "${filelist}.tmp" -C / -czf -
+
+rm -f "${filelist}.tmp"
+


### PR DESCRIPTION
This commit adds a package with some convenience scripts that make it
easy to use SSH to back up the router configuration.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>

This has been modified (and not yet re-verified) from scripts I've been using, but the reason for this Untested Request For Comments is to see if there is any interest in having this in the packages feed vs. just something I keep in my personal repository.