### PR TITLE
socat: Update init script

### DIFF
--- a/net/socat/Makefile
+++ b/net/socat/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=socat
 PKG_VERSION:=1.7.3.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.dest-unreach.org/socat/download

--- a/net/socat/files/socat.init
+++ b/net/socat/files/socat.init
@@ -10,30 +10,32 @@ NAME=socat
 
 validate_section_socat()
 {
-	uci_validate_section socat socat "${1}" \
+	uci_load_validate socat socat "$1" "$2" \
 		'enable:bool:1' \
 		'SocatOptions:string'
-	return $?
 }
 
 socat_instance()
 {
-	local SocatOptions enable
-
-	validate_section_socat "${1}" || {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
 
-	[ "${enable}" = "0" ] && return 1
+	[ "$enable" = "0" ] && return 1
 
 	procd_open_instance
 	procd_set_param command "$PROG"
-	procd_append_param command ${SocatOptions}
+	procd_append_param command $SocatOptions
 	procd_close_instance
 }
 
 start_service () {
-	config_load "${NAME}"
-	config_foreach socat_instance socat
+	config_load "$NAME"
+	config_foreach validate_section_socat socat socat_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger "$NAME"
+	procd_add_validation validate_section_socat
 }


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: armvirt-32, 2019-02-03 snapshot sdk
Run tested: armvirt-32, 2019-02-03 snapshot

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

This also adds a `service_triggers()` function and removes some unnecessary curly brackets.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>