### PR TITLE
chrony: set rtcsync option to avoid UNSYNC state

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
 PKG_VERSION:=3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.tuxfamily.org/chrony/

--- a/net/chrony/files/chrony.conf
+++ b/net/chrony/files/chrony.conf
@@ -5,3 +5,6 @@ logchange 0.5
 
 # Don't log client accesses
 noclientlog
+
+# set the system clock else the kernel will always stay in UNSYNC state
+rtcsync


### PR DESCRIPTION
Compile tested: (mips, TP-LINK TL-WR810N, LEDE lede-17.01)
Run tested: (mips, TP-LINK TL-WR810N, LEDE lede-17.01)

Description:

Set rtcsync option in config file. 
Else the system will always stay in UNSYNC state.
Even if there is no real RTC.
See chrony minimal config:
http://chrony.tuxfamily.org/faq.html#_what_is_the_minimum_recommended_configuration_for_an_ntp_client

Set RTC to UTC by default instead of local time.