### PR TITLE
python,python3: fix ncurses module build

### DIFF
--- a/lang/python/patches/011-remove-setupterm-definition.patch
+++ b/lang/python/patches/011-remove-setupterm-definition.patch
@@ -1,0 +1,12 @@
+diff --git a/Modules/_cursesmodule.c b/Modules/_cursesmodule.c
+index e478a57..eb297b4 100644
+--- a/Modules/_cursesmodule.c
++++ b/Modules/_cursesmodule.c
+@@ -117,7 +117,6 @@ char *PyCursesVersion = "2.2";
+     #defines many common symbols (such as "lines") which breaks the
+     curses module in other ways.  So the code will just specify
+     explicit prototypes here. */
+-extern int setupterm(char *,int,int *);
+ #ifdef __sgi
+ #include <term.h>
+ #endif

--- a/lang/python3/patches/011-fix-ncursesw-definition-colisions.patch
+++ b/lang/python3/patches/011-fix-ncursesw-definition-colisions.patch
@@ -1,0 +1,24 @@
+diff --git a/Modules/_cursesmodule.c b/Modules/_cursesmodule.c
+index 3bf2ca7..c156964 100644
+--- a/Modules/_cursesmodule.c
++++ b/Modules/_cursesmodule.c
+@@ -116,7 +116,6 @@ char *PyCursesVersion = "2.2";
+     #defines many common symbols (such as "lines") which breaks the
+     curses module in other ways.  So the code will just specify
+     explicit prototypes here. */
+-extern int setupterm(char *,int,int *);
+ #ifdef __sgi
+ #include <term.h>
+ #endif
+diff --git a/setup.py b/setup.py
+index af9a414..ee19ecd 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1349,7 +1349,6 @@ class PyBuildExt(build_ext):
+         panel_library = 'panel'
+         if curses_library == 'ncursesw':
+             curses_defines.append(('HAVE_NCURSESW', '1'))
+-            curses_includes.append('/usr/include/ncursesw')
+             # Bug 1464056: If _curses.so links with ncursesw,
+             # _curses_panel.so must link with panelw.
+             panel_library = 'panelw'


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/lede-project/source/commit/70395ae8cbe0bc7d0d0b27b5088b9ac4b2f67f86 mips_24kc
Run tested: N/A

Description:

Adding @artynet ; he reported & tested it works.

Fixes issue reported here: https://github.com/openwrt/packages/commit/b5b6ef34f4b7dbdab32f3300b56f6daec5f78b91

In my case, I saw no failure.
But it looks like under some environments, some build failures occur.

For Python & Python3:  there's a collision with a redefinition of `setupterm()` in both Python/Python3

For Python3, `setup.py` adds the host's `/usr/include/ncursesw` in some setups.

Reported-by: Arturo Rinaldi <arturo@arduino.org>
Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>