### PR TITLE
libuwsc: Add package

### DIFF
--- a/libs/libuwsc/Makefile
+++ b/libs/libuwsc/Makefile
@@ -1,0 +1,82 @@
+#
+# Copyright (C) 2018 Jianhui Zhao
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libuwsc
+PKG_VERSION:=1.0.9
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/zhaojh329/libuwsc.git
+PKG_SOURCE_VERSION:=7c3bdf78926436a5e394659bacb4dd5a5b7db9c9
+PKG_MIRROR_HASH:=ecc8b419a51cc7beeca626dd0196509d20b5da747862ae0d91163e769c98166a
+CMAKE_INSTALL:=1
+
+PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_SOURCE_SUBDIR)
+
+PKG_LICENSE:=GPL-3.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_MAINTAINER:=Jianhui Zhao <jianhuizhao329@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/libuwsc/default
+  SECTION:=libs
+  CATEGORY:=Libraries
+  SUBMENU:=Networking
+  TITLE:=Lightweight WebSocket client library
+  DEPENDS:=+libubox
+endef
+
+define Package/libuwsc-nossl
+  $(Package/libuwsc/default)
+  TITLE += (NO SSL)
+  VARIANT:=nossl
+endef
+
+define Package/libuwsc-openssl
+  $(Package/libuwsc/default)
+  TITLE += (openssl)
+  DEPENDS += +libustream-openssl
+  VARIANT:=openssl
+endef
+
+define Package/libuwsc-wolfssl
+  $(Package/libuwsc/default)
+  TITLE += (wolfssl)
+  DEPENDS += +libustream-wolfssl
+  VARIANT:=wolfssl
+endef
+
+define Package/libuwsc-mbedtls
+  $(Package/libuwsc/default)
+  TITLE += (mbedtls)
+  DEPENDS += +libustream-mbedtls
+  VARIANT:=mbedtls
+endef
+
+ifeq ($(BUILD_VARIANT),nossl)
+  CMAKE_OPTIONS += -DUWSC_SSL_SUPPORT=off
+endif
+
+define Package/libuwsc/default/install
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libuwsc.so* $(1)/usr/lib/
+endef
+
+Package/libuwsc-nossl/install = $(Package/libuwsc/default/install)
+Package/libuwsc-openssl/install = $(Package/libuwsc/default/install)
+Package/libuwsc-wolfssl/install = $(Package/libuwsc/default/install)
+Package/libuwsc-mbedtls/install = $(Package/libuwsc/default/install)
+
+$(eval $(call BuildPackage,libuwsc-nossl))
+$(eval $(call BuildPackage,libuwsc-mbedtls))
+$(eval $(call BuildPackage,libuwsc-wolfssl))
+$(eval $(call BuildPackage,libuwsc-openssl))


### PR DESCRIPTION
Maintainer: me
Compile tested: (mipsel,miwifi-mini, LEDE 60a39e8f5a)
Run tested: (mipsel,miwifi-mini, LEDE 60a39e8f5a)

Description:
Lightweight WebSocket client C library based on libubox for Embedded
Linux.

https://github.com/zhaojh329/libuwsc

Used by my other package rtty.