### PR TITLE
libsodium: removed `--without-pthreads` configire arg

### DIFF
--- a/libs/libsodium/Makefile
+++ b/libs/libsodium/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsodium
 PKG_VERSION:=1.0.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libsodium.org/libsodium/releases
@@ -52,7 +52,6 @@ endef
 
 CONFIGURE_ARGS+= \
 	--disable-ssp \
-	--without-pthreads \
 	$(if $(CONFIG_LIBSODIUM_MINIMAL),--enable-minimal=yes,--enable-minimal=no)
 
 define Build/InstallDev


### PR DESCRIPTION
Maintainer: @damianorenfer
Compile tested: ar71xx OpenWrt master
Run tested: ar71xx OpenWrt master

Description:
Removed `--without-pthreads` configure argument as discussed [here](https://github.com/openwrt/packages/pull/3107#discussion-diff-76971750).