### PR TITLE
net/dnscrypt-proxy: ignore parameters requiring plugins support if no…

### DIFF
--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
 PKG_VERSION:=1.9.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy \

--- a/net/dnscrypt-proxy/files/dnscrypt-proxy.init
+++ b/net/dnscrypt-proxy/files/dnscrypt-proxy.init
@@ -18,6 +18,7 @@ dnscrypt_instance() {
 create_config_file() {
     local address port resolver resolvers_list ephemeral_keys client_key syslog syslog_prefix local_cache query_log_file block_ipv6 provider_name provider_key resolver_address
     local config_path="$2"
+    local plugins_support_enabled=$(dnscrypt-proxy --version | grep 'Support for plugins: present' | wc -l)
 
     [ ! -d "$CONFIG_DIR" ] && mkdir -p "$CONFIG_DIR"
     [ -f "$config_path" ] && rm "$config_path"
@@ -36,7 +37,7 @@ create_config_file() {
     config_get_bool ephemeral_keys  $1 'ephemeral_keys' '0'
     config_get_bool local_cache     $1 'local_cache'    '0'
     config_get_bool block_ipv6      $1 'block_ipv6'     '0'
-	
+
     append_param_not_empty  "ResolverName"  "$resolver"         $config_path
     append_param            "ResolversList" "$resolvers_list"   $config_path
     append_param_not_empty  "ProviderName"  "$provider_name"    $config_path
@@ -50,10 +51,27 @@ create_config_file() {
     append_param            "SyslogPrefix"  "$syslog_prefix"    $config_path
     append_on_off           "LocalCache"    $local_cache        $config_path
     append_param_not_empty  "QueryLogFile"  "$query_log_file"   $config_path
-    append_yes_no           "BlockIPv6"     $block_ipv6         $config_path
+    if [ $plugins_support_enabled -ne 0 ]
+    then
+       append_yes_no           "block_ipv6"     $block_ipv6         $config_path
+    else
+       log_ignored_param "BlockIPv6"
+    fi
 
-    config_list_foreach $1 'blacklist' append_blacklists $config_path	
+    if [ $plugins_support_enabled -ne 0 ]
+    then
+       config_list_foreach $1 'blacklist' append_blacklists $config_path
+    else
+       log_ignored_param "blacklist"
+    fi
+
 }
+
+log_ignored_param() {
+   local param_name=$1
+   logger -t dnscrypt-proxy -p user.warn dnscrypt-proxy plugins support not present, ignoring $param_name parameter...
+}
+
 
 append_on_off() {
     local param_name=$1


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE x86_64
Run tested: LEDE x86_64

Description: fix problem reported by @Goro2030 in PR #4358
