### PR TITLE
mariadb: add MariaDB 5.5.58

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -1,0 +1,275 @@
+#
+# Copyright (C) 2017 Lucian Cristian
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mariadb
+PKG_VERSION:=5.5.58
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=\
+	http://ftp.hosteurope.de/mirror/archive.mariadb.org/$(PKG_NAME)-$(PKG_VERSION)/source/ \
+	https://mirror.netcologne.de/$(PKG_NAME)/$(PKG_NAME)-$(PKG_VERSION)/source/ \
+	https://mirror.lstn.net/$(PKG_NAME)/$(PKG_NAME)-$(PKG_VERSION)/source/ \
+	http://lon1.mirrors.digitalocean.com/$(PKG_NAME)/$(PKG_NAME)-$(PKG_VERSION)/source/ \
+	http://ftp.kaist.ac.kr/$(PKG_NAME)/$(PKG_NAME)-$(PKG_VERSION)/source/ \
+	http://ftp.utexas.edu/$(PKG_NAME)/$(PKG_NAME)-$(PKG_VERSION)/source/
+PKG_HASH:=26fdf8784a51e5d6f7624c0f4528433a6188065dd1bf92ef69e27db6b0a41002
+PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
+PKG_LICENSE:=GPL-2.0
+PKG_BUILD_DEPENDS:=mariadb/host libncurses libreadline
+HOST_BUILD_DEPENDS += mariadb/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+PKG_FIXUP:=libtool
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+include $(INCLUDE_DIR)/host-build.mk
+
+define Package/libmariadb
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+libstdcpp +zlib +libpthread +libncurses +libreadline
+  TITLE:=MariaDB client library
+  URL:=http://mariadb.org/
+  PROVIDES:=libmysqlclient libmysqlclient-r mariadb
+  CONFLICTS:=libmysqlclient libmysqlclient-r
+endef
+
+define Package/mariadb/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=mariadb
+  TITLE:=MariaDB
+  URL:=http://mariadb.org/
+  SUBMENU:=database
+endef
+
+define Package/mariadb
+  $(call Package/mariadb/Default)
+  DEPENDS:=+libmariadb
+  MENU:=1
+endef
+
+define Package/mariadb/description
+ One of the most popular database servers. Made by the original developers of MySQL.
+endef
+
+define Package/mariadb-client
+  $(call Package/mariadb/Default)
+  TITLE+= client applications
+  DEPENDS+=+libmariadb
+endef
+
+define Package/mariadb-client-extra
+  $(call Package/mariadb/Default)
+  DEPENDS+=+mariadb-client
+  TITLE+= additional client applications
+endef
+
+define Package/mariadb-server/config
+	menu "Select additional options"
+	depends on PACKAGE_mariadb-server
+	config MARIADB_LITE
+		bool "Mariadb server lite, 5M vs 20M compressed"
+		default y
+		help
+			Don't add plugins and other storage engines
+	endmenu
+endef
+
+define Package/mariadb-server
+  $(call Package/mariadb/Default)
+  TITLE+= server
+ifdef CONFIG_MARIADB_LITE
+  DEPENDS+=+libmariadb +resolveip
+else
+  DEPENDS+=+libmariadb +libpam +libpcre +resolveip
+endif
+  PROVIDES:=mysql-server
+  CONFLICTS:=mysql-server
+endef
+
+
+CMAKE_OPTIONS += -DSTACK_DIRECTION=-1
+CMAKE_OPTIONS += -DWITHOUT_TOKUDB=1
+CMAKE_OPTIONS += -DWITHOUT_HANDLERSOCKET=1
+CMAKE_OPTIONS += -DWITHOUT_DAEMON_EXAMPLE=1
+ifdef CONFIG_MARIADB_LITE
+CMAKE_OPTIONS += -DWITH_ARIA_STORAGE_ENGINE=OFF
+CMAKE_OPTIONS += -DWITHOUT_ARCHIVE=1
+CMAKE_OPTIONS += -DWITHOUT_BLACKHOLE=1
+CMAKE_OPTIONS += -DWITHOUT_EXAMPLE=1
+CMAKE_OPTIONS += -DWITHOUT_FEDERATED=1
+CMAKE_OPTIONS += -DWITHOUT_FEDERATEDX=1
+CMAKE_OPTIONS += -DWITHOUT_PERFSCHEMA=1
+CMAKE_OPTIONS += -DWITHOUT_SPHINX=1
+CMAKE_OPTIONS += -DWITHOUT_XTRADB=1
+CMAKE_OPTIONS += -DWITH_JEMALLOC=no
+CMAKE_OPTIONS += -DWITH_EXTRA_CHARSETS=none
+CMAKE_OPTIONS += -DWITH_QUERY_CACHE_INFO=OFF
+CMAKE_OPTIONS += -DWITH_SAFEMALLOC=OFF
+CMAKE_OPTIONS += -DWITHOUT_AUDIT_NULL=1
+CMAKE_OPTIONS += -DWITHOUT_AUTH_PAM=1
+CMAKE_OPTIONS += -DWITHOUT_QA_AUTH_CLIENT=1
+CMAKE_OPTIONS += -DWITHOUT_QA_AUTH_INTERFACE=1
+CMAKE_OPTIONS += -DWITHOUT_QA_AUTH_SERVER=1
+CMAKE_OPTIONS += -DWITHOUT_AUTH_TEST_PLUGIN=1
+CMAKE_OPTIONS += -DWITHOUT_FEEDBACK=1
+CMAKE_OPTIONS += -DWITHOUT_FTEXAMPLE=1
+CMAKE_OPTIONS += -DWITHOUT_QUERY_CACHE_INFO=1
+CMAKE_OPTIONS += -DWITHOUT_SEMISYNC_MASTER=1
+CMAKE_OPTIONS += -DWITHOUT_SEMISYNC_SLAVE=1
+CMAKE_OPTIONS += -DWITHOUT_SERVER_AUDIT=1
+endif
+CMAKE_OPTIONS += -DIMPORT_EXECUTABLES=$(HOST_BUILD_DIR)/host/import_executables.cmake
+
+define Host/Patch/Default
+endef
+
+NUM_CORES ?= $(shell grep -c "vendor_id" /proc/cpuinfo)
+
+define Host/Compile
+	( cd $(HOST_BUILD_DIR)/ ; mkdir host/ ; cd host ; cmake -DWITHOUT_TOKUDB=1 .. ; $(MAKE) -j$(NUM_CORES) IMPORT_EXECUTABLES )
+endef
+
+define Host/Install
+endef
+
+define Build/Compile
+	+$(MAKE) $(PKG_JOBS) -C "$(PKG_BUILD_DIR)" \
+		SUBDIRS="include" \
+		DESTDIR="$(PKG_INSTALL_DIR)"
+	$(MAKE) -C "$(PKG_BUILD_DIR)" \
+		SUBDIRS="include" \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		install
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(2)/bin $(1)/usr/bin $(1)/usr/include $(1)/usr/lib $(1)/usr/lib/mysql $(1)/usr/share/aclocal
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mysql_config $(1)/usr/bin/
+	ln -sf $(STAGING_DIR)/usr/bin/mysql_config $(2)/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/mysql $(1)/usr/include/
+	# NOTE: needed for MySQL-Python
+	$(CP) $(PKG_BUILD_DIR)/include/mysqld_error.h $(1)/usr/include/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.a $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.a $(1)/usr/lib/mysql
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/aclocal/mysql.m4 $(1)/usr/share/aclocal/
+endef
+
+define Package/libmariadb/install
+	$(INSTALL_DIR) $(1)/usr/lib $(1)/usr/lib/mysql
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmysqlclient*.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmysqlclient*.so $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/mysql_clear_password.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/dialog.so $(1)/usr/lib/mysql/
+endef
+
+define Package/mariadb-client/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysql $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqlcheck $(1)/usr/bin/
+endef
+
+define Package/mariadb-client-extra/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/innochecksum $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqlaccess $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqladmin $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqlbug $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqldump $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqldumpslow $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysql_find_rows $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysql_fix_extensions $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqlimport $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqlshow $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqlslap $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysql_waitpid $(1)/usr/bin/
+endef
+
+define Package/mariadb-server/install
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/share/mysql $(1)/usr/share/mysql/english $(1)/usr/lib/mysql $(1)/etc/mysql $(1)/etc/mysql/conf.d $(1)/etc/init.d
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqld $(1)/usr/bin/mysqld
+	$(INSTALL_BIN) files/mariadb.init $(1)/etc/init.d/mariadb
+	# these two need perl and should go into their own package which depends on perl + dbi + ?
+	$(INSTALL_CONF) files/my.cnf $(1)/etc/mysql/
+	$(INSTALL_CONF) files/conf.d/* $(1)/etc/mysql/conf.d/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/english/errmsg.sys $(1)/usr/share/mysql/english
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/fill_help_tables.sql $(1)/usr/share/mysql/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/mysql_performance_tables.sql $(1)/usr/share/mysql/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/mysql_system_tables.sql $(1)/usr/share/mysql/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/mysql_system_tables_data.sql $(1)/usr/share/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/auth_socket.so $(1)/usr/lib/mysql/
+ifndef CONFIG_MARIADB_LITE
+	# $(INSTALL_BIN) files/mysqlreport $(1)/usr/bin/
+	# $(INSTALL_BIN) files/innotop $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/* $(1)/usr/share/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/auth_pam.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/adt_null.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/feedback.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/ha_archive.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/ha_blackhole.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/ha_federated.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/ha_federatedx.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/ha_sphinx.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/mypluglib.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/qa_auth_client.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/qa_auth_interface.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/qa_auth_server.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/query_cache_info.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/server_audit.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/semisync_master.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/semisync_slave.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/sphinx.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/msql2mysql $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/myisam_ftdump $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/myisamlog $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/myisampack $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/aria_pack $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/aria_read_log $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/aria_ftdump $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/aria_chk $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/aria_dump_log $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysql_convert_table_format $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysql_tzinfo_to_sql $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqlbinlog $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysql_zap $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqlhotcopy $(1)/usr/bin/
+endif
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/ha_innodb.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/plugin/sql_errlog.so $(1)/usr/lib/mysql/
+	$(CP) $(PKG_INSTALL_DIR)/usr/scripts/mysql_install_db $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/my_print_defaults $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/myisamchk $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysql_plugin $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysql_secure_installation $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysql_setpermission $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysql_upgrade $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqld_multi $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqld_safe $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/mysqld_safe_helper $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/perror $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/replace $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/resolve_stack_dump $(1)/usr/bin/
+endef
+
+define Package/mariadb/conffiles
+/etc/mysql/my.cnf
+/etc/mysql/conf.d
+endef
+
+$(eval $(call HostBuild))
+
+$(eval $(call BuildPackage,libmariadb))
+$(eval $(call BuildPackage,mariadb))
+$(eval $(call BuildPackage,mariadb-client))
+$(eval $(call BuildPackage,mariadb-client-extra))
+$(eval $(call BuildPackage,mariadb-server))

--- a/utils/mariadb/files/conf.d/utf-8.cnf
+++ b/utils/mariadb/files/conf.d/utf-8.cnf
@@ -1,0 +1,14 @@
+[client]
+# Default is Latin1, if you need UTF-8 set this (also in server section)
+default-character-set = utf8 
+
+[mysqld]
+#
+# * Character sets
+# 
+# Default is Latin1, if you need UTF-8 set all this (also in client section)
+#
+character-set-server  = utf8 
+collation-server      = utf8_general_ci 
+character_set_server   = utf8 
+collation_server       = utf8_general_ci 

--- a/utils/mariadb/files/mariadb.init
+++ b/utils/mariadb/files/mariadb.init
@@ -1,0 +1,49 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2010-2011 OpenWrt.org
+
+START=95
+STOP=10
+
+SERVICE_DAEMONIZE=1
+SERVICE_WRITE_PID=1
+SERVICE_STOP_TIME=9
+
+error() {
+    echo "${initscript}:" "$@" 1>&2
+}
+
+init_command_msg="run mysql_install_db --force --basedir=/usr to initialize the system tables"
+
+missing_dir=0
+
+missing_dir_error() {
+    error "Error: $1 '$2' in /etc/mysql/my.cnf doesn't exist."
+    error "       Make sure that a file system is mounted at this location or you have created the directory"
+    error "       and then $init_command_msg."
+}
+
+check_dir_in_my_cnf() {
+    local dir=$(sed -n -e "s/^[[:space:]]*$1[[:space:]]*=[[:space:]\"']*\([^[:space:]\"']*\)[[:space:]\"']*/\1/p" /etc/mysql/my.cnf)
+    if [ ! -d "$dir" ]; then
+	missing_dir_error $1 $dir
+	missing_dir=1
+    fi
+}
+
+start() {
+    check_dir_in_my_cnf datadir
+    check_dir_in_my_cnf tmpdir
+    if [ $missing_dir == 1 ] ; then
+	return 1
+    fi
+    local datadir=$(sed -n -e "s/^[[:space:]]*datadir[[:space:]]*=[[:space:]\"']*\([^[:space:]\"']*\)[[:space:]\"']*/\1/p" /etc/mysql/my.cnf)
+    if [ ! -f "$datadir/mysql/tables_priv.MYD" ]; then
+	error "Error: I didn't detect a privileges table, you might need to $init_command_msg"
+	return 1
+    fi
+    service_start /usr/bin/mysqld
+}
+
+stop() {
+    service_stop /usr/bin/mysqld
+}

--- a/utils/mariadb/files/my.cnf
+++ b/utils/mariadb/files/my.cnf
@@ -1,0 +1,195 @@
+[client-server]
+port		= 3306
+socket		= /tmp/mysql.sock
+
+# https://mariadb.com/kb/en/mariadb/server-system-variables/
+
+[mysqld]
+user		= root
+pid-file	= /var/run/mariadb.pid
+basedir		= /usr
+lc_messages_dir	= /usr/share/mysql
+lc_messages	= en_US
+
+############ Don't put this on the NAND #############
+# Figure out where you are going to put the databases
+# And run mysql_install_db --force
+datadir		= /data/mariadb/
+
+######### This should also not go on the NAND #######
+tmpdir		= /data/tmp/
+
+skip-external-locking
+
+# this must be overridden, if replication is to be used
+bind-address		= 127.0.0.1
+
+#
+# * Fine Tuning
+#
+max_connections	= 100
+connect_timeout	= 5
+wait_timeout = 600
+key_buffer_size = 384M
+max_allowed_packet = 16M
+table_open_cache = 512
+sort_buffer_size = 2M
+read_buffer_size = 2M
+read_rnd_buffer_size = 8M
+myisam_sort_buffer_size = 64M
+thread_cache_size = 8
+# Try number of CPU's*2 for thread_concurrency
+thread_concurrency = 8
+
+#
+# * Query Cache Configuration
+#
+# Cache only tiny result sets, so we can fit more in the query cache.
+query_cache_limit = 128K
+query_cache_size = 32M
+# for more write intensive setups, set to DEMAND or OFF
+#query_cache_type		= DEMAND
+
+#
+# * InnoDB
+#
+# Currently only InnoDB storage engine is supported by wsrep
+default-storage-engine=innodb
+# to avoid issues with 'bulk mode inserts' using autoinc
+innodb_autoinc_lock_mode=2
+#innodb_data_home_dir = /usr/data
+innodb_data_file_path = ibdata1:2000M;ibdata2:10M:autoextend
+# path to redo log files (can be put on separate file system)
+#innodb_log_group_home_dir = /usr/data
+# You can set .._buffer_pool_size up to 50 - 80 %
+# of RAM but beware of setting memory usage too high
+#innodb_buffer_pool_size = 384M
+#innodb_additional_mem_pool_size = 20M
+# Set .._log_file_size to 25 % of buffer pool size
+#innodb_log_file_size = 100M
+#innodb_log_buffer_size = 8M
+#innodb_flush_log_at_trx_commit = 1
+#innodb_lock_wait_timeout = 50
+
+#
+# * Logging
+#
+# Be aware that this log type is a performance killer and that
+# you can enable the log at runtime!
+#general_log_file = /var/log/mariadb.log
+#general_log = 1
+#
+# Error logging goes to syslog due to /etc/mariadb/conf.d/mysqld_safe_syslog.cnf.
+#
+# we do want to know about network errors and such
+log_warnings = 2
+#
+# Enable the slow query log to see queries with especially long duration
+slow_query_log=1
+slow_query_log_file = /var/log/mariadb-slow.log
+long_query_time = 10
+log_slow_rate_limit = 20
+log_slow_verbosity = query_plan
+log-queries-not-using-indexes
+log_slow_admin_statements
+
+#
+# * Replication
+#
+# The following can be used as easy to replay backup logs or for replication.
+# Replication Master Server (default)
+#
+#
+# Replication Master
+#
+# required unique id between 1 and 2^32 - 1 defaults to 1 if
+# master-host is not set but will not function as a master if omitted
+server-id = 1
+# binary logging is required for replication
+log_bin = /data/mariadb/mysql-bin.log
+expire_logs_days	= 10
+max_binlog_size         = 100M
+#binlog_do_db		= include_database_name
+#binlog_ignore_db	= include_database_name
+#
+#
+# Replication Slave (comment out master section to use this)
+#
+# To configure this host as a replication slave, you can choose between
+# two methods :
+#
+# 1) Use the CHANGE MASTER TO command (fully described in our manual) -
+#    the syntax is:
+#
+#    CHANGE MASTER TO MASTER_HOST=<host>, MASTER_PORT=<port>,
+#    MASTER_USER=<user>, MASTER_PASSWORD=<password> ;
+#
+#    where you replace <host>, <user>, <password> by quoted strings and
+#    <port> by the master's port number (3306 by default).
+#
+#    Example:
+#
+#    CHANGE MASTER TO MASTER_HOST='125.564.12.1', MASTER_PORT=3306,
+#    MASTER_USER='joe', MASTER_PASSWORD='secret';
+#
+# OR
+#
+# 2) Set the variables below. However, in case you choose this method, then
+#    start replication for the first time (even unsuccessfully, for example
+#    if you mistyped the password in master-password and the slave fails to
+#    connect), the slave will create a master.info file, and any later
+#    change in this file to the variables' values below will be ignored and
+#    overridden by the content of the master.info file, unless you shutdown
+#    the slave server, delete master.info and restart the slaver server.
+#    For that reason, you may want to leave the lines below untouched
+#    (commented) and instead use CHANGE MASTER TO (see above)
+#
+# required unique id between 2 and 2^32 - 1
+# (and different from the master)
+# defaults to 2 if master-host is set
+# but will not function as a slave if omitted
+#server-id       = 2
+#
+# The replication master for this slave - required
+#master-host     =   <hostname>
+#
+# The username the slave will use for authentication when connecting
+# to the master - required
+#master-user     =   <username>
+#
+# The password the slave will authenticate with when connecting to
+# the master - required
+#master-password =   <password>
+#
+# The port the master is listening on.
+# optional - defaults to 3306
+#master-port     =  <port>
+#
+# binary logging - not required for slaves, but recommended
+#log-bin=mysql-bin
+#
+# binary logging format - mixed recommended 
+#binlog_format=mixed
+
+
+[mysqldump]
+quick
+max_allowed_packet	= 16M
+
+[mysql]
+#no-auto-rehash	# faster start of mysql but no tab completition
+
+[myisamchk]
+key_buffer_size = 256M
+sort_buffer_size = 256M
+read_buffer = 2M
+write_buffer = 2M
+
+[mysqlhotcopy]
+interactive-timeout
+
+#
+# * IMPORTANT: Additional settings that can override those from this file!
+#   The files must end with '.cnf', otherwise they'll be ignored.
+#
+!includedir /etc/mysql/conf.d/

--- a/utils/mariadb/patches/001-add_export_executables.patch
+++ b/utils/mariadb/patches/001-add_export_executables.patch
@@ -1,0 +1,100 @@
+From cdc38712e4d359348346758e47e1ebc7d1743f82 Mon Sep 17 00:00:00 2001
+From: James Le Cuirot <chewi@aura-online.co.uk>
+Date: Sun, 27 Apr 2014 00:02:19 +0100
+Subject: [PATCH] MySQL Bug #61340: Use CMake EXPORT feature to aid
+ cross-compiling.
+
+This technique is documented at:
+http://www.cmake.org/Wiki/CMake_Cross_Compiling#Using_executables_in_the_build_created_during_the_build
+
+Basic steps are:
+# mkdir native cross
+# cd native
+# cmake /path/to/maria
+# make IMPORT_EXECUTABLES
+# cd ../cross
+# cmake -DCMAKE_TOOLCHAIN_FILE=foo -DIMPORT_EXECUTABLES=/path/to/native/import_executables.cmake /path/to/maria
+# make
+---
+ CMakeLists.txt      | 10 ++++++++++
+ dbug/CMakeLists.txt | 16 +++++++++-------
+ sql/CMakeLists.txt  |  4 +++-
+ 3 files changed, 22 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f8ebddc..20067ad 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -364,6 +364,11 @@ ELSEIF(MYSQL_MAINTAINER_MODE MATCHES "AUTO")
+   SET(CMAKE_CXX_FLAGS_DEBUG "${MY_MAINTAINER_CXX_WARNINGS} ${CMAKE_CXX_FLAGS_DEBUG}")
+ ENDIF()
+ 
++IF(CMAKE_CROSSCOMPILING)
++  SET(IMPORT_EXECUTABLES "IMPORT_EXECUTABLES_NOT_SET" CACHE FILEPATH "Path to import_executables.cmake from a native build")
++  INCLUDE(${IMPORT_EXECUTABLES})
++ENDIF()
++
+ IF(WITH_UNIT_TESTS)
+  ENABLE_TESTING()
+  ADD_SUBDIRECTORY(unittest/mytap)
+@@ -428,6 +433,11 @@ IF(WIN32)
+ ENDIF()
+ ADD_SUBDIRECTORY(packaging/solaris)
+ 
++IF(NOT CMAKE_CROSSCOMPILING)
++  ADD_CUSTOM_TARGET(IMPORT_EXECUTABLES DEPENDS comp_err comp_sql factorial gen_lex_hash)
++  EXPORT(TARGETS comp_err comp_sql factorial gen_lex_hash FILE ${CMAKE_BINARY_DIR}/import_executables.cmake)
++ENDIF()
++
+ CONFIGURE_FILE(config.h.cmake   ${CMAKE_BINARY_DIR}/include/my_config.h)
+ CONFIGURE_FILE(config.h.cmake   ${CMAKE_BINARY_DIR}/include/config.h)
+ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/include/mysql_version.h.in
+diff --git a/dbug/CMakeLists.txt b/dbug/CMakeLists.txt
+index fddf234..bc4288c 100644
+--- a/dbug/CMakeLists.txt
++++ b/dbug/CMakeLists.txt
+@@ -24,8 +24,10 @@ TARGET_LINK_LIBRARIES(dbug mysys)
+ ADD_EXECUTABLE(tests tests.c)
+ TARGET_LINK_LIBRARIES(tests dbug)
+ 
+-ADD_EXECUTABLE(factorial my_main.c factorial.c)
+-TARGET_LINK_LIBRARIES(factorial dbug)
++IF(NOT CMAKE_CROSSCOMPILING)
++  ADD_EXECUTABLE(factorial my_main.c factorial.c)
++  TARGET_LINK_LIBRARIES(factorial dbug)
++ENDIF()
+ 
+ IF(NOT WIN32 AND NOT CMAKE_GENERATOR MATCHES Xcode)
+   FIND_PROGRAM(GROFF groff)
+@@ -36,11 +38,11 @@ IF(NOT WIN32 AND NOT CMAKE_GENERATOR MATCHES Xcode)
+   SET(SOURCE_INC factorial.r main.r example1.r example2.r example3.r)
+   ADD_CUSTOM_COMMAND(OUTPUT ${OUTPUT_INC}
+                      DEPENDS factorial
+-                     COMMAND ./factorial 1 2 3 4 5 > output1.r
+-                     COMMAND ./factorial -\#t:o 2 3 > output2.r
+-                     COMMAND ./factorial -\#d:t:o 3 > output3.r
+-                     COMMAND ./factorial -\#d,result:o 4 > output4.r
+-                     COMMAND ./factorial -\#d:f,factorial:F:L:o 3 > output5.r)
++                     COMMAND factorial 1 2 3 4 5 > output1.r
++                     COMMAND factorial -\#t:o 2 3 > output2.r
++                     COMMAND factorial -\#d:t:o 3 > output3.r
++                     COMMAND factorial -\#d,result:o 4 > output4.r
++                     COMMAND factorial -\#d:f,factorial:F:L:o 3 > output5.r)
+   FOREACH(file ${SOURCE_INC})
+     STRING(REGEX REPLACE "\\.r" ".c" srcfile ${file})
+     ADD_CUSTOM_COMMAND(OUTPUT ${file} DEPENDS ${srcfile}
+diff --git a/sql/CMakeLists.txt b/sql/CMakeLists.txt
+index ad4b128..7d2b329 100644
+--- a/sql/CMakeLists.txt
++++ b/sql/CMakeLists.txt
+@@ -218,7 +218,9 @@ RUN_BISON(
+ )
+ 
+ # Gen_lex_hash
+-ADD_EXECUTABLE(gen_lex_hash gen_lex_hash.cc)
++IF(NOT CMAKE_CROSSCOMPILING)
++  ADD_EXECUTABLE(gen_lex_hash gen_lex_hash.cc)
++ENDIF()
+ 
+ ADD_CUSTOM_COMMAND(
+   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lex_hash.h

--- a/utils/mariadb/patches/002-disable_my_context_non_x86.patch
+++ b/utils/mariadb/patches/002-disable_my_context_non_x86.patch
@@ -1,0 +1,11 @@
+--- a/include/my_context.h   2017-09-09 12:03:19.159007527 +0300
++++ b/include/my_context.h   2017-09-09 12:04:48.101508363 +0300
+@@ -31,8 +31,6 @@
+ #define MY_CONTEXT_USE_X86_64_GCC_ASM
+ #elif defined(__GNUC__) && __GNUC__ >= 3 && defined(__i386__)
+ #define MY_CONTEXT_USE_I386_GCC_ASM
+-#elif defined(HAVE_UCONTEXT_H)
+-#define MY_CONTEXT_USE_UCONTEXT
+ #else
+ #define MY_CONTEXT_DISABLE
+ #endif


### PR DESCRIPTION
Light modified version from https://github.com/m-creations/openwrt/tree/master/feeds/packages/utils/mariadb 
Added lite option

Maintainer: me
Compile/Run tested: x86_64,sunxi,mips LEDE r4807-bd24d53
Compile test: mipsel

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com