### PR TITLE
travelmate: update 0.2.4

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=0.2.3
+PKG_VERSION:=0.2.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/README.md
+++ b/net/travelmate/files/README.md
@@ -33,11 +33,11 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 * mandatory config options:
     * trm\_enabled => main switch to enable/disable the travelmate service (default: '0', disabled)
     * trm\_loop => loop timeout in seconds for wlan monitoring (default: '30')
-    * trm\_maxretry => how many times should travelmate try to connect to a certain uplink (default: '3')
+    * trm\_maxretry => how many times should travelmate try to connect to a certain uplink, to disable this check at all set it to '0' (default: '3')
 * optional config options:
     * trm\_debug => enable/disable debug logging (default: '0', disabled)
-    * trm\_device => limit travelmate to a dedicated radio, i.e 'radio0' (default: '', use all radios)
-    * trm\_iw => force travelmate to use iwinfo (even if iw is installed) set this option to 'none' (default: '', use iw if found)
+    * trm\_device => limit travelmate to a dedicated radio, i.e 'radio0' (default: use all radios)
+    * trm\_iw => set this option to '0' to use iwinfo for wlan scanning (default: '1', use iw)
 
 ## Setup
 **1. configure a wwan interface in /etc/config/network:**


### PR DESCRIPTION
Maintainer: me
Compile tested: not relevant
Run tested: LEDE, r2028

Description:
* change option 'trm_iw' to boolean,
  1 => use iw (default)
  0 => use iwinfo
* option 'trm_maxretry' now accepts '0' to disable this check at all
* documentation update

Signed-off-by: Dirk Brenken <dev@brenken.org>