### PR TITLE
libevhtp: Fix compilation on OpenSSL 1.0.2 without deprecated APIs

### DIFF
--- a/libs/libevhtp/Makefile
+++ b/libs/libevhtp/Makefile
@@ -12,15 +12,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libevhtp
 PKG_VERSION:=1.1.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=BSD-3-Clause
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://chromium.googlesource.com/external/github.com/ellzey/libevhtp
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=91071e2f20749cd469b87ac2ef1c158dc2a6806f
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
-PKG_MIRROR_HASH:=c9c4415539e78ac9021a8507cd16b9101564dd03286bc84428cc1ee11f0df1fd
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/criticalstack/libevhtp/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=725dd0a32237b2a097cdc2003d09278a082ccce310aaba7441a5fd8fa8f26635
 
 PKG_INSTALL:=1
 

--- a/libs/libevhtp/patches/021-openssl-thread.patch
+++ b/libs/libevhtp/patches/021-openssl-thread.patch
@@ -1,0 +1,26 @@
+diff --git a/evhtp.c b/evhtp.c
+index 24687be..b646925 100644
+--- a/evhtp.c
++++ b/evhtp.c
+@@ -1667,9 +1667,9 @@ _evhtp_accept_cb(evserv_t * serv, int fd, struct sockaddr * s, int sl, void * ar
+ 
+ #ifndef EVHTP_DISABLE_SSL
+ #ifndef EVHTP_DISABLE_EVTHR
+-static unsigned long
+-_evhtp_ssl_get_thread_id(void) {
+-    return (unsigned long)pthread_self();
++static void
++_evhtp_ssl_get_thread_id(CRYPTO_THREADID *id) {
++    CRYPTO_THREADID_set_numeric(id, (unsigned long)pthread_self());
+ }
+ 
+ static void
+@@ -2999,7 +2999,7 @@ evhtp_ssl_use_threads(void) {
+         pthread_mutex_init(&(ssl_locks[i]), NULL);
+     }
+ 
+-    CRYPTO_set_id_callback(_evhtp_ssl_get_thread_id);
++    CRYPTO_THREADID_set_callback(_evhtp_ssl_get_thread_id);
+     CRYPTO_set_locking_callback(_evhtp_ssl_thread_lock);
+ 
+     return 0;


### PR DESCRIPTION
Also switched to the proper upstream.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @kissg1988 
Compile tested: ar71xx