### PR TITLE
watchcat: init script not properly killing existing processes.

### DIFF
--- a/utils/watchcat/files/initd_watchcat
+++ b/utils/watchcat/files/initd_watchcat
@@ -83,7 +83,7 @@ stop() {
 
 		while read pid
 		do
-			kill "$pid"
+			kill -KILL "$pid"
 		done < "${PIDFILE}.pids"
 
 		rm "${PIDFILE}.pids"


### PR DESCRIPTION
Maintainer: @nunojpg 
tested: Not needed
Run tested: Not needed

Description:
What ends up happening is whenever a reload() or stop() is called, which happens at start(), it's not killing existing processes that are read in from /tmp/run/watchcat.pids and the processes begin to stack up with older watchcat instances still running and their pids not tracked by /tmp/run/watchcat.pids.