### PR TITLE
netifyd: Added initial package files.

### DIFF
--- a/net/netifyd/Makefile
+++ b/net/netifyd/Makefile
@@ -1,0 +1,101 @@
+#
+# Copyright (C) 2016-2019 eGloo, Incorporated
+#
+# This is free software, licensed under the GNU General Public License v2.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=netifyd
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Darryl Sokoloski <darryl@egloo.ca>
+PKG_LICENSE:=GPL-3.0+
+
+PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://gitlab.com/netify.ai/public/netify-agent.git
+PKG_SOURCE_DATE:=2019-01-03
+PKG_SOURCE_VERSION:=v2.87
+#PKG_SOURCE_VERSION:=e846598bbe26eb6d631f1eda922c7141245f48e3
+PKG_MIRROR_HASH:=05af5b4e48ccfccf60cfb3c0b08c8bb3987d8957f17723520da4488798a7b68d
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/netifyd
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Netify Agent
+  URL:=http://www.netify.ai/
+  DEPENDS:=+libcurl +libmnl +libnetfilter-conntrack +libjson-c +libpcap +zlib +libpthread
+  # Explicitly depend on libstdcpp rather than $(CXX_DEPENDS).  At the moment
+  # std::unordered_map is only available via libstdcpp which is required for
+  # performance reasons.
+  DEPENDS+=+libstdcpp
+endef
+
+define Package/netifyd/description
+The Netify Agent is a deep-packet inspection server which detects network
+protocols and applications.  These detections can be saved locally, served over
+a UNIX or TCP socket, and/or "pushed" (via HTTP POSTs) to a remote third-party
+server.  Flow metadata, network statistics, and detection classifications are
+JSON encoded for easy consumption by third-party applications.
+endef
+
+define Package/netifyd/conffiles
+/etc/netifyd.conf
+endef
+
+TARGET_CFLAGS+=-ffunction-sections -fdata-sections
+TARGET_CXXFLAGS+=-ffunction-sections -fdata-sections
+TARGET_LDFLAGS+=-Wl,--gc-sections
+
+CONFIGURE_ARGS+= \
+	--sharedstatedir=/var/run \
+	--enable-lean-and-mean \
+	--disable-ncurses \
+	--disable-libtcmalloc \
+	--without-systemdsystemunitdir \
+	--without-tmpfilesdir
+
+# Disable configuration file-watch support (deprecated feature).
+# Not to be confused with kernel/system-level inotify support.
+CONFIGURE_ARGS+= \
+	--disable-inotify
+
+ifneq ($(CONFIG_LIBCURL_ZLIB),y)
+CONFIGURE_ARGS+= \
+	--without-libcurl-zlib
+endif
+
+define Build/Configure
+	(cd $(PKG_BUILD_DIR); ./autogen.sh)
+	$(call Build/Configure/Default,$(CONFIGURE_ARGS))
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/netifyd
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/netifyd/*.h $(1)/usr/include/netifyd
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetifyd.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libnetifyd.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/netifyd/install
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/deploy/netifyd.conf $(1)/etc
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/netifyd.init $(1)/etc/init.d/netifyd
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/netifyd $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetifyd.so.* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/etc/netify.d
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/deploy/netify-sink.conf $(1)/etc/netify.d/netify-sink.conf
+	$(INSTALL_DIR) $(1)/usr/share/netifyd
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/deploy/functions.sh $(1)/usr/share/netifyd
+endef
+
+$(eval $(call BuildPackage,netifyd))

--- a/net/netifyd/README.md
+++ b/net/netifyd/README.md
@@ -1,0 +1,72 @@
+Netify Agent
+============
+Copyright ©2015-2018 eGloo Incorporated ([www.egloo.ca](https://www.egloo.ca))
+
+Deep-Packet Inspection Server
+-----------------------------
+
+The [Netify Agent](https://www.netify.ai/) is a deep-packet inspection server.  The Agent is built on top of [nDPI](http://www.ntop.org/products/deep-packet-inspection/ndpi/) (formerly OpenDPI) to detect network protocols and applications.  These detections can be saved locally, served over a UNIX or TCP socket, and/or "pushed" (via HTTP POSTs) to a remote third-party server.  Flow metadata, network statistics, and detection classifications are stored using JSON encoding.
+
+Optionally, the Netify Agent can be coupled with a [Netify Cloud](https://www.netify.ai/) subscription for further cloud processing, historical storage, machine-learning analysis, event notifications, device detection/identification, along with the option (on supported platforms) to take an active role in policing/bandwidth-shaping specific network protocols and applications.
+
+Runtime Requirements
+--------------------
+
+Ensure that the nfnetlink and nf_conntrack_netlink kernel modules are loaded.
+
+Build Requirements
+------------------
+
+Netify requires the following third-party packages:
+- libcurl
+- libjson-c
+- libmnl
+- libnetfilter-conntrack
+- libpcap
+- zlib
+
+Optional:
+- libtcmalloc (gperftools)
+
+Download Source
+---------------
+
+When cloning the source tree, ensure you use `--recursive` to include all
+sub-modules.
+
+Download Packages
+-----------------
+
+Currently you can download binary packages for the following OS distributions:
+- [ClearOS](https://www.clearos.com/products/purchase/clearos-marketplace-apps#cloud)
+- [CentOS](http://software.opensuse.org/download.html?project=home%3Aegloo&package=netifyd)
+- [Debian](http://software.opensuse.org/download.html?project=home%3Aegloo&package=netifyd)
+- [Fedora](http://software.opensuse.org/download.html?project=home%3Aegloo&package=netifyd)
+- [Ubuntu](http://software.opensuse.org/download.html?project=home%3Aegloo&package=netifyd)
+
+Configuring/Building From Source
+--------------------------------
+
+Read the appropriate documentation in the doc directory, prefixed with: BUILD-*
+
+Generally the process is:
+```
+# ./autogen.sh
+# ./configure
+# make
+```
+
+License
+-------
+```
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+```
+

--- a/net/netifyd/files/netifyd.init
+++ b/net/netifyd/files/netifyd.init
@@ -1,0 +1,28 @@
+#!/bin/sh /etc/rc.common
+#
+# Copyright (C) 2016-2019 eGloo, Incorporated
+#
+# This is free software, licensed under the GNU General Public License v2.
+
+START=50
+STOP=50
+
+USE_PROCD=1
+PROG=/usr/sbin/netifyd
+NETIFYD_AUTODETECT=yes
+
+start_service() {
+    mkdir -p /etc/netify.d
+    mkdir -p /var/run/netifyd
+
+    source /usr/share/netifyd/functions.sh
+    NETIFYD_OPTS=$(auto_detect_options)
+
+    load_modules
+
+    procd_open_instance
+    procd_set_param command $PROG -R $NETIFYD_OPTS
+    procd_set_param file /etc/netifyd.conf
+    procd_set_param respawn
+    procd_close_instance
+}


### PR DESCRIPTION
Maintainer: Darryl Sokoloski / @dsokoloski
Compile tested: ar71xx (mips) / ipq806x (arm), TP-Link Archer C2600, HEAD
Run tested: ipq806x (arm), TP-Link Archer C2600, HEAD, tests: install, start, stop, reload, restart, provision, traffic capture, JSON push (upload POST)

Description:
The [Netify](https://www.netify.ai/) Agent is a deep-packet inspection server.  The Agent is built on top of [nDPI](http://www.ntop.org/products/deep-packet-inspection/ndpi/) (formerly OpenDPI) to detect network protocols and applications.  These detections can be saved locally, served over a UNIX or TCP socket, and/or "pushed" (via HTTP POSTs) to a remote third-party server.  Flow metadata, network statistics, and detection classifications are stored using JSON encoding.

Optionally, the Netify Agent can be coupled with a [Netify Cloud](https://www.netify.ai/) subscription for further cloud processing, historical storage, machine-learning analysis, event notifications, device detection/identification, along with the option (on supported platforms) to take an active role in policing/bandwidth-shaping specific network protocols and applications.

Signed-off-by: Darryl Sokoloski <darryl@sokoloski.ca>