### PR TITLE
libs: add musl fts implementation

### DIFF
--- a/lang/python-cryptography/Makefile
+++ b/lang/python-cryptography/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptography
 PKG_VERSION:=1.5.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/21/e1/37fc14f9d77924e84ba0dcb88eb8352db914583af229287c6c965d66ba0d

--- a/lang/python-cryptography/patches/001-disable-setup-requirements.patch
+++ b/lang/python-cryptography/patches/001-disable-setup-requirements.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index b5c05df..a777dd7 100644
+--- a/setup.py
++++ b/setup.py
+@@ -266,6 +266,7 @@ class DummyPyTest(test):
+ with open(os.path.join(base_dir, "README.rst")) as f:
+     long_description = f.read()
+ 
++setup_requirements=[]
+ 
+ setup(
+     name=about["__title__"],

--- a/libs/musl-fts/Makefile
+++ b/libs/musl-fts/Makefile
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2017 Lucian Cristian <lucian.cristian@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+# updated to work with latest source from abrasive
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=musl-fts
+PKG_VERSION:=1.2.7
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/pullmoll/musl-fts.git
+PKG_SOURCE_VERSION:=0bde52df588e8969879a2cae51c3a4774ec62472
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+
+PKG_MAINTAINER:= Lucian Cristian <lucian.cristian@gmail.com>
+
+PKG_LICENSE:=LGPL-2.1
+PKG_LICENSE_FILES:=COPYING AUTHORS
+
+PKG_FIXUP:=autoreconf
+PKG_REMOVE_FILES:=autogen.sh
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=fts implementation for musl libc
+  URL:=https://github.com/pullmoll/musl-fts
+  DEPENDS:= +libpthread
+endef
+
+define Package/$(PKG_NAME)/description
+  The musl-fts package implements the fts(3) functions fts_open, fts_read, fts_children, fts_set and fts_close, which are missing in musl libc.
+endef
+
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/fts.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfts.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/musl-fts.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfts.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/net/gnunet/Makefile
+++ b/net/gnunet/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnunet
-PKG_SOURCE_VERSION:=a4295da3df82817ff2fe1fa547374a96a2e0280b
-PKG_VERSION:=0.10.2-git-20170111-$(PKG_SOURCE_VERSION)
+PKG_SOURCE_VERSION:=65f138e9a6156983ac74f8f1a5b8051d8f9be86a
+PKG_VERSION:=0.10.2-git-20170305-$(PKG_SOURCE_VERSION)
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -30,7 +30,6 @@ CONFIGURE_ARGS+= \
 	$(if $(CONFIG_PACKAGE_libsqlite3),--with-sqlite="$(STAGING_DIR)/usr",--without-sqlite) \
 	--disable-testing \
 	--disable-testruns \
-	--disable-wachs \
 	--enable-experimental \
 	--with-extractor=$(STAGING_DIR)/usr \
 	--with-gnutls=$(STAGING_DIR)/usr \
@@ -137,7 +136,7 @@ define Package/gnunet/install
 		$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gnunet-$$$$bin $(1)/usr/bin/ ; \
 	done )
 
-	( for lib in arm ats block cadet core datacache dht \
+	( for lib in arm ats block blockgroup cadetnew core datacache dht \
 	    dns dnsparser fragmentation friends hello identity natauto natnew nse \
 	    peerinfo regexblock regex revocation scalarproduct set \
 	    statistics transport util; do \
@@ -150,7 +149,7 @@ define Package/gnunet/install
 	done )
 
 	( for lex in daemon-topology helper-nat-client \
-	    helper-nat-server service-arm service-ats service-cadet \
+	    helper-nat-server service-arm service-ats service-cadet-new \
 	    service-core service-dht service-identity service-nat service-nat-auto \
 	    service-nse service-peerinfo service-regex \
 	    service-revocation service-scalarproduct-alice \
@@ -206,7 +205,6 @@ LIBEXEC_transport-wlan:=helper-transport-wlan
 
 DEPENDS_experiments:=+libglpk
 PLUGIN_experiments:=ats_mlp ats_ril
-LIBEXEC_experiments:=service-dht-whanau service-dht-xvine
 
 # BIN_dv:=dv
 LIB_dv:=dv
@@ -252,6 +250,7 @@ PLUGIN_rest:=rest_gns rest_identity rest_identity_provider rest_namestore
 LIBEXEC_rest:=rest-server
 CONF_rest:=rest
 
+DEPENDS_rps:=@BROKEN
 BIN_rps:=rps
 LIB_rps:=rps
 LIBEXEC_rps:=service-rps

--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntp
 PKG_VERSION:=4.2.8p9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/

--- a/net/ntpd/files/ntpd.hotplug
+++ b/net/ntpd/files/ntpd.hotplug
@@ -1,10 +1,10 @@
+#!/bin/sh
+
 NAME=ntpd
-CONFIG=/etc/ntp.conf
-COMMAND=/sbin/$NAME
+COMMAND=/etc/init.d/$NAME
 
 [ "$ACTION" = "ifup" -a "$INTERFACE" = "wan" ] && {
-        [ -x $COMMAND ] && [ -r $CONFIG ] && {
-		killall ntpd
-		/etc/init.d/ntpd start
-        } &
+	$COMMAND enabled && {
+		$COMMAND restart
+        }
 }


### PR DESCRIPTION
musl is missing fts implementation, fts is needed at least by clamav-0.99+

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Compile/Run tested on x86_64 LEDE Reboot (SNAPSHOT, r3640-f229f4a)