### PR TITLE
lcd4linux: Update to 1204

### DIFF
--- a/utils/lcd4linux/Makefile
+++ b/utils/lcd4linux/Makefile
@@ -8,9 +8,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lcd4linux
-PKG_REV:=1203
+PKG_REV:=1204
 PKG_VERSION:=r$(PKG_REV)
-PKG_RELEASE:=3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://ssl.bulix.org/svn/lcd4linux/trunk/
@@ -205,6 +205,8 @@ endef
 
 CONFIGURE_ARGS+= \
 	--disable-rpath \
+
+TARGET_CFLAGS += -std=gnu89
 
 EXTRA_LDFLAGS+= -Wl,-rpath-link,$(STAGING_DIR)/usr/lib
 


### PR DESCRIPTION
Very minor bugfix.

Also adjusted standard to gnu89 to fix compilation issues (lot of missing
prototypes).

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jmccrohan 
Compile tested: ar71xx