### PR TITLE
travis: fail on bad hash message

### DIFF
--- a/.travis_do.sh
+++ b/.travis_do.sh
@@ -136,7 +136,10 @@ EOF
 		echo_blue "=== $pkg_name: Starting quick tests"
 
 		exec_status '^ERROR' make "package/$pkg_name/download" V=s || RET=1
-		exec_status '^ERROR' make "package/$pkg_name/check" V=s || RET=1
+		badhash_msg_regex="HASH does not match "
+		badhash_msg_regex="$badhash_msg_regex|HASH uses deprecated hash,"
+		badhash_msg_regex="$badhash_msg_regex|HASH is missing,"
+		exec_status '^ERROR'"|$badhash_msg_regex" make "package/$pkg_name/check" V=s || RET=1
 
 		echo_blue "=== $pkg_name: quick tests done"
 	done


### PR DESCRIPTION
Maintainer: n/a
Compile tested: n/a
Run tested: n/a

Description:

Check and fail on hash mismatch, missing, deprecated

To address issues revealed in pull request #6379, #6395