### PR TITLE
python: move includes after common package variables

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -10,12 +10,6 @@ include $(TOPDIR)/rules.mk
 # For PYTHON_VERSION
 include ./files/python-version.mk
 
-# This file provides the necsessary host build variables
-include ./files/python-host.mk
-
-# For PyPackage
-include ./files/python-package.mk
-
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 PKG_RELEASE:=2
@@ -26,6 +20,12 @@ PKG_MD5SUM:=57dffcee9cee8bb2ab5f82af1d8e9a69
 
 PKG_LICENSE:=PSF
 PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
+
+# This file provides the necsessary host build variables
+include ./files/python-host.mk
+
+# For PyPackage
+include ./files/python-package.mk
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: LEDE r2517 / e0b8b24cfbaf3c3f4db4aba4401144d7e76799bd
Run tested: n/a

Description:

Move the python-host.mk and python-package.mk includes after the definition of
common package variables. This is required to ensure that PKG_UNPACK is not set
to to the dummy "true" command which happens if PKG_SOURCE is not yet set.

Fixes the following error observed while attempting to build Python on a recent
LEDE version:

    make[2]: Entering directory '.../lang/python'
    true
    [ ! -d ./src/ ] || cp -fpR ./src/* .../Python-2.7.12

    Applying ./patches/001-enable-zlib.patch using plaintext:
    can't find file to patch at input line 14
    Perhaps you used the wrong -p or --strip option?
    [...]
    Patch failed!  Please fix ./patches/001-enable-zlib.patch!
    Makefile:242: recipe for target '.../Python-2.7.12/.prepared_...' failed

Signed-off-by: Jo-Philipp Wich <jo@mein.io>