### PR TITLE
mosquitto: make DNS SRV support optional

### DIFF
--- a/net/mosquitto/Config.in
+++ b/net/mosquitto/Config.in
@@ -11,3 +11,11 @@ config MOSQUITTO_PASSWD
     default y
     help
         mosquitto_passwd is a tool for managing password files for mosquitto.
+
+config MOSQUITTO_SRV
+    bool "Include SRV lookup support"
+    depends on PACKAGE_libmosquitto || PACKAGE_libmosquitto-nossl || PACKAGE_mosquitto-client || PACKAGE_mosquitto-client-nossl
+    select PACKAGE_libcares
+    default y
+    help
+        Support DNS SRV lookups to determine which host to connect to.

--- a/net/mosquitto/Makefile
+++ b/net/mosquitto/Makefile
@@ -70,7 +70,7 @@ endef
 define Package/mosquitto-client/default
     $(Package/mosquitto/default)
     TITLE:= mosquitto - client tools
-    DEPENDS+=+libcares
+    DEPENDS+=+MOSQUITTO_SRV:libcares
 endef
 define Package/mosquitto-client
     $(call Package/mosquitto-client/default)
@@ -99,11 +99,15 @@ $(call Package/mosquitto-client/default/description)
         This package is built without SSL support
 endef
 
+define Package/libmosquitto/config
+    source "$(SOURCE)/Config.in"
+endef
+
 define Package/libmosquitto/default
     $(Package/mosquitto/default)
     SECTION:=libs
     CATEGORY:=Libraries
-    DEPENDS:=+libpthread +librt +libcares
+    DEPENDS:=+libpthread +librt +MOSQUITTO_SRV:libcares
     TITLE:= mosquitto - client library
 endef
 
@@ -209,7 +213,7 @@ define Package/libmosquittopp/install
 endef
 
 # Applies to all...
-MAKE_FLAGS += WITH_DOCS=no UNAME=Linux
+MAKE_FLAGS += WITH_DOCS=no WITH_SRV=$(if $(CONFIG_MOSQUITTO_SRV),"yes","no") UNAME=Linux
 ifeq ($(BUILD_VARIANT),nossl)
 	MAKE_FLAGS += WITH_TLS=no WITH_WEBSOCKETS=no
 else


### PR DESCRIPTION
Maintainer: @karlp 
Compile tested: LEDE r2987-25200ae on x86/64 and Octeon