### PR TITLE
samba4: add mandatory option per CVE-2018-16853

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
 PKG_VERSION:=4.9.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only
@@ -193,7 +193,7 @@ else
 	CONFIGURE_ARGS += --without-acl-support
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
-	CONFIGURE_ARGS += --enable-gnutls --with-dnsupdate --with-ads --with-ldap
+	CONFIGURE_ARGS += --enable-gnutls --with-dnsupdate --with-ads --with-ldap --with-experimental-mit-ad-dc
 	TARGET_CFLAGS := -I$(STAGING_DIR)/usr/include/python2.7 $(TARGET_CFLAGS)
 else
 	CONFIGURE_ARGS += --without-ad-dc --without-json-audit --without-libarchive --disable-python --nopyc --nopyo --disable-gnutls --without-dnsupdate --without-ads --without-ldap


### PR DESCRIPTION
Maintainer: @Andy2244 
Compile tested: arm_cortex-a15_neon-vfpv4 (ipq806x/generic), TP-Link AC2600, OpenWrt SNAPSHOT r9010-adc8b37

Description:

Since 4.9.3, Samba AD-DC with MIT Kerberos will refuse to build unless --with-experimental-mit-ad-dc is provided to the configure command.

The mandatory requirement was [introduced](https://www.samba.org/samba/security/CVE-2018-16853.html) in response to a report that a user in a Samba AD domain can crash the KDC when Samba is built in the non-default MIT Kerberos configuration.

This requirement was introduced in Samba commit c5370a4349d381ba3b64b063dc28a2c54cfacdfc.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>
