### PR TITLE
faad2: Remove BUILD_PATENTED

### DIFF
--- a/libs/faad2/Makefile
+++ b/libs/faad2/Makefile
@@ -48,7 +48,6 @@ $(call Package/faad2/Default)
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE+=library
-  DEPENDS:=@BUILD_PATENTED
   MENU:=1
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, OpenWrt trunk
Run tested: N/A

Description:
FAAD2 is freely available for non-commercial use.
Permits building of pianod and squeezelite in buildbot configs.

Signed-off-by: Ted Hess <thess@kitschensync.net>