### PR TITLE
python-service-identity: update to 17.0.0, add python3 variant

### DIFF
--- a/lang/python/python-service-identity/Makefile
+++ b/lang/python/python-service-identity/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 OpenWrt.org
+# Copyright (C) 2016-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -7,13 +7,15 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=service_identity
-PKG_VERSION:=16.0.0
+PKG_NAME:=python-service-identity
+PKG_VERSION:=17.0.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/s/service_identity
-PKG_HASH:=0630e222f59f91f3db498be46b1d879ff220955d7bbad719a5cb9ad14e3c3036
+PKG_SOURCE:=service_identity-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/de/2a/cab6e30be82c8fcd2339ef618036720eda954cf05daef514e386661c9221
+PKG_HASH:=4001fbb3da19e0df22c47a06d29681a398473af4aa9d745eca525b3b2c2302ab
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-service-identity-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -21,14 +23,39 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-service-identity/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://github.com/pyca/service_identity
+endef
 
 define Package/python-service-identity
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-service-identity
-	URL:=https://github.com/pyca/service_identity
-	DEPENDS:=+python-light +python-attrs +python-pyasn1 +python-pyasn1-modules +python-pyopenssl
+$(call Package/python-service-identity/Default)
+  TITLE:=python-service-identity
+  DEPENDS:= \
+      +PACKAGE_python-service-identity:python-light \
+      +PACKAGE_python-service-identity:python-attrs \
+      +PACKAGE_python-service-identity:python-pyasn1 \
+      +PACKAGE_python-service-identity:python-pyasn1-modules \
+      +PACKAGE_python-service-identity:python-pyopenssl
+  VARIANT:=python
+endef
+
+define Package/python3-service-identity
+$(call Package/python-service-identity/Default)
+  TITLE:=python3-service-identity
+  DEPENDS:= \
+      +PACKAGE_python3-service-identity:python3-light \
+      +PACKAGE_python3-service-identity:python3-attrs \
+      +PACKAGE_python3-service-identity:python3-pyasn1 \
+      +PACKAGE_python3-service-identity:python3-pyasn1-modules \
+      +PACKAGE_python3-service-identity:python3-pyopenssl
+  VARIANT:=python3
 endef
 
 define Package/python-service-identity/description
@@ -36,9 +63,14 @@ service_identity aspires to give you all the tools you need for
 verifying whether a certificate is valid for the intended purposes.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
+define Package/python3-service-identity/description
+$(call Package/python-service-identity/description)
+.
+(Variant for Python3)
 endef
 
 $(eval $(call PyPackage,python-service-identity))
 $(eval $(call BuildPackage,python-service-identity))
+
+$(eval $(call Py3Package,python3-service-identity))
+$(eval $(call BuildPackage,python3-service-identity))


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWRT/LEDE trunk
Run tested: none

Description:
python-service-identity: update to 17.0.0, add python3 variant

Signed-off-by: Jeffery To <jeffery.to@gmail.com>