### PR TITLE
MWAN3: Missing globals section in UCI config

### DIFF
--- a/net/mwan3/files/etc/config/mwan3
+++ b/net/mwan3/files/etc/config/mwan3
@@ -1,7 +1,7 @@
 
 config globals 'globals'
 	option enabled '1'
-		
+
 config interface 'wan'
 	option enabled '1'
 	list track_ip '8.8.4.4'

--- a/net/mwan3/files/etc/config/mwan3
+++ b/net/mwan3/files/etc/config/mwan3
@@ -1,7 +1,7 @@
 
 config globals 'globals'
 	option enabled '1'
-
+ 
 config interface 'wan'
 	option enabled '1'
 	list track_ip '8.8.4.4'

--- a/net/mwan3/files/etc/config/mwan3
+++ b/net/mwan3/files/etc/config/mwan3
@@ -1,7 +1,7 @@
 
 config globals 'globals'
 	option enabled '1'
-	
+		
 config interface 'wan'
 	option enabled '1'
 	list track_ip '8.8.4.4'

--- a/net/mwan3/files/etc/config/mwan3
+++ b/net/mwan3/files/etc/config/mwan3
@@ -1,4 +1,7 @@
 
+config globals 'globals'
+	option enabled '1'
+	
 config interface 'wan'
 	option enabled '1'
 	list track_ip '8.8.4.4'

--- a/net/mwan3/files/etc/config/mwan3
+++ b/net/mwan3/files/etc/config/mwan3
@@ -1,7 +1,7 @@
 
 config globals 'globals'
 	option enabled '1'
- 
+
 config interface 'wan'
 	option enabled '1'
 	list track_ip '8.8.4.4'


### PR DESCRIPTION
MWAN3: Missing globals section in UCI config
This causes mwan3 to fail with error: 
"Warning: mwan3 is global disabled. Usage: /etc/init.d/mwan3 start"
author-name: Rob White
Signed-off-by: Rob White <rob@blue-wave.net>

Maintainer: Florian Eckert <fe@dev.tdt.de>
Compile not required
Run tested: Run and tested on LEDE 170104

Description:
Globals section in UCI config file MUST also be named "globals" for startup scripts to work.
