### PR TITLE
mwan3: optimize the process of copying routing tables

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.7.0
+PKG_VERSION:=2.7.1
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2


### PR DESCRIPTION
 - The original copy process is to delete all routing tables first,
   then add new routing table. This process is too slow and very dirty.
 - We use diff to identify the changes and apply them.

Maintainer: me / @feckert 
Compile tested: ipq40xx
Run tested: ipq40xx

Description:
