### PR TITLE
netdata: disable atomic instructions

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -22,6 +22,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
 
+TARGET_CFLAGS+= -DNETDATA_NO_ATOMIC_INSTRUCTIONS=1
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/netdata


### PR DESCRIPTION
Maintainer: @nitroshift 
Compile tested: powerpc_464fp, Netgear Centria N900 WNDR4700/WNDR4720, LEDE 875cddd94cea002fae1b7eeb20ef2098410c44c1
Run tested: N/A

Description:

The auto detection is a bit dodgy and sometimes fails to identify support, disable atomic instruction for now.

Fixes #3251

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>