### PR TITLE
acme: Support DNS mode

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme
 PKG_VERSION:=2.7.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPLv3
 
 PKG_SOURCE_PROTO:=git
@@ -56,6 +56,22 @@ define Package/acme/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/acme.sh $(1)/usr/lib/acme/acme.sh
 endef
 
+define Package/acme-dnsapi
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+acme
+  TITLE:=DNS API integration for ACME (Letsencrypt) client
+endef
+
+define Package/acme-dnsapi/description
+ This package provides DNS API integration for ACME (Letsencrypt) client.
+endef
+
+define Package/acme-dnsapi/install
+	$(INSTALL_DIR) $(1)/usr/lib/acme/dnsapi
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/dnsapi/*.sh $(1)/usr/lib/acme/dnsapi
+endef
+
 define Package/luci-app-acme
   SECTION:=luci
   CATEGORY:=LuCI
@@ -93,4 +109,5 @@ endef
 
 
 $(eval $(call BuildPackage,acme))
+$(eval $(call BuildPackage,acme-dnsapi))
 $(eval $(call BuildPackage,luci-app-acme))

--- a/net/acme/files/acme-cbi.lua
+++ b/net/acme/files/acme-cbi.lua
@@ -69,4 +69,18 @@ dom = cs:option(DynamicList, "domains", translate("Domain names"),
                           "Note that all domain names must point at the router in the global DNS."))
 dom.datatype = "list(string)"
 
+dns = cs:option(Value, "dns", translate("DNS API"),
+                translate("To use DNS mode to issue certificates, set this to the name of a DNS API supported by acme.sh. " ..
+                          "See https://github.com/Neilpang/acme.sh/tree/master/dnsapi for the list of available APIs. " ..
+                          "In DNS mode, the domain name does not have to resolve to the router IP. " ..
+                          "DNS mode is also the only mode that supports wildcard certificates. " ..
+                          "Using this mode requires the acme-dnsapi package to be installed."))
+dns.rmempty = false
+
+cred = cs:option(DynamicList, "credentials", translate("DNS API credentials"),
+                 translate("The credentials for the DNS API mode selected above. " ..
+                           "See https://github.com/Neilpang/acme.sh/tree/master/dnsapi#how-to-use-dns-api for the format of credentials required by each API. " ..
+                           "Add multiple entries here in KEY=VAL shell variable format to supply multiple credential variables."))
+cred.datatype = "list(string)"
+
 return m


### PR DESCRIPTION
Maintainer: @tohojo
Compile tested: (ramips, ZBT WG3526, OpenWrt r6653-c0bbb97)
Run tested: (ramips, ZBT WG3526, OpenWrt r6653-c0bbb97, tests done)

Description:

Support DNS mode (acme.sh --dns), tested with dynu.com ddns.

Download https://raw.githubusercontent.com/Neilpang/acme.sh/master/dnsapi/dns_dynu.sh to `/etc/acme/dnsapi/dns_dynu.sh`.

Put dynu.com client id and secret to `/etc/acme/account.conf`:

    Dynu_ClientId="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
    Dynu_Secret="yyyyyyyyyyyyyyyyyyyyyyyyy"

Example `/etc/config/acme`:

    config acme
	    option state_dir '/etc/acme'
	    option account_email email@example.org'
	    option debug '0'

    config cert 'foo'
	    option enabled '1'
	    option use_staging '1'
	    option keylength '2048'
	    option update_uhttpd '0'
	    option dns 'dns_dynu'
	    list domains 'foo.dynu.com'
	    list domains '*.foo.dynu.com'

Run `/etc/init.d/acme start`.