### PR TITLE
psqlodbc: correct --with-unixodbc setting

### DIFF
--- a/libs/psqlodbc/Makefile
+++ b/libs/psqlodbc/Makefile
@@ -6,8 +6,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=psqlodbc
 PKG_RELEASE:=1
-PKG_VERSION:=09.06.0310
-PKG_HASH:=6c42078af094d61baca2c8bd1dc4d137a77377198ef94e4eda5989bdce3474c3
+PKG_VERSION:=10.03.0000
+PKG_HASH:=0d2ff2d10d9347ef6ce83c7ca24f4cb20b4044eeef9638c8ae3bc8107e9e92f8
 
 PKG_SOURCE_URL:=https://ftp.postgresql.org/pub/odbc/versions/src/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -21,7 +21,7 @@ PKG_BUILD_DEPENDS:=unixodbc/host
 include $(INCLUDE_DIR)/package.mk
 
 CONFIGURE_ARGS += \
-	--with-unixodbc=$(STAGING_DIR)/usr \
+	--with-unixodbc=$(STAGING_DIR_HOST)/bin/odbc_config \
 	--with-libpq=$(STAGING_DIR)/usr
 
 define Package/psqlodbc/Default


### PR DESCRIPTION
Maintainer: none listed, pinging @dangowrt as the sole contributor shown
Compile tested: ramips, openwrt master
Run tested: none

Description:
--with-unixodbc should point to the odbc_config binary, not to the top
of the install directory $(STAGING_DIR)/usr.

Without this, `SQLCOLATTRIBUTE_SQLLEN` test fails because of an empty `-I` right before the C source file in configure, `SQLCOLATTRIBUTE_SQLLEN` gets undefined, and compilation fails:
```
libtool: compile:  mipsel-openwrt-linux-musl-gcc -DHAVE_CONFIG_H -I. -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/include -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/include -I/home/equeiroz/src/openwrt-asus/staging_dir/toolchain-mipsel_74kc_gcc-7.3.0_musl/usr/include -I/home/equeiroz/src/openwrt-asus/staging_dir/toolchain-mipsel_74kc_gcc-7.3.0_musl/include/fortify -I/home/equeiroz/src/openwrt-asus/staging_dir/toolchain-mipsel_74kc_gcc-7.3.0_musl/include -I -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/include -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/include -DUNICODE_SUPPORT -Os -pipe -mno-branch-likely -mips32r2 -mtune=74kc -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float -mips16 -minterlink-mips16 -iremap/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/psqlodbc-09.06.0310:psqlodbc-09.06.0310 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -MT psqlodbcw_la-odbcapi30.lo -MD -MP -MF .deps/psqlodbcw_la-odbcapi30.Tpo -c odbcapi30.c  -fPIC -DPIC -o .libs/psqlodbcw_la-odbcapi30.o
odbcapi30.c:121:1: error: conflicting types for 'SQLColAttribute'
 SQLColAttribute(SQLHSTMT StatementHandle,
 ^~~~~~~~~~~~~~~
In file included from psqlodbc.h:93:0,
                 from odbcapi30.c:21:
/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/include/sql.h:613:24: note: previous declaration of 'SQLColAttribute' was here
     SQLRETURN  SQL_API SQLColAttribute(SQLHSTMT StatementHandle,
                        ^~~~~~~~~~~~~~~
make[4]: *** [Makefile:810: psqlodbcw_la-odbcapi30.lo] Error 1
```

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
