### PR TITLE
gammu: fix mysql depend

### DIFF
--- a/utils/gammu/Makefile
+++ b/utils/gammu/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gammu
 PKG_VERSION:=1.38.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://dl.cihar.com/gammu/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -31,7 +31,7 @@ define Package/gammu
 	URL:=http://dl.cihar.com/gammu/releases/
 	DEPENDS:=+libpthread +libcurl +glib2 $(ICONV_DEPENDS) $(INTL_DEPENDS)
 	DEPENDS+=+PACKAGE_python:python +PACKAGE_bluez-libs:bluez-libs
-	DEPENDS+=+PACKAGE_libmysqlclient:libmysqlclient +PACKAGE_unixodbc:unixodbc +PACKAGE_libpq:libpq
+	DEPENDS+=+PACKAGE_libmariadbclient:libmariadbclient +PACKAGE_unixodbc:unixodbc +PACKAGE_libpq:libpq
 	DEPENDS+=+PACKAGE_libusb-1.0:libusb-1.0
 endef
 


### PR DESCRIPTION
mysql was replaced by mariadb. The lazy dependency
"+PACKAGE_libmysqlclient:libmysqlclient" does not work anymore as
"PACKAGE_libmysqlclient" no longer exists. This results in:

```
Package gammu is missing dependencies for the following libraries:
libmysqlclient.so.18

```
This commit addresses that.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @aTanW 
Compile tested: mips24_kc
Run tested: N/A

Description:
Fix the fallout from recent mysql replacement.