### PR TITLE
freeradius3: update to 3.0.17

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
-PKG_VERSION:=release_3_0_11
-PKG_RELEASE:=3
+PKG_VERSION:=release_3_0_17
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive
-PKG_HASH:=f0b32edb90368c3b9523e2baa792a1794d8bad662407f0d210a6c460541379b7
+PKG_HASH:=5b2382f08c0d9d064298281c1fb8348fc13df76550ce7a5cfc47ea91361fad91
 
 PKG_MAINTAINER:=Lucile Quirion <lucile.quirion@savoirfairelinux.com>
 PKG_LICENSE:=GPL-2.0
@@ -486,6 +486,13 @@ ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-ldap),)
 		--with-rlm_ldap-lib-dir="$(STAGING_DIR)/usr/lib"
 else
   CONFIGURE_ARGS+= --without-rlm_ldap
+endif
+
+ifeq ($(CONFIG_USE_GLIBC),y)
+  TARGET_CFLAGS+= -DLIBBSD_OVERLAY -I$(STAGING_DIR)/usr/include/bsd \
+	-D_RPC_NETDB_H
+	#^^^^^^^^^^^^^ avoid inclusion of librpc's netdb.h
+  CONFIGURE_LIBS+= -Wl,--push-state,--as-needed -lbsd -Wl,--pop-state
 endif
 
 CONFIGURE_VARS+= \

--- a/net/freeradius3/patches/002-disable-session-cache-CVE-2017-9148.patch
+++ b/net/freeradius3/patches/002-disable-session-cache-CVE-2017-9148.patch
@@ -9,7 +9,7 @@ Last-Update: 2017-05-30
 
 --- a/src/main/tls.c
 +++ b/src/main/tls.c
-@@ -369,7 +369,7 @@ tls_session_t *tls_new_session(TALLOC_CT
+@@ -594,7 +594,7 @@ tls_session_t *tls_new_session(TALLOC_CT
  	 *
  	 *	FIXME: Also do it every N sessions?
  	 */
@@ -18,7 +18,7 @@ Last-Update: 2017-05-30
  	    ((conf->session_last_flushed + ((int)conf->session_timeout * 1800)) <= request->timestamp)){
  		RDEBUG2("Flushing SSL sessions (of #%ld)", SSL_CTX_sess_number(conf->ctx));
  
-@@ -463,7 +463,7 @@ tls_session_t *tls_new_session(TALLOC_CT
+@@ -689,7 +689,7 @@ tls_session_t *tls_new_session(TALLOC_CT
  		state->mtu = vp->vp_integer;
  	}
  
@@ -27,7 +27,7 @@ Last-Update: 2017-05-30
  
  	return state;
  }
-@@ -2675,7 +2675,7 @@ post_ca:
+@@ -3151,7 +3151,7 @@ post_ca:
  	/*
  	 *	Callbacks, etc. for session resumption.
  	 */
@@ -36,7 +36,7 @@ Last-Update: 2017-05-30
  		/*
  		 *	Cache sessions on disk if requested.
  		 */
-@@ -2745,7 +2745,7 @@ post_ca:
+@@ -3221,7 +3221,7 @@ post_ca:
  	/*
  	 *	Setup session caching
  	 */

--- a/net/freeradius3/patches/003-freeradius-fix-error-for-expansion-of-macro.patch
+++ b/net/freeradius3/patches/003-freeradius-fix-error-for-expansion-of-macro.patch
@@ -1,0 +1,33 @@
+--- a/src/include/threads.h
++++ b/src/include/threads.h
+@@ -89,7 +89,7 @@ static _t __fr_thread_local_init_##_n(pt
+ #  define fr_thread_local_get(_n) _n
+ #elif defined(HAVE_PTHREAD_H)
+ #  include <pthread.h>
+-#  define fr_thread_local_setup(_t, _n) \
++#  define fr_thread_local_setup(_t, _n) static __thread _t _n;\
+ static pthread_key_t __fr_thread_local_key_##_n;\
+ static pthread_once_t __fr_thread_local_once_##_n = PTHREAD_ONCE_INIT;\
+ static pthread_destructor_t __fr_thread_local_destructor_##_n = NULL;\
+@@ -100,17 +100,17 @@ static void __fr_thread_local_destroy_##
+ static void __fr_thread_local_key_init_##_n(void)\
+ {\
+ 	(void) pthread_key_create(&__fr_thread_local_key_##_n, __fr_thread_local_destroy_##_n);\
+-	(void) pthread_setspecific(__fr_thread_local_key_##_n, &(_n));\
+ }\
+ static _t __fr_thread_local_init_##_n(pthread_destructor_t func)\
+ {\
+ 	__fr_thread_local_destructor_##_n = func;\
+ 	if (_n) return _n; \
+ 	(void) pthread_once(&__fr_thread_local_once_##_n, __fr_thread_local_key_init_##_n);\
++	(void) pthread_setspecific(__fr_thread_local_key_##_n, &(_n));\
+ 	return _n;\
+ }
+-#  define fr_thread_local_init(_n, _f)			__fr_thread_local_init_##_n(_f)
+-#  define fr_thread_local_set(_n, _v)			__fr_thread_local_set_##_n(_v)
+-#  define fr_thread_local_get(_n)			__fr_thread_local_get_##_n()
++#  define fr_thread_local_init(_n, _f)	__fr_thread_local_init_##_n(_f)
++#  define fr_thread_local_set(_n, _v) ((int)!((_n = _v) || 1))
++#  define fr_thread_local_get(_n) _n
+ #endif
+ #endif


### PR DESCRIPTION
Latest stable release.  Adds support for openssl 1.1

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer: @LucileQ
Compile tested: ramips/bcm47xx openwrt master



