### PR TITLE
haproxy: Update deprecated API patch

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
 PKG_VERSION:=1.8.15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=haproxy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/1.8/src/

--- a/net/haproxy/patches/001-deprecated-openssl.patch
+++ b/net/haproxy/patches/001-deprecated-openssl.patch
@@ -1,5 +1,3 @@
-diff --git a/src/ssl_sock.c b/src/ssl_sock.c
-index cfbc38b..025a144 100644
 --- a/src/ssl_sock.c
 +++ b/src/ssl_sock.c
 @@ -39,6 +39,7 @@
@@ -10,106 +8,93 @@ index cfbc38b..025a144 100644
  #include <openssl/crypto.h>
  #include <openssl/ssl.h>
  #include <openssl/x509.h>
-@@ -229,6 +230,7 @@ unsigned long ssl_id_function(void)
+@@ -60,6 +61,17 @@
+ #include <openssl/async.h>
+ #endif
  
- void ssl_locking_function(int mode, int n, const char * file, int line)
- {
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L
- 	if (mode & CRYPTO_LOCK) {
- 		if (mode & CRYPTO_READ)
- 			HA_RWLOCK_RDLOCK(SSL_LOCK, &ssl_rwlocks[n]);
-@@ -241,10 +243,12 @@ void ssl_locking_function(int mode, int n, const char * file, int line)
- 		else
- 			HA_RWLOCK_WRUNLOCK(SSL_LOCK, &ssl_rwlocks[n]);
- 	}
++#ifndef OPENSSL_VERSION
++#define OPENSSL_VERSION		SSLEAY_VERSION
++#define OpenSSL_version(x)	SSLeay_version(x)
++#define OpenSSL_version_num	SSLeay
 +#endif
- }
- 
- static int ssl_locking_init(void)
- {
++
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
- 	int i;
- 
- 	ssl_rwlocks = malloc(sizeof(HA_RWLOCK_T)*CRYPTO_num_locks());
-@@ -256,7 +260,7 @@ static int ssl_locking_init(void)
- 
- 	CRYPTO_set_id_callback(ssl_id_function);
- 	CRYPTO_set_locking_callback(ssl_locking_function);
--
++#define X509_getm_notBefore X509_get_notBefore
++#define X509_getm_notAfter X509_get_notAfter
 +#endif
- 	return 0;
- }
++
+ #include <import/lru.h>
+ #include <import/xxhash.h>
  
-@@ -1711,8 +1715,13 @@ ssl_sock_do_create_cert(const char *servername, struct bind_conf *bind_conf, SSL
+@@ -217,7 +229,7 @@ static struct {
+ 	.capture_cipherlist = 0,
+ };
+ 
+-#ifdef USE_THREAD
++#if defined(USE_THREAD) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
+ 
+ static HA_RWLOCK_T *ssl_rwlocks;
+ 
+@@ -1711,8 +1723,8 @@ ssl_sock_do_create_cert(const char *servername, struct bind_conf *bind_conf, SSL
  	ASN1_INTEGER_set(X509_get_serialNumber(newcrt), HA_ATOMIC_ADD(&ssl_ctx_serial, 1));
  
  	/* Set duration for the certificate */
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L
- 	if (!X509_gmtime_adj(X509_get_notBefore(newcrt), (long)-60*60*24) ||
- 	    !X509_gmtime_adj(X509_get_notAfter(newcrt),(long)60*60*24*365))
-+#else
+-	if (!X509_gmtime_adj(X509_get_notBefore(newcrt), (long)-60*60*24) ||
+-	    !X509_gmtime_adj(X509_get_notAfter(newcrt),(long)60*60*24*365))
 +	if (!X509_gmtime_adj(X509_getm_notBefore(newcrt), (long)-60*60*24) ||
 +	    !X509_gmtime_adj(X509_getm_notAfter(newcrt),(long)60*60*24*365))
-+#endif
  		goto mkcert_error;
  
  	/* set public key in the certificate */
-@@ -6285,7 +6294,11 @@ smp_fetch_ssl_x_notafter(const struct arg *args, struct sample *smp, const char
+@@ -6285,7 +6297,7 @@ smp_fetch_ssl_x_notafter(const struct arg *args, struct sample *smp, const char
  		goto out;
  
  	smp_trash = get_trash_chunk();
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L
- 	if (ssl_sock_get_time(X509_get_notAfter(crt), smp_trash) <= 0)
-+#else
+-	if (ssl_sock_get_time(X509_get_notAfter(crt), smp_trash) <= 0)
 +	if (ssl_sock_get_time(X509_getm_notAfter(crt), smp_trash) <= 0)
-+#endif
  		goto out;
  
  	smp->data.u.str = *smp_trash;
-@@ -6385,7 +6398,11 @@ smp_fetch_ssl_x_notbefore(const struct arg *args, struct sample *smp, const char
+@@ -6385,7 +6397,7 @@ smp_fetch_ssl_x_notbefore(const struct arg *args, struct sample *smp, const char
  		goto out;
  
  	smp_trash = get_trash_chunk();
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L
- 	if (ssl_sock_get_time(X509_get_notBefore(crt), smp_trash) <= 0)
-+#else
+-	if (ssl_sock_get_time(X509_get_notBefore(crt), smp_trash) <= 0)
 +	if (ssl_sock_get_time(X509_getm_notBefore(crt), smp_trash) <= 0)
-+#endif
  		goto out;
  
  	smp->data.u.str = *smp_trash;
-@@ -8935,7 +8952,11 @@ static void __ssl_sock_init(void)
+@@ -8935,10 +8947,12 @@ static void __ssl_sock_init(void)
  #endif
  
  	xprt_register(XPRT_SSL, &ssl_sock);
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
  	SSL_library_init();
-+#else
-+	OPENSSL_init_ssl(0, NULL);
 +#endif
  	cm = SSL_COMP_get_compression_methods();
  	sk_SSL_COMP_zero(cm);
- #ifdef USE_THREAD
-@@ -8967,8 +8988,13 @@ static void __ssl_sock_init(void)
+-#ifdef USE_THREAD
++#if defined(USE_THREAD) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
+ 	ssl_locking_init();
+ #endif
+ #if (OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined OPENSSL_NO_TLSEXT && !defined OPENSSL_IS_BORINGSSL && !defined LIBRESSL_VERSION_NUMBER)
+@@ -8967,8 +8981,8 @@ static void __ssl_sock_init(void)
  #else /* OPENSSL_IS_BORINGSSL */
  	        OPENSSL_VERSION_TEXT
  		"\nRunning on OpenSSL version : %s%s",
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L
- 	       SSLeay_version(SSLEAY_VERSION),
- 	       ((OPENSSL_VERSION_NUMBER ^ SSLeay()) >> 8) ? " (VERSIONS DIFFER!)" : "");
-+#else
+-	       SSLeay_version(SSLEAY_VERSION),
+-	       ((OPENSSL_VERSION_NUMBER ^ SSLeay()) >> 8) ? " (VERSIONS DIFFER!)" : "");
 +	       OpenSSL_version(OPENSSL_VERSION),
 +	       ((OPENSSL_VERSION_NUMBER ^ OpenSSL_version_num()) >> 8) ? " (VERSIONS DIFFER!)" : "");
-+#endif
  #endif
  	memprintf(&ptr, "%s\nOpenSSL library supports TLS extensions : "
  #if OPENSSL_VERSION_NUMBER < 0x00907000L
-@@ -9060,11 +9086,14 @@ static void __ssl_sock_deinit(void)
+@@ -9059,12 +9073,14 @@ static void __ssl_sock_deinit(void)
+ 	}
  #endif
  
-         ERR_remove_state(0);
-+
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
+         ERR_remove_state(0);
          ERR_free_strings();
  
          EVP_cleanup();


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: ramips

Description: This matches what was sent upstream. It's also 15 lines smaller.
