### PR TITLE
libfastjson: Update to 0.99.8 + switch to tarball

### DIFF
--- a/libs/libfastjson/Makefile
+++ b/libs/libfastjson/Makefile
@@ -8,21 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libfastjson
-PKG_VERSION:=0.99.2
-PKG_RELEASE:=2
+PKG_VERSION:=0.99.8
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MIRROR_HASH:=66676a4c8de8c5399dfe1cfd064d140afca58e3d8187bae0a3dccdf83165d9d1
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/rsyslog/libfastjson.git
-PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_SOURCE_URL:=http://download.rsyslog.com/libfastjson
+PKG_HASH:=3544c757668b4a257825b3cbc26f800f59ef3c1ff2a260f40f96b48ab1d59e07
 
 PKG_MAINTAINER:=Dov Murik <dmurik@us.ibm.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
 
-PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Using the tarball allows getting rid of autoreconf and speeding up the build.
Also easier to bump the package.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dubek
Compile tested: ipq806x