### PR TITLE
adblock: update 1.5.0

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=1.4.10
+PKG_VERSION:=1.5.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
@@ -23,7 +23,7 @@ endef
 
 define Package/$(PKG_NAME)/description
 Powerful adblock script to block ad/abuse domains.
-The script supports 21 domain blacklist sites plus manual black- and whitelist overrides.
+The script supports many domain blacklist sites plus manual black- and whitelist overrides.
 Please see https://github.com/openwrt/packages/blob/master/net/adblock/files/README.md for further information.
 
 endef
@@ -49,7 +49,7 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DATA) ./files/adblock-helper.sh $(1)/usr/bin/
 
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
-	$(INSTALL_BIN) ./files/adblock.hotplug $(1)/etc/hotplug.d/iface/99-adblock
+	$(INSTALL_BIN) ./files/adblock.hotplug $(1)/etc/hotplug.d/iface/90-adblock
 
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/adblock.init $(1)/etc/init.d/adblock

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -62,9 +62,10 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 * status & error logging to stdout and syslog
 * use two dynamic uhttpd instances as adblock pixel server, separated for ads delivered on port 80 and on port 443
 * use dynamic iptables chains/rulesets for adblock related redirects/rejects
-* init system support (start/stop/restart/reload/toggle/stats/cfgup)
+* init system support (start/stop/restart/reload/toggle/stats/cfgup/envchk/query)
 * hotplug support, the adblock start will be triggered by wan 'ifup' event, this can be restricted to a certain wan interface or disabled at all (see config options below)
 * toggle to quickly switch adblock 'on' or 'off'
+* envchk function to check the volatile adblock environment only (without list updates)
 * query function to quickly identify blocked (sub-)domains, i.e. for whitelisting
 * optional: automatic adblock list backup/restore, backups will be (de-)compressed on the fly (disabled by default)
 * optional: add new adblock sources via uci config (see example below)
@@ -113,6 +114,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 * **adblock query `<DOMAIN>`:** to query the active blocklists for a specific domain, please run _/etc/init.d/adblock query `<DOMAIN>`_ (see example below)
 * **configuration update:** to update an outdated adblock config file with the current default version, please run _/etc/init.d/adblock cfgup_, make your individual changes and start the adblock service again
 * **debugging:** for script debugging please set the 'adb\_debug' variable in the header of _/etc/init.d/adblock_ to '1'
+* **mute output** to mute the normal adblock output and print only warn/error messages, please set 'adb\_loglevel to '0'
 * **disable active dns probing in windows:** to prevent a possible yellow exclamation mark on your internet connection icon (which wrongly means connected, but no internet), please change the following registry key/value from "1" to "0" _HKLM\SYSTEM\CurrentControlSet\Services\NlaSvc\Parameters\Internet\EnableActiveProbing_
 
 ## Further adblock config options
@@ -128,6 +130,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
     * adb\_fetchttl => set the timeout for list downloads (default: '5' seconds)
     * adb\_restricted => disable updates of the adblock config file (no flash writes) during runtime (default: '0', disabled)
     * adb\_hotplugif => restrict hotplug support to a certain wan interface or disable it at all (default: '', disabled)
+    * adb\_loglevel => set it to '0' to mute normal adblock output and print only error messages (default: '1', normal output)
 
 ## Examples
 

--- a/net/adblock/files/adblock-helper.sh
+++ b/net/adblock/files/adblock-helper.sh
@@ -6,6 +6,8 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+adb_scriptver="1.5.0"
+adb_mincfgver="2.5"
 adb_hotplugif=""
 adb_lanif="lan"
 adb_nullport="65534"
@@ -22,6 +24,7 @@ adb_minspace=12000
 adb_forcedns=1
 adb_fetchttl=5
 adb_restricted=0
+adb_loglevel=1
 adb_uci="$(which uci)"
 
 # f_envload: load adblock environment
@@ -122,7 +125,7 @@ f_envcheck()
     if [ -z "${adb_enabled}" ] || [ -z "${adb_cfgver}" ] || [ "${adb_cfgver%%.*}" != "${adb_mincfgver%%.*}" ]
     then
         rc=-1
-        f_log "outdated adblock config (${adb_mincfgver} vs. ${adb_cfgver}), please run '/etc/init.d/adblock cfgup' to update your configuration"
+        f_log "outdated adblock config (${adb_cfgver} vs. ${adb_mincfgver}), please run '/etc/init.d/adblock cfgup' to update your configuration"
         f_exit
     elif [ "${adb_cfgver#*.}" != "${adb_mincfgver#*.}" ]
     then
@@ -131,7 +134,7 @@ f_envcheck()
     if [ "${adb_enabled}" != "1" ]
     then
         rc=-10
-        f_log "adblock is currently disabled, please set adblock.global.adb_enabled=1' to use this service"
+        f_log "adblock is currently disabled, please set adb_enabled to '1' to use this service"
         f_exit
     fi
 
@@ -633,12 +636,10 @@ f_rmfirewall()
     rm_fw="$(iptables -w -t nat -vnL | grep -Fo "adb-")"
     if [ -n "${rm_fw}" ]
     then
-        iptables-save -t nat | grep -Fv -- "adb-" | iptables-restore
-        iptables-save -t filter | grep -Fv -- "adb-" | iptables-restore
+        iptables-save | grep -Fv -- "adb-" | iptables-restore
         if [ -n "$(lsmod | grep -Fo "ip6table_nat")" ]
         then
-            ip6tables-save -t nat | grep -Fv -- "adb-" | ip6tables-restore
-            ip6tables-save -t filter | grep -Fv -- "adb-" | ip6tables-restore
+            ip6tables-save | grep -Fv -- "adb-" | ip6tables-restore
         fi
     fi
 }
@@ -651,21 +652,19 @@ f_log()
     local log_msg="${1}"
     local class="info "
 
-    # check for terminal session
-    #
+    if [ $((rc)) -gt 0 ]
+    then
+        class="error"
+    elif [ $((rc)) -lt 0 ]
+    then
+        class="warn "
+    fi
     if [ -t 1 ]
     then
         log_parm="-s"
     fi
-
-    # log to different output devices and set log class accordingly
-    #
-    if [ -n "${log_msg}" ]
+    if [ -n "${log_msg}" ] && ([ $((adb_loglevel)) -gt 0 ] || [ "${class}" != "info " ])
     then
-        if [ $((rc)) -gt 0 ]
-        then
-            class="error"
-        fi
         logger ${log_parm} -t "adblock[${adb_pid}] ${class}" "${log_msg}" 2>&1
     fi
 }
@@ -747,7 +746,10 @@ f_exit()
     else
         rc=0
     fi
-    "${adb_uci}" -q commit "adblock"
+    if [ -n "$("${adb_uci}" -q changes adblock)" ]
+    then
+        "${adb_uci}" -q commit "adblock"
+    fi
     rm -f "${adb_pidfile}"
     exit ${rc}
 }

--- a/net/adblock/files/adblock-update.sh
+++ b/net/adblock/files/adblock-update.sh
@@ -10,9 +10,8 @@
 #
 adb_pid="${$}"
 adb_pidfile="/var/run/adblock.pid"
-adb_scriptver="1.4.10"
-adb_mincfgver="2.5"
 adb_scriptdir="${0%/*}"
+
 if [ -r "${adb_pidfile}" ]
 then
     rc=255

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -2,10 +2,11 @@
 #
 
 START=90
-EXTRA_COMMANDS="toggle stats cfgup query"
+EXTRA_COMMANDS="toggle stats cfgup envchk query"
 EXTRA_HELP="	toggle	Toggle adblock 'on' or 'off'
 	stats	Update adblock statistics
 	cfgup	Update adblock configuration file
+	envchk	Check/Set adblock environment
 	query	<DOMAIN> Query active blocklists for specific domain"
 
 adb_debug=0
@@ -157,5 +158,16 @@ query()
             tld="${domain#*.}"
         done
     fi
+    return 0
+}
+
+envchk()
+{
+    adb_loglevel=0
+    f_envcheck
+    rm -f "${adb_tmpfile}"
+    rm -rf "${adb_tmpdir}"
+    adb_loglevel=1
+    f_log "adblock environment check finished successfully"
     return 0
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: no
Run tested: yes, LEDE r1270

Description:
* add new 'envchk' function to check adblock environment only,
  i.e. check volatile firewall rules or uhttpd instances without list updates
* add new optional parm 'adb_loglevel', set it to "0" to mute output (print only errors)
* set hotplug priority to '90' as well (missed in the last commit)
* documentation update
* cosmetics

Signed-off-by: Dirk Brenken <dev@brenken.org>