### PR TITLE
getdns: fix missing libbsd dependency

### DIFF
--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=getdns
 PKG_VERSION:=1.4.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -54,6 +54,11 @@ CONFIGURE_ARGS += \
 		--without-libidn \
 		$(if $(CONFIG_GETDNS_ENABLE_IDN_LIBIDN2), , --without-libidn2 ) \
 		--with-ssl="$(STAGING_DIR)/usr" \
+
+# This will make 'configure' think that our libbsd.so is missing the
+# functions inet_pton, inet_ntop, strlcpy and use the builtin. This 
+# removes the libbsd dependency
+CONFIGURE_VARS += LIBBSD_LIBS=-lc
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/getdns/


### PR DESCRIPTION
Backport these commits from master to the 18.06 branch:
8365744b80c1c0c57fabe199aaa08e6bacef8063
035b22b2085c1dc5f5788a941a44f69de757826b
d0766135ade4409103cd5bfbd6180a41c4f2741a

Fixes https://github.com/openwrt/packages/issues/8093

Maintainer: @jonathanunderwood @guidosarducci @iamperson347
Compile tested: 
Run tested: 

Description:
fix missing libbsd dependency