### PR TITLE
tcp_wrappers: fix compilation warnings

### DIFF
--- a/libs/tcp_wrappers/Makefile
+++ b/libs/tcp_wrappers/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcp_wrappers
 PKG_VERSION:=7.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.porcupine.org/pub/security
@@ -30,7 +30,7 @@ define Package/libwrap
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 endef
 
-TARGET_CFLAGS += $(FPIC)
+TARGET_CFLAGS += $(FPIC) -Wall
 
 ifeq ($(CONFIG_USE_MUSL),)
 TARGET_EXTRA_LIBS:=LIBS=-lnsl

--- a/libs/tcp_wrappers/patches/006-compilation-warnings.patch
+++ b/libs/tcp_wrappers/patches/006-compilation-warnings.patch
@@ -1,0 +1,765 @@
+diff -u tcp_wrappers_7.6.orig/clean_exit.c tcp_wrappers_7.6/clean_exit.c
+--- tcp_wrappers_7.6.orig/clean_exit.c	1994-12-29 03:42:20.000000000 +1100
++++ tcp_wrappers_7.6/clean_exit.c	2017-11-14 22:50:48.000000000 +1100
+@@ -9,10 +9,11 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) clean_exit.c 1.4 94/12/28 17:42:19";
++static char sccsid[] __attribute__((__unused__)) = "@(#) clean_exit.c 1.4 94/12/28 17:42:19";
+ #endif
+ 
+ #include <stdio.h>
++#include <unistd.h>
+ 
+ extern void exit();
+ 
+diff -u tcp_wrappers_7.6.orig/diag.c tcp_wrappers_7.6/diag.c
+--- tcp_wrappers_7.6.orig/diag.c	1994-12-29 03:42:20.000000000 +1100
++++ tcp_wrappers_7.6/diag.c	2017-11-14 22:51:09.000000000 +1100
+@@ -10,7 +10,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) diag.c 1.1 94/12/28 17:42:20";
++static char sccsid[] __attribute__((__unused__)) = "@(#) diag.c 1.1 94/12/28 17:42:20";
+ #endif
+ 
+ /* System libraries */
+diff -u tcp_wrappers_7.6.orig/eval.c tcp_wrappers_7.6/eval.c
+--- tcp_wrappers_7.6.orig/eval.c	1995-01-31 05:51:46.000000000 +1100
++++ tcp_wrappers_7.6/eval.c	2017-11-14 22:51:50.000000000 +1100
+@@ -19,7 +19,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) eval.c 1.3 95/01/30 19:51:45";
++static char sccsid[] __attribute__((__unused__)) = "@(#) eval.c 1.3 95/01/30 19:51:45";
+ #endif
+ 
+ /* System libraries. */
+diff -u tcp_wrappers_7.6.orig/fakelog.c tcp_wrappers_7.6/fakelog.c
+--- tcp_wrappers_7.6.orig/fakelog.c	1994-12-29 03:42:22.000000000 +1100
++++ tcp_wrappers_7.6/fakelog.c	2017-11-14 22:52:07.000000000 +1100
+@@ -6,7 +6,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) fakelog.c 1.3 94/12/28 17:42:21";
++static char sccsid[] __attribute__((__unused__)) = "@(#) fakelog.c 1.3 94/12/28 17:42:21";
+ #endif
+ 
+ #include <stdio.h>
+@@ -17,7 +17,7 @@
+ 
+ /* ARGSUSED */
+ 
+-openlog(name, logopt, facility)
++void    openlog(name, logopt, facility)
+ char   *name;
+ int     logopt;
+ int     facility;
+@@ -27,7 +27,7 @@
+ 
+ /* vsyslog - format one record */
+ 
+-vsyslog(severity, fmt, ap)
++void    vsyslog(severity, fmt, ap)
+ int     severity;
+ char   *fmt;
+ va_list ap;
+@@ -43,7 +43,7 @@
+ 
+ /* VARARGS */
+ 
+-VARARGS(syslog, int, severity)
++void    VARARGS(syslog, int, severity)
+ {
+     va_list ap;
+     char   *fmt;
+@@ -56,7 +56,7 @@
+ 
+ /* closelog - dummy */
+ 
+-closelog()
++void    closelog()
+ {
+     /* void */
+ }
+diff -u tcp_wrappers_7.6.orig/fix_options.c tcp_wrappers_7.6/fix_options.c
+--- tcp_wrappers_7.6.orig/fix_options.c	2017-11-13 09:29:08.000000000 +1100
++++ tcp_wrappers_7.6/fix_options.c	2017-11-14 22:52:22.000000000 +1100
+@@ -6,7 +6,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) fix_options.c 1.6 97/04/08 02:29:19";
++static char sccsid[] __attribute__((__unused__)) = "@(#) fix_options.c 1.6 97/04/08 02:29:19";
+ #endif
+ 
+ #include <sys/types.h>
+@@ -29,14 +29,14 @@
+ 
+ /* fix_options - get rid of IP-level socket options */
+ 
+-fix_options(request)
+-struct request_info *request;
++void    fix_options(request)
++struct  request_info *request;
+ {
+ #ifdef IP_OPTIONS
+     unsigned char optbuf[BUFFER_SIZE / 3], *cp;
+     char    lbuf[BUFFER_SIZE], *lp;
+ #if !defined(__GLIBC__)
+-    int     optsize = sizeof(optbuf), ipproto;
++    unsigned int  optsize = sizeof(optbuf), ipproto;
+ #else /* __GLIBC__ */
+     size_t  optsize = sizeof(optbuf);
+     int     ipproto;
+diff -u tcp_wrappers_7.6.orig/fromhost.c tcp_wrappers_7.6/fromhost.c
+--- tcp_wrappers_7.6.orig/fromhost.c	1994-12-29 03:42:24.000000000 +1100
++++ tcp_wrappers_7.6/fromhost.c	2017-11-14 22:52:33.000000000 +1100
+@@ -11,7 +11,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) fromhost.c 1.17 94/12/28 17:42:23";
++static char sccsid[] __attribute__((__unused__)) = "@(#) fromhost.c 1.17 94/12/28 17:42:23";
+ #endif
+ 
+ #if defined(TLI) || defined(PTX) || defined(TLI_SEQUENT)
+diff -u tcp_wrappers_7.6.orig/hosts_access.c tcp_wrappers_7.6/hosts_access.c
+--- tcp_wrappers_7.6.orig/hosts_access.c	2017-11-13 09:29:25.000000000 +1100
++++ tcp_wrappers_7.6/hosts_access.c	2017-11-14 22:52:48.000000000 +1100
+@@ -18,7 +18,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) hosts_access.c 1.21 97/02/12 02:13:22";
++static char sccsid[] __attribute__((__unused__)) = "@(#) hosts_access.c 1.21 97/02/12 02:13:22";
+ #endif
+ 
+ /* System libraries. */
+diff -u tcp_wrappers_7.6.orig/hosts_ctl.c tcp_wrappers_7.6/hosts_ctl.c
+--- tcp_wrappers_7.6.orig/hosts_ctl.c	1994-12-29 03:42:28.000000000 +1100
++++ tcp_wrappers_7.6/hosts_ctl.c	2017-11-14 22:53:01.000000000 +1100
+@@ -12,7 +12,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) hosts_ctl.c 1.4 94/12/28 17:42:27";
++static char sccsid[] __attribute__((__unused__)) = "@(#) hosts_ctl.c 1.4 94/12/28 17:42:27";
+ #endif
+ 
+ #include <stdio.h>
+diff -u tcp_wrappers_7.6.orig/inetcf.c tcp_wrappers_7.6/inetcf.c
+--- tcp_wrappers_7.6.orig/inetcf.c	1997-02-12 12:13:24.000000000 +1100
++++ tcp_wrappers_7.6/inetcf.c	2017-11-14 22:53:11.000000000 +1100
+@@ -6,7 +6,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) inetcf.c 1.7 97/02/12 02:13:23";
++static char sccsid[] __attribute__((__unused__)) = "@(#) inetcf.c 1.7 97/02/12 02:13:23";
+ #endif
+ 
+ #include <sys/types.h>
+@@ -14,6 +14,7 @@
+ #include <stdio.h>
+ #include <errno.h>
+ #include <string.h>
++#include <stdlib.h>
+ 
+ extern int errno;
+ extern void exit();
+@@ -21,6 +22,8 @@
+ #include "tcpd.h"
+ #include "inetcf.h"
+ 
++extern int check_path(char *, struct stat *);
++
+  /*
+   * Network configuration files may live in unusual places. Here are some
+   * guesses. Shorter names follow longer ones.
+diff -u tcp_wrappers_7.6.orig/misc.c tcp_wrappers_7.6/misc.c
+--- tcp_wrappers_7.6.orig/misc.c	2017-11-13 09:29:25.000000000 +1100
++++ tcp_wrappers_7.6/misc.c	2017-11-14 22:53:23.000000000 +1100
+@@ -5,7 +5,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsic[] = "@(#) misc.c 1.2 96/02/11 17:01:29";
++static char sccsid[] __attribute__((__unused__)) = "@(#) misc.c 1.2 96/02/11 17:01:29";
+ #endif
+ 
+ #include <sys/types.h>
+diff -u tcp_wrappers_7.6.orig/myvsyslog.c tcp_wrappers_7.6/myvsyslog.c
+--- tcp_wrappers_7.6.orig/myvsyslog.c	1994-12-29 03:42:34.000000000 +1100
++++ tcp_wrappers_7.6/myvsyslog.c	2017-11-14 22:53:35.000000000 +1100
+@@ -8,7 +8,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) myvsyslog.c 1.1 94/12/28 17:42:33";
++static char sccsid[] __attribute__((__unused__)) = "@(#) myvsyslog.c 1.1 94/12/28 17:42:33";
+ #endif
+ 
+ #ifdef vsyslog
+diff -u tcp_wrappers_7.6.orig/options.c tcp_wrappers_7.6/options.c
+--- tcp_wrappers_7.6.orig/options.c	2017-11-13 09:29:08.000000000 +1100
++++ tcp_wrappers_7.6/options.c	2017-11-14 22:53:50.000000000 +1100
+@@ -29,7 +29,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) options.c 1.17 96/02/11 17:01:31";
++static char sccsid[] __attribute__((__unused__)) = "@(#) options.c 1.17 96/02/11 17:01:31";
+ #endif
+ 
+ /* System libraries. */
+@@ -47,6 +47,8 @@
+ #include <ctype.h>
+ #include <setjmp.h>
+ #include <string.h>
++#include <stdlib.h>
++#include <unistd.h>
+ 
+ #ifndef MAXPATHNAMELEN
+ #define MAXPATHNAMELEN  BUFSIZ
+@@ -108,21 +110,21 @@
+ /* List of known keywords. Add yours here. */
+ 
+ static struct option option_table[] = {
+-    "user", user_option, NEED_ARG,
+-    "group", group_option, NEED_ARG,
+-    "umask", umask_option, NEED_ARG,
+-    "linger", linger_option, NEED_ARG,
+-    "keepalive", keepalive_option, 0,
+-    "spawn", spawn_option, NEED_ARG | EXPAND_ARG,
+-    "twist", twist_option, NEED_ARG | EXPAND_ARG | USE_LAST,
+-    "rfc931", rfc931_option, OPT_ARG,
+-    "setenv", setenv_option, NEED_ARG | EXPAND_ARG,
+-    "nice", nice_option, OPT_ARG,
+-    "severity", severity_option, NEED_ARG,
+-    "allow", allow_option, USE_LAST,
+-    "deny", deny_option, USE_LAST,
+-    "banners", banners_option, NEED_ARG,
+-    0,
++   { "user", user_option, NEED_ARG },
++   { "group", group_option, NEED_ARG },
++   { "umask", umask_option, NEED_ARG },
++   { "linger", linger_option, NEED_ARG },
++   { "keepalive", keepalive_option, 0 },
++   { "spawn", spawn_option, NEED_ARG | EXPAND_ARG },
++   { "twist", twist_option, NEED_ARG | EXPAND_ARG | USE_LAST },
++   { "rfc931", rfc931_option, OPT_ARG },
++   { "setenv", setenv_option, NEED_ARG | EXPAND_ARG },
++   { "nice", nice_option, OPT_ARG },
++   { "severity", severity_option, NEED_ARG },
++   { "allow", allow_option, USE_LAST },
++   { "deny", deny_option, USE_LAST },
++   { "banners", banners_option, NEED_ARG },
++   { 0 },
+ };
+ 
+ /* process_options - process access control options */
+@@ -447,88 +449,88 @@
+ 
+ static struct syslog_names log_fac[] = {
+ #ifdef LOG_KERN
+-    "kern", LOG_KERN,
++    { "kern", LOG_KERN },
+ #endif
+ #ifdef LOG_USER
+-    "user", LOG_USER,
++    { "user", LOG_USER },
+ #endif
+ #ifdef LOG_MAIL
+-    "mail", LOG_MAIL,
++    { "mail", LOG_MAIL },
+ #endif
+ #ifdef LOG_DAEMON
+-    "daemon", LOG_DAEMON,
++    { "daemon", LOG_DAEMON },
+ #endif
+ #ifdef LOG_AUTH
+-    "auth", LOG_AUTH,
++    { "auth", LOG_AUTH },
+ #endif
+ #ifdef LOG_LPR
+-    "lpr", LOG_LPR,
++    { "lpr", LOG_LPR },
+ #endif
+ #ifdef LOG_NEWS
+-    "news", LOG_NEWS,
++    { "news", LOG_NEWS },
+ #endif
+ #ifdef LOG_UUCP
+-    "uucp", LOG_UUCP,
++    { "uucp", LOG_UUCP },
+ #endif
+ #ifdef LOG_CRON
+-    "cron", LOG_CRON,
++    { "cron", LOG_CRON },
+ #endif
+ #ifdef LOG_FTP
+-    "ftp", LOG_FTP,
++    { "ftp", LOG_FTP },
+ #endif
+ #ifdef LOG_LOCAL0
+-    "local0", LOG_LOCAL0,
++    { "local0", LOG_LOCAL0 },
+ #endif
+ #ifdef LOG_LOCAL1
+-    "local1", LOG_LOCAL1,
++    { "local1", LOG_LOCAL1 },
+ #endif
+ #ifdef LOG_LOCAL2
+-    "local2", LOG_LOCAL2,
++    { "local2", LOG_LOCAL2 },
+ #endif
+ #ifdef LOG_LOCAL3
+-    "local3", LOG_LOCAL3,
++    { "local3", LOG_LOCAL3 },
+ #endif
+ #ifdef LOG_LOCAL4
+-    "local4", LOG_LOCAL4,
++    { "local4", LOG_LOCAL4 },
+ #endif
+ #ifdef LOG_LOCAL5
+-    "local5", LOG_LOCAL5,
++    { "local5", LOG_LOCAL5 },
+ #endif
+ #ifdef LOG_LOCAL6
+-    "local6", LOG_LOCAL6,
++    { "local6", LOG_LOCAL6 },
+ #endif
+ #ifdef LOG_LOCAL7
+-    "local7", LOG_LOCAL7,
++    { "local7", LOG_LOCAL7 },
+ #endif
+-    0,
++    { 0 },
+ };
+ 
+ static struct syslog_names log_sev[] = {
+ #ifdef LOG_EMERG
+-    "emerg", LOG_EMERG,
++    { "emerg", LOG_EMERG },
+ #endif
+ #ifdef LOG_ALERT
+-    "alert", LOG_ALERT,
++    { "alert", LOG_ALERT },
+ #endif
+ #ifdef LOG_CRIT
+-    "crit", LOG_CRIT,
++    { "crit", LOG_CRIT },
+ #endif
+ #ifdef LOG_ERR
+-    "err", LOG_ERR,
++    { "err", LOG_ERR },
+ #endif
+ #ifdef LOG_WARNING
+-    "warning", LOG_WARNING,
++    { "warning", LOG_WARNING },
+ #endif
+ #ifdef LOG_NOTICE
+-    "notice", LOG_NOTICE,
++    { "notice", LOG_NOTICE },
+ #endif
+ #ifdef LOG_INFO
+-    "info", LOG_INFO,
++    { "info", LOG_INFO },
+ #endif
+ #ifdef LOG_DEBUG
+-    "debug", LOG_DEBUG,
++    { "debug", LOG_DEBUG },
+ #endif
+-    0,
++    { 0 },
+ };
+ 
+ /* severity_map - lookup facility or severity value */
+@@ -589,7 +591,7 @@
+     if (src[0] == 0)
+ 	return (0);
+ 
+-    while (ch = *src) {
++    while ((ch = *src)) {
+ 	if (ch == ':') {
+ 	    if (*++src == 0)
+ 		tcpd_warn("rule ends in \":\"");
+diff -u tcp_wrappers_7.6.orig/patchlevel.h tcp_wrappers_7.6/patchlevel.h
+--- tcp_wrappers_7.6.orig/patchlevel.h	1997-03-22 05:27:24.000000000 +1100
++++ tcp_wrappers_7.6/patchlevel.h	2017-11-14 22:54:15.000000000 +1100
+@@ -1,3 +1,3 @@
+ #ifndef lint
+-static char patchlevel[] = "@(#) patchlevel 7.6 97/03/21 19:27:23";
++static char patchlevel[] __attribute__((__unused__)) = "@(#) patchlevel 7.6 97/03/21 19:27:23";
+ #endif
+diff -u tcp_wrappers_7.6.orig/percent_m.c tcp_wrappers_7.6/percent_m.c
+--- tcp_wrappers_7.6.orig/percent_m.c	2017-11-13 09:29:08.000000000 +1100
++++ tcp_wrappers_7.6/percent_m.c	2017-11-14 22:54:31.000000000 +1100
+@@ -5,7 +5,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) percent_m.c 1.1 94/12/28 17:42:37";
++static char sccsid[] __attribute__((__unused__)) = "@(#) percent_m.c 1.1 94/12/28 17:42:37";
+ #endif
+ 
+ #include <stdio.h>
+@@ -27,7 +27,7 @@
+     char   *bp = obuf;
+     char   *cp = ibuf;
+ 
+-    while (*bp = *cp)
++    while ((*bp = *cp))
+ 	if (*cp == '%' && cp[1] == 'm') {
+ #ifdef HAVE_STRERROR
+             strcpy(bp, strerror(errno));
+diff -u tcp_wrappers_7.6.orig/percent_x.c tcp_wrappers_7.6/percent_x.c
+--- tcp_wrappers_7.6.orig/percent_x.c	1994-12-29 03:42:38.000000000 +1100
++++ tcp_wrappers_7.6/percent_x.c	2017-11-14 22:54:40.000000000 +1100
+@@ -11,7 +11,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) percent_x.c 1.4 94/12/28 17:42:37";
++static char sccsid[] __attribute__((__unused__)) = "@(#) percent_x.c 1.4 94/12/28 17:42:37";
+ #endif
+ 
+ /* System libraries. */
+@@ -19,6 +19,7 @@
+ #include <stdio.h>
+ #include <syslog.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ extern void exit();
+ 
+diff -u tcp_wrappers_7.6.orig/refuse.c tcp_wrappers_7.6/refuse.c
+--- tcp_wrappers_7.6.orig/refuse.c	1994-12-29 03:42:40.000000000 +1100
++++ tcp_wrappers_7.6/refuse.c	2017-11-14 22:54:50.000000000 +1100
+@@ -8,7 +8,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) refuse.c 1.5 94/12/28 17:42:39";
++static char sccsid[] __attribute__((__unused__)) = "@(#) refuse.c 1.5 94/12/28 17:42:39";
+ #endif
+ 
+ /* System libraries. */
+diff -u tcp_wrappers_7.6.orig/rfc931.c tcp_wrappers_7.6/rfc931.c
+--- tcp_wrappers_7.6.orig/rfc931.c	2017-11-13 09:29:08.000000000 +1100
++++ tcp_wrappers_7.6/rfc931.c	2017-11-14 22:54:58.000000000 +1100
+@@ -10,7 +10,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) rfc931.c 1.10 95/01/02 16:11:34";
++static char sccsid[] __attribute__((__unused__)) = "@(#) rfc931.c 1.10 95/01/02 16:11:34";
+ #endif
+ 
+ /* System libraries. */
+@@ -23,6 +23,7 @@
+ #include <setjmp.h>
+ #include <signal.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ /* Local stuff. */
+ 
+@@ -152,7 +153,7 @@
+ 		     * protocol, not part of the data.
+ 		     */
+ 
+-		    if (cp = strchr(user, '\r'))
++		    if ((cp = strchr(user, '\r')))
+ 			*cp = 0;
+ 		    result = user;
+ 		}
+diff -u tcp_wrappers_7.6.orig/safe_finger.c tcp_wrappers_7.6/safe_finger.c
+--- tcp_wrappers_7.6.orig/safe_finger.c	2017-11-13 09:29:08.000000000 +1100
++++ tcp_wrappers_7.6/safe_finger.c	2017-11-14 22:55:08.000000000 +1100
+@@ -15,7 +15,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) safe_finger.c 1.4 94/12/28 17:42:41";
++static char sccsid[] __attribute__((__unused__)) = "@(#) safe_finger.c 1.4 94/12/28 17:42:41";
+ #endif
+ 
+ /* System libraries */
+@@ -27,6 +27,10 @@
+ #include <ctype.h>
+ #include <pwd.h>
+ #include <syslog.h>
++#include <fcntl.h>
++#include <stdlib.h>
++#include <sys/wait.h>
++#include <unistd.h>
+ 
+ extern void exit();
+ 
+@@ -45,6 +49,8 @@
+ int	allow_severity = SEVERITY;
+ int	deny_severity = LOG_WARNING;
+ 
++int     pipe_stdin();
++
+ void    cleanup(sig)
+ int     sig;
+ {
+@@ -52,7 +58,7 @@
+     exit(0);
+ }
+ 
+-main(argc, argv)
++int     main(argc, argv)
+ int     argc;
+ char  **argv;
+ {
+diff -u tcp_wrappers_7.6.orig/scaffold.c tcp_wrappers_7.6/scaffold.c
+--- tcp_wrappers_7.6.orig/scaffold.c	2017-11-13 09:29:21.000000000 +1100
++++ tcp_wrappers_7.6/scaffold.c	2017-11-14 22:55:32.000000000 +1100
+@@ -5,7 +5,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccs_id[] = "@(#) scaffold.c 1.6 97/03/21 19:27:24";
++static char sccsid[] __attribute__((__unused__)) = "@(#) scaffold.c 1.6 97/03/21 19:27:24";
+ #endif
+ 
+ /* System libraries. */
+diff -u tcp_wrappers_7.6.orig/shell_cmd.c tcp_wrappers_7.6/shell_cmd.c
+--- tcp_wrappers_7.6.orig/shell_cmd.c	1994-12-29 03:42:44.000000000 +1100
++++ tcp_wrappers_7.6/shell_cmd.c	2017-11-14 22:55:45.000000000 +1100
+@@ -9,7 +9,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) shell_cmd.c 1.5 94/12/28 17:42:44";
++static char sccsid[] __attribute__((__unused__)) = "@(#) shell_cmd.c 1.5 94/12/28 17:42:44";
+ #endif
+ 
+ /* System libraries. */
+@@ -20,6 +20,9 @@
+ #include <stdio.h>
+ #include <syslog.h>
+ #include <string.h>
++#include <fcntl.h>
++#include <sys/wait.h>
++#include <unistd.h>
+ 
+ extern void exit();
+ 
+diff -u tcp_wrappers_7.6.orig/socket.c tcp_wrappers_7.6/socket.c
+--- tcp_wrappers_7.6.orig/socket.c	2017-11-13 09:29:08.000000000 +1100
++++ tcp_wrappers_7.6/socket.c	2017-11-14 22:55:57.000000000 +1100
+@@ -16,7 +16,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) socket.c 1.15 97/03/21 19:27:24";
++static char sccsid[] __attribute__((__unused__)) = "@(#) socket.c 1.15 97/03/21 19:27:24";
+ #endif
+ 
+ /* System libraries. */
+@@ -77,7 +77,7 @@
+     static struct sockaddr_in client;
+     static struct sockaddr_in server;
+ #if !defined (__GLIBC__)
+-    int     len;
++    unsigned int  len;
+ #else /* __GLIBC__ */
+     size_t  len;
+ #endif /* __GLIBC__ */
+@@ -229,7 +229,7 @@
+     char    buf[BUFSIZ];
+     struct sockaddr_in sin;
+ #if !defined(__GLIBC__)
+-    int     size = sizeof(sin);
++    unsigned int  size = sizeof(sin);
+ #else /* __GLIBC__ */
+     size_t  size = sizeof(sin);
+ #endif /* __GLIBC__ */
+diff -u tcp_wrappers_7.6.orig/tcpd.c tcp_wrappers_7.6/tcpd.c
+--- tcp_wrappers_7.6.orig/tcpd.c	1996-02-12 03:01:33.000000000 +1100
++++ tcp_wrappers_7.6/tcpd.c	2017-11-14 22:56:09.000000000 +1100
+@@ -11,7 +11,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) tcpd.c 1.10 96/02/11 17:01:32";
++static char sccsid[] __attribute__((__unused__)) = "@(#) tcpd.c 1.10 96/02/11 17:01:32";
+ #endif
+ 
+ /* System libraries. */
+@@ -24,6 +24,7 @@
+ #include <stdio.h>
+ #include <syslog.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ #ifndef MAXPATHNAMELEN
+ #define MAXPATHNAMELEN	BUFSIZ
+@@ -38,10 +39,12 @@
+ #include "patchlevel.h"
+ #include "tcpd.h"
+ 
++extern void fix_options(struct request_info *);
++
+ int     allow_severity = SEVERITY;	/* run-time adjustable */
+ int     deny_severity = LOG_WARNING;	/* ditto */
+ 
+-main(argc, argv)
++int     main(argc, argv)
+ int     argc;
+ char  **argv;
+ {
+diff -u tcp_wrappers_7.6.orig/tcpd.h tcp_wrappers_7.6/tcpd.h
+--- tcp_wrappers_7.6.orig/tcpd.h	2017-11-13 09:29:25.000000000 +1100
++++ tcp_wrappers_7.6/tcpd.h	2017-11-14 22:36:40.000000000 +1100
+@@ -182,10 +182,10 @@
+ 
+ #ifdef __STDC__
+ extern void tcpd_warn(char *, ...);	/* report problem and proceed */
+-extern void tcpd_jump(char *, ...);	/* report problem and jump */
++extern void tcpd_jump(char *, ...) __attribute__((__noreturn__));	/* report problem and jump */
+ #else
+ extern void tcpd_warn();
+-extern void tcpd_jump();
++extern void tcpd_jump() __attribute__((__noreturn__));
+ #endif
+ 
+ struct tcpd_context {
+diff -u tcp_wrappers_7.6.orig/tcpdchk.c tcp_wrappers_7.6/tcpdchk.c
+--- tcp_wrappers_7.6.orig/tcpdchk.c	2017-11-13 09:29:08.000000000 +1100
++++ tcp_wrappers_7.6/tcpdchk.c	2017-11-14 22:56:21.000000000 +1100
+@@ -15,7 +15,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) tcpdchk.c 1.8 97/02/12 02:13:25";
++static char sccsid[] __attribute__((__unused__)) = "@(#) tcpdchk.c 1.8 97/02/12 02:13:25";
+ #endif
+ 
+ /* System libraries. */
+@@ -30,6 +30,7 @@
+ #include <errno.h>
+ #include <netdb.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ extern int errno;
+ extern void exit();
+@@ -199,13 +200,15 @@
+     char    sv_list[BUFLEN];		/* becomes list of daemons */
+     char   *cl_list;			/* becomes list of requests */
+     char   *sh_cmd;			/* becomes optional shell command */
++#ifndef PROCESS_OPTIONS
+     char    buf[BUFSIZ];
++#endif
+     int     verdict;
+     struct tcpd_context saved_context;
+ 
+     saved_context = tcpd_context;		/* stupid compilers */
+ 
+-    if (fp = fopen(table, "r")) {
++    if ((fp = fopen(table, "r"))) {
+ 	tcpd_context.file = table;
+ 	tcpd_context.line = 0;
+ 	while (xgets(sv_list, sizeof(sv_list), fp)) {
+@@ -331,7 +334,7 @@
+ 	    clients = 0;
+ 	} else {
+ 	    clients++;
+-	    if (host = split_at(cp + 1, '@')) {	/* user@host */
++	    if ((host = split_at(cp + 1, '@'))) {	/* user@host */
+ 		check_user(cp);
+ 		check_host(host);
+ 	    } else {
+@@ -446,7 +449,7 @@
+         } else if (errno != ENOENT) {
+             tcpd_warn("open %s: %m", pat);
+         }
+-    } else if (mask = split_at(pat, '/')) {	/* network/netmask */
++    } else if ((mask = split_at(pat, '/'))) {	/* network/netmask */
+ 	if (dot_quad_addr(pat) == INADDR_NONE
+ 	    || dot_quad_addr(mask) == INADDR_NONE)
+ 	    tcpd_warn("%s/%s: bad net/mask pattern", pat, mask);
+diff -u tcp_wrappers_7.6.orig/tcpdmatch.c tcp_wrappers_7.6/tcpdmatch.c
+--- tcp_wrappers_7.6.orig/tcpdmatch.c	1996-02-12 03:01:36.000000000 +1100
++++ tcp_wrappers_7.6/tcpdmatch.c	2017-11-14 22:56:40.000000000 +1100
+@@ -14,7 +14,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) tcpdmatch.c 1.5 96/02/11 17:01:36";
++static char sccsid[] __attribute__((__unused__)) = "@(#) tcpdmatch.c 1.5 96/02/11 17:01:36";
+ #endif
+ 
+ /* System libraries. */
+@@ -29,6 +29,8 @@
+ #include <syslog.h>
+ #include <setjmp.h>
+ #include <string.h>
++#include <stdlib.h>
++#include <unistd.h>
+ 
+ extern void exit();
+ extern int optind;
+diff -u tcp_wrappers_7.6.orig/tli.c tcp_wrappers_7.6/tli.c
+--- tcp_wrappers_7.6.orig/tli.c	1997-03-22 05:27:26.000000000 +1100
++++ tcp_wrappers_7.6/tli.c	2017-11-14 22:56:50.000000000 +1100
+@@ -15,7 +15,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) tli.c 1.15 97/03/21 19:27:25";
++static char sccsid[] __attribute__((__unused__)) = "@(#) tli.c 1.15 97/03/21 19:27:25";
+ #endif
+ 
+ #ifdef TLI
+diff -u tcp_wrappers_7.6.orig/try-from.c tcp_wrappers_7.6/try-from.c
+--- tcp_wrappers_7.6.orig/try-from.c	1994-12-29 03:42:55.000000000 +1100
++++ tcp_wrappers_7.6/try-from.c	2017-11-14 22:56:59.000000000 +1100
+@@ -11,7 +11,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) try-from.c 1.2 94/12/28 17:42:55";
++static char sccsid[] __attribute__((__unused__)) = "@(#) try-from.c 1.2 94/12/28 17:42:55";
+ #endif
+ 
+ /* System libraries. */
+@@ -37,7 +37,7 @@
+ int     allow_severity = SEVERITY;	/* run-time adjustable */
+ int     deny_severity = LOG_WARNING;	/* ditto */
+ 
+-main(argc, argv)
++int     main(argc, argv)
+ int     argc;
+ char  **argv;
+ {
+diff -u tcp_wrappers_7.6.orig/update.c tcp_wrappers_7.6/update.c
+--- tcp_wrappers_7.6.orig/update.c	1994-12-29 03:42:56.000000000 +1100
++++ tcp_wrappers_7.6/update.c	2017-11-14 22:57:09.000000000 +1100
+@@ -14,7 +14,7 @@
+   */
+ 
+ #ifndef lint
+-static char sccsid[] = "@(#) update.c 1.1 94/12/28 17:42:56";
++static char sccsid[] __attribute__((__unused__)) = "@(#) update.c 1.1 94/12/28 17:42:56";
+ #endif
+ 
+ /* System libraries */
+@@ -22,6 +22,7 @@
+ #include <stdio.h>
+ #include <syslog.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ /* Local stuff. */
+ 


### PR DESCRIPTION
Maintainer: Peter Wagner / @tripolar 
Compile tested: LEDE f0c37f6
Run tested: -

Description:

As requested on https://github.com/openwrt/packages/pull/4994, added a patch to silence compilation warnings.

This does not survive adding `-Wall` to `TARGET_CFLAGS`, I guess that's what happens with code from 1997.