### PR TITLE
libxml2: Fix CVE-2018-9251 and CVE-2018-14567

### DIFF
--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxml2
 PKG_VERSION:=2.9.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://xmlsoft.org/sources/
@@ -17,6 +17,7 @@ PKG_HASH:=0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:xmlsoft:libxml2
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 

--- a/libs/libxml2/patches/010-CVE-2018-9251.patch
+++ b/libs/libxml2/patches/010-CVE-2018-9251.patch
@@ -1,0 +1,50 @@
+From 2240fbf5912054af025fb6e01e26375100275e74 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Mon, 30 Jul 2018 13:14:11 +0200
+Subject: [PATCH 13/13] Fix infinite loop in LZMA decompression
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Check the liblzma error code more thoroughly to avoid infinite loops.
+
+Closes: https://gitlab.gnome.org/GNOME/libxml2/issues/13
+Closes: https://bugzilla.gnome.org/show_bug.cgi?id=794914
+
+This is CVE-2018-9251 and CVE-2018-14567.
+
+Thanks to Dongliang Mu and Simon Wörner for the reports.
+---
+ xzlib.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/xzlib.c b/xzlib.c
+index a839169e..0ba88cfa 100644
+--- a/xzlib.c
++++ b/xzlib.c
+@@ -562,6 +562,10 @@ xz_decomp(xz_statep state)
+                          "internal error: inflate stream corrupt");
+                 return -1;
+             }
++            /*
++             * FIXME: Remapping a couple of error codes and falling through
++             * to the LZMA error handling looks fragile.
++             */
+             if (ret == Z_MEM_ERROR)
+                 ret = LZMA_MEM_ERROR;
+             if (ret == Z_DATA_ERROR)
+@@ -587,6 +591,11 @@ xz_decomp(xz_statep state)
+             xz_error(state, LZMA_PROG_ERROR, "compression error");
+             return -1;
+         }
++        if ((state->how != GZIP) &&
++            (ret != LZMA_OK) && (ret != LZMA_STREAM_END)) {
++            xz_error(state, ret, "lzma error");
++            return -1;
++        }
+     } while (strm->avail_out && ret != LZMA_STREAM_END);
+ 
+     /* update available output and crc check value */
+-- 
+2.18.0
+


### PR DESCRIPTION
Also added the CPE ID.

Taken from Fedora.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mhei 
Compile tested: ipq806x

I noticed while building that the documentation also gets built. Should be patched out I think.