### PR TITLE
netdata: create missing folder /etc/netdata/customs-plugins.d

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
 PKG_VERSION:=1.10.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
@@ -50,6 +50,8 @@ define Package/netdata/install
 	mkdir -p $(1)/etc/netdata
 	$(CP) $(PKG_INSTALL_DIR)/etc/netdata $(1)/etc
 	$(CP) ./files/netdata.conf $(1)/etc/netdata
+	mkdir -p $(1)/etc/netdata/custom-plugins.d
+
 	mkdir -p $(1)/usr/share/netdata
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/netdata $(1)/usr/share
 	rm -rf $(1)/usr/share/netdata/web/images
@@ -58,12 +60,15 @@ define Package/netdata/install
 	rm $(1)/usr/share/netdata/web/fonts/*.svg
 	rm $(1)/usr/share/netdata/web/fonts/*.ttf
 	rm $(1)/usr/share/netdata/web/fonts/*.woff
+
 	mkdir -p $(1)/usr/lib/netdata
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/netdata $(1)/usr/lib
 	rm $(1)/usr/lib/netdata/python.d/python-modules-installer.sh
 	chmod 4755 $(1)/usr/lib/netdata/plugins.d/apps.plugin
+
 	mkdir -p $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/netdata.init $(1)/etc/init.d/netdata
+
 	mkdir -p $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/netdata $(1)/usr/sbin
 endef


### PR DESCRIPTION
Maintainer: none (previous @diizzyy)
Compile tested: mvebu, Turris Omnia, OpenWRT 15.05
Run tested: mvebu, Turris Omnia, OpenWRT 15.05

Description:

When I don't use init.d (procd) script to start netdata first and start in command line via
`netdata`
 it complains that there is no directory /var/cache/netdata and others.
I checked it on Turris forum and I've noticed that I'm not first, who started netdata first in CLI instead of init.d script.

log:

> 2018-08-05 17:27:17: netdata FATAL : MAIN :Cannot cd to directory '/var/cache/netdata' # : Invalid argument
> 
> 2018-08-05 17:27:17: netdata INFO  : MAIN : EXIT: netdata prepares to exit with code 1...
> 2018-08-05 17:27:17: netdata INFO  : MAIN : EXIT: cleaning up the database...
> 2018-08-05 17:27:17: netdata INFO  : MAIN : Cleaning up database [0 hosts(s)]...
> 2018-08-05 17:27:17: netdata INFO  : MAIN : EXIT: all done - netdata is now exiting - bye bye...

It works once I'll do
`/etc/init.d/netdata start`
because in that script is included make dirs. Is there any reason, why it's not in Makefile?

I have also noticed in syslog:

> 2018-08-05 17:40:22 err netdata[14616]: cannot open plugins directory '/etc/netdata/custom-plugins.d
That's why I added it to Makefile.

Changes what I do:
- make dir moved to Makefile from init.d script
- add more new lines to make it more clear
- added folder /etc/netdata/customs-plugins.d