### PR TITLE
libs/rxtx: add support for RX/TX Java serial communications

### DIFF
--- a/libs/rxtx/Makefile
+++ b/libs/rxtx/Makefile
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2016 Dana H. Myers <k6jq@comcast.net>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rxtx
+PKG_VERSION:=2.2pre2
+PKG_RELEASE:=1
+PKG_LICENSE:=LGPL-2.1
+PKG_MAINTAINER:=Dana H. Myers <k6jq@comcast.net>
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
+PKG_SOURCE_URL:=http://rxtx.qbang.org/pub/rxtx/
+PKG_MD5SUM:=7eedb18e3f33a427e2b0e9be8ce3f94c
+
+PKG_FIXUP:=patch-libtool
+PKG_CHECK_FORMAT_SECURITY:=0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/rxtx
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=RX/TX Support for Java serial communications
+  URL:=http://rxtx.qbang.org/wiki/index.php/Main_Page
+  DEPENDS:=+libpthread
+endef
+
+define Package/rxtx/description
+	RX/TX Support for Java serial communications
+endef
+
+CONFIGURE_ARGS += \
+	--disable-PRINTER
+
+define Package/rxtx/install
+	$(INSTALL_DIR) \
+		$(1)/usr/lib/classpath
+	$(CP) $(PKG_BUILD_DIR)/$(GNU_TARGET_NAME)-gnu/.libs/*.so \
+		$(1)/usr/lib/classpath/
+	$(CP) $(PKG_BUILD_DIR)/RXTXcomm.jar \
+		$(1)/usr/lib/classpath/
+endef
+
+$(eval $(call BuildPackage,rxtx))

--- a/libs/rxtx/patches/010-acm-devices.patch
+++ b/libs/rxtx/patches/010-acm-devices.patch
@@ -1,0 +1,11 @@
+diff -rupN rxtx-2.2pre2/src/gnu/io/RXTXCommDriver.java rxtx-2.2pre2.new/src/gnu/io/RXTXCommDriver.java
+--- rxtx-2.2pre2/src/gnu/io/RXTXCommDriver.java	2008-11-13 16:44:01.000000000 -0800
++++ rxtx-2.2pre2.new/src/gnu/io/RXTXCommDriver.java	2015-08-21 16:19:14.330743949 -0700
+@@ -579,6 +579,7 @@ public class RXTXCommDriver implements C
+ 						"ttyUSB", // for USB frobs
+ 						"rfcomm",       // bluetooth serial device
+ 						"ttyircomm", // linux IrCommdevices (IrDA serial emu)
++						"ttyACM" // linux CDC ACM devices
+ 						};
+ 						CandidatePortPrefixes=Temp;
+ 					}


### PR DESCRIPTION
Maintainer: k6jq@comcast.net
Compile tested: OpenWRT Barrier Breaker, Chaos Calmer, trunk; aarch64 odroid C2, x64 virtualbox
Run tested: ar7xxx/9xxx Carambola2 & armv7 Raspberry Pi 2B; OpenWRT Barrier Breaker, Chaos Calmer,
tested with USB ACM with a Java application (Stoker II BBQ controller)

Description:

Add support for RX/TX

Signed-off-by: Dana H. Myers k6jq@comcast.net

[Yeah I completely poked my own Git-eye out, closed #3638 started with a fresh clone]
