### PR TITLE
pagekitec: Update to 0.91.180519

### DIFF
--- a/net/pagekitec/Makefile
+++ b/net/pagekitec/Makefile
@@ -8,21 +8,23 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pagekitec
-PKG_REV:=0.91.171102
-PKG_VERSION:=$(PKG_REV)C
+PKG_VERSION:=0.91.180519
 PKG_RELEASE:=1
-PKG_LICENSE:=Apache-2.0
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MIRROR_HASH:=9e04b979cff827974ec9e9708daf116867bf1268cdad7dff4ad585172123f6b5
-PKG_SOURCE_URL:=https://github.com/pagekite/libpagekite.git
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=v$(PKG_REV)
 
-include $(INCLUDE_DIR)/package.mk
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/pagekite/libpagekite/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=c5b48b1b898492a7050ee03161e76e3560c06b3ae0b8ba33cec693b54a9d46e3
+PKG_BUILD_DIR:=$(BUILD_DIR)/libpagekite-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Karl Palsson <karlp@tweak.net.au>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=doc/LICENSE-2.0.txt
 
 PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
 
 CONFIGURE_ARGS += --without-java
 
@@ -31,7 +33,6 @@ define Package/pagekitec/default
   CATEGORY:=Network
   TITLE:=Make localhost servers publicly visible.
   URL:=https://pagekite.net/wiki/Floss/LibPageKite/
-  MAINTAINER:= Karl Palsson <karlp@tweak.net.au>
   DEPENDS:=+libopenssl +libpthread +libev
 endef
 

--- a/net/pagekitec/patches/010-opensslthreadlock-Switch-to-THREADID-API.patch
+++ b/net/pagekitec/patches/010-opensslthreadlock-Switch-to-THREADID-API.patch
@@ -1,0 +1,45 @@
+From c1026bbb168b916fb936d14d86c0ee7bf9f3e70b Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 23 Nov 2018 19:31:52 -0800
+Subject: [PATCH] opensslthreadlock: Switch to THREADID API
+
+The old API was deprecated with 1.0.0. Causes compilation errors with 1.0.2
+with deprecated APIs disabled.
+---
+ libpagekite/opensslthreadlock.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libpagekite/opensslthreadlock.c b/libpagekite/opensslthreadlock.c
+index 7fee5b2..3ff8964 100644
+--- a/libpagekite/opensslthreadlock.c
++++ b/libpagekite/opensslthreadlock.c
+@@ -72,9 +72,9 @@ static void pk_ssl_locking_function(int mode, int n, const char *file, int line)
+     MUTEX_UNLOCK(pk_ssl_mutex_buf[n]);
+ }
+ 
+-static unsigned long pk_ssl_id_function(void)
++static void pk_ssl_id_function(CRYPTO_THREADID *id)
+ {
+-  return ((unsigned long)THREAD_ID);
++  CRYPTO_THREADID_set_numeric(id, (unsigned long)THREAD_ID);
+ }
+ #endif
+ 
+@@ -87,7 +87,7 @@ int pk_ssl_thread_setup(void)
+     return 0;
+   for(i = 0;  i < CRYPTO_num_locks();  i++)
+     MUTEX_SETUP(pk_ssl_mutex_buf[i]);
+-  CRYPTO_set_id_callback(pk_ssl_id_function);
++  CRYPTO_THREADID_set_callback(pk_ssl_id_function);
+   CRYPTO_set_locking_callback(pk_ssl_locking_function);
+ #endif
+   return 1;
+@@ -99,7 +99,7 @@ int pk_ssl_thread_cleanup(void)
+   int i;
+   if(!mutex_buf)
+     return 0;
+-  CRYPTO_set_id_callback(NULL);
++  CRYPTO_THREADID_set_callback(NULL);
+   CRYPTO_set_locking_callback(NULL);
+   for(i = 0;  i < CRYPTO_num_locks();  i++)
+     MUTEX_CLEANUP(pk_ssl_mutex_buf[i]);

--- a/net/pagekitec/patches/020-sslinit-Fix-compilation-without-deprecated-APIs.patch
+++ b/net/pagekitec/patches/020-sslinit-Fix-compilation-without-deprecated-APIs.patch
@@ -1,0 +1,36 @@
+From 68b777ca3bb4cfc1ed4b3e168f74716a5f2b7b90 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 23 Nov 2018 19:47:40 -0800
+Subject: [PATCH] sslinit: Fix compilation without deprecated APIs
+
+All of the removed APIs are either removed or unnecessary.
+---
+ libpagekite/pkcommon.h | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/libpagekite/pkcommon.h b/libpagekite/pkcommon.h
+index babd117..36bdc67 100644
+--- a/libpagekite/pkcommon.h
++++ b/libpagekite/pkcommon.h
+@@ -143,6 +143,7 @@ typedef unsigned int              uint32_t;
+ #    define SSL_OP_NO_COMPRESSION 0
+ #  endif
+ #  define PKS_DEFAULT_CIPHERS "HIGH:!aNULL:!eNULL:!LOW:!MD5:!EXP:!PSK:!SRP:!DSS"
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ #  define PKS_SSL_INIT(ctx) {\
+               SSL_load_error_strings(); \
+               ERR_load_BIO_strings(); \
+@@ -153,6 +154,13 @@ typedef unsigned int              uint32_t;
+               SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION); \
+               SSL_CTX_set_mode(ctx, SSL_MODE_RELEASE_BUFFERS); }
+ #else
++#  define PKS_SSL_INIT(ctx) {\
++              sk_SSL_COMP_zero(SSL_COMP_get_compression_methods()); \
++              ctx = SSL_CTX_new(TLS_method()); \
++              SSL_CTX_set_options(ctx, SSL_OP_NO_COMPRESSION); \
++              SSL_CTX_set_mode(ctx, SSL_MODE_RELEASE_BUFFERS); }
++#endif
++#else
+ #  define SSL_CTX                   void
+ #  define PKS_DEFAULT_CIPHERS       NULL
+ #  define PKS_SSL_INIT(ctx)         { ctx = NULL; }


### PR DESCRIPTION
Switch to codeload for consistency with other packages.

Add two patches to fix OpenSSL compilation without deprecated APIs.

Minor rearrangements.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @karlp 
Compile-tested: ar71xx
