### PR TITLE
wireguard: Bump to 0.0.20160722

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -9,12 +9,12 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=wireguard
 
-PKG_VERSION:=0.0.20160711
+PKG_VERSION:=0.0.20160722
 PKG_RELEASE:=1
 
 PKG_SOURCE:=WireGuard-experimental-$(PKG_VERSION).tar.xz
 # This is actually SHA256, but OpenWRT/LEDE will figure it out based on the length
-PKG_MD5SUM:=4ab876642236abcac416f7b75cf5e9e28b8581d5b7741d36a437af08c42d8081
+PKG_MD5SUM:=0dcda97b6bb4e962f731a863df9b4291c1c453b01f4faba78be4aaa13a594242
 PKG_SOURCE_URL:=https://git.zx2c4.com/WireGuard/snapshot/
 PKG_BUILD_DIR:=$(BUILD_DIR)/WireGuard-experimental-$(PKG_VERSION)
 
@@ -59,7 +59,7 @@ include $(INCLUDE_DIR)/package-defaults.mk
 MAKE_PATH:=src/tools
 
 define Build/Compile
-	$(MAKE) $(KERNEL_MAKEOPTS) SUBDIRS="$(PKG_BUILD_DIR)/src" modules
+	$(MAKE) $(KERNEL_MAKEOPTS) M="$(PKG_BUILD_DIR)/src" modules
 	$(call Build/Compile/Default)
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, latest LEDE

Also fix a new compilation error, due to upstream changes in the build
system.  SUBDIRS= is deprecated when building external kernel modules, use
M= instead to fix compilation.
