### PR TITLE
gzip: moving to Compression submenu

### DIFF
--- a/utils/gzip/Makefile
+++ b/utils/gzip/Makefile
@@ -23,6 +23,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/gzip
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Compression
   TITLE:=gzip (GNU zip) is a compression utility.
   URL:=https://www.gnu.org/software/gzip/
   MAINTAINER:=Christian Beier <dontmind@freeshell.org>


### PR DESCRIPTION
Maintainer: @bk138 
Compile tested: n/a
Run tested: the package is shown in Compression submenu

Description: Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>