### PR TITLE
opus: update to 1.1.4 for CVE-2017-0381

### DIFF
--- a/libs/opus/Makefile
+++ b/libs/opus/Makefile
@@ -8,16 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opus
-PKG_VERSION:=1.1.3
-PKG_RELEASE:=2
+PKG_VERSION:=1.1.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://downloads.xiph.org/releases/opus/
-PKG_MD5SUM:=32bbb6b557fe1b6066adc0ae1f08b629
+PKG_MD5SUM:=a2c09d995d0885665ff83b5df2505a5f
+PKG_HASH:=9122b6b380081dd2665189f97bfd777f04f92dc3ab6698eea1dbb27ad59d8692
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Nicolas Thill <nico@openwrt.org>
+PKG_MAINTAINER:=Ted Hess <thess@kitchensync.net> Ian Leonard <antonlacon@gmail.com>
 
 PKG_INSTALL:=1
 


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: mips/ar71xx - OpenWrt
Run tested: None

Description:

CVE 2017-0381: An information disclosure vulnerability in silk/NLSF_stabilize.c in libopus in Mediaserver could enable a local malicious application to access data outside of its permission levels. This issue is rated as Moderate because it could be used to access sensitive data without permission.

Patch comes from upstream:
https://github.com/xiph/opus/commit/79e8f527b0344b0897a65be35e77f7885bd99409

Signed-off-by: Ian Leonard <antonlacon@gmail.com>