### PR TITLE
watchcat: fix operation of mode 'always'

### DIFF
--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=watchcat
 PKG_VERSION:=1
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/watchcat/files/initd_watchcat
+++ b/utils/watchcat/files/initd_watchcat
@@ -50,7 +50,7 @@ load_watchcat() {
 			pingperiod="$seconds"
 			if [ "$pingperiod" -ge 0 ]
 			then
-				[ "$pingperiod" -le "$period" ] \
+				[ "$pingperiod" -lt "$period" ] \
 					|| append_string "error" "pingperiod must be less than period" "; "
 			else
 				append_string "error" 'pingperiod is not a valid time value (ex: "30"; "4m"; "6h"; "2d")' "; "
@@ -59,8 +59,6 @@ load_watchcat() {
 			pingperiod="$((period/20))"
 		fi
 	}
-	[ "$pingperiod" -lt "$period" -o "$mode" = "always" ] \
-		|| append_string "error" "pingperiod is not recognized" "; "
 	[ "$forcedelay" -ge 0 ] \
 		|| append_string "error" "forcedelay must be a integer greater or equal than 0, where 0 means disabled" "; "
 


### PR DESCRIPTION
This is a fixed pull request instead of #2357.

Maintainer: rogerdammit@gmail.com
Compile tested: openwrt trunk
Run tested: openwrt trunk

Description:

This patch fixes the watchcat init script in case of mode 'always'.
This mode just needs the config parameters: mode, period and forcedelay.
But a wrong check against the variable pingperiod, needed in the mode 'ping'
prevented mode 'always' to work properly.