### PR TITLE
libgd: update Makefile for libtiff  dependency

### DIFF
--- a/libs/libgd/Makefile
+++ b/libs/libgd/Makefile
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/libgd
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libjpeg +libpng
+  DEPENDS:=+libjpeg +libpng +libtiff
   TITLE:=The GD graphics library
   URL:=http://www.libgd.org/
 endef


### PR DESCRIPTION
Package libgd is missing dependencies for the following libraries:
libtiff.so.5