### PR TITLE
libartnet: Fix compile with GCC7

### DIFF
--- a/libs/libartnet/Makefile
+++ b/libs/libartnet/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libartnet
 PKG_VERSION:=1.1.2
-PKG_RELEASE:=1.1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/OpenLightingProject/libartnet/releases/download/1.1.2

--- a/libs/libartnet/patches/002-gcc7.patch
+++ b/libs/libartnet/patches/002-gcc7.patch
@@ -1,0 +1,13 @@
+diff --git a/artnet/transmit.c b/artnet/transmit.c
+index ce19b11..e882db9 100644
+--- a/artnet/transmit.c
++++ b/artnet/transmit.c
+@@ -163,7 +163,7 @@ int artnet_tx_tod_data(node n, int id) {
+   bloc = 0;
+ 
+   while (remaining > 0) {
+-    memset(&tod.data.toddata.tod,0x00, ARTNET_MAX_UID_COUNT);
++    memset(&tod.data.toddata.tod,0x00, ARTNET_MAX_UID_COUNT * sizeof(tod.data.toddata.tod));
+     lim = min(ARTNET_MAX_UID_COUNT, remaining);
+     tod.data.toddata.blockCount = bloc++;
+     tod.data.toddata.uidCount = lim;


### PR DESCRIPTION
error: memset' used with length equal to number of elements without
multiplication by element size

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @FriedZombie 

