### PR TITLE
utils/haveged: Add SF as primary download site

### DIFF
--- a/utils/haveged/Makefile
+++ b/utils/haveged/Makefile
@@ -12,8 +12,8 @@ PKG_VERSION:=1.9.1
 PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.issihosts.com/$(PKG_NAME) \
-	http://pkgs.fedoraproject.org/repo/pkgs/haveged/haveged-1.9.1.tar.gz/015ff58cd10607db0e0de60aeca2f5f8/
+PKG_SOURCE_URL:=@SF/haveged \
+		http://www.issihosts.com/$(PKG_NAME)
 PKG_MD5SUM:=9c2363ed9542a6784ff08e247182137e71f2ddb79e8e6c1ac4ad50d21ced3715
 PKG_LICENSE:=GPLv3
 


### PR DESCRIPTION
Maintainer: @hnyman 
Compile tested: Kirkwood, iomega iConnect, LEDE trunk
Run tested: N/A

Description:
Add Sourceforge as primary download site and main site as secondary.
Drop fedoraproject.org repo

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>