### PR TITLE
Golang: Use upx to compress files by default

### DIFF
--- a/lang/golang/golang-package.mk
+++ b/lang/golang/golang-package.mk
@@ -280,6 +280,7 @@ define GoPackage/Package/Install/Bin
 	if [ -n "$(call GoPackage/has_binaries)" ]; then \
 		$(INSTALL_DIR) $(1)/usr/bin ; \
 		$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/* $(1)/usr/bin/ ; \
+		upx --lzma -9 $(1)/usr/bin/* ; \
 	fi
 endef
 


### PR DESCRIPTION
Golang generated files are usually larger,
this is very unfriendly for small Flash devices
Signed-off-by: lrinQVQ <cqlrin@gmail.com>

Maintainer: @jefferyto
Compile tested: (ipq40xx, Asus RT-AC58U, OpenWrt master)
Run tested: (ipq40xx, Asus RT-AC58U, OpenWrt SNAPSHOT r9060+19-4029788ff3, tests done)

Description:
See details: https://github.com/openwrt/openwrt/pull/1751