### PR TITLE
v4l2rtspserver: Update to 0.1.1

### DIFF
--- a/multimedia/v4l2rtspserver/Makefile
+++ b/multimedia/v4l2rtspserver/Makefile
@@ -5,24 +5,29 @@
 # See /LICENSE for more information.
 
 include $(TOPDIR)/rules.mk
- 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/mpromonet/v4l2rtspserver.git
-PKG_MIRROR_HASH:=ccd2424b94feb7c52e53700b8613e16291463e3717aff598385d8439ad8c81af
-PKG_SOURCE_VERSION:=7ead7613fe6719b6004d229130f7d62aa0a149e7
-PKG_DATE:=2018-05-26
 
 PKG_NAME:=v4l2rtspserver
-PKG_VERSION:=$(PKG_DATE)-$(PKG_SOURCE_VERSION)
+PKG_VERSION:=0.1.1
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Roger Dammit <rogerdammit@gmail.com>
 
-LIVE555_VERSION:=2018.04.25
-LIVE555_MD5SUM:=9b58a5d62659eb29b9bd85d1b29c3a75
+#cannot use codeload as this uses submodules
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/mpromonet/v4l2rtspserver
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_MIRROR_HASH:=3e3c106b41562be010ba2132903ebf9cdc75a2caceca468b10e2cd0d2939e940
+
+PKG_MAINTAINER:=Roger Dammit <rogerdammit@gmail.com>
+PKG_LICENSE:=Unlicense
+PKG_LICENSE_FILES:=LICENSE
+
+LIVE555_VERSION:=2018.12.14
+LIVE555_HASH:=8dc31f76909602c3c07c8f876237e6ab7ac674d00f1bb065eda20e719f772a47
 LIVE555_FILE:=live.$(LIVE555_VERSION).tar.gz
 
-CMAKE_INSTALL:=1 
+PKG_BUILD_PARALLEL:=1
+CMAKE_INSTALL:=1
 
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
@@ -30,9 +35,9 @@ define Package/v4l2rtspserver
 	SECTION:=multimedia
 	CATEGORY:=Multimedia
 	TITLE:=v4l2rtspserver
-	DEPENDS:=+libstdcpp
+	DEPENDS:=$(CXX_DEPENDS)
 	URL:=https://github.com/mpromonet/v4l2rtspserver
-endef  
+endef
 
 define Package/v4l2rtspserver/description
 	RTSP server for v4L2 video sources
@@ -45,8 +50,12 @@ endef
 define Download/live555
 	URL:=https://download.videolan.org/pub/contrib/live555/
 	FILE:=$(LIVE555_FILE)
-	MD5SUM:=$(LIVE555_MD5SUM)
+	HASH:=$(LIVE555_HASH)
 endef
+
+TARGET_CFLAGS += -flto
+TARGET_CXXFLAGS += -fno-rtti
+TARGET_LDFLAGS += -Wl,--gc-sections
 
 define Build/Prepare
 	$(Build/Prepare/Default)
@@ -54,23 +63,23 @@ define Build/Prepare
 	## need to compile some dependencies so that cmake will find them
 
 	# build live555
-        $(eval $(call Download,live555))
+	$(eval $(call Download,live555))
 
 	mkdir -p $(PKG_BUILD_DIR)/live555
 	$(TAR) -xf $(DL_DIR)/$(LIVE555_FILE) --strip=1 -C $(PKG_BUILD_DIR)/live555
 	$(CP) files/config.openwrt $(PKG_BUILD_DIR)/live555
 	( cd $(PKG_BUILD_DIR)/live555; ./genMakefiles openwrt )
 
-	$(MAKE) $(MAKE_FLAGS) -C $(PKG_BUILD_DIR)/live555 
-	$(MAKE) -C $(PKG_BUILD_DIR)/live555 PREFIX="$(STAGING_DIR)/usr/" install
+	+$(MAKE_VARS) $(MAKE) $(MAKE_FLAGS) -C $(PKG_BUILD_DIR)/live555
+	 $(MAKE_VARS) $(MAKE) $(MAKE_FLAGS) -C $(PKG_BUILD_DIR)/live555 PREFIX="$(STAGING_DIR)/usr/" install
 
 	# build v4l2wrapper
-	$(MAKE) $(MAKE_FLAGS) -C $(PKG_BUILD_DIR)/v4l2wrapper CFLAGS="$(TARGET_CFLAGS) -I $(PKG_BUILD_DIR)/v4l2wrapper/inc"
+	+$(MAKE_VARS) $(MAKE) $(MAKE_FLAGS) -C $(PKG_BUILD_DIR)/v4l2wrapper
 	$(CP) $(PKG_BUILD_DIR)/v4l2wrapper/libv4l2wrapper.a $(PKG_BUILD_DIR)
 
 	# cmake patches (these are very hacky and should be a lot cleaner)
 
-	# prevent root path override 
+	# prevent root path override
 	$(SED) 's/SET(CMAKE_FIND_ROOT_PATH/#SET(CMAKE_FIND_ROOT_PATH/' $(PKG_BUILD_DIR)/CMakeLists.txt
 
 	# set search path for v4l2wrapper to current build dir
@@ -89,6 +98,6 @@ define Package/v4l2rtspserver/install
 	$(INSTALL_BIN) files/v4l2rtspserver.init $(1)/etc/init.d/v4l2rtspserver
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) files/v4l2rtspserver.config $(1)/etc/config/v4l2rtspserver
-endef 
+endef
 
 $(eval $(call BuildPackage,v4l2rtspserver))

--- a/multimedia/v4l2rtspserver/patches/010-Add-a-few-missing-headers.patch
+++ b/multimedia/v4l2rtspserver/patches/010-Add-a-few-missing-headers.patch
@@ -1,0 +1,39 @@
+From 9977cc5a4b35809bed04be543cf38e32d8f175c5 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sat, 15 Dec 2018 15:02:34 -0800
+Subject: [PATCH] Add a few missing headers
+
+Helps to compile with alternative c++ libraries.
+---
+ inc/DeviceSource.h     | 2 ++
+ inc/MemoryBufferSink.h | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/inc/DeviceSource.h b/inc/DeviceSource.h
+index 7d4aa18..0e2f996 100755
+--- a/inc/DeviceSource.h
++++ b/inc/DeviceSource.h
+@@ -18,6 +18,8 @@
+ #include <iostream>
+ #include <iomanip>
+ 
++#include <pthread.h>
++
+ // live555
+ #include <liveMedia.hh>
+ 
+diff --git a/inc/MemoryBufferSink.h b/inc/MemoryBufferSink.h
+index 97e1db1..fc6de20 100644
+--- a/inc/MemoryBufferSink.h
++++ b/inc/MemoryBufferSink.h
+@@ -12,6 +12,7 @@
+ #pragma once
+ 
+ #include <map>
++#include <string>
+ 
+ #include "MediaSink.hh"
+ 
+-- 
+2.20.1
+

--- a/multimedia/v4l2rtspserver/patches/020-replace-std-stoi-with-atoi.patch
+++ b/multimedia/v4l2rtspserver/patches/020-replace-std-stoi-with-atoi.patch
@@ -1,0 +1,25 @@
+From 6e569797c0691d7fb2ba72952f81806d0477ca03 Mon Sep 17 00:00:00 2001
+From: Michel Promonet <michel.promonet@free.fr>
+Date: Tue, 11 Dec 2018 08:25:35 +0100
+Subject: [PATCH] replace std::stoi with atoi
+
+---
+ src/ServerMediaSubsession.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ServerMediaSubsession.cpp b/src/ServerMediaSubsession.cpp
+index c90555e..9ac9a76 100755
+--- a/src/ServerMediaSubsession.cpp
++++ b/src/ServerMediaSubsession.cpp
+@@ -99,7 +99,7 @@ RTPSink*  BaseServerMediaSubsession::createSink(UsageEnvironment& env, Groupsock
+ 		getline(is, sampleRate, '/');	
+ 		std::string channels("2");
+ 		getline(is, channels);	
+-		videoSink = SimpleRTPSink::createNew(env, rtpGroupsock,rtpPayloadTypeIfDynamic, std::stoi(sampleRate), "audio", "L16", std::stoi(channels), True, False); 
++		videoSink = SimpleRTPSink::createNew(env, rtpGroupsock,rtpPayloadTypeIfDynamic, atoi(sampleRate), "audio", "L16", atoi(channels), True, False); 
+ 	}
+ 	return videoSink;
+ }
+-- 
+2.20.1
+

--- a/multimedia/v4l2rtspserver/patches/030-fix-build.patch
+++ b/multimedia/v4l2rtspserver/patches/030-fix-build.patch
@@ -1,0 +1,25 @@
+From be6dc4592e91841cfe593d88bfe8a8f068671c74 Mon Sep 17 00:00:00 2001
+From: Michel Promonet <michel.promonet@free.fr>
+Date: Tue, 11 Dec 2018 08:34:14 +0100
+Subject: [PATCH] fix build
+
+---
+ src/ServerMediaSubsession.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ServerMediaSubsession.cpp b/src/ServerMediaSubsession.cpp
+index 9ac9a76..a8b0bb3 100755
+--- a/src/ServerMediaSubsession.cpp
++++ b/src/ServerMediaSubsession.cpp
+@@ -99,7 +99,7 @@ RTPSink*  BaseServerMediaSubsession::createSink(UsageEnvironment& env, Groupsock
+ 		getline(is, sampleRate, '/');	
+ 		std::string channels("2");
+ 		getline(is, channels);	
+-		videoSink = SimpleRTPSink::createNew(env, rtpGroupsock,rtpPayloadTypeIfDynamic, atoi(sampleRate), "audio", "L16", atoi(channels), True, False); 
++		videoSink = SimpleRTPSink::createNew(env, rtpGroupsock,rtpPayloadTypeIfDynamic, atoi(sampleRate.c_str()), "audio", "L16", atoi(channels.c_str()), True, False); 
+ 	}
+ 	return videoSink;
+ }
+-- 
+2.20.1
+

--- a/multimedia/v4l2rtspserver/patches/040-Switch-Makefile-to-compile-with-g.patch
+++ b/multimedia/v4l2rtspserver/patches/040-Switch-Makefile-to-compile-with-g.patch
@@ -1,0 +1,51 @@
+From f732d44c2bc47e6eccf65e5eb3160734f11e5d3e Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Thu, 27 Dec 2018 20:16:59 -0800
+Subject: [PATCH] Switch Makefile to compile with g++
+
+With this change I managed to get OpenWrt to compile with uclibcxx
+instead of libstdcpp.
+
+Made CXX adjustable by the shell as OpenWrt needs to override this.
+It also has its own ar.
+
+EXTRA_CXXFLAGS seems to be the proper variable based on usage in the
+OpenWrt tree.
+---
+ Makefile | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 51aaa37..f05bf0d 100644
+--- a/v4l2wrapper/Makefile
++++ b/v4l2wrapper/Makefile
+@@ -1,12 +1,12 @@
+-CFLAGS = -W -Wall -pthread -g -pipe $(CFLAGS_EXTRA)
+-CFLAGS += -I inc
++CXXFLAGS ?= -W -Wall -pthread -g -pipe $(EXTRA_CXXFLAGS)
++CXXFLAGS += -I inc
+ RM = rm -rf
+-CC = $(CROSS)gcc
+-AR = $(CROSS)ar
++CXX ?= $(CROSS)g++
++AR ?= $(CROSS)ar
+ PREFIX?=/usr
+ 
+ ifneq ($(wildcard $(SYSROOT)$(PREFIX)/include/log4cpp/Category.hh),)
+-CFLAGS += -DHAVE_LOG4CPP -I $(SYSROOT)$(PREFIX)/include
++CXXFLAGS += -DHAVE_LOG4CPP -I $(SYSROOT)$(PREFIX)/include
+ endif
+ 
+ V4L2WRAPPER_CPP:=$(wildcard src/*.cpp)
+@@ -17,7 +17,7 @@ V4L2WRAPPER_OBJ:=$(V4L2WRAPPER_CPP:%.cpp=%.o)
+ all: libv4l2wrapper.a
+ 
+ %.o: %.cpp
+-	$(CC) -c -o $@ $< $(CFLAGS)
++	$(CXX) -c -o $@ $< $(CXXFLAGS)
+ 
+ libv4l2wrapper.a: $(V4L2WRAPPER_OBJ)
+ 	$(AR) rcs $@ $^
+-- 
+2.20.1
+


### PR DESCRIPTION
Switched to using versioned releases.

Removed md5 usage and went full sha256.

Various other adjustments.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @roger- 
Compile tested: ramips

I tried to get this to compile with uclibc++ but failed. I will take the issue to upstream.
