### PR TITLE
tree: use TARGET_{CFLAGS,LDFLAGS} instead of the package default

### DIFF
--- a/utils/tree/Makefile
+++ b/utils/tree/Makefile
@@ -25,6 +25,10 @@ define Package/tree
   DEPENDS:=+libc +libgcc
 endef
 
+MAKE_FLAGS += \
+	CFLAGS="$(TARGET_CFLAGS)" \
+	LDFLAGS="$(TARGET_LDFLAGS)"
+
 define Package/tree/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tree $(1)/usr/sbin/


### PR DESCRIPTION
Maintainer: Banglang Huang banglang.huang@foxmail.com
Compile tested: x86_64/debian-stable, OpenWrt SNAPSHOT, r6293+2-2805402f86
Run tested: mvebu/linksys-wrt3200acm
Description:
Package Makefile{CFLAGS,LDFLAGS} produced a segfaulting executable caused by the dynamic loader.