### PR TITLE
radicale: [18.06] add extra command "export_storage" to init script

### DIFF
--- a/net/radicale/Makefile
+++ b/net/radicale/Makefile
@@ -8,8 +8,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale
 PKG_VERSION:=1.1.6
-PKG_RELEASE:=1
-PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
+PKG_RELEASE:=2
+PKG_MAINTAINER:=
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING

--- a/net/radicale/files/radicale.init
+++ b/net/radicale/files/radicale.init
@@ -4,6 +4,11 @@
 START=80
 STOP=10
 
+EXTRA_COMMANDS="export_storage"
+EXTRA_HELP="	export_storage <PATH>
+	- export the storage into the specified folder
+	- <PATH> can be directly used with the default storage backend of Radicale 2.x.x."
+
 CFGDIR=/var/etc/radicale
 SYSCFG=$CFGDIR/config
 LOGCFG=$CFGDIR/logging
@@ -160,6 +165,30 @@ _set_permission() {
 		exit 1
 	}
 	chgrp -R radicale $DATADIR
+}
+
+export_storage() {
+	# if already running do nothing
+	local _PID=$(eval "$PGREP")
+	kill -1 $_PID 2>/dev/null && {
+		echo "Export failed !!! - Service running !" >&2
+		logger -p user.error -t "radicale[$_PID]" "Export failed !!! - Service running !"
+		return 1
+	}
+
+	[ $# -ne 1 ] || [ ! -d $1 ] && {
+		echo "Export failed !!! Directory not given or does not exist !" >&2
+		logger -p user.error -t "radicale[----]" "Export failed !!! Directory not given or does not exist !"
+		return 1
+	}
+
+	_uci2radicale
+	_set_permission
+
+	chmod 775 $1
+	chgrp radicale $1
+
+	radicale --config=$SYSCFG --export-storage $1/export
 }
 
 boot() {


### PR DESCRIPTION
Maintainer: me
Compile tested: 18.06.1
Run 18.06.1 on VirtualBox / 17.01.5 on WNDR4300

Description:
add extra command "export_storage" to export data for use with Radicale 2.x.x
remove myself as PKG_MAINTAINER
replace #6619

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>
