### PR TITLE
conserver: bump to v8.2.2 - adds openssl 1.1 compatibility

### DIFF
--- a/net/conserver/Makefile
+++ b/net/conserver/Makefile
@@ -8,13 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conserver
-PKG_VERSION:=8.2.1
+PKG_VERSION:=8.2.2
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Bjørn Mork <bjorn@mork.no>
 
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/conserver/conserver.git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.conserver.com/
-PKG_HASH:=251ae01997e8f3ee75106a5b84ec6f2a8eb5ff2f8092438eba34384a615153d0
+PKG_MIRROR_HASH:=27d92e6c04e97cd0884774eace0b44f30087695927bcce8addc11dba9c090d7c
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Added a patch based on @FauxFaux work to add openssl 1.1 compatibility.
I added a patch so that anonymous ciphers work with openssl 1.1, just as they work with previous openssl versions, to maintain the same behaviour.  Not sure I should apply the last one.
This patch has been submitted upstream.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer: @bmork 
Compile tested: bcm47xx, ramips, openwrt master
Run tested: x86_64, outside of openwrt
