### PR TITLE
nfs-kernel-server: fix segfault on x86_64

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=1.3.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MD5SUM:=1e2f3c1ed468dee02d00c534c002ea10
 
 PKG_SOURCE_URL:=@SF/nfs

--- a/net/nfs-kernel-server/patches/200-uclibc-fix.patch
+++ b/net/nfs-kernel-server/patches/200-uclibc-fix.patch
@@ -1,0 +1,29 @@
+diff -u --recursive nfs-utils-1.3.3-vanilla/support/export/hostname.c nfs-utils-1.3.3/support/export/hostname.c
+--- nfs-utils-1.3.3-vanilla/support/export/hostname.c	2016-03-31 20:14:11.101902452 -0400
++++ nfs-utils-1.3.3/support/export/hostname.c	2016-03-31 20:15:40.619134622 -0400
+@@ -101,6 +101,7 @@
+ 		.ai_protocol	= (int)IPPROTO_UDP,
+ 		.ai_flags	= AI_NUMERICHOST,
+ 		.ai_family	= AF_UNSPEC,
++		.ai_socktype    = 0,
+ 	};
+ 	struct sockaddr_in sin;
+ 	int error, inet4;
+@@ -350,7 +351,9 @@
+ 
+ 	/*
+ 	 * getaddrinfo(AI_NUMERICHOST) never fills in ai_canonname
++	 * ...well, it does on uclibc.
+ 	 */
++#ifndef __UCLIBC__
+ 	if (ai != NULL) {
+ 		free(ai->ai_canonname);		/* just in case */
+ 		ai->ai_canonname = strdup(buf);
+@@ -359,6 +362,7 @@
+ 			ai = NULL;
+ 		}
+ 	}
++#endif
+ 
+ 	return ai;
+ }


### PR DESCRIPTION
I previously made this pull request against master (#2568). That was a mistake because master uses musl. 15.05 still uses uclibc, so it requires this patch.

Signed-off-by: W. Michael Petullo <mike@flyn.org>