### PR TITLE
libndpi: fix copying of library

### DIFF
--- a/libs/libndpi/Makefile
+++ b/libs/libndpi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libndpi
 PKG_VERSION:=2.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ntop/nDPI/tar.gz/$(PKG_VERSION)?
@@ -52,7 +52,7 @@ define Build/InstallDev
 
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/local/lib/libndpi.so \
+		$(PKG_INSTALL_DIR)/usr/local/lib/libndpi.so* \
 		$(1)/usr/lib/
 
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
@@ -64,7 +64,7 @@ endef
 define Package/libndpi/install
 	$(INSTALL_DIR) $(1)/usr/lib/
 	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/local/lib/libndpi.so \
+		$(PKG_INSTALL_DIR)/usr/local/lib/libndpi.so* \
 		$(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(CP) \


### PR DESCRIPTION
Maintainer: @hbl0307106015
Compile tested: ramips, mipsel_74kc, openwrt master

Description:
The package was copying a symbolic link, not the library itself.  
Apparently, there's no soname set, so I used `libndpi.so*`, which copies the file along with the symlink.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
