### PR TITLE
privoxy: fix handling config section "system"

### DIFF
--- a/net/privoxy/Makefile
+++ b/net/privoxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=privoxy
 PKG_VERSION:=3.0.26
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=privoxy-$(PKG_VERSION)-stable-src.tar.gz
 PKG_SOURCE_URL:=@SF/ijbswa
@@ -151,7 +151,7 @@ define Package/$(PKG_NAME)/install
 		$(1)/etc/config
 	$(INSTALL_DATA) ./files/privoxy.upgrade $(1)/lib/upgrade/keep.d/privoxy
 	$(INSTALL_BIN)  ./files/privoxy.init $(1)/etc/init.d/privoxy
-	$(INSTALL_BIN)  ./files/privoxy.hotplug $(1)/etc/hotplug.d/iface/80-privoxy
+	$(INSTALL_BIN)  ./files/privoxy.hotplug $(1)/etc/hotplug.d/iface/95-privoxy
 	$(INSTALL_CONF) ./files/privoxy.config $(1)/etc/config/privoxy
 endef
 

--- a/net/privoxy/files/privoxy.init
+++ b/net/privoxy/files/privoxy.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 
-START=80
-STOP=20
+START=95
+STOP=10
 
 PIDFILE=/var/run/privoxy.pid
 CFGFILE=/var/etc/privoxy.conf
@@ -9,32 +9,38 @@ CFGTEMP=/var/etc/privoxy.conf.tmp
 
 _uci2conf() {
 	# redefined callback for options when calling config_load
-	option_cb()
-	{
-		# $1	name of variable
-		# $2	value
-		local __OPT="$1"
-		local __VAL="$2"
-		case $__OPT in
-			confdir|templdir|temporary_directory|logdir|logfile)
-				# needs to be handled separately because we need to set permissions
-				# AND needs to be defined first because of a BUG inside privoxy
-				# require directories to be defined first inside config 
-				;;
-			debug_*)
-				[ $__VAL -eq 0 ] && return	# not set ignore
-				echo -e "debug\t$(echo $__OPT | sed -e 's#debug_##g')" >> $CFGTEMP ;;
-			*)
-				# detect list options (LENGTH) and ignore
-				echo $__OPT | grep -i "_LENGTH" >/dev/null 2>&1 && return
-				# detect list options (ITEM) and ignore
-				echo $__OPT | grep -i "_ITEM" >/dev/null 2>&1 && __OPT=$(echo $__OPT | sed -e "s#_ITEM.*##g")
-				# uci only accept "_" but we need "-"
-				local __OPT=$(echo $__OPT | sed -e "s#_#-#g")
-				# write to config
-				echo -e "$__OPT\t$__VAL" >> $CFGTEMP
-				;;
-		esac
+	config_cb() {
+		if [ ."$2" != ."privoxy" ]; then
+			option_cb() { return 0; }
+		else
+			option_cb()
+			{
+				# $1	name of variable
+				# $2	value
+				local __OPT="$1"
+				local __VAL="$2"
+				case $__OPT in
+					confdir|templdir|temporary_directory|logdir|logfile)
+						# needs to be handled separately because we need to set permissions
+						# AND needs to be defined first because of a BUG inside privoxy
+						# require directories to be defined first inside config 
+						;;
+					debug_*)
+						[ $__VAL -eq 0 ] && return	# not set ignore
+						echo -e "debug\t$(echo $__OPT | sed -e 's#debug_##g')" >> $CFGTEMP ;;
+					*)
+						# detect list options (LENGTH) and ignore
+						echo $__OPT | grep -i "_LENGTH" >/dev/null 2>&1 && return
+						# detect list options (ITEM) and ignore
+						echo $__OPT | grep -i "_ITEM" >/dev/null 2>&1 && __OPT=$(echo $__OPT | sed -e "s#_ITEM.*##g")
+						# uci only accept "_" but we need "-"
+						local __OPT=$(echo $__OPT | sed -e "s#_#-#g")
+						# write to config
+						echo -e "$__OPT\t$__VAL" >> $CFGTEMP
+						;;
+				esac
+			}
+		fi
 	}
 
 	# temporary config file
@@ -92,7 +98,7 @@ _uci2conf() {
 		echo -e "temporary-directory\t$_TMP_DIR" >> $CFGTEMP
 	fi
 
-	config_load privoxy	# calling above option_cb() and write the rest into $CFGTEMP
+	config_load "privoxy"	# calling above option_cb() and write the rest into $CFGTEMP
 
 	# move temp to final privoxy readable configuration
 	mv -f $CFGTEMP $CFGFILE


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE x86
Run tested: LEDE x86 and OpenWRT 15.05.1 WNDR3800

Description:

- privoxy.init fix handling of config section "system"
- change start/stop to start=95 and stop=10

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>