### PR TITLE
libyaml-cpp: copy file matching libs soname

### DIFF
--- a/libs/libyaml-cpp/Makefile
+++ b/libs/libyaml-cpp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libyaml-cpp
 PKG_VERSION:=0.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=yaml-cpp-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jbeder/yaml-cpp/tar.gz/yaml-cpp-$(PKG_VERSION)?
@@ -46,9 +46,8 @@ endef
 
 define Package/libyaml-cpp/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	#$(INSTALL_DATA) $(PKG_BUILD_DIR)/libyaml-cpp.so.0.5.3 $(1)/usr/lib/
-	#$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libyaml-cpp.so.0.5.3 $(1)/usr/lib/
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libyaml-cpp.so.$(PKG_VERSION) $(1)/usr/lib/
+	#$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libyaml-cpp.so.0.6 $(1)/usr/lib/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libyaml-cpp.so.?.? $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libyaml-cpp))


### PR DESCRIPTION
Maintainer: @StevenHessing
Compile tested: ramips, mipsel_74kc, openwrt master

Description:
The current package copies the library with the full version number (libyaml-cpp.6.0.2), but the soname is not set to the full version, but only major.minor.  This was breaking dependent packages.

This PR is using `liyaml-cpp.so.?.?` to try to get it right and not have to change it every time.
This will work as long as the version numbers are single-digits, and they don't go back and forth with the soname schema.  Alternatively, you can use the current soname, `libyaml-cpp.6.0`, and change it every time, or use
```
$(CP $(PKG_INSTALL_DIR)/usr/lib/libyaml-cpp.so.*  $(1)/usr/lib/
```
which will always get it right, at the expense of copying an extra symbolic link.  Notice that `$(INSTALL_DATA)` can't be used instead of `$(CP), as it copies the file pointed by the symlink, so it would end up with two copies of the library.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
