### PR TITLE
CC: php: upgrade to 5.6.32

### DIFF
--- a/lang/php5/Makefile
+++ b/lang/php5/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=5.6.25
+PKG_VERSION:=5.6.26
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>, Michael Heimpold <mhei@heimpold.de>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_MD5SUM:=81cb8c0de0d0b714587edbd27a2a75bb
+PKG_MD5SUM:=c51e9115263b4d63ef8f68935cefd7d4
 
 PKG_FIXUP:=libtool autoreconf
 PKG_BUILD_PARALLEL:=1

--- a/lang/php5/Makefile
+++ b/lang/php5/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=5.6.19
-PKG_RELEASE:=2
+PKG_VERSION:=5.6.21
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>, Michael Heimpold <mhei@heimpold.de>
 
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_MD5SUM:=aab960cc1b2bfbeb00d030a9d42b38bd
+PKG_MD5SUM:=177c69d47024541739c439c9d9eb6ba5
 
 PKG_FIXUP:=libtool autoreconf
 PKG_BUILD_PARALLEL:=1

--- a/lang/php5/Makefile
+++ b/lang/php5/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=5.6.17
+PKG_VERSION:=5.6.18
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>, Michael Heimpold <mhei@heimpold.de>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_MD5SUM:=5e080e4b7df5db24f1b64313f8114bd8
+PKG_MD5SUM:=177ba962557795866ae331ad4ad99bba
 
 PKG_FIXUP:=libtool autoreconf
 PKG_BUILD_PARALLEL:=1

--- a/lang/php5/Makefile
+++ b/lang/php5/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=5.6.19
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>, Michael Heimpold <mhei@heimpold.de>
 
@@ -32,7 +32,7 @@ PHP5_MODULES = \
 	ftp \
 	gettext gd gmp \
 	hash \
-	iconv \
+	iconv intl \
 	json \
 	ldap \
 	mbstring mcrypt mysql mysqli \
@@ -98,6 +98,7 @@ endef
 
 define Package/php5-cli
   $(call Package/php5/Default)
+  DEPENDS+= +PACKAGE_php5-mod-intl:libstdcpp
   TITLE+= (CLI)
 endef
 
@@ -108,6 +109,7 @@ endef
 
 define Package/php5-cgi
   $(call Package/php5/Default)
+  DEPENDS+= +PACKAGE_php5-mod-intl:libstdcpp
   TITLE+= (CGI & FastCGI)
 endef
 
@@ -235,6 +237,12 @@ ifneq ($(SDK)$(CONFIG_PACKAGE_php5-mod-iconv),)
   CONFIGURE_ARGS+= --with-iconv=shared,"$(ICONV_PREFIX)"
 else
   CONFIGURE_ARGS+= --without-iconv
+endif
+
+ifneq ($(SDK)$(CONFIG_PACKAGE_php5-mod-intl),)
+  CONFIGURE_ARGS+= --enable-intl=shared
+else
+  CONFIGURE_ARGS+= --disable-intl
 endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_php5-mod-json),)
@@ -543,6 +551,7 @@ $(eval $(call BuildModule,gettext,Gettext,+PACKAGE_php5-mod-gettext:libintl-full
 $(eval $(call BuildModule,gmp,GMP,+PACKAGE_php5-mod-gmp:libgmp))
 $(eval $(call BuildModule,hash,Hash))
 $(eval $(call BuildModule,iconv,iConv,$(ICONV_DEPENDS)))
+$(eval $(call BuildModule,intl,Internationalization Functions,+PACKAGE_php5-mod-intl:icu))
 $(eval $(call BuildModule,json,JSON))
 $(eval $(call BuildModule,ldap,LDAP,+PACKAGE_php5-mod-ldap:libopenldap +PACKAGE_php5-mod-ldap:libsasl2))
 $(eval $(call BuildModule,mbstring,MBString))

--- a/lang/php5/Makefile
+++ b/lang/php5/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=5.6.18
+PKG_VERSION:=5.6.19
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>, Michael Heimpold <mhei@heimpold.de>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_MD5SUM:=177ba962557795866ae331ad4ad99bba
+PKG_MD5SUM:=aab960cc1b2bfbeb00d030a9d42b38bd
 
 PKG_FIXUP:=libtool autoreconf
 PKG_BUILD_PARALLEL:=1

--- a/lang/php5/Makefile
+++ b/lang/php5/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=5.6.21
+PKG_VERSION:=5.6.23
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>, Michael Heimpold <mhei@heimpold.de>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_MD5SUM:=177c69d47024541739c439c9d9eb6ba5
+PKG_MD5SUM:=c2d2155e50bcbaa0ee7a63845862c894
 
 PKG_FIXUP:=libtool autoreconf
 PKG_BUILD_PARALLEL:=1
@@ -266,7 +266,7 @@ else
 endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_php5-mod-mcrypt),)
-  CONFIGURE_ARGS+=  --with-mcrypt=shared,"$(STAGING_DIR)/usr"
+  CONFIGURE_ARGS+= --with-mcrypt=shared,"$(STAGING_DIR)/usr"
 else
   CONFIGURE_ARGS+= --without-mcrypt
 endif

--- a/lang/php5/Makefile
+++ b/lang/php5/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=5.6.23
+PKG_VERSION:=5.6.25
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>, Michael Heimpold <mhei@heimpold.de>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_MD5SUM:=c2d2155e50bcbaa0ee7a63845862c894
+PKG_MD5SUM:=81cb8c0de0d0b714587edbd27a2a75bb
 
 PKG_FIXUP:=libtool autoreconf
 PKG_BUILD_PARALLEL:=1

--- a/lang/php5/Makefile
+++ b/lang/php5/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=5.6.26
+PKG_VERSION:=5.6.32
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>, Michael Heimpold <mhei@heimpold.de>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_MD5SUM:=c51e9115263b4d63ef8f68935cefd7d4
+PKG_MD5SUM:=660cd5bc0f16eaad655b7815c757aadc
 
 PKG_FIXUP:=libtool autoreconf
 PKG_BUILD_PARALLEL:=1

--- a/lang/php5/patches/102-debian_patches_use_embedded_timezonedb.patch
+++ b/lang/php5/patches/102-debian_patches_use_embedded_timezonedb.patch
@@ -20,9 +20,9 @@ r1: initial revision
 
 --- a/ext/date/lib/parse_tz.c
 +++ b/ext/date/lib/parse_tz.c
-@@ -18,8 +18,22 @@
- 
- /* $Id$ */
+@@ -22,8 +22,22 @@
+  * THE SOFTWARE.
+  */
  
 +#ifndef PATH_MAX
 +#define PATH_MAX 4096
@@ -43,7 +43,7 @@ r1: initial revision
  #include <stdio.h>
  
  #ifdef HAVE_LOCALE_H
-@@ -32,8 +46,12 @@
+@@ -36,8 +50,12 @@
  #include <strings.h>
  #endif
  
@@ -56,7 +56,7 @@ r1: initial revision
  
  #if (defined(__APPLE__) || defined(__APPLE_CC__)) && (defined(__BIG_ENDIAN__) || defined(__LITTLE_ENDIAN__))
  # if defined(__LITTLE_ENDIAN__)
-@@ -55,6 +73,11 @@ static int read_preamble(const unsigned
+@@ -59,6 +77,11 @@ static int read_preamble(const unsigned
  {
  	uint32_t version;
  
@@ -68,7 +68,7 @@ r1: initial revision
  	/* read ID */
  	version = (*tzf)[3] - '0';
  	*tzf += 4;
-@@ -298,7 +321,406 @@ void timelib_dump_tzinfo(timelib_tzinfo
+@@ -302,7 +325,406 @@ void timelib_dump_tzinfo(timelib_tzinfo
  	}
  }
  
@@ -476,7 +476,7 @@ r1: initial revision
  {
  	int left = 0, right = tzdb->index_size - 1;
  #ifdef HAVE_SETLOCALE
-@@ -337,21 +759,90 @@ static int seek_to_tz_position(const uns
+@@ -341,21 +763,90 @@ static int seek_to_tz_position(const uns
  	return 0;
  }
  
@@ -568,7 +568,7 @@ r1: initial revision
  }
  
  static void skip_64bit_preamble(const unsigned char **tzf, timelib_tzinfo *tz)
-@@ -376,10 +867,12 @@ static void read_64bit_header(const unsi
+@@ -380,10 +871,12 @@ static void read_64bit_header(const unsi
  timelib_tzinfo *timelib_parse_tzfile(char *timezone, const timelib_tzdb *tzdb)
  {
  	const unsigned char *tzf;
@@ -582,7 +582,7 @@ r1: initial revision
  		tmp = timelib_tzinfo_ctor(timezone);
  
  		version = read_preamble(&tzf, tmp);
-@@ -393,7 +886,34 @@ timelib_tzinfo *timelib_parse_tzfile(cha
+@@ -397,7 +890,34 @@ timelib_tzinfo *timelib_parse_tzfile(cha
  			skip_64bit_types(&tzf, tmp);
  			skip_posix_string(&tzf, tmp);
  		}

--- a/lang/php5/patches/200-ext-opcache-fix-detection-of-shm-mmap.patch
+++ b/lang/php5/patches/200-ext-opcache-fix-detection-of-shm-mmap.patch
@@ -18,8 +18,6 @@ Signed-off-by: Michael Heimpold <mhei@heimpold.de>
  ext/opcache/config.m4 |  122 ++-----------------------------------------------
  1 file changed, 4 insertions(+), 118 deletions(-)
 
-diff --git a/ext/opcache/config.m4 b/ext/opcache/config.m4
-index b7e4835..7b6c0aa 100644
 --- a/ext/opcache/config.m4
 +++ b/ext/opcache/config.m4
 @@ -11,127 +11,13 @@ if test "$PHP_OPCACHE" != "no"; then
@@ -154,6 +152,3 @@ index b7e4835..7b6c0aa 100644
  
    AC_MSG_CHECKING(for mmap() using /dev/zero shared memory support)
    AC_TRY_RUN([
--- 
-1.7.10.4
-

--- a/lang/php5/patches/950-Fix-dl-cross-compiling-issue.patch
+++ b/lang/php5/patches/950-Fix-dl-cross-compiling-issue.patch
@@ -55,5 +55,5 @@
 +    AC_MSG_RESULT("no")
 +])
  
- if test "$flock_type" == "unknown"; then
+ if test "$flock_type" = "unknown"; then
  	AC_MSG_ERROR([Don't know how to define struct flock on this system[,] set --enable-opcache=no])


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: CC/adm8668, CC/sunxi
Run tested: CC/sunxi

Description:
Users on CC are probably not prepared to move to PHP 7, but we would still need to provide an upgrade path, so upgrade to the latest available version. Testing included running a phpinfo() and a mysql test connection via php-cli. Although a "segfault" appeared at end of code execution, this was present in the previous 5.6.17 build as well.