### PR TITLE
net/nlbwmon: run with lower priority

### DIFF
--- a/net/nlbwmon/files/nlbwmon.init
+++ b/net/nlbwmon/files/nlbwmon.init
@@ -5,6 +5,7 @@ START=60
 USE_PROCD=1
 NAME=nlbwmon
 PROG=/usr/sbin/nlbwmon
+NICEPRIO=19
 
 add_subnet() {
 	local network="$1"
@@ -80,6 +81,7 @@ start_service() {
 	procd_open_instance
 	procd_set_param stderr 1
 	procd_set_param command "$PROG"
+	procd_set_param nice "$NICEPRIO"
 
 	config_load nlbwmon
 	config_foreach parse_config nlbwmon


### PR DESCRIPTION
Maintainer: @jow
Compile tested: ipq806x, Netgear R7800, OpenWRT master
Run tested: pq806x, Netgear R7800, OpenWRT master

Description:
Even on a powerful platform a nlbwmon process'
activities are sometimes affecting throoughput and
latency. This is a backgroud process, that should not
be running with default priority.
Even if it is a little deplayed, that is not a worry in
this case. The routing should be the main priority,
bandwidth stats collection can wait a bit.

Tested on Netgear R7800
Signed-off-by: Marc Benoit <marcb62185@gmail.com>