### PR TITLE
dnscrypt-proxy: start from procd interface trigger, not in init

### DIFF
--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
 PKG_VERSION:=1.9.5
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy \

--- a/net/dnscrypt-proxy/files/dnscrypt-proxy.config
+++ b/net/dnscrypt-proxy/files/dnscrypt-proxy.config
@@ -1,3 +1,9 @@
+config global
+	# start dnscrypt-proxy from procd interface trigger rather than immediately in init
+	# if needed you can restrict trigger to certain interface(s)
+	# list procd_trigger 'wan'
+	# list procd_trigger 'wan6'
+
 config dnscrypt-proxy ns1
 	option address '127.0.0.1'
 	option port '5353'

--- a/net/dnscrypt-proxy/files/dnscrypt-proxy.init
+++ b/net/dnscrypt-proxy/files/dnscrypt-proxy.init
@@ -6,8 +6,13 @@ PROG=/usr/sbin/dnscrypt-proxy
 CONFIG_DIR=/var/etc
 USER=nobody
 
-dnscrypt_instance() {   
-    local config_path="$CONFIG_DIR/dnscrypt-proxy-$1.conf"     
+boot() {
+    dnscrypt_boot=1
+    rc_procd start_service
+}
+
+dnscrypt_instance() {
+    local config_path="$CONFIG_DIR/dnscrypt-proxy-$1.conf"
     create_config_file $1 "$config_path"
 
     procd_open_instance
@@ -33,7 +38,7 @@ create_config_file() {
     config_get      client_key      $1 'client_key'     ''
     config_get      syslog_prefix   $1 'syslog_prefix'  'dnscrypt-proxy'
     config_get      query_log_file  $1 'query_log_file' ''
-    config_get      log_level       $1 'log_level'	'6'
+    config_get      log_level       $1 'log_level'      '6'
     config_get_bool syslog          $1 'syslog'         '1'
     config_get_bool ephemeral_keys  $1 'ephemeral_keys' '0'
     config_get_bool local_cache     $1 'local_cache'    '0'
@@ -48,7 +53,7 @@ create_config_file() {
     append_param            "LocalAddress"  "$address:$port"    $config_path
     append_param_not_empty  "ClientKey"     "$client_key"       $config_path
     append_on_off           "EphemeralKeys" $ephemeral_keys     $config_path
-    append_param            "LogLevel"      "$log_level"	$config_path
+    append_param            "LogLevel"      "$log_level"        $config_path
     append_on_off           "Syslog"        $syslog             $config_path
     append_param            "SyslogPrefix"  "$syslog_prefix"    $config_path
     append_on_off           "LocalCache"    $local_cache        $config_path
@@ -83,7 +88,7 @@ append_on_off() {
 
     if [ $param_value -eq 1 ]
     then
-        value="on"	
+        value="on"
     else
         value="off"
     fi
@@ -99,7 +104,7 @@ append_yes_no() {
 
     if [ $param_value -eq 1 ]
     then
-        value="yes"	
+        value="yes"
     else
         value="no"
     fi
@@ -128,15 +133,32 @@ append_param_not_empty() {
 
 append_blacklists() {
     local value="$1"
-    local config_path="$2"	
+    local config_path="$2"
     append_param_not_empty "BlackList" "$value" $config_path
 }
 
 start_service() {
+    if [ -n "${dnscrypt_boot}" ]
+    then
+        return 0
+    fi
     config_load dnscrypt-proxy
     config_foreach dnscrypt_instance dnscrypt-proxy
 }
 
 service_triggers() {
+    local trigger
+    local triggerlist="$(uci_get dnscrypt-proxy.@global[0].procd_trigger)"
+
+    PROCD_RELOAD_DELAY=2000
+    if [ -n "${triggerlist}" ]
+    then
+        for trigger in ${triggerlist}
+        do
+            procd_add_interface_trigger "interface.*.up" "${trigger}" /etc/init.d/dnscrypt-proxy reload
+        done
+    else
+        procd_add_raw_trigger "interface.*.up" 2000 /etc/init.d/dnscrypt-proxy reload
+    fi
     procd_add_reload_trigger 'dnscrypt-proxy'
 }


### PR DESCRIPTION
Maintainer: @damianorenfer 
Compile tested: -
Run tested: x86, Reboot (SNAPSHOT, r4675-e5e6045130)

Description:
* Start dnscrypt-proxy from procd interface trigger rather than
immediately in init, to fix a possible race condition during boot and
get rid of rc.local restarts. You can restrict trigger interface(s) by
'procd_trigger' in new global config section.

* tab/whitespace cosmetics

Signed-off-by: Dirk Brenken <dev@brenken.org>