### PR TITLE
mosquitto: pass variable UNAME=Linux to source Makefile

### DIFF
--- a/net/mosquitto/Makefile
+++ b/net/mosquitto/Makefile
@@ -209,7 +209,7 @@ define Package/libmosquittopp/install
 endef
 
 # Applies to all...
-MAKE_FLAGS += WITH_DOCS=no
+MAKE_FLAGS += WITH_DOCS=no UNAME=Linux
 ifeq ($(BUILD_VARIANT),nossl)
 	MAKE_FLAGS += WITH_TLS=no WITH_WEBSOCKETS=no
 else


### PR DESCRIPTION
This fixes a bug when gpsd is crosscompiled in LEDE
under OS X.

Signed-off-by: Thomas Huehn <thomas@net.t-labs.tu-berlin.de>

Maintainer: @karlp
Compile tested: LEDE trunk
Run tested: LEDE trunk

