### PR TITLE
mini_snmpd: fix initscript to use l3_device for working out the interface name

### DIFF
--- a/net/mini_snmpd/Makefile
+++ b/net/mini_snmpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mini_snmpd
 PKG_VERSION:=1.4-rc1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Luke McKee <hojuruku@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING

--- a/net/mini_snmpd/files/mini_snmpd.init
+++ b/net/mini_snmpd/files/mini_snmpd.init
@@ -71,7 +71,7 @@ append_interface() {
 	local name="$1" netdev netdev_count
 	[ -z $netdev_count ] && netdev_count=0
 	# for the purposes of snmp monitoring it doesn't need to be up, it just needs to exist in /proc/net/dev
-	netdev=$(ubus -S call network.interface dump|jsonfilter -e "@.interface[@.interface=\"$name\"].device")  
+	netdev=$(ubus -S call network.interface dump|jsonfilter -e "@.interface[@.interface=\"$name\"].l3_device")  
 	if [ -n "$netdev" ] && grep -qF "$netdev" /proc/net/dev ]; then 
 		[ $netdev_count -ge 4 ] && {
 			_err "$cfg: too many network interfaces configured, ignoring $name"


### PR DESCRIPTION
Maintainer me @hojuruku

One word change to the init script.

Working:
ubus -S call network.interface dump|jsonfilter -e "@.interface[@.interface=\"wan\"].l3_device"
Broken:
ubus -S call network.interface dump|jsonfilter -e "@.interface[@.interface=\"wan\"].device"

Fix run tested:
root@wifi:/overlay/upper# ps |grep mini_snmpd
 1404 root       980 S    /usr/bin/mini_snmpd -n -c public -L Undisclosed -C VGB <admin@victimsofgaybullying.com> -t 1 -a -d /overlay,/tmp -i br-lan,pppoe-w

Before it wasn't using the pppoe interface it was using the parent
interface eth0 instead. Small 1 line fix. Merge at your convenience.

Next release should include a fix for a bug I'm submitting now regarding snmp stats coming from bridged interfaces. 


Signed-off-by: Luke McKee <hojuruku@gmail.com>