### PR TITLE
opendkim: Added compatibility wiht openssl 1.1

### DIFF
--- a/mail/opendkim/Makefile
+++ b/mail/opendkim/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opendkim
 PKG_VERSION:=2.10.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
@@ -20,6 +20,7 @@ PKG_LICENSE_FILES:=LICENSE LICENSE.Sendmail
 
 PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=openssl
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/mail/opendkim/patches/010-openssl_1.1.0_compat.patch
+++ b/mail/opendkim/patches/010-openssl_1.1.0_compat.patch
@@ -1,0 +1,90 @@
+Description: Build and work with either openssl 1.0.2 or 1.1.0
+   * Add patch to build with either openssl 1.0.2 or 1.1.0 (Closes: #828466)
+     - Thanks to Sebastian Andrzej Siewior for the patch
+Author: Sebastian Andrzej Siewior
+Bug-Debian: http://bugs.debian.org/828466
+Origin: vendor
+Forwarded: no
+Reviewed-By: Scott Kitterman <scott@kitterman.com>
+Last-Update: <YYYY-MM-DD>
+
+--- opendkim-2.11.0~alpha.orig/configure.ac
++++ opendkim-2.11.0~alpha/configure.ac
+@@ -864,26 +864,28 @@ then
+ 	AC_SEARCH_LIBS([ERR_peek_error], [crypto], ,
+ 	               AC_MSG_ERROR([libcrypto not found]))
+ 
+-	AC_SEARCH_LIBS([SSL_library_init], [ssl], ,
+-		[
+-			if test x"$enable_shared" = x"yes"
+-			then
+-				AC_MSG_ERROR([Cannot build shared opendkim
+-				              against static openssl libraries.
+-				              Configure with --disable-shared
+-				              to get this working or obtain a
+-				              shared libssl library for
+-				              opendkim to use.])
+-			fi
+ 
+-			# avoid caching issue - last result of SSL_library_init
+-			# shouldn't be cached for this next check
+-			unset ac_cv_search_SSL_library_init
+-			LIBCRYPTO_LIBS="$LIBCRYPTO_LIBS -ldl"
+-			AC_SEARCH_LIBS([SSL_library_init], [ssl], ,
+-			               AC_MSG_ERROR([libssl not found]), [-ldl])
+-		]
+-	)
++	AC_LINK_IFELSE(
++		       [AC_LANG_PROGRAM([[#include <openssl/ssl.h>]],
++					[[SSL_library_init();]])],
++					[od_have_ossl="yes";],
++					[od_have_ossl="no";])
++	if test x"$od_have_ossl" = x"no"
++	then
++		if test x"$enable_shared" = x"yes"
++		then
++			AC_MSG_ERROR([Cannot build shared opendkim
++			              against static openssl libraries.
++			              Configure with --disable-shared
++			              to get this working or obtain a
++			              shared libssl library for
++			              opendkim to use.])
++		fi
++
++		LIBCRYPTO_LIBS="$LIBCRYPTO_LIBS -ldl"
++		AC_SEARCH_LIBS([SSL_library_init], [ssl], ,
++		               AC_MSG_ERROR([libssl not found]), [-ldl])
++	fi
+ 
+ 	AC_CHECK_DECL([SHA256_DIGEST_LENGTH],
+                       AC_DEFINE([HAVE_SHA256], 1,
+--- opendkim-2.11.0~alpha.orig/opendkim/opendkim-crypto.c
++++ opendkim-2.11.0~alpha/opendkim/opendkim-crypto.c
+@@ -222,7 +222,11 @@ dkimf_crypto_free_id(void *ptr)
+ 	{
+ 		assert(pthread_setspecific(id_key, ptr) == 0);
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x10100000
++		OPENSSL_thread_stop();
++#else
+ 		ERR_remove_state(0);
++#endif
+ 
+ 		free(ptr);
+ 
+@@ -392,11 +396,15 @@ dkimf_crypto_free(void)
+ {
+ 	if (crypto_init_done)
+ 	{
++#if OPENSSL_VERSION_NUMBER >= 0x10100000
++		OPENSSL_thread_stop();
++#else
+ 		CRYPTO_cleanup_all_ex_data();
+ 		CONF_modules_free();
+ 		EVP_cleanup();
+ 		ERR_free_strings();
+ 		ERR_remove_state(0);
++#endif
+ 
+ 		if (nmutexes > 0)
+ 		{


### PR DESCRIPTION
The patch was accepted upstream for the next release.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer: @val-kulkov 
Compile tested: ramips/bcm47xx, openwrt master