### PR TITLE
aria2: update to 1.30.0

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
-PKG_VERSION:=1.28.0
+PKG_VERSION:=1.30.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/
-PKG_MD5SUM:=f649ab30f3b09d0c0ebb816ce0c0205d
+PKG_MD5SUM:=8c22f569d3fb9e42c5fd9a95173b9b5f
 PKG_INSTALL:=1
 
 PKG_MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>, Hsing-Wang Liao <kuoruan@gmail.com>


### PR DESCRIPTION
Maintainer: @kuoruan
Compile tested: mips, D-Link DIR-825 rev. C1, LEDE r2671
Run tested: mips, D-Link DIR-825 rev. C1, LEDE r2671

Description:
Issue with magnet links not starting is fixed: https://github.com/aria2/aria2/issues/793

Signed-off-by: Leong Hui Wong <wong.leonghui@gmail.com>