### PR TITLE
perl: add missing config for mips64el

### DIFF
--- a/lang/perl/files/mips64el.config
+++ b/lang/perl/files/mips64el.config
@@ -1,0 +1,21 @@
+owrt:arch=mips64el
+owrt:bits=64
+owrt:endian=little
+
+ccsymbols=''
+cppccsymbols=''
+cppsymbols=''
+d_casti32='define'
+d_double_style_ieee='define'
+d_long_double_style_ieee_doubledouble='define'
+d_modflproto='undef'
+doublekind='3'
+fpossize='24'
+longdblkind='5'
+need_va_copy='define'
+quadkind='2'
+
+owrt:sig_count=128
+owrt:sigs='ZERO HUP INT QUIT ILL TRAP ABRT EMT FPE KILL BUS SEGV SYS PIPE ALRM TERM USR1 USR2 CHLD PWR WINCH URG IO STOP TSTP CONT TTIN TTOU VTALRM PROF XCPU XFSZ'
+owrt:sig_name_extra='IOT CLD POLL'
+owrt:sig_num_extra='6 18 22'


### PR DESCRIPTION
Maintainer: @Naoir ,  @pprindeville 
Compile tested: mips-malta-64bit-little-endian, master branch

Description:
Compilation otherwise fails building for MIPS Malta 64-bit LE. Unfortunately, little-endian and 64-bit variants of the Malta platform are no longer built automatically by the bots, so these problems can creep in.

Someone knowledgeable on perl compilation should review the updates, since they are a best guess at parameters `arch`, `endian`, `doublekind`, and `longdblkind`, based on the perl documentation.