### PR TITLE
rp-pppoe: redo glibc patch

### DIFF
--- a/net/rp-pppoe/Makefile
+++ b/net/rp-pppoe/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rp-pppoe
 PKG_VERSION:=3.12
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_MAINTAINER:=Daniel Dickinson <lede@cshore.thecshore.com>
 PKG_LICENSE:=LGPL-2.0+
 

--- a/net/rp-pppoe/patches/140-glibc-avoid-include-linux_in.h.patch
+++ b/net/rp-pppoe/patches/140-glibc-avoid-include-linux_in.h.patch
@@ -1,12 +1,12 @@
 --- a/src/pppoe.h
 +++ b/src/pppoe.h
-@@ -131,7 +131,9 @@ typedef unsigned long UINT32_t;
- #include <linux/if_ether.h>
+@@ -132,6 +132,9 @@ typedef unsigned long UINT32_t;
  #endif
  
-+#ifndef __GLIBC__
  #include <netinet/in.h>
-+#endif
++/* avoid redefinitions if <linux/in.h> and <linux/in6.h> get included. */
++#define _LINUX_IN_H
++#define _LINUX_IN6_H
  
  #ifdef HAVE_NETINET_IF_ETHER_H
  #include <sys/types.h>


### PR DESCRIPTION
Maintainer: @cshoredaniel
Compile tested: mipsel, mips74k, arm (glibc and musl)

Description:
You can't #include  both `<netinet/in.h>`, and `<linux/in.h>`/`<linux/in6.h>` with glibc.
Previous fix broke compilation with kernel < 4.8, since the inclusion of these files happened in https://github.com/torvalds/linux/commit/eafe92114308acf14e45c6c3d154a5dad5523d1a. So instead of not including `<netinet/in.h>`, let's avoid inclusion of the linux header files.
Thanks to @dedeckeh for pointing this out.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
