### PR TITLE
ap51-flash: Update to 2018.0 and switch to tarball

### DIFF
--- a/utils/ap51-flash/Makefile
+++ b/utils/ap51-flash/Makefile
@@ -7,15 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ap51-flash
-PKG_VERSION:=2017-12-07
+PKG_VERSION:=2018.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/ap51-flash/ap51-flash.git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=f94f9c99711d14a3c0186318d822d67d9d0ce391
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
-PKG_MIRROR_HASH:=15786a0ecae9be5ed4e8f32940624d1a1c83da924294df08003616a863947074
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/ap51-flash/ap51-flash/releases/download/v$(PKG_VERSION)
+PKG_HASH:=e38e48a12d7c7b8e189f5538b78bbf00548044414d9ededa18ec9a5b5886afaa
 PKG_MAINTAINER:=Russell Senior <russell@personaltelco.net>
 PKG_LICENSE:=GPL-3.0+
 PKG_LICENSE_FILES:=LICENSES/preferred/GPL-3.0
@@ -26,7 +23,7 @@ define Package/ap51-flash
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=A tool for flashing (nearly) all ap51/ap61 based routers
-  URL:=http://dev.cloudtrax.com/wiki/ap51-flash-station
+  URL:=https://ap51-flash.readthedocs.io/en/latest/
 endef
 
 # pass optimization flags


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ecsv 
Compile tested: ipq806x