### PR TITLE
adblock: bugfix 2.0.1

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=2.0.0
+PKG_VERSION:=2.0.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -8,6 +8,7 @@ EXTRA_COMMANDS="suspend resume"
 EXTRA_HELP="	suspend	Suspend adblock processing
 	resume	Resume adblock processing"
 
+exec 2>/dev/null
 adb_script="/usr/bin/adblock.sh"
 adb_iface="$(uci -q get adblock.global.adb_iface)"
 
@@ -69,7 +70,6 @@ service_triggers()
     local iface
 
     procd_add_config_trigger "config.change" "adblock" /etc/init.d/adblock start
-
     if [ -z "${adb_iface}" ]
     then
         procd_add_raw_trigger "interface.*.up" 1000 /etc/init.d/adblock start


### PR DESCRIPTION
Maintainer: me
Compile tested: not relevant
Run tested: LEDE r2607

Description:
* fixed a dnsmasq restart issue (udhcpc error)
* fixed a long standing corner case bug in "disabled" state (does not remove active block lists!)
* simplified overall sort, removed needless 'for loop'
* cosmetics

Signed-off-by: Dirk Brenken <dev@brenken.org>
