### PR TITLE
python-cryptography: update to 1.5.1

### DIFF
--- a/lang/python-cryptography/Makefile
+++ b/lang/python-cryptography/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptography
-PKG_VERSION:=1.5
+PKG_VERSION:=1.5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/6e/96/b8dab146e8be98061dae07e127f80cffa3061ab0e8da0d3d42f3308c6e91
-PKG_MD5SUM:=d85a91af3e943c68fa5ff82a3ccdd5df
+PKG_SOURCE_URL:=https://pypi.python.org/packages/21/e1/37fc14f9d77924e84ba0dcb88eb8352db914583af229287c6c965d66ba0d
+PKG_MD5SUM:=66a3e01f5f436d2413ef47b7e6bb7729
 
 PKG_BUILD_DEPENDS:=python-cffi/host
 


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWrt CC / OpenWrt trunk / LEDE master
Run tested: none

Description:

Fixes #3226

Signed-off-by: Jeffery To <jeffery.to@gmail.com>