### PR TITLE
strongswan: Fix possible compilation issue by including musl.h after _GNU_SOURCE define

### DIFF
--- a/net/strongswan/patches/101-musl-fixes.patch
+++ b/net/strongswan/patches/101-musl-fixes.patch
@@ -10,7 +10,7 @@
  
 --- /dev/null
 +++ b/src/libstrongswan/musl.h
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,38 @@
 +#include <sys/types.h>
 +
 +#define crypt x_crypt
@@ -31,7 +31,6 @@
 +#define nlink_t x_nlink_t
 +#define timer_t x_timer_t
 +#define blkcnt_t x_blkcnt_t
-+#define __kernel_nlink_t void
 +
 +#include <linux/types.h>
 +
@@ -52,15 +51,14 @@
 +#undef encrypt
 --- a/src/libcharon/plugins/kernel_netlink/kernel_netlink_ipsec.c
 +++ b/src/libcharon/plugins/kernel_netlink/kernel_netlink_ipsec.c
-@@ -18,6 +18,8 @@
-  * for more details.
+@@ -19,6 +19,7 @@
   */
  
-+#include <musl.h>
-+
  #define _GNU_SOURCE
++#include <musl.h>
  #include <sys/types.h>
  #include <sys/socket.h>
+ #include <stdint.h>
 --- a/src/libcharon/plugins/kernel_netlink/kernel_netlink_net.c
 +++ b/src/libcharon/plugins/kernel_netlink/kernel_netlink_net.c
 @@ -37,6 +37,8 @@


### PR DESCRIPTION
Maintainer: @sbyx 
Compile tested: strongswan package compiles successfully on brcm63xx
Run tested: brcm63xx

Description:

…_GNU_SOURCE define

musl.h was included before _GNU_SOURCE leading to compilation issue on gcc
(RTLD_DEFAULT not being defined in dlfcn.h due to __USE_GNU not being set).
As described in the feature test macro man page feature macros can be defined in
the source code but need to be defined before including any headers

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>