### PR TITLE
autossh: add an 'enabled' option within the uci configuration file

### DIFF
--- a/net/autossh/Makefile
+++ b/net/autossh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=autossh
 PKG_VERSION:=1.4e
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=http://www.harding.motd.ca/autossh/

--- a/net/autossh/files/autossh.config
+++ b/net/autossh/files/autossh.config
@@ -3,3 +3,4 @@ config autossh
 	option gatetime	'0'
 	option monitorport	'20000'
 	option poll	'600'
+	option enabled	'0'

--- a/net/autossh/files/autossh.hotplug
+++ b/net/autossh/files/autossh.hotplug
@@ -10,5 +10,5 @@
 	[ "$ACTION" = "ifdown" ] && {
 		/etc/init.d/autossh stop
 	}
-	
+
 }

--- a/net/autossh/files/autossh.init
+++ b/net/autossh/files/autossh.init
@@ -10,6 +10,9 @@ start_instance() {
 	config_get gatetime "$section" 'gatetime'
 	config_get monitorport "$section" 'monitorport'
 	config_get poll "$section" 'poll'
+	config_get_bool enabled "$section" 'enabled' '1'
+
+	[ "$enabled" = 1 ] || exit 0
 
 	export AUTOSSH_GATETIME="${gatetime:-30}"
 	export AUTOSSH_POLL="${poll:-600}"


### PR DESCRIPTION
Maintainer: @bk138 
Compile tested: imx6
Run tested: imx6

Description:

In a tool like this one, you really want an option to establish if the service
should start or not by default on boot time, especially when its configuration
file has to be customized by the user.

In the configuration file, the new 'enabled' option is setted to '0' by default
since the configuration provided by default will not be the one finally used.

In the init script, the new 'enabled' option is setted to '1' by default in
order to support the previous configuration file behaviour.

Signed-off-by: Adrià Llaudet <adria.llaudet@gmail.com>