### PR TITLE
coremark: Add coremark package

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpd
-PKG_VERSION:=0.20.20
+PKG_VERSION:=0.20.21
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.musicpd.org/download/mpd/0.20/
-PKG_HASH:=a9e458c6e07cdf62649de7722e1e5a7f13aa82eeb397bfbbebc07cf5cf273584
+PKG_HASH:=8322764dc265c20f05c8c8fdfdd578b0722e74626bef56fcd8eebfb01acc58dc
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
 PKG_LICENSE:=GPL-2.0
@@ -144,8 +144,7 @@ CONFIGURE_ARGS += \
 	--disable-vorbis-encoder \
 	--enable-wave-encoder \
 	--disable-wavpack \
-	--disable-webdav \
-	--disable-wildmidi \
+	--enable-webdav \
 	--disable-zzip \
 	--with-zeroconf=no \
 	--disable-soxr \

--- a/utils/coremark/Makefile
+++ b/utils/coremark/Makefile
@@ -34,7 +34,7 @@ endef
 define Build/Compile
 	$(SED) 's|EXE = .exe|EXE =|' $(PKG_BUILD_DIR)/linux/core_portme.mak
 	mkdir $(PKG_BUILD_DIR)/$(ARCH)
-	cp -r $(PKG_BUILD_DIR)/linux/* $(PKG_BUILD_DIR)/$(ARCH)
+	$(CP) -r $(PKG_BUILD_DIR)/linux/* $(PKG_BUILD_DIR)/$(ARCH)
 	$(MAKE) -C $(PKG_BUILD_DIR) PORT_DIR=$(ARCH) $(MAKE_FLAGS) \
 		compile 
 endef

--- a/utils/coremark/Makefile
+++ b/utils/coremark/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2018 Lim Guo Wei
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=coremark
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/eembc/coremark.git
+PKG_SOURCE_VERSION:=509d8ef94ca17e527fd085c53f2a14a165a3650a
+PKG_SOURCE_DATE:=2018-05-31
+PKG_MAINTAINER:=Lim Guo Wei <limguowei@gmail.com>
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE.md
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/coremark
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=CoreMark Embedded Microprocessor Benchmark
+  URL:=https://github.com/eembc/coremark
+endef
+
+define Package/coremark/description
+  Embedded Microprocessor Benchmark
+endef
+
+define Build/Compile
+	$(SED) 's|EXE = .exe|EXE =|' $(PKG_BUILD_DIR)/linux/core_portme.mak
+	mkdir $(PKG_BUILD_DIR)/$(ARCH)
+	cp -r $(PKG_BUILD_DIR)/linux/* $(PKG_BUILD_DIR)/$(ARCH)
+	$(MAKE) -C $(PKG_BUILD_DIR) PORT_DIR=$(ARCH) $(MAKE_FLAGS) \
+		compile 
+endef
+
+define Package/coremark/install
+	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/coremark $(1)/bin/
+endef
+
+$(eval $(call BuildPackage,coremark))


### PR DESCRIPTION
Signed-off-by: Lim Guo Wei <limguowei@gmail.com>

Maintainer: Lim Guo Wei
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (AR71xx, WDR4300, 17.01, Run coremark binary expect result obtained)

Description:
CoreMark(r) is an industry-standard benchmark that measures the performance of central processing units (CPU) and embedded microcrontrollers (MCU).
