### PR TITLE
[lang/luasocket] patch: fix #5754 stack check fail build socket.so

### DIFF
--- a/lang/luasocket/Makefile
+++ b/lang/luasocket/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=luasocket
 PKG_SOURCE_VERSION:=6d5e40c324c84d9c1453ae88e0ad5bdd0a631448
 PKG_VERSION:=3.0-rc1-20130909
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/diegonehab/luasocket.git

--- a/lang/luasocket/patches/0002-build-fix-stack-chk-fail-socket.patch
+++ b/lang/luasocket/patches/0002-build-fix-stack-chk-fail-socket.patch
@@ -1,0 +1,30 @@
+ src/makefile | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/makefile b/src/makefile
+index 09d4882..e44837b 100644
+--- a/src/makefile
++++ b/src/makefile
+@@ -345,18 +345,18 @@ none:
+ all: $(SOCKET_SO) $(MIME_SO)
+ 
+ $(SOCKET_SO): $(SOCKET_OBJS)
+-	$(LD) $(SOCKET_OBJS) $(LDFLAGS)$@
++	$(CC) $(SOCKET_OBJS) $(LDFLAGS)$@
+ 
+ $(MIME_SO): $(MIME_OBJS)
+-	$(LD) $(MIME_OBJS) $(LDFLAGS)$@
++	$(CC) $(MIME_OBJS) $(LDFLAGS)$@
+ 
+ all-unix: all $(UNIX_SO) $(SERIAL_SO)
+ 
+ $(UNIX_SO): $(UNIX_OBJS)
+-	$(LD) $(UNIX_OBJS) $(LDFLAGS)$@
++	$(CC) $(UNIX_OBJS) $(LDFLAGS)$@
+ 
+ $(SERIAL_SO): $(SERIAL_OBJS)
+-	$(LD) $(SERIAL_OBJS) $(LDFLAGS)$@
++	$(CC) $(SERIAL_OBJS) $(LDFLAGS)$@
+ 
+ install: 
+ 	$(INSTALL_DIR) $(INSTALL_TOP_LDIR)


### PR DESCRIPTION
Maintainer: @MikePetullo
Compile _not_ tested: please build for x86/geode (32-bit) LEDE
Description:
```
options.o:/home/builder/lime-sdk/ \
17.01.4/x86/geode/sdk/build_dir/target-i386_pentium_musl-1.1.16/ \
luasocket-3.0-rc1-20130909/src/options.c:61: more undefined \
references to `__stack_chk_fail_local' follow
makefile:348: recipe for target 'socket.so.3.0-rc1' failed
make[6]: *** [socket.so.3.0-rc1] Error 1
```

