### PR TITLE
python-curl: update to 7.43.0.2

### DIFF
--- a/lang/python/python-curl/Makefile
+++ b/lang/python/python-curl/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pycurl
-PKG_VERSION:=7.43.0.1
+PKG_VERSION:=7.43.0.2
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Waldemar Konik <informatyk74@interia.pl>
 PKG_LICENSE:=LGPL-2.1
@@ -13,7 +13,7 @@ PKG_LICENSE_FILE=COPYING-LGPL
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dl.bintray.com/pycurl/pycurl/
-PKG_HASH:=43231bf2bafde923a6d9bb79e2407342a5f3382c1ef0a3b2e491c6a4e50b91aa
+PKG_HASH:=0f0cdfc7a92d4f2a5c44226162434e34f7d6967d3af416a6f1448649c09a25a4
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk


### PR DESCRIPTION
Signed-off-by: Waldemar Konik informatyk74@interia.pl

Description:
Update package python-curl to new version 7.43.0.2

Release Notes:
PycURL 7.43.0.2 - 2018-06-02
Highlights of this release:
1. Experimental perform_rs and perform_rb methods have been added to Curl objects. They return response body as a string and a byte string, respectively. The goal of these methods is to improve PycURL’s usability for typical use cases, specifically removing the need to set up StringIO/BytesIO objects to store the response body.
2. getinfo_raw and errstr_raw methods have been added to Curl objects to return transfer information as byte strings, permitting applications to retrieve transfer information that is not decodable using Python’s default encoding.
3. errstr and “fail or error” exceptions now replace undecodable bytes so as to provide usable strings; use errstr_raw to retrieve original byte strings.
4. There is no longer a need to keep references to Curl objects when they are used in CurlMulti objects - PycURL now maintains such references internally.
5. Official Windows builds now include HTTP/2 and international domain name support.
6. PycURL now officially supports BoringSSL.
7. A number of smaller improvements have been made and bugs fixed.