### PR TITLE
mutt: bump to version 1.9.4

### DIFF
--- a/mail/mutt/Makefile
+++ b/mail/mutt/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mutt
-PKG_VERSION:=1.9.3
+PKG_VERSION:=1.9.4
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=ftp://ftp.mutt.org/pub/mutt/ \
 		https://bitbucket.org/mutt/mutt/downloads/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=431a85d6933ddf75cae51c9966c17d33e32fb0588cb3bbec9d32e01b267b76e1
+PKG_HASH:=f4d1bf26350c1ac81b551f98e5a4fd80d7fecd86919aa8165e69fde87de1b5df
 
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=GPL


### PR DESCRIPTION
Maintainer: me

Compile tested: (ar71xx, TL-WDR4300, openwrt-17.01.4 tag)
Run tested: (ar71xx, TL-WDR4300, LEDE-17.01.4)
Compile tested: (ar71xx, TL-WR1043ND v2, openwrt-15.05 release branch)
Run tested: (ar71xx, TL-WR1043ND v2, openwrt-15.05.01)