### PR TITLE
node-homebridge: add new package / Node.js HomeKit Server

### DIFF
--- a/lang/node-homebridge/Makefile
+++ b/lang/node-homebridge/Makefile
@@ -1,0 +1,69 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NPM_NAME:=homebridge
+PKG_NAME:=node-$(PKG_NPM_NAME)
+PKG_VERSION:=0.4.46
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
+PKG_SOURCE_URL:=http://registry.npmjs.org/$(PKG_NPM_NAME)/-/
+PKG_HASH:=c648a5a6f6bfb79b1d2eaac71d12ee2f6cd2221f33dacd5de2e6734004f19646
+
+PKG_BUILD_DEPENDS:=node/host
+PKG_USE_MIPS16:=0
+
+PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>
+PKG_LICENSE:=ISC Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/node-homebridge
+  SUBMENU:=Node.js
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Node.js HomeKit Server
+  URL:=https://www.npmjs.org/package/homebridge
+  DEPENDS:=+node +node-npm
+  USERID:=homebridge:homebridge
+endef
+
+define Package/node-homebridge/description
+ Homebridge is a lightweight Node.js server you can run on your home network that emulates the iOS HomeKit API
+endef
+
+NODEJS_CPU:=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))))
+
+define Build/Prepare
+	$(INSTALL_DIR) $(PKG_BUILD_DIR)
+endef
+
+define Build/Compile
+	$(MAKE_VARS) \
+	$(MAKE_FLAGS) \
+	npm_config_arch=$(NODEJS_CPU) \
+	npm_config_target_arch=$(NODEJS_CPU) \
+	npm_config_build_from_source=true \
+	npm_config_nodedir=$(STAGING_DIR)/usr/ \
+	npm_config_prefix=$(PKG_INSTALL_DIR)/usr/ \
+	npm_config_cache=$(TMP_DIR)/npm-cache \
+	npm_config_tmp=$(TMP_DIR)/npm-tmp \
+	npm install -g $(DL_DIR)/$(PKG_SOURCE)
+	rm -rf $(TMP_DIR)/npm-tmp
+	rm -rf $(TMP_DIR)/npm-cache
+endef
+
+define Package/node-homebridge/install
+	$(INSTALL_DIR) $(1)/usr/lib/node
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/* $(1)/usr/lib/node/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(LN) ../lib/node/homebridge/bin/homebridge $(1)/usr/bin/homebridge
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/homebridge.init $(1)/etc/init.d/homebridge
+endef
+
+$(eval $(call BuildPackage,node-homebridge))

--- a/lang/node-homebridge/files/homebridge.init
+++ b/lang/node-homebridge/files/homebridge.init
@@ -1,0 +1,18 @@
+#!/bin/sh /etc/rc.common
+
+START=98
+USE_PROCD=1
+
+start_service() {
+	[ -d /usr/share/homebridge ] || {
+		mkdir -m 0755 -p /usr/share/homebridge
+		chmod 0700 /usr/share/homebridge
+		chown homebridge:homebridge /usr/share/homebridge
+	}
+	procd_open_instance
+	procd_set_param command /usr/bin/homebridge -U /usr/share/homebridge
+	procd_set_param user homebridge
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}


### PR DESCRIPTION
Maintainer: me 
Compile tested: mips_24kc_gcc-6.3.0_musl, LEDE head r5392-bc50a97
 Run tested: ar71xx mips 24kc 

Description:
Homebridge is a lightweight Node.js server you can run on your home network that emulates the iOS HomeKit API

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
