### PR TITLE
net/safe-search Add duckduckgo.com

### DIFF
--- a/net/safe-search/Makefile
+++ b/net/safe-search/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=safe-search
-PKG_VERSION:=1.0.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.1
+PKG_RELEASE:=1
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Gregory L. Dietsche <Gregory.Dietsche@cuw.edu>
 

--- a/net/safe-search/Readme.md
+++ b/net/safe-search/Readme.md
@@ -2,18 +2,24 @@
 
 This package prevents adult content from appearing in search results by
 configuring dnsmasq to force all devices on your network to use Google and
-Bing's Safe Search IP addresses. This is designed to be approperiate for most
+Bing's Safe Search IP addresses. This is designed to be appropriate for most
 businesses and families. The default filtering rules do not interfere with
 normal web browsing.
 
-Currently supported:
-- Google Safe Search - enabled by default
-    - https://support.google.com/websearch/answer/186669
-- Bing Safe Search - enabled by default
-    -  https://help.bing.microsoft.com/#apex/18/en-US/10003/0
-- youtube Safe Search
-    - https://support.google.com/a/answer/6214622
-    - https://support.google.com/a/answer/6212415
-    - https://www.youtube.com/check_content_restrictions
-    - Not enabled by default because it is designed for children.
-    - Enable by editing /etc/config/safe-search and then run safe-search-update
+Enabled and disable Safe Search by editing /etc/config/safe-search . To make
+your changes active, run safe-search-update.
+
+Currently Supported:
+- Enabled By Default
+    - www.bing.com Safe Search
+        -  https://help.bing.microsoft.com/#apex/18/en-US/10003/0
+    - DuckDuckGo.com Safe Search
+        - https://duck.co/help/features/safe-search
+    - www.Google.com Safe Search
+        - https://support.google.com/websearch/answer/186669
+- Not Enabled By Default:
+    - youtube Safe Search
+        - https://support.google.com/a/answer/6214622
+        - https://support.google.com/a/answer/6212415
+        - https://www.youtube.com/check_content_restrictions
+        - Not enabled because it is designed for children, and may annoy adults...

--- a/net/safe-search/files/hosts/duckduckgo.default
+++ b/net/safe-search/files/hosts/duckduckgo.default
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2019 Gregory L. Dietsche <Gregory.Dietsche@cuw.edu>
+# This is free software, licensed under the MIT License
+#
+
+#
+# IMPORTANT: if this file is not working, make sure that dnsmasq is able to READ it!
+#
+
+#50.16.250.179 safe.duckduckgo.com
+#54.208.102.2 safe.duckduckgo.com
+#52.204.96.252 safe.duckduckgo.com
+
+50.16.250.179 duckduckgo.com
+54.208.102.2 duckduckgo.com
+52.204.96.252 duckduckgo.com

--- a/net/safe-search/files/safe-search.conf
+++ b/net/safe-search/files/safe-search.conf
@@ -8,6 +8,9 @@
 config safe-search 'bing'
 	option enabled 1
 
+config safe-search 'duckduckgo'
+	option enabled 1
+
 config safe-search 'google'
 	option enabled 1
 


### PR DESCRIPTION
Signed-off-by: Gregory L. Dietsche <gregory.dietsche@cuw.edu>

Maintainer: me
Compile tested: x86 Openwrt 18.06.1
Run tested: TP-Link Archer C7 upgrade/install/uninstall

Description: Add DuckDuckGo search engine to safe search.
