### PR TITLE
libtins: copy libtins.so.* to package

### DIFF
--- a/libs/libtins/Makefile
+++ b/libs/libtins/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtins
 PKG_VERSION:=4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:= Steven Hessing <steven.hessing@gmail.com>
 
@@ -49,7 +49,7 @@ endef
 
 define Package/libtins/install
     $(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libtins.so $(1)/usr/lib/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libtins.so.* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libtins))


### PR DESCRIPTION
Maintainer: @StevenHessing 
Compile tested: ramips, mipsel_74kc, openwrt master

Description:
Package was installing `libins.so`, but the `soname` is set to `libtins.so.4.0`, breaking dependent packages.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>