### PR TITLE
python-pyopenssl: update to 16.1.0

### DIFF
--- a/lang/python-pyopenssl/Makefile
+++ b/lang/python-pyopenssl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pyOpenSSL
-PKG_VERSION:=16.0.0
+PKG_VERSION:=16.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pyOpenSSL
-PKG_MD5SUM:=9587d813dcf656e9f2760e41a3682dc3
+PKG_SOURCE_URL:=https://pypi.python.org/packages/15/1e/79c75db50e57350a7cefb70b110255757e9abd380a50ebdc0cfd853b7450
+PKG_MD5SUM:=d8100b0c333f0eeadaf05914da8792a6
 
 PKG_BUILD_DEPENDS:=python python-setuptools
 


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWrt CC / OpenWrt trunk / LEDE master
Run tested: none

Description:

Signed-off-by: Jeffery To <jeffery.to@gmail.com>