### PR TITLE
pptpd: Update init script

### DIFF
--- a/net/pptpd/Makefile
+++ b/net/pptpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pptpd
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/poptop

--- a/net/pptpd/files/pptpd.init
+++ b/net/pptpd/files/pptpd.init
@@ -10,13 +10,13 @@ CHAP_SECRETS=/var/etc/chap-secrets
 OPTIONS_PPTP=/var/etc/options.pptpd
 
 validate_login_section() {
-	uci_validate_section pptpd login "${1}" \
+	uci_load_validate pptpd login "$1" "$2" \
 		'username:string' \
 		'password:string'
 }
 
 validate_pptpd_section() {
-	uci_validate_section pptpd service "${1}" \
+	uci_load_validate pptpd service "$1" "$2" \
 		'enabled:uinteger' \
 		'localip:string' \
 		'remoteip:string' \
@@ -25,21 +25,19 @@ validate_pptpd_section() {
 }
 
 setup_login() {
-	validate_login_section "${1}" || {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
 
-	[ -n "${username}" ] || return 0
-	[ -n "${password}" ] || return 0
+	[ -n "$username" ] || return 0
+	[ -n "$password" ] || return 0
 
-	echo "${username} pptp-server ${password} *" >> $CHAP_SECRETS
+	echo "$username pptp-server $password *" >> $CHAP_SECRETS
 }
 
 setup_config() {
-	local enabled localip remoteip mppe
-
-	validate_pptpd_section "${1}" || {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
@@ -61,12 +59,21 @@ setup_config() {
 
 start_service() {
 	config_load pptpd
-	setup_config pptpd || return
-	config_foreach setup_login login
+	validate_pptpd_section pptpd setup_config || return
+	config_foreach validate_login_section login setup_login
 
 	ln -sfn $CHAP_SECRETS /etc/ppp/chap-secrets
 
 	procd_open_instance
 	procd_set_param command $BIN -c $CONFIG --fg -o $OPTIONS_PPTP
 	procd_close_instance
+}
+
+service_triggers () {
+	procd_add_reload_trigger "pptpd"
+
+	procd_open_validate
+	validate_pptpd_section
+	validate_login_section
+	procd_close_validate
 }


### PR DESCRIPTION
Maintainer: @lperkov 
Compile tested: armvirt-32, 2019-02-03 snapshot sdk
Run tested: armvirt-32, 2019-02-03 snapshot

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

This also adds a `service_triggers()` function and removes some unnecessary curly brackets.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>