### PR TITLE
CC: openldap: bump to 2.4.46

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
-PKG_VERSION:=2.4.44
+PKG_VERSION:=2.4.45
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/ \
 	ftp://sunsite.cnlab-switch.ch/mirror/OpenLDAP/openldap-release/ \
 	ftp://ftp.nl.uu.net/pub/unix/db/openldap/openldap-release/ \
 	ftp://ftp.plig.org/pub/OpenLDAP/openldap-release/
-PKG_MD5SUM:=693ac26de86231f8dcae2b4e9d768e51
+PKG_MD5SUM:=00ff8301277cdfd0af728a6927042a13
 
 PKG_FIXUP:=autoreconf
 

--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
-PKG_VERSION:=2.4.45
+PKG_VERSION:=2.4.46
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/ \
 	ftp://sunsite.cnlab-switch.ch/mirror/OpenLDAP/openldap-release/ \
 	ftp://ftp.nl.uu.net/pub/unix/db/openldap/openldap-release/ \
 	ftp://ftp.plig.org/pub/OpenLDAP/openldap-release/
-PKG_MD5SUM:=00ff8301277cdfd0af728a6927042a13
+PKG_MD5SUM:=829016c5a9f45c51adc50073ac6f9fd7
 
 PKG_FIXUP:=autoreconf
 

--- a/libs/openldap/patches/002-no-doc-and-tests-subdir.patch
+++ b/libs/openldap/patches/002-no-doc-and-tests-subdir.patch
@@ -1,0 +1,5 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1 +1 @@
+-SUBDIRS = include libraries clients servers tests doc
++SUBDIRS = include libraries clients servers


### PR DESCRIPTION
Maintainer: @MikePetullo 

Compile tested: CC/ar71xx, CC/sunxi
Runtime tested: CC/sunxi

Description:
Upgrade to latest available version, while fixing CVEs.