### PR TITLE
net/xinet.d: add /etc/xinet.d/ dir to conffiles

### DIFF
--- a/net/xinetd/Makefile
+++ b/net/xinetd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xinetd
 PKG_VERSION:=2.3.15
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.xinetd.org
@@ -39,6 +39,7 @@ endef
 
 define Package/xinetd/conffiles
 /etc/xinetd.conf
+/etc/xinetd.d/
 endef
 
 TARGET_CFLAGS += -DNO_RPC


### PR DESCRIPTION
Maintainer: @jmccrohan 
Compile tested: lantiq, xrx200, for-15.05)
Run tested: lantiq, xrx200, for-15.05

Description:
With the include param `includedir /etc/xinetd.d ` in `/etc/xinetd.conf`, it is possible to add configuration files for each service managed by xinetd. On sysupgrade the files will be lost if not add to the Makefile section `Package/xinetd/conffiles`.

 
