### PR TITLE
elektra: add libcurl dependency

### DIFF
--- a/libs/elektra/Makefile
+++ b/libs/elektra/Makefile
@@ -93,7 +93,7 @@ endef
 define Package/libelektra-plugins
   $(call Package/libelektra/Default)
   TITLE:=Useful elektra plugins
-  DEPENDS:=+libelektra-core
+  DEPENDS:=+libelektra-core +libcurl
 endef
 
 define CONTENT_ELEKTRA_PLUGINS_TEXT


### PR DESCRIPTION

Maintainer: @haraldg 
Compile tested: arm64, LEDE version: r1462+69
Run tested: NO

Description:
since all components of elektra are built enable libcurl dep too

fixes buildbot issue:
Package libelektra-plugins is missing dependencies for the following libraries:
libcurl.so.4
(ex: http://downloads.lede-project.org/snapshots/faillogs/x86_64/packages/elektra/compile.txt )

Signed-off-by: Dirk Neukirchen <plntyk.lede@plntyk.name>