### PR TITLE
travelmate: update 0.7.1

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=0.7.0
+PKG_VERSION:=0.7.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -11,7 +11,6 @@ trm_script="/usr/bin/travelmate.sh"
 
 boot()
 {
-    trm_boot=1
     ubus -t 30 wait_for network.interface 2>/dev/null
     rc_procd start_service
 }
@@ -20,10 +19,6 @@ start_service()
 {
     if [ $("${trm_init}" enabled; printf ${?}) -eq 0 ]
     then
-        if [ -n "${trm_boot}" ]
-        then
-            return 0
-        fi
         procd_open_instance "travelmate"
         procd_set_param command "${trm_script}" "${@}"
         procd_set_param stdout 1

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-trm_ver="0.7.0"
+trm_ver="0.7.1"
 trm_sysver="$(ubus -S call system board | jsonfilter -e '@.release.description')"
 trm_enabled=0
 trm_debug=0
@@ -267,6 +267,15 @@ f_main()
                 sleep 5
             done
         done
+    else
+        if [ ! -s "${trm_rtfile}" ]
+        then
+            config="$(ubus -S call network.wireless status | jsonfilter -l1 -e '@.*.interfaces[@.config.mode="sta"].section')"
+            sta_radio="$(uci -q get wireless."${config}".device)"
+            sta_ssid="$(uci -q get wireless."${config}".ssid)"
+            sta_iface="$(uci -q get wireless."${config}".network)"
+            f_jsnupdate "${sta_iface}" "${sta_radio}" "${sta_ssid}"
+        fi
     fi
 }
 


### PR DESCRIPTION
Maintainer: me
Compile tested: not relevant
Run tested: LEDE Reboot (SNAPSHOT, r3979-226e194335)

Description:
* fix startup & json update behavior
* LuCI-frontend update (see luci repo for details)

Signed-off-by: Dirk Brenken <dev@brenken.org>
