### PR TITLE
vpnc: Fix compilation without deprecated OpenSSL 1.0.2 APIs

### DIFF
--- a/net/vpnc/Makefile
+++ b/net/vpnc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=vpnc
 PKG_REV:=550
 PKG_VERSION:=0.5.3.r$(PKG_REV)
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://svn.unix-ag.uni-kl.de/vpnc/trunk/

--- a/net/vpnc/patches/110-openssl-deprecated.patch
+++ b/net/vpnc/patches/110-openssl-deprecated.patch
@@ -1,0 +1,10 @@
+--- a/crypto-openssl.c
++++ b/crypto-openssl.c
+@@ -20,6 +20,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <openssl/pem.h>
++#include <openssl/rsa.h>
+ #include "config.h"
+ #include "sysdep.h"
+ #include "crypto.h"


### PR DESCRIPTION
One missing header.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @danielg4 
Compile tested: ar71xx
