### PR TITLE
arpwatch: Import from the packages archive

### DIFF
--- a/net/arpwatch/Makefile
+++ b/net/arpwatch/Makefile
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2006-2009 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=arpwatch
+PKG_VERSION:=2.1a15
+PKG_RELEASE:=2
+
+PKG_MAINTAINER:=Michel Belleau <michel.belleau@malaiwah.com>
+PKG_LICENSE:=BSD-3-Clause
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=ftp://ftp.free.fr/.mirrors1/ftp.gentoo.org/distfiles/
+PKG_MD5SUM:=cebfeb99c4a7c2a6cee2564770415fe7
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/arpwatch
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpcap
+  TITLE:=Ethernet station activity monitor
+  URL:=http://www-nrg.ee.lbl.gov/
+endef
+
+define Package/arpwatch/description
+	Ethernet monitor program for keeping track of ethernet/ip address
+	pairings.
+endef
+
+define Package/arpwatch/conffiles
+/etc/arpwatch/arp.dat
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	chmod -R u+w $(PKG_BUILD_DIR)
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		ARPDIR=/etc/arpwatch \
+		CCOPT="$(TARGET_CFLAGS)" \
+		INCLS="-I. $(TARGET_CPPFLAGS)" \
+		LIBS="$(TARGET_LDFLAGS) -lpcap"
+endef
+
+define Package/arpwatch/install
+	$(INSTALL_DIR) $(1)/etc/arpwatch
+	$(CP) $(PKG_BUILD_DIR)/arp.dat $(1)/etc/arpwatch/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/arp{watch,snmp} $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/arpwatch.init $(1)/etc/init.d/arpwatch
+endef
+
+$(eval $(call BuildPackage,arpwatch))

--- a/net/arpwatch/Makefile
+++ b/net/arpwatch/Makefile
@@ -15,7 +15,7 @@ PKG_MAINTAINER:=Michel Belleau <michel.belleau@malaiwah.com>
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=ftp://ftp.free.fr/.mirrors1/ftp.gentoo.org/distfiles/
+PKG_SOURCE_URL:=http://distfiles.gentoo.org/distfiles/
 PKG_MD5SUM:=cebfeb99c4a7c2a6cee2564770415fe7
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/arpwatch/Makefile
+++ b/net/arpwatch/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=2.1a15
 PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Michel Belleau <michel.belleau@malaiwah.com>
-PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE:=BSD-4-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://distfiles.gentoo.org/distfiles/

--- a/net/arpwatch/Makefile
+++ b/net/arpwatch/Makefile
@@ -16,7 +16,7 @@ PKG_LICENSE:=BSD-4-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://distfiles.gentoo.org/distfiles/
-PKG_MD5SUM:=cebfeb99c4a7c2a6cee2564770415fe7
+PKG_HASH:=c1df9737e208a96a61fa92ddad83f4b4d9be66f8992f3c917e9edf4b05ff5898
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/arpwatch/files/arpwatch.init
+++ b/net/arpwatch/files/arpwatch.init
@@ -1,0 +1,10 @@
+#!/bin/sh /etc/rc.common
+START=90
+
+start () {
+	arpwatch -f /etc/arpwatch/arp.dat -i br-lan
+}
+
+stop() {
+	killall arpwatch
+}


### PR DESCRIPTION
Maintainer: Michel Belleau / @malaiwah
Compile tested: Yes, Atheros AR7xxx/AR9xxx (GL.iNet GL-AR150)
Run tested: Yes, OpenWRT-snapshot (2018-12-28)

Description:
arpwatch is a tool for monitoring Address Resolution Protocol traffic on a computer network. It generates a log of observed pairing of IP addresses with MAC addresses along with a timestamp when the pairing appeared on the network. It also has the option of sending an email to an administrator when a pairing changes or is added.