### PR TITLE
horst: fix build against musl and fortify-headers

### DIFF
--- a/net/horst/Makefile
+++ b/net/horst/Makefile
@@ -26,6 +26,7 @@ PKG_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/package.mk
 
 MAKE_FLAGS += DEBUG=1 LIBNL=tiny
+TARGET_CFLAGS += -D_GNU_SOURCE
 
 define Package/horst
 	SECTION:=net


### PR DESCRIPTION
Maintainer: @br101 
Compile tested: LEDE r2892-5932400
Run tested: -

Description:

Compile horst with -D_GNU_SOURCE in order to expose mempcpy() in musl.

Without a declared mempcpy(), the fortify headers will fail to wrap the
function, leading to the following error spotted by the buildbots:

    In file included from .../fortify/stdlib.h:28:0,
                     from display-channel.c:22:
    .../include/fortify/string.h:142:13: error: 'mempcpy' undeclared here (not in a function)
     _FORTIFY_FN(mempcpy) void *mempcpy(void *__d, const void *__s, size_t __n)
                 ^
    .../fortify/fortify-headers.h:20:40: note: in definition of macro '_FORTIFY_ORIG'
     #define _FORTIFY_ORIG(p,fn) __typeof__(fn) __orig_##fn __asm__(_FORTIFY_STR(p) #fn)
                                            ^
    .../fortify/string.h:142:1: note: in expansion of macro '_FORTIFY_FN'
     _FORTIFY_FN(mempcpy) void *mempcpy(void *__d, const void *__s, size_t __n)
     ^
    In file included from ./ccan/str/str.h:5:0,
                     from ccan/list/list.h:7,
                     from main.h:27,
                     from display-channel.c:25:
    .../fortify/string.h: In function 'mempcpy':
    .../fortify/string.h:149:9: error: called object '__orig_mempcpy' is not a function or function pointer
      return __orig_mempcpy(__d, __s, __n);
             ^
    In file included from .../fortify/stdlib.h:28:0,
                     from display-channel.c:22:
    .../fortify/fortify-headers.h:20:44: note: declared here
     #define _FORTIFY_ORIG(p,fn) __typeof__(fn) __orig_##fn __asm__(_FORTIFY_STR(p) #fn)
                                                ^
    .../fortify/fortify-headers.h:21:25: note: in expansion of macro '_FORTIFY_ORIG'
     #define _FORTIFY_FN(fn) _FORTIFY_ORIG(__USER_LABEL_PREFIX__,fn); \
                             ^
    .../fortify/string.h:142:1: note: in expansion of macro '_FORTIFY_FN'
     _FORTIFY_FN(mempcpy) void *mempcpy(void *__d, const void *__s, size_t __n)
     ^
    <builtin>: recipe for target 'display-channel.o' failed
    make[3]: *** [display-channel.o] Error 1

Signed-off-by: Jo-Philipp Wich <jo@mein.io>