### PR TITLE
libpam: Update to 1.3.1

### DIFF
--- a/libs/libpam/Makefile
+++ b/libs/libpam/Makefile
@@ -8,17 +8,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpam
-PKG_VERSION:=1.3.0
+PKG_VERSION:=1.3.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=Linux-PAM-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=http://www.linux-pam.org/library/
-PKG_HASH:=241aed1ef522f66ed672719ecf2205ec513fd0075ed80cda8e086a5b1a01d1bb
-PKG_INSTALL:=1
-PKG_FIXUP:=autoreconf
-PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
-
+PKG_SOURCE:=Linux-PAM-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/linux-pam/linux-pam/releases/download/v$(PKG_VERSION)
+PKG_HASH:=eff47a4ecd833fbf18de9686632a70ee8d0794b79aecb217ebd0ce11db4cd0db
 PKG_BUILD_DIR:=$(BUILD_DIR)/Linux-PAM-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
+PKG_LICENSE:=BSD-3c GPL
+PKG_LICENSE_FILES:=COPYING Copyright
+PKG_CPE_ID:=cpe:/a:kernel:linux-pam
+
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -33,23 +38,22 @@ define Package/libpam/description
 	The Linux-PAM Pluggable Authentication Modules.
 endef
 
-TARGET_CFLAGS += $(FPIC)
-
-define Build/Configure
-	$(call Build/Configure/Default, \
-		--enable-shared \
-		--enable-static \
-		--enable-pamlocking \
-		--disable-prelude \
-		--disable-lckpwdf \
-		--disable-selinux \
-		--disable-nls \
-		--disable-rpath \
-		--disable-nis \
-		--disable-regenerate-docu \
-		--enable-db=no \
-	)
-endef
+CONFIGURE_ARGS += \
+	--enable-pamlocking \
+	--enable-shared \
+	--enable-static \
+	--disable-audit \
+	--disable-cracklib \
+	--disable-db \
+	--disable-prelude \
+	--disable-lckpwdf \
+	--disable-nis \
+	--disable-regenerate-docu \
+	--disable-rpath \
+	--disable-selinux \
+	--with-gnu-ld \
+	--without-mailspool \
+	--without-xauth
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/lib

--- a/libs/libpam/patches/0005-build-fix-doc-build.patch
+++ b/libs/libpam/patches/0005-build-fix-doc-build.patch
@@ -26,7 +26,7 @@ index 3db4e37..5e6592a 100644
 +++ b/Makefile.am
 @@ -4,7 +4,10 @@
  
- AUTOMAKE_OPTIONS = 1.9 gnu dist-bzip2 check-news
+ AUTOMAKE_OPTIONS = 1.9 gnu dist-bzip2 dist-xz check-news
  
 -SUBDIRS = libpam tests libpamc libpam_misc modules po conf doc examples xtests
 +if ENABLE_REGENERATE_MAN

--- a/libs/libpam/patches/0007-Replace-strndupa-with-strcpy.patch
+++ b/libs/libpam/patches/0007-Replace-strndupa-with-strcpy.patch
@@ -23,13 +23,14 @@ index 0ab6548..2fbab4f 100644
    pid_t pid;
    int fds[2];
    int stdout_fds[2];
-@@ -178,11 +178,11 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
+@@ -180,12 +180,12 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
+ 	      if (resp)
+ 		{
+ 		  pam_set_item (pamh, PAM_AUTHTOK, resp);
+-		  authtok = strndupa (resp, PAM_MAX_RESP_SIZE);
++		  strcpy (authtok, resp);
+ 		  _pam_drop (resp);
  		}
- 
- 	      pam_set_item (pamh, PAM_AUTHTOK, resp);
--	      authtok = strndupa (resp, PAM_MAX_RESP_SIZE);
-+	      strcpy (authtok, resp);
- 	      _pam_drop (resp);
  	    }
  	  else
 -	    authtok = strndupa (void_pass, PAM_MAX_RESP_SIZE);
@@ -37,7 +38,7 @@ index 0ab6548..2fbab4f 100644
  
  	  if (pipe(fds) != 0)
  	    {
-@@ -222,23 +222,14 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
+@@ -225,23 +225,14 @@ call_exec (const char *pam_type, pam_handle_t *pamh,
  
        if (expose_authtok) /* send the password to the child */
  	{


### PR DESCRIPTION
Upstream switched to GitHub for releases. Follow suit.

Rearranged Makefile quite a bit to be more similar to other projects.

Added PKG_BUILD_PARALLEL for faster compilation.

Added PKG_CPE_ID for proper CVE tracking.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmav
Compile tested: mvebu