### PR TITLE
mpd: Remove glib2 dependency

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpd
 PKG_VERSION:=0.20.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.musicpd.org/download/mpd/0.20/
@@ -34,7 +34,7 @@ define Package/mpd/Default
   CATEGORY:=Sound
   TITLE:=Music Player Daemon
   URL:=http://www.musicpd.org/
-  DEPENDS:= +glib2 +libcurl +libpthread +libmpdclient +libstdcpp $(ICONV_DEPENDS) \
+  DEPENDS:= +zlib +libcurl +libpthread +libmpdclient +libstdcpp $(ICONV_DEPENDS) \
 	    +AUDIO_SUPPORT:alsa-lib +boost +boost-container +libexpat
 endef
 


### PR DESCRIPTION
Maintainer: me / @thess
Compile tested: ar71xx
Run tested: LEDE trunk, WNDR4300

Description:
Remove **glib2** from Makefile. Dependency was removed from sources recently.
...Also testing Travis ;)