### PR TITLE
utils/cryptsetup: Add convenience scripts and uci support

### DIFF
--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptsetup
 PKG_VERSION:=1.7.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0+ LGPL-2.1+
 PKG_LICENSE_FILES:=COPYING COPYING.LGPL
 
@@ -28,7 +28,7 @@ define Package/cryptsetup/Default
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Cryptsetup
-  DEPENDS:=+libblkid +libuuid +libpopt +lvm2 +libdevmapper +@KERNEL_DIRECT_IO
+  DEPENDS:=+libblkid +libuuid +libpopt +libdevmapper +@KERNEL_DIRECT_IO
   URL:=http://code.google.com/p/cryptsetup/
 endef
 
@@ -44,6 +44,12 @@ $(call Package/cryptsetup/Default)
   DEPENDS+=+libopenssl
   VARIANT:=openssl
 endef
+
+define Package/cryptsetup/conffiles
+/etc/config/crypttab
+endef
+
+Package/cryptsetup-openssl/conffiles=$(call Package/cryptsetup/conffiles)
 
 define Package/cryptsetup/Default/description
 	Cryptsetup-luks
@@ -70,6 +76,12 @@ define Package/cryptsetup/install
 	$(CP) $(PKG_BUILD_DIR)/src/.libs/cryptsetup $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_BUILD_DIR)/lib/.libs/libcryptsetup.so* $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/etc/init.d $(1)/etc/config
+	$(INSTALL_BIN) ./files/cryptstart $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/cryptsetup.init $(1)/etc/init.d/cryptsetup
+	$(INSTALL_BIN) ./files/cryptstop $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/cryptstart-varlog $(1)/usr/sbin/
+	$(INSTALL_CONF) ./files/crypttab.config $(1)/etc/config/crypttab
 endef
 
 Package/cryptsetup-openssl/install = $(Package/cryptsetup/install)

--- a/utils/cryptsetup/files/cryptsetup.init
+++ b/utils/cryptsetup/files/cryptsetup.init
@@ -1,0 +1,27 @@
+#!/bin/sh /etc/rc.common
+
+START=00
+STOP=90
+
+disable_initscript() {
+	local cfg="$1"
+	local name disable
+	config_get name "$cfg" name
+	config_get_bool disable "$cfg" disable 0
+	if [ -n "$name" ] && [ -x "/etc/init.d/$name" ] && [ "$disable" -gt 0 ] && /etc/init.d/$name enabled; then
+		/etc/init.d/$name stop || true
+		/etc/init.d/$name disable
+	fi
+}
+
+start() {
+	if [ -x /usr/sbin/cryptstart ] && [ -r /etc/config/crypttab ]; then
+		config_load crypttab
+		config_foreach disable_initscript initscript
+	fi
+}
+
+stop() {
+	/usr/sbin/cryptstop
+}
+

--- a/utils/cryptsetup/files/cryptstart
+++ b/utils/cryptsetup/files/cryptstart
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+SPECIFICDISK="$1"
+PASSPHRASESTDIN="$2"
+SKIPFSTAB="$3"
+
+NOFSTAB=0
+FOUNDDISK=0
+
+if [ ! -e /etc/config/fstab ] || [ ! -s /etc/config/fstab ]; then
+	if [ -z "$SKIPFSTAB" ]; then
+		NOFSTAB=1
+	fi
+fi
+
+cryptdisk_open() {
+	local cfg="$1"
+	local cryptdev devtype device pre_mount_command mount_command
+
+	config_get device "$cfg" device 
+	config_get devtype "$cfg" devtype luks
+	cryptdev="$(echo "$(basename "$device")"|tr '\- :,' '_')_crypt"
+
+	if [ -n "$device" ] && [ -e "$device" ]; then
+		echo "Opening device $device"
+		/usr/sbin/cryptsetup open ${PASSPHRASESTDIN:+--key-file -} --type "${devtype}" "${device}" "$cryptdev" || return
+		sleep 5
+		FOUNDDISK=1
+	else
+		return
+	fi
+
+	config_get pre_mount_command "$cfg" pre_mount_command "[ -x /etc/init.d/lvm2 ] && /etc/init.d/lvm2 start; sleep 5"
+	eval "$pre_mount_command"
+
+	# For the case fstab doesn't exist we presume the user would like to have their
+	# disk mounted and do so (unless user disabled this when calling cryptstart)
+	if [ "$NOFSTAB" = "1" ]; then
+		block detect |sed 's/ enabled 0/ enabled 1/' >/etc/config/fstab	
+	fi
+
+	config_get mount_command "$cfg" mount_command 'block mount'
+	eval "$mount_command"
+
+	sleep 5
+}
+
+run_command() {
+	local cfg="$1"
+	local command
+	local options
+	config_get command "$cfg" command
+	config_get_bool do_start "$cfg" do_start 1
+	config_get start_options "$cfg" start_options
+	if [ -n "$command" ] && [ -x "$command" ] && [ "$do_start" = "1" ]; then
+		eval "$command" "$start_options"
+	fi
+}
+
+initscript_action() {
+	local cfg="$1"
+	local action="$2"
+	local name do_stop
+	config_get name "$cfg" name
+	config_get_bool restart "$cfg" restart 1
+	
+	if [ -n "$name" ] && [ -x "/etc/init.d/$name" ]; then
+		if [ "$restart" = "1" ] && ( [ "$action" = "stop" ] || ( [ "$action" = "start" ] && [ "$FOUNDDISK" = "1" ] ) ); then
+			/etc/init.d/$name "$action"
+		fi
+	fi
+}
+
+. /lib/functions.sh
+
+config_load crypttab
+config_foreach initscript_action initscript stop
+sleep 20
+
+if [ -z "$SPECIFICDISK" ]; then
+	config_foreach cryptdisk_open cryptdisk
+else
+	cryptdisk_open "$SPECIFICDISK"
+fi
+
+if [ "$FOUNDDISK" = "0" ]; then
+	config_foreach initscript_action initscript start
+	exit 1
+fi
+
+config_foreach run_command command
+config_foreach initscript_action initscript start
+

--- a/utils/cryptsetup/files/cryptstart-varlog
+++ b/utils/cryptsetup/files/cryptstart-varlog
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+ACTION="$1"
+
+. /lib/functions.sh
+
+initscript_action() {
+	local val="$1"
+	local action="$2"
+	
+	if [ -n "$val" ] && [ -x "/etc/init.d/$val" ]; then
+		/etc/init.d/"$val" "$action"
+	fi
+}
+
+set_datadir() {
+	local cfg="$1"
+	config_get src "$cfg" src
+	config_get dest "$cfg" dest
+	if [ -n "$dest" ] && [ -n "$src" ] && [ -e "$dest" ] && [ -e "$src" ]; then
+		case "$ACTION" in 
+	        stop)
+			config_list_foreach "$cfg" initscript initscript_action stop
+			/bin/umount "${src}" 2>/dev/null || true
+			sleep 10
+			config_list_foreach "$cfg" initscript initscript_action start
+			;;
+		start)
+			config_list_foreach "$cfg" initscript initscript_action stop
+			rm -rf "$dest""${src}".old
+			mkdir -p "$dest""${src}"
+			mkdir -p "$dest""${src}".old
+			mv "${src}"/* "$dest""${src}".old/
+			/bin/umount "${src}" 2>/dev/null || true
+			sleep 10
+			mount --bind "$dest""${src}" "${src}"
+			sleep 10
+			config_list_foreach "$cfg" initscript initscript_action start
+			mkdir -p "$dest""${src}"/precrypt
+			mv "$dest""${src}".old "$dest""${src}"/precrypt/"$(date -Iminutes|tr -d ':')"
+			;;
+		esac
+	fi
+}
+
+config_load crypttab
+config_foreach set_datadir datadir

--- a/utils/cryptsetup/files/cryptstop
+++ b/utils/cryptsetup/files/cryptstop
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+SPECIFICDISK="$1"
+
+. /lib/functions.sh
+
+cryptdisk_close() {
+	local cfg="$1"
+	local device
+	local cryptdev
+
+	config_get device "$cfg" device 
+	cryptdev="$(echo "$(basename "$device")"|tr '\- :,' '_')_crypt"
+
+	if [ -n "$device" ]; then
+		echo "Closing device $device"
+		/usr/sbin/cryptsetup close "${cryptdev}" || return
+	else
+		return
+	fi
+}
+
+stop_command() {
+	local cfg="$1"
+	local command
+	local options
+	local do_stop
+	config_get command "$cfg" command
+	config_get_bool do_stop "$cfg" do_stop 1
+	config_get stop_options "$cfg" stop_options
+	if [ -n "$command" ] && [ -x "$command" ] && [ "$do_stop" = "1" ]; then
+		eval "$command $stop_options"
+	fi
+}
+
+initscript_action() {
+	local cfg="$1"
+	local action="$2"
+	local name restart
+	config_get name "$cfg" name
+	config_get_bool restart "$cfg" restart 1
+	if [ -n "$name" ] && [ -x "/etc/init.d/$name" ]; then
+		if [ "$restart" = "1" ] && ( [ "$action" = "stop" ] || [ "$action" = "start" ] ); then
+			/etc/init.d/$name "$action"
+		fi
+	fi
+}
+
+unmount_command() {
+	local cfg="$1"
+	local command
+
+	config_get command "$cfg" command
+	eval "$command"
+}
+
+post_unmount_command() {
+	local cfg="$1"
+	local command
+	
+	config_get command "$cfg" command
+	eval "$command"
+}
+
+config_load crypttab
+config_foreach initscript_action initscript stop
+config_foreach stop_command command
+sleep 20
+config_foreach unmount_command unmount
+sleep 5
+config_foreach post_unmount_command post_unmount
+if [ -z "$SPECIFICDISK" ]; then
+	config_foreach cryptdisk_close cryptdisk
+else
+	cryptdisk_close "$SPECIFICDISK"
+fi
+config_foreach initscript_action initscript start

--- a/utils/cryptsetup/files/crypttab.config
+++ b/utils/cryptsetup/files/crypttab.config
@@ -1,0 +1,34 @@
+
+config cryptdisk
+#	option device /dev/base_device
+#	option pre_mount_command 'test -x /etc/init.d/lvm2 && /etc/init.d/lvm2 start; sleep 5'
+#	option mount_command 'block mount'
+
+# initscript sections have no effect unless cryptdisk is set or disable is set to 1 (true)
+config initscript
+	option name lxc-auto
+#	option disable 0
+#	option restart 1
+
+# Has no effect until dest supplied in datadir
+config command
+	option command /usr/sbin/cryptstart-varlog
+	option do_start 1
+	option do_stop 1
+	option stop_options stop
+	option start_options start
+
+#config unmount
+#	option command 'block umount'
+
+#config post_unmount
+#	option command "test -x /sbin/vgchange && vgchange -a n"
+
+# dest needs to be filled in with actual mount point
+#config datadir
+#	option dest '/path/to/crypted-mountpoint'
+#	option src '/orig/path/to/crypt'
+#	list initscript luci_statistics
+#	list initscript collectd 
+#	list initscript vnstat 
+


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: x86_64, LEDE trunk
Run tested: x86_64, LED trunk, used cryptsetup initscript (reboots) as well as manual cryptstart and cryptstop with and without using the various options (like redirecting output from e.g. collectd from /tmp/rrd to a crypted disk mount (when cryptdisk mounted, otherwise /tmp/rrd)), as well enabling or disabling initscripts that I wanted to use only when cryptdisk was mounted.

Description:

This commit adds a set of scripts that are provide an uci
configuration interface, and are are intended to achieve the
following goals:

*) Be completely optional
*) Provide easier command line use of crypted disks
*) Provide an interface suitable for providing a LuCI frontend
*) Take care of details such as keeping data such as collectd
   statistics and logs on crypted disk, by dealing with
   daemon-related issues and moving the storage location.
*) Allow for scripted/automated control
*) As much as possible any defaults my be overridden by user
   choice.

Signed-off-by: Daniel Dickinson lede@cshore.thecshore.com
