### PR TITLE
json4lua: Update to 0.9.54 and switch to codeload

### DIFF
--- a/lang/json4lua/Makefile
+++ b/lang/json4lua/Makefile
@@ -8,18 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=json4lua
-PKG_VERSION:=0.9.53
+PKG_VERSION:=0.9.54
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MIRROR_HASH:=61a9631784aa5d7dd8adfdfa149f0a45deaa4bf80b117e89722702c612afa081
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/amrhassan/json4lua.git
-PKG_SOURCE_VERSION:=$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/amrhassan/json4lua/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=2498e5224b024521af7f2de9a2c2af4028cd8da4b724ffd6bd94beede2402cfe
 
 PKG_MAINTAINER:=Amr Hassan <amr.hassan@gmail.com>
-PKG_LICENSE=MIT
+PKG_LICENSE:=MIT
 
 LUA_MODULE_PATH:=/usr/lib/lua
 


### PR DESCRIPTION
Should be more consistent. Also simpler.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: ???
Compile tested: ipq806x