### PR TITLE
mwan3: fix interface-bound traffic when interface is offline

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.0.1
+PKG_VERSION:=2.0.2
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -47,13 +47,13 @@ case "$ACTION" in
 		mwan3_create_iface_rules $INTERFACE $DEVICE
 		mwan3_create_iface_iptables $INTERFACE $DEVICE
 		mwan3_create_iface_route $INTERFACE $DEVICE
+		mwan3_set_iface_hotplug_state $INTERFACE "online"
 		mwan3_track $INTERFACE $DEVICE
 		mwan3_set_policies_iptables
 		mwan3_set_user_rules
 	;;
 	ifdown)
-		mwan3_delete_iface_rules $INTERFACE
-		mwan3_delete_iface_route $INTERFACE
+		mwan3_set_iface_hotplug_state $INTERFACE "offline"
 		mwan3_delete_iface_ipset_entries $INTERFACE
 		mwan3_set_policies_iptables
 		mwan3_set_user_rules

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -46,7 +46,6 @@ ifdown()
 		kill $(cat /var/run/mwan3track-$1.pid)
 		rm /var/run/mwan3track-$1.pid
 	fi
-	mwan3_delete_iface_iptables $1
 }
 
 ifup()
@@ -166,6 +165,7 @@ stop()
 	done
 
 	mwan3_lock_clean
+	rm -rf $MWAN3_STATUS_DIR
 }
 
 restart() {


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: ar71xx
Run tested: ar71xx

Description:
This is a backport of 66406f9 to LEDE 17.01 and replaces hotfix 282e900.



