### PR TITLE
shadowsocks-libev: update AEAD cipher names

### DIFF
--- a/net/shadowsocks-libev/Makefile
+++ b/net/shadowsocks-libev/Makefile
@@ -14,7 +14,7 @@ include $(TOPDIR)/rules.mk
 #
 PKG_NAME:=shadowsocks-libev
 PKG_VERSION:=3.0.8
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$(PKG_VERSION)

--- a/net/shadowsocks-libev/files/shadowsocks-libev.init
+++ b/net/shadowsocks-libev/files/shadowsocks-libev.init
@@ -245,7 +245,7 @@ validate_common_server_options_() {
 	local cfg="$1"; shift
 	local func="$1"; shift
 	local stream_methods='"table", "rc4", "rc4-md5", "aes-128-cfb", "aes-192-cfb", "aes-256-cfb", "aes-128-ctr", "aes-192-ctr", "aes-256-ctr", "bf-cfb", "camellia-128-cfb", "camellia-192-cfb", "camellia-256-cfb", "salsa20", "chacha20", "chacha20-ietf"'
-	local aead_methods='"aes-128-gcm", "aes-192-gcm", "aes-256-gcm"'
+	local aead_methods='"aes-128-gcm", "aes-192-gcm", "aes-256-gcm", "chacha20-ietf-poly1305", "xchacha20-ietf-poly1305"'
 
 	"${func:-ss_validate}" "$cfgtype" "$cfg" "$@" \
 		'disabled:bool:0' \


### PR DESCRIPTION
Maintainer: @yousong
Compile tested: mips/ar71xx, DIR-825-C1, r4683-370aacf532
Run tested: mips/ar71xx, DIR-825-C1, r4683-370aacf532

Description:
Updated AEAD cipher names in aead_methods:
- chacha20-ietf-poly1305
- xchacha20-ietf-poly1305 

Reference: https://github.com/shadowsocks/shadowsocks-libev/blob/master/src/aead.c

Signed-off-by: Leong Hui Wong <wong.leonghui@gmail.com>