### PR TITLE
dhcp-forwarder: New package

### DIFF
--- a/net/dhcp-forwarder/Makefile
+++ b/net/dhcp-forwarder/Makefile
@@ -1,0 +1,74 @@
+#
+# Copyright (C) 2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dhcp-forwarder
+PKG_VERSION:=0.11
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=http://savannah.nongnu.org/download/dhcp-fwd/
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_MD5SUM:=9d1ea7939fef93ae7d7caef43397a908
+
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_MAINTAINER:=Scott K Logan <logans@cottsay.net>
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/dhcp-forwarder
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=IP Addresses and Names
+  TITLE:=DHCP relay agent
+  URL:=http://www.nongnu.org/dhcp-fwd/
+  USERID:=dhcp-fwd=375:dhcp-fwd=375
+endef
+
+define Package/dhcp-forwarder/description
+  This program forwards DHCP messages between subnets with different sublayer
+  broadcast domains. It is similarly to the DHCP relay agent dhcrelay of ISC's
+  DHCP, but has the following features which are important for me:
+
+  - Runs as non-root in a chroot-jail
+  - Uses "normal" AF_INET sockets; this allows to uses packetfilters to filter
+    incoming messages.
+  - The DHCP agent IDs can be defined freely
+  - Has a small memory footprint when using dietlibc
+
+  It tries to be RFC 2131/2132 and 3046 compliant. Probably it works with BOOTP
+  (RFC 951) also, but since the handling of the giaddr field is described
+  misleading (see RFC 1542), there may occur problems.
+endef
+
+define Package/dhcp-forwarder/conffiles
+  /etc/dhcp-fwd.conf
+endef
+
+CONFIGURE_ARGS += \
+	--disable-dietlibc \
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+	  DESTDIR="$(PKG_INSTALL_DIR)" \
+	  cfg_filename="/etc/dhcp-fwd.conf" \
+	  all install
+endef
+
+define Package/dhcp-forwarder/install
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/etc $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/dhcp-fwd $(1)/usr/bin/
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/contrib/dhcp-fwd.conf $(1)/etc/
+	$(INSTALL_BIN) ./files/dhcp-fwd.init $(1)/etc/init.d/dhcp-fwd
+endef
+
+$(eval $(call BuildPackage,dhcp-forwarder))

--- a/net/dhcp-forwarder/files/dhcp-fwd.init
+++ b/net/dhcp-forwarder/files/dhcp-fwd.init
@@ -1,0 +1,25 @@
+#!/bin/sh /etc/rc.common
+
+START=50
+USE_PROCD=1
+
+LOG_D=/var/log
+RUN_D=/var/run
+CHR_D=/var/lib/dhcp-fwd
+PID_F=$RUN_D/dhcp-fwd.pid
+
+start_service() {
+	[ -d $LOG_D ] || mkdir -p $LOG_D
+	[ -d $RUN_D ] || mkdir -p $RUN_D
+	[ -d $CHR_D ] || mkdir -p $CHR_D && chown dhcp-fwd:dhcp-fwd $CHR_D -R
+
+	procd_open_instance
+	procd_set_param command dhcp-fwd -n
+	procd_set_param respawn
+	procd_close_instance
+}
+
+service_triggers()
+{
+	procd_add_reload_trigger "dhcp"
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: target-mips_34kc_musl-1.1.14/linux-ar71xx_generic
Run tested: target-mips_34kc_musl-1.1.14/linux-ar71xx_generic/dir-601-b1

Program functions as described on my device, forwarding DHCP discovery packets from an attached subnet to the proper DHCP server. It also routes the DHCP responses back to the originating client correctly.

This package was part of OpenWrt before, but disappeared in Chaos Calmer. The package didn't function correctly as far back as Barrier Breaker anyway, and it was a version behind, so this commit adds the latest source version and an updated init file.

Description:
This program forwards DHCP messages between subnets with different sublayer broadcast domains. Check out the project site for more info: http://www.nongnu.org/dhcp-fwd/

Signed-off-by: Scott K Logan <logans@cottsay.net>