### PR TITLE
quassel-irssi: Update to newer version to fix compilation

### DIFF
--- a/net/quassel-irssi/Makefile
+++ b/net/quassel-irssi/Makefile
@@ -11,8 +11,8 @@ PKG_NAME:=quassel-irssi
 
 # quassel-irssi upstream doesn't release versions (at least, at the moment),
 # so use commit date for PKG_VERSION and embed commit hash into PKG_RELEASE.
-PKG_VERSION:=2016-09-11
-PKG_SOURCE_VERSION:=cbd9bd7f4ac44260d9fcafb809fdf153cde193e5
+PKG_VERSION:=2017-01-17
+PKG_SOURCE_VERSION:=19e810405789a35b92026b56ea49d01a3f544b07
 PKG_RELEASE:=1.$(PKG_SOURCE_VERSION)
 
 PKG_LICENSE:=GPL-3.0+
@@ -20,22 +20,23 @@ PKG_LICENSE:=GPL-3.0+
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/phhusson/quassel-irssi
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.bz2
-PKG_MIRROR_HASH:=fd13b2497e3b0d0779e0ce3d8b27c37e207d2a73b5b6dc0cb2799bd4472fc5e1
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
+PKG_MIRROR_HASH:=5ad9416ce4d522dc3bb1b487063339f559928dcefa8aef4ce88ab93d5f4d5352
 
 PKG_MAINTAINER:=Ben Rosser <rosser.bjr@gmail.com>
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
 MAKE_PATH := core
-MAKE_VARS += SYSTEM_QUASSELC=1 IRSSI_CFLAGS="$(TARGET_CFLAGS) $(EXTRA_CFLAGS) $(TARGET_CPPFLAGS) $(EXTRA_CPPFLAGS)" IRSSI_INCLUDE=$(STAGING_DIR)/usr/include/irssi
+MAKE_VARS += IRSSI_CFLAGS="$(TARGET_CFLAGS) $(EXTRA_CFLAGS) $(TARGET_CPPFLAGS) $(EXTRA_CPPFLAGS)" IRSSI_INCLUDE=$(STAGING_DIR)/usr/include/irssi
 
 define Package/quassel-irssi
     SECTION:=net
     CATEGORY:=Network
-    DEPENDS:=+irssi +quasselc
+    DEPENDS:=+irssi
     SUBMENU:=Instant Messaging
     URL:=https://github.com/phhusson/quassel-irssi
     TITLE:=An irssi plugin to connect to quassel core

--- a/net/quassel-irssi/patches/001-respect-cflags.patch
+++ b/net/quassel-irssi/patches/001-respect-cflags.patch
@@ -1,5 +1,3 @@
-diff --git a/core/Makefile b/core/Makefile
-index 6133087..389855c 100644
 --- a/core/Makefile
 +++ b/core/Makefile
 @@ -3,7 +3,7 @@ DESTDIR ?=
@@ -11,12 +9,12 @@ index 6133087..389855c 100644
  IRSSI_LIB?=$(DESTDIR)/$(LIBDIR)/irssi
  IRSSI_CFLAGS+=-I$(IRSSI_INCLUDE)/src/
  IRSSI_CFLAGS+=-I$(IRSSI_INCLUDE)/src/core/
-@@ -26,7 +26,7 @@ else
+@@ -27,7 +27,7 @@ else
      LDFLAGS += -lquasselc
  endif
  
 -CFLAGS=-std=gnu11 -Wall -Wextra -Werror -g -O2 $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations
 +CFLAGS+=-std=gnu11 -Wall -Wextra -Werror -g $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations
  
- TARGET=libquassel_core.so
- 
+ CFLAGS += $(SSL_CFLAGS)
+ LDFLAGS+= $(SSL_LDLAGS)

--- a/net/quassel-irssi/patches/002-use-cc-var.patch
+++ b/net/quassel-irssi/patches/002-use-cc-var.patch
@@ -1,8 +1,6 @@
-diff --git a/core/Makefile b/core/Makefile
-index 389855c..2f81417 100644
 --- a/core/Makefile
 +++ b/core/Makefile
-@@ -44,7 +44,7 @@ irssi/network-openssl.o: CFLAGS:=$(IRSSI_CFLAGS)
+@@ -48,7 +48,7 @@ irssi/network-openssl.o: CFLAGS:=$(IRSSI_CFLAGS)
  quasselc-connector.o: CFLAGS:=$(CFLAGS)
  
  $(TARGET): $(OBJECTS)

--- a/net/quassel-irssi/patches/003-use-pkgconfig-ldflags-quasselc.patch
+++ b/net/quassel-irssi/patches/003-use-pkgconfig-ldflags-quasselc.patch
@@ -1,8 +1,6 @@
-diff --git a/core/Makefile b/core/Makefile
-index 2f81417..aa62201 100644
 --- a/core/Makefile
 +++ b/core/Makefile
-@@ -23,7 +23,7 @@ ifndef SYSTEM_QUASSELC
+@@ -24,7 +24,7 @@ ifndef SYSTEM_QUASSELC
      QUASSELC_FLAGS:=-Ilib
  else
      QUASSELC_FLAGS:=$(shell pkg-config --cflags quasselc)
@@ -10,4 +8,4 @@ index 2f81417..aa62201 100644
 +    LDFLAGS += $(shell pkg-config --libs quasselc)
  endif
  
- CFLAGS+=-std=gnu11 -Wall -Wextra -Werror -g -O2 $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations
+ CFLAGS+=-std=gnu11 -Wall -Wextra -Werror -g $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations

--- a/net/quassel-irssi/patches/010-Use-sys-socket.h-rather-than-asm-socket.h.patch
+++ b/net/quassel-irssi/patches/010-Use-sys-socket.h-rather-than-asm-socket.h.patch
@@ -1,0 +1,26 @@
+From 7d4caa6a60af0e584dc5c3dc44437117744f6f84 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jelmer=20Vernoo=C4=B3?= <jelmer@jelmer.uk>
+Date: Sat, 14 Jan 2017 20:55:00 +0000
+Subject: [PATCH] Use sys/socket.h rather than asm/socket.h.
+
+The latter is not available on some platforms.
+---
+ core/quasselc-connector.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/core/quasselc-connector.c b/core/quasselc-connector.c
+index 08a3718..77e8d7a 100644
+--- a/core/quasselc-connector.c
++++ b/core/quasselc-connector.c
+@@ -16,7 +16,7 @@
+  */
+ 
+ #define _GNU_SOURCE
+-#include <asm/socket.h>
++#include <sys/socket.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <sys/wait.h>
+-- 
+2.19.1
+

--- a/net/quassel-irssi/patches/020-Fix-nullpointer-dereference-when-leaving-an-unconnec.patch
+++ b/net/quassel-irssi/patches/020-Fix-nullpointer-dereference-when-leaving-an-unconnec.patch
@@ -1,0 +1,28 @@
+From 525ff7ec3bafe9ccbf5802559e2664a25cf925e1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bastian=20M=C3=BCller?= <db1bm@gmx.de>
+Date: Sat, 12 Aug 2017 10:24:49 +0200
+Subject: [PATCH] Fix nullpointer dereference when leaving an unconnected
+ window
+
+---
+ core/quassel-fe-level.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/core/quassel-fe-level.c b/core/quassel-fe-level.c
+index 3d69202..3382ddc 100644
+--- a/core/quassel-fe-level.c
++++ b/core/quassel-fe-level.c
+@@ -62,6 +62,10 @@ static void sig_created(WINDOW_REC *winrec, int automatic) {
+ 		return;
+ 	}
+ 
++	if (!winrec->active_server) {
++		return;
++	}
++
+ 	CHANNEL_REC *_chanrec = channel_find(winrec->active_server, winrec->active->visible_name);
+ 	if(_chanrec->chat_type != Quassel_PROTOCOL)
+ 		return;
+-- 
+2.19.1
+

--- a/net/quassel-irssi/patches/030-Makes-gcc7-happy.patch
+++ b/net/quassel-irssi/patches/030-Makes-gcc7-happy.patch
@@ -1,0 +1,64 @@
+From ab0dc71822b3e769b4be2a990bc6c87347016cfd Mon Sep 17 00:00:00 2001
+From: Pierre-Hugues Husson <phh@archos.com>
+Date: Tue, 12 Sep 2017 17:42:46 +0200
+Subject: [PATCH] Makes gcc7 happy
+
+---
+ core/quasselc-connector.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/core/quasselc-connector.c b/core/quasselc-connector.c
+index 77e8d7a..d28fa5e 100644
+--- a/core/quasselc-connector.c
++++ b/core/quasselc-connector.c
+@@ -145,6 +145,7 @@ void handle_sync(void* irssi_arg, object_t o, function_t f, ...) {
+ 			highlight=0;
+ 			if(!fnc)
+ 				fnc="MarkBufferAsRead";
++		/* Falls through */
+ 		case Displayed:
+ 			if(!fnc)
+ 				fnc="BufferDisplayed";
+@@ -155,6 +156,7 @@ void handle_sync(void* irssi_arg, object_t o, function_t f, ...) {
+ 		case Removed:
+ 			if(!fnc)
+ 				fnc="BufferRemoved";
++		/* Falls through */
+ 		case TempRemoved:
+ 			if(!fnc)
+ 				fnc="BufferTempRemoved";
+@@ -210,6 +212,7 @@ void handle_sync(void* irssi_arg, object_t o, function_t f, ...) {
+ 		case AddUserMode:
+ 			if(!fnc)
+ 				fnc="AddUserMode";
++		/* Falls through */
+ 		case RemoveUserMode:
+ 			if(!fnc)
+ 				fnc="RemoveUserMode";
+@@ -223,6 +226,7 @@ void handle_sync(void* irssi_arg, object_t o, function_t f, ...) {
+ 		case SetNick2:
+ 			if(!fnc)
+ 				fnc="SetNick";
++		/* Falls through */
+ 		case Quit:
+ 			if(!fnc)
+ 				fnc="Quit";
+@@ -233,12 +237,15 @@ void handle_sync(void* irssi_arg, object_t o, function_t f, ...) {
+ 		case SetNick:
+ 			if(!fnc)
+ 				fnc="SetNick";
++		/* Falls through */
+ 		case SetServer:
+ 			if(!fnc)
+ 				fnc="SetServer";
++		/* Falls through */
+ 		case SetRealName:
+ 			if(!fnc)
+ 				fnc="SetRealName";
++		/* Falls through */
+ 		case PartChannel:
+ 			if(!fnc)
+ 				fnc="PartChannel";
+-- 
+2.19.1
+


### PR DESCRIPTION
This is the irssi-abi-8 branch that was not merged back to master but is
necessary for compilation. As it touches a submodule, I can't add a patch
for it. But I can backport all of the master commits.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @TC01 
Compile tested: mvebu
