### PR TITLE
openldap: update to 2.4.45

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
-PKG_VERSION:=2.4.44
+PKG_VERSION:=2.4.45
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/ \
 	ftp://sunsite.cnlab-switch.ch/mirror/OpenLDAP/openldap-release/ \
 	ftp://ftp.nl.uu.net/pub/unix/db/openldap/openldap-release/ \
 	ftp://ftp.plig.org/pub/OpenLDAP/openldap-release/
-PKG_MD5SUM:=693ac26de86231f8dcae2b4e9d768e51
+PKG_MD5SUM:=00ff8301277cdfd0af728a6927042a13
 
 PKG_FIXUP:=autoreconf
 


### PR DESCRIPTION
Fixes CVE-2017-9287

Signed-off-by: W. Michael Petullo <mike@flyn.org>