### PR TITLE
travelmate: update 0.4.1 (release 2)

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
 PKG_VERSION:=0.4.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-START=90
+START=85
 USE_PROCD=1
 
 trm_script="/usr/bin/travelmate.sh"

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-trm_ver="0.4.1"
+trm_ver="0.4.1-2"
 trm_sysver="$(ubus -S call system board | jsonfilter -e '@.release.description')"
 trm_enabled=1
 trm_debug=0
@@ -166,7 +166,6 @@ f_main()
     f_check "initial"
     if [ "${trm_ifstatus}" != "true" ]
     then
-        f_log "info " "start travelmate scanning ..."
         config_load wireless
         config_foreach f_prepare wifi-iface
         if [ -n "$(uci -q changes wireless)" ]
@@ -233,7 +232,6 @@ f_main()
                 sleep 5
             done
         done
-        f_log "info " "no wwan uplink found (${trm_sysver})"
     fi
 }
 


### PR DESCRIPTION
Maintainer: me
Compile tested: 
Run tested: TP-LINK RE-450, HOOTOO TM-05, GL-MIFI => LEDE Reboot SNAPSHOT r3644-7f0c95a7df

Description:
* revert start priority change
* mute standard logging even more

Signed-off-by: Dirk Brenken <dev@brenken.org>

Please backport/cherry-pick this version to stable LEDE tree as well, thank you!