### PR TITLE
adblock: update 1.1.16

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=1.1.15
+PKG_VERSION:=1.1.16
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -103,8 +103,8 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 * **new list sources:** you could add new blocklist sources on your own via uci config, all you need is a source url and an awk one-liner (see example below)
 * **AP mode:** in AP mode adblock uses automatically the local router ip as nullip address. To make sure that your LuCI interface will be still accessible, please change the local uhttpd instance to ports <> 80/443 (see example below)
 * **adblock toggle:** to quickly switch adblocking 'on' or 'off', simply use _/etc/init.d/adblock toggle_
-* **outdated configuration:** if adblock detects an outdated config file, please copy the current version from '/etc/adblock/adblock.conf.default' to '/etc/config/adblock', make your individual changes and finally restart the adblock service
-* **debugging:** for script debugging please change the 'DEBUG' variable in the header of _/usr/bin/adblock-update.sh_ from '0' to '1' and start this script directly (without any parameters)
+* **outdated configuration:** to update an outdated adblock config file, please use _/etc/init.d/adblock cfgup_, make your individual changes and restart the adblock service
+* **debugging:** for script debugging please set the 'adb\_debug' variable in the header of _/etc/init.d/adblock_ to '1'
 * **disable active dns probing in windows:** to prevent a possible yellow exclamation mark on your internet connection icon (which wrongly means connected, but no internet), please change the following registry key/value from "1" to "0" _HKLM\SYSTEM\CurrentControlSet\Services\NlaSvc\Parameters\Internet\EnableActiveProbing_
 
 ## Further adblock config options
@@ -117,6 +117,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
     * adb\_nullipv6 => IPv6 blackhole ip address (default: '::ffff:c000:0201', in AP mode: local router ip)
     * adb\_forcedns => redirect all DNS queries to local dnsmasq resolver (default: '1', enabled)
     * adb\_fetchttl => set the timeout for list downloads (default: '5' seconds)
+    * adb\_restricted => disable updates of the adblock config file (no flash writes) during runtime (default: '0', disabled)
 
 ## Examples
 

--- a/net/adblock/files/adblock-helper.sh
+++ b/net/adblock/files/adblock-helper.sh
@@ -12,8 +12,8 @@ f_envload()
     then
         . "/lib/functions.sh"
     else
-        rc=110
-        f_log "system function library not found" "${rc}"
+        rc=-1
+        f_log "system function library not found, please check your installation"
         f_exit
     fi
 
@@ -23,8 +23,8 @@ f_envload()
     then
         . "/lib/functions/network.sh"
     else
-        rc=115
-        f_log "system network library not found" "${rc}"
+        rc=-1
+        f_log "system network library not found, please check your installation"
         f_exit
     fi
 
@@ -39,6 +39,7 @@ f_envload()
     adb_whitelist_rset="\$1 ~/^([A-Za-z0-9_-]+\.){1,}[A-Za-z]+/{print tolower(\$1)}"
     adb_forcedns=1
     adb_fetchttl=5
+    adb_restricted=0
 
     # function to parse global section by callback
     #
@@ -95,8 +96,8 @@ f_envload()
     pkg_list="$(opkg list-installed)"
     if [ -z "${pkg_list}" ]
     then
-        rc=120
-        f_log "empty package list" "${rc}"
+        rc=-1
+        f_log "empty package list, please check your installation"
         f_exit
     fi
 
@@ -114,10 +115,11 @@ f_envload()
     adb_dnsdir="/tmp/dnsmasq.d"
     adb_dnshidedir="${adb_dnsdir}/.adb_hidden"
     adb_dnsprefix="adb_list"
-    adb_uci="$(which uci)"
     adb_iptv4="$(which iptables)"
     adb_iptv6="$(which ip6tables)"
     adb_fetch="$(which wget)"
+    adb_uci="$(which uci)"
+    adb_date="$(which date)"
     unset adb_srclist adb_revsrclist adb_errsrclist
 
     # check 'enabled' & 'version' config options
@@ -125,7 +127,7 @@ f_envload()
     if [ -z "${adb_enabled}" ] || [ -z "${adb_cfgver}" ] || [ "${adb_cfgver%%.*}" != "${adb_mincfgver%%.*}" ]
     then
         rc=-1
-        f_log "outdated adblock config (${adb_mincfgver} vs. ${adb_cfgver}), please use latest version from '/etc/adblock/adblock.conf.default'"
+        f_log "outdated adblock config (${adb_mincfgver} vs. ${adb_cfgver}), please run '/etc/init.d/adblock cfgup' to update your configuration"
         f_exit
     elif [ "${adb_cfgver#*.}" != "${adb_mincfgver#*.}" ]
     then
@@ -140,8 +142,8 @@ f_envload()
 
     # check running dnsmasq instance
     #
-    rc="$(ps | grep -q "[d]nsmasq"; printf ${?})"
-    if [ $((rc)) -ne 0 ]
+    check="$(ps | pgrep -f "dnsmasq")"
+    if [ -z "${check}" ]
     then
         rc=-1
         f_log "please enable the local dnsmasq instance to use adblock"
@@ -167,6 +169,9 @@ f_envload()
         rc=-1
         f_log "no valid IPv4/IPv6 configuration found (${adb_lanif}), please set 'adb_lanif' manually"
         f_exit
+    else
+        network_get_device adb_landev4 "${adb_lanif}"
+        network_get_device adb_landev6 "${adb_lanif}"
     fi
 
     # check logical update interfaces (with default route)
@@ -184,8 +189,8 @@ f_envload()
     then
         adb_nullipv4="${adb_ipv4}"
         adb_nullipv6="${adb_ipv6}"
-        if [ "$(uci get uhttpd.main.listen_http | grep -Fo "80")" = "80" ] ||
-           [ "$(uci get uhttpd.main.listen_https | grep -Fo "443")" = "443" ]
+        if [ "$(${adb_uci} get uhttpd.main.listen_http | grep -Fo "80")" = "80" ] ||
+           [ "$(${adb_uci} get uhttpd.main.listen_https | grep -Fo "443")" = "443" ]
         then
             rc=-1
             f_log "AP mode detected, set local LuCI instance to ports <> 80/443"
@@ -207,14 +212,26 @@ f_envcheck()
 {
     local check
 
+    # log partially outdated config
+    #
     if [ "${outdate_ok}" = "true" ]
     then
-        f_log "partially outdated adblock config (${adb_mincfgver} vs. ${adb_cfgver}), please use latest version from '/etc/adblock/adblock.conf.default'"
+        f_log "partially outdated adblock config (${adb_mincfgver} vs. ${adb_cfgver}), please run '/etc/init.d/adblock cfgup' to update your configuration"
     fi
 
+    # log ap mode
+    #
     if [ "${apmode_ok}" = "true" ]
     then
         f_log "AP mode enabled"
+    fi
+
+    # set & log restricted mode
+    #
+    if [ $((adb_restricted)) -eq 1 ]
+    then
+        adb_uci="$(which true)"
+        f_log "Restricted mode enabled"
     fi
 
     # check general package dependencies
@@ -272,7 +289,7 @@ f_envcheck()
         then
             if [ $((av_space)) -le 2000 ]
             then
-                rc=125
+                rc=105
                 f_log "not enough free space in '${adb_tmpdir}' (avail. ${av_space} kb)" "${rc}"
                 f_exit
             else
@@ -280,7 +297,7 @@ f_envcheck()
             fi
         fi
     else
-        rc=130
+        rc=110
         f_log "temp directory not found" "${rc}"
         f_exit
     fi
@@ -337,10 +354,10 @@ f_envcheck()
         f_firewall "IPv4" "filter" "A" "forwarding_rule" "adb-fwd" "-d ${adb_nullipv4} -j REJECT --reject-with icmp-host-unreachable"
         f_firewall "IPv4" "filter" "A" "output_rule" "adb-out" "-p tcp -d ${adb_nullipv4} -j REJECT --reject-with tcp-reset"
         f_firewall "IPv4" "filter" "A" "output_rule" "adb-out" "-d ${adb_nullipv4} -j REJECT --reject-with icmp-host-unreachable"
-        if [ $((adb_forcedns)) -eq 1 ]
+        if [ $((adb_forcedns)) -eq 1 ] && [ -n "${adb_landev4}" ]
         then
-            f_firewall "IPv4" "nat" "A" "prerouting_rule" "adb-dns" "-p udp --dport 53 -j DNAT --to-destination ${adb_ipv4}:53"
-            f_firewall "IPv4" "nat" "A" "prerouting_rule" "adb-dns" "-p tcp --dport 53 -j DNAT --to-destination ${adb_ipv4}:53"
+            f_firewall "IPv4" "nat" "A" "prerouting_rule" "adb-dns" "-i ${adb_landev4} -p udp --dport 53 -j DNAT --to-destination ${adb_ipv4}:53"
+            f_firewall "IPv4" "nat" "A" "prerouting_rule" "adb-dns" "-i ${adb_landev4} -p tcp --dport 53 -j DNAT --to-destination ${adb_ipv4}:53"
         fi
         if [ "${fw_done}" = "true" ]
         then
@@ -358,10 +375,10 @@ f_envcheck()
         f_firewall "IPv6" "filter" "A" "forwarding_rule" "adb-fwd" "-d ${adb_nullipv6} -j REJECT --reject-with icmp6-addr-unreachable"
         f_firewall "IPv6" "filter" "A" "output_rule" "adb-out" "-p tcp -d ${adb_nullipv6} -j REJECT --reject-with tcp-reset"
         f_firewall "IPv6" "filter" "A" "output_rule" "adb-out" "-d ${adb_nullipv6} -j REJECT --reject-with icmp6-addr-unreachable"
-        if [ $((adb_forcedns)) -eq 1 ]
+        if [ $((adb_forcedns)) -eq 1 ] && [ -n "${adb_landev6}" ]
         then
-            f_firewall "IPv6" "nat" "A" "PREROUTING" "adb-dns" "-p udp --dport 53 -j DNAT --to-destination [${adb_ipv6}]:53"
-            f_firewall "IPv6" "nat" "A" "PREROUTING" "adb-dns" "-p tcp --dport 53 -j DNAT --to-destination [${adb_ipv6}]:53"
+            f_firewall "IPv6" "nat" "A" "PREROUTING" "adb-dns" "-i ${adb_landev6} -p udp --dport 53 -j DNAT --to-destination [${adb_ipv6}]:53"
+            f_firewall "IPv6" "nat" "A" "PREROUTING" "adb-dns" "-i ${adb_landev6} -p tcp --dport 53 -j DNAT --to-destination [${adb_ipv6}]:53"
         fi
         if [ "${fw_done}" = "true" ]
         then
@@ -372,8 +389,8 @@ f_envcheck()
 
     # check volatile adblock uhttpd instance configuration
     #
-    rc="$(ps | grep -q "[u]httpd.*\-h /www/adblock"; printf ${?})"
-    if [ $((rc)) -ne 0 ]
+    check="$(ps | pgrep -f "uhttpd -h /www/adblock")"
+    if [ -z "${check}" ]
     then
         if [ -n "${adb_wanif4}" ] && [ -n "${adb_wanif6}" ]
         then
@@ -418,7 +435,7 @@ f_depend()
     check="$(printf "${pkg_list}" | grep "^${package} -")"
     if [ -z "${check}" ]
     then
-        rc=135
+        rc=115
         f_log "package '${package}' not found" "${rc}"
         f_exit
     fi
@@ -600,14 +617,14 @@ f_restore()
     then
         /etc/init.d/dnsmasq restart
         sleep 1
-        rc="$(ps | grep -q "[d]nsmasq"; printf ${?})"
-        if [ $((rc)) -eq 0 ]
+        check="$(ps | pgrep -f "dnsmasq")"
+        if [ -n "${check}" ]
         then
             rc=0
             f_cntconfig
             f_log "adblock lists with overall ${adb_count} domains loaded"
         else
-            rc=140
+            rc=120
             f_log "dnsmasq restart failed, please check 'logread' output" "${rc}"
         fi
     fi
@@ -620,6 +637,7 @@ f_exit()
 {
     local ipv4_adblock=0
     local ipv6_adblock=0
+    local lastrun="$(${adb_date} "+%d.%m.%Y %H:%M:%S")"
 
     # delete temporary files & directories
     #
@@ -651,14 +669,14 @@ f_exit()
             "${adb_uci}" -q commit "adblock"
         fi
         f_log "firewall statistics (IPv4/IPv6): ${ipv4_adblock}/${ipv6_adblock} ad related packets blocked"
-        f_log "domain adblock processing finished successfully (${adb_scriptver}, ${adb_sysver}, $(/bin/date "+%d.%m.%Y %H:%M:%S"))"
+        f_log "domain adblock processing finished successfully (${adb_scriptver}, ${adb_sysver}, ${lastrun})"
     elif [ $((rc)) -gt 0 ]
     then
         if [ -n "$(${adb_uci} -q changes adblock)" ]
         then
             "${adb_uci}" -q revert "adblock"
         fi
-        f_log "domain adblock processing failed (${adb_scriptver}, ${adb_sysver}, $(/bin/date "+%d.%m.%Y %H:%M:%S"))"
+        f_log "domain adblock processing failed (${adb_scriptver}, ${adb_sysver}, ${lastrun})"
     else
         rc=0
     fi

--- a/net/adblock/files/adblock-update.sh
+++ b/net/adblock/files/adblock-update.sh
@@ -10,11 +10,9 @@
 #
 LC_ALL=C
 
-# script debug switch (disabled by default)
-# set 'DEBUG=1' to enable script debugging
+# quiet output if 'adb_debug' not set
 #
-DEBUG=0
-if [ $((DEBUG)) -eq 0 ]
+if [ -z "${adb_debug}" ]
 then
     exec 2>/dev/null
 fi
@@ -37,7 +35,7 @@ fi
 # get current directory and set script/config version
 #
 adb_scriptdir="${0%/*}"
-adb_scriptver="1.1.15"
+adb_scriptver="1.1.16"
 adb_mincfgver="2.0"
 
 # source in adblock function library
@@ -303,8 +301,8 @@ then
     "${adb_uci}" -q set "adblock.global.adb_dnstoggle=on"
     /etc/init.d/dnsmasq restart
     sleep 1
-    rc="$(ps | grep -q "[d]nsmasq"; printf ${?})"
-    if [ $((rc)) -eq 0 ]
+    check="$(ps | pgrep -f "dnsmasq")"
+    if [ -n "${check}" ]
     then
         f_log "adblock lists with overall ${adb_count} domains loaded"
     else

--- a/net/adblock/files/adblock.conf
+++ b/net/adblock/files/adblock.conf
@@ -7,7 +7,6 @@ config adblock 'global'
 	option adb_whitelist '/etc/adblock/adblock.whitelist'
 	option adb_whitelist_rset '\$1 ~/^([A-Za-z0-9_-]+\.){1,}[A-Za-z]+/{print tolower(\$1)}'
 	option adb_forcedns '1'
-	option adb_dnstoggle 'on'
 
 config service 'backup'
 	option enabled '0'

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -2,18 +2,27 @@
 #
 
 START=99
-EXTRA_COMMANDS="toggle"
-EXTRA_HELP="        toggle  Toggle adblocking 'on' or 'off'"
+EXTRA_COMMANDS="toggle cfgup"
+EXTRA_HELP="	toggle	Toggle adblocking 'on' or 'off'
+	cfgup	Update the adblock configuration file"
 
-exec 2>/dev/null
+adb_debug=0
+if [ $((adb_debug)) -eq 0 ]
+then
+    exec 2>/dev/null
+fi
 adb_pid="${$}"
 adb_script="/usr/bin/adblock-update.sh"
 adb_dnsdir="/tmp/dnsmasq.d"
 adb_dnshidedir="${adb_dnsdir}/.adb_hidden"
 adb_dnsprefix="adb_list"
 adb_pidfile="/var/run/adblock.pid"
-adb_logger="$(which logger)"
+adb_log="$(which logger)"
 adb_uci="$(which uci)"
+if [ "$(${adb_uci} -q get "adblock.global.adb_restricted")" = "1" ]
+then
+    adb_uci="$(which true)"
+fi
 
 if [ -t 1 ]
 then
@@ -26,11 +35,11 @@ fi
 
 if [ -r "${adb_pidfile}" ]
 then
-    "${adb_logger}" ${log_parm} -t "adblock[${adb_pid}] error" "adblock service already running ($(cat ${adb_pidfile})" 2>&1
+    "${adb_log}" ${log_parm} -t "adblock[${adb_pid}] error" "adblock service already running ($(cat ${adb_pidfile}))" 2>&1
     exit 255
 fi
 
-remove_config()
+rm_config()
 {
     local value opt section="${1}" options="adb_src_timestamp adb_src_count"
     for opt in ${options}
@@ -62,32 +71,17 @@ reload()
     start
 }
 
-toggle()
-{
-if [ -d "${adb_dnshidedir}" ]
-then
-    list_dns="$(find "${adb_dnsdir}" -maxdepth 1 -type f -name "${adb_dnsprefix}*" -print)"
-    list_dnshide="$(find "${adb_dnshidedir}" -maxdepth 1 -type f -name "${adb_dnsprefix}*" -print)"
-    if [ -n "${list_dns}" ]
-    then
-        mv -f "${adb_dnsdir}/${adb_dnsprefix}"* "${adb_dnshidedir}"
-        "${adb_uci}" -q set "adblock.global.adb_dnstoggle=off"
-        "${adb_uci}" -q commit "adblock"
-        /etc/init.d/dnsmasq restart
-        "${adb_logger}" ${log_parm} -t "adblock[${adb_pid}] info " "toggle for adblocking switched 'off'" 2>&1
-    elif [ -n "${list_dnshide}" ]
-    then
-        mv -f "${adb_dnshidedir}/${adb_dnsprefix}"* "${adb_dnsdir}"
-        "${adb_uci}" -q set "adblock.global.adb_dnstoggle=on"
-        "${adb_uci}" -q commit "adblock"
-        /etc/init.d/dnsmasq restart
-        "${adb_logger}" ${log_parm} -t "adblock[${adb_pid}] info " "toggle for adblocking switched 'on'" 2>&1
-    fi
-fi
-}
-
 stop()
 {
+    if [ -n "$(${adb_uci} -q get "adblock.global.adb_overall_count")" ]
+    then
+        . "/lib/functions.sh"
+        config_load adblock
+        config_foreach rm_config source
+        "${adb_uci}" -q delete "adblock.global.adb_dnstoggle"
+        "${adb_uci}" -q delete "adblock.global.adb_overall_count"
+        "${adb_uci}" -q commit "adblock"
+    fi
     if [ -d "${adb_dnshidedir}" ]
     then
         find "${adb_dnshidedir}" -maxdepth 1 -type f -name "${adb_dnsprefix}*" -exec mv -f "{}" "${adb_dnsdir}" \;
@@ -96,26 +90,55 @@ stop()
     rc=${?}
     if [ $((rc)) -eq 0 ] && [ -n "${rm_done}" ]
     then
-        . "/lib/functions.sh"
-        config_load adblock
-        config_foreach remove_config source
-        "${adb_uci}" -q set "adblock.global.adb_dnstoggle=on"
-        "${adb_uci}" -q delete "adblock.global.adb_overall_count"
-        "${adb_uci}" -q commit "adblock"
         rm -rf "${adb_dnshidedir}"
         /etc/init.d/dnsmasq restart
         /etc/init.d/firewall restart
     fi
-
-    uhttpd_pid="$(ps | grep "[u]httpd.*\-h /www/adblock" | awk '{print $1}')"
+    uhttpd_pid="$(ps | pgrep -f "uhttpd -h /www/adblock")"
     if [ -n "${uhttpd_pid}" ]
     then
         kill -9 "${uhttpd_pid}"
     fi
-
     if [ -n "${rm_done}" ] || [ -n "${uhttpd_pid}" ]
     then
-        "${adb_logger}" ${log_parm} -t "adblock[${adb_pid}] info " "all adblock related services stopped" 2>&1
+        "${adb_log}" ${log_parm} -t "adblock[${adb_pid}] info " "all adblock related services stopped" 2>&1
     fi
     return 0
+}
+
+toggle()
+{
+    if [ -d "${adb_dnshidedir}" ]
+    then
+        list_dns="$(find "${adb_dnsdir}" -maxdepth 1 -type f -name "${adb_dnsprefix}*" -print)"
+        list_dnshide="$(find "${adb_dnshidedir}" -maxdepth 1 -type f -name "${adb_dnsprefix}*" -print)"
+        if [ -n "${list_dns}" ]
+        then
+            mv -f "${adb_dnsdir}/${adb_dnsprefix}"* "${adb_dnshidedir}"
+            "${adb_uci}" -q set "adblock.global.adb_dnstoggle=off"
+            "${adb_uci}" -q commit "adblock"
+            /etc/init.d/dnsmasq restart
+            "${adb_log}" ${log_parm} -t "adblock[${adb_pid}] info " "toggle for adblocking switched 'off'" 2>&1
+        elif [ -n "${list_dnshide}" ]
+        then
+            mv -f "${adb_dnshidedir}/${adb_dnsprefix}"* "${adb_dnsdir}"
+            "${adb_uci}" -q set "adblock.global.adb_dnstoggle=on"
+            "${adb_uci}" -q commit "adblock"
+            /etc/init.d/dnsmasq restart
+            "${adb_log}" ${log_parm} -t "adblock[${adb_pid}] info " "toggle for adblocking switched 'on'" 2>&1
+        fi
+    fi
+}
+
+cfgup()
+{
+    stop
+    cp -pf "/etc/adblock/adblock.conf.default" "/etc/config/adblock"
+    rc=$?
+    if [ $((rc)) -eq 0 ]
+    then
+        "${adb_log}" ${log_parm} -t "adblock[${adb_pid}] info " "default adblock configuration applied, please check the settings in '/etc/config/adblock'" 2>&1
+    else
+        "${adb_log}" ${log_parm} -t "adblock[${adb_pid}] info " "default adblock configuration not found, please re-install the package via 'opkg install adblock --force-maintainer'" 2>&1
+    fi
 }


### PR DESCRIPTION
* new config option 'adb_restricted' to disable updates of the adblock
    config file during runtime (no flash writes, disabled by default)
* new update function, to apply latest configuration changes if needed (/etc/init.d/adblock cfgup)
* fix dns redirect rule
* various optimizations

Signed-off-by: Dirk Brenken <dev@brenken.org>