### PR TITLE
python-dns: version update to 1.15.0

### DIFF
--- a/lang/python-dns/Makefile
+++ b/lang/python-dns/Makefile
@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dns
 PKG_RELEASE:=1
-PKG_VERSION:=1.12.0
+PKG_VERSION:=1.15.0
 PKG_SOURCE_URL:=http://www.dnspython.org/kits/$(PKG_VERSION)
-PKG_MD5SUM:=3f2601ef3c8b77fc6d21a9c77a81efeb
+PKG_MD5SUM:=63a679089822fb86127867c315286dc5
 PKG_SOURCE:=dnspython-$(PKG_VERSION).tar.gz
 PKG_MAINTAINER:=Denis Shulyaka <Shulyaka@gmail.com>
 PKG_LICENSE:=ISC


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE f20ba0f0d59dabc1a61864f35bd6e57f6ee0aab7 (28-OCT-2016), MIPS (ar71xx)
Run tested: LEDE f20ba0f0d59dabc1a61864f35bd6e57f6ee0aab7 (28-OCT-2016), MIPS (ar71xx)