### PR TITLE
[Adblock] Fix wget and implement uclient-fetch

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -17,7 +17,7 @@ define Package/$(PKG_NAME)
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=Powerful adblock script to block ad/abuse domains
-	DEPENDS=+ca-certificates
+	DEPENDS:=+ca-certificates
 	PKGARCH:=all
 endef
 

--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -17,6 +17,7 @@ define Package/$(PKG_NAME)
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=Powerful adblock script to block ad/abuse domains
+	DEPENDS=+ca-certificates
 	PKGARCH:=all
 endef
 

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -15,8 +15,16 @@ adb_enabled=1
 adb_debug=0
 adb_whitelist="/etc/adblock/adblock.whitelist"
 adb_whitelist_rset="\$1 ~/^([A-Za-z0-9_-]+\.){1,}[A-Za-z]+/{print tolower(\"^\"\$1\"\\\|[.]\"\$1)}"
-adb_fetch="/usr/bin/wget"
-adb_fetchparm="--no-config --quiet --tries=1 --no-cache --no-cookies --max-redirect=0 --timeout=5 --no-check-certificate -O"
+
+# check package to use
+if [ -r "/usr/bin/wget" ]
+then 
+	adb_fetch="/usr/bin/wget"
+    adb_fetchparm="--no-config --quiet --tries=1 --no-cache --no-cookies --max-redirect=0 --timeout=5 -O"
+else
+	adb_fetch="/bin/uclient-fetch"
+    adb_fetchparm="--quiet --timeout=5 -O"
+fi
 
 # f_envload: load adblock environment
 #


### PR DESCRIPTION
Add ca-cetificates depend to support https
Add check for the right downloader to use and switch to uclient-fetch 

Compiled & tested: Linksys wrt1900acs

Signed-off-by: Ansuel Smith ansuelsmth@gmail.com