### PR TITLE
openswitch: improve build time for kmod-only builds

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -35,6 +35,21 @@ PKG_INSTALL:=1
 # Support for kernel 4.4 is backported
 SUPPORTED_KERNELS:=LINUX_3_18||LINUX_4_1||LINUX_4_3||LINUX_4_4
 
+# If only kmod-openvswitch is enabled, then override default make path to only
+# build and install the datapath/linux subdirectory which cuts down compilation
+# time dramatically.
+ifeq ($(CONFIG_PACKAGE_openvswitch-base),)
+ ifneq ($(CONFIG_PACKAGE_kmod-openvswitch),)
+  MAKE_PATH := datapath/linux
+ endif
+endif
+
+# Additionally register PKG_CONFIG_DEPENDS to trigger a rebuild of the code
+# base if the package selection changes.
+PKG_CONFIG_DEPENDS := \
+	CONFIG_PACKAGE_openvswitch-base \
+	CONFIG_PACKAGE_kmod-openvswitch
+
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
 
@@ -71,7 +86,7 @@ endef
 define Package/openvswitch-python
   $(call Package/openvswitch/Default)
   TITLE:=Open vSwitch Python Support
-  DEPENDS:=+openvswitch +python
+  DEPENDS:=+openvswitch +PACKAGE_openvswitch-python:python
 endef
 
 define Package/openvswitch-python/description


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: LEDE r2517 / e0b8b24cfbaf3c3f4db4aba4401144d7e76799bd
Run tested: x86/64 - sucessfully loaded resulting kmod
Description:

When only kmod-openvswitch is enabled, which commonly happens during LEDE
release builds, there is no need to build the entire userland of openvswitch
as this is done at a later stage on systems dedicated to build only userspace
packages.

This change conditionalizes the dependency on python, which means that python
prerequisites are only compiled if the openvswitch-python package is enabled,
which allows us to eliminate the entire python dependency chain.

Furthermore, this change sets MAKE_PATH to the kernel module sub directory
if only kmod-openvswitch is enabled which causes the openvswitch build system
to only process sources related to the .ko files.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>