### PR TITLE
ffmpeg: 3.2.8 update

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=3.2.7
-PKG_RELEASE:=3
+PKG_VERSION:=3.2.8
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
-PKG_HASH:=28e75fc32485a88035a7ebf0a956a1e5c7e93b440dd4bbd6bc30c7268cf34fe9
+PKG_HASH:=42e7362692318afc666f14378dd445effa9a1b09787504a6ab5811fe442674cd
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Ian Leonard <antonlacon@gmail.com>
 
@@ -420,7 +420,6 @@ ifneq ($(findstring arm,$(CONFIG_ARCH)),)
 	else
 		FFMPEG_CONFIGURE+= --disable-neon
 	endif
-
 endif
 
 ifeq ($(ARCH),x86_64)
@@ -550,8 +549,7 @@ ifeq ($(BUILD_VARIANT),audio-dec)
 	$(call FFMPEG_ENABLE,decoder,$(FFMPEG_AUDIO_DECODERS)) \
 	$(call FFMPEG_ENABLE,demuxer,$(FFMPEG_AUDIO_DEMUXERS)) \
 	$(call FFMPEG_ENABLE,protocol,$(FFMPEG_AUDIO_PROTOCOLS)) \
-	--disable-decoder=pcm_bluray,pcm_dvd \
-
+	--disable-decoder=pcm_bluray,pcm_dvd
 endif
 
 ifeq ($(BUILD_VARIANT),mini)


### PR DESCRIPTION
Maintainer: me & @thess 
Compile tested: mips/ar71xx LEDE trunk
Run tested: same w/ rebuilt minidlna library

Description: Update ffmpeg to 3.2.8.