### PR TITLE
ddns-scripts: get public_suffix_list.dat without using secure connection

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.6
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/tools/public_suffix_list.sh
+++ b/net/ddns-scripts/tools/public_suffix_list.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-URL="https://publicsuffix.org/list/public_suffix_list.dat"
+URL="http://publicsuffix.org/list/public_suffix_list.dat"
 TMPFILE=$(dirname $0)/public_suffix_list.tmp
 DATFILE=$(dirname $0)/public_suffix_list.dat
 


### PR DESCRIPTION
Maintainer: me

Description:

Get public_suffix_list.dat without using secure connection. #3678

File generated during build, because it's the only option to have an
actual version packaged.
Long term Cloudflare_v1 package will be changed to no longer need
public_suffix_list.dat

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>
