### PR TITLE
node: bump to 8.10.0

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v6.11.2
-PKG_RELEASE:=4
+PKG_VERSION:=v8.10.0
+PKG_RELEASE:=1
 PKG_SOURCE:=node-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://nodejs.org/dist/${PKG_VERSION}
-PKG_HASH:=04af4992238b19124ea56f1bcfda36827613a24eb3b00fc3b50f261a415a26e4
+PKG_HASH:=b72d4e71618d6bcbd039b487b51fa7543631a4ac3331d7caf69bdf55b5b2901a
 
 HOST_BUILD_DEPENDS:=python/host
 PKG_BUILD_DEPENDS:=python/host
@@ -145,9 +145,10 @@ endef
 
 define Package/node-npm/install
 	mkdir -p $(1)/usr/bin $(1)/usr/lib/node_modules/npm/{bin,lib,node_modules}
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/npm $(1)/usr/bin/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/npm/{package.json,LICENSE,cli.js} $(1)/usr/lib/node_modules/npm
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/{npm,npx} $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/npm/{package.json,LICENSE} $(1)/usr/lib/node_modules/npm
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/npm/bin/npm-cli.js $(1)/usr/lib/node_modules/npm/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/npm/bin/npx-cli.js $(1)/usr/lib/node_modules/npm/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/npm/lib/* $(1)/usr/lib/node_modules/npm/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/npm/node_modules/* $(1)/usr/lib/node_modules/npm/node_modules/
 endef

--- a/lang/node/patches/001-hardfloat.patch
+++ b/lang/node/patches/001-hardfloat.patch
@@ -1,8 +1,6 @@
-diff --git a/deps/v8/src/base/cpu.cc b/deps/v8/src/base/cpu.cc
-index 4f58720..1f3071e 100644
 --- a/deps/v8/src/base/cpu.cc
 +++ b/deps/v8/src/base/cpu.cc
-@@ -143,6 +143,7 @@ int __detect_fp64_mode(void) {
+@@ -144,6 +144,7 @@
        ".set push\n\t"
        ".set noreorder\n\t"
        ".set oddspreg\n\t"

--- a/lang/node/patches/002-addr_info.patch
+++ b/lang/node/patches/002-addr_info.patch
@@ -1,6 +1,6 @@
 --- a/deps/uv/src/unix/getaddrinfo.c
 +++ b/deps/uv/src/unix/getaddrinfo.c
-@@ -99,6 +99,7 @@ static void uv__getaddrinfo_work(struct
+@@ -100,6 +100,7 @@
    int err;
  
    req = container_of(w, uv_getaddrinfo_t, work_req);

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/module.js
 +++ b/lib/module.js
-@@ -625,7 +625,8 @@
+@@ -714,7 +714,8 @@
    } else {
      prefixDir = path.resolve(process.execPath, '..', '..');
    }

--- a/lang/node/patches/004-node_crypto-remove-std.patch
+++ b/lang/node/patches/004-node_crypto-remove-std.patch
@@ -1,0 +1,13 @@
+diff --git a/src/node_crypto.cc b/src/node_crypto.cc
+index 972b1e4..7c0f65a 100644
+--- a/src/node_crypto.cc
++++ b/src/node_crypto.cc
+@@ -5623,7 +5623,7 @@ void PBKDF2(const FunctionCallbackInfo<Value>& args) {
+   }
+ 
+   raw_keylen = args[3]->NumberValue();
+-  if (raw_keylen < 0.0 || std::isnan(raw_keylen) || std::isinf(raw_keylen) ||
++  if (raw_keylen < 0.0 || isnan(raw_keylen) || isinf(raw_keylen) ||
+       raw_keylen > INT_MAX) {
+     type_error = "Bad key length";
+     goto err;


### PR DESCRIPTION
Maintainer: John Crispin @blogic , Adrian Panella @ianchi 
Compile tested: mvebu, OpenWrt master
Run tested: mvebu,OpenWrt master, Linksys wrt1200

Description:
Version bump to 8.10.0
Refreshed patches
Added npx install
Added 004-node_crypto-remove-std.patch

Additional patch fixes node_cypto compile failure:
./src/node_crypto.cc:5626:32: error: expected unqualified-id before '('

Signed-off-by: Arturo Rinaldi <arty.net2@gmail.com>
Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>




