### PR TITLE
vpnbypass: removed PROCD instance from start_service.

### DIFF
--- a/net/vpnbypass/Makefile
+++ b/net/vpnbypass/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vpnbypass
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 

--- a/net/vpnbypass/files/vpnbypass.init
+++ b/net/vpnbypass/files/vpnbypass.init
@@ -57,11 +57,6 @@ start_service() {
   config_get routes   'config' 'remotesubnet'
   config_get ranges   'config' 'localsubnet'
 
-	procd_open_instance
-	procd_set_param stdout 1
-	procd_set_param stderr 1
-	procd_close_instance
-
 	iptables -t mangle -D PREROUTING -m mark --mark 0x00/${FW_MASK} -g VPNBYPASS >/dev/null 2>&1
 	ipt -t mangle -N VPNBYPASS; ipt -t mangle -A PREROUTING -m mark --mark 0x00/${FW_MASK} -g VPNBYPASS;
 	ipt -t mangle -A VPNBYPASS -m set --match-set $IPSET dst -j MARK --set-mark ${FW_MARK}/${FW_MASK}


### PR DESCRIPTION
Signed-off-by: Stan Grishin stangri@melmac.net

Maintainer: me
Compile tested: ipq806x, Linksys EA8500, LEDE 17.0.1
Run tested: ipq806x, Linksys EA8500, LEDE snapshot r4053, install + run.

Description:
* removed PROCD instance from start_service (as it threw the error in the system log on newer LEDE versions)