### PR TITLE
CC: freeradius2: bump to 2.2.10

### DIFF
--- a/net/freeradius2/Makefile
+++ b/net/freeradius2/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius2
-PKG_VERSION:=2.2.8
-PKG_RELEASE:=2
+PKG_VERSION:=2.2.9
+PKG_RELEASE:=1
 
 PKG_SOURCE:=freeradius-server-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=\
 	ftp://ftp.freeradius.org/pub/freeradius/ \
 	ftp://ftp.freeradius.org/pub/freeradius/old/
-PKG_MD5SUM:=0adc2454392ab8a43664dea416022e28
+PKG_MD5SUM:=d1398327ba4e23c75da06d8a0e01096b
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYRIGHT LICENSE

--- a/net/freeradius2/Makefile
+++ b/net/freeradius2/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius2
-PKG_VERSION:=2.2.9
+PKG_VERSION:=2.2.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=freeradius-server-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=\
 	ftp://ftp.freeradius.org/pub/freeradius/ \
 	ftp://ftp.freeradius.org/pub/freeradius/old/
-PKG_MD5SUM:=d1398327ba4e23c75da06d8a0e01096b
+PKG_MD5SUM:=f1ce12d2b8258585cb3d525f5bdfeb17
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYRIGHT LICENSE


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: ar71xx, sunxi
Runtime tested: sunxi

Description:
Addresses open CVEs in these packages, while jumping to the latest (and probably the last) version in the 2.2.x branch.
