### PR TITLE
[openwrt-18.06] prometheus-node-exporter-lua: adapt 0.16 metrics

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,8 +4,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2017.12.08
-PKG_RELEASE:=5
+PKG_VERSION:=2018.06.26
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Christian Simon <simon@swine.de>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/cpu.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/cpu.lua
@@ -3,18 +3,21 @@ local function scrape()
   local stat = get_contents("/proc/stat")
 
   -- system boot time, seconds since epoch
-  metric("node_boot_time", "gauge", nil, string.match(stat, "btime ([0-9]+)"))
+  metric("node_boot_time_seconds", "gauge", nil,
+    string.match(stat, "btime ([0-9]+)"))
 
   -- context switches since boot (all CPUs)
-  metric("node_context_switches", "counter", nil, string.match(stat, "ctxt ([0-9]+)"))
+  metric("node_context_switches_total", "counter", nil,
+    string.match(stat, "ctxt ([0-9]+)"))
 
   -- cpu times, per CPU, per mode
   local cpu_mode = {"user", "nice", "system", "idle", "iowait", "irq",
                     "softirq", "steal", "guest", "guest_nice"}
   local i = 0
-  local cpu_metric = metric("node_cpu", "counter")
+  local cpu_metric = metric("node_cpu_seconds_total", "counter")
   while true do
-    local cpu = {string.match(stat, "cpu"..i.." (%d+) (%d+) (%d+) (%d+) (%d+) (%d+) (%d+) (%d+) (%d+) (%d+)")}
+    local cpu = {string.match(stat,
+      "cpu"..i.." (%d+) (%d+) (%d+) (%d+) (%d+) (%d+) (%d+) (%d+) (%d+) (%d+)")}
     if #cpu ~= 10 then
       break
     end
@@ -25,16 +28,20 @@ local function scrape()
   end
 
   -- interrupts served
-  metric("node_intr", "counter", nil, string.match(stat, "intr ([0-9]+)"))
+  metric("node_intr_total", "counter", nil,
+    string.match(stat, "intr ([0-9]+)"))
 
   -- processes forked
-  metric("node_forks", "counter", nil, string.match(stat, "processes ([0-9]+)"))
+  metric("node_forks_total", "counter", nil,
+    string.match(stat, "processes ([0-9]+)"))
 
   -- processes running
-  metric("node_procs_running", "gauge", nil, string.match(stat, "procs_running ([0-9]+)"))
+  metric("node_procs_running_total", "gauge", nil,
+    string.match(stat, "procs_running ([0-9]+)"))
 
   -- processes blocked for I/O
-  metric("node_procs_blocked", "gauge", nil, string.match(stat, "procs_blocked ([0-9]+)"))
+  metric("node_procs_blocked_total", "gauge", nil,
+    string.match(stat, "procs_blocked ([0-9]+)"))
 end
 
 return { scrape = scrape }

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/meminfo.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/meminfo.lua
@@ -4,7 +4,8 @@ local function scrape()
     if unit == 'kB' then
       size = size * 1024
     end
-    metric("node_memory_" .. name:gsub("[):]", ""):gsub("[(]", "_"), "gauge", nil, size)
+    metric("node_memory_"..name:gsub("[):]", ""):gsub("[(]", "_").."_bytes",
+        "gauge", nil, size)
   end
 end
 

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netdev.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netdev.lua
@@ -1,9 +1,23 @@
 
-local netdevsubstat = {"receive_bytes", "receive_packets", "receive_errs",
-                   "receive_drop", "receive_fifo", "receive_frame", "receive_compressed",
-                   "receive_multicast", "transmit_bytes", "transmit_packets",
-                   "transmit_errs", "transmit_drop", "transmit_fifo", "transmit_colls",
-                   "transmit_carrier", "transmit_compressed"}
+local netdevsubstat = {
+    "receive_bytes_total",
+    "receive_packets_total",
+    "receive_errs_total",
+    "receive_drop_total",
+    "receive_fifo_total",
+    "receive_frame_total",
+    "receive_compressed_total",
+    "receive_multicast_total",
+    "transmit_bytes_total",
+    "transmit_packets_total",
+    "transmit_errs_total",
+    "transmit_drop_total",
+    "transmit_fifo_total",
+    "transmit_colls_total",
+    "transmit_carrier_total",
+    "transmit_compressed_total"
+}
+
 local pattern = "([^%s:]+):%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)%s+(%d+)"
 
 local function scrape()

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netstat.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netstat.lua
@@ -1,10 +1,20 @@
+local netsubstat = {
+    "IcmpMsg",
+    "Icmp",
+    "IpExt",
+    "Ip",
+    "TcpExt",
+    "Tcp",
+    "UdpLite",
+    "Udp"
+}
+
 local function scrape()
   -- NOTE: Both of these are missing in OpenWRT kernels.
   --       See: https://dev.openwrt.org/ticket/15781
   local netstat = get_contents("/proc/net/netstat") .. get_contents("/proc/net/snmp")
 
   -- all devices
-  local netsubstat = {"IcmpMsg", "Icmp", "IpExt", "Ip", "TcpExt", "Tcp", "UdpLite", "Udp"}
   for i, nss in ipairs(netsubstat) do
     local substat_s = string.match(netstat, nss .. ": ([A-Z][A-Za-z0-9 ]+)")
     if substat_s then

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/time.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/time.lua
@@ -1,6 +1,6 @@
 local function scrape()
   -- current time
-  metric("node_time", "counter", nil, os.time())
+  metric("node_time_seconds", "counter", nil, os.time())
 end
 
 return { scrape = scrape }

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi.lua
@@ -4,8 +4,8 @@ local iwinfo = require "iwinfo"
 local function scrape()
   local metric_wifi_network_quality = metric("wifi_network_quality","gauge")
   local metric_wifi_network_bitrate = metric("wifi_network_bitrate","gauge")
-  local metric_wifi_network_noise = metric("wifi_network_noise","gauge")
-  local metric_wifi_network_signal = metric("wifi_network_signal","gauge")
+  local metric_wifi_network_noise = metric("wifi_network_noise_dbm","gauge")
+  local metric_wifi_network_signal = metric("wifi_network_signal_dbm","gauge")
 
   local u = ubus.connect()
   local status = u:call("network.wireless", "status", {})

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
@@ -2,9 +2,9 @@ local ubus = require "ubus"
 local iwinfo = require "iwinfo"
 
 local function scrape()
-  local metric_wifi_station_signal = metric("wifi_station_signal","gauge")
-  local metric_wifi_station_tx_packets = metric("wifi_station_tx_packets","gauge")
-  local metric_wifi_station_rx_packets = metric("wifi_station_rx_packets","gauge")
+  local metric_wifi_station_signal = metric("wifi_station_signal_dbm","gauge")
+  local metric_wifi_station_tx_packets = metric("wifi_station_tx_packets_total","gauge")
+  local metric_wifi_station_rx_packets = metric("wifi_station_rx_packets_total","gauge")
 
   local u = ubus.connect()
   local status = u:call("network.wireless", "status", {})


### PR DESCRIPTION
Prometheus introduced some new conventions on how to name metrics.
Read here https://prometheus.io/docs/practices/naming/

This PR breaks compatibility with past versions, just like the officials
node exporter! 💥

Signed-off-by: Paul Spooren <mail@aparcar.org>