### PR TITLE
bcp38: iptables 1.6.1 compatibility

### DIFF
--- a/net/bcp38/Makefile
+++ b/net/bcp38/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcp38
 PKG_VERSION:=5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENCE:=GPL-3.0+
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/bcp38/files/run.sh
+++ b/net/bcp38/files/run.sh
@@ -72,9 +72,9 @@ setup_iptables()
 	iptables -N "$IPTABLES_CHAIN" 2>/dev/null
 	iptables -F "$IPTABLES_CHAIN" 2>/dev/null
 
-	iptables -I output_rule -m state --state NEW -j "$IPTABLES_CHAIN"
-	iptables -I input_rule -m state --state NEW -j "$IPTABLES_CHAIN"
-	iptables -I forwarding_rule -m state --state NEW -j "$IPTABLES_CHAIN"
+	iptables -I output_rule -m conntrack --ctstate NEW -j "$IPTABLES_CHAIN"
+	iptables -I input_rule -m conntrack --ctstate NEW -j "$IPTABLES_CHAIN"
+	iptables -I forwarding_rule -m conntrack --ctstate NEW -j "$IPTABLES_CHAIN"
 
 	# always accept DHCP traffic
 	iptables -A "$IPTABLES_CHAIN" -p udp --dport 67:68 --sport 67:68 -j RETURN
@@ -90,9 +90,9 @@ destroy_ipset()
 
 destroy_iptables()
 {
-	iptables -D output_rule -m state --state NEW -j "$IPTABLES_CHAIN" 2>/dev/null
-	iptables -D input_rule -m state --state NEW -j "$IPTABLES_CHAIN" 2>/dev/null
-	iptables -D forwarding_rule -m state --state NEW -j "$IPTABLES_CHAIN" 2>/dev/null
+	iptables -D output_rule -m conntrack --ctstate NEW -j "$IPTABLES_CHAIN" 2>/dev/null
+	iptables -D input_rule -m conntrack --ctstate NEW -j "$IPTABLES_CHAIN" 2>/dev/null
+	iptables -D forwarding_rule -m conntrack --ctstate NEW -j "$IPTABLES_CHAIN" 2>/dev/null
 	iptables -F "$IPTABLES_CHAIN" 2>/dev/null
 	iptables -X "$IPTABLES_CHAIN" 2>/dev/null
 }


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: ar71xx Archer C7 v2 LEDE trunk + proposed iptables 1.6.1 bump
Run tested: ar71xx Archer C7 v2 LEDE trunk + proposed iptables 1.6.1 bump

/etc/init.d/firewall reload no longer throws errors about unknown '-m state'.

Description:

-m state has been removed, now use -m conntrack --ctstate

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>

