### PR TITLE
samba4: fix missing busybox 'hostname -f' command

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
 PKG_VERSION:=4.9.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -21,7 +21,9 @@ smb_header() {
 
 	local workgroup description charset
 	# we dont use netbios anymore as default and wsd/avahi is dns based
-	local hostname="$(hostname -f)"
+	local hostname="$(uci get system.@system[0].hostname)"
+	local domain="$(uci get dhcp.@dnsmasq[0].domain)"
+	[ -n "$domain" ] && hostname="$hostname.$domain"
 
 	config_get workgroup		$1 workgroup	"WORKGROUP"
 	config_get description		$1 description	"Samba on OpenWrt"


### PR DESCRIPTION
Maintainer: me
Compile tested: 
Run tested: arm (master)

Description:
* busybox does not have 'hostname' by default so replaced it with uci calls