### PR TITLE
[RFC] python: python3: Split setup.py build_ext and install

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -21,6 +21,8 @@ PKG_HASH:=22d9b1ac5b26135ad2b8c2901a9413537e08749a753356ee913c84dbd2df5574
 PKG_LICENSE:=PSF
 PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
 
+PYTHON_PKG_OLD:=0
+
 # This file provides the necsessary host build variables
 include ../python-host.mk
 
@@ -238,6 +240,9 @@ define PyPackage/python-base/filespec
 +|/usr/bin/python$(PYTHON_VERSION)
 $(subst $(space),$(newline),$(foreach lib_file,$(PYTHON_BASE_LIB_FILES),+|$(lib_file)))
 endef
+
+PYTHON_PKG_install_ARGS:=
+PYTHON_PKG_build_ext_ARGS:=
 
 define PyPackage/python-light/filespec
 +|/usr/lib/python$(PYTHON_VERSION)

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -24,9 +24,10 @@ PKG_HASH:=d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb
 PKG_LICENSE:=PSF
 PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
 
+PYTHON3_PKG_OLD:=0
+
 # This file provides the necsessary host build variables
 include ../python3-host.mk
-
 # For Py3Package
 include ../python3-package.mk
 
@@ -97,6 +98,10 @@ PYTHON3_LIB_FILES_DEL:=
 PYTHON3_PACKAGES:=
 PYTHON3_SO_SUFFIX:=cpython-$(PYTHON3_VERSION_MAJOR)$(PYTHON3_VERSION_MINOR).so
 PYTHON3_PACKAGES_DEPENDS:=
+
+PYTHON3_PKG_install_ARGS:=
+PYTHON3_PKG_build_ext_ARGS:=
+
 define Py3BasePackage
   PYTHON3_PACKAGES+=$(1)
   ifeq ($(3),)


### PR DESCRIPTION
Make PyPackage and Py3Package more versatile (less per-package special
cases) by splitting setup.py build_ext and setup.py install.  This
allows to better control of compilation options of python modules with
native components.  While we're at it add variables to select the
subdirectory in which to run setup.py.

Because a number of python packages (including python itself) will
need to be changed to accomodate the new packaging, default to
the old packaging unless a package specifies PYTHON{3}_PKG_OLD:=0
before importing the python{3}-package.mk.

Also, to make converting easy, make the calls to install and
build_ext generic so that they can easily be omitted or replaced.
This also allows packages that buildpy build_ext to use this
new framework.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: @commodo 
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Separated from #7829 due to being rather significant modification.

The current version uses PKG_OLD framework in order to separate the changes in the build system from the changes to a large number of packages with customizations that break with this change to the build system (and the number of packages doing custom things is in fact a motivator for this, as it eliminates the need for most of them and turns most of the rest into variable assignments).

Will be adding examples of package breakage in the next few days (no rush on this; it probably shouldn't go in 19.01/19.02).
