### PR TITLE
uanytun: remove build time/host to fix reproducible builds

### DIFF
--- a/net/uanytun/Makefile
+++ b/net/uanytun/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uanytun
 PKG_VERSION:=0.3.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.anytun.org/download/

--- a/net/uanytun/patches/100-reproducible-builds.patch
+++ b/net/uanytun/patches/100-reproducible-builds.patch
@@ -1,0 +1,12 @@
+Index: uanytun-0.3.5/src/options.c
+===================================================================
+--- uanytun-0.3.5.orig/src/options.c
++++ uanytun-0.3.5/src/options.c
+@@ -481,7 +481,6 @@ void options_print_usage()
+ void options_print_version()
+ {
+   printf("%s\n", VERSION_STRING_0);
+-  printf("%s\n", VERSION_STRING_1);
+ }
+ 
+ void options_print(options_t* opt)


### PR DESCRIPTION
Maintainer: @equinox0815
Compile tested: lantiq

Build timestamps prevents reproducible builds [0].

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>