### PR TITLE
icu: support OpenWrt trunk host-build.mk issue

### DIFF
--- a/libs/icu/Makefile
+++ b/libs/icu/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=icu4c
 PKG_VERSION:=58.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-58_2-src.tgz
 PKG_SOURCE_URL:=http://download.icu-project.org/files/$(PKG_NAME)/$(PKG_VERSION)
@@ -64,10 +64,9 @@ CONFIGURE_ARGS:= \
 	--prefix=/usr
 
 HOST_CONFIGURE_CMD:= ./runConfigureICU
+HOST_CONFIGURE_VARS:=
 HOST_CONFIGURE_ARGS:= \
 	Linux/gcc \
-	CC="$(HOSTCC_NOCACHE)" \
-	CXX="$(HOSTCXX_NOCACHE)" \
 	--disable-debug \
 	--enable-release \
 	--enable-shared \


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, mips_34kc_gcc-5.3.0_musl, OpenWrt trunk 50104
                ar71xx, mips_24kc_gcc-5.4.0_musl, LEDE trunk r3503-a112435
Run tested: NONE

Description:
openwrt buildbot reported build failure.

```
./runConfigureICU CC="gcc" CFLAGS="-O2 -I/home/builder/trunk/openwrt/staging_dir/host/include -I/home/builder/trunk/openwrt/staging_dir/host/usr/include -I/home/builder/trunk/openwrt/staging_dir/target-i386_pentium4_glibc-2.22/host/include" CPPFLAGS="-I/home/builder/trunk/openwrt/staging_dir/host/include -I/home/builder/trunk/openwrt/staging_dir/host/usr/include -I/home/builder/trunk/openwrt/staging_dir/target-i386_pentium4_glibc-2.22/host/include" LDFLAGS="-L/home/builder/trunk/openwrt/staging_dir/host/lib -L/home/builder/trunk/openwrt/staging_dir/host/usr/lib -L/home/builder/trunk/openwrt/staging_dir/target-i386_pentium4_glibc-2.22/host/lib" SHELL="/usr/bin/env bash" Linux/gcc CC="gcc" CXX="g++" --disable-debug --enable-release --enable-shared --enable-static --enable-draft --enable-renaming --disable-tracing --disable-extras --enable-dyload --prefix=/home/builder/trunk/openwrt/staging_dir/target-i386_pentium4_glibc-2.22/host ; fi )
runConfigureICU: unrecognized platform "CC=gcc" (use --help for help)
```

"host-build.mk" is differs between OpenWrt and LEDE.

https://github.com/openwrt/packages/pull/3993

https://github.com/lede-project/source/commit/83b6bfc2357458f219872f97ed9c4894106131a1

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
