### PR TITLE
ruby: bump to 2.4.2

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,15 +11,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=2.4.1
+PKG_VERSION:=2.4.2
 PKG_RELEASE:=1
 
 # First two numbes
 PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=4fc8a9992de3e90191de369270ea4b6c1b171b7941743614cc50822ddc1fe654
+PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
+PKG_HASH:=748a8980d30141bd1a4124e11745bb105b436fb1890826e0d2b9ea31af27f735
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING

--- a/lang/ruby/patches/010-configure-2.4.2.patch
+++ b/lang/ruby/patches/010-configure-2.4.2.patch
@@ -1,0 +1,40 @@
+diff -pU3 a/configure b/configure
+--- a/configure	2017-09-14 21:52:19.000000000 +0900
++++ b/configure	2017-09-15 07:03:12.000000000 +0900
+@@ -10614,6 +10614,7 @@ fi
+ ac_res=$ac_cv_search___gmpz_init
+ if test "$ac_res" != no; then :
+   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
++  $as_echo "#define HAVE_LIBGMP 1" >>confdefs.h
+ 
+ fi
+ 
+@@ -10683,6 +10684,7 @@ fi
+ ac_res=$ac_cv_search_malloc_conf
+ if test "$ac_res" != no; then :
+   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
++  $as_echo "#define HAVE_LIBJEMALLOC 1" >>confdefs.h
+ 
+ else
+   with_jemalloc=no
+diff -pU3 a/configure.in b/configure.in
+--- a/configure.in	2017-08-04 23:39:29.000000000 +0900
++++ b/configure.in	2017-09-15 07:20:40.000000000 +0900
+@@ -1403,13 +1403,15 @@ AC_ARG_WITH([gmp],
+ AS_IF([test "x$with_gmp" != xno],
+   [AC_CHECK_HEADERS(gmp.h)
+    AS_IF([test "x$ac_cv_header_gmp_h" != xno],
+-     AC_SEARCH_LIBS([__gmpz_init], [gmp]))])
++     AC_SEARCH_LIBS([__gmpz_init], [gmp],
++       [AC_DEFINE(HAVE_LIBGMP, 1)]))])
+ 
+ AC_ARG_WITH([jemalloc],
+   [AS_HELP_STRING([--with-jemalloc],[use jemalloc allocator])],
+   [with_jemalloc=$withval], [with_jemalloc=no])
+ AS_IF([test "x$with_jemalloc" = xyes],[
+-  AC_SEARCH_LIBS([malloc_conf], [jemalloc], [], [with_jemalloc=no])
++  AC_SEARCH_LIBS([malloc_conf], [jemalloc],
++    [AC_DEFINE(HAVE_LIBJEMALLOC, 1)], [with_jemalloc=no])
+   AC_CHECK_HEADER(jemalloc/jemalloc.h, [
+     AC_DEFINE(RUBY_ALTERNATIVE_MALLOC_HEADER, [<jemalloc/jemalloc.h>])
+   ])


### PR DESCRIPTION
This release contains some security fixes.

 CVE-2017-0898: Buffer underrun vulnerability in Kernel.sprintf
 CVE-2017-10784: Escape sequence injection vulnerability in the Basic authentication of WEBrick
 CVE-2017-14033: Buffer underrun vulnerability in OpenSSL ASN1 decode
 CVE-2017-14064: Heap exposure in generating JSON
 Multiple vulnerabilities in RubyGems
 Update bundled libyaml to version 0.1.7.

And many other bugfix.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me
Compile tested: Lede Trunk r4858 on x86 and ar71xx
Run tested: Lede Trunk r4858 on x86

Description:
