### PR TITLE
patch: Add missing CVE-2018-6951 patch

### DIFF
--- a/devel/patch/Makefile
+++ b/devel/patch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=patch
 PKG_VERSION:=2.7.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/patch

--- a/devel/patch/patches/010-CVE-2018-6951.patch
+++ b/devel/patch/patches/010-CVE-2018-6951.patch
@@ -1,0 +1,29 @@
+From 9bf998b5fcbcde1dea0e472dc1538abb97e9012e Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruen@gnu.org>
+Date: Mon, 12 Feb 2018 16:48:24 +0100
+Subject: [PATCH] Fix segfault with mangled rename patch
+
+http://savannah.gnu.org/bugs/?53132
+* src/pch.c (intuit_diff_type): Ensure that two filenames are specified
+for renames and copies (fix the existing check).
+---
+ src/pch.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/pch.c b/src/pch.c
+index ff9ed2c..bc6278c 100644
+--- a/src/pch.c
++++ b/src/pch.c
+@@ -974,7 +974,8 @@ intuit_diff_type (bool need_header, mode_t *p_file_type)
+     if ((pch_rename () || pch_copy ())
+ 	&& ! inname
+ 	&& ! ((i == OLD || i == NEW) &&
+-	      p_name[! reverse] &&
++	      p_name[reverse] && p_name[! reverse] &&
++	      name_is_valid (p_name[reverse]) &&
+ 	      name_is_valid (p_name[! reverse])))
+       {
+ 	say ("Cannot %s file without two valid file names\n", pch_rename () ? "rename" : "copy");
+-- 
+2.19.1
+

--- a/devel/patch/patches/020-CVE-2018-1000156.patch
+++ b/devel/patch/patches/020-CVE-2018-1000156.patch
@@ -1,4 +1,4 @@
-From ee2904728eb4364a36d62d66f723d0b68749e5df Mon Sep 17 00:00:00 2001
+From b56779aed483f0036a32a65e62ab7b5e461b07cc Mon Sep 17 00:00:00 2001
 From: Andreas Gruenbacher <agruen@gnu.org>
 Date: Fri, 6 Apr 2018 12:14:49 +0200
 Subject: [PATCH] Fix arbitrary command execution in ed-style patches
@@ -17,7 +17,7 @@ instead of rejecting them and carrying on.
  create mode 100644 tests/ed-style
 
 diff --git a/src/pch.c b/src/pch.c
-index ff9ed2c..8150493 100644
+index bc6278c..4fd5a05 100644
 --- a/src/pch.c
 +++ b/src/pch.c
 @@ -33,6 +33,7 @@
@@ -28,7 +28,7 @@ index ff9ed2c..8150493 100644
  
  #define INITHUNKMAX 125			/* initial dynamic allocation size */
  
-@@ -2388,22 +2389,28 @@ do_ed_script (char const *inname, char const *outname,
+@@ -2389,22 +2390,28 @@ do_ed_script (char const *inname, char const *outname,
      static char const editor_program[] = EDITOR_PROGRAM;
  
      file_offset beginning_of_this_line;
@@ -71,7 +71,7 @@ index ff9ed2c..8150493 100644
      for (;;) {
  	char ed_command_letter;
  	beginning_of_this_line = file_tell (pfp);
-@@ -2414,14 +2421,14 @@ do_ed_script (char const *inname, char const *outname,
+@@ -2415,14 +2422,14 @@ do_ed_script (char const *inname, char const *outname,
  	}
  	ed_command_letter = get_ed_command_letter (buf);
  	if (ed_command_letter) {
@@ -90,7 +90,7 @@ index ff9ed2c..8150493 100644
  			    write_fatal ();
  		    if (chars_read == 2  &&  strEQ (buf, ".\n"))
  			break;
-@@ -2434,13 +2441,49 @@ do_ed_script (char const *inname, char const *outname,
+@@ -2435,13 +2442,49 @@ do_ed_script (char const *inname, char const *outname,
  	    break;
  	}
      }

--- a/devel/patch/patches/030-CVE-2018-6952.patch
+++ b/devel/patch/patches/030-CVE-2018-6952.patch
@@ -1,4 +1,4 @@
-From daa51e492049d9fe3ac049165ec19641bf19cd7f Mon Sep 17 00:00:00 2001
+From 71607715f11c9875a5aaaf3240885c45f79138e9 Mon Sep 17 00:00:00 2001
 From: Andreas Gruenbacher <agruen@gnu.org>
 Date: Fri, 17 Aug 2018 13:35:40 +0200
 Subject: [PATCH] Fix swapping fake lines in pch_swap
@@ -13,10 +13,10 @@ Fixes: https://savannah.gnu.org/bugs/index.php?53133
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/pch.c b/src/pch.c
-index 8150493..6994ab2 100644
+index 4fd5a05..b0dd14d 100644
 --- a/src/pch.c
 +++ b/src/pch.c
-@@ -2114,7 +2114,7 @@ pch_swap (void)
+@@ -2115,7 +2115,7 @@ pch_swap (void)
      }
      if (p_efake >= 0) {			/* fix non-freeable ptr range */
  	if (p_efake <= i)


### PR DESCRIPTION
The last commit added PKG_CPE_ID and now uscan detects a CVE that I missed

Reordered patches by date and also adjusted patches to be the same as the
ones in the openwrt repo.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @RussellSenior
Compile tested: mvebu
