### PR TITLE
libpng: add missing symlinks

### DIFF
--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpng
 PKG_VERSION:=1.6.29
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/libpng
@@ -50,7 +50,7 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/png{,conf}.h $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libpng16 $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng16.{a,la,so*} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng{,16}.{a,la,so*} $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpng{,16}.pc $(1)/usr/lib/pkgconfig/
 	$(INSTALL_DIR) $(2)/bin
@@ -61,7 +61,7 @@ endef
 
 define Package/libpng/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng16.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpng{,16}.so* $(1)/usr/lib/
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: @jow-
Compile tested: bcm53xx, Buffalo WXR-1900DHP, Reboot (SNAPSHOT, r3972-aefa195)
Run tested: bcm53xx, Buffalo WXR-1900DHP, Reboot (SNAPSHOT, r3972-aefa195), basic tests of php7-mod-gd functionality were successful

Description:
The missing libpng.* symlinks cause ld errors when compiling
packages that depend on libpng, such as php7-mod-gd:

	"ld: cannot find -lpng"

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>
