### PR TITLE
tor: Fix compilation without OpenSSL ENGINES

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
 PKG_VERSION:=0.3.5.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
@@ -43,7 +43,7 @@ endef
 define Package/tor
 $(call Package/tor/Default)
   TITLE:=An anonymous Internet communication system
-  DEPENDS:=+libevent2 +libopenssl +libpthread +librt +zlib +libcap
+  DEPENDS:=@OPENSSL_WITH_EC +libevent2 +libopenssl +libpthread +librt +zlib +libcap
 endef
 
 define Package/tor/description

--- a/net/tor/patches/010-openssl-engines.patch
+++ b/net/tor/patches/010-openssl-engines.patch
@@ -1,0 +1,68 @@
+--- a/src/lib/crypt_ops/aes_openssl.c
++++ b/src/lib/crypt_ops/aes_openssl.c
+@@ -43,7 +43,7 @@ ENABLE_GCC_WARNING(redundant-decls)
+ #include "lib/log/log.h"
+ #include "lib/ctime/di_ops.h"
+ 
+-#ifdef ANDROID
++#ifdef OPENSSL_NO_ENGINE
+ /* Android's OpenSSL seems to have removed all of its Engine support. */
+ #define DISABLE_ENGINES
+ #endif
+--- a/src/lib/crypt_ops/crypto_hkdf.c
++++ b/src/lib/crypt_ops/crypto_hkdf.c
+@@ -18,6 +18,7 @@
+ #include "lib/log/util_bug.h"
+ 
+ #ifdef ENABLE_OPENSSL
++#include <openssl/evp.h>
+ #include <openssl/opensslv.h>
+ 
+ #if defined(HAVE_ERR_LOAD_KDF_STRINGS)
+--- a/src/lib/crypt_ops/crypto_openssl_mgt.h
++++ b/src/lib/crypt_ops/crypto_openssl_mgt.h
+@@ -50,7 +50,7 @@
+ #define OPENSSL_V_SERIES(a,b,c) \
+   OPENSSL_VER((a),(b),(c),0,0)
+ 
+-#ifdef ANDROID
++#ifdef OPENSSL_NO_ENGINE
+ /* Android's OpenSSL seems to have removed all of its Engine support. */
+ #define DISABLE_ENGINES
+ #endif
+--- a/src/lib/crypt_ops/crypto_rand.c
++++ b/src/lib/crypt_ops/crypto_rand.c
+@@ -45,6 +45,7 @@
+ #ifdef ENABLE_OPENSSL
+ DISABLE_GCC_WARNING(redundant-decls)
+ #include <openssl/rand.h>
++#include <openssl/sha.h>
+ ENABLE_GCC_WARNING(redundant-decls)
+ #endif
+ 
+--- a/src/lib/crypt_ops/crypto_rsa.c
++++ b/src/lib/crypt_ops/crypto_rsa.c
+@@ -30,6 +30,10 @@
+ #include <sys/stat.h>
+ #endif
+ 
++#ifdef ENABLE_OPENSSL
++#include <openssl/rsa.h>
++#endif
++
+ /** Return the number of bytes added by padding method <b>padding</b>.
+  */
+ int
+--- a/src/lib/tls/x509_openssl.c
++++ b/src/lib/tls/x509_openssl.c
+@@ -31,7 +31,10 @@ DISABLE_GCC_WARNING(redundant-decls)
+ #include <openssl/asn1.h>
+ #include <openssl/bio.h>
+ #include <openssl/bn.h>
++#include <openssl/evp.h>
++#include <openssl/objects.h>
+ #include <openssl/rsa.h>
++#include <openssl/x509.h>
+ 
+ ENABLE_GCC_WARNING(redundant-decls)
+ 


### PR DESCRIPTION
This will become default soon.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @hauke @tripolar 
Compile tested: ramips