### PR TITLE
mc: midnight commander 4.8.22

### DIFF
--- a/utils/mc/Makefile
+++ b/utils/mc/Makefile
@@ -6,14 +6,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mc
-PKG_VERSION:=4.8.21
-PKG_RELEASE:=4
+PKG_VERSION:=4.8.22
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 PKG_LICENSE:=GPL-3.0+
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://ftp.midnight-commander.org/
-PKG_HASH:=8f37e546ac7c31c9c203a03b1c1d6cb2d2f623a300b86badfd367e5559fe148c
+PKG_HASH:=ee7868d7ba0498cf2cccefe107d7efee7f2571098806bba2aed5a159db801318
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf gettext-version
 PKG_BUILD_DEPENDS:=MC_VFS:libtirpc

--- a/utils/mc/patches/010-subshell.patch
+++ b/utils/mc/patches/010-subshell.patch
@@ -1,6 +1,6 @@
 --- a/src/subshell/common.c
 +++ b/src/subshell/common.c
-@@ -843,16 +843,9 @@ init_subshell_precmd (char *precmd, size
+@@ -865,16 +865,9 @@ init_subshell_precmd (char *precmd, size
           * "PS1='$($PRECMD)$ '\n",
           */
          g_snprintf (precmd, buff_size,


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: OpenWrt SNAPSHOT, r8971-99956528df
Run tested: OpenWrt SNAPSHOT, r8971-99956528df

Description:
* bump mc package release to 4.8.22, news in this release see here:
  http://midnight-commander.org/wiki/NEWS-4.8.22
* refresh subshell patch

Signed-off-by: Dirk Brenken <dev@brenken.org>