### PR TITLE
mwan3: Add missing globals config section

### DIFF
--- a/net/mwan3/files/etc/config/mwan3
+++ b/net/mwan3/files/etc/config/mwan3
@@ -1,4 +1,8 @@
 
+config globals 'globals'
+	option mmx_mask '0xff00'
+	option local_source 'lan'
+	
 config interface 'wan'
 	option enabled '1'
 	list track_ip '8.8.4.4'


### PR DESCRIPTION
Add missing globals config section with default values.
Without the correctly named section, mwan3 startup will fail with the error - Warning: mwan3 is global disabled. Usage: /etc/init.d/mwan3 start.
Compile: not required
Run tested: LEDE 17.01.04
Author-name: Rob White
Maintainer: Florian Eckert <fe@dev.tdt.de>
Signed-off-by: Rob White <rob@blue-wave.net>