### PR TITLE
prometheus-statsd-exporter: add new package

### DIFF
--- a/utils/prometheus-statsd-exporter/Makefile
+++ b/utils/prometheus-statsd-exporter/Makefile
@@ -1,0 +1,48 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=prometheus-statsd-exporter
+PKG_VERSION:=0.8.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=statsd_exporter-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/prometheus/statsd_exporter/tar.gz/v${PKG_VERSION}?
+PKG_HASH:=d69af3ccdc393ec2d3007dd9d039d4f0f0a6dd9df55fb7cd3fd0304607324d51
+PKG_BUILD_DIR:=$(BUILD_DIR)/statsd_exporter-$(PKG_VERSION)
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/prometheus/statsd_exporter
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/prometheus-statsd-exporter
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=StatsD to Prometheus metrics exporter
+  URL:=http://prometheus.io
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/prometheus-statsd-exporter/description
+statsd_exporter receives StatsD-style metrics and exports them as Prometheus
+metrics.
+endef
+
+define Package/prometheus-statsd-exporter/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+
+	$(CP) ./files/* $(1)/
+endef
+
+define Package/prometheus-statsd-exporter/conffiles
+/etc/prometheus-statsd-exporter.yml
+endef
+
+$(eval $(call GoBinPackage,prometheus-statsd-exporter))
+$(eval $(call BuildPackage,prometheus-statsd-exporter))

--- a/utils/prometheus-statsd-exporter/files/etc/config/prometheus-statsd-exporter
+++ b/utils/prometheus-statsd-exporter/files/etc/config/prometheus-statsd-exporter
@@ -1,0 +1,6 @@
+config prometheus-statsd-exporter 'main'
+	option web_listen_address '127.0.0.1:9102'
+	option web_telemetry_path '/metrics'
+	option statsd_listen_udp '127.0.0.1:9125'
+	option statsd_listen_tcp '127.0.0.1:9125'
+	option statsd_mapping_config '/etc/prometheus-statsd-exporter.yml'

--- a/utils/prometheus-statsd-exporter/files/etc/init.d/prometheus-statsd-exporter
+++ b/utils/prometheus-statsd-exporter/files/etc/init.d/prometheus-statsd-exporter
@@ -1,0 +1,35 @@
+#!/bin/sh /etc/rc.common
+
+START=60
+
+USE_PROCD=1
+PROG=/usr/bin/statsd_exporter
+CONFFILE=/etc/prometheus-statsd-exporter.yml
+
+start_service() {
+	local web_listen_address
+	local web_telemetry_path
+	local statsd_listen_udp
+	local statsd_listen_tcp
+	local statsd_mapping_config
+	config_load "prometheus-statsd-exporter"
+	config_get web_listen_address main web_listen_address "127.0.0.1:9102"
+	config_get web_telemetry_path main web_telemetry_path "/metrics"
+	config_get statsd_listen_udp main statsd_listen_udp "127.0.0.1:9125"
+	config_get statsd_listen_tcp main statsd_listen_tcp "127.0.0.1:9125"
+	config_get statsd_mapping_config main statsd_mapping_config "$CONFFILE"
+
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_append_param command --web.listen-address="$web_listen_address"
+	procd_append_param command --web.telemetry-path="$web_telemetry_path"
+	procd_append_param command --statsd.listen-udp="$statsd_listen_udp"
+	procd_append_param command --statsd.listen-tcp="$statsd_listen_tcp"
+	procd_append_param command --statsd.mapping-config="$statsd_mapping_config"
+	procd_append_param command --log.level="warn"
+	procd_set_param file "$config_file"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn
+	procd_close_instance
+}

--- a/utils/prometheus-statsd-exporter/files/etc/prometheus-statsd-exporter.yml
+++ b/utils/prometheus-statsd-exporter/files/etc/prometheus-statsd-exporter.yml
@@ -1,0 +1,24 @@
+mappings:
+  # asterisk mappings
+  # use "prefix = asterisk" in asterisk's statsd.conf
+  - match: asterisk.PJSIP.registrations.state.*
+    name: "asterisk_PJSIP_registrations_state"
+    labels:
+      state: "$1"
+  - match: asterisk.PJSIP.endpoints.state.*
+    name: "asterisk_PJSIP_endpoints_state"
+    labels:
+      state: "$1"
+  - match: asterisk.PJSIP.contacts.states.*
+    name: "asterisk_PJSIP_contacts_states"
+    labels:
+      state: "$1"
+  - match: asterisk.endpoints.state.*
+    name: "asterisk_endpoints_state"
+    labels:
+      state: "$1"
+  - match: asterisk.endpoints.*.*.channels
+    name: "asterisk_endpoints_channels"
+    labels:
+      tech: "$1"
+      resource: "$2"


### PR DESCRIPTION
statsd_exporter receives StatsD-style metrics and exports them as Prometheus
metrics.

Signed-off-by: Andre Heider <a.heider@gmail.com>

Maintainer: @aparcar (for related prometheus)
Compile tested: arm/sunxi, Cubieboard 2, master
Run tested: arm/sunxi, Cubieboard 2, master, asterisk<->prometheus interop

Description:
Not ready yet for merging! While the package is built, there's an issue with `make clean` because all the files in `$BUILD_DIR/.go_work/build/pkg/mod` are not writable, so they cannot be removed. I'm not sure what the root cause is, anyone got an idea?

Apart from that, the resulting package works fine, and I'm using it with the openwrt asterisk packages. Asterisk doesn't support prometheus metrics directly, but has various statsd modules. Using those to push to this exporter, I can scrape from prometheus successfully. Asterisk statsd->prometheus label mapping are included in the yml config file.