### PR TITLE
lsof: fix build on macos

### DIFF
--- a/utils/lsof/Makefile
+++ b/utils/lsof/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=lsof
 PKG_VERSION:=4.89
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.mirrorservice.org/sites/lsof.itap.purdue.edu/pub/tools/unix/lsof/ ftp://sunsite.ualberta.ca/pub/Mirror/lsof/ ftp://ftp.fu-berlin.de/pub/unix/tools/lsof

--- a/utils/lsof/patches/005-reproducable-build.patch
+++ b/utils/lsof/patches/005-reproducable-build.patch
@@ -8,7 +8,7 @@ index 2bea108..ed8382e 100644
  	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
 -	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
 -	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
-+	@echo '#define	LSOF_CCDATE	"'`date -d @${SOURCE_DATE_EPOCH}`'"' >> version.h
++	@echo '#define	LSOF_CCDATE	"'`{ date -d @${SOURCE_DATE_EPOCH} || date -r ${SOURCE_DATE_EPOCH}; } 2> /dev/null`'"' >> version.h
 +	@echo '#define	LSOF_CCFLAGS	""' >> version.h
  	@echo '#define	LSOF_CINFO	"${CINFO}"' >> version.h
  	@if [ "X${LSOF_HOST}" = "X" ]; then \


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, Netgear WNDR3800, OpenWRT r5501-30e18c8, compile-tested on Linux
Run tested: not performed - no changes at code level

Description:
Added alternative timestamp conversion method for BSD version of `date`, should address https://github.com/openwrt/packages/pull/5279#pullrequestreview-83958663

@lynxis or anyone else who builds on OS X, please give it a try.