### PR TITLE
autoconf: prevent emacs detection and usage during compile

### DIFF
--- a/devel/autoconf/Makefile
+++ b/devel/autoconf/Makefile
@@ -21,7 +21,7 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-CONFIGURE_VARS += M4=m4
+CONFIGURE_VARS += M4=m4 EMACS=no
 
 define Package/autoconf
   SECTION:=devel


### PR DESCRIPTION
Maintainer: @xypron 
Compile tested: LEDE master (b7b223be41cde2a264c0a9c4bbd1e0a4473682a7)
Run tested: no

Description:

The LEDE buildbots currently fail to build the package since there seems
to be a problem with the emacs installed on the buildbot(s) (e.g. [1]):

-snip-
Making all in emacs
make[7]: Entering directory `/opt/buildbot/slaves/lede-slave-tah/x86_64/build/sdk/build_dir/target-x86_64_musl-1.1.15/autoconf-2.69/lib/emacs'
WARNING: Warnings can be ignored. :-)
if test "emacs" != no; then \
      set x; \
      list='autoconf-mode.el autotest-mode.el'; for p in $list; do \
        if test -f "$p"; then d=; else d="./"; fi; \
        set x "$@" "$d$p"; shift; \
      done; \
      shift; \
      EMACS="emacs" /bin/bash ../../build-aux/elisp-comp "$@" || exit 1; \
    else : ; fi
4;1H; last errno 10)
No buffers needed saving: you didn't lose any work.
mv: cannot stat '*.elc': No such file or directory
make[7]: *** [elc-stamp] Error 1
-snap-

So let's disable the emacs usage - the resulting artifacts are not
packaged at the moment at all.

[1] https://downloads.lede-project.org/snapshots/faillogs/x86_64/packages/autoconf/compile.txt

Signed-off-by: Michael Heimpold <mhei@heimpold.de>