### PR TITLE
libxml2: install cmake module

### DIFF
--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -118,6 +118,10 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libxml2.{la,a,so*} $(1)/usr/lib/
 
+	$(INSTALL_DIR) $(1)/usr/lib/cmake/libxml2
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/cmake/libxml2/libxml2-config.cmake \
+		$(1)/usr/lib/cmake/libxml2
+
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libxml-2.0.pc $(1)/usr/lib/pkgconfig/
 


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: brcm2708 on LEDE master r5106.

Description:
Since version 2.9.2, libxml2 provides its own cmake module. Install it
to avoid packages built with cmake and requiring libxml2 to fall back to
cmake's FindLibXml2 module, which seems to detect host libxml2 instead
of the one in staging_dir.

Fixes #4917.