### PR TITLE
adblock: maintenance update 2.6.3

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=2.6.2
+PKG_VERSION:=2.6.3
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -22,7 +22,7 @@ boot()
 
 start_service()
 {
-    if [ $("${adb_init}" enabled; printf ${?}) -eq 0 ]
+    if [ $("${adb_init}" enabled; printf "%u" ${?}) -eq 0 ]
     then
         if [ -n "${adb_boot}" ]
         then
@@ -34,6 +34,11 @@ start_service()
         procd_set_param stderr 1
         procd_close_instance
     fi
+}
+
+reload_service()
+{
+    rc_procd start_service reload
 }
 
 stop_service()


### PR DESCRIPTION
Maintainer: me
Compile tested: -
Run tested: LEDE Reboot SNAPSHOT r4099-4c3953ba29

Description:
**backend:**
* various small fixes & optimizations
 
**frontend (see luci repo):**
* Limit Blacklist/Whitelist Online editing to max. 512 KB, approx.
20.000 domains per list
* Automatically refresh the overview page after button onclick event,
e.g. 'Suspend/Resume' or 'Save & Apply'
* cosmetics

Signed-off-by: Dirk Brenken <dev@brenken.org>