### PR TITLE
admin/netdata: Update to 1.6.0

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.5.0
+PKG_VERSION:=1.6.0
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Daniel Engberg <daniel.engberg.lists@pyret.net>
 PKG_LICENSE:=GPL-3.0
@@ -16,7 +16,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/firehol/netdata/releases/download/v$(PKG_VERSION)
-PKG_SOURCE_VERSION:=c5f8cecf83a7ed8880003b66614c71f7b2bff5b594f412262ec85143ca44adae
+PKG_HASH:=7839491f6e8b297cc8c28ca96845ff087f7961a12b92aa0eea1f66528da8bdaf
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Maintainer: myself
Compile tested: mvebu, Linksys WRT3200ACM, LEDE trunk
Run tested: mvebu, Linksys WRT3200ACM, LEDE trunk

Description:
Update netdata to 1.6.0

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>