### PR TITLE
CC: bind: bump to 9.11.2

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.9.8-P4
-PKG_RELEASE:=1
+PKG_RELEASE:=3
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER := Noah Meyerhans <frodo@morgul.net>

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.9.9-P3
+PKG_VERSION:=9.10.4-P4
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -20,7 +20,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	ftp://ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	http://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_MD5SUM:=98d46cebb3fac3c6f282e8467424821b
+PKG_MD5SUM:=e110904a1d54f83f01d4be8bcd842927
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2006-2012 OpenWrt.org
-#               2014 Noah Meyerhans <frodo@morgul.net>
+#               2014-2016 Noah Meyerhans <frodo@morgul.net>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -26,6 +26,7 @@ PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4
 
 PKG_INSTALL:=1
+PKG_USE_MIPS16:=0
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.10.4-P5
+PKG_VERSION:=9.10.5
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -20,7 +20,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	ftp://ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	http://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_MD5SUM:=c53a3e34e7aabb16820b036ae9afd3c9
+PKG_MD5SUM:=8359e000eaec76efd6dfa186c12c3b93
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.9.8-P3
+PKG_VERSION:=9.9.8-P4
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -20,7 +20,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	ftp://ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	http://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_MD5SUM:=30b9bf88a78eee783d3fef5257445788
+PKG_MD5SUM:=5e401f6cf024f596044d733ceb0d6415
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.9.8-P4
-PKG_RELEASE:=3
+PKG_VERSION:=9.9.9-P3
+PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER := Noah Meyerhans <frodo@morgul.net>
@@ -20,7 +20,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	ftp://ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	http://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_MD5SUM:=5e401f6cf024f596044d733ceb0d6415
+PKG_MD5SUM:=98d46cebb3fac3c6f282e8467424821b
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.10.5
+PKG_VERSION:=9.10.5-P3
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -18,9 +18,9 @@ PKG_LICENSE := BSD-3-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
-	ftp://ftp.isc.org/isc/bind9/$(PKG_VERSION) \
-	http://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_MD5SUM:=8359e000eaec76efd6dfa186c12c3b93
+	http://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
+	http://ftp.isc.org/isc/bind9/$(PKG_VERSION)
+PKG_HASH:=8d7e96b5b0bbac7b900d4c4bbb82e0956b4e509433c5fa392bb72a929b96606a
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -20,7 +20,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	http://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	http://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=7f46ad8620f7c3b0ac375d7a5211b15677708fda84ce25d7aeb7222fe2e3c77a
+PKG_MD5SUM:=efca7e5a63a07efba264da9be2fbb57f
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.10.4-P4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER := Noah Meyerhans <frodo@morgul.net>
@@ -103,6 +103,7 @@ CONFIGURE_ARGS += \
 	--with-gssapi=no \
 	--with-ecdsa=no \
 	--with-readline=no
+	--sysconfdir=/etc/bind
 
 CONFIGURE_VARS += \
 	BUILD_CC="$(TARGET_CC)" \

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.10.4-P4
-PKG_RELEASE:=2
+PKG_VERSION:=9.10.4-P5
+PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER := Noah Meyerhans <frodo@morgul.net>
@@ -20,7 +20,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	ftp://ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	http://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_MD5SUM:=e110904a1d54f83f01d4be8bcd842927
+PKG_MD5SUM:=c53a3e34e7aabb16820b036ae9afd3c9
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.10.5-P3
+PKG_VERSION:=9.11.2
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -20,7 +20,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	http://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	http://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=8d7e96b5b0bbac7b900d4c4bbb82e0956b4e509433c5fa392bb72a929b96606a
+PKG_HASH:=7f46ad8620f7c3b0ac375d7a5211b15677708fda84ce25d7aeb7222fe2e3c77a
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4
@@ -42,7 +42,7 @@ endef
 define Package/bind-libs
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libopenssl
+  DEPENDS:=+libopenssl +zlib
   TITLE:=bind shared libraries
   URL:=https://www.isc.org/software/bind
 endef

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -96,6 +96,7 @@ CONFIGURE_ARGS += \
 	--disable-threads \
 	--disable-linux-caps \
 	--with-openssl="$(STAGING_DIR)/usr" \
+	--with-libjson=no \
 	--with-libtool \
 	--with-libxml2=no \
 	--enable-epoll=yes \

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -74,7 +74,7 @@ endef
 
 define Package/bind-dnssec
   $(call Package/bind/Default)
-  TITLE+= administration tools (dnssec-keygen and dnssec-signzone only)
+  TITLE+= administration tools (dnssec-keygen, dnssec-settime and dnssec-signzone only)
 endef
 
 define Package/bind-host
@@ -161,6 +161,7 @@ define Package/bind-tools/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/host $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/dnssec-keygen $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/dnssec-settime $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/dnssec-signzone $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/named-checkconf $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/named-checkzone $(1)/usr/sbin/
@@ -183,6 +184,7 @@ endef
 define Package/bind-dnssec/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/dnssec-keygen $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/dnssec-settime $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/dnssec-signzone $(1)/usr/sbin/
 endef
 

--- a/net/bind/files/bind/db.root
+++ b/net/bind/files/bind/db.root
@@ -1,45 +1,90 @@
-
-; <<>> DiG 9.2.3 <<>> ns . @a.root-servers.net.
-;; global options:  printcmd
-;; Got answer:
-;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 18944
-;; flags: qr aa rd; QUERY: 1, ANSWER: 13, AUTHORITY: 0, ADDITIONAL: 13
-
-;; QUESTION SECTION:
-;.				IN	NS
-
-;; ANSWER SECTION:
-.			518400	IN	NS	A.ROOT-SERVERS.NET.
-.			518400	IN	NS	B.ROOT-SERVERS.NET.
-.			518400	IN	NS	C.ROOT-SERVERS.NET.
-.			518400	IN	NS	D.ROOT-SERVERS.NET.
-.			518400	IN	NS	E.ROOT-SERVERS.NET.
-.			518400	IN	NS	F.ROOT-SERVERS.NET.
-.			518400	IN	NS	G.ROOT-SERVERS.NET.
-.			518400	IN	NS	H.ROOT-SERVERS.NET.
-.			518400	IN	NS	I.ROOT-SERVERS.NET.
-.			518400	IN	NS	J.ROOT-SERVERS.NET.
-.			518400	IN	NS	K.ROOT-SERVERS.NET.
-.			518400	IN	NS	L.ROOT-SERVERS.NET.
-.			518400	IN	NS	M.ROOT-SERVERS.NET.
-
-;; ADDITIONAL SECTION:
-A.ROOT-SERVERS.NET.	3600000	IN	A	198.41.0.4
-B.ROOT-SERVERS.NET.	3600000	IN	A	192.228.79.201
-C.ROOT-SERVERS.NET.	3600000	IN	A	192.33.4.12
-D.ROOT-SERVERS.NET.	3600000	IN	A	128.8.10.90
-E.ROOT-SERVERS.NET.	3600000	IN	A	192.203.230.10
-F.ROOT-SERVERS.NET.	3600000	IN	A	192.5.5.241
-G.ROOT-SERVERS.NET.	3600000	IN	A	192.112.36.4
-H.ROOT-SERVERS.NET.	3600000	IN	A	128.63.2.53
-I.ROOT-SERVERS.NET.	3600000	IN	A	192.36.148.17
-J.ROOT-SERVERS.NET.	3600000	IN	A	192.58.128.30
-K.ROOT-SERVERS.NET.	3600000	IN	A	193.0.14.129
-L.ROOT-SERVERS.NET.	3600000	IN	A	199.7.83.42
-M.ROOT-SERVERS.NET.	3600000	IN	A	202.12.27.33
-
-;; Query time: 81 msec
-;; SERVER: 198.41.0.4#53(a.root-servers.net.)
-;; WHEN: Sun Feb  1 11:27:14 2004
-;; MSG SIZE  rcvd: 436
-
+;       This file holds the information on root name servers needed to
+;       initialize cache of Internet domain name servers
+;       (e.g. reference this file in the "cache  .  <file>"
+;       configuration file of BIND domain name servers).
+;
+;       This file is made available by InterNIC 
+;       under anonymous FTP as
+;           file                /domain/named.cache
+;           on server           FTP.INTERNIC.NET
+;       -OR-                    RS.INTERNIC.NET
+;
+;       last update:    February 17, 2016
+;       related version of root zone:   2016021701
+;
+; formerly NS.INTERNIC.NET
+;
+.                        3600000      NS    A.ROOT-SERVERS.NET.
+A.ROOT-SERVERS.NET.      3600000      A     198.41.0.4
+A.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:ba3e::2:30
+;
+; FORMERLY NS1.ISI.EDU
+;
+.                        3600000      NS    B.ROOT-SERVERS.NET.
+B.ROOT-SERVERS.NET.      3600000      A     192.228.79.201
+B.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:84::b
+;
+; FORMERLY C.PSI.NET
+;
+.                        3600000      NS    C.ROOT-SERVERS.NET.
+C.ROOT-SERVERS.NET.      3600000      A     192.33.4.12
+C.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2::c
+;
+; FORMERLY TERP.UMD.EDU
+;
+.                        3600000      NS    D.ROOT-SERVERS.NET.
+D.ROOT-SERVERS.NET.      3600000      A     199.7.91.13
+D.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2d::d
+;
+; FORMERLY NS.NASA.GOV
+;
+.                        3600000      NS    E.ROOT-SERVERS.NET.
+E.ROOT-SERVERS.NET.      3600000      A     192.203.230.10
+;
+; FORMERLY NS.ISC.ORG
+;
+.                        3600000      NS    F.ROOT-SERVERS.NET.
+F.ROOT-SERVERS.NET.      3600000      A     192.5.5.241
+F.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2f::f
+;
+; FORMERLY NS.NIC.DDN.MIL
+;
+.                        3600000      NS    G.ROOT-SERVERS.NET.
+G.ROOT-SERVERS.NET.      3600000      A     192.112.36.4
+;
+; FORMERLY AOS.ARL.ARMY.MIL
+;
+.                        3600000      NS    H.ROOT-SERVERS.NET.
+H.ROOT-SERVERS.NET.      3600000      A     198.97.190.53
+H.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:1::53
+;
+; FORMERLY NIC.NORDU.NET
+;
+.                        3600000      NS    I.ROOT-SERVERS.NET.
+I.ROOT-SERVERS.NET.      3600000      A     192.36.148.17
+I.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fe::53
+;
+; OPERATED BY VERISIGN, INC.
+;
+.                        3600000      NS    J.ROOT-SERVERS.NET.
+J.ROOT-SERVERS.NET.      3600000      A     192.58.128.30
+J.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:c27::2:30
+;
+; OPERATED BY RIPE NCC
+;
+.                        3600000      NS    K.ROOT-SERVERS.NET.
+K.ROOT-SERVERS.NET.      3600000      A     193.0.14.129
+K.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fd::1
+;
+; OPERATED BY ICANN
+;
+.                        3600000      NS    L.ROOT-SERVERS.NET.
+L.ROOT-SERVERS.NET.      3600000      A     199.7.83.42
+L.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:3::42
+;
+; OPERATED BY WIDE
+;
+.                        3600000      NS    M.ROOT-SERVERS.NET.
+M.ROOT-SERVERS.NET.      3600000      A     202.12.27.33
+M.ROOT-SERVERS.NET.      3600000      AAAA  2001:dc3::35
+; End of file

--- a/net/bind/files/named.init
+++ b/net/bind/files/named.init
@@ -13,7 +13,6 @@ pid_file=/var/run/named/named.pid
 logdir=/var/log/named/
 cachedir=/var/cache/bind
 libdir=/var/lib/bind
-config_file=/etc/bind/named.conf
 
 fix_perms() {
     for dir in $libdir $logdir $cachedir; do

--- a/net/bind/patches/001-no-tests.patch
+++ b/net/bind/patches/001-no-tests.patch
@@ -1,26 +1,26 @@
-Index: bind-9.9.4/bin/Makefile.in
+Index: bind-9.10.4-P3/bin/Makefile.in
 ===================================================================
---- bind-9.9.4.orig/bin/Makefile.in
-+++ bind-9.9.4/bin/Makefile.in
+--- bind-9.10.4-P3.orig/bin/Makefile.in
++++ bind-9.10.4-P3/bin/Makefile.in
 @@ -19,7 +19,7 @@ srcdir =	@srcdir@
  VPATH =		@srcdir@
  top_srcdir =	@top_srcdir@
  
--SUBDIRS =	named rndc dig dnssec tools tests nsupdate \
-+SUBDIRS =	named rndc dig dnssec tools nsupdate \
+-SUBDIRS =	named rndc dig delv dnssec tools tests nsupdate \
++SUBDIRS =	named rndc dig delv dnssec tools nsupdate \
  		check confgen @PYTHON_TOOLS@ @PKCS11_TOOLS@
  TARGETS =
  
-Index: bind-9.9.4/lib/Makefile.in
+Index: bind-9.10.4-P3/lib/Makefile.in
 ===================================================================
---- bind-9.9.4.orig/lib/Makefile.in
-+++ bind-9.9.4/lib/Makefile.in
+--- bind-9.10.4-P3.orig/lib/Makefile.in
++++ bind-9.10.4-P3/lib/Makefile.in
 @@ -23,7 +23,7 @@ top_srcdir =	@top_srcdir@
  # Attempt to disable parallel processing.
  .NOTPARALLEL:
  .NO_PARALLEL:
--SUBDIRS =	isc isccc dns isccfg bind9 lwres tests
-+SUBDIRS =	isc isccc dns isccfg bind9 lwres
+-SUBDIRS =	isc isccc dns isccfg bind9 lwres irs tests samples
++SUBDIRS =	isc isccc dns isccfg bind9 lwres irs samples
  TARGETS =
  
  @BIND9_MAKE_RULES@

--- a/net/bind/patches/001-no-tests.patch
+++ b/net/bind/patches/001-no-tests.patch
@@ -2,20 +2,20 @@ Index: bind-9.10.4-P3/bin/Makefile.in
 ===================================================================
 --- bind-9.10.4-P3.orig/bin/Makefile.in
 +++ bind-9.10.4-P3/bin/Makefile.in
-@@ -19,7 +19,7 @@ srcdir =	@srcdir@
+@@ -10,7 +10,7 @@ srcdir =	@srcdir@
  VPATH =		@srcdir@
  top_srcdir =	@top_srcdir@
  
 -SUBDIRS =	named rndc dig delv dnssec tools tests nsupdate \
 +SUBDIRS =	named rndc dig delv dnssec tools nsupdate \
- 		check confgen @PYTHON_TOOLS@ @PKCS11_TOOLS@
+ 		check confgen @NZD_TOOLS@ @PYTHON_TOOLS@ @PKCS11_TOOLS@
  TARGETS =
  
 Index: bind-9.10.4-P3/lib/Makefile.in
 ===================================================================
 --- bind-9.10.4-P3.orig/lib/Makefile.in
 +++ bind-9.10.4-P3/lib/Makefile.in
-@@ -23,7 +23,7 @@ top_srcdir =	@top_srcdir@
+@@ -14,7 +14,7 @@ top_srcdir =	@top_srcdir@
  # Attempt to disable parallel processing.
  .NOTPARALLEL:
  .NO_PARALLEL:

--- a/net/bind/patches/002-autoconf-ar-fix.patch
+++ b/net/bind/patches/002-autoconf-ar-fix.patch
@@ -2,7 +2,7 @@ Index: bind-9.10.4-P3/configure.in
 ===================================================================
 --- bind-9.10.4-P3.orig/configure.in
 +++ bind-9.10.4-P3/configure.in
-@@ -167,26 +167,11 @@ esac
+@@ -157,26 +157,11 @@ esac
  #
  AC_CONFIG_FILES([make/rules make/includes])
  

--- a/net/bind/patches/002-autoconf-ar-fix.patch
+++ b/net/bind/patches/002-autoconf-ar-fix.patch
@@ -1,6 +1,8 @@
---- a/configure.in
-+++ b/configure.in
-@@ -93,26 +93,11 @@ esac
+Index: bind-9.10.4-P3/configure.in
+===================================================================
+--- bind-9.10.4-P3.orig/configure.in
++++ bind-9.10.4-P3/configure.in
+@@ -167,26 +167,11 @@ esac
  #
  AC_CONFIG_FILES([make/rules make/includes])
  


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: CC/adm8668, CC/sunxi
Run tested: CC/sunxi

Description:
Bump bind to a more recent version to fix CVEs, and update the root NS file.