### PR TITLE
ptunnel-ng: add new package

### DIFF
--- a/net/ptunnel-ng/Makefile
+++ b/net/ptunnel-ng/Makefile
@@ -1,0 +1,40 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ptunnel-ng
+PKG_VERSION:=1.31
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/lnslbrty/ptunnel-ng/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=8324741f55aae8ccee6800912662a429774378088d81028a5f3f62f3ea9edaf4
+
+PKG_LICENSE:=BSD-3
+PKG_LICENSE_FILES:=COPYING
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ptunnel-ng
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpthread
+  TITLE:=PingTunnel [N]ew[G]eneration
+  MAINTAINER:=Toni Uhlig <matzeton@googlemail.com>
+  URL:=https://github.com/lnslbrty/ptunnel-ng
+endef
+
+define Package/ptunnel-ng/description
+	Tunnel TCP connections through ICMP.
+endef
+
+CONFIGURE_ARGS += \
+	--disable-pcap \
+	--disable-selinux
+
+define Package/ptunnel-ng/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$(PKG_NAME) $(1)/usr/sbin/$(PKG_NAME)
+endef
+
+$(eval $(call BuildPackage,ptunnel-ng))


### PR DESCRIPTION
Maintainer: Toni Uhlig matzeton@googlemail.com
Compile tested: x86_64, debian-stable, OpenWrt SNAPSHOT r8546+7-d93b09fa74
Run tested: mvebu, linksys3200ac, OpenWrt SNAPSHOT r8546+7-d93b09fa74

Description:
Ptunnel-NG is a bugfixed and refactored version of Ptunnel.
Ptunnel is an application that allows you to reliably tunnel TCP connections to a remote host using ICMP echo request and reply packets, commonly known as ping requests and replies.