### PR TITLE
travelmate: maintenance update 0.7.4

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=0.7.3
+PKG_VERSION:=0.7.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -32,10 +32,7 @@ stop_service()
     local rtfile="$(uci -q get travelmate.global.trm_rtfile)"
 
     rtfile="${rtfile:="/tmp/trm_runtime.json"}"
-    if [ -s "${rtfile}" ]
-    then
-        > "${rtfile}"
-    fi
+    > "${rtfile}"
     rc_procd start_service
 }
 


### PR DESCRIPTION
Maintainer: me
Compile tested: -
Run tested: Reboot (SNAPSHOT, r4125-83e4ed3497)

Description:
* always update the connection status, even in case of an error
* merge multiple ubus network calls in central check routine

Signed-off-by: Dirk Brenken <dev@brenken.org>
