### PR TITLE
python: fix build with OpenSSL 1.1.0

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -12,7 +12,7 @@ include ../python-version.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)

--- a/lang/python/python/patches/011-fix-ssl-build-use-have-npn.patch
+++ b/lang/python/python/patches/011-fix-ssl-build-use-have-npn.patch
@@ -1,0 +1,22 @@
+diff --git a/Modules/_ssl.c b/Modules/_ssl.c
+index a96c419260..c80437eef7 100644
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -1586,7 +1586,7 @@ static PyObject *PySSL_version(PySSLSocket *self)
+     return PyUnicode_FromString(version);
+ }
+ 
+-#if defined(OPENSSL_NPN_NEGOTIATED) && !defined(OPENSSL_NO_NEXTPROTONEG)
++#if HAVE_NPN
+ static PyObject *PySSL_selected_npn_protocol(PySSLSocket *self) {
+     const unsigned char *out;
+     unsigned int outlen;
+@@ -2114,7 +2114,7 @@ static PyMethodDef PySSLMethods[] = {
+      PySSL_peercert_doc},
+     {"cipher", (PyCFunction)PySSL_cipher, METH_NOARGS},
+     {"version", (PyCFunction)PySSL_version, METH_NOARGS},
+-#ifdef OPENSSL_NPN_NEGOTIATED
++#if HAVE_NPN
+     {"selected_npn_protocol", (PyCFunction)PySSL_selected_npn_protocol, METH_NOARGS},
+ #endif
+ #if HAVE_ALPN


### PR DESCRIPTION
Maintainer: me
Compile tested: 
* target: Marvel Kirkwood
* https://github.com/openwrt/openwrt/commit/e95e9fcbb2bce0ce2337bf767e2bfa0943c49164 
* https://github.com/cotequeiroz/openwrt/commits/cote_openssl-1.1.1 commit-head https://github.com/cotequeiroz/openwrt/commit/b33be0b09118b5328c2ee667131615f5237cb71f 

Run tested: N/A

----------------------------------------------------------------------------------------------------------

Addresses issue from here:
  https://github.com/openwrt/packages/issues/7367#issuecomment-437685598

The SSL module in Python doesn't handle properly all the combinations of
NPN between all OpenSSL & LibreSSL versions.
This patch fixes this.
Also pushed a report & proposal upstream to Python:
  https://bugs.python.org/issue35264

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>