### PR TITLE
alsa-lib [lede-17.01]: fix build on uclibc

### DIFF
--- a/libs/alsa-lib/Makefile
+++ b/libs/alsa-lib/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2016 OpenWrt.org
+# Copyright (C) 2006-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alsa-lib
 PKG_VERSION:=1.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=ftp://ftp.alsa-project.org/pub/lib/ \

--- a/libs/alsa-lib/patches/006-properly-define-S_IRUSR.patch
+++ b/libs/alsa-lib/patches/006-properly-define-S_IRUSR.patch
@@ -1,0 +1,32 @@
+From 3f1dba9a821b53b42001605f9a126a958804884f Mon Sep 17 00:00:00 2001
+From: Takashi Iwai <tiwai@suse.de>
+Date: Mon, 9 Nov 2015 13:37:26 +0100
+Subject: [PATCH] topology: Add missing include sys/stat.h
+
+Necessary for proper definitions of S_IRUSR & co.  Otherwise it
+results in compile errors with old glibc:
+  parser.c: In function 'snd_tplg_build_file':
+  parser.c:262: error: 'S_IRUSR' undeclared (first use in this function)
+  parser.c:262: error: (Each undeclared identifier is reported only once
+  parser.c:262: error: for each function it appears in.)
+
+Signed-off-by: Takashi Iwai <tiwai@suse.de>
+---
+ src/topology/parser.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/topology/parser.c b/src/topology/parser.c
+index 80a0ae0..18bb9c7 100644
+--- a/src/topology/parser.c
++++ b/src/topology/parser.c
+@@ -16,6 +16,7 @@
+            Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ */
+ 
++#include <sys/stat.h>
+ #include "list.h"
+ #include "tplg_local.h"
+ 
+-- 
+1.7.11.7
+


### PR DESCRIPTION
Currently alsa-lib fails to build on uClibc:

parser.c: In function 'snd_tplg_build_file':
parser.c:262:35: error: 'S_IRUSR' undeclared (first use in this function)
   open(outfile, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
                                   ^
parser.c:262:35: note: each undeclared identifier is reported only once for each function it appears in
parser.c:262:45: error: 'S_IWUSR' undeclared (first use in this function)
   open(outfile, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
                                             ^
parser.c: In function 'snd_tplg_build':
parser.c:330:35: error: 'S_IRUSR' undeclared (first use in this function)
   open(outfile, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
                                   ^
parser.c:330:45: error: 'S_IWUSR' undeclared (first use in this function)
   open(outfile, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
                                             ^
Makefile:390: recipe for target 'parser.lo' failed

Fix this by adding an upstream fix as a backport.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @thess @tripolar 
Compile tested: arc700
Run tested: N/A don't have ARC hw

Description:
I'm checking why asterisk doesn't build on ARC and found one reason being that alsa-lib isn't building. Here's the fix from upstream. Upstream mentions "old glibc", but the same is applicable for uClibc in lede-17.01. 
[Link to release build failure](https://downloads.openwrt.org/releases/faillogs/arc_arc700/packages/alsa-lib/compile.txt)