### PR TITLE
lua-rs232: remove build timestamp

### DIFF
--- a/lang/lua-rs232/Makefile
+++ b/lang/lua-rs232/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lua-rs232
 PKG_VERSION:=1.0.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Dirk Chang <dirk@kooiot.com>
 PKG_LICENSE:=MIT
 

--- a/lang/lua-rs232/patches/100-remove-build-timestamps.patch
+++ b/lang/lua-rs232/patches/100-remove-build-timestamps.patch
@@ -1,0 +1,22 @@
+Index: lua-rs232-1.0.3/bindings/lua/luars232.c
+===================================================================
+--- lua-rs232-1.0.3.orig/bindings/lua/luars232.c	2014-06-05 09:48:23.000000000 +0200
++++ lua-rs232-1.0.3/bindings/lua/luars232.c	2017-12-03 13:03:51.008917783 +0100
+@@ -31,7 +31,6 @@
+ 
+ #include "librs232/rs232.h"
+ 
+-#define MODULE_TIMESTAMP __DATE__ " " __TIME__
+ #define MODULE_NAMESPACE "luars232"
+ #define MODULE_VERSION "1.0.3"
+ #define MODULE_BUILD "$Id: luars232.c 15 2011-02-23 09:02:20Z sp $"
+@@ -483,9 +482,6 @@
+ 	lua_pushstring(L, MODULE_BUILD);
+ 	lua_setfield(L, -2, "_BUILD");
+ 
+-	lua_pushstring(L, MODULE_TIMESTAMP);
+-	lua_setfield(L, -2, "_TIMESTAMP");
+-
+ 	lua_pushstring(L, MODULE_COPYRIGHT);
+ 	lua_setfield(L, -2, "_COPYRIGHT");
+ 


### PR DESCRIPTION
Maintainer: @srdgame
Compile tested: x86

Build timestamp prevents reproducible builds [0].

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>