### PR TITLE
The http://www.linux-pam.org/library/ is inactive, source change for Linux-PAM-1.2.0.tar.bz2

### DIFF
--- a/libs/libpam/Makefile
+++ b/libs/libpam/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.2.0
 PKG_RELEASE:=2
 
 PKG_SOURCE:=Linux-PAM-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=http://www.linux-pam.org/library/
+PKG_SOURCE_URL:=http://pkgs.fedoraproject.org/repo/pkgs/pam/Linux-PAM-1.2.0.tar.bz2/ee4a480d77b341c99e8b1375f8f180c0/
 PKG_MD5SUM:=ee4a480d77b341c99e8b1375f8f180c0
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Maintainer: Kirill @kirr2
Compile tested: on Debian 8.5 x86
Run tested: exit with error ( compile for TP-Link tl-mr3020 )

Description:
The http://www.linux-pam.org site is inactive (from Russia, may be it is blocking...)
I did find repository with same source code.
Without this package, compiling ending with error and exiting.

P.S.
This is my first pull request, sorry if I somehow made it wrong.
And as for my english :)