### PR TITLE
libzdb: remove iconv hack, include nls.mk

### DIFF
--- a/libs/libzdb/Makefile
+++ b/libs/libzdb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libzdb
 PKG_VERSION:=3.1
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_LICENSE:=GPL-3.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -22,14 +22,8 @@ PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=libzdb/host
 
 include $(INCLUDE_DIR)/package.mk
-
-# Help libzdb find libiconv.so when using uClibc.
-ifneq ($(CONFIG_USE_UCLIBC),)
-TARGET_CPPFLAGS+= \
-	-I$(STAGING_DIR)/usr/lib/libiconv-full/include
-TARGET_LDFLAGS += \
-	-L$(STAGING_DIR)/usr/lib/libiconv-full/lib
-endif
+# libzdb needs to find iconv when linking to libmariadb
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/libzdb
     SECTION:=libs


### PR DESCRIPTION
mariadb was sorted out by including nls.mk. Include it also in libzdb
and get rid of the previously introduced hack.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @kissg1988 
Compile tested: archs
Run tested: N/A

Description:

Hello Gergely,

Turned out my previous commit was wrong. Sorry for that! This removes the hack and adds the proper fix.

Kind regards,
Seb
