### PR TITLE
debootstrap: Filename, version and MD5SUM

### DIFF
--- a/admin/debootstrap/Makefile
+++ b/admin/debootstrap/Makefile
@@ -9,13 +9,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=debootstrap
-PKG_VERSION:=1.0.60~bpo70+1
+PKG_VERSION:=1.0.64~bpo70+1
 PKG_RELEASE:=1
 PKG_MAINTAINER=Daniel Golle <daniel@makrotopia.org>
 
 PKG_SOURCE:=$(PKG_NAME)-udeb_$(PKG_VERSION)_all.udeb
 PKG_SOURCE_URL:=http://ftp.debian.org/debian/pool/main/d/debootstrap
-PKG_MD5SUM:=6d4e3b97981b9e0bb86f49d8edac91af
+PKG_MD5SUM:=554185ccc6cb27fc15d0e9cfed260cb5
 
 UNPACK_CMD=ar -p "$(DL_DIR)/$(PKG_SOURCE)" data.tar.xz | xzcat | tar -C $(1) -xf -
 


### PR DESCRIPTION
Update debootstrap package data to reflect available file on Debian pool