### PR TITLE
measurement-kit: add new package

### DIFF
--- a/libs/libmaxminddb/Makefile
+++ b/libs/libmaxminddb/Makefile
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2019 CZ.NIC z.s.p.o. (http://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libmaxminddb
+PKG_VERSION:=1.3.2
+PKG_RELEASE=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/maxmind/libmaxminddb/releases/download/$(PKG_VERSION)/
+PKG_HASH:=e6f881aa6bd8cfa154a44d965450620df1f714c6dc9dd9971ad98f6e04f6c0f0
+
+PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libmaxminddb
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=A library for working with MaxMind DB files
+  URL:=https://maxmind.github.io/libmaxminddb/
+endef
+
+define Package/libmaxminddb/description
+ The libmaxminddb library provides functions for working MaxMind DB files.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmaxminddb.{a,so*} $(1)/usr/lib/
+endef
+
+define Package/libmaxminddb/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mmdblookup $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmaxminddb.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libmaxminddb))

--- a/libs/measurement-kit/Makefile
+++ b/libs/measurement-kit/Makefile
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2019 CZ.NIC z.s.p.o. (http://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=measurement-kit
+PKG_VERSION:=0.9.2
+PKG_RELEASE=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/measurement-kit/measurement-kit/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=b8e2624ba496c47164f3c15d35bb5e0a6c0f5e03b603e60ed9769156b1c7d82d
+
+PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/measurement-kit
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=C++14 library that implements open network measurement methodologies
+  URL:=https://measurement-kit.github.io/
+  DEPENDS:=+libstdcpp +libcurl +libevent2-pthreads +libevent2-extra +libevent2-openssl +libevent2-core +libmaxminddb +ca-bundle
+endef
+
+define Package/measurement-kit/description
+ Measurement Kit is a C++14 library that implements open network measurement methodologies (performance, censorship, etc.)
+endef
+
+CONFIGURE_ARGS+= --with-ca-bundle=/etc/ssl/cert.pem
+
+define Build/Configure
+	( cd $(PKG_BUILD_DIR); ./autogen.sh )
+	$(call Build/Configure/Default)
+endef
+
+define Package/measurement-kit/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/measurement_kit $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,measurement-kit))


### PR DESCRIPTION
Maintainer: me / @ja-pa  
Compiled tested: cortexa53, Turris MOX, OpenWrt 18.06.1
Run tested: cortexa53, Turris MOX, OpenWrt 18.06.1

Description:

Measurement-kit is library and tool that implements open network measurement methodologies (performance, censorship). It's useful for collecting information about network.
More https://measurement-kit.github.io/