### PR TITLE
nut: Prevent FSD when not specifically requested

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=13
+PKG_RELEASE:=14
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/files/nutshutdown
+++ b/net/nut/files/nutshutdown
@@ -16,11 +16,14 @@ stop_instance() {
 shutdown_instance() {
 	local cfg="$1"
 	config_get driver "$cfg" driver "usbhid-ups"
-	/lib/nut/${driver} -a "$cfg" -k
+	# Only FSD if killpower was indicated
+	if [ -f /var/run/killpower ]; then
+		/lib/nut/${driver} -a "$cfg" -k
+	fi
 }
 
-[ -f /var/run/killpower ] && {
-	[ -f /etc/config/nut_server ] && {
+if [ -f /var/run/killpower ]; then
+	if [ -f /etc/config/nut_server ]; then
 		config_load nut_server
 
 		# Can't FSD unless drivers are stopped
@@ -33,9 +36,9 @@ shutdown_instance() {
 		sleep 120
 		# Uh-oh failed to poweroff UPS
 		reboot -f
-	} || {
+	else
 		poweroff
-	}
-} || {
+	fi
+else
 	poweroff
-}
+fi


### PR DESCRIPTION
Under certain circumstances nutshutdown was causing a forced
shutdown of the UPS even though killpower was not indicated.
Prevent that.  Also clarify the logic for powering off server
by avoiding && || chains.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: me / @cshoredaniel 
Compile & Run tested Raspberry Pi B+ (brcm2708/bcm2708)

sysupgraded, rebooted a couple of times, did fsd.
