### PR TITLE
luajit: include numbered .so files in package

### DIFF
--- a/lang/luajit/Makefile
+++ b/lang/luajit/Makefile
@@ -69,7 +69,7 @@ endef
 
 define Package/luajit/install
 	$(INSTALL_DIR) $(1)/usr/lib/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/luajit-2.1.0-beta2 $(1)/usr/bin/$(PKG_NAME)
 endef


### PR DESCRIPTION
Currently the package only copies the *.so files, which doesn't seem right, so now it copies *.so* (*.so.2 etc) files as well.

Compile tested:  Debian stretch, Lede 17.01.4
Run tested:  BCM53XX, Netgear R6300V2, Lede 17.01.4

Description:
