### PR TITLE
CC: perl5: upgrade 3 CPAN packages to fix build

### DIFF
--- a/lang/perl-dbi/Makefile
+++ b/lang/perl-dbi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-dbi
-PKG_VERSION:=1.634
+PKG_VERSION:=1.641
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://www.cpan.org/authors/id/T/TI/TIMB/
 PKG_SOURCE:=DBI-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=4ad15a9c2cc9b68e3fe1f5cadf9cdb30
+PKG_MD5SUM:=e77fd37fcf77fc88fde029c1b75ded54
 
 PKG_LICENSE:=GPL-1.0+ Artistic-1.0-Perl
 PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>

--- a/lang/perl-html-parser/Makefile
+++ b/lang/perl-html-parser/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-html-parser
-PKG_VERSION:=3.71
+PKG_VERSION:=3.72
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://www.cpan.org/authors/id/G/GA/GAAS/
 PKG_SOURCE:=HTML-Parser-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=9128a45893097dfa3bf03301b19c5efe
+PKG_MD5SUM:=eb7505e5f626913350df9dd4a03d54a8
 
 PKG_LICENSE:=GPL-1.0+ Artistic-1.0-Perl
 PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>

--- a/lang/perl-uri/Makefile
+++ b/lang/perl-uri/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-uri
-PKG_VERSION:=1.71
+PKG_VERSION:=1.74
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://www.cpan.org/authors/id/E/ET/ETHER/
 PKG_SOURCE:=URI-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=247c3da29a794f72730e01aa5a715daf
+PKG_MD5SUM:=892f7183b178af40f205ba37128225db
 
 PKG_LICENSE:=GPL-1.0+ Artistic-1.0-Perl
 PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>


### PR DESCRIPTION
Compile tested: CC/sunxi, CC/kirkwood, CC/ar71xx
Runtime tested: CC/sunxi

Description:
Bump 3 packages to fix bugs, and to fix builds as the previous sources were pulled.
