### PR TITLE
multimedia/ices: Fix linking with libogg

### DIFF
--- a/multimedia/ices/Makefile
+++ b/multimedia/ices/Makefile
@@ -42,6 +42,7 @@ endef
 CONFIGURE_ARGS+= \
 	--with-ogg="$(STAGING_DIR)/usr/include" \
 	--with-vorbis="$(STAGING_DIR)/usr/include" \
+	LIBS="-logg"
 
 define Package/ices/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: Kirkwood, iomega iConnect, LEDE trunk
Run tested: N/A

Description:
Fixes linking with libogg

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>