### PR TITLE
nginx: make virtual package provide nginx

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -97,6 +97,7 @@ define Package/nginx-ssl
   TITLE += with SSL support
   DEPENDS +=+libopenssl
   VARIANT:=ssl
+  PROVIDES:=nginx
 endef
 
 Package/nginx-ssl/description = $(Package/nginx/description) \
@@ -108,6 +109,7 @@ define Package/nginx-all-module
   TITLE += with ALL module selected
   DEPENDS:=+libpcre +libopenssl +zlib +liblua +libpthread
   VARIANT:=all-module
+  PROVIDES:=nginx
 endef
 
 Package/nginx-all-module/description = $(Package/nginx/description) \


### PR DESCRIPTION
Some package needs nginx as dependency this permit to use nginx-ssl and nginx-all-module as dep for them.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>