### PR TITLE
Fix verbose setting in udpxy

### DIFF
--- a/net/udpxy/files/udpxy.init
+++ b/net/udpxy/files/udpxy.init
@@ -38,7 +38,7 @@ start_instance() {
 	procd_set_param command /usr/bin/udpxy
 	procd_append_param command "-T"
 
-	append_bool "$cfg" verbose "-V"
+	append_bool "$cfg" verbose "-v"
 	append_bool "$cfg" status "-S"
 	append_arg "$cfg" bind "-a"
 	append_arg "$cfg" port "-p"


### PR DESCRIPTION
udpxy requires "-v" for verbose mode. As stated:
-v : enable verbose output [default = disabled]

Maintainer: @champtar 
Compile tested: ar71xx,WNDR3800, 18.06.1
Run tested: ar71xx,WNDR3800, 18.06.1

Description:
The upstream use "-v" rather than "-V" for verbose mode.