### PR TITLE
libmicrohttpd: add patch to fix inside loop declaration warning

### DIFF
--- a/libs/libmicrohttpd/patches/001-fix-inside-loop-deklaration.patch
+++ b/libs/libmicrohttpd/patches/001-fix-inside-loop-deklaration.patch
@@ -1,0 +1,14 @@
+Index: libmicrohttpd-0.9.50/src/microhttpd/mhd_str.c
+===================================================================
+--- libmicrohttpd-0.9.50.orig/src/microhttpd/mhd_str.c	2016-05-02 14:22:44.000000000 +0200
++++ libmicrohttpd-0.9.50/src/microhttpd/mhd_str.c	2016-07-15 11:06:39.896282700 +0200
+@@ -271,7 +271,8 @@
+ int
+ MHD_str_equal_caseless_n_ (const char * const str1, const char * const str2, size_t maxlen)
+ {
+-  for (size_t i = 0; i < maxlen; ++i)
++  size_t i;
++  for (i = 0; i < maxlen; ++i)
+     {
+       const char c1 = str1[i];
+       const char c2 = str2[i];


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx / LEDE toolchain
Run tested: -

Description:
libmicrohttpd: add patch to fix inside loop declaration warning

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>