### PR TITLE
adblock: bugfix 3.6.4

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.6.3
+PKG_VERSION:=3.6.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL-AR750S, OpenWrt SNAPSHOT r9103-45a2771953

Description:
* respect 'adb_report' option to enable/disable adblock reporting
  (incl. tcpdump background process)
* other reporting related corner case fixes

Signed-off-by: Dirk Brenken <dev@brenken.org>