### PR TITLE
fish: fixed apropos not found

### DIFF
--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fish
 PKG_VERSION:=2.7.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fish-shell/fish-shell/tar.gz/$(PKG_VERSION)?
@@ -58,10 +58,13 @@ grep fish $${IPKG_INSTROOT}/etc/shells || \
     if [[ -e /bin/fish ]] && ([[ ! -L /bin/fish ]] || [[ "$(readlink -fn $${IPKG_INSTROOT}/bin/fish)" != "../$(CONFIGURE_PREFIX)/bin/fish" ]]); then
         ln -fs "../$(CONFIGURE_PREFIX)/bin/fish" "$${IPKG_INSTROOT}/bin/fish"
     fi
+	echo '#!/bin/sh' > /usr/bin/apropos
+	chmod +x /usr/bin/apropos
 endef
 
 define Package/fish/postrm
 	rm -rf "$${IPKG_INSTROOT}/$(CONFIGURE_PREFIX)/share/fish/$(PKG_VERSION)"
+	rm -f /usr/bin/apropos
 endef
 
 $(eval $(call BuildPackage,fish))


### PR DESCRIPTION
Signed-off-by: Curtis Jiang <jqqqqqqqqqq@qq.com>

Maintainer: jqqqqqqqqqq@qq.com
Compile tested: OpenWRT 17.01.4 (x86_64), 18.06.1 (x86_64)
Run tested: OpenWRT 17.01.4 (x86_64), 18.06.1 (x86_64)

Description:
Due to command apropos does not exists on OpenWRT, fish sometimes print error messages when completing commands.
Using an empty script to replace apropos should eliminate these errors.