### PR TITLE
ntpdate: use uci configured servers instead of static list

### DIFF
--- a/net/ntpd/files/ntpdate.init
+++ b/net/ntpd/files/ntpdate.init
@@ -3,7 +3,9 @@
 
 START=60
 
-STEP_SERVERS="0.openwrt.pool.ntp.org 1.openwrt.pool.ntp.org 2.openwrt.pool.ntp.org"
+DEFAULT_SERVERS="0.openwrt.pool.ntp.org 1.openwrt.pool.ntp.org 2.openwrt.pool.ntp.org"
+CFG_SERVERS=$(uci -q get system.ntp.server)
+STEP_SERVERS=${CFG_SERVERS:-$DEFAULT_SERVERS}
 TIMEOUT="2" # in seconds
 
 start() {


### PR DESCRIPTION
If we're going to have a list of ntp servers, we should at least respect
them.

Signed-off-by: Karl Palsson <karlp@etactica.com>

Maintainer: @tripolar 
We've carried this patch for years, just remembered it and wondered why we'd never submitted it upstream again.