### PR TITLE
samba4: update to 4.9.1

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,8 +2,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.9.0
-PKG_RELEASE:=2
+PKG_VERSION:=4.9.1
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only
@@ -11,7 +11,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE_URL:=https://download.samba.org/pub/samba/stable/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=d071e9e738e9583d0b9ce1c758d46808b76078405787c88a0c5b465bef8a9b15
+PKG_HASH:=33118cbe83a87be085eba1aae6e597878b02d6ac9b2da67454ed33cf3e9853f2
 
 # Buildroot bug? Can't add target deps via '+SAMBA4_SERVER_AD_DC:python-crypto' (as work-around we select via config.in)
 PKG_BUILD_DEPENDS:=SAMBA4_SERVER_AD_DC:python-crypto nfs-kernel-server/host


### PR DESCRIPTION
Maintainer: me
Compile tested: mips (master)
Run tested: mips/qemu (master)

Description:
* fixes: nmbd: Stop nmbd network announce storm (bug #13620).