### PR TITLE
grilo-plugins: Update to 0.3.7

### DIFF
--- a/multimedia/grilo-plugins/Makefile
+++ b/multimedia/grilo-plugins/Makefile
@@ -8,20 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grilo-plugins
-PKG_VERSION:=0.3.5
+PKG_VERSION:=0.3.7
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
-
 PKG_LICENSE:=LGPLv2.1
 PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/grilo-plugins/0.3/
-PKG_HASH:=2977827b8ecb3e15535236180e57dc35e85058d111349bdb6a1597e62a5068fb
+PKG_HASH:=fc2f3bbc319136e53e1efb6659fa65b6af45db114b6621008f9abba64fad6820
 
 PKG_BUILD_DEPENDS:=glib2 grilo
-
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -43,15 +42,29 @@ endef
 
 define Package/grilo/decription
   Grilo is a framework that provides access to different sources of
-  multimedia content, using a pluggable system. This package contains 
+  multimedia content, using a pluggable system. This package contains
   plugins to get information from a number of sources.
 endef
 
 CONFIGURE_ARGS += \
         --enable-static \
-        --without-libiconv-prefix \
-        --without-libintl-prefix \
-        --without-x \
+        --disable-compile-warnings \
+        --disable-goa \
+        --disable-filesystem \
+        --disable-optical-media \
+        --disable-youtube \
+        --disable-flickr \
+        --disable-podcasts \
+        --disable-bookmarks \
+        --disable-lua-factory \
+        --disable-metadata-store \
+        --disable-vimeo \
+        --disable-tracker \
+        --disable-local-metadata \
+        --disable-chromaprint \
+        --disable-thetvdb \
+        --disable-tmdb \
+        --disable-freebox
 
 define Package/grilo-plugins/install
 	$(INSTALL_DIR) $(1)/usr/lib/grilo-0.3
@@ -84,6 +97,6 @@ $(eval $(call BuildPlugin,dmap,DAAP and DPAP sharing,daap dpap,libdmapsharing,30
 $(eval $(call BuildPlugin,gravatar,Gravatar provider,gravatar,,30))
 $(eval $(call BuildPlugin,jamendo,Jamendo sharing,jamendo,,30))
 $(eval $(call BuildPlugin,magnatune,Magnatune sharing,magnatune,,30))
-$(eval $(call BuildPlugin,opensubtitles,Openi subtitles provider,opensubtitles,,30))
+$(eval $(call BuildPlugin,opensubtitles,Open subtitles provider,opensubtitles,,30))
 $(eval $(call BuildPlugin,raitv,Rai.tv sharing,raitv,,30))
 $(eval $(call BuildPlugin,shoutcast,SHOUTcast sharing,shoutcast,,30))

--- a/multimedia/grilo-plugins/patches/001-grilo-plugins-0.3.5-no-itstool-xmllint.patch
+++ b/multimedia/grilo-plugins/patches/001-grilo-plugins-0.3.5-no-itstool-xmllint.patch
@@ -1,7 +1,6 @@
-diff -u --recursive grilo-plugins-0.3.5-vanilla/configure grilo-plugins-0.3.5/configure
---- grilo-plugins-0.3.5-vanilla/configure	2018-01-07 21:45:18.874540074 -0500
-+++ grilo-plugins-0.3.5/configure	2018-01-07 21:46:31.145749381 -0500
-@@ -638,8 +638,6 @@
+--- a/configure
++++ b/configure
+@@ -638,8 +638,6 @@ am__EXEEXT_TRUE
  LTLIBOBJS
  LIBOBJS
  YELP_HELP_RULES
@@ -10,7 +9,7 @@ diff -u --recursive grilo-plugins-0.3.5-vanilla/configure grilo-plugins-0.3.5/co
  HELP_DIR
  YELP_LC_DIST
  YELP_LC_MEDIA_LINKS
-@@ -1084,9 +1082,7 @@
+@@ -1084,9 +1082,7 @@ MEDIAART_LIBS
  GOM_CFLAGS
  GOM_LIBS
  TRACKER_SPARQL_CFLAGS
@@ -21,7 +20,7 @@ diff -u --recursive grilo-plugins-0.3.5-vanilla/configure grilo-plugins-0.3.5/co
  
  
  # Initialize some variables set by options.
-@@ -1855,8 +1851,6 @@
+@@ -1855,8 +1851,6 @@ Some influential environment variables:
                C compiler flags for TRACKER_SPARQL, overriding pkg-config
    TRACKER_SPARQL_LIBS
                linker flags for TRACKER_SPARQL, overriding pkg-config
@@ -30,7 +29,7 @@ diff -u --recursive grilo-plugins-0.3.5-vanilla/configure grilo-plugins-0.3.5/co
  
  Use these variables to override the choices made by `configure' or to help
  it to find libraries and programs with nonstandard names/locations.
-@@ -16976,89 +16970,6 @@
+@@ -16975,89 +16969,6 @@ HELP_DIR="$with_help_dir"
  
  
  


### PR DESCRIPTION
Version .8 no longer uses Autotools and will thus take a while to be
supported.

Silenced the build from warnings to help fix a bunch of -Wformat ones that
currently break the buildbots.

Explicitly disabled all plugins that are currently unused to save on build
time.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
Compile tested: mvebu