### PR TITLE
erlang: update to version 21.0

### DIFF
--- a/lang/erlang/Makefile
+++ b/lang/erlang/Makefile
@@ -8,17 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=erlang
-PKG_VERSION:=19.3
-PKG_RELEASE:=6
+PKG_VERSION:=21.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=otp_src_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= http://www.erlang.org/download/
-PKG_HASH:=fe4a00651db39b8542b04530a48d24b2f2e7e0b77cbe93d728c9f05325bdfe83
+PKG_HASH:=c7d247c0cad2d2e718eaca2e2dff051136a1347a92097abf19ebf65ea2870131
 
 PKG_LICENSE:=ErlPL-1.1
 PKG_LICENSE_FILES:=EPLICENCE
-PKG_MAINTAINER:=Nicolas Thill <nico@openwrt.org> \
-                Arnaud Sautaux <arnaud.sautaux@infoteam.ch>
+PKG_MAINTAINER:=Arnaud Sautaux <arnaud.sautaux@infoteam.ch>
 
 PKG_BUILD_DEPENDS:=erlang/host openssl
 PKG_USE_MIPS16:=0
@@ -46,7 +45,7 @@ endef
 define Package/erlang
 $(call Package/erlang/Default)
   DEPENDS+= +libncurses +librt +zlib
-  PROVIDES:= erlang-erts=8.3 erlang-kernel=5.2 erlang-sasl=3.0.3 erlang-stdlib=3.3
+  PROVIDES:= erlang-erts=10.0.1 erlang-kernel=6.0 erlang-sasl=3.2 erlang-stdlib=3.5
 endef
 
 define Package/erlang/description
@@ -60,7 +59,7 @@ endef
 define Package/erlang-asn1
 $(call Package/erlang/Default)
   TITLE:=Abstract Syntax Notation One (ASN.1) support
-  VERSION:=4.0.4
+  VERSION:=5.0.6
   DEPENDS+= +erlang +erlang-syntax-tools
 endef
 
@@ -75,7 +74,7 @@ endef
 define Package/erlang-compiler
 $(call Package/erlang/Default)
   TITLE:=Byte code compiler
-  VERSION:=7.0.4
+  VERSION:=7.2
   DEPENDS+= +erlang +erlang-hipe
 endef
 
@@ -90,7 +89,7 @@ endef
 define Package/erlang-crypto
 $(call Package/erlang/Default)
   TITLE:=Cryptography support
-  VERSION:=3.7.3
+  VERSION:=4.3
   DEPENDS+= +erlang +libopenssl
 endef
 
@@ -105,7 +104,7 @@ endef
 define Package/erlang-hipe
 $(call Package/erlang/Default)
   TITLE:=High Performance Erlang
-  VERSION:=3.15.4
+  VERSION:=3.18
   DEPENDS+= +erlang
 endef
 
@@ -120,7 +119,7 @@ endef
 define Package/erlang-inets
 $(call Package/erlang/Default)
   TITLE:=Internet clients and servers
-  VERSION:=6.3.6
+  VERSION:=7.0
   DEPENDS+= +erlang
 endef
 
@@ -136,7 +135,7 @@ endef
 define Package/erlang-mnesia
 $(call Package/erlang/Default)
   TITLE:=Distributed database
-  VERSION:=4.14.3
+  VERSION:=4.15.4
   DEPENDS+= +erlang
 endef
 
@@ -153,7 +152,7 @@ endef
 define Package/erlang-runtime-tools
 $(call Package/erlang/Default)
   TITLE:=Low-profile debugging/tracing tools
-  VERSION:=1.11.1
+  VERSION:=1.13
   DEPENDS+= +erlang
 endef
 
@@ -168,7 +167,7 @@ endef
 define Package/erlang-snmp
 $(call Package/erlang/Default)
   TITLE:=Simple Network Management Protocol (SNMP) support
-  VERSION:=5.2.5
+  VERSION:=5.2.11
   DEPENDS+= +erlang +erlang-asn1
 endef
 
@@ -184,7 +183,7 @@ endef
 define Package/erlang-public-key
 $(call Package/erlang/Default)
   TITLE:=Public Key support
-  VERSION:=1.4
+  VERSION:=1.6
   DEPENDS+= +erlang +erlang-crypto +erlang-asn1
 endef
 
@@ -198,7 +197,7 @@ endef
 define Package/erlang-ssh
 $(call Package/erlang/Default)
   TITLE:=Secure Shell (SSH) support
-  VERSION:=4.4.1
+  VERSION:=4.7
   DEPENDS+= +erlang +erlang-crypto
 endef
 
@@ -213,7 +212,7 @@ endef
 define Package/erlang-ssl
 $(call Package/erlang/Default)
   TITLE:=Secure Sockets Layer (SSL) support
-  VERSION:=8.1.1
+  VERSION:=9.0
   DEPENDS+= +erlang +erlang-crypto
 endef
 
@@ -228,7 +227,7 @@ endef
 define Package/erlang-syntax-tools
 $(call Package/erlang/Default)
   TITLE:=Abstract Erlang syntax trees handling support
-  VERSION:=2.1.1
+  VERSION:=2.1.5
   DEPENDS+= +erlang
 endef
 
@@ -243,7 +242,7 @@ endef
 define Package/erlang-tools
 $(call Package/erlang/Default)
   TITLE:=Erlang tools support
-  VERSION:=2.9.1
+  VERSION:=3.0
   DEPENDS+= +erlang
 endef
 
@@ -257,7 +256,7 @@ endef
 define Package/erlang-reltool
 $(call Package/erlang/Default)
   TITLE:=Erlang reltool support
-  VERSION:=0.7.3
+  VERSION:=0.7.6
   DEPENDS+= +erlang
 endef
 
@@ -284,7 +283,7 @@ endef
 define Package/erlang-os_mon
 $(call Package/erlang/Default)
   TITLE:=Erlang OS Monitoring Application
-  VERSION:=2.4.2
+  VERSION:=2.4.5
   DEPENDS+= +erlang
 endef
 
@@ -300,7 +299,7 @@ endef
 define Package/erlang-xmerl
 $(call Package/erlang/Default)
   TITLE:=Erlang XML export
-  VERSION:=1.3.13
+  VERSION:=1.3.17
   DEPENDS+= +erlang
 endef
 


### PR DESCRIPTION
Signed-off-by: Arnaud Sautaux <arnaud.sautaux@infoteam.ch>

Maintainer: me @cretingame
Compile tested: for at91 with debian 8
Run tested: openwrt 18.06.1 at91

Description:

Update to a more recent erlang version and removed unreachable maintainer