### PR TITLE
transmission: Allow user to configure web ui home directory

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=2.94
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master

--- a/net/transmission/files/transmission.config
+++ b/net/transmission/files/transmission.config
@@ -6,6 +6,7 @@ config transmission
 	option group 'transmission'
 	option mem_percentage 50
 	option nice 10
+	option web_home ''
 	option alt_speed_down 50
 	option alt_speed_enabled false
 	option alt_speed_time_begin  540

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -52,6 +52,7 @@ transmission() {
 	local mem_percentage
 	local nice
 	local cmdline
+	local web_home
 
 	section_enabled "$section" || return 1
 
@@ -62,6 +63,7 @@ transmission() {
 	config_get mem_percentage "$cfg" 'mem_percentage' '50'
 	config_get config_overwrite "$cfg" config_overwrite 1
 	config_get nice "$cfg" nice 0
+	config_get web_home "$cfg" 'web_home'
 
 	local MEM=$(sed -ne 's!^MemTotal:[[:space:]]*\([0-9]*\) kB$!\1!p' /proc/meminfo)
 	if test "$MEM" -gt 1;then
@@ -121,6 +123,10 @@ transmission() {
 	else
 		procd_set_param limits core="0 0" as="$USE $USE"
 		logger -t transmission "Starting with $USE virt mem"
+	fi
+
+	if test -d "$web_home"; then
+		procd_set_param env TRANSMISSION_WEB_HOME="$web_home"
 	fi
 
 	procd_add_jail transmission log


### PR DESCRIPTION
User can set uci param `web_home` to custom web ui path. If `web_home` option was provided pass to procd env `TRANSMISSION_WEB_HOME`

Maintainer: Rosen Penev <rosenp@gmail.com>
Compile tested: (mvebu, OpenWrt 17.01.4)
Run tested: (mvebu, OpenWrt 17.01.4, tests done)

Signed-off-by: Andrii Korzh <andrii.korzh@gmail.com>