### PR TITLE
nginx: bump and add build variant and other fix

### DIFF
--- a/net/nginx/Config_ssl.in
+++ b/net/nginx/Config_ssl.in
@@ -6,14 +6,7 @@
 #
 
 menu "Configuration"
-        depends on PACKAGE_nginx
-
-config NGINX_SSL
-	bool
-	prompt "Enable SSL module"
-	help
-		Enable HTTPS/SSL support.
-	default n
+        depends on PACKAGE_nginx-ssl
 
 config NGINX_DAV
 	bool
@@ -219,7 +212,6 @@ config NGINX_HTTP_BROTLI
 config NGINX_RTMP_MODULE
 	bool
 	prompt "Enable RTMP module"
-	depends on NGINX_SSL
 	help
 		Add support for NGINX-based Media Streaming Server module.
 	default n

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -8,18 +8,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
-PKG_VERSION:=1.14.0
+PKG_VERSION:=1.15.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://nginx.org/download/
-PKG_HASH:=5d15becbf69aba1fe33f8d416d97edd95ea8919ea9ac519eff9bafebb6022cb5
+PKG_HASH:=b0b58c9a3fd73aa8b89edf5cfadc6641a352e0e6d3071db1eb3215d72b7fb516
 
-PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
+PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de> \
+				Ansuel Smith <ansuelsmth@gmail.com>
 PKG_LICENSE:=2-clause BSD-like license
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/nginx-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
+PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
@@ -67,22 +69,54 @@ PKG_CONFIG_DEPENDS := \
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/nginx
+define Package/nginx/default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
   TITLE:=Nginx web server
   URL:=http://nginx.org/
-  DEPENDS:=+NGINX_PCRE:libpcre +(NGINX_SSL||NGINX_HTTP_CACHE||NGINX_HTTP_AUTH_BASIC):libopenssl +NGINX_HTTP_GZIP:zlib +NGINX_LUA:liblua +libpthread
+  DEPENDS:=+NGINX_PCRE:libpcre +(NGINX_SSL||NGINX_HTTP_CACHE||NGINX_HTTP_AUTH_BASIC):libopenssl \
+     +NGINX_HTTP_GZIP:zlib +NGINX_LUA:liblua +libpthread
 endef
 
 define Package/nginx/description
- nginx is an HTTP and reverse proxy server, as well as a mail proxy server,
- written by Igor Sysoev.
+ nginx is an HTTP and reverse proxy server, as well as a mail proxy server, \
+ written by Igor Sysoev. (Some module require SSL module enable to show up in \
+ config menu)
 endef
+
+define Package/nginx
+  $(Package/nginx/default)
+  VARIANT:=no-ssl
+endef
+
+define Package/nginx-ssl
+  $(Package/nginx/default)
+  TITLE += with SSL support
+  DEPENDS +=+libopenssl
+  VARIANT:=ssl
+endef
+
+Package/nginx-ssl/description = $(Package/nginx/description) \
+  This varian is compiled with SSL support enabled. To enable additional module \
+  select them in the nginx default configuration menu.
+
+define Package/nginx-all-module
+  $(Package/nginx/default)
+  TITLE += with ALL module selected
+  DEPENDS:=+libpcre +libopenssl +zlib +liblua +libpthread
+  VARIANT:=all-module
+endef
+
+Package/nginx-all-module/description = $(Package/nginx/description) \
+  This varian is compiled with ALL module selected.
 
 define Package/nginx/config
   source "$(SOURCE)/Config.in"
+endef
+
+define Package/nginx-ssl/config
+  source "$(SOURCE)/Config_ssl.in"
 endef
 
 config_files=nginx.conf mime.types
@@ -91,165 +125,197 @@ define Package/nginx/conffiles
 /etc/nginx/
 endef
 
+Package/nginx-ssl/conffiles = $(Package/nginx/conffiles)
+Package/nginx-all-module/conffiles = $(Package/nginx/conffiles)
+
+
 ADDITIONAL_MODULES:=
-ifeq ($(CONFIG_NGINX_NAXSI),y)
-  ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-naxsi/naxsi_src
-endif
-ifeq ($(CONFIG_NGINX_LUA),y)
-  ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/lua-nginx
-endif
-ifeq ($(CONFIG_IPV6),y)
-  ADDITIONAL_MODULES += --with-ipv6
-endif
-ifeq ($(CONFIG_NGINX_STUB_STATUS),y)
-  ADDITIONAL_MODULES += --with-http_stub_status_module
-endif
-ifeq ($(CONFIG_NGINX_FLV),y)
-  ADDITIONAL_MODULES += --with-http_flv_module
-endif
-ifeq ($(CONFIG_NGINX_SSL),y)
-  ADDITIONAL_MODULES += --with-http_ssl_module
-endif
-ifeq ($(CONFIG_NGINX_DAV),y)
-  ADDITIONAL_MODULES += --with-http_dav_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_CACHE),y)
-  ADDITIONAL_MODULES += --without-http-cache
-endif
-ifneq ($(CONFIG_NGINX_PCRE),y)
-  ADDITIONAL_MODULES += --without-pcre
-endif
-ifneq ($(CONFIG_NGINX_HTTP_CHARSET),y)
-  ADDITIONAL_MODULES += --without-http_charset_module
+
+ifneq ($(BUILD_VARIANT),all-module)
+  ifneq ($(CONFIG_NGINX_HTTP_CACHE),y)
+    ADDITIONAL_MODULES += --without-http-cache
+  endif
+  ifneq ($(CONFIG_NGINX_PCRE),y)
+    ADDITIONAL_MODULES += --without-pcre
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_CHARSET),y)
+    ADDITIONAL_MODULES += --without-http_charset_module
+  else
+    config_files += koi-utf koi-win win-utf
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_GZIP),y)
+    ADDITIONAL_MODULES += --without-http_gzip_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_SSI),y)
+    ADDITIONAL_MODULES += --without-http_ssi_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_USERID),y)
+    ADDITIONAL_MODULES += --without-http_userid_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_ACCESS),y)
+    ADDITIONAL_MODULES += --without-http_access_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_AUTH_BASIC),y)
+    ADDITIONAL_MODULES += --without-http_auth_basic_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_AUTOINDEX),y)
+    ADDITIONAL_MODULES += --without-http_autoindex_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_GEO),y)
+    ADDITIONAL_MODULES += --without-http_geo_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_MAP),y)
+    ADDITIONAL_MODULES += --without-http_map_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_SPLIT_CLIENTS),y)
+    ADDITIONAL_MODULES += --without-http_split_clients_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_REFERER),y)
+    ADDITIONAL_MODULES += --without-http_referer_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_REWRITE),y)
+    ADDITIONAL_MODULES += --without-http_rewrite_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_PROXY),y)
+    ADDITIONAL_MODULES += --without-http_proxy_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_FASTCGI),y)
+    ADDITIONAL_MODULES += --without-http_fastcgi_module
+  else
+    config_files += fastcgi_params
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_UWSGI),y)
+    ADDITIONAL_MODULES += --without-http_uwsgi_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_SCGI),y)
+    ADDITIONAL_MODULES += --without-http_scgi_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_MEMCACHED),y)
+    ADDITIONAL_MODULES += --without-http_memcached_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_LIMIT_CONN),y)
+    ADDITIONAL_MODULES += --without-http_limit_conn_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_LIMIT_REQ),y)
+    ADDITIONAL_MODULES += --without-http_limit_req_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_EMPTY_GIF),y)
+    ADDITIONAL_MODULES += --without-http_empty_gif_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_BROWSER),y)
+    ADDITIONAL_MODULES += --without-http_browser_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_HASH),y)
+    ADDITIONAL_MODULES += --without-http_upstream_hash_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_IP_HASH),y)
+    ADDITIONAL_MODULES += --without-http_upstream_ip_hash_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_LEAST_CONN),y)
+    ADDITIONAL_MODULES += --without-http_upstream_least_conn_module
+  endif
+  ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_KEEPALIVE),y)
+    ADDITIONAL_MODULES += --without-http_upstream_keepalive_module
+  endif
+  
+  ifeq ($(BUILD_VARIANT),ssl)
+    ifneq ($(CONFIG_NGINX_SSL),y)
+      ADDITIONAL_MODULES += --with-http_ssl_module
+    endif
+  endif
+  
+  ifeq ($(CONFIG_NGINX_SSL),y)
+    ADDITIONAL_MODULES += --with-http_ssl_module
+  endif
+  ifeq ($(CONFIG_NGINX_NAXSI),y)
+    ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-naxsi/naxsi_src
+  endif
+  ifeq ($(CONFIG_NGINX_LUA),y)
+    ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/lua-nginx
+  endif
+  ifeq ($(CONFIG_IPV6),y)
+    ADDITIONAL_MODULES += --with-ipv6
+  endif
+  ifeq ($(CONFIG_NGINX_STUB_STATUS),y)
+    ADDITIONAL_MODULES += --with-http_stub_status_module
+  endif
+  ifeq ($(CONFIG_NGINX_FLV),y)
+    ADDITIONAL_MODULES += --with-http_flv_module
+  endif
+  ifeq ($(CONFIG_NGINX_DAV),y)
+    ADDITIONAL_MODULES += --with-http_dav_module
+  endif
+  ifeq ($(CONFIG_NGINX_HTTP_AUTH_REQUEST),y)
+    ADDITIONAL_MODULES += --with-http_auth_request_module
+  endif
+  ifeq ($(CONFIG_NGINX_HTTP_V2),y)
+    ADDITIONAL_MODULES += --with-http_v2_module
+  endif
+  ifeq ($(CONFIG_NGINX_HTTP_REAL_IP),y)
+    ADDITIONAL_MODULES += --with-http_realip_module
+  endif
+  ifeq ($(CONFIG_NGINX_HTTP_SECURE_LINK),y)
+    ADDITIONAL_MODULES += --with-http_secure_link_module
+  endif
+  ifeq ($(CONFIG_NGINX_HEADERS_MORE),y)
+    ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-headers-more
+  endif
+  ifeq ($(CONFIG_NGINX_HTTP_BROTLI),y)
+    ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-brotli
+  endif
+  ifeq ($(CONFIG_NGINX_RTMP_MODULE),y)
+    ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-rtmp
+  endif
+  ifeq ($(CONFIG_NGINX_TS_MODULE),y)
+    ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-ts
+  endif
 else
-  config_files += koi-utf koi-win win-utf
-endif
-ifneq ($(CONFIG_NGINX_HTTP_GZIP),y)
-  ADDITIONAL_MODULES += --without-http_gzip_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_SSI),y)
-  ADDITIONAL_MODULES += --without-http_ssi_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_USERID),y)
-  ADDITIONAL_MODULES += --without-http_userid_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_ACCESS),y)
-  ADDITIONAL_MODULES += --without-http_access_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_AUTH_BASIC),y)
-  ADDITIONAL_MODULES += --without-http_auth_basic_module
-endif
-ifeq ($(CONFIG_NGINX_HTTP_AUTH_REQUEST),y)
-  ADDITIONAL_MODULES += --with-http_auth_request_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_AUTOINDEX),y)
-  ADDITIONAL_MODULES += --without-http_autoindex_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_GEO),y)
-  ADDITIONAL_MODULES += --without-http_geo_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_MAP),y)
-  ADDITIONAL_MODULES += --without-http_map_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_SPLIT_CLIENTS),y)
-  ADDITIONAL_MODULES += --without-http_split_clients_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_REFERER),y)
-  ADDITIONAL_MODULES += --without-http_referer_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_REWRITE),y)
-  ADDITIONAL_MODULES += --without-http_rewrite_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_PROXY),y)
-  ADDITIONAL_MODULES += --without-http_proxy_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_FASTCGI),y)
-  ADDITIONAL_MODULES += --without-http_fastcgi_module
-else
-  config_files += fastcgi_params
-endif
-ifneq ($(CONFIG_NGINX_HTTP_UWSGI),y)
-  ADDITIONAL_MODULES += --without-http_uwsgi_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_SCGI),y)
-  ADDITIONAL_MODULES += --without-http_scgi_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_MEMCACHED),y)
-  ADDITIONAL_MODULES += --without-http_memcached_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_LIMIT_CONN),y)
-  ADDITIONAL_MODULES += --without-http_limit_conn_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_LIMIT_REQ),y)
-  ADDITIONAL_MODULES += --without-http_limit_req_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_EMPTY_GIF),y)
-  ADDITIONAL_MODULES += --without-http_empty_gif_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_BROWSER),y)
-  ADDITIONAL_MODULES += --without-http_browser_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_HASH),y)
-  ADDITIONAL_MODULES += --without-http_upstream_hash_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_IP_HASH),y)
-  ADDITIONAL_MODULES += --without-http_upstream_ip_hash_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_LEAST_CONN),y)
-  ADDITIONAL_MODULES += --without-http_upstream_least_conn_module
-endif
-ifneq ($(CONFIG_NGINX_HTTP_UPSTREAM_KEEPALIVE),y)
-  ADDITIONAL_MODULES += --without-http_upstream_keepalive_module
-endif
-ifeq ($(CONFIG_NGINX_HTTP_V2),y)
-  ADDITIONAL_MODULES += --with-http_v2_module
-endif
-ifeq ($(CONFIG_NGINX_HTTP_REAL_IP),y)
-  ADDITIONAL_MODULES += --with-http_realip_module
-endif
-ifeq ($(CONFIG_NGINX_HTTP_SECURE_LINK),y)
-  ADDITIONAL_MODULES += --with-http_secure_link_module
-endif
-ifeq ($(CONFIG_NGINX_HEADERS_MORE),y)
-  ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-headers-more
-endif
-ifeq ($(CONFIG_NGINX_HTTP_BROTLI),y)
-  ADDITIONAL_MODULES += --add-module=$(PKG_BUILD_DIR)/nginx-brotli
+  ADDITIONAL_MODULES += --with-http_ssl_module --add-module=$(PKG_BUILD_DIR)/nginx-naxsi/naxsi_src \
+    --add-module=$(PKG_BUILD_DIR)/lua-nginx --with-ipv6 --with-http_stub_status_module --with-http_flv_module \
+	--with-http_dav_module --with-http_auth_request_module --with-http_v2_module --with-http_realip_module \
+	--with-http_secure_link_module --add-module=$(PKG_BUILD_DIR)/nginx-headers-more \
+	--add-module=$(PKG_BUILD_DIR)/nginx-brotli --add-module=$(PKG_BUILD_DIR)/nginx-rtmp \
+	--add-module=$(PKG_BUILD_DIR)/nginx-ts
+  config_files += koi-utf koi-win win-utf fastcgi_params 
 endif
 
-define Package/nginx-mod-luci
+define Package/nginx-mod-luci/default
+  TITLE:=Nginx on LuCI
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
   TITLE:=Support file for Nginx
   URL:=http://nginx.org/
-  DEPENDS:=nginx +uwsgi-cgi +uwsgi-cgi-luci-support
+  DEPENDS:=+uwsgi-cgi +uwsgi-cgi-luci-support
+endef
+
+define Package/nginx-mod-luci
+  $(Package/nginx-mod-luci/default)
+  DEPENDS += +nginx
 endef
 
 define Package/nginx-mod-luci/description
- Support file for LuCI in nginx (include custom nginx configuration, autostart script for uwsgi)
+ Support file for LuCI in nginx. Include custom nginx configuration, autostart script for uwsgi.
 endef
 
 define Package/nginx-mod-luci-ssl
-  SECTION:=net
-  CATEGORY:=Network
-  SUBMENU:=Web Servers/Proxies
-  TITLE:=Support file for Nginx (SSL)
-  URL:=http://nginx.org/
-  DEPENDS:=nginx +nginx-mod-luci
+  $(Package/nginx-mod-luci/default)
+  TITLE += with HTTPS support
+  DEPENDS += +nginx-ssl
 endef
 
-define Package/nginx-mod-luci-ssl/description
- Support file for LuCI in nginx (include custom nginx configuration, autostart script for uwsgi, redirect from http to https)
-endef
+Package/nginx-mod-luci-ssl/description = $(define Package/nginx-mod-luci/description) \
+  This also include redirect from http to https and cert autogeneration.
 
 TARGET_CFLAGS += -fvisibility=hidden -ffunction-sections -fdata-sections -DNGX_LUA_NO_BY_LUA_BLOCK
 TARGET_LDFLAGS += -Wl,--gc-sections
 
-define Build/Configure
-	( cd $(PKG_BUILD_DIR) ; \
-		$(if $(CONFIG_NGINX_LUA),LUA_INC=$(STAGING_DIR)/usr/include LUA_LIB=$(STAGING_DIR)/usr/lib) \
-		./configure \
+ifeq ($(CONFIG_NGINX_LUA),y)
+  CONFIGURE_VARS += LUA_INC=$(STAGING_DIR)/usr/include \
+					LUA_LIB=$(STAGING_DIR)/usr/lib
+endif
+
+CONFIGURE_ARGS += \
 			--crossbuild=Linux::$(ARCH) \
 			--prefix=/usr \
 			--conf-path=/etc/nginx/nginx.conf \
@@ -264,9 +330,7 @@ define Build/Configure
 			--with-cc="$(TARGET_CC)" \
 			--with-cc-opt="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS)" \
 			--with-ld-opt="$(TARGET_LDFLAGS)" \
-			--without-http_upstream_zone_module \
-	)
-endef
+			--without-http_upstream_zone_module
 
 define Package/nginx-mod-luci/install
 	$(INSTALL_DIR) $(1)/etc/nginx
@@ -277,6 +341,7 @@ define Package/nginx-mod-luci/install
 endef
 
 define Package/nginx-mod-luci-ssl/install
+	$(Package/nginx-mod-luci/install)
 	$(INSTALL_DIR) $(1)/etc/nginx
 	$(INSTALL_BIN) ./files-luci-support/luci_nginx_ssl.conf $(1)/etc/nginx/luci_nginx_ssl.conf
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
@@ -299,12 +364,26 @@ endif
 	$(if $(CONFIG_NGINX_NAXSI),$(chmod 0640 $(1)/etc/nginx/naxsi_core.rules))
 endef
 
+Package/nginx-ssl/install = $(Package/nginx/install)
+Package/nginx-all-module/install = $(Package/nginx/install)
+
 define Build/Prepare
-	$(call Build/Prepare/Default)
-	$(if $(CONFIG_NGINX_NAXSI),$(call Prepare/nginx-naxsi))
-	$(if $(CONFIG_NGINX_LUA),$(call Prepare/lua-nginx))
-	$(if $(CONFIG_NGINX_HTTP_BROTLI),$(call Prepare/nginx-brotli))
-	$(if $(CONFIG_NGINX_HEADERS_MORE),$(call Prepare/nginx-headers-more))
+  $(call Build/Prepare/Default)
+  ifneq ($(BUILD_VARIANT),all-module)
+    $(if $(CONFIG_NGINX_NAXSI),$(call Prepare/nginx-naxsi))
+    $(if $(CONFIG_NGINX_LUA),$(call Prepare/lua-nginx))
+    $(if $(CONFIG_NGINX_HTTP_BROTLI),$(call Prepare/nginx-brotli))
+    $(if $(CONFIG_NGINX_HEADERS_MORE),$(call Prepare/nginx-headers-more))
+	$(if $(CONFIG_NGINX_RTMP_MODULE),$(call Prepare/nginx-rtmp))
+	$(if $(CONFIG_NGINX_TS_MODULE),$(call Prepare/nginx-ts))
+  else
+    $(call Prepare/nginx-naxsi)
+    $(call Prepare/lua-nginx)
+    $(call Prepare/nginx-brotli)
+    $(call Prepare/nginx-headers-more)
+	$(call Prepare/nginx-rtmp)
+	$(call Prepare/nginx-ts)
+  endif
 endef
 
 define Download/nginx-headers-more
@@ -321,7 +400,7 @@ define  Prepare/nginx-headers-more
 endef
 
 define Download/nginx-brotli
-	VERSION:=37ab9b2933a0b756ba3447000b7f31d432ed8228
+	VERSION:=e26248ee361c04e25f581b92b85d95681bdffb39
 	SUBDIR:=nginx-brotli
 	FILE:=ngx-brotli-module-$(PKG_VERSION)-$$(VERSION).tar.gz
 	URL:=https://github.com/eustas/ngx_brotli.git
@@ -333,8 +412,34 @@ define  Prepare/nginx-brotli
 	gzip -dc $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
 endef
 
+define Download/nginx-rtmp
+	VERSION:=791b6136f02bc9613daf178723ac09f4df5a3bbf
+	SUBDIR:=nginx-rtmp
+	FILE:=ngx-rtmp-module-$(PKG_VERSION)-$$(VERSION).tar.gz
+	URL:=https://github.com/arut/nginx-rtmp-module.git
+	PROTO:=git
+endef
+
+define  Prepare/nginx-rtmp
+	$(eval $(call Download,nginx-rtmp))
+	gzip -dc $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
+endef
+
+define Download/nginx-ts
+	VERSION:=ef2f874d95cc75747eb625a292524a702aefb0fd
+	SUBDIR:=nginx-ts
+	FILE:=ngx-ts-module-$(PKG_VERSION)-$$(VERSION).tar.gz
+	URL:=https://github.com/arut/nginx-ts-module.git
+	PROTO:=git
+endef
+
+define  Prepare/nginx-ts
+	$(eval $(call Download,nginx-ts))
+	gzip -dc $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
+endef
+
 define Download/nginx-naxsi
-	VERSION:=fc4740f9734cabc1ce4c9d4cddc4b472eab1cc4b
+	VERSION:=951123ad456bdf5ac94e8d8819342fe3d49bc002
 	SUBDIR:=nginx-naxsi
 	FILE:=nginx-naxsi-module-$(PKG_VERSION)-$$(VERSION).tar.gz
 	URL:=https://github.com/nbs-system/naxsi.git
@@ -347,7 +452,7 @@ define  Prepare/nginx-naxsi
 endef
 
 define Download/lua-nginx
-	VERSION:=55743aeba3075b34a250380b32bad6366eae6c30
+	VERSION:=576a10d246daf81c0ce1b959c50ee807769c01a8
 	SUBDIR:=lua-nginx
 	FILE:=lua-nginx-module-$(PKG_VERSION)-$$(VERSION).tar.gz
 	URL:=https://github.com/openresty/lua-nginx-module.git
@@ -361,5 +466,7 @@ define  Prepare/lua-nginx
 endef
 
 $(eval $(call BuildPackage,nginx))
+$(eval $(call BuildPackage,nginx-ssl))
+$(eval $(call BuildPackage,nginx-all-module))
 $(eval $(call BuildPackage,nginx-mod-luci))
 $(eval $(call BuildPackage,nginx-mod-luci-ssl))

--- a/net/nginx/patches/201-ignore-invalid-options.patch
+++ b/net/nginx/patches/201-ignore-invalid-options.patch
@@ -1,0 +1,12 @@
+--- a/auto/options
++++ b/auto/options
+@@ -391,8 +391,7 @@
+         --test-build-solaris-sendfilev)  NGX_TEST_BUILD_SOLARIS_SENDFILEV=YES ;;
+ 
+         *)
+-            echo "$0: error: invalid option \"$option\""
+-            exit 1
++            echo "$0: error: ignoring invalid option \"$option\""
+         ;;
+     esac
+ done


### PR DESCRIPTION
This add 2 variant of nginx so we can have package with SSL config flag preselected. This also add support for 2 more module and upgrade gninx to latest version. Also add myself as secondary maintainer to apply luci modification quickly.
Use of autoreconf to fix problems with recompilation on every new build (even if the version is the same). Add a patch to ignore on invalid configure option instead of trow error.
@hnyman @heil 
Think the name for the build variant are not right... Any idea about that?

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>