### PR TITLE
dmapd: update to 0.0.73

### DIFF
--- a/net/dmapd/Makefile
+++ b/net/dmapd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dmapd
-PKG_VERSION:=0.0.72
+PKG_VERSION:=0.0.73
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.flyn.org/projects/dmapd
-PKG_MD5SUM:=0fe290d1bf003296b1ed9dfcc0108d6f
+PKG_MD5SUM:=458adf9d0c0e434fb92ebc8bd9739f68
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=2


### PR DESCRIPTION
Maintainer: me
Compile tested: x86, x86_64, Openwrt 15.05
Run tested: x86, x86_64, Openwrt 15.05

Description: dmapd: update to 0.0.73

Signed-off-by: W. Michael Petullo <mike@flyn.org>