### PR TITLE
net/wireguard: version bump

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -1,4 +1,5 @@
 #
+# Copyright (C) 2016 Jason A. Donenfeld <Jason@zx2c4.com>
 # Copyright (C) 2016 Baptiste Jonglez <openwrt@bitsofnetworks.org>
 #
 # This is free software, licensed under the GNU General Public License v2.
@@ -9,14 +10,14 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=wireguard
 
-PKG_VERSION:=0.0.20161129
+PKG_VERSION:=0.0.20161218
 PKG_RELEASE:=1
 
-PKG_SOURCE:=WireGuard-experimental-$(PKG_VERSION).tar.xz
+PKG_SOURCE:=WireGuard-$(PKG_VERSION).tar.xz
 # This is actually SHA256, but OpenWRT/LEDE will figure it out based on the length
-PKG_MD5SUM:=7bdce3e56aaae91b195b8bbf7afc8d07f68632c997aa702c1ab84745c099d1b7
+PKG_MD5SUM:=d805035d3e99768e69d8cdeb8fb5250a59b994ce127fceb71a078582c30f5597
 PKG_SOURCE_URL:=https://git.zx2c4.com/WireGuard/snapshot/
-PKG_BUILD_DIR:=$(BUILD_DIR)/WireGuard-experimental-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/WireGuard-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
@@ -92,7 +93,7 @@ define KernelPackage/wireguard
   CATEGORY:=Kernel modules
   SUBMENU:=Network Support
   TITLE:=Wireguard kernel module
-  DEPENDS:=@IPV6 +kmod-udptunnel4 +kmod-udptunnel6 +kmod-ipt-hashlimit
+  DEPENDS:=+IPV6:kmod-udptunnel6 +kmod-udptunnel4 +kmod-ipt-hashlimit
   FILES:= $(PKG_BUILD_DIR)/src/wireguard.$(LINUX_KMOD_SUFFIX)
   AUTOLOAD:=$(call AutoLoad,33,wireguard)
 endef


### PR DESCRIPTION
Maintainer: @zorun
Upstream: me

Description:

Update to new snapshot version. We also make IPV6 optional, and
conditionally select the udptunnel6 module, using the same trick that
the strongswan package also uses for this kind of dependency expression.
This solves a request from users