### PR TITLE
remove python-setuptools/host dependency from other packages

### DIFF
--- a/lang/python-dns/Makefile
+++ b/lang/python-dns/Makefile
@@ -18,8 +18,6 @@ PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=LICENSE
 PKG_BUILD_DIR:=$(BUILD_DIR)/dnspython-$(PKG_VERSION)
 
-PKG_BUILD_DEPENDS:=python-setuptools/host
-
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
 

--- a/lang/python-packages/Makefile
+++ b/lang/python-packages/Makefile
@@ -29,10 +29,9 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_python-packages-index-url \
 	CONFIG_PACKAGE_python-packages-pip-opts \
 
-PKG_BUILD_DEPENDS:=python python-pip/host
+PKG_BUILD_DEPENDS:=python python/host
 
 include $(INCLUDE_DIR)/package.mk
-$(call include_mk, python-host.mk)
 $(call include_mk, python-package.mk)
 
 define Package/python-packages


### PR DESCRIPTION
Maintainer: @yousong @Shulyaka 
Compile tested: https://github.com/lede-project/source/commit/b94177e10fc72f9309eae7459c3570e5c080e960 x86_64
Run tested: N/A

Description:

Remove python-setuptools/host & python-pip/host dependency from `python-dns` & `python-packages`.
There are other packages that may need this removed.
But I'll eval them in the next few days.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>