### PR TITLE
python, python3: use STAGING_DIR_HOSTPKG

### DIFF
--- a/lang/python/files/python-host.mk
+++ b/lang/python/files/python-host.mk
@@ -5,10 +5,13 @@
 # See /LICENSE for more information.
 #
 
-# For HOST_BUILD_PREFIX
-include $(INCLUDE_DIR)/host-build.mk
+# Compatibility fallback for older OpenWrt and LEDE versions
+ifeq ($(STAGING_DIR_HOSTPKG),)
+  $(warning STAGING_DIR_HOSTPKG is unset - falling back to $$(STAGING_DIR)/host)
+  STAGING_DIR_HOSTPKG := $(STAGING_DIR)/host
+endif
 
-HOST_PYTHON_DIR:=$(HOST_BUILD_PREFIX)
+HOST_PYTHON_DIR:=$(STAGING_DIR_HOSTPKG)
 HOST_PYTHON_INC_DIR:=$(HOST_PYTHON_DIR)/include/python$(PYTHON_VERSION)
 HOST_PYTHON_LIB_DIR:=$(HOST_PYTHON_DIR)/lib/python$(PYTHON_VERSION)
 
@@ -16,7 +19,7 @@ HOST_PYTHON_PKG_DIR:=/lib/python$(PYTHON_VERSION)/site-packages
 
 HOST_PYTHON_BIN:=$(HOST_PYTHON_DIR)/bin/python$(PYTHON_VERSION)
 
-HOST_PYTHONPATH:=$(HOST_PYTHON_LIB_DIR):$(HOST_BUILD_PREFIX)/$(HOST_PYTHON_PKG_DIR)
+HOST_PYTHONPATH:=$(HOST_PYTHON_LIB_DIR):$(STAGING_DIR_HOSTPKG)/$(HOST_PYTHON_PKG_DIR)
 
 define HostPython
 	if [ "$(strip $(3))" == "HOST" ]; then \
@@ -47,7 +50,7 @@ define Build/Compile/HostPyRunHost
 		LDSHARED="$(HOSTCC) -shared" \
 		CFLAGS="$(HOST_CFLAGS)" \
 		CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON_INC_DIR)" \
-		LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON_VERSION) -Wl$(comma)-rpath=$(HOST_BUILD_PREFIX)/lib" \
+		LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib" \
 		_PYTHON_HOST_PLATFORM=linux2 \
 		$(3) \
 		, \

--- a/lang/python3/files/python3-package.mk
+++ b/lang/python3/files/python3-package.mk
@@ -5,8 +5,11 @@
 # See /LICENSE for more information.
 #
 
-# For HOST_BUILD_PREFIX
-include $(INCLUDE_DIR)/host-build.mk
+# Compatibility fallback for older OpenWrt and LEDE versions
+ifeq ($(STAGING_DIR_HOSTPKG),)
+  $(warning STAGING_DIR_HOSTPKG is unset - falling back to $$(STAGING_DIR)/host)
+  STAGING_DIR_HOSTPKG := $(STAGING_DIR)/host
+endif
 
 PYTHON3_VERSION_MAJOR:=3
 PYTHON3_VERSION_MINOR:=5
@@ -23,8 +26,8 @@ PYTHON3_PKG_DIR:=/usr/lib/python$(PYTHON3_VERSION)/site-packages
 
 PYTHON3:=python$(PYTHON3_VERSION)
 
-HOST_PYTHON3_LIB_DIR:=$(HOST_BUILD_PREFIX)/lib/python$(PYTHON3_VERSION)
-HOST_PYTHON3_BIN:=$(HOST_BUILD_PREFIX)/bin/python3
+HOST_PYTHON3_LIB_DIR:=$(STAGING_DIR_HOSTPKG)/lib/python$(PYTHON3_VERSION)
+HOST_PYTHON3_BIN:=$(STAGING_DIR_HOSTPKG)/bin/python3
 
 PYTHON3PATH:=$(PYTHON3_LIB_DIR):$(STAGING_DIR)/$(PYTHON3_PKG_DIR):$(PKG_INSTALL_DIR)/$(PYTHON3_PKG_DIR)
 define HostPython3


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: LEDE 8bf4105a71387ef502731dd3e987e82f45daad89 / r2080
Run tested: -
Description:

Currently, the python host build framework relies on HOST_BUILD_PREFIX to
refer to the $(STAGING_DIR)/host directory but using the HOST_BUILD_PREFIX
variable requires the use of include/host-build.mk which in turn includes
the python host build makefiles, leading to target redefinition errors.

In order to provide a global, uniform way to refer to the host staging
directory, LEDE introduced a new variable STAGING_DIR_HOSTPKG which points
to $(STAGING_DIR)/host for now with the purpose of eventually being able to
relocate that directory in the future.

This PR changes the python host build files to ...
 - stop including include/host-build.mk (revert of #3423)
 - replace usages of $(HOST_BUILD_PREFIX) with $(STAGING_DIR_HOSTPKG)
 - warn and fallback to $(STAGING_DIR)/host if STAGING_DIR_HOSTPKG is
   unavailable

The fallback code will ensure that the python host build infrastructure
continues to work properly on older OpenWrt and LEDE versions until the
STAGING_DIR_HOSTPKG is fully settled in and can be removed some time
in the future.

Supersedes https://github.com/lede-project/source/pull/465
Reverts #3423
Fixes #3430