### PR TITLE
python,python3: rename PyBuild/Compile rules & remove .egg-info from packages

### DIFF
--- a/lang/python/python-lxml/Makefile
+++ b/lang/python/python-lxml/Makefile
@@ -37,14 +37,14 @@ endef
 define Package/python-lxml
 $(call Package/python-lxml/Default)
   TITLE:=python-lxml
-  DEPENDS+=+python-light +python-codecs
+  DEPENDS+=+PACKAGE_python-lxml:python-light +PACKAGE_python-lxml:python-codecs
   VARIANT:=python
 endef
 
 define Package/python3-lxml
 $(call Package/python-lxml/Default)
   TITLE:=python3-lxml
-  DEPENDS+=+python3-light
+  DEPENDS+=+PACKAGE_python3-lxml:python3-light
   VARIANT:=python3
 endef
 
@@ -61,7 +61,7 @@ endef
 
 TARGET_LDFLAGS += -lxml2 -lxslt -lexslt
 
-define PyBuild/Compile/Default
+define PyBuild/Compile
 	$(call Build/Compile/PyMod,, \
 		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
 		--static \
@@ -74,7 +74,7 @@ define PyBuild/Compile/Default
 	)
 endef
 
-define Py3Build/Compile/Default
+define Py3Build/Compile
 	$(call Build/Compile/Py3Mod,, \
 		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
 		--static \

--- a/lang/python/python/files/python-package-install.sh
+++ b/lang/python/python/files/python-package-install.sh
@@ -45,6 +45,9 @@ process_filespec "$src_dir" "$dst_dir" "$filespec" || {
 	exit 1
 }
 
+# delete egg-info directories
+find "$dst_dir" -name "*.egg-info" | xargs rm -rf
+
 if [ "$mode" == "sources" ] ; then
 	# Copy only python source files
 	find $dst_dir -not -name "*\.py" | xargs rm -f

--- a/lang/python/python/files/python-package.mk
+++ b/lang/python/python/files/python-package.mk
@@ -132,8 +132,10 @@ define PyBuild/Compile/Default
 	)
 endef
 
+PyBuild/Compile=$(PyBuild/Compile/Default)
+
 ifeq ($(BUILD_VARIANT),python)
 define Build/Compile
-	$(call PyBuild/Compile/Default)
+	$(call PyBuild/Compile)
 endef
 endif # python

--- a/lang/python/python3/files/python3-package-install.sh
+++ b/lang/python/python3/files/python3-package-install.sh
@@ -45,6 +45,9 @@ process_filespec "$src_dir" "$dst_dir" "$filespec" || {
 	exit 1
 }
 
+# delete egg-info directories
+find "$dst_dir" -name "*.egg-info" | xargs rm -rf
+
 if [ "$mode" == "sources" ] ; then
 	# Copy only python source files
 	find $dst_dir -not -name "*\.py" | xargs rm -f

--- a/lang/python/python3/files/python3-package.mk
+++ b/lang/python/python3/files/python3-package.mk
@@ -132,8 +132,10 @@ define Py3Build/Compile/Default
 	)
 endef
 
+Py3Build/Compile=$(Py3Build/Compile/Default)
+
 ifeq ($(BUILD_VARIANT),python3)
 define Build/Compile
-	$(call Py3Build/Compile/Default)
+	$(call Py3Build/Compile)
 endef
 endif # python3


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/lede-project/source/commit/a3d232e1e6e5a49e7d1c1d9bc56be9ebd8ae6171 x86_64
Run tested: https://github.com/lede-project/source/commit/a3d232e1e6e5a49e7d1c1d9bc56be9ebd8ae6171 x86_64
Description:

-------------------------------

Renaming ` PyBuild/Compile/Default` to ` PyBuild/Compile` [ and the Python3 variant ] allows users to do something like:
```
define  PyBuild/Compile
$(call  PyBuild/Compile/Default)
< do extra stuff >
endef
```

And for the `.egg-info` dirs: removing them from packages, since they just take up space.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>