### PR TITLE
mariadb: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
 PKG_VERSION:=10.2.19
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := \

--- a/utils/mariadb/patches/200-openssl-deprecated.patch
+++ b/utils/mariadb/patches/200-openssl-deprecated.patch
@@ -1,0 +1,14 @@
+--- a/libmariadb/libmariadb/secure/openssl.c
++++ b/libmariadb/libmariadb/secure/openssl.c
+@@ -419,8 +419,10 @@ void ma_tls_end()
+     if (mariadb_deinitialize_ssl)
+     {
+ #ifndef HAVE_OPENSSL_1_1_API
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10000000L
+       ERR_remove_state(0);
++#else
++      ERR_remove_thread_state(NULL);
+ #endif
+       EVP_cleanup();
+       CRYPTO_cleanup_all_ex_data();


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @micmac1 
Compile tested: mvebu

https://github.com/MariaDB/mariadb-connector-c/pull/92