### PR TITLE
patch: Adjust patches to fix issues created by the CVE fixes

### DIFF
--- a/devel/patch/Makefile
+++ b/devel/patch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=patch
 PKG_VERSION:=2.7.6
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/patch

--- a/devel/patch/patches/010-CVE-2018-6951.patch
+++ b/devel/patch/patches/010-CVE-2018-6951.patch
@@ -1,4 +1,4 @@
-From 9bf998b5fcbcde1dea0e472dc1538abb97e9012e Mon Sep 17 00:00:00 2001
+From f290f48a621867084884bfff87f8093c15195e6a Mon Sep 17 00:00:00 2001
 From: Andreas Gruenbacher <agruen@gnu.org>
 Date: Mon, 12 Feb 2018 16:48:24 +0100
 Subject: [PATCH] Fix segfault with mangled rename patch
@@ -24,6 +24,3 @@ index ff9ed2c..bc6278c 100644
  	      name_is_valid (p_name[! reverse])))
        {
  	say ("Cannot %s file without two valid file names\n", pch_rename () ? "rename" : "copy");
--- 
-2.19.1
-

--- a/devel/patch/patches/011-allow-input-files-to-be-missing.patch
+++ b/devel/patch/patches/011-allow-input-files-to-be-missing.patch
@@ -1,0 +1,30 @@
+From b5a91a01e5d0897facdd0f49d64b76b0f02b43e1 Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruen@gnu.org>
+Date: Fri, 6 Apr 2018 11:34:51 +0200
+Subject: [PATCH] Allow input files to be missing for ed-style patches
+
+* src/pch.c (do_ed_script): Allow input files to be missing so that new
+files will be created as with non-ed-style patches.
+---
+ src/pch.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/src/pch.c b/src/pch.c
+index bc6278c..0c5cc26 100644
+--- a/src/pch.c
++++ b/src/pch.c
+@@ -2394,9 +2394,11 @@ do_ed_script (char const *inname, char const *outname,
+ 
+     if (! dry_run && ! skip_rest_of_patch) {
+ 	int exclusive = *outname_needs_removal ? 0 : O_EXCL;
+-	assert (! inerrno);
+-	*outname_needs_removal = true;
+-	copy_file (inname, outname, 0, exclusive, instat.st_mode, true);
++	if (inerrno != ENOENT)
++	  {
++	    *outname_needs_removal = true;
++	    copy_file (inname, outname, 0, exclusive, instat.st_mode, true);
++	  }
+ 	sprintf (buf, "%s %s%s", editor_program,
+ 		 verbosity == VERBOSE ? "" : "- ",
+ 		 outname);

--- a/devel/patch/patches/020-CVE-2018-1000156.patch
+++ b/devel/patch/patches/020-CVE-2018-1000156.patch
@@ -1,4 +1,4 @@
-From b56779aed483f0036a32a65e62ab7b5e461b07cc Mon Sep 17 00:00:00 2001
+From 123eaff0d5d1aebe128295959435b9ca5909c26d Mon Sep 17 00:00:00 2001
 From: Andreas Gruenbacher <agruen@gnu.org>
 Date: Fri, 6 Apr 2018 12:14:49 +0200
 Subject: [PATCH] Fix arbitrary command execution in ed-style patches
@@ -10,14 +10,14 @@ instead of rejecting them and carrying on.
 * tests/ed-style: New test case.
 * tests/Makefile.am (TESTS): Add test case.
 ---
- src/pch.c         | 89 +++++++++++++++++++++++++++++++++++------------
+ src/pch.c         | 91 ++++++++++++++++++++++++++++++++++-------------
  tests/Makefile.am |  1 +
- tests/ed-style    | 41 ++++++++++++++++++++++
- 3 files changed, 108 insertions(+), 23 deletions(-)
+ tests/ed-style    | 41 +++++++++++++++++++++
+ 3 files changed, 108 insertions(+), 25 deletions(-)
  create mode 100644 tests/ed-style
 
 diff --git a/src/pch.c b/src/pch.c
-index bc6278c..4fd5a05 100644
+index 0c5cc26..4fd5a05 100644
 --- a/src/pch.c
 +++ b/src/pch.c
 @@ -33,6 +33,7 @@
@@ -28,7 +28,7 @@ index bc6278c..4fd5a05 100644
  
  #define INITHUNKMAX 125			/* initial dynamic allocation size */
  
-@@ -2389,22 +2390,28 @@ do_ed_script (char const *inname, char const *outname,
+@@ -2389,24 +2390,28 @@ do_ed_script (char const *inname, char const *outname,
      static char const editor_program[] = EDITOR_PROGRAM;
  
      file_offset beginning_of_this_line;
@@ -57,9 +57,11 @@ index bc6278c..4fd5a05 100644
  
 -    if (! dry_run && ! skip_rest_of_patch) {
 -	int exclusive = *outname_needs_removal ? 0 : O_EXCL;
--	assert (! inerrno);
--	*outname_needs_removal = true;
--	copy_file (inname, outname, 0, exclusive, instat.st_mode, true);
+-	if (inerrno != ENOENT)
+-	  {
+-	    *outname_needs_removal = true;
+-	    copy_file (inname, outname, 0, exclusive, instat.st_mode, true);
+-	  }
 -	sprintf (buf, "%s %s%s", editor_program,
 -		 verbosity == VERBOSE ? "" : "- ",
 -		 outname);
@@ -71,7 +73,7 @@ index bc6278c..4fd5a05 100644
      for (;;) {
  	char ed_command_letter;
  	beginning_of_this_line = file_tell (pfp);
-@@ -2415,14 +2422,14 @@ do_ed_script (char const *inname, char const *outname,
+@@ -2417,14 +2422,14 @@ do_ed_script (char const *inname, char const *outname,
  	}
  	ed_command_letter = get_ed_command_letter (buf);
  	if (ed_command_letter) {
@@ -90,7 +92,7 @@ index bc6278c..4fd5a05 100644
  			    write_fatal ();
  		    if (chars_read == 2  &&  strEQ (buf, ".\n"))
  			break;
-@@ -2435,13 +2442,49 @@ do_ed_script (char const *inname, char const *outname,
+@@ -2437,13 +2442,49 @@ do_ed_script (char const *inname, char const *outname,
  	    break;
  	}
      }
@@ -204,6 +206,3 @@ index 0000000..d8c0689
 +check 'cat foo' <<EOF
 +foo
 +EOF
--- 
-2.19.1
-

--- a/devel/patch/patches/021-invoke-ed-directly-instead-of.patch
+++ b/devel/patch/patches/021-invoke-ed-directly-instead-of.patch
@@ -1,0 +1,35 @@
+From 3fcd042d26d70856e826a42b5f93dc4854d80bf0 Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruen@gnu.org>
+Date: Fri, 6 Apr 2018 19:36:15 +0200
+Subject: [PATCH] Invoke ed directly instead of using the shell
+
+* src/pch.c (do_ed_script): Invoke ed directly instead of using a shell
+command to avoid quoting vulnerabilities.
+---
+ src/pch.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/src/pch.c b/src/pch.c
+index 4fd5a05..16e001a 100644
+--- a/src/pch.c
++++ b/src/pch.c
+@@ -2459,9 +2459,6 @@ do_ed_script (char const *inname, char const *outname,
+ 	    *outname_needs_removal = true;
+ 	    copy_file (inname, outname, 0, exclusive, instat.st_mode, true);
+ 	  }
+-	sprintf (buf, "%s %s%s", editor_program,
+-		 verbosity == VERBOSE ? "" : "- ",
+-		 outname);
+ 	fflush (stdout);
+ 
+ 	pid = fork();
+@@ -2470,7 +2467,8 @@ do_ed_script (char const *inname, char const *outname,
+ 	else if (pid == 0)
+ 	  {
+ 	    dup2 (tmpfd, 0);
+-	    execl ("/bin/sh", "sh", "-c", buf, (char *) 0);
++	    assert (outname[0] != '!' && outname[0] != '-');
++	    execlp (editor_program, editor_program, "-", outname, (char  *) NULL);
+ 	    _exit (2);
+ 	  }
+ 	else

--- a/devel/patch/patches/022-dont-leak-temporary-file-on-failed.patch
+++ b/devel/patch/patches/022-dont-leak-temporary-file-on-failed.patch
@@ -1,0 +1,98 @@
+From 19599883ffb6a450d2884f081f8ecf68edbed7ee Mon Sep 17 00:00:00 2001
+From: Jean Delvare <jdelvare@suse.de>
+Date: Thu, 3 May 2018 14:31:55 +0200
+Subject: [PATCH] Don't leak temporary file on failed ed-style patch
+
+Now that we write ed-style patches to a temporary file before we
+apply them, we need to ensure that the temporary file is removed
+before we leave, even on fatal error.
+
+* src/pch.c (do_ed_script): Use global TMPEDNAME instead of local
+  tmpname. Don't unlink the file directly, instead tag it for removal
+  at exit time.
+* src/patch.c (cleanup): Unlink TMPEDNAME at exit.
+
+This closes bug #53820:
+https://savannah.gnu.org/bugs/index.php?53820
+
+Fixes: 123eaff0d5d1 ("Fix arbitrary command execution in ed-style patches (CVE-2018-1000156)")
+---
+ src/common.h |  2 ++
+ src/patch.c  |  1 +
+ src/pch.c    | 11 +++++------
+ 3 files changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/src/common.h b/src/common.h
+index 904a3f8..53c5e32 100644
+--- a/src/common.h
++++ b/src/common.h
+@@ -94,10 +94,12 @@ XTERN char const *origsuff;
+ XTERN char const * TMPINNAME;
+ XTERN char const * TMPOUTNAME;
+ XTERN char const * TMPPATNAME;
++XTERN char const * TMPEDNAME;
+ 
+ XTERN bool TMPINNAME_needs_removal;
+ XTERN bool TMPOUTNAME_needs_removal;
+ XTERN bool TMPPATNAME_needs_removal;
++XTERN bool TMPEDNAME_needs_removal;
+ 
+ #ifdef DEBUGGING
+ XTERN int debug;
+diff --git a/src/patch.c b/src/patch.c
+index 3fcaec5..9146597 100644
+--- a/src/patch.c
++++ b/src/patch.c
+@@ -2000,5 +2000,6 @@ cleanup (void)
+   remove_if_needed (TMPOUTNAME, &TMPOUTNAME_needs_removal);
+   remove_if_needed (TMPPATNAME, &TMPPATNAME_needs_removal);
+   remove_if_needed (TMPREJNAME, &TMPREJNAME_needs_removal);
++  remove_if_needed (TMPEDNAME, &TMPEDNAME_needs_removal);
+   output_files (NULL);
+ }
+diff --git a/src/pch.c b/src/pch.c
+index index 79a3c99..1bb3153 100644
+--- a/src/pch.c
++++ b/src/pch.c
+@@ -2392,7 +2392,6 @@ do_ed_script (char const *inname, char const *outname,
+     file_offset beginning_of_this_line;
+     size_t chars_read;
+     FILE *tmpfp = 0;
+-    char const *tmpname;
+     int tmpfd;
+     pid_t pid;
+ 
+@@ -2404,12 +2403,13 @@ do_ed_script (char const *inname, char const *outname,
+ 	   invalid commands and treats the next line as a new command, which
+ 	   can lead to arbitrary command execution.  */
+ 
+-	tmpfd = make_tempfile (&tmpname, 'e', NULL, O_RDWR | O_BINARY, 0);
++	tmpfd = make_tempfile (&TMPEDNAME, 'e', NULL, O_RDWR | O_BINARY, 0);
+ 	if (tmpfd == -1)
+-	  pfatal ("Can't create temporary file %s", quotearg (tmpname));
++	  pfatal ("Can't create temporary file %s", quotearg (TMPEDNAME));
++	TMPEDNAME_needs_removal = true;
+ 	tmpfp = fdopen (tmpfd, "w+b");
+ 	if (! tmpfp)
+-	  pfatal ("Can't open stream for file %s", quotearg (tmpname));
++	  pfatal ("Can't open stream for file %s", quotearg (TMPEDNAME));
+       }
+ 
+     for (;;) {
+@@ -2449,7 +2449,7 @@ do_ed_script (char const *inname, char const *outname,
+       write_fatal ();
+ 
+     if (lseek (tmpfd, 0, SEEK_SET) == -1)
+-      pfatal ("Can't rewind to the beginning of file %s", quotearg (tmpname));
++      pfatal ("Can't rewind to the beginning of file %s", quotearg (TMPEDNAME));
+ 
+     if (! dry_run && ! skip_rest_of_patch) {
+ 	int exclusive = *outname_needs_removal ? 0 : O_EXCL;
+@@ -2482,7 +2482,6 @@ do_ed_script (char const *inname, char const *outname,
+     }
+ 
+     fclose (tmpfp);
+-    safe_unlink (tmpname);
+ 
+     if (ofp)
+       {

--- a/devel/patch/patches/023-dont-leak-temporary-file-on-failed.patch
+++ b/devel/patch/patches/023-dont-leak-temporary-file-on-failed.patch
@@ -1,0 +1,74 @@
+From 369dcccdfa6336e5a873d6d63705cfbe04c55727 Mon Sep 17 00:00:00 2001
+From: Jean Delvare <jdelvare@suse.de>
+Date: Mon, 7 May 2018 15:14:45 +0200
+Subject: [PATCH] Don't leak temporary file on failed multi-file ed-style patch
+
+The previous fix worked fine with single-file ed-style patches, but
+would still leak temporary files in the case of multi-file ed-style
+patch. Fix that case as well, and extend the test case to check for
+it.
+
+* src/patch.c (main): Unlink TMPEDNAME if needed before moving to
+  the next file in a patch.
+
+This closes bug #53820:
+https://savannah.gnu.org/bugs/index.php?53820
+
+Fixes: 123eaff0d5d1 ("Fix arbitrary command execution in ed-style patches (CVE-2018-1000156)")
+Fixes: 19599883ffb6 ("Don't leak temporary file on failed ed-style patch")
+---
+ src/patch.c    |  1 +
+ tests/ed-style | 31 +++++++++++++++++++++++++++++++
+ 2 files changed, 32 insertions(+)
+
+diff --git a/src/patch.c b/src/patch.c
+index 9146597..81c7a02 100644
+--- a/src/patch.c
++++ b/src/patch.c
+@@ -236,6 +236,7 @@ main (int argc, char **argv)
+ 	    }
+ 	  remove_if_needed (TMPOUTNAME, &TMPOUTNAME_needs_removal);
+ 	}
++      remove_if_needed (TMPEDNAME, &TMPEDNAME_needs_removal);
+ 
+       if (! skip_rest_of_patch && ! file_type)
+ 	{
+diff --git a/tests/ed-style b/tests/ed-style
+index 6b6ef9d..504e6e5 100644
+--- a/tests/ed-style
++++ b/tests/ed-style
+@@ -39,3 +39,34 @@ EOF
+ check 'cat foo' <<EOF
+ foo
+ EOF
++
++# Test the case where one ed-style patch modifies several files
++
++cat > ed3.diff <<EOF
++--- foo
+++++ foo
++1c
++bar
++.
++--- baz
+++++ baz
++0a
++baz
++.
++EOF
++
++# Apparently we can't create a file with such a patch, while it works fine
++# when the file name is provided on the command line
++cat > baz <<EOF
++EOF
++
++check 'patch -e -i ed3.diff' <<EOF
++EOF
++
++check 'cat foo' <<EOF
++bar
++EOF
++
++check 'cat baz' <<EOF
++baz
++EOF

--- a/devel/patch/patches/030-CVE-2018-6952.patch
+++ b/devel/patch/patches/030-CVE-2018-6952.patch
@@ -1,4 +1,4 @@
-From 71607715f11c9875a5aaaf3240885c45f79138e9 Mon Sep 17 00:00:00 2001
+From 9c986353e420ead6e706262bf204d6e03322c300 Mon Sep 17 00:00:00 2001
 From: Andreas Gruenbacher <agruen@gnu.org>
 Date: Fri, 17 Aug 2018 13:35:40 +0200
 Subject: [PATCH] Fix swapping fake lines in pch_swap
@@ -13,7 +13,7 @@ Fixes: https://savannah.gnu.org/bugs/index.php?53133
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/pch.c b/src/pch.c
-index 4fd5a05..b0dd14d 100644
+index e92bc64..a500ad9 100644
 --- a/src/pch.c
 +++ b/src/pch.c
 @@ -2115,7 +2115,7 @@ pch_swap (void)
@@ -25,6 +25,3 @@ index 4fd5a05..b0dd14d 100644
  	else
  	    n = -i;
  	p_efake += n;
--- 
-2.19.1
-


### PR DESCRIPTION
There were a bunch of memory leaks and other issues caused by the previous
CVE fixes. Backport fixes for those.

This currently matches what Arch Linux is doing.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @RussellSenior
Compile tested: mvebu