### PR TITLE
vpnbypass: No longer depends on hardcoded WAN interface name.

### DIFF
--- a/net/vpnbypass/Makefile
+++ b/net/vpnbypass/Makefile
@@ -4,8 +4,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vpnbypass
-PKG_VERSION:=1.1.1
-PKG_RELEASE:=4
+PKG_VERSION:=1.3.0
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 

--- a/net/vpnbypass/files/README.md
+++ b/net/vpnbypass/files/README.md
@@ -11,7 +11,7 @@ A simple PROCD-based vpnbypass service for OpenWrt/LEDE Project. Useful if your 
 - Proudly made in Canada, using locally-sourced electrons.
 
 ## Screenshot (luci-app-vpnbypass)
-![screenshot](https://raw.githubusercontent.com/stangri/screenshots/master/vpnbypass/screenshot01.png "screenshot")
+![screenshot](https://raw.githubusercontent.com/stangri/screenshots/master/vpnbypass/screenshot02.png "screenshot")
 
 ## Requirements
 This service requires following packages to be installed on your router: ```ip-full ipset iptables dnsmasq-full``` (```ip-full``` requires you uninstall ```ip``` first; ```dnsmasq-full``` requires you uninstall ```dnsmasq``` first). Run the following commands to satisfy the requirements:
@@ -35,8 +35,19 @@ Please head to [LEDE Project Forum](https://forum.lede-project.org/t/vpn-bypass-
 Domain lists should be in following format/syntax: ```/domain1.com/domain2.com/vpnbypass```. Please don't forget the leading ```/``` and trailing ```/vpnbypass```. There's no validation if you enter something incorrectly -- it just won't work. Please see [Notes/Known Issues](#notesknown-issues) if you want to edit this setting manually, without Web UI.
 
 ## What's New
+1.3.0
+- No longer depends on hardcoded WAN interface name (```wan```) works with other interface names (like ```wwan```).
+- Table ID, IPSET name and FW_MARK as well as FW_MASK can be defined in config file.
+- Uses iptables, not ip rules for handling local IPs/ranges.
+- More reliable creation/destruction of VPNBYPASS iptables chain.
+- Updated Web UI enables/start and stops/disables service.
+- Beautified output.
+
+1.2.0
+- More elegant handling of iptables (thanks [@hnyman](https://github.com/hnyman) and [@tohojo](https://github.com/tohojo)!).
+
 1.1.1
-- More reliable way of obtaining WAN gateway on boot (thanks @dibdot for the hint!).
+- More reliable way of obtaining WAN gateway on boot (thanks [@dibdot](https://github.com/dibdot) for the hint!).
 
 1.1.0:
 - Detects individual IP addresses in the config and converts them to subnet automatically.
@@ -55,7 +66,7 @@ Domain lists should be in following format/syntax: ```/domain1.com/domain2.com/v
 - Initial release.
 
 ## Notes/Known Issues
-Domains to be accessed outside of VPN tunnel are not defined in ```/etc/config/vpnpass```, but rather in ```/etc/config/dhcp```. To add/delete/edit domains you can use VPN Bypass Web UI or you can edit ```/etc/config/dhcp``` manually or run following commands:
+Domains to be accessed outside of VPN tunnel are handled by dnsmasq and thus are not defined in ```/etc/config/vpnpass```, but rather in ```/etc/config/dhcp```. To add/delete/edit domains you can use VPN Bypass Web UI or you can edit ```/etc/config/dhcp``` manually or run following commands:
 ```sh
 uci add_list dhcp.@dnsmasq[-1].ipset='/github.com/plex.tv/google.com/vpnbypass'
 uci add_list dhcp.@dnsmasq[-1].ipset='/hulu.com/netflix.com/nhl.com/vpnbypass'

--- a/net/vpnbypass/files/vpnbypass.conf
+++ b/net/vpnbypass/files/vpnbypass.conf
@@ -1,5 +1,4 @@
 config vpnbypass 'config'
-	option enabled '1'
 	list localport '32400'
 	list localsubnet '192.168.1.81/29'
 	list remotesubnet '25.0.0.0/8'

--- a/net/vpnbypass/files/vpnbypass.init
+++ b/net/vpnbypass/files/vpnbypass.init
@@ -4,36 +4,44 @@ PKG_VERSION=
 START=94
 USE_PROCD=1
 
-readonly TID="200" FW_MARK="0x010000" IPSET="vpnbypass"
+readonly __ok__='\033[0;32m[\xe2\x9c\x93]\033[0m'
+readonly __fail__='\033[0;31m[\xe2\x9c\x97]\033[0m'
+readonly __pass__='\033[0;33m[-]\033[0m'
+readonly __error__='\033[0;31mERROR\033[0m'
 
-output() {
-	[ -n "$2" ] && [ ! $(($verbosity & $2)) -gt 0 ] && return 0;
-	[ -t 1 ] && echo -e -n "$1"
-	[ $(echo -e -n "$1" | wc -l) -gt 0 ] && logger -t "${PKG_NAME:-service} [$$]" "$(echo -e -n ${logmsg}${1})" && logmsg='' || logmsg=${logmsg}${1}
-}
+output() { local msg=$(echo -n "${1/$p_name /service }" | sed 's|\\033\[[0-9]\?;\?[0-9]\?[0-9]\?m||g'); [ -n "$2" ] && [ ! $(($verbosity & $2)) -gt 0 ] && return 0; [ -t 1 ] && echo -e -n "$1"; [ $(echo -e -n "$msg" | wc -l) -gt 0 ] && logger -t "${PKG_NAME:-service} [$$]" "$(echo -e -n ${logmsg}${msg})" && logmsg='' || logmsg=${logmsg}${msg}; }
+PKG_NAME="${PKG_NAME:-vpnbypass}"; p_name="${PKG_NAME} ${PKG_VERSION}"
 
-vpnbypass_enabled() {
-	config_load vpnbypass
-	config_get_bool enabled 'config' 'enabled' 0
+is_enabled() {
+	config_load $PKG_NAME
 	config_get verbosity    'config' 'verbosity' '2'
-	PKG_NAME="${PKG_NAME:-vpnbypass}"
-	[ -n "$PKG_VERSION" ] && p_name="$PKG_NAME $PKG_VERSION" || p_name="$PKG_NAME"
-	[ -t 1 ] || p_name='service'
+	config_get TID          'config' 'table_number' '200'
+	config_get IPSET        'config' 'ipset'  'vpnbypass'
+	config_get FW_MARK      'config' 'fw_mark' '0x010000'
+	config_get FW_MASK      'config' 'fw_mask' '0xff0000'
 	source /lib/functions/network.sh
-	[ "$enabled" -ne "0" ] && return 0
-	output "$p_name is not enabled in the config file!\n"
-	output "To enable, run 'uci set $PKG_NAME.config.enabled=1; uci commit $PKG_NAME'\n"
-	return 1
+	return 0
 }
 
-iptables_reset(){ [ -z "$PKG_NAME" ] && return 1; iptables-save | grep -Fv -- "$PKG_NAME" | iptables-restore; lsmod | grep -q ip6table_nat && ip6tables-save | grep -Fv -- "$PKG_NAME" | ip6tables-restore; }
+ipt() {
+    local d=$(echo $* | sed s/-A/-D/g)
+    [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
+    d=$(echo $* | sed s/-I/-D/g)
+    [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
+		d=$(echo $* | sed s/-N/-F/g)
+    [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
+		d=$(echo $* | sed s/-N/-X/g)
+    [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
 
-boot() { ubus -t 30 wait_for network.interface.wan && { rc_procd start_service; rc_procd service_triggers; } || output "ERROR: $p_name failed to settle network interface!\n"; }
+		iptables $* >/dev/null 2>&1
+}
+
+#boot() { ubus -t 30 wait_for network.interface.wan && { rc_procd start_service; rc_procd service_triggers; } || output "ERROR: $p_name failed to settle network interface!\n"; }
 
 start_service() {
 	local ll c=1
   config_load vpnbypass
-  vpnbypass_enabled || return 1
+  is_enabled || return 1
   config_get lports   'config' 'localport'
   config_get rports   'config' 'remoteport'
   config_get routes   'config' 'remotesubnet'
@@ -45,40 +53,49 @@ start_service() {
 	procd_set_param stderr 1
 	procd_close_instance
 
-	while : ; do network_get_ipaddr wanip wan; network_get_gateway gwip wan; [ $c -ge 15 ] && break || let "c+=1"; [ -n "$wanip" -a -n "$gwip" ] && break || output "$p_name waiting for wan gateway...\n"; sleep 2; network_flush_cache; done
-	[ -z "$wanip" -o -z "$gwip" ] && output "ERROR: $p_name could not get wan interface IP: $wanip or gateway: $gwip!\n" && exit 0
+	while : ; do
+		network_find_wan wan_if4; [ -n "wan_if4" ] && network_get_gateway wan_gw $wan_if4;
+		[ $c -ge 25 -o -n "$wan_gw" ] && break
+		output "$p_name waiting for wan gateway...\n"; sleep 2; network_flush_cache; let "c+=1";
+	done
+	[ -z "$wan_gw" ] && output "$__error__: $p_name could not discover wan gateway IP!\n" && exit 1
 
-	for ll in ${routes}; do ip route del $ll; ip route add $ll via $gwip; done
-	ip rule del fwmark "$FW_MARK" table "$TID" >/dev/null 2>&1; iptables_reset; ipset -q flush "$IPSET"; ipset -q destroy "$IPSET";
+	ipt -t mangle -N VPNBYPASS; ipt -t mangle -A PREROUTING -m mark --mark 0x00/${FW_MASK} -g VPNBYPASS;
+	ipt -t mangle -A VPNBYPASS -m set --match-set $IPSET dst -j MARK --set-mark ${FW_MARK}/${FW_MASK}
+	ip rule del fwmark "$FW_MARK" table "$TID" >/dev/null 2>&1; ipset -q flush "$IPSET"; ipset -q destroy "$IPSET";
 	ip route flush table "$TID"; ip route flush cache;
-	ip route add default via "$gwip" table "$TID"; ip route flush cache;
-	{ modprobe xt_set; modprobe ip_set; modprobe ip_set_hash_ip; } >/dev/null 2>&1
+	ip route add default via "$wan_gw" table "$TID"; ip route flush cache;
 	ipset -q -exist create "$IPSET" hash:ip; ipset -q flush "$IPSET"
-	for ll in ${lports}; do iptables -t mangle -A PREROUTING -p tcp -m multiport --sport "${ll//-/:}" -j MARK --set-mark "$FW_MARK/$FW_MARK" -m comment --comment "$PKG_NAME"; done
-	for ll in ${rports}; do iptables -t mangle -A PREROUTING -p tcp -m multiport --dport "${ll//-/:}" -j MARK --set-mark "$FW_MARK/$FW_MARK" -m comment --comment "$PKG_NAME"; done
-	for ll in ${ranges}; do iptables -t mangle -I PREROUTING -s "$ll" -j MARK --set-mark "$FW_MARK/$FW_MARK" -m comment --comment "$PKG_NAME"; done
-	iptables -t mangle -A PREROUTING -m set --match-set "$IPSET" dst -j MARK --set-mark "$FW_MARK/$FW_MARK" -m comment --comment "$PKG_NAME"
 	ip rule add fwmark "$FW_MARK" table "$TID"
+	{ modprobe xt_set; modprobe ip_set; modprobe ip_set_hash_ip; } >/dev/null 2>&1
+	for ll in ${ranges}; do ipt -t mangle -I VPNBYPASS 1 -j MARK --set-mark ${FW_MARK}/${FW_MASK} -s "$ll"; done
+	for ll in ${lports}; do ipt -t mangle -I VPNBYPASS 1 -j MARK --set-mark ${FW_MARK}/${FW_MASK} -p tcp -m multiport --sport "${ll//-/:}"; done
+	for ll in ${routes}; do ipt -t mangle -I VPNBYPASS 1 -j MARK --set-mark ${FW_MARK}/${FW_MASK} -d "$ll"; done
+	for ll in ${rports}; do ipt -t mangle -I VPNBYPASS 1 -j MARK --set-mark ${FW_MARK}/${FW_MASK} -p tcp -m multiport --dport "${ll//-/:}"; done
 	output "$p_name started with TID: $TID; FW_MARK: $FW_MARK\n"
 }
 
 stop_service() {
 	local ll
-  vpnbypass_enabled || return 1
-  config_get routes   'config' 'remotesubnet'
+  is_enabled || return 1
 
-	for ll in ${routes}; do ip route del "$ll"; done
-	ip rule del fwmark "$FW_MARK" table "$TID" >/dev/null 2>&1; iptables_reset; ipset -q flush "$IPSET"; ipset -q destroy "$IPSET";
+	ip rule del fwmark "$FW_MARK" table "$TID" >/dev/null 2>&1; ipset -q flush "$IPSET"; ipset -q destroy "$IPSET";
 	ip route flush table "$TID"; ip route flush cache;
+	ipt -t mangle -D PREROUTING -m mark --mark 0x00/${FW_MASK} -g VPNBYPASS
+	ipt -t mangle -F VPNBYPASS; ipt -t mangle -X VPNBYPASS;
 	output "$p_name stopped\n"
 }
 
-reload_service() { start_service; }
+reload_service(){
+	start_service
+}
 
+st_load_interfaces(){ local d; config_get d $1 ifname; [ "$1" == "$wan_if4" -o "$d" != "${d/tun}" -o "$d" != "${d/tap}" ] && ifaces=" ${1} ${ifaces}"; }
 service_triggers() {
+		local ifaces n
 		procd_add_reload_trigger 'vpnbypass'
 		procd_open_trigger
 		procd_add_config_trigger "config.change" "vpnbypass" /etc/init.d/vpnbypass reload
-		procd_add_interface_trigger "interface.*" "wan" /etc/init.d/vpnbypass reload
+		for n in $ifaces; do procd_add_interface_trigger "interface.*" "$n" /etc/init.d/openvpn-policy-routing reload; done;
 		procd_close_trigger
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: (ipq806x, Linksys EA8500, LEDE 17.01.0)
Run tested: (ipq806x, Linksys EA8500, LEDE snapshot r3640)

Description:
No longer depends on hardcoded WAN interface name.
Table ID, IPSET name and FW_MARK as well as FW_MASK can be defined in config file.
Uses iptables, not ip rules for handling local IPs/ranges.
More reliable creation/destruction of VPNBYPASS iptables chain.
Reworked output formatting and logic.

Signed-off-by: Stan Grishin <stangri@melmac.net>
