### PR TITLE
adblock: fix check fetch utility

### DIFF
--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -109,14 +109,22 @@ f_envcheck()
 
     # check fetch utility
     #
-    if [ -z "${adb_fetch}" ] || [ -z "${adb_fetchparm}" ] || [ ! -f "${adb_fetch}" ] || [ "$(readlink -fn "${adb_fetch}")" = "/bin/busybox" ]
+    if [ ! -f "${adb_fetch}" ] && ([ -f /bin/uclient-fetch ] || [ -f /bin/wget ])
     then
-        f_log "error" "status ::: required download utility with ssl support not found, e.g. install full 'wget' package"
-    fi
-    if [ "${adb_fetch}" = "/usr/bin/wget" ] && [ "$(readlink -fn "${adb_fetch}")" = "/bin/uclient-fetch" ]
-    then
-        adb_fetch="/bin/uclient-fetch"
-        adb_fetchparm="-q --timeout=5 --no-check-certificate -O"
+		f_log "info" "status ::: using stock download utilty. It is raccomanded to use the full package, e.g. install full 'wget' package"
+		if [ -f /bin/uclient-fetch ]
+		then
+        	adb_fetch="/bin/uclient-fetch" #LEDE utility
+        	adb_fetchparm="-q --timeout=5 --no-check-certificate -O"
+		else
+			adb_fetch="/bin/wget" #Openwrt utility
+        	adb_fetchparm="-q --timeout=5 --no-check-certificate -O"
+		fi
+    else
+		if [ ! -f "${adb_fetch}" ] || [ -z "${adb_fetch}" ] || [ -z "${adb_fetchparm}" ] || [ "$(readlink -fn "${adb_fetch}")" = "/bin/busybox" ]
+		then
+			f_log "error" "status ::: required download utility with ssl support not found, e.g. install full 'wget' package"
+		fi
     fi
 
     # create dns hideout directory

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -112,14 +112,8 @@ f_envcheck()
     if [ ! -f "${adb_fetch}" ] && ([ -f /bin/uclient-fetch ] || [ -f /bin/wget ])
     then
 		f_log "info" "status ::: using stock download utilty. It is raccomanded to use the full package, e.g. install full 'wget' package"
-		if [ -f /bin/uclient-fetch ]
-		then
-        	adb_fetch="/bin/uclient-fetch" #LEDE utility
+        	adb_fetch="/bin/uclient-fetch"
         	adb_fetchparm="-q --timeout=5 --no-check-certificate -O"
-		else
-			adb_fetch="/bin/wget" #Openwrt utility
-        	adb_fetchparm="-q --timeout=5 --no-check-certificate -O"
-		fi
     else
 		if [ ! -f "${adb_fetch}" ] || [ -z "${adb_fetch}" ] || [ -z "${adb_fetchparm}" ] || [ "$(readlink -fn "${adb_fetch}")" = "/bin/busybox" ]
 		then


### PR DESCRIPTION
if [ "${adb_fetch}" = "/usr/bin/wget" ] && [ "$(readlink -fn "${adb_fetch}")" = "/bin/uclient-fetch" ]

this condition would never accomplish so the script with no wget in the system would never run

With this commit it will check if it can run and alert the user that is using the stock download package.

Signed-off-by: Ansuel <ansuelsmth@gmail.com>