### PR TITLE
netdata: update to version 1.11.1

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.11.0
+PKG_VERSION:=1.11.1
 PKG_RELEASE:=1
 PKG_MAINTAINER:=
-PKG_LICENSE:=GPL-3.0
+PKG_LICENSE:=GPL-3.0+
 PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/netdata/netdata/releases/download/v$(PKG_VERSION)
-PKG_HASH:=c42c8411c22c72e3e52fed38d7b9537bcfaf568d01e9c1e35ec645490627619d
+PKG_HASH:=0150b2a060da0e5cc844bd9540d6704cd352c434ea1bb9d5268131830a815736
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)_rolling
 
 PKG_INSTALL:=1
@@ -74,7 +74,6 @@ define Package/netdata/install
 	$(INSTALL_DIR) $(1)/usr/share/netdata
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/netdata $(1)/usr/share
 	rm -rf $(1)/usr/share/netdata/web/images
-	rm -rf $(1)/usr/share/netdata/web/old
 	rm $(1)/usr/share/netdata/web/demo*html
 	rm $(1)/usr/share/netdata/web/fonts/*.svg
 	rm $(1)/usr/share/netdata/web/fonts/*.ttf

--- a/admin/netdata/files/netdata.conf
+++ b/admin/netdata/files/netdata.conf
@@ -1,83 +1,24 @@
-# netdata configuration
+# Full configuration can be retrieved from the running
+# server at http://localhost:19999/netdata.conf
 #
-# You can download the latest version of this file, using:
+# Example:
+#   curl -o /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
 #
-#  wget -O /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
-# or
-#  curl -o /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
-#
-# You can uncomment and change any of the options below.
-# The value shown in the commented settings, is the default value.
-#
-
-# global netdata configuration
 
 [global]
-	# glibc malloc arena max for plugins = 1
-	# hostname = LEDE
-	# history = 4036
 	update every = 2
-	# config directory = /etc/netdata
-	# log directory = /var/log/netdata
-	# web files directory = /usr/share/netdata/web
-	# cache directory = /var/cache/netdata
-	# lib directory = /var/lib/netdata
-	# home directory = /var/cache/netdata
-	# plugins directory = "/usr/lib/netdata/plugins.d" "/etc/netdata/custom-plugins.d"
-	# memory mode = save
-	# host access prefix = 
 	memory deduplication (ksm) = no
-	# TZ environment variable = :/etc/localtime
-	# timezone = UTC
-	# debug flags = 0x0000000000000000
 	debug log = syslog
 	error log = syslog
 	access log = none
-	# errors flood protection period = 1200
-	# errors to trigger flood protection = 200
 	run as user = root
-	# OOM score = 1000
-	# process scheduling policy = idle
-	# process nice level = 19
-	# pthread stack size = 81920
-	# cleanup obsolete charts after seconds = 3600
-	# gap when lost iterations above = 1
-	# cleanup orphan hosts after seconds = 3600
-	# delete obsolete charts files = yes
-	# delete orphan hosts files = yes
 
 [web]
-	# mode = static-threaded
-	# listen backlog = 4096
-	# default port = 19999
-	# bind to = *
-	# web files owner = nobody
-	# web files group = nogroup
-	# disconnect idle clients after seconds = 60
-	# timeout for first request = 60
-	# respect do not track policy = no
-	# x-frame-options response header = 
 	allow connections from = localhost 10.* 192.168.* 172.16.* 172.17.* 172.18.* 172.19.* 172.20.* 172.21.* 172.22.* 172.23.* 172.24.* 172.25.* 172.26.* 172.27.* 172.28.* 172.29.* 172.30.* 172.31.*
 	allow dashboard from = localhost 10.* 192.168.* 172.16.* 172.17.* 172.18.* 172.19.* 172.20.* 172.21.* 172.22.* 172.23.* 172.24.* 172.25.* 172.26.* 172.27.* 172.28.* 172.29.* 172.30.* 172.31.*
-	# allow badges from = *
-	# allow streaming from = *
-	# allow netdata.conf from = localhost fd* 10.* 192.168.* 172.16.* 172.17.* 172.18.* 172.19.* 172.20.* 172.21.* 172.22.* 172.23.* 172.24.* 172.25.* 172.26.* 172.27.* 172.28.* 172.29.* 172.30.* 172.31.*
-	# enable gzip compression = yes
-	# gzip compression strategy = default
-	# gzip compression level = 3
-	# web server threads = 2
-	# web server max sockets = 512
 
 [plugins]
-	# PATH environment variable = /usr/sbin:/usr/bin:/sbin:/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-	# PYTHONPATH environment variable = 
-	# proc = yes
-	# diskspace = yes
-	# cgroups = yes
-	# tc = yes
-	# idlejitter = yes
-	# enable running new plugins = yes
-	# check for new plugins every = 60
+	cgroups = no
 	apps = no
 	charts.d = no
 	fping = no
@@ -86,36 +27,3 @@
 
 [health]
 	enabled = no
-	# in memory max health log entries = 1000
-	# script to execute on alarm = /usr/lib/netdata/plugins.d/alarm-notify.sh
-	# health configuration directory = /etc/netdata/health.d
-	# run at least every seconds = 10
-	# postpone alarms during hibernation for seconds = 60
-	# rotate log every lines = 2000
-
-
-[statsd]
-	enabled = no
-	# update every (flushInterval) = 1
-	# udp messages to process at once = 10
-	# create private charts for metrics matching = *
-	# max private charts allowed = 200
-	# max private charts hard limit = 1000
-	# private charts memory mode = save
-	# private charts history = 4036
-	# decimal detail = 1000
-	# disconnect idle tcp clients after seconds = 600
-	# private charts hidden = no
-	# histograms and timers percentile (percentThreshold) = 95.00000
-	# add dimension for number of events received = yes
-	# gaps on gauges (deleteGauges) = no
-	# gaps on counters (deleteCounters) = no
-	# gaps on meters (deleteMeters) = no
-	# gaps on sets (deleteSets) = no
-	# gaps on histograms (deleteHistograms) = no
-	# gaps on timers (deleteTimers) = no
-	# statsd server max TCP sockets = 256
-	# listen backlog = 4096
-	# default port = 8125
-	# bind to = udp:localhost tcp:localhost
-

--- a/admin/netdata/patches/001-disable-plugins-by-default.patch
+++ b/admin/netdata/patches/001-disable-plugins-by-default.patch
@@ -1,5 +1,3 @@
-diff --git a/collectors/charts.d.plugin/charts.d.conf b/collectors/charts.d.plugin/charts.d.conf
-index acb2a6f..8111859 100644
 --- a/collectors/charts.d.plugin/charts.d.conf
 +++ b/collectors/charts.d.plugin/charts.d.conf
 @@ -30,7 +30,7 @@
@@ -11,8 +9,6 @@ index acb2a6f..8111859 100644
  
  # BY DEFAULT ENABLED MODULES
  # ap=yes
-diff --git a/collectors/python.d.plugin/python.d.conf b/collectors/python.d.plugin/python.d.conf
-index 97f4cb8..001a3f1 100644
 --- a/collectors/python.d.plugin/python.d.conf
 +++ b/collectors/python.d.plugin/python.d.conf
 @@ -7,7 +7,7 @@

--- a/admin/netdata/patches/002-force-python3.patch
+++ b/admin/netdata/patches/002-force-python3.patch
@@ -1,5 +1,3 @@
-diff --git a/collectors/python.d.plugin/python.d.plugin.in b/collectors/python.d.plugin/python.d.plugin.in
-index 7ac03fd..d0a3f19 100755
 --- a/collectors/python.d.plugin/python.d.plugin.in
 +++ b/collectors/python.d.plugin/python.d.plugin.in
 @@ -1,6 +1,4 @@


### PR DESCRIPTION
Maintainer: none (previous @diizzyy)
Compiled tested: cortexa53, Turris MOX, OpenWrt 18.06.1
(hash: https://github.com/openwrt/openwrt/commit/493c1d17663dbfdaf23304994e71280400493fc2 and packages hash: 890c302e1a92a493f20798c1bfb164793167b961)
Run tested: cortexa53, Turris MOX, OpenWrt 18.06.1
(hash: https://github.com/openwrt/openwrt/commit/493c1d17663dbfdaf23304994e71280400493fc2 and packages hash: 890c302e1a92a493f20798c1bfb164793167b961)

Description:
together with an update to version 1.11.1,  I have removed this row:
`rm -rf $(1)/usr/share/netdata/web/old`, because this is no longer necessary as it was removed in version [1.11.0](https://github.com/netdata/netdata/pull/3767/commits/4b20cd6260c2acde5faea5d6c58a8c1167b74535) and updated license as [they're using GPL-3.0-or-later](https://github.com/netdata/netdata/blob/master/LICENSE).