### PR TITLE
net/mwan3: fix hotplug on ACTION ifdown

### DIFF
--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -30,7 +30,9 @@ elif [ "$family" == "ipv6" ]; then
 	network_get_gateway6 gateway $INTERFACE
 fi
 
-[ -n "$gateway" ] || exit 9
+if [ "$ACTION" == "ifup" ]; then
+	[ -n "$gateway" ] || exit 9
+fi
 
 $LOG notice "$ACTION interface $INTERFACE (${DEVICE:-unknown})"
 


### PR DESCRIPTION
Maintainer: me
Run tested: lantiq, xrx200, OpenWRT

Description:
On dynamic interface proto (dhcp/pppoe) the hotplug will not execude (exit 9)
because the gateway is already released. The check will now only be made
on a ifup ACTION event.