### PR TITLE
noddos: Don't create /var/lib/noddos in Makefile (#4837)

### DIFF
--- a/net/noddos/Makefile
+++ b/net/noddos/Makefile
@@ -9,15 +9,13 @@ include $(TOPDIR)/rules.mk
 
 # Name and release number of this package
 PKG_NAME:=noddos
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPLv3
 
 PKG_SOURCE_VERSION:=0.4.1
 PKG_SOURCE_URL:=https://github.com/noddos/noddos/releases/download/v$(PKG_SOURCE_VERSION)/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz
 PKG_HASH:=f676b1c7d9aa6496184b73eacbbfe27b4f54e53c726769ef9ceeeda9c31a7fa3
-
-PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
 
@@ -47,7 +45,6 @@ define Package/noddos/install
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/etc/noddos
-	$(INSTALL_DIR) $(1)/var/lib/noddos
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/noddos $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tools/getnoddosdeviceprofiles $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tools/makenoddoscert.sh $(1)/usr/bin


### PR DESCRIPTION
Signed-off-by: Steven Hessing <steven.hessing@gmail.com>

Maintainer: Steven Hessing / @StevenHessing
Compile tested: arm_cortex-a9_vfpv3, Linksys WRT1200 AC,17.01.2
Run tested: arm_cortex-a9_vfpv3, Linksys WRT1200 AC,17.01.2, test for daemon running normally

Description:
One-liner fix for compile failure [openwrt/packages] noddos: don't create /var/lib/noddos at build time (#4837)