### PR TITLE
travelmate: update to 0.9.2

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=0.9.1
+PKG_VERSION:=0.9.2
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-trm_ver="0.9.1"
+trm_ver="0.9.2"
 trm_sysver="$(ubus -S call system board | jsonfilter -e '@.release.description')"
 trm_enabled=0
 trm_debug=0
@@ -229,7 +229,7 @@ f_main()
                                 uci -q set wireless."${config}".ssid="${sta_ssid}_err"
                                 uci -q commit wireless
                                 f_check "dev"
-                                f_log "info " "interface 'can't connect to uplink '${sta_ssid}' (${cnt}/${trm_maxretry}), uplink disabled (${trm_sysver})"
+                                f_log "info " "can't connect to uplink '${sta_ssid}' (${cnt}/${trm_maxretry}), uplink disabled (${trm_sysver})"
                             else
                                 uci -q revert wireless
                                 f_check "dev"


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: x86, LEDE Reboot (SNAPSHOT, r4696-df3295f50e)

Description:
* backend: fix typo in log message
* frontend: add/modify input datatypes in 'extra' section
* frontend: add support to edit/change wpa enterprise key phrases
* frontend: various small fixes

Signed-off-by: Dirk Brenken <dev@brenken.org>
