### PR TITLE
travelmate: update 0.9.5

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=0.9.3
+PKG_VERSION:=0.9.5
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/README.md
+++ b/net/travelmate/files/README.md
@@ -10,6 +10,7 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 * easy setup within normal OpenWrt/LEDE environment
 * strong LuCI-Support with builtin interface wizard and a wireless station manager
 * fast uplink connections
+* support all kinds of uplinks, incl. hidden and enterprise uplinks
 * manual / automatic mode support, the latter one checks the existing uplink connection regardless of ifdown event trigger actions every n seconds
 * support of devices with multiple radios
 * procd init and hotplug support
@@ -49,15 +50,14 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 
 **receive travelmate runtime information:**
 <pre><code>
-root@adb2go:~# /etc/init.d/travelmate status
 ::: travelmate runtime information
- travelmate_version : 0.9.1
+ travelmate_version : 0.9.5
  station_connection : true
- station_ssid       : blackhole.nl
+ station_id         : blackhole/04:F0:21:2F:B7:64
  station_interface  : trm_wwan
  station_radio      : radio1
- last_rundate       : 29.07.2017 18:02:01
- system             : LEDE Reboot SNAPSHOT r4639-eb43a817f7
+ last_rundate       : 06.12.2017 16:47:56
+ system             : LEDE Reboot SNAPSHOT r5422-9fe59abef8
 </code></pre>
 
 ## Manual Setup

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-START=90
+START=25
 USE_PROCD=1
 
 EXTRA_COMMANDS="status"
@@ -43,16 +43,15 @@ status()
 
 service_triggers()
 {
-    local auto="$(uci -q get travelmate.global.trm_automatic)"
+    local auto="$(uci_get travelmate.global.trm_automatic)"
 
     if [ "${auto}" = "0" ]
     then
-        local iface="$(uci -q get travelmate.global.trm_iface)"
-        local delay="$(uci -q get travelmate.global.trm_triggerdelay)"
+        local trigger="$(uci_get travelmate.global.trm_iface)"
+        local delay="$(uci_get travelmate.global.trm_triggerdelay)"
 
-        PROCD_RELOAD_DELAY=$((${delay:=2} * 1000))
-        procd_add_interface_trigger "interface.*.down" "${iface}" "${trm_init}" start
+        PROCD_RELOAD_DELAY=$((${delay:-2} * 1000))
+        procd_add_interface_trigger "interface.*.down" "${trigger}" "${trm_init}" start
     fi
-    PROCD_RELOAD_DELAY=1000
-    procd_add_config_trigger "config.change" "travelmate" "${trm_init}" start
+    procd_add_reload_trigger "travelmate"
 }


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: APU2, x86_86 / TP-Link RE450, ar71xx

Description:
* change start priority to 25
* add support for hidden uplinks
* add support for wpa enterprise uplinks
* LuCI updates (different PR in luci repo)

Signed-off-by: Dirk Brenken <dev@brenken.org>
