### PR TITLE
monit: Fix compilation without deprecated APIs

### DIFF
--- a/admin/monit/Makefile
+++ b/admin/monit/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=monit
 PKG_VERSION:=5.25.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://mmonit.com/monit/dist

--- a/admin/monit/patches/010-openssl-thread-api.patch
+++ b/admin/monit/patches/010-openssl-thread-api.patch
@@ -1,0 +1,42 @@
+diff --git a/src/ssl/Ssl.c b/src/ssl/Ssl.c
+index 6501f25..9c24ad5 100644
+--- a/src/ssl/Ssl.c
++++ b/src/ssl/Ssl.c
+@@ -302,8 +302,8 @@ static boolean_t _retry(int socket, int *timeout, int (*callback)(int socket, ti
+ 
+ 
+ #if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+-static unsigned long _threadID() {
+-        return (unsigned long)Thread_self();
++static void _threadID(CRYPTO_THREADID *id) {
++        CRYPTO_THREADID_set_numeric(id, (unsigned long)Thread_self());
+ }
+ 
+ 
+@@ -482,7 +482,7 @@ void Ssl_start() {
+         instanceMutexTable = CALLOC(locks, sizeof(Mutex_T));
+         for (int i = 0; i < locks; i++)
+                 Mutex_init(instanceMutexTable[i]);
+-        CRYPTO_set_id_callback(_threadID);
++        CRYPTO_THREADID_set_callback(_threadID);
+         CRYPTO_set_locking_callback(_mutexLock);
+ #endif
+         if (File_exist(URANDOM_DEVICE))
+@@ -496,7 +496,7 @@ void Ssl_start() {
+ 
+ void Ssl_stop() {
+ #if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+-        CRYPTO_set_id_callback(NULL);
++        CRYPTO_THREADID_set_callback(NULL);
+         CRYPTO_set_locking_callback(NULL);
+         for (int i = 0; i < CRYPTO_num_locks(); i++)
+                 Mutex_destroy(instanceMutexTable[i]);
+@@ -510,7 +510,7 @@ void Ssl_stop() {
+ 
+ void Ssl_threadCleanup() {
+ #if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+-        ERR_remove_state(0);
++        ERR_remove_thread_state(NULL);
+ #endif
+ }
+ 


### PR DESCRIPTION
This switches monit to use the THREAD API of OpenSSL 1.0.2. This is gone
in 1.1.0 but will be more stable with 1.0.2.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @champtar 
Compile tested: mvebu