### PR TITLE
krb5: fix keyutils dependency

### DIFF
--- a/net/krb5/Makefile
+++ b/net/krb5/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=krb5
 PKG_VERSION:=1.16.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -71,7 +71,8 @@ CONFIGURE_VARS += \
 	ac_cv_func_regcomp=yes \
 	ac_cv_printf_positional=yes \
 	ac_cv_file__etc_environment=no \
-	ac_cv_file__etc_TIMEZONE=no
+	ac_cv_file__etc_TIMEZONE=no \
+	ac_cv_header_keyutils_h=no
 
 CONFIGURE_ARGS += \
 	--localstatedir=/etc \


### PR DESCRIPTION
Maintainer: @MikePetullo
Compile tested: mips/arm (master)
Run tested:

Description: _(found this while trying to fix some buildbot targets for samba-4.9.0)_
* if <keyutils.h> is found krb5 pulls in the lib, which than fails to link because of a missing -fPic in libkeyutils.so
* keyutils 1.5.11 will depend on krb5, so we disable it in krb5 to avoid circular dependency

fixes: 
http://downloads.lede-project.org/snapshots/faillogs/aarch64_cortex-a53/packages/krb5/compile.txt
http://downloads.lede-project.org/snapshots/faillogs/mips_mips32/packages/krb5/compile.txt
http://downloads.lede-project.org/snapshots/faillogs/x86_64/packages/krb5/compile.txt
