### PR TITLE
bluelog: fix oui.txt processing

### DIFF
--- a/utils/bluelog/Makefile
+++ b/utils/bluelog/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bluelog
 PKG_VERSION:=1.1.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.digifail.com/software/bluelog

--- a/utils/bluelog/patches/100-gen-oui-fix-tempfile-use-mirror.patch
+++ b/utils/bluelog/patches/100-gen-oui-fix-tempfile-use-mirror.patch
@@ -1,0 +1,29 @@
+Index: bluelog-1.1.2/gen_oui.sh
+===================================================================
+--- bluelog-1.1.2.orig/gen_oui.sh
++++ bluelog-1.1.2/gen_oui.sh
+@@ -3,7 +3,7 @@
+ VER="1.2"
+ 
+ # Location of tmp file
+-TMPFILE="/tmp/oui.tmp"
++TMPFILE="./oui.tmp"
+ 
+ # File to write
+ OUIFILE="oui.txt"
+@@ -22,10 +22,11 @@ exit 1
+ 
+ get_oui ()
+ {
+-echo -n "Downloading OUI file from IEEE..."
+-wget --quiet -O $TMPFILE http://standards.ieee.org/develop/regauth/oui/oui.txt || \
+-	ErrorMsg ERR "Unable to contact IEEE server!"
+-
++echo -n "Downloading OUI file from LEDE project..."
++wget --quiet -O $TMPFILE.gz http://sources.lede-project.org/oui-2016-05-30.txt.gz || \
++	ErrorMsg ERR "Unable to contact LEDE project!"
++gunzip $TMPFILE.gz || \
++	ErrorMsg ERR "Unable to gunzip $TMPFILE.gz!"
+ echo "OK"
+ }
+ 


### PR DESCRIPTION
 - Use a temporary file path within the package build directory to avoid
   cluttering the host systems `/tmp` directory.

 - Switch to a gzipped, snapshotted copy of the `oui.txt` file since the
   upstream IEEE server is extremely slow, also fetching an unversioned HTTP
   resource during compilation breaks reproducable builds.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>