### PR TITLE
getdns: Package update to replace libidn support with libidn2

### DIFF
--- a/libs/getdns/Config.in
+++ b/libs/getdns/Config.in
@@ -7,10 +7,10 @@ config GETDNS_ENABLE_STUB_ONLY
 		getdns can be configured for stub resolution mode only. (Removes libunbound dependency)
 	default y
 	
-config GETDNS_ENABLE_IDN_LIBIDN
-	bool "GETDNS_ENABLE_IDN_LIBIDN"
+config GETDNS_ENABLE_IDN_LIBIDN2
+	bool "GETDNS_ENABLE_IDN_LIBIDN2"
 	help 
-		getdns can be configured with some IDN Support. (Requires libidn dependency)
+		getdns can be configured with some IDN Support. (Requires libidn2 dependency)
 	default n
 
 endmenu

--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=getdns
 PKG_VERSION:=1.4.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -22,7 +22,7 @@ PKG_INSTALL:=1
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_GETDNS_ENABLE_STUB_ONLY \
-	CONFIG_GETDNS_ENABLE_IDN_LIBIDN 
+	CONFIG_GETDNS_ENABLE_IDN_LIBIDN2 
 	
 include $(INCLUDE_DIR)/package.mk
 
@@ -36,7 +36,7 @@ define Package/getdns
 	SECTION:=libs
 	CATEGORY:=Libraries
 	TITLE+= (library)
-	DEPENDS+= +libopenssl +!GETDNS_ENABLE_STUB_ONLY:libunbound +GETDNS_ENABLE_IDN_LIBIDN:libidn
+	DEPENDS+= +libopenssl +!GETDNS_ENABLE_STUB_ONLY:libunbound +GETDNS_ENABLE_IDN_LIBIDN2:libidn2
 	MENU:=1
 endef
 
@@ -51,8 +51,8 @@ endef
 
 CONFIGURE_ARGS += \
 		$(if $(CONFIG_GETDNS_ENABLE_STUB_ONLY), --enable-stub-only, ) \
-		$(if $(CONFIG_GETDNS_ENABLE_IDN_LIBIDN), , --without-libidn ) \
-		--without-libidn2 \
+		--without-libidn \
+		$(if $(CONFIG_GETDNS_ENABLE_IDN_LIBIDN2), , --without-libidn2 ) \
 		--with-ssl="$(STAGING_DIR)/usr" \
 
 define Build/InstallDev


### PR DESCRIPTION
Package update to replace libidn support with libidn2

Signed-off-by: David Mora <iamperson347+public@gmail.com>

Maintainer: me / @iamperson347
Compile tested: ar71xx, archer-c7, trunk
Run tested: same as above. Tested on personal Archer C7 v2. Functionality seems to be correct.

Description: Package update to replace libidn support with libidn2

References: https://github.com/openwrt/packages/pull/5864
https://github.com/openwrt/packages/pull/5878
