### PR TITLE
net/dnscrypt-proxy: fix block_ipv6 param in init script

### DIFF
--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
 PKG_VERSION:=1.9.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy \

--- a/net/dnscrypt-proxy/files/dnscrypt-proxy.init
+++ b/net/dnscrypt-proxy/files/dnscrypt-proxy.init
@@ -53,9 +53,9 @@ create_config_file() {
     append_param_not_empty  "QueryLogFile"  "$query_log_file"   $config_path
     if [ $plugins_support_enabled -ne 0 ]
     then
-       append_yes_no           "block_ipv6"     $block_ipv6         $config_path
+       append_yes_no           "BlockIPv6"     $block_ipv6         $config_path
     else
-       log_ignored_param "BlockIPv6"
+       log_ignored_param "block_ipv6"
     fi
 
     if [ $plugins_support_enabled -ne 0 ]


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE x86_64
Run tested: LEDE x86_64

Description: Fix block_ipv6 param in init script, which led to app crash
