### PR TITLE
python3-cffi: add variant

### DIFF
--- a/lang/python-cffi/Makefile
+++ b/lang/python-cffi/Makefile
@@ -9,14 +9,22 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cffi
 PKG_VERSION:=1.8.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/0a/f3/686af8873b70028fccf67b15c78fd4e4667a3da995007afc71e786d61b0a
-PKG_MD5SUM:=c8e877fe0426a99d0cf5872cf2f95b27
+PKG_HASH:=c321bd46faa7847261b89c0469569530cad5a41976bb6dba8202c0159f476568
 
-PKG_BUILD_DEPENDS:=python python-setuptools
-HOST_BUILD_DEPENDS:=libffi/host python/host python-setuptools/host python-pycparser/host
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+HOST_BUILD_DEPENDS:=libffi/host python-pycparser/host
+ifdef CONFIG_PACKAGE_python-cffi
+HOST_BUILD_DEPENDS+=python/host
+endif
+ifdef CONFIG_PACKAGE_python3-cffi
+HOST_BUILD_DEPENDS+=python3/host
+endif
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -25,27 +33,55 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
-$(call include_mk, python-host.mk)
+$(call include_mk, python3-package.mk)
+
+define Package/python-cffi/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=http://cffi.readthedocs.org/
+  DEPENDS:=+libffi
+endef
 
 define Package/python-cffi
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-cffi
-	URL:=http://cffi.readthedocs.org/
-	DEPENDS:=+libffi +python-light +python-pycparser
+$(call Package/python-cffi/Default)
+  TITLE:=python-cffi
+  DEPENDS+=+python-light +python-pycparser
+  VARIANT:=python
+endef
+
+define Package/python3-cffi
+$(call Package/python-cffi/Default)
+  TITLE:=python3-cffi
+  DEPENDS+=+python3-light +python3-pycparser
+  VARIANT:=python3
 endef
 
 define Package/python-cffi/description
 Foreign Function Interface for Python calling C code.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
+define Package/python3-cffi/description
+$(call Package/python-cffi/description)
+.
+(Variant for Python3)
 endef
 
-define Host/Compile
+ifdef CONFIG_PACKAGE_python-cffi
+define Host/Compile/python-cffi
 	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
+endef
+endif
+
+ifdef CONFIG_PACKAGE_python3-cffi
+define Host/Compile/python3-cffi
+	$(call Build/Compile/HostPy3Mod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
+endef
+endif
+
+define Host/Compile
+$(call Host/Compile/python-cffi)
+$(call Host/Compile/python3-cffi)
 endef
 
 define Host/Install
@@ -55,3 +91,6 @@ $(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-cffi))
 $(eval $(call BuildPackage,python-cffi))
+
+$(eval $(call Py3Package,python3-cffi))
+$(eval $(call BuildPackage,python3-cffi))

--- a/lang/python-ply/Makefile
+++ b/lang/python-ply/Makefile
@@ -9,14 +9,22 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ply
 PKG_VERSION:=3.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.dabeaz.com/ply
-PKG_MD5SUM:=c5c5767376eff902617fd9874f0c76b7
+PKG_HASH:=0d7e2940b9c57151392fceaa62b0865c45e06ce1e36687fd8d03f011a907f43e
 
-PKG_BUILD_DEPENDS:=python python-setuptools
-HOST_BUILD_DEPENDS:=python/host python-setuptools/host
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+HOST_BUILD_DEPENDS:=
+ifdef CONFIG_PACKAGE_python-ply
+HOST_BUILD_DEPENDS+=python/host
+endif
+ifdef CONFIG_PACKAGE_python3-ply
+HOST_BUILD_DEPENDS+=python3/host
+endif
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=README.md
@@ -25,15 +33,27 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
-$(call include_mk, python-host.mk)
+$(call include_mk, python3-package.mk)
+
+define Package/python-ply/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=http://www.dabeaz.com/ply/
+endef
 
 define Package/python-ply
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-ply
-	URL:=http://www.dabeaz.com/ply/
-	DEPENDS:=+python-light
+$(call Package/python-ply/Default)
+  TITLE:=python-ply
+  DEPENDS:=+python-light
+  VARIANT:=python
+endef
+
+define Package/python3-ply
+$(call Package/python-ply/Default)
+  TITLE:=python3-ply
+  DEPENDS:=+python3-light
+  VARIANT:=python3
 endef
 
 define Package/python-ply/description
@@ -41,12 +61,27 @@ PLY is a 100% Python implementation of the common parsing tools lex
 and yacc.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
+define Package/python3-ply/description
+$(call Package/python-ply/description)
+.
+(Variant for Python3)
 endef
 
-define Host/Compile
+ifdef CONFIG_PACKAGE_python-ply
+define Host/Compile/python-ply
 	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
+endef
+endif
+
+ifdef CONFIG_PACKAGE_python3-ply
+define Host/Compile/python3-ply
+	$(call Build/Compile/HostPy3Mod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
+endef
+endif
+
+define Host/Compile
+$(call Host/Compile/python-ply)
+$(call Host/Compile/python3-ply)
 endef
 
 define Host/Install
@@ -56,3 +91,6 @@ $(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-ply))
 $(eval $(call BuildPackage,python-ply))
+
+$(eval $(call Py3Package,python3-ply))
+$(eval $(call BuildPackage,python3-ply))

--- a/lang/python-pycparser/Makefile
+++ b/lang/python-pycparser/Makefile
@@ -9,14 +9,22 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pycparser
 PKG_VERSION:=2.14
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pycparser
-PKG_MD5SUM:=a2bc8d28c923b4fe2b2c3b4b51a4f935
+PKG_HASH:=7959b4a74abdc27b312fed1c21e6caf9309ce0b29ea86b591fd2e99ecdf27f73
 
-PKG_BUILD_DEPENDS:=python python-setuptools
-HOST_BUILD_DEPENDS:=python/host python-setuptools/host python-ply/host
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+HOST_BUILD_DEPENDS:=python-ply/host
+ifdef CONFIG_PACKAGE_python-pycparser
+HOST_BUILD_DEPENDS+=python/host
+endif
+ifdef CONFIG_PACKAGE_python3-pycparser
+HOST_BUILD_DEPENDS+=python3/host
+endif
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -25,15 +33,27 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
-$(call include_mk, python-host.mk)
+$(call include_mk, python3-package.mk)
+
+define Package/python-pycparser/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://github.com/eliben/pycparser
+endef
 
 define Package/python-pycparser
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-pycparser
-	URL:=https://github.com/eliben/pycparser
-	DEPENDS:=+python-light +python-ply
+$(call Package/python-pycparser/Default)
+  TITLE:=python-pycparser
+  DEPENDS:=+python-light +python-ply
+  VARIANT:=python
+endef
+
+define Package/python3-pycparser
+$(call Package/python-pycparser/Default)
+  TITLE:=python3-pycparser
+  DEPENDS:=+python3-light +python3-ply
+  VARIANT:=python3
 endef
 
 define Package/python-pycparser/description
@@ -42,12 +62,27 @@ module designed to be easily integrated into applications that need to parse
 C source code.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
+define Package/python3-pycparser/description
+$(call Package/python-pycparser/description)
+.
+(Variant for Python3)
 endef
 
-define Host/Compile
+ifdef CONFIG_PACKAGE_python-pycparser
+define Host/Compile/python-pycparser
 	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
+endef
+endif
+
+ifdef CONFIG_PACKAGE_python3-pycparser
+define Host/Compile/python3-pycparser
+	$(call Build/Compile/HostPy3Mod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
+endef
+endif
+
+define Host/Compile
+$(call Host/Compile/python-pycparser)
+$(call Host/Compile/python3-pycparser)
 endef
 
 define Host/Install
@@ -57,3 +92,6 @@ $(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-pycparser))
 $(eval $(call BuildPackage,python-pycparser))
+
+$(eval $(call Py3Package,python3-pycparser))
+$(eval $(call BuildPackage,python3-pycparser))


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: https://github.com/lede-project/source/commit/b94177e10fc72f9309eae7459c3570e5c080e960  PPC 464fp, x86_64
Run tested: https://github.com/lede-project/source/commit/b94177e10fc72f9309eae7459c3570e5c080e960  x86_64

Description:

Addresses request https://github.com/openwrt/packages/issues/3302
This patchset just extends cffi to python3 ; it does not do any upgrades.

I actually wanted to try using @yousong's `python-packages`, but it did not feel solid enough.

And there were multiple issues/difficulties with running `pip` & `pip3`, and then making a consistent packaging (with the basic LEDE/OpenWrt packaging mode).

While I did not completely abandoned using the `python-packages` package to package `pip` packages, there's still some open items to resolve there, like:
* how to patch certain python packages that need patching (within the `python-packages` package)
* how to cache python packages in `dl` (this may be easy ; just did not have time to find a solution yet)

Note that this patchset relies on some recent changes that I made to `python` & `python3` for using `VARIANT`s to specify `Build/Compile` specific to each variant.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>