### PR TITLE
aria2: Update init script

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
 PKG_VERSION:=1.34.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/

--- a/net/aria2/files/aria2.init
+++ b/net/aria2/files/aria2.init
@@ -79,11 +79,11 @@ append_setting() {
 append_header() {
 	local h="$1"
 	[ -n "$h" ] && \
-		echo "header=\"${h}\"" >>"$config_file_tmp"
+		echo "header=\"$h\"" >>"$config_file_tmp"
 }
 
 aria2_validate() {
-	uci_validate_section "$NAME" aria2 "$1" \
+	uci_load_validate "$NAME" aria2 "$1" "$2" \
 		'enabled:bool:0' \
 		'enable_logging:bool' \
 		'enable_proxy:bool' \
@@ -158,23 +158,23 @@ aria2_validate() {
 
 aria2_start() {
 	local section="$1"
-	aria2_validate "$section" || { _err "Validation failed."; return 1; }
+	[ "$2" = "0" ] || { _err "Validation failed."; return 1; }
 
-	[ "$enabled" = "1" ] || { _info "Instance \"${section}\" disabled."; return 1; }
+	[ "$enabled" = "1" ] || { _info "Instance \"$section\" disabled."; return 1; }
 	[ -n "$dir" ] || { _err "Please set download dir."; return 1; }
 	[ -d "$dir" ] || { _err "Please create download dir first."; return 1; }
 
-	config_file="${config_dir}/${NAME}.conf.${section}"
-	config_file_tmp="${config_dir}/${NAME}.conf.tmp"
-	session_file="${config_dir}/${NAME}.session.${section}"
+	config_file="$config_dir/$NAME.conf.$section"
+	config_file_tmp="$config_dir/$NAME.conf.tmp"
+	session_file="$config_dir/$NAME.session.$section"
 
 	_make_dir "$config_dir" || {
-		_err "Can't create config dir: ${config_dir}"
+		_err "Can't create config dir: $config_dir"
 		return 1
 	}
 
 	_create_file "$session_file" "$config_file" "$config_file_tmp" || {
-		_err "Can't create files: ${session_file}, ${config_file}, ${config_file_tmp}"
+		_err "Can't create files: $session_file, $config_file, $config_file_tmp"
 		return 1
 	}
 
@@ -183,14 +183,14 @@ aria2_start() {
 		# Auto generated file, changes to this file will be lost.
 	EOF
 
-	append_setting "dir=${dir}"
+	append_setting "dir=$dir"
 	append_setting "enable-rpc=true"
 	append_setting "rpc-allow-origin-all=true"
 	append_setting "rpc-listen-all=true"
 	append_setting "quiet=true"
 	append_setting "continue=true"
-	append_setting "input-file=${session_file}"
-	append_setting "save-session=${session_file}"
+	append_setting "input-file=$session_file"
+	append_setting "save-session=$session_file"
 
 	if [ -z "$enable_logging" ]; then
 		append_options "log" "log_level"
@@ -201,14 +201,14 @@ aria2_start() {
 		log_dir="$(dirname "$log")"
 
 		_make_dir "$log_dir" || {
-			_err "Can't create log dir: ${log_dir}"
+			_err "Can't create log dir: $log_dir"
 			return 1
 		}
 
 		# create or clear log file
 		echo >"$log"
 
-		append_setting "log=${log}"
+		append_setting "log=$log"
 		append_options "log_level"
 	fi
 
@@ -218,30 +218,30 @@ aria2_start() {
 
 	unset_auth_method() {
 		uci -q batch <<-EOF
-			set ${NAME}.${section}.rpc_auth_method=""
+			set $NAME.$section.rpc_auth_method=""
 			commit $NAME
 		EOF
 	}
 
 	if [ -z "$rpc_auth_method" ]; then
 		if [ -n "$rpc_secret" ]; then
-			append_setting "rpc-secret=${rpc_secret}"
+			append_setting "rpc-secret=$rpc_secret"
 		elif [ -n "$rpc_user" ]; then
-			append_setting "rpc-user=${rpc_user}"
-			append_setting "rpc-passwd=${rpc_passwd}"
+			append_setting "rpc-user=$rpc_user"
+			append_setting "rpc-passwd=$rpc_passwd"
 		else
 			_info "It is recommended to set RPC secret."
 		fi
 	elif [ "$rpc_auth_method" = "token" ]; then
 		if [ -n "$rpc_secret" ]; then
-			append_setting "rpc-secret=${rpc_secret}"
+			append_setting "rpc-secret=$rpc_secret"
 		else
 			unset_auth_method
 		fi
 	elif [ "$rpc_auth_method" = "user_pass" ]; then
 		if [ -n "$rpc_user" ]; then
-			append_setting "rpc-user=${rpc_user}"
-			append_setting "rpc-passwd=${rpc_passwd}"
+			append_setting "rpc-user=$rpc_user"
+			append_setting "rpc-passwd=$rpc_passwd"
 		else
 			_info "Please set RPC user."
 			unset_auth_method
@@ -261,25 +261,25 @@ aria2_start() {
 	fi
 
 	if [ ."$enable_dht" = ."true" ]; then
-		dht_file="${config_dir}/dht.dat.${section}"
+		dht_file="$config_dir/dht.dat.$section"
 		_create_file "$dht_file" || {
-			_err "Can't create DHT file: ${dht_file}"
+			_err "Can't create DHT file: $dht_file"
 			return 1
 		}
 
 		append_setting "enable-dht=true"
-		append_setting "dht-file-path=${dht_file}"
+		append_setting "dht-file-path=$dht_file"
 	fi
 
 	if [ ."$enable_dht6" = ."true" ] && [ ."$disable_ipv6" != ."true" ]; then
-		dht6_file="${config_dir}/dht6.dat.${section}"
+		dht6_file="$config_dir/dht6.dat.$section"
 		_create_file "$dht6_file" || {
-			_err "Can't create DHT6 file: ${dht6_file}"
+			_err "Can't create DHT6 file: $dht6_file"
 			return 1
 		}
 
 		append_setting "enable-dht6=true"
-		append_setting "dht-file-path6=${dht6_file}"
+		append_setting "dht-file-path6=$dht6_file"
 	fi
 
 	if [ -n "$bt_tracker" ]; then
@@ -288,11 +288,11 @@ aria2_start() {
 			if [ -z "$bt_tracker_list" ]; then
 				bt_tracker_list="$t"
 			else
-				bt_tracker_list="${bt_tracker_list},${t}"
+				bt_tracker_list="$bt_tracker_list,$t"
 			fi
 		done
 
-		append_setting "bt-tracker=${bt_tracker_list}"
+		append_setting "bt-tracker=$bt_tracker_list"
 	fi
 
 	append_options "auto_save_interval" "bt_enable_lpd" "bt_max_open_files" "bt_max_peers" \
@@ -318,19 +318,19 @@ aria2_start() {
 
 	if [ -n "$user" ]; then
 		if ( user_exists "$user" && _change_owner "$user" "$config_dir" "$log" ); then
-				_info "Aria2 will run with user '${user}'."
+				_info "Aria2 will run with user '$user'."
 				if [ "$user" != "root" ]; then
-					_info "Please make sure user '${user}' has write access to download dir: ${dir}"
+					_info "Please make sure user '$user' has write access to download dir: $dir"
 				fi
 		else
-			_info "Setting run user to '${user}' failed, default user will be used."
+			_info "Setting run user to '$user' failed, default user will be used."
 			user=
 		fi
 	fi
 
-	procd_open_instance "${NAME}.${section}"
+	procd_open_instance "$NAME.$section"
 	procd_set_param command "$PROG"
-	procd_append_param command --conf-path="${config_file}"
+	procd_append_param command --conf-path="$config_file"
 
 	procd_set_param respawn
 	procd_set_param stdout 1
@@ -340,7 +340,7 @@ aria2_start() {
 	[ -n "$user" ] && \
 		procd_set_param user "$user"
 
-	procd_add_jail "${NAME}.${section}" log
+	procd_add_jail "$NAME.$section" log
 	procd_add_jail_mount "$config_file"
 	procd_add_jail_mount_rw "$dir" "$config_dir" "$log"
 	procd_close_instance
@@ -348,9 +348,10 @@ aria2_start() {
 
 service_triggers() {
 	procd_add_reload_trigger "$NAME"
+	procd_add_validation aria2_validate
 }
 
 start_service() {
 	config_load "$NAME"
-	config_foreach aria2_start "aria2"
+	config_foreach aria2_validate "aria2" aria2_start
 }


### PR DESCRIPTION
Maintainer: @kuoruan
Compile tested: armvirt-32, 2019-01-28 snapshot sdk
Run tested: armvirt-32, 2019-01-28 snapshot

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

This also lets procd trigger the validation function directly, and removes some unnecessary curly brackets.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>