### PR TITLE
lvm2: fixed fixed missing dependency from librt

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -26,7 +26,7 @@ define Package/libdevmapper
   CATEGORY:=Libraries
   TITLE:=The Linux Kernel Device Mapper userspace library
   URL:=http://sourceware.org/dm/
-  DEPENDS:=+kmod-dm +libpthread +libuuid
+  DEPENDS:=+kmod-dm +libpthread +libuuid +librt
 endef
 
 define Package/libdevmapper/description


### PR DESCRIPTION
Maintainer: Alexey Vinogradov / @klirichek
Compile tested: (x86_64, ubuntu 16.04, openwrt trunk@49395)

Description:
Build failed due to missing dependency from librt.
This is the fix for it
