### PR TITLE
ffmpeg: pack libpostproc for hard float archs only

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -656,10 +656,12 @@ define Build/InstallDev/full
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/lib{avcodec,avdevice,avfilter,avformat,avresample,avutil,swresample,swscale} $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avdevice,avfilter,avformat,avresample,avutil,swresample,swscale}.{a,so*} $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/lib{avcodec,avdevice,avfilter,avformat,avresample,avutil,swresample,swscale}.pc $(1)/usr/lib/pkgconfig/
+ifneq ($(CONFIG_SOFT_FLOAT),y)
 ifneq ($(CONFIG_PACKAGE_libx264),)
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libpostproc $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpostproc.{a,so*} $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpostproc.pc $(1)/usr/lib/pkgconfig/
+endif
 endif
 endef
 
@@ -722,8 +724,10 @@ endef
 define Package/libffmpeg-full/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avdevice,avfilter,avformat,avresample,avutil,swresample,swscale}.so.* $(1)/usr/lib/
+ifneq ($(CONFIG_SOFT_FLOAT),y)
 ifneq ($(CONFIG_PACKAGE_libx264),)
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpostproc.so.* $(1)/usr/lib/
+endif
 endif
 endef
 


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: x86, ARMv5, ARMv7, MIPSEL
Run tested: [Entware repo](https://github.com/Entware/entware-packages/commit/011e93d1270cc911b900dd319db67e3ac87c99e5)

Description: there's no `libx264` [dependency](https://github.com/openwrt/packages/blob/master/multimedia/ffmpeg/Makefile#L346) for soft float targets, so `libpostproc` doesn't compiled. This PR prevents `libpostproc` packaging for this case.

This bug was hidden before [this commit](https://github.com/openwrt/packages/commit/75f049946928a9569bd855298dab58fe43aec326#diff-5bd38e5ed1692addd5bce579d53c8505R482), while `CONFIG_PACKAGE_libx264=m` stays undetected.