### PR TITLE
[RFC] lxc python-lxc: Add LXC python bindings

### DIFF
--- a/lang/python/python-lxc/Makefile
+++ b/lang/python/python-lxc/Makefile
@@ -1,0 +1,85 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-lxc
+PKG_VERSION:=2.1.1
+PKG_RELEASE:=1
+
+PKG_LICENSE:=LGPL-2.1+ BSD-2-Clause GPL-2.0
+PKG_MAINTAINER:=Daniel Dickinson <cshored@thecshore.com>
+
+PKG_SOURCE:=lxc-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/
+PKG_HASH:=68663a67450a8d6734e137eac54cc7077209fb15c456eec401a2c26e6386eff6
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_FIXUP:=autoreconf
+PKG_AUTOMAKE_DIRS:=src src/python-lxc
+
+PKG_BUILD_DEPENDS:=lxc
+
+PYTHON3_PKG_OLD:=0
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python3-lxc
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=LXC Python3 bindings
+  DEPENDS:=@LXC_PYTHON +python3-light +liblxc
+  URL:=http://lxc.sourceforge.net/
+  VARIANT:=python3
+endef
+
+define Package/python3-lxc/description
+ LXC is the userspace control package for Linux Containers, a lightweight
+ virtual system mechanism sometimes described as "chroot on steroids".
+ .
+ This package contains the Python 3.7 bindings.
+endef
+
+CONFIGURE_ARGS += \
+	--disable-api-docs \
+	--disable-apparmor \
+	--disable-bash \
+	--disable-doc \
+	--disable-examples \
+	--disable-gnutls \
+	--disable-selinux \
+	--disable-cgmanager \
+	--disable-examples \
+	--enable-lua=yes \
+	--with-lua-pc="$(STAGING_DIR)/usr/lib/pkgconfig/lua.pc"
+
+ifeq ($(CONFIG_LXC_SECCOMP),y)
+CONFIGURE_ARGS+=\
+	--enable-seccomp
+else
+CONFIGURE_ARGS+=\
+	--disable-seccomp
+endif
+
+CONFIGURE_ARGS+=\
+	--enable-python=yes
+
+PYTHON3_PKG_build_ext_SUBDIR:=src/python-lxc
+PYTHON3_PKG_install_SUBDIR:=src/python-lxc
+PYTHON3_PKG_build_ext_ARGS:=build_ext --no-pkg-config
+
+$(eval $(call Py3Package,python3-lxc))
+
+define Package/python3-lxc-src
+$(call Package/python3-lxc)
+  DEPENDS:=@LXC_PYTHON
+  TITLE+= (sources)
+endef
+
+$(eval $(call BuildPackage,python3-lxc))
+$(eval $(call BuildPackage,python3-lxc-src))

--- a/lang/python/python-lxc/patches/001-nl-avoid-NULL-pointer-dereference.patch
+++ b/lang/python/python-lxc/patches/001-nl-avoid-NULL-pointer-dereference.patch
@@ -1,0 +1,37 @@
+From c8f05589644d6b719e5a2c7fc548604f248be9be Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal@milecki.pl>
+Date: Sun, 29 Jul 2018 17:44:06 +0200
+Subject: [PATCH] nl: avoid NULL pointer dereference
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It's a valid case to call nla_put() with NULL data and 0 len. It's done e.g. in
+the nla_put_attr().
+
+There has to be a check for data in nla_put() as passing NULL to the memcpy()
+is not allowed. Even if length is 0, both pointers have to be valid.
+
+For a reference see C99 standard (7.21.1/2), it says: "pointer arguments on
+such a call shall still have valid values".
+
+Reported-by: Daniel Gimpelevich <daniel@gimpelevich.san-francisco.ca.us>
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
+[christian.brauner@ubuntu.com: adapted commit message]
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+---
+ src/lxc/nl.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/src/lxc/nl.c
++++ b/src/lxc/nl.c
+@@ -61,7 +61,8 @@ static int nla_put(struct nlmsg *nlmsg,
+ 	rta = NLMSG_TAIL(nlmsg->nlmsghdr);
+ 	rta->rta_type = attr;
+ 	rta->rta_len = rtalen;
+-	memcpy(RTA_DATA(rta), data, len);
++	if (data && len)
++		memcpy(RTA_DATA(rta), data, len);
+ 	nlmsg->nlmsghdr->nlmsg_len = tlen;
+ 	return 0;
+ }

--- a/lang/python/python-lxc/patches/002-compile.patch
+++ b/lang/python/python-lxc/patches/002-compile.patch
@@ -1,0 +1,10 @@
+--- a/src/lxc/storage/aufs.h
++++ b/src/lxc/storage/aufs.h
+@@ -24,7 +24,6 @@
+ #ifndef __LXC_AUFS_H
+ #define __LXC_AUFS_H
+ 
+-#define _GNU_SOURCE
+ #include <stdbool.h>
+ #include <stdio.h>
+ #include <stdint.h>

--- a/lang/python/python-lxc/patches/003-compile.patch
+++ b/lang/python/python-lxc/patches/003-compile.patch
@@ -1,0 +1,11 @@
+--- a/src/lxc/confile_utils.c
++++ b/src/lxc/confile_utils.c
+@@ -677,7 +677,7 @@
+ 	char *endptr = NULL;
+ 
+ 	if (strncmp(*value, "unlimited", sizeof("unlimited") - 1) == 0) {
+-		*res = RLIM_INFINITY;
++		*res = (unsigned long)RLIM_INFINITY;
+ 		*value += sizeof("unlimited") - 1;
+ 		return true;
+ 	}

--- a/lang/python/python-lxc/patches/010-compile.patch
+++ b/lang/python/python-lxc/patches/010-compile.patch
@@ -1,0 +1,37 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -47,34 +47,6 @@ AC_GNU_SOURCE
+ LT_INIT
+ AC_SUBST([LIBTOOL_DEPS])
+ 
+-# Detect the distribution. This is used for the default configuration and
+-# for some distro-specific build options.
+-AC_MSG_CHECKING([host distribution])
+-AC_ARG_WITH(distro, AS_HELP_STRING([--with-distro=DISTRO], [Specify the Linux distribution to target: One of redhat, oracle, centos, fedora, suse, gentoo, debian, arch, slackware, plamo, paldo, openmandriva, pardus, sparclinux, altlinux.]))
+-if type lsb_release >/dev/null 2>&1 && test "z$with_distro" = "z"; then
+-	with_distro=`lsb_release -is`
+-fi
+-if test "z$with_distro" = "z"; then
+-	AC_CHECK_FILE(/etc/redhat-release,with_distro="redhat")
+-	AC_CHECK_FILE(/etc/oracle-release,with_distro="oracle")
+-	AC_CHECK_FILE(/etc/sparclinux-release,with_distro="sparclinux")
+-	AC_CHECK_FILE(/etc/centos-release,with_distro="centos")
+-	AC_CHECK_FILE(/etc/fedora-release,with_distro="fedora")
+-	AC_CHECK_FILE(/etc/SuSE-release,with_distro="suse")
+-	AC_CHECK_FILE(/etc/gentoo-release,with_distro="gentoo")
+-	AC_CHECK_FILE(/etc/debian_version,with_distro="debian")
+-	AC_CHECK_FILE(/etc/arch-release,with_distro="arch")
+-	AC_CHECK_FILE(/etc/slackware-version,with_distro="slackware")
+-	AC_CHECK_FILE(/etc/plamo-version,with_distro="plamo")
+-	AC_CHECK_FILE(/etc/frugalware-release,with_distro="frugalware")
+-	AC_CHECK_FILE(/etc/mandrakelinux-release, with_distro="openmandriva")
+-	AC_CHECK_FILE(/etc/mandriva-release,with_distro="openmandriva")
+-	AC_CHECK_FILE(/etc/pardus-release,with_distro="pardus")
+-	AC_CHECK_FILE(/etc/altlinux-release,with_distro="altlinux")
+-	AC_CHECK_FILE(/etc/pld-release,with_distro="pld")
+-fi
+-with_distro=`echo ${with_distro} | tr '[[:upper:]]' '[[:lower:]]'`
+-
+ if test "z$with_distro" = "zforsparc"; then
+ 	with_distro="sparclinux"
+ fi

--- a/lang/python/python-lxc/patches/015-getline.patch
+++ b/lang/python/python-lxc/patches/015-getline.patch
@@ -1,0 +1,15 @@
+--- a/src/lxc/utils.h
++++ b/src/lxc/utils.h
+@@ -59,11 +59,7 @@ extern int mkdir_p(const char *dir, mode_t mode);
+ extern char *get_rundir(void);
+ 
+ /* Define getline() if missing from the C library */
+-#ifndef HAVE_GETLINE
+-#ifdef HAVE_FGETLN
+-#include <../include/getline.h>
+-#endif
+-#endif
++#include "../include/getline.h"
+ 
+ /* Define setns() if missing from the C library */
+ #ifndef HAVE_SETNS

--- a/lang/python/python-lxc/patches/020-lxc-checkconfig.patch
+++ b/lang/python/python-lxc/patches/020-lxc-checkconfig.patch
@@ -1,0 +1,20 @@
+--- a/src/lxc/tools/lxc-checkconfig.in
++++ b/src/lxc/tools/lxc-checkconfig.in
+@@ -3,6 +3,17 @@
+ # Allow environment variables to override config
+ : ${CONFIG:=/proc/config.gz}
+ : ${MODNAME:=configs}
++: ${ZGREP:=zgrep}
++: ${GUNZIP:=gunzip}
++
++if [ -z $(which $ZGREP) ] && ! [ -z $(which $GUNZIP) ] && [ -x $(which $GUNZIP) ] &&  [ -f $CONFIG ] && [ "$CONFIG" == "/proc/config.gz" ] ; then
++
++	CONFIG_NEW="/tmp/config-$(uname -r)"
++	$GUNZIP -c $CONFIG > $CONFIG_NEW
++	CONFIG=$CONFIG_NEW
++
++	GREP=grep
++fi
+ 
+ CAT="cat"
+ 

--- a/lang/python/python-lxc/patches/025-remove-unsupported-option.patch
+++ b/lang/python/python-lxc/patches/025-remove-unsupported-option.patch
@@ -1,0 +1,24 @@
+--- a/templates/lxc-download.in
++++ b/templates/lxc-download.in
+@@ -505,20 +505,7 @@ fi
+ # Unpack the rootfs
+ echo "Unpacking the rootfs"
+ 
+-EXCLUDES=""
+-excludelist=$(relevant_file excludes)
+-if [ -f "${excludelist}" ]; then
+-    while read -r line; do
+-        EXCLUDES="${EXCLUDES} --exclude=${line}"
+-    done < "${excludelist}"
+-fi
+-
+-# Do not surround ${EXCLUDES} by quotes. This does not work. The solution could
+-# use array but this is not POSIX compliant. The only POSIX compliant solution
+-# is to use a function wrapper, but the latter can't be used here as the args
+-# are dynamic. We thus need to ignore the warning brought by shellcheck.
+-# shellcheck disable=SC2086
+-tar  --anchored ${EXCLUDES} --numeric-owner -xpJf \
++tar --numeric-owner -xpJf \
+     "${LXC_CACHE_PATH}/rootfs.tar.xz" -C "${LXC_ROOTFS}"
+ 
+ mkdir -p "${LXC_ROOTFS}/dev/pts/"

--- a/lang/python/python-lxc/patches/100-skip-python-pkg-build.patch
+++ b/lang/python/python-lxc/patches/100-skip-python-pkg-build.patch
@@ -1,0 +1,36 @@
+Index: lxc-2.1.1/src/python-lxc/Makefile.am
+===================================================================
+--- lxc-2.1.1.orig/src/python-lxc/Makefile.am
++++ lxc-2.1.1/src/python-lxc/Makefile.am
+@@ -1,31 +1,3 @@
+-if ENABLE_PYTHON
+-
+-if HAVE_DEBIAN
+-    DISTSETUPOPTS=--install-layout=deb
+-else
+-    DISTSETUPOPTS=
+-endif
+-
+-if ENABLE_RPATH
+-    RPATHOPTS=-R $(libdir)
+-else
+-    RPATHOPTS=
+-endif
+-
+-CALL_SETUP_PY := cd @srcdir@ && $(PYTHON) setup.py build -b @abs_builddir@/build egg_info -e @abs_builddir@
+-
+-all:
+-	$(CALL_SETUP_PY) build_ext -I @abs_top_srcdir@/src -L @abs_top_builddir@/src/lxc/.libs/ $(RPATHOPTS) --no-pkg-config
+-
+-DESTDIR = / # default
+-
+-install:
+-	$(CALL_SETUP_PY) install --prefix=$(prefix) --no-compile $(DISTSETUPOPTS) --root=$(DESTDIR)
+-
+-clean-local:
+-	rm -rf @builddir@/build
+-
+-endif
+ EXTRA_DIST = \
+ 	setup.py \
+ 	lxc.c \

--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -21,6 +21,10 @@ PYTHON:=python$(PYTHON_VERSION)
 
 PYTHONPATH:=$(PYTHON_LIB_DIR):$(STAGING_DIR)/$(PYTHON_PKG_DIR):$(PKG_INSTALL_DIR)/$(PYTHON_PKG_DIR)
 
+ifeq ($(strip $(PYTHON_PKG_OLD)),)
+PYTHON_PKG_OLD:=1
+endif # PYTHON_PKG_OLD
+
 # These configure args are needed in detection of path to Python header files
 # using autotools.
 CONFIGURE_ARGS += \
@@ -35,8 +39,40 @@ ifdef CONFIG_USE_MIPS16
   TARGET_CFLAGS += -mno-mips16 -mno-interlink-mips16
 endif
 
-define PyPackage
+# $(1) => build subdir
+# $(2) => additional arguments to setup.py
+# $(3) => additional variables
+define Build/Setup/PyMod
+	$(if $(strip $(2)),$(INSTALL_DIR) $(PKG_INSTALL_DIR)/$(PYTHON_PKG_DIR))
+	$(if $(strip $(2)),$(call Build/Compile/HostPyRunTarget, \
+		cd $(PKG_BUILD_DIR)/$(strip $(1)), \
+		./setup.py $(2), \
+		$(3)))
+	$(if $(strip $(2)),find $(PKG_INSTALL_DIR) -name "*\.exe" | xargs rm -f,true)
+endef
 
+Build/Compile/PyMod=$(Build/Setup/PyMod)
+
+PYTHON_PKG_SETUP_ARGS:=--single-version-externally-managed
+
+ifeq ($(PYTHON_PKG_OLD),1)
+PYTHON_PKG_build_ext_ARGS:= \
+		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
+		$(PYTHON_PKG_SETUP_ARGS)
+PYTHON_PKG_build_ext_VARS:=$(PYTHON_PKG_SETUP_VARS)
+else
+PYTHON_PKG_build_ext_ARGS:= \
+		build_ext
+PYTHON_PKG_build_ext_VARS:=
+PYTHON_PKG_install_ARGS:= \
+		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
+		--no-compile --single-version-externally-managed
+endif # !PYTHON_PKG_OLD
+PYTHON_PKG_install_SUBDIR:=
+PYTHON_PKG_install_VARS:=
+PYTHON_PKG_build_ext_SUBDIR:=
+
+define PyPackage
   define Package/$(1)-src
     $(call Package/$(1))
     DEPENDS:=
@@ -68,8 +104,12 @@ define PyPackage
   $(call shexport,PyPackage/$(1)/filespec)
 
   define Package/$(1)/install
+	$(if $(strip $(filter "$(PyBuild/Compile/Default)","$(PyBuild/Compile)")),\
+		$$(call Build/Setup/PyMod,$$(PYTHON_PKG_install_SUBDIR), \
+		$$(PYTHON_PKG_install_ARGS), \
+		$$(PYTHON_PKG_install_VARS) \
+	))
 	$(call PyPackage/$(1)/install,$$(1))
-	find $(PKG_INSTALL_DIR) -name "*\.exe" | xargs rm -f
 	$(SHELL) $(python_mk_path)python-package-install.sh "2" \
 		"$(PKG_INSTALL_DIR)" "$$(1)" \
 		"$(HOST_PYTHON_BIN)" "$$(2)" \
@@ -104,33 +144,17 @@ define Build/Compile/HostPyRunTarget
 	)
 endef
 
-# $(1) => build subdir
-# $(2) => additional arguments to setup.py
-# $(3) => additional variables
-define Build/Compile/PyMod
-	$(INSTALL_DIR) $(PKG_INSTALL_DIR)/$(PYTHON_PKG_DIR)
-	$(call Build/Compile/HostPyRunTarget, \
-		cd $(PKG_BUILD_DIR)/$(strip $(1)), \
-		./setup.py $(2), \
-		$(3))
-	find $(PKG_INSTALL_DIR) -name "*\.exe" | xargs rm -f
-endef
-
-PYTHON_PKG_SETUP_ARGS:=--single-version-externally-managed
-PYTHON_PKG_SETUP_VARS:=
-
 define PyBuild/Compile/Default
 	$(foreach pkg,$(HOST_PYTHON_PACKAGE_BUILD_DEPENDS),
 		$(call host_python_pip_install_host,$(pkg))
 	)
-	$(call Build/Compile/PyMod,, \
-		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
-		$(PYTHON_PKG_SETUP_ARGS), \
-		$(PYTHON_PKG_SETUP_VARS) \
+	$$(call Build/Setup/PyMod,$$(PYTHON_PKG_build_ext_SUBDIR), \
+		$$(PYTHON_PKG_build_ext_ARGS), \
+		$$(PYTHON_PKG_build_ext_VARS) \
 	)
 endef
 
-PyBuild/Compile=$(PyBuild/Compile/Default)
+PyBuild/Compile:=$(PyBuild/Compile/Default)
 
 ifeq ($(BUILD_VARIANT),python)
 define Build/Compile

--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -10,6 +10,10 @@
 python_mk_path:=$(dir $(lastword $(MAKEFILE_LIST)))
 include $(python_mk_path)python-host.mk
 
+ifeq ($(findstring python,$(PKG_BUILD_DEPENDS)),)
+PKG_BUILD_DEPENDS+=python/host
+endif
+
 PYTHON_DIR:=$(STAGING_DIR)/usr
 PYTHON_BIN_DIR:=$(PYTHON_DIR)/bin
 PYTHON_INC_DIR:=$(PYTHON_DIR)/include/python$(PYTHON_VERSION)

--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -21,6 +21,8 @@ PKG_HASH:=22d9b1ac5b26135ad2b8c2901a9413537e08749a753356ee913c84dbd2df5574
 PKG_LICENSE:=PSF
 PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
 
+PYTHON_PKG_OLD:=0
+
 # This file provides the necsessary host build variables
 include ../python-host.mk
 
@@ -238,6 +240,9 @@ define PyPackage/python-base/filespec
 +|/usr/bin/python$(PYTHON_VERSION)
 $(subst $(space),$(newline),$(foreach lib_file,$(PYTHON_BASE_LIB_FILES),+|$(lib_file)))
 endef
+
+PYTHON_PKG_install_ARGS:=
+PYTHON_PKG_build_ext_ARGS:=
 
 define PyPackage/python-light/filespec
 +|/usr/lib/python$(PYTHON_VERSION)

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -9,6 +9,10 @@
 python3_mk_path:=$(dir $(lastword $(MAKEFILE_LIST)))
 include $(python3_mk_path)python3-host.mk
 
+ifeq ($(findstring python3,$(PKG_BUILD_DEPENDS)),)
+PKG_BUILD_DEPENDS+=python3/host
+endif
+
 PYTHON3_DIR:=$(STAGING_DIR)/usr
 PYTHON3_BIN_DIR:=$(PYTHON3_DIR)/bin
 PYTHON3_INC_DIR:=$(PYTHON3_DIR)/include/python$(PYTHON3_VERSION)

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -24,9 +24,10 @@ PKG_HASH:=d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb
 PKG_LICENSE:=PSF
 PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
 
+PYTHON3_PKG_OLD:=0
+
 # This file provides the necsessary host build variables
 include ../python3-host.mk
-
 # For Py3Package
 include ../python3-package.mk
 
@@ -97,6 +98,10 @@ PYTHON3_LIB_FILES_DEL:=
 PYTHON3_PACKAGES:=
 PYTHON3_SO_SUFFIX:=cpython-$(PYTHON3_VERSION_MAJOR)$(PYTHON3_VERSION_MINOR).so
 PYTHON3_PACKAGES_DEPENDS:=
+
+PYTHON3_PKG_install_ARGS:=
+PYTHON3_PKG_build_ext_ARGS:=
+
 define Py3BasePackage
   PYTHON3_PACKAGES+=$(1)
   ifeq ($(3),)

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -14,7 +14,7 @@ PYTHON_VERSION:=$(PYTHON3_VERSION)
 PYTHON_VERSION_MICRO:=$(PYTHON3_VERSION_MICRO)
 
 PKG_NAME:=python3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -197,6 +197,7 @@ endef
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/ $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON_VERSION)/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/include/python$(PYTHON_VERSION) \
 		$(1)/usr/include/
@@ -204,6 +205,10 @@ define Build/InstallDev
 		$(HOST_PYTHON3_LIB_DIR) \
 		$(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON_VERSION).so* \
 		$(1)/usr/lib/
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/python3.pc \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/python-$(PYTHON3_VERSION).pc \
+		$(1)/usr/lib/pkgconfig
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/config-$(PYTHON_VERSION) \
 		$(1)/usr/lib/python$(PYTHON_VERSION)/

--- a/utils/lxc/Config.in
+++ b/utils/lxc/Config.in
@@ -50,4 +50,10 @@ config LXC_NETWORKING
 	help
 	  Enable "veth pair device" and "macvlan"
 
+config LXC_PYTHON
+	bool "Allow building Python3 bindings"
+        default y
+	help
+	  Enable "Allow building Python3 bindings"
+
 endmenu

--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -153,6 +153,18 @@ else
 CONFIGURE_ARGS += --disable-seccomp
 endif
 
+ifeq ($(CONFIG_LXC_PYTHON),y)
+CONFIGURE_ARGS += --enable-python=yes
+
+CONFIGURE_VARS += \
+	PYTHONDEV_CFLAGS="$(TARGET_CFLAGS) -I$(PYTHON_INC_DIR) \
+		-iremap$(PKG_BUILD_DIR)/src/include:lxc" \
+	CFLAGS="$(TARGET_CFLAGS) -Wno-error=deprecated-declarations" \
+	PYTHONDEV_LIBS="$(TARGET_LDFLAGS) -L$(STAGING_DIR)/usr/lib $(TARGET_LIBS) -lpython$(PYTHON3_VERSION)"
+else
+CONFIGURE_ARGS += --disable-python
+endif
+
 MAKE_FLAGS += \
 	LUA_INSTALL_CMOD="/usr/lib/lua" \
 	LUA_INSTALL_LMOD="/usr/lib/lua"

--- a/utils/lxc/patches/100-skip-python-pkg-build.patch
+++ b/utils/lxc/patches/100-skip-python-pkg-build.patch
@@ -1,0 +1,36 @@
+Index: lxc-2.1.1/src/python-lxc/Makefile.am
+===================================================================
+--- lxc-2.1.1.orig/src/python-lxc/Makefile.am
++++ lxc-2.1.1/src/python-lxc/Makefile.am
+@@ -1,31 +1,3 @@
+-if ENABLE_PYTHON
+-
+-if HAVE_DEBIAN
+-    DISTSETUPOPTS=--install-layout=deb
+-else
+-    DISTSETUPOPTS=
+-endif
+-
+-if ENABLE_RPATH
+-    RPATHOPTS=-R $(libdir)
+-else
+-    RPATHOPTS=
+-endif
+-
+-CALL_SETUP_PY := cd @srcdir@ && $(PYTHON) setup.py build -b @abs_builddir@/build egg_info -e @abs_builddir@
+-
+-all:
+-	$(CALL_SETUP_PY) build_ext -I @abs_top_srcdir@/src -L @abs_top_builddir@/src/lxc/.libs/ $(RPATHOPTS) --no-pkg-config
+-
+-DESTDIR = / # default
+-
+-install:
+-	$(CALL_SETUP_PY) install --prefix=$(prefix) --no-compile $(DISTSETUPOPTS) --root=$(DESTDIR)
+-
+-clean-local:
+-	rm -rf @builddir@/build
+-
+-endif
+ EXTRA_DIST = \
+ 	setup.py \
+ 	lxc.c \


### PR DESCRIPTION
Add the necessary configuration and additional package
to support building the LXC python bindings.  We introduce
a new package (python3-lxc) because:
   1) the python bindings depend on the main LXC having done InstallDev
   2) Even though it's in the same source tree it's really a separate
     build, especially in a cross-compiling situation.
   3) It avoids a lot of special-case packaging.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: me / @cshoredaniel 
Compile tested: brcm2708, raspberry pi. recent masters
Run tested: TBD: This is a request for comments as I got compilation working, and do have plans to use it eventually, but currently it's a WIP.

Depends on #7829 