### PR TITLE
digitemp: reintroduce package

### DIFF
--- a/utils/digitemp/Makefile
+++ b/utils/digitemp/Makefile
@@ -1,0 +1,89 @@
+#
+# Copyright (C) 2009-2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+# Comment: This makefile is based on the oldpackage makefile by acinonyx / nbd
+# https://dev.openwrt.org/browser/packages/utils/digitemp/Makefile
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=digitemp
+PKG_VERSION:=3.7.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/bcl/digitemp.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=be824bbbc81189931bf4b130a8acc39288d75662
+PKG_MAINTAINER:=Jasper Scholte <NightNL@outlook.com>
+PKG_LICENSE:=GPL-2.0+
+PKG_MIRROR_HASH:=490f9c94c671aa74ce0ef4fbc95231644f3aa7023d2b947714ed55fd712672f2
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/digitemp/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=DigiTemp is a simple to use program for reading values from 1-wire devices.
+  URL:=http://www.digitemp.com
+endef
+
+define Package/digitemp/Default/description
+	DigiTemp is a simple to use program for reading values from 1-wire devices.
+	Its main use is for reading temperature sensors, but it also reads counters,
+	and understands the 1-wire hubs with devices on different branches of the network.
+endef
+
+define Package/digitemp
+$(call Package/digitemp/Default)
+  TITLE += (serial version)
+endef
+
+define Package/digitemp/description
+$(call Package/digitemp/Default/description)
+	This package is built without USB support.
+endef
+
+define Package/digitemp-usb
+$(call Package/digitemp/Default)
+  TITLE += (USB version)
+  DEPENDS += +libusb-compat
+endef
+
+define Package/digitemp-usb/description
+$(call Package/digitemp/Default/description)
+	This package is built with USB support.
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS="$(TARGET_CFLAGS) -DLINUX $(TARGET_CPPFLAGS) \
+			-I./src -I./userial" \
+		LIBS="$(TARGET_LDFLAGS)" \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		ds9097 ds9097u
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS="$(TARGET_CFLAGS) -DLINUX $(TARGET_CPPFLAGS) \
+			-I./src -I./userial -DOWUSB" \
+		LIBS="$(TARGET_LDFLAGS) -lusb -lm -DOWUSB" \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		clean ds2490
+endef
+
+define Package/digitemp/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(CP) $(PKG_BUILD_DIR)/digitemp_{DS9097,DS9097U} $(1)/usr/bin/
+endef
+
+define Package/digitemp-usb/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(CP) $(PKG_BUILD_DIR)/digitemp_DS2490 $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,digitemp))
+$(eval $(call BuildPackage,digitemp-usb))

--- a/utils/digitemp/patches/0001_add_missing_includes.patch
+++ b/utils/digitemp/patches/0001_add_missing_includes.patch
@@ -1,0 +1,72 @@
+--- a/src/ds2438.c     2015-12-22 04:47:28.000000000 +0100
++++ b/src/ds2438.c     2017-07-02 22:52:36.671830316 +0200
+@@ -5,6 +5,7 @@
+    Licensed under GPL v2
+    ----------------------------------------------------------------------- */
+ #include <stdio.h>
++#include <sys/types.h>
+ #include "ownet.h"
+ #include "ad26.h"
+
+--- a/userial/ad26.c   2015-12-22 04:47:28.000000000 +0100
++++ b/userial/ad26.c   2017-07-02 22:58:03.902024016 +0200
+@@ -33,7 +33,7 @@
+ #include "ownet.h"
+ #include "ad26.h"
+ #include "owproto.h"
+-
++#include "sys/types.h"
+
+ extern int   owBlock(int,int,uchar *,int);
+ extern void  setcrc8(int,uchar);
+
+--- a/userial/cnt1d.c  2015-12-22 04:47:28.000000000 +0100
++++ b/userial/cnt1d.c  2017-07-02 22:56:26.850619935 +0200
+@@ -29,6 +29,7 @@
+ //  Version: 2.00
+ //
+ //
++#include "sys/types.h"
+ #include "ownet.h"
+
+ // external One Wire functions from nework layer
+
+--- a/userial/crcutil.c        2015-12-22 04:47:28.000000000 +0100
++++ b/userial/crcutil.c        2017-07-02 22:55:13.631039389 +0200
+@@ -29,6 +29,7 @@
+
+ // Include files
+ #include "ownet.h"
++#include "sys/types.h"
+
+ // Local subroutines
+ void setcrc16(int,ushort);
+
+--- a/userial/ds9097u/owtrnu.c 2015-12-22 04:47:28.000000000 +0100
++++ b/userial/ds9097u/owtrnu.c 2017-07-02 23:00:52.320902969 +0200
+@@ -39,6 +39,7 @@
+ //                        Added file I/O operations
+ //
+
++#include "sys/types.h"
+ #include "ownet.h"
+ #include "ds2480.h"
+
+--- a/userial/ioutil.c 2015-12-22 04:47:28.000000000 +0100
++++ b/userial/ioutil.c 2017-07-02 22:55:48.378843851 +0200
+@@ -36,6 +36,7 @@
+ #include <string.h>
+ #include <ctype.h>
+ #include "ownet.h"
++#include "sys/types.h"
+
+ #ifdef __MC68K__
+ #include <PalmOS.h>
+
+--- a/userial/owproto.h        2015-12-22 04:47:28.000000000 +0100
++++ b/userial/owproto.h        2017-07-02 22:58:59.561664538 +0200
+@@ -1,3 +1,4 @@
++#include "sys/types.h"
+ /* Prototypes for userial driver functions */
+
+ /* From other low level userial files */


### PR DESCRIPTION
Validator: Jasper Scholte/ @TimelessNL
Compile tested: (x86 / brcm2708, GEODE / Raspberry3B, LEDE 17.01.2)
Run tested: (x86 / brcm2708, GEODE / Raspberry3B, LEDE 17.01.2, Tested (running) for more than 5 months)

Description:
This brings back the digitemp package. I don't know why it has been removed before, but with the attached patch digitemp runs just fine on my 2 tested platforms. 

I also noticed this  #2311 pull-request, but it's unclear to me why this has been closed by the owner. And I left a message there but there has been no response for quite some time. So thats why I created a new pull-request against the master branch.