### PR TITLE
qemu: fix ccache enabled builds

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -45,7 +45,7 @@ CONFIGURE_ARGS:=$(filter-out	\
 # Building qemu-ga alone does not require zlib
 CONFIGURE_ARGS+=			\
 	--cross-prefix=$(TARGET_CROSS)	\
-	--host-cc=$(HOSTCC)		\
+	--host-cc="$(HOSTCC)"		\
 	--target-list=''		\
 	--disable-zlib-test		\
 	--enable-guest-agent


### PR DESCRIPTION

Maintainer: @yousong
Compile tested: yes, LEDE r1264+67
Run tested: NO

issue reported by buildbots
fix error:
ERROR: unknown option gcc

Signed-off-by: Dirk Neukirchen <plntyk.lede@plntyk.name>