### PR TITLE
ipsec-tools: fix syntax error in default racoon config

### DIFF
--- a/net/ipsec-tools/Makefile
+++ b/net/ipsec-tools/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ipsec-tools
 PKG_VERSION:=0.8.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_MAINTAINER := "Noah Meyerhans <frodo@morgul.net>"
 PKG_LICENSE := BSD-3-Clause
 

--- a/net/ipsec-tools/files/racoon
+++ b/net/ipsec-tools/files/racoon
@@ -60,7 +60,7 @@ config sainfo 'welcome'
 	option	defdomain	'myhome.local'
 
 config sainfo 'client'
-	p2_proposal		'std_p2'
+	option  p2_proposal	'std_p2'
 
 config tunnel 'Office'
 	option	enabled		1


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: -
Run tested: -

Description:

The default /etc/config/racoon shipped by ipsec-tools lacks an option keyword
on the p2_proposal line, leading to a syntax error when processing the file.

I didn't compile or run test as the change is too trivial for that.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>