### PR TITLE
banip: release 0.0.7

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.0.6
+PKG_VERSION:=0.0.7
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/banip/files/banip.sh
+++ b/net/banip/files/banip.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-ban_ver="0.0.6"
+ban_ver="0.0.7"
 ban_sysver="unknown"
 ban_enabled=0
 ban_automatic="1"
@@ -169,10 +169,16 @@ f_envcheck()
 
 	for iface in ${ban_iface}
 	do
-		network_get_physdev tmp "${iface}"
+		network_get_device tmp "${iface}"
 		if [ -n "${tmp}" ]
 		then
 			ban_dev="${ban_dev} ${tmp}"
+		else
+			network_get_physdev tmp "${iface}"
+			if [ -n "${tmp}" ]
+			then
+				ban_dev="${ban_dev} ${tmp}"
+			fi
 		fi
 		network_get_subnets tmp "${iface}"
 		if [ -n "${tmp}" ]


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: OpenWrt SNAPSHOT r8878-e790227553

Description:
* determine L3 and L2 network devices to support pppoe interfaces correctly

Signed-off-by: Dirk Brenken <dev@brenken.org>