### PR TITLE
[Adblock] Fix bug with "No download utility"

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -18,6 +18,7 @@ define Package/$(PKG_NAME)
 	CATEGORY:=Network
 	TITLE:=Powerful adblock script to block ad/abuse domains
 	PKGARCH:=all
+	DEPENDS:=+wget
 endef
 
 define Package/$(PKG_NAME)/description

--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -18,7 +18,6 @@ define Package/$(PKG_NAME)
 	CATEGORY:=Network
 	TITLE:=Powerful adblock script to block ad/abuse domains
 	PKGARCH:=all
-	DEPENDS:=+wget
 endef
 
 define Package/$(PKG_NAME)/description

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -15,8 +15,8 @@ adb_enabled=1
 adb_debug=0
 adb_whitelist="/etc/adblock/adblock.whitelist"
 adb_whitelist_rset="\$1 ~/^([A-Za-z0-9_-]+\.){1,}[A-Za-z]+/{print tolower(\"^\"\$1\"\\\|[.]\"\$1)}"
-adb_fetch="/usr/bin/wget"
-adb_fetchparm="--no-config --quiet --tries=1 --no-cache --no-cookies --max-redirect=0 --timeout=5 --no-check-certificate -O"
+adb_fetch="/bin/wget"
+adb_fetchparm="--quiet --timeout=5 --no-check-certificate -O"
 
 # f_envload: load adblock environment
 #


### PR DESCRIPTION
If you select this package without selecting wget, the script will fail with the error 
"status ::: no download utility with ssl support found/configured"
So we need to add wget with ssl support as a dependency

Compiled & tested: Linksys wrt1900acs

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
