### PR TITLE
[lede-17.01] bluez: fix CVE-2017-1000250

### DIFF
--- a/utils/bluez/Makefile
+++ b/utils/bluez/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bluez
 PKG_VERSION:=5.38
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/bluetooth/

--- a/utils/bluez/patches/202-CVE-2017-1000250.patch
+++ b/utils/bluez/patches/202-CVE-2017-1000250.patch
@@ -1,0 +1,13 @@
+diff --git a/src/sdpd-request.c b/src/sdpd-request.c
+index 1eefdce..318d044 100644
+--- a/src/sdpd-request.c
++++ b/src/sdpd-request.c
+@@ -917,7 +917,7 @@ static int service_search_attr_req(sdp_req_t *req, sdp_buf_t *buf)
+ 	} else {
+ 		/* continuation State exists -> get from cache */
+ 		sdp_buf_t *pCache = sdp_get_cached_rsp(cstate);
+-		if (pCache) {
++		if (pCache && cstate->cStateValue.maxBytesSent < pCache->data_size) {
+ 			uint16_t sent = MIN(max, pCache->data_size - cstate->cStateValue.maxBytesSent);
+ 			pResponse = pCache->data;
+ 			memcpy(buf->data, pResponse + cstate->cStateValue.maxBytesSent, sent);


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: mips_24kc_gcc-6.3.0_musl-1.1.16, LEDE 17.01 r3520-86f0e8b
Run tested: none

Description:
Fix for CVE-2017-1000250 (part of the recently announced BlueBorne vulnerabilities).

https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/?id=9e009647b14e810e06626dde7f1bb9ea3c375d09

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
