### PR TITLE
fcgi: Update to 2.4.1

### DIFF
--- a/libs/fcgi/Makefile
+++ b/libs/fcgi/Makefile
@@ -1,6 +1,4 @@
 #
-# Copyright (C) 2007-2011 OpenWrt.org
-#
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
@@ -8,17 +6,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fcgi
-PKG_VERSION:=2.4.0
+PKG_VERSION:=2.4.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.fastcgi.com/dist/
-PKG_HASH:=66fc45c6b36a21bf2fbbb68e90f780cc21a9da1fffbae75e76d2b4402d3f05b9
-
-PKG_FIXUP:=libtool-ucxx
+PKG_SOURCE:=$(PKG_NAME)2-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/FastCGI-Archives/fcgi2/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=53cc36624bb92a88e3d5a3d696282e1af24b280c3f275604123d9c6d407173e2
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)2-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Jacob Siverskog <jacob@teenageengineering.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.TERMS
 
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/uclibc++.mk
@@ -27,13 +28,13 @@ include $(INCLUDE_DIR)/package.mk
 define Package/fcgi/Default
   SECTION:=libs
   CATEGORY:=Libraries
-  URL:=http://www.fastcgi.com/
+  URL:=https://fastcgi-archives.github.io/
 endef
 
 define Package/fcgi
   $(call Package/fcgi/Default)
   MENU:=1
-  DEPENDS:= +libpthread
+  DEPENDS:=+libpthread
   TITLE:=Shared library of FastCGI
 endef
 
@@ -48,15 +49,6 @@ define Package/fcgi/description
  CGI that provides high performance without the limitations of
  server specific APIs.
 endef
-
-TARGET_CFLAGS += $(FPIC)
-
-CONFIGURE_ARGS += \
-	--enable-shared \
-	--enable-static \
-
-CONFIGURE_VARS += \
-	LIBS="-lm" \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include

--- a/libs/fcgi/patches/100-fcgio-int-type-fix.patch
+++ b/libs/fcgi/patches/100-fcgio-int-type-fix.patch
@@ -1,8 +1,8 @@
-Index: fcgi-2.4.0/include/fcgio.h
-===================================================================
---- fcgi-2.4.0.orig/include/fcgio.h	2007-07-17 13:30:28.000000000 +0200
-+++ fcgi-2.4.0/include/fcgio.h	2007-07-17 13:30:28.000000000 +0200
-@@ -77,10 +77,10 @@
+diff --git a/include/fcgio.h b/include/fcgio.h
+index 20d222a..92eda3c 100644
+--- a/include/fcgio.h
++++ b/include/fcgio.h
+@@ -77,10 +77,10 @@ protected:
      virtual int sync();
  
      // Remove and return the current character.
@@ -15,22 +15,23 @@ Index: fcgi-2.4.0/include/fcgio.h
  
      // Use a buffer.  The only reasons that a buffer would be useful is
      // to support the use of the unget()/putback() or seek() methods.  Using
-diff -urN fcgi-2.4.0/libfcgi/fcgio.cpp fcgi-2.4.0.new/libfcgi/fcgio.cpp
---- fcgi-2.4.0/libfcgi/fcgio.cpp	2002-02-24 21:12:22.000000000 +0100
-+++ fcgi-2.4.0.new/libfcgi/fcgio.cpp	2007-08-28 11:22:22.000000000 +0200
-@@ -89,7 +89,7 @@
+diff --git a/libfcgi/fcgio.cpp b/libfcgi/fcgio.cpp
+index 5a54c11..e57b622 100644
+--- a/libfcgi/fcgio.cpp
++++ b/libfcgi/fcgio.cpp
+@@ -89,7 +89,7 @@ int fcgi_streambuf::sync()
  }
  
  // uflow() removes the char, underflow() doesn't
 -int fcgi_streambuf::uflow() 
 +std::basic_streambuf<char>::int_type fcgi_streambuf::uflow()
  {
-     int rv = underflow();
-     if (this->bufsize) gbump(1);
-@@ -97,7 +97,7 @@
+     if (this->bufsize)
+     {
+@@ -103,7 +103,7 @@ int fcgi_streambuf::uflow()
+     }
  }
  				
- // Note that the expected behaviour when there is no buffer varies
 -int fcgi_streambuf::underflow()
 +std::basic_streambuf<char>::int_type fcgi_streambuf::underflow()
  {

--- a/libs/fcgi/patches/110-no_examples.patch
+++ b/libs/fcgi/patches/110-no_examples.patch
@@ -1,21 +1,10 @@
-diff -urN fcgi-2.4.0/Makefile.am fcgi-2.4.0.new/Makefile.am
---- fcgi-2.4.0/Makefile.am	2001-12-22 14:05:39.000000000 +0100
-+++ fcgi-2.4.0.new/Makefile.am	2007-08-28 11:05:10.000000000 +0200
+diff --git a/Makefile.am b/Makefile.am
+index b35f7f3..c34a274 100755
+--- a/Makefile.am
++++ b/Makefile.am
 @@ -4,7 +4,7 @@
- #  $Id: Makefile.am,v 1.7 2001/12/22 13:05:39 robs Exp $
+ #  $Id: Makefile.am,v 1.8 2003/11/02 21:42:47 robs Exp $
  #
- 
--SUBDIRS = libfcgi cgi-fcgi examples include
-+SUBDIRS = libfcgi cgi-fcgi include
- 
- include_HEADERS = fcgi_config.h
- 
-diff -urN fcgi-2.4.0/Makefile.in fcgi-2.4.0.new/Makefile.in
---- fcgi-2.4.0/Makefile.in	2003-01-19 18:21:15.000000000 +0100
-+++ fcgi-2.4.0.new/Makefile.in	2007-08-28 11:04:55.000000000 +0200
-@@ -93,7 +93,7 @@
- am__quote = @am__quote@
- install_sh = @install_sh@
  
 -SUBDIRS = libfcgi cgi-fcgi examples include
 +SUBDIRS = libfcgi cgi-fcgi include

--- a/libs/fcgi/patches/120-stdio.patch
+++ b/libs/fcgi/patches/120-stdio.patch
@@ -1,7 +1,7 @@
-Index: fcgi-2.4.0/libfcgi/fcgio.cpp
-===================================================================
---- fcgi-2.4.0.orig/libfcgi/fcgio.cpp	2014-05-15 10:43:15.153971782 +0200
-+++ fcgi-2.4.0/libfcgi/fcgio.cpp	2014-05-15 10:44:44.037974020 +0200
+diff --git a/libfcgi/fcgio.cpp b/libfcgi/fcgio.cpp
+index 5a54c11..9ecca45 100644
+--- a/libfcgi/fcgio.cpp
++++ b/libfcgi/fcgio.cpp
 @@ -23,6 +23,7 @@
  #endif
  

--- a/libs/fcgi/patches/200-Convert-AM_INIT_AUTOMAKE-AC_INIT-and-trigger-non-GNU.patch
+++ b/libs/fcgi/patches/200-Convert-AM_INIT_AUTOMAKE-AC_INIT-and-trigger-non-GNU.patch
@@ -1,0 +1,33 @@
+From 78fac26891fe7494355021dbac109b807b8c6d53 Mon Sep 17 00:00:00 2001
+From: Joachim Nilsson <troglobit@gmail.com>
+Date: Mon, 14 May 2018 15:40:43 +0200
+Subject: [PATCH] Convert AM_INIT_AUTOMAKE() --> AC_INIT() and trigger non-GNU
+ project
+
+Converts from old-style configure syntax with AM_INIT_AUTOMAKE to
+AC_INIT and enable "foreign" mode, i.e. non-GNU conformant tree
+to avoid copying in COPYING and other files when autogen.sh runs.
+
+Signed-off-by: Joachim Nilsson <troglobit@gmail.com>
+---
+ configure.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure.in b/configure.in
+index 2f72645..c5fbc4b 100755
+--- a/configure.in
++++ b/configure.in
+@@ -4,8 +4,8 @@ dnl     This file is an input file used by the GNU "autoconf" program to
+ dnl     generate the file "configure", which is run during the build
+ dnl     to configure the system for the local environment.
+ 
+-AC_INIT
+-AM_INIT_AUTOMAKE(fcgi, 2.4.1-SNAP-0910052249)
++AC_INIT(fcgi, 2.4.1-SNAP-0910052249)
++AM_INIT_AUTOMAKE([1.11 foreign])
+ 
+ AM_CONFIG_HEADER(fcgi_config.h)
+ 
+-- 
+2.20.0
+


### PR DESCRIPTION
Move to new GitHub fork and switch to codeload tarballs.

Also update URL to fix uscan.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jsiverskog 
Compile tested: ramips