### PR TITLE
libs/libstrophe: Fix source tarball filename

### DIFF
--- a/libs/libstrophe/Makefile
+++ b/libs/libstrophe/Makefile
@@ -15,9 +15,12 @@ PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Chih-Wei Chen <changeway@gmail.com>
 
-PKG_SOURCE_URL:=https://github.com/strophe/libstrophe/archive/
-PKG_SOURCE:=$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=2db62ab21187785ec5f870adc33b74e5
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/strophe/libstrophe
+PKG_SOURCE_SUBDIR=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=9931ad4fa2aa7f204c608010eb2ebf84bcf7d542
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_MIRROR_MD5SUM:=6a499bcfc7c52db6765957ff38f48a344ad121ac0b665fd3d4adb7d8deadc427
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
Maintainer: @changeway 
Compile tested: Kirkwood, iomega iConnect, LEDE
Run tested: N/A

Description:
Switch to git repo to properly set tarball filename

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>
