### PR TITLE
net/coova-chilli: fix -Werror=misleading-indendation

### DIFF
--- a/net/coova-chilli/patches/401-fix-compile-misleading-indentation.patch
+++ b/net/coova-chilli/patches/401-fix-compile-misleading-indentation.patch
@@ -1,0 +1,31 @@
+--- a/src/chilli.c
++++ b/src/chilli.c
+@@ -4297,8 +4297,10 @@ static int chilliauth_cb(struct radius_t
+ 	    while (!differ && r1 > 0 && r2 > 0);
+ 	  }
+ 	  
+-	  if (newfd) safe_close(newfd); newfd=0;
+-	  if (oldfd) safe_close(oldfd); oldfd=0;
++	  if (newfd) safe_close(newfd);
++	  newfd=0;
++	  if (oldfd) safe_close(oldfd);
++	  oldfd=0;
+ 	  
+ 	  if (differ) {
+ 	    log_dbg("Writing out new hs.conf file with administraive-user settings");
+--- a/src/redir.c
++++ b/src/redir.c
+@@ -3176,9 +3176,11 @@ pid_t redir_fork(int in, int out) {
+     }
+ 
+ #if defined(F_DUPFD)
+-    if (fcntl(in,F_GETFL,0) == -1) return -1; safe_close(0);
++    if (fcntl(in,F_GETFL,0) == -1) return -1;
++    safe_close(0);
+     if (fcntl(in,F_DUPFD,0) == -1) return -1;
+-    if (fcntl(out,F_GETFL,1) == -1) return -1; safe_close(1);
++    if (fcntl(out,F_GETFL,1) == -1) return -1;
++    safe_close(1);
+     if (fcntl(out,F_DUPFD,1) == -1) return -1;
+ #else
+     if (dup2(in,0) == -1) return -1;


### PR DESCRIPTION
Maintainer: Varied and many.
Compile tested: ar71xx / TP-LINK TL-WR841N/ND v11 / openwrt/openwrt@4fd87220567f1ae3ad209da1f602dc81c6b4d6b1
Run tested: none

Description:
As it currently stands, the version of coova-chilli the packages feed
will not compile against 4fd87220567f1ae3ad209da1f602dc81c6b4d6b1

I've quasi-backported (could not find a single commit which fixes these
particular issues) https://github.com/coova/coova-chilli 's formatting
on the impacted sections, and it compiles.

Once a new version is added to the feed this patch can likely be
dropped.

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>
