### PR TITLE
libssh2: Make crypto backends selectable

### DIFF
--- a/libs/libssh2/Config.in
+++ b/libs/libssh2/Config.in
@@ -1,0 +1,15 @@
+if PACKAGE_libssh2
+
+choice
+	prompt "Choose crypto backend"
+	default LIBSSH2_MBEDTLS
+
+	config LIBSSH2_MBEDTLS
+	bool "mbedtls"
+
+	config LIBSSH2_OPENSSL
+	bool "openssl"
+
+endchoice
+
+endif

--- a/libs/libssh2/Makefile
+++ b/libs/libssh2/Makefile
@@ -29,7 +29,7 @@ define Package/libssh2
   CATEGORY:=Libraries
   TITLE:=SSH2 library
   URL:=https://www.libssh2.org/
-  DEPENDS:=+libmbedtls +zlib
+  DEPENDS:=+LIBSSH2_MBEDTLS:libmbedtls +LIBSSH2_OPENSSL:libopenssl +zlib
   MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 endef
 
@@ -37,13 +37,17 @@ define Package/libssh2/description
  libssh2 is a client-side C library implementing the SSH2 protocol.
 endef
 
+define Package/libssh2/config
+	source "$(SOURCE)/Config.in"
+endef
+
 TARGET_CFLAGS += $(FPIC)
 
 CONFIGURE_ARGS += \
 	--disable-examples-build \
 	--disable-silent-rules \
-	--with-mbedtls \
-	--with-libmbedtls-prefix=$(STAGING_DIR)/usr \
+	$(if $(CONFIG_LIBSSH2_MBEDTLS),--with-mbedtls --with-libmbedtls-prefix=$(STAGING_DIR)/usr) \
+	$(if $(CONFIG_LIBSSH2_OPENSSL),--with-openssl --with-libssl-prefix=$(STAGING_DIR)/usr) \
 	--with-libz-prefix=$(STAGING_DIR)/usr
 
 define Build/InstallDev


### PR DESCRIPTION
This adds a choice to menuselect so people can select if they would like
to compile libssh2 against mbedtls (default) or openssl.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @jslachta 
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
Hi Jiri,

@vampik requested in issue #5550 that a choice is added for the crypto backend. Here's the PR for that.

Best regards,
Seb