### PR TITLE
python,python3: build bluetooth support if bluez-libs selected

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -14,7 +14,7 @@ PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 # XXX: reset PKG_RELEASE to 1 only if Python's pip & setuptools versions have also bumped;
 #      otherwise, keep bumping PKG_RELEASE
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)
@@ -37,9 +37,11 @@ HOST_BUILD_PARALLEL:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/Python-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/Python-$(PKG_VERSION)
 
-PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_python-setuptools CONFIG_PACKAGE_python-pip
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_PACKAGE_python-setuptools CONFIG_PACKAGE_python-pip \
+	CONFIG_PACKAGE_bluez-libs
 
-PKG_BUILD_DEPENDS:=python/host
+PKG_BUILD_DEPENDS:=python/host PACKAGE_bluez-libs:bluez-libs
 HOST_BUILD_DEPENDS:=bzip2/host expat/host
 
 include $(INCLUDE_DIR)/host-build.mk
@@ -87,7 +89,7 @@ endef
 define Package/python-light
 $(call Package/python/Default)
   TITLE:=Python $(PYTHON_VERSION) light installation
-  DEPENDS:=+python-base +libffi +libbz2
+  DEPENDS:=+python-base +libffi +libbz2 +PACKAGE_bluez-libs:bluez-libs
 endef
 
 define Package/python-light/description

--- a/lang/python/python/patches/005-fix-bluetooth-support.patch
+++ b/lang/python/python/patches/005-fix-bluetooth-support.patch
@@ -1,0 +1,61 @@
+diff --git a/configure b/configure
+index 4c0435e..0068a9d 100755
+--- a/configure
++++ b/configure
+@@ -7045,7 +7045,7 @@ sys/param.h sys/poll.h sys/random.h sys/select.h sys/socket.h sys/statvfs.h sys/
+ sys/termio.h sys/time.h \
+ sys/times.h sys/types.h sys/un.h sys/utsname.h sys/wait.h pty.h libutil.h \
+ sys/resource.h netpacket/packet.h sysexits.h bluetooth.h \
+-bluetooth/bluetooth.h linux/tipc.h spawn.h util.h alloca.h
++linux/tipc.h spawn.h util.h alloca.h
+ do :
+   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+@@ -7267,6 +7267,24 @@ fi
+ fi
+ 
+ 
++# bluetooth/bluetooth.h has been known to not compile with -std=c99.
++# http://permalink.gmane.org/gmane.linux.bluez.kernel/22294
++SAVE_CFLAGS=$CFLAGS
++CFLAGS="-std=c99 $CFLAGS"
++for ac_header in bluetooth/bluetooth.h
++do :
++  ac_fn_c_check_header_mongrel "$LINENO" "bluetooth/bluetooth.h" "ac_cv_header_bluetooth_bluetooth_h" "$ac_includes_default"
++if test "x$ac_cv_header_bluetooth_bluetooth_h" = xyes; then :
++  cat >>confdefs.h <<_ACEOF
++#define HAVE_BLUETOOTH_BLUETOOTH_H 1
++_ACEOF
++
++fi
++
++done
++
++CFLAGS=$SAVE_CFLAGS
++
+ # On Linux, netlink.h requires asm/types.h
+ for ac_header in linux/netlink.h
+ do :
+diff --git a/configure.ac b/configure.ac
+index 780f275..dceca1c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1702,10 +1702,17 @@ sys/param.h sys/poll.h sys/random.h sys/select.h sys/socket.h sys/statvfs.h sys/
+ sys/termio.h sys/time.h \
+ sys/times.h sys/types.h sys/un.h sys/utsname.h sys/wait.h pty.h libutil.h \
+ sys/resource.h netpacket/packet.h sysexits.h bluetooth.h \
+-bluetooth/bluetooth.h linux/tipc.h spawn.h util.h alloca.h)
++linux/tipc.h spawn.h util.h alloca.h)
+ AC_HEADER_DIRENT
+ AC_HEADER_MAJOR
+ 
++# bluetooth/bluetooth.h has been known to not compile with -std=c99.
++# http://permalink.gmane.org/gmane.linux.bluez.kernel/22294
++SAVE_CFLAGS=$CFLAGS
++CFLAGS="-std=c99 $CFLAGS"
++AC_CHECK_HEADERS(bluetooth/bluetooth.h)
++CFLAGS=$SAVE_CFLAGS
++
+ # On Linux, netlink.h requires asm/types.h
+ AC_CHECK_HEADERS(linux/netlink.h,,,[
+ #ifdef HAVE_ASM_TYPES_H

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -16,7 +16,7 @@ PYTHON_VERSION_MICRO:=$(PYTHON3_VERSION_MICRO)
 PKG_NAME:=python3
 # XXX: reset PKG_RELEASE to 1 only if Python's pip & setuptools versions have also bumped;
 #      otherwise, keep bumping PKG_RELEASE
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -40,9 +40,12 @@ HOST_BUILD_PARALLEL:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/Python-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/Python-$(PKG_VERSION)
 
-PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_python3-setuptools CONFIG_PACKAGE_python3-pip
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_PACKAGE_python3-setuptools CONFIG_PACKAGE_python3-pip \
+	CONFIG_PACKAGE_bluez-libs
 
-PKG_BUILD_DEPENDS:=python3/host
+
+PKG_BUILD_DEPENDS:=python3/host PACKAGE_bluez-libs:bluez-libs
 HOST_BUILD_DEPENDS:=bzip2/host expat/host libffi/host
 
 include $(INCLUDE_DIR)/host-build.mk
@@ -80,7 +83,7 @@ endef
 define Package/python3-light
 $(call Package/python3/Default)
   TITLE:=Python $(PYTHON_VERSION) light installation
-  DEPENDS:=+python3-base +libffi +libbz2
+  DEPENDS:=+python3-base +libffi +libbz2 +PACKAGE_bluez-libs:bluez-libs
 endef
 
 define Package/python3-light/description


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/lede-project/source/commit/17a4eacd0c9ba5554b7d3c6e201b5b047e5187ca
Run tested: N/A ; this is mostly a build issue

------------------------------------------------------------------------------

This should hopefully fix the Python3 build on buildbot.

For a while I assumed it may be a build-bot issue, but
then looking through the packages repo [and finding
the bluez package] it looks like, if you try
to build all packages, Python3 detects the bluetooth
headers installed by bluez.

It looks like Python's bluetooth support was somewhat
broken ; it was not detecting the <bluetooth/bluetooth.h>
header, so a backport from Python3 to Python fixed that.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>