### PR TITLE
pianod: Update to 174.07. Replace libmad with libmpg123

### DIFF
--- a/sound/pianod/Makefile
+++ b/sound/pianod/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pianod
-PKG_VERSION:=174.05
+PKG_VERSION:=174.07
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://github.com/thess/pianod-sc/releases/download/$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MD5SUM:=0bae19b0c1e309343bc1b351e521173fe439431542a949dd2bacf4165cce5200
+PKG_HASH:=eee969926c095497893fbd28711258a31efb2d2301da87563dbcd101d8771bff
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
@@ -28,7 +28,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/pianod
   SECTION:=sound
   CATEGORY:=Sound
-  DEPENDS:=+libao +libfaad2 +libmad +libmbedtls +libjson-c +libgcrypt +libpthread
+  DEPENDS:=+libao +libfaad2 +libmpg123 +libmbedtls +libjson-c +libgcrypt +libpthread
   TITLE:=Pandora radio daemon
   USERID:=pianod=88:pianod=88
   URL:=http://deviousfish.com/pianod1/


### PR DESCRIPTION
Maintainer: me / @thess
Compile tested: LEDE master, AR71xx, X86-64
Run tested: ar71xx, armeb, x86

Description:
New version 174.07 (update from 174.05)

* replace libmad with libmpg123
* support shoutcast credentials
* bug fixes 

Signed-off-by: Ted Hess <thess@kitschensync.net>