### PR TITLE
canutils: Update to 2018.02.0

### DIFF
--- a/utils/canutils/Makefile
+++ b/utils/canutils/Makefile
@@ -8,18 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=canutils
-PKG_RELEASE=1
+PKG_VERSION:=2018.02.0
+PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/linux-can/can-utils
-PKG_SOURCE_DATE:=2017-02-16
-PKG_SOURCE_VERSION:=cb33a55720716cbe01e6025a2bda74a1b7e492d3
-PKG_MIRROR_HASH:=d9c01eeff3d81a28161ca5c3937ec005a1f49ca3eb97bee0164d53cc66365786
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/linux-can/can-utils/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=370ad4b19447c29099f7300548f1a3362d6e123c4a6a827dbbd3110bc2c26839
+PKG_BUILD_DIR:=can-utils-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Anton Glukhov <anton.a.glukhov@gmail.com>
 PKG_LICENSE:=GPL-2.0+
 
 PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Switched to codeload for speed and reliability.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @toxxin 
Compile tested: ipq806x