### PR TITLE
Node-{arduino-firmata,cylon,hid,serialport}:  fix npm installation

### DIFF
--- a/lang/node-arduino-firmata/Makefile
+++ b/lang/node-arduino-firmata/Makefile
@@ -10,17 +10,17 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=arduino-firmata
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=0.3.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/shokai/node-arduino-firmata.git
+PKG_MIRROR_HASH:=1aef93dc704ea771b9eab51cb64103533f829aee5b2886ad55d173adf3f11ede
 PKG_SOURCE_VERSION:=v0.3.4
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_SOURCE_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz
-#PKG_MIRROR_HASH:=b7a498ccf70e466503e72d38ae5b474e91416b6c9842fd167dff249357b0dc37
 
 PKG_BUILD_DEPENDS:=node/host
-PKG_NODE_VERSION:=8.10.0
+PKG_NODE_VERSION:=`$(STAGING_DIR_HOSTPKG)/bin/node --version`
 
 PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>
 PKG_LICENSE:=MIT
@@ -51,16 +51,25 @@ EXTRA_LDFLAGS="-L$(TOOLCHAIN_DIR)/lib/ -Wl,-rpath-link $(TOOLCHAIN_DIR)/lib/" \
 define Build/Compile
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(CONFIG_ARCH) \
-	npm_config_nodedir=$(BUILD_DIR)/node-v$(PKG_NODE_VERSION)/ \
-	npm_config_cache=$(BUILD_DIR)/node-v$(PKG_NODE_VERSION)/npm-cache \
+	npm_config_nodedir=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/ \
+	npm_config_cache=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/npm-cache \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
 	npm install -g $(PKG_BUILD_DIR)
 endef
 
 define Package/node-arduino-firmata/install
 	mkdir -p $(1)/usr/lib/node
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/ $(1)/usr/lib/node
-	rm -rf $(1)/usr/lib/node/arduino-firmata/node_modules/serialport/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/. $(1)/usr/lib/node
+	rm -rf  $(1)/usr/lib/node/arduino-firmata/node_modules/serialport/ \
+		$(1)/usr/lib/node/arduino-firmata/patches \
+		$(1)/usr/lib/node/arduino-firmata/.p* \
+		$(1)/usr/lib/node/arduino-firmata/.quilt* \
+		$(1)/usr/lib/node/arduino-firmata/.built* \
+		$(1)/usr/lib/node/arduino-firmata/.config*
+	# Strip PKG_BUILD_DIR from useless metadata inserted by npm install
+	# https://github.com/npm/npm/issues/10393
+	# https://github.com/npm/npm/issues/12110
+	find $(1)/usr/lib/node -name package.json -exec sed -i -e 's,$(PKG_BUILD_DIR),,g' {} +
 	$(CP) ./files/* $(1)/
 endef
 

--- a/lang/node-cylon/Makefile
+++ b/lang/node-cylon/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=cylon
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=0.24.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/hybridgroup/cylon-firmata.git
@@ -20,7 +20,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz
 PKG_MIRROR_HASH:=dceb75539d32f402db0a5f68f2c7e2b52e5547a5ac2dec875d34fd3cc95cce00
 
 PKG_BUILD_DEPENDS:=node/host
-PKG_NODE_VERSION:=8.10.0
+PKG_NODE_VERSION:=`$(STAGING_DIR_HOSTPKG)/bin/node --version`
 
 PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>
 PKG_LICENSE:=Apache-2.0
@@ -67,8 +67,8 @@ EXTRA_LDFLAGS="-L$(TOOLCHAIN_DIR)/lib/ -Wl,-rpath-link $(TOOLCHAIN_DIR)/lib/" \
 define Build/Compile
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(CONFIG_ARCH) \
-	npm_config_nodedir=$(BUILD_DIR)/node-v$(PKG_NODE_VERSION)/ \
-	npm_config_cache=$(BUILD_DIR)/node-v$(PKG_NODE_VERSION)/npm-cache \
+	npm_config_nodedir=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/ \
+	npm_config_cache=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/npm-cache \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
 	npm install -g $(PKG_BUILD_DIR)
 endef
@@ -91,6 +91,10 @@ endef
 define Package/node-cylon-firmata/install
 	mkdir -p $(1)/usr/lib/node/cylon-firmata
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/cylon-firmata/{index.js,lib,LICENSE,package.json,README.md,RELEASES.md,spec} $(1)/usr/lib/node/cylon-firmata/
+	# Strip PKG_BUILD_DIR from useless metadata inserted by npm install
+	# https://github.com/npm/npm/issues/10393
+	# https://github.com/npm/npm/issues/12110
+	find $(1)/usr/lib/node -name package.json -exec sed -i -e 's,$(PKG_BUILD_DIR),,g' {} +
 endef
 
 $(eval $(call BuildPackage,node-cylon))

--- a/lang/node-hid/Makefile
+++ b/lang/node-hid/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=hid
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=0.7.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/node-hid/node-hid.git
@@ -19,8 +19,8 @@ PKG_SOURCE_VERSION:=v0.7.2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
 PKG_MIRROR_HASH:=ede801a26a23290ab76d64ab636c3c3e2788030bb830af7006d37444c2a7b2c4
 
-PKG_BUILD_DEPENDS:=node/host libudev-fbsd
-PKG_NODE_VERSION:=8.10.0
+PKG_BUILD_DEPENDS:=node/host
+PKG_NODE_VERSION:=`$(STAGING_DIR_HOSTPKG)/bin/node --version`
 
 PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>
 PKG_LICENSE:=Custom
@@ -50,15 +50,24 @@ define Build/Compile
 	$(MAKE_VARS) \
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(CONFIG_ARCH) \
-	npm_config_nodedir=$(BUILD_DIR)/node-v$(PKG_NODE_VERSION)/ \
-	npm_config_cache=$(BUILD_DIR)/node-v$(PKG_NODE_VERSION)/npm-cache \
+	npm_config_nodedir=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/ \
+	npm_config_cache=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/npm-cache \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
 	npm install --build-from-source --target_arch=$(CPU) -g $(PKG_BUILD_DIR)
 endef
 
 define Package/node-hid/install
 	mkdir -p $(1)/usr/lib/node/node-hid/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/ $(1)/usr/lib/node/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/. $(1)/usr/lib/node/
+	$(RM) -rf $(1)/usr/lib/node/node-hid/patches \
+		  $(1)/usr/lib/node/node-hid/.p* \
+		  $(1)/usr/lib/node/node-hid/.quilt* \
+		  $(1)/usr/lib/node/node-hid/.built* \
+		  $(1)/usr/lib/node/node-hid/.config*
+	# Strip PKG_BUILD_DIR from useless metadata inserted by npm install
+	# https://github.com/npm/npm/issues/10393
+	# https://github.com/npm/npm/issues/12110
+	find $(1)/usr/lib/node -name package.json -exec sed -i -e 's,$(PKG_BUILD_DIR),,g' {} +
 endef
 
 $(eval $(call BuildPackage,node-hid))

--- a/lang/node-serialport/Makefile
+++ b/lang/node-serialport/Makefile
@@ -10,14 +10,14 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=serialport
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=6.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=http://registry.npmjs.org/$(PKG_NPM_NAME)/-/
 PKG_HASH:=b58c326d217fb0af1639e4ea834d9fca4be16934c486499e2ddac6e52b8dd560
 
 PKG_BUILD_DEPENDS:=node/host
-PKG_NODE_VERSION:=8.10.0
+PKG_NODE_VERSION:=`$(STAGING_DIR_HOSTPKG)/bin/node --version`
 
 PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>
 PKG_LICENSE:=Custom
@@ -50,8 +50,8 @@ EXTRA_LDFLAGS="-L$(TOOLCHAIN_DIR)/lib/ -Wl,-rpath-link $(TOOLCHAIN_DIR)/lib/" \
 define Build/Compile
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(CONFIG_ARCH) \
-	npm_config_nodedir=$(BUILD_DIR)/node-v$(PKG_NODE_VERSION)/ \
-	npm_config_cache=$(BUILD_DIR)/node-v$(PKG_NODE_VERSION)/npm-cache \
+	npm_config_nodedir=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/ \
+	npm_config_cache=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/npm-cache \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
 	npm install --build-from-source --target_arch=$(CPU) -g $(PKG_BUILD_DIR)
 endef
@@ -59,6 +59,15 @@ endef
 define Package/node-serialport/install
 	mkdir -p $(1)/usr/lib/node/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/* $(1)/usr/lib/node/
+	$(RM) -rf $(1)/usr/lib/node/node-hid/patches \
+		  $(1)/usr/lib/node/node-hid/.p* \
+		  $(1)/usr/lib/node/node-hid/.quilt* \
+		  $(1)/usr/lib/node/node-hid/.built* \
+		  $(1)/usr/lib/node/node-hid/.config*
+	# Strip PKG_BUILD_DIR from useless metadata inserted by npm install
+	# https://github.com/npm/npm/issues/10393
+	# https://github.com/npm/npm/issues/12110
+	find $(1)/usr/lib/node -name package.json -exec sed -i -e 's,$(PKG_BUILD_DIR),,g' {} +
 endef
 
 $(eval $(call BuildPackage,node-serialport))


### PR DESCRIPTION
Maintainer: @blogic 
Compile tested: brcm47xx (mipsel-mips32) & ramips (mipsel-74kc), openwrt master
Run tested: none

Description:
Get node version from the node executable instead of keeping it hard-coded to the Makefile.

Current version of `npm install` installs a symlink to the build directory, instead of copying it.
The workaround is to use `npm pack` to make a tarball and install from that.
`npm install` also adds useless metadata to `package.json` exposing `PKG_BUILD_DIR`, so it needs to be stripped.

I'm also removing some build-status files (`patches`, `.built*`, `.configured`, etc.)

I'm adding multiple packages to a single PR since they all basically share the same problem, fix, and maintainer.

I am not able to run test this, so I've compared the package files with the 17.01 packages, which were the last ones--that I know of--built and shipped.  They look to be OK.

There are other ways to fix this, for example, dumping npm and using yarn instead; using a package that strips all of the useless junk from package.json (https://www.npmjs.com/package/removeNPMAbsolutePaths). However, since I'm not experienced enough with node.js, I've decided to make the fewest changes.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>