### PR TITLE
dhcpcd: bump to 7.0.5

### DIFF
--- a/net/dhcpcd/Makefile
+++ b/net/dhcpcd/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dhcpcd
-PKG_VERSION:=6.11.5
+PKG_VERSION:=7.0.5
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=ftp://roy.marples.name/pub/dhcpcd \
     http://roy.marples.name/downloads/dhcpcd
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=6f9674dc7e27e936cc787175404a6171618675ecfb6903ab9887b1b66a87d69e
+PKG_HASH:=aa43fdb990be7c413fa92bdbcfb3775e4cdbff725cbcb68cd2a714ed4f58879d
 
 PKG_LICENSE:=BSD-2c
 PKG_LICENSE_FILES:=


### PR DESCRIPTION
Maintainer: me / @ratkaj marko.ratkaj@sartura.hr
Compile tested: mvebu, brcm2709, OpenWrt master
Run tested: mvebu/wrt1200, brcm2709/RPi3, OpenWrt master

Description:
Simple version bump from 6.11.5 to 7.0.5

Signed-off-by: Marko Ratkaj marko.ratkaj@sartura.hr