### PR TITLE
lighttpd: add mod-wstunnel

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -237,4 +237,4 @@ $(eval $(call BuildPlugin,trigger_b4_dl,Trigger before download,+PACKAGE_lighttp
 $(eval $(call BuildPlugin,userdir,User directory,,30))
 $(eval $(call BuildPlugin,usertrack,User tracking,,30))
 $(eval $(call BuildPlugin,webdav,WebDAV,+PACKAGE_lighttpd-mod-webdav:libsqlite3 +PACKAGE_lighttpd-mod-webdav:libuuid +PACKAGE_lighttpd-mod-webdav:libxml2,30))
-
+$(eval $(call BuildPlugin,wstunnel,Websocket tunneling,,30))


### PR DESCRIPTION
Maintainer: W. Michael Petullo <mike@flyn.org> @MikePetullo 
Compile tested: mips, x86 - 17.0.1 latest
Run tested: mips, x86 - 17.0.1 latest

Description: Exposes the mod-wstunnel plugin which implements websocket proxying over http