### PR TITLE
perl-www-curl: fix build against curl >= 7.50

### DIFF
--- a/lang/perl-www-curl/patches/101-skip-preprocessor-symbol.path
+++ b/lang/perl-www-curl/patches/101-skip-preprocessor-symbol.path
@@ -1,0 +1,34 @@
+From 0be0223422e6e5f4091c6e4e058d213623eed105 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20P=C3=ADsa=C5=99?= <ppisar@redhat.com>
+Date: Mon, 12 Sep 2016 14:40:44 +0200
+Subject: [PATCH] Skip preprocessor symbol only CURL_STRICTER
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CURL_STRICTER leaked into curl-constants.c when building against
+curl-7.50.2. This is a preprocessor only macro without a value.
+
+CPAN RT#117793
+
+Signed-off-by: Petr Písař <ppisar@redhat.com>
+---
+ Makefile.PL | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.PL b/Makefile.PL
+index f9170bb..ad2bd3d 100644
+--- a/Makefile.PL
++++ b/Makefile.PL
+@@ -127,7 +127,7 @@ if (!defined($curl_h)) {
+     close H;
+ 
+     for my $e (sort @syms) {
+-       if($e =~ /(OBSOLETE|^CURL_EXTERN|_LAST\z|_LASTENTRY\z)/) {
++       if($e =~ /(OBSOLETE|^CURL_EXTERN|^CURL_STRICTER\z|_LAST\z|_LASTENTRY\z)/) {
+           next;
+        }
+        my ($group) = $e =~ m/^([^_]+_)/;
+-- 
+2.7.4
+


### PR DESCRIPTION
Maintainer: @Naoir 
Compile tested: LEDE SDK cns3xxx/generic, r3012-0d1b329
Run tested: -

Description:

Import a proposed upstream bug fix to allow building against recent curl
versions. Fixes the following error observed by the buildbots:

    curlopt-constants.c:129:49: error: 'CURL_STRICTER' undeclared (first use in this function)
                 if (strEQ(name, "STRICTER")) return CURL_STRICTER;

Upstream bug: https://rt.cpan.org/Public/Bug/Display.html?id=117793

Signed-off-by: Jo-Philipp Wich <jo@mein.io>
