### PR TITLE
vpnbypass: HOTFIX no longer incorrectly stopping service; reliable start

### DIFF
--- a/net/vpnbypass/Makefile
+++ b/net/vpnbypass/Makefile
@@ -4,8 +4,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vpnbypass
-PKG_VERSION:=1.0.0
-PKG_RELEASE:=4
+PKG_VERSION:=1.0.1
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 
@@ -47,7 +47,7 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/vpnbypass.conf $(1)/etc/config/vpnbypass
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/firewall
-	$(INSTALL_DATA) ./files/vpnbypass.hotplug $(1)/etc/hotplug.d/firewall/90-vpnbypass
+	$(INSTALL_DATA) ./files/vpnbypass.hotplug $(1)/etc/hotplug.d/firewall/92-vpnbypass
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/net/vpnbypass/files/README.md
+++ b/net/vpnbypass/files/README.md
@@ -1,30 +1,37 @@
-# OpenWrt Simple VPNBypass
-A simple PROCD-based vpnbypass init script for OpenWrt/LEDE Project. Useful if your router accesses internet thru VPN client/tunnel, but you want specific traffic (ports, IP ranges, domains or local IP ranges) to be routed outside of this tunnel.
+# OpenWrt VPNBypass
+A simple PROCD-based vpnbypass service for OpenWrt/LEDE Project. Useful if your router accesses internet thru VPN client/tunnel, but you want specific traffic (ports, IP ranges, domains or local IP ranges) to be routed outside of this tunnel.
 
-# Features
-- Routes Plex Media Server traffic outside of the VPN tunnel.
-- Allows you to define IPs/ranges in local network so that their traffic is routed outside of the VPN tunnel.
-- Allows you to define list of domain names which are accessed outside of the VPN tunnel (useful for Netflix, Hulu, etc).
+## Features
+- Allows to define local ports so that traffic to them is routed outside of the VPN tunnel (by default routes Plex Media Server traffic (port 32400) outside of the VPN tunnel).
+- Allows to define IPs/subnets in local network so that their traffic is routed outside of the VPN tunnel (by default routes traffic from 192.168.1.81-192.168.1.87 outside of the VPN tunnel).
+- Allows to define remote IPs/ranges that they are accessed outside of the VPN tunnel (by default routes LogmeIn Hamachi traffic (25.0.0.0/8) outside of the VPN tunnel).
+- Allows to define list of domain names which are accessed outside of the VPN tunnel (useful for Netflix, Hulu, etc).
 - Doesn't stay in memory -- creates the iptables rules which are automatically updated on WAN up/down.
+- Has a companion package (luci-app-vpnbypass) so everything can be configured with Web UI.
+- Proudly made in Canada, using locally-sourced electrons.
 
-# Requirements
-This service requires following packages to be installed on your router: ip-full ipset iptables dnsmasq-full (dnsmasq-full requires you uninstall dnsmasq first). Run the following commands to satisfy the requirements:
+## Requirements
+This service requires following packages to be installed on your router: ip-full ipset iptables dnsmasq-full (ip-full requires you uninstall ip first; dnsmasq-full requires you uninstall dnsmasq first). Run the following commands to satisfy the requirements:
 ```sh
 opkg update
 opkg remove dnsmasq ip; opkg install ip-full ipset iptables dnsmasq-full
 ```
 
-# How to install
+## How to install
 ```sh
 opkg update
 opkg install vpnbypass luci-app-vpnbypass
 ```
-Default install routes Plex Media Server traffic (port 32400) outside of the VPN tunnel, routes LogmeIn Hamachi traffic (25.0.0.0/8) outside of the VPN tunnel and also routes internet traffic from local IPs 192.168.1.80-192.168.1.88 outside of the VPN tunnel.
+Default install routes Plex Media Server traffic (port 32400) outside of the VPN tunnel, routes LogmeIn Hamachi traffic (25.0.0.0/8) outside of the VPN tunnel and also routes internet traffic from local IPs 192.168.1.81-192.168.1.87 outside of the VPN tunnel. You can safely delete these example rules if they do not apply to you.
 
-# Documentation / Discussion
-Please head to OpenWrt/LEDE Project Forums for discussion of this script.
+## Documentation / Discussion
+Please head to [LEDE Project Forum](https://forum.lede-project.org/t/vpn-bypass-split-tunneling-service-luci-ui/1106) or [OpenWrt Forum]() for discussions of this service.
 
-# What's New
+## What's New
+1.0.1:
+- Detects individual IP addresses in the config and converts them to subnet automatically.
+- Proper implementation of reload on vpnbypass config change.
+
 1.0.0:
 - Hotplug script created during install.
 
@@ -37,7 +44,7 @@ Please head to OpenWrt/LEDE Project Forums for discussion of this script.
 0.0.1:
 - Initial release.
 
-# Known Issues
+## Known Issues
 Until user-defined domains are supported within vpnbypass config, you can set domains to be accessed outside of VPN tunnel like so:
 ```sh
 uci add_list dhcp.@dnsmasq[-1].ipset='/github.com/plex.tv/google.com/vpnbypass'

--- a/net/vpnbypass/files/vpnbypass.conf
+++ b/net/vpnbypass/files/vpnbypass.conf
@@ -1,5 +1,5 @@
 config vpnbypass 'config'
 	option enabled '1'
 	list localport '32400'
+	list localsubnet '192.168.1.81/29'
 	list remotesubnet '25.0.0.0/8'
-	list localsubnet '192.168.1.80/28'

--- a/net/vpnbypass/files/vpnbypass.init
+++ b/net/vpnbypass/files/vpnbypass.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-START=90
+START=92
 USE_PROCD=1
 
 TID="200"; FW_MARK="0x010000"; IPSET="vpnbypass"; 
@@ -17,13 +17,12 @@ vpnbypass_enabled() {
     [ $((enabled)) -gt 0 ] && return 0 || { output "VPNBypass is not enabled in the config file!\nTo enable, run 'uci set vpnbypass.config.enabled=1; uci commit vpnbypass'\n"; return 1; }
 }
 
-boot() { ubus -t 30 wait_for network.interface && rc_procd start_service || output 'ERROR: Failed to settle network interface!\n'; }
+boot() { ubus -t 30 wait_for network.interface.wan && rc_procd start_service || output 'ERROR: Failed to settle network interface!\n'; }
 
 start_service() {
-	local ll
+	local ll c=1
     config_load vpnbypass
     vpnbypass_enabled || return 1
-	[ -d /etc/openvpn ] || return 1
     config_get lports   'config' 'localport'
     config_get rports   'config' 'remoteport'
     config_get routes   'config' 'remotesubnet'
@@ -35,21 +34,22 @@ start_service() {
 	procd_set_param stderr 1
 	procd_close_instance
 
-	. /lib/functions/network.sh; network_get_ipaddr wanip wan; network_get_gateway gwip wan; network_get_ipaddr lanip lan
-	[ ! "$wanip" ] && output 'ERROR: Could not get wan ip\n' && exit 0
-	[ ! "$gwip" ] && output 'ERROR: Could not get wan gateway\n' && exit 0
-	for ll in ${routes}; do (ip route del $ll; ip route add $ll via $gwip) >/dev/null 2>&1; done
-	(ip rule del fwmark $FW_MARK table $TID; iptables -t mangle -F; ipset -F $IPSET; ipset -X $IPSET) >/dev/null 2>&1
-	(ip route flush table $TID; ip route flush cache) >/dev/null 2>&1
-	(ip route add default via $gwip table $TID; ip route flush cache) >/dev/null 2>&1
-	(modprobe xt_set || modprobe ip_set; insmod ip_set_hash_ip) >/dev/null 2>&1
-	(ipset -N $IPSET iphash -q; ipset -F $IPSET) >/dev/null 2>&1
+	source /lib/functions/network.sh
+	while : ; do network_get_ipaddr wanip wan; network_get_gateway gwip wan; [ $c -ge 5 ] && break || let "c+=1"; [ -n "$wanip" -a -n "$gwip" ] && break || sleep 5; done
+	[ -z "$wanip" -o -z "$gwip" ] && output 'ERROR: Could not get WAN interface IP: $wanip or Gateway: $gwip\n' && exit 0
+
+	for ll in ${routes}; do { [ "$ll" = "${ll#*\/*}" ] && ll="${ll}/32"; ip route del $ll; ip route add $ll via $gwip; } >/dev/null 2>&1; done
+	{ ip rule del fwmark $FW_MARK table $TID; iptables -t mangle -F; ipset -F $IPSET; ipset -X $IPSET; } >/dev/null 2>&1
+	{ ip route flush table $TID; ip route flush cache; } >/dev/null 2>&1
+	{ ip route add default via $gwip table $TID; ip route flush cache; } >/dev/null 2>&1
+	{ modprobe xt_set || modprobe ip_set; insmod ip_set_hash_ip; } >/dev/null 2>&1
+	{ ipset -N $IPSET iphash -q; ipset -F $IPSET; } >/dev/null 2>&1
 	for ll in ${lports}; do iptables -t mangle -A PREROUTING -p tcp -m multiport --sport $ll -j MARK --set-mark $FW_MARK/$FW_MARK -m comment --comment "vpnbypass"; done
 	for ll in ${rports}; do iptables -t mangle -A PREROUTING -p tcp -m multiport --dport $ll -j MARK --set-mark $FW_MARK/$FW_MARK -m comment --comment "vpnbypass"; done
-	for ll in ${ranges}; do iptables -t mangle -I PREROUTING -s $ll -j MARK --set-mark $FW_MARK/$FW_MARK -m comment --comment "vpnbypass"; done
+	for ll in ${ranges}; do [ "$ll" = "${ll#*\/*}" ] && ll="${ll}/32"; iptables -t mangle -I PREROUTING -s $ll -j MARK --set-mark $FW_MARK/$FW_MARK -m comment --comment "vpnbypass"; done
 	iptables -t mangle -A PREROUTING -m set --match-set $IPSET dst -j MARK --set-mark $FW_MARK/$FW_MARK -m comment --comment "vpnbypass"
 	ip rule add fwmark $FW_MARK table $TID
-	output "vpnbypass started with TID: $TID FW_MARK: $FW_MARK\n"
+	output "vpnbypass started with TID: $TID; FW_MARK: $FW_MARK\n"
 }
 
 stop_service() {
@@ -58,16 +58,16 @@ stop_service() {
     vpnbypass_enabled || return 1
     config_get routes   'config' 'remotesubnet'
 
-	[ -d /etc/openvpn ] || return 1
-	rm -f /etc/hotplug.d/firewall/${START}-${IPSET}
-	. /lib/functions/network.sh; network_get_ipaddr wanip wan; network_get_gateway gwip wan; network_get_ipaddr lanip lan
-	[ ! "$wanip" ] && output 'ERROR: Could not get wan ip\n' && exit 0
-	[ ! "$gwip" ] && output 'ERROR: Could not get wan gateway\n' && exit 0
-	for ll in ${routes}; do ip route del $ll >/dev/null 2>&1; done
+	for ll in ${routes}; do [ "$ll" = "${ll#*\/*}" ] && ll="${ll}/32"; ip route del $ll >/dev/null 2>&1; done
 #	iptables-save | grep -Fv -- "vpnbypass" | iptables-restore
-	(ip rule del fwmark $FW_MARK table $TID; iptables -t mangle -F; ipset -F $IPSET; ipset -X $IPSET) >/dev/null 2>&1
-	(ip route flush table $TID; ip route flush cache) >/dev/null 2>&1
+	{ ip rule del fwmark $FW_MARK table $TID; iptables -t mangle -F; ipset -F $IPSET; ipset -X $IPSET; } >/dev/null 2>&1
+	{ ip route flush table $TID; ip route flush cache; } >/dev/null 2>&1
 	output "vpnbypass stopped\n"
+}
+
+reload_service()
+{
+	start_service
 }
 
 service_triggers() {


### PR DESCRIPTION
fixed: stop function used to kill the hotplug file
fixed: despite ubus wait_for network.interface.wan and WAN-IF hotplug, sometimes we'd get no WAN ip on start
updated: README.md

Signed-off-by: Stan Grishin <stangri@melmac.net>

