### PR TITLE
htop: update to 2.0.2

### DIFF
--- a/admin/htop/Makefile
+++ b/admin/htop/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2014 OpenWrt.org
+# Copyright (C) 2007-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=htop
-PKG_VERSION:=2.0.1
+PKG_VERSION:=2.0.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://hisham.hm/htop/releases/$(PKG_VERSION)/
-PKG_MD5SUM:=f75fe92b4defaa80d99109830f34b5e2
+PKG_MD5SUM:=7d354d904bad591a931ad57e99fea84a
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING

--- a/admin/htop/patches/100-fix-libtool-version-check.patch
+++ b/admin/htop/patches/100-fix-libtool-version-check.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -2,7 +2,7 @@
+ # Process this file with autoconf to produce a configure script.
+ 
+ AC_PREREQ(2.65)
+-LT_PREREQ([2.4.2])
++LT_PREREQ([2.4.0])
+ AC_INIT([htop],[2.0.2],[hisham@gobolinux.org])
+ 
+ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested: ar71xx for LEDE
Run tested: ar71xx/WDNR3700 with LEDE

Description:

* update htop to 2.0.2
* patch the new libtool check to match libtool version in use. Htop 2.0.2 includes a new configure.ac check for the existence of libtool ( https://github.com/hishamhm/htop/commit/6c1be632919baeef12143ad762b0fc0f7398f8b0 ), but as we are still using a 6-year old libtool 2.4.0 both in Openwrt & LEDE, the supposedly safe test for a 5-year old version 2.4.2 fails. I adjusted the check to look for 2.4.0 instead.

----

Note for core developers:

Any plans to update libtool from the ancient 2.4.0 (from 2010) to anything more recent?

I looked into that myself a few months ago, but dropped the effort after I noticed that there had been a rather large libtool architecture reorganisation in 2011 (which might be the reason, why libtool package has not been updated.)