### PR TITLE
net/mwan3: fix empty gateway when creating routing table

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.6.6
+PKG_VERSION:=2.6.7
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -30,6 +30,7 @@ if [ "$ACTION" == "ifup" ]; then
 		else
 			network_get_ipaddr src_ip ${INTERFACE}
 		fi
+		[ -n "$src_ip" ] || src_ip="0.0.0.0"
 	elif [ "$family" = "ipv6" ]; then
 		ubus call network.interface.${INTERFACE}_6 status &>/dev/null
 		if [ "$?" -eq "0" ]; then
@@ -37,9 +38,8 @@ if [ "$ACTION" == "ifup" ]; then
 		else
 			network_get_ipaddr6 src_ip ${INTERFACE}
 		fi
+		[ -n "$src_ip" ] || src_ip="::"
 	fi
-
-	[ -n "$src_ip" ] || exit 9
 fi
 
 if [ "$initial_state" = "offline" ]; then

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -26,24 +26,20 @@ if [ "$ACTION" == "ifup" ]; then
 	if [ "$family" = "ipv4" ]; then
 		ubus call network.interface.${INTERFACE}_4 status &>/dev/null
 		if [ "$?" -eq "0" ]; then
-			network_get_gateway gateway ${INTERFACE}_4
 			network_get_ipaddr src_ip ${INTERFACE}_4
 		else
-			network_get_gateway gateway $INTERFACE
 			network_get_ipaddr src_ip ${INTERFACE}
 		fi
 	elif [ "$family" = "ipv6" ]; then
 		ubus call network.interface.${INTERFACE}_6 status &>/dev/null
 		if [ "$?" -eq "0" ]; then
-			network_get_gateway6 gateway ${INTERFACE}_6
 			network_get_ipaddr6 src_ip ${INTERFACE}_6
 		else
-			network_get_gateway6 gateway ${INTERFACE}
 			network_get_ipaddr6 src_ip ${INTERFACE}
 		fi
 	fi
 
-	[ -n "$gateway" ] || exit 9
+	[ -n "$src_ip" ] || exit 9
 fi
 
 if [ "$initial_state" = "offline" ]; then

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -203,9 +203,7 @@ mwan3_create_iface_iptables()
 	[ -n "$id" ] || return 0
 
 	if [ "$family" == "ipv4" ]; then
-
-		ubus call network.interface.${1}_4 status &>/dev/null
-		if [ "$?" -eq "0" ]; then
+		if ubus call network.interface.${1}_4 status &>/dev/null; then
 			network_get_ipaddr src_ip ${1}_4
 		else
 			network_get_ipaddr src_ip $1
@@ -244,9 +242,7 @@ mwan3_create_iface_iptables()
 	fi
 
 	if [ "$family" == "ipv6" ]; then
-
-		ubus call network.interface.${1}_6 status &>/dev/null
-		if [ "$?" -eq "0" ]; then
+		if ubus call network.interface.${1}_6 status &>/dev/null; then
 			network_get_ipaddr6 src_ipv6 ${1}_6
 		else
 			network_get_ipaddr6 src_ipv6 $1
@@ -322,8 +318,7 @@ mwan3_create_iface_route()
 	[ -n "$id" ] || return 0
 
 	if [ "$family" == "ipv4" ]; then
-		ubus call network.interface.${1}_4 status &>/dev/null
-		if [ "$?" -eq "0" ]; then
+		if ubus call network.interface.${1}_4 status &>/dev/null; then
 			network_get_gateway route_args ${1}_4
 		else
 			network_get_gateway route_args $1
@@ -336,9 +331,7 @@ mwan3_create_iface_route()
 	fi
 
 	if [ "$family" == "ipv6" ]; then
-
-		ubus call network.interface.${1}_6 status &>/dev/null
-		if [ "$?" -eq "0" ]; then
+		if ubus call network.interface.${1}_6 status &>/dev/null; then
 			network_get_gateway6 route_args ${1}_6
 		else
 			network_get_gateway6 route_args $1

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -324,10 +324,14 @@ mwan3_create_iface_route()
 			network_get_gateway route_args $1
 		fi
 
-		route_args="via $route_args dev $2"
+		if [ -n "$route_args" -a "$route_args" != "0.0.0.0" ]; then
+			route_args="via $route_args"
+		else
+			route_args=""
+		fi
 
 		$IP4 route flush table $id
-		$IP4 route add table $id default $route_args
+		$IP4 route add table $id default $route_args dev $2
 	fi
 
 	if [ "$family" == "ipv6" ]; then
@@ -337,10 +341,14 @@ mwan3_create_iface_route()
 			network_get_gateway6 route_args $1
 		fi
 
-		route_args="via $route_args dev $2"
+		if [ -n "$route_args" -a "$route_args" != "::" ]; then
+			route_args="via $route_args"
+		else
+			route_args=""
+		fi
 
 		$IP6 route flush table $id
-		$IP6 route add table $id default $route_args
+		$IP6 route add table $id default $route_args dev $2
 	fi
 }
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -34,6 +34,10 @@ validate_track_method() {
 				$LOG warn "Missing httping. Please install httping package."
 				return 1
 			}
+			[ -n "$2" -a "$2" != "0.0.0.0" -a "$2" != "::" ] || {
+				$LOG warn "Cannot determine source IP for the interface which is required by httping."
+				return 1
+			}
 			;;
 		*)
 			$LOG warn "Unsupported tracking method: $track_method"
@@ -59,7 +63,7 @@ main() {
 
 	config_load mwan3
 	config_get track_method $1 track_method ping
-	validate_track_method $track_method || {
+	validate_track_method $track_method $SRC_IP || {
 		$LOG warn "Using ping to track interface $INTERFACE avaliability"
 		track_method=ping
 	}

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -21,7 +21,10 @@ if_down() {
 validate_track_method() {
 	case "$1" in
 		ping)
-			# Assume that ping is installed
+			which ping 1>/dev/null 2>&1 || {
+				$LOG warn "Missing ping. Please install iputils-ping package or enable ping util and recompile busybox."
+				return 1
+			}
 			;;
 		arping)
 			which arping 1>/dev/null 2>&1 || {
@@ -64,8 +67,13 @@ main() {
 	config_load mwan3
 	config_get track_method $1 track_method ping
 	validate_track_method $track_method $SRC_IP || {
-		$LOG warn "Using ping to track interface $INTERFACE avaliability"
 		track_method=ping
+		if validate_track_method $track_method; then
+			$LOG warn "Using ping to track interface $INTERFACE avaliability"
+		else
+			$LOG err "No track method avaliable"
+			exit 1
+		fi
 	}
 	config_get reliability $1 reliability 1
 	config_get count $1 count 1


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: arch:ar71xx, OpenWRT/LEDE version:Reboot 17.01.4, tests done
Run tested: arch:ar71xx, OpenWRT/LEDE version:Reboot 17.01.4, tests done

Description:
Interfaces of PtP protocol do not have a real gateway, and ubus fills these fields with '0.0.0.0'. This will cause error when adding new routing rule.
Signed-off-by: David Yang <mmyangfl@gmail.com>