### PR TITLE
vpnbypass: linted (shellshock) init script, modified README, removed unneeded dependencies

### DIFF
--- a/net/vpnbypass/Makefile
+++ b/net/vpnbypass/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vpnbypass
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=3
+PKG_RELEASE:=5
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 
@@ -14,8 +14,8 @@ include $(INCLUDE_DIR)/package.mk
 define Package/$(PKG_NAME)
 	SECTION:=net
 	CATEGORY:=Network
-	DEPENDS:=+ip-full +ipset +iptables +ubox +dnsmasq-full
-	CONFLICTS:=ip dnsmasq
+	DEPENDS:=+ipset +iptables
+	CONFLICTS:=openvpn-policy-routing
 	TITLE:=Simple VPN Bypass Service
 	PKGARCH:=all
 endef

--- a/net/vpnbypass/files/README.md
+++ b/net/vpnbypass/files/README.md
@@ -14,43 +14,67 @@ A simple PROCD-based vpnbypass service for OpenWrt/LEDE Project. Useful if your 
 ![screenshot](https://raw.githubusercontent.com/stangri/screenshots/master/vpnbypass/screenshot02.png "screenshot")
 
 ## Requirements
-This service requires following packages to be installed on your router: ```ip-full ipset iptables dnsmasq-full``` (```ip-full``` requires you uninstall ```ip``` first; ```dnsmasq-full``` requires you uninstall ```dnsmasq``` first). Run the following commands to satisfy the requirements:
+This service requires following packages to be installed on your router: ```ipset``` and ```iptables```. Additionally, if you want to use Domain Bypass feature, you need to install ```dnsmasq-full``` (```dnsmasq-full``` requires you uninstall ```dnsmasq``` first).
+
+To fully satisfy the requirements for both IP/Port VPN Bypass and Domain Bypass features connect to your router via ssh and run the following commands:
 ```sh
-opkg update
-opkg remove dnsmasq ip
-opkg install ip-full ipset iptables dnsmasq-full
+opkg update; opkg remove dnsmasq; opkg install ipset iptables dnsmasq-full
 ```
 
+To satisfy the requirements for just IP/Port VPN Bypass connect to your router via ssh and run the following commands:
+```sh
+opkg update; opkg install ipset iptables
+```
+
+#### Unmet dependencies
+If you are running a development (trunk/snapshot) build of OpenWrt/LEDE Project on your router and your build is outdated (meaning that packages of the same revision/commit hash are no longer available and when you try to satisfy the [requirements](#requirements) you get errors), please flash either current LEDE release image or current development/snapshot image.
+
 ## How to install
+<!---
+#### From Web UI/Luci
+Navigate to System->Software page on your router and then perform the following actions:
+1. Click "Update Lists"
+2. Wait for the update process to finish.
+3. In the "Download and install package:" field type ```vpnbypass luci-app-vpnbypass```
+4. Click "OK" to install ```vpnbypass``` and ```luci-app-vpnbypass```
+
+If you get an ```Unknown package 'vpnbypass'``` error, your router is not set up with the access to repository containing these packages and you need to add custom repository to your router first.
+
+#### From console/ssh
+--->
+Please make sure that the [requirements](#requirements) are satisfied and install ```vpnbypass``` and ```luci-app-vpnbypass``` from Web UI or connect to your router via ssh and run the following commands:
 ```sh
 opkg update
 opkg install vpnbypass luci-app-vpnbypass
 ```
+If these packages are not found in the official feed/repo for your version of OpenWrt/LEDE Project, you will need to [add a custom repo to your router](#add-custom-repo-to-your-router) first.
 
-Until the packages are in the official feed/repo for your version, you can install them with:
-- OpenWrt
+#### Add custom repo to your router
+If your router is not set up with the access to repository containing these packages you will need to add custom repository to your router by connecting to your router via ssh and running the following commands:
+
+###### OpenWrt CC 15.05.1
 ```sh
 opkg update; opkg install wget libopenssl
-wget --no-check-certificate https://github.com/stangri/Files/raw/master/vpnbypass.ipk -O /tmp/vpnbypass.ipk
-wget --no-check-certificate https://github.com/stangri/Files/raw/master/luci-app-vpnbypass.ipk -O /tmp/luci-app-vpnbypass.ipk
-opkg install /tmp/vpnbypass.ipk /tmp/luci-app-vpnbypass.ipk
+echo -e -n 'untrusted comment: public key 7ffc7517c4cc0c56\nRWR//HUXxMwMVnx7fESOKO7x8XoW4/dRidJPjt91hAAU2L59mYvHy0Fa\n' > /tmp/stangri-repo.pub && opkg-key add /tmp/stangri-repo.pub
+! grep -q 'stangri_repo' /etc/opkg/customfeeds.conf && echo 'src/gz stangri_repo https://raw.githubusercontent.com/stangri/openwrt-repo/master' >> /etc/opkg/customfeeds.conf
+opkg update
 ```
 
-- LEDE Project
+###### LEDE Project and OpenWrt DD trunk
 ```sh
 opkg update; opkg install uclient-fetch libustream-mbedtls
-wget --no-check-certificate https://github.com/stangri/Files/raw/master/vpnbypass.ipk -O /tmp/vpnbypass.ipk
-wget --no-check-certificate https://github.com/stangri/Files/raw/master/luci-app-vpnbypass.ipk -O /tmp/luci-app-vpnbypass.ipk
-opkg install /tmp/vpnbypass.ipk /tmp/luci-app-vpnbypass.ipk
+echo -e -n 'untrusted comment: public key 7ffc7517c4cc0c56\nRWR//HUXxMwMVnx7fESOKO7x8XoW4/dRidJPjt91hAAU2L59mYvHy0Fa\n' > /tmp/stangri-repo.pub && opkg-key add /tmp/stangri-repo.pub
+! grep -q 'stangri_repo' /etc/opkg/customfeeds.conf && echo 'src/gz stangri_repo https://raw.githubusercontent.com/stangri/openwrt-repo/master' >> /etc/opkg/customfeeds.conf
+opkg update
 ```
 
-### Default Settings
+## Default Settings
 Default configuration has service disabled (use Web UI to enable/start service or run ```uci set vpnbypass.config.enabled=1```) and routes Plex Media Server traffic (port 32400) outside of the VPN tunnel, routes LogmeIn Hamachi traffic (25.0.0.0/8) outside of the VPN tunnel and also routes internet traffic from local IPs 192.168.1.81-192.168.1.87 outside of the VPN tunnel. You can safely delete these example rules if they do not apply to you.
 
 ## Documentation / Discussion
 Please head to [LEDE Project Forum](https://forum.lede-project.org/t/vpn-bypass-split-tunneling-service-luci-ui/1106) for discussions of this service.
 
-### Bypass Domains Format/Syntax
+#### Bypass Domains Format/Syntax
 Domain lists should be in following format/syntax: ```/domain1.com/domain2.com/vpnbypass```. Please don't forget the leading ```/``` and trailing ```/vpnbypass```. There's no validation if you enter something incorrectly -- it just won't work. Please see [Notes/Known Issues](#notesknown-issues) if you want to edit this setting manually, without Web UI.
 
 ## What's New
@@ -85,10 +109,11 @@ Domain lists should be in following format/syntax: ```/domain1.com/domain2.com/v
 - Initial release.
 
 ## Notes/Known Issues
-Domains to be accessed outside of VPN tunnel are handled by dnsmasq and thus are not defined in ```/etc/config/vpnpass```, but rather in ```/etc/config/dhcp```. To add/delete/edit domains you can use VPN Bypass Web UI or you can edit ```/etc/config/dhcp``` manually or run following commands:
+1. Domains to be accessed outside of VPN tunnel are handled by dnsmasq and thus are not defined in ```/etc/config/vpnpass```, but rather in ```/etc/config/dhcp```. To add/delete/edit domains you can use VPN Bypass Web UI or you can edit ```/etc/config/dhcp``` manually or run following commands:
 ```sh
 uci add_list dhcp.@dnsmasq[-1].ipset='/github.com/plex.tv/google.com/vpnbypass'
 uci add_list dhcp.@dnsmasq[-1].ipset='/hulu.com/netflix.com/nhl.com/vpnbypass'
 uci commit dhcp
 /etc/init.d/dnsmasq restart
 ```
+This feature requires ```dnsmasq-full``` to work. See [Requirements](#requirements) paragraph for more details.

--- a/net/vpnbypass/files/vpnbypass.init
+++ b/net/vpnbypass/files/vpnbypass.init
@@ -1,15 +1,17 @@
 #!/bin/sh /etc/rc.common
 PKG_VERSION=
 
-START=94
-USE_PROCD=1
+export START=94
+export USE_PROCD=1
 
 readonly __ok__='\033[0;32m[\xe2\x9c\x93]\033[0m'
 readonly __fail__='\033[0;31m[\xe2\x9c\x97]\033[0m'
 readonly __pass__='\033[0;33m[-]\033[0m'
 readonly __error__='\033[0;31mERROR\033[0m'
 
-output() { local msg=$(echo -n "${1/$p_name /service }" | sed 's|\\033\[[0-9]\?;\?[0-9]\?[0-9]\?m||g'); [ -n "$2" ] && [ ! $(($verbosity & $2)) -gt 0 ] && return 0; [ -t 1 ] && echo -e -n "$1"; [ $(echo -e -n "$msg" | wc -l) -gt 0 ] && logger -t "${PKG_NAME:-service} [$$]" "$(echo -e -n ${logmsg}${msg})" && logmsg='' || logmsg=${logmsg}${msg}; }
+export verbosity=2 TID='200' IPSET='vpnbypass' FW_MARK='0x010000' FW_MASK='0xff0000' wan_if4 wan_gw
+
+output() { [[ $# -ne 1 ]] && { [[ ! $((verbosity & $1)) -gt 0 ]] && return 0 || shift; }; local msg; msg=$(echo -n "${1/$p_name /service }" | sed 's|\\033\[[0-9]\?;\?[0-9]\?[0-9]\?m||g'); [[ -t 1 ]] && echo -e -n "$1"; [[ $(echo -e -n "$msg" | wc -l) -gt 0 ]] && logger -t "${PKG_NAME:-service} [$$]" "$(echo -e -n ${logmsg}${msg})" && logmsg='' || logmsg=${logmsg}${msg}; }
 PKG_NAME="${PKG_NAME:-vpnbypass}"; p_name="${PKG_NAME} ${PKG_VERSION}"
 
 is_enabled() {
@@ -18,16 +20,16 @@ is_enabled() {
 	config_get_bool enabled 'config' 'enabled' 1
 	config_get verbosity    'config' 'verbosity' '2'
 	config_get TID          'config' 'table_number' '200'
-	config_get IPSET        'config' 'ipset'  'vpnbypass'
+	config_get IPSET        'config' 'ipset'   'vpnbypass'
 	config_get FW_MARK      'config' 'fw_mark' '0x010000'
 	config_get FW_MASK      'config' 'fw_mask' '0xff0000'
 	source /lib/functions/network.sh
-	[ "$enabled" -gt 0 ] || { output "$__error__: $p_name is not enabled.\n"; return 1; }
+	[[ $enabled -gt 0 ]] || { output "$__error__: $p_name is not enabled.\n"; return 1; }
 	source 	/lib/functions/network.sh
 	while : ; do
 		network_find_wan wan_if4
 		[ -n "$wan_if4" ] && network_get_gateway wan_gw $wan_if4
-		[ "$c" -ge 25 -o -n "$wan_gw" ] && break
+		[[ $c -ge 25 || -n "$wan_gw" ]] && break
 		output "$p_name waiting for wan gateway...\n"
 		sleep 2; network_flush_cache; let "c+=1";
 	done
@@ -35,32 +37,32 @@ is_enabled() {
 }
 
 ipt() {
-    local d=$(echo $* | sed s/-A/-D/g)
+    local d; d=$(echo "$*" | sed s/-A/-D/g);
     [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
-    d=$(echo $* | sed s/-I/-D/g)
+    d=$(echo "$*" | sed s/-I/-D/g)
     [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
-		d=$(echo $* | sed s/-N/-F/g)
+		d=$(echo "$*" | sed s/-N/-F/g)
     [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
-		d=$(echo $* | sed s/-N/-X/g)
+		d=$(echo "$*" | sed s/-N/-X/g)
     [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
-
-		iptables $* >/dev/null 2>&1
+		d="$*"
+		iptables $d >/dev/null 2>&1 || output "\n$__error__: iptables $d\n"
 }
 
 start_service() {
-	local ll
+	local ll lports rports routes ranges
   is_enabled || return 1
   config_get lports   'config' 'localport'
   config_get rports   'config' 'remoteport'
   config_get routes   'config' 'remotesubnet'
   config_get ranges   'config' 'localsubnet'
-  config_get domains  'config' 'domain'
 
 	procd_open_instance
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_close_instance
 
+	iptables -t mangle -D PREROUTING -m mark --mark 0x00/${FW_MASK} -g VPNBYPASS >/dev/null 2>&1
 	ipt -t mangle -N VPNBYPASS; ipt -t mangle -A PREROUTING -m mark --mark 0x00/${FW_MASK} -g VPNBYPASS;
 	ipt -t mangle -A VPNBYPASS -m set --match-set $IPSET dst -j MARK --set-mark ${FW_MARK}/${FW_MASK}
 	ip rule del fwmark "$FW_MARK" table "$TID" >/dev/null 2>&1; ipset -q flush "$IPSET"; ipset -q destroy "$IPSET";
@@ -81,8 +83,8 @@ stop_service() {
 
 	ip rule del fwmark "$FW_MARK" table "$TID" >/dev/null 2>&1; ipset -q flush "$IPSET"; ipset -q destroy "$IPSET";
 	ip route flush table "$TID"; ip route flush cache;
-	ipt -t mangle -D PREROUTING -m mark --mark 0x00/${FW_MASK} -g VPNBYPASS
-	ipt -t mangle -F VPNBYPASS; ipt -t mangle -X VPNBYPASS;
+	iptables -t mangle -D PREROUTING -m mark --mark 0x00/${FW_MASK} -g VPNBYPASS >/dev/null 2>&1
+	iptables -t mangle -F VPNBYPASS >/dev/null 2>&1; iptables -t mangle -X VPNBYPASS >/dev/null 2>&1;
 	output "$p_name stopped\n"
 }
 
@@ -90,7 +92,7 @@ reload_service(){
 	start_service
 }
 
-st_load_interfaces(){ local d; config_get d $1 ifname; [ "$1" == "$wan_if4" -o "$d" != "${d/tun}" -o "$d" != "${d/tap}" ] && ifaces=" ${1} ${ifaces}"; }
+st_load_interfaces(){ local d; config_get d $1 ifname; [[ "$1" == "$wan_if4" || "$d" != "${d/tun}" || "$d" != "${d/tap}" ]] && ifaces=" ${1} ${ifaces}"; }
 service_triggers() {
 		local ifaces n
 		procd_add_reload_trigger 'vpnbypass'


### PR DESCRIPTION
Maintainer: me
Compile tested: (ipq806x, Linksys EA8500, LEDE 17.01.0 release)
Run tested: (ipq806x, Linksys EA8500, LEDE snapshot r3777)

Description:
1. Updated README to include content relevant to installing this and luci packages from my own repo if the packages are not found in default repo.
2. Linted and modified init-script (cosmetic to follow recommended practices).
3. Removed unneeded dependencies on ip-full (the new iptables dependant code introduced a few versions ago works well with busybox'es ip) and dnsmasq-full (as not everyone required domains-based bypassing).
4. Introduced conflict with openvpn-policy-routing (as it nears completion).