### PR TITLE
spoofer: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/spoofer/Makefile
+++ b/net/spoofer/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spoofer
 PKG_VERSION:=1.4.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.caida.org/projects/spoofer/downloads

--- a/net/spoofer/patches/010-openssl-deprecated.patch
+++ b/net/spoofer/patches/010-openssl-deprecated.patch
@@ -1,0 +1,13 @@
+--- a/prober/spoofer-prober.cc
++++ b/prober/spoofer-prober.cc
+@@ -2135,8 +2135,10 @@ int main(int argc, char **argv) {
+ #endif
+ #ifdef HAVE_LIBSSL
+     if (enableTLS) {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	SSL_load_error_strings();
+ 	SSL_library_init();
++#endif
+ 	ssl_ctx = SSL_CTX_new(SSLv23_client_method());
+ 	if (!ssl_ctx) {
+ 	    ssl_err("SSL_CTX_new() failed");


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @kenkeys 
Compile tested: ramips