### PR TITLE
socat: Do not use libbsd

### DIFF
--- a/net/socat/Makefile
+++ b/net/socat/Makefile
@@ -68,6 +68,8 @@ CONFIGURE_VARS += \
 	sc_cv_sys_crdly_shift=9 \
 	sc_cv_sys_tabdly_shift=11 \
 	sc_cv_sys_csize_shift=4 \
+	ac_cv_header_bsd_libutil_h=no \
+	ac_cv_lib_bsd_openpty=no \
 	BUILD_DATE=$(SOURCE_DATE_EPOCH)
 
 define Package/socat/install


### PR DESCRIPTION
Make sure that libbsd is not picked up during configuration even if it is
compiled before socat is.

Signed-off-by: Michal Hrusecky <michal.hrusecky@nic.cz>

Maintainer: @thess 
Compile tested: mvebu, master
Run tested: mvebu, Turris Omnia, master, runs