### PR TITLE
sound/fdk-aac: Clean up Makefile, add overflow patch

### DIFF
--- a/sound/fdk-aac/Makefile
+++ b/sound/fdk-aac/Makefile
@@ -7,17 +7,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fdk-aac
 PKG_VERSION:=0.1.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=Fraunhofer-FDK-AAC-for-Android
 PKG_LICENSE_FILES:=NOTICE
-
 
 PKG_SOURCE_URL=https://codeload.github.com/mstorsjo/fdk-aac/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=adbcd793e406e1b88b3c1c41382d49f8c27371485b823c0fdab69c9124fd2ce3
 
 PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
 
 PKG_CONFIG_DEPENDS:= CONFIG_FDK-AAC_OPTIMIZE_SPEED
 
@@ -49,18 +49,16 @@ endef
 
 define Package/fdk-aac/install
 	$(INSTALL_DIR) $(1)/usr/lib/
-	$(CP) $(PKG_BUILD_DIR)/.libs/*.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfdk-aac.so* $(1)/usr/lib/
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include/fdk-aac
-	$(CP) $(PKG_BUILD_DIR)/libAACdec/include/aacdecoder_lib.h $(1)/usr/include/fdk-aac
-	$(CP) $(PKG_BUILD_DIR)/libAACenc/include/aacenc_lib.h $(1)/usr/include/fdk-aac
-	$(CP) $(PKG_BUILD_DIR)/libSYS/include/FDK_audio.h $(1)/usr/include/fdk-aac
-	$(CP) $(PKG_BUILD_DIR)/libSYS/include/genericStds.h $(1)/usr/include/fdk-aac
-	$(CP) $(PKG_BUILD_DIR)/libSYS/include/machine_type.h $(1)/usr/include/fdk-aac
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/fdk-aac $(1)/usr/include
 	$(INSTALL_DIR) $(1)/usr/lib/
-	$(CP) $(PKG_BUILD_DIR)/.libs/*.{la,so*} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfdk-aac.{la,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/fdk-aac.pc $(1)/usr/lib/pkgconfig/
 endef
 
 $(eval $(call BuildPackage,fdk-aac))

--- a/sound/fdk-aac/patches/001-fix-overflow.patch
+++ b/sound/fdk-aac/patches/001-fix-overflow.patch
@@ -1,0 +1,29 @@
+From a50eecf65b5ce5d4f03768c5c2cb4b492d2badad Mon Sep 17 00:00:00 2001
+From: Martin Storsjo <martin@martin.st>
+Date: Fri, 4 May 2018 12:46:44 +0300
+Subject: [PATCH] Fix overflows in accumulation, fixing crashes
+
+This fixes github issue #83.
+---
+ libSBRenc/src/tran_det.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libSBRenc/src/tran_det.cpp b/libSBRenc/src/tran_det.cpp
+index 0e35ec3..51d6efe 100644
+--- a/libSBRenc/src/tran_det.cpp
++++ b/libSBRenc/src/tran_det.cpp
+@@ -256,12 +256,12 @@ static FIXP_DBL addLowbandEnergies(FIXP_DBL **Energies,
+   /* freqBandTable[LORES] has MAX_FREQ_COEFFS/2 +1 coeefs max. */
+   for (ts=tran_offdiv2; ts<YBufferWriteOffset; ts++) {
+     for (k = 0; k < freqBandTable[0]; k++) {
+-      accu1 += Energies[ts][k] >> 6;
++      accu1 = fAddSaturate(accu1, Energies[ts][k] >> 6);
+     }
+   }
+   for (; ts<tran_offdiv2+(slots>>nrgSzShift); ts++) {
+     for (k = 0; k < freqBandTable[0]; k++) {
+-      accu2 += Energies[ts][k] >> 9;
++      accu2 = fAddSaturate(accu2, Energies[ts][k] >> 9);
+     }
+   }
+ 


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: mvebu, Linksys WRT3200ACM, OpenWrt master
Run tested: mvebu, Linksys WRT3200ACM, OpenWrt master

Description:
Clean up Makefile by utilizing toolchain logic
Make package pkg-config friendly
Add patch to prevent crashes due to overflow
Source: https://github.com/mstorsjo/fdk-aac/commit/a50eecf65b5ce5d4f03768c5c2cb4b492d2badad

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>