### PR TITLE
net/mwan3: add improvments and add a fix

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.6.7
+PKG_VERSION:=2.6.8
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/hotplug.d/iface/14-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/14-mwan3
@@ -28,7 +28,7 @@ src_ip=$(uci_get_state mwan3 globals src_ip)
 	ip addr del "${src_ip}/32" dev lo 1>/dev/null 2>&1
 }
 
-usleep 10000
+sleep 1
 
 [ "$ACTION" = "ifup" ] && {
 	network_get_ipaddr src_ip "${local_source}"

--- a/net/mwan3/files/lib/mwan3/common.sh
+++ b/net/mwan3/files/lib/mwan3/common.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+get_uptime() {
+	local uptime=$(cat /proc/uptime)
+	echo "${uptime%%.*}"
+}

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -3,6 +3,7 @@
 . /lib/functions.sh
 . /lib/functions/network.sh
 . /usr/share/libubox/jshn.sh
+. /lib/mwan3/common.sh
 
 MWAN3TRACK_STATUS_DIR="/var/run/mwan3track"
 
@@ -47,7 +48,7 @@ get_mwan3_status() {
 
 		time_p="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/TIME")"
 		[ -z "${time_p}" ] || {
-			time_n="$(date +'%s')"
+			time_n="$(get_uptime)"
 			let age=time_n-time_p
 		}
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 . /lib/functions.sh
+. /lib/mwan3/common.sh
 
 LOG="logger -t $(basename "$0")[$$] -p"
 INTERFACE=""
@@ -171,7 +172,7 @@ main() {
 		echo "${lost}" > /var/run/mwan3track/$1/LOST
 		echo "${score}" > /var/run/mwan3track/$1/SCORE
 		echo "${turn}" > /var/run/mwan3track/$1/TURN
-		echo "$(date +'%s')" > /var/run/mwan3track/$1/TIME
+		echo "$(get_uptime)" > /var/run/mwan3track/$1/TIME
 
 		host_up_count=0
 		sleep "${sleep_time}" &


### PR DESCRIPTION
Maintainer: me
Compile tested: not needed its a script
Run tested: x86_64 xrx200, LEDE master 

Description:

- Use system uptime for ubus not date
- fix usleep command use instead sleep