### PR TITLE
fdk-aac: Update to snapshot 20171220

### DIFF
--- a/sound/fdk-aac/Makefile
+++ b/sound/fdk-aac/Makefile
@@ -6,27 +6,25 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fdk-aac
-PKG_VERSION:=0.1.5-20171120
+PKG_VERSION:=snapshot-20171220
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=Fraunhofer-FDK-AAC-for-Android
 PKG_LICENSE_FILES:=NOTICE
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL=https://github.com/mstorsjo/fdk-aac/
-PKG_SOURCE_SUBDIR=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=56c717e223a161b11f523de97dae51c5cccd6b52
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MIRROR_HASH:=c0c035df410697bb753fc06f03bacc0079b4c456a571718b3fabb568c05c41ce
+PKG_SOURCE_URL:=https://codeload.github.com/mstorsjo/$(PKG_NAME)/tar.gz/89aeea5?dummy=/
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=0b388225a9613d272c7c4af801094cdf7fc944763f82b0c750593b1a02d98254
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-89aeea5
 
 PKG_FIXUP:=autoreconf
 
 PKG_CONFIG_DEPENDS:= CONFIG_FDK-AAC_OPTIMIZE_SPEED
 
 ifeq ($(CONFIG_FDK-AAC_OPTIMIZE_SPEED),y)
-	TARGET_CFLAGS := $(filter-out -Os,$(TARGET_CFLAGS))
+	TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS))
 	TARGET_CFLAGS += $(TARGET_CFLAGS) -O2 -flto
-	TARGET_CXXFLAGS := $(filter-out -Os,$(TARGET_CXXFLAGS))
+	TARGET_CXXFLAGS := $(filter-out -O%,$(TARGET_CXXFLAGS))
 	TARGET_CXXFLAGS += $(TARGET_CXXFLAGS) -O2 -flto
 	TARGET_LDFLAGS += $(TARGET_LDFLAGS) -flto
 endif
@@ -49,7 +47,7 @@ define Package/fdk-aac/config
 	source "$(SOURCE)/Config.in"
 endef
 
-define Package/fdk-aac/install	
+define Package/fdk-aac/install
 	$(INSTALL_DIR) $(1)/usr/lib/
 	$(CP) $(PKG_BUILD_DIR)/.libs/*.so* $(1)/usr/lib/
 endef


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: mvebu, Linksys WRT3200ACM, OpenWrt trunk
Run tested: mvebu, Linksys WRT3200ACM, OpenWrt trunk

Description:

Update fdk-aac to snapshot 20171220
Drop git and use github generated tarball instead
Adjust optimization filter
Remove stray whitespace

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>