### PR TITLE
adblock: update 3.0.2

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.0.1
+PKG_VERSION:=3.0.2
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -129,19 +129,19 @@ A lot of people already use adblocker plugins within their desktop browsers, but
     * adb\_manmode => do not automatically update block lists during startup, use backups instead (default: '0', disabled)
 
 ## Examples
-**change default dns backend to 'unbound':**
-<pre><code>
+**change default dns backend to 'unbound':**  
+
 Adblock deposits the sorted and filtered block list (adb_list.overall) in '/var/lib/unbound' where unbound can find them in its jail.
 If you use manual configuration for unbound, then just include the following line in your 'server' clause:
-
+<pre><code>
   include: "/var/lib/unbound/adb_list.overall"
 </code></pre>
   
-**change default dns backend to 'named' (bind):**
-<pre><code>
+**change default dns backend to 'named' (bind):**  
+
 Adblock deposits the sorted and filtered block list (adb_list.overall) in '/var/lib/bind' where bind can find them.
 To use the block list please modify the following bind configuration files:
-
+<pre><code>
 change '/etc/bind/named.conf', in the 'options' namespace add:
   response-policy { zone "rpz"; };
 
@@ -162,30 +162,33 @@ create the new file '/etc/bind/db.rpz' and add:
   $INCLUDE /var/lib/bind/adb_list.overall
 </code></pre>
   
-**change default dns backend to 'kresd':**
-<pre><code>
+**change default dns backend to 'kresd':**  
+
 The knot-resolver (kresd) is only available on turris omnia devices. Currently there's no package for kresd in the official LEDE / OpenWrt package repository.
 Adblock deposits the sorted and filtered block list (adb_list.overall) in '/etc/kresd' where kresd can find them.
 To use the block list please create/modify the following kresd configuration files:
+<pre><code>
+TurrisOS > 3.6:
+  edit '/etc/config/resolver' and change / uncomment the following options:
+    forward_upstream '0'
+    list rpz_file '/etc/kresd/adb_list.overall'
 
-edit '/etc/config/resolver' and uncomment the following option:
-  option include_config '/etc/kresd/custom.conf'
+TurrisOS < 3.6:
+  edit '/etc/config/resolver' and change / uncomment the following options:
+   forward_upstream '0'
+   option include_config '/etc/kresd/custom.conf'
 
-in the same file change the 'forward_upstream' option like that:
-  forward_upstream '0'
-
-create '/etc/kresd/custom.conf' and add:
-  policy.add(policy.rpz(policy.DENY, '/etc/kresd/adb_list.overall'))
-  policy.add(policy.all(policy.FORWARD('8.8.8.8')))
-  policy.add(policy.all(policy.FORWARD('8.8.4.4')))
+  create '/etc/kresd/custom.conf' and add:
+    policy.add(policy.rpz(policy.DENY, '/etc/kresd/adb_list.overall'))
+    policy.add(policy.all(policy.FORWARD({'8.8.8.8', '8.8.4.4'})))
 </code></pre>
   
-**change default dns backend to 'dnscrypt-proxy':**
-<pre><code>
+**change default dns backend to 'dnscrypt-proxy':**  
+
 Adblock deposits the sorted and filtered block list (adb_list.overall) by default in '/tmp' where DNSCrypt-Proxy can find them.
 The blacklist option is not supported by default, because DNSCrypt-Proxy is compiled without plugins support.
 Take a custom LEDE build with plugins support to use this feature:
-
+<pre><code>
 edit '/etc/config/dnscrypt-proxy' and add the following option per dnscrypt-proxy instance:
   list blacklist 'domains:/tmp/adb_list.overall'
 </code></pre>

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -10,8 +10,8 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-adb_ver="3.0.1"
-adb_sysver="$(ubus -S call system board | jsonfilter -e '@.release.description')"
+adb_ver="3.0.2"
+adb_sysver="unknown"
 adb_enabled=0
 adb_debug=0
 adb_manmode=0
@@ -34,7 +34,22 @@ adb_rc=0
 #
 f_envload()
 {
-    local dns_up cnt=0
+    local dns_up sys_call sys_desc sys_model sys_ver cnt=0
+
+    # get system information
+    #
+    sys_call="$(ubus -S call system board 2>/dev/null)"
+    if [ -n "${sys_call}" ]
+    then
+        sys_desc="$(printf '%s' "${sys_call}" | jsonfilter -e '@.release.description')"
+        sys_model="$(printf '%s' "${sys_call}" | jsonfilter -e '@.model')"
+        sys_ver="$(cat /etc/turris-version 2>/dev/null)"
+        if [ -n "${sys_ver}" ]
+        then
+            sys_desc="${sys_desc}/${sys_ver}"
+        fi
+        adb_sysver="${sys_model}, ${sys_desc}"
+    fi
 
     # source in system libraries
     #


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: LEDE trunk & Turris 3.8

Description:
* better system information
* several kresd related documentation fixes

Signed-off-by: Dirk Brenken <dev@brenken.org>