### PR TITLE
python-crypgoraphy: Update to 2.4.2

### DIFF
--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptography
-PKG_VERSION:=2.4.1
+PKG_VERSION:=2.4.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=cryptography-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= https://files.pythonhosted.org/packages/source/c/cryptography
-PKG_HASH:=e85b410885addaeb31a867eabcefc9ef4a7e904ad45eac9e60a763a54b244626
+PKG_HASH:=05a6052c6a9f17ff78ba78f8e6eb1d777d25db3b763343a1ae89a7a8670386dd
 
 PKG_LICENSE:=Apache-2.0 BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.APACHE LICENSE.BSD

--- a/lang/python/python-cryptography/patches/001-disable-setup-requirements.patch
+++ b/lang/python/python-cryptography/patches/001-disable-setup-requirements.patch
@@ -1,6 +1,6 @@
 --- a/setup.py
 +++ b/setup.py
-@@ -235,6 +235,7 @@ class DummyPyTest(test):
+@@ -243,6 +243,7 @@ class DummyPyTest(test):
  with open(os.path.join(base_dir, "README.rst")) as f:
      long_description = f.read()
  

--- a/lang/python/python-cryptography/patches/002-remove-undefined-dtls-methods.patch
+++ b/lang/python/python-cryptography/patches/002-remove-undefined-dtls-methods.patch
@@ -12,7 +12,7 @@ diff --git a/src/_cffi_src/openssl/ssl.py b/src/_cffi_src/openssl/ssl.py
 index c921dbee..f0b8939c 100644
 --- a/src/_cffi_src/openssl/ssl.py
 +++ b/src/_cffi_src/openssl/ssl.py
-@@ -714,7 +714,7 @@ static const long TLS_ST_BEFORE = 0;
+@@ -709,7 +709,7 @@ static const long TLS_ST_BEFORE = 0;
  static const long TLS_ST_OK = 0;
  #endif
  
@@ -21,6 +21,3 @@ index c921dbee..f0b8939c 100644
  static const long Cryptography_HAS_GENERIC_DTLS_METHOD = 0;
  const SSL_METHOD *(*DTLS_method)(void) = NULL;
  const SSL_METHOD *(*DTLS_server_method)(void) = NULL;
--- 
-2.19.1
-


### PR DESCRIPTION
Removed upstream patch.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @commodo @jefferyto 
Compile tested: ar71xx
