### PR TITLE
python-cryptography: update to version 1.9 ; add python3 variant, and simplify/remove python-cffi host dep 

### DIFF
--- a/lang/python/python-cffi/Makefile
+++ b/lang/python/python-cffi/Makefile
@@ -19,7 +19,10 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cffi-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
+
+HOST_PYTHON_PACKAGE_BUILD_DEPENDS:="cffi==$(PKG_VERSION)"
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:="cffi==$(PKG_VERSION)"
 
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)

--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -7,30 +7,58 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=cryptography
-PKG_VERSION:=1.5.1
-PKG_RELEASE:=2
+PKG_NAME:=python-cryptography
+PKG_VERSION:=1.9
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/21/e1/37fc14f9d77924e84ba0dcb88eb8352db914583af229287c6c965d66ba0d
-PKG_MD5SUM:=66a3e01f5f436d2413ef47b7e6bb7729
-
-PKG_BUILD_DEPENDS:=python-cffi/host
+PKG_SOURCE:=cryptography-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/2a/0c/31bd69469e90035381f0197b48bf71032991d9f07a7e444c311b4a23a3df
+PKG_HASH:=5518337022718029e367d982642f3e3523541e098ad671672a90b82474c84882
 
 PKG_LICENSE:=Apache-2.0 BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.APACHE LICENSE.BSD
-PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cryptography-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
+$(call include_mk, python3-package.mk)
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-cryptography/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://github.com/pyca/cryptography
+  DEPENDS:=+libopenssl
+endef
 
 define Package/python-cryptography
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-cryptography
-	URL:=https://github.com/pyca/cryptography
-	DEPENDS:=+libopenssl +python +python-cffi +python-enum34 +python-idna +python-ipaddress +python-pyasn1 +python-six +python-setuptools
+$(call Package/python-cryptography/Default)
+  TITLE:=python-cryptography
+  DEPENDS+= \
+      +PACKAGE_python-cryptography:python \
+      +PACKAGE_python-cryptography:python-cffi \
+      +PACKAGE_python-cryptography:python-enum34 \
+      +PACKAGE_python-cryptography:python-idna \
+      +PACKAGE_python-cryptography:python-ipaddress \
+      +PACKAGE_python-cryptography:python-pyasn1 \
+      +PACKAGE_python-cryptography:python-six
+  VARIANT:=python
+endef
+
+define Package/python3-cryptography
+$(call Package/python-cryptography/Default)
+  TITLE:=python3-cryptography
+  DEPENDS+= \
+      +PACKAGE_python3-cryptography:python3 \
+      +PACKAGE_python3-cryptography:python3-cffi \
+      +PACKAGE_python3-cryptography:python3-idna \
+      +PACKAGE_python3-cryptography:python3-pyasn1 \
+      +PACKAGE_python3-cryptography:python3-six
+  VARIANT:=python3
 endef
 
 define Package/python-cryptography/description
@@ -39,15 +67,25 @@ primitives to Python developers.  Our goal is for it to be your "cryptographic
 standard library". It supports Python 2.6-2.7, Python 3.3+, and PyPy 2.6+.
 endef
 
+define Package/python3-cryptography/description
+$(call Package/python-cryptography/description)
+.
+(Variant for Python3)
+endef
+
 define PyPackage/python-cryptography/filespec
 +|$(PYTHON_PKG_DIR)
 -|$(PYTHON_PKG_DIR)/cryptography/hazmat/backends/commoncrypto
 -|$(PYTHON_PKG_DIR)/cryptography/hazmat/bindings/commoncrypto
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
+define Py3Package/python3-cryptography/filespec
++|$(PYTHON3_PKG_DIR)
+-|$(PYTHON3_PKG_DIR)/cryptography/hazmat/backends/commoncrypto
+-|$(PYTHON3_PKG_DIR)/cryptography/hazmat/bindings/commoncrypto
 endef
 
 $(eval $(call PyPackage,python-cryptography))
 $(eval $(call BuildPackage,python-cryptography))
+$(eval $(call Py3Package,python3-cryptography))
+$(eval $(call BuildPackage,python3-cryptography))

--- a/lang/python/python-idna/Makefile
+++ b/lang/python/python-idna/Makefile
@@ -7,30 +7,45 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=idna
-PKG_VERSION:=2.1
+PKG_NAME:=python-idna
+PKG_VERSION:=2.5
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/i/idna
-PKG_MD5SUM:=f6473caa9c5e0cc1ad3fd5d04c3c114b
-
-PKG_BUILD_DEPENDS:=python python-setuptools
+PKG_SOURCE:=idna-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/d8/82/28a51052215014efc07feac7330ed758702fc0581347098a81699b5281cb
+PKG_HASH:=3cb5ce08046c4e3a560fc02f138d0ac63e00f8ce5901a56b32ec8b7994082aab
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
-PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-idna-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
+$(call include_mk, python3-package.mk)
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-idna/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://github.com/kjd/idna
+endef
 
 define Package/python-idna
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-idna
-	URL:=https://github.com/kjd/idna
-	DEPENDS:=+python-light
+$(call Package/python-idna/Default)
+  TITLE:=python-idna
+  DEPENDS:=+PACKAGE_python-idna:python-light
+  VARIANT:=python
+endef
+
+define Package/python3-idna
+$(call Package/python-idna/Default)
+  TITLE:=python3-idna
+  DEPENDS:=+PACKAGE_python3-idna:python3-light
+  VARIANT:=python3
 endef
 
 define Package/python-idna/description
@@ -40,9 +55,13 @@ is often referred to as "IDNA2008" and can produce different results
 from the earlier standard from 2003.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-idna/description
+$(call define Package/python-idna/description)
+.
+(Variant for Python3)
 endef
 
 $(eval $(call PyPackage,python-idna))
 $(eval $(call BuildPackage,python-idna))
+$(eval $(call Py3Package,python3-idna))
+$(eval $(call BuildPackage,python3-idna))

--- a/lang/python/python-pyasn1/Makefile
+++ b/lang/python/python-pyasn1/Makefile
@@ -7,30 +7,45 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=pyasn1
-PKG_VERSION:=0.1.9
+PKG_NAME:=python-pyasn1
+PKG_VERSION:=0.2.3
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pyasn1
-PKG_MD5SUM:=f00a02a631d4016818659d1cc38d229a
-
-PKG_BUILD_DEPENDS:=python python-setuptools
+PKG_SOURCE:=pyasn1-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/69/17/eec927b7604d2663fef82204578a0056e11e0fc08d485fdb3b6199d9b590
+PKG_HASH:=738c4ebd88a718e700ee35c8d129acce2286542daa80a82823a7073644f706ad
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE.txt
-PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pyasn1-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
+$(call include_mk, python3-package.mk)
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-pyasn1/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=http://pyasn1.sourceforge.net/
+endef
 
 define Package/python-pyasn1
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-pyasn1
-	URL:=http://pyasn1.sourceforge.net/
-	DEPENDS:=+python-light
+$(call Package/python-pyasn1/Default)
+  TITLE:=python-pyasn1
+  DEPENDS:=+PACKAGE_python-pyasn1:python-light
+  VARIANT:=python
+endef
+
+define Package/python3-pyasn1
+$(call Package/python-pyasn1/Default)
+  TITLE:=python3-pyasn1
+  DEPENDS:=+PACKAGE_python3-pyasn1:python3-light
+  VARIANT:=python3
 endef
 
 define Package/python-pyasn1/description
@@ -40,9 +55,13 @@ but then generalized to be suitable for a wide range of protocols
 based on ASN.1 specification.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-pyasn1/description
+$(call Package/python-pyasn1/description)
+.
+(Variant for Python3)
 endef
 
 $(eval $(call PyPackage,python-pyasn1))
 $(eval $(call BuildPackage,python-pyasn1))
+$(eval $(call Py3Package,python3-pyasn1))
+$(eval $(call BuildPackage,python3-pyasn1))

--- a/lang/python/python-six/Makefile
+++ b/lang/python/python-six/Makefile
@@ -9,35 +9,47 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-six
 PKG_VERSION:=1.10.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=six-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/source/s/six
-PKG_MD5SUM:=34eed507548117b2ab523ab14b2f8b55
+PKG_HASH:=105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a
 
 HOST_BUILD_DEPENDS:=python/host
-PKG_BUILD_DEPENDS:=python
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-six-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
+$(call include_mk, python3-package.mk)
 
 PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 HOST_UNPACK:=$(HOST_TAR) -C $(HOST_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
+define Package/python-six/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://pypi.python.org/pypi/six
+endef
+
 define Package/python-six
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-six
-	URL:=https://pypi.python.org/pypi/six
-	DEPENDS:=+python-light
+$(call Package/python-six/Default)
+  TITLE:=python-six
+  DEPENDS:=+PACKAGE_python-six:python-light
+  VARIANT:=python
+endef
+
+define Package/python3-six
+$(call Package/python-six/Default)
+  TITLE:=python3-six
+  DEPENDS:=+PACKAGE_python3-six:python3-light
+  VARIANT:=python3
 endef
 
 define Package/python-six/description
@@ -47,8 +59,10 @@ writing Python code that is compatible on both Python versions.  See the
 documentation for more information on what is provided.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-six/description
+$(call Package/python-six/description)
+.
+(Variant for Python3)
 endef
 
 define Host/Compile
@@ -61,3 +75,5 @@ $(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-six))
 $(eval $(call BuildPackage,python-six))
+$(eval $(call Py3Package,python3-six))
+$(eval $(call BuildPackage,python3-six))


### PR DESCRIPTION
Maintainer: @jefferyto 
Compile tested: http://github.com/lede-project/source/commit/d72371e42bd5b8738a75a75d970bc73b90cd9839 x86_64
Run tested: http://github.com/lede-project/source/commit/d72371e42bd5b8738a75a75d970bc73b90cd9839 x86_64

Description:

Fixes: https://github.com/openwrt/packages/issues/4638

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>