### PR TITLE
[For-15.05] libsodium: Fix download url

### DIFF
--- a/libs/libsodium/Makefile
+++ b/libs/libsodium/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.0.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://download.libsodium.org/libsodium/releases/old
+PKG_SOURCE_URL:=https://download.libsodium.org/libsodium/releases/old/unsupported
 PKG_MD5SUM:=dc40eb23e293448c6fc908757738003f
 
 PKG_FIXUP:=libtool autoreconf


### PR DESCRIPTION
Maintainer: @damianorenfer 
Compile tested: MIPS, TP-Link Archer C7 V2.0, OpenWrt 15.05.1
Run tested: MIPS, TP-Link Archer C7 V2.0, OpenWrt 15.05.1, Tested Compilation

Description:
libsodium: Fix download url

Signed-off-by: Kishan Gondaliya <kishanpgondaliya@gmail.com>