### PR TITLE
mc: release 4.8.20

### DIFF
--- a/utils/mc/Makefile
+++ b/utils/mc/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mc
-PKG_VERSION:=4.8.19
+PKG_VERSION:=4.8.20
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 PKG_LICENSE:=GPL-3.0+
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://ftp.midnight-commander.org/
-PKG_HASH:=eb9e56bbb5b2893601d100d0e0293983049b302c5ab61bfb544ad0ee2cc1f2df
+PKG_HASH:=017ee7f4f8ae420a04f4d6fcebaabe5b494661075c75442c76e9c8b1923d501c
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf gettext-version
 


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: LEDE trunk, APU2 x86_64
Run tested: LEDE trunk, APU2 x86_64

Description:
release notes: http://midnight-commander.org/wiki/NEWS-4.8.20

Signed-off-by: Dirk Brenken <dev@brenken.org>