### PR TITLE
strongswan: update to 5.5.1, preserve /etc/strongswan.d, take over maintainership

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=strongswan
-PKG_VERSION:=5.5.0
+PKG_VERSION:=5.5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.strongswan.org/ http://download2.strongswan.org/
-PKG_MD5SUM:=a96fa7eb6c62b40143dadb064b6bd586
+PKG_MD5SUM:=4eba9474f7dc6c8c8d7037261358e68d
 PKG_LICENSE:=GPL-2.0+
 PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
 

--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -393,6 +393,7 @@ define Package/strongswan/conffiles
 /etc/ipsec.secrets
 /etc/ipsec.user
 /etc/strongswan.conf
+/etc/strongswan.d/
 endef
 
 define Package/strongswan/install

--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -15,7 +15,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.strongswan.org/ http://download2.strongswan.org/
 PKG_MD5SUM:=4eba9474f7dc6c8c8d7037261358e68d
 PKG_LICENSE:=GPL-2.0+
-PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
+PKG_MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
 
 PKG_MOD_AVAILABLE:= \
 	addrblock \


### PR DESCRIPTION
Maintainer: @sbyx 
Compile tested for octeon
Run tested on octeon running LEDE r1954
