### PR TITLE
bitlbee: added openssl 1.1 support

### DIFF
--- a/net/bitlbee/Makefile
+++ b/net/bitlbee/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bitlbee
 PKG_VERSION:=3.5.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://get.bitlbee.org/src/ \

--- a/net/bitlbee/patches/010-openssl-1.1-compatibility.patch
+++ b/net/bitlbee/patches/010-openssl-1.1-compatibility.patch
@@ -1,0 +1,50 @@
+--- a/lib/ssl_openssl.c
++++ b/lib/ssl_openssl.c
+@@ -64,11 +64,17 @@ void ssl_init(void)
+ {
+ 	const SSL_METHOD *meth;
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	SSL_library_init();
+ 
+ 	meth = SSLv23_client_method();
+ 	ssl_ctx = SSL_CTX_new(meth);
+ 	SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
++#else
++	meth = TLS_client_method();
++	ssl_ctx = SSL_CTX_new(meth);
++	SSL_CTX_set_min_proto_version(ssl_ctx, TLS1_VERSION);
++#endif
+ 
+ 	initialized = TRUE;
+ }
+@@ -300,20 +306,20 @@ size_t ssl_des3_encrypt(const unsigned c
+                         const unsigned char *iv, unsigned char **res)
+ {
+ 	int output_length = 0;
+-	EVP_CIPHER_CTX ctx;
++	EVP_CIPHER_CTX *ctx;
+ 
+ 	*res = g_new0(unsigned char, 72);
+ 
+ 	/* Don't set key or IV because we will modify the parameters */
+-	EVP_CIPHER_CTX_init(&ctx);
+-	EVP_CipherInit_ex(&ctx, EVP_des_ede3_cbc(), NULL, NULL, NULL, 1);
+-	EVP_CIPHER_CTX_set_key_length(&ctx, key_len);
+-	EVP_CIPHER_CTX_set_padding(&ctx, 0);
++	ctx = EVP_CIPHER_CTX_new();
++	EVP_CipherInit_ex(ctx, EVP_des_ede3_cbc(), NULL, NULL, NULL, 1);
++	EVP_CIPHER_CTX_set_key_length(ctx, key_len);
++	EVP_CIPHER_CTX_set_padding(ctx, 0);
+ 	/* We finished modifying parameters so now we can set key and IV */
+-	EVP_CipherInit_ex(&ctx, NULL, NULL, key, iv, 1);
+-	EVP_CipherUpdate(&ctx, *res, &output_length, input, input_len);
+-	EVP_CipherFinal_ex(&ctx, *res, &output_length);
+-	EVP_CIPHER_CTX_cleanup(&ctx);
++	EVP_CipherInit_ex(ctx, NULL, NULL, key, iv, 1);
++	EVP_CipherUpdate(ctx, *res, &output_length, input, input_len);
++	EVP_CipherFinal_ex(ctx, *res, &output_length);
++	EVP_CIPHER_CTX_free(ctx);
+ 	//EVP_cleanup();
+ 
+ 	return output_length;


### PR DESCRIPTION
This patch was submitted upstream.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer: @nikil 
Compile tested: bcm47xx & ramips, openwrt master
