### PR TITLE
ddns-scripts: remove bad local shell variable declarations

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.3
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/update_cloudflare_com.sh
+++ b/net/ddns-scripts/files/update_cloudflare_com.sh
@@ -19,8 +19,6 @@
 [ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
 [ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"
 
-local __RECID __URL __KEY __KEYS __FOUND __SUBDOM __DOMAIN __TLD
-
 # split given Host/Domain into TLD, registrable domain, and subdomain
 split_FQDN $domain __TLD __DOMAIN __SUBDOM
 [ $? -ne 0 -o -z "$__DOMAIN" ] && \

--- a/net/ddns-scripts/files/update_no-ip_com.sh
+++ b/net/ddns-scripts/files/update_no-ip_com.sh
@@ -9,8 +9,7 @@
 # provider did not reactivate records, if no IP change was recognized
 # so we send a dummy (localhost) and a seconds later we send the correct IP addr
 #
-local __DUMMY
-local __UPDURL="http://[USERNAME]:[PASSWORD]@dynupdate.no-ip.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
+__UPDURL="http://[USERNAME]:[PASSWORD]@dynupdate.no-ip.com/nic/update?hostname=[DOMAIN]&myip=[IP]"
 # inside url we need username and password
 [ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
 [ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"

--- a/net/ddns-scripts/files/update_nsupdate.sh
+++ b/net/ddns-scripts/files/update_nsupdate.sh
@@ -15,8 +15,7 @@
 #
 # variable __IP already defined with the ip-address to use for update
 #
-local __TTL=600		#.preset DNS TTL (in seconds)
-local __RRTYPE __PW __TCP
+__TTL=600		#.preset DNS TTL (in seconds)
 
 [ -x /usr/bin/nsupdate ] || write_log 14 "'nsupdate' not installed or not executable !"
 

--- a/net/ddns-scripts/samples/update_sample.sh
+++ b/net/ddns-scripts/samples/update_sample.sh
@@ -17,7 +17,7 @@
 # the code here is the copy of the default used inside send_update()
 #
 # tested with spdns.de
-local __URL="http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"
+__URL="http://[USERNAME]:[PASSWORD]@update.spdns.de/nic/update?hostname=[DOMAIN]&myip=[IP]"
 # inside url we need domain, username and password
 [ -z "$domain" ]   && write_log 14 "Service section not configured correctly! Missing 'domain'"
 [ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"


### PR DESCRIPTION
Maintainer: @chris5560 
Compile tested: -
Run tested: -

Description:

Local variable declarations outside of functions are illegal since the Busybox
update to v1.25.0, therfore remove them from the appropriate places.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>