### PR TITLE
ffmpeg/libx264: Replacing YASM with NASM and fixing ffmpeg/x264 module dependency

### DIFF
--- a/libs/libx264/Makefile
+++ b/libs/libx264/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=x264
 PKG_VERSION:=snapshot-20180401-2245
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.videolan.org/x264/snapshots/
@@ -38,9 +38,9 @@ ifneq ($(CONFIG_SOFT_FLOAT)$(findstring $(call qstrip,$(CONFIG_CPU_TYPE)),$(CPU_
   CONFIGURE_ARGS += --disable-asm
 else
 ifneq ($(CONFIG_TARGET_x86),)
-ifeq ($(CONFIG_YASM),y)
-  CONFIGURE_VARS+= AS=yasm
-  MAKE_FLAGS+= AS=yasm
+ifeq ($(CONFIG_NASM),y)
+  CONFIGURE_VARS+= AS=nasm
+  MAKE_FLAGS+= AS=nasm
 else
   CONFIGURE_VARS+= AS= 
   MAKE_FLAGS+= AS= 

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=3.2.10
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
@@ -442,9 +442,12 @@ ifeq ($(ARCH),x86_64)
 	FFMPEG_CONFIGURE+= --enable-lto
 endif
 
-ifneq ($(CONFIG_YASM),y)
-FFMPEG_CONFIGURE+= --disable-yasm
-
+ifneq ($(CONFIG_TARGET_x86),)
+ifeq ($(CONFIG_NASM),y)
+  FFMPEG_CONFIGURE += --yasmexe=nasm
+else
+  FFMPEG_CONFIGURE += --disable-yasm
+endif
 endif
 
 ifeq ($(BUILD_VARIANT),full)
@@ -477,7 +480,7 @@ ifeq ($(BUILD_VARIANT),full)
 	FFMPEG_CONFIGURE+= $(if $(CONFIG_PACKAGE_lame-lib),--enable-libmp3lame)
 	# x264 support and fdk-aac support can't coexist and be distributed.
 	# Prioritize x264 over fdk-aac in default builds (maintain status-quo).
-	ifeq ($(CONFIG_PACKAGE_libx264),y)
+	ifneq ($(CONFIG_PACKAGE_libx264),)
 		FFMPEG_CONFIGURE+= \
 			--enable-gpl \
 			--enable-libx264
@@ -555,7 +558,7 @@ ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libshine),y)
 	--enable-libshine --enable-encoder=libshine
 endif
 
-ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libx264),y)
+ifneq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libx264),)
   FFMPEG_CONFIGURE+= \
 	--enable-libx264 --enable-encoder=libx264
 endif
@@ -640,7 +643,7 @@ define Build/InstallDev/full
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/lib{avcodec,avdevice,avfilter,avformat,avresample,avutil,swresample,swscale} $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avdevice,avfilter,avformat,avresample,avutil,swresample,swscale}.{a,so*} $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/lib{avcodec,avdevice,avfilter,avformat,avresample,avutil,swresample,swscale}.pc $(1)/usr/lib/pkgconfig/
-ifeq ($(CONFIG_PACKAGE_libx264),y)
+ifneq ($(CONFIG_PACKAGE_libx264),)
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libpostproc $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpostproc.{a,so*} $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpostproc.pc $(1)/usr/lib/pkgconfig/
@@ -706,7 +709,7 @@ endef
 define Package/libffmpeg-full/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avdevice,avfilter,avformat,avresample,avutil,swresample,swscale}.so.* $(1)/usr/lib/
-ifeq ($(CONFIG_PACKAGE_libx264),y)
+ifneq ($(CONFIG_PACKAGE_libx264),)
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpostproc.so.* $(1)/usr/lib/
 endif
 endef


### PR DESCRIPTION

Maintainer: @thess / @ianchi 
Compile tested: ARM, MIPS, X86
Run tested: N/A

**NOTE: Do not merge until toolchain updated**

Description:

Both libraries on X86 platforms require NASM instead of YASM going forward. Currently libx264 is not building on X86 platforms due to this requirement. ffmpeg 3.x can be buillt with either YASM or NASM however, 4.x will require NASM.

This patch also fixes a problem with ffmpeg when libx264 is built as a **M**odule as it is with the buildbots.

Signed-off-by: Ted Hess <thess@kitschensync.net>
