### PR TITLE
gkrellmd: Add package (from oldpackages).

### DIFF
--- a/admin/gkrellmd/Makefile
+++ b/admin/gkrellmd/Makefile
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2007-2009 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gkrellmd
+PKG_VERSION:=2.3.10
+PKG_RELEASE:=1
+
+PKG_SOURCE:=gkrellm-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=http://gkrellm.srcbox.net/releases
+PKG_MD5SUM:=ccc0b6af434542a2374e34a135ae68da
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/gkrellm-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gkrellmd
+  SECTION:=admin
+  CATEGORY:=Administration
+  DEPENDS:=+glib2
+  TITLE:=The GNU Krell Monitors Server
+  URL:=http://gkrellm.net/
+endef
+
+define Package/gkrellmd/description
+	Gkrellmd Listens for connections from gkrellm clients. When
+	a gkrellm client connects to a gkrellmd server all builtin
+	monitors collect their data from the server.
+endef
+
+define Package/gkrellmd/conffiles
+/etc/$(PKG_NAME).conf
+endef
+
+define Build/Compile
+	CFLAGS="$(TARGET_CFLAGS) $(EXTRA_CPPFLAGS)" \
+	LDFLAGS="$(EXTRA_LDFLAGS) " \
+	$(MAKE) -C $(PKG_BUILD_DIR)/server \
+		CC="$(TARGET_CC)" \
+		without-libsensors="yes"
+endef
+
+define Package/gkrellmd/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/server/$(PKG_NAME) $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/server/$(PKG_NAME).conf $(1)/etc/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/$(PKG_NAME).init $(1)/etc/init.d/$(PKG_NAME)
+endef
+
+$(eval $(call BuildPackage,gkrellmd))

--- a/admin/gkrellmd/files/gkrellmd.init
+++ b/admin/gkrellmd/files/gkrellmd.init
@@ -1,0 +1,16 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2007 OpenWrt.org
+
+START=60
+BIN=gkrellmd
+RUN_D=/var/run
+PID_F=$RUN_D/$BIN.pid
+
+start() {
+	mkdir -p $RUN_D
+	$BIN $OPTIONS
+}
+
+stop() {
+	[ -f $PID_F ] && kill $(cat $PID_F)
+}

--- a/admin/gkrellmd/patches/100-conf.patch
+++ b/admin/gkrellmd/patches/100-conf.patch
@@ -1,0 +1,41 @@
+*** gkrellm-2.3.10/server/gkrellmd.conf	2011-08-04 03:26:38.000000000 +0200
+--- gkrellm-2.3.10/server/gkrellmd.conf.mod	2017-06-18 10:10:54.702528926 +0200
+***************
+*** 30,47 ****
+  # Drop privileges after startup (you must start gkrellmd as root to do it).
+  # NOTE: Option ignored on Windows
+  #
+! #user	nobody
+  #group	proc
+  
+  # Create a PID file for the running gkrellmd.  Default is no PID file.
+  # NOTE: Option ignored on Windows
+  #
+! #pidfile /var/run/gkrellmd.pid
+  
+  # Run in background and detach from the controlling terminal
+  # NOTE: Option ignored on Windows
+  #
+! #detach
+  
+  # Enable writing logging message to the system syslog file
+  # NOTE: On windows this enables logging to the windows event log
+--- 30,47 ----
+  # Drop privileges after startup (you must start gkrellmd as root to do it).
+  # NOTE: Option ignored on Windows
+  #
+! user	nobody
+  #group	proc
+  
+  # Create a PID file for the running gkrellmd.  Default is no PID file.
+  # NOTE: Option ignored on Windows
+  #
+! pidfile /var/run/gkrellmd.pid
+  
+  # Run in background and detach from the controlling terminal
+  # NOTE: Option ignored on Windows
+  #
+! detach
+  
+  # Enable writing logging message to the system syslog file
+  # NOTE: On windows this enables logging to the windows event log


### PR DESCRIPTION
Updated to gkrellm version 2.3.10 and Glib2.
Signed-off-by: Erwin Rieger <erwin.rieger@ibrieger.de>

-------------------------------
Maintainer: Erwin Rieger / @<ErwinRieger>
Compile tested: (mipsel, brcm47xx, openwrt master)
Run tested: (wl-500w, DESIGNATED DRIVER (Bleeding Edge, 50107), installed per opkg and running gkrellmd successfully)

Description:
This PR adds the gkrellmd package from oldpackages. Gkrell version is updated to 2.3.10 and it uses the Glib2 library.
