### PR TITLE
softflowd: use Google Storage API to get sources from former Googlecode

### DIFF
--- a/net/softflowd/Makefile
+++ b/net/softflowd/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=0.9.9
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://softflowd.googlecode.com/files/
+PKG_SOURCE_URL:=https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/softflowd
 PKG_HASH:=2313f2c50ea9b3f2db3524e38ec7cd71f9a6e885ac2e3b55ab037bccf8173612
 PKG_MAINTAINER:=Ross Vandegrift <ross@kallisti.us>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
There's no direct access for `http://softflowd.googlecode.com/files/` files after Googlecode been closed, so the [OpenWrt sources mirrors](https://github.com/openwrt/openwrt/blob/master/scripts/download.pl#L260) was the only way to get `softflowd-0.9.9.tar.gz`.

Maintainer: @rvandegrift
Compile tested: [Entware](https://github.com/Entware)
Run tested: None
