### PR TITLE
openldap: Fix compilation without deprecated OpenSSL 1.0.2 APIs

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
 PKG_VERSION:=2.4.47
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://gpl.savoirfairelinux.net/pub/mirrors/openldap/openldap-release/ \

--- a/libs/openldap/patches/100-ITS-8353-CRYPTO_set_id_callback-deprecated-in-OpenSS.patch
+++ b/libs/openldap/patches/100-ITS-8353-CRYPTO_set_id_callback-deprecated-in-OpenSS.patch
@@ -1,0 +1,38 @@
+From d3b1558dcba6130140428a0736fe42aa39435c66 Mon Sep 17 00:00:00 2001
+From: Howard Chu <hyc@openldap.org>
+Date: Wed, 2 Jan 2019 10:16:40 +0000
+Subject: [PATCH] ITS#8353 CRYPTO_set_id_callback deprecated in OpenSSL 0.9.9
+
+---
+ libraries/libldap/tls_o.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/libraries/libldap/tls_o.c b/libraries/libldap/tls_o.c
+index 99626ec15a..4a091faa10 100644
+--- a/libraries/libldap/tls_o.c
++++ b/libraries/libldap/tls_o.c
+@@ -89,6 +89,13 @@ static void tlso_locking_cb( int mode, int type, const char *file, int line )
+ 	}
+ }
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x0909000
++static void tlso_thread_self( CRYPTO_THREADID *id )
++{
++	CRYPTO_THREADID_set_pointer( id, (void *)ldap_pvt_thread_self() );
++}
++#define CRYPTO_set_id_callback(foo)	CRYPTO_THREADID_set_callback(foo)
++#else
+ static unsigned long tlso_thread_self( void )
+ {
+ 	/* FIXME: CRYPTO_set_id_callback only works when ldap_pvt_thread_t
+@@ -101,6 +108,7 @@ static unsigned long tlso_thread_self( void )
+ 
+ 	return (unsigned long) ldap_pvt_thread_self();
+ }
++#endif
+ 
+ static void tlso_thr_init( void )
+ {
+-- 
+2.17.1
+


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
Compile tested: ar71xx