### PR TITLE
net/sshfs: update to 2.8

### DIFF
--- a/net/sshfs/Makefile
+++ b/net/sshfs/Makefile
@@ -8,17 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sshfs
-PKG_VERSION:=2.5
+PKG_VERSION:=2.8
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Zoltan HERPAI <wigyori@uid0.hu>
 
-PKG_SOURCE:=$(PKG_NAME)-fuse-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/libfuse/sshfs/releases/download/sshfs_2_5
-PKG_MD5SUM:=17494910db8383a366b1301e5f5148a9
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/libfuse/sshfs/releases/download/$(PKG_NAME)_$(PKG_VERSION)
+PKG_MD5SUM:=0ba25e848ee59e2595d6576c8f6284b6
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-fuse-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk


### PR DESCRIPTION
Maintainer: @wigyori 
Compile tested: kirkwood, ar71xx
Run tested: kirkwood, ar71xx

Description:
Update sshfs to upstream release 2.8
The directory structure for libfuse's releases of sshfs changed a little bit,
therefore the URL is adapted to fit new circumstances.