### PR TITLE
utils/lxc: Better dependencies

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -39,10 +39,11 @@ LXC_SCRIPTS += \
 
 DEPENDS_APPLETS = +libpthread +libcap +liblxc
 
-DEPENDS_create = +lxc-configs +lxc-hooks +lxc-templates +flock
+DEPENDS_create = +lxc-configs +lxc-hooks +lxc-templates +flock +!LXC_BUSYBOX_OPTIONS:tar +!LXC_BUSYBOX_OPTIONS:getopt
 
 DEPENDS_ls = +lxc-config
 DEPENDS_top = +lxc-lua +luafilesystem @BROKEN
+DEPENDS_autostart = @BROKEN
 
 
 define Package/lxc/Default


### PR DESCRIPTION
Maintainer: @lperkov 
Compile tested: x86_64, LEDE trunk
Run tested: x86_64, LEDE trunk, installed packages.

Description:

Instead of depending on configuring busybox to get functionality
not normally included (and which is default n in the lxc config
because it would force all buildbot builds to use them), if the
busybox setting config option is not set, depend on full tar
(which now has the required functionality be default) and full
getopt.  If trunk devs can be convinced to add the kernel options
we might even get lxc out of the box (except for the LXC_MISC option
the kernel options lxc needs are required for jails anyway, so this
might actually happen).