### PR TITLE
python3: fix missing dependency for libuuid in python3-light

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -80,7 +80,7 @@ endef
 define Package/python3-light
 $(call Package/python3/Default)
   TITLE:=Python $(PYTHON_VERSION) light installation
-  DEPENDS:=+python3-base +libffi +libbz2 +PYTHON3_BLUETOOTH_SUPPORT:bluez-libs
+  DEPENDS:=+python3-base +libffi +libbz2 +PYTHON3_BLUETOOTH_SUPPORT:bluez-libs +libuuid
 endef
 
 define Package/python3-light/config


### PR DESCRIPTION
Signed-off-by: Karol Wrona <wrona.vy@gmail.com>

Maintainer: no change
Compile tested: ARM/BeagleBone, master
Run tested: ARM/BB, master

Description:
master build was broken