### PR TITLE
libs/libgd: Update to 2.2.4

### DIFF
--- a/libs/libgd/Makefile
+++ b/libs/libgd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgd
-PKG_VERSION:=2.1.1
+PKG_VERSION:=2.2.4
 PKG_RELEASE:=1
 
-PKG_SOURCE:=gd-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/libgd/libgd/archive
-PKG_MD5SUM:=e91a1a99903e460e7ba00a794e72cc1e
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/gd-$(PKG_VERSION)/
+PKG_HASH:=137f13a7eb93ce72e32ccd7cebdab6874f8cf7ddf31d3a455a68e016ecd9e4e6
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=MIT
 
@@ -21,7 +21,6 @@ PKG_FIXUP:=autoreconf
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_BUILD_DIR:=$(BUILD_DIR)/libgd-gd-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -64,7 +63,7 @@ define Build/InstallDev
 		$(1)/usr/bin/gdlib-config
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/entities.h $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/gd{,_io,cache,fontg,fontl,fontmb,fonts,fontt,fx}.h \
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/gd{,_color_map,_errors,_io,cache,fontg,fontl,fontmb,fonts,fontt,fx,pp}.h \
 		$(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgd.{a,la,so*} $(1)/usr/lib/

--- a/libs/libgd/patches/101-gdlib-config.patch
+++ b/libs/libgd/patches/101-gdlib-config.patch
@@ -1,6 +1,6 @@
 --- a/config/gdlib-config.in
 +++ b/config/gdlib-config.in
-@@ -71,7 +71,7 @@ while test $# -gt 0; do
+@@ -74,7 +74,7 @@ while test $# -gt 0; do
  	echo @LDFLAGS@
  	;;
      --libs)
@@ -9,7 +9,7 @@
  	;;
      --cflags|--includes)
  	echo -I@includedir@
-@@ -84,7 +84,7 @@ while test $# -gt 0; do
+@@ -87,7 +87,7 @@ while test $# -gt 0; do
  	echo "includedir: $includedir"
  	echo "cflags:     -I@includedir@"
  	echo "ldflags:    @LDFLAGS@"

--- a/libs/libgd/patches/102-gdlib-pc-in.patch
+++ b/libs/libgd/patches/102-gdlib-pc-in.patch
@@ -1,0 +1,9 @@
+--- a/config/gdlib.pc.in
++++ b/config/gdlib.pc.in
+@@ -7,5 +7,5 @@ Name: gd
+ Description: GD graphics library
+ Version: @VERSION@
+ Cflags: -I${includedir}
+-Libs.private: @LIBS@ @LIBICONV@
++Libs.private: @LIBS@ 
+ Libs: -L${libdir} -lgd

--- a/libs/libgd/patches/200-uclibc-ceill.patch
+++ b/libs/libgd/patches/200-uclibc-ceill.patch
@@ -1,6 +1,6 @@
 --- a/src/gd_bmp.c
 +++ b/src/gd_bmp.c
-@@ -21,6 +21,7 @@
+@@ -28,6 +28,7 @@
  #include <math.h>
  #include <string.h>
  #include <stdlib.h>
@@ -8,7 +8,7 @@
  #include "gd.h"
  #include "gdhelpers.h"
  #include "bmp.h"
-@@ -42,6 +43,13 @@ static int bmp_read_rle(gdImagePtr im, g
+@@ -49,6 +50,13 @@ static int bmp_read_rle(gdImagePtr im, g
  
  #define BMP_DEBUG(s)
  


### PR DESCRIPTION
Maintainer: @jow-
Compile tested: octeon, EdgeRouter Lite, LEDE trunk + mvebu, Linksys WRT3200ACM, LEDE turnk
Run tested: mvebu, Linksys WRT3200ACM, LEDE trunk

Description:
Update libgd to 2.2.4
Fixes multiple CVEs
Refresh patches
Update list according to:
https://svnweb.freebsd.org/ports/head/graphics/gd/pkg-plist?revision=432648&view=markup
...except helpers as it's not generated.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>

