### PR TITLE
CC15.05 ruby: bump to 2.2.6

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2015 OpenWrt.org
+# Copyright (C) 2006-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,14 +10,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=2.2.4
+PKG_VERSION:=2.2.6
 PKG_RELEASE:=1
 
 PKG_LIBVER:=2.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://cache.ruby-lang.org/pub/ruby/$(PKG_LIBVER)/
-PKG_MD5SUM:=c3d65f6d2ebe90dda81a37885ea244f5
+PKG_MD5SUM:=3d13cf447142b8a11cd9beb7bc63fee0
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, x86 OpenWRT CC.1
Run tested: x86 OpenWRT CC.1, running simple scripts

Description:

This release includes new SSL certificates for RubyGems. And, this also
includes about 80 bug fixes after the previous release. See the
http://svn.ruby-lang.org/repos/ruby/tags/v2_2_6/ChangeLog for details.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>