### PR TITLE
subversion: bump to the latest stable bugfix release

### DIFF
--- a/net/subversion/Makefile
+++ b/net/subversion/Makefile
@@ -9,16 +9,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=subversion
 PKG_RELEASE:=1
-PKG_VERSION:=1.10.0
+PKG_VERSION:=1.10.2
 PKG_SOURCE_URL:=@APACHE/subversion
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=2cf23f3abb837dea0585a6b0ebd70e80e01f95bddef7c1aa097c18e3eaa6b584
+PKG_HASH:=5b35e3a858d948de9e8892bf494893c9f7886782f6abbe166c0487c19cf6ed88
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Val Kulkov <val.kulkov@gmail.com>
 
 PKG_FIXUP:=autoreconf
 PKG_MACRO_PATHS:=build/ac-macros
+PKG_BUILD_DEPENDS:=apr-util
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: arm_cortex-a9, Buffalo WXR-1900DHP, OpenWrt SNAPSHOT r7530-7c306ae
Run tested: arm_cortex-a9, Buffalo WXR-1900DHP, OpenWrt SNAPSHOT r7274-56f3aee

Description:
A straightforward update to the latest stable bugfix release.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>