### PR TITLE
pciutils: don't generate warning if file doesn't exist

### DIFF
--- a/utils/pciutils/Makefile
+++ b/utils/pciutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pciutils
 PKG_VERSION:=3.5.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/utils/pciutils
@@ -37,11 +37,20 @@ define Package/pciutils/description
  of PCI devices
 endef
 
-define Package/pciutils/postinst
-#!/bin/sh
-[ -z "$${IPKG_INSTROOT}" ] || \
-(cd $${PKG_ROOT}/usr/share; $${PKG_ROOT}/usr/sbin/update-pciids; rm pci.ids.gz.old)
-exit 0
+PCI_IDS_REV:=91cfa8a0c994634ba9a4a8639aa2ac6dff8453b9
+PCI_IDS_FILE:=pci.ids.$(PCI_IDS_REV)
+define Download/pci_ids
+  FILE:=$(PCI_IDS_FILE)
+  URL_FILE:=pci.ids
+  URL:=@GITHUB/pciutils/pciids/$(PCI_IDS_REV)
+  HASH:=798528092d1c58eeac99c6505033ec4ce8fe3e19d7e0c41b06790d58753a89b6
+endef
+$(eval $(call Download,pci_ids))
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(RM) $(PKG_BUILD_DIR)/pci.ids
+	$(CP) $(DL_DIR)/$(PCI_IDS_FILE) $(PKG_BUILD_DIR)/pci.ids
 endef
 
 MAKE_FLAGS += \


### PR DESCRIPTION
Maintainer: @Noltari 
Compile tested: x86_64, generic, HEAD (c64984c)
Run tested: same

Did a build from scratch.  No warnings this time.

Description:

Got tired of seeing:

```
make[3]: Entering directory '/home/philipp/bertram/lede'
make[3]: Nothing to be done for 'package/preconfig'.
make[3]: Leaving directory '/home/philipp/bertram/lede'
cp -fpR /home/philipp/bertram/lede/build_dir/target-x86_64_musl_powercode-bmu/root-x86 /home/philipp/bertram/lede/build_dir/target-x86_64_musl_powercode-bmu/root.orig-x86
update-pciids: /usr/share/misc/pci.ids.new is read-only
rm: cannot remove 'pci.ids.gz.old': No such file or directory
sed -i "s/Installed-Time: .*/Installed-Time: 1505529140/" /home/philipp/bertram/lede/build_dir/target-x86_64_musl_powercode-bmu/root-x86/usr/lib/opkg/status
rm -rf /home/philipp/bertram/lede/build_dir/target-x86_64_musl_powercode-bmu/root-x86/tmp/*
rm -f /home/philipp/bertram/lede/build_dir/target-x86_64_musl_powercode-bmu/root-x86/usr/lib/opkg/lists/*
rm -f /home/philipp/bertram/lede/build_dir/target-x86_64_musl_powercode-bmu/root-x86/usr/lib/opkg/info/*.postinst*
rm -f /home/philipp/bertram/lede/build_dir/target-x86_64_musl_powercode-bmu/root-x86/usr/lib/opkg/info/*.prerm*
make[2]: Leaving directory '/home/philipp/bertram/lede'
```