### PR TITLE
tinc: update to 1.0.35 (security update) [openwrt-18.06]

### DIFF
--- a/net/tinc/Makefile
+++ b/net/tinc/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinc
-PKG_VERSION:=1.0.34
+PKG_VERSION:=1.0.35
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.tinc-vpn.org/packages
-PKG_HASH:=c03a9b61dedd452116dd9a8db231545ba08a7c96bce011e0cbd3cfd2c56dcfda
+PKG_HASH:=18c83b147cc3e2133a7ac2543eeb014d52070de01c7474287d3ccecc9b16895e
 
 PKG_INSTALL:=1
 


### PR DESCRIPTION
`openwrt-18.06` backport of #7156 
CC @zioproto