### PR TITLE
nmap: fix build on MacOS X

### DIFF
--- a/net/nmap/Makefile
+++ b/net/nmap/Makefile
@@ -90,7 +90,9 @@ CONFIGURE_ARGS += \
 	--without-liblua \
 	--without-zenmap
 
-CONFIGURE_VARS += CXXFLAGS="$$$$CXXFLAGS -fno-builtin"
+CONFIGURE_VARS += \
+	ac_cv_dnet_bsd_bpf=no \
+	CXXFLAGS="$$$$CXXFLAGS -fno-builtin"
 
 ifeq ($(BUILD_VARIANT),ssl)
 	CONFIGURE_ARGS += --with-openssl="$(STAGING_DIR)/usr"


### PR DESCRIPTION
Maintainer: @nunojpg 
Compile tested: OpenWrt (older version)
Run tested: N/A

Description:

The configure script (for libdnet) seems to find <net/bpf.h> and detect some BSD stuff.

The lidnet's Makefile wants to include eth-bsd.c, arp-bsd.c and other BSD friends.

This seems to put a cork on it, and no BSD stuff appears anymore.
[at least on my system].

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>