### PR TITLE
libs/libpng: Update to 1.6.29

### DIFF
--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpng
-PKG_VERSION:=1.2.57
+PKG_VERSION:=1.6.29
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/libpng
-PKG_MD5SUM:=307052e5e8af97b82b17b64fb1b3677a
+PKG_HASH:=4245b684e8fe829ebb76186327bb37ce5a639938b219882b53d64bd3cfc5f239
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 PKG_LICENSE:=Libpng GPL-2.0+ BSD-3-Clause
@@ -42,26 +42,26 @@ CONFIGURE_ARGS += \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/libpng{,12}-config $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/libpng{,16}-config $(1)/usr/bin/
 	$(SED) \
 		's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' \
-		$(1)/usr/bin/libpng{,12}-config
+		$(1)/usr/bin/libpng{,16}-config
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/png{,conf}.h $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/libpng12 $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libpng16 $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng{,12}.{a,la,so*} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng16.{a,la,so*} $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpng{,12}.pc $(1)/usr/lib/pkgconfig/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpng{,16}.pc $(1)/usr/lib/pkgconfig/
 	$(INSTALL_DIR) $(2)/bin
-	for f in libpng{,12}-config; do \
+	for f in libpng{,16}-config; do \
 		$(LN) ../../usr/bin/$$$$f $(2)/bin/ ; \
 	done
 endef
 
 define Package/libpng/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng{,12}.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng16.so.* $(1)/usr/lib/
 endef
 
 $(eval $(call HostBuild))

--- a/libs/libpng/patches/101-old-libtool.patch
+++ b/libs/libpng/patches/101-old-libtool.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index a978473..302ac4d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -70,7 +70,7 @@ AC_PROG_MAKE_SET
+ dnl libtool/libtoolize; version 2.4.2 is the tested version. This or any
+ dnl compatible later version may be used
+ LT_INIT([win32-dll])
+-LT_PREREQ([2.4.2])
++LT_PREREQ([2.4])
+ 
+ # Some awks crash when confronted with pnglibconf.dfa, do a test run now
+ # to make sure this doesn't happen


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: mvebu, Linksys WRT3200ACM, LEDE trunk
Run tested: mvebu, Linksys WRT3200ACM, LEDE trunk

Description:
Update libpng to 1.6.29
Add patch to allow older versions of libtool

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>