### PR TITLE
perl-text-csv_xs: update to 1.36

### DIFF
--- a/lang/perl-text-csv_xs/Makefile
+++ b/lang/perl-text-csv_xs/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-text-csv_xs
-PKG_VERSION:=1.35
+PKG_VERSION:=1.36
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=http://www.cpan.org/authors/id/H/HM/HMBRAND/
+PKG_SOURCE_URL:=https://www.cpan.org/authors/id/H/HM/HMBRAND/
 PKG_SOURCE:=Text-CSV_XS-$(PKG_VERSION).tgz
-PKG_HASH:=2b4f111e9486b230b02bfabbbf50c453f959d18ec17351a930e41f0959b358b7
+PKG_HASH:=c321b09ad98a332138f25f55afb83befd7c045134085c7cb280fc325e688942c
 
 PKG_LICENSE:=GPL-1.0+ Artistic-1.0-Perl
 PKG_MAINTAINER:=Philip Prindeville <philipp@redfish-solutions.com>


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, generic, HEAD (34e2265)
Run tested: same

build and installed on running system.  reran xt_geoip_dl and xt_geoip_build scripts (the latter makes use of Text::CSV::XS to rebuild the file-based database).

Description: