### PR TITLE
radicale: update to version 1.1.3

### DIFF
--- a/net/radicale/Makefile
+++ b/net/radicale/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale
-PKG_VERSION:=1.1.2
+PKG_VERSION:=1.1.3
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
 
@@ -17,7 +17,7 @@ PKG_LICENSE_FILES:=COPYING
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/Kozea/Radicale
 PKG_SOURCE_SUBDIR=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=ee3cb8e8e69828faa865c145b32f5bb94259a62c
+PKG_SOURCE_VERSION:=d5171958ffe41e495ccaf2c02702d9acb0c6e6ad
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE 17.01
Run tested: OpenWRT 15.01 / LEDE 17.01

Description:
update to version 1.1.3

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>
