### PR TITLE
libs/alsa-lib: Add /etc/asound.conf for backup

### DIFF
--- a/libs/alsa-lib/Makefile
+++ b/libs/alsa-lib/Makefile
@@ -42,6 +42,10 @@ define Package/alsa-lib/description
  You must have enabled the ALSA support in the kernel.
 endef
 
+define Package/alsa-lib/conffiles
+/etc/asound.conf
+endef
+
 TARGET_CFLAGS += $(FPIC)
 
 CONFIGURE_ARGS+= \


### PR DESCRIPTION
Maintainer: @thess @tripolar 
Compile tested: Not needed
Run tested: Not needed

Description:
Even if /etc/asound.conf isn't installed we should try to
preserve user configurations during sysupgrades

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>