### PR TITLE
mariadb: bump to 10.2.17

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
-PKG_VERSION:=10.2.16
-PKG_RELEASE:=3
+PKG_VERSION:=10.2.17
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := \
@@ -18,7 +18,7 @@ PKG_SOURCE_URL := \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/$(PKG_NAME)-$(PKG_VERSION)/source \
 	https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
 
-PKG_HASH:=c182ee93bacee9c1395a4cece56acfc433bc5153ec627c4898927b93eee54dc4
+PKG_HASH:=e7b3078f8de874a4d451242a8a3eed49bf6f916dcd52fc3efa55886f5f35be27
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 PKG_LICENSE:=GPL-2.0 LGPL-2.1
 PKG_LICENSE_FILES:=COPYING libmariadb/COPYING.LIB

--- a/utils/mariadb/patches/100-fix_hostname.patch
+++ b/utils/mariadb/patches/100-fix_hostname.patch
@@ -1,6 +1,6 @@
 --- a/scripts/mysql_install_db.sh
 +++ b/scripts/mysql_install_db.sh
-@@ -383,7 +383,7 @@ fi
+@@ -388,7 +388,7 @@ fi
  
  
  # Try to determine the hostname


### PR DESCRIPTION
From Release Notes:

 - New variable innodb_log_optimize_ddl for avoiding delay due to page flushing and allowing concurrent backup
 - InnoDB updated to 5.7.23
 - ALTER TABLE fixes:
    MDEV-14637 - Fix hang due to DDL with FOREIGN KEY or persistent statistics
    MDEV-15953 - Alter InnoDB Partitioned Table Moves Files (which were originally not in the datadir) to the datadir
    MDEV-16515 - InnoDB: Failing assertion: ++retries < 10000 in file dict0dict.cc line 2737
    MDEV-16809 - Allow full redo logging for ALTER TABLE
 - Temporary tables: MDEV-16713 - InnoDB hang with repeating log entry
 - indexed virtual columns: MDEV-15855 - Deadlock between purge thread and DDL statement
 - locking: MDEV-16664 - Change the default to innodb_lock_schedule_algorithm=fcfs
 - Galera: MDEV-15822 - WSREP: BF lock wait long for trx
 - Fixes for the following security vulnerabilities:
    CVE-2018-3060
    CVE-2018-3064
    CVE-2018-3063
    CVE-2018-3058
    CVE-2018-3066

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: ar71xx
Run tested: ar71xx

Description:

Minor version bump, addresses also some CVEs.

Thanks in advance to whoever commits this for me!

Kind regards,
Seb