### PR TITLE
shairport-sync: Get rid of libc++ dependency

### DIFF
--- a/sound/shairport-sync/Makefile
+++ b/sound/shairport-sync/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shairport-sync
 PKG_VERSION:=3.2.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mikebrady/shairport-sync/tar.gz/$(PKG_VERSION)?
@@ -23,14 +23,13 @@ PKG_LICENSE_FILES:=COPYING LICENSES shairport.c
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf
 
-include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/shairport-sync/default
   SECTION:=sound
   CATEGORY:=Sound
   TITLE:=AirPlay compatible audio player
-  DEPENDS:=@AUDIO_SUPPORT $(CXX_DEPENDS) +libpthread +alsa-lib +libconfig +libdaemon +libpopt
+  DEPENDS:=@AUDIO_SUPPORT +libpthread +alsa-lib +libconfig +libdaemon +libpopt
   PROVIDES:=shairport-sync
   URL:=https://github.com/mikebrady/shairport-sync
 endef

--- a/sound/shairport-sync/patches/010-no-cxx.patch
+++ b/sound/shairport-sync/patches/010-no-cxx.patch
@@ -1,0 +1,35 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -17,10 +17,6 @@ else
+ endif
+ endif
+ 
+-if USE_APPLE_ALAC
+-  shairport_sync_SOURCES += apple_alac.cpp
+-endif
+-
+ if USE_CUSTOMPIDDIR
+ AM_CFLAGS+= \
+ 	-DPIDDIR=\"$(CUSTOM_PID_DIR)\"
+@@ -66,11 +62,6 @@ if USE_PA
+ shairport_sync_SOURCES += audio_pa.c
+ endif
+ 
+-if USE_CONVOLUTION
+-shairport_sync_SOURCES += FFTConvolver/AudioFFT.cpp FFTConvolver/FFTConvolver.cpp FFTConvolver/Utilities.cpp FFTConvolver/convolver.cpp
+-AM_CXXFLAGS = -std=c++11
+-endif
+-
+ if USE_DNS_SD
+ shairport_sync_SOURCES += mdns_dns_sd.c
+ endif
+--- a/configure.ac
++++ b/configure.ac
+@@ -18,7 +18,6 @@ with_os=`echo ${with_os} | tr '[[:upper:]]' '[[:lower:]]' `
+ 
+ # Checks for programs.
+ AC_PROG_CC
+-AC_PROG_CXX
+ AC_PROG_INSTALL
+ 
+ PKG_PROG_PKG_CONFIG([0.9.0])


### PR DESCRIPTION
The only C++ code is an audio filter for shairport-sync. Removing it
allows compilation without a heavy libc++.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: mt7621