### PR TITLE
nft-qos: fix monitor doesn't work when firstboot

### DIFF
--- a/net/nft-qos/Makefile
+++ b/net/nft-qos/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nft-qos
-PKG_VERSION:=1.0.2
+PKG_VERSION:=1.0.3
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0
 

--- a/net/nft-qos/files/nft-qos-monitor.hotplug
+++ b/net/nft-qos/files/nft-qos-monitor.hotplug
@@ -8,6 +8,14 @@
 logger -t nft-qos-monitor "ACTION=$ACTION, MACADDR=$MACADDR, IPADDR=$IPADDR, HOSTNAME=$HOSTNAME"
 
 case "$ACTION" in
-	add | update) qosdef_init_env && qosdef_monitor_add $MACADDR $IPADDR $HOSTNAME;;
-	remove) qosdef_init_env && qosdef_monitor_del $MACADDR $IPADDR $HOSTNAME;;
+	add | update)
+		qosdef_init_env
+		qosdef_init_monitor
+		qosdef_monitor_add $MACADDR $IPADDR $HOSTNAME
+	;;
+	remove)
+		qosdef_init_env
+		qosdef_init_monitor
+		qosdef_monitor_del $MACADDR $IPADDR $HOSTNAME
+	;;
 esac


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx, WR818, master
Run tested: ar71xx, WR818, master

Description: Fix the issue that realtime rate monitor doesn't work when firstboot. This is because the monitor table doesn't exist that result in the problem.
