### PR TITLE
uw-imap: copy actual files in devel folder

### DIFF
--- a/libs/uw-imap/Makefile
+++ b/libs/uw-imap/Makefile
@@ -54,10 +54,13 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR)	$(1)/usr/lib \
-			$(1)/usr/include
+			$(1)/usr/include/c-client
 	$(CP) $(PKG_BUILD_DIR)/c-client/libc-client.so.$(PKG_VERSION) $(1)/usr/lib/
 	$(LN) libc-client.so.$(PKG_VERSION) $(1)/usr/lib/libc-client.so
-	$(CP) $(PKG_BUILD_DIR)/c-client/*.h $(1)/usr/include/
+	$(CP) $(PKG_BUILD_DIR)/c-client/linkage.h $(1)/usr/include/c-client/
+	$(CP) $(PKG_BUILD_DIR)/src/c-client/*.h $(1)/usr/include/c-client/
+	$(CP) $(PKG_BUILD_DIR)/src/osdep/unix/*.h $(1)/usr/include/c-client/
+	$(LN) os_slx.h $(1)/usr/include/c-client/osdep.h
 endef
 
 define Package/uw-imap/install


### PR DESCRIPTION
Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Maintainer: me 
Compile/Run tested:  x86 LEDE version r5442-b0b289ea45

Description:
Don't copy the symlinks in the staging dir, copy the actual files. maybe this is why the build-bots are failing on php7-imap