### PR TITLE
iodine: properly detect endianess when building against musl libc

### DIFF
--- a/net/iodine/Makefile
+++ b/net/iodine/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iodine
 PKG_VERSION:=0.7.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://code.kryo.se/iodine/

--- a/net/iodine/patches/101-musl-workaround-incomplete-nameser-h.patch
+++ b/net/iodine/patches/101-musl-workaround-incomplete-nameser-h.patch
@@ -1,0 +1,27 @@
+The arpa/nameser.h header of musl libc indirectly depends on the endian.h
+header but fails to explicitely include it to properly define
+`__BYTE_ORDER` and `__BIG_ENDIAN` prior to declaring the DNS `HEADER`
+structure.
+
+When both the appropriate `__BYTE_ORDER` and `__BIG_ENDIAN` defines are
+unset, the `#if __BYTE_ORDER == __BIG_ENDIAN` condition in `nameser.h`
+evaluates to true, causing it to declare a bad (big endian) DNS packet
+header structure on little endian systems.
+
+Work around this musl bug by forcibly passing `-include endian.h` through
+the `osflags` file.
+
+An upstream fix for musl libc has been submitted with
+http://www.openwall.com/lists/musl/2017/12/04/3
+
+--- a/src/osflags
++++ b/src/osflags
+@@ -27,7 +27,7 @@ cflags)
+ 			echo '-Dsocklen_t=int';
+ 		;;
+ 		Linux)
+-			FLAGS="-D_GNU_SOURCE"
++			FLAGS="-D_GNU_SOURCE -include endian.h"
+ 			echo $FLAGS;
+ 		;;
+ 	esac


### PR DESCRIPTION
Maintainer: @ukleinek
Compile tested: LEDE ramips/mt76x8 SDK r5436-18cc8d5
Run tested: -
Description:

The arpa/nameser.h header of musl libc indirectly depends on the endian.h
header to properly define `__BYTE_ORDER` and `__BIG_ENDIAN` prior to
declaring the DNS `HEADER` structure.

When both the appropriate `__BYTE_ORDER` and `__BIG_ENDIAN` defines are
unset, the `#if __BYTE_ORDER == __BIG_ENDIAN` condition in `nameser.h`
evaluates to true, causing it to declare a bad (big endian) DNS packet
header structure on little endian systems.

This should solve iodine packet corruption on little endian musl systems
reparted at
http://lists.infradead.org/pipermail/lede-dev/2017-November/010085.html

Since we already patch `osflags` for musl compatibility, fix the issue
by extending the patch to forcibly add `-include endian.h` to the CFLAGS.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>
