### PR TITLE
bluez: add dependency on libncursesw

### DIFF
--- a/utils/bluez/Makefile
+++ b/utils/bluez/Makefile
@@ -47,7 +47,7 @@ $(call Package/bluez/Default)
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE+= library
-  DEPENDS:=+libpthread +kmod-bluetooth
+  DEPENDS:=+libpthread +kmod-bluetooth +libncursesw
 endef
 
 define Package/bluez-utils


### PR DESCRIPTION
urgh
--------------------------------------------------------------------
Hi :-)

I was building LEDE with a fresh config when all of a sudden a wild `cannot find -lncurses` appeared.
This commit fixes the problem.

kind regards
Leon