### PR TITLE
usbip: remove nonshared flag

### DIFF
--- a/net/usbip/Makefile
+++ b/net/usbip/Makefile
@@ -32,7 +32,6 @@ Hooks/Prepare/Pre += prepare_source_directory
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
-PKG_FLAGS:=nonshared
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk


### PR DESCRIPTION
Maintainer: @nunojpg 
Compile tested: x86/64, ar71xx/tiny, brcm2708/bcm2710 @ r7742-6031ab345d
Run tested: -

Description:

Since https://git.openwrt.org/d0e0b7049f88774e67c3d5ad6b573f7070e5f900,
OpenWrt SDKs ship the appropriate sources for building usbip userspace
packages, so special nonshared handling is not required anymore.

Sucessfully tested by compiling usbip utilities for various architectures
using self built SDKs after applying the change linked above.