### PR TITLE
travelmate: update 1.0.1

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -1,12 +1,12 @@
 #
-# Copyright (c) 2016-2017 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2016-2018 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 #
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.0.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-trm_ver="1.0.0"
+trm_ver="1.0.1"
 trm_sysver="unknown"
 trm_enabled=0
 trm_debug=0
@@ -119,12 +119,9 @@ f_check()
                 for radio in ${trm_radiolist}
                 do
                     trm_ifstatus="$(printf "%s" "${status}" | jsonfilter -l1 -e "@.${radio}.up")"
-                    if [ "${trm_ifstatus}" = "true" ]
+                    if [ "${trm_ifstatus}" = "true" ] && [ -z "$(printf "%s" "${trm_devlist}" | grep -Fo " ${radio}")" ]
                     then
                         trm_devlist="${trm_devlist} ${radio}"
-                    else
-                        trm_devlist=""
-                        break
                     fi
                 done
                 ifname="${trm_devlist}"


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: PC Engines apu2, OpenWrt SNAPSHOT r5521+111-9f8d28285d

Description:
* corner case fix with multiple (partly disabled) radios
* LuCI: BSSID will be ignored by default in 'wireless add' dialog
* LuCI: Textarea 'autoscroll down' in logfile view
* LuCI: refine logfile search term

Signed-off-by: Dirk Brenken <dev@brenken.org>