### PR TITLE
mail/msmtp: Depends on libintl

### DIFF
--- a/mail/msmtp/Makefile
+++ b/mail/msmtp/Makefile
@@ -44,7 +44,7 @@ endef
 
 define Package/msmtp
 $(call Package/msmtp/Default)
-  DEPENDS+= +libopenssl
+  DEPENDS+= +libopenssl +libintl
   TITLE+= (with SSL support)
   VARIANT:=ssl
 endef
@@ -60,6 +60,7 @@ endef
 
 define Package/msmtp-nossl
 $(call Package/msmtp/Default)
+  DEPENDS+= +libintl
   TITLE+= (without SSL support)
   VARIANT:=nossl
 endef


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: ar71xx, Netgear WNDR3800, custom build, recent trunk
Run tested: as with compile tested, in combination with ca-bundle patch, building and sending mail from SSL mail provider.

Description:

Fix issue #1820 by depending on libintl.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>