### PR TITLE
lftp: add zlib dependency

### DIFF
--- a/net/lftp/Makefile
+++ b/net/lftp/Makefile
@@ -29,7 +29,7 @@ define Package/lftp
   SUBMENU:=File Transfer
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libncurses +libopenssl +libreadline $(CXX_DEPENDS) +libexpat
+  DEPENDS:=+libncurses +libopenssl +libreadline $(CXX_DEPENDS) +libexpat +zlib
   TITLE:=a sophisticated file transfer program with command line interface.
   MAINTAINER:=Federico Di Marco <fededim@gmail.com>
   URL:=http://lftp.yar.ru/


### PR DESCRIPTION
Maintainer: Federico Di Marco <fededim@gmail.com>
Compile tested: Kirkwood, current LEDE trunk
Run tested: Kirkwood, current LEDE trunk

Description:
because otherwise the build of this package in LEDE trunk fails, complaining about lack of libz.so.1

signed off by Alberto Bursi <alberto.bursi@outlook.it>