### PR TITLE
sane-backends: fix libusb dependency

### DIFF
--- a/utils/sane-backends/Makefile
+++ b/utils/sane-backends/Makefile
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2006-2016 OpenWrt.org
-# Copyright (C) 2017 Luiz Angelo Daros de Luca <luizluca@gmail.com>
+# Copyright (C) 2017-2018 Luiz Angelo Daros de Luca <luizluca@gmail.com>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sane-backends
 PKG_VERSION:=1.0.27
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://fossies.org/linux/misc \
     https://alioth.debian.org/frs/download.php/file/4146/
@@ -136,7 +136,7 @@ define Package/libsane
   $(call Package/sane-backends/Default)
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libusb-compat
+  DEPENDS:=+libusb-1.0
   TITLE+= (libraries)
 endef
 


### PR DESCRIPTION
libusb-compat was still required by package but sane was already
builing and linking libusb-1.0. It was working because libusb-compat
requires libusb-1.0.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: me
Compile tested: OpenWrt trunk x86 and ar71xx
Run tested: no binary changes

Description:
