### PR TITLE
net/mwan3: set default mask to 0x3F00

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.6.11
-PKG_RELEASE:=2
+PKG_VERSION:=2.6.12
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2
 

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -69,7 +69,7 @@ mwan3_init()
 		MWAN3_INTERFACE_MAX=$(uci_get_state mwan3 globals iface_max)
 	else
 		config_load mwan3
-		config_get MMX_MASK globals mmx_mask '0xff00'
+		config_get MMX_MASK globals mmx_mask '0x3F00'
 		echo "$MMX_MASK" > "${MWAN3_STATUS_DIR}/mmx_mask"
 		$LOG notice "Using firewall mask ${MMX_MASK}"
 


### PR DESCRIPTION
Maintainer: me
Compile tested: not needed this are skripts
Run tested: lantiq xrx200, x86 64, OpenWrt master

Description:

The IPsec ip route table has the default number 220.
If mwan3 has more then 7 bits set then on mwan3 down
the IPsec ip route table is also cleared. To solve this set default max 7
bits in the mmx_mask for mwan3.
Then only 124 interfaces could be tracked which i think is quite enough.

8bit set 252 interfaces
7bit set 124 interfaces
