### PR TITLE
ddns-scripts: Add do.de as ddns provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.4
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -157,3 +157,5 @@
 # core-networks.de
 "core-networks.de"	"http://[USERNAME]:[PASSWORD]@dyndns.core-networks.de/?hostname=[DOMAIN]&myip=[IP]&keepipv6=1"	"good"
 
+# do.de
+"do.de"	"http://ddns.do.de/?myip=[IP]&hostname=[DOMAIN]&username=[USERNAME]&password=[PASSWORD]"

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -158,4 +158,4 @@
 "core-networks.de"	"http://[USERNAME]:[PASSWORD]@dyndns.core-networks.de/?hostname=[DOMAIN]&myip=[IP]&keepipv6=1"	"good"
 
 # do.de
-"do.de"	"http://ddns.do.de/?myip=[IP]&hostname=[DOMAIN]&username=[USERNAME]&password=[PASSWORD]"
+"do.de"	"http://ddns.do.de/?myip=[IP]&hostname=[DOMAIN]&username=[USERNAME]&password=[PASSWORD]" "good|nochg"

--- a/net/ddns-scripts/files/services_ipv6
+++ b/net/ddns-scripts/files/services_ipv6
@@ -91,3 +91,5 @@
 # duiadns.net - free dynamic DNS
 "duiadns.net"	"http://[USERNAME]:[PASSWORD]@ipv6.duia.ro/dynamic.duia?host=[DOMAIN]&ip6=[IP]"
 
+# do.de
+"do.de" "http://ddns.do.de/?myip=[IP]&hostname=[DOMAIN]&username=[USERNAME]&password=[PASSWORD]"

--- a/net/ddns-scripts/files/services_ipv6
+++ b/net/ddns-scripts/files/services_ipv6
@@ -92,4 +92,4 @@
 "duiadns.net"	"http://[USERNAME]:[PASSWORD]@ipv6.duia.ro/dynamic.duia?host=[DOMAIN]&ip6=[IP]"
 
 # do.de
-"do.de" "http://ddns.do.de/?myip=[IP]&hostname=[DOMAIN]&username=[USERNAME]&password=[PASSWORD]"
+"do.de" "http://ddns.do.de/?myip=[IP]&hostname=[DOMAIN]&username=[USERNAME]&password=[PASSWORD]" "good|nochg"


### PR DESCRIPTION
Maintainer: @chris5560
Run tested: x86_64/PC/OpenWrt master, updates both ipv4 and ipv6 fine

Description:
Add support for do.de dyndns

Signed-off-by: Tobias Schramm <tobleminer@gmail.com>