### PR TITLE
apache : fixing zlib dependency

### DIFF
--- a/net/apache/Makefile
+++ b/net/apache/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apache
 PKG_VERSION:=2.4.25
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE_NAME:=httpd
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=Apache License

--- a/net/apache/Makefile
+++ b/net/apache/Makefile
@@ -40,7 +40,7 @@ endef
 
 define Package/apache
 $(call Package/apache/Default)
-  DEPENDS:=+libapr +libaprutil +libpcre +libopenssl +unixodbc 
+  DEPENDS:=+libapr +libaprutil +libpcre +libopenssl +unixodbc +zlib
 endef
 
 define Package/apache/description


### PR DESCRIPTION
Maintainer: @heil 
Compile tested: (ar71xx mips BE, generic, OpenWRT/LEDE trunk)
Run tested: (ar71xx mips BE, generic, OpenWRT/LEDE trunk)

Description:

apparently **apache** needs **zlib** as additional dependency to be properly packaged.