### PR TITLE
grilo-plugins: disable dmap plugin, use hostpkg 

### DIFF
--- a/multimedia/grilo-plugins/Makefile
+++ b/multimedia/grilo-plugins/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grilo-plugins
 PKG_VERSION:=0.3.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPLv2.1
@@ -66,6 +66,8 @@ CONFIGURE_ARGS += \
         --disable-tmdb \
         --disable-freebox
 
+MAKE_FLAGS += \
+        GLIB_COMPILE_RESOURCES="$(STAGING_DIR_HOSTPKG)/bin/glib-compile-resources"
 define Package/grilo-plugins/install
 	$(INSTALL_DIR) $(1)/usr/lib/grilo-0.3
 endef

--- a/multimedia/grilo-plugins/Makefile
+++ b/multimedia/grilo-plugins/Makefile
@@ -95,7 +95,8 @@ endef
 $(eval $(call BuildPackage,grilo-plugins))
 
 $(eval $(call BuildPlugin,dleyna,DLNA sharing,dleyna,,30))
-$(eval $(call BuildPlugin,dmap,DAAP and DPAP sharing,daap dpap,libdmapsharing,30))
+# This is currently disabled because it won't work with libdmapsharing-4.0.so
+#$(eval $(call BuildPlugin,dmap,DAAP and DPAP sharing,daap dpap,libdmapsharing,30))
 $(eval $(call BuildPlugin,gravatar,Gravatar provider,gravatar,,30))
 $(eval $(call BuildPlugin,jamendo,Jamendo sharing,jamendo,,30))
 $(eval $(call BuildPlugin,magnatune,Magnatune sharing,magnatune,,30))


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: ramips, mipsel_74kc, openwrt master

Description:
Added `GLIB_COMPILE_RESOURCES="$(STAGING_DIR_HOSTPKG)/bin/glib-compile-resources"` to `MAKE_FLAGS` to avoid a compilation error.
However, compilation still fails as dmap plugin is not compatible with current libdmapsharing version (3.9.1).
This check fails:
```
PKG_CHECK_MODULES(DMAP, libdmapsharing-3.0 >= 2.9.12, HAVE_DMAP=yes, HAVE_DMAP=no)
```
library name for libdmapsharing is libdmapsharing-4.0.so now.

Changing the check does not work either, so to compile the other plugins, it's best to just disable dmap.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
