### PR TITLE
lua-sha2: switch to Github repository

### DIFF
--- a/lang/lua-sha2/Makefile
+++ b/lang/lua-sha2/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://code.google.com/p/sha2/
+PKG_SOURCE_URL:=https://github.com/lgierth/lua-sha2.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=02bd4bfdc806
 PKG_LICENSE:=MIT


### PR DESCRIPTION
The original Google Code repository is not available anymore, use the
equivalent Github repository instead.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>