### PR TITLE
zerotier: fix 'unknown operand' error

### DIFF
--- a/net/zerotier/files/zerotier.init
+++ b/net/zerotier/files/zerotier.init
@@ -28,7 +28,7 @@ start_instance() {
 	rm -rf $CONFIG_PATH
 
 	# Create link from CONFIG_PATH to config_path
-	if [ -n "$config_path" -a $config_path != $CONFIG_PATH ]; then
+	if [ -n "$config_path" -a "$config_path" != $CONFIG_PATH ]; then
 		if [ ! -d "$config_path" ]; then
 			echo "ZeroTier config_path does not exist: $config_path"
 			return


### PR DESCRIPTION
Signed-off-by: Moritz Warning <moritzwarning@web.de>

Maintainer: me 
Compile tested: -
Run tested: -

Description:
A rather simple shell syntax fix. Compile/Run test might not be needed for this one.
