### PR TITLE
hamlib: link with libusb-compat instead of libusb-1.0

### DIFF
--- a/utils/hamlib/Makefile
+++ b/utils/hamlib/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hamlib
 PKG_VERSION:=3.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_HASH:=3fec97ea326d02aa8f35834c4af34194a3f544e6212f391397d788c566b44e32
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -57,7 +57,7 @@ endef
 
 define Package/libhamlib
   $(call Package/libhamlib/Default)
-  DEPENDS:=+libusb-1.0
+  DEPENDS:=+libusb-compat
   MENU:=1
 endef
 
@@ -82,9 +82,6 @@ CONFIGURE_ARGS+= \
 	--without-readline \
 	--without-cxx-binding \
 	--with-pic \
-
-CONFIGURE_VARS+= \
-	LIBUSB_LIBS="-lusb-1.0" \
 
 define Package/hamlib/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
This hamlib package use usb.h and should link with libusb-compat,
link with libusb-1.0 makes a lot of missing symbols

```
  CCLD     rigctl
../src/.libs/libhamlib.so: undefined reference to `usb_find_devices'
../src/.libs/libhamlib.so: undefined reference to `usb_find_busses'
../src/.libs/libhamlib.so: undefined reference to `usb_control_msg'
../src/.libs/libhamlib.so: undefined reference to `usb_claim_interface'
../src/.libs/libhamlib.so: undefined reference to `usb_init'
../src/.libs/libhamlib.so: undefined reference to `usb_interrupt_write'
../src/.libs/libhamlib.so: undefined reference to `usb_get_driver_np'
../src/.libs/libhamlib.so: undefined reference to `usb_get_busses'
../src/.libs/libhamlib.so: undefined reference to `usb_open'
../src/.libs/libhamlib.so: undefined reference to `usb_release_interface'
../src/.libs/libhamlib.so: undefined reference to `usb_close'
../src/.libs/libhamlib.so: undefined reference to `usb_strerror'
../src/.libs/libhamlib.so: undefined reference to `usb_device'
../src/.libs/libhamlib.so: undefined reference to `usb_detach_kernel_driver_np'
../src/.libs/libhamlib.so: undefined reference to `usb_bulk_write'
../src/.libs/libhamlib.so: undefined reference to `usb_interrupt_read'
collect2: error: ld returned 1 exit status
```

Signed-off-by: Guo Li <uxgood.org@gmail.com>

Maintainer: @acinonyx 
Compile tested: x86_64, r8001-067e2f5
Run tested: x86_64, r8001-067e2f5

Description:
