### PR TITLE
mjpg-streamer: remove build timestamp

### DIFF
--- a/multimedia/mjpg-streamer/Makefile
+++ b/multimedia/mjpg-streamer/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=mjpg-streamer
 PKG_REV:=182
 PKG_VERSION:=r$(PKG_REV)
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>, \
 		Ted Hess <thess@kitschensync.net>
 

--- a/multimedia/mjpg-streamer/patches/100-reproducible-builds.patch
+++ b/multimedia/mjpg-streamer/patches/100-reproducible-builds.patch
@@ -1,0 +1,24 @@
+Index: mjpg-streamer-r182/mjpg_streamer.c
+===================================================================
+--- mjpg-streamer-r182.orig/mjpg_streamer.c
++++ mjpg-streamer-r182/mjpg_streamer.c
+@@ -253,15 +253,13 @@ int main(int argc, char *argv[])
+             /* v, version */
+         case 6:
+         case 7:
+-            printf("MJPG Streamer Version: %s\n" \
+-            "Compilation Date.....: %s\n" \
+-            "Compilation Time.....: %s\n",
++            printf("MJPG Streamer Version: %s\n",
+ #ifdef SVN_REV
+-            SVN_REV,
++            SVN_REV
+ #else
+-            SOURCE_VERSION,
++            SOURCE_VERSION
+ #endif
+-            __DATE__, __TIME__);
++            );
+             return 0;
+             break;
+ 


### PR DESCRIPTION
Maintainer: @thess @roger-
Compile tested: lantiq, LEDE master reboot-5448-gdeaf9597c67a

Build timestamp prevents reproducible builds [0].

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>