### PR TITLE
unixodbc: fix depends of pgsqlodbc and tools

### DIFF
--- a/libs/unixodbc/Makefile
+++ b/libs/unixodbc/Makefile
@@ -57,7 +57,7 @@ define Package/unixodbc-tools
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE+= Tools
-  DEPENDS:=+unixodbc +libncurses +libreadline
+  DEPENDS:=+unixodbc +PACKAGE_unixodbc-tools:libncurses +PACKAGE_unixodbc-tools:libreadline
 endef
 
 define Package/unixodbc-tools/description
@@ -69,7 +69,7 @@ define Package/pgsqlodbc
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Postgresql driver for ODBC
-  DEPENDS:=+unixodbc +libpq
+  DEPENDS:=+unixodbc +PACKAGE_pgsqlodbc:libpq
 endef
 
 define Package/pgsqlodbc/description


### PR DESCRIPTION
The depends of pgsqlodbc and unixodbc-tools are pulled in even if these
extra packages are not built. Fix this by prefixing the depends with the
respective PACKAGE_* item.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @heil 
Compile tested: arc_archs
Run tested: N/A
Description:
Hi Thomas et al,

I was trying to build kamailio on arc_archs. Even though I didn't have any kamailio module selected that depended on postgresql (which does not build on ARC), postgresql was always attempted to build. This failed always, causing kamailio build to fail as well.

I looked around what was pulling in postgresql unconditionally and found it was unixodbc's Makefile. Here's the fix for that.

Kind regards,
Seb