### PR TITLE
python3 versions of pip & setuptools

### DIFF
--- a/lang/python3-pip/Makefile
+++ b/lang/python3-pip/Makefile
@@ -8,16 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-pip
-PKG_VERSION:=8.1.1
+PKG_VERSION:=8.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=pip-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pip/
-PKG_MD5SUM:=6b86f11841e89c8241d689956ba99ed7
+PKG_SOURCE_URL:=https://pypi.python.org/packages/e7/a8/7556133689add8d1a54c0b14aeff0acb03c64707ce100ecd53934da1aa13/
+PKG_MD5SUM:=87083c0b9867963b29f7aba3613e8f4a
 
 PKG_LICENSE:=MIT
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/pip-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/python3-pip-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 PKG_USE_MIPS16:=0
 
 include $(INCLUDE_DIR)/package.mk

--- a/lang/python3-setuptools/Makefile
+++ b/lang/python3-setuptools/Makefile
@@ -8,16 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-setuptools
-PKG_VERSION:=20.7.0
+PKG_VERSION:=22.0.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=setuptools-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/s/setuptools/
-PKG_MD5SUM:=5d12b39bf3e75e80fdce54e44b255615
+PKG_SOURCE_URL:=https://pypi.python.org/packages/90/7a/b64d5804b6d1aebed1892e4df1c21bcb4f8480095ba8004e48999601119d/
+PKG_MD5SUM:=869f3029dcc66a64ba39875e2a2f044a
 
 PKG_LICENSE:=PSF
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/setuptools-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/python3-setuptools-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python3-package.mk)


### PR DESCRIPTION
python3 versions of pip & setuptools
should be built in separate from python2.7 PKG_BUILD_DIR's.
This commit also upgrades packages

Signed-off-by: Andrey Sechin <zyxmon@gmail.com>