### PR TITLE
[lede-17.01] libvpx: bump to 1.6.1

### DIFF
--- a/libs/libvpx/Makefile
+++ b/libs/libvpx/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libvpx
-PKG_VERSION:=1.6.0
+PKG_VERSION:=1.6.1
 PKG_RELEASE:=1
 
 PKG_REV:=v$(PKG_VERSION)
@@ -24,6 +24,8 @@ PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
+PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))
+
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -34,7 +36,7 @@ define Package/libvpx
   TITLE:=libvpx
   URL:=http://www.webmproject.org/
   DEPENDS:=+libpthread
-  ABI_VERSION:=$(PKG_VERSION)
+  ABI_VERSION:=$(PKG_ABI_VERSION)
 endef
 
 define Package/libvpx/description


### PR DESCRIPTION
cherry-picked from 0a7fd329f1d05466ba9184bd18148680240be8be