### PR TITLE
python,python3: use setuptools & pip versions from python{3}-version.mk

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -170,7 +170,7 @@ define Build/Compile/python-setuptools
 	$(STAGING_DIR_HOSTPKG)/bin/pip install \
 		--ignore-installed \
 		--root=$(PKG_BUILD_DIR)/install-setuptools --prefix=. \
-		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/setuptools-*.whl
+		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/setuptools-$(PYTHON_SETUPTOOLS_VERSION)-py2.py3-none-any.whl
 endef
 endif # CONFIG_PACKAGE_python-setuptools
 
@@ -179,7 +179,7 @@ define Build/Compile/python-pip
 	$(STAGING_DIR_HOSTPKG)/bin/pip install \
 		--ignore-installed \
 		--root=$(PKG_BUILD_DIR)/install-pip --prefix=. \
-		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/pip-*.whl
+		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/pip-$(PYTHON_PIP_VERSION)-py2.py3-none-any.whl
 endef
 endif # CONFIG_PACKAGE_python-pip
 

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -174,7 +174,7 @@ define Build/Compile/python3-setuptools
 	$(STAGING_DIR_HOSTPKG)/bin/pip3 install \
 		--ignore-installed \
 		--root=$(PKG_BUILD_DIR)/install-setuptools --prefix=. \
-		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/setuptools-*.whl
+		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/setuptools-$(PYTHON3_SETUPTOOLS_VERSION)-py2.py3-none-any.whl
 endef
 endif # CONFIG_PACKAGE_python3-setuptools
 
@@ -183,7 +183,7 @@ define Build/Compile/python3-pip
 	$(STAGING_DIR_HOSTPKG)/bin/pip3 install \
 		--ignore-installed \
 		--root=$(PKG_BUILD_DIR)/install-pip --prefix=. \
-		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/pip-*.whl
+		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/pip-$(PYTHON3_PIP_VERSION)-py2.py3-none-any.whl
 endef
 endif # CONFIG_PACKAGE_python3-pip
 


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/openwrt/openwrt/commit/213c0e78fa   x86_64
Run tested: N/A (this is mostly build related)

After messing up with PR https://github.com/openwrt/packages/pull/7821 , this is one good way to avoid messing up the same way again

-------------------------------------------------------------------

`setuptools` & `pip` whl files were selected via wildcards, because it was
easier in the beginning.
Also, initially there weren't any PYTHON{3}_{SETUTPTOOLS/PIP}_VERSION
variables. But now since these vars exist, it makes sense to use them,
because we can catch easier (at build) time if Python/Python3 bump these
versions.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>