### PR TITLE
mosquitto: fix provides <=> package name conflicts

### DIFF
--- a/net/mosquitto/Config.in
+++ b/net/mosquitto/Config.in
@@ -1,13 +1,13 @@
 config MOSQUITTO_LWS
     bool "libwebsockets support"
-    depends on PACKAGE_mosquitto
+    depends on PACKAGE_mosquitto-ssl
     default y
     help
         Includes websockets support in the broker, via libwebsockets
 
 config MOSQUITTO_PASSWD
     bool "Include mosquitto_passwd utility"
-    depends on PACKAGE_mosquitto
+    depends on PACKAGE_mosquitto-ssl
     default y
     help
         mosquitto_passwd is a tool for managing password files for mosquitto.

--- a/net/mosquitto/Makefile
+++ b/net/mosquitto/Makefile
@@ -21,7 +21,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSI
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/$(PKG_NAME)/default
+define Package/mosquitto/default
   SECTION:=net
   CATEGORY:=Network
   TITLE:=mosquitto - an MQTT message broker
@@ -31,7 +31,7 @@ define Package/$(PKG_NAME)/default
   USERID:=mosquitto=200:mosquitto=200
 endef
 
-define Package/$(PKG_NAME)
+define Package/mosquitto-ssl
     $(call Package/mosquitto/default)
     TITLE+= (with SSL support)
     DEPENDS+= +libopenssl +MOSQUITTO_LWS:libwebsockets-openssl
@@ -39,18 +39,18 @@ define Package/$(PKG_NAME)
     PROVIDES:=mosquitto
 endef
 
-define Package/$(PKG_NAME)-nossl
-    $(call Package/$(PKG_NAME)/default)
+define Package/mosquitto-nossl
+    $(call Package/mosquitto/default)
     TITLE+= (without SSL support)
     VARIANT:=nossl
     PROVIDES:=mosquitto
 endef
 
-define Package/$(PKG_NAME)/config
+define Package/mosquitto-ssl/config
 	source "$(SOURCE)/Config.in"
 endef
 
-define Package/$(PKG_NAME)/default/description
+define Package/mosquitto/default/description
 Mosquitto is an open source (BSD licensed) message broker that implements
 the MQTT protocol version 3.1 and 3.1.1. MQTT provides a lightweight
 method of carrying out messaging using a publish/subscribe model.
@@ -58,13 +58,13 @@ method of carrying out messaging using a publish/subscribe model.
 This package also includes some basic support for configuring via UCI
 endef
 
-define Package/$(PKG_NAME)/description
-	$(call Package/$(PKG_NAME)/default/description)
+define Package/mosquitto-ssl/description
+	$(call Package/mosquitto/default/description)
 	This package is built with SSL support
 endef
 
-define Package/$(PKG_NAME)-nossl/description
-        $(call Package/$(PKG_NAME)/default/description)
+define Package/mosquitto-nossl/description
+        $(call Package/mosquitto/default/description)
         This package is built WITHOUT SSL support.
 endef
 
@@ -77,7 +77,7 @@ endef
 define Package/mosquitto-client
     $(call Package/mosquitto-client/default)
     TITLE+= (With SSL support)
-    DEPENDS+=+libmosquitto
+    DEPENDS+=+libmosquitto-ssl
     VARIANT:=ssl
 endef
 define Package/mosquitto-client-nossl
@@ -110,7 +110,7 @@ define Package/libmosquitto/default
     PROVIDES:=libmosquitto
 endef
 
-define Package/libmosquitto
+define Package/libmosquitto-ssl
     $(call Package/libmosquitto/default)
     TITLE+= (With SSL Support)
     DEPENDS+= +libopenssl
@@ -131,7 +131,7 @@ Should be useable for communicating with any MQTT v3.1/3.1.1 compatible
 server, such as IBM's RSMB, in addition to Mosquitto
 endef
 
-define Package/libmosquitto/description
+define Package/libmosquitto-ssl/description
     $(call Package/libmosquitto/default/description)
     This package is built with SSL support
 endef
@@ -143,7 +143,7 @@ endef
 define Package/libmosquittopp
     SECTION:=libs
     CATEGORY:=Libraries
-    DEPENDS:=+libmosquitto +libstdcpp
+    DEPENDS:=+libmosquitto-ssl +libstdcpp
     TITLE:= mosquitto - client c++ library
 endef
 
@@ -151,12 +151,12 @@ define Package/libmosquittopp/description
  C++ Library wrapper for libmosquitto.
 endef
 
-define Package/$(PKG_NAME)/conffiles
+define Package/mosquitto-ssl/conffiles
 /etc/mosquitto/mosquitto.conf
 /etc/config/mosquitto
 endef
 
-Package/$(PKG_NAME)-nossl/conffiles = $(Package/$(PKG_NAME)/conffiles)
+Package/mosquitto-nossl/conffiles = $(Package/mosquitto-ssl/conffiles)
 
 define Package/mosquitto/install/default
 	$(INSTALL_DIR) $(1)/usr/sbin
@@ -170,7 +170,7 @@ define Package/mosquitto-nossl/install
 	$(call Package/mosquitto/install/default,$(1))
 endef
 
-define Package/mosquitto/install
+define Package/mosquitto-ssl/install
 	$(call Package/mosquitto/install/default,$(1))
 ifeq ($(CONFIG_MOSQUITTO_PASSWD),y)
 	$(INSTALL_DIR) $(1)/usr/bin
@@ -198,12 +198,12 @@ define Build/InstallDev
 endef
 
 # This installs files on the target.  Compare with Build/InstallDev
-define Package/libmosquitto/install
+define Package/libmosquitto-ssl/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/libmosquitto.so.1 $(1)/usr/lib/
 	$(LN) libmosquitto.so.1 $(1)/usr/lib/libmosquitto.so
 endef
-Package/libmosquitto-nossl/install = $(Package/libmosquitto/install)
+Package/libmosquitto-nossl/install = $(Package/libmosquitto-ssl/install)
 
 define Package/libmosquittopp/install
 	$(INSTALL_DIR) $(1)/usr/lib
@@ -219,9 +219,9 @@ else
 	MAKE_FLAGS += WITH_WEBSOCKETS=$(if $(CONFIG_MOSQUITTO_LWS),"yes","no")
 endif
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
-$(eval $(call BuildPackage,$(PKG_NAME)-nossl))
-$(eval $(call BuildPackage,libmosquitto))
+$(eval $(call BuildPackage,mosquitto-ssl))
+$(eval $(call BuildPackage,mosquitto-nossl))
+$(eval $(call BuildPackage,libmosquitto-ssl))
 $(eval $(call BuildPackage,libmosquitto-nossl))
 $(eval $(call BuildPackage,libmosquittopp))
 $(eval $(call BuildPackage,mosquitto-client))


### PR DESCRIPTION
Maintainer: @karlp 
Compile tested: LEDE SDK arm_cortex-a15_neon-vfpv4 / r2993-b9a408c
Run tested: -

Description:

The virtual package declared by PROVIDES must not have the same name as the
variant declaring it, otherwise buildroot will fail with errors like:

    cp: '.../pkginfo/mosquitto.provides' and '.../pkginfo/mosquitto.provides' are the same file

In order to fix the above error, rename the existing "mosquitto" and
"libmosquitto" packages into "mosquitto-ssl" and "libmosquitto-ssl"
respectively.

Also substitute use of $(PKG_NAME) with literal "mosquitto" in
Package/* defines to improve readability of the Makefile.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>
