### PR TITLE
Aria2: Edit config and update

### DIFF
--- a/net/aria2/Config.in
+++ b/net/aria2/Config.in
@@ -1,8 +1,8 @@
-menu "Aria2 configuration"
+menu "Aria2 Configuration"
 	depends on PACKAGE_aria2
 
 choice
-	prompt "SSL library"
+	prompt "SSL Library"
 	default ARIA2_OPENSSL
 
 config ARIA2_OPENSSL
@@ -12,33 +12,41 @@ config ARIA2_GNUTLS
 	bool "GNUTLS"
 
 config ARIA2_NOSSL
-	bool "No SSL support"
+	bool "No SSL Support"
 
 endchoice
 
 config ARIA2_BITTORRENT
-	bool "Enable bittorrent support"
+	bool "Enable Bittorrent Support"
 	depends on ARIA2_OPENSSL
 	default n
 
-config ARIA2_METALINK
-	bool "Enable metalink support"
-	default n
-
 config ARIA2_SFTP
-        bool "Enable sftp support"
+        bool "Enable SFTP Support"
         default n
 
+config ARIA2_ASYNC_DNS
+	bool "Enable Async DNS Support"
+	default n
+
+config ARIA2_COOKIE
+	bool "Enable Firefox3/Chromium Cookie Support"
+	default n
+
+config ARIA2_METALINK
+	bool "Enable Metalink Support"
+	default n
+
 choice
-	prompt "XML library"
-	default ARIA2_EXPAT
+	prompt "XML Library"
+	default ARIA2_LIBXML2
 	depends on ARIA2_METALINK
+
+config ARIA2_LIBXML2
+        bool "LIBXML2"
 
 config ARIA2_EXPAT
 	bool "EXPAT"
-
-config ARIA2_LIBXML2
-	bool "LIBXML2"
 
 endchoice
 

--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -24,8 +24,10 @@ PKG_CONFIG_DEPENDS := \
   ARIA2_OPENSSL \
   ARIA2_GNUTLS \
   ARIA2_BITTORRENT \
-  ARIA2_METALINK \
   ARIA2_SFTP \
+  ARIA2_ASYNC_DNS \
+  ARIA2_COOKIE \
+  ARIA2_METALINK \
   ARIA2_EXPAT \
   ARIA2_LIBXML2
 
@@ -41,7 +43,7 @@ define Package/aria2
   SUBMENU:=File Transfer
   TITLE:=lightweight download utility
   URL:=https://aria2.github.io/
-  DEPENDS:=+zlib +ARIA2_SFTP:libssh2 +ARIA2_LIBXML2:libxml2 +ARIA2_EXPAT:libexpat +libstdcpp +ARIA2_OPENSSL:libopenssl +ARIA2_GNUTLS:libgnutls
+  DEPENDS:=+zlib +libstdcpp +ARIA2_SFTP:libssh2 +ARIA2_ASYNC_DNS:libcares +ARIA2_COOKIE:libsqlite3 +ARIA2_LIBXML2:libxml2 +ARIA2_EXPAT:libexpat +ARIA2_OPENSSL:libopenssl +ARIA2_GNUTLS:libgnutls
 endef
 
 define Package/aria2/description
@@ -52,19 +54,19 @@ endef
 CONFIGURE_ARGS += \
 	--disable-nls \
 	$(if $(CONFIG_ARIA2_NOSSL),--disable,--enable)-ssl \
-	$(if $(CONFIG_ARIA2_OPENSSL),--with,--without)-openssl \
-	$(if $(CONFIG_ARIA2_GNUTLS),--with,--without)-gnutls \
 	$(if $(CONFIG_ARIA2_BITTORRENT),--enable,--disable)-bittorrent \
 	$(if $(CONFIG_ARIA2_METALINK),--enable,--disable)-metalink \
+	$(if $(CONFIG_ARIA2_OPENSSL),--with,--without)-openssl \
+	$(if $(CONFIG_ARIA2_GNUTLS),--with,--without)-gnutls \
 	$(if $(CONFIG_ARIA2_SFTP),--with,--without)-libssh2 \
+	$(if $(CONFIG_ARIA2_ASYNC_DNS),--with,--without)-libcares \
+	$(if $(CONFIG_ARIA2_COOKIE),--with,--without)-sqlite3 \
 	$(if $(CONFIG_ARIA2_LIBXML2),--with,--without)-libxml2 \
 	$(if $(CONFIG_ARIA2_EXPAT),--with,--without)-libexpat \
 	--without-libnettle \
 	--without-libgmp \
 	--without-libgcrypt \
-	--without-libcares \
 	--without-libuv \
-	--without-sqlite3 \
 	--with-libz
 
 define Package/aria2/install

--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
-PKG_VERSION:=1.30.0
+PKG_VERSION:=1.31.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/
-PKG_MD5SUM:=8c22f569d3fb9e42c5fd9a95173b9b5f
+PKG_HASH:=7b85619048b23406f241e38a5b1b8b0bc2cae9e80fd117810c2a71ecca813f8c
 PKG_INSTALL:=1
 
 PKG_MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>, Hsing-Wang Liao <kuoruan@gmail.com>


### PR DESCRIPTION
* Add more feature choices: Async DNS Support, Firefox3/Chromium Cookie Support.
* Switch default XML parser library to Libxml2, Expat has no update for a long time.
* Bump version to v1.31.0.
* Enable all features by default.

This commit https://github.com/openwrt/packages/commit/2b8aeb50029bb3a46517bd0508b05925bd793f0c revert the default setting, but I think we should enable them.

Maintainer: Hsing-Wang Liao <kuoruan@gmail.com> / @kuoruan
Compile tested: master version
Run tested: arm
