### PR TITLE
minisatip: add new package

### DIFF
--- a/multimedia/minisatip/Makefile
+++ b/multimedia/minisatip/Makefile
@@ -1,0 +1,84 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=minisatip
+PKG_VERSION:=snapshot-20181122
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/catalinii/minisatip.git
+PKG_SOURCE_VERSION:=6ca3b082e5fc2736764ff9a04f10600f36428527
+PKG_MIRROR_HASH:=f6a10446d229bbed734e19fab8d82171ed63c6c8ae4fc78a0ad24c7591b540f9
+
+PKG_MAINTAINER:=Daniel Kucera <github@danman.eu>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/minisatip
+  TITLE:=SATIP server
+  URL:=https://github.com/catalinii/minisatip
+  SECTION:=multimedia
+  CATEGORY:=Multimedia
+  DEPENDS := +MINISATIP_DVBAPI:libdvbapi +MINISATIP_DVBCSA:libdvbcsa +MINISATIP_CI:libdvben50221 +MINISATIP_AES:libopenssl
+endef
+
+define Package/minisatip/config
+	if PACKAGE_minisatip
+
+		config MINISATIP_CI
+			bool "Common Interface"
+			default n
+
+		config MINISATIP_AES
+			bool "OpenSSL (AES as part of DVBAPI)"
+			default n
+
+		config MINISATIP_DVBCSA
+			bool "DVBCSA"
+			default n
+
+		config MINISATIP_CLIENT
+			bool "SatIP Client"
+			default y
+
+		config MINISATIP_DVBAPI
+			bool "dvbapi"
+			default y
+
+	endif
+endef
+
+ifeq ($(CONFIG_MINISATIP_CI),)
+	CONFIGURE_ARGS += --disable-dvbca
+endif
+
+ifeq ($(CONFIG_MINISATIP_AES),)
+	CONFIGURE_ARGS += --disable-dvbaes
+endif
+
+ifeq ($(CONFIG_MINISATIP_DVBCSA),)
+	CONFIGURE_ARGS += --disable-dvbcsa
+endif
+
+ifeq ($(CONFIG_MINISATIP_CLIENT),)
+	CONFIGURE_ARGS += --disable-satipc
+endif
+
+ifeq ($(CONFIG_MINISATIP_DVBAPI),)
+	CONFIGURE_ARGS += --disable-dvbapi
+endif
+
+define Package/minisatip/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/minisatip $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/share/minisatip/html/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/html/* $(1)/usr/share/minisatip/html
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/minisatip.init $(1)/etc/init.d/minisatip
+endef
+
+$(eval $(call BuildPackage,minisatip))

--- a/multimedia/minisatip/files/minisatip.init
+++ b/multimedia/minisatip/files/minisatip.init
@@ -1,0 +1,16 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=99
+
+start_service() {
+	procd_open_instance minisatip
+	procd_set_param command /usr/bin/minisatip -f -R /usr/share/minisatip/html
+
+	procd_set_param respawn
+
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+


### PR DESCRIPTION
Minisatip is a multi-threaded satip server version 1.2 that runs
under Linux and it was tested with DVB-S, DVB-S2, DVB-T, DVB-T2,
DVB-C, DVB-C2, ATSC and ISDB-T cards.

https://github.com/catalinii/minisatip

Signed-off-by: Daniel Kucera <github@danman.eu>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
