### PR TITLE
net/mwan3: add failure and recovery interval

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.3
+PKG_VERSION:=2.4
 PKG_RELEASE:=5
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -383,6 +383,7 @@ mwan3_delete_iface_ipset_entries()
 mwan3_track()
 {
 	local track_ip track_ips reliability count timeout interval down up size
+	local failure_interval recovery_interval
 
 	mwan3_list_track_ips()
 	{
@@ -400,11 +401,13 @@ mwan3_track()
 		config_get count $1 count 1
 		config_get timeout $1 timeout 4
 		config_get interval $1 interval 10
+		config_get failure_interval $1 failure_interval $interval
+		config_get recovery_interval $1 recovery_interval $interval
 		config_get down $1 down 5
 		config_get up $1 up 5
 		config_get size $1 size 56
 
-		[ -x /usr/sbin/mwan3track ] && /usr/sbin/mwan3track $1 $2 $reliability $count $timeout $interval $down $up $size $track_ips &
+		[ -x /usr/sbin/mwan3track ] && /usr/sbin/mwan3track $1 $2 $reliability $count $timeout $interval $down $up $size $failure_interval $recovery_interval $track_ips &
 	fi
 }
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -z "$10" ] && echo "Error: should not be started manually" && exit 0
+[ -z "$12" ] && echo "Error: should not be started manually" && exit 0
 
 if [ -e /var/run/mwan3track-$1.pid ] ; then
 	kill $(cat /var/run/mwan3track-$1.pid) &> /dev/null
@@ -10,11 +10,14 @@ fi
 echo "$$" > /var/run/mwan3track-$1.pid
 
 score=$(($7+$8))
-track_ips=$(echo $* | cut -d ' ' -f 10-99)
+track_ips=$(echo $* | cut -d ' ' -f 12-99)
 host_up_count=0
 lost=0
+sleep_time=0
 
 while true; do
+
+	sleep_time=$6
 
 	for track_ip in $track_ips; do
 		ping -I $2 -c $4 -W $5 -s $9 -q $track_ip &> /dev/null
@@ -28,7 +31,12 @@ while true; do
 	if [ $host_up_count -lt $3 ]; then
 		let score--
 
-		if [ $score -lt $8 ]; then score=0 ; fi
+		if [ $score -lt $8 ]; then
+			score=0
+		else
+			sleep_time=$10
+		fi
+
 		if [ $score -eq $8 ]; then
 
 			logger -t mwan3track -p notice "Interface $1 ($2) is offline"
@@ -48,7 +56,12 @@ while true; do
 		let score++
 		lost=0
 
-		if [ $score -gt $8 ]; then score=$(($7+$8)); fi
+		if [ $score -gt $8 ]; then
+			score=$(($7+$8))
+		elif [ $score -le $8 ]; then
+			sleep_time=$11
+		fi
+
 		if [ $score -eq $8 ]; then
 
 			logger -t mwan3track -p notice "Interface $1 ($2) is online"
@@ -59,7 +72,7 @@ while true; do
 	fi
 
 	host_up_count=0
-	sleep $6
+	sleep $sleep_time
 done
 
 exit 1


### PR DESCRIPTION
Maintainer: me
Compile tested: --
Run tested: lantiq, xrx200, LEDE

Description:
If mwan3track detects a failure the interval check will change to
"failure_interval" value until this interface is declared "offline".
After interface gets "offline" normal "interval" value is used again.
If interface ping is successful again "recovery_interval" value is used until
interface is declared "online" again.

Using the different intervals will accelerate the wan line detections on
failure and recovery.