### PR TITLE
postgresql: security bump to 9.6.10 for 18.06

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
-PKG_VERSION:=9.6.8
+PKG_VERSION:=9.6.10
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=\
 	http://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
 	ftp://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
 
-PKG_HASH:=eafdb3b912e9ec34bdd28b651d00226a6253ba65036cb9a41cad2d9e82e3eb70
+PKG_HASH:=8615acc56646401f0ede97a767dfd27ce07a8ae9c952afdb57163b7234fe8426
 
 PKG_USE_MIPS16:=0
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
This update includes fixes for the following CVEs:

- CVE-2018-1115
- CVE-2018-10925
- CVE-2018-10915

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @dangowrt 
Compile tested: ar71xx
Run tested: ar71xx

Description:

Update minor version to get fixes for recent CVEs. The library part is 100% backwards compatible according to [ABI Laboratory](https://abi-laboratory.pro/?view=timeline&l=postgresql).

Kind regards,
Seb