### PR TITLE
net/wireguard: add support for fwmark option

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=wireguard
 
 PKG_VERSION:=0.0.20170223
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=WireGuard-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://git.zx2c4.com/WireGuard/snapshot/

--- a/net/wireguard/files/wireguard.sh
+++ b/net/wireguard/files/wireguard.sh
@@ -22,6 +22,7 @@ proto_wireguard_init_config() {
   proto_config_add_int    "listen_port"
   proto_config_add_int    "mtu"
   proto_config_add_string "preshared_key"
+  proto_config_add_string "fwmark"
   available=1
   no_proto_task=1
 }
@@ -103,6 +104,7 @@ proto_wireguard_setup() {
   config_get addresses     "${config}" "addresses"
   config_get mtu           "${config}" "mtu"
   config_get preshared_key "${config}" "preshared_key"
+  config_get fwmark        "${config}" "fwmark"
 
   # create interface
   ip link del dev "${config}" 2>/dev/null
@@ -124,6 +126,9 @@ proto_wireguard_setup() {
   fi
   if [ "${preshared_key}" ]; then
     echo "PresharedKey=${preshared_key}" >> "${wg_cfg}"
+  fi
+  if [ "${fwmark}" ]; then
+    echo "FwMark=${fwmark}" >> "${wg_cfg}"
   fi
   config_foreach proto_wireguard_setup_peer "wireguard_${config}"
 


### PR DESCRIPTION
Adds support for the fwmark option.

FwMark is a 32-bit fwmark for outgoing packets.
If set to 0 or "off", this option is disabled.

Signed-off-by: Dan Luedtke <mail@danrl.com>

Maintainer: me, @zx2c4 @zorun
Compile tested: ~~(still building)~~ EDIT: x86_64 build OK
Run tested: x86_64 VirtualBox
