### PR TITLE
wavemon: use SOURCE_DATE_EPOCH as BUILD_DATE

### DIFF
--- a/net/wavemon/Makefile
+++ b/net/wavemon/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wavemon
 PKG_VERSION:=0.8.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_MIRROR_HASH:=e00710049c34bf45735085ad59eedf54190e78d1c5f6b43d28ae9bc93d07681e
@@ -44,7 +44,8 @@ define Package/wavemon/description
 endef
 
 CONFIGURE_VARS += \
-	ac_cv_lib_cap_cap_get_flag=no
+	ac_cv_lib_cap_cap_get_flag=no \
+	BUILD_DATE=$(SOURCE_DATE_EPOCH)
 
 TARGET_CFLAGS += -pthread -I$(STAGING_DIR)/usr/include/libnl3
 


### PR DESCRIPTION
Maintainer: @jmccrohan
Compile tested: x86

Build timestamps prevent reproducible builds [0].
SOURCE_DATE_EPOCH can replace BUILD_DATE in a determinisc way.

[0] https://reproducible-builds.org/docs/timestamps/
[1] https://reproducible-builds.org/specs/source-date-epoch/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>