### PR TITLE
libyang: modify copy of .so files

### DIFF
--- a/libs/libyang/Makefile
+++ b/libs/libyang/Makefile
@@ -56,7 +56,7 @@ CMAKE_OPTIONS += \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libyang.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libyang.so* $(1)/usr/lib/
 
 	$(INSTALL_DIR) $(1)/usr/include/libyang
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/include/libyang/* $(1)/usr/include/libyang/
@@ -67,7 +67,7 @@ endef
 
 define Package/libyang/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libyang.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libyang.so* $(1)/usr/lib/
 
 	$(INSTALL_DIR) $(1)/usr/lib/libyang
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libyang/* $(1)/usr/lib/libyang/


### PR DESCRIPTION
Signed-off-by: Antonio Paunovic <antonio.paunovic@sartura.hr>

Maintainer: @mislavn
Compile tested: (MIPS_24kc, Hornet-UB, LEDE master )
Run tested: (MIPS_24kc, Hornet-UB, LEDE master)

Description:
Made a change in packages libyang to make symlinks for .so versions instead of copying them.

Change in CMake flags in sysrepo package to make timeouts larger because current numbers are too low for tested device and tools like sysrepocfg haven't worked properly.