### PR TITLE
apache: fix build without sslv3

### DIFF
--- a/net/apache/patches/005-httpd_conf.patch
+++ b/net/apache/patches/005-httpd_conf.patch
@@ -1,6 +1,6 @@
 --- a/docs/conf/httpd.conf.in
 +++ b/docs/conf/httpd.conf.in
-@@ -51,7 +51,6 @@ Listen @@Port@@
+@@ -52,7 +52,6 @@ Listen @@Port@@
  # Example:
  # LoadModule foo_module modules/mod_foo.so
  #
@@ -8,7 +8,7 @@
  
  <IfModule !mpm_netware_module>
  <IfModule !mpm_winnt_module>
-@@ -63,8 +62,8 @@ Listen @@Port@@
+@@ -64,8 +63,8 @@ Listen @@Port@@
  # It is usually good practice to create a dedicated user and group for
  # running httpd, as with most system services.
  #
@@ -19,7 +19,7 @@
  
  </IfModule>
  </IfModule>
-@@ -191,7 +190,7 @@ ErrorLog "@rel_logfiledir@/error_log"
+@@ -192,7 +191,7 @@ ErrorLog "@rel_logfiledir@/error_log"
  # Possible values include: debug, info, notice, warn, error, crit,
  # alert, emerg.
  #
@@ -28,7 +28,7 @@
  
  <IfModule log_config_module>
      #
-@@ -336,7 +335,7 @@ DefaultType text/plain
+@@ -337,7 +336,7 @@ DefaultType text/plain
  # contents of the file itself to determine its type.  The MIMEMagicFile
  # directive tells the module where the hint definitions are located.
  #
@@ -37,7 +37,7 @@
  
  #
  # Customizable error responses come in three flavors:
-@@ -358,7 +357,7 @@ DefaultType text/plain
+@@ -366,7 +365,7 @@ DefaultType text/plain
  # broken on your system.
  #
  #EnableMMAP off
@@ -46,7 +46,7 @@
  
  # Supplemental configuration
  #
-@@ -404,7 +403,7 @@ DefaultType text/plain
+@@ -412,7 +411,7 @@ DefaultType text/plain
  #       starting without SSL on platforms with no /dev/random equivalent
  #       but a statically compiled-in mod_ssl.
  #

--- a/net/apache/patches/006-remove-ssl3.patch
+++ b/net/apache/patches/006-remove-ssl3.patch
@@ -1,0 +1,13 @@
+--- a/support/ab.c
++++ b/support/ab.c
+@@ -2232,8 +2232,10 @@ int main(int argc, const char * const ar
+                 } else if (strncasecmp(optarg, "SSL2", 4) == 0) {
+                     meth = SSLv2_client_method();
+ #endif
++#ifndef OPENSSL_NO_SSL3_METHOD
+                 } else if (strncasecmp(optarg, "SSL3", 4) == 0) {
+                     meth = SSLv3_client_method();
++#endif
+ #ifdef HAVE_TLSV1_X
+                 } else if (strncasecmp(optarg, "TLS1.1", 6) == 0) {
+                     meth = TLSv1_1_client_method();


### PR DESCRIPTION
SSLv3 support is deactivated in LEDE now, which causes a build problem
in apache.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>