### PR TITLE
darkstat: procd init script and enabling additional parameters

### DIFF
--- a/net/darkstat/Makefile
+++ b/net/darkstat/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=darkstat
 PKG_VERSION:=3.0.719
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Jean-Michel Lacroix <lacroix@lepine-lacroix.info>
 

--- a/net/darkstat/files/darkstat.config
+++ b/net/darkstat/files/darkstat.config
@@ -1,13 +1,12 @@
 config darkstat
 	option interface        'lan'
 	option syslog           false
-	option verbose          true
-	option no_daemon        false
+	option verbose          false
 	option no_promisc       false
 	option no_dns           false
 	option no_macs          false
 	option no_lastseen      false
-#	option httpaddr         '0.0.0.0'
+	option httpaddr         '0.0.0.0'
 #	option httpport         '667'
 #	option network_filter   'not (src net 192.168.1 and dst net 192.168.1)'
 #	option network_netmask  '192.168.1.0/255.255.255.0'
@@ -17,4 +16,6 @@ config darkstat
 #	option ports_max        '60'
 #	option ports_keep       '30'
 #	option highest_port     '65534'
-
+#	option export_file      'darkstat_export.log'
+#	option import_file      'darkstat_export.log'
+#	option daylog_file      'darkstat_daylog.log'

--- a/net/darkstat/files/darkstat.init
+++ b/net/darkstat/files/darkstat.init
@@ -1,97 +1,100 @@
-#!/bin/sh /etc/rc.common
-# Copyright (C) 2007-2016 OpenWrt.org
+#!/bin/sh /etc/rc.common 
+# Copyright (C) 2018 Jean-Michel Lacroix
+
+USE_PROCD=1
 
 START=60
+
 APP=darkstat
 RUN_D=/var/empty
-PID_F=$RUN_D/darkstat.pid
+PID_F=$RUN_D/$APP.pid
+CONFIGNAME=darkstat
+USER=nobody
+GROUP=nogroup
 
-SYSLOG=""
-VERBOSE=""
-NODAEMON=""
-NOPROMISC=""
-NODNS=""
-NOMACS=""
-NOLASTSEEN=""
-LOCAL=""
-paramstr=""
+CONFIGSTR=""
+FILTERSTR=""
 
 export_bool () {
 	local option="$1"
 	local section="$2"
 	local _keystr="$3"
 	local _loctmp
-	paramstr=""
 	config_get_bool _loctmp "$section" "$option"
 	if [ -n "$_loctmp" ]; then
 		if [ 1 -eq "$_loctmp" ]; then
-			paramstr="${_keystr} "
+			CONFIGSTRING="$CONFIGSTRING${_keystr} "
 		fi
 	fi
 }
 
-start() {
+set_config_string(){
 	mkdir -p $RUN_D
+	chown $USER:$GROUP $RUN_D
 	. /lib/functions/network.sh
-	config_load darkstat
-	config_foreach start_darkstat darkstat
+	config_load $CONFIGNAME
+	config_foreach build_config_string darkstat
 }
 
-start_darkstat() {
-	local cfg="$1"
+build_config_string() {
+	local cfg="$1"                                 
 	config_get interface $cfg interface
+	network_get_device ifname "$interface"       
+	CONFIGSTR=" -i $ifname "
 	export_bool syslog $cfg "--syslog"
-	SYSLOG=$paramstr
 	export_bool verbose $cfg "--verbose"
-	VERBOSE=$paramstr
-	export_bool no_daemon $cfg "--no-daemon"
-	NODAEMON=$paramstr
+	# We need the --no-daemon parameter as with PROCD the process has to run in the background
+	CONFIGSTR="$CONFIGSTR--no-daemon "
 	export_bool no_promisc $cfg "--no-promisc"
-	NOPROMISC=$paramstr
 	export_bool no_dns $cfg "--no-dns"
-	NODNS=$paramstr
 	export_bool no_macs $cfg "--no-macs"
-	NOMACS=$paramstr
 	export_bool no_lastseen $cfg "--no-lastseen"
-	NOLASTSEEN=$paramstr
 	config_get httpaddr $cfg httpaddr
+	CONFIGSTR="$CONFIGSTR${httpaddr:+-b "$httpaddr"} "
 	config_get httpport $cfg httpport
-	config_get network_filter $cfg network_filter
+	CONFIGSTR="$CONFIGSTR${httpport:+-p "$httpport"} "
 	config_get network_netmask $cfg network_netmask
+	CONFIGSTR="$CONFIGSTR${network_netmask:+-l "$network_netmask"} "
 	export_bool local_only $cfg "--local-only"
-	LOCAL=$paramstr
 	config_get hosts_max $cfg hosts_max
+	CONFIGSTR="$CONFIGSTR${hosts_max:+--hosts-max "$hosts_max"} "
 	config_get hosts_keep $cfg hosts_keep
-	config_get ports_max $cfg ports_max
-	config_get ports_keep $cfg ports_keep
-	config_get highest_port	$cfg highest_port
-
-
-	network_get_device ifname "$interface" && {
-		/usr/sbin/$APP -i "$ifname" \
-			${SYSLOG} \
-			${VERBOSE} \
-			${NODAEMON} \
-			${NOPROMISC} \
-			${NODNS} \
-			${NOMACS} \
-			${NOLASTSEEN} \
-			${httpaddr:+-b "$httpaddr"} \
-			${httpport:+-p "$httpport"} \
-			${network_filter:+-f "$network_filter"} \
-			${network_netmask:+-l "$network_netmask"} \
-			${LOCAL} \
-			${hosts_max:+--hosts-max "$hosts_max"} \
-			${hosts_keep:+--hosts-keep "$hosts_keep"} \
-			${ports_max:+--ports-max "$ports_max"} \
-			${ports_keep:+--ports-keep "$ports_keep"} \
-			${highest_port:+--highest-port "$highest_port"} \
-			--chroot $RUN_D \
-			--pidfile $PID_F
-	}
+	CONFIGSTR="$CONFIGSTR${ports_keep:+--ports-keep "$ports_keep"} "
+	config_get highest_port $cfg highest_port
+	CONFIGSTR="$CONFIGSTR${highest_port:+--highest-port "$highest_port"} "
+	config_get export_file $cfg export_file
+	CONFIGSTR="$CONFIGSTR${export_file:+--export "$export_file"} "
+	config_get import_file $cfg import_file
+	CONFIGSTR="$CONFIGSTR${import_file:+--import "$import_file"} "
+	config_get daylog_file $cfg daylog_file
+	CONFIGSTR="$CONFIGSTR${daylog_file:+--daylog "$daylog_file"} "
+	CONFIGSTR="$CONFIGSTR--chroot $RUN_D --pidfile $PID_F"
+	# Now that we have the configuration string (CONFIGSTR), let us get the filter (FILTERSTR)
+	config_get network_filter $cfg network_filter
+	FILTERSTR="${network_filter:+$network_filter}"
 }
 
-stop() {
-	start-stop-daemon -K -n $APP -p $PID_F -s TERM
+service_triggers() {
+	procd_add_reload_trigger $CONFIGNAME
+}
+
+start_service() {
+	set_config_string
+	procd_open_instance
+	procd_set_param command /usr/sbin/$APP
+	procd_append_param command $CONFIGSTR
+	# Let us check if we have a filter string and apply it if we do
+	if [ "$FILTERSTR" != "" ]; then
+		procd_append_param command "-f" "$FILTERSTR"
+	fi
+	procd_close_instance
+}
+
+stop_service() {
 	rm -f $PID_F
+}
+
+reload_service() {
+	stop
+	start
 }


### PR DESCRIPTION
Maintainer: Jean-Michel Lacroix / @padre-lacroix
Compile tested: not applicable as no change to the binary
Run tested: OpenWrt SNAPSHOT r8207-99e1a12, LEDE Reboot 17.01.4, OpenWrt 18.06

Description:
This is to change the init script to a procd init script
This also enable some additional parameters in the binary that
were present but not enabled:
The export file (option export_file)
The import file (option import_file)
The daylog (option daylog_file)
These are disabled by default.  Also, the option to run as a daemon
is removed, as not compatible with procd.

There is no change in the binary.

Signed-off-by: Jean-Michel Lacroix <lacroix@lepine-lacroix.info>