### PR TITLE
glib2: fix build when res_nquery is not available

### DIFF
--- a/libs/glib2/patches/002-fix-gthreadedresolver.patch
+++ b/libs/glib2/patches/002-fix-gthreadedresolver.patch
@@ -1,0 +1,20 @@
+--- a/gio/gthreadedresolver.c
++++ b/gio/gthreadedresolver.c
+@@ -869,6 +869,8 @@ do_lookup_records (GTask         *task,
+   records = g_resolver_records_from_res_query (lrd->rrname, rrtype, answer->data, len, herr, &error);
+   g_byte_array_free (answer, TRUE);
+ 
++#ifdef HAVE_RES_NQUERY
++
+ #if defined(HAVE_RES_NDESTROY)
+   res_ndestroy (&res);
+ #elif defined(HAVE_RES_NCLOSE)
+@@ -877,6 +879,8 @@ do_lookup_records (GTask         *task,
+ #error "Your platform has res_ninit() but not res_nclose() or res_ndestroy(). Please file a bug at https://bugzilla.gnome.org/enter_bug.cgi?product=glib"
+ #endif
+ 
++#endif
++
+ #else
+ 
+   DNS_STATUS status;


### PR DESCRIPTION
Upstream commit 

> gio: Port GThreadedResolver to use res_nquery() to fix
> thread-safety

 introduced a bug that causes compile failures on
platforms where res_nquery is unavailable. This patch fixes that.

[Bug 794606 has been opened upstream.](https://bugzilla.gnome.org/show_bug.cgi?id=794606)

On the OpenWrt buildbots this bug is visible during the arc_archs
compile:

```
  gthreadedresolver.c: In function 'do_lookup_records':
  gthreadedresolver.c:875:16: error: 'res' undeclared (first use in this function); did you mean '_res'?
     res_nclose (&res);
                  ^~~
                  _res
  gthreadedresolver.c:875:16: note: each undeclared identifier is reported only once for each function it appears in
  Makefile:3334: recipe for target 'libgio_2_0_la-gthreadedresolver.lo' failed
  make[8]: *** [libgio_2_0_la-gthreadedresolver.lo] Error 1
```

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @tripolar 
Compile tested: arc_archs
Run tested: N/A

Description:
Fix compile failure