### PR TITLE
chrony: update to 3.4

### DIFF
--- a/net/chrony/Makefile
+++ b/net/chrony/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chrony
-PKG_VERSION:=3.3
-PKG_RELEASE:=3
+PKG_VERSION:=3.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.tuxfamily.org/chrony/
-PKG_HASH:=0d1fb2d5875032f2d5a86f3770374c87ee4c941916f64171e81f7684f2a73128
+PKG_HASH:=af77e47c2610a7e55c8af5b89a8aeff52d9a867dd5983d848b52d374bc0e6b9f
 
 PKG_MAINTAINER:=Miroslav Lichvar <mlichvar0@gmail.com>
 PKG_LICENSE:=GPL-2.0

--- a/net/chrony/patches/002-undefined_MIN.patch
+++ b/net/chrony/patches/002-undefined_MIN.patch
@@ -1,0 +1,10 @@
+--- a/hash_intmd5.c
++++ b/hash_intmd5.c
+@@ -29,6 +29,7 @@
+ #include "sysincl.h"
+ #include "hash.h"
+ #include "memory.h"
++#include "util.h"
+ 
+ #include "md5.c"
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: (mips, WR741, 18.06)
Run tested: (mips, WR741, 18.06, runs as an NTP client and server)