### PR TITLE
python,python3: add vars to customize setup arguments / variables

### DIFF
--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -116,13 +116,17 @@ define Build/Compile/PyMod
 	find $(PKG_INSTALL_DIR) -name "*\.exe" | xargs rm -f
 endef
 
+PYTHON_PKG_SETUP_ARGS:=--single-version-externally-managed
+PYTHON_PKG_SETUP_VARS:=
+
 define PyBuild/Compile/Default
 	$(foreach pkg,$(HOST_PYTHON_PACKAGE_BUILD_DEPENDS),
 		$(call host_python_pip_install_host,$(pkg))
 	)
 	$(call Build/Compile/PyMod,, \
 		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
-		--single-version-externally-managed \
+		$(PYTHON_PKG_SETUP_ARGS), \
+		$(PYTHON_PKG_SETUP_VARS) \
 	)
 endef
 

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -115,13 +115,17 @@ define Build/Compile/Py3Mod
 	find $(PKG_INSTALL_DIR) -name "*\.exe" | xargs rm -f
 endef
 
+PYTHON3_PKG_SETUP_ARGS:=--single-version-externally-managed
+PYTHON3_PKG_SETUP_VARS:=
+
 define Py3Build/Compile/Default
 	$(foreach pkg,$(HOST_PYTHON3_PACKAGE_BUILD_DEPENDS),
 		$(call host_python3_pip_install_host,$(pkg))
 	)
 	$(call Build/Compile/Py3Mod,, \
 		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
-		--single-version-externally-managed \
+		$(PYTHON3_PKG_SETUP_ARGS), \
+		$(PYTHON3_PKG_SETUP_VARS) \
 	)
 endef
 


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: ar71xx, OpenWRT/LEDE trunk
Run tested: none

Description:
python,python3: add vars to customize setup arguments / variables

This adds:

* PYTHON_PKG_SETUP_ARGS
* PYTHON_PKG_SETUP_VARS
* PYTHON3_PKG_SETUP_ARGS
* PYTHON3_PKG_SETUP_VARS

to customize Python package setup arguments / environment variables.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>