### PR TITLE
netdata: Streamline package

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -9,8 +9,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=1
-PKG_MAINTAINER:=Sebastian Careba <nitroshift@yahoo.com>
+PKG_RELEASE:=2
+PKG_MAINTAINER:=Daniel Engberg <daniel.engberg.lists@pyret.net>
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
 
@@ -20,8 +20,6 @@ PKG_SOURCE_VERSION:=3028b87ee19e8550df6b9decc49733d595e0bd6e
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
-
-TARGET_CFLAGS+= -DNETDATA_NO_ATOMIC_INSTRUCTIONS=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -43,19 +41,28 @@ define Package/netdata/conffiles
 endef
 
 define Package/netdata/install
-	$(INSTALL_DIR) $(1)/etc/netdata
-	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/netdata/apps_groups.conf $(1)/etc/netdata
-	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/netdata/charts.d.conf $(1)/etc/netdata
-	$(INSTALL_CONF) ./files/netdata.conf $(1)/etc/netdata
-	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) ./files/netdata.init $(1)/etc/init.d/netdata
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/netdata $(1)/usr/sbin/
-	$(INSTALL_DIR) $(1)/usr/share/netdata
-	$(INSTALL_DIR) $(1)/usr/lib/netdata
+	mkdir -p $(1)/etc/netdata
+	$(CP) $(PKG_INSTALL_DIR)/etc/netdata $(1)/etc
+	$(CP) ./files/netdata.conf $(1)/etc/netdata
+	mkdir -p $(1)/usr/share/netdata
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/netdata $(1)/usr/share
+	rm $(1)/usr/share/netdata/web/images/animated.gif
+	rm -rf $(1)/usr/share/netdata/web/old
+	rm $(1)/usr/share/netdata/web/demo*html
+	rm $(1)/usr/share/netdata/web/fonts/*.svg
+	rm $(1)/usr/share/netdata/web/fonts/*.ttf
+	rm $(1)/usr/share/netdata/web/fonts/*.woff
+	rm $(1)/usr/share/netdata/web/fonts/*.otf
+	mkdir -p $(1)/usr/lib/netdata
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/netdata $(1)/usr/lib
+	rm $(1)/usr/lib/netdata/python.d/python-modules-installer.sh
+	rm -rf $(1)/usr/lib/netdata/python.d/python_modules/pyyaml2
+	rm -rf $(1)/usr/lib/netdata/python.d/python_modules/pyyaml3
 	chmod 4755 $(1)/usr/lib/netdata/plugins.d/apps.plugin
+	mkdir -p $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/netdata.init $(1)/etc/init.d/netdata
+	mkdir -p $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/netdata $(1)/usr/sbin
 endef
 
 $(eval $(call BuildPackage,netdata))

--- a/admin/netdata/files/netdata.conf
+++ b/admin/netdata/files/netdata.conf
@@ -1,3 +1,16 @@
+### NetData Configuration
+
+### Notes about plugins
+###
+### charts.d    - REQUIRES Bash, enable here and edit charts.d.conf
+### apps        - none atm
+### node.d      - REQURIES node.js
+### tc          - QoS stats (if wanted)
+### cgcroups    - No support in OpenWRT/LEDE by default
+### health      - Disabled by default
+### KSM         - No support in OpenWRT/LEDE by default
+### python.d    - REQUIRES python and PyYAML, edit python.d.conf to enable
+
 [global]
 	run as user = nobody
 	web files owner = root
@@ -14,3 +27,10 @@
 	apps = no
 	node.d = no
 	tc = no
+	cgroups = no
+
+[health]
+	enabled = no
+
+[plugin:proc]
+	/sys/kernel/mm/ksm = no

--- a/admin/netdata/patches/001-disable_external_plugins_by_default.patch
+++ b/admin/netdata/patches/001-disable_external_plugins_by_default.patch
@@ -1,0 +1,26 @@
+diff --git a/conf.d/charts.d.conf b/conf.d/charts.d.conf
+index acb2a6f..8111859 100644
+--- a/conf.d/charts.d.conf
++++ b/conf.d/charts.d.conf
+@@ -30,7 +30,7 @@
+ 
+ # the default enable/disable for all charts.d collectors
+ # the default is "yes"
+-# enable_all_charts="yes"
++enable_all_charts="no"
+ 
+ # BY DEFAULT ENABLED MODULES
+ # ap=yes
+diff --git a/conf.d/python.d.conf b/conf.d/python.d.conf
+index 940bd91..78e2f0a 100644
+--- a/conf.d/python.d.conf
++++ b/conf.d/python.d.conf
+@@ -7,7 +7,7 @@
+ #
+ 
+ # Enable / disable the whole python.d.plugin (all its modules)
+-enabled: yes
++enabled: no
+ 
+ # Prevent log flood
+ # Define how many log messages can be written to log file in one log_interval


### PR DESCRIPTION
Maintainer: @nitroshift 
Compile tested: ar71xx, TP-Link TL-WDR3600, LEDE trunk
Run tested: ar71xx, TP-Link TL-WDR3600, LEDE trunk

Description:

* Change maintainer to myself, asked by current maintainer
* Remove atomic workaround, it's been fixed upstream in 1.4.0
* Install all plugins, disable those that depends on external applications
* Remove bundled pyYAML library, use package if you want to use python plugins
* Remove "unused" files in webdata directory, saves about 900k
  Downside is that some _very_ old browsers might break however since netdata
  is very heavy on javscript you still need a somewhat recent one anyway to get
  a decent experience.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>