### PR TITLE
boost: 1.63 Revision 2 - Fixed Regression

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -18,7 +18,7 @@ include $(INCLUDE_DIR)/target.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.63.0
 PKG_SOURCE_VERSION:=1_63_0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceforge.net/projects/boost/files/boost/$(PKG_VERSION)

--- a/libs/boost/patches/02_fix_libc_regression_execution_monitor.patch
+++ b/libs/boost/patches/02_fix_libc_regression_execution_monitor.patch
@@ -1,0 +1,22 @@
+Index: boost_1_63_0/boost/test/impl/execution_monitor.ipp
+===================================================================
+--- boost_1_63_0.orig/boost/test/impl/execution_monitor.ipp
++++ boost_1_63_0/boost/test/impl/execution_monitor.ipp
+@@ -1375,7 +1375,7 @@ enable( unsigned mask )
+ #endif
+ 
+     return ~old_cw & BOOST_FPE_ALL;
+-#elif defined(__GLIBC__) && defined(__USE_GNU)
++#elif defined(__GLIBC__) && defined(__USE_GNU) && !defined(BOOST_CLANG) && !defined(BOOST_NO_FENV_H)
+     if (BOOST_FPE_ALL == BOOST_FPE_OFF)
+         /* Not Implemented */
+         return BOOST_FPE_OFF;
+@@ -1415,7 +1415,7 @@ disable( unsigned mask )
+ #endif
+ 
+     return ~old_cw & BOOST_FPE_ALL;
+-#elif defined(__GLIBC__) && defined(__USE_GNU)
++#elif defined(__GLIBC__) && defined(__USE_GNU) && !defined(BOOST_CLANG) && !defined(BOOST_NO_FENV_H)
+     if (BOOST_FPE_ALL == BOOST_FPE_OFF)
+         /* Not Implemented */
+         return BOOST_FPE_INV;


### PR DESCRIPTION
Maintainer: @ClaymorePT
Compile tested: ixp4xx for LEDE trunk
Run tested: Compiled successfully.

Description:
This commit fixes an existent regression in boost 1.63 [1].
The regression appears when libc is used for the toolchain.

[1] -  https://svn.boost.org/trac/boost/ticket/11756

Signed-off-by: Carlos Miguel Ferreira <carlosmf.pt@gmail.com>