### PR TITLE
gdisk: Use libpopt instead of popt as dependency

### DIFF
--- a/utils/gdisk/Makefile
+++ b/utils/gdisk/Makefile
@@ -24,7 +24,7 @@ define Package/gdisk
   SECTION:=utils
   CATEGORY:=Utilities
   SUBMENU:=disc
-  DEPENDS:=+libstdcpp +popt +libuuid
+  DEPENDS:=+libstdcpp +libpopt +libuuid
   TITLE:=Partition utility that supports GPT
   URL:=http://www.rodsbooks.com/gdisk
   MAINTAINER:=Daniel Engberg <daniel.engberg.lists@pyret.net>


### PR DESCRIPTION
Maintainer: myself
Compile tested: mt7621, D-Link DIR-860L, LEDE trunk
Run tested: mt7621, D-Link DIR-860L, LEDE trunk

Description:

Adds correct dependency

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>