### PR TITLE
obfs4proxy: new packages (including dependencies)

### DIFF
--- a/lang/golang/golang-github-agl-ed25519/Makefile
+++ b/lang/golang/golang-github-agl-ed25519/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2018 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=golang-github-agl-ed25519
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/agl/ed25519.git
+PKG_SOURCE_VERSION:=5312a61534124124185d41f09206b9fef1d88403
+PKG_SOURCE_DATE:=20170117
+PKG_MIRROR_HASH:=be9e9223e7a15f4c12d9f652f5a50a59c01fd1f87ee73bea0ebfd661b5a7ca9c
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+
+GO_PKG:=github.com/agl/ed25519
+GO_PKG_SOURCE_ONLY:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../golang-package.mk
+
+define Package/golang-github-agl-ed25519-dev
+$(call GoPackage/GoSubMenu)
+  TITLE:=Ed25519 signature algorithm for Go
+  URL:=https://github.com/agl/ed25519
+  DEPENDS:=$(GO_ARCH_DEPENDS) \
+    +golang-golang-x-crypto-dev
+  PKGARCH:=all
+endef
+
+define Package/golang-github-agl-ed25519-dev/description
+Ed25519 is a public-key signature system based on elliptic-curve
+cryptography.
+endef
+
+$(eval $(call GoSrcPackage,golang-github-agl-ed25519-dev))
+$(eval $(call BuildPackage,golang-github-agl-ed25519-dev))

--- a/lang/golang/golang-github-dchest-siphash/Makefile
+++ b/lang/golang/golang-github-dchest-siphash/Makefile
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2018 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=golang-github-dchest-siphash
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/dchest/siphash.git
+PKG_SOURCE_VERSION:=4ebf1de738443ea7f45f02dc394c4df1942a126d
+PKG_SOURCE_DATE:=20160831
+PKG_MIRROR_HASH:=57da99437a6dba8c0b34bb09da48c0b8b1e70391ae0e3563453206794defe051
+
+PKG_LICENSE:=CC0-1.0
+PKG_LICENSE_FILES:=README.md
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+
+GO_PKG:=github.com/dchest/siphash
+GO_PKG_SOURCE_ONLY:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../golang-package.mk
+
+define Package/golang-github-dchest-siphash-dev
+$(call GoPackage/GoSubMenu)
+  TITLE:=Go implementation of SipHash-2-4
+  URL:=https://github.com/dchest/siphash
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+  PKGARCH:=all
+endef
+
+define Package/golang-github-dchest-siphash-dev/description
+SipHash-2-4 is a pseudorandom function (a.k.a. keyed hash function)
+optimized for speed on short messages.
+endef
+
+$(eval $(call GoSrcPackage,golang-github-dchest-siphash-dev))
+$(eval $(call BuildPackage,golang-github-dchest-siphash-dev))

--- a/lang/golang/golang-golang-x-crypto/Makefile
+++ b/lang/golang/golang-golang-x-crypto/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2018 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=golang-golang-x-crypto
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/golang/crypto.git
+PKG_SOURCE_VERSION:=a49355c7e3f8fe157a85be2f77e6e269a0f89602
+PKG_SOURCE_DATE:=20180620
+PKG_MIRROR_HASH:=80b16b203736ac56883d0610edbc5981eb78f15b7b35d11b5ca639f7c3814214
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+
+GO_PKG:=golang.org/x/crypto
+GO_PKG_SOURCE_ONLY:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../golang-package.mk
+
+define Package/golang-golang-x-crypto-dev
+$(call GoPackage/GoSubMenu)
+  TITLE:=Go supplementary cryptography libraries
+  URL:=https://godoc.org/golang.org/x/crypto
+  DEPENDS:=$(GO_ARCH_DEPENDS) \
+    +golang-golang-x-net-dev \
+    +golang-golang-x-sys-dev
+  PKGARCH:=all
+endef
+
+define Package/golang-golang-x-crypto-dev/description
+Supplementary Go cryptography libraries.
+endef
+
+$(eval $(call GoSrcPackage,golang-golang-x-crypto-dev))
+$(eval $(call BuildPackage,golang-golang-x-crypto-dev))

--- a/lang/golang/golang-golang-x-net/Makefile
+++ b/lang/golang/golang-golang-x-net/Makefile
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2018 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=golang-golang-x-net
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/golang/net.git
+PKG_SOURCE_VERSION:=afe8f62b1d6bbd81f31868121a50b06d8188e1f9
+PKG_SOURCE_DATE:=20180620
+PKG_MIRROR_HASH:=9a8bb3bf21ea60121d7e87f1bd1af9effbdcd908f758be99457653172d13eb1e
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+
+GO_PKG:=golang.org/x/net
+# exclude http2/h2i to break circular dependency with golang-golang-x-crypto-dev
+# since there are no other binaries, can skip compilation
+GO_PKG_SOURCE_ONLY:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../golang-package.mk
+
+define Package/golang-golang-x-net-dev
+$(call GoPackage/GoSubMenu)
+  TITLE:=Go supplementary network libraries
+  URL:=https://godoc.org/golang.org/x/net
+  DEPENDS:=$(GO_ARCH_DEPENDS) +golang-golang-x-text-dev
+  PKGARCH:=all
+endef
+
+define Package/golang-golang-x-net-dev/description
+Supplementary Go networking libraries.
+endef
+
+# http2/testdata/draft-ietf-httpbis-http2.xml is a non-free document
+# http2/z_spec_test.go uses http2/testdata/draft-ietf-httpbis-http2.xml
+define Package/golang-golang-x-net-dev/install
+	$(call GoPackage/Package/Install/Src,$(1))
+
+	rm -f $(1)$(GO_PKG_PATH)/src/$(GO_PKG)/http2/testdata/draft-ietf-httpbis-http2.xml
+	rmdir $(1)$(GO_PKG_PATH)/src/$(GO_PKG)/http2/testdata/
+
+	rm -f $(1)$(GO_PKG_PATH)/src/$(GO_PKG)/http2/z_spec_test.go
+endef
+
+$(eval $(call GoSrcPackage,golang-golang-x-net-dev))
+$(eval $(call BuildPackage,golang-golang-x-net-dev))

--- a/lang/golang/golang-golang-x-sys/Makefile
+++ b/lang/golang/golang-golang-x-sys/Makefile
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2018 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=golang-golang-x-sys
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/golang/sys.git
+PKG_SOURCE_VERSION:=63fc586f45fe72d95d5240a5d5eb95e6503907d3
+PKG_SOURCE_DATE:=20180621
+PKG_MIRROR_HASH:=3afe7936fb9fb291ef9b9cfa88f51576cdc19abbd34240232ce284958ac7dbaf
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+
+GO_PKG:=golang.org/x/sys
+GO_PKG_SOURCE_ONLY:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../golang-package.mk
+
+define Package/golang-golang-x-sys-dev
+$(call GoPackage/GoSubMenu)
+  TITLE:=Go packages for interaction with the OS
+  URL:=https://godoc.org/golang.org/x/sys
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+  PKGARCH:=all
+endef
+
+define Package/golang-golang-x-sys-dev/description
+Supplementary Go packages for low-level interactions with the operating
+system.
+endef
+
+$(eval $(call GoSrcPackage,golang-golang-x-sys-dev))
+$(eval $(call BuildPackage,golang-golang-x-sys-dev))

--- a/lang/golang/golang-golang-x-text/Makefile
+++ b/lang/golang/golang-golang-x-text/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2018 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=golang-golang-x-text
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/golang/text.git
+PKG_SOURCE_VERSION:=5cec4b58c438bd98288aeb248bab2c1840713d21
+PKG_SOURCE_DATE:=20180520
+PKG_MIRROR_HASH:=6c541a59f32f57afa54a2216045ddf16a077f8fe2e823fbbe77723eca04ddddb
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+
+GO_PKG:=golang.org/x/text
+# exclude gotext (and message/pipeline) to avoid dependency on golang.org/x/tools
+# since there are no other binaries, can skip compilation
+GO_PKG_SOURCE_ONLY:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../golang-package.mk
+
+define Package/golang-golang-x-text-dev
+$(call GoPackage/GoSubMenu)
+  TITLE:=Go text processing support
+  URL:=https://godoc.org/golang.org/x/text
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+  PKGARCH:=all
+endef
+
+define Package/golang-golang-x-text-dev/description
+Supplementary Go libraries for text processing, many involving Unicode.
+endef
+
+$(eval $(call GoSrcPackage,golang-golang-x-text-dev))
+$(eval $(call BuildPackage,golang-golang-x-text-dev))

--- a/lang/golang/golang-torproject-pluggable-transports-goptlib/Makefile
+++ b/lang/golang/golang-torproject-pluggable-transports-goptlib/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2018 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=golang-torproject-pluggable-transports-goptlib
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://git.torproject.org/pluggable-transports/goptlib.git
+PKG_SOURCE_VERSION:=7d56ec4f381e8b1aedfda360594e35a5731b5337
+PKG_SOURCE_DATE:=20180320
+PKG_MIRROR_HASH:=ec28d8882e031046efd561764e1b9119376844a1c3d4941e038cfbe32e60b058
+
+PKG_LICENSE:=CC0-1.0
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+
+GO_PKG:=git.torproject.org/pluggable-transports/goptlib.git
+GO_PKG_SOURCE_ONLY:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../golang-package.mk
+
+define Package/golang-torproject-pluggable-transports-goptlib-dev
+$(call GoPackage/GoSubMenu)
+  TITLE:=Tor pluggable transports library for Go
+  URL:=https://gitweb.torproject.org/pluggable-transports/goptlib.git/
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+  PKGARCH:=all
+endef
+
+define Package/golang-torproject-pluggable-transports-goptlib-dev/description
+goptlib is a library for writing Tor pluggable transports in Go.
+endef
+
+$(eval $(call GoSrcPackage,golang-torproject-pluggable-transports-goptlib-dev))
+$(eval $(call BuildPackage,golang-torproject-pluggable-transports-goptlib-dev))

--- a/net/obfs4proxy/Makefile
+++ b/net/obfs4proxy/Makefile
@@ -1,0 +1,89 @@
+#
+# Copyright (C) 2018 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=obfs4proxy
+PKG_VERSION:=0.0.7
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://git.torproject.org/pluggable-transports/obfs4.git
+PKG_SOURCE_VERSION:=8256fac93c2cf79742725e3aaced5bbe3380fd32
+PKG_SOURCE_DATE:=20161115
+PKG_MIRROR_HASH:=9c504337f7a2b46310083224cf0998fc7645f8af5d50657cf74358d39916eddc
+
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=git.torproject.org/pluggable-transports/obfs4.git
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/obfs4proxy/Default
+  TITLE:=A Tor pluggable transport proxy, implementing obfs4
+  URL:=https://gitweb.torproject.org/pluggable-transports/obfs4.git/
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/obfs4proxy
+$(call Package/obfs4proxy/Default)
+  SECTION:=net
+  CATEGORY:=Network
+endef
+
+define Package/golang-torproject-pluggable-transports-obfs4-dev
+$(call Package/obfs4proxy/Default)
+$(call GoPackage/GoSubMenu)
+  TITLE+= (source files)
+  DEPENDS+= \
+    +golang-github-agl-ed25519-dev \
+    +golang-github-dchest-siphash-dev \
+    +golang-golang-x-crypto-dev \
+    +golang-golang-x-net-dev \
+    +golang-torproject-pluggable-transports-goptlib-dev
+  PKGARCH:=all
+endef
+
+define Package/obfs4proxy/Default/description
+obfs4proxy is a tool that attempts to circumvent censorship by
+transforming the Tor traffic between the client and the bridge. This way
+censors, who usually monitor traffic between the client and the bridge,
+will see innocent-looking transformed traffic instead of the actual Tor
+traffic.
+
+obfs4proxy implements the obfsucation protocols obfs2, obfs3, and obfs4.
+
+It is written in Go and is compliant with the Tor pluggable transports
+specification, and its modular architecture allows it to support
+multiple pluggable transports.
+endef
+
+define Package/obfs4proxy/description
+$(call Package/obfs4proxy/Default/description)
+
+This package contains both the client and the bridge in a single
+program.
+endef
+
+define Package/golang-torproject-pluggable-transports-obfs4-dev/description
+$(call Package/obfs4proxy/Default/description)
+
+This package provides the source files for the client/bridge program.
+endef
+
+$(eval $(call GoBinPackage,obfs4proxy))
+$(eval $(call BuildPackage,obfs4proxy))
+
+$(eval $(call GoSrcPackage,golang-torproject-pluggable-transports-obfs4-dev))
+$(eval $(call BuildPackage,golang-torproject-pluggable-transports-obfs4-dev))

--- a/net/obfs4proxy/patches/bug-24793-send-correct-http-header-for-basic-auth.patch
+++ b/net/obfs4proxy/patches/bug-24793-send-correct-http-header-for-basic-auth.patch
@@ -1,0 +1,40 @@
+From af4824cb0b2c36a0eba4bc1590eb0737302e992e Mon Sep 17 00:00:00 2001
+From: Yawning Angel <yawning@schwanenlied.me>
+Date: Wed, 10 Jan 2018 15:11:44 +0000
+Subject: Bug 24793: Send the correct authorization HTTP header for basic auth.
+
+Apparently I didn't test the "connect via HTTP(s)" proxy with
+authentication at all when I added that functionality, so it has been
+broken for years.
+
+This should fix it now.
+---
+ obfs4proxy/proxy_http.go | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/obfs4proxy/proxy_http.go b/obfs4proxy/proxy_http.go
+index 6f11790..a5c2100 100644
+--- a/obfs4proxy/proxy_http.go
++++ b/obfs4proxy/proxy_http.go
+@@ -29,6 +29,7 @@ package main
+ 
+ import (
+ 	"bufio"
++	"encoding/base64"
+ 	"fmt"
+ 	"net"
+ 	"net/http"
+@@ -90,7 +91,9 @@ func (s *httpProxy) Dial(network, addr string) (net.Conn, error) {
+ 	}
+ 	req.Close = false
+ 	if s.haveAuth {
+-		req.SetBasicAuth(s.username, s.password)
++		// SetBasicAuth doesn't quite do what is appropriate, because
++		// the correct header is `Proxy-Authorization`.
++		req.Header.Set("Proxy-Authorization", base64.StdEncoding.EncodeToString([]byte(s.username + ":" + s.password)))
+ 	}
+ 	req.Header.Set("User-Agent", "")
+ 
+-- 
+cgit v1.1
+


### PR DESCRIPTION
Maintainer (to be): me
Compile tested: x86-legacy / x86-64 / armvirt-32 / armvirt-64 (2018-03-08 snapshot sdks), malta-be (2018-03-13 snapshot sdk), malta-le (2017-11-02 snapshot sdk)
Run tested: x86-legacy / x86-64 / armvirt-32 / armvirt-64 (2018-03-08 snapshots), malta-be (2018-03-13 snapshot), malta-le (2017-11-02 snapshot); configured tor to use obfs4proxy with obfs4 bridges

Description:
obfs4proxy is a Tor pluggable transport proxy, implementing obfs4.

This commit also includes obfs4proxy's build time dependencies:

* golang-github-agl-ed25519: Go implementation of Ed25519 signature algorithm
* golang-github-dchest-siphash: Go implementation of SipHash-2-4
* golang-golang-x-crypto: Go supplementary cryptography libraries
* golang-golang-x-net: Go supplementary network libraries
* golang-golang-x-sys: Go packages for interaction with the OS
* golang-golang-x-text: Go text processing support
* golang-torproject-pluggable-transports-goptlib: Tor pluggable transports library for Go

This also depends on #5780.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>