### PR TITLE
gst1-libav compilation fix

### DIFF
--- a/multimedia/gst1-libav/Makefile
+++ b/multimedia/gst1-libav/Makefile
@@ -146,7 +146,7 @@ LIBAV_CONFIGURE_PROTOCOLS:=$(call FILTER_CONFIG,PROTOCOL,protocol,$(LIBAV_PROTOC
 
 CONFIGURE_ARGS += \
 	--without-system-libav \
-	--with-libav-extra-configure="--target-os=linux --cpu=$(CONFIG_CPU_TYPE) \
+	--with-libav-extra-configure="--target-os=linux --cpu=$(subst $\",,$(CONFIG_CPU_TYPE)) \
 	--disable-bsfs \
 	--disable-programs \
 	--disable-devices \


### PR DESCRIPTION
Maintainer: @thess
Compile tested: x86, generic, latest
Run tested: None

Description:
Fix compiling for libtalloc
Remove quotes from cpu type - by default is " " and the error was:
```
Package libtalloc is missing dependencies for the following libraries:
libattr.so.1
```
Signed-off-by: Cezar Burlacu <cezar@embeddedp.ro>