### PR TITLE
prometheus-node-exporter-lua: close io.popen files to reap zombies

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2018.07.23
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/bin/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/bin/prometheus-node-exporter-lua
@@ -119,11 +119,13 @@ end
 
 col_mods = {}
 col_names = {}
-for c in io.popen("ls -1 /usr/lib/lua/prometheus-collectors/*.lua"):lines() do
+ls_fd = io.popen("ls -1 /usr/lib/lua/prometheus-collectors/*.lua")
+for c in ls_fd:lines() do
   c = c:match("([^/]+)%.lua$")
   col_mods[c] = require('prometheus-collectors.'..c)
   col_names[#col_names+1] = c
 end
+ls_fd:close()
 
 if port then
   server = assert(socket.bind(bind, port))

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/uname.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/uname.lua
@@ -1,11 +1,15 @@
+local uname_fd = io.popen("uname -m")
+
 local labels = {
   domainname = "",
   nodename = "",
   release = string.sub(get_contents("/proc/sys/kernel/osrelease"), 1, -2),
   sysname = string.sub(get_contents("/proc/sys/kernel/ostype"), 1, -2),
   version = string.sub(get_contents("/proc/sys/kernel/version"), 1, -2),
-  machine = string.sub(io.popen("uname -m"):read("*a"), 1, -2)
+  machine = string.sub(uname_fd:read("*a"), 1, -2)
 }
+
+uname_fd:close()
 
 local function scrape()
   labels["domainname"] = string.sub(get_contents("/proc/sys/kernel/domainname"), 1, -2)


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested: mips, tl-mr3020, r8494-3e19113
Run tested: mips, tl-mr3020, r8494-3e19113

Description:

The patch fixes two zomibe processes left after `prometheus-node-exporter-lua` startup.

Before the patch `ps` looked like following ttydump, after the patch two FDs and zombies are gone:

```
$ ps
...
 1073 root      1588 S    {prometheus-node} /usr/bin/lua /usr/bin/prometheus-node-exporter-lua --port 9100 --bind ::1
 1075 root         0 Z    [ls]
 1081 root         0 Z    [uname]
# ls -l /proc/1073/fd
lr-x------    1 root     root            64 Nov 25 02:51 0 -> /dev/null
l-wx------    1 root     root            64 Nov 25 02:51 1 -> pipe:[1464]
l-wx------    1 root     root            64 Nov 25 02:51 2 -> pipe:[1465]
lr-x------    1 root     root            64 Nov 25 02:51 3 -> pipe:[1467]
lr-x------    1 root     root            64 Nov 25 02:51 4 -> pipe:[1472]
lrwx------    1 root     root            64 Nov 25 02:51 5 -> socket:[1474]
```

Excuse me if my LUA code is wrong for some reason (e.g. missing right `local` or something like that), I've never done any serious LUA development.