### PR TITLE
acpica-unix: version bump and add parallel build

### DIFF
--- a/utils/acpica-unix/Makefile
+++ b/utils/acpica-unix/Makefile
@@ -8,18 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acpica-unix
-PKG_VERSION:=20170531
+PKG_VERSION:=20170629
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://acpica.org/sites/$(subst -unix,,$(PKG_NAME))/files/
-PKG_HASH:=50155778cd1633dfca3443b8f8fd1ccc30e70e55ddece4d3c4fceafbbf1ab0e8
+PKG_SOURCE_URL:=https://acpica.org/sites/$(subst -unix,,$(PKG_NAME))/files/$(PKG_SOURCE_URL)
+PKG_HASH:=5f05d8f63d60888d7450f090ce270ef7ed026de9293ce9f6d04fe99cbbb77635
 PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>
 
 PKG_LICENSE:=GPL-2.0
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_FORTIFY_SOURCE:=0
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, generic, LEDE HEAD (f80963d), rebuilt
Run tested: copies ipkg to running systems and reinstalled

Description:

Bump to current release.  Enable parallel builds.  Fix download URL.