### PR TITLE
quasselc, quassel-irssi: add new packages

### DIFF
--- a/libs/quasselc/Makefile
+++ b/libs/quasselc/Makefile
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2016 Ben Rosser <rosser.bjr@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=quasselc
+
+# quasselc upstream doesn't release versions (at least, at the moment),
+# so use commit date for PKG_VERSION and embed commit hash into PKG_RELEASE.
+PKG_VERSION:=2015-04-06
+PKG_SOURCE_VERSION:=fcd966966924e3d9af0954db56117e2f48767ea1
+PKG_RELEASE:=1.$(PKG_SOURCE_VERSION)
+
+PKG_LICENSE:=GPL-3.0+
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/phhusson/QuasselC
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.bz2
+
+PKG_MAINTAINER:=Ben Rosser <rosser.bjr@gmail.com>
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+MAKE_FLAGS += prefix=$(STAGING_DIR)/usr libdir=$(STAGING_DIR)/usr/lib includedir=$(STAGING_DIR)/usr/include
+MAKE_INSTALL_FLAGS += prefix=/usr libdir=/usr/lib includedir=/usr/include
+
+define Package/quasselc
+    SECTION:=libs
+    CATEGORY:=Libraries
+    DEPENDS:=+glib2
+    SUBMENU:=Instant Messaging
+    URL:=https://github.com/phhusson/QuasselC
+    TITLE:=API to access a Quassel Core in pure C
+endef
+
+define Package/quasselc/description
+  An implementation of the Quassel protocol in pure C.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/quasselc
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/quasselc/* $(1)/usr/include/quasselc/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libquasselc.so* $(1)/usr/lib/
+	$(LN) libquasselc.so.0 $(1)/usr/lib/libquasselc.so
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/quasselc.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/quasselc/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libquasselc.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,quasselc))

--- a/libs/quasselc/patches/001-respect-cflags-ldflags.patch
+++ b/libs/quasselc/patches/001-respect-cflags-ldflags.patch
@@ -1,0 +1,18 @@
+diff --git a/Makefile b/Makefile
+index 7994eea..b1f8d83 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,11 +2,11 @@ prefix ?= /usr/local
+ libdir ?= $(prefix)/lib
+ includedir ?= $(prefix)/include
+ 
+-CFLAGS:=-Wall -g -Wextra $(shell pkg-config glib-2.0 --cflags) -Wswitch-enum -std=gnu11 -O2 -fPIC
++CFLAGS+=-Wall -g -Wextra $(shell pkg-config glib-2.0 --cflags) -Wswitch-enum -std=gnu11 -fPIC
+ SO_VERSION = 0
+ VERSION = 0
+ INSTALL = install
+-LDLIBS:=$(shell pkg-config glib-2.0 --libs) -lz
++LDLIBS+=$(shell pkg-config glib-2.0 --libs) -lz
+ 
+ BOTLIBS := -Wl,-rpath,.
+ 

--- a/net/quassel-irssi/Makefile
+++ b/net/quassel-irssi/Makefile
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2016 Ben Rosser <rosser.bjr@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=quassel-irssi
+
+# quassel-irssi upstream doesn't release versions (at least, at the moment),
+# so use commit date for PKG_VERSION and embed commit hash into PKG_RELEASE.
+PKG_VERSION:=2016-09-11
+PKG_SOURCE_VERSION:=cbd9bd7f4ac44260d9fcafb809fdf153cde193e5
+PKG_RELEASE:=1.$(PKG_SOURCE_VERSION)
+
+PKG_LICENSE:=GPL-3.0+
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/phhusson/quassel-irssi
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.bz2
+
+PKG_MAINTAINER:=Ben Rosser <rosser.bjr@gmail.com>
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+MAKE_PATH := core
+MAKE_VARS += SYSTEM_QUASSELC=1 IRSSI_CFLAGS="$(TARGET_CFLAGS) $(EXTRA_CFLAGS) $(TARGET_CPPFLAGS) $(EXTRA_CPPFLAGS)" IRSSI_INCLUDE=$(STAGING_DIR)/usr/include/irssi
+
+define Package/quassel-irssi
+    SECTION:=net
+    CATEGORY:=Network
+    DEPENDS:=+irssi +quasselc
+    SUBMENU:=Instant Messaging
+    URL:=https://github.com/phhusson/quassel-irssi
+    TITLE:=An irssi plugin to connect to quassel core
+endef
+
+define Package/quassel-irssi/description
+  An irssi plugin that supports connecting to a quassel core.
+endef
+
+define Package/quassel-irssi/install
+	$(INSTALL_DIR) $(1)/usr/lib/irssi/modules/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/irssi/modules/libquassel_core.so* $(1)/usr/lib/irssi/modules/
+endef
+
+$(eval $(call BuildPackage,quassel-irssi))

--- a/net/quassel-irssi/patches/001-respect-cflags.patch
+++ b/net/quassel-irssi/patches/001-respect-cflags.patch
@@ -1,0 +1,22 @@
+diff --git a/core/Makefile b/core/Makefile
+index 6133087..389855c 100644
+--- a/core/Makefile
++++ b/core/Makefile
+@@ -3,7 +3,7 @@ DESTDIR ?=
+ LIBDIR ?= /usr/lib
+ 
+ #IRSSI_INCLUDE:=/home/phh/irssi-0.8.16-rc1.phh/
+-IRSSI_INCLUDE:=/usr/include/irssi/
++IRSSI_INCLUDE?=/usr/include/irssi/
+ IRSSI_LIB?=$(DESTDIR)/$(LIBDIR)/irssi
+ IRSSI_CFLAGS+=-I$(IRSSI_INCLUDE)/src/
+ IRSSI_CFLAGS+=-I$(IRSSI_INCLUDE)/src/core/
+@@ -26,7 +26,7 @@ else
+     LDFLAGS += -lquasselc
+ endif
+ 
+-CFLAGS=-std=gnu11 -Wall -Wextra -Werror -g -O2 $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations
++CFLAGS+=-std=gnu11 -Wall -Wextra -Werror -g $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations
+ 
+ TARGET=libquassel_core.so
+ 

--- a/net/quassel-irssi/patches/002-use-cc-var.patch
+++ b/net/quassel-irssi/patches/002-use-cc-var.patch
@@ -1,0 +1,13 @@
+diff --git a/core/Makefile b/core/Makefile
+index 389855c..2f81417 100644
+--- a/core/Makefile
++++ b/core/Makefile
+@@ -44,7 +44,7 @@ irssi/network-openssl.o: CFLAGS:=$(IRSSI_CFLAGS)
+ quasselc-connector.o: CFLAGS:=$(CFLAGS)
+ 
+ $(TARGET): $(OBJECTS)
+-	gcc -shared $^ -o $@ -lz $(LDFLAGS)
++	$(CC) -shared $^ -o $@ -lz $(LDFLAGS)
+ 
+ install: $(TARGET)
+ 	$(INSTALL) -d $(IRSSI_LIB)/modules

--- a/net/quassel-irssi/patches/003-use-pkgconfig-ldflags-quasselc.patch
+++ b/net/quassel-irssi/patches/003-use-pkgconfig-ldflags-quasselc.patch
@@ -1,0 +1,13 @@
+diff --git a/core/Makefile b/core/Makefile
+index 2f81417..aa62201 100644
+--- a/core/Makefile
++++ b/core/Makefile
+@@ -23,7 +23,7 @@ ifndef SYSTEM_QUASSELC
+     QUASSELC_FLAGS:=-Ilib
+ else
+     QUASSELC_FLAGS:=$(shell pkg-config --cflags quasselc)
+-    LDFLAGS += -lquasselc
++    LDFLAGS += $(shell pkg-config --libs quasselc)
+ endif
+ 
+ CFLAGS+=-std=gnu11 -Wall -Wextra -Werror -g -O2 $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations


### PR DESCRIPTION
Maintainer: me (@TC01)

Compile tested: tested build on ar71xx and mvebu on OpenWRT trunk. Also tested mvebu on OpenWRT CC so I could actually test: packages required some minor modifications in order to link properly against iconv (whereas, as of trunk, the pkg-config file for glib2 seems to provide the right flags for this). The makefiles here only build against OpenWRT trunk (and presumably LEDE trunk too, but I didn't test that).

(As an aside, I also had to apply [this patch](https://github.com/openwrt/packages/blob/master/libs/glib2/patches/002-gdate-Suppress-string-format-literal-warning.patch) from trunk in order to get glib to build on CC).

Run tested: tested that package actually works on a WRT1900AC (mvebu) running Chaos Calmer; specifically, I could connect to a quasselcore. (Note that sometimes irssi segfaults when exiting while disconnecting from a core; this is a 'known issue' upstream-- it occurs on other platforms too).

Description:

This adds two new packages, quasselc and quassel-irssi (quasselc is a library quassel-irssi depends on):

* quasselc is a library providing an API to access a Quassel core in pure C. Quassel is a distributed IRC client where the core can run independently of the interface(s). This library provides a C API for programs that wish to implement the Quassel protocol.

* quassel-irssi is an irssi plugin that allows irssi to connect to Quassel cores. Quassel is a distributed IRC client in which the core can run independently and be connected to by quassel clients over the network.

Signed-off-by: Ben Rosser <rosser.bjr@gmail.com>

These are my first OpenWRT packages; I did have one question about them. quasselc and quassel-irssi don't actually have "releases" per se, so these are git snapshots. Is there an OpenWRT convention as to what I should do for PKG_VERSION and PKG_RELEASE? In Fedora (where I'm also a package maintainer) the convention would be to set Version = 0 in case upstream eventually starts creating actual releases and include the git commit hash in Release. I couldn't tell simply from looking at other packages if there's a standard in OpenWRT so I did that: should I do this differently?