### PR TITLE
protobuf: Fixes missing bswap_{16,32,64} on little endian systems

### DIFF
--- a/libs/protobuf/patches/001-include-byteswap-on-musl.patch
+++ b/libs/protobuf/patches/001-include-byteswap-on-musl.patch
@@ -1,0 +1,22 @@
+Index: protobuf-3.5.1/src/google/protobuf/stubs/port.h
+===================================================================
+--- protobuf-3.5.1.orig/src/google/protobuf/stubs/port.h
++++ protobuf-3.5.1/src/google/protobuf/stubs/port.h
+@@ -93,7 +93,7 @@
+ #include <stdlib.h>  // NOLINT(build/include)
+ #elif defined(__APPLE__)
+ #include <libkern/OSByteOrder.h>
+-#elif defined(__GLIBC__) || defined(__CYGWIN__)
++#elif defined(__linux__) || defined(__CYGWIN__)
+ #include <byteswap.h>  // IWYU pragma: export
+ #endif
+ 
+@@ -366,7 +366,7 @@ inline void GOOGLE_UNALIGNED_STORE64(voi
+ #define bswap_32(x) OSSwapInt32(x)
+ #define bswap_64(x) OSSwapInt64(x)
+ 
+-#elif !defined(__GLIBC__) && !defined(__CYGWIN__)
++#elif !defined(__linux__) && !defined(__CYGWIN__)
+ 
+ static inline uint16 bswap_16(uint16 x) {
+   return static_cast<uint16>(((x & 0xFF) << 8) | ((x & 0xFF00) >> 8));


### PR DESCRIPTION
The existing logic doesn't #include <byteswap.h> on musl systems. It isn't used on
big endian systems, but on little endian it causes build errors for target
packages with protobuf as a dep.

Alpine Linux patches protobuf similarly:
https://git.alpinelinux.org/cgit/aports/tree/main/protobuf/musl-fix.patch

Signed-off-by: Shawn Nock <nock@nocko.se>

Maintainer: @kenkeys 
Compile tested: mipel, vocore2, 17.01.04
Run tested: mipel, vocore2, 17.01.04 (ran target package with protobuf dep)

