### PR TITLE
CircleCI: Do not run build as root. Move to public docker repo.

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -14,7 +14,13 @@ subversion \
 time \
 wget \
 zlib1g-dev \
+unzip \
+xz-utils \
 && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -c "OpenWrt Builder" -m -d /home/build -s /bin/bash build
+USER build
+ENV HOME /home/build
 
 # LEDE Build System (LEDE GnuPG key for unattended build jobs)
 RUN curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=gpg/626471F1.asc' | gpg --import \

--- a/.circleci/README
+++ b/.circleci/README
@@ -1,6 +1,6 @@
 # Build/update the docker image
 
 docker pull debian:9
-docker build --rm .
-docker tag <IMAGE ID> docker.io/champtar/openwrtpackagesci:latest
-docker push docker.io/champtar/openwrtpackagesci:latest
+docker build --rm -t docker.io/openwrtorg/packages-cci:latest .
+docker tag <IMAGE ID> docker.io/openwrtorg/packages-cci:<VERSION-TAG>
+docker push docker.io/openwrtorg/packages-cci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: docker.io/champtar/openwrtpackagesci@sha256:96ef72edc70cba371ea5676fba15ee25b3a94f538f648a27454b699edce61da0
+      - image: docker.io/openwrtorg/packages-cci:v1.0.1
     environment:
       - SDK_BASE_URL: "https://downloads.openwrt.org/snapshots/targets/ar71xx/generic"
       - SDK_FILE: "openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64.tar.xz"
@@ -89,6 +89,7 @@ jobs:
           name: Download source/check/compile
           working_directory: ~/build_dir
           command: |
+             set +o pipefail
              PKGS=$(cd ~/openwrt_packages; git diff --diff-filter=d --name-only "origin/$BRANCH..." | grep 'Makefile$' | grep -v '/files/' | awk -F/ '{ print $(NF-1) }')
              if [ -z "$PKGS" ] ; then
                  echo_blue "WARNING: No new or modified packages found!"


### PR DESCRIPTION
Maintainer: @champtar / me 
Run tested: Yes

Description:

Change docker hub repository to 'openwrtorg'.
Create and use non-root user 'build'. Add xz-utils and unzip.
Use version numbers for docker images (SHA has no sense of time).
Disable pipefail in build step

Signed-off-by: Ted Hess \<thess@kitschensync.net>

See Issue #7420 for a description of new Docker Hub organization repository: "openwrtorg"