### PR TITLE
sqlite3 [lede-17.01]: fix uClibc builds

### DIFF
--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqlite
 PKG_VERSION:=3190300
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_VERSION).tar.gz
 PKG_HASH:=06129c03dced9f87733a8cba408871bd60673b8f93b920ba8d815efab0a06301
@@ -67,6 +67,9 @@ $(call Package/sqlite3/Default/description)
  that can evaluate queries interactively and display the results in multiple
  formats.
 endef
+
+# On uClibc libm needs to be linked in for ISNAN()
+TARGET_LDFLAGS += $(if $(CONFIG_USE_UCLIBC),-lm)
 
 TARGET_CFLAGS += $(FPIC) \
 	-DSQLITE_ENABLE_UNLOCK_NOTIFY=1 \


### PR DESCRIPTION
When compiling against uClibc on lede-17.01 it's detected in the linking
phase that '__isnan' is nowhere to be found:

sqlite3-sqlite3.o:` In function `serialGet':
sqlite3.c:(.text+0x6364): undefined reference to `__isnan'
sqlite3-sqlite3.o: In function `sqlite3_result_double':
sqlite3.c:(.text+0x10faa): undefined reference to `__isnan'
sqlite3-sqlite3.o: In function `sqlite3VXPrintf':
sqlite3.c:(.text+0x175ca): undefined reference to `__isnan'
sqlite3-sqlite3.o: In function `sqlite3_bind_double':
sqlite3.c:(.text+0x1b0ac): undefined reference to `__isnan'
sqlite3-sqlite3.o: In function `sqlite3VdbeExec':
sqlite3.c:(.text+0x3b77e): undefined reference to `__isnan'
collect2: error: ld returned 1 exit status

To fix this libm needs to be linked in as well in the uClibc case. So
add libm ('-lm') to the TARGET_LDFLAGS accordingly.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @champtar 
Compile tested: arc700 lede-17.01
Run tested: N/A (don't have ARC hw)

Description:
Hi all,

This fixes build failure of sqlite3 on ARC (which is using uClibc). I saw that asterisk is failing to build because sqlite3 is not being built on ARC, so that is why this pull request.

Thanks!
Seb

P.S. I hope you are Etienne @champtar :)