### PR TITLE
python,python3: add option to keep egg-info dirs for python packages

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -12,7 +12,9 @@ include ./files/python-version.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=1
+# XXX: reset PKG_RELEASE to 1 only if Python's pip & setuptools versions have also bumped;
+#      otherwise, keep bumping PKG_RELEASE
+PKG_RELEASE:=2
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)

--- a/lang/python/python/files/python-package-install.sh
+++ b/lang/python/python/files/python-package-install.sh
@@ -47,7 +47,8 @@ process_filespec "$src_dir" "$dst_dir" "$filespec" || {
 }
 
 # delete egg-info directories
-find "$dst_dir" -name "*.egg-info" | xargs rm -rf
+[ "$PYTHON_KEEP_EGGINFO" == "1" ] || \
+	find "$dst_dir" -name "*.egg-info" | xargs rm -rf
 
 if [ "$mode" == "sources" ] ; then
 	# Copy only python source files

--- a/lang/python/python/files/python-package.mk
+++ b/lang/python/python/files/python-package.mk
@@ -32,6 +32,8 @@ ifdef CONFIG_USE_MIPS16
   TARGET_CFLAGS += -mno-mips16 -mno-interlink-mips16
 endif
 
+PYTHON_KEEP_EGGINFO ?= 0
+
 define PyPackage
 
   define Package/$(1)-src
@@ -68,11 +70,13 @@ define PyPackage
 	$(call PyPackage/$(1)/install,$$(1))
 	find $(PKG_INSTALL_DIR) -name "*\.exe" | xargs rm -f
 	if [ -e files/python-package-install.sh ] ; then \
+		PYTHON_KEEP_EGGINFO="$(PYTHON_KEEP_EGGINFO)" \
 		$(SHELL) files/python-package-install.sh \
 			"$(PKG_INSTALL_DIR)" "$$(1)" \
 			"$(HOST_PYTHON_BIN)" "$$(2)" \
 			"$$$$$$$$$$(call shvar,PyPackage/$(1)/filespec)" ; \
 	elif [ -e $(STAGING_DIR)/mk/python-package-install.sh ] ; then \
+		PYTHON_KEEP_EGGINFO="$(PYTHON_KEEP_EGGINFO)" \
 		$(SHELL) $(STAGING_DIR)/mk/python-package-install.sh \
 			"$(PKG_INSTALL_DIR)" "$$(1)" \
 			"$(HOST_PYTHON_BIN)" "$$(2)" \

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -16,7 +16,7 @@ PYTHON_VERSION_MICRO:=$(PYTHON3_VERSION_MICRO)
 PKG_NAME:=python3
 # XXX: reset PKG_RELEASE to 1 only if Python's pip & setuptools versions have also bumped;
 #      otherwise, keep bumping PKG_RELEASE
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz

--- a/lang/python/python3/files/python3-package-install.sh
+++ b/lang/python/python3/files/python3-package-install.sh
@@ -47,7 +47,8 @@ process_filespec "$src_dir" "$dst_dir" "$filespec" || {
 }
 
 # delete egg-info directories
-find "$dst_dir" -name "*.egg-info" | xargs rm -rf
+[ "$PYTHON3_KEEP_EGGINFO" == "1" ] || \
+	find "$dst_dir" -name "*.egg-info" | xargs rm -rf
 
 if [ "$mode" == "sources" ] ; then
 	# Copy only python source files

--- a/lang/python/python3/files/python3-package.mk
+++ b/lang/python/python3/files/python3-package.mk
@@ -32,6 +32,8 @@ ifdef CONFIG_USE_MIPS16
   TARGET_CFLAGS += -mno-mips16 -mno-interlink-mips16
 endif
 
+PYTHON3_KEEP_EGGINFO ?= 0
+
 define Py3Package
 
   define Package/$(1)-src
@@ -68,11 +70,13 @@ define Py3Package
 	$(call Py3Package/$(1)/install,$$(1))
 	find $(PKG_INSTALL_DIR) -name "*\.exe" | xargs rm -f
 	if [ -e files/python3-package-install.sh ] ; then \
+		PYTHON3_KEEP_EGGINFO="$(PYTHON3_KEEP_EGGINFO)" \
 		$(SHELL) files/python3-package-install.sh \
 			"$(PKG_INSTALL_DIR)" "$$(1)" \
 			"$(HOST_PYTHON3_BIN)" "$$(2)" \
 			"$$$$$$$$$$(call shvar,Py3Package/$(1)/filespec)" ; \
 	elif [ -e $(STAGING_DIR)/mk/python3-package-install.sh ] ; then \
+		PYTHON3_KEEP_EGGINFO="$(PYTHON3_KEEP_EGGINFO)" \
 		$(SHELL) $(STAGING_DIR)/mk/python3-package-install.sh \
 			"$(PKG_INSTALL_DIR)" "$$(1)" \
 			"$(HOST_PYTHON3_BIN)" "$$(2)" \


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/lede-project/source/commit/5508510e744ce9dfaba23cb8639977f021bd29f9
Run tested: N/A (I checked the ipkg-x86 dir)

-----------------------------------------------------------

That way some python packages can choose
to keep their egg-info dirs, if they want to, or they're needed.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>