### PR TITLE
ruby: bump to 2.4.1

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -10,7 +10,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=2.4.0
+PKG_VERSION:=2.4.1
 PKG_RELEASE:=1
 
 # First two numbes
@@ -18,7 +18,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_MD5SUM:=440bbbdc49d08d3650f340dccb35986d9399177ad69a204def56e5d3954600cf
+PKG_HASH:=ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE r3848-4d5b5c8 x86
Run tested: LEDE r3012-0d1b329 x86 ("running ruby_find_pkgsdeps" script and "gem list --remote")

This releases contains only bug and security fixes,
mostly backported from devel branch.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>