### PR TITLE
acpid: remove depends on TARGET_x86 or TARGET_x86_64

### DIFF
--- a/utils/acpid/Makefile
+++ b/utils/acpid/Makefile
@@ -25,7 +25,7 @@ define Package/acpid
   CATEGORY:=Utilities
   TITLE:=The ACPI Daemon (acpid) With Netlink Support
   URL:=http://tedfelix.com/linux/acpid-netlink.html
-  DEPENDS:=@(TARGET_x86||TARGET_x86_64) +kmod-input-evdev 
+  DEPENDS:=+kmod-input-evdev 
 endef
 
 define Package/acpid/description


### PR DESCRIPTION
acpid can react on netlinkn events that are generated also from SoC
GPIO driven event, not only acpi x86 BIOS
(see: http://forum.lemaker.org/thread-2982-1-1.html)

Signed-off-by: Antonio Silverio <menion@gmail.com>

Compile tested: sunxi, a64, snapshot
Run tested: Orange Pi PC2 with modified dts

Description:
This patch remove the restriction of acpid on TARGET_x86 and TARGET_x86_64 since the daemon does not strictly require an ACPI BIOS to work, it can react on netlink events triggered also by a GPIO configured to send supported signals (such KEY_POWER)
