### PR TITLE
prometheus-statsd-exporter: fix compilation with go 1.11.4

### DIFF
--- a/utils/prometheus-statsd-exporter/Makefile
+++ b/utils/prometheus-statsd-exporter/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-statsd-exporter
 PKG_VERSION:=0.8.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=statsd_exporter-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/prometheus/statsd_exporter/tar.gz/v${PKG_VERSION}?

--- a/utils/prometheus-statsd-exporter/Makefile
+++ b/utils/prometheus-statsd-exporter/Makefile
@@ -9,6 +9,7 @@ PKG_SOURCE_URL:=https://codeload.github.com/prometheus/statsd_exporter/tar.gz/v$
 PKG_HASH:=d69af3ccdc393ec2d3007dd9d039d4f0f0a6dd9df55fb7cd3fd0304607324d51
 PKG_BUILD_DIR:=$(BUILD_DIR)/statsd_exporter-$(PKG_VERSION)
 
+PKG_MAINTAINER:=Andre Heider <a.heider@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 

--- a/utils/prometheus-statsd-exporter/patches/001-fix-mod-checksum.patch
+++ b/utils/prometheus-statsd-exporter/patches/001-fix-mod-checksum.patch
@@ -1,0 +1,11 @@
+--- a/go.sum
++++ b/go.sum
+@@ -42,7 +42,7 @@ github.com/prometheus/client_model v0.0.
+ github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
+ github.com/prometheus/common v0.0.0-20170731114204-61f87aac8082 h1:M/45ksQhBkhxI65UXRNvyuF6sV7A08GMYk39aGZQlJQ=
+ github.com/prometheus/common v0.0.0-20170731114204-61f87aac8082/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+-github.com/prometheus/procfs v0.0.0-20170703101242-e645f4e5aaa8 h1:uZfczEBIA1FZfOQo4/JWgGnMNd/4HVsM9A+B30wtlkA=
++github.com/prometheus/procfs v0.0.0-20170703101242-e645f4e5aaa8 h1:Kh7M6mzRpQ2de1rixoSQZr4BTINXFm8WDbeN5ttnwyE=
+ github.com/prometheus/procfs v0.0.0-20170703101242-e645f4e5aaa8/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+ github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
+ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=


### PR DESCRIPTION
Maintainer: @dhewg 
Compile tested: arm/sunxi, Cubieboard 2, master
Run tested: arm/sunxi, Cubieboard 2, master

Description:
This fixes the exact same build error reported at [0].
Upstream fixed it too, see [1], but I decided to use the minimal patch
until a new version is released instead.

[0] https://github.com/golang/go/issues/29281
[1] https://github.com/prometheus/statsd_exporter/pull/171

Signed-off-by: Andre Heider <a.heider@gmail.com>