### PR TITLE
openssh: Fix ssl-engine support

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -175,7 +175,7 @@ CONFIGURE_ARGS += \
 	--without-pam
 endif
 
-ifeq ($(CONFIG_OPENSSL_ENGINE),y)
+ifeq ($(CONFIG_OPENSSL_ENGINE_CRYPTO),y)
 CONFIGURE_ARGS+= \
 	--with-ssl-engine
 endif


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: OpenWRT 15.05
Run tested: OpenWRT 15.05

Description: fixes the openssl engines support

Signed-off-by: Martin Schiller <ms@dev.tdt.de>