### PR TITLE
bluelog: fix oui.txt processing

### DIFF
--- a/utils/bluelog/Makefile
+++ b/utils/bluelog/Makefile
@@ -9,11 +9,15 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bluelog
 PKG_VERSION:=1.1.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.digifail.com/software/bluelog
 PKG_MD5SUM:=614d0fe65bae68acff1d33d9f86e4805
+
+OUI_SOURCE:=oui-2016-05-30.txt.gz
+OUI_URL:=http://sources.lede-project.org/
+OUI_MD5SUM:=38048729fdb5a7a7e0c5db6a51dc2dd1
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
@@ -58,10 +62,22 @@ define Package/bluelog-live/description
   Bluelog which creates a real-time webpage of discovered Bluetooth devices.
 endef
 
+define Download/oui.txt
+  FILE:=$(OUI_SOURCE)
+  URL:=$(OUI_URL)
+  MD5SUM:=$(OUI_MD5SUM)
+endef
+
 TARGET_CFLAGS += -DOPENWRT
 
 MAKE_FLAGS += \
 	 LIBS="$(TARGET_LDFLAGS) -lbluetooth -lm"
+
+define Build/Prepare
+	$(eval $(call Download,oui.txt))
+	$(Build/Prepare/Default)
+	zcat $(DL_DIR)/$(OUI_SOURCE) > $(PKG_BUILD_DIR)/oui.tmp
+endef
 
 define Package/bluelog/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/utils/bluelog/patches/100-gen-oui-fix-tempfile-use-mirror.patch
+++ b/utils/bluelog/patches/100-gen-oui-fix-tempfile-use-mirror.patch
@@ -1,0 +1,31 @@
+--- a/gen_oui.sh
++++ b/gen_oui.sh
+@@ -3,7 +3,7 @@
+ VER="1.2"
+ 
+ # Location of tmp file
+-TMPFILE="/tmp/oui.tmp"
++TMPFILE="./oui.tmp"
+ 
+ # File to write
+ OUIFILE="oui.txt"
+@@ -22,10 +22,7 @@ exit 1
+ 
+ get_oui ()
+ {
+-echo -n "Downloading OUI file from IEEE..."
+-wget --quiet -O $TMPFILE http://standards.ieee.org/develop/regauth/oui/oui.txt || \
+-	ErrorMsg ERR "Unable to contact IEEE server!"
+-
++[ -f "$TMPFILE" ] || ErrorMsg ERR "Unable to find $TMPFILE"
+ echo "OK"
+ }
+ 
+@@ -44,7 +41,6 @@ echo "OK"
+ clean_all ()
+ {
+ echo -n "Removing files..."
+-rm -f $TMPFILE
+ rm -f $OUIFILE
+ echo "OK"
+ }


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: LEDE trunk x86_64
Run tested: no

Description:
 - Use a temporary file path within the package build directory to avoid
   cluttering the host systems `/tmp` directory.

 - Switch to a gzipped, snapshotted copy of the `oui.txt` file since the
   upstream IEEE server is extremely slow, also fetching an unversioned HTTP
   resource during compilation breaks reproducable builds.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>
[rework to use standard download facility]
Signed-off-by: Etienne CHAMPETIER <champetier.etienne@gmail.com>