### PR TITLE
libdbi-drivers: remove build timestamp

### DIFF
--- a/libs/libdbi-drivers/Makefile
+++ b/libs/libdbi-drivers/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdbi-drivers
 PKG_VERSION:=0.9.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/libdbi-drivers

--- a/libs/libdbi-drivers/patches/100-remove-date-to-fix-reproducible-builds.patch
+++ b/libs/libdbi-drivers/patches/100-remove-date-to-fix-reproducible-builds.patch
@@ -1,0 +1,140 @@
+Index: libdbi-drivers-0.9.0/drivers/db2/dbd_db2.c
+===================================================================
+--- libdbi-drivers-0.9.0.orig/drivers/db2/dbd_db2.c	2013-01-09 22:30:19.000000000 +0100
++++ libdbi-drivers-0.9.0/drivers/db2/dbd_db2.c	2017-12-02 00:28:50.354329791 +0100
+@@ -57,8 +57,7 @@
+   "IBM DB2 database support (using DB2 Call Level Interface)",
+   "João Henrique F. Freitas <joaohf@users.sourceforge.net>",
+   "http://libdbi-drivers.sourceforge.net",
+-  "dbd_db2 v" VERSION,
+-  __DATE__
++  "dbd_db2 v" VERSION
+ };
+ 
+ static const char *custom_functions[] = {NULL}; // TODO
+Index: libdbi-drivers-0.9.0/drivers/firebird/dbd_firebird.c
+===================================================================
+--- libdbi-drivers-0.9.0.orig/drivers/firebird/dbd_firebird.c	2013-01-09 22:20:07.000000000 +0100
++++ libdbi-drivers-0.9.0/drivers/firebird/dbd_firebird.c	2017-12-02 00:28:47.418270022 +0100
+@@ -67,8 +67,7 @@
+ 	"Firebird/Interbase database support",
+ 	"Christian M. Stamgren <cms@cention.se>",
+ 	"http://libdbi-drivers.sourceforge.net",
+-	"dbd_firebird v" VERSION,
+-	__DATE__
++	"dbd_firebird v" VERSION
+ };
+ 
+ 
+Index: libdbi-drivers-0.9.0/drivers/freetds/dbd_freetds.c
+===================================================================
+--- libdbi-drivers-0.9.0.orig/drivers/freetds/dbd_freetds.c	2013-01-09 22:21:11.000000000 +0100
++++ libdbi-drivers-0.9.0/drivers/freetds/dbd_freetds.c	2017-12-02 00:29:05.482637950 +0100
+@@ -63,8 +63,7 @@
+     "MS SQL and Sybase databases support (using libct)",
+     "Vadym Kononenko <konan_v@users.sourceforge.net>",
+     "http://libdbi.sourceforge.net",
+-    "dbd_freetds v" VERSION,
+-    __DATE__
++    "dbd_freetds v" VERSION
+ };
+ 
+ static const char APP_NAME[] = "libdbi-freetds-driver";
+Index: libdbi-drivers-0.9.0/drivers/ingres/dbd_ingres.c
+===================================================================
+--- libdbi-drivers-0.9.0.orig/drivers/ingres/dbd_ingres.c	2013-01-09 22:30:19.000000000 +0100
++++ libdbi-drivers-0.9.0/drivers/ingres/dbd_ingres.c	2017-12-02 00:29:02.370574535 +0100
+@@ -44,8 +44,7 @@
+ 	"Ingres database support",
+ 	"Toby Thain <qu1j0t3@sourceforge.net>",
+ 	"http://libdbi-drivers.sourceforge.net",
+-	"dbd_ingres v" VERSION,
+-	__DATE__
++	"dbd_ingres v" VERSION
+ };
+ 
+ static const char *custom_functions[] = {NULL};
+Index: libdbi-drivers-0.9.0/drivers/msql/dbd_msql.c
+===================================================================
+--- libdbi-drivers-0.9.0.orig/drivers/msql/dbd_msql.c	2013-01-09 22:26:20.000000000 +0100
++++ libdbi-drivers-0.9.0/drivers/msql/dbd_msql.c	2017-12-02 00:29:09.034710349 +0100
+@@ -57,8 +57,7 @@
+ 	"Mini SQL (mSQL) database support",
+ 	"Christian M. Stamgren <christian@centiongroup.com>",
+ 	"libdbi-drivers.sourceforge.net", 
+-	"dbd_msql v" VERSION,
+-	__DATE__
++	"dbd_msql v" VERSION
+ };
+ 
+ static const char *custom_functions[] = {NULL}; 
+Index: libdbi-drivers-0.9.0/drivers/mysql/dbd_mysql.c
+===================================================================
+--- libdbi-drivers-0.9.0.orig/drivers/mysql/dbd_mysql.c	2013-02-28 00:16:20.000000000 +0100
++++ libdbi-drivers-0.9.0/drivers/mysql/dbd_mysql.c	2017-12-02 00:28:42.438168678 +0100
+@@ -59,8 +59,7 @@
+ 	"MySQL database support (using libmysqlclient)",
+ 	"Mark M. Tobenkin <mark@brentwoodradio.com>",
+ 	"http://libdbi-drivers.sourceforge.net",
+-	"dbd_mysql v" VERSION,
+-	__DATE__
++	"dbd_mysql v" VERSION
+ };
+ 
+ static const char *custom_functions[] = MYSQL_CUSTOM_FUNCTIONS;
+Index: libdbi-drivers-0.9.0/drivers/oracle/dbd_oracle.c
+===================================================================
+--- libdbi-drivers-0.9.0.orig/drivers/oracle/dbd_oracle.c	2013-01-09 22:27:16.000000000 +0100
++++ libdbi-drivers-0.9.0/drivers/oracle/dbd_oracle.c	2017-12-02 00:28:55.958443910 +0100
+@@ -54,8 +54,7 @@
+ 	"Oracle database support (using Oracle Call Interface)",
+ 	"Ashish Ranjan <ashishwave@yahoo.com>", 
+ 	"http://libdbi-drivers.sourceforge.net",
+-	"dbd_Oracle v" VERSION,
+-	__DATE__
++	"dbd_Oracle v" VERSION
+ };
+ 
+ static const char *custom_functions[] = {NULL}; 
+Index: libdbi-drivers-0.9.0/drivers/pgsql/dbd_pgsql.c
+===================================================================
+--- libdbi-drivers-0.9.0.orig/drivers/pgsql/dbd_pgsql.c	2017-12-02 00:28:08.737484155 +0100
++++ libdbi-drivers-0.9.0/drivers/pgsql/dbd_pgsql.c	2017-12-02 00:28:53.386391528 +0100
+@@ -61,8 +61,7 @@
+ 	"PostgreSQL database support (using libpq)",
+ 	"David A. Parker <david@neongoat.com>",
+ 	"http://libdbi-drivers.sourceforge.net",
+-	"dbd_pgsql v" VERSION,
+-	__DATE__
++	"dbd_pgsql v" VERSION
+ };
+ 
+ static const char *custom_functions[] = PGSQL_CUSTOM_FUNCTIONS;
+Index: libdbi-drivers-0.9.0/drivers/sqlite/dbd_sqlite.c
+===================================================================
+--- libdbi-drivers-0.9.0.orig/drivers/sqlite/dbd_sqlite.c	2013-01-09 22:30:20.000000000 +0100
++++ libdbi-drivers-0.9.0/drivers/sqlite/dbd_sqlite.c	2017-12-02 00:28:59.370513412 +0100
+@@ -65,8 +65,7 @@
+   "SQLite database support (using libsqlite)",
+   "Markus Hoenicka <mhoenicka@users.sourceforge.net>",
+   "http://libdbi-drivers.sourceforge.net",
+-  "dbd_sqlite v" VERSION,
+-  __DATE__
++  "dbd_sqlite v" VERSION
+ };
+ 
+ static const char *custom_functions[] = SQLITE_CUSTOM_FUNCTIONS;
+Index: libdbi-drivers-0.9.0/drivers/sqlite3/dbd_sqlite3.c
+===================================================================
+--- libdbi-drivers-0.9.0.orig/drivers/sqlite3/dbd_sqlite3.c	2013-01-23 00:29:13.000000000 +0100
++++ libdbi-drivers-0.9.0/drivers/sqlite3/dbd_sqlite3.c	2017-12-02 00:29:11.706764820 +0100
+@@ -65,8 +65,7 @@
+   "SQLite3 database support (using libsqlite3)",
+   "Markus Hoenicka <mhoenicka@users.sourceforge.net>",
+   "http://libdbi-drivers.sourceforge.net",
+-  "dbd_sqlite3 v" VERSION,
+-  __DATE__
++  "dbd_sqlite3 v" VERSION
+ };
+ 
+ static const char *custom_functions[] = SQLITE3_CUSTOM_FUNCTIONS;


### PR DESCRIPTION
Maintainer:  @psycho-nico 
Compile tested: x86

Build timestamp prevents reproducible builds [0].

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>