### PR TITLE
tiff: disable ZSTD and WebP codecs explicitly

### DIFF
--- a/libs/tiff/Makefile
+++ b/libs/tiff/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tiff
 PKG_VERSION:=4.0.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.osgeo.org/libtiff
@@ -32,7 +32,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/tiff/Default
   TITLE:=TIFF
-  URL:=http://www.remotesensing.org/libtiff/
+  URL:=http://simplesystems.org/libtiff/
   MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 endef
 
@@ -75,6 +75,8 @@ CONFIGURE_ARGS += \
 	--enable-jpeg \
 	--disable-old-jpeg \
 	--disable-jbig \
+	--disable-webp \
+	--disable-zstd \
 	--without-x
 
 define Build/InstallDev/hxx


### PR DESCRIPTION
tiff 4.0.10 added two new compression codecs, ZSTD and WebP. If the
respective libraries are found, these codecs will be built. Currently
they're not built, because these libraries do not exist in OpenWrt.

This commit adds the configure switches to disable these codecs. It's
likely that any of these libs will make their way into OpenWrt sooner or
later, so this commit prevents the related build failures (missing
depends).

If there is a need to enable these codecs in tiff in the future, then
this can be done, obviously, but at least there will be no build failure
suprises in the meantime.

Also, this commit corrects the homepage of libtiff.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @jslachta 
Compile tested: ar71xx
Run tested: N/A

Description:
Hi Jiri,

This forcibly disables some codecs which aren't build currently anyway. Also updates the upstream homepage.

Kind regards,
Seb