### PR TITLE
lm-sensors add init.d

### DIFF
--- a/utils/lm-sensors/Makefile
+++ b/utils/lm-sensors/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lm-sensors
 PKG_VERSION:=3.3.5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/groeck/lm-sensors.git
@@ -101,6 +101,8 @@ ifeq ($(ARCH),i386)
 	$(INSTALL_DIR) $(1)/etc
 	$(INSTALL_CONF) ./files/sensors.conf $(1)/etc/sensors.conf
 endif
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/lm-sensors.init $(1)/etc/init.d/lm-sensors
 endef
 
 define Package/lm-sensors-detect/install

--- a/utils/lm-sensors/files/lm-sensors.init
+++ b/utils/lm-sensors/files/lm-sensors.init
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2017 Philip Prindeville, Redfish Solutions LLC
+
+START=28
+STOP=
+
+PROG=/usr/sbin/sensors
+
+start() {
+	[ -f /etc/sensors.conf -o -f /etc/sensors3.conf ] || return
+
+	$PROG -s
+}
+


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: x86_64, generic, LEDE HEAD (04127f0)
Run tested: same

Built package, scp'd it to test box, reinstalled it, rebooted, and ran `sensors`.  Output is now correct.  Previously the ranges for inputs weren't being pushed into the kernel via the `set` lines in the `sensors.conf` file.
