### PR TITLE
squid: Upgrade to 4.0.24 beta

### DIFF
--- a/net/squid/Config.in
+++ b/net/squid/Config.in
@@ -1,0 +1,71 @@
+if PACKAGE_squid
+
+	comment "Optional features"
+
+	config SQUID_enable-ipv6
+		bool "Enable support for IP version 6"
+		default y
+
+	config SQUID_enable-snmp
+		bool "Enable SNMP monitoring support"
+		default n
+
+	config SQUID_enable-icmp
+		bool "Enable ICMP pinging and Network Measurement"
+		default n
+
+	config SQUID_enable-icap-client
+		bool "Enable ICAP client support"
+		default n
+
+	config SQUID_enable-dlmalloc
+		bool "Compile & use the malloc package by Doug Lea"
+		default y
+
+	config SQUID_enable-ssl-crtd
+		bool "Enable dynamic SSL certificate generation "
+		depends on !SQUID_use-gnutls
+		default n
+
+	config SQUID_auth-basic
+		bool "Enable the Basic authentication scheme"
+		default n
+
+	config SQUID_auth-digest
+		bool "Enable the Digest authentication scheme"
+		default n
+
+	config SQUID_auth-negotiate
+		bool "Enable the Negotiate authentication scheme"
+		default n
+
+	config SQUID_auth-ntlm
+		bool "Enable the NTLM authentication scheme"
+		default n
+
+	comment "Optional packages"
+
+	config SQUID_use-gnutls
+		bool "Use GnuTLS instead of OpenSSL"
+		default n
+
+	config SQUID_with-libcap
+		bool "Use libcap - Linux capabilities library"
+		default n
+
+	config SQUID_with-nettle
+		bool "Use nettle - GNU crypto library"
+		default n
+
+	config SQUID_with-expat
+		bool "Use expat - XML parsing library"
+		default n
+
+	config SQUID_with-libxml2
+		bool "Use libxml2 - Gnome XML library"
+		default n
+
+	comment "Additional tools"
+
+endif
+

--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -30,12 +30,18 @@ define Package/squid/Default
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
   URL:=http://www.squid-cache.org/
-  MENU:=1
 endef
 
 define Package/squid
   $(call Package/squid/Default)
-  DEPENDS:=+libopenssl +libpthread +librt +libltdl +libstdcpp +libatomic +USE_GLIBC:libbsd
+  MENU:=1
+  DEPENDS:=+libpthread +librt +libltdl +libstdcpp +libatomic +USE_GLIBC:libbsd
+  DEPENDS+= +SQUID_use-gnutls:libgnutls +!SQUID_use-gnutls:libopenssl
+  DEPENDS+= +SQUID_with-libcap:libcap
+  DEPENDS+= +SQUID_with-nettle:libnettle
+  DEPENDS+= +SQUID_with-expat:libexpat
+  DEPENDS+= +SQUID_with-libxml2:libxml2
+  USERID:=squid=137:squid=137
   TITLE:=full-featured Web proxy cache
 endef
 
@@ -43,6 +49,14 @@ define Package/squid/description
   Squid is a caching proxy for the Web supporting HTTP, HTTPS, FTP, and more.
   It reduces bandwidth and improves response times by caching and reusing
   frequently-requested web pages.
+endef
+
+define Package/squid/config
+  source "$(SOURCE)/Config.in"
+endef
+
+define Package/squid/conffiles
+  /etc/squid/squid.conf
 endef
 
 define Package/squid-mod-cachemgr
@@ -58,13 +72,9 @@ CONFIGURE_ARGS += \
 	--sysconfdir=/etc/squid \
 	--enable-shared \
 	--disable-static \
-	--enable-icmp \
 	--enable-delay-pools \
-	--enable-icap-client \
 	--enable-kill-parent-hack \
-	--disable-snmp \
 	--enable-ssl \
-	--enable-ssl-crtd \
 	--enable-cache-digests \
 	--enable-linux-netfilter \
 	--disable-unlinkd \
@@ -73,29 +83,36 @@ CONFIGURE_ARGS += \
 	--disable-auto-locale \
 	--with-dl \
 	--with-pthreads \
-	--without-expat \
-	--without-libxml2 \
-	--without-gnutls \
-	--without-nettle \
-	--with-openssl=$(STAGING_DIR)/usr \
 	--enable-epoll \
-	--with-maxfd=4096 \
+	--with-maxfd=2048 \
+	--disable-ecap \
 	--disable-external-acl-helpers \
-	--disable-auth-negotiate \
-	--disable-auth-ntlm \
-	--disable-auth-digest \
-	--disable-auth-basic \
 	--disable-arch-native \
 	--with-krb5-config=no \
 	--without-mit-krb5 \
-	--without-libcap \
-	--without-netfilter-conntrack
+	--without-netfilter-conntrack \
+	--disable-ident-lookups \
+	$(if $(CONFIG_SQUID_auth-basic),--enable,--disable)-auth-basic \
+	$(if $(CONFIG_SQUID_auth-digest),--enable,--disable)-auth-digest \
+	$(if $(CONFIG_SQUID_auth-ntlm),--enable,--disable)-auth-ntlm \
+	$(if $(CONFIG_SQUID_auth-negotiate),--enable,--disable)-auth-negotiate \
+	$(if $(CONFIG_SQUID_enable-ipv6),--enable,--disable)-dlmalloc \
+	$(if $(CONFIG_SQUID_enable-ipv6),--enable,--disable)-ipv6 \
+	$(if $(CONFIG_SQUID_enable-ssl-crtd),--enable-ssl-crtd) \
+	$(if $(CONFIG_SQUID_use-gnutls),--with,--without)-gnutls \
+	$(if $(CONFIG_SQUID_use-gnutls),--without-openssl) \
+	$(if $(CONFIG_SQUID_use-gnutls),,--with-openssl="$(STAGING_DIR)/usr") \
+	$(if $(CONFIG_SQUID_enable-icmp),--enable,--disable)-icmp \
+	$(if $(CONFIG_SQUID_enable-icap-client),--enable,--disable)-icap-client \
+	$(if $(CONFIG_SQUID_enable-snmp),--enable,--disable)-snmp \
+	$(if $(CONFIG_SQUID_with-libcap),--with,--without)-libcap \
+	$(if $(CONFIG_SQUID_with-nettle),--with,--without)-nettle \
+	$(if $(CONFIG_SQUID_with-expat),--with,--without)-expat \
+	$(if $(CONFIG_SQUID_with-libxml2),--with,--without)-libxml2
 
 CONFIGURE_VARS += \
 	ac_cv_header_linux_netfilter_ipv4_h=yes \
 	ac_cv_epoll_works=yes
-
-EXTRA_CFLAGS += -Wno-error
 
 define Build/Compile
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/lib all
@@ -109,13 +126,13 @@ define Package/squid/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/squid $(1)/usr/sbin/
 
 	$(INSTALL_DIR) $(1)/usr/lib/squid
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/squid/security_file_certgen $(1)/usr/lib/squid/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/squid/* $(1)/usr/lib/squid/
 
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/squid.config $(1)/etc/config/squid
 
 	$(INSTALL_DIR) $(1)/etc/squid
-	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/squid/mime.conf $(1)/etc/squid/
+	$(CP) $(PKG_INSTALL_DIR)/etc/squid/* $(1)/etc/squid/
 	$(INSTALL_CONF) ./files/squid.conf $(1)/etc/squid/
 
 	$(INSTALL_DIR) $(1)/etc/init.d/
@@ -123,6 +140,7 @@ define Package/squid/install
 
 	$(INSTALL_DIR) $(1)/usr/share/squid/icons/
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/squid/icons/* $(1)/usr/share/squid/icons/
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/squid/mib.txt $(1)/usr/share/squid/
 
 	$(INSTALL_DIR) $(1)/usr/share/squid/errors/templates/
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/squid/errors/templates/* $(1)/usr/share/squid/errors/templates/

--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -8,17 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
-PKG_VERSION:=3.5.27
+PKG_VERSION:=4.0.24
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://www3.us.squid-cache.org/Versions/v3/3.5/ \
-	http://www2.pl.squid-cache.org/Versions/v3/3.5/ \
-	http://www.squid-cache.org/Versions/v3/3.5/
-PKG_HASH:=5ddb4367f2dc635921f9ca7a59d8b87edb0412fa203d1543393ac3c7f9fef0ec
+PKG_SOURCE_URL:=http://www3.us.squid-cache.org/Versions/v4/ \
+	http://www2.pl.squid-cache.org/Versions/v4/ \
+	http://www.squid-cache.org/Versions/v4/
+PKG_HASH:=091da0d763307dcc0f5c784ab07ea0c5a093f6dfac60f17ff26e2a6d50f76a07
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -35,7 +35,7 @@ endef
 
 define Package/squid
   $(call Package/squid/Default)
-  DEPENDS:=+libopenssl +libpthread +librt +libltdl +libstdcpp
+  DEPENDS:=+libopenssl +libpthread +librt +libltdl +libstdcpp +libatomic +USE_GLIBC:libbsd
   TITLE:=full-featured Web proxy cache
 endef
 
@@ -93,8 +93,9 @@ CONFIGURE_ARGS += \
 
 CONFIGURE_VARS += \
 	ac_cv_header_linux_netfilter_ipv4_h=yes \
-	ac_cv_epoll_works=yes \
-	squid_cv_gnu_atomics=no
+	ac_cv_epoll_works=yes
+
+EXTRA_CFLAGS += -Wno-error
 
 define Build/Compile
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/lib all
@@ -108,7 +109,7 @@ define Package/squid/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/squid $(1)/usr/sbin/
 
 	$(INSTALL_DIR) $(1)/usr/lib/squid
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/squid/ssl_crtd $(1)/usr/lib/squid
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/squid/security_file_certgen $(1)/usr/lib/squid/
 
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/squid.config $(1)/etc/config/squid

--- a/net/squid/files/squid.conf
+++ b/net/squid/files/squid.conf
@@ -1,44 +1,80 @@
-acl localnet src 10.0.0.0/8
-acl localnet src 172.16.0.0/12
-acl localnet src 192.168.0.0/16
-acl localnet src fc00::/7
-acl localnet src fe80::/10
+#
+# Recommended minimum configuration:
+#
 
-acl ssl_ports port 443
+# Example rule allowing access from your local networks.
+# Adapt to list your (internal) IP networks from where browsing
+# should be allowed
+acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
+acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
+acl localhet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
+acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
+acl localnet src fc00::/7       	# RFC 4193 local private network range
+acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
 
-acl safe_ports port 80
-acl safe_ports port 21
-acl safe_ports port 443
-acl safe_ports port 70
-acl safe_ports port 210
-acl safe_ports port 1025-65535
-acl safe_ports port 280
-acl safe_ports port 488
-acl safe_ports port 591
-acl safe_ports port 777
-acl connect method connect
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl CONNECT method CONNECT
 
-http_access deny !safe_ports
-http_access deny connect !ssl_ports
+#
+# Recommended minimum Access Permission configuration:
+#
+# Deny requests to certain unsafe ports
+http_access deny !Safe_ports
 
+# Deny CONNECT to other than secure SSL ports
+http_access deny CONNECT !SSL_ports
+
+# Only allow cachemgr access from localhost
 http_access allow localhost manager
 http_access deny manager
 
-http_access deny to_localhost
+# We strongly recommend the following be uncommented to protect innocent
+# web applications running on the proxy server who think the only
+# one who can access services on "localhost" is a local user
+#http_access deny to_localhost
 
+#
+# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
+#
+
+# Example rule allowing access from your local networks.
+# Adapt localnet in the ACL section to list your (internal) IP networks
+# from where browsing should be allowed
 http_access allow localnet
 http_access allow localhost
 
+# And finally deny all other access to this proxy
 http_access deny all
 
-refresh_pattern ^ftp: 1440 20% 10080
-refresh_pattern ^gopher: 1440 0% 1440
-refresh_pattern -i (/cgi-bin/|\?) 0 0% 0
-refresh_pattern . 0 20% 4320
+# Uncomment and adjust the following to add a disk cache directory.
+#cache_dir ufs /usr/local/squid/var/cache/squid 100 16 256
 
-access_log none
-cache_log /dev/null
-cache_store_log stdio:/dev/null
-logfile_rotate 0
+#
+# Add any of your own refresh_pattern entries above these.
+#
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern .		0	20%	4320
 
-logfile_daemon /dev/null
+# Squid user
+cache_effective_user squid
+
+#
+# Logs, best to use only for debugging as they can become very large
+#
+
+access_log none  # daemon:/tmp/squid_access.log
+cache_log /dev/null  # /tmp/squid_cache.log

--- a/net/squid/files/squid.init
+++ b/net/squid/files/squid.init
@@ -22,6 +22,11 @@ validate_squid_section() {
 		'mime_table:string:/etc/squid/mime.conf'
 }
 
+create_squid_user() {
+	user_exists squid || user_add squid $USERID
+	group_exists squid || group_add squid $USERID && group_add_user squid squid
+}
+
 start_service() {
 	local config_file http_port http_port_options ssldb ssldb_options coredump_dir visible_hostname pinger_enable
 

--- a/net/squid/files/squid.init
+++ b/net/squid/files/squid.init
@@ -33,7 +33,7 @@ start_service() {
 	config_dir=$(dirname $CONFIGFILE)
 	[ -d $config_dir ] || mkdir -p $config_dir && chown nobody:nogroup $config_dir
 	[ -d $coredump_dir ] || mkdir -p $coredump_dir && chown nobody:nogroup $coredump_dir
-	[ "$ssldb" ] && ( [ -f "$ssldb"/size ] || /usr/lib/squid/ssl_crtd -c -s $ssldb && chown -R nobody:nogroup $ssldb )
+	[ "$ssldb" ] && ( [ -f "$ssldb"/size ] || /usr/lib/squid/security_file_certgen -c -s $ssldb $ssldb_options && chown -R nobody:nogroup $ssldb )
 
 	cat $config_file > $CONFIGFILE
 	echo http_port $http_port $http_port_options >> $CONFIGFILE
@@ -42,7 +42,7 @@ start_service() {
 	echo pinger_enable $pinger_enable >> $CONFIGFILE
 	cat $mime_table > $MIMETABLE
 	echo mime_table $MIMETABLE >> $CONFIGFILE
-	[ "$ssldb" ] && echo sslcrtd_program /usr/lib/squid/ssl_crtd -s $ssldb $ssldb_options >> $CONFIGFILE
+	[ "$ssldb" ] && echo sslcrtd_program /usr/lib/squid/security_file_certgen -s $ssldb $ssldb_options >> $CONFIGFILE
 	$PROG -s -f $CONFIGFILE -N -z 2>/dev/null
 
 	procd_open_instance

--- a/net/squid/patches/001-cross_compile.patch
+++ b/net/squid/patches/001-cross_compile.patch
@@ -1,6 +1,6 @@
 --- a/src/Makefile.in
 +++ b/src/Makefile.in
-@@ -7984,7 +7984,7 @@ cache_cf.o: cf_parser.cci
+@@ -7642,7 +7642,7 @@ cache_cf.o: cf_parser.cci
  
  # cf_gen builds the configuration files.
  cf_gen$(EXEEXT): $(cf_gen_SOURCES) $(cf_gen_DEPENDENCIES) cf_gen_defines.cci
@@ -11,16 +11,7 @@
  squid.conf.default squid.conf.documented: cf_parser.cci
 --- a/configure
 +++ b/configure
-@@ -20842,7 +20842,7 @@ else
- if test "$cross_compiling" = yes; then :
-   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
- $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
--as_fn_error $? "cannot run test program while cross compiling
-+_as_fn_error $? "cannot run test program while cross compiling
- See \`config.log' for more details" "$LINENO" 5; }
- else
-   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-@@ -29142,7 +29142,7 @@ else
+@@ -30695,7 +30695,7 @@ else
      if test "$cross_compiling" = yes; then :
    { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
  $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
@@ -29,7 +20,7 @@
  See \`config.log' for more details" "$LINENO" 5; }
  else
    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-@@ -29167,7 +29167,7 @@ else
+@@ -30720,7 +30720,7 @@ else
      if test "$cross_compiling" = yes; then :
    { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
  $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}

--- a/net/squid/patches/001-cross_compile.patch
+++ b/net/squid/patches/001-cross_compile.patch
@@ -1,31 +1,24 @@
---- a/src/Makefile.in
-+++ b/src/Makefile.in
-@@ -7642,7 +7642,7 @@ cache_cf.o: cf_parser.cci
+From fac6f63a52a2f4cbb3748cd5687eca5409093904 Mon Sep 17 00:00:00 2001
+From: Marko Ratkaj <marko.ratkaj@sartura.hr>
+Date: Thu, 20 Apr 2017 15:15:50 +0200
+Subject: [PATCH] foo
+
+Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>
+---
+ src/Makefile.in | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+Index: squid-4.0.21/src/Makefile.in
+===================================================================
+--- squid-4.0.21.orig/src/Makefile.in
++++ squid-4.0.21/src/Makefile.in
+@@ -7642,7 +7642,8 @@ cache_cf.o: cf_parser.cci
  
  # cf_gen builds the configuration files.
  cf_gen$(EXEEXT): $(cf_gen_SOURCES) $(cf_gen_DEPENDENCIES) cf_gen_defines.cci
 -	$(BUILDCXX) $(BUILDCXXFLAGS) -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
 +	g++ -o $@ $(srcdir)/cf_gen.cc -I$(srcdir) -I$(top_builddir)/include/ -I$(top_builddir)/src
++
  
  # squid.conf.default is built by cf_gen when making cf_parser.cci
  squid.conf.default squid.conf.documented: cf_parser.cci
---- a/configure
-+++ b/configure
-@@ -30695,7 +30695,7 @@ else
-     if test "$cross_compiling" = yes; then :
-   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
- $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
--as_fn_error $? "cannot run test program while cross compiling
-+_as_fn_error $? "cannot run test program while cross compiling
- See \`config.log' for more details" "$LINENO" 5; }
- else
-   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-@@ -30720,7 +30720,7 @@ else
-     if test "$cross_compiling" = yes; then :
-   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
- $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
--as_fn_error $? "cannot run test program while cross compiling
-+_as_fn_error $? "cannot run test program while cross compiling
- See \`config.log' for more details" "$LINENO" 5; }
- else
-   cat confdefs.h - <<_ACEOF >conftest.$ac_ext

--- a/net/squid/patches/002-glibc-compile.patch
+++ b/net/squid/patches/002-glibc-compile.patch
@@ -1,0 +1,12 @@
+--- squid-4.0.21.orig/src/tools.cc
++++ squid-4.0.21/src/tools.cc
+@@ -581,7 +581,8 @@
+     }
+ #else
+ 
+-    setuid(0);
++    if (setuid(0) < 0)
++	debugs(50, 1, "no_suid: setuid (0)");
+ #endif
+ #if HAVE_PRCTL && defined(PR_SET_DUMPABLE)
+     /* Set Linux DUMPABLE flag */


### PR DESCRIPTION
I imagine this is a long shot, but I have been using it in two of my routers (Linksys WRT610N and Asus RT-N56U), and in our main server at work, without a problem.

This beta version brings compatibility with openssl 1.1.  I considered adding this as a new package, but decided against it.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer:  @ratkaj
Compile tested: ramips/brcm47xx, openwrt master
Run tested: ramips (Asus RT-N56U)/brcm4x77 (WRT 610N), openwrt master