### PR TITLE
libvpx: bump to 1.6.0

### DIFF
--- a/libs/libvpx/Makefile
+++ b/libs/libvpx/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2008-2015 OpenWrt.org
+# Copyright (C) 2016 Luiz Angelo Daros de Luca
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libvpx
-PKG_VERSION:=1.5.0
+PKG_VERSION:=1.6.0
 PKG_RELEASE:=1
 
 PKG_REV:=v$(PKG_VERSION)


### PR DESCRIPTION
Maintainer: me 
Compile tested: ar71xx, x86 on LEDE trunk
Run tested: x86 on LEDE r0+2292

Description:

This release improves upon the VP9 encoder and speeds up the encoding
and decoding processes.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

@thess, @MikePetullo, this will trigger packages that depends on libvpx, like gst1-plugins-good, as it updates ABI_VERSION