### PR TITLE
openpyxl: Update to 2.5.7

### DIFF
--- a/lang/python/openpyxl/Makefile
+++ b/lang/python/openpyxl/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openpyxl
-PKG_VERSION:=2.5.0b1
+PKG_VERSION:=2.5.7
 PKG_RELEASE:=1
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/88/3c/34fbe561fc92e6a75f297478b123c2590ca986d9f2d2dbf340d879aa24dd/
-PKG_HASH:=3b42ece7933b46b2128f8d4111c57c80fb5aa46f4d16e7f83281f169e7398ba7
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/o/openpyxl
+PKG_HASH:=d3da4d6a78077d6f9fb1a1ec12d4aa500f7caa4661b8528538503b24ed72d632
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk


### PR DESCRIPTION
Switched URL to standard pythonhosted one.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @kissg1988 
Compile tested: mvebu
