### PR TITLE
openvswitch: fix build for ovs python libs & related packages

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=openvswitch
 
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=2.7.0
 PKG_RELEASE=$(PKG_SOURCE_VERSION)
 PKG_LICENSE:=Apache-2.0
@@ -22,6 +22,8 @@ PKG_USE_MIPS16:=0
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://openvswitch.org/releases/
 PKG_HASH:=e492cf08a929b4a2178b7f9b01dc4ff562f44138b547b4e942078187b2445d2e
+
+PKG_BUILD_DEPENDS:=python-six/host
 
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf
@@ -65,32 +67,11 @@ endef
 define Package/openvswitch-python
   $(call Package/openvswitch/Default)
   TITLE:=Open vSwitch Python Support
-  DEPENDS:=+openvswitch +PACKAGE_openvswitch-python:python
+  DEPENDS:=+openvswitch +python +python-six
 endef
 
 define Package/openvswitch-python/description
   Provides bindings and libraries for using Python to manipulate/work with Open vSwitch.
-endef
-
-define Package/openvswitch-ipsec
-  $(call Package/openvswitch/Default)
-  TITLE:=Open vSwitch GRE through IPsec tool
-  DEPENDS:=+openvswitch-python
-endef
-
-define Package/openvswitch-ipsec/description
-  The ovs-monitor-ipsec script provides support for encrypting GRE tunnels with 
-  IPsec.
-endef
-
-define Package/openvswitch-benchmark
-  $(call Package/openvswitch/Default)
-  TITLE:=Open vSwitch flow setup benchmark utility
-  DEPENDS:=+openvswitch
-endef
-
-define Package/openvswitch-benchmark/description
-  Utility for running OpenVSwitch benchmarking
 endef
 
 OVS_BIN_TOOLS:=ovs-appctl ovs-ofctl ovs-dpctl ovs-vsctl ovsdb-client
@@ -184,16 +165,6 @@ define Package/openvswitch-python/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/openvswitch/python/ovs/* $(1)/usr/lib/python$(PYTHON_VERSION)/ovs
 endef
 
-define Package/openvswitch-ipsec/install
-	$(INSTALL_DIR) $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/debian/ovs-monitor-ipsec $(1)/usr/sbin/
-endef
-
-define Package/openvswitch-benchmark/install
-	$(INSTALL_DIR) $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ovs-benchmark $(1)/usr/bin/
-endef
-
 define Package/openvswitch/install
 	:
 endef
@@ -208,8 +179,6 @@ $(foreach t,$(OVS_BIN_TOOLS),$(eval $(call BuildPackage,openvswitch-$(t))))
 
 $(eval $(call BuildPackage,openvswitch-base))
 $(eval $(call BuildPackage,openvswitch-python))
-$(eval $(call BuildPackage,openvswitch-ipsec))
-$(eval $(call BuildPackage,openvswitch-benchmark))
 $(eval $(call BuildPackage,openvswitch))
 $(eval $(call KernelPackage,openvswitch))
 

--- a/net/openvswitch/patches/0005-disable-module-build.patch
+++ b/net/openvswitch/patches/0005-disable-module-build.patch
@@ -1,0 +1,25 @@
+From 7cf69704374e363fdda227803be3849233ba96f3 Mon Sep 17 00:00:00 2001
+From: Dario Ernst <Dario.Ernst@riverbed.com>
+Date: Fri, 25 Nov 2016 15:33:48 +0100
+Subject: [PATCH 4/4] disable-module-build
+
+---
+ datapath/linux/Makefile.main.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/datapath/linux/Makefile.main.in b/datapath/linux/Makefile.main.in
+index 7d18253..e5555a7 100644
+--- a/datapath/linux/Makefile.main.in
++++ b/datapath/linux/Makefile.main.in
+@@ -68,7 +68,7 @@ ifeq (,$(wildcard $(CONFIG_FILE)))
+ endif
+ 
+ default:
+-	$(MAKE) -C $(KSRC) M=$(builddir) modules
++	@echo skipping module build
+ 
+ modules_install:
+ 	$(MAKE) -C $(KSRC) M=$(builddir) modules_install
+-- 
+2.9.3
+


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/lede-project/source/commit/bad2f9c4dc39ff8a8bdc7ad4bd86f2c068457a5a x86 generic
Run tested: https://github.com/lede-project/source/commit/bad2f9c4dc39ff8a8bdc7ad4bd86f2c068457a5a x86 generic

-------------------------------

Requires also https://github.com/openwrt/packages/pull/4380

Admittedly I never used those Python libs.
And the setup I was trying it on, did not have
the Python interpreter packaged, so these build failures
went un-noticed.

That's my fault for not trying it out properly on
a full LEDE repo, with all packages.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>