### PR TITLE
Pulls/lua kepler urls

### DIFF
--- a/lang/lua-rings/Makefile
+++ b/lang/lua-rings/Makefile
@@ -30,7 +30,7 @@ define Package/lua-rings
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Lua-Rings
-  URL:=http://www.inf.puc-rio.br/~roberto/lua-rings/
+  URL:=http://keplerproject.github.io/rings/
   DEPENDS:=+lua
 endef
 

--- a/lang/lua-wsapi/Makefile
+++ b/lang/lua-wsapi/Makefile
@@ -28,7 +28,7 @@ define Package/lua-wsapi/Default
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Lua WSAPI
-  URL:=http://www.keplerproject.org/wsapi
+  URL:=https://keplerproject.github.io/wsapi/
   DEPENDS:= +lua
 endef
 

--- a/lang/lua-xavante/Makefile
+++ b/lang/lua-xavante/Makefile
@@ -28,7 +28,7 @@ define Package/lua-xavante
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Xavante Web Server
-  URL:=http://www.keplerproject.org/xavante
+  URL:=http://keplerproject.github.io/xavante/
   DEPENDS:= +lua
 endef
 

--- a/lang/luaexpat/Makefile
+++ b/lang/luaexpat/Makefile
@@ -22,7 +22,7 @@ define Package/luaexpat
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=LuaExpat 
-  URL:=http://www.keplerproject.org/luaexpat/
+  URL:=http://matthewwild.co.uk/projects/luaexpat/
   MAINTAINER:=W. Michael Petullo <mike@flyn.org>
   DEPENDS:=+lua +libexpat
 endef


### PR DESCRIPTION
Maintainer: @srdgame, @MikePetullo 
Compile tested: N/A documentation changes only
Run tested: N/A documentation changes only

Description:  Replace outdated broken keplerproject.org urls with current project urls for some lua projects. (and a broken puc-rio link too)

See also https://github.com/openwrt/packages/pull/3267