### PR TITLE
python-attrs: update to 16.2.0

### DIFF
--- a/lang/python-attrs/Makefile
+++ b/lang/python-attrs/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=attrs
-PKG_VERSION:=16.0.0
+PKG_VERSION:=16.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/89/15/80d388d696c8c8ba14874635207aa698eb30ef1242dbb54d9eccf0e927ff
-PKG_MD5SUM:=5bcdd418f6e83e580434c63067c08a73
+PKG_SOURCE_URL:=https://pypi.python.org/packages/6b/71/1682316894ed80b362b9102e7a10997136d8dc1213c36a9f0515c451373a
+PKG_MD5SUM:=442b73d049af046ced010671b7bfd0e9
 
 PKG_BUILD_DEPENDS:=python python-setuptools
 


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWrt CC / OpenWrt trunk / LEDE master
Run tested: none

Description:

Signed-off-by: Jeffery To <jeffery.to@gmail.com>