### PR TITLE
mc: disable vfs support by default

### DIFF
--- a/utils/mc/Config.in
+++ b/utils/mc/Config.in
@@ -49,11 +49,11 @@ config MC_CHARSET
 
 config MC_VFS
 	bool "Enable virtual filesystem support"
-	default y
+	default n
 	help
            This option enables the Virtual File System switch code to get
            transparent access to the following file systems:
            cpio, tar, fish, sfs, ftp, sftp, extfs.
-           Enabled by default.
+           Disabled by default.
 
 endmenu

--- a/utils/mc/Makefile
+++ b/utils/mc/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mc
 PKG_VERSION:=4.8.21
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 PKG_LICENSE:=GPL-3.0+
 


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: -

Description:
* disable vfs support by default as long as the underlying
  librpc issus has not been fixed - should fix buildbot compile
  (#7180 #7349)

Signed-off-by: Dirk Brenken <dev@brenken.org>
