### PR TITLE
utils/avrdude: update to 6.3

### DIFF
--- a/utils/avrdude/Makefile
+++ b/utils/avrdude/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avrdude
-PKG_VERSION:=6.1
-PKG_RELEASE:=3
+PKG_VERSION:=6.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://download.savannah.gnu.org/releases/avrdude
-PKG_MD5SUM:=9db8c25b935d34234b9b1ba16ad55fd5
+PKG_SOURCE_URL:=@SAVANNAH/$(PKG_NAME)
+PKG_MD5SUM:=58bb42049122cf80fe4f4d0ce36d92ee
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=GPL-2.0

--- a/utils/avrdude/patches/010-configure-fixups.patch
+++ b/utils/avrdude/patches/010-configure-fixups.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -35,6 +35,7 @@ AC_CONFIG_HEADERS(ac_cfg.h)
+@@ -38,6 +38,7 @@ LT_INIT()
  
  # Checks for programs.
  AC_PROG_CC
@@ -8,7 +8,7 @@
  AC_PROG_INSTALL
  AC_PROG_SED
  AC_PROG_YACC
-@@ -183,6 +184,7 @@ fi
+@@ -182,6 +183,7 @@ fi
  AC_SUBST(LIBPTHREAD, $LIBPTHREAD)
  # Checks for header files.
  AC_CHECK_HEADERS([limits.h stdlib.h string.h])

--- a/utils/avrdude/patches/100-musl-compat.patch
+++ b/utils/avrdude/patches/100-musl-compat.patch
@@ -17,7 +17,7 @@
 +#include <sys/types.h>
  
  #include "avrdude.h"
- #include "avr.h"
+ #include "libavrdude.h"
 --- a/ser_avrdoper.c
 +++ b/ser_avrdoper.c
 @@ -248,6 +248,7 @@ static int usbGetReport(union filedescri
@@ -30,7 +30,7 @@
  #  include <lusb0_usb.h>
 --- a/usbtiny.c
 +++ b/usbtiny.c
-@@ -41,6 +41,7 @@
+@@ -40,6 +40,7 @@
  
  #if defined(HAVE_LIBUSB)      // we use LIBUSB to talk to the board
  #if defined(HAVE_USB_H)


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: kirkwood
Run tested: kirkwood

Description:
Update avrdude to upstream release 6.3
Run tested with AVRISP-mkII + flash read/write/verif on Atmega8