### PR TITLE
bind: Add support for building with libxml2 or libjson

### DIFF
--- a/net/bind/Config.in
+++ b/net/bind/Config.in
@@ -14,4 +14,24 @@ config BIND_ENABLE_FILTER_AAAA
 		Additional details are available at
 		https://kb.isc.org/article/AA-00576/0/Filter-AAAA-option-in-BIND-9-.html
 
+config BIND_LIBJSON
+	bool
+	default n
+	prompt "Include libjson support in bind-server"
+	help
+		BIND 9 supports reporting statistics about usage. libjson
+		is required to report server statistics in JSON format. 
+		Building with libjson support will require the libjson-c
+		package to be installed as well.
+
+config BIND_LIBXML2
+	bool
+	default n
+	prompt "Include libxml2 support in bind-server"
+	help
+		BIND 9 supports reporting statistics about usage. 
+		libxml2 is required to report server statistics in XML
+		format. Building with libjson support will require the
+		libxml2 package to be installed as well.
+
 endif

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.11.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -29,7 +29,16 @@ PKG_INSTALL:=1
 PKG_USE_MIPS16:=0
 
 PKG_CONFIG_DEPENDS := \
-	CONFIG_BIND_ENABLE_FILTER_AAAA
+	CONFIG_BIND_ENABLE_FILTER_AAAA \
+	CONFIG_BIND_LIBJSON \
+	CONFIG_BIND_LIBXML2
+
+ifdef CONFIG_BIND_LIBXML2
+  PKG_BUILD_DEPENDS += libxml2
+endif
+ifdef CONFIG_BIND_LIBJSON
+  PKG_BUILD_DEPENDS += libjson-c
+endif
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -48,6 +57,12 @@ define Package/bind-libs
   DEPENDS:=+libopenssl +zlib
   TITLE:=bind shared libraries
   URL:=https://www.isc.org/software/bind
+ifdef CONFIG_BIND_LIBJSON
+  DEPENDS+= +libjson-c
+endif
+ifdef CONFIG_BIND_LIBXML2
+  DEPENDS+= +libxml2
+endif
 endef
 
 define Package/bind-server
@@ -104,9 +119,7 @@ CONFIGURE_ARGS += \
 	--disable-threads \
 	--disable-linux-caps \
 	--with-openssl="$(STAGING_DIR)/usr" \
-	--with-libjson=no \
 	--with-libtool \
-	--with-libxml2=no \
 	--without-lmdb \
 	--enable-epoll=yes \
 	--with-gost=no \
@@ -118,6 +131,22 @@ CONFIGURE_ARGS += \
 ifdef CONFIG_BIND_ENABLE_FILTER_AAAA
 	CONFIGURE_ARGS += \
 		--enable-filter-aaaa
+endif
+
+ifdef CONFIG_BIND_LIBJSON
+	CONFIGURE_ARGS += \
+		--with-libjson="$(STAGING_DIR)/usr"
+else
+	CONFIGURE_ARGS += \
+		--with-libjson=no
+endif
+
+ifdef CONFIG_BIND_LIBXML2
+	CONFIGURE_ARGS += \
+		--with-libxml2="$(STAGING_DIR)/usr"
+else
+	CONFIGURE_ARGS += \
+		--with-libxml2=no
 endif
 
 CONFIGURE_VARS += \


### PR DESCRIPTION
Maintainer: Noah Meyerhans / @nmeyerhans 
Compile tested: x86_64, QEMU, LEDE trunk
Run tested: x86_64, QEMU, LEDE trunk, `bind-server` built and tested with `libxml2` support enabled

Description:
At least one of `libjson`|`libxml2` is required for bind statistics to function.

Selecting `libjson`|`libxml2` will result in an additional dependency required to build and install `bind-libs`.

![menuconfig](https://user-images.githubusercontent.com/1230969/33045537-7a01cdfc-ce4d-11e7-9697-f58edf61fcd5.png)

`libjson` support currently broken as configure does not properly locate `include/json{,-c}/json.h`:
`checking for json library... configure: error: include/json{,-c}/json.h not found.`

`json.h` is present in `./staging_dir/target-x86_64_musl/usr/include/json-c/json.h` which is passed to configure:
`CPPFLAGS="-I/path/to/lede_src/staging_dir/target-x86_64_musl/usr/include`

Any assistance in debugging why this is failing would be appreciated. libxml2 works as expected.

![bind_statistics](https://user-images.githubusercontent.com/1230969/33045193-55b94a52-ce4c-11e7-8a5c-1ce2ec923f4a.png)
