### PR TITLE
smartmontools: update to 6.6

### DIFF
--- a/utils/smartmontools/Makefile
+++ b/utils/smartmontools/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/uclibc++.mk
 
 PKG_NAME:=smartmontools
-PKG_VERSION:=6.5
+PKG_VERSION:=6.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/smartmontools
-PKG_HASH:=89e8bb080130bc6ce148573ba5bb91bfe30236b64b1b5bbca26515d4b5c945bc
+PKG_HASH:=51f43d0fb064fccaf823bbe68cf0d317d0895ff895aa353b3339a3b316a53054
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING

--- a/utils/smartmontools/patches/001-musl-compat-realpath.patch
+++ b/utils/smartmontools/patches/001-musl-compat-realpath.patch
@@ -1,0 +1,19 @@
+commit 2473c5e01ea14fae96c157d8bce3a3ec1da124f3
+Author: Maxim Storchak <m.storchak@gmail.com>
+Date:   Sat Dec 9 15:21:51 2017 +0200
+
+    Replace canonicalize_file_name with realpath equivalent
+
+diff --git a/os_linux.cpp b/os_linux.cpp
+index 134d5bc..0575a13 100644
+--- a/os_linux.cpp
++++ b/os_linux.cpp
+@@ -3176,7 +3176,7 @@ static bool is_hpsa(const char * name)
+ {
+   char path[128];
+   snprintf(path, sizeof(path), "/sys/block/%s/device", name);
+-  char * syshostpath = canonicalize_file_name(path);
++  char * syshostpath = realpath(path, NULL);
+   if (!syshostpath)
+     return false;
+ 


### PR DESCRIPTION
Signed-off-by: Maxim Storchak <m.storchak@gmail.com>

Maintainer: me
Compile tested: (ar71xx, Netgear WNDR3800, LEDE r5457-94fcd92)
Run tested: (ar71xx, Netgear WNDR3800, LEDE r4902-3fbf3ab, smartctl --xall /dev/sda)

Description:
update to 6.6, add musl compat patch