### PR TITLE
perlmod: redux handling odd Makefile.PL eval value

### DIFF
--- a/lang/perl/perlmod.mk
+++ b/lang/perl/perlmod.mk
@@ -57,7 +57,7 @@ define perlmod/Configure
 	(cd $(if $(3),$(3),$(PKG_BUILD_DIR)); \
 	PERL_MM_USE_DEFAULT=1 \
 	$(2) \
-	$(PERL_CMD) -MConfig -e '$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E"; unshift(@INC, "."); unless (defined (do "./Makefile.PL")) { if ($$$$@) { die "couldn\047t parse Makefile.PL: $$$$@"; } else { die "couldn\047t do Makefile.PL: $$$$!"; } }; die "No Makefile generated!" unless -f "Makefile";' \
+	$(PERL_CMD) -MConfig -e '$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E"; unshift(@INC, "."); unless (defined (do "./Makefile.PL")) { if ($$$$@) { die "couldn\047t parse Makefile.PL: $$$$@"; } elsif ($$$$!) { die "Could\047t run Makefile.PL: $$$$!"; } }; die "No Makefile generated!" unless -f "Makefile";' \
 		$(1) \
 		AR=ar \
 		CC=$(GNU_TARGET_NAME)-gcc \


### PR DESCRIPTION
Maintainer: me / @Naoir
Compile tested: x86_64, generic, LEDE HEAD (eb58eba)
Run tested: same

Rebuilt and verified correctness of generated `Makefile` for failing packages (`perl-inline-c` at this time).

Description:
