### PR TITLE
polipo: forcibly enable IPv6 support

### DIFF
--- a/net/polipo/Makefile
+++ b/net/polipo/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=polipo
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.pps.jussieu.fr/~jch/software/files/$(PKG_NAME)/
@@ -32,6 +32,8 @@ define Package/polipo/description
  small group of people, there is nothing that prevents it from being used
  by a larger group.
 endef
+
+TARGET_CFLAGS += -DHAVE_IPv6
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \


### PR DESCRIPTION
Maintainer: @kerneis 

Description:
Currently `polipo.h` uses the conditional
`(__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 2)` to decide
whether to enable IPv6 support.

This used to work for OpenWrt CC which uses uClibc disguising itself
as Glibc 2.x but it does not work with Musl libc anymore as this library
does not export and Glibc defines.

Forcibly enable IPv6 support by passing `-DHAVE_IPv6` unconditionally
through the build flags in the OpenWrt/LEDE Makefile.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>