### PR TITLE
openldap: remove build host/user/timestamp

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
 PKG_VERSION:=2.4.45
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/ \

--- a/libs/openldap/patches/110-reproducible-builds.patch
+++ b/libs/openldap/patches/110-reproducible-builds.patch
@@ -1,0 +1,21 @@
+Index: openldap-2.4.45/build/mkversion
+===================================================================
+--- openldap-2.4.45.orig/build/mkversion
++++ openldap-2.4.45/build/mkversion
+@@ -50,7 +50,6 @@ if test $# != 1 ; then
+ fi
+ 
+ APPLICATION=$1
+-WHOWHERE="$USER@`uname -n`:`pwd`"
+ 
+ cat << __EOF__
+ /* This work is part of OpenLDAP Software <http://www.openldap.org/>.
+@@ -72,7 +71,6 @@ static const char copyright[] =
+ "COPYING RESTRICTIONS APPLY\n";
+ 
+ $static $const char $SYMBOL[] =
+-"@(#) \$$PACKAGE: $APPLICATION $VERSION (" __DATE__ " " __TIME__ ") \$\n"
+-"\t$WHOWHERE\n";
++"@(#) \$$PACKAGE: $APPLICATION $VERSION\$\n";
+ 
+ __EOF__


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: lantiq, LEDE, reboot-5448-gdeaf9597c67a

Such information from the build system break reproducible builds.

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>