### PR TITLE
wifidog-ng: Update init script

### DIFF
--- a/net/wifidog-ng/Makefile
+++ b/net/wifidog-ng/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifidog-ng
 PKG_VERSION:=2.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)
 

--- a/net/wifidog-ng/files/wifidog-ng.init
+++ b/net/wifidog-ng/files/wifidog-ng.init
@@ -5,26 +5,27 @@ START=95
 
 BIN=/usr/bin/wifidog-ng
 
-dhcp_host_white=1
+global_dhcp_host_white=1
 
-start_wifidog() {
-	local cfg="$1"
-	local enabled interface
-
-	uci_validate_section wifidog-ng gateway "${1}" \
+validate_gateway_section() {
+	uci_load_validate wifidog-ng gateway "$1" "$2" \
 		'enabled:bool:0' \
 		'interface:uci("network", "@interface"):lan' \
 		'dhcp_host_white:bool:1'
+}
 
-	[ $? -ne 0 ] && {
+start_wifidog() {
+	[ "$2" = 0 ] || {
 		echo "validation gateway failed" >&2
 		exit 1
 	}
 
-	[ $enabled -eq 1 ] || exit 0
+	[ $enabled = 1 ] || exit 0
 
-	# timeout = 49 days
-	ipset -! create wifidog-ng-mac hash:mac timeout 4294967
+	[ $dhcp_host_white = 1 ] || global_dhcp_host_white=0
+
+	# timeout = 24.855 days
+	ipset -! create wifidog-ng-mac hash:mac timeout 2147483
 	ipset -! create wifidog-ng-ip hash:ip
 
 	modprobe wifidog-ng
@@ -36,28 +37,31 @@ start_wifidog() {
 	procd_close_instance
 }
 
-parse_server() {
-	local cfg="$1"
-	local host
+validate_server_section() {
+	uci_load_validate wifidog-ng server "$1" "$2" \
+		'host:host'
+}
 
-	config_get host $cfg host
-	validate_data ip4addr "$host" 2> /dev/null
-	if [ $? -eq 0 ];
-	then
+parse_server() {
+	[ "$2" = 0 ] || {
+		echo "validation server failed" >&2
+		exit 1
+	}
+
+	if validate_data ip4addr "$host" 2> /dev/null; then
 		ipset add wifidog-ng-ip $host
 	else
 		echo "ipset=/$host/wifidog-ng-ip" >> /tmp/dnsmasq.d/wifidog-ng
 	fi
 }
 
-parse_validated_user() {
-	local cfg="$1"
-	local mac ip
-
-	uci_validate_section wifidog-ng validated_user "${1}" \
+validate_validated_user_section() {
+	uci_load_validate wifidog-ng validated_user "$1" "$2" \
 		'mac:macaddr'
+}
 
-	[ $? -ne 0 ] && {
+parse_validated_user() {
+	[ "$2" = 0 ] || {
 		echo "validation validated_user failed" >&2
 		exit 1
 	}
@@ -65,14 +69,13 @@ parse_validated_user() {
 	[ -n "$mac" ] && ipset add wifidog-ng-mac $mac
 }
 
-parse_validated_domain() {
-	local cfg="$1"
-	local domain
-
-	uci_validate_section wifidog-ng validated_domain "${1}" \
+validate_validated_domain_section() {
+	uci_load_validate wifidog-ng validated_domain "$1" "$2" \
 		'domain:host'
+}
 
-	[ $? -ne 0 ] && {
+parse_validated_domain() {
+	[ "$2" = 0 ] || {
 		echo "validation validated_domain failed" >&2
 		exit 1
 	}
@@ -80,14 +83,13 @@ parse_validated_domain() {
 	[ -n "$domain" ] && echo "ipset=/$domain/wifidog-ng-ip" >> /tmp/dnsmasq.d/wifidog-ng
 }
 
-parse_dhcp_host() {
-	local cfg="$1"
-	local mac ip
-
-	uci_validate_section dhcp host "${1}" \
+validate_dhcp_host_section() {
+	uci_load_validate dhcp host "$1" "$2" \
 		'mac:macaddr'
+}
 
-	[ $? -ne 0 ] && {
+parse_dhcp_host() {
+	[ "$2" = 0 ] || {
 		echo "validation validated dhcp host failed" >&2
 		exit 1
 	}
@@ -97,17 +99,17 @@ parse_dhcp_host() {
 
 start_service() {
 	config_load wifidog-ng
-	config_foreach start_wifidog gateway
+	config_foreach validate_gateway_section gateway start_wifidog
 
 	echo -n > /tmp/dnsmasq.d/wifidog-ng
 
-	config_foreach parse_server server
-	config_foreach parse_validated_user validated_user
-	config_foreach parse_validated_domain validated_domain
+	config_foreach validate_server_section server parse_server
+	config_foreach validate_validated_user_section validated_user parse_validated_user
+	config_foreach validate_validated_domain_section validated_domain parse_validated_domain
 
-	[ $dhcp_host_white -eq 1 ] && {
+	[ $global_dhcp_host_white = 1 ] && {
 		config_load dhcp
-		config_foreach parse_dhcp_host host
+		config_foreach validate_dhcp_host_section host parse_dhcp_host
 	}
 
 	/etc/init.d/dnsmasq restart &
@@ -118,4 +120,16 @@ stop_service() {
 
 	ipset destroy wifidog-ng-mac
 	ipset destroy wifidog-ng-ip
+}
+
+service_triggers() {
+	procd_add_reload_trigger "wifidog-ng"
+
+	procd_open_validate
+	validate_gateway_section
+	validate_server_section
+	validate_validated_user_section
+	validate_validated_domain_section
+	validate_dhcp_host_section
+	procd_close_validate
 }

--- a/net/wifidog-ng/files/wifidog-ng.init
+++ b/net/wifidog-ng/files/wifidog-ng.init
@@ -8,114 +8,114 @@ BIN=/usr/bin/wifidog-ng
 dhcp_host_white=1
 
 start_wifidog() {
-    local cfg="$1"
-    local enabled interface
+	local cfg="$1"
+	local enabled interface
 
-    uci_validate_section wifidog-ng gateway "${1}" \
-        'enabled:bool:0' \
-        'interface:uci("network", "@interface"):lan' \
-        'dhcp_host_white:bool:1'
+	uci_validate_section wifidog-ng gateway "${1}" \
+		'enabled:bool:0' \
+		'interface:uci("network", "@interface"):lan' \
+		'dhcp_host_white:bool:1'
 
-    [ $? -ne 0 ] && {
-        echo "validation gateway failed" >&2
-        exit 1
-    }
+	[ $? -ne 0 ] && {
+		echo "validation gateway failed" >&2
+		exit 1
+	}
 
-    [ $enabled -eq 1 ] || exit 0
+	[ $enabled -eq 1 ] || exit 0
 
-    # timeout = 49 days
-    ipset -! create wifidog-ng-mac hash:mac timeout 4294967
-    ipset -! create wifidog-ng-ip hash:ip
+	# timeout = 49 days
+	ipset -! create wifidog-ng-mac hash:mac timeout 4294967
+	ipset -! create wifidog-ng-ip hash:ip
 
-    modprobe wifidog-ng
-    echo "enabled=1" > /proc/wifidog-ng/config
-    
-    procd_open_instance
-    procd_set_param command $BIN
-    procd_set_param respawn
-    procd_close_instance
+	modprobe wifidog-ng
+	echo "enabled=1" > /proc/wifidog-ng/config
+
+	procd_open_instance
+	procd_set_param command $BIN
+	procd_set_param respawn
+	procd_close_instance
 }
 
 parse_server() {
-    local cfg="$1"
-    local host
+	local cfg="$1"
+	local host
 
-    config_get host $cfg host
-    validate_data ip4addr "$host" 2> /dev/null
-    if [ $? -eq 0 ];
-    then
-        ipset add wifidog-ng-ip $host
-    else
-        echo "ipset=/$host/wifidog-ng-ip" >> /tmp/dnsmasq.d/wifidog-ng
-    fi
+	config_get host $cfg host
+	validate_data ip4addr "$host" 2> /dev/null
+	if [ $? -eq 0 ];
+	then
+		ipset add wifidog-ng-ip $host
+	else
+		echo "ipset=/$host/wifidog-ng-ip" >> /tmp/dnsmasq.d/wifidog-ng
+	fi
 }
 
 parse_validated_user() {
-    local cfg="$1"
-    local mac ip
+	local cfg="$1"
+	local mac ip
 
-    uci_validate_section wifidog-ng validated_user "${1}" \
-        'mac:macaddr'
+	uci_validate_section wifidog-ng validated_user "${1}" \
+		'mac:macaddr'
 
-    [ $? -ne 0 ] && {
-        echo "validation validated_user failed" >&2
-        exit 1
-    }
+	[ $? -ne 0 ] && {
+		echo "validation validated_user failed" >&2
+		exit 1
+	}
 
-    [ -n "$mac" ] && ipset add wifidog-ng-mac $mac
+	[ -n "$mac" ] && ipset add wifidog-ng-mac $mac
 }
 
 parse_validated_domain() {
-    local cfg="$1"
-    local domain
+	local cfg="$1"
+	local domain
 
-    uci_validate_section wifidog-ng validated_domain "${1}" \
-        'domain:host'
+	uci_validate_section wifidog-ng validated_domain "${1}" \
+		'domain:host'
 
-    [ $? -ne 0 ] && {
-        echo "validation validated_domain failed" >&2
-        exit 1
-    }
+	[ $? -ne 0 ] && {
+		echo "validation validated_domain failed" >&2
+		exit 1
+	}
 
-    [ -n "$domain" ] && echo "ipset=/$domain/wifidog-ng-ip" >> /tmp/dnsmasq.d/wifidog-ng
+	[ -n "$domain" ] && echo "ipset=/$domain/wifidog-ng-ip" >> /tmp/dnsmasq.d/wifidog-ng
 }
 
 parse_dhcp_host() {
-    local cfg="$1"
-    local mac ip
+	local cfg="$1"
+	local mac ip
 
-    uci_validate_section dhcp host "${1}" \
-        'mac:macaddr'
+	uci_validate_section dhcp host "${1}" \
+		'mac:macaddr'
 
-    [ $? -ne 0 ] && {
-        echo "validation validated dhcp host failed" >&2
-        exit 1
-    }
+	[ $? -ne 0 ] && {
+		echo "validation validated dhcp host failed" >&2
+		exit 1
+	}
 
-    [ -n "$mac" ] && ipset add wifidog-ng-mac $mac
+	[ -n "$mac" ] && ipset add wifidog-ng-mac $mac
 }
 
 start_service() {
-    config_load wifidog-ng
-    config_foreach start_wifidog gateway
+	config_load wifidog-ng
+	config_foreach start_wifidog gateway
 
-    echo -n > /tmp/dnsmasq.d/wifidog-ng
+	echo -n > /tmp/dnsmasq.d/wifidog-ng
 
-    config_foreach parse_server server
-    config_foreach parse_validated_user validated_user    
-    config_foreach parse_validated_domain validated_domain
+	config_foreach parse_server server
+	config_foreach parse_validated_user validated_user
+	config_foreach parse_validated_domain validated_domain
 
-    [ $dhcp_host_white -eq 1 ] && {
-        config_load dhcp
-        config_foreach parse_dhcp_host host
-    }
+	[ $dhcp_host_white -eq 1 ] && {
+		config_load dhcp
+		config_foreach parse_dhcp_host host
+	}
 
-    /etc/init.d/dnsmasq restart &
+	/etc/init.d/dnsmasq restart &
 }
 
 stop_service() {
-    rmmod wifidog-ng
+	rmmod wifidog-ng
 
-    ipset destroy wifidog-ng-mac
-    ipset destroy wifidog-ng-ip
+	ipset destroy wifidog-ng-mac
+	ipset destroy wifidog-ng-ip
 }


### PR DESCRIPTION
Maintainer: @zhaojh329 
Compile tested: armvirt-32, 2019-02-03 snapshot sdk
Run tested: armvirt-32, 2019-02-03 snapshot

Description:
The first commit converts the init script to use tabs for indentation. (I thought separating this into its own commit would make the real init script changes easier to see.)

The second commit ("wifidog-ng: Update init script"):
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.
    
This also adds a `service_triggers()` function.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>