### PR TITLE
net: squid: bump version to 4.4

### DIFF
--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
-PKG_VERSION:=4.3
+PKG_VERSION:=4.4
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
@@ -18,7 +18,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www3.us.squid-cache.org/Versions/v4/ \
 	http://www2.pl.squid-cache.org/Versions/v4/ \
 	http://www.squid-cache.org/Versions/v4/
-PKG_HASH:=322612ef0544828f6c673a25124b32364fb41ef5e2847e21c89480b5546a4c7c
+PKG_HASH:=4905e6da7f5574d2583ba36f398bb062a12d51e70d67035078b6e85b09e9ee82
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/net/squid/patches/001-cross_compile.patch
+++ b/net/squid/patches/001-cross_compile.patch
@@ -8,11 +8,9 @@ Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>
  src/Makefile.in | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
-Index: squid-4.0.21/src/Makefile.in
-===================================================================
---- squid-4.0.21.orig/src/Makefile.in
-+++ squid-4.0.21/src/Makefile.in
-@@ -7642,7 +7642,8 @@ cache_cf.o: cf_parser.cci
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -8383,7 +8383,8 @@
  
  # cf_gen builds the configuration files.
  cf_gen$(EXEEXT): $(cf_gen_SOURCES) $(cf_gen_DEPENDENCIES) cf_gen_defines.cci

--- a/net/squid/patches/002-glibc-compile.patch
+++ b/net/squid/patches/002-glibc-compile.patch
@@ -1,6 +1,6 @@
---- squid-4.0.21.orig/src/tools.cc
-+++ squid-4.0.21/src/tools.cc
-@@ -581,7 +581,8 @@
+--- a/src/tools.cc
++++ b/src/tools.cc
+@@ -582,7 +582,8 @@
      }
  #else
  


### PR DESCRIPTION
Maintainer: me / @ratkaj 
Compile tested: Openwrt / mvebu
Run tested: ClearFog Base / mvebu

Description:
Simple bump from 4.3 to 4.4
Patches refreshed

Changelog since 4.3:
netdb not saving to disk
Fix memory leak when parsing SNMP packet
Fix several windows build issues
Certificate fields injection via %D in ERR_SECURE_CONNECT_FAIL
Allow compilation with minimal OpenSSL
Fixed %USER_CA_CERT_xx and %USER_CERT_xx crashes
Improve const correctness for hash_link
Bug 4893: Malformed %>ru URIs for CONNECT requests

Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>