### PR TITLE
geth: Update to 1.8.21

### DIFF
--- a/net/geth/Makefile
+++ b/net/geth/Makefile
@@ -11,12 +11,12 @@ PKG_LICENSE:=ASL-2.0
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 
 PKG_NAME:=go-ethereum
-PKG_VERSION:=1.8.20
+PKG_VERSION:=1.8.21
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ethereum/go-ethereum/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=7299f72a1d35a2653075a2070babf78f98f6eb3f41da43293304737ac0156658
+PKG_HASH:=736028b4babd44d67a70a4a7883a06e97263449805c8c067b7dfd77e9fa94299
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Emergency update as the planned upgrade went south.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mislavn
Compile tested: ramips
Run tested: ramips

Description:
From the release:

Geth 1.8.21 is an emergency hotfix release to postpone the mainnet Constantinople upgrade! The reason is a last minute reentrancy vulnerability dicovered by ChainSecurity.

If you don't feel comfortable with upgrading to Geth 1.8.21, you also have the option to:

    Downgrade to Geth 1.8.19; or
    Continue running Geth 1.8.20 using the --override.constantinople=9999999 flag.

