### PR TITLE
xl2tpd: backporting fix for race condition causing xl2tpd hang

### DIFF
--- a/net/xl2tpd/Makefile
+++ b/net/xl2tpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xl2tpd
 PKG_VERSION:=devel-20151125
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE

--- a/net/xl2tpd/patches/200-xl2tpd-control-fix-xl2tpd-hanged-up-in-fopen.patch
+++ b/net/xl2tpd/patches/200-xl2tpd-control-fix-xl2tpd-hanged-up-in-fopen.patch
@@ -1,0 +1,92 @@
+From 97adf987cf230e47a4800c2f0a0940a1d0d98109 Mon Sep 17 00:00:00 2001
+From: wendy2001011 <wendy2001011@163.com>
+Date: Thu, 9 Feb 2017 17:32:14 +0800
+Subject: [PATCH] xl2tpd-control: fix xl2tpd hanged up in "fopen"
+
+This is a fix for xl2tpd hanged up in "fopen" result fifo while working
+on xl2tpd with OpenWrt.
+
+Root cause is as followings,
+1. xl2tpd-control open result fifo    ##fifo readers=1
+2. xl2tpd-control read result fifo
+3. xl2tpd-control close result fifo     ##fifo readers=0
+4. xl2tpd fopen result fifo                 ##xl2tpd is hanged up here to wait readers
+5.  xl2tpd-control unlink result fifo
+
+The fix replaces the order of "unlink" and "close" when cleaning up to
+avoid hang up issue in fopen, and add the retry waiting when reading
+result fifo.
+
+[Yousong Zhou: 2s as the timeout and 10ms as the check interval]
+---
+ xl2tpd-control.c | 23 +++++++++++++++++++++--
+ 1 file changed, 21 insertions(+), 2 deletions(-)
+
+diff --git a/xl2tpd-control.c b/xl2tpd-control.c
+index 9fcab76..b8bf822 100644
+--- a/xl2tpd-control.c
++++ b/xl2tpd-control.c
+@@ -35,6 +35,7 @@
+ 
+ #define TUNNEL_REQUIRED 1
+ #define TUNNEL_NOT_REQUIRED 0
++#define TIMEOUT 2000000  //timeout is 2s
+ 
+ char result_filename[128];
+ int result_fd = -1;
+@@ -149,9 +150,9 @@ void help()
+ void cleanup(void)
+ {
+     /* cleaning up */
+-    if (result_fd >= 0)
+-	    close (result_fd);
+     unlink (result_filename);
++    if (result_fd >= 0)
++        close (result_fd);
+ }
+ 
+ int main (int argc, char *argv[])
+@@ -340,6 +341,7 @@ void print_error (int level, const char *fmt, ...)
+     va_end (args);
+ }
+ 
++
+ int read_result(int result_fd, char* buf, ssize_t size)
+ {
+     /* read result from result_fd */
+@@ -348,6 +350,11 @@ int read_result(int result_fd, char* buf, ssize_t size)
+      */
+     ssize_t readed = 0;
+     ssize_t len;
++    int write_pipe = 0;
++    struct timeval tvs;
++    struct timeval tve;
++    unsigned long diff;
++    gettimeofday(&tvs, NULL);
+ 
+     do
+     {
+@@ -360,8 +367,20 @@ int read_result(int result_fd, char* buf, ssize_t size)
+                 "error: can't read command result: %s\n", strerror (errno));
+             break;
+         } else if (len == 0) {
++            if(!write_pipe) {
++                 gettimeofday(&tve, NULL);
++                 diff = (tve.tv_sec - tvs.tv_sec) * 1000000 + (tve.tv_usec - tvs.tv_usec);
++                 if (diff >= TIMEOUT) {
++                     print_error (DEBUG_LEVEL, "error: read timout\n");
++                     break;
++                 } else {
++                     usleep(10000);
++                     continue;
++                 }
++            }
+             break;
+         } else {
++            write_pipe = 1;
+             readed += len;
+             if ((size - readed) <= 0)
+                 break;
+-- 
+2.6.4
+


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE r3434-fec57b4
Run tested: malta-be, connection setup

Description:

The original fix was by @wendy2001011 and was accepted into upstream project only earlier today:  https://github.com/xelerance/xl2tpd/pull/125 .  I adapted it to use 2s as the timeout and 10ms as the check interval

I am going to also backport it to lede-17.01 branch.  