### PR TITLE
sound/lame: Fix optimization

### DIFF
--- a/sound/lame/Makefile
+++ b/sound/lame/Makefile
@@ -63,8 +63,7 @@ TARGET_CFLAGS+=-msse
 endif
 
 ifeq ($(CONFIG_LAME-LIB_OPTIMIZE_SPEED),y)
-	TARGET_CFLAGS += $(TARGET_CFLAGS) -O3 -ffast-math
-	TARGET_CFLAGS := $(filter-out -Os,$(TARGET_CFLAGS))
+	TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS)) -O3 -ffast-math
 endif
 
 CONFIGURE_ARGS += --disable-gtktest --disable-static


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: mvebu, Linksys WRT3200ACM, OpenWrt master
Run tested: mvebu, Linksys WRT3200ACM, OpenWrt master

Description:
Properly strip any -O switch

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>