### PR TITLE
libtalloc: add libattr dependency

### DIFF
--- a/libs/libtalloc/Makefile
+++ b/libs/libtalloc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=talloc
 PKG_VERSION:=2.1.7
 MAJOR_VERSION:=2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.samba.org/ftp/talloc/
@@ -28,7 +28,7 @@ define Package/libtalloc
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Core memory allocator used in Samba
-  DEPENDS:=+USE_GLIBC:libbsd $(ICONV_DEPENDS)
+  DEPENDS:=+USE_GLIBC:libbsd $(ICONV_DEPENDS) +libattr
   URL:=https://talloc.samba.org/talloc/doc/html/index.html
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, latest OpenWRT
Run tested: no

Description:

When libattr is selected, libtalloc links to this shared library and
the build fails with:
"Package libtalloc is missing dependencies for the following libraries:
libattr.so.1"

This commit adds libattr dependency, so that libtalloc systematically
links to this library.

Signed-off-by: Etienne CHAMPETIER <champetier.etienne@gmail.com>
[Lucile: replace attr with libattr, edit commit message]
Signed-off-by: Lucile Quirion <lucile.quirion@savoirfairelinux.com>