### PR TITLE
python,python3: add support for SOURCE_DATE_EPOCH var

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -14,7 +14,7 @@ PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 # XXX: reset PKG_RELEASE to 1 only if Python's pip & setuptools versions have also bumped;
 #      otherwise, keep bumping PKG_RELEASE
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)

--- a/lang/python/python/patches/012-add-support-source-date-epoch-pyc.patch
+++ b/lang/python/python/patches/012-add-support-source-date-epoch-pyc.patch
@@ -1,0 +1,10 @@
+--- a/Lib/py_compile.py
++++ b/Lib/py_compile.py
+@@ -108,6 +108,7 @@ def compile(file, cfile=None, dfile=None, doraise=False):
+             timestamp = long(os.fstat(f.fileno()).st_mtime)
+         except AttributeError:
+             timestamp = long(os.stat(file).st_mtime)
++        timestamp = long(os.getenv('SOURCE_DATE_EPOCH', timestamp))
+         codestring = f.read()
+     try:
+         codeobject = __builtin__.compile(codestring, dfile or file,'exec')

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -16,7 +16,7 @@ PYTHON_VERSION_MICRO:=$(PYTHON3_VERSION_MICRO)
 PKG_NAME:=python3
 # XXX: reset PKG_RELEASE to 1 only if Python's pip & setuptools versions have also bumped;
 #      otherwise, keep bumping PKG_RELEASE
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz

--- a/lang/python/python3/patches/012-add-support-source-date-epoch-pyc.patch
+++ b/lang/python/python3/patches/012-add-support-source-date-epoch-pyc.patch
@@ -1,0 +1,13 @@
+--- a/Lib/py_compile.py
++++ b/Lib/py_compile.py
+@@ -137,8 +137,9 @@ def compile(file, cfile=None, dfile=None
+     except FileExistsError:
+         pass
+     source_stats = loader.path_stats(file)
++    mtime = int(os.getenv('SOURCE_DATE_EPOCH', source_stats['mtime']))
+     bytecode = importlib._bootstrap_external._code_to_bytecode(
+-            code, source_stats['mtime'], source_stats['size'])
++            code, mtime, source_stats['size'])
+     mode = importlib._bootstrap_external._calc_mode(file)
+     importlib._bootstrap_external._write_atomic(cfile, bytecode, mode)
+     return cfile


### PR DESCRIPTION
Maintainer: me
Compile tested: s://github.com/lede-project/source/commits/60a39e8f5af7ed710c5c62b131fd9df6519b64e4 x86_64
Run tested: s://github.com/lede-project/source/commits/60a39e8f5af7ed710c5c62b131fd9df6519b64e4 x86_64


See:
https://github.com/openwrt/packages/issues/5278

This should make Python & Python3 packages reproducible
when building.
In my local tests, I got the same sha256 for a sample
.pyc file, so likely this is the solution that should address
this.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>