### PR TITLE
python-pyopenssl: update to 17.5.0

### DIFF
--- a/lang/python/python-pyopenssl/Makefile
+++ b/lang/python/python-pyopenssl/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2017 OpenWrt.org
+# Copyright (C) 2015-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -7,13 +7,13 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=pyOpenSSL
-PKG_VERSION:=17.3.0
+PKG_NAME:=python-pyopenssl
+PKG_VERSION:=17.5.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/ee/6a/cd78737dd990297205943cc4dcad3d3c502807fd2c5b18c5f33dc90ca214
-PKG_HASH:=29630b9064a82e04d8242ea01d7c93d70ec320f5e3ed48e95fcabc6b1d0f6c76
+PKG_SOURCE:=pyOpenSSL-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/3b/15/a5d90ab1a41075e8f0fae334f13452549528f82142b3b9d0c9d86ab7178c
+PKG_HASH:=2c10cfba46a52c0b0950118981d61e72c1e5b1aac451ca1bc77de1a679456773
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWRT/LEDE trunk
Run tested: none

Description:
python-pyopenssl: update to 17.5.0

Signed-off-by: Jeffery To <jeffery.to@gmail.com>