### PR TITLE
libnetconf2: modify copy of .so files

### DIFF
--- a/libs/libnetconf2/Makefile
+++ b/libs/libnetconf2/Makefile
@@ -68,7 +68,7 @@ endef
 
 define Package/libnetconf2/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libnetconf2.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetconf2.so* $(1)/usr/lib/
 
 	$(INSTALL_DIR) $(1)/usr/share/libnetconf2
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/libnetconf2/*.yin $(1)/usr/share/libnetconf2/


### PR DESCRIPTION
Signed-off-by: Antonio Paunovic <antonio.paunovic@sartura.hr>
Maintainer: @mislavn
Compile tested: (MIPS_24kc, Hornet-UB, LEDE master )
Run tested: (MIPS_24kc, Hornet-UB, LEDE master)

Description:
Made a change in package libnetconf2 to make symlinks for .so versions instead of copying them.