### PR TITLE
net-snmp: build against libnl-tiny

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,13 +9,15 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.7.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp
 PKG_MD5SUM:=d4a3459e1577d0efa8d96ca70a885e53
 PKG_MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
 PKG_LICENSE:=MIT BSD-3-Clause-Clear
+
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -38,7 +40,7 @@ define Package/libnetsnmp
 $(call Package/net-snmp/Default)
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+PACKAGE_libnl-core:libnl-core
+  DEPENDS:=+libnl-tiny
   TITLE:=Open source SNMP implementation (libraries)
 endef
 
@@ -163,6 +165,7 @@ SNMP_TRANSPORTS_INCLUDED = Callback UDP Unix
 SNMP_TRANSPORTS_EXCLUDED = TCP TCPIPv6
 
 TARGET_CFLAGS += $(FPIC)
+TARGET_CPPFLAGS += -I$(STAGING_DIR)/usr/include/libnl-tiny
 
 CONFIGURE_ARGS += \
 	--enable-mfd-rewrites \
@@ -186,7 +189,12 @@ CONFIGURE_ARGS += \
 	--without-libwrap \
 	--without-rpm \
 	--without-zlib \
+	--with-nl \
 	 $(call autoconf_bool,CONFIG_IPV6,ipv6) \
+
+CONFIGURE_VARS += \
+	ac_cv_header_netlink_netlink_h=yes \
+	netsnmp_cv_func_nl_connect_LIBS=-lnl-tiny \
 
 ifeq ($(CONFIG_IPV6),y)
 SNMP_TRANSPORTS_INCLUDED+= UDPIPv6

--- a/net/net-snmp/patches/000-cross-compile.patch
+++ b/net/net-snmp/patches/000-cross-compile.patch
@@ -1,0 +1,47 @@
+From: Jo-Philipp Wich <jo@mein.io>
+Date: Fri, 6 Jan 2017 13:41:00 +0100
+Subject: [PATCH] configure: allow overriding hardcoded /usr/include/libnl3
+
+In a cross-compile setting we do not want to probe the host systems
+/usr/include path, therfore allow to disable this include path by passing
+ac_cv_header_netlink_netlink_h=yes to configure.
+
+Also disable the testing for libraries providing nl_connect when
+netsnmp_cv_func_nl_connect_LIBS is predefined since the proprietary
+NETSNMP_SEARCH_LIBS() macro will clobber the internal link flags upon
+encountering predefined cache variables, causing all subsequent configure
+link tests to fail due to a stray "no" word getting passed to the linker.
+
+Signed-off-by: Jo-Philipp Wich <jo@mein.io>
+--- a/configure.d/config_os_libs2
++++ b/configure.d/config_os_libs2
+@@ -226,14 +226,22 @@ if test "x$with_nl" != "xno"; then
+     case $target_os in
+     linux*) # Check for libnl (linux)
+         netsnmp_save_CPPFLAGS="$CPPFLAGS"
+-        CPPFLAGS="-I/usr/include/libnl3 $CPPFLAGS"
+-        NETSNMP_SEARCH_LIBS(nl_connect, nl-3,
+-            [AC_CHECK_HEADERS(netlink/netlink.h)
+-            EXTERNAL_MIBGROUP_INCLUDES="$EXTERNAL_MIBGROUP_INCLUDES -I/usr/include/libnl3"],
+-            [CPPFLAGS="$netsnmp_save_CPPFLAGS"], [], [], [LMIBLIBS])
++        netsnmp_netlink_include_flags=""
+         if test "x$ac_cv_header_netlink_netlink_h" != xyes; then
+-            NETSNMP_SEARCH_LIBS(nl_connect, nl, [
+-                AC_CHECK_HEADERS(netlink/netlink.h)], [], [], LMIBLIBS)
++            netsnmp_netlink_include_flags="-I/usr/include/libnl3"
++        fi
++        CPPFLAGS="$netsnmp_netlink_include_flags $CPPFLAGS"
++        if test "x$netsnmp_cv_func_nl_connect_LIBS" = x; then
++            NETSNMP_SEARCH_LIBS(nl_connect, nl-3,
++                [AC_CHECK_HEADERS(netlink/netlink.h)
++                EXTERNAL_MIBGROUP_INCLUDES="$EXTERNAL_MIBGROUP_INCLUDES $netsnmp_netlink_include_flags"],
++                [CPPFLAGS="$netsnmp_save_CPPFLAGS"], [], [], [LMIBLIBS])
++            if test "x$ac_cv_header_netlink_netlink_h" != xyes; then
++                NETSNMP_SEARCH_LIBS(nl_connect, nl, [
++                    AC_CHECK_HEADERS(netlink/netlink.h)], [], [], LMIBLIBS)
++            fi
++        else
++            LMIBLIBS="$LMIBLIBS $netsnmp_cv_func_nl_connect_LIBS"
+         fi
+         if test "x$ac_cv_header_netlink_netlink_h" = xyes; then
+             AC_EGREP_HEADER([nl_socket_free], [netlink/socket.h],


### PR DESCRIPTION
Maintainer: @stintel (cc @dedeckeh )
Compile tested: LEDE r2795-bad0442
Run tested: -

Description:

Instead of causing nondeterministing conditional compilation depending on
whether libnl-core happens to be present or not, fixup the net-snmp package
to link against libnl-tiny which is present by default on the majority of
systems.

In order to successfully build against libnl-tiny, a number of things had
to be fixed in both the upstream configure and the outer Makefile:

- Add a patch which fixes the upstream configure macros to properly handle
  cases where the cache variables for nl_connect() and netlink.h tests are
  predefined. Without this patch, all subsequent link tests in configure
  will fail, causing the build system to assume functions like opendir() or
  readdir() to be missing, leading to build failures later on due to
  conflicting redefinitions of structures and function prototypes

- In the same patch, stop probing the host systems /usr/include/libnl-3 if
  ac_cv_header_netlink_netlink_h is given. This brings the proprietary
  configure bits in line with the behaviour expected from autoconfig in a
  cross compile setting

- Explicitely request nl support by passing the --with-nl flag to configure

- Pass the required cache variables to skip the broken tests for
  nl_connect() and netlink.h

- Amend TARGET_CPPFLAGS to let net-snmp's build system discover nl-tiny's
  netlink/netlink.h and netlink/socket.h

- Enable the autoreconf fixup to regenerate the broken shipped configure
  from patched macros

- Adjust the depends to unconditionally require libnl-tiny