### PR TITLE
smartmontools: use libstdc++ instead of uclibc++

### DIFF
--- a/utils/smartmontools/Makefile
+++ b/utils/smartmontools/Makefile
@@ -6,11 +6,10 @@
 #
 
 include $(TOPDIR)/rules.mk
-include $(INCLUDE_DIR)/uclibc++.mk
 
 PKG_NAME:=smartmontools
 PKG_VERSION:=6.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/smartmontools
@@ -26,7 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/smartmontools/Default
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=$(CXX_DEPENDS)
+  DEPENDS:=+libstdcpp
   TITLE:=S.M.A.R.T Monitoring
   URL:=http://smartmontools.sourceforge.net/
 endef
@@ -55,19 +54,8 @@ define Package/smartd/description
   ATA and SCSI disks. It is derived from smartsuite.
 endef
 
-# uses GNU configure
-
-CONFIGURE_VARS += \
-	CXXFLAGS="$$$$CXXFLAGS -fno-builtin -fno-rtti -nostdinc++" \
-	CPPFLAGS="$$$$CPPFLAGS -I$(STAGING_DIR)/usr/include/uClibc++ -I$(LINUX_DIR)/include" \
-	LDFLAGS="$$$$LDFLAGS" \
-	LIBS="-nodefaultlibs -lc -luClibc++ -lm $(LIBGCC_S) -lc" \
-
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		BUILD_INFO='"(localbuild)"' \
-		LD="$(TARGET_CXX)"
-endef
+CONFIGURE_ARGS += \
+        --disable-dependency-tracking \
 
 define Package/smartmontools/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
Maintainer: @mstorchak 

Description:

Start using libstdc++, while it's larger in size it gets maintained much more frequently and pretty much all applications that requires c++ libs are quite large in terms of size so overall storage requirements aren't that much of a concern. It also helps in terms of easily porting other applications later on. As a sidenote, switching also cleans up the Makefile quite a bit.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>