### PR TITLE
rsync: Add IPv6 functionality

### DIFF
--- a/net/rsync/Makefile
+++ b/net/rsync/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsync
 PKG_VERSION:=3.1.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.samba.org/pub/rsync/src
@@ -58,6 +58,12 @@ ifeq ($(CONFIG_RSYNC_zlib),y)
 	CONFIGURE_ARGS+= --with-included-zlib=no
 else
 	CONFIGURE_ARGS+= --with-included-zlib=yes
+endif
+
+ifeq ($(CONFIG_IPV6),y)
+    TARGET_CFLAGS+= -DINET6
+else
+    CONFIGURE_ARGS+= --disable-ipv6
 endif
 
 define Package/rsyncd


### PR DESCRIPTION
Maintainer: @mstorchak
Compile tested: ramips, Xiaomi MiWiFi Mini, OpenWrt master
Run tested: ramips, Xiaomi MiWiFi Mini, OpenWrt master, verified by running "rsync --version"

Description:
Configure fails to detect IPv6 support on musl systems. As a result, the standard package lacks ipv6 support (rsync --version shows no-IPV6). This commit applies Alpine Linux's [fix](https://git.alpinelinux.org/cgit/aports/commit/?id=2883d8bada0d04fb59f363e8a3c9a581f978aab3) by forcing IPV6 support on.

This is only done when the global IPV6 flag is enabled, otherwise support will be disabled explicitly by the standard rsync configure flag.

Signed-off-by: Simon Tretter simon@mediaarchitectu.re