### PR TITLE
i2c-tools: Update to 4.0 and update URLs/

### DIFF
--- a/utils/i2c-tools/Makefile
+++ b/utils/i2c-tools/Makefile
@@ -8,17 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=i2c-tools
-PKG_VERSION:=3.1.2
+PKG_VERSION:=4.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=http://dl.lm-sensors.org/i2c-tools/releases/ \
-                http://fossies.org/linux/misc/
+PKG_SOURCE_URL:=@KERNEL/software/utils/i2c-tools
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=db5e69f2e2a6e3aa2ecdfe6a5f490b149c504468770f58921c8c5b8a7860a441
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_HASH:=d900ca1c11c51ea20caa50b096f948008b8a7ad832311b23353e21baa7af28d6
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=PACKAGE_python-smbus:python
+PKG_ASLR_PIE:=1
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPLv2
@@ -29,7 +29,7 @@ include ../../lang/python/python-package.mk
 include ../../lang/python/python3-package.mk
 
 define Package/i2c/Default
-  URL:=http://lm-sensors.org/wiki/I2CTools
+  URL:=https://i2c.wiki.kernel.org/index.php/I2C_Tools
   TITLE:=I2C
 endef
 
@@ -96,8 +96,10 @@ define Build/Compile
 		LINUX="$(LINUX_DIR)" \
 		CC="$(TARGET_CC)" \
 		STAGING_DIR="$(STAGING_DIR)" \
-		LDFLAGS="$(TARGET_LDFLAGS)" \
-		CFLAGS="$(TARGET_CFLAGS)"
+		LDFLAGS="$(TARGET_LDFLAGS)" fPIC \
+		CFLAGS="$(TARGET_CFLAGS)" -fPIC \
+		BUILD_DYNAMIC_LIB=0 \
+		USE_STATIC_LIB=1
 	$(Build/Compile/python-smbus)
 	$(Build/Compile/python3-smbus)
 endef

--- a/utils/i2c-tools/patches/0001-i2c-tools-i2cbusses-Avoid-buffer-overflows-in-sysfs-.patch
+++ b/utils/i2c-tools/patches/0001-i2c-tools-i2cbusses-Avoid-buffer-overflows-in-sysfs-.patch
@@ -1,0 +1,66 @@
+From 02b19e7ad11785e04116e258c82f593809e44c8e Mon Sep 17 00:00:00 2001
+From: Jean Delvare <jdelvare@suse.de>
+Date: Thu, 2 Nov 2017 16:17:50 +0100
+Subject: [PATCH 01/10] i2c-tools: i2cbusses: Avoid buffer overflows in sysfs
+ paths
+
+sprintf isn't safe, use snprintf instead.
+---
+ CHANGES           |  3 +++
+ tools/i2cbusses.c | 10 +++++-----
+ 2 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/CHANGES b/CHANGES
+index 15ff761..539adb0 100644
+--- a/CHANGES
++++ b/CHANGES
+@@ -1,6 +1,9 @@
+ i2c-tools CHANGES
+ -----------------
+ 
++master
++  tools: Fix potential buffer overflows in i2cbusses
++
+ 4.0 (2017-10-30)
+   tools: Fix build with recent compilers (gcc 4.6+)
+          Add examples to the manual pages
+diff --git a/tools/i2cbusses.c b/tools/i2cbusses.c
+index dad22ea..cb78cc7 100644
+--- a/tools/i2cbusses.c
++++ b/tools/i2cbusses.c
+@@ -220,18 +220,18 @@ struct i2c_adap *gather_i2c_busses(void)
+ 
+ 		/* this should work for kernels 2.6.5 or higher and */
+ 		/* is preferred because is unambiguous */
+-		sprintf(n, "%s/%s/name", sysfs, de->d_name);
++		snprintf(n, NAME_MAX, "%s/%s/name", sysfs, de->d_name);
+ 		f = fopen(n, "r");
+ 		/* this seems to work for ISA */
+ 		if(f == NULL) {
+-			sprintf(n, "%s/%s/device/name", sysfs, de->d_name);
++			snprintf(n, NAME_MAX, "%s/%s/device/name", sysfs, de->d_name);
+ 			f = fopen(n, "r");
+ 		}
+ 		/* non-ISA is much harder */
+ 		/* and this won't find the correct bus name if a driver
+ 		   has more than one bus */
+ 		if(f == NULL) {
+-			sprintf(n, "%s/%s/device", sysfs, de->d_name);
++			snprintf(n, NAME_MAX, "%s/%s/device", sysfs, de->d_name);
+ 			if(!(ddir = opendir(n)))
+ 				continue;
+ 			while ((dde = readdir(ddir)) != NULL) {
+@@ -240,8 +240,8 @@ struct i2c_adap *gather_i2c_busses(void)
+ 				if (!strcmp(dde->d_name, ".."))
+ 					continue;
+ 				if ((!strncmp(dde->d_name, "i2c-", 4))) {
+-					sprintf(n, "%s/%s/device/%s/name",
+-						sysfs, de->d_name, dde->d_name);
++					snprintf(n, NAME_MAX, "%s/%s/device/%s/name",
++						 sysfs, de->d_name, dde->d_name);
+ 					if((f = fopen(n, "r")))
+ 						goto found;
+ 				}
+-- 
+2.17.0
+

--- a/utils/i2c-tools/patches/0002-tools-i2cbusses-Check-the-return-value-of-snprintf.patch
+++ b/utils/i2c-tools/patches/0002-tools-i2cbusses-Check-the-return-value-of-snprintf.patch
@@ -1,0 +1,87 @@
+From 72e1bf8f2ff898898f6ba10e9aaaac9666381245 Mon Sep 17 00:00:00 2001
+From: Jean Delvare <jdelvare@suse.de>
+Date: Wed, 8 Nov 2017 22:17:43 +0100
+Subject: [PATCH 02/10] tools: i2cbusses: Check the return value of snprintf
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It's very unlikely that these paths will ever be truncated, but
+better safe than sorry.
+
+Suggested by Uwe Kleine-König.
+---
+ tools/i2cbusses.c | 34 ++++++++++++++++++++++++++++------
+ 1 file changed, 28 insertions(+), 6 deletions(-)
+
+diff --git a/tools/i2cbusses.c b/tools/i2cbusses.c
+index cb78cc7..41f5b6b 100644
+--- a/tools/i2cbusses.c
++++ b/tools/i2cbusses.c
+@@ -137,7 +137,7 @@ struct i2c_adap *gather_i2c_busses(void)
+ 	FILE *f;
+ 	char fstype[NAME_MAX], sysfs[NAME_MAX], n[NAME_MAX];
+ 	int foundsysfs = 0;
+-	int count=0;
++	int len, count = 0;
+ 	struct i2c_adap *adapters;
+ 
+ 	adapters = calloc(BUNCH, sizeof(struct i2c_adap));
+@@ -220,18 +220,32 @@ struct i2c_adap *gather_i2c_busses(void)
+ 
+ 		/* this should work for kernels 2.6.5 or higher and */
+ 		/* is preferred because is unambiguous */
+-		snprintf(n, NAME_MAX, "%s/%s/name", sysfs, de->d_name);
++		len = snprintf(n, NAME_MAX, "%s/%s/name", sysfs, de->d_name);
++		if (len >= NAME_MAX) {
++			fprintf(stderr, "%s: path truncated\n", n);
++			continue;
++		}
+ 		f = fopen(n, "r");
+ 		/* this seems to work for ISA */
+ 		if(f == NULL) {
+-			snprintf(n, NAME_MAX, "%s/%s/device/name", sysfs, de->d_name);
++			len = snprintf(n, NAME_MAX, "%s/%s/device/name", sysfs,
++				       de->d_name);
++			if (len >= NAME_MAX) {
++				fprintf(stderr, "%s: path truncated\n", n);
++				continue;
++			}
+ 			f = fopen(n, "r");
+ 		}
+ 		/* non-ISA is much harder */
+ 		/* and this won't find the correct bus name if a driver
+ 		   has more than one bus */
+ 		if(f == NULL) {
+-			snprintf(n, NAME_MAX, "%s/%s/device", sysfs, de->d_name);
++			len = snprintf(n, NAME_MAX, "%s/%s/device", sysfs,
++				       de->d_name);
++			if (len >= NAME_MAX) {
++				fprintf(stderr, "%s: path truncated\n", n);
++				continue;
++			}
+ 			if(!(ddir = opendir(n)))
+ 				continue;
+ 			while ((dde = readdir(ddir)) != NULL) {
+@@ -240,8 +254,16 @@ struct i2c_adap *gather_i2c_busses(void)
+ 				if (!strcmp(dde->d_name, ".."))
+ 					continue;
+ 				if ((!strncmp(dde->d_name, "i2c-", 4))) {
+-					snprintf(n, NAME_MAX, "%s/%s/device/%s/name",
+-						 sysfs, de->d_name, dde->d_name);
++					len = snprintf(n, NAME_MAX,
++						       "%s/%s/device/%s/name",
++						       sysfs, de->d_name,
++						       dde->d_name);
++					if (len >= NAME_MAX) {
++						fprintf(stderr,
++							"%s: path truncated\n",
++							n);
++						continue;
++					}
+ 					if((f = fopen(n, "r")))
+ 						goto found;
+ 				}
+-- 
+2.17.0
+

--- a/utils/i2c-tools/patches/0003-lib-Module.mk-Add-missing-dependencies.patch
+++ b/utils/i2c-tools/patches/0003-lib-Module.mk-Add-missing-dependencies.patch
@@ -1,0 +1,32 @@
+From adbbcf5a7a6ad7c5f30b91c9f155d488307689c2 Mon Sep 17 00:00:00 2001
+From: Jean Delvare <jdelvare@suse.de>
+Date: Wed, 6 Dec 2017 09:55:04 +0100
+Subject: [PATCH 03/10] lib/Module.mk: Add missing dependencies
+
+The lib symlinks lacked a dependency to the actual library file, so
+parallel builds could run into a race and break.
+---
+ lib/Module.mk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/Module.mk b/lib/Module.mk
+index 432a051..fd2c8c4 100644
+--- a/lib/Module.mk
++++ b/lib/Module.mk
+@@ -42,11 +42,11 @@ endif
+ $(LIB_DIR)/$(LIB_SHLIBNAME): $(LIB_DIR)/smbus.o
+ 	$(CC) -shared $(LDFLAGS) -Wl,--version-script=$(LIB_DIR)/libi2c.map -Wl,-soname,$(LIB_SHSONAME) -o $@ $^ -lc
+ 
+-$(LIB_DIR)/$(LIB_SHSONAME):
++$(LIB_DIR)/$(LIB_SHSONAME): $(LIB_DIR)/$(LIB_SHLIBNAME)
+ 	$(RM) $@
+ 	$(LN) $(LIB_SHLIBNAME) $@
+ 
+-$(LIB_DIR)/$(LIB_SHBASENAME):
++$(LIB_DIR)/$(LIB_SHBASENAME): $(LIB_DIR)/$(LIB_SHLIBNAME)
+ 	$(RM) $@
+ 	$(LN) $(LIB_SHLIBNAME) $@
+ 
+-- 
+2.17.0
+

--- a/utils/i2c-tools/patches/0004-Makefile-Add-flag-to-disable-dynamic-library.patch
+++ b/utils/i2c-tools/patches/0004-Makefile-Add-flag-to-disable-dynamic-library.patch
@@ -1,0 +1,64 @@
+From 8b8ca5cd88647d2ad0eb1b43ae91f834f6395c6b Mon Sep 17 00:00:00 2001
+From: Angelo Compagnucci <angelo@amarulasolutions.com>
+Date: Wed, 6 Dec 2017 10:12:07 +0100
+Subject: [PATCH 04/10] Makefile: Add flag to disable dynamic library
+
+In such cases where you need to disable entirely the dynamic
+library compilation, now you can use the BUILD_DYNAMIC_LIB=0
+flag.
+
+Signed-off-by: Angelo Compagnucci <angelo@amarulasolutions.com>
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+---
+ Makefile      | 10 +++++++++-
+ lib/Module.mk |  6 +++++-
+ 2 files changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index c85317c..1bb5572 100644
+--- a/Makefile
++++ b/Makefile
+@@ -32,12 +32,20 @@ CFLAGS		?= -O2
+ CFLAGS		+= -Wall
+ SOCFLAGS	:= -fpic -D_REENTRANT $(CFLAGS)
+ 
+-USE_STATIC_LIB ?= 0
++BUILD_DYNAMIC_LIB ?= 1
+ BUILD_STATIC_LIB ?= 1
++USE_STATIC_LIB ?= 0
++
+ ifeq ($(USE_STATIC_LIB),1)
+ BUILD_STATIC_LIB := 1
+ endif
+ 
++ifeq ($(BUILD_DYNAMIC_LIB),0)
++ifeq ($(BUILD_STATIC_LIB),0)
++$(error BUILD_DYNAMIC_LIB and BUILD_STATIC_LIB cannot be disabled at the same time)
++endif
++endif
++
+ KERNELVERSION	:= $(shell uname -r)
+ 
+ .PHONY: all strip clean install uninstall
+diff --git a/lib/Module.mk b/lib/Module.mk
+index fd2c8c4..44fa938 100644
+--- a/lib/Module.mk
++++ b/lib/Module.mk
+@@ -27,9 +27,13 @@ LIB_SHSONAME	:= $(LIB_SHBASENAME).$(LIB_MAINVER)
+ LIB_SHLIBNAME	:= $(LIB_SHBASENAME).$(LIB_VER)
+ LIB_STLIBNAME	:= libi2c.a
+ 
+-LIB_TARGETS	:= $(LIB_SHLIBNAME)
+ LIB_LINKS	:= $(LIB_SHSONAME) $(LIB_SHBASENAME)
+ LIB_OBJECTS	:= smbus.o
++
++LIB_TARGETS	:=
++ifeq ($(BUILD_DYNAMIC_LIB),1)
++LIB_TARGETS	+= $(LIB_SHLIBNAME)
++endif
+ ifeq ($(BUILD_STATIC_LIB),1)
+ LIB_TARGETS	+= $(LIB_STLIBNAME)
+ LIB_OBJECTS	+= smbus.ao
+-- 
+2.17.0
+

--- a/utils/i2c-tools/patches/0005-lib-Module.mk-Drop-unused-variable-LIB_OBJECTS.patch
+++ b/utils/i2c-tools/patches/0005-lib-Module.mk-Drop-unused-variable-LIB_OBJECTS.patch
@@ -1,0 +1,32 @@
+From 02b9a1b58745497799aac2fc9ec54af6c4fc810e Mon Sep 17 00:00:00 2001
+From: Jean Delvare <jdelvare@suse.de>
+Date: Wed, 6 Dec 2017 10:46:56 +0100
+Subject: [PATCH 05/10] lib/Module.mk: Drop unused variable LIB_OBJECTS
+
+---
+ lib/Module.mk | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/lib/Module.mk b/lib/Module.mk
+index 44fa938..8a58f5b 100644
+--- a/lib/Module.mk
++++ b/lib/Module.mk
+@@ -28,7 +28,6 @@ LIB_SHLIBNAME	:= $(LIB_SHBASENAME).$(LIB_VER)
+ LIB_STLIBNAME	:= libi2c.a
+ 
+ LIB_LINKS	:= $(LIB_SHSONAME) $(LIB_SHBASENAME)
+-LIB_OBJECTS	:= smbus.o
+ 
+ LIB_TARGETS	:=
+ ifeq ($(BUILD_DYNAMIC_LIB),1)
+@@ -36,7 +35,6 @@ LIB_TARGETS	+= $(LIB_SHLIBNAME)
+ endif
+ ifeq ($(BUILD_STATIC_LIB),1)
+ LIB_TARGETS	+= $(LIB_STLIBNAME)
+-LIB_OBJECTS	+= smbus.ao
+ endif
+ 
+ #
+-- 
+2.17.0
+

--- a/utils/i2c-tools/patches/0006-tools-Module.mk-Add-missing-dependencies.patch
+++ b/utils/i2c-tools/patches/0006-tools-Module.mk-Add-missing-dependencies.patch
@@ -1,0 +1,66 @@
+From e3c4f7d1d95a729df74a37188ba27862f1cdf7d6 Mon Sep 17 00:00:00 2001
+From: Jean Delvare <jdelvare@suse.de>
+Date: Thu, 14 Dec 2017 08:52:26 +0100
+Subject: [PATCH 06/10] tools/Module.mk: Add missing dependencies
+
+Better build the library before building the tools which link against
+it, otherwise parallel builds could run into a race and break.
+
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+Tested-by: Angelo Compagnucci <angelo@amarulasolutions.com>
+Acked-by: Angelo Compagnucci <angelo@amarulasolutions.com>
+---
+ lib/Module.mk   |  7 +++++++
+ tools/Module.mk | 10 +++++-----
+ 2 files changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/lib/Module.mk b/lib/Module.mk
+index 8a58f5b..67afe91 100644
+--- a/lib/Module.mk
++++ b/lib/Module.mk
+@@ -37,6 +37,13 @@ ifeq ($(BUILD_STATIC_LIB),1)
+ LIB_TARGETS	+= $(LIB_STLIBNAME)
+ endif
+ 
++# Library file to link against (static or dynamic)
++ifeq ($(USE_STATIC_LIB),1)
++LIB_DEPS	:= $(LIB_DIR)/$(LIB_STLIBNAME)
++else
++LIB_DEPS	:= $(LIB_DIR)/$(LIB_SHBASENAME)
++endif
++
+ #
+ # Libraries
+ #
+diff --git a/tools/Module.mk b/tools/Module.mk
+index 6421a23..609de7a 100644
+--- a/tools/Module.mk
++++ b/tools/Module.mk
+@@ -24,19 +24,19 @@ TOOLS_TARGETS	:= i2cdetect i2cdump i2cset i2cget i2ctransfer
+ # Programs
+ #
+ 
+-$(TOOLS_DIR)/i2cdetect: $(TOOLS_DIR)/i2cdetect.o $(TOOLS_DIR)/i2cbusses.o
++$(TOOLS_DIR)/i2cdetect: $(TOOLS_DIR)/i2cdetect.o $(TOOLS_DIR)/i2cbusses.o $(LIB_DEPS)
+ 	$(CC) $(LDFLAGS) -o $@ $^ $(TOOLS_LDFLAGS)
+ 
+-$(TOOLS_DIR)/i2cdump: $(TOOLS_DIR)/i2cdump.o $(TOOLS_DIR)/i2cbusses.o $(TOOLS_DIR)/util.o
++$(TOOLS_DIR)/i2cdump: $(TOOLS_DIR)/i2cdump.o $(TOOLS_DIR)/i2cbusses.o $(TOOLS_DIR)/util.o $(LIB_DEPS)
+ 	$(CC) $(LDFLAGS) -o $@ $^ $(TOOLS_LDFLAGS)
+ 
+-$(TOOLS_DIR)/i2cset: $(TOOLS_DIR)/i2cset.o $(TOOLS_DIR)/i2cbusses.o $(TOOLS_DIR)/util.o
++$(TOOLS_DIR)/i2cset: $(TOOLS_DIR)/i2cset.o $(TOOLS_DIR)/i2cbusses.o $(TOOLS_DIR)/util.o $(LIB_DEPS)
+ 	$(CC) $(LDFLAGS) -o $@ $^ $(TOOLS_LDFLAGS)
+ 
+-$(TOOLS_DIR)/i2cget: $(TOOLS_DIR)/i2cget.o $(TOOLS_DIR)/i2cbusses.o $(TOOLS_DIR)/util.o
++$(TOOLS_DIR)/i2cget: $(TOOLS_DIR)/i2cget.o $(TOOLS_DIR)/i2cbusses.o $(TOOLS_DIR)/util.o $(LIB_DEPS)
+ 	$(CC) $(LDFLAGS) -o $@ $^ $(TOOLS_LDFLAGS)
+ 
+-$(TOOLS_DIR)/i2ctransfer: $(TOOLS_DIR)/i2ctransfer.o $(TOOLS_DIR)/i2cbusses.o $(TOOLS_DIR)/util.o
++$(TOOLS_DIR)/i2ctransfer: $(TOOLS_DIR)/i2ctransfer.o $(TOOLS_DIR)/i2cbusses.o $(TOOLS_DIR)/util.o $(LIB_DEPS)
+ 	$(CC) $(LDFLAGS) -o $@ $^ $(TOOLS_LDFLAGS)
+ 
+ #
+-- 
+2.17.0
+

--- a/utils/i2c-tools/patches/0007-lib-Module.mk-Fix-LIB_LINKS-dependency.patch
+++ b/utils/i2c-tools/patches/0007-lib-Module.mk-Fix-LIB_LINKS-dependency.patch
@@ -1,0 +1,34 @@
+From 1ad0c67788653b9394aa4a3dc3f04b6c1450b255 Mon Sep 17 00:00:00 2001
+From: Angelo Compagnucci <angelo@amarulasolutions.com>
+Date: Thu, 14 Dec 2017 13:34:29 +0100
+Subject: [PATCH 07/10] lib/Module.mk: Fix LIB_LINKS dependency
+
+LIB_LINKS should be added as a dependency only when
+BUILD_DYNAMIC_LIB is enabled.
+
+Signed-off-by: Angelo Compagnucci <angelo@amarulasolutions.com>
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+Fixes: 9906b2ecb6ae ("Makefile: Add flag to disable dynamic library"
+---
+ lib/Module.mk | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/lib/Module.mk b/lib/Module.mk
+index 67afe91..2ebc70d 100644
+--- a/lib/Module.mk
++++ b/lib/Module.mk
+@@ -27,10 +27,9 @@ LIB_SHSONAME	:= $(LIB_SHBASENAME).$(LIB_MAINVER)
+ LIB_SHLIBNAME	:= $(LIB_SHBASENAME).$(LIB_VER)
+ LIB_STLIBNAME	:= libi2c.a
+ 
+-LIB_LINKS	:= $(LIB_SHSONAME) $(LIB_SHBASENAME)
+-
+ LIB_TARGETS	:=
+ ifeq ($(BUILD_DYNAMIC_LIB),1)
++LIB_LINKS	:= $(LIB_SHSONAME) $(LIB_SHBASENAME)
+ LIB_TARGETS	+= $(LIB_SHLIBNAME)
+ endif
+ ifeq ($(BUILD_STATIC_LIB),1)
+-- 
+2.17.0
+

--- a/utils/i2c-tools/patches/0008-Makefile-Allow-to-really-disable-the-dynamic-library.patch
+++ b/utils/i2c-tools/patches/0008-Makefile-Allow-to-really-disable-the-dynamic-library.patch
@@ -1,0 +1,32 @@
+From 78dd17b78e3f56cde4be8e9c0049aabb6fcbcd22 Mon Sep 17 00:00:00 2001
+From: Jean Delvare <jdelvare@suse.de>
+Date: Thu, 14 Dec 2017 13:34:34 +0100
+Subject: [PATCH 08/10] Makefile: Allow to really disable the dynamic library
+
+If the user disables the build of the dynamic library, we have to
+link the tools with the static library. If we don't, the dependencies
+will cause the dynamic library to be built regardless of the user's
+request.
+
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+Fixes: 9906b2ecb6ae ("Makefile: Add flag to disable dynamic library")
+---
+ Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 1bb5572..6bb741f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -43,6 +43,8 @@ endif
+ ifeq ($(BUILD_DYNAMIC_LIB),0)
+ ifeq ($(BUILD_STATIC_LIB),0)
+ $(error BUILD_DYNAMIC_LIB and BUILD_STATIC_LIB cannot be disabled at the same time)
++else
++USE_STATIC_LIB := 1
+ endif
+ endif
+ 
+-- 
+2.17.0
+

--- a/utils/i2c-tools/patches/0009-eeprog-Module.mk-Add-missing-dependency.patch
+++ b/utils/i2c-tools/patches/0009-eeprog-Module.mk-Add-missing-dependency.patch
@@ -1,0 +1,30 @@
+From f16af9d95494a29e400b70d48f8a98c51b4f9b76 Mon Sep 17 00:00:00 2001
+From: "Maxin B. John" <maxin.john@gmail.com>
+Date: Tue, 19 Dec 2017 13:46:15 +0100
+Subject: [PATCH 09/10] eeprog/Module.mk: Add missing dependency
+
+Absence of this dependency caused parallel build to run into a race
+and break.
+
+Signed-off-by: Maxin B. John <maxin.john@intel.com>
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+---
+ eeprog/Module.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/eeprog/Module.mk b/eeprog/Module.mk
+index 9d36869..d215855 100644
+--- a/eeprog/Module.mk
++++ b/eeprog/Module.mk
+@@ -20,7 +20,7 @@ EEPROG_TARGETS	:= eeprog
+ # Programs
+ #
+ 
+-$(EEPROG_DIR)/eeprog: $(EEPROG_DIR)/eeprog.o $(EEPROG_DIR)/24cXX.o
++$(EEPROG_DIR)/eeprog: $(EEPROG_DIR)/eeprog.o $(EEPROG_DIR)/24cXX.o $(LIB_DEPS)
+ 	$(CC) $(LDFLAGS) -o $@ $^ $(EEPROG_LDFLAGS)
+ 
+ #
+-- 
+2.17.0
+

--- a/utils/i2c-tools/patches/0010-lib-Module.mk-Don-t-install-dynamic-library-when-dis.patch
+++ b/utils/i2c-tools/patches/0010-lib-Module.mk-Don-t-install-dynamic-library-when-dis.patch
@@ -1,0 +1,40 @@
+From af47768970353f01b3cbeb09a560ca25363fbb91 Mon Sep 17 00:00:00 2001
+From: Baruch Siach <baruch@tkos.co.il>
+Date: Tue, 9 Jan 2018 10:09:07 +0100
+Subject: [PATCH 10/10] lib/Module.mk: Don't install dynamic library when
+ disabled
+
+Do not attempt to install the dynamic library when build of that library
+is disabled. Fixes the following installation error:
+
+install -m 755 lib/libi2c.so.0.1.0 .../target/usr/lib
+install: cannot stat 'lib/libi2c.so.0.1.0': No such file or directory
+lib/Module.mk:90: recipe for target 'install-lib' failed
+
+Cc: Angelo Compagnucci <angelo@amarulasolutions.com>
+Signed-off-by: Baruch Siach <baruch@tkos.co.il>
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+Fixes: 9906b2ecb6ae ("Makefile: Add flag to disable dynamic library")
+---
+ lib/Module.mk | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/Module.mk b/lib/Module.mk
+index 2ebc70d..c492961 100644
+--- a/lib/Module.mk
++++ b/lib/Module.mk
+@@ -88,9 +88,11 @@ clean-lib:
+ 
+ install-lib: $(addprefix $(LIB_DIR)/,$(LIB_TARGETS))
+ 	$(INSTALL_DIR) $(DESTDIR)$(libdir)
++ifeq ($(BUILD_DYNAMIC_LIB),1)
+ 	$(INSTALL_PROGRAM) $(LIB_DIR)/$(LIB_SHLIBNAME) $(DESTDIR)$(libdir)
+ 	$(LN) $(LIB_SHLIBNAME) $(DESTDIR)$(libdir)/$(LIB_SHSONAME)
+ 	$(LN) $(LIB_SHSONAME) $(DESTDIR)$(libdir)/$(LIB_SHBASENAME)
++endif
+ ifeq ($(BUILD_STATIC_LIB),1)
+ 	$(INSTALL_DATA) $(LIB_DIR)/$(LIB_STLIBNAME) $(DESTDIR)$(libdir)
+ endif
+-- 
+2.17.0
+


### PR DESCRIPTION
Upstream has changed to kernel.org. lm-sensors.org is now defunct.

i2c-tools also builds a libi2c now. Statically link it since nothing uses it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: mvebu
