### PR TITLE
ddns-scripts: set default verbose=0 so scripts run in background

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.6
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
@@ -126,7 +126,7 @@ define Build/Compile
 		-e '/^\s*$$$$/d'	$$$$FILE; \
 	done
 	# ensure that VERSION inside dynamic_dns_functions.sh reflect PKG_VERSION of Makefile
-	$(SED) '/^VERSION=*/s/.*/VERSION="$(PKG_VERSION)"/' $(PKG_BUILD_DIR)/files/dynamic_dns_functions.sh
+	$(SED) '/^VERSION=*/s/.*/VERSION="$(PKG_VERSION)-$(PKG_RELEASE)"/' $(PKG_BUILD_DIR)/files/dynamic_dns_functions.sh
 	$(CP) ./tools $(PKG_BUILD_DIR)
 	chmod 755 $(PKG_BUILD_DIR)/tools/*
 	$(PKG_BUILD_DIR)/tools/public_suffix_list.sh

--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -23,7 +23,7 @@
 # GLOBAL VARIABLES #
 VERSION="2.7.6"
 SECTION_ID=""		# hold config's section name
-VERBOSE=1		# default mode is log to console, but easily changed with parameter
+VERBOSE=0		# default mode is log to console, but easily changed with parameter
 MYPROG=$(basename $0)	# my program call name
 
 LOGFILE=""		# logfile - all files are set in dynamic_dns_updater.sh


### PR DESCRIPTION
Maintainer: me
Compile tested:
Run tested: LEDE r2438-a245772

Description:
fix #3645 and https://github.com/lede-project/source/pull/596#issuecomment-266395456

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>