### PR TITLE
seafile-seahub: Update to 6.3.4

### DIFF
--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -8,16 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-seahub
-PKG_VERSION:=6.3.0
-PKG_RELEASE=$(PKG_SOURCE_VERSION)-1
+PKG_VERSION:=6.3.4
+PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/haiwen/seahub.git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=d1ab146a936a6ea1e1581bf3f194e86742f0d3cd
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
-PKG_MIRROR_HASH:=21c2ed3886d0c87853f9720704b14c0a0dce8215e7346af775e306f80b29fa0d
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/haiwen/seahub/tar.gz/v$(PKG_VERSION)-server?
+PKG_HASH:=53a9efdb6791fd3a2a191e89cb0f133632056046ec08adbb2ad72088e6161430
+PKG_BUILD_DIR:=$(BUILD_DIR)/seahub-$(PKG_VERSION)-server
+
+PKG_BUILD_DEPENDS:=pytz/host
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python-package.mk
@@ -27,7 +27,7 @@ define Package/seafile-seahub
     CATEGORY:=Network
     TITLE:=Seafile server - seahub component
     MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
-    URL:=http://seafile.com/
+    URL:=https://seafile.com/
     DEPENDS:=+simplejson +python +pillow +chardet +django +django-appconf \
 		+django-compressor +django-constance +django-formtools +django-jsonfield \
 		+django-picklefield +django-postoffice +django-restframework \

--- a/net/seafile-seahub/patches/010-default-config.patch
+++ b/net/seafile-seahub/patches/010-default-config.patch
@@ -1,6 +1,6 @@
 --- a/seahub/settings.py
 +++ b/seahub/settings.py
-@@ -47,7 +47,7 @@ SITE_ID = 1
+@@ -46,7 +46,7 @@ SITE_ID = 1
  
  # If you set this to False, Django will make some optimizations so as not
  # to load the internationalization machinery.
@@ -9,7 +9,7 @@
  
  # If you set this to False, Django will not format dates, numbers and
  # calendars according to the current locale.
-@@ -310,7 +310,7 @@ SHARE_LINK_EMAIL_LANGUAGE = ''
+@@ -339,7 +339,7 @@ SHARE_LINK_EMAIL_LANGUAGE = ''
  ENABLE_UPLOAD_LINK_VIRUS_CHECK = False
  
  # mininum length for user's password
@@ -18,7 +18,7 @@
  
  # LEVEL based on four types of input:
  # num, upper letter, lower letter, other symbols
-@@ -319,7 +319,7 @@ USER_PASSWORD_STRENGTH_LEVEL = 3
+@@ -348,7 +348,7 @@ USER_PASSWORD_STRENGTH_LEVEL = 3
  
  # default False, only check USER_PASSWORD_MIN_LENGTH
  # when True, check password strength level, STRONG(or above) is allowed

--- a/net/seafile-seahub/patches/020-Makefile-fixes.patch
+++ b/net/seafile-seahub/patches/020-Makefile-fixes.patch
@@ -7,7 +7,7 @@
  PROJECT=seahub
  
  develop: setup-git
-@@ -9,7 +12,7 @@ dist: locale uglify statici18n collectst
+@@ -9,7 +12,7 @@ dist: locale uglify statici18n collectstatic
  
  locale:
  	@echo "--> Compile locales"
@@ -26,8 +26,8 @@
  collectstatic:
  	@echo "--> Collect django static files to media/assets"
  	rm -rf media/assets 2> /dev/null
--	python manage.py collectstatic --noinput
-+	$(call HostPython,,manage.py collectstatic --noinput)
+-	python manage.py collectstatic --noinput -i admin -i termsandconditions -i app -i sysadmin-app -i build.js
++	$(call HostPython,,manage.py collectstatic --noinput -i admin -i termsandconditions -i app -i sysadmin-app -i build.js)
  
  compressstatic:
  	@echo "--> Compress static files(css) to media/CACHE"


### PR DESCRIPTION
Switch to codeload for simplicity and easier package bumping.

Added dependency on pytz on build time as django-admin requires it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @kissg1988 
Compile tested: ar71xx