### PR TITLE
tor: package improvements

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
 PKG_VERSION:=0.3.2.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -102,8 +102,8 @@ CONFIGURE_ARGS += \
 	--with-tor-user=tor \
 	--with-tor-group=tor
 
-TARGET_CFLAGS += -ffunction-sections -fdata-sections
-TARGET_LDFLAGS += -Wl,--gc-sections
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
+TARGET_LDFLAGS += -Wl,--gc-sections -flto
 EXTRA_CFLAGS += -std=gnu99
 
 ifneq ($(CONFIG_SSP_SUPPORT),y)

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -134,8 +134,10 @@ endef
 
 define Package/tor-geoip/install
 	$(INSTALL_DIR) $(1)/usr/share/tor
-	$(CP) $(PKG_INSTALL_DIR)/usr/share/tor/geoip $(1)/usr/share/tor/
-	$(CP) $(PKG_INSTALL_DIR)/usr/share/tor/geoip6 $(1)/usr/share/tor/
+	$(INSTALL_DATA) \
+	  $(PKG_INSTALL_DIR)/usr/share/tor/geoip \
+	  $(PKG_INSTALL_DIR)/usr/share/tor/geoip6 \
+	$(1)/usr/share/tor/
 endef
 
 $(eval $(call BuildPackage,tor))

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -89,7 +89,6 @@ endef
 
 CONFIGURE_ARGS += \
 	--with-libevent-dir="$(STAGING_DIR)/usr" \
-	--with-ssl-dir="$(STAGING_DIR)/usr" \
 	--with-openssl-dir="$(STAGING_DIR)/usr" \
 	--with-zlib-dir="$(STAGING_DIR)/usr" \
 	--disable-asciidoc \

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -19,6 +19,7 @@ PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -116,7 +116,6 @@ CONFIGURE_VARS += \
 define Package/tor/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tor $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/torify $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/tor.init $(1)/etc/init.d/tor
 	$(INSTALL_DIR) $(1)/etc/tor

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -20,6 +20,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2016 OpenWrt.org
+# Copyright (C) 2008-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -67,7 +67,7 @@ endef
 
 define Package/tor-resolve/description
 $(call Package/tor/Default/description)
- Resolve a hostname to an IP address via tor 
+ Resolve a hostname to an IP address via tor
 endef
 
 define Package/tor-geoip

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -136,7 +136,7 @@ define Package/tor-geoip/install
 	$(INSTALL_DIR) $(1)/usr/share/tor
 	$(INSTALL_DATA) \
 	  $(PKG_INSTALL_DIR)/usr/share/tor/geoip \
-	  $(PKG_INSTALL_DIR)/usr/share/tor/geoip6 \
+	  $(if $(CONFIG_IPV6),$(PKG_INSTALL_DIR)/usr/share/tor/geoip6) \
 	$(1)/usr/share/tor/
 endef
 

--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -102,6 +102,8 @@ CONFIGURE_ARGS += \
 	--with-tor-user=tor \
 	--with-tor-group=tor
 
+TARGET_CFLAGS += -ffunction-sections -fdata-sections
+TARGET_LDFLAGS += -Wl,--gc-sections
 EXTRA_CFLAGS += -std=gnu99
 
 ifneq ($(CONFIG_SSP_SUPPORT),y)

--- a/net/tor/patches/901-configure.patch
+++ b/net/tor/patches/901-configure.patch
@@ -1,0 +1,41 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -33,8 +33,8 @@ rust_ldadd=
+ endif
+ 
+ include src/include.am
+-include doc/include.am
+-include contrib/include.am
++#include doc/include.am
++#include contrib/include.am
+ 
+ EXTRA_DIST+= \
+ 	ChangeLog					\
+--- a/src/include.am
++++ b/src/include.am
+@@ -2,10 +2,10 @@ include src/ext/include.am
+ include src/trunnel/include.am
+ include src/common/include.am
+ include src/or/include.am
+-include src/rust/include.am
+-include src/test/include.am
++#include src/rust/include.am
++#include src/test/include.am
+ include src/tools/include.am
+-include src/win32/include.am
++#include src/win32/include.am
+ include src/config/include.am
+-include src/test/fuzz/include.am
+-include src/trace/include.am
++#include src/test/fuzz/include.am
++#include src/trace/include.am
+--- a/src/or/include.am
++++ b/src/or/include.am
+@@ -133,7 +133,6 @@ src_or_tor_LDFLAGS = @TOR_LDFLAGS_zlib@ @TOR_LDFLAGS_openssl@ @TOR_LDFLAGS_libev
+ src_or_tor_LDADD = src/or/libtor.a src/common/libor.a src/common/libor-ctime.a \
+ 	src/common/libor-crypto.a $(LIBKECCAK_TINY) $(LIBDONNA) \
+ 	src/common/libor-event.a src/trunnel/libor-trunnel.a \
+-	src/trace/libor-trace.a \
+ 	$(rust_ldadd) \
+ 	@TOR_ZLIB_LIBS@ @TOR_LIB_MATH@ @TOR_LIBEVENT_LIBS@ @TOR_OPENSSL_LIBS@ \
+ 	@TOR_LIB_WS32@ @TOR_LIB_GDI@ @TOR_LIB_USERENV@ \


### PR DESCRIPTION
- remove "torify" script
- tor-geoip: fix "install" recipe
- tor-geoip: honor CONFIG_IPV6
- drop deprecated configure option
- disable unwanted build targets
- build in parallel
- use global hardening configuration
- build with -ffunction-sections, -fdata-sections, --gc-sections and -flto
- update OpenWrt copyright years
- remove trailing whitespace
- bump package version

Compile- and run-tested on ar71xx/generic (TP-Link Archer C7 v2, world-wide version).

Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>