### PR TITLE
nginx: fix bug in uci-defaults scripts

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.15.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://nginx.org/download/

--- a/net/nginx/files-luci-support/60_nginx-luci-support
+++ b/net/nginx/files-luci-support/60_nginx-luci-support
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -f "/etc/nginx/luci_nginx.conf" ] && [ -f "/etc/nginx/nginx.conf" ]; then
-	if [ ! "$(cat '/etc/nginx/nginx.conf' | grep -q 'luci_uwsgi.conf')" ]; then
+	if [ ! "$(cat '/etc/nginx/nginx.conf' | grep 'luci_uwsgi.conf')" ]; then
 		mv /etc/nginx/nginx.conf /etc/nginx/nginx.conf_old
 		mv /etc/nginx/luci_nginx.conf /etc/nginx/nginx.conf
 		core_number=$(grep -c ^processor /proc/cpuinfo)
@@ -20,6 +20,8 @@ if [ -f "/etc/nginx/luci_nginx.conf" ] && [ -f "/etc/nginx/nginx.conf" ]; then
 		else
 			/etc/init.d/uwsgi start
 		fi
+	else
+		rm /etc/nginx/luci_nginx.conf
 	fi
 fi
 

--- a/net/nginx/files-luci-support/70_nginx-luci-support-ssl
+++ b/net/nginx/files-luci-support/70_nginx-luci-support-ssl
@@ -2,7 +2,7 @@
 
 
 if [ -f "/etc/nginx/luci_nginx_ssl.conf" ] && [ -f "/etc/nginx/nginx.conf" ]; then
-	if [ ! "$(cat '/etc/nginx/nginx.conf' | grep -q 'return 301 https://$host$request_uri;')" ]; then
+	if [ ! "$(cat '/etc/nginx/nginx.conf' | grep 'return 301 https://$host$request_uri;')" ]; then
 		if [ -f "/etc/nginx/nginx.conf_old" ]; then
 			rm /etc/nginx/nginx.conf
 		else
@@ -16,6 +16,8 @@ if [ -f "/etc/nginx/luci_nginx_ssl.conf" ] && [ -f "/etc/nginx/nginx.conf" ]; th
 		else
 			/etc/init.d/nginx start
 		fi
+	else
+		rm /etc/nginx/luci_nginx_ssl.conf
 	fi
 fi
 


### PR DESCRIPTION
Currently the uci-defaults scripts reset nginx config even it they are valid due to a bug in the if condition.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>

@hnyman 