### PR TITLE
mwan3: add init script to enable/disable mwan3

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.6.9
+PKG_VERSION:=2.6.10
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/hotplug.d/iface/14-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/14-mwan3
@@ -12,6 +12,9 @@ if [ "$ACTION" = "ifup" ]; then
 fi
 
 config_load mwan3
+config_get_bool enabled globals 'enabled' '0'
+[ ${enabled} -gt 0 ] || exit 0
+
 config_get local_source globals local_source 'none'
 [ "${local_source}" = "none" ] && {
 	exit 0

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -21,6 +21,7 @@ config_get initial_state $INTERFACE initial_state "online"
 [ "$enabled" == "1" ] || exit 0
 
 mwan3_lock
+mwan3_init
 mwan3_set_connected_iptables
 mwan3_unlock
 

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -12,14 +12,17 @@ if [ "$ACTION" == "ifup" ]; then
         [ -n "$DEVICE" ] || exit 3
 fi
 
-mwan3_lock
-mwan3_set_connected_iptables
-mwan3_unlock
-
 config_load mwan3
+config_get_bool enabled globals 'enabled' '0'
+[ ${enabled} -gt 0 ] || exit 0
+
 config_get enabled $INTERFACE enabled 0
 config_get initial_state $INTERFACE initial_state "online"
 [ "$enabled" == "1" ] || exit 0
+
+mwan3_lock
+mwan3_set_connected_iptables
+mwan3_unlock
 
 if [ "$ACTION" == "ifup" ]; then
 	config_get family $INTERFACE family ipv4

--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3-user
@@ -4,6 +4,9 @@
 	. /lib/functions.sh
 
 	config_load mwan3
+	config_get_bool enabled globals 'enabled' '0'
+	[ ${enabled} -gt 0 ] || exit 0
+
 	config_get enabled "$INTERFACE" enabled 0
 	[ "${enabled}" = "1" ] || exit 0
 	env -i ACTION="$ACTION" INTERFACE="$INTERFACE" DEVICE="$DEVICE" \

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -1,0 +1,32 @@
+#!/bin/sh /etc/rc.common
+
+START=19
+
+reload() {
+	local enabled
+
+	config_load mwan3
+	config_get_bool enabled globals 'enabled' 0
+	[ ${enabled} -gt 0 ] || {
+		echo "Warning: mwan3 is global disabled. Usage: /etc/init.d/mwan3 start"
+		exit 0
+	}
+	mwan3 restart
+}
+
+boot() {
+	. /lib/config/uci.sh
+	uci_toggle_state mwan3 globals enabled "1"
+}
+
+start() {
+	. /lib/config/uci.sh
+	uci_toggle_state mwan3 globals enabled "1"
+	mwan3 start
+}
+
+stop() {
+	. /lib/config/uci.sh
+	uci_toggle_state mwan3 globals enabled "0"
+	mwan3 stop
+}

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -446,7 +446,7 @@ mwan3_delete_iface_ipset_entries()
 
 mwan3_track()
 {
-	local track_ip track_ips
+	local track_ip track_ips pid
 
 	mwan3_list_track_ips()
 	{
@@ -454,7 +454,11 @@ mwan3_track()
 	}
 	config_list_foreach $1 track_ip mwan3_list_track_ips
 
-	kill $(pgrep -f "mwan3track $1 $2") &> /dev/null
+	for pid in $(pgrep -f "mwan3track $1 $2"); do
+		kill -TERM "$pid" > /dev/null 2>&1
+		sleep 1
+		kill -KILL "$pid" > /dev/null 2>&1
+	done
 	if [ -n "$track_ips" ]; then
 		[ -x /usr/sbin/mwan3track ] && /usr/sbin/mwan3track "$1" "$2" "$3" "$4" $track_ips &
 	fi

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -187,6 +187,7 @@ restart() {
 
 case "$1" in
 	ifup|ifdown|interfaces|policies|connected|rules|status|start|stop|restart)
+		mwan3_init
 		$*
 	;;
 	*)

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -54,6 +54,12 @@ ifup()
 		echo "Too many arguments. Usage: mwan3 ifup <interface>" && exit 0
 	fi
 
+	config_get_bool enabled globals 'enabled' 0
+	[ ${enabled} -gt 0 ] || {
+		echo "Warning: mwan3 is global disabled. Usage: /etc/init.d/mwan3 start"
+		exit 0
+	}
+
 	config_get enabled "$1" enabled 0
 
 	device=$(uci -p /var/state get network.$1.ifname) &> /dev/null
@@ -112,7 +118,15 @@ status()
 
 start()
 {
+	local enabled
+
 	config_load mwan3
+	config_get_bool enabled globals 'enabled' 0
+	[ ${enabled} -gt 0 ] || {
+		echo "Warning: mwan3 is global disabled. Usage: /etc/init.d/mwan3 start"
+		exit 0
+	}
+
 	config_foreach ifup interface
 }
 

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -132,9 +132,13 @@ start()
 
 stop()
 {
-	local ipset route rule table IP IPT
+	local ipset route rule table IP IPT pid
 
-	killall mwan3track &> /dev/null
+	for pid in $(pgrep -f "mwan3track"); do
+		kill -TERM "$pid" > /dev/null 2>&1
+		sleep 1
+		kill -KILL "$pid" > /dev/null 2>&1
+	done
 
 	config_load mwan3
 	config_foreach mwan3_track_clean interface

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -62,8 +62,8 @@ main() {
 	STATUS=$3
 	SRC_IP=$4
 	mkdir -p /var/run/mwan3track/$1
-	trap clean_up SIGINT SIGTERM
-	trap if_down SIGUSR1
+	trap clean_up TERM
+	trap if_down USR1
 
 	config_load mwan3
 	config_get track_method $1 track_method ping


### PR DESCRIPTION
Maintainer: me
Compile tested: shell script
Run tested: x86_64 lantiq_xrx200, OpenWRT/LEDE version, service start/stop

Description:
Adding a init script to "/etc/init.d/" introduce the possibility to
enable/disable mwan3 globally.

