### PR TITLE
adblock: fix adguard source

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=3.5.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/adblock.conf
+++ b/net/adblock/files/adblock.conf
@@ -22,7 +22,7 @@ config source 'adaway'
 
 config source 'adguard'
 	option adb_src 'https://filters.adtidy.org/windows/filters/15.txt'
-	option adb_src_rset 'BEGIN{FS=\"[/|^|\r]\"}/^\|\|([[:alnum:]_-]+\.)+[[:alpha:]]+([\/\^\r]|$)/{print tolower(\$3)}'
+	option adb_src_rset 'BEGIN{FS=\"[/|^|\r]\"}/^\|\|([[:alnum:]_-]+\.)+[[:alpha:]]+[\/\^\r]+$/{print tolower(\$3)}'
 	option adb_src_desc 'combined adguard dns filter list, frequent updates, approx. 17.000 entries'
 	option enabled '0'
 


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: already tested by different adblock users and confirmed to work

Description:
* fix regex for adguard blocklist source

Signed-off-by: Dirk Brenken <dev@brenken.org>

