### PR TITLE
lighttpd: update to 1.4.45

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
-PKG_VERSION:=1.4.42
-PKG_RELEASE:=2
+PKG_VERSION:=1.4.45
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://download.lighttpd.net/lighttpd/releases-1.4.x
-PKG_MD5SUM:=53c55d7e1dac7adec161cd5490491f6d
+PKG_MD5SUM:=a128e1eda76899ce3fd115efae5fe631
 
 PKG_LICENSE:=BSD-3c
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: me
Compile tested: BCM27xx/Raspberry Pi Models B/B+/CM/OpenWrt master

Description:
Update to 1.4.42 introduced a problem with starting lighttpd as
OpenWrt/LEDE service. It was stopping whole init process at sth like:
  783 root      1124 S    {S50lighttpd} /bin/sh /etc/rc.common /etc/rc.d/S50lighttpd boot
  799 root      1164 S    /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf

It was hanging until getting random pool:
[  176.340007] random: nonblocking pool is initialized
and then immediately the rest of init process followed:
[  176.423475] jffs2_scan_eraseblock(): End of filesystem marker found at 0x0
[  176.430754] jffs2_build_filesystem(): unlocking the mtd device... done.
[  176.437615] jffs2_build_filesystem(): erasing all blocks after the end marker... done.

This was fixed in 1.4.44, but bump directly to 1.4.45 while at it.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>