### PR TITLE
lighttpd: use procd-based init.d script

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.45
-PKG_RELEASE:=3
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x

--- a/net/lighttpd/files/lighttpd.init
+++ b/net/lighttpd/files/lighttpd.init
@@ -1,26 +1,30 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2006-2011 OpenWrt.org
 
-SERVICE_USE_PID=1
-
 START=50
+STOP=50
 
-start() {
+USE_PROCD=1
+PROG=/usr/sbin/lighttpd
+
+validate_conf() {
+	$PROG -tt -f /etc/lighttpd/lighttpd.conf >/dev/null 2>&1 || {
+		echo "validation failed"
+		return 1
+	}
+}
+
+start_service() {
 	user_exists http || user_add http
 	[ -d /var/log/lighttpd ] || {
 		mkdir -m 0775 -p /var/log/lighttpd
 		chgrp www-data /var/log/lighttpd
 	}
-	service_start /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf
-}
 
-stop() {
-	service_stop /usr/sbin/lighttpd
-}
+	validate_conf || exit 1
 
-restart() {
-	/usr/sbin/lighttpd -tt -f /etc/lighttpd/lighttpd.conf || exit 1
-	stop
-	start
+	procd_open_instance
+	procd_set_param command $PROG -D -f /etc/lighttpd/lighttpd.conf
+	procd_close_instance
 }
 


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, generic, built against LEDE HEAD (21f25bc)
Run tested: same, installed rebuilt .ipkg and ran it

Description:

`start` and `stop` work properly.