### PR TITLE
rsyslog: do not daemonize rsyslogd and allow procd to manage it

### DIFF
--- a/net/rsyslog/files/rsyslog.init
+++ b/net/rsyslog/files/rsyslog.init
@@ -7,6 +7,6 @@ USE_PROCD=1
 
 start_service() {
 	procd_open_instance
-	procd_set_param command /usr/sbin/rsyslogd
+	procd_set_param command /usr/sbin/rsyslogd -n
 	procd_close_instance
 }


### PR DESCRIPTION
-------------------------------

Maintainer: @dubek 
Compile tested: ar71xx, Archer C7 v2, LEDE ad51e09fd1301484820a466a49447a34d7504882
Run tested: ar71xx, Archer C7 v2, tested ability to stop and restart rsyslog service

Description:
Currently, rsyslogd daemonizes itself and makes it impossible for procd to control it. Running it in interactive mode instead fixes that issue.

Signed-off-by: Alexis Green <alexis@cessp.it>