### PR TITLE
zoneinfo: Updated to the latest release.

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,8 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2018f
-PKG_VERSION_CODE:=2018f
+PKG_VERSION:=2018g
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -18,16 +17,16 @@ PKG_RELEASE:=1
 PKG_LICENSE:=Public Domain
 
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
-PKG_SOURCE_CODE:=tzcode$(PKG_VERSION_CODE).tar.gz
+PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=0af6a85fc4ea95832f76524f35696a61abb3992fd3f8db33e5a1f95653e043f2
+PKG_HASH:=02dfde534872f6513ae4553a3388fdae579441e31b862ea99170dfc447f46a16
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=4ec74f8a84372570135ea4be16a042442fafe100f5598cb1017bfd30af6aaa70
+   HASH:=aa53f4fb6570f02081be61dc11ade19ea5a280c23822a5b4016ce0c6be23c427
 endef
 
 $(eval $(call Download,tzcode))
@@ -155,7 +154,7 @@ define Package/zoneinfo-simple/install
 		America/Chicago     America/New_York    America/Caracas  \
 		America/Sao_Paulo   Europe/London       Europe/Paris     \
 		Africa/Cairo        Europe/Moscow       Asia/Dubai       \
-		Asia/Karachi        Asia/Dhaka          Asia/Bankok      \
+		Asia/Karachi        Asia/Dhaka          Asia/Bangkok      \
 		Asia/Hong_Kong      Asia/Tokyo          Australia/Darwin \
 		Australia/Adelaide  Australia/Brisbane  Australia/Sydney \
 		Australia/Perth     Pacific/Noumea ; do \


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT/LEDE master
Run tested: n/a

Description:
Added missed 'g' in Bangkok for zoneinfo-simple package.
Also removed dedicated version for code, as we shouldn't mix different versions.

   Briefly:

     Morocco switches to permanent +01 on 2018-10-27.

   Changes to future timestamps

     Morocco switches from +00/+01 to permanent +01 effective 2018-10-27,
     so its clocks will not fall back on 2018-10-28 as previously scheduled.
     (Thanks to Mohamed Essedik Najd and Brian Inglis.)

   Changes to code

     When generating TZif files with leap seconds, zic no longer uses a
     format that trips up older 32-bit clients, fixing a bug introduced
     in 2018f.  (Reported by Daniel Fischer.)  Also, the zic workaround
     for QTBUG-53071 now also works for TZif files with leap seconds.

     The translator to rearguard format now rewrites the line
     "Rule Japan 1948 1951 - Sep Sat>=8 25:00 0 S" to
     "Rule Japan 1948 1951 - Sep Sun>=9  1:00 0 S".
     This caters to zic before 2007 and to Oracle TZUpdater 2.2.0
     and earlier.  (Reported by Christos Zoulas.)

   Changes to past time zone abbreviations

     Change HDT to HWT/HPT for WWII-era abbreviations in Hawaii.
     This reverts to 2011h, as the abbreviation change in 2011i was
     likely inadvertent.

   Changes to documentation

     tzfile.5 has new sections on interoperability issues.

