### PR TITLE
utils/bash: Update to 5.0

### DIFF
--- a/utils/bash/Makefile
+++ b/utils/bash/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bash
-PKG_VERSION:=4.4.18
-PKG_RELEASE:=2
+PKG_VERSION:=5.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/bash
-PKG_HASH:=604d9eec5e4ed5fd2180ee44dd756ddca92e0b6aa4217bbab2b6227380317f23
+PKG_HASH:=b4a80f2ac66170b2913efbfb9f2594f1f76c7b1afd11f799e22035d63077fb4d
 
 PKG_LICENSE:=GPL-3.0+
 PKG_LICENSE_FILES:=COPYING
@@ -55,7 +55,7 @@ endef
 # bash_cv_sys_named_pipes: Required for process substituion
 CONFIGURE_VARS += \
 	ac_cv_rl_prefix="$(STAGING_DIR)/usr" \
-	ac_cv_rl_version="7.0" \
+	ac_cv_rl_version="8.0" \
 	bash_cv_getcwd_malloc=yes \
 	bash_cv_job_control_missing=present \
 	bash_cv_dev_fd=whacky \
@@ -72,6 +72,9 @@ CONFIGURE_ARGS+= \
 	--without-bash-malloc \
 	--bindir=/bin \
 	--disable-rpath \
+	--enable-direxpand-default \
+	--enable-job-control \
+	--enable-readline
 
 define Package/bash/postinst
 #!/bin/sh
@@ -86,6 +89,5 @@ define Package/bash/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/bash $(1)/bin/
 	$(LN) bash $(1)/bin/rbash
 endef
-
 
 $(eval $(call BuildPackage,bash))

--- a/utils/bash/patches/100-fix-jobs.patch
+++ b/utils/bash/patches/100-fix-jobs.patch
@@ -3,11 +3,9 @@ Fix job control
 Patch was taken from https://git.alpinelinux.org/cgit/aports/tree/main/bash/fix-jobs.patch
 
 See also "Bash 4.4.12-r2 jobs hangs on arm (alpine 3.7)", https://bugs.alpinelinux.org/issues/8447
-diff --git a/jobs.c b/jobs.c
-index cef3c79..bf99266 100644
 --- a/jobs.c
 +++ b/jobs.c
-@@ -4166,10 +4166,8 @@ initialize_job_control (force)
+@@ -4326,10 +4326,8 @@ just_bail:
    if (js.c_childmax < 0)
      js.c_childmax = DEFAULT_CHILD_MAX;
  
@@ -18,7 +16,7 @@ index cef3c79..bf99266 100644
  
    return job_control;
  }
-@@ -4547,10 +4545,8 @@ mark_dead_jobs_as_notified (force)
+@@ -4707,10 +4705,8 @@ mark_dead_jobs_as_notified (force)
    if (js.c_childmax < 0)
      js.c_childmax = DEFAULT_CHILD_MAX;
  

--- a/utils/bash/patches/900-no_doc.patch
+++ b/utils/bash/patches/900-no_doc.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -741,10 +741,8 @@ reconfig: force
+@@ -791,10 +791,8 @@ loadables:
  #	$(MAKE) -f $(srcdir)/Makefile $(MFLAGS) srcdir=$(srcdir)
  
  doc documentation:  force


### PR DESCRIPTION
Maintainer: @naoir
Compile tested on: mvebu, WRT3200ACM, OpenWrt master + sunxi, OrangePi PC, OpenWrt master
Run tested on: sunxi, OrangePi PC, OpenWrt master

Description:
Update bash to 5.0

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>