### PR TITLE
addrwatch: Update init script

### DIFF
--- a/net/addrwatch/Makefile
+++ b/net/addrwatch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=addrwatch
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fln/addrwatch/tar.gz/v$(PKG_VERSION)?

--- a/net/addrwatch/files/addrwatch.init
+++ b/net/addrwatch/files/addrwatch.init
@@ -5,7 +5,7 @@ START=50
 USE_PROCD=1
 
 validate_section_addrwatch() {
-	uci_validate_section addrwatch addrwatch "${1}" \
+	uci_load_validate addrwatch addrwatch "$1" "$2" \
 		'disabled:bool:0' \
 		'interface:list(string):lan' \
 		'syslog:bool:1' \
@@ -17,16 +17,13 @@ validate_section_addrwatch() {
 		'blacklist:list(or(ip4addr,ip6addr))' \
 		'hashsize:range(1,65536):1024'\
 		'ratelimit:integer:3600'
-	return $?
 }
 
 start_instance() {
 	local cfg="$1"
-	local disabled interface syslog output quiet verbose ipv4only ipv6only
-	local blacklist hashsize ratelimit
 	local netdevs=""
 
-	validate_section_addrwatch "${cfg}" || {
+	[ "$2" = 0 ] || {
 		echo "validation of config $cfg failed"
 		return 1
 	}
@@ -34,14 +31,14 @@ start_instance() {
 
 	for iface in $interface; do
 		local netdev
-		network_get_physdev netdev "${iface}"
-		append netdevs "${netdev}"
+		network_get_physdev netdev "$iface"
+		append netdevs "$netdev"
 	done
 
 	procd_open_instance
 	procd_set_param command /usr/sbin/addrwatch
-	[ "${syslog}" -eq 1 ] && procd_append_param command --syslog
-	[ -n "${output}" ] && procd_append_param command --output "$output"
+	[ "$syslog" -eq 1 ] && procd_append_param command --syslog
+	[ -n "$output" ] && procd_append_param command --output "$output"
 	[ "$quiet" -eq 1 ] && procd_append_param command --quiet
 	[ "$verbose" -eq 1 ] && procd_append_param command --verbose
 	[ "$ipv4only" -eq 1 ] && procd_append_param command --ipv4only
@@ -49,14 +46,14 @@ start_instance() {
 	[ -n "$hashsize" ] && procd_append_param command --hashsize "$hashsize"
 	[ -n "$ratelimit" ] && procd_append_param command --ratelimit "$ratelimit"
 	for blitem in $blacklist; do
-		procd_append_param command "--blacklist=${blitem}"
+		procd_append_param command "--blacklist=$blitem"
 	done
 	procd_append_param command $netdevs
 	procd_set_param netdev $netdevs
 	procd_set_param respawn
 	procd_open_trigger
 	for iface in $interface; do
-		procd_add_interface_trigger "interface.*" ${iface} /etc/init.d/addrwatch reload
+		procd_add_interface_trigger "interface.*" $iface /etc/init.d/addrwatch reload
 	done
 	procd_close_trigger
 	procd_close_instance
@@ -65,9 +62,10 @@ start_instance() {
 start_service() {
 	. /lib/functions/network.sh
 	config_load 'addrwatch'
-	config_foreach start_instance 'addrwatch'
+	config_foreach validate_section_addrwatch 'addrwatch' start_instance
 }
 
 service_triggers() {
 	procd_add_reload_trigger 'addrwatch'
+	procd_add_validation validate_section_addrwatch
 }


### PR DESCRIPTION
Maintainer: @oskar456 
Compile tested: armvirt-32, 2019-01-28 snapshot sdk
Run tested: none

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

This also lets procd trigger the validation function directly, and removes some unnecessary curly brackets.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>