### PR TITLE
lxc: fix -O3 compilation with gcc 7.3

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=2.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=LGPL-2.1+ BSD-2-Clause GPL-2.0
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>

--- a/utils/lxc/patches/011-compile.patch
+++ b/utils/lxc/patches/011-compile.patch
@@ -1,0 +1,12 @@
+--- a/src/lxc/nl.c	2017-10-19 10:08:34.000000000 -0700
++++ b/src/lxc/nl.c	2018-07-11 09:05:30.881733183 -0700
+@@ -61,7 +61,8 @@
+ 	rta = NLMSG_TAIL(nlmsg->nlmsghdr);
+ 	rta->rta_type = attr;
+ 	rta->rta_len = rtalen;
+-	memcpy(RTA_DATA(rta), data, len);
++	if (len)
++		memcpy(RTA_DATA(rta), data, len);
+ 	nlmsg->nlmsghdr->nlmsg_len = tlen;
+ 	return 0;
+ }


### PR DESCRIPTION
Signed-off-by: Daniel Gimpelevich <daniel@gimpelevich.san-francisco.ca.us>

Maintainer: @ratkaj
Compile tested: x86/64, 18.06 branch
Run tested: not yet
Description:
Upstream relies on undefined libc behavior, which gcc 5.5 happily accepted even with -O3 when buffer overflow detection was enabled, but with the move to gcc 7.3, this is now an error. This patch should ideally be upstreamed.

Requesting merge into both 18.06 and master. This may be an issue that @rmilecki previously encountered with lxc, and similar issues exist in other packages, e.g. https://github.com/openwrt/packages/issues/6004