### PR TITLE
[RFC] LXC improvements

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=2.1.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=LGPL-2.1+ BSD-2-Clause GPL-2.0
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
@@ -278,6 +278,14 @@ define GenPlugin
   $$(eval $$(call BuildPackage,lxc-$(1)))
 endef
 
+define Package/lxc-autostart/install
+	$(INSTALL_DIR) $$(1)$(3)
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)$(3)/lxc-$(1) \
+		$$(1)$(3)/
+	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/lxc-autostart.init $(1)/etc/init.d/lxc-autostart
+endef
 
 $(eval $(call BuildPackage,lxc))
 $(eval $(call BuildPackage,lxc-common))

--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -141,8 +141,13 @@ endef
 
 CONFIGURE_ARGS += \
 	--disable-gnutls \
+	--disable-api-docs \
 	--disable-apparmor \
+	--disable-bash \
 	--disable-doc \
+	--disable-examples \
+	--disable-selinux \
+	--disable-cgmanager \
 	--disable-examples \
 	--enable-lua=yes \
 	--with-lua-pc="$(STAGING_DIR)/usr/lib/pkgconfig/lua.pc"

--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -56,7 +56,7 @@ endef
 define Package/lxc-auto
   $(call Package/lxc/Default)
   TITLE:= (initscript)
-  DEPENDS:=+lxc-start +lxc-stop
+  DEPENDS:=lxc +lxc-start +lxc-stop
 endef
 
 define Package/lxc-auto/description
@@ -73,7 +73,7 @@ endef
 define Package/lxc-unprivileged
   $(call Package/lxc/Default)
   TITLE:=Helper script for unprivileged containers support
-  DEPENDS:=+shadow-utils +shadow-newuidmap +shadow-newgidmap
+  DEPENDS:=lxc +shadow-utils +shadow-newuidmap +shadow-newgidmap
 endef
 
 define Package/lxc-unprivileged/description
@@ -135,7 +135,7 @@ endef
 
 define Package/lxc-init
   $(call Package/lxc/Default)
-  TITLE:=LXC Lua bindings
+  TITLE:=LXC internal init helper
   DEPENDS:= lxc +liblxc
 endef
 

--- a/utils/lxc/files/lxc-autostart.init
+++ b/utils/lxc/files/lxc-autostart.init
@@ -1,0 +1,21 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=00
+
+boot() {
+	lxc-autostart -g "onboot"
+	lxc-autostart -a
+}
+
+start() {
+	lxc-autostart -a
+}
+
+restart() {
+	lxc-autostart -r -a
+}
+
+stop() {
+	lxc-autostart -s -a -t 240
+}


### PR DESCRIPTION
Maintainer: @ratkaj
Compile tested: brcm2708 Raspberry Pi B+
Run tested: This is why it is RFC; not yet run tested.

Description:
* Add an initscript for lxc-autostart for LXC standard startup
* Fix some packages appearing outside the LXC menu in menuconfig
* Explicitly disable configure options we don't use to avoid picking up host headers / libs.