### PR TITLE
zoneinfo: Updated to the latest release.

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2018e
-PKG_VERSION_CODE:=2018e
+PKG_VERSION:=2018f
+PKG_VERSION_CODE:=2018f
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -20,14 +20,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION_CODE).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=6b288e5926841a4cb490909fe822d85c36ae75538ad69baf20da9628b63b692e
+PKG_HASH:=0af6a85fc4ea95832f76524f35696a61abb3992fd3f8db33e5a1f95653e043f2
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=ca340cf20e80b699d6e5c49b4ba47361b3aa681f06f38a0c88a8e8308c00ebce
+   HASH:=4ec74f8a84372570135ea4be16a042442fafe100f5598cb1017bfd30af6aaa70
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT/LEDE master
Run tested: n/a

Description:
The 2018f release of the tz code and data is available. It reflects the
following changes, which were either circulated on the tz mailing list or are
relatively minor technical or administrative changes:

   Briefly:

     Volgograd moves from +03 to +04 on 2018-10-28.
     Fiji ends DST 2019-01-13, not 2019-01-20.
     Most of Chile changes DST dates, effective 2019-04-06.

   Changes to future timestamps

     Volgograd moves from +03 to +04 on 2018-10-28 at 02:00.
     (Thanks to Alexander Fetisov and Stepan Golosunov.)

     Fiji ends DST 2019-01-13 instead of the 2019-01-20 previously
     predicted.  (Thanks to Raymond Kumar.)  Adjust future predictions
     accordingly.

     Most of Chile will end DST on the first Saturday in April at 24:00 mainland
     time, and resume DST on the first Saturday in September at 24:00 mainland
     time.  The changes are effective from 2019-04-06, and do not affect the
     Magallanes region modeled by America/Punta_Arenas.  (Thanks to Juan Correa
     and Tim Parenti.)  Adjust future predictions accordingly.

   Changes to past timestamps

     The 2018-05-05 North Korea 30-minute time zone change took place
     at 23:30 the previous day, not at 00:00 that day.

     China's 1988 spring-forward transition was on April 17, not
     April 10.  Its DST transitions in 1986/91 were at 02:00, not 00:00.
     (Thanks to P Chan.)

     Fix several issues for Macau before 1992.  Macau's pre-1904 LMT
     was off by 10 s.  Macau switched to +08 in 1904 not 1912, and
     temporarily switched to +09/+10 during World War II.  Macau
     observed DST in 1942/79, not 1961/80, and there were several
     errors for transition times and dates.  (Thanks to P Chan.)

     The 1948-1951 fallback transitions in Japan were at 25:00 on
     September's second Saturday, not at 24:00.  (Thanks to Phake Nick.)
     zic turns this into 01:00 on the day after September's second
     Saturday, which is the best that POSIX or C platforms can do.

     Incorporate 1940-1949 Asia/Shanghai DST transitions from a 2014
     paper by Li Yu, replacing more-questionable data from Shanks.

   Changes to time zone abbreviations

     Use "PST" and "PDT" for Philippine time.  (Thanks to Paul Goyette.)

   Changes to code

     zic now always generates TZif files where time type 0 is used for
     timestamps before the first transition.  This simplifies the
     reading of TZif files and should not affect behavior of existing
     TZif readers because the same set of time types is used; only
     their internal indexes may have changed.  This affects only the
     legacy zones EST5EDT, CST6CDT, MST7MDT, PST8PDT, CET, MET, and
     EET, which previously used nonzero types for these timestamps.

     Because of the type 0 change, zic no longer outputs a dummy
     transition at time -2**59 (before the Big Bang), as clients should
     no longer need this to handle historical timestamps correctly.
     This reverts a change introduced in 2013d and shrinks most TZif
     files by a few bytes.

     zic now supports negative time-of-day in Rule and Leap lines, e.g.,
     "Rule X min max - Apr lastSun -6:00 1:00 -" means the transition
     occurs at 18:00 on the Saturday before the last Sunday in April.
     This behavior was documented in 2018a but the code did not
     entirely match the documentation.

     localtime.c no longer requires at least one time type in TZif
     files that lack transitions or have a POSIX-style TZ string.  This
     future-proofs the code against possible future extensions to the
     format that would allow TZif files with POSIX-style TZ strings and
     without transitions or time types.

     A read-access subscript error in localtime.c has been fixed.
     It could occur only in TZif files with timecnt == 0, something that
     does not happen in practice now but could happen in future versions.

     localtime.c no longer ignores TZif POSIX-style TZ strings that
     specify only standard time.  Instead, these TZ strings now
     override the default time type for timestamps after the last
     transition (or for all time stamps if there are no transitions),
     just as DST strings specifying DST have always done.

     leapseconds.awk now outputs "#updated" and "#expires" comments,
     and supports leap seconds at the ends of months other than June
     and December.  (Inspired by suggestions from Chris Woodbury.)

   Changes to documentation

     New restrictions: A Rule name must start with a character that
     is neither an ASCII digit nor "-" nor "+", and an unquoted name
     should not use characters in the set "!$%&'()*,/:;<=>?@[\]^`{|}~".
     The latter restriction makes room for future extensions (a
     possibility noted by Tom Lane).

     tzfile.5 now documents what time types apply before the first and
     after the last transition, if any.

     Documentation now uses the spelling "timezone" for a TZ setting
     that determines timestamp history, and "time zone" for a
     geographic region currently sharing the same standard time.

     The name "TZif" is now used for the tz binary data format.

     tz-link.htm now mentions the A0 TimeZone Migration utilities.
     (Thanks to Aldrin Martoq for the link.)

   Changes to build procedure

     New 'make' target 'rearguard_tarballs' to build the rearguard
     tarball only.  This is a convenience on platforms that lack lzip
     if you want to build the rearguard tarball.  (Problem reported by
     Deborah Goldsmith.)

     tzdata.zi is now more stable from release to release.  (Problem
     noted by Tom Lane.)  It is also a bit shorter.

     tzdata.zi now can contain comment lines documenting configuration
     information, such as which data format was selected, which input
     files were used, and how leap seconds are treated.  (Problems
     noted by Lester Caine and Brian Inglis.)  If the Makefile defaults
     are used these comment lines are absent, for backward
     compatibility.  A redistributor intending to alter its copy of the
     files should also append "-LABEL" to the 'version' file's first
     line, where "LABEL" identifies the redistributor's change.