### PR TITLE
utils/mksh: update to r56b

### DIFF
--- a/utils/mksh/Makefile
+++ b/utils/mksh/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mksh
-PKG_VERSION:=55
+PKG_VERSION:=56b
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Thorsten Glaser <tg@mirbsd.org>
@@ -18,7 +18,7 @@ PKG_LICENSE:=MirOS
 PKG_SOURCE:=$(PKG_NAME)-R$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=http://www.mirbsd.org/MirOS/dist/mir/mksh \
 		http://pub.allbsd.org/MirOS/dist/mir/mksh
-PKG_HASH:=ced42cb4a181d97d52d98009eed753bd553f7c34e6991d404f9a8dcb45c35a57
+PKG_HASH:=40ec744eec256583e4e18907cde22af57c980286f535df47326fed07e48c9a7f
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/utils/mksh/patches/100-dot_mkshrc
+++ b/utils/mksh/patches/100-dot_mkshrc
@@ -20,15 +20,21 @@ Additional changes of the patch as of mksh-R55
 * Use `/etc/mkshrc` as default startup file, so there is no need to
   manually source it during interactive session.
 
+From: Alif M. A. <alive4ever@live.com>
+Date: Thu, 11 Jan 2018 02:13:46 +0000
+Subject: [PATCH] Refresh 100-dot_mkshrc for mksh-R55
+
+Refreshed 100-dot_mkshrc for mksh-r56b
+
 ---
 Reviewed-by: Thorsten Glaser <tg at mirbsd.org>
 Signed-off-by: Alif M. A. <alive4ever at live.com>
 
 --- a/dot.mkshrc
 +++ b/dot.mkshrc
-@@ -56,10 +56,9 @@
- 	done
- )
+@@ -63,10 +63,9 @@
+ 	EDITOR=
+ done
  
 -\\builtin alias ls=ls l='ls -F' la='l -a' ll='l -l' lo='l -alo'
 -\: "${HOSTNAME:=$(\\builtin ulimit -c 0; \\builtin print -r -- $(hostname \


### PR DESCRIPTION
Maintainer: me / @mirabilos 
Compile tested: x86_64, personal laptop, OpenWrt SNAPSHOT r5743-377c4a68fe
Run tested: qemu-system-x86_64 version 2.11.0 with kvm, OpenWrt SNAPSHOT r5743-377c4a68fe

Description:
Updated to mksh-r56b
