### PR TITLE
[utils/zoneinfo] Updated to the latest release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2016i
-PKG_VERSION_CODE:=2016i
+PKG_VERSION:=2016j
+PKG_VERSION_CODE:=2016j
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -20,14 +20,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION_CODE).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_MD5SUM:=73912ecfa6a9a8048ddf2e719d9bc39d
+PKG_MD5SUM:=db361d005ac8b30a2d18c5ca38d3e8ab
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   MD5SUM:=8fae14cba9396462955b7859cf04ba48
+   MD5SUM:=0684b98eb184fab250b6ca946862078d
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: ti omap targets, custom build. OpenWrt master branch
Run tested: n/a

Description:

   Briefly: Saratov, Russia moves from +03 to +04 on 2016-12-04.

   Changes to future time stamps

     Saratov, Russia switches from +03 to +04 on 2016-12-04 at 02:00.
     This hives off a new zone Europe/Saratov from Europe/Volgograd.
     (Thanks to Yuri Konotopov and Stepan Golosunov.)

   Changes to past time stamps

     The new zone Asia/Atyrau for Atyra? Region, Kazakhstan, is like
     Asia/Aqtau except it switched from +04/+05 to +05/+06 in spring
     1999, not fall 1994.  (Thanks to Stepan Golosunov.)

   Changes to past time zone abbreviations

     Asia/Gaza and Asia/Hebron now use "EEST", not "EET", to denote
     summer time before 1948.  The old use of "EET" was a typo.

   Changes to code

     zic no longer mishandles file systems that lack hard links, fixing
     bugs introduced in 2016g.  (Problems reported by Tom Lane.)
     Also, when the destination already contains symbolic links, zic
     should now work better on systems where the 'link' system call
     does not follow symbolic links.

   Changes to documentation and commentary

     tz-link.htm now documents the relationship between release version
     numbers and development-repository commit tags.  (Suggested by
     Paul Koning.)

     The 'Theory' file now documents UT.

     iso3166.tab now accents "Cura?ao", and commentary now mentions
     the names "Cabo Verde" and "Czechia".  (Thanks to Ji?? Boh??.)