### PR TITLE
python,python3: fix recursive deps caused by dangling DEPENDS

### DIFF
--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -39,6 +39,7 @@ define PyPackage
 
   define Package/$(1)-src
     $(call Package/$(1))
+    DEPENDS:=
     TITLE+= (sources)
   endef
 

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -38,6 +38,7 @@ define Py3Package
 
   define Package/$(1)-src
     $(call Package/$(1))
+    DEPENDS:=
     TITLE+= (sources)
   endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/openwrt/openwrt/commit/dd975d15a71f713cb0538a5a9f6a9bb265c6a3f8  brcm2708
Run tested: N/A

-------------------------------

For python `src` packages we should clear out the DEPENDS
to prevent recursive deps from happening.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>