### PR TITLE
ser2net: Added support for config file.

### DIFF
--- a/net/ser2net/Makefile
+++ b/net/ser2net/Makefile
@@ -46,6 +46,10 @@ define Package/ser2net/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/ser2net $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/ser2net.conf $(1)/etc/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/etc/config/ser2net $(1)/etc/config/ser2net
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/etc/init.d/ser2net $(1)/etc/init.d/ser2net
 endef
 
 $(eval $(call BuildPackage,ser2net))

--- a/net/ser2net/files/etc/config/ser2net
+++ b/net/ser2net/files/etc/config/ser2net
@@ -1,0 +1,8 @@
+config 'proxy'
+	option 'enabled' '0'
+	option 'port' '8000'
+	option 'protocol' 'raw'
+	option 'timeout' '30'
+	option 'device' '/dev/ttyUSB0'
+	option 'options' '9600 1STOPBIT 8DATABITS'
+

--- a/net/ser2net/files/etc/init.d/ser2net
+++ b/net/ser2net/files/etc/init.d/ser2net
@@ -1,0 +1,46 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2017 OpenWrt.org
+
+START=75
+STOP=10
+CONFIGFILE="/tmp/ser2net.conf"
+
+USE_PROCD=1
+PROG=/usr/sbin/ser2net
+
+start_service() {
+	config_load 'ser2net'
+
+	local enabled
+	config_get_bool enabled config 'enabled' '0'
+	[ "$enabled" -gt 0 ] || return 1
+
+	ser2net_create_config config || return 1
+	procd_open_instance
+	procd_set_param command "$PROG" -n -c "$CONFIGFILE"
+	procd_close_instance
+}
+
+ser2net_create_config() {
+	local cfg=$1
+	local port
+	local device
+	
+	config_get port $cfg port
+	config_get device $cfg device
+	[ -z "$port" -o -t "$device" ] && return 1
+
+	local protocol
+	local timeout
+	local options
+
+	config_get protocol $cfg protocol
+	config_get timeout $cfg timeout
+	config_get options $cfg options
+
+	if [ -z "$options" ]; then
+		echo "$port":"$protocol":"$timeout":"$device" >> "$CONFIGFILE
+	else
+		echo "$port":"$protocol":"$timeout":"$device":"$options" >> "$CONFIGFILE"
+	fi
+}


### PR DESCRIPTION
Maintainer: Jasper Scholte NightNL@outlook.com
Compile tested: (x86, GEODE, LEDE 17.01.02)
Run tested: (x86, GEODE, LEDE 17.01.02, tested written configuration and startup of ser2net)

Description:
This adds support for ser2net /etc/config/ser2net config file and corresponding init.d/ser2net script.

Note: this changeset is based on https://github.com/JiapengLi/OpenWrt-luci-app-ser2net/blob/master/openwrt-packages-add-luci-app-ser2net-support.patch
