### PR TITLE
pigeonhole: fix runtime dependency on dovecot's ABI

### DIFF
--- a/mail/pigeonhole/Makefile
+++ b/mail/pigeonhole/Makefile
@@ -7,50 +7,52 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=pigeonhole
-PKG_VERSION:=0.4.20
-PKG_RELEASE:=1
+PKG_NAME:=dovecot-pigeonhole
+PKG_VERSION_PLUGIN:=0.4.20
+PKG_VERSION_DOVECOT:=$(shell make --no-print-directory -C ../dovecot/ val.PKG_VERSION V=s)
+PKG_VERSION:=$(PKG_VERSION_DOVECOT)-$(PKG_VERSION_PLUGIN)
+PKG_RELEASE:=2
 
 DOVECOT_VERSION:=2.2
 
-PKG_SOURCE:=dovecot-$(DOVECOT_VERSION)-$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=dovecot-$(DOVECOT_VERSION)-pigeonhole-$(PKG_VERSION_PLUGIN).tar.gz
 PKG_SOURCE_URL:=https://pigeonhole.dovecot.org/releases/$(DOVECOT_VERSION)
 PKG_HASH:=6fe17d0b8f25f2ad580e01ad81ce47a9e965255e383a1f80e455f9ca0f00be5b
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING COPYING.LGPL
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/dovecot-$(DOVECOT_VERSION)-$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/dovecot-$(DOVECOT_VERSION)-pigeonhole-$(PKG_VERSION_PLUGIN)
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/pigeonhole
+define Package/dovecot-pigeonhole
   SECTION:=mail
   CATEGORY:=Mail
   DEPENDS:=+dovecot
+  EXTRA_DEPENDS:=dovecot (>= $(PKG_VERSION_DOVECOT))
   TITLE:=Mail filtering facilities for Dovecot
   MAINTAINER:=W. Michael Petullo <mike@flyn.org>
   URL:=https://wiki2.dovecot.org/Pigeonhole
 endef
 
-define Package/pigeonhole/description
+define Package/dovecot-pigeonhole/description
   Pigeonhole provides mail filtering facilities for Dovecot using the Sieve
   (RFC 5228) language.
 endef
 
 CONFIGURE_ARGS += \
-  --with-dovecot=$(STAGING_DIR)/usr/lib/dovecot/ \
-  --without-managesieve
+  --with-dovecot=$(STAGING_DIR)/usr/lib/dovecot/
 
 CONFIGURE_VARS += \
   LDFLAGS="$(TARGET_LDFLAGS) -L$(STAGING_DIR)/usr/lib/dovecot/" \
   CPPFLAGS="$(TARGET_CPPFLAGS) -I$(STAGING_DIR)/usr/include/dovecot/"
 
-define Package/pigeonhole/install
+define Package/dovecot-pigeonhole/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/lib/dovecot/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/dovecot/* $(1)/usr/lib/dovecot/
 	find $(1)/usr/lib/dovecot/ -name "*.a" -o -name "*.la" | xargs rm
 endef
 
-$(eval $(call BuildPackage,pigeonhole))
+$(eval $(call BuildPackage,dovecot-pigeonhole))


### PR DESCRIPTION
Maintainer: @MikePetullo
Attention dovecot package maintainer: @lucize
Compile tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5
Run tested: bcm53xx, Buffalo WXR-1900DHP, LEDE Reboot SNAPSHOT r5297-bddffc5

Description:

Closes #5062. With ABI_VERSION declaration in dovecot's Makefile introduced in PR #5182, pigeonhole plugin will now be rebuilt on every dovecot upgrade. To announce the rebuilt pigeonhole plugin to opkg, introduce a different model of version numbering. The new version numbering now includes both dovecot and pigeonhole plugin version numbers. Therefore, the rebuilt pigeonhole plugin will be visible to opkg whenever dovecot or pigeonhole plugin version changes.

Rename "pigeonhole" to "dovecot-pigeonhole". There are several reasons for renaming the package:

1. pigeonhole is a plugin. There seems to be a convention to name plugins by adding corresponding suffixes to the parent package name, such as lua-\*, luci-\*, php7-mod-\*, perlbase-\*, transmission-\* etc.

2. When named as "dovecot-pigeonhole", the pigeonhole plugin is displayed right next to dovecot in config manager ("make menuconfig") and is therefore highly visible to anyone who explores the available
modules for dovecot.

3. When named as "dovecot-pigeonhole", the package version number consisting of both dovecot and pigeonhole version numbers makes more sense: "dovecot-pigeonhole_2.2.33.2-0.4.20-2" looks more comprehensible than "pigeonhole_2.2.33.2-0.4.20-2", however admittedly both variants
look rather ugly.

Add ManageSieve to the package. Adding managesieve-login and its libraries increases the size of the package by about 11% from 702061 bytes to 781294 bytes on the bcm53xx platform. As dovecot is unlikely to be used on a low-end LEDE/OpenWrt box, the addition of ~80KB to the package size is not likely to make a noticeable difference but it adds the capability to use pigeonhole plugin for dovecot with
systems that talk ManageSieve, such as RoundCube.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>