### PR TITLE
dnscrypt-proxy: change start priority

### DIFF
--- a/net/dnscrypt-proxy/Makefile
+++ b/net/dnscrypt-proxy/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy
 PKG_VERSION:=1.9.5
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://download.dnscrypt.org/dnscrypt-proxy \

--- a/net/dnscrypt-proxy/files/dnscrypt-proxy.init
+++ b/net/dnscrypt-proxy/files/dnscrypt-proxy.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-START=50
+START=30
 USE_PROCD=1
 PROG=/usr/sbin/dnscrypt-proxy
 CONFIG_DIR=/var/etc


### PR DESCRIPTION
Maintainer: @damianorenfer 
Compile tested: -
Run tested: x86, LEDE Reboot (SNAPSHOT, r4696-df3295f50e)

Description:
* follow-up PR to adapt start priority to the new trigger based setup (see discussion in #4675)

Signed-off-by: Dirk Brenken <dev@brenken.org>
