### PR TITLE
Pulseaudio: Disable-bluez in Makefile is not valid since Pulseaudio 7.0

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -94,7 +94,6 @@ CONFIGURE_ARGS += \
 	--disable-jack \
 	--disable-asyncns \
 	--disable-lirc \
-	--disable-bluez \
 	--disable-udev \
 	--without-fftw \
 	--disable-avahi \


### PR DESCRIPTION
Bluez getting compiled depends on e.g. enable-bluez5 and others (e.g. sbc, dbus). Is otherwise harmless, but confusing.

Maintainer: @tripolar 
Compile tested: (x86/generic/Master (Lede snapshop))
Run tested: (x86/generic/Master (Lede snapshop))
Signed-off-by: Johnny Vogels
