### PR TITLE
mwan3: enhancement add ping size and flush conntrack table

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.0
+PKG_VERSION:=2.1
 PKG_RELEASE:=4
 PKG_MAINTAINER:=Jeroen Louwes <jeroen.louwes@gmail.com>, \
 		Florian Eckert <fe@dev.tdt.de>

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -46,6 +46,7 @@ case "$ACTION" in
 		mwan3_track $INTERFACE $DEVICE
 		mwan3_set_policies_iptables
 		mwan3_set_user_rules
+		mwan3_flush_conntrack $INTERFACE $DEVICE "ifup"
 	;;
 	ifdown)
 		mwan3_delete_iface_rules $INTERFACE
@@ -54,6 +55,7 @@ case "$ACTION" in
 		mwan3_delete_iface_ipset_entries $INTERFACE
 		mwan3_set_policies_iptables
 		mwan3_set_user_rules
+		mwan3_flush_conntrack $INTERFACE $DEVICE "ifdown"
 	;;
 esac
 

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -361,7 +361,7 @@ mwan3_delete_iface_ipset_entries()
 
 mwan3_track()
 {
-	local track_ip track_ips reliability count timeout interval down up
+	local track_ip track_ips reliability count timeout interval down up size
 
 	mwan3_list_track_ips()
 	{
@@ -381,8 +381,9 @@ mwan3_track()
 		config_get interval $1 interval 10
 		config_get down $1 down 5
 		config_get up $1 up 5
+		config_get size $1 size 56
 
-		[ -x /usr/sbin/mwan3track ] && /usr/sbin/mwan3track $1 $2 $reliability $count $timeout $interval $down $up $track_ips &
+		[ -x /usr/sbin/mwan3track ] && /usr/sbin/mwan3track $1 $2 $reliability $count $timeout $interval $down $up $size $track_ips &
 	fi
 }
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -z "$9" ] && echo "Error: should not be started manually" && exit 0
+[ -z "$10" ] && echo "Error: should not be started manually" && exit 0
 
 if [ -e /var/run/mwan3track-$1.pid ] ; then
 	kill $(cat /var/run/mwan3track-$1.pid) &> /dev/null
@@ -17,7 +17,7 @@ lost=0
 while true; do
 
 	for track_ip in $track_ips; do
-		ping -I $2 -c $4 -W $5 -q $track_ip &> /dev/null
+		ping -I $2 -c $4 -W $5 -s $9 -q $track_ip &> /dev/null
 		if [ $? -eq 0 ]; then
 			let host_up_count++
 		else


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE master
Run tested: lantiq, not upstream, LEDE master, tests done but more test welcome :-)

Description:

I am using mwan3 in an fail over scenario, and i am on the backup interface (3g/LTE) and mwan3 switches back to the default interface (DSL) because it is back again. Connection which are established during the fail over time still use the backup interface even though the main interface is back.
If i delete the conntrack table the connection will use the main interface again.

Signed-off-by: Florian Eckert Eckert.Florian@googlemail.com
