### PR TITLE
kea: add new package

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -1,0 +1,201 @@
+#
+# Copyright (C) 2019 Banglang Huang <banglang.huang@foxmail.com>
+# Copyright (C) 2019 Rosy Song <rosysong@rosinson.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=kea
+PKG_VERSION:=1.5.0
+PKG_RELEASE:=1
+PKG_MAINTAINER:=BangLang Huang<banglang.huang@foxmail.com>, Rosy Song<rosysong@rosinson.com>
+PKG_BUILD_DEPENDS:=boost log4cplus kea/host
+HOST_BUILD_DEPENDS:=boost boost/host log4cplus/host
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)/
+
+PKG_HASH:=edce4fab68ca7af607cf7f5bc86596e04fe0ef4b8e88906e339cdefcf21daaec
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+PKG_LICENSE:=MPL-2.0
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+
+HOST_BUILD_PREFIX:=$(STAGING_DIR_HOST)
+
+define Package/kea/Default
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=IP Addresses and Names
+  TITLE:=ISC Kea
+  URL:=https://www.isc.org/kea
+endef
+
+define Package/kea/description
+  Kea is an open source DHCPv4/DHCPv6 server being developed by Internet
+  Systems Consortium. Kea is a high-performance, extensible DHCP server
+  engine that is designed to be easily modified and extended with hooks
+  libraries. It provides DHCPv4 and DHCPv6 servers, a dynamic DNS update
+  module, a portable DHCP library, libdhcp++, control agent that provides
+  management REST interface, and a DHCP benchmarking tool, perfdhcp.
+endef
+
+define Package/kea-libs
+	$(call Package/kea/Default)
+	TITLE+= Libraries
+	DEPENDS:=+libopenssl +log4cplus \
+		+boost +boost-python3 +boost-system
+endef
+
+define Package/kea-dhcp4
+	$(call Package/kea/Default)
+	TITLE+= DHCP Server v4
+	DEPENDS:=+kea-libs
+endef
+
+define Package/kea-dhcp6
+	$(call Package/kea/Default)
+	TITLE+= DHCP Server v6
+	DEPENDS:=@IPV6 +kea-libs
+endef
+
+define Package/kea-dhcp-ddns
+	$(call Package/kea/Default)
+	TITLE+= DHCP - DDNS
+	DEPENDS:=+kea-libs
+endef
+
+define Package/kea-admin
+	$(call Package/kea/Default)
+	TITLE+= Admin
+	DEPENDS:= +kea-libs +python3
+endef
+
+define Package/kea-ctrl
+	$(call Package/kea/Default)
+	TITLE+= Control
+	DEPENDS:= +kea-dhcp4 +IPV6:kea-dhcp6 \
+		+kea-dhcp-ddns
+endef
+
+define Package/kea-lfc
+	$(call Package/kea/Default)
+	TITLE+= lfc
+	DEPENDS:=+kea-libs
+endef
+
+define Package/kea-perfdhcp
+	$(call Package/kea/Default)
+	TITLE+= perfdhcp
+	DEPENDS:=+kea-libs
+endef
+
+CONFIGURE_ARGS += \
+	--with-log4cplus="$(STAGING_DIR)/usr" \
+	$(if $(CONFIG_PACKAGE_kea-perfdhcp),--enable-perfdhcp,)
+
+CONFIGURE_VARS += \
+	cross_compiling="yes"
+
+HOST_CONFIGURE_ARGS += \
+	--enable-static-link \
+	--enable-boost-headers-only \
+	--with-log4cplus="$(STAGING_DIR_HOSTPKG)" \
+	--with-boost-include="$(STAGING_DIR)/usr/include"
+
+HOST_LDFLAGS += \
+		-Wl,--gc-sections,--as-needed
+
+TARGET_CXXFLAGS += \
+		-fdata-sections \
+		-ffunction-sections
+
+TARGET_LDFLAGS += \
+		-Wl,--gc-sections,--as-needed
+
+# Only compile the kea-msg-compiler which we need for
+# package compilation
+define Host/Compile
+	+$(HOST_MAKE_VARS) \
+	$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR)/src/lib/exceptions $(HOST_MAKE_FLAGS)
+	+$(HOST_MAKE_VARS) \
+	$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR)/src/lib/util $(HOST_MAKE_FLAGS)
+	+$(HOST_MAKE_VARS) \
+	$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR)/src/lib/log $(HOST_MAKE_FLAGS)
+endef
+
+define Host/Install
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/lib/log/compiler/kea-msg-compiler \
+		$(STAGING_DIR_HOSTPKG)/bin/
+endef
+
+define Build/Compile
+	$(INSTALL_DIR) $(PKG_BUILD_DIR)/src/lib/log/compiler
+	$(INSTALL_BIN) $(STAGING_DIR_HOSTPKG)/bin/kea-msg-compiler \
+		$(PKG_BUILD_DIR)/src/lib/log/compiler/
+	$(call Build/Compile/Default)
+endef
+
+define Package/kea-libs/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
+endef
+
+define Package/kea-dhcp4/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/kea
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kea-dhcp4 $(1)/usr/sbin/kea-dhcp4
+	$(CP) $(PKG_INSTALL_DIR)/etc/kea/kea-dhcp4.conf $(1)/etc/kea/
+endef
+
+define Package/kea-dhcp6/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/kea
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kea-dhcp6 $(1)/usr/sbin/kea-dhcp6
+	$(CP) $(PKG_INSTALL_DIR)/etc/kea/kea-dhcp6.conf $(1)/etc/kea/
+endef
+
+define Package/kea-dhcp-ddns/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/kea
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kea-dhcp-ddns $(1)/usr/sbin/kea-dhcp-ddns
+	$(CP) $(PKG_INSTALL_DIR)/etc/kea/kea-dhcp-ddns.conf $(1)/etc/kea/
+endef
+
+define Package/kea-admin/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kea-admin $(1)/usr/sbin/kea-admin
+endef
+
+define Package/kea-ctrl/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/kea
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/keactrl $(1)/usr/sbin/keactrl
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kea-ctrl-agent $(1)/usr/sbin/kea-ctrl-agent
+	$(CP) $(PKG_INSTALL_DIR)/etc/kea/keactrl.conf $(1)/etc/kea/
+	$(CP) $(PKG_INSTALL_DIR)/etc/kea/kea-ctrl-agent.conf $(1)/etc/kea/
+	$(CP) $(PKG_INSTALL_DIR)/etc/kea/kea-netconf.conf $(1)/etc/kea/
+endef
+
+define Package/kea-lfc/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kea-lfc $(1)/usr/sbin/kea-lfc
+endef
+
+define Package/kea-perfdhcp/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/perfdhcp $(1)/usr/sbin/perfdhcp
+endef
+
+$(eval $(call HostBuild))
+$(eval $(call BuildPackage,kea-libs))
+$(eval $(call BuildPackage,kea-dhcp4))
+$(eval $(call BuildPackage,kea-dhcp6))
+$(eval $(call BuildPackage,kea-dhcp-ddns))
+$(eval $(call BuildPackage,kea-admin))
+$(eval $(call BuildPackage,kea-ctrl))
+$(eval $(call BuildPackage,kea-lfc))
+$(eval $(call BuildPackage,kea-perfdhcp))

--- a/net/kea/patches/001-fix-cross-compile.patch
+++ b/net/kea/patches/001-fix-cross-compile.patch
@@ -1,0 +1,16 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -594,10 +594,10 @@ AC_TRY_COMPILE([
+         AC_MSG_RESULT(no))
+ 
+ AC_MSG_CHECKING(for usuable C++11 regex)
+-AC_TRY_RUN([
++AC_TRY_COMPILE([
+ #include <regex>
+-#include <iostream>
+-int main() {
++#include <iostream>],
++[int main() {
+   const std::regex regex(".*");
+   const std::string string = "This should match!";
+   const auto result = std::regex_search(string, regex);

--- a/net/kea/patches/002-fix-host-compile.patch
+++ b/net/kea/patches/002-fix-host-compile.patch
@@ -1,0 +1,11 @@
+--- a/m4macros/ax_crypto.m4
++++ b/m4macros/ax_crypto.m4
+@@ -454,7 +454,7 @@ EOF
+     dnl Check availability of SHA-2
+     AC_MSG_CHECKING([support of SHA-2])
+     LIBS_SAVED=${LIBS}
+-    LIBS="$LIBS $CRYPTO_LIBS"
++    LIBS="$LIBS $CRYPTO_LIBS -lpthread"
+     CPPFLAGS_SAVED=${CPPFLAGS}
+     CPPFLAGS="$CRYPTO_INCLUDES $CPPFLAGS"
+     AC_LINK_IFELSE(

--- a/net/kea/patches/003-no-test-compile.patch
+++ b/net/kea/patches/003-no-test-compile.patch
@@ -1,0 +1,328 @@
+--- a/src/bin/admin/Makefile.am
++++ b/src/bin/admin/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ # Install kea-admin in sbin.
+ sbin_SCRIPTS  = kea-admin
+--- a/src/bin/agent/Makefile.am
++++ b/src/bin/agent/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
+--- a/src/bin/d2/Makefile.am
++++ b/src/bin/d2/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
+--- a/src/bin/dhcp4/Makefile.am
++++ b/src/bin/dhcp4/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
+--- a/src/bin/dhcp6/Makefile.am
++++ b/src/bin/dhcp6/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
+--- a/src/bin/keactrl/Makefile.am
++++ b/src/bin/keactrl/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ # Install keactrl in sbin and the keactrl.conf required by the keactrl
+ # in etc. keactrl will look for its configuration file in the etc folder.
+--- a/src/bin/lfc/Makefile.am
++++ b/src/bin/lfc/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
+--- a/src/bin/netconf/Makefile.am
++++ b/src/bin/netconf/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
+--- a/src/bin/perfdhcp/Makefile.am
++++ b/src/bin/perfdhcp/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
+--- a/src/bin/shell/Makefile.am
++++ b/src/bin/shell/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ pkgpython_PYTHON = kea_conn.py kea_connector2.py kea_connector3.py
+ 
+--- a/src/hooks/dhcp/high_availability/Makefile.am
++++ b/src/hooks/dhcp/high_availability/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/hooks/dhcp/lease_cmds/Makefile.am
++++ b/src/hooks/dhcp/lease_cmds/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/hooks/dhcp/stat_cmds/Makefile.am
++++ b/src/hooks/dhcp/stat_cmds/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/hooks/dhcp/user_chk/Makefile.am
++++ b/src/hooks/dhcp/user_chk/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/asiodns/Makefile.am
++++ b/src/lib/asiodns/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/asiolink/Makefile.am
++++ b/src/lib/asiolink/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . testutils tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/cc/Makefile.am
++++ b/src/lib/cc/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/cfgrpt/Makefile.am
++++ b/src/lib/cfgrpt/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CXXFLAGS  = $(KEA_CXXFLAGS)
+--- a/src/lib/config/Makefile.am
++++ b/src/lib/config/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/config_backend/Makefile.am
++++ b/src/lib/config_backend/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/cql/Makefile.am
++++ b/src/lib/cql/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . testutils tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES) $(CQL_CPPFLAGS)
+--- a/src/lib/cryptolink/Makefile.am
++++ b/src/lib/cryptolink/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES) $(CRYPTO_CFLAGS) $(CRYPTO_INCLUDES)
+--- a/src/lib/database/Makefile.am
++++ b/src/lib/database/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . testutils tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/dhcp/Makefile.am
++++ b/src/lib/dhcp/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/dhcp_ddns/Makefile.am
++++ b/src/lib/dhcp_ddns/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/dhcpsrv/Makefile.am
++++ b/src/lib/dhcpsrv/Makefile.am
+@@ -1,6 +1,6 @@
+ AUTOMAKE_OPTIONS = subdir-objects
+ 
+-SUBDIRS = . testutils tests benchmarks
++SUBDIRS = . benchmarks
+ 
+ dhcp_data_dir = @localstatedir@/@PACKAGE@
+ kea_lfc_location = @prefix@/sbin/kea-lfc
+--- a/src/lib/dns/Makefile.am
++++ b/src/lib/dns/Makefile.am
+@@ -1,6 +1,6 @@
+ AUTOMAKE_OPTIONS = subdir-objects
+ 
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/eval/Makefile.am
++++ b/src/lib/eval/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/exceptions/Makefile.am
++++ b/src/lib/exceptions/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CXXFLAGS=$(KEA_CXXFLAGS)
+--- a/src/lib/hooks/Makefile.am
++++ b/src/lib/hooks/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/http/Makefile.am
++++ b/src/lib/http/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/log/Makefile.am
++++ b/src/lib/log/Makefile.am
+@@ -2,7 +2,6 @@ SUBDIRS = interprocess .
+ if !CROSS_COMPILING
+ SUBDIRS += compiler
+ endif
+-SUBDIRS += tests
+ 
+ AM_CPPFLAGS = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/log/interprocess/Makefile.am
++++ b/src/lib/log/interprocess/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += -DLOCKFILE_DIR=\"$(localstatedir)/run/$(PACKAGE_NAME)\"
+--- a/src/lib/mysql/Makefile.am
++++ b/src/lib/mysql/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . testutils tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES) $(MYSQL_CPPFLAGS)
+--- a/src/lib/pgsql/Makefile.am
++++ b/src/lib/pgsql/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . testutils tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES) $(PGSQL_CPPFLAGS)
+--- a/src/lib/process/Makefile.am
++++ b/src/lib/process/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . testutils tests
++SUBDIRS = .
+ dhcp_data_dir = @localstatedir@/@PACKAGE@
+ AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
+ AM_CPPFLAGS += -DDATA_DIR="\"$(dhcp_data_dir)\""
+--- a/src/lib/stats/Makefile.am
++++ b/src/lib/stats/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/util/Makefile.am
++++ b/src/lib/util/Makefile.am
+@@ -1,6 +1,6 @@
+ AUTOMAKE_OPTIONS = subdir-objects
+ 
+-SUBDIRS = . io unittests tests python threads
++SUBDIRS = . io python threads
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES)
+--- a/src/lib/util/threads/Makefile.am
++++ b/src/lib/util/threads/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . tests
++SUBDIRS = .
+ AM_CXXFLAGS = $(KEA_CXXFLAGS)
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+--- a/src/lib/yang/Makefile.am
++++ b/src/lib/yang/Makefile.am
+@@ -1,4 +1,4 @@
+-SUBDIRS = . testutils pretests tests
++SUBDIRS = .
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
+ AM_CPPFLAGS += $(BOOST_INCLUDES) $(SYSREPO_CPPFLAGS)


### PR DESCRIPTION
Kea is an open source DHCPv4/DHCPv6 server being developed by
Internet Systems Consortium. Kea is a high-performance, extensible
DHCP server engine that is designed to be easily modified and extended
with hooks libraries.

Kea is free open source, and we welcome community engagement, via the
Kea-users mailing list, this wiki, and our Github
repository. There is a small core team of dedicated software engineers
developing it and we need your contributions and support
contracts to support them.

DHCP Standardization efforts: The lead developer on KEA is
co-chair of the Dynamic Host Configuration working group in the
IETF. We are committed to providing a standards-compliant
implementation and are closely tracking developments in this working
group and evaluating them for inclusion in KEA.

wiki : http://kea.isc.org/wiki
official : https://www.isc.org/kea/
github : https://github.com/isc-projects/kea

Signed-off-by: BangLang Huang <banglang.huang@foxmail.com>
