### PR TITLE
nginx: new package nchan, update package lua

### DIFF
--- a/net/nginx/Config.in
+++ b/net/nginx/Config.in
@@ -66,6 +66,11 @@ config NGINX_HTTP_AUTH_BASIC
 	prompt "Enable HTTP auth basic"
 	default y
 
+config NGINX_HTTP_AUTH_REQUEST
+	bool
+	prompt "Enable HTTP auth request module"
+	default n
+
 config NGINX_HTTP_AUTOINDEX
 	bool
 	prompt "Enable HTTP autoindex module"
@@ -167,6 +172,11 @@ config NGINX_HTTP_CACHE
 	prompt "Enable HTTP cache"
 	default y
 
+config NGINX_HTTP_V2
+	bool
+	prompt "Enable HTTP_V2 module"
+	default n
+
 config NGINX_PCRE
 	bool
 	prompt "Enable PCRE library usage"
@@ -182,4 +192,20 @@ config NGINX_LUA
 	prompt "Enable Lua module"
 	default n
 
+config NGINX_HTTP_REAL_IP
+	bool
+	prompt "Enable HTTP real ip module"
+	default n
+
+config NGINX_HTTP_SECURE_LINK
+	bool
+	prompt "Enable HTTP secure link module"
+	default n
+	
+config NGINX_NCHAN
+	bool
+	prompt "Enable Nginx Nchan module"
+	default n
+
 endmenu
+

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -8,12 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
-PKG_VERSION:=1.10.1
-PKG_RELEASE:=1
+PKG_VERSION:=1.12.0
+PKG_RELEASE:=2
+
+NCHAN_VERSION:=1.1.7
+NCHAN_VERSION_HASH:=c8ae7791560ef19a0fec459f424366a09e3baf52ab0fc4938ffce8d962b6abd6
+
+NAXSI_VERSION:=cf73f9c8664127252c2a4958d2e169516d3845a1
+LUA_VERSION:=20d6558b074f1bda3584827412f2e364aeb00b0f
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://nginx.org/download/
-PKG_MD5SUM:=088292d9caf6059ef328aa7dda332e44
+PKG_HASH:=b4222e26fdb620a8d3c3a3a8b955e08b713672e1bc5198d1e4f462308a795b30
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=2-clause BSD-like license
 
@@ -33,6 +39,7 @@ PKG_CONFIG_DEPENDS := \
 	CONFIG_NGINX_HTTP_USERID \
 	CONFIG_NGINX_HTTP_ACCESS \
 	CONFIG_NGINX_HTTP_AUTH_BASIC \
+	CONFIG_NGINX_HTTP_AUTH_REQUEST \
 	CONFIG_NGINX_HTTP_AUTOINDEX \
 	CONFIG_NGINX_HTTP_GEO \
 	CONFIG_NGINX_HTTP_MAP \
@@ -54,9 +61,13 @@ PKG_CONFIG_DEPENDS := \
 	CONFIG_NGINX_HTTP_UPSTREAM_KEEPALIVE \
 	CONFIG_NGINX_HTTP_UPSTREAM_ZONE \
 	CONFIG_NGINX_HTTP_CACHE \
+	CONFIG_NGINX_HTTP_V2 \
 	CONFIG_NGINX_PCRE \
 	CONFIG_NGINX_NAXSI \
-	CONFIG_NGINX_LUA
+	CONFIG_NGINX_NCHAN \
+	CONFIG_NGINX_LUA \
+	CONFIG_NGINX_HTTP_REAL_IP \
+	CONFIG_NGINX_HTTP_SECURE_LINK
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -91,6 +102,9 @@ ifeq ($(CONFIG_NGINX_NAXSI),y)
 endif
 ifeq ($(CONFIG_NGINX_LUA),y)
   ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/lua-nginx
+endif
+ifeq ($(CONFIG_NGINX_NCHAN),y)
+  ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nchan-$(NCHAN_VERSION)
 endif
 ifeq ($(CONFIG_IPV6),y)
   ADDITIONAL_MODULES += --with-ipv6
@@ -132,6 +146,9 @@ ifneq ($(CONFIG_NGINX_HTTP_ACCESS),y)
 endif
 ifneq ($(CONFIG_NGINX_HTTP_AUTH_BASIC),y)
   ADDITIONAL_MODULES += --without-http_auth_basic_module
+endif
+ifeq ($(CONFIG_NGINX_HTTP_AUTH_REQUEST),y)
+  ADDITIONAL_MODULES += --with-http_auth_request_module
 endif
 ifneq ($(CONFIG_NGINX_HTTP_AUTOINDEX),y)
   ADDITIONAL_MODULES += --without-http_autoindex_module
@@ -192,6 +209,15 @@ endif
 ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_KEEPALIVE),y)
   ADDITIONAL_MODULES += --without-http_upstream_keepalive_module
 endif
+ifeq ($(CONFIG_NGINX_HTTP_V2),y)
+  ADDITIONAL_MODULES += --with-http_v2_module
+endif
+ifeq ($(CONFIG_NGINX_HTTP_REAL_IP),y)
+  ADDITIONAL_MODULES += --with-http_realip_module
+endif
+ifeq ($(CONFIG_NGINX_HTTP_SECURE_LINK),y)
+  ADDITIONAL_MODULES += --with-http_secure_link_module
+endif
 
 TARGET_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -DNGX_LUA_NO_BY_LUA_BLOCK
 TARGET_LDFLAGS += -Wl,--gc-sections
@@ -238,10 +264,11 @@ define Build/Prepare
 	$(call Build/Prepare/Default)
 	$(if $(CONFIG_NGINX_NAXSI),$(call Prepare/nginx-naxsi))
 	$(if $(CONFIG_NGINX_LUA),$(call Prepare/lua-nginx))
+	$(if $(CONFIG_NGINX_NCHAN),$(call Prepare/nginx-nchan))
 endef
 
 define Download/nginx-naxsi
-	VERSION:=5ab2309f0dc93d33e1443a15db519f8bfed8b455
+	VERSION:=$(NAXSI_VERSION)
 	SUBDIR:=nginx-naxsi
 	FILE:=nginx-naxsi-module-$(PKG_VERSION)-$$(VERSION).tar.gz
 	URL:=https://github.com/nbs-system/naxsi.git
@@ -254,7 +281,7 @@ define  Prepare/nginx-naxsi
 endef
 
 define Download/lua-nginx
-	VERSION:=1967998b0eedab1ff51bff8fafa5fc3db47976aa
+	VERSION:=$(LUA_VERSION)
 	SUBDIR:=lua-nginx
 	FILE:=lua-nginx-module-$(PKG_VERSION)-$$(VERSION).tar.gz
 	URL:=https://github.com/openresty/lua-nginx-module.git
@@ -265,6 +292,18 @@ define  Prepare/lua-nginx
 	$(eval $(call Download,lua-nginx))
 	gzip -dc $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
 	$(call PatchDir,$(PKG_BUILD_DIR),./patches-lua-nginx)
+endef
+
+define Download/nginx-nchan
+	VERSION:=$(NCHAN_VERSION)
+	FILE:=v$$(VERSION).tar.gz
+	URL:=https://github.com/slact/nchan/archive/
+	PKG_HASH:=$(NCHAN_VERSION_HASH)
+endef
+
+define Prepare/nginx-nchan
+	$(eval $(call Download,nginx-nchan))
+	gzip -dc $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
 endef
 
 $(eval $(call BuildPackage,nginx))


### PR DESCRIPTION
added new package nchan, allowing easy pub/sub with websockets
updated version of package nginx-lua (new versions of nginx do not work with older versions of lua)

Signed-off-by: ljubomirb <ljubomir.blanusa@gmail.com>