### PR TITLE
nfs-kernel-server: add support for NFSv4

### DIFF
--- a/net/nfs-kernel-server/Config.in
+++ b/net/nfs-kernel-server/Config.in
@@ -1,0 +1,8 @@
+menu "Select nfs-kernel-server configuration options"
+        depends on PACKAGE_nfs-kernel-server
+
+config NFS_KERNEL_SERVER_V4
+	bool "Include support for NFSv4"
+	default y
+
+endmenu

--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -20,7 +20,10 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=$(PKG_NAME)/host
 HOST_BUILD_DEPENDS:=libtirpc/host
-PKG_CONFIG_DEPENDS:= CONFIG_IPV6
+
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_IPV6 \
+	CONFIG_NFS_KERNEL_SERVER_V4
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -37,11 +40,15 @@ endef
 define Package/nfs-kernel-server
   $(call Package/nfs-kernel-server/Default)
   TITLE:=Kernel NFS server support
-  DEPENDS+= +kmod-fs-nfsd +kmod-fs-nfs +rpcbind
+  DEPENDS+= +kmod-fs-nfsd +kmod-fs-nfs +NFS_KERNEL_SERVER_V4:kmod-fs-nfs-v4 +rpcbind +NFS_KERNEL_SERVER_V4:nfs-utils-libs +NFS_KERNEL_SERVER_V4:libkeyutils +NFS_KERNEL_SERVER_V4:libdevmapper
 endef
 
 define Package/nfs-kernel-server/description
   Kernel NFS server support
+endef
+
+define Package/nfs-kernel-server/config
+  source "$(SOURCE)/Config.in"
 endef
 
 define Package/nfs-kernel-server-utils
@@ -58,16 +65,31 @@ define Package/nfs-kernel-server/conffiles
 /etc/exports
 endef
 
-define Package/nfs-utils
+define Package/nfs-utils/Default
   $(call Package/nfs-kernel-server/Default)
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS+= +libevent2
+  DEPENDS+= +libevent2 +NFS_KERNEL_SERVER_V4:libkeyutils +NFS_KERNEL_SERVER_V4:libdevmapper
+  URL:=http://nfs.sourceforge.net/
+  MAINTAINER:=Peter Wagner <tripolar@gmx.at>
+endef
+
+define Package/nfs-utils
+  $(call Package/nfs-utils/Default)
   TITLE:=updated mount utility (includes nfs4)
 endef
 
 define Package/nfs-utils/description
   Updated mount.nfs command - allows mounting nfs4 volumes
+endef
+
+define Package/nfs-utils-libs
+  $(call Package/nfs-utils/Default)
+  TITLE:=libraries provided by nfs-utils
+endef
+
+define Package/nfs-utils-libs/description
+  Libraries provided by nfs-utils
 endef
 
 TARGET_CFLAGS += -Wno-error=implicit-function-declaration \
@@ -81,12 +103,14 @@ TARGET_LDFLAGS += -Wl,-rpath-link=$(STAGING_DIR)/usr/lib \
 		  -L$(STAGING_DIR)/usr/lib/libevent
 
 CONFIGURE_ARGS += \
+	--disable-caps \
 	--disable-gss \
-	--disable-nfsv4 \
-	--disable-nfsv41 \
-	--enable-static \
+	--disable-nfsdcld \
+	--disable-nfsdcltrack \
 	--enable-shared \
-	--disable-caps
+	--enable-static \
+	$(if $(CONFIG_NFS_KERNEL_SERVER_V4),--enable,--disable)-nfsv4 \
+	$(if $(CONFIG_NFS_KERNEL_SERVER_V4),--enable,--disable)-nfsv41
 
 ifeq ($(CONFIG_IPV6),n)
 CONFIGURE_ARGS += --disable-ipv6
@@ -156,13 +180,28 @@ define Package/nfs-kernel-server-utils/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/nfsstat/nfsstat $(1)/usr/sbin
 endef
 
+define Package/nfs-utils/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/nfsidmap.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnfsidmap.{a,la,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libnfsidmap.pc $(1)/usr/lib/pkgconfig/
+endef
+
 define Package/nfs-utils/install
 	$(INSTALL_DIR) $(1)/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/mount.nfs $(1)/sbin/
 	(cd $(1)/sbin; ln -sf mount.nfs mount.nfs4; ln -sf mount.nfs umount.nfs; ln -sf mount.nfs umount.nfs4)
 endef
 
+define Package/nfs-utils-libs/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnfsidmap.so* $(1)/usr/lib/
+endef
+
 $(eval $(call HostBuild))
+$(eval $(call BuildPackage,nfs-utils))
+$(eval $(call BuildPackage,nfs-utils-libs))
 $(eval $(call BuildPackage,nfs-kernel-server))
 $(eval $(call BuildPackage,nfs-kernel-server-utils))
-$(eval $(call BuildPackage,nfs-utils))

--- a/net/nfs-kernel-server/files/nfsd.init
+++ b/net/nfs-kernel-server/files/nfsd.init
@@ -7,12 +7,14 @@ STOP=60
 USE_PROCD=1
 
 NFS_D=/var/lib/nfs
+RECOVERY_D=$NFS_D/v4recovery
 LOCK_D=/var/lib/nfs/sm
 
 start_service() {
 	grep -q /proc/fs/nfsd /proc/mounts || \
 		mount -t nfsd nfsd /proc/fs/nfsd
 	mkdir -p $NFS_D
+	mkdir -p $RECOVERY_D
 	mkdir -p $LOCK_D
 	touch $NFS_D/rmtab
 


### PR DESCRIPTION
This is based on earlier work by Tobias Waldvogel.

Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: @tripolar 
Compile tested: x86_64, master b6adfde0
Run tested: x86_64, master b6adfde0

Description:
Depends on #6876 and #6877 as well as the kernel package pull request at https://github.com/openwrt/openwrt/pull/1324.

I have created this a a package separate from nfs-kernel-server. I suspect we ought to instead combine the two, but I wanted to first do things this way for testing. Unless someone objects, I would like to combine nfs-kernel-server and nfsv4-kernel-server into nfs-kernel-server before we actually merge this pull request.

I still need to test the backwards support for NFSv3.
