### PR TITLE
rp-pppoe: Fixed compilation with glibc

### DIFF
--- a/net/rp-pppoe/Makefile
+++ b/net/rp-pppoe/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rp-pppoe
 PKG_VERSION:=3.12
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_MAINTAINER:=Daniel Dickinson <lede@cshore.thecshore.com>
 PKG_LICENSE:=LGPL-2.0+
 

--- a/net/rp-pppoe/patches/140-glibc-avoid-include-linux_in.h.patch
+++ b/net/rp-pppoe/patches/140-glibc-avoid-include-linux_in.h.patch
@@ -1,0 +1,12 @@
+--- a/src/pppoe.h
++++ b/src/pppoe.h
+@@ -131,7 +131,9 @@ typedef unsigned long UINT32_t;
+ #include <linux/if_ether.h>
+ #endif
+ 
++#ifndef __GLIBC__
+ #include <netinet/in.h>
++#endif
+ 
+ #ifdef HAVE_NETINET_IF_ETHER_H
+ #include <sys/types.h>


### PR DESCRIPTION
Maintainer: @cshoredaniel 
Compile tested: mipsel, mips74k (glibc and musl)
Run tested: none

Description:
Do not include <netinet/in.h> when using glibc to avoid various redefinitions.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
