### PR TITLE
net/coova-chilli: fix build for cyassl variant

### DIFF
--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.3.0+20141128
 PKG_MAINTAINER:=Jaehoon You <teslamint@gmail.com>
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=git://github.com/coova/coova-chilli

--- a/net/coova-chilli/patches/300-fix-compile-with-cyassl.patch
+++ b/net/coova-chilli/patches/300-fix-compile-with-cyassl.patch
@@ -1,20 +1,25 @@
---- a/src/md5.h
-+++ b/src/md5.h
-@@ -28,6 +28,14 @@
- #define MD5Update MD5_Update
- #define MD5Final MD5_Final
+--- a/configure.in
++++ b/configure.in
+@@ -363,7 +363,7 @@ AC_ARG_WITH([cyassl],
+  [AS_HELP_STRING([--with-cyassl], [enable support for cyassl])],[],[with_cyassl=no])
  
-+#elif HAVE_CYASSL
-+#include <cyassl/openssl/md5.h>
-+
-+#define MD5Init MD5_Init
-+#define MD5Update MD5_Update
-+#define MD5Final MD5_Final
-+
-+typedef struct CYASSL_MD5_CTX MD5_CTX;
- #else
+ AS_IF([test x"$with_cyassl" != xno],
+-  [AC_CHECK_LIB([cyassl], [CyaSSL_Init],
++  [AC_CHECK_LIB([cyassl], [wolfSSL_Init],
+               [AC_SUBST([LIBSSL], ["-lcyassl"])
+                AC_DEFINE([HAVE_CYASSL], [1],
+                          [Define if you have cyassl])
+--- a/src/ippool.c
++++ b/src/ippool.c
+@@ -20,6 +20,8 @@
  
- struct MD5Context {
+ #include "chilli.h"
+ 
++#undef USED
++
+ /*#define _DEBUG_PRINT_ 1*/
+ 
+ const unsigned int IPPOOL_STATSIZE = 0x10000;
 --- a/src/md5.c
 +++ b/src/md5.c
 @@ -18,7 +18,7 @@
@@ -26,3 +31,33 @@
  
  void byteReverse(unsigned char *buf, size_t longs);
  
+--- a/src/md5.h
++++ b/src/md5.h
+@@ -28,6 +28,16 @@
+ #define MD5Update MD5_Update
+ #define MD5Final MD5_Final
+ 
++#elif HAVE_CYASSL
++
++#include <cyassl/openssl/md5.h>
++
++#define MD5Init MD5_Init
++#define MD5Update MD5_Update
++#define MD5Final MD5_Final
++
++#define MD5Context MD5_CTX
++
+ #else
+ 
+ struct MD5Context {
+--- a/src/ssl.h
++++ b/src/ssl.h
+@@ -47,6 +47,8 @@ typedef struct {
+ #include <time.h>
+ #include <string.h>
+ 
++#define OPENSSL_EXTRA
++
+ #include <cyassl/ssl.h>
+ #include <cyassl/openssl/bio.h>
+ #include <cyassl/openssl/crypto.h>


### PR DESCRIPTION
Maintainer: @teslamint 
Compile tested: brcm2708 trunk
Run tested: N/A

Build tested with libwolfssl 3.12.2 OpenWrt.
Did not run-test this.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>