### PR TITLE
autotools: don't rely on STAGING_DIR_HOST

### DIFF
--- a/devel/autoconf/Makefile
+++ b/devel/autoconf/Makefile
@@ -21,6 +21,8 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
+CONFIGURE_VARS += M4=m4
+
 define Package/autoconf
   SECTION:=devel
   CATEGORY:=Development
@@ -42,7 +44,6 @@ endef
 
 define Package/autoconf/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(SED) 's|$(STAGING_DIR_HOST)|/usr|g' $(PKG_INSTALL_DIR)/usr/bin/autom4te
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/usr/share/autoconf
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/autoconf/INSTALL \

--- a/devel/automake/Makefile
+++ b/devel/automake/Makefile
@@ -34,6 +34,8 @@ define Package/automake/description
   with the GNU Coding Standards.
 endef
 
+FIX_PATHS = $(SED) '1c \#!/usr/bin/perl' -e 's| /[^ ]*/bin/perl| /usr/bin/perl|g'
+
 define Package/automake/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/automake-$(PKG_VERSION) \
@@ -42,10 +44,8 @@ define Package/automake/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/aclocal-$(PKG_VERSION) \
 	  $(1)/usr/bin/aclocal-$(PKG_VERSION)
 	$(LN) aclocal-$(PKG_VERSION) $(1)/usr/bin/aclocal
-	$(SED) 's|$(STAGING_DIR_HOST)|/usr|g' \
-	  $(1)/usr/bin/automake-$(PKG_VERSION)
-	$(SED) 's|$(STAGING_DIR_HOST)|/usr|g' \
-	  $(1)/usr/bin/aclocal-$(PKG_VERSION)
+	$(FIX_PATHS) $(1)/usr/bin/automake-$(PKG_VERSION)
+	$(FIX_PATHS) $(1)/usr/bin/aclocal-$(PKG_VERSION)
 	$(INSTALL_DIR) $(1)/usr/share/automake-$(PKG_VERSION)
 
 	for dir in \

--- a/devel/libtool-bin/Makefile
+++ b/devel/libtool-bin/Makefile
@@ -22,6 +22,8 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
+CONFIGURE_VARS += GREP=grep SED=sed
+
 define Package/libtool-bin
   SECTION:=devel
   CATEGORY:=Development
@@ -39,7 +41,6 @@ endef
 define Package/libtool-bin/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/libtoolize $(1)/usr/bin/
-	$(SED) 's|$(STAGING_DIR_HOST)||g' $(1)/usr/bin/libtoolize
 	$(INSTALL_DIR) $(1)/usr/share/aclocal/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/aclocal/*.m4 \
 	  $(1)/usr/share/aclocal/


### PR DESCRIPTION
Maintainer: @xypron
Compile tested: LEDE r1737 (ar71xx)
Not run tested, generated files look okay.

We're planning to restructure the host staging dirs in LEDE again, packages should not rely on tools to be found in STAGING_DIR_HOST.