### PR TITLE
nail: add compatibility with openssl 1.1

### DIFF
--- a/mail/nail/Makefile
+++ b/mail/nail/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nail
 PKG_VERSION:=12.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=BSD-2-Clause
 
 PKG_SOURCE:=heirloom-mailx_$(PKG_VERSION).orig.tar.gz

--- a/mail/nail/patches/100-handle-openssl-without-sslv2-sslv3.patch
+++ b/mail/nail/patches/100-handle-openssl-without-sslv2-sslv3.patch
@@ -4,7 +4,7 @@
  
  	cp = ssl_method_string(uhp);
  	if (cp != NULL) {
-+#ifndef OPENSSL_NO_SSL2
++#if !defined(OPENSSL_NO_SSL2) && !OPENSSL_VERSION_NUMBER >= 0x10100000L
  		if (equal(cp, "ssl2"))
  			method = SSLv2_client_method();
 -		else if (equal(cp, "ssl3"))

--- a/mail/nail/patches/200-handle-openssl-no-egd.patch
+++ b/mail/nail/patches/200-handle-openssl-no-egd.patch
@@ -1,0 +1,14 @@
+--- a/openssl.c
++++ b/openssl.c
+@@ -137,7 +137,11 @@ ssl_rand_init(void)
+ 
+ 	if ((cp = value("ssl-rand-egd")) != NULL) {
+ 		cp = expand(cp);
++#ifndef OPENSSL_NO_EGD
+ 		if (RAND_egd(cp) == -1) {
++#else
++		if (1) {
++#endif
+ 			fprintf(stderr, catgets(catd, CATSET, 245,
+ 				"entropy daemon at \"%s\" not available\n"),
+ 					cp);


### PR DESCRIPTION
Openssl 1.1 doesn't support SSL2 and does not define the OPENSSL_NO_SSL2 flag either.  Also, it defaults to NO_EGD, so do not use EGD if it's not enabled in openssl.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer: @pfzim 
Compile tested: bcm47xx/ramips, openwrt master
