### PR TITLE
node: Fix incorrect detection of arm_version and arm_fpu

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
 PKG_VERSION:=v8.10.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_SOURCE:=node-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://nodejs.org/dist/${PKG_VERSION}
 PKG_HASH:=b72d4e71618d6bcbd039b487b51fa7543631a4ac3331d7caf69bdf55b5b2901a
@@ -73,55 +73,26 @@ NODEJS_CPU:=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst
 MAKE_VARS+= \
 	DESTCPU=$(NODEJS_CPU)
 
+CONFIGURE_VARS:= \
+	CC="$(TARGET_CC) $(TARGET_OPTIMIZATION)" \
+	CXX="$(TARGET_CXX) $(TARGET_OPTIMIZATION)" \
+	CC_host="$(HOSTCC)" \
+	CXX_host="$(HOSTCXX)"
+
 CONFIGURE_ARGS:= \
 	--dest-cpu=$(NODEJS_CPU) \
 	--dest-os=linux \
 	--without-snapshot \
 	--shared-zlib \
 	--shared-openssl \
+	--with-intl=$(if $(CONFIG_NODEJS_ICU),system-icu,none) \
+	$(if $(findstring mips,$(NODEJS_CPU)), \
+		$(if $(CONFIG_SOFT_FLOAT),--with-mips-float-abi=soft)) \
+	$(if $(findstring +neon,$(CONFIG_CPU_TYPE)),--with-arm-fpu=neon) \
+	$(if $(findstring +vfp",$(CONFIG_CPU_TYPE)),--with-arm-fpu=vfp) \
+	$(if $(findstring +vfpv3",$(CONFIG_CPU_TYPE)),--with-arm-fpu=vfpv3-d16) \
+	$(if $(findstring +vfpv4",$(CONFIG_CPU_TYPE)),--with-arm-fpu=vfpv3) \
 	--prefix=/usr
-
-ifneq ($(findstring arm,$(NODEJS_CPU)),)
-ifeq ($(CONFIG_SOFT_FLOAT),y)
-CONFIGURE_ARGS+= --with-arm-float-abi=softfp
-else
-
-CONFIGURE_ARGS+= --with-arm-float-abi=hard
-
-ifneq ($(findstring vfp,$(CONFIG_CPU_TYPE)),)
-ARM_FPU=vfp
-endif
-
-ifneq ($(findstring vfpv3,$(CONFIG_CPU_TYPE)),)
-ARM_FPU=vfpv3
-endif
-
-ifneq ($(findstring vfpv3-d16,$(CONFIG_CPU_TYPE)),)
-ARM_FPU=vfpv3-d16
-endif
-
-ifneq ($(findstring neon,$(CONFIG_CPU_TYPE)),)
-ARM_FPU=neon
-endif
-
-CONFIGURE_ARGS+= --with-arm-fpu=$(ARM_FPU)
-endif
-endif
-
-ifneq ($(findstring mips,$(NODEJS_CPU)),)
-ifeq ($(CONFIG_SOFT_FLOAT),y)
-CONFIGURE_ARGS+= \
-	--with-mips-float-abi=soft
-endif
-endif
-
-ifeq ($(CONFIG_NODEJS_ICU),y)
-CONFIGURE_ARGS+= \
-	--with-intl=system-icu
-else
-CONFIGURE_ARGS+= \
-	--with-intl=none
-endif
 
 HOST_CONFIGURE_VARS:=
 


### PR DESCRIPTION
Maintainer: @blogic @ianchi and @ratkaj
Compile tested: brcm2708 (bcm2708 bcm2709 bcm2710), ar71xx (w fpu emu), Trunk r6911-0ed9281
Run tested: none

Description:
Automatic detection of the arm architecture does not work well.

http://downloads.lede-project.org/snapshots/faillogs/arm_arm1176jzf-s_vfp/packages/node/compile.txt
```
../deps/v8/src/arm/assembler-arm.cc:176:2: error: #error "CAN_USE_ARMV7_INSTRUCTIONS should match CAN_USE_VFP3_INSTRUCTIONS"
 #error "CAN_USE_ARMV7_INSTRUCTIONS should match CAN_USE_VFP3_INSTRUCTIONS"
   ^~~~~
```
Explicitly set cpu arch optimization flag to the compiler option so that "configure" script correctly identifies "arm version".
https://github.com/openwrt/packages/issues/5728

(Raspberry Pi Zero W)
Raspbian:
```
raspberrypi:~ $ echo | gcc -dM -E - | grep ARM_ARCH
#define __ARM_ARCH_ISA_ARM 1
#define __ARM_ARCH_6__ 1
#define __ARM_ARCH_ISA_THUMB 1
#define __ARM_ARCH 6
```
OpenWrt (cross-env):
```
ubuntu:~ $ echo | ./arm-openwrt-linux-muslgnueabi-gcc -dM -E - | grep ARM_ARCH
#define __ARM_ARCH_ISA_ARM 1
#define __ARM_ARCH_5T__ 1
#define __ARM_ARCH_ISA_THUMB 1
#define __ARM_ARCH 5
```
```
ubuntu:~ $ echo | ./arm-openwrt-linux-muslgnueabi-gcc -mcpu=arm1176jzf-s -dM -E - | grep ARM_ARCH
#define __ARM_ARCH_ISA_ARM 1
#define __ARM_ARCH_6KZ__ 1
#define __ARM_ARCH_ISA_THUMB 1
#define __ARM_ARCH 6
#define __ARM_ARCH_6ZK__ 1
```

Also specifying an option lines compactly.

https://github.com/openwrt/openwrt/blob/master/include/target.mk#L202-L205
https://github.com/nodejs/node/blob/22f4a35db344472db1e83f9e3156907b58f5f527/deps/v8/BUILD.gn#L303-L321
https://github.com/nodejs/node/blob/22f4a35db344472db1e83f9e3156907b58f5f527/configure#L710-L717

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
