### PR TITLE
[18.06] ffmpeg: work around hard/soft float configs for libffmpeg-full

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=3.2.12
-PKG_RELEASE:=1
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
@@ -277,7 +277,7 @@ endef
 
 
 define Package/ffserver
-$(call Package/ffserver/Default)
+$(call Package/ffmpeg/Default)
  SECTION:=multimedia
  CATEGORY:=Multimedia
  TITLE+= streaming server
@@ -341,13 +341,10 @@ endef
 define Package/libffmpeg-full
 $(call Package/libffmpeg/Default)
  TITLE+= (full)
- DEPENDS+= +alsa-lib +PACKAGE_libopus:libopus
- ifeq ($(CONFIG_SOFT_FLOAT),y)
-	DEPENDS+= +PACKAGE_shine:shine
- else
-	DEPENDS+= +PACKAGE_lame-lib:lame-lib +PACKAGE_libx264:libx264 +PACKAGE_fdk-aac:fdk-aac
-
- endif
+ DEPENDS+= +alsa-lib +PACKAGE_libopus:libopus \
+    +SOFT_FLOAT:shine \
+    +!SOFT_FLOAT:lame-lib \
+    +PACKAGE_libx264:libx264
  VARIANT:=full
 endef
 
@@ -490,15 +487,15 @@ ifeq ($(BUILD_VARIANT),full)
 		FFMPEG_CONFIGURE+= --enable-small
 	endif
 	FFMPEG_CONFIGURE+= $(if $(CONFIG_PACKAGE_lame-lib),--enable-libmp3lame)
-	# x264 support and fdk-aac support can't coexist and be distributed.
-	# Prioritize x264 over fdk-aac in default builds (maintain status-quo).
-	ifeq ($(CONFIG_PACKAGE_libx264),y)
-		FFMPEG_CONFIGURE+= \
-			--enable-gpl \
-			--enable-libx264
-	else
-		FFMPEG_CONFIGURE+= $(if $(CONFIG_PACKAGE_fdk-aac),--enable-libfdk-aac)
-	endif
+  endif
+  # x264 support and fdk-aac support can't coexist and be distributed.
+  # Prioritize x264 over fdk-aac in default builds (maintain status-quo).
+  ifneq ($(CONFIG_PACKAGE_libx264),)
+	FFMPEG_CONFIGURE+= \
+		--enable-gpl \
+		--enable-libx264
+  else
+	FFMPEG_CONFIGURE+= $(if $(CONFIG_PACKAGE_fdk-aac),--enable-libfdk-aac)
   endif
 endif
 
@@ -570,7 +567,7 @@ ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libshine),y)
 	--enable-libshine --enable-encoder=libshine
 endif
 
-ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libx264),y)
+ifneq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libx264),)
   FFMPEG_CONFIGURE+= \
 	--enable-libx264 --enable-encoder=libx264
 endif
@@ -655,7 +652,7 @@ define Build/InstallDev/full
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/lib{avcodec,avdevice,avfilter,avformat,avresample,avutil,swresample,swscale} $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avdevice,avfilter,avformat,avresample,avutil,swresample,swscale}.{a,so*} $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/lib{avcodec,avdevice,avfilter,avformat,avresample,avutil,swresample,swscale}.pc $(1)/usr/lib/pkgconfig/
-ifeq ($(CONFIG_PACKAGE_libx264),y)
+ifneq ($(CONFIG_PACKAGE_libx264),)
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libpostproc $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpostproc.{a,so*} $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpostproc.pc $(1)/usr/lib/pkgconfig/
@@ -721,7 +718,7 @@ endef
 define Package/libffmpeg-full/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avdevice,avfilter,avformat,avresample,avutil,swresample,swscale}.so.* $(1)/usr/lib/
-ifeq ($(CONFIG_PACKAGE_libx264),y)
+ifneq ($(CONFIG_PACKAGE_libx264),)
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpostproc.so.* $(1)/usr/lib/
 endif
 endef


### PR DESCRIPTION
Maintainer: me 
Compile tested: yes

Description:
Hard float includes: mp3lame
Soft float includes: shine (mp3 encoder)

libx264 is included when selected iff BUILD_PATENTED is true.

fdk-aac will not be available in libffmpeg-full due to incompatible license with libx264.
Custom builds can override licensing restrictions but results may not be re-distributable.

Signed-off-by: Ted Hess <thess@kitschensync.net>

