### PR TITLE
net/nmap: Avoid linking libssh2 unintentionally

### DIFF
--- a/net/nmap/Makefile
+++ b/net/nmap/Makefile
@@ -95,7 +95,7 @@ CONFIGURE_VARS += \
 	CXXFLAGS="$$$$CXXFLAGS -fno-builtin"
 
 ifeq ($(BUILD_VARIANT),ssl)
-	CONFIGURE_ARGS += --with-openssl="$(STAGING_DIR)/usr"
+	CONFIGURE_ARGS += --with-openssl="$(STAGING_DIR)/usr" --without-libssh2
 else
 	CONFIGURE_ARGS += --without-openssl
 endif


### PR DESCRIPTION
Maintainer: @nunojpg 
Compile tested: not needed
Run tested: not needed

Description:
Explicitly tell nmap not to link libssh2 if its available, fixes buildbot failure.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>