### PR TITLE
libcanfestival: skip building examples

### DIFF
--- a/libs/libcanfestival/Makefile
+++ b/libs/libcanfestival/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 OpenWrt.org
+# Copyright (C) 2015-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.

--- a/libs/libcanfestival/patches/003-makefile-skip-examples.patch
+++ b/libs/libcanfestival/patches/003-makefile-skip-examples.patch
@@ -1,0 +1,20 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -21,7 +21,7 @@
+ # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ # 
+ 
+-all: objdictedit canfestival examples
++all: objdictedit canfestival
+ 
+ examples: canfestival driver
+ 	$(MAKE) -C examples all
+@@ -44,7 +44,7 @@ driver:
+ install: canfestival driver
+ 	$(MAKE) -C drivers $@
+ 	$(MAKE) -C src $@
+-	$(MAKE) -C examples $@
++	#$(MAKE) -C examples $@
+ 	$(MAKE) -C objdictgen $@
+ 	ldconfig
+ 


### PR DESCRIPTION
Maintainer: @toxxin 
Compile tested: LEDE mxs
Run tested: no

Description:

At the moment, LEDE buildbots are complaining with:

-snip-
...
libcanfestival/examples/TestMasterSlave/TestMasterSlave.c:50: undefined reference to `MasterMap1'
TestMasterSlave.o: In function `InitNodes':
...
-snap-

Since we are only interessted in the library itself, skip compilation
of the example code. This should both fix the build and speedup it
a little bit.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>