### PR TITLE
opendkim: DKIM signing and verifying emails

### DIFF
--- a/mail/opendkim/Makefile
+++ b/mail/opendkim/Makefile
@@ -1,0 +1,105 @@
+#
+# Copyright (C) 2017 Val Kulkov <val.kulkov@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=opendkim
+PKG_VERSION:=2.10.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@SF/$(PKG_NAME)
+PKG_HASH:=43a0ba57bf942095fe159d0748d8933c6b1dd1117caf0273fa9a0003215e681b
+PKG_MAINTAINER:=Val Kulkov <val.kulkov@gmail.com>
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE LICENSE.Sendmail
+
+PKG_INSTALL:=1
+PKG_BUILD_DEPENDS:=openssl
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/opendkim
+  SECTION:=mail
+  CATEGORY:=Mail
+  DEPENDS:=+libopendkim
+  TITLE:=Open source milter for providing DKIM service
+  URL:=http://opendkim.org/
+  USERID:=opendkim:opendkim
+endef
+
+define Package/opendkim/description
+  The OpenDKIM daemon application and the opendkim-genkey Perl script for generating public/private key pairs.
+endef
+
+define Package/libopendkim
+  SECTION:=mail
+  CATEGORY:=Libraries
+  DEPENDS:=+libopenssl +libmilter-sendmail
+  TITLE:=Library for signing and verifying DKIM signatures
+  URL:=http://opendkim.org/
+endef
+
+define Package/libopendkim/description
+  Library for signing and verifying DomainKeys Identified Mail (DKIM) signatures.
+endef
+
+define Package/opendkim-tools
+  SECTION:=mail
+  CATEGORY:=Mail
+  DEPENDS:=+libopendkim
+  TITLE:=genzone, testkey and testmsg tools for OpenDKIM
+  URL:=http://opendkim.org/
+endef
+
+define Package/opendkim-tools/description
+  opendkim-genzone, opendkim-testkey and opendkim-testmsg tools.
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+CONFIGURE_ARGS += \
+	--without-db \
+	--without-gcov \
+	--without-gprof \
+	--without-lcov \
+	--with-milter=$(STAGING_DIR)/usr
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/lib $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/opendkim $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/opendkim-{genkey,genzone,testkey,testmsg} $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libopendkim.so* $(1)/usr/lib/
+endef
+
+define Package/opendkim/conffiles
+/etc/opendkim.conf
+/etc/opendkim/
+endef
+
+define Package/opendkim/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/opendkim $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/opendkim $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/opendkim-genkey $(1)/usr/sbin/opendkim-genkey.pl
+	$(INSTALL_BIN) ./files/opendkim-genkey $(1)/usr/sbin/
+	$(INSTALL_DATA) ./files/opendkim.conf.simple $(1)/etc/opendkim/
+	$(INSTALL_BIN) ./files/opendkim.init $(1)/etc/init.d/opendkim
+endef
+
+define Package/libopendkim/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libopendkim.so* $(1)/usr/lib/
+endef
+
+define Package/opendkim-tools/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/opendkim-{genzone,testkey,testmsg} $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,opendkim))
+$(eval $(call BuildPackage,libopendkim))
+$(eval $(call BuildPackage,opendkim-tools))

--- a/mail/opendkim/files/opendkim-genkey
+++ b/mail/opendkim/files/opendkim-genkey
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ -x /usr/bin/perl ]; then
+  /usr/sbin/opendkim-genkey.pl
+else
+  echo ""
+  echo "Perl is required for running this script. Install Perl or run"
+  echo "this script on another computer that has Perl with File::Basename"
+  echo "and Getopt::Long modules installed."
+  echo ""
+fi

--- a/mail/opendkim/files/opendkim.conf.simple
+++ b/mail/opendkim/files/opendkim.conf.simple
@@ -1,0 +1,45 @@
+# The default location of the OpenDKIM configuration file is
+# /etc/opendkim.conf
+
+# Enable to obtain very detailed logging about the logic behind
+# the filter's decision to either sign a message or verify it
+#LogWhy                 yes
+
+# Log to syslog
+Syslog                  yes
+# Log additional entries indicating successful signing or
+# verification of messages
+SyslogSuccess           yes
+
+# the canonicalization method(s) to be used when signing messages
+Canonicalization	relaxed/relaxed
+
+# A set of domains whose mail should be signed by this filter.
+# Mail from other domains will be verified rather than being signed
+Domain			example.com
+
+# Defines the name of the selector to be used when signing messages
+Selector		default
+KeyFile			/etc/openkim/example.com.private
+
+UserID			opendkim:opendkim
+Socket                  inet:8891@localhost
+
+# if using a UNIX socket, make sure that /var/run/opendkim is writable
+# to the opendkim user
+#Socket                  local:/var/run/opendkim/opendkim
+
+ReportAddress           postmaster@example.com
+SendReports             yes
+
+## Hosts to sign email for - 127.0.0.1 is default
+## See the OPERATION section of opendkim(8) for more information
+#
+# InternalHosts		192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12
+
+## For secondary mailservers - indicates not to sign or verify messages
+## from these hosts
+#
+# PeerList		X.X.X.X
+
+PidFile			/var/run/opendkim.pid

--- a/mail/opendkim/files/opendkim.init
+++ b/mail/opendkim/files/opendkim.init
@@ -1,0 +1,15 @@
+#!/bin/sh /etc/rc.common
+
+START=54
+STOP=54
+USE_PROCD=1
+
+start_service() {
+	chown opendkim.opendkim /etc/opendkim/*.private
+	procd_open_instance
+	procd_set_param command /usr/sbin/opendkim -f
+	procd_set_param respawn
+	procd_set_param file /etc/opendkim.conf
+	procd_close_instance
+}
+

--- a/mail/sendmail/Makefile
+++ b/mail/sendmail/Makefile
@@ -21,6 +21,7 @@ PKG_LICENSE:=Sendmail
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_INSTALL:=1
+PKG_BUILD_DEPENDS:=openssl
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Maintainer: me / @<github-user>
Compile tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r4149-74395d9 (2017-05-18)
Run tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r4149-74395d9 (2017-05-18); install, uninstall and run tests were successful

Description:

The OpenDKIM package provides a service for signing and verifying DomainKeys Identified Mail (DKIM) signatures. OpenDKIM consists of a library that implements the DKIM service and a milter-based filter application that can plug in to any milter-aware MTA, such as Postfix or Sendmail, to provide that service to sufficiently recent sendmail MTAs and other MTAs that support the milter protocol.

This submission provides three new packages: 
- libopendkim, a library for signing and verifying DKIM signatures,
- opendkim, the server application and the genkey script,
- opendkim-tools, a set of tools for configuring and testing OpenDKIM.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>
