### PR TITLE
[openwrt-18.06] youtube-dl: update to version 2019.01.30.1

### DIFF
--- a/multimedia/youtube-dl/Makefile
+++ b/multimedia/youtube-dl/Makefile
@@ -8,17 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=youtube-dl
-PKG_VERSION:=2018.03.10
+PKG_VERSION:=2019.01.30.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://yt-dl.org/downloads/$(PKG_VERSION)/
-PKG_HASH:=4bfadccb19e379ce38f5601c72dacf0ac5e03881230afee6df2152ab42fa75c5
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+PKG_SOURCE_URL:=https://codeload.github.com/rg3/youtube-dl/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=6ce95ef3d290c4254fbdc50d5514a1259479486e183b63dee9a4163244035d97
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_LICENSE:=Unlicense
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Adrian Panella <ianchi74@outlook.com>
+PKG_MAINTAINER:=Adrian Panella <ianchi74@outlook.com>, Josef Schlehofer <pepe.schlehofer@gmail.com>
 
 PKG_BUILD_DEPENDS:=python/host zip/host
 
@@ -33,20 +33,20 @@ define Package/youtube-dl
 endef
 
 define Package/youtube-dl/description
-  youtube-dl is a small command-line program to download videos 
-  from YouTube.com and a few more sites. 
+  youtube-dl is a small command-line program to download videos
+  from YouTube.com and a few more sites.
   It requires the Python interpreter.
 endef
 
 define Package/youtube-dl/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	
+
 	python -m compileall $(PKG_BUILD_DIR)/youtube_dl/
 	cd $(PKG_BUILD_DIR) && zip --quiet youtube-dl-c.zip youtube_dl/*.pyc youtube_dl/*/*.pyc
 	cd $(PKG_BUILD_DIR) && zip --quiet --junk-paths youtube-dl-c.zip youtube_dl/__main__.pyc
 	echo '#!/usr/bin/env python' > $(PKG_BUILD_DIR)/youtube-dl-c
 	cat $(PKG_BUILD_DIR)/youtube-dl-c.zip >> $(PKG_BUILD_DIR)/youtube-dl-c
-	
+
 	$(INSTALL_BIN) -T $(PKG_BUILD_DIR)/youtube-dl-c $(1)/usr/bin/youtube-dl
 endef
 

--- a/multimedia/youtube-dl/patches/dont-use-pandoc.patch
+++ b/multimedia/youtube-dl/patches/dont-use-pandoc.patch
@@ -1,0 +1,21 @@
+diff --git a/Makefile b/Makefile
+index 4a62f44..fee93e8 100644
+--- a/Makefile
++++ b/Makefile
+@@ -85,12 +85,12 @@ supportedsites:
+ 	$(PYTHON) devscripts/make_supportedsites.py docs/supportedsites.md
+ 
+ README.txt: README.md
+-	pandoc -f $(MARKDOWN) -t plain README.md -o README.txt
++#	pandoc -f $(MARKDOWN) -t plain README.md -o README.txt
+ 
+ youtube-dl.1: README.md
+-	$(PYTHON) devscripts/prepare_manpage.py youtube-dl.1.temp.md
+-	pandoc -s -f $(MARKDOWN) -t man youtube-dl.1.temp.md -o youtube-dl.1
+-	rm -f youtube-dl.1.temp.md
++#	$(PYTHON) devscripts/prepare_manpage.py youtube-dl.1.temp.md
++#	pandoc -s -f $(MARKDOWN) -t man youtube-dl.1.temp.md -o youtube-dl.1
++#	rm -f youtube-dl.1.temp.md
+ 
+ youtube-dl.bash-completion: youtube_dl/*.py youtube_dl/*/*.py devscripts/bash-completion.in
+ 	$(PYTHON) devscripts/bash-completion.py


### PR DESCRIPTION
Maintainer: @ianchi

Compiled tested: cortexa53, Turris MOX, OpenWrt 18.06.02 (which should be released soon)
Run tested: cortexa53, Turris MOX, OpenWrt 18.06.02 (which should be released soon)

Description:
In OpenWrt 18.06 it's a very old version of youtube-dl and it would be great if this can be merged as there a lot of improvements.

I have also included changes from master, for example, add me as co-maintainer to be able to track some issues, if some appear.