### PR TITLE
bluez: Add bdaddr tool

### DIFF
--- a/utils/bluez/Makefile
+++ b/utils/bluez/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bluez
 PKG_VERSION:=5.50
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/bluetooth/
@@ -118,6 +118,7 @@ endef
 
 define Package/bluez-utils/install
 	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_BUILD_DIR)/tools/bdaddr $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/bccmd $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/bluemoon $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/btattach $(1)/usr/bin/


### PR DESCRIPTION
Let't add the bdaddr tool, it's handy to change the BT address.

Signed-off-by: Bruno Randolf <br1@einfach.org>

Maintainer: @diizzyy
Compile tested: Rambutan, master
Run tested: Rambutan, master