### PR TITLE
vpnbypass: fix for flushing mangle table

### DIFF
--- a/net/vpnbypass/Makefile
+++ b/net/vpnbypass/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vpnbypass
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 

--- a/net/vpnbypass/files/vpnbypass.init
+++ b/net/vpnbypass/files/vpnbypass.init
@@ -1,28 +1,32 @@
 #!/bin/sh /etc/rc.common
-PKG_NAME='vpnbypass'
 PKG_VERSION=
 
 START=94
 USE_PROCD=1
 
-TID="200"; FW_MARK="0x010000"; IPSET="vpnbypass";
+readonly TID="200" FW_MARK="0x010000" IPSET="vpnbypass"
 
 output() {
 	[ -n "$2" ] && [ ! $(($verbosity & $2)) -gt 0 ] && return 0;
 	[ -t 1 ] && echo -e -n "$1"
-	[ $(echo -e -n "$1" | wc -l) -gt 0 ] && logger -t "${PKG_NAME:-service} [$$]" "$(echo -e -n ${logmsg}${1//$p_name /service })" && logmsg='' || logmsg=${logmsg}${1//p_name /service }
+	[ $(echo -e -n "$1" | wc -l) -gt 0 ] && logger -t "${PKG_NAME:-service} [$$]" "$(echo -e -n ${logmsg}${1})" && logmsg='' || logmsg=${logmsg}${1}
 }
 
 vpnbypass_enabled() {
 	config_load vpnbypass
 	config_get_bool enabled 'config' 'enabled' 0
 	config_get verbosity    'config' 'verbosity' '2'
-	[ -n "$PKG_NAME" -a -n "$PKG_VERSION" ] && p_name="$PKG_NAME $PKG_VERSION" || p_name='vpnbypass'
+	PKG_NAME="${PKG_NAME:-vpnbypass}"
+	[ -n "$PKG_VERSION" ] && p_name="$PKG_NAME $PKG_VERSION" || p_name="$PKG_NAME"
+	[ -t 1 ] || p_name='service'
+	source /lib/functions/network.sh
 	[ "$enabled" -ne "0" ] && return 0
 	output "$p_name is not enabled in the config file!\n"
-	output "To enable, run 'uci set vpnbypass.config.enabled=1; uci commit vpnbypass'\n"
+	output "To enable, run 'uci set $PKG_NAME.config.enabled=1; uci commit $PKG_NAME'\n"
 	return 1
 }
+
+iptables_reset(){ [ -z "$PKG_NAME" ] && return 1; iptables-save | grep -Fv -- "$PKG_NAME" | iptables-restore; lsmod | grep -q ip6table_nat && ip6tables-save | grep -Fv -- "$PKG_NAME" | ip6tables-restore; }
 
 boot() { ubus -t 30 wait_for network.interface.wan && { rc_procd start_service; rc_procd service_triggers; } || output "ERROR: $p_name failed to settle network interface!\n"; }
 
@@ -41,21 +45,20 @@ start_service() {
 	procd_set_param stderr 1
 	procd_close_instance
 
-	source /lib/functions/network.sh
 	while : ; do network_get_ipaddr wanip wan; network_get_gateway gwip wan; [ $c -ge 15 ] && break || let "c+=1"; [ -n "$wanip" -a -n "$gwip" ] && break || output "$p_name waiting for wan gateway...\n"; sleep 2; network_flush_cache; done
 	[ -z "$wanip" -o -z "$gwip" ] && output "ERROR: $p_name could not get wan interface IP: $wanip or gateway: $gwip!\n" && exit 0
 
-	for ll in ${routes}; do { [ "$ll" = "${ll#*\/*}" ] && ll="${ll}/32"; ip route del $ll; ip route add $ll via $gwip; } >/dev/null 2>&1; done
-	{ ip rule del fwmark $FW_MARK table $TID; iptables -t mangle -F; ipset -F $IPSET; ipset -X $IPSET; } >/dev/null 2>&1
-	{ ip route flush table $TID; ip route flush cache; } >/dev/null 2>&1
-	{ ip route add default via $gwip table $TID; ip route flush cache; } >/dev/null 2>&1
-	{ modprobe xt_set || modprobe ip_set; insmod ip_set_hash_ip; } >/dev/null 2>&1
-	{ ipset -N $IPSET iphash -q; ipset -F $IPSET; } >/dev/null 2>&1
-	for ll in ${lports}; do iptables -t mangle -A PREROUTING -p tcp -m multiport --sport $ll -j MARK --set-mark $FW_MARK/$FW_MARK -m comment --comment "vpnbypass"; done
-	for ll in ${rports}; do iptables -t mangle -A PREROUTING -p tcp -m multiport --dport $ll -j MARK --set-mark $FW_MARK/$FW_MARK -m comment --comment "vpnbypass"; done
-	for ll in ${ranges}; do [ "$ll" = "${ll#*\/*}" ] && ll="${ll}/32"; iptables -t mangle -I PREROUTING -s $ll -j MARK --set-mark $FW_MARK/$FW_MARK -m comment --comment "vpnbypass"; done
-	iptables -t mangle -A PREROUTING -m set --match-set $IPSET dst -j MARK --set-mark $FW_MARK/$FW_MARK -m comment --comment "vpnbypass"
-	ip rule add fwmark $FW_MARK table $TID
+	for ll in ${routes}; do ip route del $ll; ip route add $ll via $gwip; done
+	ip rule del fwmark "$FW_MARK" table "$TID" >/dev/null 2>&1; iptables_reset; ipset -q flush "$IPSET"; ipset -q destroy "$IPSET";
+	ip route flush table "$TID"; ip route flush cache;
+	ip route add default via "$gwip" table "$TID"; ip route flush cache;
+	{ modprobe xt_set; modprobe ip_set; modprobe ip_set_hash_ip; } >/dev/null 2>&1
+	ipset -q -exist create "$IPSET" hash:ip; ipset -q flush "$IPSET"
+	for ll in ${lports}; do iptables -t mangle -A PREROUTING -p tcp -m multiport --sport "${ll//-/:}" -j MARK --set-mark "$FW_MARK/$FW_MARK" -m comment --comment "$PKG_NAME"; done
+	for ll in ${rports}; do iptables -t mangle -A PREROUTING -p tcp -m multiport --dport "${ll//-/:}" -j MARK --set-mark "$FW_MARK/$FW_MARK" -m comment --comment "$PKG_NAME"; done
+	for ll in ${ranges}; do iptables -t mangle -I PREROUTING -s "$ll" -j MARK --set-mark "$FW_MARK/$FW_MARK" -m comment --comment "$PKG_NAME"; done
+	iptables -t mangle -A PREROUTING -m set --match-set "$IPSET" dst -j MARK --set-mark "$FW_MARK/$FW_MARK" -m comment --comment "$PKG_NAME"
+	ip rule add fwmark "$FW_MARK" table "$TID"
 	output "$p_name started with TID: $TID; FW_MARK: $FW_MARK\n"
 }
 
@@ -64,14 +67,13 @@ stop_service() {
   vpnbypass_enabled || return 1
   config_get routes   'config' 'remotesubnet'
 
-	for ll in ${routes}; do [ "$ll" = "${ll#*\/*}" ] && ll="${ll}/32"; ip route del $ll >/dev/null 2>&1; done
-#	iptables-save | grep -Fv -- "vpnbypass" | iptables-restore
-	{ ip rule del fwmark $FW_MARK table $TID; iptables -t mangle -F; ipset -F $IPSET; ipset -X $IPSET; } >/dev/null 2>&1
-	{ ip route flush table $TID; ip route flush cache; } >/dev/null 2>&1
+	for ll in ${routes}; do ip route del "$ll"; done
+	ip rule del fwmark "$FW_MARK" table "$TID" >/dev/null 2>&1; iptables_reset; ipset -q flush "$IPSET"; ipset -q destroy "$IPSET";
+	ip route flush table "$TID"; ip route flush cache;
 	output "$p_name stopped\n"
 }
 
-reload_service(){ start_service; }
+reload_service() { start_service; }
 
 service_triggers() {
 		procd_add_reload_trigger 'vpnbypass'


### PR DESCRIPTION
Signed-off-by: Stan Grishin <stangri@melmac.net>
Maintainer: me
Compile tested: (ipq806x, Linksys EA8500, LEDE 17.01 snapshot)
Run tested: (ipq806x, Linksys EA8500, LEDE 17.01 snapshot)

Description:
Biggest changes are lines 29, 52 and 71 -- instead of flushing mangle table I'm deleting the iptables (and ip6tables) rules with the $PKG_NAME comment. 
I've also:
- moved sourcing of /lib/functions/network.sh and PKG_NAME/p_name manipulation into vpnbypass_enabled()
- removed unneeded pipes to null
- made ipset commands less cryptic
- wrapped most variables in double-quotes

I suspect that my earlier PRs were hard to review because I like the long lines (like one-liner iptables_reset on line 29), if it is an issue, please advise and I will reformat the code to make it easier to review.

I've tried looking at igmpproxy and some other packages to try to figure out how can I re-write the iptables rules in the PRCOD-instance compatible format, but failed. :( If there's some sort of documentation on that beyond looking at the code of other packages, please advise.