### PR TITLE
i2c-tools: Fix typo for compiling python3-smbus.

### DIFF
--- a/utils/i2c-tools/Makefile
+++ b/utils/i2c-tools/Makefile
@@ -121,5 +121,5 @@ endef
 $(eval $(call BuildPackage,i2c-tools))
 $(eval $(call PyPackage,python-smbus))
 $(eval $(call BuildPackage,python-smbus))
-$(eval $(call PyPackage,python3-smbus))
+$(eval $(call Py3Package,python3-smbus))
 $(eval $(call BuildPackage,python3-smbus))


### PR DESCRIPTION
Maintainer: Daniel Golle <daniel@makrotopia.org>
Compile tested: mvebu, Clearfog PRO, LEDE Reboot SNAPSHOT r5150-d30f25d564
Run tested:  N/A ; this is mostly a build issue

Description:

Fix a typo in the Makefile to allow compiling the python3-smbus package.