### PR TITLE
Syslog-ng parallel build

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -10,6 +10,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/balabit/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 PKG_MD5SUM:=acf14563cf5ce435db8db35486ce66af
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, generic, OpenWRT head
Run tested: same

Did `make clean` to reset state.  Then did (or an 8-core VM) `make -j4`, `make -j5`, and `make -j8` to see if the build would fail or yield funky results.  All builds were successful.

Description:

Do parallel builds whenever possible so the buildbots aren't wasting cycles.