### PR TITLE
pytz: fix host-compile dependency

### DIFF
--- a/lang/python/pytz/Makefile
+++ b/lang/python/pytz/Makefile
@@ -17,6 +17,7 @@ PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pytz
 PKG_HASH:=31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca
 
 PKG_BUILD_DEPENDS:=python/host
+HOST_BUILD_DEPENDS:=python/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: @kissg1988 
Compile tested: openwrt master
Run tested: N/A

Description:
Add `HOST_BUILD_DEPENDS=python/host`
`make -j5` still tries to build `pytz/host` before `python/host` otherwise.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>