### PR TITLE
node: use system libnghttp2 libuv libhttp-parser

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
 PKG_VERSION:=v8.12.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=node-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/${PKG_VERSION}
 PKG_HASH:=5a9dff58016c18fb4bf902d963b124ff058a550ebcd9840c677757387bce419a
@@ -37,7 +37,7 @@ define Package/node
   SUBMENU:=Node.js
   TITLE:=Node.js is a platform built on Chrome's JavaScript runtime
   URL:=https://nodejs.org/
-  DEPENDS:=@(HAS_FPU||KERNEL_MIPS_FPU_EMULATOR) +libstdcpp +libopenssl +zlib +USE_UCLIBC:libpthread +USE_UCLIBC:librt +NODEJS_ICU:icu
+  DEPENDS:=@(HAS_FPU||KERNEL_MIPS_FPU_EMULATOR) +libstdcpp +libopenssl +zlib +libnghttp2 +libuv +libhttp-parser +USE_UCLIBC:libpthread +USE_UCLIBC:librt +NODEJS_ICU:icu
 endef
 
 define Package/node/description
@@ -86,6 +86,9 @@ CONFIGURE_ARGS:= \
 	--without-snapshot \
 	--shared-zlib \
 	--shared-openssl \
+	--shared-nghttp2 \
+	--shared-libuv \
+	--shared-http-parser \
 	--with-intl=$(if $(CONFIG_NODEJS_ICU),system-icu,none) \
 	$(if $(findstring mips,$(NODEJS_CPU)), \
 		$(if $(CONFIG_SOFT_FLOAT),--with-mips-float-abi=soft)) \


### PR DESCRIPTION
Maintainer: @blogic 
Compile tested: ramips, mipsel_74ck, openwrt master
Run tested: none

Description:
Use the openwrt system libraries instead of the ones bundled with node.
This may help with building other node-* packages, since buildbots can't access node sources anymore, and will use system headers, see #7652.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>