### PR TITLE
htpdate: modify init scripts to use procd and uci configuration

### DIFF
--- a/net/htpdate/Makefile
+++ b/net/htpdate/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=htpdate
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.vervest.org/htp/archive/c/
-PKG_MD5SUM:=c612f63282e3f23b709f37a5c81d4739
+PKG_HASH:=0d75f91cb61f8869c8298d198fa52b9a139ae505b366e9d4d331af8bc1c04880
 
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=
@@ -26,7 +26,8 @@ define Package/htpdate
   CATEGORY:=Network
   TITLE:=an HTP (Hypertext Time Protocol) implementation
   URL:=http://www.vervest.com/htp/
-  MAINTAINER:=Tijs Van Buggenhout <tvbuggen@netzerk.be>
+  MAINTAINER:=Tijs Van Buggenhout <tvbuggen@netzerk.be>, \
+              Marcin Jurkowski <marcin1j@gmail.com>
 endef
 
 define Package/htpdate/description
@@ -38,7 +39,7 @@ define Package/htpdate/description
 endef
 
 define Package/htpdate/conffiles
-/etc/default/htpdate
+/etc/config/htpdate
 endef
 
 define Build/Compile
@@ -50,8 +51,8 @@ endef
 define Package/htpdate/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/htpdate $(1)/usr/sbin/
-	$(INSTALL_DIR) $(1)/etc/default/
-	$(INSTALL_CONF) ./files/htpdate.default $(1)/etc/default/htpdate
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) ./files/htpdate.conf $(1)/etc/config/htpdate
 	$(INSTALL_DIR) $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files/htpdate.init $(1)/etc/init.d/htpdate
 endef

--- a/net/htpdate/files/htpdate.conf
+++ b/net/htpdate/files/htpdate.conf
@@ -1,0 +1,11 @@
+config htpdate 'htpdate'
+	option enabled 1
+	list server 'www.google.com'
+	list server 'www.yahoo.com'
+	list server 'www.linux.com'
+	list server 'www.freebsd.org'
+	option proxy_host ''
+	option proxy_port '8080'
+	option debug 0
+	option sanity_check 1
+	#list option '-4'

--- a/net/htpdate/files/htpdate.default
+++ b/net/htpdate/files/htpdate.default
@@ -1,1 +1,0 @@
-OPTIONS="www.google.com www.yahoo.com www.linux.org www.freebsd.org"

--- a/net/htpdate/files/htpdate.init
+++ b/net/htpdate/files/htpdate.init
@@ -2,18 +2,53 @@
 # Copyright (C) 2006 OpenWrt.org
 
 START=49
-BIN=htpdate
-DEFAULT=/etc/default/$BIN
-RUN_D=/var/run
-PID_F=$RUN_D/$BIN.pid
+USE_PROCD=1
+PROG=/usr/sbin/htpdate
 
-start() {
-	[ -f $DEFAULT ] && . $DEFAULT
-	mkdir -p $RUN_D
-	$BIN -l -s -t $OPTIONS && $BIN -D $OPTIONS
+
+
+
+validate_htpdate_section() {
+	uci_validate_section htpdate htpdate "${1}" \
+		'server:list(host)' \
+		'proxy_host:host' \
+		'proxy_port:port:8080' \
+		'debug:bool:0' \
+		'sanity_check:bool:1' \
+		'option:list(string)' \
+		'enabled:bool:1'
 }
 
-stop() {
-	[ -f $PID_F ] && kill $(cat $PID_F)
+
+start_service() {
+	local server proxy debug sanity_check option enabled
+
+        validate_htpdate_section htpdate || {
+		echo "validation failed"
+		return 1
+	}
+
+	[ "$enabled" = 0 ] && return
+
+
+	procd_open_instance
+	procd_set_param command "$PROG" -f
+
+	[ -n "$proxy" ] && procd_append_param command -P $proxy:$proxy_port
+	[ "$debug" = "1" ] && procd_append_param command -d
+	[ "$sanity_check" = "0" ] && procd_append_param command -t
+	[ -n "$option" ] && procd_append_param command $option
+	for peer in $server; do
+		procd_append_param command $peer
+	done
+
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn
+	procd_close_instance
 }
 
+service_triggers() {
+	procd_add_reload_trigger "htpdate"
+	procd_add_validation validate_htpdate_section
+}

--- a/net/htpdate/patches/101-daemon-run-in-foreground.patch
+++ b/net/htpdate/patches/101-daemon-run-in-foreground.patch
@@ -1,0 +1,40 @@
+--- a/htpdate.c
++++ b/htpdate.c
+@@ -395,6 +395,7 @@ Usage: htpdate [-046abdhlqstxD] [-i pid
+   -b    burst mode\n\
+   -d    debug mode\n\
+   -D    daemon mode\n\
++  -f    run in foreground\n\
+   -h    help\n\
+   -i    pid file\n\
+   -l    use syslog for output\n\
+@@ -510,7 +511,7 @@ int main( int argc, char *argv[] ) {
+ 
+ 
+ 	/* Parse the command line switches and arguments */
+-	while ( (param = getopt(argc, argv, "046abdhi:lm:p:qstu:xDM:P:") ) != -1)
++	while ( (param = getopt(argc, argv, "046abdhi:lm:p:qstu:xDfM:P:") ) != -1)
+ 	switch( param ) {
+ 
+ 		case '0':			/* HTTP/1.0 */
+@@ -593,6 +594,9 @@ int main( int argc, char *argv[] ) {
+ 			daemonize = 1;
+ 			logmode = 1;
+ 			break;
++		case 'f':			/* run in foreground */
++			daemonize = 2;
++			break;
+ 		case 'M':			/* maximum poll interval */
+ 			if ( ( maxsleep = atoi(optarg) ) <= 0 ) {
+ 				fputs( "Invalid sleep time\n", stderr );
+@@ -631,7 +635,9 @@ int main( int argc, char *argv[] ) {
+ 
+ 	/* Run as a daemonize when -D is set */
+ 	if ( daemonize ) {
+-		runasdaemon( pidfile );
++		if ( daemonize == 1 ) {
++			runasdaemon( pidfile );
++		}
+ 		/* Query only mode doesn't exist in daemon mode */
+ 		if ( !setmode )
+ 			setmode = 1;


### PR DESCRIPTION
Maintainer: @tisj @marcin1j 
Compile tested: mipsel_24kc
Run tested: Nexx WT-3020 (mipsel_24kc)
Description:
Modify init script to use standard uci configuration and procd for
process management. We benefit from:
- use of standard LEDE configuration with its ability to revert and
  commit changes
- validation of configuration variables
- procd taking care of restarting daemon when config changes and user
  wants to reload it
- automatic respawning of daemon process in case it dies

The source is patched to make it possible to run as a daemon in
foreground.