### PR TITLE
libzdb: add compatibility with openssl 1.1

### DIFF
--- a/libs/libzdb/Makefile
+++ b/libs/libzdb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libzdb
 PKG_VERSION:=3.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-3.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/libs/libzdb/patches/030-openssl-1.1.patch
+++ b/libs/libzdb/patches/030-openssl-1.1.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -141,7 +141,7 @@ AC_ARG_ENABLE([openssl],
+         else
+                 openssl="true"
+                 if test "x$enableval" = "xyes"; then
+-                        AC_CHECK_LIB([ssl], [SSL_library_init], [], [AC_MSG_ERROR([libssl not found])])
++                        AC_CHECK_LIB([ssl], [SSL_CTX_new], [], [AC_MSG_ERROR([libssl not found])])
+                         AC_CHECK_LIB([crypto], [SHA1_Init], [], [AC_MSG_ERROR([libcrypto not found])])
+                 else
+                         AC_MSG_CHECKING([for openssl in $enableval])


### PR DESCRIPTION
This patch merely updates the detection of the ssl library.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer: @kissg1988 
Compile tested: ramips, openwrt master
