### PR TITLE
snort: Update init script

### DIFF
--- a/net/snort/Makefile
+++ b/net/snort/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort
 PKG_VERSION:=2.9.11.1
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>

--- a/net/snort/files/snort.init
+++ b/net/snort/files/snort.init
@@ -8,24 +8,27 @@ USE_PROCD=1
 PROG=/usr/bin/snort
 
 validate_snort_section() {
-	uci_validate_section snort snort "${1}" \
+	uci_load_validate snort snort "$1" "$2" \
 		'config_file:string' \
 		'interface:string'
 }
 
-start_service() {
-	local config_file interface
-
-	validate_snort_section snort || {
+start_snort_instance() {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
 
 	procd_open_instance
 	procd_set_param command $PROG "-q" "--daq-dir" "/usr/lib/daq/" "-i" "$interface" "-c" "$config_file" "-s" "-N"
-	procd_set_param file $CONFIGFILE
+	procd_set_param file $config_file
 	procd_set_param respawn
 	procd_close_instance
+}
+
+start_service()
+{
+	validate_snort_section snort start_snort_instance
 }
 
 stop_service()


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: armvirt-32, 2019-02-03 snapshot sdk
Run tested: none

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

This also fixes a variable name typo ("CONFIGFILE" instead of "config_file").

Signed-off-by: Jeffery To <jeffery.to@gmail.com>