### PR TITLE
libpsl: Disable documentation and enable parallel building

### DIFF
--- a/libs/libpsl/Makefile
+++ b/libs/libpsl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpsl
 PKG_VERSION:=0.20.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -20,6 +20,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/rockdaboot/libpsl/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 PKG_HASH:=f8fd0aeb66252dfcc638f14d9be1e2362fdaf2ca86bde0444ff4d5cc961b560f
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -36,7 +37,10 @@ define Package/libpsl/description
   C library to handle the Public Suffix List
 endef
 
-CONFIGURE_ARGS += --disable-rpath
+CONFIGURE_ARGS += \
+	--disable-gtk-doc-html \
+	--disable-man \
+	--disable-rpath
 
 define Build/InstallDev
 	$(INSTALL_DIR) \


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
Compile tested: mvebu
