### PR TITLE
django-formtools: use PyPackage to build

### DIFF
--- a/lang/python/django-formtools/Makefile
+++ b/lang/python/django-formtools/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-formtools
 PKG_VERSION:=2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/4a/86/ccbb8225dec0621f99f7e19f3dea0a629f1e41bd99fd58ac3e2f388e028f
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/${PKG_NAME}
 PKG_HASH:=7703793f1675aa6e871f9fed147e8563816d7a5b9affdc5e3459899596217f7c
 
 include $(INCLUDE_DIR)/package.mk
@@ -27,6 +27,7 @@ define Package/django-formtools
   TITLE:=A set of high-level abstractions for Django forms
   URL:=https://django-formtools.readthedocs.io/en/latest/
   DEPENDS:=+python +django
+  VARIANT:=python
 endef
 
 define Package/django-formtools/description
@@ -34,15 +35,6 @@ define Package/django-formtools/description
   Currently for form previews and multi-step forms.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/django-formtools/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,django-formtools))
 $(eval $(call BuildPackage,django-formtools))
+$(eval $(call BuildPackage,django-formtools-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: brcm47xx & ramips, openwrt master
Run tested: ramips

Description:
Updated Makefile to use PyPackage, added option to build source package,
and updated PKG_SOURCE_URL.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
