### PR TITLE
node: address raspberry pi armv6

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
 PKG_VERSION:=v8.10.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=node-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://nodejs.org/dist/${PKG_VERSION}
 PKG_HASH:=b72d4e71618d6bcbd039b487b51fa7543631a4ac3331d7caf69bdf55b5b2901a
@@ -72,6 +72,10 @@ NODEJS_CPU:=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst
 
 MAKE_VARS+= \
 	DESTCPU=$(NODEJS_CPU)
+
+CONFIGURE_VARS:= \
+	CC="$(TARGET_CC) $(TARGET_OPTIMIZATION)" \
+	CC_host="$(HOSTCC)"
 
 CONFIGURE_ARGS:= \
 	--dest-cpu=$(NODEJS_CPU) \


### PR DESCRIPTION
node: address raspberry pi armv6

Maintainer: @blogic @ianchi
Compile tested: arm_arm1176jzf-s+vfp_gcc-7.3.0_musl_eabi, mips_24kc_gcc-6.3.0_musl(w fpu emu), Trunk r6520-02fba1a
Run tested: none

Description:
Explicitly set CPU ARCH to the compiler option so that "configure" script correctly identifies "arm_version".

http://downloads.lede-project.org/snapshots/faillogs/arm_arm1176jzf-s_vfp/packages/node/compile.txt

```
../deps/v8/src/arm/assembler-arm.cc:176:2: error: #error "CAN_USE_ARMV7_INSTRUCTIONS should match CAN_USE_VFP3_INSTRUCTIONS"
 #error "CAN_USE_ARMV7_INSTRUCTIONS should match CAN_USE_VFP3_INSTRUCTIONS"
  ^~~~~
```

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>