### PR TITLE
msmtp: Fix typo

### DIFF
--- a/mail/msmtp/Makefile
+++ b/mail/msmtp/Makefile
@@ -74,7 +74,7 @@ endef
 define Package/msmtp-mta
 $(call Package/msmtp/Default)
   TITLE+= (as MTA)
-  DEPENDS+=@(PACKAGE_msmtp||PACAKGE_msmtp-nossl)
+  DEPENDS+=@(PACKAGE_msmtp||PACKAGE_msmtp-nossl)
 endef
 
 define Package/msmtp-mta/description


### PR DESCRIPTION
Fix typo in msmtp Makefile PACAKGE -> PACKAGE

Signed-off-by: Ycarus <ycarus@zugaina.org>

Maintainer: unmaintained
Compile tested: x86_64 / master
Run tested: same