### PR TITLE
coova-chilli: Fix UCI parse error

### DIFF
--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.3.0+20141128
 PKG_MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=git://github.com/coova/coova-chilli

--- a/net/coova-chilli/files/chilli.config
+++ b/net/coova-chilli/files/chilli.config
@@ -89,13 +89,13 @@ config chilli
 
     # IP address of radius server 1
     # For most installations you need to modify this option.
-    radiusserver1 rad01.chillispot.org
+    option radiusserver1 rad01.chillispot.org
 
     # IP address of radius server 2
     # If you have only one radius server you should set radiusserver2 to the
     # same value as radiusserver1.
     # For most installations you need to modify this option.
-    radiusserver2 rad02.chillispot.org
+    option radiusserver2 rad02.chillispot.org
 
     # Radius authentication port
     # The UDP port number to use for radius authentication requests.
@@ -154,7 +154,7 @@ config chilli
     # Ethernet interface to listen to.
     # This is the network interface which is connected to the access points.
     # In a typical configuration this option should be set to eth1.
-    dhcpif eth1
+    option dhcpif eth1
 
     # Use specified MAC address.
     # An address in the range  00:00:5E:00:02:00 - 00:00:5E:FF:FF:FF falls
@@ -171,7 +171,7 @@ config chilli
     # Universal access method (UAM) parameters
 
     # URL of web server handling authentication.
-    uamserver https://radius.chillispot.org/hotspotlogin
+    option uamserver https://radius.chillispot.org/hotspotlogin
 
     # URL of welcome homepage.
     # Unauthenticated users will be redirected to this URL. If not specified


### PR DESCRIPTION
Maintainer: @kaloz 

UCI commands report errors in parsing coova-chilli
sample configuration file. This PR fixes this issue by using
proper format in configuration.

Signed-off-by: Rajan Vaja <rajan.vaja@gmail.com>