### PR TITLE
prometheus-node-exporter-lua: add openwrt exporter

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2017.12.08
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Christian Simon <simon@swine.de>
 PKG_LICENSE:=Apache-2.0
@@ -76,6 +76,11 @@ define Package/prometheus-node-exporter-lua-textfile
   DEPENDS:=prometheus-node-exporter-lua +luci-lib-nixio
 endef
 
+define Package/prometheus-node-exporter-lua-openwrt
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (openwrt collector)
+endef
+
 Build/Compile=
 
 define Package/prometheus-node-exporter-lua/install
@@ -130,6 +135,11 @@ define Package/prometheus-node-exporter-lua-textfile/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/textfile.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
+define Package/prometheus-node-exporter-lua-openwrt/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/openwrt.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
 $(eval $(call BuildPackage,prometheus-node-exporter-lua))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-nat_traffic))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-netstat))
@@ -138,3 +148,4 @@ $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi_stations))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx6))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx7))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-textfile))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-openwrt))

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/openwrt.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/openwrt.lua
@@ -1,0 +1,24 @@
+local labels = {
+    id = "",
+    release = "",
+    revision = "",
+    model = string.sub(get_contents("/tmp/sysinfo/model"), 1, -2),
+    board_name = string.sub(get_contents("/tmp/sysinfo/board_name"), 1, -2)
+}
+
+for k, v in string.gmatch(get_contents("/etc/openwrt_release"), "(DISTRIB_%w+)='(%w+)'\n") do
+    if k == "DISTRIB_ID" then
+        labels["id"] = v
+    elseif k == "DISTRIB_RELEASE" then
+        labels["release"] = v
+    elseif k == "DISTRIB_REVISION" then
+        labels["revision"] = v
+    end
+end
+
+local function scrape()
+    metric("node_openwrt_info", "gauge", labels, 1)
+end
+
+return { scrape = scrape }
+


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested: x86/64
Run tested: x86/64

Description:

adds openwrt specific information about the device.
include DISTRIB_{ID, RELEASE, REVISION}, board_name and model

Example output:

    # TYPE node_openwrt_info gauge
    node_openwrt_info{revision="55a0636",model="QEMU Standard PC (i440FX + PIIX, 1996)",id="LiMe",board_name="qemu-standard-pc-i440fx-piix-1996",release="snapshot"} 1
    node_scrape_collector_duration_seconds{collector="openwrt"} 3.814697265625e-05
    node_scrape_collector_success{collector="openwrt"} 1

Signed-off-by: Paul Spooren <spooren@informatik.uni-leipzig.de>
