### PR TITLE
admin/netdata: Update to 1.9.0

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.8.0
+PKG_VERSION:=1.9.0
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Daniel Engberg <daniel.engberg.lists@pyret.net>
+PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/firehol/netdata/releases/download/v$(PKG_VERSION)
-PKG_HASH:=1624a3b02f07dc8881b8edd5899049d4d3d53e485424ffb2fb65a322e2ff82c3
+PKG_HASH:=2358f2239e2d62da82af9f8b9ec8e6b1d37ac6cb009a15cf4c1d2cc2638a87e7
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
@@ -26,7 +26,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/netdata
   SECTION:=admin
   CATEGORY:=Administration
-  DEPENDS:=+zlib +libuuid
+  DEPENDS:=+zlib +libuuid +libmnl
   TITLE:=Real-time performance monitoring tool
   URL:=https://my-netdata.io/
 endef
@@ -36,7 +36,8 @@ define Package/netdata/description
   monitoring for Linux systems, applications and SNMP devices over the web.
 endef
 
-TARGET_CFLAGS += -ffunction-sections -fdata-sections
+TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS))
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -O3
 TARGET_LDFLAGS += -Wl,--gc-sections
 
 CONFIGURE_ARGS += --with-zlib --with-math --disable-x86-sse --disable-lto
@@ -57,7 +58,6 @@ define Package/netdata/install
 	rm $(1)/usr/share/netdata/web/fonts/*.svg
 	rm $(1)/usr/share/netdata/web/fonts/*.ttf
 	rm $(1)/usr/share/netdata/web/fonts/*.woff
-	rm $(1)/usr/share/netdata/web/fonts/*.otf
 	mkdir -p $(1)/usr/lib/netdata
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/netdata $(1)/usr/lib
 	rm $(1)/usr/lib/netdata/python.d/python-modules-installer.sh


### PR DESCRIPTION
Maintainer: 
Compile tested: ramips, D-Link DIR-860L, OpenWrt trunk
Run tested: ramips, D-Link DIR-860L, OpenWrt trunk

Description:
Update netdata to 1.9.0
O3 optimization which is set as default by upstream
Remove myself as maintainer

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>


  