### PR TITLE
pcsc-tools: remove myself as maintainer

### DIFF
--- a/utils/pcsc-tools/Makefile
+++ b/utils/pcsc-tools/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=pcsc-tools
 PKG_VERSION=1.5.2
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Daniel Engberg <daniel.engberg.lists@pyret.net>
+PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 


### PR DESCRIPTION
Maintainer:
Compile tested: Not needed
Run tested: Not needed

Description:
Remove myself as maintainer

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>