### PR TITLE
PulseAudio fixes

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -99,6 +99,7 @@ define Package/pulseaudio-profiles
 endef
 
 CONFIGURE_ARGS += \
+	$(if $(findstring neon,$(CONFIG_TARGET_OPTIMIZATION)),--enable-neon-opt,--disable-neon-opt) \
 	--with-system-user=pulse \
 	--with-system-group=pulse \
 	--with-access-group=audio \

--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2016 OpenWrt.org
+# Copyright (C) 2011-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pulseaudio
 PKG_VERSION:=11.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://freedesktop.org/software/pulseaudio/releases/

--- a/sound/pulseaudio/patches/002-no-fortify-source-override.patch
+++ b/sound/pulseaudio/patches/002-no-fortify-source-override.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -197,7 +197,7 @@ AS_CASE([" $CFLAGS "], [*" -O0 "*], [],
+     # Warnings to be aware of that appear with -D_FORTIFY_SOURCE=2 but without -U_FORTIFY_SOURCE:
+     # On Fedora 20 with -O0: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
+     # On Gentoo with -O2:    "_FORTIFY_SOURCE" redefined [enabled by default]
+-    AS_VAR_APPEND([CPPFLAGS],[" -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2"])
++    #AS_VAR_APPEND([CPPFLAGS],[" -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2"])
+ ])
+ 
+ #### Linker flags ####


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: arm_arm1176jzf-s+vfp + x86_64
Run tested: N/A

Description:
Hello Peter, all!

Currently pulseaudio fails to build on:

arm_arm1176jzf-s_vfp
arm_cortex-a8_vfpv3
arm_cortex-a9_vfpv3
arm_mpcore_vfp

That's all ARM VFP targets that do not support NEON. The first commit fixes that.

The second commit prevents PulseAudio from overriding OpenWrt's FORTIFY_SOURCE setup.

Kind regards,
Sebastian