### PR TITLE
port-mirror: bump to v1.4.3

### DIFF
--- a/net/port-mirroring/Makefile
+++ b/net/port-mirroring/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=port-mirroring
-PKG_VERSION:=1.4.2
+PKG_VERSION:=1.4.3
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Mike Maraya <mike.maraya@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
@@ -16,7 +16,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_URL:=git://github.com/mmaraya/port-mirroring.git
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=f6ead68b7760fa86e8da73ac1e062349f243ac93
+PKG_SOURCE_VERSION:=3e03191a877db260a261b0e28740fdf90409f86b
 PKG_FIXUP:=autoreconf
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 

--- a/net/port-mirroring/Makefile
+++ b/net/port-mirroring/Makefile
@@ -14,9 +14,9 @@ PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=git://github.com/mmaraya/port-mirroring.git
+PKG_SOURCE_URL:=git://github.com/splatch/port-mirroring.git
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=3e03191a877db260a261b0e28740fdf90409f86b
+PKG_SOURCE_VERSION:=7fb9cac2e0d63aa28fadc3f1752a7c64b1740051
 PKG_FIXUP:=autoreconf
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
@@ -27,7 +27,7 @@ define Package/port-mirroring
 	CATEGORY:=Network
 	DEPENDS:=+libpcap +libpthread
 	TITLE:=Copy network packets with optional support for TaZmen Sniffer Protocol (TZSP) 
-	URL:=https://github.com/mmaraya/port-mirroring
+	URL:=https://github.com/splatch/port-mirroring
 	MENU:=1
 endef
 


### PR DESCRIPTION
Maintainer: me / @splatch
Compile tested: N/A
Run tested: N/A

Description: There are couple of bug fixes in v1.4.3 declared by Mike which are not available to LEDE yet. This patch just moves package to latest available tag.

Sadly, I failed to build package and test it locally (yet).