### PR TITLE
lftp: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/lftp/Makefile
+++ b/net/lftp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lftp
 PKG_VERSION:=4.8.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://lftp.tech/ftp/ \
 		https://mirror.csclub.uwaterloo.ca/gentoo-distfiles/distfiles/

--- a/net/lftp/patches/010-openssl-deprecated.patch
+++ b/net/lftp/patches/010-openssl-deprecated.patch
@@ -1,0 +1,65 @@
+--- a/src/lftp_ssl.cc
++++ b/src/lftp_ssl.cc
+@@ -34,6 +34,9 @@
+ #include "misc.h"
+ #include "network.h"
+ #include "buffer.h"
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#define X509_STORE_CTX_get_by_subject X509_STORE_get_by_subject
++#endif
+ extern "C" {
+ #include "c-ctype.h"
+ #include "quotearg.h"
+@@ -833,11 +836,13 @@ lftp_ssl_openssl_instance::lftp_ssl_openssl_instance()
+    if(RAND_load_file(file,-1) && RAND_status()!=0)
+       atexit(lftp_ssl_write_rnd);
+ 
+-#if SSLEAY_VERSION_NUMBER < 0x0800
++#if OPENSSL_VERSION_NUMBER < 0x0800
+    ssl_ctx=SSL_CTX_new();
+    X509_set_default_verify_paths(ssl_ctx->cert);
+ #else
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    SSLeay_add_ssl_algorithms();
++#endif
+    ssl_ctx=SSL_CTX_new(SSLv23_client_method());
+    long options=SSL_OP_ALL|SSL_OP_NO_TICKET|SSL_OP_NO_SSLv2;
+    const char *priority=ResMgr::Query("ssl:priority", 0);
+@@ -1075,7 +1080,9 @@ void lftp_ssl_openssl::copy_sid(const lftp_ssl_openssl *o)
+ 
+ const char *lftp_ssl_openssl::strerror()
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    SSL_load_error_strings();
++#endif
+    int error=ERR_get_error();
+    const char *ssl_error=0;
+    if(ERR_GET_LIB(error)==ERR_LIB_SSL)
+@@ -1154,7 +1161,7 @@ int lftp_ssl_openssl::verify_crl(X509_STORE_CTX *ctx)
+     obj = X509_OBJECT_new();
+     store_ctx = X509_STORE_CTX_new();
+     X509_STORE_CTX_init(store_ctx, instance->crl_store, NULL, NULL);
+-    rc = X509_STORE_get_by_subject(store_ctx, X509_LU_CRL, subject, obj);
++    rc = X509_STORE_CTX_get_by_subject(store_ctx, X509_LU_CRL, subject, obj);
+     X509_STORE_CTX_free(store_ctx); store_ctx=0;
+     crl = X509_OBJECT_get0_X509_CRL(obj);
+     if (rc > 0 && crl != NULL) {
+@@ -1194,7 +1201,7 @@ int lftp_ssl_openssl::verify_crl(X509_STORE_CTX *ctx)
+     obj = X509_OBJECT_new();
+     store_ctx = X509_STORE_CTX_new();
+     X509_STORE_CTX_init(store_ctx, instance->crl_store, NULL, NULL);
+-    rc = X509_STORE_get_by_subject(store_ctx, X509_LU_CRL, issuer, obj);
++    rc = X509_STORE_CTX_get_by_subject(store_ctx, X509_LU_CRL, issuer, obj);
+     X509_STORE_CTX_free(store_ctx); store_ctx=0;
+     crl = X509_OBJECT_get0_X509_CRL(obj);
+     if (rc > 0 && crl != NULL) {
+--- a/src/lftp_ssl.h
++++ b/src/lftp_ssl.h
+@@ -28,6 +28,7 @@
+ #  include <openssl/err.h>
+ #  include <openssl/rand.h>
+ #  include <openssl/x509v3.h>
++#  include <openssl/x509_vfy.h>
+ # endif
+ 
+ #include "Ref.h"


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @fededim
Compile tested: ramips
