### PR TITLE
quassel-irssi: fix this statement may fall through and variable prefix

### DIFF
--- a/net/quassel-irssi/Makefile
+++ b/net/quassel-irssi/Makefile
@@ -13,7 +13,7 @@ PKG_NAME:=quassel-irssi
 # so use commit date for PKG_VERSION and embed commit hash into PKG_RELEASE.
 PKG_VERSION:=2016-09-11
 PKG_SOURCE_VERSION:=cbd9bd7f4ac44260d9fcafb809fdf153cde193e5
-PKG_RELEASE:=1.$(PKG_SOURCE_VERSION)
+PKG_RELEASE:=2.$(PKG_SOURCE_VERSION)
 
 PKG_LICENSE:=GPL-3.0+
 

--- a/net/quassel-irssi/patches/100-fix-name-prefix-ssl-to-tls.patch
+++ b/net/quassel-irssi/patches/100-fix-name-prefix-ssl-to-tls.patch
@@ -1,0 +1,34 @@
+--- a/core/quassel-net.c
++++ b/core/quassel-net.c
+@@ -130,10 +130,10 @@
+ 	ret->got = 0;
+ 	server_connect_ref(SERVER_CONNECT(conn));
+ 
+-	if(conn->use_ssl) {
++	if(conn->use_tls) {
+ 		ret->ssl = 1;
+ 	}
+-	ret->connrec->use_ssl = 0;
++	ret->connrec->use_tls = 0;
+ 
+ 	ret->channels_join = quassel_irssi_channels_join;
+ 	ret->send_message = quassel_irssi_send_message;
+--- a/core/irssi/network-openssl.c
++++ b/core/irssi/network-openssl.c
+@@ -437,11 +437,11 @@
+ 	SSL *ssl;
+ 	SSL_CTX *ctx = NULL;
+ 
+-	const char *mycert = server->connrec->ssl_cert;
+-	const char *mypkey = server->connrec->ssl_pkey;
+-	const char *cafile = server->connrec->ssl_cafile;
+-	const char *capath = server->connrec->ssl_capath;
+-	gboolean verify = server->connrec->ssl_verify;
++	const char *mycert = server->connrec->tls_cert;
++	const char *mypkey = server->connrec->tls_pkey;
++	const char *cafile = server->connrec->tls_cafile;
++	const char *capath = server->connrec->tls_capath;
++	gboolean verify = server->connrec->tls_verify;
+ 
+ 	g_return_val_if_fail(handle != NULL, NULL);
+ 

--- a/net/quassel-irssi/patches/101-fix-this-statement-may-fall-through.patch
+++ b/net/quassel-irssi/patches/101-fix-this-statement-may-fall-through.patch
@@ -1,0 +1,54 @@
+--- a/core/quasselc-connector.c
++++ b/core/quasselc-connector.c
+@@ -145,6 +145,7 @@
+ 			highlight=0;
+ 			if(!fnc)
+ 				fnc="MarkBufferAsRead";
++			__attribute__((fallthrough));
+ 		case Displayed:
+ 			if(!fnc)
+ 				fnc="BufferDisplayed";
+@@ -155,6 +156,7 @@
+ 		case Removed:
+ 			if(!fnc)
+ 				fnc="BufferRemoved";
++			__attribute__((fallthrough));
+ 		case TempRemoved:
+ 			if(!fnc)
+ 				fnc="BufferTempRemoved";
+@@ -210,6 +212,7 @@
+ 		case AddUserMode:
+ 			if(!fnc)
+ 				fnc="AddUserMode";
++			__attribute__((fallthrough));
+ 		case RemoveUserMode:
+ 			if(!fnc)
+ 				fnc="RemoveUserMode";
+@@ -223,6 +226,7 @@
+ 		case SetNick2:
+ 			if(!fnc)
+ 				fnc="SetNick";
++			__attribute__((fallthrough));
+ 		case Quit:
+ 			if(!fnc)
+ 				fnc="Quit";
+@@ -233,9 +233,11 @@
+ 		case SetNick:
+ 			if(!fnc)
+ 				fnc="SetNick";
++			__attribute__((fallthrough));
+ 		case SetServer:
+ 			if(!fnc)
+ 				fnc="SetServer";
++			__attribute__((fallthrough));
+ 		case SetRealName:
+ 			if(!fnc)
+ 				fnc="SetRealName";
+@@ -239,6 +243,7 @@
+ 		case SetRealName:
+ 			if(!fnc)
+ 				fnc="SetRealName";
++			__attribute__((fallthrough));
+ 		case PartChannel:
+ 			if(!fnc)
+ 				fnc="PartChannel";


### PR DESCRIPTION
This fix 'this statement may fall through' error in quasselc-connector.c
and aslo fix some variable prefix from ssl to tls (as they defined in
irssi/src/core/server-connect-rec.h and has chanded).

quasselc-connector.c:146:6: error: this statement may fall through [-Werror=implicit-fallthrough=]
    if(!fnc)
      ^
quasselc-connector.c:148:3: note: here
   case Displayed:
   ^~~~
quasselc-connector.c:156:6: error: this statement may fall through [-Werror=implicit-fallthrough=]
    if(!fnc)
      ^
quasselc-connector.c:158:3: note: here
   case TempRemoved:
   ^~~~
quasselc-connector.c:211:6: error: this statement may fall through [-Werror=implicit-fallthrough=]
    if(!fnc)
      ^
quasselc-connector.c:213:3: note: here
   case RemoveUserMode:
   ^~~~
quasselc-connector.c:224:6: error: this statement may fall through [-Werror=implicit-fallthrough=]
    if(!fnc)
      ^
quasselc-connector.c:226:3: note: here
   case Quit:
   ^~~~
quasselc-connector.c:234:6: error: this statement may fall through [-Werror=implicit-fallthrough=]
    if(!fnc)
      ^
quasselc-connector.c:236:3: note: here
   case SetServer:
   ^~~~
quasselc-connector.c:237:6: error: this statement may fall through [-Werror=implicit-fallthrough=]
    if(!fnc)
      ^
quasselc-connector.c:239:3: note: here
   case SetRealName:
   ^~~~
quasselc-connector.c:240:6: error: this statement may fall through [-Werror=implicit-fallthrough=]
    if(!fnc)
      ^
quasselc-connector.c:242:3: note: here
   case PartChannel:

Signed-off-by: Guo Li <uxgood.org@gmail.com>

Maintainer: @TC01 
Compile tested: x86_64, r8001-067e2f5
Run tested: x86_64, r8001-067e2f5

Description:
