### PR TITLE
mariadb: install staging libs to lib/mysql as well

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
 PKG_VERSION:=10.1.32
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
@@ -417,11 +417,12 @@ define Host/Install
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(2)/bin $(1)/usr/bin $(1)/usr/include $(1)/usr/lib/pkgconfig $(1)/usr/share/aclocal
+	$(INSTALL_DIR) $(2)/bin $(1)/usr/bin $(1)/usr/include $(1)/usr/lib/mysql $(1)/usr/lib/pkgconfig $(1)/usr/share/aclocal
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mysql_config $(1)/usr/bin/
 	$(LN) $(STAGING_DIR)/usr/bin/mysql_config $(2)/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/mysql $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmysqlclient*.so* $(1)/usr/lib/
+	$(LN) --relative $(1)/usr/lib/libmysqlclient*.so* $(1)/usr/lib/mysql/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/pkgconfig/mariadb.pc $(1)/usr/lib/pkgconfig
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/aclocal/mysql.m4 $(1)/usr/share/aclocal
 endef


### PR DESCRIPTION
Historically programs added /usr/lib/mysql to the library search path when
linking. mariadb does not do so anymore, although even its mysql_config
script suggests to use this path. When an old version of the library still
resides in this directory (like from an old mysql installation) it will be
linked against instead of the current library which is in /usr/lib.

To prevent this simply install the libs to /usr/lib/mysql in the staging
directory as well. This fixes build failures on the build bots which are
seen with libzdb and libdbi-drivers.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: x86_64
Run tested: N/A

Description:
Fix some fallout, i.e. the compile failures for libzdb and libdbi-drivers.

@hnyman and @jow- I would grateful if you could merge this as I don't have commit rights.

Thanks!

Kind regards,
Seb