### PR TITLE
libpsl: depend on libidn2 and libunistring

### DIFF
--- a/libs/libpsl/Makefile
+++ b/libs/libpsl/Makefile
@@ -29,11 +29,14 @@ define Package/libpsl
   CATEGORY:=Libraries
   TITLE:=C library to handle the Public Suffix List
   URL:=https://github.com/rockdaboot/libpsl
+  DEPENDS:=+libidn2 +libunistring
 endef
 
 define Package/libpsl/description
   C library to handle the Public Suffix List
 endef
+
+CONFIGURE_ARGS += --disable-rpath
 
 define Build/InstallDev
 	$(INSTALL_DIR) \


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86, x86_64, master a5c3bbaf

Description:
libpsl: depend on libidn2 and libunistring

Should fix issue #6574.