### PR TITLE
travelmate: update 1.2.4

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.2.3
+PKG_VERSION:=1.2.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/README.md
+++ b/net/travelmate/files/README.md
@@ -13,7 +13,7 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 * support all kinds of uplinks, incl. hidden and enterprise uplinks
 * continuously checks the existing uplink connection (quality), e.g. for conditional uplink (dis-) connections
 * captive portal detection with internet online check and a 'heartbeat' function to keep the uplink connection up & running
-* support of devices with multiple radios
+* support devices with multiple radios in any order
 * procd init and hotplug support
 * runtime information available via LuCI & via 'status' init command
 * status & debug logging to syslog
@@ -46,7 +46,7 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
     * trm\_maxwait => how long (in seconds) should travelmate wait for a successful wlan interface reload action (int/default: '30', valid range: 20-40)
     * trm\_maxretry => how many times should travelmate try to connect to an uplink (int/default: '3', valid range: 1-10)
     * trm\_timeout => overall retry timeout in seconds (int/default: '60', valid range: 30-300)
-    * trm\_radio => limit travelmate to a dedicated radio, e.g. 'radio0' (default: not set, use all radios)
+    * trm\_radio => limit travelmate to a single radio (e.g. 'radio1') or change the overall scanning order (e.g. 'radio1 radio2 radio0') (default: not set, use all radios 0-n)
     * trm\_iface => main uplink / procd trigger network interface (default: trm_wwan)
     * trm\_triggerdelay => additional trigger delay in seconds before travelmate processing begins (int/default: '2')
 

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-trm_ver="1.2.3"
+trm_ver="1.2.4"
 trm_sysver="unknown"
 trm_enabled=0
 trm_debug=0
@@ -101,10 +101,12 @@ f_prep()
 	local disabled="$(uci_get wireless "${config}" disabled)"
 	local eaptype="$(uci_get wireless "${config}" eap_type)"
 
-	if ([ -z "${trm_radio}" ] || [ "${trm_radio}" = "${radio}" ]) && \
-		[ -z "$(printf "%s" "${trm_radiolist}" | grep -Fo " ${radio}")" ]
+	if [ -z "${trm_radio}" ] && [ -z "$(printf "%s" "${trm_radiolist}" | grep -Fo " ${radio}")" ]
 	then
 		trm_radiolist="${trm_radiolist} ${radio}"
+	elif [ -n "${trm_radio}" ] && [ -z "${trm_radiolist}" ]
+	then
+		trm_radiolist="$(printf "%s" "${trm_radio}" | awk '{while(match(tolower($0),/radio[0-9]/)){ORS=" ";print substr(tolower($0),RSTART,RLENGTH);$0=substr($0,RSTART+RLENGTH)}}')"
 	fi
 	if [ "${mode}" = "sta" ] && [ "${network}" = "${trm_iface}" ]
 	then


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: OpenWrt SNAPSHOT, r8219-4a9784d0c8

Description:
* with the config option 'trm_radio' you can now restrict travelmate
  to a single radio (e.g. 'radio1') or change the overall
  scanning order (e.g. 'radio1 radio2 radio0')
* LuCI: show QR codes now inline on the overview page
  (collapsed by default)

Signed-off-by: Dirk Brenken <dev@brenken.org>