### PR TITLE
dtndht: Add -std-gnu89 to fix compilation problems.

### DIFF
--- a/libs/dtndht/Makefile
+++ b/libs/dtndht/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dtndht
 PKG_VERSION:=0.2.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.ibr.cs.tu-bs.de/projects/ibr-dtn/releases
@@ -32,6 +32,8 @@ endef
 define Package/dtndht/description
  A library with DHT functions for DTN name lookups.
 endef
+
+TARGET_CFLAGS += -std=gnu89
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)


### PR DESCRIPTION
bootstrapping.c:225:6: warning: implicit declaration of function 'blacklist_is_enabled' [-Wimplicit-function-declaration]
bootstrapping.c:226:3: warning: implicit declaration of function 'blacklist_blacklist_id'; did you mean 'dht_blacklisted'? [-Wimplicit-function-declaration]

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @morgenroth 
Compile tested: ar71xx