### PR TITLE
python-egenix-mx-base: Update to 3.2.9

### DIFF
--- a/lang/python/python-egenix-mx-base/Makefile
+++ b/lang/python/python-egenix-mx-base/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-egenix-mx-base
-PKG_VERSION:=3.2.8
+PKG_VERSION:=3.2.9
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Dmitry Trefilov <the-alien@live.ru>
 PKG_LICENSE:=eGenix.com Public License 1.1.0
 PKG_LICENSE_FILES:=LICENSE COPYRIGHT
 
-PKG_SOURCE:=egenix-mx-base-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://downloads.egenix.com/python/
-PKG_HASH:=0da55233e45bc3f88870e62e60a79c2c86bad4098b8128343fd7be877f44a3c0
+PKG_SOURCE:=egenix-mx-base-$(PKG_VERSION).zip
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/e/egenix-mx-base
+PKG_HASH:=1844adcc137834724c1aca825dc9e1cbd8d81710f208231ea4bdb6d8b3006a95
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/egenix-mx-base-$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=python
@@ -30,7 +30,7 @@ define Package/python-egenix-mx-base
   CATEGORY:=Languages
   DEPENDS:=+USE_EGLIBC:librt +USE_UCLIBC:librt +python
   TITLE:=Egenix mxBase
-  URL:=http://www.egenix.com/products/python/mxBase/
+  URL:=https://www.egenix.com/products/python/mxBase/
 endef
 
 define Package/python-egenix-mx-base/description


### PR DESCRIPTION
Switched URL to standard pythonhosted one. Only a zip file is available. No .tar.gz.

This should hopefully fix uscan.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dtrefilo-Quest 