### PR TITLE
slide-switch: update to latest version

### DIFF
--- a/utils/slide-switch/Makefile
+++ b/utils/slide-switch/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016, 2018 OpenWrt.org
+# Copyright (C) 2016, 2018 Jeffery To
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=slide-switch
-PKG_VERSION:=0.9.1
+PKG_VERSION:=0.9.2
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/jefferyto/openwrt-slide-switch.git
-PKG_SOURCE_VERSION:=d70b5a09f457050e7e3b45fe03787945aa8880a0
+PKG_SOURCE_VERSION:=234293255f919cc00dc799f4729401e91b5091c9
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
-PKG_MIRROR_HASH:=78227e0cdc36f105b4fc5657620e41d6bb429eeef76419ce2cd53d2b6700ce31
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(call version_abbrev,$(PKG_SOURCE_VERSION)).tar.xz
+PKG_MIRROR_HASH:=ca405699c826428a13b174d5ec70c8b60fdde6467184b1fa0a09df3643bf24d3
 
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx / ramips (mt76x8), sdk snapshot (2018-07-16)
Run tested: none

Description:
slide-switch: update to latest version

This also changes PKG_SOURCE to use .tar.xz, and changes the copyright line. (I believe this is more accurate, as I haven't done a copyright assignment.)

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
