### PR TITLE
zsh: add required dependency(issue #5514)

### DIFF
--- a/utils/zsh/Makefile
+++ b/utils/zsh/Makefile
@@ -26,7 +26,7 @@ define Package/zsh
   CATEGORY:=Utilities
   SUBMENU:=Shells
   TITLE:=The Z shell
-  DEPENDS:=+libncurses +libncursesw +libpcre +librt
+  DEPENDS:=+libcap +libncurses +libncursesw +libpcre +librt
   URL:=http://www.zsh.org/
 endef
 


### PR DESCRIPTION
Maintainer: Vadim A. Misbakh-Soloviov <openwrt-zsh@mva.name>
Compile tested: ramips, Xiaomi Router 3G, 6be73c0
Run tested: ramips, Xiaomi Router 3G, OpenWRT Snapshot r6022

Description: 
As indicated in https://github.com/openwrt/packages/issues/5514 zsh is compiled with --enable-cap option but libcap is not listed in dependencies.

Signed-off-by: Jakub Tymejczyk <jakub@tymejczyk.pl>