### PR TITLE
cifs-utils: Update to 6.8

### DIFF
--- a/net/cifs-utils/Makefile
+++ b/net/cifs-utils/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cifs-utils
-PKG_VERSION:=6.7
+PKG_VERSION:=6.8
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://download.samba.org/pub/linux-cifs/cifs-utils/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=b2f21612474ab012e75accd167aab607a0614ff67efb56ea0f36789fa785cfab
+PKG_HASH:=e7d1f6050c43f21f82cd77e288eb756755effd22f0c310fc2c525df9d41dff79
 
 PKG_MAINTAINER:=Florian Fainelli <florian@openwrt.org>
 PKG_LICENSE:=GPL-3.0
@@ -26,7 +26,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/cifsmount
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+kmod-fs-cifs +libtalloc
+  DEPENDS:=+kmod-fs-cifs
   TITLE:=CIFS mount utilities
   URL:=http://wiki.samba.org/index.php/LinuxCIFS_utils
 endef
@@ -36,8 +36,14 @@ TARGET_CFLAGS += -Wno-error
 CONFIGURE_ARGS += \
 	--exec-prefix=/usr \
 	--prefix=/ \
-	--with-libcap-ng=no \
-	--with-libcap=no
+	--with-libcap=no \
+	--disable-cifsupcall \
+	--disable-cifscreds \
+	--disable-cifsidmap \
+	--disable-cifsacl \
+	--disable-pam \
+	--disable-systemd \
+	--disable-man
 
 define Package/cifsmount/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/net/cifs-utils/patches/010-no-libtalloc.patch
+++ b/net/cifs-utils/patches/010-no-libtalloc.patch
@@ -1,0 +1,13 @@
+diff --git a/data_blob.h b/data_blob.h
+index 3d96147..c20749d 100644
+--- a/data_blob.h
++++ b/data_blob.h
+@@ -23,7 +23,7 @@
+ #ifndef _SAMBA_DATABLOB_H_
+ #define _SAMBA_DATABLOB_H_
+ 
+-#include <talloc.h>
++//#include <talloc.h>
+ #include <stdint.h>
+ 
+ /* used to hold an arbitrary blob of data */


### PR DESCRIPTION
Removed libtalloc dependency and adjusted configure args to skip some tests. Those packages were not being built anyway.

Size difference: 14405 vs. 14125 on mvebu. Also 11275 bytes for libtalloc are gone.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ffainelli 
Compile tested: mvebu
Run tested: mvebu