### PR TITLE
libevhtp: add openssl 1.1 compatibility

### DIFF
--- a/libs/libevhtp/Makefile
+++ b/libs/libevhtp/Makefile
@@ -12,7 +12,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libevhtp
 PKG_VERSION:=1.1.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE_PROTO:=git

--- a/libs/libevhtp/patches/020-openssl-1.1-compatibility.patch
+++ b/libs/libevhtp/patches/020-openssl-1.1-compatibility.patch
@@ -1,0 +1,132 @@
+--- a/evhtp.c
++++ b/evhtp.c
+@@ -1686,16 +1686,15 @@ _evhtp_ssl_thread_lock(int mode, int typ
+ #endif
+ static void
+ _evhtp_ssl_delete_scache_ent(evhtp_ssl_ctx_t * ctx, evhtp_ssl_sess_t * sess) {
+-    evhtp_t         * htp;
+-    evhtp_ssl_cfg_t * cfg;
+-    unsigned char   * sid;
+-    unsigned int      slen;
++    evhtp_t          * htp;
++    evhtp_ssl_cfg_t  * cfg;
++    evhtp_ssl_data_t * sid;
++    unsigned int       slen;
+ 
+     htp  = (evhtp_t *)SSL_CTX_get_app_data(ctx);
+     cfg  = htp->ssl_cfg;
+ 
+-    sid  = sess->session_id;
+-    slen = sess->session_id_length;
++    sid = (evhtp_ssl_data_t *)SSL_SESSION_get_id(sess, &slen);
+ 
+     if (cfg->scache_del) {
+         (cfg->scache_del)(htp, sid, slen);
+@@ -1706,14 +1705,17 @@ static int
+ _evhtp_ssl_add_scache_ent(evhtp_ssl_t * ssl, evhtp_ssl_sess_t * sess) {
+     evhtp_connection_t * connection;
+     evhtp_ssl_cfg_t    * cfg;
+-    unsigned char      * sid;
++    evhtp_ssl_data_t   * sid;
+     int                  slen;
+ 
+     connection = (evhtp_connection_t *)SSL_get_app_data(ssl);
+-    cfg        = connection->htp->ssl_cfg;
++    if (connection->htp == NULL)
++    {
++    	return 0;	/* We cannot get the ssl_cfg */
++    }
+ 
+-    sid        = sess->session_id;
+-    slen       = sess->session_id_length;
++    cfg	= connection->htp->ssl_cfg;
++    sid = (evhtp_ssl_data_t *)SSL_SESSION_get_id(sess, &slen);
+ 
+     SSL_set_timeout(sess, cfg->scache_timeout);
+ 
+@@ -1725,7 +1727,7 @@ _evhtp_ssl_add_scache_ent(evhtp_ssl_t *
+ }
+ 
+ static evhtp_ssl_sess_t *
+-_evhtp_ssl_get_scache_ent(evhtp_ssl_t * ssl, unsigned char * sid, int sid_len, int * copy) {
++_evhtp_ssl_get_scache_ent(evhtp_ssl_t * ssl, evhtp_ssl_data_t * sid, int sid_len, int * copy) {
+     evhtp_connection_t * connection;
+     evhtp_ssl_cfg_t    * cfg;
+     evhtp_ssl_sess_t   * sess;
+@@ -1767,12 +1769,12 @@ _evhtp_ssl_servername(evhtp_ssl_t * ssl,
+         connection->vhost_via_sni = 1;
+ 
+         SSL_set_SSL_CTX(ssl, evhtp_vhost->ssl_ctx);
+-        SSL_set_options(ssl, SSL_CTX_get_options(ssl->ctx));
++        SSL_set_options(ssl, SSL_CTX_get_options(SSL_get_SSL_CTX(ssl)));
+ 
+         if ((SSL_get_verify_mode(ssl) == SSL_VERIFY_NONE) ||
+             (SSL_num_renegotiations(ssl) == 0)) {
+-            SSL_set_verify(ssl, SSL_CTX_get_verify_mode(ssl->ctx),
+-                           SSL_CTX_get_verify_callback(ssl->ctx));
++            SSL_set_verify(ssl, SSL_CTX_get_verify_mode(SSL_get_SSL_CTX(ssl)),
++                           SSL_CTX_get_verify_callback(SSL_get_SSL_CTX(ssl)));
+         }
+ 
+         return SSL_TLSEXT_ERR_OK;
+@@ -3017,15 +3019,21 @@ evhtp_ssl_init(evhtp_t * htp, evhtp_ssl_
+         return -1;
+     }
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     SSL_library_init();
+     SSL_load_error_strings();
++#endif
+     RAND_poll();
+ 
+     STACK_OF(SSL_COMP) * comp_methods = SSL_COMP_get_compression_methods();
+     sk_SSL_COMP_zero(comp_methods);
+ 
+     htp->ssl_cfg = cfg;
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     htp->ssl_ctx = SSL_CTX_new(SSLv23_server_method());
++#else
++    htp->ssl_ctx = SSL_CTX_new(TLS_server_method());
++#endif
+ 
+ #if OPENSSL_VERSION_NUMBER >= 0x10000000L
+     SSL_CTX_set_options(htp->ssl_ctx, SSL_MODE_RELEASE_BUFFERS);
+@@ -3062,7 +3070,11 @@ evhtp_ssl_init(evhtp_t * htp, evhtp_ssl_
+     SSL_CTX_set_verify(htp->ssl_ctx, cfg->verify_peer, cfg->x509_verify_cb);
+ 
+     if (cfg->x509_chk_issued_cb != NULL) {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+         htp->ssl_ctx->cert_store->check_issued = cfg->x509_chk_issued_cb;
++#else
++	X509_STORE_set_check_issued(SSL_CTX_get_cert_store(htp->ssl_ctx), cfg->x509_chk_issued_cb);
++#endif
+     }
+ 
+     if (cfg->verify_depth) {
+--- a/evhtp.h
++++ b/evhtp.h
+@@ -34,6 +34,11 @@ typedef SSL                       evhtp_
+ typedef SSL_CTX                   evhtp_ssl_ctx_t;
+ typedef X509                      evhtp_x509_t;
+ typedef X509_STORE_CTX            evhtp_x509_store_ctx_t;
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++typedef unsigned char             evhtp_ssl_data_t;
++#else
++typedef const unsigned char       evhtp_ssl_data_t;
++#endif
+ #else
+ typedef void                      evhtp_ssl_sess_t;
+ typedef void                      evhtp_ssl_t;
+@@ -154,9 +159,9 @@ typedef int (*evhtp_headers_iterator)(ev
+ typedef int (*evhtp_ssl_verify_cb)(int pre_verify, evhtp_x509_store_ctx_t * ctx);
+ typedef int (*evhtp_ssl_chk_issued_cb)(evhtp_x509_store_ctx_t * ctx, evhtp_x509_t * x, evhtp_x509_t * issuer);
+ 
+-typedef int (*evhtp_ssl_scache_add)(evhtp_connection_t * connection, unsigned char * sid, int sid_len, evhtp_ssl_sess_t * sess);
+-typedef void (*evhtp_ssl_scache_del)(evhtp_t * htp, unsigned char * sid, int sid_len);
+-typedef evhtp_ssl_sess_t * (*evhtp_ssl_scache_get)(evhtp_connection_t * connection, unsigned char * sid, int sid_len);
++typedef int (*evhtp_ssl_scache_add)(evhtp_connection_t * connection, evhtp_ssl_data_t * sid, int sid_len, evhtp_ssl_sess_t * sess);
++typedef void (*evhtp_ssl_scache_del)(evhtp_t * htp, evhtp_ssl_data_t * sid, int sid_len);
++typedef evhtp_ssl_sess_t * (*evhtp_ssl_scache_get)(evhtp_connection_t * connection, evhtp_ssl_data_t * sid, int sid_len);
+ typedef void * (*evhtp_ssl_scache_init)(evhtp_t *);
+ 
+ #define EVHTP_VERSION           "1.1.6"


### PR DESCRIPTION
This patch is a backport of upstream changes.
I read the Makefile warning and made sure it only updates the openssl
calls and data types to the new API.  It does not touch anything else!

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer: @kissg1988 
