### PR TITLE
nut: Optionally set serial USB to NUT user

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/
@@ -81,6 +81,8 @@ define Package/nut-server/install
 	ln -sf /var/etc/nut/ups.conf $(1)/etc/nut/ups.conf
 	# Mangle libhid.usermap into a format (hotplug shell script) useful for OpenWrt
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/usb
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/tty
+	$(INSTALL_BIN) ./files/nut_serial.hotplug $(1)/etc/hotplug.d/tty/40-nut_serial
 	$(INSTALL_BIN) ./files/30-libhid-ups.head $(1)/etc/hotplug.d/usb/30-libhid-ups
 	$(CP) $(PKG_INSTALL_DIR)/etc/hotplug/usb/libhid.usermap $(PKG_BUILD_DIR)/30-libhid-ups.middle
 	$(SED) '/^$$$$/d' \

--- a/net/nut/files/nut_serial.hotplug
+++ b/net/nut/files/nut_serial.hotplug
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+nut_serial() {
+	local cfg="$cfg"
+	config_get runas upsd runas "nut"
+	config_get_bool enable_usb_serial "$cfg" enable_usb_serial 0
+}
+
+[ "$ACTION" = "add" ] && [ -n "$DEVNAME" ] && [ -z "${DEVNAME%ttyUSB*}" ] && {
+	config load nut_server
+	config_foreach nut_serial driver
+
+	[ -z "$RUNAS" ] && {
+		RUNAS="$runas"
+	}
+
+	[ "$enable_usb_serial" -eq 1 ] && {
+			chown "${RUNAS:-nut}" /dev/$DEVNAME
+			chmod g+rw /dev/$DEVNAME
+	}
+}


### PR DESCRIPTION
When using serial-port based UPSes with NUT, it is handy to be able to
configure a USB serial port to have be set tot the NUT runas user, so
that NUT can access the serial port automagically.
Closes #6997

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: me / @cshoredaniel 
Compile tested: brcm2708, Raspberry Pi B+, current masters (openwrt, packages, luci)
Run tested: same arch/model as compile test.  Doesn't break anything but I don't have hardware to test that it actually works.
