### PR TITLE
lcdproc: alternative package to drive LCD displays

### DIFF
--- a/utils/lcdproc/Makefile
+++ b/utils/lcdproc/Makefile
@@ -1,0 +1,177 @@
+#
+# Copyright (C) 2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=lcdproc
+# PKG_VERSION:=0.5.8
+PKG_BASE_VERSION:=0.5.8
+PKG_VERSION:=$(PKG_BASE_VERSION)+git2070222
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/lcdproc/lcdproc.git
+PKG_SOURCE_VERSION:=156983afab6d8f49d9a84e2a0929874eac569cc3
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_BASE_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_BASE_VERSION)
+
+#PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+#PKG_SOURCE_URL:=https://github.com/lcdproc/lcdproc/releases/download/v$(PKG_VERSION)/
+#PKG_MD5SUM:=1dd25676946c61184c6f51cc0a75379e
+PKG_MAINTAINER:=Harald Geyer <harald@ccbib.org>, \
+		Philip Prindeville <philipp@redfish-solutions.com>
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/lcdproc/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  URL:=http://lcdproc.org/
+endef
+
+define Package/lcdproc/Default-description
+LCDProc is a daemon and clients for displaying system information
+on various LCD displays
+endef
+
+
+define Package/lcdproc-clients
+  $(call Package/lcdproc/Default)
+  TITLE:=LCD Display clients
+endef
+
+define Package/lcdproc-clients/description
+$(call Package/lcdproc/Default-description)
+
+This package contains the clients distributed by the official lcdproc
+project:
+* lcdproc -- displays system information
+* lcdexec -- displays a menu structure to execute commands
+* lcdvc -- shows the content of the system console
+endef
+
+define Package/lcdproc-clients/conffiles
+/etc/lcdproc.conf
+/etc/lcdexec.conf
+/etc/lcdvc.conf
+endef
+
+
+define Package/lcdproc-server
+  $(call Package/lcdproc/Default)
+  TITLE:=LCD Display server
+  DEPENDS:=+libpthread
+endef
+
+define LCDPROC_CORE_DRIVERS_TEXT
+bayrad CFontzPacket CFontz CwLnx ea65 EyeboxOne glk icp_a106 imonlcd
+imon irtrans joy lb216 lcdm001 lcterm linux_input MD8800 ms6931
+mtc_s16209x MtxOrb NoritakeVFD Olimex_MOD_LCD1x9 pyramid rawserial
+serialPOS serialVFD sli SureElec text tyan vlsys_m428 yard2LCD
+endef
+
+LCDPROC_CORE_DRIVERS:=$(strip $(LCDPROC_CORE_DRIVERS_TEXT))
+
+define Package/lcdproc-server/description
+$(call Package/lcdproc/Default-description)
+
+This package contains the server and a core set of display drivers
+without external dependencies:
+$(LCDPROC_CORE_DRIVERS_TEXT)
+endef
+
+define Package/lcdproc-server/conffiles
+/etc/LCDd.conf
+endef
+
+
+define Package/lcdproc-drivers
+  $(call Package/lcdproc/Default)
+  TITLE:=LCD Display extra drivers
+  DEPENDS:=+lcdproc-server +libncurses +libusb-1.0 +libusb-compat +libftdi1 \
+	+GPIO_SUPPORT:libugpio
+endef
+
+define LCDPROC_OTHER_DRIVERS_TEXT
+curses futaba glcd hd44780 IOWarrior i2500vfd lis picolcd shuttleVFD ula200
+endef
+
+ifeq ($(CONFIG_PACKAGE_kmod-lp),y)
+LCDPROC_OTHER_DRIVERS_TEXT+=sdeclcd sed1330 sed1520 stv5730 t6963
+endif
+
+LCDPROC_OTHER_DRIVERS:=$(strip $(LCDPROC_OTHER_DRIVERS_TEXT))
+
+define Package/lcdproc-drivers/description
+$(call Package/lcdproc/Default-description)
+
+This package contains display drivers with external dependencies:
+$(LCDPROC_OTHER_DRIVERS_TEXT)
+endef
+
+
+# not everything groks --disable-nls
+CONFIGURE_ARGS := $(filter-out --%-nls,$(CONFIGURE_ARGS))
+
+CONFIGURE_ARGS += \
+	--disable-libX11 \
+	--disable-libhid \
+	--disable-libpng \
+	--disable-freetype \
+	--enable-drivers='all,!g15,!g15driver,!glcdlib,!irman,!lirc,!mdm166a,!mx5000,!svga,!xosd'
+
+# can't use -Wformat=2 because MUSL is somewhat broken
+TARGET_CFLAGS+=-Wall
+
+MAKE_FLAGS += \
+        CFLAGS="$(TARGET_CFLAGS)" \
+        LDFLAGS="$(TARGET_LDLAGS)"
+
+
+define Package/lcdproc-clients/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/clients/lcdproc/lcdproc $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/clients/lcdexec/lcdexec $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/clients/lcdvc/lcdvc $(1)/usr/bin/
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/clients/lcdproc/lcdproc.conf $(1)/etc/
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/clients/lcdexec/lcdexec.conf $(1)/etc/
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/clients/lcdvc/lcdvc.conf $(1)/etc/
+	$(INSTALL_BIN) ./files/lcd* $(1)/etc/init.d/
+endef
+
+define Package/lcdproc-server/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/usr/lib/lcdproc
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/server/LCDd $(1)/usr/sbin/
+	$(CP) $(foreach driver,$(LCDPROC_CORE_DRIVERS),$(PKG_BUILD_DIR)/server/drivers/$(driver).so) $(1)/usr/lib/lcdproc/
+	$(CP) -p $(PKG_BUILD_DIR)/LCDd.conf $(PKG_BUILD_DIR)/LCDd.conf.orig
+	sed -i -r \
+		-e 's!^(DriverPath=).*$$$$!\1/usr/lib/lcdproc/!' \
+		-e 's!^(Driver=)curses$$$$!\1sdeclcd!' \
+		$(PKG_BUILD_DIR)/LCDd.conf
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/LCDd.conf $(1)/etc/
+	$(INSTALL_BIN) ./files/LCDd $(1)/etc/init.d/
+endef
+
+define Package/lcdproc-drivers/install
+	$(INSTALL_DIR) $(1)/usr/lib/lcdproc
+	$(CP) $(foreach driver,$(LCDPROC_OTHER_DRIVERS),$(PKG_BUILD_DIR)/server/drivers/$(driver).so) $(1)/usr/lib/lcdproc/
+endef
+
+
+$(eval $(call BuildPackage,lcdproc-clients))
+$(eval $(call BuildPackage,lcdproc-server))
+$(eval $(call BuildPackage,lcdproc-drivers))
+

--- a/utils/lcdproc/files/LCDd
+++ b/utils/lcdproc/files/LCDd
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+
+START=22
+USE_PROCD=1
+PROG=/usr/sbin/LCDd
+
+config_file=/etc/LCDd.conf
+
+start_service() {
+	procd_open_instance
+	procd_set_param command $PROG -f -c $config_file
+	procd_close_instance
+}
+

--- a/utils/lcdproc/files/lcdexec
+++ b/utils/lcdproc/files/lcdexec
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+
+START=50
+USE_PROCD=1
+PROG=/usr/bin/lcdexec
+
+config_file=/etc/lcdexec.conf
+
+start_service() {
+	procd_open_instance
+	procd_set_param command $PROG -f -c $config_file
+	procd_close_instance
+}
+

--- a/utils/lcdproc/files/lcdproc
+++ b/utils/lcdproc/files/lcdproc
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+
+START=50
+USE_PROCD=1
+PROG=/usr/bin/lcdproc
+
+config_file=/etc/lcdproc.conf
+
+start_service() {
+	procd_open_instance
+	procd_set_param command $PROG -f -c $config_file
+	procd_close_instance
+}
+

--- a/utils/lcdproc/files/lcdvc
+++ b/utils/lcdproc/files/lcdvc
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+
+START=50
+USE_PROCD=1
+PROG=/usr/bin/lcdvc
+
+config_file=/etc/lcdvc.conf
+
+start_service() {
+	procd_open_instance
+	procd_set_param command $PROG -f -c $config_file
+	procd_close_instance
+}
+


### PR DESCRIPTION
Maintainer: me, @haraldg 
Compile tested: x86_64, xeon, OpenWRT head (871372c42a3)
Run tested: same

Been using on a Lanner FW-8771 with the display driver set to `sdeclcd`.

Tested by running `lcdproc -s localhost -p 13666 C L M I`.

All screens work correctly.

Description:

See the [LCDprog](http://lcdproc.org/) website.