### PR TITLE
tiff-utils: move to Image Manipulation submenu

### DIFF
--- a/libs/tiff/Makefile
+++ b/libs/tiff/Makefile
@@ -54,6 +54,7 @@ define Package/tiff-utils
 $(call Package/tiff/Default)
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Image Manipulation
   TITLE+= utilities
   DEPENDS:=+libtiff
 endef


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: n/a
Run tested: tiff-utils package is shown in Image Manipulation submenu

Description: Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>