### PR TITLE
rpcd-mod-attendedsysupgrade: uci update_packages

### DIFF
--- a/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.defaults
+++ b/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.defaults
@@ -6,7 +6,11 @@ touch /etc/config/attendedsysupgrade
 
 uci -q batch <<EOF
 set attendedsysupgrade.updateserver=updateserver
-set attendedsysupgrade.updateserver.url="https://betaupdate.libremesh.org"
+set attendedsysupgrade.updateserver.url='https://betaupdate.libremesh.org'
+
+set attendedsysupgrade.updateclient=updateclient
+set attendedsysupgrade.updateclient.update_packages='1'
+
 commit attendedsysupgrade
 EOF
 


### PR DESCRIPTION
add uci option to set "update_packages". this options will lead the
luci-app-attendedsysupgrade to tell the update server to check for
package updates as well (not only release upgrades)

@dangowrt 

Signed-off-by: Paul Spooren <paul@spooren.de>