### PR TITLE
utils: openzwave: disable examples and fix include

### DIFF
--- a/utils/openzwave/patches/903-no-examples.patch
+++ b/utils/openzwave/patches/903-no-examples.patch
@@ -1,0 +1,18 @@
+--- a/Makefile
++++ b/Makefile
+@@ -18,15 +18,12 @@
+ 
+ all: 
+ 	CPPFLAGS=$(CPPFLAGS) $(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS) 
+-	CPPFLAGS=$(CPPFLAGS) $(MAKE) -C $(top_srcdir)/cpp/examples/MinOZW/ -$(MAKEFLAGS) 
+ 
+ install:
+ 	$(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS) $(MAKECMDGOALS)
+-	$(MAKE) -C $(top_srcdir)/cpp/examples/MinOZW/ -$(MAKEFLAGS) $(MAKECMDGOALS)
+ 
+ clean:
+ 	$(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS) $(MAKECMDGOALS)
+-	$(MAKE) -C $(top_srcdir)/cpp/examples/MinOZW/ -$(MAKEFLAGS) $(MAKECMDGOALS)
+ 
+ cpp/src/vers.cpp:
+ 	CPPFLAGS=$(CPPFLAGS) $(MAKE) -C $(top_srcdir)/cpp/build/ -$(MAKEFLAGS) cpp/src/vers.cpp

--- a/utils/openzwave/patches/904-fix-lib-include-path.patch
+++ b/utils/openzwave/patches/904-fix-lib-include-path.patch
@@ -1,0 +1,15 @@
+diff --git a/cpp/build/Makefile b/cpp/build/Makefile
+index 666472d..41dc58c 100644
+--- a/cpp/build/Makefile
++++ b/cpp/build/Makefile
+@@ -139,8 +139,8 @@ $(top_builddir)/libopenzwave.pc: $(top_srcdir)/cpp/build/libopenzwave.pc.in $(PK
+ 	@$(SED) \
+ 		-e 's|[@]prefix@|$(PREFIX)|g' \
+ 		-e 's|[@]exec_prefix@|$(PREFIX)/bin|g' \
+-		-e 's|[@]libdir@|$(instlibdir)|g' \
+-		-e 's|[@]includedir@|$(PREFIX)/include/openzwave/|g' \
++		-e 's|[@]libdir@|$${prefix}/lib|g' \
++		-e 's|[@]includedir@|$${prefix}/include/openzwave/|g' \
+                 -e 's|[@]sysconfdir@|/etc/openzwave/|g' \
+                 -e 's|[@]gitversion@|$(GITVERSION)|g' \
+                 -e 's|[@]docdir@|$(docdir)/|g' \


### PR DESCRIPTION
Maintainer: Stijn Tintel <stijn@linux-ipv6.be> @stintel 
Compile tested: brcm2708 & mvebu, OpenWrt master
Run tested: RPi3 & ClearFog Pro/Base, OpenWrt master

Description:

Patch 903 disables building of examples.
Patch 904 fixes the following issue:

When building software that build depends on openzwave, build will
always search in /usr/include/openzwave instead of
staging_dir/.../usr/include/openzwave causing build failure.

Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>