### PR TITLE
dnscrypt-proxy: fix possible race condition during boot

### DIFF
--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
 PKG_VERSION:=1.9.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy

--- a/net/dnscrypt-proxy/files/dnscrypt-proxy.init
+++ b/net/dnscrypt-proxy/files/dnscrypt-proxy.init
@@ -6,6 +6,11 @@ PROG=/usr/sbin/dnscrypt-proxy
 CONFIG_DIR=/var/etc
 USER=nobody
 
+boot() {
+    dnscrypt_boot=1
+    rc_procd start_service
+}
+
 dnscrypt_instance() {   
     local config_path="$CONFIG_DIR/dnscrypt-proxy-$1.conf"     
     create_config_file $1 "$config_path"
@@ -113,10 +118,15 @@ append_blacklists() {
 }
 
 start_service() {
+    if [ -n "${dnscrypt_boot}" ]
+    then
+        return 0
+    fi
     config_load dnscrypt-proxy
     config_foreach dnscrypt_instance dnscrypt-proxy
 }
 
 service_triggers() {
+    procd_add_raw_trigger "interface.*.up" 2000 /etc/init.d/dnscrypt-proxy reload
     procd_add_reload_trigger 'dnscrypt-proxy'
 }


### PR DESCRIPTION
Maintainer: @jedisct1
Compile tested: -
Run tested: x86-apu2c4, LEDE Reboot SNAPSHOT r4633-9551d91b1d

Description:
* Start dnscrypt-proxy from procd raw interface trigger rather than immediately in init, to fix possible race conditions during boot.

Signed-off-by: Dirk Brenken <dev@brenken.org>