### PR TITLE
dbus: use default host install prefix

### DIFF
--- a/utils/dbus/Makefile
+++ b/utils/dbus/Makefile
@@ -122,11 +122,11 @@ HOST_CONFIGURE_ARGS+= \
 	--disable-verbose-mode \
 	--disable-xml-docs \
 	--with-dbus-user=root \
-	--with-dbus-daemondir="$(STAGIND_DIR)/host/bin" \
-	--with-system-socket="$(STAGING_DIR)/host/var/run/dbus/system_bus_socket" \
-	--with-system-pid-file="$(STAGING_DIR)/host/var/run/dbus.pid" \
+	--with-dbus-daemondir="$(HOST_BUILD_PREFIX)/bin" \
+	--with-system-socket="$(HOST_BUILD_PREFIX)/var/run/dbus/system_bus_socket" \
+	--with-system-pid-file="$(HOST_BUILD_PREFIX)/var/run/dbus.pid" \
 	--without-x \
-	--libexecdir="$(STAGING_DIR)/host/lib/dbus-1"
+	--libexecdir="$(HOST_BUILD_PREFIX)/lib/dbus-1"
 
 HOST_CONFIGURE_VARS+= \
 	ac_cv_have_abstract_sockets="yes" \


### PR DESCRIPTION
Maintainer: @sbyx
Compile tested: LEDE r1737
Run tested: doesn't change any files, affects host build only

Description:

Use default host install prefix (we're preparing some staging dir restructuring in LEDE). Also fixes a typo ("STAGIND_DIR").
