### PR TITLE
libs/libexif: Disable nls

### DIFF
--- a/libs/libexif/Makefile
+++ b/libs/libexif/Makefile
@@ -41,6 +41,7 @@ CONFIGURE_ARGS+= \
 	--enable-shared \
 	--enable-static \
 	--disable-rpath \
+	--disable-nls \
 	--without-libiconv-prefix \
 	--without-libintl-prefix \
 


### PR DESCRIPTION
Maintainer: mike@flyn.org
Compile tested: (target-mips_mips32_uClibc-0.9.33.2, target-arm_cortex-a9_glibc-2.22_eabi, OpenWRT chaos calmer)

Description:

Fixes missing @MKINSTALLDIRS@ substitution in po/Makefile.

Signed-off-by: Alin Nastac <alin.nastac@gmail.com>