### PR TITLE
miredo: Initial import of the package

### DIFF
--- a/ipv6/miredo/Makefile
+++ b/ipv6/miredo/Makefile
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2017 Petr Pudlak
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+# Developer notes:
+#   - Make sure you have gawk, othwerise you get weird syntax errors about "("
+#     and ")" when compiling.
+#   - Install ccache, otherwise you'll get configure error:
+#     "C compiler cannot create executables"
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=miredo
+PKG_VERSION:=1.2.6
+PKG_RELEASE:=1
+
+PKG_SOURCE:=miredo-1.2.6.tar.xz
+PKG_SOURCE_URL:=https://www.remlab.net/files/miredo/
+PKG_HASH:=fa26d2f4a405415833669e2e2e22677b225d8f83600844645d5683535ea43149
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Petr Pudlak <petr.mvd@gmail.com>
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+CONFIGURE_ARGS+=--with-pic --without-libiconv-prefix --without-libintl-prefix --without-Judy --enable-shared
+TARGET_CFLAGS+=-std=gnu99
+
+define Package/miredo
+	SECTION:=net
+	CATEGORY:=Network
+	TITLE:=Teredo IPv6 tunneling utility
+	URL:=https://www.remlab.net/miredo/
+	DEPENDS:=+libpthread +librt +ip +kmod-ipv6 +kmod-tun
+endef
+
+define Package/miredo/description
+ Miredo is an open-source Teredo IPv6 tunneling software, for Linux and the BSD
+ operating systems. It includes functional implementations of all components of
+ the Teredo specification (client, relay and server). It is meant to provide
+ IPv6 connectivity even from behind NAT devices.
+endef
+
+define Package/miredo/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/miredo $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/miredo-checkconf $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/lib/miredo
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/miredo/miredo-privproc $(1)/usr/lib/miredo
+	$(INSTALL_DIR) $(1)/etc/miredo
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/miredo/miredo.conf $(1)/etc/miredo
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/etc/miredo/client-hook $(1)/etc/miredo
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/miredo.init $(1)/etc/init.d/miredo
+endef
+
+$(eval $(call BuildPackage,miredo))

--- a/ipv6/miredo/files/miredo.init
+++ b/ipv6/miredo/files/miredo.init
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=20
+
+PROG=/usr/sbin/miredo
+CONFFILE=/etc/miredo/miredo.conf
+
+start_service() {
+  procd_open_instance
+  procd_set_param command $PROG -f -c $CONFFILE
+  procd_set_param respawn
+  procd_set_param file $CONFFILE
+  procd_set_param stdout 1 # forward stdout of the command to logd
+  procd_set_param stderr 1 # same for stderr
+  procd_close_instance
+}

--- a/ipv6/miredo/patches/100-cross-compile.patch
+++ b/ipv6/miredo/patches/100-cross-compile.patch
@@ -1,0 +1,40 @@
+--- a/configure
++++ b/configure
+@@ -11758,22 +11758,22 @@
+ 	if test "x$enable_binreloc" = "xauto"; then
+ 		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for /proc/self/maps" >&5
+ $as_echo_n "checking for /proc/self/maps... " >&6; }
+-if ${ac_cv_file__proc_self_maps+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  test "$cross_compiling" = yes &&
+-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+-if test -r "/proc/self/maps"; then
+-  ac_cv_file__proc_self_maps=yes
+-else
++#if ${ac_cv_file__proc_self_maps+:} false; then :
++#  $as_echo_n "(cached) " >&6
++#else
++#  test "$cross_compiling" = yes &&
++#  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
++#if test -r "/proc/self/maps"; then
++#  ac_cv_file__proc_self_maps=yes
++#else
+   ac_cv_file__proc_self_maps=no
+-fi
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_file__proc_self_maps" >&5
+-$as_echo "$ac_cv_file__proc_self_maps" >&6; }
+-if test "x$ac_cv_file__proc_self_maps" = xyes; then :
+-
+-fi
++#fi
++#fi
++#{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_file__proc_self_maps" >&5
++#$as_echo "$ac_cv_file__proc_self_maps" >&6; }
++#if test "x$ac_cv_file__proc_self_maps" = xyes; then :
++#
++#fi
+ 
+ 		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether everything is installed to the same prefix" >&5
+ $as_echo_n "checking whether everything is installed to the same prefix... " >&6; }

--- a/ipv6/miredo/patches/101-client-hook.patch
+++ b/ipv6/miredo/patches/101-client-hook.patch
@@ -1,0 +1,12 @@
+--- a/misc/client-hook.iproute
++++ b/misc/client-hook.iproute
+@@ -5,7 +5,7 @@
+ # Distributed under the terms of the GNU General Public License version 2.
+ 
+ # Linux iproute2 path:
+-IP="/sbin/ip"
++IP="/usr/sbin/ip"
+ 
+ # Linux default route default metric is 1024
+ # (we put 1029 so that Teredo is used as a last resort):
+


### PR DESCRIPTION
Maintainer: me
Compile tested: OpenWrt-SDK-15.05.1-brcm47xx-mips74k_gcc-4.8-linaro_uClibc-0.9.33.2.Linux-x86_64
Run tested: ASUS RT-N66U (brcm47xx-mips74k) running Chaos Calmer (15.05.1, r48532); works and provides IPv6 connectivity behind NAT as expected out of the box.

Description:
Miredo is an open-source Teredo IPv6 tunneling software, for Linux and the BSD operating systems. It includes functional implementations of all components of the Teredo specification (client, relay and server). It is meant to provide IPv6 connectivity even from behind NAT devices.
