### PR TITLE
libvpx: bump to 1.7.0

### DIFF
--- a/libs/libvpx/Makefile
+++ b/libs/libvpx/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libvpx
-PKG_VERSION:=1.6.1
+PKG_VERSION:=1.7.0
 PKG_RELEASE:=1
 
 PKG_REV:=v$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_REV).tar.gz
-PKG_MIRROR_HASH:=3c1e9ef2b40f71daa5c75e83dc682dc50acce597a34cd17d167f46ff2f6d08b7
+PKG_MIRROR_HASH:=be50ff18464d614a08726597ecbd72d1f11ec69ec04df2d9acdf646ecd9adcca
 PKG_SOURCE_URL:=https://chromium.googlesource.com/webm/libvpx
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_REV)


### PR DESCRIPTION
This release focused on high bit depth performance (10/12 bit) and vp9
encoding improvements.

See: https://chromium.googlesource.com/webm/libvpx/+/v1.7.0

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me
Compile tested: r6074-267873ac9b x86, ar71xx
Run tested: r6074-267873ac9b x86 using:

```
OpenWrt$ cd /www && gst-launch-1.0 videotestsrc is-live=true ! vp8enc ! webmmux streamable=true ! hlssink max-files=5
OpenWrt$ cd /www && gst-launch-1.0 videotestsrc is-live=true ! vp9enc ! webmmux streamable=true ! hlssink max-files=5
PC$ gst-play-1.0 http://192.168.1.1/playlist.m3u8
```