### PR TITLE
libs/gnutls: Don't link libidn unintentionally

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -113,6 +113,7 @@ CONFIGURE_ARGS+= \
 	--with-included-unistring \
 	--disable-guile \
 	--disable-nls \
+	--without-idn \
 	--without-zlib \
 	--enable-local-libopts \
 	--disable-doc \


### PR DESCRIPTION
Maintainer: @nmav 
Compile tested: No
Run tested: No

Description:

Fixes compilation, reported by buildbots.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>