### PR TITLE
sound/lame: Remove unnecessary optimization args

### DIFF
--- a/sound/lame/Makefile
+++ b/sound/lame/Makefile
@@ -63,7 +63,7 @@ TARGET_CFLAGS+=-msse
 endif
 
 ifeq ($(CONFIG_LAME-LIB_OPTIMIZE_SPEED),y)
-	TARGET_CFLAGS += $(TARGET_CFLAGS) -O3 -fomit-frame-pointer -ffast-math -fschedule-insns2
+	TARGET_CFLAGS += $(TARGET_CFLAGS) -O3 -ffast-math
 	TARGET_CFLAGS := $(filter-out -Os,$(TARGET_CFLAGS))
 endif
 


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: Not needed
Run tested: Not needed

Description:
-O3 already includes -fomit-frame-pointer -fschedule-insns2
Thanks Philip Prindeville for pointing this out and sorry for the noise.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>