### PR TITLE
ddns-scripts: fix dynv6.com "unchanged" response

### DIFF
--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -103,7 +103,7 @@
 
 "dynu.com"		"http://api.dynu.com/nic/update?hostname=[DOMAIN]&myip=[IP]&username=[USERNAME]&password=[PASSWORD]"
 
-"dynv6.com"		"http://dynv6.com/api/update?hostname=[DOMAIN]&token=[PASSWORD]&ipv4=[IP]"	"updated"
+"dynv6.com"		"http://dynv6.com/api/update?hostname=[DOMAIN]&token=[PASSWORD]&ipv4=[IP]"	"updated|unchanged"
 
 "easydns.com"		"http://[USERNAME]:[PASSWORD]@api.cp.easydns.com/dyn/generic.php?hostname=[DOMAIN]&myip=[IP]"	"NOERROR"
 


### PR DESCRIPTION
-------------------------------

Maintainer: Ernest Moshkov <e.moshkov@gmail.com>
Run tested: LEDE Reboot 17.01.3 r3533-d0bf257c46 

Description:

user.err ddns-scripts: IP update not accepted by DDNS Provider

dynv6.com response "unchanged" is OK

Signed-off-by: Ernest Moshkov <e.moshkov@gmail.com>