### PR TITLE
ser2net: Fixes to show*port commands

### DIFF
--- a/net/ser2net/patches/001-controlport_overrun_fix.patch
+++ b/net/ser2net/patches/001-controlport_overrun_fix.patch
@@ -1,0 +1,29 @@
+--- a/dataxfer.c
++++ b/dataxfer.c
+@@ -3679,7 +3679,7 @@ static void
+ showshortport(struct controller_info *cntlr, port_info_t *port)
+ {
+     char buffer[NI_MAXHOST], portbuff[NI_MAXSERV];
+-    int  count;
++    int  count = 0;
+     int  need_space = 0;
+     int  err;
+     struct absout out = { .out = cntrl_absout, .data = cntlr };
+@@ -3703,7 +3703,7 @@ showshortport(struct controller_info *cn
+ 		      NI_NUMERICHOST | NI_NUMERICSERV);
+     if (err) {
+ 	strcpy(buffer, "*err*");
+-	sprintf(portbuff, "%s", gai_strerror(err));
++	sprintf(portbuff, "error[%d]", err);
+     }
+     bytes_recv = netcon->bytes_received;
+     bytes_sent = netcon->bytes_sent;
+@@ -3759,7 +3759,7 @@ showport(struct controller_info *cntlr, 
+ 			  NI_NUMERICHOST | NI_NUMERICSERV);
+ 	if (err) {
+ 	    strcpy(buffer, "*err*");
+-	    sprintf(portbuff, "%s", gai_strerror(err));
++	    sprintf(portbuff, "error[%d]", err);
+ 	}
+ 	controller_outputf(cntlr, "  connected to: %s,%s\r\n",
+ 			   buffer, portbuff);

--- a/net/ser2net/patches/002-controlport_cleanup.patch
+++ b/net/ser2net/patches/002-controlport_cleanup.patch
@@ -1,0 +1,51 @@
+--- a/dataxfer.c
++++ b/dataxfer.c
+@@ -3697,6 +3697,7 @@ showshortport(struct controller_info *cn
+     if (!netcon)
+ 	netcon = &(port->netcons[0]);
+ 
++	if(netcon->raddrlen > 0) {
+     err = getnameinfo(netcon->raddr, netcon->raddrlen,
+ 		      buffer, sizeof(buffer),
+ 		      portbuff, sizeof(portbuff),
+@@ -3709,7 +3710,11 @@ showshortport(struct controller_info *cn
+     bytes_sent = netcon->bytes_sent;
+ 
+     count = controller_outputf(cntlr, "%s,%s", buffer, portbuff);
+-    while (count < 23) {
++	}
++	else {
++		count = controller_outputf(cntlr, "%s", "unconnected");
++	}
++    while (count < 33) {
+ 	controller_outs(cntlr, " ");
+ 	count++;
+     }
+@@ -3753,6 +3758,7 @@ showport(struct controller_info *cntlr, 
+     controller_outputf(cntlr, "  timeout: %d\r\n", port->timeout);
+ 
+     for_each_connection(port, netcon) {
++	if(netcon->raddrlen > 0) {
+ 	err = getnameinfo(netcon->raddr, netcon->raddrlen,
+ 			  buffer, sizeof(buffer),
+ 			  portbuff, sizeof(portbuff),
+@@ -3767,6 +3773,10 @@ showport(struct controller_info *cntlr, 
+ 			   netcon->bytes_received);
+ 	controller_outputf(cntlr, "    bytes written to TCP: %d\r\n",
+ 			   netcon->bytes_sent);
++	}
++	else {
++		controller_outputf(cntlr, "  unconnected\r\n");
++	}
+     }
+ 
+     controller_outputf(cntlr, "  device: %s\r\n", port->io.devname);
+@@ -3871,7 +3881,7 @@ showshortports(struct controller_info *c
+     port_info_t *port;
+ 
+     controller_outputf(cntlr,
+-	    "%-22s %-6s %7s %-22s %-22s %-14s %-14s %9s %9s %9s %9s %s\r\n",
++	    "%-22s %-6s %7s %-32s %-22s %-14s %-14s %9s %9s %9s %9s %s\r\n",
+ 	    "Port name",
+ 	    "Type",
+ 	    "Timeout",


### PR DESCRIPTION
Maintainer: Michael Heimpold <mhei@heimpold.de>
Compile tested: ar71xx, custom(AR9331), LEDE 1.17.01
Run tested: ar71xx, custom(AR9331), LEDE 1.17.01, confirmed overrun is fixed, command response improvements ok

Description:

001 - Fixes an overrun that occurs due to gai_strerror() filling portbuff beyond the 32byte array. No longer reporting error as string. This occurred when getnameinfo() reported an ipv6 address, it wouldn’t fit in portbuff, but process err overran the buffer.
002 - Increases showshortport “Remote address” column from 22 to 32 characters. Also, if netcon.raddrlen is too long, don’t even bother trying to call into getnameinfo(), just report “unconnected”.

Signed-off-by: David Thornley <david.thornley@touchstargroup.com>
