### PR TITLE
libs/libpng: Update to 1.6.32

### DIFF
--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpng
-PKG_VERSION:=1.6.29
-PKG_RELEASE:=2
+PKG_VERSION:=1.6.32
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/libpng
-PKG_HASH:=4245b684e8fe829ebb76186327bb37ce5a639938b219882b53d64bd3cfc5f239
+PKG_HASH:=c918c3113de74a692f0a1526ce881dc26067763eb3915c57ef3a0f7b6886f59b
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 PKG_LICENSE:=Libpng GPL-2.0+ BSD-3-Clause
@@ -39,6 +39,7 @@ TARGET_CFLAGS += $(FPIC)
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
+	$(if $(findstring neon,$(CONFIG_TARGET_OPTIMIZATION)),--enable-hardware-optimizations=yes --enable-arm-neon=yes)
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: ar71xx, TL-WDR3600, LEDE trunk + mvebu, Linksys WRT3200ACM, LEDE trunk
Run tested: ar71xx, TL-WDR3600, LEDE trunk

Description:
Update libpng to 1.6.32
Add ARM NEON optimization

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>