### PR TITLE
rsyslog: Update to 8.37.0

### DIFF
--- a/net/rsyslog/Makefile
+++ b/net/rsyslog/Makefile
@@ -8,19 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsyslog
-PKG_VERSION:=8.18.0
+PKG_VERSION:=8.37.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.rsyslog.com/files/download/rsyslog/
-PKG_HASH:=94346237ecfa22c9f78cebc3f18d59056f5d9846eb906c75beaa7e486f02c695
+PKG_SOURCE_URL:=https://www.rsyslog.com/files/download/rsyslog/
+PKG_HASH:=295c289b4c8abd8f8f3fe35a83249b739cedabe82721702b910255f9faf147e7
 
 PKG_MAINTAINER:=Dov Murik <dmurik@us.ibm.com>
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
-PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -28,7 +28,7 @@ define Package/rsyslog
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Enhanced system logging and kernel message trapping daemons
-  URL:=http://www.rsyslog.com/
+  URL:=https://www.rsyslog.com/
   DEPENDS:=+libestr +libfastjson +libuuid +zlib +USE_UCLIBC:libpthread +USE_UCLIBC:librt
 endef
 
@@ -39,9 +39,6 @@ endef
 CONFIGURE_ARGS+= \
 	--disable-libgcrypt \
 	--disable-liblogging-stdlog
-
-TARGET_CFLAGS += \
-	-std=c99
 
 define Package/rsyslog/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
HTTPS to everything

Remove autoreconf as it's not needed and slows down the build.

Build in parallel for faster building.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dubek 
Compile tested: ipq806x