### PR TITLE
libtins: Update to 4.0

### DIFF
--- a/libs/libtins/Makefile
+++ b/libs/libtins/Makefile
@@ -8,21 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtins
+PKG_VERSION:=4.0
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:= Steven Hessing <steven.hessing@gmail.com>
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/mfontanini/libtins.git
-PKG_SOURCE_VERSION:=v3.5
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz
-PKG_MIRROR_HASH:=47cd7d659ffa75dcfc2172ef54151fd36dc87de9e0f04bb066f6b076a7df7b57
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/mfontanini/libtins/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=2a758d1bed51760bbd57fcaa00610534e0cc3a6d55d91983724e5f46739d66b8
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 PKG_BUILD_PARALLEL:=1
 
 CMAKE_INSTALL:=1
@@ -32,12 +29,18 @@ CMAKE_OPTIONS += -D_RUN_RESULT_VAR=FORCE
 CMAKE_OPTIONS += -DLIBTINS_ENABLE_WPA2=0
 CMAKE_OPTIONS += -DLIBTINS_ENABLE_CXX11=1
 
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/ $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/tins $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtins* $(1)/usr/lib/
+endef
+
 define Package/libtins
 	SECTION:=net
 	CATEGORY:=Libraries
-	TITLE:=libtins 
-	URL:=http://libtins.github.io/
-	DEPENDS:=+libstdcpp +libpcap 
+	TITLE:=libtins
+	URL:=https://libtins.github.io/
+	DEPENDS:=+libstdcpp +libpcap
 endef
 
 define Package/libtins/description
@@ -46,7 +49,7 @@ endef
 
 define Package/libtins/install
     $(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libtins.so.3.5 $(1)/usr/lib/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libtins.so $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libtins))


### PR DESCRIPTION
Switched to codeload. Simpler.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @StevenHessing 
Compile tested: ipq806x