### PR TITLE
utils/gpsd: Set manbuild=no for build (disable building help/html docs)

### DIFF
--- a/utils/gpsd/Makefile
+++ b/utils/gpsd/Makefile
@@ -102,6 +102,7 @@ SCONS_OPTIONS += \
 	python=no \
 	implicit_link=no \
 	chrpath=no \
+	manbuild=no \
 	target="$(TARGET_CROSS:-=)"
 
 define Build/InstallDev


### PR DESCRIPTION
Maintainer: @psidhu 
Compile tested: ar9331, custom, 17.01.0, macOS (10.12.4)
Run tested: (ar9331, custom, 17.01.0)

Description:

This removes unnecessary dependancy on xmlto which can be problematic on macOS build environment.

Signed-off-by: David Thornley <david.thornley@touchstargroup.com>
