### PR TITLE
tang: Add package tang into tree

### DIFF
--- a/utils/tang/Makefile
+++ b/utils/tang/Makefile
@@ -1,0 +1,68 @@
+#
+# Author: Tibor Dudlák
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tang
+PKG_VERSION:=6
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://github.com/latchset/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=1df78b48a52d2ca05656555cfe52bd4427c884f5a54a2c5e37a7b39da9e155e3
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/tang
+  SECTION:=utils
+  TITLE:=tang v$(PKG_VERSION) - daemon for binding data to the presence of a third party
+  DEPENDS:=+libhttp-parser +xinetd +jose +bash
+  URL:=https://github.com/latchset/tang
+  MAINTAINER:=Tibor Dudlák <tibor.dudlak@gmail.com>
+endef
+
+define Package/tang/description
+	Tang is a small daemon for binding data to the presence of a third party.
+endef
+
+define Package/tang/conffiles
+/etc/xinetd.d/tangdx
+/usr/share/tang/db/
+endef
+
+define Package/tang/install
+	$(INSTALL_DIR)	$(1)/usr/libexec
+	$(INSTALL_DIR)	$(1)/etc/xinetd.d/
+	$(INSTALL_BIN)	$(PKG_INSTALL_DIR)/usr/lib/tangd*	$(1)/usr/libexec/
+	$(INSTALL_BIN)	./files/tangdw				$(1)/usr/libexec/
+	$(CP)		./files/tangdx				$(1)/etc/xinetd.d/
+endef
+
+define Package/tang/postinst
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	mkdir -p /usr/share/tang/db && mkdir -p /usr/share/tang/cache
+	KEYS=$(find /usr/share/tang/db/ -name "*.jw*" -maxdepth 1 | wc -l)
+	if [ "${KEYS}" = "0" ]; then # if db is empty generate new key pair
+		/usr/libexec/tangd-keygen /usr/share/tang/db/
+	elif [ "${KEYS}" = "1" ]; then # having 1 key should not happen
+		(>&2 echo "Please check the Tang's keys in /usr/share/tang/db \
+and regenate cache using /usr/libexec/tangd-update script.")
+	else
+		/usr/libexec/tangd-update /usr/share/tang/db/ /usr/share/tang/cache/
+	fi
+	(cat /etc/services | grep -E "tangd.*8888\/tcp") > /dev/null \
+		|| echo -e "tangd\t\t8888/tcp" >> /etc/services
+fi
+endef
+
+$(eval $(call BuildPackage,tang))

--- a/utils/tang/files/tangdw
+++ b/utils/tang/files/tangdw
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo "==================================" >> /var/log/tangd.log
+echo `date`: >> /var/log/tangd.log
+/usr/libexec/tangd $1 2>> /var/log/tangd.log

--- a/utils/tang/files/tangdx
+++ b/utils/tang/files/tangdx
@@ -1,0 +1,12 @@
+service tangd
+{
+    port            = 8888
+    socket_type     = stream
+    wait            = no
+    user            = root
+    server          = /usr/libexec/tangdw
+    server_args     = /usr/share/tang/cache
+    log_on_success  += USERID
+    log_on_failure  += USERID
+    disable         = no
+}

--- a/utils/tang/patches/Makefile_am.patch
+++ b/utils/tang/patches/Makefile_am.patch
@@ -1,0 +1,45 @@
+diff --git a/Makefile.am b/Makefile.am
+index 14bf91d..dfa6d07 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,5 +1,3 @@
+-DISTCHECK_CONFIGURE_FLAGS = --with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)
+-
+ AM_CFLAGS = @TANG_CFLAGS@ @jose_CFLAGS@
+ LDADD = @jose_LIBS@ @http_parser_LIBS@
+ 
+@@ -7,21 +5,11 @@ nagiosdir = $(libdir)/nagios/plugins
+ cachedir = $(localstatedir)/cache/$(PACKAGE_NAME)
+ jwkdir = $(localstatedir)/db/$(PACKAGE_NAME)
+ 
+-nodist_systemdsystemunit_DATA = \
+-    units/tangd@.service \
+-    units/tangd.socket \
+-    units/tangd-update.path \
+-    units/tangd-update.service \
+-    units/tangd-keygen.service
+-
+ dist_libexec_SCRIPTS = src/tangd-update src/tangd-keygen
+ libexec_PROGRAMS = src/tangd
+-nagios_PROGRAMS = src/tang
+-man1_MANS = doc/tang-nagios.1
+ man8_MANS = doc/tang.8
+ 
+ src_tangd_SOURCES = src/http.c src/http.h src/tangd.c
+-src_tang_SOURCES = src/nagios.c
+ 
+ %: %.in
+ 	$(AM_V_GEN)mkdir -p "`dirname "$@"`"
+@@ -32,11 +20,9 @@ src_tang_SOURCES = src/nagios.c
+ 		$(srcdir)/$@.in > $@
+ 
+ AM_TESTS_ENVIRONMENT = SD_ACTIVATE="@SD_ACTIVATE@" PATH=$(srcdir)/src:$(builddir)/src:$(PATH)
+-TESTS = tests/adv tests/rec tests/nagios
++TESTS = tests/adv tests/rec 
+ 
+-CLEANFILES = $(nodist_systemdsystemunit_DATA)
+ EXTRA_DIST = \
+-    $(foreach unit,$(nodist_systemdsystemunit_DATA),$(unit).in) \
+     COPYING \
+     $(TESTS) \
+     $(man1_MANS) \

--- a/utils/tang/patches/rm-systemd-from-configure.patch
+++ b/utils/tang/patches/rm-systemd-from-configure.patch
@@ -1,0 +1,37 @@
+diff --git a/configure.ac b/configure.ac
+index b51bb31..4b37d30 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -27,32 +27,6 @@ AC_CHECK_LIB([http_parser], [http_parser_execute],
+              [AC_MSG_ERROR([http-parser required!])])
+ 
+ PKG_CHECK_MODULES([jose], [jose >= 8])
+-PKG_CHECK_MODULES([systemd], [systemd])
+-
+-AC_ARG_WITH([systemdsystemunitdir],
+-            [AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files])],
+-            [],
+-            [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+-
+-AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
+-
+-for ac_prog in systemd-socket-activate systemd-activate; do
+-    AC_CHECK_PROG([SD_ACTIVATE], [$ac_prog], [$as_dir/$ac_prog], [],
+-		  [$PATH$PATH_SEPARATOR$($PKG_CONFIG --variable=systemdutildir systemd)])
+-    test -n "$SD_ACTIVATE" && break
+-done
+-
+-test -n "$SD_ACTIVATE" || AC_MSG_ERROR([systemd-socket-activate required!])
+-
+-AC_MSG_CHECKING([systemd-socket-activate inetd flag])
+-if $SD_ACTIVATE --help | grep -q inetd; then
+-    SD_ACTIVATE="$SD_ACTIVATE --inetd"
+-    AC_MSG_RESULT([--inetd])
+-else
+-    AC_MSG_RESULT([(default)])
+-fi
+-
+-AC_SUBST(SD_ACTIVATE)
+ 
+ TANG_CFLAGS="\
+ -Wall \

--- a/utils/tang/patches/use-readlink-in-tangd-update.patch
+++ b/utils/tang/patches/use-readlink-in-tangd-update.patch
@@ -1,0 +1,15 @@
+diff --git a/src/tangd-update b/src/tangd-update
+index 652dbef..01aa842 100755
+--- a/src/tangd-update
++++ b/src/tangd-update
+@@ -33,8 +33,8 @@ fi
+ 
+ [ ! -d "$2" ] && mkdir -p -m 0700 "$2"
+ 
+-src=`realpath "$1"`
+-dst=`realpath "$2"`
++src=`readlink -f "$1"`
++dst=`readlink -f "$2"`
+ 
+ payl=()
+ sign=()


### PR DESCRIPTION
Tang is lightweight server for binding data to network presence.
---
Tang's source: https://github.com/latchset/tang
    
Maintainer: @Tiboris
    
Compile tested: (mips, TL-WR842N, 17.01.4, r3560-79f57e422d)
    
**Tang requires a few other software libraries:**
    
1. libhttp-parser: https://github.com/openwrt/packages/pull/5446
2. xinetd's socket activation
3. jose >= 8: https://github.com/openwrt/packages/pull/4334
    
**Compared to tang upstream:**
***Two new files:***
- tangdx : configuration file for xinetd
- tangdw : wrapper for tangd service
    - puts timestamp when service activated, and
    - redirects stderr to log file in /var/log/
    
***Removed systemd requirement and nagios program***

Signed-off-by: Tibor Dudlák <tibor.dudlak@gmail.com>