### PR TITLE
clamav: Change depends from uclibcxx to CXX_DEPENDS

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clamav
 PKG_VERSION:=0.101.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr> \
@@ -28,7 +28,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/clamav/Default
   SECTION:=net
-  DEPENDS:=+libpthread +uclibcxx +zlib +libcurl +libjson-c +libmilter-sendmail +libopenssl +libltdl +libpcre2 +USE_MUSL:musl-fts
+  DEPENDS:=$(CXX_DEPENDS) +libpthread +zlib +libcurl +libjson-c +libmilter-sendmail +libopenssl +libltdl +libpcre2 +USE_MUSL:musl-fts
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
   TITLE:=ClamAV


### PR DESCRIPTION
The build system allows changing uclibc++ to libstdcpp globally. This
avoids an unnecessary depends in the case of libstdcpp usage.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: ramips