### PR TITLE
Fix for error when building diffutils on x86_64:

### DIFF
--- a/devel/diffutils/Makefile
+++ b/devel/diffutils/Makefile
@@ -35,6 +35,7 @@ define Package/diffutils/description
 endef
 
 CONFIGURE_VARS += \
+	gl_cv_func_getopt_gnu=yes \
 	ac_cv_func_mempcpy=n
 TARGET_CFLAGS += --std=gnu99
 


### PR DESCRIPTION
Compile tested: x86_64

I was getting this error when building diffutils on x86_64:
./config.h:2070:25: warning: 'struct rpl_option' declared inside ...

More information on this error here:
https://www.mail-archive.com/clfs-support@lists.clfs.org/msg00297.html

I'm not sure if this is an issue in my build environment, but I believe this is the proper fix because gzip and zile use the same option:

./utils/gzip/Makefile:	gl_cv_func_getopt_gnu=yes \
./utils/zile/Makefile:	gl_cv_func_getopt_gnu=yes \





