### PR TITLE
pulseaudio: fix non-NEON ARM compiles

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -99,6 +99,7 @@ define Package/pulseaudio-profiles
 endef
 
 CONFIGURE_ARGS += \
+	$(if $(findstring neon,$(CONFIG_TARGET_OPTIMIZATION)),--enable-neon-opt,--disable-neon-opt) \
 	--with-system-user=pulse \
 	--with-system-group=pulse \
 	--with-access-group=audio \


### PR DESCRIPTION
PulseAudio in some cases does not detect the ARM CPU's capabilities
correctly and enables NEON ASM while it is not supported. For example
when compiling for arm_arm1176jzf-s_vfp the assembler rejects this and
the compile fails:

```
{standard input}: Assembler messages:
{standard input}:27: Error: selected processor does not support `vld1.16 {d0},[r1]!' in ARM mode
{standard input}:28: Error: selected processor does not support `vmovl.s16 q0,d0' in ARM mode
{standard input}:29: Error: selected FPU does not support instruction -- `vcvt.f32.s32 q0,q0,#15'
{standard input}:31: Error: selected processor does not support `vst1.32 {q0},[r2]!' in ARM mode
{standard input}:70: Error: selected processor does not support `vld1.32 {q0},[r1]!' in ARM mode
{standard input}:71: Error: selected FPU does not support instruction -- `vcvt.s32.f32 q0,q0,#31'
{standard input}:72: Error: selected processor does not support `vqrshrn.s32 d0,q0,#16' in ARM mode
{standard input}:74: Error: selected processor does not support `vst1.16 {d0},[r2]!' in ARM mode
Makefile:8668: recipe for target 'pulsecore/libpulsecore_sconv_neon_la-sconv_neon.lo' failed
```

To fix this tell PulseAudio explicitly when to use the NEON ASM and when
not to.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @tripolar 
Compile tested: x86_64 + arm_arm1176jzf-s_vfp
Run tested: N/A

Description:
Hello Peter, all!

Currently pulseaudio fails to build on:

arm_arm1176jzf-s_vfp
arm_cortex-a8_vfpv3
arm_cortex-a9_vfpv3
arm_mpcore_vfp

That's all ARM VFP targets that do not support NEON. The commit fixes that.

Kind regards,
Sebastian