### PR TITLE
ddns-scripts: multiple fixes

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2017 OpenWrt.org
+# Copyright (C) 2008-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 #
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.7
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/dynamic_dns_lucihelper.sh
+++ b/net/ddns-scripts/files/dynamic_dns_lucihelper.sh
@@ -2,7 +2,7 @@
 # /usr/lib/ddns/dynamic_dns_lucihelper.sh
 #
 #.Distributed under the terms of the GNU General Public License (GPL) version 2.0
-#.2014-2017 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+#.2014-2018 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 # This script is used by luci-app-ddns
 #
 # variables in small chars are read from /etc/config/ddns as parameter given here
@@ -104,6 +104,7 @@ case "$1" in
 	get_registered_ip)
 		[ -z "$lookup_host" ] && usage_err "command 'get_registered_ip': 'lookup_host' not set" 
 		write_log 7 "-----> get_registered_ip IP"
+		[ -z "$SECTION" ] || IPFILE="$ddns_rundir/$SECTION.ip"
 		IP=""
 		get_registered_ip IP
 		__RET=$?

--- a/net/ddns-scripts/files/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/dynamic_dns_updater.sh
@@ -6,7 +6,7 @@
 # (Loosely) based on the script on the one posted by exobyte in the forums here:
 # http://forum.openwrt.org/viewtopic.php?id=14040
 # extended and partial rewritten
-#.2014-2017 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+#.2014-2018 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 #
 # variables in small chars are read from /etc/config/ddns
 # variables in big chars are defined inside these scripts as global vars
@@ -101,6 +101,7 @@ PIDFILE="$ddns_rundir/$SECTION_ID.pid"	# Process ID file
 UPDFILE="$ddns_rundir/$SECTION_ID.update"	# last update successful send (system uptime)
 DATFILE="$ddns_rundir/$SECTION_ID.dat"	# save stdout data of WGet and other extern programs called
 ERRFILE="$ddns_rundir/$SECTION_ID.err"	# save stderr output of WGet and other extern programs called
+IPFILE="$ddns_rundir/$SECTION_ID.ip"	#
 LOGFILE="$ddns_logdir/$SECTION_ID.log"	# log file
 
 # VERBOSE > 1 delete logfile if exist to create an empty one

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -67,6 +67,8 @@
 
 "dnsdynamic.org"	"http://[USERNAME]:[PASSWORD]@www.dnsdynamic.org/api/?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
+"dnsever.com"		"http://[USERNAME]:[PASSWORD]@dyna.dnsever.com/update.php?host[[DOMAIN]]"
+
 "dnsexit.com"		"http://update.dnsexit.com/RemoteUpdate.sv?login=[USERNAME]&password=[PASSWORD]&host=[DOMAIN]&myip=[IP]"
 
 "dnshome.de"		"http://[USERNAME]:[PASSWORD]@www.dnshome.de/dyndns.php?hostname=[DOMAIN]&ip=[IP]"
@@ -121,6 +123,8 @@
 "loopia.se"		"http://[USERNAME]:[PASSWORD]@dns.loopia.se/XDynDNSServer/XDynDNS.php?system=custom&hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 "mydns.jp"		"http://www.mydns.jp/directip.html?MID=[USERNAME]&PWD=[PASSWORD]&IPV4ADDR=[IP]"
+
+"myip.co.ua"		"http://[USERNAME]:[PASSWORD]@myip.co.ua/update?hostname=[DOMAIN]&myip=[IP]"	"good"
 
 "myonlineportal.net"	"http://[USERNAME]:[PASSWORD]@myonlineportal.net/updateddns?hostname=[DOMAIN]&ip=[IP]"	"good|nochg"
 

--- a/net/ddns-scripts/files/services_ipv6
+++ b/net/ddns-scripts/files/services_ipv6
@@ -66,7 +66,7 @@
 "dyn.com"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 "dyndns.org"		"http://[USERNAME]:[PASSWORD]@members.dyndns.org/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
-"dynu.com"    "http://api.dynu.com/nic/update?hostname=[DOMAIN]&myipv6=[IP]&username=[USERNAME]&password=[PASSWORD]"
+"dynu.com"    		"http://api.dynu.com/nic/update?hostname=[DOMAIN]&myipv6=[IP]&username=[USERNAME]&password=[PASSWORD]"
 
 "dynv6.com"		"http://dynv6.com/api/update?hostname=[DOMAIN]&token=[PASSWORD]&ipv6=[IP]"	"updated|unchanged"
 

--- a/net/ddns-scripts/files/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/update_cloudflare_com_v4.sh
@@ -5,15 +5,16 @@
 # script for sending updates to cloudflare.com
 #.based on Ben Kulbertis cloudflare-update-record.sh found at http://gist.github.com/benkulbertis
 #.and on George Johnson's cf-ddns.sh found at https://github.com/gstuartj/cf-ddns.sh
-#.2016-2017 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+#.2016-2018 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 # CloudFlare API documentation at https://api.cloudflare.com/
 #
 # This script is parsed by dynamic_dns_functions.sh inside send_update() function
 #
 # using following options from /etc/config/ddns
-# option username - your cloudflare e-mail
-# option password - cloudflare api key, you can get it from cloudflare.com/my-account/
-# option domain   - "hostname@yourdomain.TLD"	# syntax changed to remove split_FQDN() function and tld_names.dat.gz
+# option username  - your cloudflare e-mail
+# option password  - cloudflare api key, you can get it from cloudflare.com/my-account/
+# option domain    - "hostname@yourdomain.TLD"	# syntax changed to remove split_FQDN() function and tld_names.dat.gz
+# option param_opt - Whether the record is receiving the performance and security benefits of Cloudflare (not empty => false)
 #
 # variable __IP already defined with the ip-address to use for update
 #
@@ -25,7 +26,7 @@
 [ $use_https -eq 0 ] && use_https=1	# force HTTPS
 
 # used variables
-local __HOST __DOMAIN __TYPE __URLBASE __PRGBASE __RUNPROG __DATA __IPV6 __ZONEID __RECID
+local __HOST __DOMAIN __TYPE __URLBASE __PRGBASE __RUNPROG __DATA __IPV6 __ZONEID __RECID __PROXIED
 local __URLBASE="https://api.cloudflare.com/client/v4"
 
 # split __HOST __DOMAIN from $domain
@@ -174,10 +175,16 @@ __DATA=$(grep -o '"content":"[^"]*' $DATFILE | grep -o '[^"]*$' | head -1)
 }
 
 # update is needed
-# let's build data to send,
+# let's build data to send
+# set proxied parameter (default "true")
+[ -z "$param_opt" ] && __PROXIED="true" || {
+	__PROXIED="false"
+	write_log 7 "Cloudflare 'proxied' disabled"
+}
+
 # use file to work around " needed for json
 cat > $DATFILE << EOF
-{"id":"$__ZONEID","type":"$__TYPE","name":"$__HOST","content":"$__IP"}
+{"id":"$__ZONEID","type":"$__TYPE","name":"$__HOST","content":"$__IP","proxied":$__PROXIED}
 EOF
 
 # let's complete transfer command

--- a/net/ddns-scripts/files/update_godaddy_com_v1.sh
+++ b/net/ddns-scripts/files/update_godaddy_com_v1.sh
@@ -4,7 +4,7 @@
 #
 # script for sending updates to godaddy.com
 #.based on GoDaddy.sh v1.0 by Nazar78 @ TeaNazaR.com
-#.2017 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
+#.2017-2018 Christian Schoenebeck <christian dot schoenebeck at gmail dot com>
 # GoDaddy Documentation at https://developer.godaddy.com/doc
 #
 # This script is parsed by dynamic_dns_functions.sh inside send_update() function
@@ -85,6 +85,7 @@ godaddy_transfer() {
 		write_log 7 "$(cat $DATFILE)"
 		return 1
 	}
+	return 0
 }
 
 # Build base command to use


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE 17.01.4 x86/ar71xx
Run tested: OpenWRT 15.05 WNDR3800 / LEDE 17.01.4 VirtualBox

Description:
Write *.ip file with current registered IP, whenever "get_registered_IP" is called (used by next luci-app-ddns version)
Changed detection of cURL proxy support #3876
Reread data from ubus if "get_local_ip" from "ip_network" #5004 #3338
Fix godaddy_com_v1 #5285
Implement "param_opt" for "cloudflare_com_v4" #5097
Inside logfile "*password*" printed in stead of real password #5281 and others
Add ipv4 service "dnsever.com" #5178
Add ipv4 service "myip.co.ua" #5199

Signed-off-by: Christian Schoenebeck <christian.schoenebeck@gmail.com>
