### PR TITLE
tor: update to version 0.2.9.12

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.2.9.11
+PKG_VERSION:=0.2.9.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=c1959bebff9a546a54cbedb58c8289a42441991af417d2d16f7b336be8903221
+PKG_HASH:=6e7466625d53812f23c2ad60a873c5855f63f756fde0fc5cbeda8d32cee1086b
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
 PKG_LICENSE_FILES:=LICENSE
 


### PR DESCRIPTION
Maintainer: me
Compile tested: lantiq
Run tested: lantiq

This fixes the TROVE-2017-008 (CVE-2017-0380) security problem.