### PR TITLE
libupm: don't set SWIG_DIR, force python 2.7

### DIFF
--- a/libs/libupm/Makefile
+++ b/libs/libupm/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=libupm
 PKG_VERSION:=0.4.0
 
-PKG_RELEASE=$(PKG_SOURCE_VERSION)
+PKG_RELEASE=$(PKG_SOURCE_VERSION)-1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/intel-iot-devkit/upm.git
@@ -38,7 +38,7 @@ UPM_MODULES:= \
 
 CMAKE_OPTIONS=-DBUILDARCH=$(CONFIG_ARCH) \
 	-DNODE_EXECUTABLE=$(STAGING_DIR_HOSTPKG)/bin/node \
-	-DSWIG_DIR=$(STAGING_DIR_HOSTPKG)/bin
+	-DPython_ADDITIONAL_VERSIONS=2.7
 
 define Package/libupm/Default
   SECTION:=libs


### PR DESCRIPTION
Maintainer: @blogic 
Compile tested: brcm47xx, openwrt master
Run tested: none

Description:
CMake 3.0.12 uses `SWIG_DIR` to set `SWIG_LIB`, used as the library
install location, which defaults to `$(STAGING_HOSTPKG)/share/sig/(SWIGVERSION)`.  If it is set, then the
original installed swig library directory is ignored, and compilation
fails:
´´´
[  0%] Swig source
:1: Error: Unable to find 'swig.swg'
:3: Error: Unable to find 'python.swg'
´´´
Instead of setting it manually, let the default be used, which works well.  I have swig installed in my system, `which swig` returns `/usr/bin/swig`, and it picks up openwrt's swig correctly without any defines.
In case someone wishes to set the swig path anyway, the way to do it would be to add: `-DSWIG_EXECUTABLE=$(STAGING_DIR_HOSTPKG)/bin/swig`

Also, cmake picks up python3, while package wants 2.7, so we add `-DPython_ADDITIONAL_VERSIONS=2.7` to force use of 2.7, not 3.x.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>