### PR TITLE
grilo: Enable parallel building

### DIFF
--- a/multimedia/grilo/Makefile
+++ b/multimedia/grilo/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grilo
 PKG_VERSION:=0.3.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -20,8 +20,9 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/grilo/0.3/
 PKG_HASH:=1e65ca82dd58020451417fde79310d4b940adc3f63ab59997419c52ed3bc9c91
 
-PKG_BUILD_DEPENDS:=glib2 libsoup libxml2
+PKG_BUILD_DEPENDS:=glib2 libsoup libxml2 perl-xml-parser
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -40,8 +41,16 @@ endef
 
 define Package/grilo/decription
   Grilo is a framework that provides access to different sources of
-  multimedia content, using a pluggable system. 
+  multimedia content, using a pluggable system.
 endef
+
+CONFIGURE_ARGS += \
+	--disable-compile-warnings \
+	--disable-gtk-doc-html \
+	--disable-introspection \
+	--disable-test-ui \
+	--disable-tests \
+	--disable-vala
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/


### PR DESCRIPTION
Passing --disable-gtk-doc-html should fix building in parallel.

Also added some extra flags to speed up build time.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
Compile tested: mvebu