### PR TITLE
Batch of cotequeiroz-maintained python packages update

### DIFF
--- a/lang/python/django-formtools/Makefile
+++ b/lang/python/django-formtools/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-formtools
 PKG_VERSION:=2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/4a/86/ccbb8225dec0621f99f7e19f3dea0a629f1e41bd99fd58ac3e2f388e028f
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/${PKG_NAME}
 PKG_HASH:=7703793f1675aa6e871f9fed147e8563816d7a5b9affdc5e3459899596217f7c
 
 include $(INCLUDE_DIR)/package.mk
@@ -27,6 +27,7 @@ define Package/django-formtools
   TITLE:=A set of high-level abstractions for Django forms
   URL:=https://django-formtools.readthedocs.io/en/latest/
   DEPENDS:=+python +django
+  VARIANT:=python
 endef
 
 define Package/django-formtools/description
@@ -34,15 +35,6 @@ define Package/django-formtools/description
   Currently for form previews and multi-step forms.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/django-formtools/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,django-formtools))
 $(eval $(call BuildPackage,django-formtools))
+$(eval $(call BuildPackage,django-formtools-src))

--- a/lang/python/django-ranged-response/Makefile
+++ b/lang/python/django-ranged-response/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-ranged-response
 PKG_VERSION:=0.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/70/e3/9372fcdca8e9c3205e7979528ccd1a14354a9a24d38efff11c1846ff8bf1
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/${PKG_NAME}
 PKG_HASH:=f71fff352a37316b9bead717fc76e4ddd6c9b99c4680cdf4783b9755af1cf985
 
 include $(INCLUDE_DIR)/package.mk
@@ -27,21 +27,13 @@ define Package/django-ranged-response
   TITLE:=Modified Django FileResponse that adds Content-Range headers.
   URL:=https://github.com/wearespindle/django-ranged-fileresponse
   DEPENDS:=+python +django
+  VARIANT:=python
 endef
 
 define Package/django-ranged-response/description
   Modified Django FileResponse that adds Content-Range headers.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/django-ranged-response/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,django-ranged-response))
 $(eval $(call BuildPackage,django-ranged-response))
+$(eval $(call BuildPackage,django-ranged-response-src))

--- a/lang/python/django-simple-captcha/Makefile
+++ b/lang/python/django-simple-captcha/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-simple-captcha
 PKG_VERSION:=0.5.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/d7/f4/ea95b04ed3abc7bf225716f17e35c5a185f6100db4d7541a46696ce40351
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/${PKG_NAME}
 PKG_HASH:=0c30a14f02502119fd1a4d308dd5d2b899d0f4284825a396bbb010afd904754a
 
 include $(INCLUDE_DIR)/package.mk
@@ -27,6 +27,7 @@ define Package/django-simple-captcha
   TITLE:=A very simple, yet powerful, Django captcha application
   URL:=https://github.com/mbi/django-simple-captcha
   DEPENDS:=+python +python-six +django +pillow +django-ranged-response
+  VARIANT:=python
 endef
 
 define Package/django-simple-captcha/description
@@ -34,15 +35,6 @@ define Package/django-simple-captcha/description
   application to add captcha images to any Django form.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/django-simple-captcha/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,django-simple-captcha))
 $(eval $(call BuildPackage,django-simple-captcha))
+$(eval $(call BuildPackage,django-simple-captcha-src))

--- a/lang/python/django-webpack-loader/Makefile
+++ b/lang/python/django-webpack-loader/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-webpack-loader
 PKG_VERSION:=0.6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/ff/0f/e812908c5dcc7c8cac5beba2cddd14bbfe045496117b3d306a71b19fc828
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/${PKG_NAME}
 PKG_HASH:=60bab6b9a037a5346fad12d2a70a6bc046afb33154cf75ed640b93d3ebd5f520
 
 include $(INCLUDE_DIR)/package.mk
@@ -27,21 +27,13 @@ define Package/django-webpack-loader
   TITLE:=Transparently use webpack with django
   URL:=https://github.com/owais/django-webpack-loader
   DEPENDS:=+python +django
+  VARIANT:=python
 endef
 
 define Package/django-webpack-loader/description
   Use webpack to generate your static bundles without django’s staticfiles or opaque wrappers.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/django-webpack-loader/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,django-webpack-loader))
 $(eval $(call BuildPackage,django-webpack-loader))
+$(eval $(call BuildPackage,django-webpack-loader-src))

--- a/lang/python/pyjwt/Makefile
+++ b/lang/python/pyjwt/Makefile
@@ -8,41 +8,55 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pyjwt
-PKG_VERSION:=1.6.4
+PKG_VERSION:=1.7.0
 PKG_RELEASE:=1
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=PyJWT-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/00/5e/b358c9bb24421e6155799d995b4aa3aa3307ffc7ecae4ad9d29fd7e07a73
-PKG_HASH:=4ee413b357d53fd3fb44704577afac88e72e878716116270d722723d65b42176
-PKG_BUILD_DIR:=$(BUILD_DIR)/PyJWT-$(PKG_VERSION)
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/P/PyJWT
+PKG_HASH:=ddec8409c57e9d371c6006e388f91daf3b0b43bdf9fcbf99451fb7cf5ce0a86d
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-PyJWT-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/pyjwt
+define Package/python-pyjwt/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
   TITLE:=JSON Web Token implementation in Python
   URL:=http://github.com/jpadilla/pyjwt
-  DEPENDS:=+python
 endef
 
-define Package/pyjwt/description
+define Package/python-pyjwt
+  $(call Package/python-pyjwt/Default)
+  DEPENDS:=+PACKAGE_python-pyjwt:python
+  VARIANT:=python
+endef
+
+define Package/python3-pyjwt
+  $(call Package/python-pyjwt/Default)
+  DEPENDS:=+PACKAGE_python3-pyjwt:python3
+  VARIANT:=python3
+endef
+
+define Package/python-pyjwt/description
   A Python implementation of RFC 7519.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-pyjwt/description
+$(call Package/python-pyjwt/description)
+.
+(Variant for Python3)
 endef
 
-define Package/pyjwt/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
+$(eval $(call PyPackage,python-pyjwt))
+$(eval $(call BuildPackage,python-pyjwt))
+$(eval $(call BuildPackage,python-pyjwt-src))
 
-$(eval $(call BuildPackage,pyjwt))
+$(eval $(call Py3Package,python3-pyjwt))
+$(eval $(call BuildPackage,python3-pyjwt))
+$(eval $(call BuildPackage,python3-pyjwt-src))

--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -8,26 +8,39 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
-PKG_VERSION:=2018.10.15
+PKG_VERSION:=2018.11.29
 PKG_RELEASE:=1
 PKG_LICENSE:=MPL-2.0
 
 PKG_SOURCE:=certifi-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/certifi
-PKG_HASH:=6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a
-PKG_BUILD_DIR:=$(BUILD_DIR)/certifi-$(PKG_VERSION)
+PKG_HASH:=47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-certifi-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/python-certifi
+define Package/python-certifi/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
   TITLE:=Python package for providing Mozilla's CA Bundle.
   URL:=http://certifi.io/
-  DEPENDS:=+python
+endef
+
+define Package/python-certifi
+  $(call Package/python-certifi/Default)
+  DEPENDS:=+PACKAGE_python-certifi:python-light
+  VARIANT:=python
+endef
+
+define Package/python3-certifi
+  $(call Package/python-certifi/Default)
+  DEPENDS:=+PACKAGE_python3-certifi:python3-light
+  VARIANT:=python3
 endef
 
 define Package/python-certifi/description
@@ -35,15 +48,16 @@ define Package/python-certifi/description
   trustworthiness of SSL certificates while verifying the identity of TLS hosts.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-certifi/description
+$(call Package/python-certifi/description)
+.
+(Variant for Python3)
 endef
 
-define Package/python-certifi/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,python-certifi))
 $(eval $(call BuildPackage,python-certifi))
+$(eval $(call BuildPackage,python-certifi-src))
+
+$(eval $(call Py3Package,python3-certifi))
+$(eval $(call BuildPackage,python3-certifi))
+$(eval $(call BuildPackage,python3-certifi-src))

--- a/lang/python/python-oauthlib/Makefile
+++ b/lang/python/python-oauthlib/Makefile
@@ -9,40 +9,54 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-oauthlib
 PKG_VERSION:=2.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=oauthlib-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/df/5f/3f4aae7b28db87ddef18afed3b71921e531ca288dc604eb981e9ec9f8853
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/o/oauthlib
 PKG_HASH:=ac35665a61c1685c56336bda97d5eefa246f1202618a1d6f34fccb1bdd404162
-PKG_BUILD_DIR:=$(BUILD_DIR)/oauthlib-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-oauthlib-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/python-oauthlib
+define Package/python-oauthlib/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
   TITLE:=A generic, spec-compliant, thorough implementation of the OAuth request-signing logic
   URL:=https://github.com/oauthlib/oauthlib
-  DEPENDS:=+python
+endef
+
+define Package/python-oauthlib
+  $(call Package/python-oauthlib/Default)
+  DEPENDS:=+PACKAGE_python-oauthlib:python-light
+  VARIANT:=python
+endef
+
+define Package/python3-oauthlib
+  $(call Package/python-oauthlib/Default)
+  DEPENDS:=+PACKAGE_python3-oauthlib:python3-light
+  VARIANT:=python3
 endef
 
 define Package/python-oauthlib/description
   A generic, spec-compliant, thorough implementation of the OAuth request-signing logic for Python
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-oauthlib/description
+$(call Package/python-oauthlib/description)
+.
+(Variant for Python3)
 endef
 
-define Package/python-oauthlib/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,python-oauthlib))
 $(eval $(call BuildPackage,python-oauthlib))
+$(eval $(call BuildPackage,python-oauthlib-src))
+
+$(eval $(call Py3Package,python3-oauthlib))
+$(eval $(call BuildPackage,python3-oauthlib))
+$(eval $(call BuildPackage,python3-oauthlib-src))

--- a/lang/python/python-requests-oauthlib/Makefile
+++ b/lang/python/python-requests-oauthlib/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-requests-oauthlib
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=ISC
 
 PKG_SOURCE:=requests-oauthlib-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/95/be/072464f05b70e4142cb37151e215a2037b08b1400f8a56f2538b76ca6205
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/r/requests-oauthlib
 PKG_HASH:=8886bfec5ad7afb391ed5443b1f697c6f4ae98d0e5620839d8b4499c032ada3f
 PKG_BUILD_DIR:=$(BUILD_DIR)/requests-oauthlib-$(PKG_VERSION)
 
@@ -27,22 +27,14 @@ define Package/python-requests-oauthlib
   MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
   TITLE:=OAuthlib authentication support for Requests.
   URL:=https://github.com/requests/requests-oauthlib
-  DEPENDS:=+python +python-requests +python-oauthlib +python-cryptography +pyjwt
+  DEPENDS:=+python +python-requests +python-oauthlib +python-cryptography +python-pyjwt
+  VARIANT:=python
 endef
 
 define Package/python-requests-oauthlib/description
   This project provides first-class OAuth library support for Requests.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/python-requests-oauthlib/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,python-requests-oauthlib))
 $(eval $(call BuildPackage,python-requests-oauthlib))
+$(eval $(call BuildPackage,python-requests-oauthlib-src))

--- a/lang/python/python-requests/Makefile
+++ b/lang/python/python-requests/Makefile
@@ -30,21 +30,13 @@ define Package/python-requests
   TITLE:=HTTP library for Python
   URL:=http://python-requests.org/
   DEPENDS:=+python +chardet +python-idna +python-urllib3 +python-certifi
+  VARIANT:=python
 endef
 
 define Package/python-requests/description
   Requests is the only Non-GMO HTTP library for Python, safe for human consumption.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/python-requests/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,python-requests))
 $(eval $(call BuildPackage,python-requests))
+$(eval $(call BuildPackage,python-requests-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: brcm47xx & ramips, openwrt master
Run tested: ramips, openwrt master (python2 only)

Description:
I've updated the Makefiles of the python packages I maintain to use PyPackage, added src packages, and updated download URLs.

The changes are all very similar, basically:

- updating `PKG_SOURCE_URL` from hashes to names
- removing `Build/Compile`, and `Package/`name`/install`, and calling `PyPackage` instead
- adding `BuildPackage,`package`-src`

I also added python3 variants to the packages in which all dependencies can be built with pyhton3.
As a result, pyjwt package was renamed to python-pyjwt, for consistency with python3-pyjwt.  The only package that depends on it is python-requests-oauthlib, which is updated here.

All of the packages are related:  they're dependencies (not necessarily direct) of seafile-server.  So I'm opening a single PR.  If someone object, I can split it into multiple PRs, except for the pyjwt and python-requests-oauthlib, which would have to be commited at the same time because of the name-change.

There are a couple of version bumps:

- pyjwt is being updated to the latest version 1.7.0.

- python-certifi is also bumped to 2018.11.29.