### PR TITLE
bluelog: Adjust source name to try to fix buildbot

### DIFF
--- a/utils/bluelog/Makefile
+++ b/utils/bluelog/Makefile
@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bluelog
 PKG_VERSION:=1.1.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=Bluelog-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/MS3FGX/Bluelog/tar.gz/$(PKG_VERSION)?
 PKG_HASH:=ebbc1357e14bc46cbddd8390cdbd29c0131b09b8ab680a1c382164ef076cb53e
 PKG_BUILD_DIR:=$(BUILD_DIR)/Bluelog-$(PKG_VERSION)


### PR DESCRIPTION
The buildbot is failing on applying the patch:

https://downloads.openwrt.org/snapshots/faillogs/mipsel_24kc/packages/bluelog/compile.txt

Locally, this does not happen. I assume the reason is that it has some special handling for
GitHub's tar archives where it extracts it to the name in PKG_SOURCE. So adjust that.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: unmaintained / @psycho-nico 
Compile tested: ipq806x