### PR TITLE
Updated lang/python-pcapy to 0.11.1

### DIFF
--- a/lang/python-iptables/Makefile
+++ b/lang/python-iptables/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-iptables
+PKG_VERSION:=0.3.0
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Andrew McConachie <andrew@depht.com>
+PKG_LICENSE:=Apache-2.0
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=git://github.com/ldx/python-iptables.git
+#PKG_SOURCE_VERSION:=0250cebacfbca41b850a3728ec2c10ea21108434
+PKG_SOURCE_VERSION:=a71f64f40929d934da8189b729dac4cab001083d
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_BUILD_DEPENDS:=python python-setuptools
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/python-iptables
+	SECTION:=language-python
+	CATEGORY:=Languages
+	SUBMENU:=Python
+	TITLE:=python-iptables
+	URL:=https://pypi.python.org/pypi/python-iptables
+	DEPENDS:=+python
+endef
+
+define Package/python-iptables/description
+Python-iptables provides a pythonesque wrapper via python bindings to iptables under Linux. Interoperability with iptables is achieved via using the iptables C libraries (libiptc, libxtables, and the iptables extensions), not calling the iptables binary and parsing its output. It is meant primarily for dynamic and/or complex routers and firewalls, where rules are often updated or changed, or Python programs wish to interface with the Linux iptables framework.
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,,\
+		install --prefix=/usr --root="$(PKG_INSTALL_DIR)" \
+	)
+endef
+
+$(eval $(call PyPackage,python-iptables))
+$(eval $(call BuildPackage,python-iptables))

--- a/lang/python-pcapy/Makefile
+++ b/lang/python-pcapy/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 OpenWrt.org
+# Copyright (C) 2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pcapy
-PKG_VERSION:=0.10.10
+PKG_VERSION:=0.11.1
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Andrew McConachie <andrew@depht.com>
 PKG_LICENSE:=Apache-1.1
@@ -16,7 +16,7 @@ PKG_LICENSE:=Apache-1.1
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/CoreSecurity/pcapy.git
-PKG_SOURCE_VERSION:=37179f5b6187ec58d3ba11ef7b24e3c341cbabbb
+PKG_SOURCE_VERSION:=b91a418374d1636408c435f11799ef725ef70097
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_BUILD_DEPENDS:=python python-setuptools


### PR DESCRIPTION
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by:Andrew McConachie <andrew@depht.com>

Please double check that your commits:
- all start with "<package name>: "
- all contain signed-off-by
- are linked to your github account (you see your logo in front of them) 

Please also read https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md

Thanks for your contribution
Please remove this text (before ---) and fill the following template
-------------------------------

Maintainer: me / @<github-user>
Compile tested: (put here arch, model, OpenWRT/LEDE version)
Run tested: (put here arch, model, OpenWRT/LEDE version, tests done)

Description:
