### PR TITLE
net/stunnel: fix reload and crash loop on invalid configuration

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -9,11 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
 PKG_VERSION:=5.44
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=GPL-2.0+
-PKG_MAINTAINER:=Daniel Engberg <daniel.engberg.lists@pyret.net> \
-		Florian Eckert <fe@dev.tdt.de>
+PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE_FILES:=COPYING COPYRIGHT.GPL
 
 PKG_SOURCE_URL:= \

--- a/net/stunnel/files/stunnel.init
+++ b/net/stunnel/files/stunnel.init
@@ -7,6 +7,7 @@ USE_PROCD=1
 PID_FILE="/var/run/stunnel.pid"
 CONF_FILE="/tmp/stunnel.conf"
 BIN="/usr/bin/stunnel"
+SERVICE_SECTION_FOUND=0
 
 global_defs() {
 	local debug compression
@@ -86,6 +87,7 @@ service_section() {
 	config_get_bool enabled "$cfg" 'enabled' '1'
 	[ ${enabled} -gt 0 ] || return 0
 
+	SERVICE_SECTION_FOUND=1
 	printf "\n" >> "$CONF_FILE"
 	printf "[%s]\n" "$cfg" >> "$CONF_FILE"
 
@@ -150,6 +152,8 @@ process_config() {
 		rm -f "$CONF_FILE"
 		# Symlink "alt_config_file" since it's a bit easier and safer
 		ln -s "$alt_config_file" "$CONF_FILE"
+		# Set section found to start service user hopfully knows what you does
+		SERVICE_SECTION_FOUND=1
 		return 0
 	}
 
@@ -161,14 +165,16 @@ service_triggers() {
 }
 
 start_service() {
-	procd_open_instance
-	procd_set_param command "$BIN"
-	procd_append_param command "$CONF_FILE"
-
 	process_config
 
-	# set auto respawn behavior
-	procd_set_param respawn
-	procd_set_param file "$CONF_FILE"
-	procd_close_instance
+	if [ "$SERVICE_SECTION_FOUND" = 1 ]; then
+		procd_open_instance
+		procd_set_param command "$BIN"
+		procd_append_param command "$CONF_FILE"
+		procd_set_param respawn
+		procd_set_param file "$CONF_FILE"
+		procd_close_instance
+	else
+		logger -t stunnel -p daemon.info "No uci service section enabled or found!"
+	fi
 }

--- a/net/stunnel/files/stunnel.init
+++ b/net/stunnel/files/stunnel.init
@@ -156,12 +156,6 @@ process_config() {
 	config_foreach service_section service
 }
 
-reload_service() {
-	process_config
-	# SIGHUP is used by stunnel to do init.d reload
-	procd_send_signal stunnel
-}
-
 service_triggers() {
 	procd_add_reload_trigger "stunnel"
 }
@@ -175,5 +169,6 @@ start_service() {
 
 	# set auto respawn behavior
 	procd_set_param respawn
+	procd_set_param file "$CONF_FILE"
 	procd_close_instance
 }


### PR DESCRIPTION
Maintainer: me / @diizzyy 
Compile tested: not needed script change
Run tested: lantiq_xrx200 and x86_64, OpenWRT/LEDE master, reload on configuration change

Description:
This PR will solve issues with reload configuration and crash loop if configuration is not valid
see commit message
