### PR TITLE
CircleCI: Fix URL references to openwrt.org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       - image: champtar/openwrtpackagesci@sha256:d46da22bc628f4b369147eebfa1b032e4066510da42a073b22acbf6b6595b77f
     environment:
-      - SDK_BASE_URL: "https://downloads.lede-project.org/snapshots/targets/ar71xx/generic"
+      - SDK_BASE_URL: "https://downloads.openwrt.org/snapshots/targets/ar71xx/generic"
       - SDK_FILE: "openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64.tar.xz"
       - BRANCH: "master"
     steps:
@@ -27,7 +27,7 @@ jobs:
           command: |
              tar Jxf ~/sdk/$SDK_FILE --strip=1
              cat > feeds.conf <<EOF
-             src-git base https://github.com/lede-project/source.git
+             src-git base https://github.com/openwrt/openwrt.git
              src-link packages $HOME/openwrt_packages
              src-git luci https://github.com/openwrt/luci.git
              EOF


### PR DESCRIPTION
CCI builds failing due to 301 redirection returns on lede-project.org. Update script to use `openwrt.org` and openwrt github repo. 

Signed-off-by: Ted Hess <thess@kitschensync.net>