### PR TITLE
ddns-scripts: fix dnsomatic.com update url (#3090)

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.3
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -58,7 +58,7 @@
 "ovh.com"	"http://[USERNAME]:[PASSWORD]@www.ovh.com/nic/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]"
 
 # dns-o-matic is a free service by opendns.com for updating multiple hosts
-"dnsomatic.com"	"http://[USERNAME]:[PASSWORD]@updates.dnsomatic.com/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+"dnsomatic.com"	"http://[USERNAME]:[PASSWORD]@updates.dnsomatic.com/nic/update?hostname=all.dnsomatic.com&myip=[IP]"	"good|nochg"
 
 # 3322.org
 "3322.org"	"http://[USERNAME]:[PASSWORD]@members.3322.org/dyndns/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]"


### PR DESCRIPTION
Maintainer: @chris5560 
Compile tested: -
Run tested: -

Description:

There is a quirk in the way the ddns-scripts work together with dnsomatic.com:
DNS-o-matic is a service for updating multiple DynDNS hosts (and similar
services) at once.

While it has the option to update only one/multiple out of all hostnames, this
would render this service rather useless, so in most cases people will want to
update them all at once, which means specifying "all.dnsomatic.com" as
host/domain to update.

The ddns-scripts however will try to resolve the given host name/domain in
order to check if an update is necessary, this will obviously fail for the dummy
host all.dnsomatic.com

By harcoding the update url to "all.dnsomatic.com", the update gets send for all
hostnames as expected and the user can still specify a host name or domain for
the IP change checks.

Reported-by: "Schimmelreiter" <Ziggy.SpaceRat@gmx.de>
Signed-off-by: Jo-Philipp Wich <jo@mein.io>