### PR TITLE
opensc: Update to 0.19.0

### DIFF
--- a/utils/opensc/Makefile
+++ b/utils/opensc/Makefile
@@ -8,9 +8,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opensc
-PKG_VERSION:=0.18.0
+PKG_VERSION:=0.19.0
 PKG_RELEASE:=1
-PKG_HASH:=9bc0ff030dd1c10f646d54415eae1bb2b1c72dda710378343f027e17cd8c3757
+PKG_HASH:=2c5a0e4df9027635290b9c0f3addbbf0d651db5ddb0ab789cb0e978f02fd5826
 
 PKG_LICENSE:=LGPL-2.1+
 PKG_LICENSE_FILES:=COPYING
@@ -97,6 +97,10 @@ define Package/libopensc-profile-$(subst _,-,$(firstword $(subst :, ,$(1))))
   DEPENDS:=libopensc
 endef
 endef
+
+CONFIGURE_ARGS += \
+	--disable-notify \
+	--disable-strict
 
 TOOLS:= \
 	cardos-tool \


### PR DESCRIPTION
Pass --disable-notify to avoid libgio dependency.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: ar71xx
