### PR TITLE
procps-ng: fix build on systems without gettext development utilities

### DIFF
--- a/utils/procps-ng/Makefile
+++ b/utils/procps-ng/Makefile
@@ -21,6 +21,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -39,9 +40,9 @@ define Package/procps-ng/Default
   MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
 endef
 
-define Build/Configure
-	(cd $(PKG_BUILD_DIR); echo "$(PKG_VERSION)" > "$(PKG_BUILD_DIR)/.tarball-version"; ./autogen.sh );
-	$(call Build/Configure/Default)
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	echo "$(PKG_VERSION)" > "$(PKG_BUILD_DIR)/.tarball-version"
 endef
 
 define Package/procps-ng

--- a/utils/procps-ng/patches/100-no-tests-docs.patch
+++ b/utils/procps-ng/patches/100-no-tests-docs.patch
@@ -1,0 +1,26 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -13,10 +13,7 @@ PACKAGE_VERSION = @PACKAGE_VERSION@
+ 
+ ACLOCAL_AMFLAGS = -I m4
+ SUBDIRS = \
+-	include \
+-	man-po \
+-	po \
+-	testsuite
++	include
+ 
+ AM_CFLAGS = -Iproc
+ LDADD = ./proc/libprocps.la $(CYGWINFLAGS)
+--- a/configure.ac
++++ b/configure.ac
+@@ -256,8 +256,5 @@ AC_CHECK_FUNCS([__fpending alarm atexit
+ 
+ AC_CONFIG_FILES([Makefile
+                  include/Makefile
+-                 man-po/Makefile
+-                 po/Makefile.in
+-                 proc/libprocps.pc
+-                 testsuite/Makefile])
++                 proc/libprocps.pc])
+ AC_OUTPUT


### PR DESCRIPTION
The current procps-ng Makefile calls the shipped autogen.sh script which
introduces incorrect implicit dependencies on host utilities, leading to
the following error observed on a minimal build system:

    (cd .../procps-ng-3.3.11; echo "3.3.11" > ".../procps-ng-3.3.11/.tarball-version"; ./autogen.sh );
    You must have autopoint installed to generate procps-ng build system.
    The autopoint command is part of the GNU gettext package.
    Makefile:96: recipe for target '.../procps-ng-3.3.11/.configured_yynyyyyy' failed
    make[3]: *** [.../procps-ng-3.3.11/.configured_yynyyyyy] Error 1

Apply the following changes in order to fix compilation:

 - Apply the generic autoreconf fixup to generate configure and Makefiles
 - Use Build/Prepare to populate .tarball-version and revert Build/Configure
   to its default implementation
 - Disable to build of docs and tests as those require additional utilities
   not guaranteed to be present

Fixes #2890.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>