### PR TITLE
adblock: release 3.6.3

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.6.2
+PKG_VERSION:=3.6.3
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -8,7 +8,7 @@ EXTRA_COMMANDS="suspend resume query report status"
 EXTRA_HELP="	suspend	Suspend adblock processing
 	resume	Resume adblock processing
 	query	<DOMAIN> Query active blocklists for specific domains
-	report	Print dns query statistics
+	report	<SEARCH> Print dns query statistics with an optional search parameter
 	status	Print runtime information"
 
 adb_init="/etc/init.d/adblock"
@@ -81,7 +81,7 @@ query()
 report()
 {
 	[ -s "${adb_pidfile}" ] && return 1
-	rc_procd "${adb_script}" report "${1}"
+	rc_procd "${adb_script}" report "${1:-"+"}" "${2:-"50"}" "${3:-"false"}" "${4:-"true"}"
 }
 
 status()


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: PC Engines apu2, OpenWrt SNAPSHOT r9012-7175b1356e

Description:
* the DNS Report now displays the hostname, MAC-Address or
  client IP (CLI & LuCI)
* Filter the DNS Query result set for a particular domain, client or
  time frame (CLI & LuCI)
* remove needless XHR.Poll-Events from Reporting page in LuCI
* remove needless 'force sort' option in LuCI

Signed-off-by: Dirk Brenken <dev@brenken.org>