### PR TITLE
libs/libgcrypt: switch PKG_SOURCE_URL to https URI

### DIFF
--- a/libs/libgcrypt/Makefile
+++ b/libs/libgcrypt/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.6.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=ftp://ftp.gnupg.org/gcrypt/libgcrypt
+PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/libgcrypt/
 PKG_HASH:=f9461b4619bb78b273a88d468915750d418e89a3ea3b641bab0563a9af4b04d0
 PKG_LICENSE:=LGPL-2.1+ GPL-2.0+
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Signed-off-by: Ben Smith <le.ben.smith@gmail.com>


Maintainer: @MikePetullo 
Compile tested: LEDE master

Description:
PKG_SRC_URL currently uses an ftp location, which curl hangs trying to retrieve. This switches to an https location which curl is happy with.

