### PR TITLE
libglog: [fixup] fix removing libunwind dependency

### DIFF
--- a/libs/libglog/Makefile
+++ b/libs/libglog/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glog
 PKG_VERSION:=0.3.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/google/glog/tar.gz/v$(PKG_VERSION)?
@@ -32,7 +32,7 @@ define Package/glog/description
   module.  Documentation for the implementation is in doc/.
 endef
 
-CONFIGURE_VARS+=ac_cv_have_libunwind_h=0
+CONFIGURE_VARS+=ac_cv_header_libunwind_h=0
 
 TARGET_CXXFLAGS+=-std=c++11
 TARGET_LDFLAGS+=-lpthread


### PR DESCRIPTION
Maintainer: @amir-sabbaghi
Compile tested: ramips, mipsel_74kc, openwrt master

@neheb, you meant to fix this in #7219 
Description:
`ac_cv_header_libunwind_h` needs to be set to 0, as `ac_cv_have_libunwind_h` is overwritten based on the former's value:
```
if test "x$ac_cv_header_libunwind_h" = xyes; then :
  cat >>confdefs.h <<_ACEOF
#define HAVE_LIBUNWIND_H 1
_ACEOF
 ac_cv_have_libunwind_h=1
else
  ac_cv_have_libunwind_h=0
fi
```

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
