### PR TITLE
python-cryptography: Update to 2.4.1

### DIFF
--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptography
-PKG_VERSION:=2.3.1
+PKG_VERSION:=2.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=cryptography-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= https://files.pythonhosted.org/packages/source/c/cryptography
-PKG_HASH:=8d10113ca826a4c29d5b85b2c4e045ffa8bad74fb525ee0eceb1d38d4c70dfd6
+PKG_HASH:=e85b410885addaeb31a867eabcefc9ef4a7e904ad45eac9e60a763a54b244626
 
 PKG_LICENSE:=Apache-2.0 BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.APACHE LICENSE.BSD

--- a/lang/python/python-cryptography/patches/002-remove-undefined-dtls-methods.patch
+++ b/lang/python/python-cryptography/patches/002-remove-undefined-dtls-methods.patch
@@ -1,16 +1,26 @@
+From e7a6229b332969d621aaf25f3fc5cdd99e3c9072 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sun, 18 Nov 2018 18:04:01 -0800
+Subject: [PATCH] Adjust DTLS check (#4593)
+
+OpenSSL defines these even with OPENSSL_NO_DTLS.
+---
+ src/_cffi_src/openssl/ssl.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/_cffi_src/openssl/ssl.py b/src/_cffi_src/openssl/ssl.py
+index c921dbee..f0b8939c 100644
 --- a/src/_cffi_src/openssl/ssl.py
 +++ b/src/_cffi_src/openssl/ssl.py
-@@ -646,13 +646,6 @@ static const long TLS_ST_OK = 0;
- 
- #if defined(OPENSSL_NO_DTLS) || CRYPTOGRAPHY_OPENSSL_LESS_THAN_102
- static const long Cryptography_HAS_GENERIC_DTLS_METHOD = 0;
--const SSL_METHOD *(*DTLS_method)(void) = NULL;
--const SSL_METHOD *(*DTLS_server_method)(void) = NULL;
--const SSL_METHOD *(*DTLS_client_method)(void) = NULL;
--static const long SSL_OP_NO_DTLSv1 = NULL;
--static const long SSL_OP_NO_DTLSv1_2 = NULL;
--long *(*DTLS_set_link_mtu)(SSL *, long) = NULL;
--long *(*DTLS_get_link_min_mtu)(SSL *) = NULL;
- #else
- static const long Cryptography_HAS_GENERIC_DTLS_METHOD = 1;
+@@ -714,7 +714,7 @@ static const long TLS_ST_BEFORE = 0;
+ static const long TLS_ST_OK = 0;
  #endif
+ 
+-#if defined(OPENSSL_NO_DTLS) || CRYPTOGRAPHY_OPENSSL_LESS_THAN_102
++#if CRYPTOGRAPHY_OPENSSL_LESS_THAN_102
+ static const long Cryptography_HAS_GENERIC_DTLS_METHOD = 0;
+ const SSL_METHOD *(*DTLS_method)(void) = NULL;
+ const SSL_METHOD *(*DTLS_server_method)(void) = NULL;
+-- 
+2.19.1
+


### PR DESCRIPTION
Adjusted DTLS patch. Simpler this way. The if condition is wrong anyway.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @commodo @jefferyto 
Compile tested: mvebu