### PR TITLE
lxc: Use more FSH compliant /srv/lxc instead of new root dir

### DIFF
--- a/utils/luci-app-lxc/files/controller/lxc.lua
+++ b/utils/luci-app-lxc/files/controller/lxc.lua
@@ -93,10 +93,22 @@ function lxc_action(lxc_action, lxc_name)
 	luci.http.write_json(ec and {} or data)
 end
 
+function lxc_get_config_path()
+	local f = io.open("/etc/lxc/lxc.conf", "r")
+	local content = f:read("*all")
+	f:close()
+	local ret = content:match('^%s*lxc.lxcpath%s*=%s*([^%s]*)')
+	if ret then
+		return ret .. "/"
+	else
+		return "/srv/lxc/"
+	end
+end
+
 function lxc_configuration_get(lxc_name)
 	luci.http.prepare_content("text/plain")
 
-	local f = io.open("/lxc/" .. lxc_name .. "/config", "r")
+	local f = io.open(lxc_get_config_path() .. lxc_name .. "/config", "r")
 	local content = f:read("*all")
 	f:close()
 
@@ -112,7 +124,7 @@ function lxc_configuration_set(lxc_name)
 		return luci.http.write("1")
 	end
 
-	local f, err = io.open("/lxc/" .. lxc_name .. "/config","w+")
+	local f, err = io.open(lxc_get_config_path() .. lxc_name .. "/config","w+")
 	if not f then
 		return luci.http.write("2")
 	end

--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=1.1.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=LGPL-2.1+ BSD-2-Clause GPL-2.0
 PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>
@@ -199,7 +199,7 @@ define Package/lxc-common/install
 		./files/lxc.conf \
 		$(1)/etc/lxc/lxc.conf
 
-	$(INSTALL_DIR) $(1)/lxc/
+	$(INSTALL_DIR) $(1)/srv/lxc/
 endef
 
 define Package/lxc-hooks/install

--- a/utils/lxc/files/lxc.conf
+++ b/utils/lxc/files/lxc.conf
@@ -1,1 +1,1 @@
-lxc.lxcpath = /lxc
+lxc.lxcpath = /srv/lxc


### PR DESCRIPTION
Normally LXC uses /var/lib, but due to hack OpenWRT employs this is not an
option. But instead of introducing new top-level directory, FSH compatible /srv
can be used.

Signed-off-by: Michal Hrusecky <michal.hrusecky@nic.cz>