### PR TITLE
[lede-17.01] unbound: update to 1.6.8 for CVE-2017-15105

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.6.5
+PKG_VERSION:=1.6.8
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
@@ -17,9 +17,8 @@ PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@hotmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unbound.net/downloads
-PKG_HASH:=e297aa1229015f25bf24e4923cb1dadf1f29b84f82a353205006421f82cc104e
+PKG_HASH:=e3b428e33f56a45417107448418865fe08d58e0e7fea199b855515f60884dd49
 
-PKG_BUILD_DEPENDS:=libexpat
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1

--- a/net/unbound/patches/001-conf.patch
+++ b/net/unbound/patches/001-conf.patch
@@ -1,12 +1,12 @@
 diff --git a/doc/example.conf.in b/doc/example.conf.in
-index 83e7c5c..3ea2b28 100644
+index 5396029..cbb51ec 100644
 --- a/doc/example.conf.in
 +++ b/doc/example.conf.in
 @@ -1,9 +1,10 @@
 -#
 -# Example configuration file.
 -#
--# See unbound.conf(5) man page, version 1.6.5.
+-# See unbound.conf(5) man page, version 1.6.8.
 -#
 -# this is a comment.
 +##############################################################################


### PR DESCRIPTION
Maintainer: me
Tested: TL-Archer-C7v2 LEDE 17.01
Description: A vulnerability was discovered in the processing of wildcard synthesized
NSEC records. See https://unbound.net/downloads/CVE-2017-15105.txt