### PR TITLE
squid: Update init script

### DIFF
--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
 PKG_VERSION:=4.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>

--- a/net/squid/files/squid.init
+++ b/net/squid/files/squid.init
@@ -10,7 +10,7 @@ CONFIGFILE="/tmp/squid/squid.conf"
 MIMETABLE="/tmp/squid/mime.conf"
 
 validate_squid_section() {
-	uci_validate_section squid squid "${1}" \
+	uci_load_validate squid squid "$1" "$2" \
 		'config_file:string' \
 		'http_port:port:3128' \
 		'http_port_options:string' \
@@ -27,10 +27,10 @@ create_squid_user() {
 	group_exists squid || group_add squid $USERID && group_add_user squid squid
 }
 
-start_service() {
-	local config_file http_port http_port_options ssldb ssldb_options coredump_dir visible_hostname pinger_enable
+start_squid_instance() {
+	local config_dir
 
-	validate_squid_section squid || {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
@@ -57,9 +57,14 @@ start_service() {
 	procd_close_instance
 }
 
+start_service()
+{
+	validate_squid_section squid start_squid_instance
+}
+
 stop_service()
 {
-        ${PROG} -f $CONFIGFILE -N -k shutdown 2>/dev/null
+	$PROG -f $CONFIGFILE -N -k shutdown 2>/dev/null
 }
 
 service_triggers()


### PR DESCRIPTION
Maintainer: @ratkaj 
Compile tested: armvirt-32, 2019-02-03 snapshot sdk
Run tested: armvirt-32, 2019-02-03 snapshot

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

This also removes some unnecessary curly brackets.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>