### PR TITLE
giflib: add host build

### DIFF
--- a/libs/giflib/Makefile
+++ b/libs/giflib/Makefile
@@ -23,6 +23,7 @@ PKG_LICENSE_FILES:=COPYING
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=autogen.sh aclocal.m4
 
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/giflib
@@ -57,4 +58,5 @@ define Package/giflib/install
 	$(CP) $(PKG_BUILD_DIR)/lib/.libs/lib*so* $(1)/usr/lib/
 endef
 
+$(eval $(call HostBuild))
 $(eval $(call BuildPackage,giflib))


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: LEDE r3779-5420293 brcm2708
Run tested: Gentoo x86/64 (build host)

Description:
This adds host build for giflib. This is required to build Kodi's TexturePacker.