### PR TITLE
mariadb: fix uclibc builds

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
 PKG_VERSION:=10.2.16
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := \
@@ -36,6 +36,7 @@ CMAKE_INSTALL:=1
 PLUGIN_DIR:=/usr/lib/mysql/plugin
 
 MARIADB_COMMON_DEPENDS := \
+	+USE_UCLIBC:libiconv-full \
 	+libatomic \
 	+libopenssl \
 	+libstdcpp \
@@ -384,6 +385,13 @@ CMAKE_OPTIONS += \
 	-DPLUGIN_AUTH_GSSAPI_CLIENT=NO \
 	-DPLUGIN_CRACKLIB_PASSWORD_CHECK=NO
 
+# musl and glibc include their own iconv, but uclibc does not
+ifneq ($(CONFIG_USE_UCLIBC),)
+CMAKE_OPTIONS += \
+	-DICONV_INCLUDE_DIR=$(STAGING_DIR)/usr/lib/libiconv-full/include \
+	-DICONV_LIBRARIES=$(STAGING_DIR)/usr/lib/libiconv-full/lib/libiconv.so
+endif
+
 CMAKE_OPTIONS += \
 	$(foreach p,$(MARIADB_SERVER_PLUGINS),-D$(plugin-$(p))=$(if $(CONFIG_PACKAGE_$(PKG_NAME)-server-plugin-$(subst _,-,$(p))),DYNAMIC,NO))
 
@@ -424,6 +432,20 @@ define Host/Install
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/scripts/comp_sql $(1)/share/mariadb/scripts
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/sql/{gen_lex_hash,gen_lex_token} $(1)/share/mariadb/sql
 	$(INSTALL_DATA) $(HOST_BUILD_DIR)/import_executables.cmake $(1)/share/mariadb
+endef
+
+# LIBICONV_PLUG is used in GNU's libiconv for redefinition of exports [e.g.
+# from libiconv_open() to iconv_open()]. But in OpenWrt this variable is not set
+# when building libiconv-full. So when mariadb sets LIBICONV_PLUG it expects
+# iconv_open() to be available for example, which is not the case - only
+# libiconv_open() is. To address this do not set the variable when building
+# against libiconv-full.
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+ifneq ($(CONFIG_USE_UCLIBC),)
+	$(SED) '/ADD_DEFINITIONS(-DLIBICONV_PLUG)/d' $(PKG_BUILD_DIR)/libmariadb/libmariadb/CMakeLists.txt
+endif
 endef
 
 define Build/InstallDev

--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -174,6 +174,10 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk
 
+# Pass CPPFLAGS in the CFLAGS as otherwise the build system will
+# ignore them.
+TARGET_CFLAGS+=$(TARGET_CPPFLAGS)
+
 define Package/mariadb/install/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$(2) $(1)/usr/bin
 endef


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, archs
Run tested: ar71xx (I do not own archs hardware)

Description:
Fix current uclibc build failures.

Hello @hnyman and @jow- 

Can you please merge this for me?

Thanks!
Seb