### PR TITLE
nginx: fix detection of gcc builtin atomic operations

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.15.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://nginx.org/download/

--- a/net/nginx/patches/101-feature_test_fix.patch
+++ b/net/nginx/patches/101-feature_test_fix.patch
@@ -11,6 +11,15 @@
      ngx_feature_libs=
 --- a/auto/cc/conf
 +++ b/auto/cc/conf
+@@ -183,7 +183,7 @@ if [ "$NGX_PLATFORM" != win32 ]; then
+     else
+         ngx_feature="gcc builtin atomic operations"
+         ngx_feature_name=NGX_HAVE_GCC_ATOMIC
+-        ngx_feature_run=yes
++        ngx_feature_run=no
+         ngx_feature_incs=
+         ngx_feature_path=
+         ngx_feature_libs=
 @@ -204,7 +204,7 @@ if [ "$NGX_PLATFORM" != win32 ]; then
      else
          ngx_feature="C99 variadic macros"


### PR DESCRIPTION
Needed by stream module
Fix PR #6740 

Maintainer: @Ansuel 
Compile tested: mvebu
Run tested: mvebu