### PR TITLE
Node-{arduino-firmata,cylon,hid,serialport}: allow compilation with `CONFIG_AUTOREMOVE`

### DIFF
--- a/lang/node-arduino-firmata/Makefile
+++ b/lang/node-arduino-firmata/Makefile
@@ -54,8 +54,9 @@ define Build/Compile
 	npm_config_arch=$(CONFIG_ARCH) \
 	npm_config_nodedir=$(STAGING_DIR)/usr \
 	npm_config_cache=$(TMP_DIR)/npm-cache \
-	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
-	npm install -g `npm pack $(PKG_BUILD_DIR) | tail -n 1`
+	npm install -g \
+		--prefix="$(PKG_INSTALL_DIR)/usr/" \
+		`npm pack $(PKG_BUILD_DIR) | tail -n 1`
 endef
 
 define Package/node-arduino-firmata/install

--- a/lang/node-arduino-firmata/Makefile
+++ b/lang/node-arduino-firmata/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=arduino-firmata
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=0.3.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/shokai/node-arduino-firmata.git
@@ -52,8 +52,8 @@ define Build/Compile
 	cd $(PKG_BUILD_DIR) ; \
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(CONFIG_ARCH) \
-	npm_config_nodedir=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/ \
-	npm_config_cache=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/npm-cache \
+	npm_config_nodedir=$(STAGING_DIR)/usr \
+	npm_config_cache=$(TMP_DIR)/npm-cache \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
 	npm install -g `npm pack $(PKG_BUILD_DIR) | tail -n 1`
 endef

--- a/lang/node-cylon/Makefile
+++ b/lang/node-cylon/Makefile
@@ -70,8 +70,9 @@ define Build/Compile
 	npm_config_arch=$(CONFIG_ARCH) \
 	npm_config_nodedir=$(STAGING_DIR)/usr \
 	npm_config_cache=$(TMP_DIR)/npm-cache \
-	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
-	npm install -g `npm pack $(PKG_BUILD_DIR) | tail -n 1`
+	npm install -g \
+		--prefix="$(PKG_INSTALL_DIR)/usr/" \
+		`npm pack $(PKG_BUILD_DIR) | tail -n 1`
 endef
 
 define Package/node-cylon/install

--- a/lang/node-cylon/Makefile
+++ b/lang/node-cylon/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=cylon
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=0.24.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/hybridgroup/cylon-firmata.git
@@ -68,8 +68,8 @@ define Build/Compile
 	cd $(PKG_BUILD_DIR) ; \
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(CONFIG_ARCH) \
-	npm_config_nodedir=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/ \
-	npm_config_cache=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/npm-cache \
+	npm_config_nodedir=$(STAGING_DIR)/usr \
+	npm_config_cache=$(TMP_DIR)/npm-cache \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
 	npm install -g `npm pack $(PKG_BUILD_DIR) | tail -n 1`
 endef

--- a/lang/node-hid/Makefile
+++ b/lang/node-hid/Makefile
@@ -53,8 +53,8 @@ define Build/Compile
 	npm_config_arch=$(CONFIG_ARCH) \
 	npm_config_nodedir=$(STAGING_DIR)/usr \
 	npm_config_cache=$(TMP_DIR)/npm-cache \
-	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
 	npm install --build-from-source --target_arch=$(CPU) -g \
+		--prefix="$(PKG_INSTALL_DIR)/usr/" \
 		`npm pack $(PKG_BUILD_DIR) | tail -n 1`
 endef
 

--- a/lang/node-hid/Makefile
+++ b/lang/node-hid/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=hid
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=0.7.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/node-hid/node-hid.git
@@ -51,8 +51,8 @@ define Build/Compile
 	$(MAKE_VARS) \
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(CONFIG_ARCH) \
-	npm_config_nodedir=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/ \
-	npm_config_cache=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/npm-cache \
+	npm_config_nodedir=$(STAGING_DIR)/usr \
+	npm_config_cache=$(TMP_DIR)/npm-cache \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
 	npm install --build-from-source --target_arch=$(CPU) -g \
 		`npm pack $(PKG_BUILD_DIR) | tail -n 1`

--- a/lang/node-serialport/Makefile
+++ b/lang/node-serialport/Makefile
@@ -61,11 +61,11 @@ endef
 define Package/node-serialport/install
 	mkdir -p $(1)/usr/lib/node/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/* $(1)/usr/lib/node/
-	$(RM) -rf $(1)/usr/lib/node/node-hid/patches \
-		  $(1)/usr/lib/node/node-hid/.p* \
-		  $(1)/usr/lib/node/node-hid/.quilt* \
-		  $(1)/usr/lib/node/node-hid/.built* \
-		  $(1)/usr/lib/node/node-hid/.config*
+	$(RM) -rf $(1)/usr/lib/node/node-serialport/patches \
+		  $(1)/usr/lib/node/node-serialport/.p* \
+		  $(1)/usr/lib/node/node-serialport/.quilt* \
+		  $(1)/usr/lib/node/node-serialport/.built* \
+		  $(1)/usr/lib/node/node-serialport/.config*
 	# Strip PKG_BUILD_DIR from useless metadata inserted by npm install
 	# https://github.com/npm/npm/issues/10393
 	# https://github.com/npm/npm/issues/12110

--- a/lang/node-serialport/Makefile
+++ b/lang/node-serialport/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=serialport
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=6.1.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=http://registry.npmjs.org/$(PKG_NPM_NAME)/-/
@@ -51,8 +51,8 @@ define Build/Compile
 	cd $(PKG_BUILD_DIR) ; \
 	$(MAKE_FLAGS) \
 	npm_config_arch=$(CONFIG_ARCH) \
-	npm_config_nodedir=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/ \
-	npm_config_cache=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/npm-cache \
+	npm_config_nodedir=$(STAGING_DIR)/usr \
+	npm_config_cache=$(TMP_DIR)/npm-cache \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
 	npm install --build-from-source --target_arch=$(CPU) -g \
 		`npm pack $(PKG_BUILD_DIR) | tail -n 1`

--- a/lang/node-serialport/Makefile
+++ b/lang/node-serialport/Makefile
@@ -53,8 +53,8 @@ define Build/Compile
 	npm_config_arch=$(CONFIG_ARCH) \
 	npm_config_nodedir=$(STAGING_DIR)/usr \
 	npm_config_cache=$(TMP_DIR)/npm-cache \
-	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
 	npm install --build-from-source --target_arch=$(CPU) -g \
+		--prefix="$(PKG_INSTALL_DIR)/usr/" \
 		`npm pack $(PKG_BUILD_DIR) | tail -n 1`
 endef
 


### PR DESCRIPTION
Maintainer: @blogic 
Compile tested: ramips, mipsel_74kc, openwrt master
Run tested: none

Description:
node-arduino-firmata, node-cylon, node-hid, and node-serialport all set `npm_config_nodedir` to node's build dir.  When the buildbots, or buildpr build the packages, they do a clean-build, clearing up node's build dir.  Normally using node's build dir is the best way to do it, but it is not the only way.  It can be set to `STAGING_DIR/usr`, and it will pickup the include files installed there.
I can't properly run-test this.  I've compile-tested the packages, and compared the resulting files.  These packages install some (all?) of their build files, so the files don't match exactly.  More specifically, files like this:
```
--- a/lib/node/node-hid/build/HID.target.mk
+++ b/lib/node/node-hid/build/HID.target.mk
@@ -79,13 +79,13 @@ CFLAGS_CC_Release := \
        -exceptions

 INCS_Release := \
-       -I/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/node-v8.12.0/include/node \
-       -I/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/node-v8.12.0/src \
-       -I/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/node-v8.12.0/deps/openssl/config \
-       -I/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/node-v8.12.0/deps/openssl/openssl/include \
-       -I/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/node-v8.12.0/deps/uv/include \
-       -I/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/node-v8.12.0/deps/zlib \
-       -I/home/equeiroz/src/openwrt-asus/build_dir/target-mipsel_74kc_musl/node-v8.12.0/deps/v8/include \
+       -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/include/node \
+       -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/src \
+       -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/deps/openssl/config \
+       -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/deps/openssl/openssl/include \
+       -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/deps/uv/include \
+       -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/deps/zlib \
+       -I/home/equeiroz/src/openwrt-asus/staging_dir/target-mipsel_74kc_musl/usr/deps/v8/include \
        -I$(srcdir)/hidapi/hidapi \
        -I$(srcdir)/node_modules/nan
```
There's no `build_dir/target-mipsel_74kc_musl/node-v8.12.0/include/node`, but there is `staging_dir/target-mipsel_74kc_musl/usr/include/node` where node installs its headers.

More important, the resulting binaries are all the same.

I have concerns about the `deps` directories, and even copied them under staging_dir/usr/deps, but they did not make any difference in the final binaries.  What tipped me into not wanting to copy them was the presence of openssl headers there.  They are from version 1.0.2, but the packages all compile with openwrt/openwrt#965 (choosing version 1.1.1), and there's indication that openwrt 19.01 should use openssl 1.1.1.  Packages should not work if you mix 1.0.2 headers with 1.1.1 libraries, given the overwhelming changes in API.

Another alternatives are: 
- instruct the bots to not clean up node's build dir (I don't know how to do that), and leave everything as is; 
- copying after build/extracting the entire node source dir to staging_dir, and point npm_node_dir there.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>