### PR TITLE
perl-cgi: bump package release because of PKG_LEAVE_COMMENTS

### DIFF
--- a/lang/perl-cgi/Makefile
+++ b/lang/perl-cgi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-cgi
 PKG_VERSION:=4.35
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://www.cpan.org/authors/id/L/LE/LEEJO
 PKG_SOURCE:=CGI-$(PKG_VERSION).tar.gz


### PR DESCRIPTION
Maintainer: me, @Naoir 
Compile tested: x86_64, generic, OpenWRT HEAD (80f93e5513f)
Run tested: same

Rebuild from scratch, burn CFast, confirm release in `/usr/lib/opkg/status` and `inspect /usr/lib/perl5/5.22/CGI.pm` for having comments present, respectively.

Description:

Changing how the package gets generated also requires incrementing the PKG_RELEASE.