### PR TITLE
[utils/zoneinfo] Updated to the latest release version

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2016e
-PKG_VERSION_CODE:=2016e
+PKG_VERSION:=2016f
+PKG_VERSION_CODE:=2016f
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -20,14 +20,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION_CODE).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_MD5SUM:=43f9f929a8baf0dd2f17efaea02c2d2a
+PKG_MD5SUM:=b20b3c1618db1984aac685e763de001d
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   MD5SUM:=6e6d3f0046a9383aafba8c2e0708a3a3
+   MD5SUM:=b93618bb84e38dee102e0e41ec9d13e2
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: ti omap targets, custom build. OpenWrt  master branch
Run tested: n/a

Description:

Changes affecting future time stamps

     The Egyptian government changed its mind on short notice, and Africa/Cairo will not introduce DST starting 2016-07-07 after all.
     (Thanks to Mina Samuel.)

     Asia/Novosibirsk switches from +06 to +07 on 2016-07-24 at 02:00.
     (Thanks to Stepan Golosunov.)

   Changes to past and future time stamps

     Asia/Novokuznetsk and Asia/Novosibirsk now use numeric time zone abbreviations instead of invented ones.

   Changes affecting past time stamps

     Europe/Minsk's 1992-03-29 spring-forward transition was at 02:00 not 00:00.
     (Thanks to Stepan Golosunov.)