### PR TITLE
ibrdtnd: added openssl 1.1 compatibility

### DIFF
--- a/net/ibrdtnd/Makefile
+++ b/net/ibrdtnd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ibrdtnd
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.ibr.cs.tu-bs.de/projects/ibr-dtn/releases
@@ -17,6 +17,7 @@ PKG_HASH:=9bd79636154093ab6bf4fd10d6c62d67c6db45141460847b19def327c93771ed
 PKG_MAINTAINER:=Johannes Morgenroth <jm@m-network.de>
 PKG_LICENSE:=Apache-2.0
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -43,6 +44,8 @@ CONFIGURE_ARGS += \
 	--without-wifip2p \
 	--without-vmime \
 	--disable-libdaemon
+
+TARGET_CXXFLAGS += -std=gnu++03
 
 define Package/ibrdtnd/install
 	$(INSTALL_DIR) $(1)/usr/sbin/

--- a/net/ibrdtnd/patches/0001-ibrdtnd-added-openssl-compatibility.patch
+++ b/net/ibrdtnd/patches/0001-ibrdtnd-added-openssl-compatibility.patch
@@ -1,0 +1,202 @@
+From c794bbd16d2f39c656478608eb1314055e877370 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cote2004-github@yahoo.com>
+Date: Sat, 26 May 2018 23:44:54 -0300
+Subject: [PATCH] ibrdtnd: added openssl compatibility
+
+This patch adds compatibility with openssl 1.1.0 to ibrdtnd.
+
+Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
+---
+ ibrdtn/daemon/src/security/exchange/DHProtocol.cpp | 36 ++++++++++---
+ ibrdtn/daemon/src/security/exchange/Makefile.am    |  2 +
+ .../src/security/exchange/openssl_compat.cpp       | 62 ++++++++++++++++++++++
+ .../daemon/src/security/exchange/openssl_compat.h  | 13 +++++
+ 4 files changed, 107 insertions(+), 6 deletions(-)
+ create mode 100644 ibrdtn/daemon/src/security/exchange/openssl_compat.cpp
+ create mode 100644 ibrdtn/daemon/src/security/exchange/openssl_compat.h
+
+diff --git a/src/security/exchange/DHProtocol.cpp b/src/security/exchange/DHProtocol.cpp
+index e94c5026..3e0ad717 100644
+--- a/src/security/exchange/DHProtocol.cpp
++++ b/src/security/exchange/DHProtocol.cpp
+@@ -30,6 +30,7 @@
+ 
+ #include <openssl/rand.h>
+ #include <openssl/pem.h>
++#include "openssl_compat.h"
+ 
+ #define DH_KEY_LENGTH 1024
+ 
+@@ -132,6 +133,7 @@ namespace dtn
+ 
+ 		void DHProtocol::begin(KeyExchangeSession &session, KeyExchangeData &data)
+ 		{
++			const BIGNUM *pub_key, *p, *g;
+ 			// get session state
+ 			DHState &state = session.getState<DHState>();
+ 
+@@ -159,9 +161,12 @@ namespace dtn
+ 			// prepare request
+ 			KeyExchangeData request(KeyExchangeData::REQUEST, session);
+ 
+-			write(request, state.dh->pub_key);
+-			write(request, state.dh->p);
+-			write(request, state.dh->g);
++			DH_get0_pqg(state.dh, &p, NULL, &g);
++			DH_get0_key(state.dh, &pub_key, NULL);
++
++			write(request, pub_key);
++			write(request, p);
++			write(request, g);
+ 
+ 			manager.submit(session, request);
+ 		}
+@@ -177,6 +182,15 @@ namespace dtn
+ 				{
+ 					if (data.getAction() == KeyExchangeData::REQUEST)
+ 					{
++						BIGNUM *p = BN_new();
++						BIGNUM *g = BN_new();
++						if (p == NULL || g == NULL)
++						{
++							BN_free(p);
++							BN_free(g);
++							throw ibrcommon::Exception("Error while allocating space for DH parameters");
++						}
++
+ 						BIGNUM* pub_key = BN_new();
+ 						read(data, &pub_key);
+ 
+@@ -184,8 +198,16 @@ namespace dtn
+ 						state.dh = DH_new();
+ 
+ 						// read p and g paramter from message
+-						read(data, &state.dh->p);
+-						read(data, &state.dh->g);
++						read(data, &p);
++						read(data, &g);
++
++						if (DH_set0_pqg(state.dh, p, NULL, g))
++						{
++							BN_free(p);
++							BN_free(g);
++							BN_free(pub_key);
++							throw ibrcommon::Exception("Error while setting DH parameters");
++						}
+ 
+ 						int codes;
+ 						if (!DH_check(state.dh, &codes))
+@@ -213,7 +235,9 @@ namespace dtn
+ 						state.secret.assign((const char*)secret, length);
+ 
+ 						KeyExchangeData response(KeyExchangeData::RESPONSE, session);
+-						write(response, state.dh->pub_key);
++						const BIGNUM *state_dh_pub_key;
++						DH_get0_key(state.dh, &state_dh_pub_key, NULL);
++						write(response, state_dh_pub_key);
+ 
+ 						manager.submit(session, response);
+ 
+diff --git a/src/security/exchange/Makefile.am b/src/security/exchange/Makefile.am
+index a6b2f832..71ed8365 100644
+--- a/src/security/exchange/Makefile.am
++++ b/src/security/exchange/Makefile.am
+@@ -22,6 +22,8 @@ exchange_SOURCES += \
+ 	NFCProtocol.cpp \
+ 	NoneProtocol.h \
+ 	NoneProtocol.cpp \
++	openssl_compat.h \
++	openssl_compat.cpp \
+ 	QRCodeProtocol.h \
+ 	QRCodeProtocol.cpp
+ 	
+diff --git a/src/security/exchange/openssl_compat.cpp b/src/security/exchange/openssl_compat.cpp
+new file mode 100644
+index 00000000..e3baba0f
+--- /dev/null
++++ b/src/security/exchange/openssl_compat.cpp
+@@ -0,0 +1,62 @@
++/*
++ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
++ *
++ * Licensed under the OpenSSL license (the "License").  You may not use
++ * this file except in compliance with the License.  You can obtain a copy
++ * in the file LICENSE in the source distribution or at
++ * https://www.openssl.org/source/license.html
++ */
++
++#include "openssl_compat.h"
++
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++
++void DH_get0_pqg(const DH *dh,
++                 const BIGNUM **p, const BIGNUM **q, const BIGNUM **g)
++{
++    if (p != NULL)
++        *p = dh->p;
++    if (q != NULL)
++        *q = dh->q;
++    if (g != NULL)
++        *g = dh->g;
++}
++
++int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
++{
++    /* If the fields p and g in d are NULL, the corresponding input
++     * parameters MUST be non-NULL.  q may remain NULL.
++     */
++    if ((dh->p == NULL && p == NULL)
++        || (dh->g == NULL && g == NULL))
++        return 0;
++
++    if (p != NULL) {
++        BN_free(dh->p);
++        dh->p = p;
++    }
++    if (q != NULL) {
++        BN_free(dh->q);
++        dh->q = q;
++    }
++    if (g != NULL) {
++        BN_free(dh->g);
++        dh->g = g;
++    }
++
++    if (q != NULL) {
++        dh->length = BN_num_bits(q);
++    }
++
++    return 1;
++}
++
++void DH_get0_key(const DH *dh, const BIGNUM **pub_key, const BIGNUM **priv_key)
++{
++    if (pub_key != NULL)
++        *pub_key = dh->pub_key;
++    if (priv_key != NULL)
++        *priv_key = dh->priv_key;
++}
++
++#endif /* OPENSSL_VERSION_NUMBER */
+diff --git a/src/security/exchange/openssl_compat.h b/src/security/exchange/openssl_compat.h
+new file mode 100644
+index 00000000..29e7d415
+--- /dev/null
++++ b/src/security/exchange/openssl_compat.h
+@@ -0,0 +1,13 @@
++#ifndef LIBCRYPTO_COMPAT_H
++#define LIBCRYPTO_COMPAT_H
++
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++
++#include <openssl/dh.h>
++
++void DH_get0_pqg(const DH *dh, const BIGNUM **p, const BIGNUM **q, const BIGNUM **g);
++int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g);
++void DH_get0_key(const DH *dh, const BIGNUM **pub_key, const BIGNUM **priv_key);
++
++#endif /* OPENSSL_VERSION_NUMBER */
++#endif /* LIBCRYPTO_COMPAT_H */
+-- 
+2.16.1
+


### PR DESCRIPTION
This patch adds compatibility with openssl 1.1.0 to ibrdtnd.  It has been submitted upstream.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer: @morgenroth 
Compile tested: bcm47xx/ramips, openwrt master
Run tested: x86_64