### PR TITLE
net/mwan3: add new feature and bug fixes

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -39,6 +39,22 @@ endef
 define Build/Compile
 endef
 
+define Package/mwan3/postinst
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	/etc/init.d/rpcd restart
+fi
+exit 0
+endef
+
+define Package/mwan3/postrm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	/etc/init.d/rpcd restart
+fi
+exit 0
+endef
+
 define Package/mwan3/install
 $(CP) ./files/* $(1)
 endef

--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.6.1
-PKG_RELEASE:=1
+PKG_VERSION:=2.6.2
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2
 

--- a/net/mwan3/files/etc/hotplug.d/iface/14-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/14-mwan3
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. /lib/mwan3/mwan3.sh
+. /lib/functions/network.sh
+
+[ "$ACTION" = "ifup" -o "$ACTION" = "ifdown" ] || exit 1
+[ -n "$INTERFACE" ] || exit 2
+
+if [ "$ACTION" = "ifup" ]; then
+	[ -n "$DEVICE" ] || exit 3
+fi
+
+config_load mwan3
+config_get local_source globals local_source 'none'
+[ "${local_source}" = "none" ] && {
+	exit 0
+}
+
+[ "${local_source}" = "$INTERFACE" ] || {
+	exit 0
+}
+
+mwan3_lock
+src_ip=$(uci -q -P /var/state get mwan3.globals.src_ip 2>/dev/null)
+[ "${src_ip}" != "" ] && {
+	ip route del default via "${src_ip}" dev lo 1>/dev/null 2>&1
+	ip addr del "${src_ip}/32" dev lo 1>/dev/null 2>&1
+}
+
+usleep 10000
+
+[ "$ACTION" = "ifup" ] && {
+	network_get_ipaddr src_ip "${local_source}"
+	if [ "${src_ip}" = "" ]; then
+		$LOG warn "Unable to set source ip for own initiated traffic (${local_source})"
+	else
+		ip addr add "${src_ip}/32" dev lo
+		ip route add default via "${src_ip}" dev lo
+		uci -q -P /var/state set mwan3.globals.src_ip="${src_ip}"
+	fi
+}
+mwan3_unlock
+
+exit 0

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -59,7 +59,6 @@ case "$ACTION" in
 	;;
 	ifdown)
 		mwan3_delete_iface_rules $INTERFACE
-		mwan3_delete_iface_iptables $INTERFACE
 		mwan3_delete_iface_route $INTERFACE
 		mwan3_delete_iface_ipset_entries $INTERFACE
 		mwan3_track_signal $INTERFACE $DEVICE

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -12,7 +12,9 @@ if [ "$ACTION" == "ifup" ]; then
         [ -n "$DEVICE" ] || exit 3
 fi
 
+mwan3_lock
 mwan3_set_connected_iptables
+mwan3_unlock
 
 config_load mwan3
 config_get enabled $INTERFACE enabled 0

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -3,6 +3,7 @@
 . /lib/functions.sh
 . /lib/functions/network.sh
 . /lib/mwan3/mwan3.sh
+. /usr/share/libubox/jshn.sh
 
 [ "$ACTION" == "ifup" -o "$ACTION" == "ifdown" ] || exit 1
 [ -n "$INTERFACE" ] || exit 2
@@ -15,6 +16,7 @@ mwan3_set_connected_iptables
 
 config_load mwan3
 config_get enabled $INTERFACE enabled 0
+config_get initial_state $INTERFACE initial_state "online"
 [ "$enabled" == "1" ] || exit 0
 
 if [ "$ACTION" == "ifup" ]; then
@@ -42,6 +44,17 @@ if [ "$ACTION" == "ifup" ]; then
 	[ -n "$gateway" ] || exit 9
 fi
 
+if [ "$initial_state" = "offline" ]; then
+	json_load "$(ubus call mwan3 status '{"section":"interfaces"}')"
+	json_select "interfaces"
+	json_select "${INTERFACE}"
+	json_get_var running running
+	json_get_var status status
+else
+	status=online
+	running=1
+fi
+
 mwan3_lock
 $LOG notice "Execute "$ACTION" event on interface $INTERFACE (${DEVICE:-unknown})"
 
@@ -49,13 +62,18 @@ case "$ACTION" in
 	ifup)
 		mwan3_set_general_rules
 		mwan3_set_general_iptables
-		mwan3_create_iface_rules $INTERFACE $DEVICE
 		mwan3_create_iface_iptables $INTERFACE $DEVICE
-		mwan3_create_iface_route $INTERFACE $DEVICE
-		mwan3_track $INTERFACE $DEVICE ${src_ip}
-		mwan3_set_policies_iptables
-		mwan3_set_user_rules
-		mwan3_flush_conntrack $INTERFACE $DEVICE "ifup"
+		if [ ${running} -eq 1 -a "${status}" = "online" ]; then
+			mwan3_create_iface_rules $INTERFACE $DEVICE
+			mwan3_create_iface_route $INTERFACE $DEVICE
+			mwan3_track $INTERFACE $DEVICE ${src_ip} "online"
+			mwan3_set_policies_iptables
+			mwan3_set_user_rules
+			mwan3_flush_conntrack $INTERFACE $DEVICE "ifup"
+		else
+			$LOG notice "Starting tracker on interface $INTERFACE (${DEVICE:-unknown})"
+			mwan3_track $INTERFACE $DEVICE "offline"
+		fi
 	;;
 	ifdown)
 		mwan3_delete_iface_rules $INTERFACE

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -43,7 +43,7 @@ if [ "$ACTION" == "ifup" ]; then
 fi
 
 mwan3_lock
-$LOG notice "$ACTION interface $INTERFACE (${DEVICE:-unknown})"
+$LOG notice "Execute "$ACTION" event on interface $INTERFACE (${DEVICE:-unknown})"
 
 case "$ACTION" in
 	ifup)

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -5,7 +5,7 @@ IP6="ip -6"
 IPS="ipset"
 IPT4="iptables -t mangle -w"
 IPT6="ip6tables -t mangle -w"
-LOG="logger -t mwan3 -p"
+LOG="logger -t mwan3[$$] -p"
 CONNTRACK_FILE="/proc/net/nf_conntrack"
 
 # mwan3's MARKing mask (at least 3 bits should be set)

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -449,7 +449,7 @@ mwan3_track()
 	}
 	config_list_foreach $1 track_ip mwan3_list_track_ips
 
-	kill $(pgrep -f "mwan3track $1") &> /dev/null
+	kill $(pgrep -f "mwan3track $1 $2") &> /dev/null
 	if [ -n "$track_ips" ]; then
 		[ -x /usr/sbin/mwan3track ] && /usr/sbin/mwan3track "$1" "$2" "$3" $track_ips &
 	fi
@@ -459,7 +459,7 @@ mwan3_track_signal()
 {
 	local pid
 
-	pid="$(pgrep -f "mwan3track $1")"
+	pid="$(pgrep -f "mwan3track $1 $2")"
 	if [ "${pid}" != "" ]; then
 		kill -USR1 "${pid}"
 	else
@@ -789,7 +789,7 @@ mwan3_report_iface_status()
 	config_list_foreach $1 track_ip mwan3_list_track_ips
 
 	if [ -n "$track_ips" ]; then
-		if [ -n "$(pgrep -f "mwan3track $1")" ]; then
+		if [ -n "$(pgrep -f "mwan3track $1 $device")" ]; then
 			tracking="active"
 		else
 			tracking="down"

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -457,7 +457,7 @@ mwan3_track()
 
 	kill $(pgrep -f "mwan3track $1 $2") &> /dev/null
 	if [ -n "$track_ips" ]; then
-		[ -x /usr/sbin/mwan3track ] && /usr/sbin/mwan3track "$1" "$2" "$3" $track_ips &
+		[ -x /usr/sbin/mwan3track ] && /usr/sbin/mwan3track "$1" "$2" "$3" "$4" $track_ips &
 	fi
 }
 

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -8,6 +8,8 @@ IPT6="ip6tables -t mangle -w"
 LOG="logger -t mwan3[$$] -p"
 CONNTRACK_FILE="/proc/net/nf_conntrack"
 
+MWAN3_STATUS_DIR="/var/run/mwan3track"
+
 # mwan3's MARKing mask (at least 3 bits should be set)
 MMX_MASK=0xff00
 
@@ -63,6 +65,10 @@ mwan3_lock() {
 
 mwan3_unlock() {
 	lock -u /var/run/mwan3.lock
+}
+
+mwan3_lock_clean() {
+	rm -rf /var/run/mwan3.lock
 }
 
 mwan3_get_iface_id()
@@ -918,4 +924,14 @@ mwan3_flush_conntrack()
 	else
 		$LOG warning "connection tracking not enabled"
 	fi
+}
+
+mwan3_track_clean()
+{
+	rm -rf "$MWAN3_STATUS_DIR/${1}" &> /dev/null
+	[ -d "$MWAN3_STATUS_DIR" ] && {
+		if [ -z "$(ls -A "$MWAN3_STATUS_DIR")" ]; then
+			rm -rf "$MWAN3_STATUS_DIR"
+		fi
+	}
 }

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -34,7 +34,8 @@ get_mwan3_status() {
 	local iface="${1}"
 	local iface_select="${2}"
 	local running="0"
-	local pid device
+	local age=0
+	local pid device time_p time_n
 
 	network_get_device device $1
 
@@ -44,7 +45,14 @@ get_mwan3_status() {
 			running="1"
 		fi
 
+		time_p="$(cat "$MWAN3_STATUS_DIR/${iface}/TIME")"
+		[ -z "${time_p}" ] || {
+			time_n="$(date +'%s')"
+			let age=time_n-time_p
+		}
+
 		json_add_object "${iface}"
+		json_add_int age "$age"
 		json_add_string "score" "$(cat "$MWAN3_STATUS_DIR/${iface}/SCORE")"
 		json_add_string "lost" "$(cat "$MWAN3_STATUS_DIR/${iface}/LOST")"
 		json_add_string "turn" "$(cat "$MWAN3_STATUS_DIR/${iface}/TURN")"

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -53,9 +53,9 @@ get_mwan3_status() {
 
 		json_add_object "${iface}"
 		json_add_int age "$age"
-		json_add_string "score" "$(cat "$MWAN3_STATUS_DIR/${iface}/SCORE")"
-		json_add_string "lost" "$(cat "$MWAN3_STATUS_DIR/${iface}/LOST")"
-		json_add_string "turn" "$(cat "$MWAN3_STATUS_DIR/${iface}/TURN")"
+		json_add_int "score" "$(cat "$MWAN3_STATUS_DIR/${iface}/SCORE")"
+		json_add_int "lost" "$(cat "$MWAN3_STATUS_DIR/${iface}/LOST")"
+		json_add_int "turn" "$(cat "$MWAN3_STATUS_DIR/${iface}/TURN")"
 		json_add_string "status" "$(cat "$MWAN3_STATUS_DIR/${iface}/STATUS")"
 		json_add_boolean "running" "${running}"
 		json_add_array "track_ip"

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -5,7 +5,6 @@
 . /usr/share/libubox/jshn.sh
 
 MWAN3_STATUS_DIR="/var/run/mwan3track"
-MWAN3_PID_FILE="/var/run/mwan3track"
 
 IPS="ipset"
 IPT4="iptables -t mangle -w"

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 . /lib/functions.sh
+. /lib/functions/network.sh
 . /usr/share/libubox/jshn.sh
 
 MWAN3_STATUS_DIR="/var/run/mwan3track"
@@ -34,10 +35,12 @@ get_mwan3_status() {
 	local iface="${1}"
 	local iface_select="${2}"
 	local running="0"
-	local pid
+	local pid device
+
+	network_get_device device $1
 
 	if [ "${iface}" = "${iface_select}" ] || [ "${iface_select}" = "" ]; then
-		pid="$(pgrep -f "mwan3track $iface")"
+		pid="$(pgrep -f "mwan3track $iface $device")"
 		if [ "${pid}" != "" ]; then
 			running="1"
 		fi

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -37,7 +37,7 @@ get_mwan3_status() {
 	local pid
 
 	if [ "${iface}" = "${iface_select}" ] || [ "${iface_select}" = "" ]; then
-		pid="$(pgrep -f "mwan3track $iface_selected")"
+		pid="$(pgrep -f "mwan3track $iface")"
 		if [ "${pid}" != "" ]; then
 			running="1"
 		fi

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -37,6 +37,7 @@ ifdown()
 	ACTION=ifdown INTERFACE=$1 /sbin/hotplug-call iface
 
 	kill $(pgrep -f "mwan3track $1 $2") &> /dev/null
+	mwan3_track_clean $1
 }
 
 ifup()
@@ -121,6 +122,9 @@ stop()
 
 	killall mwan3track &> /dev/null
 
+	config_load mwan3
+	config_foreach mwan3_track_clean interface
+
 	for IP in "$IP4" "$IP6"; do
 
 		for route in $($IP route list table all | sed 's/.*table \([^ ]*\) .*/\1/' |  awk '{print $1}' | awk '{for(i=1;i<=NF;i++) if($i+0>0) if($i+0<255) {print;break}}'); do
@@ -153,6 +157,8 @@ stop()
 	for ipset in $($IPS -n list | grep mwan3 | grep -E '_v4|_v6'); do
 		$IPS -q destroy $ipset
 	done
+
+	mwan3_lock_clean
 }
 
 restart() {

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -36,7 +36,7 @@ ifdown()
 
 	ACTION=ifdown INTERFACE=$1 /sbin/hotplug-call iface
 
-	kill $(pgrep -f "mwan3track $1") &> /dev/null
+	kill $(pgrep -f "mwan3track $1 $2") &> /dev/null
 }
 
 ifup()

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -37,6 +37,7 @@ ifdown()
 	ACTION=ifdown INTERFACE=$1 /sbin/hotplug-call iface
 
 	kill $(pgrep -f "mwan3track $1 $2") &> /dev/null
+	mwan3_delete_iface_iptables $1
 	mwan3_track_clean $1
 }
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -47,10 +47,11 @@ main() {
 	local recovery_interval down up size
 	local keep_failure_interval
 
-	[ -z "$3" ] && echo "Error: should not be started manually" && exit 0
+	[ -z "$5" ] && echo "Error: should not be started manually" && exit 0
 
 	INTERFACE=$1
 	DEVICE=$2
+	STATUS=$3
 	mkdir -p /var/run/mwan3track/$1
 	trap clean_up SIGINT SIGTERM
 	trap if_down SIGUSR1
@@ -73,13 +74,18 @@ main() {
 	config_get recovery_interval $1 recovery_interval $interval
 
 	local score=$(($down+$up))
-	local track_ips=$(echo $* | cut -d ' ' -f 4-99)
+	local track_ips=$(echo $* | cut -d ' ' -f 5-99)
 	local host_up_count=0
 	local lost=0
 	local sleep_time=0
 	local turn=0
 
-	echo "offline" > /var/run/mwan3track/$1/STATUS
+	if [ "$STATUS" = "offline" ]; then
+		echo "offline" > /var/run/mwan3track/$1/STATUS
+		score=0
+	else
+		echo "online" > /var/run/mwan3track/$1/STATUS
+	fi
 	while true; do
 
 		sleep_time=$interval
@@ -137,6 +143,7 @@ main() {
 
 			if [ $score -eq $up ]; then
 				$LOG notice "Interface $1 ($2) is online"
+				echo "online" > /var/run/mwan3track/$1/STATUS
 				env -i ACTION=ifup INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
 				exit 0
 			fi

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -51,6 +51,7 @@ validate_track_method() {
 main() {
 	local reliability count timeout interval failure_interval
 	local recovery_interval down up size
+	local keep_failure_interval
 
 	[ -z "$3" ] && echo "Error: should not be started manually" && exit 0
 
@@ -74,6 +75,7 @@ main() {
 	config_get up $1 up 5
 	config_get size $1 size 56
 	config_get failure_interval $1 failure_interval $interval
+	config_get_bool keep_failure_interval $1 keep_failure_interval 0
 	config_get recovery_interval $1 recovery_interval $interval
 
 	local score=$(($down+$up))
@@ -111,6 +113,9 @@ main() {
 
 			if [ $score -lt $up ]; then
 				score=0
+				[ ${keep_failure_interval} -eq 1 ] && {
+					sleep_time=$failure_interval
+				}
 			else
 				sleep_time=$failure_interval
 			fi

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -10,12 +10,6 @@ IFDOWN_EVENT=0
 
 clean_up() {
 	$LOG notice "Stopping mwan3track for interface \"${INTERFACE}\""
-	if [ "$(pgrep -f "mwan3track ${INTERFACE} ${DEVICE}")" = "" ]; then
-		rm -rf "/var/run/mwan3track/${INTERFACE}" &> /dev/null
-	fi
-	if [ -z "$(ls -A "/var/run/mwan3track")" ]; then
-		rm -rf "/var/run/mwan3track"
-	fi
 	exit 0
 }
 
@@ -144,7 +138,6 @@ main() {
 			if [ $score -eq $up ]; then
 				$LOG notice "Interface $1 ($2) is online"
 				env -i ACTION=ifup INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
-				rm -rf "/var/run/mwan3track/${1}" &> /dev/null
 				exit 0
 			fi
 		fi

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -10,7 +10,7 @@ IFDOWN_EVENT=0
 
 clean_up() {
 	$LOG notice "Stopping mwan3track for interface \"${INTERFACE}\""
-	if [ "$(pgrep -f "mwan3track ${INTERFACE}")" = "" ]; then
+	if [ "$(pgrep -f "mwan3track ${INTERFACE} ${DEVICE}")" = "" ]; then
 		rm -rf "/var/run/mwan3track/${INTERFACE}" &> /dev/null
 	fi
 	if [ -z "$(ls -A "/var/run/mwan3track")" ]; then

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -154,6 +154,7 @@ main() {
 		echo "${lost}" > /var/run/mwan3track/$1/LOST
 		echo "${score}" > /var/run/mwan3track/$1/SCORE
 		echo "${turn}" > /var/run/mwan3track/$1/TURN
+		echo "$(date +'%s')" > /var/run/mwan3track/$1/TIME
 
 		host_up_count=0
 		sleep "${sleep_time}" &


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a (only changed a shell script)
Run tested: (x86_64, LEDE 17.01.0)

Description:
- fix recovery from failure state if all interface are down and last_resort is set to unreachable/blackhole
- fix ubus mwan3track wrong running state
- fix mwan3track kill command if interface has same prefix (wan, wan2)
- fix ubus output json datatype
- fix critical section for mwan3 connected ipset generation
- add interface config option keep_failure_interval -> see commit
- add interface config option initial_state -> see commit
- add age output for ubus interface -> see commit 
- add "postrm/postinst" section in makefile for rpcd reload on installation
- add globals config section for self interface auto configuration
