### PR TITLE
utils/lxc: disable gnutls during configure

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -124,6 +124,7 @@ define Package/lxc-init
 endef
 
 CONFIGURE_ARGS += \
+	--disable-gnutls \
 	--disable-apparmor \
 	--disable-doc \
 	--disable-examples \


### PR DESCRIPTION
Previous versions of LXC never compiled in gnutls support due to a bug in the
configure script. As other TLS implementations are not supported and the feature
was disabled in previous builds, disable it during configure.

See https://github.com/lxc/lxc/pull/1360 for details regarding the bug in the
autoconf of the previous versions.

Maintainer: @ratkaj 
Compile tested: x86, LEDE master
Run tested: x86, lEDE master

