### PR TITLE
net-snmp: Add support for SNMPv3

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -40,7 +40,7 @@ define Package/libnetsnmp
 $(call Package/net-snmp/Default)
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libnl-tiny
+  DEPENDS:=+libnl-tiny +libopenssl
   TITLE:=Open source SNMP implementation (libraries)
 endef
 
@@ -138,10 +138,10 @@ SNMP_MIB_MODULES_INCLUDED = \
 	ucd-snmp/vmstat \
 	util_funcs \
 	utilities/execute \
+	disman/event \
 
 SNMP_MIB_MODULES_EXCLUDED = \
 	agent_mibs \
-	disman/event \
 	disman/schedule \
 	hardware \
 	host \
@@ -181,7 +181,6 @@ CONFIGURE_ARGS += \
 	--with-mib-modules="$(SNMP_MIB_MODULES_INCLUDED)" \
 	--with-out-transports="$(SNMP_TRANSPORTS_EXCLUDED)" \
 	--with-transports="$(SNMP_TRANSPORTS_INCLUDED)" \
-	--without-openssl \
 	--without-libwrap \
 	--without-rpm \
 	--without-zlib \

--- a/net/net-snmp/files/snmpd.conf
+++ b/net/net-snmp/files/snmpd.conf
@@ -69,6 +69,10 @@ config access private_access
 	option write all
 	option notify all
 
+config v3user type
+	option rouser rosnmpuser
+	option rwuser rwsnmpuser
+
 config system
 	option sysLocation	'office'
 	option sysContact	'bofh@example.com'

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -210,6 +210,15 @@ snmpd_engineid_add() {
 	[ -n "$engineidnic" ] && echo "engineIDNic $engineidnic" >> $CONFIGFILE
 }
 
+v3user_add()
+{
+       local cfg="$1"
+       config_get rouser "$cfg" rouser
+       [ -n "$rouser" ] && echo "rouser $rouser" >> $CONFIGFILE
+       config_get rwuser "$cfg" rwuser
+       [ -n "$rwuser" ] && echo "rwuser $rwuser" >> $CONFIGFILE
+}
+
 start_service() {
 	[ -f "$CONFIGFILE" ] && rm -f "$CONFIGFILE"
 

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -210,7 +210,7 @@ snmpd_engineid_add() {
 	[ -n "$engineidnic" ] && echo "engineIDNic $engineidnic" >> $CONFIGFILE
 }
 
-v3user_add()
+snmpd_v3user_add()
 {
        local cfg="$1"
        config_get rouser "$cfg" rouser
@@ -243,7 +243,8 @@ start_service() {
 	config_foreach snmpd_exec_add exec
 	config_foreach snmpd_disk_add disk
 	config_foreach snmpd_engineid_add engineid
-	
+	config_foreach snmpd_v3user_add v3user
+
 	procd_set_param command $PROG -Lf /dev/null -f
 	procd_set_param file $CONFIGFILE
 	procd_set_param respawn


### PR DESCRIPTION
Add openssl as dependency to support SNMPv3 and also create a default
ro/rw users as part of intial configuration. Additionally, include
disman/event MIB to enable linkUpDown notifications.

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>

Maintainer: @stintel 
Compile tested: BCM27xx, BCM2709, Raspberry Pi 2 model B, OpenWrt Chaos Calmer 15.05 
Run tested: BCM27xx, BCM2709, Raspberry Pi 2 model B, OpenWrt Chaos Calmer 15.05. Tested with Cacti tool
