### PR TITLE
geth: add a new package

### DIFF
--- a/net/geth/Makefile
+++ b/net/geth/Makefile
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2018 Sartura Ltd.
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_LICENSE:=ASL-2.0
+PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
+
+PKG_NAME:=go-ethereum
+PKG_VERSION:=1.8.11
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/ethereum/go-ethereum/tar.gz/v${PKG_VERSION}?
+PKG_HASH:=ad18cc1d3154499ade6c712eab4b005d9dc0abf61282cfb349900d30dfba019a
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/ethereum/go-ethereum
+GO_PKG_BUILD_PKG:=github.com/ethereum/go-ethereum/cmd/geth
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/geth
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Ethereum Go client
+  URL:=https://geth.ethereum.org/
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+  PKGARCH:=all
+endef
+
+define Package/geth/description
+Ethereum is a decentralized platform that runs smart contracts, applications
+that run exactly as programmed without possibility of downtime, censorship,
+fraud or third party interference.
+endef
+
+define Package/geth/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/geth.init $(1)/etc/init.d/geth
+endef
+
+$(eval $(call GoBinPackage,geth))
+$(eval $(call BuildPackage,geth))

--- a/net/geth/files/geth.init
+++ b/net/geth/files/geth.init
@@ -1,0 +1,15 @@
+#!/bin/sh /etc/rc.common
+
+START=90
+STOP=10
+
+USE_PROCD=1
+PROG=/usr/bin/geth
+
+start_service() {
+    procd_open_instance
+    procd_set_param command ${PROG}
+    procd_append_param command --syncmode "light" --cache 1024
+    procd_set_param respawn
+    procd_close_instance
+}


### PR DESCRIPTION
The package was tested on raspberry pi 3. Geth needs about two hours to
fully sync the first try and uses an additional 250Mb of storage.

Signed-off-by: Mislav Novakovic <mislav.novakovic@sartura.hr>

Maintainer: @mislavn
Compile tested: arm, Raspberry pi 3, OpenWrt master branch
Run tested: arm, Raspberry pi 3, OpenWrt master branch

Description:
Golang OpenWrt package for: https://github.com/ethereum/go-ethereum