### PR TITLE
travelmate: update 0.7.3

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=0.7.2
+PKG_VERSION:=0.7.3
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>


### PR DESCRIPTION
Maintainer: me
Compile tested: -
Run tested: LEDE Reboot SNAPSHOT r4099-4c3953ba29

Description:

backend:
* refine connection check (reduce ubus polling)
* further stabilize sta-/ap-handling

frontend (see LuCI repo):
* Automatically refresh the overview page after button onclick event,
e.g. 'Save & Apply'

Signed-off-by: Dirk Brenken <dev@brenken.org>
