### PR TITLE
python-six: Update to 1.12.0

### DIFF
--- a/lang/python/python-six/Makefile
+++ b/lang/python/python-six/Makefile
@@ -8,20 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-six
-PKG_VERSION:=1.11.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.12.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=six-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/16/d8/bc6316cf98419719bd59c91742194c111b6f2e85abac88e496adefaf7afe
-PKG_HASH:=70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9
-
-HOST_BUILD_DEPENDS:=python/host
-
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/s/six
+PKG_HASH:=d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-six-$(PKG_VERSION)
 
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
+
+HOST_BUILD_DEPENDS:=python/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -35,7 +34,7 @@ define Package/python-six/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  URL:=https://pypi.python.org/pypi/six
+  URL:=https://github.com/benjaminp/six
 endef
 
 define Package/python-six


### PR DESCRIPTION
Switch to standard pythonhosted URL.

Cosmetic Makefile rearrangements for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jefferyto @commodo 
Compile tested: ramips