### PR TITLE
netopeer2: add libcurl dependency

### DIFF
--- a/net/Netopeer2/Makefile
+++ b/net/Netopeer2/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Netopeer2
 PKG_VERSION:=0.7-r1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
@@ -37,7 +37,7 @@ define Package/netopeer2-server
   CATEGORY:=Utilities
   TITLE:=NETCONF server
   URL:=$(PKG_SOURCE_URL)
-  DEPENDS:=+libpthread +libyang +libnetconf2 +netopeer2-keystored +libsysrepo +sysrepocfg +sysrepoctl +sysrepo
+  DEPENDS:=+libcurl +libpthread +libyang +libnetconf2 +netopeer2-keystored +libsysrepo +sysrepocfg +sysrepoctl +sysrepo
   MENU:=1
 endef
 

--- a/net/Netopeer2/files/netopeer2-server.default
+++ b/net/Netopeer2/files/netopeer2-server.default
@@ -32,6 +32,7 @@ if [ -x /bin/sysrepoctl ]; then
 		sysrepoctl -m ietf-netconf-server -e call-home
 		sysrepoctl -m ietf-netconf-server -e ssh-call-home
 		sysrepoctl -m ietf-netconf-server -e tls-call-home
+		sysrepoctl -m ietf-netconf -e url
 		if [ -x /bin/sysrepocfg ]; then
 			sysrepocfg -f xml -d startup -i /usr/share/netopeer2-server/stock_config.xml ietf-netconf-server
 			rm /usr/share/netopeer2-server/stock_config.xml


### PR DESCRIPTION
Signed-off-by: Mislav Novakovic mislav.novakovic@sartura.hr

Maintainer: me
Compile tested: Broadcom 27xx RPi2 32-bit
Run tested: Broadcom 27xx RPi3 32-bit

Description:
Add libcurl to netopeer2-server dependency.
Connected to #7536 