### PR TITLE
utils/xz: Update to 5.2.3 and update URLs

### DIFF
--- a/utils/xz/Makefile
+++ b/utils/xz/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2013-2015 OpenWrt.org
+# Copyright (C) 2017 Daniel Engberg <daniel.engberg.lists@pyret.net>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,13 +9,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xz
-PKG_VERSION:=5.2.2
+PKG_VERSION:=5.2.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=http://tukaani.org/xz \
-		http://fossies.org/linux/misc
-PKG_MD5SUM:=f90c9a0c8b259aee2234c4e0d7fd70af
+PKG_SOURCE_URL:=@SF/lzmautils \
+		http://tukaani.org/xz
+PKG_MD5SUM:=fd9ca16de1052aac899ad3495ad20dfa906c27b4a5070102a2ec35ca3a4740c1
 
 PKG_LICENSE:=Public-Domain LGPL-2.1+ GPL-2.0+ GPL-3.0+
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: Kirkwood, iomega iConnect, LEDE trunk
Run tested: Kirkwood, iomega iConnect, LEDE trunk

Description:
Update to 5.2.3 and sync URLs with LEDE

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>
