### PR TITLE
wireguard: add protocol dependency for endpoints

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=wireguard
 
 PKG_VERSION:=0.0.20161218
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=WireGuard-$(PKG_VERSION).tar.xz
 # This is actually SHA256, but OpenWRT/LEDE will figure it out based on the length
@@ -34,7 +34,8 @@ define Package/wireguard/Default
   SECTION:=net
   CATEGORY:=Network
   URL:=https://www.wireguard.io
-  MAINTAINER:=Baptiste Jonglez <openwrt@bitsofnetworks.org>
+  MAINTAINER:=Baptiste Jonglez <openwrt@bitsofnetworks.org>, \
+              Dan Luedtke <mail@danrl.com>
 endef
 
 define Package/wireguard/Default/description
@@ -71,7 +72,7 @@ endef
 define Package/wireguard-tools
   $(call Package/wireguard/Default)
   TITLE:=Wireguard userspace control program (wg)
-  DEPENDS:=+libmnl +resolveip
+  DEPENDS:=+libmnl
 endef
 
 define Package/wireguard-tools/description

--- a/net/wireguard/files/wireguard.sh
+++ b/net/wireguard/files/wireguard.sh
@@ -83,27 +83,6 @@ proto_wireguard_setup_peer() {
       esac
     done
   fi
-
-  #### FEATURE DISABLED
-  # proto_add_host_dependency() has failed with IPv6 addresses during tests.
-  # Endpoint dependency feature is disabled until the issue is fixed.
-  ####
-  #  # endpoint dependency
-  #  if [ "${endpoint_host}" ]; then
-  #    endpoint_dependency=0
-  #    for ip in $(resolveip -t 10 "${endpoint_host}"); do
-  #      echo "adding host depedency for ${ip} at ${config}"
-  #      proto_add_host_dependency "${config}" "${ip}"
-  #      endpoint_dependency=1
-  #    done
-  #    if [ ${endpoint_dependency} -eq 0 ]; then
-  #      echo "error resolving ${endpoint_host}!"
-  #      sleep 5
-  #      proto_setup_failed "${config}"
-  #      exit 1
-  #    fi
-  #  fi
-  ####
 }
 
 
@@ -160,6 +139,13 @@ proto_wireguard_setup() {
     proto_setup_failed "${config}"
     exit 1
   fi
+
+  # endpoint dependency
+  wg show "${config}" endpoints | while IFS=$'\t:' read -r key ip port; do
+    [ -n "${port}" ] || continue
+    echo "adding host depedency for ${ip} at ${config}"
+    proto_add_host_dependency "${config}" "${ip}"
+  done
 
   proto_send_update "${config}"
 }


### PR DESCRIPTION
Endpoint dependency implemented. The actual endpoint is used exclusively. Using
this approach we are dual-stack safe (not errors on missing protocol) and create
only the dependency that are really necessary.

Signed-off-by: Dan Luedtke <mail@danrl.com>

Maintainer: @zorun 
Compile tested: x86_64
Run tested: x86_64

@zx2c4 @zorun: requesting comments and review. Like to improve the regex, e.g. for public key matching. Maybe no really necessary? What do you think?