### PR TITLE
dovecot-pigeonhole: fix compilation with full language support

### DIFF
--- a/mail/pigeonhole/Makefile
+++ b/mail/pigeonhole/Makefile
@@ -11,7 +11,7 @@ PKG_NAME:=dovecot-pigeonhole
 PKG_VERSION_PLUGIN:=0.5.2
 PKG_VERSION_DOVECOT:=$(shell make --no-print-directory -C ../dovecot/ val.PKG_VERSION V=s)
 PKG_VERSION:=$(PKG_VERSION_DOVECOT)-$(PKG_VERSION_PLUGIN)
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 DOVECOT_VERSION:=2.3
 
@@ -25,6 +25,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/dovecot-$(DOVECOT_VERSION)-pigeonhole-$(PKG_VERSION_
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/dovecot-pigeonhole
   SECTION:=mail


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: arm_cortex-a9, Buffalo WXR-1900DHP, OpenWrt SNAPSHOT r7530-7c306ae
Run tested: arm_cortex-a9, Buffalo WXR-1900DHP, OpenWrt SNAPSHOT r7274-56f3aee

Description:

Fixes #6526. If the full language support is enabled (CONFIG_BUILD_NLS=y), compilation fails on undefined references to libiconv, libiconv_open and libiconv_closed. Including nls.mk into the package's Makefile fixes the problem.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>