### PR TITLE
libnet-1.2.x: Enable pf_packet socket support by setting libnet_cv_have_packet_socket to yes

### DIFF
--- a/libs/libnet-1.2.x/Makefile
+++ b/libs/libnet-1.2.x/Makefile
@@ -38,7 +38,7 @@ CONFIGURE_ARGS += \
 
 CONFIGURE_VARS += \
 	ac_cv_libnet_endianess=$(ENDIANESS) \
-	ac_libnet_have_pf_packet=yes \
+	libnet_cv_have_packet_socket=yes \
 	LL_INT_TYPE=libnet_link_linux
 
 define Build/Configure


### PR DESCRIPTION
Maintainer: Mislav Novakovic <mislav.novakovic@sartura.hr>
Compile tested: brcm63xx
Run tested: brcm63xx

PF_PACKET support is not enabled by setting ac_libnet_have_pf_packet but by setting libnet_cv_have_packet_socket in the Makefile.

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>