### PR TITLE
squid-4x: add package

### DIFF
--- a/net/squid-4x/Config.in
+++ b/net/squid-4x/Config.in
@@ -1,0 +1,71 @@
+if PACKAGE_squid-4x
+
+	comment "Optional features"
+
+	config SQUID_enable-ipv6
+		bool "Enable support for IP version 6"
+		default y
+
+	config SQUID_enable-snmp
+		bool "Enable SNMP monitoring support"
+		default n
+
+	config SQUID_enable-icmp
+		bool "Enable ICMP pinging and Network Measurement"
+		default n
+
+	config SQUID_enable-icap-client
+		bool "Enable ICAP client support"
+		default n
+
+	config SQUID_enable-dlmalloc
+		bool "Compile & use the malloc package by Doug Lea"
+		default y
+
+	config SQUID_enable-ssl-crtd
+		bool "Enable dynamic SSL certificate generation "
+		depends on !SQUID_use-gnutls
+		default n
+
+	config SQUID_auth-basic
+		bool "Enable the Basic authentication scheme"
+		default n
+
+	config SQUID_auth-digest
+		bool "Enable the Digest authentication scheme"
+		default n
+
+	config SQUID_auth-negotiate
+		bool "Enable the Negotiate authentication scheme"
+		default n
+
+	config SQUID_auth-ntlm
+		bool "Enable the NTLM authentication scheme"
+		default n
+
+	comment "Optional packages"
+
+	config SQUID_use-gnutls
+		bool "Use GnuTLS instead of OpenSSL"
+		default n
+
+	config SQUID_with-libcap
+		bool "Use libcap - Linux capabilities library"
+		default n
+
+	config SQUID_with-nettle
+		bool "Use nettle - GNU crypto library"
+		default n
+
+	config SQUID_with-expat
+		bool "Use expat - XML parsing library"
+		default n
+
+	config SQUID_with-libxml2
+		bool "Use libxml2 - Gnome XML library"
+		default n
+
+	comment "Additional tools"
+
+endif
+

--- a/net/squid-4x/Makefile
+++ b/net/squid-4x/Makefile
@@ -1,0 +1,158 @@
+#
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=squid-4x
+PKG_VERSION:=4.0.21
+PKG_RELEASE:=1
+
+PKG_LICENSE:=GPL-2.0
+PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
+
+PKG_SOURCE:=squid-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=http://www.squid-cache.org/Versions/v4/
+PKG_HASH:=154d8ebdfdd004f113899b71325dcc401cf07ad8736701032d531c7af1908e33
+PKG_BUILD_DIR:=$(BUILD_DIR)/squid-$(PKG_VERSION)
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/squid-4x/Default
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
+  URL:=http://www.squid-cache.org/
+endef
+
+define Package/squid-4x
+  $(call Package/squid-4x/Default)
+  MENU:=1
+  DEPENDS:=+libpthread +librt +libltdl +libstdcpp +libatomic
+  DEPENDS+= +SQUID_use-gnutls:libgnutls +!SQUID_use-gnutls:libopenssl
+  DEPENDS+= +SQUID_with-libcap:libcap
+  DEPENDS+= +SQUID_with-nettle:libnettle
+  DEPENDS+= +SQUID_with-expat:libexpat
+  DEPENDS+= +SQUID_with-libxml2:libxml2
+  TITLE:=Full-featured Web caching proxy (Beta)
+  USERID:=squid=137:squid=137
+endef
+
+define Package/squid-4x/description
+  $(TITLE)
+endef
+
+define Package/squid-4x/config
+	help
+		Squid is a caching proxy for the Web supporting HTTP, HTTPS, FTP, and more.
+		It reduces bandwidth and improves response times by caching and reusing
+		frequently-requested web pages.
+		Run as : $(USERID)
+		Version: $(PKG_VERSION)
+		Home   : $(URL)
+		Maintainer: $(PKG_MAINTAINER)
+
+	source "$(SOURCE)/Config.in"
+endef
+
+
+define Package/squid-4x-mod-cachemgr
+  $(call Package/squid-4x/Default)
+  DEPENDS:=squid-4x
+  TITLE:=Web based proxy manager and reporting tool
+endef
+
+CONFIGURE_ARGS += \
+	--datadir=/usr/share/squid \
+	--libexecdir=/usr/lib/squid \
+	--sysconfdir=/etc/squid \
+	--disable-arch-native \
+	--with-dl \
+	--enable-shared \
+	--disable-static \
+	--config-cache \
+	--enable-cache-digests \
+	--enable-delay-pools \
+	--enable-kill-parent-hack \
+	--enable-linux-netfilter \
+	--without-netfilter-conntrack \
+	--disable-unlinkd \
+	--enable-x-accelerator-vary \
+	--with-pthreads \
+	--enable-ssl \
+	--disable-translation \
+	--disable-auto-locale \
+	--enable-epoll \
+	--with-maxfd=2048 \
+	--disable-ecap \
+	--disable-external-acl-helpers \
+	--disable-ident-lookups \
+	--without-mit-krb5
+
+CONFIGURE_ARGS += \
+	$(if $(CONFIG_SQUID_auth-basic),--enable,--disable)-auth-basic \
+	$(if $(CONFIG_SQUID_auth-digest),--enable,--disable)-auth-digest \
+	$(if $(CONFIG_SQUID_auth-ntlm),--enable,--disable)-auth-ntlm \
+	$(if $(CONFIG_SQUID_auth-negotiate),--enable,--disable)-auth-negotiate \
+	$(if $(CONFIG_SQUID_enable-ipv6),--enable,--disable)-dlmalloc \
+	$(if $(CONFIG_SQUID_enable-ipv6),--enable,--disable)-ipv6 \
+	$(if $(CONFIG_SQUID_enable-ssl-crtd),--enable-ssl-crtd) \
+	$(if $(CONFIG_SQUID_use-gnutls),--with,--without)-gnutls \
+	$(if $(CONFIG_SQUID_use-gnutls),--without-openssl) \
+	$(if $(CONFIG_SQUID_use-gnutls),,--with-openssl="$(STAGING_DIR)/usr") \
+	$(if $(CONFIG_SQUID_enable-icmp),--enable,--disable)-icmp \
+	$(if $(CONFIG_SQUID_enable-icap-client),--enable,--disable)-icap-client \
+	$(if $(CONFIG_SQUID_enable-snmp),--enable,--disable)-snmp \
+	$(if $(CONFIG_SQUID_with-libcap),--with,--without)-libcap \
+	$(if $(CONFIG_SQUID_with-nettle),--with,--without)-nettle \
+	$(if $(CONFIG_SQUID_with-expat),--with,--without)-expat \
+	$(if $(CONFIG_SQUID_with-libxml2),--with,--without)-libxml2
+
+CONFIGURE_VARS += \
+	ac_cv_header_linux_netfilter_ipv4_h=yes
+
+define Build/Compile
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/lib all
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		install
+endef
+
+define Package/squid-4x/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/squid $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/sbin/
+
+	$(INSTALL_DIR) $(1)/usr/lib/squid
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/squid/* $(1)/usr/lib/squid
+
+	$(INSTALL_DIR) $(1)/etc/squid
+	$(CP) $(PKG_INSTALL_DIR)/etc/squid/* $(1)/etc/squid/
+	$(CP) ./files/squid.conf $(1)/etc/squid/
+
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/squid.init $(1)/etc/init.d/squid
+
+	$(INSTALL_DIR) $(1)/usr/share/squid/
+	$(INSTALL_DIR) $(1)/usr/share/squid/icons/
+	$(INSTALL_DIR) $(1)/usr/share/squid/errors/templates/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/squid/mib.txt $(1)/usr/share/squid/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/squid/icons/* $(1)/usr/share/squid/icons/
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/share/squid/errors/templates/* \
+		$(1)/usr/share/squid/errors/templates/
+endef
+
+define Package/squid-4x-mod-cachemgr/install
+	$(INSTALL_DIR) $(1)/www/cgi-bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/squid/cachemgr.cgi $(1)/www/cgi-bin/
+endef
+
+$(eval $(call BuildPackage,squid-4x))
+$(eval $(call BuildPackage,squid-4x-mod-cachemgr))

--- a/net/squid-4x/files/squid.conf
+++ b/net/squid-4x/files/squid.conf
@@ -1,0 +1,86 @@
+#
+# Recommended minimum configuration:
+#
+
+# Example rule allowing access from your local networks.
+# Adapt to list your (internal) IP networks from where browsing
+# should be allowed
+acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
+acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
+acl localhet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
+acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
+acl localnet src fc00::/7       	# RFC 4193 local private network range
+acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl CONNECT method CONNECT
+
+#
+# Recommended minimum Access Permission configuration:
+#
+# Deny requests to certain unsafe ports
+http_access deny !Safe_ports
+
+# Deny CONNECT to other than secure SSL ports
+http_access deny CONNECT !SSL_ports
+
+# Only allow cachemgr access from localhost
+http_access allow localhost manager
+http_access deny manager
+
+# We strongly recommend the following be uncommented to protect innocent
+# web applications running on the proxy server who think the only
+# one who can access services on "localhost" is a local user
+#http_access deny to_localhost
+
+#
+# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
+#
+
+# Example rule allowing access from your local networks.
+# Adapt localnet in the ACL section to list your (internal) IP networks
+# from where browsing should be allowed
+http_access allow localnet
+http_access allow localhost
+
+# And finally deny all other access to this proxy
+http_access deny all
+
+# Squid normally listens to port 3128
+http_port 3128
+
+# Uncomment and adjust the following to add a disk cache directory.
+#cache_dir ufs /usr/local/squid/var/cache/squid 100 16 256
+
+# Leave coredumps in the first cache dir
+coredump_dir /tmp
+
+#
+# Add any of your own refresh_pattern entries above these.
+#
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern .		0	20%	4320
+
+# Squid user
+cache_effective_user squid
+
+#
+# Logs, best to use only for debugging as they can become very large
+#
+
+access_log none  # daemon:/tmp/squid_access.log
+cache_log /dev/null  # /tmp/squid_cache.log

--- a/net/squid-4x/files/squid.init
+++ b/net/squid-4x/files/squid.init
@@ -1,0 +1,35 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2017 OpenWrt.org
+
+START=90
+STOP=10
+
+USE_PROCD=1
+PROG=/usr/sbin/squid
+CONFIG_FILE="/etc/squid/squid.conf"
+USERID=137
+
+create_squid_user() {
+	user_exists squid || user_add squid $USERID
+	group_exists squid || group_add squid $USERID && group_add_user squid squid
+}
+
+start_service() {
+	create_squid_user
+
+	procd_open_instance
+	procd_set_param command $PROG -s -f $CONFIG_FILE -N
+	procd_set_param file $CONFIG_FILE
+	procd_set_param respawn
+	procd_close_instance
+}
+
+stop_service()
+{
+        ${PROG} -f $CONFIG_FILE -N -k shutdown 2>/dev/null
+}
+
+service_triggers()
+{
+	procd_add_reload_trigger "squid"
+}

--- a/net/squid-4x/patches/0001-compile.patch
+++ b/net/squid-4x/patches/0001-compile.patch
@@ -1,0 +1,24 @@
+From fac6f63a52a2f4cbb3748cd5687eca5409093904 Mon Sep 17 00:00:00 2001
+From: Marko Ratkaj <marko.ratkaj@sartura.hr>
+Date: Thu, 20 Apr 2017 15:15:50 +0200
+Subject: [PATCH] foo
+
+Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>
+---
+ src/Makefile.in | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+Index: squid-4.0.21/src/Makefile.in
+===================================================================
+--- squid-4.0.21.orig/src/Makefile.in
++++ squid-4.0.21/src/Makefile.in
+@@ -7642,7 +7642,8 @@ cache_cf.o: cf_parser.cci
+ 
+ # cf_gen builds the configuration files.
+ cf_gen$(EXEEXT): $(cf_gen_SOURCES) $(cf_gen_DEPENDENCIES) cf_gen_defines.cci
+-	$(BUILDCXX) $(BUILDCXXFLAGS) -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
++	g++ -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
++
+ 
+ # squid.conf.default is built by cf_gen when making cf_parser.cci
+ squid.conf.default squid.conf.documented: cf_parser.cci

--- a/net/squid-4x/patches/0002-compile.patch
+++ b/net/squid-4x/patches/0002-compile.patch
@@ -1,0 +1,13 @@
+--- a/src/base/File.h
++++ b/src/base/File.h
+@@ -11,6 +11,10 @@
+ 
+ #include "sbuf/SBuf.h"
+ 
++#if HAVE_SYS_FILE_H
++#include <sys/file.h>
++#endif
++
+ /// How should a file be opened/created? Should it be locked?
+ class FileOpeningConfig
+ {

--- a/net/squid-4x/patches/0003-glibc-compile.patch
+++ b/net/squid-4x/patches/0003-glibc-compile.patch
@@ -1,0 +1,12 @@
+--- squid-4.0.21.orig/src/tools.cc
++++ squid-4.0.21/src/tools.cc
+@@ -581,7 +581,8 @@
+     }
+ #else
+ 
+-    setuid(0);
++    if (setuid(0) < 0)
++	debugs(50, 1, "no_suid: setuid (0)");
+ #endif
+ #if HAVE_PRCTL && defined(PR_SET_DUMPABLE)
+     /* Set Linux DUMPABLE flag */


### PR DESCRIPTION
Maintainer: me / marko.ratkaj@sartura.hr / @ratkaj
Compile tested: LEDE master, mvebu/brcm2708/brcm63xx
Run tested: LEDE master, mvebu/brcm2708/brcm63xx

Description:
This is a Beta version of Squid that includes several new features that might be interesting to some people. We have been using this for a while now with no issues.

The most important of these new features are:

1. Configurable helper queue size
2. Helper concurrency channels changes
3. SSL support removal
4. Helper Binary Changes
5. Secure ICAP
6. Improved SMP support
7. Improved process management
8. Initial GnuTLS support

Hoping for a discussion and review.

Im also willing to backport some of the package changes and fixes to version 3.5.x stabile.

Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>