### PR TITLE
python-ipaddress: update to 1.0.19

### DIFF
--- a/lang/python/python-ipaddress/Makefile
+++ b/lang/python/python-ipaddress/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2016 OpenWrt.org
+# Copyright (C) 2015-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ipaddress
-PKG_VERSION:=1.0.17
+PKG_VERSION:=1.0.19
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/bb/26/3b64955ff73f9e3155079b9ed31812afdfa5333b5c76387454d651ef593a
-PKG_HASH:=3a21c5a15f433710aaa26f1ae174b615973a25182006ae7f9c26de151cd51716
+PKG_SOURCE_URL:=https://pypi.python.org/packages/f0/ba/860a4a3e283456d6b7e2ab39ce5cf11a3490ee1a363652ac50abf9f0f5df
+PKG_HASH:=200d8686011d470b5e4de207d803445deee427455cd0cb7c982b68cf82524f81
 
 PKG_LICENSE:=Python-2.0
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWRT/LEDE trunk
Run tested: none

Description:
python-ipaddress: update to 1.0.19

Signed-off-by: Jeffery To <jeffery.to@gmail.com>