### PR TITLE
build,circleci: add bzr to base image

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -16,6 +16,7 @@ wget \
 zlib1g-dev \
 unzip \
 xz-utils \
+bzr \
 && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -c "OpenWrt Builder" -m -d /home/build -s /bin/bash build


### PR DESCRIPTION
solves dependency problems currently caused by a prometheus 2.6, maybe
more in the future

Signed-off-by: Paul Spooren <mail@aparcar.org>