### PR TITLE
vsftpd: Fix compilation error on x86

### DIFF
--- a/net/vsftpd/Makefile
+++ b/net/vsftpd/Makefile
@@ -55,6 +55,8 @@ else
   NLSSTRING:=-lcrypt -lnsl
 endif
 
+TARGET_CFLAGS += -D_GNU_SOURCE -include fcntl.h
+
 ifeq ($(BUILD_VARIANT),notls)
  define Build/Compile
 	$(SED) 's/-lcrypt -lnsl/$(NLSSTRING)/' $(PKG_BUILD_DIR)/Makefile


### PR DESCRIPTION
Maintainer: @obsy
Compile tested: x86 OpenWRT trunk

Description:

Signed-off-by: Alex Nikitenko <alex.nikitenko@sirinsoftware.com>

Bugfix for https://dev.openwrt.org/ticket/24901

F_SETLKW64 and F_SETLK64 in musl are defined in include/asm-generic/fcntl.h.
However simply including this header doesn't solve a problem,
since in musl both include/asm-generic/fcntl.h and include/fcntl.h
have definitions of same structures (like struct flock) which results
in conflicting declaration of structs.
Defining these values locally seems reasonable in this case.