### PR TITLE
Update Makefile

### DIFF
--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tvheadend
-PKG_VERSION:=4.0.9
+PKG_VERSION:=4.0.10
 PKG_RELEASE:=1
 
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz
-PKG_MIRROR_HASH:=c18e3803d6e36348442ccf3b0ac4868948692491c7dd646d48576f5aec09cdd8
+PKG_MIRROR_HASH:=48f3f0be217245922072075410991e59c869462ef9de052d879e54819c5d48b0
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/tvheadend/tvheadend.git
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
@@ -96,4 +96,5 @@ define Package/tvheadend/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build.linux/tvheadend $(1)/usr/bin/
 endef
 
+TARGET_CFLAGS += -Wno-error=pointer-compare
 $(eval $(call BuildPackage,tvheadend))


### PR DESCRIPTION
Update tvheadend to 4.010
added TARGET_CFLAGS += -Wno-error=pointer-compare for GCC 7.

Maintainer: sairon? thess? champtar? @<github-user> 
Compile tested: (ramips/mt7621, Xiaomi WiFi Router 3G, OpenWrt SNAPSHOT r6772-6fa88be486 )
Run tested: (ramips/mt7621, Xiaomi WiFi Router 3G, OpenWrt SNAPSHOT r6772-6fa88be486)

Description:
Update of tvheadend to 4.010.