### PR TITLE
net/rsync: Make using ACL/XATTR the default if it's core default

### DIFF
--- a/net/rsync/Config.in
+++ b/net/rsync/Config.in
@@ -3,11 +3,13 @@ if PACKAGE_rsync
 	config RSYNC_xattr
 		bool
 		prompt "Enable xattr support"
+		default y if USE_FS_ACL_ATTR
 		default n
 
 	config RSYNC_acl
 		bool
 		prompt "Enable ACL support"
+		default y if USE_FS_ACL_ATTR
 		default n
 
 	config RSYNC_zlib

--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsync
 PKG_VERSION:=3.1.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://rsync.samba.org/ftp/rsync/src


### PR DESCRIPTION
Maintainer: @mstorchak 
Compile tested: x86_64, LEDE trunk a month ago
Run tested: x86_64, LEDE trunk a month ago

Description:

Core has an option to enable ACL/XATTR by default;
if that is set default rsync to use it.

Signed-off-by: Daniel Dickinson <lede@daniel.thecshore.com>