### PR TITLE
coova-chilli: Fix multiple instance restart race condition

### DIFF
--- a/net/coova-chilli/files/chilli.init
+++ b/net/coova-chilli/files/chilli.init
@@ -55,7 +55,6 @@ stop() {
     ls /var/run/chilli*.pid 2>/dev/null && {
        kill $(cat /var/run/chilli*.pid)
        sleep 1
-       killall -9 chilli
        rm -f /var/run/chilli*
     }
 }


### PR DESCRIPTION
Maintainer: Imre Kaloz <kaloz@openwrt.org> / @kaloz 
Compile tested: MIPS, TP-Link Archer C7 V2.0, OpenWrt 15.05.1
Run tested: MIPS, TP-Link Archer C7 V2.0, OpenWrt 15.05.1, Tested multiple instances start/stop

Description:
        When there are two instance of chilli running and we restart
        chilli service, race condition occurs sometimes when second
        instance is restarting and it kills first newly restarted
        instance.

        Killing PID is already killing chilli instance and killall
        syntax is not necesory here.

Signed-off-by: Rajan Vaja <rajan.vaja@gmail.com>
Signed-off-by: Kishan Gondaliya <kishanpgondaliya@gmail.com>
