### PR TITLE
cryptodev: simplify for Jo's parameter passing

### DIFF
--- a/utils/cryptodev-linux/Makefile
+++ b/utils/cryptodev-linux/Makefile
@@ -40,6 +40,7 @@ define KernelPackage/cryptodev
   FILES:= \
 		$(PKG_BUILD_DIR)/cryptodev.$(LINUX_KMOD_SUFFIX)
   AUTOLOAD:=$(call AutoLoad,50,$(CRYPTODEV_AUTOLOAD))
+  MODPARAMS.cryptodev:= cryptodev_verbosity=-1
 endef
 
 define KernelPackage/cryptodev/description
@@ -68,13 +69,6 @@ endef
 define Build/InstallDev
 	$(INSTALL_DIR) $(STAGING_DIR)/usr/include/crypto
 	$(CP) $(PKG_BUILD_DIR)/crypto/cryptodev.h $(STAGING_DIR)/usr/include/crypto/
-endef
-
-define KernelPackage/cryptodev/install
-	$(INSTALL_DIR) $(1)/etc/modules.d
-	$(INSTALL_DATA) ./files/cryptodev.modules $(1)/etc/modules.d/50-cryptodev
-	$(INSTALL_DIR) $(1)/lib/modules/$(LINUX_VERSION)
-	$(INSTALL_DIR) $(1)/usr/sbin
 endef
 
 $(eval $(call KernelPackage,cryptodev))

--- a/utils/cryptodev-linux/files/cryptodev.modules
+++ b/utils/cryptodev-linux/files/cryptodev.modules
@@ -1,1 +1,0 @@
-cryptodev cryptodev_verbosity=-1


### PR DESCRIPTION
Maintainer: @Ansuel 
Compile tested: x86_64, generic, LEDE HEAD (eb58eba)
Run tested: same

Did make /clean /compile, then inspected `build_dir/target-x86_64_musl_powercode-bmu/root-x86/etc/modules.d/50-cryptodev` and contents is identical:

```
cryptodev cryptodev_verbosity=-1
```

Description:
