### PR TITLE
python-pyopenssl: bump to 17.2.0 ; add python3 variant ; add myself co-maintainer

### DIFF
--- a/lang/python/python-pyopenssl/Makefile
+++ b/lang/python/python-pyopenssl/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2016 OpenWrt.org
+# Copyright (C) 2015-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,38 +8,63 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pyOpenSSL
-PKG_VERSION:=16.1.0
+PKG_VERSION:=17.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/15/1e/79c75db50e57350a7cefb70b110255757e9abd380a50ebdc0cfd853b7450
-PKG_MD5SUM:=d8100b0c333f0eeadaf05914da8792a6
-
-PKG_BUILD_DEPENDS:=python python-setuptools
+PKG_SOURCE_URL:=https://pypi.python.org/packages/b0/9e/7088f6165c40c46416aff434eb806c1d64ad6ec6dbc201f5ad4d0484704e
+PKG_HASH:=5d617ce36b07c51f330aa63b83bf7f25c40a0e95958876d54d1982f8c91b4834
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pyopenssl-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 $(call include_mk, python-package.mk)
+$(call include_mk, python3-package.mk)
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-pyopenssl/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://github.com/pyca/pyopenssl
+endef
 
 define Package/python-pyopenssl
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-pyopenssl
-	URL:=https://github.com/pyca/pyopenssl
-	DEPENDS:=+python-light +python-cryptography +python-six
+$(call Package/python-pyopenssl/Default)
+  TITLE:=python-pyopenssl
+  VARIANT:=python
+  DEPENDS:= \
+      +PACKAGE_python-pyopenssl:python-light \
+      +PACKAGE_python-pyopenssl:python-cryptography \
+      +PACKAGE_python-pyopenssl:python-six
+endef
+
+define Package/python3-pyopenssl
+$(call Package/python-pyopenssl/Default)
+  TITLE:=python3-pyopenssl
+  VARIANT:=python3
+  DEPENDS:= \
+      +PACKAGE_python3-pyopenssl:python3-light \
+      +PACKAGE_python3-pyopenssl:python3-cryptography \
+      +PACKAGE_python3-pyopenssl:python3-six
 endef
 
 define Package/python-pyopenssl/description
 Python wrapper module around the OpenSSL library
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
+define Package/python3-pyopenssl/description
+$(call Package/python-pyopenssl/description)
+.
+(Variant for Python3).
 endef
 
 $(eval $(call PyPackage,python-pyopenssl))
 $(eval $(call BuildPackage,python-pyopenssl))
+$(eval $(call Py3Package,python3-pyopenssl))
+$(eval $(call BuildPackage,python3-pyopenssl))


### PR DESCRIPTION
Maintainer: me, @jefferyto 
Compile tested: https://github.com/lede-project/source/commit/df3295f50e54909090846de12f7deb3ff8de6557  x86_64
Run tested: https://github.com/lede-project/source/commit/df3295f50e54909090846de12f7deb3ff8de6557  x86_64

Description:

Fixes https://github.com/openwrt/packages/issues/4499
Though, it's likely the `python-cryptography` version bump + fix, solved that.

Bump to version 17.2.0 ; add python3 variant.
Add myself as co-maintainer.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>