### PR TITLE
zsh: move to Shells submenu

### DIFF
--- a/utils/zsh/Makefile
+++ b/utils/zsh/Makefile
@@ -24,6 +24,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/zsh
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Shells
   TITLE:=The Z shell
   DEPENDS:=+libncurses +libncursesw +libpcre +librt
   URL:=http://www.zsh.org/


### PR DESCRIPTION
Maintainer: @msva 
Compile tested: n/a
Run tested: the package shows in Shells from make menuconfig

Description:Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>