### PR TITLE
ne/mwan3: feature and fixes

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.6.3
-PKG_RELEASE:=2
+PKG_VERSION:=2.6.4
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2
 

--- a/net/mwan3/files/etc/hotplug.d/iface/14-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/14-mwan3
@@ -22,7 +22,7 @@ config_get local_source globals local_source 'none'
 }
 
 mwan3_lock
-src_ip=$(uci -q -P /var/state get mwan3.globals.src_ip 2>/dev/null)
+src_ip=$(uci_get_state mwan3 globals src_ip)
 [ "${src_ip}" != "" ] && {
 	ip route del default via "${src_ip}" dev lo 1>/dev/null 2>&1
 	ip addr del "${src_ip}/32" dev lo 1>/dev/null 2>&1
@@ -37,7 +37,7 @@ usleep 10000
 	else
 		ip addr add "${src_ip}/32" dev lo
 		ip route add default via "${src_ip}" dev lo
-		uci -q -P /var/state set mwan3.globals.src_ip="${src_ip}"
+		uci_toggle_state mwan3 globals src_ip "${src_ip}"
 	fi
 }
 mwan3_unlock

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -81,8 +81,8 @@ main() {
 	local sleep_time=0
 	local turn=0
 
-	if [ "$STATUS" = "offline" ]; then
-		echo "offline" > /var/run/mwan3track/$1/STATUS
+	if [ "$STATUS" = "unknown" ]; then
+		echo "unknown" > /var/run/mwan3track/$1/STATUS
 		score=0
 	else
 		echo "online" > /var/run/mwan3track/$1/STATUS

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -92,20 +92,24 @@ main() {
 		sleep_time=$interval
 
 		for track_ip in $track_ips; do
-			case "$track_method" in
-				ping)
-					ping -I $DEVICE -c $count -W $timeout -s $size -q $track_ip &> /dev/null ;;
-				arping)
-					arping -I $DEVICE -c $count -w $timeout -q $track_ip &> /dev/null ;;
-				httping)
-					httping -y $SRC_IP -c $count -t $timeout -q $track_ip &> /dev/null ;;
-			esac
-			if [ $? -eq 0 ]; then
-				let host_up_count++
-				echo "up" > /var/run/mwan3track/$1/TRACK_${track_ip}
+			if [ $host_up_count -lt $reliability ]; then
+				case "$track_method" in
+					ping)
+						ping -I $DEVICE -c $count -W $timeout -s $size -q $track_ip &> /dev/null ;;
+					arping)
+						arping -I $DEVICE -c $count -w $timeout -q $track_ip &> /dev/null ;;
+					httping)
+						httping -y $SRC_IP -c $count -t $timeout -q $track_ip &> /dev/null ;;
+				esac
+				if [ $? -eq 0 ]; then
+					let host_up_count++
+					echo "up" > /var/run/mwan3track/$1/TRACK_${track_ip}
+				else
+					let lost++
+					echo "down" > /var/run/mwan3track/$1/TRACK_${track_ip}
+				fi
 			else
-				let lost++
-				echo "down" > /var/run/mwan3track/$1/TRACK_${track_ip}
+				echo "skipped" > /var/run/mwan3track/$1/TRACK_${track_ip}
 			fi
 		done
 


### PR DESCRIPTION
Maintainer: me
Compile tested: not needed script files
Run tested: lantiq, xrx200, lede-17.01)

Description:
- fix self interface hotplug script to use common uci functions. And use toggle instead of set uci functionality. Because if the interface ip is often changed then each change is reflected in "/var/state". Use toggle will fix this.
- If `inital_state` is offline the interface is neither online nor offline to display this set status to unknown.
- Skip tracking ip check if interface is already detected as up.
