### PR TITLE
python-pcapy: Add uclibc++ support

### DIFF
--- a/lang/python/python-pcapy/Makefile
+++ b/lang/python/python-pcapy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pcapy
 PKG_VERSION:=0.11.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=pcapy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pcapy
@@ -19,6 +19,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/pcapy-$(PKG_VERSION)
 PKG_MAINTAINER:=Andrew McConachie <andrew@depht.com>
 PKG_LICENSE:=Apache-1.1
 
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 
@@ -28,7 +29,7 @@ define Package/python-pcapy
 	SUBMENU:=Python
 	TITLE:=python-pcapy
 	URL:=https://www.coresecurity.com/corelabs-research/open-source-tools/pcapy
-	DEPENDS:=+python +libpcap +libstdcpp
+	DEPENDS:=+python +libpcap $(CXX_DEPENDS)
 endef
 
 define Package/python-pcapy/description

--- a/lang/python/python-pcapy/patches/010-libcxx.patch
+++ b/lang/python/python-pcapy/patches/010-libcxx.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 4da69bc..165059b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -28,7 +28,7 @@ if sys.platform == 'win32':
+             library_dirs.append(r'c:\wpdpack\Lib')
+     libraries = ['wpcap', 'packet', 'ws2_32']
+ else:
+-    libraries = ['pcap', 'stdc++']
++    libraries = ['pcap']
+ 
+ 
+ # end of user configurable parameters


### PR DESCRIPTION
Reduces space required on the target device.

Added patch to get rid of the explicit libstdcpp dependency.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @smutt 
Compile tested: ramips
