### PR TITLE
python-enum34: use default variant build/compile rule, add src package

### DIFF
--- a/lang/python/python-enum34/Makefile
+++ b/lang/python/python-enum34/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2016 OpenWrt.org
+# Copyright (C) 2015-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -7,13 +7,15 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=enum34
+PKG_NAME:=python-enum34
 PKG_VERSION:=1.1.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=enum34-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/bf/3e/31d502c25302814a7c2f1d3959d2a3b3f78e509002ba91aea64993936876
 PKG_HASH:=8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-enum34-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=enum/LICENSE
@@ -22,13 +24,20 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-enum34/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://pypi.python.org/pypi/enum34/
+endef
+
 define Package/python-enum34
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-enum34
-	URL:=https://pypi.python.org/pypi/enum34/
-	DEPENDS:=+python-light
+$(call Package/python-enum34/Default)
+  TITLE:=python-enum34
+  DEPENDS:=+PACKAGE_python-enum34:python-light
+  VARIANT:=python
 endef
 
 define Package/python-enum34/description
@@ -41,9 +50,6 @@ define PyPackage/python-enum34/filespec
 -|$(PYTHON_PKG_DIR)/enum/test.py
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
 $(eval $(call PyPackage,python-enum34))
 $(eval $(call BuildPackage,python-enum34))
+$(eval $(call BuildPackage,python-enum34-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWRT/LEDE trunk
Run tested: none

Description:
python-enum34: use default variant build/compile rule, add src package

Signed-off-by: Jeffery To <jeffery.to@gmail.com>