### PR TITLE
fwknopd: More reliable network dependency

### DIFF
--- a/net/fwknop/Makefile
+++ b/net/fwknop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fwknop
 PKG_VERSION:=2.6.9
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.cipherdyne.org/fwknop/download

--- a/net/fwknop/files/fwknopd
+++ b/net/fwknop/files/fwknopd
@@ -2,7 +2,9 @@ config global
 #	option uci_enabled '1'
 
 config network
-#	option network 'wan'	# takes precedence over config.PCAP_INTF
+	# Logical network dependency, fully tracked, fwknopd gets restarted when
+	# necessary. Specifying network takes precedence over config.PCAP_INTF
+#	option network 'wan'
 
 config access
 	option SOURCE 'ANY'
@@ -10,3 +12,6 @@ config access
 	option KEY 'CHANGEME'
 
 config config
+	# Alternative direct physical interface definition, but untracked - you
+	# are on your own to correctly start/stop the service when needed
+#	option PCAP_INTF 'eth0'

--- a/net/fwknop/files/fwknopd.init
+++ b/net/fwknop/files/fwknopd.init
@@ -14,24 +14,31 @@ start_service()
 {
 	generate_configuration
 
-	procd_open_instance
-	procd_set_param command "$FWKNOPD_BIN" --foreground --syslog-enable
-	procd_set_param respawn
-
-	if [ $UCI_ENABLED -eq 1 ]; then
-		procd_append_param command -c /var/etc/fwknopd.conf
-		procd_append_param command -a /var/etc/access.conf
+	if [ -n "$DEPEND_IFNAME" ] ; then
+		# We know the interface, so we can start
+		procd_open_instance
+		procd_set_param command "$FWKNOPD_BIN" --foreground --syslog-enable
+		procd_set_param respawn
+		if [ $UCI_ENABLED -eq 1 ]; then
+			procd_append_param command -c /var/etc/fwknopd.conf
+			procd_append_param command -a /var/etc/access.conf
+		fi
+		procd_append_param command -i "$DEPEND_IFNAME"
+		procd_set_param netdev "$DEPEND_IFNAME"
+		procd_close_instance
+	else
+		logger -p daemon.info -t "fwknopd[----]" "Postponing start-up of fwknopd, network $NETWORK is not up"
 	fi
-
-	procd_append_param command -i "$DEPEND_IFNAME"
-	procd_set_param netdev "$DEPEND_IFNAME"
-
-	procd_close_instance
 }
 
 service_triggers()
 {
 	procd_add_reload_trigger "fwknopd"
+
+	if [ -n "$NETWORK" ] ; then
+		logger -p daemon.info -t "fwknopd[----]" "Listening for changes on network $NETWORK"
+		procd_add_reload_interface_trigger "$NETWORK"
+	fi
 }
 
 get_bool()
@@ -51,7 +58,7 @@ generate_configuration()
 
 	UCI_ENABLED=0
 	DEPEND_IFNAME=
-	local NETWORK=
+	NETWORK=
 	local PCAP_INTF=
 	local USER_CONFIG_PATH=/etc/fwknop/fwknopd.conf
 	local DEFAULT_UCI_NETWORK=wan
@@ -67,9 +74,16 @@ generate_configuration()
 				if [ "$option" = "uci_enabled" ] && [ "$(get_bool "$value" 0)" -eq 1 ] ; then
 					> /var/etc/fwknopd.conf
 					> /var/etc/access.conf
-                                        chmod 600 /var/etc/fwknopd.conf
-                                        chmod 600 /var/etc/access.conf
+					chmod 600 /var/etc/fwknopd.conf
+					chmod 600 /var/etc/access.conf
 					UCI_ENABLED=1
+
+					# Forced defaults
+
+					# Do not let fwknopd to shut-down when interface goes down,
+					# control it from the start-up script instead:
+					# https://bugs.openwrt.org/index.php?do=details&task_id=1481
+					echo "EXIT_AT_INTF_DOWN n" >> /var/etc/fwknopd.conf
 				fi
 			}
 		elif [ "$type" = "network" ]; then
@@ -87,12 +101,13 @@ generate_configuration()
 				if [ $UCI_ENABLED -eq 1 ] && [ $option = "PCAP_INTF" ]; then
 					PCAP_INTF="$value"
 					echo "$option $value" >> /var/etc/fwknopd.conf  #writing each option to fwknopd.conf
+				elif [ $UCI_ENABLED -eq 1 ] && [ $option = "EXIT_AT_INTF_DOWN" ]; then
+					logger -p daemon.warn -t "fwknopd[----]" "Ignoring EXIT_AT_INTF_DOWN option, forced to N (no) to work reliably with procd"
 				elif [ $UCI_ENABLED -eq 1 ]; then
 					echo "$option $value" >> /var/etc/fwknopd.conf  #writing each option to fwknopd.conf
 				fi
 			}
-		elif [ "$type" = "access" ]
-		then
+		elif [ "$type" = "access" ]; then
 			if [ -f /tmp/access.conf.tmp ] ; then
 				cat /tmp/access.conf.tmp >> /var/etc/access.conf
 				rm /tmp/access.conf.tmp
@@ -108,7 +123,7 @@ generate_configuration()
 				fi
 			}
 		else
-			option_cb() { return; }
+			reset_cb
 			if [ -z "$type" ]; then
 				# Finalize reading
 				if [ -f /tmp/access.conf.tmp ] ; then
@@ -125,8 +140,8 @@ generate_configuration()
 
 	if [ $UCI_ENABLED -eq 0 ]; then
 		if [ -f $USER_CONFIG_PATH ] ; then
-			# Scan user configuration for PCAP_INTF settings
-			DEPEND_IFNAME="$( sed -ne '/^\s*PCAP_INTF\s\+/ { s/^\s*PCAP_INTF\s\+//; s/\s\+$//; p; q; }' /etc/fwknop/fwknopd.conf )"
+			# Scan user configuration for PCAP_INTF settings and fallback to fwknopd's default
+			DEPEND_IFNAME="$( sed -ne '/^\s*PCAP_INTF\s\+/ { s/^\s*PCAP_INTF\s\+//; s/\s\+$//; p; q; }' $USER_CONFIG_PATH )"
 			if [ -n "$DEPEND_IFNAME" ]; then
 				logger -p daemon.debug -t "fwknopd[----]" "Found fwknopd.conf configuration, using PCAP_INTF interface $DEPEND_IFNAME"
 			else
@@ -146,14 +161,14 @@ generate_configuration()
 			NETWORK="$DEFAULT_UCI_NETWORK"
 		fi
 
+		# Resolve network if possible
 		if [ -n "$NETWORK" ]; then
 			. /lib/functions/network.sh
-			network_get_physdev DEPEND_IFNAME "$NETWORK"
+			network_get_device DEPEND_IFNAME "$NETWORK"
 			if [ -n "$DEPEND_IFNAME" ]; then
 				logger -p daemon.debug -t "fwknopd[----]" "Resolved network $NETWORK as interface $DEPEND_IFNAME"
 			else
-				logger -p daemon.warn -t "fwknopd[----]" "Cannot find interface for network $NETWORK, fwknopd's default $DEFAULT_FWKNOPD_IFNAME will be used"
-				DEPEND_IFNAME="$DEFAULT_FWKNOPD_IFNAME"
+				logger -p daemon.warn -t "fwknopd[----]" "Cannot find interface for network $NETWORK, probably the network is not up"
 			fi
 		elif [ -n "$PCAP_INTF" ]; then
 			DEPEND_IFNAME="$PCAP_INTF"


### PR DESCRIPTION
Maintainer: @jp-bennett
Compile tested: ar71xx, tl-wr1043nd, OpenWrt git master (from yesterday)
Run tested: ar71xx, tl-wr1043nd, OpenWrt git master (from yesterday)

Two issues:

  1. The fwknopd init script did not handle unprepared logical networks.
     This is fixed by A) not defining instance for procd when the physical
     interface is unknown, and B) by watching the logical network for
     changes.

  2. When using PPPoE, there are two physical interfaces -- one for raw
     PPPoE communication and one for wrapped communication. The function
     network_get_physdev returns the physical device, while the function
     network_get_device returns the wrapped one -- we shall use the
     wrapped interface. Usually (for non-wrapped interfaces) the physdev
     and device are the same, also other network scripts use the latter
     function.

Both issues found by and thanks are going to @lucize.