### PR TITLE
BCP38: don't slow down established connections

### DIFF
--- a/net/bcp38/Makefile
+++ b/net/bcp38/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcp38
-PKG_VERSION:=4
+PKG_VERSION:=5
 PKG_RELEASE:=1
 PKG_LICENCE:=GPL-3.0+
 

--- a/net/bcp38/files/run.sh
+++ b/net/bcp38/files/run.sh
@@ -72,9 +72,9 @@ setup_iptables()
 	iptables -N "$IPTABLES_CHAIN" 2>/dev/null
 	iptables -F "$IPTABLES_CHAIN" 2>/dev/null
 
-	iptables -I output_rule -j "$IPTABLES_CHAIN"
-	iptables -I input_rule -j "$IPTABLES_CHAIN"
-	iptables -I forwarding_rule -j "$IPTABLES_CHAIN"
+	iptables -I output_rule -m state --state NEW -j "$IPTABLES_CHAIN"
+	iptables -I input_rule -m state --state NEW -j "$IPTABLES_CHAIN"
+	iptables -I forwarding_rule -m state --state NEW -j "$IPTABLES_CHAIN"
 
 	# always accept DHCP traffic
 	iptables -A "$IPTABLES_CHAIN" -p udp --dport 67:68 --sport 67:68 -j RETURN
@@ -90,9 +90,9 @@ destroy_ipset()
 
 destroy_iptables()
 {
-	iptables -D output_rule -j "$IPTABLES_CHAIN" 2>/dev/null
-	iptables -D input_rule -j "$IPTABLES_CHAIN" 2>/dev/null
-	iptables -D forwarding_rule -j "$IPTABLES_CHAIN" 2>/dev/null
+	iptables -D output_rule -m state --state NEW -j "$IPTABLES_CHAIN" 2>/dev/null
+	iptables -D input_rule -m state --state NEW -j "$IPTABLES_CHAIN" 2>/dev/null
+	iptables -D forwarding_rule -m state --state NEW -j "$IPTABLES_CHAIN" 2>/dev/null
 	iptables -F "$IPTABLES_CHAIN" 2>/dev/null
 	iptables -X "$IPTABLES_CHAIN" 2>/dev/null
 }


### PR DESCRIPTION
Enabling BCP38 causes an iptables rule to be inserted before this rule (on forwarding_rule chain):
ACCEPT     all  --  anywhere             anywhere             ID:66773300 ctstate RELATED,ESTABLISHED

This makes all forwarded packets go through the BCP38 ipset match, which slows
down download speed from 440 Mbit/s to 340 Mbit/s.

AFAICT that is not necessary: packets are rejected based on destination IP, so if they are rejected when trying to establish a new connection you won't have packets in the established state that would match the BCP38 rules anyway.

Put BCP38 match rule in first chain after established connections are handled:
enabling BCP38 doesn't affect download speed.

To test:

* disable BCP38
```sh
uci set bcp38.@bcp38[0].enabled=0
uci commit
/etc/init.d/firewall reload
```
* measure download speed from a machine on the LAN
* enable BCP38 (use your wan interface)
```sh
uci set bcp38.@bcp38[0].enabled=1
uci set bcp38.@bcp38[0].interface='pppoe-wan'
uci commit
/etc/init.d/firewall reload
```
* measure download speed from a machine on the LAN again
* Check that BCP38 is effective, e.g.  from a machine on the LAN do:
```sh
 ping -c 2 192.0.2.1
PING 192.0.2.1 (192.0.2.1) 56(84) bytes of data.
From 192.168.1.1 icmp_seq=1 Destination Net Unreachable
From 192.168.1.1 icmp_seq=2 Destination Net Unreachable
```

With this patch applied the 2 speeds should be about the same, without this patch I see a visible   drop of  100 Mbit/s (>20%).

I tested on this router:
```
system type		: Qualcomm Atheros QCA9558 ver 1 rev 0
machine			: TP-LINK TL-WR1043ND v2
processor		: 0
cpu model		: MIPS 74Kc V5.0
BogoMIPS		: 358.80
wait instruction	: yes
microsecond timers	: yes
tlb_entries		: 32
extra interrupt vector	: yes
hardware watchpoint	: yes, count: 4, address/irw mask: [0x0ffc, 0x0ffc, 0x0ffb, 0x0ffb]
isa			: mips1 mips2 mips32r1 mips32r2
ASEs implemented	: mips16 dsp dsp2
shadow register sets	: 1
kscratch registers	: 0
package			: 0
core			: 0
VCED exceptions		: not available
VCEI exceptions		: not available
```