### PR TITLE
libyubikey: Initial checkin of makefile

### DIFF
--- a/libs/libyubikey/Makefile
+++ b/libs/libyubikey/Makefile
@@ -1,0 +1,49 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libyubikey
+PKG_VERSION:=1.13
+PKG_RELEASE:=1
+
+PKG_SOURCE:=libyubikey-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://developers.yubico.com/yubico-c/Releases
+PKG_HASH:=04edd0eb09cb665a05d808c58e1985f25bb7c5254d2849f36a0658ffc51c3401
+PKG_MAINTAINER:=Stuart B. Wilkins <stuwilkins@mac.com>
+PKG_LICENSE_FILES:=COPYING
+PKG_LICENSE:=BSD-2-Clause
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/libyubikey-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libyubikey
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=The Yuibco yubikey c library
+  URL:=https://developers.yubico.com/yubico-c/
+endef
+
+define Package/libyubikey/description
+	The c library for the yubikey from Yubico
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/include
+	$(CP) $(PKG_BUILD_DIR)/yubikey.h $(STAGING_DIR)/usr/include
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/.libs/libyubikey.so* $(STAGING_DIR)/usr/lib
+endef
+
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--disable-static
+
+define Package/libyubikey/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/modhex $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/ykgenerate $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/ykparse $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/.libs/libyubikey.so.* $(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,libyubikey))

--- a/libs/yubico-pam/Makefile
+++ b/libs/yubico-pam/Makefile
@@ -1,0 +1,51 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=yubico-pam
+PKG_VERSION:=2.26
+PKG_RELEASE:=1
+
+PKG_SOURCE:=pam_yubico-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://developers.yubico.com/yubico-pam/Releases
+PKG_HASH:=2de96495963fefd72b98243952ca5d5ec513e702c596e54bc667ef6b5e252966
+PKG_MAINTAINER:=Stuart B. Wilkins <stuwilkins@mac.com>
+PKG_BUILD_DEPENDS:=ykclient ykpers libyubikey libpam curl
+PKG_LICENSE_FILES:=COPYING
+PKG_LICENSE:=BSD-2-Clause
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/pam_yubico-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/yubico-pam
+	SECTION:=libs
+	CATEGORY:=Libraries
+	TITLE:=The Yuibco PAM module
+	URL:=https://developers.yubico.com/yubico-pam/
+	DEPENDS:=+ykclient +ykpers +libyubikey +libpam +curl
+endef
+
+define Package/yubico-pam/description
+	The Yubico PAM module provides an easy way to integrate the YubiKey 
+	into your existing user authentication infrastructure.
+endef
+	
+CONFIGURE_VARS += 	YKPERS_CFLAGS=-I$(STAGING_DIR)/usr/include \
+			YKPERS_LIBS=-L$(STAGING_DIR)/usr/lib \
+			LDFLAGS="-Wl,-rpath-link,$(STAGING_DIR)/usr/lib \
+				  -L$(STAGING_DIR)/usr/lib"
+
+CONFIGURE_ARGS += --without-ldap \
+        	  --enable-shared \
+        	  --disable-static \
+
+define Build/Compile
+    $(call Build/Compile/Default, \
+	LDFLAGS="-L$(STAGING_DIR)/usr/lib -lykpers-1")
+endef
+
+define Package/yubico-pam/install
+	$(INSTALL_DIR) $(1)/lib/security
+	$(CP) $(PKG_BUILD_DIR)/.libs/pam_yubico.so* $(1)/lib/security
+endef
+
+$(eval $(call BuildPackage,yubico-pam,+ykclient,+ykpers,+libyubikey))

--- a/utils/ykclient/Makefile
+++ b/utils/ykclient/Makefile
@@ -1,0 +1,49 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ykclient
+PKG_VERSION:=2.15
+PKG_RELEASE:=1
+
+PKG_SOURCE:=ykclient-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://developers.yubico.com/yubico-c-client/Releases/
+PKG_HASH:=f461cdefe7955d58bbd09d0eb7a15b36cb3576b88adbd68008f40ea978ea5016
+PKG_MAINTAINER:=Stuart B. Wilkins <stuwilkins@mac.com>
+PKG_LICENSE_FILES:=COPYING
+PKG_LICENSE:=BSD-2-Clause
+PKG_BUILD_DEPENDS:=curl
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/ykclient-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ykclient
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=The Yuibco yubikey c client library
+  URL:=https://developers.yubico.com/yubico-c-client/
+  DEPENDS:=curl
+endef
+
+define Package/ykclient/description
+	YubiKey C Client Library (libykclient)
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/include
+	$(CP) $(PKG_BUILD_DIR)/ykclient*.h $(STAGING_DIR)/usr/include
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/.libs/libykclient.so* $(STAGING_DIR)/usr/lib
+endef
+
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--disable-static
+
+define Package/ykclient/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/ykclient $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/.libs/libykclient.so* $(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,ykclient))

--- a/utils/ykpers/Makefile
+++ b/utils/ykpers/Makefile
@@ -1,0 +1,54 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ykpers
+PKG_VERSION:=1.19.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=ykpers-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://developers.yubico.com/yubikey-personalization/Releases
+PKG_HASH:=2bc8afa16d495a486582bad916d16de1f67c0cce9bb0a35c3123376c2d609480
+PKG_MAINTAINER:=Stuart B. Wilkins <stuwilkins@mac.com>
+PKG_LICENSE_FILES:=COPYING
+PKG_LICENSE:=BSD-2-Clause
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/ykpers-$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=libyubikey
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ykpers
+  SECTION:=utils	
+  CATEGORY:=Utilities
+  TITLE:=The Yuibco personalization package
+  URL:=https://developers.yubico.com/yubikey-personalization/
+  DEPENDS:=+curl +libyubikey +libjson-c +libusb-1.0
+endef
+
+define Package/ykpers/description
+	The YubiKey Personalization package contains a library and command 
+	line tool used to personalize (i.e., set a AES key) YubiKeys.
+endef
+
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--disable-static
+
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/include
+	$(CP) $(PKG_BUILD_DIR)/ykcore/*.h $(STAGING_DIR)/usr/include
+	$(CP) $(PKG_BUILD_DIR)/*.h $(STAGING_DIR)/usr/include
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/.libs/libykpers-1.so* $(STAGING_DIR)/usr/lib
+endef
+
+define Package/ykpers/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/ykchalresp $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/ykinfo $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/ykpersonalize $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/.libs/libykpers-1.so* $(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,ykpers))


### PR DESCRIPTION
Signed-off-by: Stuart B. Wilkins <stuwilkins@mac.com>

Maintainer: Stuart Wilkins 
Compile Tested on Marvell Armada 37x/38x/XP (Linksys WRT3200ACM (Rango))
Run tested: Marvell Armada 37x/38x/XP (Linksys WRT3200ACM (Rango))

Description:

This adds the yubikey libraries and utilities. Included is the yubico_pam module which can be used to add yubikey authentication to pam for use with ssh (for example).

Tested and verified with openssh.

This is the first attempt at a package pull request, so any comments welcome! Appologies for the mess on #7664 

Thanks!
