### PR TITLE
forked-daapd: Fix build error due to misdetected pulseaudio

### DIFF
--- a/sound/forked-daapd/Makefile
+++ b/sound/forked-daapd/Makefile
@@ -56,6 +56,7 @@ CONFIGURE_ARGS += \
 	--enable-chromecast \
 	--enable-verification \
 	--disable-spotify \
+	--without-pulseaudio \
 	--without-libevent_pthreads
 
 TARGET_CFLAGS += $(FPIC)


### PR DESCRIPTION
Yet a fix for a build problem, this one: https://github.com/openwrt/packages/pull/4746#issuecomment-324753581

configure finds libpulse and then tries to include the header, but fails,
because pulseaudio isn't a dependency in the Makefile. This change disables
pulseaudio support so configure won't do this.

It wasn't the intention with version update 25.0 of forked-daapd to extend
with pulseaudio support, but maybe do that later.

Signed-off-by: Espen Jürgensen <espenjurgensen+openwrt@gmail.com>

-------------------------------

Maintainer: Espen Jürgensen / @ejurgensen
Compile tested: ar71xx, LEDE trunk
Run tested: No

Description:
Fix for LEDE build problem, see https://github.com/openwrt/packages/pull/4746#issuecomment-324753581