### PR TITLE
lm-sensors: update name of configuration file

### DIFF
--- a/utils/lm-sensors/Makefile
+++ b/utils/lm-sensors/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lm-sensors
 PKG_VERSION:=3.3.5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/groeck/lm-sensors.git
@@ -66,6 +66,7 @@ endef
 
 define Package/lm-sensors/conffiles
 /etc/sensors.conf
+/etc/sensors3.conf
 endef
 
 define Build/Compile


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: x86_64, generic, LEDE HEAD (05d6e92)
Run tested: same

Rebuilt, installed `.ipk` file, looked at `/usr/lib/opkg/status` and confirmed `Conffiles` section for `lm-sensors` package.

Description:

The wrong `.conf` file is being listed as the configuration file for lm-sensors.