### PR TITLE
chrony: fix configuration of IPv6 client access (18.06)

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
 PKG_VERSION:=3.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.tuxfamily.org/chrony/

--- a/net/chrony/files/chronyd.init
+++ b/net/chrony/files/chronyd.init
@@ -36,8 +36,8 @@ handle_allow() {
 	elif [ "$wan6_iface" = "$iface" ]; then
 		echo allow ::/0
 	else
-		network_get_subnets subnets $iface || \
-			network_get_subnets subnets6 $iface || continue
+		network_get_subnets subnets $iface
+		network_get_subnets6 subnets6 $iface
 		for subnet in $subnets $subnets6; do
 			echo allow $subnet
 		done


### PR DESCRIPTION
Maintainer: me
Compile tested: (mips, ar7xxx, 18.06)
Run tested: (mips, WDR3600, 18.06, works as an NTP client and server with IPv6 client access)

Description:
Fix the init script to allow access from IPv6 subnets of the interface
specified in allow section in /etc/config/chrony.

This is cherry-picked from the master branch for 18.06.