### PR TITLE
libcap: executables

### DIFF
--- a/libs/libcap/Makefile
+++ b/libs/libcap/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libcap
 PKG_VERSION:=2.25
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/libs/security/linux-privs/libcap2
@@ -30,18 +30,40 @@ define Package/libcap
   URL:=http://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/
 endef
 
+define Package/libcap/config
+  if PACKAGE_libcap
+
+  config PACKAGE_libcap-bin
+    bool "install libcap executables"
+    help
+      Install capsh, getcap, getpcaps, setcap into the target image.
+    default n
+
+  config PACKAGE_libcap-bin-capsh-shell
+    string "capsh shell"
+    depends on PACKAGE_libcap-bin
+    help
+      Set the capsh shell.
+    default "/bin/sh"
+
+  endif
+endef
+
 MAKE_FLAGS += \
-    CFLAGS="$(TARGET_CFLAGS)" \
     BUILD_CC="$(CC)" \
     BUILD_CFLAGS="$(FPIC) -I$(PKG_BUILD_DIR)/libcap/include" \
     CFLAGS="$(TARGET_CFLAGS)" \
-    LD="$(TARGET_CC)" \
-    LDFLAGS="$(TARGET_LDFLAGS) -shared" \
+    LD="$(TARGET_CC) -Wl,-x -shared" \
+    LDFLAGS="$(TARGET_LDFLAGS)" \
     INDENT="| true" \
     PAM_CAP="no" \
     RAISE_SETFCAP="no" \
     DYNAMIC="yes" \
     lib="lib"
+
+ifneq ($(CONFIG_PACKAGE_libcap-bin-capsh-shell),)
+TARGET_CFLAGS += -DSHELL='\"$(CONFIG_PACKAGE_libcap-bin-capsh-shell)\"'
+endif
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/sys
@@ -53,6 +75,13 @@ endef
 define Package/libcap/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/lib/libcap.so* $(1)/usr/lib/
+ifneq ($(CONFIG_PACKAGE_libcap-bin),)
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/sbin/capsh     $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/sbin/getcap    $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/sbin/getpcaps  $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/sbin/setcap    $(1)/usr/sbin/
+endif
 endef
 
 $(eval $(call BuildPackage,libcap))

--- a/libs/libcap/patches/200-change-hardcoded-shell-to-sh.patch
+++ b/libs/libcap/patches/200-change-hardcoded-shell-to-sh.patch
@@ -1,0 +1,34 @@
+--- a/progs/capsh.c
++++ b/progs/capsh.c
+@@ -24,6 +24,9 @@
+ #include <sys/wait.h>
+ #include <sys/prctl.h>
+ 
++#ifndef SHELL
++#define SHELL "/bin/sh"
++#endif
+ #define MAX_GROUPS       100   /* max number of supplementary groups for user */
+ 
+ static const cap_value_t raise_setpcap[1] = { CAP_SETPCAP };
+@@ -557,10 +560,10 @@ int main(int argc, char *argv[], char *envp[])
+ 	    }
+ 	    printf("\n");
+ 	} else if ((!strcmp("--", argv[i])) || (!strcmp("==", argv[i]))) {
+-	    argv[i] = strdup(argv[i][0] == '-' ? "/bin/bash" : argv[0]);
++	    argv[i] = strdup(argv[i][0] == '-' ? SHELL : argv[0]);
+ 	    argv[argc] = NULL;
+ 	    execve(argv[i], argv+i, envp);
+-	    fprintf(stderr, "execve /bin/bash failed!\n");
++	    fprintf(stderr, "execve " SHELL " failed!\n");
+ 	    exit(1);
+ 	} else {
+ 	usage:
+@@ -582,7 +585,7 @@ int main(int argc, char *argv[], char *envp[])
+ 		   "  --killit=<n>   send signal(n) to child\n"
+ 		   "  --forkfor=<n>  fork and make child sleep for <n> sec\n"
+ 		   "  ==             re-exec(capsh) with args as for --\n"
+-		   "  --             remaing arguments are for /bin/bash\n"
++		   "  --             remaing arguments are for " SHELL "\n"
+ 		   "                 (without -- [%s] will simply exit(0))\n",
+ 		   argv[0], argv[0]);
+ 


### PR DESCRIPTION
Maintainer: Paul Wassi <p.wassi@gmx.at>
Compile tested: x86_64, debian-stable, OpenWrt SNAPSHOT r6376+3-11d70f0600
Run tested: mvebu, linksys3200ac, OpenWrt SNAPSHOT r6376+3-11d70f0600

Description: Added libcap executables (capsh, getcap, getpcaps, setcap) to keep/drop capabilities(7) for child processes and files (if supported). A patch enables capsh to support a different shell rather than the default /bin/bash.
