### PR TITLE
findutils: polishing of Makefile

### DIFF
--- a/utils/findutils/Makefile
+++ b/utils/findutils/Makefile
@@ -8,7 +8,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=findutils
 PKG_VERSION:=4.6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
+
+PKG_LICENSE:=GPL-3.0+
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -20,9 +22,10 @@ PKG_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 
 define Package/findutils/Default
-	TITLE:=GNU findutils
+	TITLE:=GNU Find Utilities
 	SECTION:=utils
 	CATEGORY:=Utilities
+	URL:=https://www.gnu.org/software/findutils/
 endef
 
 define Package/findutils/description/Default
@@ -32,56 +35,55 @@ sufficient functionality, but some users may want or need
 the full functionality of the GNU tools.
 endef
 
+define Package/findutils
+	$(call Package/findutils/Default)
+	TITLE+= (all)
+	DEPENDS:= \
+	+findutils-find \
+	+findutils-xargs \
+	+findutils-locate
+endef
+
 define Package/findutils-find
 	$(call Package/findutils/Default)
-	TITLE+= (find)
-endef
-
-define Package/findutils-find/description
-$(call Package/findutils/description/Default)
-This package contains the find utility
-endef
-
-define Package/findutils-xargs
-	$(call Package/findutils/Default)
-	TITLE := (xargs)
-endef
-
-define Package/findutils-xargs/description
-$(call Package/findutils/description/Default)
-This package contains the xargs utility
+	TITLE+= - find utility
 endef
 
 define Package/findutils-locate
 	$(call Package/findutils/Default)
-	TITLE := (locate)
+	TITLE+= - locate and updatedb utility
 endef
 
-define Package/findutils-locate/description
-$(call Package/findutils/description/Default)
-This package contains the locate and related updatedb utility
+define Package/findutils-xargs
+	$(call Package/findutils/Default)
+	TITLE+= - xargs utility
 endef
 
 CONFIGURE_ARGS += --localstatedir=/srv/var
 CONFIGURE_VARS += ac_cv_path_SORT=sort
 
-define Package/findutils-find/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/find $(1)/usr/bin/	
+define Package/findutils/install
+	true
 endef
 
-define Package/findutils-xargs/install
+define Package/findutils-find/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/xargs $(1)/usr/bin/	
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/find $(1)/usr/bin/
 endef
 
 define Package/findutils-locate/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/srv/var
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/locate $(1)/usr/bin/	
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/updatedb $(1)/usr/bin/	
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/locate $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/updatedb $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib $(1)/usr/
 endef
 
+define Package/findutils-xargs/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/xargs $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,findutils))
 $(eval $(call BuildPackage,findutils-find))
-$(eval $(call BuildPackage,findutils-xargs))
 $(eval $(call BuildPackage,findutils-locate))
+$(eval $(call BuildPackage,findutils-xargs))


### PR DESCRIPTION
Maintainer: none (previous @cshoredaniel)
Compile tested:
mvebu, Turris Omnia, OpenWRT 15.05
Run tested:
mvebu, Turris Omnia, OpenWRT 15.05

**Description of most interesting changes:**

- added license
- added URL
- removed descriptions of individual packages
- added 'dummy' package: findutils, which contains 3 dependencies: find, xargs, locate

In future, I'd like to separate locate into 2 separates packages: **locate** and **updatedb**, but I'm not sure about it if somebody can use updatedb alone without locate or somebody can install first locate, uninstall it and then updatedb.

It is a little bit complicated. I was thinking that I will drop all dependencies and provide just findutils.
however, I understand that some devices, which are using OpenWRT don't have enough space to install full-powered findutils, which means things get even more complicated.

_Right now, IPKs are large:_
- findutils-find 112K
- findutils-locate 91K
- findutils-xargs 27K
- findutils 922 bytes

When do you install findutils-updatedb and try to do run _updatedb_, it says:
`updatedb needs to be able to execute /usr/bin/find, but cannot.`

However, when you do `updatedb --help`, it works!

Why I'm doing this is because it was reported by one of our users on [our (Turris)](https://forum.turris.cz/t/findutils-locate-broken/8753) forum. 
He installed findutils-locate, but he would like to use it with parameter -fstype, which is not possible as it requires findutils-find. The same bug is in the latest OpenWRT as I have tested it on Turris MOX.

That's why come into this approach, which doesn't break anything and some separated packages can be dependencies to findutils-find or to others, which is the largest, so I would be fine if we can drop dependencies and provide just one package, which will do it easy for users.