### PR TITLE
cryptsetup: move to Encryption submenu

### DIFF
--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -27,6 +27,7 @@ TARGET_LDFLAGS+=-Wl,-rpath-link=$(STAGING_DIR)/usr/lib
 define Package/cryptsetup/Default
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Encryption
   TITLE:=Cryptsetup
   DEPENDS:=+libblkid +libuuid +libpopt +lvm2 +libdevmapper +@KERNEL_DIRECT_IO
   URL:=http://code.google.com/p/cryptsetup/


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: n/a
Run tested: the package is shown in Encryption submenu

Description: Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>