### PR TITLE
postfix: Fix compilation without OpenSSL ENGINE

### DIFF
--- a/mail/postfix/Makefile
+++ b/mail/postfix/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postfix
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_VERSION:=3.3.2
 PKG_SOURCE_URL:= \
 	https://cdn.postfix.johnriley.me/mirrors/postfix-release/official/ \

--- a/mail/postfix/patches/110-openssl-engine.patch
+++ b/mail/postfix/patches/110-openssl-engine.patch
@@ -1,0 +1,22 @@
+--- a/src/posttls-finger/posttls-finger.c
++++ b/src/posttls-finger/posttls-finger.c
+@@ -374,7 +374,9 @@
+ #include <tls.h>
+ 
+ #ifdef USE_TLS
++#ifndef OPENSSL_NO_ENGINE
+ #include <openssl/engine.h>
++#endif
+ #endif
+ 
+  /*
+@@ -1524,7 +1526,9 @@ static void ssl_cleanup(void)
+ #else
+     ERR_remove_state(0);		/* Deprecated with OpenSSL 1.0.0 */
+ #endif
++#ifndef OPENSSL_NO_ENGINE
+     ENGINE_cleanup();
++#endif
+     CONF_modules_unload(1);
+     ERR_free_strings();
+     EVP_cleanup();


### PR DESCRIPTION
While ENGINE is not actually used, the header being included
unconditionally as well as the cleanup function being called breaks
compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Shulyaka 
Compile tested: ar71xx