### PR TITLE
ipmitool: add 1.8.17 version

### DIFF
--- a/utils/ipmitool/Makefile
+++ b/utils/ipmitool/Makefile
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ipmitool
+PKG_VERSION:=1.8.17
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=@SF/ipmitool
+PKG_MD5SUM:=f7408aa2b40333db0413d4aab6bbe978
+PKG_MAINTAINER:=Anton D. Kachalov <mouse@yandex-team.ru>
+
+PKG_LICENSE:=SUN
+PKG_LICENSE_FILES:=COPYING
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ipmitool
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=IPMItool
+  DEPENDS:=+libopenssl
+  URL:=https://sourceforge.net/projects/ipmitool/
+endef
+
+define Package/ipmitool/description
+  IPMItool provides in-band and out-of-band IPMI software
+endef
+
+CONFIGURE_ARGS += \
+	--disable-intf-{usb,imb,lipmi,bmc,serial,free} \
+	--disable-ipmishell
+	
+
+define Package/ipmitool/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	cp -a $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,ipmitool))

--- a/utils/ipmitool/patches/01-disable-ipmishell.patch
+++ b/utils/ipmitool/patches/01-disable-ipmishell.patch
@@ -1,0 +1,11 @@
+--- ipmitool-1.8.17/configure.ac.orig	2016-05-06 17:51:58.000000000 +0300
++++ ipmitool-1.8.17/configure.ac	2016-07-22 18:55:35.879260820 +0300
+@@ -64,7 +64,7 @@ xenable_intf_lipmi=yes
+ #xenable_intf_serial=yes
+ xenable_intf_dummy=no
+ xenable_all_options=yes
+-xenable_ipmishell=yes
++xenable_ipmishell=no
+ 
+ dnl set some things so we build with GNU tools on Solaris
+ case "$host_os" in


### PR DESCRIPTION
Maintainer: me
Compile tested: armv4l, Aspeed AST2300, OpenWRT HEAD
Run tested: armv4l, Aspeed AST2300, OpenWRT HEAD

Description:
IPMItool provides a simple command-line interface to IPMI-enabled devices through an IPMIv1.5 or IPMIv2.0 LAN interface or Linux kernel driver (OpenIPMI).

Signed-off-by: Anton D. Kachalov mouse@yandex-team.ru
