### PR TITLE
openssh: Update to 7.5p1

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
-PKG_VERSION:=7.4p1
+PKG_VERSION:=7.5p1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/ \
 		https://anorien.csc.warwick.ac.uk/pub/OpenBSD/OpenSSH/portable/ \
 		https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/
-PKG_MD5SUM:=b2db2a83caf66a208bb78d6d287cdaa3
+PKG_MD5SUM:=652fdc7d8392f112bef11cacf7e69e23
 
 PKG_LICENSE:=BSD ISC
 PKG_LICENSE_FILES:=LICENCE

--- a/net/openssh/patches/130-implicit_memset_decl_fix.patch
+++ b/net/openssh/patches/130-implicit_memset_decl_fix.patch
@@ -1,6 +1,6 @@
 --- a/includes.h
 +++ b/includes.h
-@@ -60,6 +60,9 @@
+@@ -54,6 +54,9 @@
  /*
   *-*-nto-qnx needs these headers for strcasecmp and LASTLOG_FILE respectively
   */

--- a/net/openssh/patches/140-pam_uclibc_pthreads_fix.patch
+++ b/net/openssh/patches/140-pam_uclibc_pthreads_fix.patch
@@ -1,6 +1,6 @@
 --- a/auth-pam.c
 +++ b/auth-pam.c
-@@ -159,7 +159,7 @@ sshpam_sigchld_handler(int sig)
+@@ -168,7 +168,7 @@ sshpam_sigchld_handler(int sig)
  	}
  	if (WIFSIGNALED(sshpam_thread_status) &&
  	    WTERMSIG(sshpam_thread_status) == SIGTERM)
@@ -9,7 +9,7 @@
  	if (!WIFEXITED(sshpam_thread_status))
  		sigdie("PAM: authentication thread exited unexpectedly");
  	if (WEXITSTATUS(sshpam_thread_status) != 0)
-@@ -168,14 +168,14 @@ sshpam_sigchld_handler(int sig)
+@@ -177,14 +177,14 @@ sshpam_sigchld_handler(int sig)
  
  /* ARGSUSED */
  static void
@@ -26,7 +26,7 @@
      void *(*thread_start)(void *), void *arg)
  {
  	pid_t pid;
-@@ -201,7 +201,7 @@ pthread_create(sp_pthread_t *thread, con
+@@ -210,7 +210,7 @@ pthread_create(sp_pthread_t *thread, con
  }
  
  static int
@@ -35,7 +35,7 @@
  {
  	signal(SIGCHLD, sshpam_oldsig);
  	return (kill(thread, SIGTERM));
-@@ -209,7 +209,7 @@ pthread_cancel(sp_pthread_t thread)
+@@ -218,7 +218,7 @@ pthread_cancel(sp_pthread_t thread)
  
  /* ARGSUSED */
  static int
@@ -44,7 +44,7 @@
  {
  	int status;
  
-@@ -510,7 +510,7 @@ sshpam_thread(void *ctxtp)
+@@ -508,7 +508,7 @@ sshpam_thread(void *ctxtp)
  	/* XXX - can't do much about an error here */
  	ssh_msg_send(ctxt->pam_csock, sshpam_err, &buffer);
  	buffer_free(&buffer);

--- a/net/openssh/patches/200-dscp-qos.patch
+++ b/net/openssh/patches/200-dscp-qos.patch
@@ -1,6 +1,6 @@
 --- a/ssh_config
 +++ b/ssh_config
-@@ -46,3 +46,6 @@
+@@ -48,3 +48,6 @@
  #   VisualHostKey no
  #   ProxyCommand ssh -q -W %h:%p gateway.example.com
  #   RekeyLimit 1G 1h
@@ -9,7 +9,7 @@
 +#IPQoS AF21 AF11
 --- a/sshd_config
 +++ b/sshd_config
-@@ -122,6 +122,9 @@ UsePrivilegeSeparation sandbox		# Defaul
+@@ -107,6 +107,9 @@ UsePrivilegeSeparation sandbox		# Defaul
  # no default banner path
  #Banner none
  


### PR DESCRIPTION
Maintainer: @tripolar
Compile tested: x86_64 LEDE trunk, ar71xx LEDE trunk
Run tested: x86_64 LEDE trunk: Server starts and accepts connections, client successfully connects to other servers

Description: A simple update to the 7.5p1 upstream bugfix release.  I also refreshed the patches to eliminate offsets.
