### PR TITLE
opus: Disable ASM for xscale and arm926ej-s

### DIFF
--- a/libs/opus/Makefile
+++ b/libs/opus/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opus
 PKG_VERSION:=1.1.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://downloads.xiph.org/releases/opus/
@@ -43,6 +43,12 @@ CONFIGURE_ARGS+= \
 ifeq ($(CONFIG_SOFT_FLOAT),y)
 	CONFIGURE_ARGS+= \
 		--enable-fixed-point
+endif
+
+CPU_ASM_BLACKLIST:=xscale arm926ej-s
+
+ifneq ($(findstring $(call qstrip,$(CONFIG_CPU_TYPE)),$(CPU_ASM_BLACKLIST)),)
+	CONFIGURE_ARGS+= --disable-asm
 endif
 
 define Build/InstallDev


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: Several ARM configs
Run tested: None

Description:

ASM optimization fails on ARMV5TE processors requiring even numbered registers for `ldrd` opcode. I'm not sure if this is fixable in the opus source or is really a GCC problem. This patch is a workaround for this problem.

Fixes: #3541

Signed-off-by: Ted Hess <thess@kitschensync.net>