### PR TITLE
nlbwmon: preserve protocols mapping across sysupgrade

### DIFF
--- a/net/nlbwmon/Makefile
+++ b/net/nlbwmon/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nlbwmon
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/jow-/nlbwmon.git
@@ -38,5 +38,10 @@ define Package/nlbwmon/install
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nlbwmon.config $(1)/etc/config/nlbwmon
 endef
+
+define Package/nlbwmon/conffiles
+/usr/share/nlbwmon/protocols
+endef
+
 
 $(eval $(call BuildPackage,nlbwmon))


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: ar71xx, Archer C7 v2 LEDE snapshot
Run tested: ar71xx, Archer C7 v2 LEDE snapshot - after installing updated package, I confirmed the auto preserved config files list contained /usr/share/nlbwmon/protocols.  I then did a sysupgrade and proved the file had been preserved across sysupgrade.

Description:

Define package config files to preserve
/usr/share/nlbwmon/protocols across sysupgrade

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>

