### PR TITLE
RFC vnstat: run as vnstat user/group & use procd

### DIFF
--- a/net/vnstat/Makefile
+++ b/net/vnstat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vnstat
 PKG_VERSION:=1.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://humdi.net/vnstat
@@ -27,6 +27,7 @@ define Package/vnstat/Default
   SECTION:=net
   CATEGORY:=Network
   URL:=http://humdi.net/vnstat/
+  USERID:=vnstat:vnstat
 endef
 
 define Package/vnstat

--- a/net/vnstat/files/vnstat.init
+++ b/net/vnstat/files/vnstat.init
@@ -1,24 +1,26 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2008-2011 OpenWrt.org
 
-START=99
+START=95
+USE_PROCD=1
+
+CONFIGFILE="/etc/vnstat.conf"
 
 vnstat_option() {
 	sed -ne "s/^[[:space:]]*$1[[:space:]]*['\"]\([^'\"]*\)['\"].*/\1/p" \
-		/etc/vnstat.conf
+		${CONFIGFILE}
 }
 
-start() {
+service_triggers()
+{
+        procd_add_reload_trigger "vnstat"
+}
+
+start_service() {
 	local lib="$(vnstat_option DatabaseDir)"
-	local pid="$(vnstat_option PidFile)"
 
 	[ -n "$lib" ] || {
 		echo "Error: No DatabaseDir set in vnstat.conf" >&2
-		exit 1
-	}
-
-	[ -n "$pid" ] || {
-		echo "Error: No PidFile set in vnstat.conf" >&2
 		exit 1
 	}
 
@@ -65,25 +67,22 @@ start() {
 		config_get lnk "$cfg" symlink
 		config_get backup_dir "$cfg" backup_dir
 		config_list_foreach "$cfg" interface init_iface
+	}
 
-		return 1
+	chown -h vnstat:vnstat ${CONFIGFILE} || {
+		logger -s -t vnstat -p daemon.err "Invalid UID/GID. Aborting startup"
+		exit 1
 	}
 
 	config_load vnstat
 	config_foreach init_ifaces vnstat
 
-	SERVICE_PID_FILE="${pid}"
-	service_start /usr/sbin/vnstatd -d
-}
-
-stop() {
-	local pid="$(vnstat_option PidFile)"
-
-	[ -n "$pid" ] || {
-		echo "Error: No PidFile set in vnstat.conf" >&2
-		exit 1
-	}
-
-	SERVICE_PID_FILE="${pid}"
-	service_stop /usr/sbin/vnstatd
+	procd_open_instance
+	procd_set_param command /usr/sbin/vnstatd --nodaemon --noadd
+	procd_set_param respawn
+	procd_set_param file "${CONFIGFILE}"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param user vnstat
+	procd_close_instance
 }


### PR DESCRIPTION
Maintainer: @jow- 

I've had problems with vnstat losing historical data.  I store this data on an external usb drive which is automatically mounted.  However it looks like there's a race condition between fs mounting and vnstat startup, usually vnstat wins so it fails to find the old data files - then the fs is mounted at which point vnstat now overwrites the old data.  By running vnstat as 'non-root' it now needs explicit permission to write to the database directory which it won't get it the fs isn't mounted.

Thoughts? 

Description:

Run vnstatd as specific user instead of root.  Can no longer stomp on
any directories/files it feels like.  This may help prevent losing data
if vnstat is using custom data directory residing on an as yet unmounted
fs.

Similarly tell vnstatd to not add interfaces by default and hence quit
if it cannot find old database files.

Convert to procd, so gets restarted on failures.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>
