### PR TITLE
ffmpeg: Update 2.8.8, add codecs, update dlna profile, correct libopus use

### DIFF
--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -20,6 +20,7 @@ config FFMPEG_CUSTOM_MINIDLNA_SUPPORT
 	select FFMPEG_CUSTOM_DECODER_ac3
 	select FFMPEG_CUSTOM_DECODER_flac
 	select FFMPEG_CUSTOM_DECODER_h264
+	select FFMPEG_CUSTOM_DECODER_hevc
 	select FFMPEG_CUSTOM_DECODER_jpegls
 	select FFMPEG_CUSTOM_DECODER_mp3
 	select FFMPEG_CUSTOM_DECODER_mpeg1video
@@ -27,23 +28,19 @@ config FFMPEG_CUSTOM_MINIDLNA_SUPPORT
 	select FFMPEG_CUSTOM_DECODER_mpeg4
 	select FFMPEG_CUSTOM_DECODER_mpegvideo
 	select FFMPEG_CUSTOM_DECODER_png
+	select FFMPEG_CUSTOM_DECODER_opus
+	select FFMPEG_CUSTOM_DECODER_vc1
+	select FFMPEG_CUSTOM_DECODER_vorbis
 	select FFMPEG_CUSTOM_DECODER_wmav1
 	select FFMPEG_CUSTOM_DECODER_wmav2
-	select FFMPEG_CUSTOM_DEMUXER_aac
-	select FFMPEG_CUSTOM_DEMUXER_ac3
 	select FFMPEG_CUSTOM_DEMUXER_avi
 	select FFMPEG_CUSTOM_DEMUXER_flac
-	select FFMPEG_CUSTOM_DEMUXER_h264
 	select FFMPEG_CUSTOM_DEMUXER_matroska
 	select FFMPEG_CUSTOM_DEMUXER_mov
 	select FFMPEG_CUSTOM_DEMUXER_mp3
 	select FFMPEG_CUSTOM_DEMUXER_mpegts
 	select FFMPEG_CUSTOM_DEMUXER_mpegvideo
-	select FFMPEG_CUSTOM_PARSER_ac3
-	select FFMPEG_CUSTOM_PARSER_flac
-	select FFMPEG_CUSTOM_PARSER_h264
-	select FFMPEG_CUSTOM_PARSER_mpeg4video
-	select FFMPEG_CUSTOM_PARSER_mpegaudio
+	select FFMPEG_CUSTOM_DEMUXER_ogg
 	select FFMPEG_CUSTOM_PROTOCOL_file
 
 config FFMPEG_CUSTOM_AUDIO_DEC_SUPPORT
@@ -67,7 +64,6 @@ config FFMPEG_CUSTOM_AUDIO_DEC_SUPPORT
 	select FFMPEG_CUSTOM_DECODER_pcm_s16be
 	select FFMPEG_CUSTOM_DECODER_pcm_s16le
 	select FFMPEG_CUSTOM_SELECT_speex
-	select FFMPEG_CUSTOM_SELECT_libopus
 	select FFMPEG_CUSTOM_DECODER_vorbis
 	select FFMPEG_CUSTOM_DECODER_wavpack
 	select FFMPEG_CUSTOM_DECODER_wmav1
@@ -214,6 +210,10 @@ config FFMPEG_CUSTOM_DECODER_h264
 	bool "H.264"
 	depends on FFMPEG_CUSTOM_PATENTED
 
+config FFMPEG_CUSTOM_DECODER_hevc
+	bool "HEVC / H.265 Video"
+	depends on FFMPEG_CUSTOM_PATENTED
+
 config FFMPEG_CUSTOM_DECODER_jpegls
 	bool "JPEG-LS"
 
@@ -260,6 +260,10 @@ config FFMPEG_CUSTOM_DECODER_png
 	bool "PNG"
 	select FFMPEG_CUSTOM_DECODER_zlib
 
+config FFMPEG_CUSTOM_DECODER_vc1
+	bool "VC-1 / WMV9"
+	depends on FFMPEG_CUSTOM_PATENTED
+
 config FFMPEG_CUSTOM_DECODER_vorbis
 	bool "Vorbis"
 	select FFMPEG_CUSTOM_DEMUXER_ogg
@@ -288,7 +292,11 @@ config FFMPEG_CUSTOM_MUXER_ffm
 	bool "FFM (ffserver live feed)"
 
 config FFMPEG_CUSTOM_MUXER_h264
-	bool "H.264"
+	bool "H.264 Raw Video"
+	depends on FFMPEG_CUSTOM_PATENTED
+
+config FFMPEG_CUSTOM_MUXER_hevc
+	bool "HEVC / H265 Raw Video"
 	depends on FFMPEG_CUSTOM_PATENTED
 
 config FFMPEG_CUSTOM_MUXER_mp3
@@ -336,7 +344,11 @@ config FFMPEG_CUSTOM_DEMUXER_ffm
 	bool "FFM (ffserver live feed)"
 
 config FFMPEG_CUSTOM_DEMUXER_h264
-	bool "H.264"
+	bool "H.264 Raw Video"
+	depends on FFMPEG_CUSTOM_PATENTED
+
+config FFMPEG_CUSTOM_DEMUXER_hevc
+	bool "HEVC / H265 Raw Video"
 	depends on FFMPEG_CUSTOM_PATENTED
 
 config FFMPEG_CUSTOM_DEMUXER_matroska
@@ -387,6 +399,10 @@ config FFMPEG_CUSTOM_DEMUXER_sdp
 config FFMPEG_CUSTOM_DEMUXER_rtp
 	bool "RTP"
 
+config FFMPEG_CUSTOM_DEMUXER_vc1
+	bool "VC-1 / WMV9 Raw Video"
+	depends on FFMPEG_CUSTOM_PATENTED
+
 config FFMPEG_CUSTOM_DEMUXER_wav
 	bool "WAV"
 
@@ -410,6 +426,11 @@ config FFMPEG_CUSTOM_PARSER_h264
 	depends on FFMPEG_CUSTOM_PATENTED
 	select FFMPEG_CUSTOM_DECODER_h264
 
+config FFMPEG_CUSTOM_PARSER_hevc
+	bool "HEVC / H265"
+	depends on FFMPEG_CUSTOM_PATENTED
+	select FFMPEG_CUSTOM_DECODER_hevc
+
 config FFMPEG_CUSTOM_PARSER_mpegaudio
 	bool "MPEG Audio"
 
@@ -421,6 +442,11 @@ config FFMPEG_CUSTOM_PARSER_mpeg4video
 
 config FFMPEG_CUSTOM_PARSER_opus
 	bool "Opus"
+
+config FFMPEG_CUSTOM_PARSER_vc1
+	bool "VC-1 / WMV9"
+	depends on FFMPEG_CUSTOM_PATENTED
+	select FFMPEG_CUSTOM_DECODER_vc1
 
 comment "Protocols"
 

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=2.8.7
-PKG_RELEASE:=3
+PKG_VERSION:=2.8.8
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://ffmpeg.org/releases/
-PKG_MD5SUM:=7e5b1c98eedfc3a364fa8c4095deeae5
+PKG_MD5SUM:=5fae1ba5a5d37a2d0de750479b7270d4
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
 PKG_LICENSE:=LGPL-2.1+ GPL-2+ LGPL-3
@@ -42,6 +42,7 @@ FFMPEG_CUSTOM_DECODERS:= \
 	flac \
 	gif \
 	h264 \
+	hevc \
 	jpegls \
 	mp2 \
 	mp3 \
@@ -54,6 +55,7 @@ FFMPEG_CUSTOM_DECODERS:= \
 	pcm_s16be \
 	pcm_s16le \
 	png \
+	vc1 \
 	vorbis \
 	wavpack \
 	wmav1 \
@@ -64,6 +66,7 @@ FFMPEG_CUSTOM_MUXERS:= \
 	ac3 \
 	ffm \
 	h264 \
+	hevc \
 	mp3 \
 	mp4 \
 	mpeg1video \
@@ -81,6 +84,7 @@ FFMPEG_CUSTOM_DEMUXERS:= \
 	flac \
 	ffm \
 	h264 \
+	hevc \
 	matroska \
 	mov \
 	mp3 \
@@ -95,6 +99,7 @@ FFMPEG_CUSTOM_DEMUXERS:= \
 	rtp \
 	sdp \
 	v4l2 \
+	vc1 \
 	wav \
 	wv \
 
@@ -103,9 +108,11 @@ FFMPEG_CUSTOM_PARSERS:= \
 	flac \
 	ac3 \
 	h264 \
+	hevc \
 	mpegaudio \
 	mpeg4video \
 	mpegvideo \
+	vc1 \
 
 FFMPEG_CUSTOM_PROTOCOLS:= \
 	file http icecast pipe rtp tcp udp
@@ -115,34 +122,29 @@ FFMPEG_MINI_DECODERS:= \
 	ac3 \
 	flac \
 	h264 \
+	hevc \
 	jpegls \
 	mp3 \
 	mpeg1video \
 	mpeg2video \
 	mpeg4 \
 	mpegvideo \
+	opus \
 	png \
+	vc1 \
+	vorbis \
 	wmav1 \
 	wmav2 \
 
 FFMPEG_MINI_DEMUXERS:= \
-	aac \
-	ac3 \
 	avi \
 	flac \
-	h264 \
 	matroska \
 	mov \
 	mp3 \
 	mpegts \
 	mpegvideo \
-
-FFMPEG_MINI_PARSERS:= \
-	ac3 \
-	flac \
-	h264 \
-	mpeg4video \
-	mpegaudio \
+	ogg \
 
 FFMPEG_MINI_PROTOCOLS:= \
 	file \
@@ -311,7 +313,7 @@ endef
 define Package/libffmpeg-audio-dec
 $(call Package/libffmpeg/Default)
  TITLE+= (audio)
- DEPENDS+= +libspeex +libopus
+ DEPENDS+= +libspeex
  VARIANT:=audio-dec
 endef
 
@@ -526,7 +528,6 @@ ifeq ($(BUILD_VARIANT),mini)
 	--disable-everything \
 	$(call FFMPEG_ENABLE,decoder,$(FFMPEG_MINI_DECODERS)) \
 	$(call FFMPEG_ENABLE,demuxer,$(FFMPEG_MINI_DEMUXERS)) \
-	$(call FFMPEG_ENABLE,parser,$(FFMPEG_MINI_PARSERS)) \
 	$(call FFMPEG_ENABLE,protocol,$(FFMPEG_MINI_PROTOCOLS)) \
 
 endif


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: mips/ar71xx, openwrt r49395
Run tested: mips/ar71xx, openwrt r49395

Tests: rebuilt minidlna library with opus, hevc, vc1, and vorbis media (among others).

Description:

Update ffmpeg to 2.8.8.

Adds HEVC, Opus, VC-1 and Vorbis to custom's minidlna and -minidlna profiles. Removes raw aac, ac3 and h264 from minidlna profile.

Remove libopus from being selected by the -custom's audio-dec profile, and as a depend on -audio-dec. -audio-dec uses ffmpeg's internal Opus decoder, not the external library.

Don't select specific parsers in libffmpeg-mini profile. ffmpeg's configure script will select the parser if necessary. This change can probably be done to -audio-dec too, but I did not test that to submit a change there. If -audio-dec works, I would suggest ripping it out of -custom too.
