### PR TITLE
unixodbc: fix cross-compile drivers

### DIFF
--- a/libs/unixodbc/Makefile
+++ b/libs/unixodbc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unixodbc
 PKG_VERSION:=2.3.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=ftp://ftp.unixodbc.org/pub/unixODBC/
 PKG_SOURCE:=unixODBC-$(PKG_VERSION).tar.gz
@@ -22,7 +22,8 @@ include $(INCLUDE_DIR)/package.mk
 CONFIGURE_ARGS += \
 	--disable-gui \
 	--with-pic \
-	--enable-drivers
+	--enable-drivers \
+	--includedir=$(STAGING_DIR)/usr/include
 
 define Package/unixodbc/Default
   SUBMENU:=database
@@ -73,6 +74,12 @@ define Build/Compile
 		$(MAKE_FLAGS) \
 		ARCH="$(ARCH)" \
 		CC="$(TARGET_CC)"
+	rm $(PKG_BUILD_DIR)/exe/{odbc_config,odbc-config.o}
+	$(MAKE) -C $(PKG_BUILD_DIR)/exe \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		CC="$(HOSTCC)" \
+		CFLAGS="$(HOST_CFLAGS) -DUSE_UNIXODBC_CONF_H" \
+		LDFLAGS="$(HOST_LDFLAGS)"
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		DESTDIR="$(PKG_INSTALL_DIR)" \
 		$(MAKE_FLAGS) \
@@ -81,10 +88,12 @@ define Build/Compile
 endef
 
 define Build/InstallDev
+	$(INSTALL_DIR) $(1)/host/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/odbc_config $(1)/host/bin
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	$(LN) ../../host/bin/odbc_config $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/$(STAGING_DIR)/usr/include/*.h $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/etc
@@ -105,7 +114,7 @@ endef
 
 define Package/unixodbc-tools/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/{dltest,isql,iusql,odbcinst,slencheck} $(1)/usr/bin/
 endef
 
 define Package/pgsqlodbc/install

--- a/libs/unixodbc/patches/100-cross-compile-odbc-config.patch
+++ b/libs/unixodbc/patches/100-cross-compile-odbc-config.patch
@@ -1,0 +1,36 @@
+--- a/exe/odbc-config.c
++++ b/exe/odbc-config.c
+@@ -40,6 +40,33 @@
+ #include <unistd.h>
+ #endif
+ 
++#ifdef USE_UNIXODBC_CONF_H
++
++#ifdef HAVE_UNISTD_H
++#undef HAVE_UNISTD_H
++#endif
++#ifdef HAVE_PWD_H
++#undef HAVE_PWD_H
++#endif
++#ifdef HAVE_SYS_TYPES_H
++#undef HAVE_SYS_TYPES_H
++#endif
++#ifdef HAVE_LONG_LONG
++#undef HAVE_LONG_LONG
++#endif
++#ifdef ODBCINT64
++#undef ODBCINT64
++#endif
++#ifdef UODBCINT64
++#undef UODBCINT64
++#endif
++#ifdef SIZEOF_LONG_INT
++#undef SIZEOF_LONG_INT
++#endif
++
++#include <unixodbc_conf.h>
++#endif
++
+ #include <sql.h>
+ 
+ static void usage( void )


### PR DESCRIPTION
Maintainer: @heil 
Compile tested: x86/64, x86/generic
Run tested: x86/64, x86/generic

Description:
build odbc_config for host so drivers may use it to figure out build
details, patch odbc_config to return target specific values from
unixodbc_conf.h.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>
