### PR TITLE
tiff: revert uclibc++ commit

### DIFF
--- a/libs/tiff/Makefile
+++ b/libs/tiff/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tiff
 PKG_VERSION:=4.0.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.osgeo.org/libtiff
@@ -25,6 +25,7 @@ PKG_INSTALL:=1
 
 PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_libtiffxx
 
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/tiff/Default
@@ -46,7 +47,7 @@ $(call Package/tiff/Default)
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE+= library(c++ bindings)
-  DEPENDS:=+libtiff +PACKAGE_libtiffxx:libstdcpp
+  DEPENDS:=+libtiff $(CXX_DEPENDS)
 endef
 
 define Package/tiff-utils


### PR DESCRIPTION
This reverts 5b5659850dbaae4d2ac2e3f599015f71e341841e.

In hindsight I have to admit I did not correctly understand the
implications of the uclibc++.mk include.

The include allows a package to follow the user's choice regarding which
C++ library should be the standard. Linking against uClibc++ instead of
libstd++ is not a problem when running musl (which is what I had
incorrectly assumed), as both C++ libs are separate packages. And
uClibc++ is a lot smaller than libstd++, which is probably why it is
even the default C++ lib on OpenWrt currently.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @jslachta 
Compile tested: x86_64
Run tested: N/A

Description:
Hello Jiri,

The original commit was a misunderstanding on my part. Please revert. Sorry for the noise.

Best regards,
Seb
