### PR TITLE
curl/libcurl: move from LEDE to openwrt/packages/net

### DIFF
--- a/net/curl/Config.in
+++ b/net/curl/Config.in
@@ -1,0 +1,159 @@
+if PACKAGE_libcurl
+
+comment "SSL support"
+
+choice
+	prompt "Selected SSL library"
+	default LIBCURL_POLARSSL
+
+	config LIBCURL_POLARSSL
+		bool "PolarSSL"
+
+	config LIBCURL_MBEDTLS
+		bool "mbed TLS"
+
+	config LIBCURL_CYASSL
+		bool "CyaSSL"
+
+	config LIBCURL_OPENSSL
+		bool "OpenSSL"
+
+	config LIBCURL_GNUTLS
+		bool "GNUTLS"
+
+	config LIBCURL_NOSSL
+		bool "No SSL support"
+
+endchoice
+
+comment "Supported protocols"
+
+config LIBCURL_DICT
+	bool "DICT protocol"
+	default n
+
+config LIBCURL_FILE
+	bool "FILE protocol"
+	default y
+
+config LIBCURL_FTP
+	bool "FTP / FTPS protocol"
+	default y
+
+config LIBCURL_GOPHER
+	bool "Gopher protocol"
+	default n
+
+config LIBCURL_HTTP
+	bool "HTTP / HTTPS protocol"
+	default y
+
+config LIBCURL_COOKIES
+	bool "Enable Cookies support"
+	depends on LIBCURL_HTTP
+	default y
+
+config LIBCURL_IMAP
+	bool "IMAP / IMAPS protocol"
+	default n
+
+config LIBCURL_LDAP
+	bool "LDAP protocol"
+	default n
+
+config LIBCURL_LDAPS
+	bool "Enable LDAPS support"
+	depends on LIBCURL_LDAP && !LIBCURL_NOSSL
+	default y
+
+config LIBCURL_POP3
+	bool "POP3 / POP3S protocol"
+	default n
+
+config LIBCURL_RTSP
+	bool "RTSP protocol"
+	depends on LIBCURL_HTTP
+	default n
+config LIBCURL_NO_RTSP
+	string "RTSP require HTTP protocol"
+	depends on !LIBCURL_HTTP
+	default "!"
+
+config LIBCURL_SSH2
+	bool "SCP / SFTP protocol"
+	default n
+
+config LIBCURL_SMB
+	bool "SMB protocol (CIFS)"
+	depends on LIBCURL_CRYPTO_AUTH && (LIBCURL_GNUTLS || LIBCURL_OPENSSL)
+	default n
+config LIBCURL_NO_SMB
+	string "SMB require 'cryptographic authentication' and either 'GnuTLS' or 'OpenSSL'"
+	depends on !LIBCURL_CRYPTO_AUTH || (!LIBCURL_GNUTLS && !LIBCURL_OPENSSL)
+	default "!"
+
+config LIBCURL_SMTP
+	bool "SMTP / SMTPS protocol"
+	default n
+
+config LIBCURL_TELNET
+	bool "TELNET protocol"
+	default n
+
+config LIBCURL_TFTP
+	bool "TFTP protocol"
+	default n
+
+comment "Miscellaneous"
+
+config LIBCURL_PROXY
+	bool "Enable proxy support"
+	default y
+
+config LIBCURL_CRYPTO_AUTH
+	bool "Enable cryptographic authentication"
+	default n
+
+config LIBCURL_TLS_SRP
+	bool "Enable TLS-SRP authentication"
+	default n
+
+config LIBCURL_LIBIDN
+	bool "Enable IDN support"
+	default n
+
+config LIBCURL_THREADED_RESOLVER
+	bool "Enable threaded DNS resolver"
+	default n
+	help
+		Enable POSIX threaded asynchronous DNS resolution
+
+config LIBCURL_ZLIB
+	bool "Enable zlib support"
+	default n
+
+config LIBCURL_UNIX_SOCKETS
+	bool "Enable unix domain socket support"
+	default n
+	help
+		Enable HTTP over unix domain sockets.
+		To use this with the curl command line, you specify the socket path to the new --unix-domain option.
+		This feature is actually not limited to HTTP, you can do all the TCP-based protocols 
+		except FTP over the unix domain socket, but it is only HTTP that is regularly used this way. 
+		The reason FTP isn't supported is of course its use of two connections 
+		which would be even weirder to do like this.
+
+config LIBCURL_LIBCURL_OPTION
+	bool "Enable generation of C code"
+	default n
+
+config LIBCURL_VERBOSE
+	bool "Enable verbose error strings"
+	default n
+
+config LIBCURL_NTLM
+	bool "Enable NTLM support"
+	depends on LIBCURL_CRYPTO_AUTH && !LIBCURL_NOSSL
+	default n
+
+endif

--- a/net/curl/Makefile
+++ b/net/curl/Makefile
@@ -1,0 +1,180 @@
+#
+# Copyright (C) 2007-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=curl
+PKG_VERSION:=7.51.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=http://curl.haxx.se/download/ \
+	http://www.mirrorspace.org/curl/ \
+	ftp://ftp.sunet.se/pub/www/utilities/curl/ \
+	ftp://ftp.planetmirror.com/pub/curl/ \
+	http://www.mirrormonster.com/curl/download/ \
+	http://curl.mirrors.cyberservers.net/download/
+PKG_MD5SUM:=7f8240048907e5030f67be0a6129bc4b333783b9cca1391026d700835a788dde
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+
+PKG_CONFIG_DEPENDS:= \
+  CONFIG_IPV6 \
+  \
+  CONFIG_LIBCURL_CYASSL \
+  CONFIG_LIBCURL_GNUTLS \
+  CONFIG_LIBCURL_OPENSSL \
+  CONFIG_LIBCURL_POLARSSL \
+  CONFIG_LIBCURL_MBEDTLS \
+  CONFIG_LIBCURL_NOSSL \
+  \
+  CONFIG_LIBCURL_LIBIDN \
+  CONFIG_LIBCURL_SSH2 \
+  CONFIG_LIBCURL_ZLIB \
+  \
+  CONFIG_LIBCURL_DICT \
+  CONFIG_LIBCURL_FILE \
+  CONFIG_LIBCURL_FTP \
+  CONFIG_LIBCURL_GOPHER \
+  CONFIG_LIBCURL_HTTP \
+  CONFIG_LIBCURL_IMAP \
+  CONFIG_LIBCURL_LDAP \
+  CONFIG_LIBCURL_LDAPS \
+  CONFIG_LIBCURL_POP3 \
+  CONFIG_LIBCURL_RTSP \
+  CONFIG_LIBCURL_NO_RTSP \
+  CONFIG_LIBCURL_SMB \
+  CONFIG_LIBCURL_NO_SMB \
+  CONFIG_LIBCURL_SMTP \
+  CONFIG_LIBCURL_TELNET \
+  CONFIG_LIBCURL_TFTP \
+  \
+  CONFIG_LIBCURL_COOKIES \
+  CONFIG_LIBCURL_CRYPTO_AUTH \
+  CONFIG_LIBCURL_LIBCURL_OPTION \
+  CONFIG_LIBCURL_PROXY \
+  CONFIG_LIBCURL_THREADED_RESOLVER \
+  CONFIG_LIBCURL_TLS_SRP \
+  CONFIG_LIBCURL_UNIX_SOCKETS \
+  CONFIG_LIBCURL_VERBOSE \
+  CONFIG_LIBCURL_NTLM
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/curl/Default
+  SECTION:=net
+  CATEGORY:=Network
+  URL:=http://curl.haxx.se/
+  MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>
+endef
+
+define Package/curl
+  $(call Package/curl/Default)
+  SUBMENU:=File Transfer
+  DEPENDS:=+libcurl
+  TITLE:=A client-side URL transfer utility
+endef
+
+define Package/libcurl
+  $(call Package/curl/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+LIBCURL_POLARSSL:libpolarssl +LIBCURL_CYASSL:libcyassl +LIBCURL_OPENSSL:libopenssl +LIBCURL_GNUTLS:libgnutls +LIBCURL_MBEDTLS:libmbedtls
+  DEPENDS += +LIBCURL_ZLIB:zlib +LIBCURL_THREADED_RESOLVER:libpthread +LIBCURL_LDAP:libopenldap +LIBCURL_LIBIDN:libidn +LIBCURL_SSH2:libssh2
+  TITLE:=A client-side URL transfer library
+  MENU:=1
+endef
+
+
+define Package/libcurl/config
+  source "$(SOURCE)/Config.in"
+endef
+
+TARGET_CFLAGS += $(FPIC) -ffunction-sections -fdata-sections
+TARGET_CPPFLAGS += $(if $(CONFIG_LIBCURL_NTLM),,-DCURL_DISABLE_NTLM)
+TARGET_LDFLAGS += -Wl,--gc-sections
+
+CONFIGURE_ARGS += \
+	--disable-debug \
+	--disable-ares \
+	--enable-shared \
+	--enable-static \
+	--disable-manual \
+	--without-nss \
+	--without-libmetalink \
+	--without-librtmp \
+	\
+	$(call autoconf_bool,CONFIG_IPV6,ipv6) \
+	\
+	$(if $(CONFIG_LIBCURL_CYASSL),--with-cyassl="$(STAGING_DIR)/usr" --without-ca-path --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt,--without-cyassl) \
+	$(if $(CONFIG_LIBCURL_GNUTLS),--with-gnutls="$(STAGING_DIR)/usr" --without-ca-bundle --with-ca-path=/etc/ssl/certs,--without-gnutls) \
+	$(if $(CONFIG_LIBCURL_OPENSSL),--with-ssl="$(STAGING_DIR)/usr" --without-ca-bundle --with-ca-path=/etc/ssl/certs,--without-ssl) \
+	$(if $(CONFIG_LIBCURL_POLARSSL),--with-polarssl="$(STAGING_DIR)/usr" --without-ca-bundle --with-ca-path=/etc/ssl/certs,--without-polarssl) \
+	$(if $(CONFIG_LIBCURL_MBEDTLS),--with-mbedtls="$(STAGING_DIR)/usr" --without-ca-path --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt,--without-mbedtls) \
+	\
+	$(if $(CONFIG_LIBCURL_LIBIDN),--with-libidn="$(STAGING_DIR)/usr",--without-libidn) \
+	$(if $(CONFIG_LIBCURL_SSH2),--with-libssh2="$(STAGING_DIR)/usr",--without-libssh2) \
+	$(if $(CONFIG_LIBCURL_ZLIB),--with-zlib="$(STAGING_DIR)/usr",--without-zlib) \
+	\
+	$(call autoconf_bool,CONFIG_LIBCURL_DICT,dict) \
+	$(call autoconf_bool,CONFIG_LIBCURL_FILE,file) \
+	$(call autoconf_bool,CONFIG_LIBCURL_FTP,ftp) \
+	$(call autoconf_bool,CONFIG_LIBCURL_GOPHER,gopher) \
+	$(call autoconf_bool,CONFIG_LIBCURL_HTTP,http) \
+	$(call autoconf_bool,CONFIG_LIBCURL_IMAP,imap) \
+	$(call autoconf_bool,CONFIG_LIBCURL_LDAP,ldap) \
+	$(call autoconf_bool,CONFIG_LIBCURL_LDAPS,ldaps) \
+	$(call autoconf_bool,CONFIG_LIBCURL_POP3,pop3) \
+	$(call autoconf_bool,CONFIG_LIBCURL_RTSP,rtsp) \
+	$(call autoconf_bool,CONFIG_LIBCURL_SMB,smb) \
+	$(call autoconf_bool,CONFIG_LIBCURL_SMTP,smtp) \
+	$(call autoconf_bool,CONFIG_LIBCURL_TELNET,telnet) \
+	$(call autoconf_bool,CONFIG_LIBCURL_TFTP,tftp) \
+	\
+	$(call autoconf_bool,CONFIG_LIBCURL_COOKIES,cookies) \
+	$(call autoconf_bool,CONFIG_LIBCURL_CRYPTO_AUTH,crypto-auth) \
+	$(call autoconf_bool,CONFIG_LIBCURL_LIBCURL_OPTION,libcurl-option) \
+	$(call autoconf_bool,CONFIG_LIBCURL_PROXY,proxy) \
+	$(call autoconf_bool,CONFIG_LIBCURL_THREADED_RESOLVER,threaded-resolver) \
+	$(call autoconf_bool,CONFIG_LIBCURL_TLS_SRP,tls-srp) \
+	$(call autoconf_bool,CONFIG_LIBCURL_UNIX_SOCKETS,unix-sockets) \
+	$(call autoconf_bool,CONFIG_LIBCURL_VERBOSE,verbose) \
+
+define Build/Compile
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		CC="$(TARGET_CC)" \
+		install
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(2)/bin $(1)/usr/bin $(1)/usr/include $(1)/usr/lib $(1)/usr/lib/pkgconfig
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/curl-config $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/curl $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcurl.{a,so*} $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/libcurl.pc $(1)/usr/lib/pkgconfig/
+	$(SED) 's,-L$$$${exec_prefix}/lib,,g' $(1)/usr/bin/curl-config
+	[ -n "$(TARGET_LDFLAGS)" ] && $(SED) 's#$(TARGET_LDFLAGS)##g' $(1)/usr/lib/pkgconfig/libcurl.pc || true
+	$(LN) $(STAGING_DIR)/usr/bin/curl-config $(2)/bin/
+endef
+
+define Package/curl/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/curl $(1)/usr/bin/
+endef
+
+define Package/libcurl/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcurl.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,curl))
+$(eval $(call BuildPackage,libcurl))

--- a/net/curl/patches/200-no_docs_tests.patch
+++ b/net/curl/patches/200-no_docs_tests.patch
@@ -1,0 +1,22 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -153,7 +153,7 @@ CLEANFILES = $(VC6_LIBDSP) $(VC6_SRCDSP)
+ bin_SCRIPTS = curl-config
+ 
+ SUBDIRS = lib src include
+-DIST_SUBDIRS = $(SUBDIRS) tests packages docs scripts
++DIST_SUBDIRS = $(SUBDIRS) packages
+ 
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = libcurl.pc
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -613,7 +613,7 @@ CLEANFILES = $(VC6_LIBDSP) $(VC6_SRCDSP)
+ 
+ bin_SCRIPTS = curl-config
+ SUBDIRS = lib src include
+-DIST_SUBDIRS = $(SUBDIRS) tests packages docs scripts
++DIST_SUBDIRS = $(SUBDIRS) packages
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = libcurl.pc
+ LIB_VAUTH_CFILES = vauth/vauth.c vauth/cleartext.c vauth/cram.c         \

--- a/net/curl/patches/310-polarssl-disable-runtime-version-check.patch
+++ b/net/curl/patches/310-polarssl-disable-runtime-version-check.patch
@@ -1,0 +1,22 @@
+--- a/lib/vtls/polarssl.c
++++ b/lib/vtls/polarssl.c
+@@ -646,7 +646,7 @@ void Curl_polarssl_session_free(void *pt
+ 
+ size_t Curl_polarssl_version(char *buffer, size_t size)
+ {
+-  unsigned int version = version_get_number();
++  unsigned int version = POLARSSL_VERSION_NUMBER;
+   return snprintf(buffer, size, "%s/%d.%d.%d",
+                   version >= 0x01030A00?"mbedTLS":"PolarSSL",
+                   version>>24, (version>>16)&0xff, (version>>8)&0xff);
+--- a/lib/vtls/mbedtls.c
++++ b/lib/vtls/mbedtls.c
+@@ -712,7 +712,7 @@ void Curl_mbedtls_session_free(void *ptr
+ 
+ size_t Curl_mbedtls_version(char *buffer, size_t size)
+ {
+-  unsigned int version = mbedtls_version_get_number();
++  unsigned int version = MBEDTLS_VERSION_NUMBER;
+   return snprintf(buffer, size, "mbedTLS/%d.%d.%d", version>>24,
+                   (version>>16)&0xff, (version>>8)&0xff);
+ }


### PR DESCRIPTION
Maintainer: @kaloz

Description:

cURL not LEDE base build relevant, so move to openwrt/packages/net
!!! Depends on corresponding pull at
- lede-project/source#605
- openwrt/openwrt#270

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>