### PR TITLE
adblock: 3.5.4

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.5.3
+PKG_VERSION:=3.5.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -32,9 +32,11 @@ start_service()
                 return 0
             fi
         fi
+        local nice="$(uci_get adblock extra adb_nice)"
         procd_open_instance "adblock"
         procd_set_param command "${adb_script}" "${@}"
         procd_set_param pidfile "${adb_pidfile}"
+        procd_set_param nice ${nice:-0}
         procd_set_param stdout 1
         procd_set_param stderr 1
         procd_close_instance

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-adb_ver="3.5.3"
+adb_ver="3.5.4"
 adb_sysver="unknown"
 adb_enabled=0
 adb_debug=0
@@ -263,7 +263,7 @@ f_envcheck()
     f_log "info" "start adblock processing (${adb_action})"
 }
 
-# create temporay files and directories
+# create temporary files and directories
 #
 f_temp()
 {
@@ -279,7 +279,7 @@ f_temp()
     fi
 }
 
-# remove temporay files and directories
+# remove temporary files and directories
 #
 f_rmtemp()
 {
@@ -402,8 +402,8 @@ f_extconf()
 		set firewall.adblock_dns.name="Adblock DNS"
 		set firewall.adblock_dns.src="lan"
 		set firewall.adblock_dns.proto="tcp udp"
-		set firewall.adblock_dns.src_dport="53"
-		set firewall.adblock_dns.dest_port="53"
+		set firewall.adblock_dns.src_dport="53 853 5353"
+		set firewall.adblock_dns.dest_port="53 853 5353"
 		set firewall.adblock_dns.target="DNAT"
 	EOF
     elif [ -n "$(uci -q get firewall.adblock_dns)" ] && ([ ${adb_enabled} -eq 0 ] || [ ${adb_forcedns} -eq 0 ])


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: OpenWrt SNAPSHOT, r7478+48-16035a7dd3

Description:
backend:
* add low priority mode (nice level 10), disabled by default
* enhance 'Force DNS' to redirect ports 53, 853 and 5353

frontend:
* switch to dynamic XHR polling for runtime information and logfile
viewing
* add new 'Refresh' button to reload blocklists
* various cleanups & small fixes

Signed-off-by: Dirk Brenken <dev@brenken.org>
