### PR TITLE
ibrcommon: Allow usage of uclibc++

### DIFF
--- a/libs/ibrcommon/Makefile
+++ b/libs/ibrcommon/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ibrcommon
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.ibr.cs.tu-bs.de/projects/ibr-dtn/releases
@@ -20,12 +20,13 @@ PKG_LICENSE:=Apache-2.0
 PKG_INSTALL:=1
 PKG_FIXUP:=libtool
 
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/ibrcommon
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libstdcpp +libpthread +librt +libnl +libopenssl
+  DEPENDS:=$(CXX_DEPENDS) +libpthread +librt +libnl +libopenssl
   TITLE:=IBR Common C++ Library
 endef
 


### PR DESCRIPTION
Allows having only one libc++ installed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @morgenroth 
Compile tested: ramips
