### PR TITLE
nginx: change default user for luci conf

### DIFF
--- a/net/nginx/files-luci-support/luci_nginx.conf
+++ b/net/nginx/files-luci-support/luci_nginx.conf
@@ -1,5 +1,5 @@
 
-user  root;
+user nobody nogroup;
 worker_processes  1;
 
 #error_log  logs/error.log;


### PR DESCRIPTION
Currently the nginx user for the default luci config is root... This is dangerous and unnecessary, reset it back to nobody nogroup.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
