### PR TITLE
[18.06] net/mwan3: fix NDP on ipv6 for ra services

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.6.17
+PKG_VERSION:=2.6.18
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -198,6 +198,14 @@ mwan3_set_general_iptables()
 
 		if ! $IPT -S mwan3_hook &> /dev/null; then
 			$IPT -N mwan3_hook
+			# do not mangle ipv6 ra service
+			if [ "$IPT" = "$IPT6" ]; then
+				$IPT6 -A mwan3_hook -p ipv6-icmp -m icmp6 --icmpv6-type 133 -j RETURN
+				$IPT6 -A mwan3_hook -p ipv6-icmp -m icmp6 --icmpv6-type 134 -j RETURN
+				$IPT6 -A mwan3_hook -p ipv6-icmp -m icmp6 --icmpv6-type 135 -j RETURN
+				$IPT6 -A mwan3_hook -p ipv6-icmp -m icmp6 --icmpv6-type 136 -j RETURN
+				$IPT6 -A mwan3_hook -p ipv6-icmp -m icmp6 --icmpv6-type 137 -j RETURN
+			fi
 			$IPT -A mwan3_hook -j CONNMARK --restore-mark --nfmask $MMX_MASK --ctmask $MMX_MASK
 			$IPT -A mwan3_hook -m mark --mark 0x0/$MMX_MASK -j mwan3_ifaces_in
 			$IPT -A mwan3_hook -m mark --mark 0x0/$MMX_MASK -j mwan3_connected


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: 18.06 current
Run tested: 18.06 x86_64

The commit was immediately after the released 18.06 code, so it was picked nicely.