### PR TITLE
lighttpd: fix PKG_CONFIG_DEPENDS (fixes #4210)

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -21,7 +21,9 @@ PKG_LICENSE_FILES:=COPYING
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
-PKG_CONFIG_DEPENDS:=CONFIG_LIGHTTPD_SSL
+REBUILD_MODULES=authn_gssapi authn_ldap authn_mysql cml magnet mysql_vhost trigger_b4_dl webdav
+
+PKG_CONFIG_DEPENDS:=CONFIG_LIGHTTPD_SSL $(patsubst %,CONFIG_PACKAGE_lighttpd-mod-%,$(REBUILD_MODULES))
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Signed-off-by: Michael Heimpold <mhei@heimpold.de>

Maintainer: @MikePetullo
Compile tested: arm, mxs, I2SE Duckbill
Run tested: no

Description:
Populate PKG_CONFIG_DEPENDS according to proposal in issue #4210.