### PR TITLE
lighttpd: CONFIG_LIGHTTPD_SSL includes mod_openssl

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.48
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
@@ -20,6 +20,8 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+
+PKG_CONFIG_DEPENDS:=CONFIG_LIGHTTPD_SSL
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -49,6 +51,8 @@ config LIGHTTPD_SSL
 	  lighttpd confguration file.
 endef
 
+BASE_MODULES:=dirlisting indexfile staticfile
+
 CONFIGURE_ARGS+= \
 	--libdir=/usr/lib/lighttpd \
 	--sysconfdir=/etc/lighttpd \
@@ -68,6 +72,7 @@ CONFIGURE_VARS+= \
 ifneq ($(strip $(CONFIG_LIGHTTPD_SSL)),)
   CONFIGURE_ARGS+= \
 	--with-openssl="$(STAGING_DIR)/usr"
+  BASE_MODULES+= openssl
 else
   CONFIGURE_ARGS+= \
 	--without-openssl
@@ -153,7 +158,7 @@ define Package/lighttpd/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/lighttpd.init $(1)/etc/init.d/lighttpd
 	$(INSTALL_DIR) $(1)/usr/lib/lighttpd
-	for m in dirlisting indexfile staticfile; do \
+	for m in $(BASE_MODULES); do \
 		$(CP) $(PKG_INSTALL_DIR)/usr/lib/lighttpd/mod_$$$${m}.so $(1)/usr/lib/lighttpd/ ; \
 	done
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, generic, LEDE HEAD(d0a14c1)
Run tested: same, rebuilt and re-installed `.ipk` files on testbed

Description:

If `$(CONFIG_LIGHTTPD_SSL)` is set, then `mod_openssl.so` is included in the base `lighttpd-1.4.48*.ipk`.

Reinstalled all `lighttpd*.ipk`'s on testbed, then ran:

```
# lighttpd -f /etc/lighttpd/lighttpd.conf -tt
# echo $?
0
# 
```

Fixes issue #5343.