### PR TITLE
utils/xz: Adjust default settings

### DIFF
--- a/utils/xz/Makefile
+++ b/utils/xz/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xz
 PKG_VERSION:=5.2.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/lzmautils \
@@ -72,8 +72,7 @@ endef
 
 
 CONFIGURE_ARGS += \
-	--enable-small \
-	--enable-assume-ram=4 \
+	--enable-assume-ram=32 \
 	--disable-assembler \
 	--disable-werror \
 


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: mvebu, Linksys WRT3200ACM, LEDE trunk
Run tested: mvebu, Linksys WRT3200ACM, LEDE trunk

Description:
Adjust default settings to overall better performance for supported platforms.
This also makes processing data slightly faster, liblzma grows ~18K however.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>