### PR TITLE
django-restframework: update to 3.8.2

### DIFF
--- a/lang/python/django-restframework/Makefile
+++ b/lang/python/django-restframework/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-restframework
-PKG_VERSION:=3.7.1
+PKG_VERSION:=3.8.2
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=djangorestframework-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/d0/ab/8b991e7d3e26af7cf6327c84b341e60004fc56325d8a4d4019e1474f7456/
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/djangorestframework
+PKG_HASH:=b6714c3e4b0f8d524f193c91ecf5f5450092c2145439ac2769711f7eba89a9d9
 PKG_BUILD_DIR:=$(BUILD_DIR)/djangorestframework-$(PKG_VERSION)
-PKG_HASH:=305b2c6564ca46d3b558ba21110ed717135c467adf1a6dfd192bd85f4bb04d50
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
@@ -26,7 +26,7 @@ define Package/django-restframework
   CATEGORY:=Languages
   MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
   TITLE:=Web APIs for Django, made easy.
-  URL:=http://www.django-rest-framework.org/
+  URL:=https://www.django-rest-framework.org
   DEPENDS:=+python +django
 endef
 


### PR DESCRIPTION
Some minor Makefile adjustments including standard python URL.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @kissg1988 
Compile tested: mvebu