### PR TITLE
icecast: Update to 2.4.4

### DIFF
--- a/multimedia/icecast/Makefile
+++ b/multimedia/icecast/Makefile
@@ -6,18 +6,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=icecast
-PKG_VERSION:=2.4.3
-PKG_RELEASE:=3
+PKG_VERSION:=2.4.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.xiph.org/releases/icecast/
-PKG_HASH:=c85ca48c765d61007573ee1406a797ae6cb31fb5961a42e7f1c87adb45ddc592
+PKG_HASH:=49b5979f9f614140b6a38046154203ee28218d8fc549888596a683ad604e4d44
 
 PKG_MAINTAINER:=André Gaul <andre@gaul.io>, \
 		Ted Hess <thess@kitschensync.net>
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:icecast:icecast
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:= 1
@@ -30,7 +31,7 @@ define Package/icecast
   DEPENDS:=+libcurl +libxml2 +libxslt +libogg +libvorbisidec
   TITLE:=A streaming media server for Ogg/Vorbis and MP3 audio streams
   USERID:=icecast=87:icecast=87
-  URL:=http://www.icecast.org/
+  URL:=https://icecast.org/
 endef
 
 define Package/icecast/description

--- a/multimedia/icecast/patches/001-icecast-2.4.0-tremor.patch
+++ b/multimedia/icecast/patches/001-icecast-2.4.0-tremor.patch
@@ -1,3 +1,50 @@
+--- a/m4/ogg.m4
++++ b/m4/ogg.m4
+@@ -29,7 +29,7 @@ XIPH_GCC_WARNING([-I$ogg_prefix/include],,
+       ])
+ AC_CACHE_CHECK([for libogg], xt_cv_lib_ogg,
+ [dnl
+-OGG_LIBS="-logg"
++OGG_LIBS="-lvorbisidec"
+ 
+ #
+ # check if the installed Ogg is sufficiently new.
+diff --git a/m4/vorbis.m4 b/m4/vorbis.m4
+index 17add29..066dc2a 100644
+--- a/m4/vorbis.m4
++++ b/m4/vorbis.m4
+@@ -38,9 +38,9 @@ if test "x$vorbis_prefix" != "x$ogg_prefix"; then
+             ])
+ fi
+ 
+-VORBIS_LIBS="-lvorbis"
+-VORBISFILE_LIBS="-lvorbisfile"
+-VORBISENC_LIBS="-lvorbisenc"
++VORBIS_LIBS="-lvorbisidec"
++VORBISFILE_LIBS="-lvorbisidec"
++VORBISENC_LIBS="-lvorbisidec"
+ 
+ xt_save_LIBS="$LIBS"
+ xt_save_LDFLAGS="$LDFLAGS"
+@@ -58,18 +58,6 @@ AC_TRY_LINK_FUNC(ogg_stream_init, [xt_lib_vorbis=ok],
+             )
+         ])
+ 
+-if test "x$xt_lib_vorbis" = "xok"; then
+-#
+-# Now check if the installed Vorbis is sufficiently new.
+-#
+-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+-#include <vorbis/codec.h>
+-#include <vorbis/vorbisenc.h>
+-        ], [
+-struct ovectl_ratemanage_arg a;
+-])],,[xt_lib_vorbis="old version found"])
+-AC_MSG_RESULT([$xt_lib_vorbis])
+-fi
+ CPPFLAGS="$xt_save_CPPFLAGS"
+ LIBS="$xt_save_LIBS"
+ LDFLAGS="$xt_save_LDFLAGS"
 --- a/src/format_vorbis.c
 +++ b/src/format_vorbis.c
 @@ -19,7 +19,7 @@
@@ -17,7 +64,7 @@
  
  typedef struct vorbis_codec_tag
  {
-@@ -583,3 +584,91 @@ static refbuf_t *process_vorbis_page (og
+@@ -583,3 +584,91 @@ static refbuf_t *process_vorbis_page (ogg_state_t *ogg_info,
      return NULL;
  }
  
@@ -109,48 +156,3 @@
 +  oggpack_writeclear(&opb);
 +  return 0;
 +}
---- a/m4/vorbis.m4
-+++ b/m4/vorbis.m4
-@@ -38,9 +38,9 @@ if test "x$vorbis_prefix" != "x$ogg_pref
-             ])
- fi
- 
--VORBIS_LIBS="-lvorbis"
--VORBISFILE_LIBS="-lvorbisfile"
--VORBISENC_LIBS="-lvorbisenc"
-+VORBIS_LIBS="-lvorbisidec"
-+VORBISFILE_LIBS="-lvorbisidec"
-+VORBISENC_LIBS="-lvorbisidec"
- 
- xt_save_LIBS="$LIBS"
- xt_save_LDFLAGS="$LDFLAGS"
-@@ -58,18 +58,6 @@ AC_TRY_LINK_FUNC(ogg_stream_init, [xt_li
-             )
-         ])
- 
--if test "x$xt_lib_vorbis" = "xok"; then
--#
--# Now check if the installed Vorbis is sufficiently new.
--#
--AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
--#include <vorbis/codec.h>
--#include <vorbis/vorbisenc.h>
--        ], [
--struct ovectl_ratemanage_arg a;
--])],,[xt_lib_vorbis="old version found"])
--AC_MSG_RESULT([$xt_lib_vorbis])
--fi
- CPPFLAGS="$xt_save_CPPFLAGS"
- LIBS="$xt_save_LIBS"
- LDFLAGS="$xt_save_LDFLAGS"
---- a/m4/ogg.m4
-+++ b/m4/ogg.m4
-@@ -29,7 +29,7 @@ XIPH_GCC_WARNING([-I$ogg_prefix/include]
-       ])
- AC_CACHE_CHECK([for libogg], xt_cv_lib_ogg,
- [dnl
--OGG_LIBS="-logg"
-+OGG_LIBS="-lvorbisidec"
- 
- #
- # check if the installed Ogg is sufficiently new.

--- a/multimedia/icecast/patches/005-no_examples_doc_win32.patch
+++ b/multimedia/icecast/patches/005-no_examples_doc_win32.patch
@@ -9,7 +9,7 @@
  
  EXTRA_DIST = HACKING m4/acx_pthread.m4 m4/ogg.m4 \
      m4/theora.m4 m4/vorbis.m4 m4/speex.m4 \
-@@ -11,7 +11,7 @@ EXTRA_DIST = HACKING m4/acx_pthread.m4 m
+@@ -11,7 +11,7 @@ EXTRA_DIST = HACKING m4/acx_pthread.m4 m4/ogg.m4 \
      m4/xiph_types.m4 m4/xiph_xml2.m4
  
  docdir = $(datadir)/doc/$(PACKAGE)

--- a/multimedia/icecast/patches/010-fix_libcurl_test_crap.patch
+++ b/multimedia/icecast/patches/010-fix_libcurl_test_crap.patch
@@ -1,6 +1,6 @@
 --- a/m4/xiph_curl.m4
 +++ b/m4/xiph_curl.m4
-@@ -52,7 +52,7 @@ AC_CHECK_HEADERS([curl/curl.h],, curl_ok
+@@ -52,7 +52,7 @@ AC_CHECK_HEADERS([curl/curl.h],, curl_ok="no")
  AC_MSG_CHECKING(for libcurl)
  if test "$curl_ok" = "yes"
  then

--- a/multimedia/icecast/patches/020-icecast_config_for_openwrt.patch
+++ b/multimedia/icecast/patches/020-icecast_config_for_openwrt.patch
@@ -7,7 +7,7 @@
 -    <hostname>localhost</hostname>
 +    <hostname>OpenWrt</hostname>
  
-     <!-- You may have multiple <listener> elements -->
+     <!-- You may have multiple <listen-socket> elements -->
      <listen-socket>
 @@ -234,11 +234,9 @@
  


### PR DESCRIPTION
Fixes CVE-2018-18820.

Added PKG_CPE_ID for proper CVE tracking.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ar71xx