### PR TITLE
rpcd-mod-packagelist: add package

### DIFF
--- a/utils/rpcd-mod-packagelist/Makefile
+++ b/utils/rpcd-mod-packagelist/Makefile
@@ -1,0 +1,40 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rpcd-mod-packagelist
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/rpcd-mod-packagelist
+  SECTION:=utils
+  CATEGORY:=Base system
+  TITLE:=ubus packagelist
+  MAINTAINER:=Paul Spooren <paul@spooren.de>
+  DEPENDS:=rpcd @!CLEAN_IPKG
+endef
+
+define Package/rpcd-mod-packagelist/description
+	add ubus call to receive user installed packages without the need of opkg installed
+endef
+
+define Build/Compile
+endef
+
+define Build/Configure
+endef
+
+define Package/rpcd-mod-packagelist/install
+	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d/
+	$(INSTALL_BIN) ./files/packagelist.acl $(1)/usr/share/rpcd/acl.d/packagelist.json
+
+	$(INSTALL_DIR) $(1)/usr/libexec/rpcd/
+	$(INSTALL_BIN) ./files/packagelist.rpcd $(1)/usr/libexec/rpcd/packagelist
+endef
+
+$(eval $(call BuildPackage,rpcd-mod-packagelist))

--- a/utils/rpcd-mod-packagelist/files/packagelist.acl
+++ b/utils/rpcd-mod-packagelist/files/packagelist.acl
@@ -1,0 +1,12 @@
+{
+	"packagelist": {
+		"description": "get list of installed software packages",
+		"read": {
+			"ubus": {
+				"packagelist": [
+					"list"
+				]
+			}
+		}
+	}
+}

--- a/utils/rpcd-mod-packagelist/files/packagelist.rpcd
+++ b/utils/rpcd-mod-packagelist/files/packagelist.rpcd
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+. /usr/share/libubox/jshn.sh
+
+case "$1" in
+list)
+	json_init
+	json_add_object "list"
+	json_dump
+	;;
+call)
+	case "$2" in
+	list)
+		json_init;
+		json_add_object "packagelist"
+
+		if [ -f /usr/lib/opkg/status ]; then
+			while read var p1 p2 p3; do
+				if [ "$var" = "Package:" ]; then
+					pkg="$p1"
+				fi
+				if [ "$var" = "Version:" ]; then
+					version="$p1"
+				fi
+
+				if [ "$var" = "Status:" \
+					-a "$p1" = "install" \
+					-a "$p2" = "user" \
+					-a "$p3" = "installed" ]; then
+						json_add_string "$pkg" "$version";
+				fi
+			done < /usr/lib/opkg/status
+		fi
+
+		json_close_object
+		json_dump
+		;;
+	esac
+	;;
+esac


### PR DESCRIPTION
Maintainer: me / @aparcar
Compile tested: x86/64 LEDE snapshot, ar71xx/generic LEDE snapshot
Run tested: x86/64 LEDE snapshot, ar71xx/generic LEDE snapshot

Description:
Provides a way to acquire the list of installed packages without the
need to have opkg available. It is being used for the GSoC 17 project
implementing easy sysupgrade functionality.