### PR TITLE
chrony: update to 3.0

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
-PKG_VERSION:=2.4.1
-PKG_RELEASE:=2
+PKG_VERSION:=3.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.tuxfamily.org/chrony/
-PKG_MD5SUM:=d08dd5a7d79a89891d119adcccb4397d
+PKG_HASH:=a0387b91a20f047856a56d6541a1cf920c91b53b32f74c123bcb70f1a5d2cd6d
 
 PKG_MAINTAINER:=Miroslav Lichvar <mlichvar0@gmail.com>
 PKG_LICENSE:=GPL-2.0
@@ -50,7 +50,7 @@ CONFIGURE_ARGS+= \
 	--host-system=Linux \
 	--sysconfdir=/etc/chrony \
 	--prefix=/usr \
-	--chronysockdir=/var/run/chrony \
+	--chronyrundir=/var/run/chrony \
 	--disable-readline \
 	--disable-rtc \
 	--with-user=chrony


### PR DESCRIPTION
Maintainer: me
Compile tested: mips, ar9344 (wdr3600), lede HEAD
Run tested: mips, ar9344 (wdr3600), lede HEAD, runs as an NTP client and public NTP server