### PR TITLE
php7: remove build timestamp

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=7.1.12
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 

--- a/lang/php7/patches/0050-remove-build-timestamps.patch
+++ b/lang/php7/patches/0050-remove-build-timestamps.patch
@@ -1,0 +1,32 @@
+Index: php-7.1.12/ext/opcache/ZendAccelerator.c
+===================================================================
+--- php-7.1.12.orig/ext/opcache/ZendAccelerator.c
++++ php-7.1.12/ext/opcache/ZendAccelerator.c
+@@ -2604,11 +2604,6 @@ static void accel_gen_system_id(void)
+ 	PHP_MD5Update(&context, PHP_VERSION, sizeof(PHP_VERSION)-1);
+ 	PHP_MD5Update(&context, ZEND_EXTENSION_BUILD_ID, sizeof(ZEND_EXTENSION_BUILD_ID)-1);
+ 	PHP_MD5Update(&context, ZEND_BIN_ID, sizeof(ZEND_BIN_ID)-1);
+-	if (strstr(PHP_VERSION, "-dev") != 0) {
+-		/* Development versions may be changed from build to build */
+-		PHP_MD5Update(&context, __DATE__, sizeof(__DATE__)-1);
+-		PHP_MD5Update(&context, __TIME__, sizeof(__TIME__)-1);
+-	}
+ 	PHP_MD5Final(digest, &context);
+ 	for (i = 0; i < 16; i++) {
+ 		c = digest[i] >> 4;
+Index: php-7.1.12/sapi/litespeed/lsapi_main.c
+===================================================================
+--- php-7.1.12.orig/sapi/litespeed/lsapi_main.c
++++ php-7.1.12/sapi/litespeed/lsapi_main.c
+@@ -1036,9 +1036,9 @@ static int cli_main( int argc, char * ar
+             case 'v':
+                 if (php_request_startup() != FAILURE) {
+ #if ZEND_DEBUG
+-                    php_printf("PHP %s (%s) (built: %s %s) (DEBUG)\nCopyright (c) 1997-2017 The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
++                    php_printf("PHP %s (%s) (DEBUG)\nCopyright (c) 1997-2017 The PHP Group\n%s", PHP_VERSION, sapi_module.name, get_zend_version());
+ #else
+-                    php_printf("PHP %s (%s) (built: %s %s)\nCopyright (c) 1997-2017 The PHP Group\n%s", PHP_VERSION, sapi_module.name, __DATE__, __TIME__, get_zend_version());
++                    php_printf("PHP %s (%s)\nCopyright (c) 1997-2017 The PHP Group\n%s", PHP_VERSION, sapi_module.name, get_zend_version());
+ #endif
+ #ifdef PHP_OUTPUT_NEWAPI
+                     php_output_end_all();


### PR DESCRIPTION
Maintainer: @mhei
Compile tested: lantiq

Build timestamp prevents reproducible builds [0].

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>