### PR TITLE
Fix incorrect tinyproxy.conf when XTinyproxy option is set

### DIFF
--- a/net/tinyproxy/files/tinyproxy.init
+++ b/net/tinyproxy/files/tinyproxy.init
@@ -50,7 +50,7 @@ start_proxy() {
 
 	proxy_atom "$1" LogLevel >> $CFGFILE
 
-	proxy_list "$1" XTinyproxy >> $CFGFILE
+	proxy_flag "$1" XTinyproxy >> $CFGFILE
 
 	proxy_atom "$1" MaxClients >> $CFGFILE
 	proxy_atom "$1" MinSpareServers >> $CFGFILE


### PR DESCRIPTION
Switch XTinyproxy option handling to flag type

Maintainer: me / @jow- 
Compile tested: no compilation, shell script
Run tested: tested on OpenWrt 18.06.1 r7258-5eb055306f / LuCI openwrt-18.06 branch (git-18.228.31946-f64b152)

Description:
Fix the handling of XTinyproxy option to avoid syntax error when starting tinyproxy:

example:
Syntax error on line 15
Unable to parse config file. Not starting.

Signed-off-by: Mathieu Coupe <eagle.pounains@gmail.com>