### PR TITLE
avrdude: move to "Microcontroller programming" submenu

### DIFF
--- a/utils/avrdude/Makefile
+++ b/utils/avrdude/Makefile
@@ -28,6 +28,7 @@ include $(INCLUDE_DIR)/nls.mk
 define Package/avrdude
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Microcontroller programming
   TITLE:=AVR Downloader/UploaDEr
   URL:=http://www.nongnu.org/avrdude/
   DEPENDS:=+libncurses +libreadline +libusb-compat +libftdi1 +libelf1


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: n/a
Run tested: avrdude shows under Microcontroller programming submenu

Description: Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>