### PR TITLE
initial-config-download: add package

### DIFF
--- a/utils/initial-config-download/Makefile
+++ b/utils/initial-config-download/Makefile
@@ -1,0 +1,25 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=initial-config-download
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Paul Spooren <spooren@informatik.uni-leipzig.de>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/initial-config-download
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=initial-config-download
+  PKGARCH:=all
+endef
+
+Build/Compile=
+
+define Package/initial-config-download/install
+		$(INSTALL_DIR) $(1)/
+		$(CP) -r files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,initial-config-download))

--- a/utils/initial-config-download/files/etc/init.d/initial-config-download
+++ b/utils/initial-config-download/files/etc/init.d/initial-config-download
@@ -1,0 +1,15 @@
+#!/bin/sh /etc/rc.common
+
+START=91
+USE_PROCD=1
+
+BIN=/usr/bin/initial-config-download
+
+start_service() {
+	procd_open_instance "initial-config-download"
+	procd_set_param command "$BIN"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn
+	procd_close_instance
+}

--- a/utils/initial-config-download/files/etc/uci-defaults/initial-config-download
+++ b/utils/initial-config-download/files/etc/uci-defaults/initial-config-download
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+uci -q show initial-config-download.main || {
+    touch /etc/config/initial-config-download
+    uci batch <<-EOF
+    set initial-config-download.main='main'
+	set initial-config-download.main.port='8123'
+	set initial-config-download.main.file='config.tar.gz'
+	set initial-config-download.main.interfaces='br-lan'
+	commit initial-config-download
+EOF
+}

--- a/utils/initial-config-download/files/usr/bin/initial-config-download
+++ b/utils/initial-config-download/files/usr/bin/initial-config-download
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+INTERFACES="$(uci -q get initial-config-download.main.interfaces || 'br-lan')"
+CONFIG="$(uci -q get initial-config-download.main.file || 'config.tar.gz')"
+PORT="$(uci -q get initial-config-download.main.port || '8123')"
+MAC="$(cat sys/class/net/$INTERFACE/address | tr -d ':')"
+
+apply_config() {
+    # disable initial service until firstboot reset
+    /etc/init.d/initial-config-download disable
+
+    # extract config files to / of node
+    tar xz -C / -f "/tmp/${CONFIG}"
+
+    # reboot device to make LEDs blink and apply files of /etc/uci-defaults
+    reboot
+}
+
+find_neighbors() {
+    # find neighbored nodes which may offer a config
+    echo "$(ping6 -I ${interface} ff02::1 -c 2 | awk '{ print $4 }' | \
+        tail -n +2 | head -n -4 | cut -d'%' -f 1 | sort | uniq)"
+}
+
+download_config() {
+    # iterate over MAC address like PXE does
+    for i in 12 11 10 9 8 7 6 5 4 3 2 1 0; do
+        MAC_DIR="$(echo $MAC | tr -c $i)"
+        # try to download the file
+        wget "http://[${neighbor%:}%${interface}]:${PORT}/${MAC_DIR}/${CONFIG}" -P /tmp -q
+        # stop if file was successfully retrieved
+        [ -e "/tmp/${CONFIG}" ] && apply_config
+    done
+
+}
+
+# don't stop before no configuration is found
+while [[ ! -e "/tmp/${CONFIG}" ]]; do
+    # run on all configured interfaces
+    for interface in $INTERFACES; do
+        # run on every found neighbor
+        for neighbor in find_neighbors; do
+            download_config
+        done
+    done
+    sleep 5
+done
+


### PR DESCRIPTION
Maintainer: me
Compile tested: x86/64

Description:

Daemon will look for all link local neighbors and ask them for a config
archive. If a neighbor offers the requested archive it's downloaded,
unpackaged in `/`, this daemon disabled and the device reboots.

Resetting the device via hardware button or `firstboot` will enable the
daemon again to download a newly provided configuration.

The MAC address is used like for PXE to apply individual configurations,
aka it tries to download in the following order:

525400123456/config.tar.gz
52540012345/config.tar.gz
5254001234/config.tar.gz
525400123/config.tar.gz
..
3/config.tar.gz
/config.tar.gz

I used this script to rapidly test various configurations for a mesh
setup, hope it's useful for anyone else. If not, close this PR.

Signed-off-by: Paul Spooren <mail@aparcar.org>