### PR TITLE
clamav: Update init scripts

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clamav
 PKG_VERSION:=0.101.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr> \

--- a/net/clamav/files/clamav.init
+++ b/net/clamav/files/clamav.init
@@ -9,7 +9,7 @@ PROG=/usr/sbin/clamd
 CLAMD_CONFIGFILE="/tmp/clamav/clamd.conf"
 
 validate_clamav_section() {
-	uci_validate_section clamav clamav "${1}" \
+	uci_load_validate clamav clamav "$1" "$2" \
 		'clamd_config_file:string' \
 		'LogFile:string' \
 		'LogFileMaxSize:string' \
@@ -46,15 +46,8 @@ validate_clamav_section() {
 		'DatabaseDirectory:string'
 }
 
-start_service() {
-	local clamd_config_file LogFile LogTime StreamMinPort \
-		StreamMaxPort MaxThreads ReadTimeout CommandReadTimeout MaxDirectoryRecursion \
-		FollowFileSymlinks FollowDirectorySymlinks SelfCheck DetectPUA ScanPE DisableCertCheck \
-		ScanELF DetectBrokenExecutables ScanOLE2 ScanPDF ScanSWF ScanMail ScanPartialMessages \
-		ScanArchive TemporaryDirectory ArchiveBlockEncrypted MaxFileSize LocalSocket User \
-		DatabaseDirectory
-
-	validate_clamav_section clamav || {
+start_clamav_instance() {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
@@ -107,9 +100,14 @@ start_service() {
 	procd_close_instance
 }
 
+start_service()
+{
+	validate_clamav_section clamav start_clamav_instance
+}
+
 stop_service()
 {
-	service_stop ${PROG}
+	service_stop $PROG
 }
 
 service_triggers()

--- a/net/clamav/files/freshclam.init
+++ b/net/clamav/files/freshclam.init
@@ -9,7 +9,7 @@ PROG=/usr/sbin/freshclam
 FRESHCLAM_CONFIGFILE="/tmp/clamav/freshclam.conf"
 
 validate_freshclam_section() {
-	uci_validate_section freshclam freshclam "${1}" \
+	uci_load_validate freshclam freshclam "$1" "$2" \
 		'freshclam_config_file:string' \
 		'UpdateLogFile:string' \
 		'DatabaseMirror:string' \
@@ -19,11 +19,8 @@ validate_freshclam_section() {
 		'DatabaseDirectory:string:'
 }
 
-start_service() {
-	local freshclam_config_file UpdateLogFile DatabaseOwner NotifyClamd DatabaseMirror \
-	DatabaseDirectory
-
-	validate_freshclam_section freshclam || {
+start_freshclam_instance() {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
@@ -49,6 +46,11 @@ start_service() {
 	procd_set_param command $PROG -d --config-file=$FRESHCLAM_CONFIGFILE -p /tmp/freshclam.pid --no-warnings
 	procd_set_param file $FRESHCLAM_CONFIGFILE
 	procd_close_instance
+}
+
+start_service()
+{
+	validate_freshclam_section freshclam start_freshclam_instance
 }
 
 stop_service()


### PR DESCRIPTION
Maintainer: @ratkaj @lucize 
Compile tested: armvirt-32, 2019-01-28 snapshot sdk
Run tested: armvirt-32, 2019-01-28 snapshot

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

This also removes some unnecessary curly brackets.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>