### PR TITLE
net/stunnel: add enabled config option

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -9,10 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
 PKG_VERSION:=5.44
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0+
-PKG_MAINTAINER:=Daniel Engberg <daniel.engberg.lists@pyret.net>
+PKG_MAINTAINER:=Daniel Engberg <daniel.engberg.lists@pyret.net> \
+		Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE_FILES:=COPYING COPYRIGHT.GPL
 
 PKG_SOURCE_URL:= \

--- a/net/stunnel/files/stunnel.init
+++ b/net/stunnel/files/stunnel.init
@@ -81,7 +81,10 @@ print_list_colon() {
 
 service_section() {
 	local cfg="$1"
-	local accept_host accept_port
+	local accept_host accept_port enabled
+
+	config_get_bool enabled "$cfg" 'enabled' '1'
+	[ ${enabled} -gt 0 ] || return 0
 
 	printf "\n" >> "$CONF_FILE"
 	printf "[%s]\n" "$cfg" >> "$CONF_FILE"


### PR DESCRIPTION
Maintainer: @diizzyy @hnyman 
Compile tested: not needed
Run tested: lantiq_xrx200 and x86_64 , LEDE master

Description:

Add an enabled option for the service section, so you could keep your
configuration in place without apply this section on startup or service reload.
