### PR TITLE
libfolly: Add package for folly library

### DIFF
--- a/libs/libfolly/Makefile
+++ b/libs/libfolly/Makefile
@@ -1,0 +1,54 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libfolly
+PKG_VERSION:=2019.05.06.00
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/facebook/folly/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=59e88d792e4c917e2f37ac22c230af0056bce8aa7bacf2d9e94ceb177a7c1079
+PKG_BUILD_DIR:=$(BUILD_DIR)/folly-$(PKG_VERSION)
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+PKG_BUILD_PARALLEL:=1
+CMAKE_OPTIONS:= \
+	-DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+	-DCXX_STD=gnu++14 \
+	-DFOLLY_HAVE_UNALIGNED_ACCESS_EXITCODE=OFF \
+	-DFOLLY_HAVE_LINUX_VDSO_EXITCODE=OFF \
+	-DFOLLY_HAVE_WCHAR_SUPPORT_EXITCODE=OFF \
+	-DHAVE_VSNPRINTF_ERRORS_EXITCODE=OFF \
+	-DFOLLY_HAVE_XSI_STRERROR_R_EXITCODE=0 \
+	-DBUILD_SHARED_LIBS=ON
+CMAKE_INSTALL:=1
+
+define Package/libfolly
+	SECTION:=libs
+	CATEGORY:=Libraries
+	TITLE:=An open-source C++ library developed and used at Facebook.
+	URL:=https://github.com/facebook/folly
+	DEPENDS:=+libstdcpp +boost +boost-context +boost-system +boost-thread \
+		+boost-date_time +boost-filesystem +boost-program_options +boost-regex \
+		+libbz2 +libopenssl +libdouble-conversion +libevent2 +glog +zlib +libzstd \
+		+gflags +libsodium +liblzma +libaio
+endef
+
+define Package/libfolly/description
+	An open-source C++ library developed and used at Facebook.
+	Folly (acronymed loosely after Facebook Open Source Library) is a library of
+	C++14 components designed with practicality and efficiency in mind.
+	Folly contains a variety of core library components used extensively at Facebook.
+	This package includes the shared library.
+endef
+
+define Package/libfolly/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfolly*.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libfolly))

--- a/libs/libfolly/patches/100-cmake-fix-regex-match-path.patch
+++ b/libs/libfolly/patches/100-cmake-fix-regex-match-path.patch
@@ -1,0 +1,40 @@
+Index: folly-2019.05.06.00/CMakeLists.txt
+===================================================================
+--- folly-2019.05.06.00.orig/CMakeLists.txt
++++ folly-2019.05.06.00/CMakeLists.txt
+@@ -109,17 +109,19 @@ configure_file(
+ auto_sources(files "*.cpp" "RECURSE" "${FOLLY_DIR}")
+ auto_sources(hfiles "*.h" "RECURSE" "${FOLLY_DIR}")
+
++string(REPLACE + \\+ FOLLY_DIR_ESCAPED ${FOLLY_DIR})
++
+ # Exclude tests, benchmarks, and other standalone utility executables from the
+ # library sources.  Test sources are listed separately below.
+ REMOVE_MATCHES_FROM_LISTS(files hfiles
+   MATCHES
+-    "^${FOLLY_DIR}/build/"
+-    "^${FOLLY_DIR}/experimental/exception_tracer/"
+-    "^${FOLLY_DIR}/experimental/pushmi/"
+-    "^${FOLLY_DIR}/futures/exercises/"
+-    "^${FOLLY_DIR}/logging/example/"
+-    "^${FOLLY_DIR}/(.*/)?test/"
+-    "^${FOLLY_DIR}/tools/"
++    "^${FOLLY_DIR_ESCAPED}/build/"
++    "^${FOLLY_DIR_ESCAPED}/experimental/exception_tracer/"
++    "^${FOLLY_DIR_ESCAPED}/experimental/pushmi/"
++    "^${FOLLY_DIR_ESCAPED}/futures/exercises/"
++    "^${FOLLY_DIR_ESCAPED}/logging/example/"
++    "^${FOLLY_DIR_ESCAPED}/(.*/)?test/"
++    "^${FOLLY_DIR_ESCAPED}/tools/"
+     "Benchmark.cpp$"
+     "Test.cpp$"
+ )
+@@ -169,7 +171,7 @@ list(APPEND hfiles
+ if (NOT FOLLY_USE_SYMBOLIZER)
+   REMOVE_MATCHES_FROM_LISTS(files hfiles
+     MATCHES
+-      "^${FOLLY_DIR}/experimental/symbolizer/"
++      "^${FOLLY_DIR_ESCAPED}/experimental/symbolizer/"
+   )
+   list(REMOVE_ITEM files
+     ${FOLLY_DIR}/SingletonStackTrace.cpp

--- a/libs/libfolly/patches/101-remove-undefined-dcheck.patch
+++ b/libs/libfolly/patches/101-remove-undefined-dcheck.patch
@@ -1,0 +1,12 @@
+Index: folly-2019.05.06.00/folly/stats/detail/BufferedStat-defs.h
+===================================================================
+--- folly-2019.05.06.00.orig/folly/stats/detail/BufferedStat-defs.h
++++ folly-2019.05.06.00/folly/stats/detail/BufferedStat-defs.h
+@@ -74,7 +74,6 @@ void BufferedStat<DigestT, ClockT>::doUp
+     TimePoint now,
+     const std::unique_lock<SharedMutex>& g,
+     UpdateMode updateMode) {
+-  DCHECK(g.owns_lock());
+   // Check that no other thread has performed the slide after the check
+   auto oldExpiry = expiry_.load(std::memory_order_relaxed).tp;
+   if (now > oldExpiry || updateMode == UpdateMode::Now) {

--- a/libs/libfolly/patches/102-uclibc-patches.patch
+++ b/libs/libfolly/patches/102-uclibc-patches.patch
@@ -1,0 +1,114 @@
+diff --git a/folly/CachelinePadded.h b/folly/CachelinePadded.h
+--- a/folly/CachelinePadded.h
++++ b/folly/CachelinePadded.h
+@@ -35,10 +35,6 @@
+  */
+ template <typename T>
+ class CachelinePadded {
+-  static_assert(
+-      alignof(T) <= max_align_v,
+-      "CachelinePadded does not support over-aligned types.");
+-
+  public:
+   template <typename... Args>
+   explicit CachelinePadded(Args&&... args)
+diff --git a/folly/experimental/JSONSchema.cpp b/folly/experimental/JSONSchema.cpp
+--- a/folly/experimental/JSONSchema.cpp
++++ b/folly/experimental/JSONSchema.cpp
+@@ -25,6 +25,7 @@
+ #include <folly/Singleton.h>
+ #include <folly/String.h>
+ #include <folly/json.h>
++#include <folly/portability/Math.h>
+
+ namespace folly {
+ namespace jsonschema {
+@@ -141,7 +142,7 @@
+       return none;
+     }
+     if (schema_.isDouble() || value.isDouble()) {
+-      const auto rem = std::remainder(value.asDouble(), schema_.asDouble());
++      const auto rem = folly::remainder(value.asDouble(), schema_.asDouble());
+       if (std::abs(rem) > std::numeric_limits<double>::epsilon()) {
+         return makeError("a multiple of ", schema_, value);
+       }
+diff --git a/folly/external/farmhash/farmhash.cpp b/folly/external/farmhash/farmhash.cpp
+--- a/folly/external/farmhash/farmhash.cpp
++++ b/folly/external/farmhash/farmhash.cpp
+@@ -181,6 +181,7 @@
+
+ #undef bswap_32
+ #undef bswap_64
++#undef _BYTESWAP_H
+ #include <byteswap.h>
+
+ #endif
+diff --git a/folly/portability/Math.h b/folly/portability/Math.h
+--- a/folly/portability/Math.h
++++ b/folly/portability/Math.h
+@@ -20,21 +20,24 @@
+
+ namespace folly {
+
+-#ifndef __ANDROID__
++#if !defined(__ANDROID__) && !defined(__UCLIBC__)
+
+ /**
+- * Most platforms hopefully provide std::nextafter.
++ * Most platforms hopefully provide std::{nextafter,remainder}.
+  */
+
+ /* using override */ using std::nextafter;
++/* using override */ using std::remainder;
+
+-#else // !__ANDROID__
++#else // !__ANDROID__ && !__UCLIBC__
+
+ /**
+  * On Android, std::nextafter isn't implemented. However, the C functions and
+  * compiler builtins are still provided. Using the GCC builtin is actually
+  * slightly faster, as they're constexpr and the use cases within folly are in
+  * constexpr context.
++ *
++ * UCLIBC doesn't implement std::remainder. Use the builtin versions.
+  */
+
+ #if defined(__GNUC__) && !defined(__clang__)
+@@ -51,6 +54,18 @@
+   return __builtin_nextafterl(x, y);
+ }
+
++constexpr float remainder(float x, float y) {
++  return __builtin_remainderf(x, y);
++}
++
++constexpr double remainder(double x, double y) {
++  return __builtin_remainder(x, y);
++}
++
++constexpr long double remainder(long double x, long double y) {
++  return __builtin_remainderl(x, y);
++}
++
+ #else // __GNUC__
+
+ inline float nextafter(float x, float y) {
+@@ -65,6 +80,18 @@
+   return ::nextafterl(x, y);
+ }
+
++inline float remainder(float x, float y) {
++  return ::remainderf(x, y);
++}
++
++inline double remainder(double x, double y) {
++  return ::remainder(x, y);
++}
++
++inline long double remainder(long double x, long double y) {
++  return ::remainderl(x, y);
++}
++
+ #endif // __GNUC__
+
+ #endif // __ANDROID__

--- a/libs/libfolly/patches/103-openssl-compatibility.patch
+++ b/libs/libfolly/patches/103-openssl-compatibility.patch
@@ -1,0 +1,147 @@
+diff --git a/folly/io/async/ssl/OpenSSLUtils.cpp b/folly/io/async/ssl/OpenSSLUtils.cpp
+index 0504cf8..a9c2775 100644
+--- a/folly/io/async/ssl/OpenSSLUtils.cpp
++++ b/folly/io/async/ssl/OpenSSLUtils.cpp
+@@ -155,8 +155,12 @@ static std::unordered_map<uint16_t, std::string> getOpenSSLCipherNames() {
+   SSL_CTX* ctx = nullptr;
+   SSL* ssl = nullptr;
+
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+   const SSL_METHOD* meth = SSLv23_server_method();
+   OpenSSL_add_ssl_algorithms();
++#else
++  const SSL_METHOD* meth = TLS_server_method();
++#endif
+
+   if ((ctx = SSL_CTX_new(meth)) == nullptr) {
+     return ret;
+diff --git a/folly/portability/OpenSSL.h b/folly/portability/OpenSSL.h
+index a4f4b04..427bf95 100644
+--- a/folly/portability/OpenSSL.h
++++ b/folly/portability/OpenSSL.h
+@@ -27,6 +27,7 @@
+
+ #include <openssl/asn1.h>
+ #include <openssl/bio.h>
++#include <openssl/bn.h>
+ #include <openssl/crypto.h>
+ #include <openssl/dh.h>
+ #include <openssl/err.h>
+diff --git a/folly/ssl/OpenSSLCertUtils.cpp b/folly/ssl/OpenSSLCertUtils.cpp
+index 544bb4f..423dd2c 100644
+--- a/folly/ssl/OpenSSLCertUtils.cpp
++++ b/folly/ssl/OpenSSLCertUtils.cpp
+@@ -155,12 +155,17 @@ folly::Optional<std::string> OpenSSLCertUtils::toString(X509& x509) {
+   }
+ }
+
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#define X509_get0_notAfter X509_get_notAfter
++#define X509_get0_notBefore X509_get_notBefore
++#endif
++
+ std::string OpenSSLCertUtils::getNotAfterTime(X509& x509) {
+-  return getDateTimeStr(X509_get_notAfter(&x509));
++  return getDateTimeStr(X509_get0_notAfter(&x509));
+ }
+
+ std::string OpenSSLCertUtils::getNotBeforeTime(X509& x509) {
+-  return getDateTimeStr(X509_get_notBefore(&x509));
++  return getDateTimeStr(X509_get0_notBefore(&x509));
+ }
+
+ std::string OpenSSLCertUtils::getDateTimeStr(const ASN1_TIME* time) {
+diff --git a/folly/ssl/OpenSSLVersionFinder.h b/folly/ssl/OpenSSLVersionFinder.h
+index d0110d7..9d65580 100644
+--- a/folly/ssl/OpenSSLVersionFinder.h
++++ b/folly/ssl/OpenSSLVersionFinder.h
+@@ -18,6 +18,12 @@
+ #include <folly/Conv.h>
+ #include <folly/portability/OpenSSL.h>
+
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#define OPENSSL_VERSION SSLEAY_VERSION
++#define OpenSSL_version SSLeay_version
++#define OpenSSL_version_num SSLeay
++#endif
++
+ // This is used to find the OpenSSL version at runtime. Just returning
+ // OPENSSL_VERSION_NUMBER is insufficient as runtime version may be different
+ // from the compile-time version
+@@ -25,7 +31,7 @@ namespace folly {
+ namespace ssl {
+ inline std::string getOpenSSLLongVersion() {
+ #ifdef OPENSSL_VERSION_TEXT
+-  return SSLeay_version(SSLEAY_VERSION);
++  return OpenSSL_version(OPENSSL_VERSION);
+ #elif defined(OPENSSL_VERSION_NUMBER)
+   return folly::format("0x{:x}", OPENSSL_VERSION_NUMBER).str();
+ #else
+@@ -35,7 +41,7 @@ inline std::string getOpenSSLLongVersion() {
+
+ inline uint64_t getOpenSSLNumericVersion() {
+ #ifdef OPENSSL_VERSION_NUMBER
+-  return SSLeay();
++  return OpenSSL_version_num();
+ #else
+   return 0;
+ #endif
+diff --git a/folly/ssl/detail/OpenSSLThreading.cpp b/folly/ssl/detail/OpenSSLThreading.cpp
+index 3414fbd..ce345ab 100644
+--- a/folly/ssl/detail/OpenSSLThreading.cpp
++++ b/folly/ssl/detail/OpenSSLThreading.cpp
+@@ -115,6 +115,7 @@ struct SSLLock {
+ // SSLContext runs in such environments.
+ // Instead of declaring a static member we "new" the static
+ // member so that it won't be destructed on exit().
++#if !FOLLY_SSL_DETAIL_OPENSSL_IS_110
+ static std::unique_ptr<SSLLock[]>& locks() {
+   static auto locksInst = new std::unique_ptr<SSLLock[]>();
+   return *locksInst;
+@@ -128,8 +129,8 @@ static void callbackLocking(int mode, int n, const char*, int) {
+   }
+ }
+
+-static unsigned long callbackThreadID() {
+-  return static_cast<unsigned long>(folly::getCurrentThreadID());
++static void callbackThreadID(CRYPTO_THREADID *id) {
++  return CRYPTO_THREADID_set_numeric(id, folly::getCurrentThreadID());
+ }
+
+ static CRYPTO_dynlock_value* dyn_create(const char*, int) {
+@@ -150,28 +151,33 @@ dyn_lock(int mode, struct CRYPTO_dynlock_value* lock, const char*, int) {
+ static void dyn_destroy(struct CRYPTO_dynlock_value* lock, const char*, int) {
+   delete lock;
+ }
++#endif
+
+ void installThreadingLocks() {
++#if !FOLLY_SSL_DETAIL_OPENSSL_IS_110
+   // static locking
+   locks() = std::make_unique<SSLLock[]>(size_t(CRYPTO_num_locks()));
+   for (auto it : lockTypes()) {
+     locks()[size_t(it.first)].lockType = it.second;
+   }
+-  CRYPTO_set_id_callback(callbackThreadID);
++  CRYPTO_THREADID_set_callback(callbackThreadID);
+   CRYPTO_set_locking_callback(callbackLocking);
+   // dynamic locking
+   CRYPTO_set_dynlock_create_callback(dyn_create);
+   CRYPTO_set_dynlock_lock_callback(dyn_lock);
+   CRYPTO_set_dynlock_destroy_callback(dyn_destroy);
++#endif
+ }
+
+ void cleanupThreadingLocks() {
+-  CRYPTO_set_id_callback(nullptr);
++#if !FOLLY_SSL_DETAIL_OPENSSL_IS_110
++  CRYPTO_THREADID_set_callback(nullptr);
+   CRYPTO_set_locking_callback(nullptr);
+   CRYPTO_set_dynlock_create_callback(nullptr);
+   CRYPTO_set_dynlock_lock_callback(nullptr);
+   CRYPTO_set_dynlock_destroy_callback(nullptr);
+   locks().reset();
++#endif
+ }
+
+ } // namespace detail


### PR DESCRIPTION
Depends on ~PR #7098~, ~PR #7126~, ~PR #7877~

Maintainer: me
Compile tested: openwrt-18.06 for ipq40xx, ipq806x, x86 and ar71xx
Run tested: Tested on devices running on the above architectures. Verified that dependent packages can successfully build and run using the libfolly.so shared library

Description: folly is an open-source C++ library developed and used at Facebook (https://github.com/facebook/folly).
Adding this package will enable adding further packages that depend on this.
