### PR TITLE
rpcd-mod-attendedsysupgrade: upgrade to v1.1

### DIFF
--- a/utils/rpcd-mod-attendedsysupgrade/Makefile
+++ b/utils/rpcd-mod-attendedsysupgrade/Makefile
@@ -5,8 +5,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rpcd-mod-attendedsysupgrade
-PKG_VERSION:=1
-PKG_RELEASE:=1
+PKG_VERSION:=1.1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk
@@ -20,8 +20,40 @@ define Package/rpcd-mod-attendedsysupgrade
 endef
 
 define Package/rpcd-mod-attendedsysupgrade/description
-	implements sysupgrade function with ubus
-	add uci settings and needed acls
+	Implements a sysupgrade procedure which can be used to invoke sysupgrade via ubus calls
+	The	sysupgrade image must be placed at /tmp/sysupgrade.bin
+	After a successfull installation the device will perform a restart.
+
+	Usage:
+
+	ubus call attendedsysupgrade sysupgrade
+
+	Example output:
+
+	{
+		"message": "starting sysupgrade"
+	}
+
+	Possible parameters:
+
+	keep_settings: bool # preserve /config/
+
+	UCI options:
+
+	attendedsysupgrade.server.url
+	URL of compatible upgrade server [1]
+
+	attendedsysupgrade.client.upgrade_packages
+	Client should request image also if no new release but new packages upgrade are available.
+
+	attendedsysupgrade.client.advanced_mode
+	Offer advanced options like editing packages before request and show additional information.
+
+	attendedsysupgrade.client.auto_search
+	Tells the client to automattically search for upgrades
+	This can be done when opening luci or login in to console - depends on client.
+
+	[1]: https://github.com/aparcar/gsoc17-attended-sysupgrade
 endef
 
 define Build/Compile
@@ -31,9 +63,6 @@ define Build/Configure
 endef
 
 define Package/rpcd-mod-attendedsysupgrade/install
-	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d/
-	$(INSTALL_BIN) ./files/attendedsysupgrade.acl $(1)/usr/share/rpcd/acl.d/attendedsysupgrade.json
-
 	$(INSTALL_DIR) $(1)/usr/libexec/rpcd/
 	$(INSTALL_BIN) ./files/attendedsysupgrade.rpcd $(1)/usr/libexec/rpcd/attendedsysupgrade
 

--- a/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.defaults
+++ b/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.defaults
@@ -1,17 +1,17 @@
 #!/bin/sh
 
-[ -e /etc/config/attendedsysupgrade ] && exit 0
+[ -e /etc/config/attendedsysupgrade ] && return 0
 
 touch /etc/config/attendedsysupgrade
 
 uci -q batch <<EOF
-set attendedsysupgrade.updateserver=updateserver
-set attendedsysupgrade.updateserver.url='https://betaupdate.libremesh.org'
+set attendedsysupgrade.server=server
+set attendedsysupgrade.server.url='https://example.org'
 
-set attendedsysupgrade.updateclient=updateclient
-set attendedsysupgrade.updateclient.update_packages='1'
+set attendedsysupgrade.client=client
+set attendedsysupgrade.client.upgrade_packages='1'
+set attendedsysupgrade.client.auto_search='0'
+set attendedsysupgrade.client.advanced_mode='0'
 
 commit attendedsysupgrade
 EOF
-
-exit 01

--- a/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.rpcd
+++ b/utils/rpcd-mod-attendedsysupgrade/files/attendedsysupgrade.rpcd
@@ -18,6 +18,10 @@ case "$1" in
 				json_get_var keep_settings keep_settings
 
 				if [ -f "/tmp/sysupgrade.bin" ]; then
+					json_init
+					json_add_string "message" "starting sysupgrade"
+					json_dump
+
 					/etc/init.d/uhttpd stop
 					/etc/init.d/dropbear stop
 					sleep 1;


### PR DESCRIPTION
call it upgrade instead of update

added client options:
auto_search - start upgrade search on login
advanced_mode - offer more options like package_editing

message before sysupgrade

more verbose Makefile

moved acls to client

Signed-off-by: Paul Spooren <paul@spooren.de>