### PR TITLE
boost: Package Version Update -> 1.63.0

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2016 OpenWrt.org
+# Copyright (C) 2015-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -16,15 +16,15 @@ include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/target.mk 
 
 PKG_NAME:=boost
-PKG_VERSION:=1.62.0
-PKG_SOURCE_VERSION:=1_62_0
-PKG_RELEASE:=6
+PKG_VERSION:=1.63.0
+PKG_SOURCE_VERSION:=1_63_0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceforge.net/projects/boost/files/boost/$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)_$(PKG_SOURCE_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)_$(PKG_SOURCE_VERSION)
-PKG_MD5SUM:=36c96b0f6155c98404091d8ceb48319a28279ca0333fba1ad8611eb90afb2ca0
+PKG_MD5SUM:=beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0
 PKG_LICENSE:=Boost Software License <http://www.boost.org/users/license.html>
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>
 
@@ -44,7 +44,7 @@ define Package/boost/Default
 endef
 
 define Package/boost/description
-This package provides the Boost v1.62 libraries.
+This package provides the Boost v1.63 libraries.
 Boost is a set of free, peer-reviewed, portable C++ source libraries.
 
 -----------------------------------------------------------------------------
@@ -68,7 +68,7 @@ This package provides the following run-time libraries:
  - date_time
  - exception
  - filesystem
- - fiber (Requires GCC v5 and up) - BROKEN
+ - fiber (Requires GCC v5 and up)
  - graph
  - - graph-parallel
  - iostreams
@@ -88,7 +88,7 @@ This package provides the following run-time libraries:
  - wave
 
 There are many more header-only libraries supported by Boost.
-See more at http://www.boost.org/doc/libs/1_62_0/
+See more at http://www.boost.org/doc/libs/1_63_0/
 endef
 
 PKG_BUILD_DEPENDS:=boost/host PACKAGE_python:python PACKAGE_python3:python3

--- a/libs/boost/patches/01_fiber_fix.patch
+++ b/libs/boost/patches/01_fiber_fix.patch
@@ -1,8 +1,8 @@
-Index: boost_1_62_0/libs/fiber/build/Jamfile.v2
+Index: boost_1_63_0/libs/fiber/build/Jamfile.v2
 ===================================================================
---- boost_1_62_0.orig/libs/fiber/build/Jamfile.v2
-+++ boost_1_62_0/libs/fiber/build/Jamfile.v2
-@@ -43,19 +43,6 @@ lib boost_fiber
+--- boost_1_63_0.orig/libs/fiber/build/Jamfile.v2
++++ boost_1_63_0/libs/fiber/build/Jamfile.v2
+@@ -44,20 +44,6 @@ lib boost_fiber
        recursive_timed_mutex.cpp
        timed_mutex.cpp
        scheduler.cpp
@@ -11,6 +11,7 @@ Index: boost_1_62_0/libs/fiber/build/Jamfile.v2
 -               cxx11_constexpr
 -               cxx11_defaulted_functions
 -               cxx11_final
+-               cxx11_hdr_mutex
 -               cxx11_hdr_tuple
 -               cxx11_lambdas
 -               cxx11_noexcept


### PR DESCRIPTION
Maintainer: @ClaymorePT
Compile tested: Broadcom BCM2708
Run tested: None

Description:

This package update contains no new libraries.
Information about the 1.63.0 release (updated libraries, bug fixes, etc), can be found here [1].

[1]: http://www.boost.org/users/history/version_1_63_0.html

Signed-off-by: Carlos Ferreira <carlosmf.pt@gmail.com>