### PR TITLE
net/socat: Update to 1.7.3.1 and fix SSL

### DIFF
--- a/net/socat/Makefile
+++ b/net/socat/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=socat
-PKG_VERSION:=1.7.3.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.7.3.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.dest-unreach.org/socat/download
-PKG_MD5SUM:=b607edb65bc6c57f4a43f06247504274
+PKG_MD5SUM:=d2da659540c38139f388e9437bfaae16bb458d174d056cb3228432a8f489fbaa
 
 PKG_MAINTAINER:= Ted Hess <thess@kitschensync.net>
 

--- a/net/socat/patches/110-drop_egd_sslv3_support.patch
+++ b/net/socat/patches/110-drop_egd_sslv3_support.patch
@@ -1,0 +1,184 @@
+--- a/sslcls.c
++++ b/sslcls.c
+@@ -55,6 +55,7 @@ const SSL_METHOD *sycSSLv2_server_method
+ }
+ #endif
+ 
++#ifdef HAVE_SSLv3_client_method
+ const SSL_METHOD *sycSSLv3_client_method(void) {
+    const SSL_METHOD *result;
+    Debug("SSLv3_client_method()");
+@@ -62,7 +63,9 @@ const SSL_METHOD *sycSSLv3_client_method
+    Debug1("SSLv3_client_method() -> %p", result);
+    return result;
+ }
++#endif
+ 
++#ifdef HAVE_SSLv3_server_method
+ const SSL_METHOD *sycSSLv3_server_method(void) {
+    const SSL_METHOD *result;
+    Debug("SSLv3_server_method()");
+@@ -70,6 +73,7 @@ const SSL_METHOD *sycSSLv3_server_method
+    Debug1("SSLv3_server_method() -> %p", result);
+    return result;
+ }
++#endif
+ 
+ const SSL_METHOD *sycSSLv23_client_method(void) {
+    const SSL_METHOD *result;
+@@ -331,14 +335,6 @@ void sycSSL_free(SSL *ssl) {
+    return;
+ }
+ 
+-int sycRAND_egd(const char *path) {
+-   int result;
+-   Debug1("RAND_egd(\"%s\")", path);
+-   result = RAND_egd(path);
+-   Debug1("RAND_egd() -> %d", result);
+-   return result;
+-}
+-
+ DH *sycPEM_read_bio_DHparams(BIO *bp, DH **x, pem_password_cb *cb, void *u) {
+    DH *result;
+    Debug4("PEM_read_bio_DHparams(%p, %p, %p, %p)",
+@@ -375,7 +371,7 @@ int sycFIPS_mode_set(int onoff) {
+ }
+ #endif /* WITH_FIPS */
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x00908000L
++#if (OPENSSL_VERSION_NUMBER >= 0x00908000L) && !defined(OPENSSL_NO_COMP)
+ const COMP_METHOD *sycSSL_get_current_compression(SSL *ssl) {
+    const COMP_METHOD *result;
+    Debug1("SSL_get_current_compression(%p)", ssl);
+--- a/sslcls.h
++++ b/sslcls.h
+@@ -47,7 +47,6 @@ X509 *sycSSL_get_peer_certificate(SSL *s
+ int sycSSL_shutdown(SSL *ssl);
+ void sycSSL_CTX_free(SSL_CTX *ctx);
+ void sycSSL_free(SSL *ssl);
+-int sycRAND_egd(const char *path);
+ 
+ DH *sycPEM_read_bio_DHparams(BIO *bp, DH **x, pem_password_cb *cb, void *u);
+ 
+@@ -55,7 +54,7 @@ BIO *sycBIO_new_file(const char *filenam
+ 
+ int sycFIPS_mode_set(int onoff);
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x00908000L
++#if (OPENSSL_VERSION_NUMBER >= 0x00908000L) && !defined(OPENSSL_NO_COMP)
+ const COMP_METHOD *sycSSL_get_current_compression(SSL *ssl);
+ const COMP_METHOD *sycSSL_get_current_expansion(SSL *ssl);
+ const char *sycSSL_COMP_get_name(const COMP_METHOD *comp);
+@@ -98,7 +97,6 @@ const char *sycSSL_COMP_get_name(const C
+ #define sycSSL_shutdown(s) SSL_shutdown(s)
+ #define sycSSL_CTX_free(c) SSL_CTX_free(c)
+ #define sycSSL_free(s) SSL_free(s)
+-#define sycRAND_egd(p) RAND_egd(p)
+ 
+ #define sycPEM_read_bio_DHparams(b,x,p,u) PEM_read_bio_DHparams(b,x,p,u)
+ 
+--- a/test.sh
++++ b/test.sh
+@@ -576,9 +576,6 @@ filloptionvalues() {
+     *,dh,*) OPTS=$(echo "$OPTS" |sed "s/,dh,/,dh=/tmp/hugo,/g");;
+     esac
+     case "$OPTS" in
+-    *,egd,*) OPTS=$(echo "$OPTS" |sed "s/,egd,/,egd=/tmp/hugo,/g");;
+-    esac
+-    case "$OPTS" in
+     *,compress,*) OPTS=$(echo "$OPTS" |sed "s/,compress,/,compress=none,/g");;
+     esac
+     # PROXY
+--- a/xio-openssl.c
++++ b/xio-openssl.c
+@@ -108,7 +108,6 @@ const struct optdesc opt_openssl_key
+ const struct optdesc opt_openssl_dhparam     = { "openssl-dhparam",     "dh",    OPT_OPENSSL_DHPARAM,     GROUP_OPENSSL, PH_SPEC, TYPE_FILENAME, OFUNC_SPEC };
+ const struct optdesc opt_openssl_cafile      = { "openssl-cafile",     "cafile", OPT_OPENSSL_CAFILE,      GROUP_OPENSSL, PH_SPEC, TYPE_FILENAME, OFUNC_SPEC };
+ const struct optdesc opt_openssl_capath      = { "openssl-capath",     "capath", OPT_OPENSSL_CAPATH,      GROUP_OPENSSL, PH_SPEC, TYPE_FILENAME, OFUNC_SPEC };
+-const struct optdesc opt_openssl_egd         = { "openssl-egd",        "egd",    OPT_OPENSSL_EGD,         GROUP_OPENSSL, PH_SPEC, TYPE_FILENAME, OFUNC_SPEC };
+ const struct optdesc opt_openssl_pseudo      = { "openssl-pseudo",     "pseudo", OPT_OPENSSL_PSEUDO,      GROUP_OPENSSL, PH_SPEC, TYPE_BOOL,     OFUNC_SPEC };
+ #if OPENSSL_VERSION_NUMBER >= 0x00908000L
+ const struct optdesc opt_openssl_compress    = { "openssl-compress",   "compress", OPT_OPENSSL_COMPRESS,  GROUP_OPENSSL, PH_SPEC, TYPE_STRING,   OFUNC_SPEC };
+@@ -147,7 +146,7 @@ int xio_reset_fips_mode(void) {
+ static void openssl_conn_loginfo(SSL *ssl) {
+    Notice1("SSL connection using %s", SSL_get_cipher(ssl));
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x00908000L
++#if (OPENSSL_VERSION_NUMBER >= 0x00908000L) && !defined(OPENSSL_NO_COMP)
+    {
+       const COMP_METHOD *comp, *expansion;
+ 
+@@ -722,7 +721,6 @@ int
+    char *opt_dhparam = NULL;	/* file name of DH params */
+    char *opt_cafile = NULL;	/* certificate authority file */
+    char *opt_capath = NULL;	/* certificate authority directory */
+-   char *opt_egd = NULL;	/* entropy gathering daemon socket path */
+ #if OPENSSL_VERSION_NUMBER >= 0x00908000L
+    char *opt_compress = NULL;	/* compression method */
+ #endif
+@@ -741,7 +739,6 @@ int
+    retropt_string(opts, OPT_OPENSSL_CAPATH, &opt_capath);
+    retropt_string(opts, OPT_OPENSSL_KEY, &opt_key);
+    retropt_string(opts, OPT_OPENSSL_DHPARAM, &opt_dhparam);
+-   retropt_string(opts, OPT_OPENSSL_EGD, &opt_egd);
+    retropt_bool(opts,OPT_OPENSSL_PSEUDO, &opt_pseudo);
+ #if OPENSSL_VERSION_NUMBER >= 0x00908000L
+    retropt_string(opts, OPT_OPENSSL_COMPRESS, &opt_compress);
+@@ -877,10 +874,6 @@ int
+       }
+    }
+ 
+-   if (opt_egd) {
+-      sycRAND_egd(opt_egd);
+-   }
+-
+    if (opt_pseudo) {
+       long int randdata;
+       /* initialize libc random from actual microseconds */
+@@ -1105,7 +1098,7 @@ static int openssl_SSL_ERROR_SSL(int lev
+       if (e == ((ERR_LIB_RAND<<24)|
+ 		(RAND_F_SSLEAY_RAND_BYTES<<12)|
+ 		(RAND_R_PRNG_NOT_SEEDED)) /*0x24064064*/) {
+-	 Error("too few entropy; use options \"egd\" or \"pseudo\"");
++	 Error("too few entropy; use option \"pseudo\"");
+ 	 stat = STAT_NORETRY;
+       } else {
+ 	 Msg2(level, "%s(): %s", funcname, ERR_error_string(e, buf));
+--- a/xio-openssl.h
++++ b/xio-openssl.h
+@@ -21,7 +21,6 @@ extern const struct optdesc opt_openssl_
+ extern const struct optdesc opt_openssl_dhparam;
+ extern const struct optdesc opt_openssl_cafile;
+ extern const struct optdesc opt_openssl_capath;
+-extern const struct optdesc opt_openssl_egd;
+ extern const struct optdesc opt_openssl_pseudo;
+ #if OPENSSL_VERSION_NUMBER >= 0x00908000L
+ extern const struct optdesc opt_openssl_compress;
+--- a/xioopts.c
++++ b/xioopts.c
+@@ -412,7 +412,6 @@ const struct optname optionnames[] = {
+ #ifdef ECHOPRT
+ 	IF_TERMIOS("echoprt",	&opt_echoprt)
+ #endif
+-	IF_OPENSSL("egd",	&opt_openssl_egd)
+ 	IF_ANY    ("end-close",	&opt_end_close)
+ 	IF_TERMIOS("eof",	&opt_veof)
+ 	IF_TERMIOS("eol",	&opt_veol)
+@@ -1102,7 +1101,6 @@ const struct optname optionnames[] = {
+ 	IF_OPENSSL("openssl-compress",	&opt_openssl_compress)
+ #endif
+ 	IF_OPENSSL("openssl-dhparam",	&opt_openssl_dhparam)
+-	IF_OPENSSL("openssl-egd",	&opt_openssl_egd)
+ #if WITH_FIPS
+ 	IF_OPENSSL("openssl-fips",	&opt_openssl_fips)
+ #endif
+--- a/xioopts.h
++++ b/xioopts.h
+@@ -478,7 +478,6 @@ enum e_optcode {
+    OPT_OPENSSL_COMPRESS,
+ #endif
+    OPT_OPENSSL_DHPARAM,
+-   OPT_OPENSSL_EGD,
+    OPT_OPENSSL_FIPS,
+    OPT_OPENSSL_KEY,
+    OPT_OPENSSL_METHOD,


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: Kirkwood, iomega iConnect, LEDE trunk
Run tested: N/A

Description:

Update to 1.7.3.1
Fix SSL builds
Source: http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/net/socat/patches/#dirlist

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>