### PR TITLE
libs/expat: update to 2.2.0

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
-PKG_VERSION:=2.1.0
-PKG_RELEASE:=3
+PKG_VERSION:=2.2.0
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=dd7dab7a5fea97d2a6a43f511449b7cd
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_MD5SUM:=2f47841c829facb346eb6e3fab5212e2
 PKG_SOURCE_URL:=@SF/expat
 PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
 


### PR DESCRIPTION
Maintainer: @sbyx 
Compile tested: kirkwood, brcm47xx, ar71xx
Run tested: kirkwood, brcm47xx

Description:
Update libexpat to upstream release 2.2.0
Switch from tar.gz to tar.bz2 since this is the only format currently released.