### PR TITLE
autossh: import from oldpackages and update

### DIFF
--- a/net/autossh/Makefile
+++ b/net/autossh/Makefile
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2006-2012 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=autossh
+PKG_VERSION:=1.4b
+PKG_RELEASE:=6
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
+PKG_SOURCE_URL:=http://www.harding.motd.ca/autossh/
+PKG_MD5SUM:=8f9aa006f6f69e912d3c2f504622d6f7
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/autossh
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Autossh client
+  URL:=http://www.harding.motd.ca/autossh/
+  SUBMENU:=SSH
+endef
+
+define Build/Compile
+	$(call Build/Compile/Default, -f Makefile \
+		CFLAGS="$(TARGET_CFLAGS) -Wall -D\"SSH_PATH=\\\"\$$$$(SSH)\\\"\" -D\"VER=\\\"\$$$$(VER)\\\"\"" \
+		all \
+	)
+endef
+
+define Package/autossh/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/autossh $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/autossh.init $(1)/etc/init.d/autossh
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/autossh.config $(1)/etc/config/autossh
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
+	$(INSTALL_DATA) ./files/autossh.hotplug $(1)/etc/hotplug.d/iface/20-autossh
+endef
+
+define Package/autossh/conffiles
+/etc/config/autossh
+endef
+
+$(eval $(call BuildPackage,autossh))

--- a/net/autossh/Makefile
+++ b/net/autossh/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2012 OpenWrt.org
+# Copyright (C) 2006-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=autossh
-PKG_VERSION:=1.4b
-PKG_RELEASE:=6
+PKG_VERSION:=1.4e
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=http://www.harding.motd.ca/autossh/
-PKG_MD5SUM:=8f9aa006f6f69e912d3c2f504622d6f7
+PKG_MD5SUM:=f86684b96e99d22b2e9d35dc63b0aa29
+PKG_LICENSE:=0BSD
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -22,6 +23,7 @@ define Package/autossh
   CATEGORY:=Network
   TITLE:=Autossh client
   URL:=http://www.harding.motd.ca/autossh/
+  MAINTAINER:=Christian Beier <cb@shoutrlabs.com>
   SUBMENU:=SSH
 endef
 

--- a/net/autossh/files/autossh.config
+++ b/net/autossh/files/autossh.config
@@ -1,0 +1,5 @@
+config autossh
+	option ssh	'-i /etc/dropbear/id_rsa -N -T -R 2222:localhost:22 user@host'
+	option gatetime	'0'
+	option monitorport	'20000'
+	option poll	'600'

--- a/net/autossh/files/autossh.hotplug
+++ b/net/autossh/files/autossh.hotplug
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Copyright (C) 2007 OpenWrt.org
+
+/etc/init.d/autossh enabled && {
+
+	[ "$ACTION" = "ifup" ] && {
+		/etc/init.d/autossh start
+	}
+
+	[ "$ACTION" = "ifdown" ] && {
+		/etc/init.d/autossh stop
+	}
+	
+}

--- a/net/autossh/files/autossh.init
+++ b/net/autossh/files/autossh.init
@@ -1,0 +1,30 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2007-2011 OpenWrt.org
+
+START=80
+
+start_instance() {
+	local section="$1"
+
+	config_get ssh "$section" 'ssh'
+	config_get gatetime "$section" 'gatetime'
+	config_get monitorport "$section" 'monitorport'
+	config_get poll "$section" 'poll'
+
+	export AUTOSSH_GATETIME="${gatetime:-30}"
+	export AUTOSSH_POLL="${poll:-600}"
+	service_start /usr/sbin/autossh -M ${monitorport:-20000} -f ${ssh}
+}
+
+boot() {
+	return
+}
+
+start() {
+	config_load 'autossh'
+	config_foreach start_instance 'autossh'
+}
+
+stop() {
+	service_stop /usr/sbin/autossh
+}


### PR DESCRIPTION
-------------------------------

Maintainer: me / @bk138
Compile tested: ar71xx, Chaos Calmer
Run tested:  ar71xx, Chaos Calmer, simple functionality test: it does what it's supposed to

Description:
autossh is a program to start a copy of ssh and monitor it, restarting it as necessary should it die or stop passing traffic. 
