### PR TITLE
miniupnpd: fix build error when ASLR enabled

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://miniupnp.free.fr/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -40,7 +40,7 @@ define Build/Prepare
 endef
 
 TARGET_CFLAGS += -flto -ffunction-sections -fdata-sections
-TARGET_LDFLAGS += -flto -Wl,--gc-sections
+TARGET_LDFLAGS += $(FPIC) -flto -Wl,--gc-sections
 MAKE_FLAGS += \
 	TARGET_OPENWRT=1 TEST=0 LIBS="" \
 	CC="$(TARGET_CC) -DIPTABLES_143 -lip4tc -luuid \


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx & ath79 with & without ASLR enabled
Run tested: ar71xx with & without ASLR

Description:

Add -fPIC to TARGET_LD_FLAGS

ce9TpAS.ltrans0.ltrans.o: relocation R_MIPS16_26 against `syslog' can not
be used when making a shared object; recompile with -fPIC
cce9TpAS.ltrans0.ltrans.o: error adding symbols: Bad value

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>

Fixes https://github.com/openwrt/packages/issues/6226
