### PR TITLE
php7-pecl-http: ensure libidnkit is disabled

### DIFF
--- a/lang/php7-pecl-http/Makefile
+++ b/lang/php7-pecl-http/Makefile
@@ -9,7 +9,7 @@ PECL_NAME:=pecl_http
 PECL_LONGNAME:=Extended HTTP Support
 
 PKG_VERSION:=3.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_HASH:=6fb7f038365fb1f3302f1b7e7d6b55d5c422bdea36057b1efe02bbe6ad3cc01b
 
 PKG_NAME:=php7-pecl-http
@@ -51,7 +51,9 @@ CONFIGURE_ARGS+= \
 	--without-http-shared-deps \
 	--with-http-libcurl-dir="$(STAGING_DIR)/usr" \
 	--with-http-libevent-dir="$(STAGING_DIR)/usr" \
-	--with-http-libidn-dir="$(STAGING_DIR)/usr"
+	--with-http-libidn-dir="$(STAGING_DIR)/usr" \
+	--with-http-libidnkit-dir=no \
+	--with-http-libidnkit2-dir=no
 
 $(eval $(call PECLPackage,http,$(PECL_LONGNAME),+icu +libcurl +librt +libevent2 +PACKAGE_libidn:libidn +libidn2 +php7-mod-hash +php7-mod-iconv +php7-mod-session +php7-pecl-raphf +php7-pecl-propro,30))
 $(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: ramips, mipsel_74kc, openwrt master
Run tested: None

Description:
Otherwise, configure may pick up the host system library, resulting in:
```
/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/pecl-php7/pecl_http-3.2.0/src/php_http.c:41:10: fatal error: idn/version.h: No such file or directory
 #include "idn/version.h"
          ^~~~~~~~~~~~~~~
compilation terminated.
make[3]: *** [Makefile:214: src/php_http.lo] Error 1
```
Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>