### PR TITLE
python: declaring explicit Host/Compile to fix pgen tool installation…

### DIFF
--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -12,7 +12,7 @@ include ./files/python-version.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)

--- a/lang/python/Makefile
+++ b/lang/python/Makefile
@@ -242,6 +242,10 @@ HOST_CONFIGURE_ARGS+= \
 	--with-system-ffi=no \
 	CONFIG_SITE=
 
+define Host/Compile
+	$(call Host/Compile/Default,python Parser/pgen sharedmods)
+endef
+
 define Host/Install
 	$(MAKE) -C $(HOST_BUILD_DIR) install
 	$(INSTALL_DIR) $(HOST_PYTHON_DIR)/bin/


### PR DESCRIPTION
<lang/python>

Maintainer: @commodo 
Compile tested: bcm2710, Raspberry Pi 3, LEDE 17.01 stable
Run tested: bcm2710, Raspberry Pi 3, LEDE 17.01 stable

Description:

declaring explicit Host/Compile to fix **pgen** tool installation in Makefile (borrowed from master branch). If not applied, the host build will crash with the `pgen executable not found` during the `install` step.

Signed-off-by: Arturo Rinaldi arty.net2@gmail.com