### PR TITLE
pcre2: Introduce PCRE2 library into repo for fish

### DIFF
--- a/libs/pcre2/Makefile
+++ b/libs/pcre2/Makefile
@@ -1,0 +1,96 @@
+#
+# Copyright (C) 2017 Shane Peelar
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pcre2
+PKG_VERSION:=10.23
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/
+PKG_MD5SUM:=b2cd00ca7e24049040099b0a46bb3649
+PKG_HASH:=dfc79b918771f02d33968bd34a749ad7487fa1014aeb787fad29dd392b78c56e
+PKG_MAINTAINER:=Shane Peelar <lookatyouhacker@gmail.com>
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENCE
+
+PKG_FIXUP:=autoreconf
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libpcre2/default
+  SECTION:=libs
+  CATEGORY:=Libraries
+  URL:=http://www.pcre.org/
+endef
+
+define Package/libpcre2
+  $(call Package/libpcre2/default)
+  TITLE:=A Perl Compatible Regular Expression library
+endef
+
+define Package/libpcre2-16
+  $(call Package/libpcre2/default)
+  TITLE:=A Perl Compatible Regular Expression library (16bit support)
+endef
+
+
+define Package/libpcre2-32
+  $(call Package/libpcre2/default)
+  TITLE:=A Perl Compatible Regular Expression library (32bit support)
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+CONFIGURE_ARGS += \
+	--enable-pcre2-16 \
+	--enable-pcre2-32 
+
+MAKE_FLAGS += \
+	CFLAGS="$(TARGET_CFLAGS)"
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/pcre2-config $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(2)/bin
+	$(LN) $(STAGING_DIR)/usr/bin/pcre2-config $(2)/bin
+
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/pcre*.h $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre*.{a,so*} $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpcre*.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libpcre2/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre2-{8,posix}.so* $(1)/usr/lib/
+endef
+
+define Package/libpcre2-16/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre2-16.so* $(1)/usr/lib/
+endef
+
+define Package/libpcre2-32/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre2-32.so* $(1)/usr/lib/
+endef
+
+
+
+$(eval $(call BuildPackage,libpcre2))
+$(eval $(call BuildPackage,libpcre2-16))
+$(eval $(call BuildPackage,libpcre2-32))


### PR DESCRIPTION
Need PCRE2 library for the fish shell.  Took existing pcre makefile
as a base to build pcre2, supporting 8, 16, and 32 bit characters with
different install targets for each.

This was originally as part of this PR:
https://github.com/openwrt/packages/pull/3946

Signed-off-by: Shane Peelar <lookatyouhacker@gmail.com>

Maintainer: Shane Peelar / @InBetweenNames
Compile tested: AMD64
Run tested: bcm53xx, RT-AC87U, LEDE snapshots January 30th
