### PR TITLE
jansson: Update to v2.10

### DIFF
--- a/libs/jansson/Makefile
+++ b/libs/jansson/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2014 OpenWrt.org
+# Copyright (C) 2011-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=jansson
-PKG_VERSION:=2.7
+PKG_VERSION:=2.10
 PKG_RELEASE:=1
 PKG_LICENSE:=MIT
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.digip.org/jansson/releases/
-PKG_MD5SUM:=3a106a465bbb77637550b422f5b262ef
+PKG_HASH:=241125a55f739cd713808c4e0089986b8c3da746da8b384952912ad659fa2f5a
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainer: @kissg1988 
Compile tested: (mips, TL-WR842N, Chaos Calmer, r49474)

Signed-off-by: Tibor Dudlák <tibor.dudlak@gmail.com>

Description: jansson in version 2.9 or later is required as dependency for [jose](https://github.com/latchset/jose)
