### PR TITLE
build,travis: limit git depth to 1 level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+git:
+  depth: 1
 language: c
 dist: trusty
 sudo: false


### PR DESCRIPTION
Maintainer: @lynxis 
Compile tested: N/A
Run tested: N/A

------------------------------------------------------

It's just a minor optimization of the build.
No need to clone up to 50 revisions back (travis default)

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>
