### PR TITLE
utils/gnupg: Add build of gpgv

### DIFF
--- a/utils/gnupg/Makefile
+++ b/utils/gnupg/Makefile
@@ -18,7 +18,7 @@ PKG_MD5SUM:=b7af897a041c03c8ad1c7c466b54d10d
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Nicolas Thill <nico@openwrt.org>
+PKG_MAINTAINER:=Daniel Dickinson <lede@cshore.thecshore.com>
 
 PKG_INSTALL:=1
 

--- a/utils/gnupg/Makefile
+++ b/utils/gnupg/Makefile
@@ -37,6 +37,11 @@ define Package/gnupg
   MENU:=1
 endef
 
+define Package/gpgv
+  $(call Package/gnupg/Default)
+  TITLE:=GnuPG signature verification only
+endef
+
 define Package/gnupg-utils
   $(call Package/gnupg/Default)
   DEPENDS:=gnupg +libcurl
@@ -48,6 +53,13 @@ define Package/gnupg/description
  It can be used to encrypt data and to create digital signatures.
  It includes an advanced key management facility and is compliant
  with the proposed OpenPGP Internet standard as described in RFC2440.
+ .
+ GnuPG does not use any patented algorithms so it cannot be compatible
+ with PGP2 because it uses IDEA (which is patented worldwide).
+endef
+
+define Package/gpgv/description
+ GPGv is a stripped down version of GnuPG that only checks signatures.
  .
  GnuPG does not use any patented algorithms so it cannot be compatible
  with PGP2 because it uses IDEA (which is patented worldwide).
@@ -78,6 +90,11 @@ define Package/gnupg/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gpg $(1)/usr/bin/
 endef
 
+define Package/gpgv/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gpgv $(1)/usr/bin/
+endef
+
 define Package/gnupg-utils/install
 	$(INSTALL_DIR) $(1)/usr/lib/gnupg
 	for file in gpgkeys_curl gpgkeys_hkp; do \
@@ -87,4 +104,5 @@ define Package/gnupg-utils/install
 endef
 
 $(eval $(call BuildPackage,gnupg))
+$(eval $(call BuildPackage,gpgv))
 $(eval $(call BuildPackage,gnupg-utils))

--- a/utils/gnupg/Makefile
+++ b/utils/gnupg/Makefile
@@ -8,13 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnupg
-PKG_VERSION:=1.4.20
-PKG_RELEASE:=2
+PKG_VERSION:=1.4.21
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=ftp://ftp.franken.de/pub/crypt/mirror/ftp.gnupg.org/gcrypt/gnupg \
 	ftp://ftp.gnupg.org/gcrypt/gnupg
-PKG_MD5SUM:=b7af897a041c03c8ad1c7c466b54d10d
+PKG_MD5SUM:=9bdeabf3c0f87ff21cb3f9216efdd01d
+PKG_HASH:=6b47a3100c857dcab3c60e6152e56a997f2c7862c1b8b2b25adf3884a1ae2276
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: x86_64, LEDE trunk
Run tested: x86_64, LEDE trunk, debootstrap of ubuntu with ubuntu keyring (which uses gpgv)

Description:

gpgv is a stripped down gnupg useful for only verifying signatures.
Having this package can save space when all you need is signature
verification.

Signed-off-by: Daniel Dickinson lede@cshore.thecshore.com
