### PR TITLE
libnetconf2: Remove OpenSSL engine support

### DIFF
--- a/libs/libnetconf2/Makefile
+++ b/libs/libnetconf2/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetconf2
 PKG_VERSION:=0.12-r1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>

--- a/libs/libnetconf2/patches/010-remove-engine.patch
+++ b/libs/libnetconf2/patches/010-remove-engine.patch
@@ -1,0 +1,33 @@
+From 5472ebd501c0558a9434a11b309f3b6a314c2168 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Wed, 7 Nov 2018 16:58:42 -0800
+Subject: [PATCH] session: Remove engine.h include
+
+OpenSSL's engine API is not used except for a cleanup call.
+---
+ src/session.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/session.c b/src/session.c
+index edf1bb4..fe90fa9 100644
+--- a/src/session.c
++++ b/src/session.c
+@@ -36,7 +36,6 @@
+ 
+ #if defined(NC_ENABLED_SSH) || defined(NC_ENABLED_TLS)
+ 
+-#   include <openssl/engine.h>
+ #   include <openssl/conf.h>
+ #   include <openssl/err.h>
+ 
+@@ -1296,7 +1295,6 @@ static void
+ nc_ssh_destroy(void)
+ {
+     FIPS_mode_set(0);
+-    ENGINE_cleanup();
+     CONF_modules_unload(1);
+     nc_thread_destroy();
+     ssh_finalize();
+-- 
+2.19.1
+


### PR DESCRIPTION
It's not even used.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: ???
Compile tested: mvebu

Fixes compile without OpenSSL engine support