### PR TITLE
net/lftp: update to 4.7.4

### DIFF
--- a/net/lftp/Makefile
+++ b/net/lftp/Makefile
@@ -8,14 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lftp
-PKG_VERSION:=4.7.3
+PKG_VERSION:=4.7.4
 PKG_RELEASE:=1
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://lftp.yar.ru/ftp \
-		http://lftp.yar.ru/ftp/old \
-		http://lftp.cybermirror.org \
-		http://lftp.cybermirror.org/old
-PKG_MD5SUM:=23deda16014412c802f095fbaa0bebee
+PKG_SOURCE_URL:=http://lftp.tech/ftp/ \
+		ftp://ftp.st.ryukoku.ac.jp/pub/network/ftp/lftp/
+PKG_MD5SUM:=74965c798b1806d0a2659d8a606ea47f
 
 
 


### PR DESCRIPTION
Maintainer: @fededim 
Compile tested: kirkwood, brcm47xx, ar71xx
Run tested: kirkwood, brcm47xx

Description:
Update lftp to upstream release 4.7.4
For the mirrors: the new main server is called 'lftp.tech',
the lftp.cybermirror.org is 'undergoing maintenance right now and will be back shortly'
since spring 2016, therefore removed here. Instead, the official mirror ftp.st.ryukoku.ac.jp
is added.