### PR TITLE
python: disable with-ensurepip option for host build

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -12,7 +12,7 @@ include ./files/python-package.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)
@@ -228,7 +228,6 @@ HOST_CONFIGURE_ARGS+= \
 	--sbindir=$(STAGING_DIR)/host/bin \
 	--with-system-expat=$(STAGING_DIR)/host \
 	--with-system-ffi=$(STAGING_DIR)/host \
-	--with-ensurepip=upgrade \
 	CONFIG_SITE= \
 	CFLAGS="$(HOST_CFLAGS)"
 


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE trunk
Run tested: none

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>