### PR TITLE
nginx: unified indentation character and add additional configure directory

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.15.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://nginx.org/download/

--- a/net/nginx/files-luci-support/luci_nginx.conf
+++ b/net/nginx/files-luci-support/luci_nginx.conf
@@ -18,32 +18,34 @@ http {
     include       mime.types;
     default_type  application/octet-stream;
 
-	sendfile on;
+    sendfile on;
     keepalive_timeout 0;
-	
-	client_body_buffer_size 10K;
-	client_header_buffer_size 1k;
-	client_max_body_size 1G;
-	large_client_header_buffers 2 1k;
+    
+    client_body_buffer_size 10K;
+    client_header_buffer_size 1k;
+    client_max_body_size 1G;
+    large_client_header_buffers 2 1k;
 
     gzip on;
     gzip_http_version 1.1;
     gzip_vary on;
     gzip_comp_level 1;
     gzip_proxied any;
-	
-	root /www;
+    
+    root /www;
 
     server {
         listen 80 default_server;
-		listen [::]:80 default_server;
+        listen [::]:80 default_server;
         server_name  localhost;
-		
-		location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
-			expires 365d;
-		}
+        
+        location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
+            expires 365d;
+        }
 
-		include luci_uwsgi.conf;
+        include luci_uwsgi.conf;
 
     }
+
+    include /etc/nginx/conf.d/*.conf;
 }

--- a/net/nginx/files-luci-support/luci_nginx_ssl.conf
+++ b/net/nginx/files-luci-support/luci_nginx_ssl.conf
@@ -18,47 +18,49 @@ http {
     include       mime.types;
     default_type  application/octet-stream;
 
-	sendfile on;
+    sendfile on;
     keepalive_timeout 0;
-	
-	client_body_buffer_size 10K;
-	client_header_buffer_size 1k;
-	client_max_body_size 1G;
-	large_client_header_buffers 2 1k;
+    
+    client_body_buffer_size 10K;
+    client_header_buffer_size 1k;
+    client_max_body_size 1G;
+    large_client_header_buffers 2 1k;
 
     gzip on;
     gzip_http_version 1.1;
     gzip_vary on;
     gzip_comp_level 1;
     gzip_proxied any;
-	
-	root /www;
-	
-	server {
-		listen 80 default_server;
-		listen [::]:80 default_server;
-		server_name _;
-		return 301 https://$host$request_uri;
-	}
+    
+    root /www;
+    
+    server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+        server_name _;
+        return 301 https://$host$request_uri;
+    }
 
     server {
         listen 443 ssl default_server;
-		listen [::]:443 ssl default_server;
+        listen [::]:443 ssl default_server;
         server_name  localhost;
-		
-		ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
         ssl_prefer_server_ciphers on;
-		ssl_ciphers "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:DHE+AESGCM:DHE:!RSA!aNULL:!eNULL:!LOW:!RC4:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!CAMELLIA:!SEED";
+        ssl_ciphers "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:DHE+AESGCM:DHE:!RSA!aNULL:!eNULL:!LOW:!RC4:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!CAMELLIA:!SEED";
         ssl_session_tickets off;
 
-		ssl_certificate /etc/nginx/nginx.cer;
+        ssl_certificate /etc/nginx/nginx.cer;
         ssl_certificate_key /etc/nginx/nginx.key;
-		
-		location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
-			expires 365d;
-		}
+        
+        location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
+            expires 365d;
+        }
 
-		include luci_uwsgi.conf;
+        include luci_uwsgi.conf;
 
     }
+
+    include /etc/nginx/conf.d/*.conf;
 }

--- a/net/nginx/files-luci-support/luci_uwsgi.conf
+++ b/net/nginx/files-luci-support/luci_uwsgi.conf
@@ -1,19 +1,19 @@
 location /cgi-bin/luci {
-	index  index.html;
-	uwsgi_param QUERY_STRING $query_string;
-	uwsgi_param REQUEST_METHOD $request_method;
-	uwsgi_param CONTENT_TYPE $content_type;
-	uwsgi_param CONTENT_LENGTH $content_length if_not_empty;
-	uwsgi_param REQUEST_URI $request_uri;
-	uwsgi_param PATH_INFO $document_uri;
-	uwsgi_param SERVER_PROTOCOL $server_protocol;
-	uwsgi_param REMOTE_ADDR $remote_addr;
-	uwsgi_param REMOTE_PORT $remote_port;
-	uwsgi_param SERVER_ADDR $server_addr;
-	uwsgi_param SERVER_PORT $server_port;
-	uwsgi_param SERVER_NAME $server_name;
-	uwsgi_modifier1 9;
-	uwsgi_pass unix:////var/run/uwsgi.sock;
+    index  index.html;
+    uwsgi_param QUERY_STRING $query_string;
+    uwsgi_param REQUEST_METHOD $request_method;
+    uwsgi_param CONTENT_TYPE $content_type;
+    uwsgi_param CONTENT_LENGTH $content_length if_not_empty;
+    uwsgi_param REQUEST_URI $request_uri;
+    uwsgi_param PATH_INFO $document_uri;
+    uwsgi_param SERVER_PROTOCOL $server_protocol;
+    uwsgi_param REMOTE_ADDR $remote_addr;
+    uwsgi_param REMOTE_PORT $remote_port;
+    uwsgi_param SERVER_ADDR $server_addr;
+    uwsgi_param SERVER_PORT $server_port;
+    uwsgi_param SERVER_NAME $server_name;
+    uwsgi_modifier1 9;
+    uwsgi_pass unix:////var/run/uwsgi.sock;
 }
 
 location /luci-static {


### PR DESCRIPTION
This PR contains 2 commits.

commit 1: The original configure file mixed tab and space
characters as indentation, so use 4 spaces as the
default indentation character.

commit 2: Add /etc/nginx/conf.d/*.conf as nginx additional configure
files. Then we can add individual conf file for other http
applications without modify the main nginx configure file.
