### PR TITLE
mii-tool: re-introduce from oldpackages

### DIFF
--- a/net/mii-tool/Makefile
+++ b/net/mii-tool/Makefile
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2006-2010 OpenWrt.org
+# Copyright (C) 2016 Stijn Segers
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mii-tool
+PKG_VERSION=2016-07-10-$(PKG_SOURCE_VERSION)
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+PKG_MAINTAINER:=Stijn Segers <borromini.reg@protonmail.com>
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=git://git.code.sf.net/p/net-tools/code
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=115f1af2494ded1fcd21c8419d5e289bc4df380f
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/mii-tool
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=configure media type using MII commands
+  URL:=http://net-tools.sourceforge.net/
+endef
+
+define Package/mii-tool/description
+	The mii-tool command allows you to set or autodetect the media type
+	or mii chipset-based ethernet devices. It traditionally had been
+	distributed in the net-tools package. This is a single distribution
+	optimized for embedded systems and fully automated cross/-sysroot-builds
+endef
+
+define Build/Configure
+	# Failed configure.sh leaves stub config.h around.
+	rm -f $(PKG_BUILD_DIR)/config.h
+	(cd $(PKG_BUILD_DIR) && yes $$$$'\n' | ./configure.sh config.in )
+endef
+
+define Build/Compile
+	$(call Build/Compile/Default,mii-tool)
+endef
+
+define Package/mii-tool/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/mii-tool $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,mii-tool))


### PR DESCRIPTION
This re-introduces mii-tool and updates it to the latest version. Compile-tested on x86/64 and ar71xx. Run-tested on x86/64.

Signed-off-by: Stijn Segers <francesco.borromini@inventati.org>