### PR TITLE
node-mozilla-iot-gateway: add openssl 1.1 compat.

### DIFF
--- a/lang/node-mozilla-iot-gateway/Makefile
+++ b/lang/node-mozilla-iot-gateway/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=mozilla-iot-gateway
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=0.3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/mozilla-iot/gateway.git
@@ -20,6 +20,14 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_MIRROR_HASH:=ba05bc3e93c36768244df922434e7132c2dae85a1ff9e3213beea087a4844d11
 
 PKG_BUILD_DEPENDS:=node/host openzwave
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_INSTALL_DIR:=$(BUILD_DIR)/$(PKG_NAME)/ipkg-install
+
+URSA_VERSION:=0.9.4
+URSA_SOURCE:=ursa-$(URSA_VERSION).tgz
+URSA_SUBDIR:=ursa-$(URSA_VERSION)
+URSA_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/$(URSA_SUBDIR)
+URSA_TGZ:=$(BUILD_DIR)/$(PKG_NAME)/$(URSA_SOURCE)
 
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
 PKG_LICENSE:=MPL-2.0
@@ -44,6 +52,33 @@ define Package/node-mozilla-iot-gateway/description
   and defining a standard data model and APIs to make them interoperable.
 endef
 
+define Download/ursa
+  FILE:=$(URSA_SOURCE)
+  URL:=https://registry.yarnpkg.com/ursa/-/$(FILE)
+  HASH:=65516fc99958011572ef26ef02a3c84a004e47aabfd5b8aa46abb10481ae7153
+endef
+$(eval $(call Download,ursa))
+
+define Build/Prepare
+	$(PKG_UNPACK)
+	$(Build/Patch)
+	$(RM) -r "$(URSA_BUILD_DIR)" "$(BUILD_DIR)/$(PKG_NAME)/package"
+	( \
+	  cd $(PKG_BUILD_DIR)/.. && \
+	  $(TAR) -xzf $(DL_DIR)/$(URSA_SOURCE) && \
+	  mv package $(URSA_SUBDIR) \
+	)
+	cat ./files/ursa.patch | ( cd $(URSA_BUILD_DIR) && patch -p1 )
+	cat ./files/gateway.patch | ( cd $(PKG_BUILD_DIR) && patch -p1 )
+	sed -i -e 's!@@URSA_TGZ@@!$(URSA_TGZ)!' $(PKG_BUILD_DIR)/package.json
+	( \
+	  cd $(PKG_BUILD_DIR)/.. && \
+	  tar -czf $(PKG_SOURCE) $(PKG_NAME)-$(PKG_VERSION); \
+	  tar -czf $(URSA_SOURCE) $(URSA_SUBDIR) \
+	)
+endef
+
+EXTRA_CFLAGS += -Wno-error=format-security
 CPU:=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))))
 
 define Build/Compile
@@ -54,7 +89,12 @@ define Build/Compile
 	npm_config_cache=$(TMP_DIR)/npm-cache \
 	npm_config_tmp=$(TMP_DIR)/npm-tmp \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
-	$(STAGING_DIR_HOSTPKG)/bin/npm install --build-from-source --target_arch=$(CPU) -g $(DL_DIR)/$(PKG_SOURCE)
+	$(STAGING_DIR_HOSTPKG)/bin/npm install --build-from-source --target_arch=$(CPU) -g \
+		$(PKG_BUILD_DIR)/../$(PKG_SOURCE)
+endef
+
+define Build/Clean
+	$(RM) -r "$(BUILD_DIR)/$(PKG_NAME)/"
 endef
 
 define Package/node-mozilla-iot-gateway/install

--- a/lang/node-mozilla-iot-gateway/files/gateway.patch
+++ b/lang/node-mozilla-iot-gateway/files/gateway.patch
@@ -1,0 +1,10 @@
+--- a/package.json
++++ b/package.json
+@@ -25,6 +25,7 @@
+   },
+   "homepage": "https://iot.mozilla.org",
+   "dependencies": {
++    "ursa": "file:@@URSA_TGZ@@",
+     "asn1.js": "^5.0.0",
+     "bcryptjs": "^2.4.3",
+     "body-parser": "^1.17.1",

--- a/lang/node-mozilla-iot-gateway/files/ursa.patch
+++ b/lang/node-mozilla-iot-gateway/files/ursa.patch
@@ -1,0 +1,106 @@
+--- a/src/ursaNative.cc	2016-05-09 21:28:14.000000000 -0300
++++ b/src/ursaNative.cc	2018-04-20 17:18:48.000000000 -0300
+@@ -386,8 +386,12 @@
+         obj->rsa = RSA_new();
+     }
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++    RSA_set0_key(obj->rsa, BN_bin2bn(data_n, n_length, NULL), BN_bin2bn(data_e, e_length, NULL), NULL);
++#else
+     obj->rsa->n = BN_bin2bn(data_n, n_length, NULL);
+     obj->rsa->e = BN_bin2bn(data_e, e_length, NULL);
++#endif
+     free(data_n);
+     free(data_e);
+     NanReturnUndefined();
+@@ -404,7 +408,15 @@
+ 
+     // The "d" field should always be set on a private key and never
+     // set on a public key.
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++    const BIGNUM *d;
++    if (obj != NULL) {
++	RSA_get0_key(obj->rsa, NULL, NULL, &d);
++    }
++    if ((obj == NULL) || (d != NULL)) {
++#else
+     if ((obj == NULL) || (obj->rsa->d != NULL)) {
++#endif
+         return obj;
+     }
+ 
+@@ -533,7 +545,13 @@
+     obj = expectSet(obj);
+     if (obj == NULL) { NanReturnUndefined(); }
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++    BIGNUM *e;
++    RSA_get0_key(obj->rsa, NULL, (const BIGNUM**) &e, NULL);
++    bignumToBuffer(args, e);
++#else
+     bignumToBuffer(args, obj->rsa->e);
++#endif
+ }
+ 
+ /**
+@@ -549,7 +567,13 @@
+     obj = expectPrivateKey(obj);
+     if (obj == NULL) { NanReturnUndefined(); }
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++    BIGNUM *d;
++    RSA_get0_key(obj->rsa, NULL, NULL, (const BIGNUM**) &d);
++    bignumToBuffer(args, d);
++#else
+     bignumToBuffer(args, obj->rsa->d);
++#endif
+ }
+ 
+ /**
+@@ -564,7 +588,13 @@
+     obj = expectSet(obj);
+     if (obj == NULL) { NanReturnUndefined(); }
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++    BIGNUM *n;
++    RSA_get0_key(obj->rsa, (const BIGNUM**) &n, NULL, NULL);
++    bignumToBuffer(args, n);
++#else
+     bignumToBuffer(args, obj->rsa->n);
++#endif
+ }
+ 
+ /**
+@@ -1215,6 +1245,11 @@
+     }
+ 
+     if (ok) {
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++	RSA_set0_key(obj->rsa, modulus, exponent, d);
++	RSA_set0_factors(obj->rsa, p, q);
++	RSA_set0_crt_params(obj->rsa, dp, dq, inverseQ);
++#else
+         obj->rsa->n = modulus;
+         obj->rsa->e = exponent;
+         obj->rsa->p = p;
+@@ -1223,6 +1258,7 @@
+         obj->rsa->dmq1 = dq;
+         obj->rsa->iqmp = inverseQ;
+         obj->rsa->d = d;
++#endif
+     } else {
+         if (modulus) { BN_free(modulus); }
+         if (exponent) { BN_free(exponent); }
+@@ -1267,8 +1303,12 @@
+     }
+ 
+     if (ok) {
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++	RSA_set0_key(obj->rsa, modulus, exponent, NULL);
++#else
+         obj->rsa->n = modulus;
+         obj->rsa->e = exponent;
++#endif
+     } else {
+         if (modulus) { BN_free(modulus); }
+         if (exponent) { BN_free(exponent); }


### PR DESCRIPTION
This package is a bit different than most of openwrt.  It downloads its node dependencies at build time.  The actual package that needs patching to compile with openssl 1.1.0 is ursa.  What I've done was to download ursa, patch it, and generate a tgz file, which then is used instead of fetching it online.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer: me / @ratkaj 
Compile tested: ramips, mips_24kc
Run tested: none
