### PR TITLE
net-snmp: add notification config options

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.7.3
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/files/snmpd.conf
+++ b/net/net-snmp/files/snmpd.conf
@@ -88,5 +88,32 @@ config engineid
 	option engineidtype '3'
 	option engineidnic 'eth0'
 
+#config trapcommunity 'trapcommunity'
+#	option community 'public'
+
+#config trapsink
+#	option host 'nms.system.com'
+#	option community 'public'
+#	option port '162'
+
+#config trap2sink
+#	option host 'nms.system.com'
+#	option community 'secret'
+#	option port '162'
+
+#config informsink
+#	option host 'nms.sytem.com'
+#	option community 'public'
+#	option port '162'
+
+#config authtrapenable 'authtrapenable'
+#	option enable '1'
+
+#config v1trapaddress 'v1trapaddress'
+#	option host '1.2.3.4'
+
+#config trapsess 'trapsess'
+#	option trapsess	'-v 3 -e 0x80001f88808c18d3f7b0000 -u trapuser -a MD5 -A administrator -l authPriv -x DES -X rootpasswd udp:127.0.0.1:162'
+
 config snmpd general
 #	list network 'wan'

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -210,6 +210,43 @@ snmpd_engineid_add() {
 	[ -n "$engineidnic" ] && echo "engineIDNic $engineidnic" >> $CONFIGFILE
 }
 
+snmpd_sink_add() {
+	local cfg="$1"
+	local section="$2"
+	local community
+	local port
+	local host
+
+	config_get host "$cfg" host
+	[ -n "section" -a -n "$host" ] || return 0
+	# optional community
+	config_get community "$cfg" community
+	# optional port
+	config_get port "$cfg" port
+	port=${port:+:$port}
+	echo "$section $host$port $community" >> $CONFIGFILE
+}
+
+append_parm() {
+	local section="$1"
+	local option="$2"
+	local switch="$3"
+	local _loctmp
+	config_get _loctmp "$section" "$option"
+	[ -z "$_loctmp" ] && return 0
+	echo "$switch $_loctmp" >> $CONFIGFILE
+}
+
+append_authtrapenable() {
+	local section="$1"
+	local option="$2"
+	local switch="$3"
+	local _loctmp
+	config_get_bool _loctmp "$section" "$option"
+	[ -z "$_loctmp" ] && return 0
+	[ "$_loctmp" -gt 0 ] && echo "$switch $_loctmp" >> $CONFIGFILE
+}
+
 snmpd_setup_fw_rules() {
 	local net="$1"
 	local zone
@@ -256,7 +293,14 @@ start_service() {
 	config_foreach snmpd_exec_add exec
 	config_foreach snmpd_disk_add disk
 	config_foreach snmpd_engineid_add engineid
-	
+	append_parm trapcommunity community trapcommunity
+	config_foreach snmpd_sink_add trapsink trapsink
+	config_foreach snmpd_sink_add trap2sink trap2sink
+	config_foreach snmpd_sink_add informsink informsink
+	append_authtrapenable authtrapenable enable authtrapenable
+	append_parm v1trapaddress host v1trapaddress
+	append_parm trapsess trapsess trapsess
+
 	procd_set_param command $PROG -Lf /dev/null -f
 	procd_set_param file $CONFIGFILE
 	procd_set_param respawn


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: brcm63xx
Run tested: brcm63xx, OpenWRT/LEDE trunk

Description:
Add config support which allow snmpd to take a more active role by sending
traps.

Following config options are supported which map directly on snmpd directives:
-trapcommunity
-trapsink
-trap2sink
-informsink
-authtrapenable
-v1trapaddress
-trapsess

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>