### PR TITLE
libzdb: fix uclibc build issue

### DIFF
--- a/libs/libzdb/Makefile
+++ b/libs/libzdb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libzdb
 PKG_VERSION:=3.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_LICENSE:=GPL-3.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -22,6 +22,14 @@ PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=libzdb/host
 
 include $(INCLUDE_DIR)/package.mk
+
+# Help libzdb find libiconv.so when using uClibc.
+ifneq ($(CONFIG_USE_UCLIBC),)
+TARGET_CPPFLAGS+= \
+	-I$(STAGING_DIR)/usr/lib/libiconv-full/include
+TARGET_LDFLAGS += \
+	-L$(STAGING_DIR)/usr/lib/libiconv-full/lib
+endif
 
 define Package/libzdb
     SECTION:=libs

--- a/libs/libzdb/patches/010-cross-compile-fixes.patch
+++ b/libs/libzdb/patches/010-cross-compile-fixes.patch
@@ -40,7 +40,7 @@ diff -rupN libzdb-3.1.orig/configure.ac libzdb-3.1/configure.ac
 -                DBCPPFLAGS="$DBCPPFLAGS `$MYSQLCONFIG --include`"
 -                DBLDFLAGS="$DBLDFLAGS `$MYSQLCONFIG --libs`"
 +                DBCPPFLAGS="$DBCPPFLAGS -I$STAGING_DIR/usr/include/mysql"
-+                DBLDFLAGS="$DBLDFLAGS -L$STAGING_DIR/usr/lib/mysql -L$STAGING_DIR/usr/lib -lmysqlclient -lz -lcrypt -lm"
++                DBLDFLAGS="$DBLDFLAGS -L$STAGING_DIR/usr/lib/mysql -L$STAGING_DIR/usr/lib -lmysqlclient -liconv -lz -lcrypt -lm"
                  AC_DEFINE([HAVE_LIBMYSQLCLIENT], 1, [Define to 1 to enable mysql])
          else
                  CPPFLAGS=$svd_CPPFLAGS


### PR DESCRIPTION
libmariadb 10.2 needs to be linked in together with iconv. On musl and
glibc iconv is part of libc. That's not the case for uclibc, where
libiconv-full needs to be used. This commit adds -liconv to the linker
flags and aids libzdb in finding libiconv.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @kissg1988 
Compile tested: archs
Run tested: I do not own archs hardware nor do I use libzdb myself, sorry

Description:
Hi Gergely,

I'm following up on the fallout of the mariadb upgrade. This is one of the packages that is also affected.

Kind regards,
Seb