### PR TITLE
perl-cgi: Update to 4.38

### DIFF
--- a/lang/perl-cgi/Makefile
+++ b/lang/perl-cgi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-cgi
-PKG_VERSION:=4.37
+PKG_VERSION:=4.38
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://www.cpan.org/authors/id/L/LE/LEEJO
 PKG_SOURCE:=CGI-$(PKG_VERSION).tar.gz
-PKG_HASH:=7a14eee5df640f7141848f653cf48d99bfc9b5c68e18167338ee01b91cdfb883
+PKG_HASH:=8c58f4a529bb92a914b22b7e64c5e31185c9854a4070a6dfad44fe5cc248e7d4
 
 PKG_LICENSE:=GPL Artistic-2.0
 PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>, \


### PR DESCRIPTION
Maintainer: me / @Naoir 
Compile tested: x86_64, generic, LEDE HEAD (332438b)
Run tested: same, built, and installed .ipk onto test machines

Description:

Update to 4.38.