### PR TITLE
libtirpc: Initial build of v1.0.2rc3, required for rpcbind.

### DIFF
--- a/libs/libtirpc/Config.in
+++ b/libs/libtirpc/Config.in
@@ -1,0 +1,24 @@
+menu "Configuration"
+	depends on PACKAGE_libtirpc
+
+	config LIBTIRPC_GSSAPI
+		bool
+		prompt "Enable GSSAPI support"
+		help
+			Enable this switch if you have a GSSAPI installed and you wish to use it.
+		default n
+
+		menu "GSSAPI selector"
+			depends on PACKAGE_libtirpc
+
+			config LIBTIRPC_KRB5
+				depends on LIBTIRPC_GSSAPI
+				bool
+				prompt "Enable KRB5's GSSAPI support"
+				help
+					Enable this switch if you have KRB5 installed and you wish to use it.
+				default y
+
+		endmenu
+
+endmenu

--- a/libs/libtirpc/Makefile
+++ b/libs/libtirpc/Makefile
@@ -1,0 +1,66 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libtirpc
+PKG_VERSION:=1.0.2
+PKG_RELEASE:=1
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=git://git.linux-nfs.org/projects/steved/libtirpc.git
+PKG_SOURCE_VERSION:=503ac2e9fa569d95e366766202a7ca840e28b28a
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_RELEASE)
+PKG_SOURCE:=$(PKG_SOURCE_SUBDIR).tar.gz
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+PKG_FIXUP:=autoreconf
+PKG_LICENSE:=BSD-4c
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+PKG_CONFIG_DEPENDS := \
+	CONFIG_LIBTIRPC_GSSAPI \
+	CONFIG_LIBTIRPC_KRB5
+
+include $(INCLUDE_DIR)/package.mk
+
+LIBTIRPC_DEPENDS:=
+CONFIGURE_ARGS += --disable-static
+ifeq ($(CONFIG_LIBTIRPC_GSSAPI),y)
+	ifeq ($(CONFIG_LIBTIRPC_KRB5),y)
+		LIBTIRPC_DEPENDS += +krb5-libs +e2fsprogs
+		TARGET_CPPFLAGS:=-I$(STAGING_DIR)/usr/include/krb5 $(TARGET_CPPFLAGS)
+	endif
+else
+	CONFIGURE_ARGS += --disable-gssapi
+endif
+
+define Package/libtirpc
+	SECTION:=libs
+	CATEGORY:=Libraries
+	DEPENDS:=$(LIBTIRPC_DEPENDS)
+	TITLE:=Transport-Independent RPC library
+	URL:=http://nfsv4.bullopensource.org/doc/tirpc_rpcbind.php
+endef
+
+define Package/libtirpc/description
+ Libtirpc is a port of Sun's Transport-Independent RPC library to Linux.
+ It's being developed by the Bull GNU/Linux NFSv4 project.
+endef
+
+define Package/libtirpc/config
+	source "$(SOURCE)/Config.in"
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
+endef
+
+define Package/libtirpc/install
+	$(INSTALL_DIR) $(1)/usr/lib $(1)/etc
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/netconfig $(1)/etc/netconfig
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/$(PKG_NAME).so.3.0.0 $(1)/usr/lib/$(PKG_NAME).so.3.0.0
+	$(LN) /usr/lib/$(PKG_NAME).so.3.0.0 $(1)/usr/lib/$(PKG_NAME).so.3
+	$(LN) /usr/lib/$(PKG_NAME).so.3.0.0 $(1)/usr/lib/$(PKG_NAME).so
+endef
+
+$(eval $(call BuildPackage,libtirpc))

--- a/libs/libtirpc/patches/800-bzero-to-memset.patch
+++ b/libs/libtirpc/patches/800-bzero-to-memset.patch
@@ -1,0 +1,11 @@
+--- a/src/des_impl.c
++++ b/src/des_impl.c
+@@ -588,7 +588,7 @@ _des_crypt (char *buf, unsigned len, str
+     }
+   tin0 = tin1 = tout0 = tout1 = xor0 = xor1 = 0;
+   tbuf[0] = tbuf[1] = 0;
+-  __bzero (schedule, sizeof (schedule));
++  memset (schedule, 0, sizeof (schedule));
+ 
+   return (1);
+ }

--- a/libs/libtirpc/patches/801-stringh-for-memset.patch
+++ b/libs/libtirpc/patches/801-stringh-for-memset.patch
@@ -1,0 +1,10 @@
+--- a/src/svc_raw.c
++++ b/src/svc_raw.c
+@@ -29,6 +29,7 @@
+ /*
+  * Copyright (c) 1986-1991 by Sun Microsystems Inc. 
+  */
++#include <string.h>
+ 
+ /*
+  * svc_raw.c,   This a toy for simple testing and timing.

--- a/libs/libtirpc/patches/802-pollh-redirect.patch
+++ b/libs/libtirpc/patches/802-pollh-redirect.patch
@@ -1,0 +1,22 @@
+--- a/src/svc_run.c
++++ b/src/svc_run.c
+@@ -37,7 +37,7 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <unistd.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ 
+ #include <rpc/rpc.h>
+--- a/src/rtime.c
++++ b/src/rtime.c
+@@ -46,7 +46,7 @@
+ #include <unistd.h>
+ #include <errno.h>
+ #include <sys/types.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <sys/socket.h>
+ #include <sys/time.h>
+ #include <netinet/in.h>


### PR DESCRIPTION
Configured without GSSAPI support.
Library required by rpcbind.

Signed-off-by: Graham Fairweather xotic750@gmail.com
