### PR TITLE
uwsgi-cgi: fix compilation on Darwin system

### DIFF
--- a/net/uwsgi-cgi/Makefile
+++ b/net/uwsgi-cgi/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uwsgi-cgi
 PKG_VERSION:=2.0.17.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL=https://codeload.github.com/unbit/uwsgi/tar.gz/$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/uwsgi-cgi/patches/004-hard-code-Linux-as-compilation-os.patch
+++ b/net/uwsgi-cgi/patches/004-hard-code-Linux-as-compilation-os.patch
@@ -1,0 +1,15 @@
+--- a/uwsgiconfig.py
++++ b/uwsgiconfig.py
+@@ -5,9 +5,9 @@
+ import os
+ import re
+ import time
+-uwsgi_os = os.uname()[0]
+-uwsgi_os_k = re.split('[-+_]', os.uname()[2])[0]
+-uwsgi_os_v = os.uname()[3]
++uwsgi_os = "Linux"
++uwsgi_os_k = "4.4.0"
++uwsgi_os_v = "Linux"
+ uwsgi_cpu = os.uname()[4]
+ 
+ import sys


### PR DESCRIPTION
Currently the uwsgiconfig python script append some additional compilation flag based on the host system. This fix some problem related with this by hardcoding usgi_os variable to Linux

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>