### PR TITLE
bandwidthd: fix undefined references to inline functions

### DIFF
--- a/utils/bandwidthd/Makefile
+++ b/utils/bandwidthd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bandwidthd
 PKG_VERSION:=2.0.1-35
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/NethServer/bandwidthd/tar.gz/$(PKG_VERSION)?
@@ -140,7 +140,7 @@ CONFIGURE_ARGS += \
 	ac_cv_lib_sqlite3_sqlite3_open=no
 endif
 
-EXTRA_CFLAGS+= $(TARGET_CPPFLAGS)
+EXTRA_CFLAGS+= $(TARGET_CPPFLAGS) -fgnu89-inline
 EXTRA_LDFLAGS+= $(TARGET_LDFLAGS) -Wl,-rpath-link,$(STAGING_DIR)/usr/lib
 
 define Package/bandwidthd/install


### PR DESCRIPTION
gcc-7 with -Os makes inline functions disappeard. I do not know why,
but declared as extern will get them back.

```
bandwidthd.o: In function `RCDF_Load':
bandwidthd.c:(.text+0xb33): undefined reference to `FindIp'
bandwidthd.o: In function `PacketCallback':
bandwidthd.c:(.text+0x11d0): undefined reference to `FindIp'
bandwidthd.c:(.text+0x11e2): undefined reference to `Credit'
bandwidthd.c:(.text+0x11ea): undefined reference to `FindIp'
bandwidthd.c:(.text+0x11fc): undefined reference to `Credit'
bandwidthd.c:(.text+0x1218): undefined reference to `FindIp'
bandwidthd.c:(.text+0x122a): undefined reference to `Credit'
bandwidthd.c:(.text+0x1232): undefined reference to `FindIp'
bandwidthd.c:(.text+0x1244): undefined reference to `Credit'
collect2: error: ld returned 1 exit status
Makefile:20: recipe for target 'bandwidthd' failed
make[4]: *** [bandwidthd] Error 1
```

Signed-off-by: Guo Li <uxgood.org@gmail.com>

Maintainer: @padre-lacroix
Compile tested: x86_64, r8001-067e2f5
Run tested: x86_64, r8001-067e2f5

Description:
