### PR TITLE
addrwatch: new package

### DIFF
--- a/net/addrwatch/Makefile
+++ b/net/addrwatch/Makefile
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2006-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=addrwatch
+PKG_VERSION:=0.8
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-master.tar.gz
+PKG_SOURCE_URL:=https://github.com/fln/addrwatch/releases/download/$(PKG_VERSION)/
+PKG_MD5SUM:=8f401415be993005fa5fb58a05e14295
+PKG_LICENSE:=GPL-3.0
+PKG_LICENSE_FILES:=COPYING
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)-master
+PKG_FIXUP:=autoreconf
+PKG_BUILD_DEPENDS:=USE_UCLIBC:argp-standalone USE_MUSL:argp-standalone
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/addrwatch
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpcap +libevent2
+  TITLE:=IPv4/IPv6 and ethernet address pairing tool
+  URL:=https://github.com/fln/addrwatch
+  MAINTAINER:=Ondrej Caletka <ondrej@caletka.cz>
+endef
+
+define Package/addrwatch/description
+  This is a tool similar to arpwatch. It main purpose is to monitor network and 
+  log discovered ethernet/ip pairings. Addrwatch is extremely useful in networks
+  with IPv6 autoconfiguration (RFC4862) enabled. It allows to track IPv6
+  addresses of hosts using IPv6 privacy extensions (RFC4941).
+endef
+
+define Package/addrwatch/conffiles
+	/etc/config/addrwatch
+endef
+
+define Package/addrwatch/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/config $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/addrwatch $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/addrwatch.init $(1)/etc/init.d/addrwatch
+	$(INSTALL_CONF) ./files/addrwatch.config $(1)/etc/config/addrwatch$
+endef
+
+$(eval $(call BuildPackage,addrwatch))

--- a/net/addrwatch/files/addrwatch.config
+++ b/net/addrwatch/files/addrwatch.config
@@ -1,0 +1,12 @@
+
+config addrwatch
+	option disabled '0'
+	list interface 'lan'
+	#list interface 'wan'
+	#option syslog '1'
+	#option verbose '0'
+	#option output '/var/log/addrwatch'
+	#list blacklist '192.168.1.1'
+	#option hashsize '1'
+	#option ratelimit '-1'
+

--- a/net/addrwatch/files/addrwatch.init
+++ b/net/addrwatch/files/addrwatch.init
@@ -1,0 +1,74 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2016 OpenWrt.org
+
+START=50
+USE_PROCD=1
+
+. /lib/functions/network.sh
+
+validate_section_addrwatch() {
+	uci_validate_section addrwatch addrwatch "${1}" \
+		'disabled:bool:0' \
+		'interface:list(string):lan' \
+		'syslog:bool:1' \
+		'output:string' \
+		'quiet:bool:0' \
+		'verbose:bool:0' \
+		'ipv4only:bool:0' \
+		'ipv6only:bool:0' \
+		'blacklist:list(or(ip4addr,ip6addr))' \
+		'hashsize:range(1,65536):1024'\
+		'ratelimit:integer:3600'
+	return $?
+}
+
+start_instance() {
+	local cfg="$1"
+	local disabled interface syslog output quiet verbose ipv4only ipv6only
+	local blacklist hashsize ratelimit
+	local netdevs=""
+
+	validate_section_addrwatch "${cfg}" || {
+		echo "validation of config $cfg failed"
+		return 1
+	}
+	[ $disabled -ne 0 ] && return 1
+
+	for iface in $interface; do
+		local netdev
+		network_get_physdev netdev "${iface}"
+		append netdevs "${netdev}"
+	done
+
+	procd_open_instance
+	procd_set_param command /usr/sbin/addrwatch
+	[ "${syslog}" -eq 1 ] && procd_append_param command --syslog
+	[ -n "${output}" ] && procd_append_param command --output "$output"
+	[ "$quiet" -eq 1 ] && procd_append_param command --quiet
+	[ "$verbose" -eq 1 ] && procd_append_param command --verbose
+	[ "$ipv4only" -eq 1 ] && procd_append_param command --ipv4only
+	[ "$ipv6only" -eq 1 ] && procd_append_param command --ipv6only
+	[ -n "$hashsize" ] && procd_append_param command --hashsize "$hashsize"
+	[ -n "$ratelimit" ] && procd_append_param command --ratelimit "$ratelimit"
+	for blitem in $blacklist; do
+		procd_append_param command "--blacklist=${blitem}"
+	done
+	procd_append_param command $netdevs
+	procd_set_param netdev $netdevs
+	procd_set_param respawn
+	procd_open_trigger
+	for iface in $interface; do
+		procd_add_interface_trigger "interface.*" ${iface} /etc/init.d/addrwatch reload
+	done
+	procd_close_trigger
+	procd_close_instance
+}
+
+start_service() {
+	config_load 'addrwatch'
+	config_foreach start_instance 'addrwatch'
+}
+
+service_triggers() {
+	procd_add_reload_trigger 'addrwatch'
+}

--- a/net/addrwatch/patches/001-fix-sys_siglist.patch
+++ b/net/addrwatch/patches/001-fix-sys_siglist.patch
@@ -1,0 +1,32 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -56,9 +56,6 @@ AC_CHECK_HEADERS([arpa/inet.h netinet/in
+ # Checks for typedefs, structures, and compiler characteristics.
+ AC_C_INLINE
+ AC_TYPE_PID_T
+-AC_CHECK_DECLS([sys_siglist], [], [
+-	AC_MSG_ERROR([Unable to find sys_siglist declaration.])
+-], [[#include <signal.h>]])
+ AC_TYPE_UINT32_T
+ AC_TYPE_UINT16_T
+ AC_TYPE_UINT8_T
+--- a/src/addrwatch.c
++++ b/src/addrwatch.c
+@@ -339,7 +339,7 @@ void reload_cb(evutil_socket_t fd, short
+ void reload_cb(int fd, short events, void *arg)
+ #endif
+ {
+-	log_msg(LOG_DEBUG, "Received signal (%d), %s", fd, sys_siglist[fd]);
++	log_msg(LOG_DEBUG, "Received signal (%d), %s", fd, strsignal(fd));
+ 	log_msg(LOG_DEBUG, "Reopening output files");
+ 
+ 	output_flatfile_reload();
+@@ -353,7 +353,7 @@ void stop_cb(evutil_socket_t fd, short e
+ void stop_cb(int fd, short events, void *arg)
+ #endif
+ {
+-	log_msg(LOG_DEBUG, "Received signal (%d), %s", fd, sys_siglist[fd]);
++	log_msg(LOG_DEBUG, "Received signal (%d), %s", fd, strsignal(fd));
+ #if HAVE_LIBEVENT2
+ 	event_base_loopbreak(cfg.eb);
+ #else

--- a/net/addrwatch/patches/002-fix-uclibc-sysconf.patch
+++ b/net/addrwatch/patches/002-fix-uclibc-sysconf.patch
@@ -1,0 +1,11 @@
+--- a/src/addrwatch.c
++++ b/src/addrwatch.c
+@@ -492,7 +492,7 @@ int main(int argc, char *argv[])
+ 	argp_parse(&argp, argc, argv, 0, &optind, 0);
+ 
+ 	if (!cfg.hostname) {
+-		cfg.hostname_len = sysconf(_SC_HOST_NAME_MAX);
++		cfg.hostname_len = HOST_NAME_MAX;
+ 		cfg.hostname = (char *)calloc(cfg.hostname_len, sizeof(char));
+ 		gethostname(cfg.hostname, cfg.hostname_len);
+ 	}


### PR DESCRIPTION
Maintainer: Ondrej Caletka / @Oskar456
Compile tested: TurrisOS 3. (fork of Chaos Calmer), Trunk (both uClibC and musl)
Run tested: mpc85xx - TurrisOS - no problems observed
Upstream: https://github.com/fln/addrwatch / @fln

Description:

This is a tool similar to arpwatch. Its main purpose is to monitor network
and log discovered ethernet/ip pairings.

The package has been UCIfied, care has been taken to reload the deamon
every time an interface goes up or down.

Signed-off-by: Ondřej Caletka <ondrej@caletka.cz>