### PR TITLE
update of stunnel version

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.38
+PKG_VERSION:=5.40
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0+

--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -19,7 +19,7 @@ PKG_SOURCE_URL:= \
 	http://ftp.nluug.nl/pub/networking/stunnel/ \
 	http://www.usenix.org.uk/mirrors/stunnel/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=09ada29ba1683ab1fd1f31d7bed8305127a0876537e836a40cb83851da034fd5
+PKG_MD5SUM:=4125b7c7f0f8c46266b4fa245ee8cda6
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
Stunnel in the download location has changed from 5.38 to version 5.4

Please double check that your commits:
- all start with "<package name>: "
- all contain signed-off-by
- are linked to your github account (you see your logo in front of them) 

Please also read https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md

Thanks for your contribution
Please remove this text (before ---) and fill the following template
-------------------------------

Maintainer: me / @<github-user>
Compile tested: (put here arch, model, OpenWRT/LEDE version)
Run tested: (put here arch, model, OpenWRT/LEDE version, tests done)

Description:
