### PR TITLE
wireguard: Bump to 0.0.20161001

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -9,12 +9,12 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=wireguard
 
-PKG_VERSION:=0.0.20160722
+PKG_VERSION:=0.0.20161001
 PKG_RELEASE:=1
 
 PKG_SOURCE:=WireGuard-experimental-$(PKG_VERSION).tar.xz
 # This is actually SHA256, but OpenWRT/LEDE will figure it out based on the length
-PKG_MD5SUM:=0dcda97b6bb4e962f731a863df9b4291c1c453b01f4faba78be4aaa13a594242
+PKG_MD5SUM:=ac3abb7b940716ac12b96a2cb3f7666598cbefd26f19c268f627dc47cd113ac8
 PKG_SOURCE_URL:=https://git.zx2c4.com/WireGuard/snapshot/
 PKG_BUILD_DIR:=$(BUILD_DIR)/WireGuard-experimental-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE d5dcb1bf97c421fe59925dba8e9197a4b7d67536 (ar71xx)

This should massively improve performance for (at least) MIPS targets:

    * poly1305: optimize unaligned access

    This is a very appreciated fix from René van Dorst, adjusting the
    arithmetic in Poly1305 to work fast on platforms with slow unaligned
    access, such as MIPS. According to his calculation, this gives a 50%
    improvement on small MIPS boxes.

Signed-off-by: Baptiste Jonglez <git@bitsofnetworks.org>