### PR TITLE
"<ddns-scripts>:" Duiadns - IPv6 support added / IPv4 authentication method changed"

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.3
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -79,7 +79,7 @@
 "spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 # duiadns.net - free dynamic DNS
-"duiadns.net"	"http://ipv4.duia.ro/dynamic.duia?host=[DOMAIN]&password=[PASSWORD]&ip4=[IP]"
+"duiadns.net"   "http://[USERNAME]:[PASSWORD]@ipv4.duia.ro/dynamic.duia?host=[DOMAIN]&ip4=[IP]" "200"
 
 # Two-DNS - Simply. Connected. Everywhere.
 "twodns.de"	"http://[USERNAME]:[PASSWORD]@update.twodns.de/update?hostname=[DOMAIN]&ip=[IP]"

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -79,7 +79,7 @@
 "spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 # duiadns.net - free dynamic DNS
-"duiadns.net"   "http://[USERNAME]:[PASSWORD]@ipv4.duia.ro/dynamic.duia?host=[DOMAIN]&ip4=[IP]" "200"
+"duiadns.net"   "http://[USERNAME]:[PASSWORD]@ipv4.duia.ro/dynamic.duia?host=[DOMAIN]&ip4=[IP]"
 
 # Two-DNS - Simply. Connected. Everywhere.
 "twodns.de"	"http://[USERNAME]:[PASSWORD]@update.twodns.de/update?hostname=[DOMAIN]&ip=[IP]"

--- a/net/ddns-scripts/files/services_ipv6
+++ b/net/ddns-scripts/files/services_ipv6
@@ -86,3 +86,6 @@
 
 # core-networks.de
 "core-networks.de"	"https://[USERNAME]:[PASSWORD]@dyndns.core-networks.de/?hostname=[DOMAIN]&myip=[IP]&keepipv4=1"	"good"
+
+# duiadns.net - free dynamic DNS
+"duiadns.net"   "http://[USERNAME]:[PASSWORD]@ipv6.duia.ro/dynamic.duia?host=[DOMAIN]&ip6=[IP]" "200"

--- a/net/ddns-scripts/files/services_ipv6
+++ b/net/ddns-scripts/files/services_ipv6
@@ -88,4 +88,4 @@
 "core-networks.de"	"https://[USERNAME]:[PASSWORD]@dyndns.core-networks.de/?hostname=[DOMAIN]&myip=[IP]&keepipv4=1"	"good"
 
 # duiadns.net - free dynamic DNS
-"duiadns.net"   "http://[USERNAME]:[PASSWORD]@ipv6.duia.ro/dynamic.duia?host=[DOMAIN]&ip6=[IP]" "200"
+"duiadns.net"   "http://[USERNAME]:[PASSWORD]@ipv6.duia.ro/dynamic.duia?host=[DOMAIN]&ip6=[IP]"


### PR DESCRIPTION
Maintainer: Liviu Pislaru / @pliviu
Compile tested: using a duiadns account on OpenWrt Chaos Calmer 15.05 / LuCI (git-15.248.30277-3836b45)
Run tested: using a duiadns account on OpenWrt Chaos Calmer 15.05 / LuCI (git-15.248.30277-3836b45)

Description:
Duiadns IPv6 support added.
Authentication method changed for Duiadns IPv4; user & pass encoded base64 in header.

Signed-off-by: Liviu Pislaru liviu@duiadns.net