### PR TITLE
ntfs-3g : update to latest stable version

### DIFF
--- a/utils/ntfs-3g/Makefile
+++ b/utils/ntfs-3g/Makefile
@@ -10,10 +10,10 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ntfs-3g
 PKG_RELEASE:=1
 
-PKG_VERSION:=2016.2.22
+PKG_VERSION:=2017.3.23
 PKG_SOURCE:=$(PKG_NAME)_ntfsprogs-$(PKG_VERSION).tgz
-PKG_SOURCE_URL:=http://www.tuxera.com/opensource/
-PKG_MD5SUM:=ccbe8672d0f757bd0c975b50aa4c512e
+PKG_SOURCE_URL:=https://www.tuxera.com/opensource/
+PKG_MD5SUM:=d97474ae1954f772c6d2fa386a6f462c
 
 PKG_LICENSE:=GPL-2.0 LGPL-2.0
 PKG_LICENSE_FILES:=COPYING COPYING.LIB
@@ -98,8 +98,8 @@ define Package/ntfs-3g-utils/description
   considerations.
 
   Currently:
-   - ntfs-3g.secaudit
-   - ntfs-3g.usermap
+   - ntfssecaudit
+   - ntfsusermap
 endef
 
 define Package/ntfsprogs_ntfs-3g/description
@@ -215,8 +215,8 @@ endef
 
 define Package/ntfs-3g-utils/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ntfs-3g.secaudit $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ntfs-3g.usermap $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/man/man8/ntfssecaudit.8 $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/man/man8/ntfsusermap.8 $(1)/usr/bin
 endef
 
 define Package/ntfsprogs_ntfs-3g/install

--- a/utils/ntfs-3g/patches/001-fuseint-fix-path-mounted-on-musl.patch
+++ b/utils/ntfs-3g/patches/001-fuseint-fix-path-mounted-on-musl.patch
@@ -1,8 +1,6 @@
-Index: ntfs-3g-2014.2.15-1-fuseint/libfuse-lite/fusermount.c
-===================================================================
---- ntfs-3g-2014.2.15-1-fuseint.orig/libfuse-lite/fusermount.c
-+++ ntfs-3g-2014.2.15-1-fuseint/libfuse-lite/fusermount.c
-@@ -36,6 +36,10 @@
+--- a/libfuse-lite/fusermount.c
++++ b/libfuse-lite/fusermount.c
+@@ -37,6 +37,10 @@
  
  #define FUSE_DEV_NEW "/dev/fuse"
  
@@ -13,11 +11,9 @@ Index: ntfs-3g-2014.2.15-1-fuseint/libfuse-lite/fusermount.c
  #ifndef MS_DIRSYNC
  #define MS_DIRSYNC 128
  #endif
-Index: ntfs-3g-2014.2.15-1-fuseint/libfuse-lite/mount_util.c
-===================================================================
---- ntfs-3g-2014.2.15-1-fuseint.orig/libfuse-lite/mount_util.c
-+++ ntfs-3g-2014.2.15-1-fuseint/libfuse-lite/mount_util.c
-@@ -255,6 +255,10 @@ int fuse_mnt_check_fuseblk(void)
+--- a/libfuse-lite/mount_util.c
++++ b/libfuse-lite/mount_util.c
+@@ -264,6 +264,10 @@ int fuse_mnt_check_fuseblk(void)
  
  #else /* __SOLARIS__ */
  


### PR DESCRIPTION

Maintainer: Ted Hess
Compile tested: ramips, Y1, OpenWRT/LEDE latest version
Run tested: ramips, Y1, OpenWRT/LEDE latest version, tests done

The new stable version of ntfs-3g is release

Changes to NTFS-3G:

Delegated processing of special reparse points to external plugins
Allowed kernel cacheing by lowntfs-3g when not using Posix ACLs
Enabled fallback to read-only mount when the volume is hibernated
Made a full check for whether an extended attribute is allowed
Moved secaudit and usermap to ntfsprogs (now ntfssecaudit and ntfsusermap)
Enabled encoding broken UTF-16 into broken UTF-8
Autoconfigured selecting <sys/sysmacros.h> vs <sys/mkdev>
Allowed using the full library API on systems without extended attributes support
Fixed DISABLE_PLUGINS as the condition for not using plugins
Corrected validation of multi sector transfer protected records
Denied creating/removing files from $Extend
Returned the size of locale encoded target as the size of symlinks

please visit below for more details:
http://www.tuxera.com/community/release-history/
