### PR TITLE
mwan3: Improve logs when member metric is too big

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.6.8
+PKG_VERSION:=2.6.9
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -10,6 +10,7 @@ CONNTRACK_FILE="/proc/net/nf_conntrack"
 
 MWAN3_STATUS_DIR="/var/run/mwan3"
 MWAN3TRACK_STATUS_DIR="/var/run/mwan3track"
+DEFAULT_LOWEST_METRIC=256
 
 [ -d $MWAN3_STATUS_DIR ] || mkdir -p $MWAN3_STATUS_DIR/iface_state
 # mwan3's MARKing mask (at least 3 bits should be set)
@@ -480,6 +481,7 @@ mwan3_set_policy()
 	config_get weight $1 weight 1
 
 	[ -n "$iface" ] || return 0
+	[ "$metric" -gt $DEFAULT_LOWEST_METRIC ] && $LOG warn "Member interface $iface has >$DEFAULT_LOWEST_METRIC metric. Not appending to policy" && return 0
 
 	mwan3_get_iface_id id $iface
 
@@ -587,10 +589,10 @@ mwan3_create_policies_iptables()
 		esac
 	done
 
-	lowest_metric_v4=256
+	lowest_metric_v4=$DEFAULT_LOWEST_METRIC
 	total_weight_v4=0
 
-	lowest_metric_v6=256
+	lowest_metric_v6=$DEFAULT_LOWEST_METRIC
 	total_weight_v6=0
 
 	config_list_foreach $1 use_member mwan3_set_policy


### PR DESCRIPTION
If metric of member interface is bigger then 256, it is not
appended to policy, now at least warn message is printed into
syslog

Partially solves #4428