### PR TITLE
luasec: fix build with OPENSSL_NO_COMP

### DIFF
--- a/lang/luasec/Makefile
+++ b/lang/luasec/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luasec
 PKG_VERSION:=0.5.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/brunoos/luasec/archive/

--- a/lang/luasec/patches/200-compression-method-fix.patch
+++ b/lang/luasec/patches/200-compression-method-fix.patch
@@ -1,0 +1,24 @@
+--- a/src/ssl.c
++++ b/src/ssl.c
+@@ -401,17 +401,21 @@ static int meth_want(lua_State *L)
+  */
+ static int meth_compression(lua_State *L)
+ {
++#ifndef OPENSSL_NO_COMP
+   const COMP_METHOD *comp;
++#endif
+   p_ssl ssl = (p_ssl)luaL_checkudata(L, 1, "SSL:Connection");
+   if (ssl->state != LSEC_STATE_CONNECTED) {
+     lua_pushnil(L);
+     lua_pushstring(L, "closed");
+     return 2;
+   }
++#ifndef OPENSSL_NO_COMP
+   comp = SSL_get_current_compression(ssl->ssl);
+   if (comp)
+     lua_pushstring(L, SSL_COMP_get_name(comp));
+   else
++#endif
+     lua_pushnil(L);
+   return 1;
+ }


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: LEDE 27dffa0b0c53a1a817a9a37d1647c7e70672273f x86/64
Run tested: -

Description:

Currently luasec fails to build if OpenSSL was built without compression
support due to an undefined COMP_METHOD type:

    ssl.c: In function 'meth_compression':
    ssl.c:404:9: error: unknown type name 'COMP_METHOD'
       const COMP_METHOD *comp;
             ^
    <builtin>: recipe for target 'ssl.o' failed
    make[6]: *** [ssl.o] Error 1

Add a local patch to stub the `meth_compression()` function if there is no
compression support available in the OpenSSL library in order to allow
luasec to build.

A similar fix has been added upstream with
https://github.com/brunoos/luasec/pull/30

Signed-off-by: Jo-Philipp Wich <jo@mein.io>