### PR TITLE
cmdpad: Fix compile

### DIFF
--- a/utils/cmdpad/Makefile
+++ b/utils/cmdpad/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmdpad
 PKG_VERSION:=0.0.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=@SF/cmdpad
@@ -27,6 +27,8 @@ define Package/cmdpad
   TITLE:=execute commands when key is pressed/released/held down
   URL:=http://cmdpad.sourceforge.net/index.php
 endef
+
+TARGET_CFLAGS += -std=gnu89
 
 CONFIGURE_ARGS += \
 	--enable-static \


### PR DESCRIPTION
Since the switch to GCC7, this has not compiled as it assumes gnu89 behavior.

-fgnu89-inlining is not enough so use std=gnu89.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: mvebu
