### PR TITLE
mii-tool: fix kernel 4.9 compatibility

### DIFF
--- a/net/mii-tool/Makefile
+++ b/net/mii-tool/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mii-tool
 PKG_VERSION=2016-10-06-$(PKG_SOURCE_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=git://git.code.sf.net/p/net-tools/code

--- a/net/mii-tool/patches/001-mii-tool-4.9-compatibility.patch
+++ b/net/mii-tool/patches/001-mii-tool-4.9-compatibility.patch
@@ -1,0 +1,10 @@
+--- a/iptunnel.c	2016-07-10 20:15:29.000000000 +0200
++++ b/iptunnel.c	2017-10-19 19:51:09.172782821 +0200
+@@ -26,7 +26,6 @@
+ #include <sys/socket.h>
+ #include <sys/ioctl.h>
+ #include <netinet/in.h>
+-#include <netinet/ip.h>
+ #include <arpa/inet.h>
+ #include <net/if.h>
+ #include <net/if_arp.h>


### PR DESCRIPTION
Fix kernel 4.9 compatibility. Thanks to didbot for suggesting the fix in #4934.

Compile tested: ar71xx, ramips/mt7621, x86/64.

Signed-off by: Stijn Segers <francesco.borromini@inventati.org>
