### PR TITLE
addrwatch: fix imagebuilder and config file name

### DIFF
--- a/net/addrwatch/Makefile
+++ b/net/addrwatch/Makefile
@@ -46,7 +46,7 @@ define Package/addrwatch/install
 	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/config $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/addrwatch $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/addrwatch.init $(1)/etc/init.d/addrwatch
-	$(INSTALL_CONF) ./files/addrwatch.config $(1)/etc/config/addrwatch$
+	$(INSTALL_CONF) ./files/addrwatch.config $(1)/etc/config/addrwatch
 endef
 
 $(eval $(call BuildPackage,addrwatch))

--- a/net/addrwatch/Makefile
+++ b/net/addrwatch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=addrwatch
 PKG_VERSION:=0.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-master.tar.gz
 PKG_SOURCE_URL:=https://github.com/fln/addrwatch/releases/download/$(PKG_VERSION)/

--- a/net/addrwatch/files/addrwatch.init
+++ b/net/addrwatch/files/addrwatch.init
@@ -4,8 +4,6 @@
 START=50
 USE_PROCD=1
 
-. /lib/functions/network.sh
-
 validate_section_addrwatch() {
 	uci_validate_section addrwatch addrwatch "${1}" \
 		'disabled:bool:0' \
@@ -65,6 +63,7 @@ start_instance() {
 }
 
 start_service() {
+	. /lib/functions/network.sh
 	config_load 'addrwatch'
 	config_foreach start_instance 'addrwatch'
 }


### PR DESCRIPTION
Maintainer: Ondrej Caletka / @Oskar456
Compile tested: LEDE 17.01.0, TurrisOS 3.6
Run tested: Nexx WT-3020 (ramips), Turris router (mpc85xx)

Description:
This PR fixes error when trying to add `addrwatch` to an image using image builder, as well as a typo in config file name.