### PR TITLE
libcoap: fix PKG_BUILD_DIR

### DIFF
--- a/libs/libcoap/Makefile
+++ b/libs/libcoap/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libcoap
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/obgm/libcoap
@@ -19,6 +19,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.bz2
 PKG_MAINTAINER:=Anton Glukhov <anton.a.glukhov@gmail.com>
 PKG_LICENSE:=GPL-2.0+ BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING LICENSE.GPL LICENSE.BSD
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
Maintainer: @toxxin 
Compile tested: LEDE master
Run tested: no

Description:
libcoap is not building in LEDE any more because it is extracted to
/libcoap/ and the package makefiles try to access it at
/libcoap-2da31de732c0e51a9bc9e1d4aea21e25da89cf87/.

This patch defines a PKG_BUILD_DIR variable to make it use /libcoap/
without the hash.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>