### PR TITLE
python,python3: include host-build.mk in python-host.mk & python3-package.mk

### DIFF
--- a/lang/python/files/python-host.mk
+++ b/lang/python/files/python-host.mk
@@ -5,6 +5,9 @@
 # See /LICENSE for more information.
 #
 
+# For HOST_BUILD_PREFIX
+include $(INCLUDE_DIR)/host-build.mk
+
 HOST_PYTHON_DIR:=$(HOST_BUILD_PREFIX)
 HOST_PYTHON_INC_DIR:=$(HOST_PYTHON_DIR)/include/python$(PYTHON_VERSION)
 HOST_PYTHON_LIB_DIR:=$(HOST_PYTHON_DIR)/lib/python$(PYTHON_VERSION)

--- a/lang/python3/files/python3-package.mk
+++ b/lang/python3/files/python3-package.mk
@@ -5,6 +5,9 @@
 # See /LICENSE for more information.
 #
 
+# For HOST_BUILD_PREFIX
+include $(INCLUDE_DIR)/host-build.mk
+
 PYTHON3_VERSION_MAJOR:=3
 PYTHON3_VERSION_MINOR:=5
 PYTHON3_VERSION_MICRO:=2


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE trunk
Run tested: N/A

Description:

Fixes build issues introduced in https://github.com/openwrt/packages/pull/3297

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>