### PR TITLE
postgresql: fix download URLs

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -15,9 +15,9 @@ PKG_LICENSE:=PostgreSQL
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=\
-	http://ftp9.us.postgresql.org/pub/mirrors/postgresql/source/v$(PKG_VERSION) \
-	http://ftp.be.postgresql.org/postgresql/source/v$(PKG_VERSION) \
-	ftp://ftp-archives.postgresql.org/pub/source/v$(PKG_VERSION)
+	https://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
+	http://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
+	ftp://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
 PKG_MD5SUM:=cf5e571164ad66028ecd7dd8819e3765470d45bcd440d258b686be7e69c76ed0
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: ar71xx, Netgear WNDR4300, openwrt r49984
Run tested: -

Description: downloading the source package fails due to name resolution error and MD5 sum mismatch (seems like providing SHA256 hash does not work for ftp:// links). This patch corrects both issues.

```
--2016-11-09 19:25:47--  http://ftp9.us.postgresql.org/pub/mirrors/postgresql/source/v9.5.4/postgresql-9.5.4.tar.bz2
Resolving ftp9.us.postgresql.org (ftp9.us.postgresql.org)... failed: Name or service not known.
wget: unable to resolve host address 'ftp9.us.postgresql.org'
Download failed.
--2016-11-09 19:25:47--  http://ftp.be.postgresql.org/postgresql/source/v9.5.4/postgresql-9.5.4.tar.bz2
Resolving ftp.be.postgresql.org (ftp.be.postgresql.org)... failed: Name or service not known.
wget: unable to resolve host address 'ftp.be.postgresql.org'
Download failed.
--2016-11-09 19:25:47--  ftp://ftp-archives.postgresql.org/pub/source/v9.5.4/postgresql-9.5.4.tar.bz2
           => '-'
Resolving ftp-archives.postgresql.org (ftp-archives.postgresql.org)... 87.238.57.227, 2a02:c0:301:0:ffff::27
Connecting to ftp-archives.postgresql.org (ftp-archives.postgresql.org)|87.238.57.227|:21... connected.
Logging in as anonymous ... Logged in!
==> SYST ... done.    ==> PWD ... done.
==> TYPE I ... done.  ==> CWD (1) /pub/source/v9.5.4 ... done.
==> SIZE postgresql-9.5.4.tar.bz2 ... 18496299
==> PASV ... done.    ==> RETR postgresql-9.5.4.tar.bz2 ... done.
Length: 18496299 (18M) (unauthoritative)

100%[======================================================================================================================================================================================================================================>] 18,496,299  19.1MB/s   in 0.9s   

2016-11-09 19:25:48 (19.1 MB/s) - written to stdout [18496299]

MD5 sum of the downloaded file does not match (file: ad36fcf624748b8ed67783ad04529f43, requested: cf5e571164ad66028ecd7dd8819e3765470d45bcd440d258b686be7e69c76ed0) - deleting download.
```