### PR TITLE
netdata: update to 1.3.0 and use procd init

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,16 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.2.0
+PKG_VERSION:=1.3.0
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Sebastian Careba <nitroshift@yahoo.com>
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/firehol/netdata
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=bb4aa949f5ac825253d8adc6070661299abc1c3b
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://firehol.org/download/netdata/releases/v$(PKG_VERSION)
+PKG_SOURCE_VERSION:=f8ed1eac764386b839fbd2db0f41e664
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 PKG_INSTALL:=1

--- a/admin/netdata/files/netdata.init
+++ b/admin/netdata/files/netdata.init
@@ -1,11 +1,21 @@
 #!/bin/sh /etc/rc.common
 
 START=99
+USE_PROCD=1
 
-start() {
-	service_start /usr/sbin/netdata
-}
+APPBINARY=/usr/sbin/netdata
+CONFIGFILE=/etc/netdata/netdata.conf
 
-stop() {
-	service_stop /usr/sbin/netdata
-}
+	start_service() {
+	mkdir -m 0755 -p /var/cache/netdata
+	chown nobody /var/cache/netdata
+	mkdir -m 0755 -p /var/lib/netdata
+	chown nobody /var/lib/netdata
+	mkdir -m 0755 -p /var/log/netdata
+	chown nobody /var/log/netdata
+	procd_open_instance
+	procd_set_param command $APPBINARY -nd -c $CONFIGFILE
+	procd_set_param file $CONFIGFILE
+	procd_set_param respawn
+	procd_close_instance
+	}


### PR DESCRIPTION
Maintainer: @nitroshift
Compile tested: ar71xx, TP-Link TL-WDR3600, LEDE r1684
Run tested: ar71xx, TP-Link TL-WDR3600, LEDE r1684

Description:

Update to 1.3.0
Change init.d script to use procd
Use release binary instead of git

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>