### PR TITLE
fio: Add to repo

### DIFF
--- a/utils/fio/Makefile
+++ b/utils/fio/Makefile
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2018 Daniel Engberg <daniel.engberg.lists@pyret.net>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fio
+PKG_VERSION:=3.6
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Dragan Stancevic <ds@codeminutia.com>
+PKG_LICENSE:=GPL-2.0+
+PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE_URL:=http://brick.kernel.dk/snaps
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_HASH:=026a2cbb4a1bc9810f13f23d07eb146dbd4325bb467221dc49b88915ee8a52b4
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/fio
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Disc
+  DEPENDS:=+libaio +zlib
+  TITLE:=I/O testing and benchmarking tool
+  URL:=https://github.com/axboe/fio
+endef
+
+define Package/fio/description
+  Fio is an I/O testing tool that will spawn a number of threads or
+  processes doing a particular type of I/O action as specified by
+  the user. Fio can be driven by a 'job file' describing the I/O
+  load one wants to simulate.
+endef
+
+TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS))
+
+CONFIGURE_ARGS = \
+	--disable-numa \
+	--disable-rdma \
+	--disable-rados \
+	--disable-rbd \
+	--disable-gfapi \
+	--disable-lex \
+	--disable-pmem \
+	--disable-native \
+	--cc="$(TARGET_CC)" \
+	--extra-cflags="$(TARGET_CFLAGS)"
+
+define Package/fio/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/fio $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,fio))


### PR DESCRIPTION
Maintainer:
Compile tested: ramips, D-Link DIR-860L, OpenWrt trunk
Run tested: ramips, D-Link DIR-860L, OpenWrt trunk

Description:
Add fio to repo

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>