### PR TITLE
ddns-scripts: allow use of CA directory installed by ca-certificates

### DIFF
--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -781,8 +781,10 @@ do_transfer() {
 				__PROG="$__PROG --no-check-certificate"
 			elif [ -f "$cacert" ]; then
 				__PROG="$__PROG --ca-certificate=$cacert"
-			elif [ -n "$cacert" ]; then		# it's not a file; nothing else supported
-				write_log 14 "No valid certificate file '$cacert' for HTTPS communication"
+			elif [ -d "$cacert" ]; then
+				__PROG="$__PROG --ca-directory=$cacert"
+			elif [ -n "$cacert" ]; then		# it's not a file and not a directory but given
+				write_log 14 "No valid certificate(s) found at '$cacert' for HTTPS communication"
 			fi
 		fi
 		__RUNPROG="$__PROG '$__URL' 2>$ERRFILE"		# build final command


### PR DESCRIPTION
Maintainer: @chris5560 

Description:
I was receiving an error from ddns-scripts when configured with use_https '1' until I made this change. The ca-certificates package installs a directory of certificate files, so the wget command line must use --ca-directory instead of --ca-certificate.