### PR TITLE
net/mosquitto: Added further security configuration options for bridge

### DIFF
--- a/net/mosquitto/files/etc/init.d/mosquitto
+++ b/net/mosquitto/files/etc/init.d/mosquitto
@@ -125,6 +125,14 @@ add_bridge() {
     append_if "$1" identity bridge_identity
     append_if "$1" psk bridge_psk
     append_if "$1" tls_version bridge_tls_version
+
+    append_if "$1" restart_timeout
+    append_if "$1" capath bridge_capath
+    append_if "$1" cafile bridge_cafile
+    append_if "$1" certfile bridge_certfile
+    append_if "$1" keyfile bridge_keyfile
+    append_if "$1" username remote_username
+    append_if "$1" password remote_password
 }
 
 


### PR DESCRIPTION
Maintainer: @karlp
Compile tested: ar9331, custom, 17.01.1, macOS (10.12.4)
Run tested: ar9331, custom, 17.01.1

Description:

Added further security configuration passthrough options for bridge section.

Note: Only tested restart_timeout/capath/username/password but other options added for completeness are trivial and related.

Signed-off-by: David Thornley <david.thornley@touchstargroup.com>