### PR TITLE
vsftpd: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/vsftpd/Makefile
+++ b/net/vsftpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vsftpd
 PKG_VERSION:=3.0.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://security.appspot.com/downloads/

--- a/net/vsftpd/patches/010-openssl-deprecated.patch
+++ b/net/vsftpd/patches/010-openssl-deprecated.patch
@@ -1,0 +1,48 @@
+--- a/ssl.c
++++ b/ssl.c
+@@ -28,6 +28,9 @@
+ #include <openssl/err.h>
+ #include <openssl/rand.h>
+ #include <openssl/bio.h>
++#ifndef OPENSSL_NO_EC
++#include <openssl/ec.h>
++#endif
+ #include <errno.h>
+ #include <limits.h>
+ 
+@@ -59,7 +62,9 @@ ssl_init(struct vsf_session* p_sess)
+     SSL_CTX* p_ctx;
+     long options;
+     int verify_option = 0;
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     SSL_library_init();
++#endif
+     p_ctx = SSL_CTX_new(SSLv23_server_method());
+     if (p_ctx == NULL)
+     {
+@@ -120,6 +125,7 @@ ssl_init(struct vsf_session* p_sess)
+     {
+       die("SSL: RNG is not seeded");
+     }
++#ifndef OPENSSL_NO_EC
+     {
+       EC_KEY* key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+       if (key == NULL)
+@@ -129,6 +135,7 @@ ssl_init(struct vsf_session* p_sess)
+       SSL_CTX_set_tmp_ecdh(p_ctx, key);
+       EC_KEY_free(key);
+     }
++#endif
+     if (tunable_ssl_request_cert)
+     {
+       verify_option |= SSL_VERIFY_PEER;
+@@ -660,7 +667,9 @@ ssl_cert_digest(SSL* p_ssl, struct vsf_session* p_sess, struct mystr* p_str)
+ static char*
+ get_ssl_error()
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+   SSL_load_error_strings();
++#endif
+   return ERR_error_string(ERR_get_error(), NULL);
+ }
+ 


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @obsy 
Compile tested: ar71xx