### PR TITLE
openldap-server: enable crypt(3) passwords

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
 PKG_VERSION:=2.4.47
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://gpl.savoirfairelinux.net/pub/mirrors/openldap/openldap-release/ \
@@ -24,6 +24,7 @@ PKG_FIXUP:=autoreconf
 
 PKG_CONFIG_DEPENDS := \
         CONFIG_OPENLDAP_DEBUG \
+        CONFIG_OPENLDAP_CRYPT \
         CONFIG_OPENLDAP_MONITOR \
         CONFIG_OPENLDAP_DB47 \
         CONFIG_OPENLDAP_ICU
@@ -53,6 +54,25 @@ define Package/libopenldap/config
 	help
 		Enable debugging information. This option must be enabled
 		for the loglevel directive to work.
+  config OPENLDAP_CRYPT
+	bool "Crypt(3) passwords support"
+	default n
+	help
+		With crypt(3) password storage scheme enabled, OpenLDAP can
+		receive and store SHA-256 and SHA-512 password hashes from
+		Samba AD-DC. If this option is disabled, synchronization of
+		passwords between Samba AD-DC (v4.5 and above) and OpenLDAP
+		requires use of cleartext passwords.
+		To enable crypt(3) password synchronization functionality:
+		1. Re-include crypt(3) support in OpenWRT by enabling 'Include
+		crypt() support for SHA256, SHA512 and Blowfish ciphers' option
+		in "Advanced configuration options (for developers)" ->
+		"Toolchain Options".
+		2. Provision AD-DC with 'password hash userPassword schemes'
+		option. For more information, see smb.conf manpage for details
+		on 'password hash userPassword schemes'.
+		3. Use a script to synchronize passwords from AD-DC to
+		OpenLDAP. See samba-tool manpage for 'user syncpasswords'.
   config OPENLDAP_MONITOR
 	bool "Enable monitor backend"
 	default n
@@ -120,6 +140,12 @@ CONFIGURE_ARGS += \
 	--enable-null \
 	--disable-relay
 
+
+ifdef CONFIG_OPENLDAP_CRYPT
+	CONFIGURE_ARGS+= --enable-crypt
+else
+	CONFIGURE_ARGS+= --disable-crypt
+endif
 
 ifdef CONFIG_OPENLDAP_MONITOR
 	CONFIGURE_ARGS+= --enable-monitor


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: x86_64, OpenWRT virtual machine (VirtualBox), OpenWrt SNAPSHOT r9103-45a2771
Run tested: x86_64, OpenWRT virtual machine (VirtualBox), OpenWrt SNAPSHOT r9103-45a2771

Description:

Since 4.7, Samba can store SHA-256 and SHA-512 password hashes and use them to synchronize passwords with OpenLDAP directories and other authentication systems and therefore avoid the use of cleartext passwords. This Samba functionality is controlled by the new config option, 'password hash userPassword schemes'. See smb.conf manpage for more details.

To use password hashes from Samba, OpenLDAP must be compiled with --enable-crypt switch. This patch introduces a new configuration parameter to enable or disable the use of crypt(3) function by OpenLDAP.

Enabling crypt(3) increases the size of slapd binary by 12 bytes on the x86_64 target and by only 4 bytes on the ipq806x target. As the size increase is truly negligible, the use of crypt(3) has been enabled
by default. There are no known downsides from enabling crypt(3) by default.

It should be noted that of the four encryption methods provided by crypt(3), the standard OpenWrt build removes three by way of toolchain/musl/patches/901-crypt_size_hack.patch to reduce image size. This removal leaves only MD5 available. Users who want to employ the SHA256 and SHA512 methods provided by crypt(3) may do so by manually removing 901-crypt_size_hack.patch.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>
