### PR TITLE
privoxy: update to 3.0.26

### DIFF
--- a/net/privoxy/Makefile
+++ b/net/privoxy/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=privoxy
-PKG_VERSION:=3.0.24
+PKG_VERSION:=3.0.26
 PKG_RELEASE:=1
 
 PKG_SOURCE:=privoxy-$(PKG_VERSION)-stable-src.tar.gz
 PKG_SOURCE_URL:=@SF/ijbswa
-PKG_MD5SUM:=44a47d1a5000db8cccd61ace0e25e7f7
+PKG_MD5SUM:=8a1c842112ccea68c19b7ceb4a0e999f
 PKG_BUILD_DIR:=$(BUILD_DIR)/privoxy-$(PKG_VERSION)-stable
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_generic + ar71xx_generic_WNDR3700
Run tested: x86 (DD r49305) and WNDR3800 (CC 15.05.1)

Description:
update to 3.0.26
Signed-off-by: Christian Schoenebeck <christian.schoenebeck@gmail.com>