### PR TITLE
fish: Add fish shell package

### DIFF
--- a/libs/pcre2/Makefile
+++ b/libs/pcre2/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2015 OpenWrt.org
+# Copyright (C) 2017 Shane Peelar
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.

--- a/libs/pcre2/Makefile
+++ b/libs/pcre2/Makefile
@@ -1,0 +1,95 @@
+#
+# Copyright (C) 2006-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pcre2
+PKG_VERSION:=10.21
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/
+PKG_MD5SUM:=e79460519f916e3fcb204e59714bfd4a
+PKG_MAINTAINER:=Shane Peelar <lookatyouhacker@gmail.com>
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENCE
+
+PKG_FIXUP:=autoreconf
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libpcre2/default
+  SECTION:=libs
+  CATEGORY:=Libraries
+  URL:=http://www.pcre.org/
+endef
+
+define Package/libpcre2
+  $(call Package/libpcre2/default)
+  TITLE:=A Perl Compatible Regular Expression library
+endef
+
+define Package/libpcre2-16
+  $(call Package/libpcre2/default)
+  TITLE:=A Perl Compatible Regular Expression library (16bit support)
+endef
+
+
+define Package/libpcre2-32
+  $(call Package/libpcre2/default)
+  TITLE:=A Perl Compatible Regular Expression library (32bit support)
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+CONFIGURE_ARGS += \
+	--enable-pcre2-16 \
+	--enable-pcre2-32 
+
+MAKE_FLAGS += \
+	CFLAGS="$(TARGET_CFLAGS)"
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/pcre2-config $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(2)/bin
+	$(LN) $(STAGING_DIR)/usr/bin/pcre2-config $(2)/bin
+
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/pcre*.h $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre*.{a,so*} $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpcre*.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libpcre2/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre2-{8,posix}.so* $(1)/usr/lib/
+endef
+
+define Package/libpcre2-16/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre2-16.so* $(1)/usr/lib/
+endef
+
+define Package/libpcre2-32/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre2-32.so* $(1)/usr/lib/
+endef
+
+
+
+$(eval $(call BuildPackage,libpcre2))
+$(eval $(call BuildPackage,libpcre2-16))
+$(eval $(call BuildPackage,libpcre2-32))

--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -1,0 +1,71 @@
+#
+# Copyright (C) 2007-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+BASE_VERSION:=2.4.0
+
+PKG_NAME:=fish
+PKG_VERSION:=$(BASE_VERSION)
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(BASE_VERSION).tar.gz
+PKG_SOURCE_URL:=https://fishshell.com/files/2.4.0/
+PKG_SHA1SUM:=c5981245b45ea61b765008299b5ac477657089c3
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BASE_VERSION)
+
+PKG_LICENSE:=GPL-3.0+
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Shane Peelar <lookatyouhacker@gmail.com>
+
+PKG_FIXUP:=autoreconf
+
+PKG_CHECK_FORMAT_SECURITY:=0
+include $(INCLUDE_DIR)/package.mk
+
+define Package/fish
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Shells
+  TITLE:=The Friendly Interactive SHell
+  DEPENDS:=+libncurses +libpcre2-32 +libstdcpp
+  URL:=https://fishshell.com/
+endef
+
+define Package/fish/description
+  fish is a user friendly commandline shell intended mostly for interactive use. 
+	For the latest information on fish, please visit the fish homepage.
+endef
+
+
+define Build/Configure
+	$(call Build/Configure/Default, \
+		--without-included-pcre2)
+endef
+
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		SHELL="/bin/sh" \
+		all install
+endef
+
+define Package/fish/postinst
+#!/bin/sh
+grep fish $${IPKG_INSTROOT}/etc/shells || \
+	echo "/usr/bin/fish" >> $${IPKG_INSTROOT}/etc/shells
+endef
+
+define Package/fish/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fish{_indent,_key_reader} $(1)/usr/bin/
+	$(CP) -r $(PKG_INSTALL_DIR)/usr/share $(1)/usr
+endef
+
+
+$(eval $(call BuildPackage,fish))

--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2015 OpenWrt.org
+# Copyright (C) 2017 Shane Peelar
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -7,14 +7,14 @@
 
 include $(TOPDIR)/rules.mk
 
-BASE_VERSION:=2.4.0
+BASE_VERSION:=2.5.0
 
 PKG_NAME:=fish
 PKG_VERSION:=$(BASE_VERSION)
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(BASE_VERSION).tar.gz
-PKG_SOURCE_URL:=https://fishshell.com/files/2.4.0/
+PKG_SOURCE_URL:=https://fishshell.com/files/$(BASE_VERSION)/
 PKG_SHA1SUM:=c5981245b45ea61b765008299b5ac477657089c3
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BASE_VERSION)
 
@@ -24,7 +24,6 @@ PKG_MAINTAINER:=Shane Peelar <lookatyouhacker@gmail.com>
 
 PKG_FIXUP:=autoreconf
 
-PKG_CHECK_FORMAT_SECURITY:=0
 include $(INCLUDE_DIR)/package.mk
 
 define Package/fish
@@ -42,18 +41,10 @@ define Package/fish/description
 endef
 
 
-define Build/Configure
-	$(call Build/Configure/Default, \
-		--without-included-pcre2)
-endef
+CONFIG_ARGS+=--without-included-pcre2
 
-
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		SHELL="/bin/sh" \
-		all install
-endef
+TARGET_MAKE_FLAGS+='SHELL="/bin/sh"'
+PKG_INSTALL:=1
 
 define Package/fish/postinst
 #!/bin/sh
@@ -63,7 +54,7 @@ endef
 
 define Package/fish/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fish{_indent,_key_reader} $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fish{,_indent,_key_reader} $(1)/usr/bin/
 	$(CP) -r $(PKG_INSTALL_DIR)/usr/share $(1)/usr
 endef
 

--- a/utils/fish/patches/0001-configure.patch
+++ b/utils/fish/patches/0001-configure.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac	2017-02-01 15:09:24.399387241 -0500
++++ b/configure.ac	2017-02-01 15:09:09.899387310 -0500
+@@ -236,7 +236,7 @@
+ # information about running processes.
+ #
+ 
+-AC_CHECK_FILES([/proc/self/stat])
++#AC_CHECK_FILES([/proc/self/stat])
+ 
+ # Disable curses macros that conflict with the STL
+ AC_DEFINE([NCURSES_NOMACROS], [1], [Define to 1 to disable ncurses macros that conflict with the STL])


### PR DESCRIPTION
Maintainer: Shane Peelar / @<InBetweenNames>
Compile tested: AMD64
Run tested: bcm53xx, RT-AC87U, LEDE snapshots January 30th

Description:

These two commits add the PCRE2 package and the fish package.  Since fish depends on PCRE2, the former commit is necessary to make it work.