### PR TITLE
keepalived: build without libipset

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.0.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.keepalived.org/software
@@ -53,6 +53,7 @@ define Package/keepalived/conffiles
 endef
 
 CONFIGURE_ARGS+= \
+	--disable-libipset \
 	--disable-libnl \
 	--enable-sha1 \
 	--disable-snmp \


### PR DESCRIPTION
Maintainer: @scrpi, @feckert 
Compile tested: ramips, mipsel_74kc, openwrt master
Run tested: very basic, made sure it runs, but nothing else.

Description:
keepalived 2.0.7 is not compatible with libipset 7.x.

libipset is picked up by the configure script, if present in the staging dir, but apparently it is linked statically, since there's no library dependency.  I don't use this package, so I can't verify if functionality changes with libipset support or not.

Alternatives are:

- Update to 2.0.10 - package size triples 
- Apply https://github.com/acassen/keepalived/commit/b7a98f9265ffb5927c4d54c9a30726c76e65bb52, which adds support to libipset 7.x.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>