### PR TITLE
travelmate: update 0.9.0

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=0.8.2
+PKG_VERSION:=0.9.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/README.md
+++ b/net/travelmate/files/README.md
@@ -8,7 +8,7 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 ## Main Features
 * STA interfaces operating in an "always off" mode, to make sure that the AP is always accessible
 * easy setup within normal OpenWrt/LEDE environment
-* strong LuCI-Support to simplify the interface setup
+* strong LuCI-Support with builtin interface wizard and wireless interface manager
 * fast uplink connections
 * manual / automatic mode support, the latter one checks the existing uplink connection regardless of ifdown event trigger actions every n seconds
 * support of devices with multiple radios
@@ -24,7 +24,7 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 * download the package [here](https://downloads.lede-project.org/snapshots/packages/x86_64/packages)
 * install 'travelmate' (_opkg install travelmate_)
 * configure your network:
-    * automatic: use the LuCI frontend with automatic STA interface setup, that's the recommended way
+    * recommended: use the LuCI frontend with automatic STA interface setup and connection manager
     * manual: see detailed configure steps below
     * at least you need one configured AP and one STA interface
 
@@ -123,7 +123,7 @@ config wifi-iface
 </code></pre>
 
 ## Support
-Please join the travelmate discussion in this [forum thread](https://forum.openwrt.org/viewtopic.php?id=67697) or contact me by [mail](mailto:dev@brenken.org)  
+Please join the travelmate discussion in this [forum thread](https://forum.lede-project.org/t/travelmate-support-thread/5155) or contact me by [mail](mailto:dev@brenken.org)  
 
 ## Removal
 * stop the travelmate daemon with _/etc/init.d/travelmate stop_

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-trm_ver="0.8.2"
+trm_ver="0.9.0"
 trm_sysver="$(ubus -S call system board | jsonfilter -e '@.release.description')"
 trm_enabled=0
 trm_debug=0
@@ -223,11 +223,19 @@ f_main()
                                 f_log "info " "interface '${sta_iface}' on '${sta_radio}' connected to uplink '${sta_ssid}' (${trm_sysver})"
                                 f_jsnupdate "${sta_iface}" "${sta_radio}" "${sta_ssid}"
                                 return 0
+                            elif [ ${cnt} -eq ${trm_maxretry} ]
+                            then
+                                uci -q set wireless."${config}".disabled=1
+                                uci -q set wireless."${config}".ssid="${sta_ssid}_err"
+                                uci -q commit wireless
+                                f_check "dev"
+                                f_log "info " "interface 'can't connect to uplink '${sta_ssid}' (${cnt}/${trm_maxretry}), uplink disabled (${trm_sysver})"
                             else
                                 uci -q revert wireless
-                                f_log "info " "interface '${sta_iface}' on '${sta_radio}' can't connect to uplink '${sta_ssid}' (${trm_sysver})"
-                                f_jsnupdate "${sta_iface}" "${sta_radio}" "${sta_ssid}"
+                                f_check "dev"
+                                f_log "info " "can't connect to uplink '${sta_ssid}' (${cnt}/${trm_maxretry}) (${trm_sysver})"
                             fi
+                            f_jsnupdate "${sta_iface}" "${sta_radio}" "${sta_ssid}"
                         fi
                     done
                 fi


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: LEDE Reboot SNAPSHOT r4546-2be603783b

Description:

backend:
* handle errors due to misconfigured uplinks
* various bugfixes

luci frontend:
* add a powerful wireless station manager to edit and delete existing
  interfaces or scan for new uplinks

Signed-off-by: Dirk Brenken <dev@brenken.org>
