### PR TITLE
Fixed script startup at boot

### DIFF
--- a/net/p910nd/files/p910nd.init
+++ b/net/p910nd/files/p910nd.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2007 OpenWrt.org
-START=50
+START=99
 USE_PROCD=1
 
 append_bool() {


### PR DESCRIPTION
Set START variable to 99 because script won`t boot on 50