### PR TITLE
net/mwan3: pass environment variables to mwan3-user

### DIFF
--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
@@ -4,9 +4,10 @@
 	. /lib/functions.sh
 
 	config_load mwan3
-	config_get enabled $INTERFACE enabled 0
+	config_get enabled "$INTERFACE" enabled 0
 	[ "${enabled}" = "1" ] || exit 0
-	/bin/sh /etc/mwan3.user $ACTION $INTERFACE $DEVICE
+	env -i ACTION="$ACTION" INTERFACE="$INTERFACE" DEVICE="$DEVICE" \
+		/bin/sh /etc/mwan3.user
 }
 
 exit 0

--- a/net/mwan3/files/etc/mwan3.user
+++ b/net/mwan3/files/etc/mwan3.user
@@ -5,7 +5,8 @@
 # be executed with each netifd hotplug interface event
 # on interfaces for which mwan3 is enabled.
 #
-# Parameter values from hotplug.d
-# $1 = ACTION (ifup/ifdown)
-# $2 = INTERFACE (wan/lan/...)
-# $3 = DEVICE (eth0/wwan0/...)
+# There are three main environment variables that are passed to this script.
+#
+# $ACTION	Either "ifup" or "ifdown"
+# $INTERFACE	Name of the interface which went up or down (e.g. "wan" or "wwan")
+# $DEVICE	Physical device name which interface went up or down (e.g. "eth0" or "wwan0")


### PR DESCRIPTION
Maintainer: me
Compile tested: lantiq, xrx200 LEDE
Run tested: lantiq, xrx200 LEDE

Description:
This will change the mwan3-user script to get called with environment variables instead of arguments. This change simplifies the user script conversion from luci-app-mwan3 which is called with environment variables.
