### PR TITLE
utils/gpsd: Backport ncurses6 support from master

### DIFF
--- a/utils/gpsd/patches/0002-ncurses6_detection.patch
+++ b/utils/gpsd/patches/0002-ncurses6_detection.patch
@@ -1,0 +1,15 @@
+Index: gpsd-3.16/SConstruct
+===================================================================
+--- gpsd-3.16.orig/SConstruct
++++ gpsd-3.16/SConstruct
+@@ -543,6 +543,10 @@ else:
+             ncurseslibs = pkg_config('ncurses')
+ 	    if config.CheckPKG('tinfo'):
+ 		ncurseslibs += pkg_config('tinfo')
++        elif WhereIs('ncurses6-config'):
++            ncurseslibs = ['!ncurses6-config --libs --cflags']
++        elif WhereIs('ncursesw6-config'):
++            ncurseslibs = ['!ncursesw6-config --libs --cflags']
+         elif WhereIs('ncurses5-config'):
+             ncurseslibs = ['!ncurses5-config --libs --cflags']
+         elif WhereIs('ncursesw5-config'):


### PR DESCRIPTION
Because gpsd FTBTS without this patch.

Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>

Maintainer: @psidhu @p-wassi
Compile tested: OMAP+glibc, BeagleBone, LEDE-17.01
Run tested: N/A

Description:
Fixes #4299 
