### PR TITLE
icu: Bumped to v58.2

### DIFF
--- a/libs/icu/Makefile
+++ b/libs/icu/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2010 OpenWrt.org
+# Copyright (C) 2006-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,24 +8,23 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=icu4c
-PKG_VERSION:=55.1
+PKG_VERSION:=58.2
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-55_1-src.tgz
-PKG_SOURCE_URL:=http://download.icu-project.org/files/icu4c/55.1
-PKG_MD5SUM:=e2d523df79d6cb7855c2fbe284f4db29
+PKG_SOURCE:=$(PKG_NAME)-58_2-src.tgz
+PKG_SOURCE_URL:=http://download.icu-project.org/files/$(PKG_NAME)/$(PKG_VERSION)
+PKG_MD5SUM:=fac212b32b7ec7ab007a12dff1f3aea1
 
 PKG_LICENSE:=ICU-1.8.1+
-PKG_LICENSE_FILES:=license.html
+PKG_LICENSE_FILES:=LICENSE
 
-PKG_MAINTAINER:=Mirko Vogt <mirko@openwrt.org>
+PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_BUILD_DEPENDS:=icu/host
-
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
@@ -41,25 +40,39 @@ define Package/icu
   DEPENDS:=+libstdcpp +libpthread
 endef
 
-define Build/Configure
-	$(call Build/Configure/Default, \
-		--disable-debug \
-		--enable-release \
-		--enable-shared \
-		--enable-static \
-		--enable-draft \
-		--enable-renaming \
-		--disable-tracing \
-		--disable-extras \
-		--enable-dyload \
-		--enable-layout \
-		--enable-layoutex \
-		--disable-tools \
-		--disable-tests \
-		--disable-samples \
-		--with-cross-build="$(HOST_BUILD_DIR)" \
-	)
-endef
+CONFIGURE_CMD:= ./runConfigureICU
+CONFIGURE_VARS:=
+CONFIGURE_ARGS:= \
+	Linux/gcc \
+	--disable-debug \
+	--enable-release \
+	--enable-shared \
+	--enable-static \
+	--enable-draft \
+	--enable-renaming \
+	--disable-tracing \
+	--disable-extras \
+	--enable-dyload \
+	--disable-tools \
+	--disable-tests \
+	--disable-samples \
+	--with-cross-build="$(HOST_BUILD_DIR)" \
+	--prefix=/usr
+
+HOST_CONFIGURE_CMD:= ./runConfigureICU
+HOST_CONFIGURE_VARS:=
+HOST_CONFIGURE_ARGS:= \
+	Linux/gcc \
+	--disable-debug \
+	--enable-release \
+	--enable-shared \
+	--enable-static \
+	--enable-draft \
+	--enable-renaming \
+	--disable-tracing \
+	--disable-extras \
+	--enable-dyload \
+	--prefix=$(HOST_BUILD_PREFIX)
 
 define Build/InstallDev
 	$(INSTALL_DIR) \

--- a/libs/icu/patches/000-dont-cpy-files-from-topdirs.patch
+++ b/libs/icu/patches/000-dont-cpy-files-from-topdirs.patch
@@ -6,7 +6,7 @@ index 9db6c52..6aa2273 100644
  	$(INSTALL_SCRIPT) $(top_srcdir)/install-sh $(DESTDIR)$(pkgdatadir)/install-sh
  	@$(MKINSTALLDIRS) $(DESTDIR)$(libdir)/pkgconfig
  	$(INSTALL_DATA) $(ALL_PKGCONFIG_FILES) $(DESTDIR)$(libdir)/pkgconfig/
--	$(INSTALL_DATA) $(top_srcdir)/../license.html $(DESTDIR)$(pkgdatadir)/license.html
+-	$(INSTALL_DATA) $(top_srcdir)/../LICENSE $(DESTDIR)$(pkgdatadir)/LICENSE
  	$(INSTALL_SCRIPT) $(top_builddir)/config/icu-config $(DESTDIR)$(bindir)/icu-config
  	$(INSTALL_DATA) $(top_builddir)/config/Makefile.inc $(DESTDIR)$(pkglibdir)/Makefile.inc
  	$(INSTALL_DATA) $(top_builddir)/config/pkgdata.inc $(DESTDIR)$(pkglibdir)/pkgdata.inc

--- a/libs/icu/patches/001-disable-strtod_l.patch
+++ b/libs/icu/patches/001-disable-strtod_l.patch
@@ -1,0 +1,26 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -893,8 +893,8 @@
+ AC_CHECK_FUNC(strtod_l)
+ if test x$ac_cv_func_strtod_l = xyes
+ then
+-     CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1"
+-     U_HAVE_STRTOD_L=1
++     CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=0"
++     U_HAVE_STRTOD_L=0
+ else
+      CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=0"
+      U_HAVE_STRTOD_L=0
+--- a/configure
++++ b/configure
+@@ -7053,8 +7053,8 @@
+ 
+ if test x$ac_cv_func_strtod_l = xyes
+ then
+-     CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1"
+-     U_HAVE_STRTOD_L=1
++     CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=0"
++     U_HAVE_STRTOD_L=0
+ else
+      CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=0"
+      U_HAVE_STRTOD_L=0


### PR DESCRIPTION
Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>

Maintainer: @mirko
Compile tested: ar71xx mips_24kc_musl-1.1.15 LEDE r2610-324bdf3
Run tested: NONE

Description:
icu: Bumped to v58.2
 for emoji handling

previous PR https://github.com/openwrt/packages/pull/2817

add patches/001-disable-strtod_l.patch 
 missing xlocale.h in case of using musl.
