### PR TITLE
python-psycopg2: Update to 2.7.6.1

### DIFF
--- a/lang/python/python-psycopg2/Makefile
+++ b/lang/python/python-psycopg2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-psycopg2
-PKG_VERSION:=2.7.5
+PKG_VERSION:=2.7.6.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=psycopg2-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/psycopg2
-PKG_HASH:=eccf962d41ca46e6326b97c8fe0a6687b58dfc1a5f6540ed071ff1474cea749e
+PKG_HASH:=27959abe64ca1fc6d8cd11a71a1f421d8287831a3262bd4cacd43bbf43cc3c82
 PKG_BUILD_DIR:=$(BUILD_DIR)/psycopg2-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Dmitry Trefilov <the-alien@live.ru>


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dtrefilo-Quest 
Compile tested: ar71xx