### PR TITLE
linuxptp: shrink binaries and fix musl compile error

### DIFF
--- a/net/linuxptp/Makefile
+++ b/net/linuxptp/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 OpenWrt.org
+# Copyright (C) 2015-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linuxptp
 PKG_VERSION:=20151118
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_REV:=999c86f4a9da4bf4508b3a69289f58166ed18a55
 
 PKG_MAINTAINER:=Wojciech Dubowik <Wojciech.Dubowik@neratec.com>
@@ -40,6 +40,9 @@ define Package/linuxptp/description
  PTP was developed to provide very precise time coordination of LAN connected
  computers.
 endef
+
+MAKE_VARS += \
+	EXTRA_CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)"
 
 define Package/linuxptp/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/net/linuxptp/patches/001-musl-fix.patch
+++ b/net/linuxptp/patches/001-musl-fix.patch
@@ -1,7 +1,5 @@
-Index: linuxptp-20151118/raw.c
-===================================================================
---- linuxptp-20151118.orig/raw.c	2016-01-08 13:39:56.000000000 +0100
-+++ linuxptp-20151118/raw.c	2016-01-13 09:16:51.951784148 +0100
+--- a/raw.c
++++ b/raw.c
 @@ -20,7 +20,6 @@
  #include <fcntl.h>
  #include <linux/filter.h>
@@ -10,3 +8,14 @@ Index: linuxptp-20151118/raw.c
  #include <net/if.h>
  #include <netinet/in.h>
  #include <netpacket/packet.h>
+--- a/util.h
++++ b/util.h
+@@ -20,6 +20,8 @@
+ #ifndef HAVE_UTIL_H
+ #define HAVE_UTIL_H
+ 
++#include <time.h>
++
+ #include "ddt.h"
+ #include "ether.h"
+ 


### PR DESCRIPTION
Maintainer: @wodu
Compile tested: ar71xx, wndr3700v2, LEDE r865
Run tested: ar71xx, wndr3700v2, LEDE r865

Description: Binaries are significantly bloated as the -Os CFLAG is not being honoured.