### PR TITLE
openldap: forcibly disable ICU support

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
 PKG_VERSION:=2.4.43
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/ \
@@ -101,6 +101,9 @@ CONFIGURE_ARGS += \
 	--disable-hdb \
 	--disable-monitor \
 	--disable-relay
+
+CONFIGURE_VARS += \
+	ol_cv_lib_icu="no"
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \


### PR DESCRIPTION
When openldap-server is built within an environment where ICU has been
previously built, the package will pick up this unintended dependency and
fail with the following error:

    Package openldap-server is missing dependencies for the following libraries:
    libicudata.so.55
    libicuuc.so.55
    Makefile:148: recipe for target '.../openldap-server_2.4.43-2_mips_34kc.ipk' failed

Since the ICU libraries are extremely big (~12MB) we cannot simply depend on
them so add the necessary autoconfig cache variable to let the ICU presence
test fail in order to inhibit linking against those libraries.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>