### PR TITLE
freeradius3: Fixes to init script.

### DIFF
--- a/net/freeradius2/files/radiusd.init
+++ b/net/freeradius2/files/radiusd.init
@@ -19,7 +19,8 @@ start_service()
 	mkdir -p /var/db/radacct
 
 	procd_open_instance
-	procd_set_param command $PROG
+	procd_set_param command $PROG -f
+	procd_set_param env LD_LIBRARY_PATH=/usr/lib/freeradius2
 	[ -n "$IPADDR" ] && procd_append_param command -i $IPADDR
 	[ -n "$OPTIONS" ] && procd_append_param command $OPTIONS
 	procd_set_param respawn

--- a/net/freeradius3/files/radiusd.init
+++ b/net/freeradius3/files/radiusd.init
@@ -19,7 +19,8 @@ start_service()
 	mkdir -p /var/db/radacct
 
 	procd_open_instance
-	procd_set_param command $PROG
+	procd_set_param command $PROG -f
+	procd_set_param env LD_LIBRARY_PATH=/usr/lib/freeradius3
 	[ -n "$IPADDR" ] && procd_append_param command -i $IPADDR
 	[ -n "$OPTIONS" ] && procd_append_param command $OPTIONS
 	procd_set_param respawn


### PR DESCRIPTION
Maintainer: Lucile Quirion
Compile tested: ar71xx r1254
Run tested: ar71xx r1254

Description:

This fixes two issues with the freeradius3 package init script:

- The package installs libraries in /usr/lib/freeradius3, but the musl
  dynamic linker won't find them there unless LD_LIBRARY_PATH is set to
  include this directory. This adds an appropriate env statement to the
  procd init setup.

- procd expects services to stay in the foreground, or it will be unable
  to properly shut them down again. This adds the -f flag to radiusd to
  achieve that.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>