### PR TITLE
mksh: update to R56c

### DIFF
--- a/utils/mksh/Makefile
+++ b/utils/mksh/Makefile
@@ -9,24 +9,26 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mksh
-PKG_VERSION:=56b
+PKG_VERSION:=56c
 PKG_RELEASE:=1
 
-PKG_MAINTAINER:=Thorsten Glaser <tg@mirbsd.org>
+PKG_MAINTAINER:=Thorsten Glaser <tg@mirbsd.org>, \
+		Alif M. Ahmad <alive4ever@live.com>
 PKG_LICENSE:=MirOS
 
 PKG_SOURCE:=$(PKG_NAME)-R$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=http://www.mirbsd.org/MirOS/dist/mir/mksh \
 		http://pub.allbsd.org/MirOS/dist/mir/mksh
-PKG_HASH:=40ec744eec256583e4e18907cde22af57c980286f535df47326fed07e48c9a7f
+PKG_HASH:=dd86ebc421215a7b44095dc13b056921ba81e61b9f6f4cdab08ca135d02afb77
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
 include $(INCLUDE_DIR)/package.mk
 
 define Package/mksh
-  SECTION:=shells
-  CATEGORY:=Base system
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Shells
   TITLE:=MirBSD Korn Shell
   DEPENDS:=$(DEP)
   URL:=http://mirbsd.de/mksh


### PR DESCRIPTION
Updated to R56c.

Also add myself as maintainer and move the location from `Base system`
into `Utilities/Shells`.

Maintainer: me / @mirabilos
Compile tested: x86_64, virtual machine, OpenWrt SNAPSHOT r6395-a70db57
Run tested: x86_64, qemu, OpenWrt SNAPSHOT r6395-a70db57
