### PR TITLE
icu: fix CVE-2017-14952 Double-Free Vulnerability [lede-17.01]

### DIFF
--- a/libs/icu/Makefile
+++ b/libs/icu/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=icu4c
 PKG_VERSION:=58.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-58_2-src.tgz
 PKG_SOURCE_URL:=http://download.icu-project.org/files/$(PKG_NAME)/$(PKG_VERSION)

--- a/libs/icu/patches/CVE-2017-14952.patch
+++ b/libs/icu/patches/CVE-2017-14952.patch
@@ -1,0 +1,10 @@
+Index: source/i18n/zonemeta.cpp
+===================================================================
+--- source/i18n/zonemeta.cpp	(revision 40283)
++++ source/i18n/zonemeta.cpp	(revision 40324)
+@@ -684,5 +684,4 @@
+                     if (U_FAILURE(status)) {
+                         delete mzMappings;
+-                        deleteOlsonToMetaMappingEntry(entry);
+                         uprv_free(entry);
+                         break;


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, mips_24kc_gcc-6.3.0_musl-1.1.16, lede-17.01 r3567-0780e12
Run tested: NONE

Description:
[lede-17.01] icu: fix CVE-2017-14952 Double-Free Vulnerability

http://www.sourcebrella.com/blog/double-free-vulnerability-international-components-unicode-icu/

https://security-tracker.debian.org/tracker/CVE-2017-14952

Signed-off-by: Hirokazu MORIKAWA morikw2@gmail.com