### PR TITLE
dmidecode: use url alias

### DIFF
--- a/utils/dmidecode/Makefile
+++ b/utils/dmidecode/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dmidecode
 PKG_VERSION:=3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://download.savannah.gnu.org/releases/dmidecode
+PKG_SOURCE_URL:=@SAVANNAH/$(PKG_NAME)
 PKG_MD5SUM:=be7501ad0f844e875976b96106afaa3c
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 


### PR DESCRIPTION
Maintainer: @Noltari 
Compile tested: (put here arch, model, OpenWRT/LEDE version)
Run tested: (put here arch, model, OpenWRT/LEDE version, tests done)

Description:

Use url alias instead of hardcoded URL.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>