### PR TITLE
geth: Update to 1.8.20

### DIFF
--- a/net/geth/Makefile
+++ b/net/geth/Makefile
@@ -11,12 +11,12 @@ PKG_LICENSE:=ASL-2.0
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 
 PKG_NAME:=go-ethereum
-PKG_VERSION:=1.8.18
+PKG_VERSION:=1.8.20
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ethereum/go-ethereum/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=cbab18a733298830c9ed1e19c1ece37edf417fd55ec8f198803048ecc3ffa0b9
+PKG_HASH:=7299f72a1d35a2653075a2070babf78f98f6eb3f41da43293304737ac0156658
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Signed-off-by: Mislav Novakovic mislav.novakovic@sartura.hr

Maintainer: me
Compile tested: arm64, Raspberry pi 3, OpenWrt master branch
Run tested: arm64, Raspberry pi 3, OpenWrt master branch

Description:
Package update to version [1.8.20](https://github.com/ethereum/go-ethereum/releases/tag/v1.8.20).