### PR TITLE
libmosquitto: fix compilation of libmosquittopp

### DIFF
--- a/net/mosquitto/Makefile
+++ b/net/mosquitto/Makefile
@@ -144,7 +144,7 @@ endef
 define Package/libmosquittopp
     SECTION:=libs
     CATEGORY:=Libraries
-    DEPENDS:=+libmosquitto-ssl +libstdcpp
+    DEPENDS:=+libmosquitto +libmosquitto-ssl +libstdcpp
     TITLE:= mosquitto - client c++ library
 endef
 


### PR DESCRIPTION
+libmosquitto is required for libmosquittopp in order to compile with sdk.
otherwise
Package libmosquittopp is missing dependencies for the following libraries:
libmosquitto.so.1

is thrown.