### PR TITLE
openvswitch: remove supported kernels [v2]

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -29,8 +29,6 @@ PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
-SUPPORTED_KERNELS:=LINUX_3_18||LINUX_4_1||LINUX_4_3||LINUX_4_4||LINUX_4_9
-
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python-package.mk
 
@@ -55,7 +53,7 @@ endef
 define Package/openvswitch-base
   $(call Package/openvswitch/Default)
   TITLE:=Open vSwitch Userspace Package (base)
-  DEPENDS:=+libpcap +libopenssl +librt +kmod-openvswitch @($(SUPPORTED_KERNELS))
+  DEPENDS:=+libpcap +libopenssl +librt +kmod-openvswitch
 endef
 
 define Package/openvswitch-base/description
@@ -138,8 +136,7 @@ define KernelPackage/openvswitch
 	CONFIG_OPENVSWITCH_GENEVE=n
   DEPENDS:= \
 	@IPV6 +kmod-gre +kmod-lib-crc32c +kmod-mpls \
-	+kmod-vxlan +kmod-nf-nat +kmod-nf-nat6  \
-	@($(SUPPORTED_KERNELS))
+	+kmod-vxlan +kmod-nf-nat +kmod-nf-nat6
   FILES:= $(LINUX_DIR)/net/openvswitch/openvswitch.ko
   AUTOLOAD:=$(call AutoLoad,21,openvswitch)
 endef
@@ -149,7 +146,6 @@ define KernelPackage/openvswitch/description
   module. Furthermore, it supports OpenFlow.
 endef
 
-CONFIGURE_ARGS += --with-linux=$(LINUX_DIR) --with-rundir=/var/run
 CONFIGURE_ARGS += --enable-ndebug
 CONFIGURE_ARGS += --disable-ssl
 CONFIGURE_ARGS += --enable-shared


### PR DESCRIPTION
Maintainer: me
Compile tested: brcm2708 + kernel 4.9, brcm2708 + kernel 4.14 (trunk)
Run tested: brcm2708 + kernel 4.9, brcm2708 + kernel 4.14 (trunk)

--------------------------------------------

Version 1 is: https://github.com/openwrt/packages/pull/5613

This time removed all instances of `SUPPORTED_KERNELS` and the --with-linux
directive for configure.
That way, there is no kernel version check and only the userspace module is
built.

Tested on RPi 3 with kernel 4.9 and 4.14.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>