### PR TITLE
libgee: copy vapi files to unversioned vala dir

### DIFF
--- a/libs/libgee/Makefile
+++ b/libs/libgee/Makefile
@@ -1,6 +1,4 @@
 #
-# Copyright (C) 2009-2015 OpenWrt.org
-#
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
@@ -9,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgee
 PKG_VERSION:=0.20.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -23,11 +21,10 @@ PKG_HASH:=bb2802d29a518e8c6d2992884691f06ccfcc25792a5686178575c7111fea4630
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
+PKG_BUILD_DEPENDS:=vala/host
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
-
-TARGET_LDFLAGS+= \
-	-Wl,-rpath-link=$(STAGING_DIR)/usr/lib
 
 define Package/libgee
   SECTION:=libs
@@ -57,10 +54,10 @@ define Build/InstallDev
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc \
 		$(1)/usr/lib/pkgconfig/
-	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/share/vala-0.30/vapi/
+	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/share/vala/vapi/
 	$(INSTALL_DATA) \
                 $(PKG_INSTALL_DIR)/usr/share/vala/vapi/* \
-                $(STAGING_DIR_HOSTPKG)/share/vala-0.30/vapi
+                $(STAGING_DIR_HOSTPKG)/share/vala/vapi
 endef
 
 define Package/libgee/install


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: ramips, mips_74kc, openwrt master
Run tested: None

Description:
The valac directory is currently hardcoded to the wrong version

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>