### PR TITLE
prometheus-node-exporter-lua: change network metric type to counter

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,8 +4,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2018.07.23
-PKG_RELEASE:=3
+PKG_VERSION:=2018.12.30
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netdev.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/netdev.lua
@@ -29,7 +29,7 @@ local function scrape()
     end
   end
   for i, ndss in ipairs(netdevsubstat) do
-    netdev_metric = metric("node_network_" .. ndss, "gauge")
+    netdev_metric = metric("node_network_" .. ndss, "counter")
     for dev, nds_dev in pairs(nds_table) do
       netdev_metric({device=dev}, nds_dev[i+1])
     end


### PR DESCRIPTION
Maintainer: @champtar
Compile tested: N/A
Run tested: TP-Link Archer C7 v2, r7258-5eb055306f

Description:
https://prometheus.io/docs/concepts/metric_types/#counter
As network counters can only increase (or reset), they should be described as counter, not gauge, like CPU counters from `cpu.lua`:
```
# TYPE node_cpu_seconds_total counter
node_cpu_seconds_total{cpu="cpu0",mode="user"} 35800.89
```

Signed-off-by: Piotr Machała <pm7gt@933x.net>