### PR TITLE
gkrellmd: Adopt from oldpackages repo, Update to 2.3.10

### DIFF
--- a/admin/gkrellmd/Makefile
+++ b/admin/gkrellmd/Makefile
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2007-2018 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gkrellmd
+PKG_VERSION:=2.3.10
+PKG_RELEASE:=1
+
+PKG_SOURCE:=gkrellm-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=http://gkrellm.srcbox.net/releases
+PKG_MD5SUM:=ccc0b6af434542a2374e34a135ae68da
+PKG_MAINTAINER:=Peter Denison <openwrt@marshadder.org>
+PKG_LICENSE:=GPL-2.0+
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/gkrellm-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gkrellmd
+  SECTION:=admin
+  CATEGORY:=Administration
+  DEPENDS:=+glib2
+  TITLE:=The GNU Krell Monitors Server
+  URL:=http://gkrellm.net/
+endef
+
+define Package/gkrellmd/description
+	Gkrellmd listens for connections from gkrellm clients. When
+	a gkrellm client connects to a gkrellmd server all builtin
+	monitors collect their data from the server.
+endef
+
+define Package/gkrellmd/conffiles
+/etc/$(PKG_NAME).conf
+endef
+
+define Build/Compile
+	CFLAGS="$(TARGET_CFLAGS) $(EXTRA_CPPFLAGS)" \
+	LDFLAGS="$(EXTRA_LDFLAGS) " \
+	$(MAKE) -C $(PKG_BUILD_DIR)/server \
+		CC="$(TARGET_CC)" \
+		glib2="yes" \
+		without-libsensors="yes" \
+		GLIB2_LIB="$(TARGET_LDFLAGS) -lglib-2.0 -lgmodule-2.0" \
+		GLIB2_INCLUDE="-I$(STAGING_DIR)/usr/include/glib-2.0 -I$(STAGING_DIR)/usr/lib/glib-2.0/include"
+endef
+
+define Package/gkrellmd/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/server/$(PKG_NAME) $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/server/$(PKG_NAME).conf $(1)/etc/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/$(PKG_NAME).init $(1)/etc/init.d/$(PKG_NAME)
+endef
+
+$(eval $(call BuildPackage,gkrellmd))

--- a/admin/gkrellmd/Makefile
+++ b/admin/gkrellmd/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=1
 
 PKG_SOURCE:=gkrellm-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://gkrellm.srcbox.net/releases
-PKG_MD5SUM:=ccc0b6af434542a2374e34a135ae68da
+PKG_HASH:=8b9ec8baadcd5830c6aff04ba86dc9ed317a15c1c3787440bd1e680fb2fcd766
 PKG_MAINTAINER:=Peter Denison <openwrt@marshadder.org>
 PKG_LICENSE:=GPL-2.0+
 

--- a/admin/gkrellmd/files/gkrellmd.init
+++ b/admin/gkrellmd/files/gkrellmd.init
@@ -1,0 +1,16 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2007 OpenWrt.org
+
+START=60
+BIN=gkrellmd
+RUN_D=/var/run
+PID_F=$RUN_D/$BIN.pid
+
+start() {
+	mkdir -p $RUN_D
+	$BIN $OPTIONS
+}
+
+stop() {
+	[ -f $PID_F ] && kill $(cat $PID_F)
+}

--- a/admin/gkrellmd/patches/100-conf.patch
+++ b/admin/gkrellmd/patches/100-conf.patch
@@ -1,0 +1,35 @@
+Index: gkrellm-2.3.10/server/gkrellmd.conf
+===================================================================
+--- gkrellm-2.3.10.orig/server/gkrellmd.conf	2008-03-09 10:19:26.000000000 +0100
++++ gkrellm-2.3.10/server/gkrellmd.conf	2008-03-09 10:19:26.000000000 +0100
+@@ -4,7 +4,7 @@
+ # the client update frequency.  Values may be from 1 to 10 and should be
+ # smaller values to reduce network traffic.
+ #
+-#update-hz 3
++update-hz 10
+ 
+ # Limit number of simultaneous clients allowed to connect.
+ #
+@@ -30,18 +30,18 @@
+ # Drop privileges after startup (you must start gkrellmd as root to do it).
+ # NOTE: Option ignored on Windows
+ #
+-#user	nobody
++user	nobody
+ #group	proc
+ 
+ # Create a PID file for the running gkrellmd.  Default is no PID file.
+ # NOTE: Option ignored on Windows
+ #
+-#pidfile /var/run/gkrellmd.pid
++pidfile /var/run/gkrellmd.pid
+ 
+ # Run in background and detach from the controlling terminal
+ # NOTE: Option ignored on Windows
+ #
+-#detach
++detach
+ 
+ # Time interval between checks for various monitors.  If nfs-interval
+ # is <= 0 then gkrellmd will not read data for nfs file system types.


### PR DESCRIPTION
Adopt the package from the oldpackages repo at https://git.archive.openwrt.org/packages.git
Update to version 2.3.10 (released Nov 2016)
Update source URL
Depend only on GLib2, not glib1.2

Signed-off-by: Peter Denison <openwrt@marshadder.org>
Maintainer: Peter Denison <openwrt@marshadder.org>
Compile tested: mips_24kc, TL-WDR3600, snapshot-694f0bb5af
Run tested: mips_24kc, TL-WDR3600, snapshot-694f0bb5af, default config tested

Description:
Gkrellmd listens for connections from gkrellm clients. When a gkrellm client connects to a gkrellmd server, data from various system monitors are supplied to the client for display.
