### PR TITLE
net/mwan3: add ubus interface

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.4.1
+PKG_VERSION:=2.5
 PKG_RELEASE:=5
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -64,6 +64,7 @@ case "$ACTION" in
 		mwan3_delete_iface_iptables $INTERFACE
 		mwan3_delete_iface_route $INTERFACE
 		mwan3_delete_iface_ipset_entries $INTERFACE
+		mwan3_track_signal $INTERFACE $DEVICE
 		mwan3_set_policies_iptables
 		mwan3_set_user_rules
 		mwan3_flush_conntrack $INTERFACE $DEVICE "ifdown"

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -399,6 +399,23 @@ mwan3_track()
 	fi
 }
 
+mwan3_track_signal()
+{
+	local pid status
+
+	if [ -f "/var/run/mwan3track-${1}.pid" ]; then
+		pid="$(cat "/var/run/mwan3track-${1}.pid")"
+		status="$(pgrep -f mwan3track | grep "${pid}")"
+		if [ "${status}" != "" ]; then
+			kill -USR1 "${pid}"
+		else
+			$LOG warn "Unable to send signal USR1 to mwan3track on interface $1 with pid ${pid}"
+		fi
+	else
+		$LOG warn "Unable to find \"/var/run/mwan3track-${1}.pid\" file for mwan3track on interface $1"
+	fi
+}
+
 mwan3_set_policy()
 {
 	local iface_count id iface family metric probability weight

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -1,0 +1,126 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. /usr/share/libubox/jshn.sh
+
+MWAN3_STATUS_DIR="/var/run/mwan3track"
+MWAN3_PID_FILE="/var/run/mwan3track"
+
+IPS="/usr/sbin/ipset"
+IPT4="/usr/sbin/iptables -t mangle -w"
+IPT6="/usr/sbin/ip6tables -t mangle -w"
+
+report_connected_v4() {
+	local address
+
+	if [ -n "$($IPT4 -S mwan3_connected 2> /dev/null)" ]; then
+		for address in $($IPS list mwan3_connected_v4 | tail -n +8); do
+			json_add_string "" "${address}"
+		done
+	fi
+}
+
+report_connected_v6() {
+	local address
+
+	if [ -n "$($IPT6 -S mwan3_connected 2> /dev/null)" ]; then
+		for address in $($IPS list mwan3_connected_v6 | tail -n +8); do
+			json_add_string "" "${address}"
+		done
+	fi
+}
+
+get_mwan3_status() {
+	local iface="${1}"
+	local iface_select="${2}"
+	local running="0"
+	local pid=""
+	local status=""
+
+	if [ "${iface}" = "${iface_select}" ] || [ "${iface_select}" = "" ]; then
+		if [ -f "${MWAN3_PID_FILE}-${iface}.pid" ]; then
+			pid="$(cat "${MWAN3_PID_FILE}-${iface}.pid")"
+			status="$(pgrep -f mwan3track | grep "${pid}")"
+			if [ "${status}" != "" ]; then
+				running="1"
+			fi
+		fi
+
+		json_add_object "${iface}"
+		json_add_string "score" "$(cat "$MWAN3_STATUS_DIR/${iface}/SCORE")"
+		json_add_string "lost" "$(cat "$MWAN3_STATUS_DIR/${iface}/LOST")"
+		json_add_string "turn" "$(cat "$MWAN3_STATUS_DIR/${iface}/TURN")"
+		json_add_string "status" "$(cat "$MWAN3_STATUS_DIR/${iface}/STATUS")"
+		json_add_boolean "running" "${running}"
+		json_add_array "track_ip"
+		for file in $MWAN3_STATUS_DIR/${iface}/*; do
+			track="${file#*/TRACK_}"
+			if [ "${track}" != "${file}" ]; then
+				json_add_object
+				json_add_string ip "${track}"
+				json_add_string status "$(cat "${file}")"
+				json_close_object
+			fi
+		done
+		json_close_array
+		json_close_object
+	fi
+}
+
+case "$1" in
+	list)
+		json_init
+		json_add_object "status"
+		json_add_string "section" "x"
+		json_add_string "interface" "x"
+		json_close_object
+		json_dump
+		;;
+	call)
+		case "$2" in
+		status)
+			local section iface
+			read input;
+			json_load "$input"
+			json_get_var section section
+			json_get_var iface interface
+
+			config_load mwan3
+			json_init
+			case "$section" in
+				interfaces)
+					json_add_object interfaces
+					config_foreach get_mwan3_status interface "${iface}"
+					json_close_object
+					;;
+				connected)
+					json_add_object connected
+					json_add_array ipv4
+					report_connected_v4
+					json_close_array
+					json_add_array ipv6
+					report_connected_v6
+					json_close_array
+					json_close_object
+					;;
+				*)
+					# interfaces
+					json_add_object interfaces
+					config_foreach get_mwan3_status interface
+					json_close_object
+					# connected
+					json_add_object connected
+					json_add_array ipv4
+					report_connected_v4
+					json_close_array
+					json_add_array ipv6
+					report_connected_v6
+					json_close_array
+					json_close_object
+					;;
+			esac
+			json_dump
+			;;
+		esac
+		;;
+esac

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -4,6 +4,9 @@
 
 LOG="/usr/bin/logger -t $(basename "$0")[$$] -p"
 INTERFACE=""
+DEVICE=""
+
+IFDOWN_EVENT=0
 
 clean_up() {
 	$LOG notice "Stopping mwan3track for interface \"${INTERFACE}\""
@@ -15,6 +18,11 @@ clean_up() {
 	exit 0
 }
 
+if_down() {
+	$LOG info "Detect ifdown event on interface ${INTERFACE} (${DEVICE})"
+	IFDOWN_EVENT=1
+}
+
 main() {
 	local reliability count timeout interval failure_interval
 	local recovery_interval down up size
@@ -22,9 +30,11 @@ main() {
 	[ -z "$3" ] && echo "Error: should not be started manually" && exit 0
 
 	INTERFACE=$1
+	DEVICE=$2
 	echo "$$" > /var/run/mwan3track-$1.pid
 	mkdir -p /var/run/mwan3track/$1
 	trap clean_up SIGINT SIGTERM
+	trap if_down SIGUSR1
 
 	config_load mwan3
 	config_get reliability $1 reliability 1
@@ -106,6 +116,12 @@ main() {
 
 		host_up_count=0
 		sleep $sleep_time
+
+		if [ "${IFDOWN_EVENT}" -eq 1 ]; then
+			score=0
+			echo "offline" > /var/run/mwan3track/$1/STATUS
+			IFDOWN_EVENT=0
+		fi
 	done
 }
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -8,6 +8,10 @@ INTERFACE=""
 clean_up() {
 	$LOG notice "Stopping mwan3track for interface \"${INTERFACE}\""
 	rm "/var/run/mwan3track-${INTERFACE}.pid" &> /dev/null
+	rm -rf "/var/run/mwan3track/${INTERFACE}" &> /dev/null
+	if [ -z "$(ls -A "/var/run/mwan3track")" ]; then
+		rm -rf "/var/run/mwan3track"
+	fi
 	exit 0
 }
 
@@ -19,6 +23,7 @@ main() {
 
 	INTERFACE=$1
 	echo "$$" > /var/run/mwan3track-$1.pid
+	mkdir -p /var/run/mwan3track/$1
 	trap clean_up SIGINT SIGTERM
 
 	config_load mwan3
@@ -37,7 +42,9 @@ main() {
 	local host_up_count=0
 	local lost=0
 	local sleep_time=0
+	local turn=0
 
+	echo "offline" > /var/run/mwan3track/$1/STATUS
 	while true; do
 
 		sleep_time=$interval
@@ -46,8 +53,10 @@ main() {
 			ping -I $2 -c $count -W $timeout -s $size -q $track_ip &> /dev/null
 			if [ $? -eq 0 ]; then
 				let host_up_count++
+				echo "up" > /var/run/mwan3track/$1/TRACK_${track_ip}
 			else
 				let lost++
+				echo "down" > /var/run/mwan3track/$1/TRACK_${track_ip}
 			fi
 		done
 
@@ -61,6 +70,7 @@ main() {
 			fi
 
 			if [ $score -eq $up ]; then
+				echo "offline" > /var/run/mwan3track/$1/STATUS
 				$LOG notice "Interface $1 ($2) is offline"
 				env -i ACTION=ifdown INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
 				score=0
@@ -74,6 +84,7 @@ main() {
 			lost=0
 
 			if [ $score -gt $up ]; then
+				echo "online" > /var/run/mwan3track/$1/STATUS
 				score=$(($down+$up))
 			elif [ $score -le $up ]; then
 				sleep_time=$recovery_interval
@@ -83,9 +94,15 @@ main() {
 				$LOG notice "Interface $1 ($2) is online"
 				env -i ACTION=ifup INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
 				rm /var/run/mwan3track-$1.pid
+				rm -rf "/var/run/mwan3track/${1}" &> /dev/null
 				exit 0
 			fi
 		fi
+
+		let turn++
+		echo "${lost}" > /var/run/mwan3track/$1/LOST
+		echo "${score}" > /var/run/mwan3track/$1/SCORE
+		echo "${turn}" > /var/run/mwan3track/$1/TURN
 
 		host_up_count=0
 		sleep $sleep_time

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -115,7 +115,8 @@ main() {
 		echo "${turn}" > /var/run/mwan3track/$1/TURN
 
 		host_up_count=0
-		sleep $sleep_time
+		sleep "${sleep_time}" &
+		wait
 
 		if [ "${IFDOWN_EVENT}" -eq 1 ]; then
 			score=0


### PR DESCRIPTION
Maintainer: me
Compile tested: lantiq, xrx200 LEDE
Run tested: lantiq, xrx200 LEDE

Description:
- Add ubus interface to get mwan3track status informations
- Send signal to mwan3track if interface is getting down. Prevent additional down event if mwan3track recognize that the interface is down (unplug ethernet cable)
