### PR TITLE
rpcd-mod-attendedsysupgrade: add keep_settings opt

### DIFF
--- a/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.rpcd
+++ b/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.rpcd
@@ -5,25 +5,31 @@
 case "$1" in
 	list)
 		json_init
-
-       	json_add_object "sysupgrade"
-       	json_close_object
-
-       	json_dump
-        ;;
-    call)
-        case "$2" in
+		json_add_object "sysupgrade"
+		json_add_boolean "keep_settings" 1
+		json_close_object
+		json_dump
+		;;
+	call)
+		case "$2" in
 			sysupgrade)
+				read input;
+				json_load "$input"
+				json_get_var keep_settings keep_settings
+
 				if [ -f "/tmp/sysupgrade.bin" ]; then
 					/etc/init.d/uhttpd stop
 					/etc/init.d/dropbear stop
 					sleep 1;
-					/sbin/sysupgrade -c /tmp/sysupgrade.bin
+					if [ "$keep_settings" -eq "0" ]; then
+						keep_settings_param="-n"
+					fi
+					/sbin/sysupgrade $keep_settings_param /tmp/sysupgrade.bin
 				fi
 				json_init
 				json_add_string "message" "could not find /tmp/sysupgrade.bin"
 				json_dump
-        esac
-    ;;
+		esac
+		;;
 esac
 


### PR DESCRIPTION
Maintainer: me / @aparcar
Compile tested: x86/64
Run tested: x86/64

Description:

as mentioned [here][1] some firmwares require to reset all settings.
this commit add a param "keep_settings" which changes the sysupgrade
parameter "-c" to "-n" to flush all configs

[1]: https://github.com/aparcar/gsoc17-attended-sysupgrade/issues/34

Signed-off-by: Paul Spooren <paul@spooren.de>