### PR TITLE
irssi: remove nossl variant

### DIFF
--- a/net/irssi/Makefile
+++ b/net/irssi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=irssi
 PKG_VERSION:=1.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/irssi/irssi/releases/download/1.0.2/
@@ -18,68 +18,33 @@ PKG_HASH:=5c1c3cc2caf103aad073fadeb000e0f8cb3b416833a7f43ceb8bd9fcf275fbe9
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
-
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
-define Package/irssi/Default
+define Package/irssi
   SUBMENU:=Instant Messaging
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+glib2 +libncurses +libpthread
+  DEPENDS:=+glib2 +libncurses +libpthread +libopenssl
   TITLE:=Console IRC client
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
-  URL:=http://irssi.org/
-endef
-
-define Package/irssi/Default/description
-	Irssi is a terminal based IRC client for UNIX systems.
-endef
-
-define Package/irssi
-$(call Package/irssi/Default)
-  TITLE+= (with OpenSSL support)
-  DEPENDS+= +libopenssl
-  VARIANT:=ssl
+  URL:=https://irssi.org/
 endef
 
 define Package/irssi/description
-$(call Package/irssi/Default/description)
- This package is built with OpenSSL support.
-endef
-
-define Package/irssi-nossl
-$(call Package/irssi/Default)
-  TITLE+= (without OpenSSL support)
-  VARIANT:=nossl
-endef
-
-define Package/irssi-nossl/description
-$(call Package/irssi/Default/description)
- This package is built without OpenSSL support.
+	Irssi is a terminal based IRC client for UNIX systems.
 endef
 
 CONFIGURE_ARGS += \
 	--with-perl=no \
 	--with-glib-prefix="$(STAGING_DIR)/usr" \
+	--with-ssl="$(STAGING_DIR)/usr" \
 	--with-textui \
 	--without-bot \
 	--disable-proxy
 
 EXTRA_CFLAGS+=$(TARGET_CPPFLAGS)
 EXTRA_LDFLAGS+=-lncurses
-
-ifeq ($(BUILD_VARIANT),ssl)
-	CONFIGURE_ARGS += \
-		--with-ssl="$(STAGING_DIR)/usr"
-endif
-
-ifeq ($(BUILD_VARIANT),nossl)
-	CONFIGURE_ARGS += \
-		--without-ssl \
-		--disable-ssl
-endif
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/irssi
@@ -91,7 +56,5 @@ define Package/irssi/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$(PKG_NAME) $(1)/usr/bin/$(PKG_NAME)
 endef
 
-Package/irssi-nossl/install = $(Package/irssi/install)
-
 $(eval $(call BuildPackage,irssi))
-$(eval $(call BuildPackage,irssi-nossl))
+


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: ar71xx, LEDE master

I noticed in buildbot logs that irssi-nossl always fails due to crypto dependencies. I tested building it myself and the build log revealed that the SSL disabling options are currently unknown to irssi configure script.

Irssi source changelogs show that upstream has in October 2016 removed the option to build without SSL:
https://github.com/irssi/irssi/commit/6300dfec71d376c96351708f76a6c4ee4a187eb5

We need to either remove nossl variant (this PR) or develop a proprietary patch to re-enable building irssi without SSL.
