### PR TITLE
adblock: release 3.4.0

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.1.1
+PKG_VERSION:=3.4.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
@@ -17,6 +17,7 @@ define Package/adblock
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=Powerful adblock script to block ad/abuse domains
+	DEPENDS:=+jshn +jsonfilter
 	PKGARCH:=all
 endef
 
@@ -53,6 +54,7 @@ define Package/adblock/install
 	$(INSTALL_CONF) ./files/adblock.conf $(1)/etc/config/adblock
 
 	$(INSTALL_DIR) $(1)/etc/adblock
+	$(INSTALL_CONF) ./files/adblock.notify $(1)/etc/adblock/
 	$(INSTALL_CONF) ./files/adblock.blacklist $(1)/etc/adblock/
 	$(INSTALL_CONF) ./files/adblock.whitelist $(1)/etc/adblock/
 endef

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -43,8 +43,6 @@ A lot of people already use adblocker plugins within their desktop browsers, but
     * => regional blocklist for Romania, weekly updates, approx. 600 entries
     * [reg_ru](https://code.google.com/p/ruadlist)
     * => regional blocklist for Russia, weekly updates, approx. 2.000 entries
-    * [securemecca](http://www.securemecca.com)
-    * => infrequent updates, approx. 25.000 entries
     * [shallalist](http://www.shallalist.de) (categories "adv" "costtraps" "spyware" "tracker" "warez" enabled by default)
     * => daily updates, approx. 32.000 entries (a short description of all shallalist categories can be found [online](http://www.shallalist.de/categories.html))
     * [spam404](http://www.spam404.com)
@@ -76,6 +74,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 * minimal status & error logging to syslog, enable debug logging to receive more output
 * procd based init system support (start/stop/restart/reload/suspend/resume/query/status)
 * procd network interface trigger support or classic time based startup
+* keep the dns cache intact after adblock processing (currently supported by unbound and named)
 * conditional dns backend restarts by old/new blocklist comparison with sha256sum (default) or md5sum
 * suspend & resume adblock actions temporarily without blocklist reloading
 * output comprehensive runtime information via LuCI or via 'status' init command
@@ -86,6 +85,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 * optional: automatic blocklist backup & restore, they will be used in case of download errors or during startup in backup mode
 * optional: 'backup mode' to re-use blocklist backups during startup, get fresh lists only via reload or restart action
 * optional: 'whitelist mode' to block access to all domains except those explicitly listed in the whitelist file
+* optional: send notification emails in case of a processing error or if the overall domain count is &le; 0
 * optional: add new adblock sources on your own via uci config
 
 ## Prerequisites
@@ -133,18 +133,21 @@ A lot of people already use adblocker plugins within their desktop browsers, but
     * adb\_forcesrt => force overall sort on low memory devices with less than 64 MB RAM (default: '0', disabled)
     * adb\_backup_mode => do not automatically update blocklists during startup, use backups instead (default: '0', disabled)
     * adb\_whitelist_mode => block access to all domains except those explicitly listed in the whitelist file (default: '0', disabled)
+    * adb\_dnsflush => flush DNS cache after adblock processing, i.e. enable the old restart behavior (default: '0', disabled)
+    * adb\_notify => send notification emails in case of a processing error or if the overall domain count is &le; 0 (default: '0', disabled)
+    * adb\_notifycnt => Raise minimum domain count email notification trigger (default: '0')
 
 ## Examples
-**change default dns backend to 'unbound':**  
+**change default dns backend to 'unbound':**
 
-Adblock deposits the final blocklist 'adb_list.overall' in '/var/lib/unbound' where unbound can find them in its jail. If you use manual configuration for unbound, then just include the following line in your 'server' clause:
-<pre><code>
-  include: "/var/lib/unbound/adb_list.overall"
-</code></pre>
+Adblock deposits the final blocklist 'adb_list.overall' in '/var/lib/unbound' where unbound can find them in its jail.  
+To preserve the DNS cache after adblock processing you need to install 'unbound-control'.  
   
-**change default dns backend to 'named' (bind):**  
+**change default dns backend to 'named' (bind):**
 
-Adblock deposits the final blocklist 'adb_list.overall' in '/var/lib/bind'. To use the blocklist please modify '/etc/bind/named.conf':
+Adblock deposits the final blocklist 'adb_list.overall' in '/var/lib/bind'.  
+To preserve the DNS cache after adblock processing you need to install & configure 'bind-rdnc'.  
+To use the blocklist please modify '/etc/bind/named.conf':
 <pre><code>
 in the 'options' namespace add:
   response-policy { zone "rpz"; };
@@ -158,21 +161,45 @@ and at the end of the file add:
   };
 </code></pre>
   
-**change default dns backend to 'kresd':**  
+**change default dns backend to 'kresd':**
 
-The knot-resolver (kresd) is only available on turris omnia devices. Adblock deposits the final blocklist 'adb_list.overall' in '/etc/kresd'. To use the blocklist please modify '/etc/config/resolver':
-<pre><code>
-    list rpz_file '/etc/kresd/adb_list.overall'
-</code></pre>
+The knot-resolver (kresd) is only available on Turris Omnia devices.  
+Adblock deposits the final blocklist 'adb_list.overall' in '/etc/kresd', no further configuration needed.
   
-**change default dns backend to 'dnscrypt-proxy':**  
+**change default dns backend to 'dnscrypt-proxy':**
 
-The required 'blacklist' option of dnscrypt-proxy is not enabled by default, because the package will be compiled without plugins support. Take a custom LEDE build with plugins support to use this feature. Adblock deposits the final blocklist 'adb_list.overall' in '/tmp'. To use the blocklist please modify '/etc/config/dnscrypt-proxy' per instance:
+The required 'blacklist' option of dnscrypt-proxy is not enabled by default, because the package will be compiled without plugins support.  
+Take a custom LEDE build with plugins support to use this feature. Adblock deposits the final blocklist 'adb_list.overall' in '/tmp'.  
+To use the blocklist please modify '/etc/config/dnscrypt-proxy' per instance:
 <pre><code>
   list blacklist 'domains:/tmp/adb_list.overall'
 </code></pre>
   
+**enable email notification via msmtp:**
+
+To use the email notification you have to install & configure the package 'msmtp'.  
+Modify the file '/etc/msmtprc':
+<pre><code>
+[...]
+defaults
+auth            on
+tls             on
+tls_certcheck   off
+timeout         5
+syslog          LOG_MAIL
+[...]
+account         adb_notify
+host            smtp.gmail.com
+port            587
+from            dev.adblock@gmail.com
+user            dev.adblock
+password        xxx
+</code></pre>
+Edit the file '/etc/adblock/adblock.notify' and change at least the 'mail_receiver'.  
+Finally make this file executable via 'chmod' and test it directly. If no more errors come up you can comment 'mail_debug', too.
+  
 **configuration for different download utilities:**
+
 <pre><code>
 wget (default):
   option adb_fetch '/usr/bin/wget'
@@ -192,24 +219,27 @@ curl:
 </code></pre>
   
 **receive adblock runtime information:**
+
 <pre><code>
 /etc/init.d/adblock status
 ::: adblock runtime information
   + adblock_status  : enabled
-  + adblock_version : 3.1.0
-  + overall_domains : 5117
+  + adblock_version : 3.4.0
+  + overall_domains : 5167 (normal/backup mode)
   + fetch_utility   : wget (built-in)
   + dns_backend     : kresd (/etc/kresd)
-  + last_rundate    : 03.11.2017 22:57:41
-  + system_release  : Turris Omnia, OpenWrt omnia 15.05/3.8.4
+  + last_rundate    : 27.12.2017 20:52:35
+  + system_release  : Turris Omnia, OpenWrt omnia 15.05/3.9.1
 </code></pre>
   
 **cronjob for a regular block list update (/etc/crontabs/root):**
+
 <pre><code>
 0 06 * * *    /etc/init.d/adblock reload
 </code></pre>
   
 **blacklist entry (/etc/adblock/adblock.blacklist):**
+
 <pre><code>
 ads.example.com
 
@@ -224,6 +254,7 @@ This entry does not block:
 </code></pre>
   
 **whitelist entry (/etc/adblock/adblock.whitelist):**
+
 <pre><code>
 here.com
 
@@ -236,7 +267,7 @@ This entry does not remove:
   www.adwhere.com
 </code></pre>
   
-**query the active blocklist for a certain (sub-)domain, e.g. for whitelisting:**  
+**query the active blocklist for a certain (sub-)domain, e.g. for whitelisting:**
 
 The query function checks against the submitted (sub-)domain and recurses automatically to the upper top level domain. For every (sub-)domain it returns the first ten relevant results.
 <pre><code>
@@ -255,7 +286,7 @@ The query function checks against the submitted (sub-)domain and recurses automa
   + www-google-analytics.l.google.com
 </code></pre>
   
-**add a new blocklist source:**  
+**add a new blocklist source:**
 
 1. the easy way ...  
 example: https://easylist-downloads.adblockplus.org/rolist+easylist.txt  

--- a/net/adblock/files/adblock.conf
+++ b/net/adblock/files/adblock.conf
@@ -126,12 +126,6 @@ config source 'reg_ru'
 	option adb_src_rset 'BEGIN{FS=\"[|^]\"}\$0~/^\|\|([[:alnum:]_-]+\.){1,}[[:alpha:]]+\^("\\\$third-party")?$/{print tolower(\$3)}'
 	option adb_src_desc 'focus on russian ads plus generic easylist additions, weekly updates, approx. 14.500 entries'
 
-config source 'securemecca'
-	option enabled '0'
-	option adb_src 'http://securemecca.com/Downloads/hosts.txt'
-	option adb_src_rset '\$0~/^127\.0\.0\.1[[:space:]]+([[:alnum:]_-]+\.){1,}[[:alpha:]]+([[:space:]]|$)/{print tolower(\$2)}'
-	option adb_src_desc 'broad blocklist, infrequent updates, approx. 13.700 entries'
-
 config source 'shalla'
 	option enabled '0'
 	option adb_src 'http://www.shallalist.de/Downloads/shallalist.tar.gz'

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -82,7 +82,7 @@ service_triggers()
 
     if [ "${trigger}" != "none" ] && [ "${trigger}" != "timed" ]
     then
-        PROCD_RELOAD_DELAY=$((${delay:=1} * 1000))
+        PROCD_RELOAD_DELAY=$((${delay:-1} * 1000))
         procd_add_interface_trigger "interface.*.up" "${trigger}" "${adb_init}" start
     fi
     procd_add_reload_trigger "adblock"

--- a/net/adblock/files/adblock.notify
+++ b/net/adblock/files/adblock.notify
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# adblock send mail script for mstmp
+# written by Dirk Brenken (dev@brenken.org)
+# Please note: you have to install and configure the package 'mstmp' before using this script.
+
+# This is free software, licensed under the GNU General Public License v3.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+LC_ALL=C
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+mail_daemon="$(command -v sendmail)"
+mail_profile="adb_notify"
+mail_debug="--debug"
+mail_rc=0
+
+# mail header
+#
+mail_sender="no-reply@adblock"
+mail_receiver="!!!ChangeMe!!!"
+mail_topic="adblock notification"
+mail_head="From: ${mail_sender}\nTo: ${mail_receiver}\nSubject: ${mail_topic}\nReply-to: ${mail_sender}\n\n"
+
+# mail body
+#
+mail_text="adblock status, generated at $(date 2>&1)!"
+mail_text="${mail_text}\n++\n++ System Information ++\n++\n$(cat /etc/banner 2>&1)"
+mail_text="${mail_text}\n\n++\n++ Adblock Information ++\n++\n$(/etc/init.d/adblock status 2>&1)"
+
+# send mail
+#
+if [ -x "${mail_daemon}" ]
+then
+    printf "%b" "${mail_head}${mail_text}" | "${mail_daemon}" ${mail_debug} -a "${mail_profile}" "${mail_receiver}" 2>&1
+    mail_rc=${?}
+fi
+exit ${mail_rc}


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: x86, APU2 with different dns backends + Turris Omnia with kresd

Description:
* preserve DNS cache after adblock processing,
  - 'unbound' and 'named' support this (please check readme)
  - 'dnsmasq' now uses the 'servers-file' directive
    to minimize the reload disruption,
    even though the dns cache will be cleared after SIGHUP
  - 'kresd' dns cache is persistent by upstream default, anyway
    Turris Omnia devices need a small upstream software change
    which is not accepted/implemented yet
* email notification in case of an error or domain count < n
  (default 0, check readme)
* removed securemecca from default config (service has been closed)
* new separate functions for hash compare and list/overall count
* add missing package dependencies
* various clean-ups
* update documentation

Signed-off-by: Dirk Brenken <dev@brenken.org>