### PR TITLE
bind: add package dependency on libatomic

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.11.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -54,7 +54,7 @@ endef
 define Package/bind-libs
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libopenssl +zlib
+  DEPENDS:=+libatomic +libopenssl +zlib
   TITLE:=bind shared libraries
   URL:=https://www.isc.org/software/bind
 ifdef CONFIG_BIND_LIBJSON


### PR DESCRIPTION
The latest version of bind-libs needs libatomic to be successfully compiled.
Fixes [FS#1594](https://bugs.openwrt.org/index.php?do=details&task_id=1594)

Maintainer: @nmeyerhans 
Compile tested: ramips, Newifi D1, OpenWrt trunk at commit 4b50854a60fce73aa83b50c445ea93970322d442
Run tested: ramips, Newifi D1, OpenWrt trunk at e4259bed3f20f8f132555ae8aef379e3d2ffb938