### PR TITLE
gphoto2 and libgphoto2: add package

### DIFF
--- a/libs/libgphoto2/Makefile
+++ b/libs/libgphoto2/Makefile
@@ -1,0 +1,886 @@
+#
+# Copyright (C) 2006-2012 OpenWrt.org
+# Copyright (C) 2017      Leonardo Medici
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libgphoto2
+PKG_VERSION:=2.5.13
+PKG_RELEASE:=1
+PORT_VERSION:=0.12.0
+PKG_MAINTAINER:=Leonardo Medici <leonardo_medici@me.com>
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=@SF/gphoto
+PKG_MD5SUM:=73bf5b3d94c8c6f5fad9ea6b5e561843
+PKG_HASH:=ceaacbdf187d1cd1aed5336991f46b0100f6960b6c8383f9aeab98f1f64780ef
+PKG_LICENSE:=LGPL-2.1
+PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
+PKG_LIBTOOL_PATHS:=. libgphoto2_port
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/libgphoto2/Default
+  SECTION:=libs
+  CATEGORY:=Libraries
+  URL:=http://www.gphoto.org/
+endef
+
+define Package/libgphoto2
+  $(call Package/libgphoto2/Default)
+  DEPENDS:=+libpthread +libltdl +libusb-compat +libusb-1.0 $(ICONV_DEPENDS)
+  TITLE:=The basic library of the gphoto2 program, version $(PKG_VERSION).
+  MENU:=1
+endef
+
+define Package/libgphoto2-port
+  $(call Package/libgphoto2/Default)
+  DEPENDS:=libgphoto2 +libusb-1.0 +libusb-compat
+  TITLE:=Gphoto2 drivers for connect cameras
+endef
+
+define Package/libgphoto2-drivers-adc65
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for adc65 cameras
+endef
+
+define Package/libgphoto2-drivers-agfa_cl20
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for agfa_cl20 cameras
+endef
+
+define Package/libgphoto2-drivers-aox
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for aox cameras
+endef
+
+define Package/libgphoto2-drivers-ax203
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for ax203 cameras
+endef
+
+define Package/libgphoto2-drivers-barbie
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for barbie cameras
+endef
+
+define Package/libgphoto2-drivers-canon
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for canon cameras
+endef
+
+define Package/libgphoto2-drivers-casio_qv
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for casio_qv cameras
+endef
+
+define Package/libgphoto2-drivers-clicksmart310
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for clicksmart310 cameras
+endef
+
+define Package/libgphoto2-drivers-digigr8
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for digigr8 cameras
+endef
+
+define Package/libgphoto2-drivers-digita
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for digita cameras
+endef
+
+define Package/libgphoto2-drivers-dimera3500
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for dimera3500 cameras
+endef
+
+define Package/libgphoto2-drivers-directory
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for directory cameras
+endef
+
+define Package/libgphoto2-drivers-enigma13
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for enigma13 cameras
+endef
+
+define Package/libgphoto2-drivers-fuji
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for fuji cameras
+endef
+
+define Package/libgphoto2-drivers-gsmart300
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for gsmart300 cameras
+endef
+
+define Package/libgphoto2-drivers-hp215
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for hp215 cameras
+endef
+
+define Package/libgphoto2-drivers-iclick
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for iclick cameras
+endef
+
+define Package/libgphoto2-drivers-jamcam
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for jamcam cameras
+endef
+
+define Package/libgphoto2-drivers-jd11
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for jd11 cameras
+endef
+
+define Package/libgphoto2-drivers-jl2005a
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for jl2005a cameras
+endef
+
+define Package/libgphoto2-drivers-jl2005c
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for jl2005c cameras
+endef
+
+define Package/libgphoto2-drivers-kodak_dc120
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for kodak_dc120 cameras
+endef
+
+define Package/libgphoto2-drivers-kodak_dc210
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for kodak_dc210 cameras
+endef
+
+define Package/libgphoto2-drivers-kodak_dc240
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for kodak_dc240 cameras
+endef
+
+define Package/libgphoto2-drivers-kodak_dc3200
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for kodak_dc3200 cameras
+endef
+
+define Package/libgphoto2-drivers-kodak_ez200
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for kodak_ez200 cameras
+endef
+
+define Package/libgphoto2-drivers-konica
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for konica cameras
+endef
+
+define Package/libgphoto2-drivers-konica_qm150
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for konica_qm150 cameras
+endef
+
+define Package/libgphoto2-drivers-largan
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for largan cameras
+endef
+
+define Package/libgphoto2-drivers-lg_gsm
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for lg_gsm cameras
+endef
+
+define Package/libgphoto2-drivers-mars
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for mars cameras
+endef
+
+define Package/libgphoto2-drivers-dimagev
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for dimagev cameras
+endef
+
+define Package/libgphoto2-drivers-mustek
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for mustek cameras
+endef
+
+define Package/libgphoto2-drivers-panasonic_coolshot
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for panasonic_coolshot cameras
+endef
+
+define Package/libgphoto2-drivers-panasonic_l859
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for panasonic_l859 cameras
+endef
+
+define Package/libgphoto2-drivers-panasonic_dc1000
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for panasonic_dc1000 cameras
+endef
+
+define Package/libgphoto2-drivers-panasonic_dc1580
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for panasonic_dc1580 cameras
+endef
+
+define Package/libgphoto2-drivers-pccam300
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for pccam300 cameras
+endef
+
+define Package/libgphoto2-drivers-pccam600
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for pccam600 cameras
+endef
+
+define Package/libgphoto2-drivers-pentax
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for pentax cameras
+endef
+
+define Package/libgphoto2-drivers-polaroid_pdc320
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for polaroid_pdc320 cameras
+endef
+
+define Package/libgphoto2-drivers-polaroid_pdc640
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for polaroid_pdc640 cameras
+endef
+
+define Package/libgphoto2-drivers-polaroid_pdc700
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for polaroid_pdc700 cameras
+endef
+
+define Package/libgphoto2-drivers-ptp2
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for ptp2 cameras
+endef
+
+define Package/libgphoto2-drivers-ricoh
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for ricoh cameras
+endef
+
+define Package/libgphoto2-drivers-ricoh_g3
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for ricoh_g3 cameras
+endef
+
+define Package/libgphoto2-drivers-samsung
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for samsung cameras
+endef
+
+define Package/libgphoto2-drivers-sierra
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for sierra cameras
+endef
+
+define Package/libgphoto2-drivers-sipix_blink2
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for sipix_blink2 cameras
+endef
+
+define Package/libgphoto2-drivers-sipix_web2
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for sipix_web2 cameras
+endef
+
+define Package/libgphoto2-drivers-smal
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for smal cameras
+endef
+
+define Package/libgphoto2-drivers-sonix
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for sonix cameras
+endef
+
+define Package/libgphoto2-drivers-sony_dscf1
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for sony_dscf1 cameras
+endef
+
+define Package/libgphoto2-drivers-sony_dscf55
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for sony_dscf55 cameras
+endef
+
+define Package/libgphoto2-drivers-soundvision
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for soundvision cameras
+endef
+
+define Package/libgphoto2-drivers-spca50x
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for spca50x cameras
+endef
+
+define Package/libgphoto2-drivers-sq905
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for sq905 cameras
+endef
+
+define Package/libgphoto2-drivers-st2205
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for st2205 cameras
+endef
+
+define Package/libgphoto2-drivers-stv0674
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for stv0674 cameras
+endef
+
+define Package/libgphoto2-drivers-stv0680
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for stv0680 cameras
+endef
+
+define Package/libgphoto2-drivers-sx330z
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for sx330z cameras
+endef
+
+define Package/libgphoto2-drivers-topfield
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for topfield cameras
+endef
+
+define Package/libgphoto2-drivers-toshiba_pdrm11
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for toshiba_pdrm11 cameras
+endef
+
+define Package/libgphoto2-drivers-tp6801
+	$(call Package/libgphoto2/Default)
+	DEPENDS:=+libgphoto2-port
+	TITLE:=Gphoto2 drivers for tp6801 cameras
+endef
+
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--enable-static \
+	--disable-rpath \
+	--with-camlibs="all" \
+	--without-included-ltdl \
+	--without-libiconv-prefix \
+	--without-libintl-prefix \
+	--without-gd \
+	--without-jpeg \
+	--with-libexif=no \
+	--without-libxml2 \
+	--with-libxml-2.0=no \
+	--with-libusb-1.0=auto \
+	--with-libusb=no
+
+CONFIGURE_VARS += \
+	CPPFLAGS="$$$$CPPFLAGS $(ICONV_CFLAGS)" \
+	LDFLAGS="$$$$LDFLAGS $(ICONV_LDFLAGS)" \
+	LIBUSB_CFLAGS="$$$$CPPFLAGS" \
+	LIBUSB_LIBS="$$$$LDFLAGS -lusb" \
+	LIBS="-lltdl" \
+
+#	LIBEXIF_CFLAGS="$$$$CPPFLAGS" \
+#	LIBEXIF_LIBS="$$$$LDFLAGS -lexif" \
+
+# If OpenWrt is using the iconv stub, we disable iconv support
+# in libgphoto2 entirely since the stub lacks some essential
+# conversions like UCS-2 to UTF-8 which will let certain drivers
+# fail with "Failed to create iconv converter" .
+ifneq ($(ICONV_FULL),1)
+  CONFIGURE_VARS += am_cv_func_iconv=no am_cv_lib_iconv=no
+endif
+
+MAKE_FLAGS += \
+	LIBLTDL="" \
+
+TARGET_CFLAGS += $(FPIC)
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gphoto2{,-port}-config $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/gphoto2 $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2{,_port}.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libgphoto2.pc $(1)/usr/lib/pkgconfig/
+	$(SED) 's,-I$$$${prefix}/include/gphoto2,,g' $(1)/usr/bin/gphoto2{,-port}-config
+	$(SED) 's,-I$$$${prefix}/include,,g' $(1)/usr/bin/gphoto2{,-port}-config
+	# remove annoying recursive symlink
+	rm -f $(1)/usr/include/gphoto2/gphoto2
+endef
+
+define Package/libgphoto2/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2{,_port}.so.* $(1)/usr/lib/
+	ln -s $(1)/usr/lib/libgphoto2_port.so.12 $(1)/usr/lib/libgphoto2_port.so.10
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/print-camera-list $(1)/usr/lib/libgphoto2/print-camera-list
+endef
+
+define Package/libgphoto2-port/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2_port/$(PORT_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2_port/$(PORT_VERSION)/*.so $(1)/usr/lib/libgphoto2_port/$(PORT_VERSION)
+endef
+
+define Package/libgphoto2-drivers-adc65/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/adc65.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-agfa_cl20/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/agfa_cl20.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-aox/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/aox.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-ax203/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/ax203.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-barbie/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/barbie.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-canon/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/canon.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-casio_qv/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/casio_qv.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-clicksmart310/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/clicksmart310.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-digigr8/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/digigr8.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-digita/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/digita.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-dimera3500/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/dimera3500.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-directory/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/directory.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-enigma13/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/enigma13.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-fuji/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/fuji.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-gsmart300/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/gsmart300.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-hp215/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/hp215.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-iclick/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/iclick.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-jamcam/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/jamcam.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-jd11/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/jd11.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-jl2005a/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/jl2005a.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-jl2005c/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/jl2005c.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-kodak_dc120/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/kodak_dc120.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-kodak_dc210/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/kodak_dc210.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-kodak_dc240/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/kodak_dc240.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-kodak_dc3200/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/kodak_dc3200.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-kodak_ez200/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/kodak_ez200.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-konica/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/konica.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-konica_qm150/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/konica_qm150.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-largan/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/largan.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-lg_gsm/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/lg_gsm.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-mars/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/mars.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-dimagev/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/dimagev.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-mustek/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/mustek.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-panasonic_coolshot/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/panasonic_coolshot.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-panasonic_l859/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/panasonic_l859.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-panasonic_dc1000/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/panasonic_dc1000.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-panasonic_dc1580/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/panasonic_dc1580.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-pccam300/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/pccam300.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-pccam600/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/pccam600.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-pentax/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/pentax.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-polaroid_pdc320/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/polaroid_pdc320.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-polaroid_pdc640/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/polaroid_pdc640.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-polaroid_pdc700/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/polaroid_pdc700.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-ptp2/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/ptp2.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-ricoh/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/ricoh.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-ricoh_g3/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/ricoh_g3.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-samsung/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/samsung.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-sierra/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/sierra.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-sipix_blink2/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/sipix_blink2.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-sipix_web2/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/sipix_web2.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-smal/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/smal.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-sonix/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/sonix.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-sony_dscf1/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/sony_dscf1.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-sony_dscf55/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/sony_dscf55.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-soundvision/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/soundvision.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-spca50x/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/spca50x.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-sq905/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/sq905.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-st2205/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/st2205.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-stv0674/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/stv0674.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-stv0680/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/stv0680.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-sx330z/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/sx330z.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-topfield/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/topfield.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-toshiba_pdrm11/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/toshiba_pdrm11.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+define Package/libgphoto2-drivers-tp6801/install
+	$(INSTALL_DIR) $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2/$(PKG_VERSION)/tp6801.so $(1)/usr/lib/libgphoto2/$(PKG_VERSION)
+endef
+
+$(eval $(call BuildPackage,libgphoto2))
+$(eval $(call BuildPackage,libgphoto2-port))
+$(eval $(call BuildPackage,libgphoto2-drivers-adc65))
+$(eval $(call BuildPackage,libgphoto2-drivers-agfa_cl20))
+$(eval $(call BuildPackage,libgphoto2-drivers-aox))
+$(eval $(call BuildPackage,libgphoto2-drivers-ax203))
+$(eval $(call BuildPackage,libgphoto2-drivers-barbie))
+$(eval $(call BuildPackage,libgphoto2-drivers-canon))
+$(eval $(call BuildPackage,libgphoto2-drivers-casio_qv))
+$(eval $(call BuildPackage,libgphoto2-drivers-clicksmart310))
+$(eval $(call BuildPackage,libgphoto2-drivers-digigr8))
+$(eval $(call BuildPackage,libgphoto2-drivers-digita))
+$(eval $(call BuildPackage,libgphoto2-drivers-dimera3500))
+$(eval $(call BuildPackage,libgphoto2-drivers-directory))
+$(eval $(call BuildPackage,libgphoto2-drivers-enigma13))
+$(eval $(call BuildPackage,libgphoto2-drivers-fuji))
+$(eval $(call BuildPackage,libgphoto2-drivers-gsmart300))
+$(eval $(call BuildPackage,libgphoto2-drivers-hp215))
+$(eval $(call BuildPackage,libgphoto2-drivers-iclick))
+$(eval $(call BuildPackage,libgphoto2-drivers-jamcam))
+$(eval $(call BuildPackage,libgphoto2-drivers-jd11))
+$(eval $(call BuildPackage,libgphoto2-drivers-jl2005a))
+$(eval $(call BuildPackage,libgphoto2-drivers-jl2005c))
+$(eval $(call BuildPackage,libgphoto2-drivers-kodak_dc120))
+$(eval $(call BuildPackage,libgphoto2-drivers-kodak_dc210))
+$(eval $(call BuildPackage,libgphoto2-drivers-kodak_dc240))
+$(eval $(call BuildPackage,libgphoto2-drivers-kodak_dc3200))
+$(eval $(call BuildPackage,libgphoto2-drivers-kodak_ez200))
+$(eval $(call BuildPackage,libgphoto2-drivers-konica))
+$(eval $(call BuildPackage,libgphoto2-drivers-konica_qm150))
+$(eval $(call BuildPackage,libgphoto2-drivers-largan))
+$(eval $(call BuildPackage,libgphoto2-drivers-lg_gsm))
+$(eval $(call BuildPackage,libgphoto2-drivers-mars))
+$(eval $(call BuildPackage,libgphoto2-drivers-dimagev))
+$(eval $(call BuildPackage,libgphoto2-drivers-mustek))
+$(eval $(call BuildPackage,libgphoto2-drivers-panasonic_coolshot))
+$(eval $(call BuildPackage,libgphoto2-drivers-panasonic_l859))
+$(eval $(call BuildPackage,libgphoto2-drivers-panasonic_dc1000))
+$(eval $(call BuildPackage,libgphoto2-drivers-panasonic_dc1580))
+$(eval $(call BuildPackage,libgphoto2-drivers-pccam300))
+$(eval $(call BuildPackage,libgphoto2-drivers-pccam600))
+$(eval $(call BuildPackage,libgphoto2-drivers-pentax))
+$(eval $(call BuildPackage,libgphoto2-drivers-polaroid_pdc320))
+$(eval $(call BuildPackage,libgphoto2-drivers-polaroid_pdc640))
+$(eval $(call BuildPackage,libgphoto2-drivers-polaroid_pdc700))
+$(eval $(call BuildPackage,libgphoto2-drivers-ptp2))
+$(eval $(call BuildPackage,libgphoto2-drivers-ricoh))
+$(eval $(call BuildPackage,libgphoto2-drivers-ricoh_g3))
+$(eval $(call BuildPackage,libgphoto2-drivers-samsung))
+$(eval $(call BuildPackage,libgphoto2-drivers-sierra))
+$(eval $(call BuildPackage,libgphoto2-drivers-sipix_blink2))
+$(eval $(call BuildPackage,libgphoto2-drivers-sipix_web2))
+$(eval $(call BuildPackage,libgphoto2-drivers-smal))
+$(eval $(call BuildPackage,libgphoto2-drivers-sonix))
+$(eval $(call BuildPackage,libgphoto2-drivers-sony_dscf1))
+$(eval $(call BuildPackage,libgphoto2-drivers-sony_dscf55))
+$(eval $(call BuildPackage,libgphoto2-drivers-soundvision))
+$(eval $(call BuildPackage,libgphoto2-drivers-spca50x))
+$(eval $(call BuildPackage,libgphoto2-drivers-sq905))
+$(eval $(call BuildPackage,libgphoto2-drivers-st2205))
+$(eval $(call BuildPackage,libgphoto2-drivers-stv0674))
+$(eval $(call BuildPackage,libgphoto2-drivers-stv0680))
+$(eval $(call BuildPackage,libgphoto2-drivers-sx330z))
+$(eval $(call BuildPackage,libgphoto2-drivers-topfield))
+$(eval $(call BuildPackage,libgphoto2-drivers-toshiba_pdrm11))
+$(eval $(call BuildPackage,libgphoto2-drivers-tp6801))

--- a/libs/libgphoto2/patches/001-automake-compat.patch
+++ b/libs/libgphoto2/patches/001-automake-compat.patch
@@ -1,0 +1,24 @@
+Index: libgphoto2-2.5.13/configure.ac
+===================================================================
+--- libgphoto2-2.5.13.orig/configure.ac
++++ libgphoto2-2.5.13/configure.ac
+@@ -209,7 +209,6 @@ ALL_LINGUAS="cs da de es eu fr hu it ja
+ GP_GETTEXT_HACK([${PACKAGE}-${LIBGPHOTO2_CURRENT_MIN}],[The gPhoto Team],[${MAIL_GPHOTO_TRANSLATION}])
+ AM_GNU_GETTEXT_VERSION([0.14.1])
+ AM_GNU_GETTEXT([external])
+-AM_PO_SUBDIRS()
+ AM_ICONV()
+ GP_GETTEXT_FLAGS()
+ 
+Index: libgphoto2-2.5.13/libgphoto2_port/configure.ac
+===================================================================
+--- libgphoto2-2.5.13.orig/libgphoto2_port/configure.ac
++++ libgphoto2-2.5.13/libgphoto2_port/configure.ac
+@@ -124,7 +124,6 @@ GP_GETTEXT_HACK([${PACKAGE}-${LIBGPHOTO2
+ ALL_LINGUAS="cs da de es eu fi fr it ja nl pl pt_BR ru sk sr sv uk vi zh_CN zh_TW"
+ AM_GNU_GETTEXT_VERSION([0.14.1])
+ AM_GNU_GETTEXT([external])
+-AM_PO_SUBDIRS()
+ AM_ICONV()
+ GP_GETTEXT_FLAGS()
+ 

--- a/libs/libgphoto2/patches/002-no-docs-examples-test-translations.patch
+++ b/libs/libgphoto2/patches/002-no-docs-examples-test-translations.patch
@@ -1,0 +1,95 @@
+Index: libgphoto2-2.5.13/Makefile.am
+===================================================================
+--- libgphoto2-2.5.13.orig/Makefile.am
++++ libgphoto2-2.5.13/Makefile.am
+@@ -8,7 +8,7 @@ bin_SCRIPTS = gphoto2-config
+ EXTRA_DIST = HACKING MAINTAINERS TESTERS installcheck.mk
+ 
+ # Note: @subdirs@ lists all the directories from AC_CONFIG_SUBDIRS()
+-SUBDIRS = @subdirs@ libgphoto2 camlibs tests examples po packaging doc gphoto-m4
++SUBDIRS = @subdirs@ libgphoto2 camlibs packaging gphoto-m4
+ 
+ EXTRA_DIST    += libgphoto2.pc.in
+ pkgconfig_DATA = libgphoto2.pc
+Index: libgphoto2-2.5.13/Makefile.in
+===================================================================
+--- libgphoto2-2.5.13.orig/Makefile.in
++++ libgphoto2-2.5.13/Makefile.in
+@@ -482,7 +482,7 @@ EXTRA_DIST = HACKING MAINTAINERS TESTERS
+ 	INSTALL README.in README README.packaging
+ 
+ # Note: @subdirs@ lists all the directories from AC_CONFIG_SUBDIRS()
+-SUBDIRS = @subdirs@ libgphoto2 camlibs tests examples po packaging doc gphoto-m4
++SUBDIRS = @subdirs@ libgphoto2 camlibs packaging gphoto-m4
+ pkgconfig_DATA = libgphoto2.pc
+ noinst_DATA = libgphoto2-uninstalled.pc
+ doc_DATA = AUTHORS COPYING NEWS ABOUT-NLS ChangeLog README \
+Index: libgphoto2-2.5.13/configure.ac
+===================================================================
+--- libgphoto2-2.5.13.orig/configure.ac
++++ libgphoto2-2.5.13/configure.ac
+@@ -635,20 +635,11 @@ gphoto-m4/Makefile
+ libgphoto2/Makefile
+ libgphoto2.pc
+ libgphoto2-uninstalled.pc
+-examples/Makefile
+-tests/Makefile
+-tests/ddb/Makefile
+-tests/ddb/check-ddb.sh
+ packaging/Makefile
+ packaging/linux-hotplug/Makefile
+ packaging/generic/Makefile
+ packaging/rpm/Makefile
+ packaging/rpm/package.spec
+-po/Makefile.in
+-doc/Makefile
+-doc/Doxyfile
+-doc/Doxyfile-internals
+-doc/api/Makefile
+ ],[
+ dnl This relies on this code being called for each of the above files
+ dnl with ac_file set to the filename.
+Index: libgphoto2-2.5.13/libgphoto2_port/Makefile.am
+===================================================================
+--- libgphoto2-2.5.13.orig/libgphoto2_port/Makefile.am
++++ libgphoto2-2.5.13/libgphoto2_port/Makefile.am
+@@ -25,7 +25,7 @@ udevscript_PROGRAMS =
+ bin_SCRIPTS = gphoto2-port-config
+ 
+ # The . stands for the current dir, i.e. the iolibs to build.
+-SUBDIRS = po libgphoto2_port test . doc gphoto-m4
++SUBDIRS = libgphoto2_port . gphoto-m4
+ 
+ 
+ ########################################################################
+Index: libgphoto2-2.5.13/libgphoto2_port/Makefile.in
+===================================================================
+--- libgphoto2-2.5.13.orig/libgphoto2_port/Makefile.in
++++ libgphoto2-2.5.13/libgphoto2_port/Makefile.in
+@@ -574,7 +574,7 @@ EXTRA_LTLIBRARIES = disk.la ptpip.la ser
+ bin_SCRIPTS = gphoto2-port-config
+ 
+ # The . stands for the current dir, i.e. the iolibs to build.
+-SUBDIRS = po libgphoto2_port test . doc gphoto-m4
++SUBDIRS = libgphoto2_port . gphoto-m4
+ 
+ ########################################################################
+ # All iolibs are defined as EXTRA_LTLIBRARIES. This requires that
+Index: libgphoto2-2.5.13/libgphoto2_port/configure.ac
+===================================================================
+--- libgphoto2-2.5.13.orig/libgphoto2_port/configure.ac
++++ libgphoto2-2.5.13/libgphoto2_port/configure.ac
+@@ -512,13 +512,10 @@ AC_SUBST([AM_LDFLAGS])
+ # ---------------------------------------------------------------------------
+ AC_CONFIG_FILES([
+ Makefile
+-po/Makefile.in
+ libgphoto2_port/Makefile
+ libgphoto2_port.pc
+ libgphoto2_port-uninstalled.pc
+ gphoto2-port-config
+-test/Makefile
+-doc/Makefile
+ gphoto-m4/Makefile
+ ])
+ AC_OUTPUT

--- a/multimedia/gphoto2/Makefile
+++ b/multimedia/gphoto2/Makefile
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2006-2012 OpenWrt.org
+# Copyright (C) 2017      Leonardo Medici
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gphoto2
+PKG_VERSION:=2.5.11
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Leonardo Medici <leonardo_medici@me.com>
+
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=@SF/gphoto
+PKG_MD5SUM:=a62a51474a681aca51b087905deb5e35
+PKG_HASH:=392844d6a06512b0d85e7983a5a0c85c8039feb6ab3bc420674ffdbf7536f9e9
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gphoto2
+  SECTION:=multimedia
+  CATEGORY:=Multimedia
+  TITLE:=Gphoto Digital Camera Control
+  URL:=http://www.gphoto.org/
+  DEPENDS:=+libgphoto2 +libpopt +libpthread +libreadline +libncurses +libexif +libjpeg
+endef
+
+define Package/gphoto2/description
+ For downloading and controlling digital cameras
+endef
+
+CONFIGURE_ARGS += \
+	--without-aalib \
+	--without-libiconv-prefix \
+	--without-libintl-prefix \
+
+CONFIGURE_VARS += \
+	LIBGPHOTO2_CFLAGS="$$$$CFLAGS -I$(STAGING_DIR)/usr/include/gphoto2 $$$$CPPFLAGS" \
+	LIBGPHOTO2_LIBS="$$$$LDFLAGS -lgphoto2 -lgphoto2_port -lltdl" \
+	LIBEXIF_CFLAGS="$$$$CFLAGS $$$$CPPFLAGS" \
+	LIBEXIF_LIBS="$$$$LDFLAGS -lexif" \
+	POPT_CFLAGS="$$$$CFLAGS $$$$CPPFLAGS" \
+	POPT_LIBS="$$$$LDFLAGS -lpopt" \
+
+define Package/gphoto2/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/$(PKG_NAME) $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,gphoto2))

--- a/multimedia/gphoto2/patches/001-automake-compat.patch
+++ b/multimedia/gphoto2/patches/001-automake-compat.patch
@@ -1,0 +1,46 @@
+Index: gphoto2-2.5.11/Makefile.am
+===================================================================
+--- gphoto2-2.5.11.orig/Makefile.am
++++ gphoto2-2.5.11/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = gphoto-m4 contrib doc gphoto2 packaging po tests
++SUBDIRS = gphoto-m4 contrib doc gphoto2 packaging tests
+ 
+ ACLOCAL_AMFLAGS = -I auto-m4 -I gphoto-m4
+ EXTRA_DIST = README.md
+Index: gphoto2-2.5.11/Makefile.in
+===================================================================
+--- gphoto2-2.5.11.orig/Makefile.in
++++ gphoto2-2.5.11/Makefile.in
+@@ -390,7 +390,7 @@ target_alias = @target_alias@
+ top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+-SUBDIRS = gphoto-m4 contrib doc gphoto2 packaging po tests
++SUBDIRS = gphoto-m4 contrib doc gphoto2 packaging tests
+ ACLOCAL_AMFLAGS = -I auto-m4 -I gphoto-m4
+ EXTRA_DIST = README.md
+ all: config.h
+Index: gphoto2-2.5.11/configure.ac
+===================================================================
+--- gphoto2-2.5.11.orig/configure.ac
++++ gphoto2-2.5.11/configure.ac
+@@ -59,10 +59,7 @@ dnl ------------------------------------
+ GP_GETTEXT_HACK([],[Lutz Müller and others],[${MAIL_GPHOTO_TRANSLATION}])
+ ALL_LINGUAS="az cs da de en_GB es eu fi fr hu id is it ja nl pa pl pt_BR ro ru rw sk sr sv uk vi zh_CN zh_TW"
+ AM_GNU_GETTEXT_VERSION([0.14.1])
+-AM_GNU_GETTEXT([external])
+-AM_PO_SUBDIRS()
+ AM_ICONV()
+-GP_GETTEXT_FLAGS()
+ 
+ dnl We cannot use AC_DEFINE_UNQUOTED() for these definitions, as
+ dnl we require make to do insert the proper $(datadir) value
+@@ -354,7 +351,6 @@ AC_SUBST([AM_LDFLAGS])
+ # Create output files
+ # ---------------------------------------------------------------------------
+ AC_CONFIG_FILES([
+-po/Makefile.in 
+ Makefile
+ gphoto2/Makefile
+ gphoto-m4/Makefile

--- a/multimedia/gphoto2/patches/002-no-docs-test.patch
+++ b/multimedia/gphoto2/patches/002-no-docs-test.patch
@@ -1,0 +1,44 @@
+Index: gphoto2-2.5.11/Makefile.am
+===================================================================
+--- gphoto2-2.5.11.orig/Makefile.am
++++ gphoto2-2.5.11/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = gphoto-m4 contrib doc gphoto2 packaging tests
++SUBDIRS = gphoto-m4 contrib gphoto2 packaging
+ 
+ ACLOCAL_AMFLAGS = -I auto-m4 -I gphoto-m4
+ EXTRA_DIST = README.md
+Index: gphoto2-2.5.11/Makefile.in
+===================================================================
+--- gphoto2-2.5.11.orig/Makefile.in
++++ gphoto2-2.5.11/Makefile.in
+@@ -390,7 +390,7 @@ target_alias = @target_alias@
+ top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+-SUBDIRS = gphoto-m4 contrib doc gphoto2 packaging tests
++SUBDIRS = gphoto-m4 contrib gphoto2 packaging
+ ACLOCAL_AMFLAGS = -I auto-m4 -I gphoto-m4
+ EXTRA_DIST = README.md
+ all: config.h
+Index: gphoto2-2.5.11/configure.ac
+===================================================================
+--- gphoto2-2.5.11.orig/configure.ac
++++ gphoto2-2.5.11/configure.ac
+@@ -354,16 +354,10 @@ AC_CONFIG_FILES([
+ Makefile
+ gphoto2/Makefile
+ gphoto-m4/Makefile
+-doc/Makefile
+ contrib/Makefile
+ packaging/Makefile
+ packaging/rpm/Makefile
+ packaging/rpm/package.spec
+-tests/data/Makefile
+-tests/staging/subdir1/Makefile
+-tests/staging/subdir2/Makefile
+-tests/staging/Makefile
+-tests/Makefile
+ ])
+ AC_OUTPUT()dnl
+ 


### PR DESCRIPTION
Maintainer: me / @DocLM
Compile tested: (ramips, mt7688, LEDE 17.01.0)
Run tested: (ramips, mt7688, LEDE 17.01.0)

Description:
Add libgphoto2 with modular camlibs and gphoto2 packages