### PR TITLE
postfix: version update, fix file descriptor passing

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postfix
-PKG_RELEASE:=2
-PKG_VERSION:=3.2.3
+PKG_RELEASE:=1
+PKG_VERSION:=3.2.4
 PKG_SOURCE_URL:= \
 	https://cdn.postfix.johnriley.me/mirrors/postfix-release/official/ \
 	ftp://ftp.porcupine.org/mirrors/postfix-release/official/
 
-PKG_HASH:=5b0b975d075ea7561028d4109c581549b794aa92d733429ea6d9fa57751140bf
+PKG_HASH:=ec55ebaa2aa464792af8d5ee103eb68b27a42dc2b36a02fee42dafbf9740c7f6
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_MAINTAINER:=Denis Shulyaka <Shulyaka@gmail.com>
 PKG_LICENSE:=IPL-1.0

--- a/mail/postfix/patches/110-glibc-defs.patch
+++ b/mail/postfix/patches/110-glibc-defs.patch
@@ -1,0 +1,19 @@
+This patch fixes the runtime error when libmilter is used with Postfix:
+"unix_send_fd: your system has no support for file descriptor passing"
+
+The issue has been fixed upstream in 20170618 update to Postfix v.3.3:
+http://postfix.1071664.n5.nabble.com/Fix-check-for-file-descriptor-passing-td90983.html
+
+This patch must be removed before compiling Postfix v.3.3.*
+
+--- a/src/util/sys_defs.h
++++ b/src/util/sys_defs.h
+@@ -804,7 +804,7 @@ extern int initgroups(const char *, int)
+ #define KERNEL_VERSION(a,b,c) (LINUX_VERSION_CODE + 1)
+ #endif
+ #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,2,0)) \
+-	|| (__GLIBC__ < 2)
++	|| (defined(__GLIBC__) && __GLIBC__ < 2)
+ #define CANT_USE_SEND_RECV_MSG
+ #define DEF_SMTP_CACHE_DEMAND	0
+ #else


### PR DESCRIPTION
Maintainer: @Shulyaka
Compile tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5
Run tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5

Description:

Update to the latest stable release.

Fix check for file descriptor passing that causes libmilter's [runtime error](http://postfix.1071664.n5.nabble.com/Fix-check-for-file-descriptor-passing-td90983.html) when libmilter/OpenDKIM are used with Postfix: "unix_send_fd: your system has no support for file descriptor passing"

The issue with the file descriptor passing has been fixed upstream in the 20170618 update to Postfix v3.3 experimental release. The patch must therefore be removed before compiling Postfix v3.3.*

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>