### PR TITLE
collectd: enable mysql plugin

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.8.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \
@@ -366,7 +366,7 @@ $(eval $(call BuildPlugin,match-hashed,hashed match,match_hashed,))
 $(eval $(call BuildPlugin,match-regex,regex match,match_regex,))
 $(eval $(call BuildPlugin,match-timediff,timediff match,match_timediff,))
 $(eval $(call BuildPlugin,match-value,value match,match_value,))
-#$(eval $(call BuildPlugin,mysql,MySQL status input,mysql,+PACKAGE_collectd-mod-mysql:libmysqlclient-r))
+$(eval $(call BuildPlugin,mysql,MySQL status input,mysql,+PACKAGE_collectd-mod-mysql:libmysqlclient-r))
 $(eval $(call BuildPlugin,memory,physical memory usage input,memory,))
 $(eval $(call BuildPlugin,modbus,read variables through libmodbus,modbus,+PACKAGE_collectd-mod-modbus:libmodbus))
 $(eval $(call BuildPlugin,mqtt,transmit data with MQTT,mqtt,+PACKAGE_collectd-mod-mqtt:libmosquitto))


### PR DESCRIPTION
Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @hnyman @jow- 
Compile tested: mips24kc
Run tested: N/A

Description:
Hi Hannu and Jo,

I saw that the mysql plugin is commented out. I enabled it on current master checkout and it compiled OK against MariaDB (libmariadbclient, which is threadsafe).

```
sk@hotdamn ~/tmp/openwrt/bin/packages/mips_24kc/packages/test $ cat control|grep Dep
Depends: libc, collectd, libmysqlclient-r
sk@hotdamn ~/tmp/openwrt/bin/packages/mips_24kc/packages/test $ readelf -d usr/lib/collectd/mysql.so |grep mysql
 0x00000001 (NEEDED)                     Shared library: [libmysqlclient.so.18]
 0x0000000e (SONAME)                     Library soname: [mysql.so]
sk@hotdamn ~/tmp/openwrt/bin/packages/mips_24kc/packages/test $
```

The dep on libmysqlclient-r does not need changing as libmariadbclient PROVIDES both libmysqlclient and libmysqlclient-r.

If you find the time maybe one of you can merge PR #5976 for me as I don't have commit access to openwrt/packages. Thanks!

Kind regards,
Seb