### PR TITLE
Cleanup: avoid reuse of $(PKG_NAME)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ All packages you commit or submit by pull-request should follow these simple gui
 * An optional PKG_LICENSE_FILES tag including the filenames of the license-files in the source-package.
     (E.g.: PKG_LICENSE_FILES:=COPYING)
 * PKG_RELEASE should be initially set to 1 or reset to 1 if the software version is changed. You should increment it if the package itself has changed. For example, modifying a support script, changing configure options like --disable* or --enable* switches, or if you changed something in the package which causes the resulting binaries to be different. Changes like correcting md5sums, changing mirror URLs, adding a maintainer field or updating a comment or copyright year in a Makefile do not require a change to PKG_RELEASE.
+* Avoid reuse of PKG_NAME in call, define and eval lines to improve readability.
 
 #### Commits in your pull-requests should:
 

--- a/lang/lua-mosquitto/Makefile
+++ b/lang/lua-mosquitto/Makefile
@@ -21,7 +21,7 @@ PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/$(PKG_NAME)
+define Package/lua-mosquitto
     SUBMENU:=Lua
     SECTION:=lang
     CATEGORY:=Languages
@@ -30,13 +30,13 @@ define Package/$(PKG_NAME)
     MAINTAINER:=Karl Palsson <karlp@remake.is>
 endef
 
-define Package/$(PKG_NAME)/description
+define Package/lua-mosquitto/description
 	Lua bindings to libmosquitto
 endef
 
-define Package/$(PKG_NAME)/install
+define Package/lua-mosquitto/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/mosquitto.so $(1)/usr/lib/lua
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,lua-mosquitto))

--- a/lang/lua-openssl/Makefile
+++ b/lang/lua-openssl/Makefile
@@ -21,7 +21,7 @@ PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/$(PKG_NAME)
+define Package/lua-openssl
   SUBMENU:=Lua
   SECTION:=lang
   CATEGORY:=Languages
@@ -34,9 +34,9 @@ define Package/lua-openssl/description
     A free, MIT-licensed OpenSSL binding for Lua.
 endef
 
-define Package/$(PKG_NAME)/install
+define Package/lua-openssl/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openssl.so $(1)/usr/lib/lua/
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,lua-openssl))

--- a/lang/lua-penlight/Makefile
+++ b/lang/lua-penlight/Makefile
@@ -19,7 +19,7 @@ PKG_LICENSE_FILES:=LICENSE.md
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/$(PKG_NAME)
+define Package/lua-penlight
   SUBMENU:=Lua
   SECTION:=lang
   CATEGORY:=Languages
@@ -29,7 +29,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:= Karl Palsson <karlp@remake.is>
 endef
 
-define Package/$(PKG_NAME)/description
+define Package/lua-penlight/description
   It is often said of Lua that it does not include batteries.
   Penlight is the batteries.
 endef
@@ -38,9 +38,9 @@ define Build/Compile
 	echo "Nothing to compile, pure lua package"
 endef
 
-define Package/$(PKG_NAME)/install
+define Package/lua-penlight/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua
 	$(CP) $(PKG_BUILD_DIR)/lua/pl $(1)/usr/lib/lua
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,lua-penlight))

--- a/libs/libarchive/Makefile
+++ b/libs/libarchive/Makefile
@@ -22,7 +22,7 @@ PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/$(PKG_NAME)/Default
+define Package/libarchive/Default
 	SECTION:=libs
 	CATEGORY:=Libraries
 	DEPENDS:=+zlib +liblzma +libbz2 +libexpat
@@ -30,13 +30,13 @@ define Package/$(PKG_NAME)/Default
 	URL:=http://www.libarchive.org/
 endef
 
-define Package/$(PKG_NAME)
-	$(call Package/$(PKG_NAME)/Default)
+define Package/libarchive
+	$(call Package/libarchive/Default)
 	DEPENDS += +libopenssl
 endef
 
-define Package/$(PKG_NAME)-noopenssl
-	$(call Package/$(PKG_NAME)/Default)
+define Package/libarchive-noopenssl
+	$(call Package/libarchive/Default)
 	TITLE += (without OpenSSL dependency)
 	VARIANT:=noopenssl
 endef
@@ -90,7 +90,7 @@ define Package/bsdtar/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/bsdtar $(1)/usr/bin
 endef
 
-Package/$(PKG_NAME)-noopenssl/install = $(Package/$(PKG_NAME)/install)
+Package/libarchive-noopenssl/install = $(Package/libarchive/install)
 
 $(eval $(call BuildPackage,libarchive))
 $(eval $(call BuildPackage,libarchive-noopenssl))

--- a/libs/libwebsockets/Makefile
+++ b/libs/libwebsockets/Makefile
@@ -39,7 +39,7 @@ CMAKE_OPTIONS += -DLWS_WITHOUT_TESTAPPS=ON
 # CMAKE_OPTIONS += -DLWS_WITHOUT_DEBUG=ON
 
 
-define Package/$(PKG_NAME)/Default
+define Package/libwebsockets/Default
 	SECTION:=libs
 	CATEGORY:=Libraries
 	TITLE:=libwebsockets
@@ -49,21 +49,21 @@ define Package/$(PKG_NAME)/Default
 endef
 
 define Package/libwebsockets-openssl
-	$(call Package/$(PKG_NAME)/Default)
+	$(call Package/libwebsockets/Default)
 	TITLE += (OpenSSL)
 	DEPENDS += +libopenssl
 	VARIANT:=openssl
 endef
 
 define Package/libwebsockets-cyassl
-	$(call Package/$(PKG_NAME)/Default)
+	$(call Package/libwebsockets/Default)
 	TITLE += (CyaSSL)
 	DEPENDS += +libcyassl
 	VARIANT:=cyassl
 endef
 
 define Package/libwebsockets-full
-	$(call Package/$(PKG_NAME)/Default)
+	$(call Package/libwebsockets/Default)
 	TITLE += (Full - OpenSSL, libuv, plugins, CGI)
 	DEPENDS += +libopenssl +libuv
 	VARIANT:=full
@@ -102,9 +102,9 @@ define Package/libwebsockets/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libwebsockets.so* $(1)/usr/lib/
 endef
 
-Package/$(PKG_NAME)-cyassl/install = $(Package/$(PKG_NAME)/install)
-Package/$(PKG_NAME)-openssl/install = $(Package/$(PKG_NAME)/install)
-Package/$(PKG_NAME)-full/install = $(Package/$(PKG_NAME)/install)
+Package/libwebsockets-cyassl/install = $(Package/libwesockets/install)
+Package/libwebsockets-openssl/install = $(Package/libwebsockets/install)
+Package/libwesockets-full/install = $(Package/libwebsockets/install)
 
 $(eval $(call BuildPackage,libwebsockets-openssl))
 $(eval $(call BuildPackage,libwebsockets-cyassl))

--- a/libs/musl-fts/Makefile
+++ b/libs/musl-fts/Makefile
@@ -30,7 +30,7 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/$(PKG_NAME)
+define Package/musl-fts
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=fts implementation for musl libc
@@ -38,7 +38,7 @@ define Package/$(PKG_NAME)
   DEPENDS:= +libpthread
 endef
 
-define Package/$(PKG_NAME)/description
+define Package/musl-fts/description
   The musl-fts package implements the fts(3) functions fts_open, fts_read, fts_children, fts_set and fts_close, which are missing in musl libc.
 endef
 
@@ -51,9 +51,9 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/musl-fts.pc $(1)/usr/lib/pkgconfig/
 endef
 
-define Package/$(PKG_NAME)/install
+define Package/musl-fts/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfts.so* $(1)/usr/lib/
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,musl-fts))

--- a/mail/ssmtp/Makefile
+++ b/mail/ssmtp/Makefile
@@ -21,7 +21,7 @@ include $(INCLUDE_DIR)/package.mk
 
 TARGET_CFLAGS += $(TARGET_CPPFLAGS)
 
-define Package/$(PKG_NAME)
+define Package/ssmtp
 	SECTION:=mail
 	CATEGORY:=Mail
 	DEPENDS:=+libopenssl
@@ -29,14 +29,14 @@ define Package/$(PKG_NAME)
 	URL:=http://packages.debian.org/ssmtp
 endef
 
-define Package/$(PKG_NAME)/description
+define Package/ssmtp/description
 A secure, effective and simple way of getting mail off a system to your mail hub.
 Mail is simply forwarded to the configured mailhost, no daemons running in the background.
 Extremely easy configuration.
 
 endef
 
-define Package/$(PKG_NAME)/conffiles
+define Package/ssmtp/conffiles
 /etc/ssmtp/ssmtp.conf
 /etc/ssmtp/revaliases
 endef
@@ -47,7 +47,7 @@ CONFIGURE_VARS += \
 CONFIGURE_ARGS += \
 	--enable-ssl
 
-define Package/$(PKG_NAME)/install
+define Package/ssmtp/install
 	$(INSTALL_DIR) $(1)/etc/ssmtp
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/ssmtp.conf $(1)/etc/ssmtp/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/revaliases $(1)/etc/ssmtp/
@@ -56,4 +56,4 @@ define Package/$(PKG_NAME)/install
 	ln -s /usr/sbin/ssmtp $(1)/usr/sbin/sendmail
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,ssmtp))

--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -13,21 +13,21 @@ PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/$(PKG_NAME)
+define Package/adblock
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=Powerful adblock script to block ad/abuse domains
 	PKGARCH:=all
 endef
 
-define Package/$(PKG_NAME)/description
+define Package/adblock/description
 Powerful adblock script to block ad/abuse domains via dnsmasq or unbound dns backend.
 The script supports many domain blacklist sites plus manual black- and whitelist overrides.
 Please see https://github.com/openwrt/packages/blob/master/net/adblock/files/README.md for further information.
 
 endef
 
-define Package/$(PKG_NAME)/conffiles
+define Package/adblock/conffiles
 /etc/config/adblock
 /etc/adblock/adblock.whitelist
 /etc/adblock/adblock.blacklist
@@ -42,7 +42,7 @@ endef
 define Build/Compile
 endef
 
-define Package/$(PKG_NAME)/install
+define Package/adblock/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) ./files/adblock.sh $(1)/usr/bin/
 
@@ -57,4 +57,4 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_CONF) ./files/adblock.whitelist $(1)/etc/adblock/
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,adblock))

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -22,7 +22,7 @@ include $(INCLUDE_DIR)/package.mk
 # no default dependencies
 PKG_DEFAULT_DEPENDS=
 
-define Package/$(PKG_NAME)/Default
+define Package/ddns-scripts/Default
     SECTION:=net
     CATEGORY:=Network
     SUBMENU:=IP Addresses and Names
@@ -30,16 +30,16 @@ define Package/$(PKG_NAME)/Default
 endef
 
 ###### *************************************************************************
-define Package/$(PKG_NAME)
-    $(call Package/$(PKG_NAME)/Default)
+define Package/ddns-scripts
+    $(call Package/ddns-scripts/Default)
     TITLE:=Dynamic DNS Client scripts (with IPv6 support)
 endef
 # shown in LuCI package description
-define Package/$(PKG_NAME)/description
+define Package/ddns-scripts/description
     Dynamic DNS Client scripts (with IPv6 support) - Info: http://wiki.openwrt.org/doc/howto/ddns.client
 endef
 # shown in menuconfig <Help>
-define Package/$(PKG_NAME)/config
+define Package/ddns-scripts/config
 	help
 		A highly configurable set of scripts for doing dynamic dns updates.
 		  - IPv6 support
@@ -54,55 +54,55 @@ define Package/$(PKG_NAME)/config
 endef
 
 ###### *************************************************************************
-define Package/$(PKG_NAME)_cloudflare
-    $(call Package/$(PKG_NAME)/Default)
+define Package/ddns-scripts_cloudflare
+    $(call Package/ddns-scripts/Default)
     TITLE:=CloudFlare.com API v1 (deprecated)
-    DEPENDS:=$(PKG_NAME)
+    DEPENDS:=ddns-scripts
 endef
-define Package/$(PKG_NAME)_cloudflare/description
+define Package/ddns-scripts_cloudflare/description
     Dynamic DNS Client scripts extension for CloudFlare.com API-v1 (deprecated)
 endef
 
 ###### *************************************************************************
-define Package/$(PKG_NAME)_cloudflare.com-v4
-    $(call Package/$(PKG_NAME)/Default)
+define Package/ddns-scripts_cloudflare.com-v4
+    $(call Package/ddns-scripts/Default)
     TITLE:=CloudFlare.com API v4 (require cURL)
-    DEPENDS:=$(PKG_NAME) +curl
+    DEPENDS:=ddns-scripts +curl
 endef
-define Package/$(PKG_NAME)_cloudflare.com-v4/description
+define Package/ddns-scripts_cloudflare.com-v4/description
     Dynamic DNS Client scripts extension for CloudFlare.com API-v4 (require/install cURL)
 endef
 
 ###### *************************************************************************
-define Package/$(PKG_NAME)_godaddy.com-v1
-    $(call Package/$(PKG_NAME)/Default)
+define Package/ddns-scripts_godaddy.com-v1
+    $(call Package/ddns-scripts/Default)
     TITLE:=GoDaddy.com (require cURL)
-    DEPENDS:=$(PKG_NAME) +curl
+    DEPENDS:=ddns-scripts +curl
 endef
-define Package/$(PKG_NAME)_godaddy.com-v1/description
+define Package/ddns-scripts_godaddy.com-v1/description
     Dynamic DNS Client scripts extension for GoDaddy.com (require/install cURL)
 endef
 
 ###### *************************************************************************
-define Package/$(PKG_NAME)_no-ip_com
-    $(call Package/$(PKG_NAME)/Default)
+define Package/ddns-scripts_no-ip_com
+    $(call Package/ddns-scripts/Default)
     TITLE:=DDNS extension for No-IP.com
-    DEPENDS:=$(PKG_NAME)
+    DEPENDS:=ddns-scripts
 endef
-define Package/$(PKG_NAME)_no-ip_com/description
+define Package/ddns-scripts_no-ip_com/description
     Dynamic DNS Client scripts extension for No-IP.com
 endef
 
 ###### *************************************************************************
-define Package/$(PKG_NAME)_nsupdate
-    $(call Package/$(PKG_NAME)/Default)
+define Package/ddns-scripts_nsupdate
+    $(call Package/ddns-scripts/Default)
     TITLE:=DDNS extension using Bind nsupdate
-    DEPENDS:=$(PKG_NAME) +bind-client
+    DEPENDS:=ddns-scripts +bind-client
 endef
-define Package/$(PKG_NAME)_nsupdate/description
+define Package/ddns-scripts_nsupdate/description
     Dynamic DNS Client scripts extension for direct updates using Bind nsupdate
 endef
-define Package/$(PKG_NAME)_nsupdate/config
+define Package/ddns-scripts_nsupdate/config
     help
 	The script directly updates a PowerDNS (or maybe bind server) via nsupdate
 	from bind-client package. It requires
@@ -132,18 +132,18 @@ define Build/Compile
 	gzip -f9 $(PKG_BUILD_DIR)/files/public_suffix_list.dat
 endef
 
-define Package/$(PKG_NAME)/conffiles
+define Package/ddns-scripts/conffiles
 /etc/config/ddns
 endef
 
 ###### *************************************************************************
-define Package/$(PKG_NAME)/preinst
+define Package/ddns-scripts/preinst
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
 	exit 0	# suppress errors
 endef
-define Package/$(PKG_NAME)/install
+define Package/ddns-scripts/install
 	$(INSTALL_DIR)  $(1)/etc/uci-defaults
 	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns
 	$(INSTALL_DIR)  $(1)/etc/hotplug.d/iface
@@ -159,7 +159,7 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR)  $(1)/usr/lib/ddns
 	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/dynamic_dns_*.sh $(1)/usr/lib/ddns
 endef
-define Package/$(PKG_NAME)/postinst
+define Package/ddns-scripts/postinst
 	#!/bin/sh
 	# if NOT run buildroot and PKG_UPGRADE then (re)start service if enabled
 	[ -z "$${IPKG_INSTROOT}" -a "$${PKG_UPGRADE}" = "1" ] && {
@@ -171,7 +171,7 @@ define Package/$(PKG_NAME)/postinst
 	}
 	exit 0	# suppress errors
 endef
-define Package/$(PKG_NAME)/prerm
+define Package/ddns-scripts/prerm
 	#!/bin/sh
 	# if run within buildroot exit
 	[ -n "$${IPKG_INSTROOT}" ] && exit 0
@@ -184,13 +184,13 @@ define Package/$(PKG_NAME)/prerm
 endef
 
 ###### *************************************************************************
-define Package/$(PKG_NAME)_cloudflare/preinst
+define Package/ddns-scripts_cloudflare/preinst
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
 	exit 0	# suppress errors
 endef
-define Package/$(PKG_NAME)_cloudflare/install
+define Package/ddns-scripts_cloudflare/install
 	$(INSTALL_DIR)  $(1)/etc/uci-defaults
 	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_cloudflare
 	$(INSTALL_DIR)  $(1)/usr/share
@@ -198,7 +198,7 @@ define Package/$(PKG_NAME)_cloudflare/install
 	$(INSTALL_DIR)  $(1)/usr/lib/ddns
 	$(INSTALL_BIN)  $(PKG_BUILD_DIR)/files/update_cloudflare_com_v1.sh $(1)/usr/lib/ddns
 endef
-define Package/$(PKG_NAME)_cloudflare/postinst
+define Package/ddns-scripts_cloudflare/postinst
 	#!/bin/sh
 	# remove old services file entries
 	/bin/sed -i '/cloudflare\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
@@ -216,7 +216,7 @@ define Package/$(PKG_NAME)_cloudflare/postinst
 	}
 	exit 0	# suppress errors
 endef
-define Package/$(PKG_NAME)_cloudflare/prerm
+define Package/ddns-scripts_cloudflare/prerm
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
@@ -227,19 +227,19 @@ define Package/$(PKG_NAME)_cloudflare/prerm
 endef
 
 ###### *************************************************************************
-define Package/$(PKG_NAME)_cloudflare.com-v4/preinst
+define Package/ddns-scripts_cloudflare.com-v4/preinst
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
 	exit 0	# suppress errors
 endef
-define Package/$(PKG_NAME)_cloudflare.com-v4/install
+define Package/ddns-scripts_cloudflare.com-v4/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_cloudflare.com-v4
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_cloudflare_com_v4.sh $(1)/usr/lib/ddns
 endef
-define Package/$(PKG_NAME)_cloudflare.com-v4/postinst
+define Package/ddns-scripts_cloudflare.com-v4/postinst
 	#!/bin/sh
 	# remove old services file entries
 	/bin/sed -i '/cloudflare\.com-v4/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
@@ -257,7 +257,7 @@ define Package/$(PKG_NAME)_cloudflare.com-v4/postinst
 	}
 	exit 0	# suppress errors
 endef
-define Package/$(PKG_NAME)_cloudflare.com-v4/prerm
+define Package/ddns-scripts_cloudflare.com-v4/prerm
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
@@ -268,19 +268,19 @@ define Package/$(PKG_NAME)_cloudflare.com-v4/prerm
 endef
 
 ###### *************************************************************************
-define Package/$(PKG_NAME)_godaddy.com-v1/preinst
+define Package/ddns-scripts_godaddy.com-v1/preinst
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
 	exit 0	# suppress errors
 endef
-define Package/$(PKG_NAME)_godaddy.com-v1/install
+define Package/ddns-scripts_godaddy.com-v1/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_godaddy.com-v1
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_godaddy_com_v1.sh $(1)/usr/lib/ddns
 endef
-define Package/$(PKG_NAME)_godaddy.com-v1/postinst
+define Package/ddns-scripts_godaddy.com-v1/postinst
 	#!/bin/sh
 	# remove old services file entries
 	/bin/sed -i '/godaddy\.com-v1/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
@@ -298,7 +298,7 @@ define Package/$(PKG_NAME)_godaddy.com-v1/postinst
 	}
 	exit 0	# suppress errors
 endef
-define Package/$(PKG_NAME)_godaddy.com-v1/prerm
+define Package/ddns-scripts_godaddy.com-v1/prerm
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
@@ -309,19 +309,19 @@ define Package/$(PKG_NAME)_godaddy.com-v1/prerm
 endef
 
 ###### *************************************************************************
-define Package/$(PKG_NAME)_no-ip_com/preinst
+define Package/ddns-scripts_no-ip_com/preinst
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
 	exit 0	# suppress errors
 endef
-define Package/$(PKG_NAME)_no-ip_com/install
+define Package/ddns-scripts_no-ip_com/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_no-ip_com
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_no-ip_com.sh $(1)/usr/lib/ddns
 endef
-define Package/$(PKG_NAME)_no-ip_com/postinst
+define Package/ddns-scripts_no-ip_com/postinst
 	#!/bin/sh
 	# remove old services file entries
 	/bin/sed -i '/no-ip\.com/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
@@ -337,7 +337,7 @@ define Package/$(PKG_NAME)_no-ip_com/postinst
 	}
 	exit 0	# suppress errors
 endef
-define Package/$(PKG_NAME)_no-ip_com/prerm
+define Package/ddns-scripts_no-ip_com/prerm
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop		>/dev/null 2>&1
@@ -347,19 +347,19 @@ define Package/$(PKG_NAME)_no-ip_com/prerm
 endef
 
 ###### *************************************************************************
-define Package/$(PKG_NAME)_nsupdate/preinst
+define Package/ddns-scripts_nsupdate/preinst
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
 	exit 0	# suppress errors
 endef
-define Package/$(PKG_NAME)_nsupdate/install
+define Package/ddns-scripts_nsupdate/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_nsupdate
 	$(INSTALL_DIR) $(1)/usr/lib/ddns
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_nsupdate.sh $(1)/usr/lib/ddns
 endef
-define Package/$(PKG_NAME)_nsupdate/postinst
+define Package/ddns-scripts_nsupdate/postinst
 	#!/bin/sh
 	# remove old services file entries
 	/bin/sed -i '/bind-nsupdate/d' $${IPKG_INSTROOT}/etc/ddns/services	>/dev/null 2>&1
@@ -377,7 +377,7 @@ define Package/$(PKG_NAME)_nsupdate/postinst
 	}
 	exit 0	# suppress errors
 endef
-define Package/$(PKG_NAME)_nsupdate/prerm
+define Package/ddns-scripts_nsupdate/prerm
 	#!/bin/sh
 	# if NOT run buildroot then stop service
 	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop			>/dev/null 2>&1
@@ -388,9 +388,9 @@ define Package/$(PKG_NAME)_nsupdate/prerm
 endef
 
 ###### *************************************************************************
-$(eval $(call BuildPackage,$(PKG_NAME)))
-$(eval $(call BuildPackage,$(PKG_NAME)_cloudflare))
-$(eval $(call BuildPackage,$(PKG_NAME)_cloudflare.com-v4))
-$(eval $(call BuildPackage,$(PKG_NAME)_godaddy.com-v1))
-$(eval $(call BuildPackage,$(PKG_NAME)_no-ip_com))
-$(eval $(call BuildPackage,$(PKG_NAME)_nsupdate))
+$(eval $(call BuildPackage,ddns-scripts))
+$(eval $(call BuildPackage,ddns-scripts_cloudflare))
+$(eval $(call BuildPackage,ddns-scripts_cloudflare.com-v4))
+$(eval $(call BuildPackage,ddns-scripts_godaddy.com-v1))
+$(eval $(call BuildPackage,ddns-scripts_no-ip_com))
+$(eval $(call BuildPackage,ddns-scripts_nsupdate))

--- a/net/dynapoint/Makefile
+++ b/net/dynapoint/Makefile
@@ -15,7 +15,7 @@ PKG_LICENSE:=GPL-3.0+
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/$(PKG_NAME)
+define Package/dynapoint
     SECTION:=net
     CATEGORY:=Network
     SUBMENU:=wireless
@@ -23,19 +23,19 @@ define Package/$(PKG_NAME)
     TITLE:=Dynamic access point manager
 endef
 
-define Package/$(PKG_NAME)/description
+define Package/dynapoint/description
   Dynapoint uses LUA scripts to allow dynamic access point creation
   and deletion depending on changes of certain network conditions.
 endef
 
-define Package/$(PKG_NAME)/conffiles
+define Package/dynapoint/conffiles
 /etc/config/dynapoint
 endef
 
 define Build/Compile
 endef
 
-define Package/$(PKG_NAME)/install
+define Package/dynapoint/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) ./src/dynapoint.lua $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
@@ -44,4 +44,4 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DATA) ./src/dynapoint.config $(1)/etc/config/dynapoint
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,dynapoint))

--- a/net/privoxy/Makefile
+++ b/net/privoxy/Makefile
@@ -49,7 +49,7 @@ PKG_CONFIG_DEPENDS:= \
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/$(PKG_NAME)
+define Package/privoxy
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
@@ -61,12 +61,12 @@ define Package/$(PKG_NAME)
 endef
 
 # shown in LuCI package description
-define Package/$(PKG_NAME)/description
+define Package/privoxy/description
 $(TITLE) - Homepage: www.privoxy.org
 endef
 
 # shown in make menuconfig <Help>
-define Package/$(PKG_NAME)/config
+define Package/privoxy/config
 	help
 		Privoxy is a web proxy with advanced filtering capabilities for protecting
 		privacy, modifying web page content, managing cookies, controlling access,
@@ -110,14 +110,14 @@ CONFIGURE_ARGS += \
 # needed otherwise errors during compile
 MAKE_FLAGS:=
 
-define Package/$(PKG_NAME)/conffiles
+define Package/privoxy/conffiles
 /etc/config/privoxy
 /etc/privoxy/user.action
 /etc/privoxy/user.filter
 /etc/privoxy/user.trust
 endef
 
-define Package/$(PKG_NAME)/preinst
+define Package/privoxy/preinst
 	#!/bin/sh
 	[ -n "$${IPKG_INSTROOT}" ] && exit 0	# if run within buildroot exit
 
@@ -127,7 +127,7 @@ define Package/$(PKG_NAME)/preinst
 	exit 0	# suppress errors from stop command
 endef
 
-define Package/$(PKG_NAME)/install
+define Package/privoxy/install
 	if [ -f $(PKG_INSTALL_DIR)/etc/privoxy/trust ]; then \
 		mv -f $(PKG_INSTALL_DIR)/etc/privoxy/trust $(PKG_INSTALL_DIR)/etc/privoxy/user.trust; \
 	fi
@@ -155,10 +155,10 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_CONF) ./files/privoxy.config $(1)/etc/config/privoxy
 endef
 
-define Package/$(PKG_NAME)/postinst
+define Package/privoxy/postinst
 	#!/bin/sh
 	grep -i privoxy $${IPKG_INSTROOT}/etc/services >/dev/null 2>&1 || \
 		echo -e "privoxy\t8118" >> $${IPKG_INSTROOT}/etc/services
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,privoxy))

--- a/net/radicale/Makefile
+++ b/net/radicale/Makefile
@@ -28,7 +28,7 @@ $(call include_mk, python3-package.mk)
 # no default dependencies
 PKG_DEFAULT_DEPENDS:=
 
-define Package/$(PKG_NAME)/Default
+define Package/radicale/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
@@ -37,29 +37,29 @@ define Package/$(PKG_NAME)/Default
   PKGARCH:=all
   USERID:=radicale=5232:radicale=5232
 endef
-define Package/$(PKG_NAME)-py2
-  $(call Package/$(PKG_NAME)/Default)
+define Package/radicale-py2
+  $(call Package/radicale/Default)
   TITLE+= (Python 2)
   VARIANT:=2
   DEPENDS:=+python-logging +python-openssl +python-xml +python-codecs
 endef
-define Package/$(PKG_NAME)-py3
-  $(call Package/$(PKG_NAME)/Default)
+define Package/radicale-py3
+  $(call Package/radicale/Default)
   TITLE+= (Python 3)
   VARIANT:=3
   DEPENDS:=+python3-logging +python3-openssl +python3-xml +python3-codecs +python3-email
 endef
 
 # shown in LuCI package description
-define Package/$(PKG_NAME)-py2/description
+define Package/radicale-py2/description
 Radicale CalDAV/CardDAV server (Python 2) - Homepage: http://radicale.org/
 endef
-define Package/$(PKG_NAME)-py3/description
+define Package/radicale-py3/description
 Radicale CalDAV/CardDAV server (Python 3) - Homepage: http://radicale.org/
 endef
 
 # shown in make menuconfig <Help>
-define Package/$(PKG_NAME)-py2/config
+define Package/radicale-py2/config
     help
 	The Radicale Project is a CalDAV (calendar) and CardDAV (contact) server.
 	It aims to be a light solution, easy to use, easy to install, easy to configure.
@@ -69,14 +69,14 @@ define Package/$(PKG_NAME)-py2/config
 	Version : $(PKG_VERSION)
 	Homepage: http://radicale.org/
 endef
-Package/$(PKG_NAME)-py3/config = $(Package/$(PKG_NAME)-py2/config)
+Package/radicale-py3/config = $(Package/radicale-py2/config)
 
-define Package/$(PKG_NAME)-py2/conffiles
+define Package/radicale-py2/conffiles
 /etc/config/radicale
 /etc/radicale/users
 /etc/radicale/rights
 endef
-Package/$(PKG_NAME)-py3/conffiles = $(Package/$(PKG_NAME)-py2/conffiles)
+Package/radicale-py3/conffiles = $(Package/radicale-py2/conffiles)
 
 define Build/Configure
 	# nothing to configure
@@ -85,7 +85,7 @@ define Build/Compile
 	# nothing to compile
 endef
 
-define Package/$(PKG_NAME)-py2/preinst
+define Package/radicale-py2/preinst
 	#!/bin/sh
 	[ -n "$${IPKG_INSTROOT}" ] && exit 0	# if run within buildroot exit
 
@@ -94,11 +94,11 @@ define Package/$(PKG_NAME)-py2/preinst
 
 	exit 0	# suppress errors from stop command
 endef
-define Package/$(PKG_NAME)-py3/preinst
-$(call Package/$(PKG_NAME)-py2/preinst)
+define Package/radicale-py3/preinst
+$(call Package/radicale-py2/preinst)
 endef
 
-define Package/$(PKG_NAME)/inst_all
+define Package/radicale/inst_all
 	$(INSTALL_DIR)	$(1)/etc/init.d
 	$(INSTALL_BIN)  ./files/radicale.init    $(1)/etc/init.d/radicale
 
@@ -120,27 +120,27 @@ define Package/$(PKG_NAME)/inst_all
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/radicale $(1)/usr/bin/
 endef
-define Package/$(PKG_NAME)-py2/install
-	$(call Package/$(PKG_NAME)/inst_all, $(1))
+define Package/radicale-py2/install
+	$(call Package/radicale/inst_all, $(1))
 	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)/radicale
 	$(CP) $(PKG_BUILD_DIR)/radicale/* $(1)$(PYTHON_PKG_DIR)/radicale
 endef
-define Package/$(PKG_NAME)-py3/install
-	$(call Package/$(PKG_NAME)/inst_all, $(1))
+define Package/radicale-py3/install
+	$(call Package/radicale/inst_all, $(1))
 	$(INSTALL_DIR) $(1)$(PYTHON3_PKG_DIR)/radicale
 	$(CP) $(PKG_BUILD_DIR)/radicale/* $(1)$(PYTHON3_PKG_DIR)/radicale
 endef
 
-define Package/$(PKG_NAME)-py2/postinst
+define Package/radicale-py2/postinst
 	#!/bin/sh
 	# patch /usr/bin/radicale force run using python2
 	/bin/sed -i 's/python/python2/' $${IPKG_INSTROOT}/usr/bin/radicale
 endef
-define Package/$(PKG_NAME)-py3/postinst
+define Package/radicale-py3/postinst
 	#!/bin/sh
 	# patch /usr/bin/radicale force run using python3
 	/bin/sed -i 's/python/python3/' $${IPKG_INSTROOT}/usr/bin/radicale
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)-py2))
-$(eval $(call BuildPackage,$(PKG_NAME)-py3))
+$(eval $(call BuildPackage,radicale-py2))
+$(eval $(call BuildPackage,radicale-py3))

--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -13,20 +13,20 @@ PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/$(PKG_NAME)
+define Package/travelmate
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=A wlan connection manager for travel router
 	PKGARCH:=all
 endef
 
-define Package/$(PKG_NAME)/description
+define Package/travelmate/description
 A wlan connection manager for travel router.
 Please see https://github.com/openwrt/packages/blob/master/net/travelmate/files/README.md for further information.
 
 endef
 
-define Package/$(PKG_NAME)/conffiles
+define Package/travelmate/conffiles
 /etc/config/travelmate
 endef
 
@@ -39,7 +39,7 @@ endef
 define Build/Compile
 endef
 
-define Package/$(PKG_NAME)/install
+define Package/travelmate/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) ./files/travelmate.sh $(1)/usr/bin/
 
@@ -50,4 +50,4 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_CONF) ./files/travelmate.conf $(1)/etc/config/travelmate
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,travelmate))

--- a/net/vpnbypass/Makefile
+++ b/net/vpnbypass/Makefile
@@ -11,7 +11,7 @@ PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/$(PKG_NAME)
+define Package/vpnbypass
 	SECTION:=net
 	CATEGORY:=Network
 	DEPENDS:=+ip-full +ipset +iptables +ubox +dnsmasq-full
@@ -20,14 +20,14 @@ define Package/$(PKG_NAME)
 	PKGARCH:=all
 endef
 
-define Package/$(PKG_NAME)/description
+define Package/vpnbypass/description
 This service can be used to enable simple VPN split tunnelling.
 Supports accessing domains, IP ranges outside of your VPN tunnel.
 Also supports dedicating local ports/IP ranges for direct internet access (outside of your VPN tunnel).
 Please see the README for further information.
 endef
 
-define Package/$(PKG_NAME)/conffiles
+define Package/vpnbypass/conffiles
 /etc/config/vpnbypass
 endef
 
@@ -43,7 +43,7 @@ endef
 define Build/Compile
 endef
 
-define Package/$(PKG_NAME)/install
+define Package/vpnbypass/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/vpnbypass.init $(1)/etc/init.d/vpnbypass
 	$(INSTALL_DIR) $(1)/etc/config
@@ -52,4 +52,4 @@ define Package/$(PKG_NAME)/install
 	$(INSTALL_DATA) ./files/vpnbypass.hotplug $(1)/etc/hotplug.d/firewall/94-vpnbypass
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,vpnbypass))

--- a/utils/mc/Makefile
+++ b/utils/mc/Makefile
@@ -32,7 +32,7 @@ PKG_CONFIG_DEPENDS := \
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
-define Package/$(PKG_NAME)
+define Package/mc
 	SECTION:=utils
 	CATEGORY:=Utilities
 	DEPENDS:=+glib2 +libncurses +libmount +MC_VFS:libssh2 $(LIBRPC_DEPENDS) $(ICONV_DEPENDS)
@@ -41,11 +41,11 @@ define Package/$(PKG_NAME)
 	MENU:=1
 endef
 
-define Package/$(PKG_NAME)/config
+define Package/mc/config
 	source "$(SOURCE)/Config.in"
 endef
 
-define Package/$(PKG_NAME)/description
+define Package/mc/description
 GNU Midnight Commander is a visual file manager.
 It's a feature rich full-screen text mode application that allows you to copy,
 move and delete files and whole directory trees, search for files and run commands in the subshell.
@@ -98,7 +98,7 @@ CONFIGURE_ARGS += \
 	--disable-vfs
 endif
 
-define Package/$(PKG_NAME)/install
+define Package/mc/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/mc $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/etc/mc
@@ -119,9 +119,9 @@ endif
 	$(INSTALL_DIR) $(1)/etc/mc/mcedit/Syntax
 endef
 
-define Package/$(PKG_NAME)/conffiles
+define Package/mc/conffiles
 /etc/mc/mc.menu
 /etc/mc/skins/default.ini
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,mc))

--- a/utils/owfs/Makefile
+++ b/utils/owfs/Makefile
@@ -34,7 +34,7 @@ include $(INCLUDE_DIR)/package.mk
 # templates
 #
 
-define Package/$(PKG_NAME)/Default
+define Package/owfs/Default
   TITLE:=OWFS (1-Wire File System)
   URL:=http://owfs.sourceforge.net/
   SECTION:=net
@@ -42,7 +42,7 @@ define Package/$(PKG_NAME)/Default
   SUBMENU:=Filesystem
 endef
 
-define Package/$(PKG_NAME)/Default/description
+define Package/owfs/Default/description
   OWFS is a suite of programs that designed to make the 1-wire bus and its
   devices easily accessible. The underlying principle is to create a virtual
   filesystem, with the unique ID being the directory, and the individual
@@ -94,7 +94,7 @@ define Package/libow/config
 endef
 
 define Package/libow/description
-  $(call Package/$(PKG_NAME)/Default/description)
+  $(call Package/owfs/Default/description)
 
   This package contains the OWFS library.
 endef
@@ -106,7 +106,7 @@ define Package/libow-capi
 endef
 
 define Package/libow-capi/description
-  $(call Package/$(PKG_NAME)/Default/description)
+  $(call Package/owfs/Default/description)
 
   This package contains the OWFS C-API library.
 endef
@@ -122,7 +122,7 @@ define Package/owshell
 endef
 
 define Package/owshell/description
-  $(call Package/$(PKG_NAME)/Default/description)
+  $(call Package/owfs/Default/description)
 
   This package contains the OWFS shell utilities.
 endef
@@ -135,7 +135,7 @@ define Package/owfs
 endef
 
 define Package/owfs/description
-  $(call Package/$(PKG_NAME)/Default/description)
+  $(call Package/owfs/Default/description)
 
   This package contains the OWFS fuse filesystem.
 endef
@@ -150,7 +150,7 @@ define Package/owhttpd
 endef
 
 define Package/owhttpd/description
-  $(call Package/$(PKG_NAME)/Default/description)
+  $(call Package/owfs/Default/description)
 
   This package contains the OWFS http server.
 endef
@@ -161,7 +161,7 @@ define Package/owftpd
 endef
 
 define Package/owftpd/description
-  $(call Package/$(PKG_NAME)/Default/description)
+  $(call Package/owfs/Default/description)
 
   This package contains the OWFS ftp server.
 endef
@@ -172,7 +172,7 @@ define Package/owserver
 endef
 
 define Package/owserver/description
-  $(call Package/$(PKG_NAME)/Default/description)
+  $(call Package/owfs/Default/description)
 
   This package contains the OWFS network server.
 endef


### PR DESCRIPTION
For consistency, use full name instead of $(PKG_NAME) in define and eval lines for all packages.
I've seen reviews that asked to do this before, and I am asking the same during reviews now. To avoid this in the future, fix this treewide so when people use existing packages as example, we will not have to request this change anymore.

This makes all packages consistent with both LEDE and OpenWrt base repositories (check with ``git grep PKG_NAME| egrep -i 'define|call|eval'``).

There is one exception for PHP pecl packages, where ``PKG_NAME:=php7-pecl-$(PECL_NAME)``. Do we want to change these, too?
