### PR TITLE
django-ranged-response: use PyPackage to build

### DIFF
--- a/lang/python/django-ranged-response/Makefile
+++ b/lang/python/django-ranged-response/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-ranged-response
 PKG_VERSION:=0.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/70/e3/9372fcdca8e9c3205e7979528ccd1a14354a9a24d38efff11c1846ff8bf1
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/${PKG_NAME}
 PKG_HASH:=f71fff352a37316b9bead717fc76e4ddd6c9b99c4680cdf4783b9755af1cf985
 
 include $(INCLUDE_DIR)/package.mk
@@ -27,21 +27,13 @@ define Package/django-ranged-response
   TITLE:=Modified Django FileResponse that adds Content-Range headers.
   URL:=https://github.com/wearespindle/django-ranged-fileresponse
   DEPENDS:=+python +django
+  VARIANT:=python
 endef
 
 define Package/django-ranged-response/description
   Modified Django FileResponse that adds Content-Range headers.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/django-ranged-response/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,django-ranged-response))
 $(eval $(call BuildPackage,django-ranged-response))
+$(eval $(call BuildPackage,django-ranged-response-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: brcm47xx & ramips, openwrt master
Run tested: ramips

Description:
Updated Makefile to use PyPackage, added option to build source package,
and updated PKG_SOURCE_URL.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>