### PR TITLE
python,python3: build updates

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -12,7 +12,7 @@ include ./files/python-version.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)
@@ -188,6 +188,16 @@ define Build/Compile
 	$(call Build/Compile/python-pip)
 endef
 
+define Build/InstallMkFiles
+	$(INSTALL_DIR) $(STAGING_DIR)/mk/
+	$(INSTALL_DATA) \
+		./files/python-package.mk \
+		./files/python-host.mk \
+		./files/python-version.mk \
+		./files/python-package-install.sh \
+		$(STAGING_DIR)/mk/
+endef
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/ $(1)/usr/lib/ $(1)/usr/lib/pkgconfig
 	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON_VERSION)/
@@ -206,6 +216,7 @@ define Build/InstallDev
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/config \
 		$(1)/usr/lib/python$(PYTHON_VERSION)/
+	$(call Build/InstallMkFiles)
 endef
 
 PYTHON_BASE_LIB_FILES:= \
@@ -286,19 +297,10 @@ HOST_CONFIGURE_ARGS+= \
 	CONFIG_SITE=
 
 define Host/Install
+	$(call Build/InstallMkFiles)
 	$(MAKE) -C $(HOST_BUILD_DIR) install
-	$(INSTALL_DIR) $(HOST_PYTHON_DIR)/bin/ $(STAGING_DIR)/mk/
+	$(INSTALL_DIR) $(HOST_PYTHON_DIR)/bin/
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/Parser/pgen $(HOST_PYTHON_DIR)/bin/pgen2
-	# Install these mk files in the Host/Install phase ;
-	# The Build/InstallDev rule is activated only for target builds.
-	# But if someone needs only the host Python, then
-	# these files need to be installed in this phase, and not Build/InstallDev
-	$(INSTALL_DATA) \
-		./files/python-package.mk \
-		./files/python-host.mk \
-		./files/python-version.mk \
-		./files/python-package-install.sh \
-		$(STAGING_DIR)/mk/
 endef
 
 $(eval $(call HostBuild))

--- a/lang/python/python/files/python-host.mk
+++ b/lang/python/python/files/python-host.mk
@@ -37,21 +37,26 @@ define HostPython
 	$(HOST_PYTHON_BIN) $(2);
 endef
 
+define host_python_settings
+	ARCH="$(HOST_ARCH)" \
+	CC="$(HOSTCC)" \
+	CCSHARED="$(HOSTCC) $(HOST_FPIC)" \
+	CXX="$(HOSTCXX)" \
+	LD="$(HOSTCC)" \
+	LDSHARED="$(HOSTCC) -shared" \
+	CFLAGS="$(HOST_CFLAGS)" \
+	CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON_INC_DIR)" \
+	LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib" \
+	_PYTHON_HOST_PLATFORM=linux2
+endef
+
 # $(1) => commands to execute before running pythons script
 # $(2) => python script and its arguments
 # $(3) => additional variables
 define Build/Compile/HostPyRunHost
 	$(call HostPython, \
 		$(if $(1),$(1);) \
-		CC="$(HOSTCC)" \
-		CCSHARED="$(HOSTCC) $(HOST_FPIC)" \
-		CXX="$(HOSTCXX)" \
-		LD="$(HOSTCC)" \
-		LDSHARED="$(HOSTCC) -shared" \
-		CFLAGS="$(HOST_CFLAGS)" \
-		CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON_INC_DIR)" \
-		LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib" \
-		_PYTHON_HOST_PLATFORM=linux2 \
+		$(call host_python_settings) \
 		$(3) \
 		, \
 		$(2) \
@@ -63,6 +68,7 @@ endef
 # Note: I shamelessly copied this from Yousong's logic (from python-packages);
 HOST_PYTHON_PIP:=$(STAGING_DIR_HOSTPKG)/bin/pip$(PYTHON_VERSION)
 define host_python_pip_install
+	$(call host_python_settings) \
 	$(HOST_PYTHON_PIP) install \
 		--root=$(1) \
 		--prefix=$(2) \

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -16,7 +16,7 @@ PYTHON_VERSION_MICRO:=$(PYTHON3_VERSION_MICRO)
 PKG_NAME:=python3
 # XXX: reset PKG_RELEASE to 1 only if Python's pip & setuptools versions have also bumped;
 #      otherwise, keep bumping PKG_RELEASE
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -184,6 +184,16 @@ define Build/Compile
 	$(call Build/Compile/python3-pip)
 endef
 
+define Build/InstallMkFiles
+	$(INSTALL_DIR) $(STAGING_DIR)/mk/
+	$(INSTALL_DATA) \
+		./files/python-package.mk \
+		./files/python-host.mk \
+		./files/python-version.mk \
+		./files/python-package-install.sh \
+		$(STAGING_DIR)/mk/
+endef
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/ $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON_VERSION)/
@@ -197,6 +207,7 @@ define Build/InstallDev
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/config-$(PYTHON_VERSION) \
 		$(1)/usr/lib/python$(PYTHON_VERSION)/
+	$(call Build/InstallMkFiles)
 endef
 
 PYTHON3_BASE_LIB_FILES:= \
@@ -274,21 +285,10 @@ define Host/Compile
 endef
 
 define Host/Install
+	$(call Build/InstallMkFiles)
 	$(MAKE) -C $(HOST_BUILD_DIR) install
-
 	$(INSTALL_DIR) $(HOST_PYTHON3_DIR)/bin/ $(STAGING_DIR)/mk/
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/Parser/pgen $(HOST_PYTHON3_DIR)/bin/pgen3
-
-	# Install these mk files in the Host/Install phase ;
-	# The Build/InstallDev rule is activated only for target builds.
-	# But if someone needs only the host Python, then
-	# these files need to be installed in this phase, and not Build/InstallDev
-	$(INSTALL_DATA) \
-		./files/python3-package.mk \
-		./files/python3-host.mk \
-		./files/python3-version.mk \
-		./files/python3-package-install.sh \
-		$(STAGING_DIR)/mk/
 endef
 
 $(eval $(call HostBuild))

--- a/lang/python/python3/files/python3-host.mk
+++ b/lang/python/python3/files/python3-host.mk
@@ -37,21 +37,26 @@ define HostPython3
 	$(HOST_PYTHON3_BIN) $(2);
 endef
 
+define host_python3_settings
+	ARCH="$(HOST_ARCH)" \
+	CC="$(HOSTCC)" \
+	CCSHARED="$(HOSTCC) $(HOST_FPIC)" \
+	CXX="$(HOSTCXX)" \
+	LD="$(HOSTCC)" \
+	LDSHARED="$(HOSTCC) -shared" \
+	CFLAGS="$(HOST_CFLAGS)" \
+	CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON3_INC_DIR)" \
+	LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON3_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib" \
+	_PYTHON_HOST_PLATFORM=linux2
+endef
+
 # $(1) => commands to execute before running pythons script
 # $(2) => python script and its arguments
 # $(3) => additional variables
 define Build/Compile/HostPy3RunHost
 	$(call HostPython3, \
 		$(if $(1),$(1);) \
-		CC="$(HOSTCC)" \
-		CCSHARED="$(HOSTCC) $(HOST_FPIC)" \
-		CXX="$(HOSTCXX)" \
-		LD="$(HOSTCC)" \
-		LDSHARED="$(HOSTCC) -shared" \
-		CFLAGS="$(HOST_CFLAGS)" \
-		CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON3_INC_DIR)" \
-		LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON3_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib" \
-		_PYTHON_HOST_PLATFORM=linux2 \
+		$(call host_python3_settings) \
 		$(3) \
 		, \
 		$(2) \
@@ -63,6 +68,7 @@ endef
 # Note: I shamelessly copied this from Yousong's logic (from python-packages);
 HOST_PYTHON3_PIP:=$(STAGING_DIR_HOSTPKG)/bin/pip$(PYTHON3_VERSION)
 define host_python3_pip_install
+	$(call host_python3_settings) \
 	$(HOST_PYTHON3_PIP) install \
 		--root=$(1) \
 		--prefix=$(2) \


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/lede-project/source/commit/c88770c766fdc5599efc4672bca230017f52e8e4  x86_64
Run tested: N/A

Description:

There was this issue that was reported: https://github.com/openwrt/packages/issues/4829
That one [ tho fixed in the python-pyserial package ] prompted me to enforce the installation of the python mk files in the `Build/InstallDev` rule.

And I've removed the python parts from PR https://github.com/openwrt/packages/pull/4708 to this one.
At least the ones that are in my control I can submit earlier.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>
