### PR TITLE
lang/python/python-package-install.sh: assign SOURCE_DATE_EPOCH to PYTHONHASHSEED

### DIFF
--- a/lang/python/python-package-install.sh
+++ b/lang/python/python-package-install.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+[ -z "$SOURCE_DATE_EPOCH" ] || {
+	PYTHONHASHSEED="$SOURCE_DATE_EPOCH"
+	export PYTHONHASHSEED
+}
+
 process_filespec() {
 	local src_dir="$1"
 	local dst_dir="$2"


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/openwrt/openwrt/commit/5cbd22bb0f3b49189040218b6ef0029fe3f47884 ar71xx
Run tested: N/A

---------------------------------------------

Following a discussion on bugs.python.org:
* https://bugs.python.org/issue29708
* https://bugs.python.org/msg313384

It seems that setting a fixed value to PYTHONHASHSEED guarantees that
the bytecodes are generated consistently/in a reproducible manner.

Hopefully, this is the last bit to make Python3 build reproducible.
Tested this locally on a few files [that were not reproducible without
this change].

The PYTHONHASHSEED is only assigned to the host Python/Python3 during
compilation of byte-codes [from python source].

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>