### PR TITLE
net/atftp: update source URL and checksum

### DIFF
--- a/net/atftp/Makefile
+++ b/net/atftp/Makefile
@@ -13,8 +13,8 @@ PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
 PKG_LICENSE:=GPL-2.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://freefr.dl.sourceforge.net/project/atftp/
-PKG_MD5SUM:=367bf401965fbed04585b1229c2191a8
+PKG_SOURCE_URL:=@SF/$(PKG_NAME)
+PKG_HASH:=ae4c6f09cadb8d2150c3ce32d88f19036a54e8211f22d723e97864bb5e18f92d
 
 PKG_BUILD_DEPENDS:=libpcre libreadline
 


### PR DESCRIPTION
Maintainer: daniel@dd-wrt.com
Compile tested: kirkwood
Run tested: kirkwood-dockstar

Description:
Update package source to use '@SF' (SourceForge) instead of URL
Replace md5sum by new hash
