### PR TITLE
libopus: Update to 1.3.0

### DIFF
--- a/libs/opus/Makefile
+++ b/libs/opus/Makefile
@@ -8,17 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opus
-PKG_VERSION:=1.2.1
+PKG_VERSION:=1.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://archive.mozilla.org/pub/opus/
-PKG_HASH:=cfafd339ccd9c5ef8d6ab15d7e1a412c054bf4cb4ecbbbcc78c12ef2def70732
+PKG_SOURCE_URL:=https://archive.mozilla.org/pub/opus
+PKG_HASH:=4f3d69aefdf2dbaf9825408e452a8a414ffc60494c70633560700398820dc550
 
+PKG_MAINTAINER:=Ted Hess <thess@kitchensync.net>, Ian Leonard <antonlacon@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Ted Hess <thess@kitchensync.net>, Ian Leonard <antonlacon@gmail.com>
+PKG_CPE_ID:=cpe:/a:opus-codec:opus
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -27,7 +29,7 @@ define Package/libopus
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=OPUS Audio Codec
-  URL:=http://opus-codec.org/
+  URL:=https://opus-codec.org
 endef
 
 define Package/libopus/description
@@ -51,7 +53,6 @@ ifneq ($(findstring neon,$(CONFIG_TARGET_OPTIMIZATION)),)
 endif
 
 CPU_ASM_BLACKLIST:=xscale arm926ej-s
-
 ifneq ($(findstring $(call qstrip,$(CONFIG_CPU_TYPE)),$(CPU_ASM_BLACKLIST)),)
 	CONFIGURE_ARGS+= --disable-asm
 endif


### PR DESCRIPTION
Added PKG_BUILD_PARALLEL for faster compilation.

Added PKG_CPE_ID for proper CVE tracking.

Switched URL from mozilla mirror to official xiph.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess
Compile tested: mvebu