### PR TITLE
openldap: use /dev/urandom as entropy source

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
 PKG_VERSION:=2.4.45
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/ \
@@ -82,7 +82,8 @@ define Package/openldap-server/conffiles
 /etc/openldap/slapd.conf
 endef
 
-TARGET_CFLAGS += $(FPIC) -lpthread
+TARGET_CFLAGS += $(FPIC) -lpthread \
+	-DURANDOM_DEVICE=\\\"/dev/urandom\\\"
 
 CONFIGURE_ARGS += \
 	--enable-shared \


### PR DESCRIPTION
When cross-compiling, the configure script doesn't use /dev/urandom as entropy source, which would have been the case if we were doing a native build.  Instead it tries to use an EGD, which openwrt doesn't supply.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer: @MikePetullo 
Compile tested: brm47xx,ramips, openwrt master
