### PR TITLE
php7-mod-gd: add Freetype 2 support

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=7.1.11
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 
@@ -42,7 +42,7 @@ PHP7_MODULES = \
 
 PKG_CONFIG_DEPENDS:= \
 	$(patsubst %,CONFIG_PACKAGE_php7-mod-%,$(PHP7_MODULES)) \
-	CONFIG_PHP7_FILTER CONFIG_PHP7_LIBXML CONFIG_PHP7_SYSTEMTZDATA
+	CONFIG_PHP7_FILTER CONFIG_PHP7_LIBXML CONFIG_PHP7_SYSTEMTZDATA CONFIG_PHP7_LIBFREETYPE
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -142,6 +142,13 @@ define Package/php7-fpm/description
   This package contains the FastCGI Process Manager of the PHP7 interpreter.
 endef
 
+define Package/php7-mod-gd/config
+  config PHP7_LIBFREETYPE
+	bool "Enable Freetype 2 support in php7-mod-gd"
+	depends on PACKAGE_php7-mod-gd
+	default y
+endef
+
 # not everything groks --disable-nls
 DISABLE_NLS:=
 
@@ -214,7 +221,6 @@ endif
 ifneq ($(SDK)$(CONFIG_PACKAGE_php7-mod-gd),)
   CONFIGURE_ARGS+= \
 	--with-gd=shared \
-	--without-freetype-dir \
 	--with-jpeg-dir="$(STAGING_DIR)/usr" \
 	--with-png-dir="$(STAGING_DIR)/usr" \
 	--without-xpm-dir \
@@ -222,6 +228,11 @@ ifneq ($(SDK)$(CONFIG_PACKAGE_php7-mod-gd),)
 	--disable-gd-jis-conv
 else
   CONFIGURE_ARGS+= --without-gd
+endif
+ifneq ($(CONFIG_PHP7_LIBFREETYPE),)
+  CONFIGURE_ARGS+= --with-freetype-dir="$(STAGING_DIR)"
+else
+  CONFIGURE_ARGS+= --without-freetype-dir
 endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_php7-mod-gmp),)
@@ -574,7 +585,7 @@ $(eval $(call BuildModule,dom,DOM,+@PHP7_LIBXML +PACKAGE_php7-mod-dom:libxml2))
 $(eval $(call BuildModule,exif,EXIF))
 $(eval $(call BuildModule,fileinfo,Fileinfo))
 $(eval $(call BuildModule,ftp,FTP,+PACKAGE_php7-mod-ftp:libopenssl))
-$(eval $(call BuildModule,gd,GD graphics,+PACKAGE_php7-mod-gd:libjpeg +PACKAGE_php7-mod-gd:libpng))
+$(eval $(call BuildModule,gd,GD graphics,+PACKAGE_php7-mod-gd:libjpeg +PACKAGE_php7-mod-gd:libpng +PHP7_LIBFREETYPE:libfreetype))
 $(eval $(call BuildModule,gettext,Gettext,+PACKAGE_php7-mod-gettext:libintl-full))
 $(eval $(call BuildModule,gmp,GMP,+PACKAGE_php7-mod-gmp:libgmp))
 $(eval $(call BuildModule,hash,Hash))


### PR DESCRIPTION
Maintainer: @mhei
Compile tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5
Run tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5

Description:

Add Freetype 2 support to php7-mod-gd. Introduce a configuration parameter to disable Freetype 2 support if the increased package size is a concern.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>