### PR TITLE
getdns: Bump to 1.4.2

### DIFF
--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -5,8 +5,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=getdns
-PKG_VERSION:=1.4.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.4.2
+PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -14,7 +14,7 @@ PKG_MAINTAINER:=David Mora <iamperson347+public@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://getdnsapi.net/dist/
-PKG_HASH:=245233dc780f615b6ab1472f2b9cdcd957a451a736f3036717d0da466ab1c51e
+PKG_HASH:=1685b82dfe297cffc4bae08a773cdc88a3edf9a4e5a1ea27d8764bb5affc0e80
 
 PKG_FIXUP:=autoreconf
 

--- a/libs/getdns/patches/001-Bugfix-399-Reinclude-linux-sysctl.h-in-getentropy_li.patch
+++ b/libs/getdns/patches/001-Bugfix-399-Reinclude-linux-sysctl.h-in-getentropy_li.patch
@@ -1,0 +1,25 @@
+From 05bce5263735b77f91078a930ec55b9cf181d999 Mon Sep 17 00:00:00 2001
+From: Willem Toorop <willem@nlnetlabs.nl>
+Date: Sun, 13 May 2018 11:59:14 +0200
+Subject: [PATCH] Bugfix #399: Reinclude <linux/sysctl.h> in getentropy_linux.c
+
+---
+ src/compat/getentropy_linux.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/compat/getentropy_linux.c b/src/compat/getentropy_linux.c
+index 744783c..abb28f4 100644
+--- a/src/compat/getentropy_linux.c
++++ b/src/compat/getentropy_linux.c
+@@ -62,6 +62,7 @@
+ 
+ #include <linux/types.h>
+ #include <linux/random.h>
++#include <linux/sysctl.h>
+ #ifdef HAVE_GETAUXVAL
+ #include <sys/auxv.h>
+ #endif
+-- 
+2.14.1
+
+


### PR DESCRIPTION
Signed-off-by: David Mora <iamperson347+public@gmail.com>

Maintainer: me / @iamperson347
Compile tested: ar71xx, archer-c7, trunk
Run tested: same as above. Tested on personal Archer C7 v2. Functionality seems to be correct.

Description: Update to new upstream version. Needed to add a patch provided by upstream to compile with musl.
