### PR TITLE
noddos: bump up to noddos v0.5.1

### DIFF
--- a/net/noddos/Makefile
+++ b/net/noddos/Makefile
@@ -11,11 +11,12 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=noddos
 PKG_RELEASE:=1
 PKG_LICENSE:=GPLv3
+PKG_MAINTAINER:=Steven Hessing <steven.hessing@gmail.com>
 
-PKG_SOURCE_VERSION:=0.5.0
+PKG_SOURCE_VERSION:=0.5.1
 PKG_SOURCE_URL:=https://github.com/noddos/noddos/releases/download/v$(PKG_SOURCE_VERSION)/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz
-PKG_HASH:=61119d76bbc1e7de74c3f3cd58fe7048581a1653dbffa03ae4215163b5221b18
+PKG_HASH:=246bccaf9b4ad589a2884da3bfa449e4adc5fcb951307f1b5a5c2c1bcdef95c1
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
 


### PR DESCRIPTION
Maintainer: Steven Hessing / @StevenHessing
Compile tested: (mvebu / ipq806x, Linksys WRT1200AC / TPLink Archer 2600, 17.01.0/1/2)
Run tested: (Linksys WRT1200AC / TPLink Archer 2600, model, 17.01.2, service up and running for a day)

Description:
Update to [Noddos v0.5.1](https://github.com/noddos/noddos/releases/tag/v0.5.1):
* fixes memory leak in Ipset class usage of libipset
* Improved mDNS TXT handling to support 'mfg' and 'mdl' fields
* Write IPv6 and DhcpHostname to DeviceDump.json file
* No retries for MAC address lookups as we now send out ARP requests
* Hide IP addresses in device reports for the SSDP Location and the mDNS DeviceURL fields
* All but stop hosts showing up in DeviceDump.json with as IP address '0.0.0.0'
* Fix test case for Android clients for DeviceProfile matching
* logging is improved

Signed-off-by: Steven Hessing <steven.hessing@gmail.com>

