### PR TITLE
lua-openssl: Introduce new package

### DIFF
--- a/lang/lua-openssl/Makefile
+++ b/lang/lua-openssl/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2016 Amnon Paz <pazamnon@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=lua-openssl
+PKG_VERSION:=0.6.0
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Amnon Paz <pazamnon@gmail.com>
+PKG_LICENSE:=MIT
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/zhaozg/lua-openssl.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=1b950e6ff8617205cda1a1b612637ef21b9daf96
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  SUBMENU:=Lua
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Lua openSSL binding
+  URL:=http://github.com/zhaozg/lua-openssl
+  DEPENDS:=+lua +libopenssl +librt
+endef
+
+define Package/lua-openssl/description
+    A free, MIT-licensed OpenSSL binding for Lua.
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openssl.so $(1)/usr/lib/lua/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/lang/lua-openssl/patches/0001-Revise-Makefile.patch
+++ b/lang/lua-openssl/patches/0001-Revise-Makefile.patch
@@ -1,0 +1,135 @@
+diff --git a/Makefile b/Makefile
+index 6cb1176..6605879 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,85 +1,45 @@
+-T=openssl
+-
+-PREFIX		?=/usr/local
+-LIB_OPTION	?= -shared 
+-
+-#Lua auto detect
+-LUA_VERSION ?= $(shell pkg-config luajit --print-provides)
+-ifeq ($(LUA_VERSION),)                         ############ Not use luajit
+-LUAV		?= $(shell lua -e "_,_,v=string.find(_VERSION,'Lua (.+)');print(v)")
+-LUA_CFLAGS	?= -I$(PREFIX)/include/lua$(LUAV)
+-LUA_LIBS	?= -L$(PREFIX)/lib 
+-LUA_LIBDIR	?= $(PREFIX)/lib/lua/$(LUAV)
+-else
+-LUAV		?= $(shell lua -e "_,_,v=string.find(_VERSION,'Lua (.+)');print(v)")
+-LUA_CFLAGS	?= $(shell pkg-config luajit --cflags)
+-LUA_LIBS	?= $(shell pkg-config luajit --libs)
+-LUA_LIBDIR	?= $(PREFIX)/lib/lua/$(LUAV)
+-endif
+-
+-#OS auto detect
+-SYS := $(shell gcc -dumpmachine)
+-
+-ifneq (, $(findstring linux, $(SYS)))
+-# Do linux things
+-LDFLAGS		    = -fPIC -lrt -ldl
+-OPENSSL_LIBS	?= $(shell pkg-config openssl --libs) 
+-OPENSSL_CFLAGS	?= $(shell pkg-config openssl --cflags)
+-CFLAGS		    = -fPIC $(OPENSSL_CFLAGS) $(LUA_CFLAGS) 
+-endif
+-ifneq (, $(findstring apple, $(SYS)))
+-# Do darwin things
+-LDFLAGS		    = -fPIC -lrt -ldl
+-OPENSSL_LIBS	?= $(shell pkg-config openssl --libs) 
+-OPENSSL_CFLAGS	?= $(shell pkg-config openssl --cflags)
+-CFLAGS		    = -fPIC $(OPENSSL_CFLAGS) $(LUA_CFLAGS)
+-endif
+-ifneq (, $(findstring mingw, $(SYS)))
+-# Do mingw things
+-V			= $(shell lua -e "v=string.gsub('$(LUAV)','%.','');print(v)")
+-LDFLAGS		= -mwindows -lcrypt32 -lssl -lcrypto -lws2_32 $(PREFIX)/bin/lua$(V).dll 
+-LUA_CFLAGS	= -DLUA_LIB -DLUA_BUILD_AS_DLL -I$(PREFIX)/include/
+-CFLAGS		= $(OPENSSL_CFLAGS) $(LUA_CFLAGS)
+-endif
+-ifneq (, $(findstring cygwin, $(SYS)))
+-# Do cygwin things
+-OPENSSL_LIBS	?= $(shell pkg-config openssl --libs) 
+-OPENSSL_CFLAGS  ?= $(shell pkg-config openssl --cflags)
+-CFLAGS		= -fPIC $(OPENSSL_CFLAGS) $(LUA_CFLAGS)
+-endif
+-#custome config
+-ifeq (.config, $(wildcard .config))
+-include .config
+-endif
+-
+-LIBNAME= $T.so.$V
+-
+-#LIB_OPTION= -bundle -undefined dynamic_lookup #for MacOS X
+-
+-# Compilation directives
+-WARN_MOST	= -Wall -W -Waggregate-return -Wcast-align -Wmissing-prototypes -Wnested-externs -Wshadow -Wwrite-strings -pedantic
+-WARN		= -Wall -Wno-unused-value
+-WARN_MIN	= 
+-CFLAGS		+= $(WARN_MIN) -DPTHREADS 
+-CC= gcc -g $(CFLAGS) -Ideps
+-
+-
+-OBJS=src/asn1.o src/auxiliar.o src/bio.o src/cipher.o src/cms.o src/compat.o src/crl.o src/csr.o src/dh.o src/digest.o src/dsa.o \
+-src/ec.o src/engine.o src/hmac.o src/lbn.o src/lhash.o src/misc.o src/ocsp.o src/openssl.o src/ots.o src/pkcs12.o src/pkcs7.o    \
+-src/pkey.o src/rsa.o src/ssl.o src/th-lock.o src/util.o src/x509.o src/xattrs.o src/xexts.o src/xname.o src/xstore.o src/xalgor.o src/callback.o 
+-
+-.c.o:
+-	$(CC) -c -o $@ $?
+-
+-all: $T.so
+-	echo $(SYS)
+-
+-$T.so: $(OBJS)
+-	MACOSX_DEPLOYMENT_TARGET="10.3"; export MACOSX_DEPLOYMENT_TARGET; $(CC) $(CFLAGS) $(LIB_OPTION) -o $T.so $(OBJS) $(OPENSSL_LIBS) $(LUA_LIBS) $(LDFLAGS)
+-
+-install: all
+-	mkdir -p $(LUA_LIBDIR)
+-	cp $T.so $(LUA_LIBDIR)
+-
+-clean:
+-	rm -f $T.so $(OBJS) 
++.PHONY: install clean
++
++PKGC ?= pkg-config
++
++LIBNAME = openssl.so
++LIB_OPTION = -shared
++
++# lua's package config can be under various names
++LUAPKGC := $(shell for pc in lua lua5.1 lua5.2 lua5.3; do \
++		$(PKGC) --exists $$pc && echo $$pc && break; \
++	done)
++
++BUILD_DIR = $(shell pwd)
++
++# LUA include/libraries build flags
++LUA_LIBDIR := $(shell $(PKGC) --variable=libdir $(LUAPKGC))
++LUA_CFLAGS := $(shell $(PKGC) --cflags $(LUAPKGC))
++LUA_LIBS := $(shell $(PKGC) --libs-only-L $(LUAPKGC))
++
++# openssl include/libraries build flags
++OPENSSL_LIBS	= $(shell $(PKGC) openssl --libs)
++OPENSSL_CFLAGS	= $(shell $(PKGC) openssl --cflags)
++
++# openssl include/libraries build flags
++LOCAL_INCLUDE = -I$(BUILD_DIR)/deps
++
++CFLAGS	+= -fPIC -DPTHREADS -g $(LOCAL_INCLUDE) $(OPENSSL_CFLAGS) $(LUA_CFLAGS)
++LDFLAGS += -lrt -ldl $(OPENSSL_LIBS) $(LUA_LIBS)
++
++OBJS = src/asn1.o src/auxiliar.o src/bio.o src/cipher.o src/cms.o src/compat.o src/crl.o src/csr.o src/dh.o src/digest.o src/dsa.o src/ec.o src/engine.o src/hmac.o src/lbn.o src/lhash.o src/misc.o src/ocsp.o src/openssl.o src/ots.o src/pkcs12.o src/pkcs7.o src/pkey.o src/rsa.o src/ssl.o src/th-lock.o src/util.o src/x509.o src/xattrs.o src/xexts.o src/xname.o src/xstore.o src/xalgor.o src/callback.o
++
++all: clean $(LIBNAME)
++
++$(LIBNAME): $(OBJS)
++	$(CC) $(LDFLAGS) $(LIB_OPTION) $(OBJS) -o $@
++
++%.o: %.c
++	$(CC) $(CFLAGS) -c $< -o $@
++
++install: all
++	mkdir -p $(LUA_LIBDIR)
++	cp $(LIBNAME) $(LUA_LIBDIR)
++
++clean:
++	rm -f $(LIBNAME) $(OBJS)

--- a/lang/lua-openssl/patches/0010-Fix-Linkage.patch
+++ b/lang/lua-openssl/patches/0010-Fix-Linkage.patch
@@ -1,0 +1,36 @@
+diff --git a/deps/lua-compat/c-api/compat-5.3.c b/deps/lua-compat/c-api/compat-5.3.c
+index 4395bbc..4a8877c 100644
+--- a/deps/lua-compat/c-api/compat-5.3.c
++++ b/deps/lua-compat/c-api/compat-5.3.c
+@@ -491,17 +491,6 @@ COMPAT53_API int lua_geti (lua_State *L, int index, lua_Integer i) {
+ }
+
+
+-COMPAT53_API int lua_isinteger (lua_State *L, int index) {
+-  if (lua_type(L, index) == LUA_TNUMBER) {
+-    lua_Number n = lua_tonumber(L, index);
+-    lua_Integer i = lua_tointeger(L, index);
+-    if (i == n)
+-      return 1;
+-  }
+-  return 0;
+-}
+-
+-
+ static void compat53_reverse (lua_State *L, int a, int b) {
+   for (; a < b; ++a, --b) {
+     lua_pushvalue(L, a);
+diff --git a/deps/lua-compat/c-api/compat-5.3.h b/deps/lua-compat/c-api/compat-5.3.h
+index 2309294..8e67bae 100644
+--- a/deps/lua-compat/c-api/compat-5.3.h
++++ b/deps/lua-compat/c-api/compat-5.3.h
+@@ -244,9 +244,6 @@ typedef int (*lua_KFunction)(lua_State *L, int status, lua_KContext ctx);
+ #define lua_geti COMPAT53_CONCAT(COMPAT53_PREFIX, _geti)
+ COMPAT53_API int lua_geti (lua_State *L, int index, lua_Integer i);
+
+-#define lua_isinteger COMPAT53_CONCAT(COMPAT53_PREFIX, _isinteger)
+-COMPAT53_API int lua_isinteger (lua_State *L, int index);
+-
+ #define lua_numbertointeger(n, p) \
+   ((*(p) = (lua_Integer)(n)), 1)
+

--- a/lang/lua-openssl/patches/0020-support-OPENSSL_NO_SSL3_METHOD.patch
+++ b/lang/lua-openssl/patches/0020-support-OPENSSL_NO_SSL3_METHOD.patch
@@ -1,0 +1,41 @@
+--- lua-openssl-0.6.0.old/src/ssl.c	2016-09-19 08:30:43.735075695 +0200
++++ lua-openssl-0.6.0/src/ssl.c	2016-09-19 09:02:45.733813437 +0200
+@@ -24,12 +24,17 @@
+   SSL_METHOD* method = NULL;
+   const char* ciphers;
+   SSL_CTX* ctx;
+-  if (strcmp(meth, "SSLv3") == 0)
++  if (0);
++
++#ifndef OPENSSL_NO_SSL3
++  else if (strcmp(meth, "SSLv3") == 0)
+     method = SSLv3_method();    /* SSLv3 */
+   else if (strcmp(meth, "SSLv3_server") == 0)
+     method = SSLv3_server_method(); /* SSLv3 */
+   else if (strcmp(meth, "SSLv3_client") == 0)
+     method = SSLv3_client_method(); /* SSLv3 */
++#endif
++
+   else if (strcmp(meth, "SSLv23") == 0)
+     method = SSLv23_method();   /* SSLv3 but can rollback to v2 */
+   else if (strcmp(meth, "SSLv23_server") == 0)
+@@ -79,15 +84,15 @@
+ #endif
+   else
+     luaL_error(L, "#1:%s not supported\n"
+-               "Maybe SSLv3 SSLv23 TLSv1 TLSv1_1 TLSv1_2 DTLSv1 [SSLv2], option followed by _client or _server\n",
+-               "default is SSLv3",
++               "Maybe [SSLv3] SSLv23 TLSv1 TLSv1_1 TLSv1_2 DTLSv1 [SSLv2], option followed by _client or _server\n",
++               "default is TLSv1",
+                meth);
+   ciphers = luaL_optstring(L, 2, SSL_DEFAULT_CIPHER_LIST);
+   ctx = SSL_CTX_new(method);
+   if (!ctx)
+     luaL_error(L, "#1:%s not supported\n"
+-               "Maybe SSLv3 SSLv23 TLSv1 TLSv1_1 TLSv1_2 DTLSv1 [SSLv2], option followed by _client or _server\n",
+-               "default is SSLv3",
++               "Maybe [SSLv3] SSLv23 TLSv1 TLSv1_1 TLSv1_2 DTLSv1 [SSLv2], option followed by _client or _server\n",
++               "default is TLSv1",
+                meth);
+   openssl_newvalue(L, ctx);
+   SSL_CTX_set_cipher_list(ctx, ciphers);

--- a/lang/lua-openssl/patches/0030-support-OPENSSL_NO_COMP.patch
+++ b/lang/lua-openssl/patches/0030-support-OPENSSL_NO_COMP.patch
@@ -1,0 +1,20 @@
+--- lua-openssl-0.6.0.old/src/ssl.c	2016-09-19 08:30:43.735075695 +0200
++++ lua-openssl-0.6.0/src/ssl.c	2016-09-19 08:48:37.393737125 +0200
+@@ -1245,7 +1250,7 @@
+   lua_pushinteger(L, st);
+   return 2;
+ }
+-#ifndef LIBRESSL_VERSION_NUMBER
++#if !defined(OPENSSL_NO_COMP) && !defined(LIBRESSL_VERSION_NUMBER)
+ static int openssl_ssl_current_compression(lua_State *L)
+ {
+   SSL* s = CHECK_OBJECT(1, SSL, "openssl.ssl");
+@@ -1803,7 +1808,7 @@
+   {"getfd",     openssl_ssl_getfd},
+
+   {"current_cipher",        openssl_ssl_current_cipher},
+-#ifndef LIBRESSL_VERSION_NUMBER
++#if !defined(OPENSSL_NO_COMP) && !defined(LIBRESSL_VERSION_NUMBER)
+   {"current_compression",   openssl_ssl_current_compression},
+ #endif
+   {"getpeerverification",   openssl_ssl_getpeerverification},


### PR DESCRIPTION
Maintainer: @amnonpaz
Compile tested: ARM
Run tested: ARM

Description:

Add a Lua wrapper library for openssl.

Add patches for:
1. Revise the makefile, so the package can be built under openwrt
2. Remove "lua_isinteger" implementation from the package's "compat"
   code in order to avoid linkage issues - An implementation already
   exists in the target's Lua package.

Signed-off-by: Amnon Paz <pazamnon@gmail.com>