### PR TITLE
sound/mpd: Update to 0.20.23

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpd
-PKG_VERSION:=0.20.21
+PKG_VERSION:=0.20.23
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.musicpd.org/download/mpd/0.20/
-PKG_HASH:=8322764dc265c20f05c8c8fdfdd578b0722e74626bef56fcd8eebfb01acc58dc
+PKG_HASH:=503e5f9f237290f568ff7956ab2f9aed563594bf749f19b8fe994fb21434afea
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
 PKG_LICENSE:=GPL-2.0
@@ -100,7 +100,6 @@ define Package/mpd-avahi-service/conffiles
 endef
 
 EXTRA_LDFLAGS += $(if $(ICONV_FULL),-liconv,-Wl,--whole-archive -liconv -Wl,--no-whole-archive)
-EXTRA_CXXFLAGS += $(if $(CONFIG_GCC_VERSION_4_8),-std=gnu++11,-std=gnu++14)
 
 CONFIGURE_ARGS += \
 	$(call autoconf_bool,CONFIG_IPV6,ipv6) \


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: mvebu, Linksys WRT3200ACM, OpenWrt master
Run tested: mvebu, Linksys WRT3200ACM, OpenWrt master

Description:
Update to mpd to 0.20.23
Remove old compiler workarounds

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>