### PR TITLE
libgd: fix missing dependency, add build options

### DIFF
--- a/libs/libgd/Makefile
+++ b/libs/libgd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgd
 PKG_VERSION:=2.2.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/gd-$(PKG_VERSION)/
@@ -27,14 +27,32 @@ include $(INCLUDE_DIR)/package.mk
 define Package/libgd
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libjpeg +libpng
+  DEPENDS:=+libjpeg +libpng +LIBGD_TIFF:libtiff +LIBGD_FREETYPE:libfreetype
   TITLE:=The GD graphics library
   URL:=http://www.libgd.org/
+  MENU:=1
 endef
 
 define Package/libgd/description
   GD is an open source code library for the dynamic creation of images by
   programmers. GD creates PNG, JPEG and GIF images, among other formats.
+endef
+
+define Package/libgd/config
+	if PACKAGE_libgd
+		config LIBGD_TIFF
+			bool "TIFF image support"
+			default n
+			help
+				Enable TIFF image support through libtiff
+	endif
+	if PACKAGE_libgd
+		config LIBGD_FREETYPE
+			bool "Freetype 2.x library support"
+			default n
+			help
+				Enable Freetype 2.x font engine support through libfreetype
+	endif
 endef
 
 TARGET_CFLAGS += $(FPIC)
@@ -45,12 +63,25 @@ CONFIGURE_ARGS += \
 	--disable-rpath \
 	--without-x \
 	--without-fontconfig \
-	--without-freetype \
 	--with-jpeg=$(STAGING_DIR)/usr \
 	--with-png=$(STAGING_DIR)/usr \
-	--with-vpx=no \
-	--without-xpm \
-	--without-iconv
+	--without-xpm
+
+ifdef CONFIG_LIBGD_TIFF
+	CONFIGURE_ARGS+= \
+		--with-tiff=$(STAGING_DIR)/usr
+else
+	CONFIGURE_ARGS+= \
+		--without-tiff
+endif
+
+ifdef CONFIG_LIBGD_FREETYPE
+	CONFIGURE_ARGS+= \
+		--with-freetype=$(STAGING_DIR)/usr
+else
+	CONFIGURE_ARGS+= \
+		--without-freetype
+endif
 
 CONFIGURE_VARS += \
 	ac_cv_header_iconv_h=no


### PR DESCRIPTION
Maintainer: @jow-
Compile tested: bcm53xx, Buffalo WXR-1900DHP, Reboot (SNAPSHOT, r3972-aefa195)
Run tested: no

Description:
libgd fails to build due to missing dependency on the libtiff package. Fix the dependency issue and add two new configuration options, both disabled by default:
1) enable TIFF support, and
2) enable Freetype 2.x support.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>