### PR TITLE
openldap: do not build doc and tests subdirs

### DIFF
--- a/libs/openldap/patches/002-no-doc-and-tests-subdir.patch
+++ b/libs/openldap/patches/002-no-doc-and-tests-subdir.patch
@@ -1,0 +1,5 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1 +1 @@
+-SUBDIRS = include libraries clients servers tests doc
++SUBDIRS = include libraries clients servers


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: mxs, LEDE 9cac5e8
Run tested: none

Description:

At least one LEDE buildbot is missing tools to create man pages, thus the build
sometimes (depends on which buildbot is used) fails with [1]:

-snip-
make[7]: Entering directory '/mnt/build-dir/lede/armeb_xscale/build/sdk/build_dir/target-armeb_xscale_musl-1.1.15/openldap-2.4.44/doc/man/man1'
PAGES=`cd .; echo *.1`; \
for page in $PAGES; do \
    sed -e "s%LDVERSION%2.4.44%" \
	-e 's%ETCDIR%/etc/openldap%g' \
	-e 's%LOCALSTATEDIR%/var%' \
	-e 's%SYSCONFDIR%/etc/openldap%' \
	-e 's%DATADIR%/usr/share/openldap%' \
	-e 's%SBINDIR%/usr/sbin%' \
	-e 's%BINDIR%/usr/bin%' \
	-e 's%LIBDIR%/usr/lib%' \
	-e 's%LIBEXECDIR%/usr/lib%' \
	-e 's%MODULEDIR%/usr/lib/openldap%' \
	-e 's%RELEASEDATE%2016/02/05%' \
	    ./$page \
	| (cd .; soelim -) > $page.tmp; \
done
/bin/sh: 15: soelim: not found
/bin/sh: 15: soelim: not found
/bin/sh: 15: soelim: not found
/bin/sh: 15: soelim: not found
/bin/sh: 15: soelim: not found
/bin/sh: 15: soelim: not found
/bin/sh: 15: soelim: not found
/bin/sh: 15: soelim: not found
/bin/sh: 15: soelim: not found
Makefile:292: recipe for target 'all-common' failed
make[7]: *** [all-common] Error 127
-snap-

For OpenWrt/LEDE, there is no reason to build the tests and/or man pages,
so let's patch it away. And since other packages need openldap as
build dependency (e.g. php) this automatically fixes the build of these
depended packages.

[1] https://downloads.lede-project.org/snapshots/faillogs/armeb_xscale/packages/openldap/compile.txt

Signed-off-by: Michael Heimpold <mhei@heimpold.de>