### PR TITLE
iotivity: add patch for g++-7.10 compatibily

### DIFF
--- a/net/iotivity/Makefile
+++ b/net/iotivity/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iotivity
 PKG_VERSION:=1.2.1
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 PKG_SOURCE:=${PKG_NAME}-${PKG_VERSION}.tar.gz
 PKG_SOURCE_URL:=http://mirrors.kernel.org/${PKG_NAME}/${PKG_VERSION}/

--- a/net/iotivity/patches/090-Include-funcional-header.patch
+++ b/net/iotivity/patches/090-Include-funcional-header.patch
@@ -1,0 +1,55 @@
+From 26c2798188497da22e0a70efebc47991dd755db2 Mon Sep 17 00:00:00 2001
+From: Philippe Coval <philippe.coval@osg.samsung.com>
+Date: Wed, 28 Jun 2017 04:54:05 +0200
+Subject: [PATCH] resource: Include functional header for g++-7.1.0
+
+It was tested on yocto poky master on iotivity-1.2.1 (and later):
+
+  resource/include/OCUtilities.h: \
+  In function 'OCStackResult OC::nil_guard(PtrT&&, FnT&&, ParamTs&& ...)':
+  resource/include/OCUtilities.h:85:21: \
+  error: 'bind' is not a member of 'std'
+  return std::bind(fn, p, std::ref(params)...)();
+
+  resource/include/OCApi.h: At global scope:
+  resource/include/OCApi.h:362:18: \
+  error: 'function' in namespace 'std' does not name a template type
+  typedef std::function<void(std::shared_ptr<OCResource>)> FindCallback;
+
+Change-Id: Ie1cab497c33fde394f77490a1d636eb36a563396
+Origin: https://gerrit.iotivity.org/gerrit/#/c/21069/
+Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>
+Reviewed-on: https://gerrit.iotivity.org/gerrit/21067
+Reviewed-by: Thiago Macieira <thiago.macieira@intel.com>
+Tested-by: jenkins-iotivity <jenkins@iotivity.org>
+---
+ resource/include/OCApi.h       | 2 --
+ resource/include/OCUtilities.h | 1 +
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/resource/include/OCApi.h b/resource/include/OCApi.h
+index 4e14f29cc3..af9721554e 100644
+--- a/resource/include/OCApi.h
++++ b/resource/include/OCApi.h
+@@ -27,9 +27,7 @@
+ #include <map>
+ #include <memory>
+ #include <iterator>
+-#if defined(_MSC_VER)
+ #include <functional>
+-#endif
+ 
+ #include "iotivity_config.h"
+ #include "iotivity_debug.h"
+diff --git a/resource/include/OCUtilities.h b/resource/include/OCUtilities.h
+index 85039d0c14..f1c93045f4 100644
+--- a/resource/include/OCUtilities.h
++++ b/resource/include/OCUtilities.h
+@@ -26,6 +26,7 @@
+ #include <memory>
+ #include <utility>
+ #include <exception>
++#include <functional>
+ 
+ #include <OCException.h>
+ #include <StringConstants.h>


### PR DESCRIPTION
Maintainer: @hauke 
Compile tested: ramips, mipsel_74kc
Run tested: none

Description:
This applies upstream commit iotivity/iotivity@26c2798188497da22e0a70efebc47991dd755db2 that adds the `<funcional>` header, avoiding errors with `std` namespace functions, like:
```
resource/include/OCUtilities.h:85:21: error: 'bind' is not a member of 'std'
resource/include/OCApi.h:268:18: error: 'function' in namespace 'std' does not name a template type
     typedef std::function<void(std::shared_ptr<OCResource>)> FindCallback;
```
Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>