### PR TITLE
zabbix: Add SSL support for zabbix-agentd. Fixes #5675

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=3.4.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=cdee0fd44e11ae214b2cc252974da22f3627c326ea2c61a0315af95165c52d1b
@@ -22,8 +22,31 @@ PKG_INSTALL:=1
 
 PKG_FIXUP:=autoreconf
 
+PKG_CONFIG_DEPENDS:= \
+  CONFIG_ZABBIX_GNUTLS \
+  CONFIG_ZABBIX_OPENSSL
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
+
+define Package/zabbix-agentd/config
+comment "SSL support"
+
+choice
+        prompt "Selected SSL library"
+        default ZABBIX_NOSSL
+
+        config ZABBIX_OPENSSL
+                bool "OpenSSL"
+
+        config ZABBIX_GNUTLS
+                bool "GNUTLS"
+
+        config ZABBIX_NOSSL
+                bool "No SSL support"
+
+endchoice
+endef
 
 define Package/zabbix/Default
   SECTION:=admin
@@ -33,7 +56,7 @@ define Package/zabbix/Default
   SUBMENU:=zabbix
   MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
   USERID:=zabbix=53:zabbix=53
-  DEPENDS += $(ICONV_DEPENDS) +libpcre
+  DEPENDS += $(ICONV_DEPENDS) +libpcre +ZABBIX_GNUTLS:libgnutls +ZABBIX_OPENSSL:libopenssl
 endef
 
 define Package/zabbix-agentd
@@ -107,7 +130,9 @@ CONFIGURE_ARGS+= \
 	--disable-java \
 	--with-postgresql \
 	--with-libevent=$(STAGING_DIR)/usr/include/libevent \
-	--with-libpcre=$(STAGING_DIR)/usr/include
+	--with-libpcre=$(STAGING_DIR)/usr/include \
+	$(if $(CONFIG_ZABBIX_GNUTLS),--with-gnutls="$(STAGING_DIR)/usr") \
+	$(if $(CONFIG_ZABBIX_OPENSSL),--with-openssl="$(STAGING_DIR)/usr")
 
 MAKE_FLAGS += ARCH="linux"
 


### PR DESCRIPTION
Signed-off-by: Oskari Lemmela oskari@lemmela.net

Maintainer: @champtar
Compile tested: ar71xx
Run tested: ar71xx

Description:
Adds possibility to compile zabbix-agentd with SSL support