### PR TITLE
banip: update 0.0.6

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.0.5
+PKG_VERSION:=0.0.6
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
@@ -17,7 +17,7 @@ define Package/banip
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=Ban incoming and/or outgoing ip adresses via ipsets
-	DEPENDS:=+jshn +jsonfilter +ipset +iptables
+	DEPENDS:=+jshn +jsonfilter +ip +ipset +iptables
 	PKGARCH:=all
 endef
 

--- a/net/banip/files/banip.conf
+++ b/net/banip/files/banip.conf
@@ -170,7 +170,7 @@ config source 'firehol1'
 	option ban_src 'https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level1.netset'
 	option ban_src_desc 'Firehol Level 1 compilation. Contains bogons, spamhaus drop and edrop, dshield and malware lists (IPv4)'
 	option ban_src_rset '/^(([0-9]{1,3}\.){3}[0-9]{1,3}(\/[0-9]{1,2})?)([[:space:]]|$)/{print \"add firehol1 \"\$1}'
-	option ban_src_settype 'net_inet'
+	option ban_src_settype 'net'
 	option ban_src_ruletype 'src'
 	option ban_src_on '0'
 

--- a/net/banip/files/banip.hotplug
+++ b/net/banip/files/banip.hotplug
@@ -9,4 +9,4 @@ then
 	exit 0
 fi
 
-/etc/init.d/banip start
+/etc/init.d/banip refresh

--- a/net/banip/files/banip.init
+++ b/net/banip/files/banip.init
@@ -4,8 +4,9 @@
 START=30
 USE_PROCD=1
 
-EXTRA_COMMANDS="status"
-EXTRA_HELP="	status	Print runtime information"
+EXTRA_COMMANDS="refresh status"
+EXTRA_HELP="	refresh	Refresh ipsets only (no new download!)
+	status	Print runtime information"
 
 ban_init="/etc/init.d/banip"
 ban_script="/usr/bin/banip.sh"
@@ -40,6 +41,11 @@ stop_service()
 {
 	rc_procd "${ban_script}" stop
 	rc_procd start_service
+}
+
+refresh()
+{
+	rc_procd start_service "refresh"
 }
 
 status()


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL-AR750S, OpenWrt SNAPSHOT r8464-bf52c968e8

Description:
* support multiple WAN interfaces in iptables rules,
  set 'ban_iface' option accordingly (as space separated list)
  or use the LuCI frontend
* add new "refresh" mode while triggered by fw changes (no download)
* add required ip dependency
* fix wrong 'settype' definition for firehol1 in config

Signed-off-by: Dirk Brenken <dev@brenken.org>