### PR TITLE
samba4: enable avahi by default, add timemachine support

### DIFF
--- a/net/samba4/Config.in
+++ b/net/samba4/Config.in
@@ -30,17 +30,18 @@ config SAMBA4_SERVER_AD_DC
 config SAMBA4_SERVER_AVAHI
 	bool "Avahi support"
 	depends on PACKAGE_samba4-server
+	select SAMBA4_SERVER_VFS
 	select PACKAGE_libavahi-client
 	help
-		Announce Samba resources via DNS/DNS-SD using the Avahi daemon
-	default n
+		Announce Samba resources via DNS/DNS-SD using the Avahi daemon, for Linux/Mac clients.
+	default y
 
 config SAMBA4_SERVER_VFS
 	bool "Common VFS modules"
 	depends on PACKAGE_samba4-server
 	help
 		installs:
-			modules: (vfs_btrfs) vfs_fruit vfs_shadow_copy2 vfs_recycle vfs_fake_perms vfs_readonly vfs_cap vfs_offline vfs_crossrename
+			modules: (vfs_btrfs) vfs_fruit vfs_shadow_copy2 vfs_recycle vfs_fake_perms vfs_readonly vfs_cap vfs_offline vfs_crossrename vfs_catia vfs_streams_xattr
 
 		Commonly used VFS modules, vfs_btrfs requires kmod-fs-btrfs to be selected separately
         default y
@@ -60,7 +61,7 @@ config SAMBA4_SERVER_VFSX
 	depends on PACKAGE_samba4-server
 	help
 		installs:
-			modules: vfs_virusfilter vfs_shell_snap vfs_commit vfs_worm vfs_xattr_tdb vfs_streams_xattr vfs_aio_fork vfs_aio_pthread (vfs_linux_xfs_sgid) vfs_netatalk vfs_dirsort vfs_fileid vfs_catia
+			modules: vfs_virusfilter vfs_shell_snap vfs_commit vfs_worm vfs_xattr_tdb vfs_aio_fork vfs_aio_pthread (vfs_linux_xfs_sgid) vfs_netatalk vfs_dirsort vfs_fileid
 
 		Additional VFS modules that aren't commonly used, vfs_linux_xfs_sgid requires kmod-fs-xfs to be selected separately
 	default n

--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
 PKG_VERSION:=4.8.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only
@@ -275,10 +275,9 @@ BUILD_TARGETS_ADMIN :=net,smbcontrol,profiles,rpcclient,smbcacls,smbcquotas
 BUILD_TARGETS_UTILS :=smbstatus,smbtree,smbget,mvxattr,nmblookup
 
 # lib bundling
-# NOTE: Compile some unique libs into related bins, so we end-up with a unified samba4-libs base, mainly to allow package separation (server, client, admin, utils)
-CONFIGURE_ARGS += --builtin-libraries=smbclient,netapi,samba-passdb,ads,auth,cli-spoolss,libcli-lsa3,gpext,talloc,tevent,texpect,tdb,ldb,tdr,cmocka,replace
-#CONFIGURE_ARGS += --nonshared-binary=$(BUILD_TARGETS_SERVER)
 # NOTE: bundle + make private, we want to avoid version configuration (build, link) conflicts
+CONFIGURE_ARGS += --builtin-libraries=talloc,tevent,texpect,tdb,ldb,tdr,cmocka,replace
+#CONFIGURE_ARGS += --nonshared-binary=$(BUILD_TARGETS_SERVER)
 ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
 CONFIGURE_ARGS += --bundled-libraries=talloc,tevent,texpect,tdb,ldb,tdr,cmocka,replace,pytalloc-util,pyldb-util,NONE
 else

--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -22,11 +22,12 @@ smb_header() {
 	local name workgroup description charset
 	local hostname="$(uci_get system.@system[0].hostname)"
 
-	config_get name        		$1 name        	"${hostname:-OpenWrt}"
-	config_get workgroup   		$1 workgroup   	"${hostname:-WORKGROUP}"
-	config_get description 		$1 description 	"Samba on ${hostname:-OpenWrt}"
-	config_get charset  		$1 charset     	"UTF-8"
-
+	config_get name				$1 name			"${hostname:-OpenWrt}"
+	config_get workgroup		$1 workgroup	"${hostname:-WORKGROUP}"
+	config_get description		$1 description	"Samba on ${hostname:-OpenWrt}"
+	config_get charset			$1 charset		"UTF-8"
+	
+	config_get_bool MACOS			$1 macos			0
 	config_get_bool DISABLE_NETBIOS	$1 disable_netbios	0
 	config_get_bool DISABLE_AD_DC	$1 disable_ad_dc	0
 	config_get_bool DISABLE_WINBIND	$1 disable_winbind	0
@@ -65,43 +66,44 @@ smb_add_share() {
 	local name
 	local path
 	local users
-	local public
-	local writable
-	local printable
 	local create_mask
-
+	local dir_mask
 	local browseable
 	local read_only
 	local guest_ok
 	local guest_only
 	local inherit_owner
 	local vfs_objects
+	local timemachine
+	local timemachine_maxsize
+	local force_root
 
 	config_get name $1 name
 	config_get path $1 path
 	config_get users $1 users
-	config_get public $1 public
-	config_get writable $1 writable
-	config_get printable $1 printable
 	config_get create_mask $1 create_mask
 	config_get dir_mask $1 dir_mask
-
-
 	config_get browseable $1 browseable
 	config_get read_only $1 read_only
 	config_get guest_ok $1 guest_ok
 	config_get guest_only $1 guest_only
 	config_get inherit_owner $1 inherit_owner
 	config_get vfs_objects $1 vfs_objects
-
+	config_get_bool timemachine	$1 timemachine	0
+	config_get timemachine_maxsize $1 timemachine_maxsize
+	config_get_bool force_root	$1 force_root	0
 
 	[ -z "$name" -o -z "$path" ] && return
 
 	echo -e "\n[$name]\n\tpath = $path" >> /var/etc/smb.conf
-	[ -n "$users" ] && echo -e "\tvalid users = $users" >> /var/etc/smb.conf
-	[ -n "$public" ] && echo -e "\tpublic = $public" >> /var/etc/smb.conf
-	[ -n "$writable" ] && echo -e "\twritable = $writable" >> /var/etc/smb.conf
-	[ -n "$printable" ] && echo -e "\tprintable = $printable" >> /var/etc/smb.conf
+	
+	if [ "$force_root" -eq 1 ]; then
+		echo -e "\tforce user = root" >> /var/etc/smb.conf
+		echo -e "\tforce group = root" >> /var/etc/smb.conf
+	else
+		[ -n "$users" ] && echo -e "\tvalid users = $users" >> /var/etc/smb.conf
+	fi
+
 	[ -n "$create_mask" ] && echo -e "\tcreate mask = $create_mask" >> /var/etc/smb.conf
 	[ -n "$dir_mask" ] && echo -e "\tdirectory mask = $dir_mask" >> /var/etc/smb.conf
 
@@ -110,6 +112,19 @@ smb_add_share() {
 	[ -n "$guest_ok" ] && echo -e "\tguest ok = $guest_ok" >> /var/etc/smb.conf
 	[ -n "$guest_only" ] && echo -e "\tguest only = $guest_only" >> /var/etc/smb.conf
 	[ -n "$inherit_owner" ] && echo -e "\tinherit owner = $inherit_owner" >> /var/etc/smb.conf
+	
+	if [ "$MACOS" -eq 1 ]; then
+		vfs_objects="catia fruit streams_xattr $vfs_objects"
+		echo -e "\tfruit:encoding = native" >> /var/etc/smb.conf
+		echo -e "\tfruit:metadata = stream" >> /var/etc/smb.conf
+		echo -e "\tfruit:veto_appledouble = no" >> /var/etc/smb.conf
+		# avoid mixed shares order for aapl
+		if [ "$timemachine" -eq 1 ]; then
+			echo -e "\tfruit:time machine = yes" >> /var/etc/smb.conf
+			[ -n "$timemachine_maxsize" ] && echo -e "\tfruit:time machine max size = ${timemachine_maxsize}G" >> /var/etc/smb.conf
+		fi
+	fi
+	
 	[ -n "$vfs_objects" ] && echo -e "\tvfs objects = $vfs_objects" >> /var/etc/smb.conf
 }
 
@@ -150,7 +165,7 @@ service_triggers() {
 start_service() {
 	init_config
 
-	# start main AC-DC daemon, will spawn (smbd,nmbd,winbindd) as needed/configured.
+	# start main AD-DC daemon, will spawn (smbd,nmbd,winbindd) as needed/configured.
 	if [ "$DISABLE_AD_DC" -ne 1 ] && [ -x /usr/sbin/samba ]; then
 		procd_open_instance
 		procd_set_param command /usr/sbin/samba -F

--- a/net/samba4/files/smb.conf.template
+++ b/net/samba4/files/smb.conf.template
@@ -69,7 +69,7 @@
 	## Allows the server name that is advertised through MDNS to be set to the hostname rather than the Samba NETBIOS name.
 	## This allows an administrator to make Samba registered MDNS records match the case of the hostname rather than being in all capitals.
 	## (netbios, mdns)
-	#mdns name = mdns
+	mdns name = mdns
 	
 	## Clients that only support netbios won't be able to see your samba server when netbios support is disabled.
 	#disable netbios = Yes


### PR DESCRIPTION
Maintainer: me
Compile tested: arm/mips (master)
Run tested: arm

Description: 
* enable avahi by default, so Linux/Mac/Mobile Clients can see samba shares
* enable timemachine config support
* fix invalid --builtin-libraries
* default to 'mdns name = mdns' in template

The goal is to allow Linux/Mac clients to also see samba shares out of the box. I tried to create variant packages for the server, but the way samba bundles its libs, makes this nearly impossible and you either end up, with multiple duplicated packages per variant or need to statically link the smbd, which results in 20MB+ size increase. So i ended up with a default config change, that works for most users, even if its slightly larger _(300kb)_.

Updated Luci-app PR: openwrt/luci#2071