### PR TITLE
dansguardian: Fix build error due to missing cstdlib include

### DIFF
--- a/net/dansguardian/patches/002-cstdlib.patch
+++ b/net/dansguardian/patches/002-cstdlib.patch
@@ -1,0 +1,12 @@
+Index: dansguardian-2.12.0.3/src/OptionContainer.cpp
+===================================================================
+--- dansguardian-2.12.0.3.orig/src/OptionContainer.cpp
++++ dansguardian-2.12.0.3/src/OptionContainer.cpp
+@@ -17,6 +17,7 @@
+ #include <sstream>
+ #include <syslog.h>
+ #include <dirent.h>
++#include <cstdlib>
+ 
+ #include <unistd.h>		// checkme: remove?
+ 


### PR DESCRIPTION
Fixes the following build errors:

mipsel-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I..
-D__CONFFILE='"/etc/dansguardian/dansguardian.conf"'
-D__LOGLOCATION='"/var/log/dansguardian/"' -D__PIDDIR='"/var/run"'
-D__PROXYUSER='"root"' -D__PROXYGROUP='"root"'
-D__CONFDIR='"/etc/dansguardian"'
-I/local/users/fainelli/openwrt/trunk/staging_dir/target-mipsel-linux-gnu_glibc/usr/include
-I/local/users/fainelli/openwrt/trunk/staging_dir/target-mipsel-linux-gnu_glibc/include
-I/opt/toolchains/stbgcc-4.8-1.5/usr/include
-I/opt/toolchains/stbgcc-4.8-1.5/include    -Os -pipe -mno-branch-likely
-mips32r2 -mtune=24kc -fno-caller-saves -mips16 -minterlink-mips16
-fno-rtti  -MT dansguardian-OptionContainer.o -MD -MP -MF
.deps/dansguardian-OptionContainer.Tpo -c -o
dansguardian-OptionContainer.o `test -f 'OptionContainer.cpp' || echo
'./'`OptionContainer.cpp
OptionContainer.cpp: In member function 'void
OptionContainer::loadRooms()':
OptionContainer.cpp:796:9: error: 'exit' was not declared in this scope
   exit(1);
         ^
OptionContainer.cpp:824:10: error: 'exit' was not declared in this scope
    exit(1);
          ^
make[5]: *** [dansguardian-OptionContainer.o] Error 1

Signed-off-by: Florian Fainelli <f.fainelli@gmail.com>

Please double check that your commits:
- all start with "<package name>: "
- all contain signed-off-by
- are linked to your github account (you see your logo in front of them) 

Please also read https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md

Thanks for your contribution
Please remove this text (before ---) and fill the following template
-------------------------------

Maintainer: me / @<github-user>
Compile tested: (put here arch, model, OpenWRT/LEDE version)
Run tested: (put here arch, model, OpenWRT/LEDE version, tests done)

Description:
