### PR TITLE
python-pyptlib: use default variant build/compile rule, add src package

### DIFF
--- a/lang/python/python-pyptlib/Makefile
+++ b/lang/python/python-pyptlib/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015 OpenWrt.org
+# Copyright (C) 2015, 2017-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -7,13 +7,15 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=pyptlib
+PKG_NAME:=python-pyptlib
 PKG_VERSION:=0.0.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=pyptlib-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pyptlib
 PKG_HASH:=b98472e3d9e8f4689d3913ca8f89afa5e6cc5383dcd8686987606166f9dac607
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pyptlib-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -22,13 +24,20 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-pyptlib/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://pypi.python.org/pypi/pyptlib
+endef
+
 define Package/python-pyptlib
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-pyptlib
-	URL:=https://pypi.python.org/pypi/pyptlib
-	DEPENDS:=+python-light
+$(call Package/python-pyptlib/Default)
+  TITLE:=python-pyptlib
+  DEPENDS:=+PACKAGE_python-pyptlib:python-light
+  VARIANT:=python
 endef
 
 define Package/python-pyptlib/description
@@ -36,9 +45,6 @@ A python implementation of the Pluggable Transports for Circumvention
 specification for Tor
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
-endef
-
 $(eval $(call PyPackage,python-pyptlib))
 $(eval $(call BuildPackage,python-pyptlib))
+$(eval $(call BuildPackage,python-pyptlib-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWRT/LEDE trunk
Run tested: none

Description:
python-pyptlib: use default variant build/compile rule, add src package

Signed-off-by: Jeffery To <jeffery.to@gmail.com>