### PR TITLE
php7: use mysqlnd

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=7.2.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 
@@ -33,7 +33,7 @@ PHP7_MODULES = \
 	iconv imap intl \
 	json \
 	ldap \
-	mbstring mysqli \
+	mbstring mysqli mysqlnd \
 	opcache openssl \
 	pcntl pdo pdo-mysql pdo-pgsql pdo-sqlite pgsql phar \
 	session shmop simplexml snmp soap sockets sqlite3 sysvmsg sysvsem sysvshm \
@@ -292,9 +292,15 @@ else
 endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_php7-mod-mysqli),)
-  CONFIGURE_ARGS+= --with-mysqli=shared,"$(STAGING_DIR)/usr/bin/mysql_config"
+  CONFIGURE_ARGS+= --with-mysqli=shared
 else
   CONFIGURE_ARGS+= --without-mysqli
+endif
+
+ifneq ($(SDK)$(CONFIG_PACKAGE_php7-mod-mysqlnd),)
+  CONFIGURE_ARGS+= --enable-mysqlnd=shared
+else
+  CONFIGURE_ARGS+= --disable-mysqlnd
 endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_php7-mod-opcache),)
@@ -321,7 +327,7 @@ endif
 ifneq ($(SDK)$(CONFIG_PACKAGE_php7-mod-pdo),)
   CONFIGURE_ARGS+= --enable-pdo=shared
   ifneq ($(SDK)$(CONFIG_PACKAGE_php7-mod-pdo-mysql),)
-    CONFIGURE_ARGS+= --with-pdo-mysql=shared,"$(STAGING_DIR)/usr"
+    CONFIGURE_ARGS+= --with-pdo-mysql=shared
   else
     CONFIGURE_ARGS+= --without-pdo-mysql
   endif
@@ -601,12 +607,13 @@ $(eval $(call BuildModule,intl,Internationalization Functions,+PACKAGE_php7-mod-
 $(eval $(call BuildModule,json,JSON))
 $(eval $(call BuildModule,ldap,LDAP,+PACKAGE_php7-mod-ldap:libopenldap +PACKAGE_php7-mod-ldap:libsasl2))
 $(eval $(call BuildModule,mbstring,MBString))
-$(eval $(call BuildModule,mysqli,MySQL Improved Extension,+PACKAGE_php7-mod-mysqli:libmariadbclient))
+$(eval $(call BuildModule,mysqli,MySQL Improved Extension,+PACKAGE_php7-mod-mysqli:php7-mod-mysqlnd))
+$(eval $(call BuildModule,mysqlnd,MySQL Native Driver))
 $(eval $(call BuildModule,opcache,OPcache,,,zend))
 $(eval $(call BuildModule,openssl,OpenSSL,+PACKAGE_php7-mod-openssl:libopenssl))
 $(eval $(call BuildModule,pcntl,PCNTL))
 $(eval $(call BuildModule,pdo,PHP Data Objects))
-$(eval $(call BuildModule,pdo-mysql,PDO driver for MySQL,+php7-mod-pdo +PACKAGE_php7-mod-pdo-mysql:libmariadbclient))
+$(eval $(call BuildModule,pdo-mysql,PDO driver for MySQL,+php7-mod-pdo +PACKAGE_php7-mod-pdo-mysql:php7-mod-mysqlnd))
 $(eval $(call BuildModule,pdo-pgsql,PDO driver for PostgreSQL,+php7-mod-pdo +PACKAGE_php7-mod-pdo-pgsql:libpq))
 $(eval $(call BuildModule,pdo-sqlite,PDO driver for SQLite 3.x,+php7-mod-pdo +PACKAGE_php7-mod-pdo-sqlite:libsqlite3 +PACKAGE_php7-mod-pdo-sqlite:librt))
 $(eval $(call BuildModule,pgsql,PostgreSQL,+PACKAGE_php7-mod-pgsql:libpq))


### PR DESCRIPTION
This is in anticipation of the MariaDB upgrade from mariadb 10.1.x to
10.2.x. With the latter the PHP MySQL plugins fail to compile, e.g.:

```
In file included from /home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/php-7.2.6/ext/mysqli/php_mysqli_structs.h:63:0,
                 from /home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/php-7.2.6/ext/mysqli/mysqli.c:34:
/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/include/mysql/my_global.h:3:2: warning: #warning This file should not be included by clients, include only <mysql.h> [-Wcpp]
 #warning This file should not be included by clients, include only <mysql.h>
  ^~~~~~~
In file included from /home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/php-7.2.6/ext/mysqli/php_mysqli_structs.h:79:0,
                 from /home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/php-7.2.6/ext/mysqli/mysqli.c:34:
/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/include/mysql/my_sys.h:3:2: warning: #warning This file should not be included by clients, include only <mysql.h> [-Wcpp]
 #warning This file should not be included by clients, include only <mysql.h>
  ^~~~~~~
In file included from /home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/php-7.2.6/ext/mysqli/mysqli.c:34:0:
/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/php-7.2.6/ext/mysqli/php_mysqli_structs.h:82:10: fatal error: my_list.h: No such file or directory
 #include <my_list.h>

```
Upstream does not seem to be inclined to fix this, see
https://bugs.php.net/bug.php?id=75612. In the bug report it is suggested
to not use libmysqlclient/libmariadbclient and instead utilize mysqlnd
(MySQL Native Driver) provided by PHP. This is the default anyway.

So add the mysqlnd module and remove the libmariadbclient depends.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @mhei 
Compile tested: ar71xx
Run tested:  N/A

Description:
Hello @mhei 

Please consider this pull request. We're working in pull requst #6301 on upgrading mariadb in master from 10.1.x to 10.2.x, @cotequeiroz found that php7 does not compile against mariadb 10.2.x.

I have not run-tested this and as I don't anything about php I won't be able to. Maybe somebody else can do that.

Kind regards,
Seb