### PR TITLE
zip: add host compile

### DIFF
--- a/utils/zip/Makefile
+++ b/utils/zip/Makefile
@@ -21,8 +21,10 @@ PKG_LICENSE:=BSD-4-Clause
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/zip$(PKG_REV)
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)-$(PKG_VERSION)/zip$(PKG_REV)
 PKG_CHECK_FORMAT_SECURITY:=0
 
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/zip
@@ -58,4 +60,14 @@ define Package/zip/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
 endef
 
+define Host/Compile
+	+$(HOST_MAKE_VARS) $(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) -I. -f unix/Makefile generic 
+endef
+
+define Host/Install
+	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/bin/
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/zip $(STAGING_DIR_HOSTPKG)/bin/
+endef
+
+$(eval $(call HostBuild))
 $(eval $(call BuildPackage,zip))


### PR DESCRIPTION
Maintainer: @Noltari 
Compile tested: host Ubuntu 16.04
Run tested:  host Ubuntu 16.04

Description:

Add Host/Compile option to enable it to be used as a building tool for other packages.
It is needed by youtube-dl, as explained in #4823 