### PR TITLE
net/mwan3: improvements

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.7.4
+PKG_VERSION:=2.7.5
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/hotplug.d/iface/13-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/13-mwan3
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. /lib/functions/network.sh
+. /lib/mwan3/mwan3.sh
+
+LOG="logger -t mwan3[$$] -p"
+
+[ "$ACTION" = "connected" -o "$ACTION" = "disconnected" ] || exit 1
+[ -n "$INTERFACE" ] || exit 2
+
+if [ "$ACTION" = "connected" ]; then
+	[ -n "$DEVICE" ] || exit 3
+fi
+
+config_load mwan3
+config_get_bool enabled globals 'enabled' '0'
+config_get local_source globals 'local_source' 'none'
+[ ${enabled} = "1" ] || exit 0
+[ ${local_source} = "none" ] || exit 0
+
+config_get enabled $INTERFACE enabled 0
+config_get online_metric $INTERFACE online_metric 0
+[ "$enabled" == "1" ] || exit 0
+
+if [ "$online_metric" = 0 ]; then
+	$LOG notice "No online metric for interface "$INTERFACE" found"
+	exit 0
+fi
+
+mwan3_add_failover_metric() {
+	local iface="$1"
+	local device="$2"
+	local metric="$3"
+
+	local route_args
+
+	config_get family $iface family ipv4
+
+	if [ "$family" == "ipv4" ]; then
+		if ubus call network.interface.${iface}_4 status 1>/dev/null 2>&1; then
+			network_get_gateway route_args ${iface}_4
+		else
+			network_get_gateway route_args $iface
+		fi
+
+		if [ -n "$route_args" -a "$route_args" != "0.0.0.0" ]; then
+			route_args="via $route_args"
+		else
+			route_args=""
+		fi
+
+		$IP4 route add default $route_args dev $device proto static metric $metric 1>/dev/null 2>&1
+	fi
+
+	if [ "$family" == "ipv6" ]; then
+		if ubus call network.interface.${iface}_6 status 1>/dev/null 2>&1; then
+			network_get_gateway6 route_args ${iface}_6
+		else
+			network_get_gateway6 route_args $iface
+		fi
+
+		if [ -n "$route_args" -a "$route_args" != "::" ]; then
+			route_args="via $route_args"
+		else
+			route_args=""
+		fi
+
+		$IP6 route add default $route_args dev $device proto static metric $metric 1>/dev/null 2>&1
+	fi
+}
+
+mwan3_del_failover_metric() {
+	local iface="$1"
+	local device="$2"
+	local metric="$3"
+
+	config_get family $iface family ipv4
+
+	if [ "$family" == "ipv4" ]; then
+		$IP4 route del default dev $device proto static metric $metric 1>/dev/null 2>&1
+	fi
+
+	if [ "$family" == "ipv6" ]; then
+		$IP6 route del default dev $device proto static metric $metric 1>/dev/null 2>&1
+	fi
+}
+
+case "$ACTION" in
+	connected)
+		mwan3_add_failover_metric "$INTERFACE" "$DEVICE" "$online_metric"
+		;;
+	disconnected)
+		mwan3_del_failover_metric "$INTERFACE" "$DEVICE" "$online_metric"
+		;;
+esac
+
+exit 0

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -19,6 +19,7 @@ config_get_bool enabled globals 'enabled' '0'
 mwan3_lock
 mwan3_init
 mwan3_set_connected_iptables
+mwan3_set_custom_ipset
 mwan3_unlock
 
 config_get enabled $INTERFACE enabled 0

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -1092,9 +1092,7 @@ mwan3_report_connected_v4()
 	local address
 
 	if [ -n "$($IPT4 -S mwan3_connected 2> /dev/null)" ]; then
-		for address in $($IPS list mwan3_connected_v4 | egrep '[0-9]{1,3}(\.[0-9]{1,3}){3}'); do
-			echo " $address"
-		done
+		$IPS -o save list mwan3_connected_v4 | grep add | cut -d " " -f 3
 	fi
 }
 
@@ -1103,9 +1101,7 @@ mwan3_report_connected_v6()
 	local address
 
 	if [ -n "$($IPT6 -S mwan3_connected 2> /dev/null)" ]; then
-		for address in $($IPS list mwan3_connected_v6 | egrep '([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])'); do
-			echo " $address"
-		done
+		$IPS -o save list mwan3_connected_v6 | grep add | cut -d " " -f 3
 	fi
 }
 

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -1219,3 +1219,25 @@ mwan3_track_clean()
 		fi
 	}
 }
+
+mwan3_online_metric_clean() {
+	local iface="$1"
+
+	local online_metric ifname
+
+	config_get family $iface family ipv4
+	config_get online_metric $iface online_metric ""
+	ifname=$(uci_get_state network $iface ifname)
+
+	if [ "$family" == "ipv4" ] \
+		&& [ "$online_metric" != "" ] \
+		&& [ "$ifname" != "" ]; then
+		$IP4 route del default dev $ifname proto static metric $online_metric 1>/dev/null 2>&1
+	fi
+
+	if [ "$family" == "ipv6" ] \
+		&& [ "$online_metric" != "" ] \
+		&& [ "$ifname" != "" ]; then
+		$IP6 route del default dev $ifname proto static metric $online_metric 1>/dev/null 2>&1
+	fi
+}

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -7,6 +7,18 @@ IPT4="iptables -t mangle -w"
 IPT6="ip6tables -t mangle -w"
 LOG="logger -t mwan3[$$] -p"
 CONNTRACK_FILE="/proc/net/nf_conntrack"
+IPv6_REGEX="([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|"
+IPv6_REGEX="${IPv6_REGEX}([0-9a-fA-F]{1,4}:){1,7}:|"
+IPv6_REGEX="${IPv6_REGEX}([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|"
+IPv6_REGEX="${IPv6_REGEX}([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|"
+IPv6_REGEX="${IPv6_REGEX}([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|"
+IPv6_REGEX="${IPv6_REGEX}([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|"
+IPv6_REGEX="${IPv6_REGEX}([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|"
+IPv6_REGEX="${IPv6_REGEX}[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|"
+IPv6_REGEX="${IPv6_REGEX}:((:[0-9a-fA-F]{1,4}){1,7}|:)|"
+IPv6_REGEX="${IPv6_REGEX}fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|"
+IPv6_REGEX="${IPv6_REGEX}::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|"
+IPv6_REGEX="${IPv6_REGEX}([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])"
 
 MWAN3_STATUS_DIR="/var/run/mwan3"
 MWAN3TRACK_STATUS_DIR="/var/run/mwan3track"
@@ -199,7 +211,7 @@ mwan3_set_connected_iptables()
 	$IPS -! create mwan3_connected_v6 hash:net family inet6
 	$IPS create mwan3_connected_v6_temp hash:net family inet6
 
-	for connected_network_v6 in $($IP6 route | awk '{print $1}' | egrep '([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])'); do
+	for connected_network_v6 in $($IP6 route | awk '{print $1}' | egrep "$IPv6_REGEX"); do
 		$IPS -! add mwan3_connected_v6_temp $connected_network_v6
 	done
 

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -261,6 +261,12 @@ mwan3_set_connected_iptables()
 	$IPS -! create mwan3_connected list:set
 	$IPS -! add mwan3_connected mwan3_connected_v4
 	$IPS -! add mwan3_connected mwan3_connected_v6
+
+	$IPS -! create mwan3_dynamic_v4 hash:net
+	$IPS -! add mwan3_connected mwan3_dynamic_v4
+
+	$IPS -! create mwan3_dynamic_v6 hash:net family inet6
+	$IPS -! add mwan3_connected mwan3_dynamic_v6
 }
 
 mwan3_set_general_rules()

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -242,7 +242,9 @@ mwan3_set_general_iptables()
 		if ! $IPT -S mwan3_connected &> /dev/null; then
 			$IPT -N mwan3_connected
 			$IPS -! create mwan3_connected list:set
-			$IPT -A mwan3_connected -m set --match-set mwan3_connected dst -j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
+			$IPT -A mwan3_connected \
+				-m set --match-set mwan3_connected dst \
+				-j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
 		fi
 
 		if ! $IPT -S mwan3_rules &> /dev/null; then
@@ -253,18 +255,43 @@ mwan3_set_general_iptables()
 			$IPT -N mwan3_hook
 			# do not mangle ipv6 ra service
 			if [ "$IPT" = "$IPT6" ]; then
-				$IPT6 -A mwan3_hook -p ipv6-icmp -m icmp6 --icmpv6-type 133 -j RETURN
-				$IPT6 -A mwan3_hook -p ipv6-icmp -m icmp6 --icmpv6-type 134 -j RETURN
-				$IPT6 -A mwan3_hook -p ipv6-icmp -m icmp6 --icmpv6-type 135 -j RETURN
-				$IPT6 -A mwan3_hook -p ipv6-icmp -m icmp6 --icmpv6-type 136 -j RETURN
-				$IPT6 -A mwan3_hook -p ipv6-icmp -m icmp6 --icmpv6-type 137 -j RETURN
+				$IPT6 -A mwan3_hook \
+					-p ipv6-icmp \
+					-m icmp6 --icmpv6-type 133 \
+					-j RETURN
+				$IPT6 -A mwan3_hook \
+					-p ipv6-icmp \
+					-m icmp6 --icmpv6-type 134 \
+					-j RETURN
+				$IPT6 -A mwan3_hook \
+					-p ipv6-icmp \
+					-m icmp6 --icmpv6-type 135 \
+					-j RETURN
+				$IPT6 -A mwan3_hook \
+					-p ipv6-icmp \
+					-m icmp6 --icmpv6-type 136 \
+					-j RETURN
+				$IPT6 -A mwan3_hook \
+					-p ipv6-icmp \
+					-m icmp6 --icmpv6-type 137 \
+					-j RETURN
 			fi
-			$IPT -A mwan3_hook -j CONNMARK --restore-mark --nfmask $MMX_MASK --ctmask $MMX_MASK
-			$IPT -A mwan3_hook -m mark --mark 0x0/$MMX_MASK -j mwan3_ifaces_in
-			$IPT -A mwan3_hook -m mark --mark 0x0/$MMX_MASK -j mwan3_connected
-			$IPT -A mwan3_hook -m mark --mark 0x0/$MMX_MASK -j mwan3_rules
-			$IPT -A mwan3_hook -j CONNMARK --save-mark --nfmask $MMX_MASK --ctmask $MMX_MASK
-			$IPT -A mwan3_hook -m mark ! --mark $MMX_DEFAULT/$MMX_MASK -j mwan3_connected
+			$IPT -A mwan3_hook \
+				-j CONNMARK --restore-mark --nfmask $MMX_MASK --ctmask $MMX_MASK
+			$IPT -A mwan3_hook \
+				-m mark --mark 0x0/$MMX_MASK \
+				-j mwan3_ifaces_in
+			$IPT -A mwan3_hook \
+				-m mark --mark 0x0/$MMX_MASK \
+				-j mwan3_connected
+			$IPT -A mwan3_hook \
+				-m mark --mark 0x0/$MMX_MASK \
+				-j mwan3_rules
+			$IPT -A mwan3_hook \
+				-j CONNMARK --save-mark --nfmask $MMX_MASK --ctmask $MMX_MASK
+			$IPT -A mwan3_hook \
+				-m mark ! --mark $MMX_DEFAULT/$MMX_MASK \
+				-j mwan3_connected
 		fi
 
 		if ! $IPT -S PREROUTING | grep mwan3_hook &> /dev/null; then
@@ -298,11 +325,24 @@ mwan3_create_iface_iptables()
 		fi
 
 		$IPT4 -F mwan3_iface_in_$1
-		$IPT4 -A mwan3_iface_in_$1 -i $2 -m set --match-set mwan3_connected src -m mark --mark 0x0/$MMX_MASK -m comment --comment "default" -j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
-		$IPT4 -A mwan3_iface_in_$1 -i $2 -m mark --mark 0x0/$MMX_MASK -m comment --comment "$1" -j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
+		$IPT4 -A mwan3_iface_in_$1 \
+			-i $2 \
+			-m set --match-set mwan3_connected src \
+			-m mark --mark 0x0/$MMX_MASK \
+			-m comment --comment "default" \
+			-j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
+		$IPT4 -A mwan3_iface_in_$1 \
+			-i $2 \
+			-m mark --mark 0x0/$MMX_MASK \
+			-m comment --comment "$1" \
+			-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
 
-		$IPT4 -D mwan3_ifaces_in -m mark --mark 0x0/$MMX_MASK -j mwan3_iface_in_$1 &> /dev/null
-		$IPT4 -A mwan3_ifaces_in -m mark --mark 0x0/$MMX_MASK -j mwan3_iface_in_$1
+		$IPT4 -D mwan3_ifaces_in \
+			-m mark --mark 0x0/$MMX_MASK \
+			-j mwan3_iface_in_$1 &> /dev/null
+		$IPT4 -A mwan3_ifaces_in \
+			-m mark --mark 0x0/$MMX_MASK \
+			-j mwan3_iface_in_$1
 	fi
 
 	if [ "$family" == "ipv6" ]; then
@@ -317,11 +357,21 @@ mwan3_create_iface_iptables()
 		fi
 
 		$IPT6 -F mwan3_iface_in_$1
-		$IPT6 -A mwan3_iface_in_$1 -i $2 -m set --match-set mwan3_connected_v6 src -m mark --mark 0x0/$MMX_MASK -m comment --comment "default" -j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
-		$IPT6 -A mwan3_iface_in_$1 -i $2 -m mark --mark 0x0/$MMX_MASK -m comment --comment "$1" -j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
+		$IPT6 -A mwan3_iface_in_$1 -i $2 \
+			-m set --match-set mwan3_connected_v6 src \
+			-m mark --mark 0x0/$MMX_MASK \
+			-m comment --comment "default" \
+			-j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
+		$IPT6 -A mwan3_iface_in_$1 -i $2 -m mark --mark 0x0/$MMX_MASK \
+			-m comment --comment "$1" \
+			-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
 
-		$IPT6 -D mwan3_ifaces_in -m mark --mark 0x0/$MMX_MASK -j mwan3_iface_in_$1 &> /dev/null
-		$IPT6 -A mwan3_ifaces_in -m mark --mark 0x0/$MMX_MASK -j mwan3_iface_in_$1
+		$IPT6 -D mwan3_ifaces_in \
+			-m mark --mark 0x0/$MMX_MASK \
+			-j mwan3_iface_in_$1 &> /dev/null
+		$IPT6 -A mwan3_ifaces_in \
+			-m mark --mark 0x0/$MMX_MASK \
+			-j mwan3_iface_in_$1
 	fi
 }
 
@@ -331,14 +381,18 @@ mwan3_delete_iface_iptables()
 
 	if [ "$family" == "ipv4" ]; then
 
-		$IPT4 -D mwan3_ifaces_in -m mark --mark 0x0/$MMX_MASK -j mwan3_iface_in_$1 &> /dev/null
+		$IPT4 -D mwan3_ifaces_in \
+			-m mark --mark 0x0/$MMX_MASK \
+			-j mwan3_iface_in_$1 &> /dev/null
 		$IPT4 -F mwan3_iface_in_$1 &> /dev/null
 		$IPT4 -X mwan3_iface_in_$1 &> /dev/null
 	fi
 
 	if [ "$family" == "ipv6" ]; then
 
-		$IPT6 -D mwan3_ifaces_in -m mark --mark 0x0/$MMX_MASK -j mwan3_iface_in_$1 &> /dev/null
+		$IPT6 -D mwan3_ifaces_in \
+			-m mark --mark 0x0/$MMX_MASK \
+			-j mwan3_iface_in_$1 &> /dev/null
 		$IPT6 -F mwan3_iface_in_$1 &> /dev/null
 		$IPT6 -X mwan3_iface_in_$1 &> /dev/null
 	fi
@@ -568,7 +622,10 @@ mwan3_set_policy()
 
 				total_weight_v4=$weight
 				$IPT4 -F mwan3_policy_$policy
-				$IPT4 -A mwan3_policy_$policy -m mark --mark 0x0/$MMX_MASK -m comment --comment "$iface $weight $weight" -j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
+				$IPT4 -A mwan3_policy_$policy \
+					-m mark --mark 0x0/$MMX_MASK \
+					-m comment --comment "$iface $weight $weight" \
+					-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
 
 				lowest_metric_v4=$metric
 
@@ -589,12 +646,19 @@ mwan3_set_policy()
 
 				probability="-m statistic --mode random --probability $probability"
 
-				$IPT4 -I mwan3_policy_$policy -m mark --mark 0x0/$MMX_MASK $probability -m comment --comment "$iface $weight $total_weight_v4" -j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
+				$IPT4 -I mwan3_policy_$policy \
+					-m mark --mark 0x0/$MMX_MASK $probability \
+					-m comment --comment "$iface $weight $total_weight_v4" \
+					-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
 			fi
 		else
 			[ -n "$device" ] && {
 				$IPT4 -S mwan3_policy_$policy | grep -q '.*--comment ".* [0-9]* [0-9]*"' || \
-					$IPT4 -I mwan3_policy_$policy -o $device -m mark --mark 0x0/$MMX_MASK -m comment --comment "out $iface $device" -j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
+					$IPT4 -I mwan3_policy_$policy \
+					-o $device \
+					-m mark --mark 0x0/$MMX_MASK \
+					-m comment --comment "out $iface $device" \
+					-j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
 			}
 		fi
 	fi
@@ -606,7 +670,10 @@ mwan3_set_policy()
 
 				total_weight_v6=$weight
 				$IPT6 -F mwan3_policy_$policy
-				$IPT6 -A mwan3_policy_$policy -m mark --mark 0x0/$MMX_MASK -m comment --comment "$iface $weight $weight" -j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
+				$IPT6 -A mwan3_policy_$policy \
+					-m mark --mark 0x0/$MMX_MASK \
+					-m comment --comment "$iface $weight $weight" \
+					-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
 
 				lowest_metric_v6=$metric
 
@@ -627,12 +694,20 @@ mwan3_set_policy()
 
 				probability="-m statistic --mode random --probability $probability"
 
-				$IPT6 -I mwan3_policy_$policy -m mark --mark 0x0/$MMX_MASK $probability -m comment --comment "$iface $weight $total_weight_v6" -j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
+				$IPT6 -I mwan3_policy_$policy \
+					-m mark --mark 0x0/$MMX_MASK \
+					$probability \
+					-m comment --comment "$iface $weight $total_weight_v6" \
+					-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
 			fi
 		else
 			[ -n "$device" ] && {
 				$IPT6 -S mwan3_policy_$policy | grep -q '.*--comment ".* [0-9]* [0-9]*"' || \
-					$IPT6 -I mwan3_policy_$policy -o $device -m mark --mark 0x0/$MMX_MASK -m comment --comment "out $iface $device" -j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
+					$IPT6 -I mwan3_policy_$policy \
+					-o $device \
+					-m mark --mark 0x0/$MMX_MASK \
+					-m comment --comment "out $iface $device" \
+					-j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
 			}
 		fi
 	fi
@@ -660,13 +735,22 @@ mwan3_create_policies_iptables()
 
 		case "$last_resort" in
 			blackhole)
-				$IPT -A mwan3_policy_$1 -m mark --mark 0x0/$MMX_MASK -m comment --comment "blackhole" -j MARK --set-xmark $MMX_BLACKHOLE/$MMX_MASK
+				$IPT -A mwan3_policy_$1 \
+					-m mark --mark 0x0/$MMX_MASK \
+					-m comment --comment "blackhole" \
+					-j MARK --set-xmark $MMX_BLACKHOLE/$MMX_MASK
 			;;
 			default)
-				$IPT -A mwan3_policy_$1 -m mark --mark 0x0/$MMX_MASK -m comment --comment "default" -j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
+				$IPT -A mwan3_policy_$1 \
+					-m mark --mark 0x0/$MMX_MASK \
+					-m comment --comment "default" \
+					-j MARK --set-xmark $MMX_DEFAULT/$MMX_MASK
 			;;
 			*)
-				$IPT -A mwan3_policy_$1 -m mark --mark 0x0/$MMX_MASK -m comment --comment "unreachable" -j MARK --set-xmark $MMX_UNREACHABLE/$MMX_MASK
+				$IPT -A mwan3_policy_$1 \
+					-m mark --mark 0x0/$MMX_MASK \
+					-m comment --comment "unreachable" \
+					-j MARK --set-xmark $MMX_UNREACHABLE/$MMX_MASK
 			;;
 		esac
 	done
@@ -699,8 +783,13 @@ mwan3_set_sticky_iptables()
 
 			for IPT in "$IPT4" "$IPT6"; do
 				if [ -n "$($IPT -S mwan3_iface_in_$1 2> /dev/null)" ]; then
-					$IPT -I mwan3_rule_$rule -m mark --mark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK -m set ! --match-set mwan3_sticky_$rule src,src -j MARK --set-xmark 0x0/$MMX_MASK
-					$IPT -I mwan3_rule_$rule -m mark --mark 0/$MMX_MASK -j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
+					$IPT -I mwan3_rule_$rule \
+						-m mark --mark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK \
+						-m set ! --match-set mwan3_sticky_$rule src,src \
+						-j MARK --set-xmark 0x0/$MMX_MASK
+					$IPT -I mwan3_rule_$rule \
+						-m mark --mark 0/$MMX_MASK \
+						-j MARK --set-xmark $(mwan3_id2mask id MMX_MASK)/$MMX_MASK
 				fi
 			done
 		fi
@@ -756,8 +845,12 @@ mwan3_set_user_iptables_rule()
 					$IPT -F mwan3_rule_$1
 				done
 
-				$IPS -! create mwan3_sticky_v4_$rule hash:ip,mark markmask $MMX_MASK timeout $timeout
-				$IPS -! create mwan3_sticky_v6_$rule hash:ip,mark markmask $MMX_MASK timeout $timeout family inet6
+				$IPS -! create mwan3_sticky_v4_$rule \
+					hash:ip,mark markmask $MMX_MASK \
+					timeout $timeout
+				$IPS -! create mwan3_sticky_v6_$rule \
+					hash:ip,mark markmask $MMX_MASK \
+					timeout $timeout family inet6
 				$IPS -! create mwan3_sticky_$rule list:set
 				$IPS -! add mwan3_sticky_$rule mwan3_sticky_v4_$rule
 				$IPS -! add mwan3_sticky_$rule mwan3_sticky_v6_$rule
@@ -765,9 +858,15 @@ mwan3_set_user_iptables_rule()
 				config_foreach mwan3_set_sticky_iptables interface
 
 				for IPT in "$IPT4" "$IPT6"; do
-					$IPT -A mwan3_rule_$1 -m mark --mark 0/$MMX_MASK -j $policy
-					$IPT -A mwan3_rule_$1 -m mark ! --mark 0xfc00/0xfc00 -j SET --del-set mwan3_sticky_$rule src,src
-					$IPT -A mwan3_rule_$1 -m mark ! --mark 0xfc00/0xfc00 -j SET --add-set mwan3_sticky_$rule src,src
+					$IPT -A mwan3_rule_$1 \
+						-m mark --mark 0/$MMX_MASK \
+						-j $policy
+					$IPT -A mwan3_rule_$1 \
+						-m mark ! --mark 0xfc00/0xfc00 \
+						-j SET --del-set mwan3_sticky_$rule src,src
+					$IPT -A mwan3_rule_$1 \
+						-m mark ! --mark 0xfc00/0xfc00 \
+						-j SET --add-set mwan3_sticky_$rule src,src
 				done
 
 				policy="mwan3_rule_$1"
@@ -788,10 +887,24 @@ mwan3_set_user_iptables_rule()
 			for IPT in "$IPT4" "$IPT6"; do
 				case $proto in
 					tcp|udp)
-					$IPT -A mwan3_rules -p $proto -s $src_ip -d $dest_ip $ipset -m multiport --sports $src_port -m multiport --dports $dest_port -m mark --mark 0/$MMX_MASK -m comment --comment "$1" -j $policy &> /dev/null
+					$IPT -A mwan3_rules \
+						-p $proto \
+						-s $src_ip \
+						-d $dest_ip $ipset \
+						-m multiport --sports $src_port \
+						-m multiport --dports $dest_port \
+						-m mark --mark 0/$MMX_MASK \
+						-m comment --comment "$1" \
+						-j $policy &> /dev/null
 					;;
 					*)
-					$IPT -A mwan3_rules -p $proto -s $src_ip -d $dest_ip $ipset -m mark --mark 0/$MMX_MASK -m comment --comment "$1" -j $policy &> /dev/null
+					$IPT -A mwan3_rules \
+						-p $proto \
+						-s $src_ip \
+						-d $dest_ip $ipset \
+						-m mark --mark 0/$MMX_MASK \
+						-m comment --comment "$1" \
+						-j $policy &> /dev/null
 					;;
 				esac
 			done
@@ -800,10 +913,24 @@ mwan3_set_user_iptables_rule()
 
 			case $proto in
 				tcp|udp)
-				$IPT4 -A mwan3_rules -p $proto -s $src_ip -d $dest_ip $ipset -m multiport --sports $src_port -m multiport --dports $dest_port -m mark --mark 0/$MMX_MASK -m comment --comment "$1" -j $policy &> /dev/null
+				$IPT4 -A mwan3_rules \
+					-p $proto \
+					-s $src_ip \
+					-d $dest_ip $ipset \
+					-m multiport --sports $src_port \
+					-m multiport --dports $dest_port \
+					-m mark --mark 0/$MMX_MASK \
+					-m comment --comment "$1" \
+					-j $policy &> /dev/null
 				;;
 				*)
-				$IPT4 -A mwan3_rules -p $proto -s $src_ip -d $dest_ip $ipset -m mark --mark 0/$MMX_MASK -m comment --comment "$1" -j $policy &> /dev/null
+				$IPT4 -A mwan3_rules \
+					-p $proto \
+					-s $src_ip \
+					-d $dest_ip $ipset \
+					-m mark --mark 0/$MMX_MASK \
+					-m comment --comment "$1" \
+					-j $policy &> /dev/null
 				;;
 			esac
 
@@ -811,10 +938,24 @@ mwan3_set_user_iptables_rule()
 
 			case $proto in
 				tcp|udp)
-				$IPT6 -A mwan3_rules -p $proto -s $src_ip -d $dest_ip $ipset -m multiport --sports $src_port -m multiport --dports $dest_port -m mark --mark 0/$MMX_MASK -m comment --comment "$1" -j $policy &> /dev/null
+				$IPT6 -A mwan3_rules \
+					-p $proto \
+					-s $src_ip \
+					-d $dest_ip $ipset \
+					-m multiport --sports $src_port \
+					-m multiport --dports $dest_port \
+					-m mark --mark 0/$MMX_MASK \
+					-m comment --comment "$1" \
+					-j $policy &> /dev/null
 				;;
 				*)
-				$IPT6 -A mwan3_rules -p $proto -s $src_ip -d $dest_ip $ipset -m mark --mark 0/$MMX_MASK -m comment --comment "$1" -j $policy &> /dev/null
+				$IPT6 -A mwan3_rules \
+					-p $proto \
+					-s $src_ip \
+					-d $dest_ip $ipset \
+					-m mark --mark 0/$MMX_MASK \
+					-m comment --comment "$1" \
+					-j $policy &> /dev/null
 				;;
 			esac
 		fi
@@ -871,9 +1012,15 @@ mwan3_report_iface_status()
 
 	if [ -z "$id" -o -z "$device" ]; then
 		result="unknown"
-	elif [ -n "$($IP rule | awk '$1 == "'$(($id+1000)):'"')" -a -n "$($IP rule | awk '$1 == "'$(($id+2000)):'"')" -a -n "$($IPT -S mwan3_iface_in_$1 2> /dev/null)" -a -n "$($IP route list table $id default dev $device 2> /dev/null)" ]; then
+	elif [ -n "$($IP rule | awk '$1 == "'$(($id+1000)):'"')" ] && \
+		[ -n "$($IP rule | awk '$1 == "'$(($id+2000)):'"')" ] && \
+		[ -n "$($IPT -S mwan3_iface_in_$1 2> /dev/null)" ] && \
+		[ -n "$($IP route list table $id default dev $device 2> /dev/null)" ]; then
 		result="$(mwan3_get_iface_hotplug_state $1)"
-	elif [ -n "$($IP rule | awk '$1 == "'$(($id+1000)):'"')" -o -n "$($IP rule | awk '$1 == "'$(($id+2000)):'"')" -o -n "$($IPT -S mwan3_iface_in_$1 2> /dev/null)" -o -n "$($IP route list table $id default dev $device 2> /dev/null)" ]; then
+	elif [ -n "$($IP rule | awk '$1 == "'$(($id+1000)):'"')" ] || \
+		[ -n "$($IP rule | awk '$1 == "'$(($id+2000)):'"')" ] || \
+		[ -n "$($IPT -S mwan3_iface_in_$1 2> /dev/null)" ] || \
+		[ -n "$($IP route list table $id default dev $device 2> /dev/null)" ]; then
 		result="error"
 	elif [ "$enabled" == "1" ]; then
 		result="offline"

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -15,7 +15,7 @@ report_connected_v4() {
 	local address
 
 	if [ -n "$($IPT4 -S mwan3_connected 2> /dev/null)" ]; then
-		for address in $($IPS list mwan3_connected_v4 | tail -n +8); do
+		for address in $($IPS -o save list mwan3_connected_v4 | grep add | cut -d " " -f 3); do
 			json_add_string "" "${address}"
 		done
 	fi
@@ -25,7 +25,7 @@ report_connected_v6() {
 	local address
 
 	if [ -n "$($IPT6 -S mwan3_connected 2> /dev/null)" ]; then
-		for address in $($IPS list mwan3_connected_v6 | tail -n +8); do
+		for address in $($IPS -o save list mwan3_connected_v6 | grep add | cut -d " " -f 3); do
 			json_add_string "" "${address}"
 		done
 	fi

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -175,6 +175,7 @@ stop()
 
 	config_load mwan3
 	config_foreach mwan3_track_clean interface
+	config_foreach mwan3_online_metric_clean interface
 
 	for IP in "$IP4" "$IP6"; do
 


### PR DESCRIPTION
Maintainer: me
Compile tested: not needed shell scripts
Run tested: x86_64(APU3), OpenWrt 18.06, tests done

Description:

- cleanup/prettify 80 characters code boundary
- reduce duplicate code
- enhance ipset status generation
- cleanup egrep ipv6 regex
- add custom address from ip tables to connected ipset
- add dynamic ipsets to mwan3_connected ipsets
- add online_metric for local_source none 
