### PR TITLE
hfsprogs: Fix building on macOS

### DIFF
--- a/utils/hfsprogs/patches/0001-Create-short-Makefiles-for-Debian.patch
+++ b/utils/hfsprogs/patches/0001-Create-short-Makefiles-for-Debian.patch
@@ -69,7 +69,7 @@ index 0000000..8c07196
 +OFILES = $(CFILES:.c=.o)
 +
 +libdfa.a: $(OFILES)
-+	ar rc $@ $?
++	$(AR) rc $@ $?
 +
 +clean:
 +	$(RM) $(OFILES) libdfa.a


### PR DESCRIPTION
Use $(AR) which in Makefile.lnx, not system-provided ar

Maintainer: @ffainelli 
Compile tested: host – macOS 10.12.2 x86-64, target – mipsel (D-LINK DIR-620), OpenWRT Chaos Calmer
Run tested: not yet

Description:
Makefile.lnx used ar, which appeared to be the Xcode-provided ar for x86-64 Mach-o files. That's why hfsprogs failed to build. This commit changes ar to $(AR), so ar from the OpenWRT toolchain is used.