### PR TITLE
nginx: update to 1.12.2

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
-PKG_VERSION:=1.12.1
+PKG_VERSION:=1.12.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://nginx.org/download/
-PKG_HASH:=8793bf426485a30f91021b6b945a9fd8a84d87d17b566562c3797aba8fac76fb
+PKG_HASH:=305f379da1d5fb5aefa79e45c829852ca6983c7cd2a79328f8e084a324cf0416
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=2-clause BSD-like license
 


### PR DESCRIPTION
also fixes gcc7.2 compile

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>


Maintainer: @heil 
Compile/Run tested: mips_24kc TL-WR1043ND-v4 OpenWRT/LEDE version 5521-9f8d28285d
