### PR TITLE
taskwarrior: update to version 2.5.1

### DIFF
--- a/utils/taskwarrior/Makefile
+++ b/utils/taskwarrior/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=taskwarrior
-PKG_VERSION:=2.4.4
+PKG_VERSION:=2.5.1
 PKG_RELEASE:=1
 
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=task-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.taskwarrior.org/download/
-PKG_HASH:=7ff406414e0be480f91981831507ac255297aab33d8246f98dbfd2b1b2df8e3b
+PKG_SOURCE_URL:=https://www.taskwarrior.org/download/
+PKG_HASH:=d87bcee58106eb8a79b850e9abc153d98b79e00d50eade0d63917154984f2a15
 PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/task-$(PKG_VERSION)
@@ -31,7 +31,7 @@ define Package/taskwarrior
   SECTION:=utils
   CATEGORY:=Utilities
   DEPENDS:=+libstdcpp +libuuid +libgnutls
-  URL:=http://taskwarrior.org/
+  URL:=https://taskwarrior.org/
 endef
 
 TARGET_LDFLAGS += -ldl


### PR DESCRIPTION
Maintainer: @lperkov 
Compile tested: Turris Omnia (TOS4), OpenWrt 18.06.1
Run tested: Turris Omnia (TOS4), OpenWrt 18.06.1

Description:
Update to version 2.5.1 and change URL to https
Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>
