### PR TITLE
packages/utils: new package relayctl

### DIFF
--- a/utils/relayctl/Makefile
+++ b/utils/relayctl/Makefile
@@ -1,0 +1,45 @@
+# Copyright (C) 2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=relayctl
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://download.sourceforge.net/project/relayctl/relayctl-$(PKG_VERSION)
+PKG_MAINTAINER:=Heinrich Schuchardt <xypron.glpk@gmx.de>
+PKG_MD5SUM:=24c848e0d705421dcd6accfffa31f704
+PKG_LICENSE:=BSD
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/relayctl
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Simple command-line control of SainSmart USB relay boards
+  URL:=https://github.com/darryln/relayctl
+  DEPENDS:= +libftdi1 +udev
+endef
+
+define Package/relayctl/description
+ Simple command-line control of SainSmart USB relay boards based on
+ FTDI chips using bitbang mode.
+endef
+
+TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include/libftdi1
+
+define Package/relayctl/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/$(PKG_NAME) $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/lib/udev/rules.d/
+	$(CP) $(PKG_BUILD_DIR)/examples/60-relayctl.rules $(1)/lib/udev/rules.d/
+endef
+
+$(eval $(call BuildPackage,relayctl))

--- a/utils/relayctl/patches/0001-ftdi1.patch
+++ b/utils/relayctl/patches/0001-ftdi1.patch
@@ -1,0 +1,26 @@
+From 13556aaf94a2b0738a835a29f76be41d775a2d33 Mon Sep 17 00:00:00 2001
+From: Heinrich Schuchardt <xypron.glpk@gmx.de>
+Date: Sun, 3 Jul 2016 15:51:43 +0200
+Subject: [PATCH] Use -lftdi1
+
+Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
+---
+ src/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index a533d5c..4dbe6b5 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -1,7 +1,7 @@
+ sbin_PROGRAMS = \
+   relayctl
+ 
+-relayctl_LDFLAGS = -lftdi
++relayctl_LDFLAGS = -lftdi1
+ 
+ relayctl_SOURCES = relayctl.c
+ 
+-- 
+2.1.4
+


### PR DESCRIPTION
Maintainer: @xypron
Compile tested: sunxi, Lamobo_R1, OpenWRT HEAD
Run tested: sunxi, Lamobo_R1, OpenWrt Chaos Calmer

Description:

Package relayctl provides a command-line tool to control
SainSmart USB relay boards based on FTDI chips using bitbang
mode.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>