### PR TITLE
radsecproxy: Fix compilation without deprecated OpenSSL 1.0.2 APIs

### DIFF
--- a/net/radsecproxy/Makefile
+++ b/net/radsecproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radsecproxy
 PKG_VERSION:=1.7.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/radsecproxy/radsecproxy/releases/download/$(PKG_VERSION)/

--- a/net/radsecproxy/patches/100-openssl-deprecated.patch
+++ b/net/radsecproxy/patches/100-openssl-deprecated.patch
@@ -1,0 +1,22 @@
+--- a/tlscommon.c
++++ b/tlscommon.c
+@@ -44,8 +44,8 @@ static uint8_t cookie_secret_initialized = 0;
+ #if OPENSSL_VERSION_NUMBER < 0x10100000
+ static pthread_mutex_t *ssl_locks = NULL;
+ 
+-unsigned long ssl_thread_id() {
+-    return (unsigned long)pthread_self();
++void ssl_thread_id(CRYPTO_THREADID *id) {
++    CRYPTO_THREADID_set_numeric(id, (unsigned long)pthread_self());
+ }
+ 
+ void ssl_locking_callback(int mode, int type, const char *file, int line) {
+@@ -69,7 +69,7 @@ void sslinit() {
+     for (i = 0; i < CRYPTO_num_locks(); i++) {
+         pthread_mutex_init(&ssl_locks[i], NULL);
+     }
+-    CRYPTO_set_id_callback(ssl_thread_id);
++    CRYPTO_THREADID_set_callback(ssl_thread_id);
+     CRYPTO_set_locking_callback(ssl_locking_callback);
+     SSL_load_error_strings();
+ #else


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tohojo 
Compile tested: ar71xx