### PR TITLE
stubby: restart after wan interface is fully up

### DIFF
--- a/net/stubby/files/stubby.init
+++ b/net/stubby/files/stubby.init
@@ -23,3 +23,19 @@ start_service() {
   procd_close_instance
 }
 
+st_load_interfaces() {
+  local d
+  config_get d $1 ifname
+  [ "$1" == "wan" -o "$1" == "wan6" -o "$d" != "${d/tun}" -o "$d" != "${d/tap}" ] && ifaces=" ${1} ${ifaces}"
+}
+
+service_triggers() {
+  local ifaces n
+  config_load network
+  config_foreach st_load_interfaces interface
+  procd_open_trigger
+  for n in $ifaces; do
+    procd_add_interface_trigger "interface.*" $n /etc/init.d/stubby restart
+  done
+  procd_close_trigger
+}


### PR DESCRIPTION
Maintainer: @iamperson347
Compile tested: none
Run tested: BT HomeHub5 (mips/lantiq), OpenWrt 18.06.1

Description:
If stubby is configured to do dnssec validation, when it is started
it needs to download and store the trust anchor. If stubby comes up
before PPPoE/PPPoA has finished bringing up the wan interfaces,
stubby will fail to obtain the trust anchor, and will subsequently
not do any dnssec validation for lookups. This change forces stubby
to restart when the wan interfaces change state.

Note that there will still be a brief period of time after the wan
interface is up but stubby hasn't been restarted when dns lookups
will be sucessful but not dnssec validated.



