### PR TITLE
ddns-script: fix update_url incorrect for duckdns.org service

### DIFF
--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -82,7 +82,7 @@
 
 "dtdns.com"		"http://www.dtdns.com/api/autodns.cfm?id=[DOMAIN]&pw=[PASSWORD]&ip=[IP]"
 
-"duckdns.org"		"http://www.duckdns.org/update?domains=[USERNAME]&token=[PASSWORD]&ip=[IP]"	"OK"
+"duckdns.org"		"http://www.duckdns.org/update?domains=[DOMAIN]&token=[PASSWORD]&ip=[IP]"	"OK"
 
 "duiadns.net"		"http://ip.duiadns.net/dynamic.duia?host=[DOMAIN]&password=[PASSWORD]&ip4=[IP]"
 

--- a/net/vpnbypass/Makefile
+++ b/net/vpnbypass/Makefile
@@ -32,8 +32,6 @@ define Package/$(PKG_NAME)/conffiles
 endef
 
 define Build/Prepare
-#	sed -i "s|^\(PKG_NAME\).*|\1='$(PKG_NAME)'|" ./files/vpnbypass.init
-#	sed -i "s|^\(PKG_VERSION\).*|\1='$(PKG_VERSION)-$(PKG_RELEASE)'|" ./files/vpnbypass.init
 endef
 
 define Build/Configure


### PR DESCRIPTION
Maintainer: wendy2001011
Compile tested: arch:arm, OpenWRT/LEDE version:Chaos Calmer
Run tested: arch:arm, OpenWRT/LEDE version:Chaos Calmer, tests done

Description:
ddns-script: fix update_url incorrect for duckdns.org service
Signed-off-by: wendy2001011 <wendy2001011@163.com>

For duckdns.org service,
update_url should be "http://www.duckdns.org/update?domains=[DOMAIN]&token=[PASSWORD]&ip=[IP]".
Using "domains=[DOMAIN]&token=[PASSWORD]", DDNS provider answered:"OK", update successful
Using "domains=[USERNAME]&token=[PASSWORD]", DDNS provider answered:"KO", IP update not accepted by DDNS Provider