### PR TITLE
mc: add VFS support by default

### DIFF
--- a/utils/mc/Config.in
+++ b/utils/mc/Config.in
@@ -49,11 +49,11 @@ config MC_CHARSET
 
 config MC_VFS
 	bool "Enable virtual filesystem support"
-	default n
+	default y
 	help
            This option enables the Virtual File System switch code to get
            transparent access to the following file systems:
-           cpio, tar, fish, sfs, ftp, sftp, extfs, smb.
-           Disabled by default.
+           cpio, tar, fish, sfs, ftp, sftp, extfs.
+           Enabled by default.
 
 endmenu

--- a/utils/mc/Makefile
+++ b/utils/mc/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mc
 PKG_VERSION:=4.8.21
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 PKG_LICENSE:=GPL-3.0+
 
@@ -58,7 +58,6 @@ CONFIGURE_ARGS += \
 	--disable-doxygen-doc \
 	--with-homedir=/etc/mc \
 	--with-screen=ncurses \
-	--without-gpm-mouse \
 	--without-x \
 
 CONFIGURE_VARS += \


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: GL.iNet GL-AR750, OpenWrt SNAPSHOT r8021-9e58c20ec9
Run tested: GL.iNet GL-AR750, OpenWrt SNAPSHOT r8021-9e58c20ec9

Description:
* provide VFS support in midnight commander by default (see #6999), 
  this enlarge the package size by ~40KB.

Signed-off-by: Dirk Brenken <dev@brenken.org>
