### PR TITLE
bmx7-dnsupdate: add package

### DIFF
--- a/utils/bmx7-dnsupdate/Makefile
+++ b/utils/bmx7-dnsupdate/Makefile
@@ -1,0 +1,27 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bmx7-dnsupdate
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/bmx7-dnsupdate
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=bmx7-dnsupdate
+  MAINTAINER:=Paul Spooren <spooren@informatik.uni-leipzig.de>
+  DEPENDS:=+bmx7 +bmx7-json inotifywait jshn
+endef
+
+define Build/Compile
+endef
+
+define Build/Configure
+endef
+
+define Package/bmx7-dnsupdate/install
+	$(CP) files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,bmx7-dnsupdate))

--- a/utils/bmx7-dnsupdate/files/etc/init.d/bmx7-dnsupdate
+++ b/utils/bmx7-dnsupdate/files/etc/init.d/bmx7-dnsupdate
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+START=92
+USE_PROCD=1
+
+BIN=/usr/bin/bmx7-dnsupdate
+
+start_service() {
+	procd_open_instance "bmx7-dnsupdate"
+	procd_set_param command "$BIN"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn
+	procd_close_instance
+}

--- a/utils/bmx7-dnsupdate/files/usr/bin/bmx7-dnsupdate
+++ b/utils/bmx7-dnsupdate/files/usr/bin/bmx7-dnsupdate
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+. /usr/share/libubox/jshn.sh
+
+while true; do
+    json_load "$(bmx7 -c jshow=originators)"
+    json_select "originators"
+    idx="1"
+
+    # clean all bmx7 dns entries
+    > /tmp/hosts/bmx7
+
+    while json_get_type Type "$idx" && [ "$Type" == object ]; do
+        json_select "$idx"
+        json_get_var shortId shortId
+        json_get_var name name
+        json_get_var primaryIp primaryIp
+        printf "$primaryIp $name\n$primaryIp $shortId\n" >> /tmp/hosts/bmx7
+        json_select ..
+        $((idx++)) 2> /dev/null
+    done
+
+    # reload dnsmasq to apply changes
+    logger -t bmx7-dnsupdate "dnsmasq updated due to new hosts"
+    killall -HUP dnsmasq
+
+    # block until originators changes
+    inotifywait -e create -e delete -q /var/run/bmx7/json/originators/
+done


### PR DESCRIPTION
Maintainer: me
Compile tested: x86/64
Run tested: x86/64

Description:

Makes it easy to address bmx7 shorids and hostnames with ping, ssh, etc.
Both are stored in /tmp/hosts/ and so loaded by dnsmasq.
Instead of using a cron job which triggers the bmx7 deamon every so and
so, inotifywait is used to see creation or deletion of originators in
/var/run/bmx7/json/originators/

Signed-off-by: Paul Spooren <spooren@informatik.uni-leipzig.de>