### PR TITLE
travelmate: release 0.4.0

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=0.3.5
+PKG_VERSION:=0.4.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/README.md
+++ b/net/travelmate/files/README.md
@@ -9,7 +9,8 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 * STA interfaces operating in an "always off" mode, to make sure that the AP is always accessible
 * easy setup within normal OpenWrt/LEDE environment
 * fast uplink connections
-* support multiple radios
+* "active mode" support, where travelmate will be restarted every n seconds (default 60) and checks the existing uplink connection regardless of ifdown event trigger
+* support of devices with multiple radios
 * procd init system support
 * procd based hotplug support, the travelmate start will be triggered by interface triggers
 * status & debug logging to syslog
@@ -41,8 +42,10 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 * travelmate config options:
     * trm\_enabled => main switch to enable/disable the travelmate service (default: '0', disabled)
     * trm\_debug => enable/disable debug logging (default: '0', disabled)
+    * trm\_active => keep travelmate in an active state (default: '0', disabled)
     * trm\_maxwait => how long (in seconds) should travelmate wait for wlan interface reload action (default: '20')
     * trm\_maxretry => how many times should travelmate try to find an uplink after a trigger event (default: '3')
+    * trm\_timeout => timeout in seconds for "active mode" (default: '60')
     * trm\_iw => set this option to '0' to use iwinfo for wlan scanning (default: '1', use iw)
     * trm\_radio => limit travelmate to a dedicated radio, e.g. 'radio0' (default: not set, use all radios)
     * trm\_iface => restrict the procd interface trigger to a (list of) certain wan interface(s) or disable it at all (default: not set, disabled)

--- a/net/travelmate/files/travelmate.conf
+++ b/net/travelmate/files/travelmate.conf
@@ -4,6 +4,8 @@
 config travelmate 'global'
 	option trm_enabled '0'
 	option trm_debug '0'
+	option trm_active '0'
 	option trm_maxwait '20'
 	option trm_maxretry '3'
+	option trm_timeout '60'
 	option trm_iw '1'

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -11,7 +11,6 @@ start_service()
     then
         ubus -t 30 wait_for network.interface
         procd_open_instance "travelmate"
-        procd_set_param env trm_procd="true"
         procd_set_param command "${trm_script}" "${@}"
         procd_set_param stdout 1
         procd_set_param stderr 1
@@ -23,8 +22,6 @@ service_triggers()
 {
     local iface="$(uci -q get travelmate.global.trm_iface)"
 
-    procd_open_trigger
-    procd_add_config_trigger "config.change" "travelmate" /etc/init.d/travelmate start
     if [ -z "${iface}" ]
     then
         procd_add_raw_trigger "interface.*.down" 1000 /etc/init.d/travelmate start
@@ -34,5 +31,5 @@ service_triggers()
             procd_add_interface_trigger "interface.*.down" "${name}" /etc/init.d/travelmate start
         done
     fi
-    procd_close_trigger
+    procd_add_config_trigger "config.change" "travelmate" /etc/init.d/travelmate start
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: not relevant
Run tested: LEDE Reboot (SNAPSHOT, r3623-339de82347)

Description:
* add an "active mode", where travelmate will be restarted
  every n seconds (default 60) and checks existing uplink connection
  regardless of ifdown event trigger (disabled by default)
* enhance multiple radio support
    * fix the ap detection
    * respect different radios during scanning & connection handling
* cosmetics

Signed-off-by: Dirk Brenken <dev@brenken.org>
