### PR TITLE
Change lm-sensors source URI to the working clone on GitHub

### DIFF
--- a/utils/lm-sensors/Makefile
+++ b/utils/lm-sensors/Makefile
@@ -9,11 +9,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lm-sensors
 PKG_VERSION:=3.3.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
-PKG_SOURCE:=lm_sensors-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=http://dl.lm-sensors.org/lm-sensors/releases
-PKG_MD5SUM:=da506dedceb41822e64865f6ba34828a
+PKG_SOURCE_PROTO=git
+PKG_SOURCE_URL:=https://github.com/groeck/lm-sensors.git
+PKG_SOURCE_VERSION=f8cdcc35bff0785aecf49d9a8484a71ce3ebee4f
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=GPL-2.0+ LGPL-2.1+
 


### PR DESCRIPTION
Since lm-sensors.org has been dead for a while and any device profile that uses lm-sensors will not be able to download the package sources when making a clean build. See related issue #2794 

Signed-off-by: Toni Kaija <toni.kaija@corefactory.com>