### PR TITLE
perl: fix host linking for perl submodules

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \
@@ -89,7 +89,12 @@ define Host/Install
 	# Link any possibly installed static extension in
 	$(MAKE) -C $(HOST_BUILD_DIR)/relink clean || true
 	( cd $(HOST_BUILD_DIR)/relink && $(HOST_PERL_PREFIX)/bin/perl Makefile.PL )
+	( rm -f $(STAGING_DIR_HOST)/bin/perl && $(LN) $(HOST_PERL_PREFIX)/bin/perl $(STAGING_DIR_HOST)/bin/perl )
 	$(call perlmod/host/relink,$(HOST_BUILD_DIR)/relink)
+endef
+
+define Host/Uninstall
+	( rm -f $(STAGING_DIR_HOST)/bin/perl && $(LN) /usr/bin/perl $(STAGING_DIR_HOST)/bin/perl )
 endef
 
 # Target perl


### PR DESCRIPTION
$(STAGING_DIR_HOST)/bin/perl exists and is linked to /usr/bin/perl
when building packages that needs perl/host, they will link and check against
that, this is not ok if you want to build perl/host submodules as they will
not be found by build configure of package needing it

if perl/host is needed link against $(STAGING_DIR_HOSTPKG) perl so additional
submodule linking will be possible

solves at least xkeyboard-config "XML::Parser perl module is required for intltool"

I don't know why /usr/bin/perl is linked by default in host folder, because without, the config file will find /usr/bin/perl and host packages should prefer the host compiled packages

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Maintainer:  @pprindeville 
Compile/Run tested: x86/x86_64

