### PR TITLE
digitemp: bump to version 3.7.2

### DIFF
--- a/utils/digitemp/Makefile
+++ b/utils/digitemp/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=digitemp
-PKG_VERSION:=3.7.1
-PKG_RELEASE:=2
+PKG_VERSION:=3.7.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/bcl/digitemp/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6fa4d965350d5501b6ca73ee8a09276ca4f65b6d85dae62f0a796239bae5000e
+PKG_HASH:=683df4ab5cc53a45fe4f860c698f148d34bcca91b3e0568a342f32d64d12ba24
 
 PKG_MAINTAINER:=Jasper Scholte <NightNL@outlook.com>
 PKG_LICENSE:=GPL-2.0+


### PR DESCRIPTION
Maintainer: me
Compile tested: x86-64
Run tested: no

Description:
This updates Digitemp to v3.7.2.
It's only compile tested but since the differences between v3.7.1 and v3.7 are marginal. I expect it to work just fine.
