### PR TITLE
net/nmap: Update to 7.60

### DIFF
--- a/net/nmap/Makefile
+++ b/net/nmap/Makefile
@@ -13,13 +13,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nmap
-PKG_VERSION:=7.50
+PKG_VERSION:=7.60
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Nuno Goncalves <nunojpg@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=http://nmap.org/dist/
-PKG_MD5SUM:=435c7e095bdd4565e0f69c41743a45be
+PKG_SOURCE_URL:=https://nmap.org/dist/
+PKG_HASH:=a8796ecc4fa6c38aad6139d9515dc8113023a82e9d787e5a5fb5fa1b05516f21
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 
@@ -29,7 +29,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSI
 
 include $(INCLUDE_DIR)/package.mk
 
-NMAP_DEPENDS:=+libpcap +libstdcpp
+NMAP_DEPENDS:=+libpcap +libstdcpp +zlib +libpcre
 NCAT_DEPENDS:=+libpcap
 NPING_DEPENDS:=+libpcap +libpthread +libstdcpp
 NDIFF_DEPENDS:=+python
@@ -85,7 +85,7 @@ endef
 
 CONFIGURE_ARGS += \
 	--with-libdnet=included \
-	--with-libpcre=included \
+	--with-libpcre="$(STAGING_DIR)/usr" \
 	--with-libpcap="$(STAGING_DIR)/usr" \
 	--without-liblua \
 	--without-zenmap


### PR DESCRIPTION
Maintainer: @nunojpg 
Compile tested: mvebu, Linksys WRT3200ACM, LEDE trunk
Run tested: mvebu, Linksys WRT3200ACM, LEDE trunk (nmap, ncat, nping briefly)

Description:
* Update nmap-suite to 7.60
* Use PKG_HASH as PKG_MD5SUM is deprecated
* Switch download URL to HTTPS
* Add zlib as dependency and link libpcre dynamically

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>