### PR TITLE
unbound: update to 1.7.0 and add domain control options

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -152,10 +152,11 @@ define Package/unbound/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN)  ./files/unbound.init $(1)/etc/init.d/unbound
 	$(INSTALL_DIR) $(1)/usr/lib/unbound
-	$(INSTALL_BIN)  ./files/odhcpd.sh $(1)/usr/lib/unbound/odhcpd.sh
-	$(INSTALL_DATA) ./files/odhcpd.awk $(1)/usr/lib/unbound/odhcpd.awk
+	$(INSTALL_DATA) ./files/defaults.sh $(1)/usr/lib/unbound/defaults.sh
 	$(INSTALL_DATA) ./files/dnsmasq.sh $(1)/usr/lib/unbound/dnsmasq.sh
 	$(INSTALL_DATA) ./files/iptools.sh $(1)/usr/lib/unbound/iptools.sh
+	$(INSTALL_BIN)  ./files/odhcpd.sh $(1)/usr/lib/unbound/odhcpd.sh
+	$(INSTALL_DATA) ./files/odhcpd.awk $(1)/usr/lib/unbound/odhcpd.awk
 	$(INSTALL_DATA) ./files/rootzone.sh $(1)/usr/lib/unbound/rootzone.sh
 	$(INSTALL_DATA) ./files/unbound.sh $(1)/usr/lib/unbound/unbound.sh
 endef

--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.6.8
+PKG_VERSION:=1.7.0
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
@@ -17,7 +17,7 @@ PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@hotmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unbound.net/downloads
-PKG_HASH:=e3b428e33f56a45417107448418865fe08d58e0e7fea199b855515f60884dd49
+PKG_HASH:=94dd9071fb13d8ccd122a3ac67c4524a3324d0e771fc7a8a7c49af8abfb926a2
 
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf

--- a/net/unbound/files/defaults.sh
+++ b/net/unbound/files/defaults.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+##############################################################################
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# Copyright (C) 2016 Eric Luehrsen
+#
+##############################################################################
+
+UNBOUND_LIBDIR=/usr/lib/unbound
+UNBOUND_VARDIR=/var/lib/unbound
+
+UNBOUND_PIDFILE=/var/run/unbound.pid
+
+UNBOUND_SRV_CONF=$UNBOUND_VARDIR/unbound_srv.conf
+UNBOUND_EXT_CONF=$UNBOUND_VARDIR/unbound_ext.conf
+UNBOUND_DHCP_CONF=$UNBOUND_VARDIR/unbound_dhcp.conf
+UNBOUND_CONFFILE=$UNBOUND_VARDIR/unbound.conf
+
+UNBOUND_KEYFILE=$UNBOUND_VARDIR/root.key
+UNBOUND_HINTFILE=$UNBOUND_VARDIR/root.hints
+UNBOUND_TIMEFILE=$UNBOUND_VARDIR/hotplug.time
+
+UNBOUND_CTLKEY_FILE=$UNBOUND_VARDIR/unbound_control.key
+UNBOUND_CTLPEM_FILE=$UNBOUND_VARDIR/unbound_control.pem
+UNBOUND_SRVKEY_FILE=$UNBOUND_VARDIR/unbound_server.key
+UNBOUND_SRVPEM_FILE=$UNBOUND_VARDIR/unbound_server.pem
+
+##############################################################################
+
+UNBOUND_ANCHOR=/usr/sbin/unbound-anchor
+UNBOUND_CONTROL=/usr/sbin/unbound-control
+UNBOUND_CONTROL_CFG="$UNBOUND_CONTROL -c $UNBOUND_CONFFILE"
+
+##############################################################################
+

--- a/net/unbound/files/odhcpd.awk
+++ b/net/unbound/files/odhcpd.awk
@@ -86,7 +86,7 @@
 
 
         while ( ( cmd | getline adr ) > 0 ) {
-          if (( substr( adr, 1, 5 ) <= "fd00:" ) \
+          if (( substr( adr, 1, 5 ) <= "fdff:" ) \
           && ( index( adr, "anycast" ) == 0 ) \
           && ( index( adr, "via" ) == 0 )) {
             # GA or ULA routed addresses only (not LL or MC)

--- a/net/unbound/files/odhcpd.sh
+++ b/net/unbound/files/odhcpd.sh
@@ -23,56 +23,73 @@
 #
 ##############################################################################
 
-# Common file location definitions
-. /usr/lib/unbound/unbound.sh
-
-##############################################################################
-
-odhcpd_settings() {
-  # This trigger is out of normal init context, so we need to read some UCI.
-  local cfg="$1"
-  config_get UNBOUND_D_DHCP_LINK  "$cfg" dhcp_link none
-  config_get_bool UNBOUND_B_SLAAC6_MAC "$cfg" dhcp4_slaac6 0
-  config_get UNBOUND_TXT_DOMAIN "$cfg" domain lan
-}
+. /lib/functions.sh
+. /usr/lib/unbound/defaults.sh
 
 ##############################################################################
 
 odhcpd_zonedata() {
+  local longconf dateconf
   local dns_ls_add=$UNBOUND_VARDIR/dhcp_dns.add
   local dns_ls_del=$UNBOUND_VARDIR/dhcp_dns.del
   local dhcp_ls_new=$UNBOUND_VARDIR/dhcp_lease.new
   local dhcp_ls_old=$UNBOUND_VARDIR/dhcp_lease.old
   local dhcp_ls_add=$UNBOUND_VARDIR/dhcp_lease.add
   local dhcp_ls_del=$UNBOUND_VARDIR/dhcp_lease.del
+
+  local dhcp_link=$( uci_get unbound.@unbound[0].dhcp_link )
+  local dhcp4_slaac6=$( uci_get unbound.@unbound[0].dhcp4_slaac6 )
+  local dhcp_domain=$( uci_get unbound.@unbound[0].domain )
   local dhcp_origin=$( uci_get dhcp.@odhcpd[0].leasefile )
 
-  config_load unbound
-  config_foreach odhcpd_settings unbound
 
-
-  if [ "$UNBOUND_D_DHCP_LINK" = "odhcpd" -a -f "$dhcp_origin" ] ; then
+  if [ "$dhcp_link" = "odhcpd" -a -f "$dhcp_origin" ] ; then
     # Capture the lease file which could be changing often
-    cat $dhcp_origin | sort > $dhcp_ls_new
-    touch $dhcp_ls_old
-    sort $dhcp_ls_new $dhcp_ls_old $dhcp_ls_old | uniq -u > $dhcp_ls_add
-    sort $dhcp_ls_old $dhcp_ls_new $dhcp_ls_new | uniq -u > $dhcp_ls_del
+    sort $dhcp_origin > $dhcp_ls_new
 
-    # Go through the messy business of coding up A, AAAA, and PTR records
-    # This static conf will be available if Unbound restarts asynchronously
-    awk -v hostfile=$UNBOUND_DHCP_CONF -v domain=$UNBOUND_TXT_DOMAIN \
-        -v bslaac=$UNBOUND_B_SLAAC6_MAC -v bisolt=0 -v bconf=1 \
-        -f /usr/lib/unbound/odhcpd.awk $dhcp_ls_new
 
-    # Deleting and adding all records into Unbound can be a burden in a
-    # high density environment. Use unbound-control incrementally.
-    awk -v hostfile=$dns_ls_del -v domain=$UNBOUND_TXT_DOMAIN \
-        -v bslaac=$UNBOUND_B_SLAAC6_MAC -v bisolt=0 -v bconf=0 \
-        -f /usr/lib/unbound/odhcpd.awk $dhcp_ls_del
+    if [ ! -f $UNBOUND_DHCP_CONF -o ! -f $dhcp_ls_old ] ; then
+      longconf=2
 
-    awk -v hostfile=$dns_ls_add -v domain=$UNBOUND_TXT_DOMAIN \
-        -v bslaac=$UNBOUND_B_SLAAC6_MAC -v bisolt=0 -v bconf=0 \
-        -f /usr/lib/unbound/odhcpd.awk $dhcp_ls_add
+    else
+      dateconf=$(( $( date +%s ) - $( date -r $UNBOUND_DHCP_CONF +%s ) ))
+
+
+      if [ $dateconf > 150 ] ; then
+        longconf=1
+      else
+        longconf=0
+      fi
+    fi
+
+
+    if [ $longconf -gt 0 ] ; then
+      # Go through the messy business of coding up A, AAAA, and PTR records
+      # This static conf will be available if Unbound restarts asynchronously
+      awk -v hostfile=$UNBOUND_DHCP_CONF -v domain=$dhcp_domain \
+          -v bslaac=$dhcp4_slaac6 -v bisolt=0 -v bconf=1 \
+          -f /usr/lib/unbound/odhcpd.awk $dhcp_ls_new
+    fi
+
+
+    if [ $longconf -lt 2 ] ; then
+      # Deleting and adding all records into Unbound can be a burden in a
+      # high density environment. Use unbound-control incrementally.
+      sort $dhcp_ls_old $dhcp_ls_new $dhcp_ls_new | uniq -u > $dhcp_ls_del
+      awk -v hostfile=$dns_ls_del -v domain=$dhcp_domain \
+          -v bslaac=$dhcp4_slaac6 -v bisolt=0 -v bconf=0 \
+          -f /usr/lib/unbound/odhcpd.awk $dhcp_ls_del
+
+      sort $dhcp_ls_new $dhcp_ls_old $dhcp_ls_old | uniq -u > $dhcp_ls_add
+      awk -v hostfile=$dns_ls_add -v domain=$dhcp_domain \
+          -v bslaac=$dhcp4_slaac6 -v bisolt=0 -v bconf=0 \
+          -f /usr/lib/unbound/odhcpd.awk $dhcp_ls_add
+
+    else
+      awk -v hostfile=$dns_ls_add -v domain=$dhcp_domain \
+          -v bslaac=$dhcp4_slaac6 -v bisolt=0 -v bconf=0 \
+          -f /usr/lib/unbound/odhcpd.awk $dhcp_ls_new
+    fi
 
 
     if [ -f "$dns_ls_del" ] ; then

--- a/net/unbound/files/rootzone.sh
+++ b/net/unbound/files/rootzone.sh
@@ -14,21 +14,9 @@
 #
 ##############################################################################
 #
-# This component needs to be used within the unbound.sh as an include. It uses
-# defaults and UCI scope variables defined there. It will copy root.key back
-# to /etc/unbound/ periodically, but avoid ROM flash abuse (UCI option).
+# This component will copy root.key back to /etc/unbound/ periodically, but
+# avoid ROM flash abuse (UCI option).
 #
-##############################################################################
-
-rootzone_uci() {
-  local cfg=$1
-
-  # This will likely be called outside of "start_service()" context
-  config_get_bool UNBOUND_B_DNSSEC "$cfg" validator 0
-  config_get_bool UNBOUND_B_NTP_BOOT "$cfg" validator_ntp 1
-  config_get UNBOUND_N_ROOT_AGE "$cfg" root_age 9
-}
-
 ##############################################################################
 
 roothints_update() {
@@ -42,12 +30,16 @@ roothints_update() {
 rootkey_update() {
   local basekey_date rootkey_date rootkey_age filestuff
 
+  local dnssec=$( uci_get unbound.@unbound[0].validator )
+  local dnssec_ntp=$( uci_get unbound.@unbound[0].validator_ntp )
+  local dnssec_age=$( uci_get unbound.@unbound[0].root_age )
 
-  if [ "$UNBOUND_N_ROOT_AGE" -gt 90 -o "$UNBOUND_B_DNSSEC" -lt 1 ] ; then
+
+  if [ "$dnssec_age" -gt 90 -o "$dnssec" -lt 1 ] ; then
     # Feature disabled
     return 0
 
-  elif [ "$UNBOUND_B_NTP_BOOT" -gt 0 -a ! -f "$UNBOUND_TIMEFILE" ] ; then
+  elif [ "$dnssec_ntp" -gt 0 -a ! -f "$UNBOUND_TIMEFILE" ] ; then
     # We don't have time yet
     return 0
   fi
@@ -79,7 +71,7 @@ rootkey_update() {
   fi
 
 
-  if [ "$rootkey_age" -gt "$UNBOUND_N_ROOT_AGE" ] ; then
+  if [ "$rootkey_age" -gt "$dnssec_age" ] ; then
     filestuff=$( cat $UNBOUND_KEYFILE )
 
 
@@ -106,11 +98,6 @@ rootkey_update() {
 ##############################################################################
 
 rootzone_update() {
-  # Partial UCI fetch for this functional group
-  config_load unbound
-  config_foreach rootzone_uci unbound
-
-  # You need root.hints and root.key to boot strap recursion
   roothints_update
   rootkey_update
 }

--- a/net/unbound/files/unbound.init
+++ b/net/unbound/files/unbound.init
@@ -56,10 +56,13 @@ stop_service() {
 
 service_triggers() {
   local trigger
-  local triggers=$( uci_get unbound.@unbound[0].trigger )
+  local legacy=$( uci_get unbound.@unbound[0].trigger )
+  local triggers=$( uci_get unbound.@unbound[0].trigger_interface )
 
+  triggers="$triggers $legacy"
   PROCD_RELOAD_DELAY=2000
   procd_add_reload_trigger "unbound"
+
 
   if [ -n "$triggers" ] ; then
     for trigger in $triggers ; do

--- a/net/unbound/files/unbound.sh
+++ b/net/unbound/files/unbound.sh
@@ -33,7 +33,6 @@ UNBOUND_B_LOCL_BLCK=0
 UNBOUND_B_LOCL_SERV=1
 UNBOUND_B_MAN_CONF=0
 UNBOUND_B_NTP_BOOT=1
-UNBOUND_B_PRIV_BLCK=1
 UNBOUND_B_QUERY_MIN=0
 UNBOUND_B_QRY_MINST=0
 
@@ -42,6 +41,7 @@ UNBOUND_D_DOMAIN_TYPE=static
 UNBOUND_D_DHCP_LINK=none
 UNBOUND_D_EXTRA_DNS=0
 UNBOUND_D_LAN_FQDN=0
+UNBOUND_D_PRIV_BLCK=1
 UNBOUND_D_PROTOCOL=mixed
 UNBOUND_D_RESOURCE=small
 UNBOUND_D_RECURSION=passive
@@ -60,7 +60,9 @@ UNBOUND_TXT_DOMAIN=lan
 UNBOUND_TXT_FWD_ZONE=""
 UNBOUND_TXT_HOSTNAME=thisrouter
 
+UNBOUND_LIST_FORWARD=""
 UNBOUND_LIST_INSECURE=""
+UNBOUND_LIST_PRV_SUBNET=""
 
 ##############################################################################
 
@@ -69,39 +71,13 @@ UNBOUND_LIST_DOMAINS=""
 
 ##############################################################################
 
-UNBOUND_LIBDIR=/usr/lib/unbound
-UNBOUND_VARDIR=/var/lib/unbound
-
-UNBOUND_PIDFILE=/var/run/unbound.pid
-
-UNBOUND_SRV_CONF=$UNBOUND_VARDIR/unbound_srv.conf
-UNBOUND_EXT_CONF=$UNBOUND_VARDIR/unbound_ext.conf
-UNBOUND_DHCP_CONF=$UNBOUND_VARDIR/unbound_dhcp.conf
-UNBOUND_CONFFILE=$UNBOUND_VARDIR/unbound.conf
-
-UNBOUND_KEYFILE=$UNBOUND_VARDIR/root.key
-UNBOUND_HINTFILE=$UNBOUND_VARDIR/root.hints
-UNBOUND_TIMEFILE=$UNBOUND_VARDIR/hotplug.time
-
-UNBOUND_CTLKEY_FILE=$UNBOUND_VARDIR/unbound_control.key
-UNBOUND_CTLPEM_FILE=$UNBOUND_VARDIR/unbound_control.pem
-UNBOUND_SRVKEY_FILE=$UNBOUND_VARDIR/unbound_server.key
-UNBOUND_SRVPEM_FILE=$UNBOUND_VARDIR/unbound_server.pem
-
-##############################################################################
-
-UNBOUND_ANCHOR=/usr/sbin/unbound-anchor
-UNBOUND_CONTROL=/usr/sbin/unbound-control
-UNBOUND_CONTROL_CFG="$UNBOUND_CONTROL -c $UNBOUND_CONFFILE"
-
-##############################################################################
-
 . /lib/functions.sh
 . /lib/functions/network.sh
 
-. $UNBOUND_LIBDIR/dnsmasq.sh
-. $UNBOUND_LIBDIR/iptools.sh
-. $UNBOUND_LIBDIR/rootzone.sh
+. /usr/lib/unbound/defaults.sh
+. /usr/lib/unbound/dnsmasq.sh
+. /usr/lib/unbound/iptools.sh
+. /usr/lib/unbound/rootzone.sh
 
 ##############################################################################
 
@@ -395,8 +371,38 @@ create_access_control() {
 
 ##############################################################################
 
-create_domain_insecure() {
+bundle_domain_forward() {
+  UNBOUND_LIST_FORWARD="$UNBOUND_LIST_FORWARD $1"
+}
+
+##############################################################################
+
+bundle_domain_insecure() {
   UNBOUND_LIST_INSECURE="$UNBOUND_LIST_INSECURE $1"
+}
+
+##############################################################################
+
+bundle_private_interface() {
+  local ipcommand ifsubnet ifsubnets ifname
+
+  network_get_device ifname $1
+
+  if [ -n "$ifname" ] ; then
+    ipcommand="ip -6 -o address show $ifname"
+    ifsubnets=$( $ipcommand | awk '/inet6/{ print $4 }' )
+
+
+    if [ -n "$ifsubnets" ] ; then
+      for ifsubnet in $ifsubnets ; do
+        case $ifsubnet in
+        [1-9]*:*[0-9a-f])
+          # Special GLA protection for local block; ULA protected as a catagory
+          UNBOUND_LIST_PRV_SUBNET="$UNBOUND_LIST_PRV_SUBNET $ifsubnet" ;;
+        esac
+      done
+    fi
+  fi
 }
 
 ##############################################################################
@@ -569,8 +575,36 @@ unbound_control() {
 
 ##############################################################################
 
+unbound_forward() {
+  local fdomain fresolver resolvers
+  # Forward selected domains to the upstream (WAN) stub resolver. This may be
+  # faster or local pool addresses to ISP service login page. This may keep
+  # internal organization lookups, well, internal to the organization.
+
+
+  if [ -n "$UNBOUND_LIST_FORWARD" ] ; then
+    resolvers=$( grep nameserver /tmp/resolv.conf.auto | sed "s/nameserver//g" )
+
+
+    if [ -n "$resolvers" ] ; then
+      for fdomain in $UNBOUND_LIST_FORWARD ; do
+        {
+          echo "forward-zone:"
+          echo "  name: \"$fdomain.\""
+          for fresolver in $resolvers ; do
+          echo "  forward-addr: $fresolver"
+          done
+          echo
+        } >> $UNBOUND_CONFFILE
+      done
+    fi
+  fi
+}
+
+##############################################################################
+
 unbound_conf() {
-  local rt_mem rt_conn modulestring domain
+  local rt_mem rt_conn modulestring domain ifsubnet
 
   # Make fresh conf file
   echo > $UNBOUND_CONFFILE
@@ -832,7 +866,7 @@ unbound_conf() {
   fi
 
 
-  if [ "$UNBOUND_B_PRIV_BLCK" -gt 0 ] ; then
+  if [ "$UNBOUND_D_PRIV_BLCK" -gt 0 ] ; then
     {
       # Remove _upstream_ or global reponses with private addresses.
       # Unbounds own "local zone" and "forward zone" may still use these.
@@ -842,10 +876,21 @@ unbound_conf() {
       echo "  private-address: 169.254.0.0/16"
       echo "  private-address: 172.16.0.0/12"
       echo "  private-address: 192.168.0.0/16"
-      echo "  private-address: fc00::/8"
-      echo "  private-address: fd00::/8"
+      echo "  private-address: fc00::/7"
       echo "  private-address: fe80::/10"
+      echo
     } >> $UNBOUND_CONFFILE
+  fi
+
+
+  if  [ -n "$UNBOUND_LIST_PRV_SUBNET" -a "$UNBOUND_D_PRIV_BLCK" -gt 1 ] ; then
+    for ifsubnet in $UNBOUND_LIST_PRV_SUBNET ; do
+      # Remove global DNS responses with your local network IP6 GLA
+      echo "  private-address: $ifsubnet" >> $UNBOUND_CONFFILE
+    done
+
+
+    echo >> $UNBOUND_CONFFILE
   fi
 
 
@@ -857,9 +902,6 @@ unbound_conf() {
       echo "  private-address: ::1/128"
       echo
     } >> $UNBOUND_CONFFILE
-
-  else
-    echo >> $UNBOUND_CONFFILE
   fi
 
 
@@ -1026,7 +1068,6 @@ unbound_uci() {
   config_get_bool UNBOUND_B_MAN_CONF   "$cfg" manual_conf 0
   config_get_bool UNBOUND_B_QUERY_MIN  "$cfg" query_minimize 0
   config_get_bool UNBOUND_B_QRY_MINST  "$cfg" query_min_strict 0
-  config_get_bool UNBOUND_B_PRIV_BLCK  "$cfg" rebind_protection 1
   config_get_bool UNBOUND_B_LOCL_BLCK  "$cfg" rebind_localhost 0
   config_get_bool UNBOUND_B_DNSSEC     "$cfg" validator 0
   config_get_bool UNBOUND_B_NTP_BOOT   "$cfg" validator_ntp 1
@@ -1042,6 +1083,7 @@ unbound_uci() {
   config_get UNBOUND_D_DHCP_LINK   "$cfg" dhcp_link none
   config_get UNBOUND_D_EXTRA_DNS   "$cfg" add_extra_dns 0
   config_get UNBOUND_D_LAN_FQDN    "$cfg" add_local_fqdn 0
+  config_get UNBOUND_D_PRIV_BLCK   "$cfg" rebind_protection 1
   config_get UNBOUND_D_PROTOCOL    "$cfg" protocol mixed
   config_get UNBOUND_D_RECURSION   "$cfg" recursion passive
   config_get UNBOUND_D_RESOURCE    "$cfg" resource small
@@ -1050,7 +1092,9 @@ unbound_uci() {
   config_get UNBOUND_TTL_MIN     "$cfg" ttl_min 120
   config_get UNBOUND_TXT_DOMAIN  "$cfg" domain lan
 
-  config_list_foreach "$cfg" "domain_insecure" create_domain_insecure
+  config_list_foreach "$cfg" "domain_forward"   bundle_domain_forward
+  config_list_foreach "$cfg" "domain_insecure"  bundle_domain_insecure
+  config_list_foreach "$cfg" "rebind_interface" bundle_private_interface
 
   UNBOUND_LIST_DOMAINS="nowhere $UNBOUND_TXT_DOMAIN"
 
@@ -1137,11 +1181,12 @@ _resolv_setup() {
   # unbound is designated to listen on 127.0.0.1#53,
   #   set resolver file to local.
   rm -f /tmp/resolv.conf
+
   {
     echo "# /tmp/resolv.conf generated by Unbound UCI $( date )"
     echo "nameserver 127.0.0.1"
     echo "nameserver ::1"
-    echo "search $UNBOUND_TXT_DOMAIN"
+    echo "search $UNBOUND_TXT_DOMAIN."
   } > /tmp/resolv.conf
 }
 
@@ -1180,6 +1225,8 @@ unbound_start() {
       unbound_records
     fi
 
+
+    unbound_forward
     unbound_control
   fi
 

--- a/net/unbound/files/unbound.uci
+++ b/net/unbound/files/unbound.uci
@@ -27,7 +27,9 @@ config unbound
 	option unbound_control '0'
 	option validator '0'
 	option validator_ntp '1'
-	list trigger 'lan'
-	list trigger 'wan'
-	#list domain_insecure 'www.example.com'
+	list trigger_interface 'lan'
+	list trigger_interface 'wan'
+	#list rebind_interface 'lan'
+	#list domain_insecure 'ntp.example.com'
+	#list domain_forward 'mail.example.com'
 

--- a/net/unbound/patches/001-conf.patch
+++ b/net/unbound/patches/001-conf.patch
@@ -6,7 +6,7 @@ index 5396029..cbb51ec 100644
 -#
 -# Example configuration file.
 -#
--# See unbound.conf(5) man page, version 1.6.8.
+-# See unbound.conf(5) man page, version 1.7.0.
 -#
 -# this is a comment.
 +##############################################################################


### PR DESCRIPTION
Maintainer: me
Tested: OpenWrt master / TL-Archer-C7v2
Description:
- Add domain_forward to permit designated domains to forward instead
  of recurse as listed in resolve.conf.auto from DHCP WAN client
- Update rebind_protection and add rebind_interface to protect IP6
  GLA locally just like RFC 1918 protection
- Rename trigger to trigger_interface with backwards compatability
- Update odhcpd script for efficiency handling many clients
- LuCI at https://github.com/openwrt/luci/pull/1692