### PR TITLE
openvswitch: fix build

### DIFF
--- a/lang/python/python-six/Makefile
+++ b/lang/python/python-six/Makefile
@@ -7,16 +7,18 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=six
+PKG_NAME:=python-six
 PKG_VERSION:=1.10.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=six-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/source/s/six
 PKG_MD5SUM:=34eed507548117b2ab523ab14b2f8b55
 
 HOST_BUILD_DEPENDS:=python/host
 PKG_BUILD_DEPENDS:=python
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -25,6 +27,9 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+HOST_UNPACK:=$(HOST_TAR) -C $(HOST_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-six
 	SECTION:=lang

--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -188,7 +188,6 @@ define Build/Compile
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(STAGING_DIR)/mk/
 	$(INSTALL_DIR) $(1)/usr/include/ $(1)/usr/lib/ $(1)/usr/lib/pkgconfig
 	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON_VERSION)/
 	$(INSTALL_DATA) \
@@ -292,8 +291,18 @@ HOST_CONFIGURE_ARGS+= \
 
 define Host/Install
 	$(MAKE) -C $(HOST_BUILD_DIR) install
-	$(INSTALL_DIR) $(HOST_PYTHON_DIR)/bin/
+	$(INSTALL_DIR) $(HOST_PYTHON_DIR)/bin/ $(STAGING_DIR)/mk/
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/Parser/pgen $(HOST_PYTHON_DIR)/bin/pgen2
+	# Install these mk files in the Host/Install phase ;
+	# The Build/InstallDev rule is activated only for target builds.
+	# But if someone needs only the host Python, then
+	# these files need to be installed in this phase, and not Build/InstallDev
+	$(INSTALL_DATA) \
+		./files/python-package.mk \
+		./files/python-host.mk \
+		./files/python-version.mk \
+		./files/python-package-install.sh \
+		$(STAGING_DIR)/mk/
 endef
 
 $(eval $(call HostBuild))

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -182,15 +182,8 @@ define Build/Compile
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(STAGING_DIR)/mk/
 	$(INSTALL_DIR) $(1)/usr/include/ $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON_VERSION)/
-	$(INSTALL_DATA) \
-		./files/python3-package.mk \
-		./files/python3-host.mk \
-		./files/python3-version.mk \
-		./files/python3-package-install.sh \
-		$(STAGING_DIR)/mk/
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/include/python$(PYTHON_VERSION) \
 		$(1)/usr/include/
@@ -279,9 +272,20 @@ endef
 define Host/Install
 	$(MAKE) -C $(HOST_BUILD_DIR) install
 
-	$(INSTALL_DIR) $(HOST_PYTHON3_DIR)/bin/
+	$(INSTALL_DIR) $(HOST_PYTHON3_DIR)/bin/ $(STAGING_DIR)/mk/
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/Parser/pgen $(HOST_PYTHON3_DIR)/bin/pgen3
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/Programs/_freeze_importlib $(HOST_PYTHON3_DIR)/bin/_freeze_importlib
+
+	# Install these mk files in the Host/Install phase ;
+	# The Build/InstallDev rule is activated only for target builds.
+	# But if someone needs only the host Python, then
+	# these files need to be installed in this phase, and not Build/InstallDev
+	$(INSTALL_DATA) \
+		./files/python3-package.mk \
+		./files/python3-host.mk \
+		./files/python3-version.mk \
+		./files/python3-package-install.sh \
+		$(STAGING_DIR)/mk/
 endef
 
 $(eval $(call HostBuild))

--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -118,7 +118,10 @@ CONFIGURE_ARGS += --enable-shared
 TARGET_CFLAGS += -flto -std=gnu99
 
 CONFIGURE_VARS += KARCH=$(LINUX_KARCH)
-MAKE_FLAGS += ARCH="$(LINUX_KARCH)"
+MAKE_FLAGS += \
+	ARCH="$(LINUX_KARCH)" \
+	PYTHONPATH="$(HOST_PYTHONPATH)" \
+	PYTHON="$(HOST_PYTHON_BIN)"
 
 define OvsBinUtility
   define Package/openvswitch-$(1)

--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -23,7 +23,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://openvswitch.org/releases/
 PKG_HASH:=e492cf08a929b4a2178b7f9b01dc4ff562f44138b547b4e942078187b2445d2e
 
-PKG_BUILD_DEPENDS:=python-six/host
+PKG_BUILD_DEPENDS:=python/host python-six/host CONFIG_PACKAGE_openvswitch-python
 
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf

--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -67,7 +67,7 @@ endef
 define Package/openvswitch-python
   $(call Package/openvswitch/Default)
   TITLE:=Open vSwitch Python Support
-  DEPENDS:=+openvswitch +python +python-six
+  DEPENDS:=+openvswitch +PACKAGE_openvswitch-python:python +PACKAGE_openvswitch-python:python-six
 endef
 
 define Package/openvswitch-python/description

--- a/net/openvswitch/patches/0003-override-pythonpath-via-make-vars.patch
+++ b/net/openvswitch/patches/0003-override-pythonpath-via-make-vars.patch
@@ -1,0 +1,26 @@
+diff --git a/Makefile.am b/Makefile.am
+index a4dd7b8..099a3c1 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -53,7 +53,7 @@ endif
+ # foo/__init__.py into an (older) version with plain foo.py, since
+ # foo/__init__.pyc will cause Python to ignore foo.py.
+ run_python = \
+-	PYTHONPATH=$(top_srcdir)/python$(psep)$$PYTHONPATH \
++	PYTHONPATH=$(top_srcdir)/python$(psep)$(PYTHONPATH) \
+ 	PYTHONDONTWRITEBYTECODE=yes $(PYTHON)
+ 
+ ALL_LOCAL =
+diff --git a/Makefile.in b/Makefile.in
+index 8df66e2..98b54bf 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -1654,7 +1654,7 @@ AM_CFLAGS = -Wstrict-prototypes $(WARNING_FLAGS) $(OVS_CFLAGS) \
+ # foo/__init__.py into an (older) version with plain foo.py, since
+ # foo/__init__.pyc will cause Python to ignore foo.py.
+ run_python = \
+-	PYTHONPATH=$(top_srcdir)/python$(psep)$$PYTHONPATH \
++	PYTHONPATH=$(top_srcdir)/python$(psep)$(PYTHONPATH) \
+ 	PYTHONDONTWRITEBYTECODE=yes $(PYTHON)
+ 
+ 


### PR DESCRIPTION
Maintainer: me / @jefferyto (for python-six)
Compile tested: https://github.com/lede-project/source/commit/f33de8023228d7d6545ff12c4f2ef8febb486f37  ar71xx
Run tested: N/A

Description:

Seems it was not failing for me because it was probably
using my host Python, which has the `six` package available.

This patch series enforces the use of the Python package in the feed.

Locally it builds for me.
It took me a while to get it building fine.
Let's hope buildbot agrees with me.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>