### PR TITLE
net/mwan3-luci: fix iface_state on on status page for 17.01

### DIFF
--- a/net/mwan3-luci/Makefile
+++ b/net/mwan3-luci/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-mwan3
 PKG_VERSION:=1.4
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_MAINTAINER:=Aedan Renner <chipdankly@gmail.com>
 PKG_LICENSE:=GPLv2
 

--- a/net/mwan3-luci/files/usr/lib/lua/luci/controller/mwan3.lua
+++ b/net/mwan3-luci/files/usr/lib/lua/luci/controller/mwan3.lua
@@ -65,7 +65,8 @@ end
 
 function getInterfaceStatus(ruleNumber, interfaceName)
 	if ut.trim(sys.exec("uci -p /var/state get mwan3." .. interfaceName .. ".enabled")) == "1" then
-		if ut.trim(sys.exec(ip .. "route list table " .. ruleNumber)) ~= "" then
+		local fs = require "nixio.fs"
+		if fs.readfile("/var/run/mwan3/iface_state/%s" % interfaceName) == "online" then
 			if ut.trim(sys.exec("uci -p /var/state get mwan3." .. interfaceName .. ".track_ip")) ~= "" then
 				return "online"
 			else


### PR DESCRIPTION
Maintainer: me @arfett
Compile tested: not needed it is a script
Run tested: mips, lantiq_xrx200, LEDE 17.0

Description:

Since commit 4739584c2434fda6c4f14b0ef3d38fa055352c0e the status of the
interface is not reported correctly anymore. To fix this issue do not test
if the routing table is presented use instead the "/var/run/iface_state/[iface]"
to get the interface state because the routing table will not get deleted
anymore if the interface is offline.
