### PR TITLE
knot: update to 2.6.4

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014-2017 CZ.NIC, z.s.p.o. <knot-dns@labs.nic.cz>
+# Copyright (C) 2014-2018 CZ.NIC, z.s.p.o. <knot-dns@labs.nic.cz>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=2.5.6
+PKG_VERSION:=2.6.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=37d1625c2aaefe2394c85f6742a6ae9421e8348318c13119a6c451796c387cfc
+PKG_HASH:=1d0d37b5047ecd554d927519d5565c29c1ba9b501c100eb5f3a5af184d75386a
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD MIT OLDAP-2.8


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, Turris Omnia, OpenWRT 15.05
Run tested: mvebu, Turris Omnia, OpenWRT 15.05, manually tested, unittests pass