### PR TITLE
adblock: bugfix 1.5.1

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=1.5.0
+PKG_VERSION:=1.5.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/adblock-helper.sh
+++ b/net/adblock/files/adblock-helper.sh
@@ -6,7 +6,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-adb_scriptver="1.5.0"
+adb_scriptver="1.5.1"
 adb_mincfgver="2.5"
 adb_hotplugif=""
 adb_lanif="lan"
@@ -411,8 +411,8 @@ f_envcheck()
     #
     if [ -n "${adb_wanif4}" ] && [ -n "${adb_wanif6}" ]
     then
-        f_uhttpd "adbIPv4+6_80" "1" "-p ${adb_ipv4}:${adb_nullport} -p [${adb_ipv6}]:${adb_nullport}"
-        f_uhttpd "adbIPv4+6_443" "0" "-p ${adb_ipv4}:${adb_nullportssl} -p [${adb_ipv6}]:${adb_nullportssl}"
+        f_uhttpd "adbIPv46_80" "1" "-p ${adb_ipv4}:${adb_nullport} -p [${adb_ipv6}]:${adb_nullport}"
+        f_uhttpd "adbIPv46_443" "0" "-p ${adb_ipv4}:${adb_nullportssl} -p [${adb_ipv6}]:${adb_nullportssl}"
     elif [ -n "${adb_wanif4}" ]
     then
         f_uhttpd "adbIPv4_80" "1" "-p ${adb_ipv4}:${adb_nullport}"


### PR DESCRIPTION
Maintainer: me
Compile tested: no
Run tested: yes, LEDE r1270

Description:
* fix uhttpd detection in IPv4+IPv6 configurations

Signed-off-by: Dirk Brenken <dev@brenken.org>