### PR TITLE
[utils/zoneinfo] Updated to the latest release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2016g
-PKG_VERSION_CODE:=2016g
+PKG_VERSION:=2016h
+PKG_VERSION_CODE:=2016h
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -20,14 +20,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION_CODE).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_MD5SUM:=3c7e97ec8527211104d27cc1d97a23de
+PKG_MD5SUM:=878f0ec3fd9e4026ea11dd1b649a315a
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   MD5SUM:=f89867013676e3cb9544be2df7d36a91
+   MD5SUM:=00c20689d996dea4cf5b45504724ce8f
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: ti omap targets, custom build. OpenWrt master branch
Run tested: n/a

Description:
The 2016h release of the tz code and data is available. Its primary
motivation is to update to the new rules for Palestine, where 2016g
becomes incorrect starting about four hours from now (sorry, we didn't
get much notice). More generally, the 2016h release reflects the
following changes, which were either circulated on the tz mailing list
or are relatively minor technical or administrative changes:

   Changes to future time stamps

     Asia/Gaza and Asia/Hebron end DST on 2016-10-29 at 01:00, not
     2016-10-21 at 00:00.  (Thanks to Sharef Mustafa.)  Predict that
     future fall transitions will be on the last Saturday of October
     at 01:00, which is consistent with predicted spring transitions
     on the last Saturday of March.  (Thanks to Tim Parenti.)

   Changes to past time stamps

     In Turkey, transitions in 1986-1990 were at 01:00 standard time
     not at 02:00, and the spring 1994 transition was on March 20, not
     March 27.  (Thanks to K?van? Yazan.)

   Changes to past and future time zone abbreviations

     Asia/Colombo now uses numeric time zone abbreviations like "+0530"
     instead of alphabetic ones like "IST" and "LKT".  Various
     English-language sources use "IST", "LKT" and "SLST", with no
     working consensus.  (Usage of "SLST" mentioned by Sadika
     Sumanapala.)

   Changes to code

     zic no longer mishandles relativizing file names when creating
     symbolic links like /etc/localtime, when these symbolic links
     are outside the usual directory hierarchy.  This fixes a bug
     introduced in 2016g.  (Problem reported by Andreas Stieger.)

   Changes to build procedure

     New rules 'traditional_tarballs' and 'traditional_signatures' for
     building just the traditional-format distribution.  (Requested by
     Deborah Goldsmith.)

     The file 'version' is now put into the tzdata tarball too.
     (Requested by Howard Hinnant.)

   Changes to documentation and commentary

     The 'Theory' file now has a section on interface stability.
     (Requested by Paul Koning.)  It also mentions features like
     tm_zone and localtime_rz that have long been supported by the
     reference code.

     tz-link.htm has improved coverage of time zone boundaries suitable
     for geolocation.  (Thanks to heads-ups from Evan Siroky and Matt
     Johnson.)

     The US commentary now mentions Allen and the "day of two noons".

     The Fiji commentary mentions the government's 2016-10-03 press
     release.  (Thanks to Raymond Kumar.)
