### PR TITLE
nut: Fix procd crashloop no interfaces

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=13
+PKG_RELEASE:=14
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -163,12 +163,39 @@ build_config() {
 	[ -s "$UPSMON_C" ] && chgrp $(id -gn ${runas:-root}) "$UPSMON_C"
 }
 
+interface_triggers() {
+	local action="$1"
+	local triggerlist trigger
+
+	config_get triggerlist "upsmon" triggerlist
+
+	. /lib/functions/network.sh
+
+	if [ -n "$triggerlist" ]; then
+		for trigger in $triggerlist; do
+			if [ "$action" = "add_trigger" ]; then
+				procd_add_interface_trigger "interface.*" "$trigger" /etc/init.d/nut-monitor reload
+			else
+				network_is_up "$trigger" && return 0
+			fi
+		done
+	else
+		if [ "$action" = "add_trigger" ]; then
+			procd_add_raw_trigger "interface.*.up" 2000 /etc/init.d/nut-monitor reload
+		else
+			ubus call network.device status | grep -q '"up": true' && return 0
+		fi
+	fi
+	[ "$action" = "add_trigger" ] || return 1
+}
+
 start_service() {
 	local havemon havems
 	build_config
 
 	[ "$havemon" != 1 ] && return
 	[ "$havems" != 1 ] && return
+	interface_triggers "check_interface_up" || return
 
 	procd_open_instance "upsmon"
 	procd_set_param respawn
@@ -190,5 +217,7 @@ reload_service() {
 }
 
 service_triggers() {
+	confg_load nut_monitor
+	interface_triggers "add_trigger"
 	procd_add_reload_trigger "nut_monitor"
 }

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -279,11 +279,39 @@ start_driver_instance() {
 	procd_close_instance
 }
 
+interface_triggers() {
+	local action="$1"
+	local triggerlist trigger
+
+	config_get triggerlist "upsd" triggerlist
+
+	. /lib/functions/network.sh
+
+	if [ -n "$triggerlist" ]; then
+		for trigger in $triggerlist; do
+			if [ "$action" = "add_trigger" ]; then
+				procd_add_interface_trigger "interface.*" "$trigger" /etc/init.d/nut-server reload
+			else
+				network_is_up "$trigger" && return 0
+			fi
+		done
+	else
+		if [ "$action" = "add_trigger" ]; then
+			procd_add_raw_trigger "interface.*.up" 2000 /etc/init.d/nut-server reload
+		else
+			ubus call network.device status | grep -q '"up": true' && return 0
+		fi
+	fi
+	[ "$action" = "add_trigger" ] || return 1
+}
+
 start_server_instance() {
 	local RUNAS=nut
 	build_config
 
 	[ "$haveserver" != 1 ] && return
+	interface_triggers "check_interface_up" || return
+
 
 	procd_open_instance "upsd"
 	procd_set_param respawn
@@ -318,5 +346,8 @@ reload_service() {
 }
 
 service_triggers() {
+	config_load nut_server
+
+	interface_triggers "add_trigger"
 	procd_add_reload_trigger "nut_server"
 }


### PR DESCRIPTION
Fix a crashloop under procd when attempting to bind
to any address when no interfaces are yet available.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: me / @cshoredaniel 
Compile tested: brcm2708, Raspberry Pi B+, current masters
Run tested: same, rebooted device, verified NUT came up once interfaces available (previously on the Pi on some reboots the interfaces were slow to come up resulting in a crash loop and procd giving up (based on the logs)).