### PR TITLE
gcc: enable compilation with gcc 7.x

### DIFF
--- a/devel/gcc/Makefile
+++ b/devel/gcc/Makefile
@@ -23,6 +23,13 @@ TARGET_LANGUAGES:="c,c++"
 BUGURL=https://dev.openwrt.org/
 PKGVERSION=OpenWrt GCC $(PKG_VERSION)
 
+# this flag needs to be prepended, so I'll add it to CXX
+TARGET_CXX+= -std=gnu++03
+TARGET_CPPFLAGS+= -D_GLIBCXX_INCLUDE_NEXT_C_HEADERS
+CONFIGURE_ARGS+= \
+	CXX_FOR_TARGET="$(TARGET_CXX)" \
+	CXXFLAGS_FOR_TARGET="-g -O2 -D_GLIBCXX_INCLUDE_NEXT_C_HEADERS"
+
 # not using sstrip here as this fucks up the .so's somehow
 STRIP:=$(TOOLCHAIN_DIR)/bin/$(TARGET_CROSS)strip
 RSTRIP:= \


### PR DESCRIPTION
Maintainer: Noble Pepper <gccmaintain@noblepepper.com>
Compile tested: mipsel_mips32_musl, mipsel_74kc_musl, arm_cortex-a9_musl / OpenWrt master f5195e72c0fcf2949f7d6296a5db081eb58f8e32
Run tested: mipsel_74kc_musl / OpenWrt master / ASUS RT-N56U

Description:
Defining _GLIBCXX_INCLUDE_NEXT_C_HEADERS instructs gcc 7.x libstdc++ to include the system's stdlib.h and math.h, and not their own.

Signed-off-by: Eneas Queiroz <cote2004-github@yahoo.com>