### PR TITLE
perl: add host build dependencies for Darwin

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \
@@ -30,6 +30,7 @@ PKG_MAINTAINER:=Marcel Denia <naoir@gmx.net>, \
 
 # Build settings
 PKG_BUILD_DIR:=$(BUILD_DIR)/perl/$(PKG_NAME)-$(PKG_VERSION)
+HOST_BUILD_DEPENDS:=perl/host
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/perl/$(PKG_NAME)-$(PKG_VERSION)
 PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=perl/host


### PR DESCRIPTION
Maintainer: me / @Naoir
Compile tested: x86_64, generic, HEAD (4def9b7)
Run tested: N/A

Description:

Add host dependency for Darwin.