### PR TITLE
ffmpeg: Update to 3.4

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=3.2.8
+PKG_VERSION:=3.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
-PKG_HASH:=42e7362692318afc666f14378dd445effa9a1b09787504a6ab5811fe442674cd
+PKG_HASH:=aeee06e4d8b18d852c61ebbfe5e1bb7014b1e118e8728c1c2115f91e51bffbef
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Ian Leonard <antonlacon@gmail.com>
 


### PR DESCRIPTION
Maintainer: @thess , @antonlacon 
Compile tested: x86, LEDE 17.01
Run tested: mvebu, Turris Omnia, OpenWRT 15.05

Description:
Compiled and run tested on Turris Omnia - mvebu roughly OpenWRT 15.05 with little bit different set of configure options, compilation retested against x86 LEDE 17.01