### PR TITLE
minidlna: add allow wide links option

### DIFF
--- a/multimedia/minidlna/Makefile
+++ b/multimedia/minidlna/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=minidlna
 PKG_VERSION:=1.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=@SF/minidlna
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/multimedia/minidlna/files/minidlna.config
+++ b/multimedia/minidlna/files/minidlna.config
@@ -7,6 +7,7 @@ config minidlna config
 	option log_dir '/var/log'
 	option inotify '1'
 	option enable_tivo '0'
+	option wide_links '0'
 	option strict_dlna '0'
 	option presentation_url ''
 	option notify_interval '900'

--- a/multimedia/minidlna/files/minidlna.init
+++ b/multimedia/minidlna/files/minidlna.init
@@ -59,6 +59,7 @@ minidlna_create_config() {
 	minidlna_cfg_addstr $cfg log_dir
 	minidlna_cfg_addbool $cfg inotify '1'
 	minidlna_cfg_addbool $cfg enable_tivo '0'
+	minidlna_cfg_addbool $cfg wide_links '0'
 	minidlna_cfg_addbool $cfg strict_dlna '0'
 	minidlna_cfg_addstr $cfg album_art_names
 	minidlna_cfg_addstr $cfg presentation_url


### PR DESCRIPTION
Some users might create a minidlna root with symlinks
to shared locations. While this could potentially create
a vulnerability, the option should be available to allow
users to do this should they choose to.

wide_links=no : (default) no content served + error message
 [timestamp] upnphttp.c:1366: error: Rejecting wide link X

wide_links=yes : content served, no error messages

Signed-off-by: James Christopher Adduono <jc@adduono.com>
-------------------------------

Maintainer: No idea
Compile tested: armhf, R7800, LEDE 4904, LEDE GCC 5.4 and 7.2.0
Run tested: Streaming videos, music, pictures - pass

Description: above