### PR TITLE
php7: fix php-mod-gd build issues w/ musl

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=7.1.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 
@@ -142,6 +142,10 @@ define Package/php7-fpm/description
   $(call Package/php7/Default/description)
   This package contains the FastCGI Process Manager of the PHP7 interpreter.
 endef
+
+# not everything groks --disable-nls
+DISABLE_NLS:=
+CONFIGURE_ARGS := $(filter-out --%-t1lib,$(CONFIGURE_ARGS))
 
 CONFIGURE_ARGS+= \
 	--enable-cli \

--- a/lang/php7/patches/1008-fix-musl-sys-headers.patch
+++ b/lang/php7/patches/1008-fix-musl-sys-headers.patch
@@ -1,0 +1,66 @@
+--- a/configure.in	2017-04-14 11:53:48.345481008 -0600
++++ b/configure.in	2017-04-14 11:58:47.887644651 -0600
+@@ -497,6 +497,7 @@
+ locale.h \
+ monetary.h \
+ netdb.h \
++poll.h \
+ pwd.h \
+ resolv.h \
+ signal.h \
+@@ -509,7 +510,6 @@
+ sys/file.h \
+ sys/mman.h \
+ sys/mount.h \
+-sys/poll.h \
+ sys/resource.h \
+ sys/select.h \
+ sys/socket.h \
+--- a/main/php_network.h	2017-04-11 09:37:35.000000000 -0600
++++ b/main/php_network.h	2017-04-14 12:00:00.736168983 -0600
+@@ -122,8 +122,8 @@
+ /* uncomment this to debug poll(2) emulation on systems that have poll(2) */
+ /* #define PHP_USE_POLL_2_EMULATION 1 */
+ 
+-#if defined(HAVE_SYS_POLL_H) && defined(HAVE_POLL)
+-# include <sys/poll.h>
++#if defined(HAVE_POLL_H) && defined(HAVE_POLL)
++# include <poll.h>
+ typedef struct pollfd php_pollfd;
+ #else
+ typedef struct _php_pollfd {
+--- a/main/network.c	2017-04-11 09:37:35.000000000 -0600
++++ b/main/network.c	2017-04-14 11:59:44.528052372 -0600
+@@ -51,8 +51,8 @@
+ #ifdef HAVE_SYS_SELECT_H
+ #include <sys/select.h>
+ #endif
+-#if HAVE_SYS_POLL_H
+-#include <sys/poll.h>
++#if HAVE_POLL_H
++#include <poll.h>
+ #endif
+ 
+ #if defined(NETWARE)
+--- a/main/fastcgi.c	2017-04-11 09:37:35.000000000 -0600
++++ b/main/fastcgi.c	2017-04-14 12:01:06.924644901 -0600
+@@ -76,8 +76,8 @@
+ # include <netdb.h>
+ # include <signal.h>
+ 
+-# if defined(HAVE_SYS_POLL_H) && defined(HAVE_POLL)
+-#  include <sys/poll.h>
++# if defined(HAVE_POLL_H) && defined(HAVE_POLL)
++#  include <poll.h>
+ # endif
+ # if defined(HAVE_SYS_SELECT_H)
+ #  include <sys/select.h>
+@@ -1430,7 +1430,7 @@
+ 				break;
+ #else
+ 				if (req->fd >= 0) {
+-#if defined(HAVE_SYS_POLL_H) && defined(HAVE_POLL)
++#if defined(HAVE_POLL_H) && defined(HAVE_POLL)
+ 					struct pollfd fds;
+ 					int ret;
+ 


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: x86_64, generic, LEDE HEAD (fc859fb44b4)
Run tested: same

Did a scratch build, burned a CF, and rebooted.  Tried some PHP web forms and they worked as before.

Description:

Had some issues finding libpng headers and the library itself, because it's called `libpng16` and not `libpng`.  Also, there are warnings from MUSL about including `<sys/poll.h>` instead of `<poll.h>`.  Not fatal, but annoying.