### PR TITLE
syslog-ng: fix openssl callbacks to not require backward compatibility

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include  $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.9.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 

--- a/admin/syslog-ng/patches/100-use-1.0.2k-threadids.patch
+++ b/admin/syslog-ng/patches/100-use-1.0.2k-threadids.patch
@@ -1,0 +1,35 @@
+--- a/lib/crypto.c	2016-12-21 07:57:44.000000000 -0700
++++ b/lib/crypto.c	2017-03-24 13:19:34.188259018 -0600
+@@ -51,11 +51,20 @@
+     }
+ }
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10000000
+ static unsigned long
+ ssl_thread_id(void)
+ {
+   return (unsigned long) get_thread_id();
+ }
++
++#else
++static void
++ssl_thread_id2(CRYPTO_THREADID *id)
++{
++  CRYPTO_THREADID_set_numeric(id, get_thread_id());
++}
++#endif
+ 
+ static void
+ crypto_init_threading(void)
+@@ -68,7 +76,11 @@
+     {
+       g_static_mutex_init(&ssl_locks[i]);
+     }
++#if OPENSSL_VERSION_NUMBER < 0x10000000
+   CRYPTO_set_id_callback(ssl_thread_id);
++#else
++  CRYPTO_THREADID_set_callback(ssl_thread_id2);
++#endif
+   CRYPTO_set_locking_callback(ssl_locking_callback);
+ }
+ 


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, generic, LEDE head (13006712eab)
Run tested: same

Build openssl _without_ `+@OPENSSL_WITH_DEPRECATED`, rebuild, image, and run syslog-ng.  It does not bail with:

```
Error relocating /usr/lib/libsyslog-ng-3.9.so.0: CRYPTO_set_id_callback: symbol not found
```

Description:

See also:

https://github.com/balabit/syslog-ng/issues/1396
https://github.com/balabit/syslog-ng/pull/1397
