### PR TITLE
boost: Make python3 build consistent with main configuration

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -16,7 +16,7 @@ include $(INCLUDE_DIR)/target.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.68.0
 PKG_SOURCE_VERSION:=1_68_0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/
@@ -429,9 +429,13 @@ define Build/Compile
 					$(if $(CONFIG_boost-runtime-static-and-shared),runtime-link=shared$(comma)static,) \
 					$(if $(CONFIG_boost-single-thread),threading=single,) \
 					threading=multi \
+					--without-mpi \
 					$(foreach lib,$(BOOST_LIBS), \
 						$(if $(findstring python,$(lib)), \
 							$(if $(CONFIG_PACKAGE_boost-python3),python=3.6,), \
+								$(if $(CONFIG_PACKAGE_boost-$(lib)),, \
+									$(if $(findstring $(lib),wserialization),,--without-$(lib)) \
+								) \
 						) \
 					) \
 				install ;\


### PR DESCRIPTION
Maintainer: @ClaymorePT 
Compile tested: brcm63xx
Run tested: N/A

Description:
Finally tracked down build errors which I thought we had fixed. There is a 2nd invocation of **b2** for **python3** which does not respect the same choices as the chosen configuration. This patch has the same **b2** config options in both invocations.

If this is correct, I will merge and keep an eye on the 'bots.

Note: My interested in seeing **boost** build is that it is a dependency of the Music Player Daemon (MPD) which I do care about and that it is building properly on all platforms.

Signed-off-by: Ted Hess \<thess@kitschensync.net\>