### PR TITLE
lang/perl: Fix Perl fails to compile on LEDE trunk due to missing SOU…

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -79,6 +79,11 @@ define Host/Configure
 	( cd $(HOST_BUILD_DIR); ./Configure -der -Uusedl -Duserelocatableinc -Dprefix=$(HOST_PERL_PREFIX) $(if $(CONFIG_PERL_THREADS),-Dusethreads,))
 endef
 
+HOST_MAKE_FLAGS +=\
+	SHELL="/usr/bin/env SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) /bin/sh " \
+	SOURCE_DATE_EPOCH="$(SOURCE_DATE_EPOCH)" \
+	MAKE="$(MAKE) SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) "
+
 define Host/Install
 	( cd $(HOST_BUILD_DIR); ./miniperl installperl )
 	$(INSTALL_DIR) $(HOST_PERL_PREFIX)/bin/


### PR DESCRIPTION
Maintainer: @Naoir
Compile tested: x86_64
Run tested: not yet

Description:

…RCE_DATE_EPOCH for GCC

Without this, perl fails to compile complaining that SOURCE_DATE_EPOCH
is not a non-negative integer less that max for epoch when compiling
miniperl.

Signed-off-by: Daniel Dickinson lede@cshore.thecshore.com
