### PR TITLE
clamsmtp: Fix compile under musl

### DIFF
--- a/mail/clamsmtp/Makefile
+++ b/mail/clamsmtp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clamsmtp
 PKG_VERSION:=1.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://thewalter.net/stef/software/clamsmtp/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/mail/clamsmtp/patches/010-fix-build.patch
+++ b/mail/clamsmtp/patches/010-fix-build.patch
@@ -1,0 +1,12 @@
+diff --git a/common/sock_any.h b/common/sock_any.h
+index 77c3841..1e30974 100644
+--- a/common/sock_any.h
++++ b/common/sock_any.h
+@@ -39,7 +39,6 @@
+ #ifndef __SOCK_ANY_H__
+ #define __SOCK_ANY_H__
+ 
+-#include <sys/socket.h>
+ #include <sys/un.h>
+ #include <netinet/in.h>
+ 


### PR DESCRIPTION
sys/socket already includes the needed socket stuff. Including the second
header causes the build to fail.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Description: Should fix this: https://downloads.openwrt.org/snapshots/faillogs/mipsel_24kc/packages/clamsmtp/compile.txt
