### PR TITLE
gst1-plugins-bad: update to 1.12.4

### DIFF
--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-bad
-PKG_VERSION:=1.10.5
+PKG_VERSION:=1.12.4
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
@@ -20,7 +20,7 @@ PKG_LICENSE_FILES:=COPYING.LIB COPYING
 PKG_BUILD_DIR:=$(BUILD_DIR)/gst-plugins-bad-$(PKG_VERSION)
 PKG_SOURCE:=gst-plugins-bad-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-plugins-bad/
-PKG_HASH:=c5806040bb83b43be86ce592e6a19c5d83d7776f7d9f434eb4b911c4efff3573
+PKG_HASH:=0c7857be16686d5c1ba6e34bd338664d3d4599d32714a8eca5c8a41a101e2d08
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -243,8 +243,8 @@ $(eval $(call GstBuildPlugin,aiff,aiff support,audio tag,,))
 $(eval $(call GstBuildPlugin,asfmux,asf muxing support,rtp,,))
 $(eval $(call GstBuildPlugin,autoconvert,autoconvert support,,,))
 $(eval $(call GstBuildPlugin,bayer,bayer support,video,,))
-$(eval $(call GstBuildPlugin,camerabin2,camerabin support,basecamerabinsrc photography pbutils app,,))
-$(eval $(call GstBuildPlugin,dataurisrc,dataurisrc support,,,))
+$(eval $(call GstBuildPlugin,camerabin,camerabin support,basecamerabinsrc photography pbutils app,,))
+#$(eval $(call GstBuildPlugin,dataurisrc,dataurisrc support,,,))
 $(eval $(call GstBuildPlugin,debugutilsbad,debugutils support,video,,))
 $(eval $(call GstBuildPlugin,dvdspu,dvdspu support,video,,))
 $(eval $(call GstBuildPlugin,fbdevsink,fbdev support,video,,))
@@ -261,7 +261,7 @@ $(eval $(call GstBuildPlugin,mxf,mxf support,badbase audio video,,))
 $(eval $(call GstBuildPlugin,opusparse,OPUS streams library,pbutils,,+libopus))
 $(eval $(call GstBuildPlugin,pcapparse,pcapparse support,,,))
 $(eval $(call GstBuildPlugin,pnm,pnm support,video,,))
-$(eval $(call GstBuildPlugin,rawparse,rawparse support,audio video,,))
+#$(eval $(call GstBuildPlugin,rawparse,rawparse support,audio video,,))
 $(eval $(call GstBuildPlugin,rfbsrc,librfb support,video,,))
 $(eval $(call GstBuildPlugin,sdpelem,sdp support,rtp sdp,,))
 $(eval $(call GstBuildPlugin,segmentclip,segmentclip support,audio,,))

--- a/multimedia/gst1-plugins-bad/patches/001-no-translations.patch
+++ b/multimedia/gst1-plugins-bad/patches/001-no-translations.patch
@@ -1,16 +1,18 @@
---- a/configure.ac
-+++ b/configure.ac
-@@ -3841,7 +3841,6 @@ ext/xvid/Makefile
- ext/zbar/Makefile
+diff -u --recursive gst-plugins-bad-1.12.4-vanilla/configure.ac gst-plugins-bad-1.12.4/configure.ac
+--- gst-plugins-bad-1.12.4-vanilla/configure.ac	2018-02-11 19:43:06.962320214 -0500
++++ gst-plugins-bad-1.12.4/configure.ac	2018-02-11 19:43:48.643416395 -0500
+@@ -3717,7 +3717,6 @@
  ext/dtls/Makefile
  ext/webrtcdsp/Makefile
+ ext/ttml/Makefile
 -po/Makefile.in
  docs/Makefile
  docs/plugins/Makefile
  docs/libs/Makefile
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -2,11 +2,11 @@ DISTCHECK_CONFIGURE_FLAGS=--enable-gtk-d
+diff -u --recursive gst-plugins-bad-1.12.4-vanilla/Makefile.am gst-plugins-bad-1.12.4/Makefile.am
+--- gst-plugins-bad-1.12.4-vanilla/Makefile.am	2018-02-11 19:43:06.987320271 -0500
++++ gst-plugins-bad-1.12.4/Makefile.am	2018-02-11 19:43:55.023431118 -0500
+@@ -2,11 +2,11 @@
  
  SUBDIRS = \
  	gst-libs gst sys ext pkgconfig \

--- a/multimedia/gst1-plugins-bad/patches/002-no-tests.patch
+++ b/multimedia/gst1-plugins-bad/patches/002-no-tests.patch
@@ -1,7 +1,8 @@
---- a/configure.ac
-+++ b/configure.ac
-@@ -3739,37 +3739,6 @@ sys/wasapi/Makefile
- sys/wininet/Makefile
+diff -u --recursive gst-plugins-bad-1.12.4-vanilla/configure.ac gst-plugins-bad-1.12.4/configure.ac
+--- gst-plugins-bad-1.12.4-vanilla/configure.ac	2018-02-11 19:46:16.942758605 -0500
++++ gst-plugins-bad-1.12.4/configure.ac	2018-02-11 19:46:38.356808019 -0500
+@@ -3619,38 +3619,6 @@
+ sys/wasapi/Makefile
  sys/winks/Makefile
  sys/winscreencap/Makefile
 -tests/Makefile
@@ -12,6 +13,7 @@
 -tests/examples/camerabin2/Makefile
 -tests/examples/codecparsers/Makefile
 -tests/examples/directfb/Makefile
+-tests/examples/audiomixmatrix/Makefile
 -tests/examples/gl/Makefile
 -tests/examples/gl/cocoa/Makefile
 -tests/examples/gl/clutter/Makefile
@@ -38,9 +40,10 @@
  ext/voamrwbenc/Makefile
  ext/voaacenc/Makefile
  ext/assrender/Makefile
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -2,11 +2,11 @@ DISTCHECK_CONFIGURE_FLAGS=--enable-gtk-d
+diff -u --recursive gst-plugins-bad-1.12.4-vanilla/Makefile.am gst-plugins-bad-1.12.4/Makefile.am
+--- gst-plugins-bad-1.12.4-vanilla/Makefile.am	2018-02-11 19:46:16.980758692 -0500
++++ gst-plugins-bad-1.12.4/Makefile.am	2018-02-11 19:46:49.443833603 -0500
+@@ -2,11 +2,11 @@
  
  SUBDIRS = \
  	gst-libs gst sys ext pkgconfig \


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64

Description:
gst1-plugins-bad: update to 1.12.4
Requires pull #5593