### PR TITLE
dnscrypt-proxy: add optional plugins

### DIFF
--- a/net/dnscrypt-proxy/Config.in
+++ b/net/dnscrypt-proxy/Config.in
@@ -1,0 +1,8 @@
+menu "Configuration"
+	depends on PACKAGE_dnscrypt-proxy
+
+config DNSCRYPT_ENABLE_PLUGINS
+	bool "Enable plugin support (includes libldns and plugins, increases size by 125kB)"
+	default n
+
+endmenu

--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
 PKG_VERSION:=1.9.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy
@@ -21,6 +21,8 @@ PKG_INSTALL:=1
 
 PKG_MAINTAINER:=Damiano Renfer <damiano.renfer@gmail.com>
 PKG_LICENSE:=ISC
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_DNSCRYPT_ENABLE_PLUGINS
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -34,7 +36,8 @@ endef
 
 define Package/dnscrypt-proxy
   $(call Package/dnscrypt-proxy/Default)
-  DEPENDS:=+libsodium +dnscrypt-proxy-resolvers
+  DEPENDS:=+libsodium +dnscrypt-proxy-resolvers +DNSCRYPT_ENABLE_PLUGINS:libltdl \
+	+DNSCRYPT_ENABLE_PLUGINS:libldns
   TITLE:=A tool for securing communications between a client and a DNS resolver
 endef
 
@@ -68,11 +71,15 @@ define Package/hostip/description
   to IPv4 or IPv6 addresses.
 endef
 
+define Package/dnscrypt-proxy/config
+	source "$(SOURCE)/Config.in"
+endef
+
 define Build/Configure
 	$(call Build/Configure/Default, \
 	--prefix=/usr \
 	--disable-ssp \
-	--disable-plugins \
+	$(if $(CONFIG_DNSCRYPT_ENABLE_PLUGINS),,--disable-plugins) \
 	)
 endef
 
@@ -95,6 +102,12 @@ define Package/dnscrypt-proxy/install
 	$(INSTALL_BIN) ./files/dnscrypt-proxy.init $(1)/etc/init.d/dnscrypt-proxy
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/dnscrypt-proxy.config $(1)/etc/config/dnscrypt-proxy
+	$(if $(CONFIG_DNSCRYPT_ENABLE_PLUGINS), \
+		$(INSTALL_DIR) $(1)/usr/lib/dnscrypt-proxy; \
+		$(CP) $(PKG_INSTALL_DIR)/usr/lib/dnscrypt-proxy/libdcplugin_example_cache.so $(1)/usr/lib/dnscrypt-proxy/; \
+		$(CP) $(PKG_INSTALL_DIR)/usr/lib/dnscrypt-proxy/libdcplugin_example_ldns_aaaa_blocking.so $(1)/usr/lib/dnscrypt-proxy/; \
+		$(CP) $(PKG_INSTALL_DIR)/usr/lib/dnscrypt-proxy/libdcplugin_example_ldns_blocking.so $(1)/usr/lib/dnscrypt-proxy/; \
+		$(CP) $(PKG_INSTALL_DIR)/usr/lib/dnscrypt-proxy/libdcplugin_example_logging.so $(1)/usr/lib/dnscrypt-proxy/)
 endef
 
 define Package/dnscrypt-proxy-resolvers/install


### PR DESCRIPTION
The init script already supports four plugins: dns cache, dns/ip blocking,
ipv6 blocking and dns logging.  If enabled this option installs these four
plugins and also adds libldns as a dependency.  If enabled the total size
increase is around 125 kB.

Signed-off-by: Terry Stockert <stockert@inkblotadmirer.me>

Maintainer: Damiano Renfer <damiano.renfer@gmail.com>
Compile and run tested: mvebu, WRT1900ACS, LEDE r3848 with option disabled and enabled

Description:

This patch enables the options listed as "not currently supported" (see https://wiki.openwrt.org/inbox/dnscrypt)

There are eight total plugins that come with the dnscrypt-proxy baseline install; only those currently supported by the init script are installed.

Syntax for new options
        option local_cache '1'
        option block_ipv6 '1'
        option query_log_file /tmp/dns-queries.log
        list blacklist 'domains:/tmp/blacklist-domains.txt logfile:/tmp/blacklist-domains.log'
        list blacklist 'ips:/tmp/blacklist-ips.txt logfile:/tmp/blacklist-ips.log'

local_cache test:  start dnscrypt-proxy, nslookup <dns>; monitor traffic from wan interface to chosen resolver.  Initial lookup causes traffic, subsequent lookups result in a returned IP but no external traffic.

blacklist:  the logfile portion of config is optional but was used as verification that domains and ips are actually blocked (in addition to the failure of traffic).

block_ipv6: I'm not particularly sure how to prove this is working as intended.  However, dnscrypt-proxy will not start up if this option is enabled and the installed .so file is not present; with the plugins enabled this option is accepted.

Further info:  https://raw.githubusercontent.com/jedisct1/dnscrypt-proxy/master/dnscrypt-proxy.conf