### PR TITLE
rtty: depends on 'CONFIG_BUSYBOX_CONFIG_LOGIN'

### DIFF
--- a/utils/rtty/Makefile
+++ b/utils/rtty/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtty
 PKG_VERSION:=5.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
@@ -31,7 +31,7 @@ define Package/rtty/default
   CATEGORY:=Utilities
   SUBMENU:=Terminal
   TITLE:=A reverse proxy WebTTY
-  DEPENDS:=+libprotobuf-c
+  DEPENDS:=+libprotobuf-c +@BUSYBOX_CUSTOM +@BUSYBOX_CONFIG_LOGIN
 endef
 
 define Package/rtty/default/description


### PR DESCRIPTION
Signed-off-by: Jianhui Zhao <jianhuizhao329@gmail.com>

Maintainer: me
Compile tested: (mipsel,miwifi-mini, master)
Run tested: (mipsel,miwifi-mini, master)

Description: