### PR TITLE
hiredis: fix pkg-config file

### DIFF
--- a/libs/hiredis/Makefile
+++ b/libs/hiredis/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hiredis
 PKG_VERSION:=0.14.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/redis/hiredis/tar.gz/v$(PKG_VERSION)?

--- a/libs/hiredis/patches/010-fix_pkconfig_file.patch
+++ b/libs/hiredis/patches/010-fix_pkconfig_file.patch
@@ -1,0 +1,34 @@
+commit f96d9f9d2e3ba39352035e6ac26463243484d404
+Author: Sebastian Kemper <sebastian_ml@gmx.net>
+Date:   Sun Jan 13 19:25:52 2019 +0100
+
+    Setup .pc file to allow use for cross-compiling
+    
+    The Makefile is currently creating the pkg-config file using static lib
+    and include dir statements. Change that so that projects that
+    cross-compile hiredis can use pkg-config to setup other programs
+    depending on it.
+    
+    Note: these projects (like OpenWrt) call pkg-config with arguments to
+    overwrite some variables in the .pc file, namely:
+    
+    --define-variable=prefix=<...>
+    --define-variable=exec_prefix=<...>
+    
+    Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
+
+diff --git a/Makefile b/Makefile
+index 07b8a83..14d21de 100644
+--- a/Makefile
++++ b/Makefile
+@@ -166,8 +166,8 @@ $(PKGCONFNAME): hiredis.h
+ 	@echo "Generating $@ for pkgconfig..."
+ 	@echo prefix=$(PREFIX) > $@
+ 	@echo exec_prefix=\$${prefix} >> $@
+-	@echo libdir=$(PREFIX)/$(LIBRARY_PATH) >> $@
+-	@echo includedir=$(PREFIX)/$(INCLUDE_PATH) >> $@
++	@echo libdir=\$${exec_prefix}/$(LIBRARY_PATH) >> $@
++	@echo includedir=\$${prefix}/$(INCLUDE_PATH) >> $@
+ 	@echo >> $@
+ 	@echo Name: hiredis >> $@
+ 	@echo Description: Minimalistic C client library for Redis. >> $@


### PR DESCRIPTION
Fix for using the .pc file when cross-compiling.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @dangowrt 
Compile tested: ath79
Run tested: N/A (not a run-time change)

Description:
Hello Daniel,

This fixes the .pc file created by the Makefile. Patch sent upstream.

Without is calling "pkg-config --cflags hiredis" results in "-I/usr/include/hiredis", for instance.

Kind regards,
Seb