### PR TITLE
classpath: fix this statement may fall through

### DIFF
--- a/libs/classpath/Makefile
+++ b/libs/classpath/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=classpath
 PKG_VERSION:=0.99
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Dana H. Myers <k6jq@comcast.net>
 

--- a/libs/classpath/patches/020-fix-statement-may-fall-through.patch
+++ b/libs/classpath/patches/020-fix-statement-may-fall-through.patch
@@ -1,0 +1,10 @@
+--- a/native/jni/java-math/gnu_java_math_GMP.c
++++ b/native/jni/java-math/gnu_java_math_GMP.c
+@@ -1132,6 +1132,7 @@
+         break;
+       case 1:
+         res = mpz_popcount (_this);
++      __attribute__((fallthrough));
+       default:
+         JCL_ThrowException (env, "java/lang/Error",
+                             "Unexpected sign value for a native MPI");


### PR DESCRIPTION
gnu_java_math_GMP.c:1135:13: error: this statement may fall through [-Werror=implicit-fallthrough=]
         res = mpz_popcount (_this);
         ~~~~^~~~~~~~~~~~~~~~~~~~~~
gnu_java_math_GMP.c:1136:7: note: here
       default:
       ^~~~~~~

Signed-off-by: Guo Li <uxgood.org@gmail.com>

Maintainer: @danak6jq 
Compile tested: x86_64
Run tested: x86_64

Description:
