### PR TITLE
libcap: move utilities to a separate package

### DIFF
--- a/libs/libcap/Makefile
+++ b/libs/libcap/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libcap
 PKG_VERSION:=2.27
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/libs/security/linux-privs/libcap2
@@ -24,29 +24,41 @@ PKG_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/kernel.mk
 
-define Package/libcap
+define Package/libcap/Default
   TITLE:=Linux capabilities library
   SECTION:=libs
   CATEGORY:=Libraries
   URL:=https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/
 endef
 
-define Package/libcap/config
-  if PACKAGE_libcap
+define Package/libcap/description/Default
+  Linux capabilities
+endef
 
-  config PACKAGE_libcap-bin
-    bool "install libcap executables"
-    help
-      Install capsh, getcap, getpcaps, setcap into the target image.
-    default n
+define Package/libcap
+  $(call Package/libcap/Default)
+  TITLE += library
+endef
 
+define Package/libcap-bin
+  $(call Package/libcap/Default)
+  TITLE += binaries
+  DEPENDS += libcap
+endef
+
+define Package/libcap-bin/description
+  $(call Package/libcap/description/Default)
+  .
+  This package contains the libcap utilities.
+endef
+
+define Package/libcap-bin/config
+  if PACKAGE_libcap-bin
   config PACKAGE_libcap-bin-capsh-shell
     string "capsh shell"
-    depends on PACKAGE_libcap-bin
     help
       Set the capsh shell.
     default "/bin/sh"
-
   endif
 endef
 
@@ -81,13 +93,15 @@ endef
 define Package/libcap/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/lib/libcap.so* $(1)/usr/lib/
-ifneq ($(CONFIG_PACKAGE_libcap-bin),)
+endef
+
+define Package/libcap-bin/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/sbin/capsh     $(1)/usr/sbin/
 	$(CP) $(PKG_INSTALL_DIR)/sbin/getcap    $(1)/usr/sbin/
 	$(CP) $(PKG_INSTALL_DIR)/sbin/getpcaps  $(1)/usr/sbin/
 	$(CP) $(PKG_INSTALL_DIR)/sbin/setcap    $(1)/usr/sbin/
-endif
 endef
 
 $(eval $(call BuildPackage,libcap))
+$(eval $(call BuildPackage,libcap-bin))


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: @p-wassi
Compile tested: x86_64
Run tested: x86_64

Description:
This splits the utilities into a sub-package to allow the build system to build them without increasing the size of the library package. Without this change, a user needs to manually build the libcap package with the utilities enabled in order to make use of programs such as setcap.