### PR TITLE
radicale: Update to 2.1.9

### DIFF
--- a/net/radicale/Makefile
+++ b/net/radicale/Makefile
@@ -7,19 +7,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale
-PKG_VERSION:=1.1.6
+PKG_VERSION:=2.1.9
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
 
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/Kozea/Radicale/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=e28d8fdfe5a7962492fddcc3a5911df1fe73e04a355313c97ffaddbe28a19a92
+PKG_BUILD_DIR:=$(BUILD_DIR)/Radicale-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
-
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL=https://github.com/Kozea/Radicale
-PKG_SOURCE_VERSION:=7568ec39f09a753217fb2d525c5f8db64f4d98f4
-PKG_MIRROR_HASH:=73de51e296479f860d4d8cd383a6aa34e8c702d9fca63b0499c7fcc2e794e6df
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_SUBDIR=$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python-package.mk
@@ -32,7 +30,7 @@ define Package/radicale/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
-  URL:=http://radicale.org/
+  URL:=https://radicale.org/
   TITLE:=Radicale CalDAV/CardDAV server
   PKGARCH:=all
   USERID:=radicale=5232:radicale=5232

--- a/net/radicale/patches/010-Run-as-user-group-radicale-radicale.patch
+++ b/net/radicale/patches/010-Run-as-user-group-radicale-radicale.patch
@@ -4,14 +4,14 @@ Patch to run Radicale service as radicale:radicale non root user
 
 Signed-off-by: Christian Schoenebeck <christian.schoenebeck@gmail.com>
 ---
- bin/radicale | 7 +++++++
+ radicale.py | 7 +++++++
  1 file changed, 7 insertions(+)
 
-diff --git a/bin/radicale b/bin/radicale
+diff --git a/radicale.py b/radicale.py
 index 619aca5..7466020 100755
---- a/bin/radicale
-+++ b/bin/radicale
-@@ -26,6 +26,13 @@ Launch the server according to configuration and command-line options.
+--- a/radicale.py
++++ b/radicale.py
+@@ -25,6 +25,13 @@ Launch the server according to configuration and command-line options.
  
  """
  
@@ -24,7 +24,7 @@ index 619aca5..7466020 100755
 +
  import radicale.__main__
  
- 
+ radicale.__main__.run()
 -- 
 2.1.0
 


### PR DESCRIPTION
Switched to codeload for simpler Makefile and more consistent behavior.

Reorganized to better match other packages as well.

Refreshed patch.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @chris5560 
