### PR TITLE
prometheus-node-exporter-lua: switch config to openwrt interface names

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,8 +4,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2019.08.14
-PKG_RELEASE:=2
+PKG_VERSION:=2019.09.19
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/etc/config/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/etc/config/prometheus-node-exporter-lua
@@ -1,3 +1,4 @@
 config prometheus-node-exporter-lua 'main'
-	option listen_address '::1'
+	option listen_interface 'loopback'
+	option listen_ipv6 '0'
 	option listen_port '9100'

--- a/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
@@ -49,6 +49,8 @@ service_triggers()
 {
 	local interface
 
+	procd_add_reload_trigger "prometheus-node-exporter-lua"
+
 	config_load prometheus-node-exporter-lua.main
 	config_get interface "main" listen_interface "loopback"
 

--- a/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
@@ -41,6 +41,7 @@ start_service() {
 
 	procd_set_param stdout 1
 	procd_set_param stderr 1
+	procd_set_param respawn
 
 	procd_close_instance
 }

--- a/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
+++ b/utils/prometheus-node-exporter-lua/files/etc/init.d/prometheus-node-exporter-lua
@@ -4,19 +4,53 @@
 START=60
 USE_PROCD=1
 
+. /lib/functions/network.sh
+
+_log() {
+	logger -p daemon.info -t prometheus-node-exporter-lua "$@"
+}
+
 start_service() {
-	procd_open_instance
+	local interface ipv6 port bind
 
 	config_load prometheus-node-exporter-lua.main
-	config_get bind "main" listen_address ::1
+	config_get interface "main" listen_interface "loopback"
+	config_get_bool ipv6 "main" listen_ipv6 0
 	config_get port "main" listen_port 9100
 
+	if [ "$interface" = "*" ]; then
+		[ "$ipv6" = 1 ] && bind="::" || bind="0.0.0.0"
+	else
+		if [ "$ipv6" = 1 ]; then
+			network_get_ipaddr6 bind "$interface"
+		else
+			network_get_ipaddr bind "$interface"
+		fi
+
+		network_is_up "$interface" && [ -n "$bind" ] || {
+			_log "defering start until listen interface $interface becomes ready"
+			return 0
+		}
+	fi
+
+	procd_open_instance
+
 	procd_set_param command /usr/bin/prometheus-node-exporter-lua
-	procd_append_param command --port ${port}
 	procd_append_param command --bind ${bind}
+	procd_append_param command --port ${port}
 
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 
 	procd_close_instance
+}
+
+service_triggers()
+{
+	local interface
+
+	config_load prometheus-node-exporter-lua.main
+	config_get interface "main" listen_interface "loopback"
+
+	[ "$interface" = "*" ] || procd_add_reload_interface_trigger "$interface"
 }


### PR DESCRIPTION
Maintainer: @champtar
Compile tested: Cubieboard2, OpenWrt master
Run tested: Cubieboard2, OpenWrt master

Drop the config knob 'listen_address' and introduce 'listen_interface'
and 'listen_ipv6' instead.

'listen_interface' takes an openwrt interface name ('loopback', 'lan',
'wan' etc), from which the primary IP is used to listen on. If
'listen_ipv6' is set to '1', the IPv6 adress will be used, IPv4
elsewise.

procd interface triggers are now combined with this, so if the listen
interface is not yet configured when the init script is executed, the
process start is defered, and the trigger takes care of that once
the interface is ready.

Fixes #7670

Signed-off-by: Andre Heider <a.heider@gmail.com>
