### PR TITLE
libcanfestival: fix build on LEDE buildbots using ccache

### DIFF
--- a/libs/libcanfestival/patches/003-makefile-ar-ranlib.patch
+++ b/libs/libcanfestival/patches/003-makefile-ar-ranlib.patch
@@ -1,0 +1,31 @@
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -38,6 +38,9 @@ TARGET = SUB_TARGET
+ CAN_DRIVER = SUB_CAN_DRIVER
+ TIMERS_DRIVER = SUB_TIMERS_DRIVER
+ ENABLE_LSS = SUB_ENABLE_LSS
++AR ?= $(BINUTILS_PREFIX)ar
++RANLIB ?= $(BINUTILS_PREFIX)ranlib
++LD ?= $(BINUTILS_PREFIX)ld
+ 
+ INCLUDES = -I../include -I../include/$(TARGET) -I../include/$(TIMERS_DRIVER) -I../drivers/$(TARGET)
+ 
+@@ -114,15 +117,15 @@ libcanfestival.a: $(OBJS)
+ 	@echo "*********************************************"
+ 	@echo "**Building [libcanfestival.a]"
+ 	@echo "*********************************************"
+-	$(BINUTILS_PREFIX)ar rc $@ $(OBJS)
+-	$(BINUTILS_PREFIX)ranlib $@
++	$(AR) rc $@ $(OBJS)
++	$(RANLIB) $@
+ 
+ libcanfestival.o: $(OBJS)
+ 	@echo " "
+ 	@echo "*********************************************"
+ 	@echo "**Prelink [libcanfestival.o]"
+ 	@echo "*********************************************"
+-	$(BINUTILS_PREFIX)ld -r $(OBJS) -o $@
++	$(LD) -r $(OBJS) -o $@
+ 
+ $(TARGET)_%.o: %.c
+ 	@echo " "


### PR DESCRIPTION
Maintainer: @toxxin
Compile tested: mxs
Run tested: -

Description:

This error is reported at:
https://downloads.lede-project.org/snapshots/faillogs/arm_arm926ej-s/packages/libcanfestival/compile.txt

I'm not sure, whether this patch really fixes the problem on the buildbots, because I'm not using ccache locally. I would give it just a try, maybe it works...

-snip-
make -C can_socket driver
make[6]: Entering directory '/data/bowl-builder/arm_arm926ej-s/build/sdk/build_dir/target-arm_arm926ej-s_musl-1.1.15_eabi/libcanfestival/drivers/can_socket'
ccache_cc -O2 -fPIC -DDEBUG_ERR_CONSOLE_ON -g  -I../../include -I../../include/unix -I../../include/can_socket -o can_socket.o -c can_socket.c
cc1: note: someone does not honour COPTS correctly, passed 0 times
ccache_cc -shared -Wl,-soname,libcanfestival_can_socket.so  -o libcanfestival_can_socket.so can_socket.o
make[6]: Leaving directory '/data/bowl-builder/arm_arm926ej-s/build/sdk/build_dir/target-arm_arm926ej-s_musl-1.1.15_eabi/libcanfestival/drivers/can_socket'
make -C unix driver
make[6]: Entering directory '/data/bowl-builder/arm_arm926ej-s/build/sdk/build_dir/target-arm_arm926ej-s_musl-1.1.15_eabi/libcanfestival/drivers/unix'
ccache_cc -O2 -DDEBUG_ERR_CONSOLE_ON -g  -I../../include -I../../include/unix -I../../include/timers_unix -o unix.o -c unix.c
cc1: note: someone does not honour COPTS correctly, passed 0 times
Building [libcanfestival_unix.a]
ccache_ccar rc libcanfestival_unix.a unix.o ../timers_unix/timers_unix.o
make[6]: ccache_ccar: Command not found
Makefile:102: recipe for target 'libcanfestival_unix.a' failed
make[6]: *** [libcanfestival_unix.a] Error 127
make[6]: Leaving directory '/data/bowl-builder/arm_arm926ej-s/build/sdk/build_dir/target-arm_arm926ej-s_musl-1.1.15_eabi/libcanfestival/drivers/unix'
Makefile:33: recipe for target 'driver' failed
make[5]: *** [driver] Error 2
-snap- 



Signed-off-by: Michael Heimpold <mhei@heimpold.de>