### PR TITLE
ruby: fix uClibc build

### DIFF
--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -80,6 +80,17 @@ TARGET_LDFLAGS += -L$(PKG_BUILD_DIR)
 # duplicate ld args for binaries.
 CONFIGURE_VARS += XLDFLAGS="$(TARGET_LDFLAGS)"
 
+# On uClibc, finite, isinf and isnan are not directly implemented as
+# functions. Instead math.h #define's these to __finite, __isinf and
+# __isnan, confusing the Ruby configure script. Tell it that they
+# really are available.
+ifeq ($(call qstrip,$(CONFIG_LIBC)),uClibc)
+CONFIGURE_VARS += \
+	ac_cv_func_finite=yes \
+	ac_cv_func_isinf=yes \
+	ac_cv_func_isnan=yes
+endif
+
 MAKE_FLAGS += \
 	DESTDIR="$(PKG_INSTALL_DIR)" \
 	SHELL="/bin/bash"


### PR DESCRIPTION
Shamelessly copied from buildroot. All credit goes to Vicente Olivert
Riera.

Currently ruby fails to build on uClibc targets (Arc). The ruby
configure script doesn't detect platform support for finite, isinf and
isnan and defines its own versions, which later clash with uClibc's
implementations.

```
compiling bigdecimal.c
In file included from ../.././include/ruby/missing.h:23:0,
                 from ../.././include/ruby/defines.h:154,
                 from ../.././include/ruby/ruby.h:29,
                 from bigdecimal.h:14,
                 from bigdecimal.c:13:
bigdecimal.h:97:1: error: static declaration of '__finite' follows non-static declaration
 finite(double)
```

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @luizluca
Compile tested: archs (no change for non-uClibc targets)
Run tested: Don't have Arc hw

Description:
Hello all,

kamailio has a new ruby module, and it doesn't build for Arc because ruby doesn't build there. I searched for a fix and found it in a [buildroot commit](https://github.com/buildroot/buildroot/commit/99e01a35f9e6cf9d17ef65cc9c983f3b364723b7#diff-622ebd77e6593bb707cd378adbeefbd7).

I didn't rev bump because on the targets where this commit makes the change ruby currently doesn't build anyway.

Kind regards,
Seb