### PR TITLE
pyjwt: Bump to version 1.7.0 -- python-requests-oathlib:  use PyPackage

### DIFF
--- a/lang/python/pyjwt/Makefile
+++ b/lang/python/pyjwt/Makefile
@@ -8,41 +8,55 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pyjwt
-PKG_VERSION:=1.6.4
+PKG_VERSION:=1.7.0
 PKG_RELEASE:=1
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=PyJWT-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/00/5e/b358c9bb24421e6155799d995b4aa3aa3307ffc7ecae4ad9d29fd7e07a73
-PKG_HASH:=4ee413b357d53fd3fb44704577afac88e72e878716116270d722723d65b42176
-PKG_BUILD_DIR:=$(BUILD_DIR)/PyJWT-$(PKG_VERSION)
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/P/PyJWT
+PKG_HASH:=ddec8409c57e9d371c6006e388f91daf3b0b43bdf9fcbf99451fb7cf5ce0a86d
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-PyJWT-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/pyjwt
+define Package/python-pyjwt/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
   TITLE:=JSON Web Token implementation in Python
   URL:=http://github.com/jpadilla/pyjwt
-  DEPENDS:=+python
 endef
 
-define Package/pyjwt/description
+define Package/python-pyjwt
+  $(call Package/python-pyjwt/Default)
+  DEPENDS:=+PACKAGE_python-pyjwt:python
+  VARIANT:=python
+endef
+
+define Package/python3-pyjwt
+  $(call Package/python-pyjwt/Default)
+  DEPENDS:=+PACKAGE_python3-pyjwt:python3
+  VARIANT:=python3
+endef
+
+define Package/python-pyjwt/description
   A Python implementation of RFC 7519.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-pyjwt/description
+$(call Package/python-pyjwt/description)
+.
+(Variant for Python3)
 endef
 
-define Package/pyjwt/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
+$(eval $(call PyPackage,python-pyjwt))
+$(eval $(call BuildPackage,python-pyjwt))
+$(eval $(call BuildPackage,python-pyjwt-src))
 
-$(eval $(call BuildPackage,pyjwt))
+$(eval $(call Py3Package,python3-pyjwt))
+$(eval $(call BuildPackage,python3-pyjwt))
+$(eval $(call BuildPackage,python3-pyjwt-src))

--- a/lang/python/python-requests-oauthlib/Makefile
+++ b/lang/python/python-requests-oauthlib/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-requests-oauthlib
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=ISC
 
 PKG_SOURCE:=requests-oauthlib-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/95/be/072464f05b70e4142cb37151e215a2037b08b1400f8a56f2538b76ca6205
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/r/requests-oauthlib
 PKG_HASH:=8886bfec5ad7afb391ed5443b1f697c6f4ae98d0e5620839d8b4499c032ada3f
 PKG_BUILD_DIR:=$(BUILD_DIR)/requests-oauthlib-$(PKG_VERSION)
 
@@ -27,22 +27,14 @@ define Package/python-requests-oauthlib
   MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
   TITLE:=OAuthlib authentication support for Requests.
   URL:=https://github.com/requests/requests-oauthlib
-  DEPENDS:=+python +python-requests +python-oauthlib +python-cryptography +pyjwt
+  DEPENDS:=+python +python-requests +python-oauthlib +python-cryptography +python-pyjwt
+  VARIANT:=python
 endef
 
 define Package/python-requests-oauthlib/description
   This project provides first-class OAuth library support for Requests.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/python-requests-oauthlib/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,python-requests-oauthlib))
 $(eval $(call BuildPackage,python-requests-oauthlib))
+$(eval $(call BuildPackage,python-requests-oauthlib-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: brcm47xx & ramips, openwrt master
Run tested: ramips

Description:
PyJWT 1.7.0 brings compatibility with python 3.7.
As a result of building a python3 pacakge, the pithon2 package name was
changed from pyjwt to python-pyjwt.

I've included a commit for python-requests-oathlib here as well, since pyjw was a dependency, and it had the package name changed.
It had its Makefile updated to use PyPackage, added option to build source package,
updated PKG_SOURCE_URL.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>