### PR TITLE
isc-dhcp: drop .conf suffix on dhcrelay config file

### DIFF
--- a/net/isc-dhcp/Makefile
+++ b/net/isc-dhcp/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=isc-dhcp
 UPSTREAM_NAME:=dhcp
 PKG_VERSION:=4.4.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -196,7 +196,7 @@ define Package/isc-dhcp-relay-$(BUILD_VARIANT)/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/dhcrelay $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_DATA) ./files/dhcrelay.conf $(1)/etc/config
+	$(INSTALL_DATA) ./files/dhcrelay.conf $(1)/etc/config/dhcrelay
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/dhcrelay4.init $(1)/etc/init.d/dhcrelay4
 endef


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, generic, HEAD (374e646)
Run tested: N/A (verified by inspection of `.ipk` contents)

```
% ls -R ipkg-x86_64
...
ipkg-x86_64/isc-dhcp-relay-ipv4/etc/config:
dhcrelay

...
```

Description: