### PR TITLE
krb5: fix com_err, deps

### DIFF
--- a/net/krb5/Makefile
+++ b/net/krb5/Makefile
@@ -40,7 +40,8 @@ define Package/krb5-libs
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=Kerberos
-	DEPENDS:=+libncurses
+	DEPENDS:=+libncurses +PACKAGE_libopenssl:libopenssl +PACKAGE_e2fsprogs:e2fsprogs
+	# e2fsprogs because of BUG FS#1310
 	TITLE:=Kerberos 5 Shared Libraries
 	URL:=http://web.mit.edu/kerberos/
 endef
@@ -88,6 +89,8 @@ define Build/InstallDev
 	# needed for samba4, to detect system-krb5
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/krb5-config $(1)/usr/bin
+	# provide compile_et for other packages
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/compile_et $(1)/usr/bin
 endef
 
 define Package/krb5-libs/install

--- a/net/krb5/Makefile
+++ b/net/krb5/Makefile
@@ -40,8 +40,7 @@ define Package/krb5-libs
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=Kerberos
-	DEPENDS:=+libncurses +PACKAGE_libopenssl:libopenssl +PACKAGE_e2fsprogs:e2fsprogs
-	# e2fsprogs because of BUG FS#1310
+	DEPENDS:=+libncurses
 	TITLE:=Kerberos 5 Shared Libraries
 	URL:=http://web.mit.edu/kerberos/
 endef
@@ -59,7 +58,8 @@ define Package/krb5-client
 endef
 
 define Package/krb5/description
-	Kerberos
+	Kerberos is a network authentication protocol. It is designed to provide strong authentication for client/server applications by using secret-key cryptography.
+	A free implementation of this protocol is available from the Massachusetts Institute of Technology.
 endef
 
 CONFIGURE_PATH = ./src

--- a/net/krb5/Makefile
+++ b/net/krb5/Makefile
@@ -73,12 +73,15 @@ CONFIGURE_VARS += \
 	ac_cv_file__etc_TIMEZONE=no
 
 CONFIGURE_ARGS += \
+	--localstatedir=/etc \
 	--without-system-verto \
 	--without-tcl \
 	--without-libedit \
-	--localstatedir=/etc \
-	--with-size-optimizations \
 	--disable-rpath \
+	--disable-pkinit \
+	--with-size-optimizations \
+	--with-crypto-impl=builtin \
+	--without-tls-impl \
 	--without-krb5-config
 
 define Build/InstallDev


### PR DESCRIPTION
Signed-off-by: Andy Walsh <andy.walsh44+github@gmail.com>

Maintainer: @MikePetullo 
Compile tested: mvebu/wrt1200ac, master (74beb6f7)

Description: We need to ensure e2fsprogs is not breaking this package, by overwriting com_err. The other problem was that libcrypto/libssl was pulled in automatically via the plugins in stageing/usr/lib.

PS: `--with-system-et` is not working, since the compile_et from e2fsprogs is incompatible with krb5.