### PR TITLE
libgcrypt: Аdd PKC_CPE_ID for proper CVE tracking

### DIFF
--- a/libs/libgcrypt/Makefile
+++ b/libs/libgcrypt/Makefile
@@ -14,8 +14,11 @@ PKG_RELEASE:=1
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/libgcrypt/
 PKG_HASH:=f638143a0672628fde0cad745e9b14deb85dffb175709cacc1f4fe24b93f2227
+
+PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1+ GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:gnupg:libgcrypt
 
 PKG_FIXUP:=autoreconf patch-libtool
 PKG_INSTALL:=1
@@ -28,8 +31,7 @@ define Package/libgcrypt
   CATEGORY:=Libraries
   DEPENDS:=+libgpg-error
   TITLE:=GNU crypto library
-  URL:=http://directory.fsf.org/security/libgcrypt.html
-  MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+  URL:=https://www.gnupg.org/related_software/libgcrypt/
 endef
 
 define Package/libgcrypt/description


### PR DESCRIPTION
Also did some cosmetic adjustments for consistency.

No code changes.

Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
