### PR TITLE
utils/open-plc-utils: Remove non-existing dependency

### DIFF
--- a/utils/open-plc-utils/Makefile
+++ b/utils/open-plc-utils/Makefile
@@ -41,7 +41,6 @@ endef
 define GenPlugin
   define Package/$(addprefix open-plc-utils-,$(1))
     $(call Package/open-plc-utils/Default)
-    DEPENDS:=open-plc-utils
     TITLE:=Utility $(2) from the Open PLC utilities
   endef
 


### PR DESCRIPTION
Maintainer: @thomasnordquist
Compile tested: ar71xx, generic, latest
Run tested: ar71xx, wr-1043nd, 15.05, install/test of open-plc-utils-plcrate

Description:

All plc utils apps should work on their own.
The dependency to open-plc-utils (which simply does not exist) should therefore be unnecessary.

Signed-off-by: Thomas Nordquist <thomasnordquist@users.noreply.github.com>