### PR TITLE
i2c-lua: relocated upstream repo, update to upstream v1.1.2

### DIFF
--- a/lang/luai2c/Makefile
+++ b/lang/luai2c/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 OpenWrt.org
+# Copyright (C) 2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,16 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luai2c
-PKG_VERSION:=1.0.0
-PKG_RELEASE:=3
+PKG_VERSION:=1.1.2
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Frank Edelhaeuser <mrpace2@gmail.com>
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/mrpace2/i2c-lua.git
+PKG_SOURCE_URL:=https://github.com/mrpace2/lua-i2c.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=$(PKG_VERSION)
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -26,7 +26,7 @@ define Package/luai2c
 	SECTION:=lang
 	CATEGORY:=Languages
 	TITLE:=Lua I2C binding
-	URL:=https://github.com/mrpace2/i2c-lua/
+	URL:=https://github.com/mrpace2/lua-i2c/
 	DEPENDS:=+liblua +kmod-i2c-core
 	MAINTAINER:=Frank Edelhaeuser <mrpace2@gmail.com>
 endef


### PR DESCRIPTION
Maintainer: @mrpace2
Compile tested: ar71xx

Description:

- adjustments for relocated upstream repo
- bumped version to latest from upstream