### PR TITLE
libcap: Use URL alias

### DIFF
--- a/libs/libcap/Makefile
+++ b/libs/libcap/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=2.24
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/
+PKG_SOURCE_URL:=@KERNEL/linux/libs/security/linux-privs/libcap2
 PKG_MD5SUM:=d43ab9f680435a7fff35b4ace8d45b80
 PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
 


### PR DESCRIPTION
Remove hardcoded URL and use alias instead.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>