### PR TITLE
net/pptpd: add static remote ip in config file

### DIFF
--- a/net/pptpd/Makefile
+++ b/net/pptpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pptpd
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/poptop
@@ -17,8 +17,6 @@ PKG_HASH:=8fcd8b8a42de2af59e9fe8cbaa9f894045c977f4d038bbd6346a8522bb7f06c0
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-
-PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/pptpd/files/pptpd.init
+++ b/net/pptpd/files/pptpd.init
@@ -12,7 +12,8 @@ OPTIONS_PPTP=/var/etc/options.pptpd
 validate_login_section() {
 	uci_load_validate pptpd login "$1" "$2" \
 		'username:string' \
-		'password:string'
+		'password:string' \
+		'remoteip:string'
 }
 
 validate_pptpd_section() {
@@ -32,8 +33,9 @@ setup_login() {
 
 	[ -n "$username" ] || return 0
 	[ -n "$password" ] || return 0
+	[ -n "$remoteip" ] || remoteip=*
 
-	echo "$username pptp-server $password *" >> $CHAP_SECRETS
+	echo "$username pptp-server $password $remoteip" >> $CHAP_SECRETS
 }
 
 setup_config() {


### PR DESCRIPTION
Add ability to configure a static remote ip in pptp config file
This change has backward compatibility with old config files

Signed-off-by: Thiago Ricciardi <thiago.ricciardi@gmail.com>

Maintainer: Luka Perkov / @lperkov 
Compile tested: sunxi/cortexa7/arm_cortex-a8_vfpv3, BananaPi R1, OpenWrt 18.06.1 r7258-5eb055306f
Run tested: sunxi/cortexa7/arm_cortex-a8_vfpv3, BananaPi R1, OpenWrt 18.06.1 r7258-5eb055306f, changed the config file /etc/config/pptpd to have 'remoteip' option inside 'login' config as the example in the description and checked if the connections where done correctly.

Description:
This patch adds the ability to configure static remote ip for a user connecting through pptpd
/etc/config/pptpd example:
```
config service 'pptpd'
        option 'enabled' '1'
        option 'localip' '192.168.10.1'
        option 'remoteip' '192.168.10.100-200'

# backward compatibility
config 'login'
        option 'username' 'myuser'
        option 'password' 'mypass'

# explicitly setting dynamic ip
config 'login'
        option 'username' 'anotheruser'
        option 'password' 'anotherpass'
        option 'remoteip' '*'

# setting static ip for the user
config 'login'
        option 'username' 'staticuser'
        option 'password' 'staticpass'
        option 'remoteip' '192.168.10.5'
```