### PR TITLE
openocd: patch security issue

### DIFF
--- a/utils/openocd/Makefile
+++ b/utils/openocd/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openocd
 PKG_SOURCE_VERSION:=0.10.0
 PKG_VERSION:=v$(PKG_SOURCE_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=@SF/openocd
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.bz2
@@ -20,6 +20,7 @@ PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 
 PKG_MAINTAINER:=Paul Fertser <fercerpav@gmail.com>
+PKG_CPE_ID:=cpe:/a:openocd:open_on-chip_debugger
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/utils/openocd/patches/100-bind-localhost-only.patch
+++ b/utils/openocd/patches/100-bind-localhost-only.patch
@@ -1,0 +1,45 @@
+Subject: Bind to IPv4 localhost by default
+Origin: other, http://openocd.zylin.com/#/c/4331/2
+Last-Update: 2018-01-18
+
+From f8630b0b15e30dc6c51270006a4e075c79cf466a Mon Sep 17 00:00:00 2001
+From: Paul Fertser <fercerpav@gmail.com>
+Date: Sat, 13 Jan 2018 16:22:10 +0300
+Subject: [PATCH] server: bind to IPv4 localhost by default
+
+Since OpenOCD basically allows to perform arbitrary actions on behalf of
+the running user, it makes sense to restrict the exposure by default.
+
+If you need network connectivity and your environment is safe enough,
+use "bindto 0.0.0.0" to switch to the old behaviour.
+
+Change-Id: I4a4044b90d0ecb30118cea96fc92a7bcff0924e0
+Signed-off-by: Paul Fertser <fercerpav@gmail.com>
+---
+
+diff --git a/doc/openocd.texi b/doc/openocd.texi
+index 7f5b72e..5c7f465 100644
+--- a/doc/openocd.texi
++++ b/doc/openocd.texi
+@@ -7017,7 +7017,7 @@
+ 
+ @deffn Command bindto [name]
+ Specify address by name on which to listen for incoming TCP/IP connections.
+-By default, OpenOCD will listen on all available interfaces.
++By default, OpenOCD will listen on the loopback interface only.
+ @end deffn
+ 
+ @anchor{targetstatehandling}
+diff --git a/src/server/server.c b/src/server/server.c
+index 1e52e97..ea1e898 100644
+--- a/src/server/server.c
++++ b/src/server/server.c
+@@ -259,7 +259,7 @@
+ 		c->sin.sin_family = AF_INET;
+ 
+ 		if (bindto_name == NULL)
+-			c->sin.sin_addr.s_addr = INADDR_ANY;
++			c->sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+ 		else {
+ 			hp = gethostbyname(bindto_name);
+ 			if (hp == NULL) {

--- a/utils/openocd/patches/101-cve-2018-5704-css-fix.patch
+++ b/utils/openocd/patches/101-cve-2018-5704-css-fix.patch
@@ -1,0 +1,47 @@
+Subject: Prevent some forms of Cross Protocol Scripting attacks
+Author: Andreas Fritiofson <andreas.fritiofson@gmail.com>
+Origin: other, http://openocd.zylin.com/#/c/4335/
+Bug-Debian: https://bugs.debian.org/887488
+Last-Update: 2018-01-18
+
+From 3a223ca3ebc7ac24d7726a0cd58e5695bc813657 Mon Sep 17 00:00:00 2001
+From: Andreas Fritiofson <andreas.fritiofson@gmail.com>
+Date: Sat, 13 Jan 2018 21:00:47 +0100
+Subject: [PATCH] CVE-2018-5704: Prevent some forms of Cross Protocol Scripting attacks
+
+OpenOCD can be targeted by a Cross Protocol Scripting attack from
+a web browser running malicious code, such as the following PoC:
+
+var x = new XMLHttpRequest();
+x.open("POST", "http://127.0.0.1:4444", true);
+x.send("exec xcalc\r\n");
+
+This mitigation should provide some protection from browser-based
+attacks and is based on the corresponding fix in Redis:
+
+https://github.com/antirez/redis/blob/8075572207b5aebb1385c4f233f5302544439325/src/networking.c#L1758
+
+Change-Id: Ia96ebe19b74b5805dc228bf7364c7971a90a4581
+Signed-off-by: Andreas Fritiofson <andreas.fritiofson@gmail.com>
+Reported-by: Josef Gajdusek <atx@atx.name>
+---
+
+diff --git a/src/server/startup.tcl b/src/server/startup.tcl
+index 64ace40..dd1b31e 100644
+--- a/src/server/startup.tcl
++++ b/src/server/startup.tcl
+@@ -8,3 +8,14 @@
+ 	# one target
+ 	reset halt
+ }
++
++proc prevent_cps {} {
++	echo "Possible SECURITY ATTACK detected."
++	echo "It looks like somebody is sending POST or Host: commands to OpenOCD."
++	echo "This is likely due to an attacker attempting to use Cross Protocol Scripting"
++	echo "to compromise your OpenOCD instance. Connection aborted."
++	exit
++}
++
++proc POST {args} { prevent_cps }
++proc Host: {args} { prevent_cps }


### PR DESCRIPTION
Maintainer: @paulfertser 
Compile tested: Turris Omnia (TOS4), OpenWrt 18.06.1
Run tested: Turris Omnia (TOS4), OpenWrt 18.06.1

Description:
This PR contains security patches from Debian which restrict some cross-protocol scripting attacks.
CVE info https://nvd.nist.gov/vuln/detail/CVE-2018-5704

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>