### PR TITLE
Perl move -rdynamic

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=5.24.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \
@@ -96,7 +96,7 @@ define Build/Configure
 	                                -Dowrt:gccversion=$(CONFIG_GCC_VERSION) \
 	                                -Dowrt:target_cross='$(TARGET_CROSS)' \
 	                                -Dowrt:cflags='$(TARGET_CFLAGS_PERL) $(TARGET_CPPFLAGS_PERL)' \
-	                                -Dowrt:ldflags='-rdynamic $(TARGET_LDFLAGS)' \
+	                                -Dowrt:ldflags='$(TARGET_LDFLAGS)' \
 	                                -Dowrt:libc=$(subst uClibc,uclibc,$(CONFIG_LIBC)) \
 	                                -Dowrt:ipv6=$(if $($(CONFIG_IPV6)),define,undef) \
 	                                -Dowrt:threads=$(if $(CONFIG_PERL_THREADS),yes,no) \

--- a/lang/perl/files/base.config
+++ b/lang/perl/files/base.config
@@ -1008,7 +1008,7 @@ ccflags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 $owrt:cflags"
 ccflags_uselargefiles='-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64'
 ccdlflags="-fPIC -Wl,-rpath,$owrt:perllibpath/CORE"
 cccdlflags='-fPIC'
-ldflags=''
+ldflags="$owrt:ldflags"
 ldflags_uselargefiles=''
 lddlflags="-shared $owrt:ldflags"
 

--- a/lang/perl/files/base.config
+++ b/lang/perl/files/base.config
@@ -1006,7 +1006,7 @@ full_ar="${owrt:target_cross}ar"
 cppflags="$owrt:cflags"
 ccflags="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 $owrt:cflags"
 ccflags_uselargefiles='-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64'
-ccdlflags="-fPIC -Wl,-rpath,$owrt:perllibpath/CORE"
+ccdlflags="-fPIC -rdynamic -Wl,-rpath,$owrt:perllibpath/CORE"
 cccdlflags='-fPIC'
 ldflags="$owrt:ldflags"
 ldflags_uselargefiles=''


### PR DESCRIPTION
Maintainer: me / @Naoir 
Compile tested: x86_64, generic, LEDE HEAD (61048c9)
Run tested: same

Built entire image, and installed via `sysupgrade`.

Description:

Pass the build instructions in the correct places.  This PR is a precursor to updating to perl to 5.26.1 (and addressing several CVE's in 5.24.1).