### PR TITLE
Bind update 9.11.2

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.10.5-P3
+PKG_VERSION:=9.11.2
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -20,7 +20,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	http://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	http://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=8d7e96b5b0bbac7b900d4c4bbb82e0956b4e509433c5fa392bb72a929b96606a
+PKG_HASH:=7f46ad8620f7c3b0ac375d7a5211b15677708fda84ce25d7aeb7222fe2e3c77a
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4
@@ -46,7 +46,7 @@ endef
 define Package/bind-libs
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libopenssl
+  DEPENDS:=+libopenssl +zlib
   TITLE:=bind shared libraries
   URL:=https://www.isc.org/software/bind
 endef

--- a/net/bind/patches/001-no-tests.patch
+++ b/net/bind/patches/001-no-tests.patch
@@ -2,20 +2,20 @@ Index: bind-9.10.4-P3/bin/Makefile.in
 ===================================================================
 --- bind-9.10.4-P3.orig/bin/Makefile.in
 +++ bind-9.10.4-P3/bin/Makefile.in
-@@ -19,7 +19,7 @@ srcdir =	@srcdir@
+@@ -10,7 +10,7 @@ srcdir =	@srcdir@
  VPATH =		@srcdir@
  top_srcdir =	@top_srcdir@
  
 -SUBDIRS =	named rndc dig delv dnssec tools tests nsupdate \
 +SUBDIRS =	named rndc dig delv dnssec tools nsupdate \
- 		check confgen @PYTHON_TOOLS@ @PKCS11_TOOLS@
+ 		check confgen @NZD_TOOLS@ @PYTHON_TOOLS@ @PKCS11_TOOLS@
  TARGETS =
  
 Index: bind-9.10.4-P3/lib/Makefile.in
 ===================================================================
 --- bind-9.10.4-P3.orig/lib/Makefile.in
 +++ bind-9.10.4-P3/lib/Makefile.in
-@@ -23,7 +23,7 @@ top_srcdir =	@top_srcdir@
+@@ -14,7 +14,7 @@ top_srcdir =	@top_srcdir@
  # Attempt to disable parallel processing.
  .NOTPARALLEL:
  .NO_PARALLEL:

--- a/net/bind/patches/002-autoconf-ar-fix.patch
+++ b/net/bind/patches/002-autoconf-ar-fix.patch
@@ -2,7 +2,7 @@ Index: bind-9.10.4-P3/configure.in
 ===================================================================
 --- bind-9.10.4-P3.orig/configure.in
 +++ bind-9.10.4-P3/configure.in
-@@ -167,26 +167,11 @@ esac
+@@ -157,26 +157,11 @@ esac
  #
  AC_CONFIG_FILES([make/rules make/includes])
  

--- a/net/bind/patches/003-openssl-1.1.0-thread-fix.patch
+++ b/net/bind/patches/003-openssl-1.1.0-thread-fix.patch
@@ -1,0 +1,49 @@
+--- a/lib/dns/openssl_link.c	2017-07-07 09:02:06.000000000 -0600
++++ b/lib/dns/openssl_link.c	2017-08-07 10:23:18.886182931 -0600
+@@ -177,6 +177,14 @@ mem_realloc(void *ptr, size_t size FLARG
+ #endif
+ }
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10000000L
++static void
++_set_thread_id(CRYPTO_THREADID *id)
++{
++	CRYPTO_THREADID_set_numeric(id, pthread_self());
++}
++#endif
++
+ isc_result_t
+ dst__openssl_init(const char *engine) {
+ 	isc_result_t result;
+@@ -193,7 +203,7 @@ dst__openssl_init(const char *engine) {
+ 	CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);
+ #endif
+ 	CRYPTO_set_mem_functions(mem_alloc, mem_realloc, mem_free);
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if defined(OPENSSL_VERSION_NUMBER) || defined(LIBRESSL_VERSION_NUMBER)
+ 	nlocks = CRYPTO_num_locks();
+ 	locks = mem_alloc(sizeof(isc_mutex_t) * nlocks FILELINE);
+ 	if (locks == NULL)
+@@ -202,7 +204,11 @@ dst__openssl_init(const char *engine) {
+ 	if (result != ISC_R_SUCCESS)
+ 		goto cleanup_mutexalloc;
+ 	CRYPTO_set_locking_callback(lock_callback);
++# if OPENSSL_VERSION_NUMBER >= 0x10000000L
++	CRYPTO_THREADID_set_callback(_set_thread_id);
++# else
+ 	CRYPTO_set_id_callback(id_callback);
++# endif
+ 
+ 	ERR_load_crypto_strings();
+ #endif
+@@ -323,7 +335,9 @@ dst__openssl_destroy(void) {
+ 	CRYPTO_cleanup_all_ex_data();
+ #endif
+ 	ERR_clear_error();
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION >= 0x10000000L
++	ERR_remove_thread_state(NULL);
++#elif OPENSSL_VERSION_NUMBER < 0x10000000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	ERR_remove_state(0);
+ #endif
+ 	ERR_free_strings();


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: x86_64, generic, LEDE HEAD (370aacf)
Run tested: same

Build new image and installed via sysupgrade.

Description:

(1) Update to 9.11.2
(2) Add patch to build against OpenSSL 1.1.0 or later
