### PR TITLE
tvheadend: Fix compilation without deprecated OpenSSL 1.0.2 APIs

### DIFF
--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tvheadend
 PKG_VERSION:=4.0.10
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tvheadend/tvheadend/tar.gz/v$(PKG_VERSION)?

--- a/multimedia/tvheadend/patches/010-openssl-deprecated.patch
+++ b/multimedia/tvheadend/patches/010-openssl-deprecated.patch
@@ -25,7 +25,14 @@
    RAND_cleanup();
    CRYPTO_cleanup_all_ex_data();
    EVP_cleanup();
-@@ -1174,6 +1179,7 @@ main(int argc, char **argv)
+@@ -1168,12 +1173,13 @@ main(int argc, char **argv)
+ #ifndef OPENSSL_NO_COMP
+   COMP_zlib_cleanup();
+ #endif
+-  ERR_remove_state(0);
++  ERR_remove_thread_state(NULL);
+   ERR_free_strings();
+ #ifndef OPENSSL_NO_COMP
    sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
  #endif
    /* end of OpenSSL cleanup code */


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @sairon ???
Compile tested: ar71xx