### PR TITLE
lang/perlbase: Fix missing utf8 dependency on unicore

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=5.22.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=ftp://ftp.cpan.org/pub/CPAN/src/5.0 \
 		http://www.cpan.org/src/5.0 \

--- a/lang/perl/perlbase.mk
+++ b/lang/perl/perlbase.mk
@@ -1518,7 +1518,7 @@ $(eval $(call BuildPackage,perlbase-user))
 define Package/perlbase-utf8
 $(call Package/perlbase-template)
 TITLE:=utf8 perl module
-DEPENDS+=+perlbase-essential +perlbase-re
+DEPENDS+=+perlbase-essential +perlbase-re +perlbase-unicore
 endef
 
 define Package/perlbase-utf8/install


### PR DESCRIPTION
---

Maintainer: @Naoir 
Compile tested: ar71xx, Netgear WNDR3800, custom build, recent trunk
Run tested: as compile tested, verfified against git-gitweb (to be pushed) which has a dependency on perl-utf8 for the grep search function.

Description:

perlbase-utf8 depends on perlbase-unicore however that dependency was missing.
This patch fixes that.

Signed-off-by: Daniel Dickinson lede@daniel.thecshore.com
