### PR TITLE
libcanfestival: define package build directory explicitly

### DIFF
--- a/libs/libcanfestival/Makefile
+++ b/libs/libcanfestival/Makefile
@@ -20,6 +20,8 @@ PKG_MAINTAINER:=Anton Glukhov <anton.a.glukhov@gmail.com>
 PKG_LICENSE:=LGPL-2.1+
 PKG_LICENSE_FILES:=LICENCE
 
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 


### PR DESCRIPTION
Maintainer: @toxxin
Compile tested: LEDE 6b524fe for mxs
Run tested: -

Description:

This should fix the build on LEDE buildbots which bail out with:

-snip-
...
! -d ./src/ ] || cp -fpR ./src/* /data/bowl-builder/arm_arm926ej-s/build/ (wrapped)
  sdk/build_dir/target-arm_arm926ej-s_musl-1.1.15_eabi/libcanfestival-8bfe0ac0

Applying ./patches/001-sigval-ref-fix.patch using plaintext:
can't find file to patch at input line 3
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|--- a/drivers/timers_unix/timers_unix.c
|+++ b/drivers/timers_unix/timers_unix.c
--------------------------
No file to patch.  Skipping patch.
1 out of 1 hunk ignored
Patch failed!  Please fix ./patches/001-sigval-ref-fix.patch!
...
-snap-

Reason is, that the tar ball created by hg checkout does not contain the
version string appended to the root source directory as expected by
default PKG_BUILD_DIR, so this patch adjusts the expected directory name.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
