### PR TITLE
lighttpd: Fix Compilation with OpenSSL 1.1.x

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.49
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x

--- a/net/lighttpd/patches/010-openssl-deprecated.patch
+++ b/net/lighttpd/patches/010-openssl-deprecated.patch
@@ -1,0 +1,14 @@
+diff --git a/src/rand.c b/src/rand.c
+index 10cd025..63fbb0d 100644
+--- a/src/rand.c
++++ b/src/rand.c
+@@ -226,7 +226,9 @@ int li_rand_bytes (unsigned char *buf, int num)
+ void li_rand_cleanup (void)
+ {
+   #ifdef USE_OPENSSL_CRYPTO
++  #if OPENSSL_VERSION_NUMBER < 0x10100000L
+     RAND_cleanup();
++  #endif
+   #endif
+     safe_memclear(xsubi, sizeof(xsubi));
+ }


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
Compile tested: ar71xx

Upstream: https://github.com/lighttpd/lighttpd1.4/pull/93