### PR TITLE
lighttpd: CONFIG_LIGHTTPD_SSL includes mod_openssl

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.48
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://download.lighttpd.net/lighttpd/releases-1.4.x
@@ -20,6 +20,8 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+
+PKG_CONFIG_DEPENDS:=CONFIG_LIGHTTPD_SSL
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -49,6 +51,8 @@ config LIGHTTPD_SSL
 	  lighttpd confguration file.
 endef
 
+BASE_MODULES:=dirlisting indexfile staticfile
+
 CONFIGURE_ARGS+= \
 	--libdir=/usr/lib/lighttpd \
 	--sysconfdir=/etc/lighttpd \
@@ -72,6 +76,7 @@ CONFIGURE_VARS+= \
 ifneq ($(strip $(CONFIG_LIGHTTPD_SSL)),)
   CONFIGURE_ARGS+= \
 	--with-openssl="$(STAGING_DIR)/usr"
+  BASE_MODULES+= openssl
 else
   CONFIGURE_ARGS+= \
 	--without-openssl
@@ -117,7 +122,7 @@ define Package/lighttpd/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/lighttpd.init $(1)/etc/init.d/lighttpd
 	$(INSTALL_DIR) $(1)/usr/lib/lighttpd
-	for m in dirlisting indexfile staticfile; do \
+	for m in $(BASE_MODULES); do \
 		$(CP) $(PKG_INSTALL_DIR)/usr/lib/lighttpd/mod_$$$${m}.so $(1)/usr/lib/lighttpd/ ; \
 	done
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
If we're built with CONFIG_LIGHTTPD_SSL then mod_openssl.so should
be included into the base package. Fixes issue #5343.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>

Maintainer: me
Compile tested: x86_64, OpenWrt commit 2c0cd47d

Description:
Cherry pick Philip's SSL fix from master. See also https://github.com/openwrt/packages/issues/6012.