### PR TITLE
squid: update to version 4.3

### DIFF
--- a/net/squid/Config.in
+++ b/net/squid/Config.in
@@ -45,9 +45,33 @@ if PACKAGE_squid
 
 	comment "Optional packages"
 
-	config SQUID_use-gnutls
-		bool "Use GnuTLS instead of OpenSSL"
-		default n
+	choice
+		prompt "Choose SSL Library"
+		default SQUID_use-openssl
+
+		config SQUID_use-openssl
+		bool "Use OpenSSL (default)"
+
+		config SQUID_use-gnutls
+		bool "Use GnuTLS (experimental, see help)"
+		help
+			Use GnuTLS in place of OpenSSL for the core features of receiving
+			TLS connections from clients and making TLS connections to servers.
+			The GnuTLS support is still very much experimental and should be
+			tested before use.
+
+			SSL-Bump and certificate generation features are not yet supported
+			by GnuTLS builds. Nor are many other less commonly used Squid
+			TLS/SSL features.
+
+			squid.conf directives and configuration options which have undergone
+			name changes from 'ssl' to 'tls' prefix in Squid-4 have GnuTLS
+			support, unless explicitly stated otherwise.
+
+			Advanced configuration with specific selection of ciphers and
+			similar settings should still work, but needs the GnuTLS Priority
+			Strings instead of the OpenSSL options when using GnuTLS.
+	endchoice
 
 	config SQUID_with-libcap
 		bool "Use libcap - Linux capabilities library"

--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
-PKG_VERSION:=4.0.24
+PKG_VERSION:=4.3
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
@@ -18,10 +18,11 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www3.us.squid-cache.org/Versions/v4/ \
 	http://www2.pl.squid-cache.org/Versions/v4/ \
 	http://www.squid-cache.org/Versions/v4/
-PKG_HASH:=091da0d763307dcc0f5c784ab07ea0c5a093f6dfac60f17ff26e2a6d50f76a07
+PKG_HASH:=322612ef0544828f6c673a25124b32364fb41ef5e2847e21c89480b5546a4c7c
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -36,7 +37,7 @@ define Package/squid
   $(call Package/squid/Default)
   MENU:=1
   DEPENDS:=+libpthread +librt +libltdl +libstdcpp +libatomic +USE_GLIBC:libbsd
-  DEPENDS+= +SQUID_use-gnutls:libgnutls +!SQUID_use-gnutls:libopenssl
+  DEPENDS+= +SQUID_use-gnutls:libgnutls +SQUID_use-openssl:libopenssl
   DEPENDS+= +SQUID_with-libcap:libcap
   DEPENDS+= +SQUID_with-nettle:libnettle
   DEPENDS+= +SQUID_with-expat:libexpat
@@ -66,6 +67,8 @@ define Package/squid-mod-cachemgr
 endef
 
 CONFIGURE_ARGS += \
+	BUILDCXX=$(HOSTCXX) \
+	BUILDCXXFLAGS=$(if $(HOST_CXXFLAGS),$(HOST_CXXFLAGS),-O2) \
 	--config-cache \
 	--datadir=/usr/share/squid \
 	--libexecdir=/usr/lib/squid \


### PR DESCRIPTION
Maintainer: @ratkaj 
Compile tested: mipsel_mips32, mipsel_74kc, openwrt master
Run tested: mipsel_74kc

Description:
Current (beta) version has a bug in which is always responding with 'content-length: 0' for a cache HIT.  Thanks to @xuefer for pointing this out.

There's a patch to allow compilation with openssl built with `OPENSSL_NO_DEPRECATED`, submitted upstream (https://github.com/squid-cache/squid/pull/281). My intention was to wait for the approval of the PR upstream before opening this here, but the previous bug made me rush.

Also, added some help to the choice of TLS library in menuconfig, taken from the squid release notes.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>