### PR TITLE
Hashdeep: add package

### DIFF
--- a/utils/hashdeep/Makefile
+++ b/utils/hashdeep/Makefile
@@ -1,0 +1,45 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=hashdeep
+PKG_VERSION:=4.4
+PKG_RELEASE:=1
+PKG_MAINTAINER=Tobe Deprez <trldp@outlook.com>
+PKG_LICENSE:=NLPL
+PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/jessek/hashdeep/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=ad78d42142f9a74fe8ec0c61bc78d6588a528cbb9aede9440f50b6ff477f3a7f
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/uclibc++.mk
+include $(INCLUDE_DIR)/package.mk
+
+define Package/hashdeep
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Recursively compute hashsums or piecewise hashings
+  URL:=http://md5deep.sourceforge.net/
+  DEPENDS:=$(CXX_DEPENDS)
+endef
+
+define Package/hashdeep/description
+	hashdeep is a set of tools to compute MD5, SHA1, SHA256, tiger
+	and whirlpool hashsums of arbitrary number of files recursively.
+endef
+
+define Package/hashdeep/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/hashdeep \
+                   $(PKG_INSTALL_DIR)/usr/bin/md5deep \
+                   $(PKG_INSTALL_DIR)/usr/bin/sha1deep \
+                   $(PKG_INSTALL_DIR)/usr/bin/sha256deep \
+                   $(PKG_INSTALL_DIR)/usr/bin/tigerdeep \
+                   $(PKG_INSTALL_DIR)/usr/bin/whirlpooldeep \
+                   $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,hashdeep))
+


### PR DESCRIPTION
Signed-off-by: Tobe Deprez <trldp@outlook.com>

Maintainer: trldp <trldp@outlook.com>
Compile tested: x86/64 on Ubuntu
Run tested: Linksys WRT1200AC (arm_cortex-a9_vfpv3), Openwrt 18.06

Description:
Add package for hashdeep. Hashdeep is a set of tools to compute and check MD5, SHA1, SHA256, tiger
and whirlpool hashsums of arbitrary number of files recursively.

I'm not sure I've entered the license correctly. The main license is US Govenment pulbic domain with some parts GPL-2. I have selected No Limit Public License (NLPL).