### PR TITLE
boost: Release 3 -> disabled unsuported targets for context and fiber

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -18,7 +18,7 @@ include $(INCLUDE_DIR)/target.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.63.0
 PKG_SOURCE_VERSION:=1_63_0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceforge.net/projects/boost/files/boost/$(PKG_VERSION)
@@ -253,6 +253,8 @@ define Package/boost/config
 			prompt "Boost $(lib) library."
 			default m if ALL
 			$(if $(findstring locale,$(lib)),depends on BUILD_NLS,)\
+			$(if $(findstring context,$(lib)),depends on @(!TARGET_avr32&&!TARGET_octeon&&!TARGET_netlogic),)\			
+			$(if $(findstring fiber,$(lib)),depends on @(!TARGET_ar7&&!TARGET_rb532&&!TARGET_brcm63xx_smp&&!TARGET_brcm63xx&&!TARGET_brcm47xx&&!TARGET_brcm47xx_legacy&&!TARGET_brcm2708&&!TARGET_au1000&&!TARGET_ath25&&!TARGET_adm8668&&!TARGET_adm5120),)\
 			$(if $(findstring python,$(lib)),depends on PACKAGE_$(lib),)
 
 		)


### PR DESCRIPTION
Maintainer: @ClaymorePT
Compile tested: menuconfig dependency changes only.
Run tested: menuconfig dependency changes only.

Description:
Because there are several architectures that are not supported by context or fiber, it became necesary to disabled them so that the remaining boost libs could be built without problems.

Disabled targets for fiber:
 - rb532
 - ar7
 - brcm63xx
 - brcm63xx
 - brcm47xx
 - brcm47xx
 - brcm2708
 - au1000
 - ath25
 - adm8668
 - adm5120

Disabled targets for context:
 - avr32
 - octeon
 - netlogic

Signed-off-by: Carlos Miguel Ferreira <carlosmf.pt@gmail.com>