### PR TITLE
nginx: fix rtmp module with openssl 1.1.1

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.15.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://nginx.org/download/
@@ -444,6 +444,7 @@ ifeq ($(CONFIG_NGINX_RTMP_MODULE),y)
   define  Prepare/nginx-rtmp
 	$(eval $(Download/nginx-rtmp))
 	gzip -dc $(DL_DIR)/$(FILE) | tar -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
+	$(call PatchDir,$(PKG_BUILD_DIR)/nginx-rtmp,./patches-nginx-rtmp)
   endef
 endif
 

--- a/net/nginx/patches-nginx-rtmp/100-ngx_rtp_cenc.c-move-ngx_-config-core-.h-to-top.patch
+++ b/net/nginx/patches-nginx-rtmp/100-ngx_rtp_cenc.c-move-ngx_-config-core-.h-to-top.patch
@@ -1,0 +1,26 @@
+From df4113fb4d9177c7cfb0639b5e92b1fadfd4c174 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cote2004-github@yahoo.com>
+Date: Thu, 6 Dec 2018 15:54:23 -0200
+Subject: [PATCH] ngx_rtp_cenc.c: move ngx_{config,core}.h to top
+
+Fixes compilation error: unknown type name 'cpu_set_t'
+
+Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
+
+diff --git a/dash/ngx_rtmp_cenc.c b/dash/ngx_rtmp_cenc.c
+index f0b81e7..e4af2b1 100644
+--- a/dash/ngx_rtmp_cenc.c
++++ b/dash/ngx_rtmp_cenc.c
+@@ -1,10 +1,10 @@
+ 
+ 
++#include <ngx_config.h>
++#include <ngx_core.h>
+ #include <openssl/aes.h>
+ #include <openssl/rand.h>
+ #include <openssl/evp.h>
+-#include <ngx_config.h>
+-#include <ngx_core.h>
+ #include <ngx_rtmp.h>
+ #include "ngx_rtmp_cenc.h"
+ 


### PR DESCRIPTION
Maintainer: @heil, @Ansuel 
Compile & run tested: ramips, openwrt master with openwrt/openwrt#965

Description:
Patch that changes the order of some include files in `ngx_rtp_cenc.c` that caused a compilation failure.  To be honest, I haven't researched why it failed (or rather why it works).  I just followed nginx guidelines about the includes and it worked.
Patch submitted upstream (https://github.com/ut0mt8/nginx-rtmp-module/pull/13).
```
In file included from src/os/unix/ngx_process.h:12:0,
                 from src/core/ngx_core.h:54,
                 from /home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/nginx-all-module/nginx-1.15.6/nginx-rtmp/dash/ngx_rtmp_cenc.c:7:
src/os/unix/ngx_setaffinity.h:16:9: error: unknown type name 'cpu_set_t'
 typedef cpu_set_t  ngx_cpuset_t;
         ^~~~~~~~~
```

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
