### PR TITLE
htop: Minor adjustments

### DIFF
--- a/admin/htop/Makefile
+++ b/admin/htop/Makefile
@@ -9,16 +9,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=htop
 PKG_VERSION:=2.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://hisham.hm/htop/releases/$(PKG_VERSION)/
+PKG_SOURCE_URL:=https://hisham.hm/htop/releases/$(PKG_VERSION)/
 PKG_HASH:=d9d6826f10ce3887950d709b53ee1d8c1849a70fa38e91d5896ad8cbc6ba3c57
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:htop:htop
 
-PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -28,7 +29,7 @@ define Package/htop
   CATEGORY:=Administration
   TITLE:=Interactive processes viewer
   DEPENDS:=+libncurses
-  URL:=http://htop.sourceforge.net/
+  URL:=https://hisham.hm/htop/
   MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 endef
 


### PR DESCRIPTION
Added PKG_CPE_ID for proper CVE tracking.

Fixed URLs. Changed to HTTPS as well.

Removed autoreconf as there is no patching being done.

PKG_BUILD_PARALLEL was enabled for faster building.

Maintainer: @champtar 
Compile tested: ipq806x