### PR TITLE
stubby: remove unnecessary core limit

### DIFF
--- a/net/stubby/files/stubby.init
+++ b/net/stubby/files/stubby.init
@@ -13,8 +13,6 @@ start_service() {
 
   procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
 
-  procd_set_param limits core="unlimited"
-
   procd_set_param file /etc/stubby/stubby.yml
 
   procd_set_param stdout 1


### PR DESCRIPTION
Signed-off-by: Tony Ambardar itugrok@yahoo.com

Maintainer: @iamperson347
Compile tested: mips_24kc, DIR-835, LEDE 17.01.5
Run tested: mips_24kc, DIR-835, LEDE 17.01.5

Remove the limit setting core="unlimited", since this shouldn't be needed
in production use (i.e. non-debug) and on an embedded platform, which is
why it's rarely used by any existing packages.

This commit is split out from PR #6707 


