### PR TITLE
erlang: license corrected

### DIFF
--- a/lang/erlang/Makefile
+++ b/lang/erlang/Makefile
@@ -15,8 +15,8 @@ PKG_SOURCE:=otp_src_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= http://www.erlang.org/download/
 PKG_HASH:=c7d247c0cad2d2e718eaca2e2dff051136a1347a92097abf19ebf65ea2870131
 
-PKG_LICENSE:=ErlPL-1.1
-PKG_LICENSE_FILES:=EPLICENCE
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Arnaud Sautaux <arnaud.sautaux@infoteam.ch>
 
 PKG_BUILD_DEPENDS:=erlang/host openssl


### PR DESCRIPTION
Signed-off-by: Arnaud Sautaux <arnaud.sautaux@infoteam.ch>

Maintainer: @cretingame 
Compile tested: x86 debian 8 , 18.06.1
Run tested: at91, sama5d4, 18.06.1

Description:
To correct the wrong license
https://github.com/openwrt/packages/issues/7549
https://github.com/erlang/otp/blob/master/LICENSE.txt