### PR TITLE
libs/expat: Fix poor entropy compilation error

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -39,6 +39,9 @@ endef
 
 TARGET_CFLAGS += $(FPIC)
 
+HOST_CONFIGURE_VARS += \
+	CPPFLAGS="$(HOST_CFLAGS) -DXML_POOR_ENTROPY"
+
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static


### PR DESCRIPTION
Maintainer: @thess @sbyx 
Compile tested: mips64, EdgeRouter Lite, LEDE trunk
Run tested: Not yet

Description:
Add the same workaround as for the expat package in toolchain.
I'm not really sure what made it work for me earlier but this seems to fix it.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>