### PR TITLE
transmission: Add rpc_host_whitelist support.

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=2.93
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master

--- a/net/transmission/files/transmission.config
+++ b/net/transmission/files/transmission.config
@@ -3,6 +3,7 @@ config transmission
 	option config_dir '/tmp/transmission'
 	option config_overwrite '1'
 	option user 'transmission'
+	option group 'transmission'
 	option mem_percentage 50
 	option nice 10
 	option alt_speed_down 50
@@ -49,13 +50,14 @@ config transmission
 	option rpc_authentication_required false
 	option rpc_bind_address '0.0.0.0'
 	option rpc_enabled true
+	option rpc_host_whitelist '127.0.0.1,192.168.1.*'
 	option rpc_host_whitelist_enabled false
 	option rpc_password ''
 	option rpc_port 9091
 	option rpc_url '/transmission/'
 	option rpc_username ''
 	option rpc_whitelist '127.0.0.1,192.168.1.*'
-	option rpc_whitelist_enabled true
+	option rpc_whitelist_enabled false
 	option scrape_paused_torrents_enabled true
 	option script_torrent_done_enabled false
 	option script_torrent_done_filename ''

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -46,6 +46,7 @@ transmission() {
 	local USE
 
 	local user
+	local group
 	local config_overwrite
 	local download_dir config_dir
 	local mem_percentage
@@ -56,6 +57,7 @@ transmission() {
 
 	config_get config_dir "$cfg" 'config_dir' '/var/etc/transmission'
 	config_get user "$cfg" 'user'
+	config_get group "$cfg" 'group'
 	config_get download_dir "$cfg" 'download_dir' '/var/etc/transmission'
 	config_get mem_percentage "$cfg" 'mem_percentage' '50'
 	config_get config_overwrite "$cfg" config_overwrite 1
@@ -71,7 +73,7 @@ transmission() {
 		mkdir -p $config_dir
 		chmod 0755 $config_dir
 		touch $config_file
-		[ -z "$user" ] || chown -R "$user:$user" $config_dir
+		[ -z "$user" ] || chown -R "$user:$group" $config_dir
 	}
 
 	[ "$config_overwrite" == 0 ] || {
@@ -99,7 +101,7 @@ transmission() {
 		append_params_quotes "$cfg" \
 			blocklist_url bind_address_ipv4 bind_address_ipv6 download_dir incomplete_dir \
 			peer_congestion_algorithm peer_socket_tos rpc_bind_address rpc_password rpc_url \
-			rpc_username rpc_whitelist script_torrent_done_filename watch_dir
+			rpc_username rpc_host_whitelist rpc_whitelist script_torrent_done_filename watch_dir
 
 		echo "\"invalid-key\": false" >> $config_file
 		echo "}" >> $config_file
@@ -111,7 +113,7 @@ transmission() {
 	procd_set_param command $cmdline
 	procd_set_param env CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 	procd_set_param user $user
-	procd_set_param group $user
+	procd_set_param group $group
 	procd_set_param nice $nice
 	procd_set_param respawn retry=60
 


### PR DESCRIPTION
It was requested as it can be useful under certain circumstances.

Disabled rpc_whitelist by default. Not only is there a firewall, but it denies access when IP address of the device is changed.

Added group support in UCI. Fixes cases where group does not match the user (nobody:nogroup).

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me 
Compile tested: mvebu