### PR TITLE
[openwrt-18.06] unbound: update to 1.7.3

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.7.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.7.3
+PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -17,7 +17,7 @@ PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@hotmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unbound.net/downloads
-PKG_HASH:=56e085ef582c5372a20207de179d0edb4e541e59f87be7d4ee1d00d12008628d
+PKG_HASH:=c11de115d928a6b48b2165e0214402a7a7da313cd479203a7ce7a8b62cba602d
 
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf
@@ -113,6 +113,8 @@ CONFIGURE_ARGS += \
 	--disable-dsa \
 	--disable-gost \
 	--enable-allsymbols \
+	--enable-tfo-client \
+	--enable-tfo-server \
 	--with-libexpat="$(STAGING_DIR)/usr" \
 	--with-ssl="$(STAGING_DIR)/usr" \
 	--with-pidfile=/var/run/unbound.pid \

--- a/net/unbound/patches/001-conf.patch
+++ b/net/unbound/patches/001-conf.patch
@@ -1,32 +1,19 @@
 diff --git a/doc/example.conf.in b/doc/example.conf.in
-index 5396029..cbb51ec 100644
+index be83bda..7317b23 100644
 --- a/doc/example.conf.in
 +++ b/doc/example.conf.in
-@@ -1,9 +1,10 @@
--#
--# Example configuration file.
--#
--# See unbound.conf(5) man page, version 1.7.1.
--#
--# this is a comment.
-+##############################################################################
-+# MEMORY CONTROL EXAMPLE
-+# In the example config settings below memory usage is reduced. Some ser-
-+# vice levels are lower, notable very large data and a high TCP load are
-+# no longer supported ... are exceptional for the DNS.
-+# (http://unbound.net/documentation/unbound.conf.html)
-+##############################################################################
-
- #Use this to include other text into the file.
- #include: "otherfile.conf"
-@@ -12,9 +13,71 @@
- server:
- 	# whitespace is not necessary, but looks cleaner.
-
--	# verbosity number, 0 is least verbose. 1 is default.
-+	# verbosity 1 is default
+@@ -15,6 +15,76 @@ server:
+ 	# verbosity number, 0 is least verbose. 1 is default.
  	verbosity: 1
 
++	############################################################################
++	# MEMORY CONTROL EXAMPLE
++	# In the example config settings below memory usage is reduced. Some ser-
++	# vice levels are lower, notable very large data and a high TCP load are
++	# no longer supported ... are exceptional for the DNS.
++	# (http://unbound.net/documentation/unbound.conf.html)
++	############################################################################
++
 +	# Self jail Unbound with user "unbound" to /var/lib/unbound
 +	# The script /etc/init.d/unbound will setup the location
 +	username: "unbound"
@@ -85,9 +72,9 @@ index 5396029..cbb51ec 100644
 +	# have power off clock (reboot), then you may need this work around.
 +	#domain-insecure: "pool.ntp.org"
 +
-+##############################################################################
-+# Resume Stock example.conf.in
-+##############################################################################
++	############################################################################
++	# Resume Stock example.conf.in
++	############################################################################
 +
  	# print statistics to the log (for every thread) every N seconds.
  	# Set to "" or 0 to disable. Default is disabled.


### PR DESCRIPTION
Maintainer: me
Tested: TL-Archer-C7v2 OpenWrt 18.06(by branch)
Description: Upstream 1.7.3 provides bug fixes on 1.7.1. Some intermediate fixes, 1.7.2, were resting on master for a cherry-pick, but are superseded.