### PR TITLE
libs/speex and libs/speexdsp: fix configure params

### DIFF
--- a/libs/speex/Makefile
+++ b/libs/speex/Makefile
@@ -60,9 +60,6 @@ CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
 	--disable-binaries \
-	--disable-oggtest \
-	--enable-sse=no \
-	--with-ogg=$(STAGING_DIR)/usr \
-	$(if $(CONFIG_SOFT_FLOAT),--enable-fixed-point --disable-float-api)
+	$(if $(CONFIG_SOFT_FLOAT),--enable-fixed-point --disable-float-api --disable-vbr)
 
 $(eval $(call BuildPackage,libspeex))

--- a/libs/speexdsp/Makefile
+++ b/libs/speexdsp/Makefile
@@ -60,7 +60,7 @@ CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
 	--disable-examples \
-	--enable-sse=no \
+	$(if $(CONFIG_aarch64),--disable-neon) \
 	$(if $(CONFIG_SOFT_FLOAT),--enable-fixed-point --disable-float-api)
 
 $(eval $(call BuildPackage,libspeexdsp))


### PR DESCRIPTION
Hello Peter @tripolar 

Here's a PR with the commits squashed together. Watching the build bots it became apparent that only AARCH64 was failing. I checked other packages (e.g. Fedora's) and they also just disable NEON optimizations on AARCH64.

Also I didn't see them disabling SSE so I reevaluated my point of view there, too :)

Long story short, I think this is better in just one commit as it just deals with configure parameters,

Kind regards,
Seb