### PR TITLE
wifidog: use tlsv1.1 instead of tlsv1.0

### DIFF
--- a/net/wifidog/Makefile
+++ b/net/wifidog/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifidog
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 
 PKG_LICENSE:=GPL-2.0

--- a/net/wifidog/patches/010-use-tlsv1_1-instead-of-tlsv1.patch
+++ b/net/wifidog/patches/010-use-tlsv1_1-instead-of-tlsv1.patch
@@ -1,0 +1,22 @@
+--- a/src/simple_http.c
++++ b/src/simple_http.c
+@@ -163,7 +163,7 @@
+         CyaSSL_Init();
+         /* Create the CYASSL_CTX */
+         /* Allow TLSv1.0 up to TLSv1.2 */
+-        if ((cyassl_ctx = CyaSSL_CTX_new(CyaTLSv1_client_method())) == NULL) {
++        if ((cyassl_ctx = CyaSSL_CTX_new(CyaTLSv1_1_client_method())) == NULL) {
+             debug(LOG_ERR, "Could not create CYASSL context.");
+             UNLOCK_CYASSL_CTX();
+             return NULL;
+--- a/configure.in
++++ b/configure.in
+@@ -97,7 +97,7 @@
+         # AC_SEARCH_LIBS
+         AC_CHECK_HEADERS(cyassl/ssl.h)
+         AC_SEARCH_LIBS([CyaTLSv1_client_method], [cyassl], [], [
+-            AC_SEARCH_LIBS([wolfTLSv1_client_method], [wolfssl], [], [
++            AC_SEARCH_LIBS([wolfTLSv1_1_client_method], [wolfssl], [], [
+                             AC_MSG_ERROR([unable to locate SSL lib: either wolfSSL or CyaSSL needed.])
+             ])
+         ])


### PR DESCRIPTION
tlsv1.0 has been disabled in wolfssl, so we need to use tlsv1.1 instead

Signed-off-by: Guo Li <uxgood.org@gmail.com>

Maintainer: @mhaas
Compile tested: x86_64, r8018-42f1583
Run tested: x86_64, r8018-42f1583

Description:
