### PR TITLE
libuecc: Add PIC flag

### DIFF
--- a/libs/libuecc/Makefile
+++ b/libs/libuecc/Makefile
@@ -32,7 +32,8 @@ endef
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
 
 CMAKE_OPTIONS += \
-	-DCMAKE_BUILD_TYPE:String="MINSIZEREL"
+	-DCMAKE_BUILD_TYPE:String="MINSIZEREL"\
+	-DCMAKE_POSITION_INDEPENDENT_CODE:bool=true
 
 
 define Build/InstallDev


### PR DESCRIPTION
Compile tested: ar71xx-generic, tl-wdr3600-v1, LEDE 854459a2f923376e0e509ebc0fb8ff90e9f13c02
Run tested: n/a

Description:

Without the flag building fails for `mips_24kc` on current LEDE, when linking against it from, say, ecdsautils (see for example  https://github.com/freifunk-gluon/packages/blob/master/utils/ecdsautils/Makefile).