### PR TITLE
remove BUILD_PATENDED from exfat-nofuse

### DIFF
--- a/kernel/exfat-nofuse/Makefile
+++ b/kernel/exfat-nofuse/Makefile
@@ -28,7 +28,7 @@ define KernelPackage/fs-exfat
 	TITLE:=ExFAT Kernel driver
 	FILES:=$(PKG_BUILD_DIR)/exfat.ko
 	AUTOLOAD:=$(call AutoLoad,30,exfat,1)
-	DEPENDS:=+kmod-nls-base @BUILD_PATENTED
+	DEPENDS:=+kmod-nls-base
 endef
 
 define KernelPackage/fs-exfat/description


### PR DESCRIPTION
Maintainer: @yousong

Description:
Microsoft joined Open Invention Network, so I don't think BUILD_PATENTED needed now https://www.openinventionnetwork.com/pressrelease_details/?id=89