### PR TITLE
CC: net/tor: fix build and upgrade to 0.2.9.11

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.2.8.9
+PKG_VERSION:=0.2.8.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_MD5SUM:=3f5c273bb887be4aff11f4d99b9e2e52d293b81ff4f6302b730161ff16dc5316
+PKG_MD5SUM:=7adea0bfa17edafd4e09453f4f58a0dca737660e5358f9dafd52d55d55dc6ab3
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
 PKG_LICENSE_FILES:=LICENSE
 

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.2.9.9
+PKG_VERSION:=0.2.9.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_MD5SUM:=33325d2b250fd047ba2ddc5d11c2190c4e2951f4b03ec48ebd8bf0666e990d43
+PKG_MD5SUM:=6760a646a096b61e307b84fb5ae93cc7
+PKG_HASH:=d611283e1fb284b5f884f8c07e7d3151016851848304f56cfdf3be2a88bd1341
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
 PKG_LICENSE_FILES:=LICENSE
 

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.2.7.6
-PKG_RELEASE:=2
+PKG_VERSION:=0.2.8.9
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_MD5SUM:=cc19107b57136a68e8c563bf2d35b072
+PKG_MD5SUM:=3f5c273bb887be4aff11f4d99b9e2e52d293b81ff4f6302b730161ff16dc5316
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
 PKG_LICENSE_FILES:=LICENSE
 
@@ -40,7 +40,7 @@ endef
 define Package/tor
 $(call Package/tor/Default)
   TITLE:=An anonymous Internet communication system
-  DEPENDS:=+libevent2 +libopenssl +libpthread +librt +zlib
+  DEPENDS:=+libevent2 +libopenssl +libpthread +librt +zlib +libcap
 endef
 
 define Package/tor/description

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -40,7 +40,7 @@ endef
 define Package/tor
 $(call Package/tor/Default)
   TITLE:=An anonymous Internet communication system
-  DEPENDS:=+libevent2 +libopenssl +libpthread +librt
+  DEPENDS:=+libevent2 +libopenssl +libpthread +librt +zlib
 endef
 
 define Package/tor/description

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -48,6 +48,28 @@ $(call Package/tor/Default/description)
  This package contains the tor daemon.
 endef
 
+define Package/tor-gencert
+$(call Package/tor/Default)
+  TITLE:=Tor certificate generation
+  DEPENDS:=+tor
+endef
+
+define Package/tor-gencert/description
+$(call Package/tor/Default/description)
+ Generate certs and keys for Tor directory authorities
+endef
+
+define Package/tor-resolve
+$(call Package/tor/Default)
+  TITLE:=tor hostname resolve
+  DEPENDS:=+tor
+endef
+
+define Package/tor-resolve/description
+$(call Package/tor/Default/description)
+ Resolve a hostname to an IP address via tor 
+endef
+
 define Package/tor-geoip
 $(call Package/tor/Default)
   TITLE:=GeoIP db for tor
@@ -93,10 +115,21 @@ CONFIGURE_VARS += \
 define Package/tor/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tor $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/torify $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/tor.init $(1)/etc/init.d/tor
 	$(INSTALL_DIR) $(1)/etc/tor
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/tor/torrc.sample $(1)/etc/tor/torrc
+endef
+
+define Package/tor-gencert/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tor-gencert $(1)/usr/sbin/
+endef
+
+define Package/tor-resolve/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tor-resolve $(1)/usr/sbin/
 endef
 
 define Package/tor-geoip/install
@@ -106,4 +139,6 @@ define Package/tor-geoip/install
 endef
 
 $(eval $(call BuildPackage,tor))
+$(eval $(call BuildPackage,tor-gencert))
+$(eval $(call BuildPackage,tor-resolve))
 $(eval $(call BuildPackage,tor-geoip))

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.2.9.8
+PKG_VERSION:=0.2.9.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_MD5SUM:=fbdd33d3384574297b88744622382008d1e0f9ddd300d330746c464b7a7d746a
+PKG_MD5SUM:=33325d2b250fd047ba2ddc5d11c2190c4e2951f4b03ec48ebd8bf0666e990d43
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
 PKG_LICENSE_FILES:=LICENSE
 

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -102,6 +102,7 @@ endef
 define Package/tor-geoip/install
 	$(INSTALL_DIR) $(1)/usr/share/tor
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/tor/geoip $(1)/usr/share/tor/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/tor/geoip6 $(1)/usr/share/tor/
 endef
 
 $(eval $(call BuildPackage,tor))

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=0.2.7.6
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://www.torproject.org/dist \
+PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
 PKG_MD5SUM:=cc19107b57136a68e8c563bf2d35b072
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.2.8.11
+PKG_VERSION:=0.2.9.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_MD5SUM:=7adea0bfa17edafd4e09453f4f58a0dca737660e5358f9dafd52d55d55dc6ab3
+PKG_MD5SUM:=fbdd33d3384574297b88744622382008d1e0f9ddd300d330746c464b7a7d746a
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
 PKG_LICENSE_FILES:=LICENSE
 
@@ -66,17 +66,23 @@ endef
 CONFIGURE_ARGS += \
 	--with-libevent-dir="$(STAGING_DIR)/usr" \
 	--with-ssl-dir="$(STAGING_DIR)/usr" \
+	--with-openssl-dir="$(STAGING_DIR)/usr" \
+	--with-zlib-dir="$(STAGING_DIR)/usr" \
 	--disable-asciidoc \
-	--disable-seccomp
+	--disable-seccomp \
+	--disable-libscrypt \
+	--disable-unittests \
+	--disable-largefile \
+	--with-tor-user=tor \
+	--with-tor-group=tor
+
+EXTRA_CFLAGS += -std=gnu99
 
 ifneq ($(CONFIG_SSP_SUPPORT),y)
 	CONFIGURE_ARGS += \
 		--disable-gcc-hardening
-	MAKE_FLAGS += \
-		CFLAGS="$(TARGET_CFLAGS) -std=gnu99"
 else
-	MAKE_FLAGS += \
-		CFLAGS="$(TARGET_CFLAGS) -fPIC -std=gnu99"
+	EXTRA_CFLAGS += -fPIC
 endif
 
 CONFIGURE_VARS += \

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -61,6 +61,8 @@ endef
 
 define Package/tor/conffiles
 /etc/tor/torrc
+/var/lib/tor/fingerprint
+/var/lib/tor/keys/*
 endef
 
 CONFIGURE_ARGS += \

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.2.9.10
+PKG_VERSION:=0.2.9.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_MD5SUM:=6760a646a096b61e307b84fb5ae93cc7
-PKG_HASH:=d611283e1fb284b5f884f8c07e7d3151016851848304f56cfdf3be2a88bd1341
+PKG_MD5SUM:=763ae964e916c2a7a4c5015d351fcf8b
+PKG_HASH:=c1959bebff9a546a54cbedb58c8289a42441991af417d2d16f7b336be8903221
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
 PKG_LICENSE_FILES:=LICENSE
 

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2014 OpenWrt.org
+# Copyright (C) 2008-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
 PKG_VERSION:=0.2.7.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.torproject.org/dist \
@@ -18,7 +18,6 @@ PKG_MD5SUM:=cc19107b57136a68e8c563bf2d35b072
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DEPENDS:=libminiupnpc libnatpmp
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -49,17 +48,6 @@ $(call Package/tor/Default/description)
  This package contains the tor daemon.
 endef
 
-define Package/tor-fw-helper
-$(call Package/tor/Default)
-  TITLE:=Firewall helper for tor
-  DEPENDS:=+tor +libminiupnpc +libnatpmp
-endef
-
-define Package/tor-fw-helper/description
-$(call Package/tor/Default/description)
- This package contains a helper for automatically configuring port forwarding.
-endef
-
 define Package/tor-geoip
 $(call Package/tor/Default)
   TITLE:=GeoIP db for tor
@@ -78,10 +66,6 @@ endef
 CONFIGURE_ARGS += \
 	--with-libevent-dir="$(STAGING_DIR)/usr" \
 	--with-ssl-dir="$(STAGING_DIR)/usr" \
-	--enable-upnp \
-	--with-libminiupnpc-dir="$(STAGING_DIR)/usr" \
-	--enable-nat-pmp \
-	--with-libnatpmp-dir="$(STAGING_DIR)/usr" \
 	--disable-asciidoc \
 	--disable-seccomp
 
@@ -92,7 +76,7 @@ ifneq ($(CONFIG_SSP_SUPPORT),y)
 		CFLAGS="$(TARGET_CFLAGS) -std=gnu99"
 else
 	MAKE_FLAGS += \
-		CFLAGS="$(TARGET_CFLAGS) -fPIC -std=gnu99"	
+		CFLAGS="$(TARGET_CFLAGS) -fPIC -std=gnu99"
 endif
 
 CONFIGURE_VARS += \
@@ -107,16 +91,10 @@ define Package/tor/install
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/tor/torrc.sample $(1)/etc/tor/torrc
 endef
 
-define Package/tor-fw-helper/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tor-fw-helper $(1)/usr/bin/
-endef
-
 define Package/tor-geoip/install
 	$(INSTALL_DIR) $(1)/usr/share/tor
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/tor/geoip $(1)/usr/share/tor/
 endef
 
 $(eval $(call BuildPackage,tor))
-$(eval $(call BuildPackage,tor-fw-helper))
 $(eval $(call BuildPackage,tor-geoip))

--- a/net/tor/patches/001-torrc.patch
+++ b/net/tor/patches/001-torrc.patch
@@ -1,6 +1,6 @@
 --- a/src/config/torrc.sample.in
 +++ b/src/config/torrc.sample.in
-@@ -45,11 +45,11 @@
+@@ -46,11 +46,11 @@
  ## Uncomment this to start the process in the background... or use
  ## --runasdaemon 1 on the command line. This is ignored on Windows;
  ## see the FAQ entry if you want Tor to run as an NT service.
@@ -14,7 +14,7 @@
  
  ## The port on which Tor will listen for local connections from Tor
  ## controller applications, as documented in control-spec.txt.
-@@ -190,3 +190,4 @@
+@@ -202,3 +202,4 @@
  ## address manually to your friends, uncomment this line:
  #PublishServerDescriptor 0
  

--- a/net/tor/patches/001-torrc.patch
+++ b/net/tor/patches/001-torrc.patch
@@ -1,11 +1,6 @@
 --- a/src/config/torrc.sample.in
 +++ b/src/config/torrc.sample.in
-@@ -46,11 +46,11 @@
- ## Uncomment this to start the process in the background... or use
- ## --runasdaemon 1 on the command line. This is ignored on Windows;
- ## see the FAQ entry if you want Tor to run as an NT service.
--#RunAsDaemon 1
-+RunAsDaemon 1
+@@ -50,7 +50,7 @@
  
  ## The directory for keeping all the keys/etc. By default, we store
  ## things in $HOME/.tor on Unix, and in Application Data\tor on Windows.
@@ -14,7 +9,7 @@
  
  ## The port on which Tor will listen for local connections from Tor
  ## controller applications, as documented in control-spec.txt.
-@@ -202,3 +202,4 @@
+@@ -204,3 +204,4 @@
  ## address manually to your friends, uncomment this line:
  #PublishServerDescriptor 0
  

--- a/net/tor/patches/001-torrc.patch
+++ b/net/tor/patches/001-torrc.patch
@@ -1,5 +1,14 @@
 --- a/src/config/torrc.sample.in
 +++ b/src/config/torrc.sample.in
+@@ -39,7 +39,7 @@
+ ## Send every possible message to @LOCALSTATEDIR@/log/tor/debug.log
+ #Log debug file @LOCALSTATEDIR@/log/tor/debug.log
+ ## Use the system log instead of Tor's logfiles
+-#Log notice syslog
++Log notice syslog
+ ## To send all messages to stderr:
+ #Log debug stderr
+ 
 @@ -50,7 +50,7 @@
  
  ## The directory for keeping all the keys/etc. By default, we store


### PR DESCRIPTION
Maintainer: @hauke 
Compile tested: CC/adm8668
Run tested: none

Description:
Fix build with backporting the removal of tor-fw-helper and zlib dependency, and upgrade to a less ancient version (0.2.9.11). Notable change is the backporting of preserving tor keys over sysupgrade.