### PR TITLE
ssmtp: Increase PKG_RELEASE > BB value

### DIFF
--- a/mail/ssmtp/Makefile
+++ b/mail/ssmtp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ssmtp
 PKG_VERSION:=2.64
-PKG_RELEASE:=3
+PKG_RELEASE:=5
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 PKG_LICENSE:=GPL-2.0+
 


### PR DESCRIPTION
Description:

It's a generally good packaging principle that the packages in a distro release n+1 have a release value that is at least the same if not greater than the value in release n.

BB has a PKG_RELEASE of 4 so upping to 5 is a good measure.

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>