### PR TITLE
Bring in ecdsautils, make libuecc shared

### DIFF
--- a/libs/libuecc/Makefile
+++ b/libs/libuecc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuecc
 PKG_VERSION:=7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Matthias Schiffer <mschiffer@universe-factory.net>
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -35,11 +35,16 @@ CMAKE_OPTIONS += \
 	-DCMAKE_BUILD_TYPE:String="MINSIZEREL"
 
 
+define Package/libuecc/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libuecc.so* $(1)/usr/lib/
+endef
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libuecc-$(PKG_VERSION) $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libuecc.a $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libuecc.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libuecc.pc $(1)/usr/lib/pkgconfig/
 endef

--- a/net/fastd/Makefile
+++ b/net/fastd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fastd
 PKG_VERSION:=18
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Matthias Schiffer <mschiffer@universe-factory.net>
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -43,7 +43,7 @@ PKG_CONFIG_DEPENDS:=\
 	CONFIG_FASTD_WITH_STATUS_SOCKET
 
 
-PKG_BUILD_DEPENDS:=nacl libuecc
+PKG_BUILD_DEPENDS:=nacl
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -51,7 +51,7 @@ include $(INCLUDE_DIR)/cmake.mk
 define Package/fastd
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+kmod-tun +librt +libpthread +FASTD_WITH_STATUS_SOCKET:libjson-c +FASTD_WITH_CAPABILITIES:libcap
+  DEPENDS:=+kmod-tun +librt +libpthread +libuecc +FASTD_WITH_STATUS_SOCKET:libjson-c +FASTD_WITH_CAPABILITIES:libcap
   TITLE:=Fast and Secure Tunneling Daemon
   URL:=https://projects.universe-factory.net/projects/fastd
   SUBMENU:=VPN

--- a/utils/ecdsautils/Makefile
+++ b/utils/ecdsautils/Makefile
@@ -1,0 +1,72 @@
+#
+# Copyright (C) 2012-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ecdsautils
+PKG_VERSION:=0.3.2.20160630
+PKG_RELEASE:=1
+PKG_REV:=07538893fb6c2a9539678c45f9dbbf1e4f222b46
+PKG_MAINTAINER:=Matthias Schiffer <mschiffer@universe-factory.net>
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=git://github.com/tcatm/$(PKG_NAME).git
+PKG_SOURCE_VERSION:=$(PKG_REV)
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_PROTO:=git
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/libecdsautil
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+libuecc
+  TITLE:=ECDSA library
+  URL:=https://github.com/tcatm/ecdsautils
+endef
+
+define Package/ecdsautils
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libecdsautil +libuecc
+  TITLE:=ECDSA Utilities
+  URL:=https://github.com/tcatm/ecdsautils
+endef
+
+CMAKE_OPTIONS += \
+  -DCMAKE_BUILD_TYPE:String="MINSIZEREL" \
+
+
+define Package/libecdsautil/description
+ Library to sign and verify checksums using ECDSA.
+endef
+
+define Package/ecdsautils/description
+ Utilities to sign and verify checksums using ECDSA.
+endef
+
+define Package/libecdsautil/install
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libecdsautil.so* $(1)/usr/lib/
+endef
+
+define Package/ecdsautils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ecdsautil $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ecdsakeygen $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ecdsasign $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ecdsaverify $(1)/usr/bin/
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include $(1)/usr/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib $(1)/usr/
+endef
+
+$(eval $(call BuildPackage,libecdsautil))
+$(eval $(call BuildPackage,ecdsautils))


### PR DESCRIPTION
Maintainer: @NeoRaider / me (if desired)

Compile tested:
- ar71xx-generic: TP-Link WDR{3600,4300}-v1
- ramips-mt7621: Ubiquiti EdgeRouter X, ZBT WG-3526, and Digineo AC1200 Pro
- using LEDE master (66482e179bf463d286419319b33a46ad6a507453)

Run tested: Digineo AC1200 Pro (should work on TP-Link/ERX/ZBT as well)

Description: These commit brings `ecdsautils`/`libecdsautil` over from freifunk-gluon and marks `libuecc` as shared library. This is a continuation of/extension to PR #3640, which just added an `-fPIC` compile flag.

The original commits/sources can be found here:

- https://github.com/freifunk-gluon/gluon/blob/cb2ecbfdf0c478568a28aacb99d30fd6ee5c0dd1/patches/packages/openwrt/0007-libuecc-use-shared-instead-of-static-library.patch
- https://github.com/freifunk-gluon/packages/blob/0a6411b56b9edeba1809ffe45c03dbb7261bf45c/utils/ecdsautils/Makefile