### PR TITLE
libdaq: update hash and change maintainer

### DIFF
--- a/libs/libdaq/Makefile
+++ b/libs/libdaq/Makefile
@@ -9,16 +9,16 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdaq
 PKG_VERSION:=2.0.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://www.snort.org/downloads/snort/ \
 	@SF/snort
 PKG_SOURCE:=daq-$(PKG_VERSION).tar.gz
-PKG_HASH:=b40e1d1273e08aaeaa86e69d4f28d535b7e53bdb3898adf539266b63137be7cb
+PKG_HASH:=d41da5f7793e66044e6927dd868c0525e7ee4ec1a3515bf74ef9a30cd9273af0
 PKG_BUILD_DIR:=$(BUILD_DIR)/daq-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-2.0
-PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>
+PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: Atheros AR7xxx/AR9xxx, OpenWrt commit ed4ac0ed
Description:
libdaq: update hash and change maintainer
