### PR TITLE
libs/libarchive: Update to 3.2.2 and add bsdtar

### DIFF
--- a/libs/libarchive/Makefile
+++ b/libs/libarchive/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libarchive
-PKG_VERSION:=3.1.2
+PKG_VERSION:=3.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.libarchive.org/downloads
-PKG_MD5SUM:=efad5a503f66329bb9d2f4308b5de98a
+PKG_MD5SUM:=691c194ee132d1f0f7a42541f091db811bc2e56f7107e9121be2bc8c04f1060f
 PKG_MAINTAINER:=Johannes Morgenroth <morgenroth@ibr.cs.tu-bs.de>
 PKG_LICENSE:=BSD-2-Clause
 
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/$(PKG_NAME)/Default
 	SECTION:=libs
 	CATEGORY:=Libraries
-	DEPENDS:=+zlib
+	DEPENDS:=+zlib +liblzma +libbz2 +libexpat
 	TITLE:=Multi-format archive and compression library
 	URL:=http://www.libarchive.org/
 endef
@@ -41,18 +41,30 @@ define Package/$(PKG_NAME)-noopenssl
 	VARIANT:=noopenssl
 endef
 
+define Package/bsdtar
+	SECTION:=utils
+	CATEGORY:=Utilities
+	SUBMENU:=Compression
+	DEPENDS:=+libarchive-noopenssl
+	TITLE:=BSD variant that supports various file compression formats
+	URL:=http://www.libarchive.org/
+endef
+
+define Package/bsdtar/description
+	Reads a variety of formats including tar, pax, zip, xar, lha, ar,
+	cab, mtree, rar, warc, 7z and ISO images. Writes tar, pax, zip,
+	xar, ar, ISO, mtree and shar archives. Automatically handles
+	archives compressed with gzip, bzip2, lzip, xz, lzma or compress.
+endef
+
 CONFIGURE_ARGS += \
 	--disable-bsdcpio \
-	--disable-bsdtar \
+	--enable-bsdtar=shared \
 	--disable-acl \
 	--disable-xattr \
-	--without-bz2lib \
-	--without-lzma \
-	--without-lzmadec \
 	--without-lzo2 \
 	--without-nettle \
-	--without-expat \
-	--without-xml2
+	--without-xml2 \
 
 ifeq ($(BUILD_VARIANT),noopenssl)
 	CONFIGURE_ARGS += --without-openssl
@@ -71,7 +83,14 @@ define Package/libarchive/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so.* $(1)/usr/lib/
 endef
+
+define Package/bsdtar/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/bsdtar $(1)/usr/bin
+endef
+
 Package/$(PKG_NAME)-noopenssl/install = $(Package/$(PKG_NAME)/install)
 
 $(eval $(call BuildPackage,libarchive))
 $(eval $(call BuildPackage,libarchive-noopenssl))
+$(eval $(call BuildPackage,bsdtar))


### PR DESCRIPTION
Maintainer: @morgenroth 
Compile tested: ar71xx, LEDE trunk 39f8e46bb40df9c7074132b7132ed3f01bd1b815
Run tested: ar71xx, TP-Link TL-WDR3600, LEDE trunk 39f8e46bb40df9c7074132b7132ed3f01bd1b815

Description:

Updates libarchive to 3.2.2
Adds bsdtar aswell as usable archive/compression support

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>