### PR TITLE
travelmate: update 0.8.1

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=0.8.0
+PKG_VERSION:=0.8.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -11,7 +11,7 @@ trm_script="/usr/bin/travelmate.sh"
 
 boot()
 {
-    ubus -t 30 wait_for network.interface 2>/dev/null
+    ubus -t 30 wait_for network.interface network.wireless hostapd.wlan0 2>/dev/null
     rc_procd start_service
 }
 

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-trm_ver="0.8.0"
+trm_ver="0.8.1"
 trm_sysver="$(ubus -S call system board | jsonfilter -e '@.release.description')"
 trm_enabled=0
 trm_debug=0
@@ -31,10 +31,6 @@ then
 else
     f_log "error" "system libraries not found"
 fi
-
-# initial wireless recovery
-#
-ubus call network.wireless up
 
 # f_envload: load travelmate environment
 #
@@ -60,13 +56,6 @@ f_envload()
     then
         f_log "info " "travelmate is currently disabled, please set 'trm_enabled' to '1' to use this service"
         exit 0
-    fi
-
-    # check for wireless tool
-    #
-    if [ -z "${trm_iwinfo}" ]
-    then
-        f_log "error" "no wireless tool found, please install package 'iwinfo'"
     fi
 }
 


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: LEDE Reboot SNAPSHOT r4529-05d6e92594

Description:
* wait for hostapd comes up during boot
* remove needless ubus call during script startup
* remove needless iwinfo check (covered by package dependency)

Signed-off-by: Dirk Brenken <dev@brenken.org>
