### PR TITLE
 jool: split into several meta-packages

### DIFF
--- a/net/jool/Makefile
+++ b/net/jool/Makefile
@@ -50,6 +50,7 @@ define Build/Compile
 	$(call Build/Compile/Default)
 endef
 
+
 define Package/jool/Default
   SECTION:=net
   CATEGORY:=Network
@@ -71,45 +72,123 @@ define Package/jool/description
   $(call Package/jool/Default/description)
 endef
 
-define KernelPackage/jool
+define Package/jool-stateful
+  $(call Package/jool/Default)
+  TITLE:=Jool stateful meta-package
+  DEPENDS:=+kmod-jool-stateful +jool-tools-stateful
+endef
+
+define Package/jool-stateful/description
+  $(call Package/jool/Default/description)
+  
+  This meta-package provides only the stateful Jool tools and stateful kernel module.
+endef
+
+define Package/jool-stateless
+  $(call Package/jool/Default)
+  TITLE:=Jool stateless meta-package
+  DEPENDS:=+kmod-jool-stateless +jool-tools-stateless
+endef
+
+define Package/jool-stateless/description
+  $(call Package/jool/Default/description)
+  
+  This meta-package provides the stateless Jool tools and stateless kernel module.
+endef
+
+define KernelPackage/jool/Default
   SECTION:=kernel
   CATEGORY:=Kernel modules
   SUBMENU:=Network Support
-  TITLE:=Jool kernel module
   DEPENDS:= \
     @IPV6 \
     +kmod-crypto-md5 \
     +kmod-nf-conntrack \
     +kmod-nf-conntrack6
-  FILES:= \
-    $(PKG_BUILD_DIR)/mod/stateful/jool.$(LINUX_KMOD_SUFFIX) \
-    $(PKG_BUILD_DIR)/mod/stateless/jool_siit.$(LINUX_KMOD_SUFFIX)
 endef
 
-define KernelPackage/jool/description
+define KernelPackage/jool
+  $(call Package/jool/Default)
+  TITLE:=Jool kernel modules meta-package
+  DEPENDS:=+kmod-jool-stateful +kmod-jool-stateless
+endef
+
+define KernelPackage/jool-stateful
+  $(call KernelPackage/jool/Default)
+  TITLE:=Jool stateful kernel module
+  FILES:=$(PKG_BUILD_DIR)/mod/stateful/jool.$(LINUX_KMOD_SUFFIX)
+endef
+
+define KernelPackage/jool-stateful/description
   $(call Package/jool/Default/description)
 
-  This package provides the kernel module for Jool.
+  This package provides the Jool stateful kernel module.
+endef
+
+define KernelPackage/jool-stateless
+  $(call KernelPackage/jool/Default)
+  TITLE:=Jool stateless kernel module
+  FILES:=$(PKG_BUILD_DIR)/mod/stateless/jool_siit.$(LINUX_KMOD_SUFFIX)
+endef
+
+define KernelPackage/jool-stateless/description
+  $(call Package/jool/Default/description)
+
+  This package provides the Jool stateless kernel module.
 endef
 
 define Package/jool-tools
   $(call Package/jool/Default)
-  TITLE:=Jool userspace control programs
-  DEPENDS:=+libnl +ethtool
+  TITLE:=Jool userspace control programs meta-package
+  DEPENDS:=+jool-tools-stateful +jool-tools-stateless
 endef
 
 define Package/jool-tools/description
   $(call Package/jool/Default/description)
 
-  This package provides the userspace control programs for Jool.
+  This meta-package provides the stateful and stateless userspace control programs for Jool.
 endef
 
-define Package/jool-tools/install
+define Package/jool-tools-stateful
+  $(call Package/jool/Default)
+  TITLE:=Jool stateful userspace control program
+  DEPENDS:=+libnl +ethtool
+endef
+
+define Package/jool-tools-stateful/description
+  $(call Package/jool/Default/description)
+
+  This package provides the stateful userspace control program for Jool.
+endef
+
+define Package/jool-tools-stateless
+  $(call Package/jool/Default)
+  TITLE:=Jool stateless userspace control program
+  DEPENDS:=+libnl +ethtool
+endef
+
+define Package/jool-tools-stateless/description
+  $(call Package/jool/Default/description)
+
+  This package provides the stateless userspace control program for Jool.
+endef
+
+define Package/jool-tools-stateful/install
 	$(INSTALL_DIR) $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/usr/stateful/jool       $(1)/usr/sbin/
+endef
+
+define Package/jool-tools-stateless/install
+	$(INSTALL_DIR) $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/usr/stateless/jool_siit $(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,jool))
+$(eval $(call BuildPackage,jool-stateful))
+$(eval $(call BuildPackage,jool-stateless))
 $(eval $(call KernelPackage,jool))
+$(eval $(call KernelPackage,jool-stateful))
+$(eval $(call KernelPackage,jool-stateless))
 $(eval $(call BuildPackage,jool-tools))
+$(eval $(call BuildPackage,jool-tools-stateful))
+$(eval $(call BuildPackage,jool-tools-stateless))


### PR DESCRIPTION
Maintainer: Dan Luedtke <mail@danrl.com>
Compile tested: ar71xx-tiny
Run tested: yes (but Jool seems to be broken in OpenWrt anyway)

Description:
This commit is about saving space in special setups.
It is hard to fit Jool on a 4MB device. For basic configuration the userspace tools are not needed. 
Furthermore Jool offers two different things - a stateful NAT64 and a stateless NAT46.

This commit creates these new packages:
* kmod-jool-stateful
* kmod-jool-stateless
* jool-tools-stateful 
* jool-tools-stateless
* jool-stateful which selects kmod-jool-stateful and jool-tools-stateful
* jool-stateless which selects kmod-jool-stateless and jool-tools-stateless

Existing packages are being converted to meta-packages with dependencies to the corresponding new packages:
* kmod-jool selects kmod-jool-stateful and kmod-jool-stateless
* jool selects kmod-jool and jool-tools
* jool-tools selects jool-tools-stateful and jool-tools-stateless