### PR TITLE
picocom: Backport upstream fix for x86

### DIFF
--- a/utils/picocom/Makefile
+++ b/utils/picocom/Makefile
@@ -9,13 +9,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=picocom
 PKG_VERSION:=3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/npat-efault/picocom/tar.gz/$(PKG_VERSION)?
 PKG_HASH:=e6761ca932ffc6d09bd6b11ff018bdaf70b287ce518b3282d29e0270e88420bb
 
-PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
+PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
 PKG_LICENSE:=GPL-2.0+
 
 include $(INCLUDE_DIR)/package.mk

--- a/utils/picocom/patches/020-fix-compile-x86.patch
+++ b/utils/picocom/patches/020-fix-compile-x86.patch
@@ -1,0 +1,44 @@
+From 6fad89a36968fe1bf6aed63f44b7e2e375271e76 Mon Sep 17 00:00:00 2001
+From: Nick Patavalis <npat@efault.net>
+Date: Thu, 12 Apr 2018 15:16:04 +0300
+Subject: [PATCH] Compile with libc's without cispeed / cospeed
+
+Some libc implementations (e.g. musl) do not define the cispeed and
+cospeed struct termios fields. So we have to check the
+_HAVE_STRUCT_TERMIOS_C_ISPEED and _HAVE_STRUCT_TERMIOS_C_OSPEED
+macros. If not defined, we disable custom baudrate support.
+---
+ custbaud.h | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/custbaud.h b/custbaud.h
+index 48151a4..ae4ae8d 100644
+--- a/custbaud.h
++++ b/custbaud.h
+@@ -26,6 +26,8 @@
+ #ifndef CUSTBAUD_H
+ #define CUSTBAUD_H
+ 
++#include <termios.h>
++
+ #ifndef NO_CUSTOM_BAUD
+ 
+ #if defined (__linux__)
+@@ -33,7 +35,13 @@
+ /* Enable by-default for kernels > 2.6.0 on x86 and x86_64 only */
+ #include <linux/version.h>
+ #if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,0)
+-#if defined (__i386__) || defined (__x86_64__) || defined (USE_CUSTOM_BAUD)
++/* Some libc implementations (e.g. musl) do not define the cispeed and
++   cospeed struct termios fields. We do not support custom baudrates
++   on them. */
++#if ( (defined (__i386__) || defined (__x86_64__))  \
++      && defined (_HAVE_STRUCT_TERMIOS_C_ISPEED)    \
++      && defined (_HAVE_STRUCT_TERMIOS_C_OSPEED) )  \
++    || defined (USE_CUSTOM_BAUD)
+ #ifndef USE_CUSTOM_BAUD
+ #define USE_CUSTOM_BAUD
+ #endif
+-- 
+2.19.1
+


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @sbyx

edit: Fixes https://downloads.openwrt.org/snapshots/faillogs/x86_64/packages/picocom/compile.txt