### PR TITLE
mc (midnight commander): release 4.8.19

### DIFF
--- a/utils/mc/Makefile
+++ b/utils/mc/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2016 OpenWrt.org
+# Copyright (C) 2006-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mc
-PKG_VERSION:=4.8.18
+PKG_VERSION:=4.8.19
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 PKG_LICENSE:=GPL-3.0+
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://ftp.midnight-commander.org/
-PKG_MD5SUM:=f7636815c987c1719c4f5de2dcd156a0e7d097b1d10e4466d2bdead343d5bece
+PKG_HASH:=eb9e56bbb5b2893601d100d0e0293983049b302c5ab61bfb544ad0ee2cc1f2df
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf gettext-version
 
@@ -54,6 +54,8 @@ Internal viewer and editor are included as well.
 endef
 
 CONFIGURE_ARGS += \
+	--enable-silent-rules \
+	--disable-tests \
 	--disable-doxygen-doc \
 	--with-homedir=/etc/mc \
 	--with-screen=ncurses \

--- a/utils/mc/patches/010-subshell.patch
+++ b/utils/mc/patches/010-subshell.patch
@@ -1,11 +1,22 @@
 --- a/src/subshell/common.c
 +++ b/src/subshell/common.c
-@@ -849,7 +849,7 @@ init_subshell_precmd (char *precmd, size
-                     "else "
-                     "[ \"${PWD##$HOME/}\" = \"$PWD\" ] && MC_PWD=\"$PWD\" || MC_PWD=\"~/${PWD##$HOME/}\"; "
-                     "fi; "
+@@ -843,16 +843,9 @@ init_subshell_precmd (char *precmd, size
+          * "PS1='$($PRECMD)$ '\n",
+          */
+         g_snprintf (precmd, buff_size,
+-                    "precmd() { "
+-                    "if [ ! \"${PWD##$HOME}\" ]; then "
+-                    "MC_PWD=\"~\"; "
+-                    "else "
+-                    "[ \"${PWD##$HOME/}\" = \"$PWD\" ] && MC_PWD=\"$PWD\" || MC_PWD=\"~/${PWD##$HOME/}\"; "
+-                    "fi; "
 -                    "echo \"$USER@$(hostname -s):$MC_PWD\"; "
-+                    "echo \"$USER@$HOSTNAME:$MC_PWD\"; "
-                     "pwd>&%d; "
-                     "kill -STOP $$; "
-                     "}; " "PRECMD=precmd; " "PS1='$($PRECMD)$ '\n", subshell_pipe[WRITE]);
+-                    "pwd>&%d; "
+-                    "kill -STOP $$; "
+-                    "}; " "PRECMD=precmd; " "PS1='$($PRECMD)$ '\n", subshell_pipe[WRITE]);
++                    "precmd() { pwd>&%d; kill -STOP $$; }; "
++                    "PRECMD=precmd; "
++                    "PS1='$(eval $PRECMD)\\u@\\h:\\w\\$ '\n", subshell_pipe[WRITE]);
+         break;
+ 
+     case SHELL_ZSH:


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, LEDE Reboot (SNAPSHOT, r3644-7f0c95a7df)
Run tested: x86_64, LEDE Reboot (SNAPSHOT, r3644-7f0c95a7df)

Description:
* release notes: https://midnight-commander.org/wiki/NEWS-4.8.19
* refreshed subshell patch
* switched to PKG_HASH

Signed-off-by: Dirk Brenken <dev@brenken.org>