### PR TITLE
sqm-scripts: use https link

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 PKG_LICENSE:=GPLv2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_RELEASE).tar.xz
-PKG_SOURCE_URL:=git://github.com/tohojo/sqm-scripts.git
+PKG_SOURCE_URL:=https://github.com/tohojo/sqm-scripts.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_RELEASE)
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)-$(PKG_RELEASE)


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: n/a
Run tested: the https link works fine and I can download the sources

Description: change download link from git:// to https:// 
Git links are less safe (not encrypted) and, more importantly, they are blocked by company firewalls.
Https links do not have either issue.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>