### PR TITLE
lighttpd: add 'reload' to init script to make logrotate-friendly

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.45
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x

--- a/net/lighttpd/files/lighttpd.init
+++ b/net/lighttpd/files/lighttpd.init
@@ -28,3 +28,6 @@ start_service() {
 	procd_close_instance
 }
 
+reload_service() {
+	procd_send_signal lighttpd
+}


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, generic, LEDE HEAD (2be6037)
Run tested: same

Remote copy `files/lighttpd.init` to target's `/etc/init.d/lighttpd`
`/etc/init.d/lighttpd reload`
`tail /var/log/lighttpd/error.log` shows `... (server.c.1536) logfiles cycles UID = 0 PID = 1`

Description:

Make lighttpd more friendly to being used with logrotate, where you might have:

```
/var/log/lighttpd/*.log {
    postrotate
        /etc/init.d/lighttpd reload
    endscript
}
```

as part of the `/etc/logrotate.d/lighttpd` configuration.