### PR TITLE
lispmob: Update to 0.5.2.1 and switch to codeload

### DIFF
--- a/net/lispmob/Makefile
+++ b/net/lispmob/Makefile
@@ -8,16 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lispmob
-PKG_REV:=180aa39d338a00bb532e421de7f8513492cf2e8b
-PKG_VERSION:=0.4
-PKG_RELEASE:=2
+PKG_VERSION:=0.5.2.1
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_MIRROR_HASH:=584300e1a59cc976f3599213487ea8425f94300887a51c9804f0292cf2f0c8cc
-PKG_SOURCE_URL:=git://github.com/LISPmob/lispmob.git
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=$(PKG_REV)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/LISPmob/lispmob/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=aa51574fac4f70848541eb400a1347aec7b7b6f447b4a08add7b257a1441d4aa
 
 PKG_LICENSE:=GPLv2
 PKG_LICENSE_FILES:=LICENSE
@@ -33,7 +29,7 @@ define Package/lispd
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Locator/ID separation protocol (using TUN)
-  URL:=https://github.com/LISPmob
+  URL:=https://github.com/LISPmob/lispmob
   DEPENDS:= +librt +libopenssl +confuse +kmod-tun +uci @IPV6
   $(call Package/lispd/default)
 endef
@@ -41,6 +37,8 @@ endef
 define Package/lispd/description
   This packet provides support for the Locator-ID Separation Protocol.
 endef
+
+TARGET_CFLAGS += -DBSD #compile fix
 
 MAKE_FLAGS += \
 	platform=openwrt

--- a/net/lispmob/patches/001-fix-musl-build.patch
+++ b/net/lispmob/patches/001-fix-musl-build.patch
@@ -1,31 +1,42 @@
---- a/lispd/lispd_output.c
-+++ b/lispd/lispd_output.c
-@@ -26,6 +26,7 @@
-  *    Alberto Rodriguez Natal <arnatal@ac.upc.edu>
-  */
+diff --git a/lispd/data-plane/tun/tun_input.c b/lispd/data-plane/tun/tun_input.c
+index d484989..669361f 100644
+--- a/lispd/data-plane/tun/tun_input.c
++++ b/lispd/data-plane/tun/tun_input.c
+@@ -60,7 +60,7 @@ tun_read_and_decap_pkt(int sock, lbuf_t *b)
  
-+#define _GNU_SOURCE 1
+     /* FILTER UDP: with input RAW UDP sockets, we receive all UDP packets,
+      * we only want LISP data ones */
+-    if (ntohs(udph->dest) != LISP_DATA_PORT) {
++    if (ntohs(udph->uh_dport) != LISP_DATA_PORT) {
+         return (ERR_NOT_LISP);
+     }
  
- 
- #include <assert.h>
---- a/lispd/lispd_input.c
-+++ b/lispd/lispd_input.c
-@@ -26,6 +26,7 @@
-  *    Alberto Rodriguez Natal <arnatal@ac.upc.edu>
-  */
- 
-+#define _GNU_SOURCE 1
- 
- #include "lispd_input.h"
- #include "lispd_map_notify.h"
---- a/lispd/lispd_pkt_lib.c
-+++ b/lispd/lispd_pkt_lib.c
-@@ -28,6 +28,8 @@
+diff --git a/lispd/lispd_api.c b/lispd/lispd_api.c
+index ca00a8f..3fb39fd 100644
+--- a/lispd/lispd_api.c
++++ b/lispd/lispd_api.c
+@@ -17,6 +17,8 @@
   *
   */
  
 +#define _GNU_SOURCE 1
 +
- #include "lispd_afi.h"
- #include "lispd_pkt_lib.h"
- #include "lispd_lib.h"
+ #include <assert.h>
+ #include <stdio.h>
+ #include <string.h>
+diff --git a/lispd/lispd_api_internals.c b/lispd/lispd_api_internals.c
+index 3768fd7..3ce82a4 100644
+--- a/lispd/lispd_api_internals.c
++++ b/lispd/lispd_api_internals.c
+@@ -29,8 +29,10 @@
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <string.h>
+-#include <assert.h>
+ 
++#define _GNU_SOURCE 1
++
++#include <assert.h>
+ 
+ lisp_addr_t * lxml_lcaf_get_lisp_addr (xmlNodePtr xml_lcaf);
+ 


### PR DESCRIPTION
Simpler makefile and easier to bump versions.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: ???
Compile tested: ipq806x

