### PR TITLE
https-dns-proxy: Fix wrong commandline argument

### DIFF
--- a/net/https-dns-proxy/files/https_dns_proxy.init
+++ b/net/https-dns-proxy/files/https_dns_proxy.init
@@ -16,7 +16,7 @@ start_instance() {
 
 	procd_open_instance
 	procd_set_param command ${PROG} \
-		-l "$listen_addr" -p "$listen_port" \
+		-a "$listen_addr" -p "$listen_port" \
 		-u "$user" -g "$group"
 	procd_set_param respawn
 	procd_close_instance


### PR DESCRIPTION
Init scripts were configuring daemon to write log to file "127.0.0.1" instead.
Signed-off-by: Aaron Drew <aarond10@gmail.com>