### PR TITLE
wireguard: Bump to 0.0.20161025

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -9,12 +9,12 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=wireguard
 
-PKG_VERSION:=0.0.20161001
+PKG_VERSION:=0.0.20161025
 PKG_RELEASE:=1
 
 PKG_SOURCE:=WireGuard-experimental-$(PKG_VERSION).tar.xz
 # This is actually SHA256, but OpenWRT/LEDE will figure it out based on the length
-PKG_MD5SUM:=ac3abb7b940716ac12b96a2cb3f7666598cbefd26f19c268f627dc47cd113ac8
+PKG_MD5SUM:=433fb84d00afa566d77dcb29f87c30e17c1c9c8dc9a9a0026619addfc6553027
 PKG_SOURCE_URL:=https://git.zx2c4.com/WireGuard/snapshot/
 PKG_BUILD_DIR:=$(BUILD_DIR)/WireGuard-experimental-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx WR841 on LEDE r2032
