### PR TITLE
ddns-scripts: fix dynv6.com "unchanged" response

### DIFF
--- a/net/ddns-scripts/files/services_ipv6
+++ b/net/ddns-scripts/files/services_ipv6
@@ -67,7 +67,7 @@
 
 "dynu.com"    "http://api.dynu.com/nic/update?hostname=[DOMAIN]&myipv6=[IP]&username=[USERNAME]&password=[PASSWORD]"
 
-"dynv6.com"		"http://dynv6.com/api/update?hostname=[DOMAIN]&token=[PASSWORD]&ipv6=[IP]"	"updated"
+"dynv6.com"		"http://dynv6.com/api/update?hostname=[DOMAIN]&token=[PASSWORD]&ipv6=[IP]"	"updated|unchanged"
 
 "goip.de"		"http://www.goip.de/setip?username=[USERNAME]&password=[PASSWORD]&subdomain=[DOMAIN]&ip6=[IP]"
 


### PR DESCRIPTION
-------------------------------

Maintainer: Ernest Moshkov <e.moshkov@gmail.com>
Run tested: LEDE Reboot 17.01.3 r3533-d0bf257c46 

Description:

user.err ddns-scripts: IP update not accepted by DDNS Provider

dynv6.com response "unchanged" is OK

Signed-off-by: Ernest Moshkov <e.moshkov@gmail.com>