### PR TITLE
rsyslog: disable fmhttp plugin

### DIFF
--- a/net/rsyslog/Makefile
+++ b/net/rsyslog/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsyslog
 PKG_VERSION:=8.37.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.rsyslog.com/files/download/rsyslog/
@@ -37,6 +37,7 @@ define Package/rsyslog/conffiles
 endef
 
 CONFIGURE_ARGS+= \
+	--disable-fmhttp \
 	--disable-libgcrypt \
 	--disable-liblogging-stdlog
 


### PR DESCRIPTION
This plugin depends on libcurl, rsyslog fails to build if fmhttp is enabled as the package presently does not depend on libcurl.

Signed-off-by: Magnus Kroken <mkroken@gmail.com>

Maintainer: @dubek 
Compile tested: powerpc/mpc85xx, TP-Link TL-WDR4900, OpenWrt master (r8065-e51aa699f7)

Description: See https://downloads.lede-project.org/snapshots/faillogs/x86_64/packages/rsyslog/compile.txt for build failure. Since fmhttp is a single plugin it seems more sensible to disable it than pull in libcurl for all users of rsyslog.