### PR TITLE
pytz: Update to 2018.7 and add host build

### DIFF
--- a/lang/python/pytz/Makefile
+++ b/lang/python/pytz/Makefile
@@ -8,14 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pytz
-PKG_VERSION:=2018.6
+PKG_VERSION:=2018.7
 PKG_RELEASE:=1
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pytz
-PKG_HASH:=642253af8eae734d1509fc6ac9c1aee5e5b69d76392660889979b9870610a46b
+PKG_HASH:=31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca
 
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 
@@ -37,12 +38,11 @@ define Build/Compile
 	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
 endef
 
-define Package/pytz/InstallDev
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
+define Host/Compile
+	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
 endef
+
+Host/Install:=
 
 define Package/pytz/install
 	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
@@ -51,4 +51,5 @@ define Package/pytz/install
 	    $(1)$(PYTHON_PKG_DIR)
 endef
 
+$(eval $(call HostBuild))
 $(eval $(call BuildPackage,pytz))


### PR DESCRIPTION
Django 1.11 and above needs pytz to run properly. This was causing issues
with seahub, whose Makefile uses django-admin to compile locales.

Also removed InstallDev. It tried to accomplish the same thing but ended
up installing to the same directories anyways.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @kissg1988 
Compile tested: ar71xx

@cotequeiroz Removal of InstallDev OK?

@commodo Is there a better way to do this? I just copied python-six' solution.