### PR TITLE
travelmate: bugfix 1.3.4

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.3.3
+PKG_VERSION:=1.3.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL-AR750S, OpenWrt SNAPSHOT r9103-45a2771953

Description:
* fix runtime behaviour with empty scan results on radioX
* fix radiolist preparation (prevent dups)
* further optimize 'ProActive' mode

Signed-off-by: Dirk Brenken <dev@brenken.org>