### PR TITLE
yara: Fix compile without deprecated OpenSSL APIs

### DIFF
--- a/utils/yara/Makefile
+++ b/utils/yara/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yara
 PKG_VERSION:=3.8.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/utils/yara/patches/010-libyara-Switch-to-OpenSSL-s-THREADID-API.patch
+++ b/utils/yara/patches/010-libyara-Switch-to-OpenSSL-s-THREADID-API.patch
@@ -1,0 +1,47 @@
+From cd73c968e896b8ba364510abdcd3dcc63d017110 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Thu, 8 Nov 2018 14:57:49 -0800
+Subject: [PATCH] libyara: Switch to OpenSSL's THREADID API
+
+The non THREADID API was deprecated back in OpenSSL 1.0.0
+---
+ libyara/libyara.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libyara/libyara.c b/libyara/libyara.c
+index f05d1f9..6f20488 100644
+--- a/libyara/libyara.c
++++ b/libyara/libyara.c
+@@ -87,9 +87,9 @@ char yr_altercase[256];
+ static YR_MUTEX *openssl_locks;
+ 
+ 
+-static unsigned long _thread_id(void)
++static void _thread_id(CRYPTO_THREADID *id)
+ {
+-  return (unsigned long) yr_current_thread_id();
++  CRYPTO_THREADID_set_numeric(id, (unsigned long) yr_current_thread_id());
+ }
+ 
+ 
+@@ -155,7 +155,7 @@ YR_API int yr_initialize(void)
+   for (i = 0; i < CRYPTO_num_locks(); i++)
+     yr_mutex_create(&openssl_locks[i]);
+ 
+-  CRYPTO_set_id_callback(_thread_id);
++  CRYPTO_THREADID_set_callback(_thread_id);
+   CRYPTO_set_locking_callback(_locking_function);
+ 
+   #elif defined(HAVE_WINCRYPT_H)
+@@ -226,7 +226,7 @@ YR_API int yr_finalize(void)
+     yr_mutex_destroy(&openssl_locks[i]);
+ 
+   OPENSSL_free(openssl_locks);
+-  CRYPTO_set_id_callback(NULL);
++  CRYPTO_THREADID_set_callback(NULL);
+   CRYPTO_set_locking_callback(NULL);
+ 
+   #elif defined(HAVE_WINCRYPT_H)
+-- 
+2.19.1
+

--- a/utils/yara/patches/020-openssl-deprecated.patch
+++ b/utils/yara/patches/020-openssl-deprecated.patch
@@ -1,0 +1,24 @@
+--- a/libyara/modules/pe.c
++++ b/libyara/modules/pe.c
+@@ -42,6 +42,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <openssl/x509.h>
+ #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ #define X509_get_signature_nid(o) OBJ_obj2nid((o)->sig_alg->algorithm)
++#define X509_getm_notBefore X509_get_notBefore
++#define X509_getm_notAfter X509_get_notAfter
+ #endif
+ #endif
+ 
+@@ -1326,10 +1328,10 @@ void pe_parse_certificates(
+         }
+       }
+ 
+-      date_time = ASN1_get_time_t(X509_get_notBefore(cert));
++      date_time = ASN1_get_time_t(X509_getm_notBefore(cert));
+       set_integer(date_time, pe->object, "signatures[%i].not_before", counter);
+ 
+-      date_time = ASN1_get_time_t(X509_get_notAfter(cert));
++      date_time = ASN1_get_time_t(X509_getm_notAfter(cert));
+       set_integer(date_time, pe->object, "signatures[%i].not_after", counter);
+ 
+       counter++;


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ratkaj 
Compile tested: ar71xx