### PR TITLE
f2fs-tools: update to latest and split up tools

### DIFF
--- a/utils/f2fs-tools/Makefile
+++ b/utils/f2fs-tools/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=f2fs-tools
-PKG_VERSION:=1.4.0
+PKG_VERSION:=1.7.0
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPLv2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://git.kernel.org/cgit/linux/kernel/git/jaegeuk/f2fs-tools.git/snapshot/
-PKG_MD5SUM:=be9bfdddf3e5fd5e701a88d0b388dc26
+PKG_MD5SUM:=9db22274264f0c88dbee012f257917b1
 
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1
@@ -25,65 +25,66 @@ PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/f2fs-tools
+define Package/f2fs-tools/Default
   SECTION:=utils
   CATEGORY:=Utilities
   SUBMENU:=Filesystem
-  TITLE:=Tools for Flash-Friendly File System (F2FS)
-  DEPENDS:=+libuuid +libf2fs
+  DEPENDS:=+libf2fs
   URL:=http://git.kernel.org/cgit/linux/kernel/git/jaegeuk/f2fs-tools.git
-  MENU:=1
+endef
+
+define Package/mkf2fs
+  $(Package/f2fs-tools/Default)
+  TITLE:=Utility for creating a Flash-Friendly File System (F2FS)
+endef
+
+define Package/f2fsck
+  $(Package/f2fs-tools/Default)
+  TITLE:=Utility for checking/repairing a Flash-Friendly File System (F2FS)
+endef
+
+define Package/f2fs-tools
+  $(Package/f2fs-tools/Default)
+  TITLE:=Tools for Flash-Friendly File System (F2FS)
+  DEPENDS += +mkf2fs +f2fsck
 endef
 
 define Package/libf2fs
-  $(call Package/lxc/Default)
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Library for Flash-Friendly File System (F2FS) tools
-  DEPENDS:=
-endef
-
-define Package/f2fs-tools/config
-  source "$(SOURCE)/Config.in"
+  DEPENDS:=+libuuid
 endef
 
 define Package/libf2fs/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libf2fs.so* $(1)/usr/lib/
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/libf2fs.so* $(1)/usr/lib/
+endef
+
+define Package/mkf2fs/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/mkfs.f2fs $(1)/usr/sbin
+endef
+
+define Package/f2fsck/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/fsck.f2fs $(1)/usr/sbin
+	ln -s /usr/sbin/fsck.f2fs $(1)/usr/sbin/defrag.f2fs
+	ln -s /usr/sbin/fsck.f2fs $(1)/usr/sbin/dump.f2fs
+	ln -s /usr/sbin/fsck.f2fs $(1)/usr/sbin/sload.f2fs
+	ln -s /usr/sbin/fsck.f2fs $(1)/usr/sbin/resize.f2fs
 endef
 
 define Package/f2fs-tools/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-
-ifeq ($(CONFIG_F2FS_UTILS_f2fstat),y)
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/f2fstat $(1)/usr/sbin
-endif
-
-ifeq ($(CONFIG_F2FS_UTILS_fibmap_f2fs),y)
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/fibmap.f2fs $(1)/usr/sbin
-endif
-
-ifeq ($(CONFIG_F2FS_UTILS_fsck_f2fs),y)
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/fsck.f2fs $(1)/usr/sbin
-endif
-
-ifeq ($(CONFIG_F2FS_UTILS_dump_f2fs),y)
-	ln -s /usr/sbin/fsck.f2fs $(1)/usr/sbin/dump.f2fs
-endif
-
-ifeq ($(CONFIG_F2FS_UTILS_mkfs_f2fs),y)
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/mkfs.f2fs $(1)/usr/sbin
-endif
-
-endef
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_BUILD_DIR)/include/*.h $(1)/usr/include/
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libf2fs.so* $(1)/usr/lib/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libf2fs.a $(1)/usr/lib/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/f2fstat $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/fibmap.f2fs $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/parse.f2fs $(1)/usr/sbin
 endef
 
 $(eval $(call BuildPackage,libf2fs))
+$(eval $(call BuildPackage,mkf2fs))
+$(eval $(call BuildPackage,f2fsck))
 $(eval $(call BuildPackage,f2fs-tools))


### PR DESCRIPTION
Maintainer: @lperkov 
Compile tested: Kirkwood and ar71xx latest LEDE (v1949)
Run tested: Kirkwood and ar71xx, can format a flash drive, can check flash drive, the drive is also readable by my linux PC.

Description: I cloned the makefile from LEDE's f2fs-utils package https://github.com/lede-project/source/blob/master/package/utils/f2fs-tools/Makefile
Fixes issue https://github.com/openwrt/packages/issues/1848

Signed-off-by: Alberto Bursi alberto.bursi@outlook.it
