### PR TITLE
rpcd-mod-attendedsysupgrade: add package to lede-17.01

### DIFF
--- a/utils/rpcd-mod-attendedsysupgrade/Makefile
+++ b/utils/rpcd-mod-attendedsysupgrade/Makefile
@@ -1,0 +1,73 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rpcd-mod-attendedsysupgrade
+PKG_VERSION:=1.1
+PKG_RELEASE:=2
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/rpcd-mod-attendedsysupgrade
+  SECTION:=utils
+  CATEGORY:=Base system
+  TITLE:=OpenWrt ubus RPC backend server (attendedsysupgrade)
+  MAINTAINER:=Paul Spooren <paul@spooren.de>
+  DEPENDS:=rpcd +cgi-io +rpcd-mod-packagelist
+endef
+
+define Package/rpcd-mod-attendedsysupgrade/description
+	Implements a sysupgrade procedure which can be used to invoke sysupgrade via ubus calls
+	The	sysupgrade image must be placed at /tmp/sysupgrade.bin
+	After a successfull installation the device will perform a restart.
+
+	Usage:
+
+	ubus call attendedsysupgrade sysupgrade
+
+	Example output:
+
+	{
+		"message": "starting sysupgrade"
+	}
+
+	Possible parameters:
+
+	keep_settings: bool # preserve /config/
+
+	UCI options:
+
+	attendedsysupgrade.server.url
+	URL of compatible upgrade server [1]
+
+	attendedsysupgrade.client.upgrade_packages
+	Client should request image also if no new release but new packages upgrade are available.
+
+	attendedsysupgrade.client.advanced_mode
+	Offer advanced options like editing packages before request and show additional information.
+
+	attendedsysupgrade.client.auto_search
+	Tells the client to automattically search for upgrades
+	This can be done when opening luci or login in to console - depends on client.
+
+	[1]: https://github.com/aparcar/gsoc17-attended-sysupgrade
+endef
+
+define Build/Compile
+endef
+
+define Build/Configure
+endef
+
+define Package/rpcd-mod-attendedsysupgrade/install
+	$(INSTALL_DIR) $(1)/usr/libexec/rpcd/
+	$(INSTALL_BIN) ./files/attendedsysupgrade.rpcd $(1)/usr/libexec/rpcd/attendedsysupgrade
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/attendedsysupgrade.defaults $(1)/etc/uci-defaults/attendedsysupgrade
+endef
+
+$(eval $(call BuildPackage,rpcd-mod-attendedsysupgrade))

--- a/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.defaults
+++ b/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.defaults
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+[ -e /etc/config/attendedsysupgrade ] && return 0
+
+touch /etc/config/attendedsysupgrade
+
+uci -q batch <<EOF
+set attendedsysupgrade.server=server
+set attendedsysupgrade.server.url='https://example.org'
+
+set attendedsysupgrade.client=client
+set attendedsysupgrade.client.upgrade_packages='1'
+set attendedsysupgrade.client.auto_search='0'
+set attendedsysupgrade.client.advanced_mode='0'
+
+commit attendedsysupgrade
+EOF

--- a/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.rpcd
+++ b/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.rpcd
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+. /usr/share/libubox/jshn.sh
+
+case "$1" in
+	list)
+		json_init
+		json_add_object "sysupgrade"
+		json_add_boolean "keep_settings" 1
+		json_close_object
+		json_dump
+		;;
+	call)
+		case "$2" in
+			sysupgrade)
+				read input;
+				json_load "$input"
+				json_get_var keep_settings keep_settings
+
+				if [ -f "/tmp/sysupgrade.bin" ]; then
+					json_init
+					json_add_string "message" "starting sysupgrade"
+					json_dump
+
+					/etc/init.d/uhttpd stop
+					/etc/init.d/dropbear stop
+					sleep 1;
+					if [ "$keep_settings" -eq "0" ]; then
+						keep_settings_param="-n"
+					fi
+
+					/sbin/sysupgrade $keep_settings_param /tmp/sysupgrade.bin
+				fi
+				json_init
+				json_add_string "message" "could not find /tmp/sysupgrade.bin"
+				json_dump
+		esac
+		;;
+esac
+


### PR DESCRIPTION
add ubus call to perform a sysupgrade and acl file for the attended
sysupgrade use case as well uci defaults.
Package is a part of the GSoC 17 project implementing easy
sysupgrade functionality.

rpcd-mod-attendedsysupgrade: add missing .rpcd

due to renaming .rpcd was forgotten in the Makefile

rpcd-mod-attendedsysupgrade: add keep_settings opt

as mentioned [here][1] some firmwares require to reset all settings.
this commit add a param "keep_settings" which changes the sysupgrade
parameter "-c" to "-n" to flush all configs

[1]: https://github.com/aparcar/gsoc17-attended-sysupgrade/issues/34

rpcd-mod-attendedsysupgrade: simplify uci options

use named uci options

rpcd-mod-attendedsysupgrade: uci update_packages

add uci option to set "update_packages". this options will lead the
luci-app-attendedsysupgrade to tell the update server to check for
package updates as well (not only release upgrades)

Signed-off-by: Paul Spooren <paul@spooren.de>