### PR TITLE
sipgrep: Update to snapshot 20161008

### DIFF
--- a/net/sipgrep/Makefile
+++ b/net/sipgrep/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 Daniel Engberg <daniel.engberg.lists@pyret.net>
+# Copyright (C) 2016-2018 Daniel Engberg <daniel.engberg.lists@pyret.net>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,18 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sipgrep
-PKG_VERSION:=20160914-devel
+PKG_VERSION:=snapshot-20161008
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Daniel Engberg <daniel.engberg.lists@pyret.net>
+PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/sipcapture/sipgrep
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=df8a95b066569be92aa38cad01086ea595b36863
+PKG_SOURCE_URL:=https://codeload.github.com/sipcapture/$(PKG_NAME)/tar.gz/c974e75?dummy=/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MIRROR_HASH:=a9131ae443bdce760e3dadd83dcf115d51a894381fc18461cbe62522618418fa
+PKG_HASH:=94114f79ed638ad7ea7f2a2ca2df740b6bbd7ea5ee1ffb7cd465427cda0f3d90
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-c974e75
 
 PKG_FIXUP:=autoreconf
 


### PR DESCRIPTION
Maintainer: 
Compile tested: ramips, D-Link DIR-860L, OpenWrt trunk
Run tested: ramips, D-Link DIR-860L, OpenWrt trunk

Description:
Update sipgrep to snapshop 20161008
Drop git and use github generated tarball instead
Remove myself as maintainer

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>