### PR TITLE
node-arduino-firmata: bump to 0.3.4

### DIFF
--- a/lang/node-arduino-firmata/Makefile
+++ b/lang/node-arduino-firmata/Makefile
@@ -9,18 +9,18 @@ include $(TOPDIR)/rules.mk
 
 PKG_NPM_NAME:=arduino-firmata
 PKG_NAME:=node-$(PKG_NPM_NAME)
-PKG_VERSION:=0.3.3
-PKG_RELEASE:=7
+PKG_VERSION:=0.3.4
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/shokai/node-arduino-firmata.git
-PKG_SOURCE_VERSION:=16e76007edf218d72df590adbd711ac6b7432845
+PKG_SOURCE_VERSION:=v0.3.4
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_SOURCE_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz
-PKG_MIRROR_HASH:=b7a498ccf70e466503e72d38ae5b474e91416b6c9842fd167dff249357b0dc37
+#PKG_MIRROR_HASH:=b7a498ccf70e466503e72d38ae5b474e91416b6c9842fd167dff249357b0dc37
 
 PKG_BUILD_DEPENDS:=node/host
-PKG_NODE_VERSION:=6.11.2
+PKG_NODE_VERSION:=8.10.0
 
 PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>
 PKG_LICENSE:=MIT
@@ -59,8 +59,8 @@ endef
 
 define Package/node-arduino-firmata/install
 	mkdir -p $(1)/usr/lib/node
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/* $(1)/usr/lib/node
-	rm -rf $(1)/usr/lib/node/arduino-firmata/node_modules/serialport/ 
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/ $(1)/usr/lib/node
+	rm -rf $(1)/usr/lib/node/arduino-firmata/node_modules/serialport/
 	$(CP) ./files/* $(1)/
 endef
 


### PR DESCRIPTION
Maintainer: John Crispin / @blogic
Compile tested: OpenWrt master / mvebu
Run tested: OpenWrt master / mvebu / ClearFog Base

Description:
Bump to latest version
Depends on pull request #5734

Signed-off-by: Arturo Rinaldi arty.net2@gmail.com
Signed-off-by: Marko Ratkaj marko.ratkaj@sartura.hr