### PR TITLE
wget: update to 1.19.2

### DIFF
--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.19.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -66,6 +66,7 @@ endef
 CONFIGURE_ARGS+= \
 	--disable-rpath \
 	--disable-iri \
+	--with-included-libunistring \
 	--without-libuuid
 
 CONFIGURE_VARS += \


### PR DESCRIPTION
@mstorchak 

* update wget to 1.19.2
    Contains fixes for stack and heap overflows in HTTP protocol: CVE-2017-13090 and CVE-2017-13089

* disable linkage to libunistring with a hack
    advice configure to use included libunistring when there is actually none. This avoids libunistring detection in buildbot. I have verified in my own buildhost that wget gets compiled even when libunistring is present in the build system.

Compile-tested: LEDE master for mvebu, ipq806x
Run-tested: LEDE master with mvebu WRT3200ACM

(annoyingly the author is moving from .xz to .lz, so we need to fall back to .gz)
