### PR TITLE
tiff: Fix remaining CVEs

### DIFF
--- a/libs/tiff/Makefile
+++ b/libs/tiff/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tiff
 PKG_VERSION:=4.0.9
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.osgeo.org/libtiff
@@ -20,7 +20,9 @@ PKG_REMOVE_FILES:=autogen.sh aclocal.m4
 
 PKG_LICENSE:=BSD
 PKG_LICENSE_FILES:=COPYRIGHT
+PKG_CPE_ID:=cpe:/a:libtiff:libtiff
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_libtiffxx

--- a/libs/tiff/patches/020-CVE-2018-5784.patch
+++ b/libs/tiff/patches/020-CVE-2018-5784.patch
@@ -1,0 +1,128 @@
+From 49723b0eb683cca80142b01a48ba1475fed5188a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nikola=20Forr=C3=B3?= <nforro@redhat.com>
+Date: Fri, 23 Mar 2018 15:35:39 +0100
+Subject: [PATCH] Fix for bug 2772
+
+It is possible to craft a TIFF document where the IFD list is circular,
+leading to an infinite loop while traversing the chain. The libtiff
+directory reader has a failsafe that will break out of this loop after
+reading 65535 directory entries, but it will continue processing,
+consuming time and resources to process what is essentially a bogus TIFF
+document.
+
+This change fixes the above behavior by breaking out of processing when
+a TIFF document has >= 65535 directories and terminating with an error.
+---
+ contrib/addtiffo/tif_overview.c | 14 +++++++++++++-
+ tools/tiff2pdf.c                | 10 ++++++++++
+ tools/tiffcrop.c                | 13 +++++++++++--
+ 3 files changed, 34 insertions(+), 3 deletions(-)
+
+diff --git a/contrib/addtiffo/tif_overview.c b/contrib/addtiffo/tif_overview.c
+index c61ffbb..03b3573 100644
+--- a/contrib/addtiffo/tif_overview.c
++++ b/contrib/addtiffo/tif_overview.c
+@@ -65,6 +65,8 @@
+ #  define MAX(a,b)      ((a>b) ? a : b)
+ #endif
+ 
++#define TIFF_DIR_MAX  65534
++
+ void TIFFBuildOverviews( TIFF *, int, int *, int, const char *,
+                          int (*)(double,void*), void * );
+ 
+@@ -91,6 +93,7 @@ uint32 TIFF_WriteOverview( TIFF *hTIFF, uint32 nXSize, uint32 nYSize,
+ {
+     toff_t	nBaseDirOffset;
+     toff_t	nOffset;
++    tdir_t	iNumDir;
+ 
+     (void) bUseSubIFDs;
+ 
+@@ -147,7 +150,16 @@ uint32 TIFF_WriteOverview( TIFF *hTIFF, uint32 nXSize, uint32 nYSize,
+         return 0;
+ 
+     TIFFWriteDirectory( hTIFF );
+-    TIFFSetDirectory( hTIFF, (tdir_t) (TIFFNumberOfDirectories(hTIFF)-1) );
++    iNumDir = TIFFNumberOfDirectories(hTIFF);
++    if( iNumDir > TIFF_DIR_MAX )
++    {
++        TIFFErrorExt( TIFFClientdata(hTIFF),
++                      "TIFF_WriteOverview",
++                      "File `%s' has too many directories.\n",
++                      TIFFFileName(hTIFF) );
++        exit(-1);
++    }
++    TIFFSetDirectory( hTIFF, (tdir_t) (iNumDir - 1) );
+ 
+     nOffset = TIFFCurrentDirOffset( hTIFF );
+ 
+diff --git a/tools/tiff2pdf.c b/tools/tiff2pdf.c
+index 454befb..bdb9126 100644
+--- a/tools/tiff2pdf.c
++++ b/tools/tiff2pdf.c
+@@ -68,6 +68,8 @@ extern int getopt(int, char**, char*);
+ 
+ #define PS_UNIT_SIZE	72.0F
+ 
++#define TIFF_DIR_MAX    65534
++
+ /* This type is of PDF color spaces. */
+ typedef enum {
+ 	T2P_CS_BILEVEL = 0x01,	/* Bilevel, black and white */
+@@ -1049,6 +1051,14 @@ void t2p_read_tiff_init(T2P* t2p, TIFF* input){
+ 	uint16 xuint16=0;
+ 
+ 	directorycount=TIFFNumberOfDirectories(input);
++	if(directorycount > TIFF_DIR_MAX) {
++		TIFFError(
++			TIFF2PDF_MODULE,
++			"TIFF contains too many directories, %s",
++			TIFFFileName(input));
++		t2p->t2p_error = T2P_ERR_ERROR;
++		return;
++	}
+ 	t2p->tiff_pages = (T2P_PAGE*) _TIFFmalloc(TIFFSafeMultiply(tmsize_t,directorycount,sizeof(T2P_PAGE)));
+ 	if(t2p->tiff_pages==NULL){
+ 		TIFFError(
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index c69177e..c60cb38 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -217,6 +217,8 @@ extern int getopt(int argc, char * const argv[], const char *optstring);
+ #define DUMP_TEXT   1
+ #define DUMP_RAW    2
+ 
++#define TIFF_DIR_MAX  65534
++
+ /* Offsets into buffer for margins and fixed width and length segments */
+ struct offset {
+   uint32  tmargin;
+@@ -2233,7 +2235,7 @@ main(int argc, char* argv[])
+     pageNum = -1;
+   else
+     total_images = 0;
+-  /* read multiple input files and write to output file(s) */
++  /* Read multiple input files and write to output file(s) */
+   while (optind < argc - 1)
+     {
+     in = TIFFOpen (argv[optind], "r");
+@@ -2241,7 +2243,14 @@ main(int argc, char* argv[])
+       return (-3);
+ 
+     /* If only one input file is specified, we can use directory count */
+-    total_images = TIFFNumberOfDirectories(in); 
++    total_images = TIFFNumberOfDirectories(in);
++    if (total_images > TIFF_DIR_MAX)
++      {
++      TIFFError (TIFFFileName(in), "File contains too many directories");
++      if (out != NULL)
++        (void) TIFFClose(out);
++      return (1);
++      }
+     if (image_count == 0)
+       {
+       dirnum = 0;
+-- 
+2.13.6
+

--- a/libs/tiff/patches/021-CVE-2018-7456.patch
+++ b/libs/tiff/patches/021-CVE-2018-7456.patch
@@ -1,0 +1,170 @@
+From de5385cd882a5ff0970f63f4d93da0cbc87230c2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nikola=20Forr=C3=B3?= <nforro@redhat.com>
+Date: Tue, 17 Apr 2018 18:42:09 +0200
+Subject: [PATCH] Fix NULL pointer dereference in TIFFPrintDirectory
+
+The TIFFPrintDirectory function relies on the following assumptions,
+supposed to be guaranteed by the specification:
+
+(a) A Transfer Function field is only present if the TIFF file has
+    photometric type < 3.
+
+(b) If SamplesPerPixel > Color Channels, then the ExtraSamples field
+    has count SamplesPerPixel - (Color Channels) and contains
+    information about supplementary channels.
+
+While respect of (a) and (b) are essential for the well functioning of
+TIFFPrintDirectory, no checks are realized neither by the callee nor
+by TIFFPrintDirectory itself. Hence, following scenarios might happen
+and trigger the NULL pointer dereference:
+
+(1) TIFF File of photometric type 4 or more has illegal Transfer
+    Function field.
+
+(2) TIFF File has photometric type 3 or less and defines a
+    SamplesPerPixel field such that SamplesPerPixel > Color Channels
+    without defining all extra samples in the ExtraSamples fields.
+
+In this patch, we address both issues with respect of the following
+principles:
+
+(A) In the case of (1), the defined transfer table should be printed
+    safely even if it isn't 'legal'. This allows us to avoid expensive
+    checks in TIFFPrintDirectory. Also, it is quite possible that
+    an alternative photometric type would be developed (not part of the
+    standard) and would allow definition of Transfer Table. We want
+    libtiff to be able to handle this scenario out of the box.
+
+(B) In the case of (2), the transfer table should be printed at its
+    right size, that is if TIFF file has photometric type Palette
+    then the transfer table should have one row and not three, even
+    if two extra samples are declared.
+
+In order to fulfill (A) we simply add a new 'i < 3' end condition to
+the broken TIFFPrintDirectory loop. This makes sure that in any case
+where (b) would be respected but not (a), everything stays fine.
+
+(B) is fulfilled by the loop condition
+'i < td->td_samplesperpixel - td->td_extrasamples'. This is enough as
+long as (b) is respected.
+
+Naturally, we also make sure (b) is respected. This is done in the
+TIFFReadDirectory function by making sure any non-color channel is
+counted in ExtraSamples.
+
+This commit addresses CVE-2018-7456.
+---
+ libtiff/tif_dirread.c | 62 +++++++++++++++++++++++++++++++++++++++++++
+ libtiff/tif_print.c   |  2 +-
+ 2 files changed, 63 insertions(+), 1 deletion(-)
+
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+index 5e62e81..80aaf8d 100644
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -167,6 +167,7 @@ static int TIFFFetchStripThing(TIFF* tif, TIFFDirEntry* dir, uint32 nstrips, uin
+ static int TIFFFetchSubjectDistance(TIFF*, TIFFDirEntry*);
+ static void ChopUpSingleUncompressedStrip(TIFF*);
+ static uint64 TIFFReadUInt64(const uint8 *value);
++static int _TIFFGetMaxColorChannels(uint16 photometric);
+ 
+ static int _TIFFFillStrilesInternal( TIFF *tif, int loadStripByteCount );
+ 
+@@ -3506,6 +3507,35 @@ static void TIFFReadDirEntryOutputErr(TIFF* tif, enum TIFFReadDirEntryErr err, c
+ 	}
+ }
+ 
++/*
++ * Return the maximum number of color channels specified for a given photometric
++ * type. 0 is returned if photometric type isn't supported or no default value
++ * is defined by the specification.
++ */
++static int _TIFFGetMaxColorChannels( uint16 photometric )
++{
++    switch (photometric) {
++	case PHOTOMETRIC_PALETTE:
++	case PHOTOMETRIC_MINISWHITE:
++	case PHOTOMETRIC_MINISBLACK:
++            return 1;
++	case PHOTOMETRIC_YCBCR:
++	case PHOTOMETRIC_RGB:
++	case PHOTOMETRIC_CIELAB:
++            return 3;
++	case PHOTOMETRIC_SEPARATED:
++	case PHOTOMETRIC_MASK:
++            return 4;
++	case PHOTOMETRIC_LOGL:
++	case PHOTOMETRIC_LOGLUV:
++	case PHOTOMETRIC_CFA:
++	case PHOTOMETRIC_ITULAB:
++	case PHOTOMETRIC_ICCLAB:
++	default:
++            return 0;
++    }
++}
++
+ /*
+  * Read the next TIFF directory from a file and convert it to the internal
+  * format. We read directories sequentially.
+@@ -3522,6 +3552,7 @@ TIFFReadDirectory(TIFF* tif)
+ 	uint32 fii=FAILED_FII;
+         toff_t nextdiroff;
+     int bitspersample_read = FALSE;
++        int color_channels;
+ 
+ 	tif->tif_diroff=tif->tif_nextdiroff;
+ 	if (!TIFFCheckDirOffset(tif,tif->tif_nextdiroff))
+@@ -4026,6 +4057,37 @@ TIFFReadDirectory(TIFF* tif)
+ 			}
+ 		}
+ 	}
++
++	/*
++	 * Make sure all non-color channels are extrasamples.
++	 * If it's not the case, define them as such.
++	 */
++        color_channels = _TIFFGetMaxColorChannels(tif->tif_dir.td_photometric);
++        if (color_channels && tif->tif_dir.td_samplesperpixel - tif->tif_dir.td_extrasamples > color_channels) {
++                uint16 old_extrasamples;
++                uint16 *new_sampleinfo;
++
++                TIFFWarningExt(tif->tif_clientdata,module, "Sum of Photometric type-related "
++                    "color channels and ExtraSamples doesn't match SamplesPerPixel. "
++                    "Defining non-color channels as ExtraSamples.");
++
++                old_extrasamples = tif->tif_dir.td_extrasamples;
++                tif->tif_dir.td_extrasamples = (tif->tif_dir.td_samplesperpixel - color_channels);
++
++                // sampleinfo should contain information relative to these new extra samples
++                new_sampleinfo = (uint16*) _TIFFcalloc(tif->tif_dir.td_extrasamples, sizeof(uint16));
++                if (!new_sampleinfo) {
++                    TIFFErrorExt(tif->tif_clientdata, module, "Failed to allocate memory for "
++                                "temporary new sampleinfo array (%d 16 bit elements)",
++                                tif->tif_dir.td_extrasamples);
++                    goto bad;
++                }
++
++                memcpy(new_sampleinfo, tif->tif_dir.td_sampleinfo, old_extrasamples * sizeof(uint16));
++                _TIFFsetShortArray(&tif->tif_dir.td_sampleinfo, new_sampleinfo, tif->tif_dir.td_extrasamples);
++                _TIFFfree(new_sampleinfo);
++        }
++
+ 	/*
+ 	 * Verify Palette image has a Colormap.
+ 	 */
+diff --git a/libtiff/tif_print.c b/libtiff/tif_print.c
+index 24d4b98..10a588e 100644
+--- a/libtiff/tif_print.c
++++ b/libtiff/tif_print.c
+@@ -546,7 +546,7 @@ TIFFPrintDirectory(TIFF* tif, FILE* fd, long flags)
+ 				uint16 i;
+ 				fprintf(fd, "    %2ld: %5u",
+ 				    l, td->td_transferfunction[0][l]);
+-				for (i = 1; i < td->td_samplesperpixel; i++)
++				for (i = 1; i < td->td_samplesperpixel - td->td_extrasamples && i < 3; i++)
+ 					fprintf(fd, " %5u",
+ 					    td->td_transferfunction[i][l]);
+ 				fputc('\n', fd);
+-- 
+2.17.0
+

--- a/libs/tiff/patches/022-CVE-2017-9935.patch
+++ b/libs/tiff/patches/022-CVE-2017-9935.patch
@@ -1,6 +1,52 @@
+From e1cd2d7ab032e7fe80b4c13e07895194c8bac85e Mon Sep 17 00:00:00 2001
+From: Brian May <brian@linuxpenguins.xyz>
+Date: Thu, 7 Dec 2017 07:46:47 +1100
+Subject: [PATCH 1/4] [PATCH] tiff2pdf: Fix CVE-2017-9935
+
+Fix for http://bugzilla.maptools.org/show_bug.cgi?id=2704
+
+This vulnerability - at least for the supplied test case - is because we
+assume that a tiff will only have one transfer function that is the same
+for all pages. This is not required by the TIFF standards.
+
+We than read the transfer function for every page.  Depending on the
+transfer function, we allocate either 2 or 4 bytes to the XREF buffer.
+We allocate this memory after we read in the transfer function for the
+page.
+
+For the first exploit - POC1, this file has 3 pages. For the first page
+we allocate 2 extra extra XREF entries. Then for the next page 2 more
+entries. Then for the last page the transfer function changes and we
+allocate 4 more entries.
+
+When we read the file into memory, we assume we have 4 bytes extra for
+each and every page (as per the last transfer function we read). Which
+is not correct, we only have 2 bytes extra for the first 2 pages. As a
+result, we end up writing past the end of the buffer.
+
+There are also some related issues that this also fixes. For example,
+TIFFGetField can return uninitalized pointer values, and the logic to
+detect a N=3 vs N=1 transfer function seemed rather strange.
+
+It is also strange that we declare the transfer functions to be of type
+float, when the standard says they are unsigned 16 bit values. This is
+fixed in another patch.
+
+This patch will check to ensure that the N value for every transfer
+function is the same for every page. If this changes, we abort with an
+error. In theory, we should perhaps check that the transfer function
+itself is identical for every page, however we don't do that due to the
+confusion of the type of the data in the transfer function.
+---
+ libtiff/tif_dir.c |  3 +++
+ tools/tiff2pdf.c  | 69 +++++++++++++++++++++++++++++++----------------
+ 2 files changed, 49 insertions(+), 23 deletions(-)
+
+diff --git a/libtiff/tif_dir.c b/libtiff/tif_dir.c
+index f00f808..c36a5f3 100644
 --- a/libtiff/tif_dir.c
 +++ b/libtiff/tif_dir.c
-@@ -1067,6 +1067,9 @@ _TIFFVGetField(TIFF* tif, uint32 tag, va
+@@ -1067,6 +1067,9 @@ _TIFFVGetField(TIFF* tif, uint32 tag, va_list ap)
  			if (td->td_samplesperpixel - td->td_extrasamples > 1) {
  				*va_arg(ap, uint16**) = td->td_transferfunction[1];
  				*va_arg(ap, uint16**) = td->td_transferfunction[2];
@@ -10,9 +56,11 @@
  			}
  			break;
  		case TIFFTAG_REFERENCEBLACKWHITE:
+diff --git a/tools/tiff2pdf.c b/tools/tiff2pdf.c
+index bdb9126..bd23c9e 100644
 --- a/tools/tiff2pdf.c
 +++ b/tools/tiff2pdf.c
-@@ -237,7 +237,7 @@ typedef struct {
+@@ -239,7 +239,7 @@ typedef struct {
  	float tiff_whitechromaticities[2];
  	float tiff_primarychromaticities[6];
  	float tiff_referenceblackwhite[2];
@@ -21,7 +69,7 @@
  	int pdf_image_interpolate;	/* 0 (default) : do not interpolate,
  					   1 : interpolate */
  	uint16 tiff_transferfunctioncount;
-@@ -1047,6 +1047,8 @@ void t2p_read_tiff_init(T2P* t2p, TIFF*
+@@ -1049,6 +1049,8 @@ void t2p_read_tiff_init(T2P* t2p, TIFF* input){
  	uint16 pagen=0;
  	uint16 paged=0;
  	uint16 xuint16=0;
@@ -29,8 +77,8 @@
 +	uint16* tiff_transferfunction[3];
  
  	directorycount=TIFFNumberOfDirectories(input);
- 	t2p->tiff_pages = (T2P_PAGE*) _TIFFmalloc(TIFFSafeMultiply(tmsize_t,directorycount,sizeof(T2P_PAGE)));
-@@ -1147,26 +1149,48 @@ void t2p_read_tiff_init(T2P* t2p, TIFF*
+ 	if(directorycount > TIFF_DIR_MAX) {
+@@ -1157,26 +1159,48 @@ void t2p_read_tiff_init(T2P* t2p, TIFF* input){
                  }
  #endif
  		if (TIFFGetField(input, TIFFTAG_TRANSFERFUNCTION,
@@ -97,7 +145,7 @@
  		if( TIFFGetField(
  			input, 
  			TIFFTAG_ICCPROFILE, 
-@@ -1827,10 +1851,9 @@ void t2p_read_tiff_data(T2P* t2p, TIFF*
+@@ -1837,10 +1861,9 @@ void t2p_read_tiff_data(T2P* t2p, TIFF* input){
  			 &(t2p->tiff_transferfunction[0]),
  			 &(t2p->tiff_transferfunction[1]),
  			 &(t2p->tiff_transferfunction[2]))) {
@@ -111,3 +159,6 @@
  			t2p->tiff_transferfunctioncount=3;
  		} else {
  			t2p->tiff_transferfunctioncount=1;
+-- 
+2.17.0
+

--- a/libs/tiff/patches/023-CVE-2017-18013.patch
+++ b/libs/tiff/patches/023-CVE-2017-18013.patch
@@ -1,15 +1,19 @@
-From c6f41df7b581402dfba3c19a1e3df4454c551a01 Mon Sep 17 00:00:00 2001
+From b1997b9c3ac0d6bac5effd7558141986487217a9 Mon Sep 17 00:00:00 2001
 From: Even Rouault <even.rouault@spatialys.com>
 Date: Sun, 31 Dec 2017 15:09:41 +0100
-Subject: [PATCH] libtiff/tif_print.c: TIFFPrintDirectory(): fix null pointer dereference on corrupted file. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2770
+Subject: [PATCH 2/4] libtiff/tif_print.c: TIFFPrintDirectory(): fix null
+ pointer dereference on corrupted file. Fixes
+ http://bugzilla.maptools.org/show_bug.cgi?id=2770 / CVE-2017-18013
 
 ---
  libtiff/tif_print.c | 8 ++++----
  1 file changed, 4 insertions(+), 4 deletions(-)
 
+diff --git a/libtiff/tif_print.c b/libtiff/tif_print.c
+index 10a588e..b9b53a0 100644
 --- a/libtiff/tif_print.c
 +++ b/libtiff/tif_print.c
-@@ -667,13 +667,13 @@ TIFFPrintDirectory(TIFF* tif, FILE* fd,
+@@ -667,13 +667,13 @@ TIFFPrintDirectory(TIFF* tif, FILE* fd, long flags)
  #if defined(__WIN32__) && (defined(_MSC_VER) || defined(__MINGW32__))
  			fprintf(fd, "    %3lu: [%8I64u, %8I64u]\n",
  			    (unsigned long) s,
@@ -27,3 +31,6 @@ Subject: [PATCH] libtiff/tif_print.c: TIFFPrintDirectory(): fix null pointer der
  #endif
  	}
  }
+-- 
+2.17.0
+

--- a/libs/tiff/patches/024-CVE-2018-8905.patch
+++ b/libs/tiff/patches/024-CVE-2018-8905.patch
@@ -1,0 +1,53 @@
+From 1c127eb3cb7653bd61b61f9c3cfeb36fd10edab1 Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sat, 12 May 2018 15:32:31 +0200
+Subject: [PATCH 3/4] LZWDecodeCompat(): fix potential index-out-of-bounds
+ write. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2780 /
+ CVE-2018-8905
+
+The fix consists in using the similar code LZWDecode() to validate we
+don't write outside of the output buffer.
+---
+ libtiff/tif_lzw.c | 18 ++++++++++++------
+ 1 file changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/libtiff/tif_lzw.c b/libtiff/tif_lzw.c
+index bc8f9c8..186ea3c 100644
+--- a/libtiff/tif_lzw.c
++++ b/libtiff/tif_lzw.c
+@@ -604,6 +604,7 @@ LZWDecodeCompat(TIFF* tif, uint8* op0, tmsize_t occ0, uint16 s)
+ 	char *tp;
+ 	unsigned char *bp;
+ 	int code, nbits;
++	int len;
+ 	long nextbits, nextdata, nbitsmask;
+ 	code_t *codep, *free_entp, *maxcodep, *oldcodep;
+ 
+@@ -755,13 +756,18 @@ LZWDecodeCompat(TIFF* tif, uint8* op0, tmsize_t occ0, uint16 s)
+ 				}  while (--occ);
+ 				break;
+ 			}
+-			assert(occ >= codep->length);
+-			op += codep->length;
+-			occ -= codep->length;
+-			tp = op;
++			len = codep->length;
++			tp = op + len;
+ 			do {
+-				*--tp = codep->value;
+-			} while( (codep = codep->next) != NULL );
++				int t;
++				--tp;
++				t = codep->value;
++				codep = codep->next;
++				*tp = (char)t;
++			} while (codep && tp > op);
++			assert(occ >= len);
++			op += len;
++			occ -= len;
+ 		} else {
+ 			*op++ = (char)code;
+ 			occ--;
+-- 
+2.17.0
+

--- a/libs/tiff/patches/025-CVE-2018-10963.patch
+++ b/libs/tiff/patches/025-CVE-2018-10963.patch
@@ -1,0 +1,31 @@
+From 98ed6179dec22db48f6e235d8ca9e2708bf4e71a Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sat, 12 May 2018 14:24:15 +0200
+Subject: [PATCH 4/4] TIFFWriteDirectorySec: avoid assertion. Fixes
+ http://bugzilla.maptools.org/show_bug.cgi?id=2795. CVE-2018-10963
+
+---
+ libtiff/tif_dirwrite.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/libtiff/tif_dirwrite.c b/libtiff/tif_dirwrite.c
+index c68d6d2..5d0a669 100644
+--- a/libtiff/tif_dirwrite.c
++++ b/libtiff/tif_dirwrite.c
+@@ -697,8 +697,11 @@ TIFFWriteDirectorySec(TIFF* tif, int isimage, int imagedone, uint64* pdiroff)
+ 								}
+ 								break;
+ 							default:
+-								assert(0);   /* we should never get here */
+-								break;
++								TIFFErrorExt(tif->tif_clientdata,module,
++								            "Cannot write tag %d (%s)",
++								            TIFFFieldTag(o),
++                                                                            o->field_name ? o->field_name : "unknown");
++								goto bad;
+ 						}
+ 					}
+ 				}
+-- 
+2.17.0
+

--- a/libs/tiff/patches/026-CVE-2017-11613.patch
+++ b/libs/tiff/patches/026-CVE-2017-11613.patch
@@ -1,0 +1,44 @@
+From 5c3bc1c78dfe05eb5f4224650ad606b75e1f7034 Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sun, 11 Mar 2018 11:14:01 +0100
+Subject: [PATCH] ChopUpSingleUncompressedStrip: avoid memory exhaustion
+ (CVE-2017-11613)
+
+In ChopUpSingleUncompressedStrip(), if the computed number of strips is big
+enough and we are in read only mode, validate that the file size is consistent
+with that number of strips to avoid useless attempts at allocating a lot of
+memory for the td_stripbytecount and td_stripoffset arrays.
+
+Rework fix done in 3719385a3fac5cfb20b487619a5f08abbf967cf8 to work in more
+cases like https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=6979.
+Credit to OSS Fuzz
+
+Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2724
+---
+ libtiff/tif_dirread.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+index 80aaf8d..5896a78 100644
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -5760,6 +5760,16 @@ ChopUpSingleUncompressedStrip(TIFF* tif)
+         if( nstrips == 0 )
+             return;
+ 
++        /* If we are going to allocate a lot of memory, make sure that the */
++        /* file is as big as needed */
++        if( tif->tif_mode == O_RDONLY &&
++            nstrips > 1000000 &&
++            (offset >= TIFFGetFileSize(tif) ||
++             stripbytes > (TIFFGetFileSize(tif) - offset) / (nstrips - 1)) )
++        {
++            return;
++        }
++
+ 	newcounts = (uint64*) _TIFFCheckMalloc(tif, nstrips, sizeof (uint64),
+ 				"for chopped \"StripByteCounts\" array");
+ 	newoffsets = (uint64*) _TIFFCheckMalloc(tif, nstrips, sizeof (uint64),
+-- 
+2.17.1
+


### PR DESCRIPTION
Taken from Fedora. Reordered them so as to apply properly.

Added a CPE ID.

Added parallel build for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jslachta maybe @micmac1 ?
Compile tested: ipq806x
