### PR TITLE
mwan3: update package dependence

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -19,7 +19,7 @@ define Package/mwan3
    SECTION:=net
    CATEGORY:=Network
    SUBMENU:=Routing and Redirection
-   DEPENDS:=+ip +ipset +iptables +iptables-mod-conntrack-extra +iptables-mod-ipopt
+   DEPENDS:=+ip-tiny +ipset +iptables +iptables-mod-conntrack-extra +iptables-mod-ipopt
    TITLE:=Multiwan hotplug script with connection tracking support
    MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
    PKGARCH:=all


### PR DESCRIPTION
update mwan3 dependence from ip to ip-tiny

fix mwan3 start issue :
ip: invalid argument '0xfd00/0xff00' to 'fwmark'
ip: invalid argument '0xfe00/0xff00' to 'fwmark'
ip: invalid argument '0xfd00/0xff00' to 'fwmark'
ip: invalid argument '0xfe00/0xff00' to 'fwmark'
ip: invalid argument '0x100/0xff00' to 'fwmark'
