### PR TITLE
boost: Patch to support Fiber

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -18,7 +18,7 @@ include $(INCLUDE_DIR)/target.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.62.0
 PKG_SOURCE_VERSION:=1_62_0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceforge.net/projects/boost/files/boost/$(PKG_VERSION)
@@ -253,7 +253,6 @@ define Package/boost/config
 			prompt "Boost $(lib) library."
 			default m if ALL
 			$(if $(findstring locale,$(lib)),depends on BUILD_NLS,)\
-			$(if $(findstring fiber,$(lib)),depends on BROKEN,)\
 			$(if $(findstring python,$(lib)),depends on PACKAGE_$(lib),)
 
 		)
@@ -303,7 +302,7 @@ $(eval $(call DefineBoostLibrary,context,chrono system thread,))
 $(eval $(call DefineBoostLibrary,coroutine,system chrono context thread,))
 $(eval $(call DefineBoostLibrary,date_time,,))
 #$(eval $(call DefineBoostLibrary,exception,,))
-$(eval $(call DefineBoostLibrary,fiber,coroutine,,BROKEN))
+$(eval $(call DefineBoostLibrary,fiber,coroutine,,))
 $(eval $(call DefineBoostLibrary,filesystem,system,))
 $(eval $(call DefineBoostLibrary,graph,regex,))
 $(eval $(call DefineBoostLibrary,iostreams,,+zlib))

--- a/libs/boost/patches/01_fiber_fix.patch
+++ b/libs/boost/patches/01_fiber_fix.patch
@@ -1,0 +1,25 @@
+Index: boost_1_62_0/libs/fiber/build/Jamfile.v2
+===================================================================
+--- boost_1_62_0.orig/libs/fiber/build/Jamfile.v2
++++ boost_1_62_0/libs/fiber/build/Jamfile.v2
+@@ -43,19 +43,6 @@ lib boost_fiber
+       recursive_timed_mutex.cpp
+       timed_mutex.cpp
+       scheduler.cpp
+-    : <link>shared:<library>../../context/build//boost_context
+-    [ requires cxx11_auto_declarations
+-               cxx11_constexpr
+-               cxx11_defaulted_functions
+-               cxx11_final
+-               cxx11_hdr_tuple
+-               cxx11_lambdas
+-               cxx11_noexcept
+-               cxx11_nullptr
+-               cxx11_rvalue_references
+-               cxx11_template_aliases
+-               cxx11_thread_local
+-               cxx11_variadic_templates ]
+-    ;
++    : <link>shared:<library>../../context/build//boost_context ;
+ 
+ boost-install boost_fiber ;


### PR DESCRIPTION
Maintainer: @ClaymorePT
Compile tested: LEDE/trunk
Run tested: Raspberry Pi 2

Description:

This update provides a patch in order to support Boost.Fiber.

Signed-off-by: Carlos M. Ferreira carlosmf.pt@gmail.com