### PR TITLE
mwan3: support various interface tracking methods

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.5.3
-PKG_RELEASE:=5
+PKG_VERSION:=2.6
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2
 

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -23,15 +23,19 @@ if [ "$ACTION" == "ifup" ]; then
 		ubus call network.interface.${INTERFACE}_4 status &>/dev/null
 		if [ "$?" -eq "0" ]; then
 			network_get_gateway gateway ${INTERFACE}_4
+			network_get_ipaddr src_ip ${INTERFACE}_4
 		else
 			network_get_gateway gateway $INTERFACE
+			network_get_ipaddr src_ip ${INTERFACE}
 		fi
 	elif [ "$family" = "ipv6" ]; then
 		ubus call network.interface.${INTERFACE}_6 status &>/dev/null
 		if [ "$?" -eq "0" ]; then
 			network_get_gateway6 gateway ${INTERFACE}_6
+			network_get_ipaddr6 src_ip ${INTERFACE}_6
 		else
 			network_get_gateway6 gateway ${INTERFACE}
+			network_get_ipaddr6 src_ip ${INTERFACE}
 		fi
 	fi
 
@@ -48,7 +52,7 @@ case "$ACTION" in
 		mwan3_create_iface_rules $INTERFACE $DEVICE
 		mwan3_create_iface_iptables $INTERFACE $DEVICE
 		mwan3_create_iface_route $INTERFACE $DEVICE
-		mwan3_track $INTERFACE $DEVICE
+		mwan3_track $INTERFACE $DEVICE ${src_ip}
 		mwan3_set_policies_iptables
 		mwan3_set_user_rules
 		mwan3_flush_conntrack $INTERFACE $DEVICE "ifup"

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -400,7 +400,7 @@ mwan3_track()
 
 	kill $(pgrep -f "mwan3track $1") &> /dev/null
 	if [ -n "$track_ips" ]; then
-		[ -x /usr/sbin/mwan3track ] && /usr/sbin/mwan3track $1 $2 $track_ips &
+		[ -x /usr/sbin/mwan3track ] && /usr/sbin/mwan3track "$1" "$2" "$3" $track_ips &
 	fi
 }
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -24,6 +24,30 @@ if_down() {
 	IFDOWN_EVENT=1
 }
 
+validate_track_method() {
+	case "$1" in
+		ping)
+			# Assume that ping is installed
+			;;
+		arping)
+			which arping 1>/dev/null 2>&1 || {
+				$LOG warn "Missing arping. Please install iputils-arping package."
+				return 1
+			}
+			;;
+		httping)
+			which httping 1>/dev/null 2>&1 || {
+				$LOG warn "Missing httping. Please install httping package."
+				return 1
+			}
+			;;
+		*)
+			$LOG warn "Unsupported tracking method: $track_method"
+			return 2
+			;;
+	esac
+}
+
 main() {
 	local reliability count timeout interval failure_interval
 	local recovery_interval down up size
@@ -37,6 +61,11 @@ main() {
 	trap if_down SIGUSR1
 
 	config_load mwan3
+	config_get track_method $1 track_method ping
+	validate_track_method $track_method || {
+		$LOG warn "Using ping to track interface $INTERFACE avaliability"
+		track_method=ping
+	}
 	config_get reliability $1 reliability 1
 	config_get count $1 count 1
 	config_get timeout $1 timeout 4
@@ -48,7 +77,7 @@ main() {
 	config_get recovery_interval $1 recovery_interval $interval
 
 	local score=$(($down+$up))
-	local track_ips=$(echo $* | cut -d ' ' -f 3-99)
+	local track_ips=$(echo $* | cut -d ' ' -f 4-99)
 	local host_up_count=0
 	local lost=0
 	local sleep_time=0
@@ -60,7 +89,14 @@ main() {
 		sleep_time=$interval
 
 		for track_ip in $track_ips; do
-			ping -I $2 -c $count -W $timeout -s $size -q $track_ip &> /dev/null
+			case "$track_method" in
+				ping)
+					ping -I $2 -c $count -W $timeout -s $size -q $track_ip &> /dev/null ;;
+				arping)
+					arping -I $2 -c $count -w $timeout -q $track_ip &> /dev/null ;;
+				httping)
+					httping -y $3 -c $count -t $timeout -q $track_ip &> /dev/null ;;
+			esac
 			if [ $? -eq 0 ]; then
 				let host_up_count++
 				echo "up" > /var/run/mwan3track/$1/TRACK_${track_ip}


### PR DESCRIPTION
Maintainer: Florian Eckert <fe@dev.tdt.de>
Compile tested: ar71xx, mipsel_24kc
Run tested: NetGear WNDR3700v2 (ar71xx), Nexx WT-3020 (mipsel_24kc)
Description:
Adds support for interface tracking using either ping, arping or
httping. This allows to track interface status on networks with filtered
ICMP traffic or simply to monitor data link layer etc.

To facilitate binding to a specified interface its IP address is passed
as a new mwan3track parameter. It's currently required by httping
and possibly by other tools that may be added in the future.