### PR TITLE
Radsecproxy ucified

### DIFF
--- a/net/radsecproxy/Makefile
+++ b/net/radsecproxy/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2012 OpenWrt.org
+# Copyright (C) 2008-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -14,6 +14,9 @@ PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://software.uninett.no/radsecproxy/
 PKG_MD5SUM:=d76cf4fc68515667b8c67387f5045150
+
+PKG_LICENSE:=GPL-2.0+
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_INSTALL:=1
 

--- a/net/radsecproxy/Makefile
+++ b/net/radsecproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radsecproxy
 PKG_VERSION:=1.6.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://software.uninett.no/radsecproxy/
@@ -43,14 +43,14 @@ TARGET_CFLAGS += -Wno-long-long
 define Package/radsecproxy/install
 	$(INSTALL_DIR) $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/radsecproxy $(1)/usr/sbin/
-	$(INSTALL_DIR) $(1)/etc/
-	$(CP) $(PKG_BUILD_DIR)/radsecproxy.conf-example $(1)/etc/radsecproxy.conf
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_DATA) ./files/radsecproxy.conf $(1)/etc/config/radsecproxy
 	$(INSTALL_DIR) $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files/radsecproxy.init $(1)/etc/init.d/radsecproxy
 endef
 
 define Package/radsecproxy/conffiles
-/etc/radsecproxy.conf
+/etc/config/radsecproxy
 endef
 
 $(eval $(call BuildPackage,radsecproxy))

--- a/net/radsecproxy/files/radsecproxy.conf
+++ b/net/radsecproxy/files/radsecproxy.conf
@@ -1,0 +1,43 @@
+# Sample radsecproxy configuration
+
+#Basic options
+config options
+	option include '/etc/radsecproxy.conf'
+	#option LogLevel '3'
+	#option LogDestination 'x-syslog:///'
+	#list ListenUDP '127.0.0.1:1812'
+	#list ListenTLS '0.0.0.0:2083'
+	#list ListenTLS '[::]:2083'
+
+#config tls
+#	option name 'default'
+#	option CACertificatePath '/etc/ssl/certs'
+#	option certificateFile '/etc/ssl/certs/host.example.com.pem'
+#	option certificateKeyFile '/etc/ssl/private/host.example.com.key.pem'
+
+#config client
+#	option name 'localhost'
+#	option type 'udp'
+#	option secret 'mysecret'
+
+#config server
+#	option name '[2001:db8::1]'
+#	option type 'tls'
+#	option secret 'radsec'
+#	option statusServer '1'
+
+# Please note that ordering of realm blocks is important
+
+#config realm
+#	option name '/myabc\.com$'
+#	option replyMessage 'Misconfigured client: default realm of Intel PRO/Wireless supplicant!'
+#
+
+#config realm
+#	option name '/^$/'
+#	option replyMessage 'Misconfigured client: empty realm!'
+#
+
+#config realm
+#	option name '*'
+#	list server '[2001:db8::1]'

--- a/net/radsecproxy/files/radsecproxy.init
+++ b/net/radsecproxy/files/radsecproxy.init
@@ -5,12 +5,138 @@ START=70
 
 USE_PROCD=1
 PROG=/usr/sbin/radsecproxy
-CONFFILE=/etc/radsecproxy.conf
+CONFFILE=/var/etc/radsecproxy.conf
+LIST_SEP="
+"
+append_params() {
+	local param
+	local value
+	local section="$1"
+	shift
+	for param in $*; do
+		config_get value "$section" "$param"
+		[ -z "$value" ] && {
+			param=$(echo $param | tr [A-Z] [a-z])
+			config_get value "$section" "$param"
+		}
+		IFS="$LIST_SEP"
+		for value in $value; do
+			[ -n "$value" ] && echo "    $param '$value'" >> "$CONFFILE"
+		done
+		unset IFS
+	done
+}
+
+append_bools() {
+	local param
+	local value
+	local section="$1"
+	shift
+	for param in $*; do
+		config_get_bool value "$section" "$param"
+		[ -z "$value" ] && {
+			param=$(echo $param | tr [A-Z] [a-z])
+			config_get_bool value "$section" "$param"
+		}
+		[ -n "$value" ] && {
+			[ "$value" -eq 0 ] && echo "    $param off" >> "$CONFFILE"
+			[ "$value" -eq 1 ] && echo "    $param on" >> "$CONFFILE"
+		}
+	done
+}
+
+radsecproxy_options() {
+	local cfg="$1"
+	append_params "$cfg" \
+		Include PidFile LogLevel LogDestination FTicksReporting FTicksMAC FTicksKey \
+		FTicksSyslogFacility ListenUDP ListenTCP ListenTLS ListenDTLS SourceUDP \
+		SourceTCP SourceTLS SourceDTLS TTLAttribute AddTTL
+	append_bools "$cfg" \
+		LoopPrevention IPv4Only IPv6Only
+}
+
+tls_block() {
+	local cfg="$1"
+	local name
+	config_get name "$cfg" name
+	echo "tls '$name' {" >> "$CONFFILE"
+	append_params "$cfg" \
+		Include CACertificateFile CACertificatePath certificateFile certificateKeyFile \
+		certificateKeyPassword cacheExpiry policyOID
+	append_bools "$cfg" \
+		CRLCheck
+	echo "}" >> "$CONFFILE"
+}
+
+rewrite_block() {
+	local cfg="$1"
+	local name
+	config_get name "$cfg" name
+	echo "rewrite '$name' {" >> "$CONFFILE"
+	append_params "$cfg" \
+		Include addAttribute addVendorAttribute removeAttribute removeVendorAttribute \
+		modifyAttribute
+	echo "}" >> "$CONFFILE"
+}
+
+client_block() {
+	local cfg="$1"
+	local name
+	config_get name "$cfg" name
+	echo "client '$name' {" >> "$CONFFILE"
+	append_params "$cfg" \
+		Include host type secret tls matchCertificateAttribute duplicateInterval \
+		AddTTL fticksVISCOUNTRY fticksVISINST rewrite rewriteIn rewriteOut \
+		rewriteAttribute
+	append_bools "$cfg" \
+		IPv4Only IPv6Only certificateNameCheck
+	echo "}" >> "$CONFFILE"
+}
+
+server_block() {
+	local cfg="$1"
+	local name
+	config_get name "$cfg" name
+	echo "server '$name' {" >> "$CONFFILE"
+	append_params "$cfg" \
+		Include host port type secret tls matchCertificateAttribute \
+		AddTTL rewrite rewriteIn rewriteOut retryCount dynamicLookupCommand \
+		retryInterval
+	append_bools "$cfg" \
+		IPv4Only IPv6Only certificateNameCheck statusServer LoopPrevention
+	echo "}" >> "$CONFFILE"
+}
+
+realm_block() {
+	local cfg="$1"
+	local name
+	config_get name "$cfg" name
+	echo "realm '$name' {" >> "$CONFFILE"
+	append_params "$cfg" \
+		Include server accountingServer replyMessage
+	append_bools "$cfg" \
+		accountingResponse
+	echo "}" >> "$CONFFILE"
+}
 
 start_service() {
+	mkdir -p $(dirname $CONFFILE)
+	echo "# auto-generated config file from /etc/config/radsecproxy" > $CONFFILE
+	config_load 'radsecproxy'
+	config_foreach radsecproxy_options options
+	config_foreach tls_block tls
+	config_foreach rewrite_block rewrite
+	config_foreach client_block client
+	config_foreach server_block server
+	config_foreach realm_block realm
+
 	procd_open_instance
 	procd_set_param command $PROG -f -c $CONFFILE
 	procd_set_param file $CONFFILE
 	procd_set_param respawn
 	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger 'radsecproxy'
 }


### PR DESCRIPTION
Maintainer: Toke Høiland-Jørgensen / @tohojo 
Compile tested: ar71xx, TL-WDR-4300, OpenWRT 15.05 Chaos Calmer
Run tested: ar71xx, TL-WDR-4300, OpenWRT 15.05 Chaos Calmer

Description:
This pull request UCIfies configuration of `radsecproxy`. In default config file, there is just an include of the legacy config file `/etc/radsecproxy.conf`, so migration should be painless.
