### PR TITLE
tgt: Update to 1.0.74

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tgt
-PKG_VERSION:=1.0.73
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.74
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fujita/tgt/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2e3899a2235386a68df8cbf0eccb6a44e221a3e9e6bd9215c903c3fc9ed34bbf
+PKG_HASH:=bfc202790d5326d7a18bd3928b4bb204ffb0acf443a5ec5c16a1a0fbc53be99f
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0
@@ -26,7 +26,7 @@ define Package/tgt
   CATEGORY:=Network
   URL:=http://stgt.sourceforge.net/
   TITLE:=userspace iSCSI target
-  DEPENDS:=+libpthread +libaio @KERNEL_AIO
+  DEPENDS:=+libpthread +libaio
 endef
 
 define Package/tgt/description

--- a/net/tgt/patches/020-usr_Makefile.patch
+++ b/net/tgt/patches/020-usr_Makefile.patch
@@ -1,5 +1,3 @@
-diff --git a/usr/Makefile b/usr/Makefile
-index d4e3eaf..ec1c9a3 100644
 --- a/usr/Makefile
 +++ b/usr/Makefile
 @@ -1,11 +1,11 @@

--- a/net/tgt/patches/030-Makefile.patch
+++ b/net/tgt/patches/030-Makefile.patch
@@ -1,6 +1,6 @@
---- tgt-1.0.48.orig/Makefile	2014-06-04 15:03:53.000000000 +0300
-+++ tgt-1.0.48/Makefile	2014-06-04 15:18:13.132963670 +0300
-@@ -64,7 +64,7 @@
+--- a/Makefile
++++ b/Makefile
+@@ -64,7 +64,7 @@ clean-conf:
  	$(MAKE) -C conf clean
  
  .PHONY: install

--- a/net/tgt/patches/100-musl-compat.patch
+++ b/net/tgt/patches/100-musl-compat.patch
@@ -1,5 +1,3 @@
-diff --git a/usr/tgtd.h b/usr/tgtd.h
-index d8b2ac1..c6eee54 100644
 --- a/usr/tgtd.h
 +++ b/usr/tgtd.h
 @@ -9,6 +9,10 @@
@@ -13,8 +11,6 @@ index d8b2ac1..c6eee54 100644
  struct concat_buf;
  
  #define NR_SCSI_OPCODES		256
-diff --git a/usr/util.h b/usr/util.h
-index 0e34c35..3e2e63b 100644
 --- a/usr/util.h
 +++ b/usr/util.h
 @@ -16,6 +16,10 @@


### PR DESCRIPTION
Remove KERNEL_AIO dependency to avoid recursive dependency with libaio in
a future commit.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mstorchak 
Compile tested: mvebu