### PR TITLE
libs/dtc: fix build on x86_64

### DIFF
--- a/libs/dtc/Makefile
+++ b/libs/dtc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dtc
 PKG_VERSION:=1.4.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.kernel.org/pub/software/utils/dtc
 PKG_SOURCE_MD5SUM:=3d5814e31b2046ef51fca8fece998db0
@@ -55,6 +55,9 @@ define Package/libfdt/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/lib/libfdt*.so* $(1)/usr/lib
 endef
+
+TARGET_CFLAGS += \
+	$(FPIC)
 
 MAKE_FLAGS += \
 	PREFIX= \


### PR DESCRIPTION
Maintainer: @yousong 
Compile tested: https://github.com/lede-project/source/commit/01d9527357767324158e7182d1d1484dde842ccb x86_64
Run tested: N/A

---------------------------------------------------

Fixes build error:
```
x86_64-openwrt-linux-musl-gcc -L/home/sandu/work/lede/staging_dir/target-x86_64_musl-1.1.15/usr/lib -L/home/sandu/work/lede/staging_dir/target-x86_64_musl-1.1.15/lib -L/home/sandu/work/lede/staging_dir/toolchain-x86_64_gcc-5.4.0_musl-1.1.15/usr/lib -L/home/sandu/work/lede/staging_dir/toolchain-x86_64_gcc-5.4.0_musl-1.1.15/lib -znow -zrelro  -fPIC -shared -Wl,--version-script=libfdt/version.lds -Wl,-soname,libfdt.so.1 -o libfdt/libfdt-1.4.2.so libfdt/fdt.o libfdt/fdt_ro.o libfdt/fdt_wip.o libfdt/fdt_sw.o libfdt/fdt_rw.o libfdt/fdt_strerror.o libfdt/fdt_empty_tree.o libfdt/fdt_addresses.o
/home/sandu/work/lede/staging_dir/toolchain-x86_64_gcc-5.4.0_musl-1.1.15/lib64/gcc/x86_64-openwrt-linux-musl/5.4.0/../../../../x86_64-openwrt-linux-musl/bin/ld: libfdt/fdt.o: relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
libfdt/fdt.o: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
Makefile:283: recipe for target 'libfdt/libfdt-1.4.2.so' failed
make[4]: *** [libfdt/libfdt-1.4.2.so] Error 1
```

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>