### PR TITLE
gst1-plugins-bad: update to 1.14.2

### DIFF
--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-bad
-PKG_VERSION:=1.14.1
+PKG_VERSION:=1.14.2
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
@@ -20,7 +20,7 @@ PKG_LICENSE_FILES:=COPYING.LIB COPYING
 PKG_BUILD_DIR:=$(BUILD_DIR)/gst-plugins-bad-$(PKG_VERSION)
 PKG_SOURCE:=gst-plugins-bad-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://gstreamer.freedesktop.org/src/gst-plugins-bad/
-PKG_HASH:=2a77c6908032aafdf2cd2e5823fec948f16a25c2d1497a953828d762dc20d61a
+PKG_HASH:=34fab7da70994465a64468330b2168a4a0ed90a7de7e4c499b6d127c6c1b1eaf
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64, master f4d30476

Description:
