### PR TITLE
jool: Backport two fixes for newer kernels.

### DIFF
--- a/net/jool/Makefile
+++ b/net/jool/Makefile
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=jool
 PKG_VERSION:=3.5.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/NICMx/Jool/tar.gz/v$(PKG_VERSION)?

--- a/net/jool/patches/010-Add-support-for-kernel-4.17.patch
+++ b/net/jool/patches/010-Add-support-for-kernel-4.17.patch
@@ -1,0 +1,76 @@
+From 831486ea6c7d7adfbdc453587a65bcba247d698b Mon Sep 17 00:00:00 2001
+From: Alberto Leiva Popper <ydahhrk@gmail.com>
+Date: Fri, 6 Jul 2018 13:19:21 -0500
+Subject: [PATCH 1/2] Add support for kernel 4.17
+
+Fixes #266.
+---
+ mod/common/hash_table.c    | 14 +++-----------
+ mod/stateful/fragment_db.c |  4 +---
+ 2 files changed, 4 insertions(+), 14 deletions(-)
+
+diff --git a/mod/common/hash_table.c b/mod/common/hash_table.c
+index 25ddd7a6..4e9272f8 100644
+--- a/mod/common/hash_table.c
++++ b/mod/common/hash_table.c
+@@ -23,8 +23,7 @@
+  * @macro HTABLE_NAME name of the hash table structure to generate. Optional; Default: hash_table.
+  * @macro KEY_TYPE data type of the table's keys.
+  * @macro VALUE_TYPE data type of the table's values.
+- * @macro HASH_TABLE_SIZE The size of the internal array, in slots. Optional;
+- *		Default = Max = 64k - 1.
++ * @macro HASH_TABLE_SIZE The size of the internal array, in slots. MUST be a power of 2.
+  * @macro GENERATE_PRINT just define it if you want the print function; otherwise it will not be
+  *		generated.
+  * @macro GENERATE_FOR_EACH just define it if you want the for_each function; otherwise it will not
+@@ -44,13 +43,6 @@
+ #define HTABLE_NAME hash_table
+ #endif
+ 
+-#ifndef HASH_TABLE_SIZE
+-/**
+- * This number should not exceed unsigned int's maximum.
+- */
+-#define HASH_TABLE_SIZE (64 * 1024 - 1)
+-#endif
+-
+ /** Creates a token name by concatenating prefix and suffix. */
+ #define CONCAT_AUX(prefix, suffix) prefix ## suffix
+ /** Seems useless, but if not present, the compiler won't expand the HTABLE_NAME macro... */
+@@ -131,7 +123,7 @@ static struct KEY_VALUE_PAIR *GET_AUX(struct HTABLE_NAME *table, const KEY_TYPE
+ 	if (WARN(!table, "The table is NULL."))
+ 		return NULL;
+ 
+-	hash_code = table->hash_function(key) % HASH_TABLE_SIZE;
++	hash_code = table->hash_function(key) & (HASH_TABLE_SIZE - 1);
+ 	hlist_for_each(current_node, &table->table[hash_code]) {
+ 		current_pair = hlist_entry(current_node, struct KEY_VALUE_PAIR, hlist_hook);
+ 		if (table->equals_function(key, &current_pair->key))
+@@ -210,7 +202,7 @@ static int PUT(struct HTABLE_NAME *table, KEY_TYPE *key, VALUE_TYPE *value)
+ 	key_value->value = value;
+ 
+ 	/* Insert the key-value to the table. */
+-	hash_code = table->hash_function(key) % HASH_TABLE_SIZE;
++	hash_code = table->hash_function(key) & (HASH_TABLE_SIZE - 1);
+ 	hlist_add_head(&key_value->hlist_hook, &table->table[hash_code]);
+ 	list_add_tail(&key_value->list_hook, &table->list);
+ 
+diff --git a/mod/stateful/fragment_db.c b/mod/stateful/fragment_db.c
+index 44f966aa..ef0b1f5a 100644
+--- a/mod/stateful/fragment_db.c
++++ b/mod/stateful/fragment_db.c
+@@ -90,10 +90,8 @@ static bool equals_function(const struct packet *k1, const struct packet *k2)
+ static unsigned int inet6_hash_frag(__be32 id, const struct in6_addr *saddr,
+ 		const struct in6_addr *daddr, u32 rnd)
+ {
+-	u32 c;
+-	c = jhash_3words(ipv6_addr_hash(saddr), ipv6_addr_hash(daddr),
++	return jhash_3words(ipv6_addr_hash(saddr), ipv6_addr_hash(daddr),
+ 			(__force u32)id, rnd);
+-	return c & (INETFRAGS_HASHSZ - 1);
+ }
+ #endif
+ 
+-- 
+2.19.1
+

--- a/net/jool/patches/020-packet-rename-offset_to_ptr-to-skb_offset_to_ptr-to-.patch
+++ b/net/jool/patches/020-packet-rename-offset_to_ptr-to-skb_offset_to_ptr-to-.patch
@@ -1,0 +1,65 @@
+From f9e62248f252accb0609243958fb51f0f99a5bf3 Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Mon, 1 Oct 2018 22:45:17 -0300
+Subject: [PATCH 2/2] packet: rename offset_to_ptr to skb_offset_to_ptr to
+ avoid conflicts with newer kernel
+
+Rename offset_to_ptr to skb_offset_to_ptr to avoid definition conflict
+when building jool against linux >= 4.19.
+
+Fixes:
+| mod/stateful/../common/packet.c:73:14: error: conflicting types for 'offset_to_ptr'
+|  static void *offset_to_ptr(struct sk_buff *skb, unsigned int offset)
+|               ^~~~~~~~~~~~~
+| In file included from kernel-source/include/linux/export.h:45,
+|                  from kernel-source/include/linux/linkage.h:7,
+|                  from kernel-source/include/linux/kernel.h:7,
+|                  from kernel-source/include/linux/skbuff.h:17,
+|                  from mod/stateful/../../include/nat64/mod/common/packet.h:81,
+|                  from mod/stateful/../common/packet.c:1:
+| kernel-source/include/linux/compiler.h:297:21: note: previous definition of 'offset_to_ptr' was here
+|  static inline void *offset_to_ptr(const int *off)
+|                      ^~~~~~~~~~~~~
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+---
+ mod/common/packet.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/mod/common/packet.c b/mod/common/packet.c
+index 9b4fbcd6..1b094fcc 100644
+--- a/mod/common/packet.c
++++ b/mod/common/packet.c
+@@ -70,7 +70,7 @@ static int inhdr4(struct sk_buff *skb, const char *msg)
+ 	return -EINVAL;
+ }
+ 
+-static void *offset_to_ptr(struct sk_buff *skb, unsigned int offset)
++static void *skb_offset_to_ptr(struct sk_buff *skb, unsigned int offset)
+ {
+ 	return ((void *) skb->data) + offset;
+ }
+@@ -368,9 +368,9 @@ int pkt_init_ipv6(struct packet *pkt, struct sk_buff *skb)
+ 	pkt->l4_proto = meta.l4_proto;
+ 	pkt->is_inner = 0;
+ 	pkt->is_hairpin = false;
+-	pkt->hdr_frag = meta.has_frag_hdr ? offset_to_ptr(skb, meta.frag_offset) : NULL;
++	pkt->hdr_frag = meta.has_frag_hdr ? skb_offset_to_ptr(skb, meta.frag_offset) : NULL;
+ 	skb_set_transport_header(skb, meta.l4_offset);
+-	pkt->payload = offset_to_ptr(skb, meta.payload_offset);
++	pkt->payload = skb_offset_to_ptr(skb, meta.payload_offset);
+ 	pkt->original_pkt = pkt;
+ 
+ 	return 0;
+@@ -530,7 +530,7 @@ int pkt_init_ipv4(struct packet *pkt, struct sk_buff *skb)
+ 	pkt->is_hairpin = false;
+ 	pkt->hdr_frag = NULL;
+ 	skb_set_transport_header(skb, meta.l4_offset);
+-	pkt->payload = offset_to_ptr(skb, meta.payload_offset);
++	pkt->payload = skb_offset_to_ptr(skb, meta.payload_offset);
+ 	pkt->original_pkt = pkt;
+ 
+ 	return 0;
+-- 
+2.19.1
+


### PR DESCRIPTION
The first is needed for 4.14 (maybe the relevant parts got packported and
the second is for when OpenWrt migrates to 4.19.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @danrl 
Compile tested: mvebu

Fixes https://github.com/openwrt/packages/issues/7095