### PR TITLE
python: fix the --with-system-ffi build flag

### DIFF
--- a/lang/python/python/patches/014-python-fix-with-system-ffi.patch
+++ b/lang/python/python/patches/014-python-fix-with-system-ffi.patch
@@ -1,0 +1,11 @@
+--- a/setup.py
++++ b/setup.py
+@@ -2121,7 +2121,7 @@ class PyBuildExt(build_ext):
+                              sources=['_ctypes/_ctypes_test.c'])
+         self.extensions.extend([ext, ext_test])
+ 
+-        if not '--with-system-ffi' in sysconfig.get_config_var("CONFIG_ARGS"):
++        if '--with-system-ffi=no' in sysconfig.get_config_var("CONFIG_ARGS"):
+             return
+ 
+         if host_platform == 'darwin':


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: macOS High Sierra

Description:
The --with-system-ffi option is handled by the ./configure script and
ends up as either "--with-system-ffi=no" or "--with-system-ffi=yes" in the
CONFIG_ARGS variable. This variable is then used in setup.py to determine
if --with-system-ffi had been passed to configure.

Unfortunatelly the test in setup.py checks for a literal substring
"--with-system-ffi" which always exists (with either a "=yes" or "=no"
suffix). Including "=no" in the test string fixes the problem.

This fixes Python 2.7.14 host compilation on macOS High Sierra.