### PR TITLE
adblock: update 2.6.1

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=2.6.0
-PKG_RELEASE:=2
+PKG_VERSION:=2.6.1
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/adblock.conf
+++ b/net/adblock/files/adblock.conf
@@ -4,6 +4,8 @@
 config adblock 'global'
 	option adb_enabled '1'
 	option adb_debug '0'
+	option adb_forcesrt '0'
+	option adb_forcedns '0'
 	option adb_iface 'wan'
 	option adb_triggerdelay '2'
 	option adb_whitelist '/etc/adblock/adblock.whitelist'


### PR DESCRIPTION
Maintainer: me
Compile tested: not relevant
Run tested: LEDE Reboot SNAPSHOT r3995-2db05cd199

Description:
* add "adb_forcedns" to redirect all dns requests to local resolver (disabled by default)
* add "adb_forcesrt" to enable overall sort / duplicate removal
  on low memory devices with less than 64 MB RAM (disabled by default)

Signed-off-by: Dirk Brenken <dev@brenken.org>
