### PR TITLE
transmission: CONFIG_LIBCURL_ZLIB must be enabled for http announce

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -37,7 +37,7 @@ endef
 
 define Package/transmission-daemon/Default
   $(call Package/transmission/template)
-  DEPENDS:=+libcurl +libpthread +libevent2 +librt +zlib
+  DEPENDS:=+@LIBCURL_ZLIB +libcurl +libpthread +libevent2 +librt +zlib
   USERID:=transmission=224:transmission=224
 endef
 
@@ -57,7 +57,7 @@ endef
 
 define Package/transmission-cli/Default
   $(call Package/transmission/template)
-  DEPENDS:=+libcurl +libpthread +libevent2 +librt +zlib
+  DEPENDS:=+@LIBCURL_ZLIB +libcurl +libpthread +libevent2 +librt +zlib
 endef
 
 define Package/transmission-cli-openssl
@@ -76,7 +76,7 @@ endef
 
 define Package/transmission-remote/Default
   $(call Package/transmission/template)
-  DEPENDS:=+libcurl +libpthread +libevent2 +librt +zlib
+  DEPENDS:=+@LIBCURL_ZLIB +libcurl +libpthread +libevent2 +librt +zlib
 endef
 
 define Package/transmission-remote-openssl


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE 17.01.2
Run tested: Broadcom BCM47xx/53xx (ARM) device
Description:
When TR does http announce, libcurl is set with accept GZIP encoding, https://github.com/transmission/transmission/blob/2.92/libtransmission/web.c#L183
. So CONFIG_LIBCURL_ZLIB must be selected or http annouce GZIP response will cause error.

Signed-off-by: VYSE V.E.O <VEO@LIVE.COM>
