### PR TITLE
horst: remove build time to fix reproducible builds

### DIFF
--- a/net/horst/Makefile
+++ b/net/horst/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=horst
 PKG_VERSION:=5.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/br101/horst/archive/v$(PKG_VERSION)/

--- a/net/horst/patches/0001-reproducible-builds.patch
+++ b/net/horst/patches/0001-reproducible-builds.patch
@@ -1,0 +1,26 @@
+Index: horst-5.1/conf_options.c
+===================================================================
+--- horst-5.1.orig/conf_options.c
++++ horst-5.1/conf_options.c
+@@ -519,7 +519,7 @@ void config_parse_file_and_cmdline(int a
+ 			conf_filename = optarg;
+ 			break;
+ 		case 'v':
+-			printf("%s (build date: %s %s)\n", VERSION, __DATE__, __TIME__);
++			printf("%s\n", VERSION);
+ 			exit(0);
+ 		case 'h':
+ 		case '?':
+Index: horst-5.1/display-help.c
+===================================================================
+--- horst-5.1.orig/display-help.c
++++ horst-5.1/display-help.c
+@@ -36,7 +36,7 @@ void update_help_win(WINDOW *win)
+ 	print_centered(win, 2, COLS, "HORST - Horsts OLSR Radio Scanning Tool (or)");
+ 	print_centered(win, 3, COLS, "HORST - Highly Optimized Radio Scanning Tool");
+ 
+-	print_centered(win, 5, COLS, "Version " VERSION " (build date " __DATE__ " " __TIME__ ")");
++	print_centered(win, 5, COLS, "Version " VERSION);
+ 	print_centered(win, 6, COLS, "(C) 2005-2016 Bruno Randolf, Licensed under the GPLv2");
+ 
+ 	mvwprintw(win, 8, 2, "Known IEEE802.11 Packet Types:");


### PR DESCRIPTION
Maintainer: @br101 
Compile tested: lantiq

Description: remove build time to fix reproducible builds

Build timestamps are not reproducible [0].

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>
