### PR TITLE
libwebsockets: fix typos referencing package name

### DIFF
--- a/libs/libwebsockets/Makefile
+++ b/libs/libwebsockets/Makefile
@@ -102,9 +102,9 @@ define Package/libwebsockets/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libwebsockets.so* $(1)/usr/lib/
 endef
 
-Package/libwebsockets-cyassl/install = $(Package/libwesockets/install)
+Package/libwebsockets-cyassl/install = $(Package/libwebsockets/install)
 Package/libwebsockets-openssl/install = $(Package/libwebsockets/install)
-Package/libwesockets-full/install = $(Package/libwebsockets/install)
+Package/libwebsockets-full/install = $(Package/libwebsockets/install)
 
 $(eval $(call BuildPackage,libwebsockets-openssl))
 $(eval $(call BuildPackage,libwebsockets-cyassl))


### PR DESCRIPTION
In commit f82287cf5c1b2acd (treewide: use name in define and eval lines)
two typos were committed as result of replacing PKG_NAME macro with
actual package name.

Undo those typos here to make the affected variants installable.

Signed-off-by: Denis Osvald <denis.osvald@sartura.hr>

Compile tested: mvebu