### PR TITLE
ffmpeg: Add choices to libffmpeg-custom to select and build CLI programs

### DIFF
--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -125,6 +125,12 @@ config FFMPEG_CUSTOM_AUDIO_DEC_SUPPORT
 	select FFMPEG_CUSTOM_PROTOCOL_tcp
 	select FFMPEG_CUSTOM_PROTOCOL_udp
 
+config FFMPEG_CUSTOM_PROGRAMS
+	bool "Include ffmpeg command-line utilities"
+	select PACKAGE_ffmpeg-custom
+	select PACKAGE_ffserver-custom
+	select PACKAGE_ffprobe-custom
+
 comment "External Libraries"
 
 config FFMPEG_CUSTOM_SELECT_libfdk-aac

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=3.2.12
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
@@ -254,12 +254,22 @@ $(call Package/ffmpeg/Default)
  VARIANT:=full
 endef
 
+define Package/ffmpeg-custom
+$(call Package/ffmpeg/Default)
+ SECTION:=multimedia
+ CATEGORY:=Multimedia
+ TITLE+= program (custom)
+ DEPENDS+= @!ALL libffmpeg-custom
+ VARIANT:=custom
+endef
+
 define Package/ffmpeg/description
 $(call Package/ffmpeg/Default/description)
  .
  This package contains the FFmpeg command line tool.
 endef
 
+Package/ffmpeg-custom/description = $(Package/ffmpeg/description)
 
 define Package/ffprobe
 $(call Package/ffmpeg/Default)
@@ -270,12 +280,22 @@ $(call Package/ffmpeg/Default)
  VARIANT:=full
 endef
 
+define Package/ffprobe-custom
+$(call Package/ffmpeg/Default)
+ SECTION:=multimedia
+ CATEGORY:=Multimedia
+ TITLE+= CLI media identifier (custom)
+ DEPENDS+= @!ALL libffmpeg-custom
+ VARIANT:=custom
+endef
+
 define Package/ffprobe/description
 $(call Package/ffmpeg/Default/description)
  .
  This package contains the FFprobe command line tool.
 endef
 
+Package/ffprobe-custom/description = $(Package/ffprobe/description)
 
 define Package/ffserver
 $(call Package/ffmpeg/Default)
@@ -286,11 +306,22 @@ $(call Package/ffmpeg/Default)
  VARIANT:=full
 endef
 
+define Package/ffserver-custom
+$(call Package/ffmpeg/Default)
+ SECTION:=multimedia
+ CATEGORY:=Multimedia
+ TITLE+= streaming server (custom)
+ DEPENDS+= @!ALL libffmpeg-custom
+ VARIANT:=custom
+endef
+
 define Package/ffserver/description
 $(call Package/ffmpeg/Default/description)
  .
  This package contains the FFmpeg streaming server.
 endef
+
+Package/ffserver-custom/description = $(Package/ffserver/description)
 
 define Package/libffmpeg/Default
 $(call Package/ffmpeg/Default)
@@ -527,11 +558,14 @@ ifeq ($(BUILD_VARIANT),custom)
 	FFMPEG_CONFIGURE+= --enable-nonfree
   endif
 
-  FFMPEG_CONFIGURE+= \
+  ifneq ($(CONFIG_FFMPEG_CUSTOM_PROGRAMS),y)
+      FFMPEG_CONFIGURE+= \
 	--disable-programs \
 	--disable-avfilter \
-	--disable-postproc \
-	--disable-swresample \
+	--disable-swresample
+  endif
+
+  FFMPEG_CONFIGURE+= \
 	--disable-swscale \
 	--disable-everything \
 	$(call FFMPEG_ENABLE,encoder,$(FFMPEG_CUSTOM_ENCODERS),CONFIG_FFMPEG_CUSTOM_ENCODER) \
@@ -568,9 +602,11 @@ ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libshine),y)
 	--enable-libshine --enable-encoder=libshine
 endif
 
-ifneq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libx264),)
+ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libx264),y)
   FFMPEG_CONFIGURE+= \
 	--enable-libx264 --enable-encoder=libx264
+else
+  FFMPEG_CONFIGURE+= --disable-postproc
 endif
 
 endif
@@ -641,8 +677,16 @@ define Build/InstallDev/custom
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/lib{avcodec,avdevice,avformat,avutil} $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avdevice,avformat,avutil}.{a,so*} $(1)/usr/lib/
+ifeq ($(CONFIG_FFMPEG_CUSTOM_PROGRAMS),y)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avfilter,swresample}.{a,so*} $(1)/usr/lib/
+endif
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/lib{avcodec,avdevice,avformat,avutil}.pc $(1)/usr/lib/pkgconfig/
+ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libx264),y)
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libpostproc $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpostproc.{a,so*} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpostproc.pc $(1)/usr/lib/pkgconfig/
+endif
 endef
 
 # Only ffmpeg with libx264 is GPL (yes libpostproc); all other builds are lgpl (no libpostproc)
@@ -700,6 +744,8 @@ define Package/ffmpeg/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ffmpeg $(1)/usr/bin/
 endef
 
+Package/ffmpeg-custom/install = $(Package/ffmpeg/install)
+
 define Package/ffprobe/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ffprobe $(1)/usr/bin/
@@ -713,6 +759,12 @@ endef
 define Package/libffmpeg-custom/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avdevice,avformat,avutil}.so.* $(1)/usr/lib/
+ifeq ($(CONFIG_FFMPEG_CUSTOM_SELECT_libx264),y)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpostproc.so.* $(1)/usr/lib/
+endif
+ifeq ($(CONFIG_FFMPEG_CUSTOM_PROGRAMS),y)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avfilter,swresample}.so.* $(1)/usr/lib/
+endif
 endef
 
 # Only ffmpeg with libx264 is GPL (yes libpostproc); all other builds are lgpl (no libpostproc)
@@ -734,6 +786,9 @@ Package/libffmpeg-audio-dec/install = $(Package/libffmpeg-custom/install)
 $(eval $(call BuildPackage,ffmpeg))
 $(eval $(call BuildPackage,ffprobe))
 $(eval $(call BuildPackage,ffserver))
+$(eval $(call BuildPackage,ffmpeg-custom))
+$(eval $(call BuildPackage,ffprobe-custom))
+$(eval $(call BuildPackage,ffserver-custom))
 $(eval $(call BuildPackage,libffmpeg-audio-dec))
 $(eval $(call BuildPackage,libffmpeg-full))
 $(eval $(call BuildPackage,libffmpeg-mini))


### PR DESCRIPTION
Maintainer: @thess, @antonlacon 
Compile tested: ar71xx / trunk
Run tested: wndr4300

Description:

Allowing custom ffmpeg CLI programs to be built and linked to libffmpeg-custom has been requested a number of times. Selecting `"Include ffmpeg command-line utilities"` in the custom menu will result in CLI packages with a `-custom` suffix to be built.

Signed-off-by: Ted Hess <thess@kitschensync.net>

