### PR TITLE
printscan-helper: sane-backends: Add saned+p910nd helper package

### DIFF
--- a/utils/printscan-helper/Makefile
+++ b/utils/printscan-helper/Makefile
@@ -1,0 +1,52 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=printscan-helper
+PKG_VERSION:=1.0
+PKG_RELEASE:=1
+
+PKG_LICENSE:=GPL-2.0
+PKG_MAINTAINER:=Daniel Dickinson <cshored@thecshore.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/printscan-helper
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=A helper for muxing printer/scanner combos
+  ALTERNATIVES:=300:/usr/sbin/saned:/usr/sbin/saned-wrapper
+endef
+
+define Package/printscan-helper/description
+  printscan-helper is a pair of small setuid root C programs and
+  a wrapper around saned that unloads the usb lp driver before
+  scanning and reloads the lp driver after scanning so that a
+  multifunction printer/scanner can use a simple print sharing
+  app such as p910nd and sane-daemon.  It is needed because
+  the scanner drivers can't use the MFP/AIO USB device while
+  the kernel usblp driver is attached but they don't know how
+  to reattach the driver after scanning (or rather don't
+  because on systems/devices attaching and reattching is
+  problematic).
+endef
+
+define Build/Prepare
+	$(INSTALL_DIR) $(PKG_BUILD_DIR)
+	$(CP) ./src/* $(PKG_BUILD_DIR)/
+endef
+
+define Build/Configure
+	true
+endef
+
+define Package/printscan-helper/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	install -m4750 $(PKG_BUILD_DIR)/printscan-loadlp $(1)/usr/sbin/
+	install -m4750 $(PKG_BUILD_DIR)/printscan-unloadlp $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/saned-wrapper $(1)/usr/sbin/saned-wrapper
+endef
+
+$(eval $(call BuildPackage,printscan-helper))

--- a/utils/printscan-helper/src/Makefile
+++ b/utils/printscan-helper/src/Makefile
@@ -1,0 +1,9 @@
+#!/usr/bin/env make
+
+# Copyright 2019 Daniel Dickinson <cshored@thecshore.com>
+# Released under term of the GNU General Public License version 2.0
+
+# Let implicit rules take care of things
+#
+all: printscan-loadlp printscan-unloadlp saned-wrapper
+

--- a/utils/printscan-helper/src/printscan-loadlp.c
+++ b/utils/printscan-helper/src/printscan-loadlp.c
@@ -1,0 +1,18 @@
+/* A setuid helper to load the kernel usblp driver
+ *
+ * Copyright 2019 Daniel Dickinson <cshored@thecshore.com>
+ * Licensed under the terms of the GNU General Public License version 2.0
+ *
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+
+
+int main(int argc, char *const argv[]) {
+  execl("/sbin/modprobe", "/sbin/modprobe", "usblp", (char *)NULL);
+  perror("printscan-loadlp: Error loading usblp module");
+  return EXIT_FAILURE;
+}

--- a/utils/printscan-helper/src/printscan-unloadlp.c
+++ b/utils/printscan-helper/src/printscan-unloadlp.c
@@ -1,0 +1,18 @@
+/* A setuid helper to unload the kernel usblp driver
+ *
+ * Copyright 2019 Daniel Dickinson <cshored@thecshore.com>
+ * Licensed under the terms of the GNU General Public License version 2.0
+ *
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+
+
+int main(int argc, char *const argv[]) {
+  execl("/sbin/rmmod", "/sbin/rmmod", "usblp", (char *)NULL);
+  perror("printscan-unloadlp: Error removing usblp module");
+  return EXIT_FAILURE;
+}

--- a/utils/printscan-helper/src/saned-wrapper.c
+++ b/utils/printscan-helper/src/saned-wrapper.c
@@ -1,0 +1,104 @@
+/* A wrapper around saned to load/unload kernel usblp driver
+ *
+ * Copyright 2019 Daniel Dickinson <cshored@thecshore.com>
+ * Licensed under the terms of the GNU General Public License version 2.0
+ *
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+int dofork(const char command[], char *const cargv[]) {
+  int ret = 0;
+  int status = 0;
+  pid_t cpid = 0;
+  pid_t wpid = 0;
+  int childsig = 0;
+  int childret = 0;
+  int eret = 0;
+
+  cpid = fork();
+  if (!cpid) {
+    /* In child */
+    execv(command, cargv);
+    /* exec only exits on failure */
+    exit(EXIT_FAILURE);
+  }
+
+  /* Parent */
+  if (cpid < 0) {
+    perror("saned-wrapper: Error while forking");
+    return -ECHILD;
+  } else {
+    wpid = wait(&status);
+
+    if (wpid < 0) {
+      fprintf(stderr, "saned-wrapper: Error waiting for '%s'\n", command);
+      return -ECHILD;
+    }
+
+    if (!WIFEXITED(status)) {
+      if (WIFSIGNALED(status)) {
+        childsig = WTERMSIG(status);
+        fprintf(stderr, "saned-wrapper: '%s' exited due to signal %d.\n", command, childsig);
+      } else {
+        fprintf(stderr, "saned-wrapper: Unknown exit status executing '%s'.\n", command);
+        return EXIT_FAILURE;
+      }
+    } else {
+      childret = WEXITSTATUS(status);
+      if (childret) {
+        fprintf(stderr, "saned-wrapper: Error %d executing '%s'.\n", childret, command);
+      }
+    }
+  }
+
+  if (childret || childsig) {
+    if (childret) {
+      ret = childret;
+    } else {
+      ret = EXIT_FAILURE;
+    }
+  } else if (eret) {
+    ret = eret;
+  }
+
+  return ret;
+}
+
+int main(int argc, char *const argv[]) {
+  char *const uncmd[] = {
+	  "/usr/sbin/printscan-unloadlp",
+	  NULL
+  };
+  char *const ldcmd[] = {
+	  "/usr/sbin/printscan-loadlp",
+	  NULL
+  };
+  int ret1, ret2, ret3 = 0;
+
+  ret1 = dofork(*uncmd, uncmd);
+  if (ret1 == -ECHILD)
+    return EXIT_FAILURE;
+  ret2 = dofork("/usr/sbin/saned.real", argv);
+  /* Even if unload or saned exited with error or by signal, reload lp driver
+   */
+  if (ret2 == -ECHILD)
+    return EXIT_FAILURE;
+  ret3 = dofork(*ldcmd, ldcmd);
+  if (ret3 == -ECHILD)
+    return EXIT_FAILURE;
+
+  if (ret2) {
+    return ret2;
+  } else if (ret3) {
+    return ret3;
+  } else if (ret1) {
+    return ret1;
+  }
+  return EXIT_SUCCESS;
+}

--- a/utils/sane-backends/Makefile
+++ b/utils/sane-backends/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sane-backends
 PKG_VERSION:=1.0.27
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://fossies.org/linux/misc \
     https://alioth.debian.org/frs/download.php/file/4146/
@@ -126,11 +126,15 @@ $(call Package/sane-backends/Default)
   CATEGORY:=Utilities
   DEPENDS:=+libsane
   TITLE+= (network daemon)
+  ALTERNATIVES:=100:/usr/sbin/saned:/usr/sbin/saned.real
 endef
 
 define Package/sane-daemon/description
 $(call Package/sane-backends/Default/description)
 This package contains the SANE daemon.
+NB: If you plan on using a printer/scanner combo device with SANE
+and a print server such as p910nd you should also install
+printscan-helper.
 endef
 
 define Package/libsane
@@ -193,7 +197,7 @@ define Package/sane-daemon/install
 	$(INSTALL_DIR) $(1)/etc/sane.d
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/sane.d/saned.conf $(1)/etc/sane.d/
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/* $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/saned $(1)/usr/sbin/saned.real
 	$(INSTALL_DIR) $(1)/etc/xinetd.d
 	$(CP) ./files/xinet.d_sane-port $(1)/etc/xinetd.d/sane-port
 endef


### PR DESCRIPTION
At least with hplip-sane and a multifunction printer/scanner using sane-daemon
combined with a print server (e.g. p910nd) is problematic for USB devices because
sane-daemon will kick the usblp (/dev/usb/lp0) driver off the device but not add
it back when it's done.  So we add a helper to load and unload the usblp driver
when saned is started and stopped (e.g. works best with xinetd type setup).

We also update sane-daemon with ALTERNATIVES so that this wrapper can
intercept requests for saned and do the load/unload magic.

Also note that if you operate sane a none-privileged user you will need
make sure that user is part of a group allowed to execute the
load/unload helpers (and if you modify the group of the helpers to
put the setuid bit back on).

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: me (@cshoredaniel) for the helper and @luizluca for sane-backends

Compiled and Run tested on ath79, WNDR3800, current masters

Scanned and then printed using SANE and p910nd -- before this package printing would fail due printer device not existing since hplip-sane backend detachs but does not reattach kernel driver (and apparently doing that from libusb is problematic).

It's a bit of a hack but it works...