### PR TITLE
perl-mod: add authen-sasl

### DIFF
--- a/lang/perl-authen-sasl-xs/Makefile
+++ b/lang/perl-authen-sasl-xs/Makefile
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2017 Philip Prindeville <philipp@redfish-solutions.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-authen-sasl-xs
+PKG_VERSION:=1.00
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=Authen-SASL-XS
+PKG_SOURCE_URL:=http://www.cpan.org/authors/id/G/GB/GBARR/
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=1b0eaa0e7ac3a45857147d837e3d34c80c6eca1d9fdcb826a213c2a105454234
+
+PKG_LICENSE:=GPL-1.0+ Artistic-1.0-Perl
+PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-authen-sasl-xs
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Authen::XS hooks into libsasl.
+  URL:=http://search.cpan.org/dist/$(PKG_SOURCE_NAME)/
+  # DEPENDS:=perl +perl-authen-sasl +libsasl2 +perl-devel-checklib/host
+  DEPENDS:=perl +perl-authen-sasl +libsasl2
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-authen-sasl-xs/install
+	$(call perlmod/Install,$(1),Authen)
+endef
+
+
+$(eval $(call BuildPackage,perl-authen-sasl-xs))

--- a/lang/perl-authen-sasl-xs/patches/100-remove-devel-checklib-checks.patch
+++ b/lang/perl-authen-sasl-xs/patches/100-remove-devel-checklib-checks.patch
@@ -1,0 +1,49 @@
+--- a/Makefile.PL	2009-09-22 16:22:09.000000000 -0600
++++ b/Makefile.PL	2018-01-01 18:54:13.023366252 -0700
+@@ -1,7 +1,6 @@
+ # Do yourself a favour, and don't edit this file, see README for build instructions
+ 
+ use ExtUtils::MakeMaker;
+-use Devel::CheckLib;
+ 
+ my @inc_search = qw(/opt/local/include /usr/local/include);
+ my @lib_search = qw(/opt/local/lib64 /usr/local/lib64 /opt/local/lib /usr/local/lib);
+@@ -12,15 +12,7 @@ unless (exists $args{INC} or exists $arg
+ 
+   my @incpath = grep {-d} @inc_search;
+   my @libpath = grep {-d} @lib_search;
+-  my $have_sasl2 = eval {
+-    assert_lib(
+-      lib     => "sasl2",
+-      header  => "sasl/sasl.h",
+-      libpath => \@libpath,
+-      incpath => \@incpath
+-    );
+-    1;
+-  };
++  my $have_sasl2 = 1;
+ 
+   if ($have_sasl2) {
+     $mmopt{DEFINE} = "-DSASL2" unless $use_sasl2;
+@@ -28,13 +27,6 @@ unless (exists $args{INC} or exists $arg
+   }
+   else {
+     exit(0) if $use_sasl2;
+-    @incpath = grep {-d} map { ("$_/sasl", $_) } @inc_search;
+-    check_lib_or_exit(
+-      lib     => "sasl",
+-      header  => "sasl.h",
+-      libpath => \@libpath,
+-      incpath => \@incpath
+-    );
+   }
+ 
+   $mmopt{INC}  = join " ", map {"-I$_"} @incpath;
+@@ -58,7 +50,6 @@ WriteMakefile(
+           repository => 'http://github.com/gbarr/perl-authen-sasl-xs',
+         },
+         build_requires => {
+-          'Devel::CheckLib' => 0,
+         },
+       }
+       )

--- a/lang/perl-authen-sasl/Makefile
+++ b/lang/perl-authen-sasl/Makefile
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2017 Philip Prindeville <philipp@redfish-solutions.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=perl-authen-sasl
+PKG_VERSION:=2.16
+PKG_RELEASE:=1
+
+PKG_SOURCE_NAME:=Authen-SASL
+PKG_SOURCE_URL:=http://www.cpan.org/authors/id/G/GB/GBARR/
+PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=6614fa7518f094f853741b63c73f3627168c5d3aca89b1d02b1016dc32854e09
+
+PKG_LICENSE:=GPL-1.0+ Artistic-1.0-Perl
+PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../perl/perlmod.mk
+
+define Package/perl-authen-sasl
+  SUBMENU:=Perl
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Generic network authentication protocol framework.
+  URL:=http://search.cpan.org/dist/$(PKG_SOURCE_NAME)/
+  DEPENDS:=perl +perlbase-digest
+endef
+
+define Build/Configure
+	$(call perlmod/Configure,,)
+endef
+
+define Build/Compile
+	$(call perlmod/Compile,,)
+endef
+
+define Package/perl-authen-sasl/install
+	$(call perlmod/Install,$(1),Authen)
+endef
+
+
+$(eval $(call BuildPackage,perl-authen-sasl))


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, generic, HEAD (e2ec3f7)
Run tested: same... built .ipk and installed on testbed...  installs fine but I have nothing to test this with

Note: Devel::CheckLib breaks on cross-builds so I've suppressed this

Description: