### PR TITLE
rsync: fix CVE-2017-17433 and CVE-2017-17434

### DIFF
--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsync
 PKG_VERSION:=3.1.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.samba.org/pub/rsync/src

--- a/net/rsync/patches/012-check-fname-in-recv_files-sooner.patch
+++ b/net/rsync/patches/012-check-fname-in-recv_files-sooner.patch
@@ -1,0 +1,36 @@
+commit 3e06d40029cfdce9d0f73d87cfd4edaf54be9c51
+Author: Jeriko One <jeriko.one@gmx.us>
+Date:   Thu Nov 2 23:44:19 2017 -0700
+
+    Check fname in recv_files sooner.
+
+diff --git a/receiver.c b/receiver.c
+index baae3a9..9fdafa1 100644
+--- a/receiver.c
++++ b/receiver.c
+@@ -574,6 +574,12 @@ int recv_files(int f_in, int f_out, char *local_name)
+ 			file = dir_flist->files[cur_flist->parent_ndx];
+ 		fname = local_name ? local_name : f_name(file, fbuf);
+ 
++		if (daemon_filter_list.head
++		    && check_filter(&daemon_filter_list, FLOG, fname, 0) < 0) {
++			rprintf(FERROR, "attempt to hack rsync failed.\n");
++			exit_cleanup(RERR_PROTOCOL);
++		}
++
+ 		if (DEBUG_GTE(RECV, 1))
+ 			rprintf(FINFO, "recv_files(%s)\n", fname);
+ 
+@@ -645,12 +651,6 @@ int recv_files(int f_in, int f_out, char *local_name)
+ 
+ 		cleanup_got_literal = 0;
+ 
+-		if (daemon_filter_list.head
+-		    && check_filter(&daemon_filter_list, FLOG, fname, 0) < 0) {
+-			rprintf(FERROR, "attempt to hack rsync failed.\n");
+-			exit_cleanup(RERR_PROTOCOL);
+-		}
+-
+ 		if (read_batch) {
+ 			int wanted = redoing
+ 				   ? we_want_redo(ndx)

--- a/net/rsync/patches/013-check-daemoin-filter-against.patch
+++ b/net/rsync/patches/013-check-daemoin-filter-against.patch
@@ -1,0 +1,19 @@
+commit 5509597decdbd7b91994210f700329d8a35e70a1
+Author: Jeriko One <jeriko.one@gmx.us>
+Date:   Thu Nov 16 17:26:03 2017 -0800
+
+    Check daemon filter against fnamecmp in recv_files().
+
+diff --git a/receiver.c b/receiver.c
+index 9fdafa1..9c46242 100644
+--- a/receiver.c
++++ b/receiver.c
+@@ -722,7 +722,7 @@ int recv_files(int f_in, int f_out, char *local_name)
+ 				break;
+ 			}
+ 			if (!fnamecmp || (daemon_filter_list.head
+-			  && check_filter(&daemon_filter_list, FLOG, fname, 0) < 0)) {
++			  && check_filter(&daemon_filter_list, FLOG, fnamecmp, 0) < 0)) {
+ 				fnamecmp = fname;
+ 				fnamecmp_type = FNAMECMP_FNAME;
+ 			}

--- a/net/rsync/patches/014-sanitize-xname-in-read_ndx_and_attrs.patch
+++ b/net/rsync/patches/014-sanitize-xname-in-read_ndx_and_attrs.patch
@@ -1,0 +1,30 @@
+commit 70aeb5fddd1b2f8e143276f8d5a085db16c593b9
+Author: Jeriko One <jeriko.one@gmx.us>
+Date:   Thu Nov 16 17:05:42 2017 -0800
+
+    Sanitize xname in read_ndx_and_attrs.
+
+diff --git a/rsync.c b/rsync.c
+index b82e598..a0945ba 100644
+--- a/rsync.c
++++ b/rsync.c
+@@ -49,6 +49,7 @@ extern int flist_eof;
+ extern int file_old_total;
+ extern int keep_dirlinks;
+ extern int make_backups;
++extern int sanitize_paths;
+ extern struct file_list *cur_flist, *first_flist, *dir_flist;
+ extern struct chmod_mode_struct *daemon_chmod_modes;
+ #ifdef ICONV_OPTION
+@@ -396,6 +397,11 @@ int read_ndx_and_attrs(int f_in, int f_out, int *iflag_ptr, uchar *type_ptr,
+ 	if (iflags & ITEM_XNAME_FOLLOWS) {
+ 		if ((len = read_vstring(f_in, buf, MAXPATHLEN)) < 0)
+ 			exit_cleanup(RERR_PROTOCOL);
++
++		if (sanitize_paths) {
++			sanitize_path(buf, buf, "", 0, SP_DEFAULT);
++			len = strlen(buf);
++		}
+ 	} else {
+ 		*buf = '\0';
+ 		len = -1;


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, Netgear WNDR3800, OpenWrt r5501-30e18c8
Run tested: ar71xx, Netgear WNDR3800, OpenWrt r5501-30e18c8, pull/push files from/to build host

Description:
Patches from https://nvd.nist.gov/vuln/detail/CVE-2017-17433 and https://nvd.nist.gov/vuln/detail/CVE-2017-17434