### PR TITLE
adblock: let opkg itself decide if it's locked

### DIFF
--- a/net/adblock/files/adblock-helper.sh
+++ b/net/adblock/files/adblock-helper.sh
@@ -53,15 +53,6 @@ f_envload()
         f_exit
     fi
 
-    # check opkg availability
-    #
-    if [ -f "/var/lock/opkg.lock" ]
-    then
-        rc=-10
-        f_log "adblock installation finished successfully, 'opkg' currently locked by package installer"
-        f_exit
-    fi
-
     # uci function to parse global section by callback
     #
     config_cb()
@@ -141,6 +132,12 @@ f_envcheck()
     # get list with all installed packages
     #
     pkg_list="$(opkg list-installed)"
+    if [ $? == 255 ]
+    then
+        rc=-10
+        f_log "adblock installation finished successfully, 'opkg' currently locked by package installer"
+        f_exit
+    fi
     if [ -z "${pkg_list}" ]
     then
         rc=-1


### PR DESCRIPTION
Maintainer: Dirk Brenken <dev@brenken.org>

Description:
Instead of checking for the presence of `/var/lock/opkg.lock` we can let `opkg` try acquiring the lock. Inspired by https://gitlab.labs.nic.cz/turris/updater/issues/145

Signed-off-by: amq <amq@users.noreply.github.com>