### PR TITLE
bmx7-dnsupdate: wait 10 secs if bmx7 ins't running

### DIFF
--- a/utils/bmx7-dnsupdate/Makefile
+++ b/utils/bmx7-dnsupdate/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bmx7-dnsupdate
 PKG_VERSION:=0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/utils/bmx7-dnsupdate/files/usr/bin/bmx7-dnsupdate
+++ b/utils/bmx7-dnsupdate/files/usr/bin/bmx7-dnsupdate
@@ -25,5 +25,5 @@ while true; do
     killall -HUP dnsmasq
 
     # block until originators changes
-    inotifywait -e create -e delete -q /var/run/bmx7/json/originators/
+    inotifywait -e create -e delete -q /var/run/bmx7/json/originators/ || sleep 10
 done


### PR DESCRIPTION
Maintainer: me 
Compile tested: x86/64
Run tested: x86/64

Description:
If bmx7 isn't running just yet the folder
`/var/run/bmx7/json/originators` is missing and so the while loop runs
non stop. Now the loop sleeps for 10 seconds if inotifywait fails.

Signed-off-by: Paul Spooren <spooren@informatik.uni-leipzig.de>
