### PR TITLE
python-setuptools,python3-setuptools: fix path creation in setup scripts

### DIFF
--- a/lang/python-setuptools/patches/0002-fix-pyvenv-environment-get.patch
+++ b/lang/python-setuptools/patches/0002-fix-pyvenv-environment-get.patch
@@ -1,13 +1,13 @@
 diff --git a/setuptools/command/easy_install.py b/setuptools/command/easy_install.py
-index df1655b..24c34e5 100755
+index e8b90c7..8598c44 100755
 --- a/setuptools/command/easy_install.py
 +++ b/setuptools/command/easy_install.py
-@@ -1885,7 +1885,7 @@ class CommandSpec(list):
+@@ -1946,6 +1946,8 @@ class CommandSpec(list):
+         Construct a CommandSpec from a parameter to build_scripts, which may
+         be None.
+         """
++        if os.environ.get('__PYVENV_LAUNCHER__'):
++            return cls.from_environment()
+         if isinstance(param, cls):
              return param
          if isinstance(param, list):
-             return cls(param)
--        if param is None:
-+        if param is None or os.environ.get('__PYVENV_LAUNCHER__'):
-             return cls.from_environment()
-         # otherwise, assume it's a string.
-         return cls.from_string(param)

--- a/lang/python3-setuptools/patches/0002-fix-pyvenv-environment-get.patch
+++ b/lang/python3-setuptools/patches/0002-fix-pyvenv-environment-get.patch
@@ -1,13 +1,13 @@
 diff --git a/setuptools/command/easy_install.py b/setuptools/command/easy_install.py
-index df1655b..24c34e5 100755
+index e8b90c7..8598c44 100755
 --- a/setuptools/command/easy_install.py
 +++ b/setuptools/command/easy_install.py
-@@ -1885,7 +1885,7 @@ class CommandSpec(list):
+@@ -1946,6 +1946,8 @@ class CommandSpec(list):
+         Construct a CommandSpec from a parameter to build_scripts, which may
+         be None.
+         """
++        if os.environ.get('__PYVENV_LAUNCHER__'):
++            return cls.from_environment()
+         if isinstance(param, cls):
              return param
          if isinstance(param, list):
-             return cls(param)
--        if param is None:
-+        if param is None or os.environ.get('__PYVENV_LAUNCHER__'):
-             return cls.from_environment()
-         # otherwise, assume it's a string.
-         return cls.from_string(param)


### PR DESCRIPTION
Maintainer: me
Compile tested:  x86, LEDE trunk
Run tested: x86, LEDE trunk

Description:

Fixes: https://github.com/openwrt/packages/issues/3521

This was fixed a few versions back.
But then python-setuptools changed.

The problem is that python scripts installed via setuptools
& pip would have `#!/build_dir_path/staging_dir/target-x86_64_musl-1.1.15/host/bin/python`
as the path in the script, rather than the path on the target (`/usr/bin/python`).

This fixes that.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>