### PR TITLE
python-txsocksx: use variant PyBuild/Compile syntax, add src package, refresh patches

### DIFF
--- a/lang/python/python-txsocksx/Makefile
+++ b/lang/python/python-txsocksx/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2016 OpenWrt.org
+# Copyright (C) 2015, 2017-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -7,13 +7,15 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=txsocksx
+PKG_NAME:=python-txsocksx
 PKG_VERSION:=1.15.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=txsocksx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/source/t/txsocksx
 PKG_HASH:=4f79b5225ce29709bfcee45e6f726e65b70fd6f1399d1898e54303dbd6f8065f
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-txsocksx-$(PKG_VERSION)
 
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=COPYING
@@ -22,13 +24,23 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-txsocksx/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://github.com/habnabit/txsocksx
+endef
+
 define Package/python-txsocksx
-	SECTION:=lang
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=python-txsocksx
-	URL:=https://github.com/habnabit/txsocksx
-	DEPENDS:=+python-light +python-parsley +twisted
+$(call Package/python-txsocksx/Default)
+  TITLE:=python-txsocksx
+  DEPENDS:= \
+      +PACKAGE_python-txsocksx:python-light \
+      +PACKAGE_python-txsocksx:python-parsley \
+      +PACKAGE_python-txsocksx:twisted
+  VARIANT:=python
 endef
 
 define Package/python-txsocksx/description
@@ -36,7 +48,7 @@ txsocksx is SOCKS4/4a and SOCKS5 client endpoints for Twisted 10.1 or
 greater.
 endef
 
-define Build/Compile
+define PyBuild/Compile
 	$(call Build/Compile/PyMod,, \
 		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)", \
 		PKG_VERSION="$(PKG_VERSION)" \
@@ -45,3 +57,4 @@ endef
 
 $(eval $(call PyPackage,python-txsocksx))
 $(eval $(call BuildPackage,python-txsocksx))
+$(eval $(call BuildPackage,python-txsocksx-src))

--- a/lang/python/python-txsocksx/patches/001-omit-tests.patch
+++ b/lang/python/python-txsocksx/patches/001-omit-tests.patch
@@ -1,5 +1,3 @@
-diff --git a/setup.py b/setup.py
-index 7979f89..3873a1e 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -35,5 +35,5 @@ setup(

--- a/lang/python/python-txsocksx/patches/002-do-not-use-vcversioner.patch
+++ b/lang/python/python-txsocksx/patches/002-do-not-use-vcversioner.patch
@@ -1,5 +1,3 @@
-diff --git a/setup.py b/setup.py
-index 7979f89..5e1abb3 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -1,6 +1,8 @@
@@ -25,5 +23,5 @@ index 7979f89..5e1abb3 100644
 +    #},
 +    version=os.environ.get('PKG_VERSION'),
      install_requires=install_requires,
-     packages=['txsocksx', 'txsocksx.test'],
+     packages=['txsocksx'],
  )


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWRT/LEDE trunk
Run tested: none

Description:
python-txsocksx: use variant PyBuild/Compile syntax, add src package, refresh patches

Signed-off-by: Jeffery To <jeffery.to@gmail.com>