### PR TITLE
postfix: Add SQLite support and fix musl compile without POSTFIX_TLS

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postfix
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE_URL:=ftp://ftp.porcupine.org/mirrors/postfix-release/official/
 PKG_VERSION:=3.1.4
 PKG_MD5SUM:=878a059d92ee3b093d7d3e97248c915d
@@ -25,7 +25,7 @@ define Package/postfix
   CATEGORY:=Mail
   TITLE:=Postfix Mail Transmit Agent
   URL:=http://www.postfix.org/
-  DEPENDS:=+POSTFIX_TLS:libopenssl +POSTFIX_SASL:libsasl2 +POSTFIX_LDAP:libopenldap +POSTFIX_DB:libdb47 +POSTFIX_EAI:icu +libpcre
+  DEPENDS:=+POSTFIX_TLS:libopenssl +POSTFIX_SASL:libsasl2 +POSTFIX_LDAP:libopenldap +POSTFIX_DB:libdb47 +POSTFIX_SQLITE:libsqlite3 +POSTFIX_EAI:icu +libpcre
 endef
 
 define Package/postfix/description
@@ -59,6 +59,11 @@ define Package/postfix/config
 			default y
 			help
 			  Implements support for cdb files using tinycdb
+		config POSTFIX_SQLITE
+			bool "SQLITE support"
+			default y
+			help
+			  Implements support for SQLite3 DB
 		config POSTFIX_EAI
 			bool "SMTPUTF8 support"
 			default n
@@ -104,6 +109,11 @@ ifdef CONFIG_POSTFIX_DB
   endif
 else
   CCARGS+=-DNO_DB
+endif
+
+ifdef CONFIG_POSTFIX_SQLITE
+  CCARGS+=-DHAS_SQLITE -I$(STAGING_DIR)/usr/include/
+  AUXLIBS+=-L$(STAGING_DIR)/usr/lib -lsqlite3 -lpthread
 endif
 
 ifdef CONFIG_POSTFIX_EAI

--- a/mail/postfix/patches/501-include_stdio.patch
+++ b/mail/postfix/patches/501-include_stdio.patch
@@ -1,0 +1,10 @@
+--- a/src/posttls-finger/posttls-finger.c
++++ b/src/posttls-finger/posttls-finger.c
+@@ -318,6 +318,7 @@
+ #include <sys/un.h>
+ #include <netinet/in.h>
+ #include <arpa/inet.h>
++#include <stdio.h>
+ 
+ #ifdef STRCASECMP_IN_STRINGS_H
+ #include <strings.h>


### PR DESCRIPTION
Add SQLite support and fix musl compile without POSTFIX_TLS

split PR (#4093)

Compile/Run tested x86_64 LEDE/Reboot

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
