### PR TITLE
emailrelay: Remove SSLv3 option

### DIFF
--- a/mail/emailrelay/Makefile
+++ b/mail/emailrelay/Makefile
@@ -102,11 +102,6 @@ ifeq ($(CONFIG_EMAILRELAY_SUPPORT_VERBOSE_DBG),y)
 		--enable-debug=yes
 endif
 
-ifeq ($(CONFIG_OPENSSL_WITH_SSL3),y)
-	CONFIGURE_VARS += \
-		CXXFLAGS="$$$$CXXFLAGS -DSSL3_SUPPORT"
-endif
-
 define Package/emailrelay/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/main/emailrelay $(1)/usr/bin/


### PR DESCRIPTION
The next version of OpenSSL will not include support. Removing in advance.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @fededim 
