### PR TITLE
netatalk: update to version 3.1.9 and grab maintainership

### DIFF
--- a/net/netatalk/Makefile
+++ b/net/netatalk/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netatalk
-PKG_VERSION:=2.2.4
+PKG_VERSION:=3.1.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/netatalk
-PKG_MD5SUM:=40753a32340c24e4ec395aeb55ef056e
+PKG_MD5SUM:=70db9c82e9e92bbf2083b9b322e58d2a8ddea9f09ac5204c18998439b7feb0d0
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -28,7 +28,7 @@ define Package/netatalk
   DEPENDS:=+libattr +libdb47 +libgcrypt +libopenssl $(LIBRPC_DEPENDS)
   TITLE:=netatalk
   URL:=http://netatalk.sourceforge.net
-  MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+  MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 endef
 
 define Package/netatalk/decription
@@ -59,6 +59,9 @@ CONFIGURE_ARGS += \
 	--with-ssl-dir="$(STAGING_DIR)/usr" \
 	--with-uams-path="/usr/lib/uams" \
 	--without-acls \
+	--without-kerberos \
+	--without-mysql \
+	--with-mysql-config=false \
 	--without-pam \
 	--disable-admin-group \
 	--disable-srvloc \
@@ -66,20 +69,28 @@ CONFIGURE_ARGS += \
 	$(if $(CONFIG_SHADOW_PASSWORDS),--with-shadow,--without-shadow) \
 	--without-ldap
 
+define Package/netatalk/conffiles
+/etc/afp.conf
+/etc/extmap.conf
+/etc/netatalk/
+endef
+
 define Package/netatalk/install
 	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/usr/lib
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/usr/lib/uams
-	$(INSTALL_DIR) $(1)/etc/netatalk
 	$(INSTALL_DIR) $(1)/etc/init.d
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libatalk.so* $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/dbd $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ad $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/afppasswd $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/afpd $(1)/usr/sbin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/cnid_dbd $(1)/usr/sbin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/cnid_metad $(1)/usr/sbin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/uams/*.so $(1)/usr/lib/uams/
-	$(CP) ./files/AppleVolumes.default $(1)/etc/netatalk/
-	$(CP) $(PKG_INSTALL_DIR)/etc/netatalk/AppleVolumes.system $(1)/etc/netatalk/
-	$(INSTALL_CONF) ./files/afpd.conf $(1)/etc/netatalk/
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/afp.conf $(1)/etc/
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/extmap.conf $(1)/etc/
 	$(INSTALL_BIN) ./files/afpd.init $(1)/etc/init.d/afpd
 endef
 

--- a/net/netatalk/files/AppleVolumes.default
+++ b/net/netatalk/files/AppleVolumes.default
@@ -1,2 +1,0 @@
--
-/tmp Temp allow:root,nobody cnidscheme:dbd

--- a/net/netatalk/files/afpd.conf
+++ b/net/netatalk/files/afpd.conf
@@ -1,1 +1,0 @@
-- -noddp -uampath /usr/lib/uams -uamlist uams_guest.so,uams_passwd.so,uams_dhx_passwd.so,uams_randnum.so,uams_dhx2.so -passwdfile /etc/netatalk/afppasswd -savepassword -passwdminlen 0 -nosetpassword -defaultvol /etc/netatalk/AppleVolumes.default -systemvol /etc/netatalk/AppleVolumes.system -nouservol -guestname "nobody" -sleep 1 -icon

--- a/net/netatalk/files/afpd.init
+++ b/net/netatalk/files/afpd.init
@@ -1,23 +1,23 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2010-2012 OpenWrt.org
 
-START=70
+START=80
+STOP=10
 
-MAXCONS="7"
+USE_PROCD=1
 
-start()
-{
-	service_start /usr/sbin/cnid_metad
-	service_start /usr/sbin/afpd -c ${MAXCONS}
+start_service() {
+        mkdir -p /var/netatalk/CNID/
+
+	procd_open_instance
+	procd_set_param command /usr/sbin/afpd -d -F /etc/afp.conf
+	procd_set_param file /etc/afp.conf
+	procd_set_param respawn
+	procd_close_instance
+
+	procd_open_instance
+	procd_set_param command /usr/sbin/cnid_metad -d
+	procd_set_param respawn
+	procd_close_instance
 }
 
-stop()
-{
-	service_stop /usr/sbin/afpd
-	service_stop /usr/sbin/cnid_metad
-}
-
-reload()
-{
-	service_reload /usr/sbin/afpd
-}

--- a/net/netatalk/patches/002-ld_library_path.patch
+++ b/net/netatalk/patches/002-ld_library_path.patch
@@ -1,6 +1,6 @@
 --- a/macros/db3-check.m4
 +++ b/macros/db3-check.m4
-@@ -148,9 +148,9 @@ AC_DEFUN([AC_PATH_BDB],[
+@@ -148,9 +148,9 @@ if test "x$bdb_required" = "xyes"; then
                          dnl -- LD_LIBRARY_PATH on many platforms. This will be fairly
                          dnl -- portable hopefully. Reference:
                          dnl -- http://lists.gnu.org/archive/html/autoconf/2009-03/msg00040.html
@@ -12,7 +12,7 @@
  
                          if test x"${atalk_cv_bdb_version}" = x"yes"; then
                              BDB_CFLAGS="-I${bdbdir}/include${subdir}"
-@@ -171,9 +171,9 @@ AC_DEFUN([AC_PATH_BDB],[
+@@ -177,9 +177,9 @@ if test "x$bdb_required" = "xyes"; then
                             CPPFLAGS="-I${bdbdir}/include${subdir} $CPPFLAGS"
                             LDFLAGS="-L$bdblibdir $LDFLAGS"
  

--- a/net/netatalk/patches/003-fix-build-without-ldap.patch
+++ b/net/netatalk/patches/003-fix-build-without-ldap.patch
@@ -1,0 +1,15 @@
+--- a/etc/afpd/volume.c
++++ b/etc/afpd/volume.c
+@@ -380,7 +380,11 @@ static int getvolparams(const AFPObj *ob
+                         ashort |= VOLPBIT_ATTR_UNIXPRIV;
+                     if (vol->v_flags & AFPVOL_TM)
+                         ashort |= VOLPBIT_ATTR_TM;
+-                    if (!ldap_config_valid || vol->v_flags & AFPVOL_NONETIDS)
++                    if (
++#ifdef HAVE_LDAP
++                        !ldap_config_valid ||
++#endif
++                        vol->v_flags & AFPVOL_NONETIDS)
+                         ashort |= VOLPBIT_ATTR_NONETIDS;
+                     if (obj->afp_version >= 32) {
+                         if (vol->v_vfs_ea)


### PR DESCRIPTION
Maintainer: @MikePetullo
Compile tested: oxnas/generic, LEDE git HEAD
Run tested: oxnas/generic, LEDE git HEAD

Description:

 * now a single config file in /etc/afp.conf
 * convert services to procd while at it

Signed-off-by: Daniel Golle <daniel@makrotopia.org>