### PR TITLE
boost: Package Version Update -> 1.62.0

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -40,7 +40,7 @@ define Package/boost/Default
     CATEGORY:=Libraries
     TITLE:=Boost C++ source library
     URL:=http://www.boost.org
-    DEPENDS:=+libstdcpp +libpthread +librt
+    #DEPENDS:=+libstdcpp +libpthread +librt
 endef
 
 define Package/boost/description/Default
@@ -234,7 +234,7 @@ define Package/boost/config
         config boost-libs-all
             depends on @BUILD_NLS
             depends on !GCC_VERSION_4_8
-            bool "Include all Boost libraries."
+            bool "Include all Boost libraries. $(PYTHON3_VERSION)"
             select PACKAGE_boost-libs
             select boost-test-pkg
             select boost-coroutine2
@@ -305,17 +305,20 @@ define DefineBoostLibrary
 endef
 
 
-$(eval $(call DefineBoostLibrary,atomic,system,))
+
+
+
+$(eval $(call DefineBoostLibrary,atomic,,))
 $(eval $(call DefineBoostLibrary,chrono,system,))
 $(eval $(call DefineBoostLibrary,container,,))
-$(eval $(call DefineBoostLibrary,context,chrono system thread,))
+$(eval $(call DefineBoostLibrary,context,system thread chrono,))
 $(eval $(call DefineBoostLibrary,coroutine,system chrono context thread,))
 $(eval $(call DefineBoostLibrary,date_time,,))
 #$(eval $(call DefineBoostLibrary,exception,,))
 $(eval $(call DefineBoostLibrary,filesystem,system,))
 $(eval $(call DefineBoostLibrary,fiber,context,))
 $(eval $(call DefineBoostLibrary,graph,regex,))
-$(eval $(call DefineBoostLibrary,iostreams,,+PACKAGE_boost-iostreams:zlib))
+$(eval $(call DefineBoostLibrary,iostreams,,+PACKAGE_boost-iostreams:zlib +PACKAGE_boost-iostreams:libbz2))
 $(eval $(call DefineBoostLibrary,locale,system, $(ICONV_DEPENDS)))
 $(eval $(call DefineBoostLibrary,log,system chrono date_time thread filesystem regex,))
 $(eval $(call DefineBoostLibrary,math,,))
@@ -328,7 +331,7 @@ $(eval $(call DefineBoostLibrary,regex,,))
 $(eval $(call DefineBoostLibrary,serialization,,))
 $(eval $(call DefineBoostLibrary,signals,,))
 $(eval $(call DefineBoostLibrary,system,,))
-$(eval $(call DefineBoostLibrary,thread,system chrono atomic,))
+$(eval $(call DefineBoostLibrary,thread, chrono atomic date_time,))
 $(eval $(call DefineBoostLibrary,timer,chrono))
 $(eval $(call DefineBoostLibrary,wave,date_time thread filesystem,))
 
@@ -381,6 +384,7 @@ define Build/Compile
 			$(PKG_JOBS) \
 			--ignore-site-config \
 			--toolset=gcc-$(ARCH) abi=$(BOOST_ABI) \
+			$(if $(CONFIG_PACKAGE_boost-contex), valgrind=on,) \
 			$(if $(CONFIG_boost-variant-release), variant=release,) \
 			$(if $(CONFIG_boost-variant-debug), variant=debug,) \
 			$(if $(CONFIG_boost-variant-profile), variant=profile,) \

--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -40,7 +40,7 @@ define Package/boost/Default
     CATEGORY:=Libraries
     TITLE:=Boost C++ source library
     URL:=http://www.boost.org
-    DEPENDS:=+libstdcpp +librt +libpthread
+    DEPENDS:=+libstdcpp +libpthread +librt
 endef
 
 define Package/boost/description/Default
@@ -335,7 +335,7 @@ $(eval $(call DefineBoostLibrary,wave,date_time thread filesystem,))
 
 define Host/Compile
 	# b2 does not provide a configure-script nor a Makefile
-	#( cd $(HOST_BUILD_DIR)/tools/build/src/engine ; ./build.sh gcc )
+	( cd $(HOST_BUILD_DIR)/tools/build/src/engine ; ./build.sh gcc )
 endef
 
 CONFIGURE_PREFIX:=$(PKG_INSTALL_DIR)

--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -29,7 +29,7 @@ PKG_LICENSE:=Boost Software License <http://www.boost.org/users/license.html>
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>
 
 PKG_BUILD_DEPENDS += boost/host 
-PKG_BUILD_PARALLEL:=0
+#PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
 include $(INCLUDE_DIR)/package.mk
@@ -348,7 +348,7 @@ TARGET_CFLAGS += \
 	$(if $(CONFIG_SOFT_FLOAT),-DBOOST_NO_FENV_H) -fPIC
 
 TARGET_CXXFLAGS += \
-	$(if $(CONFIG_GCC_VERSION_4_8), -std=c++11, -std=c++14)
+	$(if $(CONFIG_GCC_VERSION_4_8),-std=c++11,-std=c++14)
 
 
 ifneq ($(findstring mips,$(ARCH)),)
@@ -369,7 +369,7 @@ comma := ,
 define Build/Compile
 	$(info Selected Boost API $(BOOST_ABI) for architecture $(ARCH) and cpu $(CPU_TYPE) $(CPU_SUBTYPE))
 	( cd $(PKG_BUILD_DIR) ; \
-		echo "using gcc : $(ARCH) : $(GNU_TARGET_NAME)-gcc : <compileflags>\"$(TARGET_CFLAGS)\" <cxxflags>\"$(TARGET_CXXFLAGS)\" <linkflags>\"$(TARGET_LDFLAGS)\" ;" > tools/build/src/user-config.jam ; \
+		echo "using gcc : $(ARCH) : $(GNU_TARGET_NAME)-g++ : <compileflags>\"$(TARGET_CFLAGS)\" <cxxflags>\"$(TARGET_CXXFLAGS)\" <linkflags>\"$(TARGET_LDFLAGS)\" ;" > tools/build/src/user-config.jam ; \
 		$(if $(CONFIG_PACKAGE_boost-python3), \
 			echo "using python : 3.5 : $(STAGING_DIR_ROOT)/usr/bin/python3 : $(STAGING_DIR)/usr/include/python3.5/ ;" >> \
 				tools/build/src/user-config.jam; \
@@ -380,9 +380,9 @@ define Build/Compile
 		) \
 		b2 \
 			$(CONFIGURE_ARGS) \
+			$(PKG_JOBS) \
 			--ignore-site-config \
 			--toolset=gcc-$(ARCH) abi=$(BOOST_ABI) \
-			--disable-long-double \
 			$(if $(CONFIG_boost-variant-release), variant=release,) \
 			$(if $(CONFIG_boost-variant-debug), variant=debug,) \
 			$(if $(CONFIG_boost-variant-profile), variant=profile,) \

--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -29,7 +29,6 @@ PKG_LICENSE:=Boost Software License <http://www.boost.org/users/license.html>
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>
 
 PKG_BUILD_DEPENDS += boost/host 
-#PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
 include $(INCLUDE_DIR)/package.mk
@@ -41,7 +40,7 @@ define Package/boost/Default
     CATEGORY:=Libraries
     TITLE:=Boost C++ source library
     URL:=http://www.boost.org
-    DEPENDS:=+libstdcpp +libpthread +librt
+    DEPENDS:=+libstdcpp +librt +libpthread
 endef
 
 define Package/boost/description/Default
@@ -336,11 +335,10 @@ $(eval $(call DefineBoostLibrary,wave,date_time thread filesystem,))
 
 define Host/Compile
 	# b2 does not provide a configure-script nor a Makefile
-	( cd $(HOST_BUILD_DIR)/tools/build/src/engine ; ./build.sh gcc )
+	#( cd $(HOST_BUILD_DIR)/tools/build/src/engine ; ./build.sh gcc )
 endef
 
 CONFIGURE_PREFIX:=$(PKG_INSTALL_DIR)
-TARGET_LDFLAGS += -pthread -lrt
 
 TARGET_CFLAGS += \
 	$(if $(CONFIG_PACKAGE_boost-python), -I$(STAGING_DIR)/usr/include/python2.7/) \
@@ -369,7 +367,7 @@ comma := ,
 define Build/Compile
 	$(info Selected Boost API $(BOOST_ABI) for architecture $(ARCH) and cpu $(CPU_TYPE) $(CPU_SUBTYPE))
 	( cd $(PKG_BUILD_DIR) ; \
-		echo "using gcc : $(ARCH) : $(GNU_TARGET_NAME)-g++ : <compileflags>\"$(TARGET_CFLAGS)\" <cxxflags>\"$(TARGET_CXXFLAGS)\" <linkflags>\"$(TARGET_LDFLAGS)\" ;" > tools/build/src/user-config.jam ; \
+		echo "using gcc : $(ARCH) : $(GNU_TARGET_NAME)-gcc : <compileflags>\"$(TARGET_CFLAGS)\" <cxxflags>\"$(TARGET_CXXFLAGS)\" <linkflags>\"$(TARGET_LDFLAGS)\" ;" > tools/build/src/user-config.jam ; \
 		$(if $(CONFIG_PACKAGE_boost-python3), \
 			echo "using python : 3.5 : $(STAGING_DIR_ROOT)/usr/bin/python3 : $(STAGING_DIR)/usr/include/python3.5/ ;" >> \
 				tools/build/src/user-config.jam; \

--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 OpenWrt.org
+# Copyright (C) 2015-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -16,14 +16,15 @@ include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/target.mk 
 
 PKG_NAME:=boost
-PKG_VERSION:=1_61_0
+PKG_VERSION:=1.62.0
+PKG_SOURCE_VERSION:=1_62_0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/boost
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)_$(PKG_VERSION)
-HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)_$(PKG_VERSION)
-PKG_MD5SUM:=874805ba2e2ee415b1877ef3297bf8ad
+PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://sourceforge.net/projects/boost/files/boost/$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)_$(PKG_SOURCE_VERSION)
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)_$(PKG_SOURCE_VERSION)
+PKG_MD5SUM:=36c96b0f6155c98404091d8ceb48319a28279ca0333fba1ad8611eb90afb2ca0
 PKG_LICENSE:=Boost Software License <http://www.boost.org/users/license.html>
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>
 
@@ -36,34 +37,47 @@ include $(INCLUDE_DIR)/host-build.mk
 
 
 define Package/boost/Default
-  SECTION:=libs
-  CATEGORY:=Libraries
-  TITLE:=Boost C++ source library
-  URL:=http://www.boost.org
-  DEPENDS:=+libstdcpp +libpthread +librt
+    SECTION:=libs
+    CATEGORY:=Libraries
+    TITLE:=Boost C++ source library
+    URL:=http://www.boost.org
+    DEPENDS:=+libstdcpp +libpthread +librt
 endef
 
 define Package/boost/description/Default
-  true
+    true
 endef
 
 define Package/boost/description
-This package provides the Boost v1.61 libraries.
+This package provides the Boost v1.62 libraries.
 Boost is a set of free, peer-reviewed, portable C++ source libraries.
+
+-----------------------------------------------------------------------------
+|                                Warning                                    |
+| In order to build all of the Boost Libraries, it is necessary             |
+| to use, at least, GCC version 5 (C++14 support) and, it is necessary to   |
+| compile the kernel with Full Language Support.                            |
+| Without these requirerements, the following libs will not be available:   |
+| - Boost.Locale                                                            |
+| - Boost.Coroutine2                                                        |
+| - Boost.Fiber                                                             |
+-----------------------------------------------------------------------------
+
 This package provides the following run-time libraries:
  - atomic
  - chrono
  - container
  - context
- - coroutine
- - - coroutine2 (requires GCC v5 and up)
+ - coroutine (Deprecated - use Coroutine2)
+ - - coroutine2 (Requires GCC v5 and up)
  - date_time
  - exception
  - filesystem
+ - fiber (Requires GCC v5 and up)
  - graph
  - - graph-parallel
  - iostreams
- - locale (requires kernel being compiled with full language support)
+ - locale (Requires kernel being compiled with full language support)
  - log
  - math
  - program_options
@@ -77,171 +91,183 @@ This package provides the following run-time libraries:
  - thread
  - timer
  - wave
- There are many more header-only libraries supported by Boost.
- See more at http://www.boost.org/doc/libs/1_61_0/
+
+There are many more header-only libraries supported by Boost.
+See more at http://www.boost.org/doc/libs/1_62_0/
 endef
 
 BOOST_LIBS =
 
 define Package/boost-libs
 $(call Package/boost/Default)
-  TITLE+= (all libs)
-  DEPENDS+= $(BOOST_DEPENDS)
-  HIDDEN:=1
+    TITLE+= (all libs)
+    DEPENDS+= $(BOOST_DEPENDS)
+    HIDDEN:=1
 endef
 
 define Package/boost-libs/description
-$(call Package/boost/description/Default)
- .
- This meta package contains only dependencies to the other libraries from
- the boost libraries collection.
+    $(call Package/boost/description/Default)
+    .
+    This meta package contains only dependencies to the other libraries from
+    the boost libraries collection.
 endef
 
 # Create a meta-package of dependent libraries (for ALL)
 define Package/boost-libs/install
-  true
+    true
 endef
 
 define Package/boost/install
-  true
+    true
 endef
 
 
 define Package/boost
-  $(call Package/boost/Default)
-  TITLE+= packages
-  DEPENDS:=+ALL:boost-libs +ALL:boost-test
+    $(call Package/boost/Default)
+    TITLE+= packages
+    DEPENDS:=+ALL:boost-libs
 endef
+
 
 define Package/boost/config
     menu "Select Boost Options"
-      depends on PACKAGE_boost
-      	comment "Boost compilation options."
+        depends on PACKAGE_boost
+        comment "Boost compilation options."
 
-      	choice
-      		prompt "Compile Boost libraries."
-      			default boost-static-and-shared-libs
-      			help
-      				Choose which version to compile.
-      				 -> Shared:
-      				    - Only Shared libs will be compiled.
-      				 -> Static:
-      				    - Only Static libs will be compiled.
-      				 -> Both:
-      				    - Both Static and Shared libs will be compiled.		    
+        choice
+            prompt "Compile Boost libraries."
+                default boost-static-and-shared-libs
+                help
+                    Choose which version to compile.
+                     -> Shared:
+                        - Only Shared libs will be compiled.
+                     -> Static:
+                        - Only Static libs will be compiled.
+                     -> Both:
+                        - Both Static and Shared libs will be compiled.
 
-		    config boost-shared-libs
-		    	bool "Shared"
-			
-			config boost-static-libs
-		    	bool "Static"		    	
-			
-			config boost-static-and-shared-libs
-		    	bool "Both"		    	
-	    endchoice
+            config boost-shared-libs
+                bool "Shared"
+            
+            config boost-static-libs
+                bool "Static"
+            
+            config boost-static-and-shared-libs
+                bool "Both"
+        endchoice
 
-      	choice
-      		prompt "Selects Boost Runtime linkage."
-      		default boost-runtime-shared
-      		help
-      			Choose which C and C++ runtimes to use:
-      			 -> Use Shared runtimes.
-      			 -> Use Static runtimes.
-      			    - Not available if Shared libs are to be built.
-      			 -> Use both runtimes.
-      			    - Not available if Shared libs are to be built.
-      			    - Two separate versions of Boost are built, linking each to a different runtime. 
-      			    - This option requires "Use tagged names" option to be active.
+        choice
+            prompt "Selects Boost Runtime linkage."
+            default boost-runtime-shared
+            help
+                Choose which C and C++ runtimes to use:
+                -> Use Shared runtimes.
+                -> Use Static runtimes.
+                    - Not available if Shared libs are to be built.
+                -> Use both runtimes.
+                    - Not available if Shared libs are to be built.
+                    - Two separate versions of Boost are built, linking each to a different runtime. 
+                    - This option requires "Use tagged names" option to be active.
 
-		    config boost-runtime-shared
-		    	bool "Shared"
+            config boost-runtime-shared
+                bool "Shared"
 
-		    config boost-runtime-static
-		    	depends on @(!boost-shared-libs&&!boost-static-and-shared-libs)
-		    	bool "Static"		    	
-		    
-		    config boost-runtime-static-and-shared
-		    	depends on @(boost-use-name-tags&&!boost-shared-libs&&!boost-static-and-shared-libs)
-		    	bool "Both"
-	    endchoice
+            config boost-runtime-static
+                depends on @(!boost-shared-libs&&!boost-static-and-shared-libs)
+                bool "Static"
+            
+            config boost-runtime-static-and-shared
+                depends on @(boost-use-name-tags&&!boost-shared-libs&&!boost-static-and-shared-libs)
+                bool "Both"
+        endchoice
 
-      	choice
-      		prompt "Select a Variant."
-      		default boost-variant-release
-      		help
-      			Chooses which boost variant should be selected:
-      			-> Release: Optimizes Boost for release.
-      			   - Optimization: Speed;  Debug Symbols: Off; Inlining: Full; Runtime Debugging: Off.
-      			-> Debug: 
-      			   - Optimization: Off; Debug Symbols: On; Inlining: Off; Runtime Debugging: On.
-      			-> Profile:
-      			   - Profiling: On;  Debug Symbols: On.
+        choice
+            prompt "Select a Variant."
+            default boost-variant-release
+            help
+                Chooses which boost variant should be selected:
+                -> Release: Optimizes Boost for release.
+                    - Optimization: Speed;  Debug Symbols: Off; Inlining: Full; Runtime Debugging: Off.
+                -> Debug: 
+                    - Optimization: Off; Debug Symbols: On; Inlining: Off; Runtime Debugging: On.
+                -> Profile:
+                    - Profiling: On;  Debug Symbols: On.
 
-      		config boost-variant-release
-      			bool "Release"
+            config boost-variant-release
+                bool "Release"
 
-      		config boost-variant-debug
-      			bool "Debug"
-      				
-      		config boost-variant-profile
-      			bool "Profile"
-      	endchoice	    	
+            config boost-variant-debug
+                bool "Debug"
+                    
+            config boost-variant-profile
+                bool "Profile"
+        endchoice
 
-	    config boost-use-name-tags
-	    	bool "Use tagged names."
-	    	help 
-	    		Add name tags the lib files, to diferentiate each library version:
-	    		  "-mt" for multi-threading.
-	    		  "-d" for debugging.
-	    		  "-s" for runtime static link".
-	    		Might break compatibility with libraries that expect boost libs with default names.
-	    	default n	    	
+        config boost-use-name-tags
+            bool "Use tagged names."
+            help 
+                Add name tags the lib files, to diferentiate each library version:
+                  "-mt" for multi-threading.
+                  "-d" for debugging.
+                  "-s" for runtime static link.
+                Might break compatibility with libraries that expect boost libs with default names.
+            default n
 
-	    config boost-single-thread
-	    	depends on @boost-use-name-tags
-	    	bool "Single thread Support."
-	    	help 
-	    		Compile Boost libraries in single-thread mode.
-	    	default n
-			    
-	    config boost-build-type-complete
-	    	depends on @boost-use-name-tags
-	    	bool "Complete Boost Build."
-	    	help 
-	    		Builds both release and debug libs. It will take much longer to compile.
-	    	default n	    	
+        config boost-single-thread
+            depends on @boost-use-name-tags
+            bool "Single thread Support."
+            help 
+                Compile Boost libraries in single-thread mode.
+            default n
+
+        config boost-build-type-complete
+            depends on @boost-use-name-tags
+            bool "Complete Boost Build."
+            help 
+                Builds both release and debug libs. It will take much longer to compile.
+            default n
     endmenu
 
     menu "Select Boost libraries"
-      depends on PACKAGE_boost
-		comment "Libraries"
+        depends on PACKAGE_boost
+        comment "Libraries"
 
-		config boost-libs-all
-		bool "Include all Boost libraries."
-	    	select PACKAGE_boost-libs	    	
+        config boost-libs-all
+            depends on @BUILD_NLS
+            depends on !GCC_VERSION_4_8
+            bool "Include all Boost libraries."
+            select PACKAGE_boost-libs
+            select boost-test-pkg
+            select boost-coroutine2
+            select boost-graph-parallel
+            default n
 
-		config boost-test-pkg
-		bool "Boost test package."
-	    	select PACKAGE_boost-test
-	    
-		config boost-coroutine2
-		depends on @GCC_VERSION_5
-		bool "Boost couroutine2 support."
-		select PACKAGE_boost-coroutine
-		default n
+        config boost-test-pkg
+            bool "Boost test units support."
+            select PACKAGE_boost-test
+            default n
 
-		config boost-graph-parallel
-		bool "Boost parallel graph support."
-		select PACKAGE_boost-graph
-		default n
+        config boost-coroutine2
+            depends on !GCC_VERSION_4_8
+            bool "Boost couroutine2 support."
+            select PACKAGE_boost-coroutine
+            default n
 
-		$(foreach lib,$(BOOST_LIBS), \
-		  config PACKAGE_boost-$(lib)
-		  prompt "Boost $(lib) library."
-		)
-  	endmenu
+        config boost-graph-parallel
+            bool "Boost parallel graph support."
+            select PACKAGE_boost-graph
+            default n
 
+        $(foreach lib,$(BOOST_LIBS), \
+            config PACKAGE_boost-$(lib)
+            prompt "Boost $(lib) library."
+            default n
+            $(if $(findstring locale,$(lib)), depends on @BUILD_NLS,)
+            $(if $(findstring fiber,$(lib)), depends on !GCC_VERSION_4_8,)
+        )
+    endmenu
 endef
+
 
 PKG_CONFIG_DEPENDS:= CONFIG_PACKAGE_boost-test
 
@@ -288,12 +314,13 @@ $(eval $(call DefineBoostLibrary,coroutine,system chrono context thread,))
 $(eval $(call DefineBoostLibrary,date_time,,))
 #$(eval $(call DefineBoostLibrary,exception,,))
 $(eval $(call DefineBoostLibrary,filesystem,system,))
+$(eval $(call DefineBoostLibrary,fiber,context,))
 $(eval $(call DefineBoostLibrary,graph,regex,))
 $(eval $(call DefineBoostLibrary,iostreams,,+PACKAGE_boost-iostreams:zlib))
-$(eval $(call DefineBoostLibrary,locale,system,$(ICONV_DEPENDS) @BUILD_NLS))
+$(eval $(call DefineBoostLibrary,locale,system, $(ICONV_DEPENDS)))
 $(eval $(call DefineBoostLibrary,log,system chrono date_time thread filesystem regex,))
 $(eval $(call DefineBoostLibrary,math,,))
-#$(eval $(call DefineBoostLibrary,mpi,,)) # OpenMPI does no exist in OpenWRT at this time.
+#$(eval $(call DefineBoostLibrary,mpi,,)) # OpenMPI does not exist in OpenWRT at this time.
 $(eval $(call DefineBoostLibrary,program_options,,))
 $(eval $(call DefineBoostLibrary,python,,+PACKAGE_boost-python:python))
 $(eval $(call DefineBoostLibrary,python3,,+PACKAGE_boost-python3:python3))
@@ -320,6 +347,10 @@ TARGET_CFLAGS += \
 	$(if $(CONFIG_PACKAGE_boost-python3), -I$(STAGING_DIR)/usr/include/python3.5/) \
 	$(if $(CONFIG_SOFT_FLOAT),-DBOOST_NO_FENV_H) -fPIC
 
+TARGET_CXXFLAGS += \
+	$(if $(CONFIG_GCC_VERSION_4_8), -std=c++11, -std=c++14)
+
+
 ifneq ($(findstring mips,$(ARCH)),)
     BOOST_ABI = o32
     ifneq ($(findstring 64,$(ARCH)),)
@@ -338,7 +369,7 @@ comma := ,
 define Build/Compile
 	$(info Selected Boost API $(BOOST_ABI) for architecture $(ARCH) and cpu $(CPU_TYPE) $(CPU_SUBTYPE))
 	( cd $(PKG_BUILD_DIR) ; \
-		echo "using gcc : $(ARCH) : $(GNU_TARGET_NAME)-gcc : <compileflags>\"$(TARGET_CFLAGS)\" <cxxflags>\"$(TARGET_CXXFLAGS) $(if $(CONFIG_boost-coroutine2),-std=c++14,)\" <linkflags>\"$(TARGET_LDFLAGS)\" ;" > tools/build/src/user-config.jam ; \
+		echo "using gcc : $(ARCH) : $(GNU_TARGET_NAME)-gcc : <compileflags>\"$(TARGET_CFLAGS)\" <cxxflags>\"$(TARGET_CXXFLAGS)\" <linkflags>\"$(TARGET_LDFLAGS)\" ;" > tools/build/src/user-config.jam ; \
 		$(if $(CONFIG_PACKAGE_boost-python3), \
 			echo "using python : 3.5 : $(STAGING_DIR_ROOT)/usr/bin/python3 : $(STAGING_DIR)/usr/include/python3.5/ ;" >> \
 				tools/build/src/user-config.jam; \
@@ -414,20 +445,20 @@ define Package/boost/Default/install
 		$(PKG_INSTALL_DIR)/lib/ -name 'libboost_$(2)*.so*' -exec $(CP) {} $(1)/usr/lib/ \;
 endef
 
-define Package/boost-test/install	
-		$(INSTALL_DIR) \
-			$(1)/usr/lib
+define Package/boost-test/install
+	$(INSTALL_DIR) \
+		$(1)/usr/lib
 
-		$(FIND) \
-			$(PKG_INSTALL_DIR)/lib/ -name 'libboost_unit_test_framework*.so*' -exec $(CP) {} $(1)/usr/lib/ \;
-		
-		$(FIND) \
-			$(PKG_INSTALL_DIR)/lib/ -name 'libboost_prg_exec_monitor*.so*' -exec $(CP) {} $(1)/usr/lib/ \;	
+	$(FIND) \
+		$(PKG_INSTALL_DIR)/lib/ -name 'libboost_unit_test_framework*.so*' -exec $(CP) {} $(1)/usr/lib/ \;
+
+	$(FIND) \
+		$(PKG_INSTALL_DIR)/lib/ -name 'libboost_prg_exec_monitor*.so*' -exec $(CP) {} $(1)/usr/lib/ \;
 endef
 
 define BuildBoostLibrary
   define Package/boost-$(1)/install
-	$(call Package/boost/Default/install,$$(1),$(1))
+    $(call Package/boost/Default/install,$$(1),$(1))
   endef
 
   $$(eval $$(call BuildPackage,boost-$(1)))


### PR DESCRIPTION
Maintainer: @ClaymorePT
Compile tested: Broadcom BCM2708
Run tested: None

Description:
This package version update brings two new libraries:
- Fiber [1]
  - Framework for userland-threads/fibers, from Oliver Kowalke.
- QVM [2]
  - Boost QVM is a generic library for working with quaternions, vectors
    and matrices of static size with the emphasis on 2, 3 and
    4-dimensional operations needed in graphics, video games and
    simulation applications, from Emil Dotchevski.

More information about the 1.62.0 release (bug fixes, etc), can be found
  here [3].

[1]: http://www.boost.org/doc/libs/1_62_0/libs/fiber/
[2]: http://www.boost.org/doc/libs/1_62_0/libs/qvm/
[3]: http://www.boost.org/users/history/version_1_62_0.html

Signed-off-by: Carlos M. Ferreira <carlosmf.pt@gmail.com>