### PR TITLE
squeezelite: Specify all libraries to link against

### DIFF
--- a/sound/squeezelite/Makefile
+++ b/sound/squeezelite/Makefile
@@ -128,6 +128,7 @@ TARGET_LDFLAGS+= -lasound -lpthread -lm -lrt
 
 ifeq ($(BUILD_VARIANT),full)
     TARGET_CFLAGS+= -DLINKALL
+    TARGET_LDFLAGS+= -lvorbis -logg
 endif
 
 define Package/squeezelite/install


### PR DESCRIPTION
squeezelite needs to link against libvorbis and libogg, some external
toolchains may not be able to automatically pull these dependencies in,
resulting the such linking errors:

mipsel-linux-gnu-gcc main.o slimproto.o buffer.o stream.o utils.o
output.o output_alsa.o output_pa.o output_stdout.o output_pack.o
decode.o flac.o pcm.o mad.o vorbis.o faad.o
-L/home/florian/dev/openwrt/trunk/staging_dir/target-mipsel-unknown-linux-gnu_glibc/usr/lib
-L/home/florian/dev/openwrt/trunk/staging_dir/target-mipsel-unknown-linux-gnu_glibc/lib
-L/home/florian/dev/toolchains/stbgcc-4.8-1.5/usr/lib
-L/home/florian/dev/toolchains/stbgcc-4.8-1.5/lib -znow -zrelro -lasound
-lpthread -lm -lrt  -lasound -lpthread -lm -lrt -lFLAC -lmad
-lvorbisfile -lfaad -o squeezelite
/home/florian/dev/toolchains/stbgcc-4.8-1.5/bin/../lib/gcc/mipsel-linux-gnu/4.8.5/../../../../mipsel-linux-gnu/bin/ld:
warning: libvorbis.so.0, needed by
/home/florian/dev/openwrt/trunk/staging_dir/target-mipsel-unknown-linux-gnu_glibc/usr/lib/libvorbisfile.so,
not found (try using -rpath or -rpath-link)
/home/florian/dev/toolchains/stbgcc-4.8-1.5/bin/../lib/gcc/mipsel-linux-gnu/4.8.5/../../../../mipsel-linux-gnu/bin/ld:
warning: libogg.so.0, needed by
/home/florian/dev/openwrt/trunk/staging_dir/target-mipsel-unknown-linux-gnu_glibc/usr/lib/libvorbisfile.so,
not found (try using -rpath or -rpath-link)
/home/florian/dev/openwrt/trunk/staging_dir/target-mipsel-unknown-linux-gnu_glibc/usr/lib/libvorbisfile.so:
undefined reference to `ogg_stream_reset'
collect2: error: ld returned 1 exit status

Signed-off-by: Florian Fainelli <f.fainelli@gmail.com>