### PR TITLE
ddns-scripts: "now-dns.com" service fix

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.7
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -136,7 +136,7 @@
 
 "no-ip.pl"		"http://[USERNAME]:[PASSWORD]@update.no-ip.pl/?hostname=[DOMAIN]"
 
-"now-dns.com"		"http://[USERNAME]:[PASSWORD]@now-dns.com/update?hostname=[DOMAIN]"
+"now-dns.com"		"https://[USERNAME]:[PASSWORD]@now-dns.com/update?hostname=[DOMAIN]"	"good|nochg"
 
 "nsupdate.info"		"http://[USERNAME]:[PASSWORD]@ipv4.nsupdate.info/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 

--- a/net/ddns-scripts/files/services_ipv6
+++ b/net/ddns-scripts/files/services_ipv6
@@ -86,7 +86,7 @@
 
 "no-ip.pl"		"http://[USERNAME]:[PASSWORD]@update.no-ip.pl/?hostname=[DOMAIN]"
 
-"now-dns.com"		"http://[USERNAME]:[PASSWORD]@now-dns.com/update?hostname=[DOMAIN]"
+"now-dns.com"		"https://[USERNAME]:[PASSWORD]@now-dns.com/update?hostname=[DOMAIN]"	"good|nochg"
 
 "nsupdate.info"		"http://[USERNAME]:[PASSWORD]@ipv6.nsupdate.info/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 


### PR DESCRIPTION
Maintainer: @chris5560 
Compile tested: ramips/mt7621. OpenWrt trunk r6643+29-08ccfde
Run tested: ramips/mt7621

Description:
 - Add valid responses "good|nochg" so that ddns-script could recognize "badauth"
   error that comes with http 200 code
 - Switch url to https scheme. "now-dns.com" always returns 302 redirect
   to https:// for all plain-text http requests. Since working via default
   plain-text http is not possible anyway, forcing url to https prevents
   curl sending unencrypted plain-text credentials via basic auth

Signed-off-by: Emil Muratov <gpm@hotplug.ru>