### PR TITLE
dnscrypt-proxy: mute needless warnings

### DIFF
--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
 PKG_VERSION:=1.9.5
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy \

--- a/net/dnscrypt-proxy/files/dnscrypt-proxy.init
+++ b/net/dnscrypt-proxy/files/dnscrypt-proxy.init
@@ -39,6 +39,7 @@ create_config_file() {
     config_get      syslog_prefix   $1 'syslog_prefix'  'dnscrypt-proxy'
     config_get      query_log_file  $1 'query_log_file' ''
     config_get      log_level       $1 'log_level'      '6'
+    config_get      blacklist       $1 'blacklist'      ''
     config_get_bool syslog          $1 'syslog'         '1'
     config_get_bool ephemeral_keys  $1 'ephemeral_keys' '0'
     config_get_bool local_cache     $1 'local_cache'    '0'
@@ -58,27 +59,28 @@ create_config_file() {
     append_param            "SyslogPrefix"  "$syslog_prefix"    $config_path
     append_on_off           "LocalCache"    $local_cache        $config_path
     append_param_not_empty  "QueryLogFile"  "$query_log_file"   $config_path
-    if [ $plugins_support_enabled -ne 0 ]
+
+    if [ $plugins_support_enabled -ne 0 ] && [ $block_ipv6 -ne 0 ]
     then
-       append_yes_no           "BlockIPv6"     $block_ipv6         $config_path
-    else
-       log_ignored_param "block_ipv6"
+        append_yes_no "BlockIPv6" $block_ipv6 $config_path
+    elif [ $block_ipv6 -ne 0 ]
+    then
+        log_ignored_param "block_ipv6"
     fi
 
-    if [ $plugins_support_enabled -ne 0 ]
+    if [ $plugins_support_enabled -ne 0 ] && [ -n "$blacklist" ]
     then
-       config_list_foreach $1 'blacklist' append_blacklists $config_path
-    else
-       log_ignored_param "blacklist"
+        config_list_foreach $1 'blacklist' append_blacklists $config_path
+    elif [ -n "$blacklist" ]
+    then
+        log_ignored_param "blacklist"
     fi
-
 }
 
 log_ignored_param() {
-   local param_name=$1
-   logger -t dnscrypt-proxy -p user.warn dnscrypt-proxy plugins support not present, ignoring $param_name parameter...
+    local param_name=$1
+    logger -t dnscrypt-proxy -p user.warn "dnscrypt-proxy plugins support not present, ignoring '$param_name' parameter."
 }
-
 
 append_on_off() {
     local param_name=$1


### PR DESCRIPTION
Maintainer: @damianorenfer 
Compile tested: -
Run tested: LEDE Reboot (SNAPSHOT, r4683-370aacf532)

Description:
* print only 'missing plugins support warning' if user really configured 'blacklist' or 'block_ipv6' parameter.

Signed-off-by: Dirk Brenken <dev@brenken.org>
