### PR TITLE
libidn: install libidn.pc in staging area & refresh patches

### DIFF
--- a/libs/libidn/Makefile
+++ b/libs/libidn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libidn
 PKG_VERSION:=1.33
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/libidn
@@ -28,7 +28,7 @@ define Package/idn/Default
   SECTION:=net
   CATEGORY:=Network
   URL:=http://www.gnu.org/software/libidn/
-  MAINTAINER:=Marcel Denia <naoir@gmx.net>
+  MAINTAINER:=Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>
 endef
 
 define Package/idn/Default/description
@@ -79,6 +79,8 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libidn.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libidn.pc $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/idn/install

--- a/libs/libidn/patches/002-disable-po-docs-examples.patch
+++ b/libs/libidn/patches/002-disable-po-docs-examples.patch
@@ -11,7 +11,7 @@
  EXTRA_DIST = cfg.mk maint.mk .clcopying
 --- a/configure.ac
 +++ b/configure.ac
-@@ -48,8 +48,6 @@ AC_PROG_LIBTOOL
+@@ -47,8 +47,6 @@ LT_INIT([win32-dll])
  # Checks for programs.
  AM_MISSING_PROG(PERL, perl, $missing_dir)
  AM_MISSING_PROG(HELP2MAN, help2man, $missing_dir)

--- a/libs/libidn/patches/010-fix-idn-error-usage.patch
+++ b/libs/libidn/patches/010-fix-idn-error-usage.patch
@@ -1,6 +1,6 @@
 --- a/src/idn.c
 +++ b/src/idn.c
-@@ -169,7 +169,7 @@ main (int argc, char *argv[])
+@@ -170,7 +170,7 @@ main (int argc, char *argv[])
        (args_info.idna_to_unicode_given ? 1 : 0) +
        (args_info.nfkc_given ? 1 : 0) != 1)
      {
@@ -9,7 +9,7 @@
        usage (EXIT_FAILURE);
      }
  
-@@ -184,7 +184,7 @@ main (int argc, char *argv[])
+@@ -185,7 +185,7 @@ main (int argc, char *argv[])
    if (!args_info.quiet_given
        && args_info.inputs_num == 0
        && isatty (fileno (stdin)))
@@ -18,7 +18,7 @@
  		       "terminated by a newline character.\n"));
  
    do
-@@ -199,7 +199,7 @@ main (int argc, char *argv[])
+@@ -197,7 +197,7 @@ main (int argc, char *argv[])
  	  if (feof (stdin))
  	    break;
  
@@ -26,8 +26,8 @@
 +	  error (EXIT_FAILURE, errno, "%s", _("input error"));
  	}
  
-       if (readbuf[strlen (readbuf) - 1] == '\n')
-@@ -216,7 +216,7 @@ main (int argc, char *argv[])
+       if (strlen (line) > 0)
+@@ -215,7 +215,7 @@ main (int argc, char *argv[])
  	  if (!q)
  	    {
  	      free (p);
@@ -36,7 +36,7 @@
  		     _("could not convert from UTF-8 to UCS-4"));
  	    }
  
-@@ -241,7 +241,7 @@ main (int argc, char *argv[])
+@@ -240,7 +240,7 @@ main (int argc, char *argv[])
  	  if (!q)
  	    {
  	      free (r);


### PR DESCRIPTION
Maintainer: Marcel Denia <naoir@gmx.net>
Compile tested: ar71xx, archer c7 v2 LEDE 

Description:


libidn.pc file was missing in package staging area causing build
failures for other packages expecting to find libidn package config
files.

refreshed patches to clear existing patch fuzz

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>


