### PR TITLE
libs/liboping: update to 1.9.0

### DIFF
--- a/libs/liboping/Makefile
+++ b/libs/liboping/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=liboping
-PKG_VERSION:=1.6.2
+PKG_VERSION:=1.9.0
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=LGPL-2.1+
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=http://verplant.org/liboping/files
-PKG_MD5SUM:=64a6f31310093d2517cfe7f05aa011e0
+PKG_SOURCE_URL:=https://noping.cc/files
+PKG_MD5SUM:=9c9f65bfd297d7e7092c7f219c31f66a
 
 PKG_FIXUP:=autoreconf
 


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: brcm47xx, kirkwood
Run tested: brcm47xx, kirkwood

Description:
Update liboping/oping/noping to upstream release 1.9.0.
The download location has changed (current location just redirects to new one).
Also the license is actually LGPL 2.1 (this is mentioned from 1.5.0 onwards)