### PR TITLE
bind: update to 9.11.5-P1

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.11.5
-PKG_RELEASE:=2
+PKG_VERSION:=9.11.5-P1
+PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -20,7 +20,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=a4cae11dad954bdd4eb592178f875bfec09fcc7e29fe0f6b7a4e5b5c6bc61322
+PKG_HASH:=6cd6dbf016569f12d4a0ed629e44e895d9ed41c6908274ed2e617666c5491928
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
For changes in 9.11.5-P1 see https://ftp.isc.org/isc/bind9/9.11.5-P1/CHANGES

Maintainer: @nmeyerhans 
Compile tested: ar71xx, mvebu
Run tested: ar71xx, mvebu