### PR TITLE
3proxy: Add to repo

### DIFF
--- a/net/3proxy/Makefile
+++ b/net/3proxy/Makefile
@@ -1,0 +1,95 @@
+#
+# Copyright (C) 2018 Daniel Engberg <daniel.engberg.lists@pyret.net>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=3proxy
+PKG_VERSION:=0.9-devel
+PKG_RELEASE:=1
+PKG_MAINTAINER:=
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE_URL:=https://codeload.github.com/z3APA3A/$(PKG_NAME)/tar.gz/68823c2?dummy=/
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-68823c2.tar.gz
+PKG_HASH:=c8f6e8bdf8fc71e02a8cb2512009966d6148d7f82f9fe40ed710624390e3ab7a
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-68823c2
+
+include $(INCLUDE_DIR)/package.mk
+
+3PROXY_APPLETS := \
+		3proxy ftppr mycrypt pop3p proxy smtpp socks tcppm udppm
+
+define Package/3proxy/Default
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=3proxy
+  URL:=https://3proxy.ru/
+endef
+
+define Package/3proxy
+  $(call Package/3proxy/Default)
+  TITLE:=3proxy software distribution
+  MENU:=1
+endef
+
+define Package/3proxy/description
+  Software from the 3proxy software distribution
+endef
+
+3proxy_SUBPACKAGETITLE_3proxy:=Includes all proxy servers
+3proxy_SUBPACKAGETITLE_ftppr:=FTP proxy server
+3proxy_SUBPACKAGETITLE_mycrypt:=Generate encrypted passwords (MD5/crypt and NT password)
+3proxy_SUBPACKAGETITLE_pop3p:=POP3 proxy server
+3proxy_SUBPACKAGETITLE_proxy:=HTTP proxy server
+3proxy_SUBPACKAGETITLE_smtpp:=SMTP proxy server
+3proxy_SUBPACKAGETITLE_socks:=SOCKS 4/5 proxy server
+3proxy_SUBPACKAGETITLE_tcppm:=TCP port mapping
+3proxy_SUBPACKAGETITLE_udppm:=UDP port mapping
+
+define GenPlugin
+ define Package/$(1)
+   $(call Package/3proxy/Default)
+   DEPENDS:=3proxy
+   TITLE:=$(3proxy_SUBPACKAGETITLE_$(2))
+ endef
+
+ define Package/$(1)/description
+  $(2) utility
+ endef
+endef
+
+define Package/3proxy/conffiles
+/etc/3proxy.cfg
+endef
+
+$(foreach a,$(3PROXY_APPLETS),$(eval $(call GenPlugin,3proxy-$(a),$(a))))
+
+TARGET_CFLAGS+= -fno-strict-aliasing -c -pthread -DWITHSPLICE \
+		-DGETHOSTBYNAME_R -D_THREAD_SAFE -D_REENTRANT \
+		-DNOODBC -DWITH_STD_MALLOC -DFD_SETSIZE=4096 \
+		-DWITH_POLL -DWITH_NETFILTER -D_GNU_SOURCE \
+		-ffunction-sections -fdata-sections $(FPIC)
+
+TARGET_LDFLAGS+= -pthread -Wl,--gc-sections
+
+define Package/3proxy/install
+	true
+endef
+
+define BuildPlugin
+  define Package/$(1)/install
+	$(INSTALL_DIR) $$(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/$(2) $$(1)/usr/bin/
+ endef
+
+  $$(eval $$(call BuildPackage,$(1)))
+endef
+
+$(eval $(call BuildPackage,3proxy))
+
+$(foreach a,$(3PROXY_APPLETS),$(eval $(call BuildPlugin,3proxy-$(a),$(a))))

--- a/net/3proxy/patches/100-create-a-makefile-for-openwrt.patch
+++ b/net/3proxy/patches/100-create-a-makefile-for-openwrt.patch
@@ -1,0 +1,66 @@
+From 9b67a396d19cc44c7628f5ffcda6224f59fcf8e7 Mon Sep 17 00:00:00 2001
+From: Daniel Engberg <daniel.engberg.lists@pyret.net>
+Date: Sun, 6 May 2018 22:27:29 +0200
+Subject: [PATCH 1/1] Create a Makefile for OpenWrt
+
+3proxy doesn't have a default Makefile so we need to create one
+
+Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>
+---
+ Makefile.Linux => Makefile | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+ rename Makefile.Linux => Makefile (91%)
+
+diff --git a/Makefile.Linux b/Makefile
+similarity index 91%
+rename from Makefile.Linux
+rename to Makefile
+index 54b8e1f..36187e1 100644
+--- a/Makefile.Linux
++++ b/Makefile
+@@ -8,13 +8,13 @@
+ # library support. Add -DSAFESQL for poorely written ODBC library / drivers.
+ 
+ BUILDDIR = ../bin/
+-CC = gcc
++#CC = gcc
+ 
+-CFLAGS = -g -O2 -fno-strict-aliasing -c -pthread -DWITHSPLICE -DGETHOSTBYNAME_R -D_THREAD_SAFE -D_REENTRANT -DNOODBC -DWITH_STD_MALLOC -DFD_SETSIZE=4096 -DWITH_POLL -DWITH_NETFILTER
++#CFLAGS = -g -O2 -fno-strict-aliasing -c -pthread -DWITHSPLICE -DGETHOSTBYNAME_R -D_THREAD_SAFE -D_REENTRANT -DNOODBC -DWITH_STD_MALLOC -DFD_SETSIZE=4096 -DWITH_POLL -DWITH_NETFILTER
+ COUT = -o 
+-LN = gcc
+-DCFLAGS = -fpic
+-LDFLAGS = -O2 -fno-strict-aliasing -pthread
++LN = $(CC)
++#DCFLAGS = -fpic
++#LDFLAGS = -O2 -fno-strict-aliasing -pthread
+ DLFLAGS = -shared
+ DLSUFFICS = .ld.so
+ # -lpthreads may be reuqired on some platforms instead of -pthreads
+@@ -28,13 +28,14 @@ COMPFILES = *~
+ REMOVECOMMAND = rm -f
+ TYPECOMMAND = cat
+ COMPATLIBS =
+-MAKEFILE = Makefile.Linux
++MAKEFILE = Makefile
+ # PamAuth requires libpam, you may require pam-devel package to be installed
+ # SSLPlugin requires  -lcrypto -lssl
+ #LIBS = -lcrypto -lssl -ldl 
+ LIBS = -ldl 
+ #PLUGINS = SSLPlugin StringsPlugin TrafficPlugin PCREPlugin TransparentPlugin PamAuth
+-PLUGINS = StringsPlugin TrafficPlugin PCREPlugin TransparentPlugin
++#PLUGINS = StringsPlugin TrafficPlugin PCREPlugin TransparentPlugin
++PLUGINS = StringsPlugin TransparentPlugin
+ 
+ include Makefile.inc
+ 
+@@ -158,4 +159,4 @@ install: install-chroot-dir install-bin install-etc install-log install-man inst
+ 	@if [ -f /usr/sbin/service ]; then \
+ 	 /usr/sbin/service 3proxy stop ;\
+ 	 /usr/sbin/service 3proxy start ;\
+-	fi
+\ No newline at end of file
++	fi
+-- 
+2.11.0
+


### PR DESCRIPTION
Maintainer: (Needs one)
Compile tested:
mt7621, D-Link DIR-860L, OpenWrt Master
octeon, EdgeRouter Lite, OpenWrt Master

Run tested: 
mt7621, D-Link DIR-860L, OpenWrt Master
octeon, EdgeRouter Lite, OpenWrt Master

Description:
Add 3proxy to repo

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>