### PR TITLE
snort: set configuration file path in init script

### DIFF
--- a/net/snort/files/snort.init
+++ b/net/snort/files/snort.init
@@ -22,7 +22,7 @@ start_service() {
 	}
 
 	procd_open_instance
-	procd_set_param command $PROG "-q" "--daq-dir" "/usr/lib/daq/" "-i" "$interface" "-s" "-N"
+	procd_set_param command $PROG "-q" "--daq-dir" "/usr/lib/daq/" "-i" "$interface" "-c" "$config_file" "-s" "-N"
 	procd_set_param file $CONFIGFILE
 	procd_set_param respawn
 	procd_close_instance


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64, OpenWrt commit 267873ac

Description:
snort: set configuration file path in init script

Without this change, Snort seems to ignore /etc/snort/snort.conf or whatever is listed in /etc/config/snort's config_file parameter.

Previously #5629, but removing/updating the branch closed that request.