### PR TITLE
mwan3: allow to change mwan3's MARKing mask

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.6
+PKG_VERSION:=2.6.1
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: n/a (only changed a shell script)
Run tested: (x86_64, LEDE 17.01.0, tested failover and failback; also checked iptables)

Description:
mwan3 is using a hardcoded bitmask for iptables MARKing (0xff00).  This patch allows to change this mask to eliminate conflicts with other packages that use iptables MARKing.