### PR TITLE
libs/libarchive: Fix unintended linking of liblz4

### DIFF
--- a/libs/libarchive/Makefile
+++ b/libs/libarchive/Makefile
@@ -65,6 +65,7 @@ CONFIGURE_ARGS += \
 	--without-lzo2 \
 	--without-nettle \
 	--without-xml2 \
+	--without-lz4 \
 
 ifeq ($(BUILD_VARIANT),noopenssl)
 	CONFIGURE_ARGS += --without-openssl


### PR DESCRIPTION
Description:

Fixes unintended linking of liblz4
Thanks to hnyman for making me aware of this issue.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>