### PR TITLE
mariadb: fix sporadic build failure

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -24,7 +24,8 @@ PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
 HOST_BUILD_DEPENDS:=libxml2/host
-PKG_BUILD_DEPENDS:=mariadb/host
+# Without libevent2 tests/async_queries sporadically fails on the bots
+PKG_BUILD_DEPENDS:=libevent2 mariadb/host
 
 CMAKE_INSTALL:=1
 


### PR DESCRIPTION
Observed once in about two dozen builds on the bots:

`make[6]: *** No rule to make target '/build/lede-snapshots/arm_cortex-a7_neon-vfpv4/build/sdk/staging_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/usr/lib/libevent.so', needed by 'tests/async_queries'.  Stop.`

Address this by adding libevent2 to PKG_BUILD_DEPENDS.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: mips24_kc
Run tested: N/A

Description:
Fix sporadic build failure happening on the build bots.