### PR TITLE
libs/fftw3: Updated to the latest release

### DIFF
--- a/libs/fftw3/Makefile
+++ b/libs/fftw3/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fftw3
-PKG_VERSION:=3.3.6-pl2
+PKG_VERSION:=3.3.7
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0+
 
 PKG_SOURCE:=fftw-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.fftw.org
-PKG_HASH:=a5de35c5c824a78a058ca54278c706cdf3d4abba1c56b63531c2cb05f5d57da2
+PKG_HASH:=3b609b7feba5230e8f6dd8d245ddbefac324c5a6ae4186947670d9ac2cd25573
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/fftw-$(PKG_VERSION)
 PKG_FIXUP:=autoreconf
@@ -73,10 +73,12 @@ CONFIGURE_ARGS += \
 	--enable-threads \
 	--enable-type-prefix \
 	--disable-debug \
-	--disable-fortran
+	--disable-fortran \
+	--disable-doc
 
 ifeq ($(BUILD_VARIANT), single)
 CONFIGURE_ARGS += \
+	$(if $(findstring neon,$(CONFIG_TARGET_OPTIMIZATION)),--enable-neon) \
 	--enable-single
 endif
 


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP Targets OpenWrt and Lede latest master
Run tested: n/a
Description:

Oct 29th, 2017

    Experimental support for CMake.

    The primary build mechanism for FFTW remains GNU autoconf/automake. CMake support is meant to offer an easy way to compile FFTW on Windows, and as such it does not cover all the features of the automake build system, such as exotic cycle counters, cross-compiling, or build of binaries for a mixture of ISA's (e.g., amd64 vs amd64+avx vs amd64+avx2). Patches are welcome.
    Fixes for armv7a cycle counter.
    Official support for aarch64, now that we have hardware to test it.
    Tweak usage of FMA instructions in a way that favors newer processors (Skylake and Ryzen) over older processors (Haswell).
    tests/bench: use 64-bit precision to compute mflops. 