### PR TITLE
fwknop: ensure default ifname matches default network

### DIFF
--- a/net/fwknop/Makefile
+++ b/net/fwknop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fwknop
 PKG_VERSION:=2.6.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.cipherdyne.org/fwknop/download

--- a/net/fwknop/files/fwknopd.init
+++ b/net/fwknop/files/fwknopd.init
@@ -8,6 +8,8 @@
 USE_PROCD=1
 START=95
 
+. /lib/functions/network.sh
+
 FWKNOPD_BIN=/usr/sbin/fwknopd
 
 start_service()
@@ -62,7 +64,9 @@ generate_configuration()
 	local PCAP_INTF=
 	local USER_CONFIG_PATH=/etc/fwknop/fwknopd.conf
 	local DEFAULT_UCI_NETWORK=wan
-	local DEFAULT_FWKNOPD_IFNAME=eth0
+	local DEFAULT_FWKNOPD_IFNAME=
+
+	network_get_device DEFAULT_FWKNOPD_IFNAME $DEFAULT_UCI_NETWORK
 
 	config_cb() {
 		local type="$1"
@@ -163,7 +167,6 @@ generate_configuration()
 
 		# Resolve network if possible
 		if [ -n "$NETWORK" ]; then
-			. /lib/functions/network.sh
 			network_get_device DEPEND_IFNAME "$NETWORK"
 			if [ -n "$DEPEND_IFNAME" ]; then
 				logger -p daemon.debug -t "fwknopd[----]" "Resolved network $NETWORK as interface $DEPEND_IFNAME"


### PR DESCRIPTION
Signed-off-by: Terry Stockert <stockert@inkblotadmirer.me>

Maintainer: Jonathan Bennett <JBennett@incomsystems.biz>
Compile tested: mvebu, LEDE master
Run tested: mvebu (WRT-1900ACS, WRT-1200AC), LEDE master
Description:

The init script uses wan as the default network with an interface name of eth0.  It's likely ok for the default network to be wan but it's fairly restrictive to expect this interface will be eth0, precluding the use of VLANs for example.

Tested with wan interface on a VLAN with ifname eth1.2.  The sed filter should extract everything between single quotes from the uci show command.
