### PR TITLE
tor: update to version 0.3.4.10

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.3.4.9
+PKG_VERSION:=0.3.4.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=1a171081f02b9a6ff9e28c0898defb7670e5bbb3bdbcaddfcf4e4304aedd164a
+PKG_HASH:=adeccb2bd49dbe5164185d702b973e2760009866c11975d9b2b74dae4d0c258a
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested:Turris Mox (TOS4) (aarch64 cortex-a53), OpenWRT master
Run tested:Turris Mox (TOS4) (aarch64 cortex-a53), OpenWRT master

Signed-off-by: Jan Pavlinec jan.pavlinec@nic.cz

Description:
Update to version 0.3.4.10