### PR TITLE
adb: new package (Android Debug Bridge)

### DIFF
--- a/utils/adb/Makefile
+++ b/utils/adb/Makefile
@@ -1,0 +1,61 @@
+include $(TOPDIR)/rules.mk
+#Based on adb package from AUR https://aur.archlinux.org/packages/adb/ , reused adbMakefile
+
+PKG_NAME:=adb
+PKG_VERSION:=android.5.0.2_r1
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://android.googlesource.com/platform/system/core
+PKG_SOURCE_VERSION:=6fe92d1a3fb17545d82d020a3c995f32e6b71f9d
+# PKG_SOURCE_SUBDIR specifies where repo is cloned
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_SOURCE_VERSION)
+PKG_SOURCE:=$(PKG_SOURCE_SUBDIR).tar.gz
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+PKG_MAINTAINER:=Swift Geek <swiftgeek at gmail>
+
+include $(INCLUDE_DIR)/package.mk
+
+ifeq ($(CONFIG_BIG_ENDIAN),y)
+TARGET_CFLAGS+= -DHAVE_BIG_ENDIAN=1
+beinfo: $(info *** Big endian detected, look for -DHAVE_BIG_ENDIAN=1 ***)
+endif
+TARGET_CFLAGS+= -D_GNU_SOURCE
+
+define Package/adb
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=Android Debug Bridge CLI tool
+	URL:=http://tools.android.com/
+	DEPENDS:=+zlib +libopenssl +libpthread
+endef
+
+define Package/bridge/description
+	Android Debug Bridge (adb) is a versatile command line tool that lets you communicate with an emulator instance or connected Android-powered device.
+endef
+
+# Add Makefile from AUR
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(CP) ./adbMakefile $(PKG_BUILD_DIR)/adb/Makefile
+endef
+
+# Nothing just to be sure
+define Build/Configure
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR)/adb/ \
+		$(TARGET_CONFIGURE_OPTS) \
+		TARGET=Linux \
+		CFLAGS="$(TARGET_CFLAGS)" \
+		LDFLAGS="$(TARGET_LDFLAGS)"
+	$(STRIP) $(PKG_BUILD_DIR)/adb/adb
+endef
+
+define Package/adb/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/adb/adb $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,adb))

--- a/utils/adb/adbMakefile
+++ b/utils/adb/adbMakefile
@@ -1,0 +1,42 @@
+SRCS+= adb.c
+SRCS+= adb_auth_host.c
+SRCS+= adb_client.c
+SRCS+= commandline.c
+SRCS+= console.c
+SRCS+= fdevent.c
+SRCS+= file_sync_client.c
+SRCS+= get_my_path_linux.c
+SRCS+= services.c
+SRCS+= sockets.c
+SRCS+= transport.c
+SRCS+= transport_local.c
+SRCS+= transport_usb.c
+SRCS+= usb_linux.c
+
+VPATH+= ../libcutils
+SRCS+= load_file.c
+SRCS+= socket_inaddr_any_server.c
+SRCS+= socket_local_client.c
+SRCS+= socket_local_server.c
+SRCS+= socket_loopback_client.c
+SRCS+= socket_loopback_server.c
+SRCS+= socket_network_client.c
+
+VPATH+= ../libzipfile
+SRCS+= centraldir.c
+SRCS+= zipfile.c
+
+CPPFLAGS+= -DADB_HOST=1
+CPPFLAGS+= -DHAVE_FORKEXEC=1
+CPPFLAGS+= -I.
+CPPFLAGS+= -I../include
+CPPFLAGS+= -D_FILE_OFFSET_BITS=64
+
+LIBS+= -lcrypto -lpthread -lz
+
+OBJS= $(SRCS:.c=.o)
+
+all: adb
+
+adb: $(OBJS)
+	$(CC) -o $@ $(LDFLAGS) $(OBJS) $(LIBS)


### PR DESCRIPTION
Maintainer: Swift Geek swiftgeek@gmail.com
Compile tested: (ramips, MR200, LEDE HEAD, r1658)
Run tested: (ramips, MR200, LEDE HEAD, r1658)

Description: Android Debug Bridge (adb) is a versatile command line tool that lets you communicate with an emulator instance or connected Android-powered device.

Add adb package

Signed-off-by: Henryk Heisig hyniu@o2.pl
