### PR TITLE
xl2tpd: remove demand support from netifd l2tp protocol

### DIFF
--- a/net/xl2tpd/Makefile
+++ b/net/xl2tpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xl2tpd
 PKG_VERSION:=1.3.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE

--- a/net/xl2tpd/files/l2tp.sh
+++ b/net/xl2tpd/files/l2tp.sh
@@ -14,7 +14,6 @@ proto_l2tp_init_config() {
 	proto_config_add_string "keepalive"
 	proto_config_add_string "pppd_options"
 	proto_config_add_boolean "ipv6"
-	proto_config_add_int "demand"
 	proto_config_add_int "mtu"
 	proto_config_add_int "checkup_interval"
 	proto_config_add_string "server"
@@ -58,14 +57,9 @@ proto_l2tp_setup() {
 		done
 	fi
 
-	local ipv6 demand keepalive username password pppd_options mtu
-	json_get_vars ipv6 demand keepalive username password pppd_options mtu
+	local ipv6 keepalive username password pppd_options mtu
+	json_get_vars ipv6 keepalive username password pppd_options mtu
 	[ "$ipv6" = 1 ] || ipv6=""
-	if [ "${demand:-0}" -gt 0 ]; then
-		demand="precompiled-active-filter /etc/ppp/filter demand idle $demand"
-	else
-		demand="persist"
-	fi
 
 	local interval="${keepalive##*[, ]}"
 	[ "$interval" != "$keepalive" ] || interval=5


### PR DESCRIPTION
Maintainer: Yousong Zhou yszhou4tech@gmail.com
Run tested: chaos_calmer, ARMv7, SoC BCM963138

This pppd feature does not make sense in L2TP case because the
tunnel is already connected when xl2tpd launch pppd process. If
a dial-on-demand feature is to be implemented, trigger interface
would have to be provided by xl2tpd, not pppd.
