### PR TITLE
dovecot: fix uclibc build issue

### DIFF
--- a/mail/dovecot/Makefile
+++ b/mail/dovecot/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot
 PKG_VERSION:=2.3.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.dovecot.org/releases/2.3
@@ -31,11 +31,14 @@ PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
+# iconv is needed when compiling with MySQL support. iconv will also be used by
+# dovecot itself.
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/dovecot
   SECTION:=mail
   CATEGORY:=Mail
-  DEPENDS:=+DOVECOT_GSSAPI:krb5-libs +DOVECOT_LDAP:libopenldap +DOVECOT_MYSQL:libmysqlclient +DOVECOT_PGSQL:libpq +DOVECOT_SQLITE:libsqlite3 +libopenssl +librt +zlib +libbz2 +libcap +DOVECOT_ICU:icu
+  DEPENDS:=+DOVECOT_GSSAPI:krb5-libs +DOVECOT_LDAP:libopenldap +DOVECOT_MYSQL:libmysqlclient +DOVECOT_PGSQL:libpq +DOVECOT_SQLITE:libsqlite3 +libopenssl +librt +zlib +libbz2 +libcap +DOVECOT_ICU:icu $(ICONV_DEPENDS)
   TITLE:=An IMAP and POP3 daemon
   URL:=https://www.dovecot.org/
   USERID:=dovecot=59:dovecot=59


### PR DESCRIPTION
libmariadb 10.2 needs to be linked in together with iconv. On musl and
glibc iconv is part of libc. That's not the case for uclibc, where
libiconv-full needs to be used.

But dovecot will use libiconv (if it can find it) also for its own
character conversion needs. As this is a mail program it makes sense to
add a general depend on libiconv-full when using uclibc. As a side
effect this fixes the libmariadb issue.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @lucize 
Compile tested: archs
Run tested: I don't own archs hardware, nor do I use this package myself, sorry

Description:
Hello Lucien,

I'm cleaning up after the fallout of the libmariadb 10.2.x upgrade. This is one of the affected packages.

What sets dovecot apart from the other packages I fixed (or proposed a fix for) is that dovecot will use libiconv-full itself when it detects it. I think for a mail program that makes sense, so I added a depend on libiconv-full when compiling against uclibc.

Kind regards,
Seb 