### PR TITLE
[17.01] ruby: bump to 2.4.4

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2006-2016 OpenWrt.org
-# Copyright (C) 2017 Luiz Angelo Daros de Luca <luizluca@gmail.com>
+# Copyright (C) 2017-2018 Luiz Angelo Daros de Luca <luizluca@gmail.com>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruby
-PKG_VERSION:=2.4.3
+PKG_VERSION:=2.4.4
 PKG_RELEASE:=1
 
 # First two numbes
@@ -19,7 +19,7 @@ PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cache.ruby-lang.org/pub/ruby/$(PKG_ABI_VERSION)/
-PKG_HASH:=23677d40bf3b7621ba64593c978df40b1e026d8653c74a0599f0ead78ed92b51
+PKG_HASH:=1d0034071d675193ca769f64c91827e5f54cb3a7962316a41d5217c7bc6949f0
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
This release includes some bug fixes and some security fixes.

* CVE-2017-17742: HTTP response splitting in WEBrick
* CVE-2018-6914: Unintentional file and directory creation with directory traversal in tempfile and tmpdir
* CVE-2018-8777: DoS by large request in WEBrick
* CVE-2018-8778: Buffer under-read in String#unpack
* CVE-2018-8779: Unintentional socket creation by poisoned NUL byte in UNIXServer and UNIXSocket
* CVE-2018-8780: Unintentional directory traversal by poisoned NUL byte in Dir
* Multiple vulnerabilities in RubyGems

There are also some bug fixes

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me
Compile tested: lede 17.01.cx (git) on x86
Run tested: OpenWrt SNAPSHOT r3677+2883-181bc02d2e running gem update

Description:
