### PR TITLE
Python: Fix compile of host modules

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -268,7 +268,7 @@ define PyPackage/python/filespec
 endef
 
 HOST_LDFLAGS += \
-	$$$$(pkg-config --static --libs libcrypto libssl)
+	$$$$(pkg-config --static --libs libcrypto libssl) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib
 
 ifeq ($(HOST_OS),Linux)
 HOST_LDFLAGS += \


### PR DESCRIPTION
Add -rpath linker option to host build, pointing to staging/hostpkh/lib.
It's needed to find the correct host libs during runtime, without it the
hosts libs may be used instaead, causing failures.

Signed-off-by: Jan Kardell <jan.kardell@telliq.com>

Maintainer: @commodo
Compile tested: (omap, OpenWrt 18.06.01 with packages master on OpenSUSE LEAP 15.0)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
