### PR TITLE
znc: requires deprecated api & compression in openssl lib

### DIFF
--- a/net/znc/Makefile
+++ b/net/znc/Makefile
@@ -35,7 +35,7 @@ endef
 
 define Package/znc
   $(Package/znc/default)
-  DEPENDS:=+libopenssl +libpthread +libstdcpp +ZNC_ICU:icu
+  DEPENDS:=+libopenssl +libpthread +libstdcpp +ZNC_ICU:icu +@OPENSSL_WITH_DEPRECATED +@OPENSSL_WITH_COMPRESSION
   MENU:=1
 endef
 


### PR DESCRIPTION
Maintainer: @KanjiMonster 
Compile tested: ar71xx, Archer C7 v2, Lede trunk
Run tested: ar71xx, Archer C7 v2, lede trunk, it builds & runs!

Description:

znc fails to build without openssl deprecated api & compression options.
Update dependencies to force these compile time options.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>