### PR TITLE
btrfs-progs: update to 4.11

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -8,12 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
-PKG_VERSION:=4.7.2
+PKG_VERSION:=4.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs/
-PKG_MD5SUM:=f49bc9e143ffe60260c5bd70ef3b624576673f8b50f41e309892a425f7fbe60f
+PKG_MD5SUM:=25ba238f44b9a1a54e62f7b361bdc9d8
+PKG_HASH:=e17a68cc52a27d905b715445e91ddbaa4d42de4847d54836d6ed21e012dabf0e
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
@@ -45,7 +46,7 @@ define Package/btrfs-progs/description
 endef
 
 progs = btrfs btrfs-debug-tree btrfs-find-root btrfs-image btrfs-map-logical \
-	btrfs-show-super btrfstune btrfs-zero-log fsck.btrfs mkfs.btrfs
+	btrfs-select-super btrfstune btrfs-zero-log fsck.btrfs mkfs.btrfs
 
 CONFIGURE_ARGS += \
 	--disable-backtrace \


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: Mipsel, Archer C5, LEDE 17.01 branch
Run tested: Mipsel, Archer C5, LEDE 17.01 branch

Description:
Update btrfs-progs to version 4.11

Signed-off-by: Daniel Albers <Daniel.Albers@public-files.de>