### PR TITLE
vim: Update to 8.1

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -8,14 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vim
-PKG_VERSION:=8.0.586
-PKG_RELEASE:=2
-VIMVER:=80
+PKG_VERSION:=8.1
+PKG_RELEASE:=1
+VIMVER:=81
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=ftp://ftp.vim.org/pub/vim/unix/
-PKG_HASH:=08bd0d1dd30ece3cb9905ccd48b82b2f81c861696377508021265177dc153a61
+PKG_SOURCE_URL:=http://ftp.vim.org/pub/vim/unix
+PKG_HASH:=8b69fbd01c877dd8ecbbeca1dc66e5e927228d631ac4c2174b9307eb5c827c86
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
+PKG_CPE_ID:=cpe:/a:vim:vim
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)$(VIMVER)
 PKG_BUILD_PARALLEL:=1

--- a/utils/vim/patches/001-support-defining-compilation-date-in-SOURCE_DATE_EPOCH.patch
+++ b/utils/vim/patches/001-support-defining-compilation-date-in-SOURCE_DATE_EPOCH.patch
@@ -54,9 +54,9 @@ index e287124..5a16797 100644
 +  AC_DEFINE_UNQUOTED(BUILD_DATE, ["$BUILD_DATE"])
 +fi
 +
- dnl Check for the flag that fails if stuff are missing.
- 
- AC_MSG_CHECKING(--enable-fail-if-missing argument)
+ dnl Check that the C99 features that Vim uses are supported:
+ if test x"$ac_cv_prog_cc_c99" != xno; then
+   dnl If the compiler doesn't explicitly support C99, then check
 diff --git a/src/version.c b/src/version.c
 index 65f5a4b..9422657 100644
 --- a/src/version.c

--- a/utils/vim/patches/002-remove_helptags_generation.patch
+++ b/utils/vim/patches/002-remove_helptags_generation.patch
@@ -1,6 +1,6 @@
 --- a/runtime/doc/Makefile
 +++ b/runtime/doc/Makefile
-@@ -310,7 +310,6 @@ all: tags vim.man evim.man vimdiff.man v
+@@ -317,7 +317,6 @@ all: tags vim.man evim.man vimdiff.man v
  # Use Vim to generate the tags file.  Can only be used when Vim has been
  # compiled and installed.  Supports multiple languages.
  vimtags: $(DOCS)


### PR DESCRIPTION
Switch URL to HTTP. More reliable.

Added PKG_CPE_ID for proper CVE tracking.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ratkaj 
Compile tested: ipq806x