### PR TITLE
socat: set BUILD_DATE to SOURCE_DATE_EPOCH

### DIFF
--- a/net/socat/Makefile
+++ b/net/socat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=socat
 PKG_VERSION:=1.7.3.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.dest-unreach.org/socat/download
@@ -67,7 +67,8 @@ CONFIGURE_VARS += \
 	sc_cv_termios_ispeed="no" \
 	sc_cv_sys_crdly_shift=9 \
 	sc_cv_sys_tabdly_shift=11 \
-	sc_cv_sys_csize_shift=4
+	sc_cv_sys_csize_shift=4 \
+	BUILD_DATE=$(SOURCE_DATE_EPOCH)
 
 define Package/socat/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: lantiq

Build timestamp prevents reproducible builds [0].
SOURCE_DATE_EPOCH allows to use a timestamp which depends
on deterministic behaviour [1].
Fixes reproducible builds.

[0] https://reproducible-builds.org/docs/timestamps/
[1] https://reproducible-builds.org/specs/source-date-epoch/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>