### PR TITLE
nmap: Fix compile with stripped down openssl.

### DIFF
--- a/net/nmap/patches/001-fix-missing-includes.patch
+++ b/net/nmap/patches/001-fix-missing-includes.patch
@@ -1,0 +1,14 @@
+diff --git a/ncat/ncat_ssl.c b/ncat/ncat_ssl.c
+index ee8ca97..9ff495c 100644
+--- a/ncat/ncat_ssl.c
++++ b/ncat/ncat_ssl.c
+@@ -128,7 +128,9 @@
+ 
+ #include <stdio.h>
+ #include <openssl/ssl.h>
++#include <openssl/bn.h>
+ #include <openssl/err.h>
++#include <openssl/rsa.h>
+ #include <openssl/rand.h>
+ #include <openssl/x509.h>
+ #include <openssl/x509v3.h>


### PR DESCRIPTION
This is needed until 7.32 I believe. This was upstreamed but currently fails with 7.31.