### PR TITLE
unbound: enable pthreads, disable deprecated ciphers

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.5.9
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -103,6 +103,7 @@ define Package/libunbound
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE+= (library)
+  DEPENDS+= +libpthread
 endef
 
 define Package/libunbound/description
@@ -110,13 +111,13 @@ define Package/libunbound/description
 endef
 
 CONFIGURE_ARGS += \
+	--disable-dsa \
 	--disable-gost \
 	--enable-allsymbols \
 	--with-libexpat="$(STAGING_DIR)/usr" \
 	--with-ssl="$(STAGING_DIR)/usr" \
 	--with-pidfile=/var/run/unbound.pid \
-	--with-user=unbound \
-	--without-pthreads
+	--with-user=unbound
 
 define Package/unbound/conffiles
 /etc/unbound/unbound.conf


### PR DESCRIPTION
Maintainer: hansmi
Compile tested: ar71xx and x86_64 on LEDE r1450+
Run tested: ar71xx and x86_64 on LEDE r1450+

Description: 
- Disables weak DSA ciphers
- Enables POSIX threading support

