### PR TITLE
coreutils-stdbuf: 

### DIFF
--- a/utils/coreutils/Makefile
+++ b/utils/coreutils/Makefile
@@ -106,6 +106,11 @@ define BuildPlugin
   define Package/$(1)/install
 	$(INSTALL_DIR) $$(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$(2) $$(1)/usr/bin/
+
+    ifeq ($(2),stdbuf)
+	$(INSTALL_DIR) $$(1)/usr/lib/coreutils
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/coreutils/libstdbuf.so $$(1)/usr/lib/coreutils/
+    endif
   endef
 
   $$(eval $$(call BuildPackage,$(1)))


### PR DESCRIPTION
Maintainer: Jo-Philipp Wich jow@openwrt.org @jow-
Compile tested: ar71xx
Run tested: ar71xx

Description: Fix for #1654 coreutils-stdbuf does not install libstdbuf.so. Should be working for any arch.
