### PR TITLE
python: Fix lib2to3 fixes search

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -12,7 +12,7 @@ include ../python-version.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)

--- a/lang/python/python/patches/017_lib2to3_fix_pyc_search.patch
+++ b/lang/python/python/patches/017_lib2to3_fix_pyc_search.patch
@@ -1,0 +1,17 @@
+diff --git a/Lib/lib2to3/refactor.py b/Lib/lib2to3/refactor.py
+index 7841b99..1e0d3b3 100644
+--- a/Lib/lib2to3/refactor.py
++++ b/Lib/lib2to3/refactor.py
+@@ -37,6 +37,12 @@ def get_all_fix_names(fixer_pkg, remove_prefix=True):
+             if remove_prefix:
+                 name = name[4:]
+             fix_names.append(name[:-3])
++        if name.startswith("fix_") and name.endswith(".pyc"):
++            if remove_prefix:
++                name = name[4:]
++            name = name[:-4]
++            if name not in fix_names:
++                fix_names.append(name)
+     return fix_names
+ 
+ 


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: armvirt-32 (sdk, 2019-01-11)
Run tested: armvirt-32 (snapshot, 2019-01-11)

Description:
This is the patch from c98b12d9a920ede376d1eaef0da0c0da9d26d6b3 (#7931), applied for python 2.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>