### PR TITLE
lib/expat: Update to 2.2.6

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
-PKG_VERSION:=2.2.5
+PKG_VERSION:=2.2.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/expat
-PKG_HASH:=d9dc32efba7e74f788fcc4f212a43216fc37cf5f23f4c2339664d473353aedf6
+PKG_HASH:=17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2
 PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>, \
 		Ted Hess <thess@kitschensync.net>
 


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: apm821xx, WD MyBook Live, OpenWrt master
Run tested: apm821xx, WD MyBook Live, OpenWrt master

Description:
Update (lib)expat to 2.2.6

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>