### PR TITLE
vnstat: Allow define number of tries of downloading from remote

### DIFF
--- a/net/vnstat/Makefile
+++ b/net/vnstat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vnstat
 PKG_VERSION:=1.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://humdi.net/vnstat

--- a/net/vnstat/files/vnstat.config
+++ b/net/vnstat/files/vnstat.config
@@ -2,4 +2,5 @@ config vnstat
 	list interface		br-lan
 #	list interface		eth0.1
 #	option remote		http://example.org/vnstat/
+#	option remote_tries	3
 #	option symlink		/www/vnstat

--- a/net/vnstat/files/vnstat.init
+++ b/net/vnstat/files/vnstat.init
@@ -26,14 +26,14 @@ start() {
 
 	init_ifaces() {
 		local cfg="$1"
-		local url lnk
+		local url lnk tries
 
 		init_iface() {
 			local ifn="$1"
 
 			if [ -n "$url" ]; then
 				local try=0
-				local max=3
+				local max=$tries
 				local hostname="$(cat /proc/sys/kernel/hostname)"
 
 				while [ $((++try)) -le $max ]; do
@@ -63,6 +63,7 @@ start() {
 
 		config_get url "$cfg" remote
 		config_get lnk "$cfg" symlink
+		config_get tries "$cfg" remote_tries 3
 		config_get backup_dir "$cfg" backup_dir
 		config_list_foreach "$cfg" interface init_iface
 


### PR DESCRIPTION
-------------------------------

Maintainer: Jo-Philipp Wich <jo@mein.io>

Description:

Implemented uci option 'remote_tries' in vnstat config file,
which allow variable timeout before it give up and
start statistics from zero.

Signed-off-by: Jakub Janco <kubco2@gmail.com>