### PR TITLE
attr: use git over HTTP

### DIFF
--- a/utils/attr/Makefile
+++ b/utils/attr/Makefile
@@ -13,7 +13,7 @@ PKG_VERSION:=20160302
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=git://git.sv.gnu.org/attr.git
+PKG_SOURCE_URL:=http://git.savannah.gnu.org/r/attr.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=$(PKG_REV)


### PR DESCRIPTION
Maintainer: @mstorchak 
Compile tested: x86
Run tested: none (no source change)

Git over HTTP is equivalent to git:// but works across HTTP proxy.
Currently, only 14% of packages uses git:// instead of http(s)://

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>