### PR TITLE
utils/collectd: Add cpufreq module

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -31,7 +31,6 @@ COLLECTD_PLUGINS_DISABLED:= \
 	battery \
 	ceph \
 	cgroups \
-	cpufreq \
 	curl_json \
 	curl_xml \
 	dbi \
@@ -101,6 +100,7 @@ COLLECTD_PLUGINS_SELECTED:= \
 	conntrack \
 	contextswitch \
 	cpu \
+	cpufreq \
 	csv \
 	curl \
 	df \
@@ -312,6 +312,7 @@ $(eval $(call BuildPlugin,bind,BIND server/zone input,bind,+PACKAGE_collectd-mod
 $(eval $(call BuildPlugin,conntrack,connection tracking table size input,conntrack,))
 $(eval $(call BuildPlugin,contextswitch,context switch input,contextswitch,))
 $(eval $(call BuildPlugin,cpu,CPU input,cpu,))
+$(eval $(call BuildPlugin,cpufreq,CPU Freq input,cpufreq,))
 $(eval $(call BuildPlugin,csv,CSV output,csv,))
 $(eval $(call BuildPlugin,curl,cURL input,curl,+PACKAGE_collectd-mod-curl:libcurl))
 #$(eval $(call BuildPlugin,dbi,relational database input,dbi,+PACKAGE_collectd-mod-dbi:libdbi))


### PR DESCRIPTION
Maintainer: Chris Blake / @riptidewave93
Compile tested: (x86_64, Generic, LEDE r1814)
Run tested: (x86_64, Generic, LEDE r1814) - PC Engines APU2 board

Description:

This change enables building of the built-in cpufreq module within Collectd, which is very useful on x86 and other targets that support CPU frequency scaling. Note that luci-app-statistics currently does not have support for rendering this.

Signed-off-by: Chris Blake <chrisrblake93 at gmail.com>