### PR TITLE
minidlna: decrease minidlna log verbosity

### DIFF
--- a/multimedia/minidlna/Makefile
+++ b/multimedia/minidlna/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=minidlna
 PKG_VERSION:=1.2.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=@SF/minidlna
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/multimedia/minidlna/files/minidlna.init
+++ b/multimedia/minidlna/files/minidlna.init
@@ -57,6 +57,7 @@ minidlna_create_config() {
 	minidlna_cfg_addstr $cfg friendly_name
 	minidlna_cfg_addstr $cfg db_dir
 	minidlna_cfg_addstr $cfg log_dir
+	minidlna_cfg_addstr $cfg log_level 'error'
 	minidlna_cfg_addbool $cfg inotify '1'
 	minidlna_cfg_addbool $cfg enable_tivo '0'
 	minidlna_cfg_addbool $cfg wide_links '0'


### PR DESCRIPTION
Some clients do not close connections properly or do not keep
it alive, so each time the connection times out a corresponding
log entry is written into a log.
This may be an issue if log is placed on internal flash - it may
prematurely wear a flash chip. This also prevents hdd from spinning
down if the log is located on hdd and the dlna capable tv is online.

Set the log level to "error" by default.

MAN:
Set this to change the verbosity of the information that is logged
each  section can use a different level: off, fatal, error, warn,
info, or debug
Example
log_level=general,artwork,database,inotify,scanner,metadata,http,ssdp,tivo=warn

Maintainer: @medaved 
Compile and run tested: ipq806x