### PR TITLE
utils/fio: Update to 3.7

### DIFF
--- a/utils/fio/Makefile
+++ b/utils/fio/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fio
-PKG_VERSION:=3.6
+PKG_VERSION:=3.7
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Dragan Stancevic <ds@codeminutia.com>
 PKG_LICENSE:=GPL-2.0+
@@ -16,7 +16,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE_URL:=http://brick.kernel.dk/snaps
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=026a2cbb4a1bc9810f13f23d07eb146dbd4325bb467221dc49b88915ee8a52b4
+PKG_HASH:=73aba1b307f084ba5ec3ac3084233e3a0ef297a2991e904ab391cc95f07f003c
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Maintainer: @drastx
Compile tested: ramips, WiTi Board, OpenWrt master
Run tested: ramips, WiTi Board, OpenWrt master

Description:
Update fio to 3.7

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>