### PR TITLE
stubby: add missing dependency on ca-certificates

### DIFF
--- a/net/stubby/Makefile
+++ b/net/stubby/Makefile
@@ -42,7 +42,7 @@ define Package/stubby
 	SUBMENU:=IP Addresses and Names
 	TITLE+= - (daemon that uses getdns)
 	USERID:=stubby=410:stubby=410
-	DEPENDS:= +libyaml +getdns
+	DEPENDS:= +libyaml +getdns +ca-certificates
 endef
 
 define Package/stubby/install


### PR DESCRIPTION
Signed-off-by: Tony Ambardar <itugrok@yahoo.com>

Maintainer: @iamperson347
Compile tested: mips_24kc, DIR-835, LEDE 17.01.5
Run tested: mips_24kc, DIR-835, LEDE 17.01.5

Description:
This separates out the ca-certificate dependency commit from PR #6707 as requested.