### PR TITLE
dtoverlay: add DTS overlays manipulation tools

### DIFF
--- a/utils/dtoverlay/Makefile
+++ b/utils/dtoverlay/Makefile
@@ -1,0 +1,37 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dtoverlay
+PKG_VERSION:=2016-07-06
+PKG_RELEASE=$(PKG_SOURCE_VERSION)
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=git://github.com/ya-mouse/dtoverlay.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=d503ddae11d62f12762b2fd3a52d37da55645d4b
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+
+CMAKE_INSTALL:=1
+
+PKG_LICENSE:=PublicDomain
+
+PKG_MAINTAINER:=Anton D. Kachalov <mouse@yandex-team.ru>
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/dtoverlay
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=DeviceTree manipulation tools
+  URL:=https://github.com/raspberrypi/userland/tree/master/host_applications/linux/apps/dtoverlay
+endef
+
+define Package/dtoverlay/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/dtoverlay $(1)/usr/bin/dtoverlay
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/dtmerge $(1)/usr/bin/dtmerge
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/dtc $(1)/usr/bin/dtc
+	$(LN) dtoverlay $(1)/usr/bin/dtparam
+endef
+
+$(eval $(call BuildPackage,dtoverlay))


### PR DESCRIPTION
Maintainer: me
Compile tested: armv4l, Aspeed AST2300, OpenWRT HEAD
Run tested:  armv4l, Aspeed AST2300, OpenWRT HEAD

Description:
DeviceTree overlays manipulation tools set. Support came from RaspberryPi project.
- dtoverlay to load/unload dtbo fragments
- dtparam to tune additional overlay's parameters
- dtmerge to merge several dtbs with optional parameters
- dtc is a DTS compiler

Bundled with DTC 1.4.1-g25efc119 and latest FDT from RapsberryPi repo.

Signed-off-by: Anton D. Kachalov mouse@yandex-team.ru
