### PR TITLE
netdata: Make netdata less noisy during startup

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Daniel Engberg <daniel.engberg.lists@pyret.net>
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING

--- a/admin/netdata/files/netdata.conf
+++ b/admin/netdata/files/netdata.conf
@@ -4,7 +4,7 @@
 ###
 ### charts.d    - REQUIRES Bash, enable here and edit charts.d.conf
 ### apps        - none atm
-### node.d      - REQURIES node.js
+### node.d      - REQUIRES node.js
 ### tc          - QoS stats (if wanted)
 ### cgcroups    - No support in OpenWRT/LEDE by default
 ### health      - Disabled by default
@@ -33,4 +33,11 @@
 	enabled = no
 
 [plugin:proc]
+	/proc/net/softnet_stat = no
+	/proc/net/snmp = no
 	/sys/kernel/mm/ksm = no
+	/proc/net/netstat = no
+	/proc/net/ip_vs_stats = no
+	/proc/net/stat/synproxy = no
+	/proc/net/rpc/nfsd = no
+	/proc/net/rpc/nfs = no


### PR DESCRIPTION
Maintainer: myself
Compile tested: LEDE r1952 
Run tested: ar71xx, TL-WDR3600, LEDE r1952 

Description:

Disables proc entries that aren't available/enabled by default in LEDE/OpenWRT

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>