### PR TITLE
travelmate: update 1.2.0

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.1.3
+PKG_VERSION:=1.2.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/travelmate.conf
+++ b/net/travelmate/files/travelmate.conf
@@ -3,7 +3,6 @@
 
 config travelmate 'global'
 	option trm_enabled '0'
-	option trm_automatic '1'
 	option trm_captive '1'
 	option trm_iface 'trm_wwan'
 	option trm_triggerdelay '2'

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -8,6 +8,7 @@ EXTRA_HELP="	status	Print runtime information"
 
 trm_init="/etc/init.d/travelmate"
 trm_script="/usr/bin/travelmate.sh"
+trm_pidfile="/var/run/travelmate.pid"
 
 boot()
 {
@@ -25,6 +26,12 @@ start_service()
         procd_set_param stderr 1
         procd_close_instance
     fi
+}
+
+reload_service()
+{
+    [ -s "${trm_pidfile}" ] && return 1
+    "${trm_init}" restart
 }
 
 stop_service()
@@ -59,15 +66,10 @@ status()
 
 service_triggers()
 {
-    local auto="$(uci_get travelmate global trm_automatic)"
+    local trigger="$(uci_get travelmate global trm_iface)"
+    local delay="$(uci_get travelmate global trm_triggerdelay)"
 
-    if [ "${auto}" = "0" ]
-    then
-        local trigger="$(uci_get travelmate global trm_iface)"
-        local delay="$(uci_get travelmate global trm_triggerdelay)"
-
-        PROCD_RELOAD_DELAY=$((${delay:-2} * 1000))
-        procd_add_interface_trigger "interface.*.down" "${trigger}" "${trm_init}" start
-    fi
+    PROCD_RELOAD_DELAY=$((${delay:-2} * 1000))
+    procd_add_interface_trigger "interface.*.down" "${trigger}" "${trm_init}" reload
     procd_add_reload_trigger "travelmate"
 }


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL.iNet GL-AR750, OpenWrt SNAPSHOT r6588-16efb0c1c6

Description:
* union 'automatic' and 'trigger' mode, now much more responsive if an uplink suddenly disappears
* tidy up (disable) travelmate related uplink connections if you disable the service
* change default config ('trm_automatic' removal)
* documentation update
* LuCI: remove needless 'automatic' and 'trigger' options plus small fixes

Signed-off-by: Dirk Brenken <dev@brenken.org>