### PR TITLE
ngircd: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/ngircd/Makefile
+++ b/net/ngircd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ngircd
 PKG_VERSION:=24
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Claudio Leite <leitec@staticky.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING

--- a/net/ngircd/patches/010-Fix-compilation-without-deprecated-OpenSSL-APIs.patch
+++ b/net/ngircd/patches/010-Fix-compilation-without-deprecated-OpenSSL-APIs.patch
@@ -1,0 +1,46 @@
+From d7bf6c919259a65d78b5bf67a3c75838f8894e91 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sun, 25 Nov 2018 19:59:49 -0800
+Subject: [PATCH] Fix compilation without deprecated OpenSSL APIs
+
+---
+ src/ngircd/conf-ssl.h | 4 ++++
+ src/ngircd/conn-ssl.c | 3 ++-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/ngircd/conf-ssl.h b/src/ngircd/conf-ssl.h
+index c2373797..af715af8 100644
+--- a/src/ngircd/conf-ssl.h
++++ b/src/ngircd/conf-ssl.h
+@@ -13,6 +13,10 @@
+ #ifdef HAVE_LIBSSL
+ #define SSL_SUPPORT
+ #include <openssl/ssl.h>
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#define OpenSSL_version SSLeay_version
++#define OPENSSL_VERSION SSLEAY_VERSION
++#endif
+ #endif
+ #ifdef HAVE_LIBGNUTLS
+ #define SSL_SUPPORT
+diff --git a/src/ngircd/conn-ssl.c b/src/ngircd/conn-ssl.c
+index 705c29d5..ba47e513 100644
+--- a/src/ngircd/conn-ssl.c
++++ b/src/ngircd/conn-ssl.c
+@@ -42,6 +42,7 @@ extern struct SSLOptions Conf_SSLOptions;
+ #ifdef HAVE_LIBSSL
+ #include <openssl/err.h>
+ #include <openssl/rand.h>
++#include <openssl/dh.h>
+ 
+ static SSL_CTX * ssl_ctx;
+ static DH *dh_params;
+@@ -326,7 +327,7 @@ ConnSSL_InitLibrary( void )
+ 			   Verify_openssl);
+ 	SSL_CTX_free(ssl_ctx);
+ 	ssl_ctx = newctx;
+-	Log(LOG_INFO, "%s initialized.", SSLeay_version(SSLEAY_VERSION));
++	Log(LOG_INFO, "%s initialized.", OpenSSL_version(OPENSSL_VERSION));
+ 	return true;
+ out:
+ 	SSL_CTX_free(newctx);


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @leitec 
Compile tested: ar71xx

https://github.com/ngircd/ngircd/pull/252