### PR TITLE
node: delete unnecessary TAB characters at the end of a line

### DIFF
--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -10,4 +10,3 @@
  
    if (homeDir) {
      paths.unshift(path.resolve(homeDir, '.node_libraries'));
-     


### PR DESCRIPTION
Maintainer: @blogic @ianchi
Compile tested: mips_24kc_gcc-6.3.0_musl, LEDE r4797-23317f1
Run tested: none

Description:
Delete unnecessary TAB characters at the end of a line

> Applying ./patches/003-path.patch using plaintext: 
> patching file lib/module.js
> patch unexpectedly ends in middle of line
> patch unexpectedly ends in middle of line

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
