### PR TITLE
intltool: make dependency on XML::Parser optional

### DIFF
--- a/libs/intltool/Makefile
+++ b/libs/intltool/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=intltool
 PKG_LIBVER:=0.40
 PKG_VERSION:=$(PKG_LIBVER).6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@GNOME/intltool/$(PKG_LIBVER)
@@ -18,6 +18,7 @@ PKG_MD5SUM:=69bc0353323112f42ad4f9cf351bc3e5
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
 PKG_HOST_ONLY:=1
+HOST_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -34,14 +35,6 @@ define Package/intltool/description
   intltool is a set of tools to centralize translation of many different
   file formats using GNU gettext-compatible PO files.
 endef
-
-define Require/perl-xml-parser
-  perl -e 'use XML::Parser;'
-endef
-
-$(eval $(call Require,perl-xml-parser, \
-	Please install Perl XML::Parser \
-))
 
 $(eval $(call BuildPackage,intltool))
 $(eval $(call HostBuild))

--- a/libs/intltool/patches/100-optional-perl-xml-parser.patch
+++ b/libs/intltool/patches/100-optional-perl-xml-parser.patch
@@ -1,0 +1,22 @@
+--- a/configure.in
++++ b/configure.in
+@@ -25,7 +25,7 @@ AC_MSG_CHECKING([for XML::Parser])
+ if `$PERL -e "require XML::Parser" 2>/dev/null`; then
+    AC_MSG_RESULT([ok])
+ else
+-   AC_MSG_ERROR([XML::Parser perl module is required for intltool])
++   AC_MSG_RESULT([XML::Parser perl module is required for some intltool utilitities])
+ fi
+ 
+ AC_OUTPUT([
+--- a/intltool.m4
++++ b/intltool.m4
+@@ -127,7 +127,7 @@ if test "x$2" != "xno-xml"; then
+    if `$INTLTOOL_PERL -e "require XML::Parser" 2>/dev/null`; then
+        AC_MSG_RESULT([ok])
+    else
+-       AC_MSG_ERROR([XML::Parser perl module is required for intltool])
++       AC_MSG_RESULT([XML::Parser perl module is required for some intltool utilitities])
+    fi
+ fi
+ 


### PR DESCRIPTION
Patch `configure` and the shipped `intltool.m4` macro file to make a missing
XML::Parser perl module nonfatal.

All utilities provided by intltool are programmed to fail gracefully at run
time if the module cannot be loaded and those utilities commonly used during
the build do not require it at all.

Also drop the the build-prereq on XML::Parser now that it is optional.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>