### PR TITLE
[utils/zoneinfo] Updated to the latest release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2016h
-PKG_VERSION_CODE:=2016h
+PKG_VERSION:=2016i
+PKG_VERSION_CODE:=2016i
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -20,14 +20,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION_CODE).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_MD5SUM:=878f0ec3fd9e4026ea11dd1b649a315a
+PKG_MD5SUM:=73912ecfa6a9a8048ddf2e719d9bc39d
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   MD5SUM:=00c20689d996dea4cf5b45504724ce8f
+   MD5SUM:=8fae14cba9396462955b7859cf04ba48
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: ti omap targets, custom build. OpenWrt master branch
Run tested: n/a

Description:

   Briefly: Cyprus split into two time zones on 2016-10-30, and Tonga
   reintroduces DST on 2016-11-06.

   Changes to future time stamps

     Pacific/Tongatapu begins DST on 2016-11-06 at 02:00, ending on
     2017-01-15 at 03:00.  Assume future observances in Tonga will be
     from the first Sunday in November through the third Sunday in
     January, like Fiji.  (Thanks to Pulu ?Anau.)  Switch to numeric
     time zone abbreviations for this zone.

   Changes to past and future time stamps

     Northern Cyprus is now +03 year round, causing a split in Cyprus
     time zones starting 2016-10-30 at 04:00.  This creates a zone
     Asia/Famagusta.  (Thanks to Even Scharning and Matt Johnson.)

     Antarctica/Casey switched from +08 to +11 on 2016-10-22.
     (Thanks to Steffen Thorsen.)

   Changes to past time stamps

     Several corrections were made for pre-1975 time stamps in Italy.
     These affect Europe/Malta, Europe/Rome, Europe/San_Marino, and
     Europe/Vatican.

     First, the 1893-11-01 00:00 transition in Italy used the new UT
     offset (+01), not the old (+00:49:56).  (Thanks to Michael
     Deckers.)

     Second, rules for daylight saving in Italy were changed to agree
     with Italy's National Institute of Metrological Research (INRiM)
     except for 1944, as follows (thanks to Pierpaolo Bernardi, Brian
     Inglis, and Michael Deckers):

       The 1916-06-03 transition was at 24:00, not 00:00.

       The 1916-10-01, 1919-10-05, and 1920-09-19 transitions were at
       00:00, not 01:00.

       The 1917-09-30 and 1918-10-06 transitions were at 24:00, not
       01:00.

       The 1944-09-17 transition was at 03:00, not 01:00.  This
       particular change is taken from Italian law as INRiM's table,
       (which says 02:00) appears to have a typo here.  Also, keep the
       1944-04-03 transition for Europe/Rome, as Rome was controlled by
       Germany then.

       The 1967-1970 and 1972-1974 fallback transitions were at 01:00,
       not 00:00.

   Changes to code

     The code should now be buildable on AmigaOS merely by setting the
     appropriate Makefile variables.  (From a patch by Carsten Larsen.)
