### PR TITLE
minicom: remove build time to fix reproducible builds

### DIFF
--- a/utils/minicom/Makefile
+++ b/utils/minicom/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=minicom
 PKG_VERSION:=2.7
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://alioth.debian.org/frs/download.php/file/3977/

--- a/utils/minicom/patches/110-reproducible-builds.patch
+++ b/utils/minicom/patches/110-reproducible-builds.patch
@@ -1,0 +1,20 @@
+--- a/src/minicom.c
++++ b/src/minicom.c
+@@ -1159,7 +1159,7 @@ int main(int argc, char **argv)
+       switch(c) {
+ 	case 'v':
+ 	  printf(_("%s version %s"), PACKAGE, VERSION);
+-#ifdef __DATE__
++#if 0 
+ 	  printf(_(" (compiled %s)"), __DATE__);
+ #endif
+ 	  printf("\n");
+@@ -1462,7 +1462,7 @@ int main(int argc, char **argv)
+ 
+   mc_wprintf(us, "\n%s %s\r\n", _("Welcome to minicom"), VERSION);
+   mc_wprintf(us, "\n%s: %s\r\n", _("OPTIONS"), option_string);
+-#if defined (__DATE__) && defined (__TIME__)
++#if 0
+   mc_wprintf(us, "%s %s, %s.\r\n",_("Compiled on"), __DATE__,__TIME__);
+ #endif
+   {


### PR DESCRIPTION
Maintainer: @Noltari
Compile tested: lantiq

Description: Build timestamps prevents reproducible builds [0].

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>
