### PR TITLE
node: fix soft/hard float compile on arm/mips

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -57,7 +57,18 @@ CONFIGURE_ARGS= \
 	--shared-openssl \
 	--prefix=/usr
 
+ifneq ($(findstring arm,$(ARCH)),)
+CONFIGURE_ARGS+= \
+	$(if $(CONFIG_SOFT_FLOAT),--with-arm-float-abi=soft,--with-arm-float-abi=hard)
+endif
+
+ifneq ($(findstring mips,$(ARCH)),)
+CONFIGURE_ARGS+= \
+	$(if $(CONFIG_SOFT_FLOAT),--with-mips-float-abi=soft,--with-mips-float-abi=hard)
+endif
+
 HOST_CONFIGURE_VARS:=
+
 HOST_CONFIGURE_ARGS:= \
 	--dest-os=linux \
 	--without-snapshot \


### PR DESCRIPTION
Maintainer: @blogic 
Compile tested: yes r1264+67
Run tested: NO

Description:

nodejs has currently several different build problems - this patch fixes one

- reported by brcm2708/2709 user on IRC
- replicated locally

Signed-off-by: Dirk Neukirchen <plntyk.lede@plntyk.name>