### PR TITLE
ffmpeg: fixup mpeg support in libffmpeg-mini

### DIFF
--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -66,8 +66,8 @@ config FFMPEG_CUSTOM_MINIDLNA_SUPPORT
 	select FFMPEG_CUSTOM_DEMUXER_matroska
 	select FFMPEG_CUSTOM_DEMUXER_mov
 	select FFMPEG_CUSTOM_DEMUXER_mp3
+	select FFMPEG_CUSTOM_DEMUXER_mpegps
 	select FFMPEG_CUSTOM_DEMUXER_mpegts
-	select FFMPEG_CUSTOM_DEMUXER_mpegvideo
 	select FFMPEG_CUSTOM_DEMUXER_ogg
 	select FFMPEG_CUSTOM_PROTOCOL_file
 
@@ -383,7 +383,7 @@ config FFMPEG_CUSTOM_DEMUXER_mp3
 	bool "MP3 (MPEG Audio Layer 3)"
 
 config FFMPEG_CUSTOM_DEMUXER_mpegvideo
-	bool "MPEG Video"
+	bool "MPEG Video (Raw)"
 
 config FFMPEG_CUSTOM_DEMUXER_mpegps
 	bool "MPEG-2 (PS)"

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=3.2.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
@@ -144,8 +144,8 @@ FFMPEG_MINI_DEMUXERS:= \
 	matroska \
 	mov \
 	mp3 \
+	mpegps \
 	mpegts \
-	mpegvideo \
 	ogg \
 
 FFMPEG_MINI_PROTOCOLS:= \


### PR DESCRIPTION
Maintainer: me & @thess 
Compile tested: mips/ar71xx, LEDE trunk
Run tested: None

Description:

The demuxer mpegps is for VOB support and mpegvideo is for raw mpeg video.
mpegps was intended to be included with libffmpeg-mini; mpegvideo was not.

Should resolve #4734 