### PR TITLE
softethervpn: added new package 4.21-9613

### DIFF
--- a/net/softethervpn/Makefile
+++ b/net/softethervpn/Makefile
@@ -1,0 +1,131 @@
+#
+# Copyright (C) 2008-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+# Based on the initial porting done by el1n
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=softethervpn
+PKG_VERSION:=4.21-9613
+PKG_VERREL:=beta
+PKG_VERDATE:=2016.04.24
+PKG_RELEASE:=1
+
+PKG_SOURCE:=softether-src-v$(PKG_VERSION)-$(PKG_VERREL).tar.gz
+PKG_SOURCE_URL:=http://www.softether-download.com/files/softether/v$(PKG_VERSION)-$(PKG_VERREL)-$(PKG_VERDATE)-tree/Source_Code/
+PKG_MD5SUM:=928d882d5fc23e00f0a5fa4ebf292ab9
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/v$(PKG_VERSION)
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/nls.mk 
+include $(INCLUDE_DIR)/package.mk
+
+define Package/softethervpn
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=VPN
+  DEPENDS:=+libpthread +librt +libreadline +libopenssl +libncurses +kmod-tun +zlib $(ICONV_DEPENDS)
+  TITLE:=Free Cross-platform Multi-protocol VPN server and client
+  URL:=http://www.softether.org/
+  MAINTAINER:=Federico Di Marco <fededim@gmail.com>
+endef
+
+define Package/softethervpn/description
+SoftEther VPN ("SoftEther" means "Software Ethernet") is one of the world's most powerful and easy-to-use multi-protocol VPN software developed as an academic 
+project from University of Tsukuba, Japan. SoftEther VPN has strong compatibility to today's most popular VPN products among the world. It has the interoperability
+with OpenVPN, L2TP, IPsec, EtherIP, L2TPv3, Cisco VPN Routers and MS-SSTP VPN Clients. SoftEther VPN is the world's only VPN software which supports SSL-VPN, 
+OpenVPN, L2TP, EtherIP, L2TPv3 and IPsec as a single VPN software. SoftEther VPN is not only an alternative VPN server to existing VPN products (OpenVPN, 
+IPsec and MS-SSTP), but has also original strong SSL-VPN protocol to penetrate any kinds of firewalls. Ultra-optimized SSL-VPN Protocol of SoftEther VPN
+has very fast throughput, low latency and firewall resistance.
+endef
+
+
+define Package/softethervpn/conffiles
+/usr/libexec/softethervpn/vpn_server.config
+/usr/libexec/softethervpn/vpn_client.config
+/usr/libexec/softethervpn/vpn_bridge.config
+/usr/libexec/softethervpn/lang.config
+endef
+
+
+ifeq ($(CONFIG_OPENSSL_WITH_SSL3),y)
+	SE_FLAGS=-DSSL3_SUPPORT
+endif
+
+ifeq ($(ARCH),mips)
+	SE_FLAGS+= -minterlink-mips16
+endif
+
+ifeq ($(ARCH),mipsel)
+	SE_FLAGS+= -minterlink-mips16
+endif
+
+
+define Build/Configure
+	if [ -v CONFIG_64BIT ]; then cp $(PKG_BUILD_DIR)/src/makefiles/linux_64bit.mak $(PKG_BUILD_DIR)/Makefile; else cp $(PKG_BUILD_DIR)/src/makefiles/linux_32bit.mak $(PKG_BUILD_DIR)/Makefile; fi;
+endef
+
+define Build/Compile
+	# Softether compiles first a tool called hamcorebuilder which is essentially an archiver. Then the compilation calls this archiver to pack all 
+	# resource files (*.html, *.config, .txt, readme, languages) it needs to run in an archive file called hamcore.se2. The three executables are then built 
+	# and they will have a runtime dependency on this resource archive. By default OpenWRT build process cross compiles all targets in the makefile
+	# generating therefore an error when the archive is generated since the executable is crosscompiled to run on the router and instead it is run
+	# by the build host. The workaround is to compile the archiver with the host environment, generate the hamcore.se2 archive and cross compile everything
+	# again without regenerating the archive.
+
+	# we clean the last cross compiled version
+	make -C $(PKG_BUILD_DIR) clean
+
+	# we compile the hamcorebuilder utility and generate hamcore archive using host environment
+	make -C $(PKG_BUILD_DIR) src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+
+	# we clean everything, but we save the built hamcore archive and we update its timestamp to avoid rebuilding the archive with cross compiled hamcorebuilder
+	mv $(PKG_BUILD_DIR)/src/bin/BuiltHamcoreFiles/unix/hamcore.se2 $(PKG_BUILD_DIR)/src/bin/BuiltHamcoreFiles/unix/hamcore.se2.1
+	make -C $(PKG_BUILD_DIR) clean
+		mv $(PKG_BUILD_DIR)/src/bin/BuiltHamcoreFiles/unix/hamcore.se2.1 $(PKG_BUILD_DIR)/src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+	touch -d "`date -d 1day`" $(PKG_BUILD_DIR)/src/bin/BuiltHamcoreFiles/unix/hamcore.se2
+
+	ls -la $(PKG_BUILD_DIR)/src/bin/BuiltHamcoreFiles/unix
+
+	# we cross compile everything from the scratch
+	$(MAKE) \
+		$(TARGET_CONFIGURE_OPTS) \
+		CCFLAGS="$(SE_FLAGS) -I$(STAGING_DIR)/usr/include $(ICONV_CFLAGS)" \
+		LDFLAGS="-L$(STAGING_DIR)/usr/lib $(ICONV_LDFLAGS)" \
+		-C $(PKG_BUILD_DIR)
+endef
+
+define Package/softethervpn/install
+	$(INSTALL_DIR) $(1)/usr/libexec/softethervpn
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/vpnserver/vpnserver $(1)/usr/libexec/softethervpn
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/vpnserver/hamcore.se2 $(1)/usr/libexec/softethervpn
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/vpnclient/vpnclient $(1)/usr/libexec/softethervpn
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/vpnbridge/vpnbridge $(1)/usr/libexec/softethervpn
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/vpncmd/vpncmd $(1)/usr/libexec/softethervpn
+	$(INSTALL_BIN) files/launcher.sh $(1)/usr/libexec/softethervpn
+
+	$(INSTALL_DATA) files/dummy $(1)/usr/libexec/softethervpn/vpn_server.config
+	$(INSTALL_DATA) files/dummy $(1)/usr/libexec/softethervpn/vpn_bridge.config
+	$(INSTALL_DATA) files/dummy $(1)/usr/libexec/softethervpn/vpn_client.config
+	$(INSTALL_DATA) files/dummy $(1)/usr/libexec/softethervpn/lang.config
+
+	$(INSTALL_DIR) $(1)/usr/bin
+
+	#$(LN) ../../usr/libexec/softethervpn/launcher.sh $(1)/usr/bin/vpnserver
+	#$(LN) ../../usr/libexec/softethervpn/launcher.sh $(1)/usr/bin/vpnclient
+	#$(LN) ../../usr/libexec/softethervpn/launcher.sh $(1)/usr/bin/vpnbridge
+	$(LN) ../../usr/libexec/softethervpn/launcher.sh $(1)/usr/bin/vpncmd
+
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) files/vpnserver.init $(1)/etc/init.d/softethervpnserver
+	$(INSTALL_BIN) files/vpnbridge.init $(1)/etc/init.d/softethervpnbridge
+	$(INSTALL_BIN) files/vpnclient.init $(1)/etc/init.d/softethervpnclient
+endef
+
+$(eval $(call BuildPackage,softethervpn))

--- a/net/softethervpn/files/launcher.sh
+++ b/net/softethervpn/files/launcher.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "/usr/libexec/softethervpn/${0##*/}" "$@"

--- a/net/softethervpn/files/vpnbridge.init
+++ b/net/softethervpn/files/vpnbridge.init
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+START=60
+
+start(){
+        logger -t 'softethervpn' "Starting softether vpnbridge service."
+	/usr/bin/env LANG=en_US.UTF-8 /usr/libexec/softethervpn/vpnbridge start
+}
+
+stop(){
+        logger -t 'softethervpn' "Stopping softether vpnbridge service."
+	/usr/bin/env LANG=en_US.UTF-8 /usr/libexec/softethervpn/vpnbridge stop
+}

--- a/net/softethervpn/files/vpnclient.init
+++ b/net/softethervpn/files/vpnclient.init
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+START=60
+
+start(){
+        logger -t 'softethervpn' "Starting softether vpnclient service."
+	/usr/bin/env LANG=en_US.UTF-8 /usr/libexec/softethervpn/vpnclient start
+}
+
+stop(){
+        logger -t 'softethervpn' "Stopping softether vpnclient service."
+	/usr/bin/env LANG=en_US.UTF-8 /usr/libexec/softethervpn/vpnclient stop
+}

--- a/net/softethervpn/files/vpnserver.init
+++ b/net/softethervpn/files/vpnserver.init
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+START=60
+
+start(){
+        logger -t 'softethervpn' "Starting softether vpnserver service."
+	/usr/bin/env LANG=en_US.UTF-8 /usr/libexec/softethervpn/vpnserver start
+}
+
+stop(){
+        logger -t 'softethervpn' "Stopping softether vpnserver service."
+	/usr/bin/env LANG=en_US.UTF-8 /usr/libexec/softethervpn/vpnserver stop
+}

--- a/net/softethervpn/patches/103-noeucjp.patch
+++ b/net/softethervpn/patches/103-noeucjp.patch
@@ -1,0 +1,29 @@
+--- a/src/Mayaqua/Internat.c
++++ b/src/Mayaqua/Internat.c
+@@ -123,7 +123,7 @@
+ #include <Mayaqua/Mayaqua.h>
+ 
+ extern LOCK *token_lock;
+-static char charset[MAX_SIZE] = "EUCJP";
++static char charset[MAX_SIZE] = "utf-8";
+ static LOCK *iconv_lock = NULL;
+ void *iconv_cache_wide_to_str = 0;
+ void *iconv_cache_str_to_wide = 0;
+@@ -938,7 +938,7 @@ void InitInternational()
+ #ifdef	UNIX_MACOS
+ 		StrCpy(charset, sizeof(charset), "utf-8");
+ #else	// UNIX_MACOS
+-		StrCpy(charset, sizeof(charset), "EUCJP");
++		StrCpy(charset, sizeof(charset), "utf-8");
+ #endif	// UNIX_MACOS
+ 		d = IconvWideToStrInternal();
+ 		if (d == (void *)-1)
+@@ -1198,7 +1198,7 @@ void GetCurrentCharSet(char *name, UINT
+ 		}
+ 		else
+ 		{
+-			StrCpy(name, size, "eucJP");
++			StrCpy(name, size, "utf-8");
+ 		}
+ 	}
+ 	FreeToken(t);

--- a/net/softethervpn/patches/105-nosslv3.patch
+++ b/net/softethervpn/patches/105-nosslv3.patch
@@ -1,0 +1,50 @@
+--- a/src/Mayaqua/Network.c
++++ b/src/Mayaqua/Network.c
+@@ -12966,35 +12966,46 @@ bool StartSSLEx(SOCK *sock, X *x, K *pri
+ 	{
+ 		if (sock->ServerMode)
+ 		{
++#ifdef SSL3_SUPPORT			
+ 			if (sock->AcceptOnlyTls == false)
+ 			{
+ 				SSL_CTX_set_ssl_version(ssl_ctx, SSLv23_method());
+ 			}
+ 			else
+ 			{
++#endif
+ 				SSL_CTX_set_ssl_version(ssl_ctx, TLSv1_method());
++#ifdef SSL3_SUPPORT
+ 			}
+-
++#endif
+ 			Unlock(openssl_lock);
+ 			AddChainSslCertOnDirectory(ssl_ctx);
+ 			Lock(openssl_lock);
+ 		}
+ 		else
+ 		{
++#ifdef SSL3_SUPPORT
+ 			if (client_tls == false)
+ 			{
+ 				SSL_CTX_set_ssl_version(ssl_ctx, SSLv3_method());
+ 			}
+ 			else
+ 			{
++#endif
+ 				SSL_CTX_set_ssl_version(ssl_ctx, TLSv1_client_method());
++#ifdef SSL3_SUPPORT
+ 			}
++#endif
+ 		}
+ 		sock->ssl = SSL_new(ssl_ctx);
+ 		SSL_set_fd(sock->ssl, (int)sock->socket);
+ 
+ #ifdef	SSL_CTRL_SET_TLSEXT_HOSTNAME
++# ifdef SSL3_SUPPORT
+ 		if (sock->ServerMode == false && client_tls)
++# else
++		if (sock->ServerMode == false)
++#endif
+ 		{
+ 			if (IsEmptyStr(sni_hostname) == false)
+ 			{


### PR DESCRIPTION
- based on the work done by el1n with his authorization (https://github.com/el1n/OpenWRT-package-softether)
- updated softethervpn to latest version
- introduced necessary patches for lede compatibility (nossl3)

Compile tested: ar71xx, ramips
Run tested: ramips

Signed-Off-by: Federico Di Marco <fededim@gmail.com>