### PR TITLE
syslog-ng: fix various install problems such as missing plugins, etc

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include  $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.8.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -18,7 +18,7 @@ include $(INCLUDE_DIR)/nls.mk
 define Package/syslog-ng
   SECTION:=admin
   CATEGORY:=Administration
-  DEPENDS:=+libpcre +glib2 +libeventlog +libopenssl +libuuid
+  DEPENDS:=+libpcre +glib2 +libeventlog +libopenssl +libuuid +libcurl
   TITLE:=A powerful syslog daemon
   URL:=http://www.balabit.com/network-security/syslog-ng/opensource-logging-system/
 endef
@@ -41,10 +41,13 @@ endef
 CONFIGURE_ARGS += \
   $(call autoconf_bool,CONFIG_IPV6,ipv6) \
          --disable-dependency-tracking \
+         --disable-ampq \
          --disable-tcp-wrapper \
          --disable-glibtest \
          --disable-mongodb \
          --disable-java \
+         --disable-json \
+         --disable-python \
          --disable-spoof-source \
          --disable-sql \
          --disable-linux-caps \
@@ -58,13 +61,14 @@ CONFIGURE_VARS += \
 
 define Package/syslog-ng/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsyslog-ng-3.8.so* $(1)/usr/lib/
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/syslog-ng $(1)/usr/sbin/
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		install-sbinPROGRAMS install-libLTLIBRARIES \
+		install-moduleLTLIBRARIES DESTDIR="$(1)"
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/syslog-ng.init $(1)/etc/init.d/syslog-ng
 	$(INSTALL_DIR) $(1)/etc
 	$(INSTALL_DATA) ./files/syslog-ng.conf $(1)/etc
+	$(call libtool_remove_files,$(1))
 endef
 
 $(eval $(call BuildPackage,syslog-ng))

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version:3.0
+@version:3.8
 
 options {
 	chain_hostnames(no);

--- a/admin/syslog-ng/files/syslog-ng.init
+++ b/admin/syslog-ng/files/syslog-ng.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2006-2016 OpenWrt.org
 
-START=50
+START=20
 
 SERVICE_USE_PID=1
 


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, generic, OpenWRT head
Run tested: same

Built into image and booted that image.  Now I don't see:

```
Error parsing source, source plugin unix-stream not found in /etc/syslog-ng.conf
 at line 17, column 2:
 
        unix-stream("/dev/log");
        ^^^^^^^^^^^
 
syslog-ng documentation: http://www.balabit.com/support/documentation/?product=s
yslog-ng
mailing list: https://lists.balabit.hu/mailman/listinfo/syslog-ng
```

Description:

Install the plugins as various functionality is no longer in the
utility itself but is packaged as a .so plugin instead. Disable
plugins with too many dependencies (or too exotic).

Bump the version number on the config file to agree with the package's
version number.

Clean up any .la files from libtool.

Start much earlier so that logging doesn't miss startup messages from
other services.