### PR TITLE
ffmpeg: fix depends on hardfloat targets

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=3.2.12
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
@@ -343,7 +343,7 @@ define Package/libffmpeg-full
 $(call Package/libffmpeg/Default)
  TITLE+= (full)
  DEPENDS+= +alsa-lib +PACKAGE_libopus:libopus \
-    $(if $$(CONFIG_SOFT_FLOAT),\
+    $(if $(CONFIG_SOFT_FLOAT),\
 	+PACKAGE_shine:shine,\
 	+PACKAGE_lame-lib:lame-lib +PACKAGE_libx264:libx264 +PACKAGE_fdk-aac:fdk-aac)
  VARIANT:=full


### PR DESCRIPTION
Fix variable reference. Currently the depends on hardfloat targets are
wrong, causing packaging errors:

Package libffmpeg-full is missing dependencies for the following libraries:
libmp3lame.so.0

Example targets:

arm_cortex-a9_vfpv3
x86 variety

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @thess @antonlacon 
Compile tested: x86_64
Run tested: N/A

Description:
Hello all,

I think commit c2cc90a3ddaf8df625ac7772ef3d05cdd0d5cfa7 is problematic. Since the commit (at least) ffmpeg-full builds on hard float targets are failing due to missing deps.

In the commit there's actually a comment from remarking about the build failures. Also, there is issue #7289. I think it may be directly related to this.

Thanks for reviewing!

Kind regards.
Seb