### PR TITLE
snort: fix pcap include directory

### DIFF
--- a/net/snort/Makefile
+++ b/net/snort/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort
 PKG_VERSION:=2.9.11.1
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>

--- a/net/snort/patches/002-fix_include.patch
+++ b/net/snort/patches/002-fix_include.patch
@@ -1,0 +1,14 @@
+--- a/configure.in
++++ b/configure.in
+@@ -67,6 +67,11 @@ case "$host" in
+     AC_DEFINE([SUNOS],[1],[Define if SunOS])
+     sunos4="yes"
+     ;;
++  *-openwrt*)
++    linux="yes"
++    AC_DEFINE([LINUX],[1],[Define if Linux])
++    AC_SUBST(extra_incl)
++    ;;
+   *-linux*)
+     linux="yes"
+     AC_DEFINE([LINUX],[1],[Define if Linux])


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: ramips, mipsel_74kc, openwrt master

Description:
Build was overriding openwrt pcap include directory, and it would try to pick up system's header.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>