### PR TITLE
gnupg: move to Encryption submenu

### DIFF
--- a/utils/gnupg/Makefile
+++ b/utils/gnupg/Makefile
@@ -27,6 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/gnupg/Default
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Encryption
   DEPENDS:=+zlib +libncurses +libreadline
   TITLE:=GNU privacy guard - a free PGP replacement
   URL:=http://www.gnupg.org/


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: n/a
Run tested: the package is shown in Encryption submenu

Description:Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>