### PR TITLE
boost: Package Version Update -> 1.68.0

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -16,15 +16,15 @@ include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/target.mk 
 
 PKG_NAME:=boost
-PKG_VERSION:=1.67.0
-PKG_SOURCE_VERSION:=1_67_0
-PKG_RELEASE:=2
+PKG_VERSION:=1.68.0
+PKG_SOURCE_VERSION:=1_68_0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)_$(PKG_SOURCE_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)_$(PKG_SOURCE_VERSION)
-PKG_HASH:=2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba
+PKG_HASH:=7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7
 PKG_LICENSE:=Boost Software License <http://www.boost.org/users/license.html>
 PKG_MAINTAINER:=Carlos M. Ferreira <carlosmf.pt@gmail.com>
 
@@ -44,7 +44,7 @@ define Package/boost/Default
 endef
 
 define Package/boost/description
-This package provides the Boost v1.67.0 libraries.
+This package provides the Boost v1.68.0 libraries.
 Boost is a set of free, peer-reviewed, portable C++ source libraries.
 
 -----------------------------------------------------------------------------
@@ -63,7 +63,7 @@ This package provides the following run-time libraries:
  - chrono
  - container
  - context
- - contract (new in 1.67.0)
+ - contract 
  - coroutine (Deprecated - use Coroutine2)
  - - coroutine2 (Requires GCC v5 and up)
  - date_time


### PR DESCRIPTION
Maintainer: @ClaymorePT
Compile tested: LEDE BCM2708 - Raspberry Pi B/B+/Zero/ZeroW
Run tested: None

Description:

This package update provides one new library:
 - YAP: An expression template library for C++14 and later, from Zach Laine [[1]].

More info can be found at the usual place [[2]].

[1]: https://www.boost.org/libs/yap/
[2]: https://www.boost.org/users/history/version_1_68_0.html

Signed-off-by: Carlos Miguel Ferreira <carlosmf.pt@gmail.com>