### PR TITLE
syslog-ng: add dependency on OpenSSL's no-deprecated option

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -19,7 +19,7 @@ include $(INCLUDE_DIR)/nls.mk
 define Package/syslog-ng
   SECTION:=admin
   CATEGORY:=Administration
-  DEPENDS:=+libpcre +glib2 +libeventlog +libopenssl +libuuid +libcurl
+  DEPENDS:=+libpcre +glib2 +libeventlog +libopenssl +libuuid +libcurl +@OPENSSL_WITH_DEPRECATED
   TITLE:=A powerful syslog daemon
   URL:=http://www.balabit.com/network-security/syslog-ng/opensource-logging-system/
 endef


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, generic, LEDE head (894ee9510b4)
Run tested: same

Removed `CONFIG_OPENSSL_WITH_DEPRECATED` from `.config`, and built.  Booted image, and syslog-ng fails with:

```
Error relocating /usr/lib/libsyslog-ng-3.9.so.0: CRYPTO_set_id_callback: symbol not found
```

Added dependency to syslog-ng, ran `make defconfig`, confirmed that `CONFIG_OPENSSL_WITH_DEPRECATED` was back into `.config`.  Built image, booted it, and confirmed that syslog-ng can come up normally.

Description:

Uncovered dependency that syslog-ng has on how OpenSSL is built (same dependency that haproxy has, as it turns out).