### PR TITLE
mwan3-luci: update to 1.4-5

### DIFF
--- a/net/mwan3-luci/Makefile
+++ b/net/mwan3-luci/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-mwan3
 PKG_VERSION:=1.4
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_MAINTAINER:=Aedan Renner <chipdankly@gmail.com>
 PKG_LICENSE:=GPLv2
 

--- a/net/mwan3-luci/files/usr/lib/lua/luci/controller/mwan3.lua
+++ b/net/mwan3-luci/files/usr/lib/lua/luci/controller/mwan3.lua
@@ -51,6 +51,8 @@ function index()
 		form("mwan/advanced_mwanconfig"))
 	entry({"admin", "network", "mwan", "advanced", "networkconfig"},
 		form("mwan/advanced_networkconfig"))
+	entry({"admin", "network", "mwan", "advanced", "wirelessconfig"},
+		form("mwan/advanced_wirelessconfig"))
 	entry({"admin", "network", "mwan", "advanced", "diagnostics"},
 		template("mwan/advanced_diagnostics"))
 	entry({"admin", "network", "mwan", "advanced", "diagnostics_display"},
@@ -270,6 +272,13 @@ function troubleshootingData()
 		end
 	mArray.netconfig = { networkConfig }
 
+	-- wireless config
+	local wirelessConfig = ut.trim(sys.exec("cat /etc/config/wireless | sed -e 's/.*username.*/	USERNAME HIDDEN/' -e 's/.*password.*/	PASSWORD HIDDEN/' -e 's/.*key.*/	KEY HIDDEN/'"))
+		if wirelessConfig == "" then
+			wirelessConfig = "No data found"
+		end
+	mArray.wificonfig = { wirelessConfig }
+	
 	-- ifconfig
 	local ifconfig = ut.trim(sys.exec("ifconfig"))
 		if ifconfig == "" then

--- a/net/mwan3-luci/files/usr/lib/lua/luci/model/cbi/mwan/advanced_wirelessconfig.lua
+++ b/net/mwan3-luci/files/usr/lib/lua/luci/model/cbi/mwan/advanced_wirelessconfig.lua
@@ -1,0 +1,32 @@
+-- ------ wireless configuration ------ --
+
+ut = require "luci.util"
+
+wirelessConfig = "/etc/config/wireless"
+
+
+m5 = SimpleForm("wirelessconf", nil)
+	m5:append(Template("mwan/advanced_wirelessconfig")) -- highlight current tab
+
+
+f = m5:section(SimpleSection, nil,
+	translate("This section allows you to modify the contents of /etc/config/wireless"))
+
+t = f:option(TextValue, "lines")
+	t.rmempty = true
+	t.rows = 20
+
+	function t.cfgvalue()
+		return nixio.fs.readfile(wirelessConfig) or ""
+	end
+
+	function t.write(self, section, data) -- format and write new data to script
+		return nixio.fs.writefile(wirelessConfig, "\n" .. ut.trim(data:gsub("\r\n", "\n")) .. "\n")
+	end
+
+	function f.handle(self, state, data)
+		return true
+	end
+
+
+return m5

--- a/net/mwan3-luci/files/usr/lib/lua/luci/view/mwan/advanced_diagnostics.htm
+++ b/net/mwan3-luci/files/usr/lib/lua/luci/view/mwan/advanced_diagnostics.htm
@@ -4,6 +4,7 @@
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/hotplugscript")%>"><%:Hotplug Script%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/mwanconfig")%>"><%:MWAN Config%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/networkconfig")%>"><%:Network Config%></a></li>
+	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/wirelessconfig")%>"><%:Wireless Config%></a></li>
 	<li class="cbi-tab"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/diagnostics")%>"><%:Diagnostics%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/troubleshooting")%>"><%:Troubleshooting%></a></li>
 </ul>

--- a/net/mwan3-luci/files/usr/lib/lua/luci/view/mwan/advanced_hotplugscript.htm
+++ b/net/mwan3-luci/files/usr/lib/lua/luci/view/mwan/advanced_hotplugscript.htm
@@ -2,6 +2,7 @@
 	<li class="cbi-tab"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/hotplugscript")%>"><%:Hotplug Script%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/mwanconfig")%>"><%:MWAN Config%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/networkconfig")%>"><%:Network Config%></a></li>
+	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/wirelessconfig")%>"><%:Wireless Config%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/diagnostics")%>"><%:Diagnostics%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/troubleshooting")%>"><%:Troubleshooting%></a></li>
 </ul>

--- a/net/mwan3-luci/files/usr/lib/lua/luci/view/mwan/advanced_mwanconfig.htm
+++ b/net/mwan3-luci/files/usr/lib/lua/luci/view/mwan/advanced_mwanconfig.htm
@@ -2,6 +2,7 @@
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/hotplugscript")%>"><%:Hotplug Script%></a></li>
 	<li class="cbi-tab"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/mwanconfig")%>"><%:MWAN Config%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/networkconfig")%>"><%:Network Config%></a></li>
+	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/wirelessconfig")%>"><%:Wireless Config%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/diagnostics")%>"><%:Diagnostics%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/troubleshooting")%>"><%:Troubleshooting%></a></li>
 </ul>

--- a/net/mwan3-luci/files/usr/lib/lua/luci/view/mwan/advanced_networkconfig.htm
+++ b/net/mwan3-luci/files/usr/lib/lua/luci/view/mwan/advanced_networkconfig.htm
@@ -2,6 +2,7 @@
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/hotplugscript")%>"><%:Hotplug Script%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/mwanconfig")%>"><%:MWAN Config%></a></li>
 	<li class="cbi-tab"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/networkconfig")%>"><%:Network Config%></a></li>
+	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/wirelessconfig")%>"><%:Wireless Config%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/diagnostics")%>"><%:Diagnostics%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/troubleshooting")%>"><%:Troubleshooting%></a></li>
 </ul>

--- a/net/mwan3-luci/files/usr/lib/lua/luci/view/mwan/advanced_troubleshooting.htm
+++ b/net/mwan3-luci/files/usr/lib/lua/luci/view/mwan/advanced_troubleshooting.htm
@@ -4,6 +4,7 @@
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/hotplugscript")%>"><%:Hotplug Script%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/mwanconfig")%>"><%:MWAN Config%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/networkconfig")%>"><%:Network Config%></a></li>
+	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/wirelessconfig")%>"><%:Wireless Config%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/diagnostics")%>"><%:Diagnostics%></a></li>
 	<li class="cbi-tab"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/troubleshooting")%>"><%:Troubleshooting%></a></li>
 </ul>
@@ -19,6 +20,7 @@
 				var versions = '<span class="description">Software versions : </span><br /><br />';
 				var mwanConfig = '<br /><br /><span class="description">Output of &#34;cat /etc/config/mwan3&#34; : </span><br /><br />';
 				var netConfig = '<br /><br /><span class="description">Output of &#34;cat /etc/config/network&#34; : </span><br /><br />';
+				var wifiConfig = '<br /><br /><span class="description">Output of &#34;cat /etc/config/wireless&#34; : </span><br /><br />';
 				var ifconfig = '<br /><br /><span class="description">Output of &#34;ifconfig&#34; : </span><br /><br />';
 				var ipRoute = '<br /><br /><span class="description">Output of &#34;route -n&#34; : </span><br /><br />';
 				var ipRuleShow = '<br /><br /><span class="description">Output of &#34;ip rule show&#34; : </span><br /><br />';
@@ -26,10 +28,11 @@
 				var firewallOut = '<br /><br /><span class="description">Firewall default output policy (must be ACCEPT) : </span><br /><br />';
 				var iptables = '<br /><br /><span class="description">Output of &#34;iptables -L -t mangle -v -n&#34; : </span><br /><br />';
 				tshoot.innerHTML = String.format(
-					'<pre>%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s</pre>',
+					'<pre>%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s</pre>',
 					versions, mArray.versions[0], mwanConfig, mArray.mwanconfig[0], netConfig, mArray.netconfig[0],
-					ifconfig, mArray.ifconfig[0], ipRoute, mArray.routeshow[0], ipRuleShow, mArray.iprule[0],
-					routeListTable, mArray.routelist[0], firewallOut, mArray.firewallout[0], iptables, mArray.iptables[0]
+					wifiConfig, mArray.wificonfig[0], ifconfig, mArray.ifconfig[0], ipRoute, mArray.routeshow[0],
+					ipRuleShow, mArray.iprule[0], routeListTable, mArray.routelist[0], firewallOut, mArray.firewallout[0],
+					iptables, mArray.iptables[0]
 				);
 			}
 			else

--- a/net/mwan3-luci/files/usr/lib/lua/luci/view/mwan/advanced_wirelessconfig.htm
+++ b/net/mwan3-luci/files/usr/lib/lua/luci/view/mwan/advanced_wirelessconfig.htm
@@ -1,0 +1,24 @@
+<ul class="cbi-tabmenu">
+	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/hotplugscript")%>"><%:Hotplug Script%></a></li>
+	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/mwanconfig")%>"><%:MWAN Config%></a></li>
+	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/networkconfig")%>"><%:Network Config%></a></li>
+	<li class="cbi-tab"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/wirelessconfig")%>"><%:Wireless Config%></a></li>
+	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/diagnostics")%>"><%:Diagnostics%></a></li>
+	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/network/mwan/advanced/troubleshooting")%>"><%:Troubleshooting%></a></li>
+</ul>
+
+<style type="text/css">
+  .container {	/* container for entire page. fixes bootstrap theme's ridiculously small page width */
+	max-width: none;
+	margin: 0px 0px 0px 30px;
+	padding-right: 30px;
+	width: auto;
+  }
+  .cbi-section-node {
+	margin-top: 20px;
+  }
+  .cbi-section {
+	border: 1px dotted #555555;
+	padding: 20px;
+  }
+</style>


### PR DESCRIPTION
Maintainer: @arfett 
Compile tested: ramips, xiaomi mini, r49946
Run tested: ramips, xiaomi mini, r49946

Description: Bump to 1.4-5. Added new page for wifi configuration edit, similar how the current network configuration page works.
Also enabled collecting of wifi configuration in troubleshooting page.

Signed-of-by: Tomislav Požega pozega.tomislav@gmail.com
