### PR TITLE
 fixup: Node-{arduino-firmata,cylon,hid,serialport}: fix symlinks

### DIFF
--- a/lang/node-arduino-firmata/Makefile
+++ b/lang/node-arduino-firmata/Makefile
@@ -49,12 +49,13 @@ endef
 EXTRA_LDFLAGS="-L$(TOOLCHAIN_DIR)/lib/ -Wl,-rpath-link $(TOOLCHAIN_DIR)/lib/" \
 
 define Build/Compile
+	cd $(PKG_BUILD_DIR) ; \
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(CONFIG_ARCH) \
 	npm_config_nodedir=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/ \
 	npm_config_cache=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/npm-cache \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
-	npm install -g $(PKG_BUILD_DIR)
+	npm install -g `npm pack $(PKG_BUILD_DIR) | tail -n 1`
 endef
 
 define Package/node-arduino-firmata/install

--- a/lang/node-cylon/Makefile
+++ b/lang/node-cylon/Makefile
@@ -65,12 +65,13 @@ endef
 EXTRA_LDFLAGS="-L$(TOOLCHAIN_DIR)/lib/ -Wl,-rpath-link $(TOOLCHAIN_DIR)/lib/" \
 
 define Build/Compile
+	cd $(PKG_BUILD_DIR) ; \
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(CONFIG_ARCH) \
 	npm_config_nodedir=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/ \
 	npm_config_cache=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/npm-cache \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
-	npm install -g $(PKG_BUILD_DIR)
+	npm install -g `npm pack $(PKG_BUILD_DIR) | tail -n 1`
 endef
 
 define Package/node-cylon/install

--- a/lang/node-hid/Makefile
+++ b/lang/node-hid/Makefile
@@ -34,7 +34,7 @@ define Package/node-hid
   CATEGORY:=Languages
   TITLE:=Node.js package to access HID devices
   URL:=https://github.com/node-hid/node-hid
-  DEPENDS:=+node +node-npm +libusb-1.0 +hidapi +libstdcpp
+  DEPENDS:=+node +node-npm +libusb-1.0 +hidapi +libstdcpp +libudev-fbsd
 endef
 
 define Package/node-hid/description
@@ -47,13 +47,15 @@ EXTRA_CFLAGS+=-I$(STAGING_DIR)/usr/include/libusb-1.0
 
 define Build/Compile
 	git init $(PKG_BUILD_DIR)
+	cd $(PKG_BUILD_DIR) ; \
 	$(MAKE_VARS) \
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(CONFIG_ARCH) \
 	npm_config_nodedir=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/ \
 	npm_config_cache=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/npm-cache \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
-	npm install --build-from-source --target_arch=$(CPU) -g $(PKG_BUILD_DIR)
+	npm install --build-from-source --target_arch=$(CPU) -g \
+		`npm pack $(PKG_BUILD_DIR) | tail -n 1`
 endef
 
 define Package/node-hid/install

--- a/lang/node-serialport/Makefile
+++ b/lang/node-serialport/Makefile
@@ -48,12 +48,14 @@ CPU:=$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))
 EXTRA_LDFLAGS="-L$(TOOLCHAIN_DIR)/lib/ -Wl,-rpath-link $(TOOLCHAIN_DIR)/lib/" \
 
 define Build/Compile
+	cd $(PKG_BUILD_DIR) ; \
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(CONFIG_ARCH) \
 	npm_config_nodedir=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/ \
 	npm_config_cache=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/npm-cache \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
-	npm install --build-from-source --target_arch=$(CPU) -g $(PKG_BUILD_DIR)
+	npm install --build-from-source --target_arch=$(CPU) -g \
+		`npm pack $(PKG_BUILD_DIR) | tail -n 1`
 endef
 
 define Package/node-serialport/install


### PR DESCRIPTION
Maintainer: @blogic 
Compile tested: ramips, mipsel_74kc, openwrt master

Description:
@hnyman 
Sorry about this. It was meant to be done in #6720 (description was even there), but wasn't.  
Current version of npm install installs a link to the build directory. The workaround is to use npm pack to make a tarball and install from that.