### PR TITLE
ttyd: update to 1.4.0

### DIFF
--- a/utils/ttyd/Makefile
+++ b/utils/ttyd/Makefile
@@ -8,15 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ttyd
-PKG_VERSION:=1.3.3+git-04d5bc
+PKG_VERSION:=1.4.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/tsl0922/ttyd.git
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=04d5bc1ecb59667d025a94e1967a83c24141f911
-PKG_MIRROR_HASH=87ea900f7bf67daf5131ecfcec0917e175d168ce52771012139c06dbafcc641d
+PKG_SOURCE_URL:=https://codeload.github.com/tsl0922/ttyd/tar.gz/$(PKG_VERSION)?
+PKG_SOURCE_VERSION=$(PKG_VERSION)
+PKG_HASH=757a9b5b5dd3de801d7db8fab6035d97ea144b02a51c78bdab28a8e07bcf05d6
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -30,7 +29,7 @@ define Package/ttyd
 	SECTION:=utils
 	CATEGORY:=Utilities
 	TITLE:=Command-line tool for sharing terminal over the web
-	DEPENDS:=+libopenssl +libjson-c +libpthread +libwebsockets-openssl
+	DEPENDS:=+libopenssl +libjson-c +libpthread +libwebsockets-full
 	URL:=https://github.com/tsl0922/ttyd
 	SUBMENU:=Terminal
 	MAINTAINER:=Shuanglei Tao <tsl0922@gmail.com>


### PR DESCRIPTION
Maintainer: me
Compile tested: (ramips, mt7621, [LEDE snapshots](https://downloads.lede-project.org/snapshots/targets/ramips/mt7621/openwrt-sdk-ramips-mt7621_gcc-5.5.0_musl.Linux-x86_64.tar.xz))
Run tested: none

Description:

ttyd: update to 1.4.0
Signed-off-by: Shuanglei Tao tsl0922@gmail.com
