### PR TITLE
sox: remove build timestamp

### DIFF
--- a/sound/sox/Makefile
+++ b/sound/sox/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sox
 PKG_VERSION:=14.4.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/sox

--- a/sound/sox/patches/020-reproducible-builds.patch
+++ b/sound/sox/patches/020-reproducible-builds.patch
@@ -1,0 +1,32 @@
+--- a/src/libsox.c
++++ b/src/libsox.c
+@@ -65,8 +65,6 @@ sox_version_info_t const * sox_version_i
+ #else
+         NULL,
+ #endif
+-        /* sox_time */
+-        __DATE__ " " __TIME__,
+         /* sox_distro */
+ #ifdef DISTRO
+         DISTRO,
+--- a/src/sox.h
++++ b/src/sox.h
+@@ -1321,7 +1321,6 @@ typedef struct sox_version_info_t {
+     sox_uint32_t version_code; /**< version number = 0x140400 */
+     char const * version;      /**< version string = sox_version(), for example, "14.4.0" */
+     char const * version_extra;/**< version extra info or null = "PACKAGE_EXTRA", for example, "beta" */
+-    char const * time;         /**< build time = "__DATE__ __TIME__", for example, "Jan  7 2010 03:31:50" */
+     char const * distro;       /**< distro or null = "DISTRO", for example, "Debian" */
+     char const * compiler;     /**< compiler info or null, for example, "msvc 160040219" */
+     char const * arch;         /**< arch, for example, "1248 48 44 L OMP" */
+--- a/src/sox.c
++++ b/src/sox.c
+@@ -1828,8 +1828,6 @@ static void display_SoX_version(FILE * f
+       info->version_extra ? info->version_extra : "");
+ 
+   if (sox_globals.verbosity > 3) {
+-    if (info->time)
+-      fprintf(file, "time:     %s\n", info->time);
+     if (info->distro)
+       fprintf(file, "issue:    %s\n", info->distro);
+ #if HAVE_SYS_UTSNAME_H


### PR DESCRIPTION
Maintainer: @thess
Compile tested: lantiq

Description: Build timestamp prevents reproducible builds [0].

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>
