### PR TITLE
nano: update to 2.8.4

### DIFF
--- a/utils/nano/Makefile
+++ b/utils/nano/Makefile
@@ -8,15 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nano
-PKG_VERSION:=2.7.5
+PKG_VERSION:=2.8.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/nano
-PKG_MD5SUM:=002703e368e07882f75e304c8860d83d
-PKG_HASH:=a64d24e6bc4fc448376d038f9a755af77f8e748c9051b6f45bf85e783a7e67e4
+PKG_HASH:=c7cf264f0f3e4af43ecdbc4ec72c3b1e831c69a1a5f6512d5b0c109e6bac7b11
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
@@ -40,10 +39,9 @@ endef
 
 CONFIGURE_ARGS += \
 	--enable-tiny \
-	--disable-glibtest \
 	--disable-utf8 \
-        --without-slang \
-        --disable-color \
+	--without-slang \
+	--disable-color \
 
 CONFIGURE_VARS += \
 	ac_cv_header_regex_h=no \


### PR DESCRIPTION
* update nano to 2.8.1
* remove deprecated glibtest configure argument
* fix whitespace in configure arguments

I am not sure if this is ready for merge yet, as I noticed that the size of the binary file has doubled from 2.7.5. Might be due to the gnulib usage since 2.8.0. Some additional tweaking might be needed to keep the size down.

Maintainer: @jp-bennett 
Run tested: mvebu WRT3200ACM with LEDE master

https://www.nano-editor.org/news.php

> 2017 April 12
> 
> GNU nano 2.8.1 "Ellert" fixes build failures on MacOS and on musl, fixes scrolling problems in softwrap mode when double-width characters on row boundaries are involved, shows double-width characters as ">" and "<" when split across two rows, moves the cursor more predictably (at the cost of sometimes putting it on the second "half" of a character), avoids creating lines that consist of only blanks when using autoindent, makes ^Home and ^End go to the start and end of the file (on terminals that support those keystrokes), places the cursor better when linting, lets the linter ask only once whether to open an included file, and adds bindings for ^Up and ^Down in the file browser.  Don't sit on your hands.
> 
> 2017 March 31
> 
> GNU nano 2.8.0 "Axat" makes it easier to move around in softwrapped lines: the Up and Down keys now step from visual row to visual row instead of jumping between logical lines, and the Home and End keys now move to the start and end of a row, and only when already there, then to the start and end of the logical line. Furthermore, the screen can now scroll per row instead of always per logical line.  On an entirely different front: nano now makes use of gnulib, to make it build on more platforms.  In short: there were many internal changes, not many user-visible ones (apart form the new softwrap navigation).  The conversion to gnulib was done by Mike Frysinger, the softwrap overhaul by David Ramsey.

