### PR TITLE
crconf: switch to git repo and update to more recent code

### DIFF
--- a/utils/crconf/Makefile
+++ b/utils/crconf/Makefile
@@ -6,13 +6,15 @@
 
 include $(TOPDIR)/rules.mk
 
+PKG_SOURCE_VERSION:=8bd996400d087028ba56b724abc1f5b378eaa77f
+
 PKG_NAME:=crconf
-PKG_VERSION:=pre2
+PKG_VERSION:=pre2-$(PKG_SOURCE_VERSION)
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/crconf
-PKG_HASH:=15d39b599acda93a50f473190e702d593ba13613b6ed31711f3584b5726b81b8
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://git.code.sf.net/p/crconf/code
+PKG_MIRROR_HASH:=f772306c0b005c18f481b73e3be193dba5ebb9f6f3bf20cb3f67c4a80dac0613
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/83483ba787e5c972099da1e983e95f396961c7f2
Run tested: x86 https://github.com/openwrt/openwrt/commit/83483ba787e5c972099da1e983e95f396961c7f2

-------------------------------------------

crconf hasn't released any new version since 2012 or so.
And there are quite a few updates in the repo, including newer kernel
support.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>