### PR TITLE
lsof: reproducible build

### DIFF
--- a/utils/lsof/Makefile
+++ b/utils/lsof/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=lsof
 PKG_VERSION:=4.89
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.mirrorservice.org/sites/lsof.itap.purdue.edu/pub/tools/unix/lsof/ ftp://sunsite.ualberta.ca/pub/Mirror/lsof/ ftp://ftp.fu-berlin.de/pub/unix/tools/lsof
@@ -57,6 +57,10 @@ define Build/Configure
 endef
 
 define Build/Compile	
+	LSOF_HOST="none" \
+	LSOF_LOGNAME="none" \
+	LSOF_SYSINFO="none" \
+	LSOF_USER="none" \
 	$(MAKE) -C $(PKG_BUILD_DIR)
 endef
 

--- a/utils/lsof/patches/005-reproducable-build.patch
+++ b/utils/lsof/patches/005-reproducable-build.patch
@@ -1,0 +1,24 @@
+diff --git a/dialects/linux/Makefile b/dialects/linux/Makefile
+index 2bea108..ed8382e 100644
+--- a/dialects/linux/Makefile
++++ b/dialects/linux/Makefile
+@@ -78,8 +78,8 @@ version.h:	FRC
+ 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
+ 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
+ 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
+-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
+-	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
++	@echo '#define	LSOF_CCDATE	"'`date -d @${SOURCE_DATE_EPOCH}`'"' >> version.h
++	@echo '#define	LSOF_CCFLAGS	""' >> version.h
+ 	@echo '#define	LSOF_CINFO	"${CINFO}"' >> version.h
+ 	@if [ "X${LSOF_HOST}" = "X" ]; then \
+ 	  echo '#define	LSOF_HOST	"'`uname -n`'"' >> version.h; \
+@@ -90,7 +90,7 @@ version.h:	FRC
+ 	    echo '#define	LSOF_HOST	"${LSOF_HOST}"' >> version.h; \
+ 	  fi \
+ 	fi
+-	@echo '#define	LSOF_LDFLAGS	"${CFGL}"' >> version.h
++	@echo '#define	LSOF_LDFLAGS	""' >> version.h
+ 	@if [ "X${LSOF_LOGNAME}" = "X" ]; then \
+ 	  echo '#define	LSOF_LOGNAME	"${LOGNAME}"' >> version.h; \
+ 	else \


### PR DESCRIPTION
Maintainer: me
Compile tested: (ar71xx, Netgear WNDR3800, OpenWRT r5501-30e18c8)
Run tested: (ar71xx, Netgear WNDR3800, OpenWRT r5501-30e18c8, lsof -v doesn't show build fingerprints anymore, lsof works normally)

Description:
- clear build host and user info
- clear compiler/linker flags because they expose absolute paths
- set date to SOURCE_DATE_EPOCH
```
# lsof -v
lsof version information:
    revision: 4.89
    latest revision: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/
    latest FAQ: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/FAQ
    latest man page: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/lsof_man
    constructed: Sat Dec 9 16:11:07 UTC 2017
    constructed by and on: smm@devvm1
    compiler: mips-openwrt-linux-musl-gcc
    compiler version: 5.5.0 (LEDE GCC 5.5.0 r5457-94fcd92)
    compiler flags: -Os -pipe -mno-branch-likely -mips32r2 -mtune=24kc -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float -mips16 -minterlink-mips16 -iremap/share/lede/build_dir/target-mips_24kc_musl/lsof_4.89:lsof_4.89 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -DLINUXV=316036 -DGLIBCV=2 -DHASIPv6 -DHASIPv6 -DNEEDS_NETINET_TCPH -DHASUXSOCKEPT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DLSOF_VSTR="3.16.36" -O
    loader flags: -L./lib -llsof -L/share/lede/staging_dir/target-mips_24kc_musl/usr/lib -L/share/lede/staging_dir/target-mips_24kc_musl/lib -L/share/lede/staging_dir/toolchain-mips_24kc_gcc-5.5.0_musl/usr/lib -L/share/lede/staging_dir/toolchain-mips_24kc_gcc-5.5.0_musl/lib -znow -zrelro -lrpc
    system info: Linux devvm1 3.16.0-4-amd64 #1 SMP Debian 3.16.36-1+deb8u2 (2016-10-19) x86_64 GNU/Linux
    Anyone can list all files.
    /dev warnings are disabled.
    Kernel ID check is disabled.
```
```
# /tmp/lsof -v
lsof version information:
    revision: 4.89
    latest revision: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/
    latest FAQ: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/FAQ
    latest man page: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/lsof_man
    constructed: Tue Dec 12 21:24:26 UTC 2017
    compiler: mips-openwrt-linux-musl-gcc
    compiler version: 5.5.0 (LEDE GCC 5.5.0 r5457-94fcd92)
    Anyone can list all files.
    /dev warnings are disabled.
    Kernel ID check is disabled.
```