### PR TITLE
ddns-scripts: add support for glue records

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.1
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -956,6 +956,7 @@ get_registered_ip() {
 	# 1	no IP detected
 
 	[ $# -lt 1 -o $# -gt 2 ] && write_log 12 "Error calling 'get_registered_ip()' - wrong number of parameters"
+	[ $is_glue -eq 1 ] && [ -z "$(which host)" ] && write_log 12 "Update of glue records is only supported using BIND host"
 	write_log 7 "Detect registered/public IP"
 
 	# set correct regular expression
@@ -968,6 +969,7 @@ get_registered_ip() {
 			[ $use_ipv6 -eq 0 ] && __PROG="$__PROG -4"  || __PROG="$__PROG -6"
 		fi
 		[ $force_dnstcp -eq 1 ] && __PROG="$__PROG -T"	# force TCP
+		[ $is_glue -eq 1 ] && __PROG="$__PROG -v" # use verbose output to get additional section
 
 		__RUNPROG="$__PROG $lookup_host $dns_server >$DATFILE 2>$ERRFILE"
 		__PROG="BIND host"
@@ -1039,6 +1041,12 @@ get_registered_ip() {
 		else
 			if [ "$__PROG" = "BIND host" ]; then
 				__DATA=$(cat $DATFILE | awk -F "address " '/has/ {print $2; exit}' )
+
+				if [ $is_glue -eq 1 ]; then
+					__DATA=$(cat $DATFILE | grep "^$lookup_host" | grep -m 1 -o "$__REGEX" )
+				else
+					__DATA=$(cat $DATFILE | awk -F "address " '/has/ {print $2; exit}' )
+				fi
 			elif [ "$__PROG" = "Knot host" ]; then
 				__DATA=$(cat $DATFILE | awk -F "address " '/has/ {print $2; exit}' )
 			elif [ "$__PROG" = "drill" ]; then

--- a/net/ddns-scripts/files/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/dynamic_dns_updater.sh
@@ -110,6 +110,7 @@ trap "trap_handler 15" 15	# SIGTERM	Termination
 # force_dnstcp		force communication with DNS server via TCP instead of default UDP
 # proxy			using a proxy for communication !!! ALSO used to detect local IP via web => return proxy's IP !!!
 # use_logfile		self-explanatory "/var/log/ddns/$SECTION_ID.log"
+# is_glue			the record that should be updated is a glue record
 #
 # some functionality needs
 # - GNU Wget or cURL installed for sending updates to DDNS service


### PR DESCRIPTION
Assuming the following dns zone configuration for kresin.me:

    .                   1800  IN  NS  ns.inwx.de.
    home.kresin.me.     1800  IN  NS  gw.home.kresin.me.
    gw.home.kresin.me.  60    IN  A   198.51.100.1

Using the example, gw.home.kresin.me is a glue record and used as DDNS
record as well. gw.home.kresin.me points to the OpenWrt installation
where the ddns-scripts are running.

Since ns.inwx.de isn't the authoritative server for home.kresin.me,
a query for the the A record of gw.home.kresin.me will be "forwarded"
to and replied by the authoritative server 198.51.100.1. If the
authoritative server can't be reached, the query times out without any
address returned.

The only way to get the A record of the glue record is to use bind
host in verbose output mode, query ns.inwx.de for gw.home.kresin.me and
evaluate the additional section of the response.

To my knowledge, only bind host in verbose output mode shows the
additional section of the response. Therefore, this features depends on
bind host.

It is not possible to use the bind host verbose mode for all queries.
In verbose mode the "has address" line isn't returned. Grepping for the
hostname might fail if the hostname is CNAME. Grepping for the first
occurrence of an ip-address is way to error prone, since it could
return the ip address of a different record type.

Signed-off-by: Mathias Kresin <dev@kresin.me>