### PR TITLE
conserver: add advanced serial console package

### DIFF
--- a/net/conserver/Makefile
+++ b/net/conserver/Makefile
@@ -1,0 +1,75 @@
+#
+# Copyright (C) 2017 Bjørn Mork <bjorn@mork.no>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=conserver
+PKG_VERSION:=8.2.1
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Bjørn Mork <bjorn@mork.no>
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.conserver.com/
+PKG_HASH:=251ae01997e8f3ee75106a5b84ec6f2a8eb5ff2f8092438eba34384a615153d0
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/conserver
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Connect multiple user to a serial console with logging
+  URL:=http://www.conserver.com/
+  DEPENDS:=+libopenssl
+endef
+
+define Package/conserver/description
+ Conserver is an application that allows multiple users to watch a
+ serial console at the same time.  It can log the data, allows users
+ to take write-access of a console (one at a time), and has a
+ variety of bells and whistles to accentuate that basic
+ functionality.  The idea is that conserver will log all your serial
+ traffic so you can go back and review why something crashed, look
+ at changes (if done on the console), or tie the console logs into a
+ monitoring system (just watch the logfiles it creates).  With
+ multi-user capabilities you can work on equipment with others,
+ mentor, train, etc.  It also does all that client-server stuff so
+ that, assuming you have a network connection, you can interact with
+ any of the equipment from home or wherever.
+endef
+
+define Package/conserver/conffiles
+/etc/conserver/conserver.cf
+/etc/conserver/conserver.passwd
+/etc/conserver/console.cf
+endef
+
+CONFIGURE_ARGS += \
+	--with-openssl \
+	--sysconfdir=/etc/conserver \
+	--with-port=3109 \
+	--with-logfile=/var/log/conserver/server.log
+
+define Package/conserver/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/conserver $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/console $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/conserver
+	$(INSTALL_CONF) ./files/conserver.cf $(1)/etc/conserver/
+	$(INSTALL_CONF) ./files/console.cf $(1)/etc/conserver/
+	touch $(1)/etc/conserver/conserver.passwd
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/conserver.init $(1)/etc/init.d/conserver
+endef
+
+$(eval $(call BuildPackage,conserver))

--- a/net/conserver/files/conserver.cf
+++ b/net/conserver/files/conserver.cf
@@ -1,0 +1,13 @@
+config * {
+}
+default full {
+	rw *;
+}
+default * {
+	logfile /var/log/conserver/&.log;
+	timestamp "";
+	include full;
+}
+access * {
+	trusted 127.0.0.1;
+}

--- a/net/conserver/files/conserver.init
+++ b/net/conserver/files/conserver.init
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2017 Bjørn Mork <bjorn@mork.no>
+
+START=99
+STOP=99
+
+USE_PROCD=1
+
+start_service() {
+	[ -d /var/log/conserver ] || mkdir -m 0755 -p /var/log/conserver
+	procd_open_instance
+	procd_set_param command /usr/sbin/conserver
+	procd_close_instance
+}

--- a/net/conserver/files/console.cf
+++ b/net/conserver/files/console.cf
@@ -1,0 +1,4 @@
+config * {
+	master	localhost;
+	port	3109;
+}

--- a/net/conserver/patches/001-remove-strip.patch
+++ b/net/conserver/patches/001-remove-strip.patch
@@ -1,0 +1,48 @@
+diff -ur conserver-8.2.1.old/autologin/Makefile.in conserver-8.2.1/autologin/Makefile.in
+--- conserver-8.2.1.old/autologin/Makefile.in	2013-09-14 00:46:49.000000000 +0200
++++ conserver-8.2.1/autologin/Makefile.in	2016-03-30 17:11:44.489446435 +0200
+@@ -9,7 +9,7 @@
+ 
+ ### Installation programs and flags
+ INSTALL = @INSTALL@
+-INSTALL_PROGRAM = @INSTALL_PROGRAM@ -s
++INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ LN_S = @LN_S@
+ MKDIR = @MKDIR@
+ 
+diff -ur conserver-8.2.1.old/conserver/Makefile.in conserver-8.2.1/conserver/Makefile.in
+--- conserver-8.2.1.old/conserver/Makefile.in	2013-09-14 00:46:53.000000000 +0200
++++ conserver-8.2.1/conserver/Makefile.in	2016-03-30 17:11:44.509446803 +0200
+@@ -14,7 +14,7 @@
+ 
+ ### Installation programs and flags
+ INSTALL = @INSTALL@
+-INSTALL_PROGRAM = @INSTALL_PROGRAM@ -s
++INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ LN_S = @LN_S@
+ MKDIR = @MKDIR@
+ 
+diff -ur conserver-8.2.1.old/console/Makefile.in conserver-8.2.1/console/Makefile.in
+--- conserver-8.2.1.old/console/Makefile.in	2013-09-14 00:46:55.000000000 +0200
++++ conserver-8.2.1/console/Makefile.in	2016-03-30 17:11:44.481446288 +0200
+@@ -10,7 +10,7 @@
+ 
+ ### Installation programs and flags
+ INSTALL = @INSTALL@
+-INSTALL_PROGRAM = @INSTALL_PROGRAM@ -s
++INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ LN_S = @LN_S@
+ MKDIR = @MKDIR@
+ 
+diff -ur conserver-8.2.1.old/contrib/chat/Makefile.in conserver-8.2.1/contrib/chat/Makefile.in
+--- conserver-8.2.1.old/contrib/chat/Makefile.in	2013-09-14 00:47:31.000000000 +0200
++++ conserver-8.2.1/contrib/chat/Makefile.in	2016-03-30 17:11:44.501446656 +0200
+@@ -10,7 +10,7 @@
+ 
+ ### Installation programs and flags
+ INSTALL = @INSTALL@
+-INSTALL_PROGRAM = @INSTALL_PROGRAM@ -s
++INSTALL_PROGRAM = @INSTALL_PROGRAM@
+ LN_S = @LN_S@
+ MKDIR = @MKDIR@
+ 


### PR DESCRIPTION
Conserver is an application that allows multiple users to use
serial consoles at the same time, with logging.  It has a client-
server design which makes it easy to manage a distributed set
of serial consoles.  Logging makes post-crash analyses easier.

Signed-off-by: Bjørn Mork <bjorn@mork.no>


Maintainer: @bmork
Compile tested: mvebu, WRT1900ACv1, LEDE master + 17.01
Compile tested: ar71xx, UniFi-AC-PRO, LEDE 17.01.1
Run tested:  mvebu, WRT1900ACv1, LEDE-17.01.1
Run tested: ar71xx, UniFi-AC-PRO, LEDE 17.01.1
