### PR TITLE
unixodbc: Fix LIB_PREFIX in host build

### DIFF
--- a/libs/unixodbc/Makefile
+++ b/libs/unixodbc/Makefile
@@ -132,6 +132,7 @@ endef
 define Host/Configure
 	$(call Host/Configure/Default)
 	cp $(PKG_BUILD_DIR)/config.h $(HOST_BUILD_DIR)
+	sed -i -e 's!\(LIB_PREFIX \).*$$$$!\1"$(STAGING_DIR)/usr/lib"!' $(HOST_BUILD_DIR)/config.h
 	cp $(PKG_BUILD_DIR)/unixodbc_conf.h $(HOST_BUILD_DIR)
 endef
 

--- a/libs/unixodbc/Makefile
+++ b/libs/unixodbc/Makefile
@@ -97,6 +97,8 @@ endef
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/$(STAGING_DIR)/usr/include/*.h $(1)/usr/include/
+	# Save autoconf config.h file for host build
+	$(CP) $(PKG_BUILD_DIR)/config.h $(1)/usr/include/unixodbc_ac_config.h
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/etc
@@ -131,7 +133,8 @@ endef
 
 define Host/Configure
 	$(call Host/Configure/Default)
-	cp $(PKG_BUILD_DIR)/config.h $(HOST_BUILD_DIR)
+	# copy target autoconf config.h file for host build
+	cp $(STAGING_DIR)/usr/include/unixodbc_ac_config.h $(HOST_BUILD_DIR)
 	sed -i -e 's!\(LIB_PREFIX \).*$$$$!\1"$(STAGING_DIR)/usr/lib"!' $(HOST_BUILD_DIR)/config.h
 	cp $(PKG_BUILD_DIR)/unixodbc_conf.h $(HOST_BUILD_DIR)
 endef


### PR DESCRIPTION
Maintainer: @heil 
Compile tested: x86_64-linux (host), openwrt master
Run tested: x86_64-linux (host), openwrt master

Description:
When copying config.h from PKG_BUILD_DIR to HOST_BUILD_DIR, LIB_PREFIX
is set to /usr/lib.  Then when odbc_config is run, it reports /usr/lib
as the --lib-dir, and in --libs as well, and dependent packages may
fail.  Set it to $(STAGING_DIR)/usr/lib to make it right.

Since this does not affect the target package, PKG_RELEASE is not changed.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
