### PR TITLE
noddos: add compatibility with openssl 1.1

### DIFF
--- a/net/noddos/Makefile
+++ b/net/noddos/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 # Name and release number of this package
 PKG_NAME:=noddos
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPLv3
 PKG_MAINTAINER:=Steven Hessing <steven.hessing@gmail.com>
 

--- a/net/noddos/patches/010-openssl-1.1-fixes.patch
+++ b/net/noddos/patches/010-openssl-1.1-fixes.patch
@@ -1,0 +1,13 @@
+--- a/src/opensslfingerprint.cxx
++++ b/src/opensslfingerprint.cxx
+@@ -110,7 +110,9 @@ std::string getCertFingerprint(const std
+ 	snprintf(&fpbuf[57], 3, "%02x", md[19]);
+ 
+ 	if (Debug) {
+-		syslog (LOG_DEBUG, "Cert: %s, fingerprint: %s", x->name, fpbuf);
++		char *namebuf = X509_NAME_oneline(X509_get_subject_name(x),NULL,0);
++		syslog (LOG_DEBUG, "Cert: %s, fingerprint: %s", namebuf, fpbuf);
++		free(namebuf);
+ 	}
+ 
+ 	std::string fp = fpbuf;


### PR DESCRIPTION
Maintainer: @StevenHessing 
Compile tested: ramips/brcm47xx, openwrt master

Adapted minor piece of code (a debug message) to the new API.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>