### PR TITLE
adblock: update 2.3.2

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=2.3.1
+PKG_VERSION:=2.3.2
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>


### PR DESCRIPTION
Maintainer: me
Compile tested: not relevant
Run tested: LEDE r3544-55ffc38004

Description:
* optimize memory consumption & enable overall sort only on devices with > 64MB RAM,
  this prevents sort related kernel dumps (see adblock support thread in LEDE forum)

Signed-off-by: Dirk Brenken <dev@brenken.org>
