### PR TITLE
libsoxr: Change URL to HTTPS and change file to .xz

### DIFF
--- a/libs/libsoxr/Makefile
+++ b/libs/libsoxr/Makefile
@@ -10,14 +10,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsoxr
 PKG_VERSION:=0.1.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=git://git.code.sf.net/p/soxr/code
+PKG_SOURCE_URL:=https://git.code.sf.net/p/soxr/code
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
-PKG_MIRROR_HASH:=939259d5c02bbe55cf8329e7bd05ce4d660e37d5c97fcbb0fdeef04f11a63e7f
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
+PKG_MIRROR_HASH:=85ceb9983f47a05d5e4ed4a6619b36b6a03db695654551e07b3026236056ed5d
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Mike Brady <mikebrady@eircom.net>


### PR DESCRIPTION
HTTPS tends to go through firewalls. .xz is smaller.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 

There's also a new version out.