### PR TITLE
net/unbound: Change maintainer to Eric Luehrsen

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=4
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Michael Hanselmann <public@hansmi.ch>
+PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@hotmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unbound.net/downloads


### PR DESCRIPTION
Maintainer: @hansmi
Compile tested: -
Run tested: -

Description:

Eric (@EricLuehrsen) has offered to take over maintainership for the net/unbound package.

Signed-off-by: Michael Hanselmann <public@hansmi.ch>