### PR TITLE
gstreamer: bump to 1.10.5

### DIFF
--- a/multimedia/gst1-libav/Makefile
+++ b/multimedia/gst1-libav/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-libav
-PKG_VERSION:=1.8.2
-PKG_RELEASE:=2
+PKG_VERSION:=1.10.5
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
 		Ted Hess <thess@kitschensync.net>
 
 PKG_SOURCE:=gst-libav-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-libav
-PKG_HASH:=b5f3c7a27b39b5f5c2f0bfd546b0c655020faf6b38d27b64b346c43e5ebf687a
+PKG_HASH:=e4d2f315f478d47281fbfdfbd590a63d23704ca37911d7142d5992616f4b28d3
 
 PKG_LICENSE:=GPL-2.0 LGPL-2.0
 PKG_LICENSE_FILES:=COPYING COPYING.LIB

--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-bad
-PKG_VERSION:=1.8.2
+PKG_VERSION:=1.10.5
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
@@ -20,9 +20,9 @@ PKG_LICENSE_FILES:=COPYING.LIB COPYING
 PKG_BUILD_DIR:=$(BUILD_DIR)/gst-plugins-bad-$(PKG_VERSION)
 PKG_SOURCE:=gst-plugins-bad-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-plugins-bad/
-PKG_HASH:=d7995317530c8773ec088f94d9320909d41da61996b801ebacce9a56af493f97
+PKG_HASH:=c5806040bb83b43be86ce592e6a19c5d83d7776f7d9f434eb4b911c4efff3573
 
-PKG_BUILD_DEPENDS:= libgstreamer1 gstreamer1-plugins-base
+PKG_BUILD_DEPENDS:= libgstreamer1 gst1-plugins-base libgst1basecamerabinsrc libgst1photography libgst1adaptivedemux libgst1uridownloader libgst1badbase
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -38,7 +38,7 @@ define Package/gstreamer1-bad/Default
   SECTION:=multimedia
   TITLE:=GStreamer
   URL:=http://gstreamer.freedesktop.org/
-  DEPENDS:= +libgstreamer1 $(ICONV_DEPENDS)
+  DEPENDS:= +gst1-plugins-base +libgstreamer1 +libgst1pbutils $(ICONV_DEPENDS)
 endef
 
 define Package/gstreamer1-bad/description/Default

--- a/multimedia/gst1-plugins-bad/patches/001-no-translations.patch
+++ b/multimedia/gst1-plugins-bad/patches/001-no-translations.patch
@@ -1,9 +1,9 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -3717,7 +3717,6 @@ ext/x265/Makefile
- ext/xvid/Makefile
+@@ -3841,7 +3841,6 @@ ext/xvid/Makefile
  ext/zbar/Makefile
  ext/dtls/Makefile
+ ext/webrtcdsp/Makefile
 -po/Makefile.in
  docs/Makefile
  docs/plugins/Makefile

--- a/multimedia/gst1-plugins-bad/patches/002-no-tests.patch
+++ b/multimedia/gst1-plugins-bad/patches/002-no-tests.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -3617,38 +3617,6 @@ sys/wasapi/Makefile
+@@ -3739,37 +3739,6 @@ sys/wasapi/Makefile
  sys/wininet/Makefile
  sys/winks/Makefile
  sys/winscreencap/Makefile
@@ -21,7 +21,6 @@
 -tests/examples/gl/generic/doublecube/Makefile
 -tests/examples/gl/generic/recordgraphic/Makefile
 -tests/examples/gl/gtk/Makefile
--tests/examples/gl/gtk/gtkvideooverlay/Makefile
 -tests/examples/gl/gtk/3dvideo/Makefile
 -tests/examples/gl/gtk/filternovideooverlay/Makefile
 -tests/examples/gl/gtk/filtervideooverlay/Makefile

--- a/multimedia/gst1-plugins-base/Makefile
+++ b/multimedia/gst1-plugins-base/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-base
-PKG_VERSION:=1.8.2
+PKG_VERSION:=1.10.5
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
@@ -20,7 +20,7 @@ PKG_LICENSE_FILES:=COPYING.LIB COPYING
 PKG_BUILD_DIR:=$(BUILD_DIR)/gst-plugins-base-$(PKG_VERSION)
 PKG_SOURCE:=gst-plugins-base-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-plugins-base/
-PKG_HASH:=9d7109c8fb0a5dec8edb17b0053c59a46aba7ddf48dc48ea822ebbbd4339d38d
+PKG_HASH:=1c401a79bd1e4521c6ef1b66579bddedd9136e164e54792aab4bfcf3485bf9a7
 
 PKG_BUILD_DEPENDS:= libgstreamer1
 PKG_CONFIG_DEPENDS:= \

--- a/multimedia/gst1-plugins-base/patches/001-no-translations.patch
+++ b/multimedia/gst1-plugins-base/patches/001-no-translations.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -929,7 +929,6 @@ docs/design/Makefile
+@@ -963,7 +963,6 @@ docs/design/Makefile
  docs/libs/Makefile
  docs/plugins/Makefile
  docs/version.entities

--- a/multimedia/gst1-plugins-base/patches/002-no-tests.patch
+++ b/multimedia/gst1-plugins-base/patches/002-no-tests.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -907,23 +907,6 @@ pkgconfig/gstreamer-video.pc
+@@ -940,24 +940,6 @@ pkgconfig/gstreamer-video.pc
  pkgconfig/gstreamer-video-uninstalled.pc
  pkgconfig/gstreamer-plugins-base.pc
  pkgconfig/gstreamer-plugins-base-uninstalled.pc
@@ -9,6 +9,7 @@
 -tests/examples/Makefile
 -tests/examples/app/Makefile
 -tests/examples/audio/Makefile
+-tests/examples/decodebin_next/Makefile
 -tests/examples/dynamic/Makefile
 -tests/examples/encoding/Makefile
 -tests/examples/fft/Makefile

--- a/multimedia/gst1-plugins-base/patches/003-no-docs.patch
+++ b/multimedia/gst1-plugins-base/patches/003-no-docs.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -907,11 +907,6 @@ pkgconfig/gstreamer-video.pc
+@@ -940,11 +940,6 @@ pkgconfig/gstreamer-video.pc
  pkgconfig/gstreamer-video-uninstalled.pc
  pkgconfig/gstreamer-plugins-base.pc
  pkgconfig/gstreamer-plugins-base-uninstalled.pc

--- a/multimedia/gst1-plugins-good/Makefile
+++ b/multimedia/gst1-plugins-good/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-good
-PKG_VERSION:=1.8.2
+PKG_VERSION:=1.10.5
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
@@ -20,9 +20,9 @@ PKG_LICENSE_FILES:=COPYING
 PKG_BUILD_DIR:=$(BUILD_DIR)/gst-plugins-good-$(PKG_VERSION)
 PKG_SOURCE:=gst-plugins-good-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-plugins-good/
-PKG_HASH:=8d7549118a3b7a009ece6bb38a05b66709c551d32d2adfd89eded4d1d7a23944
+PKG_HASH:=be053f6ed716eeb517cec148cec637cdce571c6e04d5c21409e2876fb76c7639
 
-PKG_BUILD_DEPENDS:= libgstreamer1 gstreamer1-plugins-base
+PKG_BUILD_DEPENDS:= libgstreamer1 gst1-plugins-base
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -37,7 +37,7 @@ define Package/gstreamer1-good/Default
   SECTION:=multimedia
   TITLE:=GStreamer
   URL:=http://gstreamer.freedesktop.org/
-  DEPENDS:= +libgstreamer1 $(ICONV_DEPENDS)
+  DEPENDS:= +libgstreamer1 +libgst1pbutils $(ICONV_DEPENDS)
 endef
 
 define Package/gstreamer1-good/description/Default

--- a/multimedia/gst1-plugins-good/patches/001-no-translations.patch
+++ b/multimedia/gst1-plugins-good/patches/001-no-translations.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1049,7 +1049,6 @@ sys/sunaudio/Makefile
+@@ -1061,7 +1061,6 @@ sys/sunaudio/Makefile
  sys/v4l2/Makefile
  sys/waveform/Makefile
  sys/ximage/Makefile

--- a/multimedia/gst1-plugins-good/patches/002-no-tests.patch
+++ b/multimedia/gst1-plugins-good/patches/002-no-tests.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1049,21 +1049,6 @@ sys/sunaudio/Makefile
+@@ -1061,21 +1061,6 @@ sys/sunaudio/Makefile
  sys/v4l2/Makefile
  sys/waveform/Makefile
  sys/ximage/Makefile

--- a/multimedia/gst1-plugins-good/patches/003-no-docs.patch
+++ b/multimedia/gst1-plugins-good/patches/003-no-docs.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1052,9 +1052,6 @@ sys/ximage/Makefile
+@@ -1064,9 +1064,6 @@ sys/ximage/Makefile
  common/Makefile
  common/m4/Makefile
  m4/Makefile

--- a/multimedia/gst1-plugins-ugly/Makefile
+++ b/multimedia/gst1-plugins-ugly/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-ugly
-PKG_VERSION:=1.8.2
+PKG_VERSION:=1.10.5
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
@@ -20,7 +20,7 @@ PKG_LICENSE_FILES:=COPYING
 PKG_BUILD_DIR:=$(BUILD_DIR)/gst-plugins-ugly-$(PKG_VERSION)
 PKG_SOURCE:=gst-plugins-ugly-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-plugins-ugly/
-PKG_HASH:=9c5b33a2a98fc1d6d6c99a1b536b1fb2de45f53cc8bf8ab85a8b8141fed1a8ac
+PKG_HASH:=d6edc046350809c967f5b058c5c2e534d99d1d69fe1b26acd849e87781a7d7fc
 
 PKG_BUILD_DEPENDS:= libgstreamer1 gstreamer1-plugins-base
 PKG_CONFIG_DEPENDS:= \

--- a/multimedia/gst1-plugins-ugly/patches/001-no-translations.patch
+++ b/multimedia/gst1-plugins-ugly/patches/001-no-translations.patch
@@ -1,17 +1,15 @@
-diff -u --recursive gst-plugins-ugly-1.6.2-vanilla/configure.ac gst-plugins-ugly-1.6.2/configure.ac
---- gst-plugins-ugly-1.6.2-vanilla/configure.ac	2016-01-01 10:47:06.333623730 -0500
-+++ gst-plugins-ugly-1.6.2/configure.ac	2016-01-01 10:47:20.211613708 -0500
-@@ -470,7 +470,6 @@
- tests/Makefile
+--- a/configure.ac
++++ b/configure.ac
+@@ -482,7 +482,6 @@ tests/Makefile
  tests/check/Makefile
+ tests/files/Makefile
  m4/Makefile
 -po/Makefile.in
  pkgconfig/Makefile
  pkgconfig/gstreamer-plugins-ugly-uninstalled.pc
  gst-plugins-ugly.spec
-diff -u --recursive gst-plugins-ugly-1.6.2-vanilla/Makefile.am gst-plugins-ugly-1.6.2/Makefile.am
---- gst-plugins-ugly-1.6.2-vanilla/Makefile.am	2016-01-01 10:47:06.333623730 -0500
-+++ gst-plugins-ugly-1.6.2/Makefile.am	2016-01-01 10:47:14.523210855 -0500
+--- a/Makefile.am
++++ b/Makefile.am
 @@ -1,7 +1,7 @@
  DISTCHECK_CONFIGURE_FLAGS=--enable-gtk-doc
  

--- a/multimedia/gstreamer1/Makefile
+++ b/multimedia/gstreamer1/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gstreamer1
-PKG_VERSION:=1.8.2
+PKG_VERSION:=1.10.5
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
@@ -20,7 +20,7 @@ PKG_LICENSE_FILES:=COPYING
 PKG_BUILD_DIR:=$(BUILD_DIR)/gstreamer-$(PKG_VERSION)
 PKG_SOURCE:=gstreamer-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gstreamer/
-PKG_HASH:=9dbebe079c2ab2004ef7f2649fa317cabea1feb4fb5605c24d40744b90918341
+PKG_HASH:=bc06243600817f637029da29d089d5908d1d266542f68bf6626a10c5f05f1f1d
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=autogen.sh aclocal.m4
@@ -134,11 +134,6 @@ define Build/InstallDev
 	( cd $(PKG_INSTALL_DIR); $(CP) \
 		./usr/include/gstreamer-$(GST_VERSION)/* \
 		$(1)/usr/include/gstreamer-$(GST_VERSION)/ \
-	)
-	$(INSTALL_DIR) $(1)/usr/lib/gstreamer-$(GST_VERSION)/include/gst
-	( cd $(PKG_INSTALL_DIR); $(CP) \
-		./usr/lib/gstreamer-$(GST_VERSION)/include/gst/*.h \
-		$(1)/usr/lib/gstreamer-$(GST_VERSION)/include/gst \
 	)
 	$(INSTALL_DIR) $(1)/usr/lib
 	( cd $(PKG_INSTALL_DIR); $(CP) \

--- a/multimedia/gstreamer1/patches/001-no-translations.patch
+++ b/multimedia/gstreamer1/patches/001-no-translations.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -998,7 +998,6 @@ libs/gst/net/Makefile
+@@ -1047,7 +1047,6 @@ libs/gst/net/Makefile
  plugins/Makefile
  plugins/elements/Makefile
  plugins/tracers/Makefile

--- a/multimedia/gstreamer1/patches/002-no-tests.patch
+++ b/multimedia/gstreamer1/patches/002-no-tests.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -998,21 +998,6 @@ libs/gst/net/Makefile
+@@ -1047,21 +1047,6 @@ libs/gst/net/Makefile
  plugins/Makefile
  plugins/elements/Makefile
  plugins/tracers/Makefile

--- a/multimedia/gstreamer1/patches/003-no-docs.patch
+++ b/multimedia/gstreamer1/patches/003-no-docs.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1001,18 +1001,6 @@ plugins/tracers/Makefile
+@@ -1050,18 +1050,6 @@ plugins/tracers/Makefile
  tools/Makefile
  common/Makefile
  common/m4/Makefile


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: brcm63xx, LEDE trunk
Run tested: brcm63xx, Lede trunk

Description:
Update gstreamer to the 1.10 stable branch; select latest stable 1.10.5
See https://gstreamer.freedesktop.org/releases/1.10/ for major new and bugfixes

