### PR TITLE
ddns-scripts: fix incompatibility with luci-app-ddns <= V.2.4.8-2

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.7
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -1144,14 +1144,14 @@ get_registered_ip() {
 			fi
 			[ -n "$__DATA" ] && {
 				write_log 7 "Registered IP '$__DATA' detected"
-				echo "$__DATA" > $IPFILE
+				[ -z "$IPFILE" ] || echo "$__DATA" > $IPFILE
 				eval "$1=\"$__DATA\""	# valid data found
 				return 0		# leave here
 			}
 			write_log 4 "NO valid IP found"
 			__ERR=127
 		fi
-		echo "" > $IPFILE
+		[ -z "$IPFILE" ] || echo "" > $IPFILE
 
 		[ -n "$LUCI_HELPER" ] && return $__ERR	# no retry if called by LuCI helper script
 		[ -n "$2" ] && return $__ERR		# $2 is given -> no retry


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE 17.01.4
Run tested: LEDE 17.01.4 on VirtualBox

Description:
fix incompatibility with luci-app-ddns versions <= 2.4.8-2 (#5430)

Signed-off-by: Christian Schoenebeck <christian.schoenebeck@gmail.com>
