### PR TITLE
sshtunnel: Update init script

### DIFF
--- a/net/sshtunnel/Makefile
+++ b/net/sshtunnel/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sshtunnel
 PKG_VERSION:=4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0+
 
 PKG_MAINTAINER:=Nuno Goncalves <nunojpg@gmail.com>

--- a/net/sshtunnel/files/sshtunnel.init
+++ b/net/sshtunnel/files/sshtunnel.init
@@ -29,7 +29,7 @@ append_params() {
 }
 
 append_string() {
-	local varname="$1"; local add="$2"; local separator="${3:- }"; local actual
+	local varname="$1"; local add="$2"; local separator="${3:- }"; local actual new
 	eval "actual=\$$varname"
 
 	new="${actual:+$actual$separator}$add"
@@ -37,7 +37,7 @@ append_string() {
 }
 
 validate_server_section() {
-	uci_validate_section sshtunnel server "$1" \
+	uci_load_validate sshtunnel server "$1" "$2" \
 		'user:string(1)' \
 		'hostname:host' \
 		'port:port' \
@@ -49,14 +49,14 @@ validate_server_section() {
 		'IdentityFile:file' \
 		'LogLevel:or("QUIET", "FATAL", "ERROR", "INFO", "VERBOSE", "DEBUG", "DEBUG1", "DEBUG2", "DEBUG3"):INFO' \
 		'ServerAliveCountMax:min(1)' \
-		'ServerAliveInterval:min(1)' \
-		'StrictHostKeyChecking:or("yes", "no")' \
+		'ServerAliveInterval:min(0)' \
+		'StrictHostKeyChecking:or("yes", "no", "accept-new")' \
 		'TCPKeepAlive:or("yes", "no")' \
 		'VerifyHostKeyDNS:or("yes", "no")'
 }
 
 validate_tunnelR_section() {
-	uci_validate_section sshtunnel tunnelR "$1" \
+	uci_load_validate sshtunnel tunnelR "$1" "$2" \
 		'remoteaddress:or(host, "*"):*' \
 		'remoteport:port' \
 		'localaddress:host' \
@@ -64,7 +64,7 @@ validate_tunnelR_section() {
 }
 
 validate_tunnelL_section() {
-	uci_validate_section sshtunnel tunnelL "$1" \
+	uci_load_validate sshtunnel tunnelL "$1" "$2" \
 		'remoteaddress:host' \
 		'remoteport:port' \
 		'localaddress:or(host, "*"):*' \
@@ -72,13 +72,13 @@ validate_tunnelL_section() {
 }
 
 validate_tunnelD_section() {
-	uci_validate_section sshtunnel tunnelD "$1" \
+	uci_load_validate sshtunnel tunnelD "$1" "$2" \
 		'localaddress:or(host, "*"):*' \
 		'localport:port'
 }
 
 validate_tunnelW_section() {
-	uci_validate_section sshtunnel tunnelW "$1" \
+	uci_load_validate sshtunnel tunnelW "$1" "$2" \
 		'vpntype:or("ethernet", "point-to-point"):point-to-point' \
 		'localdev:or("any", min(1))' \
 		'remotedev:or("any", min(1))'
@@ -91,15 +91,14 @@ load_tunnelR() {
 	[ "$server" = "$section_server" ] || return 0
 
 	# validate and load this remote tunnel config
-	local remoteaddress remoteport localaddress localport
-	validate_tunnelR_section "$1" || { _err "tunnelR ${1}: validation failed"; return 1; }
+	[ "$2" = 0 ] || { _err "tunnelR $1: validation failed"; return 1; }
 
-	[ -n "$remoteport" -a -n "$localport" -a -n "$remoteaddress" ] || { _err "tunnelR ${1}: missing required options"; return 1; }
+	[ -n "$remoteport" -a -n "$localport" -a -n "$remoteaddress" ] || { _err "tunnelR $1: missing required options"; return 1; }
 
 	# count nr of valid sections to make sure there are at least one
 	let count++
 
-	_log "tunnelR at ${server}: -R $remoteaddress:$remoteport:$localaddress:$localport"
+	_log "tunnelR at $server: -R $remoteaddress:$remoteport:$localaddress:$localport"
 	append_string "ARGS_tunnels" "-R $remoteaddress:$remoteport:$localaddress:$localport"
 }
 
@@ -110,15 +109,14 @@ load_tunnelL() {
 	[ "$server" = "$section_server" ] || return 0
 
 	# validate and load this remote tunnel config
-	local remoteaddress remoteport localaddress localport
-	validate_tunnelL_section "$1" || { _err "tunnelL ${1}: validation failed"; return 1; }
+	[ "$2" = 0 ] || { _err "tunnelL $1: validation failed"; return 1; }
 
-	[ -n "$remoteport" -a -n "$localport" -a -n "$remoteaddress" ] || { _err "tunnelL ${1}: missing required options"; return 1; }
+	[ -n "$remoteport" -a -n "$localport" -a -n "$remoteaddress" ] || { _err "tunnelL $1: missing required options"; return 1; }
 
 	# count nr of valid sections to make sure there are at least one
 	let count++
 
-	_log "tunnelL at ${server}: -L $localaddress:$localport:$remoteaddress:$remoteport"
+	_log "tunnelL at $server: -L $localaddress:$localport:$remoteaddress:$remoteport"
 	append_string "ARGS_tunnels" "-L $localaddress:$localport:$remoteaddress:$remoteport"
 }
 
@@ -129,15 +127,14 @@ load_tunnelD() {
 	[ "$server" = "$section_server" ] || return 0
 
 	# validate and load this remote tunnel config
-	local localaddress localport
-	validate_tunnelD_section "$1" || { _err "tunnelD ${1}: validation failed"; return 1; }
+	[ "$2" = 0 ] || { _err "tunnelD $1: validation failed"; return 1; }
 
-	[ -n "$localport" ] || { _err "tunnelD ${1}: missing localport"; return 1; }
+	[ -n "$localport" ] || { _err "tunnelD $1: missing localport"; return 1; }
 
 	# count nr of valid sections to make sure there are at least one
 	let count++
 
-	_log "proxy via ${server}: -D $localaddress:$localport"
+	_log "proxy via $server: -D $localaddress:$localport"
 	append_string "ARGS_tunnels" "-D $localaddress:$localport"
 }
 
@@ -148,38 +145,34 @@ load_tunnelW() {
 	[ "$server" = "$section_server" ] || return 0
 
 	# validate and load this remote tunnel config
-	local localdev remotedev vpntype
-	validate_tunnelW_section "$1" || { _err "tunnelW ${1}: validation failed"; return 1; }
+	[ "$2" = 0 ] || { _err "tunnelW $1: validation failed"; return 1; }
 
 	[ -n "$vpntype" -a -n "$localdev" -a -n "$remotedev" ] || { _err "tunnelW $1: missing or bad options"; return 1; }
 
-	[ "$user" == "root" ] || { _err "tunnelW ${1}: root is required for tun"; return 1; }
+	[ "$user" = "root" ] || { _err "tunnelW $1: root is required for tun"; return 1; }
 
 	# count nr of valid sections to make sure there are at least one
 	let count++
 
-	_log "tunnelW to ${server}: -w $localdev:$remotedev -o Tunnel=$vpntype"
+	_log "tunnelW to $server: -w $localdev:$remotedev -o Tunnel=$vpntype"
 	append_string "ARGS_tunnels" "-w $localdev:$remotedev -o Tunnel=$vpntype"
 }
 
 load_server() {
-	server="$1"
-	local user hostname port retrydelay PKCS11Provider CheckHostIP Compression \
-		CompressionLevel IdentityFile LogLevel ServerAliveCountMax \
-		ServerAliveInterval StrictHostKeyChecking TCPKeepAlive VerifyHostKeyDNS
+	local server="$1"
 
-	validate_server_section "$server" || { _err "server ${server}: validation failed"; return 1; }
+	[ "$2" = 0 ] || { _err "server $server: validation failed"; return 1; }
 
-	ARGS=""
-	ARGS_options=""
-	ARGS_tunnels=""
-	count=0
+	local ARGS=""
+	local ARGS_options=""
+	local ARGS_tunnels=""
+	local count=0
 
-	config_foreach load_tunnelR "tunnelR"
-	config_foreach load_tunnelL "tunnelL"
-	config_foreach load_tunnelD "tunnelD"
-	config_foreach load_tunnelW "tunnelW"
-	[ "$count" -eq 0 ] && { _err "tunnels to ${server} not started - no tunnels defined"; return 1; }
+	config_foreach validate_tunnelR_section "tunnelR" load_tunnelR
+	config_foreach validate_tunnelL_section "tunnelL" load_tunnelL
+	config_foreach validate_tunnelD_section "tunnelD" load_tunnelD
+	config_foreach validate_tunnelW_section "tunnelW" load_tunnelW
+	[ "$count" -eq 0 ] && { _err "tunnels to $server not started - no tunnels defined"; return 1; }
 
 	append_params CheckHostIP Compression CompressionLevel IdentityFile \
 		LogLevel PKCS11Provider ServerAliveCountMax ServerAliveInterval \
@@ -197,7 +190,7 @@ load_server() {
 
 start_service() {
 	config_load "sshtunnel"
-	config_foreach load_server "server"
+	config_foreach validate_server_section "server" load_server
 }
 
 service_triggers() {

--- a/net/sshtunnel/files/uci_sshtunnel
+++ b/net/sshtunnel/files/uci_sshtunnel
@@ -18,7 +18,7 @@
 #	option PKCS11Provider		/lib/pteidpkcs11.so
 #	option ServerAliveCountMax	3
 #	option ServerAliveInterval	0
-#	option StrictHostKeyChecking	ask
+#	option StrictHostKeyChecking	accept-new
 #	option TCPKeepAlive		yes
 #	option VerifyHostKeyDNS		yes
 


### PR DESCRIPTION
Maintainer: @nunojpg 
Compile tested: armvirt-32, 2019-02-03 snapshot sdk
Run tested: armvirt-32, 2019-02-03 snapshot

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

This also fixes some validation, makes variable declarations local, removes unnecessary curly brackets.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>