### PR TITLE
mwan3: Add missing globals config section

### DIFF
--- a/net/mwan3/files/etc/config/mwan3
+++ b/net/mwan3/files/etc/config/mwan3
@@ -1,4 +1,8 @@
 
+config globals 'globals'
+	option mmx_mask '0x3f00'
+	option local_source 'lan'
+
 config interface 'wan'
 	option enabled '1'
 	list track_ip '8.8.4.4'

--- a/net/mwan3/files/etc/config/mwan3
+++ b/net/mwan3/files/etc/config/mwan3
@@ -1,6 +1,6 @@
 
 config globals 'globals'
-	option mmx_mask '0x3f00'
+	option mmx_mask '0x3F00'
 	option local_source 'lan'
 
 config interface 'wan'


### PR DESCRIPTION
Add missing globals config section with default values.
Without the correctly named section, mwan3 startup will fail with the error - Warning: mwan3 is global disabled. Usage: /etc/init.d/mwan3 start.
Signed-off-by: Rob White <rob@blue-wave.net>