### PR TITLE
wireguard: bump to release 0.0.20170907

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -11,12 +11,12 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=wireguard
 
-PKG_VERSION:=0.0.20170810
+PKG_VERSION:=0.0.20170907
 PKG_RELEASE:=1
 
 PKG_SOURCE:=WireGuard-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://git.zx2c4.com/WireGuard/snapshot/
-PKG_HASH:=ab96230390625aad6f4816fa23aef6e9f7fee130f083d838919129ff12089bf7
+PKG_HASH:=a1ee12d60662607e4c5a19f84b5115e56f083e2600053882e161537f12d963fd
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
@@ -36,6 +36,7 @@ define Package/wireguard/Default
   SUBMENU:=VPN
   URL:=https://www.wireguard.io
   MAINTAINER:=Baptiste Jonglez <openwrt@bitsofnetworks.org>, \
+              Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk> \
               Dan Luedtke <mail@danrl.com>, \
               Jason A. Donenfeld <Jason@zx2c4.com>
 endef


### PR DESCRIPTION
Maintainer: @zx2c4 
Compile & run tested: ar71xx: archer c7 v2

Description:

wireguard: bump to release 0.0.20170907

Add myself as another co-maintainer of the package.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>

Aug 10 09:25:58 <KevinDB>       Generated a PR to bump wireguard package on LEDE/openwrt https://github.com/openwrt/packages/pull/4687
Aug 10 13:44:47 <zx2c4> KevinDB: thanks for sending the bump
Aug 10 13:44:49 <zx2c4> thats super helpful
Aug 10 13:45:04 <zx2c4> i sort of hate having to do it myself
Aug 10 13:45:10 <zx2c4> (if you want to totally take over openwrt all the time...)