### PR TITLE
krb5: Bump to v1.14.2

### DIFF
--- a/net/krb5/Makefile
+++ b/net/krb5/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=krb5
-PKG_VERSION:=1.14.1
+PKG_VERSION:=1.14.2
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=NOTICE
 
 PKG_SOURCE:=krb5-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://web.mit.edu/kerberos/dist/krb5/1.14/
-PKG_MD5SUM:=400de0cabbfbe85c2c36f60347bf7dc6
+PKG_MD5SUM:=2e35f0af0344d68aba99cef616d3a64f
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/net/krb5/patches/001-fix-uninitialized-warning-errors.patch
+++ b/net/krb5/patches/001-fix-uninitialized-warning-errors.patch
@@ -1,6 +1,6 @@
 --- a/src/lib/kadm5/str_conv.c
 +++ b/src/lib/kadm5/str_conv.c
-@@ -131,7 +131,7 @@
+@@ -131,7 +131,7 @@ raw_flagspec_to_mask(const char *s, int
  {
      int found = 0, invert = 0;
      size_t i;
@@ -11,7 +11,7 @@
      for (i = 0; !found && i < NFTBL; i++) {
 --- a/src/lib/krad/packet.c
 +++ b/src/lib/krad/packet.c
-@@ -253,7 +253,7 @@
+@@ -253,7 +253,7 @@ krad_packet_new_request(krb5_context ctx
  {
      krb5_error_code retval;
      krad_packet *pkt;
@@ -22,7 +22,7 @@
      pkt = packet_new();
 --- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
 +++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
-@@ -3618,7 +3618,7 @@
+@@ -3618,7 +3618,7 @@ pkinit_open_session(krb5_context context
  {
      CK_ULONG i, r;
      unsigned char *cp;
@@ -33,7 +33,7 @@
      CK_TOKEN_INFO tinfo;
 --- a/src/util/profile/prof_file.c
 +++ b/src/util/profile/prof_file.c
-@@ -309,7 +309,7 @@
+@@ -309,7 +309,7 @@ errcode_t profile_update_file_data_locke
      unsigned long frac;
      time_t now;
  #endif
@@ -44,7 +44,7 @@
  #ifdef HAVE_STAT
 --- a/src/kadmin/ktutil/ktutil_funcs.c
 +++ b/src/kadmin/ktutil/ktutil_funcs.c
-@@ -64,7 +64,7 @@
+@@ -64,7 +64,7 @@ krb5_error_code ktutil_delete(context, l
      krb5_kt_list *list;
      int idx;
  {


### PR DESCRIPTION
Added John's changes (https://github.com/openwrt/packages/pull/2777) to remove errors and rebased the patch.

Signed-off-by: Graham Fairweather <xotic750@gmail.com>