### PR TITLE
nail: fix build against OpenSSL with disabled SSLv3

### DIFF
--- a/mail/nail/Makefile
+++ b/mail/nail/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nail
 PKG_VERSION:=12.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=BSD-2-Clause
 
 PKG_SOURCE:=heirloom-mailx_$(PKG_VERSION).orig.tar.gz

--- a/mail/nail/patches/100-handle-openssl-without-sslv2-sslv3.patch
+++ b/mail/nail/patches/100-handle-openssl-without-sslv2-sslv3.patch
@@ -1,6 +1,6 @@
 --- a/openssl.c
 +++ b/openssl.c
-@@ -216,9 +216,12 @@ ssl_select_method(const char *uhp)
+@@ -216,11 +216,17 @@ ssl_select_method(const char *uhp)
  
  	cp = ssl_method_string(uhp);
  	if (cp != NULL) {
@@ -10,7 +10,13 @@
 -		else if (equal(cp, "ssl3"))
 +		else
 +#endif
++#ifndef OPENSSL_NO_SSL3
 +		if (equal(cp, "ssl3"))
  			method = SSLv3_client_method();
- 		else if (equal(cp, "tls1"))
+-		else if (equal(cp, "tls1"))
++		else
++#endif
++		if (equal(cp, "tls1"))
  			method = TLSv1_client_method();
+ 		else {
+ 			fprintf(stderr, catgets(catd, CATSET, 244,


### PR DESCRIPTION
Maintainer: @pfzim  
Compile tested: LEDE SDK cns3xxx/generic, r3012-0d1b329
Run tested: -

Description:

Extend the existing patch handling disabled SSLv2 to cover the SSLv3 case as
well in order to fix the following build error reported by the buildbot:

    openssl.o: In function `ssl_open':
    openssl.c:(.text+0xa1c): undefined reference to `SSLv3_client_method'
    collect2: error: ld returned 1 exit status

Signed-off-by: Jo-Philipp Wich <jo@mein.io>
