### PR TITLE
Jq fix mips compile flags

### DIFF
--- a/utils/jq/Makefile
+++ b/utils/jq/Makefile
@@ -20,6 +20,10 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
+ifdef CONFIG_USE_MIPS16
+  TARGET_CFLAGS += -fno-ipa-sra
+endif
+
 define Package/jq
   SECTION:=utils
   CATEGORY:=Utilities

--- a/utils/jq/patches/001-stack-exhaustion.patch
+++ b/utils/jq/patches/001-stack-exhaustion.patch
@@ -1,0 +1,37 @@
+From 2d38a12d686a5156d4e7afb1fed7851805590582 Mon Sep 17 00:00:00 2001
+From: W-Mark Kubacki <wmark@hurrikane.de>
+Date: Fri, 19 Aug 2016 19:50:39 +0200
+Subject: [PATCH] Skip printing at MAX_DEPTH and deeper
+
+This addresses #1136, and mitigates a stack exhaustion when printing
+a very deeply nested term.
+---
+ src/jv_print.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/jv_print.c b/src/jv_print.c
+index 5f4f234..cf6651b 100644
+--- src/jv_print.c
++++ src/jv_print.c
+@@ -13,6 +13,10 @@
+ #include "jv_dtoa.h"
+ #include "jv_unicode.h"
+
++#ifndef MAX_DEPTH
++#define MAX_DEPTH 256
++#endif
++
+ #define ESC "\033"
+ #define COL(c) (ESC "[" c "m")
+ #define COLRESET (ESC "[0m")
+@@ -150,7 +154,9 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
+       }
+     }
+   }
+-  switch (jv_get_kind(x)) {
++  if (indent > MAX_DEPTH) {
++    put_str("<stripped: exceeds max depth>", F, S, flags & JV_PRINT_ISATTY);
++  } else switch (jv_get_kind(x)) {
+   default:
+   case JV_KIND_INVALID:
+     if (flags & JV_PRINT_INVALID) {

--- a/utils/jq/patches/002-heap-buffer-overflow.patch
+++ b/utils/jq/patches/002-heap-buffer-overflow.patch
@@ -1,0 +1,34 @@
+From 8eb1367ca44e772963e704a700ef72ae2e12babd Mon Sep 17 00:00:00 2001
+From: Nicolas Williams <nico@cryptonector.com>
+Date: Sat, 24 Oct 2015 17:24:57 -0500
+Subject: [PATCH] Heap buffer overflow in tokenadd() (fix #105)
+
+This was an off-by one: the NUL terminator byte was not allocated on
+resize.  This was triggered by JSON-encoded numbers longer than 256
+bytes.
+---
+ src/jv_parse.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/jv_parse.c b/src/jv_parse.c
+index 3102ed4..84245b8 100644
+--- src/jv_parse.c
++++ src/jv_parse.c
+@@ -383,7 +383,7 @@ static pfunc stream_token(struct jv_parser* p, char ch) {
+
+ static void tokenadd(struct jv_parser* p, char c) {
+   assert(p->tokenpos <= p->tokenlen);
+-  if (p->tokenpos == p->tokenlen) {
++  if (p->tokenpos >= (p->tokenlen - 1)) {
+     p->tokenlen = p->tokenlen*2 + 256;
+     p->tokenbuf = jv_mem_realloc(p->tokenbuf, p->tokenlen);
+   }
+@@ -485,7 +485,7 @@ static pfunc check_literal(struct jv_parser* p) {
+     TRY(value(p, v));
+   } else {
+     // FIXME: better parser
+-    p->tokenbuf[p->tokenpos] = 0; // FIXME: invalid
++    p->tokenbuf[p->tokenpos] = 0;
+     char* end = 0;
+     double d = jvp_strtod(&p->dtoa, p->tokenbuf, &end);
+     if (end == 0 || *end != 0)


### PR DESCRIPTION
Maintainer: Marko Ratkaj <marko.ratkaj@sartura.hr> (me)
Compile tested: LEDE master - mvebu, x86 and mips
Run tested: LEDE master - mvebu, x86 and mips

Description:

There is a gcc related bug that causes the following issue on MIPS:
Assertion failed: jv_get_kind(a) == JV_KIND_STRING (jv.c: jvp_string_ptr: 435)
 
This patch set will disable SRA optimizations on MIPS platform and prevent the above issue and also import some general fixes from debian.