### PR TITLE
forked-daapd: Fix build error due to missing gperf

### DIFF
--- a/sound/forked-daapd/Makefile
+++ b/sound/forked-daapd/Makefile
@@ -15,6 +15,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ejurgensen/$(PKG_NAME)/releases/download/$(PKG_VERSION)/
 PKG_HASH:=5741a64d8f54e11e89dfa2fbfae693b2837e1e19a0c4980a20f8ff56bce4456e
 
+PKG_BUILD_DEPENDS:=gperf/host
 PKG_FIXUP:=autoreconf
 PKG_USE_MIPS16:=0
 PKG_INSTALL:=1


### PR DESCRIPTION
Need to put the build dependency to gperf back (I removed the gperf dependency in pr #4671), because there is a bug in forked-daapd 25.0's configure.ac when building without gperf. I think it should fix this build problem: http://buildbot.openwrt.org:8010/broken_packages/arm64/forked-daapd/compile.txt

Signed-off-by: Espen Jürgensen <espenjurgensen+openwrt@gmail.com>

-------------------------------

Maintainer: Espen Jürgensen / @ejurgensen
Compile tested: Yes, ar71xx
Run tested: No

Description:
Fix build problem by putting back dependency on gperf on the build host