### PR TITLE
open-plc-utils: Force creation of open-plc-utils metapackage

### DIFF
--- a/utils/open-plc-utils/Makefile
+++ b/utils/open-plc-utils/Makefile
@@ -91,6 +91,7 @@ define Build/Compile
 endef
 
 define Package/open-plc-utils/install
+	true
 endef
 
 define BuildPlugin


### PR DESCRIPTION
Please double check that your commits:
- all start with "<package name>: "
- all contain signed-off-by
- are linked to your github account (you see your logo in front of them) 

Please also read https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md

Thanks for your contribution
Please remove this text (before ---) and fill the following template
-------------------------------

Maintainer: me
Compile tested: Malta, latest LEDE and OpenWrt 15.05 branch
Run tested: Malta, on both latest LEDE and OpenWRt 15.05 branch, checked that meta package can be installed through local package mirror

Description:

Without it, all other plugin packages are not installable.

Fixes #3481

Signed-off-by: Florian Fainelli <f.fainelli@gmail.com>