### PR TITLE
Fire culex bonnie++

### DIFF
--- a/utils/bonnie++/Makefile
+++ b/utils/bonnie++/Makefile
@@ -8,17 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bonnie++
-PKG_VERSION:=1.97
+PKG_VERSION:=1.97.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=http://www.coker.com.au/bonnie++/experimental/
-PKG_HASH:=44f5a05937648a6526ba99354555d7d15f2dd392e55d3436f6746da6f6c35982
+PKG_HASH:=e27b386ae0dc054fa7b530aab6bdead7aea6337a864d1f982bc9ebacb320746e 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=copyright.txt
 PKG_MAINTAINER:=Florian Fainelli <florian@openwrt.org>
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION).1
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/utils/bonnie++/patches/001-cross_compile_fix.patch
+++ b/utils/bonnie++/patches/001-cross_compile_fix.patch
@@ -1,7 +1,7 @@
-Index: bonnie++-1.97.1/configure
+Index: bonnie++-1.97.3/configure
 ===================================================================
---- bonnie++-1.97.1.orig/configure
-+++ bonnie++-1.97.1/configure
+--- bonnie++-1.97.3.orig/configure
++++ bonnie++-1.97.3/configure
 @@ -3955,9 +3955,7 @@ rm -f core conftest.err conftest.$ac_obj
  
  if test "$cross_compiling" = yes; then :
@@ -15,8 +15,8 @@ Index: bonnie++-1.97.1/configure
  /* end confdefs.h.  */
 Index: bonnie++-1.97.1/Makefile
 ===================================================================
---- bonnie++-1.97.1.orig/Makefile
-+++ bonnie++-1.97.1/Makefile
+--- bonnie++-1.97.3.orig/Makefile
++++ bonnie++-1.97.3/Makefile
 @@ -1,5 +1,7 @@
  EXES=bonnie++ zcav getc_putc getc_putc_helper
  EXE=bon_csv2html generate_randfile


### PR DESCRIPTION
per https://bugs.openwrt.org/index.php?do=details&task_id=1436 updated to latest bonnie works that works with GCC 7.

Signed-off-by: Matthew M. Dean fireculex@gmail.com
