### PR TITLE
gst1-libav: Remove BUILD_PATENTED from MPEG[12].

### DIFF
--- a/multimedia/gst1-libav/Config.in
+++ b/multimedia/gst1-libav/Config.in
@@ -19,7 +19,7 @@ config GET_LIBAV_COMMON_AV_SUPPORT
 	select GST1_LIBAV_DECODER_jpegls
 	select GST1_LIBAV_DECODER_mp3
 	select GST1_LIBAV_DECODER_mpeg1video
-	select GST1_LIBAV_DECODER_mpeg2video if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DECODER_mpeg2video
 	select GST1_LIBAV_DECODER_mpeg4 if GST1_LIBAV_PATENTED
 	select GST1_LIBAV_DECODER_mpeg4aac if GST1_LIBAV_PATENTED
 	select GST1_LIBAV_DECODER_mpegvideo
@@ -37,7 +37,7 @@ config GET_LIBAV_COMMON_AV_SUPPORT
 	select GST1_LIBAV_DEMUXER_ac3
 	select GST1_LIBAV_DEMUXER_h264 if GST1_LIBAV_PATENTED
 	select GST1_LIBAV_DEMUXER_mp3
-	select GST1_LIBAV_DEMUXER_mpegvideo if GST1_LIBAV_PATENTED
+	select GST1_LIBAV_DEMUXER_mpegvideo
 	select GST1_LIBAV_DEMUXER_ogg
 
 comment "Encoders ---"
@@ -54,7 +54,6 @@ config GST1_LIBAV_ENCODER_mpeg1video
 
 config GST1_LIBAV_ENCODER_mpeg2video
 	bool "MPEG-2 Video"
-	depends on GST1_LIBAV_PATENTED
 
 config GST1_LIBAV_ENCODER_mpeg4
 	bool "MPEG-4"
@@ -115,7 +114,6 @@ config GST1_LIBAV_DECODER_mpeg1video
 
 config GST1_LIBAV_DECODER_mpeg2video
 	bool "MPEG-2 Video"
-	depends on GST1_LIBAV_PATENTED
 
 config GST1_LIBAV_DECODER_mpeg4
 	bool "MPEG-4"


### PR DESCRIPTION
According to MPEG-LA, the last patent expired February 13, 2018. MPEG1 probably expired a while ago.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 