### PR TITLE
node-mozilla-iot-gateway: Cleanup init script

### DIFF
--- a/lang/node-mozilla-iot-gateway/Makefile
+++ b/lang/node-mozilla-iot-gateway/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=mozilla-iot-gateway
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=0.6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_REV:=df2d06def2051238bde7b8e5ee306262235d4c9f
 
 PKG_SOURCE_PROTO:=git

--- a/lang/node-mozilla-iot-gateway/files/mozilla-iot-gateway.init
+++ b/lang/node-mozilla-iot-gateway/files/mozilla-iot-gateway.init
@@ -2,26 +2,20 @@
 
 START=99
 
+USE_PROCD=1
+
 HOME=/root
 MOZIOT_HOME="${HOME}/.mozilla-iot"
 export PATH="/opt/mozilla-iot/gateway/tools:${PATH}"
 
-run_app() {
-	cd /opt/mozilla-iot/gateway
-
-	echo "node version"
-	node --version
-	echo "npm version"
-	npm --version
-	echo "Starting gateway ..."
-	npm start
-}
-
-start()
+start_service()
 {
 	mkdir -p /usr/etc/
 	ln -sf /etc/openzwave /usr/etc/openzwave
 
-	mkdir -p "${MOZIOT_HOME}/log"
-	run_app &> "${MOZIOT_HOME}/log/run-app.log" &
+	procd_open_instance mozilla-iot-gateway
+	procd_set_param command /usr/bin/npm start --prefix /opt/mozilla-iot/gateway
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
 }


### PR DESCRIPTION
Migrates to procd (and fixes actual shutdown of the service) and also avoids
writing log to roots home directory by using system log.

Signed-off-by: Michal Hrusecky <michal.hrusecky@nic.cz>

Maintainer: @ratkaj 
Compile tested: mvebu, Turris Omnia, OpenWrt 15.05
Run tested: mvebu, Turris Omnia, OpenWrt 15.05, starts and shuts down