### PR TITLE
cgi-io: fix compilation error

### DIFF
--- a/net/cgi-io/src/main.c
+++ b/net/cgi-io/src/main.c
@@ -141,8 +141,8 @@ md5sum(const char *file)
 		close(fds[0]);
 		close(fds[1]);
 
-		if (execl("/bin/busybox", "/bin/busybox", "md5sum", file, NULL));
-			return NULL;
+		{ { if (execl("/bin/busybox", "/bin/busybox", "md5sum", file, NULL)); }
+			return NULL; }
 
 		break;
 


### PR DESCRIPTION
This package is currently broken with this error:

/home/Ansuel/source/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/cgi-io/main.c:144:3: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
   if (execl("/bin/busybox", "/bin/busybox", "md5sum", file, NULL));
   ^~
/home/Ansuel/source/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/cgi-io/main.c:145:4: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
    return NULL;
    ^~~~~~
cc1: all warnings being treated as errors

This fix this compilation error

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>