### PR TITLE
openconnect: openconnect-wrapper: rewrite

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=7.08
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/openconnect/files/openconnect-wrapper
+++ b/net/openconnect/files/openconnect-wrapper
@@ -10,32 +10,4 @@ test -z "$1" && exit 1
 
 pwfile=$1
 shift
-
-pidfile=/var/run/ocwrap-$$.pid
-
-cleanup()
-{
-	if ! test -z "$pid";then
-		kill $pid
-		wait $pid
-	fi
-	exit 0
-}
-
-cleanup2()
-{
-	if ! test -z "$pid";then
-		kill -2 $pid
-		wait $pid
-	fi
-	exit 0
-}
-
-trap cleanup2 2
-trap cleanup 1 3 6 15
-
-rm -f "$pidfile"
-/usr/sbin/openconnect $* <$pwfile &
-pid=$!
-
-wait $pid
+exec /usr/sbin/openconnect "$@" <$pwfile


### PR DESCRIPTION
Maintainer: @nmav 
Compile tested: ar71xx HiWiFi HC6361
Run tested: ar71xx HiWiFi HC6361

 - use exec directly to eliminate a level in the process tree
 - use "$@" instead of "$*" to pass arguments to openconnect

According to openconnect(8), openconnect will call vpnc-script to
cleanup before quit when it received SIGINT(2) and will quit immediately
when it received SIGTERM (the default signal by kill command)

Before and after the change, openconnect process will be killed first
with SIGINT sent from netifd.  This was decided by the
'proto_kill_command "$config" 2' notify call in the proto script.

SIGKILL is the only other signal that can be sent from netifd when the
process did not quit on SIGINT on time.  There should be no need to trap
on signal 1 3 6 9 (HUP QUIT ABRT KILL)

Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>