### PR TITLE
packages: add missing PKG_CPE_IDs for stunnel and keepalived

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -15,6 +15,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.keepalived.org/software
 PKG_HASH:=bce45d6d5cf3620bfd88472ec839a75b5a14a54fda12d09e890670244873b8ab
 
+PKG_CPE_ID:=cpe:/a:keepalived:keepalived
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Ben Kelly <ben@benjii.net> \

--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -14,6 +14,7 @@ PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0+
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE_FILES:=COPYING COPYRIGHT.GPL
+PKG_CPE_ID:=cpe:/a:stunnel:stunnel
 
 PKG_SOURCE_URL:= \
 	http://ftp.nluug.nl/pub/networking/stunnel/ \


### PR DESCRIPTION
Maintainer: me
Compile tested: -
Run tested: -

Description:
Update missing **PKG_CPE_ID**s for stunnel und keepalived