### PR TITLE
screen: add option for 256 colors support

### DIFF
--- a/utils/screen/Makefile
+++ b/utils/screen/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=screen
 PKG_VERSION:=4.6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=9433706b653e941cc4c745f28e252e57be2a141eded923e61cc2c4a09768fed4
@@ -38,6 +38,7 @@ endef
 define Build/Configure
 	$(call Build/Configure/Default,\
 		--with-sys-screenrc=/etc/screenrc \
+		--enable-colors256 \
 	)
 	# XXX: memmove() works well with overlapped memory areas
 	echo "#define USEMEMMOVE 1" >>$(PKG_BUILD_DIR)/config.h


### PR DESCRIPTION
Hello @champtar 
I find GNU screen pacakge do not support 256 colors term, but tmux dose.
screen configure need an option --enable-colors256, so I add an option item to make menuconfig. If anyone who need this feature can check it to turn on, it default disable.
for more information please see post: 
https://forum.lede-project.org/t/gnu-screen-no-256-colors-feature/4927

Regards,
ffee