### PR TITLE
rsyslog: Add uClibc dependencies

### DIFF
--- a/net/rsyslog/Makefile
+++ b/net/rsyslog/Makefile
@@ -29,7 +29,7 @@ define Package/rsyslog
   CATEGORY:=Network
   TITLE:=Enhanced system logging and kernel message trapping daemons
   URL:=http://www.rsyslog.com/
-  DEPENDS:=+libestr +libfastjson +libuuid +zlib
+  DEPENDS:=+libestr +libfastjson +libuuid +zlib +USE_UCLIBC:libpthread +USE_UCLIBC:librt
 endef
 
 define Package/rsyslog/conffiles


### PR DESCRIPTION
Maintainer: @dubek 
Compile tested: mpc85xx, Turris 1.1, OpenWRT 15.05
Run tested: Just minor dependencies change so no extensive testing

Description:

Package doesn't build with uClibc without them, but no change for other libc
variants so no need to bump revision.

Signed-off-by: Michal Hrušecký Michal.Hrusecky@nic.cz
