### PR TITLE
Tor: update to 0.2.8.9 and use sha256 instead of md5

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.2.7.6
-PKG_RELEASE:=2
+PKG_VERSION:=0.2.8.9
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_MD5SUM:=cc19107b57136a68e8c563bf2d35b072
+PKG_MD5SUM:=3f5c273bb887be4aff11f4d99b9e2e52d293b81ff4f6302b730161ff16dc5316
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
 PKG_LICENSE_FILES:=LICENSE
 
@@ -40,7 +40,7 @@ endef
 define Package/tor
 $(call Package/tor/Default)
   TITLE:=An anonymous Internet communication system
-  DEPENDS:=+libevent2 +libopenssl +libpthread +librt +zlib
+  DEPENDS:=+libevent2 +libopenssl +libpthread +librt +zlib +libcap
 endef
 
 define Package/tor/description


### PR DESCRIPTION
Seems like this package hasn't been updated for a long time. I hope it hasn't been abandoned...
I just updated it to the latest stable version and changed md5 to sha256. which according to the [documentation](https://wiki.openwrt.org/doc/devel/packages#buildpackage_variables) and [code](https://git.lede-project.org/?p=source.git;a=blob;f=scripts/download.pl;h=90d50a88622f26f554344f20b07f9da7ba649e74;hb=HEAD#l63) should work perfectly.
