### PR TITLE
ldns: fix cross compiling on darwin

### DIFF
--- a/libs/ldns/patches/001-fix-cross-compile-on-darwin.patch
+++ b/libs/ldns/patches/001-fix-cross-compile-on-darwin.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -842,7 +842,7 @@ ACX_CHECK_FORMAT_ATTRIBUTE
+ ACX_CHECK_UNUSED_ATTRIBUTE
+ 
+ # check OSX deployment target, if needed
+-if echo $build_os | grep darwin > /dev/null; then
++if echo $target_os | grep darwin > /dev/null; then
+   sdk_p=`xcode-select -print-path`;
+   sdk_v="$( /usr/bin/xcrun --show-sdk-version )";
+   case $sdk_v in


### PR DESCRIPTION
Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>

Maintainer: @psycho-nico 
Compile tested: ar71xx, Archer C7 v2, master. built on mac os
Run tested: as above

Description:

Fix build failure when building OpenWrt on mac os.  Configure script made assumption that build system and target system were the same and would thus apply darwin 'special sauce' even though we're cross compiling to a linux environment.

