### PR TITLE
net/safe-search: Fix double installation bug

### DIFF
--- a/net/safe-search/Makefile
+++ b/net/safe-search/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=safe-search
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Gregory L. Dietsche <Gregory.Dietsche@cuw.edu>
 

--- a/net/safe-search/files/safe-search.defaults
+++ b/net/safe-search/files/safe-search.defaults
@@ -3,6 +3,7 @@
 # Copyright (c) 2018 Gregory L. Dietsche <Gregory.Dietsche@cuw.edu>
 # This is free software, licensed under the MIT License
 #
+uci del_list dhcp.@dnsmasq[0].addnhosts=/etc/safe-search/enabled
 uci add_list dhcp.@dnsmasq[0].addnhosts=/etc/safe-search/enabled
 uci commit dhcp
 


### PR DESCRIPTION
Maintainer: me
Compile tested: (ar71xxx, archer c7, OpenWrt version 18.06.1)
Run tested:  (ar71xxx, archer c7, OpenWrt version 18.06.1)

Description:
If safe search is built directly into an image, the /etc/config/dhcp
file will have multiple entries added to it after using sysupgrade
for the nth time (2 or more sysupgrade cycles).

In /etc/config/dhcp, this bug creates duplicate entries like this:

    config dnsmasq
            list addnhosts '/etc/safe-search/enabled'
            list addnhosts '/etc/safe-search/enabled'

This patch ensures that safe search only registers itself one time.