### PR TITLE
[utils/zoneinfo] Updated to the latest release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2016j
-PKG_VERSION_CODE:=2016j
+PKG_VERSION:=2017a
+PKG_VERSION_CODE:=2017a
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -20,14 +20,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION_CODE).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_MD5SUM:=db361d005ac8b30a2d18c5ca38d3e8ab
+PKG_MD5SUM:=cb8274cd175f8a4d9d1b89895df876dc
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   MD5SUM:=0684b98eb184fab250b6ca946862078d
+   MD5SUM:=eef0bfac7a52dce6989a7d8b40d86fe0
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: ti omap targets, custom build. OpenWrt master branch
Run tested: n/a

   Briefly: Southern Chile moves from -04/-03 to -03, and Mongolia
   discontinues DST.

   Changes to future time stamps

     Mongolia no longer observes DST.  (Thanks to Ganbold Tsagaankhuu.)

     Chile's Region of Magallanes moves from -04/-03 to -03 year-round.
     Its clocks diverge from America/Santiago starting 2017-05-13 at
     23:00, hiving off a new zone America/Punta_Arenas.  Although the
     Chilean government says this change expires in May 2019, for now
     assume it's permanent.  (Thanks to Juan Correa and Deborah
     Goldsmith.)  This also affects Antarctica/Palmer.

   Changes to past time stamps

     Fix many entries for historical time stamps for Europe/Madrid
     before 1979, to agree with tables compiled by Pere Planesas of the
     National Astronomical Observatory of Spain.  As a side effect,
     this changes some time stamps for Africa/Ceuta before 1929, which
     are probably guesswork anyway.  (Thanks to Steve Allen and
     Pierpaolo Bernardi for the heads-ups, and to Michael Deckers for
     correcting the 1901 transition.)

     Ecuador observed DST from 1992-11-28 to 1993-02-05.
     (Thanks to Alois Treindl.)

     Asia/Atyrau and Asia/Oral were at +03 (not +04) before 1930-06-21.
     (Thanks to Stepan Golosunov.)

   Changes to past and future time zone abbreviations

     Switch to numeric time zone abbreviations for South America, as
     part of the ongoing project of removing invented abbreviations.
     This avoids the need to invent an abbreviation for the new Chilean
     new zone.  Similarly, switch from invented to numeric time zone
     abbreviations for Afghanistan, American Samoa, the Azores,
     Bangladesh, Bhutan, the British Indian Ocean Territory, Brunei,
     Cape Verde, Chatham Is, Christmas I, Cocos (Keeling) Is, Cook Is,
     Dubai, East Timor, Eucla, Fiji, French Polynesia, Greenland,
     Indochina, Iran, Iraq, Kiribati, Lord Howe, Macquarie, Malaysia,
     the Maldives, Marshall Is, Mauritius, Micronesia, Mongolia,
     Myanmar, Nauru, Nepal, New Caledonia, Niue, Norfolk I, Palau,
     Papua New Guinea, the Philippines, Pitcairn, Qatar, R?union, St
     Pierre & Miquelon, Samoa, Saudi Arabia, Seychelles, Singapore,
     Solomon Is, Tokelau, Tuvalu, Wake, Vanuatu, Wallis & Futuna, and
     Xinjiang; for 20-minute daylight saving time in Ghana before 1943;
     for half-hour daylight saving time in Belize before 1944 and in
     the Dominican Republic before 1975; and for Canary Islands before
     1946, for Guinea-Bissau before 1975, for Iceland before 1969, for
     Indian Summer Time before 1942, for Indonesia before around 1964,
     for Kenya before 1960, for Liberia before 1973, for Madeira before
     1967, for Namibia before 1943, for the Netherlands in 1937-9, for
     Pakistan before 1971, for Western Sahara before 1977, and for
     Zaporozhye in 1880-1924.

     For Alaska time from 1900 through 1967, instead of "CAT" use the
     abbreviation "AST", the abbreviation commonly used at the time
     (Atlantic Standard Time had not been standardized yet).  Use "AWT"
     and "APT" instead of the invented abbreviations "CAWT" and "CAPT".

     Use "CST" and "CDT" instead of invented abbreviations for Macau
     before 1999 and Taiwan before 1938, and use "JST" instead of the
     invented abbreviation "JCST" for Japan and Korea before 1938.

   Change to database entry category

     Move the Pacific/Johnston link from 'australasia' to 'backward',
     since Johnston is now uninhabited.

   Changes to code

     zic no longer mishandles some transitions in January 2038 when it
     attempts to work around Qt bug 53071.  This fixes a bug affecting
     Pacific/Tongatapu that was introduced in zic 2016e. localtime.c
     now contains a workaround, useful when loading a file generated by
     a buggy zic.  (Problem and localtime.c fix reported by Bradley
     White.)

     zdump -i now outputs non-hour numeric time zone abbreviations
     without a colon, e.g., "+0530" rather than "+05:30".  This agrees
     with zic %z and with common practice, and simplifies auditing of
     zdump output.

     zdump is now buildable again with -DUSE_LTZ=0.
     (Problem reported by Joseph Myers.)

     zdump.c now always includes private.h, to avoid code duplication
     with private.h.  (Problem reported by Kees Dekker.)

     localtime.c no longer mishandles early or late timestamps
     when TZ is set to a POSIX-style string that specifies DST.
     (Problem reported by Kees Dekker.)

     date and strftime now cause %z to generate "-0000" instead of
     "+0000" when the UT offset is zero and the time zone abbreviation
     begins with "-".

   Changes to documentation and commentary

     The 'Theory' file now better documents choice of historical time
     zone abbreviations.  (Problems reported by Michael Deckers.)

     tz-link.htm now covers leap smearing, which is popular in clouds.