### PR TITLE
logrotate: import from oldpackages

### DIFF
--- a/utils/logrotate/Makefile
+++ b/utils/logrotate/Makefile
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2006-2012 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=logrotate
+PKG_VERSION:=3.8.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
+PKG_SOURCE_URL:= \
+	http://ftp.debian.org/debian/pool/main/l/logrotate \
+	http://ftp.de.debian.org/debian/pool/main/l/logrotate \
+	http://ftp.fr.debian.org/debian/pool/main/l/logrotate \
+	http://ftp.us.debian.org/debian/pool/main/l/logrotate
+PKG_MD5SUM:=bd2e20d8dc644291b08f9215397d28a5
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/logrotate
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libpopt
+  TITLE:=rotates, compresses, and mails system logs
+  URL:=http://packages.debian.org/unstable/admin/logrotate
+endef
+
+define Package/logrotate/description
+ logrotate is designed to ease administration of systems that generate large
+ numbers of log files. It allows auto-matic rotation, compression, removal and
+ mailing of log files. Each log file may be handled daily, weekly, monthly or
+ when it grows too large.
+endef
+
+define Package/logrotate/conffiles
+/etc/logrotate.conf
+endef
+
+EXTRA_CFLAGS += $(TARGET_CPPFLAGS)
+EXTRA_LDFLAGS += $(TARGET_LDFLAGS)
+
+define Build/Compile
+	$(call Build/Compile/Default, \
+		RPM_OPT_FLAGS:="$(TARGET_CFLAGS) $(EXTRA_CFLAGS)" \
+		LDFLAGS="$(EXTRA_LDFLAGS)" \
+		logrotate \
+	)
+endef
+
+define Package/logrotate/install	
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) ${PKG_BUILD_DIR}/logrotate $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DATA) ./files/logrotate.conf $(1)/etc/
+	$(INSTALL_DIR) $(1)/etc/logrotate.d
+endef
+
+$(eval $(call BuildPackage,logrotate))

--- a/utils/logrotate/Makefile
+++ b/utils/logrotate/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2012 OpenWrt.org
+# Copyright (C) 2006-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,16 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=logrotate
-PKG_VERSION:=3.8.1
+PKG_VERSION:=3.10.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
-PKG_SOURCE_URL:= \
-	http://ftp.debian.org/debian/pool/main/l/logrotate \
-	http://ftp.de.debian.org/debian/pool/main/l/logrotate \
-	http://ftp.fr.debian.org/debian/pool/main/l/logrotate \
-	http://ftp.us.debian.org/debian/pool/main/l/logrotate
-PKG_MD5SUM:=bd2e20d8dc644291b08f9215397d28a5
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:= https://github.com/logrotate/logrotate/releases/download/$(PKG_VERSION)
+PKG_MD5SUM:=888f58caf07082c76f5dd39e5d30ec12
+PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -26,7 +23,8 @@ define Package/logrotate
   CATEGORY:=Utilities
   DEPENDS:=+libpopt
   TITLE:=rotates, compresses, and mails system logs
-  URL:=http://packages.debian.org/unstable/admin/logrotate
+  URL:=https://github.com/logrotate/logrotate
+  MAINTAINER:=Christian Beier <cb@shoutrlabs.com>
 endef
 
 define Package/logrotate/description

--- a/utils/logrotate/files/logrotate.conf
+++ b/utils/logrotate/files/logrotate.conf
@@ -1,0 +1,30 @@
+# rotate log files weekly
+weekly
+#daily
+
+# keep 4 weeks worth of backlogs
+rotate 4
+
+# create new (empty) log files after rotating old ones
+create
+
+notifempty
+nomail
+#olddir /var/log/backup/
+missingok
+#dateext
+
+# uncomment this if you want your log files compressed
+#compress
+
+# packages can drop log rotation information into this directory
+include /etc/logrotate.d
+
+# no packages own lastlog or wtmp -- we'll rotate them here
+#/var/log/wtmp {
+#    monthly
+#    create 0664 root utmp
+#    rotate 1
+#}
+
+# system-specific logs may be also be configured here.


### PR DESCRIPTION
-------------------------------

Maintainer: me / @bk138
Compile tested: ar71xx, Chaos Calmer
Run tested: ar71xx, Chaos Calmer, rotates logs as expected

Description:
The logrotate utility is designed to simplify the administration of log files on a system which generates a lot of log files. Logrotate allows for the automatic rotation compression, removal and mailing of log files. Logrotate can be set to handle a log file daily, weekly, monthly or when the log file gets to a certain size.
