### PR TITLE
aria2: fix "Illegal instruction" crash on ar71xx

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -8,13 +8,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
 PKG_VERSION:=1.34.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/
 PKG_HASH:=3a44a802631606e138a9e172a3e9f5bcbaac43ce2895c1d8e2b46f30487e77a3
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16=0
 
 PKG_MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>, \
 	Hsing-Wang Liao <kuoruan@gmail.com>


### PR DESCRIPTION
Signed-off-by: Peter Wagner <tripolar@gmx.at>

Maintainer: kuoruan@gmail.com
Compile tested: ar71xx
Run tested: ar71xx

Description: 
the lto optimization leads to an "Illegal instruction" crash on ar71xx
