### PR TITLE
moreutils: Update to 0.62 and switch to git tarball

### DIFF
--- a/utils/moreutils/Makefile
+++ b/utils/moreutils/Makefile
@@ -8,17 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=moreutils
-PKG_VERSION:=0.60
+PKG_VERSION:=0.62
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.xz
-PKG_SOURCE_URL:=http://http.debian.net/debian/pool/main/m/moreutils/
-PKG_HASH:=e42d18bacbd2d003779a55fb3542befa5d1d217ee37c1874e8c497581ebc17c5
+PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://git.kitenet.net/index.cgi/moreutils.git/snapshot
+PKG_HASH:=812ac4e9e09dbfb812c64fb1929ed5275c279312d78e3fe1c30b01380c902db9
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)_$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nikil Mehta <nikil.mehta@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 
+PKG_BUILD_PARALLEL:=0
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/utils/moreutils/patches/001_disable-manuals.patch
+++ b/utils/moreutils/patches/001_disable-manuals.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -13,7 +13,7 @@
+@@ -13,7 +13,7 @@ endif
  
  DOCBOOK2XMAN=xsltproc --param man.authors.section.enabled 0 $(DOCBOOKXSL)/manpages/docbook.xsl
  
@@ -8,8 +8,8 @@
 +all: $(BINS)
  
  clean:
- 	rm -f $(BINS) $(MANS) dump.c errnos.h errno.o
-@@ -27,9 +27,6 @@
+ 	rm -f $(BINS) $(MANS) dump.c errnos.h errno.o \
+@@ -28,9 +28,6 @@ install:
  	$(INSTALL_BIN) $(BINS) $(DESTDIR)$(PREFIX)/bin
  	install $(PERLSCRIPTS) $(DESTDIR)$(PREFIX)/bin
  

--- a/utils/moreutils/patches/002_no-install-strip.patch
+++ b/utils/moreutils/patches/002_no-install-strip.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -2,7 +2,7 @@
+@@ -2,7 +2,7 @@ BINS=isutf8 ifdata ifne pee sponge mispipe lckdo parallel errno
  PERLSCRIPTS=vidir vipe ts combine zrun chronic
  MANS=sponge.1 vidir.1 vipe.1 isutf8.1 ts.1 combine.1 ifdata.1 ifne.1 pee.1 zrun.1 chronic.1 mispipe.1 lckdo.1 parallel.1 errno.1
  CFLAGS?=-O2 -g -Wall


### PR DESCRIPTION
It's more generic in addition to being the source for the debian package.

PKG_BUILD_PARALLEL was explicitly set to no just in case as I see no
handling for it in the Makefile.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nikil 
Compile tested: ipq806x