### PR TITLE
net/stunnel: Update to 5.37

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.36
+PKG_VERSION:=5.37
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0+
@@ -19,7 +19,7 @@ PKG_SOURCE_URL:= \
 	http://ftp.nluug.nl/pub/networking/stunnel/ \
 	http://www.usenix.org.uk/mirrors/stunnel/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=b3c002c312e757d9a40caf95363800b3
+PKG_MD5SUM:=d0e3530e3effc64fdec792c71791d4937c6b8bd3b9ea4895c6bb6526dcd0d241
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
Maintainer: myself
Compile tested: ar71xx, TL-WDR3600, LEDE trunk
Run tested: ar71xx, TL-WDR3600, LEDE trunk

Description:

Updates stunnel to version 5.37

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>