### PR TITLE
libglog: Remove libunwind dependency

### DIFF
--- a/libs/libglog/Makefile
+++ b/libs/libglog/Makefile
@@ -1,16 +1,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glog
-PKG_RELEASE:=1
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/google/glog.git
-PKG_SOURCE_VERSION:=v0.3.5
-PKG_MIRROR_HASH:=4677fba927e2d9cdcbc518c34c88465260d506d88072ea16217a8171310b9a1c
+PKG_VERSION:=0.3.5
+PKG_RELEASE:=2
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/google/glog/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=7580e408a2c0b5a89ca214739978ce6ff480b5e7d8d7698a2aa92fadc484d1e0
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILE:=COPYING
 
 PKG_FIXUP:=autoreconf
-PKG_INSTALL:=1
 
-PKG_LICENSE_FILE:=COPYING
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -27,6 +31,8 @@ define Package/glog/description
   This repository contains a C++ implementation of the Google logging
   module.  Documentation for the implementation is in doc/.
 endef
+
+CONFIGURE_VARS+=ac_cv_have_libunwind_h=0
 
 TARGET_CXXFLAGS+=-std=c++11
 TARGET_LDFLAGS+=-lpthread


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @amir-sabbaghi 
Compile tested: mvebu

Buildbots are failing since they have libunwind.