### PR TITLE
python-egenix-mx-base: use source distribution

### DIFF
--- a/lang/python/python-egenix-mx-base/Makefile
+++ b/lang/python/python-egenix-mx-base/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-egenix-mx-base
 PKG_VERSION:=3.2.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Dmitry Trefilov <the-alien@live.ru>
 PKG_LICENSE:=eGenix.com Public License 1.1.0
 PKG_LICENSE_FILES:=LICENSE COPYRIGHT
 
-PKG_SOURCE:=egenix-mx-base-$(PKG_VERSION).zip
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/e/egenix-mx-base
-PKG_HASH:=1844adcc137834724c1aca825dc9e1cbd8d81710f208231ea4bdb6d8b3006a95
+PKG_SOURCE:=egenix-mx-base-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://downloads.egenix.com/python
+PKG_HASH:=1c6b67688e7a231c6c1da09b7a6a2210745c3f2507bdda70e2639faedbf68977
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/egenix-mx-base-$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=python


### PR DESCRIPTION
Maintainer: @dtrefilo-Quest 
Compile tested: ramips, mipsel_74kc, openwrt master
Run tested: none

Description:
The current zip file distribution does not include the source files, and instead of building from source, downloaded pre-built binaries for the host, resulting in errors like:
```
Package python-egenix-mx-base is missing dependencies for the following libraries:
libc.so.6
libdl.so.2
libm.so.6
libpthread.so.0
librt.so.1
```
Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>