### PR TITLE
pthsem: Add linux 4.x to supported platforms

### DIFF
--- a/libs/pthsem/patches/003-linux4x-fix.patch
+++ b/libs/pthsem/patches/003-linux4x-fix.patch
@@ -1,0 +1,13 @@
+Index: pthsem-2.0.8/acinclude.m4
+===================================================================
+--- pthsem-2.0.8.orig/acinclude.m4
++++ pthsem-2.0.8/acinclude.m4
+@@ -894,6 +894,8 @@ changequote(, )dnl
+             x2.[23456789]* ) ;;
+ changequote(, )dnl
+             x3.* ) ;;
++changequote(, )dnl
++            x4.* ) ;;
+ changequote([, ])
+             * ) braindead=yes ;;
+         esac


### PR DESCRIPTION
Fixes the following build failures:

pth_mctx.c: In function '__pth_mctx_set':
pth_mctx.c:480:2: error: #error "Unsupported Linux (g)libc version
and/or platform"
 #error "Unsupported Linux (g)libc version and/or platform"
  ^
Makefile:991: recipe for target 'pth_mctx.lo' failed

Signed-off-by: Florian Fainelli <f.fainelli@gmail.com>