### PR TITLE
libhttp-parser: Update to v2.7.1

### DIFF
--- a/libs/libhttp-parser/Makefile
+++ b/libs/libhttp-parser/Makefile
@@ -8,19 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libhttp-parser
-PKG_VERSION:=2.3.0
+SRC_NAME:=http-parser
+PKG_VERSION:=2.7.1
 PKG_RELEASE=1
 PKG_MAINTAINER:=Ramanathan Sivagurunathan <ramzthecoder@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE-MIT
-
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_MIRROR_HASH:=721ee45b09e8d999e814afe60508bcf0c8d35940cb71417ee96c0db5cdc161ff
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=git://github.com/joyent/http-parser.git
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=56f7ad0e2e5a80f79d214015c91e1f17d11d109f
-
+PKG_BUILD_DIR:=$(SRC_NAME)-$(PKG_VERSION)
+PKG_SOURCE:=$(SRC_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/nodejs/$(SRC_NAME)/archive/v$(PKG_VERSION)/
+PKG_HASH:=70409ad324e5de2da6a0f39e859e566d497c1ff0a249c0c38a5012df91b386b3
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -28,20 +25,20 @@ define Package/libhttp-parser
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=A library to parse http request and response
-  URL:=https://github.com/joyent/http-parser
+  URL:=https://github.com/nodejs/http-parser
 endef
 
-define Package/libhttp-parser/description
-  A parser for HTTP messages written in C. It parses both requests and responses. 
-  The parser is designed to be used in performance HTTP applications. 
-  It does not make any syscalls nor allocations, it does not buffer data, 
-  it can be interrupted at anytime. Depending on your architecture, 
-  it only requires about 40 bytes of data per message stream 
+define Package/$(PKG_NAME)/description
+  A parser for HTTP messages written in C. It parses both requests and responses.
+  The parser is designed to be used in performance HTTP applications.
+  It does not make any syscalls nor allocations, it does not buffer data,
+  it can be interrupted at anytime. Depending on your architecture,
+  it only requires about 40 bytes of data per message stream
   (in a web server that is per connection).
 endef
 
 define Build/Compile
-	$(call Build/Compile/Default, library) 
+	$(call Build/Compile/Default, library)
 endef
 
 define Build/InstallDev
@@ -52,10 +49,10 @@ define Build/InstallDev
 	( cd $(1)/usr/lib ; ln -s libhttp_parser.so.* libhttp_parser.so )
 endef
 
-define Package/libhttp-parser/install
+define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_BUILD_DIR)/libhttp_parser.so.* $(1)/usr/lib/
 	( cd $(1)/usr/lib ; ln -s libhttp_parser.so.* libhttp_parser.so )
 endef
 
-$(eval $(call BuildPackage,libhttp-parser))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/libs/libhttp-parser/patches/http-parser-0001-parser-HTTP_STATUS_MAP-XX-and-enum-http_status.patch
+++ b/libs/libhttp-parser/patches/http-parser-0001-parser-HTTP_STATUS_MAP-XX-and-enum-http_status.patch
@@ -1,0 +1,101 @@
+From 335850f6b868d3411968cbf5a4d59fe619dee36f Mon Sep 17 00:00:00 2001
+From: Nathaniel McCallum <npmccallum@redhat.com>
+Date: Thu, 6 Oct 2016 02:03:36 -0400
+Subject: [PATCH] parser: HTTP_STATUS_MAP(XX) and enum http_status
+
+This patch provides an enum for the standardized HTTP status codes.
+Additionally, the HTTP_STATUS_MAP(XX) can be used for other purposes as
+well, such as code-to-name lookups and code-based switch statements.
+
+PR-URL: https://github.com/nodejs/http-parser/pull/337
+Reviewed-By: Fedor Indutny <fedor@indutny.com>
+Reviewed-By: Brian White <mscdex@mscdex.net>
+Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>
+---
+ http_parser.h | 70 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 70 insertions(+)
+
+diff --git a/http_parser.h b/http_parser.h
+index ea26394..45c72a0 100644
+--- a/http_parser.h
++++ b/http_parser.h
+@@ -90,6 +90,76 @@ typedef int (*http_data_cb) (http_parser*, const char *at, size_t length);
+ typedef int (*http_cb) (http_parser*);
+ 
+ 
++/* Status Codes */
++#define HTTP_STATUS_MAP(XX)                                                 \
++  XX(100, CONTINUE,                        Continue)                        \
++  XX(101, SWITCHING_PROTOCOLS,             Switching Protocols)             \
++  XX(102, PROCESSING,                      Processing)                      \
++  XX(200, OK,                              OK)                              \
++  XX(201, CREATED,                         Created)                         \
++  XX(202, ACCEPTED,                        Accepted)                        \
++  XX(203, NON_AUTHORITATIVE_INFORMATION,   Non-Authoritative Information)   \
++  XX(204, NO_CONTENT,                      No Content)                      \
++  XX(205, RESET_CONTENT,                   Reset Content)                   \
++  XX(206, PARTIAL_CONTENT,                 Partial Content)                 \
++  XX(207, MULTI_STATUS,                    Multi-Status)                    \
++  XX(208, ALREADY_REPORTED,                Already Reported)                \
++  XX(226, IM_USED,                         IM Used)                         \
++  XX(300, MULTIPLE_CHOICES,                Multiple Choices)                \
++  XX(301, MOVED_PERMANENTLY,               Moved Permanently)               \
++  XX(302, FOUND,                           Found)                           \
++  XX(303, SEE_OTHER,                       See Other)                       \
++  XX(304, NOT_MODIFIED,                    Not Modified)                    \
++  XX(305, USE_PROXY,                       Use Proxy)                       \
++  XX(307, TEMPORARY_REDIRECT,              Temporary Redirect)              \
++  XX(308, PERMANENT_REDIRECT,              Permanent Redirect)              \
++  XX(400, BAD_REQUEST,                     Bad Request)                     \
++  XX(401, UNAUTHORIZED,                    Unauthorized)                    \
++  XX(402, PAYMENT_REQUIRED,                Payment Required)                \
++  XX(403, FORBIDDEN,                       Forbidden)                       \
++  XX(404, NOT_FOUND,                       Not Found)                       \
++  XX(405, METHOD_NOT_ALLOWED,              Method Not Allowed)              \
++  XX(406, NOT_ACCEPTABLE,                  Not Acceptable)                  \
++  XX(407, PROXY_AUTHENTICATION_REQUIRED,   Proxy Authentication Required)   \
++  XX(408, REQUEST_TIMEOUT,                 Request Timeout)                 \
++  XX(409, CONFLICT,                        Conflict)                        \
++  XX(410, GONE,                            Gone)                            \
++  XX(411, LENGTH_REQUIRED,                 Length Required)                 \
++  XX(412, PRECONDITION_FAILED,             Precondition Failed)             \
++  XX(413, PAYLOAD_TOO_LARGE,               Payload Too Large)               \
++  XX(414, URI_TOO_LONG,                    URI Too Long)                    \
++  XX(415, UNSUPPORTED_MEDIA_TYPE,          Unsupported Media Type)          \
++  XX(416, RANGE_NOT_SATISFIABLE,           Range Not Satisfiable)           \
++  XX(417, EXPECTATION_FAILED,              Expectation Failed)              \
++  XX(421, MISDIRECTED_REQUEST,             Misdirected Request)             \
++  XX(422, UNPROCESSABLE_ENTITY,            Unprocessable Entity)            \
++  XX(423, LOCKED,                          Locked)                          \
++  XX(424, FAILED_DEPENDENCY,               Failed Dependency)               \
++  XX(426, UPGRADE_REQUIRED,                Upgrade Required)                \
++  XX(428, PRECONDITION_REQUIRED,           Precondition Required)           \
++  XX(429, TOO_MANY_REQUESTS,               Too Many Requests)               \
++  XX(431, REQUEST_HEADER_FIELDS_TOO_LARGE, Request Header Fields Too Large) \
++  XX(451, UNAVAILABLE_FOR_LEGAL_REASONS,   Unavailable For Legal Reasons)   \
++  XX(500, INTERNAL_SERVER_ERROR,           Internal Server Error)           \
++  XX(501, NOT_IMPLEMENTED,                 Not Implemented)                 \
++  XX(502, BAD_GATEWAY,                     Bad Gateway)                     \
++  XX(503, SERVICE_UNAVAILABLE,             Service Unavailable)             \
++  XX(504, GATEWAY_TIMEOUT,                 Gateway Timeout)                 \
++  XX(505, HTTP_VERSION_NOT_SUPPORTED,      HTTP Version Not Supported)      \
++  XX(506, VARIANT_ALSO_NEGOTIATES,         Variant Also Negotiates)         \
++  XX(507, INSUFFICIENT_STORAGE,            Insufficient Storage)            \
++  XX(508, LOOP_DETECTED,                   Loop Detected)                   \
++  XX(510, NOT_EXTENDED,                    Not Extended)                    \
++  XX(511, NETWORK_AUTHENTICATION_REQUIRED, Network Authentication Required) \
++
++enum http_status
++  {
++#define XX(num, name, string) HTTP_STATUS_##name = num,
++  HTTP_STATUS_MAP(XX)
++#undef XX
++  };
++
++
+ /* Request Methods */
+ #define HTTP_METHOD_MAP(XX)         \
+   XX(0,  DELETE,      DELETE)       \
+-- 
+2.10.2
+


### PR DESCRIPTION
Signed-off-by: Tibor Dudlák <tibor.dudlak@gmail.com>
-------------------------------

Maintainer: @ageekymonk 

Compile tested: (mips, TL-WR842N, Chaos Calmer, r49474)

Description: 
http-parser also with jose (https://github.com/openwrt/packages/pull/4334) and xinetd is required as dependency for Tang server.

Tang project page: https://github.com/latchset/tang

Thank you.