### PR TITLE
faad2: Update to 2.8.8 + patent fixes

### DIFF
--- a/libs/faad2/Makefile
+++ b/libs/faad2/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=faad2
-PKG_VERSION:=2.8.6
+PKG_VERSION:=2.8.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/faac/faad2-src/$(PKG_NAME)-2.8.0
-PKG_HASH:=654977adbf62eb81f4fca00152aca58ce3b6dd157181b9edd7bed687a7c73f21
+PKG_HASH:=985c3fadb9789d2815e50f4ff714511c79c2710ac27a4aaaf5c0c2662141426d
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
 PKG_FIXUP:=autoreconf
@@ -58,6 +58,11 @@ endef
 
 TARGET_CFLAGS += $(FPIC)
 CONFIGURE_ARGS+= --without-xmms
+
+ifeq ($(CONFIG_BUILD_PATENTED),n)
+	TARGET_CFLAGS+= -DLC_ONLY_DECODER -UDRM_PS
+	CONFIGURE_ARGS+= --without-drm
+endif
 
 ifeq ($(CONFIG_SOFT_FLOAT),y)
 	TARGET_CFLAGS+= -DFIXED_POINT


### PR DESCRIPTION
Added a check for BUILD_PATENTED so as to only enable AAC-LC decoding. AAC-HE and HEv2 are newer and still patent encumbered. They also happen to be somewhat rare (except for audiobooks).

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: mvebu
