### PR TITLE
getdns: fix missing libbsd dependency

### DIFF
--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=getdns
 PKG_VERSION:=1.4.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -36,7 +36,7 @@ define Package/getdns
 	SECTION:=libs
 	CATEGORY:=Libraries
 	TITLE+= (library)
-	DEPENDS+= +libopenssl +!GETDNS_ENABLE_STUB_ONLY:libunbound +GETDNS_ENABLE_IDN_LIBIDN2:libidn2
+	DEPENDS+= +libopenssl +libbsd +!GETDNS_ENABLE_STUB_ONLY:libunbound +GETDNS_ENABLE_IDN_LIBIDN2:libidn2
 	MENU:=1
 endef
 

--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -36,7 +36,7 @@ define Package/getdns
 	SECTION:=libs
 	CATEGORY:=Libraries
 	TITLE+= (library)
-	DEPENDS+= +libopenssl +libbsd +!GETDNS_ENABLE_STUB_ONLY:libunbound +GETDNS_ENABLE_IDN_LIBIDN2:libidn2
+	DEPENDS+= +libopenssl +!GETDNS_ENABLE_STUB_ONLY:libunbound +GETDNS_ENABLE_IDN_LIBIDN2:libidn2
 	MENU:=1
 endef
 
@@ -54,6 +54,8 @@ CONFIGURE_ARGS += \
 		--without-libidn \
 		$(if $(CONFIG_GETDNS_ENABLE_IDN_LIBIDN2), , --without-libidn2 ) \
 		--with-ssl="$(STAGING_DIR)/usr" \
+
+CONFIGURE_VARS += LIBBSD_LIBS=-lc
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/getdns/

--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -55,6 +55,9 @@ CONFIGURE_ARGS += \
 		$(if $(CONFIG_GETDNS_ENABLE_IDN_LIBIDN2), , --without-libidn2 ) \
 		--with-ssl="$(STAGING_DIR)/usr" \
 
+# This will make 'configure' think that our libbsd.so is missing the
+# functions inet_pton, inet_ntop, strlcpy and use the builtin. This 
+# removes the libbsd dependency
 CONFIGURE_VARS += LIBBSD_LIBS=-lc
 
 define Build/InstallDev


### PR DESCRIPTION
Signed-off-by: Guo Li <uxgood.org@gmail.com>

Maintainer: @iamperson347 
Compile tested: x86_64, r8001-067e2f5
Run tested: x86_64, r8001-067e2f5

Description:
