### PR TITLE
net/telnet-bsd: Add telnet-bsd 1.2 to repo

### DIFF
--- a/net/telnet-bsd/Makefile
+++ b/net/telnet-bsd/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2017 Daniel Engberg <daniel.engberg.lists@pyret.net>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=telnet-bsd
+PKG_VERSION=1.2
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Daniel Engberg <daniel.engberg.lists@pyret.net>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE_URL:=@DISTFILES
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_SUBDIR=$(PKG_NAME)-$(PKG_VERSION)
+PKG_HASH:=d6a9d26740ef75565cb1ed8ff11e327d240e6734748b2d1d2e96c126849e4733
+
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+
+TARGET_CFLAGS+= -Wno-format-security
+
+define Package/telnet-bsd
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libncurses
+  TITLE:=telnet-bsd
+  URL:=https://www.openbsd.org/
+endef
+
+define Package/telnet-bsd/description
+  Telnet client ported from OpenBSD
+endef
+
+define Package/telnet-bsd/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/telnet/telnet $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,telnet-bsd))

--- a/net/telnet-bsd/patches/001-telnet-bsd-1.2-fbsd.patch
+++ b/net/telnet-bsd/patches/001-telnet-bsd-1.2-fbsd.patch
@@ -1,0 +1,105 @@
+diff --git a/configure.in b/configure.in
+index 1547e9b..eda5fb1 100644
+--- a/configure.in
++++ b/configure.in
+@@ -12,6 +12,8 @@ ALL_LINGUAS="de"
+ AC_SUBST(PACKAGE)
+ AC_SUBST(VERSION)
+ 
++AC_CHECK_HEADERS([pty.h utmp.h])
++
+ if test x"$ac_default_prefix" = x"/usr"
+ then
+ 	if test x"${mandir}" = x'${prefix}/man'
+diff --git a/telnet/commands.c b/telnet/commands.c
+index c0d349c..fa2cf8a 100644
+--- a/telnet/commands.c
++++ b/telnet/commands.c
+@@ -29,11 +29,13 @@
+ 
+ #include "telnet_locl.h"
+ #include <err.h>
++#include <unistd.h>
+ 
+ #if	defined(IPPROTO_IP) && defined(IP_TOS)
+ int tos = -1;
+ #endif /* defined(IPPROTO_IP) && defined(IP_TOS) */
+ 
++extern char **environ;
+ char *hostname;
+ 
+ typedef int (*intrtn_t) __P ((int, char **));
+diff --git a/telnet/ring.h b/telnet/ring.h
+index 66f7191..9ef8fb8 100644
+--- a/telnet/ring.h
++++ b/telnet/ring.h
+@@ -29,6 +29,7 @@
+  */
+ 
+ #include <sys/cdefs.h>
++#include <sys/types.h>
+ #define P __P
+ 
+ /*
+diff --git a/telnetd/setproctitle.c b/telnetd/setproctitle.c
+index f332277..b2adc92 100644
+--- a/telnetd/setproctitle.c
++++ b/telnetd/setproctitle.c
+@@ -72,6 +72,7 @@ char setproctitle_rcsid[] =
+ static char **Argv = NULL;		/* pointer to argument vector */
+ static char *LastArgv = NULL;		/* end of argv */
+ static char Argv0[128];			/* program name */
++extern char **environ;
+ 
+ void
+ initsetproctitle(int argc, char **argv, char **envp)
+@@ -86,10 +87,10 @@ initsetproctitle(int argc, char **argv, char **envp)
+ 
+ 	for (i = 0; envp[i] != NULL; i++)
+ 		continue;
+-	__environ = (char **) malloc(sizeof (char *) * (i + 1));
++	environ = (char **) malloc(sizeof (char *) * (i + 1));
+ 	for (i = 0; envp[i] != NULL; i++)
+-		__environ[i] = strdup(envp[i]);
+-	__environ[i] = NULL;
++		environ[i] = strdup(envp[i]);
++	environ[i] = NULL;
+ 
+ 	/*
+ 	**  Save start and extent of argv for setproctitle.
+diff --git a/telnetd/sys_term.c b/telnetd/sys_term.c
+index 1235428..6fcc601 100644
+--- a/telnetd/sys_term.c
++++ b/telnetd/sys_term.c
+@@ -27,8 +27,15 @@
+  * SUCH DAMAGE.
+  */
+ 
++#include <config.h>
++
++#include <sys/types.h>
++#ifdef HAVE_UTMP_H 
+ #include <utmp.h>
++#endif
++#ifdef HAVE_PTY_H
+ #include <pty.h>
++#endif
+ 
+ #include "telnetd.h"
+ #include "pathnames.h"
+@@ -820,6 +827,7 @@ addarg (struct argv_stuff *avs, const char *val)
+ void
+ cleanup (int sig)
+ {
++#if !defined(__FreeBSD__) || __FreeBSD__ < 9
+   sigset_t sigset;
+   char *p;
+   (void) sig;
+@@ -847,6 +855,7 @@ cleanup (int sig)
+   *p = 'p';
+   chmod (line, 0666);
+   chown (line, 0, 0);
++#endif
+   shutdown (net, 2);
+   exit (1);
+ }

--- a/net/telnet-bsd/patches/002-dont-compile-telnetd.patch
+++ b/net/telnet-bsd/patches/002-dont-compile-telnetd.patch
@@ -1,0 +1,50 @@
+diff --git a/Makefile.am b/Makefile.am
+index d02b78a..67b757e 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -3,7 +3,7 @@
+ #
+ AUTOMAKE_OPTIONS = 1.8 gnits dist-bzip2
+ #
+-SUBDIRS = m4 telnet telnetd
++SUBDIRS = m4 telnet
+ 
+ CLEANFILES = *~
+ 
+diff --git a/Makefile.in b/Makefile.in
+index ba3d415..0075d81 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -164,7 +164,7 @@ target_vendor = @target_vendor@
+ #
+ AUTOMAKE_OPTIONS = 1.8 gnits dist-bzip2
+ #
+-SUBDIRS = m4 telnet telnetd
++SUBDIRS = m4 telnet
+ CLEANFILES = *~
+ ACLOCAL_AMFLAGS = -I m4
+ all: config.h
+diff --git a/configure b/configure
+index d61ce4f..ccb1953 100755
+--- a/configure
++++ b/configure
+@@ -3279,7 +3279,7 @@ _ACEOF
+ fi
+ 
+ 
+-                                        ac_config_files="$ac_config_files Makefile m4/Makefile telnet/Makefile telnetd/Makefile"
++                                        ac_config_files="$ac_config_files Makefile m4/Makefile telnet/Makefile"
+ 
+ cat >confcache <<\_ACEOF
+ # This file is a shell script that caches the results of configure
+diff --git a/configure.in b/configure.in
+index 1547e9b..4527158 100644
+--- a/configure.in
++++ b/configure.in
+@@ -52,5 +52,5 @@ AC_SUBST(PIE_LDFLAGS)
+ dnl Checks for typedefs, structures, and compiler characteristics.
+ AC_C_CONST
+ 
+-AC_CONFIG_FILES([Makefile m4/Makefile telnet/Makefile telnetd/Makefile])
++AC_CONFIG_FILES([Makefile m4/Makefile telnet/Makefile])
+ AC_OUTPUT


### PR DESCRIPTION
Maintainer: myself
Compile tested: mvebu, WRT3200ACM, LEDE trunk + ar71xx, Archer C7, LEDE 17.01.2
Run tested: ar71xx, Archer C7, LEDE 17.01.2

Description:
net/telnet-bsd: Add telnet-bsd 1.2 to repo

Patch sources:
https://gitweb.gentoo.org/repo/gentoo.git/tree/net-misc/telnet-bsd/files

Template for excluding telnetd:
https://github.com/theeternalsw0rd/telnet-macos

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>