### PR TITLE
sound/sox: Reduce dependencies

### DIFF
--- a/sound/sox/Makefile
+++ b/sound/sox/Makefile
@@ -10,11 +10,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sox
 PKG_VERSION:=14.4.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/sox
-PKG_MD5SUM:=81a6956d4330e75b5827316e44ae381e6f1e8928003c6aa45896da9041ea149c
+PKG_HASH:=81a6956d4330e75b5827316e44ae381e6f1e8928003c6aa45896da9041ea149c
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=LGPL-2.1 GPL-2.0
@@ -31,9 +31,9 @@ TARGET_LDFLAGS+= \
 define Package/sox
   SECTION:=sound
   CATEGORY:=Sound
-  DEPENDS:=+BUILD_PATENTED:lame-lib +BUILD_PATENTED:libmad +BUILD_PATENTED:libid3tag \
-		+libvorbis +libvorbisidec +alsa-lib +libsndfile +libflac \
-		+libmagic +libpng
+  DEPENDS:=+lame-lib +libmad +libid3tag \
+		+libvorbis +libvorbisidec +alsa-lib +libflac \
+		+libmagic
   TITLE:=Sox is a general purpose sound converter/player/recorder
   URL:=http://sox.sourceforge.net/
 endef
@@ -52,15 +52,11 @@ define Build/Configure
 		--without-ao \
 		--with-alsa \
 		--without-libltdl \
-		--with-ogg \
 		--with-flac \
-		--without-amr-wb \
-		--without-amr-nb \
-		--without-samplerate \
 		--without-ladspa \
-		--$(if $(CONFIG_BUILD_PATENTED),with-mad,without-mad) \
-		--$(if $(CONFIG_BUILD_PATENTED),with-lame,without-lame) \
-		--$(if $(CONFIG_BUILD_PATENTED),with-id3tag,without-id3tag) \
+		--without-png \
+		--with-lame \
+		--with-id3tag \
 	)
 endef
 


### PR DESCRIPTION
Maintainer: @thess 
Compile mvebu, Linksys WRT3200ACM, LEDE trunk
Run tested: No

Description:

Reduce dependencies and remove not used functionality linked in using external libs.

libsndfile: Only needed if SoX's internal file reader chokes
libpng: Only used to generate spectrograms
Clean up configure arguments
libid3tag doesn't fall into the BUILD_PATENTED category as far as I can tell.
Update PKG_MD5SUM (deprecated) to PKG_HASH
Remove BUILD_PATENTED, reference:
#4587

Sources:
http://sox.sourceforge.net/soxformat.html (formats handled by SoX vs libsndfile)
https://sourceforge.net/p/sox/code/ci/master/tree/src/spectrogram.c

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>