### PR TITLE
fish: Add (lib)pcre2 dependency

### DIFF
--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -25,7 +25,7 @@ define Package/fish
   CATEGORY:=Utilities
   SUBMENU:=Shells
   TITLE:=A smart and user-friendly command line shell
-  DEPENDS:=+libncurses +libstdcpp +librt
+  DEPENDS:=+libncurses +libstdcpp +librt +libpcre2-32
   URL:=https://fishshell.com
 endef
 


### PR DESCRIPTION
Maintainer: @jqqqqqqqqqq 
Compile tested: mvebu, Linksys WRT3200ACM, OpenWrt master
Run tested: Not needed

Description:
Use the shared version of libpcre2 instead of bundled.

Fixes the following error:
Package fish is missing dependencies for the following libraries:
libpcre2-32.so.0

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>
