### PR TITLE
lighttpd: update to 1.4.41

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
-PKG_VERSION:=1.4.38
+PKG_VERSION:=1.4.41
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://download.lighttpd.net/lighttpd/releases-1.4.x
-PKG_MD5SUM:=7adc12323f37ed24ecf026c7547b577d
+PKG_MD5SUM:=1df2e4dbc965cfe6f99f008ac3db4d8d
 
 PKG_LICENSE:=BSD-3c
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64/PC/OpenWrt 15.05

Description:
lighttpd: update to 1.4.41

Signed-off-by: W. Michael Petullo <mike@flyn.org>