### PR TITLE
apr: Fix pid_t format

### DIFF
--- a/libs/apr/Makefile
+++ b/libs/apr/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apr
 PKG_VERSION:=1.6.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@APACHE/apr/
@@ -29,7 +29,7 @@ define Package/libapr
   CATEGORY:=Libraries
   DEPENDS:=+libpthread +librt +libuuid
   TITLE:=Apache Portable Runtime Library
-  URL:=http://apr.apache.org/
+  URL:=https://apr.apache.org/
 endef
 
 TARGET_CFLAGS += $(FPIC)

--- a/libs/apr/patches/301-apr-fix-off_t-size-doesn-t-match-in-glibc-when-cross.patch
+++ b/libs/apr/patches/301-apr-fix-off_t-size-doesn-t-match-in-glibc-when-cross.patch
@@ -1,0 +1,78 @@
+From f4d6e45ed5d2ccffd1af4c2ccdf7099ba0dce137 Mon Sep 17 00:00:00 2001
+From: Dengke Du <dengke.du@windriver.com>
+Date: Wed, 14 Dec 2016 18:13:08 +0800
+Subject: [PATCH 6/7] apr: fix off_t size doesn't match in glibc when cross
+ compiling
+
+In configure.in, it contains the following:
+
+	APR_CHECK_SIZEOF_EXTENDED([#include <sys/types.h>], off_t, 8)
+
+the macro "APR_CHECK_SIZEOF_EXTENDED" was defined in build/apr_common.m4,
+it use the "AC_TRY_RUN" macro, this macro let the off_t to 8, when cross
+compiling enable.
+
+So it was hardcoded for cross compiling, we should detect it dynamic based on
+the sysroot's glibc. We change it to the following:
+
+	AC_CHECK_SIZEOF(off_t)
+
+The same for the following hardcoded types for cross compiling:
+
+	pid_t	8
+	ssize_t	8
+	size_t	8
+	off_t	8
+
+Change the above correspondingly.
+
+Signed-off-by: Dengke Du <dengke.du@windriver.com>
+
+Upstream-Status: Pending
+---
+ configure.in | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/configure.in b/configure.in
+index 3b10422..a227e72 100644
+--- a/configure.in
++++ b/configure.in
+@@ -1771,7 +1771,7 @@ else
+     socklen_t_value="int"
+ fi
+ 
+-APR_CHECK_SIZEOF_EXTENDED([#include <sys/types.h>], pid_t, 8)
++AC_CHECK_SIZEOF(pid_t)
+ 
+ if test "$ac_cv_sizeof_pid_t" = "$ac_cv_sizeof_short"; then
+     pid_t_fmt='#define APR_PID_T_FMT "hd"'
+@@ -1840,7 +1840,7 @@ APR_CHECK_TYPES_COMPATIBLE(ssize_t, long, [ssize_t_fmt="ld"])
+ APR_CHECK_TYPES_COMPATIBLE(size_t, unsigned int, [size_t_fmt="u"])
+ APR_CHECK_TYPES_COMPATIBLE(size_t, unsigned long, [size_t_fmt="lu"])
+ 
+-APR_CHECK_SIZEOF_EXTENDED([#include <sys/types.h>], ssize_t, 8)
++AC_CHECK_SIZEOF(ssize_t)
+ 
+ AC_MSG_CHECKING([which format to use for apr_ssize_t])
+ if test -n "$ssize_t_fmt"; then
+@@ -1857,7 +1857,7 @@ fi
+ 
+ ssize_t_fmt="#define APR_SSIZE_T_FMT \"$ssize_t_fmt\""
+ 
+-APR_CHECK_SIZEOF_EXTENDED([#include <stddef.h>], size_t, 8)
++AC_CHECK_SIZEOF(size_t)
+ 
+ AC_MSG_CHECKING([which format to use for apr_size_t])
+ if test -n "$size_t_fmt"; then
+@@ -1874,7 +1874,7 @@ fi
+ 
+ size_t_fmt="#define APR_SIZE_T_FMT \"$size_t_fmt\""
+ 
+-APR_CHECK_SIZEOF_EXTENDED([#include <sys/types.h>], off_t, 8)
++AC_CHECK_SIZEOF(off_t)
+ 
+ if test "${ac_cv_sizeof_off_t}${apr_cv_use_lfs64}" = "4yes"; then
+     # Enable LFS
+-- 
+1.8.3.1
+


### PR DESCRIPTION
musl defines pid_t to be int all the time. The configure script picks it
up as a long long int for some reason.

Fixes apache compilation issue as Apache passes -Werror.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @heil 
Compile tested: mvebu