### PR TITLE
rng-tools: Fixup Makefile and initscript

### DIFF
--- a/utils/rng-tools/Makefile
+++ b/utils/rng-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rng-tools
 PKG_VERSION:=5
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/gkernel/rng-tools/$(PKG_VERSION)/
@@ -52,8 +52,8 @@ CONFIGURE_ARGS += \
 define Package/rng-tools/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/rngd.init $(1)/etc/init.d/rngd
-	$(INSTALL_DIR) $(1)/etc/uci_defaults
-	$(INSTALL_BIN) ./files/rngd.uci_defaults $(1)/etc/uci_defaults/rngd
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/rngd.uci_defaults $(1)/etc/uci-defaults/rngd
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/rngtest $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/sbin

--- a/utils/rng-tools/files/rngd.init
+++ b/utils/rng-tools/files/rngd.init
@@ -3,22 +3,24 @@
 
 START=98
 
-RNGD_FILLWATER=$(uci -q get system.@rngd[0].fill_watermark)
-RNGD_DEVICE=$(uci -q get system.@rngd[0].device)
-RNGD_ENABLED=$(uci -q get system.@rngd[0].enabled)
-RNGD_PRECMD=$(uci -q get system.@rngd[0].precmd)
+USE_PROCD=1
+PROG=/sbin/rngd
 
-: ${RNGD_FILLWATER:=4000}
+start_service() {
+	local enabled=$(uci -q get system.@rngd[0].enabled)
+	local precmd=$(uci -q get system.@rngd[0].precmd)
+	local device=$(uci -q get system.@rngd[0].device)
+	local watermark=$(uci -q get system.@rngd[0].fill_watermark)
 
-echo PRECMD=\'$RNGD_PRECMD\'
+	[ "$enabled" = "1" ] || return
 
-start() {
-    [ 1 -eq "$RNGD_ENABLED" ] && {
-      [ -z "${RNGD_PRECMD}" ] || ${RNGD_PRECMD} ${RNGD_DEVICE}
-      service_start /sbin/rngd -r ${RNGD_DEVICE} -W ${RNGD_FILLWATER}
-    }
-}
+	[ -z "$precmd" ] || ${precmd} ${device}
 
-stop() {
-	service_stop /sbin/rngd
+	[ -z "$device" ] || device="-r ${device}"
+	[ -z "$watermark" ] || watermark="-W ${watermark}"
+
+	procd_open_instance
+	procd_set_param command "$PROG" -f ${device} ${watermark}
+	procd_set_param stderr 1
+	procd_close_instance
 }


### PR DESCRIPTION
Maintainer: @nwf 
Compile tested: x86-64, lede r2144)
Run tested: x86-64, lede r2144, tested all possible uci settings and no uci config at all

Fixup Makefile and initscript:
- typo in path of uci-defaults scripts (script is currently never run)
- fix init script when there is no rngd config at all
- fix init-script when there is no device entry in uci
- convert init script to procd

Change: When there is no fill_watermark setting in uci, the default of rng-tools (2048) is used instead of the old hardcoded default of 4000.

Service stop is not needed anymore for procd scripts.

Signed-off-by: Stefan Hellermann <stefan@the2masters.de>