### PR TITLE
libftdi1: Fix compilation with cmake 3.12

### DIFF
--- a/libs/libftdi1/Makefile
+++ b/libs/libftdi1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libftdi1
 PKG_VERSION:=1.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.intra2net.com/en/developer/libftdi/download/

--- a/libs/libftdi1/patches/101-use-findSWIG.patch
+++ b/libs/libftdi1/patches/101-use-findSWIG.patch
@@ -1,0 +1,11 @@
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -3,7 +3,7 @@ option ( LINK_PYTHON_LIBRARY "Link again
+ 
+ if ( PYTHON_BINDINGS )
+   # workaround for cmake bug #0013449
+-  if ( NOT DEFINED CMAKE_FIND_ROOT_PATH )
++  if ( NOT DEFINED CMAKE_FIND_ROOT_PATH OR CMAKE_VERSION VERSION_GREATER_EQUAL 3.0.0 )
+     find_package ( SWIG )
+   else ()
+     find_program ( SWIG_EXECUTABLE NAMES swig2.0 swig )


### PR DESCRIPTION
Maintainer: @Noltari 
Compile tested: ramips, openwrt master
Run tested: none

Description:
Applied a patch, adapted and just submitted upstream, that fixes a compilation error with
cmake 3.12
```
cd /home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/libftdi1-1.4/python && /home/equeiroz/src/openwrt-asus/staging_dir/host/bin/cmake -E env SWIG_LIB= /home/equeiroz/src/openwrt-asus/staging_dir/hostpkg/bin/swig -python -outdir /home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/libftdi1-1.4/python -I/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/libftdi1-1.4/src -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/include/libusb-1.0 -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/include/python3.7 -o /home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/libftdi1-1.4/python/CMakeFiles/_ftdi1.dir/ftdi1PYTHON_wrap.c /home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/libftdi1-1.4/python/ftdi1.i
:1: Error: Unable to find 'swig.swg'
:3: Error: Unable to find 'python.swg'
/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/libftdi1-1.4/python/ftdi1.i:34: Error: Unable to find 'typemaps.i'
/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/libftdi1-1.4/python/ftdi1.i:35: Error: Unable to find 'cstring.i'
```

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
