### PR TITLE
ntpd: fix for multiple ntp server configuration generation

### DIFF
--- a/net/ntpd/files/ntpd.init
+++ b/net/ntpd/files/ntpd.init
@@ -68,7 +68,9 @@ start_service() {
 		emit ""
 	fi
 
-	emit "server $server iburst"
+	for srv in $server; do
+		emit "server $srv iburst"
+	done
 
 	mkdir -p /var/lib/ntp
 	chown -R ntp:ntp /var/lib/ntp


### PR DESCRIPTION
Compile tested: ar71xx, tl-wr1043nd-v2, Reboot (SNAPSHOT, r5445+3-04127f0fec)
Run tested: ar71xx, tl-wr1043nd-v2, Reboot (SNAPSHOT, r5445+3-04127f0fec)

Description:
The current script emits the complete list of ntp servers (collected through uci) in one liner into ntpd.conf, while basically making only the first one working correctly. The fix emits each ntp server on one line in ntpd.conf.