### PR TITLE
dnscrypt-proxy: Add custom resolver config support

### DIFF
--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
 PKG_VERSION:=1.9.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy

--- a/net/dnscrypt-proxy/files/dnscrypt-proxy.init
+++ b/net/dnscrypt-proxy/files/dnscrypt-proxy.init
@@ -16,7 +16,7 @@ dnscrypt_instance() {
 }
 
 create_config_file() {
-    local address port resolver resolvers_list ephemeral_keys client_key syslog syslog_prefix local_cache query_log_file block_ipv6
+    local address port resolver resolvers_list ephemeral_keys client_key syslog syslog_prefix local_cache query_log_file block_ipv6 provider_name provider_key resolver_address
     local config_path="$2"
 
     [ ! -d "$CONFIG_DIR" ] && mkdir -p "$CONFIG_DIR"
@@ -25,6 +25,9 @@ create_config_file() {
     config_get      address         $1 'address'        '127.0.0.1'
     config_get      port            $1 'port'           '5353'
     config_get      resolver        $1 'resolver'       ''
+    config_get      provider_name   $1 'providername'   ''
+    config_get      provider_key    $1 'providerkey'    ''
+    config_get      resolver_address $1 'resolveraddress'    ''
     config_get      resolvers_list  $1 'resolvers_list' '/usr/share/dnscrypt-proxy/dnscrypt-resolvers.csv'
     config_get      client_key      $1 'client_key'     ''
     config_get      syslog_prefix   $1 'syslog_prefix'  'dnscrypt-proxy'
@@ -36,6 +39,9 @@ create_config_file() {
 	
     append_param_not_empty  "ResolverName"  "$resolver"         $config_path
     append_param            "ResolversList" "$resolvers_list"   $config_path
+    append_param_not_empty  "ProviderName"  "$provider_name"    $config_path
+    append_param_not_empty  "ProviderKey"   "$provider_key"     $config_path
+    append_param_not_empty  "ResolverAddress" "$resolver_address" $config_path
     append_param            "User"          "$USER"             $config_path
     append_param            "LocalAddress"  "$address:$port"    $config_path
     append_param_not_empty  "ClientKey"     "$client_key"       $config_path


### PR DESCRIPTION
Maintainer: @damianorenfer
Compile tested: arm_cortex-a9_vfpv3, mvebu, Linksys WRT1900AC v2, LEDE 
Run tested: arm_cortex-a9_vfpv3, mvebu, Linksys WRT1900AC v2, LEDE - tests done: I installed my built ipk, and a configuration that includes `providername`, `providerkey` and `resolveraddress` values. I checked the generated configuration to verify that `ProviderName`, `ProviderKey`, and `ResolverAddress` were present & correct.

Description:
This pr modifies the dnscrypt-proxy plugin's `dnscrypt-proxy.init` script to allow specifying a custom dnscrypt resolver. Prior to this pr users of the dnscrypt-proxy plugin are only able to choose from
a dnscrypt resolver that is present in the packaged `ResolversList` CSV file.

To specify a custom resolver [three new configuration parameters are required](https://github.com/jedisct1/dnscryptproxy/blob/9eee47477031ad0ffef94160d7370d4dec6f2c3a/dnscrpt-proxy.conf#L28:L32): `ProviderName`, `ProviderKey` and `ResolverAddress`.

The `dnscrypt-proxy.init` script now maps `providername`, `providerkey`, and `resolveraddress` values (if present) from a `dnscrypt-proxy.config` file into the generated DNSCrypt configuration file.

`PKG_RELEASE` is increased from 1 to 2 to reflect the new functionality.

Note: I deliberately did not reformat the table indentation in the script to make the diff easier to review. If you would like, I can update the formatting as well.

Signed-off-by: Daniel McCarney <daniel@binaryparadox.net>
