### PR TITLE
tmux: update to 2.7

### DIFF
--- a/utils/tmux/Makefile
+++ b/utils/tmux/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tmux
-PKG_VERSION:=2.6
+PKG_VERSION:=2.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/tmux/tmux/releases/download/$(PKG_VERSION)
-PKG_HASH:=b17cd170a94d7b58c0698752e1f4f263ab6dc47425230df7e53a6435cc7cd7e8
+PKG_HASH:=9ded7d100313f6bc5a87404a4048b3745d61f2332f99ec1400a7c4ed9485d452
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 
 PKG_LICENSE:=ISC


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, Netgear WNDR3800, r6702-030a230)
Run tested: ar71xx, Netgear WNDR3800, r5501-30e18c8, basic run test

Description:
update to  2.7