### PR TITLE
Import efivar and efibootmgr utilities

### DIFF
--- a/libs/efivar/Makefile
+++ b/libs/efivar/Makefile
@@ -1,0 +1,66 @@
+#
+# Copyright (C) 2007-2011 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=efivar
+PKG_VERSION:=30
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://github.com/rhinstaller/efivar/releases/download/$(PKG_VERSION)/ \
+	http://mirror.opencompute.org/onie/
+PKG_HASH:=1f5720a9434ddb29a5cb8213e4e3973e212d90eff95dd9b173a5444f48b5128b
+PKG_MAINTAINER:=Curt Brune <curt@cumulusnetworks.com>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_PARALLEL:=1
+
+PKG_LICENSE:=LGPLv2.1
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/efivar
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=@TARGET_x86||@TARGET_arm64 +libpopt
+  TITLE:=Tools and libraries to manipulate EFI variables
+  URL:=https://github.com/rhinstaller/efivar
+endef
+
+CONFIGURE_ARGS +=
+TARGET_CFLAGS +=
+TARGET_LDFLAGS +=
+CONFIGURE_VARS +=
+MAKE_FLAGS += \
+	libdir=/usr/lib \
+	BINTARGETS=efivar
+
+# makeguids is an internal host tool and must be built separately with
+# the host CC, otherwise it is cross compiled.
+define Build/Compile
+	CFLAGS="$(HOST_CFLAGS) -std=gnu99" \
+		$(MAKE) -C $(PKG_BUILD_DIR)/src gcc_cflags= makeguids
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/efivar
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/efivar/*.h $(1)/usr/include/efivar/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libefi*.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/efi*.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/efivar/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libefi*.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,efivar))

--- a/libs/efivar/patches/0001-Use-z-muldefs-to-avoid-the-multiple-definitions-bug-.patch
+++ b/libs/efivar/patches/0001-Use-z-muldefs-to-avoid-the-multiple-definitions-bug-.patch
@@ -1,0 +1,29 @@
+From 314eb67b239e60c2ed3700e2baf9cd0e590465f3 Mon Sep 17 00:00:00 2001
+From: Peter Jones <pjones@redhat.com>
+Date: Thu, 27 Oct 2016 09:19:18 -0400
+Subject: [PATCH] Use -z muldefs to avoid the multiple definitions bug
+ without -flto
+
+This fixes github issue #64
+
+Signed-off-by: Peter Jones <pjones@redhat.com>
+Signed-off-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+---
+ Make.defaults | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Make.defaults b/Make.defaults
+index aa974d9..c9d599f 100644
+--- a/Make.defaults
++++ b/Make.defaults
+@@ -32,6 +32,7 @@ cflags	= $(CFLAGS) -I${TOPDIR}/src/include/efivar/ \
+ clang_ccldflags =
+ gcc_ccldflags =
+ ccldflags = $(cflags) -L. $(CCLDFLAGS) $(LDFLAGS) \
++	-Wl,-z,muldefs \
+ 	$(if $(findstring clang,$(CCLD)),$(clang_ccldflags),) \
+ 	$(if $(findstring gcc,$(CCLD)),$(gcc_ccldflags),) \
+ 	$(call pkg-config-ccldflags)
+-- 
+2.10.2
+

--- a/libs/efivar/patches/0002-Allow-build-with-uClibc.patch
+++ b/libs/efivar/patches/0002-Allow-build-with-uClibc.patch
@@ -1,0 +1,38 @@
+From 2255601757a8a58baddad2d37d0bcc6b003a3732 Mon Sep 17 00:00:00 2001
+From: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Date: Fri, 25 Nov 2016 19:42:27 +0200
+Subject: [PATCH] Allow build with uClibc
+
+Basically this replaces type definitions in <uchar.h>.
+
+Signed-off-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+---
+ src/export.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/export.c b/src/export.c
+index 7f2d4dd..72c02d1 100644
+--- a/src/export.c
++++ b/src/export.c
+@@ -21,11 +21,17 @@
+ #include <inttypes.h>
+ #include <stdint.h>
+ #include <stdlib.h>
+-#include <uchar.h>
+ 
+ #include <efivar.h>
+ #include "lib.h"
+ 
++#ifdef __UCLIBC__
++typedef int_least16_t char16_t;
++typedef int_least32_t char32_t;
++#else
++#include <uchar.h>
++#endif
++
+ #define EFIVAR_MAGIC 0xf3df1597
+ 
+ #define ATTRS_UNSET 0xa5a5a5a5a5a5a5a5
+-- 
+2.10.2
+

--- a/libs/efivar/patches/0003-Allow-build-with-musl.patch
+++ b/libs/efivar/patches/0003-Allow-build-with-musl.patch
@@ -1,0 +1,43 @@
+musl's byteswapping definitions are incompatible with the use in this program,
+just copy them from the header.
+
+Inspired by:
+
+  commit 0d259ad72bb04c5a9bc1c83d35b1cd327f4240e6
+  Author: Aric Belsito <lluixhi@gmail.com>
+  Date:   Mon Nov 21 13:25:37 2016 -0800
+
+      sys-libs/efivar: Add 30
+
+From: git@github.com:gentoo/musl.git
+
+diff --recursive -U5 efivar-30/src/makeguids.c efivar-30.b/src/makeguids.c
+--- efivar-30/src/makeguids.c	2016-09-27 13:35:22.000000000 -0700
++++ efivar-30.b/src/makeguids.c	2017-06-05 16:24:05.078378721 -0700
+@@ -149,21 +149,22 @@
+ 
+ 	fprintf(header, "#ifndef EFIVAR_GUIDS_H\n#define EFIVAR_GUIDS_H 1\n\n");
+ 
+ 	fprintf(symout, "#include <efivar.h>\n");
+ 	fprintf(symout, "#include <endian.h>\n");
++	fprintf(symout, "#include <linux/swab.h>\n");
+ 	fprintf(symout, """\n\
+ #if BYTE_ORDER == BIG_ENDIAN\n\
+ #define cpu_to_be32(n) (n)\n\
+ #define cpu_to_be16(n) (n)\n\
+-#define cpu_to_le32(n) (__bswap_constant_32(n))\n\
+-#define cpu_to_le16(n) (__bswap_constant_16(n))\n\
++#define cpu_to_le32(n) (___constant_swab32(n))\n\
++#define cpu_to_le16(n) (___constant_swab16(n))\n\
+ #else\n\
+ #define cpu_to_le32(n) (n)\n\
+ #define cpu_to_le16(n) (n)\n\
+-#define cpu_to_be32(n) (__bswap_constant_32(n))\n\
+-#define cpu_to_be16(n) (__bswap_constant_16(n))\n\
++#define cpu_to_be32(n) (___constant_swab32(n))\n\
++#define cpu_to_be16(n) (___constant_swab16(n))\n\
+ #endif\n\
+ """);
+ 
+ 	for (unsigned int i = 0; i < line-1; i++) {
+ 		uint8_t *guid_data = (uint8_t *) &outbuf[i].guid;

--- a/libs/efivar/patches/0004-Define-strndupa-for-musl.patch
+++ b/libs/efivar/patches/0004-Define-strndupa-for-musl.patch
@@ -1,0 +1,35 @@
+The musl libc does not define strndupa()
+
+Inspired by:
+
+  commit 0d259ad72bb04c5a9bc1c83d35b1cd327f4240e6
+  Author: Aric Belsito <lluixhi@gmail.com>
+  Date:   Mon Nov 21 13:25:37 2016 -0800
+
+      sys-libs/efivar: Add 30
+
+From: git@github.com:gentoo/musl.git
+
+diff --recursive -U5 efivar-30/src/linux.c efivar-30.b/src/linux.c
+--- efivar-30/src/linux.c	2016-09-27 13:35:22.000000000 -0700
++++ efivar-30.b/src/linux.c	2017-06-05 16:29:39.578277681 -0700
+@@ -46,10 +46,19 @@
+ 
+ #include "dp.h"
+ #include "linux.h"
+ #include "util.h"
+ 
++#ifndef strndupa
++#define strndupa(s, n) \
++       (__extension__ ({const char *__in = (s); \
++                        size_t __len = strnlen (__in, (n)) + 1; \
++                        char *__out = (char *) alloca (__len); \
++                        __out[__len-1] = '\0'; \
++                        (char *) memcpy (__out, __in, __len-1);}))
++#endif
++
+ int
+ __attribute__((__visibility__ ("hidden")))
+ set_disk_and_part_name(struct disk_info *info)
+ {
+ 	char *linkbuf;

--- a/utils/efibootmgr/Makefile
+++ b/utils/efibootmgr/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2007-2011 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=efibootmgr
+PKG_VERSION:=14
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://github.com/rhinstaller/efibootmgr/releases/download/$(PKG_VERSION)/ \
+	http://mirror.opencompute.org/onie/
+PKG_HASH:=377ec16484414b80afd1b8a586153d7ef55ccf048638080101d49b7c77f37ad8
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_PARALLEL:=1
+
+PKG_MAINTAINER:=Curt Brune <curt@cumulusnetworks.com>
+PKG_LICENSE:=GPLv2+
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/efibootmgr
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+efivar +gettext
+  TITLE:=Tool to manipulate EFI Boot Manager
+  URL:=https://github.com/rhinstaller/efibootmgr
+endef
+
+CONFIGURE_ARGS +=
+TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include/efivar
+TARGET_LDFLAGS +=
+CONFIGURE_VARS +=
+MAKE_FLAGS +=
+
+define Package/efibootmgr/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/efibootmgr $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,efibootmgr))

--- a/utils/efibootmgr/patches/0001-Allow-build-with-uClibc.patch
+++ b/utils/efibootmgr/patches/0001-Allow-build-with-uClibc.patch
@@ -1,0 +1,40 @@
+From bbfcc60497c326576bb23cb01d90115ef3cf6947 Mon Sep 17 00:00:00 2001
+From: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Date: Fri, 25 Nov 2016 20:26:52 +0200
+Subject: [PATCH] Remove unneeded <uchar.h> include
+
+This fixes the build with uClibc.
+
+Signed-off-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+---
+ src/efibootdump.c | 1 -
+ src/eficonman.c   | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/src/efibootdump.c b/src/efibootdump.c
+index 6ff8360..7c5a1c5 100644
+--- a/src/efibootdump.c
++++ b/src/efibootdump.c
+@@ -19,7 +19,6 @@
+ #include <stdint.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+-#include <uchar.h>
+ #include <unistd.h>
+ 
+ #include "error.h"
+diff --git a/src/eficonman.c b/src/eficonman.c
+index 2c2be38..9bfae79 100644
+--- a/src/eficonman.c
++++ b/src/eficonman.c
+@@ -17,7 +17,6 @@
+ #include <stdint.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+-#include <uchar.h>
+ #include <unistd.h>
+ 
+ #define  _(String) gettext (String)
+-- 
+2.10.2
+


### PR DESCRIPTION
Maintainer: @cbrune
Compile tested: x86_64, virtual machine, OpenWRT commit openwrt/openwrt@c15bd8d6ee8bac11558c6d82bc8260ee8f20568d
Run tested: x86_64, virtual machine, OpenWRT commit openwrt/openwrt@c15bd8d6ee8bac11558c6d82bc8260ee8f20568d.

I built a kernel and cpio initramfs containing efivar and efibootmgr.  After booting I successfully ran the efibootmgr command to display and modify the boot order.

Description:

Import efivar and efibootmgr packages.  These packages allow for manipulating the UEFI boot manager state on UEFI capable systems.