### PR TITLE
net-snmp: Enable MIB ip-mib/inetNetToMediaTable

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -128,6 +128,7 @@ SNMP_MIB_MODULES_INCLUDED = \
 	host/hr_system \
 	ieee802dot11 \
 	if-mib/ifXTable \
+	ip-mib/inetNetToMediaTable \
 	mibII/at \
 	mibII/icmp \
 	mibII/ifTable \
@@ -164,6 +165,7 @@ SNMP_MIB_MODULES_EXCLUDED = \
 	hardware \
 	host \
 	if-mib \
+	ip-mib \
 	mibII \
 	notification \
 	notification-log-mib \


### PR DESCRIPTION
This enables the table `inetNetToMediaTable` from `ip-mib`, which implements
the `ipNetToPhysicalTable`. The former one is already enabled with the current
configuraiton, but it has been deprecatd by the IP version-neutral
`ipNetToMediaTable`, which also supports IPv6 entries [1]. It also disables all
other submodules from this MIB to keep the footprint small.

[1]: http://net-snmp.sourceforge.net/docs/mibs/IP-MIB.txt

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
