### PR TITLE
acl: Switch to tarballs

### DIFF
--- a/utils/acl/Makefile
+++ b/utils/acl/Makefile
@@ -8,16 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acl
-PKG_REV:=c39f7c5475e3e00d8abeb7b30e61958670fb3ee2
-PKG_VERSION:=20180121
+PKG_VERSION:=2.2.53
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MIRROR_HASH:=0291d931bbac041f14bc12d317e505cd596e0ec6f1b8bcdfa03b9a1fad274ac2
-PKG_SOURCE_URL:=https://git.savannah.gnu.org/git/acl.git
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=$(PKG_REV)
+PKG_SOURCE_URL:=https://git.savannah.nongnu.org/cgit/acl.git/snapshot
+PKG_HASH:=9e905397ac10d06768c63edd0579c34b8431555f2ea8e8f2cee337b31f856805
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 
 PKG_LICENSE:=LGPL-2.1 GPL-2.0
@@ -30,7 +26,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/acl/Default
   TITLE:=Access control list (ACL) manipulation
-  URL:=http://savannah.nongnu.org/projects/acl
+  URL:=https://savannah.nongnu.org/projects/acl
   SUBMENU:=Filesystem
 endef
 


### PR DESCRIPTION
Should be faster. Also fixes uscan.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mstorchak 
Compile tested: ipq806x