### PR TITLE
[RFC] exfat-nofuse: fix compile error on kernel 4.18+

### DIFF
--- a/kernel/exfat-nofuse/Makefile
+++ b/kernel/exfat-nofuse/Makefile
@@ -11,11 +11,11 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=exfat-nofuse
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=https://github.com/dorimanx/exfat-nofuse.git
+PKG_SOURCE_URL:=https://github.com/AndyLavr/exfat-nofuse.git
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_DATE:=2018-04-17
-PKG_SOURCE_VERSION:=01c30ad52625a7261e1b0d874553b6ca7af25966
-PKG_MIRROR_HASH:=47e3b6b8384e4beaa07dc762f4e0cce9a067750cbb4b2fb4ba18d2348038c270
+PKG_SOURCE_DATE:=2018-12-18
+PKG_SOURCE_VERSION:=c1920b2a18fc01311955f1de668b69c176a452f5
+PKG_MIRROR_HASH:=df4593261a44b5ae70de563a403b9caadc62427d5de88eefe5afeb73c31c66bd
 
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_LICENSE:=GPL-2.0
@@ -26,8 +26,10 @@ include $(INCLUDE_DIR)/package.mk
 define KernelPackage/fs-exfat
 	SUBMENU:=Filesystems
 	TITLE:=ExFAT Kernel driver
-	FILES:=$(PKG_BUILD_DIR)/exfat.ko
-	AUTOLOAD:=$(call AutoLoad,30,exfat,1)
+	FILES:= \
+		$(PKG_BUILD_DIR)/exfat_core.ko \
+		$(PKG_BUILD_DIR)/exfat_fs.ko
+	AUTOLOAD:=$(call AutoLoad,30,exfat_fs,1)
 	DEPENDS:=+kmod-nls-base @BUILD_PATENTED
 endef
 

--- a/kernel/exfat-nofuse/patches/000-fix-macros.patch
+++ b/kernel/exfat-nofuse/patches/000-fix-macros.patch
@@ -1,0 +1,29 @@
+diff --git a/exfat_config.h b/exfat_config.h
+index e831666..185ba0e 100644
+--- a/exfat_config.h
++++ b/exfat_config.h
+@@ -46,9 +46,9 @@ extern "C" {
+ #define FFS_CONFIG_SUPPORT_CP949        1
+ #define FFS_CONFIG_SUPPORT_CP950        1
+ #define FFS_CONFIG_SUPPORT_UTF8         1
+-#define EXFAT_CONFIG_DISCARD		1
++#define CONFIG_EXFAT_DISCARD		1
+ #define EXFAT_CONFIG_KERNEL_DEBUG	1
+-#define EXFAT_CONFIG_DEBUG_MSG		0
++#define CONFIG_EXFAT_KERNEL_DEBUG	1
+ 
+ #ifdef __cplusplus
+ }
+diff --git a/exfat_data.h b/exfat_data.h
+index b625a44..d0fa090 100644
+--- a/exfat_data.h
++++ b/exfat_data.h
+@@ -33,6 +33,8 @@ extern "C" {
+ #define BUF_CACHE_HASH_SIZE     64
+ #define DEFAULT_CODEPAGE        437
+ #define DEFAULT_IOCHARSET       "utf8"
++#define CONFIG_EXFAT_DEFAULT_CODEPAGE 437
++#define CONFIG_EXFAT_DEFAULT_IOCHARSET "utf8"
+ #ifdef __cplusplus
+ }
+ #endif

--- a/kernel/exfat-nofuse/patches/001-backward-compat.patch
+++ b/kernel/exfat-nofuse/patches/001-backward-compat.patch
@@ -1,0 +1,16 @@
+diff --git a/exfat_super.c b/exfat_super.c
+index e1e7135..ea981db 100644
+--- a/exfat_super.c
++++ b/exfat_super.c
+@@ -114,6 +114,11 @@
+ 
+ #include "exfat_super.h"
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4,18,0)
++#define timespec_to_timespec64
++#define timespec64_to_timespec
++#endif
++
+ static struct kmem_cache *exfat_inode_cachep;
+ 
+ static int exfat_default_codepage = CONFIG_EXFAT_DEFAULT_CODEPAGE;


### PR DESCRIPTION
Switched to https://github.com/AndyLavr/exfat-nofuse

Maintainer: @yousong @diizzyy 
Compile tested: mvebu kernel 4.19.10; ramip kernel 4.14.88
Run tested: mvebu kernel 4.19.10