### PR TITLE
wget: Disable libpsl to fix builds on buildbots

### DIFF
--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.19.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -67,7 +67,8 @@ CONFIGURE_ARGS+= \
 	--disable-rpath \
 	--disable-iri \
 	--with-included-libunistring \
-	--without-libuuid
+	--without-libuuid \
+	--without-libpsl
 
 CONFIGURE_VARS += \
 	ac_cv_header_uuid_uuid_h=no


### PR DESCRIPTION
Maintainer: @tripolar 
Run tested: Not needed

Description:
Disable libpsl to fix dependency issue on buildbots

```
...
Package wget is missing dependencies for the following libraries:
libpsl.so.5
```
http://downloads.lede-project.org/snapshots/faillogs/arm_cortex-a9_neon/packages/wget/ssl/compile.txt

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>

