### PR TITLE
mjpg-streamer: Add PKG_MIRROR_HASH for buildbots w/o svn

### DIFF
--- a/multimedia/mjpg-streamer/Makefile
+++ b/multimedia/mjpg-streamer/Makefile
@@ -1,6 +1,4 @@
 #
-# Copyright (C) 2006-2015 OpenWrt.org
-#
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
@@ -11,13 +9,15 @@ PKG_NAME:=mjpg-streamer
 PKG_REV:=182
 PKG_VERSION:=r$(PKG_REV)
 PKG_RELEASE:=8
-PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
+PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>, \
+		Ted Hess <thess@kitschensync.net>
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).1.tar.bz2
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).1.tar.xz
 PKG_SOURCE_URL:=https://svn.code.sf.net/p/mjpg-streamer/code/mjpg-streamer-experimental
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=$(PKG_REV)
 PKG_SOURCE_PROTO:=svn
+PKG_MIRROR_HASH:=ccff417d0a34f7cee12c7984f77788267b1da0f2a7d849bc1b2e3614e670078b
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: me / @roger-
Compile tested: LEDE master, ar71xx
Run tested: Not necessary

Description:
* Add PKG_MIRROR_HASH for buildbots w/o svn
* Remove old (unnecessary) copyright
* Use tar.xz (preferred)
* Add myself as co-maintainer
