### PR TITLE
icu: Don't link icudata as a data only library

### DIFF
--- a/libs/icu/Makefile
+++ b/libs/icu/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=icu4c
 PKG_VERSION:=59.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-59_1-src.tgz
 PKG_SOURCE_URL:=http://download.icu-project.org/files/$(PKG_NAME)/$(PKG_VERSION)

--- a/libs/icu/patches/002-Disable-LDFLAGSICUDT-for-Linux.patch
+++ b/libs/icu/patches/002-Disable-LDFLAGSICUDT-for-Linux.patch
@@ -1,0 +1,28 @@
+From 0c82d6aa02c08e41b13c83b14782bd7024e25d59 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 15 Feb 2014 21:06:42 +0000
+Subject: [PATCH] Disable LDFLAGSICUDT for Linux
+
+Upstream-Status: Inappropriate [ OE Configuration ]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ source/config/mh-linux |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config/mh-linux b/config/mh-linux
+index 366f0cc..2689aab 100644
+--- a/config/mh-linux
++++ b/config/mh-linux
+@@ -23,7 +23,7 @@ LD_RPATH= -Wl,-zorigin,-rpath,'$$'ORIGIN
+ LD_RPATH_PRE = -Wl,-rpath,
+ 
+ ## These are the library specific LDFLAGS
+-LDFLAGSICUDT=-nodefaultlibs -nostdlib
++# LDFLAGSICUDT=-nodefaultlibs -nostdlib
+ 
+ ## Compiler switch to embed a library name
+ # The initial tab in the next line is to prevent icu-config from reading it.
+-- 
+1.7.10.4
+


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE r4403-3ff3158, arm_cortex-a7+neon-vfpv4_gcc-5.4.0_musl_eabi, mips_24kc_gcc-5.4.0_musl
Run tested: none

Description:
libicudata.so not build hard-float ABI
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=653457

resend PR (https://github.com/openwrt/packages/pull/3330)

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
