### PR TITLE
unbound: fix boot time and default run directory

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.7.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -36,7 +36,7 @@ define Package/unbound
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=IP Addresses and Names
-  USERID:=unbound=553:unbound=553
+  USERID:=unbound:unbound
   TITLE+= (daemon)
   DEPENDS+= +libunbound
 endef
@@ -117,8 +117,10 @@ CONFIGURE_ARGS += \
 	--enable-tfo-server \
 	--with-libexpat="$(STAGING_DIR)/usr" \
 	--with-ssl="$(STAGING_DIR)/usr" \
-	--with-pidfile=/var/run/unbound.pid \
-	--with-user=unbound
+	--with-user=unbound \
+	--with-run-dir=/var/lib/unbound \
+	--with-conf-file=/var/lib/unbound/unbound.conf \
+	--with-pidfile=/var/run/unbound.pid
 
 define Package/unbound/conffiles
 /etc/config/unbound
@@ -142,7 +144,7 @@ define Package/unbound/install
 		$(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/unbound
 	$(INSTALL_DATA) \
-		$(PKG_INSTALL_DIR)/etc/unbound/unbound.conf \
+		$(PKG_INSTALL_DIR)/var/lib/unbound/unbound.conf \
 		$(1)/etc/unbound/unbound.conf
 	$(INSTALL_DATA) ./files/root.key $(1)/etc/unbound/root.key
 	$(INSTALL_DATA) ./files/unbound_ext.conf $(1)/etc/unbound/unbound_ext.conf

--- a/net/unbound/files/defaults.sh
+++ b/net/unbound/files/defaults.sh
@@ -41,6 +41,7 @@ UB_TLS_ETC_FILE=/etc/ssl/certs/ca-certificates.crt
 UB_RKEY_FILE=$UB_VARDIR/root.key
 UB_RHINT_FILE=$UB_VARDIR/root.hints
 UB_TIME_FILE=$UB_VARDIR/hotplug.time
+UB_SKIP_FILE=$UB_VARDIR/skip.time
 
 # control app keys
 UB_CTLKEY_FILE=$UB_VARDIR/unbound_control.key
@@ -50,7 +51,7 @@ UB_SRVPEM_FILE=$UB_VARDIR/unbound_server.pem
 
 # similar default SOA / NS RR as Unbound uses for private ARPA zones
 UB_XSER=$(( $( date +%s ) / 60 ))
-UB_XSOA="7200 IN SOA localhost. nobody.invalid. $UB_XSER 3600 1200 9600 600"
+UB_XSOA="7200 IN SOA localhost. nobody.invalid. $UB_XSER 3600 1200 9600 300"
 UB_XNS="7200 IN NS localhost."
 UB_XTXT="7200 IN TXT \"comment=local intranet dns zone\""
 UB_MTXT="7200 IN TXT \"comment=masked internet dns zone\""

--- a/net/unbound/files/dnsmasq.sh
+++ b/net/unbound/files/dnsmasq.sh
@@ -206,6 +206,7 @@ dnsmasq_local_arpa() {
 dnsmasq_inactive() {
   local record
 
+
   if [ "$UB_D_EXTRA_DNS" -gt 0 ] ; then
     # Parasite from the uci.dhcp.domain clauses
     DM_LIST_KNOWN_ZONES="$DM_LIST_KNOWN_ZONES $UB_TXT_DOMAIN"

--- a/net/unbound/files/odhcpd.sh
+++ b/net/unbound/files/odhcpd.sh
@@ -43,8 +43,8 @@ odhcpd_zonedata() {
   local dhcp_origin=$( uci_get dhcp.@odhcpd[0].leasefile )
 
 
-  if [ -f "$UB_TIME_FILE" -a "$dhcp_link" = "odhcpd" \
-    -a -f "$dhcp_origin" -a -n "$dhcp_domain" ] ; then
+  if [ -f "$UB_TOTAL_CONF" -a -f "$dhcp_origin" \
+       -a "$dhcp_link" = "odhcpd" -a -n "$dhcp_domain" ] ; then
     # Capture the lease file which could be changing often
     sort $dhcp_origin > $dhcp_ls_new
 

--- a/net/unbound/files/unbound.init
+++ b/net/unbound/files/unbound.init
@@ -54,22 +54,31 @@ stop_service() {
 ##############################################################################
 
 service_triggers() {
-  local trigger
   local legacy=$( uci_get unbound.@unbound[0].trigger )
   local triggers=$( uci_get unbound.@unbound[0].trigger_interface )
+  local trigger="$triggers $legacy"
 
-  triggers="$triggers $legacy"
-  PROCD_RELOAD_DELAY=2000
-  procd_add_reload_trigger "unbound"
+  . /usr/lib/unbound/defaults.sh
 
 
-  if [ -n "$triggers" ] ; then
+  if [ ! -f "$UB_TOTAL_CONF" -o -n "$UB_BOOT" ] ; then
+    # Unbound is can be a bit heavy, so wait some on first start but any
+    # interface coming up affects the trigger and delay so guarantee start
+    procd_add_raw_trigger "interface.*.up" 5000 /etc/init.d/unbound restart
+
+  elif [ -n "$triggers" ] ; then
+    PROCD_RELOAD_DELAY=2000
+    procd_add_reload_trigger "unbound" "dhcp"
+
+
     for trigger in $triggers ; do
-      # due to some netifd/procd interactions with IP6, limit interfaces
+      # User selected triggers to restart at any other time
       procd_add_reload_interface_trigger "$trigger"
     done
+
   else
-    procd_add_raw_trigger "interface.*.up" 2000 /etc/init.d/unbound reload
+    PROCD_RELOAD_DELAY=2000
+    procd_add_reload_trigger "unbound" "dhcp"
   fi
 }
 


### PR DESCRIPTION
Maintainer: me
Tested: TL-Archer-C7v2 OpenWrt master
Description:
Unbound struggles with boot ifup, and procd triggers are changed to push outside of this noise. Unbound has run in /var/lib/unbound/, so chroot (jail) protects /etc/, and it can save flash wear. Compiled defaults reflect this now, so Unbound tools are easier run on the command line.