### PR TITLE
perl: fix compilation of host perl on Fedora 28

### DIFF
--- a/lang/perl/patches/011-glibc-guard-old-libcrypt-fix.patch
+++ b/lang/perl/patches/011-glibc-guard-old-libcrypt-fix.patch
@@ -1,0 +1,16 @@
+--- a/pp.c
++++ b/pp.c
+@@ -3650,8 +3650,12 @@ PP(pp_crypt)
+ #if defined(__GLIBC__) || defined(__EMX__)
+ 	if (PL_reentrant_buffer->_crypt_struct_buffer) {
+ 	    PL_reentrant_buffer->_crypt_struct_buffer->initialized = 0;
+-	    /* work around glibc-2.2.5 bug */
++#if (defined(__GLIBC__) && __GLIBC__ == 2) && \
++    (defined(__GLIBC_MINOR__) && __GLIBC_MINOR__ >= 2 && __GLIBC_MINOR__ < 4)
++	    /* work around glibc-2.2.5 bug, has been fixed at some
++	     * time in glibc-2.3.X */
+ 	    PL_reentrant_buffer->_crypt_struct_buffer->current_saltbits = 0;
++#endif
+ 	}
+ #endif
+     }


### PR DESCRIPTION
Hi,

hostpkg perl is broken on Fedora 28 due to a very old glibc libcrypt patch. 

Fedora worked around it in perl 5.26.1 with this patch, perhaps worth including in openwrt.

Thanks very much for your time!

-dc

Patch is from Fedora perl rpm repo:
```

commit 13e70b397dcb0d1bf4a869b670f041c1d7b730d0
Author: Björn Esser <besser82@fedoraproject.org>
Date:   Sat Jan 20 20:22:53 2018 +0100

    pp: Guard fix for really old bug in glibc libcrypt
```

Signed-off-by: David Connolly <david@connol.ly>