### PR TITLE
[18.06] nut: Default to run as root but fix alt runas

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -9,7 +9,7 @@ nut_upsmon_conf() {
 
 	echo "# Config file automatically generated from UCI config" > "$UPSMON_C"
 
-	config_get runas "$cfg" runas "nut"
+	config_get runas "$cfg" runas
 	[ -n "$runas" ] && echo "RUN_AS_USER $runas" >> $UPSMON_C
 
 	config_get val "$cfg" minsupplies 1

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -44,7 +44,7 @@ upsd_runas() {
 
 	[ -n "$RUNAS" ] && return
 
-	config_get runas "$cfg" runas "nut"
+	config_get runas "$cfg" runas
 	RUNAS="$runas"
 }
 
@@ -62,7 +62,7 @@ upsd_config() {
 
     # Note runas support requires you make sure USB device file is readable by
     # the runas user
-    config_get runas "$cfg" runas "nut"
+    config_get runas "$cfg" runas
     RUNAS="$runas"
 
     config_get statepath "$cfg" statepath "/var/run/nut"
@@ -221,7 +221,7 @@ build_global_driver_config() {
 	get_write_driver_config "$cfg" retrydelay
 	get_write_driver_config "$cfg" pollinterval
 	get_write_driver_config "$cfg" synchronous
-	config_get runas "$cfg" user "nut"
+	config_get runas "$cfg" user
 	RUNAS="$runas"
 	upsd_runas
 
@@ -229,7 +229,6 @@ build_global_driver_config() {
 }
 
 build_config() {
-	local RUNAS=nut
 	local STATEPATH=/var/run/nut
 
         mkdir -m 0755 -p "$(dirname "$UPS_C")"
@@ -252,7 +251,7 @@ start_driver_instance() {
 	local requested="$2"
 	local driver
 	local STATEPATH=/var/run/nut
-	local RUNAS=nut
+	local RUNAS
 
 	[ "$havedriver" != 1 ] && return
 
@@ -301,6 +300,7 @@ start_server_instance() {
 start_service() {
 	local havedriver haveserver
 	local STATEPATH=/var/run/nut
+	local RUNAS
 
 	# Avoid hotplug inadvertenly restarting driver during
 	# forced shutdown


### PR DESCRIPTION
Since the new hotplug script in master was not backport (new feature),
for 18.06 branch revert the old behavior of running NUT daemons and
drivers as root by default to avoid permisions problems, but backport
fix the support for running as another user for those who can set the
appropriate permissions on the USB (or other) device.

Closes: #7742

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: me / @cshoredaniel 
Compile tested: TBD (will update when done) 
Run tested: TBD (will update when done)
**EDIT:**  (compile** and run tested now, see comment below)

Description:

This is an RFC but will be working on compile and run testing over the next few days; but wanted to get this out for comments and/or other test ASAP since 18.06.2 maintenance release is coming up really fast.

@malakingpusa, @ivanich, @tofurky, @mantinan, @hnyman, @dibdot, @jow-

Any testing and comments would be appreciated before the 18.06.2 maintenance release