### PR TITLE
net/stunnel: Update to 5.44

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.41
+PKG_VERSION:=5.44
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0+
@@ -20,9 +20,10 @@ PKG_SOURCE_URL:= \
 	http://www.usenix.org.uk/mirrors/stunnel/ \
 	https://www.stunnel.org/downloads/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=f05c6321ee1f6ddebacc234ccf20825971941e831b5beea6d0ce0b8e1668148f
+PKG_HASH:=990a325dbb47d77d88772dd02fbbd27d91b1fea3ece76c9ff4461eca93f12299
 
 PKG_FIXUP:=autoreconf
+PKG_FIXUP:=patch-libtool
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -53,7 +54,8 @@ CONFIGURE_ARGS+= \
 	--with-threads=pthread \
 	--with-ssl=$(STAGING_DIR)/usr \
 	--disable-libwrap \
-	--disable-systemd
+	--disable-systemd \
+	--disable-fips
 
 ifeq ($(CONFIG_IPV6),n)
 CONFIGURE_ARGS+= \


### PR DESCRIPTION
Maintainer: myself
Compile tested: ramips, D-Link DIR-860L B1, LEDE trunk
Run tested: ramips, D-Link DIR-860L B1, LEDE trunk

Description:
Update stunnel to 5.44
* Disable FIPS

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>