### PR TITLE
wireguard: remove misspelled debugging line

### DIFF
--- a/net/wireguard/files/wireguard.sh
+++ b/net/wireguard/files/wireguard.sh
@@ -168,7 +168,6 @@ proto_wireguard_setup() {
     sed -E 's/\[?([0-9.:a-f]+)\]?:([0-9]+)/\1 \2/' | \
     while IFS=$'\t ' read -r key address port; do
     [ -n "${port}" ] || continue
-    echo "adding host depedency for ${address} at ${config}"
     proto_add_host_dependency "${config}" "${address}"
   done
 


### PR DESCRIPTION
There are no other "echo" debug lines in this file, and it seems
clear that this one was accidentally left as a debugging line,
since it misspelled "dependency". So, we just remove this line.

We don't bump the package version, though, because this is
pretty inconsequential.

Maintainer: me / @danrl 