### PR TITLE
cgi-io: support SHA256 checksums for file uploads

### DIFF
--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_LICENSE:=GPL-2.0+
 


### PR DESCRIPTION
Maintainer: @blogic 
Compile tested: x86/64, LEDE r3585-421754191d
Run tested: x86/64, LEDE r4497-a73471dea7

Description:

Report SHA256 checksums in addition to the MD5 ones to make cgi-io suitable
for sysupgrade image verification.

Also allow stat(), md5sum and/or sha256sum to fail and respond with a JSON
null value instead, leaving it to the frontend to handle errors as needed.

Fixes #4790.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>
