### PR TITLE
mwan3: update to version 2.7.9

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.7.8
+PKG_VERSION:=2.7.9
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -72,14 +72,14 @@ case "$ACTION" in
 			$LOG notice "Starting tracker on interface $INTERFACE (${DEVICE:-unknown})"
 			mwan3_set_iface_hotplug_state $INTERFACE "online"
 			mwan3_track $INTERFACE $DEVICE "online" "$src_ip"
-			mwan3_set_policies_iptables
-			mwan3_set_user_rules
-			mwan3_flush_conntrack $INTERFACE $DEVICE "ifup"
 		else
 			$LOG notice "Starting tracker on interface $INTERFACE (${DEVICE:-unknown})"
 			mwan3_set_iface_hotplug_state $INTERFACE "offline"
 			mwan3_track $INTERFACE $DEVICE "unknown" "$src_ip"
 		fi
+		mwan3_set_policies_iptables
+		mwan3_set_user_rules
+		mwan3_flush_conntrack $INTERFACE $DEVICE "ifup"
 	;;
 	ifdown)
 		mwan3_set_iface_hotplug_state $INTERFACE "offline"

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -75,7 +75,7 @@ case "$ACTION" in
 		else
 			$LOG notice "Starting tracker on interface $INTERFACE (${DEVICE:-unknown})"
 			mwan3_set_iface_hotplug_state $INTERFACE "offline"
-			mwan3_track $INTERFACE $DEVICE "unknown" "$src_ip"
+			mwan3_track $INTERFACE $DEVICE "offline" "$src_ip"
 		fi
 		mwan3_set_policies_iptables
 		mwan3_set_user_rules

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -1112,7 +1112,7 @@ mwan3_set_iface_hotplug_state() {
 mwan3_get_iface_hotplug_state() {
 	local iface=$1
 
-	cat $MWAN3_STATUS_DIR/iface_state/$iface 2>/dev/null || echo "unknown"
+	cat $MWAN3_STATUS_DIR/iface_state/$iface 2>/dev/null || echo "offline"
 }
 
 mwan3_report_iface_status()
@@ -1135,7 +1135,7 @@ mwan3_report_iface_status()
 	fi
 
 	if [ -z "$id" -o -z "$device" ]; then
-		result="unknown"
+		result="offline"
 	elif [ -n "$($IP rule | awk '$1 == "'$(($id+1000)):'"')" ] && \
 		[ -n "$($IP rule | awk '$1 == "'$(($id+2000)):'"')" ] && \
 		[ -n "$($IPT -S mwan3_iface_in_$1 2> /dev/null)" ] && \

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -856,7 +856,9 @@ mwan3_set_sticky_iptables()
 
 mwan3_set_user_iptables_rule()
 {
-	local ipset family proto policy src_ip src_port sticky dest_ip dest_port use_policy timeout rule policy IPT
+	local ipset family proto policy src_ip src_port sticky dest_ip
+	local dest_port use_policy timeout rule policy IPT
+	local global_logging rule_logging loglevel
 
 	rule="$1"
 
@@ -870,6 +872,10 @@ mwan3_set_user_iptables_rule()
 	config_get dest_port $1 dest_port 0:65535
 	config_get use_policy $1 use_policy
 	config_get family $1 family any
+
+	config_get rule_logging $1 logging 0
+	config_get global_logging globals logging 0
+	config_get loglevel globals loglevel notice
 
 	if [ "$1" != $(echo "$1" | cut -c1-15) ]; then
 		$LOG warn "Rule $1 exceeds max of 15 chars. Not setting rule" && return 0
@@ -945,6 +951,17 @@ mwan3_set_user_iptables_rule()
 			for IPT in "$IPT4" "$IPT6"; do
 				case $proto in
 					tcp|udp)
+					[ "$global_logging" = "1" ] && [ "$rule_logging" = "1" ] && {
+						$IPT -A mwan3_rules \
+							-p $proto \
+							-s $src_ip \
+							-d $dest_ip $ipset \
+							-m multiport --sports $src_port \
+							-m multiport --dports $dest_port \
+							-m mark --mark 0/$MMX_MASK \
+							-m comment --comment "$1" \
+							-j LOG --log-level "$loglevel" --log-prefix "MWAN3($1)" &> /dev/null
+					}
 					$IPT -A mwan3_rules \
 						-p $proto \
 						-s $src_ip \
@@ -956,6 +973,15 @@ mwan3_set_user_iptables_rule()
 						-j $policy &> /dev/null
 					;;
 					*)
+					[ "$global_logging" = "1" ] && [ "$rule_logging" = "1" ] && {
+						$IPT -A mwan3_rules \
+							-p $proto \
+							-s $src_ip \
+							-d $dest_ip $ipset \
+							-m mark --mark 0/$MMX_MASK \
+							-m comment --comment "$1" \
+							-j LOG --log-level "$loglevel" --log-prefix "MWAN3($1)" &> /dev/null
+					}
 					$IPT -A mwan3_rules \
 						-p $proto \
 						-s $src_ip \
@@ -971,6 +997,17 @@ mwan3_set_user_iptables_rule()
 
 			case $proto in
 				tcp|udp)
+				[ "$global_logging" = "1" ] && [ "$rule_logging" = "1" ] && {
+					$IPT -A mwan3_rules \
+						-p $proto \
+						-s $src_ip \
+						-d $dest_ip $ipset \
+						-m multiport --sports $src_port \
+						-m multiport --dports $dest_port \
+						-m mark --mark 0/$MMX_MASK \
+						-m comment --comment "$1" \
+						-j LOG --log-level "$loglevel" --log-prefix "MWAN3($1)" &> /dev/null
+				}
 				$IPT4 -A mwan3_rules \
 					-p $proto \
 					-s $src_ip \
@@ -982,6 +1019,15 @@ mwan3_set_user_iptables_rule()
 					-j $policy &> /dev/null
 				;;
 				*)
+				[ "$global_logging" = "1" ] && [ "$rule_logging" = "1" ] && {
+					$IPT4 -A mwan3_rules \
+						-p $proto \
+						-s $src_ip \
+						-d $dest_ip $ipset \
+						-m mark --mark 0/$MMX_MASK \
+						-m comment --comment "$1" \
+						-j LOG --log-level "$loglevel" --log-prefix "MWAN3($1)" &> /dev/null
+				}
 				$IPT4 -A mwan3_rules \
 					-p $proto \
 					-s $src_ip \
@@ -996,6 +1042,17 @@ mwan3_set_user_iptables_rule()
 
 			case $proto in
 				tcp|udp)
+				[ "$global_logging" = "1" ] && [ "$rule_logging" = "1" ] && {
+					$IPT6 -A mwan3_rules \
+						-p $proto \
+						-s $src_ip \
+						-d $dest_ip $ipset \
+						-m multiport --sports $src_port \
+						-m multiport --dports $dest_port \
+						-m mark --mark 0/$MMX_MASK \
+						-m comment --comment "$1" \
+						-j LOG --log-level "$loglevel" --log-prefix "MWAN3($1)" &> /dev/null
+				}
 				$IPT6 -A mwan3_rules \
 					-p $proto \
 					-s $src_ip \
@@ -1007,6 +1064,15 @@ mwan3_set_user_iptables_rule()
 					-j $policy &> /dev/null
 				;;
 				*)
+				[ "$global_logging" = "1" ] && [ "$rule_logging" = "1" ] && {
+					$IPT6 -A mwan3_rules \
+						-p $proto \
+						-s $src_ip \
+						-d $dest_ip $ipset \
+						-m mark --mark 0/$MMX_MASK \
+						-m comment --comment "$1" \
+						-j LOG --log-level  "$loglevel" --log-prefix "MWAN3($1)" &> /dev/null
+				}
 				$IPT6 -A mwan3_rules \
 					-p $proto \
 					-s $src_ip \

--- a/net/mwan3/files/usr/sbin/mwan3rtmon
+++ b/net/mwan3/files/usr/sbin/mwan3rtmon
@@ -25,7 +25,8 @@ main() {
 	sleep 3
 	while mwan3_rtmon_ipv4 || mwan3_rtmon_ipv6; do
 		[ "$rtmon_interval" = "0" ] && break
-		sleep $rtmon_interval
+		sleep "$rtmon_interval" &
+		wait
 	done
 }
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -112,8 +112,8 @@ main() {
 	local loss=0
 	local latency=0
 
-	if [ "$STATUS" = "unknown" ]; then
-		echo "unknown" > /var/run/mwan3track/$1/STATUS
+	if [ "$STATUS" = "offline" ]; then
+		echo "offline" > /var/run/mwan3track/$1/STATUS
 		echo "0" > /var/run/mwan3track/$1/UPTIME
 		echo "$(get_uptime)" > /var/run/mwan3track/$1/DOWNTIME
 		score=0


### PR DESCRIPTION
Maintainer: me
Compile tested: not needed this a scripts
Run tested: x86_64, APU3, OpenWrt master

Description:

- Add syslog debug possibility for rules
- Fix initial_state offline issue
- Replace interface unknown with offline
- Fix interrupt sleep mwan3rtmon on signal trap event
