### PR TITLE
avahi: patch systemd runtime_dir change in 0.7

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avahi
 PKG_VERSION:=0.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lathiat/avahi/releases/download/v$(PKG_VERSION) \

--- a/libs/avahi/patches/020-revert-runtime-dir-systemd-change.patch
+++ b/libs/avahi/patches/020-revert-runtime-dir-systemd-change.patch
@@ -1,0 +1,26 @@
+From ef0ea001f6dd13d6a2e0bc17d13f595d2829f8a8 Mon Sep 17 00:00:00 2001
+From: Jeremiah McConnell <miah@miah.com>
+Date: Fri, 15 Jun 2018 11:31:10 -0600
+Subject: [PATCH] move runtime_dir to /var/run
+
+Upstream transitioned to using /run as runtime_dir for 0.7.  Revert
+that change for procd compatibility.
+
+Signed-off-by: Jeremiah McConnell <miah@miah.com>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 72d61478..8f6e9768 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -984,7 +984,7 @@ AC_DEFINE_UNQUOTED(AVAHI_AUTOIPD_GROUP,"$AVAHI_AUTOIPD_GROUP", [Group for runnin
+ #
+ # Avahi runtime dir
+ #
+-avahi_runtime_dir="/run"
++avahi_runtime_dir="${localstatedir}/run"
+ avahi_socket="${avahi_runtime_dir}/avahi-daemon/socket"
+ AC_SUBST(avahi_runtime_dir)
+ AC_SUBST(avahi_socket)


### PR DESCRIPTION
In avahi 0.7 the runtime_dir was updated to be /run instead of /var/run
for better systemd compatibility.  Patch out that change to fix
avahi-daemon.

This is just a reverse patch of https://github.com/lathiat/avahi/commit/60bd97ceeb1f7924df2b347b5ac18fa5949898cc.

Version 0.7 was broken with this result:
```
avahi-daemon[22143]: Found user 'nobody' (UID 65534) and group 'nogroup' (GID 65534).
avahi-daemon[22143]: Successfully dropped root privileges.
avahi-daemon[22143]: open(/run/avahi-daemon//pid): Permission denied
avahi-daemon[22143]: Failed to create PID file: Permission denied
```
