### PR TITLE
libs/libaudiofile: Update PKG_SOURCE_URL

### DIFF
--- a/libs/libaudiofile/Makefile
+++ b/libs/libaudiofile/Makefile
@@ -9,12 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=audiofile
 PKG_VERSION:=0.3.6
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:= \
-	http://github.com/downloads/mpruett/audiofile/ \
-	http://www.68k.org/~michael/audiofile/
+PKG_SOURCE_URL:=http://audiofile.68k.org/
 PKG_MD5SUM:=2731d79bec0acef3d30d2fc86b0b72fd
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
@@ -27,7 +25,7 @@ define Package/libaudiofile
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Audio File library
-  URL:=http://www.68k.org/~michael/audiofile/
+  URL:=http://audiofile.68k.org/'
   DEPENDS:=+libflac +libstdcpp
 endef
 


### PR DESCRIPTION
The source file was moved from 'http://www.68k.org/~michael/audiofile/' to 'http://audiofile.68k.org/'
Also, the Github URL changed, as well the file's MD5SUM, the MD5SUM from 'http://audiofile.68k.org/' is still the same.
And the Github file was not compiling.