### PR TITLE
Add libraries WebSocket++ and cpprestsdk

### DIFF
--- a/libs/cpprestsdk/Makefile
+++ b/libs/cpprestsdk/Makefile
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2018 Bruno Randolf (br1@einfach.org)
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cpprestsdk
+PKG_VERSION:=2.10.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-git.tar.gz
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/Microsoft/cpprestsdk
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_MIRROR_HASH:=4ebbc832e6abaf3a3abd9f70bb9f9556fcd6b6645239c76e84d9201f8f805678
+
+PKG_MAINTAINER:=Bruno Randolf <br1@einfach.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=license.txt
+
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=websocketpp
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+CMAKE_INSTALL:=1
+CMAKE_SOURCE_DIR:=Release
+CMAKE_OPTIONS += -DWERROR:Bool=OFF
+CMAKE_OPTIONS += -DBUILD_TESTS:Bool=OFF
+CMAKE_OPTIONS += -DBUILD_SAMPLES:Bool=OFF
+
+define Package/cpprestsdk
+	SECTION:=libs
+	CATEGORY:=Libraries
+	DEPENDS:=+zlib +libopenssl +boost +boost-atomic +boost-chrono +boost-date_time +boost-filesystem +boost-random +boost-regex +boost-system +boost-thread
+	TITLE:=Microsoft C++ REST SDK
+	URL:=https://github.com/Microsoft/cpprestsdk
+endef
+
+define Package/cpprestsdk/description
+	Microsoft project for cloud-based client-server communication in native
+	code using a modern asynchronous C++ API design.
+endef
+
+define Package/cpprestsdk/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcpprest.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,cpprestsdk))

--- a/libs/cpprestsdk/patches/001-fix-headers.patch
+++ b/libs/cpprestsdk/patches/001-fix-headers.patch
@@ -1,0 +1,18 @@
+Index: cpprestsdk-2018-09-24/Release/include/cpprest/asyncrt_utils.h
+===================================================================
+--- cpprestsdk-2018-09-24.orig/Release/include/cpprest/asyncrt_utils.h
++++ cpprestsdk-2018-09-24/Release/include/cpprest/asyncrt_utils.h
+@@ -33,10 +33,12 @@
+ /* Systems using glibc: xlocale.h has been removed from glibc 2.26
+    The above include of locale.h is sufficient
+    Further details: https://sourceware.org/git/?p=glibc.git;a=commit;h=f0be25b6336db7492e47d2e8e72eb8af53b5506d */
+-#include <xlocale.h>
++//#include <xlocale.h>
+ #endif
+ #endif
+ 
++#include <sys/time.h>
++
+ /// Various utilities for string conversions and date and time manipulation.
+ namespace utility
+ {

--- a/libs/websocketpp/Makefile
+++ b/libs/websocketpp/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2018 Bruno Randolf (br1@einfach.org)
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=websocketpp
+PKG_VERSION:=0.8.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-git.tar.gz
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/zaphoyd/websocketpp.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
+PKG_MIRROR_HASH:=23811ec9a5530f28f08d3e5cf66ef04d87742ab037ddec4ba90ef469182017b4
+
+PKG_MAINTAINER:=Bruno Randolf <br1@einfach.org>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=COPYING
+
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=zlib openssl
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+CMAKE_INSTALL:=1
+
+define Package/websocketpp
+	SECTION:=libs
+	CATEGORY:=Libraries
+	TITLE:=WebSocket++
+	URL:=https://www.zaphoyd.com/websocketpp
+endef
+
+define Package/websocketpp/description
+	WebSocket++ is a header only C++ library that implements RFC6455
+	The WebSocket Protocol.
+endef
+
+$(eval $(call BuildPackage,websocketpp))


### PR DESCRIPTION
Maintainer: Bruno Randolf <br1@einfach.org> / @br101
Compile tested: ar71xx, 8devices Carambola2, Rambutan, OpenWRT master, 18.06
Run tested:  ar71xx, 8devices Carambola2, OpenWRT 18.06

Description:
Cpprestsdk is a Microsoft project and it's huge, but my clients need it.
WebSocket++ is a dependency of Cpprestsdk and useful on it's own too.