### PR TITLE
luaposix: musl compatibility with XOPEN_REALTIME

### DIFF
--- a/lang/luaposix/Makefile
+++ b/lang/luaposix/Makefile
@@ -44,6 +44,9 @@ CONFIGURE_VARS += ac_cv_path_LDOC="true"
 TARGET_CFLAGS += -DLUA_USE_LINUX $(FPIC) -std=gnu99
 ifeq ($(CONFIG_USE_MUSL),y)
   TARGET_CFLAGS += -D_POSIX_PRIORITY_SCHEDULING
+  # Musl doesn't do all of XOPEN_REALTIME, but it does for luaposix.
+  # see https://github.com/luaposix/luaposix/issues/295
+  TARGET_CFLAGS += -D_XOPEN_REALTIME=1
 endif
 
 ifneq ($(CONFIG_USE_GLIBC),)


### PR DESCRIPTION
musl-libc doesn't define _XOPEN_REALTIME as it doesn't implement the
full set of the realtime operations.  However, it _does_ implement
POSIX_TIMERS, which is what luaposix _should_ be checking for in the
posix.time module.

I've filed https://github.com/luaposix/luaposix/issues/295 to track this
upstream, but this is a simpler, verified fix for our older version of
luaposix.

This restores functions like posix.time.clock_gettime(CLOCK_MONOTONIC)
for instance, which was available with pre-musl builds of luaposix.

Signed-off-by: Karl Palsson <karlp@etactica.com>
Compile tested: ar71xx
Run tested: ar71xx

maintainer: @mstorchak 