### PR TITLE
python-cffi: update to 1.7.0

### DIFF
--- a/lang/python-cffi/Makefile
+++ b/lang/python-cffi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cffi
-PKG_VERSION:=1.5.2
-PKG_RELEASE:=2
+PKG_VERSION:=1.7.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/c/cffi
-PKG_MD5SUM:=fa766133f7299464c8bf857e0c966a82
+PKG_SOURCE_URL:=https://pypi.python.org/packages/83/3c/00b553fd05ae32f27b3637f705c413c4ce71290aa9b4c4764df694e906d9
+PKG_MD5SUM:=34122a545060cee58bab88feab57006d
 
 PKG_BUILD_DEPENDS:=python python-setuptools
 HOST_BUILD_DEPENDS:=libffi/host python/host python-setuptools/host python-pycparser/host


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, TP-Link TL-MR3020, OpenWRT CC / OpenWRT trunk / LEDE trunk
Run tested: none :joy:

Description:
update to 1.7.0

Signed-off-by: Jeffery To <jeffery.to@gmail.com>