### PR TITLE
pptpd: Allow ppp or ppp-multilink as depencies

### DIFF
--- a/net/pptpd/Makefile
+++ b/net/pptpd/Makefile
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/pptpd
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+kmod-ppp +kmod-gre +kmod-mppe +ppp
+  DEPENDS:=@(PACKAGE_ppp||PACKAGE_ppp-multilink) +kmod-ppp +kmod-gre +kmod-mppe
   TITLE:=PopTop pptp server
   URL:=http://poptop.sourceforge.net/
   SUBMENU:=VPN


### PR DESCRIPTION
Maintainer: Luka Perkov <luka@openwrt.org>
Compile tested: latest LEDE-Trunk (git)
Run tested: on lantiq-xrx-200 (fb7360sl) and ar71xx (wndr3700V1)

Description:
When we select the package pptpd, the dependency pppd is selected. In this case it is unable to use (when we need) pppd-multilink. I submitted a git diff as patch which fixes the problem.

Signed-off-by: Guido Lipke <lipkegu@gmail.com>
