### PR TITLE
php7-fpm: add configuration files to conffiles

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=7.1.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 
@@ -457,6 +457,7 @@ CONFIGURE_VARS+= \
 
 define Package/php7/conffiles
 /etc/php.ini
+/etc/php7/
 endef
 
 define Package/php7/install
@@ -498,6 +499,12 @@ define Package/php7-fpm/install
 
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/php7-fpm.init $(1)/etc/init.d/php7-fpm
+endef
+
+define Package/php7-fpm/conffiles
+/etc/php7-fpm.conf
+/etc/php7-fpm.d/
+/etc/config/php7-fpm
 endef
 
 define Build/Prepare


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5
Run tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5

Description:

Two important configuration files, /etc/php7-fpm.conf and /etc/php7-fpm.d/www.conf are silently overwritten on each php7-fpm upgrade or lost on a sysupgrade.

This commit adds the conffiles section for php7-fpm for saving these two configuration files and /etc/config/php7-fpm.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>