### PR TITLE
libs/libcap: update to 2.25

### DIFF
--- a/libs/libcap/Makefile
+++ b/libs/libcap/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libcap
-PKG_VERSION:=2.24
+PKG_VERSION:=2.25
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/libs/security/linux-privs/libcap2
-PKG_MD5SUM:=d43ab9f680435a7fff35b4ace8d45b80
-PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
+PKG_MD5SUM:=6666b839e5d46c2ad33fc8aa2ceb5f77
+PKG_MAINTAINER:=Paul Wassi <p.wassi@gmx.at>
 
 PKG_INSTALL:=1
 
@@ -37,7 +37,7 @@ MAKE_FLAGS += \
     LDFLAGS="$(TARGET_LDFLAGS) -shared" \
     INDENT="| true" \
     PAM_CAP="no" \
-    LIBATTR="no" \
+    RAISE_SETFCAP="no" \
     DYNAMIC="yes" \
     lib="lib"
 


### PR DESCRIPTION
Maintainer: @sbyx 
Compile tested: kirkwood, brcm47xx
Run tested: kirkwood

Description:
Update libcap to upstream release 2.25
Since the libattr thing was dropped upstream in [1] it is also removed here.
Then, to overcome an issue in cross-compiling [2], set the Make parameter
according to [3].

[1]:
http://git.kernel.org/cgit/linux/kernel/git/morgan/libcap.git/commit/?id=85f38a573fc47472ab792e813b6f6b6f0b1df112

[2]:
libcap: progs/Makefile:30 executes the cross-compiled binary on the host

[3]:
libcap: Make.Rules: comment from lines 74-81
