### PR TITLE
net/wireguard: add stub install section

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -67,6 +67,10 @@ define Build/Compile
 	$(call Build/Compile/Default)
 endef
 
+define Package/wireguard/install
+  true
+endef
+
 define Package/wireguard/description
   $(call Package/wireguard/Default/description)
 endef


### PR DESCRIPTION
This is in response to the metapackage discussion in openwrt/luci#1030.


Maintainer: me / @zx2c4 / @danrl / @zorun