### PR TITLE
perlmod: fix ability to build module out-of-feed

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \

--- a/lang/perl/perlmod.mk
+++ b/lang/perl/perlmod.mk
@@ -1,7 +1,11 @@
 # This makefile simplifies perl module builds.
 #
 
-include ../perl/perlver.mk
+ifeq ($(origin PERL_INCLUDE_DIR),undefined)
+  PERL_INCLUDE_DIR:=$(dir $(lastword $(MAKEFILE_LIST)))
+endif
+
+include $(PERL_INCLUDE_DIR)/perlver.mk
 
 ifneq ($(PKG_NAME),perl)
   PKG_VERSION:=$(PKG_VERSION)+perl$(PERL_VERSION2)


### PR DESCRIPTION
Maintainer: me / @Naoir 
Compile tested: x86_64, generic, HEAD (4def9b7)
Run tested: same

`scp`'d packages over to production router, forced reinstall with `opkg --force-reinstall install *.ipk`.

Ran `/usr/lib/xtables-addons/xt_geoip_build` to rebuild geoip database.  No issues.

Description: