### PR TITLE
unbound: update to 1.5.10

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.5.9
-PKG_RELEASE:=4
+PKG_VERSION:=1.5.10
+PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -17,7 +17,7 @@ PKG_MAINTAINER:=Michael Hanselmann <public@hansmi.ch>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unbound.net/downloads
-PKG_MD5SUM:=0cefa62c1690b4db18583db84bff00e3
+PKG_MD5SUM:=0a3a236811f1ab5c1dc31974fa74e047
 
 PKG_BUILD_DEPENDS:=libexpat
 PKG_BUILD_PARALLEL:=1

--- a/net/unbound/patches/001-conf.patch
+++ b/net/unbound/patches/001-conf.patch
@@ -11,7 +11,7 @@ index ff90e3b..5c20fdf 100644
  
  	# enable this feature to copy the source address of queries to reply.
  	# Socket options are not supported on all platforms. experimental.
-@@ -57,6 +59,7 @@ server:
+@@ -66,6 +68,7 @@ server:
  	# port range that can be open simultaneously.  About double the
  	# num-queries-per-thread, or, use as many as the OS will allow you.
  	# outgoing-range: 4096
@@ -19,7 +19,7 @@ index ff90e3b..5c20fdf 100644
  
  	# permit unbound to use this port number or port range for
  	# making outgoing queries, using an outgoing interface.
-@@ -73,9 +76,11 @@ server:
+@@ -82,9 +85,11 @@ server:
  
  	# number of outgoing simultaneous tcp buffers to hold per thread.
  	# outgoing-num-tcp: 10
@@ -31,7 +31,7 @@ index ff90e3b..5c20fdf 100644
  
  	# buffer size for UDP port 53 incoming (SO_RCVBUF socket option).
  	# 0 is system default.  Use 4m to catch query spikes for busy servers.
-@@ -103,18 +108,22 @@ server:
+@@ -118,18 +123,22 @@ server:
  	# buffer size for handling DNS data. No messages larger than this
  	# size can be sent or received, by UDP or TCP. In bytes.
  	# msg-buffer-size: 65552
@@ -54,7 +54,7 @@ index ff90e3b..5c20fdf 100644
  
  	# if very busy, 50% queries run to completion, 50% get timeout in msec
  	# jostle-timeout: 200
-@@ -125,11 +134,13 @@ server:
+@@ -140,11 +149,13 @@ server:
  	# the amount of memory to use for the RRset cache.
  	# plain value in bytes or you can append k, m or G. default is "4Mb".
  	# rrset-cache-size: 4m
@@ -68,7 +68,7 @@ index ff90e3b..5c20fdf 100644
  
  	# the time to live (TTL) value lower bound, in seconds. Default 0.
  	# If more than an hour could easily give trouble due to stale data.
-@@ -153,9 +164,11 @@ server:
+@@ -168,9 +179,11 @@ server:
  	# the number of slabs must be a power of 2.
  	# more slabs reduce lock contention, but fragment memory usage.
  	# infra-cache-slabs: 4
@@ -78,18 +78,18 @@ index ff90e3b..5c20fdf 100644
  	# infra-cache-numhosts: 10000
 +	infra-cache-numhosts: 200
  
- 	# Enable IPv4, "yes" or "no".
- 	# do-ip4: yes
-@@ -188,6 +201,8 @@ server:
+ 	# define a number of tags here, use with local-zone, access-control.
+ 	# repeat the define-tag statement to add additional tags.
+@@ -215,6 +228,8 @@ server:
  	# access-control: ::0/0 refuse
  	# access-control: ::1 allow
  	# access-control: ::ffff:127.0.0.1 allow
 +	access-control: 0.0.0.0/0 allow
 +	access-control: ::0/0 allow
  
- 	# if given, a chroot(2) is done to the given directory.
- 	# i.e. you can chroot to the working directory, for example,
-@@ -266,12 +284,15 @@ server:
+ 	# tag access-control with list of tags (in "" with spaces between)
+ 	# Clients using this access control element use localzones that
+@@ -309,12 +324,15 @@ server:
  	#	positive value: fetch that many targets opportunistically.
  	# Enclose the list of numbers between quotes ("").
  	# target-fetch-policy: "3 2 1 0 0"
@@ -105,7 +105,7 @@ index ff90e3b..5c20fdf 100644
  
  	# Harden against out of zone rrsets, to avoid spoofing attempts.
  	# harden-glue: yes
-@@ -367,7 +388,7 @@ server:
+@@ -414,7 +432,7 @@ server:
  	# you start unbound (i.e. in the system boot scripts).  And enable:
  	# Please note usage of unbound-anchor root anchor is at your own risk
  	# and under the terms of our LICENSE (see that file in the source).
@@ -114,7 +114,7 @@ index ff90e3b..5c20fdf 100644
  
  	# File with DLV trusted keys. Same format as trust-anchor-file.
  	# There can be only one DLV configured, it is trusted from root down.
-@@ -456,15 +477,18 @@ server:
+@@ -504,15 +522,18 @@ server:
  	# the amount of memory to use for the key cache.
  	# plain value in bytes or you can append k, m or G. default is "4Mb".
  	# key-cache-size: 4m


### PR DESCRIPTION
Maintainer: @hansmi 

Compile tested: ar71xx and x86/64
Run tested: not yet but trivial update.

Description: This updates unbound to 1.5.10; adjusts the config patch as well.

Signed-off-by: Stijn Segers <francesco.borromini@inventati.org>