### PR TITLE
luarocks: Fix seeded uname (s/m) in site-config.lua

### DIFF
--- a/lang/luarocks/Makefile
+++ b/lang/luarocks/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luarocks
 PKG_VERSION:=2.2.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_PROTO:=git
@@ -42,6 +42,10 @@ CONFIGURE_ARGS = \
     --prefix=$(CONFIGURE_PREFIX) \
     --sysconfdir=/etc \
     --with-lua=$(STAGING_DIR)/host
+
+CONFIGURE_VARS = \
+	LUAROCKS_UNAME_S="Linux" \
+	LUAROCKS_UNAME_M="$(ARCH)"
 
 define Build/Compile
 	$(call Build/Compile/Default,build)

--- a/lang/luarocks/patches/02_allow_configure_uname_siteconfig_adjustment.patch
+++ b/lang/luarocks/patches/02_allow_configure_uname_siteconfig_adjustment.patch
@@ -1,0 +1,37 @@
+Index: luarocks-2.2.2/configure
+===================================================================
+--- luarocks-2.2.2.orig/configure
++++ luarocks-2.2.2/configure
+@@ -388,18 +388,22 @@ then
+ fi
+ 
+ echo_n "Configuring for system... "
+-if uname -s
+-then
+-   LUAROCKS_UNAME_S=`uname -s`
+-else
+-   die "Could not determine operating system. 'uname -s' failed."
++if [ -z "$LUAROCKS_UNAME_S" ]; then
++    if uname -s
++    then
++        LUAROCKS_UNAME_S=`uname -s`
++    else
++        die "Could not determine operating system. 'uname -s' failed."
++    fi
+ fi
+ echo_n "Configuring for architecture... "
+-if uname -m
+-then
+-   LUAROCKS_UNAME_M=`uname -m`
+-else
+-   die "Could not determine processor architecture. 'uname -m' failed."
++if [ -z "$LUAROCKS_UNAME_M" ]; then
++    if uname -m
++    then
++        LUAROCKS_UNAME_M=`uname -m`
++    else
++        die "Could not determine processor architecture. 'uname -m' failed."
++    fi
+ fi
+ 
+ for v in 5.1 5.2 5.3; do


### PR DESCRIPTION
Maintainer: David Thornley / @thornley-touchstar
Compile tested: mips, ar9331, LEDE master
Run tested: mips, ar9331(custom), LEDE master, check site-config.lua matches uname output on device

Description:

LUAROCKS_UNAME_S/LUAROCKS_UNAME_M were being set automatically to host’s architecture and system/kernel name (e.g.. x86 and Darwin for the macOS)
The variables can now be supplied to configure via the supplied patch.
They are currently _S being hardcoded to “Linux” and _M set to the target architecture in the MakeFile.

Signed-off-by: David Thornley <david.thornley@touchstargroup.com>
