### PR TITLE
syslog-ng: fix typo in .pid file path

### DIFF
--- a/admin/syslog-ng/files/syslog-ng.init
+++ b/admin/syslog-ng/files/syslog-ng.init
@@ -6,7 +6,7 @@ PROG=/usr/sbin/syslog-ng
 PROG2=/usr/sbin/syslog-ng-ctl
 
 SERVICE_USE_PID=1
-SERVICE_PID_FILE=/var/log/syslog-ng.pid
+SERVICE_PID_FILE=/var/run/syslog-ng.pid
 
 config_file=/etc/syslog-ng.conf
 


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, generic, LEDE HEAD (0d4cda8)
Run tested: same

Description:

Fixes regression introduced in PR #4610 when refactoring commits for @stintel.
