### PR TITLE
aria2: explicitely disable libuv support

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
 PKG_VERSION:=1.18.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/aria2
@@ -59,6 +59,7 @@ CONFIGURE_ARGS += \
 	--without-libgcrypt \
 	--without-libexpat \
 	--without-libcares \
+	--without-libuv \
 	--without-sqlite3 \
 	--with-libz
 


### PR DESCRIPTION
If libuv is present within the build environment, aria2 will fail to build
with the following error:

    LibuvEventPoll.cc: In member function 'virtual void aria2::LibuvEventPoll::poll(const timeval&)':
    LibuvEventPoll.cc:144:59: error: invalid conversion from 'void (*)(uv_timer_t*, int) {aka void (*)(uv_timer_s*, int)}' to 'uv_timer_cb {aka void (*)(uv_timer_s*)}' [-fpermissive]
         uv_timer_start(timer, timer_callback, timeout, timeout);
                                                               ^
    In file included from LibuvEventPoll.h:43:0,
                     from LibuvEventPoll.cc:44:
    .../staging_dir/target-arm_xscale_musl-1.1.14_eabi/usr/include/uv.h:770:44: note:   initializing argument 2 of 'int uv_timer_start(uv_timer_t*, uv_timer_cb, uint64_t, uint64_t)'
     UV_EXTERN int uv_timer_start(uv_timer_t* handle,
                                                ^
    Makefile:2271: recipe for target 'LibuvEventPoll.lo' failed
    make[6]: *** [LibuvEventPoll.lo] Error 1

Explicitely disable the libuv support in `configure` to avoid picking up this
unwanted dependency.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>