### PR TITLE
lxc: no warning when do not use GPG

### DIFF
--- a/utils/lxc/patches/030-no-warn-gpg.patch
+++ b/utils/lxc/patches/030-no-warn-gpg.patch
@@ -1,0 +1,12 @@
+--- a/templates/lxc-download.in
++++ b/templates/lxc-download.in
+@@ -39,7 +39,7 @@
+ DOWNLOAD_READY_GPG="false"
+ DOWNLOAD_RELEASE=
+ DOWNLOAD_SERVER="images.linuxcontainers.org"
+-DOWNLOAD_SHOW_GPG_WARNING="true"
++DOWNLOAD_SHOW_GPG_WARNING="false"
+ DOWNLOAD_SHOW_HTTP_WARNING="true"
+ DOWNLOAD_TARGET="system"
+ DOWNLOAD_URL=
+ 


### PR DESCRIPTION
Maintainer: @ratkaj
Compile tested: arm (mvebu), LEDE master
Run tested: arm (mvebu), LEDE master

Description:
GPG seems a package few used in OpenWRT so it seems better do not warning when the option "--no-validate" is used. This option is used in luci-app-lxc, for example.

Signed-off-by: Admin Localnet <localnet@users.noreply.github.com>