### PR TITLE
getdns: Remove iamperson347 from maintainer

### DIFF
--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -10,7 +10,7 @@ PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=David Mora <iamperson347+public@gmail.com>
+PKG_MAINTAINER:=Jonathan Underwood <jonathan.underwood@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://getdnsapi.net/dist/


### PR DESCRIPTION
I am no longer able to support maintaining the getdns lib for openwrt. I suggest Jonathan Underwood <jonathan.underwood@gmail.com> as a replacement.