### PR TITLE
micropython-lib: workaround the `install` build rule

### DIFF
--- a/lang/micropython-lib/Makefile
+++ b/lang/micropython-lib/Makefile
@@ -42,13 +42,12 @@ define Package/micropython-lib/description
 endef
 
 MAKE_FLAGS:=\
-	-C $(PKG_BUILD_DIR) \
-	PREFIX=$(PKG_BUILD_DIR)/_install_tmp \
+	PREFIX=$(PKG_BUILD_DIR)/_install_tmp/dist \
 	install
 
 define Package/micropython-lib/install
 	$(INSTALL_DIR) $(1)/usr/lib/micropython
-	$(CP) $(PKG_BUILD_DIR)/_install_tmp/* $(1)/usr/lib/micropython
+	$(CP) $(PKG_BUILD_DIR)/_install_tmp/dist/* $(1)/usr/lib/micropython
 endef
 
 $(eval $(call BuildPackage,micropython-lib))


### PR DESCRIPTION
Maintainer: @roger- 
Compile tested: lede-project/source@c1b12aa ar71x
Run tested: N/A

-------------------------------

So, I chose to workaround it in the Makefile.
A proper fix is a bit more work that I would like to do now,
and I have no suggestion/idea for a good fix right now.

The problem is with the `CMD` part that's used in the install rule,
together with the fact that PREFIX is the same as the source location.

```
CMD="find . -maxdepth 1 -mindepth 1 \( -name '*.py' -not -name 'test_*' -not -name 'setup.py' \) -or \( -type d -not -name 'dist' -not -name '*.egg-info' -not -name '__pycache__' \)| xargs --no-run-if-empty cp -r -t $(PREFIX)"
```

The gist of it, is that it seems that this will filter
and copy to `PREFIX` all python sources and folders that
are not names `dist`, `__pycache__`, or `*.egg-info`.
And it searches all folders at (exactly) depth 1.

The solution I chose is to put a `dist` folder under
`_install_tmp`, which is kind of a trick to go
to depth 2 and avoid both conditions in the `find` call.

This avoids errors:
```
cp: './weakref.py' and '/home/sandu/work/lede/build_dir/target-mips_24kc_musl-1.1.16/micropython-lib-1.8.6-f81e979c56dddb771ad36ec381b7f2c6cd12111f-f81e979c56dddb771ad36ec381b7f2c6cd12111f/_install_tmp/weakref.py' are the same file
cp: './xmltok.py' and '/home/sandu/work/lede/build_dir/target-mips_24kc_musl-1.1.16/micropython-lib-1.8.6-f81e979c56dddb771ad36ec381b7f2c6cd12111f-f81e979c56dddb771ad36ec381b7f2c6cd12111f/_install_tmp/xmltok.py' are the same file
cp: './zipfile.py' and '/home/sandu/work/lede/build_dir/target-mips_24kc_musl-1.1.16/micropython-lib-1.8.6-f81e979c56dddb771ad36ec381b7f2c6cd12111f-f81e979c56dddb771ad36ec381b7f2c6cd12111f/_install_tmp/zipfile.py' are the same file
```

Initially I tried to add exit 0 (https://github.com/openwrt/packages/pull/3810), but that would
just hide other (potentially worse) issues.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>