### PR TITLE
libx264: more build fixes

### DIFF
--- a/libs/libx264/Makefile
+++ b/libs/libx264/Makefile
@@ -27,6 +27,9 @@ include $(INCLUDE_DIR)/package.mk
 TARGET_CFLAGS+=-std=gnu99 -fPIC -O3 -ffast-math -I.
 MAKE_FLAGS+= LD="$(TARGET_CC) -o" 
 
+# ARM ASM depends on ARM1156 or later, blacklist earlier or incompatible cores
+CPU_ASM_BLACKLIST:=arm920t arm926ej-s arm1136j-s arm1176jzf-s fa526 mpcore xscale
+
 ifneq ($(CONFIG_TARGET_x86),)
 ifeq ($(CONFIG_YASM),y)
   CONFIGURE_VARS+= AS=yasm
@@ -38,7 +41,7 @@ else
 endif
 endif
 
-ifneq ($(CONFIG_SOFT_FLOAT),)
+ifneq ($(CONFIG_SOFT_FLOAT)$(findstring $(CONFIG_CPU_TYPE),$(CPU_ASM_BLACKLIST)),)
 CONFIGURE_VARS+= AS= 
 MAKE_FLAGS+= AS= 
 CONFIGURE_ARGS += --disable-asm
@@ -53,7 +56,7 @@ define Package/libx264
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=H264/AVC free codec library.
-  DEPENDS:=@BUILD_PATENTED
+  DEPENDS:=+libpthread @BUILD_PATENTED
   URL:=http://www.videolan.org/developers/x264.html
 endef
 


### PR DESCRIPTION
Maintainer: @ianchi 
Compile tested: oxnas, LEDE git HEAD

Description:

Introduce blacklist for CPU_TYPEs without ASM support in libx264
Add libpthread dependency required on non-musl builds
( should fix http://downloads.lede-project.org/snapshots/faillogs/arc_arc700/packages/libx264/compile.txt and http://downloads.lede-project.org/snapshots/faillogs/arm_mpcore_vfp/packages/libx264/compile.txt )

Signed-off-by: Daniel Golle <daniel@makrotopia.org>