### PR TITLE
Mwan3 add network

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.5
+PKG_VERSION:=2.5.1
 PKG_RELEASE:=5
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -4,11 +4,6 @@
 . /lib/functions/network.sh
 . /lib/mwan3/mwan3.sh
 
-config_load mwan3
-
-config_get enabled $INTERFACE enabled 0
-[ "$enabled" == "1" ] || exit 0
-
 [ "$ACTION" == "ifup" -o "$ACTION" == "ifdown" ] || exit 1
 [ -n "$INTERFACE" ] || exit 2
 
@@ -21,6 +16,12 @@ fi
 [ -x /usr/sbin/iptables ] || exit 6
 [ -x /usr/sbin/ip6tables ] || exit 7
 [ -x /usr/bin/logger ] || exit 8
+
+mwan3_set_connected_iptables
+
+config_load mwan3
+config_get enabled $INTERFACE enabled 0
+[ "$enabled" == "1" ] || exit 0
 
 if [ "$ACTION" == "ifup" ]; then
 	config_get family $INTERFACE family ipv4
@@ -44,8 +45,6 @@ if [ "$ACTION" == "ifup" ]; then
 fi
 
 $LOG notice "$ACTION interface $INTERFACE (${DEVICE:-unknown})"
-
-mwan3_set_connected_iptables
 
 case "$ACTION" in
 	ifup)


### PR DESCRIPTION
Maintainer: me
Compile tested: lantiq, xrx200 LEDE
Run tested: lantiq, xrx200 LEDE version, tests done

Description:
Add/Remove connected network to the ipset `mwan3_connected` regardless from interface tracking of mwan3.
