### PR TITLE
nft-qos: fix useless log in syslog

### DIFF
--- a/net/nft-qos/Makefile
+++ b/net/nft-qos/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nft-qos
-PKG_VERSION:=1.0.3
+PKG_VERSION:=1.0.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0
 

--- a/net/nft-qos/files/nft-qos-dynamic.hotplug
+++ b/net/nft-qos/files/nft-qos-dynamic.hotplug
@@ -3,6 +3,8 @@
 # Copyright 2018 rosysong@rosinson.com
 #
 
+export initscript="nft-qos-dynamic"
+
 . /lib/functions.sh
 . /lib/nft-qos/core.sh
 . /lib/nft-qos/dynamic.sh

--- a/net/nft-qos/files/nft-qos-monitor.hotplug
+++ b/net/nft-qos/files/nft-qos-monitor.hotplug
@@ -3,6 +3,8 @@
 # Copyright 2018 rosysong@rosinson.com
 #
 
+export initscript="nft-qos-monitor"
+
 . /lib/nft-qos/monitor.sh
 
 logger -t nft-qos-monitor "ACTION=$ACTION, MACADDR=$MACADDR, IPADDR=$IPADDR, HOSTNAME=$HOSTNAME"


### PR DESCRIPTION
Since the functions in procd.sh invoke "initscript" variable which is
not defined when imported procd.sh from hotplug scripts. And this
results in error when calling basename utility.

Sun Jan 20 12:34:50 2019 daemon.debug dnsmasq-script[15340]: BusyBox v1.28.4 () multi-call binary.
Sun Jan 20 12:34:50 2019 daemon.debug dnsmasq-script[15340]:
Sun Jan 20 12:34:50 2019 daemon.debug dnsmasq-script[15340]: Usage: basename FILE [SUFFIX]
Sun Jan 20 12:34:50 2019 daemon.debug dnsmasq-script[15340]:
Sun Jan 20 12:34:50 2019 daemon.debug dnsmasq-script[15340]: Strip directory path and .SUFFIX from FILE
Sun Jan 20 12:34:50 2019 user.notice nft-qos-monitor: ACTION=update, MACADDR=xxxxxx, IPADDR=192.168.11.109, HOSTNAME=Honor_Play
Sun Jan 20 12:34:50 2019 daemon.info dnsmasq[15340]: 250 192.168.11.109/60566 reply www.google.com is 216.58.215.68
Sun Jan 20 12:34:50 2019 daemon.info dnsmasq[15340]: 251 192.168.11.109/43456 reply mtalk.google.com is <CNAME>
Sun Jan 20 12:34:50 2019 daemon.info dnsmasq[15340]: 251 192.168.11.109/43456 reply mobile-gtalk.l.google.com is 173.194.222.188
Sun Jan 20 12:34:50 2019 daemon.debug dnsmasq-script[15340]: BusyBox v1.28.4 () multi-call binary.
Sun Jan 20 12:34:50 2019 daemon.debug dnsmasq-script[15340]:
Sun Jan 20 12:34:50 2019 daemon.debug dnsmasq-script[15340]: Usage: basename FILE [SUFFIX]
Sun Jan 20 12:34:50 2019 daemon.debug dnsmasq-script[15340]:
Sun Jan 20 12:34:50 2019 daemon.debug dnsmasq-script[15340]: Strip directory path and .SUFFIX from FILE
Sun Jan 20 12:34:51 2019 daemon.debug dnsmasq-script[15340]: BusyBox v1.28.4 () multi-call binary.
Sun Jan 20 12:34:51 2019 daemon.debug dnsmasq-script[15340]:
Sun Jan 20 12:34:51 2019 daemon.debug dnsmasq-script[15340]: Usage: basename FILE [SUFFIX]
Sun Jan 20 12:34:51 2019 daemon.debug dnsmasq-script[15340]:
Sun Jan 20 12:34:51 2019 daemon.debug dnsmasq-script[15340]: Strip directory path and .SUFFIX from FILE
Sun Jan 20 12:34:51 2019 user.notice nft-qos-dynamic: ACTION=update, MACADDR=xxxxxx, IPADDR=192.168.11.109, HOSTNAME=Honor_Play

Signed-off-by: Rosy Song <rosysong@rosinson.com>

Maintainer: me
Compile tested: mips, wr818, master
Run tested: mips, wr818, master

This commit fix the useless output in syslog when calling hotplug script of nft-qos.
