### PR TITLE
postgresql: security bump to 9.6.10

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
-PKG_VERSION:=9.6.8
+PKG_VERSION:=9.6.10
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=\
 	http://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
 	ftp://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
 
-PKG_HASH:=eafdb3b912e9ec34bdd28b651d00226a6253ba65036cb9a41cad2d9e82e3eb70
+PKG_HASH:=8615acc56646401f0ede97a767dfd27ce07a8ae9c952afdb57163b7234fe8426
 
 PKG_USE_MIPS16:=0
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
This update includes fixes for the following CVEs:

- CVE-2018-1115
- CVE-2018-10925
- CVE-2018-10915

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @dangowrt 
Compile tested: ar71xx
Run tested: ar71xx

```
root@hank2:/tmp# opkg install pgsql-server_9.6.10-1_mips_24kc.ipk
Installing pgsql-server (9.6.10-1) to root...
Configuring pgsql-server.
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.

The database cluster will be initialized with locales
  COLLATE:  C
  CTYPE:    C.UTF-8
  MESSAGES: C
  MONETARY: C
  NUMERIC:  C
  TIME:     C
The default database encoding has accordingly been set to "UTF8".
The default text search configuration will be set to "english".

Data page checksums are disabled.

creating directory /var/postgresql/data ... ok
creating subdirectories ... ok
selecting default max_connections ... 100
selecting default shared_buffers ... 128MB
selecting dynamic shared memory implementation ... posix
creating configuration files ... ok
running bootstrap script ... ok
performing post-bootstrap initialization ... sh: locale: not found
No usable system locales were found.
Use the option "--debug" to see details.
ok
syncing data to disk ... ok

WARNING: enabling "trust" authentication for local connections
You can change this by editing pg_hba.conf or using the option -A, or
--auth-local and --auth-host, the next time you run initdb.

Success. You can now start the database server using:

    /usr/bin/pg_ctl -D /var/postgresql/data -l logfile start

root@hank2:/tmp# /usr/bin/psql -l -U postgres
                              List of databases
   Name    |  Owner   | Encoding | Collate |  Ctype  |   Access privileges   
-----------+----------+----------+---------+---------+-----------------------
 postgres  | postgres | UTF8     | C       | C.UTF-8 | 
 template0 | postgres | UTF8     | C       | C.UTF-8 | =c/postgres          +
           |          |          |         |         | postgres=CTc/postgres
 template1 | postgres | UTF8     | C       | C.UTF-8 | =c/postgres          +
           |          |          |         |         | postgres=CTc/postgres
(3 rows)

root@hank2:~#
```
Description:

Update minor version to get fixes for recent CVEs. The library part is 100% backwards compatible according to [ABI Laboratory](https://abi-laboratory.pro/?view=timeline&l=postgresql).

Kind regards,
Seb