### PR TITLE
prometheus-node-exporter-lua: handle fancy release backport to 18.06

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2017.12.08
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_MAINTAINER:=Christian Simon <simon@swine.de>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/openwrt.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/openwrt.lua
@@ -6,7 +6,7 @@ local labels = {
     board_name = string.sub(get_contents("/tmp/sysinfo/board_name"), 1, -2)
 }
 
-for k, v in string.gmatch(get_contents("/etc/openwrt_release"), "(DISTRIB_%w+)='(%w+)'\n") do
+for k, v in string.gmatch(get_contents("/etc/openwrt_release"), "(DISTRIB_%w+)='(.-)'\n") do
     if k == "DISTRIB_ID" then
         labels["id"] = v
     elseif k == "DISTRIB_RELEASE" then


### PR DESCRIPTION
Some releases may have non letters in it's name currently resulting in
an empty ("") output which is then discarded, resulting in *missing*
labels in the metric.

Now it uses `.-` to catch as little as possible, but anything.

Signed-off-by: Paul Spooren <mail@aparcar.org>