### PR TITLE
transmission: Restored config_overwrite due to popular demand.

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=2.93
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/transmission/transmission-releases/raw/master
+PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master
 PKG_HASH:=8815920e0a4499bcdadbbe89a4115092dab42ce5199f71ff9a926cfd12b9b90b
 PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
@@ -32,12 +32,11 @@ define Package/transmission/template
   CATEGORY:=Network
   TITLE:=BitTorrent client
   URL:=http://www.transmissionbt.com
-  MAINTAINER:=Rosen Penev <rosenp@gmail.com>
+  DEPENDS:=+ca-bundle +libcurl +libevent2 +libminiupnpc +libnatpmp +libpthread +librt +zlib
 endef
 
 define Package/transmission-daemon/Default
   $(call Package/transmission/template)
-  DEPENDS:=+ca-bundle +libcurl +libevent2 +libminiupnpc +libpthread +librt +zlib
   USERID:=transmission=224:transmission=224
 endef
 
@@ -55,39 +54,29 @@ define Package/transmission-daemon-mbedtls
   VARIANT:=mbedtls
 endef
 
-define Package/transmission-cli/Default
-  $(call Package/transmission/template)
-  DEPENDS:=+ca-bundle +libcurl +libevent2 +libminiupnpc +libpthread +librt +zlib
-endef
-
 define Package/transmission-cli-openssl
-  $(call Package/transmission-cli/Default)
+  $(call Package/transmission/template)
   TITLE+= (with OpenSSL)
   DEPENDS+=+libopenssl
   VARIANT:=openssl
 endef
 
 define Package/transmission-cli-mbedtls
-  $(call Package/transmission-cli/Default)
+  $(call Package/transmission/template)
   TITLE+= (with mbed TLS)
   DEPENDS+=+libmbedtls
   VARIANT:=mbedtls
 endef
 
-define Package/transmission-remote/Default
-  $(call Package/transmission/template)
-  DEPENDS:=+ca-bundle +libcurl +libevent2 +libminiupnpc +libpthread +librt +zlib
-endef
-
 define Package/transmission-remote-openssl
-  $(call Package/transmission-remote/Default)
+  $(call Package/transmission/template)
   TITLE+= (with OpenSSL)
   DEPENDS+=+libopenssl
   VARIANT:=openssl
 endef
 
 define Package/transmission-remote-mbedtls
-  $(call Package/transmission-remote/Default)
+  $(call Package/transmission/template)
   TITLE+= (with mbed TLS)
   DEPENDS+=+libmbedtls
   VARIANT:=mbedtls

--- a/net/transmission/files/transmission.config
+++ b/net/transmission/files/transmission.config
@@ -1,6 +1,7 @@
 config transmission
 	option enabled 0
 	option config_dir '/tmp/transmission'
+	option config_overwrite '1'
 	option user 'transmission'
 	option mem_percentage 50
 	option nice 10

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -46,6 +46,7 @@ transmission() {
 	local USE
 
 	local user
+	local config_overwrite
 	local download_dir config_dir
 	local mem_percentage
 	local nice
@@ -57,6 +58,7 @@ transmission() {
 	config_get user "$cfg" 'user'
 	config_get download_dir "$cfg" 'download_dir' '/var/etc/transmission'
 	config_get mem_percentage "$cfg" 'mem_percentage' '50'
+	config_get config_overwrite "$cfg" config_overwrite 1
 	config_get nice "$cfg" nice 0
 
 	local MEM=$(sed -ne 's!^MemTotal:[[:space:]]*\([0-9]*\) kB$!\1!p' /proc/meminfo)
@@ -72,33 +74,37 @@ transmission() {
 		[ -z "$user" ] || chown -R "$user:$user" $config_dir
 	}
 
-	echo "{" > $config_file
+	[ "$config_overwrite" == 0 ] || {
 
-	append_params "$cfg" \
-		alt_speed_down alt_speed_enabled alt_speed_time_begin alt_speed_time_day \
-		alt_speed_time_enabled alt_speed_time_end alt_speed_up blocklist_enabled \
-		cache_size_mb download_queue_enabled download_queue_size \
-		dht_enabled encryption idle_seeding_limit idle_seeding_limit_enabled \
-		incomplete_dir_enabled lazy_bitfield_enabled lpd_enabled message_level \
-		peer_limit_global peer_limit_per_torrent peer_port \
-		peer_port_random_high peer_port_random_low peer_port_random_on_start \
-		pex_enabled port_forwarding_enabled preallocation prefetch_enabled \
-		ratio_limit ratio_limit_enabled rename_partial_files rpc_authentication_required \
-		rpc_enabled rpc_port rpc_whitelist_enabled queue_stalled_enabled \
-		queue_stalled_minutes scrape_paused_torrents_enabled script_torrent_done_enabled \
-		seed_queue_enabled seed_queue_size \
-		speed_limit_down speed_limit_down_enabled speed_limit_up \
-		speed_limit_up_enabled start_added_torrents trash_original_torrent_files \
-		umask upload_slots_per_torrent utp_enabled scrape_paused_torrents \
-		watch_dir_enabled rpc_host_whitelist_enabled
+		echo "{" > $config_file
 
-	append_params_quotes "$cfg" \
-		blocklist_url bind_address_ipv4 bind_address_ipv6 download_dir incomplete_dir \
-		peer_congestion_algorithm peer_socket_tos rpc_bind_address rpc_password rpc_url \
-		rpc_username rpc_whitelist script_torrent_done_filename watch_dir
+		append_params "$cfg" \
+			alt_speed_down alt_speed_enabled alt_speed_time_begin alt_speed_time_day \
+			alt_speed_time_enabled alt_speed_time_end alt_speed_up blocklist_enabled \
+			cache_size_mb download_queue_enabled download_queue_size \
+			dht_enabled encryption idle_seeding_limit idle_seeding_limit_enabled \
+			incomplete_dir_enabled lazy_bitfield_enabled lpd_enabled message_level \
+			peer_limit_global peer_limit_per_torrent peer_port \
+			peer_port_random_high peer_port_random_low peer_port_random_on_start \
+			pex_enabled port_forwarding_enabled preallocation prefetch_enabled \
+			ratio_limit ratio_limit_enabled rename_partial_files rpc_authentication_required \
+			rpc_enabled rpc_port rpc_whitelist_enabled queue_stalled_enabled \
+			queue_stalled_minutes scrape_paused_torrents_enabled script_torrent_done_enabled \
+			seed_queue_enabled seed_queue_size \
+			speed_limit_down speed_limit_down_enabled speed_limit_up \
+			speed_limit_up_enabled start_added_torrents trash_original_torrent_files \
+			umask upload_slots_per_torrent utp_enabled scrape_paused_torrents \
+			watch_dir_enabled rpc_host_whitelist_enabled
 
-	echo "\"invalid-key\": false" >> $config_file
-	echo "}" >> $config_file
+		append_params_quotes "$cfg" \
+			blocklist_url bind_address_ipv4 bind_address_ipv6 download_dir incomplete_dir \
+			peer_congestion_algorithm peer_socket_tos rpc_bind_address rpc_password rpc_url \
+			rpc_username rpc_whitelist script_torrent_done_filename watch_dir
+
+		echo "\"invalid-key\": false" >> $config_file
+		echo "}" >> $config_file
+
+	}
 
 	cmdline="transmission-daemon -g $config_dir -f"
 	procd_open_instance


### PR DESCRIPTION
libnatpmp was added as a dependancy to avoid built-in version.

Makefile went through a few adjustments to make it simpler.

CMake support is not happening since Travis is using a broken Ubuntu install.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me
Compile tested: ar71xx