### PR TITLE
libmpdclient: Update to 2.14. Use autotools

### DIFF
--- a/libs/libmpdclient/Makefile
+++ b/libs/libmpdclient/Makefile
@@ -6,18 +6,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmpdclient
-PKG_VERSION:=2.11
+PKG_VERSION:=2.14
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=15fe693893c0d7ea3f4c35c4016fbd0332836164178b20983eec9b470846baf6
-PKG_SOURCE_URL:=http://www.musicpd.org/download/libmpdclient/2/
-PGK_HASH:=15fe693893c0d7ea3f4c35c4016fbd0332836164178b20983eec9b470846baf6
+PKG_HASH:=0a84e2791bfe3077cf22ee1784c805d5bb550803dffe56a39aa3690a38061372
+PKG_SOURCE_URL:=https://www.musicpd.org/download/libmpdclient/2/
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -33,12 +33,13 @@ define Package/libmpdclient/description
     A stable, documented, asynchronous API library for interfacing MPD in the C, C++ & Objective C languages.
 endef
 
-TARGET_CFLAGS+="-std=gnu99"
+CONFIGURE_ARGS+= --disable-documentation
 
-define Build/Configure
-	$(call Build/Configure/Default, \
-		--disable-documentation \
-	)
+# Newer sources require meson/ninja to build so...
+# Use our hacked-up version of the libmpdclient v2.11 autotools.
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(CP) ./autotools-files/* $(PKG_BUILD_DIR)/
 endef
 
 define Build/InstallDev

--- a/libs/libmpdclient/autotools-files/Makefile.am
+++ b/libs/libmpdclient/autotools-files/Makefile.am
@@ -1,0 +1,114 @@
+ACLOCAL_AMFLAGS = -I m4
+AUTOMAKE_OPTIONS = foreign 1.11 dist-xz subdir-objects
+
+mpdincludedir = $(includedir)/mpd
+mpdinclude_HEADERS = \
+	include/mpd/async.h \
+	include/mpd/audio_format.h \
+	include/mpd/client.h \
+	include/mpd/capabilities.h \
+	include/mpd/compiler.h \
+	include/mpd/connection.h \
+	include/mpd/database.h \
+	include/mpd/directory.h \
+	include/mpd/entity.h \
+	include/mpd/error.h \
+	include/mpd/idle.h \
+	include/mpd/list.h \
+	include/mpd/mixer.h \
+	include/mpd/parser.h \
+	include/mpd/password.h \
+	include/mpd/player.h \
+	include/mpd/playlist.h \
+	include/mpd/protocol.h \
+	include/mpd/queue.h \
+	include/mpd/recv.h \
+	include/mpd/response.h \
+	include/mpd/send.h \
+	include/mpd/status.h \
+	include/mpd/stats.h \
+	include/mpd/tag.h \
+	include/mpd/output.h \
+	include/mpd/pair.h \
+	include/mpd/search.h \
+	include/mpd/socket.h \
+	include/mpd/song.h \
+	include/mpd/sticker.h \
+	include/mpd/settings.h \
+	include/mpd/message.h \
+	include/mpd/version.h
+
+AM_CPPFLAGS += -I$(srcdir)/include -Iinclude
+
+lib_LTLIBRARIES = src/libmpdclient.la
+
+src_libmpdclient_la_SOURCES = \
+	src/async.c src/iasync.h \
+	src/buffer.h \
+	src/internal.h \
+	src/ierror.c src/ierror.h \
+	src/resolver.c src/resolver.h \
+	src/capabilities.c \
+	src/connection.c \
+	src/database.c \
+	src/directory.c \
+	src/rdirectory.c \
+	src/error.c \
+	src/fd_util.c src/fd_util.h \
+	src/output.c \
+	src/coutput.c \
+	src/entity.c \
+	src/idle.c \
+	src/iso8601.h \
+	src/iso8601.c \
+	src/kvlist.c \
+	src/list.c \
+	src/mixer.c \
+	src/parser.c \
+	src/password.c \
+	src/player.c \
+	src/playlist.c \
+	src/rplaylist.c \
+	src/cplaylist.c \
+	src/queue.c \
+	src/quote.c src/quote.h \
+	src/recv.c \
+	src/response.c \
+	src/run.c src/run.h \
+	src/search.c \
+	src/send.c src/isend.h \
+	src/socket.c src/socket.h \
+	src/song.c \
+	src/status.c \
+	src/cstatus.c \
+	src/stats.c \
+	src/cstats.c \
+	src/sync.c src/sync.h \
+	src/tag.c \
+	src/sticker.c \
+	src/settings.c \
+	src/message.c \
+	src/cmessage.c \
+	src/uri.h
+
+src_libmpdclient_la_LDFLAGS = -version-info @LIBMPDCLIENT_LIBTOOL_VERSION@ \
+	-no-undefined
+
+if HAVE_GNU_LD
+src_libmpdclient_la_LDFLAGS += -Wl,--version-script=$(srcdir)/libmpdclient.ld
+endif
+
+#
+# Installation
+#
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libmpdclient.pc
+
+#
+# Distribution
+#
+
+EXTRA_DIST = \
+	libmpdclient.ld \
+	libmpdclient.pc.in 

--- a/libs/libmpdclient/autotools-files/config.h.in
+++ b/libs/libmpdclient/autotools-files/config.h.in
@@ -1,0 +1,79 @@
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Default MPD host */
+#undef DEFAULT_HOST
+
+/* Default MPD port */
+#undef DEFAULT_PORT
+
+/* Default UNIX socket path */
+#undef DEFAULT_SOCKET
+
+/* Define to enable TCP support */
+#undef ENABLE_TCP
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#undef HAVE_DLFCN_H
+
+/* Define to 1 if you have the `getaddrinfo' function. */
+#undef HAVE_GETADDRINFO
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#undef HAVE_INTTYPES_H
+
+/* Define to 1 if you have the <memory.h> header file. */
+#undef HAVE_MEMORY_H
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#undef HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+#undef HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#undef HAVE_STRING_H
+
+/* Define to 1 if you have the `strndup' function. */
+#undef HAVE_STRNDUP
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#undef HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#undef HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#undef HAVE_UNISTD_H
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#undef LT_OBJDIR
+
+/* Name of package */
+#undef PACKAGE
+
+/* Define to the address where bug reports for this package should be sent. */
+#undef PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#undef PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#undef PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
+/* Define to the version of this package. */
+#undef PACKAGE_VERSION
+
+/* Define to 1 if you have the ANSI C header files. */
+#undef STDC_HEADERS
+
+/* Version number of package */
+#undef VERSION

--- a/libs/libmpdclient/autotools-files/configure.ac
+++ b/libs/libmpdclient/autotools-files/configure.ac
@@ -1,0 +1,162 @@
+AC_PREREQ(2.60)
+AC_INIT(libmpdclient, 2.14, musicpd-dev-team@lists.sourceforge.net)
+AC_CONFIG_SRCDIR([src/connection.c])
+AC_CONFIG_AUX_DIR(build)
+AM_INIT_AUTOMAKE([foreign 1.11 dist-xz subdir-objects silent-rules])
+AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIR([m4])
+
+AC_SUBST(MAJOR_VERSION,2)
+AC_SUBST(MINOR_VERSION,14)
+AC_SUBST(PATCH_VERSION,0)
+
+LIBMPDCLIENT_LIBTOOL_VERSION=2:14:0
+AC_SUBST(LIBMPDCLIENT_LIBTOOL_VERSION)
+
+# Remove the check for c++ and fortran compiler
+m4_defun([_LT_AC_LANG_CXX_CONFIG], [:])
+m4_defun([_LT_AC_LANG_F77_CONFIG], [:])
+
+dnl Check for programs
+AC_PROG_CC_C99
+AC_PROG_INSTALL
+
+AC_PROG_LD
+AM_CONDITIONAL(HAVE_GNU_LD, test x$with_gnu_ld = xyes)
+
+AC_LIBTOOL_WIN32_DLL
+AC_PROG_LIBTOOL
+
+
+dnl
+dnl initialize variables
+dnl
+
+set -- $CFLAGS
+
+
+dnl
+dnl OS specific defaults
+dnl
+
+AC_CANONICAL_HOST
+
+case "$host_os" in
+mingw32* | windows*)
+	LIBS="$LIBS -lws2_32"
+	;;
+esac
+
+
+dnl
+dnl Check for libraries
+dnl
+
+AC_SEARCH_LIBS([socket], [network socket])
+
+
+dnl
+dnl build options
+dnl
+
+AC_ARG_ENABLE(documentation,
+	AS_HELP_STRING([--disable-documentation],
+		[Disable API doc generation @<:@default=enabled@:>@]),,
+	[enable_documentation=yes])
+
+if test "x$enable_documentation" = xyes; then
+	AC_PATH_PROG(DOXYGEN, doxygen)
+	if test x$DOXYGEN = x; then
+		AC_MSG_ERROR([doxygen not found])
+	fi
+
+	AC_SUBST(DOXYGEN)
+fi
+AM_CONDITIONAL(DOXYGEN, test x$enable_documentation = xyes)
+
+AC_ARG_ENABLE(tcp,
+	AS_HELP_STRING([--disable-tcp],
+		[Disable TCP support @<:@default=enabled@:>@]),,
+	[enable_tcp=yes])
+if test "x$enable_tcp" = xyes; then
+	AC_DEFINE([ENABLE_TCP], 1, [Define to enable TCP support])
+	AC_SEARCH_LIBS([gethostbyname], [nsl])
+	AC_CHECK_FUNCS([getaddrinfo])
+	AC_CHECK_FUNCS([strndup])
+fi
+
+AC_ARG_ENABLE(werror,
+	AS_HELP_STRING([--enable-werror],
+		[Treat warnings as errors @<:@default=disabled@:>@]),
+	enable_werror=no)
+
+if test "x$enable_werror" = xyes; then
+	AM_CFLAGS="$AM_CFLAGS -Werror -pedantic-errors"
+fi
+
+AC_ARG_ENABLE(debug,
+	AS_HELP_STRING([--enable-debug],
+		[Enable debugging @<:@default=disabled@:>@]),
+	enable_debug=no)
+
+if test "x$enable_debug" = xno; then
+	AM_CFLAGS="$AM_CFLAGS -DNDEBUG"
+fi
+
+
+dnl
+dnl CFLAGS
+dnl
+
+AC_SUBST(AM_CFLAGS)
+AC_SUBST(AM_CPPFLAGS)
+
+WANTED_CFLAGS="-Wall -W -Wextra -Wno-deprecated-declarations -Wmissing-prototypes -Wshadow -Wpointer-arith -Wstrict-prototypes -Wcast-qual -Wwrite-strings"
+for flag in $WANTED_CFLAGS ; do
+	AX_CHECK_COMPILER_FLAGS([$flag], [CFLAGS="$CFLAGS $flag"],)
+done
+
+dnl
+dnl Compile-time options
+dnl
+
+AC_ARG_WITH([default-socket],
+	AC_HELP_STRING([--with-default-socket=PATH],
+		[default path of the socket file @<:@/var/run/mpd/socket@:>@]),,
+	[with_default_socket=auto])
+
+if test x$with_default_socket = xauto; then
+	case "$host_os" in
+	mingw32* | windows*)
+		# no UNIX domain sockets on WIN32
+		with_default_socket=no
+		;;
+	*)
+		with_default_socket=/var/run/mpd/socket
+		;;
+	esac
+fi
+
+if test x$with_default_socket != xno; then
+	AC_DEFINE_UNQUOTED([DEFAULT_SOCKET], ["$with_default_socket"],
+		[Default UNIX socket path])
+fi
+
+AC_ARG_WITH([default-host],
+	AC_HELP_STRING([--with-default-host=ARG],
+		[default MPD host @<:@localhost@:>@]),,
+	[with_default_host=localhost])
+AC_DEFINE_UNQUOTED([DEFAULT_HOST], ["$with_default_host"], [Default MPD host])
+
+AC_ARG_WITH([default-port],
+	AC_HELP_STRING([--with-default-port=ARG],
+		[default MPD port @<:@6600@:>@]),,
+	[with_default_port=6600])
+AC_DEFINE_UNQUOTED([DEFAULT_PORT], [$with_default_port], [Default MPD port])
+
+
+dnl
+dnl Done
+dnl
+
+AC_OUTPUT([Makefile include/mpd/version.h libmpdclient.pc doc/doxygen.conf])

--- a/libs/libmpdclient/autotools-files/libmpdclient.pc.in
+++ b/libs/libmpdclient/autotools-files/libmpdclient.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libmpdclient
+Description: Music Player Daemon client library
+Version: @VERSION@
+Libs: -L${libdir} -lmpdclient
+Cflags: -I${includedir}

--- a/libs/libmpdclient/autotools-files/m4/ax_check_compiler_flags.m4
+++ b/libs/libmpdclient/autotools-files/m4/ax_check_compiler_flags.m4
@@ -1,0 +1,74 @@
+# ===========================================================================
+#     http://www.nongnu.org/autoconf-archive/ax_check_compiler_flags.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILER_FLAGS(FLAGS, [ACTION-SUCCESS], [ACTION-FAILURE])
+#
+# DESCRIPTION
+#
+#   Check whether the given compiler FLAGS work with the current language's
+#   compiler, or whether they give an error. (Warnings, however, are
+#   ignored.)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2009 Matteo Frigo
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+AC_DEFUN([AX_CHECK_COMPILER_FLAGS],
+[AC_PREREQ(2.59) dnl for _AC_LANG_PREFIX
+AC_MSG_CHECKING([whether _AC_LANG compiler accepts $1])
+dnl Some hackery here since AC_CACHE_VAL can't handle a non-literal varname:
+AS_LITERAL_IF([$1],
+  [AC_CACHE_VAL(AS_TR_SH(ax_cv_[]_AC_LANG_ABBREV[]_flags_[$1]), [
+      ax_save_FLAGS=$[]_AC_LANG_PREFIX[]FLAGS
+      _AC_LANG_PREFIX[]FLAGS="$1"
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
+        AS_TR_SH(ax_cv_[]_AC_LANG_ABBREV[]_flags_[$1])=yes,
+        AS_TR_SH(ax_cv_[]_AC_LANG_ABBREV[]_flags_[$1])=no)
+      _AC_LANG_PREFIX[]FLAGS=$ax_save_FLAGS])],
+  [ax_save_FLAGS=$[]_AC_LANG_PREFIX[]FLAGS
+   _AC_LANG_PREFIX[]FLAGS="$1"
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
+     eval AS_TR_SH(ax_cv_[]_AC_LANG_ABBREV[]_flags_[$1])=yes,
+     eval AS_TR_SH(ax_cv_[]_AC_LANG_ABBREV[]_flags_[$1])=no)
+   _AC_LANG_PREFIX[]FLAGS=$ax_save_FLAGS])
+eval ax_check_compiler_flags=$AS_TR_SH(ax_cv_[]_AC_LANG_ABBREV[]_flags_[$1])
+AC_MSG_RESULT($ax_check_compiler_flags)
+if test "x$ax_check_compiler_flags" = xyes; then
+	m4_default([$2], :)
+else
+	m4_default([$3], :)
+fi
+])dnl AX_CHECK_COMPILER_FLAGS


### PR DESCRIPTION
Maintainer: me 
Compile tested: MIPS_24kc
Run tested: AR71xx/WNDR4300

Posted for review and to give folks a chance to reject this somewhat gross hack. I'm totally open to simpler alternatives to moving forward with packages needing the python3/meson/ninja toolchain and configurations for cross compiling. 

Description:

Package versions newer than 2.11 require meson/ninja which OpenWrt does not
support in its build environment. These files provide the minimum autotool
configuration necessary to build later versions.

Signed-off-by: Ted Hess <thess@kitschensync.net>

