### PR TITLE
file: fix install section

### DIFF
--- a/libs/file/Makefile
+++ b/libs/file/Makefile
@@ -9,10 +9,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=file
 PKG_VERSION:=5.25
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=ftp://ftp.astron.com/pub/file/
+PKG_SOURCE_URL:=https://sources.lede-project.org/ \
+	http://pkgs.fedoraproject.org/lookaside/pkgs/file/ \
+	http://download.openpkg.org/components/cache/file/ \
+	ftp://ftp.astron.com/pub/file/
 PKG_HASH:=3735381563f69fb4239470b8c51b876a80425348b8285a7cded8b61d6b890eca
 
 PKG_LICENSE:=BSD-2c
@@ -27,7 +30,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/file/Default
   TITLE:=File type determination
   URL:=ftp://ftp.astron.com/pub/file/
-  MAINTAINER:=Luka Perkov <luka@openwrt.org>
+  MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
 endef
 
 define Package/file
@@ -90,7 +93,7 @@ endef
 
 define Package/libmagic/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libmagic.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmagic.so.* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,file))


### PR DESCRIPTION
Maintainer: Marko Ratkaj <marko.ratkaj@sartura.hr> / @ratkaj
Compile tested: LEDE master, mvebu
Run tested: LEDE master, mvebu, Linksys wrt3200

Mantainer changed to me with permission from Luka Perkov @lperkov 

Description:
By using $(CP) instead of $(INSTALL_DATA) we preserve symbolic links and
by doing so we don't copy the same file multiple times. This saves some
space.