### PR TITLE
lighttpd: fix build with nls.mk include

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -26,6 +26,7 @@ REBUILD_MODULES=authn_gssapi authn_ldap authn_mysql cml magnet mysql_vhost trigg
 PKG_CONFIG_DEPENDS:=CONFIG_LIGHTTPD_SSL $(patsubst %,CONFIG_PACKAGE_lighttpd-mod-%,$(REBUILD_MODULES))
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/lighttpd/Default
   SUBMENU:=Web Servers/Proxies


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86, x86_64, master a5c3bbaf

Description:
lighttpd: fix build with nls.mk include