### PR TITLE
openssh: if we don't generate a dsa key we shouldn't look for it

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
 PKG_VERSION:=7.5p1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \

--- a/net/openssh/patches/900-remove-dsa-key-file-patch.patch
+++ b/net/openssh/patches/900-remove-dsa-key-file-patch.patch
@@ -1,0 +1,13 @@
+--- a/servconf.c	2017-03-19 20:39:27.000000000 -0600
++++ b/servconf.c	2017-06-01 19:12:51.338645002 -0600
+@@ -201,8 +201,10 @@
+ 		/* fill default hostkeys for protocols */
+ 		options->host_key_files[options->num_host_key_files++] =
+ 		    _PATH_HOST_RSA_KEY_FILE;
++#if 0
+ 		options->host_key_files[options->num_host_key_files++] =
+ 		    _PATH_HOST_DSA_KEY_FILE;
++#endif
+ #ifdef OPENSSL_HAS_ECC
+ 		options->host_key_files[options->num_host_key_files++] =
+ 		    _PATH_HOST_ECDSA_KEY_FILE;


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: x86_64, generic, LEDE HEAD (21f25bc4a32)
Run tested: same, built and reinstalled w/ opkg

Description:

Stopped the service.
Copied over the opkg and installed it.
Restarted the service.
Checked for:

`% egrep 'sshd\[[0-9]*\]: error: Could not load host key: /etc/ssh/ssh_host_dsa_key' /var/log/messages`

and didn't find any new messages post restart.