### PR TITLE
[packages] tinyproxy: handling of option XTinyproxy

### DIFF
--- a/net/tinyproxy/Makefile
+++ b/net/tinyproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tinyproxy
 PKG_VERSION:=1.8.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.banu.com/pub/tinyproxy/1.8/

--- a/net/tinyproxy/files/tinyproxy.init
+++ b/net/tinyproxy/files/tinyproxy.init
@@ -50,7 +50,7 @@ start_proxy() {
 
 	proxy_atom "$1" LogLevel >> $CFGFILE
 
-	proxy_list "$1" XTinyproxy >> $CFGFILE
+	proxy_flag "$1" XTinyproxy >> $CFGFILE
 
 	proxy_atom "$1" MaxClients >> $CFGFILE
 	proxy_atom "$1" MinSpareServers >> $CFGFILE


### PR DESCRIPTION
1.) Fix the handling of XTinyproxy option to avoid syntax error when starting tinyproxy:

example:
Syntax error on line 15
Unable to parse config file. Not starting.

Signed-off-by: Mathieu Coupé <eagle.pounains@gmail.com>

Maintainer: me / @jow- 
Compile tested: no compilation, shell script
Run tested: tested on OpenWrt 18.06.1 r7258-5eb055306f / LuCI openwrt-18.06 branch (git-18.228.31946-f64b152)

Description: Fix the handling of XTinyproxy option to avoid syntax error when starting tinyproxy
