### PR TITLE
micropython-lib: add 0 return code for `install` rule/script

### DIFF
--- a/lang/micropython-lib/Makefile
+++ b/lang/micropython-lib/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=micropython-lib
 PKG_VERSION=1.8.6-$(PKG_SOURCE_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=MIT, PSFL

--- a/lang/micropython-lib/patches/001-add-exit-0-ret-code-for-install-rule.patch
+++ b/lang/micropython-lib/patches/001-add-exit-0-ret-code-for-install-rule.patch
@@ -1,0 +1,11 @@
+diff --git a/Makefile b/Makefile
+index 7ae0883..9286088 100644
+--- a/Makefile
++++ b/Makefile
+@@ -13,4 +13,5 @@ install:
+ 	        echo $$d; \
+ 	        (cd $$d; sh -c $(CMD)); \
+ 	    done \
+-	fi
++	fi ; \
++	exit 0


### PR DESCRIPTION
Maintainer: @roger- 
Compile tested: https://github.com/lede-project/source/commit/c1b12aa838587952b269a75ad278e8805aa9a65f  ar71xx
Run tested: N/A

----------------------------------------------------------
I get these weird errors:
```
Makefile:8: recipe for target 'install' failed
make[4]: *** [install] Error 123
```

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>