### PR TITLE
Unbound: bug fix odhcpd and add auto adblock

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.6.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -27,7 +27,7 @@ PKG_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 
 define Package/unbound/Default
-  TITLE:=Unbound is a validating, recursive, and caching DNS resolver.
+  TITLE:=Validating Recursive DNS Server
   URL:=http://www.unbound.net/
   DEPENDS:=+libopenssl
 endef
@@ -51,7 +51,7 @@ define Package/unbound-anchor
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=IP Addresses and Names
-  TITLE+= (anchor utility)
+  TITLE+= (DSKEY utility)
   DEPENDS+= +unbound +libexpat
 endef
 
@@ -77,7 +77,7 @@ define Package/unbound-control-setup
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=IP Addresses and Names
-  TITLE+= (control setup utility)
+  TITLE+= (control setup)
   DEPENDS+= +unbound-control +openssl-util
 endef
 
@@ -90,7 +90,7 @@ define Package/unbound-host
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=IP Addresses and Names
-  TITLE+= (DNS lookup utility)
+  TITLE+= (lookup utility)
   DEPENDS+= +libunbound
 endef
 

--- a/net/unbound/files/README.md
+++ b/net/unbound/files/README.md
@@ -8,6 +8,9 @@ Unbound may be useful on consumer grade embedded hardware. It is *intended* to b
 
 This package builds on Unbounds capabilities with OpenWrt UCI. Not every Unbound option is in UCI, but rather, UCI simplifies the combination of related options. Unbounds native options are bundled and balanced within a smaller set of choices. Options include resources, DNSSEC, access control, and some TTL tweaking. The UCI also provides an escape option and work at the raw "unbound.conf" level.
 
+## Adblocking
+The UCI scripts will work with OpenWrt/pacakages/net/adblock (2.3.0 and above) if it is installed and enabled. Its all detected and integrated automatically. In brief, the adblock scripts create distinct local-zone files that are simply included in the unbound conf file during UCI generation. If you don't want this, then disable adblock or reconfigure adblock to not send these files to Unbound.
+
 ## HOW TO Integrate with DHCP
 Some UCI options and scripts help Unbound to work with DHCP servers to load the local DNS. The examples provided here are serial dnsmasq-unbound, parallel dnsmasq-unbound, and unbound scripted with odhcpd.
 
@@ -29,7 +32,8 @@ In this case, dnsmasq is not changed *much* with respect to the default OpenWRT/
 **/etc/config/dhcp**:
 
 	config dnsmasq
-		option noresolv '0'
+		option domain 'yourdomain'
+		option noresolv '1'
 		option resolvfile '/tmp/resolv.conf.auto'
 		option port '53'
 		list server '127.0.0.1#1053'
@@ -56,13 +60,12 @@ In this case, Unbound serves your local network directly for all purposes. It wi
 		...
 
 	config dhcp 'lan'
+		# dnsmasq may not issue DNS option if not std. configuration 
 		list dhcp_option 'option:dns-server,0.0.0.0'
 		...
 
 ### Only odhcpd
-Why use dnsmasq you might ask? Well test, try, and review. You can have Unbound and odhcpd only. When odhcpd configures as DHCP lease, it will call a script. The script provided with Unbound will read the lease file and enter DHCP-DNS records as much as dnsmasq once did.
-
-*note: You must install unbound-control. The lease file loads are done without starting, stopping, or re-writing conf files.*
+Why use dnsmasq you might ask? Well test, try, and review. You can have Unbound and odhcpd only. When odhcpd configures each DHCP lease, it will call a script. The script provided with Unbound will read the lease file and enter DHCP-DNS records as much as dnsmasq once did. You **must install** `unbound-control`, because the lease records are added and removed without starting, stopping, flushing cache, or re-writing conf files.
 
 *note: if you run the default LEDE/OpenWrt setup with dnsmasq and odhcpd, then use the link to dnsmasq. Unbound will pole dnsmasq. dnsmasq merges its lease file and odhcpd lease file.*
 

--- a/net/unbound/files/odhcpd.awk
+++ b/net/unbound/files/odhcpd.awk
@@ -74,7 +74,8 @@
 
 
         while ( ( cmd | getline adr ) > 0 ) {
-          if ( substr( adr, 1, 5 ) <= "fd00:" ) {
+          if (( substr( adr, 1, 5 ) <= "fd00:" ) \
+          && ( index( adr, "via" ) == 0 )) {
             # GA or ULA routed addresses only (not LL or MC)
             sub( /\/.*/, "", adr ) ;
             adr = ( adr slaac ) ;


### PR DESCRIPTION
Bug fix dhcp4_slaac6 option was adding to all IP6 routes.
Filtering was added to this process to only include addresses
served from "this dhcp interface."

adblock 2.3.0 file output is now detected and automatically
integrated into Unbound local-zones. adblock deposites its
block site zone-files into /var/lib/unbound. If this is not
desired, then disable adblock or reconfigure to avoid Unbound.

Makefile titles were long for menuconfig including +TITLE.
These have been revised so that menuconfig gets a description.

Maintainer: me
Tested: TL-Archer-C7 w/ LEDE Trunk

@dibdot heads up; this uses existing files and restart (not live loads per email discussion).
@hnyman this one is tested and ready.