### PR TITLE
python-psycopg2: Update to 2.7.5

### DIFF
--- a/lang/python/python-psycopg2/Makefile
+++ b/lang/python/python-psycopg2/Makefile
@@ -8,17 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-psycopg2
-PKG_VERSION:=2.6.2
+PKG_VERSION:=2.7.5
 PKG_RELEASE:=1
+
+PKG_SOURCE:=psycopg2-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/psycopg2
+PKG_HASH:=eccf962d41ca46e6326b97c8fe0a6687b58dfc1a5f6540ed071ff1474cea749e
+PKG_BUILD_DIR:=$(BUILD_DIR)/psycopg2-$(PKG_VERSION)
+
 PKG_MAINTAINER:=Dmitry Trefilov <the-alien@live.ru>
 PKG_LICENSE:=LGPL-3.0+
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_SOURCE:=psycopg2-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://initd.org/psycopg/tarballs/PSYCOPG-2-6/
-PKG_HASH:=70490e12ed9c5c818ecd85d185d363335cc8a8cbf7212e3c185431c79ff8c05c
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/psycopg2-$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=python/host
 
 include $(INCLUDE_DIR)/package.mk
@@ -29,7 +30,7 @@ define Package/python-psycopg2
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=PostgreSQL database adapter for Python
-  URL:=http://www.initd.org/
+  URL:=http://initd.org/psycopg/
   DEPENDS:=+python +libpq +python-egenix-mx-base
 endef
 


### PR DESCRIPTION
Switched URL to standard pythonhosted one.

Reorganized Makefile for consistency with other packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dtrefilo-Quest 
Compile tested: mvebu
