### PR TITLE
aria2: fix some typo and init script mistakes

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
 PKG_VERSION:=1.34.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/

--- a/net/aria2/files/aria2.init
+++ b/net/aria2/files/aria2.init
@@ -312,9 +312,9 @@ aria2_start() {
 
 	if [ -n "$user" ]; then
 		if ( user_exists "$user" && _change_owner "$user" "$config_dir" "$log" ); then
-				_info "Aria2 will run with uer '${user}'."
+				_info "Aria2 will run with user '${user}'."
 				if [ "$user" != "root" ]; then
-					_info "Please make sure user '${user}' has write access to downlod dir: ${dir}"
+					_info "Please make sure user '${user}' has write access to download dir: ${dir}"
 				fi
 		else
 			_info "Set run user to '${user}' failed, default user will be used."


### PR DESCRIPTION
1. fix some typo in aria2.init script
2. fix log option according to the luci-app-aria2 setting
