### PR TITLE
wireguard: new upstream version

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -10,12 +10,12 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=wireguard
 
-PKG_VERSION:=0.0.20161230
+PKG_VERSION:=0.0.20170105
 PKG_RELEASE:=1
 
 PKG_SOURCE:=WireGuard-$(PKG_VERSION).tar.xz
 # This is actually SHA256, but OpenWRT/LEDE will figure it out based on the length
-PKG_MD5SUM:=69c9770daf9c8ff6632d614afc117b60774760f1224c9322c84f8da92b9ae396
+PKG_MD5SUM:=1bd990eeae6fbf599ccddde81caa92770f58623ad9705f875bcfab8254583896
 PKG_SOURCE_URL:=https://git.zx2c4.com/WireGuard/snapshot/
 PKG_BUILD_DIR:=$(BUILD_DIR)/WireGuard-$(PKG_VERSION)
 
@@ -96,7 +96,7 @@ define KernelPackage/wireguard
   TITLE:=Wireguard kernel module
   DEPENDS:=+IPV6:kmod-udptunnel6 +kmod-udptunnel4 +kmod-ipt-hashlimit
   FILES:= $(PKG_BUILD_DIR)/src/wireguard.$(LINUX_KMOD_SUFFIX)
-  AUTOLOAD:=$(call AutoLoad,33,wireguard)
+  AUTOLOAD:=$(call AutoProbe,wireguard)
 endef
 
 define KernelPackage/wireguard/description


### PR DESCRIPTION
Signed-off-by: Dan Luedtke <mail@danrl.com>


Maintainer:  @zorun & me
Compile tested: x86_64 latest source from yesterday evening

Description: Version bump. Also introduced new variable `PKG_HASH` for compatibility with anticipated build system changes.
