### PR TITLE
strongswan: put package items into own submenu

### DIFF
--- a/net/strongswan/Makefile
+++ b/net/strongswan/Makefile
@@ -105,7 +105,7 @@ PKG_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/package.mk
 
 define Package/strongswan/Default
-  SUBMENU:=VPN
+  SUBMENU:=StrongSwan
   SECTION:=net
   CATEGORY:=Network
   TITLE:=StrongSwan


### PR DESCRIPTION
Signed-off-by: Moritz Warning <moritzwarning@web.de>
Maintainer: @stintel 

Description:
Strongswan occupies around 100 items in menu Netwok/VPN.
A submenu in Network would make Network/VPN less crowded.
