### PR TITLE
openconnect: fix compilation against libp11 >= 0.4.7

### DIFF
--- a/libs/libp11/Makefile
+++ b/libs/libp11/Makefile
@@ -42,7 +42,7 @@ CONFIGURE_ARGS += --with-enginesdir=/usr/lib/engines
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/libp11.h $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libp11.{a,so} $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libp11.so* $(1)/usr/lib/

--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=7.08
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/openconnect/patches/0001-Fix-compilation-with-libp11-version-0.4.7.patch
+++ b/net/openconnect/patches/0001-Fix-compilation-with-libp11-version-0.4.7.patch
@@ -1,0 +1,50 @@
+From 03ecd34e0137b3f0bf0d2fc3ab7f7d8b3682785e Mon Sep 17 00:00:00 2001
+From: Yousong Zhou <yszhou4tech@gmail.com>
+Date: Thu, 14 Dec 2017 18:03:35 +0800
+Subject: [PATCH] Fix compilation with libp11 version >= 0.4.7
+
+libp11 0.4.7 renamed then dropped macro definition in commits
+
+ 4f0fce4: Error reporting fixes
+ e4c641b: PKCS11 errors separated into P11 and CKR
+
+This change assumes that libp11 will restore compatibility by bringing
+back old forms of macro definition
+
+Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
+---
+ openssl-pkcs11.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/openssl-pkcs11.c b/openssl-pkcs11.c
+index 61da123..ba7e491 100644
+--- a/openssl-pkcs11.c
++++ b/openssl-pkcs11.c
+@@ -30,6 +30,24 @@
+ #include <libp11.h>
+ #include <p11-kit/pkcs11.h>
+ 
++#ifndef ERR_LIB_PKCS11
++#	if defined(ERR_LIB_CKR)
++#		define ERR_LIB_PKCS11 ERR_LIB_CKR
++#	elif defined(ERR_LIB_USER)
++#		define ERR_LIB_PKCS11 ERR_LIB_USER
++#	else
++#		error undefined macro ERR_LIB_PKCS11
++#	endif
++#endif
++
++#ifndef PKCS11_F_PKCS11_LOGIN
++#	if defined(CKR_F_PKCS11_LOGIN)
++#		define PKCS11_F_PKCS11_LOGIN CKR_F_PKCS11_LOGIN
++#	else
++#		error undefined macro PKCS11_F_PKCS11_LOGIN
++#	endif
++#endif
++
+ static PKCS11_CTX *pkcs11_ctx(struct openconnect_info *vpninfo)
+ {
+ 	PKCS11_CTX *ctx;
+-- 
+1.8.3.1
+


### PR DESCRIPTION
Maintainer: @dangowrt @nmav 
Compile tested: ar71xx, LEDE r5461-01c5cf0
Run tested: not yet.

Description:

With the updated libp11 0.4.7, header file p11_err.h is missing in the InstallDev section and error code definition has also changed cause api incompatibility issue with openconnect

The other thing is that the bulidbot seems to have also failed catching this error in the check-compile.txt stage: it did not even try to reconfigure, recompile the code: http://downloads.lede-project.org/snapshots/faillogs/mips_24kc/packages/openconnect/check-compile.txt