### PR TITLE
adblock: update 1.4.6

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=1.4.5
+PKG_VERSION:=1.4.6
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/adblock-helper.sh
+++ b/net/adblock/files/adblock-helper.sh
@@ -175,7 +175,7 @@ f_envcheck()
             rc=-1
             f_log "AP mode detected, please set local LuCI instance to ports <> 80/443"
             f_exit
-        elif [ -z "$(pgrep -f "dnsmasq")" ]
+        elif [ ! -f "/etc/init.d/dnsmasq" ]
         then
             rc=-1
             f_log "please enable the local dnsmasq instance to use adblock"

--- a/net/adblock/files/adblock-update.sh
+++ b/net/adblock/files/adblock-update.sh
@@ -10,7 +10,7 @@
 #
 adb_pid="${$}"
 adb_pidfile="/var/run/adblock.pid"
-adb_scriptver="1.4.5"
+adb_scriptver="1.4.6"
 adb_mincfgver="2.4"
 adb_scriptdir="${0%/*}"
 if [ -r "${adb_pidfile}" ]

--- a/net/adblock/files/www/adblock/index.html
+++ b/net/adblock/files/www/adblock/index.html
@@ -1,5 +1,8 @@
 <html>
-     <body>
+    <head>
+        <script>window.close();</script>
+    </head>
+    <body>
         <img src="data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=" alt=""></img>
     </body>
 </html>


### PR DESCRIPTION
Maintainer: me
Run tested: LEDE r1390, javascript tested with firefox/chrome under linux & windows 10

Description:
* added a 'window.close()' to adblock landing page to automatically close any pop-ups that might get loaded with a blocked ad
* simplified dnsmasq check in ap mode

Signed-off-by: Dirk Brenken <dev@brenken.org>