### PR TITLE
mtr: Fix compile with libcap

### DIFF
--- a/net/mtr/Makefile
+++ b/net/mtr/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mtr
 PKG_VERSION:=0.92
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Jonathan McCrohan <jmccrohan@gmail.com>
 
@@ -32,7 +32,7 @@ define Package/mtr
   CATEGORY:=Network
   DEPENDS:=+libncurses
   TITLE:=Full screen ncurses traceroute tool
-  URL:=http://www.bitwizard.nl/mtr/
+  URL:=https://www.bitwizard.nl/mtr/
 endef
 
 define Package/mtr/description
@@ -48,25 +48,17 @@ endef
 
 CONFIGURE_ARGS += \
 	--without-gtk \
-	--without-glib \
 	$(call autoconf_bool,CONFIG_IPV6,ipv6)
 
 define Build/Configure
-	(cd $(PKG_BUILD_DIR); touch \
-		configure.in \
-		aclocal.m4 \
-		Makefile.in \
-		img/Makefile.in \
-		stamp-h.in \
-		config.h.in \
-		configure \
-	);
+	echo $(PKG_VERSION) > .tarball-version
 	$(call Build/Configure/Default)
 endef
 
 define Package/mtr/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/mtr $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/mtr-packet $(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,mtr))

--- a/net/mtr/patches/010-remove-libcap-support.patch
+++ b/net/mtr/patches/010-remove-libcap-support.patch
@@ -1,0 +1,15 @@
+diff --git a/configure.ac b/configure.ac
+index a08ce67..83bf094 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -106,10 +106,6 @@ AS_IF([test "x$with_ncurses" = "xyes"],
+ ])
+ AM_CONDITIONAL([WITH_CURSES], [test "x$with_ncurses" = xyes])
+ 
+-AC_CHECK_LIB([cap], [cap_set_proc], [],
+-  AS_IF([test "$host_os" = linux-gnu],
+-    AC_MSG_WARN([Capabilities support is strongly recommended for increased security.  See SECURITY for more information.])))
+-
+ # Enable ipinfo
+ AC_ARG_WITH([ipinfo],
+   [AS_HELP_STRING([--without-ipinfo], [Do not try to use ipinfo lookup at all])],

--- a/net/mtr/patches/020-Sami-Kerola-prevent-MTR-reporting-unknown-revision.patch
+++ b/net/mtr/patches/020-Sami-Kerola-prevent-MTR-reporting-unknown-revision.patch
@@ -1,0 +1,24 @@
+From 94218682b15832fd6f8ed09a767941974075a1b4 Mon Sep 17 00:00:00 2001
+From: "R.E. Wolff" <R.E.Wolff@BitWizard.nl>
+Date: Tue, 7 Nov 2017 17:24:14 +0100
+Subject: [PATCH] Sami Kerola: prevent MTR reporting unknown revision
+
+---
+ Makefile.am | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/Makefile.am b/Makefile.am
+index c0709ca..23ac1fc 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -156,3 +156,7 @@ endif  # if CYGWIN
+ if BUILD_BASH_COMPLETION
+ dist_bashcompletion_DATA = bash-completion/mtr
+ endif
++
++dist-hook:
++	$(AM_V_GEN)echo $(VERSION) > $(distdir)/.tarball-version
++
+-- 
+2.17.1
+


### PR DESCRIPTION
Selecting libcap in addition to mtr causes it to error with

Package mtr is missing dependencies for the following libraries:
libcap.so.2

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jmccrohan 
Compile tested: ar71xx
