### PR TITLE
net/shadowsocks-libev: Update to 2.6.1

### DIFF
--- a/net/shadowsocks-libev/Makefile
+++ b/net/shadowsocks-libev/Makefile
@@ -8,15 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shadowsocks-libev
-PKG_VERSION:=2.2.3
+PKG_VERSION:=2.6.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/shadowsocks/shadowsocks-libev.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_RELEASE)
-PKG_SOURCE_VERSION:=2b1eef11973de3f7380401fd20f937e84bc2b756
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_SOURCE_VERSION:=a3bf80cf11e0a88589abdd87266b5351f270197c
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
 PKG_MAINTAINER:=Jian Chang <aa65535@live.com>
+PKG_MIRROR_MD5SUM:=fc60936d8b990fdecd69b908bc6b770b1c1e54598da6622cc9669750c76fa2d1
 
 PKG_LICENSE:=GPLv2
 PKG_LICENSE_FILES:=LICENSE
@@ -36,23 +37,26 @@ define Package/shadowsocks-libev/Default
 	TITLE:=Lightweight Secured Socks5 Proxy $(2)
 	URL:=https://github.com/shadowsocks/shadowsocks-libev
 	VARIANT:=$(1)
-	DEPENDS:=$(3) +libpthread +ipset +ip +iptables-mod-tproxy
+	DEPENDS:=$(3) +libpthread +ipset +ip +iptables-mod-tproxy +libpcre +zlib
 endef
 
+CONFIGURE_ARGS += \
+	--disable-documentation \
+
 Package/shadowsocks-libev = $(call Package/shadowsocks-libev/Default,openssl,(OpenSSL),+libopenssl)
-Package/shadowsocks-libev-polarssl = $(call Package/shadowsocks-libev/Default,polarssl,(PolarSSL),+libpolarssl)
+Package/shadowsocks-libev-mbedtls = $(call Package/shadowsocks-libev/Default,mbedtls,(mbed TLS),+libmbedtls)
 
 define Package/shadowsocks-libev/description
 Shadowsocks-libev is a lightweight secured socks5 proxy for embedded devices and low end boxes.
 endef
 
-Package/shadowsocks-libev-polarssl/description = $(Package/shadowsocks-libev/description)
+Package/shadowsocks-libev-mbedtls/description = $(Package/shadowsocks-libev/description)
 
 define Package/shadowsocks-libev/conffiles
 /etc/config/shadowsocks-libev
 endef
 
-Package/shadowsocks-libev-polarssl/conffiles = $(Package/shadowsocks-libev/conffiles)
+Package/shadowsocks-libev-mbedtls/conffiles = $(Package/shadowsocks-libev/conffiles)
 
 define Package/shadowsocks-libev/postinst
 #!/bin/sh
@@ -67,10 +71,10 @@ EOF
 exit 0
 endef
 
-Package/shadowsocks-libev-polarssl/postinst = $(Package/shadowsocks-libev/postinst)
+Package/shadowsocks-libev-mbedtls/postinst = $(Package/shadowsocks-libev/postinst)
 
-ifeq ($(BUILD_VARIANT),polarssl)
-	CONFIGURE_ARGS += --with-crypto-library=polarssl
+ifeq ($(BUILD_VARIANT),mbedtls)
+	CONFIGURE_ARGS += --with-crypto-library=mbedtls
 endif
 
 define Package/shadowsocks-libev/install
@@ -85,7 +89,7 @@ define Package/shadowsocks-libev/install
 	$(INSTALL_DATA) ./files/firewall.include $(1)/usr/share/shadowsocks-libev/firewall.include
 endef
 
-Package/shadowsocks-libev-polarssl/install = $(Package/shadowsocks-libev/install)
+Package/shadowsocks-libev-mbedtls/install = $(Package/shadowsocks-libev/install)
 
 $(eval $(call BuildPackage,shadowsocks-libev))
-$(eval $(call BuildPackage,shadowsocks-libev-polarssl))
+$(eval $(call BuildPackage,shadowsocks-libev-mbedtls))


### PR DESCRIPTION
Maintainer: @aa65535 
Compile tested: ar71xx, TP-Link TL-WDR3600, LEDE trunk
Run tested: N/A

Description:
Update to 2.6.1 to support mbed TLS
Use xz instead of gz git tarball

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>