### PR TITLE
net/cshark: New version layout, use mbed TLS and xz

### DIFF
--- a/net/cshark/Makefile
+++ b/net/cshark/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cshark
-PKG_VERSION:=2015-11-24
-PKG_RELEASE=$(PKG_SOURCE_VERSION)
+PKG_VERSION=2015-11-24-$(PKG_SOURCE_VERSION)
+PKG_RELEASE=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/cloudshark/cshark.git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_SUBDIR=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=e575ab3d35d75a6f70488001fcba45690ebe9b3e
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -28,7 +28,7 @@ define Package/cshark
   CATEGORY:=Network
   TITLE:=CloudShark capture tool
   URL:=http://www.cloudshark.org/
-  DEPENDS:=+libjson-c +libpcap +libuci +libubox +libuclient +libustream-polarssl
+  DEPENDS:=+libjson-c +libpcap +libuci +libubox +libuclient +libustream-mbedtls
   MAINTAINER:=Luka Perkov <luka@openwrt.org>
 endef
 


### PR DESCRIPTION
Maintainer: @lperkov 
Compile tested: ar71xx, TL-WDR3600, LEDE trunk
Run tested: N/A

Description:
Move git hash to PKG_VERSION instead of PKG_RELEASE
Use xz git tarball instead of gz
Add dependency to ustream-mbedtls as mbed TLS 1.3 is deprecated.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>