### PR TITLE
shairport-sync: Support ALSA mixer index in UCI configuration

### DIFF
--- a/sound/shairport-sync/files/shairport-sync.config
+++ b/sound/shairport-sync/files/shairport-sync.config
@@ -44,6 +44,7 @@ config shairport-sync 'shairport_sync'
 	option alsa_output_device '' # default
 	option alsa_mixer_control_name '' # PCM
 	option alsa_mixer_device '' # default
+	option alsa_mixer_index '' # 0
 	option alsa_latency_offset '' # 0
 	option alsa_buffer_length '' # 6615
 	option alsa_disable_synchronization '' # no/yes

--- a/sound/shairport-sync/files/shairport-sync.init
+++ b/sound/shairport-sync/files/shairport-sync.init
@@ -126,6 +126,9 @@ start_instance() {
 	procd_set_param command /usr/bin/shairport-sync
 	procd_append_param command -c $conf_file
 
+	config_get aux "$cfg" 'alsa_mixer_index' '0'
+	[ $conf_custom -ne 1 ] && [ "$aux" -gt 0 ] && procd_append_param command -- -i $aux
+
 	config_get_bool aux "$cfg" 'respawn' '0'
 	[ "$aux" = 1 ] && procd_set_param respawn
 


### PR DESCRIPTION
Maintainer: Ted Hess <thess@kitschensync.net>, \
                Mike Brady <mikebrady@eircom.net>
Compile tested: mpc85xx, LEDE HEAD
Run tested: tested: mpc85xx, LEDE HEAD
Tested with 'alsa_mixer_index' '0', 'alsa_mixer_index' '1'

Description:
shairport-sync only supports ALSA mixer index setting via run-time arguments and not reading it from a config file. Update the init script and config file to support this.

Signed-off-by: Andrew Yong <me@ndoo.sg>