### PR TITLE
travelmate: update for Last rundate.

### DIFF
--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -36,7 +36,9 @@ service_triggers()
 {
     local iface="$(uci -q get travelmate.global.trm_iface)"
     local delay="$(uci -q get travelmate.global.trm_triggerdelay)"
-
+    local trm_rtfile="/tmp/trm_runtime.json"
+ 
+    [ -f $trm_rtfile ] && rm -f $trm_rtfile
     PROCD_RELOAD_DELAY=$((${delay:=2} * 1000))
     for name in ${iface}
     do


### PR DESCRIPTION
Maintainer: me / @<github-user>
Compile tested: not relevant
Run tested: ramips, oy-0001,  OpenWrt 15.05.1 r49389

Description:
Update Runtime information - "Last rundate"  after restart travelmate service.