### PR TITLE
travelmate: bugfix 0.3.1

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -1,12 +1,12 @@
 #
-# Copyright (c) 2016 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2016-2017 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 #
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=0.3.0
+PKG_VERSION:=0.3.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/README.md
+++ b/net/travelmate/files/README.md
@@ -7,7 +7,7 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 
 ## Main Features
 * STA interfaces operating in an "always off" mode, to make sure that the AP is always accessible
-* zero-conf like automatic installation & setup, usually no manual changes needed
+* easy setup within normal OpenWrt/LEDE environment
 * fast uplink connections
 * procd init system support
 * procd based hotplug support, the travelmate start will be triggered by interface triggers


### PR DESCRIPTION
Maintainer: me
Compile tested: not relevant
Run tested: LEDE r2815

Description:
* fix error handling, i.e. a wrong uplink key in wireless config

Signed-off-by: Dirk Brenken <dev@brenken.org>
