### PR TITLE
fwknop: Add start-up dependency on network interface for fwknopd.

### DIFF
--- a/net/fwknop/files/fwknopd
+++ b/net/fwknop/files/fwknopd
@@ -1,6 +1,9 @@
 config global
 #	option uci_enabled '1'
 
+config network
+#	option network 'wan'	# takes precedence over config.PCAP_INTF
+
 config access
 	option SOURCE 'ANY'
 	option HMAC_KEY 'CHANGEME'

--- a/net/fwknop/files/fwknopd.init
+++ b/net/fwknop/files/fwknopd.init
@@ -5,49 +5,59 @@
 # list of contributors, see the file 'CREDITS'.
 #
 . /lib/functions.sh
+
+USE_PROCD=1
 START=95
 
 FWKNOPD_BIN=/usr/sbin/fwknopd
 
-start()
+start_service()
 {
-	gen_confs
-	if [ $UCI_ENABLED ]; then
-        	$FWKNOPD_BIN -c /var/etc/fwknopd.conf -a /var/etc/access.conf 
-	else
-        	$FWKNOPD_BIN 
+	generate_configuration
+
+	procd_open_instance
+	procd_set_param command "$FWKNOPD_BIN" --foreground --syslog-enable
+	procd_set_param respawn
+
+	if [ $UCI_ENABLED -eq 1 ]; then
+		procd_append_param command -c /var/etc/fwknopd.conf
+		procd_append_param command -a /var/etc/access.conf
 	fi
 
+	procd_append_param command -i "$DEPEND_IFNAME"
+	procd_set_param netdev "$DEPEND_IFNAME"
+
+	procd_close_instance
 }
 
-stop()
+service_triggers()
 {
-        $FWKNOPD_BIN -K
+	procd_add_reload_trigger "fwknopd"
 }
 
-restart()
+get_bool()
 {
-    stop;
-    sleep 1;
-    start;
+	local _tmp="$1"
+	case "$_tmp" in
+		1|on|true|yes|enabled) _tmp=1;;
+		0|off|false|no|disabled) _tmp=0;;
+		*) _tmp="$2";;
+	esac
+	echo -n "$_tmp"
 }
 
-reload()
-{
-	gen_confs
-        $FWKNOPD_BIN -R
-}
-
-gen_confs()
+generate_configuration()
 {
 	[ -f /tmp/access.conf.tmp ] && rm /tmp/access.conf.tmp
-	if [ -z "$( uci get fwknopd.@config[0].PCAP_INTF )" ]
-	then
-		. /lib/functions/network.sh
-		network_get_physdev device wan
-		uci set fwknopd.@config[0].PCAP_INTF="$device"
-		uci commit
-	fi
+
+	UCI_ENABLED=0
+	DEPEND_IFNAME=
+	local NETWORK=
+	local PCAP_INTF=
+	local USER_CONFIG_PATH=/etc/fwknop/fwknopd.conf
+	local DEFAULT_UCI_NETWORK=wan
+	local DEFAULT_FWKNOPD_IFNAME=eth0
+
 	config_cb() {
 		local type="$1"
 		local name="$2"
@@ -55,7 +65,7 @@ gen_confs()
 			option_cb() {
 				local option="$1"
 				local value="$2"
-				if [ "$option" = "uci_enabled" ] && [ "$value" -eq 1 ] ; then
+				if [ "$option" = "uci_enabled" ] && [ "$(get_bool "$value" 0)" -eq 1 ] ; then
 					> /var/etc/fwknopd.conf
 					> /var/etc/access.conf
                                         chmod 600 /var/etc/fwknopd.conf
@@ -63,11 +73,22 @@ gen_confs()
 					UCI_ENABLED=1
 				fi
 			}
+		elif [ "$type" = "network" ]; then
+			option_cb() {
+				local option="$1"
+				local value="$2"
+				if [ $UCI_ENABLED -eq 1 ] && [ $option = "network" ]; then
+					NETWORK="$value"
+				fi
+			}
 		elif [ "$type" = "config" ]; then
 			option_cb() {
 				local option="$1"
 				local value="$2"
-				if [ $UCI_ENABLED ]; then
+				if [ $UCI_ENABLED -eq 1 ] && [ $option = "PCAP_INTF" ]; then
+					PCAP_INTF="$value"
+					echo "$option $value" >> /var/etc/fwknopd.conf  #writing each option to fwknopd.conf
+				elif [ $UCI_ENABLED -eq 1 ]; then
 					echo "$option $value" >> /var/etc/fwknopd.conf  #writing each option to fwknopd.conf
 				fi
 			}
@@ -80,22 +101,64 @@ gen_confs()
 			option_cb() {
 				local option="$1"
 				local value="$2"
-				if [ $UCI_ENABLED ] && [ $option = "SOURCE" ]; then
+				if [ $UCI_ENABLED -eq 1 ] && [ $option = "SOURCE" ]; then
 					echo "$option $value" >> /var/etc/access.conf  #writing each option to access.conf
 				fi
-				if [ $UCI_ENABLED ] && [ $option != "SOURCE" ]; then
+				if [ $UCI_ENABLED -eq 1 ] && [ $option != "SOURCE" ]; then
 					echo "$option $value" >> /tmp/access.conf.tmp  #writing each option to access.conf
 				fi
 			}
+		else
+			option_cb() { return; }
+			if [ -z "$type" ]; then
+				# Finalize reading
+				if [ -f /tmp/access.conf.tmp ] ; then
+					cat /tmp/access.conf.tmp >> /var/etc/access.conf
+					rm /tmp/access.conf.tmp
+				fi
+			fi
 		fi
 	}
 
 	if [ -f /etc/config/fwknopd ]; then
 		config_load fwknopd
-		if [ -f /tmp/access.conf.tmp ] ; then
-			cat /tmp/access.conf.tmp >> /var/etc/access.conf
-			rm /tmp/access.conf.tmp
-		fi
 	fi
 
+	if [ $UCI_ENABLED -eq 0 ]; then
+		if [ -f $USER_CONFIG_PATH ] ; then
+			# Scan user configuration for PCAP_INTF settings
+			DEPEND_IFNAME="$( sed -ne '/^\s*PCAP_INTF\s\+/ { s/^\s*PCAP_INTF\s\+//; s/\s\+$//; p; q; }' /etc/fwknop/fwknopd.conf )"
+			if [ -n "$DEPEND_IFNAME" ]; then
+				logger -p daemon.debug -t "fwknopd[----]" "Found fwknopd.conf configuration, using PCAP_INTF interface $DEPEND_IFNAME"
+			else
+				logger -p daemon.info -t "fwknopd[----]" "No PCAP_INTF interface specified in fwknopd.conf, fwknopd's default $DEFAULT_FWKNOPD_IFNAME will be used"
+				DEPEND_IFNAME="$DEFAULT_FWKNOPD_IFNAME"
+			fi
+		else
+			logger -p daemon.error -t "fwknopd[----]" "No $USER_CONFIG_PATH found, not starting"
+			exit 1
+		fi
+	elif [ $UCI_ENABLED -eq 1 ]; then
+		if [ -n "$NETWORK" ] && [ -n "$PCAP_INTF" ]; then
+			logger -p daemon.warn -t "fwknopd[----]" "Specified both network and PCAP_INTF. Ignoring PCAP_INTF"
+		elif [ -z "$NETWORK" ] && [ -z "$PCAP_INTF" ]; then
+			# Fallback - compatibility with old script, which used wan interface by default
+			logger -p daemon.info -t "fwknopd[----]" "Neither network, nor PCAP_INTF interface specified, trying network $DEFAULT_UCI_NETWORK"
+			NETWORK="$DEFAULT_UCI_NETWORK"
+		fi
+
+		if [ -n "$NETWORK" ]; then
+			. /lib/functions/network.sh
+			network_get_physdev DEPEND_IFNAME "$NETWORK"
+			if [ -n "$DEPEND_IFNAME" ]; then
+				logger -p daemon.debug -t "fwknopd[----]" "Resolved network $NETWORK as interface $DEPEND_IFNAME"
+			else
+				logger -p daemon.warn -t "fwknopd[----]" "Cannot find interface for network $NETWORK, fwknopd's default $DEFAULT_FWKNOPD_IFNAME will be used"
+				DEPEND_IFNAME="$DEFAULT_FWKNOPD_IFNAME"
+			fi
+		elif [ -n "$PCAP_INTF" ]; then
+			DEPEND_IFNAME="$PCAP_INTF"
+			logger -p daemon.debug -t "fwknopd[----]" "Using configured PCAP_INTF interface $DEPEND_IFNAME"
+		fi
+	fi
 }


### PR DESCRIPTION
Maintainer: @jp-bennett 
Compile tested: ar71xx, tl-wr842n-v3, LEDE git master (from today)
Run tested: ar71xx, tl-wr842n-v3, LEDE git master, tested uci_enabled 0 (with and without fwknopd.conf file), uci_enabled 1 (without network+PCAP_INTF values, with invalid network value, with valid network value, with PCAP_INTF value, with both network+PCAP_INTF values).

Description:
Added new "network" section with option "network", which takes network
interface name.

The start-up is migrated to use procd and depend either on the "network"
interface (after resolving it to a physical device), or on the PCAP_INTF
option from "config" section (usual place for raw interface name for
fwknopd). When the uci_enabled option is disabled, the value of PCAP_INTF
is taken from the user-provided fwknopd.conf.

Also fixed UCI_ENABLED variable evaluation.

Signed-off-by: Oldřich Jedlička <oldium.pro@gmail.com>