### PR TITLE
adblock: update 2.7.1

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=2.7.0
+PKG_VERSION:=2.7.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -135,7 +135,7 @@ If you use manual configuration for unbound, then just include the following lin
 <pre><code>
 wget (default):
   option adb_fetch="/usr/bin/wget"
-  option adb_fetchparm="--no-config --quiet --no-cache --no-cookies --max-redirect=0 --timeout=10 --no-check-certificate -O"
+  option adb_fetchparm="--quiet --no-cache --no-cookies --max-redirect=0 --timeout=10 --no-check-certificate -O"
 
 aria2c:
   option adb_fetch '/usr/bin/aria2c'
@@ -165,7 +165,7 @@ root@blackhole:~# /etc/init.d/adblock status
   
 **cronjob for a regular block list update (/etc/crontabs/root):**
 <pre><code>
-0 06 * * *    /etc/init.d/adblock start
+0 06 * * *    /etc/init.d/adblock reload
 </code></pre>
   
 **blacklist entry (/etc/adblock/adblock.blacklist):**

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-adb_ver="2.7.0"
+adb_ver="2.7.1"
 adb_sysver="$(ubus -S call system board | jsonfilter -e '@.release.description')"
 adb_enabled=1
 adb_debug=0
@@ -486,7 +486,7 @@ f_main()
         elif [ "${src_name}" = "shalla" ]
         then
             shalla_archive="${adb_tmpdir}/shallalist.tar.gz"
-            "${adb_fetch}" ${adb_fetchparm} "${shalla_archive}" "${url}"
+            "${adb_fetch}" ${adb_fetchparm} "${shalla_archive}" "${url}" 2>/dev/null
             adb_rc=${?}
             if [ ${adb_rc} -eq 0 ]
             then
@@ -503,7 +503,7 @@ f_main()
             rm -f "${shalla_archive}"
             rm -rf "${adb_tmpdir}/BL"
         else
-            "${adb_fetch}" ${adb_fetchparm} "${adb_tmpload}" "${url}"
+            "${adb_fetch}" ${adb_fetchparm} "${adb_tmpload}" "${url}" 2>/dev/null
             adb_rc=${?}
         fi
 


### PR DESCRIPTION
Maintainer: me
Compile tested: -
Run tested: LEDE Reboot SNAPSHOT r4356-7f91cabd0d

Description:
backend:
* cosmetics

frontend:
* "Save & Reply" now distinguish between normal and manual/backup mode
  and triggers an appropriate reload or a start action

Signed-off-by: Dirk Brenken <dev@brenken.org>