### PR TITLE
libdouble-conversion: Add host build to libdouble-conversion

### DIFF
--- a/libs/libdouble-conversion/Makefile
+++ b/libs/libdouble-conversion/Makefile
@@ -9,11 +9,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdouble-conversion
 PKG_VERSION:=3.1.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=double-conversion-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/google/double-conversion/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=95004b65e43fefc6100f337a25da27bb99b9ef8d4071a36a33b5e83eb1f82021
+
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/double-conversion-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/double-conversion-$(PKG_VERSION)
 
 PKG_MAINTAINER:=
@@ -21,6 +23,7 @@ PKG_LICENSE:=BSD-3c
 PKG_LICENSE_FILES:=COPYING LICENSE
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 define Package/libdouble-conversion
@@ -67,3 +70,4 @@ define Package/libdouble-conversion/install
 endef
 
 $(eval $(call BuildPackage,libdouble-conversion))
+$(eval $(call HostBuild))


### PR DESCRIPTION
This change adds the ability to produce host static build for the
libdouble-conversion library. Other host build tools can now depend on
this library if they need it.

Compile tested: on a x86_64 host build machine.
make package/libdouble-conversion/host/compile produces staging_dir/hostpkg/lib/libdouble-conversion.a file

Signed-off-by: Amol Bhave <ambhave@fb.com>