### PR TITLE
libyang: Update to 0.16

### DIFF
--- a/libs/libyang/Makefile
+++ b/libs/libyang/Makefile
@@ -8,21 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libyang
-PKG_VERSION:=0.15.130
-PKG_RELEASE=$(PKG_SOURCE_VERSION)
+PKG_VERSION:=0.16-r1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/CESNET/libyang/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=43ab396fc7529251dc9cf02fbd8da48dcf476b998ea0f9e66197632988969074
 
 PKG_LICENSE:=GPL-2.0+
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
-
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=d6baaf90e24af3b07649e9dda6fc0d9b272b2ebc
-PKG_MIRROR_HASH:=eace667ae787ac27b7c717a52f672d05e55608c47d9e54d39d60f8ab5e47f0c9
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/CESNET/libyang.git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION)
-
-PKG_BUILD_ROOT:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
-PKG_BUILD_DIR:=$(PKG_BUILD_ROOT)
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -34,7 +28,7 @@ define Package/libyang
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=YANG data modeling language library
-  URL:=$(PKG_SOURCE_URL)
+  URL:=https://github.com/CESNET/libyang
   DEPENDS:=+libpcre +libpthread
 endef
 
@@ -42,7 +36,7 @@ define Package/yanglint
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=YANG data modeling language utility
-  URL:=$(PKG_SOURCE_URL)
+  URL:=https://github.com/CESNET/libyang
   DEPENDS:=+libyang
 endef
 


### PR DESCRIPTION
Switched to codeload for simplicity and easier package bumping.

Also rearranged Makefile to be more consistent with other packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mamidzic 
Compile tested: mvebu