### PR TITLE
znc: Update to 1.6.6 + HTTPS.

### DIFF
--- a/net/znc/Makefile
+++ b/net/znc/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=znc
-PKG_VERSION:=1.6.5
+PKG_VERSION:=1.6.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://znc.in/releases \
-		http://znc.in/releases/archive
-PKG_HASH:=2f0225d49c53a01f8d94feea4619a6fe92857792bb3401a4eb1edd65f0342aca
+PKG_SOURCE_URL:=https://znc.in/releases \
+		https://znc.in/releases/archive
+PKG_HASH:=7fb841bc71dc1749b1dc081e9eaf22ceb56ebb03c6b1d8804a4f9eb8bbd59525
 
 PKG_MAINTAINER:=Jonas Gorski <jogo@openwrt.org>
 PKG_LICENSE:=Apache-2.0
@@ -23,14 +23,14 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_USE_MIPS16:=0
 PKG_BUILD_PARALLEL:=1
 
-PKG_CONFIG_DEPENDS := CONFIG_ZNC_ICU
+PKG_CONFIG_DEPENDS:= CONFIG_ZNC_ICU
 
 define Package/znc/default
   SUBMENU:=Instant Messaging
   SECTION:=net
   CATEGORY:=Network
   TITLE:=ZNC
-  URL:=http://en.znc.in/
+  URL:=https://znc.in/
   USERID:=znc:znc
 endef
 


### PR DESCRIPTION
Fixed links and switched to HTTPS as the site defaults to it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @KanjiMonster 
