### PR TITLE
grilo: update to 0.3.1

### DIFF
--- a/multimedia/grilo/Makefile
+++ b/multimedia/grilo/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grilo
-PKG_VERSION:=0.3.0
+PKG_VERSION:=0.3.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/grilo/0.3/
-PKG_MD5SUM:=f8a51aacc604dcc308e71f8bca4c57ae
+PKG_MD5SUM:=3b6733633e42143ff90fac1fef34cf42
 
 PKG_BUILD_DEPENDS:=glib2 libsoup libxml2
 


### PR DESCRIPTION
Maintainer: me
Compile tested: brcm2708, Raspberry Pi B, Openwrt master
Run tested: brcm2708, Raspberry Pi B, Openwrt master

Description: grilo: update to 0.3.1

Signed-off-by: W. Michael Petullo <mike@flyn.org>