### PR TITLE
lang/python3-bottle: Update to 0.12.12

### DIFF
--- a/lang/python3-bottle/Makefile
+++ b/lang/python3-bottle/Makefile
@@ -8,16 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-bottle
-PKG_VERSION:=0.12.8
+PKG_VERSION:=0.12.12
 PKG_RELEASE:=1
 
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>
 
-PKG_SOURCE:=$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/bottlepy/bottle/archive
-PKG_MD5SUM:=50a6ebada59391e8d01b2bd2ec52f05b
+PKG_SOURCE:=bottle-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/f7/dd/8ceaa148eeed5371a83fa1fb5a54b01dfc95000799c649924ece23f9f0e1/
+PKG_MD5SUM:=3d4b6b0e22f67b421c273105b30d9a21fd147eaf0c1576172378ee034fbf5313
 PKG_BUILD_DIR:=$(BUILD_DIR)/bottle-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python3-package.mk)


### PR DESCRIPTION
Maintainer: @lperkov @zvonimirfras 
Compile tested: Kirkwood, iomega iConnect, LEDE trunk
Run tested: N/A

Description:
Update to 0.12.12
Switch to pypi repo which also fixes file name on tarball

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>
