### PR TITLE
Bandwidthd 18.06: fix undefined references to inline functions

### DIFF
--- a/utils/bandwidthd/Makefile
+++ b/utils/bandwidthd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bandwidthd
 PKG_VERSION:=2.0.1-34
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/NethServer/bandwidthd/archive/$(PKG_VERSION)
@@ -140,6 +140,7 @@ CONFIGURE_ARGS += \
 	ac_cv_lib_sqlite3_sqlite3_open=no
 endif
 
+TARGET_CFLAGS += -std=gnu89
 EXTRA_CFLAGS+= $(TARGET_CPPFLAGS)
 EXTRA_LDFLAGS+= $(TARGET_LDFLAGS) -Wl,-rpath-link,$(STAGING_DIR)/usr/lib
 


### PR DESCRIPTION
Maintainer: Jean-Michel Lacroix / @padre-lacroix
Compile tested: i386_pentium4 OpenWrt 18.06
Run tested: OpenWrt 18.06.1 r7258-5eb055306f, QEMU Virtual CPU version (cpu64-rhel6).  Able to generate the graphs as expected.

Signed-off-by: Jean-Michel Lacroix <lacroix@lepine-lacroix.info>

Description:
This is the same commit that took place in master 3 weeks ago.
gcc-7 with -Os makes inline functions disappeard. It is caused by
the new C11 inline semantics. pass option -fgnu89-inline to gcc let
it use gnu inline semantics.
see https://wiki.debian.org/GCC7#Porting_help

This will allow to have bandwidthd in 18.06.
