### PR TITLE
Postfix: security update to 3.2.2, add PostgreSQL and PCRE support and refresh patches

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -8,15 +8,25 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postfix
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 PKG_SOURCE_URL:=ftp://ftp.porcupine.org/mirrors/postfix-release/official/
-PKG_VERSION:=3.1.4
-PKG_MD5SUM:=878a059d92ee3b093d7d3e97248c915d
+PKG_VERSION:=3.2.2
+PKG_HASH:=d06849418d119d09366997b2b481bb23f737629769b4e4a52da42fb3ad8b0576
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_MAINTAINER:=Denis Shulyaka <Shulyaka@gmail.com>
 PKG_LICENSE:=IPL-1.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_BUILD_DEPENDS:=+POSTFIX_CDB:tinycdb
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_POSTFIX_TLS \
+	CONFIG_POSTFIX_SASL \
+	CONFIG_POSTFIX_LDAP \
+	CONFIG_POSTFIX_CDB \
+	CONFIG_POSTFIX_DB \
+	CONFIG_POSTFIX_SQLITE \
+	CONFIG_POSTFIX_PGSQL \
+	CONFIG_POSTFIX_PCRE \
+	CONFIG_POSTFIX_EAI \
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -25,7 +35,7 @@ define Package/postfix
   CATEGORY:=Mail
   TITLE:=Postfix Mail Transmit Agent
   URL:=http://www.postfix.org/
-  DEPENDS:=+POSTFIX_TLS:libopenssl +POSTFIX_SASL:libsasl2 +POSTFIX_LDAP:libopenldap +POSTFIX_DB:libdb47 +POSTFIX_SQLITE:libsqlite3 +POSTFIX_EAI:icu +libpcre
+  DEPENDS:=+POSTFIX_TLS:libopenssl +POSTFIX_SASL:libsasl2 +POSTFIX_LDAP:libopenldap +POSTFIX_DB:libdb47 +POSTFIX_SQLITE:libsqlite3 +POSTFIX_PGSQL:libpq +POSTFIX_EAI:icu +POSTFIX_PCRE:libpcre
 endef
 
 define Package/postfix/description
@@ -64,16 +74,26 @@ define Package/postfix/config
 			default y
 			help
 			  Implements support for SQLite3 DB
+		config POSTFIX_PGSQL
+			bool "PostgreSQL support"
+			default n
+			help
+			  Implement support for PostgreSQL
+		config POSTFIX_PCRE
+			bool "PCRE support"
+			default n
+			help
+			  Implement support for Perl Compatible Regular Expressions
 		config POSTFIX_EAI
 			bool "SMTPUTF8 support"
 			default n
 			help
-				Enable Postfix support for Email Address Internationalization
-				(EAI) as defined in RFC 6531 (SMTPUTF8 extension), RFC 6532
-				(Internationalized email headers) and RFC 6533
-				(Internationalized delivery status notifications).
-				Since version 3.0, Postfix fully supports UTF-8 email
-				addresses and UTF-8 message header values.
+			  Enable Postfix support for Email Address Internationalization
+			  (EAI) as defined in RFC 6531 (SMTPUTF8 extension), RFC 6532
+			  (Internationalized email headers) and RFC 6533
+			  (Internationalized delivery status notifications).
+			  Since version 3.0, Postfix fully supports UTF-8 email
+			  addresses and UTF-8 message header values.
 	endmenu
 endef
 
@@ -114,6 +134,18 @@ endif
 ifdef CONFIG_POSTFIX_SQLITE
   CCARGS+=-DHAS_SQLITE -I$(STAGING_DIR)/usr/include/
   AUXLIBS+=-L$(STAGING_DIR)/usr/lib -lsqlite3 -lpthread
+endif
+
+ifdef CONFIG_POSTFIX_PGSQL
+  CCARGS+=-DHAS_PGSQL -I$(STAGING_DIR)/usr/include/
+  AUXLIBS+=-L$(STAGING_DIR)/usr/lib -lpq
+endif
+
+ifdef CONFIG_POSTFIX_PCRE
+  CCARGS+=-DHAS_PCRE -I$(STAGING_DIR)/usr/include/
+  AUXLIBS+=-L$(STAGING_DIR)/usr/lib -lpcre
+else
+  CCARGS+=-DNO_PCRE
 endif
 
 ifdef CONFIG_POSTFIX_EAI

--- a/mail/postfix/patches/100-fsstat.patch
+++ b/mail/postfix/patches/100-fsstat.patch
@@ -1,7 +1,7 @@
 diff -rupN postfix-2.8.1/src/smtpd/smtpd_check.c postfix-2.8.1_patched/src/smtpd/smtpd_check.c
 --- postfix-2.8.1/src/smtpd/smtpd_check.c	2011-01-04 22:03:50.000000000 +0300
 +++ postfix-2.8.1_patched/src/smtpd/smtpd_check.c	2011-03-06 19:35:39.000000000 +0300
-@@ -5296,7 +5296,7 @@ char   *smtpd_check_queue(SMTPD_STATE *s
+@@ -5302,7 +5302,7 @@ char   *smtpd_check_queue(SMTPD_STATE *s
       */
  #define BLOCKS(x)	((x) / fsbuf.block_size)
  

--- a/mail/postfix/patches/200-manpages.patch
+++ b/mail/postfix/patches/200-manpages.patch
@@ -37,7 +37,7 @@ diff -Naur postfix-2.10.2/conf/post-install postfix-2.10.2_patched/conf/post-ins
 diff -Naur postfix-2.10.2/postfix-install postfix-2.10.2_patched/postfix-install
 --- postfix-2.10.2/postfix-install	2012-05-22 23:40:29.000000000 +0400
 +++ postfix-2.10.2_patched/postfix-install	2013-11-19 21:12:20.694160734 +0400
-@@ -554,13 +554,13 @@
+@@ -563,13 +563,13 @@
       exit 1;;
  esac
  
@@ -58,7 +58,7 @@ diff -Naur postfix-2.10.2/postfix-install postfix-2.10.2_patched/postfix-install
  
  for path in "$html_directory" "$readme_directory" "$shlib_directory"
  do
-@@ -573,7 +573,7 @@
+@@ -582,7 +582,7 @@
  done
  
  for path in "$daemon_directory" "$data_directory" "$command_directory" "$queue_directory" \
@@ -67,7 +67,7 @@ diff -Naur postfix-2.10.2/postfix-install postfix-2.10.2_patched/postfix-install
      "$meta_directory"
  do
     case "$path" in
-@@ -780,8 +780,8 @@
+@@ -789,8 +789,8 @@
  		compare_or_replace $mode "$owner" "$group" html/$file \
  		    $HTML_DIRECTORY/$file || exit 1;;
  	'$manpage_directory')

--- a/mail/postfix/patches/300-bdb_hash_segfault.patch
+++ b/mail/postfix/patches/300-bdb_hash_segfault.patch
@@ -1,10 +1,9 @@
-diff -Naur postfix-2.11.3/src/util/dict_db.c postfix-2.11.3_patched/src/util/dict_db.c
---- postfix-2.11.3/src/util/dict_db.c	2012-01-25 04:41:08.000000000 +0400
-+++ postfix-2.11.3_patched/src/util/dict_db.c	2014-11-01 12:36:44.287641712 +0300
-@@ -687,8 +687,8 @@
+--- a/src/util/dict_db.c	2017-07-16 16:56:00.819659962 +0300
++++ b/src/util/dict_db.c	2017-07-16 16:58:31.011401358 +0300
+@@ -733,8 +733,8 @@
+ 	msg_fatal("create DB database: %m");
+     if (db == 0)
  	msg_panic("db_create null result");
-     if ((errno = db->set_cachesize(db, 0, dict_db_cache_size, 0)) != 0)
- 	msg_fatal("set DB cache size %d: %m", dict_db_cache_size);
 -    if (type == DB_HASH && db->set_h_nelem(db, DICT_DB_NELM) != 0)
 -	msg_fatal("set DB hash element count %d: %m", DICT_DB_NELM);
 +//    if (type == DB_HASH && db->set_h_nelem(db, DICT_DB_NELM) != 0)

--- a/mail/postfix/patches/400-cdb.patch
+++ b/mail/postfix/patches/400-cdb.patch
@@ -1,7 +1,7 @@
 diff -Naur postfix-2.11.1/src/util/sys_defs.h postfix-2.11.1.patched/src/util/sys_defs.h
 --- postfix-2.11.1/src/util/sys_defs.h	2013-09-30 00:51:55.000000000 +0400
 +++ postfix-2.11.1.patched/src/util/sys_defs.h	2014-09-29 03:11:48.962277971 +0400
-@@ -769,9 +769,8 @@
+@@ -759,9 +759,8 @@
  #define INTERNAL_LOCK	MYFLOCK_STYLE_FLOCK
  #define DEF_MAILBOX_LOCK "fcntl, dotlock"	/* RedHat >= 4.x */
  #define HAS_FSYNC

--- a/mail/postfix/patches/500-crosscompile.patch
+++ b/mail/postfix/patches/500-crosscompile.patch
@@ -1,6 +1,6 @@
 --- a/makedefs	2016-01-28 12:30:14.444082390 -0500
 +++ b/makedefs	2016-01-28 13:44:02.092006512 -0500
-@@ -198,7 +198,7 @@ error() {
+@@ -210,7 +210,7 @@ error() {
  
  case $# in
   # Officially supported usage.
@@ -9,7 +9,7 @@
      RELEASE=`(uname -r) 2>/dev/null`
      # No ${x%%y} support in Solaris 11 /bin/sh
      RELEASE_MAJOR=`expr "$RELEASE" : '\([0-9]*\)'` || exit 1
-@@ -212,6 +212,15 @@ case $# in
+@@ -224,6 +224,15 @@ case $# in
  esac
  
  case "$SYSTEM.$RELEASE" in

--- a/mail/postfix/patches/600-nopostconf.patch
+++ b/mail/postfix/patches/600-nopostconf.patch
@@ -1,7 +1,7 @@
 diff -Naur postfix-2.11.1/postfix-install postfix-2.11.1.patched/postfix-install
 --- postfix-2.11.1/postfix-install	2014-10-05 20:43:58.598876904 +0400
 +++ postfix-2.11.1.patched/postfix-install	2014-10-05 20:47:36.076700082 +0400
-@@ -852,23 +852,23 @@
+@@ -861,23 +861,23 @@
      esac
  done
  


### PR DESCRIPTION
switch to latest upstream, the update contains security fixes !

add option for PostgreSQl and PCRE
refresh patches
cosmetic fix

maintainer: @Shulyaka 

Compile/Run tested on x86  Lede r4588-cd10577


Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
