### PR TITLE
adblock: update 1.4.7

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=1.4.6
+PKG_VERSION:=1.4.7
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -48,7 +48,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
     * [zeus tracker](https://zeustracker.abuse.ch)
     * => daily updates, approx. 440 entries
 * zero-conf like automatic installation & setup, usually no manual changes needed (i.e. ip address, network devices etc.)
-* supports a wide range of router modes (incl. AP mode), as long as the firewall and the DNS server are enabled & in use
+* supports a wide range of router modes (incl. AP mode), as long as firewall and dnsmasq are installed and in use
 * full IPv4 and IPv6 support
 * each blocklist source will be updated and processed separately
 * timestamp check to download and process only updated adblock list sources
@@ -103,10 +103,11 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 * **list updates:** for a scheduled call of the adblock service add an appropriate crontab entry (see example below)
 * **hotplug fine tuning:** to restrict hotplug support to a certain wan interface or to disable it at all, you can set 'adb\_hotplugif' to an existing interface like 'wan' or to a non-existing 'dummy' interface
 * **new list sources:** you could add new blocklist sources on your own via uci config, all you need is a source url and an awk one-liner (see example below)
-* **AP mode:** in 'AP mode' adblock uses automatically the local router ip as nullip address. To make sure that your LuCI interface will be still accessible, you have to change the local uhttpd instance to ports <> 80/443 (see example below)
+* **AP mode:** in 'AP mode' adblock uses automatically the local router ip as nullip address. To make sure that your LuCI interface will be still accessible, you have to change the local uhttpd instance to ports <> 80/443 (see example below), also make sure that firewall and dnsmasq are installed and running
 * **restricted mode:** to disable flash writes with adblock status information to the adblock config file (used by LuCI frontend), please set 'adb\_restricted' to '1'
 * **adblock toggle:** to quickly switch adblocking 'on' or 'off', simply use _/etc/init.d/adblock toggle_
 * **adblock statistics:** to update only the adblock statistics (without updating the block lists as well), please run _/etc/init.d/adblock stats_
+* **adblock query <DOMAIN>:** to query the active blocklists for a specific domain, please run _/etc/init.d/adblock query <DOMAIN>_
 * **configuration update:** to update an outdated adblock config file with the current default version, please run _/etc/init.d/adblock cfgup_, make your individual changes and start the adblock service again
 * **debugging:** for script debugging please set the 'adb\_debug' variable in the header of _/etc/init.d/adblock_ to '1'
 * **disable active dns probing in windows:** to prevent a possible yellow exclamation mark on your internet connection icon (which wrongly means connected, but no internet), please change the following registry key/value from "1" to "0" _HKLM\SYSTEM\CurrentControlSet\Services\NlaSvc\Parameters\Internet\EnableActiveProbing_
@@ -177,16 +178,6 @@ This entry does not remove:
 config uhttpd 'main'
     list listen_http '0.0.0.0:88'
     list listen_https '0.0.0.0:445'
-</code></pre>
-  
-**example grep for blocked (sub-)domains in adblock source files:**
-<pre><code>
-grep "google-analytics.com" "/tmp/dnsmasq.d/adb_list"*
-
-This will output all matches with corresponding source files:
-  /tmp/dnsmasq.d/adb_list.winhelp:address=/ssl.google-analytics.com/198.18.0.1
-  /tmp/dnsmasq.d/adb_list.winhelp:address=/www.google-analytics.com/198.18.0.1
-  /tmp/dnsmasq.d/adb_list.yoyo:address=/google-analytics.com/198.18.0.1
 </code></pre>
   
 **example to find blocked domains on certain sites for whitelisting:**

--- a/net/adblock/files/adblock-helper.sh
+++ b/net/adblock/files/adblock-helper.sh
@@ -169,21 +169,11 @@ f_envcheck()
     then
         adb_nullipv4="${adb_ipv4}"
         adb_nullipv6="${adb_ipv6}"
-        if [ -n "$(${adb_uci} -q get uhttpd.main.listen_http | grep -Fo "80")" ] ||
-           [ -n "$(${adb_uci} -q get uhttpd.main.listen_https | grep -Fo "443")" ]
+        if [ -n "$(${adb_uci} -q get uhttpd.main.listen_http | grep -o ":80$")" ] ||
+           [ -n "$(${adb_uci} -q get uhttpd.main.listen_https | grep -o ":443$")" ]
         then
             rc=-1
             f_log "AP mode detected, please set local LuCI instance to ports <> 80/443"
-            f_exit
-        elif [ ! -f "/etc/init.d/dnsmasq" ]
-        then
-            rc=-1
-            f_log "please enable the local dnsmasq instance to use adblock"
-            f_exit
-        elif [ ! -f "/var/run/fw3.state" ]
-        then
-            rc=-1
-            f_log "please enable the local firewall to use adblock"
             f_exit
         else
             apmode_ok="true"
@@ -204,23 +194,25 @@ f_envcheck()
 
     # check general package dependencies
     #
-    f_depend "busybox"
-    f_depend "uci"
-    f_depend "uhttpd"
-    f_depend "iptables"
-    f_depend "kmod-ipt-nat"
+    f_depend "busybox -"
+    f_depend "uci -"
+    f_depend "uhttpd -"
+    f_depend "iptables -"
+    f_depend "kmod-ipt-nat -"
+    f_depend "firewall -"
+    f_depend "dnsmasq*"
 
     # check ipv6 related package dependencies
     #
     if [ -n "${adb_wanif6}" ]
     then
-        f_depend "ip6tables" "true"
+        f_depend "ip6tables -" "true"
         if [ "${package_ok}" = "false" ]
         then
             f_log "package 'ip6tables' not found, IPv6 support will be disabled"
             unset adb_wanif6
         else
-            f_depend "kmod-ipt-nat6" "true"
+            f_depend "kmod-ipt-nat6 -" "true"
             if [ "${package_ok}" = "false" ]
             then
                 f_log "package 'kmod-ipt-nat6' not found, IPv6 support will be disabled"
@@ -231,13 +223,13 @@ f_envcheck()
 
     # check uclient-fetch/wget dependencies
     #
-    f_depend "uclient-fetch" "true"
+    f_depend "uclient-fetch -" "true"
     if [ "${package_ok}" = "true" ]
     then
-        f_depend "libustream-polarssl" "true"
+        f_depend "libustream-polarssl -" "true"
         if [ "${package_ok}" = "false" ]
         then
-            f_depend "libustream-\(mbedtls\|openssl\|cyassl\)" "true"
+            f_depend "libustream-\(mbedtls\|openssl\|cyassl\) -" "true"
             if [ "${package_ok}" = "true" ]
             then
                 adb_fetch="$(which uclient-fetch)"
@@ -248,7 +240,7 @@ f_envcheck()
     fi
     if [ -z "${adb_fetch}" ]
     then
-        f_depend "wget" "true"
+        f_depend "wget -" "true"
         if [ "${package_ok}" = "true" ]
         then
             adb_fetch="$(which wget)"
@@ -263,7 +255,7 @@ f_envcheck()
 
     # check ca-certificate package and set fetch parm accordingly
     #
-    f_depend "ca-certificates" "true"
+    f_depend "ca-certificates -" "true"
     if [ "${package_ok}" = "false" ]
     then
         fetch_parm="${fetch_parm} --no-check-certificate"
@@ -452,7 +444,7 @@ f_depend()
     local check_only="${2}"
     package_ok="true"
 
-    check="$(printf "${pkg_list}" | grep "^${package} -")"
+    check="$(printf "${pkg_list}" | grep "^${package}")"
     if [ "${check_only}" = "true" ] && [ -z "${check}" ]
     then
         package_ok="false"

--- a/net/adblock/files/adblock-update.sh
+++ b/net/adblock/files/adblock-update.sh
@@ -10,7 +10,7 @@
 #
 adb_pid="${$}"
 adb_pidfile="/var/run/adblock.pid"
-adb_scriptver="1.4.6"
+adb_scriptver="1.4.7"
 adb_mincfgver="2.4"
 adb_scriptdir="${0%/*}"
 if [ -r "${adb_pidfile}" ]

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -2,10 +2,11 @@
 #
 
 START=99
-EXTRA_COMMANDS="toggle stats cfgup"
+EXTRA_COMMANDS="toggle stats cfgup query"
 EXTRA_HELP="	toggle	Toggle adblock 'on' or 'off'
 	stats	Update adblock statistics
-	cfgup	Update adblock configuration file"
+	cfgup	Update adblock configuration file
+	query	<DOMAIN> Query active blocklists for specific domain"
 
 adb_debug=0
 adb_pid="${$}"
@@ -124,6 +125,18 @@ cfgup()
         f_log "default adblock configuration applied, please check the settings in '/etc/config/adblock'"
     else
         f_log "default adblock configuration not found, please re-install the package via 'opkg install adblock --force-maintainer'"
+    fi
+    return 0
+}
+
+query()
+{
+    if [ -z "${1}" ]
+    then
+        f_log "no domain query input, please submit a specific search domain"
+    else
+        f_log "results for search domain '${1}':"
+        grep "${1}" "/tmp/dnsmasq.d/adb_list"*
     fi
     return 0
 }


### PR DESCRIPTION
Maintainer: me
Run tested: LEDE r1390

Description:
* add a query function to search the active blocklists for a specific domain (/etc/init.d/adblock query _DOMAIN_)
* fix bug in ap mode/uhttpd port detection
* check general firewall and dnsmasq package dependencies and remove redundant checks in ap mode

Signed-off-by: Dirk Brenken <dev@brenken.org>