### PR TITLE
github: adapt templates

### DIFF
--- a/.github/issue_template
+++ b/.github/issue_template
@@ -1,17 +1,14 @@
-Please make sure that the issue subject starts with `<package-name>: ` so that it's easily identifiable.
+Please make sure that the issue subject starts with `<package-name>: `
 
-This repo here is ONLY for packages maintained in this repo.  For base packages residing in the same repo as the build system and maintained by core devs, please consider opening tickets there for more timely responses
+This repo here is only for packages maintained in this repo.  For base packages residing in the same repo as the build system and maintained by core devs, please consider opening tickets there for more timely responses
 
- - OpenWrt: https://dev.openwrt.org/newticket
- - LEDE: https://bugs.lede-project.org/
+ - OpenWrt base system: https://bugs.openwrt.org
  - Most LuCI packages: https://github.com/openwrt/luci/issues
 
-Thanks for your contribution
-Please remove this text (before ---) and fill the following template
--------------------------------
+# Issue template (remove lines from top till here)
 
-Maintainer: @<github-user> (find it by checking history of the package Makefile)
-Environment: (put here arch, model, OpenWRT/LEDE version)
+Maintainer: @\<github-user> (find it by checking history of the package Makefile)
+Environment: (put here arch, model, OpenWrt version)
 
 Description:
 

--- a/.github/pull_request_template
+++ b/.github/pull_request_template
@@ -1,16 +1,5 @@
-Please double check that your commits:
-- all start with "<package name>: "
-- all contain signed-off-by
-- are linked to your github account (you see your logo in front of them) 
-
-Please also read https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md
-
-Thanks for your contribution
-Please remove this text (before ---) and fill the following template
--------------------------------
-
-Maintainer: me / @<github-user>
-Compile tested: (put here arch, model, OpenWRT/LEDE version)
-Run tested: (put here arch, model, OpenWRT/LEDE version, tests done)
+Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
+Compile tested: (put here arch, model, OpenWrt version)
+Run tested: (put here arch, model, OpenWrt version, tests done)
 
 Description:


### PR DESCRIPTION
@openwrt/package-maintainers , please goto my [`fork of the repo`](https://github.com/yousong/packages) for a feel.

Remove refs to LEDE and use "OpenWrt" instead of "OpenWRT"

Remove instructions on self-checking pull request content for the
following considerations

 - The checks are now enforced by travis autocheck scripts
 - Github now prompts users to refer to the contributing guide on
   submitting new issue and pull request


Comments for improvement are welcome