### PR TITLE
wireguard: Bump to 0.0.20161110

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -9,12 +9,12 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=wireguard
 
-PKG_VERSION:=0.0.20161105
+PKG_VERSION:=0.0.20161110
 PKG_RELEASE:=1
 
 PKG_SOURCE:=WireGuard-experimental-$(PKG_VERSION).tar.xz
 # This is actually SHA256, but OpenWRT/LEDE will figure it out based on the length
-PKG_MD5SUM:=3e98535184a9e00e739c8f2b6cc9b20aea876157e36d72726ca7662c9b5556b5
+PKG_MD5SUM:=205478709127c4797b5aa9d6448fae03c10b083404414444bad33e62a609e48f
 PKG_SOURCE_URL:=https://git.zx2c4.com/WireGuard/snapshot/
 PKG_BUILD_DIR:=$(BUILD_DIR)/WireGuard-experimental-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE r2155 for ar71xx and x86_64
Run tested: LEDE r2155 PCengines APU x86_64

This release fixes a kernel stack overflow on MIPS architectures.