### PR TITLE
mxml: update to 2.12

### DIFF
--- a/libs/mxml/Makefile
+++ b/libs/mxml/Makefile
@@ -1,21 +1,14 @@
-#
-# Copyright (C) 2006-2017 OpenWrt.org
-#
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
-
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mxml
-PKG_VERSION:=2.11
+PKG_VERSION:=2.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/michaelrsweet/mxml.git
-PKG_SOURCE_VERSION:=7b0bb60e51d39b2aaa8e8ca5bf9f3c38e63d643b
-PKG_MIRROR_HASH:=e6f38a91f420c0bc64f892163049c37c5cc7744bffbcb05ad1fddec7b34ea438
+PKG_SOURCE_VERSION:=3aaa12c7d709d05286255d191998f29105dd407a
+PKG_MIRROR_HASH:=fccb77d4c9f6139db9937483596068f40112424ef261025227cda258a5561002
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_FIXUP:=autoreconf
@@ -31,6 +24,7 @@ define Package/mxml
   CATEGORY:=Libraries
   TITLE:=Mini-XML
   URL:=http://www.minixml.org/
+  DEPENDS:=+zlib
 endef
 
 define Package/mxml/description


### PR DESCRIPTION
Signed-off-by: Espen Jürgensen <espenjurgensen+openwrt@gmail.com>

Maintainer: me
Compile tested: AR7xxx, trunk
Run tested: no

Description:
Update mxml to version 2.12