### PR TITLE
pkgconf: Add new package

### DIFF
--- a/devel/pkgconf/Makefile
+++ b/devel/pkgconf/Makefile
@@ -1,0 +1,57 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pkgconf
+PKG_VERSION:=1.5.1
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://distfiles.dereferenced.org/pkgconf
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_HASH:=d6877d721f84b59f137da48b237f16e68b598f5afc4f2a04d0a5c9e7e2bf5462
+PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
+PKG_LICENSE:=GPL-2+
+
+PKG_FIXUP:=autoreconf libtool
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/libpkgconf
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=libpkgconf
+  URL=http://pkgconf.org/
+endef
+
+define Package/pkgconf
+  SECTION:=devel
+  CATEGORY:=Development
+  TITLE:=pkgconf
+  DEPENDS:=+libpkgconf
+  URL:=http://pkgconf.org/
+endef
+
+define Package/pkgconf/description
+  pkgconf is a helper tool used when compiling applications and libraries.
+  It helps you insert the correct compiler options on the command line so an
+  application can use gcc -o test test.cpkg-config --libs --cflags glib-2.0
+  for instance, rather than hard-coding values on where to find glib (or
+  other libraries).
+endef
+
+define Package/libpkgconf/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libpkgconf* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpkgconf.pc $(1)/usr/lib/pkgconfig
+endef
+
+define Package/pkgconf/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/pkgconf $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/share/aclocal/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/pkg.m4 $(1)/usr/share/aclocal/
+endef
+
+$(eval $(call BuildPackage,libpkgconf))
+$(eval $(call BuildPackage,pkgconf))

--- a/devel/pkgconf/patches/010-fix-libtool.patch
+++ b/devel/pkgconf/patches/010-fix-libtool.patch
@@ -1,0 +1,29 @@
+diff --git a/m4/ltversion.m4 b/m4/ltversion.m4
+deleted file mode 100644
+index fa04b52..0000000
+--- a/m4/ltversion.m4
++++ /dev/null
+@@ -1,23 +0,0 @@
+-# ltversion.m4 -- version numbers			-*- Autoconf -*-
+-#
+-#   Copyright (C) 2004, 2011-2015 Free Software Foundation, Inc.
+-#   Written by Scott James Remnant, 2004
+-#
+-# This file is free software; the Free Software Foundation gives
+-# unlimited permission to copy and/or distribute it, with or without
+-# modifications, as long as this notice is preserved.
+-
+-# @configure_input@
+-
+-# serial 4179 ltversion.m4
+-# This file is part of GNU Libtool
+-
+-m4_define([LT_PACKAGE_VERSION], [2.4.6])
+-m4_define([LT_PACKAGE_REVISION], [2.4.6])
+-
+-AC_DEFUN([LTVERSION_VERSION],
+-[macro_version='2.4.6'
+-macro_revision='2.4.6'
+-_LT_DECL(, macro_version, 0, [Which release of libtool.m4 was used?])
+-_LT_DECL(, macro_revision, 0)
+-])


### PR DESCRIPTION
pkgconf is a new package meant to replace pkg-config. It it a leaner and
less buggy version of pkg-config. What that means is that it is not
necessarily bug compatible with pkg-config but is compatible with properly
formatted .pc files.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: mvebu

This is meant to eventually replace pkg-config. Right now I just want it in.
