### PR TITLE
utils/zip: fix LARGE_FILE_SUPPORT in configure script

### DIFF
--- a/utils/zip/Makefile
+++ b/utils/zip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=zip
 PKG_REV:=30
 PKG_VERSION:=3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)$(PKG_REV).tar.gz
 PKG_SOURCE_URL:=@SF/infozip

--- a/utils/zip/patches/001-unix-configure-borrow-the-LFS-test-from-autotools.patch
+++ b/utils/zip/patches/001-unix-configure-borrow-the-LFS-test-from-autotools.patch
@@ -1,0 +1,90 @@
+From fc392c939b9a18959482f588aff0afc29dd6d30a Mon Sep 17 00:00:00 2001
+From: Romain Naour <romain.naour at openwide.fr>
+Date: Fri, 23 Jan 2015 22:20:18 +0100
+Subject: [PATCH 6/6] unix/configure: borrow the LFS test from autotools.
+
+Infozip's LFS check can't work for cross-compilation
+since it try to run a target's binary on the host system.
+
+Instead, use to LFS test used by autotools which is a
+compilation test.
+(see autotools/lib/autoconf/specific.m4)
+
+Reported-by: Richard Genoud <richard.genoud at gmail.com>
+Signed-off-by: Romain Naour <romain.naour at openwide.fr>
+---
+ configure |   46 +++++++++++++++-------------------------------
+ 1 file changed, 15 insertions(+), 31 deletions(-)
+
+diff --rupN a/unix/configure b/unix/configure
+--- a/unix/configure
++++ b/unix/configure
+@@ -399,9 +399,8 @@ else
+ fi
+ 
+ 
+-# Now we set the 64-bit file environment and check the size of off_t
+-# Added 11/4/2003 EG
+-# Revised 8/12/2004 EG
++# LFS check borrowed from autotools sources
++# lib/autoconf/specific.m4
+ 
+ echo Check for Large File Support
+ cat > conftest.c << _EOF_
+@@ -410,23 +409,19 @@ cat > conftest.c << _EOF_
+ # define _FILE_OFFSET_BITS 64       /* select default interface as 64 bit */
+ # define _LARGE_FILES        /* some OSes need this for 64-bit off_t */
+ #include <sys/types.h>
+-#include <sys/stat.h>
+-#include <unistd.h>
+-#include <stdio.h>
++
++ /* Check that off_t can represent 2**63 - 1 correctly.
++    We can't simply define LARGE_OFF_T to be 9223372036854775807,
++    since some C++ compilers masquerading as C compilers
++    incorrectly reject 9223372036854775807.  */
++#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
++  int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
++		       && LARGE_OFF_T % 2147483647 == 1)
++		      ? 1 : -1];
++
+ int main()
+ {
+-  off_t offset;
+-  struct stat s;
+-  /* see if have 64-bit off_t */
+-  if (sizeof(offset) < 8)
+-    return 1;
+-  printf("  off_t is %d bytes\n", sizeof(off_t));
+-  /* see if have 64-bit stat */
+-  if (sizeof(s.st_size) < 8) {
+-    printf("  s.st_size is %d bytes\n", sizeof(s.st_size));
+-    return 2;
+-  }
+-  return 3;
++  return 0;
+ }
+ _EOF_
+ # compile it
+@@ -434,19 +429,8 @@ $CC -o conftest conftest.c >/dev/null 2>
+ if [ $? -ne 0 ]; then
+   echo -- no Large File Support
+ else
+-# run it
+-  ./conftest
+-  r=$?
+-  if [ $r -eq 1 ]; then
+-    echo -- no Large File Support - no 64-bit off_t
+-  elif [ $r -eq 2 ]; then
+-    echo -- no Large File Support - no 64-bit stat
+-  elif [ $r -eq 3 ]; then
+-    echo -- yes we have Large File Support!
+-    CFLAGS="${CFLAGS} -DLARGE_FILE_SUPPORT"
+-  else
+-    echo -- no Large File Support - conftest returned $r
+-  fi
++  echo -- yes we have Large File Support!
++  CFLAGS="${CFLAGS} -DLARGE_FILE_SUPPORT"
+ fi
+ 
+ 


### PR DESCRIPTION
Maintainer: @Noltari 
Compile tested: kirkwood
Run tested: kirkwood

Description:
Package zip is currently broken with a runtime error.
When zip is run, it immediately exits with
"zip warning : Not supported (uzoff_t not same size as zoff_t)"

The issue boils down to the package's configure script which tries to
determine LARGE_FILE_SUPPORT on *host* side. The conftest.c is
compiled and ran on the building host to see whether LFS is given or not.
This will fail when cross-compiling. The patch here is created by Romain Naour,
taken from http://lists.busybox.net/pipermail/buildroot/2015-January/117909.html
Reworked and tested by me. Now LFS is detected and the built binaries work
on the target.