### PR TITLE
loudmouth: fix autoconf errors

### DIFF
--- a/libs/loudmouth/Makefile
+++ b/libs/loudmouth/Makefile
@@ -43,11 +43,6 @@ endef
 CONFIGURE_ARGS += \
 	--with-ssl=openssl
 
-define Build/Configure
-	( cd $(PKG_BUILD_DIR); ./autogen.sh )
-	$(call Build/Configure/Default)
-endef
-
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/
 	$(CP) \

--- a/libs/loudmouth/patches/900-disable-docs-examples-tests.patch
+++ b/libs/loudmouth/patches/900-disable-docs-examples-tests.patch
@@ -1,0 +1,27 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,7 +1,7 @@
+ include $(top_srcdir)/build/Makefile.am.lm
+ 
+-SUBDIRS = loudmouth docs examples $(TEST_DIRS)
+-DIST_SUBDIRS = loudmouth docs examples tests
++SUBDIRS = loudmouth
++DIST_SUBDIRS = loudmouth
+ 
+ ACLOCAL_AMFLAGS = -I m4
+ 
+--- a/configure.ac
++++ b/configure.ac
+@@ -307,12 +307,7 @@ AC_SUBST(LOUDMOUTH_LIBS)
+ 
+ AC_OUTPUT([
+ Makefile
+-docs/Makefile
+-docs/reference/Makefile
+ loudmouth/Makefile
+-examples/Makefile
+-tests/Makefile
+-tests/parser-tests/Makefile
+ loudmouth-1.0.pc])
+ 
+ dnl ==========================================================================


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: LEDE SDK cns3xxx/generic, r3012-0d1b329
Run tested: -

Description:

Do not override configure recipe and do not invoke upstream autogen.sh.
The shipped autogen.sh attempts to call "gtkdocize" which is no guaranteed
build prereq of LEDE or OpenWrt.

Also add a patch to disable the processing of documentation, tests and
examples as these resources rely on gtk-doc infrastructure which is not
available within LEDE or OpenWrt.

Example error for the bad autogen.sh invocation:

    ( cd .../loudmouth-1.5.3; ./autogen.sh )
    ./autogen.sh: 33: ./autogen.sh: gtkdocize: not found
    Makefile:73: recipe for target '.../.configured_yynyyyyn' failed

Example error for the lacking gtk-doc automake infrastructure:

    automake: error: cannot open < gtk-doc.make: No such file or directory
    autoreconf: .../host/bin/automake failed with exit status: 1
    [...]
    config.status: error: cannot find input file: `docs/reference/Makefile.in'
    Makefile:72: recipe for target '.../.configured_yynyn' failed

Signed-off-by: Jo-Philipp Wich <jo@mein.io>