### PR TITLE
sqm-scripts: fix iptables dependency

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -24,7 +24,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/sqm-scripts
   SECTION:=net
   CATEGORY:=Base system
-  DEPENDS:=+tc +kmod-sched +kmod-ifb +iptables \
+  DEPENDS:=+tc +kmod-sched +kmod-ifb iptables \
 	+iptables-mod-ipopt +iptables-mod-conntrack-extra
   TITLE:=SQM Scripts (QoS)
   PKGARCH:=all


### PR DESCRIPTION
Maintainer: @tohojo
Compile tested: OpenWRT 15.05

Description:

sqm-scripts should only be selectable if iptables was selected like in
strongswan-full package. Otherwise this leads to a recursive
dependency

Signed-off-by: Florian Eckert <Eckert.Florian@googlemail.com>