### PR TITLE
[RFC] net/mwan3: add ubus interface for mwan3track

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.4
+PKG_VERSION:=2.5
 PKG_RELEASE:=5
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. /usr/share/libubox/jshn.sh
+
+MWAN3_STATUS_DIR="/var/run/mwan3track"
+MWAN3_PID_FILE="/var/run/mwan3track"
+
+get_mwan3_status() {
+	local iface="${1}"
+	local iface_select="${2}"
+	local running="0"
+	local pid=""
+	local status=""
+
+	if [ "${iface}" = "${iface_select}" ] || [ "${iface_select}" = "" ]; then
+		if [ -f "${MWAN3_PID_FILE}-${iface}.pid" ]; then
+			pid="$(cat "${MWAN3_PID_FILE}-${iface}.pid")"
+			status="$(ps | grep mwan3track | awk '{print $1}' | grep "${pid}")"
+			if [ "${status}" != "" ]; then
+				running="1"
+			fi
+		fi
+
+		json_add_object "${iface}"
+		json_add_string "score" "$(cat "$MWAN3_STATUS_DIR/${iface}/SCORE")"
+		json_add_string "lost" "$(cat "$MWAN3_STATUS_DIR/${iface}/LOST")"
+		json_add_string "turn" "$(cat "$MWAN3_STATUS_DIR/${iface}/TURN")"
+		json_add_string "status" "$(cat "$MWAN3_STATUS_DIR/${iface}/STATUS")"
+		json_add_boolean "running" "${running}"
+		json_add_array "track_ip"
+		for file in $MWAN3_STATUS_DIR/${iface}/*; do
+			track="${file#*/TRACK_}"
+			if [ "${track}" != "${file}" ]; then
+				json_add_object
+				json_add_string ip "${track}"
+				json_add_string status "$(cat "${file}")"
+				json_close_object
+			fi
+		done
+		json_close_array
+		json_close_object
+	fi
+}
+
+case "$1" in
+	list)
+		json_init
+		json_add_object "status"
+		json_add_string "section" "x"
+		json_add_string "interface" "x"
+		json_close_object
+		json_dump
+		;;
+	call)
+		case "$2" in
+		status)
+			local section iface
+			read input;
+			json_load "$input"
+			json_get_var section section
+			json_get_var iface interface
+
+			config_load mwan3
+			json_init
+			case "$section" in
+				interfaces)
+					json_add_object interfaces
+					config_foreach get_mwan3_status interface "${iface}"
+					json_close_object
+					;;
+				*)
+					json_add_object interfaces
+					config_foreach get_mwan3_status interface
+					json_close_object
+					;;
+			esac
+			json_dump
+			;;
+		esac
+		;;
+esac

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -45,6 +45,7 @@ ifdown()
 	if [ -e /var/run/mwan3track-$1.pid ] ; then
 		kill $(cat /var/run/mwan3track-$1.pid)
 		rm /var/run/mwan3track-$1.pid
+		rm -rf /var/run/mwan3track/$1 &> /dev/null
 	fi
 }
 
@@ -130,6 +131,7 @@ stop()
 
 	killall mwan3track &> /dev/null
 	rm /var/run/mwan3track-* &> /dev/null
+	rm -rf /var/run/mwan3track &> /dev/null
 
 	for IP in "$IP4" "$IP6"; do
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -8,13 +8,16 @@ if [ -e /var/run/mwan3track-$1.pid ] ; then
 fi
 
 echo "$$" > /var/run/mwan3track-$1.pid
+mkdir -p /var/run/mwan3track/$1
 
 score=$(($7+$8))
 track_ips=$(echo $* | cut -d ' ' -f 12-99)
 host_up_count=0
 lost=0
 sleep_time=0
+turn=0
 
+echo "online" > /var/run/mwan3track/$1/STATUS
 while true; do
 
 	sleep_time=$6
@@ -23,8 +26,10 @@ while true; do
 		ping -I $2 -c $4 -W $5 -s $9 -q $track_ip &> /dev/null
 		if [ $? -eq 0 ]; then
 			let host_up_count++
+			echo "up" > /var/run/mwan3track/$1/TRACK_${track_ip}
 		else
 			let lost++
+			echo "down" > /var/run/mwan3track/$1/TRACK_${track_ip}
 		fi
 	done
 
@@ -39,6 +44,7 @@ while true; do
 
 		if [ $score -eq $8 ]; then
 
+			echo "offline" > /var/run/mwan3track/$1/STATUS
 			logger -t mwan3track -p notice "Interface $1 ($2) is offline"
 			env -i ACTION=ifdown INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
 			score=0
@@ -64,12 +70,18 @@ while true; do
 
 		if [ $score -eq $8 ]; then
 
+			echo "online" > /var/run/mwan3track/$1/STATUS
 			logger -t mwan3track -p notice "Interface $1 ($2) is online"
 			env -i ACTION=ifup INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
 			rm /var/run/mwan3track-$1.pid
 			exit 0
 		fi
 	fi
+
+	let turn++
+	echo "${lost}" > /var/run/mwan3track/$1/LOST
+	echo "${score}" > /var/run/mwan3track/$1/SCORE
+	echo "${turn}" > /var/run/mwan3track/$1/TURN
 
 	host_up_count=0
 	sleep $sleep_time


### PR DESCRIPTION
Maintainer: me
Compile tested: lantiq, xrx200, LEDE
Run tested: lantiq, xrx200, LEDE

Description:
Add ubus interface to mwan3track to get some important tracking data. In the future the other datas
ike policies, rules and connected. should also be made available through the ubus interface.