### PR TITLE
isc-dhcp: update to 4.4.1

### DIFF
--- a/net/isc-dhcp/Makefile
+++ b/net/isc-dhcp/Makefile
@@ -9,8 +9,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=isc-dhcp
 UPSTREAM_NAME:=dhcp
-PKG_VERSION:=4.4.0
-PKG_RELEASE:=4
+PKG_VERSION:=4.4.1
+PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -20,7 +20,7 @@ PKG_SOURCE:=$(UPSTREAM_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.isc.org/isc/dhcp/$(PKG_VERSION) \
 		http://ftp.funet.fi/pub/mirrors/ftp.isc.org/isc/dhcp/$(PKG_VERSION) \
 		http://ftp.iij.ad.jp/pub/network/isc/dhcp/$(PKG_VERSION)
-PKG_HASH:=4a90be0f22ad81c987f5584661b60a594f1b21c581b82bfba3ae60f89ae44397
+PKG_HASH:=2a22508922ab367b4af4664a0472dc220cc9603482cf3c16d9aff14f3a76b608
 
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, generic, HEAD (097f3aa)
Run tested: x86_64, generic, HEAD (097f3aa)

Built `.ipk` files, copied to and installed on test router, restarted `dhcpd` service.

Description: