### PR TITLE
noddos: Noddos v0.5.0 with mDNS / DNS-SD support

### DIFF
--- a/net/noddos/Makefile
+++ b/net/noddos/Makefile
@@ -9,13 +9,13 @@ include $(TOPDIR)/rules.mk
 
 # Name and release number of this package
 PKG_NAME:=noddos
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 PKG_LICENSE:=GPLv3
 
-PKG_SOURCE_VERSION:=0.4.1
+PKG_SOURCE_VERSION:=0.5.0
 PKG_SOURCE_URL:=https://github.com/noddos/noddos/releases/download/v$(PKG_SOURCE_VERSION)/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz
-PKG_HASH:=f676b1c7d9aa6496184b73eacbbfe27b4f54e53c726769ef9ceeeda9c31a7fa3
+PKG_HASH:=61119d76bbc1e7de74c3f3cd58fe7048581a1653dbffa03ae4215163b5221b18
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
 
@@ -28,7 +28,7 @@ define Package/noddos
 	CATEGORY:=Network
 	TITLE:=noddos -- device-aware cloud-powered firewall
 	URL:=https://www.noddos.io/
-	DEPENDS:=+libstdcpp +libnetfilter-conntrack +libcurl +libopenssl +openssl-util +ca-bundle +ca-certificates +wget +bzip2 +libtins +ipset
+	DEPENDS:=+libstdcpp +libnetfilter-conntrack +libcurl +libopenssl +openssl-util +ca-bundle +ca-certificates +wget +bzip2 +libtins +ipset +libpthread
 endef
 
 define Package/noddos/description


### PR DESCRIPTION
Maintainer: Steven Hessing / @StevenHessing
Compile tested: (mvebu, Linksys WRT1200AC, OpenWRT/LEDE 17.01.2)
Run tested: (mvebu, Linksys WRT1200AC, OpenWRT/LEDE 17.01.2, service up and running)

Description:
Noddos v0.5.0 rounds out the support for service discovery on the LAN by adding support for mDNS, DNS-SD and WS-Discovery.

Signed-off-by: Steven Hessing <steven.hessing@gmail.com>
