### PR TITLE
ssmtp: change symlink handling

### DIFF
--- a/mail/ssmtp/Makefile
+++ b/mail/ssmtp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ssmtp
 PKG_VERSION:=2.64
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 PKG_LICENSE:=GPL-2.0+
 
@@ -53,11 +53,7 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/revaliases $(1)/etc/ssmtp/
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ssmtp $(1)/usr/sbin/
-endef
-
-define Package/$(PKG_NAME)/postinst
-#!/bin/sh
-ln -sf ssmtp $${IPKG_INSTROOT}/usr/sbin/sendmail
+	ln -s /usr/sbin/ssmtp $(1)/usr/sbin/sendmail
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
* sendmail symlink handling is no longer forced and part of install step

Signed-off-by: Dirk Brenken <dev@brenken.org>