### PR TITLE
clamav: fixup disabling xml

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clamav
 PKG_VERSION:=0.100.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr> \
@@ -68,7 +68,7 @@ define Build/Configure
 		--prefix=/usr/ \
 		--exec-prefix=/usr/ \
 		--enable-milter \
-		--disable-xml \
+		--with-xml=no \
 		--disable-bzip2 \
 		--with-user nobody \
 		--with-group nogroup \


### PR DESCRIPTION
Maintainer: @ratkaj , @lucize 
Compile tested: ramips, mipsel_74kc, openwrt master

Description:
`--disable-xml` is not doing its job, but `--with-xml=no` works.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>