### PR TITLE
libsoup: disable overly strict warnings, use system wide intltool.m4

### DIFF
--- a/libs/libsoup/Makefile
+++ b/libs/libsoup/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsoup
 PKG_VERSION:=2.53.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/$(PKG_NAME)/2.53
@@ -19,6 +19,7 @@ PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
+PKG_REMOVE_FILES:=m4/intltool.m4
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -43,6 +44,7 @@ define Build/Configure
 		--without-apache-httpd \
 		--without-gnome \
 		--enable-vala=no \
+		--disable-more-warnings \
 	)
 endef
 


### PR DESCRIPTION
When building libsoup within the SDK, the following usually nonfatal warning
is causing the build to fail:

    make[6]: Entering directory '.../build_dir/target-arm_xscale_musl-1.1.14_eabi/libsoup-2.53.2/libsoup'
      CC       libsoup_2_4_la-soup-address.lo
    cc1: error: .../staging_dir/target-arm_xscale_musl-1.1.14_eabi/include: No such file or directory [-Werror=missing-include-dirs]
    cc1: some warnings being treated as errors
    Makefile:962: recipe for target 'libsoup_2_4_la-soup-address.lo' failed

Use the upstream `--disable-more-warnings` configure switch to disable this
class of `-Werror` flags.

Also drop the shipped copy of `intltool.m4` to force using the system wide one
which does not require the `XML::Parser` module to be installed (see #2771).

Signed-off-by: Jo-Philipp Wich <jo@mein.io>