### PR TITLE
python,python3: add zlib/host to HOST_BUILD_DEPENDS

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -14,7 +14,7 @@ PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 # XXX: reset PKG_RELEASE to 1 only if Python's pip & setuptools versions have also bumped;
 #      otherwise, keep bumping PKG_RELEASE
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)
@@ -42,7 +42,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PYTHON_BLUETOOTH_SUPPORT
 
 PKG_BUILD_DEPENDS:=python/host
-HOST_BUILD_DEPENDS:=bzip2/host expat/host
+HOST_BUILD_DEPENDS:=bzip2/host expat/host zlib/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -16,7 +16,7 @@ PYTHON_VERSION_MICRO:=$(PYTHON3_VERSION_MICRO)
 PKG_NAME:=python3
 # XXX: reset PKG_RELEASE to 1 only if Python's pip & setuptools versions have also bumped;
 #      otherwise, keep bumping PKG_RELEASE
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -45,7 +45,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PYTHON3_BLUETOOTH_SUPPORT
 
 PKG_BUILD_DEPENDS:=python3/host
-HOST_BUILD_DEPENDS:=bzip2/host expat/host libffi/host
+HOST_BUILD_DEPENDS:=bzip2/host expat/host libffi/host zlib/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: SDK http://downloads.lede-project.org/snapshots/targets/x86/64/ snapshot from 19th of November 2017
Run tested: N/A

--------------------------------------------------------

This should fix the zlibmodule build on the host side.

Usually, if zlib is not found, Python/Python3 builds fine
without it, but there are some cases where the Python/Python3
interpreter on the host-side requires zlib to run.

At the moment, zlib does not have a host-build.
This should be available when this PR gets merged:
https://github.com/lede-project/source/pull/1329
[ or a similar one that contains host-build support for zlib ].

In the meantime, this change can go into Python/Python3.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>