### PR TITLE
libb64: Add new package

### DIFF
--- a/libs/libb64/Makefile
+++ b/libs/libb64/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2018 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libb64
+PKG_VERSION:=1.2.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
+PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)
+PKG_HASH:=20106f0ba95cfd9c35a13c71206643e3fb3e46512df3e2efb2fdbf87116314b2
+PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/libb64
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=base64 library
+  URL:=http://libb64.sourceforge.net/
+endef
+
+define Package/libb64/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libb64.so $(1)/usr/lib/
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libb64.so $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/include/b64
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/include/b64/* $(1)/usr/include/b64/
+endef
+
+$(eval $(call BuildPackage,libb64))

--- a/libs/libb64/patches/0001-Remove-Makefile-add-Makefile.am-and-CMakeLists.txt.patch
+++ b/libs/libb64/patches/0001-Remove-Makefile-add-Makefile.am-and-CMakeLists.txt.patch
@@ -1,0 +1,83 @@
+From f0277a79471fc9b944c60c92a29b01c6ad3ee8a7 Mon Sep 17 00:00:00 2001
+From: Mike Gelfand <mikedld@mikedld.com>
+Date: Sun, 1 Jan 2017 16:49:15 +0300
+Subject: [PATCH 1/3] Remove Makefile, add Makefile.am and CMakeLists.txt
+
+---
+ CMakeLists.txt | 12 ++++++++++++
+ Makefile       | 31 -------------------------------
+ Makefile.am    |  5 +++++
+ 3 files changed, 17 insertions(+), 31 deletions(-)
+ create mode 100644 CMakeLists.txt
+ delete mode 100644 Makefile
+ create mode 100644 Makefile.am
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..d51293f
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,12 @@
++cmake_minimum_required(VERSION 2.8)
++project(b64 C)
++
++include_directories(include)
++
++add_library(${PROJECT_NAME} SHARED
++    src/cdecode.c
++    src/cencode.c
++)
++
++install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION lib)
++install(DIRECTORY include/b64 DESTINATION include)
+diff --git a/Makefile b/Makefile
+deleted file mode 100644
+index db40356..0000000
+--- a/Makefile
++++ /dev/null
+@@ -1,31 +0,0 @@
+-all: all_src all_base64 all_examples
+-
+-all_src:
+-	$(MAKE) -C src
+-all_base64: all_src
+-	$(MAKE) -C base64
+-all_examples:
+-	$(MAKE) -C examples
+-	
+-clean: clean_src clean_base64 clean_include clean_examples
+-	rm -f *~ *.bak
+-
+-clean_include:
+-	rm -f include/b64/*~
+-
+-clean_src:
+-	$(MAKE) -C src clean;
+-clean_base64:
+-	$(MAKE) -C base64 clean;
+-clean_examples:
+-	$(MAKE) -C examples clean;
+-		
+-distclean: clean distclean_src distclean_base64 distclean_examples
+-
+-distclean_src:
+-	$(MAKE) -C src distclean;
+-distclean_base64:
+-	$(MAKE) -C base64 distclean;
+-distclean_examples:
+-	$(MAKE) -C examples distclean;
+-
+diff --git a/Makefile.am b/Makefile.am
+new file mode 100644
+index 0000000..d7801d7
+--- /dev/null
++++ b/Makefile.am
+@@ -0,0 +1,5 @@
++AM_CPPFLAGS = -I$(srcdir)/include
++noinst_LIBRARIES = libb64.a
++libb64_a_SOURCES = src/cdecode.c src/cencode.c
++noinst_HEADERS = include/b64/cdecode.h include/b64/cencode.h include/b64/decode.h include/b64/encode.h
++EXTRA_DIST = AUTHORS CHANGELOG CMakeLists.txt INSTALL LICENSE README
+-- 
+2.14.3
+

--- a/libs/libb64/patches/0002-Work-properly-when-char-is-unsigned.-Fixes-upsteam-S.patch
+++ b/libs/libb64/patches/0002-Work-properly-when-char-is-unsigned.-Fixes-upsteam-S.patch
@@ -1,0 +1,70 @@
+From c30e15786beea42a84ae15f3dd8dff9bbd934547 Mon Sep 17 00:00:00 2001
+From: Mike Gelfand <mikedld@mikedld.com>
+Date: Sun, 1 Jan 2017 16:59:38 +0300
+Subject: [PATCH 2/3] Work properly when char is unsigned. Fixes upsteam SF-1.
+
+---
+ src/cdecode.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/cdecode.c b/src/cdecode.c
+index a6c0a42..d9ca881 100644
+--- a/src/cdecode.c
++++ b/src/cdecode.c
+@@ -9,7 +9,7 @@ For details, see http://sourceforge.net/projects/libb64
+ 
+ int base64_decode_value(char value_in)
+ {
+-	static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
++	static const signed char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
+ 	static const char decoding_size = sizeof(decoding);
+ 	value_in -= 43;
+ 	if (value_in < 0 || value_in >= decoding_size) return -1;
+@@ -26,7 +26,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
+ {
+ 	const char* codechar = code_in;
+ 	char* plainchar = plaintext_out;
+-	char fragment;
++	int fragment;
+ 	
+ 	*plainchar = state_in->plainchar;
+ 	
+@@ -42,7 +42,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
+ 					state_in->plainchar = *plainchar;
+ 					return plainchar - plaintext_out;
+ 				}
+-				fragment = (char)base64_decode_value(*codechar++);
++				fragment = base64_decode_value(*codechar++);
+ 			} while (fragment < 0);
+ 			*plainchar    = (fragment & 0x03f) << 2;
+ 	case step_b:
+@@ -53,7 +53,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
+ 					state_in->plainchar = *plainchar;
+ 					return plainchar - plaintext_out;
+ 				}
+-				fragment = (char)base64_decode_value(*codechar++);
++				fragment = base64_decode_value(*codechar++);
+ 			} while (fragment < 0);
+ 			*plainchar++ |= (fragment & 0x030) >> 4;
+ 			*plainchar    = (fragment & 0x00f) << 4;
+@@ -65,7 +65,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
+ 					state_in->plainchar = *plainchar;
+ 					return plainchar - plaintext_out;
+ 				}
+-				fragment = (char)base64_decode_value(*codechar++);
++				fragment = base64_decode_value(*codechar++);
+ 			} while (fragment < 0);
+ 			*plainchar++ |= (fragment & 0x03c) >> 2;
+ 			*plainchar    = (fragment & 0x003) << 6;
+@@ -77,7 +77,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
+ 					state_in->plainchar = *plainchar;
+ 					return plainchar - plaintext_out;
+ 				}
+-				fragment = (char)base64_decode_value(*codechar++);
++				fragment = base64_decode_value(*codechar++);
+ 			} while (fragment < 0);
+ 			*plainchar++   |= (fragment & 0x03f);
+ 		}
+-- 
+2.14.3
+

--- a/libs/libb64/patches/0003-Don-t-break-lines-at-72-chars-boundary.patch
+++ b/libs/libb64/patches/0003-Don-t-break-lines-at-72-chars-boundary.patch
@@ -1,0 +1,51 @@
+From 8456a5b5c99ef4544a2ed8e8f20a2fb673dd4192 Mon Sep 17 00:00:00 2001
+From: Mike Gelfand <mikedld@mikedld.com>
+Date: Sun, 1 Jan 2017 17:33:32 +0300
+Subject: [PATCH 3/3] Don't break lines at 72 chars boundary
+
+---
+ src/cencode.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/cencode.c b/src/cencode.c
+index 03ba5b6..de3902f 100644
+--- a/src/cencode.c
++++ b/src/cencode.c
+@@ -7,7 +7,9 @@ For details, see http://sourceforge.net/projects/libb64
+ 
+ #include <b64/cencode.h>
+ 
++/*
+ const int CHARS_PER_LINE = 72;
++*/
+ 
+ void base64_init_encodestate(base64_encodestate* state_in)
+ {
+@@ -72,12 +74,14 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
+ 			result  = (fragment & 0x03f) >> 0;
+ 			*codechar++ = base64_encode_value(result);
+ 			
++			/*
+ 			++(state_in->stepcount);
+ 			if (state_in->stepcount == CHARS_PER_LINE/4)
+ 			{
+ 				*codechar++ = '\n';
+ 				state_in->stepcount = 0;
+ 			}
++			*/
+ 		}
+ 	}
+ 	/* control should not reach here */
+@@ -102,7 +106,9 @@ int base64_encode_blockend(char* code_out, base64_encodestate* state_in)
+ 	case step_A:
+ 		break;
+ 	}
++	/*
+ 	*codechar++ = '\n';
++	*/
+ 	
+ 	return codechar - code_out;
+ }
+-- 
+2.14.3
+


### PR DESCRIPTION
library for fast base64 encoding and decoding

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me
Compile tested: ar71xx

Description:
library used by Transmission. Making it a separate package due to Travis breakage.