### PR TITLE
alsa-lib: Update to 1.1.6

### DIFF
--- a/libs/alsa-lib/Makefile
+++ b/libs/alsa-lib/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alsa-lib
-PKG_VERSION:=1.1.5
+PKG_VERSION:=1.1.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=ftp://ftp.alsa-project.org/pub/lib/ \
 		http://distfiles.gentoo.org/distfiles/
 
-PKG_HASH:=f4f68ad3c6da36b0b5241ac3c798a7a71e0e97d51f972e9f723b3f20a9650ae6
+PKG_HASH:=5f2cd274b272cae0d0d111e8a9e363f08783329157e8dd68b3de0c096de6d724
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Peter Wagner <tripolar@gmx.at>
 


### PR DESCRIPTION
Maintainer: @tripolar @thess 
Compile tested: 
mvebu, Linksys WRT3200ACM, OpenWrt master
ramips, D-Link DIR-860L, OpenWrt master
Run tested: 
mvebu, Linksys WRT3200ACM, OpenWrt master
ramips, D-Link DIR-860L, OpenWrt master

Description:
Update alsa-lib to 1.1.6

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>