### PR TITLE
chrony: update to 2.4.1

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
-PKG_VERSION:=2.4
+PKG_VERSION:=2.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://download.tuxfamily.org/chrony/
-PKG_MD5SUM:=d0598aa8a9be8faccef9386f6fc0d5f2
+PKG_SOURCE_URL:=https://download.tuxfamily.org/chrony/
+PKG_MD5SUM:=d08dd5a7d79a89891d119adcccb4397d
 
 PKG_MAINTAINER:=Miroslav Lichvar <mlichvar0@gmail.com>
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: MIPS, WDR-3600, LEDE trunk
Run tested: MIPS, WDR-3600, LEDE trunk, NTP client and server work as expected