### PR TITLE
fio: Update to 3.10 and disable HTTP

### DIFF
--- a/utils/fio/Makefile
+++ b/utils/fio/Makefile
@@ -8,15 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fio
-PKG_VERSION:=3.9
+PKG_VERSION:=3.10
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Dragan Stancevic <ds@codeminutia.com>
-PKG_LICENSE:=GPL-2.0+
-PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE_URL:=http://brick.kernel.dk/snaps
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=74737319addca4eb33051a07e481b425757c54a69999b7cd9884bc3b8c54c4b5
+PKG_HASH:=21150f1ac0b8d70f1b435a090221305b4e89ea17db3a313274d96b90b40dafcf
+
+PKG_MAINTAINER:=Dragan Stancevic <ds@codeminutia.com>
+PKG_LICENSE:=GPL-2.0+
+PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -42,6 +43,7 @@ CONFIGURE_ARGS = \
 	--disable-numa \
 	--disable-rdma \
 	--disable-rados \
+	--disable-http \
 	--disable-rbd \
 	--disable-gfapi \
 	--disable-lex \


### PR DESCRIPTION
HTTP support is new and requires libcurl and an SSL library.

Rearranged Makefile for consistency with other projects.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @drastx
Compile tested: mvebu