### PR TITLE
perl-cgi: disable comment stripping which damages module

### DIFF
--- a/lang/perl-cgi/Makefile
+++ b/lang/perl-cgi/Makefile
@@ -16,9 +16,13 @@ PKG_SOURCE:=CGI-$(PKG_VERSION).tar.gz
 PKG_MD5SUM:=15e63942c02354426b25f056f2a4467c
 
 PKG_LICENSE:=GPL Artistic-2.0
-PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>
+PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>, \
+		Philip Prindeville <philipp@redfish-solutions.com>
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/perl/CGI-$(PKG_VERSION)
+
+# don't strip comments because that will mangle this module
+PKG_LEAVE_COMMENTS:=1
 
 include $(INCLUDE_DIR)/package.mk
 include ../perl/perlmod.mk


### PR DESCRIPTION
Maintainer: @Naoir
Compile tested: (x86_64, generic, OpenWRT HEAD 187ad05)
Run tested:

Same as above.

Tried the "hello world" example in module documentation.  Ran as expected.

Description:

Bump to latest version on CPAN.  Note that while the module builds fine, the stripping in perlmod.mk is extremely detrimental as the last line of the sequence:

```
my $appease_cpants_kwalitee = q/
use strict;
use warnings;
#/;
```

gets deleted because the macro mistakenly things it's a comment.  It's obviously not.  Though I have to wonder what purpose the hash before the closing slash serves... it would appear to be superfluous.