### PR TITLE
uwsgi-cgi: add missing library

### DIFF
--- a/net/uwsgi-cgi/Makefile
+++ b/net/uwsgi-cgi/Makefile
@@ -23,7 +23,7 @@ define Package/uwsgi-cgi
   SUBMENU:=Web Servers/Proxies
   TITLE:=The uWSGI server
   URL:=http://unbit.com/
-  DEPENDS:=+python +libopenssl +libpcre
+  DEPENDS:=+python +libopenssl +libpcre +jansson
 endef
 
 define Package/uwsgi-cgi/description


### PR DESCRIPTION
This fix compilation error for the missing library libjansson
@hnyman 

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>