### PR TITLE
diffutils: fix 'compilation error on x86_64

### DIFF
--- a/devel/diffutils/Makefile
+++ b/devel/diffutils/Makefile
@@ -35,6 +35,7 @@ define Package/diffutils/description
 endef
 
 CONFIGURE_VARS += \
+	gl_cv_func_getopt_gnu=yes \
 	ac_cv_func_mempcpy=n
 TARGET_CFLAGS += --std=gnu99
 


### PR DESCRIPTION
Signed-off-by: Sébastien Delafond <sdelafond@gmail.com>

Maintainer: Roger D <rogerdammit@gmail.com>
Compile tested: x86_64
Run tested: x86_64, snapshot 6c81c27 from 2018-05-30, diff working fine

Description:
--

Here was the first error I got:

  xstrtol-error.c:84:26: error: invalid use of undefined type 'struct
  rpl_option'

More information on this error here:
  https://www.mail-archive.com/clfs-support@lists.clfs.org/msg00297.html

I'm not sure if this is an issue in my build environment, but I believe
this is the proper fix because gzip and zile use the same option:

  ./utils/gzip/Makefile:	gl_cv_func_getopt_gnu=yes \
  ./utils/zile/Makefile:	gl_cv_func_getopt_gnu=yes \

This commit is mostly a reformat/sign-off of previous work by Dirk
Morris <dmorris@untangle.com>

