### PR TITLE
netdata: disable atomic instructions

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Sebastian Careba <nitroshift@yahoo.com>
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
@@ -21,6 +21,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
+
+TARGET_CFLAGS+= -DNETDATA_NO_ATOMIC_INSTRUCTIONS=1
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Maintainer: @nitroshift
Compile tested: powerpc_464fp, Netgear Centria N900 WNDR4700/WNDR4720, LEDE 875cddd94cea002fae1b7eeb20ef2098410c44c1
Run tested: N/A

Description:

The auto detection is a bit dodgy and sometimes fails to identify support, disable atomic instruction for now.

Fixes #3251 and bumps PKG_RELEASE

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>