### PR TITLE
cryptodev-linux: bump to last commit

### DIFF
--- a/utils/cryptodev-linux/Makefile
+++ b/utils/cryptodev-linux/Makefile
@@ -10,14 +10,13 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=cryptodev-linux
-PKG_VERSION:=1.9
+PKG_VERSION:=1.9.git-2017-05-29
 PKG_RELEASE:=1
 
+PKG_SOURCE_URL:=https://github.com/cryptodev-linux/cryptodev-linux
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
-PKG_MIRROR_HASH:=d2b49408682795a0e200c0e54a8605f72be4b11088e07b1cd4d48f6c1427b0f4
-PKG_SOURCE_URL:=https://github.com/cryptodev-linux/cryptodev-linux.git
-PKG_SOURCE_VERSION:=87d959d9a279c055b361de8e730fab6a7144edd7
+PKG_SOURCE_VERSION:=a705360197260d28535746ae98c461ba2cfb7a9e
+PKG_MIRROR_HASH:=553069ecf1f3d5d5652404aaf438610f555c94db4369c7c1db85210c4e3cdfee
 
 PKG_MAINTAINER:=Ansuel Smith ansuelsmth@gmail.com
 


### PR DESCRIPTION
Fix:
This patch fixes a kernel crash observed with cipher-gcm test.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>