### PR TITLE
bcp38: add init script

### DIFF
--- a/net/bcp38/Makefile
+++ b/net/bcp38/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcp38
 PKG_VERSION:=5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENCE:=GPL-3.0+
 
 include $(INCLUDE_DIR)/package.mk
@@ -50,6 +50,8 @@ define Package/bcp38/install
 	$(INSTALL_BIN) ./files/run.sh $(1)/usr/lib/bcp38/run.sh
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/bcp38.defaults $(1)/etc/uci-defaults/bcp38
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/bcp38.init $(1)/etc/init.d/bcp38
 endef
 
 define Package/bcp38/postinst

--- a/net/bcp38/files/bcp38.init
+++ b/net/bcp38/files/bcp38.init
@@ -1,0 +1,11 @@
+#!/bin/sh /etc/rc.common
+
+START=20
+
+USE_PROCD=1
+NAME=bcp38
+
+service_triggers()
+{
+	procd_add_config_trigger "config.change" "bcp38" /etc/init.d/firewall reload
+}


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: OpenWrt r6728-8ffd06dd4e
Run tested: LEDE SNAPSHOT r4497+16-a73471dea7 x86/64

Description:

This commit adds a simple procd init script for bcp38 with the sole purpose
to register a configuration change trigger for /etc/config/bcp38.

The change will allow for automatic firewall reloads triggered by invoking
/sbin/reload_config or through ubus config change events emitted by LuCI.

With the init script in place and started, calling

  ubus call service event '{"type":"config.change","data":{"package":"bcp38"}}'

or

  /sbin/reload_config

will issue an /etc/init.d/firewall reload if /etc/config/bcp38 has been
modified since the last reload_config call.