### PR TITLE
avrdude: change libelf1 dependency to libelf

### DIFF
--- a/utils/avrdude/Makefile
+++ b/utils/avrdude/Makefile
@@ -31,7 +31,7 @@ define Package/avrdude
   SUBMENU:=Microcontroller programming
   TITLE:=AVR Downloader/UploaDEr
   URL:=http://www.nongnu.org/avrdude/
-  DEPENDS:=+libncurses +libreadline +libusb-compat +libftdi1 +libelf1
+  DEPENDS:=+libncurses +libreadline +libusb-compat +libftdi1 +libelf
 endef
 
 define Package/avrdude/description


### PR DESCRIPTION
The libelf1 source package has been renamed to libelf in OpenWrt base,
adjust the dependency in avrdude accordingly.

There are no functional changes and no changes in the resulting binary.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
