### PR TITLE
Fwknopd: Various updates

### DIFF
--- a/net/fwknop/Config.in
+++ b/net/fwknop/Config.in
@@ -7,6 +7,10 @@ config FWKNOPD_GPG
 	select PACKAGE_gnupg
 	default n
 
+config FWKNOPD_NFQ_CAPTURE
+	bool "Enable netfilter_queue capture support (disables libpcap support)"
+	select PACKAGE_iptables-mod-nfqueue
+	default n
 
 
 endmenu

--- a/net/fwknop/Makefile
+++ b/net/fwknop/Makefile
@@ -9,11 +9,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fwknop
 PKG_VERSION:=2.6.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.cipherdyne.org/fwknop/download
 PKG_MD5SUM:=e2c49e9674888a028bd443a55c3aaa22
+PKG_HASH:=5bf47fe1fd30e862d29464f762c0b8bf89b5e298665c37624d6707826da956d4
 PKG_MAINTAINER:=Jonathan Bennett <JBennett@incomsystems.biz>
 PKG_LICENSE:=GPLv2
 PKG_INSTALL:=1
@@ -42,7 +43,8 @@ define Package/fwknopd
   CATEGORY:=Network
   SUBMENU:=Firewall
   TITLE+= Daemon
-  DEPENDS:=+iptables +libfko +libpcap +FWKNOP_GPG:gnupg
+  DEPENDS:=+iptables +libfko +!FWKNOPD_NFQ_CAPTURE:libpcap +FWKNOPD_NFQ_CAPTURE:iptables-mod-nfqueue +FWKNOP_GPG:gnupg \
+	+FWKNOPD_NFQ_CAPTURE:libnetfilter-queue +FWKNOPD_NFQ_CAPTURE:libnfnetlink
 endef
 
 define Package/fwknopd/description
@@ -90,6 +92,10 @@ endef
 
 ifneq ($(CONFIG_FWKNOPD_GPG),y)
 	CONFIGURE_ARGS += --without-gpgme 
+endif
+
+ifeq ($(CONFIG_FWKNOPD_NFQ_CAPTURE),y)
+ 	CONFIGURE_ARGS += --enable-nfq-capture 
 endif
 
 CONFIGURE_ARGS += \

--- a/net/fwknop/files/fwknopd.init
+++ b/net/fwknop/files/fwknopd.init
@@ -12,7 +12,12 @@ FWKNOPD_BIN=/usr/sbin/fwknopd
 start()
 {
 	gen_confs
-        $FWKNOPD_BIN 
+	if [ $UCI_ENABLED ]; then
+        	$FWKNOPD_BIN -c /var/etc/fwknopd.conf -a /var/etc/access.conf 
+	else
+        	$FWKNOPD_BIN 
+	fi
+
 }
 
 stop()
@@ -51,10 +56,10 @@ gen_confs()
 				local option="$1"
 				local value="$2"
 				if [ "$option" = "uci_enabled" ] && [ "$value" -eq 1 ] ; then
-					> /etc/fwknop/fwknopd.conf
-					> /etc/fwknop/access.conf
-                                        chmod 600 /etc/fwknop/fwknopd.conf
-                                        chmod 600 /etc/fwknop/access.conf
+					> /var/etc/fwknopd.conf
+					> /var/etc/access.conf
+                                        chmod 600 /var/etc/fwknopd.conf
+                                        chmod 600 /var/etc/access.conf
 					UCI_ENABLED=1
 				fi
 			}
@@ -63,20 +68,20 @@ gen_confs()
 				local option="$1"
 				local value="$2"
 				if [ $UCI_ENABLED ]; then
-					echo "$option $value" >> /etc/fwknop/fwknopd.conf  #writing each option to fwknopd.conf
+					echo "$option $value" >> /var/etc/fwknopd.conf  #writing each option to fwknopd.conf
 				fi
 			}
 		elif [ "$type" = "access" ]
 		then
 			if [ -f /tmp/access.conf.tmp ] ; then
-				cat /tmp/access.conf.tmp >> /etc/fwknop/access.conf
+				cat /tmp/access.conf.tmp >> /var/etc/access.conf
 				rm /tmp/access.conf.tmp
 			fi
 			option_cb() {
 				local option="$1"
 				local value="$2"
 				if [ $UCI_ENABLED ] && [ $option = "SOURCE" ]; then
-					echo "$option $value" >> /etc/fwknop/access.conf  #writing each option to access.conf
+					echo "$option $value" >> /var/etc/access.conf  #writing each option to access.conf
 				fi
 				if [ $UCI_ENABLED ] && [ $option != "SOURCE" ]; then
 					echo "$option $value" >> /tmp/access.conf.tmp  #writing each option to access.conf
@@ -88,7 +93,7 @@ gen_confs()
 	if [ -f /etc/config/fwknopd ]; then
 		config_load fwknopd
 		if [ -f /tmp/access.conf.tmp ] ; then
-			cat /tmp/access.conf.tmp >> /etc/fwknop/access.conf
+			cat /tmp/access.conf.tmp >> /var/etc/access.conf
 			rm /tmp/access.conf.tmp
 		fi
 	fi


### PR DESCRIPTION
Adds configuration option for NFQ capture, moves often written
configuration files to /var/etc.

Signed-off-by: Jonathan Bennett <JBennett@incomsystems.biz>

Maintainer: me
Compile tested: LEDE latest git
Run tested: LEDE latest git, x86_64

Description:
This changeset pulls in the suggested changes from https://github.com/openwrt/packages/pull/3506 as well.  Thanks to InkblotAdmirer.