### PR TITLE
python-cffi: fix host build/installation

### DIFF
--- a/lang/python/python-cffi/Makefile
+++ b/lang/python/python-cffi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cffi
 PKG_VERSION:=1.11.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=cffi-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/c9/70/89b68b6600d479034276fed316e14b9107d50a62f5627da37fafe083fde3
@@ -20,6 +20,8 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cffi-$(PKG_VERSION)
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
+
+PKG_BUILD_DEPENDS:=libffi/host
 
 HOST_PYTHON_PACKAGE_BUILD_DEPENDS:="cffi==$(PKG_VERSION)"
 HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:="cffi==$(PKG_VERSION)"


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/lede-project/source/commit/23bba9cb330cd298739a16e350b0029ed9429eef ar71xx
Run tested:

-------------------------------

Fixes:
https://github.com/openwrt/packages/issues/5318

Not sure how this worked before.
The host python-cffi needs a libffi installed on the host side.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>