### PR TITLE
coova-chilli: remove matrixssl dependency

### DIFF
--- a/net/coova-chilli/Config.in
+++ b/net/coova-chilli/Config.in
@@ -38,9 +38,6 @@ choice
 config COOVACHILLI_NOSSL
 	bool "No SSL support"
 
-config COOVACHILLI_MATRIXSSL
-	bool "MatrixSSL"
-
 config COOVACHILLI_CYASSL
 	bool "CyaSSL"
 

--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.3.0+20141128
 PKG_MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=git://github.com/coova/coova-chilli
@@ -31,7 +31,6 @@ PKG_CONFIG_DEPENDS := \
   COOVACHILLI_UAMDOMAINFILE \
   COOVACHILLI_LARGELIMITS \
   COOVACHILLI_NOSSL \
-  COOVACHILLI_MATRIXSSL \
   COOVACHILLI_CYASSL \
   COOVACHILLI_OPENSSL
 
@@ -42,7 +41,7 @@ define Package/coova-chilli
   SUBMENU:=Captive Portals
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+kmod-tun +librt +COOVACHILLI_MATRIXSSL:libmatrixssl +COOVACHILLI_CYASSL:libcyassl +COOVACHILLI_OPENSSL:libopenssl
+  DEPENDS:=+kmod-tun +librt +COOVACHILLI_CYASSL:libcyassl +COOVACHILLI_OPENSSL:libopenssl
   TITLE:=Wireless LAN HotSpot controller (Coova Chilli Version)
   URL:=http://www.coova.org/CoovaChilli
   MENU:=1
@@ -112,7 +111,6 @@ define Build/Configure
 	$(if $(CONFIG_COOVACHILLI_USERAGENT),--enable,--disable)-useragent \
 	$(if $(CONFIG_COOVACHILLI_LARGELIMITS),--enable,--disable)-largelimits \
 	$(if $(CONFIG_COOVACHILLI_UAMDOMAINFILE),--enable,--disable)-uamdomainfile \
-	$(if $(CONFIG_COOVACHILLI_MATRIXSSL),--with,--without)-matrixssl \
 	$(if $(CONFIG_COOVACHILLI_CYASSL),--with,--without)-cyassl \
 	$(if $(CONFIG_COOVACHILLI_OPENSSL),--with,--without)-openssl \
 	$(if $(CONFIG_PACKAGE_kmod-ipt-coova),--with-nfcoova) \


### PR DESCRIPTION
matrixssl is still in the oldpackages repo, so coova-chilli should not depend on it.
Remove the config option for selecting matrixssl lib and the dependency declaration.

compile-tested with ar71xx

@kaloz is the maintainer, but has not been active with this package for some time.

The package itself should be updated to a current version, but I just fixed the dependency warning.
