### PR TITLE
net/sslsplit: Added a package for SSLsplit (https://www.roe.ch/SSLsplit)

### DIFF
--- a/net/sslsplit/Makefile
+++ b/net/sslsplit/Makefile
@@ -1,4 +1,3 @@
-
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -7,14 +6,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sslsplit
-PKG_VERSION:=0.5.2
+PKG_VERSION:=0.5.4
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE LICENSE.contrib LICENSE.third
 
-PKG_SOURCE:=sslsplit-0.5.2.tar.bz2
+PKG_SOURCE:=sslsplit-${PKG_VERSION}.tar.bz2
 PKG_SOURCE_URL:=https://mirror.roe.ch/rel/sslsplit/
-PKG_HASH:=f32c7fd760a45bb521adb8d96c819173fcaed1964bf114e666fcd7cf7ff043a8
+PKG_HASH:=336c54c4578a2f2bd9d8bae153f31499156037515fa07d5fa7d5373f4c1378c2
 
 PKG_INSTALL:=1
 

--- a/net/sslsplit/Makefile
+++ b/net/sslsplit/Makefile
@@ -1,5 +1,4 @@
-#
-# Copyright (C) 2016-2018 OpenWrt.org
+
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -13,10 +12,9 @@ PKG_RELEASE:=1
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE LICENSE.contrib LICENSE.third
 
-PKG_SOURCE:=sslsplit.tar.gz
-PKG_SOURCE_URL:=https://github.com/droe/sslsplit.git
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=0.5.2
+PKG_SOURCE:=sslsplit-0.5.2.tar.bz2
+PKG_SOURCE_URL:=https://mirror.roe.ch/rel/sslsplit/
+PKG_HASH:=f32c7fd760a45bb521adb8d96c819173fcaed1964bf114e666fcd7cf7ff043a8
 
 PKG_INSTALL:=1
 
@@ -45,3 +43,4 @@ define Package/sslsplit/install
 endef
 
 $(eval $(call BuildPackage,sslsplit))
+

--- a/net/sslsplit/Makefile
+++ b/net/sslsplit/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2016-2018 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=sslsplit
+PKG_VERSION:=0.5.2
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE LICENSE.contrib LICENSE.third
+
+PKG_SOURCE:=sslsplit.tar.gz
+PKG_SOURCE_URL:=https://github.com/droe/sslsplit.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=0.5.2
+
+PKG_INSTALL:=1
+
+PKG_MAINTAINER:=Awais Chishti <chishtiawais511@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/sslsplit
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libevent2 +libopenssl +libevent2-openssl +libevent2-pthreads +USE_MUSL:musl-fts
+  TITLE:=Transparent SSL/TLS interception
+  URL:=https://www.roe.ch/SSLsplit
+endef
+
+define Package/sslsplit/description
+  Transparent SSL/TLS interception
+endef
+
+MAKE_FLAGS += prefix=/usr \
+	OSNAME=Linux
+
+define Package/sslsplit/install
+	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/local/bin/sslsplit $(1)/bin/
+endef
+
+$(eval $(call BuildPackage,sslsplit))

--- a/net/sslsplit/patches/GNUmakefile.patch
+++ b/net/sslsplit/patches/GNUmakefile.patch
@@ -1,0 +1,12 @@
+diff -r -u sslsplit/GNUmakefile sslsplit_new/GNUmakefile
+--- sslsplit/GNUmakefile	2018-06-15 16:31:26.206724177 +0500
++++ sslsplit_new/GNUmakefile	2018-06-15 17:13:47.900160437 +0500
+@@ -304,6 +304,8 @@
+ TPKG_LDFLAGS+=	-L$(CHECK_FOUND)/lib
+ TPKG_LIBS+=	-lcheck
+ endif
++# Additional flags for compilation with musl-fts
++PKG_LIBS+=	-lfts
+ 
+ ifneq (,$(strip $(PKGS)))
+ PKG_CFLAGS+=	$(shell $(PKGCONFIG) $(PCFLAGS) --cflags-only-other $(PKGS))


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, TP-Link (TL-MR3020), LEDE 17.01
Run tested: ar71xx, TP-Link (TL-MR3020), LEDE 17.01

Description:
SSLsplit package (see [the official page](https://www.roe.ch/SSLsplit)) for MITM attacks against SSL/TLS connections.

Signed-off-by: Awais Chishti <chishtiawais@hotmail.com>