### PR TITLE
coremark: Add coremark package

### DIFF
--- a/utils/coremark/Makefile
+++ b/utils/coremark/Makefile
@@ -34,7 +34,7 @@ endef
 define Build/Compile
 	$(SED) 's|EXE = .exe|EXE =|' $(PKG_BUILD_DIR)/linux/core_portme.mak
 	mkdir $(PKG_BUILD_DIR)/$(ARCH)
-	cp -r $(PKG_BUILD_DIR)/linux/* $(PKG_BUILD_DIR)/$(ARCH)
+	$(CP) -r $(PKG_BUILD_DIR)/linux/* $(PKG_BUILD_DIR)/$(ARCH)
 	$(MAKE) -C $(PKG_BUILD_DIR) PORT_DIR=$(ARCH) $(MAKE_FLAGS) \
 		compile 
 endef

--- a/utils/coremark/Makefile
+++ b/utils/coremark/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2018 Lim Guo Wei
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=coremark
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/eembc/coremark.git
+PKG_SOURCE_VERSION:=509d8ef94ca17e527fd085c53f2a14a165a3650a
+PKG_SOURCE_DATE:=2018-05-31
+PKG_MAINTAINER:=Lim Guo Wei <limguowei@gmail.com>
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE.md
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/coremark
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=CoreMark Embedded Microprocessor Benchmark
+  URL:=https://github.com/eembc/coremark
+endef
+
+define Package/coremark/description
+  Embedded Microprocessor Benchmark
+endef
+
+define Build/Compile
+	$(SED) 's|EXE = .exe|EXE =|' $(PKG_BUILD_DIR)/linux/core_portme.mak
+	mkdir $(PKG_BUILD_DIR)/$(ARCH)
+	cp -r $(PKG_BUILD_DIR)/linux/* $(PKG_BUILD_DIR)/$(ARCH)
+	$(MAKE) -C $(PKG_BUILD_DIR) PORT_DIR=$(ARCH) $(MAKE_FLAGS) \
+		compile 
+endef
+
+define Package/coremark/install
+	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/coremark $(1)/bin/
+endef
+
+$(eval $(call BuildPackage,coremark))


### PR DESCRIPTION
Signed-off-by: Lim Guo Wei <limguowei@gmail.com>

Maintainer: Lim Guo Wei
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (AR71xx, WDR4300, 17.01, Run coremark binary expect result obtained)

Description:
CoreMark(r) is an industry-standard benchmark that measures the performance of central processing units (CPU) and embedded microcrontrollers (MCU).