### PR TITLE
libvpx: bump to 1.6.1 (maybe also for lede-17.01)

### DIFF
--- a/libs/libvpx/Makefile
+++ b/libs/libvpx/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libvpx
-PKG_VERSION:=1.6.0
+PKG_VERSION:=1.6.1
 PKG_RELEASE:=1
 
 PKG_REV:=v$(PKG_VERSION)
@@ -24,6 +24,8 @@ PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
+PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))
+
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -34,7 +36,7 @@ define Package/libvpx
   TITLE:=libvpx
   URL:=http://www.webmproject.org/
   DEPENDS:=+libpthread
-  ABI_VERSION:=$(PKG_VERSION)
+  ABI_VERSION:=$(PKG_ABI_VERSION)
 endef
 
 define Package/libvpx/description


### PR DESCRIPTION
v1.6.1:
- Faster VP9 encoding and decoding
- Bug Fixes

Now the ABI_VERSION is derived from PKG_VERSION. The result is that ABI version on libvpx.ipk will change from 1.6.0 to 1.6

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me 
Compile tested: x86, ramips, ar71xx on LEDE r3012-0d1b329 
Run tested: x86 with:
- openwrt# cd /www; gst-launch-1.0 videotestsrc is-live=true ! vp8enc ! webmmux streamable=true ! hlssink max-files=5
- pc$ gst-play-1.0 playbin http://192.168.1.1/playlist.m3u8

This update is a good candidate to be backported to lede-17.01 as it includes only performance improvements and bugfixes (and keeps ABI compatibility)