### PR TITLE
syslog-ng: stop service when uninstalling/updating

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include  $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.17.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -72,6 +72,21 @@ define Package/syslog-ng/install
 	$(INSTALL_DATA) ./files/syslog-ng.conf $(1)/etc
 	$(INSTALL_DIR) $(1)/etc/syslog-ng.d/
 	$(call libtool_remove_files,$(1))
+endef
+
+define Package/syslog-ng/prerm
+	#!/bin/sh
+	# check if we are on real system
+	if [ -z "$${IPKG_INSTROOT}" ]; then
+		# wish we had pidof unconditionally
+		pid=$(ps | grep syslog | grep -v grep | awk '{ print $$1; }')
+		[ -n "$$pid" ] && /etc/init.d/syslog-ng stop
+		[ "$${PKG_UPGRADE}" != "1" ] && {
+			echo "Removing rc.d symlink for syslog-ng"
+			/etc/init.d/syslog-ng disable
+		}
+	fi
+	exit 0
 endef
 
 $(eval $(call BuildPackage,syslog-ng))


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, generic, HEAD (4ad3f94)
Run tested: same, build, copied over to target system, installed

Description:

See the following post install:

```
# opkg install /tmp/syslog-ng_3.17.2-1_x86_64.ipk 
Upgrading syslog-ng on root from 3.16.1-2 to 3.17.2-1...
Removing rc.d symlink for syslog-ng
Removing obsolete file /usr/lib/libevtlog-3.16.so.0.0.0.
Removing obsolete file /usr/lib/libloggen_helper-3.16.so.0.0.0.
Removing obsolete file /usr/lib/libloggen_helper-3.16.so.0.
Removing obsolete file /usr/lib/libevtlog-3.16.so.0.
Removing obsolete file /usr/lib/libloggen_plugin-3.16.so.0.0.0.
Removing obsolete file /usr/lib/libsyslog-ng-3.16.so.0.0.0.
Removing obsolete file /usr/lib/libsyslog-ng-3.16.so.0.
Removing obsolete file /usr/lib/libloggen_plugin-3.16.so.0.
Configuring syslog-ng.
[2018-08-22T21:09:01.545361] WARNING: Configuration file format is too old, syslog-ng is running in compatibility mode. Please update it to use the syslog-ng 3.17 format at your time of convenience. To upgrade the configuration, please review the warnings about incompatible changes printed by syslog-ng, and once completed change the @version header at the top of the configuration file.;
Collected errors:
 * resolve_conffiles: Existing conffile /etc/syslog-ng.conf is different from the conffile in the new package. The new conffile will be placed at /etc/syslog-ng.conf-opkg.
# 
```

note the line from the new `/prerm` script:

```
Removing rc.d symlink for syslog-ng
```

and `ps` shows me that a new process has been started, as does `/var/log/messages`:

```
Aug 22 21:08:59 OpenWrt2 syslog-ng[15525]: syslog-ng shutting down; version='3.16.1'
Aug 22 21:09:01 OpenWrt2 syslog-ng[15632]: syslog-ng starting up; version='3.17.2'
```

