### PR TITLE
utils/mksh: update to r54

### DIFF
--- a/utils/mksh/Makefile
+++ b/utils/mksh/Makefile
@@ -9,15 +9,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mksh
-PKG_VERSION:=52c
+PKG_VERSION:=54
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Thorsten Glaser <tg@mirbsd.org>
 PKG_LICENSE:=MirOS
 
 PKG_SOURCE:=$(PKG_NAME)-R$(PKG_VERSION).tgz
-PKG_SOURCE_URL:=http://www.mirbsd.org/MirOS/dist/mir/mksh
-PKG_MD5SUM:=cc3884e02314447e7b4a3073b8d65d1e
+PKG_SOURCE_URL:=http://www.mirbsd.org/MirOS/dist/mir/mksh \
+		http://pub.allbsd.org/MirOS/dist/mir/mksh/
+PKG_MD5SUM:=be0a6fb93b4a5f927bcc1893bb6692f8
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/utils/mksh/patches/100-dot_mkshrc
+++ b/utils/mksh/patches/100-dot_mkshrc
@@ -1,4 +1,4 @@
-Refreshed for mksh-r52c, based on tg's patch
+Refreshed for mksh-r54, based on tg's patch
 
 From 23712cea8e2a623fd952eb781df0011c501703d0 Mon Sep 17 00:00:00 2001
 From: Thorsten Glaser <tg@mirbsd.org>
@@ -35,7 +35,7 @@ Signed-off-by: Alif M. A. <alive4ever at live.com>
  \alias doch='sudo mksh -c "$(\builtin fc -ln -1)"'
  \command -v rot13 >/dev/null || \alias rot13='tr \
      abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ \
-@@ -601,4 +602,8 @@
+@@ -600,4 +601,8 @@
  
  \unset p
  


### PR DESCRIPTION
Update to current latest upstream: r54.
Also add a new download mirror to fetch the source.

Signed-off-by: Alif M. Ahmad <alive4ever@live.com>

-------------------------------

Maintainer: me / @mirabilos 
Compile tested: x86_64, LEDE_RELEASE="LEDE Reboot SNAPSHOT r3580+8-e8871d946a"
Run tested: x86_64 and generic, qemu with kvm, LEDE Reboot SNAPSHOT r3580+8-e8871d946a

Description:
Works fine without crashes.

Changing the shell to ``/bin/mksh`` only gives the desired effect on ssh sessions.

Serial or virtual console (which is indicated by ``Please press Enter to activate this console``) only uses the builtin busybox shell (``/bin/ash``). To use ``mksh`` on console, one has to call ``mksh`` explicitly and source ``/etc/mkshrc``.