### PR TITLE
automake: update to 1.15.1

### DIFF
--- a/devel/automake/Makefile
+++ b/devel/automake/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=automake
-PKG_VERSION:=1.15
-PKG_RELEASE:=4
+PKG_VERSION:=1.15.1
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@GNU/automake
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=9908c75aabd49d13661d6dcb1bc382252d22cc77bf733a2d55e87f2aa2db8636
+PKG_HASH:=af6ba39142220687c500f79b4aa2f181d9b24e4f8d8ec497cea4ba26c64bedaf
 PKG_MAINTAINER:=Heinrich Schuchardt <xypron.glpk@gmx.de>
 PKG_LICENSE:=GPL-3.0+
 
@@ -36,22 +36,24 @@ endef
 
 FIX_PATHS = $(SED) '1c \#!/usr/bin/perl' -e 's| /[^ ]*/bin/perl| /usr/bin/perl|g'
 
+AM_VERSION:=$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
+
 define Package/automake/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/automake-$(PKG_VERSION) \
-	  $(1)/usr/bin/automake-$(PKG_VERSION)
-	$(LN) automake-$(PKG_VERSION) $(1)/usr/bin/automake
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/aclocal-$(PKG_VERSION) \
-	  $(1)/usr/bin/aclocal-$(PKG_VERSION)
-	$(LN) aclocal-$(PKG_VERSION) $(1)/usr/bin/aclocal
-	$(FIX_PATHS) $(1)/usr/bin/automake-$(PKG_VERSION)
-	$(FIX_PATHS) $(1)/usr/bin/aclocal-$(PKG_VERSION)
-	$(INSTALL_DIR) $(1)/usr/share/automake-$(PKG_VERSION)
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/automake-$(AM_VERSION) \
+	  $(1)/usr/bin/automake-$(AM_VERSION)
+	$(LN) automake-$(AM_VERSION) $(1)/usr/bin/automake
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/aclocal-$(AM_VERSION) \
+	  $(1)/usr/bin/aclocal-$(AM_VERSION)
+	$(LN) aclocal-$(AM_VERSION) $(1)/usr/bin/aclocal
+	$(FIX_PATHS) $(1)/usr/bin/automake-$(AM_VERSION)
+	$(FIX_PATHS) $(1)/usr/bin/aclocal-$(AM_VERSION)
+	$(INSTALL_DIR) $(1)/usr/share/automake-$(AM_VERSION)
 
 	for dir in \
-	  automake-$(PKG_VERSION) automake-$(PKG_VERSION)/Automake \
-	  automake-$(PKG_VERSION)/am aclocal \
-	  aclocal-$(PKG_VERSION) aclocal-$(PKG_VERSION)/internal \
+	  automake-$(AM_VERSION) automake-$(AM_VERSION)/Automake \
+	  automake-$(AM_VERSION)/am aclocal \
+	  aclocal-$(AM_VERSION) aclocal-$(AM_VERSION)/internal \
 	; do \
 		$(INSTALL_DIR) $(1)/usr/share/$$$$dir; \
 		for file in $$$$(cd $(PKG_INSTALL_DIR) && \


### PR DESCRIPTION
Signed-off-by: Michael Heimpold <mhei@heimpold.de>

Maintainer: @xypron 
Compile tested: mxs
Run tested: no

Description:
Needed to introduce a new AM_VERSION variable which contains only the first two version number elements.
I did not bump to 1.16.1 since OpenWrt is also still using 1.15.1.