### PR TITLE
vim: fix compilation error

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -216,6 +216,7 @@ define Package/vim-fuller/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/vim_big $(1)/usr/bin/vim
 	$(INSTALL_DIR) $(1)/usr/share/vim
+	$(INSTALL_DIR) $(1)/usr/share/vim$(VIMVER)
 	$(CP) -r $(PKG_INSTALL_DIR)/usr/share/vim/vim$(VIMVER) $(1)/usr/share/vim
 	$(INSTALL_CONF) ./files/vimrc.full $(1)/usr/share/vim/vimrc
 endef


### PR DESCRIPTION
fix compilation erro when vim is being copied to non existing directory

Signed-off-by: Jaymin Patel <jem.patel@gmail.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
