### PR TITLE
adblock: release 2.4.0

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=2.3.2
+PKG_VERSION:=2.4.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -57,6 +57,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 * automatically selects uclient-fetch or wget as download utility (other tools like curl or aria2c are supported as well)
 * automatically supports a wide range of router modes, even AP modes are supported
 * full IPv4 and IPv6 support
+* supports tld compression (top level domain compression), this feature removes thousands of needless host entries from the block lists and lowers the memory footprint for the dns backends
 * each block list source will be updated and processed separately
 * block list source parsing by fast & flexible regex rulesets
 * overall duplicate removal in separate block lists
@@ -120,6 +121,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
     * adb\_iface => restrict the procd interface trigger to a (list of) certain wan interface(s) or disable it at all (default: not set, disabled)
     * adb\_fetch => full path to a different download utility, see example below (default: not set, use wget)
     * adb\_fetchparm => options for the download utility, see example below (default: not set, use wget options)
+    * adb\_tldcomp => enable/disable tld compression (default: '1', enabled)
 
 ## Examples
 
@@ -136,19 +138,19 @@ If you use manual configuration for unbound, then just include the following lin
 <pre><code>
 wget (default):
   option adb_fetch="/usr/bin/wget"
-  option adb_fetchparm="--no-config --quiet --tries=1 --no-cache --no-cookies --max-redirect=0 --timeout=5 --no-check-certificate -O"
+  option adb_fetchparm="--no-config --quiet --no-cache --no-cookies --max-redirect=0 --timeout=10 --no-check-certificate -O"
 
 aria2c:
   option adb_fetch '/usr/bin/aria2c'
-  option adb_fetchparm '-q --max-tries=1 --timeout=5 --allow-overwrite=true --auto-file-renaming=false --check-certificate=false -o'
+  option adb_fetchparm '-q --timeout=10 --allow-overwrite=true --auto-file-renaming=false --check-certificate=false -o'
 
 uclient-fetch:
   option adb_fetch '/bin/uclient-fetch'
-  option adb_fetchparm '-q --timeout=5 --no-check-certificate -O'
+  option adb_fetchparm '-q --timeout=10 --no-check-certificate -O'
 
 curl:
   option adb_fetch '/usr/bin/curl'
-  option adb_fetchparm '-s --retry 1 --connect-timeout 5 --insecure -o'
+  option adb_fetchparm '-s --connect-timeout 10 --insecure -o'
 </code></pre>
   
 **receive adblock statistics via ubus:**

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -37,7 +37,6 @@ start_service()
     if [ $(/etc/init.d/adblock enabled; printf ${?}) -eq 0 ]
     then
         procd_open_instance "adblock"
-        procd_set_param env adb_procd="true"
         procd_set_param command "${adb_script}" "${@}"
         procd_set_param stdout 1
         procd_set_param stderr 1
@@ -52,7 +51,6 @@ reload_service()
 
 stop_service()
 {
-    export adb_procd="true"
     rc_procd "${adb_script}" stop
 }
 
@@ -73,7 +71,6 @@ resume()
 
 query()
 {
-    export adb_procd="true"
     rc_procd "${adb_script}" query "${1}"
 }
 
@@ -81,8 +78,6 @@ service_triggers()
 {
     local iface="$(uci -q get adblock.global.adb_iface)"
 
-    procd_open_trigger
-    procd_add_config_trigger "config.change" "adblock" /etc/init.d/adblock start
     if [ -z "${iface}" ]
     then
         procd_add_raw_trigger "interface.*.up" 1000 /etc/init.d/adblock start
@@ -92,5 +87,5 @@ service_triggers()
             procd_add_interface_trigger "interface.*.up" "${name}" /etc/init.d/adblock start
         done
     fi
-    procd_close_trigger
+    procd_add_config_trigger "config.change" "adblock" /etc/init.d/adblock start
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: not relevant
Run tested: LEDE Reboot SNAPSHOT r3581-23dff07148

Description:
* add tld compression,
  this new "top level domain compression" removes up to 40 thousand
  needless host entries from the block lists and lowers 
  the memory footprint for the dns backends by 8-10 MByte
* optimize restart behaviour in case of an error
* cosmetics

Signed-off-by: Dirk Brenken <dev@brenken.org>