### PR TITLE
shorewall-core: Don't depend on iptables

### DIFF
--- a/net/shorewall-core/Makefile
+++ b/net/shorewall-core/Makefile
@@ -27,7 +27,6 @@ include $(INCLUDE_DIR)/package.mk
 define Package/shorewall-core
     SECTION:=net
     CATEGORY:=Network
-    DEPENDS:=+ip +iptables
     TITLE:=Shorewall Core
     URL:=http://www.shorewall.net/
     SUBMENU:=Firewall


### PR DESCRIPTION
Maintainer: @wvdakker 

Description:
shorewall-lite will depend on ip and iptables so shorewall-core
doesn't need to.

If one only wanted shorewall6-lite for example, one shouldn't
need iptables, just ip6tables.  If ip6tables needs iptables,
it should depend on it.

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>
