### PR TITLE
python-cffi: upgrade to 1.10.0 (together with dependencies)

### DIFF
--- a/lang/python/python-cffi/Makefile
+++ b/lang/python/python-cffi/Makefile
@@ -7,33 +7,25 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=cffi
-PKG_VERSION:=1.8.3
-PKG_RELEASE:=2
+PKG_NAME:=python-cffi
+PKG_VERSION:=1.10.0
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/0a/f3/686af8873b70028fccf67b15c78fd4e4667a3da995007afc71e786d61b0a
-PKG_HASH:=c321bd46faa7847261b89c0469569530cad5a41976bb6dba8202c0159f476568
+PKG_SOURCE:=cffi-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/5b/b9/790f8eafcdab455bcd3bd908161f802c9ce5adbf702a83aa7712fcc345b7
+PKG_HASH:=b3b02911eb1f6ada203b0763ba924234629b51586f72a21faacc638269f4ced5
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
-HOST_BUILD_DEPENDS:=libffi/host python-pycparser/host
-ifdef CONFIG_PACKAGE_python-cffi
-HOST_BUILD_DEPENDS+=python/host
-endif
-ifdef CONFIG_PACKAGE_python3-cffi
-HOST_BUILD_DEPENDS+=python3/host
-endif
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cffi-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
-include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
 $(call include_mk, python3-package.mk)
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-cffi/Default
   SECTION:=lang
@@ -46,14 +38,14 @@ endef
 define Package/python-cffi
 $(call Package/python-cffi/Default)
   TITLE:=python-cffi
-  DEPENDS+=+python-light +python-pycparser
+  DEPENDS+=+PACKAGE_python-cffi:python-light +PACKAGE_python-cffi:python-pycparser
   VARIANT:=python
 endef
 
 define Package/python3-cffi
 $(call Package/python-cffi/Default)
   TITLE:=python3-cffi
-  DEPENDS+=+python3-light +python3-pycparser
+  DEPENDS+=+PACKAGE_python3-cffi:python3-light +PACKAGE_python3-cffi:python3-pycparser
   VARIANT:=python3
 endef
 
@@ -66,28 +58,6 @@ $(call Package/python-cffi/description)
 .
 (Variant for Python3)
 endef
-
-ifdef CONFIG_PACKAGE_python-cffi
-define Host/Compile/python-cffi
-	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-endif
-
-ifdef CONFIG_PACKAGE_python3-cffi
-define Host/Compile/python3-cffi
-	$(call Build/Compile/HostPy3Mod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-endif
-
-define Host/Compile
-$(call Host/Compile/python-cffi)
-$(call Host/Compile/python3-cffi)
-endef
-
-define Host/Install
-endef
-
-$(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-cffi))
 $(eval $(call BuildPackage,python-cffi))

--- a/lang/python/python-ply/Makefile
+++ b/lang/python/python-ply/Makefile
@@ -7,33 +7,25 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=ply
-PKG_VERSION:=3.9
-PKG_RELEASE:=2
+PKG_NAME:=python-ply
+PKG_VERSION:=3.10
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=ply-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.dabeaz.com/ply
-PKG_HASH:=0d7e2940b9c57151392fceaa62b0865c45e06ce1e36687fd8d03f011a907f43e
+PKG_HASH:=96e94af7dd7031d8d6dd6e2a8e0de593b511c211a86e28a9c9621c275ac8bacb
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
-HOST_BUILD_DEPENDS:=
-ifdef CONFIG_PACKAGE_python-ply
-HOST_BUILD_DEPENDS+=python/host
-endif
-ifdef CONFIG_PACKAGE_python3-ply
-HOST_BUILD_DEPENDS+=python3/host
-endif
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-ply-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=README.md
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
-include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
 $(call include_mk, python3-package.mk)
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-ply/Default
   SECTION:=lang
@@ -45,14 +37,14 @@ endef
 define Package/python-ply
 $(call Package/python-ply/Default)
   TITLE:=python-ply
-  DEPENDS:=+python-light
+  DEPENDS:=+PACKAGE_python-ply:python-light
   VARIANT:=python
 endef
 
 define Package/python3-ply
 $(call Package/python-ply/Default)
   TITLE:=python3-ply
-  DEPENDS:=+python3-light
+  DEPENDS:=+PACKAGE_python3-ply:python3-light
   VARIANT:=python3
 endef
 
@@ -66,28 +58,6 @@ $(call Package/python-ply/description)
 .
 (Variant for Python3)
 endef
-
-ifdef CONFIG_PACKAGE_python-ply
-define Host/Compile/python-ply
-	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-endif
-
-ifdef CONFIG_PACKAGE_python3-ply
-define Host/Compile/python3-ply
-	$(call Build/Compile/HostPy3Mod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-endif
-
-define Host/Compile
-$(call Host/Compile/python-ply)
-$(call Host/Compile/python3-ply)
-endef
-
-define Host/Install
-endef
-
-$(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-ply))
 $(eval $(call BuildPackage,python-ply))

--- a/lang/python/python-pycparser/Makefile
+++ b/lang/python/python-pycparser/Makefile
@@ -7,33 +7,25 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=pycparser
-PKG_VERSION:=2.14
-PKG_RELEASE:=4
+PKG_NAME:=python-pycparser
+PKG_VERSION:=2.17
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pycparser
-PKG_HASH:=7959b4a74abdc27b312fed1c21e6caf9309ce0b29ea86b591fd2e99ecdf27f73
+PKG_SOURCE:=pycparser-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/be/64/1bb257ffb17d01f4a38d7ce686809a736837ad4371bcc5c42ba7a715c3ac
+PKG_HASH:=0aac31e917c24cb3357f5a4d5566f2cc91a19ca41862f6c3c22dc60a629673b6
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
-HOST_BUILD_DEPENDS:=python-ply/host
-ifdef CONFIG_PACKAGE_python-pycparser
-HOST_BUILD_DEPENDS+=python/host
-endif
-ifdef CONFIG_PACKAGE_python3-pycparser
-HOST_BUILD_DEPENDS+=python3/host
-endif
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pycparser-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
-include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
 $(call include_mk, python3-package.mk)
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-pycparser/Default
   SECTION:=lang
@@ -45,14 +37,14 @@ endef
 define Package/python-pycparser
 $(call Package/python-pycparser/Default)
   TITLE:=python-pycparser
-  DEPENDS:=+python-light +python-ply
+  DEPENDS:=+PACKAGE_python-pycparser:python-light +PACKAGE_python-pycparser:python-ply
   VARIANT:=python
 endef
 
 define Package/python3-pycparser
 $(call Package/python-pycparser/Default)
   TITLE:=python3-pycparser
-  DEPENDS:=+python3-light +python3-ply
+  DEPENDS:=+PACKAGE_python3-pycparser:python3-light +PACKAGE_python3-pycparser:python3-ply
   VARIANT:=python3
 endef
 
@@ -67,28 +59,6 @@ $(call Package/python-pycparser/description)
 .
 (Variant for Python3)
 endef
-
-ifdef CONFIG_PACKAGE_python-pycparser
-define Host/Compile/python-pycparser
-	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-endif
-
-ifdef CONFIG_PACKAGE_python3-pycparser
-define Host/Compile/python3-pycparser
-	$(call Build/Compile/HostPy3Mod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-endif
-
-define Host/Compile
-$(call Host/Compile/python-pycparser)
-$(call Host/Compile/python3-pycparser)
-endef
-
-define Host/Install
-endef
-
-$(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-pycparser))
 $(eval $(call BuildPackage,python-pycparser))


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: https://github.com/lede-project/source/commit/6bdb662debf804d1c5049b7cdddc30591e42a1e1 x86_64
Run tested: https://github.com/lede-project/source/commit/6bdb662debf804d1c5049b7cdddc30591e42a1e1 x86_64

Description:

This also removes the host builds ==> yay.
I also found an elegant way to remove the `python-cffi/host` build dependency from `python-cryptography`
But that will come later.

Python host-builds are a pain to do/maintain, because of the Python & Python3 variants.
It's pretty cumbersome to define variants for host-side builds in the.
Luckily, Python & Python3 are separate packages, and installing host-side deps via `pip` looks viable [long term].

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>