### PR TITLE
shairport-sync: update to v2.8.6

### DIFF
--- a/sound/shairport-sync/Makefile
+++ b/sound/shairport-sync/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shairport-sync
-PKG_VERSION:=2.8.4
+PKG_VERSION:=2.8.6
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git


### PR DESCRIPTION
Maintainers: @Noltari, @thess, @mikebrady 

Compile tested: LEDE trunk r2096, ramips MT7620 - Xiaomi MiWifi Mini
Run tested: LEDE trunk r2096, ramips MT7620 - Xiaomi MiWifi Mini - app/service starts and works as expected, tested with TuneBlade 1.6.3.0

Description:
update to v2.8.6

Signed-off-by: Dmitry Sutyagin <f3flight@gmail.com>