### PR TITLE
bugfix: extract host and domain from via regex

### DIFF
--- a/net/ddns-scripts/files/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/update_cloudflare_com_v4.sh
@@ -34,8 +34,8 @@ local __URLBASE="https://api.cloudflare.com/client/v4"
 # given data:
 # @example.com for "domain record"
 # host.sub@example.com for a "host record"
-__HOST=$(printf %s "$domain" | cut -d@ -f1)
-__DOMAIN=$(printf %s "$domain" | cut -d@ -f2)
+__HOST=$(printf %s "$domain" | sed -E 's/\.[^.]+\.[^.]+$//g')
+__DOMAIN=$(printf %s "$domain" | grep -oE '[^.]+\.[^.]+$')
 
 # Cloudflare v4 needs:
 # __DOMAIN = the base domain i.e. example.com


### PR DESCRIPTION
Maintainer: @dibdot (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
Fix wrong extraction of `__HOST` and `__DOMAIN` in `update_cloudflare_com_v4.sh`

Assume the `domain` variable we set is `some.host.example.com`,  
`__HOST` and `__DOMAIN` are expected to be `some.host` and `example.com` respectively.