### PR TITLE
Fix x264 build

### DIFF
--- a/libs/libx264/Makefile
+++ b/libs/libx264/Makefile
@@ -53,7 +53,7 @@ define Package/libx264
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=H264/AVC free codec library.
-  DEPENDS:=@BUILD_PATENTED
+  DEPENDS:=@BUILD_PATENTED @!powerpc||BROKEN
   URL:=http://www.videolan.org/developers/x264.html
 endef
 

--- a/libs/libx264/Makefile
+++ b/libs/libx264/Makefile
@@ -38,14 +38,16 @@ else
 endif
 endif
 
+ifneq ($(CONFIG_SOFT_FLOAT),)
+CONFIGURE_VARS+= AS= 
+MAKE_FLAGS+= AS= 
+CONFIGURE_ARGS += --disable-asm
+endif
+
 CONFIGURE_ARGS += \
 		--enable-shared \
 		--enable-pic \
 		--disable-cli 
-
-ifeq ($(CONFIG_SOFT_FLOAT),y)
-CONFIGURE_ARGS += --disable-asm
-endif
 
 define Package/libx264
   SECTION:=libs


### PR DESCRIPTION
Maintainer: @ianchi
Compile tested: oxnas, LEDE git HEAD

Description:
work-around build issues on non-FPU ARM CPUs
mark as broken as PowerPC ( http://downloads.lede-project.org/snapshots/faillogs/powerpc_440/packages/libx264/compile.txt )