### PR TITLE
[utils/zoneinfo] Updated to the latest release version

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2016f
-PKG_VERSION_CODE:=2016f
+PKG_VERSION:=2016g
+PKG_VERSION_CODE:=2016g
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -20,14 +20,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION_CODE).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_MD5SUM:=b20b3c1618db1984aac685e763de001d
+PKG_MD5SUM:=3c7e97ec8527211104d27cc1d97a23de
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   MD5SUM:=b93618bb84e38dee102e0e41ec9d13e2
+   MD5SUM:=f89867013676e3cb9544be2df7d36a91
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: ti omap targets, custom build. OpenWrt master branch
Run tested: n/a

Description:

Changes to future time stamps

     Turkey switched from EET/EEST (+02/+03) to permanent +03,
     effective 2016-09-07.  (Thanks to Burak AYDIN.)  Use "+03" rather
     than an invented abbreviation for the new time.

     New leap second 2016-12-31 23:59:60 UTC as per IERS Bulletin C 52.
     (Thanks to Tim Parenti.)

   Changes to past time stamps

     For America/Los_Angeles, spring-forward transition times have been
     corrected from 02:00 to 02:01 in 1948, and from 02:00 to 01:00 in
     1950-1966.

     For zones using Soviet time on 1919-07-01, transitions to UT-based
     time were at 00:00 UT, not at 02:00 local time.  The affected
     zones are Europe/Kirov, Europe/Moscow, Europe/Samara, and
     Europe/Ulyanovsk.  (Thanks to Alexander Belopolsky.)

   Changes to past and future time zone abbreviations

     The Factory zone now uses the time zone abbreviation -00 instead
     of a long English-language string, as -00 is now the normal way to
     represent an undefined time zone.

     Several zones in Antarctica and the former Soviet Union, along
     with zones intended for ships at sea that cannot use POSIX TZ
     strings, now use numeric time zone abbreviations instead of
     invented or obsolete alphanumeric abbreviations.  The affected
     zones are Antarctica/Casey, Antarctica/Davis,
     Antarctica/DumontDUrville, Antarctica/Mawson, Antarctica/Rothera,
     Antarctica/Syowa, Antarctica/Troll, Antarctica/Vostok,
     Asia/Anadyr, Asia/Ashgabat, Asia/Baku, Asia/Bishkek, Asia/Chita,
     Asia/Dushanbe, Asia/Irkutsk, Asia/Kamchatka, Asia/Khandyga,
     Asia/Krasnoyarsk, Asia/Magadan, Asia/Omsk, Asia/Sakhalin,
     Asia/Samarkand, Asia/Srednekolymsk, Asia/Tashkent, Asia/Tbilisi,
     Asia/Ust-Nera, Asia/Vladivostok, Asia/Yakutsk, Asia/Yekaterinburg,
     Asia/Yerevan, Etc/GMT-14, Etc/GMT-13, Etc/GMT-12, Etc/GMT-11,
     Etc/GMT-10, Etc/GMT-9, Etc/GMT-8, Etc/GMT-7, Etc/GMT-6, Etc/GMT-5,
     Etc/GMT-4, Etc/GMT-3, Etc/GMT-2, Etc/GMT-1, Etc/GMT+1, Etc/GMT+2,
     Etc/GMT+3, Etc/GMT+4, Etc/GMT+5, Etc/GMT+6, Etc/GMT+7, Etc/GMT+8,
     Etc/GMT+9, Etc/GMT+10, Etc/GMT+11, Etc/GMT+12, Europe/Kaliningrad,
     Europe/Minsk, Europe/Samara, Europe/Volgograd, and
     Indian/Kerguelen.  For Europe/Moscow the invented abbreviation MSM
     was replaced by +05, whereas MSK and MSD were kept as they are not
     our invention and are widely used.

   Changes to zone names

     Rename Asia/Rangoon to Asia/Yangon, with a backward compatibility link.
     (Thanks to David Massoud.)

   Changes to code

     zic no longer generates binary files containing POSIX TZ-like
     strings that disagree with the local time type after the last
     explicit transition in the data.  This fixes a bug with
     Africa/Casablanca and Africa/El_Aaiun in some year-2037 time
     stamps on the reference platform.  (Thanks to Alexander Belopolsky
     for reporting the bug and suggesting a way forward.)

     If the installed localtime and/or posixrules files are symbolic
     links, zic now keeps them symbolic links when updating them, for
     compatibility with platforms like OpenSUSE where other programs
     configure these files as symlinks.

     zic now avoids hard linking to symbolic links, avoids some
     unnecessary mkdir and stat system calls, and uses shorter file
     names internally.

     zdump has a new -i option to generate transitions in a
     more-compact but still human-readable format.  This option is
     experimental, and the output format may change in future versions.
     (Thanks to Jon Skeet for suggesting that an option was needed,
     and thanks to Tim Parenti and Chris Rovick for further comments.)

   Changes to build procedure

     An experimental distribution format is available, in addition
     to the traditional format which will continue to be distributed.
     The new format is a tarball tzdb-VERSION.tar.lz with signature
     file tzdb-VERSION.tar.lz.asc.  It unpacks to a top-level directory
     tzdb-VERSION containing the code and data of the traditional
     two-tarball format, along with extra data that may be useful.
     (Thanks to Antonio Diaz Diaz, Oscar van Vlijmen, and many others
     for comments about the experimental format.)

     The release version number is now more accurate in the usual case
     where releases are built from a Git repository.  For example, if
     23 commits and some working-file changes have been made since
     release 2016g, the version number is now something like
     '2016g-23-g50556e3-dirty' instead of the misleading '2016g'.
     Official releases uses the same version number format as before,
     e.g., '2016g'.  To support the more-accurate version number, its
     specification has moved from a line in the Makefile to a new
     source file 'version'.

     The experimental distribution contains a file to2050.tzs that
     contains what should be the output of 'zdump -i -c 2050' on
     primary zones.  If this file is available, 'make check' now checks
     that zdump generates this output.

     'make check_web' now works on Fedora-like distributions.

   Changes to documentation and commentary

     tzfile.5 now documents the new restriction on POSIX TZ-like
     strings that is now implemented by zic.

     Comments now cite URLs for some 1917-1921 Russian DST decrees.
     (Thanks to Alexander Belopolsky.)

     tz-link.htm mentions JuliaTime (thanks to Curtis Vogt) and Time4J
     (thanks to Meno Hochschild) and ThreeTen-Extra, and its
     description of Java 8 has been brought up to date (thanks to
     Stephen Colebourne).  Its description of local time on Mars has
     been updated to match current practice, and URLs have been updated
     and some obsolete ones removed.
