### PR TITLE
ibrcommon: Backport patch fixing compilation without deprecated APIs

### DIFF
--- a/libs/ibrcommon/Makefile
+++ b/libs/ibrcommon/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ibrcommon
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.ibr.cs.tu-bs.de/projects/ibr-dtn/releases

--- a/libs/ibrcommon/patches/020-openssl-deprecated.patch
+++ b/libs/ibrcommon/patches/020-openssl-deprecated.patch
@@ -1,0 +1,25 @@
+--- a/ibrcommon/ssl/TLSStream.cpp
++++ b/ibrcommon/ssl/TLSStream.cpp
+@@ -259,16 +259,22 @@ namespace ibrcommon
+ 		/* openssl initialization */
+ 		/* the if block is needed because SSL_library_init() is not reentrant */
+ 		if(!_SSL_initialized){
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 			SSL_load_error_strings();
+ 			SSL_library_init();
+ 			ERR_load_BIO_strings();
+ 			ERR_load_SSL_strings();
++#endif
+ 			_SSL_initialized = true;
+ 		}
+ 
+ 
+ 		/* create ssl context and throw exception if it fails */
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 		_ssl_ctx = SSL_CTX_new(TLSv1_method());
++#else
++		_ssl_ctx = SSL_CTX_new(TLS_method());
++#endif
+ 		if(!_ssl_ctx){
+ 			char err_buf[ERR_BUF_SIZE];
+ 			ERR_error_string_n(ERR_get_error(), err_buf, ERR_BUF_SIZE);


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @morgenroth 
Compile tested: ar71xx