### PR TITLE
lcdgrilo: remove check dependency

### DIFF
--- a/libs/libgee/Makefile
+++ b/libs/libgee/Makefile
@@ -54,10 +54,10 @@ define Build/InstallDev
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc \
 		$(1)/usr/lib/pkgconfig/
-	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/share/vala/vapi/
+	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/share/vala-`$(STAGING_DIR_HOSTPKG)/bin/valac --api-version`/vapi/
 	$(INSTALL_DATA) \
                 $(PKG_INSTALL_DIR)/usr/share/vala/vapi/* \
-                $(STAGING_DIR_HOSTPKG)/share/vala/vapi
+                $(STAGING_DIR_HOSTPKG)/share/vala-`$(STAGING_DIR_HOSTPKG)/bin/valac --api-version`/vapi
 endef
 
 define Package/libgee/install

--- a/multimedia/grilo/Makefile
+++ b/multimedia/grilo/Makefile
@@ -20,6 +20,7 @@ PKG_HASH:=1e65ca82dd58020451417fde79310d4b940adc3f63ab59997419c52ed3bc9c91
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
+PKG_BUILD_DEPENDS:=vala/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -58,13 +59,13 @@ define Build/InstallDev
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc \
 		$(1)/usr/lib/pkgconfig/
-	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/share/vala/vapi/
+	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/share/vala-`$(STAGING_DIR_HOSTPKG)/bin/valac --api-version`/vapi/
 	# Note: this are compiled elsewhere because grilo refuses to
 	# generate VAPI files unless gobject-introspection exists;
 	# OpenWrt does not yet have a gobject-introspection package.
 	$(INSTALL_DATA) \
 		./files/*.vapi \
-		$(STAGING_DIR_HOSTPKG)/share/vala/vapi
+		$(STAGING_DIR_HOSTPKG)/share/vala-`$(STAGING_DIR_HOSTPKG)/bin/valac --api-version`/vapi
 endef
 
 define Package/grilo/install

--- a/multimedia/lcdgrilo/Makefile
+++ b/multimedia/lcdgrilo/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lcdgrilo
 PKG_VERSION:=0.0.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -22,6 +22,7 @@ PKG_HASH:=2e5028fff7a90b1a3688c466f048e978a52d9a4da20a382546d5e5bd42e2fc6a
 PKG_BUILD_DEPENDS:=vala
 
 PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk

--- a/multimedia/lcdgrilo/patches/010-remove-check-dependency.patch
+++ b/multimedia/lcdgrilo/patches/010-remove-check-dependency.patch
@@ -1,0 +1,10 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -85,7 +85,6 @@ AM_CONDITIONAL(USE_GSTREAMER, test x"$HA
+ AC_SUBST(GSTREAMER_CFLAGS)
+ AC_SUBST(GSTREAMER_LIBS)
+ 
+-PKG_CHECK_MODULES([CHECK], [check >= 0.9.4],have_check=yes,have_check=no)
+ AM_CONDITIONAL(HAVE_CHECK, test x"$have_check" = "xyes")
+ 
+ AM_PROG_VALAC([0.11.4])


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: ramips, mipsel_74kc, openwrt master
Run tested: none

Description:
It picks up libcheck:
```
Package lcdgrilo is missing dependencies for the following libraries:
libcheck.so.0
```

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
