### PR TITLE
p910nd: (fix executing script on boot)

### DIFF
--- a/net/p910nd/files/p910nd.init
+++ b/net/p910nd/files/p910nd.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2007 OpenWrt.org
-START=50
+START=99
 USE_PROCD=1
 
 append_bool() {


### PR DESCRIPTION
Compile tested: (AR71xx, TP-Link MR3220 V2, OpenWRT 15.05.1 Chaos Calmer)
Run tested: (AR71xx, TP-Link MR3220 V2, OpenWRT 15.05.1 Chaos Calmer, tests done)

Description:
Set START variable from 50 runlevel to 99 (not boots on 50).

Signed-off-by: Arsenii Babitckii <a.babitckii@gmail.com>