### PR TITLE
ddns-scripts: extended/updated Makefile

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.6
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
@@ -29,7 +29,7 @@ define Package/$(PKG_NAME)/Default
     PKGARCH:=all
 endef
 
-##### **********************************
+###### *************************************************************************
 define Package/$(PKG_NAME)
     $(call Package/$(PKG_NAME)/Default)
     TITLE:=Dynamic DNS Client scripts (with IPv6 support)
@@ -53,7 +53,7 @@ define Package/$(PKG_NAME)/config
 		Info   : http://wiki.openwrt.org/doc/howto/ddns.client
 endef
 
-##### **********************************
+###### *************************************************************************
 define Package/$(PKG_NAME)_cloudflare
     $(call Package/$(PKG_NAME)/Default)
     TITLE:=CloudFlare.com API v1 (deprecated)
@@ -63,7 +63,7 @@ define Package/$(PKG_NAME)_cloudflare/description
     Dynamic DNS Client scripts extension for CloudFlare.com API-v1 (deprecated)
 endef
 
-##### **********************************
+###### *************************************************************************
 define Package/$(PKG_NAME)_cloudflare.com-v4
     $(call Package/$(PKG_NAME)/Default)
     TITLE:=CloudFlare.com API v4 (require cURL)
@@ -73,7 +73,7 @@ define Package/$(PKG_NAME)_cloudflare.com-v4/description
     Dynamic DNS Client scripts extension for CloudFlare.com API-v4 (require/install cURL)
 endef
 
-##### **********************************
+###### *************************************************************************
 define Package/$(PKG_NAME)_godaddy.com-v1
     $(call Package/$(PKG_NAME)/Default)
     TITLE:=GoDaddy.com (require cURL)
@@ -83,7 +83,7 @@ define Package/$(PKG_NAME)_godaddy.com-v1/description
     Dynamic DNS Client scripts extension for GoDaddy.com (require/install cURL)
 endef
 
-##### **********************************
+###### *************************************************************************
 define Package/$(PKG_NAME)_no-ip_com
     $(call Package/$(PKG_NAME)/Default)
     TITLE:=DDNS extension for No-IP.com
@@ -93,7 +93,7 @@ define Package/$(PKG_NAME)_no-ip_com/description
     Dynamic DNS Client scripts extension for No-IP.com
 endef
 
-##### **********************************
+###### *************************************************************************
 define Package/$(PKG_NAME)_nsupdate
     $(call Package/$(PKG_NAME)/Default)
     TITLE:=DDNS extension using Bind nsupdate
@@ -112,7 +112,7 @@ define Package/$(PKG_NAME)_nsupdate/config
 
 endef
 
-##### **********************************
+###### *************************************************************************
 define Build/Configure
 endef
 define Build/Compile
@@ -138,7 +138,13 @@ define Package/$(PKG_NAME)/conffiles
 /etc/config/ddns
 endef
 
-##### **********************************
+###### *************************************************************************
+define Package/$(PKG_NAME)/preinst
+	#!/bin/sh
+	# if NOT run buildroot and PKG_UPGRADE then stop service
+	[ -z "$${IPKG_INSTROOT}" -a "$${PKG_UPGRADE}" = "1" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+	exit 0	# suppress errors
+endef
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR)  $(1)/etc/uci-defaults
 	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns
@@ -155,108 +161,201 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR)  $(1)/usr/lib/ddns
 	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/dynamic_dns_*.sh $(1)/usr/lib/ddns
 endef
+define Package/$(PKG_NAME)/postinst
+	#!/bin/sh
+	# if NOT run buildroot and PKG_UPGRADE then (re)start service if enabled
+	[ -z "$${IPKG_INSTROOT}" -a "$${PKG_UPGRADE}" = "1" ] \
+		&& /etc/init.d/ddns enabled \
+		&& /etc/init.d/ddns start >/dev/null 2>&1
+	exit 0	# suppress errors
+endef
 define Package/$(PKG_NAME)/prerm
 	#!/bin/sh
 	# if run within buildroot exit
 	[ -n "$${IPKG_INSTROOT}" ] && exit 0
 
 	# stop running scripts
-	/etc/init.d/ddns disable
 	/etc/init.d/ddns stop
+	/etc/init.d/ddns disable
 
 	# clear LuCI indexcache
 	rm -f /tmp/luci-indexcache >/dev/null 2>&1
 
-	exit 0
+	exit 0	# suppress errors
 endef
 
-##### **********************************
+###### *************************************************************************
+define Package/$(PKG_NAME)_cloudflare/preinst
+	#!/bin/sh
+	# if NOT run buildroot then stop service
+	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+	exit 0	# suppress errors
+endef
 define Package/$(PKG_NAME)_cloudflare/install
 	$(INSTALL_DIR)  $(1)/etc/uci-defaults
 	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_cloudflare
-	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_DIR)  $(1)/usr/lib/ddns
 	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/update_cloudflare_com_v1.sh $(1)/usr/lib/ddns
 	$(INSTALL_DIR)  $(1)/usr/share
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/public_suffix_list.dat.gz $(1)/usr/share
 endef
 define Package/$(PKG_NAME)_cloudflare/postinst
 	#!/bin/sh
-	printf "%s\\t%s\\n" '"cloudflare.com-v1"' '"update_cloudflare_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-	printf "%s\\t%s\\n" '"cloudflare.com-v1"' '"update_cloudflare_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
+	# if NOT upgrading add entries
+	[ "$${PKG_UPGRADE}" = "1" ] || {
+		printf "%s\\t%s\\n" '"cloudflare.com-v1"' '"update_cloudflare_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+		printf "%s\\t%s\\n" '"cloudflare.com-v1"' '"update_cloudflare_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
+	}
+	# on real system restart service if enabled
+	[ -z "$${IPKG_INSTROOT}" ] \
+		&& /etc/init.d/ddns enabled \
+		&& /etc/init.d/ddns start >/dev/null 2>&1
+	exit 0	# suppress errors
 endef
 define Package/$(PKG_NAME)_cloudflare/prerm
 	#!/bin/sh
+	# if NOT run buildroot then stop service
+	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
 	/bin/sed -i '/cloudflare\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
 	/bin/sed -i '/cloudflare\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+	exit 0	# suppress errors
 endef
 
-##### **********************************
+###### *************************************************************************
+define Package/$(PKG_NAME)_cloudflare.com-v4/preinst
+	#!/bin/sh
+	# if NOT run buildroot then stop service
+	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+	exit 0	# suppress errors
+endef
 define Package/$(PKG_NAME)_cloudflare.com-v4/install
-	$(INSTALL_DIR)  $(1)/etc/uci-defaults
-	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_cloudflare.com-v4
-	$(INSTALL_DIR)  $(1)/usr/lib/ddns
-	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/update_cloudflare_com_v4.sh $(1)/usr/lib/ddns
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_cloudflare.com-v4
+	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_cloudflare_com_v4.sh $(1)/usr/lib/ddns
 endef
 define Package/$(PKG_NAME)_cloudflare.com-v4/postinst
 	#!/bin/sh
-	printf "%s\\t%s\\n" '"cloudflare.com-v4"' '"update_cloudflare_com_v4.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-	printf "%s\\t%s\\n" '"cloudflare.com-v4"' '"update_cloudflare_com_v4.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
+	# if NOT upgrading add entries
+	[ "$${PKG_UPGRADE}" = "1" ] || {
+		printf "%s\\t%s\\n" '"cloudflare.com-v4"' '"update_cloudflare_com_v4.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+		printf "%s\\t%s\\n" '"cloudflare.com-v4"' '"update_cloudflare_com_v4.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
+	}
+	# on real system restart service if enabled
+	[ -z "$${IPKG_INSTROOT}" ] \
+		&& /etc/init.d/ddns enabled \
+		&& /etc/init.d/ddns start >/dev/null 2>&1
+	exit 0	# suppress errors
 endef
 define Package/$(PKG_NAME)_cloudflare.com-v4/prerm
 	#!/bin/sh
+	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
 	/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
 	/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+	exit 0	# suppress errors
 endef
 
-##### **********************************
+###### *************************************************************************
+define Package/$(PKG_NAME)_godaddy.com-v1/preinst
+	#!/bin/sh
+	# if NOT run buildroot then stop service
+	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+	exit 0	# suppress errors
+endef
 define Package/$(PKG_NAME)_godaddy.com-v1/install
-	$(INSTALL_DIR)  $(1)/etc/uci-defaults
-	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_godaddy.com-v1
-	$(INSTALL_DIR)  $(1)/usr/lib/ddns
-	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/update_godaddy_com_v1.sh $(1)/usr/lib/ddns
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_godaddy.com-v1
+	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_godaddy_com_v1.sh $(1)/usr/lib/ddns
 endef
 define Package/$(PKG_NAME)_godaddy.com-v1/postinst
 	#!/bin/sh
-	printf "%s\\t%s\\n" '"godaddy.com-v1"' '"update_godaddy_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-	printf "%s\\t%s\\n" '"godaddy.com-v1"' '"update_godaddy_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
+	# if NOT upgrading add entries
+	[ "$${PKG_UPGRADE}" = "1" ] || {
+		printf "%s\\t%s\\n" '"godaddy.com-v1"' '"update_godaddy_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+		printf "%s\\t%s\\n" '"godaddy.com-v1"' '"update_godaddy_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
+	}
+	# on real system restart service if enabled
+	[ -z "$${IPKG_INSTROOT}" ] \
+		&& /etc/init.d/ddns enabled \
+		&& /etc/init.d/ddns start >/dev/null 2>&1
+	exit 0	# suppress errors
 endef
 define Package/$(PKG_NAME)_godaddy.com-v1/prerm
 	#!/bin/sh
+	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
 	/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
 	/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+	exit 0	# suppress errors
 endef
 
-##### **********************************
+###### *************************************************************************
+define Package/$(PKG_NAME)_no-ip_com/preinst
+	#!/bin/sh
+	# if NOT run buildroot then stop service
+	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+	exit 0	# suppress errors
+endef
 define Package/$(PKG_NAME)_no-ip_com/install
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_no-ip_com
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
-	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/update_no-ip_com.sh $(1)/usr/lib/ddns
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_no-ip_com.sh $(1)/usr/lib/ddns
 endef
 define Package/$(PKG_NAME)_no-ip_com/postinst
 	#!/bin/sh
-	printf "%s\\t%s\\n" '"no-ip.com"' '"update_no-ip_com.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+	# if NOT upgrading add entries
+	[ "$${PKG_UPGRADE}" = "1" ] || {
+		printf "%s\\t%s\\n" '"no-ip.com"' '"update_no-ip_com.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+	}
+	# on real system restart service if enabled
+	[ -z "$${IPKG_INSTROOT}" ] \
+		&& /etc/init.d/ddns enabled \
+		&& /etc/init.d/ddns start >/dev/null 2>&1
+	exit 0	# suppress errors
 endef
 define Package/$(PKG_NAME)_no-ip_com/prerm
 	#!/bin/sh
+	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop		>/dev/null 2>&1
 	/bin/sed -i '/no-ip\.com/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
+	exit 0	# suppress errors
 endef
 
-##### **********************************
+###### *************************************************************************
+define Package/$(PKG_NAME)_nsupdate/preinst
+	#!/bin/sh
+	# if NOT run buildroot then stop service
+	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+	exit 0	# suppress errors
+endef
 define Package/$(PKG_NAME)_nsupdate/install
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_nsupdate
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
-	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/update_nsupdate.sh $(1)/usr/lib/ddns
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_nsupdate.sh $(1)/usr/lib/ddns
 endef
 define Package/$(PKG_NAME)_nsupdate/postinst
 	#!/bin/sh
-	printf "%s\\t%s\\n" '"bind-nsupdate"' '"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-	printf "%s\\t%s\\n" '"bind-nsupdate"' '"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
+	# if NOT upgrading add entries
+	[ "$${PKG_UPGRADE}" = "1" ] || {
+		printf "%s\\t%s\\n" '"bind-nsupdate"' '"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+		printf "%s\\t%s\\n" '"bind-nsupdate"' '"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
+	}
+	# on real system restart service if enabled
+	[ -z "$${IPKG_INSTROOT}" ] \
+		&& /etc/init.d/ddns enabled \
+		&& /etc/init.d/ddns start >/dev/null 2>&1
+	exit 0	# suppress errors
 endef
 define Package/$(PKG_NAME)_nsupdate/prerm
 	#!/bin/sh
+	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop			>/dev/null 2>&1
 	/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
 	/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+	exit 0	# suppress errors
 endef
 
-##### **********************************
+###### *************************************************************************
 $(eval $(call BuildPackage,$(PKG_NAME)))
 $(eval $(call BuildPackage,$(PKG_NAME)_cloudflare))
 $(eval $(call BuildPackage,$(PKG_NAME)_cloudflare.com-v4))


### PR DESCRIPTION
Maintainer: me

Description:

modified Makefile to:
- stop service before install when updating reported at http://forum.lede-project.org/t/ddns-scripts-upgrade-issue/456/1
- run uci-defaults for all packages
- modify services files only on new installation

still some commands already covered by default_postinst() etc. but they are in there for backward compatibilty.

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>