### PR TITLE
[openwrt-18.06] nut: Fix procd integration and FSD

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -63,6 +63,7 @@ define Package/nut/install
 endef
 
 define Package/nut-server/install
+	# Server portion
 	$(INSTALL_DIR) $(1)/etc/nut
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/etc/init.d
@@ -70,14 +71,15 @@ define Package/nut-server/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/nut-server.init $(1)/etc/init.d/nut-server
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/upsd $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/upsdrvctl $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/nut/cmdvartab $(1)/usr/share/nut/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/nut/driver.list $(1)/usr/share/nut/
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nut_server $(1)/etc/config/nut_server
-	ln -sf /var/etc/nut/ups.conf $(1)/etc/nut/ups.conf
 	ln -sf /var/etc/nut/upsd.users  $(1)/etc/nut/upsd.users
 	ln -sf /var/etc/nut/upsd.conf $(1)/etc/nut/upsd.conf
+	# Driver common portion
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/upsdrvctl $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/nut/driver.list $(1)/usr/share/nut/
+	ln -sf /var/etc/nut/ups.conf $(1)/etc/nut/ups.conf
 endef
 
 define Package/nut-common
@@ -110,6 +112,7 @@ define Package/nut-server
 	$(call Package/nut/Default)
 	TITLE+= (server)
 	DEPENDS:=nut +nut-common
+	USERID:=nut=113:nut=113
 endef
 
 define Package/nut-server/description
@@ -123,9 +126,9 @@ endef
 
 define Package/nut-server/conffiles
 /etc/config/nut_server
-/etc/nut/ups.conf
 /etc/nut/upsd.conf
 /etc/nut/upsd.users
+/etc/nut/ups.conf
 endef
 
 define Package/nut-upsmon
@@ -349,7 +352,7 @@ define DriverPackage
         define Package/nut-driver-$(2)
 		$(call Package/nut/Default)
 		TITLE:=$(2) (NUT $(1) driver)
-		DEPENDS:=nut +nut-common
+		DEPENDS:=nut +nut-server
 		$(if $(filter $(1),snmp),DEPENDS+= @NUT_DRIVER_SNMP)
 		$(if $(filter $(1),usb),DEPENDS+= @NUT_DRIVER_USB)
 		$(if $(filter $(1),serial),DEPENDS+= @NUT_DRIVER_SERIAL)

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -75,7 +75,6 @@ define Package/nut-server/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/nut/driver.list $(1)/usr/share/nut/
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nut_server $(1)/etc/config/nut_server
-	ln -sf /var/etc/nut/nut.conf $(1)/etc/nut/nut.conf
 	ln -sf /var/etc/nut/ups.conf $(1)/etc/nut/ups.conf
 	ln -sf /var/etc/nut/upsd.users  $(1)/etc/nut/upsd.users
 	ln -sf /var/etc/nut/upsd.conf $(1)/etc/nut/upsd.conf
@@ -94,6 +93,10 @@ endef
 define Package/nut-common/description
 $(call Package/nut/description/Default)
 This package contains the common files.
+endef
+
+define Package/nut-common/conffiles
+/etc/nut/nut.conf
 endef
 
 define Package/nut-common/install
@@ -120,6 +123,9 @@ endef
 
 define Package/nut-server/conffiles
 /etc/config/nut_server
+/etc/nut/ups.conf
+/etc/nut/upsd.conf
+/etc/nut/upsd.users
 endef
 
 define Package/nut-upsmon
@@ -141,6 +147,7 @@ endef
 
 define Package/nut-upsmon/conffiles
 /etc/config/nut_monitor
+/etc/nut/upsmon.conf
 endef
 
 define Package/nut-upsmon/install

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -80,6 +80,16 @@ define Package/nut-server/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/upsdrvctl $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/nut/driver.list $(1)/usr/share/nut/
 	ln -sf /var/etc/nut/ups.conf $(1)/etc/nut/ups.conf
+	# Mangle libhid.usermap into a format (hotplug shell script) useful for OpenWrt
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/usb
+	$(INSTALL_BIN) ./files/30-libhid-ups.head $(1)/etc/hotplug.d/usb/30-libhid-ups
+	$(CP) $(PKG_INSTALL_DIR)/etc/hotplug/usb/libhid.usermap $(PKG_BUILD_DIR)/30-libhid-ups.middle
+	$(SED) '/^$$$$/d' \
+		-e '/^#/d' \
+		-E -e 's:^[^ ][^ ]*  *0x0003  *0x0{0,3}([^ ][^ ]*)  *0x{0,3}*([^ ][^ ]*).*:\1/\2/* | \\:' \
+		$(PKG_BUILD_DIR)/30-libhid-ups.middle
+	tail -n+2 $(PKG_BUILD_DIR)/30-libhid-ups.middle >>$(1)/etc/hotplug.d/usb/30-libhid-ups
+	cat ./files/30-libhid-ups.tail >>$(1)/etc/hotplug.d/usb/30-libhid-ups
 endef
 
 define Package/nut-common
@@ -515,6 +525,7 @@ CONFIGURE_ARGS += \
 	--without-neon \
 	--without-powerman \
 	--without-wrap \
+	--with-hotplug-dir=/etc/hotplug \
 	--with-cgi \
 	--without-ipmi \
 	--without-freeipmi \

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -169,6 +169,7 @@ define Package/nut-upsmon/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/nut-monitor.init $(1)/etc/init.d/nut-monitor
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/upsmon $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/nutshutdown $(1)/usr/sbin/nutshutdown
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nut_monitor $(1)/etc/config/nut_monitor
 	ln -sf /var/etc/nut/upsmon.conf $(1)/etc/nut/upsmon.conf

--- a/net/nut/files/30-libhid-ups.head
+++ b/net/nut/files/30-libhid-ups.head
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+nut_driver_config() {
+	local cfg="$1"
+	local nomatch="$2"
+
+	config_get runas "$cfg" runas "nut"
+	config_get vendorid "$cfg" vendorid
+	config_get productid "$cfg" productid
+
+	[ "$ACTION" = "add" ] &&[ -n "$DEVNAME" ] && {
+		chmod 0660 /dev/"$DEVNAME"
+		chown ${runas:-root}:$(id -gn "${runas:-root}") /dev/"$DEVNAME"
+	}
+
+	if [ "$(printf "%04x" 0x"$pvendid")" = "$vendorid" ] && \
+		[ "$(printf "%04x" 0x"$pprodid")" = "$productid" ]; then
+			[ "$ACTION" = "add" ] && {
+				/etc/init.d/nut-server start "$cfg"
+			}
+			[ "$ACTION" = "remove" ] && {
+				/etc/init.d/nut-server stop "$cfg"
+			}
+			found=1
+	elif [ "$nomatch" = "1" ]; then
+		[ "$ACTION" = "add" ] && {
+			/etc/init.d/nut-server start "$cfg"
+		}
+		[ "$ACTION" = "remove" ] && {
+			/etc/init.d/nut-server stop "$cfg"
+		}
+	fi
+}
+
+perform_libhid_action() {
+	local vendorid productid runas
+	local pvendid pprodid found
+
+	pvendid=${PRODUCT%/*}
+	pvendid=${pvendid%/*}
+	pprodid=${PRODUCT%/*}
+	pprodid=${pprodid##*/}
+
+	config_load nut_server
+	config_foreach nut_driver_config driver 0
+	[ "$found" != "1" ] && config_foreach nut_driver_config driver 1
+}
+
+[ -n "$PRODUCT" ] && case "$PRODUCT" in

--- a/net/nut/files/30-libhid-ups.tail
+++ b/net/nut/files/30-libhid-ups.tail
@@ -1,0 +1,5 @@
+"")
+	[ -d /var/run/nut ] && [ ! -f /var/run/nut/disable-hotplug ] && \
+		/etc/init.d/nut-server enabled &&  perform_libhid_action
+	;;
+esac

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -15,7 +15,7 @@ nut_upsmon_conf() {
 	config_get val "$cfg" minsupplies 1
 	echo "MINSUPPLIES $val" >> $UPSMON_C
 
-	config_get val "$cfg" shutdowncmd "/sbin/halt"
+	config_get val "$cfg" shutdowncmd "/usr/sbin/nutshutdown"
 	echo "SHUTDOWNCMD \"$val\"" >> $UPSMON_C
 
 	config_get val "$cfg" notifycmd

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -126,12 +126,6 @@ nut_upsmon_add() {
 	local password
 	local system
 
-	# if UPSMON_C is a symlink we're only doing generated config
-	[ -L $UPSMON_C ] && {
-		rm -f $UPSMON_C
-		nut_upsmon_conf ""
-	}
-
 	config_get upsname "$cfg" upsname
 	config_get hostname "$cfg" hostname localhost
 	config_get port "$cfg" port
@@ -145,37 +139,46 @@ nut_upsmon_add() {
 	echo "MONITOR $system $powervalue $username $password $type" >> $UPSMON_C
 }
 
-start_service() {
-	mkdir -p "$(dirname "$UPSMON_C")"
-	chmod 750 "$(dirname "$UPSMON_C")"
+build_config() {
+	local runas
+	mkdir -m 0750 -p "$(dirname "$UPSMON_C")"
 
 	config_load nut_monitor
-
 	config_foreach nut_upsmon_conf upsmon
 	config_foreach nut_upsmon_add master master
 	config_foreach nut_upsmon_add slave slave
 
-	[ -z "$(cat /var/etc/nut/nut.conf)" ] && echo "MODE=netclient" >>/var/etc/nut/nut.conf
-
-	chmod 640 $UPSMON_C
-	chmod 640 /var/etc/nut/nut.conf
-
-	chown ${runas:-root}:$(id -gn ${runas:-root}) /var/etc/nut
-	chown ${runas:-root}:$(id -gn ${runas:-root}) /var/etc/nut/nut.conf
-	chown ${runas:-root}:$(id -gn ${runas:-root}) $UPSMON_C
-
-	[ -d /var/run/nut ] || {
-		mkdir -m 0750 -p /var/run/nut
-		chown ${runas:-root}:$(id -gn ${runas:-root}) /var/run/nut
+	[ -z "$(cat /var/etc/nut/nut.conf)" ] && {
+		echo "MODE=netclient" >>/var/etc/nut/nut.conf
+		chmod 640 /var/etc/nut/nut.conf
+		chgrp $(id -gn ${runas:-root}) /var/etc/nut/nut.conf
 	}
 
-	exec $DEBUG /usr/sbin/upsmon $UPSMON_OPTIONS
+	chmod 640 "$UPSMON_C"
+	chgrp $(id -gn ${runas:-root}) "$UPSMON_C"
 }
 
-stop_service() {
-	exec /usr/sbin/upsmon -c stop
+start_service() {
+	build_config
+	procd_open_instance
+	procd_set_param respawn
+	procd_set_param stderr 0
+	procd_set_param stdout 1
+	procd_set_param command /usr/sbin/upsmon -D
+	procd_close_instance
 }
 
 reload_service() {
-	exec /usr/sbin/upsmon -c reload
+	if pgrep upsmon >/dev/null 2>/dev/null; then
+		build_config
+		upsmon -c reload
+	else
+		stop
+		sleep 1
+		start
+	fi
+}
+
+service_triggers() {
+	procd_add_reload_trigger nut_monitor
 }

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -6,13 +6,37 @@
 #
 START=50
 
-RUN_D=/var/run
-PID_F=$RUN_D/upsd.pid
-UPS_C=/var/etc/nut/ups.conf
 USERS_C=/var/etc/nut/upsd.users
 UPSD_C=/var/etc/nut/upsd.conf
+UPS_C=/var/etc/nut/ups.conf
 
 USE_PROCD=1
+
+get_write_driver_config() {
+	local cfg="$1"
+	local var="$2"
+	local def="$3"
+	local flag="$4"
+	local val
+
+	[ -z "$flag" ] && {
+		config_get val "$cfg" "$var" "$def"
+		[ -n "$val" ] && [ "$val" != "0" ] && echo "$var = $val" >>"$UPS_C"
+	}
+
+	[ -n "$flag" ] && {
+		config_get_bool val "$cfg" "$var" "$def"
+		[ "$val" = 1 ] && echo "$var" >>"$UPS_C"
+	}
+}
+
+upsd_statepath() {
+	local cfg="$1"
+	local statepath
+
+	config_get statepath "$cfg" statepath "/var/run/nut"
+	STATEPATH="$statepath"
+}
 
 listen_address() {
     local cfg="$1"
@@ -22,18 +46,17 @@ listen_address() {
     echo "LISTEN $address $port" >>$UPSD_C
 }
 
-upsd_statepath() {
-    local cfg="$1"
-    config_get statepath "$cfg" statepath
-}
-
 upsd_config() {
     local cfg="$1"
-    local maxage maxconn certfile
+    local maxage maxconn certfile runas statepath
 
     # Note runas support requires you make sure USB device file is readable by
     # the runas user
-    config_get runas "$cfg" runas
+    config_get runas "$cfg" runas "nut"
+    RUNAS="$runas"
+
+    config_get statepath "$cfg" statepath "/var/run/nut"
+    STATEPATH="$statepath"
 
     config_get maxage "$cfg" maxage
     [ -n "$maxage" ] && echo "MAXAGE $maxage" >>$UPSD_C
@@ -78,81 +101,158 @@ nut_user_add() {
 	fi
 }
 
-start_service() {
-	local runas statepath
-
-        mkdir -p /var/etc/nut
-	chmod -R 750 /var/etc/nut
-
-	rm -f $UPSD_C
-	rm -f $USERS_C
-	rm -f $UPSD_C
+build_server_config() {
+        mkdir -m 0755 -p "$(dirname "$UPSD_C")"
+	rm -f "$USERS_C"
+	rm -f "$UPSD_C"
 	rm -f /var/etc/nut/nut.conf
 
-	echo "# Config file automatically generated from UCI config" > $UPS_C
 	echo "# Config file automatically generated from UCI config" > $USERS_C
 	echo "# Config file automatically generated from UCI config" > $UPSD_C
 
-        local in_driver have_drivers
-	config_cb() {
-	    if [ "$1" != "driver" ]; then
-		in_driver=
-	    else
-		echo "[$2]" >> $UPS_C
-		in_driver=true
-		have_drivers=true
-	    fi
-	}
-	option_cb() {
-	    if [ "$in_driver" = "true" ]; then
-		echo " $1 = $2" >> $UPS_C
-	    fi
-	}
-
-	config_load nut_server
-
 	config_foreach nut_user_add user
-	config_foreach upsd_config upsd
 	config_foreach listen_address listen_address
-
+	config_foreach upsd_config upsd
 	echo "MODE=netserver" >>/var/etc/nut/nut.conf
 
 	chmod 0640 $USERS_C
 	chmod 0640 $UPS_C
 	chmod 0640 $UPSD_C
 	chmod 0640 /var/etc/nut/nut.conf
-	[ -d "${statepath:-/var/run/nut}" ] || {
-		mkdir -m 0750 -p "${statepath:-/var/run/nut}"
-		chown $runas:$(id -gn $runas) "${statepath:-/var/run/nut}"
+
+	[ -d "${STATEPATH}" ] || {
+		mkdir -m 0750 -p "${STATEPATH}"
 	}
 
-	if [ -n "$runas" ]; then
-		chown -R $runas:$(id -gn $runas) /var/etc/nut
-	fi
-
-	if [ "$have_drivers" = "true" ]; then
-	    $DEBUG /usr/sbin/upsd ${runas:+-u $runas} $OPTIONS
-	    $DEBUG /usr/sbin/upsdrvctl ${runas:+-u $runas} start
+	if [ -n "$RUNAS" ]; then
+		chown $RUNAS:$(id -gn $RUNAS) "${STATEPATH}"
+		chgrp $(id -gn $RUNAS) "$USERS_C"
+		chgrp $(id -gn $RUNAS) "$UPSD_C"
 	fi
 }
 
-
-nut_driver_stop() {
+build_driver_config() {
 	local cfg="$1"
+	local runas
+
+	echo "[$cfg]" >>"$UPS_C"
+
+	config_get runas "$cfg" runas "nut"
+	RUNAS="$runas"
+
+	get_write_driver_config "$cfg" driver "usbhid-ups"
+	get_write_driver_config "$cfg" port "auto"
+	get_write_driver_config "$cfg" mfr
+	get_write_driver_config "$cfg" model
+	get_write_driver_config "$cfg" serial
+	get_write_driver_config "$cfg" sdtime
+	get_write_driver_config "$cfg" offdelay 20
+	get_write_driver_config "$cfg" ondelay 30
+	get_write_driver_config "$cfg" pollfreq 30
+	get_write_driver_config "$cfg" vendor
+	get_write_driver_config "$cfg" product
+	get_write_driver_config "$cfg" bus
+	get_write_driver_config "$cfg" interruptonly 0 1
+	get_write_driver_config "$cfg" interruptsize 0
+	get_write_driver_config "$cfg" maxreport
+	get_write_driver_config "$cfg" vendorid
+	get_write_driver_config "$cfg" productid
+	get_write_driver_config "$cfg" community
+	get_write_driver_config "$cfg" snmp_version
+	get_write_driver_config "$cfg" snmp_retries 0
+	get_write_driver_config "$cfg" snmp_timeout 0
+	get_write_driver_config "$cfg" notransferoids 0 1
+	get_write_driver_config "$cfg" other
+	echo "" >>$UPS_C
+}
+
+build_config() {
+        mkdir -m 0755 -p "$(dirname "$UPS_C")"
+	rm -f "$UPS_C"
+	echo "# Config file automatically generated from UCI config" > "$UPS_C"
+	chmod 0640 "$UPS_C"
+
+	config_load nut_server
+	config_foreach build_driver_config driver
+	[ -n "$RUNAS" ] && chgrp $(id -gn $RUNAS) "$UPS_C"
+
+	build_server_config
+}
+
+start_driver_instance() {
+	local cfg="$1"
+	local requested="$2"
+	local RUNAS=nut
 	local driver
 
-	config_get driver "$cfg" driver
+	# If wanting a specific instance, only start it
+	[ "$requested" != "$cfg" ] && [ x"$requested" != x"" ] && return 0
 
-	[ -r ${statepath:-/var/run/nut}/$driver-$cfg ] && /usr/sbin/upsdrvctl stop $cfg
+	mkdir -m 0755 -p "$(dirname "$UPS_C")"
+
+	[ ! -s "$UPS_C" ] && build_config
+
+
+	# Avoid hotplug inadvertenly restarting driver during
+	# forced shutdown
+	[ -f /var/run/killpower ] && return 0
+	[ -d /var/run/nut ] && [ -f /var/run/nut/disable-hotplug ] && return 0
+
+
+	if [ -n "$RUNAS" ]; then
+		chown $RUNAS:$(id -gn $RUNAS) "${STATEPATH}"
+		chown $RUNAS:$(id -gn $RUNAS) "$(dirname "$UPS_C")"
+	fi
+
+	config_get driver "$cfg" driver "usbhid-ups"
+	procd_open_instance "$cfg"
+	procd_set_param respawn
+	procd_set_param stderr 0
+	procd_set_param stdout 1
+	procd_set_param command /lib/nut/${driver} -D -a "$cfg" ${RUNAS:+-u $RUNAS}
+	procd_close_instance
 }
 
-stop_service() {
-	[ -r $PID_F ] && /usr/sbin/upsd -c stop
-	config_load ups
+start_server_instance() {
+	local RUNAS STATEPATH
+	build_config
+
+	procd_open_instance "upsd"
+	procd_set_param respawn
+	procd_set_param stderr 0
+	procd_set_param stdout 1
+	procd_set_param command /usr/sbin/upsd -D ${RUNAS:+-u $RUNAS}
+	procd_close_instance
+}
+
+start_service() {
+	local STATEPATH=/var/run/nut
+
+	# Avoid hotplug inadvertenly restarting driver during
+	# forced shutdown
+	[ -f /var/run/killpower ] && return 0
+	[ -d /var/run/nut ] && [ -f /var/run/nut/disable-hotplug ] && return 0
+
+	config_load nut_server
 	config_foreach upsd_statepath upsd
-	config_foreach nut_driver_stop driver
+
+	[ -d "${STATEPATH}" ] || {
+		mkdir -m 0750 -p "${STATEPATH}"
+	}
+
+	build_config
+	config_foreach start_driver_instance driver "$@"
+
+	[ "$1" != "upsd" ] && [ x"$1" != x"" ] && return 0
+	start_server_instance "upsd"
 }
 
 reload_service() {
-	upsd -c reload
+	stop
+	sleep 2
+	start
+}
+
+service_triggers() {
+	procd_add_reload_trigger "nut_server"
 }

--- a/net/nut/files/nut_monitor
+++ b/net/nut/files/nut_monitor
@@ -1,7 +1,7 @@
 #config upsmon 'upsmon'
 #	option runas run-as-user
 #	option minsupplies 1
-#	option shutdowncmd /sbin/halt
+#	option shutdowncmd '/usr/sbin/nutshutdown'
 #	option notifycmd /path/to/cmd
 #	list defaultnotify SYSLOG
 #	option pollfreq 5

--- a/net/nut/files/nut_monitor
+++ b/net/nut/files/nut_monitor
@@ -51,4 +51,3 @@
 #	option powervalue 1
 #	option username upsuser
 #	option password upspassword
-

--- a/net/nut/files/nut_server
+++ b/net/nut/files/nut_server
@@ -19,5 +19,6 @@
 #	option maxage 15
 #	option statepath /var/run/nut
 #	option maxconn 1024
+#	option runas nut
 # NB: certificates only apply to SSL-enabled version
 #       option certfile /usr/local/etc/upsd.pem

--- a/net/nut/files/nutshutdown
+++ b/net/nut/files/nutshutdown
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+. /lib/functions.sh
+
+mount -o remount,ro /overlay /overlay
+mount -o remount,ro / /
+
+stop_instance() {
+	/etc/init.d/nut-server stop "$1"
+}
+
+shutdown_instance() {
+	local cfg="$1"
+	config_get driver "$cfg" driver "usbhid-ups"
+	/lib/nut/${driver} -a "$cfg" -k
+}
+
+[ -f /var/run/killpower ] && {
+	[ -f /etc/config/nut_server ] && {
+		config_load nut_server
+
+		# Can't FSD unless drivers are stopped
+		config_foreach stop_instance driver
+		# Driver will  wait 'offdelay' before shutting down
+		config_foreach shutdown_instance driver
+		# So this can happen
+		poweroff
+		# And just in case
+		sleep 120
+		# Uh-oh failed to poweroff UPS
+		reboot -f
+	} || {
+		poweroff
+	}
+} || {
+	poweroff
+}


### PR DESCRIPTION
Maintainer: me 
Compile & Run tested on ar71xx, CR5000, openwrt-18.06 openwrt & openwrt-packages openwrt-18.06 (tips).

1. Clean slate (sysupgrade -n).  Create configs.
2. Verify monitoring and FSD
3. After reboot verify monitoring and FSD.

Description:
Fixes issues with restarts and stop due to not quite properly procd integrated initscripts and fix FSD by adding a nutshutdown script which upsmon calls.  Fixes https://github.com/openwrt/packages/issues/6843 and the power race that can occur without FSD.