### PR TITLE
net/mwan3: some fixes

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.7.1
+PKG_VERSION:=2.7.2
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -3,15 +3,7 @@
 START=19
 
 reload() {
-	local enabled
-
-	config_load mwan3
-	config_get_bool enabled globals 'enabled' 0
-	[ ${enabled} -gt 0 ] || {
-		echo "Warning: mwan3 is global disabled. Usage: /etc/init.d/mwan3 start"
-		exit 0
-	}
-	mwan3 restart
+	/usr/sbin/mwan3 restart
 }
 
 boot() {
@@ -20,13 +12,9 @@ boot() {
 }
 
 start() {
-	. /lib/config/uci.sh
-	uci_toggle_state mwan3 globals enabled "1"
-	mwan3 start
+	/usr/sbin/mwan3 start
 }
 
 stop() {
-	. /lib/config/uci.sh
-	uci_toggle_state mwan3 globals enabled "0"
-	mwan3 stop
+	/usr/sbin/mwan3 stop
 }

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -46,6 +46,12 @@ ifup()
 	local device enabled up l3_device
 
 	config_load mwan3
+	config_get_bool enabled globals 'enabled' 0
+	[ ${enabled} -gt 0 ] || {
+		echo "The service mwan3 is global disabled."
+		echo "Please execute \"/etc/init.d/mwan3 start\" first."
+		exit 1
+	}
 
 	if [ -z "$1" ]; then
 		echo "Expecting interface. Usage: mwan3 ifup <interface>" && exit 0
@@ -123,12 +129,7 @@ start()
 {
 	local enabled src_ip local_source
 
-	config_load mwan3
-	config_get_bool enabled globals 'enabled' 0
-	[ ${enabled} -gt 0 ] || {
-		echo "Warning: mwan3 is global disabled. Usage: /etc/init.d/mwan3 start"
-		exit 0
-	}
+	uci_toggle_state mwan3 globals enabled "1"
 
 	config_get local_source globals local_source 'none'
 	[ "${local_source}" = "none" ] || {
@@ -211,6 +212,8 @@ stop()
 		ip route del default via "${src_ip}" dev lo 1>/dev/null 2>&1
 		ip addr del "${src_ip}/32" dev lo 1>/dev/null 2>&1
 	}
+
+	uci_toggle_state mwan3 globals enabled "0"
 }
 
 restart() {

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -239,8 +239,10 @@ main() {
 		wait
 
 		if [ "${IFDOWN_EVENT}" -eq 1 ]; then
-			score=0
 			echo "offline" > /var/run/mwan3track/$1/STATUS
+			$LOG notice "Interface $1 ($2) is offline"
+			env -i ACTION="disconnected" INTERFACE="$1" DEVICE="$2" /sbin/hotplug-call iface
+			score=0
 			IFDOWN_EVENT=0
 		fi
 	done

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -55,6 +55,7 @@ main() {
 	local recovery_interval down up size
 	local keep_failure_interval check_quality failure_latency
 	local recovery_latency failure_loss recovery_loss
+	local max_ttl
 
 	[ -z "$5" ] && echo "Error: should not be started manually" && exit 0
 
@@ -84,6 +85,7 @@ main() {
 	config_get down $1 down 5
 	config_get up $1 up 5
 	config_get size $1 size 56
+	config_get max_ttl $1 max_ttl 60
 	config_get failure_interval $1 failure_interval $interval
 	config_get_bool keep_failure_interval $1 keep_failure_interval 0
 	config_get recovery_interval $1 recovery_interval $interval
@@ -120,10 +122,10 @@ main() {
 				case "$track_method" in
 					ping)
 						if [ $check_quality -eq 0 ]; then
-							ping -I $DEVICE -c $count -W $timeout -s $size -q $track_ip &> /dev/null
+							ping -I $DEVICE -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null
 							result=$?
 						else
-							ping_result="$(ping -I $DEVICE -c $count -W $timeout -s $size -q $track_ip | tail -2)"
+							ping_result="$(ping -I $DEVICE -c $count -W $timeout -s $size -t $max_ttl -q $track_ip | tail -2)"
 							loss="$(echo "$ping_result" | grep "packet loss" |  cut -d "," -f3 | awk '{print $1}' | sed -e 's/%//')"
 							if [ "$loss" -eq 100 ]; then
 								latency=999999


### PR DESCRIPTION
Maintainer: me
Compile tested: not needed
Run tested: x86_64, APU3l, OpenWrt 18.06

Description:

- add ttl check
- mwan3track should also send disconnected action on signal USR1
- fix start/stop/restart execution