### PR TITLE
python-curl: add new package

### DIFF
--- a/lang/python/python-curl/Makefile
+++ b/lang/python/python-curl/Makefile
@@ -1,0 +1,47 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pycurl
+PKG_VERSION:=7.43.0
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Waldemar Konik <informatyk74@interia.pl>
+PKG_LICENSE:=LGPL-2.1
+PKG_LICENSE_FILE=COPYING-LGPL
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://dl.bintray.com/pycurl/pycurl/
+PKG_HASH:=aa975c19b79b6aa6c0518c0cc2ae33528900478f0b500531dbcdbf05beec584c
+
+PKG_BUILD_DEPENDS:=python libcurl
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+
+define Package/python-curl
+  CATEGORY:=Languages
+  SECTION:=lang
+  SUBMENU:=Python
+  TITLE:=Python module interface to the cURL library
+  URL:=http://pycurl.io/
+  DEPENDS:=+python +libcurl
+endef
+
+define Package/python-curl/description
+Python module interface to the cURL library.
+endef
+
+define Build/Compile
+	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+endef
+
+define Package/python-curl/install
+	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
+	$(CP) \
+		$(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
+		$(1)$(PYTHON_PKG_DIR)
+endef
+
+$(eval $(call BuildPackage,python-curl))


### PR DESCRIPTION
Maintainer: Waldemar Konik <informatyk74@interia.pl>
Compile tested: (x86_64, mips_24kc/tl-wdr4300, LEDE snapshot 2017.06.12, LEDE 17.04.2)
Run tested: (x86_64, LEDE LEDE snapshot 2017.06.12, LEDE 17.04.2 install package, run pyLoad)

Description:

PycURL is a Python interface to libcurl, the multiprotocol file transfer library. Similarly to the urllib Python module, PycURL can be used to fetch objects identified by a URL from a Python program. Beyond simple fetches however PycURL exposes most of the functionality of libcurl.

Signed-off-by: Waldemar Konik <informatyk74@interia.pl>
