### PR TITLE
chrony: disable sechash support

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
 PKG_VERSION:=3.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.tuxfamily.org/chrony/
@@ -53,6 +53,7 @@ CONFIGURE_ARGS+= \
 	--chronyrundir=/var/run/chrony \
 	--disable-readline \
 	--disable-rtc \
+	--disable-sechash \
 	--with-user=chrony
 
 CONFIGURE_VARS+=CPPFLAGS=-DNDEBUG


### PR DESCRIPTION
Maintainer: me
Compile tested: mips, wr-741nd, lede-17.01
Run tested: mips, wr-741nd, lede-17.01, runs as a client and server

Description:
Don't use the Nettle library (or NSS, libtomcrypt) even if it is available in the build root. This should prevent the package from having unexpected dependencies.