### PR TITLE
python-pyasn1: bump to version 0.4.5

### DIFF
--- a/lang/python/python-pyasn1/Makefile
+++ b/lang/python/python-pyasn1/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyasn1
-PKG_VERSION:=0.4.4
+PKG_VERSION:=0.4.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=pyasn1-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyasn1
-PKG_HASH:=f58f2a3d12fd754aa123e9fa74fb7345333000a035f3921dbdaa08597aa53137
+PKG_HASH:=da2420fe13a9452d8ae97a0e478adde1dee153b11ba832a95b223a2ba01c10f7
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE.txt


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/openwrt/openwrt/commit/213c0e78fa   x86_64
Run tested: https://github.com/openwrt/openwrt/commit/213c0e78fa   x86_64

--------------------------------------------------------------------------------------------

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>