### PR TITLE
lighttpd: update to 1.4.45 (add new modules)

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.45
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://download.lighttpd.net/lighttpd/releases-1.4.x
+PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
 PKG_MD5SUM:=a128e1eda76899ce3fd115efae5fe631
 
 PKG_LICENSE:=BSD-3c
@@ -58,10 +58,6 @@ CONFIGURE_ARGS+= \
 	--without-attr \
 	--without-bzip2 \
 	--without-fam \
-	--without-gdbm \
-	--without-ldap \
-	--with-lua \
-	--without-memcache \
 	--with-pcre \
 	--without-valgrind \
 	 $(call autoconf_bool,CONFIG_IPV6,ipv6)
@@ -77,12 +73,52 @@ else
 	--without-openssl
 endif
 
-ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-mysql-vhost),)
-  CONFIGURE_ARGS+= \
-	--with-mysql
+ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-authn_gssapi),)
+  CONFIGURE_ARGS+= --with-krb5
 else
-  CONFIGURE_ARGS+= \
-	--without-mysql
+  CONFIGURE_ARGS+= --without-krb5
+endif
+
+ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-authn_ldap),)
+  CONFIGURE_ARGS+= --with-ldap
+else
+  CONFIGURE_ARGS+= --without-ldap
+endif
+
+ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-authn_mysql),)
+  CONFIGURE_ARGS+= --with-mysql
+else
+  CONFIGURE_ARGS+= --without-mysql
+endif
+
+#ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-geoip),)
+#  CONFIGURE_ARGS+= --with-geoip
+#else
+#  CONFIGURE_ARGS+= --without-geoip
+#endif
+
+ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-cml)$(CONFIG_PACKAGE_lighttpd-mod-magnet),)
+  CONFIGURE_ARGS+= --with-lua
+else
+  CONFIGURE_ARGS+= --without-lua
+endif
+
+ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-mysql_vhost),)
+  CONFIGURE_ARGS+= --with-mysql
+else
+  CONFIGURE_ARGS+= --without-mysql
+endif
+
+#ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-cml)$(CONFIG_PACKAGE_lighttpd-mod-trigger_b4_dl),)
+#  CONFIGURE_ARGS+= --with-memcached
+#else
+#  CONFIGURE_ARGS+= --without-memcached
+#endif
+
+ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-trigger_b4_dl),)
+  CONFIGURE_ARGS+= --with-gdbm
+else
+  CONFIGURE_ARGS+= --without-gdbm
 endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-webdav),)
@@ -134,6 +170,7 @@ define BuildPlugin
     TITLE:=$(2) module
   endef
 
+ ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-$(1)),)
   define Package/lighttpd-mod-$(1)/install
 	$(INSTALL_DIR) $$(1)/usr/lib/lighttpd
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lighttpd/mod_$(1).so $$(1)/usr/lib/lighttpd
@@ -144,6 +181,7 @@ define BuildPlugin
 		echo 'server.modules += ( "mod_$(1)" )' > $$(1)/etc/lighttpd/conf.d/$(4)-$(1).conf ; \
 	fi
   endef
+ endif
 
   $$(eval $$(call BuildPackage,lighttpd-mod-$(1)))
 endef
@@ -156,21 +194,27 @@ $(eval $(call BuildPlugin,redirect,URL redirection,+PACKAGE_lighttpd-mod-redirec
 # Next, permit authentication.
 $(eval $(call BuildPlugin,auth,Authentication,,20))
 $(eval $(call BuildPlugin,authn_file,File-based authentication,,20))
+$(eval $(call BuildPlugin,authn_gssapi,Kerberos-based authentication,+PACKAGE_lighttpd-mod-authn_gssapi:krb5-libs,20))
+$(eval $(call BuildPlugin,authn_ldap,LDAP-based authentication,+PACKAGE_lighttpd-mod-authn_ldap:libopenldap,20))
+$(eval $(call BuildPlugin,authn_mysql,Mysql-based authentication,+PACKAGE_lighttpd-mod-authn_mysql:libmysqlclient,20))
 
 # Finally, everything else.
 $(eval $(call BuildPlugin,access,Access restrictions,,30))
 $(eval $(call BuildPlugin,accesslog,Access logging,,30))
 $(eval $(call BuildPlugin,alias,Directory alias,,30))
 $(eval $(call BuildPlugin,cgi,CGI,,30))
-$(eval $(call BuildPlugin,cml,Cache Meta Language,+liblua,30))
+#$(eval $(call BuildPlugin,cml,Cache Meta Language,+PACKAGE_lighttpd-mod-cml:liblua +PACKAGE_lighttpd-mod-cml:libmemcached,30))
+$(eval $(call BuildPlugin,cml,Cache Meta Language,+PACKAGE_lighttpd-mod-cml:liblua,30))
 $(eval $(call BuildPlugin,compress,Compress output,+PACKAGE_lighttpd-mod-compress:zlib,30))
+$(eval $(call BuildPlugin,deflate,Compress dynamic output,+PACKAGE_lighttpd-mod-deflate:zlib,30))
 $(eval $(call BuildPlugin,evasive,Evasive,,30))
-$(eval $(call BuildPlugin,evhost,Exnhanced Virtual-Hosting,,30))
+$(eval $(call BuildPlugin,evhost,Enhanced Virtual-Hosting,,30))
 $(eval $(call BuildPlugin,expire,Expire,,30))
 $(eval $(call BuildPlugin,extforward,Extract client,,30))
 $(eval $(call BuildPlugin,fastcgi,FastCGI,,30))
 $(eval $(call BuildPlugin,flv_streaming,FLV streaming,,30))
-$(eval $(call BuildPlugin,magnet,Magnet,+liblua,30))
+#$(eval $(call BuildPlugin,geoip,Geolocation,+PACKAGE_lighttpd-mod-geoip:libgeoip,30))
+$(eval $(call BuildPlugin,magnet,Magnet,+PACKAGE_lighttpd-mod-magnet:liblua,30))
 $(eval $(call BuildPlugin,mysql_vhost,Mysql virtual hosting,+PACKAGE_lighttpd-mod-mysql_vhost:libmysqlclient,30))
 $(eval $(call BuildPlugin,proxy,Proxy,,30))
 $(eval $(call BuildPlugin,rewrite,URL rewriting,+PACKAGE_lighttpd-mod-rewrite:libpcre,30))
@@ -179,9 +223,10 @@ $(eval $(call BuildPlugin,scgi,SCGI,,30))
 $(eval $(call BuildPlugin,secdownload,Secure and fast download,,30))
 $(eval $(call BuildPlugin,setenv,Environment variable setting,,30))
 $(eval $(call BuildPlugin,simple_vhost,Simple virtual hosting,,30))
-$(eval $(call BuildPlugin,ssi,SSI,+libpcre,30))
+$(eval $(call BuildPlugin,ssi,SSI,+PACKAGE_lighttpd-mod-ssi:libpcre,30))
 $(eval $(call BuildPlugin,status,Server status display,,30))
-$(eval $(call BuildPlugin,trigger_b4_dl,Trigger before download,+PACKAGE_lighttpd-mod-trigger_b4_dl:libpcre,30))
+#$(eval $(call BuildPlugin,trigger_b4_dl,Trigger before download,+PACKAGE_lighttpd-mod-trigger_b4_dl:libpcre +PACKAGE_lighttpd-mod-trigger_b4_dl:libgdbm +PACKAGE_lighttpd-mod-trigger_b4_dl:libmemcached,30))
+$(eval $(call BuildPlugin,trigger_b4_dl,Trigger before download,+PACKAGE_lighttpd-mod-trigger_b4_dl:libpcre +PACKAGE_lighttpd-mod-trigger_b4_dl:libgdbm,30))
 $(eval $(call BuildPlugin,userdir,User directory,,30))
 $(eval $(call BuildPlugin,usertrack,User tracking,,30))
 $(eval $(call BuildPlugin,webdav,WebDAV,+PACKAGE_lighttpd-mod-webdav:libsqlite3 +PACKAGE_lighttpd-mod-webdav:libuuid +PACKAGE_lighttpd-mod-webdav:libxml2,30))

--- a/net/lighttpd/files/lighttpd.conf
+++ b/net/lighttpd/files/lighttpd.conf
@@ -1,6 +1,3 @@
-server.modules = (
-)
-
 server.document-root        = "/www"
 server.upload-dirs          = ( "/tmp" )
 server.errorlog             = "/var/log/lighttpd/error.log"
@@ -10,7 +7,7 @@ server.groupname            = "www-data"
 
 index-file.names            = ( "index.php", "index.html",
                                 "index.htm", "default.htm",
-                                "index.lighttpd.html" )
+                              )
 
 static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
 
@@ -20,7 +17,7 @@ static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
 #server.bind                 = "localhost"
 #server.tag                  = "lighttpd"
 #server.errorlog-use-syslog  = "enable"
-#server.network-backend      = "write"
+#server.network-backend      = "writev"
 
 ### Use IPv6 if available
 #include_shell "/usr/share/lighttpd/use-ipv6.pl"
@@ -28,5 +25,5 @@ static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
 #dir-listing.encoding        = "utf-8"
 #server.dir-listing          = "enable"
 
-include       "/etc/lighttpd/mime.conf"
-include_shell "cat /etc/lighttpd/conf.d/*.conf"
+include "/etc/lighttpd/mime.conf"
+include "/etc/lighttpd/conf.d/*.conf"

--- a/net/lighttpd/files/lighttpd.init
+++ b/net/lighttpd/files/lighttpd.init
@@ -18,3 +18,9 @@ stop() {
 	service_stop /usr/sbin/lighttpd
 }
 
+restart() {
+	/usr/sbin/lighttpd -tt -f /etc/lighttpd/lighttpd.conf || exit 1
+	stop
+	start
+}
+


### PR DESCRIPTION
add new modules to build, add restart() to lighttpd.init, file-glob includes in lighttpd.conf

Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>

-------------------------------

Maintainer: me
Compile tested: MIPS 74K, NetGear WNDR3700v3, OpenWRT master
Run tested: MIPS 74K, NetGear WNDR3700v3, OpenWRT master

Description: add new modules to build, add restart() to lighttpd.init, file-glob includes in lighttpd.conf