### PR TITLE
mail/mutt: update to 1.7.2

### DIFF
--- a/mail/mutt/Makefile
+++ b/mail/mutt/Makefile
@@ -8,12 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mutt
-PKG_VERSION:=1.5.24
+PKG_VERSION:=1.7.2
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=ftp://ftp.mutt.org/pub/mutt/
+PKG_SOURCE_URL:=ftp://ftp.mutt.org/pub/mutt/ \
+		https://bitbucket.org/mutt/mutt/downloads/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=7f25d27f3c7c82285ac07aac35f5f0f2
+PKG_MD5SUM:=15425c4c9946d58c22ccb44901544e6d
 
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=GPL

--- a/mail/mutt/patches/0001-no-po-and-docs.patch
+++ b/mail/mutt/patches/0001-no-po-and-docs.patch
@@ -13,7 +13,7 @@ diff --git a/Makefile.in b/Makefile.in
 index 1909835..cfa7ca0 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -458,7 +458,7 @@ get_cs_cmdline = $(call get_cs_compile,$(1)) $(call get_cs_all_flags,$(1),check_
+@@ -470,7 +470,7 @@ get_cs_cmdline = $(call get_cs_compile,$
  AUTOMAKE_OPTIONS = 1.6 foreign
  @BUILD_IMAP_TRUE@IMAP_SUBDIR = imap
  @BUILD_IMAP_TRUE@IMAP_INCLUDES = -I$(top_srcdir)/imap

--- a/mail/mutt/patches/100-CVE-2014-9116.patch
+++ b/mail/mutt/patches/100-CVE-2014-9116.patch
@@ -1,0 +1,31 @@
+From: Antonio Radici <antonio@debian.org>
+Date: Fri, 18 Sep 2015 11:48:47 +0200
+Subject: 771125-CVE-2014-9116-jessie
+
+This patch solves the issue raised by CVE-2014-9116 in bug 771125.
+
+We correctly redefine what are the whitespace characters as per RFC5322; by
+doing so we prevent mutt_substrdup from being used in a way that could lead to
+a segfault.
+
+The lib.c part was written by Antonio Radici <antonio@debian.org> to prevent
+crashes due to this kind of bugs from happening again.
+
+Signed-off-by: Matteo F. Vescovi <mfv@debian.org>
+---
+ lib.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff -rupN a/lib.c b/lib.c
+--- a/lib.c
++++ b/lib.c
+@@ -815,6 +815,9 @@ char *mutt_substrdup (const char *begin,
+   size_t len;
+   char *p;
+ 
++  if (end != NULL && end < begin)
++    return NULL;
++
+   if (end)
+     len = end - begin;
+   else


### PR DESCRIPTION
Maintainer: @philenotfound 
Compile tested: kirkwood, brcm47xx
Run tested: kirkwood, brcm47xx

Description:
Update mutt to upstream release 1.7.1
Also introduce a patch for CVE-2014-9116, which addresses
a DoS-attack. The patch is originally found at Debian's
package of mutt 1.7.1:
https://packages.debian.org/stretch/mutt