### PR TITLE
zabbix: Update to 3.4.12

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,16 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=3.4.10
+PKG_VERSION:=3.4.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=cdee0fd44e11ae214b2cc252974da22f3627c326ea2c61a0315af95165c52d1b
 PKG_SOURCE_URL:=@SF/zabbix
+PKG_HASH:=d7e55b2be8ea69921f18bc7f08bdd7d1b87c268513286f46286744bf4da729fe
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:zabbix:zabbix
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 PKG_FIXUP:=autoreconf
@@ -29,7 +31,7 @@ define Package/zabbix/Default
   SECTION:=admin
   CATEGORY:=Administration
   TITLE:=Zabbix
-  URL:=http://www.zabbix.com/
+  URL:=https://www.zabbix.com/
   SUBMENU:=zabbix
   MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
   USERID:=zabbix=53:zabbix=53

--- a/admin/zabbix/patches/010-change-agentd-config.patch
+++ b/admin/zabbix/patches/010-change-agentd-config.patch
@@ -27,7 +27,7 @@
  ### Option: LogFileSize
  #	Maximum size of log file in MB.
  #	0 - disable automatic log rotation.
-@@ -114,6 +111,7 @@ Server=127.0.0.1
+@@ -116,6 +113,7 @@ Server=127.0.0.1
  # Range: 0-100
  # Default:
  # StartAgents=3
@@ -35,7 +35,7 @@
  
  ##### Active checks related
  
-@@ -129,8 +127,6 @@ Server=127.0.0.1
+@@ -131,8 +129,6 @@ Server=127.0.0.1
  # Default:
  # ServerActive=
  
@@ -44,7 +44,7 @@
  ### Option: Hostname
  #	Unique, case sensitive hostname.
  #	Required for active checks and must match hostname as configured on the server.
-@@ -140,8 +136,6 @@ ServerActive=127.0.0.1
+@@ -142,8 +138,6 @@ ServerActive=127.0.0.1
  # Default:
  # Hostname=
  
@@ -53,7 +53,7 @@
  ### Option: HostnameItem
  #	Item used for generating Hostname if it is undefined. Ignored if Hostname is defined.
  #	Does not support UserParameters or aliases.
-@@ -259,8 +253,8 @@ Hostname=Zabbix server
+@@ -261,8 +255,8 @@ Hostname=Zabbix server
  # Include=
  
  # Include=/usr/local/etc/zabbix_agentd.userparams.conf

--- a/admin/zabbix/patches/110-reproducible-builds.patch
+++ b/admin/zabbix/patches/110-reproducible-builds.patch
@@ -1,8 +1,6 @@
-Index: zabbix-3.2.7/src/libs/zbxcommon/str.c
-===================================================================
---- zabbix-3.2.7.orig/src/libs/zbxcommon/str.c
-+++ zabbix-3.2.7/src/libs/zbxcommon/str.c
-@@ -51,7 +51,7 @@ static const char	help_message_footer[]
+--- a/src/libs/zbxcommon/str.c
++++ b/src/libs/zbxcommon/str.c
+@@ -52,7 +52,7 @@ static const char	help_message_footer[] =
  void	version(void)
  {
  	printf("%s (Zabbix) %s\n", title_message, ZABBIX_VERSION);


### PR DESCRIPTION
Switch URL to HTTPS.

Add PKG_CPE_ID for proper CVE tracking.

Add PKG_BUILD_PARALLEL for faster compilation.

Some other cosmetic fixes.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @champtar 
Compile tested: ipq806x