### PR TITLE
msmtpq-ng: update and remove deprecation

### DIFF
--- a/mail/msmtp-scripts/Makefile
+++ b/mail/msmtp-scripts/Makefile
@@ -41,7 +41,7 @@ endef
 
 define Package/msmtpq-ng
 $(call Package/msmtp-scripts/Default)
-  DEPENDS+= @(PACKAGE_msmtp||PACKAGE_msmtp-nossl)
+  DEPENDS+= +msmtp
   TITLE+= (msmtpq-ng wrappers)
 endef
 
@@ -61,6 +61,12 @@ $(call Package/msmtp-scripts/Default)
   TITLE+= (as MTA)
   DEPENDS+=+msmtpq-ng
   USERID:=msmtp=482:msmtp=482
+  ALTERNATIVES:=\
+    400:/usr/sbin/sendmail:/usr/bin/msmtpq-ng-mta \
+    400:/usr/lib/sendmail:/usr/bin/msmtpq-ng-mta \
+    400:/usr/sbin/mailq:/usr/bin/msmtpq-ng-queue-mta \
+    400:/usr/sbin/postqueue:/usr/bin/msmtpq-ng-queue-mta \
+    400:/usr/sbin/postsuper:/usr/sin/msmtpq-ng-queue-mta
 endef
 
 define Package/msmtp-queue-mta/conffiles
@@ -126,11 +132,6 @@ define Package/msmtpq-ng-mta/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/msmtpq-ng-mta/msmtpq-ng-queue-mta $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/etc/crontabs
 	$(INSTALL_BIN) ./files/msmtpq-ng-mta.init $(1)/etc/init.d/msmtpq-ng-mta
-	ln -sf ../bin/msmtpq-ng-mta $(1)/usr/sbin/sendmail
-	ln -sf ../bin/msmtpq-ng-mta $(1)/usr/lib/sendmail
-	ln -sf ../bin/msmtpq-ng-queue-mta $(1)/usr/sbin/mailq
-	ln -sf ../bin/msmtpq-ng-queue-mta $(1)/usr/sbin/postqueue
-	ln -sf ../bin/msmtpq-ng-queue-mta $(1)/usr/sbin/postsuper
 endef
 
 define Package/msmtpq-ng-mta-smtpd/install

--- a/mail/msmtp-scripts/Makefile
+++ b/mail/msmtp-scripts/Makefile
@@ -1,7 +1,6 @@
 #
 # Copyright (C) 2009 David Cooper <dave@kupesoft.com>
-# Copyright (C) 2009-2015 OpenWrt.org
-# Copyright (C) 2016 Daniel Dickinson <cshored@thecshore.com>
+# Copyright (C) 2016-2018 Daniel Dickinson <cshored@thecshore.com>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,12 +9,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=msmtp-scripts
-PKG_VERSION:=1.0.8
+PKG_VERSION:=1.2-b-3
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/msmtp-scripts
-PKG_HASH:=2aec48d47b02facf2a33cf97a7434e969c1a054224406e6c55320d825c7902b2
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://launchpad.net/$(PKG_NAME)/$(firstword $(subst -, ,$(PKG_VERSION)))/$(PKG_VERSION)/+download
+PKG_HASH:=b1d112df3ba8f42848102ba75d678a3ecef6dae6dd78b12a1357772313292639
+PKG_MAINTAINER:=Daniel F. Dickinson <cshored@thecshore.com>
 
 PKG_LICENSE:=GPL-3.0+
 PKG_LICENSE_FILES:=COPYING
@@ -25,28 +25,25 @@ include $(INCLUDE_DIR)/package.mk
 define Package/msmtp-scripts/Default
   SECTION:=mail
   CATEGORY:=Mail
-  TITLE:=DEPRECATED: Simple sendmail SMTP queueing and forwarding
-  URL:=http://msmtp-scripts.sourceforge.net/
+  TITLE:=Forwarding only SMTP with queuing
+  URL:=https://launchpad.net/msmtp-scripts
 endef
 
 define Package/msmtp-scripts/Default/description
- DEPRECATED: SourceForge project is abandonded; and upstream (on GitHub)
- has deprecated this project. See:
- https://github.com/cshore-history/msmtp-scripts#deprecation-notice
-
  msmtp-scripts are scripts wrappers around the msmtp SMTP client that
- add queueing, logging to syslog or file, a subset of sendmail/postfix
+ add queueing, logging to syslog or file, and a subset of sendmail/postfix
  mailq/postsuper/postqueue commands implemented in a compatible fashion.
 endef
 
 define Package/msmtpq-ng
 $(call Package/msmtp-scripts/Default)
   DEPENDS+= +msmtp
-  TITLE+= (msmtpq-ng wrappers)
+  TITLE+= (common)
 endef
 
 define Package/msmtpq-ng/conffiles
 /etc/msmtpq-ng.rc
+/etc/msmtpq-ng-msmtprc
 endef
 
 define Package/msmtpq-ng/description
@@ -66,11 +63,12 @@ $(call Package/msmtp-scripts/Default)
     400:/usr/lib/sendmail:/usr/bin/msmtpq-ng-mta \
     400:/usr/sbin/mailq:/usr/bin/msmtpq-ng-queue-mta \
     400:/usr/sbin/postqueue:/usr/bin/msmtpq-ng-queue-mta \
-    400:/usr/sbin/postsuper:/usr/sin/msmtpq-ng-queue-mta
+    400:/usr/sbin/postsuper:/usr/bin/msmtpq-ng-queue-mta
 endef
 
 define Package/msmtp-queue-mta/conffiles
 /etc/msmtpq-ng-mta.rc
+/etc/msmtpq-ng-mta-msmtprc
 endef
 
 define Package/msmtpq-ng-mta/description
@@ -84,7 +82,7 @@ endef
 define Package/msmtpq-ng-mta-smtpd
 $(call Package/msmtp-scripts/Default)
   DEPENDS+= +msmtpq-ng-mta +xinetd
-  TITLE+= (basic SMTP server)
+  TITLE+= (localhost SMTPd)
 endef
 
 define Package/msmtp-ng-mta-smtpd/description
@@ -100,11 +98,7 @@ endef
 
 define Package/msmtpq-ng-mta/postinst
 	mkdir -p $${IPKG_INSTROOT}/etc/crontabs
-	if ! grep -q msmtpq-ng-mta $${IPKG_INSTROOT}/etc/crontabs/root; then echo $$'\n'"*/60 * * * * /usr/bin/msmtpq-ng-mta -q" >>$${IPKG_INSTROOT}/etc/crontabs/root; fi
-endef
-
-define Package/msmtp-queue-mta/prerm
-	if grep -q msmtpq-ng-mta $${IPKG_INSTROOT}/etc/crontabs/root; then grep -v '\*/60 \* \* \* \* /usr/bin/msmtpq-ng-mta -q' $${IPKG_INSTROOT}/etc/crontabs/root >$${IPKG_INSTROOT}/etc/crontabs/root.new; mv -f $${IPKG_INSTROOT}/etc/crontabs/root.new $${IPKG_INSTROOT}/etc/crontabs; fi
+	if ! grep -q msmtpq-ng-mta $${IPKG_INSTROOT}/etc/crontabs/root 2>/dev/null; then echo $$'\n'"*/60 * * * * /usr/bin/msmtpq-ng-mta -q" >>$${IPKG_INSTROOT}/etc/crontabs/root; fi
 endef
 
 define Build/Configure
@@ -117,21 +111,20 @@ endef
 
 define Package/msmtpq-ng/install
 	$(INSTALL_DIR) $(1)/etc
-	$(INSTALL_CONF) ./files/msmtpq-ng.rc $(1)/etc/msmtpq-ng.rc
+	$(INSTALL_DATA) ./files/msmtpq-ng.rc $(1)/etc/msmtpq-ng.rc
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_BUILD_DIR)/msmtpq-ng/msmtpq-ng $(1)/usr/bin/
-	$(SED) 's/logger -i/logger/' $(1)/usr/bin/msmtpq-ng
 	$(CP) $(PKG_BUILD_DIR)/msmtpq-ng/msmtpq-ng-queue $(1)/usr/bin/
 endef
 
 define Package/msmtpq-ng-mta/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/sbin $(1)/usr/lib $(1)/etc/init.d
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/msmtpq-ng-mta/msmtpq-ng-mta.rc $(1)/etc/
-	echo 'MSMTP_LOCK_DIR=/var/lock/msmtp' >>$(1)/etc/msmtpq-ng-mta.rc
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/msmtpq-ng-mta/msmtpq-ng-mta.rc $(1)/etc/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/msmtpq-ng-mta/msmtpq-ng-mta $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/msmtpq-ng-mta/msmtpq-ng-queue-mta $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/etc/crontabs
 	$(INSTALL_BIN) ./files/msmtpq-ng-mta.init $(1)/etc/init.d/msmtpq-ng-mta
+	ln -s /etc/msmtprc $(1)/etc/msmtpq-ng-mta-msmtprc
 endef
 
 define Package/msmtpq-ng-mta-smtpd/install

--- a/mail/msmtp-scripts/files/msmtpq-ng-mta.init
+++ b/mail/msmtp-scripts/files/msmtpq-ng-mta.init
@@ -5,12 +5,12 @@ START=90
 
 boot() {
 	[ ! -d /var/spool/msmtp ] && {
-		mkdir -m 0770 -p /var/spool/msmtp
+		mkdir -m1777 -p /var/spool/msmtp
 		chown msmtp:msmtp /var/spool/msmtp
 	}
 
 	[ ! -d /var/lock/msmtp ] && {
-		mkdir -m 0770 -p /var/lock/msmtp
+		mkdir -m1777 -p /var/lock/msmtp
 		chown msmtp:msmtp /var/lock/msmtp
 	}
 }

--- a/mail/msmtp-scripts/files/msmtpq-ng.rc
+++ b/mail/msmtp-scripts/files/msmtpq-ng.rc
@@ -1,9 +1,6 @@
-#Q=~/msmtp.queue
-#LOG=~/log/.msmtp.queue.log
 #MAXLOGLEVEL=7
-#MSMTP_LOCKDIR=/var/lock
 EMAIL_CONN_TEST=p
-EMAIL_CONN_TEST_SITE=www.lede-project.org
+EMAIL_CONN_TEST_PING=openwrt.org
 #EMAIL_CONN_TEST_IP=8.8.8.8
 #MSMTP_UMASK=077
 #MSMTP_LOG_UMASK=077
@@ -14,5 +11,5 @@ EMAIL_CONN_TEST_SITE=www.lede-project.org
 #MSMTP_MAXIMUM_QUEUE_LIFETIME=345600	# Four days
 #MSMTP=msmtp
 #MSMTPQ_NG_QUEUE=msmtpq-ng-queue
-#MSMTP_HOLD_SMTP_MAIL=true
+#MSMTP_HOLD_SMTP_MAIL=false
 #MSMTP_HOLD_CLI_MAIL=false

--- a/mail/msmtp/Makefile
+++ b/mail/msmtp/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=msmtp
 PKG_VERSION:=1.8.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://marlam.de/msmtp/releases
@@ -48,6 +48,7 @@ $(call Package/msmtp/Default)
   DEPENDS+= +libgnutls +ca-bundle
   TITLE+= (with SSL support)
   VARIANT:=ssl
+  DEFAULT_VARIANT:=1
 endef
 
 define Package/msmtp/conffiles
@@ -63,6 +64,7 @@ define Package/msmtp-nossl
 $(call Package/msmtp/Default)
   TITLE+= (without SSL support)
   VARIANT:=nossl
+  PROVIDES:=msmtp
 endef
 
 define Package/msmtp-nossl/description
@@ -73,7 +75,10 @@ endef
 define Package/msmtp-mta
 $(call Package/msmtp/Default)
   TITLE+= (as MTA)
-  DEPENDS+=@(PACKAGE_msmtp||PACKAGE_msmtp-nossl)
+  DEPENDS+=+msmtp
+  ALTERNATIVES:=\
+	100:/usr/sbin/sendmail:/usr/bin/msmtp \
+	100:/usr/lib/sendmail:/usr/bin/msmtp
 endef
 
 define Package/msmtp-mta/description
@@ -84,7 +89,7 @@ endef
 
 define Package/msmtp-queue
 $(call Package/msmtp/Default)
-  DEPENDS+= +bash @(PACKAGE_msmtp||PACKAGE_msmtp-nossl)
+  DEPENDS+= +bash +msmtp
   TITLE+= (queue scripts)
 endef
 
@@ -128,8 +133,6 @@ endef
 
 define Package/msmtp-mta/install
 	$(INSTALL_DIR) $(1)/usr/sbin $(1)/usr/lib
-	ln -sf ../bin/msmtp $(1)/usr/sbin/sendmail
-	ln -sf ../bin/msmtp $(1)/usr/lib/sendmail
 endef
 
 Package/msmtp-nossl/conffiles = $(Package/msmtp/conffiles)


### PR DESCRIPTION
Maintainer: @cshoredaniel / @neheb 

Compile tested: ath79, CR5000 + WNDR3800, brcm2708 Raspberry Pi B+, recent masters
Same for run tested; used with NUT to emit notifications, sent test mails, queued and dequeued mail.
