### PR TITLE
boxbackup: a bandwidth-efficient client-server backup system

### DIFF
--- a/utils/boxbackup/Makefile
+++ b/utils/boxbackup/Makefile
@@ -1,0 +1,117 @@
+#
+# Copyright (C) 2017 Val Kulkov <val.kulkov@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+#
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=boxbackup
+PKG_SOURCE_DATE:=2017-10-18
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/boxbackup/boxbackup.git
+PKG_SOURCE_VERSION:=24aca3fc618e36e2feb448bd7b5c05b31a064bd3
+PKG_MIRROR_HASH:=ba6a76040c070b864f4d0057c160492eca522107dfa2e006df41abd1554b2161
+PKG_MAINTAINER:=Val Kulkov <val.kulkov@gmail.com>
+
+PKG_LICENSE:=GPL-2.0 BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE.txt LICENSE-DUAL.txt LICENSE-GPL.txt COPYING.txt
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/boxbackup/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  URL:=https://www.boxbackup.org/
+  TITLE:=A client-server online backup system
+endef
+
+define Package/boxbackup/description/Default
+Box Backup is an open source, completely automatic, on-line backup
+system that supports both continuous and snapshot backups and secure
+file transfer over an untrusted network.
+endef
+
+define Package/boxbackup-server
+  $(call Package/boxbackup/Default)
+  TITLE+= (server)
+  USERID:=bbstored:bbstored
+  DEPENDS:=+libopenssl +zlib +libstdcpp +coreutils-stat +openssl-util
+endef
+
+define Package/boxbackup-server/description
+$(call Package/boxbackup/description/Default)
+endef
+
+define Package/boxbackup-client
+  $(call Package/boxbackup/Default)
+  TITLE+= (client)
+  DEPENDS:=+libopenssl +zlib +libstdcpp +coreutils-stat +openssl-util
+endef
+
+define Package/boxbackup-client/description
+$(call Package/boxbackup/description/Default)
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+CONFIGURE_VARS += ac_cv_have_decl_optreset=no
+
+CONFIGURE_ARGS += \
+	--with-random=/dev/urandom
+
+config_directory=/etc/boxbackup
+
+define Package/boxbackup-server/conffiles
+$(config_directory)/bbstored.conf
+$(config_directory)/raidfile.conf
+$(config_directory)/bbstored/
+endef
+
+define Package/boxbackup-client/conffiles
+$(config_directory)/bbackupd.conf
+$(config_directory)/bbackupd/
+endef
+
+define Build/Prepare
+$(call Build/Prepare/Default)
+	( cd $(PKG_BUILD_DIR) ; \
+		export TAR_TIMESTAMP=$$(basename $(PKG_BUILD_DIR) | sed 's/$(PKG_NAME)-//') ; \
+		sed -i "s/USE_SVN_VERSION/$$$${TAR_TIMESTAMP}/" VERSION.txt ; \
+		[ -f ./configure ] || ./bootstrap ; \
+	)
+endef
+
+define Build/Install
+	$(call Build/Install/Default,install install-backup-client)
+	$(call Build/Install/Default,install install-backup-server)
+endef
+
+define Package/boxbackup-server/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/boxbackup/bbstored $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/bbstored $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/bbstoreaccounts $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/raidfile-config $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/bbstored-certs $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/bbstored-config $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/bbstored.init $(1)/etc/init.d/bbstored
+	$(INSTALL_CONF) ./files/bbstored.conf.bb $(1)/etc/boxbackup/
+	$(INSTALL_CONF) ./files/raidfile.conf.bb $(1)/etc/boxbackup/
+endef
+
+define Package/boxbackup-client/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/bbackupd $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/bbackupquery $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/bbackupctl $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/bbackupd.init $(1)/etc/init.d/bbackupd
+	$(INSTALL_BIN) ./files/bbackupd-config $(1)/usr/sbin
+endef
+
+$(eval $(call BuildPackage,boxbackup-server))
+$(eval $(call BuildPackage,boxbackup-client))
+

--- a/utils/boxbackup/files/bbackupd-config
+++ b/utils/boxbackup/files/bbackupd-config
@@ -1,0 +1,647 @@
+#!/bin/sh
+#
+# A port of bbackupd-config Perl script to Bash.
+# Copyright (C) 2017 Val Kulkov <val.kulkov@gmail.com>
+
+# should be running # should be running as root
+if [ $(id -u) != "0" ]; then
+	echo ""
+	echo "WARNING: this should be run as root"
+	echo "" ; echo ""
+fi
+
+error_print_usage() {
+	cat <<__E
+
+Setup bbackupd config utility.
+
+Bad command line parameters.
+Usage:
+    bbackupd-config config-dir backup-mode account-num server-hostname
+        working-dir [backup directories]
+
+Parameters:
+    config-dir          is usually /etc/boxbackup
+    backup-mode         is lazy or snapshot:
+        lazy mode       runs continously, uploading files over a specified age
+        snapshot mode   uploads a snapshot of the filesystem when instructed
+                        explicitly, using bbackupctl sync
+    account-num (hexdecimal) is supplied by the server administrator
+    server-hostname     is supplied by the server administrator
+    working-dir         is usually /var/bbackupd
+    backup directories  is list of directories to back up
+
+__E
+	if [ -n "$1" ]; then
+		echo "=========" && echo "ERROR:"
+		echo $1
+		echo "" && echo ""
+	fi
+}
+
+# check and get command line parameters
+if [ $# -lt 6 ]; then
+	error_print_usage
+	exit 1
+fi
+
+# check for OPENSSL_CONF environment var being set
+if [ -n "$OPENSSL_CONF" ]; then
+	cat <<__E
+
+---------------------------------------
+
+WARNING:
+    You have the OPENSSL_CONF environment variable set.
+    Use of non-standard openssl configs may cause problems.
+
+---------------------------------------
+
+__E
+fi
+
+# default locations
+default_config_location='/etc/boxbackup/bbackupd.conf'
+
+# command line parameters
+config_dir=$1 && shift
+backup_mode=$1 && shift
+account_num=$1 && shift
+server=$1 && shift
+working_dir=$1 && shift
+
+# check backup mode is valid
+if [ "$backup_mode" != 'lazy' -a "$backup_mode" != 'snapshot' ]; then
+	error_print_usage "ERROR: backup mode must be 'lazy' or 'snapshot'"
+	exit 1
+fi
+
+# check server exists
+if [ $(nslookup "$server" | awk -F': ' 'NR==6 { print $2 } ') = "" ]; then
+	echo "Backup server specified as '$server', but it could not found."
+	echo "(A test DNS lookup failed -- check arguments)"
+fi
+
+echo "$working_dir" | grep -q '^/'
+if [ $? -ne 0 ]; then
+	echo "Working directory $working_dir is not specified as an absolute path"
+	exit 1
+fi
+
+# ssl stuff
+private_key="${config_dir}/bbackupd/${account_num}-key.pem"
+certificate_request="${config_dir}/bbackupd/${account_num}-csr.pem"
+certificate="${config_dir}/bbackupd/${account_num}-cert.pem"
+ca_root_cert="${config_dir}/bbackupd/serverCA.pem"
+
+# encryption keys
+enc_key_file="${config_dir}/bbackupd/${account_num}-FileEncKeys.raw"
+
+# other files
+config_file="${config_dir}/bbackupd.conf"
+notify_script="${config_dir}/bbackupd/NotifySysadmin.sh"
+
+# ask user to confirm overwriting an existing config file
+if [ -s "$config_file" ]; then
+	echo ""
+	read -p "$config_file already exists. Are you sure you want to overwrite it [y/N]? " ans
+	if [ -z "$ans" -o -n "$(echo "$ans" | grep '^[^yY]')" ]; then
+		echo ""
+		exit
+	fi
+fi
+
+# check that the directories are allowable
+for d in $@; do
+	if [ "$d" = '/' ]; then
+		echo "It is not recommended that you backup the root directory of your disc"
+		exit 1
+	fi
+	echo "$d" | grep -q '^/'
+	if [ $? -ne 0 ]; then
+		echo "Directory $d is not specified as an absolute path"
+		exit 1
+	fi
+	if [ ! -d "$d" ]; then
+		echo "$d is not a directory"
+		exit 1
+	fi
+done
+
+# summarise configuration
+cat <<__E
+
+Setup bbackupd config utility.
+
+Configuration:
+   Writing configuration file: $config_file
+   Account: $account_num
+   Server hostname: $server
+   Directories to back up:
+__E
+for d in $@; do
+	echo "      $d"
+done
+cat <<__E
+
+Note: If other file systems are mounted inside these directories, then
+they will NOT be backed up. You will have to create separate locations for
+any mounted filesystems inside your backup locations.
+
+__E
+
+# create directories
+if [ ! -d "$config_dir" ]; then
+	echo "Creating $config_dir..."
+	mkdir -p -m 0755 "$config_dir"
+	if [ $? -ne 0 ]; then
+		echo "Can't create $config_dir"
+		exit 1
+	fi
+fi
+
+if [ ! -d "${config_dir}/bbackupd" ]; then
+	echo "Creating ${config_dir}/bbackupd"
+	mkdir -p -m 0700 "${config_dir}/bbackupd"
+	if [ $? -ne 0 ]; then
+		echo "Can't create ${config_dir}/bbackupd"
+		exit 1
+	fi
+fi
+
+if [ ! -d "$working_dir" ]; then
+	echo "Creating $working_dir"
+	mkdir -p -m 0700 "$working_dir"
+	if [ $? -ne 0 ]; then
+		echo "Couldn't create $working_dir -- create this manually and try again"
+		exit 1
+	fi
+fi
+
+# generate the private key for the server
+if [ ! -f "$private_key" ]; then
+	echo "Generating private key..."
+	openssl genrsa -out "$private_key" 2048
+	if [ $? -ne 0 ]; then
+		echo "Couldn't generate private key."
+		exit 1
+	fi
+	chmod o-rwx "$private_key"
+fi
+
+# generate a certificate request
+if [ ! -f "$certificate_request" ]; then
+	cat <<__E | openssl req -new -key "$private_key" -sha1 -out "$certificate_request"
+.
+.
+.
+.
+.
+BACKUP-$account_num
+.
+.
+.
+
+__E
+	if [ $? -ne 0 ]; then
+		echo "Couldn't run openssl for CSR generation"
+		exit 1
+	fi
+	echo "" && echo ""
+	if [ ! -s "$certificate_request" ]; then
+		echo "Certificate request wasn't created."
+		exit 1
+	fi
+	chmod o-rwx "$certificate_request"
+fi
+
+# generate the key material for the file
+if [ ! -f "$enc_key_file" ]; then
+	echo "Generating keys for file backup"
+	openssl rand -out "$enc_key_file" 1024
+	if [ $? -ne 0 ]; then
+		echo "Couldn't generate file backup keys."
+		exit 1
+	fi
+	chmod o-rwx "$enc_key_file"
+fi
+
+# write the notify when store full script
+echo "Writing notify script $notify_script"
+
+hostname=$(uci get system.@system[0].hostname)
+current_username=$(id -un)
+sendmail=$(which sendmail)
+
+if [ "$sendmail" = "" ]; then
+	sendmail="sendmail"
+	echo "WARNING: sendmail executable is not found. E-mail notifications from"
+	echo "NotifySysadmin.sh will not be sent until sendmail or sendmail-like"
+	echo "executable is installed."
+fi
+
+cat <<__EOS >"$notify_script"
+#!/bin/sh
+
+# This script is run whenever bbackupd changes state or encounters a
+# problem which requires the system administrator to assist:
+#
+# 1) The store is full, and no more data can be uploaded.
+# 2) Some files or directories were not readable.
+# 3) A backup run starts or finishes.
+#
+# The default script emails the system administrator, except for backups
+# starting and stopping, where it does nothing.
+
+SUBJECT="BACKUP PROBLEM on host $hostname"
+SENDTO="$current_username"
+
+if [ "\$1" = "" ]; then
+	echo "Usage: \$0 <store-full|read-error|backup-ok|backup-error|backup-start|backup-finish>" >&2
+	exit 2
+elif [ "\$1" = store-full ]; then
+	$sendmail \$SENDTO <<EOM
+Subject: \$SUBJECT (store full)
+To: \$SENDTO
+
+
+The store account for $hostname is full.
+
+=============================
+FILES ARE NOT BEING BACKED UP
+=============================
+
+Please adjust the limits on account $account_num on server $server.
+
+EOM
+elif [ "\$1" = read-error ]; then
+$sendmail \$SENDTO <<EOM
+Subject: \$SUBJECT (read errors)
+To: \$SENDTO
+
+
+Errors occured reading some files or directories for backup on $hostname.
+
+===================================
+THESE FILES ARE NOT BEING BACKED UP
+===================================
+
+Check the logs on $hostname for the files and directories which caused
+these errors, and take appropriate action.
+
+Other files are being backed up.
+
+EOM
+elif [ "\$1" = backup-start -o "\$1" = backup-finish -o "\$1" = backup-ok ]; then
+	# do nothing by default
+	true
+else
+$sendmail \$SENDTO <<EOM
+Subject: \$SUBJECT (unknown)
+To: \$SENDTO
+
+
+The backup daemon on $hostname reported an unknown error (\$1).
+
+==========================
+FILES MAY NOT BE BACKED UP
+==========================
+
+Please check the logs on $hostname.
+
+EOM
+fi
+__EOS
+
+if [ ! -s "$notify_script" ]; then
+	echo "Cannot create $notify_script"
+	exit 1
+fi
+chmod 0700 "$notify_script"
+if [ $? -ne 0 ]; then
+	echo "Can't chmod $notify_script"
+	exit 1
+fi
+
+# write the configuration file
+echo "Writing configuration file $config_file"
+cat <<__E >"$config_file"
+
+StoreHostname = $server
+AccountNumber = 0x$account_num
+KeysFile = $enc_key_file
+
+CertificateFile = $certificate
+PrivateKeyFile = $private_key
+TrustedCAsFile = $ca_root_cert
+
+DataDirectory = $working_dir
+
+
+# This script is run whenever bbackupd changes state or encounters a
+# problem which requires the system administrator to assist:
+#
+# 1) The store is full, and no more data can be uploaded.
+# 2) Some files or directories were not readable.
+# 3) A backup run starts or finishes.
+#
+# The default script emails the system administrator, except for backups
+# starting and stopping, where it does nothing.
+
+NotifyScript = $notify_script
+
+__E
+if [ ! -s "$config_file" ]; then
+	echo "Cannot create config file $config_file"
+	exit 1
+fi
+
+if [ "$backup_mode" = "lazy" ]; then
+	# lazy mode configuration
+	cat <<__E >>"$config_file"
+
+# The number of seconds between backup runs under normal conditions. To avoid 
+# cycles of load on the server, this time is randomly adjusted by a small 
+# percentage as the daemon runs.
+
+UpdateStoreInterval = 3600
+
+
+# The minimum age of a file, in seconds, that will be uploaded. Avoids 
+# repeated uploads of a file which is constantly being modified.
+
+MinimumFileAge = 21600
+
+
+# If a file is modified repeated, it won't be uploaded immediately in case 
+# it's modified again, due to the MinimumFileAge specified above. However, it 
+# should be uploaded eventually even if it is being modified repeatedly. This 
+# is how long we should wait, in seconds, after first noticing a change. 
+# (86400 seconds = 1 day)
+
+MaxUploadWait = 86400
+
+# If the connection is idle for some time (e.g. over 10 minutes or 600
+# seconds, not sure exactly how long) then the server will give up and
+# disconnect the client, resulting in Connection Protocol_Timeout errors
+# on the server and TLSReadFailed or TLSWriteFailed errors on the client.
+# Also, some firewalls and NAT gateways will kill idle connections after
+# similar lengths of time. 
+#
+# This can happen for example when most files are backed up already and
+# don't need to be sent to the store again, while scanning a large
+# directory, or while calculating diffs of a large file. To avoid this,
+# KeepAliveTime specifies that special keep-alive messages should be sent
+# when the connection is otherwise idle for a certain length of time,
+# specified here in seconds.
+#
+# The default is that these messages are never sent, equivalent to setting
+# this option to zero, but we recommend that all users enable this.
+
+KeepAliveTime = 120
+
+__E
+else
+	# snapshot configuration
+	cat <<__E >>"$config_file"
+
+# This configuration file is written for snapshot mode.
+# You will need to run bbackupctl to instruct the daemon to upload files.
+
+AutomaticBackup = no
+UpdateStoreInterval = 0
+MinimumFileAge = 0
+MaxUploadWait = 0
+
+__E
+fi
+
+cat <<__E >>"$config_file"
+
+# Files above this size (in bytes) are tracked, and if they are renamed they will simply be
+# renamed on the server, rather than being uploaded again. (64k - 1)
+
+FileTrackingSizeThreshold = 65535
+
+
+# The daemon does "changes only" uploads for files above this size (in bytes).
+# Files less than it are uploaded whole without this extra processing.
+
+DiffingUploadSizeThreshold = 8192
+
+
+# The limit on how much time is spent diffing files, in seconds. Most files 
+# shouldn't take very long, but if you have really big files you can use this 
+# to limit the time spent diffing them.
+#
+# * Reduce if you are having problems with processor usage.
+#
+# * Increase if you have large files, and think the upload of changes is too 
+#   large and you want bbackupd to spend more time searching for unchanged
+#   blocks.
+
+MaximumDiffingTime = 120
+
+
+# Uncomment this line to see exactly what the daemon is going when it's connected to the server.
+
+# ExtendedLogging = yes
+
+
+# This specifies a program or script script which is run just before each 
+# sync, and ideally the full path to the interpreter. It will be run as the 
+# same user bbackupd is running as, usually root.
+#
+# The script must output (print) either "now" or a number to STDOUT (and a 
+# terminating newline, no quotes).
+#
+# If the result was "now", then the sync will happen. If it's a number, then 
+# no backup will happen for that number of seconds (bbackupd will pause) and 
+# then the script will be run again.
+#
+# Use this to temporarily stop bbackupd from syncronising or connecting to the 
+# store. For example, you could use this on a laptop to only backup when on a 
+# specific network, or when it has a working Internet connection.
+
+# SyncAllowScript = /path/to/intepreter/or/exe script-name parameters etc
+
+
+# Where the command socket is created in the filesystem.
+
+CommandSocket = $working_dir/bbackupd.sock
+
+# Uncomment the StoreObjectInfoFile to enable the experimental archiving
+# of the daemon's state (including client store marker and configuration)
+# between backup runs. This saves time and increases efficiency when
+# bbackupd is frequently stopped and started, since it removes the need
+# to rescan all directories on the remote server. However, it is new and
+# not yet heavily tested, so use with caution.
+
+# StoreObjectInfoFile = $working_dir/bbackupd.state
+
+Server
+{
+	PidFile = /var/run/bbackupd.pid
+}
+
+
+# BackupLocations specifies which locations on disc should be backed up. Each
+# directory is in the format
+# 
+# 	name
+# 	{
+# 		Path = /path/of/directory
+# 		(optional exclude directives)
+# 	}
+# 
+# 'name' is derived from the Path by the config script, but should merely be
+# unique.
+# 
+# The exclude directives are of the form
+# 
+# 	[Exclude|AlwaysInclude][File|Dir][|sRegex] = regex or full pathname
+# 
+# (The regex suffix is shown as 'sRegex' to make File or Dir plural)
+#
+# For example:
+# 
+# 	ExcludeDir = /home/guest-user
+# 	ExcludeFilesRegex = \.(mp3|MP3)\$
+# 	AlwaysIncludeFile = /home/username/veryimportant.mp3
+# 
+# This excludes the directory /home/guest-user from the backup along with all mp3
+# files, except one MP3 file in particular.
+# 
+# In general, Exclude excludes a file or directory, unless the directory is
+# explicitly mentioned in a AlwaysInclude directive. However, Box Backup
+# does NOT scan inside excluded directories and will never back up an
+# AlwaysIncluded file or directory inside an excluded directory or any
+# subdirectory thereof.
+#
+# To back up a directory inside an excluded directory, use a configuration
+# like this, to ensure that each directory in the path to the important
+# files is included, but none of their contents will be backed up except
+# the directories further down that path to the important one.
+#
+# ExcludeDirsRegex = ^/home/user/bigfiles/
+# ExcludeFilesRegex = ^/home/user/bigfiles/
+# AlwaysIncludeDir = /home/user/bigfiles/path
+# AlwaysIncludeDir = /home/user/bigfiles/path/to
+# AlwaysIncludeDir = /home/user/bigfiles/path/important
+# AlwaysIncludeDir = /home/user/bigfiles/path/important/files
+# AlwaysIncludeDirsRegex = ^/home/user/bigfiles/path/important/files/
+# AlwaysIncludeFilesRegex = ^/home/user/bigfiles/path/important/files/
+# 
+# If a directive ends in Regex, then it is a regular expression rather than a 
+# explicit full pathname. See
+# 
+# 	man 7 re_format
+# 
+# for the regex syntax on your platform.
+
+BackupLocations
+{
+__E
+
+# write the dirs to backup
+enc_key_file_bn=$(basename "$enc_key_file")
+for d in $@; do
+	d=$(echo $d | sed 's/\/$//')
+	n=$(echo $d | sed 's/^.//' | tr / -)
+	
+	cat <<__E >>"$config_file"
+	$n
+	{
+		Path = $d
+__E
+	for kf in $(find "$d" -name "$enc_key_file_bn"); do
+		cat <<__E
+
+NOTE: Keys file has been explicitly excluded from the backup:
+  $kf
+__E
+		cat <<__E >>"$config_file"
+		ExcludeFile = $kf
+__E
+	done
+	cat <<__E >>"$config_file"
+	}
+__E
+	
+done
+cat <<__E >>"$config_file"
+}
+
+
+__E
+
+
+# explain to the user what they need to do next
+if [ "$config_file" = "$default_config_location" ]; then
+	daemon_args=""
+	ctl_daemon_args=""
+else
+	daemon_args=" $config_file"
+	ctl_daemon_args=" -c $config_file"
+fi
+
+cat <<__E
+
+===================================================================
+
+bbackupd basic configuration complete.
+
+What you need to do now...
+
+1) Make a backup of $enc_key_file
+   This should be a secure offsite backup.
+   Without it, you cannot restore backups. Everything else can
+   be replaced. But this cannot.
+   KEEP IT IN A SAFE PLACE, OTHERWISE YOUR BACKUPS ARE USELESS.
+
+2) Send $certificate_request
+   to the administrator of the backup server, and ask for it to
+   be signed.
+
+3) The administrator will send you two files. Install them as
+      $certificate
+      $ca_root_cert
+   after checking their authenticity.
+
+4) You may wish to read the configuration file
+      $config_file
+   and adjust as appropriate.
+   
+   There are some notes in it on excluding files you do not
+   wish to be backed up.
+
+5) Review the script
+      $notify_script
+   and check that it will email the right person when the store
+   becomes full. This is important -- when the store is full, no
+   more files will be backed up. You want to know about this.
+
+6) Start the backup daemon with the command
+      /usr/sbin/bbackupd$daemon_args
+   in /etc/rc.local, or your local equivalent.
+   Note that bbackupd must run as root.
+__E
+if [ "$backup_mode" = "snapshot" ]; then
+	cat <<__E
+
+7) Set up a cron job to run whenever you want a snapshot of the
+   file system to be taken. Run the command
+      /usr/bin/bbackupctl -q$ctl_daemon_args sync
+__E
+fi
+cat <<__E
+
+===================================================================
+
+Remember to make a secure, offsite backup of your backup keys,
+as described in step 1 above. If you do not, you have no backups.
+
+__E
+
+chmod o-rwx "$config_file"
+

--- a/utils/boxbackup/files/bbackupd.init
+++ b/utils/boxbackup/files/bbackupd.init
@@ -1,0 +1,29 @@
+#!/bin/sh /etc/rc.common
+
+START=95
+STOP=15
+USE_PROCD=1
+
+CONFDIR='/etc/boxbackup'
+CONFFILE="${CONFDIR}/bbackupd.conf"
+
+start_service() {
+	if [ ! -d "${CONFDIR}/bbackupd" ]; then
+		mkdir -p -m 0750 "${CONFDIR}/bbackupd"
+	fi
+	if [ ! -s "$CONFFILE" ]; then
+		echo "Please configure bbackupd with bbackupd-config."
+		exit
+	fi
+
+	datadir=$(grep DataDirectory "$CONFFILE" | sed 's/.*= *//')
+	if [ ! -d "$datadir" ]; then
+		mkdir -p -m 0700 "$datadir"
+	fi
+	procd_open_instance
+	procd_set_param command /usr/sbin/bbackupd -F
+	procd_set_param respawn
+	procd_set_param file "$CONFFILE"
+	procd_close_instance
+}
+

--- a/utils/boxbackup/files/bbstored-certs
+++ b/utils/boxbackup/files/bbstored-certs
@@ -1,0 +1,319 @@
+#!/bin/sh
+#
+# A port of bbstored-certs Perl script to Bash.
+# Copyright (C) 2017 Val Kulkov <val.kulkov@gmail.com>
+
+cert_dir=""
+root_sign_period=""
+sign_period=""
+
+cmd_init_create_root() {
+	entity=$1
+
+	cert="${cert_dir}/roots/${entity}CA.pem"
+	serial="${cert_dir}/roots/${entity}CA.srl"
+	key="${cert_dir}/keys/${entity}RootKey.pem"
+	csr="${cert_dir}/keys/${entity}RootCSR.pem"
+
+	# generate key
+	openssl genrsa -out $key 2048
+	if [ ! -s "$key" ]; then
+		echo "Couldn't generate private key."
+		exit 1
+	fi
+	
+	# make CSR
+	cat <<__E | openssl req -new -key $key -sha1 -out $csr
+.
+.
+.
+.
+.
+Backup system $entity root
+.
+.
+.
+
+__E
+	echo ""
+	if [ ! -s "$csr" ]; then
+		echo "Certificate request wasn't created."
+		exit 1
+	fi
+	
+	# sign it to make a self-signed root CA key
+	openssl x509 -req -in "$csr" -sha1 -extensions v3_ca -signkey "$key" -out "$cert" -days "$root_sign_period"
+	if [ ! -s "$cert" ]; then
+		echo "Couldn't generate root certificate."
+		exit 1
+	fi
+	
+	# write the initial serial number
+	echo "00" > "$serial"
+	if [ ! -s "$serial" ]; then
+		echo "Can't open $serial for writing"
+		exit 1
+	fi
+}
+
+get_csr_common_name() {
+	csr=$1
+	
+	subject=$(openssl req -text -in "$csr" | sed 's/Subject:.*CN\s\?=\s\?\([-\.[:alnum:]]\+\)/\1/p;d')
+	if [ "$subject" = '' ]; then
+		echo "No subject found in CSR $csr"
+	fi
+	echo $subject
+}
+
+get_confirmation() {
+	read -p "$1" line
+	lcline=$(echo $line | tr '[A-Z]' '[a-z]')
+	if [ "$lcline" != "yes" ]; then
+		echo "CANCELLED"
+	fi
+}
+
+cmd_sign() {
+	csr=$1
+	
+	if [ ! -s "$csr" ]; then
+		echo "$csr does not exist"
+		exit 1
+	fi
+	
+	# get the common name specified in this certificate
+	common_name=$(get_csr_common_name "$csr")
+	
+	# look OK?
+	acc=$(echo $common_name | sed 's/^BACKUP-\([[:alnum:]]\+\)$/\1/')
+	if [ -z "$acc" ]; then
+		echo "The certificate presented does not appear to be a backup client certificate"
+		exit 1
+	fi
+	
+	# check against filename
+	certno=$(basename $csr | sed 's/-.*//g' )
+	if [ "$certno" != "$acc" ]; then
+		echo "Certificate request filename does not match name in certificate ($common_name)"
+		exit 1
+	fi
+		
+	cat <<__E
+
+This certificate is for backup account
+
+   $acc
+
+Ensure this matches the account number you are expecting. The filename is
+
+   $csr
+
+which should include this account number, and additionally, you should check
+that you received it from the right person.
+
+Signing the wrong certificate compromises the security of your backup system.
+
+__E
+
+	retval=$(get_confirmation "Would you like to sign this certificate? (type 'yes' to confirm) ")
+	if [ "$retval" = "CANCELLED" ]; then
+		echo $retval
+		exit
+	fi
+
+	# out certificate
+	out_cert="${cert_dir}/clients/${acc}-cert.pem"
+
+	# sign it!
+	openssl x509 -req -in "$csr" -sha1 -extensions usr_crt -CA "${cert_dir}/roots/clientCA.pem" -CAkey "${cert_dir}/keys/clientRootKey.pem" -out "$out_cert" -days "$sign_period"
+	if [ $? -ne 0 ]; then
+		echo "Signing failed"
+		exit 1
+	fi
+	
+	# tell user what to do next
+	cat <<__E
+
+
+Certificate signed.
+
+Send the files
+
+   $out_cert
+   $cert_dir/roots/serverCA.pem
+
+to the client.
+
+__E
+}
+
+
+cmd_init() {
+	cert_dir=$1
+	# create directories
+	mkdir -p -m 0700 "${cert_dir}/roots" \
+		&& mkdir -m 0700 "${cert_dir}/keys" \
+		&& mkdir -m 0700 "${cert_dir}/servers" \
+		&& mkdir -m 0700 "${cert_dir}/clients" \
+		|| ( echo "Failed to create directory structure"; exit 1 )
+
+	# create root keys and certrs
+	cmd_init_create_root 'client'
+	cmd_init_create_root 'server'
+}
+
+
+cmd_sign_server() {
+	csr=$1
+
+	if [ ! -s "$csr" ]; then
+		echo "$csr does not exist"
+		exit 1
+	fi
+	
+	# get the common name specified in this certificate
+	common_name=$(get_csr_common_name "$csr")
+	
+	# look OK?
+	cncheck=$(echo $common_name | sed 's/[-\.[:alnum:]]//g')
+	if [ -n "$cncheck" ]; then
+		echo "Invalid server name"
+		exit 1
+	fi
+	cat <<__E
+
+This certificate is for backup server
+
+   $common_name
+
+Signing the wrong certificate compromises the security of your backup system.
+
+__E
+
+	retval=$(get_confirmation "Would you like to sign this certificate? (type 'yes' to confirm) ")
+	if [ "$retval" = "CANCELLED" ]; then
+		echo $retval
+		exit
+	fi
+
+	# out certificate
+	out_cert="${cert_dir}/servers/${common_name}-cert.pem"
+
+	# sign it!
+	openssl x509 -req -in "$csr" -sha1 -extensions usr_crt -CA "${cert_dir}/roots/serverCA.pem" -CAkey "${cert_dir}/keys/serverRootKey.pem" -out "$out_cert" -days "$sign_period"
+	if [ $? -ne 0 ]; then
+		echo "Signing failed"
+		exit 1
+	fi
+	
+	# tell user what to do next
+	cat <<__E
+
+
+Certificate signed.
+
+Install the files
+
+   $out_cert
+   $cert_dir/roots/clientCA.pem
+
+on the server.
+
+__E
+}
+
+
+# validity period for root certificates -- default is 2038, the best we can do for now
+root_sign_period=$(( ( 2**31 - $(date +%s) ) / 86400 ))
+
+# but less so for client certificates
+sign_period='5000'
+if [ $sign_period -gt $root_sign_period ]; then
+	sign_period=$root_sign_period
+fi
+
+# check and get command line parameters
+if [ $# -eq 0 ]; then
+	cat <<__E
+
+bbstored certificates utility.
+
+Bad command line parameters.
+Usage:
+	bbstored-certs certs-dir command [arguments]
+
+certs-dir is the directory holding the root keys and certificates for the backup system
+command is the action to perform, taking parameters.
+
+Commands are
+
+	init
+		-- generate initial root certificates (certs-dir must not already exist)
+	sign path-to-certificate
+		-- sign a client certificate
+	sign-server path-to-certificate
+		-- sign a server certificate
+
+Signing requires confirmation that the certificate is correct and should be signed.
+
+__E
+	exit 1
+fi
+
+# check for OPENSSL_CONF environment var being set
+if [ -n "$OPENSSL_CONF" ]; then
+	cat <<__E
+
+---------------------------------------
+
+WARNING:
+    You have the OPENSSL_CONF environment variable set.
+    Use of non-standard openssl configs may cause problems.
+
+---------------------------------------
+
+__E
+fi
+
+# directory structure:
+#
+# roots/
+#	clientCA.pem -- root certificate for client (used on server)
+#	serverCA.pem -- root certificate for servers (used on clients)
+# keys/
+#   clientRootKey.pem -- root key for clients
+#   serverRootKey.pem -- root key for servers
+# servers/
+#   hostname.pem -- certificate for server 'hostname'
+# clients/
+#   account.pem -- certficiate for account 'account' (ID in hex)
+#
+
+
+# check parameters
+cert_dir=$1 && shift
+command=$1 && shift
+args=$@
+
+# check directory exists
+if [ "$command" != 'init' ]; then
+	if [ ! -d "$cert_dir" ]; then
+		echo "$cert_dir does not exist"
+		exit 1
+	fi
+fi
+
+# run command
+if [ "$command" = 'init' ]; then
+	cmd_init "$cert_dir"
+elif [ "$command" = 'sign' ]; then
+	cmd_sign $@
+elif [ "$command" = 'sign-server' ]; then
+	cmd_sign_server $@
+else
+	echo "Unknown command $command"
+	exit 1
+fi
+
+

--- a/utils/boxbackup/files/bbstored-config
+++ b/utils/boxbackup/files/bbstored-config
@@ -1,0 +1,277 @@
+#!/bin/sh
+#
+# A port of bbstored-config Perl script to Bash.
+# Copyright (C) 2017 Val Kulkov <val.kulkov@gmail.com>
+
+
+make_dir() {
+	d=$1
+	u=$2
+	if [ ! -d $d ]; then
+		echo "Creating $d..."
+		mkdir -p -m 0750 "$d"
+		if [ $? -ne 0 ]; then
+			echo "Can't create $d"
+			exit 1
+		fi
+		chown $u "$d"
+	fi
+}
+
+
+# should be running as root
+if [ $(id -u) != "0" ]; then
+	echo ""
+	echo "WARNING: this should be run as root"
+	echo "" ; echo ""
+fi
+
+# check and get command line parameters
+if [ $# -lt 2 ]; then
+	cat <<__E
+
+Setup bbstored config utility.
+
+Bad command line parameters.
+Usage:
+    bbstored-config config-dir server-hostname username [raidfile-config]
+
+Parameters:
+    config-dir       is usually /etc/boxbackup
+    server-hostname  is the hostname that clients will use to connect to
+                     this server
+    username         is the user to run the server under
+    raidfile-config  is optional. Use if you have a non-standard
+                     raidfile.conf file.
+
+__E
+	exit 1
+fi
+
+# check for OPENSSL_CONF environment var being set
+if [ -n "$OPENSSL_CONF" ]; then
+	cat <<__E
+
+---------------------------------------
+
+WARNING:
+    You have the OPENSSL_CONF environment variable set.
+    Use of non-standard openssl configs may cause problems.
+
+---------------------------------------
+
+__E
+fi
+
+# default locations
+default_config_location='/etc/boxbackup/bbstored.conf'
+
+# command line parameters
+config_dir=$1 && shift
+server=$1 && shift
+username=$1 && shift
+raidfile_config=$1
+
+if [ -z "$raidfile_config" ]; then
+	raidfile_config="${config_dir}/raidfile.conf"
+fi
+
+# check server exists, but don't bother checking that it's actually this machine.
+if [ $(nslookup $server | awk -F': ' 'NR==6 { print $2 } ') = "" ]; then
+	echo "Server '$server' not found. (check server name, test DNS lookup failed.)"
+fi
+
+# check this exists
+if [ ! -f "$raidfile_config" ]; then
+	echo "The RaidFile configuration file $raidfile_config doesn't exist."
+	echo "You may need to create it with raidfile-config."
+	echo "Won't configure bbstored without it."
+	exit 1
+fi
+
+# check that the user exists
+if [ $username = "root" ]; then
+	echo "You shouldn't run bbstored as root"
+	exit 1
+fi
+id $username &>/dev/null
+if [ $? -ne 0 ]; then
+	echo "User $username doesn't exist"
+	exit 1
+fi
+
+if [ ! -r "$raidfile_config" ]; then
+	echo "The RaidFile configuration file $raidfile_config is not readable."
+	exit 1
+fi
+
+# check that directories are writeable
+user_uid=$(id -u $username)
+user_gid=$(id -g $username)
+for d in $(cat "$raidfile_config" | sed 's/Dir[0-2][[:space:]]*=[[:space:]]*\([^[:space:]]\+\)/\1/p;d'); do
+	if [ ! -d "$d" ]; then
+		echo "Directory $d in $raidfile_config does not exist."
+		exit 1
+	fi
+	if [ -d "${d}/backup" ]; then
+		d="${d}/backup"
+	fi
+	echo "Checking permissions on $d"
+        mode=$(stat -Lc '%a' "$d")
+        uid=$(stat -Lc '%u' "$d")
+        gid=$(stat -Lc '%g' "$d")
+        writeable=0
+        if [ "$uid" = "$user_uid" -a "$(printf '%o' $(( 0700 & 0$mode )))" = "700" ]; then
+                writeable=1
+        elif [ "$gid" = "$user_gid" -a "$(printf '%o' $(( 0070 & 0$mode )))" = "70" ]; then
+                writeable=1
+        elif [ "$(printf '%o' $(( 0007 & 0$mode )))" = "7" ]; then
+                writeable=1
+        fi
+	if [ ! $writeable ]; then
+		echo "$username doesn't appear to have the necessary permissions on $d"
+		echo "Either adjust permissions, or create a directory 'backup' inside the"
+		echo "directory specified in raidfile.conf which is writable."
+		exit
+	fi
+done
+
+# ssl stuff
+private_key="${config_dir}/bbstored/${server}-key.pem"
+certificate_request="${config_dir}/bbstored/${server}-csr.pem"
+certificate="${config_dir}/bbstored/${server}-cert.pem"
+ca_root_cert="${config_dir}/bbstored/clientCA.pem"
+
+# other files
+config_file="${config_dir}/bbstored.conf"
+accounts_file="${config_dir}/bbstored/accounts.txt"
+
+# ask user to confirm overwriting an existing config file
+if [ -s "$config_file" ]; then
+	echo ""
+	read -p "$config_file already exists. Are you sure you want to overwrite it [y/N]? " ans
+	if [ -z "$ans" -o -n "$(echo "$ans" | grep '^[^yY]')" ]; then
+		echo ""
+		exit
+	fi
+fi
+
+# summarise configuration
+cat <<__E
+
+Setup bbstored config utility.
+
+Configuration:
+   Writing configuration file: $config_file
+   Writing empty accounts file: $accounts_file
+   Server hostname: $server
+   RaidFile config: $raidfile_config
+
+__E
+
+# create directories
+
+make_dir "$config_dir" $username
+make_dir "${config_dir}/bbstored" $username
+
+# create blank accounts file
+if [ ! -f "$accounts_file" ]; then
+	echo "Creating blank accounts file"
+	touch "$accounts_file"
+fi
+
+# generate the private key for the server
+if [ ! -f "$private_key" ]; then
+	echo "Generating private key..."
+	openssl genrsa -out "$private_key" 2048
+	if [ $? -ne 0 ]; then
+		echo "Couldn't generate private key."
+		exit 1
+	fi
+fi
+
+# generate a certificate request
+if [ ! -f "$certificate_request" ]; then
+	cat <<__E | openssl req -new -key "$private_key" -sha1 -out "$certificate_request"
+.
+.
+.
+.
+.
+$server
+.
+.
+.
+
+__E
+	echo "" && echo ""
+	if [ ! -s "$certificate_request" ]; then
+		echo "Certificate request wasn't created."
+		exit 1
+	fi
+fi
+
+# write the configuration file
+echo "Writing configuration file $config_file"
+cat <<__E >$config_file
+
+RaidFileConf = $raidfile_config
+AccountDatabase = $accounts_file
+
+# Uncomment this line to see exactly what commands are being received from clients.
+# ExtendedLogging = yes
+
+# scan all accounts for files which need deleting every 15 minutes.
+
+TimeBetweenHousekeeping = 900
+
+Server
+{
+	PidFile = /var/run/bbstored.pid
+	User = $username
+	ListenAddresses = inet:$server
+	CertificateFile = $certificate
+	PrivateKeyFile = $private_key
+	TrustedCAsFile = $ca_root_cert
+}
+
+
+__E
+
+
+# explain to the user what they need to do next
+daemon_args=""
+if [ "$config_file" != "$default_config_location" ]; then
+	daemon_args=" $config_file"
+fi
+
+cat <<__E
+
+===================================================================
+
+bbstored basic configuration complete.
+
+What you need to do now...
+
+1) Sign $certificate_request
+   using the bbstored-certs utility.
+
+2) Install the server certificate and root CA certificate as
+      $certificate
+      $ca_root_cert
+
+3) You may wish to read the configuration file
+      $config_file
+   and adjust as appropraite.
+
+4) Create accounts with bbstoreaccounts
+
+5) Start the backup store daemon with the command
+      /usr/sbin/bbstored$daemon_args
+   in /etc/rc.local, or your local equivalent.
+
+===================================================================
+
+__E
+
+

--- a/utils/boxbackup/files/bbstored.conf.bb
+++ b/utils/boxbackup/files/bbstored.conf.bb
@@ -1,0 +1,21 @@
+
+RaidFileConf = <confdir>/raidfile.conf
+AccountDatabase = <confdir>/bbstored/accounts.txt
+
+# Uncomment this line to see exactly what commands are being received from clients.
+# ExtendedLogging = yes
+
+# scan all accounts for files which need deleting every 2 hours.
+TimeBetweenHousekeeping = 7200
+
+Server
+{
+	User = bbstored
+	PidFile = <pidfile>
+	ListenAddresses = inet:<hostname>
+	CertificateFile = <confdir>/bbstored/<hostname>-cert.pem
+	PrivateKeyFile = <confdir>/bbstored/<hostname>-key.pem
+	TrustedCAsFile = <confdir>/bbstored/clientCA.pem
+}
+
+

--- a/utils/boxbackup/files/bbstored.init
+++ b/utils/boxbackup/files/bbstored.init
@@ -1,0 +1,124 @@
+#!/bin/sh /etc/rc.common
+
+START=95
+STOP=15
+USE_PROCD=1
+
+CONFDIR='/etc/boxbackup'
+PIDFILE='/var/run/bbstored/bbstored.pid'
+HOSTNAME=$(uci get system.@system[0].hostname)
+
+make_bbstored_conf() {
+	pidf=$(echo $PIDFILE | sed 's=/=\\/=g')
+	confd=$(echo $CONFDIR | sed 's=/=\\/=g')
+	cat "${CONFDIR}/bbstored.conf.bb" | \
+		sed "s/<hostname>/$HOSTNAME/" | \
+		sed "s/<pidfile>/$pidf/" | \
+		sed "s/<confdir>/$confd/" > \
+		"${CONFDIR}/bbstored.conf"
+	rm "${CONFDIR}/bbstored.conf.bb"
+	chmod o-rwx "${CONFDIR}/bbstored.conf"
+	# create blank accounts file
+	if [ ! -f "$accounts_file" ]; then
+		touch "${CONFDIR}/bbstored/accounts.txt"
+	fi
+}
+make_keys() {
+	CertificateFile="${CONFDIR}/bbstored/${HOSTNAME}-cert.pem"
+	CertificateReqFile="${CONFDIR}/bbstored/${HOSTNAME}-csr.pem"
+	PrivateKeyFile="${CONFDIR}/bbstored/${HOSTNAME}-key.pem"
+	TrustedCAsFile="${CONFDIR}/bbstored/clientCA.pem"
+	echo "Generating private key..."
+	openssl genrsa -out "$PrivateKeyFile" 2048
+	cat <<__CSRREQ | openssl req -new -key "$PrivateKeyFile" -sha1 -out "$CertificateReqFile"
+.
+.
+.
+.
+.
+$HOSTNAME
+.
+.
+.
+
+__CSRREQ
+	chmod o-wrx "$PrivateKeyFile" "${CONFDIR}/bbstored"
+	echo "" && echo ""
+
+	# make certs-dir and generate root keys and certificates for the backup system
+	CAdir="${CONFDIR}/ca"
+	if [ ! -d "$CAdir" ]; then
+		bbstored-certs "$CAdir" init
+		echo "yes" | bbstored-certs "$CAdir" sign-server "${CONFDIR}/bbstored/${HOSTNAME}-csr.pem"
+		cp "$CAdir/servers/${HOSTNAME}-cert.pem" "${CONFDIR}/bbstored/"
+		cp "$CAdir/roots/clientCA.pem" "${CONFDIR}/bbstored/"
+		chmod o-rwx "${CONFDIR}/bbstored"
+		chmod o-rwx "$CAdir"
+		echo "" && echo "" && echo ""
+		echo "*****************************************************************"
+		echo ""
+		echo "The Certification Authority (CA) has been set up in ${CAdir}."
+		echo "It is recommended that you move your CA to a machine that is neither"
+		echo "the client nor the server, preferably a machine without direct network"
+		echo "access in order to limit the impact of a server compromise."
+		echo "The contents of the CA directory control who can access your backup"
+		echo "store server."
+		echo ""
+		echo ""
+		echo "The certificate for backup server $HOSTNAME:"
+		echo "  $CAdir/servers/${HOSTNAME}-cert.pem"
+		echo "has been signed and copied to ${CONFDIR}/bbstored/."
+		echo ""
+		echo "The client root certificate:"
+		echo "  $CAdir/roots/clientCA.pem"
+		echo "has been copied to ${CONFDIR}/bbstored/."
+		echo "" && echo ""
+	fi
+}
+make_raidfile_conf() {
+	# detect mount point of an external storage device
+	mp=$(mount | grep '/dev/[hs]d' | head -1 | cut -f 3 -d ' ')
+	mp=${mp%/overlay}
+	mp="${mp}/bbstore"
+	if [ ! -d "$mp" ]; then
+		mkdir -p -m 0755 "$mp"
+	fi
+	chown bbstored.bbstored "$mp"
+
+	echo "bbstored will store backups in:"
+	echo "  $mp"
+	echo "Edit ${CONFDIR}/raidfile.conf to change this location."
+	echo "Note that the backup store directory must be writable to bbstored."
+	echo "" && echo ""
+	mp=$(echo $mp | sed 's=/=\\/=g')
+	cat "${CONFDIR}/raidfile.conf.bb" | \
+		sed "s/<mountpoint>/$mp/" > \
+		"${CONFDIR}/raidfile.conf"
+	rm "${CONFDIR}/raidfile.conf.bb"
+	chmod o-rwx "${CONFDIR}/raidfile.conf"
+}
+
+
+initial_config() {
+	make_bbstored_conf
+	make_keys
+	make_raidfile_conf
+	echo "You are now ready to set up accounts with bbstoreaccounts."
+	echo ""
+}
+
+
+start_service() {
+	[ -f "${CONFDIR}/bbstored.conf.bb" ] && initial_config
+	piddir=$(dirname $PIDFILE)
+	[ ! -d "$piddir" ] && mkdir -p "$piddir" && chown bbstored "$piddir"
+	chown -R bbstored "${CONFDIR}/bbstored" "${CONFDIR}/bbstored.conf" "${CONFDIR}/raidfile.conf"
+
+	procd_open_instance
+	procd_set_param command /usr/sbin/bbstored -F
+	procd_set_param user bbstored
+	procd_set_param respawn
+	procd_set_param file "${CONFDIR}/bbstored.conf"
+	procd_close_instance
+}
+

--- a/utils/boxbackup/files/raidfile-config
+++ b/utils/boxbackup/files/raidfile-config
@@ -1,0 +1,126 @@
+#!/bin/sh
+#
+# A port of raidfile-config Perl script to Bash.
+# Copyright (C) 2017 Val Kulkov <val.kulkov@gmail.com>
+
+
+# should be running as root
+if [ $(id -u) != "0" ]; then
+	echo ""
+	echo "WARNING: this should be run as root"
+	echo "" ; echo ""
+fi
+
+# check and get command line parameters
+if [ $# -ne 5 -a $# -ne 3 ]; then
+	cat <<__E
+
+Setup raidfile config utility.
+
+Bad command line parameters.
+Usage:
+    raidfile-config config-dir block-size dir0 [dir1 dir2]
+
+Parameters:
+    config-dir        is usually /etc/boxbackup
+    block-size        must be a power of two, and usually the block or
+                      fragment size of your file system
+    dir0, dir1, dir2  are the directories used as the root of the raid
+                      file system
+
+If only one directory is specified, then userland RAID is disabled.
+Specifying three directories enables it.
+
+__E
+	exit 1
+fi
+
+config_dir=$1 && shift
+block_size=$1 && shift
+conf="${config_dir}/raidfile.conf"
+
+dir1=$(echo $1 | sed 's/\/$//')
+if [ $# -eq 3 ]; then
+	dir2=$(echo $2 | sed 's/\/$//')
+	dir3=$(echo $3 | sed 's/\/$//')
+	# check dirs are unique
+	if [ "$dir1" = "$dir2" -o "$dir1" = "$dir3" -o "$dir2" = "$dir3" ]; then
+		echo "A directory cannot be used more than once in userland RAID."
+		exit 1
+	fi
+fi
+
+for d in $@; do
+	# dirs must exist
+	if [ ! -d "$d" ]; then
+		echo "$d does not exist or is not a directory."
+		exit 1
+	fi
+	
+	echo "$d" | grep -q '^/'
+	if [ $? -ne 0 ]; then
+		echo "$d must be an absolute path."
+		exit 1
+	fi
+done
+
+# check block size is OK
+block_size=$(echo $block_size | awk '{print int($1)}')
+if [ $block_size -le 0 ]; then
+	echo "Bad block size"
+	exit 1
+fi
+c=1
+while true; do
+	[ $c -eq $block_size ] && break
+	if [ $c -gt $block_size ]; then
+		echo "Block size $block_size is not a power of two"
+		exit 1
+	fi
+	c=$(( $c * 2 ))
+done
+
+# check that it doesn't already exist
+if [ -f "$conf" ]; then
+	echo "$conf already exists. Delete and try again"
+	exit 1
+fi
+
+# create directory
+if [ ! -d "$config_dir" ]; then
+	echo "Creating $config_dir..."
+	mkdir -m 0755 -p "$config_dir"
+	if [ $? -ne 0 ]; then
+		echo "Can't create $config_dir"
+		exit 1
+	fi
+fi
+
+# adjust if userland RAID is disabled
+if [ $# -eq 1 ]; then
+	dir2=$dir1
+	dir3=$dir1
+	echo "WARNING: userland RAID is disabled."
+fi
+
+# write the file
+cat <<__E >"$conf"
+
+disc0
+{
+	SetNumber = 0
+	BlockSize = $block_size
+	Dir0 = $dir1
+	Dir1 = $dir2
+	Dir2 = $dir3
+}
+
+__E
+
+if [ ! -s "$conf" ]; then
+	echo "Can't open $conf for writing"
+	exit 1
+fi
+
+echo "Config file written."
+

--- a/utils/boxbackup/files/raidfile.conf.bb
+++ b/utils/boxbackup/files/raidfile.conf.bb
@@ -1,0 +1,10 @@
+
+disc0
+{
+	SetNumber = 0
+	BlockSize = 1024
+	Dir0 = <mountpoint>
+	Dir1 = <mountpoint>
+	Dir2 = <mountpoint>
+}
+

--- a/utils/boxbackup/patches/001-parcels-remove-docs.patch
+++ b/utils/boxbackup/patches/001-parcels-remove-docs.patch
@@ -1,0 +1,54 @@
+--- a/parcels.txt
++++ b/parcels.txt
+@@ -8,23 +8,6 @@ backup-client
+ 	bin bbackupquery
+ 	bin bbackupctl
+ 	script bin/bbackupd/bbackupd-config
+-	noinstall script COPYING.txt
+-	noinstall script LICENSE-GPL.txt
+-	noinstall script LICENSE-DUAL.txt
+-
+-	html bbackupd
+-	html bbackupquery
+-	html bbackupctl
+-	html bbackupd-config
+-	html bbackupd.conf
+-
+-EXCEPT:mingw32,mingw32msvc
+-	man bbackupd.8
+-	man bbackupquery.8
+-	man bbackupctl.8
+-	man bbackupd-config.8
+-	man bbackupd.conf.5
+-END-EXCEPT
+ 
+ ONLY:mingw32,mingw32msvc
+ 	script bin/bbackupd/win32/installer.iss 
+@@ -56,27 +39,6 @@ backup-server
+ 	script bin/bbstored/bbstored-certs
+ 	script bin/bbstored/bbstored-config
+ 	script lib/raidfile/raidfile-config
+-	noinstall script COPYING.txt
+-	noinstall script LICENSE-GPL.txt
+-	noinstall script LICENSE-DUAL.txt
+-
+-	html bbstored
+-	html bbstoreaccounts
+-	html bbstored-certs
+-	html bbstored-config
+-	html raidfile-config
+-	html bbstored.conf
+-	html raidfile.conf
+-
+-EXCEPT:mingw32,mingw32msvc
+-	man bbstored.8
+-	man bbstoreaccounts.8
+-	man bbstored-certs.8
+-	man bbstored-config.8
+-	man raidfile-config.8
+-	man bbstored.conf.5
+-	man raidfile.conf.5
+-END-EXCEPT
+ 
+ ONLY:SunOS
+ 	script contrib/solaris/bbstored-manifest.xml lib/svc/manifest

--- a/utils/boxbackup/patches/002-remove-memleaks-collection.patch
+++ b/utils/boxbackup/patches/002-remove-memleaks-collection.patch
@@ -1,0 +1,12 @@
+--- a/lib/common/BoxPlatform.h
++++ b/lib/common/BoxPlatform.h
+@@ -68,6 +68,9 @@
+ 	#define PLATFORM_DISABLE_MEM_LEAK_TESTING
+ #endif
+ 
++// LEDE/OpenWrt platform: do not use the memleaks collection mechanism
++#define PLATFORM_DISABLE_MEM_LEAK_TESTING
++
+ // Darwin also has a weird idea of permissions and dates on symlinks:
+ // perms are fixed at creation time by your umask, and dates can't be
+ // changed. This breaks unit tests if we try to compare these things.


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5
Run tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5

Description:

Box Backup is an on-line multiplatform client-server backup system that supports both continuous and snapshot backups. Box Backup is designed to be lightweight and to run on embedded systems.

Box Backup supports secure data transfer over untrusted networks. All data are transferred and stored encrypted. The data can be decoded only by the original client. Only changes within files are sent to the server, minimising the bandwidth used between clients and server.

This commit introduces two new packages, boxbackup-client and boxbackup-server. Each package is independent of the other. At the time of this submission, Box Backup is the only backup solution published in the LEDE/OpenWrt packages feed.

boxbackup-server has been tested with a client on Ubuntu 16.04 and with a client on LEDE Reboot SNAPSHOT r5297-bddffc5. boxbackup-client has been tested with a Box Backup server on LEDE Reboot SNAPSHOT r5297-bddffc5.

Box Backup v0.11 was previously ported to OpenWrt. However, it has never been brought back into the LEDE/OpenWrt packages feed from oldpackages. This Box Backup port is a completely new one. This port makes use of the most recent version of Box Backup that, unlike v0.11, does not have a issue backing up files from an overlay filesystem.

bbstored-config, bbstored-certs, bbackupd-config and raidfile-config scripts have been ported from Perl to Bash, eliminating the dependency on Perl.

The Box Backup server installation process has been additionally automated as compared to the upstream version. The installation script will look for an external storage device and, if one is detected at a mount point or as the extroot drive, use it for Box Backup data store.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>
