### PR TITLE
sysrepo: update to 0.7.6

### DIFF
--- a/net/sysrepo/Makefile
+++ b/net/sysrepo/Makefile
@@ -11,12 +11,12 @@ PKG_LICENSE:=ASL-2.0
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 
 PKG_NAME:=sysrepo
-PKG_VERSION:=0.7.5
+PKG_VERSION:=0.7.6
 PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sysrepo/sysrepo/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=3ef20e1e005fd22f13d1996231ccfc72241f3f76c5700397ad59dda0f9b29f72
+PKG_HASH:=44389df29618f0056192a1b7659a64c9d3b3f88fd87cea395b3a9cd8d224032b
 
 CMAKE_INSTALL:=1
 


### PR DESCRIPTION
Signed-off-by: Mislav Novakovic <mislav.novakovic@sartura.hr>

Maintainer: me
Compile tested: Broadcom 27xx RPi2 32-bit
Run tested: Broadcom 27xx RPi3 32-bit

Description:
Update to the latest sysrepo [release](https://github.com/sysrepo/sysrepo/releases/tag/v0.7.6).