### PR TITLE
emailrelay: avoind linking with -lpam

### DIFF
--- a/mail/emailrelay/Makefile
+++ b/mail/emailrelay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=emailrelay
 PKG_VERSION:=2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=@SF/emailrelay/$(PKG_VERSION)
@@ -83,6 +83,11 @@ CONFIGURE_ARGS += \
 	--disable-mac \
 	--disable-testing \
 	--disable-windows
+
+# Workaround for https://sourceforge.net/p/emailrelay/bugs/38/
+# This should be fixed in the next release.
+CONFIGURE_VARS += \
+	ac_cv_search_pam_end=no
 
 ifeq ($(CONFIG_EMAILRELAY_SSL),y)
 	CONFIGURE_ARGS += \


### PR DESCRIPTION
Maintainer: @fededim 
Compile tested: brcm47xx, openwrt master
Run tested: none

Description:
The package seems to link to `-lpam` even when using `--without-pam`.  

```
Package emailrelay is missing dependencies for the following libraries:
libpam.so.0
```
config.log:
```
configure:5370: mipsel-openwrt-linux-musl-gcc -o conftest -Os -pipe -mno-branch-likely -mips32r2 -mtune=74kc -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float -mips16 -minterlink-mips16 -iremap/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/emailrelay-2.0:emailrelay-2.0 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro  -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/include -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/include -I/home/equeiroz/src/openwrt-asus/staging_dir/toolchain-mipsel_74kc_gcc-7.3.0_musl/usr/include -I/home/equeiroz/src/openwrt-asus/staging_dir/toolchain-mipsel_74kc_gcc-7.3.0_musl/include/fortify -I/home/equeiroz/src/openwrt-asus/staging_dir/toolchain-mipsel_74kc_gcc-7.3.0_musl/include  -L/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/lib -L/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/lib -L/home/equeiroz/src/openwrt-asus/staging_dir/toolchain-mipsel_74kc_gcc-7.3.0_musl/usr/lib -L/home/equeiroz/src/openwrt-asus/staging_dir/toolchain-mipsel_74kc_gcc-7.3.0_musl/lib -znow -zrelro  conftest.c -lpam   >&5
configure:5370: $? = 0
configure:5387: result: -lpam
```
Set `ac_cv_search_pam_end=no` to avoid it.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>