### PR TITLE
net/mosquitto: support more mosquitto.conf options in UCI

### DIFF
--- a/net/mosquitto/Makefile
+++ b/net/mosquitto/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mosquitto
 PKG_VERSION:=1.5.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_CPE_ID:=cpe:/a:eclipse:mosquitto

--- a/net/mosquitto/files/etc/init.d/mosquitto
+++ b/net/mosquitto/files/etc/init.d/mosquitto
@@ -50,6 +50,17 @@ append_optional_bool() {
     fi
 }
 
+filter_and_set_auth_opts() {
+	local name
+	local value
+	case $2 in
+		CONFIG_$1_auth_opt_*)
+			name=${2##CONFIG_$1_}
+			name=${name%%=*}
+			value=${2##CONFIG_$1_$name=}
+			echo "$name $value" >> $TCONF
+	esac
+}
 
 convert_mosq_general() {
 	local cfg="$1"
@@ -91,6 +102,7 @@ convert_mosq_general() {
 	append_if "$1" sys_interval
 	append_if "$1" upgrade_outgoing_qos
 	append_if "$1" user
+	append_optional_bool "$1" per_listener_settings
 }
 
 convert_persistence() {
@@ -144,6 +156,8 @@ add_listener() {
     append_optional_bool "$1" use_identity_as_username
     append_optional_bool "$1" use_subject_as_username
     append_if "$1" psk_hint
+    append_if "$1" auth_plugin
+    eval "$(set | sed 's/^/filter_and_set_auth_opts $1 /')"
 }
 
 add_topic() {


### PR DESCRIPTION
In particular support for the per_listener_settings, auth_plugin, and
auth_opt_* options is added.
The latter requires some shell trickery because we don't know a priori
the exact UCI option names, only that they begin with auth_opt_.
The solution is to look at the variables defined by the UCI parsing code,
match against the pattern CONFIG_<sectionname>_auth_opt_* and parse out
the option name and value.

Signed-off-by: Dirk Feytons <dirk.feytons@gmail.com>