### PR TITLE
libffi: fix location of host side headers ; python,python3: set correct build flags to host pip build

### DIFF
--- a/lang/python/python/files/python-host.mk
+++ b/lang/python/python/files/python-host.mk
@@ -37,21 +37,26 @@ define HostPython
 	$(HOST_PYTHON_BIN) $(2);
 endef
 
+define host_python_settings
+	ARCH="$(HOST_ARCH)" \
+	CC="$(HOSTCC)" \
+	CCSHARED="$(HOSTCC) $(HOST_FPIC)" \
+	CXX="$(HOSTCXX)" \
+	LD="$(HOSTCC)" \
+	LDSHARED="$(HOSTCC) -shared" \
+	CFLAGS="$(HOST_CFLAGS)" \
+	CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON_INC_DIR)" \
+	LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib" \
+	_PYTHON_HOST_PLATFORM=linux2
+endef
+
 # $(1) => commands to execute before running pythons script
 # $(2) => python script and its arguments
 # $(3) => additional variables
 define Build/Compile/HostPyRunHost
 	$(call HostPython, \
 		$(if $(1),$(1);) \
-		CC="$(HOSTCC)" \
-		CCSHARED="$(HOSTCC) $(HOST_FPIC)" \
-		CXX="$(HOSTCXX)" \
-		LD="$(HOSTCC)" \
-		LDSHARED="$(HOSTCC) -shared" \
-		CFLAGS="$(HOST_CFLAGS)" \
-		CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON_INC_DIR)" \
-		LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib" \
-		_PYTHON_HOST_PLATFORM=linux2 \
+		$(call host_python_settings) \
 		$(3) \
 		, \
 		$(2) \
@@ -63,6 +68,7 @@ endef
 # Note: I shamelessly copied this from Yousong's logic (from python-packages);
 HOST_PYTHON_PIP:=$(STAGING_DIR_HOSTPKG)/bin/pip$(PYTHON_VERSION)
 define host_python_pip_install
+	$(call host_python_settings) \
 	$(HOST_PYTHON_PIP) install \
 		--root=$(1) \
 		--prefix=$(2) \

--- a/lang/python/python3/files/python3-host.mk
+++ b/lang/python/python3/files/python3-host.mk
@@ -37,21 +37,26 @@ define HostPython3
 	$(HOST_PYTHON3_BIN) $(2);
 endef
 
+define host_python3_settings
+	ARCH="$(HOST_ARCH)" \
+	CC="$(HOSTCC)" \
+	CCSHARED="$(HOSTCC) $(HOST_FPIC)" \
+	CXX="$(HOSTCXX)" \
+	LD="$(HOSTCC)" \
+	LDSHARED="$(HOSTCC) -shared" \
+	CFLAGS="$(HOST_CFLAGS)" \
+	CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON3_INC_DIR)" \
+	LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON3_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib" \
+	_PYTHON_HOST_PLATFORM=linux2
+endef
+
 # $(1) => commands to execute before running pythons script
 # $(2) => python script and its arguments
 # $(3) => additional variables
 define Build/Compile/HostPy3RunHost
 	$(call HostPython3, \
 		$(if $(1),$(1);) \
-		CC="$(HOSTCC)" \
-		CCSHARED="$(HOSTCC) $(HOST_FPIC)" \
-		CXX="$(HOSTCXX)" \
-		LD="$(HOSTCC)" \
-		LDSHARED="$(HOSTCC) -shared" \
-		CFLAGS="$(HOST_CFLAGS)" \
-		CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON3_INC_DIR)" \
-		LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON3_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib" \
-		_PYTHON_HOST_PLATFORM=linux2 \
+		$(call host_python3_settings) \
 		$(3) \
 		, \
 		$(2) \
@@ -63,6 +68,7 @@ endef
 # Note: I shamelessly copied this from Yousong's logic (from python-packages);
 HOST_PYTHON3_PIP:=$(STAGING_DIR_HOSTPKG)/bin/pip$(PYTHON3_VERSION)
 define host_python3_pip_install
+	$(call host_python3_settings) \
 	$(HOST_PYTHON3_PIP) install \
 		--root=$(1) \
 		--prefix=$(2) \

--- a/libs/libffi/Makefile
+++ b/libs/libffi/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libffi
 PKG_VERSION:=3.2.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://sourceware.org/pub/libffi/
-PKG_MD5SUM:=83b89587607e3eb65c70d361f13bab43
+PKG_HASH:=d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -76,6 +76,16 @@ define Package/libffi/install
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/libffi.so.* \
 		$(1)/usr/lib/
+endef
+
+define Host/Install
+	$(call Host/Install/Default)
+	# Adjust host libffi headers ; the default rule does
+	# not seem to install them to the proper include folder
+	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/include
+	$(CP) \
+		$(STAGING_DIR_HOSTPKG)/lib/libffi-$(PKG_VERSION)/include/*.h \
+		$(STAGING_DIR_HOSTPKG)/include
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: me, @tripolar 
Compile tested: https://github.com/lede-project/source/commit/df3295f50e54909090846de12f7deb3ff8de6557 mipsel_24kc
Run tested: N/A

Description:

This should fix the host side build of the python-cffi builds.
Err is:
http://downloads.lede-project.org/snapshots/faillogs/mipsel_24kc/packages/python-cffi/python/compile.txt

```
    running build_ext
    building '_cffi_backend' extension
    creating build/temp.linux-x86_64-2.7
    creating build/temp.linux-x86_64-2.7/c
    ccache gcc -pthread -DNDEBUG -g -O3 -Wall -Wstrict-prototypes -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/data/bowl-builder/mipsel_24kc/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include -I/data/bowl-builder/mipsel_24kc/build/sdk/staging_dir/hostpkg/include/python2.7 -c c/_cffi_backend.c -o build/temp.linux-x86_64-2.7/c/_cffi_backend.o
    In file included from /data/bowl-builder/mipsel_24kc/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include/ffi.h:67:0,
                     from c/_cffi_backend.c:15:
    /data/bowl-builder/mipsel_24kc/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include/ffitarget.h:36:26: fatal error: asm/sgidefs.h: No such file or directory
     # include <asm/sgidefs.h>
                              ^
    compilation terminated.
    error: command 'ccache' failed with exit status 1
```

Fixing that build seems to need addressing the `libffi` package and the `python` & `python3` packages,

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>