### PR TITLE
tinc: Fix to actually build without deprecated APIs

### DIFF
--- a/net/tinc/Makefile
+++ b/net/tinc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinc
 PKG_VERSION:=1.0.35
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.tinc-vpn.org/packages
@@ -41,6 +41,9 @@ CONFIGURE_ARGS += \
 	--with-kernel="$(LINUX_DIR)" \
 	--with-zlib="$(STAGING_DIR)/usr" \
 	--with-lzo-include="$(STAGING_DIR)/usr/include/lzo"
+
+CONFIGURE_VARS += \
+	ac_cv_have_decl_OpenSSL_add_all_algorithms=yes
 
 define Package/tinc/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
The configure script checks for the existence of OpenSSL by checking a
deprecated function. This works around it. The other changes have been done
previously

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @zioproto 
Compile tested: ramips