### PR TITLE
python: fix intermitent build failure

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -192,12 +192,6 @@ endef
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/ $(1)/usr/lib/ $(1)/usr/lib/pkgconfig
 	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON_VERSION)/
-	$(INSTALL_DATA) \
-		./files/python-package.mk \
-		./files/python-host.mk \
-		./files/python-version.mk \
-		./files/python-package-install.sh \
-		$(STAGING_DIR)/mk/
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/include/python$(PYTHON_VERSION) \
 		$(1)/usr/include/


### PR DESCRIPTION
Maintainer: me
Compile tested: github.com/lede-project/source/commit/a3d232e1e6e5a49e7d1c1d9bc56be9ebd8ae6171 ar71xx
Run tested: N/A

-------------------------------

Fixes: https://github.com/openwrt/packages/issues/4548

When running parallel jobs, there are chances
that the Build/InstallDev rule may run before
the Host/Install rule and fail the build.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>