### PR TITLE
rng-tools: uci-fy, default to doing nothing

### DIFF
--- a/utils/rng-tools/Makefile
+++ b/utils/rng-tools/Makefile
@@ -9,13 +9,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rng-tools
 PKG_VERSION:=5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/gkernel/rng-tools/$(PKG_VERSION)/
 PKG_MD5SUM:=6726cdc6fae1f5122463f24ae980dd68
 PKG_LICENSE:=GPLv2
-PKG_MAINTAINER:=Hannu Nyman <hannu.nyman@iki.fi>
+PKG_MAINTAINER:=Nathaniel Wesley Filardo <nwfilardo@gmail.com>
 
 PKG_FIXUP:=autoreconf
 
@@ -52,6 +52,8 @@ CONFIGURE_ARGS += \
 define Package/rng-tools/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/rngd.init $(1)/etc/init.d/rngd
+	$(INSTALL_DIR) $(1)/etc/uci_defaults
+	$(INSTALL_BIN) ./files/rngd.uci_defaults $(1)/etc/uci_defaults/rngd
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/rngtest $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/sbin

--- a/utils/rng-tools/files/rngd.init
+++ b/utils/rng-tools/files/rngd.init
@@ -3,12 +3,20 @@
 
 START=98
 
-RNGD_AMOUNT=4000
-RNGD_DEVICE="/dev/urandom"
-# Use /dev/urandom as source, as hardware sources like /dev/hwrng are usually not present
+RNGD_FILLWATER=$(uci -q get system.@rngd[0].fill_watermark)
+RNGD_DEVICE=$(uci -q get system.@rngd[0].device)
+RNGD_ENABLED=$(uci -q get system.@rngd[0].enabled)
+RNGD_PRECMD=$(uci -q get system.@rngd[0].precmd)
+
+: ${RNGD_FILLWATER:=4000}
+
+echo PRECMD=\'$RNGD_PRECMD\'
 
 start() {
-	service_start /sbin/rngd -r $RNGD_DEVICE -W $RNGD_AMOUNT
+    [ 1 -eq "$RNGD_ENABLED" ] && {
+      [ -z "${RNGD_PRECMD}" ] || ${RNGD_PRECMD} ${RNGD_DEVICE}
+      service_start /sbin/rngd -r ${RNGD_DEVICE} -W ${RNGD_FILLWATER}
+    }
 }
 
 stop() {

--- a/utils/rng-tools/files/rngd.uci_defaults
+++ b/utils/rng-tools/files/rngd.uci_defaults
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+uci -q show system.@rngd[0] || {
+	uci add system rngd
+	uci set system.@rngd[0].enabled=0
+	uci set system.@rngd[0].device=/dev/urandom
+	uci commit
+}


### PR DESCRIPTION
Maintainer: @hnyman 
Compile tested: LEDE head
Run tested: kirkwood with TrueRNG 2 and config

config rngd
    option enabled '1'
        option precmd 'stty raw -F'
    option device '/dev/ttyACM0'

Description:

Enabling the default configuration will pipe /dev/urandom back into
/dev/random ala the current package behavior.  Because this amounts to
disabling the in-kernel entropy estimation, default disabled.

While here, uci-paramaterize the high watermark.
While here, add a pre-command hook for real RNGs that need 'stty raw'
or other such hooks.  (e.g. the TrueRNG devices)

Signed-off-by: Nathaniel Wesley Filardo nwfilardo@gmail.com

See github openwrt/packages#3142.
