### PR TITLE
file: Disable libseccomp by default

### DIFF
--- a/libs/file/Makefile
+++ b/libs/file/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=file
 PKG_VERSION:=5.33
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://sources.lede-project.org/ \
@@ -52,6 +52,7 @@ endef
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
+	--disable-libseccomp
 
 MAKE_PATH := src
 


### PR DESCRIPTION
Fixes the buildbot. libseccomp is not that useful for file.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ratkaj 
Compile tested: mvebu