### PR TITLE
python-dns: add python-setuptools as dependency (fixes build)

### DIFF
--- a/lang/python-dns/Makefile
+++ b/lang/python-dns/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dns
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=1.15.0
 PKG_SOURCE_URL:=http://www.dnspython.org/kits/$(PKG_VERSION)
 PKG_MD5SUM:=63a679089822fb86127867c315286dc5
@@ -17,6 +17,8 @@ PKG_MAINTAINER:=Denis Shulyaka <Shulyaka@gmail.com>
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=LICENSE
 PKG_BUILD_DIR:=$(BUILD_DIR)/dnspython-$(PKG_VERSION)
+
+PKG_BUILD_DEPENDS:=python-setuptools/host
 
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)

--- a/lang/python-dns/Makefile
+++ b/lang/python-dns/Makefile
@@ -36,7 +36,7 @@ endef
 
 define Build/Compile
 	$(call Build/Compile/PyMod,,\
-		install --prefix="$(PKG_INSTALL_DIR)/usr" \
+		install --prefix=/usr --root="$(PKG_INSTALL_DIR)" \
 	)
 endef
 


### PR DESCRIPTION
Maintainer: @Shulyaka 
Compile tested: LEDE trunk
Run tested:N/A

Description:

After commit a4b0c0a
python host does not install/have the built-in setuptools package.

So, for python-dns, we need to add it explicitly (since it's required).

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>