### PR TITLE
mail/msmtp: Make msmtp ssl version depend on ca-bundle

### DIFF
--- a/mail/msmtp/Makefile
+++ b/mail/msmtp/Makefile
@@ -44,7 +44,7 @@ endef
 
 define Package/msmtp
 $(call Package/msmtp/Default)
-  DEPENDS+= +libopenssl
+  DEPENDS+= +libopenssl +ca-bundle
   TITLE+= (with SSL support)
   VARIANT:=ssl
 endef


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: ar71xx, Netgear WNDR3800, custom build, recent trunk
Run tested: As with compile tested, verified through sending mail via mail provider.

Description:

msmtp fails when /etc/ssl/certs/ca-certifictes.crt bundle is
not present (for the SSL version), therefore add a dependency
on ca-bundle packages (newly added to trunk).

Signed-off-by: Daniel Dickinson <openwrt@daniel.thecshore.com>