### PR TITLE
lua-struct: Add struct routines to pack/unpack binary strings

### DIFF
--- a/lang/lua-struct/Makefile
+++ b/lang/lua-struct/Makefile
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=lua-struct
+PKG_VERSION:=0.2
+PKG_RELEASE:=1
+
+_BASENAME:=struct
+
+PKG_SOURCE:=$(_BASENAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.inf.puc-rio.br/~roberto/struct
+PKG_MD5SUM:=99384bf1f54457ec9f796ad0b539d19c
+PKG_MAINTAINER:=Anton D. Kachalov <mouse@yandex-team.ru>
+PKG_LICENSE:=MIT
+
+PKG_INSTALL:=1
+
+UNPACK_CMD=tar -C $(1) -xf "$(DL_DIR)/$(PKG_SOURCE)"
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/lua-struct
+  SUBMENU:=Lua
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Lua binary struct pack/unpack
+  URL:=http://www.inf.puc-rio.br/~roberto/struct/
+  DEPENDS:=+lua
+endef
+
+define Package/lua-struct/description
+  This library offers basic facilities to convert Lua values to and from C structs.
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		PREFIX="$(STAGING_DIR)/usr" \
+		LUA_LIBDIR="$(STAGING_DIR)/usr/lib/lua" \
+		clean
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		PREFIX="$(STAGING_DIR)/usr" \
+		LUA_LIBDIR="$(STAGING_DIR)/usr/lib/lua" \
+		LIB_OPTION="-shared" \
+		CC="$(TARGET_CROSS)gcc" \
+		CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)" \
+		all
+endef
+
+define Package/lua-struct/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/struct.so $(1)/usr/lib/lua/struct.so
+endef
+
+$(eval $(call BuildPackage,lua-struct))

--- a/lang/lua-struct/patches/001-makefile.patch
+++ b/lang/lua-struct/patches/001-makefile.patch
@@ -1,0 +1,48 @@
+--- a/makefile	2012-07-04 19:55:36.000000000 +0400
++++ b/makefile	2016-08-24 11:16:54.991229269 +0300
+@@ -1,24 +1,24 @@
+-# point it to where the compiler can find the Lua header files (lua.h, etc.)
+-# LUADIR = ../lua
+-LUADIR = /usr/include/lua5.1/
+-
+-# define your own "large" integer type; not defining a proper type
+-# will default to 'long', which may cause problems with 'size_t'
+-INTTYPE = -DSTRUCT_INT="long long"
+-
+-
+-CWARNS = -Wall -W -pedantic \
+-        -Waggregate-return \
+-        -Wcast-align \
+-        -Wmissing-prototypes \
+-        -Wnested-externs \
+-        -Wpointer-arith \
+-        -Wshadow \
+-        -Wwrite-strings
++LUA=/usr/lib/lua
++LUAINC=$(LUA)/include
++LUALIB=$(LUA)/lib
++LUABIB=$(LUA)/bin
+ 
+-CFLAGS = -D_POSIX_SOURCE $(CWARNS) $(INTTYPE) -O2 -I$(LUADIR)
+-CC = gcc
++OFLAGS = -O0
+ 
+-struct.so: struct.c makefile
+-	$(CC) $(CFLAGS) -shared -fpic -o struct.so struct.c
++STRUCT_CFLAGS = -I$(LUAINC) -std=gnu99 -DSTRUCT_INT="long long"
++STRUCT_LDFLAGS = -L$(LUALIB) -llua
++STRUCT_OBJ = struct.o
++STRUCT_LIB = struct.so
+ 
++all: $(STRUCT_LIB)
++
++%.o: %.c
++	$(CC) $(CPPFLAGS) $(CFLAGS) $(OFLAGS) $(LUA_CFLAGS) $(STRUCT_CFLAGS) $(FPIC) -c -o $@ $<
++
++$(STRUCT_LIB): $(STRUCT_OBJ)
++	$(CC) $(LDFLAGS) -shared -o $(STRUCT_LIB) $(STRUCT_OBJ) $(STRUCT_LDFLAGS)
++
++install: $(STRUCT_LIB)
++
++clean:
++	rm -f *.o *.so


### PR DESCRIPTION
Maintainer: me
Compile tested: armv4l, Aspeed AST2300, OpenWRT HEAD
Run tested: armv4l, Aspeed AST2300, OpenWRT HEAD

Description:
This library offers basic facilities to convert Lua values to and from C structs. Its main functions are struct.pack, which packs multiple Lua values into a struct-like string; and struct.unpack, which unpacks multiple Lua values from a given struct-like string.
