### PR TITLE
libdmapsharing: Update to 3.9.3

### DIFF
--- a/libs/libdmapsharing/Makefile
+++ b/libs/libdmapsharing/Makefile
@@ -10,7 +10,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdmapsharing
-PKG_VERSION:=3.9.2
+PKG_VERSION:=3.9.3
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -20,7 +20,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=libdmapsharing-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.flyn.org/projects/libdmapsharing/
-PKG_HASH:=377276d99799945dcfd241ecc8c93f49adbd6d95483360b4c0ebc949b2d86d2a
+PKG_HASH:=a19df4b6fbd669fc95824860c235aa4aed33b69ecc25eb9d9d6dccb4e98c3f18
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64, master b6adfde0
Run tested: x86_64, master b6adfde0

Description:
