### PR TITLE
at: change libelf1 dependency to libelf

### DIFF
--- a/utils/at/Makefile
+++ b/utils/at/Makefile
@@ -24,7 +24,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/at
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libelf1
+  DEPENDS:=+libelf
   TITLE:=Delayed job execution and batch processing
   URL:=http://packages.debian.org/stable/at
 endef


### PR DESCRIPTION
Maintainer: @philenotfound 
Compile tested: mips_24kc
Run tested: -

Description:

The libelf1 source package has been renamed to libelf in OpenWrt base,
adjust the dependency in "at" accordingly.

There are no functional changes and no changes in the resulting binary.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>