### PR TITLE
adblock: update 1.4.4

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=1.4.3
+PKG_VERSION:=1.4.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/adblock-helper.sh
+++ b/net/adblock/files/adblock-helper.sh
@@ -686,7 +686,7 @@ f_statistics()
     if [ -n "${adb_wanif4}" ]
     then
         ipv4_blk="$(iptables -t nat -vxnL adb-nat | awk '$3 ~ /^DNAT$/ {sum += $1} END {printf sum}')"
-        ipv4_all="$(iptables -t nat -vxnL PREROUTING | awk '$3 ~ /^prerouting_rule$/ {sum += $1} END {printf sum}')"
+        ipv4_all="$(iptables -t nat -vxnL PREROUTING | awk '$3 ~ /^(delegate_prerouting|prerouting_rule)$/ {sum += $1} END {printf sum}')"
         if [ $((ipv4_all)) -gt 0 ] && [ $((ipv4_blk)) -gt 0 ] && [ $((ipv4_all)) -gt $((ipv4_blk)) ]
         then
             ipv4_pct="$(printf "${ipv4_blk}" | awk -v all="${ipv4_all}" '{printf( "%5.2f\n",$1/all*100)}')"

--- a/net/adblock/files/adblock-update.sh
+++ b/net/adblock/files/adblock-update.sh
@@ -10,7 +10,7 @@
 #
 adb_pid="${$}"
 adb_pidfile="/var/run/adblock.pid"
-adb_scriptver="1.4.3"
+adb_scriptver="1.4.4"
 adb_mincfgver="2.3"
 adb_scriptdir="${0%/*}"
 if [ -r "${adb_pidfile}" ]
@@ -97,7 +97,7 @@ do
     then
         if [ "${src_name}" = "blacklist" ]
         then
-            tmp_domains="$(cat "${url}")"
+            tmp_domains="$(cat "${url}" | strings -n 1)"
         elif [ "${src_name}" = "shalla" ]
         then
             shalla_archive="${adb_tmpdir}/shallalist.tar.gz"
@@ -117,13 +117,13 @@ do
                         break
                     fi
                 done
-                tmp_domains="$(cat "${shalla_file}")"
+                tmp_domains="$(cat "${shalla_file}" | strings -n 1)"
                 rm -rf "${adb_tmpdir}/BL"
                 rm -f "${shalla_archive}"
                 rm -f "${shalla_file}"
             fi
         else
-            tmp_domains="$(${adb_fetch} ${fetch_parm} -O- "${url}")"
+            tmp_domains="$(${adb_fetch} ${fetch_parm} -O- "${url}" | strings -n 1)"
         fi
         rc=${?}
     else


### PR DESCRIPTION
Maintainer: me
Run tested: LEDE r1197, x86_64

Description:
* filter non-printable characters/binary data in input stream
* fix IPv4 adblock statistics in CC

Signed-off-by: Dirk Brenken <dev@brenken.org>