### PR TITLE
ccrypt: move to Encryption submenu

### DIFF
--- a/utils/ccrypt/Makefile
+++ b/utils/ccrypt/Makefile
@@ -24,6 +24,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/ccrypt
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Encryption
   TITLE:=ccrypt is a utility for encrypting and decrypting files and streams
   URL:=http://ccrypt.sourceforge.net/
 endef


### PR DESCRIPTION
Maintainer: @hnyman 
Compile tested: n/a
Run tested: the package is shown in Encryption submenu

Description: Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>