### PR TITLE
libedit: install pkgconfig file

### DIFF
--- a/libs/libedit/Makefile
+++ b/libs/libedit/Makefile
@@ -44,6 +44,9 @@ define Build/InstallDev
 	
 	$(INSTALL_DIR)						$(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libedit.{a,so*}	$(1)/usr/lib/
+
+	$(INSTALL_DIR)						$(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libedit.pc	$(1)/usr/lib/pkgconfig
 endef
 
 define Package/libedit/install


### PR DESCRIPTION
Some configure scripts rely on pkgconfig to detect libedit, for instance
asterisk-13. Install the file so libedit can be used there as well.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @salzmdan 
Compile tested: (mips24, LEDE master)