### PR TITLE
acme: Fix for curl linked against mbed TLS.

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme
-PKG_SOURCE_VERSION:=6d84da588b98733dd9c4f5b88440281ab1eb4989
-PKG_VERSION:=1.4
+PKG_SOURCE_VERSION:=7b40cbe8c1a52041351524bcde4b37665a7cdf79
+PKG_VERSION:=1.5
 PKG_RELEASE:=1
 PKG_LICENSE:=GPLv3
 
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/acme
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+curl +ca-certificates +openssl-util +netcat
+  DEPENDS:=+curl +ca-bundle +openssl-util +netcat
   TITLE:=ACME (Letsencrypt) client
   PKGARCH:=all
   MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -10,7 +10,7 @@
 
 CHECK_CRON=$1
 ACME=/usr/lib/acme/acme.sh
-export SSL_CERT_DIR=/etc/ssl/certs
+export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 export NO_TIMESTAMP=1
 
 UHTTPD_LISTEN_HTTP=


### PR DESCRIPTION
Maintainer: @tohojo
Run tested: ar71xx, TP-Link Archer C7, LEDE 17.01.0

Description:
Due to the change from PolarSSL to mbed TLS, curl does not accept a directory with CA-Certificates and crashes.
This PR fixes that by depending on the CA-Bundle and passing that instead.

Actually, the newest version of curl (7.53) *should* handle this with a warning, but LEDE still includes 7.52.