### PR TITLE
mdnsresponder: bump to 878.200.35 and refresh patches

### DIFF
--- a/net/mdnsresponder/Makefile
+++ b/net/mdnsresponder/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mDNSResponder
-PKG_VERSION:=878.70.2
+PKG_VERSION:=878.200.35
 PKG_RELEASE:=1
 
 PKG_SOURCE:=mDNSResponder-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://opensource.apple.com/tarballs/mDNSResponder/
-PKG_HASH:=cdd03171ca05f16ea987bba1f8b0c4847d3035283ea0f5fa0ade75f64ec83ed5
+PKG_SOURCE_URL:=https://opensource.apple.com/tarballs/mDNSResponder/
+PKG_HASH:=e777b4d7dbf5eb1552cb80090ad1ede319067ab6e45e3990d68aabf6e8b3f5a0
 PKG_MAINTAINER:=
 PKG_LICENSE:=Apache-2.0
 

--- a/net/mdnsresponder/patches/100-linux_fixes.patch
+++ b/net/mdnsresponder/patches/100-linux_fixes.patch
@@ -220,39 +220,15 @@ index b392fc7..f551ad5 100755
  
  /* Converts a prefix length to IPv6 network mask */
  void plen_to_mask(int plen, char *addr) {
-@@ -86,7 +87,7 @@ struct ifi_info *get_ifi_info_linuxv6(int family, int doaliases)
-     FILE *fp = NULL;
-     char addr[8][5];
-     int flags, myflags, index, plen, scope;
--    char ifname[9], lastname[IFNAMSIZ];
-+    char ifname[IFNAMSIZ], lastname[IFNAMSIZ];
-     char addr6[32+7+1]; /* don't forget the seven ':' */
-     struct addrinfo hints, *res0;
-     int err;
-@@ -92,7 +93,8 @@ struct ifi_info *get_ifi_info_linuxv6(int family, int doaliases)
-     int err;
-     int sockfd = -1;
-     struct ifreq ifr;
--
-+    char mask[64] = "%4s%4s%4s%4s%4s%4s%4s%4s %02x %02x %02x %02x %";
-+    sprintf(mask+strlen(mask), "%ds\n", IFNAMSIZ);
-     res0=NULL;
-     ifihead = NULL;
-     ifipnext = &ifihead;
-@@ -104,11 +106,12 @@ struct ifi_info *get_ifi_info_linuxv6(int family, int doaliases)
-             goto gotError;
-         }
-         while (fscanf(fp,
--                      "%4s%4s%4s%4s%4s%4s%4s%4s %02x %02x %02x %02x %8s\n",
-+                      mask,
-                       addr[0],addr[1],addr[2],addr[3],
-                       addr[4],addr[5],addr[6],addr[7],
-                       &index, &plen, &scope, &flags, ifname) != EOF) {
+@@ -127,6 +128,8 @@
+             nitems = fscanf(fp, ifnameFmt, ifname);
+             if (nitems != 1) break;
  
 +            if (flags & IFA_F_DEPRECATED) continue;
-             myflags = 0;
-             if (strncmp(lastname, ifname, IFNAMSIZ) == 0) {
++
+             if (strcmp(lastname, ifname) == 0) {
                  if (doaliases == 0)
+                     continue;   /* already processed this interface */
 diff --git a/mDNSShared/dnsextd_parser.y b/mDNSShared/dnsextd_parser.y
 index 18c5990..d4b63ce 100644
 --- a/mDNSShared/dnsextd_parser.y

--- a/net/mdnsresponder/patches/120-reproducible-builds.patch
+++ b/net/mdnsresponder/patches/120-reproducible-builds.patch
@@ -1,6 +1,6 @@
 --- a/Clients/dns-sd.c
 +++ b/Clients/dns-sd.c
-@@ -2288,7 +2288,7 @@ Fail:
+@@ -2281,7 +2281,7 @@ Fail:
  
  // NOT static -- otherwise the compiler may optimize it out
  // The "@(#) " pattern is a special prefix the "what" command looks for
@@ -48,5 +48,5 @@
  
  // NOT static -- otherwise the compiler may optimize it out
  // The "@(#) " pattern is a special prefix the "what" command looks for
--const char VersionString_SCCS_libdnssd[] = "@(#) libdns_sd " STRINGIFY(mDNSResponderVersion) " (" __DATE__ " " __TIME__ ")";
-+const char VersionString_SCCS_libdnssd[] = "@(#) libdns_sd " STRINGIFY(mDNSResponderVersion);
+-const char VersionString_SCCS_libdnssd[] DNSSD_USED = "@(#) libdns_sd " STRINGIFY(mDNSResponderVersion) " (" __DATE__ " " __TIME__ ")";
++const char VersionString_SCCS_libdnssd[] DNSSD_USED = "@(#) libdns_sd " STRINGIFY(mDNSResponderVersion);


### PR DESCRIPTION
While at it, change the source URL to https.

Signed-off-by: Jacob Siverskog <jacob@teenage.engineering>

Compile tested: omap
Run tested: omap, custom board, openwrt ~15.05, tested with AirPlay and Avahi Zeroconf Browser

Description:
