### PR TITLE
zlib: Add Makefile for zlib v1.2.11

### DIFF
--- a/libs/zlib/Makefile
+++ b/libs/zlib/Makefile
@@ -1,0 +1,90 @@
+#
+# Copyright (C) 2006-2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=zlib
+PKG_VERSION:=1.2.11
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.zlib.net @SF/libpng
+PKG_MD5SUM:=1c9f62f0778697a09d36121ead88e08e
+
+PKG_LICENSE:=Zlib
+PKG_LICENSE_FILES:=README
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/zlib
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Library implementing the deflate compression method
+  URL:=http://www.zlib.net/
+endef
+
+define Package/zlib-dev
+  SECTION:=devel
+  CATEGORY:=Development
+  SUBMENU:=Libraries
+  DEPENDS:=zlib
+  TITLE:=Development files for the zlib library
+endef
+
+define Package/zlib/description
+ zlib is a lossless data-compression library.
+ This package includes the shared library.
+endef
+
+define Package/zlib-dev/description
+ zlib is a lossless data-compression library.
+ This package includes the development support files.
+endef
+
+define Build/Configure
+	(cd $(PKG_BUILD_DIR); \
+		$(TARGET_CONFIGURE_OPTS) \
+		LDSHARED="$(TARGET_CC) -shared -Wl,-soname,libz.so.1" \
+		CFLAGS="$(TARGET_CFLAGS) $(FPIC)" \
+		./configure \
+			--prefix=/usr \
+			--shared \
+			--uname=Linux \
+	);
+endef
+
+define Build/Compile
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS="$(TARGET_CFLAGS)" \
+		libz.a libz.so.$(PKG_VERSION)
+	mkdir -p $(PKG_INSTALL_DIR)
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		install
+endef
+
+define Build/InstallDev
+	mkdir -p $(1)/usr/include
+	$(CP)	$(PKG_INSTALL_DIR)/usr/include/z{conf,lib}.h \
+		$(1)/usr/include/
+	mkdir -p $(1)/usr/lib
+	$(CP)	$(PKG_INSTALL_DIR)/usr/lib/libz.{a,so*} \
+		$(1)/usr/lib/
+	mkdir -p $(1)/usr/lib/pkgconfig
+	$(CP)	$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/zlib.pc \
+		$(1)/usr/lib/pkgconfig/
+endef
+
+# libz.so is needed for openssl (zlib-dynamic)
+define Package/zlib/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libz.so $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libz.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,zlib))


### PR DESCRIPTION
Compile tested: (mips, TL-WR842N, Chaos Calmer, r49474)

Signed-off-by: Tibor Dudlák <tibor.dudlak@gmail.com>

Description: zlib is required as dependency for [jose](https://github.com/latchset/jose) - Library for managing JOSE objects using zlib

I could not find zlib makefile on this github and I would like to update it from zlib version 1.2.8 found on [dev.openwrt.org](https://dev.openwrt.org/browser/trunk/package/libs/zlib/Makefile?rev=37589) which I can list with opkg to zlib version 1.2.11.
