### PR TITLE
mwan3: add nping to tracking method

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.7.6
+PKG_VERSION:=2.7.7
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -43,6 +43,12 @@ validate_track_method() {
 				return 1
 			}
 			;;
+		nping-*)
+			which nping 1>/dev/null 2>&1 || {
+				$LOG warn "Missing nping. Please install nping package."
+				return 1
+			}
+			;;
 		*)
 			$LOG warn "Unsupported tracking method: $track_method"
 			return 2
@@ -145,6 +151,18 @@ main() {
 					httping)
 						httping -y $SRC_IP -c $count -t $timeout -q $track_ip &> /dev/null
 						result=$?
+					;;
+					nping-tcp)
+						result=$(nping -e $DEVICE -c $count $track_ip --tcp | grep Lost | awk '{print $12}')
+					;;
+					nping-udp)
+						result=$(nping -e $DEVICE -c $count $track_ip --udp | grep Lost | awk '{print $12}')
+					;;
+					nping-icmp)
+						result=$(nping -e $DEVICE -c $count $track_ip --icmp | grep Lost | awk '{print $12}')
+					;;
+					nping-arp)
+						result=$(nping -e $DEVICE -c $count $track_ip --arp | grep Lost | awk '{print $12}')
 					;;
 				esac
 				if [ $check_quality -eq 0 ]; then


### PR DESCRIPTION
Maintainer: me
Compile tested: only scripts
Run tested: x86, APU3, OpenWrt master, done

Description:
Add **nping** to the usable tracking methods.
