### PR TITLE
mtr: depend on libcap

### DIFF
--- a/net/mtr/Makefile
+++ b/net/mtr/Makefile
@@ -30,7 +30,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/mtr
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libncurses
+  DEPENDS:=+libcap +libncurses
   TITLE:=Full screen ncurses traceroute tool
   URL:=http://www.bitwizard.nl/mtr/
 endef


### PR DESCRIPTION
Maintainer: @jmccrohan 
Compile tested: OpenWrt master r7690-50c5fdd54d @ x86/64
Run tested: OpenWrt master r7690-50c5fdd54d @ x86/64

Description:
When libcap is detected during build, support for it is enabled. This
will cause a build failure due to a missing dependency. It can be
disabled by passing ac_cv_lib_cap_cap_set_proc=no to CONFIGURE_VARS,
but capabilities support is strongly recommended for increased security.
Depend on libcap instead to fix this.