### PR TITLE
wireguard: multiple: static addressing/ version bump/ ipv6 bugfix

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2016 Jason A. Donenfeld <Jason@zx2c4.com>
 # Copyright (C) 2016 Baptiste Jonglez <openwrt@bitsofnetworks.org>
+# Copyright (C) 2016-2017 Dan Luedtke <mail@danrl.com>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,20 +11,19 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=wireguard
 
-PKG_VERSION:=0.0.20170105
+PKG_VERSION:=0.0.20170115
 PKG_RELEASE:=1
 
 PKG_SOURCE:=WireGuard-$(PKG_VERSION).tar.xz
-# This is actually SHA256, but OpenWRT/LEDE will figure it out based on the length
-PKG_MD5SUM:=1bd990eeae6fbf599ccddde81caa92770f58623ad9705f875bcfab8254583896
 PKG_SOURCE_URL:=https://git.zx2c4.com/WireGuard/snapshot/
-PKG_BUILD_DIR:=$(BUILD_DIR)/WireGuard-$(PKG_VERSION)
+PKG_MD5SUM:=7e5f9f4699a2d4ace90d0df5d81bf0f67205ee08c45b95e0acc379bedef5ffe8
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 
-PKG_USE_MIPS16:=0
+PKG_BUILD_DIR:=$(BUILD_DIR)/WireGuard-$(PKG_VERSION)
 PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
 
 # Wireguard's makefile needs this to know where to build the kernel module
 export KERNELDIR:=$(LINUX_DIR)


### PR DESCRIPTION
Maintainer: @zorun & me
Compile tested: today's source.git on x86
Run tested: today's source.git on x86

Description:

Two changes in this PR, therefore two commits.
1) Change package source from web download to git
Using source protocol git allows us to fetch a particular commit should it ever
be necessary. Furthermore, version bumps are slightly easier to maintain since
all we need is the commit hash of the tagged version.

2) allow static addressing for tunnel interfaces without requiring an interface on top
Current approach: https://lede-project.org/docs/user-guide/tunneling_interface_protocols#static_addressing_of_wireguard_tunnel
This is not very user friendly for *most* use cases. Users have been confused and complained. Almost all use cases I have seen so far use static addresses and the new approach allows easy configuration for all of them. The protocol handler adds IP addresses. However, users who wish to stack interfaces can still do so. The field is optional. A corresponding PR for LUCI is underway.

**PS: If possible, please merge before Mon Jan 16 2017 so this change will be part of the upcoming freeze.**