### PR TITLE
nginx: Package bump to 1.14.0

### DIFF
--- a/net/nginx/Config.in
+++ b/net/nginx/Config.in
@@ -201,5 +201,19 @@ config NGINX_HTTP_SECURE_LINK
 	bool
 	prompt "Enable HTTP secure link module"
 	default n
+	
+config NGINX_HEADERS_MORE
+	bool
+	prompt "Enable Headers_more module"
+	help
+		Set and clear input and output headers...more than "add"!
+	default y
+	
+config NGINX_HTTP_BROTLI
+	bool
+	prompt "Enable Brotli compression module"
+	help
+		Add support for brotli compression module.
+	default n
 
 endmenu

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -8,12 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
-PKG_VERSION:=1.12.2
+PKG_VERSION:=1.14.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://nginx.org/download/
-PKG_HASH:=305f379da1d5fb5aefa79e45c829852ca6983c7cd2a79328f8e084a324cf0416
+PKG_HASH:=5d15becbf69aba1fe33f8d416d97edd95ea8919ea9ac519eff9bafebb6022cb5
+
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=2-clause BSD-like license
 
@@ -60,7 +61,9 @@ PKG_CONFIG_DEPENDS := \
 	CONFIG_NGINX_NAXSI \
 	CONFIG_NGINX_LUA \
 	CONFIG_NGINX_HTTP_REAL_IP \
-	CONFIG_NGINX_HTTP_SECURE_LINK
+	CONFIG_NGINX_HTTP_SECURE_LINK \
+	CONFIG_NGINX_HTTP_BROTLI \
+	CONFIG_NGINX_HEADERS_MORE
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -208,6 +211,12 @@ endif
 ifeq ($(CONFIG_NGINX_HTTP_SECURE_LINK),y)
   ADDITIONAL_MODULES += --with-http_secure_link_module
 endif
+ifeq ($(CONFIG_NGINX_HEADERS_MORE),y)
+  ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-headers-more
+endif
+ifeq ($(CONFIG_NGINX_HTTP_BROTLI),y)
+  ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-brotli
+endif
 
 TARGET_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -DNGX_LUA_NO_BY_LUA_BLOCK
 TARGET_LDFLAGS += -Wl,--gc-sections
@@ -254,10 +263,38 @@ define Build/Prepare
 	$(call Build/Prepare/Default)
 	$(if $(CONFIG_NGINX_NAXSI),$(call Prepare/nginx-naxsi))
 	$(if $(CONFIG_NGINX_LUA),$(call Prepare/lua-nginx))
+	$(if $(CONFIG_NGINX_HTTP_BROTLI),$(call Prepare/nginx-brotli))
+	$(if $(CONFIG_NGINX_HEADERS_MORE),$(call Prepare/nginx-headers-more))
+endef
+
+define Download/nginx-headers-more
+	VERSION:=a9f7c7e86cc7441d04e2f11f01c2e3a9c4b0301d
+	SUBDIR:=nginx-headers-more
+	FILE:=headers-more-nginx-module-$(PKG_VERSION)-$$(VERSION).tar.gz
+	URL:=https://github.com/openresty/headers-more-nginx-module.git
+	PROTO:=git
+endef
+
+define  Prepare/nginx-headers-more
+	$(eval $(call Download,nginx-headers-more))
+	gzip -dc $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
+endef
+
+define Download/nginx-brotli
+	VERSION:=37ab9b2933a0b756ba3447000b7f31d432ed8228
+	SUBDIR:=nginx-brotli
+	FILE:=ngx-brotli-module-$(PKG_VERSION)-$$(VERSION).tar.gz
+	URL:=https://github.com/eustas/ngx_brotli.git
+	PROTO:=git
+endef
+
+define  Prepare/nginx-brotli
+	$(eval $(call Download,nginx-brotli))
+	gzip -dc $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
 endef
 
 define Download/nginx-naxsi
-	VERSION:=cf73f9c8664127252c2a4958d2e169516d3845a1
+	VERSION:=fc4740f9734cabc1ce4c9d4cddc4b472eab1cc4b
 	SUBDIR:=nginx-naxsi
 	FILE:=nginx-naxsi-module-$(PKG_VERSION)-$$(VERSION).tar.gz
 	URL:=https://github.com/nbs-system/naxsi.git
@@ -270,7 +307,7 @@ define  Prepare/nginx-naxsi
 endef
 
 define Download/lua-nginx
-	VERSION:=cdd2ae921f67bf396c743406493127be496e57ce
+	VERSION:=55743aeba3075b34a250380b32bad6366eae6c30
 	SUBDIR:=lua-nginx
 	FILE:=lua-nginx-module-$(PKG_VERSION)-$$(VERSION).tar.gz
 	URL:=https://github.com/openresty/lua-nginx-module.git

--- a/net/nginx/patches-lua-nginx/100-no_by_lua_block.patch
+++ b/net/nginx/patches-lua-nginx/100-no_by_lua_block.patch
@@ -1,6 +1,6 @@
 --- a/lua-nginx/src/ngx_http_lua_module.c
 +++ b/lua-nginx/src/ngx_http_lua_module.c
-@@ -157,14 +157,14 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -165,14 +165,14 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        offsetof(ngx_http_lua_loc_conf_t, log_socket_errors),
        NULL },
@@ -17,7 +17,7 @@
      { ngx_string("init_by_lua"),
        NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
        ngx_http_lua_init_by_lua,
-@@ -178,14 +178,14 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -186,14 +186,14 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_MAIN_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_init_by_file },
@@ -34,7 +34,7 @@
      { ngx_string("init_worker_by_lua"),
        NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
        ngx_http_lua_init_worker_by_lua,
-@@ -201,6 +201,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -209,6 +209,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        (void *) ngx_http_lua_init_worker_by_file },
  
  #if defined(NDK) && NDK
@@ -42,7 +42,7 @@
      /* set_by_lua $res { inline Lua code } [$arg1 [$arg2 [...]]] */
      { ngx_string("set_by_lua_block"),
        NGX_HTTP_SRV_CONF|NGX_HTTP_SIF_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
-@@ -209,7 +210,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -217,7 +218,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_filter_set_by_lua_inline },
@@ -51,7 +51,7 @@
      /* set_by_lua $res <inline script> [$arg1 [$arg2 [...]]] */
      { ngx_string("set_by_lua"),
        NGX_HTTP_SRV_CONF|NGX_HTTP_SIF_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
-@@ -237,7 +238,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -245,7 +246,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_rewrite_handler_inline },
@@ -60,7 +60,7 @@
      /* rewrite_by_lua_block { <inline script> } */
      { ngx_string("rewrite_by_lua_block"),
        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
-@@ -246,7 +247,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -254,7 +255,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_rewrite_handler_inline },
@@ -69,7 +69,7 @@
      /* access_by_lua "<inline script>" */
      { ngx_string("access_by_lua"),
        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
-@@ -255,7 +256,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -263,7 +264,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_access_handler_inline },
@@ -78,7 +78,7 @@
      /* access_by_lua_block { <inline script> } */
      { ngx_string("access_by_lua_block"),
        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
-@@ -264,7 +265,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -272,7 +273,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_access_handler_inline },
@@ -87,7 +87,7 @@
      /* content_by_lua "<inline script>" */
      { ngx_string("content_by_lua"),
        NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_TAKE1,
-@@ -272,7 +273,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -280,7 +281,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_content_handler_inline },
@@ -96,7 +96,7 @@
      /* content_by_lua_block { <inline script> } */
      { ngx_string("content_by_lua_block"),
        NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_BLOCK|NGX_CONF_NOARGS,
-@@ -280,7 +281,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -288,7 +289,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_content_handler_inline },
@@ -105,7 +105,7 @@
      /* log_by_lua <inline script> */
      { ngx_string("log_by_lua"),
        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
-@@ -289,7 +290,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -297,7 +298,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_log_handler_inline },
@@ -114,7 +114,7 @@
      /* log_by_lua_block { <inline script> } */
      { ngx_string("log_by_lua_block"),
        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
-@@ -298,7 +299,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -306,7 +307,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_log_handler_inline },
@@ -123,7 +123,7 @@
      { ngx_string("rewrite_by_lua_file"),
        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
                          |NGX_CONF_TAKE1,
-@@ -353,7 +354,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -361,7 +362,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_header_filter_inline },
@@ -132,7 +132,7 @@
      /* header_filter_by_lua_block { <inline script> } */
      { ngx_string("header_filter_by_lua_block"),
        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
-@@ -362,7 +363,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -370,7 +371,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_header_filter_inline },
@@ -141,7 +141,7 @@
      { ngx_string("header_filter_by_lua_file"),
        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
                          |NGX_CONF_TAKE1,
-@@ -378,7 +379,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -386,7 +387,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_body_filter_inline },
@@ -150,7 +150,7 @@
      /* body_filter_by_lua_block { <inline script> } */
      { ngx_string("body_filter_by_lua_block"),
        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
-@@ -387,7 +388,7 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -395,7 +396,7 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_body_filter_inline },
@@ -159,7 +159,7 @@
      { ngx_string("body_filter_by_lua_file"),
        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF
                          |NGX_CONF_TAKE1,
-@@ -395,14 +396,14 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -403,14 +404,14 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        0,
        (void *) ngx_http_lua_body_filter_file },
@@ -176,7 +176,7 @@
      { ngx_string("balancer_by_lua_file"),
        NGX_HTTP_UPS_CONF|NGX_CONF_TAKE1,
        ngx_http_lua_balancer_by_lua,
-@@ -509,14 +510,14 @@ static ngx_command_t ngx_http_lua_cmds[]
+@@ -517,14 +518,14 @@ static ngx_command_t ngx_http_lua_cmds[]
        NGX_HTTP_LOC_CONF_OFFSET,
        offsetof(ngx_http_lua_loc_conf_t, ssl_ciphers),
        NULL },

--- a/net/nginx/patches/101-feature_test_fix.patch
+++ b/net/nginx/patches/101-feature_test_fix.patch
@@ -11,7 +11,7 @@
      ngx_feature_libs=
 --- a/auto/cc/conf
 +++ b/auto/cc/conf
-@@ -200,7 +200,7 @@ if [ "$NGX_PLATFORM" != win32 ]; then
+@@ -204,7 +204,7 @@ if [ "$NGX_PLATFORM" != win32 ]; then
      else
          ngx_feature="C99 variadic macros"
          ngx_feature_name="NGX_HAVE_C99_VARIADIC_MACROS"
@@ -20,7 +20,7 @@
          ngx_feature_incs="#include <stdio.h>
  #define var(dummy, ...)  sprintf(__VA_ARGS__)"
          ngx_feature_path=
-@@ -214,7 +214,7 @@ if [ "$NGX_PLATFORM" != win32 ]; then
+@@ -218,7 +218,7 @@ if [ "$NGX_PLATFORM" != win32 ]; then
  
      ngx_feature="gcc variadic macros"
      ngx_feature_name="NGX_HAVE_GCC_VARIADIC_MACROS"
@@ -40,7 +40,7 @@
  ngx_feature_incs="#include <sys/epoll.h>"
  ngx_feature_path=
  ngx_feature_libs=
-@@ -93,7 +93,7 @@ ngx_feature_test="int fd; struct stat sb
+@@ -110,7 +110,7 @@ ngx_feature_test="int fd; struct stat sb
  CC_AUX_FLAGS="$cc_aux_flags -D_GNU_SOURCE"
  ngx_feature="sendfile()"
  ngx_feature_name="NGX_HAVE_SENDFILE"
@@ -49,7 +49,7 @@
  ngx_feature_incs="#include <sys/sendfile.h>
                    #include <errno.h>"
  ngx_feature_path=
-@@ -114,7 +114,7 @@ fi
+@@ -131,7 +131,7 @@ fi
  CC_AUX_FLAGS="$cc_aux_flags -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64"
  ngx_feature="sendfile64()"
  ngx_feature_name="NGX_HAVE_SENDFILE64"
@@ -58,7 +58,7 @@
  ngx_feature_incs="#include <sys/sendfile.h>
                    #include <errno.h>"
  ngx_feature_path=
-@@ -132,7 +132,7 @@ ngx_include="sys/prctl.h"; . auto/includ
+@@ -149,7 +149,7 @@ ngx_include="sys/prctl.h"; . auto/includ
  
  ngx_feature="prctl(PR_SET_DUMPABLE)"
  ngx_feature_name="NGX_HAVE_PR_SET_DUMPABLE"
@@ -69,7 +69,7 @@
  ngx_feature_libs=
 --- a/auto/unix
 +++ b/auto/unix
-@@ -735,7 +735,7 @@ ngx_feature_test="void *p; p = memalign(
+@@ -840,7 +840,7 @@ ngx_feature_test="void *p; p = memalign(
  
  ngx_feature="mmap(MAP_ANON|MAP_SHARED)"
  ngx_feature_name="NGX_HAVE_MAP_ANON"
@@ -78,7 +78,7 @@
  ngx_feature_incs="#include <sys/mman.h>"
  ngx_feature_path=
  ngx_feature_libs=
-@@ -748,7 +748,7 @@ ngx_feature_test="void *p;
+@@ -853,7 +853,7 @@ ngx_feature_test="void *p;
  
  ngx_feature='mmap("/dev/zero", MAP_SHARED)'
  ngx_feature_name="NGX_HAVE_MAP_DEVZERO"
@@ -87,7 +87,7 @@
  ngx_feature_incs="#include <sys/mman.h>
                    #include <sys/stat.h>
                    #include <fcntl.h>"
-@@ -763,7 +763,7 @@ ngx_feature_test='void *p; int  fd;
+@@ -868,7 +868,7 @@ ngx_feature_test='void *p; int  fd;
  
  ngx_feature="System V shared memory"
  ngx_feature_name="NGX_HAVE_SYSVSHM"
@@ -96,7 +96,7 @@
  ngx_feature_incs="#include <sys/ipc.h>
                    #include <sys/shm.h>"
  ngx_feature_path=
-@@ -777,7 +777,7 @@ ngx_feature_test="int  id;
+@@ -882,7 +882,7 @@ ngx_feature_test="int  id;
  
  ngx_feature="POSIX semaphores"
  ngx_feature_name="NGX_HAVE_POSIX_SEM"

--- a/net/nginx/patches/102-sizeof_test_fix.patch
+++ b/net/nginx/patches/102-sizeof_test_fix.patch
@@ -16,7 +16,7 @@
      return 0;
  }
  
-@@ -40,7 +45,7 @@ eval "$ngx_test >> $NGX_AUTOCONF_ERR 2>&
+@@ -40,7 +46,7 @@ eval "$ngx_test >> $NGX_AUTOCONF_ERR 2>&
  
  
  if [ -x $NGX_AUTOTEST ]; then


### PR DESCRIPTION
This bump nginx package to latest stable.
Also add support for the brotli compression module and head_more module.
head_mode module from this

https://forum.lede-project.org/t/nginx-extra-or-with-headers-more-nginx-module/1731/3

@heil 
Run tested: r7800

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
