### PR TITLE
openconnect: added missing libs for openssl

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -31,7 +31,7 @@ endef
 define Package/openconnect
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libxml2 +kmod-tun +resolveip +vpnc-scripts +OPENCONNECT_OPENSSL:libopenssl +OPENCONNECT_GNUTLS:libgnutls +OPENCONNECT_STOKEN:libstoken
+  DEPENDS:=+libxml2 +kmod-tun +resolveip +vpnc-scripts +OPENCONNECT_OPENSSL:libopenssl +OPENCONNECT_OPENSSL:p11-kit +OPENCONNECT_OPENSSL:libp11 +OPENCONNECT_GNUTLS:libgnutls +OPENCONNECT_STOKEN:libstoken
   TITLE:=OpenConnect VPN client (Cisco AnyConnect compatible)
   MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
   URL:=http://www.infradead.org/openconnect/


### PR DESCRIPTION
Maintainer: @nmav 
Compile tested: ar71xx, latest LEDE version
Run tested: no, but from make menuconfig the packages get selected when I add openssl support to openconnect

Description: added missing libraries to fix issue https://github.com/openwrt/packages/issues/3301

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>