### PR TITLE
perl: when Makefile.PL fails give more feedback

### DIFF
--- a/lang/perl/perlmod.mk
+++ b/lang/perl/perlmod.mk
@@ -57,7 +57,7 @@ define perlmod/Configure
 	(cd $(if $(3),$(3),$(PKG_BUILD_DIR)); \
 	PERL_MM_USE_DEFAULT=1 \
 	$(2) \
-	$(PERL_CMD) -MConfig -e '$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E"; do "./Makefile.PL"' \
+	$(PERL_CMD) -MConfig -e '$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E"; unshift(@INC, "."); unless (defined (do "./Makefile.PL")) { if ($$$$@) { die "couldn\047t parse Makefile.PL: $$$$@"; } else { die "couldn\047t do Makefile.PL: $$$$!"; } }; die "No Makefile generated!" unless -f "Makefile";' \
 		$(1) \
 		AR=ar \
 		CC=$(GNU_TARGET_NAME)-gcc \


### PR DESCRIPTION
Maintainer: me / @Naoir 
Compile tested: x86_64, generic, LEDE HEAD (21e59ee)
Run tested: same

Built `perl-http-server-simple`, `perl-www-curl`, and `perl-www-mechanize` which were previously failing.

Description:

If packages are failing when running `./Makefile.PL`, capture any error messages which might have been emitted and send them along... plus fail the command (and hence the rule, and thereby the target).