### PR TITLE
quassel-irssi: Update to 2017-11-30

### DIFF
--- a/net/quassel-irssi/Makefile
+++ b/net/quassel-irssi/Makefile
@@ -11,8 +11,8 @@ PKG_NAME:=quassel-irssi
 
 # quassel-irssi upstream doesn't release versions (at least, at the moment),
 # so use commit date for PKG_VERSION and embed commit hash into PKG_RELEASE.
-PKG_VERSION:=2016-09-11
-PKG_SOURCE_VERSION:=cbd9bd7f4ac44260d9fcafb809fdf153cde193e5
+PKG_VERSION:=2017-11-30
+PKG_SOURCE_VERSION:=079be662dde374a383646256108a4974c2bc7796
 PKG_RELEASE:=1.$(PKG_SOURCE_VERSION)
 
 PKG_LICENSE:=GPL-3.0+
@@ -21,10 +21,11 @@ PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/phhusson/quassel-irssi
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.bz2
-PKG_MIRROR_HASH:=fd13b2497e3b0d0779e0ce3d8b27c37e207d2a73b5b6dc0cb2799bd4472fc5e1
+PKG_MIRROR_HASH:=2236a879e6c21f030392b6883348eb49be4390dbb4f2c8ec5ae6068781b4a4a9
 
 PKG_MAINTAINER:=Ben Rosser <rosser.bjr@gmail.com>
 
+PKG_BUILD_PARALLEL:=0
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/quassel-irssi/patches/001-respect-cflags.patch
+++ b/net/quassel-irssi/patches/001-respect-cflags.patch
@@ -11,12 +11,12 @@ index 6133087..389855c 100644
  IRSSI_LIB?=$(DESTDIR)/$(LIBDIR)/irssi
  IRSSI_CFLAGS+=-I$(IRSSI_INCLUDE)/src/
  IRSSI_CFLAGS+=-I$(IRSSI_INCLUDE)/src/core/
-@@ -26,7 +26,7 @@ else
+@@ -28,7 +28,7 @@ else
      LDFLAGS += -lquasselc
  endif
  
 -CFLAGS=-std=gnu11 -Wall -Wextra -Werror -g -O2 $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations
 +CFLAGS+=-std=gnu11 -Wall -Wextra -Werror -g $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations
  
- TARGET=libquassel_core.so
- 
+ CFLAGS += $(SSL_CFLAGS)
+ LDFLAGS+= $(SSL_LDLAGS)

--- a/net/quassel-irssi/patches/002-use-cc-var.patch
+++ b/net/quassel-irssi/patches/002-use-cc-var.patch
@@ -2,7 +2,7 @@ diff --git a/core/Makefile b/core/Makefile
 index 389855c..2f81417 100644
 --- a/core/Makefile
 +++ b/core/Makefile
-@@ -44,7 +44,7 @@ irssi/network-openssl.o: CFLAGS:=$(IRSSI_CFLAGS)
+@@ -49,7 +49,7 @@ irssi/network-openssl.o: CFLAGS:=$(IRSSI_CFLAGS)
  quasselc-connector.o: CFLAGS:=$(CFLAGS)
  
  $(TARGET): $(OBJECTS)

--- a/net/quassel-irssi/patches/003-use-pkgconfig-ldflags-quasselc.patch
+++ b/net/quassel-irssi/patches/003-use-pkgconfig-ldflags-quasselc.patch
@@ -2,7 +2,7 @@ diff --git a/core/Makefile b/core/Makefile
 index 2f81417..aa62201 100644
 --- a/core/Makefile
 +++ b/core/Makefile
-@@ -23,7 +23,7 @@ ifndef SYSTEM_QUASSELC
+@@ -25,7 +25,7 @@ ifndef SYSTEM_QUASSELC
      QUASSELC_FLAGS:=-Ilib
  else
      QUASSELC_FLAGS:=$(shell pkg-config --cflags quasselc)
@@ -10,4 +10,4 @@ index 2f81417..aa62201 100644
 +    LDFLAGS += $(shell pkg-config --libs quasselc)
  endif
  
- CFLAGS+=-std=gnu11 -Wall -Wextra -Werror -g -O2 $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations
+ CFLAGS+=-std=gnu11 -Wall -Wextra -Werror -g $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations

--- a/net/quassel-irssi/patches/010-Get-compatible-with-potential-irssi-abi-8-and-drop-p.patch
+++ b/net/quassel-irssi/patches/010-Get-compatible-with-potential-irssi-abi-8-and-drop-p.patch
@@ -1,0 +1,118 @@
+From 5307782abccf1552468d2f37d13831f571b88e92 Mon Sep 17 00:00:00 2001
+From: Pierre-Hugues Husson <phh@phh.me>
+Date: Tue, 17 Jan 2017 23:09:24 +0100
+Subject: [PATCH] Get compatible with potential irssi abi 8, and drop polling
+
+---
+ core/Makefile      |  1 -
+ core/quassel-net.c | 64 +++++++++++++++++++++++++++++++++++++++++++++---------
+ 2 files changed, 55 insertions(+), 12 deletions(-)
+
+diff --git a/core/Makefile b/core/Makefile
+index 37e396b..2c0caab 100644
+--- a/core/Makefile
++++ b/core/Makefile
+@@ -16,7 +16,6 @@ SSL_CFLAGS=$(shell pkg-config --cflags openssl)
+ SSL_LDLAGS=$(shell pkg-config --libs openssl)
+ OBJECTS:=quasselc-connector.o quassel-core.o
+ OBJECTS+=quassel-net.o quassel-msgs.o quassel-cmds.o
+-OBJECTS+=irssi/network-openssl.o
+ OBJECTS+=quassel-fe-window.o quassel-fe-level.o quassel-cfg.o
+ 
+ LDFLAGS ?=
+diff --git a/core/quassel-net.c b/core/quassel-net.c
+index 8a6eb55..5db7fe0 100644
+--- a/core/quassel-net.c
++++ b/core/quassel-net.c
+@@ -132,10 +132,10 @@ static SERVER_REC* quassel_server_init_connect(SERVER_CONNECT_REC* conn) {
+ 	ret->got = 0;
+ 	server_connect_ref(SERVER_CONNECT(conn));
+ 
+-	if(conn->use_ssl) {
++	if(conn->use_tls) {
+ 		ret->ssl = 1;
+ 	}
+-	ret->connrec->use_ssl = 0;
++	ret->connrec->use_tls = 0;
+ 
+ 	ret->channels_join = quassel_irssi_channels_join;
+ 	ret->send_message = quassel_irssi_send_message;
+@@ -161,12 +161,59 @@ void quassel_net_init(CHAT_PROTOCOL_REC* rec) {
+ 	signal_add_first("server connected", (SIGNAL_FUNC) sig_connected);
+ }
+ 
+-GIOChannel *irssi_ssl_get_iochannel(GIOChannel *handle, int port, SERVER_REC *server);
++static void quassel_net_final_setup(SERVER_REC* server, GIOChannel *handle) {
++	quassel_login(handle, server->connrec->nick, server->connrec->password);
++	server->handle->handle = handle;
++
++	server->readtag =
++		g_input_add(handle,
++			    G_INPUT_READ,
++			    (GInputFunction) quassel_parse_incoming, server);
++}
++
++static void quassel_net_ssl_callback(SERVER_REC *server, GIOChannel *handle) {
++	int error;
++
++	g_return_if_fail(IS_SERVER(server));
++
++	error = irssi_ssl_handshake(handle);
++	if (error == -1) {
++		server->connection_lost = TRUE;
++		server_connect_failed(server, NULL);
++		return;
++	}
++	if (error & 1) {
++		if (server->connect_tag != -1)
++			g_source_remove(server->connect_tag);
++		server->connect_tag = g_input_add(handle, error == 1 ? G_INPUT_READ : G_INPUT_WRITE,
++						  (GInputFunction)
++						  quassel_net_ssl_callback,
++						  server);
++		return;
++	}
++
++	if (server->connect_tag != -1) {
++		g_source_remove(server->connect_tag);
++		server->connect_tag = -1;
++	}
++
++	quassel_net_final_setup(server, handle);
++}
++
+ void quassel_irssi_init_ack(void *arg) {
+ 	Quassel_SERVER_REC *server = (Quassel_SERVER_REC*)arg;
+-	if(!server->ssl)
+-		goto login;
+-	GIOChannel* ssl_handle = irssi_ssl_get_iochannel(server->handle->handle, 1337, SERVER(server));
++	GIOChannel* ssl_handle = net_start_ssl((SERVER_REC*)server);
++
++	if(server->readtag != -1) {
++		g_source_remove(server->readtag);
++		server->readtag = -1;
++	}
++
++	if(!server->ssl) {
++		quassel_net_final_setup((SERVER_REC*)server, server->handle->handle);
++		return;
++	}
++
+ 	int error;
+ 	//That's polling, and that's really bad...
+ 	while( (error=irssi_ssl_handshake(ssl_handle)) & 1) {
+@@ -175,10 +222,7 @@ void quassel_irssi_init_ack(void *arg) {
+ 			return;
+ 		}
+ 	}
+-	server->handle->handle = ssl_handle;
+-
+-login:
+-	quassel_login(server->handle->handle, server->connrec->nick, server->connrec->password);
++	quassel_net_ssl_callback((SERVER_REC*)server, ssl_handle);
+ }
+ 
+ void quassel_irssi_init_nack(void *arg) {
+-- 
+2.7.4
+


### PR DESCRIPTION
OpenWrt currently uses GCC7, which fails to compile this package. Funny
enough, the last commit "Makes gcc7 happy".

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @TC01 