### PR TITLE
luajit: add .hpp to InstallDev

### DIFF
--- a/lang/luajit/Makefile
+++ b/lang/luajit/Makefile
@@ -59,7 +59,7 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/luajit-2.1
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/luajit-2.1/*.h $(1)/usr/include/luajit-2.1
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/luajit-2.1/*.{h,hpp} $(1)/usr/include/luajit-2.1
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.{a,so*} $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: @milani
Compile tested: x86, x86_64, master a0773047

Description:
This is necessary to build Snort 3.0.0 for OpenWrt.