### PR TITLE
libs/libtasn1: Update to 4.9

### DIFF
--- a/libs/libtasn1/Makefile
+++ b/libs/libtasn1/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtasn1
-PKG_VERSION:=4.8
-PKG_RELEASE:=2
+PKG_VERSION:=4.9
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=ftp://ftp.gnu.org/gnu/libtasn1
-PKG_MD5SUM:=9a6767705725544f2b86670dcfb34107
+PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
+PKG_MD5SUM:=4f6f7a8fd691ac2b8307c8ca365bad711db607d4ad5966f6938a9d2ecd65c920
 PKG_LICENSE:=LGPLv2.1+
 PKG_LICENSE_FILES:=COPYING.LIB
 
@@ -39,6 +39,7 @@ TARGET_CFLAGS += $(FPIC)
 
 CONFIGURE_ARGS += \
 		--enable-shared \
+		--disable-gcc-warnings \
 		--enable-static
 
 define Build/InstallDev


### PR DESCRIPTION
Maintainer: @nmav 
Compile tested: ar71xx, LEDE trunk
Run tested: N/A

Description:

Update to 4.9 and use URL alias

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>