### PR TITLE
libs/liblz4: Use xz compression instead of gz

### DIFF
--- a/libs/liblz4/Makefile
+++ b/libs/liblz4/Makefile
@@ -16,7 +16,7 @@ PKG_RELEASE:=1
 PKG_LICENSE:=BSD-2-Clause
 PKG_MAINTAINER:=Darik Horn <dajhorn@vanadac.com>
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_URL:=https://github.com/Cyan4973/lz4.git


### PR DESCRIPTION
Maintainer: @dajhorn 
Compile tested: N/A
Run tested: N/A

Description:

Use xz compression as it saves space compared to gz.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>