### PR TITLE
loudmouth: Fix compilation issue with newer glib

### DIFF
--- a/libs/loudmouth/Makefile
+++ b/libs/loudmouth/Makefile
@@ -9,21 +9,18 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=loudmouth
 PKG_VERSION:=1.5.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/mcabber/loudmouth/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=12972fcffd9bbcc4a3b2b9fbf4b0e549f7b4caf0f11c8d2af2059087ce4e8792
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
-
 PKG_LICENSE:=LGPLv2.1
 PKG_LICENSE_FILES:=COPYING
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MIRROR_HASH:=46a3f1a13a6ec5ff5377c028ce25bc723ab86247af40e686aa2b24718a5cd0d1
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/mcabber/loudmouth.git
-PKG_SOURCE_VERSION:=$(PKG_VERSION)
-
 PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -41,8 +38,9 @@ define Package/loudmouth/description
 endef
 
 CONFIGURE_ARGS += \
-	--with-ssl=openssl \
-	--with-idn=no
+	--without-compile-warnings \
+	--without-idn \
+	--with-ssl=openssl
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/

--- a/libs/loudmouth/patches/010-add-private.patch
+++ b/libs/loudmouth/patches/010-add-private.patch
@@ -1,0 +1,277 @@
+From 110bd9800bb9cb3afdd724e4e4a3292d29c817a1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20K=C4=99pie=C5=84?= <github@kempniu.pl>
+Date: Thu, 27 Sep 2018 21:29:29 +0200
+Subject: [PATCH] Move away from g_type_class_add_private()
+
+g_type_class_add_private() will be deprecated in GLib 2.58.  Replace:
+
+  - g_type_class_add_private() with G_DEFINE_TYPE_WITH_PRIVATE()
+  - G_TYPE_INSTANCE_GET_PRIVATE() with *_get_instance_private()
+---
+ loudmouth/lm-blocking-resolver.c | 17 +++++++----------
+ loudmouth/lm-feature-ping.c      | 22 ++++++++++------------
+ loudmouth/lm-resolver.c          | 28 +++++++++++++---------------
+ 3 files changed, 30 insertions(+), 37 deletions(-)
+
+diff --git a/loudmouth/lm-blocking-resolver.c b/loudmouth/lm-blocking-resolver.c
+index 5a25061..d980d24 100644
+--- a/loudmouth/lm-blocking-resolver.c
++++ b/loudmouth/lm-blocking-resolver.c
+@@ -38,10 +38,10 @@
+ 
+ #define SRV_LEN 8192
+ 
+-#define GET_PRIV(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), LM_TYPE_BLOCKING_RESOLVER, LmBlockingResolverPriv))
++#define GET_PRIV(obj) (lm_blocking_resolver_get_instance_private (LM_BLOCKING_RESOLVER(obj)))
+ 
+-typedef struct LmBlockingResolverPriv LmBlockingResolverPriv;
+-struct LmBlockingResolverPriv {
++typedef struct LmBlockingResolverPrivate LmBlockingResolverPrivate;
++struct LmBlockingResolverPrivate {
+     GSource *idle_source;
+ };
+ 
+@@ -49,7 +49,7 @@ static void     blocking_resolver_dispose     (GObject       *object);
+ static void     blocking_resolver_lookup      (LmResolver    *resolver);
+ static void     blocking_resolver_cancel      (LmResolver    *resolver);
+ 
+-G_DEFINE_TYPE (LmBlockingResolver, lm_blocking_resolver, LM_TYPE_RESOLVER)
++G_DEFINE_TYPE_WITH_PRIVATE (LmBlockingResolver, lm_blocking_resolver, LM_TYPE_RESOLVER)
+ 
+ static void
+ lm_blocking_resolver_class_init (LmBlockingResolverClass *class)
+@@ -61,9 +61,6 @@ lm_blocking_resolver_class_init (LmBlockingResolverClass *class)
+ 
+     resolver_class->lookup = blocking_resolver_lookup;
+     resolver_class->cancel = blocking_resolver_cancel;
+-
+-    g_type_class_add_private (object_class,
+-                              sizeof (LmBlockingResolverPriv));
+ }
+ 
+ static void
+@@ -194,7 +191,7 @@ blocking_resolver_lookup_service (LmBlockingResolver *resolver)
+ static gboolean
+ blocking_resolver_idle_lookup (LmBlockingResolver *resolver)
+ {
+-    LmBlockingResolverPriv *priv = GET_PRIV (resolver);
++    LmBlockingResolverPrivate *priv = GET_PRIV (resolver);
+     gint                    type;
+ 
+     /* Start the DNS querying */
+@@ -219,7 +216,7 @@ blocking_resolver_idle_lookup (LmBlockingResolver *resolver)
+ static void
+ blocking_resolver_lookup (LmResolver *resolver)
+ {
+-    LmBlockingResolverPriv *priv;
++    LmBlockingResolverPrivate *priv;
+     GMainContext           *context;
+ 
+     g_return_if_fail (LM_IS_BLOCKING_RESOLVER (resolver));
+@@ -236,7 +233,7 @@ blocking_resolver_lookup (LmResolver *resolver)
+ static void
+ blocking_resolver_cancel (LmResolver *resolver)
+ {
+-    LmBlockingResolverPriv *priv;
++    LmBlockingResolverPrivate *priv;
+ 
+     g_return_if_fail (LM_IS_BLOCKING_RESOLVER (resolver));
+ 
+diff --git a/loudmouth/lm-feature-ping.c b/loudmouth/lm-feature-ping.c
+index b2dd439..bfd1e6d 100644
+--- a/loudmouth/lm-feature-ping.c
++++ b/loudmouth/lm-feature-ping.c
+@@ -28,10 +28,10 @@
+ 
+ #define XMPP_NS_PING "urn:xmpp:ping"
+ 
+-#define GET_PRIV(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), LM_TYPE_FEATURE_PING, LmFeaturePingPriv))
++#define GET_PRIV(obj) (lm_feature_ping_get_instance_private (LM_FEATURE_PING(obj)))
+ 
+-typedef struct LmFeaturePingPriv LmFeaturePingPriv;
+-struct LmFeaturePingPriv {
++typedef struct LmFeaturePingPrivate LmFeaturePingPrivate;
++struct LmFeaturePingPrivate {
+     LmConnection *connection;
+     guint         keep_alive_rate;
+     GSource      *keep_alive_source;
+@@ -55,7 +55,7 @@ feature_ping_keep_alive_reply                    (LmMessageHandler *handler,
+                                                   gpointer          user_data);
+ static gboolean feature_ping_send_keep_alive     (LmFeaturePing    *fp);
+ 
+-G_DEFINE_TYPE (LmFeaturePing, lm_feature_ping, G_TYPE_OBJECT)
++G_DEFINE_TYPE_WITH_PRIVATE (LmFeaturePing, lm_feature_ping, G_TYPE_OBJECT)
+ 
+ enum {
+     PROP_0,
+@@ -103,8 +103,6 @@ lm_feature_ping_class_init (LmFeaturePingClass *class)
+                       NULL, NULL,
+                       _lm_marshal_VOID__VOID,
+                       G_TYPE_NONE, 0);
+-
+-    g_type_class_add_private (object_class, sizeof (LmFeaturePingPriv));
+ }
+ 
+ static void
+@@ -127,7 +125,7 @@ feature_ping_get_property (GObject    *object,
+                            GValue     *value,
+                            GParamSpec *pspec)
+ {
+-    LmFeaturePingPriv *priv;
++    LmFeaturePingPrivate *priv;
+ 
+     priv = GET_PRIV (object);
+ 
+@@ -147,7 +145,7 @@ feature_ping_set_property (GObject      *object,
+                            const GValue *value,
+                            GParamSpec   *pspec)
+ {
+-    LmFeaturePingPriv *priv;
++    LmFeaturePingPrivate *priv;
+ 
+     priv = GET_PRIV (object);
+ 
+@@ -171,7 +169,7 @@ feature_ping_keep_alive_reply (LmMessageHandler *handler,
+                                LmMessage        *m,
+                                gpointer          user_data)
+ {
+-    LmFeaturePingPriv *priv;
++    LmFeaturePingPrivate *priv;
+ 
+     priv = GET_PRIV (user_data);
+ 
+@@ -183,7 +181,7 @@ feature_ping_keep_alive_reply (LmMessageHandler *handler,
+ static gboolean
+ feature_ping_send_keep_alive (LmFeaturePing *fp)
+ {
+-    LmFeaturePingPriv *priv;
++    LmFeaturePingPrivate *priv;
+     LmMessage         *ping;
+     LmMessageNode     *ping_node;
+     LmMessageHandler  *keep_alive_handler;
+@@ -237,7 +235,7 @@ feature_ping_send_keep_alive (LmFeaturePing *fp)
+ void
+ lm_feature_ping_start (LmFeaturePing *fp)
+ {
+-    LmFeaturePingPriv *priv;
++    LmFeaturePingPrivate *priv;
+ 
+     g_return_if_fail (LM_IS_FEATURE_PING (fp));
+ 
+@@ -260,7 +258,7 @@ lm_feature_ping_start (LmFeaturePing *fp)
+ void
+ lm_feature_ping_stop (LmFeaturePing *fp)
+ {
+-    LmFeaturePingPriv *priv;
++    LmFeaturePingPrivate *priv;
+ 
+     g_return_if_fail (LM_IS_FEATURE_PING (fp));
+ 
+diff --git a/loudmouth/lm-resolver.c b/loudmouth/lm-resolver.c
+index b9d7762..a0500ef 100644
+--- a/loudmouth/lm-resolver.c
++++ b/loudmouth/lm-resolver.c
+@@ -36,10 +36,10 @@
+ #include "lm-marshal.h"
+ #include "lm-resolver.h"
+ 
+-#define GET_PRIV(obj) (G_TYPE_INSTANCE_GET_PRIVATE ((obj), LM_TYPE_RESOLVER, LmResolverPriv))
++#define GET_PRIV(obj) (lm_resolver_get_instance_private (LM_RESOLVER(obj)))
+ 
+-typedef struct LmResolverPriv LmResolverPriv;
+-struct LmResolverPriv {
++typedef struct LmResolverPrivate LmResolverPrivate;
++struct LmResolverPrivate {
+     GMainContext       *context;
+ 
+     LmResolverCallback  callback;
+@@ -71,7 +71,7 @@ static void     resolver_set_property        (GObject           *object,
+                                               const GValue      *value,
+                                               GParamSpec        *pspec);
+ 
+-G_DEFINE_TYPE (LmResolver, lm_resolver, G_TYPE_OBJECT)
++G_DEFINE_TYPE_WITH_PRIVATE (LmResolver, lm_resolver, G_TYPE_OBJECT)
+ 
+ enum {
+     PROP_0,
+@@ -151,8 +151,6 @@ lm_resolver_class_init (LmResolverClass *class)
+                                                           "Protocol for SRV lookup",
+                                                           NULL,
+                                                           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+-
+-    g_type_class_add_private (object_class, sizeof (LmResolverPriv));
+ }
+ 
+ static void
+@@ -164,7 +162,7 @@ lm_resolver_init (LmResolver *resolver)
+ static void
+ resolver_finalize (GObject *object)
+ {
+-    LmResolverPriv *priv;
++    LmResolverPrivate *priv;
+ 
+     priv = GET_PRIV (object);
+ 
+@@ -190,7 +188,7 @@ resolver_get_property (GObject    *object,
+                        GValue     *value,
+                        GParamSpec *pspec)
+ {
+-    LmResolverPriv *priv;
++    LmResolverPrivate *priv;
+ 
+     priv = GET_PRIV (object);
+ 
+@@ -228,7 +226,7 @@ resolver_set_property (GObject      *object,
+                        const GValue *value,
+                        GParamSpec   *pspec)
+ {
+-    LmResolverPriv *priv;
++    LmResolverPrivate *priv;
+ 
+     priv = GET_PRIV (object);
+ 
+@@ -301,7 +299,7 @@ lm_resolver_new_for_host (const gchar        *host,
+                           gpointer            user_data)
+ {
+     LmResolver     *resolver;
+-    LmResolverPriv *priv;
++    LmResolverPrivate *priv;
+ 
+     g_return_val_if_fail (host != NULL, NULL);
+     g_return_val_if_fail (callback != NULL, NULL);
+@@ -327,7 +325,7 @@ lm_resolver_new_for_service (const gchar        *domain,
+                              gpointer            user_data)
+ {
+     LmResolver     *resolver;
+-    LmResolverPriv *priv;
++    LmResolverPrivate *priv;
+ 
+     g_return_val_if_fail (domain != NULL, NULL);
+     g_return_val_if_fail (service != NULL, NULL);
+@@ -373,7 +371,7 @@ lm_resolver_cancel (LmResolver *resolver)
+ struct addrinfo *
+ lm_resolver_results_get_next (LmResolver *resolver)
+ {
+-    LmResolverPriv  *priv;
++    LmResolverPrivate  *priv;
+     struct addrinfo *ret_val;
+ 
+     g_return_val_if_fail (LM_IS_RESOLVER (resolver), NULL);
+@@ -401,7 +399,7 @@ skipresult:
+ void
+ lm_resolver_results_reset (LmResolver *resolver)
+ {
+-    LmResolverPriv *priv;
++    LmResolverPrivate *priv;
+ 
+     g_return_if_fail (LM_IS_RESOLVER (resolver));
+ 
+@@ -427,7 +425,7 @@ _lm_resolver_set_result (LmResolver       *resolver,
+                          LmResolverResult  result,
+                          struct addrinfo  *results)
+ {
+-    LmResolverPriv *priv;
++    LmResolverPrivate *priv;
+ 
+     g_return_if_fail (LM_IS_RESOLVER (resolver));
+ 


### PR DESCRIPTION
Loudmouth enforces -Werror which errors on deprecated APIs.

Also switched to codeload for Makefile consistency between projects.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
Compile tested: ar71xx