### PR TITLE
libs/libx264: Update to snapshot 20181006

### DIFF
--- a/libs/libx264/Makefile
+++ b/libs/libx264/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=x264
-PKG_VERSION:=snapshot-20180401-2245
-PKG_RELEASE:=2
+PKG_VERSION:=snapshot-20181006-2245
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.videolan.org/x264/snapshots/
 PKG_MAINTAINER:=Adrian Panella <ianchi74@outlook.com>
-PKG_HASH:=657a915497a5b0ffed3598988657395358cf4dc961db14aebd918b7ffb7c5364
+PKG_HASH:=eae60e969958c0759554d5e338dea9b91f1f1fe85d9523c152c2259d8546f469
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
@@ -25,18 +25,19 @@ PKG_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 
 TARGET_CFLAGS:=$(filter-out -O%,$(TARGET_CFLAGS)) -std=gnu99 -fPIC -O3 -ffast-math -I.
-MAKE_FLAGS+= LD="$(TARGET_CC) -o" 
+MAKE_FLAGS+= LD="$(TARGET_CC) -o"
 
 # ARM ASM depends on ARM1156 or later, blacklist earlier or incompatible cores
 # AMD Geode LX and i486 do not have SSE
 CPU_ASM_BLACKLIST:=geode i486 arm920t arm926ej-s arm1136j-s arm1176jzf-s fa526 mpcore xscale \
-		   mips32 24kc 34kc 74kc octeon mips64
+		   464fp mips32 24kc 34kc 74kc octeon mips64
 
 ifneq ($(CONFIG_SOFT_FLOAT)$(findstring $(call qstrip,$(CONFIG_CPU_TYPE)),$(CPU_ASM_BLACKLIST)),)
   CONFIGURE_VARS+= AS= 
   MAKE_FLAGS+= AS= 
   CONFIGURE_ARGS += --disable-asm
 else
+  CONFIGURE_ARGS += --enable-lto
 ifneq ($(CONFIG_TARGET_x86),)
 ifeq ($(CONFIG_NASM),y)
   CONFIGURE_VARS+= AS=nasm
@@ -67,7 +68,7 @@ define Package/libx264
 endef
 
 define Package/libx264/description
-  x264 is a free software library for encoding 
+  x264 is a free software library for encoding
   video streams into the H.264/MPEG-4 AVC compression format.
 endef
 


### PR DESCRIPTION
Maintainer: @ianchi 

Compile tested: 
apm821xx, WD MyBook Live, OpenWrt master
mvebu, Linksys WRT3200ACM, OpenWrt master
sunxi, OrangePi PC, OpenWrt master

Run tested:
mvebu, Linksys WRT3200ACM, OpenWrt master
sunxi, OrangePi PC, OpenWrt master

Description:
Update libx264 to snapshot 20181006
Add 464fp to ASM blacklist (doesn't support AltiVec instructions)
Enable LTO by default for platforms that uses ASM
Remove a few whitespaces (cosmetic)

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>