### PR TITLE
openconnect: support reading password from script

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=7.08
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/openconnect/README
+++ b/net/openconnect/README
@@ -25,6 +25,10 @@ config interface 'MYVPN'
 	# HOTP/TOTP tokens
         #option token_mode 'hotp'
         #option token_secret '00'
+	
+	# tokens from script
+	#option token_mode 'script'
+	#option token_script '/lib/custom/getocpass.sh'
 
 	# Juniper vpn support
 	#option juniper '1'

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -77,7 +77,7 @@ proto_openconnect_setup() {
 		[ "$token_mode" = "script" ] && {
 			$token_script > "$pwfile" 2> /dev/null || {
 				logger -t openconenct "Cannot get password from script '$token_script'"
-				sleep 60
+				sleep 1
 				proto_setup_failed "$config"
 			}
 		}

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -16,6 +16,7 @@ proto_openconnect_init_config() {
 	proto_config_add_string "password2"
 	proto_config_add_string "token_mode"
 	proto_config_add_string "token_secret"
+	proto_config_add_string "token_script"
 	proto_config_add_string "os"
 	proto_config_add_string "csd_wrapper"
 	no_device=1
@@ -25,7 +26,7 @@ proto_openconnect_init_config() {
 proto_openconnect_setup() {
 	local config="$1"
 
-	json_get_vars server port interface username serverhash authgroup password password2 token_mode token_secret os csd_wrapper mtu juniper
+	json_get_vars server port interface username serverhash authgroup password password2 token_mode token_secret token_script os csd_wrapper mtu juniper
 
 	grep -q tun /proc/modules || insmod tun
 	ifname="vpn-$config"
@@ -65,16 +66,25 @@ proto_openconnect_setup() {
 	}
 	[ -n "$authgroup" ] && append cmdline "--authgroup $authgroup"
 	[ -n "$username" ] && append cmdline "-u $username"
-	[ -n "$password" ] && {
+	[ -n "$password" ] || [ "$token_mode" = "script" ] && {
 		umask 077
 		mkdir -p /var/etc
 		pwfile="/var/etc/openconnect-$config.passwd"
-		echo "$password" > "$pwfile"
-		[ -n "$password2" ] && echo "$password2" >> "$pwfile"
+		[ -n "$password" ] && {
+			echo "$password" > "$pwfile"
+			[ -n "$password2" ] && echo "$password2" >> "$pwfile"
+		}
+		[ "$token_mode" = "script" ] && {
+			$token_script > "$pwfile" 2> /dev/null || {
+				logger -t openconenct "Cannot get password from script '$token_script'"
+				sleep 60
+				proto_setup_failed "$config"
+			}
+		}
 		append cmdline "--passwd-on-stdin"
 	}
 
-	[ -n "$token_mode" ] && append cmdline "--token-mode=$token_mode"
+	[ -n "$token_mode" ] && ! [ "$token_mode" = "script" ] && append cmdline "--token-mode=$token_mode"
 	[ -n "$token_secret" ] && append cmdline "--token-secret=$token_secret"
 	[ -n "$os" ] && append cmdline "--os=$os"
 	[ -n "$csd_wrapper" ] && [ -x "$csd_wrapper" ] && append cmdline "--csd-wrapper=$csd_wrapper"


### PR DESCRIPTION
option "token_mode" add support for "script", which execute "token_script" to get the password.
Some token is not supported by OpenConnect natively, e.g. "MobilePass" or "Softoken II" used in Cisco VPN

Tested on: netgear wndr4300

Maintainer: @yousong @nmav 
