### PR TITLE
rpcbind: Initial build of v0.2.3

### DIFF
--- a/net/rpcbind/Makefile
+++ b/net/rpcbind/Makefile
@@ -1,0 +1,45 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rpcbind
+PKG_VERSION:=0.2.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=http://downloads.sourceforge.net/rpcbind/
+PKG_MD5SUM:=c8875246b2688a1adfbd6ad43480278d
+
+PKG_LICENSE:=BSD-4c
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/rpcbind
+	SECTION:=net
+	CATEGORY:=Network
+	DEPENDS:=+libtirpc
+	TITLE:=Universal addresses to RPC program number mapper
+	URL:=https://sourceforge.net/projects/rpcbind/
+endef
+
+define Package/rpcbind/description
+ The rpcbind utility is a server that converts RPC program numbers into
+ universal addresses. It must be running on the host to be able to make
+ RPC calls on a server on that machine.
+endef
+
+CONFIGURE_ARGS += \
+	--with-rpcuser=root \
+	--without-systemdsystemunitdir
+
+define Package/rpcbind/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/rpcbind $(1)/usr/bin/rpcbind
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/rpcinfo $(1)/usr/bin/rpcinfo
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/rpcbind $(1)/etc/init.d/rpcbind
+endef
+
+$(eval $(call BuildPackage,rpcbind))

--- a/net/rpcbind/files/rpcbind
+++ b/net/rpcbind/files/rpcbind
@@ -1,0 +1,13 @@
+#!/bin/sh /etc/rc.common
+
+START=19
+STOP=19
+
+USE_PROCD=1
+PROG=/usr/bin/rpcbind
+
+start_service() {
+	procd_open_instance
+	procd_set_param command "$PROG" -f
+	procd_close_instance
+}

--- a/net/rpcbind/patches/800-do-not-use-xpauth.patch
+++ b/net/rpcbind/patches/800-do-not-use-xpauth.patch
@@ -1,0 +1,20 @@
+--- a/src/rpcb_svc_com.c
++++ b/src/rpcb_svc_com.c
+@@ -1274,10 +1274,17 @@ handle_reply(int fd, SVCXPRT *xprt)
+ 	a.rmt_localvers = fi->versnum;
+ 
+ 	xprt_set_caller(xprt, fi);
++#if defined(SVC_XP_AUTH)
++	SVC_XP_AUTH(xprt) = svc_auth_none;
++#else 
+ 	xprt->xp_auth = &svc_auth_none;
++#endif
+ 	svc_sendreply(xprt, (xdrproc_t) xdr_rmtcall_result, (char *) &a);
++#if !defined(SVC_XP_AUTH)
+ 	SVCAUTH_DESTROY(xprt->xp_auth);
+ 	xprt->xp_auth = NULL;
++#endif
++
+ done:
+ 	if (buffer)
+ 		free(buffer);

--- a/net/rpcbind/patches/801-fix-implicit-declarations.patch
+++ b/net/rpcbind/patches/801-fix-implicit-declarations.patch
@@ -1,0 +1,20 @@
+--- a/src/pmap_svc.c
++++ b/src/pmap_svc.c
+@@ -50,6 +50,7 @@ static	char sccsid[] = "@(#)pmap_svc.c 1
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <stdio.h>
++#include <string.h>
+ #include <rpc/rpc.h>
+ #include <rpc/pmap_prot.h>
+ #include <rpc/rpcb_prot.h>
+--- a/src/warmstart.c
++++ b/src/warmstart.c
+@@ -35,6 +35,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <stdio.h>
++#include <string.h>
+ #include <rpc/rpc.h>
+ #include <rpc/rpcb_prot.h>
+ #include <rpc/xdr.h>

--- a/net/rpcbind/patches/802-fix-redirections.patch
+++ b/net/rpcbind/patches/802-fix-redirections.patch
@@ -1,0 +1,38 @@
+--- a/src/rpcb_svc_com.c
++++ b/src/rpcb_svc_com.c
+@@ -42,7 +42,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <sys/param.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <bits/poll.h>
+ #include <sys/socket.h>
+ #include <rpc/rpc.h>
+--- a/src/rpcbind.c
++++ b/src/rpcbind.c
+@@ -42,11 +42,11 @@
+ 
+ #include <sys/types.h>
+ #include <sys/stat.h>
+-#include <sys/errno.h>
++#include <errno.h>
+ #include <sys/resource.h>
+ #include <sys/wait.h>
+ #include <sys/time.h>
+-#include <sys/signal.h>
++#include <signal.h>
+ #include <sys/file.h>
+ #include <sys/socket.h>
+ #include <sys/un.h>
+--- a/src/util.c
++++ b/src/util.c
+@@ -45,7 +45,7 @@
+ #include <net/if.h>
+ #include <netinet/in.h>
+ #include <ifaddrs.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <rpc/rpc.h>
+ #include <errno.h>
+ #include <stdlib.h>


### PR DESCRIPTION
`rpcbind` is the replacement for `portmap` offering IPv6 support.
Requires `libtirpc` (https://github.com/openwrt/packages/pull/2857)

Signed-off-by: Graham Fairweather xotic750@gmail.com
