### PR TITLE
net/inadyn: Update to 2.2

### DIFF
--- a/net/inadyn/Makefile
+++ b/net/inadyn/Makefile
@@ -8,18 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=inadyn
-PKG_VERSION=2017-02-02
+PKG_VERSION=2.2
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Daniel Engberg <daniel.engberg.lists@pyret.net>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/troglobit/inadyn
-PKG_SOURCE_SUBDIR=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=3b9ae1c22f96194232cc86ded33af9e0a1602af2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MIRROR_HASH:=9db6cd8d2b421d8bc61d4ae60c8215a86d73657746a1b06d79f4fbfd79734f6e
+PKG_SOURCE_URL:=https://github.com/troglobit/inadyn/releases/download/v$(PKG_VERSION)
+PKG_HASH:=27aed84a3d04591540b01ef91a5af4b02cbd0e0c20db36a2660453780bd645f6
 
 PKG_FIXUP:=autoreconf
 
@@ -46,7 +43,6 @@ CONFIGURE_ARGS += --enable-shared --disable-static --enable-openssl
 
 define Package/inadyn/install
 	$(INSTALL_DIR) $(1)/etc
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/examples/dyndns.conf $(1)/etc/inadyn.conf
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/inadyn $(1)/usr/sbin/
 endef


### PR DESCRIPTION
Maintainer: myself
Compile tested: mvebu, Linksys WRT3200ACM, LEDE trunk
Run tested: mvebu, Linksys WRT3200ACM, LEDE trunk

Description:
Update inadyn to 2.2
Switch to release tarball
Remove example file from package

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>