### PR TITLE
CC: php5: bump to 5.6.36 to fix CVEs

### DIFF
--- a/lang/php5/Makefile
+++ b/lang/php5/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=5.6.32
+PKG_VERSION:=5.6.36
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>, Michael Heimpold <mhei@heimpold.de>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_MD5SUM:=660cd5bc0f16eaad655b7815c757aadc
+PKG_MD5SUM:=42a0bf7a41bbb732c400df4d85856e50
 
 PKG_FIXUP:=libtool autoreconf
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: CC/sunxi, CC/kirkwood, CC/ar71xx
Runtime tested: CC/sunxi

Description:
Testing included running a phpinfo() and a mysql test connection via php-cli. A "segfault" appeared at end of code execution, however this was present in the previous 5.6.17 and 5.6.26 builds as well.