### PR TITLE
python-cryptography: update to 2.1.4, refresh patches

### DIFF
--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2016 OpenWrt.org
+# Copyright (C) 2015-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptography
-PKG_VERSION:=2.1.3
+PKG_VERSION:=2.1.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=cryptography-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/f3/7c/ec4f94489719803cb14d35e9625d1f5a613b9c4b8d01ee52a4c77485e681
-PKG_HASH:=68a26c353627163d74ee769d4749f2ee243866e9dac43c93bb33ebd8fbed1199
+PKG_SOURCE_URL:=https://pypi.python.org/packages/78/c5/7188f15a92413096c93053d5304718e1f6ba88b818357d05d19250ebff85
+PKG_HASH:=e4d967371c5b6b2e67855066471d844c5d52d210c36c28d49a8507b96e2c5291
 
 PKG_LICENSE:=Apache-2.0 BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.APACHE LICENSE.BSD

--- a/lang/python/python-cryptography/patches/001-disable-setup-requirements.patch
+++ b/lang/python/python-cryptography/patches/001-disable-setup-requirements.patch
@@ -1,8 +1,6 @@
-diff --git a/setup.py b/setup.py
-index b5c05df..a777dd7 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -266,6 +266,7 @@ class DummyPyTest(test):
+@@ -235,6 +235,7 @@ class DummyPyTest(test):
  with open(os.path.join(base_dir, "README.rst")) as f:
      long_description = f.read()
  

--- a/lang/python/python-cryptography/patches/002-remove-undefined-dtls-methods.patch
+++ b/lang/python/python-cryptography/patches/002-remove-undefined-dtls-methods.patch
@@ -1,8 +1,6 @@
-diff --git a/src/_cffi_src/openssl/ssl.py b/src/_cffi_src/openssl/ssl.py
-index 8bda4e0..aa81060 100644
 --- a/src/_cffi_src/openssl/ssl.py
 +++ b/src/_cffi_src/openssl/ssl.py
-@@ -595,9 +595,6 @@ static const long TLS_ST_OK = 0;
+@@ -597,9 +597,6 @@ static const long TLS_ST_OK = 0;
  
  #if defined(OPENSSL_NO_DTLS) || CRYPTOGRAPHY_OPENSSL_LESS_THAN_102
  static const long Cryptography_HAS_GENERIC_DTLS_METHOD = 0;


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWRT/LEDE trunk
Run tested: none

Description:
python-cryptography: update to 2.1.4, refresh patches

Signed-off-by: Jeffery To <jeffery.to@gmail.com>