### PR TITLE
libfmt: bump to new release 5.1.0

### DIFF
--- a/libs/libfmt/Makefile
+++ b/libs/libfmt/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libfmt
-PKG_VERSION:=5.0.0
+PKG_VERSION:=5.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

Maintainer: me
Compile tested: mpc85xx, tl-wdr4900-v1, trunk
Compile tested: ar71xx, wndr3700, trunk

Description:
new upstream release
