### PR TITLE
hdparm: Fix LDFLAGS

### DIFF
--- a/utils/hdparm/Makefile
+++ b/utils/hdparm/Makefile
@@ -10,7 +10,6 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=hdparm
 PKG_VERSION:=9.58
 PKG_RELEASE:=1
-PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
@@ -20,8 +19,6 @@ PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
 PKG_LICENSE:=BSD-Style Open Source License
 
 include $(INCLUDE_DIR)/package.mk
-
-TARGET_CFLAGS+=-D_GNU_SOURCE
 
 define Package/hdparm
   SECTION:=utils

--- a/utils/hdparm/patches/010-ldflags.patch
+++ b/utils/hdparm/patches/010-ldflags.patch
@@ -1,0 +1,13 @@
+--- a/Makefile
++++ b/Makefile
+@@ -13,9 +13,8 @@ oldmandir = $(manprefix)/man
+ CC ?= gcc
+ STRIP ?= strip
+ 
+-CFLAGS := -O2 -W -Wall -Wbad-function-cast -Wcast-align -Wpointer-arith -Wcast-qual -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -fkeep-inline-functions -Wwrite-strings -Waggregate-return -Wnested-externs -Wtrigraphs $(CFLAGS)
++CFLAGS ?= -O2 -W -Wall -Wbad-function-cast -Wcast-align -Wpointer-arith -Wcast-qual -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -fkeep-inline-functions -Wwrite-strings -Waggregate-return -Wnested-externs -Wtrigraphs $(CFLAGS)
+ 
+-LDFLAGS = -s
+ #LDFLAGS = -s -static
+ INSTALL = install
+ INSTALL_DATA = $(INSTALL) -m 644


### PR DESCRIPTION
Based on debian patch. LDFLAGS were not being passed, which caused relro
to not be applies.

Also made stock CFLAGS optional. -fkeep-inline was keeping sizes high.

Removed PKG_NO_MIPS16 as the original problem seems to be gone.

Size from 54338 to 50761

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me
Compile tested: ramips
Run tested: ramips GnuBee PC1