### PR TITLE
ffmpeg: update to 3.2.7

### DIFF
--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -141,7 +141,6 @@ config FFMPEG_CUSTOM_SELECT_libfdk-aac
 
 config FFMPEG_CUSTOM_SELECT_libmp3lame
 	bool "Libmp3lame"
-	depends on FFMPEG_CUSTOM_PATENTED
 	depends on PACKAGE_lame-lib
 	select FFMPEG_CUSTOM_DECODER_mp3
 	select FFMPEG_CUSTOM_MUXER_mp3
@@ -253,11 +252,9 @@ config FFMPEG_CUSTOM_DECODER_jpegls
 
 config FFMPEG_CUSTOM_DECODER_mp2
 	bool "MP2 (MPEG Audio Layer 2)"
-	depends on FFMPEG_CUSTOM_PATENTED
 
 config FFMPEG_CUSTOM_DECODER_mp3
-	bool "MP3 (MPEG Audio Layer 2)"
-	depends on FFMPEG_CUSTOM_PATENTED
+	bool "MP3 (MPEG Audio Layer 3)"
 
 config FFMPEG_CUSTOM_DECODER_mpegvideo
 	bool "MPEG Video"

--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -119,12 +119,6 @@ config FFMPEG_CUSTOM_AUDIO_DEC_SUPPORT
 	select FFMPEG_CUSTOM_DEMUXER_sdp
 	select FFMPEG_CUSTOM_DEMUXER_wav
 	select FFMPEG_CUSTOM_DEMUXER_wv
-	select FFMPEG_CUSTOM_PARSER_aac
-	select FFMPEG_CUSTOM_PARSER_aac_latm
-	select FFMPEG_CUSTOM_PARSER_ac3
-	select FFMPEG_CUSTOM_PARSER_flac
-	select FFMPEG_CUSTOM_PARSER_mpegaudio
-	select FFMPEG_CUSTOM_PARSER_opus
 	select FFMPEG_CUSTOM_PROTOCOL_file
 	select FFMPEG_CUSTOM_PROTOCOL_http
 	select FFMPEG_CUSTOM_PROTOCOL_rtp
@@ -160,14 +154,12 @@ config FFMPEG_CUSTOM_SELECT_libx264
 	select FFMPEG_CUSTOM_DECODER_h264
 	select FFMPEG_CUSTOM_MUXER_h264
 	select FFMPEG_CUSTOM_DEMUXER_h264
-	select FFMPEG_CUSTOM_PARSER_h264
 
 comment "Encoders"
 
 config FFMPEG_CUSTOM_ENCODER_ac3
 	bool "AC3"
 	depends on FFMPEG_CUSTOM_PATENTED
-	select FFMPEG_CUSTOM_PARSER_ac3
 
 config FFMPEG_CUSTOM_ENCODER_jpegls
 	bool "JPEG-LS"
@@ -204,7 +196,6 @@ comment "Decoders"
 config FFMPEG_CUSTOM_DECODER_aac
 	bool "AAC (Advanced Audio Coding)"
 	depends on FFMPEG_CUSTOM_PATENTED
-	select FFMPEG_CUSTOM_PARSER_aac
 
 config FFMPEG_CUSTOM_SELECT_adpcm
 	bool "ADPCM (multiple types)"
@@ -212,7 +203,6 @@ config FFMPEG_CUSTOM_SELECT_adpcm
 config FFMPEG_CUSTOM_DECODER_ac3
 	bool "AC3"
 	depends on FFMPEG_CUSTOM_PATENTED
-	select FFMPEG_CUSTOM_PARSER_ac3
 
 config FFMPEG_CUSTOM_DECODER_alac
 	bool "ALAC"
@@ -234,7 +224,6 @@ config FFMPEG_CUSTOM_DECODER_atrac3
 
 config FFMPEG_CUSTOM_DECODER_flac
 	bool "FLAC"
-	select FFMPEG_CUSTOM_PARSER_flac
 
 config FFMPEG_CUSTOM_DECODER_gif
 	bool "GIF"
@@ -392,7 +381,6 @@ config FFMPEG_CUSTOM_DEMUXER_mov
 
 config FFMPEG_CUSTOM_DEMUXER_mp3
 	bool "MP3 (MPEG Audio Layer 3)"
-	select FFMPEG_CUSTOM_PARSER_mpegaudio
 
 config FFMPEG_CUSTOM_DEMUXER_mpegvideo
 	bool "MPEG Video"

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -404,6 +404,8 @@ endif
 
 # selectively disable optimizations according to arch/cpu type
 ifneq ($(findstring arm,$(CONFIG_ARCH)),)
+	FFMPEG_CONFIGURE+= --enable-lto
+
 	ifneq ($(findstring vfp,$(CONFIG_TARGET_OPTIMIZATION)),)
 		FFMPEG_CONFIGURE+= --enable-vfp
 	else
@@ -417,6 +419,10 @@ ifneq ($(findstring arm,$(CONFIG_ARCH)),)
 		FFMPEG_CONFIGURE+= --disable-neon
 	endif
 
+endif
+
+ifeq ($(ARCH),x86_64)
+	FFMPEG_CONFIGURE+= --enable-lto
 endif
 
 ifneq ($(CONFIG_YASM),y)

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -199,14 +199,6 @@ FFMPEG_AUDIO_DEMUXERS:= \
 	wav \
 	wv \
 
-FFMPEG_AUDIO_PARSERS:= \
-	aac \
-	aac_latm \
-	ac3 \
-	flac \
-	mpegaudio \
-	opus \
-
 FFMPEG_AUDIO_PROTOCOLS:= \
 	file http icecast rtp tcp udp
 
@@ -549,7 +541,6 @@ ifeq ($(BUILD_VARIANT),audio-dec)
 	--disable-everything \
 	$(call FFMPEG_ENABLE,decoder,$(FFMPEG_AUDIO_DECODERS)) \
 	$(call FFMPEG_ENABLE,demuxer,$(FFMPEG_AUDIO_DEMUXERS)) \
-	$(call FFMPEG_ENABLE,parser,$(FFMPEG_AUDIO_PARSERS)) \
 	$(call FFMPEG_ENABLE,protocol,$(FFMPEG_AUDIO_PROTOCOLS)) \
 	--disable-decoder=pcm_bluray,pcm_dvd \
 

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -9,13 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=3.2.6
-PKG_RELEASE:=2
+PKG_VERSION:=3.2.7
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
-PKG_MD5SUM:=7a35bd97bd7253305bf5c0af5f9dd3ce
-PKG_HASH:=3751cebb5c71a861288267769114d12b966a7703a686a325d90a93707f3a6d9f
+PKG_HASH:=28e75fc32485a88035a7ebf0a956a1e5c7e93b440dd4bbd6bc30c7268cf34fe9
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Ian Leonard <antonlacon@gmail.com>
 
@@ -150,7 +149,7 @@ FFMPEG_MINI_DEMUXERS:= \
 	ogg \
 
 FFMPEG_MINI_PROTOCOLS:= \
-	file \
+	file
 
 FFMPEG_AUDIO_DECODERS:= \
 	aac \
@@ -380,34 +379,16 @@ FFMPEG_CONFIGURE:= \
 	--disable-doc \
 	--disable-debug \
 	\
-	--disable-dxva2 \
 	--disable-lzma \
 	--disable-vaapi \
-	--disable-vda \
 	--disable-vdpau \
 	--disable-outdevs
 
 ifeq ($(CONFIG_SOFT_FLOAT),y)
-FFMPEG_CONFIGURE += \
+FFMPEG_CONFIGURE+= \
 	--disable-altivec \
 	--disable-vsx \
 	--disable-power8 \
-	--disable-amd3dnow \
-	--disable-amd3dnowext \
-	--disable-mmx \
-	--disable-mmxext \
-	--disable-sse \
-	--disable-sse2 \
-	--disable-sse3 \
-	--disable-ssse3 \
-	--disable-sse4 \
-	--disable-sse42 \
-	--disable-avx \
-	--disable-xop \
-	--disable-fma3 \
-	--disable-fma4 \
-	--disable-avx2 \
-	--disable-aesni \
 	--disable-armv5te \
 	--disable-armv6 \
 	--disable-armv6t2 \
@@ -421,37 +402,33 @@ FFMPEG_CONFIGURE += \
 	--disable-runtime-cpudetect
 
 else ifneq ($(findstring arm,$(CONFIG_ARCH)),)
-FFMPEG_CONFIGURE += \
+FFMPEG_CONFIGURE+= \
 	--disable-runtime-cpudetect
 # XXX: GitHub issue 3320 ppc cpu with fpu but no altivec (WNDR4700)
 else ifneq ($(findstring powerpc,$(CONFIG_ARCH)),)
-FFMPEG_CONFIGURE += \
+FFMPEG_CONFIGURE+= \
 	--disable-altivec
 endif
 
 # selectively disable optimizations according to arch/cpu type
 ifneq ($(findstring arm,$(CONFIG_ARCH)),)
 	ifneq ($(findstring vfp,$(CONFIG_TARGET_OPTIMIZATION)),)
-		FFMPEG_CONFIGURE+= \
-			--enable-vfp
+		FFMPEG_CONFIGURE+= --enable-vfp
 	else
-		FFMPEG_CONFIGURE+= \
-			--disable-vfp
+		FFMPEG_CONFIGURE+= --disable-vfp
 	endif
 	ifneq ($(findstring neon,$(CONFIG_TARGET_OPTIMIZATION)),)
 		FFMPEG_CONFIGURE+= \
 			--enable-neon \
 			--enable-vfp
 	else
-		FFMPEG_CONFIGURE+= \
-			--disable-neon
+		FFMPEG_CONFIGURE+= --disable-neon
 	endif
 
 endif
 
 ifneq ($(CONFIG_YASM),y)
-FFMPEG_CONFIGURE += \
-	--disable-yasm
+FFMPEG_CONFIGURE+= --disable-yasm
 
 endif
 
@@ -465,8 +442,12 @@ ifeq ($(BUILD_VARIANT),full)
 		\
 		$(if $(CONFIG_PACKAGE_shine),--enable-libshine)
   else
+	ifeq ($(ARCH),x86_64)
+		FFMPEG_CONFIGURE+= --enable-hardcoded-tables
+	else
+		FFMPEG_CONFIGURE+= --enable-small
+	endif
 	FFMPEG_CONFIGURE+= \
-		--enable-small \
 		--enable-gpl \
 		\
 		$(if $(CONFIG_PACKAGE_lame-lib),--enable-libmp3lame) \
@@ -597,7 +578,7 @@ ifeq ($(BUILD_VARIANT),mini)
 endif
 
 ifneq ($(CONFIG_TARGET_x86),)
-  TARGET_CFLAGS += -fomit-frame-pointer
+  TARGET_CFLAGS+= -fomit-frame-pointer
 endif
 
 define Build/Configure


### PR DESCRIPTION
Maintainer: me & @thess 
Compile tested: mips/ar71xx, x86-64/generic, arm/mvebu, arm/imx6, arm/bcm47xx, LEDE trunk
Run tested: Partial on mips/ar71xx

Description:

This series updates ffmpeg to 3.2.7, cleans up the Makefile and adds some new optimizations. The commits mostly detail what they're doing, but to summarize it removes ./configure that have no affect on our builds. A minor change is made to x86-64 where it is set to not build with limiting size of code as a priority.

Patch 2 removes the parser selection for libffmpeg-audio-dec and libffmpeg-custom to allow ffmpeg's configure script to choose the necessary parsers for the chosen decoders/encoders. I left this patch unsquashed for Ted to look at first.

Patch 3 toggles on LTO for arm and x86-64. Building for mips failed so I will look at it again when gcc6/7 becomes default. I lack the hardware to run test this patch, so I've left it separate for easy revert if buildbots error.