### PR TITLE
kernel-packages: new package (adapted from `kernel` package from core)

### DIFF
--- a/kernel/linux/Makefile
+++ b/kernel/linux/Makefile
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=kernel-packages
+PKG_FLAGS:=hold
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+
+PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/packages
+SCAN_DEPS=modules/*.mk $(TOPDIR)/target/linux/*/modules.mk $(TOPDIR)/include/netfilter.mk
+
+PKG_LICENSE:=GPLv2
+PKG_LICENSE_FILES:=
+
+export SHELL:=/bin/sh
+.ONESHELL:
+
+include $(INCLUDE_DIR)/package.mk
+
+STAMP_BUILT:=$(STAMP_BUILT)_$(firstword $(shell $(SCRIPT_DIR)/kconfig.pl $(LINUX_DIR)/.config | md5sum))
+
+-include $(LINUX_DIR)/.config
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define KernelPackage/depends
+endef
+
+CONFIG_PACKAGE_kernel-packages=y
+define Package/kernel-packages
+  SECTION:=sys
+  CATEGORY:=Kernel
+  DEFAULT:=y
+  TITLE:=Virtual kernel package (in packages feed)
+  VERSION:=$(LINUX_VERSION)-$(LINUX_RELEASE)-$(LINUX_VERMAGIC)-packages
+  URL:=http://www.kernel.org/
+  DEPENDS+=kernel
+endef
+
+define Package/kernel-packages/install
+  # nothing to do
+endef
+
+define Package/kernel-packages/extra_provides
+	sed -e 's,.*/,,' $(LINUX_DIR)/modules.builtin;
+endef
+
+$(eval $(call BuildPackage,kernel-packages))
+
+include $(sort $(wildcard ./modules/*.mk))

--- a/kernel/linux/modules/netsupport.mk
+++ b/kernel/linux/modules/netsupport.mk
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+NETWORK_SUPPORT_MENU:=Network Support
+
+define KernelPackage/openvswitch
+  SECTION:=kernel
+  CATEGORY:=Kernel modules
+  SUBMENU:=Network Support
+  TITLE:=Open vSwitch Kernel Package
+  KCONFIG:= \
+	CONFIG_BRIDGE \
+	CONFIG_OPENVSWITCH \
+	CONFIG_OPENVSWITCH_GRE=n \
+	CONFIG_OPENVSWITCH_VXLAN=n \
+	CONFIG_OPENVSWITCH_GENEVE=n
+  DEPENDS:= \
+	@IPV6 +kmod-gre +kmod-lib-crc32c +kmod-mpls \
+	+kmod-vxlan +kmod-nf-nat +kmod-nf-nat6
+  FILES:= $(LINUX_DIR)/net/openvswitch/openvswitch.ko
+  AUTOLOAD:=$(call AutoLoad,21,openvswitch)
+endef
+
+define KernelPackage/openvswitch/description
+  This package contains the Open vSwitch kernel moodule and bridge compat
+  module. Furthermore, it supports OpenFlow.
+endef
+
+$(eval $(call KernelPackage,openvswitch))
+

--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -8,7 +8,6 @@
 # $Id: Makefile $
 
 include $(TOPDIR)/rules.mk
-include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=openvswitch
 
@@ -123,30 +122,6 @@ endef
 define Package/openvswitch/description
   Provides the main userspace components required for Open vSwitch to function.
   Includes also most of  OVS utilities.
-endef
-
-define KernelPackage/openvswitch
-  SECTION:=kernel
-  CATEGORY:=Kernel modules
-  SUBMENU:=Network Support
-  TITLE:=Open vSwitch Kernel Package
-  KCONFIG:= \
-	CONFIG_BRIDGE \
-	CONFIG_OPENVSWITCH \
-	CONFIG_OPENVSWITCH_GRE=n \
-	CONFIG_OPENVSWITCH_VXLAN=n \
-	CONFIG_OPENVSWITCH_GENEVE=n
-  DEPENDS:= \
-	@IPV6 +kmod-gre +kmod-lib-crc32c +kmod-mpls \
-	+kmod-vxlan +kmod-nf-nat +kmod-nf-nat6  \
-	@($(SUPPORTED_KERNELS))
-  FILES:= $(LINUX_DIR)/net/openvswitch/openvswitch.ko
-  AUTOLOAD:=$(call AutoLoad,21,openvswitch)
-endef
-
-define KernelPackage/openvswitch/description
-  This package contains the Open vSwitch kernel moodule and bridge compat
-  module. Furthermore, it supports OpenFlow.
 endef
 
 CONFIGURE_ARGS += --with-linux=$(LINUX_DIR) --with-rundir=/var/run
@@ -277,5 +252,3 @@ $(eval $(call BuildPackage,openvswitch-ovn))
 $(eval $(call BuildPackage,openvswitch-vtep))
 $(eval $(call BuildPackage,openvswitch-python))
 $(eval $(call BuildPackage,openvswitch))
-$(eval $(call KernelPackage,openvswitch))
-


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A
Run tested: N/A

-------------------------------

For certain packages in the packages feed, some
kernel from the kernel tree are needed.
One example is OVS, but others could appear.

Adding those kernel modules as packages here,
would hopefully offer a more granular control over
kernel modules that would get installed for those packages.

And it would help keep core at a reduced size.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>