### PR TITLE
strongswan: fix OpenWrt hotplug script handling

### DIFF
--- a/net/strongswan/patches/101-musl-fixes.patch
+++ b/net/strongswan/patches/101-musl-fixes.patch
@@ -51,14 +51,14 @@
 +#undef encrypt
 --- a/src/libcharon/plugins/kernel_netlink/kernel_netlink_ipsec.c
 +++ b/src/libcharon/plugins/kernel_netlink/kernel_netlink_ipsec.c
-@@ -19,6 +19,7 @@
+@@ -40,6 +40,7 @@
   */
  
  #define _GNU_SOURCE
 +#include <musl.h>
  #include <sys/types.h>
  #include <sys/socket.h>
- #include <stdint.h>
+ #include <sys/ioctl.h>
 --- a/src/libcharon/plugins/kernel_netlink/kernel_netlink_net.c
 +++ b/src/libcharon/plugins/kernel_netlink/kernel_netlink_net.c
 @@ -37,6 +37,8 @@

--- a/net/strongswan/patches/300-include-ipsec-hotplug.patch
+++ b/net/strongswan/patches/300-include-ipsec-hotplug.patch
@@ -9,7 +9,7 @@
 +# This files/scripts are executed by the openwrt hotplug functionality on
 +# ipsec events.
 +
-+exec /sbin/hotplug-call ipsec "$1"
++/sbin/hotplug-call ipsec "$1"
 +
  #      PLUTO_VERSION
  #              indicates  what  version of this interface is being

--- a/net/strongswan/patches/305-minimal_dh_plugin.patch
+++ b/net/strongswan/patches/305-minimal_dh_plugin.patch
@@ -8,7 +8,7 @@
  ARG_DISBL_SET([curve25519],     [disable Curve25519 Diffie-Hellman plugin.])
  ARG_DISBL_SET([hmac],           [disable HMAC crypto implementation plugin.])
  ARG_ENABL_SET([md4],            [enable MD4 software implementation plugin.])
-@@ -1379,6 +1380,7 @@ ADD_PLUGIN([gcrypt],               [s ch
+@@ -1407,6 +1408,7 @@ ADD_PLUGIN([gcrypt],               [s ch
  ADD_PLUGIN([af-alg],               [s charon scepclient pki scripts medsrv attest nm cmd aikgen])
  ADD_PLUGIN([fips-prf],             [s charon nm cmd])
  ADD_PLUGIN([gmp],                  [s charon scepclient pki scripts manager medsrv attest nm cmd aikgen fuzz])
@@ -16,7 +16,7 @@
  ADD_PLUGIN([curve25519],           [s charon pki scripts nm cmd])
  ADD_PLUGIN([agent],                [s charon nm cmd])
  ADD_PLUGIN([keychain],             [s charon cmd])
-@@ -1516,6 +1518,7 @@ AM_CONDITIONAL(USE_SHA3, test x$sha3 = x
+@@ -1547,6 +1549,7 @@ AM_CONDITIONAL(USE_SHA3, test x$sha3 = x
  AM_CONDITIONAL(USE_MGF1, test x$mgf1 = xtrue)
  AM_CONDITIONAL(USE_FIPS_PRF, test x$fips_prf = xtrue)
  AM_CONDITIONAL(USE_GMP, test x$gmp = xtrue)
@@ -24,7 +24,7 @@
  AM_CONDITIONAL(USE_CURVE25519, test x$curve25519 = xtrue)
  AM_CONDITIONAL(USE_RDRAND, test x$rdrand = xtrue)
  AM_CONDITIONAL(USE_AESNI, test x$aesni = xtrue)
-@@ -1783,6 +1786,7 @@ AC_CONFIG_FILES([
+@@ -1823,6 +1826,7 @@ AC_CONFIG_FILES([
  	src/libstrongswan/plugins/mgf1/Makefile
  	src/libstrongswan/plugins/fips_prf/Makefile
  	src/libstrongswan/plugins/gmp/Makefile
@@ -34,7 +34,7 @@
  	src/libstrongswan/plugins/aesni/Makefile
 --- a/src/libstrongswan/Makefile.am
 +++ b/src/libstrongswan/Makefile.am
-@@ -323,6 +323,13 @@ if MONOLITHIC
+@@ -341,6 +341,13 @@ if MONOLITHIC
  endif
  endif
  


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: brcm63xx, OpenWrt trunk
Run tested: brcm63xx, OpenWrt trunk

Description:
Fix OpenWrt hotplug script handling as it breaks connectivity due to the usage of exec
At the same time refresh the patches


