### PR TITLE
tor: update to version 0.2.9.10

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.2.9.9
+PKG_VERSION:=0.2.9.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_MD5SUM:=33325d2b250fd047ba2ddc5d11c2190c4e2951f4b03ec48ebd8bf0666e990d43
+PKG_MD5SUM:=d611283e1fb284b5f884f8c07e7d3151016851848304f56cfdf3be2a88bd1341
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
 PKG_LICENSE_FILES:=LICENSE
 


### PR DESCRIPTION
Maintainer: @monosoul
Compile tested: MIPS, Asus RT-N66U
Run tested: MIPS, Asus RT-N66U, starting/working w/o any issues

Description:
Updated tor version to current stable: 0.2.9.10