### PR TITLE
CONFIG_LIBCURL_ZLIB must be enabled for announcer

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -37,7 +37,7 @@ endef
 
 define Package/transmission-daemon/Default
   $(call Package/transmission/template)
-  DEPENDS:=+libcurl +libpthread +libevent2 +librt +zlib
+  DEPENDS:=+@LIBCURL_ZLIB +libpthread +libevent2 +librt +zlib
   USERID:=transmission=224:transmission=224
 endef
 
@@ -57,7 +57,7 @@ endef
 
 define Package/transmission-cli/Default
   $(call Package/transmission/template)
-  DEPENDS:=+libcurl +libpthread +libevent2 +librt +zlib
+  DEPENDS:=+@LIBCURL_ZLIB +libpthread +libevent2 +librt +zlib
 endef
 
 define Package/transmission-cli-openssl
@@ -76,7 +76,7 @@ endef
 
 define Package/transmission-remote/Default
   $(call Package/transmission/template)
-  DEPENDS:=+libcurl +libpthread +libevent2 +librt +zlib
+  DEPENDS:=+@LIBCURL_ZLIB +libpthread +libevent2 +librt +zlib
 endef
 
 define Package/transmission-remote-openssl


### PR DESCRIPTION
When TR does http announce, libcurl is set with accept GZIP encoding, https://github.com/transmission/transmission/blob/2.92/libtransmission/web.c#L183
. So CONFIG_LIBCURL_ZLIB must be selected or http annouce GZIP response will cause error.

Please double check that your commits:
- all start with "<package name>: "
- all contain signed-off-by
- are linked to your github account (you see your logo in front of them) 

Please also read https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md

Thanks for your contribution
Please remove this text (before ---) and fill the following template
-------------------------------

Maintainer: me / @<github-user>
Compile tested: (put here arch, model, OpenWRT/LEDE version)
Run tested: (put here arch, model, OpenWRT/LEDE version, tests done)

Description:
