### PR TITLE
zope-interface: update to 4.2.0

### DIFF
--- a/lang/zope-interface/Makefile
+++ b/lang/zope-interface/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2015 OpenWrt.org
+# Copyright (C) 2006-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zope.interface
-PKG_VERSION:=4.1.3
+PKG_VERSION:=4.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/z/zope.interface
-PKG_MD5SUM:=9ae3d24c0c7415deb249dd1a132f0f79
+PKG_SOURCE_URL:=https://pypi.python.org/packages/ea/a3/38bdc8e8bd068ea5b4d21a2d80eca1547cd8509318e8d7c875f7247abe43
+PKG_MD5SUM:=2950a6db7e985e19c7a846cc20f5d82a
 
 PKG_BUILD_DEPENDS:=python python-setuptools
 


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, TP-Link TL-MR3020, OpenWRT CC / OpenWrt trunk / LEDE trunk
Run tested: none :joy:

Description:
update to 4.2.0

Signed-off-by: Jeffery To <jeffery.to@gmail.com>