### PR TITLE
libv4l: Remove libudev dependency

### DIFF
--- a/libs/libv4l/Makefile
+++ b/libs/libv4l/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v4l-utils
 PKG_VERSION:=1.14.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.linuxtv.org/downloads/v4l-utils

--- a/libs/libv4l/patches/010-build-without-libudev.patch
+++ b/libs/libv4l/patches/010-build-without-libudev.patch
@@ -1,0 +1,31 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -258,16 +258,18 @@ else
+    AC_MSG_WARN(ALSA library not available)
+ fi
+ 
+-PKG_CHECK_MODULES(libudev, libudev, have_libudev=yes, have_libudev=no)
+-if test "x$have_libudev" = "xyes"; then
+-	AC_DEFINE([HAVE_LIBUDEV], [], [Use libudev])
+-	LIBUDEV_CFLAGS="$libudev_CFLAGS"
+-	LIBUDEV_LIBS="$libudev_LIBS"
+-	AC_SUBST(LIBUDEV_CFLAGS)
+-	AC_SUBST(LIBUDEV_LIBS)
+-else
+-   AC_MSG_WARN(udev library not available)
+-fi
++# Build without libudev
++havelibudev=no
++#PKG_CHECK_MODULES(libudev, libudev, have_libudev=yes, have_libudev=no)
++#if test "x$have_libudev" = "xyes"; then
++#	AC_DEFINE([HAVE_LIBUDEV], [], [Use libudev])
++#	LIBUDEV_CFLAGS="$libudev_CFLAGS"
++#	LIBUDEV_LIBS="$libudev_LIBS"
++#	AC_SUBST(LIBUDEV_CFLAGS)
++#	AC_SUBST(LIBUDEV_LIBS)
++#else
++#   AC_MSG_WARN(udev library not available)
++#fi
+ 
+ AC_SUBST([JPEG_LIBS])
+ 


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: ramips, mipsel_74kc, openwrt master
Run tested: none

Description:
It was picking up libudev (in `utils/media-ctl/libmediactl.c`):
```
Package v4l-utils is missing dependencies for the following libraries:
libevdev.so.2
libudev.so.1
```

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

