### PR TITLE
net/rp-pppoe: Update to 3.12

### DIFF
--- a/net/rp-pppoe/Makefile
+++ b/net/rp-pppoe/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rp-pppoe
-PKG_VERSION:=3.11
+PKG_VERSION:=3.12
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Daniel Dickinson <lede@daniel.thecshore.com>
+PKG_MAINTAINER:=Daniel Dickinson <lede@cshore.thecshore.com>
 PKG_LICENSE:=LGPL-2.0+
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://roaringpenguin.com/files/download
-PKG_MD5SUM:=13b5900c56bd602df6cc526e5e520722
+PKG_MD5SUM:=00794e04031546b0e9b8cf286f2a6d1ccfc4a621b2a3abb2d7ef2a7ab7cc86c2
 
 PKG_BUILD_DEPENDS:=ppp
 


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, LEDE trunk
Run tested: ar71xx, LEDE trunk WNDR3800, basic connectivity tests.

Description:

Update package to latest stable upstream and update my maintainer email

Signed-off-by: Daniel Dickinson <lede@cshore.thecshore.com>