### PR TITLE
gnutls: Use HTTP instead of FTP

### DIFF
--- a/libs/gnutls/Makefile
+++ b/libs/gnutls/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=ftp://ftp.gnutls.org/gcrypt/gnutls/v3.5
+PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5
 PKG_HASH:=0924dec90c37c05f49fec966eba3672dab4d336d879e5c06e06e13325cbfec25
 #PKG_FIXUP:=autoreconf gettext-version
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>


### PR DESCRIPTION
While recently building asterisk, the make system stalled on gnutls. On my install of Ubuntu 16.04 on WSL, it seems curl can't download from ftp and doesn't even time out properly. Easiest solution is to switch the gnutls Makefile to use HTTPS instead.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmav 
Compile tested: mvebu
Run tested: mvebu, LEDE trunk