### PR TITLE
zip/unzip: remove build timestamps

### DIFF
--- a/utils/unzip/Makefile
+++ b/utils/unzip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=unzip
 PKG_REV:=60
 PKG_VERSION:=6.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)$(PKG_REV).tar.gz
 PKG_SOURCE_URL:=@SF/infozip

--- a/utils/unzip/patches/010-remove-build-date.patch
+++ b/utils/unzip/patches/010-remove-build-date.patch
@@ -1,0 +1,17 @@
+From: Jérémy Bobbio <lunar@debian.org>
+Subject: Remove build date
+Bug-Debian: https://bugs.debian.org/782851
+ In order to make unzip build reproducibly, we remove the
+ (already optional) build date from the binary.
+
+--- a/unix/unix.c
++++ b/unix/unix.c
+@@ -1705,7 +1705,7 @@
+ #endif /* Sun */
+ #endif /* SGI */
+ 
+-#ifdef __DATE__
++#if 0
+       " on ", __DATE__
+ #else
+       "", ""

--- a/utils/zip/Makefile
+++ b/utils/zip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=zip
 PKG_REV:=30
 PKG_VERSION:=3.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)$(PKG_REV).tar.gz
 PKG_SOURCE_URL:=@SF/infozip

--- a/utils/zip/patches/010-remove-build-date.patch
+++ b/utils/zip/patches/010-remove-build-date.patch
@@ -1,0 +1,15 @@
+From: Santiago Vila <sanvila@debian.org>
+Subject: Remove (optional) build date to make the build reproducible
+Bug-Debian: http://bugs.debian.org/779042
+
+--- a/unix/unix.c
++++ b/unix/unix.c
+@@ -1020,7 +1020,7 @@
+ 
+ 
+ /* Define the compile date string */
+-#ifdef __DATE__
++#if 0
+ #  define COMPILE_DATE " on " __DATE__
+ #else
+ #  define COMPILE_DATE ""


### PR DESCRIPTION
Maintainer: @Noltari 
Compile tested: lantiq
Description:

Build timestamps prevents reproducible builds [0].
Thanks to debian for the patches.

[0] https://reproducible-builds.org/docs/timestamps/
