### PR TITLE
perl-inline-c: patch Makefile.PL to not eval undef

### DIFF
--- a/lang/perl-inline-c/patches/010-makefile_pl-dont-eval-undef.patch
+++ b/lang/perl-inline-c/patches/010-makefile_pl-dont-eval-undef.patch
@@ -1,0 +1,8 @@
+--- a/Makefile.PL	2017-05-30 14:58:53.000000000 -0600
++++ b/Makefile.PL	2017-11-07 13:40:05.172119764 -0700
+@@ -82,3 +82,5 @@ package
+ MY;
+ use File::ShareDir::Install qw(postamble);
+ }
++
++1;


### PR DESCRIPTION
Maintainer: me / @Naoir 
Compile tested: x86_64, generic, LEDE HEAD (eb58eba)
Run tested: same

Rebuilt following merge of PR #5082.

Have asked upstream for a permanent fix.

Description:
