### PR TITLE
utils/ccid: Update to 1.4.27

### DIFF
--- a/utils/ccid/Makefile
+++ b/utils/ccid/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ccid
-PKG_VERSION:=1.4.26
+PKG_VERSION:=1.4.27
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=https://alioth.debian.org/frs/download.php/file/4205
-PKG_MD5SUM:=3267bf708ab780c02f01f6241b7c7277cb892d30fd1179a9926a8cc0ca40be2f
+PKG_SOURCE_URL:=https://alioth.debian.org/frs/download.php/file/4218
+PKG_HASH:=a660e269606986cb94840ad5ba802ffb0cd23dd12b98f69a35035e0deb9dd137
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=LGPL-2.1+
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: mvebu, Linksys WRT3200ACM, LEDE trunk
Run tested: mvebu, Linksys WRT3200ACM, LEDE trunk

Description:
Update ccid to 1.4.27
Replace obsolete tarball hash variable with PKG_HASH

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>