### PR TITLE
lua-lsqlite3: update to 0.9.5

### DIFF
--- a/lang/lua-lsqlite3/Makefile
+++ b/lang/lua-lsqlite3/Makefile
@@ -8,18 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lsqlite3
-PKG_VERSION:=0.9.3
+PKG_VERSION:=0.9.5
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=http://lua.sqlite.org/index.cgi/zip/lsqlite3_fsl09w.zip
-PKG_HASH:=b857df8b66d01a803378cc86e56b787958beffdc8b851ad304f4ce8c7f0e9dbb
+PKG_SOURCE:=lsqlite3_fsl09y.zip
+PKG_SOURCE_URL:=http://lua.sqlite.org/index.cgi/zip/
+PKG_HASH:=d38402aa7640055d260c1246c36e6d6d31b425a25a805431f13695694466b722
 
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/$(PKG_NAME)_fsl09w.zip
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(basename $(PKG_SOURCE))
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -38,21 +37,21 @@ endef
 
 TARGET_CFLAGS += $(FPIC) -std=gnu99
 TARGET_CPPFLAGS += -DLUA_USE_LINUX
-TARGET_LDFLAGS += -llua -lsqlite3 -lpthread
+TARGET_LDFLAGS += -lsqlite3 -lpthread
 
 define Build/Compile
 	$(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_CPPFLAGS) \
-		-c $(PKG_BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/lsqlite3.c \
-		-o $(PKG_BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/lsqlite3.o \
-		-DSQLITE_VERSION="$(PKG_VERSION)"
+		-c $(PKG_BUILD_DIR)/lsqlite3.c \
+		-o $(PKG_BUILD_DIR)/lsqlite3.o \
+		-DLSQLITE_VERSION=\"$(PKG_VERSION)\"
 	$(TARGET_CC) $(TARGET_LDFLAGS) -shared \
-		$(PKG_BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/lsqlite3.o \
-		-o $(PKG_BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/lsqlite3.so
+		$(PKG_BUILD_DIR)/lsqlite3.o \
+		-o $(PKG_BUILD_DIR)/lsqlite3.so
 endef
 
 define Package/lsqlite3/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua
-	$(CP) $(PKG_BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/*.so $(1)/usr/lib/lua/
+	$(CP) $(PKG_BUILD_DIR)/*.so $(1)/usr/lib/lua/
 endef
 
 $(eval $(call BuildPackage,lsqlite3))


### PR DESCRIPTION
Changes in the package
* ability to pass flags to the open() calls
* multithreading helpers

Full log at http://lua.sqlite.org/index.cgi/artifact/cc0df52dfc332ae0

Changes in packaging
* actually use PKG_BUILD_DIR
* Work with current upstream sources.  (current release only builds
because it's archived on openwrt servers)
* don't link against liblua, this is an anti-pattern
* properly specify the LSQLITE version instead of overriding the SQLITE
version.

Signed-off-by: Karl Palsson <karlp@etactica.com>

Maintainer: @oskarirauta
Compile tested: ar71xx, openwrt 1806 (patch is against master)
Run tested: ar71xx, openwrt1806, checked that sqlite3.version() and lversion() behave, checked that open with sqlite3.OPEN_READONLY correctly fails when the DB doesn't exist now.

