### PR TITLE
ntpd: Update init script

### DIFF
--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntp
 PKG_VERSION:=4.2.8p12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/

--- a/net/ntpd/files/ntpd.init
+++ b/net/ntpd/files/ntpd.init
@@ -8,7 +8,7 @@ USE_PROCD=1
 PROG=/sbin/ntpd
 HOTPLUG_HELPER=/usr/sbin/ntpd.hotplug-helper
 
-config_file=/var/run/ntpd.conf
+config_file=/var/etc/ntpd.conf
 
 trunc() {
 	echo -n "" > $config_file
@@ -19,15 +19,15 @@ emit() {
 }
 
 validate_ntp_section() {
-	uci_validate_section system timeserver "${1}" \
+	uci_load_validate system timeserver "$1" "$2" \
 		'server:list(host)' 'enabled:bool:1' 'enable_server:bool:0' \
 		'interface:list(string)'
 }
 
-start_service() {
-	local server enabled enable_server interface intf
+start_ntpd_instance() {
+	local intf i
 
-	validate_ntp_section ntp || {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
@@ -84,4 +84,13 @@ start_service() {
 	procd_open_instance
 	procd_set_param command $HOTPLUG_HELPER
 	procd_close_instance
+}
+
+start_service() {
+	validate_ntp_section ntp start_ntpd_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger "system"
+	procd_add_validation validate_ntp_section
 }


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: armvirt-32, 2019-01-28 snapshot sdk
Run tested: armvirt-32, 2019-01-28 snapshot

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

This also moves the generated config file to `/var/etc` and adds a `service_triggers()` function.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>