### PR TITLE
net-snmp: add symlink for net-snmp-config into usr/bin

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -209,6 +209,7 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(2)/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/net-snmp-config $(2)/bin/
 	$(SED) 's,=/usr,=$(STAGING_DIR)/usr,g' $(2)/bin/net-snmp-config
+	$(LN) $(STAGING_DIR)/host/bin/net-snmp-config $(STAGING_DIR)/usr/bin/
 
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/net-snmp $(1)/usr/include/


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: x86_64, generic, HEAD (3ff3158)
Run tested:

Built package.  Built another package which relied on libnetsnmp (in this case, php7's snmp functionality).

Description:

A lot of programs using libnetsnmp expect --with-net-snmp-dir=$(STAGING_DIR)/usr to point to the correct path for the bin/net-snmp-config script.