### PR TITLE
avrdude: add zlib dependency

### DIFF
--- a/utils/avrdude/Makefile
+++ b/utils/avrdude/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avrdude
 PKG_VERSION:=6.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SAVANNAH/$(PKG_NAME)
@@ -31,7 +31,7 @@ define Package/avrdude
   SUBMENU:=Microcontroller programming
   TITLE:=AVR Downloader/UploaDEr
   URL:=http://www.nongnu.org/avrdude/
-  DEPENDS:=+libncurses +libreadline +libusb-compat +libftdi1 +libelf1
+  DEPENDS:=+libncurses +libreadline +libusb-compat +libftdi1 +libelf1 +zlib
 endef
 
 define Package/avrdude/description
@@ -45,6 +45,9 @@ CONFIGURE_ARGS+= \
 
 TARGET_CFLAGS+= \
 	-D_GNU_SOURCE \
+
+TARGET_LDFLAGS+= \
+	-lz \
 
 define Package/avrdude/conffiles
 /etc/avrdude.conf


### PR DESCRIPTION
Maintainer: @thess
Compile tested: ar71xx, trunk r7540-20c4819 
Run tested: NONE

Description:
zlib dependency is required due to libelf1 (elfutils) was updated.

https://downloads.openwrt.org/snapshots/faillogs/mips_24kc/packages/avrdude/compile.txt
```
/var/lib/buildbot/slaves/slave-lede-builds4/mips_24kc/build/sdk/staging_dir/target-mips_24kc_musl/usr/lib/libelf.a(elf_compress.o): In function `__libelf_compress':
elf_compress.c:(.text+0x134): undefined reference to `deflateInit_'
elf_compress.c:(.text+0x194): undefined reference to `deflateEnd'
elf_compress.c:(.text+0x23c): undefined reference to `deflate'
elf_compress.c:(.text+0x298): undefined reference to `deflateEnd'
elf_compress.c:(.text+0x2f0): undefined reference to `deflateEnd'
elf_compress.c:(.text+0x334): undefined reference to `deflateEnd'
/var/lib/buildbot/slaves/slave-lede-builds4/mips_24kc/build/sdk/staging_dir/target-mips_24kc_musl/usr/lib/libelf.a(elf_compress.o): In function `__libelf_decompress':
elf_compress.c:(.text+0x404): undefined reference to `inflateInit_'
elf_compress.c:(.text+0x440): undefined reference to `inflate'
elf_compress.c:(.text+0x450): undefined reference to `inflateReset'
elf_compress.c:(.text+0x468): undefined reference to `inflateEnd'
collect2: error: ld returned 1 exit status
```

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
