### PR TITLE
Emailrelay: enabled support for debug logging in order to have better log for investigating crashes

### DIFF
--- a/net/emailrelay/Makefile
+++ b/net/emailrelay/Makefile
@@ -81,8 +81,9 @@ define Package/emailrelay-nossl/conffiles
 endef
 
 CONFIGURE_ARGS += \
-	--with-pam=no
-
+	--with-pam=no \
+	--enable-debug=yes
+	
 CONFIGURE_VARS += \
 	CXXFLAGS="$$$$CXXFLAGS -fno-rtti"	
 


### PR DESCRIPTION
Signed-off-by: Federico Di Marco <fededim@gmail.com>
