### PR TITLE
bind: disable libjson support

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -104,6 +104,7 @@ CONFIGURE_ARGS += \
 	--disable-threads \
 	--disable-linux-caps \
 	--with-openssl="$(STAGING_DIR)/usr" \
+	--with-libjson=no \
 	--with-libtool \
 	--with-libxml2=no \
 	--enable-epoll=yes \


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile/runtime tested: ar71xx/ubnt-rspro, LEDE r2354

Description: disable libjson support to solve this dependency error:
```
Package bind-libs is missing dependencies for the following libraries:
libjson-c.so.2
```