### PR TITLE
gstreamer1: build without libdw

### DIFF
--- a/multimedia/gstreamer1/Makefile
+++ b/multimedia/gstreamer1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gstreamer1
 PKG_VERSION:=1.14.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
 		Ted Hess <thess@kitschensync.net>
@@ -127,6 +127,7 @@ CONFIGURE_ARGS += \
 	--disable-gtk-doc-html \
 	--disable-tests \
 	--disable-valgrind \
+	--without-dw \
 	--without-libiconv-prefix \
 	--without-libintl-prefix \
 	--without-unwind


### PR DESCRIPTION
Maintainer: @thess, @MikePetullo 
Compile tested: ramips, mipsel_74kc, openwrt master
Run tested: None

Description:
Avoids dependencies with libdw and libelf:
```
Package libgstreamer1 is missing dependencies for the following libraries:
libdw.so.1
libelf.so.1
```

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>