### PR TITLE
libs/speex: fix configure params

### DIFF
--- a/libs/speex/Makefile
+++ b/libs/speex/Makefile
@@ -60,9 +60,7 @@ CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
 	--disable-binaries \
-	--disable-oggtest \
 	--enable-sse=no \
-	--with-ogg=$(STAGING_DIR)/usr \
-	$(if $(CONFIG_SOFT_FLOAT),--enable-fixed-point --disable-float-api)
+	$(if $(CONFIG_SOFT_FLOAT),--enable-fixed-point --disable-float-api --disable-vbr)
 
 $(eval $(call BuildPackage,libspeex))

--- a/libs/speexdsp/Makefile
+++ b/libs/speexdsp/Makefile
@@ -60,6 +60,7 @@ CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
 	--disable-examples \
+	--enable-neon=no \
 	--enable-sse=no \
 	$(if $(CONFIG_SOFT_FLOAT),--enable-fixed-point --disable-float-api)
 


### PR DESCRIPTION
Hello Peter @tripolar 

Sorry for not getting it right the first time. I should've paid more attention.

Kind regards,
Seb

After re-reading the speex docs it became apparent that when the float
compatibility API is disabled, VBR should be disabled as well, as VBR
has not been implemented in fixed-point (yet, upstream mentions it in
TODO file). This is also mentioned on the speex project's website, front
page.

Remove the OGG params as well as the configure script doesn't know them.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>