### PR TITLE
Nano: update to 2.6.0

### DIFF
--- a/utils/nano/Makefile
+++ b/utils/nano/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nano
-PKG_VERSION:=2.5.3
+PKG_VERSION:=2.6.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@GNU/nano
-PKG_MD5SUM:=a04d77611422ab4b6a7b489650c7a793
+PKG_SOURCE_URL:=https://www.nano-editor.org/dist/v2.6/
+PKG_MD5SUM:=89051965a1de963190696348bc291b86
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
@@ -33,7 +33,7 @@ define Package/nano
 endef
 
 define Package/nano/description
-  GNU nano (Nano's ANOther editor, or Not ANOther editor) is an enhanced clone
+  Nano (Nano's ANOther editor, or Not ANOther editor) is an enhanced clone
   of the Pico text editor.
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE Trunk Fedora 24
Run tested: LEDE Trunk KVM

Description:  Updates nano to 2.6.0.  With this release, nano is no longer a GNU project, so switching back to using the nano-editor.org download location.
Signed-off-by: Jonathan Bennett <jbennett@incomsystems.biz>