### PR TITLE
unbound: fix typo in unbound.sh

### DIFF
--- a/net/unbound/files/unbound.sh
+++ b/net/unbound/files/unbound.sh
@@ -441,7 +441,7 @@ unbound_uci() {
   ####################
   
   config_get_bool UNBOUND_B_DNS64     "$cfg" dns64 0
-  config_get_bool UNBOUND_B_GATE_NAME "$cfg" dnsmsaq_gate_name 0
+  config_get_bool UNBOUND_B_GATE_NAME "$cfg" dnsmasq_gate_name 0
   config_get_bool UNBOUND_B_DNSMASQ   "$cfg" dnsmasq_link_dns 0
   config_get_bool UNBOUND_B_LOCL_NAME "$cfg" dnsmasq_only_local 0
   config_get_bool UNBOUND_B_LOCL_SERV "$cfg" localservice 1


### PR DESCRIPTION
Maintainer: @EricLuehrsen 

Hi Eric,

I noticed a small typo in the unbound.sh script; this fixes it. Looks like you did great work, I'm in the process of converting my Unbound setup.

I'll add this as well - opening an issue for this might be a bit weird - but I see my WAN IP listed in `access-control` as allow. Firewall blocks that of course, but it sits a bit uneasy with me. Can that be removed?

Signed-off-by: Stijn Segers <francesco.borromini@inventati.org>