### PR TITLE
cyrus-sasl: Fix compilation without deprecated APIs on OpenSSL

### DIFF
--- a/libs/cyrus-sasl/Makefile
+++ b/libs/cyrus-sasl/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=cyrus-sasl
 PKG_VERSION_BASE:=2.1.27
 PKG_VERSION:=$(PKG_VERSION_BASE)-rc8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 

--- a/libs/cyrus-sasl/patches/010-openssl-deprecated.patch
+++ b/libs/cyrus-sasl/patches/010-openssl-deprecated.patch
@@ -1,0 +1,39 @@
+From d2a7592b9884049d3da384c5c37f77629ce9ac56 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 6 Nov 2018 18:58:30 -0800
+Subject: [PATCH] openssl: Fix compilation without deprecated APIs
+
+bn.h was missing. Including engine.h does not work if OpenSSL was built
+without it. cyrus-sasl makes no use of it anyway.
+---
+ common/crypto-compat.c | 1 -
+ common/crypto-compat.h | 1 +
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/crypto-compat.c b/common/crypto-compat.c
+index f4717b6..8195879 100644
+--- a/common/crypto-compat.c
++++ b/common/crypto-compat.c
+@@ -12,7 +12,6 @@
+ #if defined(HAVE_OPENSSL) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
+ 
+ #include <string.h>
+-#include <openssl/engine.h>
+ 
+ static void *OPENSSL_zalloc(size_t num)
+ {
+diff --git a/common/crypto-compat.h b/common/crypto-compat.h
+index 73424ad..d3ffdca 100644
+--- a/common/crypto-compat.h
++++ b/common/crypto-compat.h
+@@ -15,6 +15,7 @@
+ #include <openssl/dh.h>
+ #include <openssl/evp.h>
+ #include <openssl/hmac.h>
++#include <openssl/bn.h>
+ 
+ int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
+ int RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q);
+-- 
+2.19.1
+


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
Compile tested: mvebu