### PR TITLE
Python3: Fix host build on OpenSUSE

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -264,7 +264,7 @@ define Py3Package/python3/filespec
 endef
 
 HOST_LDFLAGS += \
-	$$$$(pkg-config --static --libs libcrypto libssl)
+	$$$$(pkg-config --static --libs libcrypto libssl) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib
 
 ifeq ($(HOST_OS),Linux)
 HOST_LDFLAGS += \


### PR DESCRIPTION
The linker option -rpath is required to find libs in staging_dir. Now it
is included when building host modules. Without it the import test of
the _ctypes module would fail, as it uses system libs. The _ctypes module uses
libffi.so.6 from staging, but OpenSUSE LEAP 15 has libffi.so.7.
It will also fail on LEAP 42.x, Fedora28 and 29 and future or old
versions of Ubuntu.

Fix needed in master and 18.06 branches.

Signed-off-by: Jan Kardell <jan.kardell@telliq.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (omap, OpenWrt 18.06.01 with packages master on OpenSUSE LEAP 15.0)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
