### PR TITLE
[for-15.05] ldns: Avoid perl bug for manpages.

### DIFF
--- a/libs/ldns/Makefile
+++ b/libs/ldns/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ldns
 PKG_VERSION:=1.6.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.nlnetlabs.nl/downloads/ldns

--- a/libs/ldns/patches/001-perl5-defined-array.patch
+++ b/libs/ldns/patches/001-perl5-defined-array.patch
@@ -1,0 +1,11 @@
+--- a/doc/doxyparse.pl
++++ b/doc/doxyparse.pl
+@@ -273,7 +273,7 @@ foreach (keys %manpages) {
+ 
+ 	print MAN $MAN_MIDDLE;
+ 
+-	if (defined(@$also)) {
++	if (@$also) {
+ 		print MAN "\n.SH SEE ALSO\n\\fI";
+ 		print MAN join "\\fR, \\fI", @$also;
+ 		print MAN "\\fR.\nAnd ";


### PR DESCRIPTION
Compile tested: 15.05 git HEAD

Description:

Cherry-Pick fix for #2663 for 15.05 branch, no changes

(cherry picked from commit a4a9038f58c4876d419a173bb17d34c0800fae75)