### PR TITLE
f2fs-tools: added upstream patch for selinux

### DIFF
--- a/utils/f2fs-tools/patches/020-conditional_selinux.patch
+++ b/utils/f2fs-tools/patches/020-conditional_selinux.patch
@@ -1,0 +1,80 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -54,7 +54,9 @@ AC_PATH_PROG([LDCONFIG], [ldconfig],
+ 
+ # Checks for libraries.
+ PKG_CHECK_MODULES([libuuid], [uuid])
+-PKG_CHECK_MODULES([libselinux], [libselinux])
++PKG_CHECK_MODULES([libselinux], [libselinux],
++	[AC_DEFINE([HAVE_LIBSELINUX], [1], [Use libselinux])],
++	[AC_MSG_NOTICE([libselinux not found])])
+ 
+ # Checks for header files.
+ AC_CHECK_HEADERS([linux/fs.h fcntl.h mntent.h stdlib.h string.h \
+diff --git a/fsck/sload.c b/fsck/sload.c
+index ea072d1..68799c1 100644
+--- a/fsck/sload.c
++++ b/fsck/sload.c
+@@ -16,8 +16,11 @@
+ #include <libgen.h>
+ #include <dirent.h>
+ #include <mntent.h>
++
++#ifdef HAVE_LIBSELINUX
+ #include <selinux/selinux.h>
+ #include <selinux/label.h>
++#endif
+ 
+ #ifdef WITH_ANDROID
+ #include <selinux/label.h>
+@@ -110,10 +113,12 @@ static int build_directory(struct f2fs_sb_info *sbi, const char *full_path,
+ 		handle_selabel(dentries + i, S_ISDIR(stat.st_mode),
+ 							target_out_dir);
+ 
++#ifdef HAVE_LIBSELINUX
+ 		if (sehnd && selabel_lookup(sehnd, &dentries[i].secon,
+ 					dentries[i].path, stat.st_mode) < 0)
+ 			ERR_MSG("Cannot lookup security context for %s\n",
+ 						dentries[i].path);
++#endif
+ 
+ 		dentries[i].pino = dir_ino;
+ 
+@@ -174,6 +179,7 @@ static int build_directory(struct f2fs_sb_info *sbi, const char *full_path,
+ 			MSG(1, "Error unknown file type\n");
+ 		}
+ 
++#ifdef HAVE_LIBSELINUX
+ 		if (dentries[i].secon) {
+ 			inode_set_selinux(sbi, dentries[i].ino, dentries[i].secon);
+ 			MSG(1, "File = %s \n----->SELinux context = %s\n",
+@@ -184,10 +190,12 @@ static int build_directory(struct f2fs_sb_info *sbi, const char *full_path,
+ 					dentries[i].gid, dentries[i].capabilities);
+ 		}
+ 
++		free(dentries[i].secon);
++#endif
++
+ 		free(dentries[i].path);
+ 		free(dentries[i].full_path);
+ 		free((void *)dentries[i].name);
+-		free(dentries[i].secon);
+ 	}
+ 
+ 	free(dentries);
+@@ -218,6 +226,7 @@ int f2fs_sload(struct f2fs_sb_info *sbi, const char *from_dir,
+ 		return ret;
+ 	}
+ 
++#ifdef HAVE_LIBSELINUX
+ 	if (sehnd) {
+ 		char *secontext = NULL;
+ 
+@@ -233,6 +242,7 @@ int f2fs_sload(struct f2fs_sb_info *sbi, const char *from_dir,
+ 		}
+ 		free(secontext);
+ 	}
++#endif
+ 
+ 	/* update curseg info; can update sit->types */
+ 	move_curseg_info(sbi, SM_I(sbi)->main_blkaddr);


### PR DESCRIPTION
Maintainer: @lperkov 
Compile tested: Kirkwood and ar71xx LEDE v2058
Run tested: Kirkwood and ar71xx, can format a flash drive, can check flash drive, the drive is also readable by my linux PC.

Description: this patch comes from upstream and allows to compile f2fs-tools without selinux support if no selinux libraries are present at compile time.

here the upstream patch https://git.kernel.org/cgit/linux/kernel/git/jaegeuk/f2fs-tools.git/patch/?id=b0a2386089fd6efade6b89094325ed8a9f8c6fff

Fixes issue reported in the last PR thread about f2fs-tools here https://github.com/openwrt/packages/pull/3373
(compile error)
"checking for libselinux... no
configure: error: Package requirements (libselinux) were not met:
No package 'libselinux' found"

On my PC with OpenSUSE the library was present and used so I didn't get the error, I tested this in a Ubuntu system as the issue was reported there.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>