### PR TITLE
micropython: Update to 1.10

### DIFF
--- a/lang/python/micropython/Makefile
+++ b/lang/python/micropython/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=micropython
-PKG_VERSION:=1.9.4
+PKG_VERSION:=1.10
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/micropython/micropython/releases/download/v$(PKG_VERSION)
-PKG_HASH:=0db042011bffcbd65362b67eb3cca87eaefa9f2a55b747fa75e922c706b8ce1a
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://micropython.org/resources/source
+PKG_HASH:=8488ec243217c4578f1cf2ed20e749344b01510a52d443da95304949cf7abfdb
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=MIT

--- a/lang/python/micropython/patches/000-Makefile-no-errors.patch
+++ b/lang/python/micropython/patches/000-Makefile-no-errors.patch
@@ -1,5 +1,3 @@
-diff --git a/ports/unix/Makefile b/ports/unix/Makefile
-index cbdd3f3..0ab157d 100644
 --- a/ports/unix/Makefile
 +++ b/ports/unix/Makefile
 @@ -21,7 +21,7 @@ INC +=  -I$(TOP)


### PR DESCRIPTION
Switched to official xz tarball, which is much smaller (9.1 vs. 21.4) MB.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @roger- 
Compile tested: ramips