### PR TITLE
dfu-programmer: move to "Microcontroller programming" submenu

### DIFF
--- a/utils/dfu-programmer/Makefile
+++ b/utils/dfu-programmer/Makefile
@@ -27,6 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/dfu-programmer
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Microcontroller programming
   TITLE:=USB programmer for Atmel microcontrollers
   URL:=http://dfu-programmer.github.io/
   DEPENDS:=+libusb-1.0


### PR DESCRIPTION
Maintainer: @the2masters 
Compile tested: n/a
Run tested: dfu-programmer is shown in "Microcontroller programming" submenu

Description: Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>