### PR TITLE
utils/pcsc-tools: Update to 1.5.3

### DIFF
--- a/utils/pcsc-tools/Makefile
+++ b/utils/pcsc-tools/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pcsc-tools
-PKG_VERSION=1.5.2
+PKG_VERSION=1.5.3
 PKG_RELEASE:=1
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0
@@ -16,7 +16,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://ludovic.rousseau.free.fr/softwares/pcsc-tools/
-PKG_HASH:=ff4e087c76700aa5a25dd7d0bc4f55bb4a5e71cd4f0d6b5301babe0b434f86fc
+PKG_HASH:=daaa011c28daa00653bd8e2a3d8b0b9f8abae00f7344f50b1a94fbd2b01f1d14
 
 PKG_FIXUP:=autoreconf
 

--- a/utils/pcsc-tools/patches/001-disable-atr.patch
+++ b/utils/pcsc-tools/patches/001-disable-atr.patch
@@ -1,17 +1,16 @@
-Windows (Win32) doesn't support the analyze ATR perl-script and since we 
-don't want to pull in perl as a dependency add the same workaround here. 
+Disable the analyze ATR perl-script and as we don't want to pull in perl
+as a dependency.
 
 diff --git a/pcsc_scan.c b/pcsc_scan.c
-index e1d8942..81344e1 100644
+index d89bc3e..134b675 100644
 --- a/pcsc_scan.c
 +++ b/pcsc_scan.c
-@@ -224,9 +224,7 @@ int main(int argc, char *argv[])
- 	printf("PC/SC device scanner\n");
- 	printf("V " PACKAGE_VERSION " (c) 2001-2017, Ludovic Rousseau <ludovic.rousseau@free.fr>\n");
- 
--#ifdef WIN32
- 	analyse_atr = FALSE;
--#endif
- 
- 	while ((opt = getopt(argc, argv, "Vhns")) != EOF)
- 	{
+@@ -241,7 +241,7 @@ static void initialize_options(options_t *options, const char *pname)
+ #ifdef WIN32
+ 	options->analyse_atr = False;
+ #else
+-	options->analyse_atr = True;
++	options->analyse_atr = False;
+ #endif
+ 	options->stress_card = False;
+ 	options->print_version = False;


### PR DESCRIPTION
Maintainer: N/A
Compile tested: mvebu, Linksys WRT3200ACM, OpenWrt master
Run tested: mvebu, Linksys WRT3200ACM, OpenWrt master

Description:
Update pcsc-tools to 1.5.3

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>