### PR TITLE
ssh: Add umdns entry to the init script.

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
 PKG_VERSION:=7.5p1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \

--- a/net/openssh/files/sshd.init
+++ b/net/openssh/files/sshd.init
@@ -20,7 +20,11 @@ start_service() {
 	}; done
 	mkdir -m 0700 -p /var/empty
 
+	local lport=`grep ^Port /etc/ssh/sshd_config | cut -d " " -f 2`
+	[ -z $lport ] && lport=22
+
 	procd_open_instance
+	procd_add_mdns "ssh" "tcp" "$lport"
 	procd_set_param command $PROG -D
 	procd_close_instance
 }


### PR DESCRIPTION
This is usefull for hosts to discover the ssh server, especially
on macOS.

Signed-off by: Rosen Penev <rosenp@gmail.com>