### PR TITLE
(lede 17.01) sqlite3 security bump

### DIFF
--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqlite
-PKG_VERSION:=3190300
-PKG_RELEASE:=2
+PKG_VERSION:=3260000
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_VERSION).tar.gz
-PKG_HASH:=06129c03dced9f87733a8cba408871bd60673b8f93b920ba8d815efab0a06301
-PKG_SOURCE_URL:=http://www.sqlite.org/2017/
+PKG_HASH:=5daa6a3fb7d1e8c767cd59c4ded8da6e4b00c61d3b466d0685e35c4dd6d7bf5d
+PKG_SOURCE_URL:=https://www.sqlite.org/2018/
 
 PKG_LICENSE:=PUBLICDOMAIN
 PKG_LICENSE_FILES:=
@@ -43,7 +43,7 @@ define Package/libsqlite3
   $(call Package/sqlite3/Default)
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libpthread
+  DEPENDS:=+libpthread +zlib
   TITLE+= (library)
 endef
 

--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -79,7 +79,8 @@ TARGET_CFLAGS += $(FPIC) \
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
-	--disable-editline
+	--disable-editline \
+	--disable-static-shell
 
 CONFIGURE_VARS += \
 	config_BUILD_CC="$(HOSTCC)" \


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested: ar71xx, dir-825-c1, 17.01
Run tested: ar71xx, dir-825-c1, 17.01, let FreeSWITCH run with updated lib, checked DB with cli util

Description:
Hi all,

This is for [Magellan](https://blade.tencent.com/magellan/index_en.html).

I hope you don't mind I piggy-backed the 2nd commit. Packing a static lib seems like a waste of space (and the configure switch is already in master).

I also check in [ABI laboratory](https://abi-laboratory.pro/?view=timeline&l=sqlite), there's no backward compatibility issues mentioned between these versions.

Kind regards,
Seb