### PR TITLE
net-snmp: fix inbound firewall rule support

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -228,6 +228,7 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(2)/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/net-snmp-config $(2)/bin/
 	$(SED) 's,=/usr,=$(STAGING_DIR)/usr,g' $(2)/bin/net-snmp-config
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/bin
 	$(LN) $(STAGING_DIR)/host/bin/net-snmp-config $(STAGING_DIR)/usr/bin/
 
 	$(INSTALL_DIR) $(1)/usr/include

--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=net-snmp
 PKG_VERSION:=5.7.3
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/net-snmp

--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -325,6 +325,7 @@ start_service() {
 
 stop_service() {
 	[ -f "$CONFIGFILE" ] && rm -f "$CONFIGFILE"
+	procd_set_config_changed firewall
 }
 
 service_triggers(){
@@ -336,4 +337,8 @@ service_triggers(){
 	procd_close_trigger
 
 	procd_add_reload_trigger 'snmpd'
+}
+
+service_started() {
+	procd_set_config_changed firewall
 }


### PR DESCRIPTION
Maintainer:  @stintel 
Compile tested: brcm63xx, LEDE trunk
Run tested: brcm63xx, LEDE trunk

Description:
Commit ae5ee6ba6c506b42d942c98349b3a54181790ec8 added support for inbound
firewall rule support but some corner cases were not covered.

In case net-snmp is started and the network interface is already up
the procd firewall rule is created but not applied by fw3 as
service_started calling procd_set_config_changed firewall was missing.

When stopping net-snmp clean up the net-snmp inbound firewall rules in
iptables by calling procd_set_config_changed firewall in stop_service
which will trigger fw3 to remove the inbound firewall rules.