### PR TITLE
openconnect: add options to support juniper

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=7.08
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -32,19 +32,20 @@ define Package/openconnect
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+libxml2 +kmod-tun +resolveip +vpnc-scripts +OPENCONNECT_OPENSSL:libopenssl +OPENCONNECT_OPENSSL:p11-kit +OPENCONNECT_OPENSSL:libp11 +OPENCONNECT_GNUTLS:libgnutls +OPENCONNECT_STOKEN:libstoken
-  TITLE:=OpenConnect VPN client (Cisco AnyConnect compatible)
+  TITLE:=OpenConnect VPN client (Cisco AnyConnect and Juniper/Pulse compatible)
   MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
   URL:=http://www.infradead.org/openconnect/
   SUBMENU:=VPN
 endef
 
 define Package/openconnect/description
-	A VPN client compatible with Cisco's AnyConnect SSL VPN and ocserv.
+	A VPN client compatible with Cisco's AnyConnect SSL VPN, ocserv and Juniper (Pulse secure).
 
         OpenConnect is a client that follows the Cisco's AnyConnect SSL VPN protocol,
         which is supported by IOS 12.4(9)T or later on Cisco SR500, 870, 880, 1800,
         2800, 3800, 7200 Series and Cisco 7301 Routers, as well as the OpenConnect
-        VPN server.
+        VPN server. It has later been ported to support the Juniper SSL VPN which
+        is now known as Pulse Connect Secure.
 endef
 
 CONFIGURE_ARGS += \

--- a/net/openconnect/README
+++ b/net/openconnect/README
@@ -26,6 +26,9 @@ config interface 'MYVPN'
         #option token_mode 'hotp'
         #option token_secret '00'
 
+	# Juniper vpn support
+	#option juniper '1'
+
 The additional files are also used:
 /etc/openconnect/user-cert-vpn-MYVPN.pem: The user certificate
 /etc/openconnect/user-key-vpn-MYVPN.pem: The user private key

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -7,6 +7,7 @@ proto_openconnect_init_config() {
 	proto_config_add_string "server"
 	proto_config_add_int "port"
 	proto_config_add_int "mtu"
+	proto_config_add_int "juniper"
 	proto_config_add_string "username"
 	proto_config_add_string "serverhash"
 	proto_config_add_string "authgroup"
@@ -23,7 +24,7 @@ proto_openconnect_init_config() {
 proto_openconnect_setup() {
 	local config="$1"
 
-	json_get_vars server port username serverhash authgroup password password2 token_mode token_secret os csd_wrapper mtu
+	json_get_vars server port username serverhash authgroup password password2 token_mode token_secret os csd_wrapper mtu juniper
 
 	grep -q tun /proc/modules || insmod tun
 	ifname="vpn-$config"
@@ -52,6 +53,11 @@ proto_openconnect_setup() {
 		append cmdline "--cafile /etc/openconnect/ca-vpn-$config.pem"
 		append cmdline "--no-system-trust"
 	}
+
+	if [ "${juniper:-0}" -gt 0 ]; then
+		append cmdline "--juniper"
+	fi
+
 	[ -n "$serverhash" ] && {
 		append cmdline " --servercert=$serverhash"
 		append cmdline "--no-system-trust"


### PR DESCRIPTION
Run tested: LEDE trunk on wdr4300

Description:
Add option into uci proto file to support juniper option. Openconnect is already built with support for juniper so only need an option in protocol.