### PR TITLE
python-cryptography: Add Missing OpenSSL dependencies

### DIFF
--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptography
 PKG_VERSION:=2.3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=cryptography-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= https://files.pythonhosted.org/packages/source/c/cryptography
@@ -32,7 +32,7 @@ define Package/python-cryptography/Default
   CATEGORY:=Languages
   SUBMENU:=Python
   URL:=https://github.com/pyca/cryptography
-  DEPENDS:=+libopenssl
+  DEPENDS:=+libopenssl +@OPENSSL_WITH_DEPRECATED +@OPENSSL_ENGINE
 endef
 
 define Package/python-cryptography


### PR DESCRIPTION
These are hidden from the buildbots because of haproxy enabling everything
unnecessarily.

Unlike the DTLS dependency, these require massive patching and are not
feasible to remove.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jefferyto @commodo 
Compile tested: mvebu, ar71xx
