### PR TITLE
postfix: version update to 3.3.1

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postfix
 PKG_RELEASE:=1
-PKG_VERSION:=3.3.0
+PKG_VERSION:=3.3.1
 PKG_SOURCE_URL:= \
 	https://cdn.postfix.johnriley.me/mirrors/postfix-release/official/ \
 	ftp://ftp.porcupine.org/mirrors/postfix-release/official/
 
-PKG_HASH:=7942e89721e30118d7050675b0d976955e3160e21f7898b85a79cac4f4baef39
+PKG_HASH:=54f514dae42b5275cb4bc9c69283f16c06200b71813d0bb696568c4ba7ae7e3b
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_MAINTAINER:=Denis Shulyaka <Shulyaka@gmail.com>
 PKG_LICENSE:=IPL-1.0


### PR DESCRIPTION
Signed-off-by: Denis Shulyaka <Shulyaka@gmail.com>

Maintainer: me
Compile tested: D-Link DIR-825 (ar71xx, OpenWRT trunk)
Run tested: Turris Omnia (mvebu/armv7-a, start/stop)

Description: Version bump from 3.3.0 to 3.3.1