### PR TITLE
prometheus-node-exporter-lua: extend bmx7 plugin

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2017.12.08
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Christian Simon <simon@swine.de>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/bmx7.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/bmx7.lua
@@ -39,7 +39,28 @@ local function scrape()
     }
     metric_bmx7_rxRate(labels, interpret_suffix(link.rxRate))
     metric_bmx7_txRate(labels, interpret_suffix(link.txRate))
+  end
+
+  local metric_bmx7_tunIn = metric("bmx7_tunIn", "gauge")
+  local parameters = json.decode(get_contents("/var/run/bmx7/json/parameters")).OPTIONS
+  for _, option in pairs(parameters) do
+    if option.name == "tunIn" then
+      for _, instance in pairs(option.INSTANCES) do
+        for _, child_instance in pairs(instance.CHILD_INSTANCES) do
+          local labels = {
+            name = instance.value,
+            network = child_instance.value
+          }
+          metric_bmx7_tunIn(labels, 1)
+        end
+      end
+    elseif option.name == "plugin" then
+      local metric_bmx7_plugin = metric("bmx7_plugin", "gauge")
+      for _, instance in pairs(option.INSTANCES) do
+        metric_bmx7_plugin({ name = instance.value }, 1)
+      end
     end
+  end
 end
 
 return { scrape = scrape }


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested: x86/64
Run tested: x86/64

Description:

Now monitors as well the tunIn parameters, aka the annoucend routes to
the network. This is handy to check if a node annouces itself as a
gateway.

Also list all activated plugins.

Example output:

    # TYPE bmx7_tunIn gauge
    bmx7_tunIn{name="myIP4",network="10.198.52.86/32"} 1
    bmx7_tunIn{name="myIP6",network="2012:0:0:56::/128"} 1
    bmx7_tunIn{name="inet4",network="0.0.0.0/0"} 1
    # TYPE bmx7_plugin gauge
    bmx7_plugin{name="bmx7_config.so"} 1
    bmx7_plugin{name="bmx7_json.so"} 1
    bmx7_plugin{name="bmx7_sms.so"} 1
    bmx7_plugin{name="bmx7_tun.so"} 1

Signed-off-by: Paul Spooren <spooren@informatik.uni-leipzig.de>
