### PR TITLE
i2c-tools: Added python3-smbus package

### DIFF
--- a/utils/i2c-tools/Makefile
+++ b/utils/i2c-tools/Makefile
@@ -26,6 +26,7 @@ PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
+$(call include_mk, python3-package.mk)
 
 define Package/i2c/Default
   URL:=http://lm-sensors.org/wiki/I2CTools
@@ -48,12 +49,25 @@ define Package/python-smbus
   DEPENDS:=+python-light
 endef
 
+define Package/python3-smbus
+  $(call Package/i2c/Default)
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Python bindings for the SMBUS
+  DEPENDS:=+python3-light
+endef
+
 define Package/i2c-tools/description
  This package contains an heterogeneous set of I2C tools for Linux. These tools
  were originally part of the lm-sensors package.
 endef
 
 define Package/python-smbus/description
+ This package contain the python bindings for Linux SMBus access through i2c-dev.
+endef
+
+define Package/python3-smbus/description
  This package contain the python bindings for Linux SMBus access through i2c-dev.
 endef
 
@@ -68,6 +82,15 @@ ifdef CONFIG_PACKAGE_python-smbus
   endef
 endif
 
+ifdef CONFIG_PACKAGE_python3-smbus
+  define Build/Compile/python3-smbus
+	$(if $(Build/Compile/Py3Mod),,@echo Python3 packaging code not found.; false)
+	$(call Build/Compile/Py3Mod,./py-smbus/, \
+		install --prefix="$(PKG_INSTALL_DIR)/usr", \
+	)
+  endef
+endif
+
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		LINUX="$(LINUX_DIR)" \
@@ -76,6 +99,7 @@ define Build/Compile
 		LDFLAGS="$(TARGET_LDFLAGS)" \
 		CFLAGS="$(TARGET_CFLAGS)"
 	$(Build/Compile/python-smbus)
+	$(Build/Compile/python3-smbus)
 endef
 
 define Package/i2c-tools/install
@@ -87,9 +111,15 @@ define Package/i2c-tools/install
 endef
 
 define PyPackage/python-smbus/filespec
-+|$(PYTHON_PKG_DIR)/smbus.so
++|$(PYTHON_PKG_DIR)
+endef
+
+define PyPackage/python3-smbus/filespec
++|$(PYTHON3_PKG_DIR)
 endef
 
 $(eval $(call BuildPackage,i2c-tools))
 $(eval $(call PyPackage,python-smbus))
 $(eval $(call BuildPackage,python-smbus))
+$(eval $(call PyPackage,python3-smbus))
+$(eval $(call BuildPackage,python3-smbus))


### PR DESCRIPTION
Maintainer: Daniel Golle / @dangowrt 
Compile tested: arm sunxi, Orange Pi, trunk
Run tested: arm sunxi, Orange Pi, trunk
Description:
This only replicates the existing python-smbus package into Python 3

Tests done: 

```
root@192:/# python
Python 2.7.11 (default, Aug 16 2016, 03:28:13) 
[GCC 5.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from smbus import SMBus
>>> 
```

```
root@192:/# python3
Python 3.5.1 (default, Aug 16 2016, 03:38:08) 
[GCC 5.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from smbus import SMBus
>>> 
```
