### PR TITLE
dmapd: update to 0.0.79

### DIFF
--- a/net/dmapd/Makefile
+++ b/net/dmapd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dmapd
-PKG_VERSION:=0.0.77
+PKG_VERSION:=0.0.79
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -18,7 +18,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.flyn.org/projects/dmapd
-PKG_HASH:=2ffadffaba3bf680ade3ab851132a1b0d596f7a9dd9cdc7fc8bfbabacc7fab8d
+PKG_HASH:=3edd9e31961751317d35c5d4b1f8c7f52b0d4968c8850fbb03da778c8fcb0ce0
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=2


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo mike@flyn.org

Maintainer: me
Compile tested: x86_64 master
Run tested: x86_64 master

Description:
dmapd: Update to 0.0.78

Depends on pull #8037. 