### PR TITLE
travis_do.sh: Switch to mirror

### DIFF
--- a/.travis_do.sh
+++ b/.travis_do.sh
@@ -5,7 +5,7 @@
 set -e
 
 SDK_HOME="$HOME/sdk"
-SDK_PATH=https://downloads.lede-project.org/snapshots/targets/ar71xx/generic/
+SDK_PATH=https://ftp.halifax.rwth-aachen.de/lede/snapshots/targets/ar71xx/generic/
 SDK=lede-sdk-ar71xx-generic_gcc-5.5.0_musl.Linux-x86_64
 PACKAGES_DIR="$PWD"
 


### PR DESCRIPTION
Offload the infrastructure by using a mirror and that's overall faster

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>