### PR TITLE
httping: import from oldpackages and upgrade to version 2.5

### DIFF
--- a/net/httping/Makefile
+++ b/net/httping/Makefile
@@ -1,0 +1,90 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=httping
+PKG_VERSION:=2.5
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
+PKG_SOURCE_URL:=http://www.vanheusden.com/httping
+PKG_HASH:=3e895a0a6d7bd79de25a255a1376d4da88eb09c34efdd0476ab5a907e75bfaf8
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/httping/Default
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Httping is like 'ping' but for http-requests
+  URL:=http://www.vanheusden.com/httping/
+  DEPENDS:=$(INTL_DEPENDS)
+  MAINTAINER:=Marcin Jurkowski <marcin1j@gmail.com>
+endef
+
+define Package/httping/Default/description
+	Give it an url, and it'll show you how long it takes to connect, send a
+	request and retrieve the reply (only the headers). Be aware that the
+	transmission across the network also takes time!
+endef
+
+define Package/httping
+  $(call Package/httping/Default)
+  DEPENDS+= +libopenssl
+  TITLE+= (with SSL support)
+  VARIANT:=ssl
+endef
+
+define Package/httping/description
+	$(call Package/httping/Default/description)
+	This package is built with SSL support.
+endef
+
+define Package/httping-nossl
+  $(call Package/httping/Default)
+  TITLE+= (without SSL support)
+  VARIANT:=nossl
+endef
+
+define Package/httping-nossl/description
+	$(call Package/httping/Default/description)
+	This package is built without SSL support.
+endef
+
+define Build/Configure
+endef
+
+TARGET_LDFLAGS += $(INTL_LDFLAGS) $(if $(INTL_FULL),-lintl)
+
+MAKE_FLAGS += \
+	DEBUG="no" \
+	FW="no" \
+	NC="no" \
+	TFO="no" \
+	JSON="no" \
+	NAGIOS="no" \
+	HELP="yes" \
+	FULLHELP="no"
+
+
+ifeq ($(BUILD_VARIANT),nossl)
+	MAKE_FLAGS += SSL="no"
+endif
+
+define Package/httping/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/httping $(1)/usr/bin/
+endef
+
+Package/httping-nossl/install = $(Package/httping/install)
+
+$(eval $(call BuildPackage,httping))
+$(eval $(call BuildPackage,httping-nossl))

--- a/net/httping/patches/001-no_strip.patch
+++ b/net/httping/patches/001-no_strip.patch
@@ -1,0 +1,12 @@
+--- a/Makefile
++++ b/Makefile
+@@ -115,9 +115,6 @@ install: $(TARGET) $(TRANSLATIONS)
+ 	$(INSTALLMAN) $(MAN_RU) $(DESTDIR)/$(MANDIR)/ru/man1
+ 	$(INSTALLDIR) $(DESTDIR)/$(DOCDIR)
+ 	$(INSTALLDOC) $(DOCS) $(DESTDIR)/$(DOCDIR)
+-ifneq ($(DEBUG),yes)
+-	$(STRIP) $(DESTDIR)/$(BINDIR)/$(TARGET)
+-endif
+ 	mkdir -p $(DESTDIR)/$(PREFIX)/share/locale/nl/LC_MESSAGES
+ 	cp nl.mo $(DESTDIR)/$(PREFIX)/share/locale/nl/LC_MESSAGES/httping.mo
+ 	mkdir -p $(DESTDIR)/$(PREFIX)/share/locale/ru/LC_MESSAGES

--- a/net/httping/patches/002-fix_compile_warnings.patch
+++ b/net/httping/patches/002-fix_compile_warnings.patch
@@ -1,0 +1,10 @@
+--- a/http.c
++++ b/http.c
+@@ -4,6 +4,7 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <unistd.h>
++#include <stdlib.h>
+ #ifndef NO_SSL
+ #include <openssl/ssl.h>
+ #include "mssl.h"

--- a/net/httping/patches/003-fix_response_time.patch
+++ b/net/httping/patches/003-fix_response_time.patch
@@ -1,0 +1,17 @@
+--- a/utils.c
++++ b/utils.c
+@@ -18,12 +18,11 @@
+ double get_ts(void)
+ {
+ 	struct timeval ts;
+-       	struct timezone tz;
+ 
+-	if (gettimeofday(&ts, &tz) == -1)
++	if (gettimeofday(&ts, NULL) == -1)
+ 		error_exit(gettext("gettimeofday failed"));
+ 
+-	return (double)ts.tv_sec + ((double)ts.tv_usec)/1000000.0 + (double)(tz.tz_minuteswest * 60);
++	return (double)ts.tv_sec + ((double)ts.tv_usec)/1000000.0;
+ }
+ 
+ void split_string(const char *in, const char *split, char ***list, int *list_n)

--- a/net/httping/patches/004-minimize.patch
+++ b/net/httping/patches/004-minimize.patch
@@ -1,0 +1,375 @@
+--- a/main.c
++++ b/main.c
+@@ -51,25 +51,40 @@ volatile int stop = 0;
+ 
+ int quiet = 0;
+ char machine_readable = 0;
++#ifdef ENABLE_JSON
+ char json_output = 0;
++#else
++#define json_output 0
++#endif
+ char show_ts = 0;
+ 
++#ifdef ENABLE_HELP_FORMAT
+ int max_x = 80, max_y = 24;
++#endif
+ 
++#ifdef ENABLE_NAGIOS
+ char nagios_mode = 0;
++#else
++#define nagios_mode 0
++#endif
++#ifdef NC
+ char ncurses_mode = 0;
++#else
++#define ncurses_mode 0
++#endif
+ 
+ int fd = -1;
+ 
+ volatile char got_sigquit = 0;
+ 
+-void handler_quit(int s)
++void handler_quit()
+ {
+ 	signal(SIGQUIT, handler_quit);
+ 
+ 	got_sigquit = 1;
+ }
+ 
++#ifdef ENABLE_HELP_FORMAT
+ void determine_terminal_size(int *max_y, int *max_x)
+ {
+         struct winsize size;
+@@ -104,6 +119,7 @@ void determine_terminal_size(int *max_y,
+                         *max_y = 24;
+         }
+ }
++#endif
+ 
+ void emit_statuslines(double run_time)
+ {
+@@ -159,6 +175,7 @@ void emit_headers(char *in)
+ #endif
+ }
+ 
++#ifdef ENABLE_JSON
+ void emit_json(char ok, int seq, double start_ts, stats_t *t_resolve, stats_t *t_connect, stats_t *t_request, int http_code, const char *msg, int header_size, int data_size, double Bps, const char *host, const char *ssl_fp, double toff_diff_ts, char tfo_success, stats_t *t_ssl, stats_t *t_write, stats_t *t_close, int n_cookies, stats_t *stats_to, stats_t *tcp_rtt_stats, int re_tx, int pmtu, int recv_tos, stats_t *t_total)
+ {
+ 	if (seq > 1)
+@@ -203,6 +220,7 @@ void emit_json(char ok, int seq, double
+ 	printf("\"tos\" : \"%02x\" ", recv_tos);
+ 	printf("}");
+ }
++#endif
+ 
+ char *get_ts_str(int verbose)
+ {
+@@ -240,8 +258,13 @@ void emit_error(int verbose, int seq, do
+ 		if (!quiet && !machine_readable && !nagios_mode && !json_output)
+ 			printf("%s%s%s%s\n", ts ? ts : "", c_error, get_error(), c_normal);
+ 
++#ifdef ENABLE_JSON
+ 	if (json_output)
+ 		emit_json(0, seq, start_ts, NULL, NULL, NULL, -1, get_error(), -1, -1, -1, "", "", -1, 0, NULL, NULL, NULL, 0, NULL, NULL, 0, 0, 0, NULL);
++#else
++	(void) seq;
++	(void) start_ts;
++#endif
+ 
+ 	clear_error();
+ 
+@@ -590,6 +613,7 @@ void fetch_proxy_settings(char **proxy_u
+ 	}
+ }
+ 
++#ifdef ENABLE_NAGIOS
+ void parse_nagios_settings(const char *in, double *nagios_warn, double *nagios_crit)
+ {
+ 	char *dummy = strchr(in, ',');
+@@ -600,6 +624,7 @@ void parse_nagios_settings(const char *i
+ 
+ 	*nagios_crit = atof(dummy + 1);
+ }
++#endif
+ 
+ void parse_bind_to(const char *in, struct sockaddr_in *bind_to_4, struct sockaddr_in6 *bind_to_6, struct sockaddr_in **bind_to)
+ {
+@@ -722,6 +747,7 @@ char check_compressed(const char *reply)
+ 	return 0;
+ }
+ 
++#ifdef ENABLE_NAGIOS
+ int nagios_result(int ok, int nagios_mode, int nagios_exit_code, double avg_httping_time, double nagios_warn, double nagios_crit)
+ {
+ 	if (nagios_mode == 1)
+@@ -762,6 +788,7 @@ int nagios_result(int ok, int nagios_mod
+ 
+ 	return -1;
+ }
++#endif
+ 
+ void proxy_to_host_and_port(char *in, char **proxy_host, int *proxy_port)
+ {
+@@ -896,8 +923,10 @@ int main(int argc, char *argv[])
+ 	int n_static_cookies = 0, n_dynamic_cookies = 0;
+ 	char resolve_once = 0;
+ 	char have_resolved = 0;
++#ifdef ENABLE_NAGIOS
+ 	double nagios_warn=0.0, nagios_crit=0.0;
+ 	int nagios_exit_code = 2;
++#endif
+ 	double avg_httping_time = -1.0;
+ 	int get_instead_of_head = 0;
+ 	char show_Bps = 0, ask_compression = 0;
+@@ -928,9 +957,17 @@ int main(int argc, char *argv[])
+ 	stats_t t_connect, t_request, t_total, t_resolve, t_write, t_ssl, t_close, stats_to, tcp_rtt_stats, stats_header_size;
+ 	char first_resolve = 1;
+ 	double graph_limit = MY_DOUBLE_INF;
++#ifdef NC
++#ifdef FW
+ 	char nc_graph = 1;
++#else
++	#define nc_graph 1
++#endif
++#endif
+ 	char adaptive_interval = 0;
++#ifdef NC
+ 	double show_slow_log = MY_DOUBLE_INF;
++#endif
+ 	char use_tcp_nodelay = 1;
+ 	int max_mtu = -1;
+ 	int write_sleep = 500; /* in us (microseconds), determines resolution of transmit time determination */
+@@ -980,8 +1017,10 @@ int main(int argc, char *argv[])
+ 		{"user-agent",	1, NULL, 'I' },
+ 		{"referer",	1, NULL, 'S' },
+ 		{"resolve-once",0, NULL, 'r' },
++#ifdef ENABLE_NAGIOS
+ 		{"nagios-mode-1",	1, NULL, 'n' },
+ 		{"nagios-mode-2",	1, NULL, 'n' },
++#endif
+ 		{"bind-to",	1, NULL, 'y' },
+ 		{"quiet",	0, NULL, 'q' },
+ 		{"username",	1, NULL, 'U' },
+@@ -1052,7 +1091,9 @@ int main(int argc, char *argv[])
+ #endif
+ 	init_statst(&stats_header_size);
+ 
++#ifdef ENABLE_HELP_FORMAT
+ 	determine_terminal_size(&max_y, &max_x);
++#endif
+ 
+ 	signal(SIGPIPE, SIG_IGN);
+ 
+@@ -1108,11 +1149,11 @@ int main(int argc, char *argv[])
+ 			case 14:
+ 				draw_phase = 1;
+ 				break;
+-#endif
+ 
+ 			case 13:
+ 				show_slow_log = atof(optarg);
+ 				break;
++#endif
+ 
+ 			case 12:
+ 				adaptive_interval = 1;
+@@ -1144,9 +1185,11 @@ int main(int argc, char *argv[])
+ 				fprintf(stderr, gettext("\n *** -A is no longer required ***\n\n"));
+ 				break;
+ 
++#ifdef ENABLE_JSON
+ 			case 'M':
+ 				json_output = 1;
+ 				break;
++#endif
+ 
+ 			case 'v':
+ 				verbose++;
+@@ -1338,6 +1381,7 @@ int main(int argc, char *argv[])
+ 				version();
+ 				return 0;
+ 
++#ifdef ENABLE_NAGIOS
+ 			case 'n':
+ 				if (nagios_mode)
+ 					error_exit(gettext("-n and -N are mutual exclusive\n"));
+@@ -1352,6 +1396,7 @@ int main(int argc, char *argv[])
+ 				nagios_mode = 2;
+ 				nagios_exit_code = atoi(optarg);
+ 				break;
++#endif
+ 
+ 			case 'P':
+ 				auth_password = optarg;
+@@ -1497,8 +1542,10 @@ int main(int argc, char *argv[])
+ 			printf("PING %s%s:%s%d%s (%s):\n", c_green, hostname, c_bright, portnr, c_normal, get);
+ 	}
+ 
++#ifdef ENABLE_JSON
+ 	if (json_output)
+ 		printf("[\n");
++#endif
+ 
+ 	if (adaptive_interval && wait <= 0.0)
+ 		error_exit(gettext("Interval must be > 0 when using adaptive interval"));
+@@ -1593,7 +1640,10 @@ int main(int argc, char *argv[])
+ 		int age = -1;
+ 		char *sc = NULL, *scdummy = NULL;
+ 		char *fp = NULL;
+-		int re_tx = 0, pmtu = 0, recv_tos = 0;
++		int recv_tos = 0;
++#if defined(NC) || defined(ENABLE_JSON)
++		int re_tx = 0, pmtu = 0;
++#endif
+ 		socklen_t recv_tos_len = sizeof recv_tos;
+ 
+ 		dstart = get_ts();
+@@ -1607,7 +1657,9 @@ int main(int argc, char *argv[])
+ 			char req_sent = 0;
+ 			double dummy_ms = 0.0;
+ 			double their_est_ts = -1.0, toff_diff_ts = -1.0;
++#if defined(ENABLE_JSON) || defined(TCP_TFO)
+ 			char tfo_success = 0;
++#endif
+ 			double ssl_handshake = 0.0;
+ 			char cur_have_resolved = 0;
+ #if defined(linux) || defined(__FreeBSD__)
+@@ -2114,7 +2166,7 @@ persistent_loop:
+ 
+ 				update_statst(&tcp_rtt_stats, (double)info.tcpi_rtt / 1000.0);
+ 
+-#ifdef linux
++#if defined(linux) && (defined(NC) || defined(ENABLE_JSON))
+ 				re_tx = info.tcpi_retransmits;
+ 				pmtu = info.tcpi_pmtu;
+ #endif
+@@ -2134,6 +2186,7 @@ persistent_loop:
+ 			toff_diff_ts = ((double)their_ts - their_est_ts) * 1000.0;
+ 			update_statst(&stats_to, toff_diff_ts);
+ 
++#ifdef ENABLE_JSON
+ 			if (json_output)
+ 			{
+ 				char current_host[4096] = { 0 };
+@@ -2145,7 +2198,9 @@ persistent_loop:
+ 
+ 				emit_json(1, curncount, dstart, &t_resolve, &t_connect, &t_request, atoi(sc ? sc : "-1"), sc ? sc : "?", headers_len, len, Bps, current_host, fp, toff_diff_ts, tfo_success, &t_ssl, &t_write, &t_close, n_dynamic_cookies, &stats_to, &tcp_rtt_stats, re_tx, pmtu, recv_tos, &t_total);
+ 			}
+-			else if (machine_readable)
++			else
++#endif
++			if (machine_readable)
+ 			{
+ 				if (sc)
+ 				{
+@@ -2404,14 +2459,18 @@ persistent_loop:
+ 		stats_line(1, complete_url, count, curncount, err, ok, started_at, verbose, &t_total, avg_httping_time, show_Bps ? &bps : NULL);
+ 
+ error_exit:
++#ifdef ENABLE_NAGIOS
+ 	if (nagios_mode)
+ 		return nagios_result(ok, nagios_mode, nagios_exit_code, avg_httping_time, nagios_warn, nagios_crit);
++#endif
+ 
+ 	if (!json_output && !machine_readable)
+ 		printf("%s", c_very_normal);
+ 
++#ifdef ENABLE_JSON
+ 	if (json_output)
+ 		printf("\n]\n");
++#endif
+ 
+ 	free_cookies(static_cookies, n_static_cookies);
+ 	free_cookies(dynamic_cookies, n_dynamic_cookies);
+--- a/help.c
++++ b/help.c
+@@ -93,6 +93,8 @@ void version(void)
+ 	fprintf(stderr, gettext("\n"));
+ }
+ 
++#ifdef ENABLE_HELP
++#ifdef ENABLE_HELP_FORMAT
+ void format_help(const char *short_str, const char *long_str, const char *descr)
+ {
+ 	int par_width = SWITCHES_COLUMN_WIDTH, max_wrap_width = par_width / 2, cur_par_width = 0;
+@@ -167,9 +169,30 @@ void format_help(const char *short_str,
+ 		p = n;
+ 	}
+ }
++#else
++void format_help(const char *short_str, const char *long_str, const char *descr)
++{
++	if (short_str)
++	{
++		fputs(short_str, stderr);
++		fputc(' ', stderr);
++	}
++
++	if (long_str)
++	{
++		fputs(long_str, stderr);
++		fputc(' ', stderr);
++	}
++
++	fputs(descr, stderr);
++	fputc('\n', stderr);
++}
++#endif
++#endif
+ 
+ void usage(const char *me)
+ {
++#ifdef ENABLE_HELP
+ 	char *dummy = NULL, has_color = 0;
+ 	char host[256] = { 0 };
+ 
+@@ -270,11 +293,15 @@ void usage(const char *me)
+ 	fprintf(stderr, gettext(" *** output mode settings ***\n"));
+ 	format_help("-q", "--quiet", gettext("quiet, only returncode"));
+ 	format_help("-m", "--parseable-output", gettext("give machine parseable output (see also -o and -e)"));
++#ifdef ENABLE_JSON
+ 	format_help("-M", NULL, gettext("json output, cannot be combined with -m"));
++#endif
+ 	format_help("-o rc,rc,...", "--ok-result-codes", gettext("what http results codes indicate 'ok' comma separated WITHOUT spaces inbetween default is 200, use with -e"));
+ 	format_help("-e x", "--result-string", gettext("string to display when http result code doesn't match"));
++#ifdef ENABLE_NAGIOS
+ 	format_help("-n warn,crit", "--nagios-mode-1 / --nagios-mode-2", gettext("Nagios-mode: return 1 when avg. response time >= warn, 2 if >= crit, otherwhise return 0"));
+ 	format_help("-N x", NULL, gettext("Nagios mode 2: return 0 when all fine, 'x' when anything failes"));
++#endif
+ 	format_help("-C cookie=value", "--cookie", gettext("add a cookie to the request"));
+ 	format_help("-Y", "--colors", gettext("add colors"));
+ 	format_help("-a", "--audible-ping", gettext("audible ping"));
+@@ -309,5 +336,6 @@ void usage(const char *me)
+ 	fprintf(stderr, gettext("Example:\n"));
+ 	fprintf(stderr, "\t%s %s%s -s -Z\n\n", me, host, has_color ? " -Y" : "");
+ 
++#endif
+ 	new_version_alert();
+ }
+--- a/Makefile
++++ b/Makefile
+@@ -88,6 +88,22 @@ OBJS+=fft.o
+ LDFLAGS+=-lfftw3
+ endif
+ 
++ifeq ($(JSON),yes)
++CFLAGS+=-DENABLE_JSON
++endif
++
++ifeq ($(NAGIOS),yes)
++CFLAGS+=-DENABLE_NAGIOS
++endif
++
++ifeq ($(HELP),yes)
++CFLAGS+=-DENABLE_HELP
++endif
++
++ifeq ($(HELPFORMAT),yes)
++CFLAGS+=-DENABLE_HELP_FORMAT
++endif
++
+ ifeq ($(DEBUG),yes)
+ CFLAGS+=-D_DEBUG -ggdb
+ LDFLAGS+=-g


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, mipsel_24kc
Run tested: NetGear WNDR3700v2 (ar71xx), Nexx WT-3020 (mipsel_24kc)
Description:
Package version upgraded to 2.5 with patches:
- Fixed compiler warnings
- Fixed miscalculated response time
- Reduced binary size by stripping unused code