### PR TITLE
perlmod: global knob to disable comment stripping modules

### DIFF
--- a/lang/perl/Config.in
+++ b/lang/perl/Config.in
@@ -17,4 +17,15 @@ config PERL_TESTS
 		Test support is still in development. Some tests will fail,
 		others are just missing completely.
 
+config PERL_NOCOMMENT
+	bool "Strip comments and pod sections from modules"
+	default y
+	help
+		Remove comments and pod sections for all perl packages.
+
+		This will descrease the size of perl libraries moderately.
+
+		Stripping occasionally gets confused and mangles valid code,
+		so disable this option if you're not pressed for space.
+
 endmenu

--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=5.22.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=ftp://ftp.cpan.org/pub/CPAN/src/5.0 \
 		http://www.cpan.org/src/5.0 \
@@ -24,7 +24,8 @@ PKG_MD5SUM:=19295bbb775a3c36123161b9bf4892f1
 
 PKG_LICENSE:=GPL-1.0+ Artistic-1.0-Perl
 PKG_LICENSE_FILES:=Copying Artistic README
-PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>
+PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>, \
+		Philip Prindeville <philipp@redfish-solutions.com>
 
 # Build settings
 PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_NAME)-$(PKG_VERSION)

--- a/lang/perl/perlmod.mk
+++ b/lang/perl/perlmod.mk
@@ -129,9 +129,7 @@ define perlmod/Install/NoStrip
 endef
 
 
-define perlmod/Install
-	$(call perlmod/Install/NoStrip,$(1),$(2),$(3))
-
+define perlmod/_DoStrip
 	@echo "---> Stripping modules in: $(strip $(1))$(PERL_SITELIB)"
 	find $(strip $(1))$(PERL_SITELIB) -name \*.pm -or -name \*.pl | \
 	xargs -r sed -i \
@@ -139,6 +137,12 @@ define perlmod/Install
 		-e '/^=\(head\|pod\|item\|over\|back\|encoding\|begin\|end\|for\)/,$$$$d' \
 		-e '/^#$$$$/d' \
 		-e '/^#[^!"'"'"']/d'
+endef
+
+define perlmod/Install
+	$(call perlmod/Install/NoStrip,$(1),$(2),$(3))
+
+	$(if $(CONFIG_PERL_NOCOMMENT),$(if $(PKG_LEAVE_COMMENTS),,$(call perlmod/_DoStrip,$(1),$(2),$(3))))
 endef
 
 # You probably don't want to use this directly. Look at perlmod/InstallTests


### PR DESCRIPTION
Maintainer: @Naoir
Compile tested: (x86_64, generic, OpenWRT HEAD 187ad05)
Run tested: same

Edited `.config` to include `CONFIG_PERL_NOCOMMENT=y` and built a sample module:

```
make -j1 package/perl-cgi/clean package/perl-cgi/install V=s
```

and confirmed that stripping occurred as before.  Then deleted the above line from my `.config` file and repeated the `make` as above.  This time the stripping occurred.

Description:

Certain strings are misinterpreted as comments by perlmod.mk and removed
when they shouldn't be (in particular, perl-cgi).  Enable this whenever
you have sufficient flash space.

The module `CGI-4.35` contains the following sequence is several files:

```
my $appease_cpants_kwalitee = q/
use strict;
use warnings;
#/;
```

with the disastrous result that the last line in the sequence above is erroneous deleted because of the last two expressions sent to `sed` here:

```
        @echo "---> Stripping modules in: $(strip $(1))$(PERL_SITELIB)"
        find $(strip $(1))$(PERL_SITELIB) -name \*.pm -or -name \*.pl | \
        xargs -r sed -i \
                -e '/^=\(head\|pod\|item\|over\|back\|encoding\|begin\|end\|for\)/,/^=cut/d' \
                -e '/^=\(head\|pod\|item\|over\|back\|encoding\|begin\|end\|for\)/,$$$$d' \
                -e '/^#$$$$/d' \
                -e '/^#[^!"'"'"']/d'
```

note that a line beginning with hash could occur in a multi-line string literal or in a here-document, etc. and there's no foolproof way to know (contextually) if you're inside a comment or not without more sophisticated syntax analysis than a simple regex can provide.