### PR TITLE
pytz: upgrade to version 2016.6.1

### DIFF
--- a/lang/pytz/Makefile
+++ b/lang/pytz/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pytz
-PKG_VERSION:=2016.3
+PKG_VERSION:=2016.6.1
 PKG_RELEASE:=1
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://pypi.python.org/packages/source/p/pytz/
-PKG_MD5SUM:=abae92c3301b27bd8a9f56b14f52cb29
+PKG_SOURCE_URL:=https://pypi.python.org/packages/5d/8e/6635d8f3f9f48c03bb925fab543383089858271f9cfd1216b83247e8df94/
+PKG_MD5SUM:=b6c28a3b968bc1d8badfb61b93874e03
 PKG_BUILD_DEPENDS:=python python-setuptools
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, Netgear WNDR4300, openwrt r49926
Run tested: -

Description: upgrades pytz package to version 2016.6.1
