### PR TITLE
perl-inline-c: update to 0.78

### DIFF
--- a/lang/perl-inline-c/Makefile
+++ b/lang/perl-inline-c/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-inline-c
-PKG_VERSION:=0.76
+PKG_VERSION:=0.78
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=http://www.cpan.org/authors/id/I/IN/INGY
+PKG_SOURCE_URL:=http://www.cpan.org/authors/id/T/TI/TINITA
 PKG_SOURCE:=Inline-C-$(PKG_VERSION).tar.gz
-PKG_HASH:=22e9713b4d331d3c49e4a9a9f012dbf84cec25a01e5da4f57091be287f1a9a35
+PKG_HASH:=9a7804d85c01a386073d2176582b0262b6374c5c0341049da3ef84c6f53efbc7
 
 PKG_LICENSE:=GPL-1.0+ Artistic-1.0-Perl
 PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>

--- a/lang/perl-inline-c/Makefile
+++ b/lang/perl-inline-c/Makefile
@@ -33,7 +33,7 @@ define Package/perl-inline-c
   CATEGORY:=Languages
   TITLE:=C Language Support for Inline
   URL:=http://search.cpan.org/dist/Inline-C/
-  DEPENDS:=perl +perl-inline +perl-parse-recdescent +perlbase-config +perlbase-cwd +perlbase-data +perlbase-essential +perlbase-extutils +perlbase-file +perlbase-if
+  DEPENDS:=perl +perl-inline +perl-parse-recdescent +perlbase-config +perlbase-cwd +perlbase-data +perlbase-essential +perlbase-file +perlbase-if
 endef
 
 define Host/Configure


### PR DESCRIPTION
Maintainer: me / @Naoir
Compile tested: x86_64, generic, LEDE HEAD (eb58eba)
Run tested: same

Rebuilt and installed `.ipk` on testbed.

Description:
