### PR TITLE
wireguard: bump to release 0.0.20171005 for 17.01

### DIFF
--- a/net/wireguard/Makefile
+++ b/net/wireguard/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 Jason A. Donenfeld <Jason@zx2c4.com>
+# Copyright (C) 2016-2017 Jason A. Donenfeld <Jason@zx2c4.com>
 # Copyright (C) 2016 Baptiste Jonglez <openwrt@bitsofnetworks.org>
 # Copyright (C) 2016-2017 Dan Luedtke <mail@danrl.com>
 #
@@ -11,12 +11,12 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=wireguard
 
-PKG_VERSION:=0.0.20170115
+PKG_VERSION:=0.0.20171005
 PKG_RELEASE:=1
 
 PKG_SOURCE:=WireGuard-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://git.zx2c4.com/WireGuard/snapshot/
-PKG_MD5SUM:=7e5f9f4699a2d4ace90d0df5d81bf0f67205ee08c45b95e0acc379bedef5ffe8
+PKG_HASH:=832a3b7cbb510f6986fd0c3a6b2d86bc75fc9f23b6754d8f46bc58ea8e02d608
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
@@ -33,9 +33,12 @@ include $(INCLUDE_DIR)/package.mk
 define Package/wireguard/Default
   SECTION:=net
   CATEGORY:=Network
-  URL:=https://www.wireguard.io
+  SUBMENU:=VPN
+  URL:=https://www.wireguard.com
   MAINTAINER:=Baptiste Jonglez <openwrt@bitsofnetworks.org>, \
-              Dan Luedtke <mail@danrl.com>
+              Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>, \
+              Dan Luedtke <mail@danrl.com>, \
+              Jason A. Donenfeld <Jason@zx2c4.com>
 endef
 
 define Package/wireguard/Default/description
@@ -44,8 +47,7 @@ define Package/wireguard/Default/description
   more useful than IPSec, while avoiding the massive headache. It intends to
   be considerably more performant than OpenVPN.  WireGuard is designed as a
   general purpose VPN for running on embedded interfaces and super computers
-  alike, fit for many different circumstances.
-  It runs over UDP.
+  alike, fit for many different circumstances. It uses UDP.
 endef
 
 define Package/wireguard
@@ -63,6 +65,10 @@ MAKE_PATH:=src/tools
 define Build/Compile
 	$(MAKE) $(KERNEL_MAKEOPTS) M="$(PKG_BUILD_DIR)/src" modules
 	$(call Build/Compile/Default)
+endef
+
+define Package/wireguard/install
+  true
 endef
 
 define Package/wireguard/description
@@ -94,7 +100,7 @@ define KernelPackage/wireguard
   CATEGORY:=Kernel modules
   SUBMENU:=Network Support
   TITLE:=Wireguard kernel module
-  DEPENDS:=+IPV6:kmod-udptunnel6 +kmod-udptunnel4 +kmod-ipt-hashlimit
+  DEPENDS:=+IPV6:kmod-udptunnel6 +kmod-udptunnel4
   FILES:= $(PKG_BUILD_DIR)/src/wireguard.$(LINUX_KMOD_SUFFIX)
   AUTOLOAD:=$(call AutoProbe,wireguard)
 endef


### PR DESCRIPTION
Maintainer: me and @ldir-EDB0

---

WireGuard is well documented for being an experimental project, not
currently ready to be stabilized. As such, it's important for packagers
to always keep the project up to date in all contexts.

However, it is common for some projects, such as LEDE/OpenWrt to have
stable branches, which don't expect a lot of churn or modification.

The WireGuard that happened to ship with 17.01 is broken and crufty and
shouldn't be used at all. It's highly unlikely that there's anybody out
there even using it; it won't work with anything else.

So, this commit updates the 17.01 package to the latest upstream
version. Because the 17.01 stable branch can't be updated all the time,
it's important that this bump here in this commit is a stable one.

I believe 0.0.20171005 to be a fairly stable snapshot, which should be
suitable for the 17.01 branch. As stated earlier, the 0.0.20170115
currently in this branch is highly problematic. 0.0.20171005 offers
extremely important changes.

I'll continue to send package bumps for 17.01, but only for snapshot
releases that I think fix an important bug or provide a noted increase
in stability, or have similar goals to this commit.

----

@hnyman - this is a PR for what was discussed elsewhere with fixing the wireguard-neglected stable tree.
@ldir-EDB0 - could you put this through some paces on your archer and report back?