### PR TITLE
clamav: Fix OpenSSL dependency

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clamav
 PKG_VERSION:=0.99.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr> \
@@ -71,6 +71,7 @@ define Build/Configure
 		--with-user nobody \
 		--with-group nogroup \
 		--with-pcre="$(STAGING_DIR)/usr/" \
+		--with-openssl="$(STAGING_DIR)/usr/" \
 	)
 endef
 


### PR DESCRIPTION
Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Maintainer: me 
Compile/Run tested: x86 Lede r4531-c2a4f14

Description:
Should fix #4549 because buildbots are failing at finding OpenSSL path