### PR TITLE
[for-15.05] darkstat: from oldpackages, update to 3.0.719

### DIFF
--- a/net/darkstat/Makefile
+++ b/net/darkstat/Makefile
@@ -1,0 +1,66 @@
+#
+# Copyright (C) 2007-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=darkstat
+PKG_VERSION:=3.0.719
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Jean-Michel Lacroix <lacroix@lepine-lacroix.info>
+
+PKG_LICENSE:=GPL-2.0 BSD-ISC
+PKG_LICENSE_FILES:=COPYING.GPL LICENSE
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=http://unix4lyfe.org/darkstat
+PKG_MD5SUM:=963145de05cb21f4d93a9c244beeaea0
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/darkstat
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpcap +zlib
+  TITLE:=Network bandwidth monitor
+  URL:=http://unix4lyfe.org/darkstat/
+endef
+
+define Package/darkstat/description
+darkstat is a packet sniffer that runs as a background process on a cable/DSL
+router, gathers all sorts of statistics about network usage, and serves them
+over HTTP.
+endef
+
+define Package/darkstat/conffiles
+/etc/config/darkstat
+endef
+
+CONFIGURE_ARGS += \
+	--disable-debug \
+	--with-chroot-dir=/var/empty
+
+TARGET_CFLAGS += -std=gnu99
+
+define Build/Compile
+	$(HOSTCC) $(PKG_BUILD_DIR)/static/c-ify.c \
+		-o $(PKG_BUILD_DIR)/c-ify
+	$(call Build/Compile/Default)
+endef
+
+define Package/darkstat/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/darkstat $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/darkstat.init $(1)/etc/init.d/darkstat
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/darkstat.config $(1)/etc/config/darkstat
+endef
+
+$(eval $(call BuildPackage,darkstat))

--- a/net/darkstat/files/darkstat.config
+++ b/net/darkstat/files/darkstat.config
@@ -1,0 +1,20 @@
+config darkstat
+	option interface        'lan'
+	option syslog           false
+	option verbose          true
+	option no_daemon        false
+	option no_promisc       false
+	option no_dns           false
+	option no_macs          false
+	option no_lastseen      false
+#	option httpaddr         '0.0.0.0'
+#	option httpport         '667'
+#	option network_filter   'not (src net 192.168.1 and dst net 192.168.1)'
+#	option network_netmask  '192.168.1.0/255.255.255.0'
+	option local_only       false
+#	option hosts_max        '1000'
+#	option hosts_keep       '500'
+#	option ports_max        '60'
+#	option ports_keep       '30'
+#	option highest_port     '65534'
+

--- a/net/darkstat/files/darkstat.init
+++ b/net/darkstat/files/darkstat.init
@@ -1,0 +1,97 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2007-2016 OpenWrt.org
+
+START=60
+APP=darkstat
+RUN_D=/var/empty
+PID_F=$RUN_D/darkstat.pid
+
+SYSLOG=""
+VERBOSE=""
+NODAEMON=""
+NOPROMISC=""
+NODNS=""
+NOMACS=""
+NOLASTSEEN=""
+LOCAL=""
+paramstr=""
+
+export_bool () {
+	local option="$1"
+	local section="$2"
+	local _keystr="$3"
+	local _loctmp
+	paramstr=""
+	config_get_bool _loctmp "$section" "$option"
+	if [ -n "$_loctmp" ]; then
+		if [ 1 -eq "$_loctmp" ]; then
+			paramstr="${_keystr} "
+		fi
+	fi
+}
+
+start() {
+	mkdir -p $RUN_D
+	. /lib/functions/network.sh
+	config_load darkstat
+	config_foreach start_darkstat darkstat
+}
+
+start_darkstat() {
+	local cfg="$1"
+	config_get interface $cfg interface
+	export_bool syslog $cfg "--syslog"
+	SYSLOG=$paramstr
+	export_bool verbose $cfg "--verbose"
+	VERBOSE=$paramstr
+	export_bool no_daemon $cfg "--no-daemon"
+	NODAEMON=$paramstr
+	export_bool no_promisc $cfg "--no-promisc"
+	NOPROMISC=$paramstr
+	export_bool no_dns $cfg "--no-dns"
+	NODNS=$paramstr
+	export_bool no_macs $cfg "--no-macs"
+	NOMACS=$paramstr
+	export_bool no_lastseen $cfg "--no-lastseen"
+	NOLASTSEEN=$paramstr
+	config_get httpaddr $cfg httpaddr
+	config_get httpport $cfg httpport
+	config_get network_filter $cfg network_filter
+	config_get network_netmask $cfg network_netmask
+	export_bool local_only $cfg "--local-only"
+	LOCAL=$paramstr
+	config_get hosts_max $cfg hosts_max
+	config_get hosts_keep $cfg hosts_keep
+	config_get ports_max $cfg ports_max
+	config_get ports_keep $cfg ports_keep
+	config_get highest_port	$cfg highest_port
+
+
+	network_get_device ifname "$interface" && {
+		/usr/sbin/$APP -i "$ifname" \
+			${SYSLOG} \
+			${VERBOSE} \
+			${NODAEMON} \
+			${NOPROMISC} \
+			${NODNS} \
+			${NOMACS} \
+			${NOLASTSEEN} \
+			${httpaddr:+-b "$httpaddr"} \
+			${httpport:+-p "$httpport"} \
+			${network_filter:+-f "$network_filter"} \
+			${network_netmask:+-l "$network_netmask"} \
+			${LOCAL} \
+			${hosts_max:+--hosts-max "$hosts_max"} \
+			${hosts_keep:+--hosts-keep "$hosts_keep"} \
+			${ports_max:+--ports-max "$ports_max"} \
+			${ports_keep:+--ports-keep "$ports_keep"} \
+			${highest_port:+--highest-port "$highest_port"} \
+			--chroot $RUN_D \
+			--pidfile $PID_F
+	}
+}
+
+stop() {
+	start-stop-daemon -K -n $APP -p $PID_F -s TERM
+	rm -f $PID_F
+}

--- a/net/darkstat/patches/100-do-not-use-NI_IDN.patch
+++ b/net/darkstat/patches/100-do-not-use-NI_IDN.patch
@@ -1,0 +1,12 @@
+--- a/dns.c
++++ b/dns.c
+@@ -347,9 +347,6 @@ dns_main(void)
+ 
+          reply.addr = ip;
+          flags = NI_NAMEREQD;
+-#  ifdef NI_IDN
+-         flags |= NI_IDN;
+-#  endif
+          switch (ip.family) {
+             case IPv4:
+                sin.sin_family = AF_INET;


### PR DESCRIPTION
PMaintainer: Jean-Michel Lacroix / @padre-lacroix
Compile tested: ar71xx, TL-WDR3600, OpenWRT 15.05
Run tested: ar71xx, TL-WDR3600, OpenWRT 15.05

These are the same files that can be found currently in trunk and that were pulled about a month ago. They work for both trunk and Chaos Calmer.

Description:

Network bandwidth monitor
Signed-off-by: Jean-Michel Lacroix <lacroix@lepine-lacroix.info>