### PR TITLE
mail/{msmtp,postfix}: Add provides sendmail-command

### DIFF
--- a/mail/bogofilter/Makefile
+++ b/mail/bogofilter/Makefile
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/bogofilter
   SECTION:=mail
   CATEGORY:=Mail
-  DEPENDS:=+libdb47
+  DEPENDS:=+libdb47 +sendmail-command
   TITLE:=bogofilter
   MAINTAINER:=W. Michael Petullo <mike@flyn.org>
   URL:=http://bogofilter.sourceforge.net/

--- a/mail/msmtp/Makefile
+++ b/mail/msmtp/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=msmtp
 PKG_VERSION:=1.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/msmtp
@@ -47,6 +47,7 @@ $(call Package/msmtp/Default)
   DEPENDS+= +libopenssl
   TITLE+= (with SSL support)
   VARIANT:=ssl
+  PROVIDES:=sendmail-command
 endef
 
 define Package/msmtp/conffiles
@@ -62,6 +63,7 @@ define Package/msmtp-nossl
 $(call Package/msmtp/Default)
   TITLE+= (without SSL support)
   VARIANT:=nossl
+  PROVIDES:=sendmail-command
 endef
 
 define Package/msmtp-nossl/description
@@ -110,19 +112,7 @@ define Package/msmtp/install
 		$(1)/etc/msmtprc
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/msmtp $(1)/usr/bin/
-endef
-
-define Package/msmtp/postinst
-	[ -e $${IPKG_INSTROOT}/usr/sbin/sendmail ] || {
-		mkdir -p $${IPKG_INSTROOT}/usr/sbin
-		ln -sf ../bin/msmtp $${IPKG_INSTROOT}/usr/sbin/sendmail
-	}
-endef
-
-define Package/msmtp/prerm
-	[ "../bin/msmtp" = "$(readlink -qs $${IPKG_INSTROOT}/usr/sbin/sendmail)" ] && {
-		rm -f $${IPKG_INSTROOT}/usr/sbin/sendmail
-	}
+	ln -s ../bin/msmtp $(1)/usr/sbin/sendmail
 endef
 
 Package/msmtp-nossl/conffiles = $(Package/msmtp/conffiles)

--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postfix
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE_URL:=ftp://ftp.porcupine.org/mirrors/postfix-release/official/
 PKG_VERSION:=3.1.0
 PKG_MD5SUM:=b4a506fa74c69c6fb1875c0971268344
@@ -26,6 +26,7 @@ define Package/postfix
   TITLE:=Postfix Mail Transmit Agent
   URL:=http://www.postfix.org/
   DEPENDS:=+POSTFIX_TLS:libopenssl +POSTFIX_SASL:libsasl2 +POSTFIX_LDAP:libopenldap +POSTFIX_DB:libdb47 +POSTFIX_EAI:icu +libpcre
+  PROVIDES:=sendmail-command
 endef
 
 define Package/postfix/description
@@ -190,7 +191,7 @@ define Build/Compile
 endef
 
 define Package/postfix/install
-	cd $(PKG_BUILD_DIR); $(MAKE) install_root=$(1) command_directory=$(command_directory) daemon_directory=$(daemon_directory) data_directory=$(data_directory) html_directory=$(html_directory) mail_owner=postfix mailq_path=$(mailq_path)$(ln_suffix) manpage_directory=$(manpage_directory) newaliases_path=$(newaliases_path)$(ln_suffix) queue_directory=$(queue_directory) readme_directory=$(readme_directory) sendmail_path=$(sendmail_path)$(ln_suffix) setgid_group=postdrop sample_directory=$(sample_directory) config_directory=$(config_directory) shlib_directory=$(shlib_directory) meta_directory=$(meta_directory) mail_version=$(PKG_VERSION) non-interactive-package
+	cd $(PKG_BUILD_DIR); $(MAKE) install_root=$(1) command_directory=$(command_directory) daemon_directory=$(daemon_directory) data_directory=$(data_directory) html_directory=$(html_directory) mail_owner=postfix mailq_path=$(mailq_path) manpage_directory=$(manpage_directory) newaliases_path=$(newaliases_path) queue_directory=$(queue_directory) readme_directory=$(readme_directory) sendmail_path=$(sendmail_path) setgid_group=postdrop sample_directory=$(sample_directory) config_directory=$(config_directory) shlib_directory=$(shlib_directory) meta_directory=$(meta_directory) mail_version=$(PKG_VERSION) non-interactive-package
 	$(INSTALL_DIR) $(1)$(mail_spool_directory)
 	$(INSTALL_DIR) $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files/postfix.init $(1)/etc/init.d/postfix
@@ -198,31 +199,6 @@ endef
 
 define Package/postfix/postinst
 #!/bin/sh
-
- if [ -f "$${IPKG_INSTROOT}$(sendmail_path)" -a "$$(readlink "$${IPKG_INSTROOT}$(sendmail_path)")" != "$(sendmail_path)$(ln_suffix)" ]; then
-  mv "$${IPKG_INSTROOT}$(sendmail_path)" "$${IPKG_INSTROOT}$(sendmail_path)$(ln_old_suffix)"
-  echo "Warning: $${IPKG_INSTROOT}$(sendmail_path) saved as $${IPKG_INSTROOT}$(sendmail_path)$(ln_old_suffix)"
- fi
- if [ ! -f "$${IPKG_INSTROOT}$(sendmail_path)" ]; then
-  ln -s "$${IPKG_INSTROOT}$(sendmail_path)$(ln_suffix)" "$(sendmail_path)"
- fi
-
- if [ -f "$${IPKG_INSTROOT}$(newaliases_path)" -a "$$(readlink "$${IPKG_INSTROOT}$(newaliases_path)")" != "$(newaliases_path)$(ln_suffix)" ]; then
-  mv "$${IPKG_INSTROOT}$(newaliases_path)" "$${IPKG_INSTROOT}$(newaliases_path)$(ln_old_suffix)"
-  echo "Warning: $${IPKG_INSTROOT}$(newaliases_path) saved as $${IPKG_INSTROOT}$(newaliases_path)$(ln_old_suffix)"
- fi
- if [ ! -f "$${IPKG_INSTROOT}$(newaliases_path)" ]; then
-  ln -s "$${IPKG_INSTROOT}$(newaliases_path)$(ln_suffix)" "$(newaliases_path)"
- fi
-
- if [ -f "$${IPKG_INSTROOT}$(mailq_path)" -a "$$(readlink "$${IPKG_INSTROOT}$(mailq_path)")" != "$(mailq_path)$(ln_suffix)" ]; then
-  mv "$${IPKG_INSTROOT}$(mailq_path)" "$${IPKG_INSTROOT}$(mailq_path)$(ln_old_suffix)"
-  echo "Warning: $${IPKG_INSTROOT}$(mailq_path) saved as $${IPKG_INSTROOT}$(mailq_path)$(ln_old_suffix)"
- fi
- if [ ! -f "$(mailq_path)" ]; then
-  ln -s "$${IPKG_INSTROOT}$(mailq_path)$(ln_suffix)" "$(mailq_path)"
- fi
-
  grep -qc main\.cf "$${IPKG_INSTROOT}"/etc/sysupgrade.conf >/dev/null || echo "$(config_directory)/main.cf" >> "$${IPKG_INSTROOT}"/etc/sysupgrade.conf
  grep -qc master\.cf "$${IPKG_INSTROOT}"/etc/sysupgrade.conf >/dev/null || echo "$(config_directory)/master.cf" >> "$${IPKG_INSTROOT}"/etc/sysupgrade.conf
  grep -qc aliases "$${IPKG_INSTROOT}"/etc/sysupgrade.conf >/dev/null || echo "$(config_directory)/aliases" >> "$${IPKG_INSTROOT}"/etc/sysupgrade.conf
@@ -247,21 +223,6 @@ define Package/postfix/postrm
  rm -f $${IPKG_INSTROOT}$(config_directory)/aliases.cdb $${IPKG_INSTROOT}$(config_directory)/aliases.db $${IPKG_INSTROOT}$(data_directory)/master.lock
 
  rm -f $${IPKG_INSTROOT}$(config_directory)/virtual.cdb $${IPKG_INSTROOT}$(config_directory)/virtual.db
-
- rm -f "$${IPKG_INSTROOT}$(sendmail_path)" "$${IPKG_INSTROOT}$(newaliases_path)" "$${IPKG_INSTROOT}$(mailq_path)"
-
- if [ -f "$${IPKG_INSTROOT}$(sendmail_path)$(ln_old_suffix)" ]; then
-  mv "$${IPKG_INSTROOT}$(sendmail_path)$(ln_old_suffix)" "$${IPKG_INSTROOT}$(sendmail_path)"
-  echo "Warning: $${IPKG_INSTROOT}$(sendmail_path) restored from $${IPKG_INSTROOT}$(sendmail_path)$(ln_old_suffix)"
- fi
- if [ -f "$${IPKG_INSTROOT}$(newaliases_path)$(ln_old_suffix)" ]; then
-  mv "$${IPKG_INSTROOT}$(newaliases_path)$(ln_old_suffix)" "$${IPKG_INSTROOT}$(newaliases_path)"
-  echo "Warning: $${IPKG_INSTROOT}$(newaliases_path) restored from $${IPKG_INSTROOT}$(newaliases_path)$(ln_old_suffix)"
- fi
- if [ -f "$${IPKG_INSTROOT}$(mailq_path)$(ln_old_suffix)" ]; then
-  mv "$${IPKG_INSTROOT}$(mailq_path)$(ln_old_suffix)" "$${IPKG_INSTROOT}$(mailq_path)"
-  echo "Warning: $${IPKG_INSTROOT}$(mailq_path) restored from $${IPKG_INSTROOT}$(mailq_path)$(ln_old_suffix)"
- fi
 endef
 
 $(eval $(call BuildPackage,postfix))


### PR DESCRIPTION
For mail programs that supply a sendmail command,
add PROVIDES sendmail-command so that programs
which depend on having sendmail can depend on
sendmail-command without forcing the user to
use a particular sendmail provider.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>