### PR TITLE
python-cffi: update to 1.8.3

### DIFF
--- a/lang/python-cffi/Makefile
+++ b/lang/python-cffi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cffi
-PKG_VERSION:=1.7.0
+PKG_VERSION:=1.8.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/83/3c/00b553fd05ae32f27b3637f705c413c4ce71290aa9b4c4764df694e906d9
-PKG_MD5SUM:=34122a545060cee58bab88feab57006d
+PKG_SOURCE_URL:=https://pypi.python.org/packages/0a/f3/686af8873b70028fccf67b15c78fd4e4667a3da995007afc71e786d61b0a
+PKG_MD5SUM:=c8e877fe0426a99d0cf5872cf2f95b27
 
 PKG_BUILD_DEPENDS:=python python-setuptools
 HOST_BUILD_DEPENDS:=libffi/host python/host python-setuptools/host python-pycparser/host


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWrt CC / OpenWrt trunk / LEDE master (but see description below)
Run tested: none

Description:
This doesn't build correctly yet (#3192) but I'm fairly certain the problem isn't related to this package.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>