### PR TITLE
relayctl: Add PKG_FIXUP to fix autotools version error

### DIFF
--- a/utils/relayctl/Makefile
+++ b/utils/relayctl/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=relayctl
 PKG_VERSION:=0.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/relayctl/relayctl-$(PKG_VERSION)
@@ -18,6 +18,7 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Maintainer: Heinrich Schuchart / @xypron 
Compile tested: MIPS_34kc
Run tested: "Well, it builds now" :smile:

Build errors:
>/opt/ledesrc/build_dir/target-mips_34kc_musl-1.1.15/relayctl-0.1/missing: line 81: automake-1.14: co
mmand not found
>WARNING: 'automake-1.14' is missing on your system.

Added PKG_FIXUP:=autoreconf

Signed-off-by: Ted Hess <thess@kitschensync.net>