### PR TITLE
rpcd-mod-attendedsysupgrade: add package

### DIFF
--- a/utils/rpcd-mod-attendedsysupgrade/Makefile
+++ b/utils/rpcd-mod-attendedsysupgrade/Makefile
@@ -1,0 +1,44 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rpcd-mod-attendedsysupgrade
+PKG_VERSION:=1
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/rpcd-mod-attendedsysupgrade
+  SECTION:=utils
+  CATEGORY:=Base system
+  TITLE:=OpenWrt ubus RPC backend server (attendedsysupgrade)
+  MAINTAINER:=Paul Spooren <paul@spooren.de>
+  DEPENDS:=rpcd +cgi-io +rpcd-mod-packagelist
+endef
+
+define Package/rpcd-mod-attendedsysupgrade/description
+	implements sysupgrade function with ubus
+	add uci settings and needed acls
+endef
+
+define Build/Compile
+endef
+
+define Build/Configure
+endef
+
+define Package/rpcd-mod-attendedsysupgrade/install
+	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d/
+	$(INSTALL_BIN) ./files/attendedsysupgrade.acl $(1)/usr/share/rpcd/acl.d/attendedsysupgrade.json
+
+	$(INSTALL_DIR) $(1)/usr/libexec/rpcd/
+	$(INSTALL_BIN) ./files/attendedsysupgrade $(1)/usr/libexec/rpcd/attendedsysupgrade
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults/
+	$(INSTALL_BIN) ./files/attendedsysupgrade.defaults $(1)/etc/uci-defaults/attendedsysupgrade
+endef
+
+$(eval $(call BuildPackage,rpcd-mod-attendedsysupgrade))

--- a/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.acl
+++ b/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.acl
@@ -1,0 +1,26 @@
+{
+	"attendedsysupgrade": {
+		"description": "attended sysupgrade via rpcd",
+		"read": {
+			"ubus": {
+				"attendedsysupgrade": [
+					"sysupgrade"
+				], 
+				"system": [
+					"board"
+				],
+				"uci": [ 
+					"get" 
+				]
+			},
+			"uci": [ 
+				"*" 
+			]
+		},
+		"write": {
+			"cgi-io": [
+				"upload"
+			]
+		}
+	}
+}

--- a/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.defaults
+++ b/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.defaults
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+[ -e /etc/config/attendedsysupgrade ] && exit 0
+
+touch /etc/config/attendedsysupgrade
+
+uci -q batch <<EOF
+add attendedsysupgrade settings
+set attendedsysupgrade.@settings[0].update_server=https://betaupdate.libremesh.org
+commit attendedsysupgrade
+EOF
+
+exit 01

--- a/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.rpcd
+++ b/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.rpcd
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+. /usr/share/libubox/jshn.sh
+
+case "$1" in
+	list)
+		json_init
+
+       	json_add_object "sysupgrade"
+       	json_close_object
+
+       	json_dump
+        ;;
+    call)
+        case "$2" in
+			sysupgrade)
+				if [ -f "/tmp/sysupgrade.bin" ]; then
+					/etc/init.d/uhttpd stop
+					/etc/init.d/dropbear stop
+					sleep 1;
+					/sbin/sysupgrade -c /tmp/sysupgrade.bin
+				fi
+				json_init
+				json_add_string "message" "could not find /tmp/sysupgrade.bin"
+				json_dump
+        esac
+    ;;
+esac
+


### PR DESCRIPTION
Maintainer: me / @aparcar
Compile tested: x86/64 LEDE snapshot, ar71xx/generic LEDE snapshot
Run tested: x86/64 LEDE snapshot, ar71xx/generic LEDE snapshot

Description:

add ubus call to perform a sysupgrade and acl file for the attended
sysupgrade use case as well uci defaults.
Package is a part of the GSoC 17 project implementing easy
sysupgrade functionality.

Signed-off-by: Paul Spooren <paul@spooren.de>



