### PR TITLE
Netdata: update to v. 1.4.0

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,16 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.3.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.4.0
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Sebastian Careba <nitroshift@yahoo.com>
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://firehol.org/download/netdata/releases/v$(PKG_VERSION)
-PKG_SOURCE_VERSION:=f8ed1eac764386b839fbd2db0f41e664
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_VERSION:=3028b87ee19e8550df6b9decc49733d595e0bd6e
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Maintainer: Sebastian Careba nitroshift@yahoo.com
Compile tested: mvebu, WRT1900AC v1 (Mamba), OpenWRT r49953
Run tested: mvebu, WRT1900AC v1 (Mamba), OpenWRT r49953

Description:

Updated package to latest release and switch to tar.xz.

Signed-off-by: Sebastian Careba nitroshift@yahoo.com