### PR TITLE
dovecot: add missing dependency

### DIFF
--- a/mail/dovecot/Makefile
+++ b/mail/dovecot/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot
 PKG_VERSION:=2.2.26.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.dovecot.org/releases/2.2
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/dovecot
   SECTION:=mail
   CATEGORY:=Mail
-  DEPENDS:=+DOVECOT_LDAP:libopenldap +libopenssl +librt +zlib +libbz2 +libcap
+  DEPENDS:=+DOVECOT_LDAP:libopenldap +libopenssl +librt +zlib +libbz2 +libcap +icu
   TITLE:=An IMAP and POP3 daemon
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
   URL:=http://www.dovecot.org/


### PR DESCRIPTION
Maintainer: unknown (PKG_MAINTAINER not defined)
Compile tested: ar71xx, mips_24kc_gcc-6.3.0_musl, LEDE trunk r3598-eb09d79 
Run tested: NONE

Description:
dovecot build fail,  missing dependency.

```
Package dovecot is missing dependencies for the following libraries:
libicudata.so.58
libicui18n.so.58
libicuuc.so.58
```
Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
