### PR TITLE
unzip: patch CVE-2018-1000035 and add PKG_CPE_IDE

### DIFF
--- a/utils/unzip/Makefile
+++ b/utils/unzip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=unzip
 PKG_REV:=60
 PKG_VERSION:=6.0
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)$(PKG_REV).tar.gz
 PKG_SOURCE_URL:=@SF/infozip
@@ -19,6 +19,7 @@ PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 
 PKG_LICENSE:=BSD-4-Clause
 PKG_LICENSE_FILES:=LICENSE
+ PKG_CPE_ID:=cpe:/a:unzip:unzip
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/unzip$(PKG_REV)
 PKG_CHECK_FORMAT_SECURITY:=0

--- a/utils/unzip/patches/011-CVE-2018-1000035-overflow-password-protect.patch
+++ b/utils/unzip/patches/011-CVE-2018-1000035-overflow-password-protect.patch
@@ -1,0 +1,34 @@
+--- a/fileio.c
++++ b/fileio.c
+@@ -1,5 +1,5 @@
+ /*
+-  Copyright (c) 1990-2009 Info-ZIP.  All rights reserved.
++  Copyright (c) 1990-2017 Info-ZIP.  All rights reserved.
+
+   See the accompanying file LICENSE, version 2009-Jan-02 or later
+   (the contents of which are also included in unzip.h) for terms of use.
+@@ -1582,6 +1582,8 @@
+     int r = IZ_PW_ENTERED;
+     char *m;
+     char *prompt;
++    char *ep;
++    char *zp;
+
+ #ifndef REENTRANT
+     /* tell picky compilers to shut up about "unused variable" warnings */
+@@ -1590,9 +1592,12 @@
+
+     if (*rcnt == 0) {           /* First call for current entry */
+         *rcnt = 2;
+-        if ((prompt = (char *)malloc(2*FILNAMSIZ + 15)) != (char *)NULL) {
+-            sprintf(prompt, LoadFarString(PasswPrompt),
+-                    FnFilter1(zfn), FnFilter2(efn));
++        zp = FnFilter1( zfn);
++        ep = FnFilter2( efn);
++        prompt = (char *)malloc(        /* Slightly too long (2* "%s"). */
++         sizeof( PasswPrompt)+ strlen( zp)+ strlen( ep));
++        if (prompt != (char *)NULL) {
++            sprintf(prompt, LoadFarString(PasswPrompt), zp, ep);
+             m = prompt;
+         } else
+             m = (char *)LoadFarString(PasswPrompt2);


### PR DESCRIPTION


Maintainer: @Noltari 
Compiled tested: cortexa53, Turris MOX, OpenWrt 18.06.1
Run tested: cortexa53, Turris MOX, OpenWrt 18.06.1

Description:
This patch fixes CVE-2018-1000035 https://nvd.nist.gov/vuln/detail/CVE-2018-1000035

Advisory from sec-consult https://sec-consult.com/en/blog/advisories/multiple-vulnerabilities-in-infozip-unzip/index.html

Patch is backported from 6.10c23: http://antinode.info/ftp/info-zip/unzip610c23.zip

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>
