### PR TITLE
avahi: fix deps for avahi-utils

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -243,7 +243,7 @@ define Package/avahi-utils
   $(call Package/avahi/Default)
   SUBMENU:=IP Addresses and Names
   VARIANT:=dbus
-  DEPENDS:=libavahi-client +libgdbm
+  DEPENDS:=+avahi +dbus +libavahi-client +libgdbm
   TITLE+= (utilities)
 endef
 


### PR DESCRIPTION
Fixes:

Package avahi-utils is missing dependencies for the following libraries:
libavahi-client.so.3
libavahi-common.so.3
libdbus-1.so.3
libgdbm.so.4

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>