### PR TITLE
setserial: introduce package

### DIFF
--- a/utils/setserial/Makefile
+++ b/utils/setserial/Makefile
@@ -1,0 +1,34 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=setserial
+PKG_VERSION:=2.17
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@SF/setserial
+PKG_HASH:=7e4487d320ac31558563424189435d396ddf77953bb23111a17a3d1487b5794a
+
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+PKG_LICENSE:=GPL-2.0
+
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/setserial
+  SECTION:=utils
+  CATEGORY:=Utilities
+  URL:=http://setserial.sourceforge.net/
+  TITLE:=Serial port attribute utility
+endef
+
+define Package/setserial/install
+	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/setserial $(1)/bin/
+endef
+
+define Package/setserial/description
+ Setserial is a program which allows you to look at and change various
+ attributes of a serial device, including its port, its IRQ, and other
+ serial port options.
+endef
+
+$(eval $(call BuildPackage,setserial))


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE-SDK x86/64 r5498-72051f7
Run tested: LEDE x86/64 r4497+16-a73471dea7

Description:

This packages setserial, the standard Linux program for setting serial
device attributes such as baud rate, flow control etc.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>