### PR TITLE
rtl_433: add package

### DIFF
--- a/utils/rtl_433/Makefile
+++ b/utils/rtl_433/Makefile
@@ -1,0 +1,46 @@
+# 
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rtl_433
+PKG_VERSION:=6531ea4
+PKG_RELEASE:=$(PKG_SOURCE_VERSION)
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=git://github.com/merbanan/rtl_433.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=6531ea48a7933ac8289724672059e54fd8aad8eb
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_MIRROR_HASH:=f96301c8d7e87605b113aad4493f15b63a675fea6f00642b0606de5a3a858746
+
+CMAKE_INSTALL:=1
+
+PKG_LICENSE:=GPLv2
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/rtl_433
+  TITLE:=Realtek RTL2832 based 433.92MHz generic data receiver
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+librtlsdr +rtl-sdr +libtool-bin
+  URL:=https://github.com/merbanan/rtl_433
+  MAINTAINER:=Jasper Scholte <NightNL@outlook.com>
+endef
+
+define Package/rtl-sdr/description
+  rtl_433 turns your Realtek RTL2832 based DVB dongle into a 433.92MHz generic data receiver.
+endef
+
+define Package/rtl_433/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/rtl_433 $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,rtl_433))


### PR DESCRIPTION
Maintainer: Jasper Scholte/ @TimelessNL
Compile tested: (x86 / brcm2708 /  ar71xx, GEODE / Raspberry3B / GL.iNet 6416, LEDE 17.01.2)
Run tested: (x86 / brcm2708 /  ar71xx, GEODE / Raspberry3B / GL.iNet 6416, LEDE 17.01. Tested (running) for more than 3 months)

Description:
This will add the rtl_433 package. I've been running this since a couple of months. And so far no issues. It's nice to have in combination with Domoticz.
