### PR TITLE
libtalloc compilation fix

### DIFF
--- a/libs/libtalloc/Makefile
+++ b/libs/libtalloc/Makefile
@@ -28,7 +28,7 @@ define Package/libtalloc
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Core memory allocator used in Samba
-  DEPENDS:=+USE_GLIBC:libbsd $(ICONV_DEPENDS)
+  DEPENDS:=+USE_GLIBC:libbsd $(ICONV_DEPENDS) libattr
   URL:=https://talloc.samba.org/talloc/doc/html/index.html
 endef
 


### PR DESCRIPTION
Maintainer: @LucileQ
Compile tested: x86, generic, latest
Run tested: None

Description:
Fix compiling for libtalloc - add libattr dependency
