### PR TITLE
libyang: update to 0.16-r2

### DIFF
--- a/libs/libyang/Makefile
+++ b/libs/libyang/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libyang
-PKG_VERSION:=0.16-r1
+PKG_VERSION:=0.16-r2
 
 PKG_LICENSE:=GPL-2.0+
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/CESNET/libyang/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=43ab396fc7529251dc9cf02fbd8da48dcf476b998ea0f9e66197632988969074
+PKG_HASH:=cf354481788f224c58ebe4785a08f992ef00af503529c8d516fdc4d0592996e0
 
 CMAKE_INSTALL:=1
 


### PR DESCRIPTION
Signed-off-by: Mislav Novakovic <mislav.novakovic@sartura.hr>

Maintainer: me
Compile tested: Broadcom 27xx RPi2 32-bit
Run tested: Broadcom 27xx RPi3 32-bit

Description:
Updated the libyang package to latest version, fixes issue with big and little endian.
https://github.com/CESNET/libyang/releases/tag/v0.16-r2