### PR TITLE
sound/opus-tools: Update to 0.1.10

### DIFF
--- a/sound/opus-tools/Makefile
+++ b/sound/opus-tools/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opus-tools
-PKG_VERSION:=0.1.9
+PKG_VERSION:=0.1.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://downloads.xiph.org/releases/opus/
-PKG_HASH:=b1873dd78c7fbc98cf65d6e10cfddb5c2c03b3af93f922139a2104baedb4643a
+PKG_HASH:=a2357532d19471b70666e0e0ec17d514246d8b3cb2eb168f68bb0f6fd372b28c
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING
@@ -24,8 +24,8 @@ PKG_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 
 define Package/opus-tools
-  SECTION:=utils
-  CATEGORY:=Utilities
+  SECTION:=sound
+  CATEGORY:=Sound
   DEPENDS:=+libogg +libopus
   TITLE:=OPUS Codec tools
   URL:=http://opus-codec.org/


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: ar71xx, TP-Link TL-WDR3600, LEDE trunk
Run tested: ar71xx, TP-Link TL-WDR3600, LEDE trunk

Description:
Update opus-tools to 0.1.10
Move to sound directory and category

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>