### PR TITLE
unbound: Fix odhcpd trigger script

### DIFF
--- a/net/unbound/files/odhcpd.sh
+++ b/net/unbound/files/odhcpd.sh
@@ -33,6 +33,7 @@ odhcpd_settings() {
   local cfg="$1"
   config_get UNBOUND_D_DHCP_LINK  "$cfg" dhcp_link none
   config_get_bool UNBOUND_B_SLAAC6_MAC "$cfg" dhcp4_slaac6 0
+  config_get UNBOUND_TXT_DOMAIN "$cfg" domain lan
 }
 
 ##############################################################################


### PR DESCRIPTION
Maintainer: Eric Luehrsen / @EricLuehrsen 
Compile tested: N/A
Run tested: LEDE Reboot (17.01.0, r3205-59508e3)

Description:
Fix odhcpd trigger script to update leases into Unbound.
The script was not fetching the domain configured and was using default value ('lan').