### PR TITLE
protobuf: Update to 3.6.1

### DIFF
--- a/libs/protobuf/Makefile
+++ b/libs/protobuf/Makefile
@@ -8,19 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=protobuf
-PKG_VERSION:=3.5.1
+PKG_VERSION:=3.7.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-cpp-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/google/protobuf/releases/download/v$(PKG_VERSION)
-PKG_HASH:=c28dba8782da2cfea1e11c61d335958c31a9c1bc553063546af9cbe98f204092
+PKG_HASH:=97f6cdaa0724d5a8cd3375d5f5cf4bd253d5ad5291154f533ed0d94a9d501ef3
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_DEPENDS:=protobuf/host
-PKG_USE_MIPS16:=0# MIPS16 prevents protobuf's usage of the 'sync' asm-opcode
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -31,7 +31,7 @@ define Package/protobuf/Default
   CATEGORY:=Libraries
   TITLE:=A structured data encoding library
   URL:=https://github.com/google/protobuf
-  DEPENDS:=+zlib +libpthread +libstdcpp
+  DEPENDS:=+zlib +libpthread +libatomic +libstdcpp
   MAINTAINER:=Ken Keys <kkeys@caida.org>
 endef
 


### PR DESCRIPTION
Added upstream patch to fix compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @kenkeys 
Compile tested: ramips
