### PR TITLE
ntfs-3g: ship /sbin/mount.ntfs compatibility symlink

### DIFF
--- a/utils/ntfs-3g/Makefile
+++ b/utils/ntfs-3g/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntfs-3g
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_VERSION:=2015.3.14
 PKG_SOURCE:=$(PKG_NAME)_ntfsprogs-$(PKG_VERSION).tgz
@@ -169,6 +169,7 @@ define Package/ntfs-3g/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libntfs-3g.so.* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/sbin
 	$(CP) $(PKG_INSTALL_DIR)/sbin/mount.ntfs-3g $(1)/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/sbin/mount.ntfs-3g $(1)/sbin/mount.ntfs
 endef
 
 define Package/ntfs-3g/postinst


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: LEDE x86/64 r1963
Run tested: LEDE x86/64 r1963 (qemu-system-x86_64; mount & block mount tests with NTFS disk)

Description:

Like on other common desktop Linux distributions, ship an /sbin/mount.ntfs
symlink in addition to the /sbin/mount.ntfs-3g one in order to let wrapper
programs successfully call external mount helpers by the filesystem name.

The assumption is that /sbin/mount.ntfs is only ever called by util-linux
mount and other mount-wrappers when kernel NTFS support is not available,
means shipping the additional symlink will not interfere with kernel mode
NTFS support.

This commit is mainly intended to prepare transparent fs-tools support for
mounting fuse filesystems, with focus on ntfs-3g in particular.

Please see http://git.lede-project.org/f027c68 for the corresponding
fs-tools support code.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>