### PR TITLE
suricata: add new package

### DIFF
--- a/net/suricata/Config.in
+++ b/net/suricata/Config.in
@@ -1,0 +1,36 @@
+menu "Configuration"
+	depends on PACKAGE_suricata
+
+config SURICATA_LOGROTATE
+	bool "Copy Suricata logrotate file"
+	default n
+
+config SURICATA_DEBUG
+	bool "Enable debug output"
+	default n
+
+config SURICATA_LUA
+	bool "Enable Lua support"
+	default n
+
+config SURICATA_MAGIC
+	bool "Enable Libmagic support"
+	default y
+
+config SURICATA_NFLOG
+	bool "Enable libnetfilter_log support"
+	default n
+
+config SURICATA_NFQ
+	bool "Enable NFQUEUE support for inline IDP"
+	default y
+
+config SURICATA_PIE
+	bool "Enable compiling as a position independent executable"
+	default n
+
+config SURICATA_SOCKET
+	bool "Enable Unix Socket"
+	default n
+
+endmenu

--- a/net/suricata/Makefile
+++ b/net/suricata/Makefile
@@ -1,0 +1,104 @@
+#
+# Copyright (C) 2018 Ashkan Jazayeri <ashkan@jazayeri.net>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=suricata
+PKG_VERSION:=4.0.4
+PKG_RELEASE:=1
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=\
+		https://github.com/OISF/suricata/releases/download/$(PKG_NAME)-$(PKG_VERSION)/ \
+		https://www.openinfosecfoundation.org/download/
+
+PKG_HASH:=617e83b6e20b03aa7d5e05a980d3cb6d2810ec18a6f15a36bf66c81c9c0a2abb
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+PKG_LICENSE:=GPL-2.0
+PKG_MAINTAINER:=Ashkan Jazayeri <ashkan@jazayeri.net>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/suricata
+ SUBMENU:=Firewall
+ SECTION:=net
+ CATEGORY:=Network
+ DEPENDS:=+jansson +libiconv-full +libpcap +libpcre +libpthread +libyaml +zlib +SURICATA_LOGROTATE:logrotate +SURICATA_LUA:lua +SURICATA_MAGIC:file +SURICATA_NFLOG:libnetfilter-log +SURICATA_NFQ:kmod-ipt-nfqueue +SURICATA_NFQ:libnetfilter-queue
+ TITLE:=Network IDS, IPS and NSM engine
+ URL:=https://github.com/OISF/suricata
+endef
+
+define Package/suricata/description
+ Suricata is a network IDS, IPS and NSM engine.
+endef
+
+define Package/suricata/conffiles
+/etc/config/suricata
+/etc/logrotate.d/suricata.logrotate
+/etc/suricata/
+endef
+
+define Package/suricata/config
+	source "$(SOURCE)/Config.in"
+endef
+
+TARGET_CPPFLAGS += -I$(STAGING_DIR)/usr/lib/libiconv-full/include
+TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib/libiconv-full/lib
+
+CONFIGURE_ARGS += \
+	$(if $(CONFIG_SURICATA_DEBUG),--enable,--disable)-debug \
+	--disable-gccmarch-native \
+	$(if $(CONFIG_SURICATA_MAGIC),--enable-magic,--disable-libmagic) \
+	--disable-python \
+	--disable-static \
+	$(if $(CONFIG_SURICATA_SOCKET),--enable,--disable)-unix-socket
+
+ifeq ($(CONFIG_SURICATA_LUA),y)
+CONFIGURE_ARGS += \
+	--enable-lua
+endif
+ifeq ($(CONFIG_SURICATA_NFLOG),y)
+CONFIGURE_ARGS += \
+	--enable-nflog
+endif
+ifeq ($(CONFIG_SURICATA_NFQ),y)
+CONFIGURE_ARGS += \
+	--enable-nfqueue
+endif
+ifeq ($(CONFIG_SURICATA_PIE),y)
+CONFIGURE_ARGS += \
+	--enable-pie
+endif
+
+define Package/suricata/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/suricata.config $(1)/etc/config/suricata
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/suricata.init $(1)/etc/init.d/suricata
+
+ifeq ($(CONFIG_SURICATA_LOGROTATE),y)
+	$(INSTALL_DIR) $(1)/etc/logrotate.d
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/etc/suricata.logrotate $(1)/etc/logrotate.d
+endif
+	$(INSTALL_DIR) $(1)/etc/suricata
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/{classification,reference,threshold}.config $(1)/etc/suricata
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/suricata.yaml $(1)/etc/suricata
+
+	$(INSTALL_DIR) $(1)/etc/suricata/rules
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/rules/*.rules $(1)/etc/suricata/rules
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/suricata $(1)/usr/bin
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libhtp.so* $(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,suricata))

--- a/net/suricata/Makefile
+++ b/net/suricata/Makefile
@@ -29,7 +29,9 @@ define Package/suricata
  SUBMENU:=Firewall
  SECTION:=net
  CATEGORY:=Network
- DEPENDS:=+jansson +libiconv-full +libpcap +libpcre +libpthread +libyaml +zlib +SURICATA_LOGROTATE:logrotate +SURICATA_LUA:lua +SURICATA_MAGIC:file +SURICATA_NFLOG:libnetfilter-log +SURICATA_NFQ:kmod-ipt-nfqueue +SURICATA_NFQ:libnetfilter-queue
+ DEPENDS:=+jansson +libiconv-full +libpcap +libpcre +libpthread +libyaml 
+ DEPENDS+=+zlib +SURICATA_LOGROTATE:logrotate +SURICATA_LUA:lua +SURICATA_MAGIC:file 
+ DEPENDS+=+SURICATA_NFLOG:libnetfilter-log +SURICATA_NFQ:kmod-ipt-nfqueue +SURICATA_NFQ:libnetfilter-queue
  TITLE:=Network IDS, IPS and NSM engine
  URL:=https://github.com/OISF/suricata
 endef

--- a/net/suricata/files/suricata.config
+++ b/net/suricata/files/suricata.config
@@ -1,0 +1,3 @@
+config suricata instance
+	option verbose	0
+	option mode	af-packet

--- a/net/suricata/files/suricata.init
+++ b/net/suricata/files/suricata.init
@@ -21,7 +21,7 @@ start_service() {
 	[ -f /var/run/suricata.pid -a -z $(pgrep suricata) ] && rm /var/run/suricata.pid && logger -t suricata[init_script] -p daemon.alert -s "Suricata was not closed properly or it has crashed. Successfully removed the previous /var/run/suricata.pid"
 	procd_open_instance
 	procd_set_param command /usr/bin/suricata
-    [ "$verbose" -gt 0 ] && {
+	[ "$verbose" -gt 0 ] && {
 		procd_append_param command -$(printf 'v%.0s' $(seq 1 $verbose))
 		procd_set_param stdout 1
 		procd_set_param stderr 1

--- a/net/suricata/files/suricata.init
+++ b/net/suricata/files/suricata.init
@@ -1,0 +1,47 @@
+#!/bin/sh /etc/rc.common
+# (C) 2018 Ashkan Jazayeri <ashkan@jazayeri.net>
+
+START=75
+USE_PROCD=1
+
+validate_suricata_section() {
+	uci_validate_section suricata suricata "${1}" \
+		'mode:string:af-packet' \
+		'queue:list(range(0,65535))' \
+		'verbose:range(0,4):0'
+}
+
+start_service() {
+	local mode number queue verbose
+	validate_suricata_section instance || {
+		echo "validation failed"
+		return 1
+	}
+	[ -d /var/log/suricata ] || mkdir /var/log/suricata
+	[ -f /var/run/suricata.pid -a -z $(pgrep suricata) ] && rm /var/run/suricata.pid && logger -t suricata[init_script] -p daemon.alert -s "Suricata was not closed properly or it has crashed. Successfully removed the previous /var/run/suricata.pid"
+	procd_open_instance
+	procd_set_param command /usr/bin/suricata
+    [ "$verbose" -gt 0 ] && {
+		procd_append_param command -$(printf 'v%.0s' $(seq 1 $verbose))
+		procd_set_param stdout 1
+		procd_set_param stderr 1
+	}
+	case "$mode" in
+		"af-packet" ) procd_append_param command --af-packet
+		;;
+		"nfq" )
+			[ -n "$queue" ] || {
+				logger -t suricata[init_script] -p daemon.emerg -s "No queue list provided. In NFQUEUE mode, a queue list must be specified under suricata config section (e.g. uci add_list suricata.instance.queue=9)"
+				return 1
+			}
+			for number in $queue; do procd_append_param command -q $number ;done
+		;;
+	esac
+	procd_append_param command --pidfile /var/run/suricata.pid
+	procd_close_instance
+}
+
+reload_service()
+{
+	kill -USR2 $(pidof suricata)
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: (x86_64, generic, r7087-7197744cd6)
Run tested: (x86_64, generic, r7087-7197744cd6, af-packet)

Description:
Suricata is a network IDS, IPS and NSM engine. This commit adds a
recent stable version of this package to the packages tree.
Luka Perkov's Snort package was used as a template for writing this one.
Implementations on Selks, Arch, Turis and Debian have also been reviewed.

Non-blocking service reload command taken from:
http://suricata.readthedocs.io/en/latest/rule-management/rule-reload.html

Signed-off-by: Ashkan Jazayeri <ashkan@jazayeri.net>