### PR TITLE
travelmate: update 1.2.2

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.2.1
+PKG_VERSION:=1.2.2
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -22,6 +22,7 @@ start_service()
     then
         procd_open_instance "travelmate"
         procd_set_param command "${trm_script}" "${@}"
+        procd_set_param pidfile "${trm_pidfile}"
         procd_set_param stdout 1
         procd_set_param stderr 1
         procd_close_instance
@@ -31,15 +32,12 @@ start_service()
 reload_service()
 {
     [ -s "${trm_pidfile}" ] && return 1
-    "${trm_init}" restart
+    rc_procd start_service
 }
 
 stop_service()
 {
-    local rtfile="$(uci_get travelmate global trm_rtfile)"
-
-    rtfile="${rtfile:-"/tmp/trm_runtime.json"}"
-    > "${rtfile}"
+    rc_procd "${trm_script}" stop
     rc_procd start_service
 }
 

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-trm_ver="1.2.1"
+trm_ver="1.2.2"
 trm_sysver="unknown"
 trm_enabled=0
 trm_debug=0
@@ -52,9 +52,7 @@ f_envload()
 
     # (re-)initialize global list variables
     #
-    trm_devlist=""
-    trm_stalist=""
-    trm_radiolist=""
+    unset trm_devlist trm_stalist trm_radiolist
 
     # load config and check 'enabled' option
     #
@@ -69,10 +67,6 @@ f_envload()
     if [ ${trm_enabled} -ne 1 ]
     then
         f_log "info" "travelmate is currently disabled, please set 'trm_enabled' to '1' to use this service"
-        config_load wireless
-        config_foreach f_prep wifi-iface
-        uci_commit wireless
-        ubus call network reload
         exit 0
     fi
 
@@ -134,7 +128,7 @@ f_prep()
 #
 f_check()
 {
-    local ifname radio dev_status config sta_essid sta_bssid result wait=1 mode="${1}" status="${2:-"false"}" IFS=" "
+    local IFS ifname radio dev_status config sta_essid sta_bssid result wait=1 mode="${1}" status="${2:-"false"}"
 
     trm_ifquality=0
     trm_ifstatus="false"
@@ -167,7 +161,7 @@ f_check()
                     ifname="${trm_devlist}"
                     break
                 else
-                    trm_devlist=""
+                    unset trm_devlist
                 fi
             elif [ "${mode}" = "rev" ]
             then
@@ -225,7 +219,7 @@ f_jsnup()
     then
         status="connected (${trm_connection:-"-"})"
     else
-        trm_connection=""
+        unset trm_connection
         if [ "${status}" = "false" ]
         then
             status="not connected"
@@ -261,7 +255,6 @@ f_jsnup()
     json_add_string "last_rundate" "$(/bin/date "+%d.%m.%Y %H:%M:%S")"
     json_add_string "system" "${trm_sysver}"
     json_dump > "${trm_rtfile}"
-
     f_log "debug" "f_jsnup::: config: ${config:-"-"}, status: ${status:-"-"}, sta_iface: ${sta_iface:-"-"}, sta_radio: ${sta_radio:-"-"}, sta_essid: ${sta_essid:-"-"}, sta_bssid: ${sta_bssid:-"-"}, faulty_list: ${faulty_list:-"-"}"
 }
 
@@ -274,12 +267,12 @@ f_log()
 
     if [ -n "${log_msg}" ] && ([ "${class}" != "debug" ] || [ ${trm_debug} -eq 1 ])
     then
-        logger -p "${class}" -t "travelmate-[${trm_ver}]" "${log_msg}"
+        logger -p "${class}" -t "travelmate-${trm_ver}[${$}]" "${log_msg}"
         if [ "${class}" = "err" ]
         then
             trm_ifstatus="error"
             f_jsnup
-            logger -p "${class}" -t "travelmate-[${trm_ver}]" "Please check 'https://github.com/openwrt/packages/blob/master/net/travelmate/files/README.md' (${trm_sysver})"
+            logger -p "${class}" -t "travelmate-${trm_ver}[${$}]" "Please check 'https://github.com/openwrt/packages/blob/master/net/travelmate/files/README.md' (${trm_sysver})"
             exit 1
         fi
     fi
@@ -289,7 +282,7 @@ f_log()
 #
 f_main()
 {
-    local cnt dev config scan scan_list scan_essid scan_bssid scan_quality sta sta_essid sta_bssid sta_radio sta_iface IFS=" " faulty_list
+    local IFS cnt dev config scan scan_list scan_essid scan_bssid scan_quality sta sta_essid sta_bssid sta_radio sta_iface faulty_list
 
     f_check "initial"
     if [ "${trm_ifstatus}" != "true" ]
@@ -298,10 +291,7 @@ f_main()
         config_foreach f_prep wifi-iface
         uci_commit wireless
         f_check "dev" "running"
-        if [ -s "${trm_rtfile}" ]
-        then
-            json_get_var faulty_list "faulty_stations"
-        fi
+        json_get_var faulty_list "faulty_stations"
         f_log "debug" "f_main ::: iwinfo: ${trm_iwinfo}, dev_list: ${trm_devlist}, sta_list: ${trm_stalist:0:800}, faulty_list: ${faulty_list:-"-"}"
         for dev in ${trm_devlist}
         do
@@ -310,7 +300,7 @@ f_main()
                 continue
             fi
             cnt=1
-            while [ ${trm_maxretry} -eq 0 ] || [ ${cnt} -le ${trm_maxretry} ]
+            while [ ${cnt} -le ${trm_maxretry} ]
             do
                 scan_list="$(${trm_iwinfo} "${dev}" scan 2>/dev/null | awk 'BEGIN{FS="[/ ]"}/Address:/{var1=$NF}/ESSID:/{var2="";for(i=12;i<=NF;i++)if(var2==""){var2=$i}else{var2=var2" "$i}}/Quality:/{printf "%i,%s,%s\n",(100/$NF*$(NF-1)),var1,var2}' | sort -rn | awk '{ORS=",";print $0}')"
                 f_log "debug" "f_main ::: dev: ${dev}, scan_list: ${scan_list:0:800}, cnt: ${cnt}, max_cnt: ${trm_maxretry}"
@@ -323,6 +313,7 @@ f_main()
                         sta_essid="$(uci_get wireless "${config}" ssid)"
                         sta_bssid="$(uci_get wireless "${config}" bssid)"
                         sta_iface="$(uci_get wireless "${config}" network)"
+                        json_get_var faulty_list "faulty_stations"
                         if [ -n "$(printf "%s" "${faulty_list}" | grep -Fo "${sta_radio}/${sta_essid}/${sta_bssid}")" ]
                         then
                             continue
@@ -353,30 +344,31 @@ f_main()
                                         if [ "${trm_ifstatus}" = "true" ]
                                         then
                                             uci_commit wireless
-                                            f_log "info" "interface '${sta_iface}' on '${sta_radio}' connected to uplink '${sta_essid:-"-"}/${sta_bssid:-"-"}' (${trm_sysver})"
+                                            f_check "initial"
+                                            f_log "info" "connected to uplink '${sta_radio}/${sta_essid}/${sta_bssid:-"-"}' (${trm_sysver})"
                                             return 0
                                         elif [ ${cnt} -eq ${trm_maxretry} ]
                                         then
                                             uci_set wireless "${config}" disabled 1
                                             uci_commit wireless
-                                            faulty_station="${sta_radio}/${sta_essid}/${sta_bssid}"
+                                            faulty_station="${sta_radio}/${sta_essid}/${sta_bssid:-"-"}"
                                             f_jsnup "${faulty_station}"
-                                            f_log "info" "can't connect to uplink '${sta_essid:-"-"}/${sta_bssid:-"-"}', uplink disabled (${trm_sysver})"
+                                            f_log "info" "can't connect to uplink '${sta_radio}/${sta_essid}/${sta_bssid:-"-"}', uplink disabled (${trm_sysver})"
                                             f_check "rev"
+                                            break
                                         else
                                             uci -q revert wireless
                                             f_jsnup
-                                            f_log "info" "can't connect to uplink '${sta_essid:-"-"}/${sta_bssid:-"-"}' (${trm_sysver})"
+                                            f_log "info" "can't connect to uplink '${sta_radio}/${sta_essid}/${sta_bssid:-"-"}' (${trm_sysver})"
                                             f_check "rev"
+                                            break
                                         fi
                                     fi
                                 fi
-                                scan_quality=""
-                                scan_bssid=""
-                                scan_essid=""
+                                unset scan_quality scan_bssid scan_essid
                             fi
                         done
-                        IFS=" "
+                        unset IFS scan_quality scan_bssid scan_essid
                     done
                 fi
                 cnt=$(( cnt + 1 ))
@@ -421,13 +413,16 @@ while true
 do
     if [ -z "${trm_action}" ]
     then
-        > "${trm_pidfile}"
         sleep ${trm_timeout}
+    elif [ "${trm_action}" = "stop" ]
+    then
+        > "${trm_rtfile}"
+        f_log "info" "travelmate instance stopped ::: action: ${trm_action}, pid: $(cat ${trm_pidfile} 2>/dev/null)"
+        exit 0
     else
-        printf '%s' "${$}" > "${trm_pidfile}"
-        trm_action=""
+        f_log "info" "travelmate instance started ::: action: ${trm_action}, pid: ${$}"
+        unset trm_action
     fi
     f_envload
     f_main
 done
-


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL-AR750, OpenWrt SNAPSHOT r7744-a692e4e3de

Description:
* fix restart behaviour after successful connection
* fix labeling of faulty stations
* optimize re-connect behaviour at locations where multiple uplinks with the same SSID are in range
* use procd pidfile handling
* refine logging
* small fixes

Signed-off-by: Dirk Brenken <dev@brenken.org>
