### PR TITLE
mwan3: code cleanup

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.7.7
+PKG_VERSION:=2.7.8
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -132,34 +132,16 @@ status()
 
 start()
 {
-	local enabled src_ip local_source
+	local enabled
 
 	uci_toggle_state mwan3 globals enabled "1"
-
-	config_get local_source globals local_source 'none'
-	[ "${local_source}" = "none" ] || {
-		src_ip=$(uci_get_state mwan3 globals src_ip)
-		[ "${src_ip}" != "" ] && {
-			ip route del default via "${src_ip}" dev lo 1>/dev/null 2>&1
-			ip addr del "${src_ip}/32" dev lo 1>/dev/null 2>&1
-		}
-
-		network_get_ipaddr src_ip "${local_source}"
-		if [ "${src_ip}" = "" ]; then
-			$LOG warn "Unable to set source ip for own initiated traffic (${local_source})"
-		else
-			ip addr add "${src_ip}/32" dev lo
-			ip route add default via "${src_ip}" dev lo
-			uci_toggle_state mwan3 globals src_ip "${src_ip}"
-		fi
-	}
 
 	config_foreach ifup interface
 }
 
 stop()
 {
-	local ipset route rule table IP IPT pid src_ip
+	local ipset route rule table IP IPT pid
 
 	for pid in $(pgrep -f "mwan3rtmon"); do
 		kill -TERM "$pid" > /dev/null 2>&1
@@ -211,12 +193,6 @@ stop()
 
 	mwan3_lock_clean
 	rm -rf $MWAN3_STATUS_DIR $MWAN3TRACK_STATUS_DIR
-
-	src_ip=$(uci_get_state mwan3 globals src_ip)
-	[ "${src_ip}" = "" ] || {
-		ip route del default via "${src_ip}" dev lo 1>/dev/null 2>&1
-		ip addr del "${src_ip}/32" dev lo 1>/dev/null 2>&1
-	}
 
 	uci_toggle_state mwan3 globals enabled "0"
 }

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -61,12 +61,6 @@ ifup()
 		echo "Too many arguments. Usage: mwan3 ifup <interface>" && exit 0
 	fi
 
-	config_get_bool enabled globals 'enabled' 0
-	[ ${enabled} -gt 0 ] || {
-		echo "Warning: mwan3 is global disabled. Usage: /etc/init.d/mwan3 start"
-		exit 0
-	}
-
 	status=$(ubus -S call network.interface.$1 status)
 	[ -n "$status" ] && {
 		json_load $status
@@ -74,7 +68,6 @@ ifup()
 	}
 
 	config_get enabled "$1" enabled 0
-
 
 	if [ "$up" = "1" ] \
 		&& [ -n "$l3_device" ] \


### PR DESCRIPTION
Maintainer: me
Compile tested: only scripts
Run tested: -

Description:
code cleanup

- remove duplicate global enable check on **mwan3 start**
- remove code artefact's for deprecated **local_source**  option