### PR TITLE
net/netopeer2: reuse "sysrepoctl -l" output

### DIFF
--- a/net/netopeer2/files/netopeer2-server.default
+++ b/net/netopeer2/files/netopeer2-server.default
@@ -3,27 +3,30 @@
 # Warning, problems can occur if the device restarts in the middle of this uci-default script
 
 if [ -x /bin/sysrepoctl ]; then
-	match=$(sysrepoctl -l | grep "ietf-ssh-server\ ")
+
+	yang_modules=$(sysrepoctl -l | awk -F ' ' '{print $1}')
+
+	match=$(echo $yang_modules | grep -o ietf-ssh-server)
 	if [ ! "$match" ]; then
 		sysrepoctl --install --yang=/etc/sysrepo/yang/ietf-ssh-server.yang -p 600
 	fi
 
-	match=$(sysrepoctl -l | grep "ietf-tls-server\ ")
+	match=$(echo $yang_modules | grep -o ietf-tls-server)
 	if [ ! "$match" ]; then
 		sysrepoctl --install --yang=/etc/sysrepo/yang/ietf-tls-server.yang -p 600
 	fi
 
-	match=$(sysrepoctl -l | grep "iana-crypt-hash\ ")
+	match=$(echo $yang_modules | grep -o iana-crypt-hash)
 	if [ ! "$match" ]; then
 		sysrepoctl --install --yang=/etc/sysrepo/yang/iana-crypt-hash.yang -p 600
 	fi
 
-	match=$(sysrepoctl -l | grep "ietf-x509-cert-to-name\ ")
+	match=$(echo $yang_modules | grep -o ietf-x509-cert-to-name)
 	if [ ! "$match" ]; then
 		sysrepoctl --install --yang=/etc/sysrepo/yang/ietf-x509-cert-to-name.yang -p 600
 	fi
 
-	match=$(sysrepoctl -l | grep "ietf-netconf-server\ ")
+	match=$(echo $yang_modules | grep -o ietf-netconf-server)
 	if [ ! "$match" ]; then
 		sysrepoctl --install --yang=/etc/sysrepo/yang/ietf-netconf-server.yang -o root:root -p 600
 		sysrepoctl -m ietf-netconf-server -e listen
@@ -34,12 +37,13 @@ if [ -x /bin/sysrepoctl ]; then
 		fi
 	fi
 
-	match=$(sysrepoctl -l | grep "ietf-system\ ")
+	match=$(echo $yang_modules | grep -o ietf-system)
 	if [ ! "$match" ]; then
 		sysrepoctl --install --yang=/etc/sysrepo/yang/ietf-system.yang -o root:root -p 600
 		sysrepoctl -m ietf-system -e authentication
 		sysrepoctl -m ietf-system -e local-users
 	fi
+
 fi
 
 exit 0


### PR DESCRIPTION
Maintainer: @mogula pranay
Compile tested: not needed
Run tested: Installed yang modules only if module doesn't contain in sysrepo.

Description:
Instead of listing yang modules every time for each yang module installation, reuse the "sysrepoctl -l" output using a local variable.

Signed-off-by: mogula pranay <mogulapranay57@gmail.com>