### PR TITLE
ffmpeg: Resolve hard/float builds with work-around dependencies

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=3.2.12
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
@@ -278,7 +278,7 @@ endef
 
 
 define Package/ffserver
-$(call Package/ffserver/Default)
+$(call Package/ffmpeg/Default)
  SECTION:=multimedia
  CATEGORY:=Multimedia
  TITLE+= streaming server
@@ -343,9 +343,9 @@ define Package/libffmpeg-full
 $(call Package/libffmpeg/Default)
  TITLE+= (full)
  DEPENDS+= +alsa-lib +PACKAGE_libopus:libopus \
-    $(if $$(CONFIG_SOFT_FLOAT),\
-	+PACKAGE_shine:shine,\
-	+PACKAGE_lame-lib:lame-lib +PACKAGE_libx264:libx264 +PACKAGE_fdk-aac:fdk-aac)
+    +SOFT_FLOAT:shine \
+    +!SOFT_FLOAT:lame-lib \
+    +!SOFT_FLOAT:libx264
  VARIANT:=full
 endef
 


### PR DESCRIPTION
Maintainer: @thess, @antonlacon 
Compile tested: ar71xx, mvebu, x86-64 (Trunk / 18.06)
Run tested: N/A

Description:

Hard float includes: libx264, mp3lame
Soft float includes: shine (mp3 encoder)

fdk-aac will not be available in libffmpeg-full due to incompatible license with libx264.
Custom builds can override licensing restrictions but results may not be re-distributable.

Signed-off-by: Ted Hess <thess@kitschensync.net>

