### PR TITLE
python-gmpy2: update to 2.0.8

### DIFF
--- a/lang/python-gmpy2/Makefile
+++ b/lang/python-gmpy2/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 OpenWrt.org
+# Copyright (C) 2015-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gmpy2
-PKG_VERSION:=2.0.7
+PKG_VERSION:=2.0.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/g/gmpy2
-PKG_MD5SUM:=b5aada3ee5afb316ea94604f45192054
+PKG_SOURCE_URL:=https://pypi.python.org/packages/90/f4/9a2e384b325b69bc5827b9a6510a8fb4a51698c915c06a3f25a86458892a
+PKG_MD5SUM:=56d40bddcf8f22be0a36d60f764f3241
 
 PKG_LICENSE:=LGPL-3.0+
 PKG_LICENSE_FILES:=COPYING.LESSER


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, TP-Link TL-MR3020, OpenWRT CC / OpenWrt trunk / LEDE trunk
Run tested: none :joy:

Description:
update to 2.0.8

Signed-off-by: Jeffery To <jeffery.to@gmail.com>