### PR TITLE
python-psycopg2: replace python-setuptools dep with python/host

### DIFF
--- a/lang/python-psycopg2/Makefile
+++ b/lang/python-psycopg2/Makefile
@@ -19,7 +19,7 @@ PKG_SOURCE_URL:=http://initd.org/psycopg/tarballs/PSYCOPG-2-6/
 PKG_MD5SUM:=4a392949ba31a378a18ed3e775a4693f
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/psycopg2-$(PKG_VERSION)
-PKG_BUILD_DEPENDS:=python libpq python-setuptools
+PKG_BUILD_DEPENDS:=python libpq python/host
 
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)


### PR DESCRIPTION
Maintainer: @the-alien
Compile tested: https://github.com/lede-project/source/commit/75d48d80c7b6012bcc2efbc3d07a7be5aaaafcc6 PPC 464fp
Run tested: N/A

Description:

Fixes: https://github.com/openwrt/packages/issues/3953

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>