### PR TITLE
Esniper: update to 2.35

### DIFF
--- a/net/esniper/Makefile
+++ b/net/esniper/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2016 Thomas Weißschuh
+# Copyright (C) 2015-2018 Thomas Weißschuh
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=esniper
-PKG_VERSION:=2.33.0
+PKG_VERSION:=2.35.0
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING
@@ -19,7 +19,7 @@ VERSION_TRANSFORMED:=$(subst .,-,$(PKG_VERSION))
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(VERSION_TRANSFORMED)
 PKG_SOURCE:=$(PKG_NAME)-$(VERSION_TRANSFORMED).tgz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
-PKG_HASH:=c9b8b10aefe5c397d7dee4c569f87f227c6710de528b1dc402379e5b4f1793dd
+PKG_HASH:=a93d4533e31640554f2e430ac76b43e73a50ed6d721511066020712ac8923c12
 
 PKG_BUILD_PARALLEL:=1
 


### PR DESCRIPTION
Maintainer: me
Compile tested: Atheros AR7XXX, TP-LINK TL-WDR4300 v1, OpenWrt master (8c2b8d862b8de10c6de303efb615d2ef2dfbbde5, to be compatible to 18.06.0-rc2)
Run tested: WDR4300, 18.06.0-rc2

Description: new upstream release.