### PR TITLE
Adblock config: Added new Steven Blacks hosts list

### DIFF
--- a/net/adblock/files/adblock.conf
+++ b/net/adblock/files/adblock.conf
@@ -74,6 +74,12 @@ config source 'openphish'
 	option adb_src_desc 'focus on phishing, numerous updates on the same day, approx. 2.400 entries'
 	option enabled '0'
 
+config source 'steven_black'
+	option adb_src 'https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts'
+	option adb_src_rset '/^0\.0\.0\.0[[:space:]]+([[:alnum:]_-]+\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower(\$2)}'
+	option adb_src_desc 'Steven Black List, approx. 40.000 entries'
+	option enabled '0'
+
 config source 'ransomware'
 	option adb_src 'https://ransomwaretracker.abuse.ch/downloads/RW_DOMBL.txt'
 	option adb_src_rset '/^([[:alnum:]_-]+\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower(\$1)}'


### PR DESCRIPTION
Maintainer: dibdot
Compile tested: no, just a config file
Run tested: PC Engines APU 2, current OpenWrt

Description: Additional hosts list from Steven Black.

Signed-off-by: Patric <rir0@maqsis.ch>