### PR TITLE
libs/libupnpp: Update to 0.17.0

### DIFF
--- a/libs/libupnpp/Makefile
+++ b/libs/libupnpp/Makefile
@@ -8,16 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libupnpp
-PKG_VERSION:=0.14.0
+PKG_VERSION:=0.17.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.lesbonscomptes.com/upmpdcli/downloads
-PKG_HASH:=13027f8e2b5341d00370ccf34eb8845f1bce73ec58890c02a38dc639e9f91b13
+PKG_SOURCE_URL:=https://www.lesbonscomptes.com/upmpdcli/downloads
+PKG_HASH:=7035dda48207c254cbd8cd64e4e679a9e5f085a35d28c19bc2ddeba0deaff58b
 PKG_MAINTAINER:=Petko Bordjukov <bordjukov@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -25,7 +26,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/libupnpp
   SECTION:=libs
   CATEGORY:=Libraries
-  URL:=http://www.lesbonscomptes.com/upmpdcli
+  URL:=https://www.lesbonscomptes.com/upmpdcli
   DEPENDS+= +libstdcpp +libexpat +librt +libcurl +libupnp
   TITLE:=The libupnpp C++ library wraps libupnp for easier use by upmpdcli and upplay
 endef
@@ -39,8 +40,9 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libupnpp $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libupnpp.so* $(1)/usr/lib/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libupnpp.la $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libupnpp.{la,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libupnpp.pc $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/libupnpp/install


### PR DESCRIPTION
Maintainer: @ignisf
Compile tested: sunxi, Orange Pi PC, OpenWrt master
Run tested: sunxi, Orange Pi PC, OpenWrt master

Description:
Update libupnpp to 0.17.0

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>
