### PR TITLE
elektra: update to 0.8.21

### DIFF
--- a/libs/elektra/Makefile
+++ b/libs/elektra/Makefile
@@ -13,12 +13,12 @@ PKG_MAINTAINER:=Harald Geyer <harald@ccbib.org>
 
 PKG_NAME:=elektra
 PKG_LICENSE:=BSD-3-Clause
-PKG_LICENSE_FILES:=doc/COPYING
-PKG_VERSION:=0.8.19
+PKG_LICENSE_FILES:=LICENSE.md
+PKG_VERSION:=0.8.21
 PKG_RELEASE:=1
 
 # Use this for official releasees
-PKG_HASH:=cc14f09539aa95623e884f28e8be7bd67c37550d25e08288108a54fd294fd2a8
+PKG_HASH:=51892570f18d1667d0da4d0908a091e41b41c20db9835765677109a3d150cd26
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://ftp.libelektra.org/ftp/elektra/releases
 
@@ -97,10 +97,11 @@ define Package/libelektra-plugins
 endef
 
 define CONTENT_ELEKTRA_PLUGINS_TEXT
-base64 boolean cachefilter ccode conditionals csvstorage
-enum filecheck glob hexcode hidden hosts iconv keytometa
-line lineendings list mathcheck network null path profile
-shell syslog uname validation
+base64 boolean cachefilter camel ccode conditionals csvstorage
+date directoryvalue enum file filecheck glob hexcode hidden
+hosts iconv ipaddr keytometa line lineendings list mathcheck
+mini network null path profile range shell syslog uname
+validation
 endef
 
 CONTENT_ELEKTRA_PLUGINS = $(strip $(CONTENT_ELEKTRA_PLUGINS_TEXT))
@@ -158,7 +159,7 @@ endef
 define Package/libelektra-curlget
   $(call Package/libelektra/Default)
   TITLE:=Elektra curlget plugin
-  DEPENDS:=+libelektra-core +libcurl
+  DEPENDS:=+libelektra-core +libcurl +libopenssl
 endef
 
 define Package/libelektra-curlget/description
@@ -178,6 +179,21 @@ $(call Package/libelektra/Default-description)
 
 This package contains support for dbus notification on configuration
 changes.
+endef
+
+define Package/libelektra-xerces
+  $(call Package/libelektra/Default)
+  TITLE:=Elektra xerces based xml plugin
+  DEPENDS:=+libelektra-core +libstdcpp +libxerces-c
+endef
+
+define Package/libelektra-xerces/description
+$(call Package/libelektra/Default-description)
+
+The xerces plugin supplants the xmltool plugin
+and allows us to use XML files not following a specific schemata.
+Attributes are mapped to Elektra's metadata, multiple keys with the
+same names are mapped to arrays.
 endef
 
 define Package/libelektra-xml
@@ -203,6 +219,19 @@ $(call Package/libelektra/Default-description)
 
 This package contains support for storing the key database as json files.
 endef
+
+define Package/libelektra-yamlcpp
+  $(call Package/libelektra/Default)
+  TITLE:=Elektra yaml plugin
+  DEPENDS:=+libelektra-core +libyaml-cpp
+endef
+
+define Package/libelektra-yamlcpp/description
+$(call Package/libelektra/Default-description)
+
+This package contains support for storing the key database as yaml files.
+endef
+
 
 define Package/libelektra-python2
   $(call Package/libelektra/Default)
@@ -247,7 +276,7 @@ define Package/libelektra-extra
 endef
 
 define CONTENT_EXTRA_PLUGINS_TEXT
-blockresolver c constants counter desktop dpkg error
+blockresolver c constants counter desktop dini dpkg error
 fcrypt fstab logchange mozprefs passwd rename required
 simplespeclang timeofday tracer
 endef
@@ -273,7 +302,7 @@ CMAKE_OPTIONS = \
 	-DKDB_DEFAULT_RESOLVER=resolver_fm_pb_b \
 	-DKDB_DEFAULT_STORAGE=ini \
 	-DENABLE_OPTIMIZATIONS=OFF \
-	-DPLUGINS="ALL"
+	-DPLUGINS="ALL;-multifile"
 
 CMAKE_HOST_OPTIONS = \
 	-DCMAKE_SKIP_RPATH=FALSE \
@@ -293,6 +322,7 @@ define Package/libelektra-core/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra.so* $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-core.so* $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-ease.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-invoke.so* $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-kdb.so* $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-meta.so* $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-plugin.so* $(1)/usr/lib/
@@ -300,6 +330,7 @@ define Package/libelektra-core/install
 	#The next is only supported with glibc, so skip it.
 	#$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektraintercept-* $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-resolver_fm_pb_b.so $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-utility.so* $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-ni.so $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-ini.so $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-sync.so $(1)/usr/lib/
@@ -353,6 +384,11 @@ define Package/libelektra-dbus/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-dbus.so $(1)/usr/lib/
 endef
 
+define Package/libelektra-xerces/install
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-xerces.so $(1)/usr/lib/
+endef
+
 define Package/libelektra-xml/install
 	$(INSTALL_DIR) $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-xmltool.so $(1)/usr/lib/
@@ -361,6 +397,11 @@ endef
 define Package/libelektra-yajl/install
 	$(INSTALL_DIR) $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-yajl.so $(1)/usr/lib/
+endef
+
+define Package/libelektra-yamlcpp/install
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelektra-yamlcpp.so $(1)/usr/lib/
 endef
 
 define Package/libelektra-python2/install
@@ -401,6 +442,8 @@ $(eval $(call BuildPackage,libelektra-cpp))
 $(eval $(call BuildPackage,libelektra-curlget))
 $(eval $(call BuildPackage,libelektra-crypto))
 $(eval $(call BuildPackage,libelektra-dbus))
+$(eval $(call BuildPackage,libelektra-xerces))
+$(eval $(call BuildPackage,libelektra-yamlcpp))
 $(eval $(call BuildPackage,libelektra-xml))
 $(eval $(call BuildPackage,libelektra-yajl))
 $(eval $(call BuildPackage,libelektra-python2))


### PR DESCRIPTION
Maintainer: me
Compile tested: arm_arm926ej-s, LEDE: 23bba9cb330cd298739a16e350b0029ed9429eef
Run tested: not

Description:
Just an update to the latest upstream version, adjusting dependencies and introducing two new binaray packages. Nothing noteworthy IMO. Compiler warnings are reported upstream.