### PR TITLE
perl-cgi: update to 4.37

### DIFF
--- a/lang/perl-cgi/Makefile
+++ b/lang/perl-cgi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-cgi
-PKG_VERSION:=4.36
+PKG_VERSION:=4.37
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://www.cpan.org/authors/id/L/LE/LEEJO
 PKG_SOURCE:=CGI-$(PKG_VERSION).tar.gz
-PKG_HASH:=fefe84d4f2461e867f9be80f3f988e17bcbbcb4e306952cf2fd1dea7e4515490
+PKG_HASH:=7a14eee5df640f7141848f653cf48d99bfc9b5c68e18167338ee01b91cdfb883
 
 PKG_LICENSE:=GPL Artistic-2.0
 PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>, \


### PR DESCRIPTION
Maintainer: me / @Naoir 
Compile tested: x86_64, generic, LEDE HEAD (eb58eba)
Run tested: same

Built into new image, installed, via `sysupgrade`.  Did unit tests.  Worked fine.

Description:
