### PR TITLE
transmission: Fix HTTPS and mobile devices.

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=2.93
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master
@@ -124,6 +124,7 @@ CONFIGURE_ARGS += \
 	--enable-daemon \
 	--enable-cli \
 	--without-gtk \
+	--enable-external-natpmp \
 	--enable-largefile \
 	--enable-lightweight
 

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -110,7 +110,6 @@ transmission() {
 	procd_open_instance
 	procd_set_param command $cmdline
 	procd_set_param env CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-	procd_set_param env TR_CURL_SSL_VERIFY=1
 	procd_set_param user $user
 	procd_set_param group $user
 	procd_set_param nice $nice

--- a/net/transmission/patches/040-https-portcheck.patch
+++ b/net/transmission/patches/040-https-portcheck.patch
@@ -1,0 +1,26 @@
+From 6de0a3d7a3cd0b2ca6d1b33b5d4d7f44908c1ac3 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Thu, 1 Mar 2018 11:21:43 -0800
+Subject: [PATCH] portcheck: Switch to HTTPS.
+
+Useful for OpenWrt.
+---
+ libtransmission/rpcimpl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libtransmission/rpcimpl.c b/libtransmission/rpcimpl.c
+index 46fd3192c..dcd96df59 100644
+--- a/libtransmission/rpcimpl.c
++++ b/libtransmission/rpcimpl.c
+@@ -1455,7 +1455,7 @@ portTest (tr_session               * session,
+           struct tr_rpc_idle_data  * idle_data)
+ {
+   const int port = tr_sessionGetPeerPort (session);
+-  char * url = tr_strdup_printf ("http://portcheck.transmissionbt.com/%d", port);
++  char * url = tr_strdup_printf ("https://portcheck.transmissionbt.com/%d", port);
+   tr_webRun (session, url, portTested, idle_data);
+   tr_free (url);
+   return NULL;
+-- 
+2.14.3
+

--- a/net/transmission/patches/050-fix-safari.patch
+++ b/net/transmission/patches/050-fix-safari.patch
@@ -1,0 +1,26 @@
+From 405d768bfea661c418e2c75686a7bac95e4bb17b Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Thu, 1 Mar 2018 11:25:15 -0800
+Subject: [PATCH] fix web interface with Safari.
+
+Backport of bcfe147e6a41ce7774f569ede6179a7ed2c7f560
+---
+ web/javascript/common.js | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/web/javascript/common.js b/web/javascript/common.js
+index 7162d3f82..77bf96857 100644
+--- a/web/javascript/common.js
++++ b/web/javascript/common.js
+@@ -61,7 +61,7 @@ $(document).ready(function() {
+ 			// Fix min height for isMobileDevice when run in full screen mode from home screen
+ 			// so the footer appears in the right place
+ 			$('body div#torrent_container').css('min-height', '338px');
+-		$("label[for=torrent_upload_url]").text("URL: ");
++		$("label[for=torrent_upload_url]").text = "URL: ";
+ 	} else {
+ 		// Fix for non-Safari-3 browsers: dark borders to replace shadows.
+ 		$('div.dialog_container div.dialog_window').css('border', '1px solid #777');
+-- 
+2.14.3
+


### PR DESCRIPTION
HTTPS verification is totally broken in Transmission. Unclear why. Disabling as a result.

Safari exposes a JavaScript bug that makes it not load. Fixed.

Portcheck was backported to HTTPS for testing initially. Seems like a good idea.

Makefile was also fixed to use the external libnatpmp. Smaller binary.

Maintainer: me
Compile tested: mt7621
Run tested: mt7621

Description:
Keeping ca-bundle as I want to reenable this at some point.