### PR TITLE
haproxy: Fix Lua support for non-mips targets.

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -95,6 +95,9 @@ ENABLE_LUA:=y
 ifeq ($(CONFIG_mips),y)
   ENABLE_LUA:=n
 endif
+ifeq ($(CONFIG_mipsel),y)
+  ENABLE_LUA:=n
+endif
 
 ifeq ($(CONFIG_avr32),y)
   LINUX_TARGET:=linux26
@@ -105,13 +108,13 @@ endif
 ifeq ($(BUILD_VARIANT),ssl)
 	ADDON+=USE_OPENSSL=1
 	ADDON+=ADDLIB="-lcrypto -lm "
-else ifeq ($(CONFIG_mips),n)
+endif
+
+ifeq ($(ENABLE_LUA),y)
 	ADDON+=USE_LUA=1
 	ADDON+=LUA_LIB_NAME="lua534"
 	ADDON+=LUA_INC="$(STAGING_DIR)/lua-5.3.4/include"
 	ADDON+=LUA_LIB="$(STAGING_DIR)/lua-5.3.4/lib"
-else
-	ADDON+=ADDLIB="-lm"
 endif
 
 ifeq ($(ENABLE_LUA),y)


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>
Compile tested: mvebu (wrt1900acs), mips, mipsel, mips64
Run tested: mvebu (wrt1900acs), checked mips, mipsel for non-Lua support, checked mips64 for Lua-support

Description:
Fix Lua support for non-mips targets. The previous logic inside Makefile prevented Lua-support on all targets.
- mips and mipsel both currently do not build with Lua-support enabled => disable both
- mips64 and mips64el were tested do build fine with Lua-support enabled
- the previous Lua-enable logic was bogus and has been fixed to enable support for Lua on non-mips targets