### PR TITLE
libnfc: switch git repository to github

### DIFF
--- a/libs/libnfc/Makefile
+++ b/libs/libnfc/Makefile
@@ -15,7 +15,7 @@ PKG_FIXUP:=autoreconf
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://code.google.com/p/libnfc/
+PKG_SOURCE_URL:=https://github.com/nfc-tools/libnfc
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_NAME)-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: Sebastian Wendel packages@sourceindex.de / @sourceindex
Compile tested: mips, mt7688, 15.05
Run tested: mips, mt7688, 15.05

Description:

Switch libnfc git repository to github as google code shutdown in 2016.