### PR TITLE
libs/libmicrohttpd: Update to version 0.9.59

### DIFF
--- a/libs/libmicrohttpd/Makefile
+++ b/libs/libmicrohttpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmicrohttpd
-PKG_VERSION:=0.9.55
+PKG_VERSION:=0.9.59
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/libmicrohttpd
-PKG_HASH:=0c1cab8dc9f2588bd3076a28f77a7f8de9560cbf2d80e53f9a8696ada80ed0f8
+PKG_HASH:=9b9ccd7d0b11b0e179f1f58dc2caa3e0c62c8609e1e1dc7dcaadf941b67d923c
 
 PKG_MAINTAINER:=Alexander Couzens <lynxis@fe80.eu>
 


### PR DESCRIPTION
Maintainer: @lynxis 
Compile tested: kirkwood
Run tested: kirkwood

Description: Update libmicrohttpd to version 0.9.59
