### PR TITLE
sqm-scripts: select luci-base instead of depending on it

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -51,7 +51,7 @@ define Package/luci-app-sqm
   TITLE:=SQM Scripts - LuCI interface
   MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
   PKGARCH:=all
-  DEPENDS:= lua luci-base +sqm-scripts
+  DEPENDS:= +lua +luci-base +sqm-scripts
   SUBMENU:=3. Applications
 endef
 


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: r8284-212aa33226 (by issuing `make defconfig`)
Run tested: -

Description:

Currently luci-app-sqm provided by sqm-scripts depends on luci-base instead
of selecting it, this leads to an indirect circular dependency in kconfig:

    tmp/.config-package.in:34646:error: recursive dependency detected!
    For a resolution refer to Documentation/kbuild/kconfig-language.txt
    subsection "Kconfig recursive dependency limitations"
    tmp/.config-package.in:34646:	symbol PACKAGE_iptables is selected by PACKAGE_sqm-scripts
    For a resolution refer to Documentation/kbuild/kconfig-language.txt
    subsection "Kconfig recursive dependency limitations"
    tmp/.config-package.in:961:	symbol PACKAGE_sqm-scripts is selected by PACKAGE_luci-app-sqm
    For a resolution refer to Documentation/kbuild/kconfig-language.txt
    subsection "Kconfig recursive dependency limitations"
    tmp/.config-package.in:22421:	symbol PACKAGE_luci-app-sqm depends on PACKAGE_luci-base
    For a resolution refer to Documentation/kbuild/kconfig-language.txt
    subsection "Kconfig recursive dependency limitations"
    tmp/.config-package.in:21387:	symbol PACKAGE_luci-base is selected by PACKAGE_luci-lib-iptparser
    For a resolution refer to Documentation/kbuild/kconfig-language.txt
    subsection "Kconfig recursive dependency limitations"
    tmp/.config-package.in:22899:	symbol PACKAGE_luci-lib-iptparser is selected by PACKAGE_luci-app-splash
    For a resolution refer to Documentation/kbuild/kconfig-language.txt
    subsection "Kconfig recursive dependency limitations"
    tmp/.config-package.in:22402:	symbol PACKAGE_luci-app-splash is selected by PACKAGE_luci-mod-freifunk-community
    For a resolution refer to Documentation/kbuild/kconfig-language.txt
    subsection "Kconfig recursive dependency limitations"
    tmp/.config-package.in:21552:	symbol PACKAGE_luci-mod-freifunk-community depends on PACKAGE_iptables

Solve the issue by turning the dependencies into selecting ones which also
matches the behaviour of other LuCI applications.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>