### PR TITLE
Hplip 3.16.11 and cups (libs only)

### DIFF
--- a/libs/libcups/Makefile
+++ b/libs/libcups/Makefile
@@ -1,0 +1,93 @@
+#
+# Copyright (C) 2006-2012 OpenWrt.org
+# Copyright (C) 2017 Luiz Angelo Daros de Luca <luizluca@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cups
+PKG_VERSION:=2.2.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-source.tar.gz
+PKG_SOURCE_URL:=https://github.com/apple/cups/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=66701fe15838f2c892052c913bde1ba106bbee2e0a953c955a62ecacce76885f
+PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=LICENSE.txt
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libcups/Default
+  URL:=http://www.cups.org/
+  SUBMENU:=Printing
+endef
+
+define Package/libcups
+$(call Package/cups/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+zlib +libpthread +libpng +libjpeg
+  TITLE:=Common UNIX Printing System - Core library
+endef
+
+define Package/libcups/description
+	Common UNIX Printing System - Core library
+endef
+
+TARGET_LDFLAGS+=-Wl,-rpath-link=$(STAGING_DIR)/usr/lib
+
+CONFIGURE_ARGS+=--with-cups-user="nobody" \
+		--with-cups-group="nogroup" \
+		--with-components="embedded" \
+		--with-pdftops="none" \
+		--without-perl \
+		--without-python \
+		--without-php \
+		--enable-shared \
+		--enable-image \
+		--enable-libusb \
+		--disable-acl \
+		--disable-dbus \
+		--disable-dnssd \
+		--disable-launchd \
+		--disable-ldap \
+		--disable-pam \
+		--disable-slp \
+		--disable-gnutls \
+		--disable-openssl \
+		--disable-cdsassl \
+		--disable-ssl \
+		--disable-gssapi \
+		--disable-tiff \
+		UNAME="Linux" \
+		LIBS="$(TARGET_LDFLAGS) -lz -lpng -ljpeg"
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR)/cups \
+		$(TARGET_CONFIGURE_OPTS) \
+		DSTROOT="$(PKG_INSTALL_DIR)" \
+		STRIP="/bin/true" \
+		libcups.so.2 install-libs install-headers
+	$(MAKE) -C $(PKG_BUILD_DIR)/filter \
+		$(TARGET_CONFIGURE_OPTS) \
+		DSTROOT="$(PKG_INSTALL_DIR)" \
+		STRIP="/bin/true" \
+		libcupsimage.so.2 install-libs install-headers
+	$(INSTALL_DIR) $(PKG_INSTALL_DIR)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/cups-config $(PKG_INSTALL_DIR)/usr/bin
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(2)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/cups-config $(2)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/cups $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcups*.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libcups))

--- a/libs/libcups/patches/100-components.patch
+++ b/libs/libcups/patches/100-components.patch
@@ -1,0 +1,42 @@
+--- a/configure
++++ b/configure
+@@ -1560,6 +1560,7 @@ Optional Packages:
+   --with-operkey          set the default operator @AUTHKEY value
+   --with-components       set components to build:
+ 			    - "all" (default) builds everything
++			    - "embedded" builds everything except man and notifier
+ 			    - "core" builds libcups and ipptool
+   --with-privateinclude   set path for private include files, default=none
+   --with-lpdconfig        set URI for LPD config file
+@@ -5916,6 +5917,10 @@ case "$COMPONENTS" in
+ 		BUILDDIRS="filter backend berkeley cgi-bin monitor notifier ppdc scheduler systemv conf data desktop locale man doc examples templates"
+ 		;;
+ 
++	embedded)
++		BUILDDIRS="filter backend berkeley cgi-bin driver monitor ppdc scheduler systemv conf data locale doc examples templates"
++		;;
++
+ 	core)
+ 		BUILDDIRS="data locale"
+ 		;;
+--- a/config-scripts/cups-common.m4
++++ b/config-scripts/cups-common.m4
+@@ -440,6 +440,7 @@ COMPONENTS="all"
+ 
+ AC_ARG_WITH(components, [  --with-components       set components to build:
+ 			    - "all" (default) builds everything
++			    - "embedded" builds everything except locale, man and notifier
+ 			    - "core" builds libcups and ipptool],
+ 	COMPONENTS="$withval")
+ 
+@@ -448,6 +449,10 @@ case "$COMPONENTS" in
+ 		BUILDDIRS="filter backend berkeley cgi-bin monitor notifier ppdc scheduler systemv conf data desktop locale man doc examples templates"
+ 		;;
+ 
++	embedded)
++		BUILDDIRS="filter backend berkeley cgi-bin driver monitor ppdc scheduler systemv conf data locale doc examples templates"
++		;;
++
+ 	core)
+ 		BUILDDIRS="data locale"
+ 		;;

--- a/libs/libcups/patches/140-uname.patch
+++ b/libs/libcups/patches/140-uname.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -2504,7 +2504,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+ 
+ 
+-uname=`uname`
++uname=${UNAME:-`uname`}
+ uversion=`uname -r | sed -e '1,$s/^[^0-9]*\([0-9]*\)\.\([0-9]*\).*/\1\2/'`
+ uarch=`uname -m`
+ 

--- a/libs/libcups/patches/160-ppdc.patch
+++ b/libs/libcups/patches/160-ppdc.patch
@@ -1,0 +1,16 @@
+--- a/ppdc/Makefile
++++ b/ppdc/Makefile
+@@ -217,12 +217,7 @@ uninstall:
+ 
+ genstrings:		genstrings.o libcupsppdc.a ../cups/$(LIBCUPSSTATIC) \
+ 			sample.drv ../data/media.defs
+-	echo Linking $@...
+-	$(CXX) $(ARCHFLAGS) $(LDFLAGS) -o genstrings genstrings.o \
+-		libcupsppdc.a ../cups/$(LIBCUPSSTATIC) $(LIBGSSAPI) $(SSLLIBS) \
+-		$(DNSSDLIBS) $(COMMONLIBS) $(LIBZ)
+-	echo Generating localization strings...
+-	./genstrings >sample.c
++	echo Not Linking $@...
+ 
+ 
+ #

--- a/libs/libcups/patches/200-str4181.patch
+++ b/libs/libcups/patches/200-str4181.patch
@@ -1,0 +1,13 @@
+--- a/backend/ipp.c
++++ b/backend/ipp.c
+@@ -1787,6 +1787,10 @@ main(int  argc,				/* I - Number of comm
+ 	  ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD,
+ 		       "compression", NULL, compression);
+ 
++        if (compression)
++	  ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD,
++		       "compression", NULL, compression);
++
+ 	fprintf(stderr, "DEBUG: Sending file %d using chunking...\n", i + 1);
+ 	fprintf(stderr, "DEBUG: IPP/%d.%d %s #%d\n", version / 10, version % 10, ippOpString(ippGetOperation(request)), ippGetRequestId(request));
+ 	debug_attributes(request);

--- a/utils/hplip/Makefile
+++ b/utils/hplip/Makefile
@@ -1,0 +1,104 @@
+#
+# Copyright (C) 2006-2011 OpenWrt.org
+# Copyright (C) 2017 Luiz Angelo Daros de Luca <luizluca@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=hplip
+PKG_VERSION:=3.17.6
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@SF/hplip
+PKG_HASH:=80287834aad7e3fa30f2e252ff281d351e3f2eb15267ac541531353dc7b5107e
+PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
+PKG_LICENSE:=GPL-2.0 GPL-2.0+
+PKG_LICENSE_FILES:=COPYING LICENSE
+
+PKG_BUILD_DEPENDS := python libcups
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/hplip/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=HP Linux Imaging and Printing
+  URL:=http://sourceforge.net/projects/hplip/
+endef
+
+define Package/hplip/Default/description
+	HPLIP is an HP developed solution for printing, scanning, and faxing with HP inkjet and laser based printers in Linux.
+endef
+
+define Package/hplip-common
+$(call Package/hplip/Default)
+  TITLE+= (common files)
+  #DEPENDS+=+libjpeg +libtiff +libusb-compat
+  DEPENDS+=+libusb-compat
+endef
+
+define Package/hplip-common/description
+$(call Package/hplip/Default/description)
+
+These are common files shared between subpackages
+endef
+
+define Package/hplip-sane
+$(call Package/hplip/Default)
+  TITLE+= (scanner drivers)
+  DEPENDS+=+libsane +hplip-common
+endef
+
+define Package/hplip-sane/description
+$(call Package/hplip/Default/description)
+
+S.A.N.E backend for HP Scanners
+endef
+
+CONFIGURE_ARGS += \
+	--disable-gui-build \
+	--disable-network-build \
+	--disable-fax-build \
+	--disable-pp-build \
+	--disable-doc-build \
+	--disable-dbus-build \
+	--enable-lite-build
+
+define Package/hplip-common/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/.libs/libhpip.so* $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/.libs/libhpmud.so* $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/etc/hp
+	$(CP) $(PKG_BUILD_DIR)/hplip.conf $(1)/etc/hp/hplip.conf
+
+	$(INSTALL_DIR) $(1)/usr/share/hplip/data/models/
+	$(CP) $(PKG_BUILD_DIR)/data/models/models.dat $(1)/usr/share/hplip/data/models/
+
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/usb/
+	$(INSTALL_BIN) ./files/20-hplip $(1)/etc/hotplug.d/usb/
+endef
+
+define Package/hplip-sane/install
+	$(INSTALL_DIR) $(1)/usr/lib/sane
+	$(CP) $(PKG_BUILD_DIR)/.libs/libsane-hpaio.so* $(1)/usr/lib/sane
+
+	$(INSTALL_DIR) $(1)/etc/sane.d/dll.d/
+	$(INSTALL_DATA) ./files/hplib.conf $(1)/etc/sane.d/dll.d/hplib
+endef
+
+define Package/hplip-common/conffiles
+/etc/hp/hplip.conf
+endef
+
+define Package/hplip-sane/conffiles
+/etc/sane.d/dll.d/hplib
+endef
+
+$(eval $(call BuildPackage,hplip-common))
+$(eval $(call BuildPackage,hplip-sane))

--- a/utils/hplip/files/20-hplip
+++ b/utils/hplip/files/20-hplip
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Copyright (C) 2009 OpenWrt.org
+
+
+case "$ACTION" in
+        add)
+                # You have to figure out your PRODUCT id. Uncomment the line below,
+                # attach and detach your HP USB printer to find your id in /tmp/hplip.test.
+                # It will look like "Found 3f0/1717/100 on /proc/bus/usb/002/009"
+                # Replace 3f0/1717/100 below with your id.
+                #
+                # echo "Found $PRODUCT on $DEVICE" > /tmp/hplip.test
+
+                [ "$PRODUCT" = "3f0/1717/100" ] && chown nobody $DEVICE && chmod 666 $DEVICE
+                ;;
+        remove)
+                # device is gone
+                ;;
+esac

--- a/utils/hplip/files/hplib.conf
+++ b/utils/hplip/files/hplib.conf
@@ -1,0 +1,2 @@
+# Load the hplib driver
+hpaio

--- a/utils/hplip/patches/010-libusb_fix.patch
+++ b/utils/hplip/patches/010-libusb_fix.patch
@@ -1,0 +1,13 @@
+--- a/configure.in
++++ b/configure.in
+@@ -561,6 +561,10 @@ if test "$hpijs_only_build" = "no" && te
+    else
+       AC_CHECK_LIB([usb-1.0], [libusb_init], [LIBS="$LIBS"], [AC_MSG_ERROR([cannot find libusb 1.0 support], 2)])
+       AC_CHECK_HEADERS(libusb-1.0/libusb.h, ,[AC_MSG_ERROR([cannot find libusb-1.0-devel support], 11)])
++      PKG_CHECK_MODULES(LIBUSB_1_0, [ libusb-1.0 >= 1.0.0 ], have_libusb_1_0=yes, have_libusb_1_0=no)
++      if test "$have_libusb_1_0" = "yes"; then
++        CFLAGS="$CFLAGS $LIBUSB_1_0_CFLAGS"
++      fi
+    fi
+ fi
+ 

--- a/utils/hplip/patches/020-remove_cups_dep_on_scan.patch
+++ b/utils/hplip/patches/020-remove_cups_dep_on_scan.patch
@@ -1,0 +1,163 @@
+--- a/scan/sane/hpaio.c
++++ b/scan/sane/hpaio.c
+@@ -34,7 +34,6 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <cups/cups.h>
+ #include "hpmud.h"
+ #include "hpip.h"
+ #include "hp_ipp.h"
+@@ -144,98 +143,6 @@ static int GetUriLine(char *buf, char *u
+    return i;
+ }
+ 
+-static int AddCupsList(char *uri, char ***printer)
+-{
+-   int i, stat=1;
+-
+-   /* Look for hp network URIs only. */
+-   if (strncasecmp(uri, "hp:/net/", 8) !=0)
+-      goto bugout;
+-
+-   if (*printer == NULL)
+-   {
+-      /* Allocate array of string pointers. */
+-      *printer = malloc(sizeof(char *) * MAX_DEVICE);
+-      memset(*printer, 0, sizeof(char *) * MAX_DEVICE);
+-   }
+-
+-   /* Ignor duplicates (ie: printer queues using the same device). */
+-   for (i=0; (*printer)[i] != NULL && i<MAX_DEVICE; i++)
+-   {
+-      if (strcmp((*printer)[i], uri) == 0)
+-         goto bugout;
+-   }
+-
+-   /* Find empty slot in array of pointers. */
+-   for (i=0; i<MAX_DEVICE; i++)
+-   {
+-      if ((*printer)[i] == NULL)
+-      {
+-         (*printer)[i] = strdup(uri);
+-         break;
+-      }
+-   }
+-
+-   stat = 0;
+-
+-bugout:
+-
+-   return stat;
+-}
+-
+-
+-static int GetCupsPrinters(char ***printer)
+-{
+-   http_t *http=NULL;     /* HTTP object */
+-   ipp_t *request=NULL;  /* IPP request object */
+-   ipp_t *response=NULL; /* IPP response object */
+-   ipp_attribute_t *attr;     /* Current IPP attribute */
+-   int cnt=0;
+-
+-   /* Connect to the HTTP server */
+-   if ((http = httpConnectEncrypt(cupsServer(), ippPort(), cupsEncryption())) == NULL)
+-      goto bugout;
+-
+-   /* Assemble the IPP request */
+-   request = ippNew();
+-
+-   ippSetOperation( request, CUPS_GET_PRINTERS );
+-   ippSetRequestId( request, 1 );
+-
+-   ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_CHARSET, "attributes-charset", NULL, "utf-8");
+-   ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_LANGUAGE, "attributes-natural-language", NULL, "en");
+-   ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD, "requested-attributes", NULL, "device-uri");
+-
+-   /* Send the request and get a response. */
+-   if ((response = cupsDoRequest(http, request, "/")) == NULL)
+-      goto bugout;
+-
+-   for (attr = ippFirstAttribute ( response ); attr != NULL; attr = ippNextAttribute( response ))
+-   {
+-      /* Skip leading attributes until we hit a printer. */
+-      while (attr != NULL && ippGetGroupTag( attr ) != IPP_TAG_PRINTER)
+-         attr = ippNextAttribute( response );
+-
+-      if (attr == NULL)
+-         break;
+-
+-      while (attr != NULL && ippGetGroupTag( attr ) == IPP_TAG_PRINTER)
+-      {
+-         if (strcmp(ippGetName( attr ), "device-uri") == 0 && ippGetValueTag( attr ) == IPP_TAG_URI && AddCupsList(ippGetString( attr, 0, NULL ), printer) == 0)
+-            cnt++;
+-         attr = ippNextAttribute( response );
+-      }
+-
+-      if (attr == NULL)
+-         break;
+-   }
+-
+-   ippDelete(response);
+-
+- bugout:
+-   return cnt;
+-}
+-
+ static int AddDevice(char *uri)
+ {
+     struct hpmud_model_attributes ma;
+@@ -264,7 +171,6 @@ static int DevDiscovery(int localOnly)
+     char uri[HPMUD_LINE_SIZE];
+     char *tail = message;
+     int i, scan_type, cnt=0, total=0, bytes_read;
+-    char **cups_printer=NULL;     /* list of printers */
+     char* token = NULL;
+     enum HPMUD_RESULT stat;
+ 
+@@ -279,34 +185,6 @@ static int DevDiscovery(int localOnly)
+         total += AddDevice(uri);
+     }
+ 
+-    /* Look for Network Scan devices if localonly flag if FALSE. */
+-    if (!localOnly)
+-    {
+-        /* Look for all-in-one scan devices for which print queue created */
+-        cnt = GetCupsPrinters(&cups_printer);
+-        for (i=0; i<cnt; i++)
+-        {
+-            total += AddDevice(cups_printer[i]);
+-            free(cups_printer[i]);
+-        }
+-        if (cups_printer)
+-            free(cups_printer);
+-#ifdef HAVE_LIBNETSNMP
+-        /* Discover NW scanners using Bonjour*/
+-        bytes_read = mdns_probe_nw_scanners(message, sizeof(message), &cnt);
+-        token = strtok(message, ";");
+-        while (token)
+-        {
+-            total += AddDevice(token);
+-            token = strtok(NULL, ";");
+-        }
+-#endif
+-        if(!total)
+-        {          
+-          SendScanEvent("hpaio:/net/HP_Scan_Devices?ip=1.1.1.1", EVENT_ERROR_NO_PROBED_DEVICES_FOUND);
+-        }
+-    }
+-
+ bugout:
+    return total;
+ }
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -60,7 +60,7 @@ else
+ libsane_hpaio_la_LDFLAGS = -version-info 1:0:0
+ endif
+ # The following is a interlibrary dependency that must be compiled first.
+-libsane_hpaio_la_LIBADD = libhpip.la libhpmud.la libhpipp.la $(DBUS_LIBS) -lcups -ldl
++libsane_hpaio_la_LIBADD = libhpip.la libhpmud.la libhpipp.la $(DBUS_LIBS) -ldl
+ #libsane_hpaio_la_CFLAGS = -DWITH_NONAMESPACES -DSOAP_DEBUG
+ libsane_hpaio_la_CFLAGS = $(DBUS_CFLAGS) -Iprotocol
+ 

--- a/utils/hplip/patches/030-replace_unsafe_memcpy_with_memmove.patch
+++ b/utils/hplip/patches/030-replace_unsafe_memcpy_with_memmove.patch
@@ -1,0 +1,11 @@
+--- a/io/hpmud/musb.c
++++ b/io/hpmud/musb.c
+@@ -775,7 +775,7 @@ static int device_id(int fd, unsigned ch
+         len = size-1;   /* leave byte for zero termination */
+     if (len > 2)
+         len -= 2;
+-    memcpy(buffer, buffer+2, len);    /* remove length */
++    memmove(buffer, buffer+2, len);    /* remove length */
+     buffer[len]=0;
+     DBG("read actual device_id successfully fd=%d len=%d\n", fd, len);
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE trunk and 17.01.2 for x86 and ar71xx
Run tested: LEDE 17.01.0 on ar71xx (tl-wr2543nd)

Description:

I have maintained hplip in parallel repo since CC as cups got unmaintained. I tried to isolate the usage of cups inside hplip but it is too complex. cups is a hard requirement for hplip. You can opt-out the hplip-sane part, not the cups one.

I managed to simplify cups package in order to only build the files hplip needed (libcups.so, libcups.so, cups-config and headers). I disabled all install so no ipk is generated. The PKG_NAME is still cups as it would also mess with the builddir and patches, but I renamed the package directory to libcups and put it under lib. If there is a cleaner way for anything I did, please, let me know.

On the sane-backends part, I disabled (commented) sane-cups package as without cups service, it is useless.

Once a full cups is imported, it might conflict with libcups, which should immediately be removed (gladly). Also, sane-cups will need to be reactivated.