### PR TITLE
unrar: Properly pass LDFLAGS

### DIFF
--- a/utils/unrar/Makefile
+++ b/utils/unrar/Makefile
@@ -58,6 +58,9 @@ define Package/libunrar/description
   archives
 endef
 
+MAKE_FLAGS += \
+	LDFLAGS="$(TARGET_LDFLAGS) -lpthread"
+
 ifeq ($(BUILD_VARIANT),lib)
 define Build/Compile
 	$(call Build/Compile/Default,lib)


### PR DESCRIPTION
External toolchains don't automatically have STAGING_DIR in their
default search path, so make sure we pass TARGET_LDFLAGS down. Since the
unrar makefile does not allow overriding, we also need to preserve the
original LDFLAGS which include lpthread.

Signed-off-by: Florian Fainelli <f.fainelli@gmail.com>