### PR TITLE
debootstrap: add xz dependency

### DIFF
--- a/admin/debootstrap/Makefile
+++ b/admin/debootstrap/Makefile
@@ -28,7 +28,7 @@ define Package/debootstrap
   CATEGORY:=Administration
   TITLE:=Bootstrap a basic Debian system
   URL:=http://wiki.debian.org/Debootstrap
-  DEPENDS:= +coreutils +coreutils-chroot +coreutils-sha1sum +ar
+  DEPENDS:= +coreutils +coreutils-chroot +coreutils-sha1sum +ar +xz
 endef
 
 define Package/debootstrap/description


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: not necessary
Run tested: not necessary

Description: required to extract some packages as stated in issue https://github.com/openwrt/packages/issues/3365

Signed-off-by: Alberto Bursi alberto.bursi@outlook.it
