### PR TITLE
python,python3: attempt to fix Mac OS X host build issues

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -268,8 +268,12 @@ define PyPackage/python/filespec
 endef
 
 HOST_LDFLAGS += \
-	-Wl,--no-as-needed -lrt \
 	$$$$(pkg-config --static --libs libcrypto libssl)
+
+ifeq ($(HOST_OS),Linux)
+HOST_LDFLAGS += \
+	-Wl,--no-as-needed -lrt
+endif
 
 HOST_CONFIGURE_ARGS+= \
 	--without-cxx-main \

--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -282,7 +282,6 @@ HOST_CONFIGURE_ARGS+= \
 	--prefix=$(HOST_PYTHON_DIR) \
 	--exec-prefix=$(HOST_PYTHON_DIR) \
 	--with-system-expat=$(STAGING_DIR_HOSTPKG) \
-	--with-system-ffi=no \
 	--with-ensurepip=install \
 	CONFIG_SITE=
 

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -278,7 +278,6 @@ HOST_CONFIGURE_ARGS+= \
 	--prefix=$(HOST_PYTHON3_DIR) \
 	--exec-prefix=$(HOST_PYTHON3_DIR) \
 	--with-system-expat=$(STAGING_DIR_HOSTPKG) \
-	--with-system-ffi=no \
 	--with-ensurepip=install \
 	CONFIG_SITE=
 

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -264,8 +264,12 @@ define Py3Package/python3/filespec
 endef
 
 HOST_LDFLAGS += \
-	-Wl,--no-as-needed -lrt \
 	$$$$(pkg-config --static --libs libcrypto libssl)
+
+ifeq ($(HOST_OS),Linux)
+HOST_LDFLAGS += \
+	-Wl,--no-as-needed -lrt
+endif
 
 HOST_CONFIGURE_ARGS+= \
 	--without-cxx-main \


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/openwrt/openwrt/commit/56767dfa4232d3045136cf6c02956bfd4451af5e  x86_64
Run tested: N/A

Description:

Issues: https://github.com/openwrt/packages/issues/5310 https://github.com/openwrt/packages/issues/5638

Both issues were reported as build-failures on Mac OS X, and they also contain the solutions for the failures.
The issue is with the host Python/Python3 segfault-ing on Mac OS X.
Tested on Linux to check that the build does not fail ; since I don't have a Mac.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>