### PR TITLE
xinetd: Update URLs.

### DIFF
--- a/net/xinetd/Makefile
+++ b/net/xinetd/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=2.3.15
 PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.xinetd.org
+PKG_SOURCE_URL:=https://github.com/xinetd-org/xinetd/archive
 PKG_HASH:=bf4e060411c75605e4dcbdf2ac57c6bd9e1904470a2f91e01ba31b50a80a5be3
 PKG_LICENSE:=xinetd
 PKG_LICENSE_FILES:=COPYRIGHT
@@ -25,7 +25,7 @@ define Package/xinetd
   SECTION:=net
   CATEGORY:=Network
   TITLE:=A powerful and secure super-server
-  URL:=http://www.xinetd.org/
+  URL:=https://github.com/xinetd-org
   PKG_MAINTAINER:=Jonathan McCrohan <jmccrohan@gmail.com>
 endef
 


### PR DESCRIPTION
xinetd.org has been defunct for a long time and it seems the main developer moved everything to GitHub.

Discovered with uscan.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jmccrohan 