### PR TITLE
erlang: fix compilation error by disabling mips16

### DIFF
--- a/lang/erlang/Makefile
+++ b/lang/erlang/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=erlang
 PKG_VERSION:=17.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=otp_src_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= http://www.erlang.org/download/ \
@@ -21,6 +21,7 @@ PKG_LICENSE_FILES:=EPLICENCE
 PKG_MAINTAINER:=Nicolas Thill <nico@openwrt.org>
 
 PKG_BUILD_DEPENDS:=erlang/host openssl
+PKG_USE_MIPS16:=0
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/otp_src_$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/otp_src_$(PKG_VERSION)


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: ar71xx, LEDE
Run tested: no

Description:

This is caused by a toolchain bug and has been reported to GCC a
while a ago without receiving any responses yet [1].  Fix it at the
moment by not compiling with mips16 enabled.

Should fix #1750 and #1904.

 [1] Bug 71519 - "Out of range operand" bteqz inst generated by
     "casesi_internal_mips16_<mode>",
     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71519

Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>