### PR TITLE
libical: update to version 3.0.4

### DIFF
--- a/libs/libical/Makefile
+++ b/libs/libical/Makefile
@@ -8,46 +8,41 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libical
-PKG_VERSION:=1.0
+PKG_VERSION:=3.0.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=7c39b3448e4927a2de2775d853f52b3aaeb42400970a3db0b01a78987e6ec0b7
-PKG_SOURCE_URL:=@SF/freeassociation
+PKG_HASH:=72b216e10233c3f60cb06062facf41f3b0f70615e5a60b47f9853341a0d5d145
+PKG_SOURCE_URL:=https://github.com/libical/libical/releases/download/v$(PKG_VERSION)/
 
-PKG_LICENSE:=LGPL-2.1 MPL-1.0
+PKG_LICENSE:=LGPL-2.1 MPL-2.0
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Nicolas Thill <nico@openwrt.org>
-
-PKG_FIXUP:=libtool
-PKG_INSTALL:=1
+PKG_MAINTAINER:=Jose Zapater <jzapater@gmail.com>
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/libical
   SECTION:=libs
   CATEGORY:=Libraries
-  TITLE:=iCal (RFC 2445) library
-  URL:=http://www.nabber.org/projects/ical/
+  TITLE:=An implementation of iCalendar protocols and data formats
+  URL:=http://libical.github.io/libical/
   DEPENDS:=+libpthread
 endef
 
 define Package/libical/description
- This package provides a a read/write library of classes for object oriented
- languages (Initial goals of PHP and Python) that implement and enforce the iCal
- standard (RFC 2445).
+ Libical is an Open Source implementation of the iCalendar protocols and protocol
+ data units. The iCalendar specification describes how calendar clients can
+ communicate with calendar servers so users can store their calendar data and
+ arrange meetings with other users.
+ Libical implements RFC2445, RFC2446 and some of RFC2447.
 endef
 
-CONFIGURE_ARGS += \
-	--enable-shared \
-	--enable-static \
-	--disable-cxx \
-	--disable-java \
-	--disable-python \
+CMAKE_OPTIONS += -DWITH_CXX_BINDINGS=false -DICAL_BUILD_DOCS=false -DICAL_GLIB=false
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/{ical.h,libical} $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/include/libical
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libical/* $(1)/usr/include/libical/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libical{,ss,vcal}.{a,so*} $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig

--- a/libs/libical/patches/001-disable-icu-and-bdb-support.patch
+++ b/libs/libical/patches/001-disable-icu-and-bdb-support.patch
@@ -1,0 +1,83 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1cc7180..295bc20 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -161,43 +161,43 @@ endif()
+ # libicu is highly recommended for RSCALE support
+ #  libicu can be found at http://www.icu-project.org
+ #  RSCALE info at http://tools.ietf.org/html/rfc7529
+-find_package(ICU)
+-set_package_properties(ICU PROPERTIES
+-  TYPE RECOMMENDED
+-  PURPOSE "For RSCALE (RFC7529) support"
+-)
+-add_feature_info(
+-  "RSCALE support (RFC7529)"
+-  ICU_FOUND
+-  "build in RSCALE support"
+-)
+-if(ICU_FOUND)
+-  set(REQUIRES_PRIVATE_ICU "Requires.private: icu-i18n") #for libical.pc
+-  set(HAVE_LIBICU 1)
+-  if(ICU_MAJOR_VERSION VERSION_GREATER 50)
+-    set(HAVE_ICU_DANGI TRUE)
+-  else()
+-    set(HAVE_ICU_DANGI FALSE)
+-  endif()
+-endif()
+-if(ICU_I18N_FOUND)
+-  set(HAVE_LIBICU_I18N 1)
+-endif()
++# find_package(ICU)
++# set_package_properties(ICU PROPERTIES
++#   TYPE RECOMMENDED
++#   PURPOSE "For RSCALE (RFC7529) support"
++# )
++# add_feature_info(
++#   "RSCALE support (RFC7529)"
++#   ICU_FOUND
++#   "build in RSCALE support"
++# )
++# if(ICU_FOUND)
++#   set(REQUIRES_PRIVATE_ICU "Requires.private: icu-i18n") #for libical.pc
++#   set(HAVE_LIBICU 1)
++#   if(ICU_MAJOR_VERSION VERSION_GREATER 50)
++#     set(HAVE_ICU_DANGI TRUE)
++#   else()
++#     set(HAVE_ICU_DANGI FALSE)
++#   endif()
++# endif()
++# if(ICU_I18N_FOUND)
++#   set(HAVE_LIBICU_I18N 1)
++# endif()
+ 
+ # compile in Berkeley DB support
+-find_package(BDB)
+-set_package_properties(BDB PROPERTIES
+-  TYPE OPTIONAL
+-  PURPOSE "For Berkeley DB storage support"
+-)
+-add_feature_info(
+-  "Berkeley DB storage support"
+-  BDB_FOUND
+-  "build in support for Berkeley DB storage"
+-)
+-if(BDB_FOUND)
+-  set(HAVE_BDB True)
+-endif()
++# find_package(BDB)
++# set_package_properties(BDB PROPERTIES
++#   TYPE OPTIONAL
++#   PURPOSE "For Berkeley DB storage support"
++# )
++# add_feature_info(
++#   "Berkeley DB storage support"
++#   BDB_FOUND
++#   "build in support for Berkeley DB storage"
++# )
++# if(BDB_FOUND)
++#   set(HAVE_BDB True)
++# endif()
+ 
+ # MSVC specific definitions
+ if(WIN32)


### PR DESCRIPTION
I have problems with the modules: asterisk13-res-calendar-icalendar and asterisk15-res-calendar-icalendar

I config a calendar in calendar.conf, but when I load ical module in asterisk, received segmentation fault.

I updated to last libical version and the problems are solved. Now, I can use google calendar events into asterisk in openwrt and it's great !!!