### PR TITLE
tinc: update to 1.1 branch (with ECC support)

### DIFF
--- a/net/tinc/Makefile
+++ b/net/tinc/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2015 OpenWrt.org
+# Copyright (C) 2007-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinc
-PKG_VERSION:=1.0.28
+PKG_VERSION:=1.1pre14
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.tinc-vpn.org/packages
-PKG_MD5SUM:=9ca14c9902fb4011b5df6a09ffd40ea9
+PKG_MD5SUM:=401ad9b0610dc4da233d6edb1f463cb8
 
 PKG_INSTALL:=1
 
@@ -22,7 +22,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/tinc
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+liblzo +libopenssl +kmod-tun
+  DEPENDS:=+liblzo +libopenssl +kmod-tun +libncurses +libreadline
   TITLE:=VPN tunneling daemon
   URL:=http://www.tinc-vpn.org/
   MAINTAINER:=Saverio Proto <zioproto@gmail.com>
@@ -39,10 +39,14 @@ TARGET_CFLAGS += -std=gnu99
 CONFIGURE_ARGS += \
 	--with-kernel="$(LINUX_DIR)" \
 	--with-zlib="$(STAGING_DIR)/usr" \
-	--with-lzo-include="$(STAGING_DIR)/usr/include/lzo"
+	--with-lzo-include="$(STAGING_DIR)/usr/include/lzo" \
+	--with-curses \
+	--with-readline \
+	--enable-jumbograms
 
 define Package/tinc/install
 	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/tinc $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/tincd $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d/
 	$(INSTALL_BIN) files/$(PKG_NAME).init $(1)/etc/init.d/$(PKG_NAME)


### PR DESCRIPTION
Updating tinc package to latest version from 1.1 branch, featuring ECC cryptography, better peers discovery, interactive managing utility and many more.