### PR TITLE
Syslog-ng bump to v3.9

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -1,14 +1,15 @@
 include  $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
-PKG_VERSION:=3.8.1
-PKG_RELEASE:=3
+PKG_VERSION:=3.9.1
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/balabit/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_MD5SUM:=acf14563cf5ce435db8db35486ce66af
+PKG_MD5SUM:=1b48da9ef620cf06e55e481b5abb677a
+PKG_HASH:=5678856a550ae790618fabde9d1447f932ce7a9080d55dca8fc5df1202c70a17
 
 PKG_INSTALL:=1
 
@@ -41,7 +42,7 @@ endef
 CONFIGURE_ARGS += \
   $(call autoconf_bool,CONFIG_IPV6,ipv6) \
          --disable-dependency-tracking \
-         --disable-ampq \
+         --disable-amqp \
          --disable-tcp-wrapper \
          --disable-glibtest \
          --disable-mongodb \

--- a/admin/syslog-ng/files/custom-logs.conf
+++ b/admin/syslog-ng/files/custom-logs.conf
@@ -1,0 +1,2 @@
+# place to put customization of logging
+

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -1,4 +1,4 @@
-@version:3.8
+@version:3.9
 
 options {
 	chain_hostnames(no);
@@ -14,7 +14,7 @@ options {
 
 source src {
 	internal();
-	unix-stream("/dev/log");
+	unix-dgram("/dev/log");
 };
 
 source net {
@@ -35,3 +35,6 @@ log {
         source(kernel);
 	destination(messages);
 };
+
+@include "/etc/custom-logs.conf"
+


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, generic, OpenWRT head
Run tested: same

Rebuilt image, burned CF, rebooted... confirmed syslogging is working properly and that `/etc/syslog-ng.conf` contains correct version.

Description:

Slight redux of Milan's patch, to:

1. enable parallel builds;
2. annotate version bump into `syslog-ng.conf` file as well;
3. open `/dev/log` as `SOCK_DGRAM` since this is how libc opens it;