### PR TITLE
libs/libsodium: update to 1.0.12

### DIFF
--- a/libs/libsodium/Makefile
+++ b/libs/libsodium/Makefile
@@ -8,12 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsodium
-PKG_VERSION:=1.0.11
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.12
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://download.libsodium.org/libsodium/releases
-PKG_MD5SUM:=b58928d035064b2a46fb564937b83540
+PKG_SOURCE_URL:=https://download.libsodium.org/libsodium/releases \
+https://github.com/jedisct1/libsodium/releases/download/$(PKG_VERSION)
+PKG_HASH:=b8648f1bb3a54b0251cf4ffa4f0d76ded13977d4fa7517d988f4c902dd8e2f95
 
 PKG_FIXUP:=libtool autoreconf
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Maintainer: me 
Compile tested: LEDE x86_64
Run tested: LEDE x86_64

Description:
* Update to 1.0.12
* Use PKG_HASH instead of PKG_MD5SUM
* Add libsodium github link in PKG_SOURCE_URL
