### PR TITLE
python: don't use libressl for host build

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -12,7 +12,7 @@ include ./files/python-version.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)

--- a/lang/python/patches/012-disable-openssl-for-hashlib-on-host-build.patch
+++ b/lang/python/patches/012-disable-openssl-for-hashlib-on-host-build.patch
@@ -1,0 +1,11 @@
+--- a/setup.py
++++ b/setup.py
+@@ -859,7 +859,7 @@ class PyBuildExt(build_ext):
+ 
+         min_openssl_ver = 0x00907000
+         have_any_openssl = ssl_incs is not None and ssl_libs is not None
+-        have_usable_openssl = (have_any_openssl and
++        have_usable_openssl = cross_compiling and (have_any_openssl and
+                                openssl_ver >= min_openssl_ver)
+ 
+         if have_any_openssl:


### PR DESCRIPTION
Maintainer: me / @<github-user>
Compile tested: https://github.com/lede-project/source/commit/d8dde8c5178eba8c847dd48e7d06e6663ba1979f  omap (arm_cortex-a9_vfpv3)
Run tested: N/A

-------------------------------

Fixes: https://github.com/openwrt/packages/issues/3767

Since commit:
https://github.com/lede-project/source/commit/f6e6341d896adb78f9b496f71aab8f45e1742d5a

libressl is built on the host-side.

Python picks it up [ via the openssl/* headers ] and assumes
it has SSL libs.
Compiling works fine, linking fails.
Doesn't look like it's because:
https://github.com/lede-project/source/commit/2fd5ce9488d11c7e6eee7dc30f128bd12be889f5

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>