### PR TITLE
libx264: Fix build errors on x86 targets due to missing ASM features …

### DIFF
--- a/libs/libx264/Makefile
+++ b/libs/libx264/Makefile
@@ -24,8 +24,13 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-TARGET_CFLAGS:=-Wno-maybe-uninitialized -Wshadow -Wall -std=gnu99 -fPIC -O3 -ffast-math -I. 
+TARGET_CFLAGS+=-std=gnu99 -fPIC -O3 -ffast-math -I.
 MAKE_FLAGS+= LD="$(TARGET_CC) -o" 
+
+ifneq ($(CONFIG_TARGET_x86),)
+  CONFIGURE_VARS+= AS=yasm
+  MAKE_FLAGS+= AS=yasm
+endif
 
 CONFIGURE_ARGS += \
 		--enable-shared \
@@ -40,7 +45,7 @@ define Package/libx264
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=H264/AVC free codec library.
-  DEPENDS:=@BUILD_PATENTED
+  DEPENDS:=@BUILD_PATENTED @!TARGET_x86||YASM
   URL:=http://www.videolan.org/developers/x264.html
 endef
 


### PR DESCRIPTION

Maintainer: @ianchi 
Compile tested: mips, arm, x86
Run tested: mips

@dangowrt - Thanks for this. Now to cleanup ffmpeg depends (unavoidable recursive DEPENDS)

Description:

…(yasm)

	minor cleanup of CFLAGS, remove COPTS warnings
	yasm needs to be added to x86 toolchain
	(LEDE updated:  https://github.com/lede-project/source/commit/c08651226f5645204f91f79d247801033f6015d1 )

Signed-off-by: Daniel Golle daniel@makrotopia.org
Signed-off-by: Ted Hess <thess@kitschensync.net>