### PR TITLE
logrotate: configure without libacl

### DIFF
--- a/utils/logrotate/Makefile
+++ b/utils/logrotate/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=logrotate
 PKG_VERSION:=3.10.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= https://github.com/logrotate/logrotate/releases/download/$(PKG_VERSION)
@@ -37,6 +37,8 @@ endef
 define Package/logrotate/conffiles
 /etc/logrotate.conf
 endef
+
+CONFIGURE_ARGS += --with-acl=no
 
 EXTRA_CFLAGS += $(TARGET_CPPFLAGS) -Wno-nonnull-compare
 EXTRA_LDFLAGS += $(TARGET_LDFLAGS)


### PR DESCRIPTION

Maintainer: @bk138
Compile tested: ar71xx mips_24kc musl-1.1.15 gcc-6.2.0, LEDE r1643
Run tested: none

Description:
 configure logrotate without libacl.

Issue:
 https://github.com/openwrt/packages/issues/3191

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>