### PR TITLE
clamsmtp: Really fix compilation

### DIFF
--- a/mail/clamsmtp/Makefile
+++ b/mail/clamsmtp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clamsmtp
 PKG_VERSION:=1.10
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=http://thewalter.net/stef/software/clamsmtp/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/mail/clamsmtp/patches/010-fix-build.patch
+++ b/mail/clamsmtp/patches/010-fix-build.patch
@@ -1,12 +1,19 @@
-diff --git a/common/sock_any.h b/common/sock_any.h
-index 77c3841..1e30974 100644
---- a/common/sock_any.h
-+++ b/common/sock_any.h
-@@ -39,7 +39,6 @@
- #ifndef __SOCK_ANY_H__
- #define __SOCK_ANY_H__
+--- a/configure.in
++++ b/configure.in
+@@ -78,16 +78,6 @@ AC_CHECK_HEADERS([limits.h err.h paths.h],,)
+ AC_CHECK_HEADERS([unistd.h stdio.h stddef.h fcntl.h stdlib.h assert.h errno.h stdarg.h string.h netdb.h], ,
+     [echo "ERROR: Required C header missing"; exit 1])
  
--#include <sys/socket.h>
- #include <sys/un.h>
- #include <netinet/in.h>
- 
+-# Check for linux type transparent proxy support
+-AC_CHECK_HEADERS([linux/netfilter_ipv4.h],
+-   AC_DEFINE(LINUX_TRANSPARENT_PROXY, 1, [Whether the system supports a linux type transparent proxy]),
+-   , 
+-   [[
+-   #ifdef HAVE_LIMITS_H
+-   #include <limits.h>
+-   #endif
+-   ]] )
+-
+ # Checks for typedefs, structures, and compiler characteristics.
+ AC_C_CONST
+ AC_TYPE_SIZE_T


### PR DESCRIPTION
It seems Linux headers are broken/incompatible with musl for some reason.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: ar71xx