### PR TITLE
mwan3: fix dynamic interface l3 layer device detection

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Jeroen Louwes <jeroen.louwes@gmail.com>
 PKG_LICENSE:=GPLv2
 

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -64,7 +64,7 @@ ifup()
 
 	config_get enabled "$1" enabled 0
 
-	device=$(uci -p /var/state get network.$1.ifname) &> /dev/null
+	network_get_device device "$1"
 
 	if [ -n "$device" ] ; then
 		[ "$enabled" -eq 1 ] && ACTION=ifup INTERFACE=$1 DEVICE=$device /sbin/hotplug-call iface


### PR DESCRIPTION
Control script uses uci state to determine device name, which can't
account for dynamically created interfaces (eg. ncm/directip/mbim/uqmi
protocols).
The correct way of retrieving L3 device name is to use network_get_device
function from /lib/functions/network.sh.

Signed-off-by: Marcin Jurkowski <marcin1j@gmail.com>