### PR TITLE
vpnc: Updated deprecated patch to include OpenSSL 1.1

### DIFF
--- a/net/vpnc/Makefile
+++ b/net/vpnc/Makefile
@@ -10,14 +10,13 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=vpnc
 PKG_REV:=550
 PKG_VERSION:=0.5.3.r$(PKG_REV)
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://svn.unix-ag.uni-kl.de/vpnc/trunk/
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=$(PKG_REV)
 PKG_SOURCE_PROTO:=svn
-PKG_MIRROR_HASH:=f95e2ac4e7e55c06553e0fed016a908b0f2695cee988bc70c9994c03e2f588c4
 
 PKG_MAINTAINER:=Daniel Gimpelevich <daniel@gimpelevich.san-francisco.ca.us>
 PKG_LICENSE:=VARIOUS

--- a/net/vpnc/patches/110-openssl-deprecated.patch
+++ b/net/vpnc/patches/110-openssl-deprecated.patch
@@ -8,3 +8,16 @@
  #include "config.h"
  #include "sysdep.h"
  #include "crypto.h"
+@@ -35,10 +36,12 @@ crypto_ctx *crypto_ctx_new(crypto_error **error)
+ 		return NULL;
+ 	}
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	OpenSSL_add_all_ciphers();
+ 	OpenSSL_add_all_digests();
+ 	OpenSSL_add_all_algorithms();
+ 	ERR_load_crypto_strings();
++#endif
+ 
+ 	memset(ctx, 0, sizeof(crypto_ctx));
+ 	ctx->stack = sk_X509_new_null();


### PR DESCRIPTION
Patch was only for 1.0.2. This adds 1.1 support.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @danielg4
Compile tested: ar71xx