### PR TITLE
libgcrypt: remove build timestamp

### DIFF
--- a/libs/libgcrypt/Makefile
+++ b/libs/libgcrypt/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgcrypt
 PKG_VERSION:=1.6.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=ftp://ftp.gnupg.org/gcrypt/libgcrypt
@@ -17,7 +17,7 @@ PKG_HASH:=f9461b4619bb78b273a88d468915750d418e89a3ea3b641bab0563a9af4b04d0
 PKG_LICENSE:=LGPL-2.1+ GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
 
-PKG_FIXUP:=patch-libtool
+PKG_FIXUP:=autoreconf patch-libtool
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 

--- a/libs/libgcrypt/patches/002-Add-configure-option-enable-build-timestamp.patch
+++ b/libs/libgcrypt/patches/002-Add-configure-option-enable-build-timestamp.patch
@@ -1,0 +1,43 @@
+From a785cc3db0c4e8eb8ebbf784b833a40d2c42ec3e Mon Sep 17 00:00:00 2001
+From: Werner Koch <wk@gnupg.org>
+Date: Tue, 25 Aug 2015 21:11:05 +0200
+Subject: [PATCH] Add configure option --enable-build-timestamp.
+
+* configure.ac (BUILD_TIMESTAMP): Set to "<none>" by default.
+--
+
+This is based on
+libgpg-error commit d620005fd1a655d591fccb44639e22ea445e4554
+but changed to be disabled by default.  Check there for some
+background.
+
+Signed-off-by: Werner Koch <wk@gnupg.org>
+---
+ configure.ac | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 48e217947287..2acfa3630cac 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2272,7 +2272,16 @@ changequote([,])dnl
+ BUILD_FILEVERSION="${BUILD_FILEVERSION}mym4_revision_dec"
+ AC_SUBST(BUILD_FILEVERSION)
+ 
+-BUILD_TIMESTAMP=`date -u +%Y-%m-%dT%H:%M+0000 2>/dev/null || date`
++AC_ARG_ENABLE([build-timestamp],
++  AC_HELP_STRING([--enable-build-timestamp],
++                 [set an explicit build timestamp for reproducibility.
++                  (default is the current time in ISO-8601 format)]),
++     [if test "$enableval" = "yes"; then
++        BUILD_TIMESTAMP=`date -u +%Y-%m-%dT%H:%M+0000 2>/dev/null || date`
++      else
++        BUILD_TIMESTAMP="$enableval"
++      fi],
++     [BUILD_TIMESTAMP="<none>"])
+ AC_SUBST(BUILD_TIMESTAMP)
+ AC_DEFINE_UNQUOTED(BUILD_TIMESTAMP, "$BUILD_TIMESTAMP",
+                    [The time this package was configured for a build])
+-- 
+2.15.1
+


### PR DESCRIPTION
Maintainer: @MikePetullo
Compile tested: lantiq, LEDE master, reboot-5448-gdeaf9597c67a

Build timestamp prevents reproducible builds [0].
The patch is a backport from upstream.

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>