### PR TITLE
collectd: fix uclibc build issue

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.8.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \
@@ -184,6 +184,8 @@ PKG_CONFIG_DEPENDS:= \
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/kernel.mk
+# collectd-mod-mysql needs iconv
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/collectd/Default
   SECTION:=utils


### PR DESCRIPTION
libmariadb 10.2 needs to be linked in together with iconv. On musl and
glibc iconv is part of libc. That's not the case for uclibc, where
libiconv-full needs to be used. This commit aids collect-mod-mysql in
finding libiconv.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @jow- and @hnyman 
Compile tested: archs
Run tested: I don't have archs hardware nor do I use this package myself, sorry,

Description:
Hello Jo and Hannu,

I'm checking for fallout from the mariadb 10.2 upgrade. This is one of the affected packages (and my attempt to fix it).

Kind regards,
Seb