### PR TITLE
nut: Fix a typo in setting a driver parameter

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -210,7 +210,7 @@ build_global_driver_config() {
 	get_write_driver_config "$cfg" maxretry
 	get_write_driver_config "$cfg" retrydelay
 	get_write_driver_config "$cfg" pollinterval
-	get_write_dirver_config "$cfg" synchronous
+	get_write_driver_config "$cfg" synchronous
 	config_get runas "$cfg" user "nut"
 	RUNAS="$runas"
 


### PR DESCRIPTION
Maintainer: me / @cshoredaniel 
Build & Run Arch/Version: bcm2708 (Raspberryi Pi B+), OpenWrt master, Packages master, LuCI master as of Dec 4 late evening UTC -0500.

Description:

Fix a typo in the setting of a driver parameter.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>