### PR TITLE
expat: fix host build issue with docbook

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -44,6 +44,9 @@ CONFIGURE_ARGS += \
 	--enable-static \
 	--without-docbook
 
+HOST_CONFIGURE_ARGS += \
+	--without-docbook
+
 define Host/Install
 	$(MAKE) -C $(HOST_BUILD_DIR) install
 endef


### PR DESCRIPTION
Maintainer: @sbyx @thess
Compile tested: imx6
Run tested: no

Description:

Additionally to the fix issued for #6923, we need to disable the docbook
usage also for the host build. This prevents the following error:

checking for docbook2man... docbook2man
configure: error: Your local docbook2man was found to work with SGML rather
  than XML. Please install docbook2X and use variable DOCBOOK_TO_MAN to point
  configure to command docbook2x-man of docbook2X.
  Or use DOCBOOK_TO_MAN="xmlto man --skip-validation" if you have xmlto around.
  You can also configure using --without-docbook if you can do without a man
  page for xmlwf.

Signed-off-by: Michael Heimpold <michael.heimpold@i2se.com>

