### PR TITLE
samba4: Remove libbsd dependency

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
 PKG_VERSION:=4.8.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/samba4/patches/200-Remove_libbsd_dependency_check.patch
+++ b/net/samba4/patches/200-Remove_libbsd_dependency_check.patch
@@ -1,0 +1,61 @@
+diff --git a/lib/replace/wscript b/lib/replace/wscript
+index 0e04bf7..f13f648 100644
+--- a/lib/replace/wscript
++++ b/lib/replace/wscript
+@@ -302,22 +302,13 @@ def configure(conf):
+ 
+     conf.CHECK_FUNCS('prctl dirname basename')
+ 
+-    strlcpy_in_bsd = False
+-
+-    # libbsd on some platforms provides strlcpy and strlcat
+-    if not conf.CHECK_FUNCS('strlcpy strlcat'):
+-        if conf.CHECK_FUNCS_IN('strlcpy strlcat', 'bsd', headers='bsd/string.h',
+-                               checklibc=True):
+-            strlcpy_in_bsd = True
+-    if not conf.CHECK_FUNCS('getpeereid'):
+-        conf.CHECK_FUNCS_IN('getpeereid', 'bsd', headers='sys/types.h bsd/unistd.h')
+-    if not conf.CHECK_FUNCS_IN('setproctitle', 'setproctitle', headers='setproctitle.h'):
+-        conf.CHECK_FUNCS_IN('setproctitle', 'bsd', headers='sys/types.h bsd/unistd.h')
+-    if not conf.CHECK_FUNCS('setproctitle_init'):
+-        conf.CHECK_FUNCS_IN('setproctitle_init', 'bsd', headers='sys/types.h bsd/unistd.h')
+-
+-    if not conf.CHECK_FUNCS('closefrom'):
+-        conf.CHECK_FUNCS_IN('closefrom', 'bsd', headers='bsd/unistd.h')
++    # Not checking for libbsd
++    conf.CHECK_FUNCS('strlcpy strlcat')
++    conf.CHECK_FUNCS('getpeereid')
++    conf.CHECK_FUNCS_IN('setproctitle', 'setproctitle', headers='setproctitle.h')
++    conf.CHECK_FUNCS('setproctitle_init')
++
++    conf.CHECK_FUNCS('closefrom')
+ 
+     conf.CHECK_CODE('''
+                 struct ucred cred;
+@@ -667,9 +658,6 @@ removeea setea
+ 
+     # look for a method of finding the list of network interfaces
+     for method in ['HAVE_IFACE_GETIFADDRS', 'HAVE_IFACE_AIX', 'HAVE_IFACE_IFCONF', 'HAVE_IFACE_IFREQ']:
+-        bsd_for_strlcpy = ''
+-        if strlcpy_in_bsd:
+-            bsd_for_strlcpy = ' bsd'
+         if conf.CHECK_CODE('''
+                            #define %s 1
+                            #define NO_CONFIG_H 1
+@@ -682,7 +670,7 @@ removeea setea
+                            #include "test/getifaddrs.c"
+                            ''' % method,
+                            method,
+-                           lib='nsl socket' + bsd_for_strlcpy,
++                           lib='nsl socket',
+                            addmain=False,
+                            execute=True):
+             break
+@@ -730,7 +718,6 @@ def build(bld):
+                 break
+ 
+     extra_libs = ''
+-    if bld.CONFIG_SET('HAVE_LIBBSD'): extra_libs += ' bsd'
+ 
+     bld.SAMBA_SUBSYSTEM('LIBREPLACE_HOSTCC',
+         REPLACE_HOSTCC_SOURCE,


### PR DESCRIPTION
As libbsd does not depend on glibc anymore, the build fails due to missing
dependency.

Patch taken from libtalloc. Same codebase.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Andy2244 
Compile tested: ipq806x

Patch from @thess 