### PR TITLE
aria2: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
 PKG_VERSION:=1.34.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/

--- a/net/aria2/patches/010-Platform-Fix-compilation-without-deprecated-OpenSSL-.patch
+++ b/net/aria2/patches/010-Platform-Fix-compilation-without-deprecated-OpenSSL-.patch
@@ -1,0 +1,30 @@
+From 0cfd523a6d0ea16d8b7c94160216838d53c30da6 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sat, 8 Dec 2018 18:39:50 -0800
+Subject: [PATCH] Platform: Fix compilation without deprecated OpenSSL APIs
+
+---
+ src/Platform.cc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/Platform.cc b/src/Platform.cc
+index ea73b6c6..0af62d18 100644
+--- a/src/Platform.cc
++++ b/src/Platform.cc
+@@ -111,11 +111,13 @@ bool Platform::setUp()
+ #endif // ENABLE_NLS
+ 
+ #ifdef HAVE_OPENSSL
++#if !OPENSSL_101_API
+   // for SSL initialization
+   SSL_load_error_strings();
+   SSL_library_init();
+   // Need this to "decrypt" p12 files.
+   OpenSSL_add_all_algorithms();
++#endif // !OPENSSL_101_API
+ #endif // HAVE_OPENSSL
+ #ifdef HAVE_LIBGCRYPT
+   if (!gcry_check_version("1.2.4")) {
+-- 
+2.20.0
+


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @kuoruan 
Compile tested: ar71xx