### PR TITLE
python3: sync makefiles with python package

### DIFF
--- a/lang/python3/Makefile
+++ b/lang/python3/Makefile
@@ -25,6 +25,10 @@ PKG_HASH:=b0c5f904f685e32d9232f7bdcbece9819a892929063b6e385414ad2dd6a23622
 PKG_LICENSE:=PSF
 PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
 
+# This file provides the necsessary host build variables
+include ./files/python3-host.mk
+
+# For Py3Package
 include ./files/python3-package.mk
 
 PKG_INSTALL:=1
@@ -34,7 +38,7 @@ HOST_BUILD_PARALLEL:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/Python-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/Python-$(PKG_VERSION)
 
-PKG_BUILD_DEPENDS:=libbz2/host expat/host python3/host
+PKG_BUILD_DEPENDS:=python3/host
 HOST_BUILD_DEPENDS:=bzip2/host expat/host libffi/host
 
 include $(INCLUDE_DIR)/host-build.mk
@@ -84,8 +88,12 @@ endef
 PYTHON3_LIB_FILES_DEL:=
 PYTHON3_PACKAGES:=
 PYTHON3_SO_SUFFIX:=cpython-$(PYTHON3_VERSION_MAJOR)$(PYTHON3_VERSION_MINOR).so
+PYTHON3_PACKAGES_DEPENDS:=
 define Py3BasePackage
   PYTHON3_PACKAGES+=$(1)
+  ifeq ($(3),)
+    PYTHON3_PACKAGES_DEPENDS+=$(1)
+  endif
   PYTHON3_LIB_FILES_DEL+=$(2)
   define Py3Package/$(1)/filespec
     $(subst $(space),$(newline),$(foreach lib_file,$(2),+|$(lib_file)))
@@ -96,7 +104,7 @@ include ./files/python3-package-*.mk
 
 define Package/python3
 $(call Package/python3/Default)
-  DEPENDS:=+python3-light $(foreach package,$(filter-out python3-dev python3-lib2to3,$(PYTHON3_PACKAGES)),+$(package))
+  DEPENDS:=+python3-light $(foreach package,$(PYTHON3_PACKAGES_DEPENDS),+$(package))
 endef
 
 define Package/python3/description
@@ -154,6 +162,7 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON_VERSION)/
 	$(INSTALL_DATA) \
 		./files/python3-package.mk \
+		./files/python3-host.mk \
 		./files/python3-version.mk \
 		$(STAGING_DIR)/mk/
 	$(CP) \

--- a/lang/python3/files/python3-host.mk
+++ b/lang/python3/files/python3-host.mk
@@ -1,0 +1,96 @@
+#
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+ifneq ($(__python3_host_mk_inc),1)
+__python3_host_mk_inc=1
+
+# For PYTHON3_VERSION
+$(call include_mk, python3-version.mk)
+
+# Compatibility fallback for older OpenWrt and LEDE versions
+ifeq ($(STAGING_DIR_HOSTPKG),)
+  $(warning STAGING_DIR_HOSTPKG is unset - falling back to $$(STAGING_DIR)/host)
+  STAGING_DIR_HOSTPKG := $(STAGING_DIR)/host
+endif
+
+HOST_PYTHON3_DIR:=$(STAGING_DIR_HOSTPKG)
+HOST_PYTHON3_INC_DIR:=$(HOST_PYTHON3_DIR)/include/python$(PYTHON3_VERSION)
+HOST_PYTHON3_LIB_DIR:=$(HOST_PYTHON3_DIR)/lib/python$(PYTHON3_VERSION)
+
+HOST_PYTHON3_PKG_DIR:=$(HOST_PYTHON3_DIR)/lib/python$(PYTHON3_VERSION)/site-packages
+
+HOST_PYTHON3_BIN:=$(HOST_PYTHON3_DIR)/bin/python$(PYTHON3_VERSION)
+
+HOST_PYTHON3PATH:=$(HOST_PYTHON3_LIB_DIR):$(HOST_PYTHON3_PKG_DIR)
+
+define HostPython3
+	if [ "$(strip $(3))" == "HOST" ]; then \
+		export PYTHONPATH="$(HOST_PYTHON3PATH)"; \
+		export PYTHONDONTWRITEBYTECODE=0; \
+	else \
+		export PYTHONPATH="$(PYTHON3PATH)"; \
+		export PYTHONDONTWRITEBYTECODE=1; \
+		export _python_sysroot="$(STAGING_DIR)"; \
+		export _python_prefix="/usr"; \
+		export _python_exec_prefix="/usr"; \
+	fi; \
+	export PYTHONOPTIMIZE=""; \
+	$(1) \
+	$(HOST_PYTHON3_BIN) $(2);
+endef
+
+# $(1) => commands to execute before running pythons script
+# $(2) => python script and its arguments
+# $(3) => additional variables
+define Build/Compile/HostPy3RunHost
+	$(call HostPython3, \
+		$(if $(1),$(1);) \
+		CC="$(HOSTCC)" \
+		CCSHARED="$(HOSTCC) $(HOST_FPIC)" \
+		CXX="$(HOSTCXX)" \
+		LD="$(HOSTCC)" \
+		LDSHARED="$(HOSTCC) -shared" \
+		CFLAGS="$(HOST_CFLAGS)" \
+		CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON3_INC_DIR)" \
+		LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON3_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib" \
+		_PYTHON_HOST_PLATFORM=linux2 \
+		$(3) \
+		, \
+		$(2) \
+		, \
+		HOST \
+	)
+endef
+
+
+# $(1) => build subdir
+# $(2) => additional arguments to setup.py
+# $(3) => additional variables
+define Build/Compile/HostPy3Mod
+	$(call Build/Compile/HostPy3RunHost, \
+		cd $(HOST_BUILD_DIR)/$(strip $(1)), \
+		./setup.py $(2), \
+		$(3))
+endef
+
+define HostPy3/Compile/Default
+	$(call Build/Compile/HostPy3Mod,,\
+		install --root="$(HOST_BUILD_PREFIX)" --prefix="" \
+		--single-version-externally-managed \
+	)
+endef
+
+ifeq ($(BUILD_VARIANT),python3)
+define Host/Compile
+	$(call HostPy3/Compile/Default)
+endef
+
+define Host/Install
+endef
+endif # python3
+
+endif # __python3_host_mk_inc

--- a/lang/python3/files/python3-package-dev.mk
+++ b/lang/python3/files/python3-package-dev.mk
@@ -8,7 +8,7 @@
 define Package/python3-dev
 $(call Package/python3/Default)
   TITLE:=Python $(PYTHON3_VERSION) development files
-  DEPENDS:=+python3
+  DEPENDS:=+python3 +python3-lib2to3
 endef
 
 define Py3Package/python3-dev/install
@@ -22,4 +22,6 @@ $(eval $(call Py3BasePackage,python3-dev, \
     /usr/lib/python$(PYTHON_VERSION)/config-$(PYTHON_VERSION) \
     /usr/include/python$(PYTHON_VERSION) \
     /usr/lib/pkgconfig \
+	, \
+	DO_NOT_ADD_TO_PACKAGE_DEPENDS \
 ))

--- a/lang/python3/files/python3-package-lib2to3.mk
+++ b/lang/python3/files/python3-package-lib2to3.mk
@@ -13,4 +13,6 @@ endef
 
 $(eval $(call Py3BasePackage,python3-lib2to3, \
 	/usr/lib/python$(PYTHON3_VERSION)/lib2to3 \
+	, \
+	DO_NOT_ADD_TO_PACKAGE_DEPENDS \
 ))


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/lede-project/source/commit/c296ba834db4ce8c71e0ad7030aab188fe60b27b  x86_64
Run tested: https://github.com/lede-project/source/commit/c296ba834db4ce8c71e0ad7030aab188fe60b27b  x86_64  (minimal run)

Description:
Basically, did a diff with `python` makefiles : `Makefile`, `files/python-host.mk` & `files/python-package.mk`
Prepare to use VARIANT for python/python3 packages.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>