### PR TITLE
libpfring: add new package

### DIFF
--- a/kernel/pfring/Makefile
+++ b/kernel/pfring/Makefile
@@ -1,0 +1,63 @@
+#
+# Copyright (C) 2017 Banglang Huang
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=pfring
+PKG_VERSION:=7.2.0
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Banglang Huang <banglang.huang@foxmail.com>
+
+PKG_LICENSE:=GPL-2.0
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/ntop/PF_RING/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=5d349ac37a6ece5966bf606a6f131d628b98d88654c2f502d3c4b8bbf6ef9796
+
+PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/PF_RING-$(PKG_VERSION)
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+CONFIGURE_PATH:=kernel
+MAKE_PATH:=kernel
+
+define KernelPackage/pfring
+  SUBMENU:=Network Support
+  TITLE:=PF_RING Kernel driver
+  FILES:=$(PKG_BUILD_DIR)/kernel/pf_ring.ko
+  AUTOLOAD:=$(call AutoLoad,90,pf_ring,1)
+endef
+
+define KernelPackage/pfring/description
+  Kernel module for libpfring package
+endef
+
+EXTRA_CFLAGS += \
+	-I$(PKG_BUILD_DIR)/kernel
+
+MAKE_OPTS := \
+	ARCH="$(LINUX_KARCH)" \
+	CROSS_COMPILE="$(TARGET_CROSS)" \
+	SUBDIRS="$(PKG_BUILD_DIR)/kernel" \
+	CFLAGS="$(TARGET_CFLAGS)" \
+	EXTRA_CFLAGS="$(EXTRA_CFLAGS)"
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/linux
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/linux/*.h $(1)/usr/include/linux
+endef
+
+define Build/Compile
+	+$(MAKE) -C "$(LINUX_DIR)" \
+		$(MAKE_OPTS) \
+		modules
+endef
+
+$(eval $(call KernelPackage,pfring))

--- a/libs/libpfring/Makefile
+++ b/libs/libpfring/Makefile
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2017 Banglang Huang
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libpfring
+PKG_VERSION:=7.2.0
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Banglang Huang <banglang.huang@foxmail.com>
+
+PKG_LICENSE:=LGPL-2.1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/ntop/PF_RING/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=5d349ac37a6ece5966bf606a6f131d628b98d88654c2f502d3c4b8bbf6ef9796
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/PF_RING-$(PKG_VERSION)
+
+PKG_INSTALL:=1
+PKG_FIXUP:=patch-libtool
+
+include $(INCLUDE_DIR)/package.mk
+
+CONFIGURE_PATH:=userland
+MAKE_PATH:=userland/lib
+
+define Package/libpfring
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Library for PR_RING (package process framework)
+  URL:=https://github.com/ntop/pf_ring
+  DEPENDS:=+kmod-pfring +libpcap +libpthread
+endef
+
+define Package/libpfring/description
+  PF_RING is a high speed packet capture library that turns a commodity PC into an efficient and cheap
+  network measurement box suitable for both packet and active traffic analysis and manipulation.
+  Moreover, PF_RING opens totally new markets as it enables the creation of efficient application such as
+  traffic balancers or packet filters in a matter of lines of codes.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/include/* \
+		$(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/libpfring.so* \
+		$(1)/usr/lib/
+endef
+
+CONFIGURE_VARS += \
+	MACHINE="$(ARCH)"
+
+define Package/libpfring/install
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/libpfring.so* \
+		$(1)/usr/lib/
+	$(LN) libpfring.so $(1)/usr/lib/libpfring.so.1
+endef
+
+$(eval $(call BuildPackage,libpfring))

--- a/libs/libpfring/patches/0001-fix-cross-compiling.patch
+++ b/libs/libpfring/patches/0001-fix-cross-compiling.patch
@@ -1,0 +1,32 @@
+--- a/userland/configure
++++ b/userland/configure
+@@ -3745,12 +3745,6 @@ fi
+ if test "$IS_FREEBSD" != "1"; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if r/w locks are supported" >&5
+ $as_echo_n "checking if r/w locks are supported... " >&6; }
+-  if test "$cross_compiling" = yes; then :
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run test program while cross compiling
+-See \`config.log' for more details" "$LINENO" 5; }
+-else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+@@ -3763,7 +3757,7 @@ else
+ 
+ 
+ _ACEOF
+-if ac_fn_c_try_run "$LINENO"; then :
++if ac_fn_c_try_compile "$LINENO"; then :
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ $as_echo "yes" >&6; }
+ cat >>confdefs.h <<_ACEOF
+@@ -3777,7 +3771,6 @@ $as_echo "no" >&6; }
+ fi
+ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+   conftest.$ac_objext conftest.beam conftest.$ac_ext
+-fi
+ 
+ fi
+ 

--- a/libs/libpfring/patches/0002-fix-march-native.patch
+++ b/libs/libpfring/patches/0002-fix-march-native.patch
@@ -1,0 +1,21 @@
+--- a/userland/configure
++++ b/userland/configure
+@@ -3296,14 +3296,16 @@ fi
+ done
+ 
+ 
+-MACHINE=`uname -m`
++if test -z "$MACHINE"; then
++  MACHINE=`uname -m`
++fi
+ CFLAGS=""
+ SYS_LIBS=""
+ 
+ VER=`cat ../kernel/linux/pf_ring.h | grep RING_VERSION | head -1 | cut -d '"' -f 2`
+ MAJOR_VER=`cat ../kernel/linux/pf_ring.h | grep RING_VERSION | head -1 | cut -d '"' -f 2 | cut -d '.' -f 1`
+ 
+-NATIVE=`$CC -c -Q -march=native --help=target| grep "march" | xargs | cut -d ' ' -f 2`
++NATIVE=`$CC -c -Q --help=target| grep "march" | xargs | cut -d ' ' -f 2`
+ if test -f "lib/libs/libpfring_zc_x86_64_$NATIVE.a"; then
+   CFLAGS="-march=native -mtune=native $CFLAGS"
+   LIBARCH="_$NATIVE"

--- a/libs/libpfring/patches/0003-fix-strncpy.patch
+++ b/libs/libpfring/patches/0003-fix-strncpy.patch
@@ -1,0 +1,10 @@
+--- a/userland/lib/pfring_mod.c
++++ b/userland/lib/pfring_mod.c
+@@ -24,6 +24,7 @@
+ #include <ifaddrs.h>
+ 
+ #ifdef ENABLE_BPF
++#include <string.h>
+ #include <pcap/pcap.h>
+ #include <pcap/bpf.h>
+ #include <pcap-int.h>


### PR DESCRIPTION
PF_RING is a high speed packet capture library that turns a commodity PC into an efficient and cheap
network measurement box suitable for both packet and active traffic analysis and manipulation.
Moreover, PF_RING opens totally new markets as it enables the creation of efficient application such as
traffic balancers or packet filters in a matter of lines of codes.

Signed-off-by: BangLang Huang <banglang.huang@foxmail.com>

official: http://www.ntop.org/products/packet-capture/pf_ring/
github: https://github.com/ntop/pf_ring

Maintainer: me
Compile tested: x86_64, x86_64 relevant machine, LEDE latest
Run tested: x86_64, x86_64 relevant machine, LEDE latest, tests done


