### PR TITLE
python,python3: remove `--ignore-installed` flag for host packages

### DIFF
--- a/lang/python/python-host.mk
+++ b/lang/python/python-host.mk
@@ -76,7 +76,6 @@ define host_python_pip_install
 	$(HOST_PYTHON_PIP) install \
 		--root=$(1) \
 		--prefix=$(2) \
-		--ignore-installed \
 		$(3)
 endef
 

--- a/lang/python/python3-host.mk
+++ b/lang/python/python3-host.mk
@@ -76,7 +76,6 @@ define host_python3_pip_install
 	$(HOST_PYTHON3_PIP) install \
 		--root=$(1) \
 		--prefix=$(2) \
-		--ignore-installed \
 		$(3)
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A
Run tested: N/A

----------------------------------------------------------------

This was copied over from python-packages, when support for installing
packages host-side (via pip) was added.

Based on the discussion on this commit:
  https://github.com/openwrt/packages/commit/612c53fc6c3d9ba2a57f7329baf055f1d59a9246
it was mentioned that removing this may add more benefit in terms of
reducing build time, because packages won't get reinstalled every time.

I'm not entirely sure about any potential side-effects of this, but it's
worth trying it out.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>