### PR TITLE
aria2: code size optimizations and build-parallel

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -80,6 +80,9 @@ CONFIGURE_ARGS += \
 	--without-libuv \
 	--with-libz
 
+TARGET_CXXFLAGS += -ffunction-sections -fdata-sections -flto
+TARGET_LDFLAGS += -Wl,--gc-sections -flto
+
 define Package/aria2/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/aria2c $(1)/usr/bin

--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -14,6 +14,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/
 PKG_HASH:=3a44a802631606e138a9e172a3e9f5bcbaac43ce2895c1d8e2b46f30487e77a3
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 PKG_MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>, \
 	Hsing-Wang Liao <kuoruan@gmail.com>


### PR DESCRIPTION
Maintainer: @kuoruan 
Compile tested: ar71xx, mvebu, OpenWrt master
Run tested: mvebu, OpenWrt master

Description:
Enable LTO and sections garbage collection, reducing binary size by 22%
Enable `PKG_BUILD_PARALLEL`