### PR TITLE
build,travis: dynamicly use all cores available

### DIFF
--- a/.travis_do.sh
+++ b/.travis_do.sh
@@ -118,7 +118,8 @@ EOF
 
 		# we can't enable verbose built else we often hit Travis limits
 		# on log size and the job get killed
-		exec_status '^ERROR' make "package/$pkg_name/compile" -j3 || RET=1
+		CPU_MAX="$(( $(grep -c ^processor /proc/cpuinfo) + 1 ))"
+		exec_status '^ERROR' make "package/$pkg_name/compile" -j$CPU_MAX || RET=1
 
 		echo_blue "=== $pkg_name: compile test done"
 


### PR DESCRIPTION
CPU_MAX is set to the number of cores +1
Travis seems to offer 32 cores for building.
This could speed up the build process a bit. 

@lynxis 

Signed-off-by: Paul Spooren <paul@spooren.de>