### PR TITLE
syslog-ng: add file to contain customization for projects/custom builds

### DIFF
--- a/admin/syslog-ng/files/custom-logs.conf
+++ b/admin/syslog-ng/files/custom-logs.conf
@@ -1,0 +1,2 @@
+# place to put customization of logging
+

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -35,3 +35,6 @@ log {
         source(kernel);
 	destination(messages);
 };
+
+@include "/etc/custom-logs.conf"
+


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, generic, OpenWRT head
Run tested: same

Built and re-burned flash, rebooted.

Worked fine.

Created `$(topdir)/files/etc/custom-logs.conf` file and added more directives:

```
destination authlog {
        file("/var/log/auth.log");
};

filter auth {
        facility(auth);
};

log {
        source(src);
        filter(auth);
        destination(authlog);
};
```

used `logger` to generate auth messages, and they appeared in desired log.

Description:

With more interest in syslog-ng, it's been updated to latest and people are using it.

With use comes fixes and improvements, which is causing the `/etc/syslog-ng.conf` file to churn.

If people put their changes there (via a `files/etc/syslog-ng.conf` override), they won't pick up those fixes.  Therefore, give them a better place to put their customizations.

If they don't use it, it's one inode and one disk block... so no harm done.
