### PR TITLE
horst: Use version 5.0

### DIFF
--- a/net/horst/Makefile
+++ b/net/horst/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=horst
-PKG_VERSION:=4.2
+PKG_VERSION:=5.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-git.tar.gz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=git://br1.einfach.org/horst
+PKG_SOURCE_URL:=git://github.com/br101/horst.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=version-$(PKG_VERSION)
 
@@ -25,13 +25,13 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-MAKE_FLAGS += DEBUG=1
+MAKE_FLAGS += DEBUG=1 LIBNL=tiny
 
 define Package/horst
 	SECTION:=net
 	CATEGORY:=Network
 	SUBMENU:=wireless
-	DEPENDS:=+libncurses
+	DEPENDS:=+libncurses +libnl-tiny
 	MAINTAINER:=Bruno Randolf <br1@einfach.org>
 	TITLE:=Highly Optimized 802.11 Radio Scanning Tool
 	URL:=http://br1.einfach.org/tech/horst/


### PR DESCRIPTION
Maintainer: Bruno Randolf <br1@einfach.org>
Compile tested: BCM2709, OpenWRT 15.05
Run tested: BCM2709, OpenWRT 15.05

Description:

Update horst to latest version

Signed-off-by: Bruno Randolf <br1@einfach.org>