### PR TITLE
ocserv: Add libev prefix to stop configure stage failure

### DIFF
--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ocserv
 PKG_VERSION:=0.11.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_USE_MIPS16:=0
 
 PKG_BUILD_DIR :=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
@@ -63,6 +63,7 @@ CONFIGURE_ARGS+= \
 	--without-lz4 \
 	--without-gssapi \
 	--with-libcrypt-prefix="$(STAGING_DIR)/" \
+	--with-libev-prefix="$(STAGING_DIR)/" \
 	--without-lz4 \
 	--with-local-talloc \
 


### PR DESCRIPTION
Maintainer: @nmav 
Compile tested: AR71xx WRT160NL
Run tested: ar71xx WRT160NL (working)

Description:

This version of ocserv needs us to explicitly specify the prefix
for libev. Add a --with-libev-prefix parameter to make the
configure stage to get the right library.