### PR TITLE
graphicsmagick: new package, an imagemagick alternative

### DIFF
--- a/multimedia/graphicsmagick/Makefile
+++ b/multimedia/graphicsmagick/Makefile
@@ -1,0 +1,101 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=graphicsmagick
+PKG_VERSION:=1.3.31
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/GraphicsMagick-$(PKG_VERSION)
+PKG_SOURCE:=GraphicsMagick-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=@SF/graphicsmagick
+PKG_HASH:=69ee4ac6a49a818098f47f51c4f430ca9bb2493cb3594f322eb211b8aeb71f41
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=Copyright.txt
+PKG_MAINTAINER:=Val Kulkov <val.kulkov@gmail.com>
+
+PKG_BUILD_PARALLEL:=1
+DISABLE_NLS:=
+PKG_BUILD_DEPENDS:=zlib freetype libpng libjpeg tiff
+
+include $(INCLUDE_DIR)/package.mk
+
+PKG_INSTALL:=1
+
+define Package/graphicsmagick/Default
+  SECTION:=multimedia
+  CATEGORY:=Multimedia
+  TITLE:=Graphics manipulation tools
+  URL:=https://www.graphicsmagick.org/
+  DEPENDS:=graphicsmagick
+endef
+
+define Package/graphicsmagick
+  $(call Package/graphicsmagick/Default)
+  DEPENDS:=+libltdl +libpthread +zlib +libfreetype +libpng +libjpeg +libtiff
+endef
+
+define Package/graphicsmagick/description
+GraphicsMagick is a free and open-source software suite for displaying,
+converting, and editing raster image and vector image files. It is a fork
+of GraphicsMagick.
+endef
+
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--disable-static \
+	--enable-dependency-tracking \
+	--with-modules \
+	--with-threads \
+	--without-magick-plus-plus \
+	--without-perl \
+	--without-bzlib \
+	--without-dps \
+	--without-fpx \
+	--without-jbig \
+	--without-webp \
+	--with-jpeg \
+	--without-jp2 \
+	--without-lcms2 \
+	--without-lzma \
+	--with-png \
+	--with-tiff \
+	--without-trio \
+	--with-ttf \
+	--without-umem \
+	--without-wmf \
+	--without-xml \
+	--with-zlib \
+	--without-zstd \
+	--without-x
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/include/* \
+		$(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/*.so* \
+		$(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/* \
+		$(1)/usr/lib/pkgconfig/
+endef
+
+GMlibdir:=usr/lib/GraphicsMagick-$(PKG_VERSION)
+define Package/graphicsmagick/install
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/$(GMlibdir)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/$(GMlibdir)/* $(1)/$(GMlibdir)/
+endef
+
+$(eval $(call BuildPackage,graphicsmagick))
+


### PR DESCRIPTION
Maintainer: me
Compile tested:
- x86_64, OpenWRT virtual machine (VirtualBox), OpenWrt SNAPSHOT r9135-eaaee18
- mipsel_74kc, brcm47xx/mips74k, OpenWrt SNAPSHOT r9103-45a2771

Run tested: x86_64, OpenWRT virtual machine (VirtualBox), OpenWrt SNAPSHOT r9135-eaaee18; "gm convert" worked fine to resize jpg images and convert a jpg file into png and pdf.


Description:

GraphicsMagick is a fork of ImageMagick, licensed under the MIT license. It requires less space and it is [reportedly] faster than ImageMagick.

GraphicsMagick's installation footprint is:
- x86_64: 4.3 MB, and
- brcm47xx-mips74k (mipsel_74kc): 3.7 MB.

The shared libraries occupy 1.2 MB (mipsel_74kc). The 90 GraphicsMagick's modules occupy 2.5 MB. It may be possible to reduce the installation footprint by introducing build parameters to control the election of modules. In view of the large number of modules and the possibility of breakage due to module interdependencies or other reasons, such attempt is not made at this time.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>

