### PR TITLE
net/zerotier: fix broken dependency detection

### DIFF
--- a/net/zerotier/patches/0002-fix-build.patch
+++ b/net/zerotier/patches/0002-fix-build.patch
@@ -7,30 +7,45 @@ Subject: [PATCH 2/2] fix build
  make-linux.mk | 30 +++++++++++++++---------------
  1 file changed, 15 insertions(+), 15 deletions(-)
 
-Index: ZeroTierOne-1.1.14/make-linux.mk
-===================================================================
---- ZeroTierOne-1.1.14.orig/make-linux.mk
-+++ ZeroTierOne-1.1.14/make-linux.mk
-@@ -39,19 +39,19 @@ include objects.mk
+--- a/make-linux.mk
++++ b/make-linux.mk
+@@ -39,24 +39,24 @@ include objects.mk
  
  # On Linux we auto-detect the presence of some libraries and if present we
  # link against the system version. This works with our package build images.
 -ifeq ($(wildcard /usr/include/lz4.h),)
-+ifeq ($(wildcard $(STAGING_DIR)/usr/include/lz4.h),)
++#ifeq ($(wildcard $(STAGING_DIR)/usr/include/lz4.h),)
  	OBJS+=ext/lz4/lz4.o
- else
- 	LDLIBS+=-llz4
- 	DEFS+=-DZT_USE_SYSTEM_LZ4
- endif
+-else
+-	LDLIBS+=-llz4
+-	DEFS+=-DZT_USE_SYSTEM_LZ4
+-endif
 -ifeq ($(wildcard /usr/include/http_parser.h),)
-+ifeq ($(wildcard $(STAGING_DIR)/usr/include/http_parser.h),)
++#else
++#	LDLIBS+=-llz4
++#	DEFS+=-DZT_USE_SYSTEM_LZ4
++#endif
++#ifeq ($(wildcard $(STAGING_DIR)/usr/include/http_parser.h),)
  	OBJS+=ext/http-parser/http_parser.o
- else
- 	LDLIBS+=-lhttp_parser
- 	DEFS+=-DZT_USE_SYSTEM_HTTP_PARSER
- endif
+-else
+-	LDLIBS+=-lhttp_parser
+-	DEFS+=-DZT_USE_SYSTEM_HTTP_PARSER
+-endif
 -ifeq ($(wildcard /usr/include/json-parser/json.h),)
-+ifeq ($(wildcard $(STAGING_DIR)/usr/include/json-parser/json.h),)
++#else
++#	LDLIBS+=-lhttp_parser
++#	DEFS+=-DZT_USE_SYSTEM_HTTP_PARSER
++#endif
++#ifeq ($(wildcard $(STAGING_DIR)/usr/include/json-parser/json.h),)
  	OBJS+=ext/json-parser/json.o
- else
- 	LDLIBS+=-ljsonparser
+-else
+-	LDLIBS+=-ljsonparser
+-	DEFS+=-DZT_USE_SYSTEM_JSON_PARSER
+-endif
++#else
++#	LDLIBS+=-ljsonparser
++#	DEFS+=-DZT_USE_SYSTEM_JSON_PARSER
++#endif
+ 
+ ifeq ($(ZT_USE_MINIUPNPC),1)
+ 	OBJS+=osdep/PortMapper.o


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, wr703, LEDE head
Run tested: no

Description:
Fix undefined references to liblz4 etc.
Dependency detection in the zerotier makefile was broken.
Now it is disabled and uses the implementations that are part of the zerotier source bundle.