### PR TITLE
[openwrt-18.06] unbound: update to 1.8.1

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.7.3
-PKG_RELEASE:=3
+PKG_VERSION:=1.8.1
+PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -17,7 +17,7 @@ PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unbound.net/downloads
-PKG_HASH:=c11de115d928a6b48b2165e0214402a7a7da313cd479203a7ce7a8b62cba602d
+PKG_HASH:=c362b3b9c35d1b8c1918da02cdd5528d729206c14c767add89ae95acae363c5d
 
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf

--- a/net/unbound/patches/100-example-conf-in.patch
+++ b/net/unbound/patches/100-example-conf-in.patch
@@ -1,5 +1,10 @@
-diff --git a/doc/example.conf.in b/doc/example.conf.in
-index be83bda..7317b23 100644
+OpenWrt (modification):
+Patch the default configuration file with the tiny memory
+configuration example from Unbound documentation. This is the best
+starting point for embedded routers if one is not going to use UCI.
+
+Index: doc/example.conf.in
+===================================================================
 --- a/doc/example.conf.in
 +++ b/doc/example.conf.in
 @@ -15,6 +15,76 @@ server:


### PR DESCRIPTION
Maintainer: me
Tested: TL-Archer-C7v2 (ar71xx) OpenWrt 18.06
Description:
Update to 1.8.1. Bug fixes for memory leaks. Bug fixes for DNS over TLS. OpenWrt 18.06 has recipes for manual DNS/TLS and experiences the same memory growth as master (with UCI) has had.