### PR TITLE
netopeer2-keystored: add new dependency

### DIFF
--- a/net/netopeer2/Makefile
+++ b/net/netopeer2/Makefile
@@ -64,7 +64,7 @@ define Package/netopeer2-keystored
   CATEGORY:=Utilities
   TITLE:=Netopeer2 key store management
   URL:=$(PKG_SOURCE_URL)
-  DEPENDS:=+libopenssl +libsysrepo +sysrepo +sysrepocfg +sysrepoctl +SSH_KEYS:openssh-keygen
+  DEPENDS:=+libopenssl +libsysrepo +sysrepo +sysrepocfg +sysrepoctl +SSH_KEYS:openssh-keygen +SSH_KEYS:openssl-util
   MENU:=1
 endef
 


### PR DESCRIPTION
Signed-off-by: Antonio Paunovic <antonio.paunovic@sartura.hr>

Maintainer: @antonio-paunovic
Compile tested: (MIPS_24kc, Hornet-UB, LEDE master )
Run tested: (MIPS_24kc, Hornet-UB, LEDE master)

Description:
Added dependency for openssl-util because it is needed to generate keys. 