### PR TITLE
miniupnpd: Update to 2.1.20180706

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
-PKG_VERSION:=2.1
-PKG_RELEASE:=2
+PKG_VERSION:=2.1.20180706
+PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=http://miniupnp.free.fr/files
+PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=950894779661197fe093855fda29a728f434b5756eb4fa6cb5f7b9bff7ffe0c1
+PKG_HASH:=fc2d2fd044d8c3f8d02b63d70489bb35ece836a4fc1b6386865ac8fbe8d8b006
 
 PKG_LICENSE:=BSD-3-Clause
 
@@ -26,7 +26,7 @@ define Package/miniupnpd
   DEPENDS:=+iptables +libip4tc +IPV6:libip6tc +IPV6:ip6tables +libuuid
   TITLE:=Lightweight UPnP IGD, NAT-PMP & PCP daemon
   SUBMENU:=Firewall
-  URL:=http://miniupnp.free.fr/
+  URL:=https://miniupnp.tuxfamily.org/
 endef
 
 define Package/miniupnpd/conffiles
@@ -38,7 +38,8 @@ define Build/Prepare
 	echo "$(VERSION_NUMBER)" | tr '() ' '_' >$(PKG_BUILD_DIR)/os.openwrt
 endef
 
-TARGET_CFLAGS += -flto -ffunction-sections -fdata-sections
+TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS))
+TARGET_CFLAGS += -flto -ffunction-sections -fdata-sections -O2
 TARGET_LDFLAGS += $(FPIC) -flto -Wl,--gc-sections
 MAKE_FLAGS += \
 	TARGET_OPENWRT=1 TEST=0 LIBS="" \

--- a/net/miniupnpd/patches/100-build-on-OpenWrt.patch
+++ b/net/miniupnpd/patches/100-build-on-OpenWrt.patch
@@ -28,7 +28,7 @@
  if [ -z "$V6SOCKETS_ARE_V6ONLY" ] ; then
 --- a/Makefile.linux
 +++ b/Makefile.linux
-@@ -73,7 +73,10 @@ CPPFLAGS += -DIPTABLES_143
+@@ -74,7 +74,10 @@ CPPFLAGS += -DIPTABLES_143
  endif
  
  CFLAGS  += $(shell $(PKG_CONFIG) --cflags libiptc)
@@ -39,7 +39,7 @@
  LDFLAGS += $(shell $(PKG_CONFIG) --libs-only-L libiptc)
  LDFLAGS += $(shell $(PKG_CONFIG) --libs-only-other libiptc)
  else
-@@ -153,6 +156,8 @@ LDLIBS += $(shell $(PKG_CONFIG) --static
+@@ -154,6 +157,8 @@ LDLIBS += $(shell $(PKG_CONFIG) --static
  LDLIBS += $(shell $(PKG_CONFIG) --static --libs-only-l libnetfilter_conntrack)
  endif # ($(TEST),1)
  
@@ -48,7 +48,7 @@
  LDLIBS += $(shell $(PKG_CONFIG) --static --libs-only-l libssl)
  
  TEST := $(shell $(PKG_CONFIG) --exists uuid && echo 1)
-@@ -161,6 +166,7 @@ LDLIBS += $(shell $(PKG_CONFIG) --static
+@@ -162,6 +167,7 @@ LDLIBS += $(shell $(PKG_CONFIG) --static
  else
  $(info please install uuid-dev package / libuuid)
  endif # ($(TEST),1)


### PR DESCRIPTION
Switched to upstream mirror 2, which is reachable over HTTPS.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: Nobody
Compile tested: ipq806x

May fix https://github.com/openwrt/packages/issues/6631