### PR TITLE
utils/tar: Fix defaulting to selecting dependencies

### DIFF
--- a/utils/tar/Makefile
+++ b/utils/tar/Makefile
@@ -36,27 +36,29 @@ define Package/tar
 endef
 
 define Package/tar/config
-	config PACKAGE_TAR_POSIX_ACL
-	bool "tar: Enable POSIX ACL support" if PACKAGE_tar
-	default n
+	if PACKAGE_tar
+		config PACKAGE_TAR_POSIX_ACL
+			bool "tar: Enable POSIX ACL support"
+			default n
 
-	config PACKAGE_TAR_XATTR
-	bool "tar: Enable extended attribute (xattr) support" if PACKAGE_tar
-	default n
+		config PACKAGE_TAR_XATTR
+			bool "tar: Enable extended attribute (xattr) support"
+			default n
 
-	config PACKAGE_TAR_GZIP
-	bool "tar: Enable seamless gzip support" if PACKAGE_tar
-	default y
+		config PACKAGE_TAR_GZIP
+			bool "tar: Enable seamless gzip support"
+			default y
 
-	config PACKAGE_TAR_BZIP2
-	bool "tar: Enable seamless bzip2 support" if PACKAGE_tar
-	default y
+		config PACKAGE_TAR_BZIP2
+			bool "tar: Enable seamless bzip2 support"
+			default y
 
-	config PACKAGE_TAR_XZ
-	bool "tar: Enable seamless xz support" if PACKAGE_tar
-	select PACKAGE_xz-utils
-	select PACKAGE_xz
-	default y
+		config PACKAGE_TAR_XZ
+			bool "tar: Enable seamless xz support"
+			select PACKAGE_xz-utils
+			select PACKAGE_xz
+			default y
+	endif
 endef
 
 define Package/tar/description


### PR DESCRIPTION
Due to KConfig misbehavior the tar config options where getting
enabled even when tar was not enabled.  We fix this by enclosing
the options in an if PACKAGE_tar ; endif block.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>

This ought to fix menuconfig automatically selecting xz-utils due to tar config options.