### PR TITLE
libgcrypt: update to version 1.6.6

### DIFF
--- a/libs/libgcrypt/Makefile
+++ b/libs/libgcrypt/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgcrypt
-PKG_VERSION:=1.6.1
+PKG_VERSION:=1.6.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=ftp://ftp.gnupg.org/gcrypt/libgcrypt
-PKG_MD5SUM:=a5a5060dc2f80bcac700ab0236ea47dc
+PKG_MD5SUM:=944cf6595021d0c33478148a315b335b
 
 PKG_FIXUP:=patch-libtool
 PKG_INSTALL:=1


### PR DESCRIPTION
Maintainer: @MikePetullo
Compile tested: ar71xx, TL-WR841ND v8, LEDE git HEAD

Description:

Fixes CVE-2016-6313:
Entropy Loss and Output Predictability in the Libgcrypt PRNG

Signed-off-by: Daniel Golle <daniel@makrotopia.org>