### PR TITLE
emailrelay: Remove unnecessary OpenSSL engine include

### DIFF
--- a/mail/emailrelay/Makefile
+++ b/mail/emailrelay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=emailrelay
 PKG_VERSION:=2.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-src.tar.gz
 PKG_SOURCE_URL:=@SF/emailrelay/$(PKG_VERSION)

--- a/mail/emailrelay/patches/020-openssl-engine.patch
+++ b/mail/emailrelay/patches/020-openssl-engine.patch
@@ -1,0 +1,10 @@
+--- a/src/gssl/gssl_openssl.cpp
++++ b/src/gssl/gssl_openssl.cpp
+@@ -32,7 +32,6 @@
+ #include <openssl/ssl.h>
+ #include <openssl/err.h>
+ #include <openssl/rand.h>
+-#include <openssl/engine.h>
+ #include <openssl/conf.h>
+ #include <openssl/evp.h>
+ #include <openssl/hmac.h>


### PR DESCRIPTION
There's no usage of any ENGINE APIs and trying to include the header
breaks compilation with ENGINE support disabled.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @fededim 
Compile tested: ar71xx
