### PR TITLE
smstools3: Move init script to use procd

### DIFF
--- a/utils/smstools3/Makefile
+++ b/utils/smstools3/Makefile
@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=smstools3
 PKG_VERSION:=3.1.21
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
-PKG_MAINTAINER:=Gérald Kerma <dreagle@doukki.net>
+PKG_MAINTAINER:=Harald Geyer <harald@ccbib.org>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -59,7 +59,7 @@ define Package/smstools3/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/smstools3.init $(1)/etc/init.d/smstools3
 	$(INSTALL_DIR) $(1)/etc
-	$(INSTALL_DATA) ./files/smstools3.conf $(1)/etc/smsd.conf
+	$(INSTALL_CONF) ./files/smstools3.conf $(1)/etc/smsd.conf
 endef
 
 $(eval $(call BuildPackage,smstools3))

--- a/utils/smstools3/files/smstools3.conf
+++ b/utils/smstools3/files/smstools3.conf
@@ -10,11 +10,15 @@ failed = /var/spool/sms/failed
 sent = /var/spool/sms/sent
 receive_before_send = no
 autosplit = 3
+logfile = 1
+loglevel = 5
 
-[GSM1]
-init = AT+CPMS="ME","ME","ME"
-device = /dev/ttyUSB0
-incoming = yes
-pin = 0000
-baudrate = 9600
+# Uncomment (and edit) this section to allow smsd to start:
+#
+#[GSM1]
+#init = AT+CPMS="ME","ME","ME"
+#device = /dev/ttyUSB0
+#incoming = yes
+#pin = 0000
+#baudrate = 115200
 

--- a/utils/smstools3/files/smstools3.init
+++ b/utils/smstools3/files/smstools3.init
@@ -1,43 +1,21 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2014 OpenWrt.org
-# smsd initscript openwrt mod
+# Copyright (C) 2014-2018 OpenWrt.org
 
-START=99
-STOP=99
+START=94
 
-EXTRA_COMMANDS="status"
-EXTRA_HELP="        status  View pid and service status "
-
-# Set USER and GROUP, if necessary:
-USER=""
-GROUP=""
+USE_PROCD=1
 
 # If an unpriviledged user is selected, make sure that next two
 # files are writable by that user:
 PIDFILE="/var/run/smsd.pid"
 INFOFILE="/var/run/smsd.working"
-# Logfile can also be defined in here:
-LOGFILE="/var/log/smsd.log"
 
 DAEMON=/usr/bin/smsd
-# A program which turns power off for couple of seconds:
-RESETMODEMS=/usr/bin/smsd_resetmodems
-NAME=smsd
-PSOPT=""
 
 # Set/edit this before starting service !!!!!
 WRT_SPOOL=/var/spool
 
-# Maximum time to stop smsd, after that it gets killed hardly:
-MAXWAIT=45
-
-boot() {
-	start
-}
-
-start() {
-	test -x $DAEMON || exit 0
-
+start_service() {
 	echo "Creating minimum spool directories"
 	mkdir -p $WRT_SPOOL
 	mkdir -p $WRT_SPOOL/sms
@@ -47,106 +25,13 @@ start() {
 	mkdir -p $WRT_SPOOL/sms/failed
 	mkdir -p $WRT_SPOOL/sms/sent
 
-	echo -n "Starting SMS Daemon: "
-	MSG="."
-	ARGS="-n MAINPROCESS -p$PIDFILE -i$INFOFILE"
-	[ "x$USER" != x ] && ARGS="$ARGS -u$USER"
-	[ "x$GROUP" != x ] && ARGS="$ARGS -g$GROUP"
-	[ "x$LOGFILE" != x ] && ARGS="$ARGS -l$LOGFILE"
-	PID=`cat $PIDFILE 2>/dev/null`
-	if [ "x$PID" != x ]; then
-	  if kill -0 $PID 2>/dev/null; then
-	    MSG=" already running ($PID)."
-	  else
-	    PID=""
-	  fi
-	fi
-	if [ "x$PID" = x ]; then
-	  if ps $PSOPT | grep $NAME | grep -v grep >/dev/null; then
-	    MSG=" already running."
-	  else
-	    $DAEMON $ARGS
-	    sleep 1
-	    PIDS=`ps $PSOPT | grep $NAME | grep -v grep`
-	    [ "x$PIDS" = x ] && MSG=" failed."
-	  fi
-	fi
-	echo "$NAME$MSG"
+	procd_open_instance
+
+	procd_set_param command $DAEMON -n MAINPROCESS -p$PIDFILE -i$INFOFILE
+	procd_set_param respawn
+	procd_set_param stdout 1
+
+	procd_close_instance
 }
 
-stop() {
-	if ps $PSOPT | grep $NAME | grep -v grep >/dev/null; then
-	  PID=`cat $PIDFILE 2>/dev/null`
-	  if [ "x$PID" != x ]; then
-	    P=`kill -0 $PID 2>/dev/null`
-	    [ "x$P" != x ] && PID=""
-	  fi
-	  if [ "x$PID" != x ]; then
-	    kill $PID
-	  else
-	    kill `ps $PSOPT | grep $NAME | grep -v grep | awk '{print $1}'` >/dev/null 2>&1
-	  fi
-	  sleep 1
-	  if ps $PSOPT | grep $NAME | grep -v grep >/dev/null; then
-	    echo "Allowing $NAME to terminate gracefully within $MAXWAIT seconds"
-	    infofound=0
-	    dots=0
-	    seconds=0
-	    while ps $PSOPT | grep $NAME | grep -v grep >/dev/null; do
-	      if [ $infofound -lt 1 ]; then
-	        if [ -f $INFOFILE ]; then
-	          infofound=1
-	          if [ $dots -gt 0 ]; then
-	            echo ""
-	            dots=0
-	          fi
-	          $ECHO -n "$NAME is currently "
-	          cat $INFOFILE
-	          echo "Time counting is now disabled and we will wait until this job is complete."
-	        fi
-	      fi
-	      [ $infofound -lt 1 ] && seconds=`expr $seconds + 1`
-	      echo -n "."
-	      dots=`expr $dots + 1`
-	      if [ "$seconds" -ge $MAXWAIT ]; then
-	        if [ $dots -gt 0 ]; then
-	          echo ""
-	          dots=0
-	        fi
-	        echo "Timeout occurred, killing $NAME hardly."
-	        kill -9 `ps $PSOPT | grep $NAME | grep -v grep | awk '{print $1}'` >/dev/null 2>&1
-	        [ -f $PIDFILE ] && rm $PIDFILE
-	        seconds=0
-	      fi
-	      sleep 1
-	    done
-	    [ $dots -gt 0 ] && echo ""
-	    #echo "$NAME is stopped."
-	  fi
-	fi
-}
-
-restart() {
-	stop
-	start
-}
-
-
-status() {
-	PID=$(cat $PIDFILE)
-
-	test -e $PIDFILE
-	if [ $? == 0 ]; then
-		echo $NAME " running! pid $PID"
-	else
-		echo $NAME " not running !!!"
-	fi
-}
-
-reset() {
-	$0 stop
-	[ -f "$RESETMODEMS" ] && "$RESETMODEMS"
-	sleep 30
-	$0 start
-}
 

--- a/utils/smstools3/patches/004-modem-processes.patch
+++ b/utils/smstools3/patches/004-modem-processes.patch
@@ -1,0 +1,26 @@
+commit 3790bd05ed86b1692719df22857ef76c1293b01c
+Author: Harald Geyer <harald@ccbib.org>
+Date:   Sun Feb 18 19:24:48 2018 +0100
+
+    Make modem processes terminate when main process dies
+
+diff --git a/src/smsd.c b/src/smsd.c
+index fdfa193..37b2e4d 100755
+--- a/src/smsd.c
++++ b/src/smsd.c
+@@ -34,6 +34,7 @@ Either version 2 of the License, or (at your option) any later version.
+ #ifndef DISABLE_INOTIFY
+ #include <sys/inotify.h>
+ #endif
++#include <sys/prctl.h>
+ 
+ #include "extras.h"
+ #include "locking.h"
+@@ -8100,6 +8101,7 @@ int main(int argc,char** argv)
+ 
+       if (pid == 0)
+       {
++        prctl(PR_SET_PDEATHSIG, SIGTERM, 0, 0, 0);
+         process_id = i;
+         strcpy(process_title, DEVICE.name);
+         apply_process_name(argc, argv, process_title);


### PR DESCRIPTION
* properly install config file

* prevent smsd from starting right after installation to avoid loss of data
  (make default device unavailable by turning configuration into comments)

* move init script to procd

* log to syslog - at the moment via stdout and procd
  this is a workaround to force smsd to stay in the foreground

* the init script can't do a modem reset anymore
  use an alarmhandler script instead

* add local patch to make modem processes terminate if the main process dies
  this allows procd to properly stop the service

Signed-off-by: Harald Geyer <harald@ccbib.org>

Maintainer: @erdoukki is unresponsive/unreachable, last update was by @p-wassi
Compile tested: arm926ej-s, imx233-olinuxino (mxs), cabb0c506526fe468e4aa985086e50c440192122
Run tested: see above, tests done: init script, crash recovery, logging

Description: