### PR TITLE
python-pcapy: Update to 0.11.4

### DIFF
--- a/lang/python/python-pcapy/Makefile
+++ b/lang/python/python-pcapy/Makefile
@@ -8,17 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pcapy
-PKG_VERSION:=0.11.1
+PKG_VERSION:=0.11.4
 PKG_RELEASE:=1
+
+PKG_SOURCE:=pcapy-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pcapy
+PKG_HASH:=aa239913678d7ba116e66057a37f914de7726aecd11d00db470127df115c4e78
+PKG_BUILD_DIR:=$(BUILD_DIR)/pcapy-$(PKG_VERSION)
+
 PKG_MAINTAINER:=Andrew McConachie <andrew@depht.com>
 PKG_LICENSE:=Apache-1.1
-
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MIRROR_HASH:=05c8d6978baa3512070ff4c041e5931384e702bbc2ac2c8063760176035958f1
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/CoreSecurity/pcapy.git
-PKG_SOURCE_VERSION:=b91a418374d1636408c435f11799ef725ef70097
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk


### PR DESCRIPTION
Switched to regular tarballs from standard pythonhosted source.

Small Makefile rearrangements for consistency.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @smutt 
Compile tested: mvebu
