### PR TITLE
treewide: start logger at priority 12

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include  $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.9.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 

--- a/admin/syslog-ng/files/syslog-ng.init
+++ b/admin/syslog-ng/files/syslog-ng.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2006-2016 OpenWrt.org
 
-START=20
+START=12
 PROG=/usr/sbin/syslog-ng
 PROG2=/usr/sbin/syslog-ng-ctl
 

--- a/net/rsyslog/Makefile
+++ b/net/rsyslog/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsyslog
 PKG_VERSION:=8.18.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.rsyslog.com/files/download/rsyslog/

--- a/net/rsyslog/files/rsyslog.init
+++ b/net/rsyslog/files/rsyslog.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2014 OpenWrt.org
 
-START=20
+START=12
 
 USE_PROCD=1
 


### PR DESCRIPTION
Maintainer: @blogic, @MikePetullo, @dubek, @psycho-nico 
Compile tested: x86_64, generic, LEDE head (6be7010)
Run tested: same

Built and installed (via scp/opkg install) all three packages and tested them individually, rebooting each time.

Description:

Set `START` priority to 12 (instead of 20, same as `network`).