### PR TITLE
travelmate: update 0.2.3

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=0.2.2
+PKG_VERSION:=0.2.3
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/README.md
+++ b/net/travelmate/files/README.md
@@ -1,4 +1,4 @@
-# travelmate, a connection manager for travel router
+# travelmate, a wlan connection manager for travel router
 
 ## Description
 If you’re planning an upcoming vacation or a business trip, taking your laptop, tablet or smartphone give you the ability to connect with friends or complete work on the go. But many hotels don’t have a secure wireless network setup or you’re limited on using a single device at once. Investing in a portable, mini travel router is a great way to connect all of your devices at once while having total control over your own personalized wireless network.  
@@ -20,12 +20,12 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 ## OpenWrt / LEDE trunk Installation & Usage
 * install 'travelmate' (_opkg install travelmate_)
 * configure your network to support (multiple) wlan uplinks and set travelmate config options (details see below)
+* set 'trm\_enabled' option in travelmate config to '1'
 * travelmate starts automatically during boot, triggered by procd as soon as the wireless subsystem is up & running
 
 ## Chaos Calmer installation notes
 * 'travelmate' is _not_ available as an ipk package in the Chaos Calmer download repository
-* download the package from a development snapshot package directory:
-    * for 'travelmate' look [here](https://downloads.lede-project.org/snapshots/packages/x86_64/packages/)
+* download the package from a development snapshot package directory, i.e. look [here](https://downloads.lede-project.org/snapshots/packages/x86_64/packages/)
 * manually transfer the package to your routers temp directory (with tools like _sshfs_ or _winscp_)
 * install the package as described above
 
@@ -33,26 +33,22 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 * mandatory config options:
     * trm\_enabled => main switch to enable/disable the travelmate service (default: '0', disabled)
     * trm\_loop => loop timeout in seconds for wlan monitoring (default: '30')
-    * trm\_maxretry => how many times should travelmate try to connect to uplink xyz (default: '3')
+    * trm\_maxretry => how many times should travelmate try to connect to a certain uplink (default: '3')
 * optional config options:
     * trm\_debug => enable/disable debug logging (default: '0', disabled)
     * trm\_device => limit travelmate to a dedicated radio, i.e 'radio0' (default: '', use all radios)
     * trm\_iw => force travelmate to use iwinfo (even if iw is installed) set this option to 'none' (default: '', use iw if found)
 
 ## Setup
-**1. configure (multiple) wwan interfaces in /etc/config/network:**
+**1. configure a wwan interface in /etc/config/network:**
 <pre><code>
 [...]
-config interface 'wwan01'
-        option proto 'dhcp'
-config interface 'wwan02'
-        option proto 'dhcp'
-config interface 'wwan03'
+config interface 'wwan'
         option proto 'dhcp'
 [...]
 </code></pre>
 
-**2. add these interfaces to your firewall configuration in /etc/config/firewall:**
+**2. add this interface to your firewall configuration in /etc/config/firewall:**
 <pre><code>
 [...]
 config zone
@@ -62,49 +58,49 @@ config zone
         option forward 'REJECT'
         option masq '1'
         option mtu_fix '1'
-        option network 'wan wan6 wwan01 wwan02 wwan03 [...]'
+        option network 'wan wan6 wwan'
 [...]
 </code></pre>
 
-**3. add required station interfaces to your wireless configuration in etc/config/wireless:**
+**3. add required wwan stations to your wireless configuration in etc/config/wireless:**
 <pre><code>
 [...]
 config wifi-iface
         option device 'radio0'
-        option network 'wwan01'
+        option network 'wwan'
         option mode 'sta'
         option ssid 'example_01'
-        option ifname 'wlan1'
+        option ifname 'wwan01'
         option encryption 'psk2+ccmp'
         option key 'abc'
         option disabled '1'
 config wifi-iface
         option device 'radio0'
-        option network 'wwan02'
+        option network 'wwan'
         option mode 'sta'
         option ssid 'example_02'
-        option ifname 'wlan2'
+        option ifname 'wwan02'
         option encryption 'psk2+ccmp'
         option key 'xyz'
         option disabled '1'
 config wifi-iface
         option device 'radio0'
-        option network 'wwan03'
+        option network 'wwan'
         option mode 'sta'
-        option ssid 'Telekom_ICE'
-        option ifname 'wlan3'
+        option ssid 'example_03'
+        option ifname 'wwan03'
         option encryption 'none'
         option disabled '1'
 [...]
 </code></pre>
 
-**4. configure & start travelmate:**
+**4. reload network configuration & start travelmate:**
 <pre><code>
 /etc/init.d/network reload
 /etc/init.d/travelmate start
 </code></pre>
 
-**Common runtime outputs**
+**Common runtime outputs (visible via logread)**
 
 **Success:** Sun Oct  9 17:02:21 2016 user.notice root: travelmate-0.2.1[712] info : wlan interface "wwan06" connected to uplink "blackhole.nl"
 

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -12,7 +12,7 @@ LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 trm_debug="0"
 trm_pid="${$}"
-trm_ver="0.2.2"
+trm_ver="0.2.3"
 trm_loop=30
 trm_maxretry=3
 trm_device=""
@@ -23,15 +23,15 @@ trm_iw="$(which iw)"
 trm_prepare()
 {
     local config="${1}"
-    local device="$(uci -q get wireless."${config}".device)"
     local mode="$(uci -q get wireless."${config}".mode)"
+    local device="$(uci -q get wireless."${config}".device)"
     local network="$(uci -q get wireless."${config}".network)"
+    local ifname="$(uci -q get wireless."${config}".ifname)"
     local disabled="$(uci -q get wireless."${config}".disabled)"
 
     if [ "${mode}" = "ap" ] &&
         ([ -z "${trm_device}" ] || [ "${trm_device}" = "${device}" ])
     then
-        ifname="$(uci -q get wireless."${config}".ifname)"
         trm_aplist="${trm_aplist} ${ifname}"
         if [ -z "${disabled}" ] || [ "${disabled}" = "1" ]
         then
@@ -47,7 +47,7 @@ trm_prepare()
     fi
 }
 
-# function to set different wlan interface states
+# function to set different wlan interface status
 #
 trm_set()
 {
@@ -91,7 +91,7 @@ trm_set()
     fi
 }
 
-# function to check interface state on "up" event
+# function to check interface status on "up" event
 #
 trm_check()
 {
@@ -103,10 +103,10 @@ trm_check()
         while [ $((cnt)) -lt 15 ]
         do
             json_load "$(ubus -S call network.interface."${interface}" status)"
-            json_get_var trm_state up
-            if [ "${trm_state}" = "1" ] || [ -n "${trm_uplink}" ]
+            json_get_var trm_status up
+            if [ "${trm_status}" = "1" ] || [ -n "${trm_uplink}" ]
             then
-                trm_log "debug" "check::: interface: ${interface}, status: ${trm_state}, uplink: ${trm_uplink}, count: ${cnt}"
+                trm_log "debug" "check::: interface: ${interface}, status: ${trm_status}, uplink: ${trm_uplink}, ssid: ${trm_ssid} count: ${cnt}"
                 json_cleanup
                 break
             fi
@@ -114,11 +114,12 @@ trm_check()
             sleep 1
         done
     done
-    if [ -n "${trm_uplink}" ] && [ "${trm_state}" = "0" ]
+    if [ -n "${trm_uplink}" ] && [ "${trm_status}" = "0" ]
     then
         ubus call network reload
+        eval "trm_count_${trm_uplink}=\$((trm_count_${trm_uplink}+1))"
         trm_checklist=""
-        trm_log "info" "uplink ${ssid} get lost"
+        trm_log "info" "uplink ${trm_ssid} get lost"
     elif [ -z "${trm_uplink}" ] && [ -n "${trm_checklist}" ]
     then
         trm_checklist=""
@@ -158,7 +159,9 @@ option_cb()
     local value="${2}"
     eval "${option}=\"${value}\""
 }
+
 config_load travelmate
+
 if [ "${trm_enabled}" != "1" ]
 then
     trm_log "info" "travelmate is currently disabled, please set 'trm_enabled' to '1' to use this service"
@@ -172,7 +175,7 @@ then
     trm_iwinfo="$(which iwinfo)"
     if [ ! -f "${trm_iwinfo}" ]
     then
-        trm_log "error" "no wireless tool for scanning found, please install 'iw' or 'iwinfo'"
+        trm_log "error" "no wireless tool for wlan scanning found, please install 'iw' or 'iwinfo'"
         exit 255
     fi
 fi
@@ -181,7 +184,7 @@ fi
 #
 while true
 do
-    if [ -z "${trm_uplink}" ] || [ "${trm_state}" = "0" ]
+    if [ -z "${trm_uplink}" ] || [ "${trm_status}" = "0" ]
     then
         trm_uplink=""
         trm_aplist=""
@@ -203,34 +206,35 @@ do
             then
                 for sta in ${trm_stalist}
                 do
-                    config="${sta%%_*}"
-                    network="${sta##*_}"
-                    ssid="\"$(uci -q get wireless."${config}".ssid)\""
-                    if [ $((trm_count_${network})) -lt $((trm_maxretry)) ]
+                    trm_config="${sta%%_*}"
+                    trm_network="${sta##*_}"
+                    trm_ifname="$(uci -q get wireless."${trm_config}".ifname)"
+                    trm_ssid="\"$(uci -q get wireless."${trm_config}".ssid)\""
+                    if [ $((trm_count_${trm_config}_${trm_network})) -lt $((trm_maxretry)) ]
                     then
-                        if [ -n "$(printf "${trm_ssidlist}" | grep -Fo "${ssid}")" ]
+                        if [ -n "$(printf "${trm_ssidlist}" | grep -Fo "${trm_ssid}")" ]
                         then
-                            trm_set "partial" "${config}" "${network}" "up"
-                            if [ "${trm_state}" = "1" ]
+                            trm_set "partial" "${trm_config}" "${trm_network}" "up"
+                            if [ "${trm_status}" = "1" ]
                             then
-                                trm_uplink="${network}"
-                                trm_checklist="${trm_uplink}"
+                                trm_checklist="${trm_network}"
+                                trm_uplink="${trm_config}_${trm_network}"
                                 trm_set "defer"
-                                trm_log "info" "wlan interface \"${network}\" connected to uplink ${ssid}" 
+                                trm_log "info" "wwan interface \"${trm_ifname}\" connected to uplink ${trm_ssid}" 
                                 break 2
                             else
                                 trm_set "revert"
-                                eval "trm_count_${network}=\$((trm_count_${network}+1))"
+                                eval "trm_count_${trm_config}_${trm_network}=\$((trm_count_${trm_config}_${trm_network}+1))"
                             fi
                         fi
-                    elif [ $((trm_count_${network})) -eq $((trm_maxretry)) ]
+                elif [ $((trm_count_${trm_config}_${trm_network})) -eq $((trm_maxretry)) ]
                     then
-                        eval "trm_count_${network}=\$((trm_count_${network}+1))"
-                        trm_log "info" "uplink ${ssid} disabled due to permanent connection failures"
+                        eval "trm_count_${trm_config}_${trm_network}=\$((trm_count_${trm_config}_${trm_network}+1))"
+                        trm_log "info" "uplink ${trm_ssid} disabled due to permanent connection failures"
                     fi
                 done
             fi
-            sleep 1
+            sleep 5
         done
         sleep 5
     else


### PR DESCRIPTION
Maintainer: me
Compile tested: not relevant
Run tested: LEDE r2028

Description:
* simplified network setup
* refine scan-timeout between different radios
* raise error counter on lost uplink connections too
* documentation update

Signed-off-by: Dirk Brenken <dev@brenken.org>