### PR TITLE
mariadb: Small init script polishing

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
 PKG_VERSION:=10.2.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := \
@@ -493,10 +493,12 @@ define Package/mariadb-server/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/etc/mysql/conf.d
 	$(INSTALL_BIN) files/mysqld.init $(1)/etc/init.d/mysqld
-	$(INSTALL_CONF) conf/my.cnf $(1)/etc/mysql
+	# DATA because spomebody thought giving CONF 0600 rights is a good idea
+	$(INSTALL_DATA) conf/my.cnf $(1)/etc/mysql
 	$(INSTALL_CONF) conf/mysqld.default $(1)/etc/default/mysqld
 	$(INSTALL_DIR) $(1)$(PLUGIN_DIR)
-	$(INSTALL_CONF) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/daemon_example.ini $(1)$(PLUGIN_DIR)
+	# DATA because spomebody thought giving CONF 0600 rights is a good idea
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/daemon_example.ini $(1)$(PLUGIN_DIR)
 	$(INSTALL_DIR) $(1)/usr/share/mysql/english
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/mysql/english/errmsg.sys $(1)/usr/share/mysql/english
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/mysql/fill_help_tables.sql $(1)/usr/share/mysql

--- a/utils/mariadb/files/mysqld.init
+++ b/utils/mariadb/files/mysqld.init
@@ -12,6 +12,7 @@ MYSQLD=mysqld
 
 DEFAULT=/etc/default/$MYSQLD
 LOGGER="/usr/bin/logger -p user.err -s -t $MYSQLD"
+[ -x /usr/bin/logger ] || LOGGER=echo
 PROG=/usr/bin/$MYSQLD
 
 unset MY_ARGS MY_GROUP MY_USER
@@ -22,11 +23,13 @@ my_user="${MY_USER:-mariadb}"
 my_group="${MY_GROUP:-mariadb}"
 
 start_service() {
-	local conf='/etc/mysql/my.cnf'
-	local datadir="$( sed -nE "s/^\s*datadir\s*=\s*('([^']*)'|\x22([^\x22]*)\x22|(.*\S))\s*$/\2\3\4/p" "$conf" )"
+	local datadir="$(/usr/bin/mysqld --help --verbose | sed -n 's|^[[:blank:]]*datadir[[:blank:]]*/|/|p')"
+	local tmpdir="$(/usr/bin/mysqld --help --verbose | sed -n 's|^[[:blank:]]*tmpdir[[:blank:]]*/|/|p')"
+	local pidfile="$(/usr/bin/mysqld --help --verbose | sed -n 's|^[[:blank:]]*pid-file[[:blank:]]*/|/|p')"
+	local socketfile="$(/usr/bin/mysqld --help --verbose | sed -n 's|^[[:blank:]]*socket[[:blank:]]*/|/|p')"
 
 	[ -d "$datadir" ] || {
-		$LOGGER "datadir '$datadir' in '$conf' does not exist"
+		$LOGGER "datadir '$datadir' does not exist"
 		return 1
 	}
 
@@ -36,18 +39,17 @@ start_service() {
 		return 1
 	}
 
-	mkdir -p /var/lib/mysql
-	chown "$my_user":"$my_group" /var/lib/mysql
-
-	mkdir -p /var/run/mysqld
-	chown "$my_user":"$my_group" /var/run/mysqld
+	for i in /var/lib/mysql "$datadir" "$tmpdir" "$(dirname "$pidfile")" "$(dirname "$socketfile")"; do
+		mkdir -p "$i"
+		chown "$my_user":"$my_group" "$i"
+	done
 
 	procd_open_instance
 
 	procd_set_param command $PROG $MY_ARGS
-	procd_set_param pidfile /var/run/mysqld.pid
 	# forward stderr to logd
 	procd_set_param stderr 1
+	procd_set_param user "$my_user"
 
 	procd_close_instance
 }

--- a/utils/mariadb/files/mysqld.init
+++ b/utils/mariadb/files/mysqld.init
@@ -22,11 +22,16 @@ unset MY_ARGS MY_GROUP MY_USER
 my_user="${MY_USER:-mariadb}"
 my_group="${MY_GROUP:-mariadb}"
 
+mysql_get_var() {
+	echo "$MYSQL_VARS_OUTPUT" | sed -n 's|^'"$1"'[[:blank:]]\+||p'
+}
+
 start_service() {
-	local datadir="$(/usr/bin/mysqld --help --verbose | sed -n 's|^[[:blank:]]*datadir[[:blank:]]*/|/|p')"
-	local tmpdir="$(/usr/bin/mysqld --help --verbose | sed -n 's|^[[:blank:]]*tmpdir[[:blank:]]*/|/|p')"
-	local pidfile="$(/usr/bin/mysqld --help --verbose | sed -n 's|^[[:blank:]]*pid-file[[:blank:]]*/|/|p')"
-	local socketfile="$(/usr/bin/mysqld --help --verbose | sed -n 's|^[[:blank:]]*socket[[:blank:]]*/|/|p')"
+	MYSQL_VARS_OUTPUT="$(/usr/bin/mysqld --help --verbose | grep '^[a-z]')"
+	local datadir="$(mysql_get_var datadir)"
+	local tmpdir="$(mysql_get_var tmpdir)"
+	local pidfile="$(mysql_get_var pid-file)"
+	local socketfile="$(mysql_get_var socket)"
 
 	[ -d "$datadir" ] || {
 		$LOGGER "datadir '$datadir' does not exist"

--- a/utils/mariadb/files/mysqld.init
+++ b/utils/mariadb/files/mysqld.init
@@ -23,11 +23,10 @@ my_user="${MY_USER:-mariadb}"
 my_group="${MY_GROUP:-mariadb}"
 
 mysql_get_var() {
-	echo "$MYSQL_VARS_OUTPUT" | sed -n 's|^'"$1"'[[:blank:]]\+||p'
+	/usr/bin/mysqld --help --verbose | sed -n 's|^'"$1"'[[:blank:]]\+||p'
 }
 
 start_service() {
-	MYSQL_VARS_OUTPUT="$(/usr/bin/mysqld --help --verbose | grep '^[a-z]')"
 	local datadir="$(mysql_get_var datadir)"
 	local tmpdir="$(mysql_get_var tmpdir)"
 	local pidfile="$(mysql_get_var pid-file)"

--- a/utils/mariadb/files/mysqld.init
+++ b/utils/mariadb/files/mysqld.init
@@ -43,9 +43,11 @@ start_service() {
 		return 1
 	}
 
-	for i in /var/lib/mysql "$datadir" "$tmpdir" "$(dirname "$pidfile")" "$(dirname "$socketfile")"; do
-		mkdir -p "$i"
-		chown "$my_user":"$my_group" "$i"
+	for i in /var/lib/mysql "$tmpdir" "$(dirname "$pidfile")" "$(dirname "$socketfile")"; do
+		if [ \! -d "$i" ]; then
+			mkdir -p "$i"
+			chown "$my_user":"$my_group" "$i"
+		fi
 	done
 
 	procd_open_instance


### PR DESCRIPTION
Using mysqld to get datadir, tmpdir, pidfile and socketfile. This way they
don't need to be set or can be set in included configuration file. Also allows
people to override location of pid file and socket file.

Apart from that, drop pidfile created by procd and let Maria create it by
itself but start MariaDB as mysql user and install configuration files in a way
Maria can read it.

Also include fallback when logger is not available.

Signed-off-by: Michal Hrusecky <Michal@Hrusecky.net>

Maintainer: @micmac1 
Compile tested: mvebu, Turris MOX, OpenWRT master
Run tested: mvebu, Turris MOX, OpenWRT master, starts