### PR TITLE
transmission: conversion polarssl to mbedtls

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -8,12 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
-PKG_VERSION:=2.92
-PKG_RELEASE:=3
+PKG_VERSION:=2.92+git
+PKG_RELEASE:=4
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/transmission/transmission-releases/raw/master
-PKG_MD5SUM:=3fce404a436e3cd7fde80fb6ed61c264
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/transmission/transmission.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=35fea28d1a37875ef7480ac061754df617805b19
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -45,11 +47,11 @@ define Package/transmission-daemon-openssl
   VARIANT:=openssl
 endef
 
-define Package/transmission-daemon-polarssl
+define Package/transmission-daemon-mbedtls
   $(call Package/transmission-daemon/Default)
-  TITLE+= (with PolarSSL)
-  DEPENDS+=+libpolarssl
-  VARIANT:=polarssl
+  TITLE+= (with mbed TLS)
+  DEPENDS+=+libmbedtls
+  VARIANT:=mbedtls
 endef
 
 define Package/transmission-cli/Default
@@ -64,11 +66,11 @@ define Package/transmission-cli-openssl
   VARIANT:=openssl
 endef
 
-define Package/transmission-cli-polarssl
+define Package/transmission-cli-mbedtls
   $(call Package/transmission-cli/Default)
-  TITLE+= (with PolarSSL)
-  DEPENDS+=+libpolarssl
-  VARIANT:=polarssl
+  TITLE+= (with mbed TLS)
+  DEPENDS+=+libmbedtls
+  VARIANT:=mbedtls
 endef
 
 define Package/transmission-remote/Default
@@ -83,17 +85,17 @@ define Package/transmission-remote-openssl
   VARIANT:=openssl
 endef
 
-define Package/transmission-remote-polarssl
+define Package/transmission-remote-mbedtls
   $(call Package/transmission-remote/Default)
-  TITLE+= (with PolarSSL)
-  DEPENDS+=+libpolarssl
-  VARIANT:=polarssl
+  TITLE+= (with mbed TLS)
+  DEPENDS+=+libmbedtls
+  VARIANT:=mbedtls
 endef
 
 define Package/transmission-web
   $(call Package/transmission/template)
   TITLE+= (webinterface)
-  DEPENDS:=@(PACKAGE_transmission-daemon-openssl||PACKAGE_transmission-daemon-polarssl)
+  DEPENDS:=@(PACKAGE_transmission-daemon-openssl||PACKAGE_transmission-daemon-mbedtls)
 endef
 
 
@@ -104,19 +106,19 @@ define Package/transmission-daemon/Default/description
  This package contains the daemon itself.
 endef
 Package/transmission-daemon-openssl/description = $(Package/transmission-daemon/Default/description)
-Package/transmission-daemon-polarssl/description = $(Package/transmission-daemon/Default/description)
+Package/transmission-daemon-mbedtls/description = $(Package/transmission-daemon/Default/description)
 
 define Package/transmission-cli/Default/description
  CLI utilities for transmission.
 endef
 Package/transmission-cli-openssl/description = $(Package/transmission-cli/Default/description)
-Package/transmission-cli-polarssl/description = $(Package/transmission-cli/Default/description)
+Package/transmission-cli-mbedtls/description = $(Package/transmission-cli/Default/description)
 
 define Package/transmission-remote/Default/description
  CLI remote interface for transmission.
 endef
 Package/transmission-remote-openssl/description = $(Package/transmission-remote/Default/description)
-Package/transmission-remote-polarssl/description = $(Package/transmission-remote/Default/description)
+Package/transmission-remote-mbedtls/description = $(Package/transmission-remote/Default/description)
 
 define Package/transmission-web/description
  Webinterface resources for transmission.
@@ -125,7 +127,7 @@ endef
 define Package/transmission-daemon-openssl/conffiles
 /etc/config/transmission
 endef
-Package/transmission-daemon-polarssl/conffiles = $(Package/transmission-daemon-openssl/conffiles)
+Package/transmission-daemon-mbedtls/conffiles = $(Package/transmission-daemon-openssl/conffiles)
 
 
 CONFIGURE_VARS += \
@@ -143,15 +145,23 @@ ifeq ($(BUILD_VARIANT),openssl)
 	--with-crypto=openssl
 endif
 
-ifeq ($(BUILD_VARIANT),polarssl)
+ifeq ($(BUILD_VARIANT),mbedtls)
   CONFIGURE_ARGS += \
 	--with-crypto=polarssl
+  CONFIGURE_VARS += \
+	MBEDTLS_CFLAGS="-I$(STAGING_DIR)/usr/include/mbedtls" \
+	MBEDTLS_LIBS="-lmbedtls -lmbedcrypto"
 endif
 
 MAKE_FLAGS += \
 	CFLAGS="$(TARGET_CFLAGS) -D_GNU_SOURCE"
 
 TARGET_CFLAGS += -std=gnu99
+
+define Build/Configure
+	( cd $(PKG_BUILD_DIR); ./autogen.sh $(CONFIGURE_ARGS))
+	$(call Build/Configure/Default,$CONFIGURE_ARGS)
+endef
 
 define Package/transmission-daemon-openssl/install
 	$(INSTALL_DIR) $(1)/usr/bin
@@ -161,7 +171,7 @@ define Package/transmission-daemon-openssl/install
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) files/transmission.config $(1)/etc/config/transmission
 endef
-Package/transmission-daemon-polarssl/install = $(Package/transmission-daemon-openssl/install)
+Package/transmission-daemon-mbedtls/install = $(Package/transmission-daemon-openssl/install)
 
 define Package/transmission-cli-openssl/install
 	$(INSTALL_DIR) $(1)/usr/bin
@@ -171,13 +181,13 @@ define Package/transmission-cli-openssl/install
 			$(PKG_INSTALL_DIR)/usr/bin/transmission-show \
 			$(1)/usr/bin/
 endef
-Package/transmission-cli-polarssl/install = $(Package/transmission-cli-openssl/install)
+Package/transmission-cli-mbedtls/install = $(Package/transmission-cli-openssl/install)
 
 define Package/transmission-remote-openssl/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/transmission-remote $(1)/usr/bin/
 endef
-Package/transmission-remote-polarssl/install = $(Package/transmission-remote-openssl/install)
+Package/transmission-remote-mbedtls/install = $(Package/transmission-remote-openssl/install)
 
 define Package/transmission-web/install
 	$(INSTALL_DIR) $(1)/usr/share/transmission
@@ -185,9 +195,9 @@ define Package/transmission-web/install
 endef
 
 $(eval $(call BuildPackage,transmission-daemon-openssl))
-$(eval $(call BuildPackage,transmission-daemon-polarssl))
+$(eval $(call BuildPackage,transmission-daemon-mbedtls))
 $(eval $(call BuildPackage,transmission-cli-openssl))
-$(eval $(call BuildPackage,transmission-cli-polarssl))
+$(eval $(call BuildPackage,transmission-cli-mbedtls))
 $(eval $(call BuildPackage,transmission-remote-openssl))
-$(eval $(call BuildPackage,transmission-remote-polarssl))
+$(eval $(call BuildPackage,transmission-remote-mbedtls))
 $(eval $(call BuildPackage,transmission-web))

--- a/net/transmission/patches/040-fix-for-mbedtls.patch
+++ b/net/transmission/patches/040-fix-for-mbedtls.patch
@@ -1,0 +1,31 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -153,25 +153,9 @@
+ ])
+ AS_IF([test "x$want_crypto" = "xauto" -o "x$want_crypto" = "xpolarssl"], [
+     PKG_CHECK_MODULES(MBEDTLS, [mbedtls >= $POLARSSL_MINIMUM],
+-        [want_crypto="polarssl"; CRYPTO_PKG="polarssl"; CRYPTO_CFLAGS="$MBEDTLS_CFLAGS"; CRYPTO_LIBS="$MBEDTLS_LIBS"; POLARSSL_IS_MBEDTLS=yes],
+-        [AC_CHECK_HEADER([polarssl/version.h],
+-            [AC_EGREP_CPP([version_ok], [#include <polarssl/version.h>
+-                                         #if defined (POLARSSL_VERSION_NUMBER) && POLARSSL_VERSION_NUMBER >= $POLARSSL_MINIMUM
+-                                         version_ok
+-                                         #endif],
+-                [AC_CHECK_LIB([polarssl], [dhm_calc_secret],
+-                    [want_crypto="polarssl"; CRYPTO_PKG="polarssl"; CRYPTO_CFLAGS=""; CRYPTO_LIBS="-lpolarssl"],
+-                    [AS_IF([test "x$want_crypto" = "xpolarssl"],
+-                        [AC_MSG_ERROR([PolarSSL support requested, but library not found.])]
+-                    )]
+-                )],
+-                [AS_IF([test "x$want_crypto" = "xpolarssl"],
+-                    [AC_MSG_ERROR([PolarSSL support requested, but version not suitable.])]
+-                )]
+-            )],
+-            [AS_IF([test "x$want_crypto" = "xpolarssl"],
+-                [AC_MSG_ERROR([PolarSSL support requested, but headers not found.])]
+-            )]
++        [want_crypto="polarssl"; CRYPTO_PKG="polarssl"; CRYPTO_CFLAGS="$MBEDTLS_CFLAGS"; CRYPTO_LIBS="$MBEDTLS_LIBS"; POLARSSL_IS_MBEDTLS=yes],
++        [AS_IF([test "x$want_crypto" = "xpolarssl"],
++            [AC_MSG_ERROR([PolarSSL support requested, but library not found.])]
+         )]
+     )
+ ])


### PR DESCRIPTION
Maintainer: me / @obsy
Compile tested: x86, LEDE
Run tested: x86/geode, LEDE

Description:
- up to current git version: 35fea28d1a37875ef7480ac061754df617805b19
- replace polarssl via mbedtls

Closes https://github.com/openwrt/packages/issues/3731

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>
