### PR TITLE
libgphoto2: update package 2.5.22

### DIFF
--- a/libs/libgphoto2/Makefile
+++ b/libs/libgphoto2/Makefile
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2006-2012 OpenWrt.org
-# Copyright (C) 2017-2018 Leonardo Medici
+# Copyright (C) 2017-2019 Leonardo Medici
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,14 +9,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgphoto2
-PKG_VERSION:=2.5.21
+PKG_VERSION:=2.5.22
 PKG_RELEASE:=1
 PORT_VERSION:=0.12.0
 PKG_MAINTAINER:=Leonardo Medici <leonardo_medici@me.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/gphoto
-PKG_HASH:=c5572b1a52af32a40ca6a014682f7548bfb58d47109ad77fba29ec295b448bb1
+PKG_HASH:=15d7327aa9a986af1e1dbfd8f15ba81352b67450d30e44562ce768ff9435ce58
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING
 


### PR DESCRIPTION
Maintainer: me
Compile tested: (AR7xxx/AR9xxx, Generic, OpenWrt 18.06.1)

Description: update package 2.5.22