### PR TITLE
jpeg-tools: move to Image Manipulation submenu

### DIFF
--- a/libs/libjpeg/Makefile
+++ b/libs/libjpeg/Makefile
@@ -41,6 +41,7 @@ define Package/jpeg-tools
   $(call Package/jpeg/Default)
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Image Manipulation
   DEPENDS:=+libjpeg
   TITLE+= manipulation tools
 endef


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: n/a
Run tested: the jpeg-tools package is shown in the Image Manipulation submenu

Description:Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>