### PR TITLE
git: Fix gitweb missing dependency

### DIFF
--- a/net/git/Makefile
+++ b/net/git/Makefile
@@ -56,7 +56,16 @@ endef
 define Package/git-gitweb
 $(call Package/git/Default)
   TITLE:=Git repository web interface
-  DEPENDS+= +git +perlbase-essential +perlbase-file +perlbase-fcntl +perlbase-encode +perlbase-digest +perlbase-time +perl-cgi
+  DEPENDS+=	+git \
+		+perl-cgi \
+		+perlbase-digest \
+		+perlbase-encode \
+		+perlbase-essential \
+		+perlbase-fcntl \
+		+perlbase-file \
+		+perlbase-filetest \
+		+perlbase-storable \
+		+perlbase-time
 endef
 
 define Package/git-gitweb/description


### PR DESCRIPTION
gitweb is missing a dependency on perlbase-filetest (gitweb fails to launch
without it).

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: @tripolar 
Compile tested: ath79, WNDR3800
Run tested: ath79, WNDR3800

Verified gitweb shows projects after sysupgrade (previous there'd be a an error message in the browser, and logread/syslog would show an @INC error on filetest module).