### PR TITLE
fish: updated to v3.0.0, revert "apropos fix" for being fixed officially

### DIFF
--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fish
-PKG_VERSION:=2.7.1
-PKG_RELEASE:=2
+PKG_VERSION:=3.0.0
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fish-shell/fish-shell/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=eb43ea2eb9accf76661c487dd530a5fd345fa40a3201bd22cef2c52be39fb474
+PKG_HASH:=a16b0ff31111167ef4f3831ef428bb236bef592b7f49a2867bf42405ee95ff33
 PKG_MAINTAINER:=Curtis Jiang <jqqqqqqqqqq@gmail.com>
 PKG_LICENSE:=GPL-2.0
 
@@ -58,13 +58,10 @@ grep fish $${IPKG_INSTROOT}/etc/shells || \
     if [[ -e /bin/fish ]] && ([[ ! -L /bin/fish ]] || [[ "$(readlink -fn $${IPKG_INSTROOT}/bin/fish)" != "../$(CONFIGURE_PREFIX)/bin/fish" ]]); then
         ln -fs "../$(CONFIGURE_PREFIX)/bin/fish" "$${IPKG_INSTROOT}/bin/fish"
     fi
-	echo '#!/bin/sh' > /usr/bin/apropos
-	chmod +x /usr/bin/apropos
 endef
 
 define Package/fish/postrm
 	rm -rf "$${IPKG_INSTROOT}/$(CONFIGURE_PREFIX)/share/fish/$(PKG_VERSION)"
-	rm -f /usr/bin/apropos
 endef
 
 $(eval $(call BuildPackage,fish))

--- a/utils/fish/patches/001-no-hostname-and-whoami.patch
+++ b/utils/fish/patches/001-no-hostname-and-whoami.patch
@@ -1,16 +1,13 @@
 diff --git a/share/functions/prompt_hostname.fish b/share/functions/prompt_hostname.fish
-index 4348bce2..8502ce3f 100644
+index 225f437c..dc7f1cf8 100644
 --- a/share/functions/prompt_hostname.fish
 +++ b/share/functions/prompt_hostname.fish
-@@ -2,7 +2,7 @@
- # hostname command uses. So cache the answer so including it in the prompt doesn't make fish seem
- # slow.
- if not set -q __fish_prompt_hostname
--    set -g __fish_prompt_hostname (hostname | string split '.')[1]
-+    set -g __fish_prompt_hostname (uname -n | string split '.')[1]
- end
- 
+@@ -1,4 +1,4 @@
  function prompt_hostname
+     # return the short hostname only by default (#4804)
+-    string replace -r "\..*" "" $hostname
++    string replace -r "\..*" "" (uname -n)
+ end
 diff --git a/share/tools/web_config/sample_prompts/pythonista.fish b/share/tools/web_config/sample_prompts/pythonista.fish
 index 9529035c..57ffaf86 100644
 --- a/share/tools/web_config/sample_prompts/pythonista.fish


### PR DESCRIPTION
Maintainer: Curtis Jiang <jqqqqqqqqqq@gmail.com>
Compile tested: OpenWrt 18.06.1 (armv7l)
Run tested: OpenWrt 18.06.1 (armv7l)

Description:
Fish v3.0.0 is released. And the issue with "apropos" has been solved in that.