### PR TITLE
libssh: modify copy of .so files

### DIFF
--- a/libs/libssh/Makefile
+++ b/libs/libssh/Makefile
@@ -68,7 +68,7 @@ define Build/InstallDev
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/libssh/* $(1)/usr/include/libssh/
 
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libssh* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libssh* $(1)/usr/lib/
 
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/* $(1)/usr/lib/pkgconfig/
@@ -76,7 +76,7 @@ endef
 
 define Package/libssh/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libssh* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libssh* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libssh))


### PR DESCRIPTION
Signed-off-by: Antonio Paunovic <antonio.paunovic@sartura.hr>
Maintainer: @mislavn
Compile tested: (MIPS_24kc, Hornet-UB, LEDE master )
Run tested: (MIPS_24kc, Hornet-UB, LEDE master)

Description:
Made a change in packages libssh to make symlinks for .so versions instead of copying them.