### PR TITLE
libimobiledevice: Fix compilation without deprecated OpenSSL 1.0.2 APIs

### DIFF
--- a/libs/libimobiledevice/patches/010-openssl-deprecated.patch
+++ b/libs/libimobiledevice/patches/010-openssl-deprecated.patch
@@ -1,0 +1,51 @@
+--- a/common/userpref.c
++++ b/common/userpref.c
+@@ -37,6 +37,7 @@
+ #include <unistd.h>
+ #include <usbmuxd.h>
+ #ifdef HAVE_OPENSSL
++#include <openssl/bn.h>
+ #include <openssl/pem.h>
+ #include <openssl/rsa.h>
+ #include <openssl/x509.h>
+--- a/src/idevice.c
++++ b/src/idevice.c
+@@ -37,6 +37,8 @@
+ #ifdef HAVE_OPENSSL
+ #include <openssl/err.h>
+ #include <openssl/ssl.h>
++#include <openssl/bn.h>
++#include <openssl/rsa.h>
+ #if OPENSSL_VERSION_NUMBER >= 0x10000001L
+ /* since OpenSSL 1.0.0-beta1 */
+ #define HAVE_ERR_REMOVE_THREAD_STATE 1
+@@ -60,9 +62,9 @@ static void locking_function(int mode, int n, const char* file, int line)
+ 		mutex_unlock(&mutex_buf[n]);
+ }
+ 
+-static unsigned long id_function(void)
++static void id_function(CRYPTO_THREADID *id)
+ {
+-	return ((unsigned long)THREAD_ID);
++	CRYPTO_THREADID_set_numeric(id, (unsigned long)THREAD_ID);
+ }
+ #endif
+ 
+@@ -78,7 +80,7 @@ static void internal_idevice_init(void)
+ 	for (i = 0; i < CRYPTO_num_locks(); i++)
+ 		mutex_init(&mutex_buf[i]);
+ 
+-	CRYPTO_set_id_callback(id_function);
++	CRYPTO_THREADID_set_callback(id_function);
+ 	CRYPTO_set_locking_callback(locking_function);
+ #else
+ 	gnutls_global_init();
+@@ -90,7 +92,7 @@ static void internal_idevice_deinit(void)
+ #ifdef HAVE_OPENSSL
+ 	int i;
+ 	if (mutex_buf) {
+-		CRYPTO_set_id_callback(NULL);
++		CRYPTO_THREADID_set_callback(NULL);
+ 		CRYPTO_set_locking_callback(NULL);
+ 		for (i = 0; i < CRYPTO_num_locks(); i++)
+ 			mutex_destroy(&mutex_buf[i]);


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: ???
Compile tested: ar71xx