### PR TITLE
libs/avahi: add netifd proto handler for avahi-autoipd

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -357,6 +357,8 @@ define Package/avahi-autoipd/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/etc/avahi/avahi-autoipd.action $(1)/etc/avahi/
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/avahi-autoipd $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/lib/netifd/proto
+	$(INSTALL_BIN) ./files/lib/netifd/proto/autoip.sh $(1)/lib/netifd/proto
 endef
 
 define Package/avahi-daemon/install

--- a/libs/avahi/files/lib/netifd/proto/autoip.sh
+++ b/libs/avahi/files/lib/netifd/proto/autoip.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. ../netifd-proto.sh
+init_proto "$@"
+
+proto_autoip_setup() {
+	local config="$1"
+	local iface="$2"
+
+	proto_export "INTERFACE=$config"
+	proto_run_command "$config" avahi-autoipd $iface
+}
+
+proto_autoip_teardown() {
+	local interface="$1"
+	proto_kill_command "$interface"
+}
+
+add_protocol autoip


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: mpc85xx, OpenWRT (newer than CC, but not trunk)
Run tested: OpenWRT (newer than CC, but not trunk)

Description:

With this change, you can now specify in '/etc/config/network'

```
config interface 'eth1_autoip'
	option ifname	'eth1'
	option proto	'autoip'
```

And netifd would handle the rest of the logic/setup.

Signed-off-by: Claudiu Brasovean <cbrasho@gmail.com>