### PR TITLE
miniupnpc: bump to 2.0.20170509

### DIFF
--- a/net/miniupnpc/Makefile
+++ b/net/miniupnpc/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpc
-PKG_VERSION:=2.0.20161216
+PKG_VERSION:=2.0.20170509
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://miniupnp.free.fr/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=01e14408d6fc628de9afabc4417b84adeaba4c0ec517e7b8e278cb2993dafd3e
+PKG_HASH:=d3c368627f5cdfb66d3ebd64ca39ba54d6ff14a61966dbecb8dd296b7039f16a
 PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
 
 PKG_INSTALL:=1

--- a/net/miniupnpc/patches/100-no_minixml_test.patch
+++ b/net/miniupnpc/patches/100-no_minixml_test.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -151,8 +151,8 @@ installpythonmodule3:	pythonmodule3
+@@ -187,8 +187,8 @@ installpythonmodule3:	pythonmodule3
  	python3 setup.py install
  
  validateminixml:	minixmlvalid

--- a/net/miniupnpc/patches/200-miniupnpc_desc.patch
+++ b/net/miniupnpc/patches/200-miniupnpc_desc.patch
@@ -1,6 +1,6 @@
 --- a/upnpcommands.c
 +++ b/upnpcommands.c
-@@ -367,7 +367,7 @@ UPNP_AddPortMapping(const char * control
+@@ -370,7 +370,7 @@ UPNP_AddPortMapping(const char * control
  	AddPortMappingArgs[5].elt = "NewEnabled";
  	AddPortMappingArgs[5].val = "1";
  	AddPortMappingArgs[6].elt = "NewPortMappingDescription";
@@ -8,4 +8,4 @@
 +	AddPortMappingArgs[6].val = desc?desc:"miniupnpc";
  	AddPortMappingArgs[7].elt = "NewLeaseDuration";
  	AddPortMappingArgs[7].val = leaseDuration?leaseDuration:"0";
- 	if(!(buffer = simpleUPnPcommand(-1, controlURL, servicetype,
+ 	buffer = simpleUPnPcommand(-1, controlURL, servicetype,


### PR DESCRIPTION
Maintainer: @sbyx 
Compile tested: ar71xx, Archer C7 v2 LEDE snapshot
Run tested: ar71xx, Archer C7 v2 LEDE snapshot, added/removed port mappings

Fix CVE-2017-8798

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>

Should probably be picked for 17.01