### PR TITLE
ddns-scripts: fixes for nslookup and khost

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.6
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -1121,20 +1121,18 @@ get_registered_ip() {
 			write_log 3 "$__PROG error: '$__ERR'"
 			write_log 7 "$(cat $ERRFILE)"
 		else
-			if [ -n "$BIND_HOST" ]; then
+			if [ -n "$BIND_HOST" -o -n "$KNOT_HOST" ]; then
 				if [ $is_glue -eq 1 ]; then
 					__DATA=$(cat $DATFILE | grep "^$lookup_host" | grep -om1 "$__REGEX" )
 				else
 					__DATA=$(cat $DATFILE | awk -F "address " '/has/ {print $2; exit}' )
 				fi
-			elif [ -n "$KNOT_HOST" ]; then
-				__DATA=$(cat $DATFILE | awk -F "address " '/has/ {print $2; exit}' )
 			elif [ -n "$DRILL" ]; then
 				__DATA=$(cat $DATFILE | awk '/^'"$lookup_host"'/ {print $5; exit}' )
 			elif [ -n "$HOSTIP" ]; then
 				__DATA=$(cat $DATFILE | grep -om1 "$__REGEX")
 			elif [ -n "$NSLOOKUP" ]; then
-				__DATA=$(cat $DATFILE | sed -e '1,/Name:/d' | grep -om1 "$__REGEX" )
+				__DATA=$(cat $DATFILE | sed -ne "/^Name:/,\$ { s/^Address[0-9 ]\{0,\}: \($__REGEX\).*$/\\1/p }" )
 			fi
 			[ -n "$__DATA" ] && {
 				write_log 7 "Registered IP '$__DATA' detected"


### PR DESCRIPTION
Maintainer: me

Description:

- fix ip extraction if knot host is used together with glue records
- fix ip extraction from nslookup if reverse dns record has ip with dot reported at http://forum.lede-project.org/t/ddns-scripts-error/909

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>
