### PR TITLE
hiredis: Fix __redis_strerror_r lvalue error

### DIFF
--- a/libs/hiredis/patches/001-lvalue_fix.patch
+++ b/libs/hiredis/patches/001-lvalue_fix.patch
@@ -1,0 +1,13 @@
+Index: hiredis-0.13.3/hiredis.h
+===================================================================
+--- hiredis-0.13.3.orig/hiredis.h
++++ hiredis-0.13.3/hiredis.h
+@@ -98,7 +98,7 @@
+          * then GNU strerror_r returned an internal static buffer and we       \
+          * need to copy the result into our private buffer. */                 \
+         if (err_str != (buf)) {                                                \
+-            buf[(len)] = '\0';                                                 \
++            (buf)[(len)] = '\0';                                               \
+             strncat((buf), err_str, ((len) - 1));                              \
+         }                                                                      \
+     } while (0)


### PR DESCRIPTION
Fixes the following build error:
hiredis.h:101:24: error: lvalue required as left operand of assignment
             buf[(len)] = '\0';

Signed-off-by: Florian Fainelli <f.fainelli@gmail.com>