### PR TITLE
stubby: Bump to 0.2.2 plus updates to default config

### DIFF
--- a/net/stubby/Makefile
+++ b/net/stubby/Makefile
@@ -5,16 +5,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stubby
-PKG_VERSION:=0.2.1
+PKG_VERSION:=0.2.2
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=David Mora <iamperson347+public@gmail.com>
 
-PKG_SOURCE:=v$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/getdnsapi/stubby/archive/
-PKG_HASH:=adf030a55426918933870f2d49a0caed93023bb1ec806efb255c3e7494985821
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/getdnsapi/$(PKG_NAME)
+PKG_SOURCE_VERSION:=1a6acd642c7dc9a04cf092e1a3837c5636d4b465
+PKG_MIRROR_HASH:=f5a270a0ef4e7e2f0387b649ed77d66917ba9bd88dee14e3f9edd2573e8d3c3a
 
 PKG_FIXUP:=autoreconf
 
@@ -29,6 +31,8 @@ endef
 
 define Package/stubby/description
 	This package contains the Stubby daemon (which utilizes the getdns library).
+
+	See https://github.com/openwrt/packages/blob/master/net/stubby/files/README.md for more details.
 endef
 
 define Package/stubby

--- a/net/stubby/files/README.md
+++ b/net/stubby/files/README.md
@@ -1,0 +1,63 @@
+# Stubby for OpenWRT
+
+## Stubby Description
+[Stubby](https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Daemon+-+Stubby) is an application that acts as a local DNS Privacy stub resolver (using DNS-over-TLS). Stubby encrypts DNS queries sent from a client machine (desktop or laptop) to a DNS Privacy resolver increasing end user privacy.
+
+Stubby is developed by the [getdns](http://getdnsapi.net/) project.
+
+For more background and FAQ see our [About Stubby](https://dnsprivacy.org/wiki/display/DP/About+Stubby) page. Stubby is in the early stages of development but is suitable for technical/advanced users. A more generally user-friendly version is on the way!
+
+## Prerequisites
+
+You must have a ca cert bundle installed on your device for stubby to make the TLS enabled connections.
+
+- You can install this by running the following: opkg install ca-certificates
+- You can also install this through the LUCI web interface
+
+## Package Overview
+This package has some modifications that makes it differ from the default upstream configuration. They are outlined below.
+
+### General Cleanup
+Comments are removed, etc.
+
+### EDNS Client-Subnet Option Changed to 0
+The value of "edns_client_subnet_private" is '1' in the upstream default config. This informs the upstream resolver to NOT forward your connection's IP to any other upstream servers. This is good for privacy, but could result in sub-optimal routing to CDNs, etc.
+
+To give a more "comparable" DNS experience similar to google/opendns, this package disables this option.
+
+### Default Listening Ports Changed
+The value of "listen_addresses" in the default config does not list port numbers, which will cause stubby to default to port 53. However, Openwrt defaults to dnsmasq as the main name server daemon, which runs on port 53. By setting the listening ports to non-standard values, this allows users to keep the main name server daemon in place (dnsmasq/unbound/etc.) and have that name server forward to stubby.
+
+Additionally, due to the slight overhead involved with DNS-over-TLS, it is recommended to have a caching name server on the network.
+
+### Round Robin Upstream Setting Changed
+
+The default stubby config list multiple upstream resolvers, and because of this, it makes sense to "load balance" between them. However, in this package's default stubby config, the only upstream service listed is quad9. One entry is for ipv6 and one for ipv4.
+
+By setting the "round_robin_upstreams" value to 0, we are simply forcing stubby to try and use ipv6 connectivity to quad9 first, and if not available, simply use the ipv4 service.
+
+quad9 is an Anycast DNS service. This should take care of any needed "failover" in the event that one of quad9's nodes goes down.
+
+### Upstream Resolvers Changed
+
+Most of the default resolvers for stubby are in Europe. To provide a better experience for a larger number of users, this package defaults to using quad9's DNS service.
+
+Note: quad9 has multiple IPs available for their service. The "features" applied are based on the endpoint your DNS client connects to. For this package, the default resolvers are set to the non-filtering, EDNS Client-Subnet capable endpoints.
+
+https://www.quad9.net/faq/#Is_there_a_service_that_Quad9_offers_that_does_not_have_the_blocklist_or_other_security
+
+https://www.quad9.net/faq/#Does_Quad9_support_DNS_over_TLS
+
+``````
+
+# IPv6 addresses 
+# Quad 9 IPv6
+  - address_data: 2620:fe::10
+    tls_auth_name: "dns.quad9.net"
+
+# IPv4 addresses
+# Quad 9 service
+  - address_data: 9.9.9.10
+    tls_auth_name: "dns.quad9.net"
+
+``````

--- a/net/stubby/files/stubby.yml
+++ b/net/stubby/files/stubby.yml
@@ -7,9 +7,9 @@ dns_transport_list:
 
 tls_authentication: GETDNS_AUTHENTICATION_REQUIRED
 
-tls_query_padding_blocksize: 256
+tls_query_padding_blocksize: 128
 
-edns_client_subnet_private : 1
+edns_client_subnet_private : 0
 
 idle_timeout: 10000
 
@@ -21,9 +21,9 @@ round_robin_upstreams: 0
 
 upstream_recursive_servers:
 # Quad 9 IPv6
-  - address_data: 2620:fe::fe
+  - address_data: 2620:fe::10
     tls_auth_name: "dns.quad9.net"
 # IPv4 addresses
 # Quad 9 service
-  - address_data: 9.9.9.9
+  - address_data: 9.9.9.10
     tls_auth_name: "dns.quad9.net"


### PR DESCRIPTION
Maintainer: me / @iamperson347
Compile tested: ar71xx, archer-c7, trunk
Run tested: same as above. Tested on personal Archer C7 v2. Functionality seems to be correct.

Description: Bump to version 0.2.2 plus changes to address concerns regarding default config for stubby provided with this package. 

Addresses: https://github.com/openwrt/packages/issues/5552

Signed-off-by: David Mora iamperson347+public@gmail.com