### PR TITLE
vala: bump to version 0.34.5

### DIFF
--- a/lang/vala/Makefile
+++ b/lang/vala/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2016 OpenWrt.org
+# Copyright (C) 2006-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vala
-PKG_VERSION:=0.34.2
+PKG_VERSION:=0.34.5
 PKG_RELEASE:=1
 PKG_LICENSE:=LGPL-2.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/vala/0.34/
-PKG_HASH:=765e9c2b429a66db93247940f8588319b43f35c173d057bcae5717a97d765c41
+PKG_HASH:=3fd4ba371778bc87da42827b8d23f1f42b0629759a9a1c40c9683dfb7e73fae5
 
 PKG_BUILD_DEPENDS:=glib2 glib2/host vala/host
 HOST_BUILD_DEPENDS:=glib2/host


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, Netgear WNDR4300, openwrt r50139
Run tested: -

Description:

A minor update containing bugfixes.
