### PR TITLE
darkstat: correction of a variable in the init script

### DIFF
--- a/net/darkstat/Makefile
+++ b/net/darkstat/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=darkstat
 PKG_VERSION:=3.0.719
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Jean-Michel Lacroix <lacroix@lepine-lacroix.info>
 

--- a/net/darkstat/files/darkstat.init
+++ b/net/darkstat/files/darkstat.init
@@ -23,7 +23,7 @@ export_bool () {
 	config_get_bool _loctmp "$section" "$option"
 	if [ -n "$_loctmp" ]; then
 		if [ 1 -eq "$_loctmp" ]; then
-			CONFIGSTRING="$CONFIGSTRING${_keystr} "
+			CONFIGSTR="$CONFIGSTR${_keystr} "
 		fi
 	fi
 }


### PR DESCRIPTION
Maintainer: Jean-Michel Lacroix / @padre-lacroix 
Compile tested: not applicable as no change to the binary
Run tested: OpenWrt SNAPSHOT r8207-99e1a12

Description:
This is to correct the variable name CONFIGSTR in the export_bool
sub-routine: the variable in line 26 was written CONFIGSTRING instead
of CONFIGSTR.
As this is a minor change, the revision number in the Makefile has not
been increased.

Signed-off-by: Jean-Michel Lacroix <lacroix@lepine-lacroix.info>