### PR TITLE
net/stunnel: Update to 5.41

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.40
+PKG_VERSION:=5.41
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0+
@@ -17,9 +17,10 @@ PKG_LICENSE_FILES:=COPYING COPYRIGHT.GPL
 
 PKG_SOURCE_URL:= \
 	http://ftp.nluug.nl/pub/networking/stunnel/ \
-	http://www.usenix.org.uk/mirrors/stunnel/
+	http://www.usenix.org.uk/mirrors/stunnel/ \
+	https://www.stunnel.org/downloads/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=23acdb390326ffd507d90f8984ecc90e0d9993f6bd6eac1d0a642456565c45ff
+PKG_HASH:=f05c6321ee1f6ddebacc234ccf20825971941e831b5beea6d0ce0b8e1668148f
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
Maintainer: myself
Compile tested: mvebu, Linksys WRT3200ACM, LEDE trunk
Run tested: mvebu, Linksys WRT3200ACM, LEDE trunk

Description:
Update stunnel to 5.41
Add main site as last resort mirror

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>