### PR TITLE
[utils/zoneinfo] Updated to the latest release version

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2016d
-PKG_VERSION_CODE:=2016d
+PKG_VERSION:=2016e
+PKG_VERSION_CODE:=2016e
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -20,14 +20,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION_CODE).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_MD5SUM:=14bf84b6c2cdab0a9428991e0150ebe6
+PKG_MD5SUM:=43f9f929a8baf0dd2f17efaea02c2d2a
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   MD5SUM:=06fc6fc111cd8dd681abdc5326529afd
+   MD5SUM:=6e6d3f0046a9383aafba8c2e0708a3a3
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
The 2016e release of the tz code and data is available.  It reflects the
following changes, which were either circulated on the tz mailing list or are
relatively minor technical or administrative changes:

   Changes affecting future time stamps

     Africa/Cairo observes DST in 2016 from July 7 to the end of October.
     Guess October 27 and 24:00 transitions. (Thanks to Steffen Thorsen.)
     For future years, guess April's last Thursday to October's last
     Thursday except for Ramadan.

   Changes affecting past time stamps

     Locations while uninhabited now use '-00', not 'zzz', as a
     placeholder time zone abbreviation.  This is inspired by Internet
     RFC 3339 and is more consistent with numeric time zone
     abbreviations already used elsewhere.  The change affects several
     arctic and antarctic locations, e.g., America/Cambridge_Bay before
     1920 and Antarctica/Troll before 2005.

     Asia/Baku's 1992-09-27 transition from +04 (DST) to +04 (non-DST) was
     at 03:00, not 23:00 the previous day.  (Thanks to Michael Deckers.)

   Changes to code

     zic now outputs a dummy transition at time 2**31 - 1 in zones
     whose POSIX-style TZ strings contain a '<'.  This mostly works
     around Qt bug 53071 <https://bugreports.qt.io/browse/QTBUG-53071>.
     (Thanks to Zhanibek Adilbekov for reporting the Qt bug.)

   Changes affecting documentation and commentary

     tz-link.htm says why governments should give plenty of notice for
     time zone or DST changes, and refers to Matt Johnson's blog post.

     tz-link.htm mentions Tzdata for Elixir.  (Thanks to Matt Johnson.)