### PR TITLE
bash: enable non-detectable features; unify indents

### DIFF
--- a/utils/bash/Makefile
+++ b/utils/bash/Makefile
@@ -39,17 +39,11 @@ define Package/bash/description
   incorporates useful features from the Korn and C shells (ksh and csh).
 endef
 
-CONFIGURE_VARS += \
+CONFIGURE_ARGS += \
 	bash_cv_job_control_missing=present \
-	bash_cv_sys_named_pipes=present
-
-define Build/Configure
-	$(call Build/Configure/Default, \
-		--without-bash-malloc \
-		--bindir=/bin \
-	)
-endef
-
+	bash_cv_sys_named_pipes=present \
+	--without-bash-malloc \
+	--bindir=/bin
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR)/builtins LDFLAGS_FOR_BUILD= mkbuiltins

--- a/utils/bash/Makefile
+++ b/utils/bash/Makefile
@@ -11,7 +11,7 @@ BASE_VERSION:=4.3
 
 PKG_NAME:=bash
 PKG_VERSION:=$(BASE_VERSION).42
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(BASE_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/bash
@@ -39,11 +39,14 @@ define Package/bash/description
   incorporates useful features from the Korn and C shells (ksh and csh).
 endef
 
+CONFIGURE_VARS += \
+	bash_cv_job_control_missing=present \
+	bash_cv_sys_named_pipes=present
 
 define Build/Configure
 	$(call Build/Configure/Default, \
 		--without-bash-malloc \
-                --bindir=/bin \
+		--bindir=/bin \
 	)
 endef
 


### PR DESCRIPTION
Maintainer: @Naoir 
Compile tested: Turris OS 3.2 (fork of OpenWrt CC), mvebu - Turris Omnia
Run tested: mvebu - Turris Omnia

Description:

Some of the features can't be detected when cross-compiling Bash. Two of the most missed (at least for me) are named pipes and job control. This patch enables these two through configure vars.
