### PR TITLE
ffmpeg: Update to 2.8.7. Add support for x264 and libmp3lame

### DIFF
--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -1,11 +1,10 @@
-menu "Configuration"
-	depends on PACKAGE_libffmpeg-custom
+if PACKAGE_libffmpeg-custom
 
 config FFMPEG_CUSTOM_PATENTED
 	bool "Include patented codecs and technologies"
 	default BUILD_PATENTED
 
-comment "Profiles ---"
+comment "Profiles"
 
 config FFMPEG_CUSTOM_FFSERVER_SUPPORT
 	bool "Include support for ffserver (FFmpeg streaming server)"
@@ -68,6 +67,7 @@ config FFMPEG_CUSTOM_AUDIO_DEC_SUPPORT
 	select FFMPEG_CUSTOM_DECODER_pcm_s16be
 	select FFMPEG_CUSTOM_DECODER_pcm_s16le
 	select FFMPEG_CUSTOM_SELECT_speex
+	select FFMPEG_CUSTOM_SELECT_libopus
 	select FFMPEG_CUSTOM_DECODER_vorbis
 	select FFMPEG_CUSTOM_DECODER_wavpack
 	select FFMPEG_CUSTOM_DECODER_wmav1
@@ -108,7 +108,14 @@ config FFMPEG_CUSTOM_AUDIO_DEC_SUPPORT
 	select FFMPEG_CUSTOM_PROTOCOL_tcp
 	select FFMPEG_CUSTOM_PROTOCOL_udp
 
-comment "External Libraries ---"
+comment "External Libraries"
+
+config FFMPEG_CUSTOM_SELECT_mp3lame
+	bool "MP3 LAME"
+	depends on FFMPEG_CUSTOM_PATENTED
+	select FFMPEG_CUSTOM_DECODER_mp3
+	select FFMPEG_CUSTOM_MUXER_mp3
+	select FFMPEG_CUSTOM_DEMUXER_mp3
 
 config FFMPEG_CUSTOM_SELECT_libopus
 	bool "Opus"
@@ -116,7 +123,15 @@ config FFMPEG_CUSTOM_SELECT_libopus
 config FFMPEG_CUSTOM_SELECT_speex
 	bool "Speex"
 
-comment "Encoders ---"
+config FFMPEG_CUSTOM_SELECT_x264
+	depends on FFMPEG_CUSTOM_PATENTED
+	bool "x264"
+	select FFMPEG_CUSTOM_DECODER_h264
+	select FFMPEG_CUSTOM_MUXER_h264
+	select FFMPEG_CUSTOM_DEMUXER_h264
+	select FFMPEG_CUSTOM_PARSER_h264
+
+comment "Encoders"
 
 config FFMPEG_CUSTOM_ENCODER_ac3
 	bool "AC3"
@@ -153,7 +168,7 @@ config FFMPEG_CUSTOM_ENCODER_vorbis
 config FFMPEG_CUSTOM_ENCODER_zlib
 	bool "Zlib"
 
-comment "Decoders ---"
+comment "Decoders"
 
 config FFMPEG_CUSTOM_DECODER_aac
 	bool "AAC (Advanced Audio Coding)"
@@ -261,7 +276,7 @@ config FFMPEG_CUSTOM_DECODER_wmav2
 config FFMPEG_CUSTOM_DECODER_zlib
 	bool "Zlib"
 
-comment "Muxers ---"
+comment "Muxers"
 
 config FFMPEG_CUSTOM_MUXER_ac3
 	bool "AC3"
@@ -295,7 +310,7 @@ config FFMPEG_CUSTOM_MUXER_ogg
 config FFMPEG_CUSTOM_MUXER_rtp
 	bool "RTP"
 
-comment "Demuxers ---"
+comment "Demuxers"
 
 config FFMPEG_CUSTOM_DEMUXER_aac
 	bool "AAC"
@@ -376,7 +391,7 @@ config FFMPEG_CUSTOM_DEMUXER_wav
 config FFMPEG_CUSTOM_DEMUXER_wv
 	bool "WV"
 
-comment "Parsers ---"
+comment "Parsers"
 
 config FFMPEG_CUSTOM_PARSER_aac
 	bool "AAC (Advanced Audio Coding)"
@@ -405,7 +420,7 @@ config FFMPEG_CUSTOM_PARSER_mpeg4video
 config FFMPEG_CUSTOM_PARSER_opus
 	bool "Opus"
 
-comment "Protocols ---"
+comment "Protocols"
 
 config FFMPEG_CUSTOM_PROTOCOL_file
 	bool "file:"
@@ -430,5 +445,5 @@ config FFMPEG_CUSTOM_PROTOCOL_tcp
 config FFMPEG_CUSTOM_PROTOCOL_udp
 	bool "udp:"
 
-endmenu
 
+endif

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=2.7.6
+PKG_VERSION:=2.8.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://ffmpeg.org/releases/
-PKG_MD5SUM:=578c88242872e58cf0db5f23faa4b2af
+PKG_MD5SUM:=7e5b1c98eedfc3a364fa8c4095deeae5
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
 PKG_LICENSE:=LGPL-2.1+ GPL-2+ LGPL-3
@@ -277,13 +277,12 @@ $(call Package/ffmpeg/Default/description)
  This package contains the FFmpeg streaming server.
 endef
 
-
 define Package/libffmpeg/Default
 $(call Package/ffmpeg/Default)
  SECTION:=libs
  CATEGORY:=Libraries
  TITLE+= libraries
- DEPENDS+= +libpthread +zlib +libbz2
+ DEPENDS+= @BUILD_PATENTED +libpthread +zlib +libbz2
  PROVIDES:= libffmpeg
 endef
 
@@ -291,7 +290,8 @@ endef
 define Package/libffmpeg-custom
 $(call Package/libffmpeg/Default)
  TITLE+= (custom)
- DEPENDS+= @DEVEL @!ALL +libopus +libspeex
+ DEPENDS+= +FFMPEG_CUSTOM_SELECT_libopus:libopus +FFMPEG_CUSTOM_SELECT_speex:libspeex \
+           +FFMPEG_CUSTOM_SELECT_x264:libx264 +FFMPEG_CUSTOM_SELECT_mp3lame:lame-lib
  VARIANT:=custom
  MENU:=1
 endef
@@ -310,7 +310,7 @@ endef
 define Package/libffmpeg-audio-dec
 $(call Package/libffmpeg/Default)
  TITLE+= (audio)
- DEPENDS+= @BUILD_PATENTED +libspeex
+ DEPENDS+= +libspeex +libopus
  VARIANT:=audio-dec
 endef
 
@@ -324,7 +324,7 @@ endef
 define Package/libffmpeg-full
 $(call Package/libffmpeg/Default)
  TITLE+= (full)
- DEPENDS+= @BUILD_PATENTED +alsa-lib
+ DEPENDS+= +alsa-lib +libx264 +lame-lib +libopus +libspeex
  VARIANT:=full
 endef
 
@@ -338,7 +338,6 @@ endef
 define Package/libffmpeg-mini
 $(call Package/libffmpeg/Default)
  TITLE+= (mini)
- DEPENDS+= @BUILD_PATENTED
  VARIANT:=mini
 endef
 
@@ -387,10 +386,8 @@ FFMPEG_CONFIGURE:= \
 	--disable-fma3 \
 	--disable-fma4 \
 	--disable-avx2 \
-	--disable-vfp \
-	--disable-neon \
-	--disable-inline-asm \
 	--disable-yasm \
+	--disable-inline-asm \
 	--disable-mips32r2 \
 	--disable-mipsdspr1 \
 	--disable-mipsdspr2 \
@@ -402,6 +399,33 @@ FFMPEG_CONFIGURE:= \
 	--disable-vda \
 	--disable-vdpau \
 	--disable-outdevs
+
+
+#selectibly disable optimizations according to arch/cpu type
+ifneq ($(findstring arm,$(CONFIG_ARCH)),)
+	ifeq (,$(findstring vfp,$(CONFIG_TARGET_OPTIMIZATION)))
+		FFMPEG_CONFIGURE+= \
+			--disable-vfp
+	endif
+	ifeq (,$(findstring neon,$(CONFIG_TARGET_OPTIMIZATION)))
+		FFMPEG_CONFIGURE+= \
+			--disable-neon
+	endif
+
+else ifneq ($(ARCH),aarch64)
+	FFMPEG_CONFIGURE+= \
+		--disable-vfp \
+		--disable-neon
+
+endif
+
+ifeq ($(BUILD_VARIANT),full)
+	FFMPEG_CONFIGURE+= \
+		--enable-libopus --enable-decoder=libopus \
+		--enable-libspeex --enable-decoder=libspeex \
+		--enable-libx264 \
+		--enable-libmp3lame
+endif
 
 ifeq ($(BUILD_VARIANT),custom)
 
@@ -434,14 +458,22 @@ endif
 
 ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libopus),y)
   FFMPEG_CONFIGURE+= \
-	--enable-libopus --enable-decoder=libopus \
-
+	--enable-libopus --enable-decoder=libopus
 endif
 
 ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_speex),y)
   FFMPEG_CONFIGURE+= \
-	--enable-libspeex --enable-decoder=libspeex \
+	--enable-libspeex --enable-decoder=libspeex
+endif
 
+ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_x264),y)
+  FFMPEG_CONFIGURE+= \
+	--enable-libx264 --enable-decoder=libx264
+endif
+
+ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_mp3lame),y)
+  FFMPEG_CONFIGURE+= \
+	--enable-libmp3lame --enable-encoder=mp3
 endif
 
 endif
@@ -593,7 +625,9 @@ Package/libffmpeg-audio-dec/install = $(Package/libffmpeg-custom/install)
 $(eval $(call BuildPackage,ffmpeg))
 $(eval $(call BuildPackage,ffprobe))
 $(eval $(call BuildPackage,ffserver))
-$(eval $(call BuildPackage,libffmpeg-custom))
+$(eval $(call BuildPackage,libffmpeg-audio-dec))
 $(eval $(call BuildPackage,libffmpeg-full))
 $(eval $(call BuildPackage,libffmpeg-mini))
-$(eval $(call BuildPackage,libffmpeg-audio-dec))
+ifneq ($(CONFIG_ALL),y)
+   $(eval $(call BuildPackage,libffmpeg-custom))
+endif


### PR DESCRIPTION

Maintainer: thess
Compile tested: ar71xx, bcm27xx
Run tested: Netgear WNDR4300 (no vfp-neon testing)

Description:

Add support for libmp3lame & libx264 to 'full' and optional in 'custom'.
Enable some optimizations according to ARCH and CPU type.
Cleaup options and dependencies.

Signed-off-by: Adrian Panella <ianchi74@outlook.com>
Signed-off-by: Ted Hess <thess@kitschensync.net>
