### PR TITLE
ddns-scripts: make cloudflare v1 same "domain" parameter syntax

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2016 OpenWrt.org
+# Copyright (C) 2008-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 #
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.6
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
@@ -139,8 +139,8 @@ endef
 ###### *************************************************************************
 define Package/$(PKG_NAME)/preinst
 	#!/bin/sh
-	# if NOT run buildroot and PKG_UPGRADE then stop service
-	[ -z "$${IPKG_INSTROOT}" -a "$${PKG_UPGRADE}" = "1" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+	# if NOT run buildroot then stop service
+	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
 	exit 0	# suppress errors
 endef
 define Package/$(PKG_NAME)/install
@@ -162,23 +162,24 @@ endef
 define Package/$(PKG_NAME)/postinst
 	#!/bin/sh
 	# if NOT run buildroot and PKG_UPGRADE then (re)start service if enabled
-	[ -z "$${IPKG_INSTROOT}" -a "$${PKG_UPGRADE}" = "1" ] \
-		&& /etc/init.d/ddns enabled \
-		&& /etc/init.d/ddns start >/dev/null 2>&1
+	[ -z "$${IPKG_INSTROOT}" -a "$${PKG_UPGRADE}" = "1" ] && {
+		[ -x /etc/uci-defaults/ddns ] && \
+			/etc/uci-defaults/ddns && \
+				rm -f /etc/uci-defaults/ddns >/dev/null 2>&1
+		/etc/init.d/ddns enabled && \
+			/etc/init.d/ddns start >/dev/null 2>&1
+	}
 	exit 0	# suppress errors
 endef
 define Package/$(PKG_NAME)/prerm
 	#!/bin/sh
 	# if run within buildroot exit
 	[ -n "$${IPKG_INSTROOT}" ] && exit 0
-
 	# stop running scripts
 	/etc/init.d/ddns stop
 	/etc/init.d/ddns disable
-
 	# clear LuCI indexcache
 	rm -f /tmp/luci-indexcache >/dev/null 2>&1
-
 	exit 0	# suppress errors
 endef
 
@@ -192,28 +193,34 @@ endef
 define Package/$(PKG_NAME)_cloudflare/install
 	$(INSTALL_DIR)  $(1)/etc/uci-defaults
 	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_cloudflare
-	$(INSTALL_DIR)  $(1)/usr/lib/ddns
-	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/update_cloudflare_com_v1.sh $(1)/usr/lib/ddns
 	$(INSTALL_DIR)  $(1)/usr/share
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/public_suffix_list.dat.gz $(1)/usr/share
+	$(INSTALL_DIR)  $(1)/usr/lib/ddns
+	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/update_cloudflare_com_v1.sh $(1)/usr/lib/ddns
 endef
 define Package/$(PKG_NAME)_cloudflare/postinst
 	#!/bin/sh
-	# if NOT upgrading add entries
-	[ "$${PKG_UPGRADE}" = "1" ] || {
-		printf "%s\\t%s\\n" '"cloudflare.com-v1"' '"update_cloudflare_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-		printf "%s\\t%s\\n" '"cloudflare.com-v1"' '"update_cloudflare_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
-	}
+	# remove old services file entries
+	/bin/sed -i '/cloudflare\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
+	/bin/sed -i '/cloudflare\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+	# and create new
+	printf "%s\\t%s\\n" '"cloudflare.com-v1"' '"update_cloudflare_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+	printf "%s\\t%s\\n" '"cloudflare.com-v1"' '"update_cloudflare_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
 	# on real system restart service if enabled
-	[ -z "$${IPKG_INSTROOT}" ] \
-		&& /etc/init.d/ddns enabled \
-		&& /etc/init.d/ddns start >/dev/null 2>&1
+	[ -z "$${IPKG_INSTROOT}" ] && {
+		[ -x /etc/uci-defaults/ddns_cloudflare ] && \
+			/etc/uci-defaults/ddns_cloudflare && \
+				rm -f /etc/uci-defaults/ddns_cloudflare >/dev/null 2>&1
+		/etc/init.d/ddns enabled && \
+			/etc/init.d/ddns start >/dev/null 2>&1
+	}
 	exit 0	# suppress errors
 endef
 define Package/$(PKG_NAME)_cloudflare/prerm
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
+	# remove services file entries
 	/bin/sed -i '/cloudflare\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
 	/bin/sed -i '/cloudflare\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
 	exit 0	# suppress errors
@@ -234,20 +241,27 @@ define Package/$(PKG_NAME)_cloudflare.com-v4/install
 endef
 define Package/$(PKG_NAME)_cloudflare.com-v4/postinst
 	#!/bin/sh
-	# if NOT upgrading add entries
-	[ "$${PKG_UPGRADE}" = "1" ] || {
-		printf "%s\\t%s\\n" '"cloudflare.com-v4"' '"update_cloudflare_com_v4.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-		printf "%s\\t%s\\n" '"cloudflare.com-v4"' '"update_cloudflare_com_v4.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
-	}
+	# remove old services file entries
+	/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
+	/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+	# and create new
+	printf "%s\\t%s\\n" '"cloudflare.com-v4"' '"update_cloudflare_com_v4.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+	printf "%s\\t%s\\n" '"cloudflare.com-v4"' '"update_cloudflare_com_v4.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
 	# on real system restart service if enabled
-	[ -z "$${IPKG_INSTROOT}" ] \
-		&& /etc/init.d/ddns enabled \
-		&& /etc/init.d/ddns start >/dev/null 2>&1
+	[ -z "$${IPKG_INSTROOT}" ] && {
+		[ -x /etc/uci-defaults/ddns_cloudflare.com-v4 ] && \
+			/etc/uci-defaults/ddns_cloudflare.com-v4 && \
+				rm -f /etc/uci-defaults/ddns_cloudflare.com-v4 >/dev/null 2>&1
+		/etc/init.d/ddns enabled && \
+			/etc/init.d/ddns start >/dev/null 2>&1
+	}
 	exit 0	# suppress errors
 endef
 define Package/$(PKG_NAME)_cloudflare.com-v4/prerm
 	#!/bin/sh
+	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
+	# remove services file entries
 	/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
 	/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
 	exit 0	# suppress errors
@@ -268,20 +282,27 @@ define Package/$(PKG_NAME)_godaddy.com-v1/install
 endef
 define Package/$(PKG_NAME)_godaddy.com-v1/postinst
 	#!/bin/sh
-	# if NOT upgrading add entries
-	[ "$${PKG_UPGRADE}" = "1" ] || {
-		printf "%s\\t%s\\n" '"godaddy.com-v1"' '"update_godaddy_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-		printf "%s\\t%s\\n" '"godaddy.com-v1"' '"update_godaddy_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
-	}
+	# remove old services file entries
+	/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
+	/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+	# and create new
+	printf "%s\\t%s\\n" '"godaddy.com-v1"' '"update_godaddy_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+	printf "%s\\t%s\\n" '"godaddy.com-v1"' '"update_godaddy_com_v1.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
 	# on real system restart service if enabled
-	[ -z "$${IPKG_INSTROOT}" ] \
-		&& /etc/init.d/ddns enabled \
-		&& /etc/init.d/ddns start >/dev/null 2>&1
+	[ -z "$${IPKG_INSTROOT}" ] && {
+		[ -x /etc/uci-defaults/ddns_godaddy.com-v1 ] && \
+			/etc/uci-defaults/ddns_godaddy.com-v1 && \
+				rm -f /etc/uci-defaults/ddns_godaddy.com-v1 >/dev/null 2>&1
+		/etc/init.d/ddns enabled \
+			&& /etc/init.d/ddns start >/dev/null 2>&1
+	}
 	exit 0	# suppress errors
 endef
 define Package/$(PKG_NAME)_godaddy.com-v1/prerm
 	#!/bin/sh
+	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
+	# remove services file entries
 	/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
 	/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
 	exit 0	# suppress errors
@@ -302,19 +323,25 @@ define Package/$(PKG_NAME)_no-ip_com/install
 endef
 define Package/$(PKG_NAME)_no-ip_com/postinst
 	#!/bin/sh
-	# if NOT upgrading add entries
-	[ "$${PKG_UPGRADE}" = "1" ] || {
-		printf "%s\\t%s\\n" '"no-ip.com"' '"update_no-ip_com.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-	}
+	# remove old services file entries
+	/bin/sed -i '/no-ip\.com/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
+	# and create new
+	printf "%s\\t%s\\n" '"no-ip.com"' '"update_no-ip_com.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
 	# on real system restart service if enabled
-	[ -z "$${IPKG_INSTROOT}" ] \
-		&& /etc/init.d/ddns enabled \
-		&& /etc/init.d/ddns start >/dev/null 2>&1
+	[ -z "$${IPKG_INSTROOT}" ] && {
+		[ -x /etc/uci-defaults/ddns_no-ip_com ] && \
+			/etc/uci-defaults/ddns_no-ip_com && \
+				rm -f /etc/uci-defaults/ddns_no-ip_com >/dev/null 2>&1
+		/etc/init.d/ddns enabled && \
+			/etc/init.d/ddns start >/dev/null 2>&1
+	}
 	exit 0	# suppress errors
 endef
 define Package/$(PKG_NAME)_no-ip_com/prerm
 	#!/bin/sh
+	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop		>/dev/null 2>&1
+	# remove services file entries
 	/bin/sed -i '/no-ip\.com/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
 	exit 0	# suppress errors
 endef
@@ -334,20 +361,27 @@ define Package/$(PKG_NAME)_nsupdate/install
 endef
 define Package/$(PKG_NAME)_nsupdate/postinst
 	#!/bin/sh
-	# if NOT upgrading add entries
-	[ "$${PKG_UPGRADE}" = "1" ] || {
-		printf "%s\\t%s\\n" '"bind-nsupdate"' '"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
-		printf "%s\\t%s\\n" '"bind-nsupdate"' '"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
-	}
+	# remove old services file entries
+	/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
+	/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+	# and create new
+	printf "%s\\t%s\\n" '"bind-nsupdate"' '"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+	printf "%s\\t%s\\n" '"bind-nsupdate"' '"update_nsupdate.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
 	# on real system restart service if enabled
-	[ -z "$${IPKG_INSTROOT}" ] \
-		&& /etc/init.d/ddns enabled \
-		&& /etc/init.d/ddns start >/dev/null 2>&1
+	[ -z "$${IPKG_INSTROOT}" ] && {
+		[ -x /etc/uci-defaults/ddns_nsupdate ] && \
+			/etc/uci-defaults/ddns_nsupdate && \
+				rm -f /etc/uci-defaults/ddns_nsupdate >/dev/null 2>&1
+		/etc/init.d/ddns enabled && \
+			/etc/init.d/ddns start >/dev/null 2>&1
+	}
 	exit 0	# suppress errors
 endef
 define Package/$(PKG_NAME)_nsupdate/prerm
 	#!/bin/sh
+	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop			>/dev/null 2>&1
+	# remove services file entries
 	/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
 	/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
 	exit 0	# suppress errors

--- a/net/ddns-scripts/files/ddns.defaults
+++ b/net/ddns-scripts/files/ddns.defaults
@@ -1,67 +1,263 @@
 #!/bin/sh
 
+g_pslfile=/usr/share/public_suffix_list.dat.gz
+[ -f "$g_pslfile" ] || g_pslfile="$(dirname $0)/public_suffix_list.dat.gz"
+
+g_pslerr=0
+g_cfgfile="ddns"
+
+# modify "cloudflare.com-v1" domain to new syntax
+# returns "host[.subdom]@domain.TLD" of given FQDN #############################
+mod_cloudflare_v1_domain() {
+	# $1	entry to validate/split
+	[ -f "$g_pslfile" ] || return 1
+
+	[ $# -ne 1 -o -z "$1" ] && \
+		{ printf "%s\\n" "mod_cloudflare_v1_domain() - Invalid number of parameters" >&2; return 1; }
+
+	local mcd_fqdn=$1
+	local mcd_fsub=""
+	local mcd_fdom=""
+	local mcd_ctld=""
+	local mcd_ftld=""
+
+	# check if already new syntax, "@" inside string
+	if [ $( printf "%s" "$mcd_fqdn" | grep -cF "@" 2>/dev/null ) -gt 0 ]; then
+		# already done
+		printf "%s" "$mcd_fqdn"
+		return 0
+	fi
+
+	# we need to do in one line because otherwise sh doesn't work correctly
+	# to lower | replace "." to " " | awk invert word order
+	set -- $(printf %s "$mcd_fqdn" | tr [A-Z] [a-z] | tr "." " " \
+			| awk '{do printf "%s"(NF>1?OFS:ORS),$NF;while (--NF)}' )
+
+	while [ -n "${1:-}" ] ; do			# as long we have parameters
+		if [ -z "$mcd_ctld" ]; then 		# first loop
+			mcd_ctld="$1"			# CURRENT TLD to look at
+			shift
+		else
+			mcd_ctld="$1.$mcd_ctld"		# Next TLD to look at
+			shift
+		fi
+		# check if TLD exact match in public_suffix_name.dat, save TLD
+		zcat $g_pslfile | grep -E "^$mcd_ctld$" >/dev/null 2>&1 && {
+			mcd_ftld="$mcd_ctld"		# save found
+			mcd_fdom="${1:-}"		# save domain next step might be invalid
+			continue
+		}
+		# check if match any "*" in public_suffix_name.dat,
+		zcat $g_pslfile | grep -E "^\*.$mcd_ctld$" >/dev/null 2>&1 && {
+			[ -z "${1:-}" ] && break	# no more data break
+			# check if next level TLD match excludes "!" in tld_names.dat
+			if zcat $g_pslfile | grep -E "^!$1.$mcd_ctld$" >/dev/null 2>&1 ; then
+				mcd_ftld="$mcd_ctld"	# Yes
+			else
+				mcd_ftld="$1.$mcd_ctld"
+				shift
+			fi
+			mcd_fdom="$1"; shift
+		}
+		[ -n "$mcd_ftld" ] && break	# we have something valid, break
+	done
+
+	# the leftover parameters are the HOST/SUBDOMAIN
+	while [ -n "${1:-}" ]; do
+		mcd_fsub="${1}${mcd_fsub:+.$mcd_fsub}"	# remember we need to invert
+		shift					# and insert dot if mcd_fsub not empty
+	done
+
+	# now validate found data
+	[ -z "$mcd_ftld" ] && { printf "%s\\n" "mod_cloudflare_v1_domain() - no TLD not found in '$mcd_fqdn'" >&1; return 1; }
+	[ -z "$mcd_fdom" ] && { printf "%s\\n" "mod_cloudflare_v1_domain() - no registrable Domain not found in '$mcd_fqdn'" >&1; return 1; }
+
+	# return data
+	printf "%s" "${mcd_fsub:+${mcd_fsub}@}${mcd_fdom}.${mcd_ftld}"
+	return 0
+}
+
+# modify timer settings from interval and unit to dhms format
+timer2dhms() {
+# $1	Number and
+# $2	Unit of time interval
+	local t=0
+	case $2 in
+		days)		t=$(( $1 * 86400 ));;
+		hours)		t=$(( $1 * 3600 ));;
+		minutes)	t=$(( $1 * 60 ));;
+		*)		t=$1;;
+	esac
+
+	local d=$(( $t / 86400 ))
+	local h=$(( $t % 86400 / 3600 ))
+	local m=$(( $t % 3600 / 60 ))
+	local s=$(( $t % 60 ))
+	if [ $d -gt 0 ]; then printf "%dd %02dh %02dm %02ds" "$d" "$h" "$m" "$s"
+	elif [ $h -gt 0 ]; then printf "%dh %02dm %02ds" "$h" "$m" "$s"
+	elif [ $m -gt 0 ]; then printf "%dm %02ds" "$m" "$s"
+	else printf "%ds" "$s"; fi
+
+	unset d h m s t
+	return 0
+}
+
 # using function to not confuse function calls with existing ones inside /lib/functions.sh
-update_ddns_config() {
-	udc_uci="$(which uci) -q"	# ignore errors
-	udc_pkg="ddns"
-	udc_cfg=""
-	udc_name=""
-	udc_var=""
-	udc_val=""
+update_config() {
+	uc_uci="$(which uci) -q"	# ignore errors
+	uc_cfg=""
+	uc_name=""
+	uc_var=""
+	uc_val=""
 	package() { return 0; }
 	config () {
-		udc_cfg="$1"
-		udc_name="$2"
+		uc_cfg="$1"
+		uc_name="$2"
 
 		# Type = ddns	Name = global
-		if [ "$udc_cfg" = "$udc_pkg" -a "$udc_name" = "global" ]; then
-			option() { return 0; }
-			# rename options
-			$udc_uci rename $udc_pkg.$udc_name.allow_local_ip="upd_privateip"
-			$udc_uci rename $udc_pkg.$udc_name.date_format="ddns_dateformat"
-			$udc_uci rename $udc_pkg.$udc_name.log_dir="ddns_logdir"
-			$udc_uci rename $udc_pkg.$udc_name.log_lines="ddns_loglines"
-			$udc_uci rename $udc_pkg.$udc_name.run_dir="ddns_rundir"
+		if [ "$uc_cfg" = "$g_cfgfile" -a "$uc_name" = "global" ]; then
+			option() {
+				uc_var="$1"; shift
+				uc_val="$*"
+				case "$uc_var" in
+					allow_local_ip)	$uc_uci rename $g_cfgfile.$uc_name.$uc_var="upd_privateip";;
+					date_format)	$uc_uci rename $g_cfgfile.$uc_name.$uc_var="ddns_dateformat";;
+					log_lines)	$uc_uci rename $g_cfgfile.$uc_name.$uc_var="ddns_loglines";;
+					log_dir)	$uc_uci rename $g_cfgfile.$uc_name.$uc_var="ddns_logdir";;
+					run_dir)	$uc_uci rename $g_cfgfile.$uc_name.$uc_var="ddns_rundir";;
+					# leave all other options currently unchanged
+					*)	;;
+				esac
+			}
 
 		# Type = service	Name = ???
-		elif [ "$udc_cfg" = "service" ]; then
+		elif [ "$uc_cfg" = "service" ]; then
 			option() {
-				udc_var="$1"; shift
-				udc_val="$*"
-				# fix some option service_name values
-				case "$udc_var" in
-					service_name)
-						case "$udc_val" in
+				uc_var="$1"; shift
+				uc_val="$*"
+				case "$uc_var" in
+					# fix some option service_name values
+					# and some settings for specific providers
+					service_name|upd_provider)
+						case "$uc_val" in
 							freedns\.afraid\.org|afraid\.org)
-								$udc_uci set $udc_pkg.$udc_name.$udc_var="afraid.org-keyauth";;
+								$uc_uci set $g_cfgfile.$uc_name.$uc_var="afraid.org-keyauth";;
 							Bind-nsupdate)
-								$udc_uci set $udc_pkg.$udc_name.$udc_var="bind-nsupdate";;
-							CloudFlare|cloudflare\.com)
-								$udc_uci set $udc_pkg.$udc_name.$udc_var="cloudflare.com-v1";;
+								$uc_uci set $g_cfgfile.$uc_name.$uc_var="bind-nsupdate";;
+							CloudFlare|cloudflare\.com|cloudflare\.com-v1)
+								# verify if lookup_host is set
+								$uc_uci get $g_cfgfile.$uc_name.lookup_host >/dev/null 2>&1 || {
+									ucv_domain=$($uc_uci get $g_cfgfile.$uc_name.domain 2>/dev/null)
+									$uc_uci set $g_cfgfile.$uc_name.lookup_host="$ucv_domain"
+								}
+								if [ -f "$g_pslfile" ]; then
+									# change value of domain/upd_object to new syntax
+									# there is no sort order inside uci data so we need multiple checks
+									ucv_domain=$($uc_uci get $g_cfgfile.$uc_name.domain 2>/dev/null)
+									ucv_object=$($uc_uci get $g_cfgfile.$uc_name.upd_object 2>/dev/null)
+									# still old option domain
+									if [ -n "$ucv_domain" ]; then
+										ucv_new=$(mod_cloudflare_v1_domain "$ucv_domain") || g_pslerr=1
+										# no error save data save data
+										[ $g_pslerr -eq 0 ] && \
+											$uc_uci set $g_cfgfile.$uc_name.domain="$ucv_new"
+									fi
+									# already new option upd_object
+									if [ -n "$ucv_object" ]; then
+										ucv_new=$(mod_cloudflare_v1_domain "$ucv_object") || g_pslerr=1
+										# no error save data save data
+										[ $g_pslerr -eq 0 ] && \
+											$uc_uci set $g_cfgfile.$uc_name.upd_object="$ucv_new"
+									fi
+								fi
+								unset ucv_domain ucv_object ucv_new
+								# set new option value
+								$uc_uci set $g_cfgfile.$uc_name.$uc_var="cloudflare.com-v1"
+								;;
 							dyndns\.org|dyndns\.com)
-								$udc_uci set $udc_pkg.$udc_name.$udc_var="dyn.com";;
+								$uc_uci set $g_cfgfile.$uc_name.$uc_var="dyn.com";;
 							free\.editdns\.net)
-								$udc_uci set $udc_pkg.$udc_name.$udc_var="editdns.net";;
+								$uc_uci set $g_cfgfile.$uc_name.$uc_var="editdns.net";;
 							domains\.google\.com)
-								$udc_uci set $udc_pkg.$udc_name.$udc_var="google.com";;
+								$uc_uci set $g_cfgfile.$uc_name.$uc_var="google.com";;
 							loopia\.com)
-								$udc_uci set $udc_pkg.$udc_name.$udc_var="loopia.se";;
+								$uc_uci set $g_cfgfile.$uc_name.$uc_var="loopia.se";;
 							NoIP\.com|No-IP\.com)
-								$udc_uci set $udc_pkg.$udc_name.$udc_var="no-ip.com";;
+								$uc_uci set $g_cfgfile.$uc_name.$uc_var="no-ip.com";;
 							spdns\.de)
-								$udc_uci set $udc_pkg.$udc_name.$udc_var="spdyn.de";;
+								$uc_uci set $g_cfgfile.$uc_name.$uc_var="spdyn.de";;
 							strato\.de)
-								$udc_uci set $udc_pkg.$udc_name.$udc_var="strato.com";;
+								$uc_uci set $g_cfgfile.$uc_name.$uc_var="strato.com";;
 							*)
 								# all others leave unchanged
 								;;
 						esac
 						# rename option service_name to option upd_provider
-#						$udc_uci rename $udc_pkg.$udc_name.$udc_var="upd_provider"
+#						$uc_uci rename $g_cfgfile.$uc_name.$uc_var="upd_provider"
 						;;
-					*)
-						# leave all other options currently unchanged
+					domain|upd_object)
+						# verify if lookup_host is set
+						$uc_uci get $g_cfgfile.$uc_name.lookup_host >/dev/null 2>&1 || \
+							$uc_uci set $g_cfgfile.$uc_name.lookup_host="$uc_val"
+						if [ -f "$g_pslfile" ]; then
+							# if service_name/upd_provider cloudflare_v1 then change domain/upd_object to new syntax
+							# there is no sort order inside uci data so we need multiple checks
+							uco_provider=$($uc_uci get $g_cfgfile.$uc_name.upd_provider 2>/dev/null) || \
+								uco_provider=$($uc_uci get $g_cfgfile.$uc_name.service_name 2>/dev/null)
+							if [ "$uco_provider" = "CloudFlare" \
+							  -o "$uco_provider" = "cloudflare.com" \
+							  -o "$uco_provider" = "cloudflare.com-v1" ]; then
+								ucv_new=$(mod_cloudflare_v1_domain "$uc_val") || g_pslerr=1
+								# no error save data save data
+								[ $g_pslerr -eq 0 ] && \
+									$uc_uci set $g_cfgfile.$uc_name.$uc_var="$ucv_new"
+								unset ucv_new
+							fi
+							unset uco_provider
+						fi
+						# rename option domain to option upd_object
+#						$uc_uci rename $g_cfgfile.$uc_name.$uc_var="upd_object"
 						;;
+#					dns_server)
+#						# if bind-nsupdate takeover old "dns_server" value as new "upd_nsupd_server" value
+#						uco_provider=$($uc_uci get $g_cfgfile.$uc_name.upd_provider 2>/dev/null) || \
+#							uco_provider=$($uc_uci get $g_cfgfile.$uc_name.service_name 2>/dev/null)
+#						[ "$uco_provider" = "Bind-nsupdate" -o \
+#						  "$uco_provider" = "bind-nsupdate" ] && \
+#							$uc_uci set $g_cfgfile.$uc_name.upd_nsupd_server="$uc_val"
+#						# rename option dns_server to new option global_dnssvr
+#						$udc_uci rename $g_cfgfile.$uc_name.$uc_var="global_dnssvr"
+#						;;
+#					bind_network)
+#						$udc_uci set $g_cfgfile.$uc_name.upd_url_bindnet="$uc_val"
+#						$udc_uci rename $g_cfgfile.$uc_name.$uc_var="lip_url_bindnet"
+#						;;
+#					proxy)
+#						# proxy value must include protocoll
+#						$udc_uci set $g_cfgfile.$uc_name.$uc_var="http://$uc_val"
+#						$udc_uci rename $g_cfgfile.$uc_name.$uc_var="upd_url_proxy"
+#						;;
+#					use_ipv6)
+#						$udc_uci set $g_cfgfile.$uc_name.$uc_var="$(( 4 + ( 2 * $uc_val ) ))"
+#						$udc_uci rename $g_cfgfile.$uc_name.$uc_var="upd_ipversion"
+#				TODO	update_url)
+#				TODO	update_script)
+					# other renames
+#				TODO	lookup_host)	-> rip_host
+#					enabled)	$udc_uci rename $g_cfgfile.$uc_name.$uc_var="upd_enabled";;
+#					force_dnstcp)	$udc_uci rename $g_cfgfile.$uc_name.$uc_var="rip_host_dnstcp";;
+#					is_glue)	$udc_uci rename $g_cfgfile.$uc_name.$uc_var="rip_host_isglue";;
+#					ip_interface)	$udc_uci rename $g_cfgfile.$uc_name.$uc_var="lip_iface";;
+#					ip_network)	$udc_uci rename $g_cfgfile.$uc_name.$uc_var="lip_net";;
+#					use_https)	$udc_uci rename $g_cfgfile.$uc_name.$uc_var="upd_url_secure";;
+#					cacert)		$udc_uci rename $g_cfgfile.$uc_name.$uc_var="upd_url_cacert";;
+#					username)	$udc_uci rename $g_cfgfile.$uc_name.$uc_var="upd_username";;
+#					password)	$udc_uci rename $g_cfgfile.$uc_name.$uc_var="upd_password";;
+#					param_opt)	$udc_uci rename $g_cfgfile.$uc_name.$uc_var="upd_paramopt";;
+#					param_enc)	$udc_uci rename $g_cfgfile.$uc_name.$uc_var="upd_paramenc";;
+
+					# leave all other options currently unchanged
+					*)	;;
 				esac
 				return 0
 			}
@@ -73,27 +269,41 @@ update_ddns_config() {
 		fi
 	}
 
-	# read package config file
-	udc_data=$($udc_uci -S -n export "$udc_pkg")
-	udc_ret="$?"
-	# No error and udc_data then execute (eval)
+	# read config file
+	uc_data=$($uc_uci -S -n export "$g_cfgfile")
+	uc_ret="$?"
+	# Error then create config file
+	[ $uc_ret -ne 0 ] && {
+		touch /etc/config/$uc_cfgfile
+		chmod 644 /etc/config/$uc_cfgfile
+	}
+	# No error and uc_data then execute (eval)
 	# this will call functions defined above
-	[ "$udc_ret" -eq 0 -a -n "$udc_data" ] && eval "$udc_data"
+	[ $uc_ret -eq 0 -a -n "$uc_data" ] && eval "$uc_data"
 
 	# add config ddns "global" (ignore error if exists)
-	$udc_uci set ddns.global="$udc_pkg"
+	$uc_uci set ddns.global="$g_cfgfile"
 
 	# write changes to config file
-	$udc_uci commit "$udc_pkg"
+	$uc_uci commit "$g_cfgfile"
 
-	unset udc_uci udc_pkg udc_cfg udc_name udc_var udc_val udc_ret udc_data
+	unset uc_uci uc_cfg uc_name uc_var uc_val uc_ret uc_data
 	return 0
 }
 
-# do existing config update
-update_ddns_config
-
-# clear Ludc_uci indexcache
+# clear LuCI indexcache
 rm -f /tmp/luci-indexcache >/dev/null 2>&1
 
+# do config update
+update_config
+
+#cleanup
+[ $g_pslerr -ne 0 ] && {
+	unset g_pslfile g_pslerr g_cfgfile
+	return 1
+}
+
+[ -f "$g_pslfile" ] && rm -f "$g_pslfile"
+unset g_pslfile g_pslerr g_cfgfile
 return 0
+

--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -6,7 +6,7 @@
 # (Loosely) based on the script on the one posted by exobyte in the forums here:
 # http://forum.openwrt.org/viewtopic.php?id=14040
 # extended and partial rewritten
-#.2014-2016 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+#.2014-2017 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 #
 # function timeout
 # copied from http://www.ict.griffith.edu.au/anthony/software/timeout.sh
@@ -89,22 +89,22 @@ UCLIENT_FETCH_SSL=$(find /lib /usr/lib -name libustream-ssl.so* 2>/dev/null)
 
 # Global configuration settings
 # allow NON-public IP's
-upd_privateip=$(uci -q get ddns.global.allow_local_ip) || upd_privateip=0
+upd_privateip=$(uci -q get ddns.global.upd_privateip) || upd_privateip=0
 
 # directory to store run information to.
-ddns_rundir=$(uci -q get ddns.global.run_dir) || ddns_rundir="/var/run/ddns"
+ddns_rundir=$(uci -q get ddns.global.ddns_rundir) || ddns_rundir="/var/run/ddns"
 [ -d $ddns_rundir ] || mkdir -p -m755 $ddns_rundir
 
 # directory to store log files
-ddns_logdir=$(uci -q get ddns.global.log_dir) || ddns_logdir="/var/log/ddns"
+ddns_logdir=$(uci -q get ddns.global.ddns_logdir) || ddns_logdir="/var/log/ddns"
 [ -d $ddns_logdir ] || mkdir -p -m755 $ddns_logdir
 
 # number of lines to before rotate logfile
-ddns_loglines=$(uci -q get ddns.global.log_lines) || ddns_loglines=250
+ddns_loglines=$(uci -q get ddns.global.ddns_loglines) || ddns_loglines=250
 ddns_loglines=$((ddns_loglines + 1))	# correct sed handling
 
 # format to show date information in log and luci-app-ddns default ISO 8601 format
-ddns_dateformat=$(uci -q get ddns.global.date_format) || ddns_dateformat="%F %R"
+ddns_dateformat=$(uci -q get ddns.global.ddns_dateformat) || ddns_dateformat="%F %R"
 DATE_PROG="date +'$ddns_dateformat'"
 
 # USE_CURL if GNU Wget and cURL installed normally Wget is used by do_transfer()

--- a/net/ddns-scripts/files/dynamic_dns_lucihelper.sh
+++ b/net/ddns-scripts/files/dynamic_dns_lucihelper.sh
@@ -2,7 +2,7 @@
 # /usr/lib/ddns/dynamic_dns_lucihelper.sh
 #
 #.Distributed under the terms of the GNU General Public License (GPL) version 2.0
-#.2014-2016 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+#.2014-2017 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 # This script is used by luci-app-ddns
 #
 # variables in small chars are read from /etc/config/ddns as parameter given here

--- a/net/ddns-scripts/files/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/dynamic_dns_updater.sh
@@ -6,7 +6,7 @@
 # (Loosely) based on the script on the one posted by exobyte in the forums here:
 # http://forum.openwrt.org/viewtopic.php?id=14040
 # extended and partial rewritten
-#.2014-2016 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+#.2014-2017 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 #
 # variables in small chars are read from /etc/config/ddns
 # variables in big chars are defined inside these scripts as global vars
@@ -299,7 +299,7 @@ get_uptime CURR_TIME
 if [ $LAST_TIME -eq 0 ]; then
 	write_log 7 "last update: never"
 else
-	EPOCH_TIME=$(( $(date +%s) - CURR_TIME + LAST_TIME ))
+	EPOCH_TIME=$(( $(date +%s) - $CURR_TIME + $LAST_TIME ))
 	EPOCH_TIME="date -d @$EPOCH_TIME +'$ddns_dateformat'"
 	write_log 7 "last update: $(eval $EPOCH_TIME)"
 fi

--- a/net/ddns-scripts/files/public_suffix_list.dat
+++ b/net/ddns-scripts/files/public_suffix_list.dat
@@ -5928,142 +5928,13 @@ gov.rs
 in.rs
 org.rs
 
-// ru : http://www.cctld.ru/ru/docs/aktiv_8.php
-// Industry domains
+// ru : https://cctld.ru/en/domains/domens_ru/reserved/
 ru
 ac.ru
-com.ru
 edu.ru
-int.ru
-net.ru
-org.ru
-pp.ru
-// Geographical domains
-adygeya.ru
-altai.ru
-amur.ru
-arkhangelsk.ru
-astrakhan.ru
-bashkiria.ru
-belgorod.ru
-bir.ru
-bryansk.ru
-buryatia.ru
-cbg.ru
-chel.ru
-chelyabinsk.ru
-chita.ru
-chukotka.ru
-chuvashia.ru
-dagestan.ru
-dudinka.ru
-e-burg.ru
-grozny.ru
-irkutsk.ru
-ivanovo.ru
-izhevsk.ru
-jar.ru
-joshkar-ola.ru
-kalmykia.ru
-kaluga.ru
-kamchatka.ru
-karelia.ru
-kazan.ru
-kchr.ru
-kemerovo.ru
-khabarovsk.ru
-khakassia.ru
-khv.ru
-kirov.ru
-koenig.ru
-komi.ru
-kostroma.ru
-krasnoyarsk.ru
-kuban.ru
-kurgan.ru
-kursk.ru
-lipetsk.ru
-magadan.ru
-mari.ru
-mari-el.ru
-marine.ru
-mordovia.ru
-// mosreg.ru  Bug 1090800 - removed at request of Aleksey Konstantinov <konstantinovav@mosreg.ru>
-msk.ru
-murmansk.ru
-nalchik.ru
-nnov.ru
-nov.ru
-novosibirsk.ru
-nsk.ru
-omsk.ru
-orenburg.ru
-oryol.ru
-palana.ru
-penza.ru
-perm.ru
-ptz.ru
-rnd.ru
-ryazan.ru
-sakhalin.ru
-samara.ru
-saratov.ru
-simbirsk.ru
-smolensk.ru
-spb.ru
-stavropol.ru
-stv.ru
-surgut.ru
-tambov.ru
-tatarstan.ru
-tom.ru
-tomsk.ru
-tsaritsyn.ru
-tsk.ru
-tula.ru
-tuva.ru
-tver.ru
-tyumen.ru
-udm.ru
-udmurtia.ru
-ulan-ude.ru
-vladikavkaz.ru
-vladimir.ru
-vladivostok.ru
-vologda.ru
-voronezh.ru
-vrn.ru
-vyatka.ru
-yakutia.ru
-yamal.ru
-yaroslavl.ru
-yekaterinburg.ru
-yuzhno-sakhalinsk.ru
-// More geographical domains
-amursk.ru
-baikal.ru
-cmw.ru
-fareast.ru
-jamal.ru
-kms.ru
-k-uralsk.ru
-kustanai.ru
-kuzbass.ru
-mytis.ru
-nakhodka.ru
-nkz.ru
-norilsk.ru
-oskol.ru
-pyatigorsk.ru
-rubtsovsk.ru
-snz.ru
-syzran.ru
-vdonsk.ru
-zgrad.ru
-// State domains
 gov.ru
+int.ru
 mil.ru
-// Technical domains
 test.ru
 
 // rw : http://www.nic.rw/cgi-bin/policy.pl
@@ -11799,6 +11670,10 @@ gist.githubcloud.com
 // Submitted by Alex Hanselka <alex@gitlab.com>
 gitlab.io
 
+// UKHomeOffice : https://www.gov.uk/government/organisations/home-office
+// Submitted by Jon Shanks <jon.shanks@digital.homeoffice.gov.uk>
+homeoffice.gov.uk
+
 // GlobeHosting, Inc.
 // Submitted by Zoltan Egresi <egresi@globehosting.com>
 ro.im
@@ -12341,6 +12216,10 @@ lib.de.us
 // Submitted by Simon Kissel <hostmaster@viprinet.com>
 router.management
 
+// Western Digital Technologies, Inc : https://www.wdc.com
+// Submitted by Jung Jin <jungseok.jin@wdc.com>
+remotewd.com
+
 // Wikimedia Labs : https://wikitech.wikimedia.org
 // Submitted by Yuvi Panda <yuvipanda@wikimedia.org>
 wmflabs.org
@@ -12367,5 +12246,11 @@ za.org
 // Zeit, Inc. : https://zeit.domains/
 // Submitted by Olli Vanhoja <olli@zeit.co>
 now.sh
+
+// 1GB LLC : https://www.1gb.ua/
+// Submitted by 1GB LLC <noc@1gb.com.ua>
+cc.ua
+inf.ua
+ltd.ua
 
 // ===END PRIVATE DOMAINS===

--- a/net/ddns-scripts/files/update_cloudflare_com_v1.sh
+++ b/net/ddns-scripts/files/update_cloudflare_com_v1.sh
@@ -2,7 +2,7 @@
 #.Distributed under the terms of the GNU General Public License (GPL) version 2.0
 #
 # script for sending updates to cloudflare.com
-#.2014-2015 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+#.2014-2017 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 # many thanks to Paul for testing and feedback during development
 #
 # This script is parsed by dynamic_dns_functions.sh inside send_update() function
@@ -19,15 +19,26 @@
 [ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'username'"
 [ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"
 
-local __RECID __URL __KEY __KEYS __FOUND __SUBDOM __DOMAIN __TLD
+local __RECID __URL __KEY __KEYS __FOUND __SUBDOM __DOMAIN __FQDN
 
-# split given Host/Domain into TLD, registrable domain, and subdomain
-split_FQDN $domain __TLD __DOMAIN __SUBDOM
-[ $? -ne 0 -o -z "$__DOMAIN" ] && \
-	write_log 14 "Wrong Host/Domain configuration ($domain). Please correct configuration!"
+# split __SUBDOM __DOMAIN from $domain
+# given data:
+# @example.com for "domain record"
+# host.sub@example.com for a "host record"
+__SUBDOM=$(printf %s "$domain" | cut -d@ -f1)
+__DOMAIN=$(printf %s "$domain" | cut -d@ -f2)
 
-# put together what we need
-__DOMAIN="$__DOMAIN.$__TLD"
+# Cloudflare v1 needs:
+# __DOMAIN = the base domain i.e. example.com
+# __SUBDOM = the host.sub to change if a "host record" or blank if domain record
+# __FQDN   = the FQDN to detect record_id to change
+# i.e. example.com for the "domain record" or host.sub.example.com for "host record"
+if [ -z "$__SUBDOM" -o "$__SUBDOM" = "$__DOMAIN" ]; then
+	__SUBDOM=""
+	__FQDN="$__DOMAIN"
+else
+	__FQDN="${__SUBDOM}.${__DOMAIN}"
+fi
 
 # parse OpenWrt script with
 # functions for parsing and generating json
@@ -90,7 +101,7 @@ cleanup() {
 	#	json_get_var __DISPLAY "display_name"	# for debugging
 		json_get_var __NAME "name"
 		json_get_var __TYPE "type"
-		if [ "$__NAME" = "$domain" ]; then
+		if [ "$__NAME" = "$__FQDN" ]; then
 			# we must verify IPv4 and IPv6 because there might be both for the same host
 			[ \( $use_ipv6 -eq 0 -a "$__TYPE" = "A" \) -o \( $use_ipv6 -eq 1 -a "$__TYPE" = "AAAA" \) ] && {
 				__FOUND=1	# mark found
@@ -106,7 +117,7 @@ cleanup() {
 	}
 	json_get_var __RECID "rec_id"	# last thing to do get rec_id
 	json_cleanup			# cleanup
-	write_log 7 "rec_id '$__RECID' detected for host/domain '$domain'"
+	write_log 7 "rec_id '$__RECID' detected for host/domain '$__FQDN'"
 }
 
 # build url according to cloudflare client api at https://www.cloudflare.com/docs/client-api.html

--- a/net/ddns-scripts/files/update_godaddy_com_v1.sh
+++ b/net/ddns-scripts/files/update_godaddy_com_v1.sh
@@ -4,7 +4,7 @@
 #
 # script for sending updates to godaddy.com
 #.based on GoDaddy.sh v1.0 by Nazar78 @ TeaNazaR.com
-#.2016 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+#.2017 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 # GoDaddy Documentation at https://developer.godaddy.com/doc
 #
 # This script is parsed by dynamic_dns_functions.sh inside send_update() function
@@ -27,9 +27,17 @@
 local __HOST __DOMAIN __TYPE __URL __PRGBASE __RUNPROG __DATA __IPV6
 
 # split __HOST __DOMAIN from $domain
+# given data:
+# @example.com for "domain record"
+# host.sub@example.com for a "host record"
 __HOST=$(printf %s "$domain" | cut -d@ -f1)
 __DOMAIN=$(printf %s "$domain" | cut -d@ -f2)
-[ -z "$__HOST" -o "$__HOST" = "$__DOMAIN" ] && __HOST="%40"	# no expizit host given so set to default "@" => urlencode "%40"
+
+# GoDaddy needs:
+# __DOMAIN = the base domain i.e. example.com
+# __HOST   = host.sub if updating a host record or
+# __HOST   = "@" urlencoded "%40" for a domain record
+[ -z "$__HOST" -o "$__HOST" = "$__DOMAIN" ] && __HOST="%40"
 
 # set record type
 [ $use_ipv6 -eq 0 ] && __TYPE="A" || __TYPE="AAAA"


### PR DESCRIPTION
Maintainer: me
Compile tested: OpenWrt CC 15.05.1 / OpenWrt DD
Run tested: OpenWrt CC 15.05.1 / OpenWrt DD

Description:
- cloudflare v1 change syntax of option domain to "host.sub@example.com" like already cloudflare v4 and godaddy to prepare logterm remove of public_suffix_list.dat from package
- change Makefile to be backportable to CC15.05 and working on DD
- change ddns.defaults to prepare future releases of ddns-scripts
- minor fixes

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>
