### PR TITLE
adblock: update 2.8.2

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=2.8.1
+PKG_VERSION:=2.8.2
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: LEDE Reboot (SNAPSHOT, r4497-a73471dea7)

Description:
* made DNS restart conditional (compare list hash values),
  to prevent needless restarts of the DNS backend

Signed-off-by: Dirk Brenken <dev@brenken.org>
