### PR TITLE
python-lxml: bump to version 4.3.0

### DIFF
--- a/lang/python/python-lxml/Makefile
+++ b/lang/python/python-lxml/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-lxml
-PKG_VERSION:=4.2.5
+PKG_VERSION:=4.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=lxml-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/l/lxml
-PKG_HASH:=36720698c29e7a9626a0dc802ef8885f8f0239bfd1689628ecd459a061f2807f
+PKG_HASH:=d1e111b3ab98613115a208c1017f266478b0ab224a67bc8eac670fa0bad7d488
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-lxml-$(PKG_VERSION)
 PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/openwrt/openwrt/commit/488af51f81991b658e35654c3e0b8ab3bf734bc5  x86
Run tested: https://github.com/openwrt/openwrt/commit/488af51f81991b658e35654c3e0b8ab3bf734bc5  x86

------------------------------------------------------------------------------------------------------------

This change upgrades the version of lxml to 4.3.0.
Run-tested on an x86 VM.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>