### PR TITLE
adblock: bugfix 3.0.1

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.0.0
+PKG_VERSION:=3.0.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: LEDE trunk

Description:
* fix startup issues with backends like dnscrypt-proxy or kresd
  which does not come up without an existing block list
* fix a small 'chown' issue

Signed-off-by: Dirk Brenken <dev@brenken.org>