### PR TITLE
python-cryptography: fix build by disabling setup requirements

### DIFF
--- a/lang/python-cryptography/Makefile
+++ b/lang/python-cryptography/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptography
 PKG_VERSION:=1.5.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/21/e1/37fc14f9d77924e84ba0dcb88eb8352db914583af229287c6c965d66ba0d

--- a/lang/python-cryptography/patches/001-disable-setup-requirements.patch
+++ b/lang/python-cryptography/patches/001-disable-setup-requirements.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index b5c05df..a777dd7 100644
+--- a/setup.py
++++ b/setup.py
+@@ -266,6 +266,7 @@ class DummyPyTest(test):
+ with open(os.path.join(base_dir, "README.rst")) as f:
+     long_description = f.read()
+ 
++setup_requirements=[]
+ 
+ setup(
+     name=about["__title__"],


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: https://github.com/lede-project/source/commit/e01b034cdc64123baaca8d15f15b2b90e8a39db9 mips_24kc powerpc_464fp
Run tested: N/A

Description:

Fixes https://github.com/openwrt/packages/issues/3913

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>