### PR TITLE
Reaver: "config.h is no longer needed"

### DIFF
--- a/net/reaver/Makefile
+++ b/net/reaver/Makefile
@@ -10,12 +10,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=reaver
 PKG_VERSION:=1.6.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/t6x/reaver-wps-fork-t6x/releases/download/v$(PKG_VERSION)
-PKG_HASH:=191f785f53030e4803260ada1a29ca4b42c848d56f6f3982e320d03b6117aaf2
+PKG_HASH:=1fbdf8d76ee4e5fe2c39e1a3eb2f3b46b1de968b
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=docs/LICENSE


### PR DESCRIPTION
"i keep getting reports of people who are not capable of reading README
which states that ./configure must be used, and then get a build error
because they miss config.h.

since 10e7637 it is no longer needed
anyway, the only thing we took from config.h was the version numer
passed in the macro PACKAGE_VERSION."

From original Reaver repository commit.

Please double check that your commits:
- all start with "<package name>: "
- all contain signed-off-by
- are linked to your github account (you see your logo in front of them) 

Please also read https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md

Thanks for your contribution
Please remove this text (before ---) and fill the following template
-------------------------------

Maintainer: me / @<github-user>
Compile tested: (put here arch, model, OpenWRT/LEDE version)
Run tested: (put here arch, model, OpenWRT/LEDE version, tests done)

Description:
