### PR TITLE
syslog-ng: use syslog-ng-ctl to handle reload operation

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include  $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.9.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -30,7 +30,8 @@ define Package/syslog-ng/description
 endef
 
 define Package/syslog-ng/conffiles
-  /etc/syslog-ng.conf
+/etc/syslog-ng.conf
+/etc/syslog-ng.d/
 endef
 
 define Build/Configure
@@ -68,8 +69,8 @@ define Package/syslog-ng/install
 		install-moduleLTLIBRARIES DESTDIR="$(1)"
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/syslog-ng.init $(1)/etc/init.d/syslog-ng
-	$(INSTALL_DIR) $(1)/etc
 	$(INSTALL_DATA) ./files/syslog-ng.conf $(1)/etc
+	$(INSTALL_DIR) $(1)/etc/syslog-ng.d/
 	$(call libtool_remove_files,$(1))
 endef
 

--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -8,7 +8,6 @@ PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/balabit/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_MD5SUM:=1b48da9ef620cf06e55e481b5abb677a
 PKG_HASH:=5678856a550ae790618fabde9d1447f932ce7a9080d55dca8fc5df1202c70a17
 
 PKG_INSTALL:=1

--- a/admin/syslog-ng/files/custom-logs.conf
+++ b/admin/syslog-ng/files/custom-logs.conf
@@ -1,2 +1,0 @@
-# place to put customization of logging
-

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -36,5 +36,6 @@ log {
 	destination(messages);
 };
 
-@include "/etc/custom-logs.conf"
+# put any customization files in this directory
+@include "/etc/syslog-ng.d/"
 

--- a/admin/syslog-ng/files/syslog-ng.init
+++ b/admin/syslog-ng/files/syslog-ng.init
@@ -12,6 +12,12 @@ config_file=/etc/syslog-ng.conf
 
 start() {
 	[ -f $config_file ] || return 1
+
+	if ! $PROG -s 2>/dev/null ; then
+		echo "Couldn't parse $(basename $config_file)" >&2
+		exit 1
+	fi
+
 	service_start $PROG --process-mode background \
 		-p $SERVICE_PID_FILE
 }

--- a/admin/syslog-ng/files/syslog-ng.init
+++ b/admin/syslog-ng/files/syslog-ng.init
@@ -12,7 +12,8 @@ config_file=/etc/syslog-ng.conf
 
 start() {
 	[ -f $config_file ] || return 1
-	service_start $PROG -p $SERVICE_PID_FILE
+	service_start $PROG --process-mode background \
+		-p $SERVICE_PID_FILE
 }
 
 stop() {

--- a/admin/syslog-ng/files/syslog-ng.init
+++ b/admin/syslog-ng/files/syslog-ng.init
@@ -2,18 +2,23 @@
 # Copyright (C) 2006-2016 OpenWrt.org
 
 START=20
+PROG=/usr/sbin/syslog-ng
+PROG2=/usr/sbin/syslog-ng-ctl
 
 SERVICE_USE_PID=1
+SERVICE_PID_FILE=/var/log/syslog-ng.pid
+
+config_file=/etc/syslog-ng.conf
 
 start() {
-	[ -f /etc/syslog-ng.conf ] || return 1
-	service_start /usr/sbin/syslog-ng
+	[ -f $config_file ] || return 1
+	service_start $PROG -p $SERVICE_PID_FILE
 }
 
 stop() {
-	service_stop /usr/sbin/syslog-ng
+	service_stop $PROG
 }
 
 reload() {
-	service_reload /usr/sbin/syslog-ng
+	service_reload $PROG
 }

--- a/admin/syslog-ng/files/syslog-ng.init
+++ b/admin/syslog-ng/files/syslog-ng.init
@@ -27,5 +27,5 @@ stop() {
 }
 
 reload() {
-	service_reload $PROG
+	$PROG2 reload
 }


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, generic, LEDE HEAD (6bdb662)
Run tested: same

Built package.  Stopped service on test box.  Installed .ipk on test box.  Restarted service.

Description:

Fix `reload` command in init.d script (by using `syslog-ng-ctl reload` to handle it).

Retired `/etc/custom-logs.conf` in favor of `/etc/syslog-ng.d` directory.

Add parsing of config files to `start` command in init.d script.
