### PR TITLE
netwhere: fix memory corruption problem

### DIFF
--- a/libs/libgcrypt/Makefile
+++ b/libs/libgcrypt/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.6.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=ftp://ftp.gnupg.org/gcrypt/libgcrypt
+PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/libgcrypt/
 PKG_HASH:=f9461b4619bb78b273a88d468915750d418e89a3ea3b641bab0563a9af4b04d0
 PKG_LICENSE:=LGPL-2.1+ GPL-2.0+
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: @benhsmith
Compile tested: brcm47xx, OpenWRT b8edaf4
Run tested: brcm47xx, ASUS RT-N16, DESIGNATED DRIVER (Bleeding Edge, 50140)

netwhere: fix memory corruption problem

Signed-off-by: Ben Smith <le.ben.smith@gmail.com>
