### PR TITLE
gperf: Update to 3.1

### DIFF
--- a/libs/gperf/Makefile
+++ b/libs/gperf/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,9 +8,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gperf
-PKG_VERSION:=3.0.4
+PKG_VERSION:=3.1
 PKG_RELEASE:=1
-PKG_MD5SUM:=c1f1db32fb6598d6a93e6e88796a8632
+PKG_HASH:=588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/gperf

--- a/libs/gperf/patches/100-include_own_first.patch
+++ b/libs/gperf/patches/100-include_own_first.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/Makefile.in b/lib/Makefile.in
+index 29bbf92..cf2bf3c 100644
+--- a/lib/Makefile.in
++++ b/lib/Makefile.in
+@@ -61,7 +61,7 @@ SHELL = /bin/sh
+ VPATH = $(srcdir)
+ 
+ OBJECTS  = getopt.$(OBJEXT) getopt1.$(OBJEXT) getline.$(OBJEXT) hash.$(OBJEXT)
+-CPPFLAGS = @CPPFLAGS@ -I$(srcdir)
++CPPFLAGS = -I$(srcdir) @CPPFLAGS@
+ 
+ TARGETLIB = libgp.a
+ 
+diff --git a/src/Makefile.in b/src/Makefile.in
+index 6866ffd..bd4df14 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -64,7 +64,7 @@ VPATH = $(srcdir)
+ OBJECTS  = version.$(OBJEXT) positions.$(OBJEXT) options.$(OBJEXT) keyword.$(OBJEXT) keyword-list.$(OBJEXT) \
+            input.$(OBJEXT) bool-array.$(OBJEXT) hash-table.$(OBJEXT) search.$(OBJEXT) output.$(OBJEXT) main.$(OBJEXT)
+ LIBS     = ../lib/libgp.a @GPERF_LIBM@
+-CPPFLAGS = @CPPFLAGS@ -I. -I$(srcdir)/../lib
++CPPFLAGS = -I. -I$(srcdir)/../lib @CPPFLAGS@
+ 
+ TARGETPROG = gperf$(EXEEXT)
+ 


### PR DESCRIPTION
The patch fixes a problem where an incorrect getline.h would get included
(not gperf's own which resides in ./lib)

Signed-off-by: Espen Jürgensen <espenjurgensen+openwrt@gmail.com>

-------------------------------

Maintainer: Espen Jürgensen / @ejurgensen
Compile tested: (yes, ar7xxx, OpenWRT trunk)
Run tested: no

Description:
Version update