### PR TITLE
[RFC] Python3 pkging enhancements

### DIFF
--- a/lang/python/python-package-install.sh
+++ b/lang/python/python-package-install.sh
@@ -11,6 +11,7 @@ process_filespec() {
 	local dst_dir="$2"
 	local filespec="$3"
 	echo "$filespec" | (
+	set -e
 	IFS='|'
 	while read fop fspec fperm; do
 		local fop=`echo "$fop" | tr -d ' \t\n'`
@@ -37,7 +38,7 @@ process_filespec() {
 			chmod -R $fperm ${dst_dir}${fspec}
 		fi
 	done
-	)
+	) || exit 1	# Otherwise error return gets ignored
 }
 
 ver="$1"

--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -96,6 +96,7 @@ define PyPackage
 		if [ -d $(PKG_INSTALL_DIR)/usr/bin ]; then \
 			$(INSTALL_DIR) $$(1)/usr/bin ; \
 			$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $$(1)/usr/bin/ ; \
+			$(SED) 's,^#!.*python.*,#!/usr/bin/python$(PYTHON_VERSION),' $$(1)/usr/bin/* ; \
 		fi
     endef
   endif

--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -21,6 +21,8 @@ PKG_HASH:=22d9b1ac5b26135ad2b8c2901a9413537e08749a753356ee913c84dbd2df5574
 PKG_LICENSE:=PSF
 PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
 
+PYTHON_PKG_OLD:=0
+
 # This file provides the necsessary host build variables
 include ../python-host.mk
 
@@ -238,6 +240,9 @@ define PyPackage/python-base/filespec
 +|/usr/bin/python$(PYTHON_VERSION)
 $(subst $(space),$(newline),$(foreach lib_file,$(PYTHON_BASE_LIB_FILES),+|$(lib_file)))
 endef
+
+PYTHON_PKG_install_ARGS:=
+PYTHON_PKG_build_ext_ARGS:=
 
 define PyPackage/python-light/filespec
 +|/usr/lib/python$(PYTHON_VERSION)

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -100,6 +100,7 @@ define Py3Package
 		if [ -d $(PKG_INSTALL_DIR)/usr/bin ]; then \
 			$(INSTALL_DIR) $$(1)/usr/bin ; \
 			$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $$(1)/usr/bin/ ; \
+			$(SED) 's,^#!.*python.*,#!/usr/bin/python$(PYTHON3_VERSION),' $$(1)/usr/bin/* ; \
 		fi
     endef
   endif

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -24,9 +24,10 @@ PKG_HASH:=d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb
 PKG_LICENSE:=PSF
 PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
 
+PYTHON3_PKG_OLD:=0
+
 # This file provides the necsessary host build variables
 include ../python3-host.mk
-
 # For Py3Package
 include ../python3-package.mk
 
@@ -97,6 +98,10 @@ PYTHON3_LIB_FILES_DEL:=
 PYTHON3_PACKAGES:=
 PYTHON3_SO_SUFFIX:=cpython-$(PYTHON3_VERSION_MAJOR)$(PYTHON3_VERSION_MINOR).so
 PYTHON3_PACKAGES_DEPENDS:=
+
+PYTHON3_PKG_install_ARGS:=
+PYTHON3_PKG_build_ext_ARGS:=
+
 define Py3BasePackage
   PYTHON3_PACKAGES+=$(1)
   ifeq ($(3),)

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -197,6 +197,7 @@ endef
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/ $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON_VERSION)/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/include/python$(PYTHON_VERSION) \
 		$(1)/usr/include/
@@ -204,6 +205,10 @@ define Build/InstallDev
 		$(HOST_PYTHON3_LIB_DIR) \
 		$(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON_VERSION).so* \
 		$(1)/usr/lib/
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/python3.pc \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/python-$(PYTHON3_VERSION).pc \
+		$(1)/usr/lib/pkgconfig
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/config-$(PYTHON_VERSION) \
 		$(1)/usr/lib/python$(PYTHON_VERSION)/


### PR DESCRIPTION
Maintainer: **EDIT**: @commodo @jefferyto   -- must have been autopilot.
Compile tested: brcm2708, raspbery pi, recent masters
Run tested: N/A (but have actually used radicale2 with these changes).

Description:
Add some hooks to the python packaging magic so that we can add more types
of Python package without a per-package cut&paste and modify the main
packaging magic.  I'm using this for radicale2 and python-lxc which I am working on adding.