### PR TITLE
libmicrohttpd: Update to 0.9.62 and rework Makefile

### DIFF
--- a/libs/libmicrohttpd/Makefile
+++ b/libs/libmicrohttpd/Makefile
@@ -8,69 +8,64 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmicrohttpd
-PKG_VERSION:=0.9.60
+PKG_VERSION:=0.9.62
 PKG_RELEASE:=1
-
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@GNU/libmicrohttpd
-PKG_HASH:=cd0e5d3f95a9e55ef7cdf4d0530e997ba00b8411af9149d9287db785d729c471
-
 PKG_MAINTAINER:=Alexander Couzens <lynxis@fe80.eu>
-
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
-PKG_BUILD_PARALLEL:=1
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@GNU/libmicrohttpd
+PKG_HASH:=bd3e097d703f5091a6a01b56c0464a90fdd17f5d50478cea50a346b25c88db49
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/libmicrohttpd/Default
-   SECTION:=libs
-   CATEGORY:=Libraries
-   TITLE:=GNU libmicrohttpd is a library that runs an HTTP server.
-   URL:=http://www.gnu.org/software/libmicrohttpd/
+define Package/libmicrohttpd/default
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=GNU libmicrohttpd is a library that runs an HTTP server.
+  URL:=http://www.gnu.org/software/libmicrohttpd/
 endef
 
 define Package/libmicrohttpd
-$(call Package/libmicrohttpd/Default)
-   TITLE+=(with-ssl)
-   DEPENDS:=+libpthread +libgcrypt +libgnutls +libgpg-error
+$(call Package/libmicrohttpd/default)
+  VARIANT:=nossl
+  CONFLICTS:=libmicrohttpd-ssl
 endef
 
-define Package/libmicrohttpd-no-ssl
-$(call Package/libmicrohttpd/Default)
-   TITLE+=(no-ssl)
-   DEPENDS:=+libpthread
-   VARIANT:=no-ssl
-   CONFLICTS:=libmicrohttpd
-endef
-
-define Package/libmicrohttpd/description/Default
-	GNU libmicrohttpd is a small C library that is supposed to make it easy
-	to run an HTTP server as part of another application.
-endef
-
-define Package/libmicrohttpd-no-ssl/description
-$(call Package/libmicrohttp/description/Default)
+define Package/libmicrohttpd-ssl
+$(call Package/libmicrohttpd/default)
+  TITLE+= with SSL support
+  VARIANT:=ssl
+  DEPENDS:=+libgcrypt +libgnutls +libgpg-error
+  PROVIDES:=libmicrohttpd
 endef
 
 CONFIGURE_ARGS+= \
 	--disable-curl \
-	--disable-spdy \
-	--without-openssl
+	--disable-rpath \
+	--disable-doc \
+	--disable-examples \
+	--enable-poll=no \
+	--enable-epoll=yes \
 
-ifeq ($(BUILD_VARIANT),no-ssl)
-CONFIGURE_ARGS += \
-	--disable-https \
-	--without-gnutls
-else
+ifeq ($(BUILD_VARIANT),ssl)
 CONFIGURE_ARGS += \
 	--enable-https \
 	--with-gnutls
+else
+CONFIGURE_ARGS += \
+	--disable-https \
+	--without-gnutls
 endif
+
+define Package/libmicrohttpd/description
+  GNU libmicrohttpd is a small C library that is supposed to make it easy
+  to run an HTTP server as part of another application.
+endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/
@@ -86,9 +81,5 @@ define Package/libmicrohttpd/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
 endef
 
-define Package/libmicrohttpd-no-ssl/install
-$(call Package/libmicrohttpd/install,$1)
-endef
-
 $(eval $(call BuildPackage,libmicrohttpd))
-$(eval $(call BuildPackage,libmicrohttpd-no-ssl))
+$(eval $(call BuildPackage,libmicrohttpd-ssl))


### PR DESCRIPTION
Maintainer: @lynxis
Compile tested: sunxi, Orange Pi PC, OpenWrt master
Run tested: sunxi, Orange Pi PC, OpenWrt master

Description:
Update to 0.9.62
Various cosmetic changes to Makefile
Fix variants and default to no ssl variant

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>
