### PR TITLE
coova-chilli: Fix removal of old files

### DIFF
--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.3.0+20141128
 PKG_MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=git://github.com/coova/coova-chilli

--- a/net/coova-chilli/files/chilli.init
+++ b/net/coova-chilli/files/chilli.init
@@ -7,7 +7,7 @@ config_cb() {
     chilli_inst=$2
     if [ "$chilli_inst" != "" ]
     then
-       rm -f /var/run/chilli_${chilli_inst}*
+       rm -f /var/run/chilli_${chilli_inst}.*
        chilli_conf=/var/run/chilli_${chilli_inst}.conf
        eval "start_chilli_$chilli_inst=1"
     fi


### PR DESCRIPTION
Maintainer: @kaloz 
Compile tested: MIPS, TP-Link Archer C7 V2.0, OpenWrt 15.05.1
Run tested: MIPS, TP-Link Archer C7 V2.0, OpenWrt 15.05.1, Tested Coova start/stop/login

Description:

Before starting chilli instance, it first removes generated
files (/var/run/chilli*) for the instance. While deleting
generated files, it doesn't match full instance name.

Thus if coova-chilli config file (/etc/config/chilli) has
instances wlan11 and wlan1 in order,
when creating coova-chilli instance for wlan1, it is removing
files generated for wlan11 instances also (as it uses wlan1*
in remove command).

Fix issue by matching full instance name while removing old files.

Signed-off-by: Rajan Vaja <rajan.vaja@gmail.com>
Signed-off-by: Bhargav Patel <br13patel@gmail.com>