### PR TITLE
socat: work around missing stddef.h include

### DIFF
--- a/net/socat/Makefile
+++ b/net/socat/Makefile
@@ -69,6 +69,9 @@ CONFIGURE_VARS += \
 	sc_cv_sys_tabdly_shift=11 \
 	sc_cv_sys_csize_shift=4
 
+TARGET_CFLAGS += \
+	-include stddef.h
+
 define Package/socat/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/socat $(1)/usr/bin/


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: LEDE SDK arm_cortex-a15_neon-vfpv4 / r2993-b9a408c
Run tested: -

Description:

The buildbots fail to build socat due to the following error:

    nestlex.c:14:7: error: unknown type name 'ptrdiff_t'

It appears that certain source files do not include all required headers,
depending on the configure options passed to socat.

Work around the error by passing `-include stddef.h` via `TARGET_CFLAGS` to
forcibly inject this header file into all compilation units.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>
