### PR TITLE
git: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/git/Makefile
+++ b/net/git/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=git
 PKG_VERSION:=2.20.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/scm/git/

--- a/net/git/patches/300-openssl-deprecated.patch
+++ b/net/git/patches/300-openssl-deprecated.patch
@@ -1,0 +1,32 @@
+From fa37195d8378ac958d1f9bd884b47bd73730040e Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Thu, 27 Dec 2018 09:58:07 -0800
+Subject: [PATCH] imap-send: Fix compilation without deprecated OpenSSL APIs
+
+Initialization in OpenSSL has been deprecated in version 1.1. This makes
+compilation fail when deprecated APIs for OpenSSL are compile-time
+disabled.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ imap-send.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/imap-send.c b/imap-send.c
+index b4eb886e2..877a4e368 100644
+--- a/imap-send.c
++++ b/imap-send.c
+@@ -284,8 +284,10 @@ static int ssl_socket_connect(struct imap_socket *sock, int use_tls_only, int ve
+ 	int ret;
+ 	X509 *cert;
+ 
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+ 	SSL_library_init();
+ 	SSL_load_error_strings();
++#endif
+ 
+ 	meth = SSLv23_method();
+ 	if (!meth) {
+-- 
+2.20.1
+


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: ar71xx