### PR TITLE
mariadb: create symlinks in a portable way

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -422,7 +422,7 @@ define Build/InstallDev
 	$(LN) $(STAGING_DIR)/usr/bin/mysql_config $(2)/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/mysql $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmysqlclient*.so* $(1)/usr/lib/
-	$(LN) --relative $(1)/usr/lib/libmysqlclient*.so* $(1)/usr/lib/mysql/
+	cd $(1)/usr/lib/mysql; $(LN) ../libmysqlclient*.so* .
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/pkgconfig/mariadb.pc $(1)/usr/lib/pkgconfig
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/aclocal/mysql.m4 $(1)/usr/share/aclocal
 endef


### PR DESCRIPTION
Hannu mentioned that --recursive could not be available always. That is
correct. While GNU coreutils' ln supports this, BSD's ln for example does
not.

This commit addresses that.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: x86_64
Run tested: N/A

Description:
Hi @hnyman 

I did some digging to find out if --recursive is always support or not. You were right, of course, it is not. Let's do it in a portable fashion like you suggested.

Apologies for the noise!

Best regards,
Seb