### PR TITLE
ulogd: conditionalize dependencies

### DIFF
--- a/net/ulogd/Makefile
+++ b/net/ulogd/Makefile
@@ -46,55 +46,55 @@ endef
 
 define Package/ulogd-mod-dbi
   $(call Package/ulogd/Default)
-  DEPENDS:=ulogd +libdbi
+  DEPENDS:=ulogd +PACKAGE_ulogd-mod-dbi:libdbi
   TITLE:=Output plugin for logging to a database using libdbi
 endef
 
 define Package/ulogd-mod-json
   $(call Package/ulogd/Default)
-  DEPENDS:=ulogd +jansson
+  DEPENDS:=ulogd +PACKAGE_ulogd-mod-json:jansson
   TITLE:=JSON output plugin
 endef
 
 define Package/ulogd-mod-mysql
   $(call Package/ulogd/Default)
-  DEPENDS:=ulogd +libmysqlclient
+  DEPENDS:=ulogd +PACKAGE_ulogd-mod-mysql:libmysqlclient
   TITLE:=Output plugin for logging to a MySQL database
 endef
 
 define Package/ulogd-mod-nfacct
   $(call Package/ulogd/Default)
-  DEPENDS:=ulogd +libnetfilter-acct
+  DEPENDS:=ulogd +PACKAGE_ulogd-mod-nfacct:libnetfilter-acct
   TITLE:=Input plugin for flow-based logging (accounting)
 endef
 
 define Package/ulogd-mod-nfct
   $(call Package/ulogd/Default)
-  DEPENDS:=ulogd +libnetfilter-conntrack
+  DEPENDS:=ulogd +PACKAGE_ulogd-mod-nfct:libnetfilter-conntrack
   TITLE:=Input plugin for flow-based logging (conntracking)
 endef
 
 define Package/ulogd-mod-nflog
   $(call Package/ulogd/Default)
-  DEPENDS:=ulogd +libnetfilter-log
+  DEPENDS:=ulogd +PACKAGE_ulogd-mod-nflog:libnetfilter-log
   TITLE:=Input plugin using NFLOG
 endef
 
 define Package/ulogd-mod-pcap
   $(call Package/ulogd/Default)
-  DEPENDS:=ulogd +libpcap
+  DEPENDS:=ulogd +PACKAGE_ulogd-mod-pcap:libpcap
   TITLE:=Output plugin for logging in pcap format
 endef
 
 define Package/ulogd-mod-pgsql
   $(call Package/ulogd/Default)
-  DEPENDS:=ulogd +libpq
+  DEPENDS:=ulogd +PACKAGE_ulogd-mod-pgsql:libpq
   TITLE:=Output plugin for logging to a PostgreSQL database
 endef
 
 define Package/ulogd-mod-sqlite
   $(call Package/ulogd/Default)
-  DEPENDS:=ulogd +libsqlite3
+  DEPENDS:=ulogd +PACKAGE_ulogd-mod-sqlite:libsqlite3
   TITLE:=Output plugin for logging to an SQLite database
 endef
 
@@ -106,7 +106,7 @@ endef
 
 define Package/ulogd-mod-xml
   $(call Package/ulogd/Default)
-  DEPENDS:=ulogd +libnetfilter-acct +libnetfilter-conntrack +libnetfilter-log
+  DEPENDS:=ulogd +PACKAGE_ulogd-mod-xml:libnetfilter-acct +PACKAGE_ulogd-mod-xml:libnetfilter-conntrack +PACKAGE_ulogd-mod-xml:libnetfilter-log
   TITLE:=XML output plugin
 endef
 


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: LEDE r5834-7488be7010
Run tested: -

Description:
Make most dependencies depend on the selection state of the respective
plugins requiring them. This cuts down compile time considerably when
plugins like MySQL support are disabled.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>