### PR TITLE
ulogd: use strncpy instead of memcpy

### DIFF
--- a/net/ulogd/Makefile
+++ b/net/ulogd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ulogd
 PKG_VERSION:=2.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=ftp://ftp.netfilter.org/pub/ulogd/ \

--- a/net/ulogd/patches/101-ulogd-use-strncpy-instead-of-memcpy.patch
+++ b/net/ulogd/patches/101-ulogd-use-strncpy-instead-of-memcpy.patch
@@ -1,0 +1,31 @@
+From e0c75c9d20b76ff3d496a776ce43341c752914c3 Mon Sep 17 00:00:00 2001
+From: Eric Leblond <eric@regit.org>
+Date: Tue, 21 Mar 2017 21:49:46 +0100
+Subject: [PATCH] ulogd: use strncpy instead of memcpy
+
+On some architecture, ulogd is not starting due to a
+crash in memcpy. This patch switches to strncpy to
+avoid the problem.
+
+Reported-by: Alexandru Ardelean <ardeleanalex@gmail.com>
+Signed-off-by: Eric Leblond <eric@regit.org>
+---
+ src/ulogd.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ulogd.c b/src/ulogd.c
+index 5b9a586..919a317 100644
+--- a/src/ulogd.c
++++ b/src/ulogd.c
+@@ -668,7 +668,7 @@ pluginstance_alloc_init(struct ulogd_plugin *pl, char *pi_id,
+ 	INIT_LLIST_HEAD(&pi->plist);
+ 	pi->plugin = pl;
+ 	pi->stack = stack;
+-	memcpy(pi->id, pi_id, sizeof(pi->id));
++	strncpy(pi->id, pi_id, ULOGD_MAX_KEYLEN);
+ 
+ 	ptr = (void *)pi + sizeof(*pi);
+ 
+-- 
+2.7.4
+


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: https://github.com/lede-project/source/commit/4a405ac8f956b725de037744d62497f93bba6080 LEDE 17.01 mpc85xx 
Run tested: https://github.com/lede-project/source/commit/4a405ac8f956b725de037744d62497f93bba6080 LEDE 17.01 mpc85xx 

Description:

This time solution applied from upstream:
https://git.netfilter.org/ulogd2/commit/?id=e0c75c9d20b76ff3d496a776ce43341c752914c3

Fixes https://github.com/openwrt/packages/issues/4090

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>