### PR TITLE
e2guardian: Update init script

### DIFF
--- a/net/e2guardian/Makefile
+++ b/net/e2guardian/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=e2guardian
 PKG_VERSION:=3.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>

--- a/net/e2guardian/files/e2guardian.init
+++ b/net/e2guardian/files/e2guardian.init
@@ -11,7 +11,7 @@ LOGFILE="/tmp/e2guardian/access.log"
 GROUPCONFIG="/tmp/e2guardian/e2guardianf1.conf"
 
 validate_e2guardian_section() {
-	uci_validate_section e2guardian e2guardian "${1}" \
+	uci_load_validate e2guardian e2guardian "$1" "$2" \
 		'accessdeniedaddress:string' \
 		'bannediplist:string' \
 		'contentscanexceptions:string' \
@@ -83,22 +83,9 @@ validate_e2guardian_section() {
 		'weightedphrasemode:range(0,2)'
 }
 
-start_service() {
+start_e2guardian_instance() {
 
-	local accessdeniedaddress bannediplist contentscanexceptions contentscanner contentscannertimeout \
-		createlistcachefiles custombannedflashfile custombannedimagefile deletedownloadedtempfiles \
-		downloadmanager exceptioniplist filecachedir loglocation \
-		filtergroups filtergroupslist filterip filterports forcequicksearch forwardedfor hexdecodecontent \
-		initialtrickledelay ipcfilename ipipcfilename language languagedir logadblocks logchildprocesshandling \
-		logclienthostnames logconnectionhandlingerrors logexceptionhits logfileformat loglevel loguseragent \
-		maxagechildren maxchildren maxcontentfilecachescansize maxcontentfiltersize maxcontentramcachescansize \
-		maxips maxsparechildren maxuploadsize minchildren minsparechildren nodaemon nologger \
-		pcontimeout perroomdirectory phrasefiltermode prefercachedlists preforkchildren preservecase proxyexchange \
-		proxyip proxyport proxytimeout recheckreplacedurls reverseaddresslookups reverseclientiplookups scancleancache \
-		showweightedfound softrestart trickledelay urlcacheage urlcachenumber urlipcfilename usecustombannedflash \
-		usecustombannedimage usexforwardedfor weightedphrasemode
-
-	validate_e2guardian_section e2guardian || {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
@@ -196,6 +183,11 @@ start_service() {
 	procd_set_param file $CONFIGFILE
 	procd_close_instance
 
+}
+
+start_service()
+{
+	validate_e2guardian_section e2guardian start_e2guardian_instance
 }
 
 stop_service()


### PR DESCRIPTION
Maintainer: @lperkov 
Compile tested: armvirt-32, 2019-01-28 snapshot sdk
Run tested: armvirt-32, 2019-01-28 snapshot

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>