### PR TITLE
conserver: Fix compilation without deprecated OpenSSL 1.0.2 APIs

### DIFF
--- a/net/conserver/Makefile
+++ b/net/conserver/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=conserver
 PKG_VERSION:=8.2.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Bjørn Mork <bjorn@mork.no>
 
 PKG_SOURCE_PROTO:=git

--- a/net/conserver/patches/010-openssl-deprecated.patch
+++ b/net/conserver/patches/010-openssl-deprecated.patch
@@ -1,0 +1,11 @@
+--- a/conserver/cutil.h
++++ b/conserver/cutil.h
+@@ -7,6 +7,8 @@
+ #include <stdarg.h>
+ #if HAVE_OPENSSL
+ # include <openssl/ssl.h>
++# include <openssl/bn.h>
++# include <openssl/dh.h>
+ # include <openssl/err.h>
+ # if OPENSSL_VERSION_NUMBER < 0x10100000L
+ #  define TLS_method SSLv23_method


### PR DESCRIPTION
Two headers were missing.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @bmork 
Compile tested: ar71xx