### PR TITLE
logrotate: Fix nonnull-compare compile error

### DIFF
--- a/utils/logrotate/Makefile
+++ b/utils/logrotate/Makefile
@@ -38,7 +38,7 @@ define Package/logrotate/conffiles
 /etc/logrotate.conf
 endef
 
-EXTRA_CFLAGS += $(TARGET_CPPFLAGS)
+EXTRA_CFLAGS += $(TARGET_CPPFLAGS) -Wno-nonnull-compare
 EXTRA_LDFLAGS += $(TARGET_LDFLAGS)
 
 define Build/Compile


### PR DESCRIPTION
Maintainer: me / @nxhack
Compile tested: ar71xx mips_24kc_musl-1.1.15, LEDE r1589
Run tested: none

Description:
logrotate: Fix nonnull-compare compile error
---
config.c: In function 'strndup':
config.c:87:10: error: nonnull argument 's' compared to NULL [-Werror=nonnull-compare]
        if(!s)
          ^
cc1: all warnings being treated as errors
---

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>