### PR TITLE
lualane: avoid luajit dependency

### DIFF
--- a/lang/lualanes/Makefile
+++ b/lang/lualanes/Makefile
@@ -42,6 +42,8 @@ define Build/Compile
         CC="$(TARGET_CC)" \
         LUA="$(STAGING_DIR_HOSTPKG)/bin/lua" \
         LUAC="$(STAGING_DIR_HOSTPKG)/bin/luac" \
+	LUA_FLAGS= \
+	LUA_LIBS=-llua \
         OPT_FLAGS="$(TARGET_CFLAGS) -Dpthread_yield=sched_yield"
 endef
 


### PR DESCRIPTION
Maintainer: @first-leon 
Compile tested: ramips, mipsel_74kc, openwrt master
Run tested: none, but package does not change

Description:
Set `LUA_LIBS=-llua` manually to avoid picking up libluajit.  Otherwise, build fails with
```
Package lualanes is missing dependencies for the following libraries:
libluajit-5.1.so.2
```

I've checked that the sha256sum of the package is the same with and without this PR (disabling luajit, of course), so I'm not increasing `PKG_RELEASE`.

Alternatively, you may either always use luajit, or use it conditionally with
```
DEPENDS:=+lua +luac +PACKAGE_luajit:luajit +!PACKAGE_luajit:liblua +libpthread
```

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>