### PR TITLE
strongswan: Fix compile error due to __kernel_nlink_t being re-defined

### DIFF
--- a/net/strongswan/patches/101-musl-fixes.patch
+++ b/net/strongswan/patches/101-musl-fixes.patch
@@ -10,7 +10,7 @@
  
 --- /dev/null
 +++ b/src/libstrongswan/musl.h
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,38 @@
 +#include <sys/types.h>
 +
 +#define crypt x_crypt
@@ -31,7 +31,6 @@
 +#define nlink_t x_nlink_t
 +#define timer_t x_timer_t
 +#define blkcnt_t x_blkcnt_t
-+#define __kernel_nlink_t void
 +
 +#include <linux/types.h>
 +


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: Atheros ar7xxx, TP-LINK TL-WDR4300, LEDE trunk, BCM63xx
Run tested: Atheros ar7xxx, TP-LINK TL-WDR4300l, LEDE trunk

Description:

Patch 101-musl-fixes defines __kernel_nlink_t as void; but using
a pre-3.6.11 kernel on an arm cortex defines __kernel_nlink_t as
unsigned short using uclibc
Fix the compile issue by not redefining __kernel_nlink_t

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>