### PR TITLE
ocserv: Correctly get runtime LAN ifname and addresses

### DIFF
--- a/net/ocserv/Makefile
+++ b/net/ocserv/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ocserv
 PKG_VERSION:=0.11.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_USE_MIPS16:=0
 
 PKG_BUILD_DIR :=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
@@ -44,12 +44,12 @@ define Package/ocserv
 endef
 
 define Package/ocserv/description
- OpenConnect server (ocserv) is an SSL VPN server. Its purpose is to be 
+ OpenConnect server (ocserv) is an SSL VPN server. Its purpose is to be
  a secure, small, fast and configurable VPN server. It implements the
  OpenConnect SSL VPN protocol, and has also (currently experimental)
  compatibility with clients using the AnyConnect SSL VPN protocol. The
  OpenConnect VPN protocol uses the standard IETF security protocols such
- as TLS 1.2, and Datagram TLS to provide the secure VPN service. 
+ as TLS 1.2, and Datagram TLS to provide the secure VPN service.
 endef
 
 EXTRA_CPPFLAGS+=-I$(STAGING_DIR)/usr/include/readline/

--- a/net/ocserv/files/ocserv.init
+++ b/net/ocserv/files/ocserv.init
@@ -3,6 +3,8 @@
 START=50
 USE_PROCD=1
 
+. $IPKG_INSTROOT/lib/functions/network.sh
+
 setup_config() {
 	config_get port         $1 port "4443"
 	config_get max_clients  $1 max_clients "8"
@@ -33,26 +35,27 @@ setup_config() {
 				uci set dhcp.lan.start=100
 				uci set dhcp.lan.limit=91
 			fi
-			ip=$(uci get network.lan.ipaddr)
+			network_get_ipaddr ip lan
 			ipaddr="$(echo $ip|cut -d . -f1,2,3).192"
 			netmask="255.255.255.192"
-			uci set ocserv.config.ipaddr="$ipaddr"
-			uci set ocserv.config.netmask="$netmask"
-			uci commit
 		fi
 
 		if test -z "$ip6addr";then
-			ip6addr=$(uci get network.lan.ip6addr 2>/dev/null)
-			test -n "$ip6addr" && uci set ocserv.config.ip6addr="$ip6addr"
-			uci commit
+			network_get_ipaddr6 ip6addr lan
+			# Append ipv6 prefix
+			test -n "$ip6addr" && ip6addr="$ip6addr/96"
 		fi
 
 		ping_leases=1
-		test -n "$ipaddr" && sysctl -w "net.ipv4.conf.$(uci get network.lan.ifname).proxy_arp"=1 >/dev/null
-		test -n "$ip6addr" && sysctl -w "net.ipv6.conf.$(uci get network.lan.ifname).proxy_ndp"=1 >/dev/null
+		local ifname
+		network_get_device ifname lan
+		if test -n "ifname";then
+			test -n "$ipaddr" && sysctl -w "net.ipv4.conf.$ifname.proxy_arp"=1 >/dev/null
+			test -n "$ip6addr" && sysctl -w "net.ipv6.conf.$ifname.proxy_ndp"=1 >/dev/null
+		fi
 	else
-		test "$ipaddr" = "" && ipaddr="192.168.100.0"
-		test "$netmask" = "" && ipaddr="255.255.255.0"
+		test -z "$ipaddr" && ipaddr="192.168.100.0"
+		test -z "$netmask" && netmask="255.255.255.0"
 	fi
 
 	enable_default_domain="#"
@@ -147,7 +150,7 @@ start_service() {
 	[ -f /etc/config/ocserv-dir/ca-key.pem ] && mv /etc/config/ocserv-dir/ca-key.pem /etc/ocserv/ca-key.pem
 	[ -f /etc/config/ocserv-dir/ca.pem ] && mv /etc/config/ocserv-dir/ca.pem /etc/ocserv/ca.pem
 	[ -f /etc/config/ocserv-dir/server-key.pem ] && mv /etc/config/ocserv-dir/server-key.pem /etc/ocserv/server-key.pem
-	[ -f /etc/config/ocserv-dir/server-cert.pem ] && mv /etc/config/ocserv-dir/server-cert.pem /etc/ocserv/server-cert.pem 
+	[ -f /etc/config/ocserv-dir/server-cert.pem ] && mv /etc/config/ocserv-dir/server-cert.pem /etc/ocserv/server-cert.pem
 	[ -d /etc/config/ocserv-dir ] && rmdir /etc/config/ocserv-dir
 
 	[ ! -f /etc/ocserv/ca-key.pem ] && [ -x /usr/bin/certtool ] && {


### PR DESCRIPTION
Maintainer: @billsq
Compile tested: (mvebu, WRT1900ACS, LEDE 17.01.1)
Run tested: (mvebu, WRT1900ACS, LEDE 17.01.1)

Description:
1. Correctly get LAN runtime ifname and addresses using network functions.
2. Do not store ip settings in config file as they may change next time.

Signed-off-by: Qian Sheng <billsq@billsq.me>