### PR TITLE
sqlite3: Set platform configuration flags & cleanup

### DIFF
--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqlite
 PKG_VERSION:=3260000
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_VERSION).tar.gz
 PKG_HASH:=5daa6a3fb7d1e8c767cd59c4ded8da6e4b00c61d3b466d0685e35c4dd6d7bf5d
@@ -76,9 +76,9 @@ $(call Package/sqlite3/Default/description)
 endef
 
 TARGET_CFLAGS += \
-	-DSQLITE_ENABLE_UNLOCK_NOTIFY=1 \
 	-DHAVE_ISNAN=1 \
-	-DHAVE_MALLOC_USABLE_SIZE=1
+	-DHAVE_MALLOC_USABLE_SIZE=1 \
+	-DSQLITE_ENABLE_UNLOCK_NOTIFY=1
 
 ifneq ($(CONFIG_SQLITE_FTS3),y)
 TARGET_CFLAGS += -USQLITE_ENABLE_FTS3
@@ -93,14 +93,6 @@ CONFIGURE_ARGS += \
 	--enable-static \
 	--disable-editline \
 	--disable-static-shell
-
-CONFIGURE_VARS += \
-	config_BUILD_CC="$(HOSTCC)" \
-	config_BUILD_CFLAGS="-O2" \
-	config_TARGET_CC="$(TARGET_CC)" \
-	config_TARGET_CFLAGS="$(TARGET_CFLAGS)" \
-	config_TARGET_READLINE_INC="$(TARGET_CPPFLAGS)" \
-	config_TARGET_READLINE_LIBS="$(TARGET_LDFLAGS) -lreadline -lncurses" \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
Maintainer: @micmac1 
Compile tested: ramips, MQMaker WiTi board, OpenWrt master
Run tested:

Description:
Set platform specfic flags to avoid sqlite using built-in variants
Remove CONFIGURE_VARS, already properly set by toolchain

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>