### PR TITLE
ddns-scripts: submit one change at a time to route53

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.8
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=

--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -21,7 +21,7 @@
 . /lib/functions/network.sh
 
 # GLOBAL VARIABLES #
-VERSION="2.7.8-5"
+VERSION="2.7.8-6"
 SECTION_ID=""		# hold config's section name
 VERBOSE=0		# default mode is log to console, but easily changed with parameter
 MYPROG=$(basename $0)	# my program call name

--- a/net/ddns-scripts/files/update_route53_v1.sh
+++ b/net/ddns-scripts/files/update_route53_v1.sh
@@ -80,7 +80,7 @@ signature="$(sign "${signing_key}" "${sigmsg}")"
 
 authorization="AWS4-HMAC-SHA256 Credential=${AWS_ACCESS_KEY_ID}/${credential}, SignedHeaders=${signed_headers}, Signature=${signature}"
 
-ANSWER="$(curl \
+ANSWER="$(flock /tmp/$(basename -s .sh "$0").lock curl \
     -X "POST" \
     -H "Host: route53.amazonaws.com" \
     -H "X-Amz-Date: ${fulldate}" \


### PR DESCRIPTION
This prevents updates from failing if multiple instances of the script are running in parallel. This fixes #7492.