### PR TITLE
libdouble-conversion: Update to 3.1.1

### DIFF
--- a/libs/libdouble-conversion/Makefile
+++ b/libs/libdouble-conversion/Makefile
@@ -8,15 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdouble-conversion
-PKG_VERSION:=2.0
+PKG_VERSION:=3.1.1
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=0d25506a2e7fb52928963313343e0237e890059e
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MIRROR_HASH:=7466f634421f3136174cbc2b00635788509a3312894de28367f31d891fd401ad
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/google/double-conversion.git
+PKG_SOURCE:=double-conversion-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/google/double-conversion/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=c49a6b3fa9c917f827b156c8e0799ece88ae50440487a99fc2f284cfd357a5b9
+PKG_BUILD_DIR:=$(BUILD_DIR)/double-conversion-$(PKG_VERSION)
+
+PKG_MAINTAINER:=
+PKG_LICENSE:=BSD-3c
 PKG_LICENSE_FILES:=COPYING LICENSE
 
 include $(INCLUDE_DIR)/package.mk
@@ -32,7 +33,7 @@ endef
 
 define Package/libdouble-conversion/description
   double-conversion provides binary-decimal and decimal-binary routines for IEEE doubles.
-  
+
   The library consists of efficient conversion routines that have been extracted
   from the V8 JavaScript engine. The code has been refactored and improved so that
   it can be used more easily in other projects.


### PR DESCRIPTION
This is unused by anything. It also seems to be relatively unmaintained.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: ???