### PR TITLE
seafile: update to version 6.0.7

### DIFF
--- a/lang/django-compressor/Makefile
+++ b/lang/django-compressor/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2016 OpenWrt.org
+# Copyright (C) 2007-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-compressor
-PKG_VERSION:=2.1
+PKG_VERSION:=2.1.1
 PKG_RELEASE:=1
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=django_compressor-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/23/46/2c7d582255969ad5259937f5f9e14aec1f3349d0fc0651129330918d1c6d/
+PKG_SOURCE_URL:=https://pypi.python.org/packages/38/58/03098a826062b856956c7169a8f778ec2b8e2767ddc63da0629062df5621/
 PKG_BUILD_DIR:=$(BUILD_DIR)/django_compressor-$(PKG_VERSION)/
-PKG_MD5SUM:=21ecfe4e8615eae64f7068a5599df9af
+PKG_MD5SUM:=5e74141076b70272149ed07e6ce0ea56
 PKG_BUILD_DEPENDS:=python python-setuptools
 
 include $(INCLUDE_DIR)/package.mk

--- a/lang/django-constance/Makefile
+++ b/lang/django-constance/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2016 OpenWrt.org
+# Copyright (C) 2007-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-constance
-PKG_VERSION:=1.2
+PKG_VERSION:=1.3.4
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/0a/ff/1c1caae2b7be9c26f2aee0703236998e22cf5557fa56726347b5afa149d1/
-PKG_MD5SUM:=f9f8e527df50b0a1533149d9be0b814b
+PKG_SOURCE_URL:=https://pypi.python.org/packages/0c/19/74c6bbf29a7882bab377db7a4ca30b43e09173dc1e6cabe163dc8d6a3931/
+PKG_MD5SUM:=2e197701ed93082e5fa41df0f4742294
 PKG_BUILD_DEPENDS:=python python-setuptools
 
 include $(INCLUDE_DIR)/package.mk

--- a/lang/django-restframework/Makefile
+++ b/lang/django-restframework/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2016 OpenWrt.org
+# Copyright (C) 2007-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-restframework
-PKG_VERSION:=3.3.3
+PKG_VERSION:=3.5.4
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=djangorestframework-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://pypi.python.org/packages/source/d/djangorestframework/
+PKG_SOURCE_URL:=https://pypi.python.org/packages/e9/24/86dfe19fb82a40a3d7a4c50371a8bd85b9277d3506698bf332a6d41d08f6/
 PKG_BUILD_DIR:=$(BUILD_DIR)/djangorestframework-$(PKG_VERSION)
-PKG_MD5SUM:=6f5ee9646e7fa87dad4385d3c7e7678d
+PKG_MD5SUM:=979808c387dad8d0ebb6025c39dc7b94
 PKG_BUILD_DEPENDS:=python python-setuptools
 
 include $(INCLUDE_DIR)/package.mk

--- a/lang/django-statici18n/Makefile
+++ b/lang/django-statici18n/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2016 OpenWrt.org
+# Copyright (C) 2007-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-statici18n
-PKG_VERSION:=1.2.1
+PKG_VERSION:=1.3.0
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/72/76/6ee13019e1691bff6b759136068ee77fcc2982b700135caa134030937b28/
-PKG_MD5SUM:=67cac19909dd3272ae1fc73ad8d1dca3
+PKG_SOURCE_URL:=https://pypi.python.org/packages/86/6b/2c2e86a7e144ba7b064119eaafb2c8c67665c2a0e722f0819daa9657e551/
+PKG_MD5SUM:=61e22a6f2399f9f829308e4d91b36ee0
 PKG_BUILD_DEPENDS:=python python-setuptools
 
 include $(INCLUDE_DIR)/package.mk

--- a/lang/django/Makefile
+++ b/lang/django/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2016 OpenWrt.org
+# Copyright (C) 2007-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=1.8.12
+PKG_VERSION:=1.8.17
 PKG_RELEASE=1
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/django/django.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=c168aeba175dbb92c615460a360cb1ea978de5d3
+PKG_SOURCE_VERSION:=d3d12fc11da56e4ea8af37a22a9a0aa6579ab2d5
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
 PKG_BUILD_DEPENDS:=python python-setuptools
 

--- a/lang/openpyxl/Makefile
+++ b/lang/openpyxl/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2016 OpenWrt.org
+# Copyright (C) 2007-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openpyxl
-PKG_VERSION:=2.4.0
+PKG_VERSION:=2.4.2
 PKG_RELEASE:=1
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/7e/75/9bb309f80e4f75d139ecc55e9edf65c5844336b5a84966a609267255f961/
-PKG_MD5SUM:=e3376d1fce0681fd0b4047ab89218af4
+PKG_SOURCE_URL:=https://pypi.python.org/packages/56/c6/a2a7c36196e4732acceca093ce5961db907f5a855b557d6a727a7f59b8b4/
+PKG_MD5SUM:=28b6b5f74f01e6249e8c7f526c57a2e7
 PKG_BUILD_DEPENDS:=python python-setuptools
 
 include $(INCLUDE_DIR)/package.mk

--- a/lang/python-dateutil/Makefile
+++ b/lang/python-dateutil/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dateutil
-PKG_VERSION:=2.5.2
-PKG_RELEASE:=2
+PKG_VERSION:=2.6.0
+PKG_RELEASE:=1
 PKG_LICENSE:=BSD-2-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://pypi.python.org/packages/source/p/python-dateutil/
-PKG_MD5SUM:=eafe168e8f404bf384514f5116eedbb6
+PKG_SOURCE_URL:=https://pypi.python.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/
+PKG_MD5SUM:=6e38f91e8c94c15a79ce22768dfeca87
 PKG_BUILD_DEPENDS:=python python-setuptools
 
 include $(INCLUDE_DIR)/package.mk

--- a/lang/python-urllib3/Makefile
+++ b/lang/python-urllib3/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2016 OpenWrt.org
+# Copyright (C) 2007-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-urllib3
-PKG_VERSION:=1.19
+PKG_VERSION:=1.20
 PKG_RELEASE:=1
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=urllib3-$(PKG_VERSION).tar.gz
 PKG_BUILD_DIR:=$(BUILD_DIR)/urllib3-$(PKG_VERSION)/
-PKG_SOURCE_URL:=https://pypi.python.org/packages/08/37/48b443a36af9eda6274f673b70a9140c13e2409edb2ef20b2d8a620efef5/
-PKG_MD5SUM:=4aa7c6c310cd938683e9b1831e110bac
+PKG_SOURCE_URL:=https://pypi.python.org/packages/20/56/a6aa403b0998f857b474a538343ee483f5c02491bd1aebf61d42a3f60f77/
+PKG_MD5SUM:=34691d4e7e20a8e9cdb452ea24fc38e7
 PKG_BUILD_DEPENDS:=python python-setuptools
 
 include $(INCLUDE_DIR)/package.mk

--- a/libs/libsearpc/Makefile
+++ b/libs/libsearpc/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2016 OpenWrt.org
+# Copyright (C) 2007-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsearpc
-PKG_VERSION:=5.1.4
+PKG_VERSION:=6.0.7
 PKG_RELEASE=$(PKG_SOURCE_VERSION)-1
 PKG_LICENSE:=GPL-3.0
 

--- a/net/seafile-ccnet/Makefile
+++ b/net/seafile-ccnet/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2016 OpenWrt.org
+# Copyright (C) 2007-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-ccnet
-PKG_VERSION:=5.1.4
+PKG_VERSION:=6.0.7
 PKG_RELEASE=$(PKG_SOURCE_VERSION)-1
 PKG_LICENSE:=GPL-3.0
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/haiwen/ccnet.git
+PKG_SOURCE_URL:=https://github.com/haiwen/ccnet-server.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=44f74fdc5160c1bf16a92e71d79b856763ddbc15
+PKG_SOURCE_VERSION:=a0de32b9cfeca98ab93d84cacbe9d315d7ecca35
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -33,7 +33,7 @@ define Package/seafile-ccnet
     DEPENDS:=+libsearpc +libevent2 +libopenssl \
 		+glib2 +python +libzdb +libuuid \
 		+libpthread +libsqlite3 +jansson $(ICONV_DEPENDS)
-    EXTRA_DEPENDS:=libsearpc (=5.1.4-8998e7b2c5587f0b94c48db24e2952d08def5add-1)
+    EXTRA_DEPENDS:=libsearpc (=6.0.7-8998e7b2c5587f0b94c48db24e2952d08def5add-1)
 endef
 
 define Package/seafile-ccnet/description

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2016 OpenWrt.org
+# Copyright (C) 2007-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-seahub
-PKG_VERSION:=5.1.4
-PKG_RELEASE=$(PKG_SOURCE_VERSION)-1
+PKG_VERSION:=6.0.7
+PKG_RELEASE=$(PKG_SOURCE_VERSION)-2
 PKG_LICENSE:=Apache-2.0
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/haiwen/seahub.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=1e1c02aa4f2a0256ffa29a28224aad2d678f43a0
+PKG_SOURCE_VERSION:=2cf75b17a372216a88842172f769d61f621416fd
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/seafile-server/Makefile
+++ b/net/seafile-server/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2016 OpenWrt.org
+# Copyright (C) 2007-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-server
-PKG_VERSION:=5.1.4
-PKG_RELEASE=$(PKG_SOURCE_VERSION)-1
+PKG_VERSION:=6.0.7
+PKG_RELEASE=$(PKG_SOURCE_VERSION)-3
 PKG_LICENSE:=GPL-3.0
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/haiwen/seafile.git
+PKG_SOURCE_URL:=https://github.com/haiwen/seafile-server.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=b9dc96ee845bb0148d9075aec597e6e07652cbdc
+PKG_SOURCE_VERSION:=715f072c1bbc78eedddcaf7748e28c83c3f4dbc6
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -33,7 +33,7 @@ define Package/seafile-server
     DEPENDS:=+libarchive +libopenssl +glib2 +libsearpc +seafile-ccnet +seafile-seahub +sqlite3-cli +python-mysql +python-urllib3 \
 		+jansson +libevent2 +libevent2-openssl +zlib +libzdb +libsqlite3 +libmysqlclient \
 		+libpthread +libuuid +bash +procps-ng +procps-ng-pkill +SEAFILE_FUSE_SUPPORT:libfuse $(ICONV_DEPENDS)
-    EXTRA_DEPENDS:=seafile-ccnet (=5.1.4-44f74fdc5160c1bf16a92e71d79b856763ddbc15-1), seafile-seahub (=5.1.4-1e1c02aa4f2a0256ffa29a28224aad2d678f43a0-1)
+    EXTRA_DEPENDS:=seafile-ccnet (=6.0.7-a0de32b9cfeca98ab93d84cacbe9d315d7ecca35-1), seafile-seahub (=6.0.7-2cf75b17a372216a88842172f769d61f621416fd-2)
     MENU:=1
 endef
 


### PR DESCRIPTION
Update several dependencies, as well:

* django-compressor -> 2.1.1
* django-constance -> 1.3.4
* django-restframework -> 3.5.4
* django-statici18n -> 1.3.0
* django -> 1.8.17
* openpyxl -> 2.4.2
* python-dateutil -> 2.6.0
* python-urllib3 -> 1.20

Maintainer: me
Compile tested: ar71xx, Netgear WNDR4300, openwrt r50104
Run tested: ar71xx, Netgear WNDR4300, openwrt r50104
Tests done:

* clean installation & upgrading from previous version
* post-install configuration after clean install
* first-time run (set up admin account, "My Library" auto-creation)
* basic testing of Seahub web interface (login, browse libraries, upload/download files, change admin interface settings)
* test file syncing using Seafile GUI on Linux

Description: update to version 6.0.7
