### PR TITLE
fdm: add compatibility with openssl 1.1

### DIFF
--- a/mail/fdm/Makefile
+++ b/mail/fdm/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fdm
 PKG_VERSION:=1.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=BSD-2-Clause
 
 PKG_SOURCE:=$(PKG_VERSION).zip

--- a/mail/fdm/patches/040-openssl-1.1.patch
+++ b/mail/fdm/patches/040-openssl-1.1.patch
@@ -1,0 +1,31 @@
+From 070cee8d1efba1ca260777a204fba7cdfe676ca5 Mon Sep 17 00:00:00 2001
+From: Nicholas Marriott <nicholas.marriott@gmail.com>
+Date: Tue, 17 Jan 2017 23:14:03 +0000
+Subject: [PATCH] Look for OPENSSL_init_ssl, from Tomasz Miasko.
+
+---
+ configure.ac | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 5793c2d..161040c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -93,11 +93,16 @@ if test "x$found_libcrypto" = xno; then
+ 	AC_MSG_ERROR("libcrypto not found")
+ fi
+ AC_SEARCH_LIBS(
+-	SSL_library_init,
++	OPENSSL_init_ssl,
+ 	[ssl],
+ 	found_libssl=yes,
+ 	found_libssl=no
+ )
++AC_SEARCH_LIBS(
++	SSL_library_init,
++	[ssl],
++	found_libssl=yes
++)
+ if test "x$found_libssl" = xno; then
+ 	AC_MSG_ERROR("libssl not found")
+ fi


### PR DESCRIPTION
The patch was merged in upstream's master branch.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer: @pfzim 
Compile tested: mips_24kc/ramips/bcm47xx, openwrt master

