### PR TITLE
jose: Add Makefile for jose v10

### DIFF
--- a/libs/jose/Makefile
+++ b/libs/jose/Makefile
@@ -1,0 +1,74 @@
+#
+# Author: Tibor Dudlák
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=jose
+PKG_VERSION:=10
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://github.com/latchset/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=5c9cdcfb535c4d9f781393d7530521c72b1dd81caa9934cab6dd752cc7efcd72
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libjose
+  SECTION:=libs
+  TITLE:=Provides a full crypto stack including key generation, signing and encryption.
+  DEPENDS:=+zlib +jansson +libopenssl +libpthread
+  URL:=https://github.com/latchset/jose
+  MAINTAINER:=Tibor Dudlák <tibor.dudlak@gmail.com>
+endef
+
+define Package/jose
+  SECTION:=utils
+  TITLE:=Provides a full crypto stack including key generation, signing and encryption.
+  DEPENDS:=+libjose
+  URL:=https://github.com/latchset/jose
+  MAINTAINER:=Tibor Dudlák <tibor.dudlak@gmail.com>
+endef
+
+define Package/jose/description
+	jose is a command line utility for performing various tasks on JSON
+	Object Signing and Encryption (JOSE) objects. José provides a full
+	crypto stack including key generation, signing and encryption.
+endef
+
+define Package/libjose/description
+	libjose is a library for performing various tasks on JSON
+	Object Signing and Encryption (JOSE) objects. José provides a full
+	crypto stack including key generation, signing and encryption.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR)	$(1)/usr/lib
+	$(INSTALL_DIR)  $(1)/usr/include
+	$(INSTALL_DIR)	$(1)/usr/include/$(PKG_NAME)
+	$(INSTALL_DIR)	$(1)/usr/lib/pkgconfig
+	$(CP)	$(PKG_INSTALL_DIR)/usr/lib/lib$(PKG_NAME).so*	$(1)/usr/lib
+	$(CP)	$(PKG_INSTALL_DIR)/usr/include/$(PKG_NAME)/*.h	$(1)/usr/include/$(PKG_NAME)
+	$(CP)	$(PKG_BUILD_DIR)/*.pc				$(1)/usr/lib/pkgconfig
+endef
+
+define Package/libjose/install
+	$(INSTALL_DIR)	$(1)/usr/lib
+	$(CP)		$(PKG_INSTALL_DIR)/usr/lib/lib$(PKG_NAME).so*	$(1)/usr/lib/
+endef
+
+define Package/jose/install
+	$(INSTALL_DIR)  $(1)/usr/bin
+	$(INSTALL_BIN)  $(PKG_INSTALL_DIR)/usr/bin/$(PKG_NAME)          $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,libjose))
+$(eval $(call BuildPackage,jose))

--- a/libs/jose/patches/Fix_minor_leak_upstream_198f720.patch
+++ b/libs/jose/patches/Fix_minor_leak_upstream_198f720.patch
@@ -1,0 +1,33 @@
+From 198f7207427ad7f569aa3592ea16e2bb400db040 Mon Sep 17 00:00:00 2001
+From: Nathaniel McCallum <npmccallum@redhat.com>
+Date: Fri, 29 Sep 2017 14:49:57 -0400
+Subject: [PATCH] Fix minor FILE* leak
+
+---
+ cmd/jwe/pwd.h | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/jwe/pwd.h b/cmd/jwe/pwd.h
+index 0b5be54..2f021eb 100644
+--- a/cmd/jwe/pwd.h
++++ b/cmd/jwe/pwd.h
+@@ -57,8 +57,10 @@ jwe_getpass(const char *prompt)
+     nf.c_lflag &= ~ECHO;
+     nf.c_lflag |= ECHONL;
+ 
+-    if (tcsetattr(fileno(tty), TCSANOW, &nf) != 0)
++    if (tcsetattr(fileno(tty), TCSANOW, &nf) != 0) {
++        fclose(tty);
+         return NULL;
++    }
+ 
+     fprintf(tty, "%s", prompt);
+ 
+@@ -72,6 +74,7 @@ jwe_getpass(const char *prompt)
+     }
+ 
+     tcsetattr(fileno(tty), TCSANOW, &of);
++    fclose(tty);
+     return pwd;
+ }
+ #endif


### PR DESCRIPTION
Signed-off-by: Tibor Dudlák <tibor.dudlak@gmail.com>
-------------------------------

Maintainer: @Tiboris / TBA

Compile tested: (mips, TL-WR842N, 17.01.4, r3560-79f57e422d)

Description:
José is a command line utility for performing various tasks on JSON Object Signing and Encryption (JOSE) objects. José provides a full crypto stack including key generation, signing and encryption.
Project page: https://github.com/latchset/jose

José also depends on jansson >= 2.9 
- [x] https://github.com/openwrt/packages/pull/4289

jose also with http-parser 
- [x] https://github.com/openwrt/packages/pull/5446

and xinetd is required as dependency for Tang server.
Tang project page: https://github.com/latchset/tang

Thank you.