### PR TITLE
gst1-plugins-bad: update to 1.14.1

### DIFF
--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-bad
-PKG_VERSION:=1.12.4
+PKG_VERSION:=1.14.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
@@ -20,7 +20,7 @@ PKG_LICENSE_FILES:=COPYING.LIB COPYING
 PKG_BUILD_DIR:=$(BUILD_DIR)/gst-plugins-bad-$(PKG_VERSION)
 PKG_SOURCE:=gst-plugins-bad-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-plugins-bad/
-PKG_HASH:=0c7857be16686d5c1ba6e34bd338664d3d4599d32714a8eca5c8a41a101e2d08
+PKG_HASH:=2a77c6908032aafdf2cd2e5823fec948f16a25c2d1497a953828d762dc20d61a
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -200,7 +200,6 @@ $(eval $(call GstBuildLibrary,adaptivedemux,adaptivedemux,app uridownloader,))
 $(eval $(call GstBuildLibrary,photography,photography,,))
 $(eval $(call GstBuildLibrary,basecamerabinsrc,basecamerabinsrc,app,))
 $(eval $(call GstBuildLibrary,uridownloader,uridownloader,,))
-$(eval $(call GstBuildLibrary,badbase,badbase,,))
 
 # 1: short name
 # 2: description
@@ -257,7 +256,7 @@ $(eval $(call GstBuildPlugin,mpegpsdemux,mpegpsdemux support,pbutils,,))
 $(eval $(call GstBuildPlugin,mpegpsmux,mpegpsmux support,,,))
 #$(eval $(call GstBuildPlugin,mpegtsdemux,mpegtsdemux support,mpegts pbutils,,))
 #$(eval $(call GstBuildPlugin,mpegtsmux,mpegtsmux support,video,,))
-$(eval $(call GstBuildPlugin,mxf,mxf support,badbase audio video,,))
+$(eval $(call GstBuildPlugin,mxf,mxf support,audio video,,))
 $(eval $(call GstBuildPlugin,opusparse,OPUS streams library,pbutils,,+libopus))
 $(eval $(call GstBuildPlugin,pcapparse,pcapparse support,,,))
 $(eval $(call GstBuildPlugin,pnm,pnm support,video,,))

--- a/multimedia/gst1-plugins-bad/patches/002-no-tests.patch
+++ b/multimedia/gst1-plugins-bad/patches/002-no-tests.patch
@@ -1,7 +1,7 @@
-diff -u --recursive gst-plugins-bad-1.12.4-vanilla/configure.ac gst-plugins-bad-1.12.4/configure.ac
---- gst-plugins-bad-1.12.4-vanilla/configure.ac	2018-02-11 19:46:16.942758605 -0500
-+++ gst-plugins-bad-1.12.4/configure.ac	2018-02-11 19:46:38.356808019 -0500
-@@ -3619,38 +3619,6 @@
+diff -u --recursive gst-plugins-bad-1.14.1-vanilla/configure.ac gst-plugins-bad-1.14.1/configure.ac
+--- gst-plugins-bad-1.14.1-vanilla/configure.ac	2018-07-08 22:17:07.553492088 -0400
++++ gst-plugins-bad-1.14.1/configure.ac	2018-07-08 22:17:38.866597074 -0400
+@@ -2600,24 +2600,6 @@
  sys/wasapi/Makefile
  sys/winks/Makefile
  sys/winscreencap/Makefile
@@ -12,37 +12,23 @@ diff -u --recursive gst-plugins-bad-1.12.4-vanilla/configure.ac gst-plugins-bad-
 -tests/examples/avsamplesink/Makefile
 -tests/examples/camerabin2/Makefile
 -tests/examples/codecparsers/Makefile
+-tests/examples/compositor/Makefile
 -tests/examples/directfb/Makefile
 -tests/examples/audiomixmatrix/Makefile
--tests/examples/gl/Makefile
--tests/examples/gl/cocoa/Makefile
--tests/examples/gl/clutter/Makefile
--tests/examples/gl/generic/Makefile
--tests/examples/gl/generic/cube/Makefile
--tests/examples/gl/generic/cubeyuv/Makefile
--tests/examples/gl/generic/doublecube/Makefile
--tests/examples/gl/generic/recordgraphic/Makefile
--tests/examples/gl/gtk/Makefile
--tests/examples/gl/gtk/3dvideo/Makefile
--tests/examples/gl/gtk/filternovideooverlay/Makefile
--tests/examples/gl/gtk/filtervideooverlay/Makefile
--tests/examples/gl/gtk/fxtest/Makefile
--tests/examples/gl/gtk/switchvideooverlay/Makefile
--tests/examples/gl/qt/Makefile
--tests/examples/gl/sdl/Makefile
--tests/examples/gtk/Makefile
+-tests/examples/ipcpipeline/Makefile
 -tests/examples/mpegts/Makefile
 -tests/examples/mxf/Makefile
 -tests/examples/opencv/Makefile
 -tests/examples/uvch264/Makefile
 -tests/examples/waylandsink/Makefile
+-tests/examples/webrtc/Makefile
 -tests/icles/Makefile
  ext/voamrwbenc/Makefile
  ext/voaacenc/Makefile
  ext/assrender/Makefile
-diff -u --recursive gst-plugins-bad-1.12.4-vanilla/Makefile.am gst-plugins-bad-1.12.4/Makefile.am
---- gst-plugins-bad-1.12.4-vanilla/Makefile.am	2018-02-11 19:46:16.980758692 -0500
-+++ gst-plugins-bad-1.12.4/Makefile.am	2018-02-11 19:46:49.443833603 -0500
+diff -u --recursive gst-plugins-bad-1.14.1-vanilla/Makefile.am gst-plugins-bad-1.14.1/Makefile.am
+--- gst-plugins-bad-1.14.1-vanilla/Makefile.am	2018-07-08 22:17:07.553492088 -0400
++++ gst-plugins-bad-1.14.1/Makefile.am	2018-07-08 22:17:51.278638694 -0400
 @@ -2,11 +2,11 @@
  
  SUBDIRS = \
@@ -55,5 +41,5 @@ diff -u --recursive gst-plugins-bad-1.12.4-vanilla/Makefile.am gst-plugins-bad-1
 -	m4 common docs tests tools
 +	m4 common docs tools
  
- # include before EXTRA_DIST for win32 assignment
- include $(top_srcdir)/common/win32.mak
+ EXTRA_DIST = \
+ 	depcomp \


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86, x86_64, master 4fdc6ca3

Description:
gst1-plugins-bad: update to 1.14.1