### PR TITLE
libtalloc: add libattr dependency

### DIFF
--- a/libs/libtalloc/Makefile
+++ b/libs/libtalloc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=talloc
 PKG_VERSION:=2.1.7
 MAJOR_VERSION:=2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.samba.org/ftp/talloc/
@@ -28,7 +28,7 @@ define Package/libtalloc
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Core memory allocator used in Samba
-  DEPENDS:=+USE_GLIBC:libbsd $(ICONV_DEPENDS)
+  DEPENDS:=+USE_GLIBC:libbsd $(ICONV_DEPENDS) +attr
   URL:=https://talloc.samba.org/talloc/doc/html/index.html
 endef
 


### PR DESCRIPTION
Maintainer: @LucileQ
Compile tested: ar71xx, latest LEDE
Run tested: no
Description:

when doing full build libtalloc picks libattr as dependency
then packaging fails with
"Package libtalloc is missing dependencies for the following libraries: libattr.so.1"

Signed-off-by: Etienne CHAMPETIER champetier.etienne@gmail.com
