### PR TITLE
vsftpd: create directory for extra config files

### DIFF
--- a/net/vsftpd/Makefile
+++ b/net/vsftpd/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vsftpd
 PKG_VERSION:=3.0.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://security.appspot.com/downloads/
-PKG_MD5SUM:=da119d084bd3f98664636ea05b5bb398
+PKG_HASH:=9d4d2bf6e6e2884852ba4e69e157a2cecd68c5a7635d66a3a8cf8d898c955ef7
 PKG_LICENSE:=GPLv2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
@@ -24,8 +24,8 @@ define Package/vsftpd/Default
   SUBMENU:=File Transfer
   SECTION:=net
   CATEGORY:=Network
-  TITLE:=A fast and secure FTP server
-  URL:=http://vsftpd.beasts.org/
+  TITLE:=Fast and secure FTP server
+  URL:=https://security.appspot.com/vsftpd.html
   MAINTAINER:=Cezary Jackiewicz <cezary@eko.one.pl>
 endef
 
@@ -45,6 +45,7 @@ endef
 
 define Package/vsftpd/conffiles
 /etc/vsftpd.conf
+/etc/vsftpd
 endef
 
 Package/vsftpd-tls/conffiles=$(Package/vsftpd/conffiles)
@@ -88,6 +89,7 @@ define Package/vsftpd/install
 	$(INSTALL_CONF) ./files/$(PKG_NAME).conf $(1)/etc/$(PKG_NAME).conf
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/$(PKG_NAME).init $(1)/etc/init.d/$(PKG_NAME)
+	$(INSTALL_DIR) $(1)/etc/vsftpd
 endef
 
 Package/vsftpd-tls/install=$(Package/vsftpd/install)

--- a/net/vsftpd/files/vsftpd.conf
+++ b/net/vsftpd/files/vsftpd.conf
@@ -11,13 +11,13 @@ session_support=NO
 #syslog_enable=YES
 #userlist_enable=YES
 #userlist_deny=NO
-#userlist_file=/etc/vsftpd.users
+#userlist_file=/etc/vsftpd/vsftpd.users
 #xferlog_enable=YES
 #xferlog_file=/var/log/vsftpd.log
 #xferlog_std_format=YES
 ###
 ### TLS/SSL options
-### example key generation: openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/config/vsftpd_privkey.pem -out /etc/config/vsftpd_cert.pem -subj /C="DE"/ST="Saxony"/L="Leipzig"/CN="OpenWrt"
+### example key generation: openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/vsftpd/vsftpd_privkey.pem -out /etc/vsftpd/vsftpd_cert.pem -subj /C="DE"/ST="Saxony"/L="Leipzig"/CN="OpenWrt"
 #ssl_enable=YES
 #allow_anon_ssl=NO
 #force_local_data_ssl=NO
@@ -25,6 +25,6 @@ session_support=NO
 #ssl_tlsv1=YES
 #ssl_sslv2=NO
 #ssl_sslv3=NO
-#rsa_cert_file=/etc/config/vsftpd_cert.pem
-#rsa_private_key_file=/etc/config/vsftpd_privkey.pem
+#rsa_cert_file=/etc/vsftpd/vsftpd_cert.pem
+#rsa_private_key_file=/etc/vsftpd/vsftpd_privkey.pem
 


### PR DESCRIPTION
@obsy 
Any objections to the proposed changes?

* create /etc/vsftpd directory for additional config files like userlist, SSL certificate and key
* modify config file to use that directory for the example items
* include that directory in conffiles definition, so that the files will get included in the backup

Additionally,
* use PKG_HASH (instead of deprecated PKG_MD5SUM)
* update URL

Run-tested for mvebu LEDE master and ipq806x LEDE 17.01