### PR TITLE
mailsend: bump to v. 1.19, add openssl 1.1

### DIFF
--- a/mail/mailsend/Makefile
+++ b/mail/mailsend/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mailsend
-PKG_VERSION:=1.17b15
-PKG_RELEASE:=2
+PKG_VERSION:=1.19
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/muquit/mailsend/archive/$(PKG_VERSION)
-PKG_HASH:=73cb1b2455de95ab126e3682bf19c62e6baabee00f449da692be0bebd3ceb26b
+PKG_HASH:=565ef6be26c58ef75065c5519eae8dd55bae3142928619696b28d242b73493f7
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 

--- a/mail/mailsend/patches/0001-OpenSSL-1.1-support-for-HMAC-api.patch
+++ b/mail/mailsend/patches/0001-OpenSSL-1.1-support-for-HMAC-api.patch
@@ -1,0 +1,49 @@
+From 960df6d7a11eef90128dc2ae660866b27f0e4336 Mon Sep 17 00:00:00 2001
+From: muquit <muquit@gmail.com>
+Date: Wed, 21 Sep 2016 12:46:24 -0400
+Subject: [PATCH] OpenSSL 1.1 support for HMAC api
+
+---
+ utils.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/utils.c b/utils.c
+index b072138..abfb86e 100755
+--- a/utils.c
++++ b/utils.c
+@@ -791,8 +791,14 @@ char *encode_cram_md5(char *challenge,char *user,char *secret)
+     unsigned char
+         hmac_md5[16];
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     HMAC_CTX
+         ctx;
++#else
++    /* OpenSSL 1.1.x*/
++    HMAC_CTX
++        *ctx;
++#endif
+ 
+     const EVP_MD
+         *md5=NULL;
+@@ -831,11 +837,20 @@ char *encode_cram_md5(char *challenge,char *user,char *secret)
+     showVerbose("Challenge After decoding: %s\n",data);
+ 
+     /* take HMAC-MD5 of the challenge*/
++
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     md5=EVP_get_digestbyname("md5");
+     HMAC_CTX_init(&ctx);
+     HMAC_Init(&ctx,secret,strlen(secret),md5);
+     HMAC_Update(&ctx,data,data_len);
+     HMAC_Final(&ctx,hmac_md5,&hmac_len);
++#else
++    /* OpenSSL 1.1.x */
++    ctx = HMAC_CTX_new();
++    HMAC_Init_ex(ctx,secret,strlen(secret),EVP_md5(),NULL);
++    HMAC_Update(ctx,data,data_len);
++    HMAC_Final(ctx,hmac_md5,&hmac_len);
++#endif
+ 
+     /* convert the digest to hex */
+     memset(hex,0,sizeof(hex));

--- a/mail/mailsend/patches/0002-Removed-API-deprecated-by-OpenSSL-1.1.0.patch
+++ b/mail/mailsend/patches/0002-Removed-API-deprecated-by-OpenSSL-1.1.0.patch
@@ -1,0 +1,44 @@
+From 2d585baa473314f79d492c0876b3bbf96758562c Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cote2004-github@yahoo.com>
+Date: Fri, 8 Jun 2018 14:41:23 -0300
+Subject: [PATCH] Removed API deprecated by OpenSSL 1.1.0
+
+Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
+---
+ main.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/main.c b/main.c
+index d275e6a..51bfb1d 100755
+--- a/main.c
++++ b/main.c
+@@ -91,7 +91,11 @@ static void usage(void)
+     (void) printf(" Copyright: %.1024s\n\n",NO_SPAM_STATEMENT);
+ #ifdef HAVE_OPENSSL
+     (void) fprintf(stdout," (Compiled with OpenSSL version: %s)\n",
++# if OPENSSL_VERSION_NUMBER < 0x10100000L
+                    SSLeay_version(SSLEAY_VERSION));
++# else
++                   OpenSSL_version(OPENSSL_VERSION));
++# endif
+ #else
+     (void) fprintf(stdout," (Not compiled with OpenSSL)\n");
+ #endif /* HAVE_OPENSSL */
+@@ -1056,9 +1060,13 @@ int main(int argc,char **argv)
+                 (void) fprintf(stderr,"mailsend Version: %.1024s\n",MAILSEND_VERSION);
+ #ifdef HAVE_OPENSSL
+                 (void) fprintf(stderr,"Compiled with OpenSSL: %s\n",
++# if OPENSSL_VERSION_NUMBER < 0x10100000L
+                                SSLeay_version(SSLEAY_VERSION));
++# else
++                               OpenSSL_version(OPENSSL_VERSION));
++# endif
+ #else
+-                (void) fprintf(stderr,"Not Compiled OpenSSL, some auth methods will be unavailable\n");
++                (void) fprintf(stderr,"Not Compiled with OpenSSL, some auth methods will be unavailable\n");
+ #endif /* ! HAVE_OPENSSL */
+                 rc = 0;
+                 goto ExitProcessing;
+-- 
+2.16.4
+


### PR DESCRIPTION
Applied a patch merged upstream that adds support to openssl 1.1.0, and added a (cosmetic, really) patch, just submitted upstream, that removed deprecated API.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer: @thess 
Compile tested: brcm47xx, WRT 610N, openwrt master
Run tested: brcm47xx, WRT 610N, openwrt master