### PR TITLE
squid: Fix compilation without OpenSSL ENGINE support

### DIFF
--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
 PKG_VERSION:=4.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>

--- a/net/squid/patches/010-openssl-engine.patch
+++ b/net/squid/patches/010-openssl-engine.patch
@@ -1,0 +1,11 @@
+--- a/src/ssl/support.cc
++++ b/src/ssl/support.cc
+@@ -485,7 +485,7 @@ Ssl::Initialize(void)
+ 
+     SQUID_OPENSSL_init_ssl();
+ 
+-#if HAVE_OPENSSL_ENGINE_H
++#ifndef OPENSSL_NO_ENGINE
+     if (::Config.SSL.ssl_engine) {
+         ENGINE_load_builtin_engines();
+         ENGINE *e;


### PR DESCRIPTION
OpenSSL 1.1 includes the header but support has to be checked in another
way.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ratkaj 
Compile tested: ar71xx
