### PR TITLE
Fixing sha256 checksum

### DIFF
--- a/libs/protobuf/Makefile
+++ b/libs/protobuf/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-cpp-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/google/protobuf/releases/download/v$(PKG_VERSION)
-PKG_HASH:=578a2589bf9258adb03245dec5d624b61536867ebb732dbb8aeb30d96b0ada1f
+PKG_HASH:=5e2587dea2f9287885e3b04d3a94ed4e8b9b2d2c5dd1f0032ceef3ea1d153bd7
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Apparently the sha256 checksum for this package has been changed that causes compilation of this package impossible. 
https://github.com/google/protobuf/releases/download/v3.3.0/protobuf-cpp-3.3.0.tar.gz

$sha256sum protobuf-cpp-3.3.0.tar.gz 
5e2587dea2f9287885e3b04d3a94ed4e8b9b2d2c5dd1f0032ceef3ea1d153bd7  protobuf-cpp-3.3.0.tar.gz
