### PR TITLE
dovecot: Fix compilation for OpenSSL without deprecated APIs

### DIFF
--- a/mail/dovecot/Makefile
+++ b/mail/dovecot/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot
 PKG_VERSION:=2.3.2.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.dovecot.org/releases/2.3

--- a/mail/dovecot/patches/100-openssl-deprecated.patch
+++ b/mail/dovecot/patches/100-openssl-deprecated.patch
@@ -1,0 +1,26 @@
+diff --git a/src/lib-dcrypt/dcrypt-openssl.c b/src/lib-dcrypt/dcrypt-openssl.c
+index c2dbd30..201ab40 100644
+--- a/src/lib-dcrypt/dcrypt-openssl.c
++++ b/src/lib-dcrypt/dcrypt-openssl.c
+@@ -20,6 +20,7 @@
+ #include <openssl/engine.h>
+ #include <openssl/hmac.h>
+ #include <openssl/objects.h>
++#include <openssl/bn.h>
+ #include "dcrypt.h"
+ #include "dcrypt-private.h"
+ 
+diff --git a/src/lib-ssl-iostream/iostream-openssl-context.c b/src/lib-ssl-iostream/iostream-openssl-context.c
+index e3c902e..ad6a9c1 100644
+--- a/src/lib-ssl-iostream/iostream-openssl-context.c
++++ b/src/lib-ssl-iostream/iostream-openssl-context.c
+@@ -6,6 +6,9 @@
+ #include "dovecot-openssl-common.h"
+ 
+ #include <openssl/crypto.h>
++#include <openssl/rsa.h>
++#include <openssl/dh.h>
++#include <openssl/bn.h>
+ #include <openssl/x509.h>
+ #include <openssl/pem.h>
+ #include <openssl/ssl.h>


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: mvebu