### PR TITLE
dovecot: disable ICU normalization support for FTS

### DIFF
--- a/mail/dovecot/Makefile
+++ b/mail/dovecot/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot
 PKG_VERSION:=2.2.26.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.dovecot.org/releases/2.2
@@ -55,7 +55,8 @@ CONFIGURE_ARGS += \
 	--with-moduledir=/usr/lib/dovecot/modules \
 	--with-notify=dnotify \
 	--without-lzma \
-	--without-lz4
+	--without-lz4 \
+	--with-icu=no
 
 ifneq ($(strip $(CONFIG_DOVECOT_LDAP)),)
   CONFIGURE_ARGS+= \


### PR DESCRIPTION
Maintainer: @tripolar
Compile tested: ar71xx, mips_24kc_gcc-6.3.0_musl, LEDE trunk r3598-eb09d79
Run tested: NONE

Description:
dovecot build fail,  missing icu dependency.
So made "ICU normalization support for FTS" disabled.

```
Package dovecot is missing dependencies for the following libraries:
libicudata.so.58
libicui18n.so.58
libicuuc.so.58
```

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
