### PR TITLE
fwknop: add netfilter_queue option

### DIFF
--- a/net/fwknop/Config.in
+++ b/net/fwknop/Config.in
@@ -7,6 +7,9 @@ config FWKNOPD_GPG
 	select PACKAGE_gnupg
 	default n
 
-
+config FWKNOPD_NFQ_CAPTURE
+	bool "Enable netfilter_queue capture support (disables libpcap support)"
+	select PACKAGE_iptables-mod-nfqueue
+	default n
 
 endmenu

--- a/net/fwknop/Makefile
+++ b/net/fwknop/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fwknop
 PKG_VERSION:=2.6.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=http://www.cipherdyne.org/fwknop/download
+PKG_SOURCE_URL:=https://www.cipherdyne.org/fwknop/download
 PKG_MD5SUM:=e2c49e9674888a028bd443a55c3aaa22
 PKG_MAINTAINER:=Jonathan Bennett <JBennett@incomsystems.biz>
 PKG_LICENSE:=GPLv2
@@ -42,7 +42,8 @@ define Package/fwknopd
   CATEGORY:=Network
   SUBMENU:=Firewall
   TITLE+= Daemon
-  DEPENDS:=+iptables +libfko +libpcap +FWKNOP_GPG:gnupg
+  DEPENDS:=+iptables +libfko +!FWKNOPD_NFQ_CAPTURE:libpcap +FWKNOPD_NFQ_CAPTURE:iptables-mod-nfqueue +FWKNOPD_GPG:gnupg \
+           +FWKNOPD_NFQ_CAPTURE:libnetfilter-queue +FWKNOPD_NFQ_CAPTURE:libnfnetlink
 endef
 
 define Package/fwknopd/description
@@ -90,6 +91,10 @@ endef
 
 ifneq ($(CONFIG_FWKNOPD_GPG),y)
 	CONFIGURE_ARGS += --without-gpgme 
+endif
+
+ifeq ($(CONFIG_FWKNOPD_NFQ_CAPTURE),y)
+	CONFIGURE_ARGS += --enable-nfq-capture
 endif
 
 CONFIGURE_ARGS += \


### PR DESCRIPTION
Maintainer: Jonathan Bennett <JBennett@incomsystems.biz>
Compile tested: mvebu, shelby, LEDE
Run tested: mvebu, shelby, LEDE; installs and properly accepts SPA using NFQ

Description:
A configuration option is added to allow use of netfilter_queue to accept SPA packets instead of libpcap.  When this option is selected libpcap support is disabled at compile time; since libpcap is the existing default setup this selection is disabled by default.

If NFQ is enabled the following changes must be made to /etc/fwknop/fwknopd.conf:
Add line:
  ENABLE_NFQ_CAPTURE Y
If default listen configurations aren't desired these lines can be added:
  NFQ_INTERFACE <interface>
  NFQ_PORT <port #>
  NFQ_TABLE mangle
  NFQ_CHAIN FWKNOP_NFQ
  NFQ_QUEUE_NUMBER <#>
  NFQ_LOOP_SLEEP <# in us>
Remove lines with:
  PCAP_INTF
  PCAP_FILTER

Signed-off-by: InkblotAdmirer <github@inkblotadmirer.me>