### PR TITLE
geth: update to 1.8.12

### DIFF
--- a/net/geth/Makefile
+++ b/net/geth/Makefile
@@ -11,12 +11,12 @@ PKG_LICENSE:=ASL-2.0
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 
 PKG_NAME:=go-ethereum
-PKG_VERSION:=1.8.11
+PKG_VERSION:=1.8.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ethereum/go-ethereum/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=ad18cc1d3154499ade6c712eab4b005d9dc0abf61282cfb349900d30dfba019a
+PKG_HASH:=53cfd6ff2f82f7a42fa5175e2a795aada4425a22353e5d46008cd566bfb5e239
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Signed-off-by: Mislav Novakovic mislav.novakovic@sartura.hr

Maintainer: @mislavn
Compile tested: arm, Raspberry pi 3, OpenWrt master branch
Run tested: arm, Raspberry pi 3, OpenWrt master branch

Description:
Package update to version 1.8.12 (https://github.com/ethereum/go-ethereum/releases/tag/v1.8.12).