### PR TITLE
openssh: fix pthread functions redefine with pam module

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -193,6 +193,7 @@ CONFIGURE_VARS += LD="$(TARGET_CC)"
 
 ifeq ($(BUILD_VARIANT),with-pam)
 TARGET_LDFLAGS += -lpthread
+TARGET_CFLAGS += -DUNSUPPORTED_POSIX_THREADS_HACK
 endif
 
 define Build/Compile


### PR DESCRIPTION
we should pass -DUNSUPPORTED_POSIX_THREADS_HACK to CFLAGS to openssh
to prevent function redefine, I don't know why pam module use
micro UNSUPPORTED_POSIX_THREADS_HACK to detect whether define
pthread functions, but not detect whether define
UNSUPPORTED_POSIX_THREADS_HACK.

Signed-off-by: Guo Li <uxgood.org@gmail.com>

Maintainer: @tripolar
Compile tested: x86_64, r8018-42f1583
Run tested: x86_64, r8018-42f1583

Description:
```
auth-pam.c -o auth-pam.o
auth-pam.c:179:1: error: static declaration of 'pthread_exit' follows non-static declaration
 pthread_exit(void *value)
 ^~~~~~~~~~~~
In file included from /store/buildbot/slave/arm_cortex-a9/build/sdk/staging_dir/target-arm_cortex-a9_musl_eabi/usr/include/rpc/compat.h:15:0,
                 from /store/buildbot/slave/arm_cortex-a9/build/sdk/staging_dir/target-arm_cortex-a9_musl_eabi/usr/include/rpc/types.h:36,
                 from includes.h:115,
                 from auth-pam.c:50:
/store/buildbot/slave/arm_cortex-a9/build/sdk/staging_dir/toolchain-arm_cortex-a9_gcc-7.3.0_musl_eabi/include/pthread.h:79:16: note: previous declaration of 'pthread_exit' was here
 _Noreturn void pthread_exit(void *);
                ^~~~~~~~~~~~
auth-pam.c:186:1: error: conflicting types for 'pthread_create'
 pthread_create(sp_pthread_t *thread, const void *attr,
 ^~~~~~~~~~~~~~
In file included from /store/buildbot/slave/arm_cortex-a9/build/sdk/staging_dir/target-arm_cortex-a9_musl_eabi/usr/include/rpc/compat.h:15:0,
                 from /store/buildbot/slave/arm_cortex-a9/build/sdk/staging_dir/target-arm_cortex-a9_musl_eabi/usr/include/rpc/types.h:36,
                 from includes.h:115,
                 from auth-pam.c:50:
/store/buildbot/slave/arm_cortex-a9/build/sdk/staging_dir/toolchain-arm_cortex-a9_gcc-7.3.0_musl_eabi/include/pthread.h:77:5: note: previous declaration of 'pthread_create' was here
 int pthread_create(pthread_t *__restrict, const pthread_attr_t *__restrict, void *(*)(void *), void *__restrict);
     ^~~~~~~~~~~~~~
auth-pam.c:212:1: error: conflicting types for 'pthread_cancel'
 pthread_cancel(sp_pthread_t thread)
 ^~~~~~~~~~~~~~
In file included from /store/buildbot/slave/arm_cortex-a9/build/sdk/staging_dir/target-arm_cortex-a9_musl_eabi/usr/include/rpc/compat.h:15:0,
                 from /store/buildbot/slave/arm_cortex-a9/build/sdk/staging_dir/target-arm_cortex-a9_musl_eabi/usr/include/rpc/types.h:36,
                 from includes.h:115,
                 from auth-pam.c:50:
/store/buildbot/slave/arm_cortex-a9/build/sdk/staging_dir/toolchain-arm_cortex-a9_gcc-7.3.0_musl_eabi/include/pthread.h:92:5: note: previous declaration of 'pthread_cancel' was here
 int pthread_cancel(pthread_t);
     ^~~~~~~~~~~~~~
auth-pam.c:220:1: error: conflicting types for 'pthread_join'
 pthread_join(sp_pthread_t thread, void **value)
 ^~~~~~~~~~~~
In file included from /store/buildbot/slave/arm_cortex-a9/build/sdk/staging_dir/target-arm_cortex-a9_musl_eabi/usr/include/rpc/compat.h:15:0,
                 from /store/buildbot/slave/arm_cortex-a9/build/sdk/staging_dir/target-arm_cortex-a9_musl_eabi/usr/include/rpc/types.h:36,
                 from includes.h:115,
                 from auth-pam.c:50:
/store/buildbot/slave/arm_cortex-a9/build/sdk/staging_dir/toolchain-arm_cortex-a9_gcc-7.3.0_musl_eabi/include/pthread.h:80:5: note: previous declaration of 'pthread_join' was here
 int pthread_join(pthread_t, void **);
     ^~~~~~~~~~~~
Makefile:160: recipe for target 'auth-pam.o' failed
make[4]: *** [auth-pam.o] Error 1
make[4]: Leaving directory '/store/buildbot/slave/arm_cortex-a9/build/sdk/build_dir/target-arm_cortex-a9_musl_eabi/openssh-with-pam/openssh-7.8p1'
Makefile:271: recipe for target '/store/buildbot/slave/arm_cortex-a9/build/sdk/build_dir/target-arm_cortex-a9_musl_eabi/openssh-with-pam/openssh-7.8p1/.built' failed
make[3]: *** [/store/buildbot/slave/arm_cortex-a9/build/sdk/build_dir/target-arm_cortex-a9_musl_eabi/openssh-with-pam/openssh-7.8p1/.built] Error 2
time: package/feeds/packages/openssh/with-pam/compile#77.74#39.79#282.43

```
[http://downloads.lede-project.org/snapshots/faillogs/arm_cortex-a9/packages/openssh/with-pam/compile.txt](http://downloads.lede-project.org/snapshots/faillogs/arm_cortex-a9/packages/openssh/with-pam/compile.txt)