### PR TITLE
clamav: use PCRE2

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/clamav/Default
   SECTION:=net
-  DEPENDS:=+libpthread +uclibcxx +zlib +libcurl +libopenssl +libltdl +libpcre +USE_MUSL:musl-fts
+  DEPENDS:=+libpthread +uclibcxx +zlib +libcurl +libopenssl +libltdl +libpcre2 +USE_MUSL:musl-fts
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
   TITLE:=ClamAV
@@ -70,6 +70,7 @@ define Build/Configure
 		--disable-bzip2 \
 		--with-user nobody \
 		--with-group nogroup \
+		--with-pcre="$(STAGING_DIR)/usr/" \
 	)
 endef
 


### PR DESCRIPTION
fix location of PCRE libs and prefer PCRE2 over PCRE

Compile/Run tested on LEDE Reboot SNAPSHOT r3640-f229f4a

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
