### PR TITLE
python: backport CVE-2018-14647 patches from upstream

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -12,7 +12,7 @@ include ../python-version.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)

--- a/lang/python/python/patches/014-2.7-bpo-34623-Use-XML_SetHashSalt-in-_elementtree-GH.patch
+++ b/lang/python/python/patches/014-2.7-bpo-34623-Use-XML_SetHashSalt-in-_elementtree-GH.patch
@@ -1,0 +1,92 @@
+From 18b20bad75b4ff0486940fba4ec680e96e70f3a2 Mon Sep 17 00:00:00 2001
+From: Christian Heimes <christian@python.org>
+Date: Tue, 18 Sep 2018 15:13:09 +0200
+Subject: [PATCH] [2.7] bpo-34623: Use XML_SetHashSalt in _elementtree
+ (GH-9146) (GH-9394)
+
+The C accelerated _elementtree module now initializes hash randomization
+salt from _Py_HashSecret instead of libexpat's default CPRNG.
+
+Signed-off-by: Christian Heimes <christian@python.org>
+
+https://bugs.python.org/issue34623.
+(cherry picked from commit cb5778f00ce48631c7140f33ba242496aaf7102b)
+
+Co-authored-by: Christian Heimes <christian@python.org>
+
+
+
+https://bugs.python.org/issue34623
+---
+ Include/pyexpat.h                                            | 4 +++-
+ .../next/Security/2018-09-10-16-05-39.bpo-34623.Ua9jMv.rst   | 2 ++
+ Modules/_elementtree.c                                       | 5 +++++
+ Modules/pyexpat.c                                            | 5 +++++
+ 4 files changed, 15 insertions(+), 1 deletion(-)
+ create mode 100644 Misc/NEWS.d/next/Security/2018-09-10-16-05-39.bpo-34623.Ua9jMv.rst
+
+diff --git a/Include/pyexpat.h b/Include/pyexpat.h
+index 5340ef5fa3..3fc5fa54da 100644
+--- a/Include/pyexpat.h
++++ b/Include/pyexpat.h
+@@ -3,7 +3,7 @@
+ 
+ /* note: you must import expat.h before importing this module! */
+ 
+-#define PyExpat_CAPI_MAGIC  "pyexpat.expat_CAPI 1.0"
++#define PyExpat_CAPI_MAGIC  "pyexpat.expat_CAPI 1.1"
+ #define PyExpat_CAPSULE_NAME "pyexpat.expat_CAPI"
+ 
+ struct PyExpat_CAPI 
+@@ -43,6 +43,8 @@ struct PyExpat_CAPI
+         XML_Parser parser, XML_UnknownEncodingHandler handler,
+         void *encodingHandlerData);
+     void (*SetUserData)(XML_Parser parser, void *userData);
++    /* might be none for expat < 2.1.0 */
++    int (*SetHashSalt)(XML_Parser parser, unsigned long hash_salt);
+     /* always add new stuff to the end! */
+ };
+ 
+diff --git a/Misc/NEWS.d/next/Security/2018-09-10-16-05-39.bpo-34623.Ua9jMv.rst b/Misc/NEWS.d/next/Security/2018-09-10-16-05-39.bpo-34623.Ua9jMv.rst
+new file mode 100644
+index 0000000000..31ad92ef85
+--- /dev/null
++++ b/Misc/NEWS.d/next/Security/2018-09-10-16-05-39.bpo-34623.Ua9jMv.rst
+@@ -0,0 +1,2 @@
++The C accelerated _elementtree module now initializes hash randomization
++salt from _Py_HashSecret instead of libexpat's default CSPRNG.
+diff --git a/Modules/_elementtree.c b/Modules/_elementtree.c
+index f7f992dd3a..b38e0ab329 100644
+--- a/Modules/_elementtree.c
++++ b/Modules/_elementtree.c
+@@ -2574,6 +2574,11 @@ xmlparser(PyObject* self_, PyObject* args, PyObject* kw)
+         PyErr_NoMemory();
+         return NULL;
+     }
++    /* expat < 2.1.0 has no XML_SetHashSalt() */
++    if (EXPAT(SetHashSalt) != NULL) {
++        EXPAT(SetHashSalt)(self->parser,
++                           (unsigned long)_Py_HashSecret.prefix);
++    }
+ 
+     ALLOC(sizeof(XMLParserObject), "create expatparser");
+ 
+diff --git a/Modules/pyexpat.c b/Modules/pyexpat.c
+index 2b4d31293c..1f8c0d70a5 100644
+--- a/Modules/pyexpat.c
++++ b/Modules/pyexpat.c
+@@ -2042,6 +2042,11 @@ MODULE_INITFUNC(void)
+     capi.SetProcessingInstructionHandler = XML_SetProcessingInstructionHandler;
+     capi.SetUnknownEncodingHandler = XML_SetUnknownEncodingHandler;
+     capi.SetUserData = XML_SetUserData;
++#if XML_COMBINED_VERSION >= 20100
++    capi.SetHashSalt = XML_SetHashSalt;
++#else
++    capi.SetHashSalt = NULL;
++#endif
+ 
+     /* export using capsule */
+     capi_object = PyCapsule_New(&capi, PyExpat_CAPSULE_NAME, NULL);
+-- 
+2.19.1
+

--- a/lang/python/python/patches/015-2.7-bpo-34623-Mention-CVE-2018-14647-in-news-entry-G.patch
+++ b/lang/python/python/patches/015-2.7-bpo-34623-Mention-CVE-2018-14647-in-news-entry-G.patch
@@ -1,0 +1,31 @@
+From 10be1d3f802b874914b2a13eb41407c7a582d9b3 Mon Sep 17 00:00:00 2001
+From: "Miss Islington (bot)"
+ <31488909+miss-islington@users.noreply.github.com>
+Date: Fri, 21 Sep 2018 21:57:00 -0700
+Subject: [PATCH] [2.7] bpo-34623: Mention CVE-2018-14647 in news entry
+ (GH-9482) (GH-9490)
+
+https://bugs.python.org/issue34623
+(cherry picked from commit 026337a7101369297c8083047d2f3c6fc9dd1e2b)
+
+
+Co-authored-by: Christian Heimes <christian@python.org>
+
+
+https://bugs.python.org/issue34623
+---
+ .../next/Security/2018-09-10-16-05-39.bpo-34623.Ua9jMv.rst    | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Misc/NEWS.d/next/Security/2018-09-10-16-05-39.bpo-34623.Ua9jMv.rst b/Misc/NEWS.d/next/Security/2018-09-10-16-05-39.bpo-34623.Ua9jMv.rst
+index 31ad92ef85..cbaa4b7506 100644
+--- a/Misc/NEWS.d/next/Security/2018-09-10-16-05-39.bpo-34623.Ua9jMv.rst
++++ b/Misc/NEWS.d/next/Security/2018-09-10-16-05-39.bpo-34623.Ua9jMv.rst
+@@ -1,2 +1,2 @@
+-The C accelerated _elementtree module now initializes hash randomization
+-salt from _Py_HashSecret instead of libexpat's default CSPRNG.
++CVE-2018-14647: The C accelerated _elementtree module now initializes hash
++randomization salt from _Py_HashSecret instead of libexpat's default CSPRNG.
+-- 
+2.19.1
+


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/openwrt/openwrt/commit/213c0e78fa   x86_64
Run tested: https://github.com/openwrt/openwrt/commit/213c0e78fa   x86_64

--------------------------------------------------------------------------------------------

These patches are backports from Python 2.7 upstream.
The security issue is described here:
  https://nvd.nist.gov/vuln/detail/CVE-2018-14647

The Python bug report:
  https://bugs.python.org/issue34623

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>