### PR TITLE
net-snmp: remove cached user credentials

### DIFF
--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -271,6 +271,7 @@ snmpd_setup_fw_rules() {
 
 start_service() {
 	[ -f "$CONFIGFILE" ] && rm -f "$CONFIGFILE"
+	rm -rf /usr/lib/snmp/*
 
 	config_load snmpd
 
@@ -325,6 +326,7 @@ start_service() {
 
 stop_service() {
 	[ -f "$CONFIGFILE" ] && rm -f "$CONFIGFILE"
+	rm -rf /usr/lib/snmp/*
 }
 
 service_triggers(){


### PR DESCRIPTION
net-snmp caches the user credentials in /usr/lib/snmp/*. If the user
credentials are changed later in UCI, these changes will not get updated
upon a restart and net-snmp will run with the old credentials.

Therefore, clean up the cache on each service start/stop.

Signed-off-by: Simon Wunderlich <sw@simonwunderlich.de>

Description: I've found this problem and fixed it on an older net-snmp version (5.4.4), but it doesn't look like much changed since then. I'd suggest to test it first, though.
