### PR TITLE
mksh: bump to R55 and use PKG_HASH

### DIFF
--- a/utils/mksh/Makefile
+++ b/utils/mksh/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mksh
-PKG_VERSION:=54
+PKG_VERSION:=55
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Thorsten Glaser <tg@mirbsd.org>
@@ -17,8 +17,8 @@ PKG_LICENSE:=MirOS
 
 PKG_SOURCE:=$(PKG_NAME)-R$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=http://www.mirbsd.org/MirOS/dist/mir/mksh \
-		http://pub.allbsd.org/MirOS/dist/mir/mksh/
-PKG_MD5SUM:=be0a6fb93b4a5f927bcc1893bb6692f8
+		http://pub.allbsd.org/MirOS/dist/mir/mksh
+PKG_HASH:=ced42cb4a181d97d52d98009eed753bd553f7c34e6991d404f9a8dcb45c35a57
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -63,7 +63,7 @@ define Build/Compile
 		CC="$(TARGET_CC)" \
 		TARGET_OS="$(shell uname -s)" \
 		CFLAGS="$(TARGET_CFLAGS)" \
-		CPPFLAGS="-DMKSH_SMALL=1 -DMKSH_ASSUME_UTF8=0 -DMKSH_BINSHPOSIX" \
+		CPPFLAGS="-DMKSH_SMALL=1 -DMKSH_ASSUME_UTF8=0 -DMKSH_BINSHPOSIX -DMKSHRC_PATH=\\\"/etc/mkshrc\\\"" \
 		HAVE_CAN_FSTACKPROTECTORALL=0 \
 		HAVE_CAN_FSTACKPROTECTORSTRONG=0 \
 		LDFLAGS="$(TARGET_LDFLAGS)" \

--- a/utils/mksh/patches/100-dot_mkshrc
+++ b/utils/mksh/patches/100-dot_mkshrc
@@ -1,5 +1,3 @@
-Refreshed for mksh-r54, based on tg's patch
-
 From 23712cea8e2a623fd952eb781df0011c501703d0 Mon Sep 17 00:00:00 2001
 From: Thorsten Glaser <tg@mirbsd.org>
 Date: Thu, 25 Jul 2013 22:07:33 +0200
@@ -10,37 +8,35 @@ Subject: [PATCH] Make default mkshrc file suitable for OpenWrt environment:
   - ls(1) has no -o option
 * OpenWrt and FreeWRT-1.0 fix:
   - since this is not ~/.mkshrc make sure subshells find it
+
+From: Alif M. A. <alive4ever@live.com>
+Date: Thu, 20 Jul 2017 14:52:39 +0000
+Subject: [PATCH] Refresh 100-dot_mkshrc for mksh-R55
+
+Additional changes of the patch as of mksh-R55
+* Use content of `/proc/sys/kernel/hostname` to set `$HOSTNAME`, since
+  `hostname` applet isn't compiled into `busybox`.
+* Use `/bin/vi` as fallback `$EDITOR`.
+* Use `/etc/mkshrc` as default startup file, so there is no need to
+  manually source it during interactive session.
+
 ---
+Reviewed-by: Thorsten Glaser <tg at mirbsd.org>
 Signed-off-by: Alif M. A. <alive4ever at live.com>
+
 --- a/dot.mkshrc
 +++ b/dot.mkshrc
-@@ -28,8 +28,9 @@
- *) return 0 ;;
- esac
+@@ -56,10 +56,9 @@
+ 	done
+ )
  
--PS1='#'; (( USER_ID )) && PS1='$'; \: "${TERM:=vt100}${HOSTNAME:=$(\ulimit -c \
--    0; hostname 2>/dev/null)}${EDITOR:=/bin/ed}${USER:=$(\ulimit -c 0; id -un \
-+PS1='#'; (( USER_ID )) && PS1='$'; \: "${HOSTNAME:=$(</proc/sys/kernel/hostname\
-+    )} = *([     ]|localhost) && HOSTNAME=$(\ulimit -c \
-+    0; hostname 2>/dev/null)}${EDITOR:=/bin/vi}${USER:=$(\ulimit -c 0; id -un \
-     2>/dev/null || \echo \?)}${MKSH:=$(\builtin whence -p mksh)}"
- HOSTNAME=${HOSTNAME%%*([	 ]).*}; HOSTNAME=${HOSTNAME##*([	 ])}
- [[ $HOSTNAME = ?(ip6-)localhost?(6) ]] && HOSTNAME=
-@@ -52,7 +53,7 @@
- \alias l='ls -F'
- \alias la='l -a'
- \alias ll='l -l'
--\alias lo='l -alo'
-+\alias lo='l -al'
- \alias doch='sudo mksh -c "$(\builtin fc -ln -1)"'
- \command -v rot13 >/dev/null || \alias rot13='tr \
-     abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ \
-@@ -600,4 +601,8 @@
+-\\builtin alias ls=ls l='ls -F' la='l -a' ll='l -l' lo='l -alo'
+-\: "${HOSTNAME:=$(\\builtin ulimit -c 0; \\builtin print -r -- $(hostname \
+-    2>/dev/null))}${EDITOR:=/bin/ed}${TERM:=vt100}${USER:=$(\\builtin ulimit \
+-    -c 0; id -un 2>/dev/null)}${USER:=?}"
++\\builtin alias ls=ls l='ls -F' la='l -a' ll='l -l' lo='l -al'
++\: "${HOSTNAME:=$(</proc/sys/kernel/hostname)}${EDITOR:=/bin/vi}${TERM:=vt100}\
++	${USER:=$(\\builtin ulimit -c 0; id -un 2>/dev/null)}${USER:=?}"
+ [[ $HOSTNAME = ?(?(ip6-)localhost?(6)) ]] && HOSTNAME=nil; \\builtin unalias ls
+ \\builtin export EDITOR HOSTNAME TERM USER
  
- \unset p
- 
-+# we need this in OpenWrt for subshells that are not login shells
-+\: ${ENV=/etc/mkshrc}
-+[[ -z $ENV ]] || export ENV
-+
- \: place customisations above this line


### PR DESCRIPTION
mksh: bump to R55 and use PKG_HASH

Upgrade the package to R55. Patches refreshed.

Added `-DMKSHRC_PATH=\"/etc/mkshrc\"` to `CPPFLAGS` to set the default
startup file during both login and nonlogin sessions, so that there is
no need to source `/etc/mkshrc` file manually.

In addition to the package upgrade, use PKG_HASH instead of
PKG_MD5SUM.

Maintainer: @mirabilos 
Compile tested: x86_64, generic, LEDE Reboot (SNAPSHOT, r4462-f33de80232) 
Run tested: x86_64, qemu 2.9.0 with kvm, LEDE Reboot (SNAPSHOT, r4462-f33de80232)
Test result:
* `/bin/mksh` is about 168k.
*  `EDITOR` is set to `/bin/vi`
* The default startup file `/etc/mkshrc` is loaded automatically for both login and nonlogin shells.
