### PR TITLE
bonnie++: Replace libstdcpp depend with generic CXX.

### DIFF
--- a/utils/bonnie++/Makefile
+++ b/utils/bonnie++/Makefile
@@ -9,31 +9,40 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bonnie++
 PKG_VERSION:=1.97.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
-PKG_SOURCE_URL:=http://www.coker.com.au/bonnie++/
+PKG_SOURCE_URL:=https://www.coker.com.au/bonnie++/
 PKG_HASH:=e27b386ae0dc054fa7b530aab6bdead7aea6337a864d1f982bc9ebacb320746e
+
+PKG_MAINTAINER:=Florian Fainelli <florian@openwrt.org>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=copyright.txt
-PKG_MAINTAINER:=Florian Fainelli <florian@openwrt.org>
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
 
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/bonniexx
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libstdcpp +libpthread
+  DEPENDS:=$(CXX_DEPENDS) +libpthread
   TITLE:=Bonnie++ - hard drive bottleneck testing program.
-  URL:=http://www.coker.com.au/bonnie++/
+  URL:=https://www.coker.com.au/bonnie++/
 endef
 
 define Package/bonniexx/description
   Bonnie++ is a benchmark suite that is aimed at performing a number of simple
   tests of hard drive and file system performance.
 endef
+
+ifeq ($(CONFIG_USE_UCLIBCXX),y)
+TARGET_LDFLAGS +=-nodefaultlibs
+endif
+
+TARGET_CXXFLAGS +=-fno-rtti
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \

--- a/utils/bonnie++/patches/010-uclibcxx.patch
+++ b/utils/bonnie++/patches/010-uclibcxx.patch
@@ -1,0 +1,35 @@
+--- a/configure.in
++++ b/configure.in
+@@ -31,7 +31,6 @@ fi
+ 
+ dnl Checks for programs.
+ AC_LANG_CPLUSPLUS
+-AC_PROG_CC
+ AC_PROG_CXX
+ AC_PROG_CXXCPP
+ AC_PROG_INSTALL
+@@ -60,13 +59,13 @@ if [[ -n "$snprintf" ]]; then
+    snprintf="#define NO_SNPRINTF"
+ fi
+ 
+-AC_CHECK_HEADERS(algorithm algo.h algo)
++AC_CHECK_HEADERS(algorithm)
+ 
+ AC_SUBST(linux_pthread)
+ AC_TRY_COMPILE([#define _GNU_SOURCE
+ #include <pthread.h>
+ ] , [pthread_mutexattr_t attr;
+-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP);]
++    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);]
+   , linux_pthread="yes")
+ if [[ -n "$linux_pthread" ]]; then
+    linux_pthread="#define LINUX_PTHREAD"
+@@ -83,7 +82,7 @@ void * thread_func(void * param) { return NULL; }
+   , thread_ldflags="-pthread")
+ 
+ AC_SUBST(large_file)
+-AC_TRY_RUN([#ifndef _LARGEFILE64_SOURCE
++AC_TRY_COMPILE([#ifndef _LARGEFILE64_SOURCE
+ #define _LARGEFILE64_SOURCE
+ #endif
+ #include <stdio.h>


### PR DESCRIPTION
This allows to get rid of the heavy libstdcpp dependency.

Also did some Makefile rearrangements for consistency.

Added HTTPS to URLs.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ffainelli 
Compile tested: ramips mvebu
Run tested: turris omnia