### PR TITLE
lxc: Disable use of unwanted libraries explicity

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -140,10 +140,13 @@ define Package/lxc-init
 endef
 
 CONFIGURE_ARGS += \
-	--disable-gnutls \
 	--disable-apparmor \
+	--disable-cgmanager \
 	--disable-doc \
 	--disable-examples \
+	--disable-gnutls \
+	--disable-selinux \
+	--disable-python \
 	--enable-lua=yes \
 	--with-lua-pc="$(STAGING_DIR)/usr/lib/pkgconfig/lua.pc"
 


### PR DESCRIPTION
Otherwise one gets a failure if the libraries (e.g. Python
header file) exist in the build system.  Worse in some cases
is host headers being found if one doesn't specifically
disable a library search in autotools.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: @ratkaj 
Compile tested: ath79, (WNDR3800 and CR5000)
Run tested: TBD
