### PR TITLE
libftdi1: explicitely disable Boost unit tests

### DIFF
--- a/libs/libftdi1/Makefile
+++ b/libs/libftdi1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libftdi1
 PKG_VERSION:=1.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.intra2net.com/en/developer/libftdi/download/
@@ -21,6 +21,8 @@ PKG_LICENSE_FILES:=COPYING.LIB
 
 PKG_INSTALL:=1
 PKG_USE_MIPS16:=0
+
+CMAKE_OPTIONS:=-DBUILD_TESTS=OFF
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
When libftdi1 is detecting the presence of the Boost unit testing framework,
it will conditionally enable the build of libftdi1 test binaries which fail to
link on some targets with the following error:

    CMakeFiles/test_libftdi1.dir/basic.cpp.o: In function `main':
    basic.cpp:(.text.startup+0xc): undefined reference to `boost::unit_test::unit_test_main(bool (*)(), int, char**)'
    collect2: error: ld returned 1 exit status
    test/CMakeFiles/test_libftdi1.dir/build.make:123: recipe for target 'test/test_libftdi1' failed
    make[6]: *** [test/test_libftdi1] Error 1

Since we do not care about test cases and since we want to avoid unpredictable
conditional compilation simply disable the testcases entirely.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>