### PR TITLE
tor: update to version 0.2.9.11

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.2.9.10
+PKG_VERSION:=0.2.9.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_MD5SUM:=6760a646a096b61e307b84fb5ae93cc7
-PKG_HASH:=d611283e1fb284b5f884f8c07e7d3151016851848304f56cfdf3be2a88bd1341
+PKG_MD5SUM:=763ae964e916c2a7a4c5015d351fcf8b
+PKG_HASH:=c1959bebff9a546a54cbedb58c8289a42441991af417d2d16f7b336be8903221
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
 PKG_LICENSE_FILES:=LICENSE
 


### PR DESCRIPTION
Maintainer: me / @hauke
Compile tested: lantiq
Run tested: no

Description:
This fixes CVE-2017-0376

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>