### PR TITLE
perl: remove build timestamp

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=5.26.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \

--- a/lang/perl/patches/120-remove-build-timestamp.patch
+++ b/lang/perl/patches/120-remove-build-timestamp.patch
@@ -1,0 +1,21 @@
+Index: perl-5.26.1/perl.c
+===================================================================
+--- perl-5.26.1.orig/perl.c
++++ perl-5.26.1/perl.c
+@@ -1870,16 +1870,6 @@ S_Internals_V(pTHX_ CV *cv)
+     PUSHs(Perl_newSVpvn_flags(aTHX_ non_bincompat_options,
+ 			      sizeof(non_bincompat_options) - 1, SVs_TEMP));
+ 
+-#ifndef PERL_BUILD_DATE
+-#  ifdef __DATE__
+-#    ifdef __TIME__
+-#      define PERL_BUILD_DATE __DATE__ " " __TIME__
+-#    else
+-#      define PERL_BUILD_DATE __DATE__
+-#    endif
+-#  endif
+-#endif
+-
+ #ifdef PERL_BUILD_DATE
+     PUSHs(Perl_newSVpvn_flags(aTHX_
+ 			      STR_WITH_LEN("Compiled at " PERL_BUILD_DATE),


### PR DESCRIPTION
Maintainer: @pprindeville
Compile tested: lantiq

Build timestamp prevents reproducible builds [0].

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>