### PR TITLE
krb5: more uninitialized warning errors

### DIFF
--- a/net/krb5/patches/001-fix-uninitialized-warning-errors.patch
+++ b/net/krb5/patches/001-fix-uninitialized-warning-errors.patch
@@ -1,6 +1,5 @@
-diff -u --recursive krb5-1.14.1-vanilla/src/lib/kadm5/str_conv.c krb5-1.14.1/src/lib/kadm5/str_conv.c
---- krb5-1.14.1-vanilla/src/lib/kadm5/str_conv.c	2016-03-26 19:49:13.651926364 -0400
-+++ krb5-1.14.1/src/lib/kadm5/str_conv.c	2016-03-26 21:05:37.436084066 -0400
+--- a/src/lib/kadm5/str_conv.c
++++ b/src/lib/kadm5/str_conv.c
 @@ -131,7 +131,7 @@
  {
      int found = 0, invert = 0;
@@ -10,9 +9,8 @@ diff -u --recursive krb5-1.14.1-vanilla/src/lib/kadm5/str_conv.c krb5-1.14.1/src
      unsigned long ul;
  
      for (i = 0; !found && i < NFTBL; i++) {
-diff -u --recursive krb5-1.14.1-vanilla/src/lib/krad/packet.c krb5-1.14.1/src/lib/krad/packet.c
---- krb5-1.14.1-vanilla/src/lib/krad/packet.c	2016-03-26 19:49:13.634926238 -0400
-+++ krb5-1.14.1/src/lib/krad/packet.c	2016-03-26 21:13:03.023144940 -0400
+--- a/src/lib/krad/packet.c
++++ b/src/lib/krad/packet.c
 @@ -253,7 +253,7 @@
  {
      krb5_error_code retval;
@@ -22,9 +20,8 @@ diff -u --recursive krb5-1.14.1-vanilla/src/lib/krad/packet.c krb5-1.14.1/src/li
      size_t attrset_len;
  
      pkt = packet_new();
-diff -u --recursive krb5-1.14.1-vanilla/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c krb5-1.14.1/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
---- krb5-1.14.1-vanilla/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c	2016-03-26 19:49:13.653926379 -0400
-+++ krb5-1.14.1/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c	2016-03-26 21:17:07.151335877 -0400
+--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
++++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
 @@ -3618,7 +3618,7 @@
  {
      CK_ULONG i, r;
@@ -34,10 +31,8 @@ diff -u --recursive krb5-1.14.1-vanilla/src/plugins/preauth/pkinit/pkinit_crypto
      CK_ULONG count = 0;
      CK_SLOT_ID_PTR slotlist;
      CK_TOKEN_INFO tinfo;
-Only in krb5-1.14.1/src/plugins/preauth/pkinit: .pkinit_crypto_openssl.c.swp
-diff -u --recursive krb5-1.14.1-vanilla/src/util/profile/prof_file.c krb5-1.14.1/src/util/profile/prof_file.c
---- krb5-1.14.1-vanilla/src/util/profile/prof_file.c	2016-03-26 19:49:13.633926230 -0400
-+++ krb5-1.14.1/src/util/profile/prof_file.c	2016-03-26 21:03:07.934427580 -0400
+--- a/src/util/profile/prof_file.c
++++ b/src/util/profile/prof_file.c
 @@ -309,7 +309,7 @@
      unsigned long frac;
      time_t now;
@@ -47,3 +42,14 @@ diff -u --recursive krb5-1.14.1-vanilla/src/util/profile/prof_file.c krb5-1.14.1
      int isdir = 0;
  
  #ifdef HAVE_STAT
+--- a/src/kadmin/ktutil/ktutil_funcs.c
++++ b/src/kadmin/ktutil/ktutil_funcs.c
+@@ -64,7 +64,7 @@
+     krb5_kt_list *list;
+     int idx;
+ {
+-    krb5_kt_list lp, prev;
++    krb5_kt_list lp, prev = NULL;
+     int i;
+ 
+     for (lp = *list, i = 1; lp; prev = lp, lp = lp->next, i++) {


### PR DESCRIPTION
ktutil_funcs.c: In function 'ktutil_delete':
ktutil_funcs.c:75:28: error: 'prev' may be used uninitialized in this function [-Werror=maybe-uninitialized]

Signed-off-by: John Crispin <john@phrozen.org>