### PR TITLE
libnet-1.2.x: simplify build dep installation

### DIFF
--- a/libs/libnet-1.2.x/Makefile
+++ b/libs/libnet-1.2.x/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnet
 PKG_VERSION:=1.2-rc3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://sourceforge.net/projects/libnet-dev/files/
@@ -53,14 +53,14 @@ endef
 
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib/libnet-1.2.x/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/libnet.h $(STAGING_DIR)/usr/lib/libnet-1.2.x/include
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libnet.h $(STAGING_DIR)/usr/include
 
-	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib/libnet-1.2.x/include/libnet
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/libnet/libnet-*.h $(STAGING_DIR)/usr/lib/libnet-1.2.x/include/libnet
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/include/libnet
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libnet/libnet-*.h $(STAGING_DIR)/usr/include/libnet
 
-	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib/libnet-1.2.x/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnet.{a,la,so*} $(STAGING_DIR)/usr/lib/libnet-1.2.x/lib
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnet.{a,la,so*} $(STAGING_DIR)/usr/lib
 endef
 
 define Package/libnet-1.2.x/install

--- a/net/netdiscover/Makefile
+++ b/net/netdiscover/Makefile
@@ -30,10 +30,6 @@ define Package/netdiscover
   URL:=https://sourceforge.net/projects/netdiscover
 endef
 
-CONFIGURE_VARS+= \
-	CPPFLAGS="$(TARGET_CPPFLAGS) -I$(STAGING_DIR)/usr/lib/libnet-1.2.x/lib" \
-	LDFLAGS="$(TARGET_LDFLAGS) -L$(STAGING_DIR)/usr/lib/libnet-1.2.x/lib"
-
 define Package/netdiscover/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/netdiscover $(1)/usr/sbin/


### PR DESCRIPTION
Signed-off-by: Stefan Tomanek <stefan.tomanek@wertarbyte.de>

Maintainer: me / @wertarbyte
Compile tested: ar71xx, TP-Link Archer C7, LEDE 17.01.2
Run tested: ar71xx, TP-Link Archer C7, LEDE 17.01.2, tested basic functionality
Description: Install include files and libraries into a common place; this makes compiling depending packages easier.
