### PR TITLE
zoneinfo: capitalize submenu name (zoneinfo -> Zoneinfo)

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -33,7 +33,7 @@ endef
 $(eval $(call Download,tzcode))
 
 define Package/zoneinfo/Default
-  SUBMENU:=zoneinfo
+  SUBMENU:=Zoneinfo
   TITLE:=Zone Information
   SECTION:=utils
   CATEGORY:=Utilities


### PR DESCRIPTION
Maintainer: @Wedmer 
Compile tested: n/a
Run tested: Packages are shown under Zoneinfo submenu

Description: Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>