### PR TITLE
sound/lame: Update as MP3 isn't covered by patents

### DIFF
--- a/sound/lame/Makefile
+++ b/sound/lame/Makefile
@@ -30,7 +30,6 @@ define Package/lame/Default
   SECTION:=sound
   CATEGORY:=Sound
   URL:=http://sourceforge.net/projects/lame
-  DEPENDS:=@BUILD_PATENTED
 endef
 
 define Package/lame


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: No
Run tested: No

Description:
In April Technicolor's and Fraunhofer IIS's patents and mp3 licensing programs has been expired and/or terminated.

Sources:
https://www.iis.fraunhofer.de/en/ff/amm/prod/audiocodec/audiocodecs/mp3.html
https://en.wikipedia.org/wiki/MP3#Licensing.2C_ownership_and_legislation

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>