### PR TITLE
wifidog-ng: Update to 1.3.0

### DIFF
--- a/net/wifidog-ng/Makefile
+++ b/net/wifidog-ng/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifidog-ng
-PKG_VERSION:=1.2.4
+PKG_VERSION:=1.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE_URL=https://github.com/zhaojh329/wifidog-ng.git
-PKG_MIRROR_HASH:=e437366d73f3becb61701560d88740fb097b8060b636febe3ad872831c83b598
+PKG_MIRROR_HASH:=a65ecad48dd3668a1f7416fd7882386a57b8bccf503e353224dbca54c398f052
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_SOURCE_SUBDIR)
 
@@ -31,7 +31,8 @@ define Package/wifidog-ng/default
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Next generation WifiDog
-  DEPENDS:=+kmod-wifidog-ng +libuci +libuclient +libblobmsg-json +libubus +libcares
+  DEPENDS:=+kmod-wifidog-ng +libuci +libuclient +libblobmsg-json +libubus +libcares \
+	  +ipset +libpcap
 endef
 
 define Package/wifidog-ng-nossl
@@ -84,7 +85,7 @@ include $(INCLUDE_DIR)/kernel.mk
 define KernelPackage/wifidog-ng
   SUBMENU:=Other modules
   TITLE:=Kernel module for wifidog-ng
-  DEPENDS:=+kmod-nf-nat
+  DEPENDS:=+kmod-nf-nat +kmod-ipt-ipset
   FILES:=$(PKG_BUILD_DIR)/kmod/wifidog-ng.ko
 endef
 

--- a/net/wifidog-ng/files/wifidog-ng.init
+++ b/net/wifidog-ng/files/wifidog-ng.init
@@ -26,6 +26,9 @@ parse_whitelist() {
 start_service() {
     modprobe wifidog-ng
 
+    ipset create wifidog-ng-mac hash:mac
+    ipset create wifidog-ng-ip hash:ip timeout 10000
+
     config_load wifidog-ng
     config_foreach parse_whitelist whitelist
 
@@ -37,4 +40,7 @@ start_service() {
 
 stop_service() {
     rmmod wifidog-ng
+
+    ipset destroy wifidog-ng-mac
+    ipset destroy wifidog-ng-ip
 }


### PR DESCRIPTION
be35e54 Optimized by use ipset
2dcc126 Optimize kernel module code
08231b4 Remove url param of login api
bf7b435 Support compile kernel module on ubuntu for test
ffca07a Optimize kernel module
b03c757 Optimize code

Signed-off-by: Jianhui Zhao <jianhuizhao329@gmail.com>

Maintainer: me
Compile tested: (mipsel,miwifi-mini, master)
Run tested: (mipsel,miwifi-mini, master)

Description:
