### PR TITLE
uledd: add a tiny ubus frontend for PWM/RGB leds

### DIFF
--- a/utils/uledd/Makefile
+++ b/utils/uledd/Makefile
@@ -1,0 +1,32 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=uledd
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://github.com/blogic/uledd.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=bc94c7e52009f7ec33b23652502b4754351d8040
+PKG_MIRROR_HASH:=23a407197d6a423bb0b32f381e93ad3676e15f07465d7b53c843a2b510c7c284
+PKG_MAINTAINER:=John Crispin <john@phrozen.org>
+PKG_LICENSE:=GPL-2.0
+
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/uledd
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libubox +libubus
+  TITLE:=PWM/RGB LED ubus frontend
+endef
+
+define Package/uledd/install
+	$(INSTALL_DIR) $(1)/sbin $(1)/etc/init.d
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/uledd $(1)/sbin/
+	$(INSTALL_BIN) ./files/uledd.init $(1)/etc/init.d/uledd
+endef
+
+$(eval $(call BuildPackage,uledd))

--- a/utils/uledd/files/uledd.init
+++ b/utils/uledd/files/uledd.init
@@ -1,0 +1,13 @@
+#!/bin/sh /etc/rc.common
+
+START=95
+
+USE_PROCD=1
+PROG=/sbin/uledd
+
+start_service() {
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_set_param respawn
+	procd_close_instance
+}


### PR DESCRIPTION
This daemon allows users to controll PWM driven RGB LEDs using ubus.
Currently it is possible to make leds blink at different brightnesses
and or make them fade in between colours.

the following call will turn green on and red off:
ubus call led set '{ "leds": { "ap:green:status": 255, "ap:red:status": 0 } }'

the following call will make green and red fade on/off over 2 seconds:
ubus call led set '{ "leds": { "ap:green:status": [0, 255], "ap:red:status": [255, 0] }, "on": 2000, "off": 2000, "fade": 1 }'

Signed-off-by: John Crispin <john@phrozen.org>
