### PR TITLE
openldap: update to 2.4.44

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
-PKG_VERSION:=2.4.43
-PKG_RELEASE:=3
+PKG_VERSION:=2.4.44
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/ \
 	ftp://sunsite.cnlab-switch.ch/mirror/OpenLDAP/openldap-release/ \
 	ftp://ftp.nl.uu.net/pub/unix/db/openldap/openldap-release/ \
 	ftp://ftp.plig.org/pub/OpenLDAP/openldap-release/
-PKG_MD5SUM:=49ca65e27891fcf977d78c10f073c705
+PKG_MD5SUM:=693ac26de86231f8dcae2b4e9d768e51
 
 PKG_FIXUP:=autoreconf
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64/PC/OpenWrt master

Description:
openldap: update to 2.4.44

Signed-off-by: W. Michael Petullo <mike@flyn.org>