### PR TITLE
nfs-kernel-server: fix missing libbsd dependency

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=2.3.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_HASH:=3c8c63611c7e78b7a3b2f8a28b9928a5b5e66d5e9ad09a1e54681508884320a4
 
 PKG_SOURCE_URL:=@SF/nfs
@@ -95,6 +95,7 @@ endif
 CONFIGURE_VARS += \
 	libblkid_cv_is_recent=yes \
 	ac_cv_lib_resolv___res_querydomain=yes \
+	ac_cv_lib_bsd_daemon=no \
 	CONFIG_SQLITE3_TRUE="\#" \
 	CONFIG_NFSDCLD_TRUE="\#"
 


### PR DESCRIPTION
libbsd may compile before nfs-kernel-server, it  will make
nfs-kernel-server depends libbsd.so.0, that is not we want to see. so
gave option to 'configure' to disable libbsd detect and tell it we have
no libbsd

Signed-off-by: Guo Li <uxgood.org@gmail.com>

Maintainer: @tripolar
Compile tested: x86_64, r8024-43d4b8e
Run tested: x86_64, r8024-43d4b8e

Description:
see [http://downloads.lede-project.org/snapshots/faillogs/x86_64/packages/nfs-kernel-server/compile.txt](http://downloads.lede-project.org/snapshots/faillogs/x86_64/packages/nfs-kernel-server/compile.txt)