### PR TITLE
lang: luasql: update URL to current

### DIFF
--- a/lang/luasql/Makefile
+++ b/lang/luasql/Makefile
@@ -30,7 +30,7 @@ define Package/luasql/Default
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Lua SQL binding
-  URL:=http://www.keplerproject.org/luasql/
+  URL:=http://keplerproject.github.io/luasql/
   DEPENDS:= +lua
 endef
 


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: N/A doc update only
Run tested: N/A doc update only

Description:

Old keplerproject.org urls are all down.
github project source for this project references new githubio website.

Signed-off-by: Karl Palsson <karlp@etactica.com>