### PR TITLE
youtube-dl: update to version 2018.12.09

### DIFF
--- a/multimedia/youtube-dl/Makefile
+++ b/multimedia/youtube-dl/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=youtube-dl
-PKG_VERSION:=2018.06.04
+PKG_VERSION:=2018.12.09
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://yt-dl.org/downloads/$(PKG_VERSION)/
-PKG_HASH:=436ef69e59a1acf8091f5c294a563d6859ce6ec42543ea3abb501e2c09131301
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+PKG_SOURCE_URL:=https://codeload.github.com/rg3/youtube-dl/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=f277dee39adcf1fa19a14846eebc1e2c3749dd245e11d51783fa5ea366f34bff
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_LICENSE:=Unlicense
 PKG_LICENSE_FILES:=LICENSE
@@ -33,20 +33,20 @@ define Package/youtube-dl
 endef
 
 define Package/youtube-dl/description
-  youtube-dl is a small command-line program to download videos 
-  from YouTube.com and a few more sites. 
+  youtube-dl is a small command-line program to download videos
+  from YouTube.com and a few more sites.
   It requires the Python interpreter.
 endef
 
 define Package/youtube-dl/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	
+
 	python -m compileall $(PKG_BUILD_DIR)/youtube_dl/
 	cd $(PKG_BUILD_DIR) && zip --quiet youtube-dl-c.zip youtube_dl/*.pyc youtube_dl/*/*.pyc
 	cd $(PKG_BUILD_DIR) && zip --quiet --junk-paths youtube-dl-c.zip youtube_dl/__main__.pyc
 	echo '#!/usr/bin/env python' > $(PKG_BUILD_DIR)/youtube-dl-c
 	cat $(PKG_BUILD_DIR)/youtube-dl-c.zip >> $(PKG_BUILD_DIR)/youtube-dl-c
-	
+
 	$(INSTALL_BIN) -T $(PKG_BUILD_DIR)/youtube-dl-c $(1)/usr/bin/youtube-dl
 endef
 

--- a/multimedia/youtube-dl/patches/dont-use-pandoc.patch
+++ b/multimedia/youtube-dl/patches/dont-use-pandoc.patch
@@ -1,0 +1,21 @@
+diff --git a/Makefile b/Makefile
+index 4a62f44..fee93e8 100644
+--- a/Makefile
++++ b/Makefile
+@@ -85,12 +85,12 @@ supportedsites:
+ 	$(PYTHON) devscripts/make_supportedsites.py docs/supportedsites.md
+ 
+ README.txt: README.md
+-	pandoc -f $(MARKDOWN) -t plain README.md -o README.txt
++#	pandoc -f $(MARKDOWN) -t plain README.md -o README.txt
+ 
+ youtube-dl.1: README.md
+-	$(PYTHON) devscripts/prepare_manpage.py youtube-dl.1.temp.md
+-	pandoc -s -f $(MARKDOWN) -t man youtube-dl.1.temp.md -o youtube-dl.1
+-	rm -f youtube-dl.1.temp.md
++#	$(PYTHON) devscripts/prepare_manpage.py youtube-dl.1.temp.md
++#	pandoc -s -f $(MARKDOWN) -t man youtube-dl.1.temp.md -o youtube-dl.1
++#	rm -f youtube-dl.1.temp.md
+ 
+ youtube-dl.bash-completion: youtube_dl/*.py youtube_dl/*/*.py devscripts/bash-completion.in
+ 	$(PYTHON) devscripts/bash-completion.py


### PR DESCRIPTION
Maintainer: @ianchi 
Compiled tested: cortexa53, Turris MOX, OpenWrt 18.06.1
Run tested: cortexa53, Turris MOX, OpenWrt 18.06.1

Description:

I don't know, why in Makefile of youtube-dl, there's a need for pandoc, which is a converter for documentation.
 
If the host build doesn't have it, it ends up with this kind of error:
```
chmod a+x youtube-dl
/bin/sh: 1: pandoc: not found
/bin/sh: 1: [: =: unexpected operator
pandoc -f markdown -t plain README.md -o README.txt
make[3]: pandoc: Command not found
Makefile:88: recipe for target 'README.txt' failed
```

Once, I have installed pandoc to my computer, the compilation went well and in the compiled package, there was no documentation, just the binary. As the documentation is not needed and the binary has its own help included via parameter **youtube-dl --help**. I have created a patch, which comments out lines for pandoc and it works, so you don't need to have installed pandoc.

I can understand that someone can say that it is an ugly hack, but maybe some of you know some better ways, how to do it. However, if you want to put pandoc/host to PKG_BUILD_DEPENDS, I have not problems with that even though I think that this should be handled by upstream (in this case youtube-dl).

While I was at it, I have noticed that they have [Github repository](https://github.com/rg3/youtube-dl), which is properly tagged, so I have switched it to codeload.