### PR TITLE
libssh2: Fix compilation with deprecated APIs disabled

### DIFF
--- a/libs/libssh2/Makefile
+++ b/libs/libssh2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libssh2
 PKG_VERSION:=1.8.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.libssh2.org/download

--- a/libs/libssh2/patches/02-openssl-deprecated.patch
+++ b/libs/libssh2/patches/02-openssl-deprecated.patch
@@ -1,0 +1,69 @@
+diff --git a/src/openssl.c b/src/openssl.c
+index 4f63ef9..411f9f6 100644
+--- a/src/openssl.c
++++ b/src/openssl.c
+@@ -1062,6 +1062,7 @@ _libssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
+                               "Unable to extract public key from private key "
+                               "file: Unable to open private key file");
+     }
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     if (!EVP_get_cipherbyname("des")) {
+         /* If this cipher isn't loaded it's a pretty good indication that none
+          * are.  I have *NO DOUBT* that there's a better way to deal with this
+@@ -1070,6 +1071,7 @@ _libssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
+          */
+         OpenSSL_add_all_ciphers();
+     }
++#endif
+     BIO_reset(bp);
+     pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void*)passphrase);
+     BIO_free(bp);
+@@ -1138,6 +1140,7 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
+     if (!bp) {
+         return -1;
+     }
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     if (!EVP_get_cipherbyname("des")) {
+         /* If this cipher isn't loaded it's a pretty good indication that none
+          * are.  I have *NO DOUBT* that there's a better way to deal with this
+@@ -1146,6 +1149,7 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
+          */
+         OpenSSL_add_all_ciphers();
+     }
++#endif
+     BIO_reset(bp);
+     pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void*)passphrase);
+     BIO_free(bp);
+diff --git a/src/openssl.h b/src/openssl.h
+index 3ca71fa..7a89793 100644
+--- a/src/openssl.h
++++ b/src/openssl.h
+@@ -40,7 +40,9 @@
+ #include <openssl/opensslconf.h>
+ #include <openssl/sha.h>
+ #include <openssl/rsa.h>
++#ifndef OPENSSL_NO_ENGINE
+ #include <openssl/engine.h>
++#endif
+ #ifndef OPENSSL_NO_DSA
+ #include <openssl/dsa.h>
+ #endif
+@@ -226,10 +228,18 @@ int _libssh2_md5_init(libssh2_md5_ctx *ctx);
+ #define libssh2_hmac_cleanup(ctx) HMAC_cleanup(ctx)
+ #endif
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#ifndef OPENSSL_NO_ENGINE
+ #define libssh2_crypto_init() \
+   OpenSSL_add_all_algorithms(); \
+   ENGINE_load_builtin_engines(); \
+   ENGINE_register_all_complete()
++#else
++#define libssh2_crypto_init() OpenSSL_add_all_algorithms()
++#endif
++#else
++#define libssh2_crypto_init()
++#endif
+ 
+ #define libssh2_crypto_exit()
+ 


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jslachta 
Compile tested: ar71xx

This is fixed upstream but is a bit convoluted to backport.