### PR TITLE
libndpi: Add PKG_BUILD_DEPENDS to fix compilation

### DIFF
--- a/libs/libndpi/Makefile
+++ b/libs/libndpi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libndpi
 PKG_VERSION:=2.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ntop/nDPI/tar.gz/$(PKG_VERSION)?
@@ -20,6 +20,7 @@ PKG_MAINTAINER:=Banglang Huang <banglang.huang@foxmail.com>
 PKG_LICENSE:=LGPLv3
 
 PKG_FIXUP:=autoreconf
+PKG_BUILD_DEPENDS:=libpcap
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
@@ -34,7 +35,7 @@ define Package/libndpi
 endef
 
 define Package/libndpi/description
-  nDPI is an open source LGPLv3 library for deep-packet inspection. 
+  nDPI is an open source LGPLv3 library for deep-packet inspection.
   Based on OpenDPI it includes ntop extensions.
 endef
 
@@ -46,28 +47,28 @@ endef
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/include/ndpi \
+		$(PKG_INSTALL_DIR)/usr/local/include/ndpi \
 		$(1)/usr/include/
 
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/libndpi.so* \
+		$(PKG_INSTALL_DIR)/usr/local/lib/libndpi.so \
 		$(1)/usr/lib/
 
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/local/libdata/pkgconfig/libndpi.pc \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libndpi.pc \
 		$(1)/usr/lib/pkgconfig/
 endef
 
 define Package/libndpi/install
 	$(INSTALL_DIR) $(1)/usr/lib/
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/libndpi.so* \
+		$(PKG_INSTALL_DIR)/usr/local/lib/libndpi.so \
 		$(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/local/bin/ndpiReader \
+		$(PKG_INSTALL_DIR)/usr/bin/ndpiReader \
 		$(1)/usr/bin/
 endef
 

--- a/libs/libndpi/patches/0001-Move-the-configure-include-file-inclusion-and-code-d.patch
+++ b/libs/libndpi/patches/0001-Move-the-configure-include-file-inclusion-and-code-d.patch
@@ -1,0 +1,75 @@
+From 91ac4e4beed953fc9d2185ca2e6813dde47e8d5a Mon Sep 17 00:00:00 2001
+From: Guido Falsi <mad@madpilot.net>
+Date: Mon, 27 Aug 2018 17:52:56 +0200
+Subject: [PATCH 1/9] Move the configure include file inclusion and code
+ depending on it in code protected by the NDPI_LIB_COMPILATION define, this
+ should avoid it polluting the environment when including this file from
+ ntopng, version against stable branch.
+
+---
+ src/include/ndpi_typedefs.h | 15 ++++++++++-----
+ src/lib/ndpi_main.c         |  7 -------
+ 2 files changed, 10 insertions(+), 12 deletions(-)
+
+diff --git a/src/include/ndpi_typedefs.h b/src/include/ndpi_typedefs.h
+index 6a61b44..386b217 100644
+--- a/src/include/ndpi_typedefs.h
++++ b/src/include/ndpi_typedefs.h
+@@ -26,9 +26,6 @@
+ 
+ #include "ndpi_define.h"
+ 
+-/* Needed to have access to HAVE_* defines */
+-#include "ndpi_config.h"
+-
+ /* NDPI_LOG_LEVEL */
+ typedef enum {
+   NDPI_LOG_ERROR,
+@@ -854,7 +851,17 @@ typedef struct ndpi_proto {
+ #define NUM_CUSTOM_CATEGORIES      5
+ #define CUSTOM_CATEGORY_LABEL_LEN 32
+ 
++#ifdef NDPI_LIB_COMPILATION
++
++/* Needed to have access to HAVE_* defines */
++#include "ndpi_define.h"
++
+ #ifdef HAVE_HYPERSCAN
++struct hs {
++  hs_database_t *database;
++  hs_scratch_t  *scratch;
++};
++
+ struct hs_list {
+   char *expression;
+   unsigned int id;
+@@ -862,8 +869,6 @@ struct hs_list {
+ };
+ #endif
+ 
+-#ifdef NDPI_LIB_COMPILATION
+-
+ struct ndpi_detection_module_struct {
+   NDPI_PROTOCOL_BITMASK detection_bitmask;
+   NDPI_PROTOCOL_BITMASK generic_http_packet_bitmask;
+diff --git a/src/lib/ndpi_main.c b/src/lib/ndpi_main.c
+index b002126..8061aa1 100644
+--- a/src/lib/ndpi_main.c
++++ b/src/lib/ndpi_main.c
+@@ -51,13 +51,6 @@
+ #include <hs/hs.h>
+ #endif
+ 
+-#ifdef HAVE_HYPERSCAN
+-struct hs {
+-  hs_database_t *database;
+-  hs_scratch_t  *scratch;
+-};
+-#endif
+-
+ #define NDPI_CONST_GENERIC_PROTOCOL_NAME  "GenericProtocol"
+ 
+ static int _ndpi_debug_callbacks = 0;
+-- 
+2.19.1
+

--- a/libs/libndpi/patches/0002-Fixes-600.patch
+++ b/libs/libndpi/patches/0002-Fixes-600.patch
@@ -1,17 +1,19 @@
-From 0e09c2b5c573ad1fce7c8f13b6bf255e1f21d390 Mon Sep 17 00:00:00 2001
+From 6be5188ff93780a7f2acd48f41c4ac1846597091 Mon Sep 17 00:00:00 2001
 From: Luca <deri@ntop.org>
 Date: Tue, 11 Sep 2018 10:02:34 +0300
-Subject: [PATCH] Fixes #600 Backport of recent fixes (e.g. #601)
+Subject: [PATCH 2/9] Fixes #600 Backport of recent fixes (e.g. #601)
 
 ---
  Makefile.am                        |  5 ++-
  autogen.sh                         |  2 +-
  configure.seed                     | 13 +++++--
+ src/lib/Makefile                   | 26 --------------
  src/lib/Makefile.in                | 54 ++++++++++++++++++++++++++++++
  src/lib/ndpi_main.c                |  2 --
  src/lib/protocols/ssl.c            | 36 ++++++++++++++------
  src/lib/third_party/include/hash.h |  1 +
- 7 files changed, 94 insertions(+), 19 deletions(-)
+ 8 files changed, 94 insertions(+), 45 deletions(-)
+ delete mode 100644 src/lib/Makefile
  create mode 100644 src/lib/Makefile.in
 
 diff --git a/Makefile.am b/Makefile.am
@@ -88,6 +90,38 @@ index 6b85c66..8f8817f 100644
  AC_SUBST(SVN_DATE)
  AC_SUBST(JSON_C_LIB)
  AC_SUBST(PCAP_INC)
+diff --git a/src/lib/Makefile b/src/lib/Makefile
+deleted file mode 100644
+index 19c6f1c..0000000
+--- a/src/lib/Makefile
++++ /dev/null
+@@ -1,26 +0,0 @@
+-#
+-# Simple non-autotools dependent makefile
+-#
+-# ./autogen.sh
+-# cd src/lib
+-# make -f Makefile.simple
+-#
+-CFLAGS += -fPIC -DPIC -I../include -Ithird_party/include -DNDPI_LIB_COMPILATION -g
+-RANLIB  = ranlib
+-
+-OBJECTS = $(patsubst protocols/%.c, protocols/%.o, $(wildcard protocols/*.c)) $(patsubst third_party/src/%.c, third_party/src/%.o, $(wildcard third_party/src/*.c)) ndpi_main.o
+-HEADERS = $(wildcard ../include/*.h)
+-
+-all: libndpi.a
+-
+-ndpi_main.c: ndpi_content_match.c.inc
+-
+-libndpi.a: $(OBJECTS)
+-	   ar rc $@ $(OBJECTS)
+-	   $(RANLIB) $@	       
+-
+-%.o: %.c $(HEADERS) Makefile
+-	$(CC) $(CFLAGS) -c $< -o $@
+-
+-clean:
+-	/bin/rm -f libndpi.a $(OBJECTS)
 diff --git a/src/lib/Makefile.in b/src/lib/Makefile.in
 new file mode 100644
 index 0000000..ca29001
@@ -106,7 +140,7 @@ index 0000000..ca29001
 +#
 +# Installation directories
 +#
-+prefix     = /usr
++prefix     = /usr/local
 +libdir     = ${prefix}/lib
 +includedir = ${prefix}/include/ndpi
 +CC         = @CC@
@@ -149,7 +183,7 @@ index 0000000..ca29001
 +	mkdir -p $(DESTDIR)$(includedir)
 +	cp ../include/*.h $(DESTDIR)$(includedir)
 diff --git a/src/lib/ndpi_main.c b/src/lib/ndpi_main.c
-index b002126..5beb6b4 100644
+index 8061aa1..540e158 100644
 --- a/src/lib/ndpi_main.c
 +++ b/src/lib/ndpi_main.c
 @@ -43,9 +43,7 @@

--- a/libs/libndpi/patches/0003-Fixed-duplicate-protocol-name.-607.patch
+++ b/libs/libndpi/patches/0003-Fixed-duplicate-protocol-name.-607.patch
@@ -1,0 +1,26 @@
+From efd8348c3a5ace204410608f1805c9d5899096ab Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=98=D0=B2=D0=B0=D0=BD=20=D0=A1=D0=BF=D0=B8=D0=BD=D0=B5?=
+ =?UTF-8?q?=D0=BD=D0=BA=D0=BE?= <ispinenko@ideco.ru>
+Date: Thu, 13 Sep 2018 18:23:47 +0500
+Subject: [PATCH 3/9] Fixed duplicate protocol name. #607
+
+---
+ src/lib/ndpi_main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/lib/ndpi_main.c b/src/lib/ndpi_main.c
+index 540e158..33ccbb1 100644
+--- a/src/lib/ndpi_main.c
++++ b/src/lib/ndpi_main.c
+@@ -1225,7 +1225,7 @@ static void ndpi_init_protocol_defaults(struct ndpi_detection_module_struct *ndp
+ 			    ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */);
+     ndpi_set_proto_defaults(ndpi_mod, NDPI_PROTOCOL_FUN, NDPI_PROTOCOL_VIDTO,
+ 			    no_master,
+-			    no_master, "PPStream", NDPI_PROTOCOL_CATEGORY_MEDIA,
++			    no_master, "Vidto", NDPI_PROTOCOL_CATEGORY_MEDIA,
+ 			    ndpi_build_default_ports(ports_a, 0, 0, 0, 0, 0) /* TCP */,
+ 			    ndpi_build_default_ports(ports_b, 0, 0, 0, 0, 0) /* UDP */);
+ 
+-- 
+2.19.1
+

--- a/libs/libndpi/patches/0004-Added-missing-ndpi_protocol2id-prototype.patch
+++ b/libs/libndpi/patches/0004-Added-missing-ndpi_protocol2id-prototype.patch
@@ -1,0 +1,60 @@
+From ba72865f23cd0d52f373573308e0e05c5bd37ba8 Mon Sep 17 00:00:00 2001
+From: Luca Deri <deri@ntop.org>
+Date: Wed, 19 Sep 2018 11:11:15 +0200
+Subject: [PATCH 4/9] Added missing ndpi_protocol2id() prototype Fixed error
+ when crearing symlink in Makefile
+
+---
+ src/include/ndpi_api.h | 15 ++++++++++++++-
+ src/lib/Makefile.in    |  2 +-
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/src/include/ndpi_api.h b/src/include/ndpi_api.h
+index 3fefc8e..56c5436 100644
+--- a/src/include/ndpi_api.h
++++ b/src/include/ndpi_api.h
+@@ -420,7 +420,7 @@ extern "C" {
+ 			char *bigram_to_match);
+ 
+   /**
+-   * Write the protocol name in the buffer -buf- as master_protocol.protocol
++   * Write the protocol name in the buffer -buf- as master_protocol.protocol (string)
+    *
+    * @par     ndpi_mod      = the detection module
+    * @par     proto         = the struct ndpi_protocol contain the protocols name
+@@ -432,6 +432,19 @@ extern "C" {
+   char* ndpi_protocol2name(struct ndpi_detection_module_struct *ndpi_mod,
+ 			   ndpi_protocol proto, char *buf, u_int buf_len);
+ 
++  /**
++   * Write the protocol name in the buffer -buf- as master_protocol.protocol (number)
++   *
++   * @par     ndpi_mod      = the detection module
++   * @par     proto         = the struct ndpi_protocol contain the protocols name
++   * @par     buf           = the buffer to write the name of the protocols
++   * @par     buf_len       = the length of the buffer
++   * @return  the buffer contains the master_protocol and protocol name
++   *
++   */
++  char* ndpi_protocol2id(struct ndpi_detection_module_struct *ndpi_mod,
++			 ndpi_protocol proto, char *buf, u_int buf_len);
++
+   /**
+    * Find out if a given category is custom/user-defined
+    *
+diff --git a/src/lib/Makefile.in b/src/lib/Makefile.in
+index ca29001..cbbc54b 100644
+--- a/src/lib/Makefile.in
++++ b/src/lib/Makefile.in
+@@ -38,7 +38,7 @@ $(NDPI_LIB_STATIC): $(OBJECTS)
+ 
+ $(NDPI_LIB_SHARED): $(OBJECTS)
+ 	$(CC) -shared -fPIC -o $@ $(OBJECTS)
+-	ln -Fs $(NDPI_LIB_SHARED) $(NDPI_LIB_SHARED_BASE)
++	ln -fs $(NDPI_LIB_SHARED) $(NDPI_LIB_SHARED_BASE)
+ 
+ %.o: %.c $(HEADERS) Makefile
+ 	$(CC) $(CFLAGS) -c $< -o $@
+-- 
+2.19.1
+

--- a/libs/libndpi/patches/0005-Do-not-use-the-available-clang-as-the-default-compil.patch
+++ b/libs/libndpi/patches/0005-Do-not-use-the-available-clang-as-the-default-compil.patch
@@ -1,0 +1,30 @@
+From 54fd7face86f3d5287bc8d0f2633bd13c66498cf Mon Sep 17 00:00:00 2001
+From: Vitaly Lavrov <vel21ripn@gmail.com>
+Date: Sun, 30 Sep 2018 22:49:18 +0300
+Subject: [PATCH 5/9] Do not use the available clang as the default compiler.
+ Use the CC environment variable when running autogen.sh and configure.
+
+---
+ configure.seed | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/configure.seed b/configure.seed
+index 8f8817f..b150fdb 100644
+--- a/configure.seed
++++ b/configure.seed
+@@ -51,12 +51,6 @@ if test $SHORT_MACHINE = "arm"; then
+ else
+      AC_CHECK_LIB([numa], [numa_available], [LIBNUMA="-lnuma"])
+ fi
+-
+-if test -z `which clang`; then
+-CC=gcc
+-else
+-CC=clang
+-fi
+  
+ HS_LIB=
+ HS_INC=
+-- 
+2.19.1
+

--- a/libs/libndpi/patches/0006-Backported-ndpi_protocol2id.patch
+++ b/libs/libndpi/patches/0006-Backported-ndpi_protocol2id.patch
@@ -1,0 +1,83 @@
+From 6dcf1f3fbab782804339db5a3fe8cd0c88c07795 Mon Sep 17 00:00:00 2001
+From: lucaderi <deri@ntop.org>
+Date: Thu, 4 Oct 2018 21:36:46 +0200
+Subject: [PATCH 6/9] Backported ndpi_protocol2id
+
+---
+ src/include/ndpi_api.h | 17 +++++++++++++++--
+ src/lib/ndpi_main.c    | 17 +++++++++++++++++
+ 2 files changed, 32 insertions(+), 2 deletions(-)
+
+diff --git a/src/include/ndpi_api.h b/src/include/ndpi_api.h
+index 56c5436..ccbad73 100644
+--- a/src/include/ndpi_api.h
++++ b/src/include/ndpi_api.h
+@@ -274,7 +274,7 @@ extern "C" {
+    */
+   u_int16_t ndpi_get_flow_masterprotocol(struct ndpi_detection_module_struct *ndpi_struct,
+ 					 struct ndpi_flow_struct *flow);
+-  
++
+   /**
+    * API call that is called internally by ndpi_detection_process_packet or by apps
+    * that want to avoid calling ndpi_detection_process_packet as they have already
+@@ -432,6 +432,19 @@ extern "C" {
+   char* ndpi_protocol2name(struct ndpi_detection_module_struct *ndpi_mod,
+ 			   ndpi_protocol proto, char *buf, u_int buf_len);
+ 
++  /**
++   * Same as ndpi_protocol2name() with the difference that the numeric protocol
++   * name is returned
++   *
++   * @par     ndpi_mod      = the detection module
++   * @par     proto         = the struct ndpi_protocol contain the protocols name
++   * @par     buf           = the buffer to write the name of the protocols
++   * @par     buf_len       = the length of the buffer
++   * @return  the buffer contains the master_protocol and protocol name
++   *
++   */
++  char* ndpi_protocol2id(struct ndpi_detection_module_struct *ndpi_mod,
++                         ndpi_protocol proto, char *buf, u_int buf_len);
+   /**
+    * Write the protocol name in the buffer -buf- as master_protocol.protocol (number)
+    *
+@@ -746,7 +759,7 @@ extern "C" {
+   u_int ndpi_get_ndpi_num_custom_protocols(struct ndpi_detection_module_struct *ndpi_mod);
+   u_int ndpi_get_ndpi_detection_module_size();
+   void ndpi_set_log_level(struct ndpi_detection_module_struct *ndpi_mod, u_int l);
+-  
++
+   /**
+    * Add a string to match to an automata
+    *
+diff --git a/src/lib/ndpi_main.c b/src/lib/ndpi_main.c
+index 33ccbb1..e1cf577 100644
+--- a/src/lib/ndpi_main.c
++++ b/src/lib/ndpi_main.c
+@@ -5319,6 +5319,23 @@ ndpi_protocol ndpi_guess_undetected_protocol(struct ndpi_detection_module_struct
+ 
+ /* ****************************************************** */
+ 
++char* ndpi_protocol2id(struct ndpi_detection_module_struct *ndpi_mod,
++		       ndpi_protocol proto, char *buf, u_int buf_len) {
++  if((proto.master_protocol != NDPI_PROTOCOL_UNKNOWN)
++     && (proto.master_protocol != proto.app_protocol)) {
++    if(proto.app_protocol != NDPI_PROTOCOL_UNKNOWN)
++      snprintf(buf, buf_len, "%u.%u",
++               proto.master_protocol, proto.app_protocol);
++    else
++      snprintf(buf, buf_len, "%u", proto.master_protocol);
++  } else
++    snprintf(buf, buf_len, "%u", proto.app_protocol);
++
++  return(buf);
++}
++
++/* ****************************************************** */
++
+ char* ndpi_protocol2name(struct ndpi_detection_module_struct *ndpi_mod,
+ 			 ndpi_protocol proto, char *buf, u_int buf_len) {
+   if((proto.master_protocol != NDPI_PROTOCOL_UNKNOWN)
+-- 
+2.19.1
+

--- a/libs/libndpi/patches/0007-Symlink-the-shared-library-to-pwd.patch
+++ b/libs/libndpi/patches/0007-Symlink-the-shared-library-to-pwd.patch
@@ -1,0 +1,41 @@
+From a1f6cbb6c9a212b5b3b6605254ae35bead5c43df Mon Sep 17 00:00:00 2001
+From: Hank Leininger <hlein@korelogic.com>
+Date: Mon, 8 Oct 2018 18:17:30 -0600
+Subject: [PATCH 7/9] Symlink the shared library to pwd.
+
+DESTDIR is used, for instance, by distros to facilitate installing
+to a temp path for testing / package-building.
+
+In general nDPI supports DESTDIR (yay!), but using an absolute path
+for the target of the library link has two problems:
+
+1) If DESTDIR is set to /some/tmp/path, we end up with a link that
+points to /some/tmp/path/usr/lib/libndpi-x.y.z, which is definitely
+not what is intended - once the package is installed, the link is
+broken.
+
+2) Absolute links are problematic for distributions; pointing to
+/usr/lib/libndpi-x.y.z during package build-and-test would point to
+either a nonexistent file, or an old and possibly wrong one.
+
+Both of these are avoided if we just link to the target with no path
+at all.
+---
+ src/lib/Makefile.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/lib/Makefile.in b/src/lib/Makefile.in
+index cbbc54b..dc1e34b 100644
+--- a/src/lib/Makefile.in
++++ b/src/lib/Makefile.in
+@@ -49,6 +49,6 @@ clean:
+ install: $(NDPI_LIBS)
+ 	mkdir -p $(DESTDIR)$(libdir)
+ 	cp $(NDPI_LIBS) $(DESTDIR)$(libdir)/
+-	ln -Fs $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED) $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED_BASE)
++	ln -Fs $(NDPI_LIB_SHARED) $(DESTDIR)$(libdir)/$(NDPI_LIB_SHARED_BASE)
+ 	mkdir -p $(DESTDIR)$(includedir)
+ 	cp ../include/*.h $(DESTDIR)$(includedir)
+-- 
+2.19.1
+

--- a/libs/libndpi/patches/0008-Use-a-more-standard-path-for-pkg-config-files.patch
+++ b/libs/libndpi/patches/0008-Use-a-more-standard-path-for-pkg-config-files.patch
@@ -1,0 +1,29 @@
+From cfd97bbbca6afddb1bcedb407cb21127d7cb5d53 Mon Sep 17 00:00:00 2001
+From: Hank Leininger <hlein@korelogic.com>
+Date: Mon, 8 Oct 2018 19:08:51 -0600
+Subject: [PATCH 8/9] Use a more standard path for pkg-config files.
+
+The Linuxes I've checked all seem to use /usr/{,local/}lib*/pkgconfig,
+not /usr/libdata/.  I think FreeBSD does use /usr/libdata/ but also
+supports /usr/lib*/pkgconfig, although I have not tested this change
+on a FreeBSD system.
+---
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 37f0849..4090817 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,7 +1,7 @@
+ ACLOCAL_AMFLAGS = -I m4
+ SUBDIRS = src/lib example tests
+ 
+-pkgconfigdir = $(prefix)/libdata/pkgconfig
++pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = libndpi.pc
+ 
+ EXTRA_DIST = autogen.sh
+-- 
+2.19.1
+

--- a/libs/libndpi/patches/0009-Correct-the-include-file-path-in-I-CFLAGS-argument.patch
+++ b/libs/libndpi/patches/0009-Correct-the-include-file-path-in-I-CFLAGS-argument.patch
@@ -1,0 +1,28 @@
+From b4b7a810697145b718a9a3b6d8a39e700613a640 Mon Sep 17 00:00:00 2001
+From: Hank Leininger <hlein@korelogic.com>
+Date: Mon, 8 Oct 2018 21:22:41 -0600
+Subject: [PATCH 9/9] Correct the include file path in -I CFLAGS argument.
+
+src/lib/Makefile.in install headers into ${prefix}/include/ndpi,
+but the shipped libndpi.pc.in specifies a different path.  Therefore
+anything trying to build using $(pkg-config --cflags libndpi) will
+fail to find the nDPI headers.
+
+This patch simply makes libndpi.pc.in agree with src/lib/Makefile.in.
+---
+ libndpi.pc.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libndpi.pc.in b/libndpi.pc.in
+index 291429c..5e1cde7 100644
+--- a/libndpi.pc.in
++++ b/libndpi.pc.in
+@@ -7,4 +7,4 @@ Name: libndpi
+ Description: deep packet inspection library
+ Version: @VERSION@
+ Libs: -L${libdir} -lndpi
+-Cflags: -I${includedir}/libndpi-@VERSION@
++Cflags: -I${includedir}/ndpi
+-- 
+2.19.1
+


### PR DESCRIPTION
I just tested it and it seems to work.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @hbl0307106015
Compile tested: mvebu