### PR TITLE
nlbwmon: add package

### DIFF
--- a/net/nlbwmon/Makefile
+++ b/net/nlbwmon/Makefile
@@ -1,0 +1,42 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nlbwmon
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/jow-/nlbwmon.git
+PKG_SOURCE_DATE:=2017-07-28
+PKG_SOURCE_VERSION:=76487b5ec06cdeed097bd91c0216ab61861bcf07
+PKG_MIRROR_HASH:=981c70a7cb1811bbf45261e64a18c5c0fca3fb3a93ac299ce614c08c153ac7e0
+
+CMAKE_INSTALL:=1
+
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include/libnl-tiny
+
+define Package/nlbwmon
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libubox +libnl-tiny +zlib +kmod-nf-conntrack-netlink
+  TITLE:=LEDE Traffic Usage Monitor
+endef
+
+define Package/nlbwmon/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/nlbwmon $(1)/usr/sbin/nlbwmon
+	$(LN) nlbwmon $(1)/usr/sbin/nlbw
+	$(INSTALL_DIR) $(1)/usr/share/nlbwmon
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/protocols.txt $(1)/usr/share/nlbwmon/protocols
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/nlbwmon.init $(1)/etc/init.d/nlbwmon
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/nlbwmon.config $(1)/etc/config/nlbwmon
+endef
+
+$(eval $(call BuildPackage,nlbwmon))

--- a/net/nlbwmon/files/nlbwmon.config
+++ b/net/nlbwmon/files/nlbwmon.config
@@ -1,0 +1,51 @@
+config nlbwmon
+	# Interval at which the temporary in-memory database is committed to
+	# the persistent database directory
+	option commit_interval 24h
+
+	# Interval at which traffic counters of still established connections
+	# are refreshed from netlink information
+	option refresh_interval 30s
+
+	# Storage directory for the database files
+	option database_directory /var/lib/nlbwmon
+
+	# Amount of database generations to retain. If the limit is reached,
+	# the oldest database files are deleted.
+	option database_generations 10
+
+	# Accounting period interval; may be either in the format YYYY-MM-DD/NN
+	# to start a new accounting period exactly every NN days, beginning at
+	# the given date, or a number specifiying the day of month at which to
+	# start the next accounting period.
+	#option database_interval '2017-01-17/14' # every 14 days, starting at Tue
+	#option database_interval '-2' # second last day of month, e.g. 30th in March
+	option database_interval '1' # first day of month (default)
+
+	# The maximum amount of entries that should be put into the database,
+	# setting the limit to 0 will allow databases to grow indefinitely.
+	option database_limit 10000
+
+	# Whether to preallocate the maximum possible database size in memory.
+	# This is mainly useful for memory constrained systems which might not
+	# be able to satisfy memory allocation after longer uptime periods.
+	# Only effective in conjunction with database_limit, ignored otherwise.
+	#option database_prealloc 0
+
+	# Whether to gzip compress archive databases. Compressing the database
+	# files makes accessing old data slightly slower but helps to reduce
+	# storage requirements.
+	#option database_compress 1
+
+	# Protocol description file, used to distinguish traffic streams by
+	# IP protocol number and port
+	option protocol_database /usr/share/nlbwmon/protocols
+
+	# List of local subnets. Only conntrack streams from or to any of these
+	# subnets are counted. Logical interface names may be specified to
+	# resolve the local subnets on the fly.
+	list local_network '192.168.0.0/16'
+	list local_network '172.16.0.0/12'
+	list local_network '10.0.0.0/8'
+	list local_network 'lan'
+

--- a/net/nlbwmon/files/nlbwmon.init
+++ b/net/nlbwmon/files/nlbwmon.init
@@ -1,0 +1,89 @@
+#!/bin/sh /etc/rc.common
+
+START=60
+
+USE_PROCD=1
+NAME=nlbwmon
+PROG=/usr/sbin/nlbwmon
+
+add_subnet() {
+	local network="$1"
+	local range ranges
+
+	case "$network" in
+		*.*|*:*)
+			procd_append_param command '-s' "$network"
+		;;
+		*)
+			if network_get_subnets ranges "$network"; then
+				for range in $ranges; do
+					procd_append_param command '-s' "$range"
+				done
+			fi
+
+			if network_get_subnets6 ranges "$network"; then
+				for range in $ranges; do
+					procd_append_param command '-s' "$range"
+				done
+			fi
+		;;
+	esac
+}
+
+add_option() {
+	local cfg="$1"
+	local flag="$2"
+	local option="$3"
+	local default="$4"
+	local value
+
+	config_get value "$cfg" "$option" "$default"
+	[ -n "$value" ] && procd_append_param command "$flag" "$value"
+}
+
+add_bool() {
+	local cfg="$1"
+	local flag="$2"
+	local option="$3"
+	local default="$4"
+	local value
+
+	config_get_bool value "$cfg" "$option" "$default"
+	[ $value -eq 1 ] && procd_append_param command "$flag"
+}
+
+parse_config() {
+	. /lib/functions/network.sh
+
+	local cfg="$1"
+	local dir
+
+	config_get dir "$cfg" database_directory /var/lib/nlbwmon
+
+	mkdir -p "$dir"
+	procd_append_param command -o "$dir"
+
+	add_option "$cfg" -i commit_interval 24h
+	add_option "$cfg" -r refresh_interval 30s
+	add_option "$cfg" -p protocol_database /usr/share/nlbwmon/protocols
+	add_option "$cfg" -G database_generations 10
+	add_option "$cfg" -I database_interval 1
+	add_option "$cfg" -L database_limit 10000
+
+	add_bool "$cfg" -P database_prealloc 0
+	add_bool "$cfg" -Z database_compress 1
+
+	config_list_foreach "$cfg" local_network add_subnet
+}
+
+start_service() {
+	procd_open_instance
+	procd_set_param stderr 1
+	procd_set_param command "$PROG"
+
+	config_load nlbwmon
+	config_foreach parse_config nlbwmon
+
+	procd_close_instance
+}
+


### PR DESCRIPTION
Maintainer: @jow-
Compile tested: LEDE r4647-faa7721daa
Run tested: LEDE r4497+16-a73471dea7 / x86/64

Description:

This commit introduces nlbwmon, the lightweight NetLink BandWidth Montor.

The nlbwmon daemon gathers per-host traffic statistics by querying netlink
accounting data. Due to this approach, the executable is very small and does
not rely on libpcap and CPU intensive raw sockets to monitor traffic.

Besides raw per-host traffic counters, nlbwmon also support rudimentary
traffic classification by observing IP protocols and used port numbers.

Gathered accounting data is stored into a series of database files which
are regularily committed to persistent storage.

Refresh, commit and accounting intervals are freely configurable as well
as the layer7 protocol mapping rules and observed source subnets.

This package also bundles a cli client which can be used to dump the
gathered traffic data as JSON, CSV or plaintext data. A pull request to
add a graphical LuCI frontend for nlbwmon is pending.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>

