### PR TITLE
lighttpd: Update and small fix

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
-PKG_VERSION:=1.4.38
+PKG_VERSION:=1.4.39
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://download.lighttpd.net/lighttpd/releases-1.4.x
-PKG_MD5SUM:=7adc12323f37ed24ecf026c7547b577d
+PKG_MD5SUM:=63c7563be1c7a7a9819a51f07f1af8b2
 
 PKG_LICENSE:=BSD-3c
 PKG_LICENSE_FILES:=COPYING

--- a/net/lighttpd/patches/01-set-path.patch
+++ b/net/lighttpd/patches/01-set-path.patch
@@ -1,0 +1,14 @@
+--- a/src/mod_cgi.c.orig
++++ b/src/mod_cgi.c
+@@ -958,6 +958,11 @@ static int cgi_create_env(server *srv, c
+ 		force_assert(s);
+ 		cgi_env_add(&env, CONST_STR_LEN("REQUEST_METHOD"), s, strlen(s));
+ 
++		s = getenv("PATH");
++		if (s != NULL) {
++			cgi_env_add(&env, CONST_STR_LEN("PATH"), s, strlen(s));
++		}
++
+ 		if (!buffer_string_is_empty(con->request.pathinfo)) {
+ 			cgi_env_add(&env, CONST_STR_LEN("PATH_INFO"), CONST_BUF_LEN(con->request.pathinfo));
+ 		}


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: mpc85xx-p2020 & arm-mvebu, OpenWRT 15.01
Run tested: mpc85xx-p2020, Turris 1.1, OpenWRT 15.01, runs and web works

Description:
Updating to the latest stable releasing and improving behavior of CGI scripts a little bit.
