### PR TITLE
postfix: add mysql support & fix start priority

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postfix
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=3.3.1
 PKG_SOURCE_URL:= \
 	https://cdn.postfix.johnriley.me/mirrors/postfix-release/official/ \
@@ -27,6 +27,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_POSTFIX_CDB \
 	CONFIG_POSTFIX_DB \
 	CONFIG_POSTFIX_SQLITE \
+	CONFIG_POSTFIX_MYSQL \
 	CONFIG_POSTFIX_PGSQL \
 	CONFIG_POSTFIX_PCRE \
 	CONFIG_POSTFIX_EAI \
@@ -41,7 +42,7 @@ define Package/postfix
   	postfix=25:postfix=25 \
   	postdrop=26:postdrop=26
   URL:=http://www.postfix.org/
-  DEPENDS:=+POSTFIX_TLS:libopenssl +POSTFIX_SASL:libsasl2 +POSTFIX_LDAP:libopenldap +POSTFIX_DB:libdb47 +POSTFIX_SQLITE:libsqlite3 +POSTFIX_PGSQL:libpq +POSTFIX_EAI:icu +POSTFIX_PCRE:libpcre
+  DEPENDS:=+POSTFIX_TLS:libopenssl +POSTFIX_SASL:libsasl2 +POSTFIX_LDAP:libopenldap +POSTFIX_DB:libdb47 +POSTFIX_SQLITE:libsqlite3 +POSTFIX_MYSQL:libmysqlclient +POSTFIX_PGSQL:libpq +POSTFIX_EAI:icu +POSTFIX_PCRE:libpcre
 endef
 
 define Package/postfix/description
@@ -80,6 +81,11 @@ define Package/postfix/config
 			default y
 			help
 			  Implements support for SQLite3 DB
+		config POSTFIX_MYSQL
+			bool "MYSQL support"
+			default n
+			help
+			  Implements support for MySQL
 		config POSTFIX_PGSQL
 			bool "PostgreSQL support"
 			default n
@@ -142,6 +148,11 @@ endif
 ifdef CONFIG_POSTFIX_SQLITE
   CCARGS+=-DHAS_SQLITE -I$(STAGING_DIR)/usr/include/
   AUXLIBS+=-L$(STAGING_DIR)/usr/lib -lsqlite3 -lpthread
+endif
+
+ifdef CONFIG_POSTFIX_MYSQL
+  CCARGS+=-DHAS_MYSQL -I$(STAGING_DIR)/usr/include/mysql
+  AUXLIBS+=-L$(STAGING_DIR)/usr/lib -lmysqlclient -lz -lm
 endif
 
 ifdef CONFIG_POSTFIX_PGSQL

--- a/mail/postfix/files/postfix.init
+++ b/mail/postfix/files/postfix.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2014 OpenWrt.org
 
-START=50
+START=72
 STOP=50
 EXTRA_COMMANDS="status abort flush postinst"
 EXTRA_HELP="	status	Display the service status


### PR DESCRIPTION
also delay the init, but not greater than dovecot as it has dependencies on postfix

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Maintainer: @Shulyaka 
Compile/Run tested: x86_64  OpenWrt SNAPSHOT, r7966-01793e8752
