### PR TITLE
tcpreplay: update to version 4.2.5

### DIFF
--- a/net/tcpreplay/Makefile
+++ b/net/tcpreplay/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcpreplay
-PKG_VERSION:=4.2.3
+PKG_VERSION:=4.2.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/appneta/tcpreplay/releases/download/v$(PKG_VERSION)
-PKG_HASH:=68d8d49dab5bf58b2e8d244eee1ee7f2379d967da19fe97dd9d59bcf40a22abc
+PKG_HASH:=941026be34e1db5101d3d22ebddd6fff76179a1ee81e273338f533ba4eca89d7
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=docs/LICENSE


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE v17.01.3, powerpc64
Run tested: LEDE v17.01.3, powerpc64

I had a ppc64 build around, and was more comfortable to test with that.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>