### PR TITLE
ddns-scripts: fix reporting wrong version

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.5
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -21,7 +21,7 @@
 . /lib/functions/network.sh
 
 # GLOBAL VARIABLES #
-VERSION="2.7.4"
+VERSION="2.7.5"
 SECTION_ID=""		# hold config's section name
 VERBOSE_MODE=1		# default mode is log to console, but easily changed with parameter
 


### PR DESCRIPTION
Maintainer: me
Compile tested: -
Run tested: x86 / WNDR3800

Description:
Fix reporting wrong version (needed by luci-app-ddns)

Signed-off-by: Christian Schoenebeck <christian.schoenebeck@gmail.com>