### PR TITLE
irssi: update to version 1.1.2

### DIFF
--- a/net/irssi/Makefile
+++ b/net/irssi/Makefile
@@ -8,12 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=irssi
-PKG_VERSION:=1.1.1
+PKG_VERSION:=1.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/irssi/irssi/releases/download/1.1.1/
-PKG_HASH:=784807e7a1ba25212347f03e4287cff9d0659f076edfb2c6b20928021d75a1bf
+PKG_SOURCE_URL:=https://github.com/irssi/irssi/releases/download/1.1.2/
+PKG_HASH:=5ccc2b89a394e91bea0aa83a951c3b1d471c76da87b4169ec435530a31bf9732
+
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_CPE_ID:=cpe:/a:irssi:irssi
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: Compiled tested: cortexa53, Turris MOX, OpenWrt 18.06.1
Run tested: Compiled tested: cortexa53, Turris MOX, OpenWrt 18.06.1

Description:
Fixes CVE-2019-5882 - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5882

Changes
-add PKG_CPE_ID
-license info

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>