### PR TITLE
ldns: Make ENGINE support optional

### DIFF
--- a/libs/ldns/Makefile
+++ b/libs/ldns/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ldns
 PKG_VERSION:=1.7.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.nlnetlabs.nl/downloads/ldns

--- a/libs/ldns/patches/300-openssl-engine.patch
+++ b/libs/ldns/patches/300-openssl-engine.patch
@@ -1,0 +1,23 @@
+--- a/keys.c
++++ b/keys.c
+@@ -20,8 +20,10 @@
+ #include <openssl/bn.h>
+ #include <openssl/rsa.h>
+ #include <openssl/dsa.h>
+-#include <openssl/engine.h>
+ #include <openssl/ui.h>
++#ifndef OPENSSL_NO_ENGINE
++#include <openssl/engine.h>
++#endif
+ #endif /* HAVE_SSL */
+ 
+ ldns_lookup_table ldns_signing_algorithms[] = {
+@@ -103,7 +105,7 @@ ldns_key_new_frm_fp(ldns_key **k, FILE *fp)
+ 	return ldns_key_new_frm_fp_l(k, fp, NULL);
+ }
+ 
+-#ifdef HAVE_SSL
++#if defined(HAVE_SSL) && !defined(OPENSSL_NO_ENGINE)
+ ldns_status
+ ldns_key_new_frm_engine(ldns_key **key, ENGINE *e, char *key_id, ldns_algorithm alg)
+ {


### PR DESCRIPTION
ENGINE support is needed for GOST, which is already disabled. However, it
is going to be disabled by default in a future update. This fixes the
compilation failure.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: none
Compile tested: ar71xx