### PR TITLE
knxd: bump to new version

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2016 OpenWrt.org
+# Copyright (C) 2008-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -11,12 +11,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
-PKG_VERSION=2016-10-08
+PKG_VERSION=2017-01-18
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/knxd/knxd.git
-PKG_SOURCE_VERSION:=43e90c6ee3028194c8ce6d7776e7dedbe1032dc1
+PKG_SOURCE_VERSION:=8255bf08b6e1a972c1489012b570bf0ff8679cb0
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz
 
@@ -38,7 +38,7 @@ define Package/knxd
   SECTION:=net
   CATEGORY:=Network
   TITLE:=EIB KNX daemon
-  DEPENDS:=+pthsem +libusb-1.0
+  DEPENDS:=+libusb-1.0 +libstdcpp +libev
 endef
 
 define Package/knxd/description
@@ -53,30 +53,24 @@ define Package/knxd-tools
   SECTION:=net
   CATEGORY:=Network
   TITLE:=EIB KNX Utils
+  DEPENDS:=+libstdcpp +libev
 endef
 
 define Package/knxd-tools/description
 EIB KNX Tools
 endef
 
-TARGET_CXXFLAGS+= -fno-rtti
+TARGET_CXXFLAGS+= -std=c++0x
 TARGET_CXX=$(TARGET_CC)
 
 CONFIGURE_ARGS+= \
-	--disable-ft12 \
 	--enable-eibnetip \
 	--enable-eibnetiptunnel \
 	--enable-eibnetipserver \
-	--enable-usb \
-	--enable-tpuarts \
-	--disable-pei16s \
-	--enable-groupcache \
-	--without-pth-test \
-	--disable-systemd \
-	--without-libstdc
+	--disable-systemd
 
 EXTRA_LDFLAGS+= \
-       -fno-builtin -largp
+	-largp -lstdc++
 
 define Package/knxd/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/net/knxd/files/knxd.config
+++ b/net/knxd/files/knxd.config
@@ -9,16 +9,18 @@ config daemon args
 	option Discovery 1
 	# EIBADDR set our EIB address to EIBADDR (default 0.0.1)
 	option eibaddr "0.0.1"
+	# CLIENT-ADDRS assign addresses ADDRSTART through ADDRSTART+n
+	option client-addrs "0.0.2:10"
 	# LEVEL set error level
 	option error 0
 	# PORT listen at TCP port PORT (default 6720)
 	option listen_tcp "6720"
-	# wait for L_Data_ind while sending (for all EMI based backends)
-	option no_emisend_queuing 0
+	# Interface to use
+	option Interface ""
+	# wait while sending
+	option send-delay ""
 	# SERVERNAME name of the EIBnet/IP server (default is 'knxd')
 	option Name "OpenWrt"
-	# do not assume KNXnet/IP Tunneling bus interface can handle parallel cEMI requests
-	option no_tunnel_client_queuing 0
 	# the next Layer2 interface may not enter monitor mode
 	option no_monitor 0
 	# enable EIBnet/IP Routing in the EIBnet/IP server

--- a/net/knxd/files/knxd.init
+++ b/net/knxd/files/knxd.init
@@ -33,15 +33,16 @@ start_service() {
 	local options url
 	config_load knxd
 	append_parm args eibaddr "eibaddr" "0.0.1"
+	append_parm args client-addrs "client-addrs" "0.0.2:10"
 	append_parm args layer2 "layer2"
 	append_bool args GroupCache "GroupCache" 0
 	append_parm args daemon "daemon" "/var/log/knxd.log"
 	append_bool args Discovery "Discovery" 1
 	append_parm args error "error" # "5"
 	append_parm args listen_tcp "listen-tcp" "6720"
-	append_bool args no_emisend_queuing "no-emisend-queuing" 0
+	append_parm args Interface "Interface" # "eth0"
+	append_parm args send-delay "send-delay" # "50"
 	append_parm args Name "Name" "OpenWrt"
-	append_bool args no_tunnel_client_queuing "no-tunnel-client-queuing" 0
 	append_bool args no_monitor "no-monitor" 0
 	append_bool args Routing "Routing" 0
 	append_parm args trace "trace" # "7"


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWRT trunk
Run tested: ar71xx, WNDR3700, OpenWRT trunk

Description:
- first version based on libev instead of pthsem, needs libstdcpp
- changed command line parameters, config and init script

Signed-off-by: Othmar Truniger <github@truniger.ch>
