### PR TITLE
net/cifs-utils: missing dependency

### DIFF
--- a/net/cifs-utils/Makefile
+++ b/net/cifs-utils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cifs-utils
 PKG_VERSION:=6.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://ftp.samba.org/pub/linux-cifs/cifs-utils
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -24,6 +24,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/cifsmount
   SECTION:=net
   CATEGORY:=Network
+  DEPENDS:=+kmod-fs-cifs
   TITLE:=CIFS mount utilities
   URL:=http://wiki.samba.org/index.php/LinuxCIFS_utils
 endef


### PR DESCRIPTION
'cifsmount' alone is not able to mount a SMB share, after
having installed kmod-fs-cifs this was possible.
So I guess adding kmod-fs-cifs as a dependency to cifsmount is ok.

Signed-off-by: Paul Wassi <p.wassi@gmx.at>