### PR TITLE
travelmate: update 0.8.0

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=0.7.5
+PKG_VERSION:=0.8.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
@@ -17,7 +17,7 @@ define Package/travelmate
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=A wlan connection manager for travel router
-	DEPENDS:=+iw
+	DEPENDS:=+iwinfo
 	PKGARCH:=all
 endef
 

--- a/net/travelmate/files/README.md
+++ b/net/travelmate/files/README.md
@@ -10,7 +10,7 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 * easy setup within normal OpenWrt/LEDE environment
 * strong LuCI-Support to simplify the interface setup
 * fast uplink connections
-* manual / automatic mode support, the latter one checks the existing uplink connection regardless of ifdown event trigger every n seconds
+* manual / automatic mode support, the latter one checks the existing uplink connection regardless of ifdown event trigger actions every n seconds
 * support of devices with multiple radios
 * procd init and hotplug support
 * runtime information available via LuCI & via 'status' init command
@@ -18,7 +18,7 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 
 ## Prerequisites
 * [LEDE](https://www.lede-project.org) 17.01 or latest snapshot
-* iw for wlan scanning
+* iwinfo for wlan scanning
 
 ## LEDE trunk Installation & Usage
 * download the package [here](https://downloads.lede-project.org/snapshots/packages/x86_64/packages)
@@ -26,7 +26,7 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 * configure your network:
     * automatic: use the LuCI frontend with automatic STA interface setup, that's the recommended way
     * manual: see detailed configure steps below
-    * at least you need one AP and one STA interface configured
+    * at least you need one configured AP and one STA interface
 
 ## LuCI travelmate companion package
 * download the package [here](https://downloads.lede-project.org/snapshots/packages/x86_64/luci)

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-trm_ver="0.7.5"
+trm_ver="0.8.0"
 trm_sysver="$(ubus -S call system board | jsonfilter -e '@.release.description')"
 trm_enabled=0
 trm_debug=0
@@ -18,7 +18,7 @@ trm_automatic=1
 trm_maxretry=3
 trm_maxwait=30
 trm_timeout=60
-trm_iw="$(command -v iw)"
+trm_iwinfo="$(command -v iwinfo)"
 trm_radio=""
 trm_rtfile="/tmp/trm_runtime.json"
 
@@ -32,13 +32,17 @@ else
     f_log "error" "system libraries not found"
 fi
 
+# initial wireless recovery
+#
+ubus call network.wireless up
+
 # f_envload: load travelmate environment
 #
 f_envload()
 {
     # initialize lists
     #
-    trm_aplist=""
+    trm_devlist=""
     trm_stalist=""
     trm_radiolist=""
 
@@ -60,9 +64,9 @@ f_envload()
 
     # check for wireless tool
     #
-    if [ -z "${trm_iw}" ]
+    if [ -z "${trm_iwinfo}" ]
     then
-        f_log "error" "no wireless tool found, please install package 'iw'"
+        f_log "error" "no wireless tool found, please install package 'iwinfo'"
     fi
 }
 
@@ -75,11 +79,12 @@ f_prepare()
     local radio="$(uci -q get wireless."${config}".device)"
     local disabled="$(uci -q get wireless."${config}".disabled)"
 
-    if [ "${mode}" = "ap" ] && ([ -z "${disabled}" ] || [ "${disabled}" = "0" ]) && \
-        ([ -z "${trm_radio}" ] || [ "${trm_radio}" = "${radio}" ])
+    if ([ -z "${trm_radio}" ] || [ "${trm_radio}" = "${radio}" ]) && \
+        [ -z "$(printf "%s" "${trm_radiolist}" | grep -Fo " ${radio}")" ]
     then
         trm_radiolist="${trm_radiolist} ${radio}"
-    elif [ "${mode}" = "sta" ]
+    fi
+    if [ "${mode}" = "sta" ]
     then
         trm_stalist="${trm_stalist} ${config}_${radio}"
         if [ -z "${disabled}" ] || [ "${disabled}" = "0" ]
@@ -87,7 +92,7 @@ f_prepare()
             uci -q set wireless."${config}".disabled=1
         fi
     fi
-    f_log "debug" "mode: ${mode}, radio: ${radio}, config: ${config}, disabled: ${disabled}"
+    f_log "debug" "prepare: ${mode}, radio: ${radio}, config: ${config}, disabled: ${disabled}"
 }
 
 # f_check: check interface status
@@ -96,44 +101,43 @@ f_check()
 {
     local ifname radio status cnt=1 mode="${1}"
 
-    ubus call network reload
     trm_ifstatus="false"
+    ubus call network reload
     while [ ${cnt} -le ${trm_maxwait} ]
     do
         status="$(ubus -S call network.wireless status 2>/dev/null)"
         if [ -n "${status}" ]
         then
-            if [ "${mode}" = "ap" ]
+            if [ "${mode}" = "dev" ]
             then
                 for radio in ${trm_radiolist}
                 do
-                    trm_ifstatus="$(printf "%s" "${status}" | jsonfilter -e "@.${radio}.up")"
+                    trm_ifstatus="$(printf "%s" "${status}" | jsonfilter -l1 -e "@.${radio}.up")"
                     if [ "${trm_ifstatus}" = "true" ]
                     then
-                        trm_aplist="${trm_aplist} $(printf "%s" "${status}" | jsonfilter -e "@.${radio}.interfaces[@.config.mode=\"ap\"].ifname")_${radio}"
-                        ifname="${trm_aplist}"
+                        trm_devlist="${trm_devlist} ${radio}"
                     else
-                        trm_aplist=""
-                        trm_ifstatus="false"
+                        trm_devlist=""
                         break
                     fi
                 done
+                ifname="${trm_devlist}"
             else
-                ifname="$(printf "%s" "${status}" | jsonfilter -e '@.*.interfaces[@.config.mode="sta"].ifname')"
+                ifname="$(printf "%s" "${status}" | jsonfilter -l1 -e '@.*.interfaces[@.config.mode="sta"].ifname')"
                 if [ -n "${ifname}" ]
                 then
-                    trm_ifstatus="$(ubus -S call network.interface dump 2>/dev/null | jsonfilter -e "@.interface[@.device=\"${ifname}\"].up")"
+                    trm_ifstatus="$(ubus -S call network.interface dump 2>/dev/null | jsonfilter -l1 -e "@.interface[@.device=\"${ifname}\"].up")"
                 fi
             fi
-        fi
-        if [ "${mode}" = "initial" ] || [ "${trm_ifstatus}" = "true" ]
-        then
-            break
+            if [ "${mode}" = "initial" ] || [ "${trm_ifstatus}" = "true" ]
+            then
+                break
+            fi
         fi
         cnt=$((cnt+1))
         sleep 1
     done
-    f_log "debug" "mode: ${mode}, name: ${ifname}, status: ${trm_ifstatus}, count: ${cnt}, max-wait: ${trm_maxwait}, automatic: ${trm_automatic}"
+    f_log "debug" "check: ${mode}, name: ${ifname}, status: ${trm_ifstatus}, count: ${cnt}, max-wait: ${trm_maxwait}, automatic: ${trm_automatic}"
 }
 
 # f_jsnupdate: update runtime information
@@ -197,7 +201,7 @@ f_log()
 #
 f_main()
 {
-    local config ssid_list ap ap_radio sta_ssid sta_radio sta_iface cnt=1
+    local dev config ssid_list sta_ssid sta_radio sta_iface cnt=1
 
     f_check "initial"
     if [ "${trm_ifstatus}" != "true" ]
@@ -209,22 +213,19 @@ f_main()
         then
             uci -q commit wireless
         fi
-        f_check "ap"
-        f_log "debug" "ap-list: ${trm_aplist}, sta-list: ${trm_stalist}"
-        for ap in ${trm_aplist}
+        f_check "dev"
+        f_log "debug" "main: ${trm_devlist}, sta-list: ${trm_stalist}"
+        for dev in ${trm_devlist}
         do
             cnt=1
-            ap_radio="${ap##*_}"
-            ap="${ap%%_*}"
-            if [ -z "$(printf "%s" "${trm_stalist}" | grep -Fo "_${ap_radio}")" ]
+            if [ -z "$(printf "%s" "${trm_stalist}" | grep -Fo "_${dev}")" ]
             then
                 continue
             fi
             while [ ${cnt} -le ${trm_maxretry} ]
             do
-                ssid_list="$(${trm_iw} dev "${ap}" scan 2>/dev/null | \
-                    awk '/SSID: /{if(!seen[$0]++){printf "\"";for(i=2; i<=NF; i++)if(i==2)printf $i;else printf " "$i;printf "\" "}}')"
-                f_log "debug" "iw: ${trm_iw}, ap: ${ap}, ssids: ${ssid_list}"
+                ssid_list="$(${trm_iwinfo} "${dev}" scan | awk '/ESSID: "/{ORS=" ";if (!seen[$0]++) for(i=2; i<=NF; i++) print $i}')"
+                f_log "debug" "main: ${trm_iwinfo}, dev: ${dev}, ssids: ${ssid_list}"
                 if [ -n "${ssid_list}" ]
                 then
                     for sta in ${trm_stalist}
@@ -233,7 +234,7 @@ f_main()
                         sta_radio="${sta##*_}"
                         sta_ssid="$(uci -q get wireless."${config}".ssid)"
                         sta_iface="$(uci -q get wireless."${config}".network)"
-                        if [ -n "$(printf "%s" "${ssid_list}" | grep -Fo "\"${sta_ssid}\"")" ] && [ "${ap_radio}" = "${sta_radio}" ]
+                        if [ -n "$(printf "%s" "${ssid_list}" | grep -Fo "\"${sta_ssid}\"")" ] && [ "${dev}" = "${sta_radio}" ]
                         then
                             uci -q set wireless."${config}".disabled=0
                             f_check "sta"


### PR DESCRIPTION
Maintainer: me
Compile tested: -
Run tested: LEDE Reboot (SNAPSHOT, r4424-3ccca56eb0)

Description:
* use iwinfo instead iw for wlan scanning,
  scanning now works on radio-level
* enhance multiple radio support:
    * support STA-only radio configurations,
      e.g first radio with local AP, second radio
      with a bunch of STAs (without APs)

Signed-off-by: Dirk Brenken <dev@brenken.org>
