### PR TITLE
wireguard-tools: Add netifd protocol helper

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=wireguard
 
 PKG_VERSION:=0.0.20161110
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=WireGuard-experimental-$(PKG_VERSION).tar.xz
 # This is actually SHA256, but OpenWRT/LEDE will figure it out based on the length
@@ -70,18 +70,20 @@ endef
 define Package/wireguard-tools
   $(call Package/wireguard/Default)
   TITLE:=Wireguard userspace control program (wg)
-  DEPENDS:=+libmnl
+  DEPENDS:=+libmnl +resolveip
 endef
 
 define Package/wireguard-tools/description
   $(call Package/wireguard/Default/description)
 
-  This package provides the userspace control program for wireguard: `wg`.
+  This package provides the userspace control program for wireguard, `wg`,
+  and a netifd protocol helper.
 endef
 
 define Package/wireguard-tools/install
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/tools/wg $(1)/usr/bin/
+	$(INSTALL_BIN) ./files/wireguard.sh $(1)/lib/netifd/proto/
 endef
 
 define KernelPackage/wireguard

--- a/net/wireguard/files/wireguard.sh
+++ b/net/wireguard/files/wireguard.sh
@@ -1,0 +1,176 @@
+#!/bin/sh
+# Copyright 2016 Dan Luedtke <mail@danrl.com>
+# Licensed to the public under the Apache License 2.0.
+
+
+WG=/usr/bin/wg
+if [ ! -x $WG ]; then
+  logger -t "wireguard" "error: missing wireguard-tools (${WG})"
+  exit 0
+fi
+
+
+[ -n "$INCLUDE_ONLY" ] || {
+  . /lib/functions.sh
+  . ../netifd-proto.sh
+  init_proto "$@"
+}
+
+
+proto_wireguard_init_config() {
+  proto_config_add_string "private_key"
+  proto_config_add_int    "listen_port"
+  proto_config_add_int    "mtu"
+  proto_config_add_string "preshared_key"
+  available=1
+  no_proto_task=1
+}
+
+
+proto_wireguard_setup_peer() {
+  local peer_config="$1"
+
+  local public_key
+  local allowed_ips
+  local route_allowed_ips
+  local endpoint_host
+  local endpoint_port
+  local persistent_keepalive
+
+  config_get      public_key           "${peer_config}" "public_key"
+  config_get      allowed_ips          "${peer_config}" "allowed_ips"
+  config_get_bool route_allowed_ips    "${peer_config}" "route_allowed_ips" 0
+  config_get      endpoint_host        "${peer_config}" "endpoint_host"
+  config_get      endpoint_port        "${peer_config}" "endpoint_port"
+  config_get      persistent_keepalive "${peer_config}" "persistent_keepalive"
+
+  # peer configuration
+  echo "[Peer]"                                         >> "${wg_cfg}"
+  echo "PublicKey=${public_key}"                        >> "${wg_cfg}"
+  for allowed_ip in $allowed_ips; do
+    echo "AllowedIPs=${allowed_ip}"                     >> "${wg_cfg}"
+  done
+  if [ "${endpoint_host}" ]; then
+    case "${endpoint_host}" in
+      *:*)
+        endpoint="[${endpoint_host}]"
+      ;;
+      *)
+        endpoint="${endpoint_host}"
+      ;;
+    esac
+    if [ "${endpoint_port}" ]; then
+      endpoint="${endpoint}:${endpoint_port}"
+    else
+      endpoint="${endpoint}:51820"
+    fi
+    echo "Endpoint=${endpoint}"                         >> "${wg_cfg}"
+  fi
+  if [ "${persistent_keepalive}" ]; then
+    echo "PersistentKeepalive=${persistent_keepalive}"  >> "${wg_cfg}"
+  fi
+
+  # add routes for allowed ips
+  if [ ${route_allowed_ips} -ne 0 ]; then
+    for allowed_ip in ${allowed_ips}; do
+      case "${allowed_ip}" in
+        *:*/*)
+          proto_add_ipv6_route "${allowed_ip%%/*}" "${allowed_ip##*/}"
+        ;;
+        */*)
+          proto_add_ipv4_route "${allowed_ip%%/*}" "${allowed_ip##*/}"
+        ;;
+      esac
+    done
+  fi
+
+  #### FEATURE DISABLED
+  # proto_add_host_dependency() has failed with IPv6 addresses during tests.
+  # Endpoint dependency feature is disabled until the issue is fixed.
+  ####
+  #  # endpoint dependency
+  #  if [ "${endpoint_host}" ]; then
+  #    endpoint_dependency=0
+  #    for ip in $(resolveip -t 10 "${endpoint_host}"); do
+  #      echo "adding host depedency for ${ip} at ${config}"
+  #      proto_add_host_dependency "${config}" "${ip}"
+  #      endpoint_dependency=1
+  #    done
+  #    if [ ${endpoint_dependency} -eq 0 ]; then
+  #      echo "error resolving ${endpoint_host}!"
+  #      sleep 5
+  #      proto_setup_failed "${config}"
+  #      exit 1
+  #    fi
+  #  fi
+  ####
+}
+
+
+proto_wireguard_setup() {
+  local config="$1"
+  local wg_dir="/tmp/wireguard"
+  local wg_cfg="${wg_dir}/${config}"
+
+  local private_key
+  local listen_port
+  local mtu
+  local preshared_key
+
+  # load configuration
+  config_load network
+  config_get private_key   "${config}" "private_key"
+  config_get listen_port   "${config}" "listen_port"
+  config_get mtu           "${config}" "mtu"
+  config_get preshared_key "${config}" "preshared_key"
+
+  # create interface
+  ip link del dev "${config}" 2>/dev/null
+  ip link add dev "${config}" type wireguard
+
+  if [ "${mtu}" ]; then
+    ip link set mtu "${mtu}" dev "${config}"
+  fi
+
+  proto_init_update "${config}" 1
+
+  # generate configuration file
+  umask 077
+  mkdir -p "${wg_dir}"
+  echo "[Interface]"                     >  "${wg_cfg}"
+  echo "PrivateKey=${private_key}"       >> "${wg_cfg}"
+  if [ "${listen_port}" ]; then
+    echo "ListenPort=${listen_port}"     >> "${wg_cfg}"
+  fi
+  if [ "${preshared_key}" ]; then
+    echo "PresharedKey=${preshared_key}" >> "${wg_cfg}"
+  fi
+  config_foreach proto_wireguard_setup_peer "wireguard_${config}"
+
+  # apply configuration file
+  ${WG} setconf ${config} "${wg_cfg}"
+  WG_RETURN=$?
+
+  # delete configuration file
+  rm -f "${wg_cfg}"
+
+  # check status
+  if [ ${WG_RETURN} -ne 0 ]; then
+    sleep 5
+    proto_setup_failed "${config}"
+    exit 1
+  fi
+
+  proto_send_update "${config}"
+}
+
+
+proto_wireguard_teardown() {
+  local config="$1"
+  ip link del dev "${config}" >/dev/null 2>&1
+}
+
+
+[ -n "$INCLUDE_ONLY" ] || {
+  add_protocol wireguard
+}


### PR DESCRIPTION
Maintainer: @zorun
Run tested: x86, latest snapshot
Description: Adds netifd protocol helper for WireGuard, which is used by luci-proto-wireguard.

Signed-off-by: Dan Luedtke <mail@danrl.com>