### PR TITLE
adblock: update 3.4.1

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -1,12 +1,12 @@
 #
-# Copyright (c) 2015-2017 Dirk Brenken (dev@brenken.org)
+# Copyright (c) 2015-2018 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the GNU General Public License v3.
 #
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.4.0
+PKG_VERSION:=3.4.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
@@ -16,13 +16,13 @@ include $(INCLUDE_DIR)/package.mk
 define Package/adblock
 	SECTION:=net
 	CATEGORY:=Network
-	TITLE:=Powerful adblock script to block ad/abuse domains
+	TITLE:=Powerful adblock script to block ad/abuse domains by using DNS
 	DEPENDS:=+jshn +jsonfilter
 	PKGARCH:=all
 endef
 
 define Package/adblock/description
-Powerful adblock script to block ad/abuse domains via dnsmasq, unbound or bind dns backend.
+Powerful adblock script to block ad/abuse domains via dnsmasq, unbound, named, kresd or dnscrypt-proxy.
 The script supports many domain blacklist sites plus manual black- and whitelist overrides.
 Please see https://github.com/openwrt/packages/blob/master/net/adblock/files/README.md for further information.
 

--- a/net/adblock/files/adblock.conf
+++ b/net/adblock/files/adblock.conf
@@ -31,7 +31,7 @@ config source 'bitcoin'
 	option adb_src_desc 'focus on malicious bitcoin mining sites, infrequent updates, approx. 20 entries'
 
 config source 'blacklist'
-	option enabled '0'
+	option enabled '1'
 	option adb_src '/etc/adblock/adblock.blacklist'
 	option adb_src_rset '\$0~/^([[:alnum:]_-]+\.){1,}[[:alpha:]]+([[:space:]]|$)/{print tolower(\$1)}'
 	option adb_src_desc 'static local domain blacklist, always deny these domains'

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -72,17 +72,31 @@ query()
 
 status()
 {
-    rc_procd "${adb_script}" status
+    local key keylist value rtfile="$(uci_get adblock.extra.adb_rtfile)"
+
+    rtfile="${rtfile:-"/tmp/adb_runtime.json"}"
+    if [ -s "${rtfile}" ]
+    then
+        printf "%s\n" "::: adblock runtime information"
+        json_load "$(cat "${rtfile}" 2>/dev/null)"
+        json_select data
+        json_get_keys keylist
+        for key in ${keylist}
+        do
+            json_get_var value "${key}"
+            printf "  + %-15s : %s\n" "${key}" "${value}"
+        done
+    fi
 }
 
 service_triggers()
 {
     local trigger="$(uci_get adblock.global.adb_trigger)"
-    local delay="$(uci_get adblock.global.adb_triggerdelay)"
+    local delay="$(uci_get adblock.extra.adb_triggerdelay)"
 
     if [ "${trigger}" != "none" ] && [ "${trigger}" != "timed" ]
     then
-        PROCD_RELOAD_DELAY=$((${delay:-1} * 1000))
+        PROCD_RELOAD_DELAY=$((${delay:-2} * 1000))
         procd_add_interface_trigger "interface.*.up" "${trigger}" "${adb_init}" start
     fi
     procd_add_reload_trigger "adblock"

--- a/net/adblock/files/adblock.notify
+++ b/net/adblock/files/adblock.notify
@@ -10,10 +10,16 @@
 
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-mail_daemon="$(command -v sendmail)"
+mail_ver="1.0.0"
+mail_daemon="$(command -v msmtp)"
 mail_profile="adb_notify"
 mail_debug="--debug"
-mail_rc=0
+mail_rc=1
+
+if [ ! -x "${mail_daemon}" ]
+then
+    mail_daemon="$(command -v sendmail)"
+fi
 
 # mail header
 #
@@ -32,7 +38,11 @@ mail_text="${mail_text}\n\n++\n++ Adblock Information ++\n++\n$(/etc/init.d/adbl
 #
 if [ -x "${mail_daemon}" ]
 then
-    printf "%b" "${mail_head}${mail_text}" | "${mail_daemon}" ${mail_debug} -a "${mail_profile}" "${mail_receiver}" 2>&1
+    printf "%b" "${mail_head}${mail_text}" 2>/dev/null | "${mail_daemon}" ${mail_debug} -a "${mail_profile}" "${mail_receiver}" >/dev/null 2>&1
     mail_rc=${?}
+    logger -p "info" -t "adblock-notify-[${mail_ver}]" "mail sent to '${mail_receiver}' with rc '${mail_rc}'"
+else
+    logger -p "err" -t "adblock-notify-[${mail_ver}]" "msmtp mail daemon not found"
 fi
+
 exit ${mail_rc}

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-adb_ver="3.4.0"
+adb_ver="3.4.1"
 adb_sysver="unknown"
 adb_enabled=0
 adb_debug=0
@@ -44,6 +44,12 @@ f_envload()
 {
     local dns_up sys_call sys_desc sys_model sys_ver cnt=0
 
+    # create temp files and directories
+    #
+    adb_tmpload="$(mktemp -tu)"
+    adb_tmpfile="$(mktemp -tu)"
+    adb_tmpdir="$(mktemp -p /tmp -d)"
+
     # get system information
     #
     sys_call="$(ubus -S call system board 2>/dev/null)"
@@ -73,7 +79,7 @@ f_envload()
         . "/lib/functions.sh"
         . "/usr/share/libubox/jshn.sh"
     else
-        f_log "error" "system libraries not found"
+        f_log "err" "system libraries not found"
     fi
 
     # parse 'global' and 'extra' section by callback
@@ -119,7 +125,7 @@ f_envload()
     #
     case "${adb_dns}" in
         dnsmasq)
-            adb_dnsinstance=0
+            adb_dnsinstance="${adb_dnsinstance:-"0"}"
             adb_dnsuser="${adb_dnsuser:-"dnsmasq"}"
             adb_dnsdir="${adb_dnsdir:-"/tmp"}"
             adb_dnsheader=""
@@ -131,7 +137,7 @@ f_envload()
             fi
         ;;
         unbound)
-            adb_dnsinstance=0
+            adb_dnsinstance="${adb_dnsinstance:-"0"}"
             adb_dnsuser="${adb_dnsuser:-"unbound"}"
             adb_dnsdir="${adb_dnsdir:-"/var/lib/unbound"}"
             adb_dnsheader=""
@@ -143,7 +149,7 @@ f_envload()
             fi
         ;;
         named)
-            adb_dnsinstance=0
+            adb_dnsinstance="${adb_dnsinstance:-"0"}"
             adb_dnsuser="${adb_dnsuser:-"bind"}"
             adb_dnsdir="${adb_dnsdir:-"/var/lib/bind"}"
             adb_dnsheader="\$TTL 2h"$'\n'"@ IN SOA localhost. root.localhost. (1 6h 1h 1w 2h)"$'\n'"  IN NS localhost."
@@ -155,7 +161,7 @@ f_envload()
             fi
         ;;
         kresd)
-            adb_dnsinstance=0
+            adb_dnsinstance="${adb_dnsinstance:-"0"}"
             adb_dnsuser="${adb_dnsuser:-"root"}"
             adb_dnsdir="${adb_dnsdir:-"/etc/kresd"}"
             adb_dnsheader="\$TTL 2h"$'\n'"@ IN SOA localhost. root.localhost. (1 6h 1h 1w 2h)"$'\n'"  IN NS  localhost."
@@ -167,7 +173,7 @@ f_envload()
             fi
         ;;
         dnscrypt-proxy)
-            adb_dnsinstance=0
+            adb_dnsinstance="${adb_dnsinstance:-"0"}"
             adb_dnsuser="${adb_dnsuser:-"nobody"}"
             adb_dnsdir="${adb_dnsdir:-"/tmp"}"
             adb_dnsheader=""
@@ -181,9 +187,15 @@ f_envload()
     then
         f_extconf
         f_rmdns
-        f_jsnupdate
-        f_log "info " "adblock is currently disabled, please set adb_enabled to '1' to use this service"
+        f_jsnup
+        f_log "info" "adblock is currently disabled, please set adb_enabled to '1' to use this service"
+        f_rmtemp
         exit 0
+    fi
+
+    if [ "${adb_dns}" = "dnsmasq" ] && [ ${adb_dnsinstance} -ne 0 ]
+    then
+        adb_dnsfile="${adb_dnsprefix}.overall.${adb_dnsinstance}"
     fi
 
     if [ -d "${adb_dnsdir}" ] && [ ! -f "${adb_dnsdir}/${adb_dnsfile}" ]
@@ -214,7 +226,7 @@ f_envload()
 
     if [ -z "${adb_dns}" ] || [ -z "${adb_dnsformat}" ] || [ ! -x "$(command -v ${adb_dns})" ] || [ ! -d "${adb_dnsdir}" ]
     then
-        f_log "error" "'${adb_dns}' not running, DNS backend not found"
+        f_log "err" "'${adb_dns}' not running, DNS backend not found"
     fi
 }
 
@@ -224,7 +236,7 @@ f_envcheck()
 {
     local ssl_lib
 
-    f_log "info " "start adblock processing (${adb_action})"
+    f_log "info" "start adblock processing (${adb_action})"
 
     # check external uci config files
     #
@@ -232,7 +244,6 @@ f_envcheck()
 
     # check fetch utility
     #
-    ssl_lib="-"
     if [ -x "${adb_fetchutil}" ]
     then
         if [ "$(readlink -fn "${adb_fetchutil}")" = "/usr/bin/wget-nossl" ]
@@ -260,19 +271,12 @@ f_envcheck()
     fi
     if [ ! -x "${adb_fetchutil}" ] || [ -z "${adb_fetchutil}" ] || [ -z "${adb_fetchparm}" ]
     then
-        f_log "error" "no download utility found, please install 'uclient-fetch' with 'libustream-mbedtls' or the full 'wget' package"
+        f_log "err" "no download utility found, please install 'uclient-fetch' with 'libustream-mbedtls' or the full 'wget' package"
     fi
-    adb_fetchinfo="${adb_fetchutil##*/} (${ssl_lib})"
-
-    # initialize temp files and directories
-    #
-    adb_tmpload="$(mktemp -tu)"
-    adb_tmpfile="$(mktemp -tu)"
-    adb_tmpdir="$(mktemp -p /tmp -d)"
-    > "${adb_tmpdir}/tmp.whitelist"
+    adb_fetchinfo="${adb_fetchutil##*/} (${ssl_lib:-"-"})"
 }
 
-# remove temporary files and directories
+# remove temp files and directories
 #
 f_rmtemp()
 {
@@ -290,37 +294,43 @@ f_rmdns()
 {
     if [ -n "${adb_dns}" ]
     then
-        f_hashcompare
+        f_hash
         printf '%s\n' "${adb_dnsheader}" > "${adb_dnsdir}/${adb_dnsfile}"
         > "${adb_dnsdir}/.${adb_dnsfile}"
         > "${adb_rtfile}"
         rm -f "${adb_backupdir}/${adb_dnsprefix}"*.gz
-        f_hashcompare
+        f_hash
         if [ ${?} -eq 1 ]
         then
-            f_dnsrestart
+            f_dnsup
         fi
     fi
+    f_log "debug" "f_rmdns::: dns: ${adb_dns}, dns_dir: ${adb_dnsdir}, dns_prefix: ${adb_dnsprefix}, dns_file: ${adb_dnsfile}, rt_file: ${adb_rtfile}, backup_dir: ${adb_backupdir}"
 }
 
 # commit uci changes
 #
-f_ucichange()
+f_uci()
 {
-    local config="${1}"
+    local change config="${1}"
 
-    if [ -n "$(uci -q changes "${config}")" ]
+    if [ -n "${config}" ]
     then
-        uci -q commit "${config}"
-        case "${config}" in
-            dhcp)
-                /etc/init.d/"${adb_dns}" reload >/dev/null 2>&1
-            ;;
-            firewall)
-                /etc/init.d/firewall reload >/dev/null 2>&1
-            ;;
-        esac
+        change="$(uci -q changes "${config}" | awk '{ORS=" "; print $0}')"
+        if [ -n "${change}" ]
+        then
+            uci -q commit "${config}"
+            case "${config}" in
+                firewall)
+                    /etc/init.d/firewall reload >/dev/null 2>&1
+                ;;
+                *)
+                    /etc/init.d/"${adb_dns}" reload >/dev/null 2>&1
+                ;;
+            esac
+        fi
     fi
+    f_log "debug" "f_uci  ::: config: ${config}, change: ${change}"
 }
 
 # list/overall count
@@ -330,11 +340,11 @@ f_count()
     local mode="${1}"
 
     adb_cnt=0
-    if [ -s "${adb_dnsdir}/${adb_dnsfile}" ] && ([ -z "${mode}" ] || [ "${mode}" = "format" ])
+    if [ -s "${adb_dnsdir}/${adb_dnsfile}" ] && ([ -z "${mode}" ] || [ "${mode}" = "final" ])
     then
         if [ "${adb_dns}" = "named" ] || [ "${adb_dns}" = "kresd" ]
         then
-            adb_cnt="$(( ( $(wc -l  2>/dev/null < "${adb_dnsdir}/${adb_dnsfile}") - $(printf "%s" "${adb_dnsheader}" | grep -c "^") ) / 2 ))"
+            adb_cnt="$(( ($(wc -l 2>/dev/null < "${adb_dnsdir}/${adb_dnsfile}") - $(printf "%s" "${adb_dnsheader}" | grep -c "^")) / 2 ))"
         else
             adb_cnt="$(wc -l 2>/dev/null < "${adb_dnsdir}/${adb_dnsfile}")"
         fi
@@ -370,17 +380,16 @@ f_extconf()
             then
                 uci -q del_list resolver.kresd.rpz_file="${adb_dnsdir}/${adb_dnsfile}"
             fi
-# wait for upstream change
-#            if [ ${adb_enabled} -eq 1 ] && [ ${adb_dnsflush} -eq 0 ] && [ "$(uci -q get resolver.common.msg_keep_cache)" != "1" ]
-#            then
-#                uci -q set resolver.common.msg_keep_cache="1"
-#            elif [ ${adb_enabled} -eq 0 ] || ([ ${adb_dnsflush} -eq 1 ] && [ "$(uci -q get resolver.common.msg_keep_cache)" = "1" ])
-#            then
-#                uci -q delete resolver.common.msg_keep_cache
-#            fi
+            if [ ${adb_enabled} -eq 1 ] && [ ${adb_dnsflush} -eq 0 ] && [ "$(uci -q get resolver.kresd.keep_cache)" != "1" ]
+            then
+                uci -q set resolver.kresd.keep_cache="1"
+            elif [ ${adb_enabled} -eq 0 ] || ([ ${adb_dnsflush} -eq 1 ] && [ "$(uci -q get resolver.kresd.keep_cache)" = "1" ])
+            then
+                uci -q delete resolver.kresd.keep_cache
+            fi
         ;;
     esac
-    f_ucichange "${uci_config}"
+    f_uci "${uci_config}"
 
     uci_config="firewall"
     if [ ${adb_enabled} -eq 1 ] && [ ${adb_forcedns} -eq 1 ] && \
@@ -397,21 +406,19 @@ f_extconf()
     then
         uci -q delete firewall.adblock_dns
     fi
-    f_ucichange "${uci_config}"
+    f_uci "${uci_config}"
 }
 
 # restart of the dns backend
 #
-f_dnsrestart()
+f_dnsup()
 {
-    local dns_up cache_util cache_rc out_rc=1 cnt=0
+    local dns_up cache_util cache_rc cnt=0
 
-    if [ ${adb_dnsflush} -eq 0 ] && [ ${adb_enabled} -eq 1 ] && \
-       [ "${adb_rc}" -eq 0 ] && [ "${adb_action}" != "stop" ]
+    if [ ${adb_dnsflush} -eq 0 ] && [ ${adb_enabled} -eq 1 ] && [ "${adb_rc}" -eq 0 ]
     then
         case "${adb_dns}" in
             dnsmasq)
-                cache_util="n/a"
                 killall -q -HUP "${adb_dns}"
                 cache_rc=${?}
             ;;
@@ -424,7 +431,7 @@ f_dnsrestart()
                 "/etc/init.d/${adb_dns}" restart >/dev/null 2>&1
             ;;
             kresd)
-                cache_util="n/a"
+                cache_util="keep_cache"
                 "/etc/init.d/${adb_dns}" restart >/dev/null 2>&1
                 cache_rc=${?}
             ;;
@@ -446,6 +453,7 @@ f_dnsrestart()
         "/etc/init.d/${adb_dns}" restart >/dev/null 2>&1
     fi
 
+    adb_rc=1
     while [ ${cnt} -le 10 ]
     do
         dns_up="$(ubus -S call service list "{\"name\":\"${adb_dns}\"}" | jsonfilter -l1 -e "@[\"${adb_dns}\"].instances.*.running")"
@@ -470,14 +478,13 @@ f_dnsrestart()
                     fi
                 ;;
             esac
-            out_rc=0
+            adb_rc=0
             break
         fi
         cnt=$((cnt+1))
         sleep 1
     done
-    f_log "debug" "cache_util: ${cache_util}, cache_rc: ${cache_rc}, cache_flush: ${adb_dnsflush}, count: ${cnt}, out_rc: ${out_rc}"
-    return ${out_rc}
+    f_log "debug" "f_dnsup::: cache_util: ${cache_util:-"-"}, cache_rc: ${cache_rc}, cache_flush: ${adb_dnsflush}, cache_cnt: ${cnt}, out_rc: ${adb_rc}"
 }
 
 # backup/restore/remove blocklists
@@ -488,15 +495,14 @@ f_list()
 
     case "${mode}" in
         backup)
-            if [ ${adb_backup} -eq 1 ] && [ -d "${adb_backupdir}" ]
+            if [ -d "${adb_backupdir}" ]
             then
                 gzip -cf "${adb_tmpfile}" > "${adb_backupdir}/${adb_dnsprefix}.${src_name}.gz" 2>/dev/null
                 adb_rc=${?}
             fi
         ;;
         restore)
-            if [ ${adb_backup} -eq 1 ] && [ -d "${adb_backupdir}" ] &&
-                [ -f "${adb_backupdir}/${adb_dnsprefix}.${src_name}.gz" ]
+            if [ -d "${adb_backupdir}" ] && [ -f "${adb_backupdir}/${adb_dnsprefix}.${src_name}.gz" ]
             then
                 gunzip -cf "${adb_backupdir}/${adb_dnsprefix}.${src_name}.gz" > "${adb_tmpfile}" 2>/dev/null
                 adb_rc=${?}
@@ -516,8 +522,7 @@ f_list()
                 adb_rc=${?}
             fi
         ;;
-        format)
-            src_name="overall"
+        final)
             if [ -s "${adb_tmpdir}/tmp.whitelist" ]
             then
                 grep -vf "${adb_tmpdir}/tmp.whitelist" "${adb_tmpdir}/${adb_dnsfile}" | eval "${adb_dnsformat}" > "${adb_dnsdir}/${adb_dnsfile}"
@@ -533,26 +538,29 @@ f_list()
         ;;
     esac
     f_count "${mode}"
-    f_log "debug" "name: ${src_name}, mode: ${mode}, count: ${adb_cnt}, in_rc: ${in_rc}, out_rc: ${adb_rc}"
+    f_log "debug" "f_list ::: mode: ${mode}, cnt: ${adb_cnt}, in_rc: ${in_rc}, out_rc: ${adb_rc}"
 }
 
 # top level domain compression
 #
-f_tldcompression()
+f_tld()
 {
-    local source="${1}" temp="${adb_tmpload}"
+    local cnt cnt_srt cnt_tld source="${1}" temp="${adb_tmpload}"
 
-    awk -F "." '{for(f=NF;f > 1;f--) printf "%s.", $f;print $1}' "${source}" 2>/dev/null | sort -u > "${temp}"
-    awk '{if(NR==1){tld=$NF};while(getline){if($NF !~ tld"\\."){print tld;tld=$NF}}print tld}' "${temp}" 2>/dev/null > "${source}"
-    awk -F "." '{for(f=NF;f > 1;f--) printf "%s.", $f;print $1}' "${source}" 2>/dev/null > "${temp}"
-    sort -u "${temp}" > "${source}"
+    cnt="$(wc -l 2>/dev/null < "${source}")"
+    awk -F "." '{for(f=NF;f>1;f--)printf "%s.",$f;print $1}' "${source}" 2>/dev/null | sort -u > "${temp}"
+    cnt_srt="$(wc -l 2>/dev/null < "${temp}")"
+    awk '{if(NR==1){tld=$NF};while(getline){if($NF!~tld"\\."){print tld;tld=$NF}}print tld}' "${temp}" 2>/dev/null |\
+    awk -F "." '{for(f=NF;f>1;f--)printf "%s.",$f;print $1}' 2>/dev/null | sort > "${source}"
+    cnt_tld="$(wc -l 2>/dev/null < "${source}")"
+    f_log "debug" "f_tld  ::: source: ${source}, cnt: ${cnt}, cnt_srt: ${cnt_srt}, cnt_tld: ${cnt_tld}"
 }
 
 # blocklist hash compare
 #
-f_hashcompare()
+f_hash()
 {
-    local hash out_rc=1
+    local hash hash_rc=1
 
     if [ -x "${adb_hashutil}" ] && [ -f "${adb_dnsdir}/${adb_dnsfile}" ]
     then
@@ -568,14 +576,14 @@ f_hashcompare()
         then
             if [ "${adb_hashold}" = "${adb_hashnew}" ]
             then
-                out_rc=0
+                hash_rc=0
             fi
             adb_hashold=""
             adb_hashnew=""
         fi
     fi
-    f_log "debug" "hash_util: ${adb_hashutil}, hash: ${hash}, out_rc: ${out_rc}"
-    return ${out_rc}
+    f_log "debug" "f_hash ::: hash_util: ${adb_hashutil}, hash: ${hash}, out_rc: ${hash_rc}"
+    return ${hash_rc}
 }
 
 # suspend/resume adblock processing
@@ -586,22 +594,22 @@ f_switch()
 
     if [ ! -s "${adb_dnsdir}/.${adb_dnsfile}" ] && [ "${mode}" = "suspend" ]
     then
-        f_hashcompare
+        f_hash
         cat "${adb_dnsdir}/${adb_dnsfile}" > "${adb_dnsdir}/.${adb_dnsfile}"
         printf '%s\n' "${adb_dnsheader}" > "${adb_dnsdir}/${adb_dnsfile}"
-        f_hashcompare
+        f_hash
     elif [ -s "${adb_dnsdir}/.${adb_dnsfile}" ] && [ "${mode}" = "resume" ]
     then
-        f_hashcompare
+        f_hash
         cat "${adb_dnsdir}/.${adb_dnsfile}" > "${adb_dnsdir}/${adb_dnsfile}"
         > "${adb_dnsdir}/.${adb_dnsfile}"
-        f_hashcompare
+        f_hash
     fi
     if [ ${?} -eq 1 ]
     then
-        f_dnsrestart
-        f_jsnupdate
-        f_log "info " "${mode} adblock processing"
+        f_dnsup
+        f_jsnup
+        f_log "info" "${mode} adblock processing"
     fi
 }
 
@@ -637,9 +645,9 @@ f_query()
 
 # update runtime information
 #
-f_jsnupdate()
+f_jsnup()
 {
-    local status mode="normal mode" rundate="$(/bin/date "+%d.%m.%Y %H:%M:%S")"
+    local status bg_pid mode="normal mode" rundate="$(/bin/date "+%d.%m.%Y %H:%M:%S")"
 
     if [ ${adb_rc} -gt 0 ]
     then
@@ -675,41 +683,23 @@ f_jsnupdate()
     json_add_string "adblock_status" "${status}"
     json_add_string "adblock_version" "${adb_ver}"
     json_add_string "overall_domains" "${adb_cnt} (${mode})"
-    json_add_string "fetch_utility" "${adb_fetchinfo}"
+    json_add_string "fetch_utility" "${adb_fetchinfo:-"-"}"
     json_add_string "dns_backend" "${adb_dns} (${adb_dnsdir})"
     json_add_string "last_rundate" "${rundate}"
     json_add_string "system_release" "${adb_sysver}"
     json_close_object
     json_dump > "${adb_rtfile}"
 
-    if [ ${adb_notify} -eq 1 ] && [ -x /etc/adblock/adblock.notify ] && ([ "${status}" = "error" ] || \
+    if [ ${adb_notify} -eq 1 ] && [ -x /etc/adblock/adblock.notify ] && ([ "${status}" = "error" ] ||\
         ([ "${status}" = "enabled" ] && [ ${adb_whitelist_mode} -eq 0 ] && [ ${adb_cnt} -le ${adb_notifycnt} ]))
     then
         (/etc/adblock/adblock.notify >/dev/null 2>&1) &
+        bg_pid=${!}
     fi
+    f_log "debug" "f_jsnup::: status: ${status}, mode: ${mode}, cnt: ${adb_cnt}, notify: ${adb_notify}, notify_cnt: ${adb_notifycnt}, notify_pid: ${bg_pid:-"-"}"
 }
 
-# output runtime information
-#
-f_status()
-{
-    local key keylist value
-
-    if [ -s "${adb_rtfile}" ]
-    then
-        printf "%s\n" "::: adblock runtime information"
-        json_load "$(cat "${adb_rtfile}" 2>/dev/null)"
-        json_select data
-        json_get_keys keylist
-        for key in ${keylist}
-        do
-            json_get_var value "${key}"
-            printf "  + %-15s : %s\n" "${key}" "${value}"
-        done
-    fi
-}
-
-# write to syslog, exit on error
+# write to syslog
 #
 f_log()
 {
@@ -717,14 +707,13 @@ f_log()
 
     if [ -n "${log_msg}" ] && ([ "${class}" != "debug" ] || [ ${adb_debug} -eq 1 ])
     then
-        logger -t "adblock-[${adb_ver}] ${class}" "${log_msg}"
-        if [ "${class}" = "error" ]
+        logger -p "${class}" -t "adblock-[${adb_ver}]" "${log_msg}"
+        if [ "${class}" = "err" ]
         then
-            adb_rc=1
             f_rmdns
-            f_jsnupdate
+            f_jsnup
             f_rmtemp
-            logger -t "adblock-[${adb_ver}] ${class}" "Please check 'https://github.com/openwrt/packages/blob/master/net/adblock/files/README.md' (${adb_sysver})"
+            logger -p "${class}" -t "adblock-[${adb_ver}]" "Please also check 'https://github.com/openwrt/packages/blob/master/net/adblock/files/README.md' (${adb_sysver})"
             exit 1
         fi
     fi
@@ -736,9 +725,10 @@ f_main()
 {
     local src_name src_rset shalla_archive enabled url mem_total="$(awk '/^MemTotal/ {print int($2/1000)}' "/proc/meminfo")"
 
-    f_log "debug" "dns: ${adb_dns}, fetch_util: ${adb_fetchinfo}, backup: ${adb_backup}, backup_mode: ${adb_backup_mode}, whitelist_mode: ${adb_whitelist_mode}, force_srt/_dns: ${adb_forcesrt}/${adb_forcedns}, mem_total: ${mem_total}"
+    f_log "debug" "f_main ::: dns: ${adb_dns}, fetch_util: ${adb_fetchinfo}, backup: ${adb_backup}, backup_mode: ${adb_backup_mode}, whitelist_mode: ${adb_whitelist_mode}, force_srt: ${adb_forcesrt}, force_dns: ${adb_forcedns}, mem_total: ${mem_total}"
     > "${adb_rtfile}"
     > "${adb_dnsdir}/.${adb_dnsfile}"
+    > "${adb_tmpdir}/tmp.whitelist"
 
     # prepare whitelist entries
     #
@@ -757,8 +747,8 @@ f_main()
     #
     if [ ${adb_whitelist_mode} -eq 1 ] && [ "${adb_dns}" != "dnscrypt-proxy" ]
     then
-        f_hashcompare
-        f_tldcompression "${adb_tmpdir}/tmp.whitelist"
+        f_hash
+        f_tld "${adb_tmpdir}/tmp.whitelist"
         eval "${adb_dnsformat}" "${adb_tmpdir}/tmp.whitelist" > "${adb_dnsdir}/${adb_dnsfile}"
         printf '%s\n' "${adb_dnsblock}" >> "${adb_dnsdir}/${adb_dnsfile}"
         if [ -n "${adb_dnsheader}" ]
@@ -766,20 +756,19 @@ f_main()
             printf '%s\n' "${adb_dnsheader}" | cat - "${adb_dnsdir}/${adb_dnsfile}" > "${adb_tmpdir}/${adb_dnsfile}"
             cat "${adb_tmpdir}/${adb_dnsfile}" > "${adb_dnsdir}/${adb_dnsfile}"
         fi
-        f_hashcompare
+        f_hash
         if [ ${?} -eq 1 ]
         then
-            f_dnsrestart
+            f_dnsup
         fi
-        if [ ${?} -eq 0 ]
+        f_jsnup
+        if [ ${adb_rc} -eq 0 ]
         then
-            f_jsnupdate "${adb_cnt}"
-            f_log "info " "whitelist with overall ${adb_cnt} domains loaded successfully (${adb_sysver})"
+            f_log "info" "whitelist with overall ${adb_cnt} domains loaded successfully (${adb_sysver})"
+            return 0
         else
-            f_log "error" "dns backend restart with active whitelist failed"
+            f_log "err" "dns backend restart with active whitelist failed"
         fi
-        f_rmtemp
-        return
     fi
 
     # normal & backup mode processing
@@ -791,11 +780,11 @@ f_main()
         eval "src_rset=\"\${adb_src_rset_${src_name}}\""
         > "${adb_tmpload}"
         > "${adb_tmpfile}"
-        adb_rc=4
+        adb_rc=1
 
         # basic pre-checks
         #
-        f_log "debug" "name: ${src_name}, enabled: ${enabled}"
+        f_log "debug" "f_main ::: name: ${src_name}, enabled: ${enabled}"
         if [ "${enabled}" != "1" ] || [ -z "${url}" ] || [ -z "${src_rset}" ]
         then
             f_list remove
@@ -816,10 +805,13 @@ f_main()
 
         # download blocklist
         #
-        if [ "${src_name}" = "blacklist" ] && [ -s "${url}" ]
+        if [ "${src_name}" = "blacklist" ]
         then
-            cat "${url}" > "${adb_tmpload}"
-            adb_rc=${?}
+            if [ -s "${url}" ]
+            then
+                cat "${url}" > "${adb_tmpload}"
+                adb_rc=${?}
+            fi
         elif [ "${src_name}" = "shalla" ]
         then
             shalla_archive="${adb_tmpdir}/shallalist.tar.gz"
@@ -851,15 +843,20 @@ f_main()
             awk "${src_rset}" "${adb_tmpload}" 2>/dev/null > "${adb_tmpfile}"
             if [ -s "${adb_tmpfile}" ]
             then
-                f_tldcompression "${adb_tmpfile}"
-                if [ "${src_name}" != "blacklist" ]
+                if [ ${mem_total} -lt 64 ] && [ ${adb_forcesrt} -eq 0 ]
+                then
+                    f_tld "${adb_tmpfile}"
+                fi
+                if [ ${adb_backup} -eq 1 ] && [ "${src_name}" != "blacklist" ]
                 then
                     f_list backup
                 fi
-            else
+            elif [ ${adb_backup} -eq 1 ]
+            then
                 f_list restore
             fi
-        else
+        elif [ ${adb_backup} -eq 1 ] && [ "${src_name}" != "blacklist" ]
+        then
             f_list restore
         fi
 
@@ -879,32 +876,31 @@ f_main()
 
     # overall sort and conditional dns restart
     #
-    f_hashcompare
+    f_hash
     if [ -s "${adb_tmpdir}/${adb_dnsfile}" ]
     then
         if [ ${mem_total} -ge 64 ] || [ ${adb_forcesrt} -eq 1 ]
         then
-            f_tldcompression "${adb_tmpdir}/${adb_dnsfile}"
+            f_tld "${adb_tmpdir}/${adb_dnsfile}"
         fi
-        f_list format
+        f_list final
     else
         > "${adb_dnsdir}/${adb_dnsfile}"
     fi
     chown "${adb_dnsuser}" "${adb_dnsdir}/${adb_dnsfile}" 2>/dev/null
 
-    f_hashcompare
+    f_hash
     if [ ${?} -eq 1 ]
     then
-        f_dnsrestart
+        f_dnsup
     fi
-    if [ ${?} -eq 0 ]
+    f_jsnup
+    if [ ${adb_rc} -eq 0 ]
     then
-        f_jsnupdate "${adb_cnt}"
-        f_log "info " "blocklist with overall ${adb_cnt} domains loaded successfully (${adb_sysver})"
+        f_log "info" "blocklist with overall ${adb_cnt} domains loaded successfully (${adb_sysver})"
     else
-        f_log "error" "dns backend restart with active blocklist failed"
+        f_log "err" "dns backend restart with active blocklist failed"
     fi
-    f_rmtemp
 }
 
 # handle different adblock actions
@@ -915,8 +911,8 @@ case "${adb_action}" in
         f_rmdns
     ;;
     restart)
-        f_envcheck
         f_rmdns
+        f_envcheck
         f_main
     ;;
     suspend)
@@ -928,12 +924,11 @@ case "${adb_action}" in
     query)
         f_query "${2}"
     ;;
-    status)
-        f_status
-    ;;
-    *)
+    start|reload)
         f_envcheck
         f_main
     ;;
 esac
-exit 0
+
+f_rmtemp
+exit ${adb_rc}


### PR DESCRIPTION


Maintainer: me / @dibdot
Compile tested: -
Run tested: APU2 + Turris Omnia

Description:
* enable code to support Turris Omnia forthcoming upstream change
  (new kresd 'keep_cache' option) to preserve kresd DNS cache
* fix a 'status' race condition while the adblock process
  is running in parallel
* various small speed improvements
* rework debug output
* refine blacklist handling
* enable the (empty) blacklist source in the default config
* email notification supports mstmp, even without sendmail symlink
* email notification writes minimal status to log (one-liner)
* LuCI: refine logfile search term
* LuCI: Textarea 'autoscroll down' in logfile view
* LuCI: Left-align blocklist source table plus a more compact design

Signed-off-by: Dirk Brenken <dev@brenken.org>