### PR TITLE
libfreetype: restore host build

### DIFF
--- a/libs/freetype/Makefile
+++ b/libs/freetype/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freetype
 PKG_VERSION:=2.8.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/freetype
@@ -56,6 +56,8 @@ endef
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/freetype-config $(1)/bin/
+	$(INSTALL_DIR) $(2)/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/freetype-config $(2)/bin/
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/freetype2 $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
@@ -63,11 +65,6 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/freetype2.pc $(1)/usr/lib/pkgconfig/
 
-	$(SED) \
-		's,^\(prefix\|exec_prefix\)=.*,\1="$(STAGING_DIR)/usr",; \
-		 s,^\(includedir\)=.*,\1="$(STAGING_DIR)/usr/include",; \
-		 s,^\(libdir\)=.*,\1="$(STAGING_DIR)/usr/lib",' \
-		 $(1)/bin/freetype-config
 	$(SED) \
 		's,/usr/include,$$$${prefix}/include,g; \
 		 s,/usr/lib,$$$${exec_prefix}/lib,g' \
@@ -80,4 +77,5 @@ define Package/libfreetype/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfreetype.so.* $(1)/usr/lib/
 endef
 
+$(eval $(call HostBuild))
 $(eval $(call BuildPackage,libfreetype))


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5
Run tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5

Description:

Restore host building on request from a user: see PR #5126. Apparently, some packages outside of openwrt/packages feed rely on Freetype 2 building on host.

While at it, remove sed-editing of freetype-config inside Makefile that is no longer necessary. The current version of freetype-config correctly identifies prefix, exec_prefix, includedir and libdir within the LEDE/OpenWrt build system.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>
