### PR TITLE
grilo: Disable debug and tests

### DIFF
--- a/multimedia/grilo/Makefile
+++ b/multimedia/grilo/Makefile
@@ -46,10 +46,10 @@ endef
 
 CONFIGURE_ARGS += \
 	--disable-compile-warnings \
+	--disable-debug \
 	--disable-gtk-doc-html \
 	--disable-introspection \
 	--disable-test-ui \
-	--disable-tests \
 	--disable-vala
 
 define Build/InstallDev


### PR DESCRIPTION
Turns out --disable-tests actually enables them, breaking the buildbots.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
Compile tested: ar71xx