### PR TITLE
openvswitch: remove dependency on kernel version

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -29,8 +29,6 @@ PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
-SUPPORTED_KERNELS:=LINUX_3_18||LINUX_4_1||LINUX_4_3||LINUX_4_4||LINUX_4_9
-
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python-package.mk
 
@@ -55,7 +53,7 @@ endef
 define Package/openvswitch-base
   $(call Package/openvswitch/Default)
   TITLE:=Open vSwitch Userspace Package (base)
-  DEPENDS:=+libpcap +libopenssl +librt +kmod-openvswitch @($(SUPPORTED_KERNELS))
+  DEPENDS:=+libpcap +libopenssl +librt +kmod-openvswitch
 endef
 
 define Package/openvswitch-base/description


### PR DESCRIPTION
Maintainer: me
Compile tested: n/a
Run tested: n/a

--------------------------------------------------

For a while now OVS has been using the kernel's kmod.
So it doesn't make sense to limit the package build for a specific set of
kernels anymore.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>