### PR TITLE
chaosvpn: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/chaosvpn/Makefile
+++ b/net/chaosvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=chaosvpn
 
 PKG_VERSION:=2.19
-PKG_RELEASE=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ryd/chaosvpn/tar.gz/v$(PKG_VERSION)?

--- a/net/chaosvpn/patches/010-openssl-deprecated.patch
+++ b/net/chaosvpn/patches/010-openssl-deprecated.patch
@@ -1,0 +1,47 @@
+--- a/crypto.c
++++ b/crypto.c
+@@ -14,6 +14,12 @@
+ #include <openssl/pem.h>
+ #include <openssl/ssl.h>
+ 
++#ifndef OPENSSL_VERSION
++#define OPENSSL_VERSION		SSLEAY_VERSION
++#define OpenSSL_version(x)	SSLeay_version(x)
++#define OpenSSL_version_num	SSLeay
++#endif
++
+ /*
+ 
+ This checks data in a struct string against a signature in a second
+@@ -250,14 +256,18 @@ bail_out:
+ void
+ crypto_init(void)
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     /* Just load the crypto library error strings, not SSL */
+     ERR_load_crypto_strings();
++#endif
+ }
+ 
+ void
+ crypto_finish(void)
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     ERR_free_strings();
++#endif
+ }
+ 
+ void
+@@ -268,10 +278,10 @@ crypto_warn_openssl_version_changed(void)
+      * OpenSSL library used.
+      * Output a warning if not.
+      */
+-    if (SSLeay() != OPENSSL_VERSION_NUMBER) {
++    if (OpenSSL_version_num() != OPENSSL_VERSION_NUMBER) {
+         log_info("Note: compiled using OpenSSL version '%s' headers, but linked to "
+           "OpenSSL version '%s' library",
+           OPENSSL_VERSION_TEXT,
+-          SSLeay_version(SSLEAY_VERSION));
++          OpenSSL_version(OPENSSL_VERSION));
+     }
+ }


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @TuxCoder 
Compile tested: ar71xx