### PR TITLE
python-ipaddress: use default variant build/compile rule, add src package

### DIFF
--- a/lang/python/python-ipaddress/Makefile
+++ b/lang/python/python-ipaddress/Makefile
@@ -7,13 +7,15 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=ipaddress
+PKG_NAME:=python-ipaddress
 PKG_VERSION:=1.0.19
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=ipaddress-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/f0/ba/860a4a3e283456d6b7e2ab39ce5cf11a3490ee1a363652ac50abf9f0f5df
 PKG_HASH:=200d8686011d470b5e4de207d803445deee427455cd0cb7c982b68cf82524f81
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-ipaddress-$(PKG_VERSION)
 
 PKG_LICENSE:=Python-2.0
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
@@ -21,22 +23,26 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-ipaddress/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://github.com/phihag/ipaddress
+endef
+
 define Package/python-ipaddress
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-ipaddress
-	URL:=https://github.com/phihag/ipaddress
-	DEPENDS:=+python-light
+$(call Package/python-ipaddress/Default)
+  TITLE:=python-ipaddress
+  DEPENDS:=+PACKAGE_python-ipaddress:python-light
+  VARIANT:=python
 endef
 
 define Package/python-ipaddress/description
 Python 3.3+'s ipaddress for Python 2.6, 2.7, 3.2.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
 $(eval $(call PyPackage,python-ipaddress))
 $(eval $(call BuildPackage,python-ipaddress))
+$(eval $(call BuildPackage,python-ipaddress-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWRT/LEDE trunk
Run tested: none

Description:
python-ipaddress: use default variant build/compile rule, add src package

Signed-off-by: Jeffery To <jeffery.to@gmail.com>