### PR TITLE
unixodbc: save unixodbc_conf.h for host build

### DIFF
--- a/libs/unixodbc/Makefile
+++ b/libs/unixodbc/Makefile
@@ -98,7 +98,10 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/$(STAGING_DIR)/usr/include/*.h $(1)/usr/include/
 	# Save autoconf config.h file for host build
-	$(CP) $(PKG_BUILD_DIR)/config.h $(1)/usr/include/unixodbc_ac_config.h
+	# copy target autoconf config.h and unixodbc_conf.h file for host build
+	$(INSTALL_DIR) $(1)/tmp/unixodbc
+	$(CP) $(PKG_BUILD_DIR)/config.h $(1)/tmp/unixodbc/
+	$(CP) $(PKG_BUILD_DIR)/unixodbc_conf.h $(1)/tmp/unixodbc/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/etc
@@ -133,10 +136,9 @@ endef
 
 define Host/Configure
 	$(call Host/Configure/Default)
-	# copy target autoconf config.h file for host build
-	cp $(STAGING_DIR)/usr/include/unixodbc_ac_config.h $(HOST_BUILD_DIR)
+	cp $(STAGING_DIR)/tmp/unixodbc/config.h $(HOST_BUILD_DIR)
 	sed -i -e 's!\(LIB_PREFIX \).*$$$$!\1"$(STAGING_DIR)/usr/lib"!' $(HOST_BUILD_DIR)/config.h
-	cp $(PKG_BUILD_DIR)/unixodbc_conf.h $(HOST_BUILD_DIR)
+	cp $(STAGING_DIR)/tmp/unixodbc/unixodbc_conf.h $(HOST_BUILD_DIR)
 endef
 
 define Host/Compile


### PR DESCRIPTION
Maintainer: @heil 
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
Save a copy of unixodbc_conf.h in STAGING_DIR to be used by host build.
Use STAGING_DIR/tmp/unixodbc instead of include, to avoid an unlikely collision, and not to place internal headers in a public directory.  I chose `tmp/unixodbc`, but if there's a better place, I'll change it.

This is a fixup for e4693dd.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>