### PR TITLE
sqm-scripts: Fix return value bug in postrm script

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sqm-scripts
 PKG_SOURCE_VERSION:=8217081f7e52af342c362b29480461575c496387
 PKG_VERSION:=1.1.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPLv2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_RELEASE).tar.xz
@@ -81,7 +81,7 @@ uci -q get ucitrack.@sqm[0] > /dev/null && {
   uci delete ucitrack.@sqm[0]
   uci del_list ucitrack.@firewall[0].affects=sqm
   uci commit
-}
+} || exit 0
 endef
 
 $(eval $(call BuildPackage,sqm-scripts))


### PR DESCRIPTION
Description:

The Makefile's 'postrm' scriptlet removes the UCI option ucitrack.@sqm[0] if present and then returns success. If that UCI option is already absent however, the script incorrectly returns failure, which blocks upgrade of the luci-app-sqm package.

Maintainer: @tohojo 
Build and run tested: ar71xx arch on DIR-835 running stable LEDE 17.01.4
