### PR TITLE
rpcd-mod-packagelist: add package to lede-17.01

### DIFF
--- a/utils/rpcd-mod-packagelist/Makefile
+++ b/utils/rpcd-mod-packagelist/Makefile
@@ -1,0 +1,60 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rpcd-mod-packagelist
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/rpcd-mod-packagelist
+  SECTION:=utils
+  CATEGORY:=Base system
+  TITLE:=ubus packagelist
+  MAINTAINER:=Paul Spooren <paul@spooren.de>
+  DEPENDS:=rpcd @!CLEAN_IPKG
+endef
+
+define Package/rpcd-mod-packagelist/description
+	This package adds a function to ubus to list all installed packages.
+	It uses /usr/lib/opkg/status so opkg is not required for operation.
+	Returns package name and version.
+
+	Usage:
+	ubus call packagelist list
+
+	Example output:
+	{
+		"packagelist": {
+			"libuci-lua": "2017-09-29-5ad59ad4-1",
+			"cgi-io": "4",
+			"mkf2fs": "1.9.0-1",
+			"opkg": "2017-07-28-4bd8601e-1",
+			...
+	}
+
+	The package is used by luci-app-attendedsysupgrade
+
+	Further information
+	https://github.com/aparcar/gsoc17-attended-sysupgrade#created-lede-packages
+endef
+
+define Build/Compile
+endef
+
+define Build/Configure
+endef
+
+define Package/rpcd-mod-packagelist/install
+	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d/
+	$(INSTALL_BIN) ./files/packagelist.acl $(1)/usr/share/rpcd/acl.d/packagelist.json
+
+	$(INSTALL_DIR) $(1)/usr/libexec/rpcd/
+	$(INSTALL_BIN) ./files/packagelist.rpcd $(1)/usr/libexec/rpcd/packagelist
+endef
+
+$(eval $(call BuildPackage,rpcd-mod-packagelist))

--- a/utils/rpcd-mod-packagelist/files/packagelist.acl
+++ b/utils/rpcd-mod-packagelist/files/packagelist.acl
@@ -1,0 +1,12 @@
+{
+	"packagelist": {
+		"description": "get list of installed software packages",
+		"read": {
+			"ubus": {
+				"packagelist": [
+					"list"
+				]
+			}
+		}
+	}
+}

--- a/utils/rpcd-mod-packagelist/files/packagelist.rpcd
+++ b/utils/rpcd-mod-packagelist/files/packagelist.rpcd
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+. /usr/share/libubox/jshn.sh
+
+case "$1" in
+list)
+	json_init
+	json_add_object "list"
+	json_dump
+	;;
+call)
+	case "$2" in
+	list)
+		json_init;
+		json_add_object "packagelist"
+
+		if [ -f /usr/lib/opkg/status ]; then
+			while read var p1 p2 p3; do
+				if [ "$var" = "Package:" ]; then
+					pkg="$p1"
+				fi
+				if [ "$var" = "Version:" ]; then
+					version="$p1"
+				fi
+
+				if [ "$var" = "Status:" \
+					-a "$p1" = "install" \
+					-a "$p2" = "user" \
+					-a "$p3" = "installed" ]; then
+						json_add_string "$pkg" "$version";
+				fi
+			done < /usr/lib/opkg/status
+		fi
+
+		json_close_object
+		json_dump
+		;;
+	esac
+	;;
+esac


### PR DESCRIPTION
Provides a way to acquire the list of installed packages without the
need to have opkg available. It is being used for the GSoC 17 project
implementing easy sysupgrade functionality.

Signed-off-by: Paul Spooren <paul@spooren.de>