### PR TITLE
lighttpd: Fix dependencies among auth mods

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.49
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
@@ -195,11 +195,11 @@ $(eval $(call BuildPackage,lighttpd))
 $(eval $(call BuildPlugin,redirect,URL redirection,+PACKAGE_lighttpd-mod-redirect:libpcre,10))
 
 # Next, permit authentication.
-$(eval $(call BuildPlugin,auth,Authentication,,20))
-$(eval $(call BuildPlugin,authn_file,File-based authentication,,20))
-$(eval $(call BuildPlugin,authn_gssapi,Kerberos-based authentication,+PACKAGE_lighttpd-mod-authn_gssapi:krb5-libs,20))
-$(eval $(call BuildPlugin,authn_ldap,LDAP-based authentication,+PACKAGE_lighttpd-mod-authn_ldap:libopenldap,20))
-$(eval $(call BuildPlugin,authn_mysql,Mysql-based authentication,+PACKAGE_lighttpd-mod-authn_mysql:libmysqlclient,20))
+$(eval $(call BuildPlugin,auth,Authentication,+lighttpd-mod-authn_file,20))
+$(eval $(call BuildPlugin,authn_file,File-based authentication,+lighttpd-mod-auth,20))
+$(eval $(call BuildPlugin,authn_gssapi,Kerberos-based authentication,+lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_gssapi:krb5-libs,20))
+$(eval $(call BuildPlugin,authn_ldap,LDAP-based authentication,+lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_ldap:libopenldap,20))
+$(eval $(call BuildPlugin,authn_mysql,Mysql-based authentication,+lighttpd-mod-auth +PACKAGE_lighttpd-mod-authn_mysql:libmysqlclient,20))
 
 # Finally, everything else.
 $(eval $(call BuildPlugin,access,Access restrictions,,30))


### PR DESCRIPTION
lighttpd-mod-auth has to be installed with lighttpd-mod-authn_file,
otherwise an error will appear even when auth.backend is not "plain".

  (plugin.c.229) dlopen() failed for: /usr/lib/lighttpd/mod_authn_file.so Error loading shared library /usr/lib/lighttpd/mod_authn_file.so: No such file or directory

Signed-off-by: David Yang <mmyangfl@gmail.com>

Maintainer: @MikePetullo