### PR TITLE
net/ipvsadm: add virtual server administration tool

### DIFF
--- a/net/ipvsadm/Makefile
+++ b/net/ipvsadm/Makefile
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2016-2017 Mauro Mozzarelli
+#
+# This is free software, licensed under the GNU General Public License
+# See /LICENSE for more information.
+#
+# AUTHOR: Mauro Mozzarelli <mauro@ezplanet.org>
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ipvsadm
+PKG_VERSION:=1.29
+PKG_MAINTAINER:=Mauro Mozzarelli <mauro@ezplanet.org>, \
+		Florian Eckert <fe@dev.tdt.de>
+PKG_LICENSE:=GPL-2.0+
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://www.kernel.org/pub/linux/utils/kernel/ipvsadm/
+PKG_HASH:=c3de4a21d90a02c621f0c72ee36a7aa27374b6f29fd4178f33fbf71b4c66c149
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ipvsadm
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=IP Virtual Server Configuration Manager
+  URL:=http://www.linuxvirtualserver.org
+  DEPENDS:= +kmod-nf-ipvs +libnl-tiny +libpopt
+endef
+
+define Package/ipvsadm/description
+  IPVS (IP Virtual Server) implements transport-layer load balancing
+  inside the Linux kernel, so called Layer-4 switching. The command line tool
+  ipvsadm is used to set up, maintain or inspect the virtual server table
+  in the Linux kernel. The Linux Virtual Server can be used to build scalable
+  network services based on a cluster of two or more nodes.
+endef
+
+TARGET_CFLAGS += \
+	-D_GNU_SOURCE \
+	-I$(STAGING_DIR)/usr/include/libnl-tiny
+
+define Build/Compile
+	CFLAGS="$(TARGET_CFLAGS)" \
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		CC="$(TARGET_CC)" \
+		LIBS="$(TARGET_LDFLAGS) -lnl-tiny -lpopt"
+endef
+
+define Package/ipvsadm/install
+	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ipvsadm $(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ipvsadm-save $(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ipvsadm-restore $(1)/sbin/
+endef
+
+$(eval $(call BuildPackage,ipvsadm))

--- a/net/ipvsadm/patches/001-Makefile.patch
+++ b/net/ipvsadm/patches/001-Makefile.patch
@@ -1,0 +1,54 @@
+--- a/Makefile
++++ b/Makefile
+@@ -35,7 +35,7 @@ ARCH		= $(shell uname -m)
+ RPMSOURCEDIR	= $(shell rpm --eval '%_sourcedir')
+ RPMSPECDIR	= $(shell rpm --eval '%_specdir')
+ 
+-CC		= gcc
++BUILD_ROOT	= $(DESTDIR)
+ INCLUDE		=
+ SBIN		= $(BUILD_ROOT)/sbin
+ MANDIR		= usr/man
+@@ -46,9 +46,9 @@ INSTALL		= install
+ STATIC_LIBS	= libipvs/libipvs.a
+ 
+ ifeq "${ARCH}" "sparc64"
+-    CFLAGS = -Wall -Wunused -Wstrict-prototypes -g -m64 -pipe -mcpu=ultrasparc -mcmodel=medlow
++    CFLAGS += -Wall -Wunused -Wstrict-prototypes -g -m64 -pipe -mcpu=ultrasparc -mcmodel=medlow
+ else
+-    CFLAGS = -Wall -Wunused -Wstrict-prototypes -g
++    CFLAGS += -Wall -Wunused -Wstrict-prototypes -g
+ endif
+ 
+ 
+@@ -83,8 +83,9 @@ DEFINES		+= $(shell if [ ! -f ../ip_vs.h
+ 
+ all:            libs ipvsadm
+ 
++$(STATIC_LIBS): libs
+ libs:
+-		make -C libipvs
++		$(MAKE) -C libipvs
+ 
+ ipvsadm:	$(OBJS) $(STATIC_LIBS)
+ 		$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
+@@ -106,7 +107,7 @@ clean:
+ 		rm -rf debian/tmp
+ 		find . -name '*.[ao]' -o -name "*~" -o -name "*.orig" \
+ 		  -o -name "*.rej" -o -name core | xargs rm -f
+-		make -C libipvs clean
++		$(MAKE) -C libipvs clean
+ 
+ distclean:	clean
+ 
+--- a/libipvs/Makefile
++++ b/libipvs/Makefile
+@@ -1,7 +1,6 @@
+ # Makefile for libipvs
+ 
+-CC		= gcc
+-CFLAGS		= -Wall -Wunused -Wstrict-prototypes -g -fPIC
++CFLAGS		+= -Wall -Wunused -Wstrict-prototypes -g -fPIC
+ ifneq (0,$(HAVE_NL))
+ CFLAGS		+= -DLIBIPVS_USE_NL
+ CFLAGS		+= $(shell \

--- a/net/ipvsadm/patches/002-save-restore.patch
+++ b/net/ipvsadm/patches/002-save-restore.patch
@@ -1,0 +1,34 @@
+--- a/ipvsadm-restore
++++ b/ipvsadm-restore
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/bin/sh
+ #      ipvsadm-restore - Restore IPVS rules
+ #
+ #      A very simple wrapper to restore IPVS rules
+@@ -11,6 +11,8 @@
+ #      This file:
+ #
+ #      ChangeLog
++#      M. Mozzarelli       :        Amended to use /bin/sh for compatibility
++#                          :        with embedded systems using busybox
+ #      Horms               :        Clear IPVS rules before adding from STDIN
+ #      Horms               :        Filter out "^#"
+ #
+--- a/ipvsadm-save
++++ b/ipvsadm-save
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/bin/sh
+ #      ipvsadm-save - Save IPVS rules
+ #
+ #      A very simple wrapper to save IPVS rules
+@@ -12,6 +12,8 @@
+ #
+ #      ChangeLog
+ #
++#    M. Mozzarelli          :  Amended to use /bin/sh for compatibility
++#                           :  with embedded systems using busybox
+ #	 Wensong Zhang          :  Added the "-n" option and the help()
+ #
+ 


### PR DESCRIPTION
Maintainer: me / @ezplanet
Compile tested: x86_64, APU3, OpenWrt-18.06
Run tested: x86_64 , APU3, OpenWrt-18.06, Tests: only programm execution

Description:

Add the ipvsadm command line tool to set up, maintain or inspect the virtual
server table in the Linux kernel.

This dependence on PR https://github.com/openwrt/openwrt/pull/1375