### PR TITLE
libiio: add iiod init script

### DIFF
--- a/libs/libiio/Makefile
+++ b/libs/libiio/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libiio
 PKG_VERSION:=0.10
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/analogdevicesinc/libiio/tar.gz/v$(PKG_VERSION)?
@@ -91,6 +91,8 @@ define Package/libiio/install
 endef
 
 define Package/iiod/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/iiod.init $(1)/etc/init.d/iiod
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/iiod $(1)/usr/sbin/
 endef

--- a/libs/libiio/files/iiod.init
+++ b/libs/libiio/files/iiod.init
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+
+START=90
+USE_PROCD=1
+PROG=/usr/sbin/iiod
+
+start_service() {
+	procd_open_instance
+	procd_set_param command $PROG
+	procd_set_param respawn
+	procd_close_instance
+}


### PR DESCRIPTION
Maintainer: @mhei
Compile tested: brcm2708 @ LEDE master r5106
Run tested: brcm2708 @ LEDE master r5106

Description:
Add init script for the Industrial I/O daemon