### PR TITLE
admin/netdata: Update to 1.8.0

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.7.0
+PKG_VERSION:=1.8.0
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Daniel Engberg <daniel.engberg.lists@pyret.net>
 PKG_LICENSE:=GPL-3.0
@@ -16,7 +16,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/firehol/netdata/releases/download/v$(PKG_VERSION)
-PKG_HASH:=7fa23ceaccf6548fba165cd4839ce694784b2fcf7f90de0a0162b9c529805fc0
+PKG_HASH:=1624a3b02f07dc8881b8edd5899049d4d3d53e485424ffb2fb65a322e2ff82c3
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
@@ -35,6 +35,9 @@ define Package/netdata/description
   netdata is a highly optimized Linux daemon providing real-time performance
   monitoring for Linux systems, applications and SNMP devices over the web.
 endef
+
+TARGET_CFLAGS += -ffunction-sections -fdata-sections
+TARGET_LDFLAGS += -Wl,--gc-sections
 
 CONFIGURE_ARGS += --with-zlib --with-math --disable-x86-sse --disable-lto
 
@@ -58,8 +61,6 @@ define Package/netdata/install
 	mkdir -p $(1)/usr/lib/netdata
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/netdata $(1)/usr/lib
 	rm $(1)/usr/lib/netdata/python.d/python-modules-installer.sh
-	rm -rf $(1)/usr/lib/netdata/python.d/python_modules/pyyaml2
-	rm -rf $(1)/usr/lib/netdata/python.d/python_modules/pyyaml3
 	chmod 4755 $(1)/usr/lib/netdata/plugins.d/apps.plugin
 	mkdir -p $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/netdata.init $(1)/etc/init.d/netdata


### PR DESCRIPTION
Maintainer: myself
Compile tested: ar71xx, TP-Link WDR-3600, LEDE trunk
Run tested: ar71xx, TP-Link WDR-3600, LEDE trunk

Description:
Update netdata to 1.8.0
Add back python modules, these are tweaked (modified) for netdata
Add additional flags to slim down the binary size
 
Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>
