### PR TITLE
net/mwan3: add mmx config option over uci

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.6.2
+PKG_VERSION:=2.6.3
 PKG_RELEASE:=2
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -11,7 +11,15 @@ CONNTRACK_FILE="/proc/net/nf_conntrack"
 MWAN3_STATUS_DIR="/var/run/mwan3track"
 
 # mwan3's MARKing mask (at least 3 bits should be set)
-MMX_MASK=0xff00
+if [ -e "${MWAN3_STATUS_DIR}/mmx_mask" ]; then
+	MMX_MASK=$(cat "${MWAN3_STATUS_DIR}/mmx_mask")
+else
+	config_load mwan3
+	config_get MMX_MASK globals mmx_mask '0xff00'
+	mkdir -p "${MWAN3_STATUS_DIR}"
+	echo "$MMX_MASK" > "${MWAN3_STATUS_DIR}/mmx_mask"
+	$LOG notice "Using firewall mask ${MMX_MASK}"
+fi
 
 # counts how many bits are set to 1
 # n&(n-1) clears the lowest bit set to 1

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -160,6 +160,7 @@ stop()
 	done
 
 	mwan3_lock_clean
+	rm -rf "${MWAN3_STATUS_DIR}/mmx_mask"
 }
 
 restart() {


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a (only changed a shell script)
Run tested: (lantiq_xrx200, LEDE master, tested failover and failback; also checked iptables)

Description:
Make new mmx_mask configurable over uci.
This was added with #4670 