### PR TITLE
netopeer2: enable callhome by default

### DIFF
--- a/net/Netopeer2/Makefile
+++ b/net/Netopeer2/Makefile
@@ -11,6 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Netopeer2
 PKG_VERSION:=0.7-r1
+PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>

--- a/net/Netopeer2/files/netopeer2-server.default
+++ b/net/Netopeer2/files/netopeer2-server.default
@@ -28,6 +28,10 @@ if [ -x /bin/sysrepoctl ]; then
 		sysrepoctl --install --yang=/etc/sysrepo/yang/ietf-netconf-server@2016-11-02.yang -o root:root -p 600
 		sysrepoctl -m ietf-netconf-server -e listen
 		sysrepoctl -m ietf-netconf-server -e ssh-listen
+		sysrepoctl -m ietf-netconf-server -e tls-listen
+		sysrepoctl -m ietf-netconf-server -e call-home
+		sysrepoctl -m ietf-netconf-server -e ssh-call-home
+		sysrepoctl -m ietf-netconf-server -e tls-call-home
 		if [ -x /bin/sysrepocfg ]; then
 			sysrepocfg -f xml -d startup -i /usr/share/netopeer2-server/stock_config.xml ietf-netconf-server
 			rm /usr/share/netopeer2-server/stock_config.xml


### PR DESCRIPTION
Signed-off-by: Mislav Novakovic <mislav.novakovic@sartura.hr>

Maintainer: me
Compile tested: Broadcom 27xx RPi2 32-bit
Run tested: Broadcom 27xx RPi3 32-bit

Description:
Enabled call home functionality by default in the UCI default script.