### PR TITLE
bash: move to Shells submenu

### DIFF
--- a/utils/bash/Makefile
+++ b/utils/bash/Makefile
@@ -28,6 +28,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/bash
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Shells
   TITLE:=The GNU Bourne Again SHell
   DEPENDS:=+libncurses
   URL:=http://www.gnu.org/software/bash/


### PR DESCRIPTION
Maintainer: @Naoir 
Compile tested: n/a
Run tested: the package shows in the Shells submenu now.

Description: Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>