### PR TITLE
nfs-kernel-server: add workaround for musl getservbyport

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=1.3.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MD5SUM:=9b87d890669eaaec8e97a2b0a35b2665
 
 PKG_SOURCE_URL:=@SF/nfs

--- a/net/nfs-kernel-server/patches/101-musl-getservbyport.patch
+++ b/net/nfs-kernel-server/patches/101-musl-getservbyport.patch
@@ -1,0 +1,18 @@
+Musl will always return something with getservbyport so we cannot skip
+ports that returns non-null.
+
+diff --git a/utils/statd/rmtcall.c b/utils/statd/rmtcall.c
+index fd576d9..d72a0bf 100644
+--- a/utils/statd/rmtcall.c
++++ b/utils/statd/rmtcall.c
+@@ -90,8 +90,10 @@ statd_get_socket(void)
+ 					__func__);
+ 			break;
+ 		}
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+ 		se = getservbyport(sin.sin_port, "udp");
+ 		if (se == NULL)
++#endif
+ 			break;
+ 		/* rather not use that port, try again */
+ 


### PR DESCRIPTION
Fixes https://dev.openwrt.org/ticket/20038

Patch is based on http://git.alpinelinux.org/cgit/aports/plain/main/nfs-utils/musl-getservbyport.patch?id=3579df3582b5e5ea53be8cd8eef240f3f0cabb10

Signed-off-by: Maxim Storchak <m.storchak@gmail.com>