### PR TITLE
libldns: Fix OpenSSL deprecated API usage

### DIFF
--- a/libs/ldns/Makefile
+++ b/libs/ldns/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ldns
 PKG_VERSION:=1.7.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.nlnetlabs.nl/downloads/ldns
@@ -20,6 +20,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=
 
 PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/libs/ldns/patches/200-deprecated-openssl.patch
+++ b/libs/ldns/patches/200-deprecated-openssl.patch
@@ -1,0 +1,88 @@
+diff --git a/dnssec.c b/dnssec.c
+index e3c99de..aae16c8 100644
+--- a/dnssec.c
++++ b/dnssec.c
+@@ -23,6 +23,9 @@
+ #include <openssl/rand.h>
+ #include <openssl/err.h>
+ #include <openssl/md5.h>
++#include <openssl/bn.h>
++#include <openssl/rsa.h>
++#include <openssl/dsa.h>
+ #endif
+ 
+ ldns_rr *
+diff --git a/dnssec_sign.c b/dnssec_sign.c
+index 22f0981..6cdfc9f 100644
+--- a/dnssec_sign.c
++++ b/dnssec_sign.c
+@@ -17,6 +17,9 @@
+ #include <openssl/rand.h>
+ #include <openssl/err.h>
+ #include <openssl/md5.h>
++#include <openssl/bn.h>
++#include <openssl/rsa.h>
++#include <openssl/dsa.h>
+ #endif /* HAVE_SSL */
+ 
+ ldns_rr *
+diff --git a/dnssec_verify.c b/dnssec_verify.c
+index c554e4f..d688b9c 100644
+--- a/dnssec_verify.c
++++ b/dnssec_verify.c
+@@ -594,7 +594,9 @@ ldns_dnssec_trust_tree_print_sm_fmt(FILE *out,
+ 						if (tree->parent_status[i]
+ 						    == LDNS_STATUS_SSL_ERR) {
+ 							printf("; SSL Error: ");
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 							ERR_load_crypto_strings();
++#endif
+ 							ERR_print_errors_fp(stdout);
+ 							printf("\n");
+ 						}
+diff --git a/drill/drill.c b/drill/drill.c
+index 3a9482b..5c56adb 100644
+--- a/drill/drill.c
++++ b/drill/drill.c
+@@ -1013,7 +1013,7 @@ main(int argc, char *argv[])
+ 	xfree(tsig_data);
+ 	xfree(tsig_algorithm);
+ 
+-#ifdef HAVE_SSL
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	CRYPTO_cleanup_all_ex_data();
+ 	ERR_free_strings();
+ 	EVP_cleanup();
+diff --git a/host2str.c b/host2str.c
+index 747d543..1a07d0c 100644
+--- a/host2str.c
++++ b/host2str.c
+@@ -28,6 +28,10 @@
+ #include <time.h>
+ #include <sys/time.h>
+ 
++#include <openssl/bn.h>
++#include <openssl/rsa.h>
++#include <openssl/dsa.h>
++
+ #ifndef INET_ADDRSTRLEN
+ #define INET_ADDRSTRLEN 16
+ #endif
+diff --git a/keys.c b/keys.c
+index 31208cb..8258ee0 100644
+--- a/keys.c
++++ b/keys.c
+@@ -16,8 +16,12 @@
+ 
+ #ifdef HAVE_SSL
+ #include <openssl/ssl.h>
+-#include <openssl/engine.h>
+ #include <openssl/rand.h>
++#include <openssl/bn.h>
++#include <openssl/rsa.h>
++#include <openssl/dsa.h>
++#include <openssl/engine.h>
++#include <openssl/ui.h>
+ #endif /* HAVE_SSL */
+ 
+ ldns_lookup_table ldns_signing_algorithms[] = {


### PR DESCRIPTION
Tested with OpenSSL 1.0.2 and 1.1.1

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ar71xx
