### PR TITLE
perl: modules failing due to dot not in @INC

### DIFF
--- a/lang/perl/perlmod.mk
+++ b/lang/perl/perlmod.mk
@@ -57,7 +57,7 @@ define perlmod/Configure
 	(cd $(if $(3),$(3),$(PKG_BUILD_DIR)); \
 	PERL_MM_USE_DEFAULT=1 \
 	$(2) \
-	$(PERL_CMD) -MConfig -e '$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E"; do "Makefile.PL"' \
+	$(PERL_CMD) -MConfig -e '$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E"; do "./Makefile.PL"' \
 		$(1) \
 		AR=ar \
 		CC=$(GNU_TARGET_NAME)-gcc \


### PR DESCRIPTION
Maintainer: me / @Naoir 
Compile tested: x86_64, generic, LEDE HEAD (21e59ee3a23)
Run tested: same

Built an image with all perl modules (except perl-test-harness, perl-www-curl, and perl-www-mechanize) enabled.  Installed it via sysupgrade.  Seems solid.

Description:

Following the bump to 5.26.1, `@INC` doesn't include `.`.  This was causing `do "Makefile.PL"` to fail since it was in the current directory.