### PR TITLE
sound/mpd: Update to 0.20.9

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpd
-PKG_VERSION:=0.20.8
+PKG_VERSION:=0.20.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.musicpd.org/download/mpd/0.20/
-PKG_HASH:=7d177f29663c4a0997413401e52bbf11d2bb472773bbcf9294f839c4b8751e35
+PKG_HASH:=cd77a2869e32354b004cc6b34fcb0bee56114caa2d9ed862aaa8071441e34eb7
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
 PKG_LICENSE:=GPL-2.0
@@ -27,16 +27,14 @@ PKG_INSTALL:=1
 PKG_USE_MIPS16:=0
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/nls.mk
 
 define Package/mpd/Default
   SECTION:=sound
   CATEGORY:=Sound
   TITLE:=Music Player Daemon
   URL:=http://www.musicpd.org/
-  DEPENDS:= +glib2 +libcurl +libpthread +libmpdclient +libstdcpp $(ICONV_DEPENDS) \
-	    +libflac +BUILD_PATENTED:libmad +libvorbisidec +AUDIO_SUPPORT:alsa-lib \
-            +boost +boost-container +libexpat
+  DEPENDS:= +glib2 +libcurl +libpthread +libmpdclient +libstdcpp \
+	    +AUDIO_SUPPORT:alsa-lib +boost +boost-container +libexpat
 endef
 
 define Package/mpd/Default/description
@@ -49,9 +47,7 @@ endef
 define Package/mpd-full
 $(call Package/mpd/Default)
   TITLE+= (full)
-  DEPENDS+= \
-	+libaudiofile +BUILD_PATENTED:libfaad2 +libffmpeg +libid3tag \
-	+libmms +libogg +libsndfile +libvorbis +libupnp
+  DEPENDS+= +libffmpeg +libid3tag +libmms +libupnp +libshout
   PROVIDES:=mpd
   VARIANT:=full
 endef
@@ -69,6 +65,7 @@ endef
 define Package/mpd-mini
 $(call Package/mpd/Default)
   TITLE+= (mini)
+  DEPENDS+= +libflac +libmpg123 +libvorbisidec
   PROVIDES:=mpd
   VARIANT:=mini
 endef
@@ -101,83 +98,75 @@ define Package/mpd-avahi-service/conffiles
 /etc/avahi/services/mpd.service
 endef
 
-TARGET_CFLAGS += -ggdb3
-TARGET_LDFLAGS += -Wl,-rpath-link=$(STAGING_DIR)/usr/lib $(if $(ICONV_FULL),-liconv)
-EXTRA_CXXFLAGS += $(if $(CONFIG_GCC_VERSION_4_8),-std=gnu++11,-std=gnu++14)
+EXTRA_CXXFLAGS += -std=gnu++14
 
 CONFIGURE_ARGS += \
 	$(call autoconf_bool,CONFIG_IPV6,ipv6) \
 	--disable-debug \
 	--disable-documentation \
 	--disable-test \
-	--disable-werror \
-	\
+	--disable-aac \
+	--disable-adplugin \
 	--disable-ao \
+	--disable-audiofile \
 	--disable-bzip2 \
+	--disable-cdio-paranoia \
 	--disable-fluidsynth \
 	--disable-wildmidi \
 	--disable-gme \
 	--enable-inotify \
 	--disable-icu \
-	--disable-eventfd \
 	--disable-iso9660 \
 	--disable-jack \
 	--disable-roar \
 	--disable-libwrap \
 	--disable-lsr \
+	--disable-mad \
 	--disable-mikmod \
 	--disable-modplug \
 	--disable-mpc \
-	--disable-mpg123 \
+	--disable-nfs \
 	--disable-openal \
 	--disable-opus \
 	--disable-pulse \
 	--disable-sidplay \
+	--disable-smbclient \
+	--disable-sndfile \
 	--disable-solaris-output \
 	--disable-sqlite \
+	--disable-systemd-daemon \
 	--disable-lame-encoder \
 	--disable-twolame-encoder \
 	--disable-shine-encoder \
+	--disable-vorbis-encoder \
 	--enable-wave-encoder \
 	--disable-wavpack \
+	--disable-webdav \
 	--disable-wildmidi \
 	--disable-zzip \
 	--with-zeroconf=no \
 	--disable-soxr \
-	\
 	--enable-curl \
-	--enable-flac \
 	--enable-httpd-output \
-	$(call autoconf_bool,CONFIG_BUILD_PATENTED,mad) \
 	$(call autoconf_bool,CONFIG_AUDIO_SUPPORT,alsa) \
 	--enable-tcp \
-	--enable-un \
-
-CONFIGURE_VARS += \
-	FLAC_CFLAGS="$(TARGET_CFLAGS) -I$(STAGING_DIR)/usr/include/FLAC" \
-	FLAC_LIBS="$(TARGET_LDFLAGS) -lFLAC" \
-	$(if $(CONFIG_BUILD_PATENTED),MAD_CFLAGS="$(TARGET_CFLAGS)") \
-	$(if $(CONFIG_BUILD_PATENTED),MAD_LIBS="$(TARGET_LDFLAGS) -lmad") \
+	--disable-sndio \
+	--disable-haiku \
+	--disable-iconv \
 
 ifeq ($(BUILD_VARIANT),full)
 
   CONFIGURE_ARGS += \
 	--enable-upnp \
-	$(call autoconf_bool,CONFIG_BUILD_PATENTED,aac) \
-	--enable-audiofile \
-	--enable-fifo \
 	--enable-ffmpeg \
+	--disable-flac \
 	--enable-id3 \
 	--enable-mms \
-	--enable-flac \
+	--disable-mpg123 \
 	--enable-pipe-output \
 	--enable-recorder-output \
-	--disable-shout \
-	--enable-sndfile \
-	--enable-vorbis \
-	--disable-vorbis-encoder \
-	--with-tremor=yes \
-
+	--enable-shout \
+	--disable-vorbis
 endif
 
 ifeq ($(BUILD_VARIANT),mini)
@@ -185,20 +174,14 @@ ifeq ($(BUILD_VARIANT),mini)
   # oggflac is not compatible with tremor
   CONFIGURE_ARGS += \
 	--disable-upnp \
-	--disable-aac \
-	--disable-audiofile \
 	--disable-fifo \
 	--disable-ffmpeg \
 	--disable-id3 \
 	--disable-mms \
-	--disable-pipe-output \
-	--disable-recorder-output \
 	--disable-shout \
-	--disable-sndfile \
-	--disable-vorbis \
-	--disable-vorbis-encoder \
+	--enable-vorbis \
 	--with-tremor=yes \
-
+	--disable-recorder-output
 endif
 
 define Package/mpd/install


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: mvebu, Linksys WRT3200ACM, LEDE trunk
Run tested: No

Description:
Update mpd to 0.20.9
Rearrange dependencies
General cleanup of Makefile
Fix compilation

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>