### PR TITLE
libs/libarchive: Update to 3.3.1

### DIFF
--- a/libs/libarchive/Makefile
+++ b/libs/libarchive/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libarchive
-PKG_VERSION:=3.2.2
+PKG_VERSION:=3.3.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.libarchive.org/downloads
-PKG_MD5SUM:=691c194ee132d1f0f7a42541f091db811bc2e56f7107e9121be2bc8c04f1060f
+PKG_HASH:=29ca5bd1624ca5a007aa57e16080262ab4379dbf8797f5c52f7ea74a3b0424e7
 PKG_MAINTAINER:=Johannes Morgenroth <morgenroth@ibr.cs.tu-bs.de>
 PKG_LICENSE:=BSD-2-Clause
 


### PR DESCRIPTION
Maintainer: @morgenroth 
Compile tested: mvebu, Linksys WRT3200ACM, LEDE trunk
Run tested: mvebu, Linksys WRT3200ACM, LEDE trunk

Description:
Update libarchive to 3.3.1 and make use of PKG_HASH variable.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>