### PR TITLE
python/python3: remove zlib/host dependency

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -40,7 +40,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PYTHON_BLUETOOTH_SUPPORT
 
 PKG_BUILD_DEPENDS:=python/host
-HOST_BUILD_DEPENDS:=bzip2/host expat/host zlib/host
+HOST_BUILD_DEPENDS:=bzip2/host expat/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -43,7 +43,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PYTHON3_BLUETOOTH_SUPPORT
 
 PKG_BUILD_DEPENDS:=python3/host
-HOST_BUILD_DEPENDS:=bzip2/host expat/host libffi/host zlib/host
+HOST_BUILD_DEPENDS:=bzip2/host expat/host libffi/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: lantiq
Run tested: no

zlib is now a host tool and the zlib/host package was removed. this
dependency is not needed any more as there will always be a zlib host
library.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>