### PR TITLE
aria2: Fix faulty patch

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
 PKG_VERSION:=1.34.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/

--- a/net/aria2/patches/010-Platform-Fix-compilation-without-deprecated-OpenSSL-.patch
+++ b/net/aria2/patches/010-Platform-Fix-compilation-without-deprecated-OpenSSL-.patch
@@ -15,13 +15,13 @@ index ea73b6c6..0af62d18 100644
  #endif // ENABLE_NLS
  
  #ifdef HAVE_OPENSSL
-+#if !OPENSSL_101_API
++#if OPENSSL_101_API
    // for SSL initialization
    SSL_load_error_strings();
    SSL_library_init();
    // Need this to "decrypt" p12 files.
    OpenSSL_add_all_algorithms();
-+#endif // !OPENSSL_101_API
++#endif // OPENSSL_101_API
  #endif // HAVE_OPENSSL
  #ifdef HAVE_LIBGCRYPT
    if (!gcry_check_version("1.2.4")) {


### PR DESCRIPTION
The if condition was wrong and caused compilation errors with 1.1.
Potentially broke 1.0.2.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @kuoruan 
Compile tested: ramips

Description:
Some mixup between different versions of said patch.