### PR TITLE
chrony: update to 3.2

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
-PKG_VERSION:=3.1
-PKG_RELEASE:=2
+PKG_VERSION:=3.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.tuxfamily.org/chrony/
-PKG_HASH:=9d9107dcdb7768a03dc129d33b2a7a25f1eea2f5620bc85eb00cfea07c1b6075
+PKG_HASH:=329f6718dd8c3ece3eee78be1f4821cbbeb62608e7d23f25da293cfa433c4116
 
 PKG_MAINTAINER:=Miroslav Lichvar <mlichvar0@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/net/chrony/patches/001-freebind_uclibc.patch
+++ b/net/chrony/patches/001-freebind_uclibc.patch
@@ -1,9 +1,9 @@
 diff --git a/sysincl.h b/sysincl.h
-index 30e9b48..8fe16c0 100644
+index a9e4da0..e2a6e78 100644
 --- a/sysincl.h
 +++ b/sysincl.h
-@@ -70,4 +70,8 @@
- #include <arpa/inet.h>
+@@ -80,4 +80,8 @@
+ #include <sys/random.h>
  #endif
  
 +#if defined(LINUX) && !defined(IP_FREEBIND)


### PR DESCRIPTION
Update to the latest upstream release.
Changelog: https://git.tuxfamily.org/chrony/chrony.git/plain/NEWS

Signed-off-by: Miroslav Lichvar <mlichvar0@gmail.com>

Maintainer: me
Compile tested: ar71xx, WDR3600+RB711, LEDE 17.01
Run tested: same