### PR TITLE
getdns: Bump to 1.4.0 plus fixes

### DIFF
--- a/libs/getdns/Config.in
+++ b/libs/getdns/Config.in
@@ -7,8 +7,8 @@ config GETDNS_ENABLE_STUB_ONLY
 		getdns can be configured for stub resolution mode only. (Removes libunbound dependency)
 	default y
 	
-config GETDNS_ENABLE_IDN
-	bool "GETDNS_ENABLE_IDN"
+config GETDNS_ENABLE_IDN_LIBIDN
+	bool "GETDNS_ENABLE_IDN_LIBIDN"
 	help 
 		getdns can be configured with some IDN Support. (Requires libidn dependency)
 	default n

--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=getdns
-PKG_VERSION:=1.3.0
+PKG_VERSION:=1.4.0
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
@@ -14,7 +14,7 @@ PKG_MAINTAINER:=David Mora <iamperson347+public@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://getdnsapi.net/dist/
-PKG_HASH:=920fa2e07c72fd0e5854db1820fa777108009fc5cb702f9aa5155ef58b12adb1
+PKG_HASH:=de360cd554fdec4bae3f5afbb36145872b8ff7306ded5deb0905442c4909f7b3
 
 PKG_FIXUP:=autoreconf
 
@@ -22,7 +22,7 @@ PKG_INSTALL:=1
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_GETDNS_ENABLE_STUB_ONLY \
-	CONFIG_GETDNS_ENABLE_IDN 
+	CONFIG_GETDNS_ENABLE_IDN_LIBIDN 
 	
 include $(INCLUDE_DIR)/package.mk
 
@@ -36,7 +36,7 @@ define Package/getdns
 	SECTION:=libs
 	CATEGORY:=Libraries
 	TITLE+= (library)
-	DEPENDS+= +libopenssl +!GETDNS_ENABLE_STUB_ONLY:libunbound +GETDNS_ENABLE_IDN:libidn
+	DEPENDS+= +libopenssl +!GETDNS_ENABLE_STUB_ONLY:libunbound +GETDNS_ENABLE_IDN_LIBIDN:libidn
 	MENU:=1
 endef
 
@@ -51,7 +51,9 @@ endef
 
 CONFIGURE_ARGS += \
 		$(if $(CONFIG_GETDNS_ENABLE_STUB_ONLY), --enable-stub-only, ) \
-		$(if $(CONFIG_GETDNS_ENABLE_IDN), , --without-libidn ) 
+		$(if $(CONFIG_GETDNS_ENABLE_IDN_LIBIDN), , --without-libidn ) \
+		--without-libidn2 \
+		--with-ssl="$(STAGING_DIR)/usr" \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/getdns/


### PR DESCRIPTION
Maintainer: me / @iamperson347
Compile tested: ar71xx, archer-c7, trunk
Run tested: same as above. Tested on personal Archer C7 v2. Functionality seems to be correct.

Description:  Bump to 1.4.0 plus a small fix to makefile

Signed-off-by: David Mora <iamperson347+public@gmail.com>