### PR TITLE
opencv: install missing pkgconfig file in staging folder

### DIFF
--- a/libs/opencv/Makefile
+++ b/libs/opencv/Makefile
@@ -61,6 +61,8 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/opencv2 $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libopencv* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/opencv.pc $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/opencv/install


### PR DESCRIPTION
Maintainer: WRTnode Team <pub@wrtnode.com>
Compile tested: mips, head version
Run tested: mips, head version