### PR TITLE
ffmpeg: update to 3.2.3, add libshine support and cleanups

### DIFF
--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -1,8 +1,29 @@
 if PACKAGE_libffmpeg-custom
 
+comment "Build Licensing"
+
+config FFMPEG_CUSTOM_GPL
+	bool "Allow use of GPL code"
+	help
+		By default, FFMpeg is licensed under the LGPL. This builds a GPL licensed version.
+		Some software requires this, such as libx264.
+	default y
+
+config FFMPEG_CUSTOM_GPLV3
+	bool "Use (L)GPL v3"
+	help
+		Uses the LPGL v3 if GPL isn't selected, or GPL v3 if it is.
+
 config FFMPEG_CUSTOM_PATENTED
 	bool "Include patented codecs and technologies"
 	default BUILD_PATENTED
+
+comment "Build Properties"
+
+config FFMPEG_CUSTOM_LARGE
+	bool "Build libffmpeg for performance instead of minimizing size on disk"
+	default y if ( x86_64 )
+	default n
 
 comment "Profiles"
 
@@ -105,6 +126,9 @@ config FFMPEG_CUSTOM_AUDIO_DEC_SUPPORT
 
 comment "External Libraries"
 
+config FFMPEG_CUSTOM_SELECT_libshine
+	bool "Libshine"
+
 config FFMPEG_CUSTOM_SELECT_mp3lame
 	bool "MP3 LAME"
 	depends on FFMPEG_CUSTOM_PATENTED
@@ -119,6 +143,7 @@ config FFMPEG_CUSTOM_SELECT_libopus
 config FFMPEG_CUSTOM_SELECT_x264
 	bool "x264"
 	depends on FFMPEG_CUSTOM_PATENTED
+	depends on FFMPEG_CUSTOM_GPL
 	depends on PACKAGE_libx264
 	select FFMPEG_CUSTOM_DECODER_h264
 	select FFMPEG_CUSTOM_MUXER_h264

--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -14,6 +14,13 @@ config FFMPEG_CUSTOM_GPLV3
 	help
 		Uses the LPGL v3 if GPL isn't selected, or GPL v3 if it is.
 
+config FFMPEG_CUSTOM_NONFREE
+	bool "Use code with complex licensing requirements; see help"
+	help
+		This sets --enable-nonfree, which in almost all cases, will prohibit redistribution of the resulting package.
+		Use this with care.
+	default n
+
 config FFMPEG_CUSTOM_PATENTED
 	bool "Include patented codecs and technologies"
 	default BUILD_PATENTED
@@ -126,11 +133,14 @@ config FFMPEG_CUSTOM_AUDIO_DEC_SUPPORT
 
 comment "External Libraries"
 
-config FFMPEG_CUSTOM_SELECT_libshine
-	bool "Libshine"
+#config FFMPEG_CUSTOM_SELECT_libfdk-aac
+#	bool "Fraunhofer FDK AAC encoding library (libfdk-aac)"
+#	depends on FFMPEG_CUSTOM_NONFREE
+#	depends on FFMPEG_CUSTOM_PATENTED
+#	depends on PACKAGE_fdk-aac
 
-config FFMPEG_CUSTOM_SELECT_mp3lame
-	bool "MP3 LAME"
+config FFMPEG_CUSTOM_SELECT_libmp3lame
+	bool "Libmp3lame"
 	depends on FFMPEG_CUSTOM_PATENTED
 	depends on PACKAGE_lame-lib
 	select FFMPEG_CUSTOM_DECODER_mp3
@@ -138,10 +148,13 @@ config FFMPEG_CUSTOM_SELECT_mp3lame
 	select FFMPEG_CUSTOM_DEMUXER_mp3
 
 config FFMPEG_CUSTOM_SELECT_libopus
-	bool "Opus"
+	bool "Libopus"
 
-config FFMPEG_CUSTOM_SELECT_x264
-	bool "x264"
+config FFMPEG_CUSTOM_SELECT_libshine
+	bool "Libshine"
+
+config FFMPEG_CUSTOM_SELECT_libx264
+	bool "Libx264"
 	depends on FFMPEG_CUSTOM_PATENTED
 	depends on FFMPEG_CUSTOM_GPL
 	depends on PACKAGE_libx264

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -287,7 +287,7 @@ $(call Package/ffmpeg/Default)
  SECTION:=libs
  CATEGORY:=Libraries
  TITLE+= libraries
- DEPENDS+= @BUILD_PATENTED +zlib +libbz2
+ DEPENDS+= +libpthread +zlib +libbz2
  PROVIDES:= libffmpeg
 endef
 
@@ -317,6 +317,7 @@ endef
 define Package/libffmpeg-audio-dec
 $(call Package/libffmpeg/Default)
  TITLE+= (audio)
+ DEPENDS+= @BUILD_PATENTED
  VARIANT:=audio-dec
 endef
 
@@ -330,9 +331,15 @@ endef
 define Package/libffmpeg-full
 $(call Package/libffmpeg/Default)
  TITLE+= (full)
- DEPENDS+= +alsa-lib +PACKAGE_libx264:libx264 +PACKAGE_lame-lib:lame-lib +PACKAGE_libopus:libopus +PACKAGE_shine:shine
+ DEPENDS+= @BUILD_PATENTED +alsa-lib +PACKAGE_libopus:libopus
+ ifeq ($(CONFIG_SOFT_FLOAT),y)
+	DEPENDS+= +PACKAGE_shine:shine
+ else
+	DEPENDS+= +PACKAGE_lame-lib:lame-lib +PACKAGE_libx264:libx264
+ endif
  VARIANT:=full
 endef
+
 
 define Package/libffmpeg-full/description
 $(call Package/ffmpeg/Default/description)
@@ -344,6 +351,7 @@ endef
 define Package/libffmpeg-mini
 $(call Package/libffmpeg/Default)
  TITLE+= (mini)
+ DEPENDS+= @BUILD_PATENTED
  VARIANT:=mini
 endef
 
@@ -441,13 +449,20 @@ endif
 
 ifeq ($(BUILD_VARIANT),full)
 	FFMPEG_CONFIGURE+= \
+		$(if $(CONFIG_PACKAGE_libopus),--enable-libopus)
+  ifeq ($(CONFIG_SOFT_FLOAT),y)
+	FFMPEG_CONFIGURE+= \
+		--enable-small \
+		\
+		$(if $(CONFIG_PACKAGE_shine),--enable-libshine)
+  else
+	FFMPEG_CONFIGURE+= \
 		--enable-small \
 		--enable-gpl \
 		\
-		$(if $(CONFIG_PACKAGE_libopus),--enable-libopus) \
-		$(if $(CONFIG_PACKAGE_libx264),--enable-libx264) \
 		$(if $(CONFIG_PACKAGE_lame-lib),--enable-libmp3lame) \
-		$(if $(CONFIG_PACKAGE_shine),--enable-libshine)
+		$(if $(CONFIG_PACKAGE_libx264),--enable-libx264)
+  endif
 endif
 
 ifeq ($(BUILD_VARIANT),custom)
@@ -473,6 +488,10 @@ ifeq ($(BUILD_VARIANT),custom)
 	FFMPEG_CONFIGURE+= --enable-version3
   endif
 
+  ifeq ($(CONFIG_FFMPEG_CUSTOM_NONFREE),y)
+	FFMPEG_CONFIGURE+= --enable-nonfree
+  endif
+
   FFMPEG_CONFIGURE+= \
 	--disable-programs \
 	--disable-avfilter \
@@ -494,9 +513,14 @@ ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_adpcm),y)
 	--enable-decoder=adpcm_ms
 endif
 
-ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libshine),y)
+ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libfdk-aac),y)
   FFMPEG_CONFIGURE+= \
-	--enable-libshine --enable-encoder=libshine
+	--enable-libfdk-aac --enable-encoder=libfdk_aac
+endif
+
+ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libmp3lame),y)
+  FFMPEG_CONFIGURE+= \
+	--enable-libmp3lame --enable-encoder=libmp3lame
 endif
 
 ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libopus),y)
@@ -504,14 +528,14 @@ ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libopus),y)
 	--enable-libopus --enable-decoder=libopus --enable-encoder=libopus
 endif
 
-ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_x264),y)
+ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libshine),y)
   FFMPEG_CONFIGURE+= \
-	--enable-libx264
+	--enable-libshine --enable-encoder=libshine
 endif
 
-ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_mp3lame),y)
+ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libx264),y)
   FFMPEG_CONFIGURE+= \
-	--enable-libmp3lame
+	--enable-libx264 --enable-encoder=libx264
 endif
 
 endif
@@ -550,7 +574,6 @@ ifeq ($(BUILD_VARIANT),mini)
 
   FFMPEG_CONFIGURE+= \
 	--enable-small \
-	--enable-gpl \
 	\
 	--disable-programs \
 	--disable-avdevice \
@@ -561,8 +584,7 @@ ifeq ($(BUILD_VARIANT),mini)
 	--disable-everything \
 	$(call FFMPEG_ENABLE,decoder,$(FFMPEG_MINI_DECODERS)) \
 	$(call FFMPEG_ENABLE,demuxer,$(FFMPEG_MINI_DEMUXERS)) \
-	$(call FFMPEG_ENABLE,protocol,$(FFMPEG_MINI_PROTOCOLS)) \
-
+	$(call FFMPEG_ENABLE,protocol,$(FFMPEG_MINI_PROTOCOLS))
 endif
 
 ifneq ($(CONFIG_TARGET_x86),)
@@ -588,6 +610,17 @@ define Build/InstallDev/custom
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/lib{avcodec,avdevice,avformat,avutil}.pc $(1)/usr/lib/pkgconfig/
 endef
 
+# Soft float is LGPL (no libpostproc); Hard float is GPL (yes libpostproc)
+ifeq ($(CONFIG_SOFT_FLOAT),y)
+define Build/InstallDev/full
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/lib{avcodec,avdevice,avfilter,avformat,avutil,swresample,swscale} $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avdevice,avfilter,avformat,avutil,swresample,swscale}.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/lib{avcodec,avdevice,avfilter,avformat,avutil,swresample,swscale}.pc $(1)/usr/lib/pkgconfig/
+endef
+else
 define Build/InstallDev/full
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/lib{avcodec,avdevice,avfilter,avformat,avutil,postproc,swresample,swscale} $(1)/usr/include/
@@ -596,6 +629,7 @@ define Build/InstallDev/full
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/lib{avcodec,avdevice,avfilter,avformat,avutil,postproc,swresample,swscale}.pc $(1)/usr/lib/pkgconfig/
 endef
+endif
 
 define Build/InstallDev/mini
 	$(INSTALL_DIR) $(1)/usr/include
@@ -652,10 +686,18 @@ define Package/libffmpeg-custom/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avdevice,avformat,avutil}.so.* $(1)/usr/lib/
 endef
 
+# Soft float is LGPL (no libpostproc); Hard float is GPL (yes libpostproc)
+ifeq ($(CONFIG_SOFT_FLOAT),y)
+define Package/libffmpeg-full/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avdevice,avfilter,avformat,avutil,swresample,swscale}.so.* $(1)/usr/lib/
+endef
+else
 define Package/libffmpeg-full/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avdevice,avfilter,avformat,avutil,postproc,swresample,swscale}.so.* $(1)/usr/lib/
 endef
+endif
 
 define Package/libffmpeg-mini/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2006-2017 OpenWrt.org
+# Copyright (C) 2017 Ian Leonard <antonlacon@gmail.com>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,13 +9,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=3.2.2
+PKG_VERSION:=3.2.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
-PKG_MD5SUM:=e34d1b92c5d844f2a3611c741a6dba18
-PKG_HASH:=3f01bd1fe1a17a277f8c84869e5d9192b4b978cb660872aa2b54c3cc8a2fedfc
+PKG_MD5SUM:=4f01244929a992bc5bae4136f329f4b1
+PKG_HASH:=54ce502aca10b7e6059f19220ea2f68fa0c9c4c4d255ae13e615f08f0c94dcc5
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
 PKG_LICENSE:=LGPL-2.1+ GPL-2+ LGPL-3
@@ -224,7 +225,8 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/ffmpeg/Default
  TITLE:=FFmpeg
- URL:=http://ffmpeg.mplayerhq.hu/
+ URL:=https://ffmpeg.org/
+ DEPENDS+= +libpthread
 endef
 
 define Package/ffmpeg/Default/description
@@ -238,7 +240,7 @@ $(call Package/ffmpeg/Default)
  SECTION:=multimedia
  CATEGORY:=Multimedia
  TITLE+= program
- DEPENDS+= +libpthread +libffmpeg-full
+ DEPENDS+= +libffmpeg-full
  VARIANT:=full
 endef
 
@@ -270,7 +272,7 @@ $(call Package/ffserver/Default)
  SECTION:=multimedia
  CATEGORY:=Multimedia
  TITLE+= streaming server
- DEPENDS+= +libpthread +libffmpeg-full
+ DEPENDS+= +libffmpeg-full
  VARIANT:=full
 endef
 
@@ -285,7 +287,7 @@ $(call Package/ffmpeg/Default)
  SECTION:=libs
  CATEGORY:=Libraries
  TITLE+= libraries
- DEPENDS+= @BUILD_PATENTED +libpthread +zlib +libbz2
+ DEPENDS+= @BUILD_PATENTED +zlib +libbz2
  PROVIDES:= libffmpeg
 endef
 
@@ -294,7 +296,8 @@ define Package/libffmpeg-custom
 $(call Package/libffmpeg/Default)
  TITLE+= (custom)
  DEPENDS+= +FFMPEG_CUSTOM_SELECT_libopus:libopus \
-           +PACKAGE_libx264:libx264 +PACKAGE_lame-lib:lame-lib
+           +PACKAGE_libx264:libx264 +PACKAGE_lame-lib:lame-lib \
+           +FFMPEG_CUSTOM_SELECT_libshine:shine
 
  VARIANT:=custom
  MENU:=1
@@ -327,7 +330,7 @@ endef
 define Package/libffmpeg-full
 $(call Package/libffmpeg/Default)
  TITLE+= (full)
- DEPENDS+= +alsa-lib +PACKAGE_libx264:libx264 +PACKAGE_lame-lib:lame-lib +libopus
+ DEPENDS+= +alsa-lib +PACKAGE_libx264:libx264 +PACKAGE_lame-lib:lame-lib +PACKAGE_libopus:libopus +PACKAGE_shine:shine
  VARIANT:=full
 endef
 
@@ -363,14 +366,10 @@ FFMPEG_CONFIGURE:= \
 	--pkg-config="pkg-config" \
 	--enable-shared \
 	--enable-static \
-	--enable-small \
 	--enable-pthreads \
 	--enable-zlib \
 	--disable-doc \
 	--disable-debug \
-	\
-	--enable-gpl \
-	--enable-version3 \
 	\
 	--disable-dxva2 \
 	--disable-lzma \
@@ -415,18 +414,13 @@ FFMPEG_CONFIGURE += \
 else ifneq ($(findstring arm,$(CONFIG_ARCH)),)
 FFMPEG_CONFIGURE += \
 	--disable-runtime-cpudetect
+# XXX: GitHub issue 3320 ppc cpu with fpu but no altivec (WNDR4700)
 else ifneq ($(findstring powerpc,$(CONFIG_ARCH)),)
 FFMPEG_CONFIGURE += \
 	--disable-altivec
 endif
 
-ifneq ($(CONFIG_YASM),y)
-FFMPEG_CONFIGURE += \
-	--disable-yasm
-
-endif
-
-#selectibly disable optimizations according to arch/cpu type
+# selectively disable optimizations according to arch/cpu type
 ifneq ($(findstring arm,$(CONFIG_ARCH)),)
 	ifeq (,$(findstring vfp,$(CONFIG_TARGET_OPTIMIZATION)))
 		FFMPEG_CONFIGURE+= \
@@ -439,11 +433,21 @@ ifneq ($(findstring arm,$(CONFIG_ARCH)),)
 
 endif
 
+ifneq ($(CONFIG_YASM),y)
+FFMPEG_CONFIGURE += \
+	--disable-yasm
+
+endif
+
 ifeq ($(BUILD_VARIANT),full)
 	FFMPEG_CONFIGURE+= \
-		--enable-libopus --enable-decoder=libopus \
+		--enable-small \
+		--enable-gpl \
+		\
+		$(if $(CONFIG_PACKAGE_libopus),--enable-libopus) \
 		$(if $(CONFIG_PACKAGE_libx264),--enable-libx264) \
-		$(if $(CONFIG_PACKAGE_lame-lib),--enable-libmp3lame)
+		$(if $(CONFIG_PACKAGE_lame-lib),--enable-libmp3lame) \
+		$(if $(CONFIG_PACKAGE_shine),--enable-libshine)
 endif
 
 ifeq ($(BUILD_VARIANT),custom)
@@ -452,6 +456,22 @@ ifeq ($(BUILD_VARIANT),custom)
 	$(foreach c, $(2), \
 		$(if $($(3)_$(c)),--enable-$(1)="$(c)") \
 	)
+
+  ifeq ($(CONFIG_FFMPEG_CUSTOM_LARGE),y)
+	FFMPEG_CONFIGURE+= \
+		--enable-hardcoded-tables
+  else
+	FFMPEG_CONFIGURE+= \
+		--enable-small
+  endif
+
+  ifeq ($(CONFIG_FFMPEG_CUSTOM_GPL),y)
+	FFMPEG_CONFIGURE+= --enable-gpl
+  endif
+
+  ifeq ($(CONFIG_FFMPEG_CUSTOM_GPLV3),y)
+	FFMPEG_CONFIGURE+= --enable-version3
+  endif
 
   FFMPEG_CONFIGURE+= \
 	--disable-programs \
@@ -471,13 +491,17 @@ ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_adpcm),y)
   FFMPEG_CONFIGURE+= \
 	--enable-decoder=adpcm_ima_wav \
 	--enable-decoder=adpcm_ima_qt \
-	--enable-decoder=adpcm_ms \
+	--enable-decoder=adpcm_ms
+endif
 
+ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libshine),y)
+  FFMPEG_CONFIGURE+= \
+	--enable-libshine --enable-encoder=libshine
 endif
 
 ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libopus),y)
   FFMPEG_CONFIGURE+= \
-	--enable-libopus --enable-decoder=libopus
+	--enable-libopus --enable-decoder=libopus --enable-encoder=libopus
 endif
 
 ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_x264),y)
@@ -500,6 +524,9 @@ ifeq ($(BUILD_VARIANT),audio-dec)
 	)
 
   FFMPEG_CONFIGURE+= \
+	--enable-small \
+	--enable-gpl \
+	\
 	--disable-programs \
 	--disable-avfilter \
 	--disable-postproc \
@@ -522,6 +549,9 @@ ifeq ($(BUILD_VARIANT),mini)
 	)
 
   FFMPEG_CONFIGURE+= \
+	--enable-small \
+	--enable-gpl \
+	\
 	--disable-programs \
 	--disable-avdevice \
 	--disable-avfilter \


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: mips/ar71xx OpenWrt trunk
Run tested: None

Description:
Updates ffmpeg to 3.2.3 and wires in support for libshine.

Also makes the following changes:

Updates project URL and moves libpthread to a common dependency;
Makes libopus support in libffmpeg-full contingent on selecting the libopus package, like other external libraries;
Adds note regarding disabling altivec in ppc hard-float;
Reorganizes SIMD sections to be together;
Drops the need to specify decoder=libopus from -full, done by default;
Adds encoder=libopus to custom.

Expand options for libffmpeg-custom:
	Build licensing: GPL, GPLv3, LGPLv3
	Building for performance or size

Drops version 3 of GPL for -audio-dec, -mini, and -full. Version 3 is at the discretion of the packager, per:
	http://ffmpeg.org/doxygen/trunk/md_LICENSE.html

This contains some updates relating to issue #3914. More changes will be necessary to resolve that issue, but these should be non-controversial ones. I'll do run testing later in the week, after getting a LEDE environment up, but I suspect others will want to test this too.