### PR TITLE
adblock: update 1.1.15

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=1.1.12
+PKG_VERSION:=1.1.15
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -59,8 +59,9 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 * status & error logging to stdout and syslog
 * use a dynamic uhttpd instance as an adblock pixel server
 * use dynamic iptables rulesets for adblock related redirects/rejects
-* openwrt init system support (start/stop/restart/reload)
+* init system support (start/stop/restart/reload/toggle)
 * hotplug support, the adblock start will be triggered by wan 'ifup' event
+* adblock toggle to quickly (temporary) switch adblocking 'on' or 'off'
 * optional: automatic adblock list backup/restore, backups will be (de-)compressed on the fly (disabled by default)
 * optional: add new adblock sources via uci config (see example below)
 
@@ -101,6 +102,8 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 * **list updates:** for a scheduled call of the adblock service add an appropriate crontab entry (see example below)
 * **new list sources:** you could add new blocklist sources on your own via uci config, all you need is a source url and an awk one-liner (see example below)
 * **AP mode:** in AP mode adblock uses automatically the local router ip as nullip address. To make sure that your LuCI interface will be still accessible, please change the local uhttpd instance to ports <> 80/443 (see example below)
+* **adblock toggle:** to quickly switch adblocking 'on' or 'off', simply use _/etc/init.d/adblock toggle_
+* **outdated configuration:** if adblock detects an outdated config file, please copy the current version from '/etc/adblock/adblock.conf.default' to '/etc/config/adblock', make your individual changes and finally restart the adblock service
 * **debugging:** for script debugging please change the 'DEBUG' variable in the header of _/usr/bin/adblock-update.sh_ from '0' to '1' and start this script directly (without any parameters)
 * **disable active dns probing in windows:** to prevent a possible yellow exclamation mark on your internet connection icon (which wrongly means connected, but no internet), please change the following registry key/value from "1" to "0" _HKLM\SYSTEM\CurrentControlSet\Services\NlaSvc\Parameters\Internet\EnableActiveProbing_
 
@@ -113,6 +116,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
     * adb\_nullipv4 => IPv4 blackhole ip address (default: '192.0.2.1', in AP mode: local router ip)
     * adb\_nullipv6 => IPv6 blackhole ip address (default: '::ffff:c000:0201', in AP mode: local router ip)
     * adb\_forcedns => redirect all DNS queries to local dnsmasq resolver (default: '1', enabled)
+    * adb\_fetchttl => set the timeout for list downloads (default: '5' seconds)
 
 ## Examples
 

--- a/net/adblock/files/adblock-update.sh
+++ b/net/adblock/files/adblock-update.sh
@@ -37,8 +37,8 @@ fi
 # get current directory and set script/config version
 #
 adb_scriptdir="${0%/*}"
-adb_scriptver="1.1.12"
-adb_mincfgver="1.3"
+adb_scriptver="1.1.15"
+adb_mincfgver="2.0"
 
 # source in adblock function library
 #
@@ -298,8 +298,9 @@ fi
 #
 f_cntconfig
 adb_count="$(${adb_uci} -q get "adblock.global.adb_overall_count")"
-if [ -n "${adb_revsrclist}" ] || [ -n "${rm_done}" ] || [ -n "${restore_done}" ]
+if [ -n "${adb_revsrclist}" ] || [ -n "${rm_done}" ] || [ -n "${restore_done}" ] || [ -n "${mv_done}" ]
 then
+    "${adb_uci}" -q set "adblock.global.adb_dnstoggle=on"
     /etc/init.d/dnsmasq restart
     sleep 1
     rc="$(ps | grep -q "[d]nsmasq"; printf ${?})"

--- a/net/adblock/files/adblock.conf
+++ b/net/adblock/files/adblock.conf
@@ -3,10 +3,11 @@
 
 config adblock 'global'
 	option adb_enabled '1'
-	option adb_cfgver '1.3'
+	option adb_cfgver '2.0'
 	option adb_whitelist '/etc/adblock/adblock.whitelist'
 	option adb_whitelist_rset '\$1 ~/^([A-Za-z0-9_-]+\.){1,}[A-Za-z]+/{print tolower(\$1)}'
 	option adb_forcedns '1'
+	option adb_dnstoggle 'on'
 
 config service 'backup'
 	option enabled '0'

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -2,13 +2,18 @@
 #
 
 START=99
+EXTRA_COMMANDS="toggle"
+EXTRA_HELP="        toggle  Toggle adblocking 'on' or 'off'"
 
 exec 2>/dev/null
 adb_pid="${$}"
 adb_script="/usr/bin/adblock-update.sh"
+adb_dnsdir="/tmp/dnsmasq.d"
+adb_dnshidedir="${adb_dnsdir}/.adb_hidden"
+adb_dnsprefix="adb_list"
 adb_pidfile="/var/run/adblock.pid"
-adb_logger="/usr/bin/logger"
-adb_uci="/sbin/uci"
+adb_logger="$(which logger)"
+adb_uci="$(which uci)"
 
 if [ -t 1 ]
 then
@@ -30,7 +35,7 @@ remove_config()
     local value opt section="${1}" options="adb_src_timestamp adb_src_count"
     for opt in ${options}
     do
-        ${adb_uci} -q delete "adblock.${section}.${opt}"
+        "${adb_uci}" -q delete "adblock.${section}.${opt}"
     done
 }
 
@@ -57,17 +62,47 @@ reload()
     start
 }
 
+toggle()
+{
+if [ -d "${adb_dnshidedir}" ]
+then
+    list_dns="$(find "${adb_dnsdir}" -maxdepth 1 -type f -name "${adb_dnsprefix}*" -print)"
+    list_dnshide="$(find "${adb_dnshidedir}" -maxdepth 1 -type f -name "${adb_dnsprefix}*" -print)"
+    if [ -n "${list_dns}" ]
+    then
+        mv -f "${adb_dnsdir}/${adb_dnsprefix}"* "${adb_dnshidedir}"
+        "${adb_uci}" -q set "adblock.global.adb_dnstoggle=off"
+        "${adb_uci}" -q commit "adblock"
+        /etc/init.d/dnsmasq restart
+        "${adb_logger}" ${log_parm} -t "adblock[${adb_pid}] info " "toggle for adblocking switched 'off'" 2>&1
+    elif [ -n "${list_dnshide}" ]
+    then
+        mv -f "${adb_dnshidedir}/${adb_dnsprefix}"* "${adb_dnsdir}"
+        "${adb_uci}" -q set "adblock.global.adb_dnstoggle=on"
+        "${adb_uci}" -q commit "adblock"
+        /etc/init.d/dnsmasq restart
+        "${adb_logger}" ${log_parm} -t "adblock[${adb_pid}] info " "toggle for adblocking switched 'on'" 2>&1
+    fi
+fi
+}
+
 stop()
 {
-    rm_done="$(find "/tmp/dnsmasq.d" -maxdepth 1 -type f -name "adb_list.*" -print -exec rm -f "{}" \;)"
+    if [ -d "${adb_dnshidedir}" ]
+    then
+        find "${adb_dnshidedir}" -maxdepth 1 -type f -name "${adb_dnsprefix}*" -exec mv -f "{}" "${adb_dnsdir}" \;
+    fi
+    rm_done="$(find "${adb_dnsdir}" -maxdepth 1 -type f -name "${adb_dnsprefix}*" -print -exec rm -f "{}" \;)"
     rc=${?}
     if [ $((rc)) -eq 0 ] && [ -n "${rm_done}" ]
     then
         . "/lib/functions.sh"
         config_load adblock
         config_foreach remove_config source
-        ${adb_uci} -q delete "adblock.global.adb_overall_count"
-        ${adb_uci} -q commit "adblock"
+        "${adb_uci}" -q set "adblock.global.adb_dnstoggle=on"
+        "${adb_uci}" -q delete "adblock.global.adb_overall_count"
+        "${adb_uci}" -q commit "adblock"
+        rm -rf "${adb_dnshidedir}"
         /etc/init.d/dnsmasq restart
         /etc/init.d/firewall restart
     fi


### PR DESCRIPTION
* toggle to quickly switch adblocking 'on' or 'off' (/etc/init.d/adblock toggle)
* new config option 'fetchttl' to set download timeouts (default: 5 seconds)
* better config check, distinct between major/minor changes
* documentation update

Signed-off-by: Dirk Brenken <dev@brenken.org>