### PR TITLE
net/rp-pppoe: fix typo in init script

### DIFF
--- a/net/rp-pppoe/Makefile
+++ b/net/rp-pppoe/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rp-pppoe
 PKG_VERSION:=3.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Daniel Dickinson <lede@cshore.thecshore.com>
 PKG_LICENSE:=LGPL-2.0+
 

--- a/net/rp-pppoe/Makefile
+++ b/net/rp-pppoe/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rp-pppoe
 PKG_VERSION:=3.12
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Daniel Dickinson <lede@cshore.thecshore.com>
 PKG_LICENSE:=LGPL-2.0+
 

--- a/net/rp-pppoe/files/pppoe-relay.init
+++ b/net/rp-pppoe/files/pppoe-relay.init
@@ -23,12 +23,11 @@ pppoe_triggers() {
 
 pppoe_relay_instance() {
     local cfg="$1"
-    local interface server_interfaces client_interfaces both_interfaces maxsessions maxsesssions timeout OPTIONS
+    local interface server_interfaces client_interfaces both_interfaces maxsessions timeout OPTIONS
     config_get server_interfaces "$cfg" server_interface
     config_get client_interfaces "$cfg" client_interface
     config_get both_interfaces "$cfg" both_interfaces
     config_get maxsessions "$cfg" maxsessions
-    config_get maxsesssions "$cfg" maxsesssions
     config_get timeout "$cfg" timeout
     config_get_bool use_non_uci_config "$cfg" use_non_uci_config 0
 
@@ -46,7 +45,6 @@ pppoe_relay_instance() {
 	    append OPTIONS "-B $interface"
 	done
 	[ -n "$maxsessions" ] && append OPTIONS "-n $maxsessions"
-	[ -n "$maxsesssions" ] && append OPTIONS "-n $maxsesssions"
 	[ -n "$timeout" ] && append OPTIONS "-i $timeout"
     fi
 

--- a/net/rp-pppoe/files/pppoe-relay.init
+++ b/net/rp-pppoe/files/pppoe-relay.init
@@ -23,11 +23,12 @@ pppoe_triggers() {
 
 pppoe_relay_instance() {
     local cfg="$1"
-    local interface server_interfaces client_interfaces both_interfaces maxsessions timeout OPTIONS
+    local interface server_interfaces client_interfaces both_interfaces maxsessions maxsesssions timeout OPTIONS
     config_get server_interfaces "$cfg" server_interface
     config_get client_interfaces "$cfg" client_interface
     config_get both_interfaces "$cfg" both_interfaces
-    config_get maxsessions "$cfg" maxsesssions
+    config_get maxsessions "$cfg" maxsessions
+    config_get maxsesssions "$cfg" maxsesssions
     config_get timeout "$cfg" timeout
     config_get_bool use_non_uci_config "$cfg" use_non_uci_config 0
 
@@ -44,6 +45,7 @@ pppoe_relay_instance() {
 	for interface in $both_interfaces; do
 	    append OPTIONS "-B $interface"
 	done
+	[ -n "$maxsessions" ] && append OPTIONS "-n $maxsessions"
 	[ -n "$maxsesssions" ] && append OPTIONS "-n $maxsesssions"
 	[ -n "$timeout" ] && append OPTIONS "-i $timeout"
     fi

--- a/net/rp-pppoe/files/pppoe-server.init
+++ b/net/rp-pppoe/files/pppoe-server.init
@@ -12,11 +12,12 @@ pppoe_triggers() {
 
 pppoe_instance() {
 	local cfg="$1"
-	local interface ac_name service_names service_name maxsessionsperpeer localip firstremoteip maxsessions optionsfiles randomsession unit offset timeout mss sync OPTIONS
+	local interface ac_name service_names service_name maxsessionsperpeer maxsesssionsperpeer localip firstremoteip maxsessions optionsfiles randomsession unit offset timeout mss sync OPTIONS
 	config_get interface "$cfg" interface
 	config_get ac_name "$cfg" ac_name
 	config_get service_names "$cfg" service_name
-	config_get maxsessionsperpeer "$cfg" maxsesssionsperpeer
+	config_get maxsessionsperpeer "$cfg" maxsessionsperpeer
+	config_get maxsesssionsperpeer "$cfg" maxsesssionsperpeer
 	config_get localip "$cfg" localip
 	config_get firstremoteip "$cfg" firstremoteip
 	config_get maxsessions "$cfg" maxsessions
@@ -38,6 +39,7 @@ pppoe_instance() {
 		append OPTIONS "-S $service_name"
 	    done
 	    append OPTIONS "-I $interface"
+	    [ -n "$maxsessionsperpeer" ] && append OPTIONS "-x $maxsessionsperpeer"
 	    [ -n "$maxsesssionsperpeer" ] && append OPTIONS "-x $maxsesssionsperpeer"
 	    [ -n "$localip" ] && append OPTIONS "-L $localip"
 	    [ -n "$firstremoteip" ] && append OPTIONS "-R $firstremoteip"

--- a/net/rp-pppoe/files/pppoe-server.init
+++ b/net/rp-pppoe/files/pppoe-server.init
@@ -12,12 +12,11 @@ pppoe_triggers() {
 
 pppoe_instance() {
 	local cfg="$1"
-	local interface ac_name service_names service_name maxsessionsperpeer maxsesssionsperpeer localip firstremoteip maxsessions optionsfiles randomsession unit offset timeout mss sync OPTIONS
+	local interface ac_name service_names service_name maxsessionsperpeer localip firstremoteip maxsessions optionsfiles randomsession unit offset timeout mss sync OPTIONS
 	config_get interface "$cfg" interface
 	config_get ac_name "$cfg" ac_name
 	config_get service_names "$cfg" service_name
 	config_get maxsessionsperpeer "$cfg" maxsessionsperpeer
-	config_get maxsesssionsperpeer "$cfg" maxsesssionsperpeer
 	config_get localip "$cfg" localip
 	config_get firstremoteip "$cfg" firstremoteip
 	config_get maxsessions "$cfg" maxsessions
@@ -40,7 +39,6 @@ pppoe_instance() {
 	    done
 	    append OPTIONS "-I $interface"
 	    [ -n "$maxsessionsperpeer" ] && append OPTIONS "-x $maxsessionsperpeer"
-	    [ -n "$maxsesssionsperpeer" ] && append OPTIONS "-x $maxsesssionsperpeer"
 	    [ -n "$localip" ] && append OPTIONS "-L $localip"
 	    [ -n "$firstremoteip" ] && append OPTIONS "-R $firstremoteip"
 	    [ -n "maxsessions" ] && append OPTIONS "-N $maxsessions"


### PR DESCRIPTION
Maintainer: @cshoredaniel 

In the initscripts, 'maxsessions' is sometimes spelled with three 's' in a row.
Currently, the correct parameter is not appended to the cmdline of the server/relay
due to this typo.