### PR TITLE
owfs: disable avahi dependency

### DIFF
--- a/utils/owfs/Makefile
+++ b/utils/owfs/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=owfs
 PKG_VERSION:=3.2p3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/owfs/owfs/releases/download/v$(PKG_VERSION)
@@ -86,8 +86,7 @@ define Package/libow
   DEPENDS:= \
     +libpthread \
     +LIBOW_MASTER_USB:libusb-compat \
-    +LIBOW_MASTER_W1:kmod-w1 \
-    +libavahi-client
+    +LIBOW_MASTER_W1:kmod-w1
   TITLE:=OWFS - common shared library
 endef
 
@@ -192,6 +191,7 @@ CONFIGURE_ARGS += \
 	--disable-owphp \
 	--disable-owtcl \
 	--disable-swig \
+	--disable-avahi \
 	$(if $(CONFIG_LIBOW_MASTER_USB),--enable-usb,--disable-usb) \
 	$(if $(CONFIG_LIBOW_MASTER_W1),--enable-w1,--disable-w1) \
 	$(if $(CONFIG_LIBOW_MASTER_I2C),--enable-i2c,--disable-i2c) \


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: ath79, TL-WR842ND v1, r8685
Run tested: ath79, TL-WR842ND v1, r8685, tested using owserver-powered remote drone

Description:
Avahi is not a mandatory owfs dependency so disable it to avoid Avahi/DBus daemons bloat. 

Given restricted resources available on some devices this should be either optional or disabled. It's also possible to make this configurable but I don't know if someone really needs this Avahi stuff so currently it's simply excluded from build.