### PR TITLE
net/mwan3: add lock

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.5.2
+PKG_VERSION:=2.5.3
 PKG_RELEASE:=5
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -38,6 +38,7 @@ if [ "$ACTION" == "ifup" ]; then
 	[ -n "$gateway" ] || exit 9
 fi
 
+mwan3_lock
 $LOG notice "$ACTION interface $INTERFACE (${DEVICE:-unknown})"
 
 case "$ACTION" in
@@ -63,5 +64,7 @@ case "$ACTION" in
 		mwan3_flush_conntrack $INTERFACE $DEVICE "ifdown"
 	;;
 esac
+
+mwan3_unlock
 
 exit 0

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -8,6 +8,14 @@ IPT6="ip6tables -t mangle -w"
 LOG="logger -t mwan3 -p"
 CONNTRACK_FILE="/proc/net/nf_conntrack"
 
+mwan3_lock() {
+	lock /var/run/mwan3.lock
+}
+
+mwan3_unlock() {
+	lock -u /var/run/mwan3.lock
+}
+
 mwan3_get_iface_id()
 {
 	local _tmp _iface _iface_count

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -738,7 +738,7 @@ mwan3_report_iface_status()
 	config_list_foreach $1 track_ip mwan3_list_track_ips
 
 	if [ -n "$track_ips" ]; then
-		if [ -n "$(ps -w | grep mwan3track | grep -v grep | sed '/.*\/usr\/sbin\/mwan3track \([^ ]*\) .*$/!d;s//\1/' | awk '$1 == "'$1'"')" ]; then
+		if [ -n "$(pgrep -f "mwan3track $1")" ]; then
 			tracking="active"
 		else
 			tracking="down"


### PR DESCRIPTION
Maintainer: me / @feckert
Compile tested: -
Run tested: lantiq, xrx200, LEDE 17.01

Description:

- If more then one interface get up/down at once mwan3 could be in a undefined state, because more then one mwan3 "hotplug script" (15_mwan3) are running and editing the iptables.
- simplify tracking status statement command