### PR TITLE
libs/libx264: Update to snapshot 20170623

### DIFF
--- a/libs/libx264/Makefile
+++ b/libs/libx264/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=x264
-PKG_VERSION:=snapshot-20160815-2245-stable
-PKG_RELEASE:=3
+PKG_VERSION:=snapshot-20170623-2245-stable
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.videolan.org/x264/snapshots/
 PKG_MAINTAINER:=Adrian Panella <ianchi74@outlook.com>
-PKG_MD5SUM:=93fa596ea1b5513fec73e9de27589dd4
+PKG_HASH:=e8af5d199b6af8124b6e54631ab7b2ff20f1ce86bbcc2f58bd800bc85bee6b2f
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
@@ -52,7 +52,11 @@ endif
 CONFIGURE_ARGS += \
 		--enable-shared \
 		--enable-pic \
-		--disable-cli 
+		--enable-strip \
+		--disable-cli \
+		--disable-avs \
+		--disable-ffms \
+		--disable-lsmash
 
 define Package/libx264
   SECTION:=libs


### PR DESCRIPTION
Maintainer: @ianchi 
Compile tested: mvebu, Linksys WRT3200ACM, LEDE trunk
Run tested: mvebu, Linksys WRT3200ACM, LEDE trunk (quick test)

Description:
Update libx264 to snapshot 20170623

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>