### PR TITLE
net/stunnel: add archive mirror

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -18,7 +18,9 @@ PKG_LICENSE_FILES:=COPYING COPYRIGHT.GPL
 PKG_SOURCE_URL:= \
 	http://ftp.nluug.nl/pub/networking/stunnel/ \
 	http://www.usenix.org.uk/mirrors/stunnel/ \
-	https://www.stunnel.org/downloads/
+	https://www.stunnel.org/downloads/ \
+	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
+
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=1011d5a302ce6a227882d094282993a3187250f42f8a801dcc1620da63b2b8df
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, APU3, OpenWrt 18.06
Run tested: x86_64, APU3, OpenWrt 18.06, download and compile

Description:
The registered URLs only point to the latest version. After adding the archive
URL we could now download older version again.
