### PR TITLE
gpsd: fix cross platform compilation

### DIFF
--- a/utils/gpsd/Makefile
+++ b/utils/gpsd/Makefile
@@ -103,7 +103,8 @@ SCONS_OPTIONS += \
 	nostrip=yes \
 	python=no \
 	implicit_link=no \
-	chrpath=no
+	chrpath=no \
+	target="$(TARGET_CROSS:-=)"
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
Maintainer: @psidhu 
Compile tested: lede master, mips, linux and macOS
Run tested: mips - ar71xx (custom platform)

Description:

In SConstruct the set of executables in the devenv variable should be adjusted to use the cross compile toolchain (as opposed to host's executables).
Achieved by setting target option to the toolchain prefix which corrects compilation on macOS.

Signed-off-by: David Thornley <david.thornley@touchstargroup.com>