### PR TITLE
grilo: Fix build dependency on perl-xml-parser

### DIFF
--- a/multimedia/grilo/Makefile
+++ b/multimedia/grilo/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grilo
 PKG_VERSION:=0.3.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -20,7 +20,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/grilo/0.3/
 PKG_HASH:=1e65ca82dd58020451417fde79310d4b940adc3f63ab59997419c52ed3bc9c91
 
-PKG_BUILD_DEPENDS:=glib2 libsoup libxml2 perl-xml-parser
+PKG_BUILD_DEPENDS:=glib2 libsoup libxml2
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/multimedia/grilo/patches/010-remove-xml-parser.patch
+++ b/multimedia/grilo/patches/010-remove-xml-parser.patch
@@ -1,0 +1,19 @@
+--- a/configure
++++ b/configure
+@@ -14433,16 +14433,6 @@ else
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $IT_PERL_VERSION" >&5
+ $as_echo "$IT_PERL_VERSION" >&6; }
+ fi
+-if test "x" != "xno-xml"; then
+-   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for XML::Parser" >&5
+-$as_echo_n "checking for XML::Parser... " >&6; }
+-   if `$INTLTOOL_PERL -e "require XML::Parser" 2>/dev/null`; then
+-       { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
+-$as_echo "ok" >&6; }
+-   else
+-       as_fn_error $? "XML::Parser perl module is required for intltool" "$LINENO" 5
+-   fi
+-fi
+ 
+ # Substitute ALL_LINGUAS so we can use it in po/Makefile
+ 


### PR DESCRIPTION
The depends should be on the host build.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 

This may finally fix the buildbots.
