### PR TITLE
golang: properly handle files with spaces

### DIFF
--- a/lang/golang/golang-package.mk
+++ b/lang/golang/golang-package.mk
@@ -165,6 +165,7 @@ define GoPackage/Build/Configure
 		fi ; \
 		\
 		echo "Copying files from $(PKG_BUILD_DIR) into $(GO_PKG_BUILD_DIR)/src/$(GO_PKG)" ; \
+		IFS=$$$$'\n'; \
 		for file in $$$$files; do \
 			echo $$$$file ; \
 			dest=$(GO_PKG_BUILD_DIR)/src/$(GO_PKG)/$$$$file ; \


### PR DESCRIPTION
Some go packages might contain files with spaces (e.g. in their test
files). Limit the file name separator to ensure we properly keep the
file names intact.

Fixes: c137c382573f ("golang: new packages")
Signed-off-by: Jonas Gorski \<jonas.gorski@gmail.com\>

Maintainer: @jefferyto 
Compile tested: mvebu 
Run tested: mvebu / Clearfog Pro
