### PR TITLE
libsodium and dnscrypt-proxy url change for 15.05

### DIFF
--- a/libs/libsodium/Makefile
+++ b/libs/libsodium/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.0.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://download.libsodium.org/libsodium/releases
+PKG_SOURCE_URL:=https://download.libsodium.org/libsodium/releases/old
 PKG_MD5SUM:=dc40eb23e293448c6fc908757738003f
 
 PKG_FIXUP:=libtool autoreconf

--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.4.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy
+PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy/old
 PKG_MD5SUM:=54d172236a8f321fb5689ff81767f1ba
 
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Maintainer: Stephan Conrad / @julbrygd
Compile tested: mvebu
Run tested: no run tests

Description: I change the download url for the libsodium and dnscrypt-proxy. I apanded "/old" to the url, so the url is found
