### PR TITLE
qemu: package qemu-nbd and qemu-img

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -96,6 +96,20 @@ define Package/qemu-bridge-helper/install
 	$(INSTALL_DATA) ./files/bridge.conf $(1)/etc/qemu
 endef
 
+define Package/qemu-img
+ SECTION:=utils
+ CATEGORY:=Utilities
+ SUBMENU:=Virtualization
+ TITLE:=QEMU Image utility
+ URL:=http://www.qemu.org
+ DEPENDS:=+glib2 $(CXX_DEPENDS) $(QEMU_DEPS_IN_HOST)
+endef
+
+define Package/qemu-img/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/qemu-img $(1)/usr/bin/qemu-img
+endef
+
 PKG_CONFIG_DEPENDS += CONFIG_PACKAGE_qemu-ga
 
 # Naming rules used in qemu Makefile.target
@@ -246,6 +260,7 @@ MAKE_FLAGS:=$(filter-out	\
 QEMU_MAKE_TARGETS := \
 	$(if $(CONFIG_PACKAGE_qemu-ga),qemu-ga) \
 	$(if $(CONFIG_PACKAGE_qemu-bridge-helper),qemu-bridge-helper) \
+	$(if $(CONFIG_PACKAGE_qemu-img),qemu-img) \
 	$(foreach target,$(QEMU_TARGET_LIST),$(if $(CONFIG_PACKAGE_qemu-$(target)),subdir-$(target))) \
 
 define Build/Compile
@@ -255,6 +270,7 @@ endef
 $(eval $(call BuildPackage,virtio-console-helper))
 $(eval $(call BuildPackage,qemu-ga))
 $(eval $(call BuildPackage,qemu-bridge-helper))
+$(eval $(call BuildPackage,qemu-img))
 $(eval $(call BuildPackage,qemu-blobs))
 $(foreach target,$(QEMU_TARGET_LIST), \
   $(eval $(call BuildPackage,qemu-$(target))) \

--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -110,6 +110,20 @@ define Package/qemu-img/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/qemu-img $(1)/usr/bin/qemu-img
 endef
 
+define Package/qemu-nbd
+ SECTION:=utils
+ CATEGORY:=Utilities
+ SUBMENU:=Virtualization
+ TITLE:=QEMU Network Block Device Utility
+ URL:=http://www.qemu.org
+ DEPENDS:=+glib2 $(CXX_DEPENDS) $(QEMU_DEPS_IN_HOST) +kmod-nbd
+endef
+
+define Package/qemu-nbd/install
+	$(INSTALL_DIR) $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/qemu-nbd $(1)/usr/sbin/qemu-nbd
+endef
+
 PKG_CONFIG_DEPENDS += CONFIG_PACKAGE_qemu-ga
 
 # Naming rules used in qemu Makefile.target
@@ -261,6 +275,7 @@ QEMU_MAKE_TARGETS := \
 	$(if $(CONFIG_PACKAGE_qemu-ga),qemu-ga) \
 	$(if $(CONFIG_PACKAGE_qemu-bridge-helper),qemu-bridge-helper) \
 	$(if $(CONFIG_PACKAGE_qemu-img),qemu-img) \
+	$(if $(CONFIG_PACKAGE_qemu-nbd),qemu-nbd) \
 	$(foreach target,$(QEMU_TARGET_LIST),$(if $(CONFIG_PACKAGE_qemu-$(target)),subdir-$(target))) \
 
 define Build/Compile
@@ -271,6 +286,7 @@ $(eval $(call BuildPackage,virtio-console-helper))
 $(eval $(call BuildPackage,qemu-ga))
 $(eval $(call BuildPackage,qemu-bridge-helper))
 $(eval $(call BuildPackage,qemu-img))
+$(eval $(call BuildPackage,qemu-nbd))
 $(eval $(call BuildPackage,qemu-blobs))
 $(foreach target,$(QEMU_TARGET_LIST), \
   $(eval $(call BuildPackage,qemu-$(target))) \


### PR DESCRIPTION
Maintainer: @yousong
Compile tested: x86_64 (SDK master snapshot from Jun 16), layerscape (aarch64)
Run tested: layerscape (aarch64), master 

Description:
This packages the qemu-img and qemu-nbd tools, which can be used to manipulate virtual machine images.