### PR TITLE
net/dnscrypt-proxy: Use bz2 tarball

### DIFF
--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -13,10 +13,9 @@ PKG_NAME:=dnscrypt-proxy
 PKG_VERSION:=1.8.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy
-PKG_MD5SUM:=2b30b49f0cc1d926023501afc1692dde
-
+PKG_MD5SUM:=dfc59de962b31709b8ba277c6cbb9768dde5104c3b2f2f039a3533703e90475c
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 


### PR DESCRIPTION
Maintainer: @damianorenfer
Compile tested: N/A
Run tested: N/A

Description:
Use bz2 tarball, saves space and bandwidth. 
Use SHA256 checksum instead of MD5.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>