### PR TITLE
tinyproxy: add custom options to config

### DIFF
--- a/net/tinyproxy/files/tinyproxy.init
+++ b/net/tinyproxy/files/tinyproxy.init
@@ -4,6 +4,7 @@
 START=50
 
 CFGFILE=/var/etc/tinyproxy.conf
+LN=/etc/tinyproxy_custom.conf
 
 section_enabled() {
 	config_get_bool enabled "$1" 'enabled' 0
@@ -71,7 +72,12 @@ start_proxy() {
 	proxy_list "$1" ConnectPort >> $CFGFILE
 
 	config_foreach write_upstream upstream
-
+        
+	[ -f $LN ] && {
+	    echo "" >> $CFGFILE
+	    cat $LN >> $CFGFILE
+	}
+	
 	service_start /usr/sbin/tinyproxy -c "$CFGFILE"
 }
 


### PR DESCRIPTION
Signed-off-by:  Vladimir Vasiliev `<vvvovan@gmail.com>`
 
Compile tested: ar71xx, tp-link 842n, OpenWRT 15.05.1
Run tested: ar71xx, tp-link 842n, OpenWRT 15.05.1

Description:
Add extra options to configuration file from /etc/tinyproxy_custom.conf
