### PR TITLE
avahi: Changed the condition of InstallDev

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avahi
 PKG_VERSION:=0.6.32
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lathiat/avahi/releases/download/v$(PKG_VERSION)
@@ -317,8 +317,10 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libavahi-* $(1)/usr/lib/
-ifeq ($(CONFIG_PACKAGE_libavahi-compat-libdnssd)-$(BUILD_VARIANT),y-dbus)
+ifneq ($(CONFIG_PACKAGE_libavahi-compat-libdnssd),)
+ifeq ($(BUILD_VARIANT),dbus)
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdns_sd* $(1)/usr/lib/
+endif
 endif
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/* $(1)/usr/lib/pkgconfig/


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: mips_24kc_gcc-6.3.0_musl, LEDE head r5376-c61a239 
Run tested: none

Description:
Changed the condition of InstallDev.
I'm in trouble when I want to create a new packages that requires libdns_sd.so".

Currently, InstallDev will not install "libdns_sd.so" unless "built-in label" of "libavahi-compat-libdnssd" is specified.
This change is permitted even if "package label" is specified.

When installing package using "libdns_sd.so", we need to be aware that the avahi packages uses the dbus version, not the nodbus version.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
