### PR TITLE
apache: fix nghttp2 support

### DIFF
--- a/net/apache/Makefile
+++ b/net/apache/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apache
 PKG_VERSION:=2.4.27
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE_NAME:=httpd
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=Apache License
@@ -40,7 +40,7 @@ endef
 
 define Package/apache
 $(call Package/apache/Default)
-  DEPENDS:=+libapr +libaprutil +libpcre +libopenssl +unixodbc +zlib
+  DEPENDS:=+libapr +libaprutil +libpcre +libopenssl +unixodbc +zlib +libnghttp2
 endef
 
 define Package/apache/description


### PR DESCRIPTION
Maintainer: @heil 
Compile tested: ar71xx, tplink-wdr4300, LEDE trunk
Run tested: ar71xx, tplink-wdr4300, LEDE trunk

Description:
Commit 0e265dc0c7 adds support for the nghttp2 library in the Lede git repo.
In case the libnghttp2 package is enabled apache compilation will fail with
as error "missing dependency for libnghttp2.so.14.14.0".
Fix this by adding a dependency on libnghttp2 for apache.
