### PR TITLE
net/stunnel: Update to version 5.40

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.38
+PKG_VERSION:=5.40
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0+
@@ -19,7 +19,7 @@ PKG_SOURCE_URL:= \
 	http://ftp.nluug.nl/pub/networking/stunnel/ \
 	http://www.usenix.org.uk/mirrors/stunnel/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=09ada29ba1683ab1fd1f31d7bed8305127a0876537e836a40cb83851da034fd5
+PKG_MD5SUM:=23acdb390326ffd507d90f8984ecc90e0d9993f6bd6eac1d0a642456565c45ff
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
Maintainer: myself
Compile tested: Kirkwood, iomega iConnect, LEDE trunk
Run tested: Kirkwood, iomega iConnect, LEDE trunk

Description:
Update stunnel to 5.40

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>
