### PR TITLE
zerotier: fix multiple instance handling and port setting 

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
 PKG_VERSION:=1.2.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-3.0
 
@@ -66,10 +66,7 @@ ifeq ($(CONFIG_ZEROTIER_ENABLE_SELFTEST),y)
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/zerotier-selftest $(1)/usr/bin/
 endif
 
-	$(INSTALL_DIR) $(1)/etc/init.d/
-	$(INSTALL_BIN) files/zerotier.init $(1)/etc/init.d/zerotier
-	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_CONF) files/zerotier.config $(1)/etc/config/zerotier
+	$(CP) ./files/* $(1)/
 endef
 
 $(eval $(call BuildPackage,zerotier))

--- a/net/zerotier/files/etc/config/zerotier
+++ b/net/zerotier/files/etc/config/zerotier
@@ -8,7 +8,8 @@ config zerotier sample_config
 	#option port '9993'
 
 	# Generate secret on first start
-	option secret 'generate'
+	option secret ''
 
 	# Join a public network called Earth
 	list join '8056c2e21c000001'
+	#list join '<other_network>'

--- a/net/zerotier/files/etc/init.d/zerotier
+++ b/net/zerotier/files/etc/init.d/zerotier
@@ -9,13 +9,13 @@ CONFIG_PATH=/var/lib/zerotier-one
 
 section_enabled() {
 	config_get_bool enabled "$1" 'enabled' 0
-	[ $enabled -gt 0 ]
+	[ $enabled -ne 0 ]
 }
 
 start_instance() {
 	local cfg="$1"
-	local port secret config_path
-	local ARGS=""
+	local port secret config_path path
+	local args=""
 
 	if ! section_enabled "$cfg"; then
 		echo "disabled in config"
@@ -23,29 +23,35 @@ start_instance() {
 	fi
 
 	config_get config_path $cfg 'config_path'
-	config_get_bool port $cfg 'port'
+	config_get port $cfg 'port'
 	config_get secret $cfg 'secret'
 
+	path=${CONFIG_PATH}_$cfg
+
 	# Remove existing link or folder
-	rm -rf $CONFIG_PATH
+	rm -rf $path
 
 	# Create link from CONFIG_PATH to config_path
-	if [ -n "$config_path" -a "$config_path" != $CONFIG_PATH ]; then
+	if [ -n "$config_path" -a "$config_path" != "$path" ]; then
 		if [ ! -d "$config_path" ]; then
-			echo "ZeroTier config_path does not exist: $config_path"
+			echo "ZeroTier config_path does not exist: $config_path" 1>&2
 			return
 		fi
 
-		ln -s $config_path $CONFIG_PATH
+		ln -s $config_path $path
 	fi
 
-	mkdir -p $CONFIG_PATH/networks.d
+	mkdir -p $path/networks.d
+
+	# link latest default config path to latest config path
+	rm -f $CONFIG_PATH
+	ln -s $path $CONFIG_PATH
 
 	if [ -n "$port" ]; then
-		ARGS="$ARGS -p$port"
+		args="$args -p${port}"
 	fi
 
-	if [ "$secret" = "generate" ]; then
+	if [ -z "$secret" ]; then
 		echo "Generate secret - please wait..."
 		local sf="/tmp/zt.$cfg.secret"
 
@@ -60,20 +66,20 @@ start_instance() {
 	fi
 
 	if [ -n "$secret" ]; then
-		echo "$secret" > $CONFIG_PATH/identity.secret
+		echo "$secret" > $path/identity.secret
 		# make sure there is not previous identity.public
-		rm -f $CONFIG_PATH/identity.public
+		rm -f $path/identity.public
 	fi
 
 	add_join() {
 		# an (empty) config file will cause ZT to join a network
-		touch $CONFIG_PATH/networks.d/$1.conf
+		touch $path/networks.d/$1.conf
 	}
 
 	config_list_foreach $cfg 'join' add_join
 
 	procd_open_instance
-	procd_set_param command $PROG $ARGS $CONFIG_PATH
+	procd_set_param command $PROG $args $path
 	procd_set_param stderr 1
 	procd_close_instance
 }
@@ -87,10 +93,11 @@ stop_instance() {
 	local cfg="$1"
 
 	# Remove existing link or folder
-	rm -rf $CONFIG_PATH
+	rm -rf ${CONFIG_PATH}_${cfg}
 }
 
 stop_service() {
 	config_load 'zerotier'
 	config_foreach stop_instance 'zerotier'
+	rm -f ${CONFIG_PATH}
 }


### PR DESCRIPTION
Maintainer: me 
Compile tested: current OpenWrt master
Run tested: ramips / Nexx wt3020

Description:
Fixes: https://github.com/mwarning/zerotier-openwrt/issues/40
Multiple ZeroTier instances are a rare configuration and had a bug that is now fixed.