### PR TITLE
vnstat: port init-script to procd and enable auto-respawn

### DIFF
--- a/net/vnstat/Makefile
+++ b/net/vnstat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vnstat
 PKG_VERSION:=1.18
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://humdi.net/vnstat

--- a/net/vnstat/files/vnstat.init
+++ b/net/vnstat/files/vnstat.init
@@ -3,22 +3,18 @@
 
 START=99
 
+USE_PROCD=1
+
 vnstat_option() {
 	sed -ne "s/^[[:space:]]*$1[[:space:]]*['\"]\([^'\"]*\)['\"].*/\1/p" \
 		/etc/vnstat.conf
 }
 
-start() {
+start_service() {
 	local lib="$(vnstat_option DatabaseDir)"
-	local pid="$(vnstat_option PidFile)"
 
 	[ -n "$lib" ] || {
 		echo "Error: No DatabaseDir set in vnstat.conf" >&2
-		exit 1
-	}
-
-	[ -n "$pid" ] || {
-		echo "Error: No PidFile set in vnstat.conf" >&2
 		exit 1
 	}
 
@@ -72,18 +68,18 @@ start() {
 	config_load vnstat
 	config_foreach init_ifaces vnstat
 
-	SERVICE_PID_FILE="${pid}"
-	service_start /usr/sbin/vnstatd -d
+	procd_open_instance
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param command /usr/sbin/vnstatd --nodaemon
+	procd_set_param file /etc/vnstat.conf
+	procd_close_instance
 }
 
-stop() {
-	local pid="$(vnstat_option PidFile)"
+reload_service() {
+	procd_send_signal vnstat
+}
 
-	[ -n "$pid" ] || {
-		echo "Error: No PidFile set in vnstat.conf" >&2
-		exit 1
-	}
-
-	SERVICE_PID_FILE="${pid}"
-	service_stop /usr/sbin/vnstatd
+service_triggers() {
+	procd_add_reload_trigger vnstat
 }

--- a/net/vnstat/files/vnstat.init
+++ b/net/vnstat/files/vnstat.init
@@ -73,6 +73,7 @@ start_service() {
 	procd_set_param stderr 1
 	procd_set_param command /usr/sbin/vnstatd --nodaemon
 	procd_set_param file /etc/vnstat.conf
+	procd_set_param respawn
 	procd_close_instance
 }
 


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: LEDE master
Run tested: LEDE master, tested with the Lantiq xrx200 target (BT HomeHub 5A)

Description:
* the first commit updates the vnstat init-script to use procd (which is preparation for the second commit)
* the second commit enables procd's auto-respawn functionality for vnstat to fix a "race condition" between the vnstat startup and setting the correct date/time (which means that traffic stats are lost between system boot and a manual restart of vnstat) - see the commit description for more information

please note that this is the first time that I'm touching anything procd related, so please keep this in mind while reviewing this!