### PR TITLE
softethervpn: update to latest release and rework makefile

### DIFF
--- a/net/softethervpn/Makefile
+++ b/net/softethervpn/Makefile
@@ -9,14 +9,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=softethervpn
-PKG_VERSION:=4.25-9656
-PKG_VERREL:=rtm
-PKG_VERDATE:=2018.01.15
+PKG_VERSION:=4.28-9669
+PKG_VERREL:=beta
+PKG_VERDATE:=2018.09.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=softether-src-v$(PKG_VERSION)-$(PKG_VERREL).tar.gz
 PKG_SOURCE_URL:=http://www.softether-download.com/files/softether/v$(PKG_VERSION)-$(PKG_VERREL)-$(PKG_VERDATE)-tree/Source_Code/
-PKG_HASH:=b946dec3da5833ad2be69125224784b8a8e2a4149297d0c0a907ba0e1c4535f8
+PKG_HASH:=1e641fa227a732b3eec3fe8bdcf4d4fd2b1d0b0a5084119126c1216d2ec1b545
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/v$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/v$(PKG_VERSION)
@@ -82,11 +82,10 @@ define Build/Configure
 endef
 
 
-define Package/softethervpn
+define Package/softethervpn/default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=VPN
-  DEPENDS:=+libpthread +librt +libreadline +libopenssl +libncurses +kmod-tun +zlib $(ICONV_DEPENDS)
   TITLE:=Free Cross-platform Multi-protocol VPN server and client
   URL:=http://www.softether.org/
   MAINTAINER:=Federico Di Marco <fededim@gmail.com>
@@ -101,41 +100,98 @@ IPsec and MS-SSTP), but has also original strong SSL-VPN protocol to penetrate a
 has very fast throughput, low latency and firewall resistance.
 endef
 
-
-define Package/softethervpn/conffiles
-/usr/libexec/softethervpn/vpn_server.config
-/usr/libexec/softethervpn/vpn_client.config
-/usr/libexec/softethervpn/vpn_bridge.config
-/usr/libexec/softethervpn/lang.config
+define Package/softethervpn-base
+  $(Package/softethervpn/default)
+  DEPENDS:=+libpthread +librt +libreadline +libopenssl +libncurses +kmod-tun +zlib $(ICONV_DEPENDS)
+  TITLE += (Base)
 endef
 
-define Package/softethervpn/install
+define Package/softethervpn-server
+  $(Package/softethervpn/default)
+  DEPENDS:=+softethervpn-base
+  TITLE += (Server)
+endef
+
+define Package/softethervpn-bridge
+  $(Package/softethervpn/default)
+  DEPENDS:=+softethervpn-base
+  TITLE += (Bridge)
+endef
+
+define Package/softethervpn-client
+  $(Package/softethervpn/default)
+  DEPENDS:=+softethervpn-base
+  TITLE += (Client)
+endef
+
+Package/softethervpn-base/description = $(Package/softethervpn/description)
+Package/softethervpn-server/description = $(Package/softethervpn/description)
+Package/softethervpn-bridge/description = $(Package/softethervpn/description)
+Package/softethervpn-client/description = $(Package/softethervpn/description)
+
+define Package/softethervpn-base/conffiles
+  /usr/libexec/softethervpn/lang.config
+endef
+
+define Package/softethervpn-server/conffiles
+  /usr/libexec/softethervpn/vpn_server.config
+endef
+
+define Package/softethervpn-client/conffiles
+  /usr/libexec/softethervpn/vpn_client.config
+endef
+
+define Package/softethervpn-bridge/conffiles
+  /usr/libexec/softethervpn/vpn_bridge.config
+endef
+
+define Package/softethervpn-base/install
 	$(INSTALL_DIR) $(1)/usr/libexec/softethervpn
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/vpnserver/vpnserver $(1)/usr/libexec/softethervpn
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/vpnserver/hamcore.se2 $(1)/usr/libexec/softethervpn
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/vpnclient/vpnclient $(1)/usr/libexec/softethervpn
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/vpnbridge/vpnbridge $(1)/usr/libexec/softethervpn
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/vpncmd/vpncmd $(1)/usr/libexec/softethervpn
 	$(INSTALL_BIN) files/launcher.sh $(1)/usr/libexec/softethervpn
 
-	$(INSTALL_DATA) files/dummy $(1)/usr/libexec/softethervpn/vpn_server.config
-	$(INSTALL_DATA) files/dummy $(1)/usr/libexec/softethervpn/vpn_bridge.config
-	$(INSTALL_DATA) files/dummy $(1)/usr/libexec/softethervpn/vpn_client.config
 	$(INSTALL_DATA) files/dummy $(1)/usr/libexec/softethervpn/lang.config
 
 	$(INSTALL_DIR) $(1)/usr/bin
-
-	#$(LN) ../../usr/libexec/softethervpn/launcher.sh $(1)/usr/bin/vpnserver
-	#$(LN) ../../usr/libexec/softethervpn/launcher.sh $(1)/usr/bin/vpnclient
-	#$(LN) ../../usr/libexec/softethervpn/launcher.sh $(1)/usr/bin/vpnbridge
 	$(LN) ../../usr/libexec/softethervpn/launcher.sh $(1)/usr/bin/vpncmd
+endef
+
+define Package/softethervpn-server/install
+	$(INSTALL_DIR) $(1)/usr/libexec/softethervpn
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/vpnserver/vpnserver $(1)/usr/libexec/softethervpn
+
+	$(INSTALL_DATA) files/dummy $(1)/usr/libexec/softethervpn/vpn_server.config
 
 	$(INSTALL_DIR) $(1)/etc
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) files/vpnserver.init $(1)/etc/init.d/softethervpnserver
+endef
+
+define Package/softethervpn-bridge/install
+	$(INSTALL_DIR) $(1)/usr/libexec/softethervpn
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/vpnbridge/vpnbridge $(1)/usr/libexec/softethervpn
+
+	$(INSTALL_DATA) files/dummy $(1)/usr/libexec/softethervpn/vpn_bridge.config
+
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) files/vpnbridge.init $(1)/etc/init.d/softethervpnbridge
+endef
+
+define Package/softethervpn-client/install
+	$(INSTALL_DIR) $(1)/usr/libexec/softethervpn
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/vpnclient/vpnclient $(1)/usr/libexec/softethervpn
+
+	$(INSTALL_DATA) files/dummy $(1)/usr/libexec/softethervpn/vpn_client.config
+
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) files/vpnclient.init $(1)/etc/init.d/softethervpnclient
 endef
 
-$(eval $(call BuildPackage,softethervpn))
+$(eval $(call BuildPackage,softethervpn-base))
+$(eval $(call BuildPackage,softethervpn-server))
+$(eval $(call BuildPackage,softethervpn-client))
+$(eval $(call BuildPackage,softethervpn-bridge))
 $(eval $(call HostBuild))

--- a/net/softethervpn/patches/001-Encrypt_set_default_RSA.patch
+++ b/net/softethervpn/patches/001-Encrypt_set_default_RSA.patch
@@ -1,0 +1,61 @@
+From 1fad008e1adba5cb596da6f9ec6a244d49a585cf Mon Sep 17 00:00:00 2001
+From: Davide Beatrici <davidebeatrici@gmail.com>
+Date: Mon, 9 Apr 2018 22:02:34 +0200
+Subject: [PATCH] Encrypt: set default RSA key size to 1024 everywhere, using
+ the RSA_KEY_SIZE macro
+
+This commit also fixes the problem described in #31, which was caused by the test key generated in RsaCheck() being too small for newer OpenSSL versions.
+---
+ src/Mayaqua/Encrypt.c | 8 ++++----
+ src/Mayaqua/Encrypt.h | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+--- a/src/Mayaqua/Encrypt.c
++++ b/src/Mayaqua/Encrypt.c
+@@ -2458,7 +2458,7 @@ bool RsaVerifyEx(void *data, UINT data_s
+ 	}
+ 	if (bits == 0)
+ 	{
+-		bits = 1024;
++		bits = RSA_KEY_SIZE;
+ 	}
+ 
+ 	// Hash the data
+@@ -2497,7 +2497,7 @@ bool RsaSignEx(void *dst, void *src, UIN
+ 	}
+ 	if (bits == 0)
+ 	{
+-		bits = 1024;
++		bits = RSA_KEY_SIZE;
+ 	}
+ 
+ 	Zero(dst, bits / 8);
+@@ -2684,7 +2684,7 @@ bool RsaCheck()
+ 	BIO *bio;
+ 	char errbuf[MAX_SIZE];
+ 	UINT size = 0;
+-	UINT bit = 32;
++	UINT bit = RSA_KEY_SIZE;
+ 	// Validate arguments
+ 
+ 	// Key generation
+@@ -2754,7 +2754,7 @@ bool RsaGen(K **priv, K **pub, UINT bit)
+ 	}
+ 	if (bit == 0)
+ 	{
+-		bit = 1024;
++		bit = RSA_KEY_SIZE;
+ 	}
+ 
+ 	// Key generation
+--- a/src/Mayaqua/Encrypt.h
++++ b/src/Mayaqua/Encrypt.h
+@@ -128,7 +128,7 @@ void RAND_Free_For_SoftEther();
+ #define	DES_IV_SIZE					8			// DES IV size
+ #define DES_BLOCK_SIZE				8			// DES block size
+ #define DES3_KEY_SIZE				(8 * 3)		// 3DES key size
+-#define RSA_KEY_SIZE				128			// RSA key size
++#define RSA_KEY_SIZE				1024		// RSA key size
+ #define DH_KEY_SIZE					128			// DH key size
+ #define	RSA_MIN_SIGN_HASH_SIZE		(15 + SHA1_HASH_SIZE)	// Minimum RSA hash size
+ #define	RSA_SIGN_HASH_SIZE			(RSA_MIN_SIGN_HASH_SIZE)	// RSA hash size


### PR DESCRIPTION
This package install both server client and bridge app... This is useless if someone needs to run only the server on the device. Split the package in 3 subpackage and a base package that contains file needed by all 3. This also upgrade the package to latest release to fix some bug and memory leak.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>

