### PR TITLE
libjpeg-turbo: Add new package

### DIFF
--- a/libs/libjpeg-turbo/Makefile
+++ b/libs/libjpeg-turbo/Makefile
@@ -1,0 +1,70 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libjpeg-turbo
+PKG_VERSION:=2.0.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@SF/$(PKG_NAME)
+PKG_HASH:=778876105d0d316203c928fd2a0374c8c01f755d0a00b12a1c8934aeccff8868
+
+PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
+PKG_LICENSE:=BSD-3-Clause IJG zlib
+PKG_LICENSE_FILES:=LICENSE.md
+
+PKG_USE_MIPS16:=0 #Allows ASM compilation for speed.
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/libjpeg-turbo
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=libjpeg-turbo
+  URL:=https://libjpeg-turbo.org/
+endef
+
+define Package/libjpeg-turbo-utils
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libjpeg-turbo
+  TITLE:=libjpeg-turbo-utils
+  URL:=https://libjpeg-turbo.org/
+endef
+
+define Package/libjpeg-turbo/description
+	libjpeg-turbo is a speed focused fork of libjpeg.
+endef
+
+define Package/libjpeg-turbo-utils/description
+	These are the JPEG utilities that come with libjpeg-turbo.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libturbojpeg.{a,so*} $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libjpeg.{a,so*} $(1)/usr/lib
+endef
+
+define Package/libjpeg-turbo/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libturbojpeg.so* $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libjpeg.so* $(1)/usr/lib
+endef
+
+define Package/libjpeg-turbo-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tjbench $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/rdjpgcom $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wrjpgcom $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/cjpeg $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/djpeg $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/jpegtran $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,libjpeg-turbo))
+$(eval $(call BuildPackage,libjpeg-turbo-utils))

--- a/libs/libjpeg-turbo/patches/010-simd-mips-Don-t-compile-float-code-on-softfloat-targ.patch
+++ b/libs/libjpeg-turbo/patches/010-simd-mips-Don-t-compile-float-code-on-softfloat-targ.patch
@@ -1,0 +1,75 @@
+From e2940b173e31253aaa160d2ec9a27c8fb92a9b6d Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sat, 11 Aug 2018 11:53:01 -0700
+Subject: [PATCH] simd: mips: Don't compile float code on softfloat targets
+
+Doing so causes opcode errors.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ simd/mips/jsimd.c       | 4 ++++
+ simd/mips/jsimd_dspr2.S | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/simd/mips/jsimd.c b/simd/mips/jsimd.c
+index af886f6..09d2758 100644
+--- a/simd/mips/jsimd.c
++++ b/simd/mips/jsimd.c
+@@ -709,7 +709,9 @@ GLOBAL(void)
+ jsimd_convsamp_float(JSAMPARRAY sample_data, JDIMENSION start_col,
+                      FAST_FLOAT *workspace)
+ {
++#ifndef __mips_soft_float
+   jsimd_convsamp_float_dspr2(sample_data, start_col, workspace);
++#endif
+ }
+ 
+ GLOBAL(int)
+@@ -821,7 +823,9 @@ GLOBAL(void)
+ jsimd_quantize_float(JCOEFPTR coef_block, FAST_FLOAT *divisors,
+                      FAST_FLOAT *workspace)
+ {
++#ifndef __mips_soft_float
+   jsimd_quantize_float_dspr2(coef_block, divisors, workspace);
++#endif
+ }
+ 
+ GLOBAL(int)
+diff --git a/simd/mips/jsimd_dspr2.S b/simd/mips/jsimd_dspr2.S
+index 2ec543e..6fa79ab 100644
+--- a/simd/mips/jsimd_dspr2.S
++++ b/simd/mips/jsimd_dspr2.S
+@@ -2810,6 +2810,7 @@ LEAF_DSPR2(jsimd_quantize_dspr2)
+ END(jsimd_quantize_dspr2)
+ 
+ 
++#ifndef __mips_soft_float
+ /*****************************************************************************/
+ LEAF_DSPR2(jsimd_quantize_float_dspr2)
+ /*
+@@ -2889,6 +2890,7 @@ LEAF_DSPR2(jsimd_quantize_float_dspr2)
+      nop
+ 
+ END(jsimd_quantize_float_dspr2)
++#endif
+ 
+ 
+ /*****************************************************************************/
+@@ -4110,6 +4112,7 @@ LEAF_DSPR2(jsimd_convsamp_dspr2)
+ END(jsimd_convsamp_dspr2)
+ 
+ 
++#ifndef __mips_soft_float
+ /*****************************************************************************/
+ LEAF_DSPR2(jsimd_convsamp_float_dspr2)
+ /*
+@@ -4467,5 +4470,6 @@ LEAF_DSPR2(jsimd_convsamp_float_dspr2)
+      nop
+ 
+ END(jsimd_convsamp_float_dspr2)
++#endif
+ 
+ /*****************************************************************************/
+-- 
+2.7.4
+


### PR DESCRIPTION
This is meant to replace the regular libjpeg. This is needed as libjpeg is
not only incompatible but -turbo has ASM optimizations for MIPS.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me
Compile tested: ipq806x
Run tested: R7800

Description:
I would like to replace the old libjpeg in the packages repo with this eventually. Most distros AFAIK have switched to -turbo.

@jow- Thoughts?