### PR TITLE
net/mwan3: fix connected networks

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.6.16
+PKG_VERSION:=2.6.17
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -16,14 +16,14 @@ config_load mwan3
 config_get_bool enabled globals 'enabled' '0'
 [ ${enabled} -gt 0 ] || exit 0
 
-config_get enabled $INTERFACE enabled 0
-config_get initial_state $INTERFACE initial_state "online"
-[ "$enabled" == "1" ] || exit 0
-
 mwan3_lock
 mwan3_init
 mwan3_set_connected_iptables
 mwan3_unlock
+
+config_get enabled $INTERFACE enabled 0
+config_get initial_state $INTERFACE initial_state "online"
+[ "$enabled" == "1" ] || exit 0
 
 if [ "$ACTION" == "ifup" ]; then
 	config_get family $INTERFACE family ipv4


### PR DESCRIPTION
Maintainer: me 
Compile tested: only scripts
Run tested: x86_64, lantiq_xrx200, OpenWrt master, running tests

Description:
If an interface is not tracked by mwan3 or enabled and this interface is setup by netifd, then the connected ipset is not update by mwan3. To fix this also call connected ipset update code even if the interface is not tracked or enabled by mwan3.
