### PR TITLE
nut: Fix for nut-upsmon without nut-server

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -126,8 +126,11 @@ nut_upsmon_add() {
 	local password
 	local system
 
-	# If no core config, use defaults
-	[ -r $UPSMON_C ] || nut_upsmon_conf ""
+	# if UPSMON_C is a symlink we're only doing generated config
+	[ -L $UPSMON_C ] && {
+		rm -f $UPSMON_C
+		nut_upsmon_conf ""
+	}
 
 	config_get upsname "$cfg" upsname
 	config_get hostname "$cfg" hostname localhost
@@ -143,7 +146,8 @@ nut_upsmon_add() {
 }
 
 start_service() {
-	rm -f $UPSMON_C
+	mkdir -p "$(dirname "$UPSMON_C")"
+	chmod 750 "$(dirname "$UPSMON_C")"
 
 	config_load nut_monitor
 
@@ -156,20 +160,22 @@ start_service() {
 	chmod 640 $UPSMON_C
 	chmod 640 /var/etc/nut/nut.conf
 
+	chown ${runas:-root}:$(id -gn ${runas:-root}) /var/etc/nut
+	chown ${runas:-root}:$(id -gn ${runas:-root}) /var/etc/nut/nut.conf
+	chown ${runas:-root}:$(id -gn ${runas:-root}) $UPSMON_C
+
 	[ -d /var/run/nut ] || {
 		mkdir -m 0750 -p /var/run/nut
 		chown ${runas:-root}:$(id -gn ${runas:-root}) /var/run/nut
 	}
 
-	chown ${runas:-root}:$(id -gn ${runas:-root}) $UPSMON_C
-	$DEBUG /usr/sbin/upsmon $UPSMON_OPTIONS
+	exec $DEBUG /usr/sbin/upsmon $UPSMON_OPTIONS
 }
 
 stop_service() {
-	[ -r $PID_F ] && /usr/sbin/upsmon -c stop
-	rm -f $UPSMON_C
+	exec /usr/sbin/upsmon -c stop
 }
 
 reload_service() {
-	upsmon -c reload
+	exec /usr/sbin/upsmon -c reload
 }


### PR DESCRIPTION
nut-monitor failed to create required dir /var/etc/nut, as
well as failing to set appropriate user on the directory and
conf files.  Fixing this closes
https://github.com/openwrt/packages/issues/6644

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: me / @cshoredaniel
Compile tested: ath79, pcs_cr3000, latest master
Run tested: ath79, pcs_cr3000, latest master

Configured /etc/config/nut_monitor
Started, restarted, stopped upsmon
rebooted (to ensure correctly starts on boot).
upsmon puts it's operation in syslog which was viewed to see it's operation

Since a user noticed this in 18.06.0 (https://github.com/openwrt/packages/issues/6644), can it be backported to 18.06 for .1?  I can submit the 18.06 PR if need be.