### PR TITLE
uwsgi-cgi: fix error

### DIFF
--- a/net/uwsgi-cgi/Makefile
+++ b/net/uwsgi-cgi/Makefile
@@ -8,6 +8,7 @@ PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/unbit/uwsgi
 PKG_SOURCE_DATE:=2018-02-26
 PKG_SOURCE_VERSION:=50ffc6b28a7a84e273fb2b79c8d657b45887fe87
+PKG_MIRROR_HASH:=7ffb9b361ff5dae5268181b8eabfbc56e5a5cf2c9a4439a728c115749de97001
 
 PKG_LICENSE:=GPL2 + linking exception
 PKG_LICENSE_FILES:=LICENSE
@@ -35,7 +36,7 @@ endef
 
 define Package/uwsgi-cgi/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-    $(INSTALL_BIN) $(PKG_BUILD_DIR)/uwsgi $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/uwsgi $(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,uwsgi-cgi))


### PR DESCRIPTION
Bad makefile, fix missing separator error.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
