### PR TITLE
pytz: add Package/InstallDev

### DIFF
--- a/lang/python/pytz/Makefile
+++ b/lang/python/pytz/Makefile
@@ -37,6 +37,13 @@ define Build/Compile
 	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
 endef
 
+define Package/pytz/InstallDev
+	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
+	$(CP) \
+	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
+	    $(1)$(PYTHON_PKG_DIR)
+endef
+
 define Package/pytz/install
 	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
 	$(CP) \


### PR DESCRIPTION
Maintainer: @kissg1988 
Compile tested: mips_24kc, openwrt master

Description:
Building would not work for packages that depended on this when the
build directory was deleted after compiled, so they failed when
BUILDBOT=y.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>