### PR TITLE
unbound: update to 1.6.5

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.6.4
+PKG_VERSION:=1.6.5
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
@@ -17,7 +17,7 @@ PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@hotmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unbound.net/downloads
-PKG_HASH:=df0a88816ec31ccb8284c9eb132e1166fbf6d9cde71fbc4b8cd08a91ee777fed
+PKG_HASH:=e297aa1229015f25bf24e4923cb1dadf1f29b84f82a353205006421f82cc104e
 
 PKG_BUILD_DEPENDS:=libexpat
 PKG_BUILD_PARALLEL:=1

--- a/net/unbound/patches/001-conf.patch
+++ b/net/unbound/patches/001-conf.patch
@@ -6,7 +6,7 @@ index 5396029..cbb51ec 100644
 -#
 -# Example configuration file.
 -#
--# See unbound.conf(5) man page, version 1.6.4.
+-# See unbound.conf(5) man page, version 1.6.5.
 -#
 -# this is a comment.
 +##############################################################################


### PR DESCRIPTION
Maintainer: me 
Tested: LEDE master TL-Archer-C7v2
Description: Upstream bug fix 1.6.5 for root DNSSEC key roll
