### PR TITLE
imagemagick: reintroduce package, cleanup and upgrade

### DIFF
--- a/multimedia/imagemagick/Makefile
+++ b/multimedia/imagemagick/Makefile
@@ -1,0 +1,140 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=imagemagick
+PKG_VERSION:=7.0.8
+PKG_REVISION:=49
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Val Kulkov <val.kulkov@gmail.com>
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_REVISION).tar.gz
+PKG_SOURCE_URL:=http://github.com/ImageMagick/ImageMagick/archive/$(PKG_VERSION)-$(PKG_REVISION)
+PKG_HASH:=53f7963bbe81520e799e9e178a13757890ed43bc9faf2e86fae1cf58aea28575
+PKG_BUILD_DIR:=$(BUILD_DIR)/ImageMagick-$(PKG_VERSION)-$(PKG_REVISION)
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_USE_MIPS16:=0
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/imagemagick/Default
+  SECTION:=multimedia
+  CATEGORY:=Multimedia
+  TITLE:=Image manipulation tools
+  URL:=https://www.imagemagick.org/
+endef
+
+define Package/imagemagick
+  $(call Package/imagemagick/Default)
+  DEPENDS:=+libltdl +libpthread +zlib +libfreetype +libpng +libjpeg +libtiff
+endef
+
+define Package/imagemagick/description
+ImageMagick is a free and open-source software suite for displaying,
+converting, and editing raster image and vector image files.
+NOTE: this package may not be suitable for many embedded devices because
+of its large size. Consider using extroot or alternatively consider
+graphicsmagick which is smaller but similar in functionality.
+endef
+
+define Package/imagemagick/conffiles
+/etc/ImageMagick-7/colors.xml
+/etc/ImageMagick-7/delegates.xml
+/etc/ImageMagick-7/log.xml
+/etc/ImageMagick-7/mime.xml
+/etc/ImageMagick-7/policy.xml
+/etc/ImageMagick-7/quantization-table.xml
+/etc/ImageMagick-7/thresholds.xml
+/etc/ImageMagick-7/type-apple.xml
+/etc/ImageMagick-7/type-dejavu.xml
+/etc/ImageMagick-7/type-ghostscript.xml
+/etc/ImageMagick-7/type-urw-base35.xml
+/etc/ImageMagick-7/type-windows.xml
+/etc/ImageMagick-7/type.xml
+endef
+
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--disable-static \
+	--disable-docs \
+	--enable-dependency-tracking \
+	--with-modules \
+	--with-threads \
+	--with-ltdl \
+	--with-zlib \
+	--disable-hdri \
+	--with-quantum-depth=8 \
+	--disable-deprecated \
+	--disable-cipher \
+	--without-bzlib \
+	--without-autotrace \
+	--without-djvu \
+	--without-dps \
+	--without-fftw \
+	--without-flif \
+	--without-fpx \
+	--without-fontconfig \
+	--without-gslib \
+	--without-gvc \
+	--without-heic \
+	--without-jbig \
+	--without-lcms \
+	--without-lqr \
+	--without-lzma \
+	--without-magick-plus-plus \
+	--without-openexr \
+	--without-openjp2 \
+	--without-raqm \
+	--without-raw \
+	--without-webp \
+	--without-x \
+	--without-zstd \
+	--without-gslib \
+	--without-gvc \
+	--without-pango \
+	--without-perl \
+	--without-rsvg \
+	--without-wmf \
+	--without-xml \
+	--with-freetype \
+	--with-jpeg \
+	--with-png \
+	--with-tiff
+
+TARGET_CFLAGS += -flto
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/include/* \
+		$(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/*.so* \
+		$(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/* \
+		$(1)/usr/lib/pkgconfig/
+endef
+
+IMlibdir:=usr/lib/ImageMagick-$(PKG_VERSION)
+define Package/imagemagick/install
+	$(INSTALL_DIR) $(1)/etc $(1)/usr/bin $(1)/$(IMlibdir)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	$(RM) $(1)/usr/bin/*-config
+	$(CP) $(PKG_INSTALL_DIR)/etc/ImageMagick-* $(1)/etc/
+	$(CP) $(PKG_INSTALL_DIR)/$(IMlibdir)/* $(1)/$(IMlibdir)/
+endef
+
+$(eval $(call BuildPackage,imagemagick))


### PR DESCRIPTION
Maintainer: me
Compile tested: ipq806x, TP-Link Archer C2600, OpenWrt SNAPSHOT r9257-5a8d03c; bcm53xx, Buffalo WXR-1900DHP, OpenWrt SNAPSHOT r9257-5a8d03c; x86_64, VirtualBox VM, OpenWrt SNAPSHOT r9257-5a8d03c
Run tested: ipq806x, TP-Link Archer C2600, OpenWrt SNAPSHOT r9257-5a8d03c; bcm53xx, Buffalo WXR-1900DHP, OpenWrt SNAPSHOT r9257-5a8d03c; x86_64, VirtualBox VM, OpenWrt SNAPSHOT r9257-5a8d03c

Description:

ImageMagick is a free and open-source software suite for displaying, converting, and editing raster image and vector image files. This package provides the prominent 'convert' utility.

ImageMagick's installation footprint is:

- x86_64: 6.7 MB,
- ipq806x (ARM): 6.0 MB, 
- bcm53xx: 6.2 MB.

The shared libraries occupy 2.4 MB on bcm53xx, 2.3 MB on ipq806x, and 2.5 MB on x86_64. The 114 ImageMagick's modules occupy from 3.4 MB to 4.0 MB depending on the target. It may be possible to reduce the installation footprint by introducing build parameters to control the  selection of modules. In view of the large number of modules and the  possibility of breakage due to module interdependencies or other reasons, such attempt is not made at this time.

ImageMagick is therefore best suited for extroot-enabled or x86_64 OpenWrt systems.

In many cases, GraphicsMagick may be used as a substitute for ImageMagick. GraphicsMagick provides similar functionality, it is faster and it has a smaller installation footprint. It is therefore better suited for non-extroot OpenWrt systems. However, in tests to reduce resolution (and size) of a high-resolution JPEG image GraphicsMagick required about 25% more RAM than ImageMagick (no HDRI, quantum depth of 8) during its execution.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>
