### PR TITLE
Fwknopd: Bump PKG_RELEASE and minor fix

### DIFF
--- a/net/fwknop/Makefile
+++ b/net/fwknop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fwknop
 PKG_VERSION:=2.6.9
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.cipherdyne.org/fwknop/download

--- a/net/fwknop/files/fwknopd.init
+++ b/net/fwknop/files/fwknopd.init
@@ -4,7 +4,6 @@
 # Copyright (C) 2009-2014 fwknop developers and contributors. For a full
 # list of contributors, see the file 'CREDITS'.
 #
-. /lib/functions.sh
 
 USE_PROCD=1
 START=95


### PR DESCRIPTION
An unneccesary include in the init file was causing problems when using the package builder.
Signed-off-by: Jonathan Bennett <JBennett@incomsystems.biz>