### PR TITLE
uwsgi-cgi: set socket to 666 permission

### DIFF
--- a/net/uwsgi-cgi/Makefile
+++ b/net/uwsgi-cgi/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uwsgi-cgi
 PKG_VERSION:=2.0.17.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL=https://codeload.github.com/unbit/uwsgi/tar.gz/$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/uwsgi-cgi/files-luci-support/uwsgi.conf
+++ b/net/uwsgi-cgi/files-luci-support/uwsgi.conf
@@ -24,3 +24,4 @@ pidfile		= /var/run/uwsgi.pid
 die-on-term	= true
 threads		= 3
 processes	= 3
+chmod-socket	= 666


### PR DESCRIPTION
Currently the socket file for uwsgi can be open only from root user, change this to permit other use to use it. (Needed for nginx to use uwsgi as nobody or dedicated user)

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>