### PR TITLE
netsnmp: add global enabled config option

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.7.3
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/files/snmpd.conf
+++ b/net/net-snmp/files/snmpd.conf
@@ -116,4 +116,5 @@ config engineid
 #	option trapsess	'-v 3 -e 0x80001f88808c18d3f7b0000 -u trapuser -a MD5 -A administrator -l authPriv -x DES -X rootpasswd udp:127.0.0.1:162'
 
 config snmpd general
+	option enabled '1'
 #	list network 'wan'

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -272,9 +272,12 @@ snmpd_setup_fw_rules() {
 start_service() {
 	[ -f "$CONFIGFILE" ] && rm -f "$CONFIGFILE"
 
-	procd_open_instance
-
 	config_load snmpd
+
+	config_get_bool snmp_enabled general enabled 1
+	[ "$snmp_enabled" -eq 0 ] && return
+
+	procd_open_instance
 
 	config_foreach snmpd_agent_add agent
 	config_foreach snmpd_agentx_add agentx


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: brcm63xx, LEDE trunk
Run tested: brcm63xx, LEDE trunk

Description:
Add enabled config option in the global uci section; it allows to put into
place the snmpd config but not yet start the netsnmp daemon.
If config option is unset; netsnmp daemon will be started as before.