### PR TITLE
libnopoll: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/libs/libnopoll/Makefile
+++ b/libs/libnopoll/Makefile
@@ -9,23 +9,20 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nopoll
 PKG_VERSION:=0.4.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/ASPLes/nopoll.git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=5cf7c10c3b0b758ad254504bf0ae7e600b118528
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
-PKG_MIRROR_HASH:=fae82c7c711520be07ed4e9828724d0a8ee5de7d7b4395e4ac9f72da25fcc524
+PKG_SOURCE_URL:=https://codeload.github.com/ASPLes/nopoll/tar.gz/$(PKG_VERSION)?
+PKG_SOURCE:=nopoll-$(PKG_VERSION).tar.gz
+PKG_HASH:=16eae3885d572495ba1f22d85fa9032139c761fb21ef1d80205039acd3143f5a
+PKG_BUILD_DIR:=$(BUILD_DIR)/nopoll-$(PKG_VERSION)
 
 PKG_MAINTAINER:=John Clark <inindev@gmail.com>
+PKG_LICENSE:=LGPL-2.1
+PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-
-PKG_LICENSE:=LGPL-2.1
-PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -34,7 +31,7 @@ define Package/libnopoll
   CATEGORY:=Libraries
   DEPENDS:=+libopenssl
   TITLE:=noPoll C WebSocket Library
-  URL:=http://www.aspl.es/nopoll
+  URL:=https://www.aspl.es/nopoll
 endef
 
 define Package/libnopoll/description

--- a/libs/libnopoll/patches/010-openssl-deprecated.patch
+++ b/libs/libnopoll/patches/010-openssl-deprecated.patch
@@ -1,0 +1,87 @@
+diff --git a/src/nopoll.c b/src/nopoll.c
+index d4b50f3..3603f41 100644
+--- a/src/nopoll.c
++++ b/src/nopoll.c
+@@ -868,9 +868,11 @@ void nopoll_cleanup_library (void)
+ {
+ 	
+ 	if (__nopoll_tls_was_init) {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 		EVP_cleanup ();
+ 		CRYPTO_cleanup_all_ex_data ();
+ 		ERR_free_strings ();
++#endif
+ 
+ 		/* notify the library isn't initialized */
+ 		__nopoll_tls_was_init = nopoll_false;
+diff --git a/src/nopoll_conn.c b/src/nopoll_conn.c
+index 0b85382..1770723 100644
+--- a/src/nopoll_conn.c
++++ b/src/nopoll_conn.c
+@@ -1380,7 +1380,9 @@ noPollConn * nopoll_conn_tls_new (noPollCtx  * ctx,
+ 	/* init ssl ciphers and engines */
+ 	if (! __nopoll_tls_was_init) {
+ 		__nopoll_tls_was_init = nopoll_true;
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 		SSL_library_init ();
++#endif
+ 	} /* end if */
+ 
+ 	/* call common implementation */
+@@ -1426,7 +1428,9 @@ noPollConn * nopoll_conn_tls_new6 (noPollCtx  * ctx,
+ 	/* init ssl ciphers and engines */
+ 	if (! __nopoll_tls_was_init) {
+ 		__nopoll_tls_was_init = nopoll_true;
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 		SSL_library_init ();
++#endif
+ 	} /* end if */
+ 
+ 	/* call common implementation */
+@@ -1495,7 +1499,9 @@ noPollConn * nopoll_conn_tls_new_with_socket (noPollCtx  * ctx,
+ 	/* init ssl ciphers and engines */
+ 	if (! __nopoll_tls_was_init) {
+ 		__nopoll_tls_was_init = nopoll_true;
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 		SSL_library_init ();
++#endif
+ 	} /* end if */
+ 
+ 	/* call common implementation */
+@@ -4755,7 +4761,9 @@ nopoll_bool __nopoll_conn_accept_complete_common (noPollCtx * ctx, noPollConnOpt
+ 		/* init ssl ciphers and engines */
+ 		if (! __nopoll_tls_was_init) {
+ 			__nopoll_tls_was_init = nopoll_true;
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 			SSL_library_init ();
++#endif
+ 		} /* end if */
+ 
+ 		/* now configure chainCertificate */
+diff --git a/src/nopoll_decl.h b/src/nopoll_decl.h
+index bfe496e..b0ce535 100644
+--- a/src/nopoll_decl.h
++++ b/src/nopoll_decl.h
+@@ -511,20 +511,18 @@ typedef enum {
+ 	 * established with this method will only understand this
+ 	 * method.
+ 	 */
+-	NOPOLL_METHOD_TLSV1_1     = 5
++	NOPOLL_METHOD_TLSV1_1     = 5,
+ #endif
+ #if defined(NOPOLL_HAVE_TLSv12_ENABLED)
+-	,
+ 	/** 
+ 	 * @brief Allows to define TLSv1.2 as SSL protocol used by the
+ 	 * client or server connection. A connection/listener
+ 	 * established with this method will only understand this
+ 	 * method.
+ 	 */
+-	NOPOLL_METHOD_TLSV1_2     = 6
++	NOPOLL_METHOD_TLSV1_2     = 6,
+ #endif
+ #if defined(NOPOLL_HAVE_TLS_FLEXIBLE_ENABLED)
+-	,
+ 	/** 
+ 	 * @brief Allows to define TLS flexible negotiation where the
+ 	 * highest version available will be negotiated by both


### PR DESCRIPTION
Switched to codeload for simplicity and consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @inindev 
Compile tested: ar71xx
