### PR TITLE
wireguard: Bump to 0.0.20160708.1

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -9,10 +9,12 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=wireguard
 
-PKG_VERSION:=0.0.20160630
+PKG_VERSION:=0.0.20160708.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=WireGuard-experimental-$(PKG_VERSION).tar.xz
+# This is actually SHA256, but OpenWRT/LEDE will figure it out based on the length
+PKG_MD5SUM:=11faf795dd45ff0d13cdd204775b07e01fda596b4a9c2a1b326614c226e9725d
 PKG_SOURCE_URL:=https://git.zx2c4.com/WireGuard/snapshot/
 PKG_BUILD_DIR:=$(BUILD_DIR)/WireGuard-experimental-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: me

Description: This pull request supersedes #2938.

Also add the SHA256SUM, since upstream now publishes it when releasing:

  https://lists.zx2c4.com/pipermail/wireguard/2016-July/000196.html

Signed-off-by: Baptiste Jonglez <git@bitsofnetworks.org>