### PR TITLE
perl: fix include in perlmod.mk

### DIFF
--- a/lang/perl/perlmod.mk
+++ b/lang/perl/perlmod.mk
@@ -1,7 +1,7 @@
 # This makefile simplifies perl module builds.
 #
 
-include ../perl/perlver.mk
+include $(TOPDIR)/feeds/packages/lang/perl/perlver.mk
 
 ifneq ($(PKG_NAME),perl)
   PKG_VERSION:=$(PKG_VERSION)+perl$(PERL_VERSION2)


### PR DESCRIPTION
Commit 0d9584724ff1c011f587540c2d25be8a90a81413 introduced perlver.mk,
which is included by perlmod.mk.

When perlmod.mk is included by Makefiles which are not in the "lang"
directory, this fails. For example, the freeswitch-stable Makefile
includes perlmod.mk and when attempting a build this now fails with:

Makefile:243: /projects/openwrt-18.06/feeds/packages/lang/perl/perlmod.mk:4: ../perl/perlver.mk: No such file or directory

That's because the relative link ../perl/perlver.mk does not work unless
your package is inside the "lang" directory.

To fix this simply specify the full path.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @pprindeville 
Compile tested: ar71xx
Run tested: N/A

Description:

Hello Philip,

This fixes an update and build failure caused by recent perl commit as reported by @NickSchaf in telephony issue #364.

Kind regards,
Seb