### PR TITLE
rp-pppoe: improve init scripts

### DIFF
--- a/net/rp-pppoe/Makefile
+++ b/net/rp-pppoe/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rp-pppoe
 PKG_VERSION:=3.12
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Daniel Dickinson <lede@cshore.thecshore.com>
 PKG_LICENSE:=LGPL-2.0+
 

--- a/net/rp-pppoe/files/pppoe-relay.init
+++ b/net/rp-pppoe/files/pppoe-relay.init
@@ -13,20 +13,14 @@ pppoe_triggers() {
     config_get server_interfaces "$cfg" server_interface
     config_get client_interfaces "$cfg" client_interface
     config_get both_interfaces "$cfg" both_interfaces
-    for interface in $server_interfaces; do
-	append interfaces "$interface" "|"
-    done
-    for interface in $client_interfaces; do
-	append interfaces "$interface" "|"
-    done
-    for interface in $both_interfaces; do
-	append interfaces "$interface" "|"
+    for interface in $server_interfaces $client_interfaces $both_interfaces; do
+	procd_add_reload_interface_trigger $interface
     done
 }
 
 pppoe_relay_instance() {
     local cfg="$1"
-    local enabled interface server_interfaces client_interfaces both_interfaces maxsessions timeout OPTIONS
+    local enabled interface device server_interfaces client_interfaces both_interfaces maxsessions timeout OPTIONS
     config_get_bool enabled "$cfg" enabled 1
     [ "$enabled" -gt 0 ] || return 0
     config_get server_interfaces "$cfg" server_interface
@@ -39,23 +33,34 @@ pppoe_relay_instance() {
     if [ "$use_non_uci_config" -gt 0 ]; then
 	. /etc/default/pppoe-relay
     else
-	[ -z "${server_interfaces}${client_interfaces}${both_interfaces}" ] && return 1
+	local NEED_INTFS=SC
+	. /lib/functions/network.sh
 	for interface in $server_interfaces; do
-	    append OPTIONS "-S $interface"
+	    if network_get_physdev device $interface; then
+		append OPTIONS "-S $device"
+		NEED_INTFS=${NEED_INTFS/S/}
+	    fi
 	done
 	for interface in $client_interfaces; do
-	    append OPTIONS "-C $interface"
+	    if network_get_physdev device $interface; then
+		append OPTIONS "-C $device"
+		NEED_INTFS=${NEED_INTFS/C/}
+	    fi
         done
 	for interface in $both_interfaces; do
-	    append OPTIONS "-B $interface"
+	    if network_get_physdev device $interface; then
+		append OPTIONS "-B $device"
+		NEED_INTFS=${NEED_INTFS/?/}
+	    fi
 	done
+	[ -z "${NEED_INTFS}" ] || return 1 # need at least 2 interfaces, one for server(s) and one for client(s)
 	[ -n "$maxsessions" ] && append OPTIONS "-n $maxsessions"
 	[ -n "$timeout" ] && append OPTIONS "-i $timeout"
     fi
 
     procd_open_instance
-    procd_set_param command /usr/sbin/pppoe-relay -F
-    procd_append_param command $OPTIONS
+    procd_set_param command /usr/sbin/pppoe-relay -F $OPTIONS
+    procd_set_param respawn
     procd_close_instance
 }
 
@@ -66,12 +71,9 @@ start_service() {
     config_foreach pppoe_relay_instance pppoe_relay
 }
 
-reload_triggers() {
-    local interfaces
+service_triggers() {
+    procd_add_reload_trigger "pppoe"
 
     config_load pppoe
     config_foreach pppoe_triggers pppoe_relay
-
-    procd_add_reload_trigger "pppoe"
-    procd_add_interface_trigger "$interfaces"
 }

--- a/net/rp-pppoe/files/pppoe-relay.init
+++ b/net/rp-pppoe/files/pppoe-relay.init
@@ -7,7 +7,9 @@ USE_PROCD=1
 
 pppoe_triggers() {
     local cfg="$1"
-    local interface server_interfaces client_interfaces both_interfaces
+    local enabled interface server_interfaces client_interfaces both_interfaces
+    config_get_bool enabled "$cfg" enabled 1
+    [ "$enabled" -gt 0 ] || return 0
     config_get server_interfaces "$cfg" server_interface
     config_get client_interfaces "$cfg" client_interface
     config_get both_interfaces "$cfg" both_interfaces
@@ -24,7 +26,9 @@ pppoe_triggers() {
 
 pppoe_relay_instance() {
     local cfg="$1"
-    local interface server_interfaces client_interfaces both_interfaces maxsessions timeout OPTIONS
+    local enabled interface server_interfaces client_interfaces both_interfaces maxsessions timeout OPTIONS
+    config_get_bool enabled "$cfg" enabled 1
+    [ "$enabled" -gt 0 ] || return 0
     config_get server_interfaces "$cfg" server_interface
     config_get client_interfaces "$cfg" client_interface
     config_get both_interfaces "$cfg" both_interfaces

--- a/net/rp-pppoe/files/pppoe-relay.init
+++ b/net/rp-pppoe/files/pppoe-relay.init
@@ -2,6 +2,7 @@
 # Copyright (C) 2006-2011 OpenWrt.org
 
 START=50
+STOP=50
 USE_PROCD=1
 
 pppoe_triggers() {
@@ -55,18 +56,18 @@ pppoe_relay_instance() {
 }
 
 start_service() {
-	local use_non_uci_config
+    local use_non_uci_config
 
-	config_load pppoe
-	config_foreach pppoe_relay_instance pppoe_relay
+    config_load pppoe
+    config_foreach pppoe_relay_instance pppoe_relay
 }
 
 reload_triggers() {
-	local interfaces
+    local interfaces
 
-	config_load pppoe
-	config_foreach pppoe_triggers pppoe_relay
+    config_load pppoe
+    config_foreach pppoe_triggers pppoe_relay
 
-	procd_add_reload_trigger "pppoe"
-	procd_add_interface_trigger "$interfaces"
+    procd_add_reload_trigger "pppoe"
+    procd_add_interface_trigger "$interfaces"
 }

--- a/net/rp-pppoe/files/pppoe-server.init
+++ b/net/rp-pppoe/files/pppoe-server.init
@@ -2,73 +2,74 @@
 # Copyright (C) 2006-2011 OpenWrt.org
 
 START=50
+STOP=50
 USE_PROCD=1
 
 pppoe_triggers() {
-	local cfg="$1"
-	local interface
-	config_get interface "$cfg" interface
+    local cfg="$1"
+    local interface
+    config_get interface "$cfg" interface
 }
 
 pppoe_instance() {
-	local cfg="$1"
-	local interface ac_name service_names service_name maxsessionsperpeer localip firstremoteip maxsessions optionsfiles randomsession unit offset timeout mss sync OPTIONS
-	config_get interface "$cfg" interface
-	config_get ac_name "$cfg" ac_name
-	config_get service_names "$cfg" service_name
-	config_get maxsessionsperpeer "$cfg" maxsessionsperpeer
-	config_get localip "$cfg" localip
-	config_get firstremoteip "$cfg" firstremoteip
-	config_get maxsessions "$cfg" maxsessions
-	config_get optionsfile "$cfg" optionsfile
-	config_get_bool randomsession "$cfg" randomsession 1
-	config_get_bool unit "$cfg" unit 0
-	config_get offset "$cfg" offset
-	config_get timeout "$cfg" timeout
-	config_get mss "$cfg" mss
-	config_get_bool sync "$cfg" sync 0
-	config_get use_non_uci_config "$cfg" use_non_uci_config 0
+    local cfg="$1"
+    local interface ac_name service_names service_name maxsessionsperpeer localip firstremoteip maxsessions optionsfiles randomsession unit offset timeout mss sync OPTIONS
+    config_get interface "$cfg" interface
+    config_get ac_name "$cfg" ac_name
+    config_get service_names "$cfg" service_name
+    config_get maxsessionsperpeer "$cfg" maxsessionsperpeer
+    config_get localip "$cfg" localip
+    config_get firstremoteip "$cfg" firstremoteip
+    config_get maxsessions "$cfg" maxsessions
+    config_get optionsfile "$cfg" optionsfile
+    config_get_bool randomsession "$cfg" randomsession 1
+    config_get_bool unit "$cfg" unit 0
+    config_get offset "$cfg" offset
+    config_get timeout "$cfg" timeout
+    config_get mss "$cfg" mss
+    config_get_bool sync "$cfg" sync 0
+    config_get use_non_uci_config "$cfg" use_non_uci_config 0
 
-	if [ "$use_non_uci_config" -gt 0 ]; then
-	    . /etc/default/pppoe-server
-        else
-	    [ -z "$interface" ] && return 1
-	    [ -n "$ac_name" ] && append OPTIONS "-C $ac_name"
-	    for service_name in $service_names; do
-		append OPTIONS "-S $service_name"
-	    done
-	    append OPTIONS "-I $interface"
-	    [ -n "$maxsessionsperpeer" ] && append OPTIONS "-x $maxsessionsperpeer"
-	    [ -n "$localip" ] && append OPTIONS "-L $localip"
-	    [ -n "$firstremoteip" ] && append OPTIONS "-R $firstremoteip"
-	    [ -n "maxsessions" ] && append OPTIONS "-N $maxsessions"
-	    [ -n "optionsfile" ] && append OPTIONS "-O $optionsfile"
-	    [ "$randomsession" = "1" ] && append OPTIONS "-r"
-	    [ "$unit" = "1" ] && append OPTIONS "-u"
-	    [ -n "$offset" ] && append OPTIONS "-o $offset"
-	    [ -n "$timeout" ] && append OPTIONS "-T $timeout"
-	    [ -n "$mss" ] && append OPTIONS "-m $mss"
-	    [ "$sync" = "1" ] && append OPTIONS "-s"
-	fi
+    if [ "$use_non_uci_config" -gt 0 ]; then
+	. /etc/default/pppoe-server
+    else
+	[ -z "$interface" ] && return 1
+	[ -n "$ac_name" ] && append OPTIONS "-C $ac_name"
+	for service_name in $service_names; do
+	    append OPTIONS "-S $service_name"
+	done
+	append OPTIONS "-I $interface"
+	[ -n "$maxsessionsperpeer" ] && append OPTIONS "-x $maxsessionsperpeer"
+	[ -n "$localip" ] && append OPTIONS "-L $localip"
+	[ -n "$firstremoteip" ] && append OPTIONS "-R $firstremoteip"
+	[ -n "maxsessions" ] && append OPTIONS "-N $maxsessions"
+	[ -n "optionsfile" ] && append OPTIONS "-O $optionsfile"
+	[ "$randomsession" = "1" ] && append OPTIONS "-r"
+	[ "$unit" = "1" ] && append OPTIONS "-u"
+	[ -n "$offset" ] && append OPTIONS "-o $offset"
+	[ -n "$timeout" ] && append OPTIONS "-T $timeout"
+	[ -n "$mss" ] && append OPTIONS "-m $mss"
+	[ "$sync" = "1" ] && append OPTIONS "-s"
+    fi
 
-	procd_open_instance
-	procd_set_param command /usr/sbin/pppoe-server -F
-	procd_append_param command -k $OPTIONS
-	procd_set_param file /etc/ppp/options
-	procd_append_param file /etc/ppp/pppoe-server-options
-	procd_close_instance
+    procd_open_instance
+    procd_set_param command /usr/sbin/pppoe-server -F
+    procd_append_param command -k $OPTIONS
+    procd_set_param file /etc/ppp/options
+    procd_append_param file /etc/ppp/pppoe-server-options
+    procd_close_instance
 }
 
 start_service() {
-	config_load pppoe
-	config_foreach pppoe_instance pppoe_server
+    config_load pppoe
+    config_foreach pppoe_instance pppoe_server
 }
 
 service_triggers() {
-	local interface
-	config_load pppoe
-	config_foreach pppoe_triggers pppoe_server
+    local interface
+    config_load pppoe
+    config_foreach pppoe_triggers pppoe_server
 
-	procd_add_reload_trigger "pppoe"
-	procd_add_interface_trigger "$interface"
+    procd_add_reload_trigger "pppoe"
+    procd_add_interface_trigger "$interface"
 }

--- a/net/rp-pppoe/files/pppoe-server.init
+++ b/net/rp-pppoe/files/pppoe-server.init
@@ -7,13 +7,17 @@ USE_PROCD=1
 
 pppoe_triggers() {
     local cfg="$1"
-    local interface
+    local enabled interface
+    config_get_bool enabled "$cfg" enabled 1
+    [ "$enabled" -gt 0 ] || return 0
     config_get interface "$cfg" interface
 }
 
 pppoe_instance() {
     local cfg="$1"
-    local interface ac_name service_names service_name maxsessionsperpeer localip firstremoteip maxsessions optionsfiles randomsession unit offset timeout mss sync OPTIONS
+    local enabled interface ac_name service_names service_name maxsessionsperpeer localip firstremoteip maxsessions optionsfiles randomsession unit offset timeout mss sync OPTIONS
+    config_get_bool enabled "$cfg" enabled 1
+    [ "$enabled" -gt 0 ] || return 0
     config_get interface "$cfg" interface
     config_get ac_name "$cfg" ac_name
     config_get service_names "$cfg" service_name
@@ -28,7 +32,7 @@ pppoe_instance() {
     config_get timeout "$cfg" timeout
     config_get mss "$cfg" mss
     config_get_bool sync "$cfg" sync 0
-    config_get use_non_uci_config "$cfg" use_non_uci_config 0
+    config_get_bool use_non_uci_config "$cfg" use_non_uci_config 0
 
     if [ "$use_non_uci_config" -gt 0 ]; then
 	. /etc/default/pppoe-server

--- a/net/rp-pppoe/files/pppoe-server.init
+++ b/net/rp-pppoe/files/pppoe-server.init
@@ -11,11 +11,12 @@ pppoe_triggers() {
     config_get_bool enabled "$cfg" enabled 1
     [ "$enabled" -gt 0 ] || return 0
     config_get interface "$cfg" interface
+    procd_add_reload_interface_trigger $interface
 }
 
 pppoe_instance() {
     local cfg="$1"
-    local enabled interface ac_name service_names service_name maxsessionsperpeer localip firstremoteip maxsessions optionsfiles randomsession unit offset timeout mss sync OPTIONS
+    local enabled interface device ac_name service_names service_name maxsessionsperpeer localip firstremoteip maxsessions optionsfiles randomsession unit offset timeout mss sync OPTIONS
     config_get_bool enabled "$cfg" enabled 1
     [ "$enabled" -gt 0 ] || return 0
     config_get interface "$cfg" interface
@@ -37,12 +38,13 @@ pppoe_instance() {
     if [ "$use_non_uci_config" -gt 0 ]; then
 	. /etc/default/pppoe-server
     else
-	[ -z "$interface" ] && return 1
+	. /lib/functions/network.sh
+	network_get_physdev device $interface || return 1
 	[ -n "$ac_name" ] && append OPTIONS "-C $ac_name"
 	for service_name in $service_names; do
 	    append OPTIONS "-S $service_name"
 	done
-	append OPTIONS "-I $interface"
+	append OPTIONS "-I $device"
 	[ -n "$maxsessionsperpeer" ] && append OPTIONS "-x $maxsessionsperpeer"
 	[ -n "$localip" ] && append OPTIONS "-L $localip"
 	[ -n "$firstremoteip" ] && append OPTIONS "-R $firstremoteip"
@@ -57,8 +59,8 @@ pppoe_instance() {
     fi
 
     procd_open_instance
-    procd_set_param command /usr/sbin/pppoe-server -F
-    procd_append_param command -k $OPTIONS
+    procd_set_param command /usr/sbin/pppoe-server -F -k $OPTIONS
+    procd_set_param respawn
     procd_set_param file /etc/ppp/options
     procd_append_param file /etc/ppp/pppoe-server-options
     procd_close_instance
@@ -70,10 +72,8 @@ start_service() {
 }
 
 service_triggers() {
-    local interface
+    procd_add_reload_trigger "pppoe"
+
     config_load pppoe
     config_foreach pppoe_triggers pppoe_server
-
-    procd_add_reload_trigger "pppoe"
-    procd_add_interface_trigger "$interface"
 }


### PR DESCRIPTION
Input interface parameters using their netifd logical names, fix
interface triggers and add enable boolean parameter in
pppoe_{server,relay} UCI sections.

Signed-off-by: Alin Nastac <alin.nastac@gmail.com>

Maintainer: Daniel Dickinson <lede@cshore.thecshore.com>
Run tested: arm_cortex-a9 openwrt/chaos_calmer
