### PR TITLE
elektra: skip ruby plugin in host/compile

### DIFF
--- a/libs/elektra/Makefile
+++ b/libs/elektra/Makefile
@@ -313,7 +313,7 @@ CMAKE_HOST_OPTIONS = \
 	-DINSTALL_SYSTEM_FILES=OFF \
 	-DFORCE_IN_SOURCE_BUILD=ON \
 	-DBUILD_TESTING=OFF \
-	-DPLUGINS="ALL;-python2;-python" \
+	-DPLUGINS="ALL;-python2;-python;-ruby" \
 	-DTOOLS="gen;kdb"
 
 define Package/libelektra-core/install


### PR DESCRIPTION
Maintainer: @haraldg 
Compile & Run tested: x86_64 (host), openwrt master

Description:
Linking is failing, and the plugin is not needed for the host build anyway.
```
[ 57%] Linking CXX shared module ../../../lib/libelektra-ruby.so
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: /home/equeiroz/src/openwrt-asus/staging_dir/hostpkg/lib/libruby-static.a(compile.o): warning: relocation against `stdout@@GLIBC_2.2.5' in read-only section `.text'
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: /home/equeiroz/src/openwrt-asus/staging_dir/hostpkg/lib/libruby-static.a(gc.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
make[5]: *** [src/plugins/ruby/CMakeFiles/elektra-ruby.dir/build.make:91: lib/libelektra-ruby.so] Error 1
```

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
