### PR TITLE
pagekitec: add new package

### DIFF
--- a/net/pagekitec/Makefile
+++ b/net/pagekitec/Makefile
@@ -1,0 +1,104 @@
+#
+# Copyright (C) 2012 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pagekitec
+PKG_REV:=0.91.171102
+PKG_VERSION:=$(PKG_REV)C
+PKG_RELEASE:=1
+PKG_LICENSE:=Apache-2.0
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=git@github.com:pagekite/libpagekite.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=v$(PKG_REV)
+
+include $(INCLUDE_DIR)/package.mk
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+CONFIGURE_ARGS += --without-java
+
+define Package/pagekitec/default
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Make localhost servers publicly visible.
+  URL:=https://pagekite.net/wiki/Floss/LibPageKite/
+  MAINTAINER:= Karl Palsson <karlp@tweak.net.au>
+  DEPENDS:=+libopenssl +libpthread +libev
+endef
+
+define Package/libpagekite
+  $(call Package/pagekitec/default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE+= (library)
+endef
+
+define Package/pagekitec
+  $(call Package/pagekitec/default)
+  DEPENDS:=+libpagekite
+endef
+
+define Package/pagekitec/default/description
+PageKite is a system for running publicly visible servers (generally
+web servers) on machines without a direct connection to the Internet,
+such as mobile devices or computers behind restrictive firewalls.
+PageKite works around NAT, firewalls and IP-address limitations by
+using a combination of tunnels and reverse proxies.
+
+This package provides an implementation of the PageKite Protocol in C,
+optimized for high-performance or embedded applications.
+
+endef
+
+define Package/libpagekite/description
+  $(call Package/pagekitec/default/description)
+
+This package contains the core library
+endef
+
+define Package/pagekitec/description
+  $(call Package/pagekitec/default/description)
+
+This package contains a basic backend useful for exposing http/ssh servers.
+
+Basic UCI support for configuring this backend is also included.
+endef
+
+define Package/pagekitec/conffiles
+/etc/config/pagekitec
+endef
+
+define Build/Configure
+	(cd $(PKG_BUILD_DIR); ./autogen.sh );
+	$(call Build/Configure/Default)
+endef
+
+#this installs files into ./staging_dir/. so that you can cross compile from the host
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/{include,lib/pkgconfig}
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libpagekite/pagekite.h $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpagekite.{a,so*} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/* $(1)/usr/lib/pkgconfig
+endef
+
+define Package/libpagekite/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libpagekite.so* $(1)/usr/lib
+endef
+
+define Package/pagekitec/install
+	$(CP) ./files/* $(1)/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/pagekitec $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,pagekitec))
+$(eval $(call BuildPackage,libpagekite))

--- a/net/pagekitec/files/etc/config/pagekitec
+++ b/net/pagekitec/files/etc/config/pagekitec
@@ -1,0 +1,1 @@
+config pagekitec pagekitec

--- a/net/pagekitec/files/etc/init.d/pagekitec
+++ b/net/pagekitec/files/etc/init.d/pagekitec
@@ -1,0 +1,36 @@
+#!/bin/sh /etc/rc.common
+# Oct 2012, karlp@remake.is
+START=99
+APP=pagekitec
+USE_PROCD=1
+
+add_instance() {
+	local cfg="$1"
+	local kitename kitesecret simple_http simple_ssh static
+	config_get kitename "$cfg" kitename
+	config_get kitesecret "$cfg" kitesecret
+	[ -z "$kitename" -o -z "$kitesecret" ] && {
+		echo "Both kitename and kitesecret must be specified"
+		return 1
+	}
+	config_get_bool simple_http "$cfg" simple_http 0
+	config_get_bool simple_ssh "$cfg" simple_ssh 0
+	config_get_bool static "$cfg" static 0
+
+	procd_open_instance
+	procd_set_param command $APP
+	procd_append_param command -s
+	[ $static -eq 1 ] && procd_append_param command -S
+	[ $simple_http -eq 1 ] && procd_append_param command 80 http $kitename 80 $kitesecret
+	[ $simple_ssh -eq 1 ] && procd_append_param command 22 raw $kitename 443 $kitesecret
+	procd_close_instance
+}
+
+start_service() {
+	config_load pagekitec && config_foreach add_instance pagekitec
+}
+
+service_triggers()
+{
+	procd_add_reload_trigger "pagekitec"
+}


### PR DESCRIPTION
From the package description:
PageKite is a system for running publicly visible servers (generally
 web servers) on machines without a direct connection to the Internet,
 such as mobile devices or computers behind restrictive firewalls.
 PageKite works around NAT, firewalls and IP-address limitations by
 using a combination of tunnels and reverse proxies.

 This package provides an implementation of the PageKite Protocol in C,
 optimized for high-performance or embedded applications.

Signed-off-by: Karl Palsson <karlp@tweak.net.au>

Maintainer: me
Compile tested: ar71xx, OpenWrt SNAPSHOT r6206+3-97c27f01be
Run tested: same
