### PR TITLE
noddos: introduction of noddos package

### DIFF
--- a/libs/libtins/Makefile
+++ b/libs/libtins/Makefile
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2017 Steven Hessing
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libtins
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:= Steven Hessing <steven.hessing@gmail.com>
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/mfontanini/libtins.git
+PKG_SOURCE_VERSION:=v3.5
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz
+PKG_MIRROR_HASH:=47cd7d659ffa75dcfc2172ef54151fd36dc87de9e0f04bb066f6b076a7df7b57
+
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+PKG_BUILD_PARALLEL:=1
+
+CMAKE_INSTALL:=1
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+CMAKE_OPTIONS += -D_RUN_RESULT_VAR=FORCE
+CMAKE_OPTIONS += -DLIBTINS_ENABLE_WPA2=0
+CMAKE_OPTIONS += -DLIBTINS_ENABLE_CXX11=1
+
+define Package/libtins
+	SECTION:=net
+	CATEGORY:=Libraries
+	TITLE:=libtins 
+	URL:=http://libtins.github.io/
+	DEPENDS:=+libstdcpp +libpcap 
+endef
+
+define Package/libtins/description
+libtins is a high-level, multiplatform C++ network packet sniffing and crafting library.
+endef
+
+define Package/libtins/install
+    $(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libtins.so.3.5 $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libtins))

--- a/net/noddos/Makefile
+++ b/net/noddos/Makefile
@@ -1,0 +1,85 @@
+#
+# Copyright (C) 2017 Steven Hessing
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+# Name and release number of this package
+PKG_NAME:=noddos
+PKG_RELEASE:=1
+PKG_LICENSE:=GPLv3
+
+PKG_SOURCE_VERSION:=0.4.1
+PKG_SOURCE_URL:=https://github.com/noddos/noddos/releases/download/v$(PKG_SOURCE_VERSION)/
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz
+PKG_HASH:=f676b1c7d9aa6496184b73eacbbfe27b4f54e53c726769ef9ceeeda9c31a7fa3
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
+
+CMAKE_INSTALL:=1
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/noddos
+	SECTION:=net
+	CATEGORY:=Network
+	TITLE:=noddos -- device-aware cloud-powered firewall
+	URL:=https://www.noddos.io/
+	DEPENDS:=+libstdcpp +libnetfilter-conntrack +libcurl +libopenssl +openssl-util +ca-bundle +ca-certificates +wget +bzip2 +libtins +ipset
+endef
+
+define Package/noddos/description
+Noddos discovers what devices you have in your network and tailors the firewall rules based on whitelisted flows for that device. Noddos downloads the firewall rules periodically from the cloud. In order to support creating these firewall rules, noddos can optionally upload anonimized traffic statistics for each device to the cloud.
+endef
+
+define Package/noddos/conffiles
+	/etc/config/noddos	
+endef
+
+define Package/noddos/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DIR) $(1)/etc/noddos
+	$(INSTALL_DIR) $(1)/var/lib/noddos
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/noddos $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tools/getnoddosdeviceprofiles $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tools/makenoddoscert.sh $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/noddos.init $(1)/etc/init.d/noddos
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/noddos.uciconfig $(1)/etc/config/noddos
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/noddos.conf-base $(1)/etc/noddos
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/noddosconfig.pem $(1)/etc/noddos
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/noddos.conf-base $(1)/etc/noddos
+endef
+
+define Package/noddos/prerm
+	#!/bin/sh
+	# check if we are on real system
+	if [ -z "$${IPKG_INSTROOT}" ]; then
+		/etc/init.d/noddos stop
+		echo "Removing rc.d symlink for noddos"
+		/etc/init.d/noddos disable
+	fi
+	exit 0
+endef
+
+define Package/noddos/postrm
+	#!/bin/sh
+	# check if we are on real system
+	if [ -z "$${IPKG_INSTROOT}" ]; then
+		echo "Removing noddos data directory"
+		rm -rf /var/lib/noddos
+		if [ -f /var/etc/noddos.conf ]; then
+			rm /var/etc/noddos.conf
+		fi
+	fi
+	exit 0
+endef
+
+$(eval $(call BuildPackage,noddos))


### PR DESCRIPTION
Signed-off-by: Steven Hessing (steven.hessing@gmail.com)

Maintainer: Steven Hessing / @StevenHessing
Compile tested: arm_cortex-a9_vfpv3, Linksys WRT1200 AC,17.01.2
Run tested: arm_cortex-a9_vfpv3, Linksys WRT1200 AC,17.01.2, test for daemon running normally

Description:
The [Noddos](https://github.com/noddos/noddos) client monitors network traffic in the home- or enterprise network, identifies IOT and other devices and will soon dynamically apply device-specific ACLs to the traffic of the identified devices. Its goal is to identify and stop rogue traffic from devices in the home that have been breached, for example when a device is being used in a DDOS attack. 