### PR TITLE
dovecot: prepare for runtime dependency by plugins

### DIFF
--- a/mail/dovecot/Makefile
+++ b/mail/dovecot/Makefile
@@ -9,15 +9,22 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot
 PKG_VERSION:=2.2.33.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.dovecot.org/releases/2.2
 PKG_HASH:=fe1e3b78609a56ee22fc209077e4b75348fa1bbd54c46f52bde2472a4c4cee84
 PKG_LICENSE:=LGPL-2.1 MIT BSD-3-Clause Unique
 PKG_LICENSE_FILES:=COPYING COPYING.LGPL COPYING.MIT
+PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 
 PKG_BUILD_DEPENDS:=libiconv
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_DOVECOT_LDAP \
+	CONFIG_DOVECOT_MYSQL \
+	CONFIG_DOVECOT_PGSQL \
+	CONFIG_DOVECOT_SQLITE \
+	CONFIG_DOVECOT_ICU
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -27,11 +34,11 @@ include $(INCLUDE_DIR)/package.mk
 define Package/dovecot
   SECTION:=mail
   CATEGORY:=Mail
-  DEPENDS:=+DOVECOT_LDAP:libopenldap +DOVECOT_MYSQL:libmysqlclient +DOVECOT_PGSQL:libpq +DOVECOT_SQLITE:libsqlite3 +libopenssl +librt +zlib +libbz2 +libcap
+  DEPENDS:=+DOVECOT_LDAP:libopenldap +DOVECOT_MYSQL:libmysqlclient +DOVECOT_PGSQL:libpq +DOVECOT_SQLITE:libsqlite3 +libopenssl +librt +zlib +libbz2 +libcap +DOVECOT_ICU:icu
   TITLE:=An IMAP and POP3 daemon
-  MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
   URL:=http://www.dovecot.org/
   USERID:=dovecot=59:dovecot=59
+  ABI_VERSION:=$(PKG_VERSION)
 endef
 
 define Package/dovecot/description
@@ -61,7 +68,24 @@ define Package/dovecot/config
                         default n
                         help
                           Implements SQLite DB support in dovecot.
+                config DOVECOT_ICU
+                        bool "Enable i18n features"
+                        default n
+                        help
+                          Enable ICU (International Components for Unicode) support.
         endmenu
+endef
+
+define Package/dovecot/conffiles
+/etc/init.d/dovecot
+/etc/dovecot/
+endef
+
+define Package/dovecot-utils
+  SECTION:=mail
+  CATEGORY:=Mail
+  DEPENDS:=+dovecot
+  TITLE:=doveadm and dsync utilities for Dovecot
 endef
 
 CONFIGURE_ARGS += \
@@ -71,11 +95,11 @@ CONFIGURE_ARGS += \
 	--with-notify=dnotify \
 	--without-lzma \
 	--without-lz4 \
-	--with-icu=no \
 	$(if $(CONFIG_DOVECOT_LDAP),--with-ldap=yes,--with-ldap=no) \
 	$(if $(CONFIG_DOVECOT_MYSQL),--with-mysql=yes,--with-mysql=no) \
 	$(if $(CONFIG_DOVECOT_PGSQL),--with-pgsql=yes,--with-pgsql=no) \
-	$(if $(CONFIG_DOVECOT_SQLITE),--with-sqlite=yes,--with-sqlite=no)
+	$(if $(CONFIG_DOVECOT_SQLITE),--with-sqlite=yes,--with-sqlite=no) \
+	$(if $(CONFIG_DOVECOT_ICU),--with-icu=yes,--with-icu=no)
 
 CONFIGURE_VARS += \
 	RPCGEN= \
@@ -101,13 +125,13 @@ endef
 define Package/dovecot/install
 	$(INSTALL_DIR)  $(1)/etc/init.d \
 			$(1)/etc/dovecot \
-			$(1)/usr/share/doc/dovecot/example-config \
+			$(1)/usr/share/doc/dovecot \
 			$(1)/usr/lib/dovecot \
 			$(1)/usr/bin \
 			$(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/etc/dovecot/* $(1)/etc/dovecot/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/dovecot/* $(1)/usr/lib/dovecot/
-	$(CP) $(PKG_INSTALL_DIR)/usr/share/doc/dovecot/example-config $(1)/usr/share/doc/dovecot/example-config
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/doc/dovecot/example-config $(1)/usr/share/doc/dovecot/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/doveconf $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/* $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/dovecot.init $(1)/etc/init.d/dovecot
@@ -115,4 +139,11 @@ define Package/dovecot/install
 	find $(1)/usr/lib/dovecot/ -name "*.a" -o -name "*.la" | xargs rm
 endef
 
+define Package/dovecot-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/doveadm $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/dsync $(1)/usr/bin/
+endef
+
 $(eval $(call BuildPackage,dovecot))
+$(eval $(call BuildPackage,dovecot-utils))


### PR DESCRIPTION
Maintainer: @lucize 
Attention pigeonhole package maintainer: @MikePetullo 
Compile tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5
Run tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5

Description:

Add ABI_VERSION declaration in order to tell dovecot plugins that are runtime-dependent on dovecot's Application Binary Interface (ABI) version, such as the pigeonhole mail filter, that they need to be rebuilt each time the dovecot's ABI version changes.

This PR is not yet closing issue #5062. A forthcoming PR for pigeonhole package will close the issue.

Introduce a new configuration parameter to enable ICU (i18n) support. Make the ICU disabled by default.

Declare the conffiles section to save dovecot's configuration files and its init.d script on sysupgrade.

Introduce a new package, dovecot-utils, to contain doveadm and dsync utilities: closes #4912.

Correct the destination directory for the installation of example-config files. At present, the example files are installed into /usr/share/doc/dovecot/example-config/example-config.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>