### PR TITLE
nail: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/mail/nail/Makefile
+++ b/mail/nail/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nail
 PKG_VERSION:=12.5
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_LICENSE:=BSD-2-Clause
 
 PKG_SOURCE:=heirloom-mailx_$(PKG_VERSION).orig.tar.gz

--- a/mail/nail/patches/300-openssl-deprecated.patch
+++ b/mail/nail/patches/300-openssl-deprecated.patch
@@ -1,0 +1,47 @@
+--- a/openssl.c
++++ b/openssl.c
+@@ -174,7 +174,9 @@ ssl_init(void)
+ {
+ 	verbose = value("verbose") != NULL;
+ 	if (initialized == 0) {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 		SSL_library_init();
++#endif
+ 		initialized = 1;
+ 	}
+ 	if (rand_init == 0)
+@@ -215,12 +217,13 @@ ssl_verify_cb(int success, X509_STORE_CTX *store)
+ static const SSL_METHOD *
+ ssl_select_method(const char *uhp)
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	const SSL_METHOD *method;
+ 	char	*cp;
+ 
+ 	cp = ssl_method_string(uhp);
+ 	if (cp != NULL) {
+-#if !defined(OPENSSL_NO_SSL2) && !OPENSSL_VERSION_NUMBER >= 0x10100000L
++#ifndef OPENSSL_NO_SSL2
+ 		if (equal(cp, "ssl2"))
+ 			method = SSLv2_client_method();
+ 		else
+@@ -240,6 +243,9 @@ ssl_select_method(const char *uhp)
+ 	} else
+ 		method = SSLv23_client_method();
+ 	return method;
++#else
++	return TLS_client_method();
++#endif
+ }
+ 
+ static void 
+@@ -427,7 +433,9 @@ ssl_gen_err(const char *fmt, ...)
+ 	va_start(ap, fmt);
+ 	vfprintf(stderr, fmt, ap);
+ 	va_end(ap);
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	SSL_load_error_strings();
++#endif
+ 	fprintf(stderr, ": %s\n",
+ 			(ERR_error_string(ERR_get_error(), NULL)));
+ }


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @pfzim 
Compile tested: ar71xx

This package should probably be replaced by s-nail given how abandoned it is. Debian and Arch Linux have already done so. Thoughts?