### PR TITLE
acpica: initial commit

### DIFF
--- a/utils/acpica-unix/Makefile
+++ b/utils/acpica-unix/Makefile
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2017 Philip Prindeville
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=acpica-unix
+PKG_VERSION:=20170531
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://acpica.org/sites/$(subst -unix,,$(PKG_NAME))/files/
+PKG_HASH:=50155778cd1633dfca3443b8f8fd1ccc30e70e55ddece4d3c4fceafbbf1ab0e8
+PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>
+
+PKG_LICENSE:=GPL-2.0
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_FORTIFY_SOURCE:=0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/acpica-unix
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=
+  TITLE:=ACPI utilities for UNIX
+  URL:=https://acpica.org/
+endef
+
+define Package/acpica-unix/description
+	Open Source utilities for ACPI including the ACPICA Machine Language
+	(AML) interpreter, a simulator, test suites, and a compiler to
+	translate ACPI Source Language (ASL) into AML.
+endef
+
+define Build/Configure
+endef
+
+MAKE_VARS += HOST=_LINUX
+
+MAKE_PATH:=generate/unix
+
+define Package/acpica-unix/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/generate/unix/acpidump/obj/acpidump $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,acpica-unix))


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, generic, built against LEDE HEAD (680a5c5)
Run tested: built an image, installed on test box, ran "acpidump".

Description:

Output of "acpidump" concurs with dmesg `ACPI:` section.