### PR TITLE
samba4: update to 4.9.0

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,8 +2,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.8.5
-PKG_RELEASE:=2
+PKG_VERSION:=4.9.0
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only
@@ -11,7 +11,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE_URL:=https://download.samba.org/pub/samba/stable/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=e58ee6b1262d4128b8932ceee59d5f0b0a9bbe00547eb3cc4c41552de1a65155
+PKG_HASH:=d071e9e738e9583d0b9ce1c758d46808b76078405787c88a0c5b465bef8a9b15
 
 # Buildroot bug? Can't add target deps via '+SAMBA4_SERVER_AD_DC:python-crypto' (as work-around we select via config.in)
 PKG_BUILD_DEPENDS:=SAMBA4_SERVER_AD_DC:python-crypto nfs-kernel-server/host
@@ -51,12 +51,12 @@ define Package/samba4-libs
   $(call Package/samba4/Default)
   TITLE+= libs
   DEPENDS:= +zlib +libtirpc +krb5-libs +libpopt \
-	+PACKAGE_libcap:libcap +PACKAGE_jansson:jansson +PACKAGE_libpthread:libpthread +PACKAGE_libnettle:libnettle \
-	+PACKAGE_libarchive:libarchive +PACKAGE_libgcrypt:libgcrypt +PACKAGE_libpam:libpam +PACKAGE_dbus:dbus +PACKAGE_libavahi-client:libavahi-client \
+	+PACKAGE_libcap:libcap +PACKAGE_libpthread:libpthread +PACKAGE_libnettle:libnettle \
+	+PACKAGE_libgcrypt:libgcrypt +PACKAGE_libpam:libpam +PACKAGE_dbus:dbus +PACKAGE_libavahi-client:libavahi-client \
 	+SAMBA4_SERVER_VFS:attr \
 	+SAMBA4_SERVER_ACL:acl +SAMBA4_SERVER_ACL:attr \
 	+SAMBA4_SERVER_AVAHI:libavahi-client \
-	+SAMBA4_SERVER_AD_DC:python-base +SAMBA4_SERVER_AD_DC:libopenssl +SAMBA4_SERVER_AD_DC:libgnutls +SAMBA4_SERVER_AD_DC:libopenldap
+	+SAMBA4_SERVER_AD_DC:python-base +SAMBA4_SERVER_AD_DC:libopenssl +SAMBA4_SERVER_AD_DC:libgnutls +SAMBA4_SERVER_AD_DC:libopenldap +SAMBA4_SERVER_AD_DC:jansson +SAMBA4_SERVER_AD_DC:libarchive
 endef
 
 define Package/samba4-server
@@ -196,7 +196,7 @@ ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
 	CONFIGURE_ARGS += --enable-gnutls --with-dnsupdate --with-ads --with-ldap
 	TARGET_CFLAGS := -I$(STAGING_DIR)/usr/include/python2.7 $(TARGET_CFLAGS)
 else
-	CONFIGURE_ARGS += --without-ad-dc --disable-python --nopyc --nopyo --disable-gnutls --without-dnsupdate --without-ads --without-ldap
+	CONFIGURE_ARGS += --without-ad-dc --without-json-audit --without-libarchive --disable-python --nopyc --nopyo --disable-gnutls --without-dnsupdate --without-ads --without-ldap
 	CONFIGURE_VARS += \
 		python_LDFLAGS="" \
 		python_LIBDIR=""
@@ -213,13 +213,13 @@ SAMBA4_PDB_MODULES :=pdb_smbpasswd,pdb_tdbsam,
 SAMBA4_AUTH_MODULES :=auth_builtin,auth_sam,auth_unix,auth_script,
 SAMBA4_VFS_MODULES :=vfs_default,
 ifeq ($(CONFIG_SAMBA4_SERVER_VFS),y)
-	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_fruit,vfs_shadow_copy2,vfs_recycle,vfs_fake_perms,vfs_readonly,vfs_cap,vfs_offline,vfs_crossrename,vfs_catia,vfs_streams_xattr,
+	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_fruit,vfs_shadow_copy2,vfs_recycle,vfs_fake_perms,vfs_readonly,vfs_cap,vfs_offline,vfs_crossrename,vfs_catia,vfs_streams_xattr,vfs_xattr_tdb,
 ifeq ($(CONFIG_PACKAGE_kmod-fs-btrfs),y)
 	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_btrfs,
 endif
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_VFSX),y)
-	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_virusfilter,vfs_shell_snap,vfs_commit,vfs_worm,vfs_xattr_tdb,vfs_aio_fork,vfs_aio_pthread,vfs_netatalk,vfs_dirsort,vfs_fileid,
+	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_virusfilter,vfs_shell_snap,vfs_commit,vfs_worm,vfs_aio_fork,vfs_aio_pthread,vfs_netatalk,vfs_dirsort,vfs_fileid,
 ifeq ($(CONFIG_PACKAGE_kmod-fs-xfs),y)
 	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_linux_xfs_sgid,
 endif
@@ -235,6 +235,7 @@ endif
 ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
 	SAMBA4_PDB_MODULES :=$(SAMBA4_PDB_MODULES)pdb_samba_dsdb,
 	SAMBA4_AUTH_MODULES :=$(SAMBA4_AUTH_MODULES)auth_samba4,
+	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_audit,vfs_ext_audit,vfs_full_audit,
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_WINBIND),y)
 	SAMBA4_IDMAP_MODULES :=$(SAMBA4_IDMAP_MODULES)idmap_passdb,idmap_nss,idmap_tdb,idmap_tdb2,idmap_script,nss_info_template,
@@ -359,8 +360,8 @@ define Package/samba4-server/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/smbd $(1)/usr/sbin/
 ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/python2.7 $(1)/usr/lib/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{samba-tool,ntlm_auth} $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/{samba,samba_gpoupdate,samba_dnsupdate,samba_kcc,samba_spnupdate,samba_upgradedns} $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{samba-tool,ntlm_auth,smbtar} $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/{samba,samba-gpupdate,samba_dnsupdate,samba_kcc,samba_spnupdate,samba_upgradedns} $(1)/usr/sbin/
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_NETBIOS),y)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/nmbd $(1)/usr/sbin/

--- a/net/samba4/waf-cross-answers/aarch64.txt
+++ b/net/samba4/waf-cross-answers/aarch64.txt
@@ -16,6 +16,7 @@ Checking value of NSIG: "65"
 Checking value of _NSIG: "65"
 Checking value of SIGRTMAX: "64"
 Checking value of SIGRTMIN: "35"
+Checking for a 64-bit host to support lmdb: NO
 Checking whether the WRFILE -keytab is supported: OK
 Checking errno of iconv for illegal multibyte sequence: OK
 Checking for kernel change notify support: OK

--- a/net/samba4/waf-cross-answers/arc.txt
+++ b/net/samba4/waf-cross-answers/arc.txt
@@ -16,6 +16,7 @@ Checking value of NSIG: "65"
 Checking value of _NSIG: "65"
 Checking value of SIGRTMAX: "64"
 Checking value of SIGRTMIN: "35"
+Checking for a 64-bit host to support lmdb: NO
 Checking whether the WRFILE -keytab is supported: OK
 Checking errno of iconv for illegal multibyte sequence: OK
 Checking for kernel change notify support: OK

--- a/net/samba4/waf-cross-answers/arm.txt
+++ b/net/samba4/waf-cross-answers/arm.txt
@@ -16,6 +16,7 @@ Checking value of NSIG: "65"
 Checking value of _NSIG: "65"
 Checking value of SIGRTMAX: "64"
 Checking value of SIGRTMIN: "35"
+Checking for a 64-bit host to support lmdb: NO
 Checking whether the WRFILE -keytab is supported: OK
 Checking errno of iconv for illegal multibyte sequence: OK
 Checking for kernel change notify support: OK

--- a/net/samba4/waf-cross-answers/armeb.txt
+++ b/net/samba4/waf-cross-answers/armeb.txt
@@ -16,6 +16,7 @@ Checking value of NSIG: "65"
 Checking value of _NSIG: "65"
 Checking value of SIGRTMAX: "64"
 Checking value of SIGRTMIN: "35"
+Checking for a 64-bit host to support lmdb: NO
 Checking whether the WRFILE -keytab is supported: OK
 Checking errno of iconv for illegal multibyte sequence: OK
 Checking for kernel change notify support: OK

--- a/net/samba4/waf-cross-answers/i386.txt
+++ b/net/samba4/waf-cross-answers/i386.txt
@@ -16,6 +16,7 @@ Checking value of NSIG: "65"
 Checking value of _NSIG: "65"
 Checking value of SIGRTMAX: "64"
 Checking value of SIGRTMIN: "35"
+Checking for a 64-bit host to support lmdb: NO
 Checking whether the WRFILE -keytab is supported: OK
 Checking errno of iconv for illegal multibyte sequence: OK
 Checking for kernel change notify support: OK

--- a/net/samba4/waf-cross-answers/mips.txt
+++ b/net/samba4/waf-cross-answers/mips.txt
@@ -16,6 +16,7 @@ Checking value of NSIG: "128"
 Checking value of _NSIG: "128"
 Checking value of SIGRTMAX: "127"
 Checking value of SIGRTMIN: "35"
+Checking for a 64-bit host to support lmdb: NO
 Checking whether the WRFILE -keytab is supported: OK
 Checking errno of iconv for illegal multibyte sequence: OK
 Checking for kernel change notify support: OK

--- a/net/samba4/waf-cross-answers/mips64.txt
+++ b/net/samba4/waf-cross-answers/mips64.txt
@@ -16,6 +16,7 @@ Checking value of NSIG: "128"
 Checking value of _NSIG: "128"
 Checking value of SIGRTMAX: "127"
 Checking value of SIGRTMIN: "35"
+Checking for a 64-bit host to support lmdb: NO
 Checking whether the WRFILE -keytab is supported: OK
 Checking errno of iconv for illegal multibyte sequence: OK
 Checking for kernel change notify support: OK

--- a/net/samba4/waf-cross-answers/mips64el.txt
+++ b/net/samba4/waf-cross-answers/mips64el.txt
@@ -16,6 +16,7 @@ Checking value of NSIG: "128"
 Checking value of _NSIG: "128"
 Checking value of SIGRTMAX: "127"
 Checking value of SIGRTMIN: "35"
+Checking for a 64-bit host to support lmdb: NO
 Checking whether the WRFILE -keytab is supported: OK
 Checking errno of iconv for illegal multibyte sequence: OK
 Checking for kernel change notify support: OK

--- a/net/samba4/waf-cross-answers/mipsel.txt
+++ b/net/samba4/waf-cross-answers/mipsel.txt
@@ -16,6 +16,7 @@ Checking value of NSIG: "128"
 Checking value of _NSIG: "128"
 Checking value of SIGRTMAX: "127"
 Checking value of SIGRTMIN: "35"
+Checking for a 64-bit host to support lmdb: NO
 Checking whether the WRFILE -keytab is supported: OK
 Checking errno of iconv for illegal multibyte sequence: OK
 Checking for kernel change notify support: OK

--- a/net/samba4/waf-cross-answers/powerpc.txt
+++ b/net/samba4/waf-cross-answers/powerpc.txt
@@ -16,6 +16,7 @@ Checking value of NSIG: "65"
 Checking value of _NSIG: "65"
 Checking value of SIGRTMAX: "64"
 Checking value of SIGRTMIN: "35"
+Checking for a 64-bit host to support lmdb: NO
 Checking whether the WRFILE -keytab is supported: OK
 Checking errno of iconv for illegal multibyte sequence: OK
 Checking for kernel change notify support: OK

--- a/net/samba4/waf-cross-answers/x86_64.txt
+++ b/net/samba4/waf-cross-answers/x86_64.txt
@@ -16,6 +16,7 @@ Checking value of NSIG: "65"
 Checking value of _NSIG: "65"
 Checking value of SIGRTMAX: "64"
 Checking value of SIGRTMIN: "35"
+Checking for a 64-bit host to support lmdb: NO
 Checking whether the WRFILE -keytab is supported: OK
 Checking errno of iconv for illegal multibyte sequence: OK
 Checking for kernel change notify support: OK


### PR DESCRIPTION
Maintainer: me
Compile tested: arm/mips (master)
Run tested: arm/mips (qemu, master)

Description:
* update to 4.9.0
* move vfs_xattr_tdb to defaults
* add vfs_audit, vfs_extd_audit, vfs_full_audit to AD-DC variant
* disable jansson, libarchive by default, enabled for AD-DC variant
* update waf answers

Noteable smb.conf changes:
* store dos attributes Default changed yes
* ea support Default changed yes

Fixes: Timemachine `The identity of the Backup disk ... has changed since the previous backup.`