### PR TITLE
nginx: Fix warnings while compile rtmp and ts modules

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.15.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://nginx.org/download/
@@ -439,7 +439,7 @@ ifeq ($(CONFIG_NGINX_RTMP_MODULE),y)
   $(eval $(call Download,nginx-rtmp))
 
   define  Prepare/nginx-rtmp
-	$(eval $(call Download,nginx-rtmp))
+	$(eval $(Download/nginx-rtmp))
 	gzip -dc $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
   endef
 endif
@@ -457,7 +457,7 @@ ifeq ($(CONFIG_NGINX_TS_MODULE),y)
   $(eval $(call Download,nginx-ts))
 
   define  Prepare/nginx-ts
-	$(eval $(call Download,nginx-ts))
+	$(eval $(Download/nginx-ts))
 	gzip -dc $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
   endef
 endif


### PR DESCRIPTION
Description:
Compile nginx with rtmp and ts modules will got some warnings below for several times:

>``make[2]: Entering directory `/home/travis/build/openwrt/packages/net/nginx'
Makefile:523: warning: overriding commands for target `/tmp/tmp.nxWyAOihhf/dl/ngx-rtmp-module-1.15.2-791b6136f02bc9613daf178723ac09f4df5a3bbf.tar.gz'
Makefile:442: warning: ignoring old commands for target `/tmp/tmp.nxWyAOihhf/dl/ngx-rtmp-module-1.15.2-791b6136f02bc9613daf178723ac09f4df5a3bbf.tar.gz'
Makefile:523: warning: overriding commands for target `/tmp/tmp.nxWyAOihhf/dl/ngx-ts-module-1.15.2-ef2f874d95cc75747eb625a292524a702aefb0fd.tar.gz'
Makefile:460: warning: ignoring old commands for target `/tmp/tmp.nxWyAOihhf/dl/ngx-ts-module-1.15.2-ef2f874d95cc75747eb625a292524a702aefb0fd.tar.gz'``

----------
Maintainer: none
Compile tested: marvell mvebu, 6031ab345df86c285ea55d6523d6888cc596f63d
Run tested: marvell mvebu, 6031ab345df86c285ea55d6523d6888cc596f63d

Please check it, Thanks! @Ansuel