### PR TITLE
picocom: use Google Storage API to get sources from former Googlecode

### DIFF
--- a/utils/picocom/Makefile
+++ b/utils/picocom/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.7
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://picocom.googlecode.com/files
+PKG_SOURCE_URL:=https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/picocom
 PKG_HASH:=d0f31c8f7a215a76922d30c81a52b9a2348c89e02a84935517002b3bc2c1129e
 
 PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>


### PR DESCRIPTION
There's no direct access for `http://picocom.googlecode.com/files/` files after Googlecode been closed, so the [OpenWrt sources mirrors](https://github.com/openwrt/openwrt/blob/master/scripts/download.pl#L260) was the only way to get `picocom-1.7.tar.gz`.

Maintainer: @sbyx /@jow
Compile tested: [Entware](https://github.com/Entware)
Run tested: None
