### PR TITLE
libgphoto2: fix configure args to disable libgd

### DIFF
--- a/libs/libgphoto2/Makefile
+++ b/libs/libgphoto2/Makefile
@@ -10,13 +10,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgphoto2
 PKG_VERSION:=2.5.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PORT_VERSION:=0.12.0
 PKG_MAINTAINER:=Leonardo Medici <leonardo_medici@me.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/gphoto
-PKG_MD5SUM:=65acb6cbd2b4f3f46829599f5dabd89c
 PKG_HASH:=d3ce70686fb87d6791b9adcbb6e5693bfbe1cfef9661c23c75eb8a699ec4e274
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING
@@ -436,16 +435,15 @@ CONFIGURE_ARGS += \
 	--enable-static \
 	--disable-rpath \
 	--with-camlibs="all" \
+	--with-gdlib=no \
+	--with-libexif=no \
+	--with-libusb=no \
+	--with-libusb-1.0=auto \
+	--with-libxml-2.0=no \
 	--without-included-ltdl \
+	--without-jpeg \
 	--without-libiconv-prefix \
 	--without-libintl-prefix \
-	--without-gd \
-	--without-jpeg \
-	--with-libexif=no \
-	--without-libxml2 \
-	--with-libxml-2.0=no \
-	--with-libusb-1.0=auto \
-	--with-libusb=no
 
 CONFIGURE_VARS += \
 	CPPFLAGS="$$$$CPPFLAGS $(ICONV_CFLAGS)" \


### PR DESCRIPTION
Maintainer: me / @DocLM
Compile tested: (ramips, mt7688, LEDE 17.01.0)
Run tested: (ramips, mt7688, LEDE 17.01.0)

Description:
Should fix buildbot libgphoto2 build errors

See #4452 