### PR TITLE
python3-idna: Fix openwrt/openwrt#519, opkg package list segfault.

### DIFF
--- a/lang/python/python-idna/Makefile
+++ b/lang/python/python-idna/Makefile
@@ -56,7 +56,7 @@ from the earlier standard from 2003.
 endef
 
 define Package/python3-idna/description
-$(call define Package/python-idna/description)
+$(call Package/python-idna/description)
 .
 (Variant for Python3)
 endef


### PR DESCRIPTION
This fixes https://github.com/openwrt/openwrt/issues/519, where opkg apparently choked and segfaulted on a bad description in the python3-idna package.