### PR TITLE
zoneinfo: Updated to the latest release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2017 OpenWrt.org
+# Copyright (C) 2007-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2017c
-PKG_VERSION_CODE:=2017c
+PKG_VERSION:=2018c
+PKG_VERSION_CODE:=2018c
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -20,14 +20,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION_CODE).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=d6543f92a929826318e2f44ff3a7611ce5f565a43e10250b42599d0ba4cbd90b
+PKG_HASH:=2825c3e4b7ef520f24d393bcc02942f9762ffd3e7fc9b23850789ed8f22933f6
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=81e8b4bc23e60906640c266bbff3789661e22f0fa29fe61b96ec7c2816c079b7
+   HASH:=31fa7fc0f94a6ff2d6bc878c0a35e8ab8b5aa0e8b01445a1d4a8f14777d0e665
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me 
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT/LEDE master
Run tested: n/a

Description:

The 2018c release of the tz code and data is available. It follows on
the 2018a and 2018b releases, which were published but were not
announced until now, due to problems discovered late in their release
processes. 2018a had a build-failure typo, and 2018a and 2018b both had
problems with ICU and Java, downstream packages which do not support a
feature (negative DST offsets) used in 2018a and 2018b. The typo has
been fixed, and data changes using negative DST offsets have been
reverted pending development of a mechanism to export data to platforms
lacking support for such data.

The 2018a through 2018c releases reflect the following changes, which
were either circulated on the tz mailing list or are relatively minor
technical or administrative changes. This announcement has merged the
set of changes made by the three releases, to make it easier to see the
difference between 2017c and 2018c; please see the 2018c NEWS file for
more details about intermediate versions.

Release 2018c - 2018-01-22 23:00:44 -0800
Release 2018b - 2018-01-17 23:24:48 -0800
Release 2018a - 2018-01-12 22:29:21 -0800

   Briefly:
   S?o Tom? and Pr?ncipe switched from +00 to +01.
   Brazil's DST will now start on November's first Sunday.
   Use Debian-style installation locations, instead of 4.3BSD-style.
   New zic option -t.

   Changes to past and future time stamps

     S?o Tom? and Pr?ncipe switched from +00 to +01 on 2018-01-01 at
     01:00.? (Thanks to Steffen Thorsen and Michael Deckers.)

   Changes to future time stamps

     Starting in 2018 southern Brazil will begin DST on November's
     first Sunday instead of October's third Sunday. (Thanks to
     Steffen Thorsen.)

   Changes to past time stamps

     Japanese DST transitions (1948-1951) were Sundays at 00:00, not
     Saturdays or Sundays at 02:00.? (Thanks to Takayuki Nikai.)

     A discrepancy of 4 s in timestamps before 1931 in South Sudan has
     been corrected.? The 'backzone' and 'zone.tab' files did not agree
     with the 'africa' and 'zone1970.tab' files.? (Problem reported by
     Michael Deckers.)

     The abbreviation invented for Bolivia Summer Time (1931-2) is now
     BST instead of BOST, to be more consistent with the convention
     used for Latvian Summer Time (1918-9) and for British Summer Time.

   Changes to build procedure

     The default installation locations have been changed to mostly
     match Debian circa 2017, instead of being designed as an add-on to
     4.3BSD circa 1986.? This affects the Makefile macros TOPDIR,
     TZDIR, MANDIR, and LIBDIR.? New Makefile macros TZDEFAULT, USRDIR,
     USRSHAREDIR, BINDIR, ZDUMPDIR, and ZICDIR let installers tailor
     locations more precisely.? (This responds to suggestions from
     Brian Inglis and from Steve Summit.)

     The default installation procedure no longer creates the
     backward-compatibility link US/Pacific-New, which causes
     confusion during user setup (e.g., see Debian bug 815200).
     Use 'make BACKWARD="backward pacificnew"' to create the link
     anyway, for now.? Eventually we plan to remove the link entirely.

     tzdata.zi now contains a version-number comment.
     (Suggested by Tom Lane.)

     The Makefile now quotes values like BACKWARD more carefully when
     passing them to the shell.? (Problem reported by Zefram.)

     Builders no longer need to specify -DHAVE_SNPRINTF on platforms
     that have snprintf and use pre-C99 compilers. (Problem reported
     by Jon Skeet.)

     The build procedure now works around mawk 1.3.3's lack of support
     for character class expressions.? (Problem reported by Ohyama.)

   Changes to code

     zic has a new option -t FILE that specifies the location of the
     file that determines local time when TZ is unset. The default for
     this location can be configured via the new TZDEFAULT makefile
     macro, which defaults to /etc/localtime.

     Diagnostics and commentary now distinguish UT from UTC more
     carefully; see theory.html for more information about UT vs UTC.

     zic has been ported to GCC 8's -Wstringop-truncation option.
     (Problem reported by Martin Sebor.)

   Changes to documentation and commentary

     The zic man page now documents the longstanding behavior that
     times and years can be out of the usual range, with negative times
     counting backwards from midnight and with year 0 preceding year 1.
     (Problem reported by Michael Deckers.)

     The theory.html file now mentions the POSIX limit of six chars
     per abbreviation, and lists alphabetic abbreviations used.

     The files tz-art.htm and tz-link.htm have been renamed to
     tz-art.html and tz-link.html, respectively, for consistency with
     other file names and to simplify web server configuration.

