### PR TITLE
alsa-utils: bump to 1.1.7

### DIFF
--- a/sound/alsa-utils/Makefile
+++ b/sound/alsa-utils/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alsa-utils
-PKG_VERSION:=1.1.6
-PKG_RELEASE:=2
+PKG_VERSION:=1.1.7
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=ftp://ftp.alsa-project.org/pub/utils/ \
 		http://distfiles.gentoo.org/distfiles/
-PKG_HASH:=155caecc40b2220f686f34ba3655a53e3bdbc0586adb1056733949feaaf7d36e
+PKG_HASH:=1db27fb54ab7fdeb54b00d68b8a174808ffea198cfbd67e3c959482194e1540a
 PKG_INSTALL:=1
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 


### PR DESCRIPTION
Signed-off-by: Eduardo Abinader <eduardoabinader@gmail.com>

Maintainer: @thess 
Compile tested: ar71xx
Run tested: ar71xx

Description:
