### PR TITLE
cifs-utils: Remove libtalloc dependancy by removing cifs.upcall.

### DIFF
--- a/net/cifs-utils/Makefile
+++ b/net/cifs-utils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cifs-utils
 PKG_VERSION:=6.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://download.samba.org/pub/linux-cifs/cifs-utils/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -26,7 +26,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/cifsmount
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+kmod-fs-cifs +libtalloc
+  DEPENDS:=+kmod-fs-cifs
   TITLE:=CIFS mount utilities
   URL:=http://wiki.samba.org/index.php/LinuxCIFS_utils
 endef
@@ -36,6 +36,8 @@ TARGET_CFLAGS += -Wno-error
 CONFIGURE_ARGS += \
 	--exec-prefix=/usr \
 	--prefix=/ \
+	--disable-cifsupcall \
+	--disable-systemd \
 	--with-libcap-ng=no \
 	--with-libcap=no
 


### PR DESCRIPTION
libtalloc is needed for cifs.upcall which is not useful in OpenWrt's case since keyctl is needed as well as a request-key binary.

The libtalloc dependancy may have been indirectly responsible for the recent samba3.6 breakage...

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ffainelli 
Compile tested: ar71xx

The other utilities that can be disabled don't seem useful either. 