### PR TITLE
perlmod: avoid 'do' semantics and just concatenate 

### DIFF
--- a/lang/perl-inline-c/patches/010-makefile_pl-dont-eval-undef.patch
+++ b/lang/perl-inline-c/patches/010-makefile_pl-dont-eval-undef.patch
@@ -1,8 +1,0 @@
---- a/Makefile.PL	2017-05-30 14:58:53.000000000 -0600
-+++ b/Makefile.PL	2017-11-07 13:40:05.172119764 -0700
-@@ -82,3 +82,5 @@ package
- MY;
- use File::ShareDir::Install qw(postamble);
- }
-+
-+1;

--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=5.26.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \

--- a/lang/perl/perlmod.mk
+++ b/lang/perl/perlmod.mk
@@ -57,7 +57,7 @@ define perlmod/Configure
 	(cd $(if $(3),$(3),$(PKG_BUILD_DIR)); \
 	PERL_MM_USE_DEFAULT=1 \
 	$(2) \
-	$(PERL_CMD) -MConfig -e '$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E"; unshift(@INC, "."); unless (defined (do "./Makefile.PL")) { if ($$$$@) { die "couldn\047t parse Makefile.PL: $$$$@"; } else { die "couldn\047t do Makefile.PL: $$$$!"; } }; die "No Makefile generated!" unless -f "Makefile";' \
+	$(PERL_CMD) -MConfig -e '$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E"; do "./Makefile.PL"' \
 		$(1) \
 		AR=ar \
 		CC=$(GNU_TARGET_NAME)-gcc \

--- a/lang/perl/perlmod.mk
+++ b/lang/perl/perlmod.mk
@@ -57,7 +57,7 @@ define perlmod/Configure
 	(cd $(if $(3),$(3),$(PKG_BUILD_DIR)); \
 	PERL_MM_USE_DEFAULT=1 \
 	$(2) \
-	$(PERL_CMD) -MConfig -e '$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E"; unshift(@INC, "."); unless (defined (do "./Makefile.PL")) { if ($$$$@) { die "couldn\047t parse Makefile.PL: $$$$@"; } elsif ($$$$!) { die "Could\047t run Makefile.PL: $$$$!"; } }; die "No Makefile generated!" unless -f "Makefile";' \
+	$(PERL_CMD) -MConfig -e '$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E"; unshift(@INC, "."); unless (defined (do "./Makefile.PL")) { if ($$$$@) { die "couldn\047t parse Makefile.PL: $$$$@"; } else { die "couldn\047t do Makefile.PL: $$$$!"; } }; die "No Makefile generated!" unless -f "Makefile";' \
 		$(1) \
 		AR=ar \
 		CC=$(GNU_TARGET_NAME)-gcc \

--- a/lang/perl/perlmod.mk
+++ b/lang/perl/perlmod.mk
@@ -55,9 +55,10 @@ endef
 
 define perlmod/Configure
 	(cd $(if $(3),$(3),$(PKG_BUILD_DIR)); \
-	PERL_MM_USE_DEFAULT=1 \
-	$(2) \
-	$(PERL_CMD) -MConfig -e '$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E"; do "./Makefile.PL"' \
+	 (echo -e 'use Config;\n\n$$$${tied %Config::Config}{cpprun}="$(GNU_TARGET_NAME)-cpp -E";\n' ; cat Makefile.PL) | \
+	 PERL_MM_USE_DEFAULT=1 \
+	 $(2) \
+	 $(PERL_CMD) -I. -- - \
 		$(1) \
 		AR=ar \
 		CC=$(GNU_TARGET_NAME)-gcc \
@@ -103,8 +104,8 @@ define perlmod/Configure
 		INSTALLVENDORMAN3DIR=" " \
 		LINKTYPE=dynamic \
 		DESTDIR=$(PKG_INSTALL_DIR) \
-	);
-	sed 's!^PERL_INC = .*!PERL_INC = $(STAGING_DIR)/usr/lib/perl5/$(PERL_VERSION)/CORE/!' -i $(if $(3),$(3),$(PKG_BUILD_DIR))/Makefile
+	)
+	sed -i -e 's!^PERL_INC = .*!PERL_INC = $(STAGING_DIR)/usr/lib/perl5/$(PERL_VERSION)/CORE/!' $(if $(3),$(3),$(PKG_BUILD_DIR))/Makefile
 endef
 
 define perlmod/Compile


### PR DESCRIPTION
Maintainer: me / @Naoir 
Compile tested: x86_64, generic, OpenWrt HEAD (5bbcd80)
Run tested: same

Description:

Simplify how we run the `Makefile.PL` keeping in mind that (a) some of them don't return a value, evaluating to `undef` instead, and (b) this first fact makes `do "Makefile.PL";` unsuitable.