### PR TITLE
sispmctl: Change URL to HTTPS

### DIFF
--- a/utils/sispmctl/Makefile
+++ b/utils/sispmctl/Makefile
@@ -16,7 +16,7 @@ PKG_SOURCE_VERSION:=5ff4a05a5bcb6a64a9d6f77fed47014512f66b11
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_MIRROR_HASH:=d09782160dbcc1ba3bd6a38941f38e130049d8383843f6f292409909678aed82
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=git://git.code.sf.net/p/sispmctl/git
+PKG_SOURCE_URL:=https://git.code.sf.net/p/sispmctl/git
 PKG_MAINTAINER:=Richard Kunze <richard.kunze@web.de>
 PKG_LICENSE:=GPL-2.0+
 


### PR DESCRIPTION
HTTPS goes through firewalls easier.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @rkunze 
