### PR TITLE
hd-idle: convert init script to procd

### DIFF
--- a/utils/hd-idle/Makefile
+++ b/utils/hd-idle/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hd-idle
 PKG_VERSION:=1.04
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Lim Guo Wei <limguowei@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/utils/hd-idle/files/hd-idle.init
+++ b/utils/hd-idle/files/hd-idle.init
@@ -2,38 +2,22 @@
 # Copyright (C) 2008-2011 OpenWrt.org
 
 START=50
+STOP=10
 
-append_bool() {
-	local section="$1"
-	local option="$2"
-	local value="$3"
-	local _val
-	config_get_bool _val "$section" "$option" '0'
-	[ "$_val" -gt 0 ] && append args "$3"
-}
+USE_PROCD=1
 
-append_string() {
-	local section="$1"
-	local option="$2"
-	local value="$3"
-	local _val
-	config_get _val "$section" "$option"
-	[ -n "$_val" ] && append args "$3 $_val"
+validate_section_hdidle()
+{
+	uci_validate_section hd-idle hd-idle "${1}" \
+		'disk:string' \
+		'enabled:bool' \
+		'idle_time_interval:uinteger:10' \
+		'idle_time_unit:string:minutes'
 }
 
 compute_seconds() {
 	local interval="$1"
 	local unit="$2"
-
-	if [ -z "$interval" ]
-	then
-		interval=10
-	fi
-
-	if [ -z "$unit" ]
-	then
-		unit="minutes"
-	fi
 
 	# compute interval in seconds
 	case "$unit" in
@@ -58,22 +42,31 @@ compute_seconds() {
 	echo $interval_seconds
 }
 
+hdidle_append() {
+	local disk enabled idle_time_interval idle_time_unit
+
+	validate_section_hdidle "${1}" || return
+
+	[ "$enabled" -gt 0 ] || return
+
+	if [ "$numdisks" = "0" ]; then
+		procd_open_instance
+		procd_set_param command /usr/bin/hd-idle
+		procd_append_param command -d -i 0
+	fi
+	procd_append_param command -a $disk
+	procd_append_param command -i "$(compute_seconds $idle_time_interval $idle_time_unit)"
+	numdisks=$(( numdisks + 1 ))
+}
+
 start_service() {
-	local section="$1"
-	args=""
-	config_get "interval" "$section" "idle_time_interval"
-	config_get "unit" "$section" "idle_time_unit"
-	append_string "$section" "disk" "-a"
-	config_get_bool "enabled" "$section" "enabled" '1'
-	[ "$enabled" -gt 0 ] || return 1
-	service_start /usr/bin/hd-idle $args -i "$(compute_seconds $interval $unit)"
-}
-
-start() {
 	config_load "hd-idle"
-	config_foreach start_service "hd-idle"
-}
 
-stop() {
-	service_stop /usr/bin/hd-idle
+	numdisks="0"
+	config_foreach hdidle_append "hd-idle"
+
+	if [ "$numdisks" -gt 0 ]; then
+		procd_set_param respawn
+		procd_close_instance
+	fi
 }


### PR DESCRIPTION
Maintainer: @gwlim
Compile tested: LEDE git HEAD, oxnas/generic
Run tested: LEDE git HEAD, oxnas/generic, verified it works as expected with 0 to many disks

Description:

Clean up init script and introduce support for multiple disks.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>