### PR TITLE
lftp: set readline location

### DIFF
--- a/net/lftp/Makefile
+++ b/net/lftp/Makefile
@@ -61,6 +61,7 @@ CONFIGURE_ARGS += \
 	--without-libidn \
 	--without-libresolv \
 	--with-openssl="$(STAGING_DIR)/usr" \
+	--with-readline="$(STAGING_DIR)/usr" \
 	--with-zlib="$(STAGING_DIR)/usr" \
 	--disable-static
 


### PR DESCRIPTION
Maintainer: @fededim
Compile tested: yes,LEDE r1264+67
Run tested: NO

configure tries to use host location
- fixes buildbot compile

https://downloads.lede-project.org/snapshots/faillogs/x86_64/packages/lftp/compile.txt
configure: error: cannot find readline library, install readline-devel package

Signed-off-by: Dirk Neukirchen <plntyk.lede@plntyk.name>