### PR TITLE
utils/lxc: Fix openwrt common config

### DIFF
--- a/utils/lxc/patches/050-fix-openwrt-conf-file.patch
+++ b/utils/lxc/patches/050-fix-openwrt-conf-file.patch
@@ -1,0 +1,56 @@
+Index: lxc-1.1.5/config/templates/openwrt.common.conf.in
+===================================================================
+--- lxc-1.1.5.orig/config/templates/openwrt.common.conf.in
++++ lxc-1.1.5/config/templates/openwrt.common.conf.in
+@@ -1,37 +1,19 @@
+-# Default console settings
+-lxc.devttydir = lxc
+-lxc.tty = 4
+-lxc.pts = 1024
+-
+-# Default capabilities
+-lxc.cap.drop = mac_admin
+-lxc.cap.drop = mac_override
++# This derives from the global common config
++lxc.include = @LXCTEMPLATECONFIG@/common.conf
++
++# Drop additional default capabilities
+ lxc.cap.drop = sys_admin
+-lxc.cap.drop = sys_module
+ lxc.cap.drop = sys_nice
+ lxc.cap.drop = sys_pacct
+ lxc.cap.drop = sys_ptrace
+ lxc.cap.drop = sys_rawio
+ lxc.cap.drop = sys_resource
+-lxc.cap.drop = sys_time
+ lxc.cap.drop = sys_tty_config
+ lxc.cap.drop = syslog
+ lxc.cap.drop = wake_alarm
+ 
+-# Default cgroups - all denied except those whitelisted
+-lxc.cgroup.devices.deny = a
+-## /dev/null and zero
+-lxc.cgroup.devices.allow = c 1:3 rwm
+-lxc.cgroup.devices.allow = c 1:5 rwm
+-## consoles
+-lxc.cgroup.devices.allow = c 5:0 rwm
+-lxc.cgroup.devices.allow = c 5:1 rwm
+-## /dev/{,u}random
+-lxc.cgroup.devices.allow = c 1:8 rwm
+-lxc.cgroup.devices.allow = c 1:9 rwm
+-## /dev/pts/*
+-lxc.cgroup.devices.allow = c 5:2 rwm
+-lxc.cgroup.devices.allow = c 136:* rwm
++# Additional devices
++
+ ## rtc
+ lxc.cgroup.devices.allow = c 254:0 rm
+ ## tun
+@@ -45,6 +27,4 @@ lxc.cgroup.devices.allow = c 4:1 rwm
+ ## configuration file (uncommented).
+ #lxc.cgroup.devices.allow = b 7:* rwm
+ 
+-# Blacklist some syscalls which are not safe in privileged
+-# containers
+-lxc.seccomp = /usr/share/lxc/config/common.seccomp
++


### PR DESCRIPTION
Maintainer: @lperkov 
Compile tested: x86_64, LEDE trunk
Run tested: x86_64, LEDE trunk, ran openwrt-based containers using lxc-openwrt templates from PR #3479 

Description:

OpenWrt common config is missing system mounts (e.g. proc),
so fix that by making openwrt common default workable.

Signed-off-by: Daniel Dickinson <lede@cshore.thecshore.com>