### PR TITLE
sqlite3-cli: use shared library to link sqlite3 binary

### DIFF
--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqlite
 PKG_VERSION:=3210000
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_VERSION).tar.gz
 PKG_HASH:=d7dd516775005ad87a57f428b6f86afd206cb341722927f104d3f0cf65fbbbe3
@@ -91,7 +91,8 @@ endif
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
-	--disable-editline
+	--disable-editline \
+	--disable-static-shell
 
 CONFIGURE_VARS += \
 	config_BUILD_CC="$(HOSTCC)" \


### PR DESCRIPTION
The sqlite3 binary was linked against the static library of libsqlite3. It now uses the .so library of the libsqlite3 package. This dropped size of sqlite3 binary from 640k to 80k.

The static library is now disabled (--disable-static).

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: lede-17.01.4-ar71xx-nand-wndr3700v4
Run tested: lede-17.01.4-ar71xx-nand-wndr3700v4

Description:
