### PR TITLE
ddns-scripts: fixes "sed: no previous regexp"

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.7
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -262,9 +262,9 @@ write_log() {
 	[ $VERBOSE -gt 0 -o $__EXIT -gt 0 ] && echo -e "$__MSG"
 	# write to logfile
 	if [ ${use_logfile:-1} -eq 1 -o $VERBOSE -gt 1 ]; then
-		printf "%s\n" "$__MSG" | \
-			sed -e "s/$password/*password*/g; \
-				s/$URL_PASS/*URL_PASS*/g" >> $LOGFILE
+		[ -n "$password" ] && __MSG=$( printf "%s" "$__MSG" | sed -e "s/$password/*password*/g" )
+		[ -n "$URL_PASS" ] && __MSG=$( printf "%s" "$__MSG" | sed -e "s/$URL_PASS/*URL_PASS*/g" )
+		printf "%s\n" "$__MSG" >> $LOGFILE
 		# VERBOSE > 1 then NO loop so NO truncate log to $ddns_loglines lines
 		[ $VERBOSE -gt 1 ] || sed -i -e :a -e '$q;N;'$ddns_loglines',$D;ba' $LOGFILE
 	fi


### PR DESCRIPTION
Maintainer: me
Compile tested: LEDE 17.01.4 / x86
Run tested: OpenWrt 15.05 / WNDR3800

Description:
Rewritten Pull for #5885

When ran from the command line, the script prints
error messages like below. They are caused by supplying
empty "$password" and "$URL_PASS" for some log messages
like "130822       : Detect local IP on 'interface'".
The fix is to check if the values are not empty before running
through sed.

/etc/init.d/ddns start
sed: no previous regexp

Reported by Marc Benoit <<marcb62185@gmail.com>>

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>
