### PR TITLE
ipmitool: Fix compile with OpenSSL 1.1 without deprecated APIs.

### DIFF
--- a/admin/ipmitool/Makefile
+++ b/admin/ipmitool/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ipmitool
 PKG_VERSION:=1.8.18
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
@@ -24,7 +24,7 @@ define Package/ipmitool
   CATEGORY:=Administration
   DEPENDS:=+libopenssl +libncurses +libreadline
   TITLE:=Command-line interface to IPMI-enabled devices
-  URL:=http://sourceforge.net/projects/ipmitool/
+  URL:=https://github.com/ipmitool/ipmitool
   MAINTAINER:=Alexander Couzens <lynxis@fe80.eu>
 endef
 

--- a/admin/ipmitool/patches/0005-ipmitool-Fix-compile-with-deprecated-APIs-disabled.patch
+++ b/admin/ipmitool/patches/0005-ipmitool-Fix-compile-with-deprecated-APIs-disabled.patch
@@ -1,0 +1,47 @@
+From cf39da53236abf02d39c6a98a645488933f3e861 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 21 Aug 2018 19:29:07 -0700
+Subject: [PATCH] ipmitool: Fix compile with deprecated APIs disabled.
+
+From the man page:
+
+EVP_CIPHER_CTX was made opaque in OpenSSL 1.1.0. As a result,
+EVP_CIPHER_CTX_reset() appeared and EVP_CIPHER_CTX_cleanup() disappeared.
+EVP_CIPHER_CTX_init() remains as an alias for EVP_CIPHER_CTX_reset().
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ src/plugins/lanplus/lanplus_crypt_impl.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/plugins/lanplus/lanplus_crypt_impl.c b/src/plugins/lanplus/lanplus_crypt_impl.c
+index 9652a5e..e94401e 100644
+--- a/src/plugins/lanplus/lanplus_crypt_impl.c
++++ b/src/plugins/lanplus/lanplus_crypt_impl.c
+@@ -183,7 +183,11 @@ lanplus_encrypt_aes_cbc_128(const uint8_t * iv,
+ 		lprintf(LOG_DEBUG, "ERROR: EVP_CIPHER_CTX_new() failed");
+ 		return;
+ 	}
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	EVP_CIPHER_CTX_init(ctx);
++#else
++	EVP_CIPHER_CTX_reset(ctx);
++#endif
+ 	EVP_EncryptInit_ex(ctx, EVP_aes_128_cbc(), NULL, key, iv);
+ 	EVP_CIPHER_CTX_set_padding(ctx, 0);
+ 
+@@ -262,7 +266,11 @@ lanplus_decrypt_aes_cbc_128(const uint8_t * iv,
+ 		lprintf(LOG_DEBUG, "ERROR: EVP_CIPHER_CTX_new() failed");
+ 		return;
+ 	}
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	EVP_CIPHER_CTX_init(ctx);
++#else
++	EVP_CIPHER_CTX_reset(ctx);
++#endif
+ 	EVP_DecryptInit_ex(ctx, EVP_aes_128_cbc(), NULL, key, iv);
+ 	EVP_CIPHER_CTX_set_padding(ctx, 0);
+ 
+-- 
+2.7.4
+


### PR DESCRIPTION
Also updated the URL as the SourceForge page is obsolete.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lynxis 
Compile tested: ipq806x
