### PR TITLE
libs/libx264: Update to snapshot 20180401

### DIFF
--- a/libs/libx264/Makefile
+++ b/libs/libx264/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=x264
-PKG_VERSION:=snapshot-20170623-2245-stable
+PKG_VERSION:=snapshot-20180401-2245
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.videolan.org/x264/snapshots/
 PKG_MAINTAINER:=Adrian Panella <ianchi74@outlook.com>
-PKG_HASH:=e8af5d199b6af8124b6e54631ab7b2ff20f1ce86bbcc2f58bd800bc85bee6b2f
+PKG_HASH:=657a915497a5b0ffed3598988657395358cf4dc961db14aebd918b7ffb7c5364
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
@@ -24,7 +24,7 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-TARGET_CFLAGS+=-std=gnu99 -fPIC -O3 -ffast-math -I.
+TARGET_CFLAGS:=$(filter-out -O%,$(TARGET_CFLAGS)) -std=gnu99 -fPIC -O3 -ffast-math -I.
 MAKE_FLAGS+= LD="$(TARGET_CC) -o" 
 
 # ARM ASM depends on ARM1156 or later, blacklist earlier or incompatible cores


### PR DESCRIPTION
Maintainer: @ianchi 
Compile tested: mvebu, Linksys WRT3200ACM, OpenWrt master
Run tested: mvebu, Linksys WRT3200ACM, OpenWrt master

Description:
Update libx264 to snapshot 20180401
Scrub any previous set -O flags, cosmetic change.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>