### PR TITLE
python-cryptography: bump to version 2.0.3 ; add python-asn1crypto (dep required for python-cryptography)

### DIFF
--- a/lang/python/python-asn1crypto/Makefile
+++ b/lang/python/python-asn1crypto/Makefile
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-asn1crypto
+PKG_VERSION:=0.22.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=asn1crypto-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/67/14/5d66588868c4304f804ebaff9397255f6ec5559e46724c2496e0f26e68d6
+PKG_HASH:=cbbadd640d3165ab24b06ef25d1dca09a3441611ac15f6a6b452474fdf0aed1a
+
+PKG_LICENSE:=MIT
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-asn1crypto-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+$(call include_mk, python-package.mk)
+$(call include_mk, python3-package.mk)
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-asn1crypto/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://github.com/wbond/asn1crypto
+endef
+
+define Package/python-asn1crypto
+$(call Package/python-asn1crypto/Default)
+  TITLE:=python-asn1crypto
+  DEPENDS:=+PACKAGE_python-asn1crypto:python-light
+  VARIANT:=python
+endef
+
+define Package/python3-asn1crypto
+$(call Package/python-asn1crypto/Default)
+  TITLE:=python3-asn1crypto
+  DEPENDS:=+PACKAGE_python3-asn1crypto:python3-light
+  VARIANT:=python3
+endef
+
+define Package/python-asn1crypto/description
+Fast ASN.1 parser and serializer with definitions for
+private keys, public keys, certificates, CRL, OCSP,
+CMS, PKCS#3, PKCS#7, PKCS#8, PKCS#12, PKCS#5, X.509 and TSP
+endef
+
+define Package/python3-asn1crypto/description
+$(call Package/python-asn1crypto/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-asn1crypto))
+$(eval $(call BuildPackage,python-asn1crypto))
+$(eval $(call Py3Package,python3-asn1crypto))
+$(eval $(call BuildPackage,python3-asn1crypto))

--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptography
-PKG_VERSION:=1.9
+PKG_VERSION:=2.0.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=cryptography-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/2a/0c/31bd69469e90035381f0197b48bf71032991d9f07a7e444c311b4a23a3df
-PKG_HASH:=5518337022718029e367d982642f3e3523541e098ad671672a90b82474c84882
+PKG_SOURCE_URL:=https://pypi.python.org/packages/9c/1a/0fc8cffb04582f9ffca61b15b0681cf2e8588438e55f61403eb9880bd8e0
+PKG_HASH:=d04bb2425086c3fe86f7bc48915290b13e798497839fbb18ab7f6dffcf98cc3a
 
 PKG_LICENSE:=Apache-2.0 BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.APACHE LICENSE.BSD
@@ -44,7 +44,7 @@ $(call Package/python-cryptography/Default)
       +PACKAGE_python-cryptography:python-enum34 \
       +PACKAGE_python-cryptography:python-idna \
       +PACKAGE_python-cryptography:python-ipaddress \
-      +PACKAGE_python-cryptography:python-pyasn1 \
+      +PACKAGE_python-cryptography:python-asn1crypto \
       +PACKAGE_python-cryptography:python-six
   VARIANT:=python
 endef
@@ -56,7 +56,7 @@ $(call Package/python-cryptography/Default)
       +PACKAGE_python3-cryptography:python3 \
       +PACKAGE_python3-cryptography:python3-cffi \
       +PACKAGE_python3-cryptography:python3-idna \
-      +PACKAGE_python3-cryptography:python3-pyasn1 \
+      +PACKAGE_python3-cryptography:python3-asn1crypto \
       +PACKAGE_python3-cryptography:python3-six
   VARIANT:=python3
 endef
@@ -71,18 +71,6 @@ define Package/python3-cryptography/description
 $(call Package/python-cryptography/description)
 .
 (Variant for Python3)
-endef
-
-define PyPackage/python-cryptography/filespec
-+|$(PYTHON_PKG_DIR)
--|$(PYTHON_PKG_DIR)/cryptography/hazmat/backends/commoncrypto
--|$(PYTHON_PKG_DIR)/cryptography/hazmat/bindings/commoncrypto
-endef
-
-define Py3Package/python3-cryptography/filespec
-+|$(PYTHON3_PKG_DIR)
--|$(PYTHON3_PKG_DIR)/cryptography/hazmat/backends/commoncrypto
--|$(PYTHON3_PKG_DIR)/cryptography/hazmat/bindings/commoncrypto
 endef
 
 $(eval $(call PyPackage,python-cryptography))

--- a/lang/python/python-cryptography/patches/002-remove-undefined-dtls-methods.patch
+++ b/lang/python/python-cryptography/patches/002-remove-undefined-dtls-methods.patch
@@ -1,0 +1,14 @@
+diff --git a/src/_cffi_src/openssl/ssl.py b/src/_cffi_src/openssl/ssl.py
+index 8bda4e0..aa81060 100644
+--- a/src/_cffi_src/openssl/ssl.py
++++ b/src/_cffi_src/openssl/ssl.py
+@@ -595,9 +595,6 @@ static const long TLS_ST_OK = 0;
+ 
+ #if defined(OPENSSL_NO_DTLS) || CRYPTOGRAPHY_OPENSSL_LESS_THAN_102
+ static const long Cryptography_HAS_GENERIC_DTLS_METHOD = 0;
+-const SSL_METHOD *(*DTLS_method)(void) = NULL;
+-const SSL_METHOD *(*DTLS_server_method)(void) = NULL;
+-const SSL_METHOD *(*DTLS_client_method)(void) = NULL;
+ #else
+ static const long Cryptography_HAS_GENERIC_DTLS_METHOD = 1;
+ #endif


### PR DESCRIPTION
Maintainer: me, @jefferyto 
Compile tested: https://github.com/lede-project/source/commit/e7373e489d8a215402d6b0c408a26188342c7c17 x86_64
Run tested: https://github.com/lede-project/source/commit/e7373e489d8a215402d6b0c408a26188342c7c17 x86_64

Description:

Bump version of python-cryptography to 2.0.3
Unfortunately, python-cryptography has replace pyasn1 with asn1crypto, so, new package added for that....  Oh Well...

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>