### PR TITLE
stm32flash: move to "Microcontroller programming" submenu

### DIFF
--- a/utils/stm32flash/Makefile
+++ b/utils/stm32flash/Makefile
@@ -23,6 +23,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/stm32flash
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Microcontroller programming
   URL:=http://code.google.com/p/stm32flash/
   TITLE:=Firmware flash tool for STM32's serial bootloader
 endef


### PR DESCRIPTION
Maintainer: @equinox0815 
Compile tested: n/a
Run tested: stm32flash is shown in Microcontroller programming submenu

Description: Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>