### PR TITLE
packages: add tree new package

### DIFF
--- a/utils/tree/Makefile
+++ b/utils/tree/Makefile
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tree
+PKG_RELEASE:=1
+PKG_VERSION:=1.7.0
+PKG_SOURCE_URL:=ftp://mama.indstate.edu/linux/tree/
+PKG_HASH:=6957c20e82561ac4231638996e74f4cfa4e6faabc5a2f511f0b4e3940e8f7b12
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
+PKG_MAINTAINER:=Banglang Huang <banglang.huang@foxmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/tree
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=List contents of directories in a tree-like format
+  DEPENDS:=+libc +libgcc
+endef
+
+define Package/tree/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tree $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,tree))


### PR DESCRIPTION
Tree is a recursive directory listing command that produces a depth indented listing of files,
which is colorized ala dircolors if the LS_COLORS environment variable is set and output is to tty.

Tree has been ported and reported to work under the following operating systems:
Linux, FreeBSD, OS X, Solaris, HP/UX, Cygwin, HP Nonstop and OS/2.

root@lede:/# tree -L 1
.
├── bin
├── dev
├── etc
├── lib
├── mnt
├── overlay
├── proc
├── rom
├── root
├── sbin
├── sys
├── tmp
├── usr
├── var -> /tmp
└── www

15 directories, 0 files

http://mama.indstate.edu/users/ice/tree/
