### PR TITLE
net/mwan3: fix mwan3track initial_state and track_ip order

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.6.5
+PKG_VERSION:=2.6.6
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -77,7 +77,7 @@ case "$ACTION" in
 		else
 			$LOG notice "Starting tracker on interface $INTERFACE (${DEVICE:-unknown})"
 			mwan3_set_iface_hotplug_state $INTERFACE "offline"
-			mwan3_track $INTERFACE $DEVICE "offline" "$src_ip"
+			mwan3_track $INTERFACE $DEVICE "unknown" "$src_ip"
 		fi
 	;;
 	ifdown)

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -460,7 +460,7 @@ mwan3_track()
 
 	mwan3_list_track_ips()
 	{
-		track_ips="$1 $track_ips"
+		track_ips="$track_ips $1"
 	}
 	config_list_foreach $1 track_ip mwan3_list_track_ips
 


### PR DESCRIPTION
Maintainer: me
Compile tested: not needed it is a shell script
Run tested: x86, 64, LEDE

Description:

- Fix an inattention. Without this PR the change which was done in PR https://github.com/openwrt/packages/pull/4792/commits/0c678d39cc336c05693001ab912a4b2a343d2e80 does not make sense!

- Fix target ping orders. Use order as set in /etc/config/mwan3/ track_ip


