### PR TITLE
net-snmp: add inbound firewall rule support

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.7.3
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/files/snmpd.conf
+++ b/net/net-snmp/files/snmpd.conf
@@ -87,3 +87,6 @@ config engineid
 #	option engineid 'LEDE'
 	option engineidtype '3'
 	option engineidnic 'eth0'
+
+config snmpd general
+#	list network 'wan'

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -210,6 +210,28 @@ snmpd_engineid_add() {
 	[ -n "$engineidnic" ] && echo "engineIDNic $engineidnic" >> $CONFIGFILE
 }
 
+snmpd_setup_fw_rules() {
+	local net="$1"
+	local zone
+
+	zone=$(fw3 -q network "$net" 2>/dev/null)
+
+	local handled_zone
+	for handled_zone in $HANDLED_SNMP_ZONES; do
+		[ "$handled_zone" = "$zone" ] && return
+	done
+
+	json_add_object ""
+	json_add_string type rule
+	json_add_string src "$zone"
+	json_add_string proto udp
+	json_add_string dest_port 161
+	json_add_string target ACCEPT
+	json_close_object
+
+	HANDLED_SNMP_ZONES="$HANDLED_SNMP_ZONES $zone"
+}
+
 start_service() {
 	[ -f "$CONFIGFILE" ] && rm -f "$CONFIGFILE"
 
@@ -242,6 +264,14 @@ start_service() {
 	for iface in $(ls /sys/class/net 2>/dev/null); do
 		procd_append_param netdev "$iface"
 	done
+
+	procd_open_data
+
+	json_add_array firewall
+	config_list_foreach general network snmpd_setup_fw_rules
+	json_close_array
+
+	procd_close_data
 
 	procd_close_instance
 }


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: brcm63xx, LEDE trunk
Run tested: brcm63xx, LEDE trunk

Description:
Add UCI section general which holds the uci parameter network defining
on which wan interface(s) the snmp agent is reachable for inbound snmp
requests.
For the different zones to which the different (wan) interfaces belong
firewall procd input rules are created making the snmp agent reachable
on udp port 161.

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>
