### PR TITLE
ffmpeg: BUILD_PATENTED and libffmpeg-custom corrections

### DIFF
--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -1,4 +1,5 @@
-if PACKAGE_libffmpeg-custom
+menu "Libffmpeg-custom configuration"
+	depends on PACKAGE_libffmpeg-custom
 
 config FFMPEG_CUSTOM_PATENTED
 	bool "Include patented codecs and technologies"
@@ -108,7 +109,6 @@ comment "External Libraries"
 config FFMPEG_CUSTOM_SELECT_mp3lame
 	bool "MP3 LAME"
 	depends on FFMPEG_CUSTOM_PATENTED
-	depends on PACKAGE_lame-lib
 	select FFMPEG_CUSTOM_DECODER_mp3
 	select FFMPEG_CUSTOM_MUXER_mp3
 	select FFMPEG_CUSTOM_DEMUXER_mp3
@@ -119,7 +119,6 @@ config FFMPEG_CUSTOM_SELECT_libopus
 config FFMPEG_CUSTOM_SELECT_x264
 	bool "x264"
 	depends on FFMPEG_CUSTOM_PATENTED
-	depends on PACKAGE_libx264
 	select FFMPEG_CUSTOM_DECODER_h264
 	select FFMPEG_CUSTOM_MUXER_h264
 	select FFMPEG_CUSTOM_DEMUXER_h264
@@ -470,4 +469,4 @@ config FFMPEG_CUSTOM_PROTOCOL_udp
 	bool "udp:"
 
 
-endif
+endmenu

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -285,7 +285,7 @@ $(call Package/ffmpeg/Default)
  SECTION:=libs
  CATEGORY:=Libraries
  TITLE+= libraries
- DEPENDS+= @BUILD_PATENTED +libpthread +zlib +libbz2
+ DEPENDS+= +libpthread +zlib +libbz2
  PROVIDES:= libffmpeg
 endef
 
@@ -294,7 +294,8 @@ define Package/libffmpeg-custom
 $(call Package/libffmpeg/Default)
  TITLE+= (custom)
  DEPENDS+= +FFMPEG_CUSTOM_SELECT_libopus:libopus \
-           +PACKAGE_libx264:libx264 +PACKAGE_lame-lib:lame-lib
+           +FFMPEG_CUSTOM_SELECT_x264:libx264 \
+           +FFMPEG_CUSTOM_SELECT_mp3lame:lame-lib
 
  VARIANT:=custom
  MENU:=1
@@ -314,6 +315,7 @@ endef
 define Package/libffmpeg-audio-dec
 $(call Package/libffmpeg/Default)
  TITLE+= (audio)
+ DEPENDS+= @BUILD_PATENTED
  VARIANT:=audio-dec
 endef
 
@@ -327,7 +329,7 @@ endef
 define Package/libffmpeg-full
 $(call Package/libffmpeg/Default)
  TITLE+= (full)
- DEPENDS+= +alsa-lib +PACKAGE_libx264:libx264 +PACKAGE_lame-lib:lame-lib +libopus
+ DEPENDS+= @BUILD_PATENTED +alsa-lib +PACKAGE_libx264:libx264 +PACKAGE_lame-lib:lame-lib +libopus
  VARIANT:=full
 endef
 
@@ -341,6 +343,7 @@ endef
 define Package/libffmpeg-mini
 $(call Package/libffmpeg/Default)
  TITLE+= (mini)
+ DEPENDS+= @BUILD_PATENTED
  VARIANT:=mini
 endef
 


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: mips/ar71xx - OpenWrt
Run tested: none

Description: Clean ups on libffmpeg-custom

For BUILD_PATENTED, setting it for all libffmpeg is wrong as libffmpeg-custom may be built without patent obstructions.

Additionally, clean up library depends for libffmpeg-custom. Dependencies should be set within the Makefile, while internal package dependencies are set in the Config.in.

Didn't bump PKG_RELEASE as this should not change compiled code.