### PR TITLE
adblock: update Unbound integration

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=2.1.5
-PKG_RELEASE:=2
+PKG_VERSION:=2.1.6
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -117,7 +117,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
     * adb\_iface => restrict the procd interface trigger to a (list of) certain wan interface(s) or disable it at all (default: not set, disabled)
     * adb\_fetch => full path to a different download utility, see example below (default: not set, use wget)
     * adb\_fetchparm => options for the download utility, see example below (default: not set, use wget options)
-    * adb\_dns => use 'unbound' as dns backend, see example below (default: not set, use dnsmasq)
+    * adb\_dns => use 'unbound' with 'unbound-control' as dns backend, see example below (default: not set, use dnsmasq)
 
 ## Examples
 
@@ -126,16 +126,10 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 set 'unbound' as dns backend in /etc/config/adblock:
   [...]
   option adb_dns 'unbound'
-
-switch to 'manual' unbound config in /etc/config/unbound:
-  [...]
-  option manual_conf '1'
-
-include adblock lists in /etc/unbound/unbound.conf:
-  [...]
-  include: "/tmp/lib/unbound/adb_list.*"
 </code></pre>
-  
+
+Note: This requires 'unbound-control' because it is recommended practice by [NLnet Labs](https://unbound.net/) for large DNS loads. If 'dnsmasq' is disabled or uninstalled, 'unbound' is installed, 'unbound-control' is installed, and 'unbound' is enabled, then Unbound will be automatically selected as backend.
+
 **configuration for different download utilities:**
 <pre><code>
 wget (default):


### PR DESCRIPTION
Maintainer: @dibdot 
Compile tested: LEDE Trunk
Run tested: TL Archer C7

Description:
This update enhances adblocks integration with Unbound
as the DNS backend. It uses 'unbound-control' to feed
the block lists live without requiring a hard restart.
This is the recommended practice after Unbound 1.6.0.
Changes are stuctured for any future DNS backend that
may have similar live input controls.

Also the default behavior is more adaptive. If Unbound
is installed and dnsmasq is not, then the user does not
need to set the UCI to get adblock to work.