### PR TITLE
htpdate: Update init script

### DIFF
--- a/net/htpdate/Makefile
+++ b/net/htpdate/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=htpdate
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.vervest.org/htp/archive/c/

--- a/net/htpdate/files/htpdate.init
+++ b/net/htpdate/files/htpdate.init
@@ -9,7 +9,7 @@ PROG=/usr/sbin/htpdate
 
 
 validate_htpdate_section() {
-	uci_validate_section htpdate htpdate "${1}" \
+	uci_load_validate htpdate htpdate "$1" "$2" \
 		'server:list(host)' \
 		'proxy_host:host' \
 		'proxy_port:port:8080' \
@@ -20,10 +20,10 @@ validate_htpdate_section() {
 }
 
 
-start_service() {
-	local server proxy debug sanity_check option enabled
+start_htpdate_instance() {
+	local peer
 
-        validate_htpdate_section htpdate || {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
@@ -34,7 +34,7 @@ start_service() {
 	procd_open_instance
 	procd_set_param command "$PROG" -f
 
-	[ -n "$proxy" ] && procd_append_param command -P $proxy:$proxy_port
+	[ -n "$proxy_host" ] && procd_append_param command -P $proxy_host:$proxy_port
 	[ "$debug" = "1" ] && procd_append_param command -d
 	[ "$sanity_check" = "0" ] && procd_append_param command -t
 	[ -n "$option" ] && procd_append_param command $option
@@ -46,6 +46,10 @@ start_service() {
 	procd_set_param stderr 1
 	procd_set_param respawn
 	procd_close_instance
+}
+
+start_service() {
+	validate_htpdate_section htpdate start_htpdate_instance
 }
 
 service_triggers() {


### PR DESCRIPTION
Maintainer: @tisj @marcin1j
Compile tested: armvirt-32, 2019-01-28 snapshot sdk
Run tested: armvirt-32, 2019-01-28 snapshot

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

This also corrects a variable name typo ("proxy" instead of "proxy_host").

Signed-off-by: Jeffery To <jeffery.to@gmail.com>