### PR TITLE
classpath: Fix breakage caused by -Werror=implicit-fallthrough

### DIFF
--- a/libs/classpath/Makefile
+++ b/libs/classpath/Makefile
@@ -50,6 +50,7 @@ define Download/antlr
 endef
 $(eval $(call Download,antlr))
 
+EXTRA_CFLAGS += -Wno-error=implicit-fallthrough
 CONFIGURE_ARGS += \
 	--with-gmp="$(STAGING_DIR)/usr" \
 	--without-x \


### PR DESCRIPTION
`classpath` builds with `-Wextra` and, unless configured with
`--disable-werror`, also `-Werror`.  Since GCC 7 added `-Wimplicit-fallthrough=3`
to -Wextra we need to make it not an error for code that doesn't use
`__attribute__((fallthrough))` yet.

Signed-off-by: Daniel Santos <daniel.santos@pobox.com>

Maintainer: Dana H. Myers <k6jq@comcast.net>
Compile tested: ramips, mt7620, v18.06.1
Run tested: ramips, mt7620, v18.06.1

Description:
