### PR TITLE
klish: move to Shells submenu

### DIFF
--- a/utils/klish/Makefile
+++ b/utils/klish/Makefile
@@ -26,6 +26,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/klish/default
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Shells
   TITLE:=Kommand Line Interface SHell ($(1))
   URL:=http://libcode.org/projects/klish/
 endef


### PR DESCRIPTION
Maintainer: @t-umeno 
Compile tested: n/a
Run tested: the package is now shown in Shells submenu

Description: Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>