### PR TITLE
hfsprogs: fix when not linking aginst glibc

### DIFF
--- a/utils/hfsprogs/Makefile
+++ b/utils/hfsprogs/Makefile
@@ -60,7 +60,7 @@ define Build/Compile
 		-f Makefile.lnx \
 		$(TARGET_CONFIGURE_OPTS) \
 		CFLAGS+="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) -I$(PKG_BUILD_DIR)/include -DDEBUG_BUILD=0 -D_FILE_OFFSET_BITS=64 -D LINUX=1 -D BSD=1" \
-		LDFLAGS+="$(TARGET_LDFLAGS) -lbsd" \
+		LDFLAGS+="$(TARGET_LDFLAGS) $(if $(CONFIG_USE_GLIBC),-lbsd)" \
 		all
 endef
 


### PR DESCRIPTION
Only link with libbsd when we are using GLIBC

Signed-off-by: Matthew McClintock <msm-oss@mcclintock.net>

Please double check that your commits:
- all start with "<package name>: "
- all contain signed-off-by
- are linked to your github account (you see your logo in front of them) 

Please also read https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md

Thanks for your contribution
Please remove this text (before ---) and fill the following template
-------------------------------

Maintainer: me / @<github-user>
Compile tested: (put here arch, model, OpenWRT/LEDE version)
Run tested: (put here arch, model, OpenWRT/LEDE version, tests done)

Description:
