### PR TITLE
python3-bottle: Update to 0.12.13

### DIFF
--- a/lang/python/python3-bottle/Makefile
+++ b/lang/python/python3-bottle/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-bottle
-PKG_VERSION:=0.12.12
+PKG_VERSION:=0.12.13
 PKG_RELEASE:=1
 
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>
 
 PKG_SOURCE:=bottle-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/f7/dd/8ceaa148eeed5371a83fa1fb5a54b01dfc95000799c649924ece23f9f0e1/
-PKG_HASH:=3d4b6b0e22f67b421c273105b30d9a21fd147eaf0c1576172378ee034fbf5313
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/b/bottle
+PKG_HASH:=39b751aee0b167be8dffb63ca81b735bbf1dd0905b3bc42761efedee8f123355
 PKG_BUILD_DIR:=$(BUILD_DIR)/bottle-$(PKG_VERSION)
 PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
@@ -28,7 +28,7 @@ define Package/python3-bottle
 	CATEGORY:=Languages
 	SUBMENU:=Python
 	TITLE:=Bottle is a fast, simple and lightweight WSGI micro web-framework for Python
-	URL:=http://bottlepy.org
+	URL:=https://bottlepy.org
 	DEPENDS:=+python3
 endef
 


### PR DESCRIPTION
Switched to a proper URL.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lperkov inactive?
Compile tested: ar71xx