### PR TITLE
syslog-ng: procdify and add proper reload support

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include  $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.9.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 

--- a/admin/syslog-ng/files/syslog-ng.init
+++ b/admin/syslog-ng/files/syslog-ng.init
@@ -2,18 +2,17 @@
 # Copyright (C) 2006-2016 OpenWrt.org
 
 START=20
+USE_PROCD=1
+PROG=/usr/sbin/syslog-ng
 
-SERVICE_USE_PID=1
+config_file=/etc/syslog-ng.conf
 
-start() {
-	[ -f /etc/syslog-ng.conf ] || return 1
-	service_start /usr/sbin/syslog-ng
+start_service() {
+	procd_open_instance
+	procd_set_param command $PROG -F -f $config_file
+	procd_close_instance
 }
 
-stop() {
-	service_stop /usr/sbin/syslog-ng
-}
-
-reload() {
-	service_reload /usr/sbin/syslog-ng
+reload_service() {
+	procd_send_signal syslog-ng
 }


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, generic, LEDE HEAD (2be6037)
Run tested: same

Manually copied `files/syslog-ng.init` to target's `/etc/init.d/syslog-ng`
`chmod 755 /etc/init.d/syslog-ng`
`killall syslog-ng`
`/etc/init.d/syslog-ng start`
`ps -lww | grep syslog-ng` to verify it's running
`/etc/init.d/syslog-ng reload`
`egrep "syslog-ng.*: Configuration reload request" /var/log/messages` to verify reload


Description:

Add `procd` support (and SIGHUP-based `reload`) to the init script.