### PR TITLE
xmlrpc-c: update to 1.39.12, download source as .tgz

### DIFF
--- a/libs/xmlrpc-c/Makefile
+++ b/libs/xmlrpc-c/Makefile
@@ -8,15 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xmlrpc-c
-PKG_REV:=2640
-PKG_VERSION:=1.39.0
+PKG_VERSION:=1.39.12
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://svn.code.sf.net/p/xmlrpc-c/code/advanced
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=$(PKG_REV)
-PKG_SOURCE_PROTO:=svn
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
+PKG_SOURCE_URL:=@SF/xmlrpc-c/Xmlrpc-c%20Super%20Stable/$(PKG_VERSION)
+PKG_HASH:=d830f3264a832dfe09f629cc64036acfd08121692526d0fabe090f7ff881ce08
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=VARIOUS


### PR DESCRIPTION
Maintainer: @thess 

* Update to version 1.39.12
* Download sources as a .tgz file

compile-tested: ar71xx for LEDE
run-tested: no

Apparently svn is not an official prerequisite (as it was earlier practically mandatory due to the main repo being svn based), and some LEDE buildslaves do not have svn installed, which leads to intermittent build  failures for xmlrpc-c in buildbot:
```
Checking out files from the svn repository...
/bin/sh: 1: svn: not found
/bin/sh: 1: svn: not found
Makefile:219: recipe for target '/var/lib/buildbot/slaves/slave-lede-builds4/mips_mips32/build/sdk/dl/xmlrpc-c-1.39.0.tar.gz' failed
make[3]: *** [/var/lib/buildbot/slaves/slave-lede-builds4/mips_mips32/build/sdk/dl/xmlrpc-c-1.39.0.tar.gz] Error 127
```
So switch download from svn to .tgz file that is offered for the "super stable" 1.39 branch.

Based on xmlrpc-c homepage the 1.39 branch is now "super-stable" and the current release is 1.39.12 (based on svn r2910). Our current package version is based on svn 2640
https://sourceforge.net/projects/xmlrpc-c/files/Xmlrpc-c%20Super%20Stable/

Stable branch is 1.43 but that is not offered as .tgz download.
https://sourceforge.net/p/xmlrpc-c/code/HEAD/tree/

Note: if version update is not wanted, another possibility might be to define a PKG_MIRROR_HASH so that the buildbot would accept the local source cache file instead of trying svn download each time.