### PR TITLE
geth: Update to 1.8.15

### DIFF
--- a/net/geth/Makefile
+++ b/net/geth/Makefile
@@ -11,12 +11,12 @@ PKG_LICENSE:=ASL-2.0
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 
 PKG_NAME:=go-ethereum
-PKG_VERSION:=1.8.13
+PKG_VERSION:=1.8.15
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ethereum/go-ethereum/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=c0c211172c1bc80855d19387300321fe233708bf8af1e4839ccf3b7de447bfb1
+PKG_HASH:=5081f21ab53f7eb9b84dbed32c4b58bb1c59a61163a6efaa0e4a8de764177c62
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Signed-off-by: Mislav Novakovic <mislav.novakovic@sartura.hr>

Maintainer: me
Compile tested: arm64, Raspberry pi 3, OpenWrt master branch
Run tested: arm64, Raspberry pi 3, OpenWrt master branch

Description:
Package update to version [1.8.15](https://github.com/ethereum/go-ethereum/releases/tag/v1.8.15).