### PR TITLE
lpc21isp: remove build timestamp

### DIFF
--- a/devel/lpc21isp/Makefile
+++ b/devel/lpc21isp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lpc21isp
 PKG_VERSION:=197
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=LGPL-3.0+
 PKG_LICENSE_FILES:=README gpl.txt lgpl-3.0.txt
 

--- a/devel/lpc21isp/patches/100-fix-reproducible-builds.patch
+++ b/devel/lpc21isp/patches/100-fix-reproducible-builds.patch
@@ -1,0 +1,13 @@
+Index: lpc21isp_197/lpc21isp.c
+===================================================================
+--- lpc21isp_197.orig/lpc21isp.c	2017-12-03 06:01:05.854070061 +0100
++++ lpc21isp_197/lpc21isp.c	2017-12-03 06:01:23.326431659 +0100
+@@ -1549,7 +1549,7 @@
+         DebugPrintf(2, "\n"
+                        "Portable command line ISP\n"
+                        "for NXP LPC family and Analog Devices ADUC 70xx\n"
+-                       "Version " VERSION_STR " compiled for " COMPILED_FOR ": " __DATE__ ", " __TIME__ "\n"
++                       "Version " VERSION_STR " compiled for " COMPILED_FOR "\n"
+                        "Copyright (c) by Martin Maurer, 2003-2013, Email: Martin.Maurer@clibb.de\n"
+                        "Portions Copyright (c) by Aeolus Development 2004, www.aeolusdevelopment.com\n"
+                        "\n");


### PR DESCRIPTION
Maintainer: @Skeen
Compile tested: x86

Build timestamps prevent reproducible builds [0].

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>
