### PR TITLE
lksctp-tools: Update to 1.0.18

### DIFF
--- a/net/lksctp-tools/Makefile
+++ b/net/lksctp-tools/Makefile
@@ -8,19 +8,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lksctp-tools
-PKG_VERSION:=1.0.16
+PKG_VERSION:=1.0.18
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/lksctp
-PKG_HASH:=0903dd526b7f30a89d5031aa2c82757612becc38ed7bc6e4f972f8deae351f26
+PKG_SOURCE_URL:=https://codeload.github.com/sctp/lksctp-tools/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=3e9ab5b3844a8b65fc8152633aafe85f406e6da463e53921583dfc4a443ff03a
 
+PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Nicolas Thill <nico@openwrt.org>
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -37,29 +38,26 @@ $(call Package/lksctp-tools/Default)
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE+= library
-  URL:=http://lksctp.sourceforge.net
   DEPENDS:=+kmod-sctp
 endef
 
 define Package/sctp
 $(call Package/lksctp-tools/Default)
   TITLE+= (meta)
-  URL:=http://lksctp.sourceforge.net
   DEPENDS:=+libsctp +sctp-tools
 endef
 
 define Package/sctp-tools
 $(call Package/lksctp-tools/Default)
   TITLE+= tools
-  URL:=http://lksctp.sourceforge.net
   DEPENDS:=+libsctp
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/include/netinet \
-		$(STAGING_DIR)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/include/netinet
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)/usr/include/netinet/sctp.h \
+		$(1)/usr/include/netinet
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/libsctp.{a,so*} \
@@ -73,16 +71,12 @@ define Package/libsctp/install
 		$(1)/usr/lib/
 endef
 
-define Package/sctp/install
-	:
-endef
-
 define Package/sctp-tools/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) \
+	$(INSTALL_BIN) \
 		$(PKG_INSTALL_DIR)/usr/bin/checksctp \
 		$(1)/usr/bin/
-	$(CP) \
+	$(INSTALL_BIN) \
 		$(PKG_INSTALL_DIR)/usr/bin/sctp_{darn,status,test} \
 		$(1)/usr/bin/
 endef

--- a/net/lksctp-tools/patches/010-build-fix-netinet-sctp.h-not-to-be-installed.patch
+++ b/net/lksctp-tools/patches/010-build-fix-netinet-sctp.h-not-to-be-installed.patch
@@ -1,0 +1,35 @@
+From 378560050a8f93786c590cc99a55461666205b61 Mon Sep 17 00:00:00 2001
+From: Xin Long <lucien.xin@gmail.com>
+Date: Fri, 24 Aug 2018 01:13:32 +0800
+Subject: [PATCH] build: fix netinet/sctp.h not to be installed
+
+After libcnetinet_HEADERS was set to sctp.h.in, netinet/sctp.h can
+no longer be installed into ${includedir}.
+
+Since "AC_CONFIG_HEADERS([src/include/netinet/sctp.h])" is already
+added into configure.ac, there's no need to generate sctp.h by
+automake.
+
+So we simply set libcnetinet_HEADERS back to sctp.h.
+
+Fixes: 9607dd85e70a ("netinet/sctp.h: dynamically build based on system setup")
+Signed-off-by: Xin Long <lucien.xin@gmail.com>
+Signed-off-by: Marcelo Ricardo Leitner <marcelo.leitner@gmail.com>
+---
+ src/include/netinet/Makefile.am | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/include/netinet/Makefile.am b/src/include/netinet/Makefile.am
+index ca0aac2..965db8c 100644
+--- a/src/include/netinet/Makefile.am
++++ b/src/include/netinet/Makefile.am
+@@ -11,5 +11,4 @@ libcnetinetdir = $(includedir)/netinet
+ # API.
+ include_HEADERS =
+ 
+-libcnetinet_HEADERS = sctp.h.in
+-BUILT_SOURCES = sctp.h
++libcnetinet_HEADERS = sctp.h
+-- 
+2.17.1
+


### PR DESCRIPTION
Switch to new upstream.

Remove Nico as Maintainer out of inactivity.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ramips
