### PR TITLE
Changing Google DDNS to use HTTPS

### DIFF
--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -114,7 +114,7 @@
 
 "goip.de"		"http://www.goip.de/setip?username=[USERNAME]&password=[PASSWORD]&subdomain=[DOMAIN]&ip4=[IP]"
 
-"google.com"		"http://[USERNAME]:[PASSWORD]@domains.google.com/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
+"google.com"		"https://[USERNAME]:[PASSWORD]@domains.google.com/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
 "he.net"		"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 


### PR DESCRIPTION
Google Domains seems to be requiring HTTPS instead of HTTP requests at this time; the HTTP address is returning a 302 that curl seems to be failing to follow correctly.

I just tested this as a hotfix on my Turris Omnia to be clear... it doesn't seem like a config change like this requires a compile, and I wanted to share. If I need to set up a dev environment, etc, for this I can but it seemed silly to not point it out...


Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
