### PR TITLE
Unbound: Permit forward all queries to upstream resolvers.

### DIFF
--- a/net/unbound/files/unbound.sh
+++ b/net/unbound/files/unbound.sh
@@ -249,7 +249,7 @@ create_local_zone() {
     # New Zone! Bundle local-zones: by first two name tiers "abcd.tld."
     partial=$( echo "$target" | awk -F. '{ j=NF ; i=j-1; print $i"."$j }' )
     UNBOUND_LIST_DOMAINS="$UNBOUND_LIST_DOMAINS $partial"
-    echo "  local-zone: $partial. transparent" >> $UNBOUND_CONFFILE
+    echo "  local-zone: \"$partial.\" transparent" >> $UNBOUND_CONFFILE
   fi
 }
 
@@ -1070,9 +1070,9 @@ unbound_hostname() {
   if [ -n "$UNBOUND_TXT_DOMAIN" ] ; then
     {
       # Hostname as TLD works, but not transparent through recursion
-      echo "  domain-insecure: $UNBOUND_TXT_HOSTNAME"
-      echo "  private-domain: $UNBOUND_TXT_HOSTNAME"
-      echo "  local-zone: $UNBOUND_TXT_HOSTNAME. static"
+      echo "  domain-insecure: \"$UNBOUND_TXT_HOSTNAME\""
+      echo "  private-domain: \"$UNBOUND_TXT_HOSTNAME\""
+      echo "  local-zone: \"$UNBOUND_TXT_HOSTNAME.\" static"
       echo "  local-data: \"$UNBOUND_TXT_HOSTNAME. $UNBOUND_XSOA\""
       echo "  local-data: \"$UNBOUND_TXT_HOSTNAME. $UNBOUND_XNS\""
       echo
@@ -1090,8 +1090,8 @@ unbound_hostname() {
           if [ -n "$ifarpa" ] ; then
             {
               # Do NOT forward queries with your GLA ip6.arpa
-              echo "  domain-insecure: $ifarpa"
-              echo "  local-zone: $ifarpa. $UNBOUND_D_DOMAIN_TYPE"
+              echo "  domain-insecure: \"$ifarpa\""
+              echo "  local-zone: \"$ifarpa.\" $UNBOUND_D_DOMAIN_TYPE"
               echo "  local-data: \"$ifarpa. $UNBOUND_XSOA\""
               echo "  local-data: \"$ifarpa. $UNBOUND_XNS\""
               echo
@@ -1110,8 +1110,8 @@ unbound_hostname() {
           if [ -n "$ifarpa" ] ; then
             {
               # Do NOT forward queries with your ULA ip6.arpa or in-addr.arpa
-              echo "  domain-insecure: $ifarpa"
-              echo "  local-zone: $ifarpa. $UNBOUND_D_DOMAIN_TYPE"
+              echo "  domain-insecure: \"$ifarpa\""
+              echo "  local-zone: \"$ifarpa.\" $UNBOUND_D_DOMAIN_TYPE"
               echo "  local-data: \"$ifarpa. $UNBOUND_XSOA\""
               echo "  local-data: \"$ifarpa. $UNBOUND_XNS\""
               echo
@@ -1123,18 +1123,18 @@ unbound_hostname() {
 
       {
         # avoid upstream involvement in RFC6762
-        echo "  domain-insecure: local"
-        echo "  private-domain: local"
-        echo "  local-zone: local. $UNBOUND_D_DOMAIN_TYPE"
+        echo "  domain-insecure: \"local\""
+        echo "  private-domain: \"local\""
+        echo "  local-zone: \"local.\" $UNBOUND_D_DOMAIN_TYPE"
         echo "  local-data: \"local. $UNBOUND_XSOA\""
         echo "  local-data: \"local. $UNBOUND_XNS\""
         echo "  local-data: \"local. 3600 IN TXT RFC6762\""
         echo
         # type static means only this router has your domain
         # type transparent will permit forward-zone: or stub-zone: clauses
-        echo "  domain-insecure: $UNBOUND_TXT_DOMAIN"
-        echo "  private-domain: $UNBOUND_TXT_DOMAIN"
-        echo "  local-zone: $UNBOUND_TXT_DOMAIN. $UNBOUND_D_DOMAIN_TYPE"
+        echo "  domain-insecure: \"$UNBOUND_TXT_DOMAIN\""
+        echo "  private-domain: \"$UNBOUND_TXT_DOMAIN\""
+        echo "  local-zone: \"$UNBOUND_TXT_DOMAIN.\" $UNBOUND_D_DOMAIN_TYPE"
         echo "  local-data: \"$UNBOUND_TXT_DOMAIN. $UNBOUND_XSOA\""
         echo "  local-data: \"$UNBOUND_TXT_DOMAIN. $UNBOUND_XNS\""
         echo
@@ -1143,9 +1143,9 @@ unbound_hostname() {
 
     *)
       # likely transparent domain with fordward-zone: clause to next router
-      echo "  domain-insecure: $UNBOUND_TXT_DOMAIN"
-      echo "  private-domain: $UNBOUND_TXT_DOMAIN"
-      echo "  local-zone: $UNBOUND_TXT_DOMAIN. $UNBOUND_D_DOMAIN_TYPE"
+      echo "  domain-insecure: \"$UNBOUND_TXT_DOMAIN\""
+      echo "  private-domain: \"$UNBOUND_TXT_DOMAIN\""
+      echo "  local-zone: \"$UNBOUND_TXT_DOMAIN.\" $UNBOUND_D_DOMAIN_TYPE"
       echo
       ;;
     esac

--- a/net/unbound/files/unbound.sh
+++ b/net/unbound/files/unbound.sh
@@ -615,7 +615,7 @@ unbound_forward() {
       for fdomain in $UNBOUND_LIST_FORWARD ; do
         {
           echo "forward-zone:"
-          echo "  name: \"$fdomain.\""
+          echo "  name: \"$fdomain\""
           for fresolver in $resolvers ; do
           echo "  forward-addr: $fresolver"
           done


### PR DESCRIPTION
Maintainer: @EricLuehrsen
Compile tested: mvebu, Turris Omnia, 18.06-rc1
Run tested: mvebu, Turris Omnia, 18.06-rc1, visual check the generated configuration and checked the correct forwarding to upstream resolvers.

Description:
  - Permit forward all queries to upstream resolvers.
  - More consistency with quotation marks

Signed-off-by: Admin Localnet <localnet@users.noreply.github.com>