### PR TITLE
mysql: remove $(FPIC), fix AARCH64 builds

### DIFF
--- a/utils/mysql/Makefile
+++ b/utils/mysql/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2015 OpenWrt.org
+# Copyright (C) 2006-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/uclibc++.mk
 
 PKG_NAME:=mysql
 PKG_VERSION:=5.1.73
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=\
@@ -60,8 +60,6 @@ endef
 ifneq ($(CONFIG_USE_UCLIBCXX),)
   TARGET_CXX=g++-uc
 endif
-
-TARGET_CFLAGS += $(FPIC)
 
 CONFIGURE_ARGS += \
 	--enable-shared \


### PR DESCRIPTION
mysql already makes sure that the compiler emits position-independent code when
appropriate, namely when compiling shared objects. The mysql build system puts
its own flag behind the CFLAGS, overriding whatever was set before.

Additionally, forcing applications into PIC mode will just slow them
down (mysql not only provides shared objects but also applications).

Last but not least OpenWrt's $(FPIC) can cause build failures. This is
the case currently for AARCH64:

```
  net_serv.o: In function `my_net_init':
  net_serv.cc:(.text+0x28): relocation truncated to fit: R_AARCH64_LD64_GOTPAGE_LO15 against symbol `my_malloc' defined in .text section in ../mysys/libmysys.a(my_malloc.o)
  net_serv.cc:(.text+0x28): warning: Too many GOT entries for -fpic, please recompile with -fPIC
  /data/bowl-builder/aarch64_cortex-a53/build/sdk/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.3.0_musl/bin/../lib/gcc/aarch64-openwrt-linux-musl/7.3.0/../../../../aarch64-openwrt-linux-musl/bin/ld: final link failed: Symbol needs debug section which does not exist
  collect2: error: ld returned 1 exit status
  Makefile:955: recipe for target 'mysqld' failed
  make[7]: *** [mysqld] Error 1
```

Remove $(FPIC) from TARGET_CFLAGS to address all of the above.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @jow- 
Compile tested: aarch64_cortex-a53_musl
Run tested: N/A

Description:
Hi @jow-,

This fixes a build failure that occurs on AARCH64. But this also has a more general merit, as IMHO adding $(FPIC) to TARGET_CFLAGS in usually is not a good idea. See [this link](https://wiki.gentoo.org/wiki/Project:Hardened/Position_Independent_Code_internals) for instance.

Kind regards,
Seb