### PR TITLE
telldus-core: Add new package.

### DIFF
--- a/utils/telldus-core/Makefile
+++ b/utils/telldus-core/Makefile
@@ -1,0 +1,61 @@
+# 
+# Copyright (C) 2010 Telldus Technologies AB
+#
+# This is free software, licensed under the GNU General Public License v2.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=telldus-core
+PKG_VERSION:=2.1.2
+PKG_RELEASE:=1
+
+PKG_LICENSE:=LGPL-2.1
+PKG_BUILD_DEPENDS:=argp-standalone 
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://download.telldus.com/TellStick/Software/telldus-core/
+PKG_HASH:=a20f6c74814afc23312d2c93ebbb37fdea9deaaee05ae7b6a6275e11e4662014
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/telldus-core
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=Telldus TellStick USB interface
+	URL:=http://www.telldus.com
+	MAINTAINER:=Peter Liedholm <PeterFromSwe884@gmail.com>
+	DEPENDS:=+confuse +libftdi +libstdcpp $(ICONV_DEPENDS)
+endef
+
+define Package/telldus-core/description
+	Telldus driver for USB-based 433 MHz RF transceiver for home automation.
+	MUST be built with full language support, (don't know how to DEPEND that)
+endef
+
+CMAKE_OPTIONS+=\
+	-DBUILD_LIBTELLDUS-CORE=1 \
+	-DBUILD_TDTOOL=1 \
+	-DGENERATE_MAN=0 \
+	-DICONV_LIBRARY=-liconv
+
+define Package/telldus-core/conffiles
+/etc/tellstick.conf
+endef
+
+define Package/telldus-core/install
+	$(INSTALL_DIR)  $(1)/usr/bin
+	$(INSTALL_BIN)  $(PKG_INSTALL_DIR)/usr/bin/tdtool $(1)/usr/bin
+	$(INSTALL_DIR)  $(1)/usr/sbin
+	$(INSTALL_BIN)  $(PKG_INSTALL_DIR)/usr/sbin/telldusd $(1)/usr/sbin
+	$(INSTALL_BIN)  $(PKG_INSTALL_DIR)/usr/sbin/tdadmin $(1)/usr/sbin
+	$(INSTALL_DIR)  $(1)/usr/lib
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libtelldus* $(1)/usr/lib
+	$(INSTALL_DIR)  $(1)/etc/config
+	$(INSTALL_CONF) ./files/tellstick.conf $(1)/etc
+	$(INSTALL_DIR)  $(1)/etc/init.d
+	$(INSTALL_BIN)  ./files/telldusd $(1)/etc/init.d
+endef
+
+$(eval $(call BuildPackage,telldus-core))

--- a/utils/telldus-core/files/telldusd
+++ b/utils/telldus-core/files/telldusd
@@ -1,0 +1,20 @@
+#!/bin/sh /etc/rc.common
+
+
+START=99
+
+USE_PROCD=1
+PROG=/usr/sbin/telldusd
+CONFFILE=/etc/tellstick.conf
+
+start_service() {
+	procd_open_instance
+	procd_set_param command $PROG
+	procd_append_param command --nodaemon # foreground required by procd
+	procd_set_param file $CONFFILE
+	procd_set_param term_timeout 10 # telldusd is slow to exit of some reason
+	procd_set_param respawn  # respawn the service if it exits
+	procd_set_param stdout 1 # forward stdout of the command to logd
+	procd_set_param stderr 1 # same for stderr
+	procd_close_instance
+}

--- a/utils/telldus-core/files/tellstick.conf
+++ b/utils/telldus-core/files/tellstick.conf
@@ -1,0 +1,21 @@
+user = "root"
+group = "root"
+ignoreControllerConfirmation = "false"
+device {
+  id = 1
+  name = "Example device"
+  protocol = "arctech"
+  model = "codeswitch"
+  parameters {
+    house = "A"
+    unit = "1"
+  }
+}
+
+# Example controller (tellstick duo)
+#controller {
+  #id=1
+  # name=""
+  #type=2
+  #serial="A501IVK7"
+#}

--- a/utils/telldus-core/patches/100-add_includes.patch
+++ b/utils/telldus-core/patches/100-add_includes.patch
@@ -1,0 +1,21 @@
+Added missing includes required by openwrt. Expected to be portable.
+--- a/common/Socket_unix.cpp
++++ b/common/Socket_unix.cpp
+@@ -8,6 +8,7 @@
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <sys/socket.h>
++#include <sys/select.h> // POSIX.1-2001
+ #include <sys/un.h>
+ #include <fcntl.h>
+ #include <math.h>
+--- a/service/ConnectionListener_unix.cpp
++++ b/service/ConnectionListener_unix.cpp
+@@ -13,6 +13,7 @@
+ #include <fcntl.h>
+ #include <errno.h>
+ #include <string>
++#include <cstring> // strcpy
+ 
+ #include "service/ConnectionListener.h"
+ #include "common/Socket.h"

--- a/utils/telldus-core/patches/110-fix_warnings.patch
+++ b/utils/telldus-core/patches/110-fix_warnings.patch
@@ -1,0 +1,23 @@
+Added a typecast (signed/unsigned char problem). Should be portable.
+--- a/service/ProtocolIkea.cpp
++++ b/service/ProtocolIkea.cpp
+@@ -23,7 +23,7 @@ int ProtocolIkea::methods() const {
+ 
+ std::string ProtocolIkea::getStringForMethod(int method, unsigned char level, Controller *) {
+ 	const char B1[] = {84, 84, 0};
+-	const char B0[] = {170, 0};
++	const char B0[] = {(char)170, 0};
+ 
+ 	int intSystem = this->getIntParameter(L"system", 1, 16)-1;
+ 	int intFadeStyle = TelldusCore::comparei(this->getStringParameter(L"fade", L"true"), L"true");
+--- a/service/ProtocolX10.cpp
++++ b/service/ProtocolX10.cpp
+@@ -22,7 +22,7 @@ int ProtocolX10::methods() const {
+ std::string ProtocolX10::getStringForMethod(int method, unsigned char data, Controller *controller) {
+ 	const unsigned char S = 59, L = 169;
+ 	const char B0[] = {S, S, 0};
+-	const char B1[] = {S, L, 0};
++	const char B1[] = {S, (char)L, 0};
+ 	const unsigned char START_CODE[] = {'S', 255, 1, 255, 1, 255, 1, 100, 255, 1, 180, 0};
+ 	const unsigned char STOP_CODE[] = {S, 0};
+ 

--- a/utils/telldus-core/patches/120-fix_missing_var_conf.patch
+++ b/utils/telldus-core/patches/120-fix_missing_var_conf.patch
@@ -1,0 +1,11 @@
+Added a missing initialisation that under special circumstanses causes seg fault.
+--- a/service/SettingsConfuse.cpp
++++ b/service/SettingsConfuse.cpp
+@@ -435,6 +435,7 @@ bool readVarConfig(cfg_t **cfg) {
+ 
+ 	FILE *fp = fopen(VAR_CONFIG_FILE, "re");  // e for setting O_CLOEXEC on the file handle
+ 	if (!fp) {
++		(*cfg) = 0;
+ 		Log::warning("Unable to open var config file, %s", VAR_CONFIG_FILE);
+ 		return false;
+ 	}

--- a/utils/telldus-core/patches/900-openwrt_fixes_cmake.patch
+++ b/utils/telldus-core/patches/900-openwrt_fixes_cmake.patch
@@ -1,0 +1,45 @@
+Adopted to OpenWrt target. Most likely these changes go elsewhere when done right.
+--- a/service/CMakeLists.txt
++++ b/service/CMakeLists.txt
+@@ -98,7 +98,7 @@ IF (UNIX AND NOT APPLE)
+ 	IF (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+ 		SET(DEFAULT_STATE_INSTALL_DIR "/var/spool")
+ 	ELSE ()
+-		SET(DEFAULT_STATE_INSTALL_DIR "/var/state")
++		SET(DEFAULT_STATE_INSTALL_DIR "/tmp/state") # OpenWrt has var as symlink to tmp
+ 	ENDIF ()
+ 	SET(STATE_INSTALL_DIR "${DEFAULT_STATE_INSTALL_DIR}" CACHE PATH "The directory to store state information of the devices")
+ 
+--- a/tdadmin/CMakeLists.txt
++++ b/tdadmin/CMakeLists.txt
+@@ -38,8 +38,11 @@ ELSEIF (CMAKE_SYSTEM_NAME MATCHES "FreeB
+ 		${ARGP_LIBRARY}
+ 	)
+ ELSE (WIN32)
++	# Linux, in this case openwrt that requires argp-standalone
++	FIND_LIBRARY(ARGP_LIBRARY argp)
+ 	TARGET_LINK_LIBRARIES(tdadmin
+ 		${CMAKE_BINARY_DIR}/client/libtelldus-core.so
++		${ARGP_LIBRARY}
+ 	)
+ ENDIF (WIN32)
+ 
+--- a/common/CMakeLists.txt
++++ b/common/CMakeLists.txt
+@@ -66,12 +66,16 @@ ELSEIF (CMAKE_SYSTEM_NAME MATCHES "FreeB
+ 	)
+ ELSE (APPLE)
+ 	#### Linux ####
++	#FIND_LIBRARY(ICONV_LIBRARY iconv) Does not work
+ 	ADD_DEFINITIONS( -D_LINUX )
+ 	LIST(APPEND  telldus-common_SRCS
+ 		Event_unix.cpp
+ 		EventHandler_unix.cpp
+ 		Socket_unix.cpp
+ 	)
++	LIST(APPEND telldus-common_LIBRARIES
++		${ICONV_LIBRARY}
++	)
+ ENDIF (APPLE)
+ 
+ 

--- a/utils/telldus-core/patches/920-openwrt_missing_var_conf.patch
+++ b/utils/telldus-core/patches/920-openwrt_missing_var_conf.patch
@@ -1,0 +1,18 @@
+On OpenWrt targets the tmp filesystem is wiped upon power cycle, so files 
+requires to be created.
+--- a/service/SettingsConfuse.cpp
++++ b/service/SettingsConfuse.cpp
+@@ -436,6 +436,13 @@ bool readVarConfig(cfg_t **cfg) {
+ 	FILE *fp = fopen(VAR_CONFIG_FILE, "re");  // e for setting O_CLOEXEC on the file handle
+ 	if (!fp) {
+ 		(*cfg) = 0;
++		fp = fopen(VAR_CONFIG_FILE, "we"); // If missing, create file if possible
++		if(fp) {
++			fclose(fp);
++		}
++		else {
++			Log::warning("Unable to create var config file, %s", VAR_CONFIG_FILE);
++		}
+ 		Log::warning("Unable to open var config file, %s", VAR_CONFIG_FILE);
+ 		return false;
+ 	}


### PR DESCRIPTION
Maintainer: me
Compile tested: mips_24kc, arm_cortex-a9_cfpv3, Openwrt v18.06.1
Run tested: mips_24kc, arm_cortex-a9_cfpv3

Description:
telldus-core is driver and utilities to control NEXA and other 433 MHz RF remote receivers /sensors through a TellStick USB interface.
http://telldus.com

Signed-off-by: Peter Liedholm PeterFromSwe884@gmail.com