### PR TITLE
mwan3: extend mwan3track to check device operstate

### DIFF
--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -13,53 +13,91 @@ score=$(($7+$8))
 track_ips=$(echo $* | cut -d ' ' -f 9-99)
 host_up_count=0
 lost=0
+loop_count=0
+current_operstate="up"
+last_operstate="unknown"
 
 while true; do
 
-	for track_ip in $track_ips; do
-		ping -I $2 -c $4 -W $5 -q $track_ip &> /dev/null
-		if [ $? -eq 0 ]; then
-			let host_up_count++
+	if [ $loop_count -eq $6 ]; then
+
+		for track_ip in $track_ips; do
+			ping -I $2 -c $4 -W $5 -q $track_ip &> /dev/null
+			if [ $? -eq 0 ]; then
+				let host_up_count++
+			else
+				let lost++
+			fi
+		done
+
+		if [ $host_up_count -lt $3 ]; then
+			let score--
+
+			if [ $score -lt $8 ]; then score=0 ; fi
+			if [ $score -eq $8 ]; then
+
+				logger -t mwan3track -p notice "Interface $1 ($2) is offline"
+				env -i ACTION=ifdown INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
+				score=0
+
+			fi
+
 		else
-			let lost++
+
+			if [ $score -lt $(($7+$8)) ] && [ $lost -gt 0 ]; then
+
+				logger -t mwan3track -p info "Lost $(($lost*$4)) ping(s) on interface $1 ($2)"
+
+			fi
+
+			let score++
+			lost=0
+
+			if [ $score -gt $8 ]; then score=$(($7+$8)); fi
+			if [ $score -eq $8 ]; then
+
+				logger -t mwan3track -p notice "Interface $1 ($2) is online"
+				env -i ACTION=ifup INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
+				rm /var/run/mwan3track-$1.pid
+				exit 0
+			fi
 		fi
-	done
-
-	if [ $host_up_count -lt $3 ]; then
-		let score--
-
-		if [ $score -lt $8 ]; then score=0 ; fi
-		if [ $score -eq $8 ]; then
-
-			logger -t mwan3track -p notice "Interface $1 ($2) is offline"
-			env -i ACTION=ifdown INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
-			score=0
-
-		fi
-
-	else
-
-		if [ $score -lt $(($7+$8)) ] && [ $lost -gt 0 ]; then
-
-			logger -t mwan3track -p info "Lost $(($lost*$4)) ping(s) on interface $1 ($2)"
-
-		fi
-
-		let score++
-		lost=0
-
-		if [ $score -gt $8 ]; then score=$(($7+$8)); fi
-		if [ $score -eq $8 ]; then
-
-			logger -t mwan3track -p notice "Interface $1 ($2) is online"
-			env -i ACTION=ifup INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
-			rm /var/run/mwan3track-$1.pid
-			exit 0
-		fi
+		host_up_count=0
+		loop_count=0
 	fi
 
-	host_up_count=0
-	sleep $6
+	if [ -e "/sys/class/net/${2}/operstate" ]; then
+
+		last_operstate=$current_operstate
+		current_operstate=$(cat "/sys/class/net/${2}/operstate")
+
+		if [ "$current_operstate" != "unknown" ]; then
+
+			if [ "$current_operstate" != "$last_operstate" ]; then
+
+				if [ "$current_operstate" = "up" ]; then
+
+					logger -t mwan3track -p notice "Interface $1 ($2) link is up"
+					env -i ACTION=ifup INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
+					rm /var/run/mwan3track-$1.pid
+					exit 0
+
+				elif [ "$current_operstate" = "down" ]; then
+
+					logger -t mwan3track -p notice "Interface $1 ($2) link is down"
+					env -i ACTION=ifdown INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
+					score=0
+
+				fi
+
+			fi
+
+		fi
+
+	fi
+
+	let loop_count++
+	sleep 1
 done
 
 exit 1


### PR DESCRIPTION
Maintainer: @Adze1502
Compile tested: LEDE master
Run tested: lantiq, not upstream, LEDE master, tests done but more test welcome :-)

Description:

If the operstate of the tracked device changes state up->down (unplug ethernet cable), mwan3track will bring down the interface immediatelly and do not wait until ping detects an failure. The same is vaild for device changes operstate from down->up (plugin ethernet cable).

Signed-off-by: Florian Eckert Eckert.Florian@googlemail.com
