### PR TITLE
badvpn, httping, corkscrew, p7zip: Add new packages

### DIFF
--- a/net/badvpn/Makefile
+++ b/net/badvpn/Makefile
@@ -1,0 +1,62 @@
+# Copyright (C) 2009 Ambroz Bizjak
+#
+# This is free software, licensed under the GNU General Public License v2.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=badvpn
+PKG_VERSION:=1.999.130
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=HEAD
+PKG_SOURCE_URL:=https://github.com/ambrop72/badvpn.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)
+PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION)-$(PKG_RELEASE).tar.gz
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+PKG_MD5SUM:=0b5a9ea860841209eca421707ad1b109
+PKG_MAINTAINER:=Galih Prastowo Aji <galih.prastowo@gmail.com>
+	
+include $(INCLUDE_DIR)/package.mk
+
+define Package/badvpn
+	SECTION:=net
+	CATEGORY:=Network
+	DEPENDS:=+librt +libpthread +udev +coreutils +coreutils-stdbuf
+	TITLE:=BadVPN
+	SUBMENU:=VPN
+endef
+
+define Package/badvpn/description
+	BadVPN creates a transparent proxy of your SSH tunnel,
+	so you won't have to set your browser's proxy manually.
+endef
+
+define Build/Configure
+	echo -e \
+	"SET(CMAKE_SYSTEM_NAME Linux)\n" \
+	"SET(CMAKE_C_COMPILER $(TARGET_CC))\n" \
+	"SET(CMAKE_CXX_COMPILER $(TARGET_CXX))\n" \
+	"SET(CMAKE_FIND_ROOT_PATH $(STAGING_DIR) $(STAGING_DIR_HOST))\n" \
+	> "$(PKG_BUILD_DIR)/toolchain.cmake"
+	(cd $(PKG_BUILD_DIR); \
+		CFLAGS="$(TARGET_CFLAGS)" \
+		LDFLAGS="$(TARGET_LDFLAGS)" \
+		cmake . \
+		-DCMAKE_TOOLCHAIN_FILE=$(PKG_BUILD_DIR)/toolchain.cmake \
+		-DBUILD_NOTHING_BY_DEFAULT=1 \
+		-DBUILD_TUN2SOCKS=1 \
+	);
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR)
+endef
+
+define Package/badvpn/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tun2socks/badvpn-tun2socks $(1)/usr/bin/badvpn-tun2socks
+endef
+
+$(eval $(call BuildPackage,badvpn))

--- a/net/corkscrew/Makefile
+++ b/net/corkscrew/Makefile
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2010 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=corkscrew
+PKG_VERSION:=2.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://mirror2.openwrt.org/sources/
+PKG_MD5SUM:=35df77e7f0e59c0ec4f80313be52c10a
+PKG_MAINTAINER:=Galih Prastowo Aji <galih.prastowo@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/corkscrew
+	SECTION:=net
+	CATEGORY:=Network
+	SUBMENU:=SSH
+	TITLE:=Tunneling SSH through HTTP proxies.
+	URL:=http://www.agroman.net/corkscrew/
+endef
+
+define Build/Configure
+	$(call Build/Configure/Default,)
+endef
+
+define Package/corkscrew/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_BUILD_DIR)/corkscrew $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,corkscrew))

--- a/net/httping/Makefile
+++ b/net/httping/Makefile
@@ -1,0 +1,85 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=httping
+PKG_VERSION:=2.5
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
+PKG_SOURCE_URL:=http://www.vanheusden.com/httping
+PKG_MD5SUM:=a92976c06af8b80af17f70f0cb059bdc
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_INSTALL:=1
+PKG_MAINTAINER:=Galih Prastowo Aji <galih.prastowo@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/httping/Default
+	SECTION:=net
+	CATEGORY:=Network
+	TITLE:=Httping is like 'ping' but for http-requests
+	URL:=http://www.vanheusden.com/httping/
+	DEPENDS:=$(INTL_DEPENDS)
+endef
+
+define Package/httping/Default/description
+	Give it an url, and it'll show you how long it takes to connect, send a
+	request and retrieve the reply (only the headers). Be aware that the
+	transmission across the network also takes time!
+endef
+
+define Package/httping
+	$(call Package/httping/Default)
+	DEPENDS:=+libopenssl
+	TITLE+= (with SSL support)
+	VARIANT:=ssl
+endef
+
+define Package/httping/description
+	$(call Package/httping/Default/description)
+	This package is built with SSL support.
+endef
+
+define Package/httping-nossl
+	$(call Package/httping/Default)
+	TITLE+= (without SSL support)
+	VARIANT:=nossl
+endef
+
+define Package/httping-nossl/description
+	$(call Package/httping/Default/description)
+	This package is built without SSL support.
+endef
+
+define Build/Configure
+endef
+
+TARGET_LDFLAGS += $(INTL_LDFLAGS) $(if $(INTL_FULL),-lintl)
+
+MAKE_FLAGS += \
+	DEBUG="no" \
+	FW="no" \
+	NC="no" \
+	TFO="no"
+
+ifeq ($(BUILD_VARIANT),nossl)
+	MAKE_FLAGS += SSL="no"
+endif
+
+define Package/httping/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/httping $(1)/usr/bin/
+endef
+
+Package/httping-nossl/install = $(Package/httping/install)
+
+$(eval $(call BuildPackage,httping,+libopenssl))
+$(eval $(call BuildPackage,httping-nossl,))

--- a/net/httping/patches/001-no_strip.patch
+++ b/net/httping/patches/001-no_strip.patch
@@ -1,0 +1,12 @@
+--- a/Makefile
++++ b/Makefile
+@@ -113,9 +113,6 @@ install: $(TARGET) $(TRANSLATIONS)
+ 	$(INSTALLMAN) $(MAN_NL) $(DESTDIR)/$(MANDIR)/nl/man1
+ 	$(INSTALLDIR) $(DESTDIR)/$(DOCDIR)
+ 	$(INSTALLDOC) $(DOCS) $(DESTDIR)/$(DOCDIR)
+-ifneq ($(DEBUG),yes)
+-	$(STRIP) $(DESTDIR)/$(BINDIR)/$(TARGET)
+-endif
+ 	mkdir -p $(DESTDIR)/$(PREFIX)/share/locale/nl/LC_MESSAGES
+ 	cp nl.mo $(DESTDIR)/$(PREFIX)/share/locale/nl/LC_MESSAGES/httping.mo
+ 

--- a/utils/p7zip/Makefile
+++ b/utils/p7zip/Makefile
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2009-2011 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=p7zip
+PKG_VERSION:=16.02
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION)_src_all.tar.bz2
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)_$(PKG_VERSION)
+PKG_SOURCE_URL:=@SF/$(PKG_NAME)
+PKG_HASH:=5eb20ac0e2944f6cb9c2d51dd6c4518941c185347d4089ea89087ffdd6e2341f
+PKG_MAINTAINER:=Galih Prastowo Aji <galih.prastowo@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/p7zip
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=p7zip archiver
+	URL:=http://http://www.7-zip.org
+	DEPENDS:=+libstdcpp +libpthread
+endef
+
+define Package/p7zip/description
+	p7zip is a tool to extract and create 7z files
+endef
+
+define Package/p7zip/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/7za $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,p7zip))


### PR DESCRIPTION
Maintainer: **@hillz2**
Compile tested: brcm63xx, ar71xx, sunxi
Run tested: HG553 (brcm63xx), GL.iNet 6416 (ar71xx), Orange Pi Zero (sunxi)

Description:
1. Httping is like 'ping' but for http-requests.
Give it an url, and it'll show you how long it takes to connect, send a request and retrieve the reply (only the headers). Be aware that the transmission across the network also takes time! So it measures the latency of the webserver + network.
It supports, of course, IPv6.
2. Corkscrew is a program that enables the user to tunnel arbitrary TCP connections through most HTTP and HTTPS proxy servers. Combined with features of SSH such as port forwarding, this can allow many types of services to be run securely over the SSH via HTTP connections.
3. BadVPN creates a transparent proxy of your SSH tunnel, so you won't have to set your browser's proxy manually.
4. p7zip is a tool to extract and create 7z files.
> Signed-off-by: Galih Prastowo Aji galih.prastowo@gmail.com