### PR TITLE
Add ICU patch.  Was needed for QtWebkit on ARM without this icu shared

### DIFF
--- a/libs/icu/patches/0001-Disable-LDFLAGSICUDT-for-Linux.patch
+++ b/libs/icu/patches/0001-Disable-LDFLAGSICUDT-for-Linux.patch
@@ -1,0 +1,28 @@
+From 0c82d6aa02c08e41b13c83b14782bd7024e25d59 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 15 Feb 2014 21:06:42 +0000
+Subject: [PATCH] Disable LDFLAGSICUDT for Linux
+
+Upstream-Status: Inappropriate [ OE Configuration ]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ source/config/mh-linux |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config/mh-linux b/config/mh-linux
+index 366f0cc..2689aab 100644
+--- a/config/mh-linux
++++ b/config/mh-linux
+@@ -21,7 +21,7 @@ LD_RPATH= -Wl,-zorigin,-rpath,'$$'ORIGIN
+ LD_RPATH_PRE = -Wl,-rpath,
+ 
+ ## These are the library specific LDFLAGS
+-LDFLAGSICUDT=-nodefaultlibs -nostdlib
++# LDFLAGSICUDT=-nodefaultlibs -nostdlib
+ 
+ ## Compiler switch to embed a library name
+ # The initial tab in the next line is to prevent icu-config from reading it.
+-- 
+1.7.10.4
+


### PR DESCRIPTION
Package icu
Maintainer: n/a
signed-off-by Chris Rutherford
Compile tested: master
Run tested: master, run Qt5 Webkit

object could not be loaded.  See patch:

Subject: [PATCH] Disable LDFLAGSICUDT for Linux
