### PR TITLE
socat: Fix compile with deprecated APIs disabled

### DIFF
--- a/net/socat/Makefile
+++ b/net/socat/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=socat
 PKG_VERSION:=1.7.3.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.dest-unreach.org/socat/download

--- a/net/socat/patches/200-openssl-deprecated.patch
+++ b/net/socat/patches/200-openssl-deprecated.patch
@@ -1,0 +1,13 @@
+diff --git a/xio-openssl.c b/xio-openssl.c
+index e931983..84ec100 100644
+--- a/xio-openssl.c
++++ b/xio-openssl.c
+@@ -8,6 +8,8 @@
+ #if WITH_OPENSSL	/* make this address configure dependend */
+ #include <openssl/conf.h>
+ #include <openssl/x509v3.h>
++#include <openssl/dh.h>
++#include <openssl/bn.h>
+ 
+ #include "xioopen.h"
+ 


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ar71xx
