### PR TITLE
mariadb: security bump to 10.1.38

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
-PKG_VERSION:=10.1.37
+PKG_VERSION:=10.1.38
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -18,7 +18,7 @@ PKG_SOURCE_URL := \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/$(PKG_NAME)-$(PKG_VERSION)/source \
 	https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
 
-PKG_HASH:=8cd516b0a7f7aa36a7c1d6e687dbbad8c0b08c92d5fd60c6e691b19a6cab4d46
+PKG_HASH:=caf1f4fc237d143343995b6625375aef911dfc366433645d400727e7063f077f
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING

--- a/utils/mariadb/patches/100-fix_hostname.patch
+++ b/utils/mariadb/patches/100-fix_hostname.patch
@@ -1,6 +1,6 @@
 --- a/scripts/mysql_install_db.sh
 +++ b/scripts/mysql_install_db.sh
-@@ -384,7 +384,7 @@ fi
+@@ -394,7 +394,7 @@ fi
  
  
  # Try to determine the hostname


### PR DESCRIPTION
Upstream Release Notes:

- MDEV-17475: Maximum value of table_definition_cache is now 2097152
- MDEV-13671: InnoDB should use case-insensitive column name comparisons
  like the rest of the server
- ALTER TABLE fixes: MDEV-17230, MDEV-16499, MDEV-17904, MDEV-17833,
  MDEV-17470, MDEV-18237, MDEV-18016
- Improvements to InnoDB page checksum, recovery, and Mariabackup:
  MDEV-17957, MDEV-12112, MDEV-18025, MDEV-18279, MDEV-18183
- Galera
  - MDEV-15740: Galera durability fix
  - New configuration variable wsrep_certification_rules, used for
    controlling whether to use new/optimized
    (--wsrep_certification_rules=optimized) certification rules or the
    old/classic ones (--wsrep_certification_rules=strict). Setting the
    variable to strict can cause more certification failures.

- Fixes for the following security vulnerabilities:
  - CVE-2019-2537
  - CVE-2019-2529

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: mips24kc 18.06
Run tested: mips24kc, dlink dir-825-c1, ran server, created database and user, created table, inserted some items etc.

Description:
mariadb bump, addresses two CVEs.