### PR TITLE
chrony: enable asynchronous name resolving

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
 PKG_VERSION:=2.4.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.tuxfamily.org/chrony/
@@ -27,7 +27,7 @@ define Package/chrony
   SUBMENU:=Time Synchronization
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libcap
+  DEPENDS:=+libcap +libpthread
   USERID:=chrony=323:chrony=323
   TITLE:=A versatile NTP client and server
   URL:=http://chrony.tuxfamily.org/
@@ -53,7 +53,6 @@ CONFIGURE_ARGS+= \
 	--chronysockdir=/var/run/chrony \
 	--disable-readline \
 	--disable-rtc \
-	--disable-asyncdns \
 	--with-user=chrony
 
 CONFIGURE_VARS+=CPPFLAGS=-DNDEBUG


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, RB411, LEDE trunk
Run tested: ar71xx, RB411, LEDE trunk, client resolves pool.ntp.org addresses and synchronizes as expected

Description: enable asynchronous name resolving with pthreads

Signed-off-by: Miroslav Lichvar <mlichvar0@gmail.com>