### PR TITLE
noddos: bump to v0.5.5

### DIFF
--- a/libs/libyaml-cpp/Makefile
+++ b/libs/libyaml-cpp/Makefile
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2017 Steven Hessing
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libyaml-cpp
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:= Steven Hessing <steven.hessing@gmail.com>
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/jbeder/yaml-cpp/
+PKG_SOURCE_DATA:=2017-11-01
+PKG_SOURCE_VERSION:=beb44b872c07c74556314e730c6f20a00b32e8e5
+PKG_MIRROR_HASH:=3ddb1f5a6c564f33fd164c0300df8048c689c319964a08386d869637a0f5c8e2
+
+PKG_SOURCE_SUBDIR:=yaml-cpp
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+PKG_BUILD_PARALLEL:=1
+
+CMAKE_INSTALL:=1
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+CMAKE_OPTIONS += -DBUILD_SHARED_LIBS=ON
+#CMAKE_OPTIONS += -DBUILD_SHARED_LIBS=OFF
+
+define Package/libyaml-cpp
+	SECTION:=development
+	CATEGORY:=Libraries
+	TITLE:=libyaml-cpp 
+	URL:=https://github.com/jbeder/yaml-cpp
+	DEPENDS:=+libstdcpp
+endef
+
+define Package/libyaml-cpp/description
+yaml-cpp is a YAML parser and emitter in C++ matching the YAML 1.2 spec.
+endef
+
+define Package/libyaml-cpp/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	#$(INSTALL_DATA) $(PKG_BUILD_DIR)/libyaml-cpp.so.0.5.3 $(1)/usr/lib/
+	#$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libyaml-cpp.so.0.5.3 $(1)/usr/lib/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libyaml-cpp.so.0.5 $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libyaml-cpp))

--- a/net/noddos/Makefile
+++ b/net/noddos/Makefile
@@ -13,10 +13,10 @@ PKG_RELEASE:=1
 PKG_LICENSE:=GPLv3
 PKG_MAINTAINER:=Steven Hessing <steven.hessing@gmail.com>
 
-PKG_SOURCE_VERSION:=0.5.4
+PKG_SOURCE_VERSION:=0.5.5
 PKG_SOURCE_URL:=https://github.com/noddos/noddos/releases/download/v$(PKG_SOURCE_VERSION)/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz
-PKG_HASH:=1021a72fd66f4901cdc1e7bd3a203450cee5c453ec52ea7c6d8f8691fc4e9d0e
+PKG_HASH:=1f5be0c1015b0407036eecc8449d60d2abcacec442bba55db85fc32e89f754db
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
 
@@ -29,15 +29,15 @@ define Package/noddos
 	CATEGORY:=Network
 	TITLE:=noddos -- device-aware cloud-powered firewall
 	URL:=https://www.noddos.io/
-	DEPENDS:=+libstdcpp +libnetfilter-conntrack +libcurl +libopenssl +openssl-util +ca-bundle +ca-certificates +wget +bzip2 +libtins +ipset +libpthread
+	DEPENDS:=+libstdcpp +libnetfilter-conntrack +libcurl +libopenssl +openssl-util +ca-bundle +ca-certificates +wget +bzip2 +libtins +ipset +libpthread +libyaml-cpp
 endef
 
 define Package/noddos/description
-Noddos discovers what devices you have in your network and tailors the firewall rules based on whitelisted flows for that device. Noddos downloads the firewall rules periodically from the cloud. In order to support creating these firewall rules, noddos can optionally upload anonimized traffic statistics for each device to the cloud.
+Noddos discovers what devices you have in your network and tailors the firewall rules based on whitelisted flows for that device. Noddos downloads the firewall rules periodically from the cloud. In order to support creating these firewall rules, noddos can, after opt-in, upload anonimized traffic statistics for each device to the cloud. The Luci interface is available in the luci-apps-noddos package. For information, visit https://www.noddos.io/
 endef
 
 define Package/noddos/conffiles
-	/etc/config/noddos	
+	/etc/config/noddos
 endef
 
 define Package/noddos/install
@@ -51,9 +51,8 @@ define Package/noddos/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tools/makenoddoscert.sh $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/noddos.init $(1)/etc/init.d/noddos
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/noddos.uciconfig $(1)/etc/config/noddos
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/noddos.conf-base $(1)/etc/noddos
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/noddos.yml-base $(1)/etc/noddos
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/noddosconfig.pem $(1)/etc/noddos
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/noddos.conf-base $(1)/etc/noddos
 endef
 
 define Package/noddos/prerm
@@ -73,8 +72,8 @@ define Package/noddos/postrm
 	if [ -z "$${IPKG_INSTROOT}" ]; then
 		echo "Removing noddos data directory"
 		rm -rf /var/lib/noddos
-		if [ -f /var/etc/noddos.conf ]; then
-			rm /var/etc/noddos.conf
+		if [ -f /var/etc/noddos.yml ]; then
+			rm /var/etc/noddos.yml
 		fi
 	fi
 	exit 0


### PR DESCRIPTION
Signed-off-by: Steven Hessing <steven.hessing@gmail.com>

Maintainer: Steven Hessing / @StevenHessing
Compile tested: (mvebu / ipq806x, Linksys WRT1200AC / TPLink Archer 2600, 17.01.3 / 17.01.4)
Run tested: (Linksys WRT1200AC 17.01.3 / TPLink Archer 2600 17.01.4, service up and running for a day)

Description:

New features:
* Use yaml for the noddos configuration file
* Add support for SsdpDeviceType and MdnsHostname
* Further reduce logging by making debug logging for main event loop optional (disabled by default)
* (OpenWRT/LEDE) Automatic interface detection
* (OpenWRT/LEDE) Automatic installation of cronjob

Bug fixes:
* [#39](https://github.com/noddos/noddos/issues/39) DnsQueryCache expired too soon
* [#34](https://github.com/noddos/noddos/issues/34) DnsCache.json expiration incorrect

Instructions:
* Users of previous versions have to manually copy configuration settings made to noddos.conf to noddos.yml
* OpenWRT/LEDE Users: if you install noddos manually, you now also have to download and install the libyaml-cpp package.