### PR TITLE
treewide: add missing PKGARCH:=all to non-binary packages

### DIFF
--- a/lang/dkjson/Makefile
+++ b/lang/dkjson/Makefile
@@ -27,6 +27,7 @@ define Package/dkjson
 	URL:=http://dkolf.de/src/dkjson-lua.fsl/home
 	MAINTAINER:=Lars Gierth <larsg@systemli.org>
 	DEPENDS:=+lua
+	PKGARCH:=all
 endef
 
 define Package/dkjson/description

--- a/lang/json4lua/Makefile
+++ b/lang/json4lua/Makefile
@@ -29,6 +29,7 @@ define Package/json4lua
   TITLE:=json4lua
   URL:=https://github.com/amrhassan/json4lua
   DEPENDS:=+lua +luasocket
+  PKGARCH:=all
 endef
 
 define Package/json4lua/description

--- a/lang/lua-bencode/Makefile
+++ b/lang/lua-bencode/Makefile
@@ -27,6 +27,7 @@ define Package/lua-bencode
 	TITLE:=lua-bencode
 	URL:=https://bitbucket.org/wilhelmy/lua-bencode
 	DEPENDS:=+lua
+	PKGARCH:=all
 endef
 
 define Package/lua-bencode/description

--- a/lang/lua-mobdebug/Makefile
+++ b/lang/lua-mobdebug/Makefile
@@ -32,6 +32,7 @@ define Package/lua-mobdebug
   TITLE:=Lua-MobDebug
   URL:=https://github.com/pkulchenko/MobDebug
   DEPENDS:=+lua
+  PKGARCH:=all
 endef
 
 define Package/lua-mobdebug/description

--- a/lang/lua-wsapi/Makefile
+++ b/lang/lua-wsapi/Makefile
@@ -31,6 +31,7 @@ define Package/lua-wsapi/Default
   TITLE:=Lua WSAPI
   URL:=https://keplerproject.github.io/wsapi/
   DEPENDS:= +lua
+  PKGARCH:=all
 endef
 
 define Package/lua-wsapi/Default/description

--- a/lang/lua-xavante/Makefile
+++ b/lang/lua-xavante/Makefile
@@ -31,6 +31,7 @@ define Package/lua-xavante
   TITLE:=Xavante Web Server
   URL:=https://keplerproject.github.io/xavante/
   DEPENDS:= +lua
+  PKGARCH:=all
 endef
 
 define Package/lua-xavante/description

--- a/lang/luasoap/Makefile
+++ b/lang/luasoap/Makefile
@@ -30,6 +30,7 @@ define Package/luasoap
   TITLE:=LuaSOAP
   URL:=https://github.com/tomasguisasola/luasoap
   DEPENDS:=+lua +luaexpat +luasec +luasocket
+  PKGARCH:=all
 endef
 
 define Package/luasoap/description

--- a/lang/uuid/Makefile
+++ b/lang/uuid/Makefile
@@ -32,6 +32,7 @@ define Package/uuid
   TITLE:=uuid
   URL:=https://github.com/Tieske/uuid
   DEPENDS:=+lua +luasocket
+  PKGARCH:=all
 endef
 
 define Package/uuid/description

--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -17,6 +17,7 @@ PKG_SOURCE_URL:=https://codeload.github.com/Neilpang/acme.sh/tar.gz/$(PKG_VERSIO
 PKG_HASH:=25f8eef1a53584e3ebc653e1ae7763362ca97c40bb476ab7fee01aa50fa3a101
 PKG_BUILD_DIR:=$(BUILD_DIR)/acme.sh-$(PKG_VERSION)
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
+PKGARCH:=all
 
 LUCI_DIR:=/usr/lib/lua/luci
 

--- a/net/bcp38/Makefile
+++ b/net/bcp38/Makefile
@@ -20,6 +20,7 @@ define Package/bcp38
   URL:=https://github.com/dtaht/ceropackages-3.10
   MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
   DEPENDS:=+ipset
+  PKGARCH:=all
 endef
 
 define Package/bcp38/description

--- a/net/bonding/Makefile
+++ b/net/bonding/Makefile
@@ -23,6 +23,7 @@ define Package/proto-bonding
   CATEGORY:=Network
   TITLE:=Link Aggregation (Channel Bonding) proto handler
   DEPENDS:=+kmod-bonding
+  PKGARCH:=all
 endef
 
 define Package/proto-bonding/description

--- a/net/dynapoint/Makefile
+++ b/net/dynapoint/Makefile
@@ -21,6 +21,7 @@ define Package/dynapoint
     SUBMENU:=wireless
     DEPENDS:=+lua +libubus-lua +libuci-lua +libubox-lua +luci-lib-nixio
     TITLE:=Dynamic access point manager
+    PKGARCH:=all
 endef
 
 define Package/dynapoint/description

--- a/net/nft-qos/Makefile
+++ b/net/nft-qos/Makefile
@@ -23,6 +23,7 @@ define Package/nft-qos
   CATEGORY:=Base system
   DEPENDS:=+nftables +kmod-nft-netdev +kmod-nft-bridge
   TITLE:=QoS scripts over nftables
+  PKGARCH:=all
 endef
 
 define Package/nft-qos/description

--- a/net/pppossh/Makefile
+++ b/net/pppossh/Makefile
@@ -19,6 +19,7 @@ define Package/pppossh
   CATEGORY:=Network
   TITLE:=PPPoSSH (Point-to-Point Protocol over SSH)
   DEPENDS:=+ppp +resolveip @(PACKAGE_dropbear||PACKAGE_openssh-client)
+  PKGARCH:=all
 endef
 
 define Package/pppossh/description

--- a/net/sshtunnel/Makefile
+++ b/net/sshtunnel/Makefile
@@ -22,6 +22,7 @@ define Package/sshtunnel
   SUBMENU:=SSH
   TITLE:=Manages Local and Remote openssh ssh(1) tunnels
   DEPENDS:=+openssh-client
+  PKGARCH:=all
 endef
 
 define Package/sshtunnel/description

--- a/net/vpnc-scripts/Makefile
+++ b/net/vpnc-scripts/Makefile
@@ -19,6 +19,7 @@ define Package/vpnc-scripts
   TITLE:=VPN configuration script for vpnc and OpenConnect
   MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
   SUBMENU:=VPN
+  PKGARCH:=all
 endef
 
 define Package/vpnc-scripts/description

--- a/net/wakeonlan/Makefile
+++ b/net/wakeonlan/Makefile
@@ -26,6 +26,7 @@ define Package/wakeonlan
   TITLE:=Sends 'magic packets' to wake-on-LAN enabled ethernet adapters
   URL:=http://gsd.di.uminho.pt/jpo/software/wakeonlan/
   DEPENDS:=+perl +perlbase-getopt +perlbase-net +perlbase-socket
+  PKGARCH:=all
 endef
 
 define Package/wakeonlan/description

--- a/utils/attendedsysupgrade-common/Makefile
+++ b/utils/attendedsysupgrade-common/Makefile
@@ -17,6 +17,7 @@ define Package/attendedsysupgrade-common
   TITLE:=Common files neede by attendedsysupgrade packages
   MAINTAINER:=Paul Spooren <paul@spooren.de>
   DEPENDS:=+rpcd +rpcd-mod-rpcsys
+  PKGARCH:=all
 endef
 
 define Package/attendedsysupgrade-common/description

--- a/utils/bmx7-dnsupdate/Makefile
+++ b/utils/bmx7-dnsupdate/Makefile
@@ -12,6 +12,7 @@ define Package/bmx7-dnsupdate
   TITLE:=bmx7-dnsupdate
   MAINTAINER:=Paul Spooren <spooren@informatik.uni-leipzig.de>
   DEPENDS:=+bmx7 +bmx7-json inotifywait jshn
+  PKGARCH:=all
 endef
 
 define Build/Compile

--- a/utils/watchcat/Makefile
+++ b/utils/watchcat/Makefile
@@ -20,6 +20,7 @@ define Package/watchcat
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Enable the configuration of programed reboots
+  PKGARCH:=all
 endef
 
 define Package/watchcat/description

--- a/utils/wifitoggle/Makefile
+++ b/utils/wifitoggle/Makefile
@@ -22,6 +22,7 @@ define Package/wifitoggle
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Script to toggle Wi-Fi with a button and UCI config
+  PKGARCH:=all
 endef
 
 define Package/wifitoggle/description


### PR DESCRIPTION
Packages such as Perl, Python, Lua, shell scripts don't generate binary files.
Add `PKGARCH:=all` to them.
