### PR TITLE
squashfs-tools: move to Filesystems submenu

### DIFF
--- a/utils/squashfs-tools/Makefile
+++ b/utils/squashfs-tools/Makefile
@@ -25,6 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/squashfs-tools/Default
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Filesystem
   TITLE:=squashfs-tools
   URL:=https://github.com/plougher/squashfs-tools
   DEPENDS += +libpthread +zlib \


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: n/a
Run tested: the packages are shown in Filesystem submenu

Description: Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>