### PR TITLE
gitolite: Remove unecessary Makefile variables

### DIFF
--- a/net/gitolite/Makefile
+++ b/net/gitolite/Makefile
@@ -14,8 +14,6 @@ PKG_RELEASE:=1
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=0ae3bea637b25cff13826e5ecd181c7b74a6eff377cf4c2243d85c2b0a290d3f
 PKG_SOURCE_URL:=https://codeload.github.com/sitaramc/gitolite/tar.gz/v$(PKG_VERSION)?
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
PKG_SOURCE_DIR and PKG_BUILD_DIR are just the default, so remove them
from the gitolite Makefile

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: me / @cshoredaniel 
Compile tested: brcm2708, raspberry pi, recent masters
Run tested: shouldn't be needed as there is no binary change.

Description:
