### PR TITLE
nginx: added stream support

### DIFF
--- a/net/nginx/Config.in
+++ b/net/nginx/Config.in
@@ -236,4 +236,11 @@ config NGINX_TS_MODULE
 		Add support for MPEG-TS Live Module module.
 	default n
 
+config NGINX_STREAM_CORE_MODULE
+        bool
+        prompt "Enable stream support"
+        help
+                Add support for NGINX request streaming.
+        default n
+
 endmenu

--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.15.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://nginx.org/download/
@@ -68,6 +68,7 @@ PKG_CONFIG_DEPENDS := \
 	CONFIG_NGINX_HEADERS_MORE \
 	CONFIG_NGINX_RTMP_MODULE \
 	CONFIG_NGINX_TS_MODULE \
+	CONFIG_NGINX_STREAM_CORE_MODULE \
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -497,6 +498,10 @@ ifeq ($(CONFIG_NGINX_LUA),y)
 	gzip -dc $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
 	$(call PatchDir,$(PKG_BUILD_DIR),./patches-lua-nginx)
   endef
+endif
+
+ifneq ($(CONFIG_NGINX_STREAM_CORE_MODULE),y)
+  ADDITIONAL_MODULES += --with-stream
 endif
 
 $(eval $(call BuildPackage,nginx))


### PR DESCRIPTION
Maintainer: @Ansuel
Compile tested: x86_64, qemu, 18.06.0
Run tested: x86_64, qemu, enable stream in nginx configuration and have nginx check configuration

Description:
This will add the option `--with-stream` to nginx makefile. This options enable the use of the `stream` directive in nginx configuration as in the example

```nginx
stream {
    upstream backend {
        hash $remote_addr consistent;

        server backend1.example.com:12345 weight=5;
        server 127.0.0.1:12345            max_fails=3 fail_timeout=30s;
        server unix:/tmp/backend3;
    }

    upstream dns {
       server 192.168.0.1:53535;
       server dns.example.com:53;
    }

    server {
        listen 12345;
        proxy_connect_timeout 1s;
        proxy_timeout 3s;
        proxy_pass backend;
    }

    server {
        listen 127.0.0.1:53 udp reuseport;
        proxy_timeout 20s;
        proxy_pass dns;
    }

    server {
        listen [::1]:12345;
        proxy_pass unix:/tmp/stream.socket;
    }
}
```

This will enable streaming requests to other hosts in environments where you don't want your router to be the SSL termination for incoming connections.