### PR TITLE
django-webpack-loader: use PyPackage to build

### DIFF
--- a/lang/python/django-webpack-loader/Makefile
+++ b/lang/python/django-webpack-loader/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-webpack-loader
 PKG_VERSION:=0.6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/ff/0f/e812908c5dcc7c8cac5beba2cddd14bbfe045496117b3d306a71b19fc828
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/${PKG_NAME}
 PKG_HASH:=60bab6b9a037a5346fad12d2a70a6bc046afb33154cf75ed640b93d3ebd5f520
 
 include $(INCLUDE_DIR)/package.mk
@@ -27,21 +27,13 @@ define Package/django-webpack-loader
   TITLE:=Transparently use webpack with django
   URL:=https://github.com/owais/django-webpack-loader
   DEPENDS:=+python +django
+  VARIANT:=python
 endef
 
 define Package/django-webpack-loader/description
   Use webpack to generate your static bundles without django’s staticfiles or opaque wrappers.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/django-webpack-loader/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,django-webpack-loader))
 $(eval $(call BuildPackage,django-webpack-loader))
+$(eval $(call BuildPackage,django-webpack-loader-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: brcm47xx & ramips, openwrt master
Run tested: ramips

Description:
Updated Makefile to use PyPackage, added option to build source package,
and updated PKG_SOURCE_URL.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>