### PR TITLE
python,python3: refresh patches via refresh cmd (reduce patch fuzz)

### DIFF
--- a/lang/python/python/patches/001-enable-zlib.patch
+++ b/lang/python/python/patches/001-enable-zlib.patch
@@ -7,11 +7,9 @@ Subject: [PATCH] enable zlib
  Modules/Setup.dist | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/Modules/Setup.dist b/Modules/Setup.dist
-index 01fb85f..01ac492 100644
 --- a/Modules/Setup.dist
 +++ b/Modules/Setup.dist
-@@ -358,7 +358,7 @@ _symtable symtablemodule.c
+@@ -464,7 +464,7 @@ GLHACK=-Dclear=__GLclear
  # Andrew Kuchling's zlib module.
  # This require zlib 1.1.3 (or later).
  # See http://www.gzip.org/zlib/
@@ -20,6 +18,3 @@ index 01fb85f..01ac492 100644
  
  # Interface to the Expat XML parser
  #
--- 
-1.8.4.5
-

--- a/lang/python/python/patches/002-do-not-add-include-dirs-when-cross-compiling.patch
+++ b/lang/python/python/patches/002-do-not-add-include-dirs-when-cross-compiling.patch
@@ -1,8 +1,6 @@
-diff --git a/setup.py b/setup.py
-index cbdeaf3..5154412 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -480,7 +480,8 @@ class PyBuildExt(build_ext):
+@@ -497,7 +497,8 @@ class PyBuildExt(build_ext):
                          add_dir_to_list(dir_list, directory)
  
          if os.path.normpath(sys.prefix) != '/usr' \

--- a/lang/python/python/patches/003-do-not-compile-tests-at-build.patch
+++ b/lang/python/python/patches/003-do-not-compile-tests-at-build.patch
@@ -1,8 +1,6 @@
-diff --git a/Makefile.pre.in b/Makefile.pre.in
-index 7f4ec2f..e270bf2 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
-@@ -1038,6 +1038,7 @@ libinstall:	build_all $(srcdir)/Lib/$(PLATDIR) $(srcdir)/Modules/xxmodule.c
+@@ -1116,6 +1116,7 @@ libinstall:	build_all $(srcdir)/Lib/$(PL
  		done; \
  	done
  	$(INSTALL_DATA) $(srcdir)/LICENSE $(DESTDIR)$(LIBDEST)/LICENSE.txt
@@ -10,7 +8,7 @@ index 7f4ec2f..e270bf2 100644
  	if test -d $(DESTDIR)$(LIBDEST)/distutils/tests; then \
  		$(INSTALL_DATA) $(srcdir)/Modules/xxmodule.c \
  			$(DESTDIR)$(LIBDEST)/distutils/tests ; \
-@@ -1064,6 +1065,7 @@ libinstall:	build_all $(srcdir)/Lib/$(PLATDIR) $(srcdir)/Modules/xxmodule.c
+@@ -1142,6 +1143,7 @@ libinstall:	build_all $(srcdir)/Lib/$(PL
  		$(PYTHON_FOR_BUILD) -m lib2to3.pgen2.driver $(DESTDIR)$(LIBDEST)/lib2to3/Grammar.txt
  	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
  		$(PYTHON_FOR_BUILD) -m lib2to3.pgen2.driver $(DESTDIR)$(LIBDEST)/lib2to3/PatternGrammar.txt

--- a/lang/python/python/patches/004-do-not-write-bytes-codes.patch
+++ b/lang/python/python/patches/004-do-not-write-bytes-codes.patch
@@ -1,8 +1,6 @@
-diff --git a/Python/pythonrun.c b/Python/pythonrun.c
-index 748a63b..cb6e291 100644
 --- a/Python/pythonrun.c
 +++ b/Python/pythonrun.c
-@@ -79,7 +79,7 @@ int Py_InteractiveFlag; /* Needed by Py_FdIsInteractive() below */
+@@ -79,7 +79,7 @@ int Py_InteractiveFlag; /* Needed by Py_
  int Py_InspectFlag; /* Needed to determine whether to exit at SystemExit */
  int Py_NoSiteFlag; /* Suppress 'import site' */
  int Py_BytesWarningFlag; /* Warn on str(bytes) and str(buffer) */
@@ -11,7 +9,7 @@ index 748a63b..cb6e291 100644
  int Py_UseClassExceptionsFlag = 1; /* Needed by bltinmodule.c: deprecated */
  int Py_FrozenFlag; /* Needed by getpath.c */
  int Py_UnicodeFlag = 0; /* Needed by compile.c */
-@@ -174,7 +174,7 @@ Py_InitializeEx(int install_sigs)
+@@ -185,7 +185,7 @@ Py_InitializeEx(int install_sigs)
      if ((p = Py_GETENV("PYTHONOPTIMIZE")) && *p != '\0')
          Py_OptimizeFlag = add_flag(Py_OptimizeFlag, p);
      if ((p = Py_GETENV("PYTHONDONTWRITEBYTECODE")) && *p != '\0')

--- a/lang/python/python/patches/006-remove-multi-arch-and-local-paths.patch
+++ b/lang/python/python/patches/006-remove-multi-arch-and-local-paths.patch
@@ -1,5 +1,3 @@
-diff --git a/setup.py b/setup.py
-index 54054c2..d043761 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -454,13 +454,8 @@ class PyBuildExt(build_ext):

--- a/lang/python/python/patches/008-distutils-use-python-sysroot.patch
+++ b/lang/python/python/patches/008-distutils-use-python-sysroot.patch
@@ -16,11 +16,9 @@ taken from the sysconfigdata module.
 
 Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
 
-Index: b/Lib/distutils/sysconfig.py
-===================================================================
 --- a/Lib/distutils/sysconfig.py
 +++ b/Lib/distutils/sysconfig.py
-@@ -19,8 +19,13 @@
+@@ -19,8 +19,13 @@ import sys
  from distutils.errors import DistutilsPlatformError
  
  # These are needed in a couple of spots, so just compute them once.
@@ -36,11 +34,9 @@ Index: b/Lib/distutils/sysconfig.py
  
  # Path to the base directory of the project. On Windows the binary may
  # live in project/PCBuild9.  If we're dealing with an x64 Windows build,
-Index: b/Lib/distutils/command/build_ext.py
-===================================================================
 --- a/Lib/distutils/command/build_ext.py
 +++ b/Lib/distutils/command/build_ext.py
-@@ -237,7 +237,10 @@
+@@ -240,7 +240,10 @@ class build_ext (Command):
          if (sysconfig.get_config_var('Py_ENABLE_SHARED')):
              if not sysconfig.python_build:
                  # building third party extensions

--- a/lang/python/python/patches/009-do-not-use-dblib_dir-when-cross-compiling.patch
+++ b/lang/python/python/patches/009-do-not-use-dblib_dir-when-cross-compiling.patch
@@ -1,8 +1,6 @@
-diff --git a/setup.py b/setup.py
-index 7868b7b..10ec68f 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -1067,6 +1067,7 @@ class PyBuildExt(build_ext):
+@@ -1083,6 +1083,7 @@ class PyBuildExt(build_ext):
                          if db_setup_debug: print "db lib: ", dblib, "not found"
  
          except db_found:
@@ -10,7 +8,7 @@ index 7868b7b..10ec68f 100644
              if db_setup_debug:
                  print "bsddb using BerkeleyDB lib:", db_ver, dblib
                  print "bsddb lib dir:", dblib_dir, " inc dir:", db_incdir
-@@ -1081,7 +1082,7 @@ class PyBuildExt(build_ext):
+@@ -1097,7 +1098,7 @@ class PyBuildExt(build_ext):
              exts.append(Extension('_bsddb', ['_bsddb.c'],
                                    depends = ['bsddb.h'],
                                    library_dirs=dblib_dir,
@@ -19,7 +17,7 @@ index 7868b7b..10ec68f 100644
                                    include_dirs=db_incs,
                                    libraries=dblibs))
          else:
-@@ -1292,10 +1293,11 @@ class PyBuildExt(build_ext):
+@@ -1308,10 +1309,11 @@ class PyBuildExt(build_ext):
                              break
                  elif cand == "bdb":
                      if db_incs is not None:

--- a/lang/python/python/patches/010-do-not-add-rt-lib-dirs-when-cross-compiling.patch
+++ b/lang/python/python/patches/010-do-not-add-rt-lib-dirs-when-cross-compiling.patch
@@ -1,8 +1,6 @@
-diff --git a/setup.py b/setup.py
-index 7868b7b..544fa7e 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -452,8 +452,9 @@ class PyBuildExt(build_ext):
+@@ -463,8 +463,9 @@ class PyBuildExt(build_ext):
          # directly since an inconsistently reproducible issue comes up where
          # the environment variable is not set even though the value were passed
          # into configure and stored in the Makefile (issue found on OS X 10.3).

--- a/lang/python/python/patches/011-remove-setupterm-definition.patch
+++ b/lang/python/python/patches/011-remove-setupterm-definition.patch
@@ -1,5 +1,3 @@
-diff --git a/Modules/_cursesmodule.c b/Modules/_cursesmodule.c
-index e478a57..eb297b4 100644
 --- a/Modules/_cursesmodule.c
 +++ b/Modules/_cursesmodule.c
 @@ -117,7 +117,6 @@ char *PyCursesVersion = "2.2";

--- a/lang/python/python3/patches/001-enable-zlib.patch
+++ b/lang/python/python3/patches/001-enable-zlib.patch
@@ -7,11 +7,9 @@ Subject: [PATCH] enable zlib
  Modules/Setup.dist | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/Modules/Setup.dist b/Modules/Setup.dist
-index 01fb85f..01ac492 100644
 --- a/Modules/Setup.dist
 +++ b/Modules/Setup.dist
-@@ -358,7 +358,7 @@ _symtable symtablemodule.c
+@@ -362,7 +362,7 @@ _symtable symtablemodule.c
  # Andrew Kuchling's zlib module.
  # This require zlib 1.1.3 (or later).
  # See http://www.gzip.org/zlib/
@@ -20,6 +18,3 @@ index 01fb85f..01ac492 100644
  
  # Interface to the Expat XML parser
  #
--- 
-1.8.4.5
-

--- a/lang/python/python3/patches/003-do-not-run-distutils-tests.patch
+++ b/lang/python/python3/patches/003-do-not-run-distutils-tests.patch
@@ -1,10 +1,8 @@
-diff --git a/Makefile.pre.in b/Makefile.pre.in
-index ce2c0aa..b0c8322 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
-@@ -1256,41 +1256,6 @@ libinstall:	build_all $(srcdir)/Lib/$(PLATDIR) $(srcdir)/Modules/xxmodule.c
- 		done; \
- 	done
+@@ -1307,41 +1307,6 @@ libinstall:	build_all $(srcdir)/Modules/
+ 	$(INSTALL_DATA) `cat pybuilddir.txt`/_sysconfigdata_$(ABIFLAGS)_$(MACHDEP)_$(MULTIARCH).py \
+ 		$(DESTDIR)$(LIBDEST); \
  	$(INSTALL_DATA) $(srcdir)/LICENSE $(DESTDIR)$(LIBDEST)/LICENSE.txt
 -	if test -d $(DESTDIR)$(LIBDEST)/distutils/tests; then \
 -		$(INSTALL_DATA) $(srcdir)/Modules/xxmodule.c \
@@ -42,5 +40,5 @@ index ce2c0aa..b0c8322 100644
 -	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
 -		$(PYTHON_FOR_BUILD) -m lib2to3.pgen2.driver $(DESTDIR)$(LIBDEST)/lib2to3/PatternGrammar.txt
  
- # Create the PLATDIR source directory, if one wasn't distributed..
- $(srcdir)/Lib/$(PLATDIR):
+ python-config: $(srcdir)/Misc/python-config.in Misc/python-config.sh
+ 	# Substitution happens here, as the completely-expanded BINDIR

--- a/lang/python/python3/patches/004-do-not-write-bytes-codes.patch
+++ b/lang/python/python3/patches/004-do-not-write-bytes-codes.patch
@@ -1,8 +1,6 @@
-diff --git a/Python/pylifecycle.c b/Python/pylifecycle.c
-index 640271f..5479e6c 100644
 --- a/Python/pylifecycle.c
 +++ b/Python/pylifecycle.c
-@@ -88,7 +88,7 @@ int Py_BytesWarningFlag; /* Warn on str(bytes) and str(buffer) */
+@@ -88,7 +88,7 @@ int Py_BytesWarningFlag; /* Warn on str(
  int Py_UseClassExceptionsFlag = 1; /* Needed by bltinmodule.c: deprecated */
  int Py_FrozenFlag; /* Needed by getpath.c */
  int Py_IgnoreEnvironmentFlag; /* e.g. PYTHONPATH, PYTHONHOME */
@@ -11,7 +9,7 @@ index 640271f..5479e6c 100644
  int Py_NoUserSiteDirectory = 0; /* for -s and site.py */
  int Py_UnbufferedStdioFlag = 0; /* Unbuffered binary std{in,out,err} */
  int Py_HashRandomizationFlag = 0; /* for -R and PYTHONHASHSEED */
-@@ -329,7 +329,7 @@ _Py_InitializeEx_Private(int install_sigs, int install_importlib)
+@@ -329,7 +329,7 @@ _Py_InitializeEx_Private(int install_sig
      if ((p = Py_GETENV("PYTHONOPTIMIZE")) && *p != '\0')
          Py_OptimizeFlag = add_flag(Py_OptimizeFlag, p);
      if ((p = Py_GETENV("PYTHONDONTWRITEBYTECODE")) && *p != '\0')

--- a/lang/python/python3/patches/006-remove-multi-arch-and-local-paths.patch
+++ b/lang/python/python3/patches/006-remove-multi-arch-and-local-paths.patch
@@ -1,5 +1,3 @@
-diff --git a/setup.py b/setup.py
-index f04bf22..01b851e 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -487,16 +487,9 @@ class PyBuildExt(build_ext):

--- a/lang/python/python3/patches/007-distutils-do-not-adjust-path.patch
+++ b/lang/python/python3/patches/007-distutils-do-not-adjust-path.patch
@@ -1,8 +1,8 @@
 --- a/Lib/distutils/command/build_scripts.py
 +++ b/Lib/distutils/command/build_scripts.py
-@@ -89,6 +89,7 @@ class build_scripts (Command):
-                     adjust = 1
-                     post_interp = match.group(1) or ''
+@@ -91,6 +91,7 @@ class build_scripts(Command):
+                     adjust = True
+                     post_interp = match.group(1) or b''
  
 +            adjust = 0
              if adjust:

--- a/lang/python/python3/patches/008-fix-distutils-path-creation.patch
+++ b/lang/python/python3/patches/008-fix-distutils-path-creation.patch
@@ -1,5 +1,3 @@
-diff --git a/Lib/imp.py b/Lib/imp.py
-index 781ff23..beeac70 100644
 --- a/Lib/imp.py
 +++ b/Lib/imp.py
 @@ -203,8 +203,9 @@ def load_package(name, path):

--- a/lang/python/python3/patches/010-do-not-add-rt-lib-dirs-when-cross-compiling.patch
+++ b/lang/python/python3/patches/010-do-not-add-rt-lib-dirs-when-cross-compiling.patch
@@ -1,8 +1,6 @@
-diff --git a/setup.py b/setup.py
-index 7868b7b..544fa7e 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -452,8 +452,9 @@ class PyBuildExt(build_ext):
+@@ -497,8 +497,9 @@ class PyBuildExt(build_ext):
          # directly since an inconsistently reproducible issue comes up where
          # the environment variable is not set even though the value were passed
          # into configure and stored in the Makefile (issue found on OS X 10.3).

--- a/lang/python/python3/patches/011-fix-ncursesw-definition-colisions.patch
+++ b/lang/python/python3/patches/011-fix-ncursesw-definition-colisions.patch
@@ -1,5 +1,3 @@
-diff --git a/Modules/_cursesmodule.c b/Modules/_cursesmodule.c
-index 3bf2ca7..c156964 100644
 --- a/Modules/_cursesmodule.c
 +++ b/Modules/_cursesmodule.c
 @@ -116,7 +116,6 @@ char *PyCursesVersion = "2.2";

--- a/lang/python/python3/patches/012-disable-wcsftime-detection.patch
+++ b/lang/python/python3/patches/012-disable-wcsftime-detection.patch
@@ -1,8 +1,6 @@
-diff --git a/configure b/configure
-index 274af7e..85bbf0e 100755
 --- a/configure
 +++ b/configure
-@@ -10555,7 +10555,7 @@ for ac_func in alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
+@@ -11271,7 +11271,7 @@ for ac_func in alarm accept4 setitimer g
   sigtimedwait sigwait sigwaitinfo snprintf strftime strlcpy symlinkat sync \
   sysconf tcgetpgrp tcsetpgrp tempnam timegm times tmpfile tmpnam tmpnam_r \
   truncate uname unlinkat unsetenv utimensat utimes waitid waitpid wait3 wait4 \

--- a/lang/python/python3/patches/014-remove-platform-so-suffix.patch
+++ b/lang/python/python3/patches/014-remove-platform-so-suffix.patch
@@ -1,8 +1,6 @@
-diff --git a/configure b/configure
-index e823a08..84c525f 100755
 --- a/configure
 +++ b/configure
-@@ -14365,7 +14365,7 @@ $as_echo_n "checking ABIFLAGS... " >&6; }
+@@ -14986,7 +14986,7 @@ $as_echo_n "checking ABIFLAGS... " >&6;
  $as_echo "$ABIFLAGS" >&6; }
  { $as_echo "$as_me:${as_lineno-$LINENO}: checking SOABI" >&5
  $as_echo_n "checking SOABI... " >&6; }
@@ -11,11 +9,9 @@ index e823a08..84c525f 100755
  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $SOABI" >&5
  $as_echo "$SOABI" >&6; }
  
-diff --git a/configure.ac b/configure.ac
-index 56a73df..1855af5 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -4314,7 +4314,7 @@ AC_SUBST(SOABI)
+@@ -4639,7 +4639,7 @@ AC_SUBST(SOABI)
  AC_MSG_CHECKING(ABIFLAGS)
  AC_MSG_RESULT($ABIFLAGS)
  AC_MSG_CHECKING(SOABI)

--- a/lang/python/python3/patches/015-abort-on-failed-modules.patch
+++ b/lang/python/python3/patches/015-abort-on-failed-modules.patch
@@ -1,8 +1,6 @@
-diff --git a/setup.py b/setup.py
-index da67731..928e0de 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -293,6 +293,7 @@ class PyBuildExt(build_ext):
+@@ -308,6 +308,7 @@ class PyBuildExt(build_ext):
              print("Failed to build these modules:")
              print_three_column(failed)
              print()

--- a/lang/python/python3/patches/016-adjust-config-paths.patch
+++ b/lang/python/python3/patches/016-adjust-config-paths.patch
@@ -1,8 +1,6 @@
-diff --git a/Lib/distutils/sysconfig.py b/Lib/distutils/sysconfig.py
-index 8bf1a70..c2708c3 100644
 --- a/Lib/distutils/sysconfig.py
 +++ b/Lib/distutils/sysconfig.py
-@@ -424,6 +424,7 @@ def _init_posix():
+@@ -421,6 +421,7 @@ def _init_posix():
          platform=sys.platform,
          multiarch=getattr(sys.implementation, '_multiarch', ''),
      ))
@@ -10,8 +8,6 @@ index 8bf1a70..c2708c3 100644
      _temp = __import__(name, globals(), locals(), ['build_time_vars'], 0)
      build_time_vars = _temp.build_time_vars
      global _config_vars
-diff --git a/Lib/sysconfig.py b/Lib/sysconfig.py
-index 9314e71..4861261 100644
 --- a/Lib/sysconfig.py
 +++ b/Lib/sysconfig.py
 @@ -343,6 +343,7 @@ def get_makefile_filename():
@@ -22,11 +18,9 @@ index 9314e71..4861261 100644
      return os.environ.get('_PYTHON_SYSCONFIGDATA_NAME',
          '_sysconfigdata_{abi}_{platform}_{multiarch}'.format(
          abi=sys.abiflags,
-diff --git a/Makefile.pre.in b/Makefile.pre.in
-index cd7d33d..ad6572f 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
-@@ -1301,7 +1301,7 @@ libinstall:	build_all $(srcdir)/Modules/xxmodule.c
+@@ -1304,7 +1304,7 @@ libinstall:	build_all $(srcdir)/Modules/
  			esac; \
  		done; \
  	done
@@ -34,8 +28,8 @@ index cd7d33d..ad6572f 100644
 +	$(INSTALL_DATA) `cat pybuilddir.txt`/_sysconfigdata*.py \
  		$(DESTDIR)$(LIBDEST); \
  	$(INSTALL_DATA) $(srcdir)/LICENSE $(DESTDIR)$(LIBDEST)/LICENSE.txt
- 	if test -d $(DESTDIR)$(LIBDEST)/distutils/tests; then \
-@@ -1436,7 +1436,7 @@ sharedinstall: sharedmods
+ 
+@@ -1404,7 +1404,7 @@ sharedinstall: sharedmods
  		--install-scripts=$(BINDIR) \
  		--install-platlib=$(DESTSHARED) \
  		--root=$(DESTDIR)/
@@ -44,11 +38,9 @@ index cd7d33d..ad6572f 100644
  	-rm -r $(DESTDIR)$(DESTSHARED)/__pycache__
  
  # Here are a couple of targets for MacOSX again, to install a full
-diff --git a/configure b/configure
-index cf95b27..8203fbb 100755
 --- a/configure
 +++ b/configure
-@@ -14895,7 +14895,7 @@ LDVERSION='$(VERSION)$(ABIFLAGS)'
+@@ -15005,7 +15005,7 @@ LDVERSION='$(VERSION)$(ABIFLAGS)'
  $as_echo "$LDVERSION" >&6; }
  
  
@@ -57,11 +49,9 @@ index cf95b27..8203fbb 100755
    LIBPL='$(prefix)'"/lib/python${VERSION}/config-${LDVERSION}"
  else
    LIBPL='$(prefix)'"/lib/python${VERSION}/config-${LDVERSION}-${PLATFORM_TRIPLET}"
-diff --git a/configure.ac b/configure.ac
-index 1d63813..25f25ed 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -4600,7 +4600,7 @@ AC_MSG_RESULT($LDVERSION)
+@@ -4656,7 +4656,7 @@ AC_MSG_RESULT($LDVERSION)
  
  dnl define LIBPL after ABIFLAGS and LDVERSION is defined.
  AC_SUBST(PY_ENABLE_SHARED)


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a
Run tested: n/a

------------------------------------------

Ran `make package/python(3)/refresh`

This was a bit overdue.
I did not know about this methodology.
Reduces patch fuzz.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>