### PR TITLE
net/gitolite: Add gitolite for git repo administration/access control

### DIFF
--- a/net/gitolite/Makefile
+++ b/net/gitolite/Makefile
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2009-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gitolite
+PKG_VERSION:=3.6.5
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://github.com/cshore/gitolite
+PKG_SOURCE_VERSION:=d0409ae1164030913801d37ce5425ed93529c69d
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gitolite
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Version Control Systems
+  DEPENDS:=+perlbase-essential +perlbase-sys +perlbase-data +perlbase-digest +perlbase-env +perlbase-time +git +perlbase-findbin +perlbase-storable +perlbase-text +perlbase-getopt +perlbase-utf8 +openssh-keygen +openssh-server +openssh-moduli perl
+  TITLE:=Easy administration of git repositories
+  URL:=http://gitolite.com/gitlolite
+  MAINTAINER:=Daniel Dickinson <lede@daniel.thecshore.com>
+  USERID:=git=382:git=382
+endef
+
+define Package/gitolite/description
+  Gitolite is a system for managing access to git repositories
+endef
+
+define Package/gitolite/postinst
+sed -i -e 's,/var/run/git,/srv/git,' $${IPKG_INSTROOT}/etc/passwd
+sed -i -e 's,git:\(.*\):/bin/false,git:\1:/bin/ash,' $${IPKG_INSTROOT}/etc/passwd
+endef
+
+define Build/Configure
+	true
+endef
+
+define Build/Compile
+	mkdir -p $(PKG_INSTALL_DIR)/usr/libexec/gitolite	
+	$(PKG_BUILD_DIR)/install -to $(PKG_INSTALL_DIR)/usr/libexec/gitolite
+	mkdir -p $(PKG_INSTALL_DIR)/usr/bin
+	ln -sf /usr/libexec/gitolite/gitolite $(PKG_INSTALL_DIR)/usr/bin/gitolite
+endef
+
+define Package/gitolite/install
+	$(INSTALL_DIR) $(1)
+	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
+endef
+
+$(eval $(call BuildPackage,gitolite))


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, KVM VM, custom build, recent trunk
Run tested: As compile tested, in daily use for my own work, tested ACLs and integration with gitweb.

Description:

Adds gitolite package which is a handy administrative tool for
managing shared git repositories.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>