### PR TITLE
collectd: Introduce collectd-mod-ethstat

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.8.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \
@@ -39,7 +39,6 @@ COLLECTD_PLUGINS_DISABLED:= \
 	dpdkevents \
 	dpdkstat \
 	drbd \
-	ethstat \
 	fhcount \
 	genericjmx \
 	gmond \
@@ -129,6 +128,7 @@ COLLECTD_PLUGINS_SELECTED:= \
 	dns \
 	email \
 	entropy \
+	ethstat \
 	exec \
 	filecount \
 	fscache \
@@ -350,6 +350,7 @@ $(eval $(call BuildPlugin,disk,disk usage/timing input,disk,))
 $(eval $(call BuildPlugin,dns,DNS traffic input,dns,+PACKAGE_collectd-mod-dns:libpcap))
 $(eval $(call BuildPlugin,email,email output,email,))
 $(eval $(call BuildPlugin,entropy,Entropy amount input,entropy,))
+$(eval $(call BuildPlugin,ethstat,Ethernet adapter statistics input,ethstat,))
 $(eval $(call BuildPlugin,exec,process exec input,exec,))
 $(eval $(call BuildPlugin,filecount,file count input,filecount,))
 $(eval $(call BuildPlugin,fscache,file-system based caching framework input,fscache,))


### PR DESCRIPTION
Maintainer: @jow-, @hnyman
Compile tested: x86_64, Arch Linux, OpenWrt 18.06.1, r7258-5eb055306f 
Run tested: ar71xx, D-Link DAP-2695 rev. A1, OpenWrt 18.06.1, r7258-5eb055306f, added to collectd config

Description:

The ethstat plugin for collectd provides a convenient way to track a large list
of variables associated with network interfaces such as channel busy time and
many others.

A list of the available variables for a given interface may be acquired by
running `ethtool -S <interface>`

Example for ath10k:

```
root@openwrt:~# ethtool -S wlan0
NIC statistics:
     rx_packets: 0
     rx_bytes: 0
     rx_duplicates: 0
     rx_fragments: 0
     rx_dropped: 0
     tx_packets: 0
     tx_bytes: 0
     tx_filtered: 0
     tx_retry_failed: 0
     tx_retries: 0
     sta_state: 0
     txrate: 0
     rxrate: 0
     signal: 0
     channel: 5260
     noise: 161
     ch_time: 46
     ch_time_busy: 0
     ch_time_ext_busy: 18446744073709551615
     ch_time_rx: 18446744073709551615
     ch_time_tx: 18446744073709551615
     tx_hw_reaped: 77552
     tx_pkts_nic: 0
     tx_bytes_nic: 0
     tx_bytes_to_fw: 20533
     rx_pkts_nic: 54
     rx_bytes_nic: 229196
     rx_drop_unchain_oom: 0
     rx_drop_decap_non_raw_chained: 0
     rx_drop_no_freq: 0
     rx_drop_cac_running: 0
     d_noise_floor: 18446744073709551521
     d_cycle_count: 2432156477
     d_tx_cycle_count: 15330413
     d_rx_cycle_count: 12120
     d_busy_count: 16963980
     d_flags: 1
     d_phy_error: 0
     d_rts_bad: 0
     d_rts_good: 0
     d_tx_power: 36
     d_rx_crc_err: 0
     d_no_beacon: 239
     d_tx_mpdus_queued: 77552
     d_tx_msdu_queued: 77552
     d_tx_msdu_dropped: 0
     d_local_enqued: 77465
     d_local_freed: 77465
     d_tx_ppdu_hw_queued: 77552
     d_tx_ppdu_reaped: 77552
     d_tx_fifo_underrun: 0
     d_tx_ppdu_abort: 0
     d_tx_mpdu_requed: 0
     d_tx_excessive_retries: 0
     d_tx_hw_rate: 3
     d_tx_dropped_sw_retries: 0
     d_tx_noack: 0
     d_tx_noack_bytes: 0
     d_tx_discard: 0
     d_tx_discard_bytes: 0
     d_tx_illegal_rate: 0
     d_tx_continuous_xretries: 0
     d_tx_timeout: 0
     d_tx_mpdu_txop_limit: 0
     d_pdev_resets: 9
     d_rx_mid_ppdu_route_change: 0
     d_rx_status: 54
     d_rx_extra_frags_ring0: 0
     d_rx_extra_frags_ring1: 0
     d_rx_extra_frags_ring2: 0
     d_rx_extra_frags_ring3: 0
     d_rx_msdu_htt: 54
     d_rx_mpdu_htt: 54
     d_rx_msdu_stack: 54
     d_rx_mpdu_stack: 54
     d_rx_phy_err: 26
     d_rx_phy_err_drops: 0
     d_rx_mpdu_errors: 0
     d_fw_crash_count: 0
     d_fw_warm_reset_count: 6
     d_fw_cold_reset_count: 0
     d_fw_powerup_failed: 0
     d_short_tx_retries: 0
     d_long_tx_retries: 0
     d_fw_adc_temp: 0
```

Example for ath9k:
```
root@openwrt:~# ethtool -S wlan1
NIC statistics:
     rx_packets: 0
     rx_bytes: 0
     rx_duplicates: 0
     rx_fragments: 0
     rx_dropped: 0
     tx_packets: 0
     tx_bytes: 0
     tx_filtered: 0
     tx_retry_failed: 0
     tx_retries: 0
     sta_state: 0
     txrate: 0
     rxrate: 0
     signal: 0
     channel: 2432
     noise: 161
     ch_time: 4135019
     ch_time_busy: 405039
     ch_time_ext_busy: 18446744073709551615
     ch_time_rx: 371814
     ch_time_tx: 187
     tx_pkts_nic: 5682
     tx_bytes_nic: 1140594
     rx_pkts_nic: 53883
     rx_bytes_nic: 13456947
     d_tx_pkts_BE: 0
     d_tx_pkts_BK: 0
     d_tx_pkts_VI: 0
     d_tx_pkts_VO: 5682
     d_tx_bytes_BE: 0
     d_tx_bytes_BK: 0
     d_tx_bytes_VI: 0
     d_tx_bytes_VO: 1140594
     d_tx_mpdus_queued_BE: 0
     d_tx_mpdus_queued_BK: 0
     d_tx_mpdus_queued_VI: 0
     d_tx_mpdus_queued_VO: 5562
     d_tx_mpdus_completed_BE: 0
     d_tx_mpdus_completed_BK: 0
     d_tx_mpdus_completed_VI: 0
     d_tx_mpdus_completed_VO: 5677
     d_tx_mpdu_xretries_BE: 0
     d_tx_mpdu_xretries_BK: 0
     d_tx_mpdu_xretries_VI: 0
     d_tx_mpdu_xretries_VO: 5
     d_tx_aggregates_BE: 0
     d_tx_aggregates_BK: 0
     d_tx_aggregates_VI: 0
     d_tx_aggregates_VO: 0
     d_tx_ampdus_queued_hw_BE: 0
     d_tx_ampdus_queued_hw_BK: 0
     d_tx_ampdus_queued_hw_VI: 0
     d_tx_ampdus_queued_hw_VO: 0
     d_tx_ampdus_completed_BE: 0
     d_tx_ampdus_completed_BK: 0
     d_tx_ampdus_completed_VI: 0
     d_tx_ampdus_completed_VO: 0
     d_tx_ampdu_retries_BE: 0
     d_tx_ampdu_retries_BK: 0
     d_tx_ampdu_retries_VI: 0
     d_tx_ampdu_retries_VO: 0
     d_tx_ampdu_xretries_BE: 0
     d_tx_ampdu_xretries_BK: 0
     d_tx_ampdu_xretries_VI: 0
     d_tx_ampdu_xretries_VO: 0
     d_tx_fifo_underrun_BE: 0
     d_tx_fifo_underrun_BK: 0
     d_tx_fifo_underrun_VI: 0
     d_tx_fifo_underrun_VO: 0
     d_tx_op_exceeded_BE: 0
     d_tx_op_exceeded_BK: 0
     d_tx_op_exceeded_VI: 0
     d_tx_op_exceeded_VO: 0
     d_tx_timer_expiry_BE: 0
     d_tx_timer_expiry_BK: 0
     d_tx_timer_expiry_VI: 0
     d_tx_timer_expiry_VO: 0
     d_tx_desc_cfg_err_BE: 0
     d_tx_desc_cfg_err_BK: 0
     d_tx_desc_cfg_err_VI: 0
     d_tx_desc_cfg_err_VO: 0
     d_tx_data_underrun_BE: 0
     d_tx_data_underrun_BK: 0
     d_tx_data_underrun_VI: 0
     d_tx_data_underrun_VO: 0
     d_tx_delim_underrun_BE: 0
     d_tx_delim_underrun_BK: 0
     d_tx_delim_underrun_VI: 0
     d_tx_delim_underrun_VO: 0
     d_rx_crc_err: 26504
     d_rx_decrypt_crc_err: 0
     d_rx_phy_err: 1835
     d_rx_mic_err: 0
     d_rx_pre_delim_crc_err: 0
     d_rx_post_delim_crc_err: 1064
     d_rx_decrypt_busy_err: 0
     d_rx_phyerr_radar: 0
     d_rx_phyerr_ofdm_timing: 0
     d_rx_phyerr_cck_timing: 0
```