### PR TITLE
openvswitch: don't attempt to use sphinx-build found on the build host

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -159,6 +159,7 @@ TARGET_CFLAGS += -flto -std=gnu99
 CONFIGURE_VARS += \
 	ovs_cv_flake8=no \
 	ovs_cv_python3=no \
+	ovs_cv_sphinx=no \
 	KARCH=$(LINUX_KARCH)
 
 MAKE_FLAGS += \


### PR DESCRIPTION
Maintainer: @commodo
Compile tested: x86-64
Run tested: no, issue affects build only

Description:

openvswitch fails to build on my Arch Linux system, as it tries to use my build
host's sphinx-build with OpenWrt's python. Add an override to ensure this can't
happen.