### PR TITLE
net/https-dns-proxy: Update to 2018-01-24.

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -1,15 +1,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https_dns_proxy
-PKG_VERSION:=2017-01-07
-PKG_RELEASE=2
+PKG_VERSION:=2018-01-24
+PKG_RELEASE=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MIRROR_HASH:=befd075fd8175bb5322de8eeb8c7be218fd4ec255814cbf07051216f613fe2e6
+PKG_MIRROR_HASH:=0eef98106c584b986117f33458e8d1e2447a8b6eb12a2e3bfc5df06d45114144
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy/
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=c62ce3f6807a4067230a8bc5ea5a829f532de785
+PKG_SOURCE_VERSION:=f08b51d7c07c0156794e2c23d7a4d1a5344b2e07
 PKG_MAINTAINER:=Aaron Drew <aarond10@gmail.com>
 PKG_LICENSE:=MIT
 
@@ -20,7 +20,7 @@ define Package/https_dns_proxy
   SECTION:=net
   CATEGORY:=Network
   TITLE:=DNS over HTTPS proxy server
-  DEPENDS:=+libcares +libcurl +libev
+  DEPENDS:=+libcares +libcurl +libev +ca-bundle
 endef
 
 define Package/https_dns_proxy/install


### PR DESCRIPTION
Add dependency on ca-bundle without which the HTTPS fetches fail.
Add "-x" option to force HTTP/1.1 instead of HTTP/2.0
Add a workaround for bug in libcurl <7.530 that prevents it from
working at all when built with mbedtls.

Signed-of-by: Darren Tucker <dtucker@dtucker.net>

Maintainer: @aarond10 
Compile tested: GL.inet AR150 ar71xx OpenWrt SNAPSHOT, r5938-6f425a2
Run tested: GL.inet AR150 ar71xx OpenWrt SNAPSHOT, r5938-6f425a2
Description: Update to 2018-01-24, depend on ca-bundle.
