### PR TITLE
[for-15.05] glib2: fix (host-)build with gcc6

### DIFF
--- a/libs/glib2/patches/002-gdate-Suppress-string-format-literal-warning.patch
+++ b/libs/glib2/patches/002-gdate-Suppress-string-format-literal-warning.patch
@@ -1,0 +1,29 @@
+From 0817af40e8c74c721c30f6ef482b1f53d12044c7 Mon Sep 17 00:00:00 2001
+From: coypu <coypu@sdf.org>
+Date: Mon, 8 Feb 2016 00:06:06 +0200
+Subject: gdate: Suppress string format literal warning
+
+Newer versions of GCC emit an error here, but we know it's safe.
+https://bugzilla.gnome.org/761550
+---
+ glib/gdate.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/glib/gdate.c b/glib/gdate.c
+index 4aece02..cdc735c 100644
+--- a/glib/gdate.c
++++ b/glib/gdate.c
+@@ -2494,7 +2494,10 @@ g_date_strftime (gchar       *s,
+        * recognize whether strftime actually failed or just returned "".
+        */
+       tmpbuf[0] = '\1';
++      #pragma GCC diagnostic push
++      #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+       tmplen = strftime (tmpbuf, tmpbufsize, locale_format, &tm);
++      #pragma GCC diagnostic pop
+ 
+       if (tmplen == 0 && tmpbuf[0] != '\0')
+         {
+-- 
+cgit v0.12
+

--- a/libs/glib2/patches/003-gdate-Move-warning-pragma-outside-of-function.patch
+++ b/libs/glib2/patches/003-gdate-Move-warning-pragma-outside-of-function.patch
@@ -1,0 +1,47 @@
+From 8cdbc7fb2c8c876902e457abe46ee18a0b134486 Mon Sep 17 00:00:00 2001
+From: coypu <coypu@sdf.org>
+Date: Wed, 2 Mar 2016 19:38:48 +0200
+Subject: gdate: Move warning pragma outside of function
+
+Commit 0817af40e8c74c721c30f6ef482b1f53d12044c7 breaks the build on
+older versions of GCC, which don't allow pragma inside functions.
+
+https://bugzilla.gnome.org/761550
+---
+ glib/gdate.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/glib/gdate.c b/glib/gdate.c
+index cdc735c..92c34d2 100644
+--- a/glib/gdate.c
++++ b/glib/gdate.c
+@@ -2439,6 +2439,9 @@ win32_strftime_helper (const GDate     *d,
+  *
+  * Returns: number of characters written to the buffer, or 0 the buffer was too small
+  */
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wformat-nonliteral"
++
+ gsize     
+ g_date_strftime (gchar       *s, 
+                  gsize        slen, 
+@@ -2494,10 +2497,7 @@ g_date_strftime (gchar       *s,
+        * recognize whether strftime actually failed or just returned "".
+        */
+       tmpbuf[0] = '\1';
+-      #pragma GCC diagnostic push
+-      #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+       tmplen = strftime (tmpbuf, tmpbufsize, locale_format, &tm);
+-      #pragma GCC diagnostic pop
+ 
+       if (tmplen == 0 && tmpbuf[0] != '\0')
+         {
+@@ -2552,3 +2552,5 @@ g_date_strftime (gchar       *s,
+   return retval;
+ #endif
+ }
++
++#pragma GCC diagnostic pop
+-- 
+cgit v0.12
+


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: 15.05 git HEAD

Description:

Cherry-Pick commit from master fixing glib2 compilation with gcc 6 on host, no changes

Signed-off-by: Daniel Golle daniel@makrotopia.org
(cherry picked from commit 0e99e5eea9f24cfcd9479f0f5b9736bbf9127ae5)
