### PR TITLE
keepalived: fix recvmsg/sendmsg on mips64 again

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=1.2.19
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= http://www.keepalived.org/software

--- a/net/keepalived/patches/101-0001-vrrp-update-struct-msghdr.patch
+++ b/net/keepalived/patches/101-0001-vrrp-update-struct-msghdr.patch
@@ -1,0 +1,50 @@
+From dbb2cac9139954bd18813e88bfcb622ad3e93c54 Mon Sep 17 00:00:00 2001
+From: Stijn Tintel <stijn@linux-ipv6.be>
+Date: Tue, 10 May 2016 04:26:31 +0300
+Subject: [PATCH] vrrp: update struct msghdr
+
+The vrrp netlink code assumes an order for the members of struct msghdr.
+This breaks recvmsg and sendmsg with musl libc on mips64. Fix this by
+using designated initializers instead.
+
+Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>
+---
+ keepalived/vrrp/vrrp_netlink.c | 15 ++++++++++++---
+ 1 file changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/keepalived/vrrp/vrrp_netlink.c b/keepalived/vrrp/vrrp_netlink.c
+index b19e2e7..2c2fd59 100644
+--- a/keepalived/vrrp/vrrp_netlink.c
++++ b/keepalived/vrrp/vrrp_netlink.c
+@@ -416,8 +416,12 @@ netlink_parse_info(int (*filter) (struct sockaddr_nl *, struct nlmsghdr *),
+ 		char buf[4096];
+ 		struct iovec iov = { buf, sizeof buf };
+ 		struct sockaddr_nl snl;
+-		struct msghdr msg =
+-		    { (void *) &snl, sizeof snl, &iov, 1, NULL, 0, 0 };
++		struct msghdr msg = {
++			.msg_name = &snl,
++			.msg_namelen = sizeof(snl),
++			.msg_iov = &iov,
++			.msg_iovlen = 1,
++		};
+ 		struct nlmsghdr *h;
+ 
+ 		status = recvmsg(nl->fd, &msg, 0);
+@@ -538,7 +542,12 @@ netlink_talk(nl_handle_t *nl, struct nlmsghdr *n)
+ 	int ret, flags;
+ 	struct sockaddr_nl snl;
+ 	struct iovec iov = { (void *) n, n->nlmsg_len };
+-	struct msghdr msg = { (void *) &snl, sizeof snl, &iov, 1, NULL, 0, 0 };
++	struct msghdr msg = {
++		.msg_name = &snl,
++		.msg_namelen = sizeof(snl),
++		.msg_iov = &iov,
++		.msg_iovlen = 1,
++	};
+ 
+ 	memset(&snl, 0, sizeof snl);
+ 	snl.nl_family = AF_NETLINK;
+-- 
+2.10.2
+

--- a/net/keepalived/patches/101-0002-Reinstate-initialisation-of-msghdr-fields.patch
+++ b/net/keepalived/patches/101-0002-Reinstate-initialisation-of-msghdr-fields.patch
@@ -1,0 +1,41 @@
+From eaabcc1b09cccff2f8815d03da4d5778ab6bbd17 Mon Sep 17 00:00:00 2001
+From: Quentin Armitage <quentin@armitage.org.uk>
+Date: Mon, 16 May 2016 23:09:13 +0100
+Subject: [PATCH] Reinstate initialisation of msghdr fields
+
+Commit dbb2cac removed initialisation of the struct msghdr msg_control,
+msg_controllen and msg_flags fields. This commit reinstates initialisation
+of those fields.
+
+Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>
+---
+ keepalived/vrrp/vrrp_netlink.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/keepalived/vrrp/vrrp_netlink.c b/keepalived/vrrp/vrrp_netlink.c
+index 2c2fd59..62c37d6 100644
+--- a/keepalived/vrrp/vrrp_netlink.c
++++ b/keepalived/vrrp/vrrp_netlink.c
+@@ -421,6 +421,9 @@ netlink_parse_info(int (*filter) (struct sockaddr_nl *, struct nlmsghdr *),
+ 			.msg_namelen = sizeof(snl),
+ 			.msg_iov = &iov,
+ 			.msg_iovlen = 1,
++			.msg_control = NULL,
++			.msg_controllen = 0,
++			.msg_flags = 0
+ 		};
+ 		struct nlmsghdr *h;
+ 
+@@ -547,6 +550,9 @@ netlink_talk(nl_handle_t *nl, struct nlmsghdr *n)
+ 		.msg_namelen = sizeof(snl),
+ 		.msg_iov = &iov,
+ 		.msg_iovlen = 1,
++		.msg_control = NULL,
++		.msg_controllen = 0,
++		.msg_flags = 0
+ 	};
+ 
+ 	memset(&snl, 0, sizeof snl);
+-- 
+2.10.2
+


### PR DESCRIPTION
Maintainer: @commodo 

Commit e73964fa8fae94473e9046dfd8fd505206b50ab3 incorrectly dropped the
patch 101-update-struct-msghdr.patch. Add it again, and while add it
also add the follow-up patch that was added upstream.

Fixes #3757.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>