### PR TITLE
Update CloudFlare DDNS script to use API v4.

### DIFF
--- a/net/ddns-scripts/files/update_cloudflare_com.sh
+++ b/net/ddns-scripts/files/update_cloudflare_com.sh
@@ -35,7 +35,7 @@ __DOMAIN="$__DOMAIN.$__TLD"
 
 # function copied from /usr/share/libubox/jshn.sh
 # from BB14.09 for backward compatibility to AA12.09
-grep -i "json_get_keys" /usr/share/libubox/jshn.sh >/dev/null 2>&1 || json_get_keys() {
+type json_get_keys >/dev/null 2>&1 || json_get_keys() {
   local __dest="$1"
   local _tbl_cur
 

--- a/net/ddns-scripts/files/update_cloudflare_com.sh
+++ b/net/ddns-scripts/files/update_cloudflare_com.sh
@@ -12,13 +12,13 @@
 # option username - your cloudflare e-mail
 # option password - cloudflare api key, you can get it from cloudflare.com/my-account/
 # option domain   - your full hostname to update, in cloudflare its subdomain.domain
-#   i.e. myhost.example.com where myhost is the subdomain and example.com is your domain
+#                   i.e. myhost.example.com where myhost is the subdomain and example.com is your domain
 #
 # variable __IP already defined with the ip-address to use for update
 #
 [ "$use_https" -eq 0 ] && write_log 14 "CloudFlare only supports updates via HTTPS. Please correct configuration!"
-[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
-[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"
+[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'."
+[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'."
 
 local __ZONEID __RECID __OLDIP __TYPE __SUBDOM __DOMAIN __TLD
 

--- a/net/ddns-scripts/files/update_cloudflare_com.sh
+++ b/net/ddns-scripts/files/update_cloudflare_com.sh
@@ -78,10 +78,10 @@ do_request() {
 
   if [ -n "$WGET_SSL" -a $USE_CURL -eq 0 ]; then
     [ -n "$data" ] && set -- --body-data="$data" "$@"
-    wget -O "$DATFILE" --method="$method" "$@"
+    "$WGET_SSL" -O "$DATFILE" --method="$method" "$@"
   elif [ -n "$CURL_SSL" ]; then
     [ -n "$data" ] && set -- --data="$data" "$@"
-    curl -o "$DATFILE" -X "$method" "$@"
+    "$CURL_SSL" -o "$DATFILE" -X "$method" "$@"
   else
     write_log 14 "CloudFlare only supports updates via HTTPS. 'wget-ssl' or 'curl-ssl' has to be installed!"
   fi

--- a/net/ddns-scripts/files/update_cloudflare_com.sh
+++ b/net/ddns-scripts/files/update_cloudflare_com.sh
@@ -3,6 +3,7 @@
 #
 # script for sending updates to cloudflare.com
 #.2014-2015 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+#.2016 Markus Reiter <me@reitermark.us>
 # many thanks to Paul for testing and feedback during development
 #
 # This script is parsed by dynamic_dns_functions.sh inside send_update() function
@@ -11,21 +12,20 @@
 # option username - your cloudflare e-mail
 # option password - cloudflare api key, you can get it from cloudflare.com/my-account/
 # option domain   - your full hostname to update, in cloudflare its subdomain.domain
-#			i.e. myhost.example.com where myhost is the subdomain and example.com is your domain
+#   i.e. myhost.example.com where myhost is the subdomain and example.com is your domain
 #
 # variable __IP already defined with the ip-address to use for update
 #
-[ $use_https -eq 0 ] && write_log 14 "Cloudflare only support updates via Secure HTTP (HTTPS). Please correct configuration!"
+[ "$use_https" -eq 0 ] && write_log 14 "CloudFlare only supports updates via HTTPS. Please correct configuration!"
 [ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
 [ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"
 
-local __RECID __URL __KEY __KEYS __FOUND __SUBDOM __DOMAIN __TLD
+local __ZONEID __RECID __OLDIP __TYPE __SUBDOM __DOMAIN __TLD
 
 # split given Host/Domain into TLD, registrable domain, and subdomain
 split_FQDN $domain __TLD __DOMAIN __SUBDOM
 [ $? -ne 0 -o -z "$__DOMAIN" ] && \
-	write_log 14 "Wrong Host/Domain configuration ($domain). Please correct configuration!"
-
+  write_log 14 "Wrong host/domain configuration ($domain). Please correct configuration!"
 # put together what we need
 __DOMAIN="$__DOMAIN.$__TLD"
 
@@ -36,109 +36,124 @@ __DOMAIN="$__DOMAIN.$__TLD"
 # function copied from /usr/share/libubox/jshn.sh
 # from BB14.09 for backward compatibility to AA12.09
 grep -i "json_get_keys" /usr/share/libubox/jshn.sh >/dev/null 2>&1 || json_get_keys() {
-	local __dest="$1"
-	local _tbl_cur
+  local __dest="$1"
+  local _tbl_cur
 
-	if [ -n "$2" ]; then
-		json_get_var _tbl_cur "$2"
-	else
-		_json_get_var _tbl_cur JSON_CUR
-	fi
-	local __var="${JSON_PREFIX}KEYS_${_tbl_cur}"
-	eval "export -- \"$__dest=\${$__var}\"; [ -n \"\${$__var+x}\" ]"
+  if [ -n "$2" ]; then
+    json_get_var _tbl_cur "$2"
+  else
+    _json_get_var _tbl_cur JSON_CUR
+  fi
+  local __var="${JSON_PREFIX}KEYS_${_tbl_cur}"
+  eval "export -- \"$__dest=\${$__var}\"; [ -n \"\${$__var+x}\" ]"
 }
 
 # function to "sed" unwanted string parts from DATFILE
 cleanup() {
-	# based on the sample output on cloudflare.com homepage we need to do some cleanup
-	sed -i 's/^[ \t]*//;s/[ \t]*$//' $DATFILE	# remove invisible chars at beginning and end of lines
-	sed -i '/^-$/d' $DATFILE			# remove lines with "-" (dash)
-	sed -i '/^$/d' $DATFILE				# remove empty lines
-	sed -i "#'##g" $DATFILE				# remove "'" (single quote)
+  # based on the sample output on cloudflare.com homepage we need to do some cleanup
+  sed -i 's/^[ \t]*//;s/[ \t]*$//' $DATFILE  # remove invisible chars at beginning and end of lines
+  sed -i '/^-$/d' $DATFILE                   # remove lines with "-" (dash)
+  sed -i '/^$/d' $DATFILE                    # remove empty lines
+  sed -i "#'##g" $DATFILE                    # remove "'" (single quote)
 }
 
-[ -n "$rec_id" ] && __RECID="$rec_id" || {
-	# build url according to cloudflare client api at https://www.cloudflare.com/docs/client-api.html
-	# to "rec_load_all" to detect rec_id needed for update
-	__URL="https://www.cloudflare.com/api_json.html"	# https://www.cloudflare.com/api_json.html
-	__URL="${__URL}?a=rec_load_all"				#  -d 'a=rec_load_all'
-	__URL="${__URL}&tkn=$password"				#  -d 'tkn=8afbe6dea02407989af4dd4c97bb6e25'
-	__URL="${__URL}&email=$username"			#  -d 'email=sample@example.com'
-	__URL="${__URL}&z=$__DOMAIN"				#  -d 'z=example.com'
+do_request() {
+  local method data url success messages args
+  method="$1"
+  shift
 
-	# lets request the data
-	do_transfer "$__URL" || return 1
+  if [ "$method" != "GET" ]; then
+    data="$1"
+    shift
+  fi
 
-	cleanup				# cleanup dat file
-	json_load "$(cat $DATFILE)"	# lets extract data
-	__FOUND=0			# found record indicator
-	json_get_var __RES "result"	# cloudflare result of last request
-	json_get_var __MSG "msg"	# cloudflare error message
-	[ "$__RES" != "success" ] && {
-		write_log 4 "'rec_load_all' failed with error: \n$__MSG"
-		return 1
-	}
+  url="$@"
 
-	json_select "response"
-	json_select "recs"
-	json_select "objs"
-	json_get_keys __KEYS
-	for __KEY in $__KEYS; do
-		local __ZONE __DISPLAY __NAME __TYPE
-		json_select "$__KEY"
-	#	json_get_var __ZONE "zone_name"		# for debugging
-	#	json_get_var __DISPLAY "display_name"	# for debugging
-		json_get_var __NAME "name"
-		json_get_var __TYPE "type"
-		if [ "$__NAME" = "$domain" ]; then
-			# we must verify IPv4 and IPv6 because there might be both for the same host
-			[ \( $use_ipv6 -eq 0 -a "$__TYPE" = "A" \) -o \( $use_ipv6 -eq 1 -a "$__TYPE" = "AAAA" \) ] && {
-				__FOUND=1	# mark found
-				break		# found leave for loop
-			}
-		fi
-		json_select ..
-	done
-	[ $__FOUND -eq 0 ] && {
-		# we don't need to continue trying to update cloudflare because record to update does not exist
-		# user has to setup record first outside ddns-scripts
-		write_log 14 "No valid record found at Cloudflare setup. Please create first!"
-	}
-	json_get_var __RECID "rec_id"	# last thing to do get rec_id
-	json_cleanup			# cleanup
-	write_log 7 "rec_id '$__RECID' detected for host/domain '$domain'"
+  set -- \
+    --quiet \
+    --header "Content-Type: application/json" \
+    --header "X-Auth-Email: $username" \
+    --header "X-Auth-Key: $password" \
+    "$@"
+
+  if [ -n "$WGET_SSL" -a $USE_CURL -eq 0 ]; then
+    [ -n "$data" ] && set -- --body-data="$data" "$@"
+    wget -O "$DATFILE" --method="$method" "$@"
+  elif [ -n "$CURL_SSL" ]; then
+    [ -n "$data" ] && set -- --data="$data" "$@"
+    curl -o "$DATFILE" -X "$method" "$@"
+  else
+    write_log 14 "CloudFlare only supports updates via HTTPS. 'wget-ssl' or 'curl-ssl' has to be installed!"
+  fi
+  cleanup
+
+  json_init
+  json_load "$(cat $DATFILE)"
+  json_get_var success "success" && [ $success -eq 1 ] || {
+    json_get_values messages "messages"
+    write_log 4 "'$url' failed with error: \n$messages"
+    return 1
+  }
+
+  return 0
 }
 
-# build url according to cloudflare client api at https://www.cloudflare.com/docs/client-api.html
-# for "rec_edit" to update IP address
-__URL="https://www.cloudflare.com/api_json.html"	# https://www.cloudflare.com/api_json.html
-__URL="${__URL}?a=rec_edit"				#  -d 'a=rec_edit'
-__URL="${__URL}&tkn=$password"				#  -d 'tkn=8afbe6dea02407989af4dd4c97bb6e25'
-__URL="${__URL}&id=$__RECID"				#  -d 'id=9001'
-__URL="${__URL}&email=$username"			#  -d 'email=sample@example.com'
-__URL="${__URL}&z=$__DOMAIN"				#  -d 'z=example.com'
 
-[ $use_ipv6 -eq 0 ] && __URL="${__URL}&type=A"		#  -d 'type=A'		(IPv4)
-[ $use_ipv6 -eq 1 ] && __URL="${__URL}&type=AAAA"	#  -d 'type=AAAA'	(IPv6)
+# GET ZONE
 
-# handle subdomain or domain record
-[ -n "$__SUBDOM" ] && __URL="${__URL}&name=$__SUBDOM"	#  -d 'name=sub'	(HOST/SUBDOMAIN)
-[ -z "$__SUBDOM" ] && __URL="${__URL}&name=$__DOMAIN"	#  -d 'name=example.com'(DOMAIN)
+do_request GET "https://api.cloudflare.com/client/v4/zones?name=$__DOMAIN" || return 1
 
-__URL="${__URL}&content=$__IP"				#  -d 'content=1.2.3.4'
-__URL="${__URL}&service_mode=0"				#  -d 'service_mode=0'
-__URL="${__URL}&ttl=1"					#  -d 'ttl=1'
+json_get_keys result "result"
+json_select "result"
 
-# lets do the update
-do_transfer "$__URL" || return 1
+for zone in $result; do
+  json_select "$zone"
+  json_get_var __ZONEID "id"
+  json_select ..
+  break
+done
 
-cleanup				# cleanup tmp file
-json_load "$(cat $DATFILE)"	# lets extract data
-json_get_var __RES "result"	# cloudflare result of last request
-json_get_var __MSG "msg"	# cloudflare error message
-[ "$__RES" != "success" ] && {
-	write_log 4 "'rec_edit' failed with error:\n$__MSG"
-	return 1
-}
-write_log 7 "Update of rec_id '$__RECID' successful"
+if [ -z "$__ZONEID" ]; then
+  write_log 14 "No valid Zone found on CloudFlare. Please create one first!"
+else
+  write_log 7 "Zone ID '$__ZONEID' detected for domain '$__DOMAIN'."
+fi
+
+
+# GET DNS RECORD
+
+do_request GET "https://api.cloudflare.com/client/v4/zones/$__ZONEID/dns_records?name=$domain" || return 1
+
+json_get_keys result "result"
+json_select "result"
+
+for record in $result; do
+  json_select "$record"
+  json_get_var __TYPE "type"
+  if [ \( "$use_ipv6" -eq 0 -a "$__TYPE" = "A" \) -o \( "$use_ipv6" -eq 1 -a "$__TYPE" = "AAAA" \) ]; then
+    json_get_var __RECID "id"
+    json_get_var __OLDIP "content"
+    break
+  fi
+  json_select ..
+done
+
+if [ -z "$__RECID" ]; then
+  write_log 14 "No valid DNS record found on CloudFlare. Please create one first!"
+else
+  write_log 7 "Record ID '$__RECID' detected for host/domain '$domain'."
+fi
+
+
+# UPDATE IP
+
+if [ "$__OLDIP" = "$__IP" ]; then
+  return 0
+fi
+
+do_request PUT "{\"type\":\"$__TYPE\",\"name\":\"$domain\",\"content\":\"$__IP\"}" \
+  "https://api.cloudflare.com/client/v4/zones/$__ZONEID/dns_records/$__RECID" || return 1
+
+write_log 7 "DNS record with ID '$__RECID' updated successfully."
+
 return 0


### PR DESCRIPTION
Maintainer: ––
Compile tested: ––
Run tested: Allwinner A1, Lamobo R1, OpenWrt Designated Driver 50013

Description:

The CloudFlare API v1 has been deprecated in favour of v4.