### PR TITLE
python-dateutil: update dateutil packaging

### DIFF
--- a/lang/python/python-dateutil/Makefile
+++ b/lang/python/python-dateutil/Makefile
@@ -9,39 +9,55 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dateutil
 PKG_VERSION:=2.7.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=BSD-2-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/python-dateutil
 PKG_HASH:=88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-dateutil-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
-include ../python-package.mk
 
-define Package/python-dateutil
+include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-dateutil/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
   TITLE:=Extensions to the standard Python datetime module
   URL:=https://dateutil.readthedocs.org/
-  DEPENDS:=+python +python-six
+endef
+
+define Package/python-dateutil
+$(call Package/python-dateutil/Default)
+  DEPENDS:=+PACKAGE_python-dateutil:python +PACKAGE_python-dateutil:python-six
+  VARIANT:=python
 endef
 
 define Package/python-dateutil/description
   Extensions to the standard Python datetime module
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-dateutil
+$(call Package/python-dateutil/Default)
+  DEPENDS:=+PACKAGE_python3-dateutil:python3 +PACKAGE_python3-dateutil:python3-six
+  VARIANT:=python3
 endef
 
-define Package/python-dateutil/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
+define Package/python3-dateutil/description
+$(call Package/python-dateutil/description)
+.
+(Variant for Python3)
 endef
 
+$(eval $(call PyPackage,python-dateutil))
 $(eval $(call BuildPackage,python-dateutil))
+$(eval $(call BuildPackage,python-dateutil-src))
+$(eval $(call Py3Package,python3-dateutil))
+$(eval $(call BuildPackage,python3-dateutil))
+$(eval $(call BuildPackage,python3-dateutil-src))


### PR DESCRIPTION
Maintainer: @kissg1988 @commodo @jefferyto 

Compile & Run tested brcm2708 Raspberry Pi Model B+ for the python3 version using Radicale v2 (in progress, too be added).
Depends on https://github.com/openwrt/packages/pull/7869 which commit is included here (but is not the purpose of the commit) to make CircleCI happy.

Description:
Update the packaging to use the generic bits by @commodo.
Radicale 2.x requires Python3 and python-dateutils, so
build for Python3 as well.