### PR TITLE
wifidog-ng: depends ipset

### DIFF
--- a/net/wifidog-ng/Makefile
+++ b/net/wifidog-ng/Makefile
@@ -32,7 +32,7 @@ define Package/wifidog-ng/default
   CATEGORY:=Network
   TITLE:=Next generation WifiDog
   DEPENDS:=+kmod-wifidog-ng +libuci +libuclient +libblobmsg-json +libubus +libcares \
-	  +libipset +libpcap
+	  +ipset +libpcap
 endef
 
 define Package/wifidog-ng-nossl


### PR DESCRIPTION
Signed-off-by: Jianhui Zhao <jianhuizhao329@gmail.com>

Maintainer: me
Compile tested: (mipsel,miwifi-mini, master)
Run tested: (mipsel,miwifi-mini, master)

Description:
