### PR TITLE
libxml2: revision bump to force clean build

### DIFF
--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxml2
 PKG_VERSION:=2.9.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://xmlsoft.org/sources/


### PR DESCRIPTION
Commit dcd68100c23f980a7bbd1d7d9567a315ee584bdf fixed the zlib pkgconfig
file. But libxml2/host is stuck in the compile phase on the build bots.
Bumping the revision will force a clean build.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @mhei 
Compile tested: N/A
Run tested: N/A

Description:
Hello Michael,

@jow fixed issue #6073, but on the openwrt-18.06 build bot libxml2/host is stuck in the compile phase. Bumping the revision will cause a clean build, so that the configure stage is run again and libxml2 picks up the correct headers.

There is the arc700 target which was added _after_ jow fixed the zlib package. It's visible that there libxml2/host builds fine.

Thanks!
Seb