### PR TITLE
python-cryptography: update to 1.4, fixed lede compilation

### DIFF
--- a/lang/python-cryptography/Makefile
+++ b/lang/python-cryptography/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptography
-PKG_VERSION:=1.3.1
+PKG_VERSION:=1.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/c/cryptography
-PKG_MD5SUM:=bc8148d2ff2d80fef8ef2d2e856b3a7f
+PKG_SOURCE_URL:=https://pypi.python.org/packages/a9/5b/a383b3a778609fe8177bd51307b5ebeee369b353550675353f46cb99c6f0
+PKG_MD5SUM:=a9763e3831cc7cdb402c028fac1ceb39
 
 PKG_BUILD_DEPENDS:=python-cffi/host
 

--- a/lang/python-cryptography/patches/001-cmac-check.patch
+++ b/lang/python-cryptography/patches/001-cmac-check.patch
@@ -1,0 +1,22 @@
+diff --git a/src/_cffi_src/openssl/cmac.py b/src/_cffi_src/openssl/cmac.py
+index f4a3686..bf52144 100644
+--- a/src/_cffi_src/openssl/cmac.py
++++ b/src/_cffi_src/openssl/cmac.py
+@@ -5,7 +5,7 @@
+ from __future__ import absolute_import, division, print_function
+ 
+ INCLUDES = """
+-#if OPENSSL_VERSION_NUMBER >= 0x10001000L
++#if !defined(OPENSSL_NO_CMAC) && OPENSSL_VERSION_NUMBER >= 0x10001000L
+ #include <openssl/cmac.h>
+ #endif
+ """
+@@ -28,7 +28,7 @@ void CMAC_CTX_free(CMAC_CTX *);
+ """
+ 
+ CUSTOMIZATIONS = """
+-#if OPENSSL_VERSION_NUMBER < 0x10001000L
++#if defined(OPENSSL_NO_CMAC) || OPENSSL_VERSION_NUMBER < 0x10001000L
+ 
+ static const long Cryptography_HAS_CMAC = 0;
+ typedef void CMAC_CTX;


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, TP-Link TL-MR3020, OpenWRT CC / OpenWrt trunk / LEDE trunk
Run tested: none :joy:

Description:
update to 1.4, fixed lede compilation

Signed-off-by: Jeffery To <jeffery.to@gmail.com>