### PR TITLE
gnutls: optionally disable tpm support

### DIFF
--- a/libs/gnutls/Config.in
+++ b/libs/gnutls/Config.in
@@ -39,6 +39,11 @@ config GNUTLS_ANON
 	bool "enable anonymous authentication support"
 	default y
 
+config GNUTLS_TPM
+	bool "enable tpm support"
+	select GNUTLS_PKCS11
+	default n
+
 config GNUTLS_PKCS11
 	bool "enable smart card (PKCS11) support"
 	select GNUTLS_EXT_LIBTASN1

--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnutls
 PKG_VERSION:=3.5.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -35,6 +35,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_GNUTLS_PKCS11 \
 	CONFIG_GNUTLS_PSK \
 	CONFIG_GNUTLS_SRP \
+	CONFIG_GNUTLS_TPM \
 	CONFIG_LIBNETTLE_MINI \
 
 include $(INCLUDE_DIR)/package.mk
@@ -161,6 +162,10 @@ ifneq ($(CONFIG_GNUTLS_OCSP),y)
 CONFIGURE_ARGS += --disable-ocsp
 endif
 
+ifneq ($(CONFIG_GNUTLS_TPM),y)
+CONFIGURE_ARGS += --without-tpm
+endif
+
 ifeq ($(CONFIG_GNUTLS_CRYPTODEV),y)
 CONFIGURE_ARGS += --enable-cryptodev
 endif
@@ -218,6 +223,11 @@ endif
 ifeq ($(CONFIG_GNUTLS_PKCS11),y)
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/bin/p11tool \
+		$(1)/usr/bin/
+endif
+ifeq ($(CONFIG_GNUTLS_TPM),y)
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/bin/tpmtool \
 		$(1)/usr/bin/
 endif
 endef


### PR DESCRIPTION
Maintainer: @nmav 
Compile tested: (mipsel, pistachio marduk, 15.05)

Description:
Add option that allows you to explicitly disable use of the tpm
otherwise if a tss stack such as trousers is found by gnutls build
system then it will use it which will cause a build failure when
PKCS11 support is not enabled.