### PR TITLE
relayctl: remove superfluous dependency on udev

### DIFF
--- a/utils/relayctl/Makefile
+++ b/utils/relayctl/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=relayctl
 PKG_VERSION:=0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/relayctl/relayctl-$(PKG_VERSION)
@@ -26,7 +26,7 @@ define Package/relayctl
   CATEGORY:=Utilities
   TITLE:=Simple command-line control of SainSmart USB relay boards
   URL:=https://github.com/darryln/relayctl
-  DEPENDS:= +libftdi1 +udev
+  DEPENDS:= +libftdi1
 endef
 
 define Package/relayctl/description


### PR DESCRIPTION
Maintainer: me / @xypron
Compile tested: sunxi, Lamobo-R1, 15.05.1
Run tested: sunxi, Lamobo-R1, 15.05.1

Description:

Package udev does not exist in Lede.
We do not need udev to use package relayctl.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>