### PR TITLE
transmission: Fix port test + other fixes.

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=2.93
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/transmission/transmission-releases/raw/master
@@ -37,7 +37,7 @@ endef
 
 define Package/transmission-daemon/Default
   $(call Package/transmission/template)
-  DEPENDS:=+libcurl +libevent2 +libminiupnpc +libpthread +librt +zlib
+  DEPENDS:=+ca-bundle +libcurl +libevent2 +libminiupnpc +libpthread +librt +zlib
   USERID:=transmission=224:transmission=224
 endef
 
@@ -57,7 +57,7 @@ endef
 
 define Package/transmission-cli/Default
   $(call Package/transmission/template)
-  DEPENDS:=+libcurl +libevent2 +libminiupnpc +libpthread +librt +zlib
+  DEPENDS:=+ca-bundle +libcurl +libevent2 +libminiupnpc +libpthread +librt +zlib
 endef
 
 define Package/transmission-cli-openssl
@@ -76,7 +76,7 @@ endef
 
 define Package/transmission-remote/Default
   $(call Package/transmission/template)
-  DEPENDS:=+libcurl +libevent2 +libminiupnpc +libpthread +librt +zlib
+  DEPENDS:=+ca-bundle +libcurl +libevent2 +libminiupnpc +libpthread +librt +zlib
 endef
 
 define Package/transmission-remote-openssl

--- a/net/transmission/files/transmission.config
+++ b/net/transmission/files/transmission.config
@@ -1,10 +1,9 @@
 config transmission
 	option enabled 0
 	option config_dir '/tmp/transmission'
-	#option user 'nobody'
+	option user 'transmission'
 	option mem_percentage 50
 	option nice 10
-	option ionice_flags '-c 3'
 	option alt_speed_down 50
 	option alt_speed_enabled false
 	option alt_speed_time_begin  540

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -4,18 +4,17 @@
 START=99
 USE_PROCD=1
 
-
 LIST_SEP="
 "
 
 append_params() {
 	local p; local v; local s="$1"; shift
-	for p in $*; do
+	for p in "$@"; do
 		config_get v "$s" "$p"
 		IFS="$LIST_SEP"
 		for v in $v; do
 			[ -n "$v" ] && (
-				echo "\""$p"\": "$v"," | sed -e 's|_|-|g' >> $config_file
+				echo "\"$p\": $v," | sed -e 's|_|-|g' >> $config_file
 			)
 		done
 		unset IFS
@@ -24,13 +23,13 @@ append_params() {
 
 append_params_quotes() {
 	local p; local v; local s="$1"; shift
-	for p in $*; do
+	for p in "$@"; do
 		config_get v "$s" "$p"
 		IFS="$LIST_SEP"
 		for v in $v; do
 			[ -n "$v" ] && (
-				echo -n "\""$p | sed -e 's|/|\\/|g;s|_|-|g' >> $config_file; \
-				echo "\": \""$v"\"," >> $config_file
+				echo -n "\"$p" | sed -e 's|/|\\/|g;s|_|-|g' >> $config_file; \
+				echo "\": \"$v\"," >> $config_file
 			)
 		done
 		unset IFS
@@ -38,7 +37,7 @@ append_params_quotes() {
 }
 
 section_enabled() {
-	config_get_bool enabled "$1" 'enabled' 0
+	config_get_bool enabled "$1" enabled 0
 	[ $enabled -gt 0 ]
 }
 
@@ -49,7 +48,7 @@ transmission() {
 	local user
 	local download_dir config_dir
 	local mem_percentage
-	local config_overwrite nice ionice_flags
+	local nice
 	local cmdline
 
 	section_enabled "$section" || return 1
@@ -58,10 +57,7 @@ transmission() {
 	config_get user "$cfg" 'user'
 	config_get download_dir "$cfg" 'download_dir' '/var/etc/transmission'
 	config_get mem_percentage "$cfg" 'mem_percentage' '50'
-	config_get config_overwrite "$cfg" config_overwrite 1
 	config_get nice "$cfg" nice 0
-	config_get ionice_flags "$cfg" ionice_flags ''
-	which ionice > /dev/null || ionice_flags=''
 
 	local MEM=$(sed -ne 's!^MemTotal:[[:space:]]*\([0-9]*\) kB$!\1!p' /proc/meminfo)
 	if test "$MEM" -gt 1;then
@@ -70,52 +66,51 @@ transmission() {
 
 	config_file="$config_dir/settings.json"
 	[ -d $config_dir ] || {
-		mkdir -m 0755 -p "$config_dir"
+		mkdir -p $config_dir
+		chmod 0755 $config_dir
 		touch $config_file
-		[ -z "$user" ] || chown -R $user $config_dir
+		[ -z "$user" ] || chown -R "$user:$user" $config_dir
 	}
 
-	[ "$config_overwrite" == 0 ] || {
+	echo "{" > $config_file
 
-		echo "{" > $config_file
+	append_params "$cfg" \
+		alt_speed_down alt_speed_enabled alt_speed_time_begin alt_speed_time_day \
+		alt_speed_time_enabled alt_speed_time_end alt_speed_up blocklist_enabled \
+		cache_size_mb download_queue_enabled download_queue_size \
+		dht_enabled encryption idle_seeding_limit idle_seeding_limit_enabled \
+		incomplete_dir_enabled lazy_bitfield_enabled lpd_enabled message_level \
+		peer_limit_global peer_limit_per_torrent peer_port \
+		peer_port_random_high peer_port_random_low peer_port_random_on_start \
+		pex_enabled port_forwarding_enabled preallocation prefetch_enabled \
+		ratio_limit ratio_limit_enabled rename_partial_files rpc_authentication_required \
+		rpc_enabled rpc_port rpc_whitelist_enabled queue_stalled_enabled \
+		queue_stalled_minutes scrape_paused_torrents_enabled script_torrent_done_enabled \
+		seed_queue_enabled seed_queue_size \
+		speed_limit_down speed_limit_down_enabled speed_limit_up \
+		speed_limit_up_enabled start_added_torrents trash_original_torrent_files \
+		umask upload_slots_per_torrent utp_enabled scrape_paused_torrents \
+		watch_dir_enabled rpc_host_whitelist_enabled
 
-		append_params "$cfg" \
-			alt_speed_down alt_speed_enabled alt_speed_time_begin alt_speed_time_day \
-			alt_speed_time_enabled alt_speed_time_end alt_speed_up blocklist_enabled \
-			cache_size_mb download_queue_enabled download_queue_size \
-			dht_enabled encryption idle_seeding_limit idle_seeding_limit_enabled \
-			incomplete_dir_enabled lazy_bitfield_enabled lpd_enabled message_level \
-			peer_limit_global peer_limit_per_torrent peer_port \
-			peer_port_random_high peer_port_random_low peer_port_random_on_start \
-			pex_enabled port_forwarding_enabled preallocation prefetch_enabled \
-			ratio_limit ratio_limit_enabled rename_partial_files rpc_authentication_required \
-			rpc_enabled rpc_port rpc_whitelist_enabled queue_stalled_enabled \
-			queue_stalled_minutes scrape_paused_torrents_enabled script_torrent_done_enabled \
-			seed_queue_enabled seed_queue_size \
-			speed_limit_down speed_limit_down_enabled speed_limit_up \
-			speed_limit_up_enabled start_added_torrents trash_original_torrent_files \
-			umask upload_slots_per_torrent utp_enabled scrape_paused_torrents \
-			watch_dir_enabled rpc_host_whitelist_enabled
+	append_params_quotes "$cfg" \
+		blocklist_url bind_address_ipv4 bind_address_ipv6 download_dir incomplete_dir \
+		peer_congestion_algorithm peer_socket_tos rpc_bind_address rpc_password rpc_url \
+		rpc_username rpc_whitelist script_torrent_done_filename watch_dir
 
-		append_params_quotes "$cfg" \
-			blocklist_url bind_address_ipv4 bind_address_ipv6 download_dir incomplete_dir \
-			peer_congestion_algorithm peer_socket_tos rpc_bind_address rpc_password rpc_url \
-			rpc_username rpc_whitelist script_torrent_done_filename watch_dir
+	echo "\"invalid-key\": false" >> $config_file
+	echo "}" >> $config_file
 
-		echo "\""invalid-key"\": false" >> $config_file
-		echo "}" >> $config_file
-
-	}
-
-	cmdline="/usr/bin/transmission-daemon -g $config_dir -f"
-	[ "$ionice_flags" ] && cmdline="ionice $ionice_flags $cmdline"
+	cmdline="transmission-daemon -g $config_dir -f"
 	procd_open_instance
 	procd_set_param command $cmdline
+	procd_set_param env CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+	procd_set_param env TR_CURL_SSL_VERIFY=1
+	procd_set_param user $user
+	procd_set_param group $user
+	procd_set_param nice $nice
 	procd_set_param respawn retry=60
-	procd_set_param user "$user"
-	procd_set_param group "$user"
-	procd_set_param nice "$nice"
-	if test -z "$USE";then
+
+	if test -z $USE; then
 		procd_set_param limits core="0 0"
 	else
 		procd_set_param limits core="0 0" as="$USE $USE"

--- a/net/transmission/patches/030-fix-port-test.patch
+++ b/net/transmission/patches/030-fix-port-test.patch
@@ -1,0 +1,30 @@
+From d6655cca7db1b960456811b8206ce222700e010d Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 30 Jan 2018 13:19:58 -0800
+Subject: [PATCH] Remove compressed responses from web servers.
+
+While zlib is mandatory for transmission, it is not mandatory for curl.
+
+A libcurl that has been compiled with no support for zlib will return no data if compressed responses are set to on.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ libtransmission/web.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libtransmission/web.c b/libtransmission/web.c
+index c7f0627..db34976 100644
+--- a/libtransmission/web.c
++++ b/libtransmission/web.c
+@@ -180,7 +180,7 @@ createEasy (tr_session * s, struct tr_web * web, struct tr_web_task * task)
+   task->timeout_secs = getTimeoutFromURL (task);
+ 
+   curl_easy_setopt (e, CURLOPT_AUTOREFERER, 1L);
+-  curl_easy_setopt (e, CURLOPT_ENCODING, "gzip;q=1.0, deflate, identity");
++  curl_easy_setopt (e, CURLOPT_ENCODING, "");
+   curl_easy_setopt (e, CURLOPT_FOLLOWLOCATION, 1L);
+   curl_easy_setopt (e, CURLOPT_MAXREDIRS, -1L);
+   curl_easy_setopt (e, CURLOPT_NOSIGNAL, 1L);
+-- 
+2.7.4
+


### PR DESCRIPTION
Ran the transmission init script through shellcheck and fixed errors. Also cleaned up a bit.

Removed ionice support. Will reintroduce if procd adds support.

Removed config_overwrite debugging variable. No need for it.

Enabled TLS verify by default. Added a dependancy to ca-bundle as a result. This is a default in current trunk.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me
Compile tested: ramips mt7621
Run tested: ramips mt7621 OpenWrt trunk

