### PR TITLE
travelmate: update 0.9.1

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=0.9.0
+PKG_VERSION:=0.9.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -43,14 +43,16 @@ status()
 
 service_triggers()
 {
-    local iface="$(uci -q get travelmate.global.trm_iface)"
-    local delay="$(uci -q get travelmate.global.trm_triggerdelay)"
+    local auto="$(uci -q get travelmate.global.trm_automatic)"
 
-    PROCD_RELOAD_DELAY=$((${delay:=2} * 1000))
-    for name in ${iface}
-    do
-        procd_add_interface_trigger "interface.*.down" "${name}" "${trm_init}" start
-    done
+    if [ "${auto}" = "0" ]
+    then
+        local iface="$(uci -q get travelmate.global.trm_iface)"
+        local delay="$(uci -q get travelmate.global.trm_triggerdelay)"
+
+        PROCD_RELOAD_DELAY=$((${delay:=2} * 1000))
+        procd_add_interface_trigger "interface.*.down" "${iface}" "${trm_init}" start
+    fi
     PROCD_RELOAD_DELAY=1000
     procd_add_config_trigger "config.change" "travelmate" "${trm_init}" start
 }

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-trm_ver="0.9.0"
+trm_ver="0.9.1"
 trm_sysver="$(ubus -S call system board | jsonfilter -e '@.release.description')"
 trm_enabled=0
 trm_debug=0


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: LEDE Reboot SNAPSHOT r4639-eb43a817f7

Description:
backend:
* load procd reload trigger only in 'manual' mode
* documentation update

frontend:
* further optimized Station Overview & Scan page,
  especially for mobile devices
* add a "Rescan" button in manual mode on overview page
* XHTML fixes

Signed-off-by: Dirk Brenken <dev@brenken.org>
