### PR TITLE
Add more functionality to ISC-DHCP configuration

### DIFF
--- a/net/isc-dhcp/files/dhcpd.init
+++ b/net/isc-dhcp/files/dhcpd.init
@@ -206,6 +206,8 @@ general_config() {
 	config_get max_lease_time "isc_dhcpd" "max_lease_time" 86400
 	config_get log_facility "isc_dhcpd" "log_facility"
 
+	config_get domain "isc_dhcpd" "domain"
+
 	[ $always_broadcast -eq 1 ] && echo "always-broadcast true;"
 	[ $authoritative -eq 1 ] && echo "authoritative;"
 	[ $boot_unknown_clients -eq 0 ] && echo "boot-unknown-clients false;"
@@ -220,6 +222,8 @@ general_config() {
 	fi
 	echo "default-lease-time $default_lease_time;"
 	echo "max-lease-time $max_lease_time;"
+
+	[ -n "$domain" ] && echo "option domain-name \"$domain\";"
 }
 
 start_service() {
@@ -231,7 +235,7 @@ start_service() {
 		touch $lease_file
 	fi
 
-	dhcp_ifs=""
+	local domain dhcp_ifs
 
 	if [ -e "/etc/dhcpd.conf" ] ; then
 		config_file="/etc/dhcpd.conf"

--- a/net/isc-dhcp/files/dhcpd.init
+++ b/net/isc-dhcp/files/dhcpd.init
@@ -120,7 +120,44 @@ static_hosts() {
 	config_foreach static_host_add host "$@"
 }
 
+typeof() {
+	echo "$1" | awk '
+/^\d+\.\d+\.\d+\.d+$/		{ print "ip\n"; next; }
+/^(true|false)$/		{ print "bool\n"; next; }
+/^\d+$/				{ print "integer\n"; next; }
+/^"[^"]*"$/			{ print "string\n"; next; }
+				{ print "other\n"; next; }
+'
+}
+
+append_dhcp_options() {
+	local tuple="$1"
+
+	# strip redundant "option:" prefix
+	tuple="${tuple#option:}"
+
+	local tag="${tuple%%,*}"
+	local values="${tuple#$tag,}"
+
+	local formatted value
+	local IFS=$', \n'
+	for value in $values; do
+		# detect type of $value and quote if necessary
+		case $(typeof "$value") in
+		ip|bool|integer|string)
+			;;
+		other)
+			value="\"$value\""
+			;;
+		esac
+		formatted="$formatted${formatted:+, }$value"
+	done
+	echo " option $tag $formatted;"
+}
+
 gen_dhcp_subnet() {
+	local cfg="$1"
+
 	echo "subnet $NETWORK netmask $NETMASK {"
 	echo " range $START $END;"
 	echo " option subnet-mask $netmask;"
@@ -140,6 +177,7 @@ gen_dhcp_subnet() {
 	fi
 	echo " option routers $gateway;"
 	echo " option domain-name-servers $DNS;"
+	config_list_foreach "$cfg" "dhcp_option" append_dhcp_options
 	echo "}"
 }
 
@@ -193,7 +231,7 @@ dhcpd_add() {
 		gateway="$IP"
 	fi
 
-	gen_dhcp_subnet >> $config_file
+	gen_dhcp_subnet "$cfg" >> $config_file
 }
 
 general_config() {


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, generic, HEAD (759ee14)
Run tested: built and installed .ipk on production router

Description:

CentOS/Fedora/RHEL all need the domain as one of the DHCP options they are given or bad things happen when using DHCP and NetworkManager.

Adding `ntp-servers` and `domain-search` as low-hanging fruit as well.