### PR TITLE
nginx: add luci-support package

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -74,7 +74,6 @@ define Package/nginx
   TITLE:=Nginx web server
   URL:=http://nginx.org/
   DEPENDS:=+NGINX_PCRE:libpcre +(NGINX_SSL||NGINX_HTTP_CACHE||NGINX_HTTP_AUTH_BASIC):libopenssl +NGINX_HTTP_GZIP:zlib +NGINX_LUA:liblua +libpthread
-  MENU:=1
 endef
 
 define Package/nginx/description
@@ -218,6 +217,32 @@ ifeq ($(CONFIG_NGINX_HTTP_BROTLI),y)
   ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-brotli
 endif
 
+define Package/nginx-mod-luci
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
+  TITLE:=Support file for Nginx
+  URL:=http://nginx.org/
+  DEPENDS:=nginx +uwsgi-cgi +uwsgi-cgi-luci-support
+endef
+
+define Package/nginx-mod-luci/description
+ Support file for LuCI in nginx (include custom nginx configuration, autostart script for uwsgi)
+endef
+
+define Package/nginx-mod-luci-ssl
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
+  TITLE:=Support file for Nginx (SSL)
+  URL:=http://nginx.org/
+  DEPENDS:=nginx +nginx-mod-luci
+endef
+
+define Package/nginx-mod-luci-ssl/description
+ Support file for LuCI in nginx (include custom nginx configuration, autostart script for uwsgi, redirect from http to https)
+endef
+
 TARGET_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -DNGX_LUA_NO_BY_LUA_BLOCK
 TARGET_LDFLAGS += -Wl,--gc-sections
 
@@ -241,6 +266,21 @@ define Build/Configure
 			--with-ld-opt="$(TARGET_LDFLAGS)" \
 			--without-http_upstream_zone_module \
 	)
+endef
+
+define Package/nginx-mod-luci/install
+	$(INSTALL_DIR) $(1)/etc/nginx
+	$(INSTALL_BIN) ./files-luci-support/luci_uwsgi.conf $(1)/etc/nginx/luci_uwsgi.conf
+	$(INSTALL_BIN) ./files-luci-support/luci_nginx.conf $(1)/etc/nginx/luci_nginx.conf
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files-luci-support/60_nginx-luci-support $(1)/etc/uci-defaults/60_nginx-luci-support
+endef
+
+define Package/nginx-mod-luci-ssl/install
+	$(INSTALL_DIR) $(1)/etc/nginx
+	$(INSTALL_BIN) ./files-luci-support/luci_nginx_ssl.conf $(1)/etc/nginx/luci_nginx_ssl.conf
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files-luci-support/70_nginx-luci-support-ssl $(1)/etc/uci-defaults/70_nginx-luci-support-ssl
 endef
 
 define Package/nginx/install
@@ -321,3 +361,5 @@ define  Prepare/lua-nginx
 endef
 
 $(eval $(call BuildPackage,nginx))
+$(eval $(call BuildPackage,nginx-mod-luci))
+$(eval $(call BuildPackage,nginx-mod-luci-ssl))

--- a/net/nginx/files-luci-support/60_nginx-luci-support
+++ b/net/nginx/files-luci-support/60_nginx-luci-support
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+if [ -f "/etc/nginx/luci_nginx.conf" ] && [ -f "/etc/nginx/nginx.conf" ]; then
+	if [ ! "$(cat '/etc/nginx/nginx.conf' | grep -q 'luci_uwsgi.conf')" ]; then
+		mv /etc/nginx/nginx.conf /etc/nginx/nginx.conf_old
+		mv /etc/nginx/luci_nginx.conf /etc/nginx/nginx.conf
+		core_number=$(grep -c ^processor /proc/cpuinfo)
+		sed -i "3s/.*/worker_processes  "$core_number";/" /etc/nginx/nginx.conf
+		if [ -n "$(pgrep uhttpd)" ]; then
+			/etc/init.d/uhttpd stop
+			/etc/init.d/uhttpd disable
+		fi
+		if [ -n "$(pgrep nginx)" ]; then
+			/etc/init.d/nginx restart
+		else
+			/etc/init.d/nginx start
+		fi
+		if [ -n "$(pgrep uwsgi)" ]; then
+			/etc/init.d/uwsgi restart
+		else
+			/etc/init.d/uwsgi start
+		fi
+	fi
+fi
+
+exit 0

--- a/net/nginx/files-luci-support/70_nginx-luci-support-ssl
+++ b/net/nginx/files-luci-support/70_nginx-luci-support-ssl
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+
+if [ -f "/etc/nginx/luci_nginx_ssl.conf" ] && [ -f "/etc/nginx/nginx.conf" ]; then
+	if [ ! "$(cat '/etc/nginx/nginx.conf' | grep -q 'return 301 https://$host$request_uri;')" ]; then
+		if [ -f "/etc/nginx/nginx.conf_old" ]; then
+			rm /etc/nginx/nginx.conf
+		else
+			mv /etc/nginx/nginx.conf /etc/nginx/nginx.conf_old
+		fi
+		mv /etc/nginx/luci_nginx_ssl.conf /etc/nginx/nginx.conf
+		core_number=$(grep -c ^processor /proc/cpuinfo)
+		sed -i "3s/.*/worker_processes  "$core_number";/" /etc/nginx/nginx.conf
+		if [ -n "$(pgrep nginx)" ]; then
+			/etc/init.d/nginx restart
+		else
+			/etc/init.d/nginx start
+		fi
+	fi
+fi
+
+
+if [ ! -f "/etc/nginx/nginx.key" ]; then
+	
+	NGINX_KEY=/etc/nginx/nginx.key
+	NGINX_CER=/etc/nginx/nginx.cer
+	OPENSSL_BIN=/usr/bin/openssl
+	PX5G_BIN=/usr/sbin/px5g
+	
+	# Prefer px5g for certificate generation (existence evaluated last)
+	GENKEY_CMD=""
+	UNIQUEID=$(dd if=/dev/urandom bs=1 count=4 | hexdump -e '1/1 "%02x"')
+	[ -x "$OPENSSL_BIN" ] && GENKEY_CMD="$OPENSSL_BIN req -x509 -nodes"
+	[ -x "$PX5G_BIN" ] && GENKEY_CMD="$PX5G_BIN selfsigned"
+	[ -n "$GENKEY_CMD" ] && {
+		$GENKEY_CMD \
+			-days 730 -newkey rsa:2048 -keyout "${NGINX_KEY}.new" -out "${NGINX_CER}.new" \
+			-subj /C="ZZ"/ST="Somewhere"/L="Unknown"/O="OpenWrt""$UNIQUEID"/CN="OpenWrt"
+		sync
+		mv "${NGINX_KEY}.new" "${NGINX_KEY}"
+		mv "${NGINX_CER}.new" "${NGINX_CER}"
+	}
+fi
+
+
+exit 0

--- a/net/nginx/files-luci-support/luci_nginx.conf
+++ b/net/nginx/files-luci-support/luci_nginx.conf
@@ -1,0 +1,55 @@
+
+user  root;
+worker_processes  1;
+
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+	sendfile on;
+    keepalive_timeout 0;
+	
+	client_body_buffer_size 10K;
+	client_header_buffer_size 1k;
+	client_max_body_size 1G;
+	large_client_header_buffers 2 1k;
+
+    gzip on;
+    gzip_http_version 1.1;
+    gzip_vary on;
+    gzip_comp_level 1;
+    gzip_proxied any;
+	
+	root /www;
+
+    server {
+        listen 80 default_server;
+		listen [::]:80 default_server;
+        server_name  localhost;
+		
+		location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
+			expires 365d;
+		}
+
+        location / {
+            index  index.html;
+			include luci_uwsgi.conf;
+        }
+		
+		location /luci-static {
+			
+		}
+    }
+}

--- a/net/nginx/files-luci-support/luci_nginx_ssl.conf
+++ b/net/nginx/files-luci-support/luci_nginx_ssl.conf
@@ -1,0 +1,70 @@
+
+user  root;
+worker_processes  1;
+
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+	sendfile on;
+    keepalive_timeout 0;
+	
+	client_body_buffer_size 10K;
+	client_header_buffer_size 1k;
+	client_max_body_size 1G;
+	large_client_header_buffers 2 1k;
+
+    gzip on;
+    gzip_http_version 1.1;
+    gzip_vary on;
+    gzip_comp_level 1;
+    gzip_proxied any;
+	
+	root /www;
+	
+	server {
+		listen 80 default_server;
+		listen [::]:80 default_server;
+		server_name _;
+		return 301 https://$host$request_uri;
+	}
+
+    server {
+        listen 443 ssl default_server;
+		listen [::]:443 ssl default_server;
+        server_name  localhost;
+		
+		ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        ssl_prefer_server_ciphers on;
+		ssl_ciphers "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:DHE+AESGCM:DHE:!RSA!aNULL:!eNULL:!LOW:!RC4:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!CAMELLIA:!SEED";
+        ssl_session_tickets off;
+
+		ssl_certificate /etc/nginx/nginx.cer;
+        ssl_certificate_key /etc/nginx/nginx.key;
+		
+		location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
+			expires 365d;
+		}
+
+        location / {
+            index  index.html;
+			include luci_uwsgi.conf;
+        }
+		
+		location /luci-static {
+			
+		}
+    }
+}

--- a/net/nginx/files-luci-support/luci_uwsgi.conf
+++ b/net/nginx/files-luci-support/luci_uwsgi.conf
@@ -1,0 +1,14 @@
+uwsgi_param QUERY_STRING $query_string;
+uwsgi_param REQUEST_METHOD $request_method;
+uwsgi_param CONTENT_TYPE $content_type;
+uwsgi_param CONTENT_LENGTH $content_length if_not_empty;
+uwsgi_param REQUEST_URI $request_uri;
+uwsgi_param PATH_INFO $document_uri;
+uwsgi_param SERVER_PROTOCOL $server_protocol;
+uwsgi_param REMOTE_ADDR $remote_addr;
+uwsgi_param REMOTE_PORT $remote_port;
+uwsgi_param SERVER_ADDR $server_addr;
+uwsgi_param SERVER_PORT $server_port;
+uwsgi_param SERVER_NAME $server_name;
+uwsgi_modifier1 9;
+uwsgi_pass unix:////var/run/uwsgi.sock;


### PR DESCRIPTION
This adds an additional file for ngix that contains all the files need to make luci works on the nginx webserver.

@hnyman i think there is a lot to change... starting from the uci-defaults scripts...
Should i use a post install script? 

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
