### PR TITLE
getdns_and_stubby: Initial commit for lede/openwrt support

### DIFF
--- a/libs/getdns/Config.in
+++ b/libs/getdns/Config.in
@@ -1,0 +1,16 @@
+menu "Configuration"
+	depends on PACKAGE_getdns
+
+config GETDNS_ENABLE_STUB_ONLY
+	bool "GETDNS_ENABLE_STUB_ONLY"
+	help
+		getdns can be configured for stub resolution mode only. (Removes libunbound dependency)
+	default y
+	
+config GETDNS_ENABLE_IDN
+	bool "GETDNS_ENABLE_IDN"
+	help 
+		getdns can be configured with some IDN Support. (Requires libidn dependency)
+	default n
+
+endmenu

--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -1,0 +1,73 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=getdns
+PKG_VERSION:=1.3.0
+PKG_RELEASE:=1
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=David Mora <iamperson347+public@gmail.com>
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://getdnsapi.net/dist/
+PKG_HASH:=920fa2e07c72fd0e5854db1820fa777108009fc5cb702f9aa5155ef58b12adb1
+
+PKG_FIXUP:=autoreconf
+
+PKG_INSTALL:=1
+
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_GETDNS_ENABLE_STUB_ONLY \
+	CONFIG_GETDNS_ENABLE_IDN 
+	
+include $(INCLUDE_DIR)/package.mk
+
+define Package/getdns/Default
+	TITLE:=getdns
+	URL:=https://getdnsapi.net/
+endef
+
+define Package/getdns
+	$(call Package/getdns/Default)
+	SECTION:=libs
+	CATEGORY:=Libraries
+	TITLE+= (library)
+	DEPENDS+= +libopenssl +!GETDNS_ENABLE_STUB_ONLY:libunbound +GETDNS_ENABLE_IDN:libidn
+	MENU:=1
+endef
+
+define Package/getdns/description
+	This package contains the getdns library (libgetdns). 
+	This package also contains the "getdns_query" command line wrapper for getdns exposing the features of this implementation (both in the official API and the additional API functions).
+endef
+
+define Package/getdns/config
+	source "$(SOURCE)/Config.in"
+endef
+
+CONFIGURE_ARGS += \
+		$(if $(CONFIG_GETDNS_ENABLE_STUB_ONLY), --enable-stub-only, ) \
+		$(if $(CONFIG_GETDNS_ENABLE_IDN), , --without-libidn ) 
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/getdns/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/getdns/getdns*.h $(1)/usr/include/getdns/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgetdns*.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/getdns*.pc $(1)/usr/lib/pkgconfig/
+endef
+	
+	
+define Package/getdns/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libgetdns.so.* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/sbin	
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/getdns_query $(1)/usr/sbin/getdns_query
+endef
+
+$(eval $(call BuildPackage,getdns))

--- a/net/stubby/Makefile
+++ b/net/stubby/Makefile
@@ -1,0 +1,59 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=stubby
+PKG_VERSION:=0.2.1
+PKG_RELEASE:=1
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=David Mora <iamperson347+public@gmail.com>
+
+PKG_SOURCE:=v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/getdnsapi/stubby/archive/
+PKG_HASH:=adf030a55426918933870f2d49a0caed93023bb1ec806efb255c3e7494985821
+
+PKG_FIXUP:=autoreconf
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/stubby/Default
+	TITLE:=stubby
+	URL:=https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby
+endef
+
+define Package/stubby/description
+	This package contains the Stubby daemon (which utilizes the getdns library).
+endef
+
+define Package/stubby
+	$(call Package/stubby/Default)
+	SECTION:=net
+	CATEGORY:=Network
+	SUBMENU:=IP Addresses and Names
+	TITLE+= - (daemon that uses getdns)
+	USERID:=stubby=410:stubby=410
+	DEPENDS:= +libyaml +getdns
+endef
+
+define Package/stubby/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/stubby $(1)/usr/sbin/stubby
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN)  ./files/stubby.init $(1)/etc/init.d/stubby
+	$(INSTALL_DIR) $(1)/etc/stubby
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/stubby/stubby.yml $(1)/etc/stubby/stubby.yml.default
+	$(INSTALL_DATA) ./files/stubby.yml $(1)/etc/stubby/stubby.yml
+endef
+
+
+define Package/stubby/conffiles
+	/etc/stubby/stubby.yml
+endef
+
+$(eval $(call BuildPackage,stubby))

--- a/net/stubby/files/stubby.init
+++ b/net/stubby/files/stubby.init
@@ -1,0 +1,25 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+START=50
+STOP=51
+
+PROG=/usr/sbin/stubby
+
+start_service() {
+  procd_open_instance stubby
+  procd_set_param command /usr/sbin/stubby
+
+  procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+
+  procd_set_param limits core="unlimited"
+
+  procd_set_param file /etc/stubby/stubby.yml
+
+  procd_set_param stdout 1
+  procd_set_param stderr 1
+  procd_set_param user stubby
+  procd_close_instance
+}
+

--- a/net/stubby/files/stubby.yml
+++ b/net/stubby/files/stubby.yml
@@ -1,0 +1,29 @@
+#NOTE: See '/etc/stubby/stubby.yml.default' for original config file and descriptions
+
+resolution_type: GETDNS_RESOLUTION_STUB
+
+dns_transport_list:
+  - GETDNS_TRANSPORT_TLS
+
+tls_authentication: GETDNS_AUTHENTICATION_REQUIRED
+
+tls_query_padding_blocksize: 256
+
+edns_client_subnet_private : 1
+
+idle_timeout: 10000
+
+listen_addresses:
+  - 127.0.0.1@5453
+  -  0::1@5453
+
+round_robin_upstreams: 0
+
+upstream_recursive_servers:
+# Quad 9 IPv6
+  - address_data: 2620:fe::fe
+    tls_auth_name: "dns.quad9.net"
+# IPv4 addresses
+# Quad 9 service
+  - address_data: 9.9.9.9
+    tls_auth_name: "dns.quad9.net"


### PR DESCRIPTION
Signed-off-by: David Mora <iamperson347+public@gmail.com>

Maintainer: me / @iamperson347
Compile tested: ar71xx, archer-c7, trunk
Run tested: same as above. Tested on personal Archer C7 v2. Functionality seems to be correct.

Description: Initial commit for support of using getdns library and stubby deamon on lede/openwrt firmware.

https://getdnsapi.net/
https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby