### PR TITLE
prometheus-node-exporter-lua: add bmx6/7 scraper

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -58,6 +58,18 @@ define Package/prometheus-node-exporter-lua-wifi_stations
   DEPENDS:=prometheus-node-exporter-lua +libiwinfo-lua +libubus-lua
 endef
 
+define Package/prometheus-node-exporter-lua-bmx6
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (bmx6 links collector)
+  DEPENDS:=prometheus-node-exporter-lua bmx6 +lua-cjson +bmx6-json
+endef
+
+define Package/prometheus-node-exporter-lua-bmx7
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (bmx7 links collector)
+  DEPENDS:=prometheus-node-exporter-lua bmx7 +lua-cjson +bmx7-json
+endef
+
 Build/Compile=
 
 define Package/prometheus-node-exporter-lua/install
@@ -97,8 +109,20 @@ define Package/prometheus-node-exporter-lua-wifi_stations/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/wifi_stations.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
+define Package/prometheus-node-exporter-lua-bmx6/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/bmx6.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
+define Package/prometheus-node-exporter-lua-bmx7/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/bmx7.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
 $(eval $(call BuildPackage,prometheus-node-exporter-lua))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-nat_traffic))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-netstat))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi_stations))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx6))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx7))

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/bmx6.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/bmx6.lua
@@ -1,0 +1,39 @@
+#!/usr/bin/lua
+
+local json = require "cjson"
+
+local function interpret_suffix(rate)
+  local value = string.sub(rate, 1, -2)
+  local suffix = string.sub(rate, -1)
+  if suffix == "K" then return tonumber(value) * 10^3 end
+  if suffix == "M" then return tonumber(value) * 10^6 end
+  if suffix == "G" then return tonumber(value) * 10^9 end
+  return rate
+end
+
+local function scrape()
+  local status = json.decode(get_contents("/var/run/bmx6/json/status")).status
+  local labels = {
+    version = status.version,
+    id = status.name,
+    address = status.primaryIp
+  }
+
+  metric("bmx6_status", "gauge", labels, 1)
+
+  local links = json.decode(get_contents("/var/run/bmx6/json/links")).links
+  local metric_bmx6_rxRate = metric("bmx6_link_rxRate","gauge")
+  local metric_bmx6_txRate = metric("bmx6_link_txRate","gauge")
+
+  for _, link in pairs(links) do
+    local labels = {
+      source = status.name,
+      target = link.name,
+      dev = link.viaDev
+    }
+    metric_bmx6_rxRate(labels, interpret_suffix(link.rxRate))
+    metric_bmx6_txRate(labels, interpret_suffix(link.txRate))
+  end
+end
+
+return { scrape = scrape }

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/bmx7.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/bmx7.lua
@@ -1,0 +1,45 @@
+#!/usr/bin/lua
+
+local json = require "cjson"
+
+local function interpret_suffix(rate)
+  if rate ~= nil then
+    local value = string.sub(rate, 1, -2)
+    local suffix = string.sub(rate, -1)
+    if suffix == "K" then return tonumber(value) * 10^3 end
+    if suffix == "M" then return tonumber(value) * 10^6 end
+    if suffix == "G" then return tonumber(value) * 10^9 end
+  end
+  return rate
+end
+
+local function scrape()
+  local status = json.decode(get_contents("/var/run/bmx7/json/status")).status
+  local labels = {
+    id = status.shortId,
+    name = status.name,
+    address = status.primaryIp,
+    revision = status.revision,
+  }
+
+  metric("bmx7_status", "gauge", labels, 1)
+  metric("bmx7_cpu_usage", "gauge", nil, status.cpu)
+  metric("bmx7_mem_usage", "gauge", nil, interpret_suffix(status.mem))
+
+  local links = json.decode(get_contents("/var/run/bmx7/json/links")).links
+  local metric_bmx7_rxRate = metric("bmx7_link_rxRate","gauge")
+  local metric_bmx7_txRate = metric("bmx7_link_txRate","gauge")
+
+  for _, link in pairs(links) do
+    local labels = {
+      source = status.shortId,
+      target = link.shortId,
+      name = link.name,
+      dev = link.dev
+    }
+    metric_bmx7_rxRate(labels, interpret_suffix(link.rxRate))
+    metric_bmx7_txRate(labels, interpret_suffix(link.txRate))
+    end
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
Maintainer: @champtar
Compile tested: snapshot ramips/mt7620
Run tested: snapshot ar71xx/generic

Description:

example output:
```
# TYPE bmx6_status gauge
bmx6_status{id="qMp-LibreMesh-1706",version="BMX6-0.1-alpha",address="fd66:66:66:a:6670:2ff:fe3e:9d28"} 1
# TYPE bmx6_link_rxRate gauge
# TYPE bmx6_link_txRate gauge
bmx6_link_rxRate{target="UPC-CN-C6-E104-Alix",source="qMp-LibreMesh-1706",dev="wlan0-mesh_12"} 100
bmx6_link_txRate{target="UPC-CN-C6-E104-Alix",source="qMp-LibreMesh-1706",dev="wlan0-mesh_12"} 100
bmx6_link_rxRate{target="UPC-CN-C6-E104-Alix-Paul",source="qMp-LibreMesh-1706",dev="wlan1-adhoc_12"} 100
bmx6_link_txRate{target="UPC-CN-C6-E104-Alix-Paul",source="qMp-LibreMesh-1706",dev="wlan1-adhoc_12"} 100
bmx6_link_rxRate{target="UPC-CN-C6-E104-Turoffner",source="qMp-LibreMesh-1706",dev="wlan0-mesh_12"} 97
bmx6_link_txRate{target="UPC-CN-C6-E104-Turoffner",source="qMp-LibreMesh-1706",dev="wlan0-mesh_12"} 100
node_scrape_collector_duration_seconds{collector="bmx6"} 0.0025260448455811
node_scrape_collector_success{collector="bmx6"} 1
```


scrapes bmx7 status and connected links.

example output:
```
# TYPE bmx7_status gauge
bmx7_status{id="C68791D2",revision="3a52f89",name="smpl-18f4ce",address="fd70:c687:91d2:8ab3:1a88:6b14:bad0:2b18"} 1
# TYPE bmx7_cpu_usage gauge
bmx7_cpu_usage 0.7
# TYPE bmx7_mem_usage gauge
bmx7_mem_usage 3204000
# TYPE bmx7_link_rxRate gauge
# TYPE bmx7_link_txRate gauge
bmx7_link_rxRate{target="F48239CD",dev="wlan0-mesh_13",source="C68791D2",name="smpl-07889a"} 54000
bmx7_link_txRate{target="F48239CD",dev="wlan0-mesh_13",source="C68791D2",name="smpl-07889a"} 52729
node_scrape_collector_duration_seconds{collector="bmx7"} 0.0020999908447266
node_scrape_collector_success{collector="bmx7"} 1
```

the mem usage is fixed in upstream bmx7 and so not yet shown here.

Signed-off-by: Paul Spooren <spooren@informatik.uni-leipzig.de>