### PR TITLE
strongswan: don't depend on ip when ip-full is enabled

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -116,7 +116,7 @@ endef
 
 define Package/strongswan
 $(call Package/strongswan/Default)
-  DEPENDS:= +libpthread +ip \
+  DEPENDS:= +libpthread +!PACKAGE_ip-full:ip \
 	+kmod-crypto-authenc \
 	+kmod-ipsec +kmod-ipsec4 +IPV6:kmod-ipsec6 \
 	+kmod-ipt-ipsec +iptables-mod-ipsec


### PR DESCRIPTION
Maintainer: @sbyx 
Compile tested: LEDE r1823 x86/64
Run tested: LEDE r1823 x86/64

Description:

The ip and ip-full packages conflict with each other. Because of this,
it's not possible to enable ip-full when using strongSwan. Solve this by
not depending on ip when ip-full is enabled.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>