### PR TITLE
ca-certificates: move to openwrt/packages/net

### DIFF
--- a/net/ca-certificates/Makefile
+++ b/net/ca-certificates/Makefile
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2006-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ca-certificates
+PKG_VERSION:=20161130
+PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
+
+PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=http://ftp.debian.org/debian/pool/main/c/ca-certificates
+PKG_MD5SUM:=1a0a3a1b3390dc83affed4b0c2ae1c05
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ca-certificates
+  SECTION:=base
+  CATEGORY:=Base system
+  TITLE:=System CA certificates
+  PKGARCH:=all
+endef
+
+define Package/ca-bundle
+  SECTION:=base
+  CATEGORY:=Base system
+  TITLE:=System CA certificates as a bundle
+  PKGARCH:=all
+endef
+
+define Build/Install
+	mkdir -p \
+		$(PKG_INSTALL_DIR)/usr/sbin \
+		$(PKG_INSTALL_DIR)/usr/share/ca-certificates
+	$(call Build/Install/Default,)
+endef
+
+define Package/ca-certificates/install
+	$(INSTALL_DIR) $(1)/etc/ssl/certs
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/ca-certificates/*/*.crt $(1)/etc/ssl/certs/
+
+	for CERTFILE in `ls -1 $(1)/etc/ssl/certs`; do \
+		HASH=`openssl x509 -hash -noout -in $(1)/etc/ssl/certs/$$$$CERTFILE` ; \
+		SUFFIX=0 ; \
+		while [ -h "$(1)/etc/ssl/certs/$$$$HASH.$$$$SUFFIX" ]; do \
+			let "SUFFIX += 1" ; \
+		done ; \
+		$(LN) "$$$$CERTFILE" "$(1)/etc/ssl/certs/$$$$HASH.$$$$SUFFIX" ; \
+	done
+endef
+
+define Package/ca-bundle/install
+	$(INSTALL_DIR) $(1)/etc/ssl/certs
+	cat $(PKG_INSTALL_DIR)/usr/share/ca-certificates/*/*.crt >$(1)/etc/ssl/certs/ca-certificates.crt
+endef
+$(eval $(call BuildPackage,ca-certificates))
+$(eval $(call BuildPackage,ca-bundle))


### PR DESCRIPTION
Maintainer: me

Description:

ca-certificates not base build relevant, so move to openwrt/packages/net
!!! Depends on corresponding pulls at
- lede-project/source#615
- openwrt/openwrt#273

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>