### PR TITLE
libmicrohttpd: update to version 0.9.55

### DIFF
--- a/libs/libmicrohttpd/Makefile
+++ b/libs/libmicrohttpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmicrohttpd
-PKG_VERSION:=0.9.52
+PKG_VERSION:=0.9.55
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/libmicrohttpd
-PKG_MD5SUM:=54797f6e763d417627f89f60e4ae0a431dab0523f92f83def23ea02d0defafea
+PKG_HASH:=0c1cab8dc9f2588bd3076a28f77a7f8de9560cbf2d80e53f9a8696ada80ed0f8
 
 PKG_MAINTAINER:=Alexander Couzens <lynxis@fe80.eu>
 


### PR DESCRIPTION
Maintainer: me
Compile tested on ar71xx.
Runtime tested on ar71xx.

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>