### PR TITLE
qemu: Fix sizeof(size_t) doesn't match GLIB_SIZEOF_SIZE_T

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -24,6 +24,7 @@ PKG_USE_MIPS16:=0
 
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 
 QEMU_DEPS_IN_GUEST := @(TARGET_x86_64||TARGET_armvirt||TARGET_arm64||TARGET_malta)


### PR DESCRIPTION
ERROR: sizeof(size_t) doesn't match GLIB_SIZEOF_SIZE_T.
       You probably need to set PKG_CONFIG_LIBDIR
       to point to the right pkg-config files for your
       build target

Signed-off-by: 李国 <uxgood.org@gmail.com>

Maintainer: @yousong
Compile tested: x86_64, r7986-dc9388a
Run tested: x86_64

Description:
