### PR TITLE
pyodbc: fix python-pyodbc variant ; wasn't working

### DIFF
--- a/lang/python/pyodbc/Makefile
+++ b/lang/python/pyodbc/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pyodbc
 PKG_VERSION:=4.0.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/ce/57/6b92aa5b3497dde6be55fd6fcb76c7db215ed1d56fde45c613add4a43095/
@@ -29,19 +29,22 @@ define Package/python-pyodbc/Default
   CATEGORY:=Languages
   SUBMENU:=Python
   URL:=https://github.com/mkleehammer/pyodbc
+  DEPENDS:=+unixodbc +libstdcpp
 endef
 
 define Package/python-pyodbc
 $(call Package/python-pyodbc/Default)
   TITLE:=python-pyodbc
-  DEPENDS:=+unixodbc +libstdcpp +python-light
+  DEPENDS+=+PACKAGE_python-pyodbc:python-light \
+           +PACKAGE_python-pyodbc:python-logging \
+           +PACKAGE_python-pyodbc:python-openssl
   VARIANT:=python
 endef
 
 define Package/python3-pyodbc
 $(call Package/python-pyodbc/Default)
   TITLE:=python3-pyodbc
-  DEPENDS:=+unixodbc +libstdcpp +python3-light
+  DEPENDS+=+PACKAGE_python3-pyodbc:python3-light
   VARIANT:=python3
 endef
 


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: https://github.com/lede-project/source/commit/a3d232e1e6e5a49e7d1c1d9bc56be9ebd8ae6171 x86_64
Run tested: https://github.com/lede-project/source/commit/a3d232e1e6e5a49e7d1c1d9bc56be9ebd8ae6171 x86_64

------------------------------------------

Python3 variant was working fine.

Also add add PACKAGE_python-pyodbc conditional depend for python packages

Otherwise, both Python & Python3 interpreters get built,
even tho only one variant is selected.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>