### PR TITLE
mwan3: remove bad local shell variable declarations

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Jeroen Louwes <jeroen.louwes@gmail.com>
 PKG_LICENSE:=GPLv2
 

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -22,8 +22,6 @@ fi
 [ -x /usr/sbin/ip6tables ] || exit 7
 [ -x /usr/bin/logger ] || exit 8
 
-local family gateway
-
 config_get family $INTERFACE family ipv4
 
 if [ "$family" == "ipv4" ]; then

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-local IP4 IP6 IPS IPT4 IPT6 LOG
-
 IP4="/usr/bin/ip -4"
 IP6="/usr/bin/ip -6"
 IPS="/usr/sbin/ipset"


### PR DESCRIPTION
Maintainer: @Adze1502 
Compile tested: -
Run tested: -

Description:

Local variable declarations outside of functions are illegal since the Busybox
update to v1.25.0, therfore remove them from the appropriate places.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>