### PR TITLE
dht: Add package

### DIFF
--- a/libs/dht/Makefile
+++ b/libs/dht/Makefile
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2018 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dht
+PKG_VERSION:=0.25
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/jech/dht/archive
+PKG_HASH:=68099eb95a0d3f34d796696a2b17439a46b3e3e30db0bfe9ff65ce281db0cfeb
+PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENCE
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/dht
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=DHT Library
+  URL:=https://www.irif.fr/~jch//software/bittorrent/
+endef
+
+define Package/dht/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libdht.so $(1)/usr/lib/
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libdht.so $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/include/dht
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/dht/dht.h $(1)/usr/include/dht/
+endef
+
+$(eval $(call BuildPackage,dht))

--- a/libs/dht/patches/001-add-cmake.patch
+++ b/libs/dht/patches/001-add-cmake.patch
@@ -1,0 +1,32 @@
+From 472efb82184b67686ae31316dfc05026926d7f31 Mon Sep 17 00:00:00 2001
+From: Mike Gelfand <mikedld@mikedld.com>
+Date: Sun, 1 Jan 2017 16:23:21 +0300
+Subject: [PATCH] Remove Makefile, add Makefile.am and CMakeLists.txt
+
+---
+ CMakeLists.txt |  9 +++++++++
+ Makefile       |  9 ---------
+ Makefile.am    | 11 +++++++++++
+ 3 files changed, 20 insertions(+), 9 deletions(-)
+ create mode 100644 CMakeLists.txt
+ delete mode 100644 Makefile
+ create mode 100644 Makefile.am
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..4c0d2c0
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,9 @@
++cmake_minimum_required(VERSION 2.8)
++project(dht C)
++
++add_library(${PROJECT_NAME} SHARED
++    dht.c
++)
++
++install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION lib)
++install(FILES dht.h DESTINATION include/dht)
+-- 
+2.14.3
+


### PR DESCRIPTION
dht is a library implementing Distributed Hash Table support.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me
Compile tested: ar71xx

Description:
This library is used by Transmission. Adding it separately since this is a newer version than the built-in one.