### PR TITLE
ruby: bump to 2.5.1

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=2.5.0
+PKG_VERSION:=2.5.1
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=1da0afed833a0dab94075221a615c14487b05d0c407f991c8080d576d985b49b
+PKG_HASH:=886ac5eed41e3b5fc699be837b0087a6a5a3d10f464087560d2d21b3e71b754d
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
This release includes some bug fixes and some security fixes.

* CVE-2017-17742: HTTP response splitting in WEBrick
* CVE-2018-6914: Unintentional file and directory creation with directory traversal in tempfile and tmpdir
* CVE-2018-8777: DoS by large request in WEBrick
* CVE-2018-8778: Buffer under-read in String#unpack
* CVE-2018-8779: Unintentional socket creation by poisoned NUL byte in UNIXServer and UNIXSocket
* CVE-2018-8780: Unintentional directory traversal by poisoned NUL byte in Dir
* Multiple vulnerabilities in RubyGems

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me
Compile tested: OpenWrt SNAPSHOT r3677+2883-181bc02d2e
Run tested: OpenWrt SNAPSHOT r3677+2883-181bc02d2e running gem update

Description:
