### PR TITLE
setserial: Don't build docs to remove nroff dependency

### DIFF
--- a/utils/setserial/Makefile
+++ b/utils/setserial/Makefile
@@ -2,6 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=setserial
 PKG_VERSION:=2.17
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/setserial

--- a/utils/setserial/patches/010-no-docs.patch
+++ b/utils/setserial/patches/010-no-docs.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.in b/Makefile.in
+index 00b9eb1..2fdbae3 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -17,7 +17,7 @@ DEFS = @DEFS@
+ INCS = -I.
+ TAR = tar
+ 
+-all: setserial setserial.cat
++all: setserial
+ 
+ setserial: setserial.c
+ 	$(CC) $(CFLAGS) $(DEFS) $(INCS) setserial.c -o setserial


### PR DESCRIPTION
Buildbots are failing as they lack nroff.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jow- 