### PR TITLE
xl2tpd: Enable netifd notification teardown_on_l3_link_down

### DIFF
--- a/net/xl2tpd/Makefile
+++ b/net/xl2tpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xl2tpd
-PKG_VERSION:=devel-20151125
+PKG_VERSION:=devel-20160811
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/net/xl2tpd/files/l2tp.sh
+++ b/net/xl2tpd/files/l2tp.sh
@@ -21,6 +21,7 @@ proto_l2tp_init_config() {
 	available=1
 	no_device=1
 	no_proto_task=1
+	teardown_on_l3_link_down=1
 }
 
 proto_l2tp_setup() {


### PR DESCRIPTION

Maintainer: @yousong 
Compile tested: brcm63xx
Run tested: brcm63xx

Description:

Set teardown_on_l3_link_down notifying netifd xl2tpd wants to be
teared down when layer3 link loss is detected

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>