### PR TITLE
vallumd: new package

### DIFF
--- a/net/vallumd/Makefile
+++ b/net/vallumd/Makefile
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2017 Stijn Tintel <stijn@linux-ipv6.be>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=vallumd
+PKG_VERSION:=0.1.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/stintel/vallumd/archive/$(PKG_VERSION)/
+PKG_MD5SUM:=81f6a721a2f2b5fefcec9217bafb121d6a969440a9165da8d5a3084704743e5c
+
+PKG_LICENSE:=GPL-3.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/vallumd
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Centralized or distributed blacklist
+  DEPENDS:=+ipset +libmosquitto
+endef
+
+define Package/vallumd/description
+  Centralized or distributed blacklist
+endef
+
+define Package/vallumd/conffiles
+/etc/config/vallumd
+endef
+
+define Package/vallumd/install
+	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/init.d $(1)/usr/sbin
+	$(INSTALL_CONF) ./files/vallumd.conf $(1)/etc/config/vallumd
+	$(INSTALL_BIN) ./files/vallumd.init $(1)/etc/init.d/vallumd
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/vallumd $(1)/usr/sbin/vallumd
+endef
+
+
+$(eval $(call BuildPackage,vallumd))

--- a/net/vallumd/files/vallumd.conf
+++ b/net/vallumd/files/vallumd.conf
@@ -1,0 +1,6 @@
+config vallumd mqtt
+	option host 127.0.0.1
+	option port 1883
+	list topics blacklist4
+	list topics blacklist6
+	option enabled 0

--- a/net/vallumd/files/vallumd.init
+++ b/net/vallumd/files/vallumd.init
@@ -1,0 +1,34 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+USE_PROCD=1
+PROG=/usr/sbin/vallumd
+
+add_topic() {
+	procd_append_param command -t "$1"
+}
+
+start_service() {
+	local enabled
+	local mqtt_host
+	local mqtt_port
+
+	config_load "vallumd"
+	config_get_bool enabled "mqtt" "enabled" 1
+	[ "$enabled" -gt 0 ] || return 1
+
+	config_get mqtt_host "mqtt" "host"
+	config_get mqtt_port "mqtt" "port"
+
+	procd_open_instance
+
+	procd_set_param command $PROG
+
+	[ -n "$mqtt_host" ] && procd_append_param command -h "$mqtt_host"
+	[ -n "$mqtt_port" ] && procd_append_param command -p "$mqtt_port"
+	config_list_foreach mqtt topics add_topic
+
+	procd_set_param respawn
+
+	procd_close_instance
+}


### PR DESCRIPTION
Maintainer: me
Compile/run tested: LEDE r2960 on x86/64 and Octeon

Description:
Vallumd allows you to centralize or distribute IPsets by connecting to an MQTT broker and listening for messages with IP addresses. See https://github.com/stintel/vallumd

@openwrt/package-maintainers thanks for review/ack/nak.