### PR TITLE
klish: update to latest version (2.1.2) 

### DIFF
--- a/utils/klish/Makefile
+++ b/utils/klish/Makefile
@@ -9,15 +9,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=klish
-PKG_VERSION:=2.1.1
+PKG_VERSION:=2.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://libcode.org/attachments/download/61/
+PKG_SOURCE_URL:=http://libcode.org/attachments/download/64/
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENCE
 PKG_MAINTAINER:=Takashi Umeno <umeno.takashi@gmail.com>
-PKG_MD5SUM:=4913259794d85585de0f8791c54ac633
+PKG_MD5SUM:=fd33f454118aa173b9e4b3faf9a0b1a5
 
 PKG_INSTALL:=1
 


### PR DESCRIPTION

Maintainer: me 
Compile tested: x86, DESIGNATED DRIVER (Bleeding Edge, r49395)
Run tested: x86, DESIGNATED DRIVER (Bleeding Edge, r49395)

Description:
klish: update to latest version (2.1.2) 

Signed-off-by: Takashi Umeno <umeno.takashi@gmail.com>