### PR TITLE
rng-tools: start rngd early enough to actually be useful

### DIFF
--- a/utils/rng-tools/files/rngd.init
+++ b/utils/rng-tools/files/rngd.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2011-2014 OpenWrt.org
 
-START=98
+START=25
 
 USE_PROCD=1
 PROG=/sbin/rngd


### PR DESCRIPTION
lighttpd starts at priority 50, but promptly calls getrandom() on
initialization (li_rand_reseed() and li_rand_device_bytes() from
server_init()). If /dev/urandom (which getrandom() uses by default)
doesn't have sufficient entropy, this will block.

Since Openwrt runs the startup scripts serially, this can block
initialization indefinitely.  I've seen 15-20 minutes typically.

Seeding the pool early on can quickly built sufficient entropy to
complete booting without blocking.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>

Please double check that your commits:
- all start with "<package name>: "
- all contain signed-off-by
- are linked to your github account (you see your logo in front of them) 

Please also read https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md

Thanks for your contribution
Please remove this text (before ---) and fill the following template
-------------------------------

Maintainer: @nwf 
Compile tested: x86_64, generic, OpenWRT head db8a583b6eb
Run tested: same

Built and tested on Haswell box.  Immediately `lighttpd` stopped blocking indefinitely at boot-time, and the entire boot sequence (from POST) took less that 44 seconds.

Description:

Run `rngd` early enough that it seeds entropy for subsequent consumers of `/dev/urandom`.