### PR TITLE
ddns-scripts: bump to version 2.7.5

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -116,6 +116,8 @@ endef
 
 ##### **********************************
 define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.hotplug $(1)/etc/hotplug.d/iface/95-ddns
 	$(INSTALL_DIR) $(1)/etc/init.d
@@ -132,19 +134,8 @@ define Package/$(PKG_NAME)/postinst
 	# if run within buildroot exit
 	[ -n "$${IPKG_INSTROOT}" ] && exit 0
 
-	# add new section "ddns" "global" if not exists
-	uci -q get ddns.global > /dev/null || uci -q set ddns.global='ddns'
-	uci -q get ddns.global.date_format > /dev/null || uci -q set ddns.global.date_format='%F %R'
-	uci -q get ddns.global.log_lines > /dev/null || uci -q set ddns.global.log_lines='250'
-	uci -q get ddns.global.allow_local_ip > /dev/null || uci -q set ddns.global.allow_local_ip='0'
-	uci -q commit ddns
-
-	# fix some service_name entries to new once
-	/bin/sed -i '/service_name/s/freedns.afraid.org/afraid.org/g' /etc/config/ddns
-	/bin/sed -i '/service_name/s/free.editdns.net/editdns.net/g' /etc/config/ddns
-	/bin/sed -i '/service_name/s/domains.google.com/google.com/g' /etc/config/ddns
-	/bin/sed -i '/service_name/s/spdns.de/spdyn.de/g' /etc/config/ddns
-	/bin/sed -i '/service_name/s/strato.de/strato.com/g' /etc/config/ddns
+	# apply changes introduced during release changes
+	/etc/uci-defaults/ddns
 
 	# clear LuCI indexcache
 	rm -f /tmp/luci-indexcache >/dev/null 2>&1

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -129,19 +129,6 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/services* $(1)/usr/lib/ddns
 	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/dynamic_*.sh $(1)/usr/lib/ddns
 endef
-define Package/$(PKG_NAME)/postinst
-	#!/bin/sh
-	# if run within buildroot exit
-	[ -n "$${IPKG_INSTROOT}" ] && exit 0
-
-	# apply changes introduced during release changes
-	/etc/uci-defaults/ddns
-
-	# clear LuCI indexcache
-	rm -f /tmp/luci-indexcache >/dev/null 2>&1
-
-	exit 0
-endef
 define Package/$(PKG_NAME)/prerm
 	#!/bin/sh
 	# if run within buildroot exit

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ddns-scripts
 # Version == major.minor.patch
 # increase on new functionality (minor) or patches (patch)
-PKG_VERSION:=2.7.4
+PKG_VERSION:=2.7.5
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=4
+PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.4
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
@@ -138,6 +138,13 @@ define Package/$(PKG_NAME)/postinst
 	uci -q get ddns.global.log_lines > /dev/null || uci -q set ddns.global.log_lines='250'
 	uci -q get ddns.global.allow_local_ip > /dev/null || uci -q set ddns.global.allow_local_ip='0'
 	uci -q commit ddns
+
+	# fix some service_name entries to new once
+	/bin/sed -i '/service_name/s/freedns.afraid.org/afraid.org/g' /etc/config/ddns
+	/bin/sed -i '/service_name/s/free.editdns.net/editdns.net/g' /etc/config/ddns
+	/bin/sed -i '/service_name/s/domains.google.com/google.com/g' /etc/config/ddns
+	/bin/sed -i '/service_name/s/spdns.de/spdyn.de/g' /etc/config/ddns
+	/bin/sed -i '/service_name/s/strato.de/strato.com/g' /etc/config/ddns
 
 	# clear LuCI indexcache
 	rm -f /tmp/luci-indexcache >/dev/null 2>&1

--- a/net/ddns-scripts/files/ddns.defaults
+++ b/net/ddns-scripts/files/ddns.defaults
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# add new section "ddns" "global" if not exists
+/sbin/uci -q get ddns.global > /dev/null		|| /sbin/uci -q set ddns.global='ddns'
+/sbin/uci -q get ddns.global.date_format > /dev/null	|| /sbin/uci -q set ddns.global.date_format='%F %R'
+/sbin/uci -q get ddns.global.log_lines > /dev/null	|| /sbin/uci -q set ddns.global.log_lines='250'
+/sbin/uci -q get ddns.global.allow_local_ip > /dev/null	|| /sbin/uci -q set ddns.global.allow_local_ip='0'
+/sbin/uci -q commit ddns
+
+# fix some service_name entries to new once
+/bin/sed -i \
+	-e '/service_name/s/CloudFlare/cloudflare\.com/g' \
+	-e '/service_name/s/NoIP\.com/no-ip\.com/g' \
+	-e '/service_name/s/No-IP\.com/no-ip\.com/g' \
+	-e '/service_name/s/freedns.afraid.org/afraid.org/g' \
+	-e '/service_name/s/free.editdns.net/editdns.net/g' \
+	-e '/service_name/s/domains.google.com/google.com/g' \
+	-e '/service_name/s/spdns.de/spdyn.de/g' \
+	-e '/service_name/s/strato.de/strato.com/g' \
+	/etc/config/ddns
+
+# clear LuCI indexcache
+rm -f /tmp/luci-indexcache >/dev/null 2>&1
+
+exit 0

--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -1062,10 +1062,12 @@ get_registered_ip() {
 		__RUNPROG="$__PROG $lookup_host >$DATFILE 2>$ERRFILE"
 		__PROG="hostip"
 	elif [ -n "$NSLOOKUP" ]; then	# last use BusyBox nslookup
-		[ $force_ipversion -ne 0 -o $force_dnstcp -ne 0 ] && \
-			write_log 14 "Busybox nslookup - no support to 'force IP Version' or 'DNS over TCP'"
+		[ $force_dnstcp -ne 0 ] && \
+			write_log 14 "Busybox nslookup - no support for 'DNS over TCP'"
 		[ -n "$NSLOOKUP_MUSL" -a -n "$dns_server" ] && \
 			write_log 14 "Busybox compiled with musl - nslookup don't support the use of DNS Server"
+		[ $force_ipversion -ne 0 ] && \
+			write_log 5 "Busybox nslookup - no support to 'force IP Version' (ignored)"
 
 		__RUNPROG="$NSLOOKUP $lookup_host $dns_server >$DATFILE 2>$ERRFILE"
 		__PROG="BusyBox nslookup"

--- a/net/ddns-scripts/files/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/dynamic_dns_updater.sh
@@ -13,27 +13,33 @@
 # variables in big chars beginning with "__" are local defined inside functions only
 # set -vx  	#script debugger
 
-. /usr/lib/ddns/dynamic_dns_functions.sh	# global vars are also defined here
+. $(dirname $0)/dynamic_dns_functions.sh	# global vars are also defined here
 
 [ $# -lt 1 -o -n "${2//[0-3]/}" -o ${#2} -gt 1 ] && {
-	echo -e "\n  ddns-scripts Version: $VERSION"
-	echo -e "\n  USAGE:"
-	echo    "  $0 [OPTION]"
-	echo    "  [OPTION]	  '-V' or '--version' display version and exit"
-	echo -e "\n  $0 [SECTION] [VERBOSE_MODE]\n"
-	echo    "  [SECTION]      - service section as defined in /etc/config/ddns"
-	echo    "  [VERBOSE_MODE] - '0' NO output to console"
-	echo    "                   '1' output to console"
-	echo    "                   '2' output to console AND logfile"
-	echo    "                       + run once WITHOUT retry on error"
-	echo    "                   '3' output to console AND logfile"
-	echo    "                       + run once WITHOUT retry on error"
-	echo -e "                       + NOT sending update to DDNS service\n"
+	local __ME=$(basename $0)
+	cat << EOF
+ddns-scripts Version: $VERSION
+
+Usage:
+  $__ME -V         display version and exit
+  $__ME --version  display version and exit
+
+  $__ME <SECTION> <VERBOSE_MODE>
+  <SECTION>        service section as defined in /etc/config/ddns
+  <VERBOSE_MODE>   '0' NO output to console
+                   '1' output to console
+                   '2' output to console AND logfile
+                       + run once WITHOUT retry on error
+                   '3' output to console AND logfile
+                       + run once WITHOUT retry on error
+                       + NOT sending update to DDNS service
+
+EOF
 	exit 1
 }
 
 [ "$1" = "-V" -o "$1" = "--version" ] && {
-	echo -e "ddns-scripts $VERSION\n"
+	printf %s\\n "ddns-scripts $VERSION"
 	exit 0
 }
 

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -32,130 +32,139 @@
 # "answer"	single words inside providers answer string; use "|" to combine "or"
 #
 # 44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444
+#
+# cloudflare.com	!!! Please install additional package "ddns-scripts_cloudflare"
+# no-ip.com / noip.com	!!! Please install additional package "ddns-scripts_no-ip_com"
 
-"dyndns.org"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
-"changeip.com"		"http://[USERNAME]:[PASSWORD]@nic.changeip.com/nic/update?u=[USERNAME]&p=[PASSWORD]&cmd=update&hostname=[DOMAIN]&ip=[IP]"
-"zoneedit.com"		"http://[USERNAME]:[PASSWORD]@dynamic.zoneedit.com/auth/dynamic.html?host=[DOMAIN]&dnsto=[IP]"
-"free.editdns.net"	"http://dyndns-free.editdns.net/api/dynLinux.php?p=[PASSWORD]&r=[DOMAIN]"
+"3322.org"		"http://[USERNAME]:[PASSWORD]@members.3322.org/dyndns/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]"
 
-# freedns.afraid.org is weird, you just need an update code, for which we use the password variable
-"freedns.afraid.org"	"http://freedns.afraid.org/dynamic/update.php?[PASSWORD]&address=[IP]"
+"able.or.kr"		"http://able.or.kr/ddns/src/update.php?hostname=[DOMAIN]&myip=[IP]&ddnsuser=[USERNAME]&pwd=[PASSWORD]"
 
-# DNS Max and resellers' update urls
-"dnsmax.com"	"http://update.dnsmax.com/update/?username=[USERNAME]&password=[PASSWORD]&resellerid=1&clientname=openwrt&clientversion=8.09&protocolversion=2.0&updatehostname=[DOMAIN]&ip=[IP]"
-"thatip.com"	"http://update.dnsmax.com/update/?username=[USERNAME]&password=[PASSWORD]&resellerid=2&clientname=openwrt&clientversion=8.09&protocolversion=2.0&updatehostname=[DOMAIN]&ip=[IP]"
+"afraid.org"		"http://freedns.afraid.org/dynamic/update.php?[PASSWORD]&address=[IP]"
 
-# Hurricane Electric Dynamic DNS
-"he.net"	"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+"all-inkl.com"		"http://[USERNAME]:[PASSWORD]@dyndns.kasserver.com/?myip=[IP]"
 
-# DNSdynamic.org
-"dnsdynamic.org"	"http://[USERNAME]:[PASSWORD]@www.dnsdynamic.org/api/?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+"changeip.com"		"http://[USERNAME]:[PASSWORD]@nic.changeip.com/nic/update?u=[USERNAME]&p=[PASSWORD]&cmd=update&hostname=[DOMAIN]&ip=[IP]"	"good|NOCHG"
 
-# dnsExit.com free dynamic DNS update url
-"dnsexit.com"	"http://www.dnsexit.com/RemoteUpdate.sv?login=[USERNAME]&password=[PASSWORD]&host=[DOMAIN]&myip=[IP]"
-
-# OVH
-"ovh.com"	"http://[USERNAME]:[PASSWORD]@www.ovh.com/nic/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]"
-
-# dns-o-matic is a free service by opendns.com for updating multiple hosts
-"dnsomatic.com"	"http://[USERNAME]:[PASSWORD]@updates.dnsomatic.com/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
-
-# 3322.org
-"3322.org"	"http://[USERNAME]:[PASSWORD]@members.3322.org/dyndns/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]"
-
-# namecheap.com
-"namecheap.com"	"http://dynamicdns.park-your-domain.com/update?host=[USERNAME]&domain=[DOMAIN]&password=[PASSWORD]&ip=[IP]"
-
-# easydns.com dynamic DNS
-"easydns.com"	"http://[USERNAME]:[PASSWORD]@api.cp.easydns.com/dyn/tomato.php?hostname=[DOMAIN]&myip=[IP]"
-
-# Winco DDNS
-"ddns.com.br"	"http://[DOMAIN]:[PASSWORD]@members.ddns.com.br/nic/update?hostname=[DOMAIN]&myip=[IP]"
-
-# Mythic Beasts Dynamic DNS
-"mythic-beasts.com"	"http://dnsapi4.mythic-beasts.com/?domain=[USERNAME]&password=[PASSWORD]&command=REPLACE%20[DOMAIN]%2060%20A%20DYNAMIC_IP&origin=."
-
-# Securepoint Dynamic-DNS-Service	(http://www.spdns.de)
-"spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdyn.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
-"spdyn.de"	"http://[USERNAME]:[PASSWORD]@update.spdyn.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
-
-# duiadns.net - free dynamic DNS
-"duiadns.net"	"http://[USERNAME]:[PASSWORD]@ipv4.duia.ro/dynamic.duia?host=[DOMAIN]&ip4=[IP]"
-
-# Two-DNS - Simply. Connected. Everywhere.
-"twodns.de"	"http://[USERNAME]:[PASSWORD]@update.twodns.de/update?hostname=[DOMAIN]&ip=[IP]"
-
-# MyDNS.JP
-"mydns.jp"	"http://www.mydns.jp/directip.html?MID=[USERNAME]&PWD=[PASSWORD]&IPV4ADDR=[IP]"
-
-# LoopiaDNS
-"loopia.se"	"http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"
-
-# SelfHost.de
-"selfhost.de"	"http://carol.selfhost.de/update?username=[USERNAME]&password=[PASSWORD]&myip=[IP]&hostname=1"	"good|nochg"
-
-# no-ip.pl nothing to do with no-ip.com (domain registered to www.domeny.tv) (IP autodetected by provider)
-"no-ip.pl"	"http://[USERNAME]:[PASSWORD]@update.no-ip.pl/?hostname=[DOMAIN]"
-
-# domains.google.com	non free service - require HTTPS communication
-"domains.google.com"	"http://[USERNAME]:[PASSWORD]@domains.google.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
-
-# Schokokeks Hosting, schokokeks.org
-"schokokeks.org"	"http://[USERNAME]:[PASSWORD]@dyndns.schokokeks.org/nic/update?myip=[IP]"	"good|nochg"
-
-# STRATO AG
-"strato.de"		"http://[USERNAME]:[PASSWORD]@dyndns.strato.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
-
-# Variomedia AG
-"variomedia.de" 	"http://[USERNAME]:[PASSWORD]@dyndns.variomedia.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
-
-# DtDNS
-"dtdns.com"	"http://www.dtdns.com/api/autodns.cfm?id=[DOMAIN]&pw=[PASSWORD]&ip=[IP]"
-
-# dy.fi Dynamic DNS for finnish users (IP autodetected by provider)
-"dy.fi"		"http://[USERNAME]:[PASSWORD]@www.dy.fi/nic/update?hostname=[DOMAIN]"	"good|nochg"
-
-# duckdns.org
-"duckdns.org"	"http://www.duckdns.org/update?domains=[USERNAME]&token=[PASSWORD]&ip=[IP]"	"OK"
-
-# zzzz.io Free Dynamic DNS
-"zzzz.io"	"http://zzzz.io/api/v1/update/[DOMAIN]/?token=[PASSWORD]&ip=[IP]"	"Updated|No change"
-
-# dynu.com
-"dynu.com"  "http://api.dynu.com/nic/update?hostname=[DOMAIN]&myip=[IP]&username=[USERNAME]&password=[PASSWORD]"
-
-# nubem.com
-"nubem.com"	"http://[USERNAME]:[PASSWORD]@nubem.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
-
-# nettica.com
-"nettica.com"	"http://www.nettica.com/Domain/Update.aspx?U=[USERNAME]&PC=[PASSWORD]&FQDN=[DOMAIN]&N=[IP]"
-
-# zerigo.com
-"zerigo.com"	"http://update.zerigo.com/dynamic?host=[DOMAIN]&ip=[IP]&user=[USERNAME]&password=[PASSWORD]"
-
-# regfish.de
-"regfish.de"	"http://dyndns.regfish.de/?fqdn=[DOMAIN]&forcehost=1&authtype=secure&token=[PASSWORD]&ipv4=[IP]"	"success|100|101"
-
-# nsupdate.info - a free service - supports https
-"nsupdate.info"	"http://[USERNAME]:[PASSWORD]@ipv4.nsupdate.info/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
-
-# dyndnss.net
-"dyndnss.net"	"http://www.dyndnss.net/?user=[USERNAME]&pass=[PASSWORD]&domain=[DOMAIN]&updater=other"
-
-# goip.de
-"goip.de"	"http://www.goip.de/setip?username=[USERNAME]&password=[PASSWORD]&subdomain=[DOMAIN]&ip4=[IP]"
-
-# myonlineportal.net
-"myonlineportal.net"	"http://[USERNAME]:[PASSWORD]@myonlineportal.net/updateddns?hostname=[DOMAIN]&ip=[IP]"	"good|nochg"
-
-# dyns.net
-"dyns.net"	"http://www.dyns.net/postscript011.php?username=[USERNAME]&password=[PASSWORD]&host=[DOMAIN]&ip=[IP]"	"200"
-
-# dnshome.de
-"dnshome.de"	"http://[USERNAME]:[PASSWORD]@www.dnshome.de/dyndns.php?hostname=[DOMAIN]&ip=[IP]"
-
-# core-networks.de
 "core-networks.de"	"http://[USERNAME]:[PASSWORD]@dyndns.core-networks.de/?hostname=[DOMAIN]&myip=[IP]&keepipv6=1"	"good"
 
-# do.de
-"do.de"	"http://ddns.do.de/?myip=[IP]&hostname=[DOMAIN]&username=[USERNAME]&password=[PASSWORD]" "good|nochg"
+"ddns.com.br"		"http://[DOMAIN]:[PASSWORD]@members.ddns.com.br/nic/update?hostname=[DOMAIN]&myip=[IP]"
+
+# "ddnss.de"		"http://[USERNAME]:[PASSWORD]@ip4.ddnss.de/upd.php?host=[DOMAIN]&ip=[IP]"	"good|nochg"
+"ddnss.de"		"http://ip4.ddnss.de/upd.php?user=[USERNAME]&pwd=[PASSWORD]&host=[DOMAIN]&ip=[IP]"	"good|nochg"
+
+"ddo.jp"		"http://free.ddo.jp/dnsupdate.php?dn=[DOMAIN]&pw=[PASSWORD]&ip=[IP]"
+
+"desec.io"		"http://[USERNAME]:[PASSWORD]@update.dedyn.io/?hostname=[DOMAIN]&myipv4=[IP]"	"good|nochg"
+
+"dhis.org"		"http://[USERNAME]:[PASSWORD]@is.dhis.org/"
+
+"dnsdynamic.org"	"http://[USERNAME]:[PASSWORD]@www.dnsdynamic.org/api/?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"dnsexit.com"		"http://www.dnsexit.com/RemoteUpdate.sv?login=[USERNAME]&password=[PASSWORD]&host=[DOMAIN]&myip=[IP]"	"0=|1="
+
+"dnshome.de"		"http://[USERNAME]:[PASSWORD]@www.dnshome.de/dyndns.php?hostname=[DOMAIN]&ip=[IP]"
+
+"dnsmadeeasy.com"	"http://www.dnsmadeeasy.com/servlet/updateip?username=[USERNAME]&password=[PASSWORD}&id=[DOMAIN]&ip=[IP]"	"success|ip-same"
+
+"dnsmax.com"		"http://update.dnsmax.com/update/?username=[USERNAME]&password=[PASSWORD]&resellerid=1&clientname=openwrt&clientversion=8.09&protocolversion=2.0&updatehostname=[DOMAIN]&ip=[IP]"
+
+"dnsomatic.com"		"http://[USERNAME]:[PASSWORD]@updates.dnsomatic.com/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"dnspark.com"		"http://[USERNAME]:[PASSWORD]@control.dnspark.com/api/dynamic/update.php?hostname=[DOMAIN]&ip=[IP]"	"ok|nochange"
+
+"do.de"			"http://ddns.do.de/?myip=[IP]&hostname=[DOMAIN]&username=[USERNAME]&password=[PASSWORD]"	"good|nochg"
+
+"domopoli.de"		"http://[USERNAME]:[PASSWORD]@http://dyndns.domopoli.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"dtdns.com"		"http://www.dtdns.com/api/autodns.cfm?id=[DOMAIN]&pw=[PASSWORD]&ip=[IP]"
+
+"duckdns.org"		"http://www.duckdns.org/update?domains=[USERNAME]&token=[PASSWORD]&ip=[IP]"	"OK"
+
+"duiadns.net"		"http://[USERNAME]:[PASSWORD]@ipv4.duia.ro/dynamic.duia?host=[DOMAIN]&ip4=[IP]"
+
+"dy.fi"			"http://[USERNAME]:[PASSWORD]@www.dy.fi/nic/update?hostname=[DOMAIN]"	"good|nochg"
+
+"dyndns.it"		"http://[USERNAME]:[PASSWORD]@update.dyndns.it/nic/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"dyn.com"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+"dyndns.org"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"dyndnss.net"		"http://www.dyndnss.net/?user=[USERNAME]&pass=[PASSWORD]&domain=[DOMAIN]&updater=other"
+
+"dynsip.org"		"http://[USERNAME]:[PASSWORD]@dynsip.org/nic/update?hostname=[DOMAIN]&myip=[IP]"
+
+"dyns.net"		"http://www.dyns.net/postscript011.php?username=[USERNAME]&password=[PASSWORD]&host=[DOMAIN]&ip=[IP]"	"200"
+
+"dynu.com"		"http://api.dynu.com/nic/update?hostname=[DOMAIN]&myip=[IP]&username=[USERNAME]&password=[PASSWORD]"
+
+"dynv6.com"		"http://dynv6.com/api/update?hostname=[DOMAIN]&token=[PASSWORD]&ipv4=[IP]"	"updated"
+
+"easydns.com"		"http://[USERNAME]:[PASSWORD]@api.cp.easydns.com/dyn/generic.php?hostname=[DOMAIN]&myip=[IP]"	"NOERROR"
+
+"editdns.net"		"http://dyndns-free.editdns.net/api/dynLinux.php?p=[PASSWORD]&r=[DOMAIN]"
+
+"goip.de"		"http://www.goip.de/setip?username=[USERNAME]&password=[PASSWORD]&subdomain=[DOMAIN]&ip4=[IP]"
+
+"google.com"		"http://[USERNAME]:[PASSWORD]@domains.google.com/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"he.net"		"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"joker.com"		"http://svc.joker.com/nic/update?username=[USERNAME]&password=[PASSWORD]&myip=[IP]&hostname=[DOMAIN]"	"good|nochg"
+
+"loopia.com"		"http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"loopia.se"		"http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"mydns.jp"		"http://www.mydns.jp/directip.html?MID=[USERNAME]&PWD=[PASSWORD]&IPV4ADDR=[IP]"
+
+"myonlineportal.net"	"http://[USERNAME]:[PASSWORD]@myonlineportal.net/updateddns?hostname=[DOMAIN]&ip=[IP]"	"good|nochg"
+
+"mythic-beasts.com"	"http://dnsapi4.mythic-beasts.com/?domain=[USERNAME]&password=[PASSWORD]&command=REPLACE%20[DOMAIN]%2060%20A%20DYNAMIC_IP&origin=."
+
+"namecheap.com"		"http://dynamicdns.park-your-domain.com/update?host=[USERNAME]&domain=[DOMAIN]&password=[PASSWORD]&ip=[IP]"
+
+"nettica.com"		"http://www.nettica.com/Domain/Update.aspx?U=[USERNAME]&PC=[PASSWORD]&FQDN=[DOMAIN]&N=[IP]"
+
+"no-ip.pl"		"http://[USERNAME]:[PASSWORD]@update.no-ip.pl/?hostname=[DOMAIN]"
+
+"nsupdate.info"		"http://[USERNAME]:[PASSWORD]@ipv4.nsupdate.info/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"nubem.com"		"http://[USERNAME]:[PASSWORD]@nubem.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
+
+"opendns.com"		"http://[USERNAME]:[PASSWORD]@updates.opendns.com/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"oray.com"		"http://[USERNAME]:[PASSWORD]@ddns.oray.com/ph/update?hostname=[DOMAIN]&myip=[IP]"
+
+"ovh.com"		"http://[USERNAME]:[PASSWORD]@www.ovh.com/nic/update?system=dyndns&hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"regfish.de"		"http://dyndns.regfish.de/?fqdn=[DOMAIN]&forcehost=1&authtype=secure&token=[PASSWORD]&ipv4=[IP]"	"success|100|101"
+
+"schokokeks.org"	"http://[USERNAME]:[PASSWORD]@dyndns.schokokeks.org/nic/update?myip=[IP]"	"good|nochg"
+
+"selfhost.de"		"http://carol.selfhost.de/update?username=[USERNAME]&password=[PASSWORD]&myip=[IP]&hostname=1"	"good|nochg|200|204"
+
+"sitelutions.com"	"http://www.sitelutions.com/dnsup?user=[USERNAME]&pass=[PASSWORD]&id=[DOMAIN]&ip=[IP]"	"success"
+
+"spdyn.de"		"http://[USERNAME]:[PASSWORD]@update.spdyn.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"strato.com"		"http://[USERNAME]:[PASSWORD]@dyndns.strato.com/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"system-ns.com"		"http://system-ns.com/api?type=dynamic&command=set&domain=[DOMAIN]&token=[PASSWORD]&ip=[IP]"	"0"
+
+"thatip.com"		"http://update.dnsmax.com/update/?username=[USERNAME]&password=[PASSWORD]&resellerid=2&clientname=openwrt&clientversion=8.09&protocolversion=2.0&updatehostname=[DOMAIN]&ip=[IP]"
+
+"twodns.de"		"http://[USERNAME]:[PASSWORD]@update.twodns.de/update?hostname=[DOMAIN]&ip=[IP]"
+
+"udmedia.de"		"http://[USERNAME]:[PASSWORD]@www.udmedia.de/nic/update?myip=[IP]"
+
+"variomedia.de" 	"http://[USERNAME]:[PASSWORD]@dyndns.variomedia.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"xlhost.de"		"http://[USERNAME]:[PASSWORD]@nsupdate.xlhost.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"zerigo.com"		"http://update.zerigo.com/dynamic?user=[USERNAME]&password=[PASSWORD]&host=[DOMAIN]&ip=[IP]"	"ok"
+
+"zoneedit.com"		"http://[USERNAME]:[PASSWORD]@dynamic.zoneedit.com/auth/dynamic.html?host=[DOMAIN]&dnsto=[IP]"
+
+"zzzz.io"		"http://zzzz.io/api/v1/update/[DOMAIN]/?token=[PASSWORD]&ip=[IP]"	"Updated|No change"
+

--- a/net/ddns-scripts/files/services_ipv6
+++ b/net/ddns-scripts/files/services_ipv6
@@ -32,64 +32,65 @@
 # "answer"	words inside providers answer string; use "|" to combine "or"
 #
 # 66666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666
+#
+# cloudflare.com	!!! Please install additional package "ddns-scripts_cloudflare"
+# no-ip.com / noip.com	!!! Please install additional package "ddns-scripts_no-ip_com"
 
-# IPv6 @ Securepoint Dynamic-DNS-Service
-"spdns.de"	"http://[USERNAME]:[PASSWORD]@update.spdyn.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
-"spdyn.de"	"http://[USERNAME]:[PASSWORD]@update.spdyn.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+"afraid.org"		"http://freedns.afraid.org/dynamic/update.php?[PASSWORD]&address=[IP]"
 
-# IPv6 @ Hurricane Electric Dynamic DNS
-"he.net"	"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+"all-inkl.com"		"http://[USERNAME]:[PASSWORD]@dyndns.kasserver.com/?myip=[IP]"
 
-# IPv6 @ MyDNS.JP
-"mydns.jp"	"http://www.mydns.jp/directip.html?MID=[USERNAME]&PWD=[PASSWORD]&IPV6ADDR=[IP]"
-
-# IPv6 @ no-ip.pl nothing to do with no-ip.com (domain registered to www.domeny.tv) (IP autodetected by provider)
-"no-ip.pl"	"http://[USERNAME]:[PASSWORD]@update.no-ip.pl/?hostname=[DOMAIN]"
-
-# IPv6 @ freedns.afraid.org
-"freedns.afraid.org"	"http://freedns.afraid.org/dynamic/update.php?[PASSWORD]&address=[IP]"
-
-# IPv6 @ LoopiaDNS
-"loopia.se"	"http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"
-
-# Variomedia AG
-"variomedia.de"		"http://[USERNAME]:[PASSWORD]@dyndns.variomedia.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
-
-# IPv6 @ Dyn.com
-"dyndns.org"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
-
-# duckdns.org
-"duckdns.org"	"http://www.duckdns.org/update?domains=[DOMAIN]&token=[PASSWORD]&ipv6=[IP]"	"OK"
-
-# IPv6 @ zzzz.io Free Dynamic DNS
-"zzzz.io"	"http://zzzz.io/api/v1/update/[DOMAIN]/?token=[PASSWORD]&type=aaaa&ip=[IP]"	"Updated|No change"
-
-# IPv6 @ zerigo.com
-"zerigo.com"	"http://update.zerigo.com/dynamic?host=[DOMAIN]&ip=[IP]&user=[USERNAME]&password=[PASSWORD]"
-
-# IPv6 @ regfish.de
-"regfish.de"	"http://dyndns.regfish.de/?fqdn=[DOMAIN]&forcehost=1&authtype=secure&token=[PASSWORD]&ipv6=[IP]"	"success|100|101"
-
-# Mythic Beasts (https://www.mythic-beasts.com) Dynamic DNS
-"mythic-beasts.com"	"http://dnsapi6.mythic-beasts.com/?domain=[USERNAME]&password=[PASSWORD]&command=REPLACE%20[DOMAIN]%2060%20AAAA%20DYNAMIC_IP&origin=."
-
-# nsupdate.info - a free service - supports https
-"nsupdate.info"	"http://[USERNAME]:[PASSWORD]@ipv6.nsupdate.info/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
-
-# goip.de
-"goip.de"	"http://www.goip.de/setip?username=[USERNAME]&password=[PASSWORD]&subdomain=[DOMAIN]&ip6=[IP]"
-
-# myonlineportal.net
-"myonlineportal.net"	"http://[USERNAME]:[PASSWORD]@myonlineportal.net/updateddns?hostname=[DOMAIN]&ip6=[IP]"	"good|nochg"
-
-# dnshome.de
-"dnshome.de"	"http://[USERNAME]:[PASSWORD]@www.dnshome.de/dyndns.php?hostname=[DOMAIN]&ip6=[IP]"
-
-# core-networks.de
 "core-networks.de"	"http://[USERNAME]:[PASSWORD]@dyndns.core-networks.de/?hostname=[DOMAIN]&myip=[IP]&keepipv4=1"	"good"
 
-# duiadns.net - free dynamic DNS
-"duiadns.net"	"http://[USERNAME]:[PASSWORD]@ipv6.duia.ro/dynamic.duia?host=[DOMAIN]&ip6=[IP]"
+# "ddnss.de"		"http://[USERNAME]:[PASSWORD]@ip6.ddnss.de/upd.php?host=[DOMAIN]&ip6=[IP]"	"good|nochg"
+"ddnss.de"		"http://ip6.ddnss.de/upd.php?user=[USERNAME]&pwd=[PASSWORD]&host=[DOMAIN]&ip6=[IP]"	"good|nochg"
 
-# do.de
-"do.de" "http://ddns.do.de/?myip=[IP]&hostname=[DOMAIN]&username=[USERNAME]&password=[PASSWORD]" "good|nochg"
+"desec.io"		"http://[USERNAME]:[PASSWORD]@update.dedyn.io/?hostname=[DOMAIN]&myipv6=[IP]"	"good|nochg"
+
+"dhis.org"		"http://[USERNAME]:[PASSWORD]@is.dhis.org/"
+
+"dnshome.de"		"http://[USERNAME]:[PASSWORD]@www.dnshome.de/dyndns.php?hostname=[DOMAIN]&ip6=[IP]"
+
+"do.de"			"http://ddns.do.de/?myip=[IP]&hostname=[DOMAIN]&username=[USERNAME]&password=[PASSWORD]"	"good|nochg"
+
+"duckdns.org"		"http://www.duckdns.org/update?domains=[DOMAIN]&token=[PASSWORD]&ipv6=[IP]"	"OK"
+
+"duiadns.net"		"http://[USERNAME]:[PASSWORD]@ipv6.duia.ro/dynamic.duia?host=[DOMAIN]&ip6=[IP]"
+
+"dyn.com"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+"dyndns.org"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"dynv6.com"		"http://dynv6.com/api/update?hostname=[DOMAIN]&token=[PASSWORD]&ipv6=[IP]"	"updated"
+
+"goip.de"		"http://www.goip.de/setip?username=[USERNAME]&password=[PASSWORD]&subdomain=[DOMAIN]&ip6=[IP]"
+
+"google.com"		"http://[USERNAME]:[PASSWORD]@domains.google.com/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"he.net"		"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"loopia.com"		"http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"loopia.se"		"http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"mydns.jp"		"http://www.mydns.jp/directip.html?MID=[USERNAME]&PWD=[PASSWORD]&IPV6ADDR=[IP]"
+
+"myonlineportal.net"	"http://[USERNAME]:[PASSWORD]@myonlineportal.net/updateddns?hostname=[DOMAIN]&ip6=[IP]"	"good|nochg"
+
+"mythic-beasts.com"	"http://dnsapi6.mythic-beasts.com/?domain=[USERNAME]&password=[PASSWORD]&command=REPLACE%20[DOMAIN]%2060%20AAAA%20DYNAMIC_IP&origin=."
+
+"no-ip.pl"		"http://[USERNAME]:[PASSWORD]@update.no-ip.pl/?hostname=[DOMAIN]"
+
+"nsupdate.info"		"http://[USERNAME]:[PASSWORD]@ipv6.nsupdate.info/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"regfish.de"		"http://dyndns.regfish.de/?fqdn=[DOMAIN]&forcehost=1&authtype=secure&token=[PASSWORD]&ipv6=[IP]"	"success|100|101"
+
+"spdyn.de"		"http://[USERNAME]:[PASSWORD]@update.spdyn.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"udmedia.de"		"http://[USERNAME]:[PASSWORD]@www.udmedia.de/nic/update?myip=[IP]"
+
+"variomedia.de"		"http://[USERNAME]:[PASSWORD]@dyndns.variomedia.de/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+
+"zerigo.com"		"http://update.zerigo.com/dynamic?user=[USERNAME]&password=[PASSWORD]&host=[DOMAIN]&ip=[IP]"	"ok"
+
+"zzzz.io"		"http://zzzz.io/api/v1/update/[DOMAIN]/?token=[PASSWORD]&type=aaaa&ip=[IP]"	"Updated|No change"
+

--- a/net/ddns-scripts/files/update_nsupdate.sh
+++ b/net/ddns-scripts/files/update_nsupdate.sh
@@ -15,9 +15,9 @@
 #
 # variable __IP already defined with the ip-address to use for update
 #
-__TTL=600		#.preset DNS TTL (in seconds)
-__RRTYPE __PW __TCP
-__PROG=$(which nsupdate)			# BIND nsupdate ?
+local __TTL=600		#.preset DNS TTL (in seconds)
+local __RRTYPE __PW __TCP
+local __PROG=$(which nsupdate)			# BIND nsupdate ?
 [ -z "$__PROG" ] && __PROG=$(which knsupdate)	# Knot nsupdate ?
 
 [ -z "$__PROG" ]     && write_log 14 "'nsupdate' or 'knsupdate' not installed !"

--- a/net/ddns-scripts/files/update_nsupdate.sh
+++ b/net/ddns-scripts/files/update_nsupdate.sh
@@ -15,11 +15,12 @@
 #
 # variable __IP already defined with the ip-address to use for update
 #
-local __TTL=600		#.preset DNS TTL (in seconds)
-local __RRTYPE __PW __TCP
+__TTL=600		#.preset DNS TTL (in seconds)
+__RRTYPE __PW __TCP
+__PROG=$(which nsupdate)			# BIND nsupdate ?
+[ -z "$__PROG" ] && __PROG=$(which knsupdate)	# Knot nsupdate ?
 
-[ -x /usr/bin/nsupdate ] || write_log 14 "'nsupdate' not installed or not executable !"
-
+[ -z "$__PROG" ]     && write_log 14 "'nsupdate' or 'knsupdate' not installed !"
 [ -z "$username" ]   && write_log 14 "Service section not configured correctly! Missing 'username'"
 [ -z "$password" ]   && write_log 14 "Service section not configured correctly! Missing 'password'"
 [ -z "$dns_server" ] && write_log 14 "Service section not configured correctly! Missing 'dns_server'"
@@ -35,12 +36,13 @@ update del $domain $__RRTYPE
 update add $domain $__TTL $__RRTYPE $__IP
 show
 send
+answer
 quit
 EOF
 
-/usr/bin/nsupdate -d $__TCP $DATFILE >$ERRFILE 2>&1
+$__PROG -d $__TCP $DATFILE >$ERRFILE 2>&1
 
 # nsupdate always return success
-write_log 7 "nsupdate reports:\n$(cat $ERRFILE)"
+write_log 7 "(k)nsupdate reports:\n$(cat $ERRFILE)"
 
 return 0


### PR DESCRIPTION
Maintainer: me
Compile tested: DD trunk 
Run tested: DD trunk x86 and WNDR3800

Description:
- commands to apply changes introduced during release changes, moved from Makefile postinst to /etc/uci-defaults/ddns
- do not break execution if using nslookup and force_ipversion=1
- add support of knsupdate (update_nsupdate.sh
- url update easydns.com
- add some service answers
- alphabetic reorder services files for easier reading
- rename services/provider (Makefile postinst handle /etc/config/ddns)

1. freedns.afraid.org -> afraid.org
2. free.editdns.net -> editdns.net
3. domains.google.com -> google.com
4. spdns.de -> spdyn.de
5. strato.de -> strato.com

- new provider (looking in deep into https://sourceforge.net/projects/inadyn-mt project)

1. dyn.com (= dyndns.org)
2. ddnss.de
3. dhis.org
4. dnspark.com (IPv4 only)
5. dynsip.org (IPv4 only)
6. dynv6.com
7. joker.com (IPv4 only)
8. loopia.com (= loopia.se)
9. sitelutions.com (IPv4 only)
10. system-ns.com (IPv4 only)

- new provider (looking in deep into /etc.defaults/ddns_provider.conf file for Synology DiskStation published at https://gist.github.com/ntrepid8/6653274)

1. able.or.kr (IPv4 only)
2. ddo.jp (IPv4 only)
3. dnsmadeeasy.com (IPv4 only)
4. oray.com (IPv4 only)

- new provider (looking in deep into https://github.com/ipfire/ddns project)

1. all-inkl.com
2. desec.io
3. domopoli.de (IPv4 only)
4. opendns.com (IPv4 only)
5. udmedia.de
6. xlhost.de (IPv4 only)

- new provider (looking in deep into https://github.com/yaddns/yaddns project )

1. dyndns.it (IPv4 only)

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>