### PR TITLE
keepalived: use old keepalived.conf by default

### DIFF
--- a/net/keepalived/files/keepalived.config
+++ b/net/keepalived/files/keepalived.config
@@ -1,5 +1,5 @@
-#config global_defs
-#	option alt_config_file		"/etc/keepalived/keepalived.conf"
+config global_defs
+	option alt_config_file		"/etc/keepalived/keepalived.conf"
 #	list notification_email		"acassen@firewall.loc"
 #	list notification_email		"failover@firewall.loc"
 #	list notification_email		"sysadmin@firewall.loc"


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A
Run tested: N/A

Description:
Fixes https://github.com/openwrt/packages/issues/3756
Reported by @stintel

When merging, please merge before merging https://github.com/openwrt/packages/issues/3756
I did not increase the PKG_RELEASE on this PR.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>