### PR TITLE
wget: add missing zlib dependency

### DIFF
--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/wget/Default
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libpcre
+  DEPENDS:=+libpcre +zlib
   SUBMENU:=File Transfer
   TITLE:=Non-interactive network downloader
   URL:=http://www.gnu.org/software/wget/index.html
@@ -55,7 +55,6 @@ endef
 define Package/wget-nossl
 $(call Package/wget/Default)
   TITLE+= (without SSL support)
-  DEPENDS+= +zlib
   VARIANT:=nossl
 endef
 


### PR DESCRIPTION
-------------------------------

Maintainer: Maxim Storchak <m.storchak@gmail.com>
Compile tested: x86/64, apu2, LEDE 1100-g07577c5
Run tested: x86/64, apu2, LEDE 1100-g07577c5, tested by downloading a kernel from kernel.org

Description: this fixed a build error, where LEDE complained about a missing dependency,

  ```
Package wget is missing dependencies for the following libraries:
libz.so.1
```

Moved the zlib dependency to the Package/wget/Default define stanza and removed it from the nossl variant, because it seemed to be needed for both the ssl and nossl variants.

Signed-off-by: Russell Senior <russell@personaltelco.net>