### PR TITLE
vnstat: Add support for uci configuration

### DIFF
--- a/net/vnstat/files/vnstat.init
+++ b/net/vnstat/files/vnstat.init
@@ -2,88 +2,201 @@
 # Copyright (C) 2008-2011 OpenWrt.org
 
 START=99
+USE_PROCD=1
+
+TCONF=/tmp/vnstat.generated.conf
+CONF=/etc/vnstat.conf
+PID_FILE=/var/run/vnstat/vnstat.pid
+DATABASE_DIR=
 
 vnstat_option() {
 	sed -ne "s/^[[:space:]]*$1[[:space:]]*['\"]\([^'\"]*\)['\"].*/\1/p" \
 		/etc/vnstat.conf
 }
 
-start() {
-	local lib="$(vnstat_option DatabaseDir)"
-	local pid="$(vnstat_option PidFile)"
-
-	[ -n "$lib" ] || {
-		echo "Error: No DatabaseDir set in vnstat.conf" >&2
-		exit 1
-	}
-
-	[ -n "$pid" ] || {
-		echo "Error: No PidFile set in vnstat.conf" >&2
-		exit 1
-	}
-
-	mkdir -p "$lib"
-
-	init_ifaces() {
-		local cfg="$1"
-		local url lnk
-
-		init_iface() {
-			local ifn="$1"
-
-			if [ -n "$url" ]; then
-				local try=0
-				local max=3
-				local hostname="$(cat /proc/sys/kernel/hostname)"
-
-				while [ $((++try)) -le $max ]; do
-					if wget -q -O "$lib/$ifn" "$url/${hostname}_$ifn" 2>/dev/null && [ -e "$lib/$ifn" ]; then
-						logger -t "vnstat" "Downloaded backup for database $ifn"
-						break
-					else
-						logger -t "vnstat" "Download try $try/$max for database $ifn failed"
-						sleep 30
-					fi
-				done
-			elif [ -n "$backup_dir" ]; then
-				if cp -f "$backup_dir/$ifn" "$lib/" &>/dev/null; then
-					logger -t "vnstat" "Restored backup for database $ifn"
-				else
-					logger -t "vnstat" "Restore of backup for database $ifn failed"
-				fi
-			fi
-
-			/usr/bin/vnstat -u -i "$ifn" >/dev/null
-
-			[ -n "$lnk" ] && {
-				mkdir -p "$lnk"
-				[ -L "$lnk/$ifn" ] || ln -s "$lib/$ifn" "$lnk/$ifn"
-			}
-		}
-
-		config_get url "$cfg" remote
-		config_get lnk "$cfg" symlink
-		config_get backup_dir "$cfg" backup_dir
-		config_list_foreach "$cfg" interface init_iface
-
-		return 1
-	}
-
-	config_load vnstat
-	config_foreach init_ifaces vnstat
-
-	SERVICE_PID_FILE="${pid}"
-	service_start /usr/sbin/vnstatd -d
+# Usage: append_(string/number/bool) cfg uci_name output_name
+# add a config line of the form "output_name <value>"
+# if the "uci_name" was found, if not export default
+# output_name defaults to uci_name if not specified.
+append_string() {
+    local cfg="$1"
+    local uci_name="$2"
+    local out_name="$3"
+    if [ -z "$out_name" ]; then
+        out_name=$uci_name
+    fi
+    config_get val $cfg $uci_name
+    if [ -n "$val" ]; then
+        echo "$out_name \"$val\"" >> $TCONF
+    fi
 }
 
-stop() {
-	local pid="$(vnstat_option PidFile)"
+append_number() {
+    local cfg="$1"
+    local uci_name="$2"
+    local out_name="$3"
+    if [ -z "$out_name" ]; then
+        out_name=$uci_name
+    fi
+    config_get val $cfg $uci_name
+    if [ -n "$val" ]; then
+        echo "$out_name $val" >> $TCONF
+    fi
+}
 
-	[ -n "$pid" ] || {
-		echo "Error: No PidFile set in vnstat.conf" >&2
-		exit 1
-	}
+# as per append_if, but gets the value as a uci bool, not raw
+append_bool() {
+    local cfg="$1"
+    local uci_name="$2"
+    local out_name="$3"
+    config_get val $cfg $uci_name
+    if [ -n "$val" ]; then
+        config_get_bool real $cfg $uci_name
+        echo "$out_name $real" >> $TCONF
+    fi
+}
 
-	SERVICE_PID_FILE="${pid}"
-	service_stop /usr/sbin/vnstatd
+# Build generated conf file from uci
+convert_uci() {
+    local cfg="$1"
+
+    rm -rf $TCONF
+    echo "Generating vnstat config file in $TCONF"
+    echo "# vnstat.conf file generated from UCI config." >> $TCONF
+
+    append_string $cfg database_dir      "DatabaseDir"
+    append_string $cfg default_interface "Interface"
+    append_string $cfg log_file          "LogFile"
+
+    append_number $cfg update_interval   "UpdateInterval"
+    append_number $cfg poll_interval     "PollInterval"
+    append_number $cfg save_interval     "SaveInterval"
+
+    append_bool   $cfg create_dirs       "CreateDirs"
+    append_string $cfg pid_file          "PidFile"
+
+    # Extract pid file if overriden in uci
+    config_get new_pid $cfg pid_file
+    if [ -n "$new_pid" ]; then
+        PID_FILE=$new_pid
+    fi
+
+    # Process database directory
+    config_get DATABASE_DIR $cfg database_dir
+    config_get_bool create_dirs $cfg create_dirs
+    if [ "$create_dirs" -eq 1 ]; then
+        # if enabled, ensure the folder is created
+        mkdir -p "$DATABASE_DIR"
+    else
+        if [ ! -d "$DATABASE_DIR" ]; then
+            logger -t vnstat "Database Directory[$DATABASE_DIR] not found, exiting..."
+            exit 1
+        fi
+    fi
+}
+
+start_service_real() {
+    local cfg="$1"
+
+    config_load vnstat
+
+    # Determine if we are configuring via UCI or directly from /etc/vnstat.conf
+    local use_uci
+    config_get_bool use_uci "$cfg" use_uci
+    if [ "$use_uci" == "1" ]; then
+        CONF=$TCONF
+        convert_uci $1
+    else
+        local lib="$(vnstat_option DatabaseDir)"
+        local pid="$(vnstat_option PidFile)"
+
+        [ -n "$lib" ] || {
+            echo "Error: No DatabaseDir set in vnstat.conf" >&2
+            exit 1
+        }
+
+        [ -n "$pid" ] || {
+            echo "Error: No PidFile set in vnstat.conf" >&2
+            exit 1
+        }
+
+        mkdir -p "$lib"
+
+        PID_FILE=$pid
+        DATABASE_DIR=$lib
+    fi
+
+    # Initialise databases and handle restoration of backup
+
+    init_iface() {
+        local ifn="$1"
+
+        if [ -n "$url" ]; then
+            local try=0
+            local max=3
+            local hostname="$(cat /proc/sys/kernel/hostname)"
+
+            while [ $((++try)) -le $max ]; do
+                if wget -q -O "$lib/$ifn" "$url/${hostname}_$ifn" 2>/dev/null && [ -e "$lib/$ifn" ]; then
+                    logger -t "vnstat" "Downloaded backup for database $ifn"
+                    break
+                else
+                    logger -t "vnstat" "Download try $try/$max for database $ifn failed"
+                    sleep 30
+                fi
+            done
+        elif [ -n "$backup_dir" ]; then
+            if cp -f "$backup_dir/$ifn" "$lib/" &>/dev/null; then
+                logger -t "vnstat" "Restored backup for database $ifn"
+            else
+                logger -t "vnstat" "Restore of backup for database $ifn failed"
+            fi
+        fi
+
+        /usr/bin/vnstat -u -i "$ifn" --config $CONF >/dev/null
+
+        [ -n "$lnk" ] && {
+            mkdir -p "$lnk"
+            [ -L "$lnk/$ifn" ] || ln -s "$lib/$ifn" "$lnk/$ifn"
+        }
+    }
+
+    local url lnk backup_dir
+    config_get url "$cfg" remote
+    config_get lnk "$cfg" symlink
+    config_get backup_dir "$cfg" backup_dir
+
+    config_list_foreach "$cfg" interface init_iface
+
+    # Handle database creation semantics and debug option
+    local always_add no_add debug
+    config_get_bool always_add "$cfg" always_add
+    config_get_bool no_add "$cfg" no_add
+    config_get_bool debug "$cfg" debug
+
+    # if we are using UCI, and no_add is not set, enable it as the interface
+    #  update (-u) above will create the databases for selected interfaces only.
+    if [ -z "$no_add" ] && [ "$use_uci" == "1" ]; then
+        no_add=1
+    fi
+
+    # Define the service in procd
+    procd_open_instance
+    procd_set_param command vnstatd
+    procd_append_param command -d
+    procd_append_param command --config $CONF
+    [ "$always_add" == "1" ] && procd_append_param command --alwaysadd
+    [ "$no_add" == "1" ] && procd_append_param command --noadd
+    [ "$debug" == "1" ] && procd_append_param command --debug
+    procd_set_param file $CONF
+    procd_close_instance
+}
+
+start_service() {
+    config_load vnstat
+    config_foreach start_service_real vnstat
+}
+
+service_triggers() {
+    procd_add_reload_trigger "vnstat"
 }

--- a/net/vnstat/files/vnstat.init
+++ b/net/vnstat/files/vnstat.init
@@ -103,7 +103,7 @@ start_service_real() {
     # Determine if we are configuring via UCI or directly from /etc/vnstat.conf
     local use_uci
     config_get_bool use_uci "$cfg" use_uci
-    if [ "$use_uci" == "1" ]; then
+    if [ "$use_uci" = "1" ]; then
         CONF=$TCONF
         convert_uci $1
     else
@@ -176,7 +176,7 @@ start_service_real() {
 
     # if we are using UCI, and no_add is not set, enable it as the interface
     #  update (-u) above will create the databases for selected interfaces only.
-    if [ -z "$no_add" ] && [ "$use_uci" == "1" ]; then
+    if [ -z "$no_add" ] && [ "$use_uci" = "1" ]; then
         no_add=1
     fi
 
@@ -185,9 +185,9 @@ start_service_real() {
     procd_set_param command vnstatd
     procd_append_param command -d
     procd_append_param command --config $CONF
-    [ "$always_add" == "1" ] && procd_append_param command --alwaysadd
-    [ "$no_add" == "1" ] && procd_append_param command --noadd
-    [ "$debug" == "1" ] && procd_append_param command --debug
+    [ "$always_add" = "1" ] && procd_append_param command --alwaysadd
+    [ "$no_add" = "1" ] && procd_append_param command --noadd
+    [ "$debug" = "1" ] && procd_append_param command --debug
     procd_set_param file $CONF
     procd_close_instance
 }


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: ar71xx, custom(AR9331), LEDE 1.17.01
Run tested: ar71xx, custom(AR9331), LEDE 1.17.01

Description:

Modelled from mosquitto approach which creates /tmp/vnstat.generated.conf based on use_uci option (disabled by default for backward compatibility.

Supports configuration mappings: -

- database_dir (string) -> DatabaseDir
- default_interface (string) -> Interface
- log_file (string) -> LogFile
- update_interval (number) -> UpdateInterval
- poll_interval (number) -> PollInterval
- save_interval (number) -> SaveInterval
- create_dirs (bool) -> CreateDirs
- pid_file (string) -> PidFile

Supports command line options: -

- always_add (bool)
- no_add (bool) -> default to true if use_uci is enabled
- debug (bool)

Backup/restore from URL system should still work (untested)
Updated to use procd

Signed-off-by: David Thornley <david.thornley@touchstargroup.com>
