### PR TITLE
mosquitto: add deps on specific OpenSSL config options

### DIFF
--- a/net/mosquitto/Makefile
+++ b/net/mosquitto/Makefile
@@ -34,7 +34,7 @@ endef
 define Package/$(PKG_NAME)
     $(call Package/mosquitto/default)
     TITLE+= (with SSL support)
-    DEPENDS+= +libopenssl +MOSQUITTO_LWS:libwebsockets-openssl
+    DEPENDS+= +libopenssl +@OPENSSL_WITH_DEPRECATED +@OPENSSL_WITH_PSK +MOSQUITTO_LWS:libwebsockets-openssl
     VARIANT:=ssl
 endef
 
@@ -110,7 +110,7 @@ endef
 define Package/libmosquitto
     $(call Package/libmosquitto/default)
     TITLE+= (With SSL Support)
-    DEPENDS+= +libopenssl
+    DEPENDS+= +libopenssl +@OPENSSL_WITH_DEPRECATED +@OPENSSL_WITH_PSK
     VARIANT=ssl
 endef
 define Package/libmosquitto-nossl


### PR DESCRIPTION
These OpenSSL config options are introduced as part of the patch set
https://lists.openwrt.org/pipermail/openwrt-devel/2016-June/041777.html
and https://github.com/lede-project/source/pull/103

Obviously this change can only be merged when the related OpenSSL changes are merged.

Signed-off-by: Dirk Feytons dirk.feytons@gmail.com
