### PR TITLE
aggregate: respect CFLAGS, LDFLAGS

### DIFF
--- a/net/aggregate/Makefile
+++ b/net/aggregate/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aggregate
 PKG_VERSION:=1.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/aggregate/

--- a/net/aggregate/patches/500-cross_compile_flags.patch
+++ b/net/aggregate/patches/500-cross_compile_flags.patch
@@ -1,0 +1,14 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -25,8 +25,9 @@
+ INSTALL = @INSTALL@
+ DEFS = @DEFS@
+ LIBS = @LIBS@
+-CFLAGS = -O
+-LDFLAGS = -s
++CFLAGS = @CFLAGS@
++CPPFLAGS = @CPPFLAGS@
++LDFLAGS = @LDFLAGS@
+ prefix = @prefix@
+ 
+ SHELL = /bin/sh


### PR DESCRIPTION
Maintainer: @nikil 
Compile tested: arm, mipsel
Run tested: [on Entware repo](https://github.com/Entware/entware-packages/tree/master/net/aggregate)

Description: do not ignore `CFLAGS`, `CPPFLAGS` and `LDFLAGS` during cross-compilation.