### PR TITLE
mtr: add autoreconf

### DIFF
--- a/net/mtr/Makefile
+++ b/net/mtr/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mtr
 PKG_VERSION:=0.92
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.bitwizard.nl/mtr/files
@@ -21,6 +21,8 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -48,10 +50,6 @@ CONFIGURE_ARGS += \
 	$(call autoconf_bool,CONFIG_IPV6,ipv6)
 
 CONFIGURE_VARS += ac_cv_lib_cap_cap_set_proc=no
-
-define Build/Configure
-	$(call Build/Configure/Default)
-endef
 
 define Package/mtr/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
The official tarball does not contain configure, we should set
PKG_FIXUP=autoreconf to generate one

make[4]: *** No targets specified and no makefile found.  Stop.

Signed-off-by: Guo Li <uxgood.org@gmail.com>

Maintainer: @jmccrohan @neheb
Compile tested: x86_64, r8001-067e2f5
Run tested: x86_64, r8001-067e2f5

Description:
