### PR TITLE
python-cryptodome: add new package

### DIFF
--- a/lang/python/python-cryptodome/Makefile
+++ b/lang/python/python-cryptodome/Makefile
@@ -1,0 +1,75 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-cryptodome
+PKG_VERSION:=3.7.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=pycryptodome-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pycryptodome
+PKG_HASH:=1a222250e43f3c659b4ebd5df3e11c2f112aab6aef58e38af55ef5678b9f0636
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cryptodome-$(PKG_VERSION)
+
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE.rst
+PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+PYTHON_PKG_SETUP_ARGS:=
+PYTHON_PKG_SETUP_VARS:= \
+  CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)"
+
+PYTHON3_PKG_SETUP_ARGS:=
+PYTHON3_PKG_SETUP_VARS:= \
+  CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)"
+
+define Package/python-cryptodome/Default
+  SECTION:=lang-python
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=A self-contained cryptographic library for Python
+  URL:=https://www.pycryptodome.org/
+  DEPENDS:=+libgmp
+endef
+
+define Package/python-cryptodome
+$(call Package/python-cryptodome/Default)
+  DEPENDS+=+PACKAGE_python-cryptodome:python
+  VARIANT:=python
+  CONFLICTS:=python-crypto
+endef
+
+define Package/python3-cryptodome
+$(call Package/python-cryptodome/Default)
+  DEPENDS+=+PACKAGE_python3-cryptodome:python3
+  VARIANT:=python3
+  CONFLICTS:=python3-crypto
+endef
+
+define Package/python-cryptodome/description
+PyCryptodome is a self-contained Python package of low-level
+cryptographic primitives.
+endef
+
+define Package/python3-cryptodome/description
+$(call Package/python-cryptodome/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-cryptodome))
+$(eval $(call BuildPackage,python-cryptodome))
+$(eval $(call BuildPackage,python-cryptodome-src))
+
+$(eval $(call Py3Package,python3-cryptodome))
+$(eval $(call BuildPackage,python3-cryptodome))
+$(eval $(call BuildPackage,python3-cryptodome-src))

--- a/lang/python/python-cryptodome/patches/001-fix-libgmp-loading.patch
+++ b/lang/python/python-cryptodome/patches/001-fix-libgmp-loading.patch
@@ -1,0 +1,11 @@
+--- a/lib/Crypto/Math/_IntegerGMP.py
++++ b/lib/Crypto/Math/_IntegerGMP.py
+@@ -92,7 +92,7 @@ gmp_defs = """typedef unsigned long UNIX_ULONG;
+         int __gmpz_divisible_ui_p (const mpz_t n, UNIX_ULONG d);
+         """
+ 
+-lib = load_lib("gmp", gmp_defs)
++lib = load_lib("libgmp.so.10", gmp_defs)
+ implementation = {"library": "gmp", "api": backend}
+ 
+ if hasattr(lib, "__mpir_version"):

--- a/lang/python/python-cryptodome/patches/002-omit-tests.patch
+++ b/lang/python/python-cryptodome/patches/002-omit-tests.patch
@@ -1,0 +1,50 @@
+--- a/setup.py
++++ b/setup.py
+@@ -245,16 +245,6 @@
+     "Crypto.Signature",
+     "Crypto.Util",
+     "Crypto.Math",
+-    "Crypto.SelfTest",
+-    "Crypto.SelfTest.Cipher",
+-    "Crypto.SelfTest.Hash",
+-    "Crypto.SelfTest.IO",
+-    "Crypto.SelfTest.Protocol",
+-    "Crypto.SelfTest.PublicKey",
+-    "Crypto.SelfTest.Random",
+-    "Crypto.SelfTest.Signature",
+-    "Crypto.SelfTest.Util",
+-    "Crypto.SelfTest.Math",
+ ]
+ package_dir = {"Crypto": "lib/Crypto"}
+ package_data = {
+@@ -268,30 +258,6 @@
+     "Crypto.Signature" : [ "*.pyi" ],
+     "Crypto.IO" : [ "*.pyi" ],
+     "Crypto.Util" : [ "*.pyi" ],
+-    "Crypto.SelfTest.Cipher" : [
+-        "test_vectors/AES/*.rsp",
+-        "test_vectors/TDES/*.rsp",
+-        "test_vectors/wycheproof/*.json",
+-    ],
+-    "Crypto.SelfTest.Hash" : [
+-        "test_vectors/SHA1/*.rsp",
+-        "test_vectors/SHA2/*.rsp",
+-        "test_vectors/SHA3/*.txt",
+-        "test_vectors/keccak/*.txt",
+-        "test_vectors/BLAKE2s/*.txt",
+-        "test_vectors/BLAKE2b/*.txt",
+-        "test_vectors/wycheproof/*.json",
+-    ],
+-    "Crypto.SelfTest.Signature" : [
+-        "test_vectors/DSA/*.*",
+-        "test_vectors/ECDSA/*.*",
+-        "test_vectors/PKCS1-v1.5/*.*",
+-        "test_vectors/PKCS1-PSS/*.*",
+-        "test_vectors/wycheproof/*.json",
+-    ],
+-    "Crypto.SelfTest.PublicKey" : [
+-        "test_vectors/ECC/*.*",
+-    ],
+ }
+ 
+ system_bits = 8 * struct.calcsize("P")

--- a/lang/python/python-cryptodomex/Makefile
+++ b/lang/python/python-cryptodomex/Makefile
@@ -1,0 +1,73 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-cryptodomex
+PKG_VERSION:=3.7.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=pycryptodomex-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pycryptodomex
+PKG_HASH:=b70fe991564e178af02ccf89435a8f9e8d052707a7c4b95bf6027cb785da3175
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cryptodomex-$(PKG_VERSION)
+
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE.rst
+PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+PYTHON_PKG_SETUP_ARGS:=
+PYTHON_PKG_SETUP_VARS:= \
+  CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)"
+
+PYTHON3_PKG_SETUP_ARGS:=
+PYTHON3_PKG_SETUP_VARS:= \
+  CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)"
+
+define Package/python-cryptodomex/Default
+  SECTION:=lang-python
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=A self-contained cryptographic library for Python
+  URL:=https://www.pycryptodome.org/
+  DEPENDS:=+libgmp
+endef
+
+define Package/python-cryptodomex
+$(call Package/python-cryptodomex/Default)
+  DEPENDS+=+PACKAGE_python-cryptodomex:python
+  VARIANT:=python
+endef
+
+define Package/python3-cryptodomex
+$(call Package/python-cryptodomex/Default)
+  DEPENDS+=+PACKAGE_python3-cryptodomex:python3
+  VARIANT:=python3
+endef
+
+define Package/python-cryptodomex/description
+PyCryptodome is a self-contained Python package of low-level
+cryptographic primitives.
+endef
+
+define Package/python3-cryptodomex/description
+$(call Package/python-cryptodomex/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-cryptodomex))
+$(eval $(call BuildPackage,python-cryptodomex))
+$(eval $(call BuildPackage,python-cryptodomex-src))
+
+$(eval $(call Py3Package,python3-cryptodomex))
+$(eval $(call BuildPackage,python3-cryptodomex))
+$(eval $(call BuildPackage,python3-cryptodomex-src))

--- a/lang/python/python-cryptodomex/patches/001-fix-libgmp-loading.patch
+++ b/lang/python/python-cryptodomex/patches/001-fix-libgmp-loading.patch
@@ -1,0 +1,11 @@
+--- a/lib/Cryptodome/Math/_IntegerGMP.py
++++ b/lib/Cryptodome/Math/_IntegerGMP.py
+@@ -92,7 +92,7 @@ gmp_defs = """typedef unsigned long UNIX_ULONG;
+         int __gmpz_divisible_ui_p (const mpz_t n, UNIX_ULONG d);
+         """
+ 
+-lib = load_lib("gmp", gmp_defs)
++lib = load_lib("libgmp.so.10", gmp_defs)
+ implementation = {"library": "gmp", "api": backend}
+ 
+ if hasattr(lib, "__mpir_version"):

--- a/lang/python/python-cryptodomex/patches/002-omit-tests.patch
+++ b/lang/python/python-cryptodomex/patches/002-omit-tests.patch
@@ -1,0 +1,50 @@
+--- a/setup.py
++++ b/setup.py
+@@ -245,16 +245,6 @@
+     "Crypto.Signature",
+     "Crypto.Util",
+     "Crypto.Math",
+-    "Crypto.SelfTest",
+-    "Crypto.SelfTest.Cipher",
+-    "Crypto.SelfTest.Hash",
+-    "Crypto.SelfTest.IO",
+-    "Crypto.SelfTest.Protocol",
+-    "Crypto.SelfTest.PublicKey",
+-    "Crypto.SelfTest.Random",
+-    "Crypto.SelfTest.Signature",
+-    "Crypto.SelfTest.Util",
+-    "Crypto.SelfTest.Math",
+ ]
+ package_dir = {"Crypto": "lib/Crypto"}
+ package_data = {
+@@ -268,30 +258,6 @@
+     "Crypto.Signature" : [ "*.pyi" ],
+     "Crypto.IO" : [ "*.pyi" ],
+     "Crypto.Util" : [ "*.pyi" ],
+-    "Crypto.SelfTest.Cipher" : [
+-        "test_vectors/AES/*.*",
+-        "test_vectors/TDES/*.*",
+-        "test_vectors/wycheproof/*.*",
+-    ],
+-    "Crypto.SelfTest.Hash" : [
+-        "test_vectors/SHA1/*.*",
+-        "test_vectors/SHA2/*.*",
+-        "test_vectors/SHA3/*.*",
+-        "test_vectors/keccak/*.*",
+-        "test_vectors/BLAKE2s/*.*",
+-        "test_vectors/BLAKE2b/*.*",
+-        "test_vectors/wycheproof/*.*",
+-    ],
+-    "Crypto.SelfTest.Signature" : [
+-        "test_vectors/DSA/*.*",
+-        "test_vectors/ECDSA/*.*",
+-        "test_vectors/PKCS1-v1.5/*.*",
+-        "test_vectors/PKCS1-PSS/*.*",
+-        "test_vectors/wycheproof/*.*",
+-    ],
+-    "Crypto.SelfTest.PublicKey" : [
+-        "test_vectors/ECC/*.*",
+-    ],
+ }
+ 
+ system_bits = 8 * struct.calcsize("P")


### PR DESCRIPTION
Maintainer: me
Compile tested: [openwrt-sdk-18.06.1-ramips-mt7621_gcc-7.3.0_musl.Linux-x86_64](https://downloads.openwrt.org/releases/18.06.1/targets/ramips/mt7621/openwrt-sdk-18.06.1-ramips-mt7621_gcc-7.3.0_musl.Linux-x86_64.tar.xz)
Run tested: openwrt-18.06.1-ramips-mt7621-mir3g
Tested with `python3 -m Crypto.SelfTest`
Test output:
```
Skipping AESNI tests
Skipping test of PCLMULDQD in AES GCM
...
Ran 23457 tests in 4538.036s
```

Description:
[PyCryptodome](https://www.pycryptodome.org) is an almost drop-in replacement for the old PyCrypto library.

PyCryptodome uses libgmp for faster public key operations, but it's not
required. And there's an issue about Python's ctypes.util.find_library,
making pycryptodome failed to load libgmp. So I don't add libgmp as
dependency.

Python uses `ld` to get library path and `objdump` to get library's `SONAME`.
https://github.com/python/cpython/blob/1edb3dc6ff70db88a7e89586578e58a86ee0e75e/Lib/ctypes/util.py#L278-L303
https://github.com/python/cpython/blob/1edb3dc6ff70db88a7e89586578e58a86ee0e75e/Lib/ctypes/util.py#L149-L169

However, `ld` is not available in OpenWrt and `objdump` can't read `SONAME` from shared object.
My workaround to get libgmp working is use two shell script fake `ld` and `objdump`.

ld
```
#!/bin/sh

libpath=/lib:/usr/lib

# https://unix.stackexchange.com/a/124447
lupdate() { case ":${LD_LIBRARY_PATH:=$1}:" in *:$1:*) ;; *) LD_LIBRARY_PATH="$1:$LD_LIBRARY_PATH" ;; esac; }

for arg; do
	if [ ${arg:0:2} = "-l" ]; then
		lupdate $libpath

		# https://stackoverflow.com/a/11655875/6911112
		(
			IFS=:
			for path in $LD_LIBRARY_PATH; do
				find "$path" -maxdepth 1 -type f -name "lib${arg:2}.so*"
			done
		)

		break
	fi
done
```

objdump
```
#!/bin/sh

for arg; do
	if [ $skip ]; then
		skip=
		continue
	elif [ ${arg:0:2} = "-j" ]; then
		skip=1
		continue
	elif [ ${arg:0:1} = "-" ]; then
		continue
	fi
	echo -n " SONAME "
	basename "$arg"
done
```

<del>Also, pycryptodome requires cffi to use libgmp, don't forget to install `python-cffi`/`python3-cffi`.</del>
**In fact cffi is not required to use libgmp.**