### PR TITLE
/net/tunneldigger: Add Tunneldigger package

### DIFF
--- a/net/tunneldigger/Makefile
+++ b/net/tunneldigger/Makefile
@@ -1,0 +1,54 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tunneldigger
+PKG_VERSION:=0.3.0
+PKG_RELEASE:=1
+PKG_REV:=235e111fb8fa02c4687af7f695e21204d9d28fe6
+PKG_MAINTAINER:=Robert Marko <robimarko@gmail.com>
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/wlanslovenija/tunneldigger.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=$(PKG_REV)
+PKG_MIRROR_HASH:=bc8ced8c789f5af997ef4a1d97ca03900469f2455529e318b32647e3cd9dbc3b
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/tunneldigger
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libnl-tiny +kmod-l2tp +kmod-l2tp-ip +kmod-l2tp-eth +librt +libpthread
+  TITLE:=tunneldigger
+endef
+
+define Package/tunneldigger/description
+  Tunneldigger is one of the projects of wlan slovenija open wireless network. 
+  It is a simple VPN tunneling solution based on L2TPv3 tunnels supported in recent Linux kernels.
+endef
+
+TARGET_CFLAGS += \
+	-I$(STAGING_DIR)/usr/include/libnl-tiny \
+	-I$(STAGING_DIR)/usr/include \
+	-DLIBNL_TINY
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	mv $(PKG_BUILD_DIR)/client/* $(PKG_BUILD_DIR)
+	sed -i s/-lnl/-lnl-tiny/g $(PKG_BUILD_DIR)/Makefile
+endef
+
+define Package/tunneldigger/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/l2tp_client $(1)/usr/bin/tunneldigger
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/tunneldigger.init $(1)/etc/init.d/tunneldigger
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/config.default $(1)/etc/config/tunneldigger
+endef
+
+define Package/tunneldigger/conffiles
+/etc/config/tunneldigger
+endef
+
+$(eval $(call BuildPackage,tunneldigger))

--- a/net/tunneldigger/files/config.default
+++ b/net/tunneldigger/files/config.default
@@ -1,0 +1,8 @@
+config broker
+	list address 'x.y.z.w:8942'
+	list address 'x.y.z.w:53'
+	list address 'x.y.z.w:123'
+	option uuid 'abcd'
+	option interface 'digger0'
+	option limit_bw_down '1024'
+	option enabled '0'

--- a/net/tunneldigger/files/tunneldigger.init
+++ b/net/tunneldigger/files/tunneldigger.init
@@ -1,0 +1,75 @@
+#!/bin/sh /etc/rc.common
+
+. $IPKG_INSTROOT/lib/functions/network.sh
+
+START=90
+
+PIDPATH=/var/run
+tunnel_id=1
+
+missing() {
+	echo "Not starting tunneldigger - missing $1" >&2
+}
+
+config_cb() {
+	local cfg="$CONFIG_SECTION"
+	config_get configname "$cfg" TYPE
+	case "$configname" in
+		broker)
+			config_get_bool enabled "$cfg" enabled 1
+			config_get addresses "$cfg" address
+			config_get uuid "$cfg" uuid
+			config_get interface "$cfg" interface
+			config_get limit_bw_down "$cfg" limit_bw_down
+			config_get hook_script "$cfg" hook_script
+			config_get bind_interface "$cfg" bind_interface
+			
+			[ $enabled -eq 0 ] && return
+
+			local broker_opts=""
+			for address in $addresses; do
+			  append broker_opts "-b ${address}"
+			done
+
+			[ ! -z "${limit_bw_down}" ] && append broker_opts "-L ${limit_bw_down}"
+			[ ! -z "${hook_script}" ] && append broker_opts "-s ${hook_script}"
+			[ ! -z "${bind_interface}" ] && {
+				# Resolve logical interface name.
+				unset _bind_interface
+				network_get_device _bind_interface "${bind_interface}" || _bind_interface="${bind_interface}"
+				append broker_opts "-I ${_bind_interface}"
+			}
+
+			if [ -z "$uuid" ]; then
+				missing uuid
+				return
+			elif [ -z "$interface" ]; then
+				missing interface
+				return
+			fi
+
+			echo "Starting tunneldigger on ${interface}"
+			/sbin/start-stop-daemon -S -q -b -m -p ${PIDPATH}/tunneldigger.${interface}.pid -x /usr/bin/tunneldigger -- -u ${uuid} -i ${interface} -t ${tunnel_id} ${broker_opts}
+
+			let tunnel_id++
+		;;
+	esac
+}
+
+start() {
+	config_load tunneldigger
+}
+
+stop() {
+	for PIDFILE in `find ${PIDPATH}/ -name "tunneldigger\.*\.pid"`; do
+		PID="$(cat ${PIDFILE})"
+		IFACE="$(echo ${PIDFILE} | awk -F\/tunneldigger '{print $2}' | cut -d'.' -f2)"
+		echo "Stopping tunneldigger for interface ${IFACE}"
+		start-stop-daemon -K -q -p $PIDFILE 
+		while test -d "/proc/${PID}"; do
+			echo "  waiting for tunneldigger to stop"
+			sleep 1
+		done
+		echo "  tunneldigger stopped"
+	done
+}


### PR DESCRIPTION
Add Tunneldigger package.

Tunneldigger is one of the projects of wlan slovenija open wireless network. It is a simple VPN tunneling solution based on L2TPv3 tunnels supported in recent Linux kernels.
It is used for VPN tunneling in wlan slovenija and otvorenamreza.org wireless networks.

Building tested in lede-sdk-17.01.1-ar71xx-generic_gcc-5.4.0_musl-1.1.16.Linux-x86_64.
Builds without issues.
Signed-off-by: Robert Marko <robimarko@gmail.com>
