### PR TITLE
libtalloc: Remove libbsd dependencies. Add myself as maintainer

### DIFF
--- a/libs/libtalloc/Makefile
+++ b/libs/libtalloc/Makefile
@@ -1,6 +1,4 @@
 #
-# Copyright (C) 2016 OpenWrt.org
-#
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
@@ -10,13 +8,13 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=talloc
 PKG_VERSION:=2.1.14
 MAJOR_VERSION:=2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.samba.org/ftp/talloc
 PKG_HASH:=b185602756a628bac507fa8af8b9df92ace69d27c0add5dab93190ad7c3367ce
 
-PKG_MAINTAINER:=Lucile Quirion <lucile.quirion@savoirfairelinux.com>
+PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=LGPL-3.0+
 
 PKG_BUILD_PARALLEL:=0
@@ -28,7 +26,7 @@ define Package/libtalloc
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Core memory allocator used in Samba
-  DEPENDS:=+USE_GLIBC:libbsd $(ICONV_DEPENDS) +libattr
+  DEPENDS:=$(ICONV_DEPENDS) +libattr
   URL:=https://talloc.samba.org/talloc/doc/html/index.html
 endef
 

--- a/libs/libtalloc/patches/100-Remove_libbsd_dependency_check.patch
+++ b/libs/libtalloc/patches/100-Remove_libbsd_dependency_check.patch
@@ -1,0 +1,58 @@
+--- a/lib/replace/wscript
++++ b/lib/replace/wscript
+@@ -340,22 +340,13 @@ def configure(conf):
+ 
+     conf.CHECK_FUNCS('prctl dirname basename')
+ 
+-    strlcpy_in_bsd = False
++    # Not checking for libbsd
++    conf.CHECK_FUNCS('strlcpy strlcat')
++    conf.CHECK_FUNCS('getpeereid')
++    conf.CHECK_FUNCS_IN('setproctitle', 'setproctitle', headers='setproctitle.h')
++    conf.CHECK_FUNCS('setproctitle_init')
+ 
+-    # libbsd on some platforms provides strlcpy and strlcat
+-    if not conf.CHECK_FUNCS('strlcpy strlcat'):
+-        if conf.CHECK_FUNCS_IN('strlcpy strlcat', 'bsd', headers='bsd/string.h',
+-                               checklibc=True):
+-            strlcpy_in_bsd = True
+-    if not conf.CHECK_FUNCS('getpeereid'):
+-        conf.CHECK_FUNCS_IN('getpeereid', 'bsd', headers='sys/types.h bsd/unistd.h')
+-    if not conf.CHECK_FUNCS_IN('setproctitle', 'setproctitle', headers='setproctitle.h'):
+-        conf.CHECK_FUNCS_IN('setproctitle', 'bsd', headers='sys/types.h bsd/unistd.h')
+-    if not conf.CHECK_FUNCS('setproctitle_init'):
+-        conf.CHECK_FUNCS_IN('setproctitle_init', 'bsd', headers='sys/types.h bsd/unistd.h')
+-
+-    if not conf.CHECK_FUNCS('closefrom'):
+-        conf.CHECK_FUNCS_IN('closefrom', 'bsd', headers='bsd/unistd.h')
++    conf.CHECK_FUNCS('closefrom')
+ 
+     conf.CHECK_CODE('''
+                 struct ucred cred;
+@@ -698,9 +689,6 @@ def configure(conf):
+ 
+     # look for a method of finding the list of network interfaces
+     for method in ['HAVE_IFACE_GETIFADDRS', 'HAVE_IFACE_AIX', 'HAVE_IFACE_IFCONF', 'HAVE_IFACE_IFREQ']:
+-        bsd_for_strlcpy = ''
+-        if strlcpy_in_bsd:
+-            bsd_for_strlcpy = ' bsd'
+         if conf.CHECK_CODE('''
+                            #define %s 1
+                            #define NO_CONFIG_H 1
+@@ -713,7 +701,7 @@ def configure(conf):
+                            #include "test/getifaddrs.c"
+                            ''' % method,
+                            method,
+-                           lib='nsl socket' + bsd_for_strlcpy,
++                           lib='nsl socket',
+                            addmain=False,
+                            execute=True):
+             break
+@@ -761,7 +749,6 @@ def build(bld):
+                 break
+ 
+     extra_libs = ''
+-    if bld.CONFIG_SET('HAVE_LIBBSD'): extra_libs += ' bsd'
+ 
+     bld.SAMBA_SUBSYSTEM('LIBREPLACE_HOSTCC',
+         REPLACE_HOSTCC_SOURCE,


### PR DESCRIPTION
Maintainer: me
Compile tested: mips_24kc, Trunk
Run tested: N/A

Description:
libbsd is un-necessary for this library. However, if libbsd exists in build tree it is used. This patch removes the dependency check in the waf configure script (lib/replace/wscript)

Building either with or without libbsd present now produces the same package - that is without the libbsd dependency.

Previouis maintainer no longer has a Github account AFAICT.

Signed-off-by: Ted Hess <thess@kitschensync.net>
