### PR TITLE
libnetfilter-acct: Update to 1.0.3

### DIFF
--- a/libs/libnetfilter-acct/Makefile
+++ b/libs/libnetfilter-acct/Makefile
@@ -8,15 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetfilter_acct
-PKG_VERSION:=1.0.2
+PKG_VERSION:=1.0.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:= \
-	http://www.netfilter.org/projects/libnetfilter_acct/files/ \
-	ftp://ftp.netfilter.org/pub/libnetfilter_acct/ \
-	http://mirrors.evolva.ro/netfilter.org/libnetfilter_acct/
-PKG_HASH:=0128f19c3419fbd84f7e6d46b13a33ef7bda9b9f5e493bc5ae1882d087514b71
+PKG_SOURCE_URL:=https://netfilter.org/projects/libnetfilter_acct/files
+PKG_HASH:=4250ceef3efe2034f4ac05906c3ee427db31b9b0a2df41b2744f4bf79a959a1a
 
 PKG_LICENSE:=LGPL-2.1+
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Remove dead URL and FTP since it tends to be unreliable. Main URL was switched to HTTPS.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @psycho-nico 
Compile tested: mvebu