### PR TITLE
adblock: update 1.4.5

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=1.4.4
+PKG_VERSION:=1.4.5
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -16,7 +16,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
     * [feodotracker](https://feodotracker.abuse.ch)
     * => daily updates, approx. 0-10 entries
     * [hphosts](https://hosts-file.net)
-    * => monthly updates, approx. 390.000 entries
+    * => monthly updates, approx. 50.000 entries
     * [malwaredomains](http://malwaredomains.com)
     * => daily updates, approx. 16.000 entries
     * [malwaredomainlist](http://www.malwaredomainlist.com)
@@ -61,7 +61,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 * use two dynamic uhttpd instances as adblock pixel server, separated for ads delivered on port 80 and on port 443
 * use dynamic iptables chains/rulesets for adblock related redirects/rejects
 * init system support (start/stop/restart/reload/toggle/stats/cfgup)
-* hotplug support, the adblock start will be triggered by wan 'ifup' event
+* hotplug support, the adblock start will be triggered by wan 'ifup' event, this can be restricted to a certain wan interface or disabled at all (see config options below)
 * toggle to quickly switch adblock 'on' or 'off'
 * optional: automatic adblock list backup/restore, backups will be (de-)compressed on the fly (disabled by default)
 * optional: add new adblock sources via uci config (see example below)
@@ -101,6 +101,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 * **white-/blacklist:** add domain white- or blacklist entries to always-allow or -deny certain (sub) domains, by default both lists are located in _/etc/adblock_. Please add one domain per line - ip addresses, wildcards & regex are _not_ allowed (see example below)
 * **backup/restore:** enable the backup/restore feature, to restore automatically the latest compressed backup of your adblock lists in case of any processing error (i.e. a single blocklist source is down). Please use an (external) solid partition and _not_ your volatile router temp directory for this
 * **list updates:** for a scheduled call of the adblock service add an appropriate crontab entry (see example below)
+* **hotplug fine tuning:** to restrict hotplug support to a certain wan interface or to disable it at all, you can set 'adb\_hotplugif' to an existing interface like 'wan' or to a non-existing 'dummy' interface
 * **new list sources:** you could add new blocklist sources on your own via uci config, all you need is a source url and an awk one-liner (see example below)
 * **AP mode:** in 'AP mode' adblock uses automatically the local router ip as nullip address. To make sure that your LuCI interface will be still accessible, you have to change the local uhttpd instance to ports <> 80/443 (see example below)
 * **restricted mode:** to disable flash writes with adblock status information to the adblock config file (used by LuCI frontend), please set 'adb\_restricted' to '1'
@@ -122,6 +123,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
     * adb\_forcedns => redirect all local DNS queries to the local dnsmasq resolver (default: '1', enabled / always disabled in 'AP mode')
     * adb\_fetchttl => set the timeout for list downloads (default: '5' seconds)
     * adb\_restricted => disable updates of the adblock config file (no flash writes) during runtime (default: '0', disabled)
+    * adb\_hotplugif => restrict hotplug support to a certain wan interface or disable it at all (default: '', disabled)
 
 ## Examples
 

--- a/net/adblock/files/adblock-helper.sh
+++ b/net/adblock/files/adblock-helper.sh
@@ -6,6 +6,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+adb_hotplugif=""
 adb_lanif="lan"
 adb_nullport="65534"
 adb_nullportssl="65535"

--- a/net/adblock/files/adblock-update.sh
+++ b/net/adblock/files/adblock-update.sh
@@ -10,8 +10,8 @@
 #
 adb_pid="${$}"
 adb_pidfile="/var/run/adblock.pid"
-adb_scriptver="1.4.4"
-adb_mincfgver="2.3"
+adb_scriptver="1.4.5"
+adb_mincfgver="2.4"
 adb_scriptdir="${0%/*}"
 if [ -r "${adb_pidfile}" ]
 then
@@ -97,7 +97,7 @@ do
     then
         if [ "${src_name}" = "blacklist" ]
         then
-            tmp_domains="$(cat "${url}" | strings -n 1)"
+            tmp_domains="$(strings -n 1 "${url}")"
         elif [ "${src_name}" = "shalla" ]
         then
             shalla_archive="${adb_tmpdir}/shallalist.tar.gz"
@@ -117,7 +117,7 @@ do
                         break
                     fi
                 done
-                tmp_domains="$(cat "${shalla_file}" | strings -n 1)"
+                tmp_domains="$(strings -n 1 "${shalla_file}")"
                 rm -rf "${adb_tmpdir}/BL"
                 rm -f "${shalla_archive}"
                 rm -f "${shalla_file}"

--- a/net/adblock/files/adblock.conf
+++ b/net/adblock/files/adblock.conf
@@ -3,7 +3,7 @@
 
 config adblock 'global'
 	option adb_enabled '1'
-	option adb_cfgver '2.3'
+	option adb_cfgver '2.4'
 	option adb_whitelist '/etc/adblock/adblock.whitelist'
 	option adb_whitelist_rset '\$1 ~/^([A-Za-z0-9_-]+\.){1,}[A-Za-z]+/{print tolower(\"^\"\$1\"\\\|[.]\"\$1)}'
 	option adb_forcedns '1'
@@ -44,9 +44,9 @@ config source 'feodo'
 
 config source 'hphosts'
 	option enabled '0'
-	option adb_src 'https://hosts-file.net/download/hosts.txt'
+	option adb_src 'https://hosts-file.net/ad_servers.txt'
 	option adb_src_rset '\$0 ~/^127\.0\.0\.1[ \t]+([A-Za-z0-9_-]+\.){1,}[A-Za-z]+/{print tolower(\$2)}'
-	option adb_src_desc 'broad blocklist against ad-, tracking- and other malicious hosts, monthly updates, approx. 390.000 entries'
+	option adb_src_desc 'broad blocklist against ad- and tracking hosts, monthly updates, approx. 50.000 entries'
 
 config source 'malware'
 	option enabled '0'

--- a/net/adblock/files/adblock.hotplug
+++ b/net/adblock/files/adblock.hotplug
@@ -15,6 +15,9 @@ f_envload
 
 if [ "${INTERFACE}" = "${adb_wanif4}" ] || [ "${INTERFACE}" = "${adb_wanif6}" ]
 then
-    /etc/init.d/adblock start
-    f_log "adblock service started due to '${ACTION}' of '${INTERFACE}' interface"
+    if [ -z "${adb_hotplugif}" ] || [ "${INTERFACE}" = "${adb_hotplugif}" ]
+    then
+        /etc/init.d/adblock start
+        f_log "adblock service started due to '${ACTION}' of '${INTERFACE}' interface"
+    fi
 fi


### PR DESCRIPTION
Maintainer: me
Run tested: x86_64. LEDE r1197

Description:
* change the default hphosts list source to ad and tracking servers only, the overall list includes to many false positives
* new optional config parm 'adb_hotplugif' to restrict hotplug support to a certain wan interface or to disable it at all
* documentation update
* cosmetics

Signed-off-by: Dirk Brenken <dev@brenken.org>