### PR TITLE
expat: disable docbook

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -41,7 +41,8 @@ TARGET_CFLAGS += $(FPIC)
 
 CONFIGURE_ARGS += \
 	--enable-shared \
-	--enable-static
+	--enable-static \
+	--without-docbook
 
 define Host/Install
 	$(MAKE) -C $(HOST_BUILD_DIR) install


### PR DESCRIPTION
Maintainer: @sbyx @thess 
Compile tested: arm (master)
Run tested: 

Description: 
got this build error:
```
checking for docbook2x-man... no
checking for db2x_docbook2man... no
checking for docbook2man... docbook2man
configure: error: Your local docbook2man was found to work with SGML rather
  than XML. Please install docbook2X and use variable DOCBOOK_TO_MAN to point
  configure to command docbook2x-man of docbook2X.
  Or use DOCBOOK_TO_MAN="xmlto man --skip-validation" if you have xmlto around.
  You can also configure using --without-docbook if you can do without a man
  page for xmlwf.
make[2]: *** [Makefile:71: /root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/expat-2.2.6/.configured_68b329da9893e34099c7d8ad5cb9c940] Error 1
make[2]: Leaving directory '/root/openwrt/feeds/packages/libs/expat'
```
We don't install man pages anyway so i just disabled docbook.