### PR TITLE
nft-qos: use prerouting chain rather than input for upload rate limit

### DIFF
--- a/net/nft-qos/files/lib/static.sh
+++ b/net/nft-qos/files/lib/static.sh
@@ -43,7 +43,7 @@ qosdef_flush_static() {
 # static limit rate init
 qosdef_init_static() {
 	local unit_dl unit_ul rate_dl rate_ul
-	local limit_enable limit_type hook_ul="input" hook_dl="postrouting"
+	local limit_enable limit_type hook_ul="prerouting" hook_dl="postrouting"
 
 	uci_validate_section nft-qos default default \
 		'limit_enable:bool:0' \
@@ -63,7 +63,7 @@ qosdef_init_static() {
 
 	[ -z "$NFT_QOS_HAS_BRIDGE" ] && {
 		hook_ul="postrouting"
-		hook_dl="input"
+		hook_dl="prerouting"
 	}
 
 	qosdef_appendx "table $NFT_QOS_INET_FAMILY nft-qos-static {\n"


### PR DESCRIPTION
Using the input chain can only limit the upload rate in local network.
Since to do the limit rate on both native and remote, we have to
replace the input hook with prerouting.

Signed-off-by: Rosy Song <rosysong@rosinson.com>

Maintainer: me
Compile tested: ar71xx, wr818, master
Run tested: ar71xx, wr818, master

