### PR TITLE
ddns-scripts: remove gzip timestamp

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.6
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=20
+PKG_RELEASE:=21
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
@@ -129,7 +129,7 @@ define Build/Compile
 		-e '/^[[:space:]]*$$$$/d'	$$$$FILE; \
 	done
 	# compress public_suffix_list.dat
-	gzip -f9 $(PKG_BUILD_DIR)/files/public_suffix_list.dat
+	gzip -nf9 $(PKG_BUILD_DIR)/files/public_suffix_list.dat
 endef
 
 define Package/ddns-scripts/conffiles


### PR DESCRIPTION
Maintainer: @chris5560
Compile tested: x86

gzip create a header by default containing the filename
and the timestamp of the file.
This timestamp will break reproducible builds [0].

[0] https://reproducible-builds.org/docs/timestamps/