### PR TITLE
net/wan3: add some enhancements

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.6.10
-PKG_RELEASE:=2
+PKG_VERSION:=2.6.11
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2
 

--- a/net/mwan3/files/etc/mwan3.user
+++ b/net/mwan3/files/etc/mwan3.user
@@ -7,6 +7,10 @@
 #
 # There are three main environment variables that are passed to this script.
 #
-# $ACTION	Either "ifup" or "ifdown"
+# $ACTION
+#      <ifup>         Is called by netifd and mwan3track
+#      <ifdown>       Is called by netifd and mwan3track
+#      <connected>    Is only called by mwan3track if tracking was successful
+#      <disconnected> Is only called by mwan3track if tracking has failed
 # $INTERFACE	Name of the interface which went up or down (e.g. "wan" or "wwan")
 # $DEVICE	Physical device name which interface went up or down (e.g. "eth0" or "wwan0")

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -58,7 +58,7 @@ mwan3_id2mask()
 mwan3_init()
 {
 	local bitcnt
-	local mmdefault mmblackhole mmunreachable
+	local mmdefault
 
 	[ -d $MWAN3_STATUS_DIR ] || mkdir -p $MWAN3_STATUS_DIR/iface_state
 

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -145,7 +145,7 @@ stop()
 
 	for IP in "$IP4" "$IP6"; do
 
-		for route in $($IP route list table all | sed 's/.*table \([^ ]*\) .*/\1/' |  awk '{print $1}' | awk '{for(i=1;i<=NF;i++) if($i+0>0) if($i+0<255) {print;break}}'); do
+		for route in $(seq 1 $MWAN3_INTERFACE_MAX); do
 			$IP route flush table $route &> /dev/null
 		done
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -142,6 +142,7 @@ main() {
 				echo "offline" > /var/run/mwan3track/$1/STATUS
 				$LOG notice "Interface $1 ($2) is offline"
 				env -i ACTION=ifdown INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
+				env -i ACTION="disconnected" INTERFACE="$1" DEVICE="$2" /sbin/hotplug-call iface
 				score=0
 			fi
 		else
@@ -162,6 +163,7 @@ main() {
 			if [ $score -eq $up ]; then
 				$LOG notice "Interface $1 ($2) is online"
 				echo "online" > /var/run/mwan3track/$1/STATUS
+				env -i ACTION="connected" INTERFACE="$1" DEVICE="$2" /sbin/hotplug-call iface
 				env -i ACTION=ifup INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
 				exit 0
 			fi


### PR DESCRIPTION
Maintainer: me
Compile tested: this are shellscripts
Run tested: lantiq_xrx200 and x86_64, OpenWrt master

Description:

- The ACTIONs ifup/ifdown are called from netifd and mwan3track. To differ if the ACTIONs are called from mwan3track add connected/disconnected ACTION to mwan3track to signal changes in tracking state.

- Do not delete all 255 `ip rule tables ` make it depend on the firewall mask. The package mwan3 could administrate up to 252 interface if the firewall mask is set to 0xFF. But if the firewall mask is 0x0E you could only administrate 4 Interfaces . So on the lower firewall mask you only need to delete 4 `ip rule tables`. This will fix an issue with ipsec which default `ip rule table` is 220.