### PR TITLE
uw-imap: Fix compilation without deprecated APIs for OpenSSL

### DIFF
--- a/libs/uw-imap/Makefile
+++ b/libs/uw-imap/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uw-imap
 PKG_VERSION:=2007f
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=imap-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \

--- a/libs/uw-imap/patches/020-deprecated-openssl.patch
+++ b/libs/uw-imap/patches/020-deprecated-openssl.patch
@@ -1,0 +1,12 @@
+diff --git a/src/osdep/unix/ssl_unix.c b/src/osdep/unix/ssl_unix.c
+index 3bfdff3..3ed1cb5 100644
+--- a/src/osdep/unix/ssl_unix.c
++++ b/src/osdep/unix/ssl_unix.c
+@@ -35,6 +35,7 @@
+ #include <bio.h>
+ #include <crypto.h>
+ #include <rand.h>
++#include <rsa.h>
+ #undef crypt
+ 
+ #define SSLBUFLEN 8192


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: mvebu