### PR TITLE
fcgi: change PKG_SOURCE_URL

### DIFF
--- a/libs/fcgi/Makefile
+++ b/libs/fcgi/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=2.4.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.fastcgi.com/dist/
+PKG_SOURCE_URL:=https://github.com/helllkz/openwrt-package/raw/master/
 PKG_HASH:=66fc45c6b36a21bf2fbbb68e90f780cc21a9da1fffbae75e76d2b4402d3f05b9
 
 PKG_FIXUP:=libtool-ucxx
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/fcgi/Default
   SECTION:=libs
   CATEGORY:=Libraries
-  URL:=http://www.fastcgi.com/
+  URL:=https://fastcgi-archives.github.io/
 endef
 
 define Package/fcgi


### PR DESCRIPTION
Signed-off-by: kaizhong liu <helllkz@126.com>

Description:

Due to www.fastcgi.com is unavailable, just change pkg url to github