### PR TITLE
adblock: maintenance update 2.6.4

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=2.6.3
+PKG_VERSION:=2.6.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>


### PR DESCRIPTION
Maintainer: me
Compile tested: -
Run tested: Reboot (SNAPSHOT, r4125-83e4ed3497)

Description:
* made wget default parms compatible with older program versions
* shift dns detection routine to simplify dns override,
  just set 'adb_dnslist' to force a particular backend priority
  (default: 'dnsmasq unbound')
* reduce ubus polling during dns detection

Signed-off-by: Dirk Brenken <dev@brenken.org>
