### PR TITLE
tor: package improvements

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -20,6 +20,8 @@ PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -68,7 +70,7 @@ endef
 
 define Package/tor-resolve/description
 $(call Package/tor/Default/description)
- Resolve a hostname to an IP address via tor 
+ Resolve a hostname to an IP address via tor
 endef
 
 define Package/tor-geoip
@@ -90,25 +92,24 @@ endef
 
 CONFIGURE_ARGS += \
 	--with-libevent-dir="$(STAGING_DIR)/usr" \
-	--with-ssl-dir="$(STAGING_DIR)/usr" \
 	--with-openssl-dir="$(STAGING_DIR)/usr" \
 	--with-zlib-dir="$(STAGING_DIR)/usr" \
 	--disable-asciidoc \
 	--disable-seccomp \
 	--disable-libscrypt \
 	--disable-unittests \
-	--disable-largefile \
 	--disable-lzma \
 	--with-tor-user=tor \
 	--with-tor-group=tor
 
-EXTRA_CFLAGS += -std=gnu99
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
+TARGET_LDFLAGS += -Wl,--gc-sections -flto
 
 ifneq ($(CONFIG_SSP_SUPPORT),y)
 	CONFIGURE_ARGS += \
 		--disable-gcc-hardening
 else
-	EXTRA_CFLAGS += -fPIC
+	EXTRA_CFLAGS += $(FPIC)
 endif
 
 CONFIGURE_VARS += \
@@ -117,7 +118,6 @@ CONFIGURE_VARS += \
 define Package/tor/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tor $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/torify $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/tor.init $(1)/etc/init.d/tor
 	$(INSTALL_DIR) $(1)/etc/tor
@@ -136,8 +136,10 @@ endef
 
 define Package/tor-geoip/install
 	$(INSTALL_DIR) $(1)/usr/share/tor
-	$(CP) $(PKG_INSTALL_DIR)/usr/share/tor/geoip $(1)/usr/share/tor/
-	$(CP) $(PKG_INSTALL_DIR)/usr/share/tor/geoip6 $(1)/usr/share/tor/
+	$(INSTALL_DATA) \
+	  $(PKG_INSTALL_DIR)/usr/share/tor/geoip \
+	  $(PKG_INSTALL_DIR)/usr/share/tor/geoip6 \
+	$(1)/usr/share/tor/
 endef
 
 $(eval $(call BuildPackage,tor))


### PR DESCRIPTION
* remove "torify" script
  - "torify" script is just a wrapper around torsocks,
    but torsocks is not currently present in packages.
* tor-geoip: fix "install" recipe:
  - use $(INSTALL_DATA) instead of $(CP) as a proper way
    of installing files
* tor-geoip: honor CONFIG_IPV6:
  - provide /usr/share/tor/geoip6 only if CONFIG_IPV6 is selected,
    which is default
* drop deprecated configure option:
    "--with-ssl-dir" is considered deprecated and obsolete,
    while "--with-openssl-dir" is already present.
* build in parallel
* build with -ffunction-sections, -fdata-sections,
  --gc-sections and -flto
* remove "--disable-largefile" in CONFIGURE_ARGS
* remove "-std=gnu99" in EXTRA_CFLAGS
* use $(FPIC) in EXTRA_CFLAGS
* remove trailing whitespace

Compile- and run-tested on ar71xx/generic,
TP-Link Archer C7 v2 (world-wide version).

Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>