### PR TITLE
privoxy: fix uci configuration parsing after upstream OpenWrt changes

### DIFF
--- a/net/privoxy/Makefile
+++ b/net/privoxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=privoxy
 PKG_VERSION:=3.0.26
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=privoxy-$(PKG_VERSION)-stable-src.tar.gz
 PKG_SOURCE_URL:=@SF/ijbswa

--- a/net/privoxy/files/privoxy.init
+++ b/net/privoxy/files/privoxy.init
@@ -40,6 +40,11 @@ _uci2conf() {
 						;;
 				esac
 			}
+
+			list_cb()
+			{
+				option_cb "$@"
+			}
 		fi
 	}
 


### PR DESCRIPTION
OpenWrt changed the way the uci shell parsing functions deal with list
configuration items.

This change broke the generation of the privoxy runtime configuration
because no callbacks were emitted anymore.

Fix the problem by defining a list_cb() that simply calls the existing
option_cb() to deal with list item values.

Ref: c9c0fc28a9 ("base-files: fix UCI config parsing and callback handling")
Ref: https://forum.lede-project.org/t/openwrt-snapshot-privoxy-error/15919
Signed-off-by: Jo-Philipp Wich <jo@mein.io>
