### PR TITLE
libs/liblz4: update to v1.7.5

### DIFF
--- a/libs/liblz4/Makefile
+++ b/libs/liblz4/Makefile
@@ -19,7 +19,7 @@ PKG_MAINTAINER:=Darik Horn <dajhorn@vanadac.com>
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/Cyan4973/lz4.git
+PKG_SOURCE_URL:=https://github.com/lz4/lz4.git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk

--- a/libs/liblz4/Makefile
+++ b/libs/liblz4/Makefile
@@ -8,9 +8,10 @@
 include $(TOPDIR)/rules.mk
 
 # Although liblz4 exports a major.minor.patch version, it isn't always
-# incremented for new releases, so use the release tag instead.
+# incremented for new releases. Check the NEWS file and instead use a
+# release tag when appropriate. (eg: PKG_VERSION:=r131)
 PKG_NAME:=liblz4
-PKG_VERSION:=r131
+PKG_VERSION:=v1.7.5
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
Maintainer: @dajhorn
Compile tested: Designated Driver (openwrt-mirror/openwrt@9b4650b3b92e6246b986ac9e3d7c2a80d66b805b)
Run tested: bcm53xx
Description: Minor upstream point release.

Signed-off-by: Darik Horn <dajhorn@vanadac.com>