### PR TITLE
net/wireguard update to 0.0.20160708.1

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=wireguard
 
-PKG_VERSION:=0.0.20160630
+PKG_VERSION:=0.0.20160708.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=WireGuard-experimental-$(PKG_VERSION).tar.xz


### PR DESCRIPTION
net/wireguard
update as mentioned in author email 
"
  * persistent keepalive: start sending immediately -- the previously released
    feature was not useful without this extra commit. So, getting this in here
    now so that people can actually test this out. Sorry for the churn. Don't
    bother packaging the previous snapshot.
"