### PR TITLE
 xl2tpd: add netifd l2tp proto support for redial parameters and remove unused parameters

### DIFF
--- a/net/xl2tpd/Makefile
+++ b/net/xl2tpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xl2tpd
 PKG_VERSION:=1.3.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: Yousong Zhou <yszhou4tech@gmail.com>
Run tested: chaos_calmer, ARMv7, SoC BCM963138 

Description:
Currently netifd's l2tp protocol does not try to restart the connection when initial attempt fails or when remote peer close the PPP session or L2TP tunnel. The newly added parameters "redial" (default value true), "max_redials"  and "redial_timeout" (xl2tpd has a default of 30 seconds for it) will allow xl2tpd to to re-establish the link when needed.

Parameter "checkup_interval" is not currently used and "demand" although is used to select pppd options like "precompiled-active-filter /etc/ppp/filter demand idle $demand" and "persist", these options are also not used.