### PR TITLE
bluez: Disable printing subsystem rule

### DIFF
--- a/utils/bluez/Makefile
+++ b/utils/bluez/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bluez
 PKG_VERSION:=5.49
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/bluetooth/

--- a/utils/bluez/patches/204-no-printing-subsystem.patch
+++ b/utils/bluez/patches/204-no-printing-subsystem.patch
@@ -1,0 +1,17 @@
+diff --git a/src/bluetooth.conf b/src/bluetooth.conf
+index 0c0b221..013cf97 100644
+--- a/src/bluetooth.conf
++++ b/src/bluetooth.conf
+@@ -26,10 +26,10 @@
+   </policy>
+ 
+   <!-- allow users of lp group (printing subsystem) to 
+-       communicate with bluetoothd -->
++       communicate with bluetoothd
+   <policy group="lp">
+     <allow send_destination="org.bluez"/>
+-  </policy>
++  </policy> -->
+ 
+   <policy context="default">
+     <deny send_destination="org.bluez"/>


### PR DESCRIPTION
Maintainer: @psycho-nico 
Compile tested: ramips, D-Link DIR-860L (B1), OpenWrt Master
Run tested: ramips, D-Link DIR-860L (B1), OpenWrt Master

Description:
By default bluez allows the printing subsystem to communicate
via dbus. This refers to the group lp which isn't available
on OpenWrt and makes dbus fail to start.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>