### PR TITLE
wget: disable libpcre2

### DIFF
--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.20
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -66,6 +66,7 @@ endef
 CONFIGURE_ARGS+= \
 	--disable-rpath \
 	--disable-iri \
+	--disable-pcre2 \
 	--with-included-libunistring \
 	--without-libuuid \
 	--without-libpsl


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: ramips, openwrt master

Description:
Current package fails when libpcre2 is built before wget:
```
Package wget is missing dependencies for the following libraries:
libpcre2-8.so.0
```
libpcre2 is preferred by wget's configure, so use `--disable-pcre2` to use libpcre.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>