### PR TITLE
mariadb: minor version bump + cfg file move

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
-PKG_VERSION:=10.2.19
-PKG_RELEASE:=4
+PKG_VERSION:=10.2.21
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := \
@@ -18,7 +18,7 @@ PKG_SOURCE_URL := \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/$(PKG_NAME)-$(PKG_VERSION)/source \
 	https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
 
-PKG_HASH:=c0e103cfd73ee96d58402073e9513f0f7b5c0bd216641faecc8d763fb6529727
+PKG_HASH:=637f0808b65ec06902897a2f885a60377828d019d35802402dca541f8113536c
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 PKG_LICENSE:=GPL-2.0 LGPL-2.1
 PKG_LICENSE_FILES:=COPYING libmariadb/COPYING.LIB
@@ -520,6 +520,7 @@ define Package/libmariadb/install
 	$(INSTALL_DIR) $(1)$(CONF_DIR)/conf.d
 	$(INSTALL_DIR) $(1)$(PLUGIN_DIR)
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{mariadb,mysqlclient}*.so* $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/caching_sha2_password.so $(1)$(PLUGIN_DIR)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/dialog.so $(1)$(PLUGIN_DIR)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/mysql_clear_password.so $(1)$(PLUGIN_DIR)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/sha256_password.so $(1)$(PLUGIN_DIR)

--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -211,10 +211,15 @@ endef
 
 define Package/libmariadb
   $(call Package/libmariadb/Default)
-  DEPENDS:=$(MARIADB_COMMON_DEPENDS)
+  DEPENDS:=+mariadb-common \
+	  $(MARIADB_COMMON_DEPENDS)
   TITLE:=MariaDB database client library
   MENU:=1
   PROVIDES:=libmariadbclient libmysqlclient libmysqlclient-r
+endef
+
+define Package/libmariadb/conffiles
+$(CONF_DIR)/conf.d/50-client.cnf
 endef
 
 define Package/libmariadb/description
@@ -256,7 +261,6 @@ define Package/mariadb-client-base
 endef
 
 define Package/mariadb-client-base/conffiles
-$(CONF_DIR)/conf.d/50-client.cnf
 $(CONF_DIR)/conf.d/50-mysql-clients.cnf
 endef
 
@@ -513,11 +517,13 @@ define Build/InstallDev
 endef
 
 define Package/libmariadb/install
+	$(INSTALL_DIR) $(1)$(CONF_DIR)/conf.d
 	$(INSTALL_DIR) $(1)$(PLUGIN_DIR)
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{mariadb,mysqlclient}*.so* $(1)/usr/lib
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/dialog.so $(1)$(PLUGIN_DIR)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/mysql_clear_password.so $(1)$(PLUGIN_DIR)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/sha256_password.so $(1)$(PLUGIN_DIR)
+	$(INSTALL_CONF) conf/50-client.cnf $(1)$(CONF_DIR)/conf.d
 endef
 
 define Package/mariadb-client/install
@@ -531,7 +537,6 @@ endef
 
 define Package/mariadb-client-base/install
 	$(INSTALL_DIR) $(1)$(CONF_DIR)/conf.d
-	$(INSTALL_CONF) conf/50-client.cnf $(1)$(CONF_DIR)/conf.d
 	$(INSTALL_CONF) conf/50-mysql-clients.cnf $(1)$(CONF_DIR)/conf.d
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: mips24kc
Run tested: mips24kc, dlink dir-825-c1, running standalone server & running kamailio using the client lib to connect to remote server with TLS

Description:
Hi all,

Just a minor version bump and a small fix.

Kind regards,
Seb