### PR TITLE
netatalk: fix config files permissions

### DIFF
--- a/net/netatalk/Makefile
+++ b/net/netatalk/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netatalk
 PKG_VERSION:=3.1.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/netatalk
@@ -35,10 +35,6 @@ define Package/netatalk/decription
   Netatalk is a freely-available Open Source AFP fileserver.
   It also provides a kernel level implementation of the AppleTalk
   Protocol Suite.
-endef
-
-define Package/netatalk/conffiles
-/etc/netatalk/afpd.conf
 endef
 
 TARGET_CFLAGS += -std=gnu99
@@ -89,8 +85,8 @@ define Package/netatalk/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/cnid_dbd $(1)/usr/sbin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/cnid_metad $(1)/usr/sbin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/uams/*.so $(1)/usr/lib/uams/
-	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/afp.conf $(1)/etc/
-	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/extmap.conf $(1)/etc/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/afp.conf $(1)/etc/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/extmap.conf $(1)/etc/
 	$(INSTALL_BIN) ./files/afpd.init $(1)/etc/init.d/afpd
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/lede-project/source/commit/334f8f4fc33f5fbc52e08477f00971f1e66405ae ar71xx
Run tested: N/A

-------------------------------

Fixes https://github.com/openwrt/packages/issues/4318

After checking in the ipkg-install dir of netatalk,
it seems that the permissions it sets to the conf-files
are 644.

 ~ ls -la lede/build_dir/target-mips_24kc_musl/netatalk-3.1.11/ipkg-install/etc
 -rw-r--r-- 1 sandu sandu   226 iun  5 20:53 afp.conf
 -rw-r--r-- 1 sandu sandu  1948 iun  5 20:53 dbus-session.conf
 -rw-r--r-- 1 sandu sandu 25037 iun  5 20:53 extmap.conf

While the Package/netatalk/install build rule overrides
them to 600.

According to
* https://github.com/openwrt/packages/issues/4318
* https://forum.lede-project.org/t/help-with-apple-filesharing-protocol-for-time-machine/3259/5
this is a problem in some setups.

So, this patch changes them to what the netatalk
package creators intended initially (i.e. 644).

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>