### PR TITLE
django-simple-captcha: use PyPackage to build

### DIFF
--- a/lang/python/django-simple-captcha/Makefile
+++ b/lang/python/django-simple-captcha/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-simple-captcha
 PKG_VERSION:=0.5.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/d7/f4/ea95b04ed3abc7bf225716f17e35c5a185f6100db4d7541a46696ce40351
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/${PKG_NAME}
 PKG_HASH:=0c30a14f02502119fd1a4d308dd5d2b899d0f4284825a396bbb010afd904754a
 
 include $(INCLUDE_DIR)/package.mk
@@ -27,6 +27,7 @@ define Package/django-simple-captcha
   TITLE:=A very simple, yet powerful, Django captcha application
   URL:=https://github.com/mbi/django-simple-captcha
   DEPENDS:=+python +python-six +django +pillow +django-ranged-response
+  VARIANT:=python
 endef
 
 define Package/django-simple-captcha/description
@@ -34,15 +35,6 @@ define Package/django-simple-captcha/description
   application to add captcha images to any Django form.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/django-simple-captcha/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,django-simple-captcha))
 $(eval $(call BuildPackage,django-simple-captcha))
+$(eval $(call BuildPackage,django-simple-captcha-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: brcm47xx & ramips, openwrt master
Run tested: ramips

Description:
Updated Makefile to use PyPackage, added option to build source package,
and updated PKG_SOURCE_URL.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>