### PR TITLE
vala: update to version 0.34.2

### DIFF
--- a/lang/vala/Makefile
+++ b/lang/vala/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vala
-PKG_VERSION:=0.32.0
+PKG_VERSION:=0.34.2
 PKG_RELEASE:=1
 PKG_LICENSE:=LGPL-2.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@GNOME/vala/0.32/
-PKG_MD5SUM:=d3ff298424bb80476f7d189e6b614c35
+PKG_SOURCE_URL:=@GNOME/vala/0.34/
+PKG_MD5SUM:=f9b4a0a10b76b56b0b6e914c506a6828
 
 PKG_BUILD_DEPENDS:=glib2 glib2/host vala/host
 HOST_BUILD_DEPENDS:=glib2/host
@@ -48,45 +48,45 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) \
-		$(1)/usr/share/vala-0.32/vapi \
+		$(1)/usr/share/vala-0.34/vapi \
 		$(1)/usr/lib \
-		$(1)/usr/share/pkgconfig
+		$(1)/usr/lib/pkgconfig
 
 	$(INSTALL_DATA) \
-		$(PKG_INSTALL_DIR)/usr/share/vala-0.32/vapi/* \
-		$(1)/usr/share/vala-0.32/vapi
+		$(PKG_INSTALL_DIR)/usr/share/vala-0.34/vapi/* \
+		$(1)/usr/share/vala-0.34/vapi
 
 	$(INSTALL_DATA) \
-		$(PKG_INSTALL_DIR)/usr/lib/libvala-0.32.{so*,la} \
+		$(PKG_INSTALL_DIR)/usr/lib/libvala-0.34.{so*,la} \
 		$(1)/usr/lib
 
 	$(INSTALL_DATA) \
-		$(PKG_INSTALL_DIR)/usr/share/pkgconfig/*.pc \
-		$(1)/usr/share/pkgconfig
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc \
+		$(1)/usr/lib/pkgconfig
 endef
 
 define Package/vala/install
 	$(INSTALL_DIR) \
-		$(1)/usr/share/vala-0.32/vapi \
+		$(1)/usr/share/vala-0.34/vapi \
 		$(1)/usr/lib \
-		$(1)/usr/share/pkgconfig \
+		$(1)/usr/lib/pkgconfig \
 		$(1)/usr/bin
 
 	$(INSTALL_DATA) \
-		$(PKG_INSTALL_DIR)/usr/share/vala-0.32/vapi/* \
-		$(1)/usr/share/vala-0.32/vapi
+		$(PKG_INSTALL_DIR)/usr/share/vala-0.34/vapi/* \
+		$(1)/usr/share/vala-0.34/vapi
 
 	$(INSTALL_DATA) \
-		$(PKG_INSTALL_DIR)/usr/lib/libvala-0.32.{so*,la} \
+		$(PKG_INSTALL_DIR)/usr/lib/libvala-0.34.{so*,la} \
 		$(1)/usr/lib
 
 	$(INSTALL_BIN) \
-		$(PKG_INSTALL_DIR)/usr/bin/{vala,vala-0.32,valac,valac-0.32,vapicheck,vapicheck-0.32,vapigen,vapigen-0.32,vala-gen-introspect,vala-gen-introspect-0.32} \
+		$(PKG_INSTALL_DIR)/usr/bin/{vala,vala-0.34,valac,valac-0.34,vapicheck,vapicheck-0.34,vapigen,vapigen-0.34,vala-gen-introspect,vala-gen-introspect-0.34} \
 		$(1)/usr/bin
 
 	$(INSTALL_DATA) \
-		$(PKG_INSTALL_DIR)/usr/share/pkgconfig/*.pc \
-		$(1)/usr/share/pkgconfig
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc \
+		$(1)/usr/lib/pkgconfig
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: me
Compile tested: brcm2708, Raspberry Pi Model B, openwrt r49975
Run tested: -

Description: update to version 0.34.2
