### PR TITLE
libs/libmpdclient: Update to 2.16

### DIFF
--- a/libs/libmpdclient/Makefile
+++ b/libs/libmpdclient/Makefile
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmpdclient
-PKG_VERSION:=2.14
+PKG_VERSION:=2.16
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=0a84e2791bfe3077cf22ee1784c805d5bb550803dffe56a39aa3690a38061372
+PKG_HASH:=fa6bdab67c0e0490302b38f00c27b4959735c3ec8aef7a88327adb1407654464
 PKG_SOURCE_URL:=https://www.musicpd.org/download/libmpdclient/2/
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>

--- a/libs/libmpdclient/autotools-files/Makefile.am
+++ b/libs/libmpdclient/autotools-files/Makefile.am
@@ -16,6 +16,7 @@ mpdinclude_HEADERS = \
 	include/mpd/idle.h \
 	include/mpd/list.h \
 	include/mpd/mixer.h \
+	include/mpd/mount.h \
 	include/mpd/parser.h \
 	include/mpd/password.h \
 	include/mpd/player.h \
@@ -44,6 +45,7 @@ lib_LTLIBRARIES = src/libmpdclient.la
 
 src_libmpdclient_la_SOURCES = \
 	src/async.c src/iasync.h \
+	src/audio_format.c \
 	src/buffer.h \
 	src/internal.h \
 	src/ierror.c src/ierror.h \
@@ -64,6 +66,8 @@ src_libmpdclient_la_SOURCES = \
 	src/kvlist.c \
 	src/list.c \
 	src/mixer.c \
+	src/mount.c \
+	src/cmount.c \
 	src/parser.c \
 	src/password.c \
 	src/player.c \

--- a/libs/libmpdclient/autotools-files/configure.ac
+++ b/libs/libmpdclient/autotools-files/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT(libmpdclient, 2.14, musicpd-dev-team@lists.sourceforge.net)
+AC_INIT(libmpdclient, 2.16, musicpd-dev-team@lists.sourceforge.net)
 AC_CONFIG_SRCDIR([src/connection.c])
 AC_CONFIG_AUX_DIR(build)
 AM_INIT_AUTOMAKE([foreign 1.11 dist-xz subdir-objects silent-rules])
@@ -7,10 +7,10 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_SUBST(MAJOR_VERSION,2)
-AC_SUBST(MINOR_VERSION,14)
+AC_SUBST(MINOR_VERSION,16)
 AC_SUBST(PATCH_VERSION,0)
 
-LIBMPDCLIENT_LIBTOOL_VERSION=2:14:0
+LIBMPDCLIENT_LIBTOOL_VERSION=2:16:0
 AC_SUBST(LIBMPDCLIENT_LIBTOOL_VERSION)
 
 # Remove the check for c++ and fortran compiler


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: mvebu, Linksys WRT3200ACM, OpenWrt master
Run tested: Linksys WRT3200ACM, OpenWrt master

Description:
Update libmpdclient to 2.16

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>