### PR TITLE
Pulseaudio: variant avahi/bluez

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pulseaudio
 PKG_VERSION:=11.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://freedesktop.org/software/pulseaudio/releases/
@@ -21,6 +21,8 @@ PKG_BUILD_DEPENDS:=intltool/host
 
 PKG_FIXUP:=autoreconf
 PKG_USE_MIPS16:=0
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_INSTALL = 1
 
@@ -41,6 +43,15 @@ endef
 
 define Package/pulseaudio-daemon
   $(call Package/pulseaudio/Default)
+  VARIANT:=noavahi
+endef
+
+define Package/pulseaudio-daemon-avahi
+  $(call Package/pulseaudio/Default)
+  DEPENDS+=+dbus +libavahi-client +sbc
+#  DEPENDS+=+avahi-daemon 
+  TITLE+= (avahi/bluez)
+  VARIANT:=avahi
 endef
 
 define Package/pulseaudio/Default/description
@@ -51,7 +62,19 @@ define Package/pulseaudio-daemon/description
   $(call Package/pulseaudio/Default/description)
 endef
 
+define Package/pulseaudio-daemon-avahi/description
+  $(call Package/pulseaudio/Default/description)
+  This package enables avahi,bluez and is compiled against dbus, sbc, and avahi.
+endef
+
 define Package/pulseaudio-daemon/conffiles
+/etc/pulse/client.conf
+/etc/pulse/daemon.conf
+/etc/pulse/default.pa
+/etc/pulse/system.pa
+endef
+
+define Package/pulseaudio-daemon-avahi/conffiles
 /etc/pulse/client.conf
 /etc/pulse/daemon.conf
 /etc/pulse/default.pa
@@ -64,6 +87,7 @@ define Package/pulseaudio-tools
   DEPENDS:=+libsndfile +pulseaudio
   TITLE:=Tools for Pulseaudio
   URL:=http://www.pulseaudio.org
+  VARIANT:=noavahi
 endef
 
 define Package/pulseaudio-profiles
@@ -94,13 +118,23 @@ CONFIGURE_ARGS += \
 	--disable-jack \
 	--disable-asyncns \
 	--disable-lirc \
-	--disable-bluez \
 	--disable-udev \
 	--without-fftw \
-	--disable-avahi \
-	--disable-dbus \
 	--without-soxr \
 	--without-speex
+# --disable-bluez
+
+ifeq ($(BUILD_VARIANT),avahi)
+CONFIGURE_ARGS += \
+	--enable-avahi \
+	--enable-dbus
+endif
+
+ifeq ($(BUILD_VARIANT),noavahi)
+CONFIGURE_ARGS += \
+	--disable-avahi \
+	--disable-dbus
+endif
 
 CONFIGURE_VARS += \
 	PKG_CONFIG_LIBDIR="$(STAGING_DIR)/usr/lib/pkgconfig"
@@ -167,6 +201,49 @@ define Package/pulseaudio-daemon/install
 
 endef
 
+define Package/pulseaudio-daemon-avahi/install
+	$(INSTALL_DIR) \
+		$(1)/etc/pulse \
+		$(1)/etc/init.d \
+		$(1)/usr/bin \
+		$(1)/usr/lib \
+		$(1)/usr/lib/pulseaudio \
+		$(1)/usr/lib/pulse-$(PKG_VERSION)/modules \
+		$(1)/etc/dbus-1/system.d
+
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/bin/pulseaudio \
+		$(1)/usr/bin/pulseaudio
+
+	$(INSTALL_BIN) \
+		./files/pulseaudio.init \
+		$(1)/etc/init.d/pulseaudio
+
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)/etc/pulse/* \
+		$(1)/etc/pulse
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/*.so* \
+		$(1)/usr/lib/
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/pulseaudio/* \
+		$(1)/usr/lib/pulseaudio/
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/pulse-$(PKG_VERSION)/modules/lib*.so \
+		$(1)/usr/lib/
+
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/pulse-$(PKG_VERSION)/modules/module*.so \
+		$(1)/usr/lib/pulse-$(PKG_VERSION)/modules/
+
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)/etc/dbus-1/system.d/pulseaudio-system.conf \
+		$(1)/etc/dbus-1/system.d/pulseaudio-system.conf
+endef
+
 define Package/pulseaudio-tools/install
 	$(INSTALL_DIR) \
 		$(1)/usr/bin
@@ -191,5 +268,6 @@ define Package/pulseaudio-profiles/install
 endef
 
 $(eval $(call BuildPackage,pulseaudio-daemon))
+$(eval $(call BuildPackage,pulseaudio-daemon-avahi))
 $(eval $(call BuildPackage,pulseaudio-tools))
 $(eval $(call BuildPackage,pulseaudio-profiles))


### PR DESCRIPTION
UNDEAD package pulseaudio-daemon-avahi
Removed pulseaudio-system.conf as travis fails on it
Signed-off-by: Johnny Vogels <35307256+jmv2009@users.noreply.github.com>




Builds/packages will enable bluetooth audio, stereo a2dp and avahi-zeroconf. I combined them, as both require dbus.


Maintainer: @tripolar
Compile tested: (x86, generic, master)
Run tested: (x86, generic, master). Get pulseaudio loaded, stereo a2dp functionality

Description:
Enable bluez and avahi modules in UNDEAD package "pulseaudio-daemon-avahi". Should not impact other packages.
Is reversal of https://github.com/openwrt/packages/commit/4b1fad86f85bed0d867324c21d7e4a75d9957bfc
See issue https://github.com/openwrt/packages/issues/5487.
Misc: Removal of libavahi-daemon in DEPENDS. Added sbc to DEPENDS for bluez. Removal of --disable-bluez (does not work anyway). Description of package included bluez:"This package enables avahi, bluez and is compiled against dbus, sbc, and avahi." Separate packages build in their own folder (which enables building in travis, improves the building of packages, and the placement of pulseaudio-system.conf).

Question: Shouldn't it be compiled with udev and speex support as well, as recommended by the pulseaudio package?

*************
This largely follows https://wiki.openwrt.org/doc/howto/bluetooth.audio:
Note:
Additional changes to files on system may be required to activate bluetooth:

Files to change on system are:

/etc/init.d/pulseaudio
remove `--disable-module-loading`

/etc/pulse/system.pa
add `load-module module-bluez5-discover` and `load-module module-bluetooth-policy`

/etc/dbus-1/system.d/bluetooth.conf
add 
```
    <allow send_type="method_call"/>
    <allow send_type="method_return"/>
```
under the org.bluez line and

/etc/dbus-1/system.d/pulseaudio-system.conf
add 
```
    <allow send_type="method_call"/>
    <allow send_type="method_return"/>
```
under the org.pulseaudio.Server line.

uinput may be required for some bluetooth functionality (AVRCP)