### PR TITLE
haproxy: Fix Lua-support for mips(el)

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -94,13 +94,6 @@ endef
 ENABLE_LUA:=y
 ENABLE_REGPARM:=n
 
-ifeq ($(CONFIG_mips),y)
-  ENABLE_LUA:=n
-endif
-ifeq ($(CONFIG_mipsel),y)
-  ENABLE_LUA:=n
-endif
-
 ifeq ($(CONFIG_TARGET_x86),y)
   ENABLE_REGPARM:=y
 endif
@@ -152,6 +145,7 @@ define Build/Compile
 		USE_ZLIB=yes USE_PCRE=1 USE_PCRE_JIT=1 USE_GETADDRINFO=1 \
 		VERSION="$(PKG_VERSION)-patch$(PKG_RELEASE)" \
 		$(ADDON) \
+		CFLAGS="$(TARGET_CFLAGS)" \
 		LD="$(TARGET_CC)" \
 		LDFLAGS="$(TARGET_LDFLAGS) -latomic" \
 		IGNOREGIT=1


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>
Compile tested: mips, mipsel, mvebu, x86
Run tested: mvebu (wrt1900acs)

Description:
Fix Lua-support for mips(el)
- TARGET_CFLAGS were missing for haproxy which caused issue #4606 because auf architectural differences between the Lua-library and haproxy. This has been fixed.
- All targets have Lua support again