### PR TITLE
squeezelite: Replace libmad with libmpg123

### DIFF
--- a/sound/squeezelite/Makefile
+++ b/sound/squeezelite/Makefile
@@ -1,6 +1,4 @@
 #
-# Copyright (C) 2015-2016 OpenWrt.org
-#
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
@@ -9,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squeezelite
 PKG_VERSION:=1.8.4-743
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=LICENSE.txt
@@ -20,10 +18,11 @@ PKG_SOURCE_URL:=https://github.com/ralph-irving/squeezelite.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=e37ed17fed9e11a7346cbe9f1e1deeccc051f42e
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_MIRROR_HASH:=b6ea4a11366330790f5e36bd875b45bb19a9772dfc984c462f436dfca30256c0
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
-PKG_BUILD_DEPENDS:=libflac libvorbis libmad libfaad2 SQUEEZELITE_WMA:libffmpeg-audio-dec
+PKG_BUILD_DEPENDS:=libflac libvorbis libmpg123 libfaad2 SQUEEZELITE_WMA:libffmpeg-audio-dec
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -40,7 +39,7 @@ endef
 define Package/squeezelite-full
     $(call Package/squeezelite/default)
     TITLE+= (full)
-    DEPENDS+= +libflac +libvorbis +libmad +libfaad2 \
+    DEPENDS+= +libflac +libvorbis +libmpg123 +libfaad2 \
               +SQUEEZELITE_WMA:libffmpeg-audio-dec
     VARIANT:=full
 endef

--- a/sound/squeezelite/files/squeezelite.init
+++ b/sound/squeezelite/files/squeezelite.init
@@ -102,7 +102,7 @@ make_cmdline() {
 	local vorbis_lib="libvorbisidec.so.1"
 
 	excl_codecs=`checkcodec decode_flac "libFLAC.so.8" flac "$excl_codecs"`
-	excl_codecs=`checkcodec decode_mp3 "libmad.so.0" mp3 "$excl_codecs"`
+	excl_codecs=`checkcodec decode_mp3 "libmpg123.so.0" mp3 "$excl_codecs"`
 	excl_codecs=`checkcodec decode_aac "libfaad.so.2" aac "$excl_codecs"`
 
 	[ -e "/usr/lib/$vorbis_lib" ] || vorbis_lib="libvorbisfile.so.3"

--- a/sound/squeezelite/patches/020-no_libmad.patch
+++ b/sound/squeezelite/patches/020-no_libmad.patch
@@ -5,7 +5,7 @@
  	main.c slimproto.c buffer.c stream.c utils.c \
  	output.c output_alsa.c output_pa.c output_stdout.c output_pack.c decode.c \
 -	flac.c pcm.c mad.c vorbis.c faad.c mpg.c
-+	flac.c pcm.c mad.c vorbis.c faad.c
++	flac.c pcm.c vorbis.c faad.c mpg.c
  
  SOURCES_DSD      = dsd.c dop.c dsd2pcm/dsd2pcm.c
  SOURCES_FF       = ffmpeg.c
@@ -14,22 +14,22 @@
  LINK_LINUX       = -ldl
  
 -LINKALL          = -lFLAC -lmad -lvorbisfile -lfaad -lmpg123
-+LINKALL          = -lFLAC -lmad -lvorbisfile -lfaad
++LINKALL          = -lFLAC -lvorbisfile -lfaad -lmpg123
  LINKALL_FF       = -lavcodec -lavformat -lavutil
  LINKALL_RESAMPLE = -lsoxr
  LINKALL_IR       = -llirc_client
 --- a/decode.c
 +++ b/decode.c
-@@ -147,8 +147,8 @@ void decode_init(log_level level, const
- 	// try mad then mpg for mp3 unless command line option passed
- 	if (!(strstr(exclude_codecs, "mp3") || strstr(exclude_codecs, "mad")) &&
- 		(!include_codecs || strstr(include_codecs, "mp3") || strstr(include_codecs, "mad")))	codecs[i] = register_mad();
--	if (!(strstr(exclude_codecs, "mp3") || strstr(exclude_codecs, "mpg")) && !codecs[i] &&
--		(!include_codecs || strstr(include_codecs, "mp3") || strstr(include_codecs, "mpg")))    codecs[i] = register_mpg();
-+//	if (!(strstr(exclude_codecs, "mp3") || strstr(exclude_codecs, "mpg")) && !codecs[i] &&
-+//		(!include_codecs || strstr(include_codecs, "mp3") || strstr(include_codecs, "mpg")))    codecs[i] = register_mpg();
+@@ -145,8 +145,8 @@ void decode_init(log_level level, const
+ 	if (!strstr(exclude_codecs, "pcm")  && (!include_codecs || strstr(include_codecs, "pcm")))  codecs[i++] = register_pcm();
  
- 	mutex_create(decode.mutex);
+ 	// try mad then mpg for mp3 unless command line option passed
+-	if (!(strstr(exclude_codecs, "mp3") || strstr(exclude_codecs, "mad")) &&
+-		(!include_codecs || strstr(include_codecs, "mp3") || strstr(include_codecs, "mad")))	codecs[i] = register_mad();
++//	if (!(strstr(exclude_codecs, "mp3") || strstr(exclude_codecs, "mad")) &&
++//		(!include_codecs || strstr(include_codecs, "mp3") || strstr(include_codecs, "mad")))	codecs[i] = register_mad();
+ 	if (!(strstr(exclude_codecs, "mp3") || strstr(exclude_codecs, "mpg")) && !codecs[i] &&
+ 		(!include_codecs || strstr(include_codecs, "mp3") || strstr(include_codecs, "mpg")))    codecs[i] = register_mpg();
  
 --- a/main.c
 +++ b/main.c
@@ -39,45 +39,45 @@
  #endif
 -#define CODECS_MP3  " (mad,mpg for specific mp3 codec)"
 +//#define CODECS_MP3  " (mad,mpg for specific mp3 codec)"
-+#define CODECS_MP3  " (mad for specific mp3 codec)"
++#define CODECS_MP3  " (mpg123 for specific mp3 codec)"
  
  #define CODECS CODECS_BASE CODECS_FF CODECS_DSD CODECS_MP3
  
 --- a/squeezelite.h
 +++ b/squeezelite.h
-@@ -155,7 +155,7 @@
+@@ -154,7 +154,7 @@
+ 
  #if LINUX
  #define LIBFLAC "libFLAC.so.8"
- #define LIBMAD  "libmad.so.0"
--#define LIBMPG "libmpg123.so.0"
-+//#define LIBMPG "libmpg123.so.0"
+-#define LIBMAD  "libmad.so.0"
++//#define LIBMAD  "libmad.so.0"
+ #define LIBMPG "libmpg123.so.0"
  #define LIBVORBIS "libvorbisfile.so.3"
  #define LIBTREMOR "libvorbisidec.so.1"
- #define LIBFAAD "libfaad.so.2"
-@@ -169,7 +169,7 @@
+@@ -168,7 +168,7 @@
+ 
  #if OSX
  #define LIBFLAC "libFLAC.8.dylib"
- #define LIBMAD  "libmad.0.dylib"
--#define LIBMPG "libmpg123.0.dylib"
-+//#define LIBMPG "libmpg123.0.dylib"
+-#define LIBMAD  "libmad.0.dylib"
++//#define LIBMAD  "libmad.0.dylib"
+ #define LIBMPG "libmpg123.0.dylib"
  #define LIBVORBIS "libvorbisfile.3.dylib"
  #define LIBTREMOR "libvorbisidec.1.dylib"
- #define LIBFAAD "libfaad.2.dylib"
-@@ -182,7 +182,7 @@
+@@ -181,7 +181,7 @@
+ 
  #if WIN
  #define LIBFLAC "libFLAC.dll"
- #define LIBMAD  "libmad-0.dll"
--#define LIBMPG "libmpg123-0.dll"
-+//#define LIBMPG "libmpg123-0.dll"
+-#define LIBMAD  "libmad-0.dll"
++//#define LIBMAD  "libmad-0.dll"
+ #define LIBMPG "libmpg123-0.dll"
  #define LIBVORBIS "libvorbisfile.dll"
  #define LIBTREMOR "libvorbisidec.dll"
- #define LIBFAAD "libfaad2.dll"
-@@ -195,7 +195,7 @@
+@@ -194,7 +194,7 @@
+ 
  #if FREEBSD
  #define LIBFLAC "libFLAC.so.11"
- #define LIBMAD  "libmad.so.2"
--#define LIBMPG "libmpg123.so.0"
-+//#define LIBMPG "libmpg123.so.0"
+-#define LIBMAD  "libmad.so.2"
++//#define LIBMAD  "libmad.so.2"
+ #define LIBMPG "libmpg123.so.0"
  #define LIBVORBIS "libvorbisfile.so.6"
  #define LIBTREMOR "libvorbisidec.so.1"
- #define LIBFAAD "libfaad.so.2"


### PR DESCRIPTION
Maintainer: me / @thess
Compile tested: ar71xx
Run tested: Not at this time

Description:
Remove libmad and re-enable mpg123