### PR TITLE
tdb: avoid installing duplicate files

### DIFF
--- a/libs/tdb/Makefile
+++ b/libs/tdb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tdb
 PKG_VERSION:=1.3.15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -83,7 +83,7 @@ endef
 
 define Package/tdb/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so.* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
 endef


### PR DESCRIPTION
Maintainer: @pfzim 
Compile tested: mipsel, brcm47xx, openwrt master
Run tested: none

Description:
Use $(CP) instead of $(INSTALL) so that libtdb.so.1 is installed as
symlink, and not duplicated.
Resolves #5784 

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

