### PR TITLE
net/sshfs: update to 2.10

### DIFF
--- a/net/sshfs/Makefile
+++ b/net/sshfs/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sshfs
-PKG_VERSION:=2.8
+PKG_VERSION:=2.10
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Zoltan HERPAI <wigyori@uid0.hu>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/libfuse/sshfs/releases/download/$(PKG_NAME)_$(PKG_VERSION)
-PKG_HASH:=7f689174d02e6b7e2631306fda4fb8e6b4483102d1bce82b3cdafba33369ad22
+PKG_SOURCE_URL:=https://github.com/libfuse/sshfs/releases/download/$(PKG_NAME)-$(PKG_VERSION)
+PKG_HASH:=70845dde2d70606aa207db5edfe878e266f9c193f1956dd10ba1b7e9a3c8d101
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: mips/ar71xx CC 15.05.1, arm/mvebu LEDE 17.01.4, mips/ar71xx LEDE 17.01.4
Run tested: arm/mvebu LEDE 17.01.4, test mount capability

Description:
Update to the latest release usable with fuse 2.x