### PR TITLE
Aria2: Bump to 1.31.0

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
-PKG_VERSION:=1.30.0
+PKG_VERSION:=1.31.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/
-PKG_MD5SUM:=8c22f569d3fb9e42c5fd9a95173b9b5f
+PKG_HASH:=7b85619048b23406f241e38a5b1b8b0bc2cae9e80fd117810c2a71ecca813f8c
 PKG_INSTALL:=1
 
 PKG_MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>, Hsing-Wang Liao <kuoruan@gmail.com>


### PR DESCRIPTION
Better error message when local file status cannot be retrieved

Fix assertion failure in SimpleRandomizer::getRandomBytes

errno might not be initialized to 0, and we may get both rv == -1
and errno != ENOSYS. This leads to assertion failure. Since
getrandom_linux always returns -1 on failure, checking errno is
useless in this function.

Add option content-disposition-default-utf8

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>