### PR TITLE
<ddns-scripts>: Add OK to valid easydns response.

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.7
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -108,7 +108,7 @@
 
 "dynv6.com"		"http://dynv6.com/api/update?hostname=[DOMAIN]&token=[PASSWORD]&ipv4=[IP]"	"updated|unchanged"
 
-"easydns.com"		"http://[USERNAME]:[PASSWORD]@api.cp.easydns.com/dyn/generic.php?hostname=[DOMAIN]&myip=[IP]"	"NOERROR"
+"easydns.com"		"http://[USERNAME]:[PASSWORD]@api.cp.easydns.com/dyn/generic.php?hostname=[DOMAIN]&myip=[IP]"	"OK|NOERROR"
 
 "editdns.net"		"http://dyndns-free.editdns.net/api/dynLinux.php?p=[PASSWORD]&r=[DOMAIN]"
 


### PR DESCRIPTION
Maintainer: @<christian.schoenebeck@gmail.com>

Environment:
ddns-scripts 2.7.6-13
Linksys WRT1900ACSv2
LEDE Reboot 17.01.4 r3560-79f57e422d / LuCI lede-17.01 branch (git-18.097.73852-3737637)

Run tested: (put here arch, model, OpenWrt version, tests done)

Description:

Add "OK" to valid response from easydns to solve issue described in
https://github.com/openwrt/packages/issues/5910

After the change the following log shows the update has been flagged as accepted:

```
 095809       : ************ ************** ************** **************
 095809  note : PID '11234' started at 2018-04-14 09:58
 095809       : ddns version  : 2.7.6-13
 095809       : uci configuration:
ddns.myddns_ipv4.check_interval='30'
ddns.myddns_ipv4.domain='xxxxxxx.ca'
ddns.myddns_ipv4.enabled='1'
ddns.myddns_ipv4.force_interval='7'
ddns.myddns_ipv4.force_unit='days'
ddns.myddns_ipv4.interface='wan'
ddns.myddns_ipv4.ip_network='wan'
ddns.myddns_ipv4.ip_source='network'
ddns.myddns_ipv4.lookup_host='xxxxxxx.ca'
ddns.myddns_ipv4.password='xxxxxxxxx'
ddns.myddns_ipv4.service_name='easydns.com'
ddns.myddns_ipv4.use_https='1'
ddns.myddns_ipv4.username='xxxxxxxxx'
ddns.myddns_ipv4=service
 095809       : verbose mode  : 0 - run normal, NO console output
 095809       : check interval: 1800 seconds
 095809       : force interval: 604800 seconds
 095809       : retry interval: 60 seconds
 095809       : retry counter : 0 times
 095809       : No old process
 095809       : last update: never
 095809       : Detect registered/public IP
 095809       : #> /usr/bin/nslookup xxxxxx.ca  >/var/run/ddns/myddns_ipv4.dat 2>/var/run/ddns/myddns_ipv4.err
 095809       : Registered IP 'xxx.xxx.xx.xx' detected
 095809  info : Starting main loop at 2018-04-14 09:58
 095809       : Detect local IP on 'network'
 095809       : Local IP 'xxx.xxx.xx.xx' detected on network 'wan'
 095809       : Forced Update - L: 'xxx.xxx.xx.xx' == R: 'xxx.xxx.xx.xx'
 095809       : #> /usr/bin/wget-ssl -nv -t 1 -O /var/run/ddns/myddns_ipv4.dat -o /var/run/ddns/myddns_ipv4.err --no-proxy 'https://xxxxxxx:xxxxxxxx@api.cp.easydns.com/dyn/generic.php?hostname=xxxxxx.ca&myip=xxx.xxx.xx.xx'
 095811       : DDNS Provider answered:
<HTML><BODY><FONT FACE="sans-serif" SIZE="-1">OK<br />
<hr noshade size="1">
no update required for xxxxxx.ca to xxx.xxx.xx.xx<br />
</FONT></BODY></HTML>
 095811  info : Forced update successful - IP: 'xxx.xxx.xx.xx' send
 095811       : Waiting 1800 seconds (Check Interval)
 102811       : Detect registered/public IP
 102811       : #> /usr/bin/nslookup xxxxxx.ca  >/var/run/ddns/myddns_ipv4.dat 2>/var/run/ddns/myddns_ipv4.err
 102811       : Registered IP 'xxx.xxx.xx.xx' detected
 102811  info : Rerun IP check at 2018-04-14 10:28
 102811       : Detect local IP on 'network'
 102811       : Local IP 'xxx.xxx.xx.xx' detected on network 'wan'
 102811       : Waiting 1800 seconds (Check Interval)

```
Signed-off-by: Danny Scott <doscott@gmail.com>
