### PR TITLE
Perl update 5.26.2

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl
-PKG_VERSION:=5.26.1
-PKG_RELEASE:=3
+PKG_VERSION:=5.26.2
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \
@@ -19,7 +19,7 @@ PKG_SOURCE_URL:=\
 		https://mirrors.sonic.net/cpan/src/5.0 \
 		https://www.cpan.org/src/5.0
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=fe8208133e73e47afc3251c08d2c21c5a60160165a8ab8b669c43a420e4ec680
+PKG_HASH:=0f8c0fb1b0db4681adb75c3ba0dd77a0472b1b359b9e80efd79fc27b4352132c
 
 PKG_LICENSE:=GPL-1.0+ Artistic-1.0-Perl
 PKG_LICENSE_FILES:=Copying Artistic README

--- a/lang/perl/files/version.config
+++ b/lang/perl/files/version.config
@@ -1,7 +1,7 @@
 # Set the version here
 PERL_REVISION=5
 PERL_VERSION=26
-PERL_SUBVERSION=1
+PERL_SUBVERSION=2
 
 # (api_revison, api_version, api_subversion) = (revision, version, 0) usually
 PERL_API_REVISION=5

--- a/lang/perl/patches/010-musl-compat.patch
+++ b/lang/perl/patches/010-musl-compat.patch
@@ -1,11 +1,11 @@
---- a/pp.c
-+++ b/pp.c
-@@ -43,7 +43,7 @@ extern Pid_t getpid (void);
-  * Some BSDs and Cygwin default to POSIX math instead of IEEE.
-  * This switches them over to IEEE.
-  */
--#if defined(LIBM_LIB_VERSION)
-+#if defined(LIBM_LIB_VERSION) && (defined(__GLIBC__) || defined(__UCLIBC__))
-     _LIB_VERSION_TYPE _LIB_VERSION = _IEEE_;
+--- a/perl.c
++++ b/perl.c
+@@ -286,7 +286,7 @@ perl_construct(pTHXx)
+     PL_localpatches = local_patches;	/* For possible -v */
  #endif
  
+-#if defined(LIBM_LIB_VERSION)
++#if defined(LIBM_LIB_VERSION) && (defined(__GLIBC__) || defined(__UCLIBC__))
+     /*
+      * Some BSDs and Cygwin default to POSIX math instead of IEEE.
+      * This switches them over to IEEE.

--- a/lang/perl/patches/120-remove-build-timestamp.patch
+++ b/lang/perl/patches/120-remove-build-timestamp.patch
@@ -2,7 +2,7 @@ Index: perl-5.26.1/perl.c
 ===================================================================
 --- perl-5.26.1.orig/perl.c
 +++ perl-5.26.1/perl.c
-@@ -1870,16 +1870,6 @@ S_Internals_V(pTHX_ CV *cv)
+@@ -1878,16 +1878,6 @@ S_Internals_V(pTHX_ CV *cv)
      PUSHs(Perl_newSVpvn_flags(aTHX_ non_bincompat_options,
  			      sizeof(non_bincompat_options) - 1, SVs_TEMP));
  

--- a/lang/perl/patches/910-miniperl-needs-inc-dot.patch
+++ b/lang/perl/patches/910-miniperl-needs-inc-dot.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.SH	2017-10-15 18:57:08.436234652 -0600
 +++ b/Makefile.SH	2017-10-15 19:02:47.587658819 -0600
-@@ -327,7 +327,7 @@ PATH_SEP = $p_
+@@ -328,7 +328,7 @@ PATH_SEP = $p_
  # Macros to invoke a copy of miniperl during the build.  Targets which
  # are built using these macros should depend on \$(MINIPERL_EXE)
  MINIPERL_EXE = miniperl\$(EXE_EXT)
@@ -9,7 +9,7 @@
  
  # Macros to invoke sort the MANIFEST during build
  MANIFEST_SRT = MANIFEST.srt
-@@ -990,7 +990,7 @@ NAMESPACEFLAGS = -force_flat_namespace
+@@ -991,7 +991,7 @@ NAMESPACEFLAGS = -force_flat_namespace
  	@$(RMS) miniperl.xok
  	$(CC) $(CLDFLAGS) $(NAMESPACEFLAGS) -o $(MINIPERL_EXE) \
  	    $(miniperl_objs) $(libs)
@@ -18,7 +18,7 @@
  	$(MINIPERL) -f write_buildcustomize.pl
  !NO!SUBS!
  		;;
-@@ -1001,16 +1001,16 @@ lib/buildcustomize.pl: $& $(miniperl_obj
+@@ -1002,16 +1002,16 @@ lib/buildcustomize.pl: $& $(miniperl_obj
  	@\$(RMS) miniperl.xok
  	@\$(RMS) \$(MINIPERL_EXE)
  	\$(LNS) \$(HOST_PERL) \$(MINIPERL_EXE)


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, generic, HEAD (097f3aa)
Run tested: same

Built perl `.ipk` for and installed on test router.  Passes basic sanity.

Description: