### PR TITLE
tcpproxy: remove build timestamp and hostname

### DIFF
--- a/net/tcpproxy/Makefile
+++ b/net/tcpproxy/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcpproxy
 PKG_VERSION:=1.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.spreadspace.org/tcpproxy/releases/
@@ -51,7 +51,6 @@ define Build/Configure
     echo '#define TCPPROXY_config_h_INCLUDED' >> config.h; \
     echo '' >> config.h; \
     echo '#define VERSION_STRING_0 "tcpproxy version '`cat $(PKG_BUILD_DIR)/version`'"' >> config.h; \
-    echo '#define VERSION_STRING_1 "built on '`hostname`', '`date +"%d.%m.%Y %H:%M:%S %Z"`'"' >> config.h; \
     echo '' >> config.h; \
     echo '#define TARGET "linux"' >> config.h; \
     echo '#define PREFIX "/usr"' >> config.h; \

--- a/net/tcpproxy/patches/100-remove-build-timestamps-build-hostname.patch
+++ b/net/tcpproxy/patches/100-remove-build-timestamps-build-hostname.patch
@@ -1,0 +1,40 @@
+Index: tcpproxy-1.2/src/configure
+===================================================================
+--- tcpproxy-1.2.orig/src/configure	2017-12-03 13:12:34.483712208 +0100
++++ tcpproxy-1.2/src/configure	2017-12-03 13:13:56.677386919 +0100
+@@ -195,9 +195,6 @@
+     fi
+ fi
+ 
+-HOSTNAME=`hostname`
+-DATE=`date +"%d.%m.%Y %H:%M:%S %Z"`
+-
+ cat > config.h <<EOF
+ /*
+  * tcpproxy config header
+@@ -211,7 +208,6 @@
+ #define TCPPROXY_config_h_INCLUDED
+ 
+ #define VERSION_STRING_0 "tcpproxy version $VERSION"
+-#define VERSION_STRING_1 "built on $HOSTNAME, $DATE"
+ 
+ #define TARGET "$TARGET"
+ #define PREFIX "$PREFIX"
+Index: tcpproxy-1.2/src/options.c
+===================================================================
+--- tcpproxy-1.2.orig/src/options.c	2015-05-14 00:14:22.000000000 +0200
++++ tcpproxy-1.2/src/options.c	2017-12-03 13:14:37.442219952 +0100
+@@ -326,11 +326,9 @@
+ {
+   printf("%s\n", VERSION_STRING_0);
+ #if defined(__clang__)
+-  printf("%s, using CLANG %s\n", VERSION_STRING_1, __clang_version__);
++  printf("using CLANG %s\n", __clang_version__);
+ #elif defined(__GNUC__)
+-  printf("%s, using GCC %d.%d.%d\n", VERSION_STRING_1, __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+-#else
+-  printf("%s\n", VERSION_STRING_1);
++  printf("using GCC %d.%d.%d\n", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+ #endif
+ }
+ 


### PR DESCRIPTION
Maintainer: @equinox0815
Compile tested: x86

Build timestamp prevents reproducible builds [0].
Build hostname also breaks reproducible builds.

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>