### PR TITLE
libs/alsa-lib: Adjust URLs

### DIFF
--- a/libs/alsa-lib/Makefile
+++ b/libs/alsa-lib/Makefile
@@ -12,8 +12,11 @@ PKG_VERSION:=1.1.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=ftp://ftp.alsa-project.org/pub/lib/ \
-		http://alsa.cybermirror.org/lib/
+PKG_SOURCE_URL:= \ 
+	https://mirrors.rit.edu/gentoo/distfiles/ \
+	https://mirror.yandex.ru/gentoo-distfiles/distfiles/ \
+	https://mirror.csclub.uwaterloo.ca/gentoo-distfiles/distfiles/ \
+	ftp://ftp.alsa-project.org/pub/lib/
 PKG_HASH:=82f50a09487079755d93e4c9384912196995bade6280bce9bfdcabf094bfb515
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Peter Wagner <tripolar@gmx.at>


### PR DESCRIPTION
Offload main site and switch to HTTPS as primary source
As the ALSA project doesn't provide an up to date list of mirrors piggyback on Gentoo's distfiles repository just like FreeBSD.
http://www.freshports.org/audio/alsa-lib/

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>