### PR TITLE
net/mwan3: add ubus interface check

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.2
+PKG_VERSION:=2.3
 PKG_RELEASE:=5
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -22,15 +22,24 @@ fi
 [ -x /usr/sbin/ip6tables ] || exit 7
 [ -x /usr/bin/logger ] || exit 8
 
-config_get family $INTERFACE family ipv4
-
-if [ "$family" == "ipv4" ]; then
-	network_get_gateway gateway $INTERFACE
-elif [ "$family" == "ipv6" ]; then
-	network_get_gateway6 gateway $INTERFACE
-fi
-
 if [ "$ACTION" == "ifup" ]; then
+	config_get family $INTERFACE family ipv4
+	if [ "$family" = "ipv4" ]; then
+		ubus call network.interface.${INTERFACE}_4 status &>/dev/null
+		if [ "$?" -eq "0" ]; then
+			network_get_gateway gateway ${INTERFACE}_4
+		else
+			network_get_gateway gateway $INTERFACE
+		fi
+	elif [ "$family" = "ipv6" ]; then
+		ubus call network.interface.${INTERFACE}_6 status &>/dev/null
+		if [ "$?" -eq "0" ]; then
+			network_get_gateway6 gateway ${INTERFACE}_6
+		else
+			network_get_gateway6 gateway ${INTERFACE}
+		fi
+	fi
+
 	[ -n "$gateway" ] || exit 9
 fi
 

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -130,7 +130,12 @@ mwan3_create_iface_iptables()
 
 	if [ "$family" == "ipv4" ]; then
 
-		network_get_ipaddr src_ip $1
+		ubus call network.interface.${1}_4 status &>/dev/null
+		if [ "$?" -eq "0" ]; then
+			network_get_ipaddr src_ip ${1}_4
+		else
+			network_get_ipaddr src_ip $1
+		fi
 
 		$IPS -! create mwan3_connected list:set
 
@@ -166,7 +171,12 @@ mwan3_create_iface_iptables()
 
 	if [ "$family" == "ipv6" ]; then
 
-		network_get_ipaddr6 src_ipv6 $1
+		ubus call network.interface.${1}_6 status &>/dev/null
+		if [ "$?" -eq "0" ]; then
+			network_get_ipaddr6 src_ipv6 ${1}_6
+		else
+			network_get_ipaddr6 src_ipv6 $1
+		fi
 
 		$IPS -! create mwan3_connected_v6 hash:net family inet6
 
@@ -238,8 +248,13 @@ mwan3_create_iface_route()
 	[ -n "$id" ] || return 0
 
 	if [ "$family" == "ipv4" ]; then
+		ubus call network.interface.${1}_4 status &>/dev/null
+		if [ "$?" -eq "0" ]; then
+			network_get_gateway route_args ${1}_4
+		else
+			network_get_gateway route_args $1
+		fi
 
-		network_get_gateway route_args $1
 		route_args="via $route_args dev $2"
 
 		$IP4 route flush table $id
@@ -248,7 +263,13 @@ mwan3_create_iface_route()
 
 	if [ "$family" == "ipv6" ]; then
 
-		network_get_gateway6 route_args $1
+		ubus call network.interface.${1}_6 status &>/dev/null
+		if [ "$?" -eq "0" ]; then
+			network_get_gateway6 route_args ${1}_6
+		else
+			network_get_gateway6 route_args $1
+		fi
+
 		route_args="via $route_args dev $2"
 
 		$IP6 route flush table $id


### PR DESCRIPTION
Maintainer: me
Compile tested: lantiq, xrx200, LEDE
Run tested: lantiq, xrx200, LEDE

Description:
On interfaces with interface proto "qmi|ncm" and option dhcp
enabled the interface will be changed to $iface_4 | $iface_6. The
interface mapping in mwan3 will not recognize this interface. To fix
this issue an `ubus call` will check if an upper interface exists.
This should fix issue #3110
