### PR TITLE
python,python3: batch updates

### DIFF
--- a/lang/python/pyodbc/Makefile
+++ b/lang/python/pyodbc/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pyodbc
 PKG_VERSION:=4.0.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/ce/57/6b92aa5b3497dde6be55fd6fcb76c7db215ed1d56fde45c613add4a43095/
@@ -29,19 +29,22 @@ define Package/python-pyodbc/Default
   CATEGORY:=Languages
   SUBMENU:=Python
   URL:=https://github.com/mkleehammer/pyodbc
+  DEPENDS:=+unixodbc +libstdcpp
 endef
 
 define Package/python-pyodbc
 $(call Package/python-pyodbc/Default)
   TITLE:=python-pyodbc
-  DEPENDS:=+unixodbc +libstdcpp +python-light
+  DEPENDS+=+PACKAGE_python-pyodbc:python-light \
+           +PACKAGE_python-pyodbc:python-logging \
+           +PACKAGE_python-pyodbc:python-openssl
   VARIANT:=python
 endef
 
 define Package/python3-pyodbc
 $(call Package/python-pyodbc/Default)
   TITLE:=python3-pyodbc
-  DEPENDS:=+unixodbc +libstdcpp +python3-light
+  DEPENDS+=+PACKAGE_python3-pyodbc:python3-light
   VARIANT:=python3
 endef
 

--- a/lang/python/python-cffi/Makefile
+++ b/lang/python/python-cffi/Makefile
@@ -7,33 +7,25 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=cffi
-PKG_VERSION:=1.8.3
-PKG_RELEASE:=2
+PKG_NAME:=python-cffi
+PKG_VERSION:=1.10.0
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/0a/f3/686af8873b70028fccf67b15c78fd4e4667a3da995007afc71e786d61b0a
-PKG_HASH:=c321bd46faa7847261b89c0469569530cad5a41976bb6dba8202c0159f476568
+PKG_SOURCE:=cffi-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/5b/b9/790f8eafcdab455bcd3bd908161f802c9ce5adbf702a83aa7712fcc345b7
+PKG_HASH:=b3b02911eb1f6ada203b0763ba924234629b51586f72a21faacc638269f4ced5
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
-HOST_BUILD_DEPENDS:=libffi/host python-pycparser/host
-ifdef CONFIG_PACKAGE_python-cffi
-HOST_BUILD_DEPENDS+=python/host
-endif
-ifdef CONFIG_PACKAGE_python3-cffi
-HOST_BUILD_DEPENDS+=python3/host
-endif
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cffi-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
-include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
 $(call include_mk, python3-package.mk)
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-cffi/Default
   SECTION:=lang
@@ -46,14 +38,14 @@ endef
 define Package/python-cffi
 $(call Package/python-cffi/Default)
   TITLE:=python-cffi
-  DEPENDS+=+python-light +python-pycparser
+  DEPENDS+=+PACKAGE_python-cffi:python-light +PACKAGE_python-cffi:python-pycparser
   VARIANT:=python
 endef
 
 define Package/python3-cffi
 $(call Package/python-cffi/Default)
   TITLE:=python3-cffi
-  DEPENDS+=+python3-light +python3-pycparser
+  DEPENDS+=+PACKAGE_python3-cffi:python3-light +PACKAGE_python3-cffi:python3-pycparser
   VARIANT:=python3
 endef
 
@@ -66,28 +58,6 @@ $(call Package/python-cffi/description)
 .
 (Variant for Python3)
 endef
-
-ifdef CONFIG_PACKAGE_python-cffi
-define Host/Compile/python-cffi
-	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-endif
-
-ifdef CONFIG_PACKAGE_python3-cffi
-define Host/Compile/python3-cffi
-	$(call Build/Compile/HostPy3Mod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-endif
-
-define Host/Compile
-$(call Host/Compile/python-cffi)
-$(call Host/Compile/python3-cffi)
-endef
-
-define Host/Install
-endef
-
-$(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-cffi))
 $(eval $(call BuildPackage,python-cffi))

--- a/lang/python/python-lxml/Makefile
+++ b/lang/python/python-lxml/Makefile
@@ -37,14 +37,14 @@ endef
 define Package/python-lxml
 $(call Package/python-lxml/Default)
   TITLE:=python-lxml
-  DEPENDS+=+python-light +python-codecs
+  DEPENDS+=+PACKAGE_python-lxml:python-light +PACKAGE_python-lxml:python-codecs
   VARIANT:=python
 endef
 
 define Package/python3-lxml
 $(call Package/python-lxml/Default)
   TITLE:=python3-lxml
-  DEPENDS+=+python3-light
+  DEPENDS+=+PACKAGE_python3-lxml:python3-light
   VARIANT:=python3
 endef
 
@@ -61,7 +61,7 @@ endef
 
 TARGET_LDFLAGS += -lxml2 -lxslt -lexslt
 
-define PyBuild/Compile/Default
+define PyBuild/Compile
 	$(call Build/Compile/PyMod,, \
 		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
 		--static \
@@ -74,7 +74,7 @@ define PyBuild/Compile/Default
 	)
 endef
 
-define Py3Build/Compile/Default
+define Py3Build/Compile
 	$(call Build/Compile/Py3Mod,, \
 		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
 		--static \

--- a/lang/python/python-ply/Makefile
+++ b/lang/python/python-ply/Makefile
@@ -7,33 +7,25 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=ply
-PKG_VERSION:=3.9
-PKG_RELEASE:=2
+PKG_NAME:=python-ply
+PKG_VERSION:=3.10
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=ply-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.dabeaz.com/ply
-PKG_HASH:=0d7e2940b9c57151392fceaa62b0865c45e06ce1e36687fd8d03f011a907f43e
+PKG_HASH:=96e94af7dd7031d8d6dd6e2a8e0de593b511c211a86e28a9c9621c275ac8bacb
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
-HOST_BUILD_DEPENDS:=
-ifdef CONFIG_PACKAGE_python-ply
-HOST_BUILD_DEPENDS+=python/host
-endif
-ifdef CONFIG_PACKAGE_python3-ply
-HOST_BUILD_DEPENDS+=python3/host
-endif
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-ply-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=README.md
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
-include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
 $(call include_mk, python3-package.mk)
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-ply/Default
   SECTION:=lang
@@ -45,14 +37,14 @@ endef
 define Package/python-ply
 $(call Package/python-ply/Default)
   TITLE:=python-ply
-  DEPENDS:=+python-light
+  DEPENDS:=+PACKAGE_python-ply:python-light
   VARIANT:=python
 endef
 
 define Package/python3-ply
 $(call Package/python-ply/Default)
   TITLE:=python3-ply
-  DEPENDS:=+python3-light
+  DEPENDS:=+PACKAGE_python3-ply:python3-light
   VARIANT:=python3
 endef
 
@@ -66,28 +58,6 @@ $(call Package/python-ply/description)
 .
 (Variant for Python3)
 endef
-
-ifdef CONFIG_PACKAGE_python-ply
-define Host/Compile/python-ply
-	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-endif
-
-ifdef CONFIG_PACKAGE_python3-ply
-define Host/Compile/python3-ply
-	$(call Build/Compile/HostPy3Mod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-endif
-
-define Host/Compile
-$(call Host/Compile/python-ply)
-$(call Host/Compile/python3-ply)
-endef
-
-define Host/Install
-endef
-
-$(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-ply))
 $(eval $(call BuildPackage,python-ply))

--- a/lang/python/python-pycparser/Makefile
+++ b/lang/python/python-pycparser/Makefile
@@ -7,33 +7,25 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=pycparser
-PKG_VERSION:=2.14
-PKG_RELEASE:=4
+PKG_NAME:=python-pycparser
+PKG_VERSION:=2.17
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pycparser
-PKG_HASH:=7959b4a74abdc27b312fed1c21e6caf9309ce0b29ea86b591fd2e99ecdf27f73
+PKG_SOURCE:=pycparser-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/be/64/1bb257ffb17d01f4a38d7ce686809a736837ad4371bcc5c42ba7a715c3ac
+PKG_HASH:=0aac31e917c24cb3357f5a4d5566f2cc91a19ca41862f6c3c22dc60a629673b6
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
-HOST_BUILD_DEPENDS:=python-ply/host
-ifdef CONFIG_PACKAGE_python-pycparser
-HOST_BUILD_DEPENDS+=python/host
-endif
-ifdef CONFIG_PACKAGE_python3-pycparser
-HOST_BUILD_DEPENDS+=python3/host
-endif
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pycparser-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
-include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
 $(call include_mk, python3-package.mk)
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-pycparser/Default
   SECTION:=lang
@@ -45,14 +37,14 @@ endef
 define Package/python-pycparser
 $(call Package/python-pycparser/Default)
   TITLE:=python-pycparser
-  DEPENDS:=+python-light +python-ply
+  DEPENDS:=+PACKAGE_python-pycparser:python-light +PACKAGE_python-pycparser:python-ply
   VARIANT:=python
 endef
 
 define Package/python3-pycparser
 $(call Package/python-pycparser/Default)
   TITLE:=python3-pycparser
-  DEPENDS:=+python3-light +python3-ply
+  DEPENDS:=+PACKAGE_python3-pycparser:python3-light +PACKAGE_python3-pycparser:python3-ply
   VARIANT:=python3
 endef
 
@@ -67,28 +59,6 @@ $(call Package/python-pycparser/description)
 .
 (Variant for Python3)
 endef
-
-ifdef CONFIG_PACKAGE_python-pycparser
-define Host/Compile/python-pycparser
-	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-endif
-
-ifdef CONFIG_PACKAGE_python3-pycparser
-define Host/Compile/python3-pycparser
-	$(call Build/Compile/HostPy3Mod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-endif
-
-define Host/Compile
-$(call Host/Compile/python-pycparser)
-$(call Host/Compile/python3-pycparser)
-endef
-
-define Host/Install
-endef
-
-$(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-pycparser))
 $(eval $(call BuildPackage,python-pycparser))

--- a/lang/python/python-six/Makefile
+++ b/lang/python/python-six/Makefile
@@ -9,16 +9,15 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-six
 PKG_VERSION:=1.10.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=six-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/source/s/six
 PKG_MD5SUM:=34eed507548117b2ab523ab14b2f8b55
 
 HOST_BUILD_DEPENDS:=python/host
-PKG_BUILD_DEPENDS:=python
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-six-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -27,17 +26,30 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
+$(call include_mk, python3-package.mk)
 
 PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 HOST_UNPACK:=$(HOST_TAR) -C $(HOST_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
+define Package/python-six/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://pypi.python.org/pypi/six
+endef
+
 define Package/python-six
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-six
-	URL:=https://pypi.python.org/pypi/six
-	DEPENDS:=+python-light
+$(call Package/python-six/Default)
+  TITLE:=python-six
+  DEPENDS:=+PACKAGE_python-six:python-light
+  VARIANT:=python
+endef
+
+define Package/python3-six
+$(call Package/python-six/Default)
+  TITLE:=python3-six
+  DEPENDS:=+PACKAGE_python3-six:python3-light
+  VARIANT:=python3
 endef
 
 define Package/python-six/description
@@ -47,8 +59,10 @@ writing Python code that is compatible on both Python versions.  See the
 documentation for more information on what is provided.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-six/description
+$(call Package/python-six/description)
+.
+(Variant for Python3)
 endef
 
 define Host/Compile
@@ -61,3 +75,5 @@ $(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-six))
 $(eval $(call BuildPackage,python-six))
+$(eval $(call Py3Package,python3-six))
+$(eval $(call BuildPackage,python3-six))

--- a/lang/python/python/files/python-package-install.sh
+++ b/lang/python/python/files/python-package-install.sh
@@ -45,6 +45,9 @@ process_filespec "$src_dir" "$dst_dir" "$filespec" || {
 	exit 1
 }
 
+# delete egg-info directories
+find "$dst_dir" -name "*.egg-info" | xargs rm -rf
+
 if [ "$mode" == "sources" ] ; then
 	# Copy only python source files
 	find $dst_dir -not -name "*\.py" | xargs rm -f

--- a/lang/python/python/files/python-package.mk
+++ b/lang/python/python/files/python-package.mk
@@ -132,8 +132,10 @@ define PyBuild/Compile/Default
 	)
 endef
 
+PyBuild/Compile=$(PyBuild/Compile/Default)
+
 ifeq ($(BUILD_VARIANT),python)
 define Build/Compile
-	$(call PyBuild/Compile/Default)
+	$(call PyBuild/Compile)
 endef
 endif # python

--- a/lang/python/python3/files/python3-package-install.sh
+++ b/lang/python/python3/files/python3-package-install.sh
@@ -45,6 +45,9 @@ process_filespec "$src_dir" "$dst_dir" "$filespec" || {
 	exit 1
 }
 
+# delete egg-info directories
+find "$dst_dir" -name "*.egg-info" | xargs rm -rf
+
 if [ "$mode" == "sources" ] ; then
 	# Copy only python source files
 	find $dst_dir -not -name "*\.py" | xargs rm -f

--- a/lang/python/python3/files/python3-package.mk
+++ b/lang/python/python3/files/python3-package.mk
@@ -132,8 +132,10 @@ define Py3Build/Compile/Default
 	)
 endef
 
+Py3Build/Compile=$(Py3Build/Compile/Default)
+
 ifeq ($(BUILD_VARIANT),python3)
 define Build/Compile
-	$(call Py3Build/Compile/Default)
+	$(call Py3Build/Compile)
 endef
 endif # python3


### PR DESCRIPTION
Maintainer: me, @dangowrt, @jefferyto 
Compile tested: https://github.com/lede-project/source/commit/a3d232e1e6e5a49e7d1c1d9bc56be9ebd8ae6171 x86_64
Run tested: https://github.com/lede-project/source/commit/a3d232e1e6e5a49e7d1c1d9bc56be9ebd8ae6171 x86_64

Description:

I'm touching on a few python packages.
* python,python3: remove .egg-info dirs from packages ; they're useless
* pyodbc: fix python-pyodbc variant ; wasn't working
* for python-cffi (deps & variants) : drop host builds ; newer version does not seem to require host build ; so w00h00 ; shorter build times
* python-six : add python3-six variant ; this will be needed for python3-cryptography variant ; not sure, whether to do it; but let's see

For all python & python3 variants: added conditional DEPENDS ; seems that both Python & Python3 interpreters are built only if building `python-xxx` variant (or the other).
This should also reduce build times.

All of these changes were tested on x86_64 VM ; quick testing ; start python & python3 interpreters, import packages, do dir (<imported_package>)

Will monitor build bot for the next few days to watch for any fallout I did not see locally.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>