### PR TITLE
utils/collectd: Re-add option to enable encrypted network output

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.8.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \
@@ -203,6 +203,14 @@ define Package/collectd/description
  and provides mechanismns to store the values in a variety of ways.
 endef
 
+define Package/collectd/config
+	config PACKAGE_COLLECTD_ENCRYPTED_NETWORK
+	bool "Enable ability to use encrypted networking"
+	default n
+	depends on PACKAGE_collectd
+	select PACKAGE_collectd-mod-network
+endef
+
 ifneq ($(CONFIG_avr32),)
   TARGET_CFLAGS += -fsigned-char
 endif
@@ -214,7 +222,6 @@ CONFIGURE_ARGS+= \
 	--enable-daemon \
 	--with-nan-emulation \
 	--with-libyajl=no \
-	--without-libgcrypt \
 	--without-perl-bindings \
 	--without-libudev
 
@@ -222,6 +229,16 @@ CONFIGURE_VARS+= \
 	CFLAGS="$$$$CFLAGS $(FPIC)" \
 	LDFLAGS="$$$$LDFLAGS -lm -lz" \
 	KERNEL_DIR="$(LINUX_DIR)" \
+
+ifneq ($(CONFIG_PACKAGE_COLLECTD_ENCRYPTED_NETWORK),)
+CONFIGURE_ARGS+= \
+	--with-libgcrypt=$(STAGING_DIR)/usr
+CONFIGURE_VARS+= \
+	GCRYPT_LIBS="-lgcrypt"
+else
+CONFIGURE_ARGS+= \
+	--without-libgcrypt
+endif
 
 CONFIGURE_PLUGIN= \
 	$(foreach m, $(1), \
@@ -353,7 +370,7 @@ $(eval $(call BuildPlugin,match-value,value match,match_value,))
 $(eval $(call BuildPlugin,memory,physical memory usage input,memory,))
 $(eval $(call BuildPlugin,modbus,read variables through libmodbus,modbus,+PACKAGE_collectd-mod-modbus:libmodbus))
 $(eval $(call BuildPlugin,netlink,netlink input,netlink,+PACKAGE_collectd-mod-netlink:libmnl))
-$(eval $(call BuildPlugin,network,network input/output,network,))
+$(eval $(call BuildPlugin,network,network input/output,network,+PACKAGE_COLLECTD_ENCRYPTED_NETWORK:libgcrypt))
 $(eval $(call BuildPlugin,nginx,nginx status input,nginx,+PACKAGE_collectd-mod-nginx:libcurl))
 $(eval $(call BuildPlugin,ntpd,NTP daemon status input,ntpd,))
 $(eval $(call BuildPlugin,nut,UPS monitoring input,nut,+PACKAGE_collectd-mod-nut:nut-common))


### PR DESCRIPTION
Maintainer: me / @hnyman 
Compile tested: vrx200 / BT Home Hub 5A / LEDE 17.01.4
Run tested: vrx200 / BT Home Hub 5A / LEDE 17.01.4

Tested with CONFIG_PACKAGE_COLLECTD_ENCRYPTED_NETWORK set to n to ensure no libgcrypt dependency (on core or collectd-mod-network package) and that runs as expected. Tested with it set to y and collectd-mod-network not installed to ensure no extra libgcrypt dependency had been added. Then installed collectd-mod-network and confirmed correct operation with a collectd server running on a Debian system configured for encrypted clients only.

Description:

As per discussion in #5458 this PR/commit re-enables support in collectd for encryption in the network plugin. This enables OpenWRT/LEDE running routers to securely send collectd statistics off box to a central host where they can be collated (or act as a central server to receive such statistics) without requiring additional efforts to ensure security/authorization.