### PR TITLE
expat: upgrade to v2.2.20 (support aarch64 builds)

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
-PKG_VERSION:=2.1.0
-PKG_RELEASE:=3
+PKG_VERSION:=2.2.0
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=dd7dab7a5fea97d2a6a43f511449b7cd
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_MD5SUM:=2f47841c829facb346eb6e3fab5212e2
 PKG_SOURCE_URL:=@SF/expat
 PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
 


### PR DESCRIPTION
-------------------------------

Maintainer: me / @<github-user>
Compile tested: OpenWRT: aarch64 odroid C2 & x64 virtualbox
Run tested: ar7xxx/9xxx Carambola2, functional test of router

Description:

Upgrade expat to v2.2.0; allows building on aarch64

Signed-off-by: Dana H. Myers <k6jq@comcast.net>