### PR TITLE
apfree-wifidog: Add new package

### DIFF
--- a/net/apfree-wifidog/Makefile
+++ b/net/apfree-wifidog/Makefile
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2018 Dengfeng Liu
+#
+# This is free software, licensed under the GNU General Public License v3.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=apfree-wifidog
+PKG_VERSION:=3.8.1588
+PKG_RELEASE=1
+
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+PKG_MAINTAINER:=Dengfeng Liu <liudf0716@gmail.com>
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/liudf0716/apfree_wifidog.git
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
+PKG_MIRROR_HASH:=0d10ad5a29358a7124ba75570894f48998af841519b0f295e3fcbed66ee7bccc
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/apfree-wifidog
+  SUBMENU:=Captive Portals
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+zlib +iptables-mod-extra +iptables-mod-ipopt +kmod-ipt-nat +iptables-mod-nat-extra \
+           +libjson-c +ipset +libip4tc +libevent2 +libevent2-openssl \
+           +fping +libmosquitto +libuci +px5g
+  TITLE:=Apfree's wireless captive portal solution
+  URL:=https://github.com/liudf0716/apfree_wifidog
+endef
+
+define Package/apfree-wifidog/description
+	The ApFree Wifidog project is a complete and embeddable captive
+	portal solution for wireless community groups or individuals
+	who wish to open a free Hotspot while still preventing abuse
+	of their Internet connection.
+	It's enhanced wifidog
+endef
+
+define Package/apfree-wifidog/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wifidog $(1)/usr/bin/wifidogx
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wdctl $(1)/usr/bin/wdctlx
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libhttpd.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/wdping $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/wifidog-msg.html $(1)/etc/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/wifidog-redir.html $(1)/etc/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/wifidog-redir.html.front $(1)/etc/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/wifidog-redir.html.rear $(1)/etc/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/authserver-offline.html $(1)/etc/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/internet-offline.html $(1)/etc/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/wifidogx.init $(1)/etc/init.d/wifidogx
+	$(INSTALL_DIR) $(1)/etc/config
+	$(CP) ./files/wifidogx.conf $(1)/etc/config/wifidogx
+endef
+
+$(eval $(call BuildPackage,apfree-wifidog))

--- a/net/apfree-wifidog/README.md
+++ b/net/apfree-wifidog/README.md
@@ -1,0 +1,125 @@
+![ApFreeWiFiDog](https://github.com/liudf0716/apfree_wifidog/blob/master/logo.png)
+
+
+[![license][1]][2]
+[![PRs Welcome][3]][4]
+[![Issue Welcome][5]][6]
+[![Release Version][7]][8]
+[![OpenWRT][11]][12]
+[![Join the QQ Group][15]][16]
+
+
+[1]: https://img.shields.io/badge/license-GPLV3-brightgreen.svg?style=plastic
+[2]: https://github.com/liudf0716/apfree_wifidog/blob/master/COPYING
+[3]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=plastic
+[4]: https://github.com/liudf0716/apfree_wifidog/pulls
+[5]: https://img.shields.io/badge/Issues-welcome-brightgreen.svg?style=plastic
+[6]: https://github.com/liudf0716/apfree_wifidog/issues/new
+[7]: https://img.shields.io/badge/release-3.11.1716-red.svg?style=plastic
+[8]: https://github.com/liudf0716/apfree_wifidog/releases
+[11]: https://img.shields.io/badge/Platform-%20OpenWRT%7C%20LEDE%20-brightgreen.svg?style=plastic
+[12]: https://github.com/KunTengRom/kunteng-lede-17.01.4
+[13]: https://img.shields.io/badge/KunTeng-Inside-blue.svg?style=plastic
+[14]: https://www.kunteng.org.cn
+[15]: https://img.shields.io/badge/chat-qq%20group-brightgreen.svg
+[16]: https://jq.qq.com/?_wv=1027&k=4ADDSev
+
+## ApFree WiFiDog: A high performance captive portal solution for HTTP(s)
+
+ApFree WiFiDog is a high performance captive portal solution for HTTP(s), which mainly used in ([LEDE](https://github.com/lede-project/source)&[Openwrt](https://github.com/openwrt/openwrt)) platform. 
+
+
+**[中文介绍](https://github.com/liudf0716/apfree_wifidog/blob/master/README_ZH.md)**
+
+## Enhancement of apfree-wifidog 
+
+In fact, the title should be why we choose apfree-wifidog, the reason was the following: 
+
+>  Stable
+
+apfree-wifidog was widely used in tens of thousands device, which were running in business scene. In order to improve its stable, we rewrite all iptables rule by api instead of fork call, which will easily cause deadlock in multithread-fork running environment. we also re-write the code and replace libhttpd (which unmaitained for years) with libevent
+
+> Performance
+
+apfree-wifidog's http request-response is more quick, u can find statistic data in our test document
+
+> HTTPs redirect
+
+apfree-wifidog support https redirect, in current internet environment, captive portal solution without supporting https redirect will become unsuitable gradually
+
+
+> More features
+
+apfree-wifidog support mac temporary-pass, ip,domain,pan-domain,white-mac,black-mac rule and etc. all these rules can be applied without restarting wifidog
+
+> MQTT support
+
+by enable mqtt support, u can remotely deliver such as trusted ip, domian and pan-domain rules to apfree wifidog 
+
+> Compitable with wifidog protocol
+
+u don't need to modify your wifidog authentication server to adapt apfree-wifidog; if u have pression on server-side, apfree wifidog's improved protocol can greatly relieve it, which disabled by default
+
+
+## Getting started
+
+before starting apfree-wifidog, we must know how to configure it. apfree-wifidog use OpenWrt standard uci config system, all your apfree-wifidog configure information stored in `/etc/confg/wifidogx`, which will be parsed by  `/etc/init.d/wifidogx` to /tmp/wifidog.conf, apfree-wifidog's real configure file is `/tmp/wifidog.conf`
+
+The default apfree-wifidog UCI configuration file like this:
+
+```
+config wifidog
+    option  gateway_interface   'br-lan'
+    option  auth_server_hostname    'wifidog.kunteng.org.cn'
+    option  auth_server_port    443
+    option  auth_server_path    '/wifidog/'
+    option  check_interval      60
+    option  client_timeout      5
+    option  apple_cna           1
+    option  thread_number       5
+    option  wired_passed        0
+    option  enable      0
+```
+
+> auth_server_hostname was apfree-wifidog auth server, it can be domain or ip; wifidog.kunteng.org.cn is a free auth server we provided, it was also [open source](https://github.com/wificoin-project/wwas) 
+
+> apple_cna 1 apple captive detect deceive; 2 apple captive detect deceive to  disallow portal page appear
+
+> wired_passed means whether LAN access devices need to auth or not, value 1 means no need to auth 
+
+> enable means whether start apfree-wifidog when we executed `/etc/init.d/wifidogx start`, if u wanted to start apfree-wifidog, you must set enable to 1 before executing `/etc/init.d/wifidogx start`
+
+### How to support https redirect
+
+In order to support https redirect, apfree-wifidog need x509 pem cert and private key, u can generate youself like this:
+
+```
+PX5G_BIN="/usr/sbin/px5g"
+OPENSSL_BIN="/usr/bin/openssl"
+APFREE_CERT="/etc/apfree.crt"
+APFREE_KEY="/etc/apfree.key"
+
+generate_keys() {
+    local days bits country state location commonname
+
+    # Prefer px5g for certificate generation (existence evaluated last)
+    local GENKEY_CMD=""
+    local UNIQUEID=$(dd if=/dev/urandom bs=1 count=4 | hexdump -e '1/1 "%02x"')
+    [ -x "$OPENSSL_BIN" ] && GENKEY_CMD="$OPENSSL_BIN req -x509 -sha256 -outform pem -nodes"
+    [ -x "$PX5G_BIN" ] && GENKEY_CMD="$PX5G_BIN selfsigned -pem"
+    [ -n "$GENKEY_CMD" ] && {
+        $GENKEY_CMD \
+            -days ${days:-730} -newkey rsa:${bits:-2048} -keyout "${APFREE_KEY}.new" -out "${APFREE_CERT}.new" \
+            -subj /C="${country:-CN}"/ST="${state:-localhost}"/L="${location:-Unknown}"/O="${commonname:-ApFreeWiFidog}$UNIQUEID"/CN="${commonname:-ApFreeWiFidog}"
+        sync
+        mv "${APFREE_KEY}.new" "${APFREE_KEY}"
+        mv "${APFREE_CERT}.new" "${APFREE_CERT}"
+    }
+}
+
+```
+
+or when u start `/etc/init.d/wifidogx start`, it will generate it automatically
+
+
+For more information, please refer to the upstream [project page](https://github.com/liudf0716/apfree_wifidog)

--- a/net/apfree-wifidog/files/wdping
+++ b/net/apfree-wifidog/files/wdping
@@ -1,0 +1,7 @@
+#!/bin/sh
+IP=$1
+[ -x /usr/sbin/fping ] && {
+	fping -t 100 -c 1 $IP &> /dev/null && echo 1 || echo 0
+} || {
+	ping -w 1 -c 1 $IP &> /dev/null && echo 1 || echo 0
+}

--- a/net/apfree-wifidog/files/wifidogx.conf
+++ b/net/apfree-wifidog/files/wifidogx.conf
@@ -1,0 +1,13 @@
+config wifidog
+	option	gateway_interface	'br-lan'
+	option	auth_server_hostname	'change wifidog.kunteng.org.cn to your auth server domain or ip'
+	option	auth_server_port	8001
+	option	auth_server_path	'/wifidog/'	
+	option	check_interval		60
+	option	client_timeout		5
+	option	httpd_max_conn		200
+	option	pool_mode			1
+	option	thread_number		5
+	option	queue_size			20
+	option	wired_passed		0
+	option	enable		0

--- a/net/apfree-wifidog/files/wifidogx.init
+++ b/net/apfree-wifidog/files/wifidogx.init
@@ -1,0 +1,302 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2018 Dengfeng Liu
+
+. /lib/functions/network.sh
+
+START=99
+
+USE_PROCD=1
+PROG=/usr/bin/wifidogx
+CONFIGFILE=/tmp/wifidog.conf
+
+EXTRA_COMMANDS="status"
+EXTRA_HELP="        status Print the status of the service"
+
+PX5G_BIN="/usr/sbin/px5g"
+OPENSSL_BIN="/usr/bin/openssl"
+APFREE_CERT="/etc/apfree.crt"
+APFREE_KEY="/etc/apfree.key"
+
+generate_keys() {
+	local days bits country state location commonname
+	local UNIQUEID GENKEY_CMD
+
+		# Prefer px5g for certificate generation (existence evaluated last)
+		UNIQUEID=$(hexdump -n 4 -e '4/1 "%02x" "\n"' /dev/urandom)
+		[ -x "$OPENSSL_BIN" ] && GENKEY_CMD="$OPENSSL_BIN req -x509 -sha256 -outform pem -nodes"
+		[ -x "$PX5G_BIN" ] && GENKEY_CMD="$PX5G_BIN selfsigned -pem"
+		[ -n "$GENKEY_CMD" ] && {
+			$GENKEY_CMD \
+				-days "${days:-720}" -newkey rsa:"${bits:-2048}" -keyout "${APFREE_KEY}.new" -out "${APFREE_CERT}.new" \
+				-subj /C="${country:-CN}"/ST="${state:-Beijing}"/L="${location:-Unknown}"/O="${commonname:-ApFreeWiFidog}$UNIQUEID"/CN="${commonname:-ApFreeWiFidog}"
+			sync
+			mv "${APFREE_KEY}.new" "${APFREE_KEY}"
+			mv "${APFREE_CERT}.new" "${APFREE_CERT}"
+    }
+}
+
+service_trigger() {
+	procd_add_reload_trigger "wifidogx"
+}
+
+echo_firewall_rule() {
+	echo "    FirewallRule $1"
+}
+
+prepare_mqtt_conf() {
+	local cfg=$1
+	local serveraddr
+	local serverport
+
+	config_get serveraddr "$cfg" "serveraddr"
+	config_get serverport "$cfg" "serverport"
+	[ -z "${serveraddr}" -o -z "${serverport}" ] && return 1
+
+	cat <<-EOF >>${CONFIGFILE}
+		MQTT {
+			ServerAddr ${serveraddr}
+			ServerPort ${serverport}
+		}
+	EOF
+}
+
+prepare_wifidog_conf() {
+	local cfg=$1
+	local enable
+	local gateway_id
+	local gateway_interface
+	local auth_server_hostname
+	local auth_server_path
+	local auth_server_path_login
+	local auth_server_path_portal
+	local auth_server_path_msg
+	local auth_server_path_ping
+	local auth_server_path_auth
+	local delta_traffic
+	local check_interval
+	local client_timeout
+	local httpd_max_conn
+	local trusted_domains
+	local js_filter
+	local trusted_maclist
+	local untrusted_maclist
+	local pool_mode
+	local thread_number
+	local queue_size
+	local wired_passed
+	local trusted_iplist
+	local trusted_pan_domains
+	local proxy_port
+	local no_auth
+	local apple_cna
+	local update_domain_interval
+	local dns_timeout
+	local default_gateway_id
+	local external_interface
+	local auth_server_port
+
+	[ -f ${CONFIGFILE} ] && rm -f ${CONFIGFILE}
+
+	config_get enable "${cfg}" "enable" 0
+	[ "${enable}" = "1" ] || return
+
+	default_gateway_id=$(sed -e 's/://g' /sys/class/net/br-lan/address)
+
+	network_get_device external_interface wan
+
+	config_get gateway_id "${cfg}" "gateway_id" "${default_gateway_id}"
+	config_get gateway_interface "${cfg}" "gateway_interface" "br-lan"
+	config_get auth_server_hostname "${cfg}" "auth_server_hostname" 
+	config_get auth_server_port "${cfg}" "auth_server_port" "80"
+	config_get auth_server_path "${cfg}" "auth_server_path" "/wifidog/"
+	config_get auth_server_path_login "${cfg}" "auth_server_path_login"
+	config_get auth_server_path_portal "${cfg}" "auth_server_path_portal"
+	config_get auth_server_path_msg "${cfg}" "auth_server_path_msg"
+	config_get auth_server_path_ping "${cfg}" "auth_server_path_ping"
+	config_get auth_server_path_auth "${cfg}" "auth_server_path_auth"
+	config_get delta_traffic "${cfg}" "delta_traffic"
+	config_get check_interval "${cfg}" "check_interval" "60"
+	config_get js_filter "${cfg}" "js_filter" 1
+	config_get client_timeout "${cfg}" "client_timeout"	"5"
+	config_get httpd_max_conn "${cfg}" "httpd_max_conn"	"200"
+	config_get trusted_domains "${cfg}" "trusted_domains"
+	config_get trusted_maclist "${cfg}" "trusted_maclist"
+	config_get untrusted_maclist "${cfg}" "untrusted_maclist"
+	config_get pool_mode "${cfg}" "pool_mode" 0
+	config_get thread_number "${cfg}" "thread_number" 20
+	config_get queue_size "${cfg}" "queue_size" 200
+	config_get wired_passed "${cfg}" "wired_passed" 1
+	config_get trusted_iplist "${cfg}" "trusted_iplist"
+	config_get trusted_pan_domains "${cfg}" "trusted_pan_domains"
+	config_get proxy_port "${cfg}" "proxy_port"
+	config_get no_auth "${cfg}" "no_auth"
+	config_get apple_cna "${cfg}" "bypass_apple_cna"
+	config_get update_domain_interval "${cfg}" "update_domain_interval"
+	config_get dns_timeout "${cfg}" "dns_timeout"
+
+	local set_auth_server_path_login
+	local set_auth_server_path_portal
+	local set_auth_server_path_msg
+	local set_auth_server_path_ping
+	local set_auth_server_path_auth
+	local set_delta_traffic
+	local set_trusted_maclist
+	local set_untrusted_maclist
+	local set_trusted_domains
+	local set_trusted_iplist
+	local set_trusted_pan_domains
+	local set_proxy_port
+	local set_no_auth
+	local set_firewall_rule_global
+	local set_firewall_rule_validating_users
+	local set_firewall_rule_known_users
+	local set_firewall_rule_auth_is_down
+	local set_firewall_rule_unknown_users
+	local set_firewall_rule_locked_users
+	local set_apple_cna
+	local set_update_domain_interval
+	local set_dns_timeout
+	
+	set_auth_server_path_login=$([ -n "$auth_server_path_login" ] && echo "    LoginScriptPathFragment $auth_server_path_login")
+	set_auth_server_path_portal=$([ -n "$auth_server_path_portal" ] && echo "    PortalScriptPathFragment $auth_server_path_portal")
+	set_auth_server_path_msg=$([ -n "$auth_server_path_msg" ] && echo "    MsgScriptPathFragment $auth_server_path_msg")
+	set_auth_server_path_ping=$([ -n "$auth_server_path_ping" ] && echo "    PingScriptPathFragment $auth_server_path_ping")
+	set_auth_server_path_auth=$([ -n "$auth_server_path_auth" ] && echo "    AuthScriptPathFragment $auth_server_path_auth") 
+	set_delta_traffic=$([ -n "$delta_traffic" ] && echo "DeltaTraffic $delta_traffic") 
+	set_trusted_maclist=$([ -n "$trusted_maclist" ] && echo "TrustedMACList $trusted_maclist") 
+	set_untrusted_maclist=$([ -n "$untrusted_maclist" ] && echo "UntrustedMACList $untrusted_maclist") 
+	set_trusted_domains=$([ -n "$trusted_domains" ] && echo "TrustedDomains	$trusted_domains")
+	set_trusted_iplist=$([ -n "$trusted_iplist" ] && echo "TrustedIpList	$trusted_iplist")
+	set_trusted_pan_domains=$([ -n "$trusted_pan_domains" ] && echo "TrustedPanDomains	$trusted_pan_domains")
+	set_proxy_port=$([ -n "$proxy_port" ] && echo "Proxyport	$proxy_port")
+	set_no_auth=$([ -n "$no_auth"  ] && echo "NoAuth  $no_auth")
+	set_firewall_rule_global=$(config_list_foreach "$cfg" "firewall_rule_global" echo_firewall_rule)
+	set_firewall_rule_validating_users=$(config_list_foreach "$cfg" "firewall_rule_validating_users" echo_firewall_rule)
+	set_firewall_rule_known_users=$(config_list_foreach "$cfg" "firewall_rule_known_users" echo_firewall_rule)
+	set_firewall_rule_auth_is_down=$(config_list_foreach "$cfg" "firewall_rule_auth_is_down" echo_firewall_rule)
+	set_firewall_rule_unknown_users=$(config_list_foreach "$cfg" "firewall_rule_unknown_users" echo_firewall_rule)
+	set_firewall_rule_locked_users=$(config_list_foreach "$cfg" "firewall_rule_locked_users" echo_firewall_rule)
+	set_apple_cna=$([ -n "$apple_cna"  ] && echo "BypassAppleCNA $apple_cna")
+	set_update_domain_interval=$([ -n "$update_domain_interval" ] && echo "UpdateDomainInterval $update_domain_interval")
+	set_dns_timeout=$([ -n "$dns_timeout" ] && echo "DNSTimeout $dns_timeout")
+	
+	cat <<-EOF >$CONFIGFILE
+		GatewayID $gateway_id
+		GatewayInterface $gateway_interface
+		Externalinterface $external_interface
+ 
+		AuthServer {
+			Hostname $auth_server_hostname
+			HTTPPort $auth_server_port
+			Path $auth_server_path
+			$set_auth_server_path_login
+			$set_auth_server_path_portal
+			$set_auth_server_path_msg
+			$set_auth_server_path_ping
+			$set_auth_server_path_auth
+		}
+ 
+		$set_delta_traffic
+		CheckInterval $check_interval
+		ClientTimeout $client_timeout
+		JsFilter $js_filter
+		WiredPassed $wired_passed
+
+		HTTPDMaxConn $httpd_max_conn
+
+		PoolMode $pool_mode
+		ThreadNumber $thread_number
+		QueueSize $queue_size
+
+		$set_trusted_domains
+
+		$set_untrusted_maclist
+
+		$set_trusted_maclist
+
+		$set_trusted_iplist
+
+		$set_trusted_pan_domains
+
+		$set_proxy_port
+
+		$set_no_auth
+
+		$set_apple_cna
+
+		$set_update_domain_interval
+
+		$set_dns_timeout
+
+		FirewallRuleSet global {
+			$set_firewall_rule_global
+		}
+ 
+		FirewallRuleSet validating-users {
+			$set_firewall_rule_validating_users
+			FirewallRule allow to 0.0.0.0/0
+		}
+ 
+		FirewallRuleSet known-users {
+			$set_firewall_rule_known_users
+			FirewallRule allow to 0.0.0.0/0
+		}
+ 
+		FirewallRuleSet auth-is-down {
+			$set_firewall_rule_auth_is_down
+		}
+ 
+		FirewallRuleSet unknown-users {
+			$set_firewall_rule_unknown_users
+			FirewallRule allow udp port 53
+			FirewallRule allow tcp port 53
+			FirewallRule allow udp port 67
+			FirewallRule allow tcp port 67
+		}
+ 
+		FirewallRuleSet locked-users {
+			$set_firewall_rule_locked_users
+			FirewallRule block to 0.0.0.0/0
+		}
+EOF
+}
+
+init_config() {
+	config_load wifidogx
+	config_foreach prepare_wifidog_conf wifidog
+
+	[ ! -f ${CONFIGFILE} ] && {
+		echo "no wifidog.conf, exit..."
+		stop
+		exit
+	}
+	
+	[ -s "${APFREE_CERT}" -a -s "${APFREE_KEY}" ] || {
+		generate_keys
+	}
+	
+	[ -s ${APFREE_KEY} -a -s ${APFREE_CERT} ] || {
+		echo "no cert or key, exit..."
+		stop
+		exit
+	}
+
+	config_foreach prepare_mqtt_conf mqtt
+	
+	sed -i -e '/^$/d' ${CONFIGFILE}
+}
+
+start_service() {
+	init_config
+
+	procd_open_instance
+	# -f: run in foreground
+	procd_set_param command $PROG -c $CONFIGFILE -f -d 0
+	procd_set_param respawn # respawn automatically if something died
+	procd_set_param file $CONFIGFILE
+	procd_close_instance
+}
+
+status() {
+	/usr/bin/wdctlx status
+}


### PR DESCRIPTION
Signed-off-by: Dengfeng Liu <liudengfeng@kunteng.org.cn>

Maintainer: me / @liudf0716
Compile tested: x86, x86_64, CentOS 7, OpenWrt master 7e73e912
Run tested: arm, R7800, OpenWrt master 7e73e912

Description:
comparing with wifidog, apfree-wifidog is an impoved solution, which is more stable and more efficient. apfree-wifidog was widely used at business scene especially in china.
