### PR TITLE
rpcd-mod-packagelist: switch to object array

### DIFF
--- a/utils/rpcd-mod-packagelist/Makefile
+++ b/utils/rpcd-mod-packagelist/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rpcd-mod-packagelist
-PKG_VERSION:=0.1
+PKG_VERSION:=0.2
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0
 

--- a/utils/rpcd-mod-packagelist/files/packagelist.rpcd
+++ b/utils/rpcd-mod-packagelist/files/packagelist.rpcd
@@ -11,8 +11,8 @@ list)
 call)
 	case "$2" in
 	list)
-		json_init;
-		json_add_object "packagelist"
+		json_init
+		json_add_array "packagelist"
 
 		if [ -f /usr/lib/opkg/status ]; then
 			while read var p1 p2 p3; do
@@ -27,12 +27,15 @@ call)
 					-a "$p1" = "install" \
 					-a "$p2" = "user" \
 					-a "$p3" = "installed" ]; then
-						json_add_string "$pkg" "$version";
+						json_add_object "package"
+						json_add_string "name" "$pkg"
+						json_add_string "version" "$version"
+						json_close_object
 				fi
 			done < /usr/lib/opkg/status
 		fi
 
-		json_close_object
+		json_close_array
 		json_dump
 		;;
 	esac


### PR DESCRIPTION
JSON keys must not contain dash characters ('-'), but some package
names do... Convert package list to an array of objects each having
a "name" and a "version" string attribute to allow package names
containing dash characters which isn't possible in the current way of
using a JSON table where the package name is used as a the key.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>