### PR TITLE
pen: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/pen/Makefile
+++ b/net/pen/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pen
 PKG_VERSION:=0.34.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://siag.nu/pub/pen/
@@ -17,8 +17,9 @@ PKG_HASH:=2b640795029df9d1672e17202c109cc5d42538f6754a6070dc27da640881e864
 
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Nicolas Thill <nico@openwrt.org>
+PKG_MAINTAINER:=
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -28,7 +29,7 @@ define Package/pen
   CATEGORY:=Network
   DEPENDS:=+libopenssl
   TITLE:=Simple TCP load balancer
-  URL:=http://morestuff.siag.nu/category/pen/
+  URL:=http://siag.nu/pen/
 endef
 
 define Package/pen/description

--- a/net/pen/patches/010-deprecated-openssl.patch
+++ b/net/pen/patches/010-deprecated-openssl.patch
@@ -1,0 +1,49 @@
+From 652dd89d297df2dbf7fc7a235d5305b5fc945e2f Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sun, 25 Nov 2018 19:09:33 -0800
+Subject: [PATCH] Fix compilation under OpenSSL 1.1 without deprecated APIs
+
+---
+ ssl.c | 4 ++++
+ ssl.h | 2 ++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/ssl.c b/ssl.c
+index 6c67879..1a222bb 100644
+--- a/ssl.c
++++ b/ssl.c
+@@ -359,7 +359,9 @@ static SSL_CTX *ssl_create_context(char *keyfile, char *certfile,
+ 			debug("continuing anyway...");
+ 		}
+ 	}
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	SSL_CTX_set_tmp_rsa_callback(ssl_context, ssl_temp_rsa_cb);
++#endif
+ 	SSL_CTX_set_info_callback(ssl_context, ssl_info_cb);
+ 	SSL_CTX_set_tlsext_status_cb(ssl_context, ssl_stapling_cb);
+ 	SSL_CTX_set_tlsext_servername_callback(ssl_context, ssl_sni_cb);
+@@ -405,8 +407,10 @@ static SSL_CTX *ssl_create_context(char *keyfile, char *certfile,
+ 
+ int ssl_init(void)
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	SSL_load_error_strings();
+ 	SSLeay_add_ssl_algorithms();
++#endif
+ 	ssl_context = ssl_create_context(keyfile, certfile, cacert_dir, cacert_file);
+ 	if (ssl_context == NULL) {
+ 		error("Unable to create default context");
+diff --git a/ssl.h b/ssl.h
+index a0dcd18..b63161e 100644
+--- a/ssl.h
++++ b/ssl.h
+@@ -1,6 +1,8 @@
+ #ifdef HAVE_LIBSSL
+ #include <openssl/ssl.h>
+ #include <openssl/err.h>
++#include <openssl/bn.h>
++#include <openssl/rsa.h>
+ 
+ #define SRV_SSL_V23 0
+ #define SRV_SSL_V2 1
+


### PR DESCRIPTION
Patch was sent upstream.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ar71xx