### PR TITLE
perl: fix compilation with glibc 2.27

### DIFF
--- a/lang/perl/patches/010-musl-compat.patch
+++ b/lang/perl/patches/010-musl-compat.patch
@@ -1,11 +1,11 @@
 --- a/perl.c
 +++ b/perl.c
-@@ -286,7 +286,7 @@ perl_construct(pTHXx)
+@@ -303,7 +303,7 @@ perl_construct(pTHXx)
      PL_localpatches = local_patches;	/* For possible -v */
  #endif
  
 -#if defined(LIBM_LIB_VERSION)
-+#if defined(LIBM_LIB_VERSION) && (defined(__GLIBC__) || defined(__UCLIBC__))
++#if defined(LIBM_LIB_VERSION) && defined(__UCLIBC__)
      /*
       * Some BSDs and Cygwin default to POSIX math instead of IEEE.
       * This switches them over to IEEE.


### PR DESCRIPTION
Maintainer: @pprindeville 
Compile tested: ar71xx, Archer C7, OpenWrt trunk
Run tested: ar71xx, Archer C7, OpenWrt trunk

Description:
Remove dependency on glibc in 010-musl-compat patch as glibc does not
support _LIB_VERSION anymore in 2.27; see
https://sourceware.org/ml/libc-announce/2018/msg00000.html