### PR TITLE
noddos: Fix compilation after ipset 7 update

### DIFF
--- a/net/noddos/Makefile
+++ b/net/noddos/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 # Name and release number of this package
 PKG_NAME:=noddos
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPLv3
 PKG_MAINTAINER:=Steven Hessing <steven.hessing@gmail.com>
 
@@ -39,6 +39,8 @@ endef
 define Package/noddos/conffiles
 	/etc/config/noddos
 endef
+
+TARGET_CXXFLAGS += -fpermissive
 
 define Package/noddos/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/net/noddos/patches/020-fix-ipset-7.patch
+++ b/net/noddos/patches/020-fix-ipset-7.patch
@@ -1,0 +1,302 @@
+--- a/src/Ipset.cxx
++++ b/src/Ipset.cxx
+@@ -104,9 +104,9 @@ void Ipset::Open (const std::string inIpsetName, std::string inIpsetType, bool i
+     }
+     int r = ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str());
+     if ( r < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
+     } else if (r > 0) {
+         if (Debug == true) {
+             syslog (LOG_DEBUG, "Ipset: Not creating set %s as it already exists", ipsetName.c_str());
+@@ -115,27 +115,27 @@ void Ipset::Open (const std::string inIpsetName, std::string inIpsetType, bool i
+         return;
+     }
+     if (ipset_session_data_set(session, IPSET_OPT_TYPENAME, ipsetType.c_str()) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s to type %s: %s", ipsetName.c_str(), ipsetType.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s to type %s: %s", ipsetName.c_str(), ipsetType.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set type " + ipsetType + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set type " + ipsetType + ": " + ipset_session_report_msg(session));
+     }
+     const struct ipset_type *type = ipset_type_get(session, IPSET_CMD_CREATE);
+     if (type == NULL) {
+-        syslog (LOG_ERR, "Ipset: Can't set create ip %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set create ip %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't create ipset " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't create ipset " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+ 
+     uint32_t timeout = 0; /* default to infinity */
+     if (ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s to timeout %d: %s", ipsetName.c_str(), timeout, ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s to timeout %d: %s", ipsetName.c_str(), timeout, ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set time-out " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set time-out " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_session_data_set(session, IPSET_OPT_TYPE, type)) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s option type: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s option type: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set ipset type: " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set ipset type: " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     uint8_t family = 0;
+     if (ipsetType == "hash:ip" && isIpsetv4 == true) {
+@@ -149,20 +149,20 @@ void Ipset::Open (const std::string inIpsetName, std::string inIpsetType, bool i
+         throw std::invalid_argument("Unknown ipset data type " + ipsetType);
+     }
+     if (ipset_session_data_set(session, IPSET_OPT_FAMILY, &family) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s address family %d: %s", ipsetName.c_str(), family, ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s address family %d: %s", ipsetName.c_str(), family, ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Cannot set ipset family: " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Cannot set ipset family: " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+ 
+     if (ipset_cmd(session, IPSET_CMD_CREATE, /*lineno*/ 0) != 0) {
+-        syslog (LOG_ERR, "Ipset: Can't create setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't create setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Failed to create ipset " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Failed to create ipset " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_commit(session) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     ipset_session_fini(session);
+ }
+@@ -186,20 +186,20 @@ bool Ipset::ipset_exec(enum ipset_cmd cmd) {
+         throw std::runtime_error ("Can't set environment option.");
+     }
+     if (ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str()) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+ 
+     if (ipset_cmd(session, cmd, 0) != 0) {
+         ipset_session_fini(session);
+-        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
+-        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
++        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_commit(session) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     ipset_session_fini(session);
+     return true;
+@@ -223,48 +223,48 @@ bool Ipset::ipset_exec(enum ipset_cmd cmd,  const Tins::IPv4Address &inIpAddress
+         throw std::runtime_error ("Can't set environment option.");
+     }
+     if (ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str()) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     const struct ipset_type *type = ipset_type_get(session, cmd);
+     if (type == NULL) {
+-        syslog (LOG_ERR, "Ipset: Can't get type for set %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't get type for set %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+ 
+     uint8_t family = NFPROTO_IPV4;
+     if (ipset_session_data_set(session, IPSET_OPT_FAMILY, &family) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set session data to IPv4 family for set %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set session data to IPv4 family for set %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set session data for " + ipsetName + " to the IPv4 family, error: " + ipset_session_error(session));
++        throw std::runtime_error("Can't set session data for " + ipsetName + " to the IPv4 family, error: " + ipset_session_report_msg(session));
+     }
+     struct in_addr sin;
+     inet_aton (inIpAddress.to_string().c_str(), &sin);
+     if (ipset_session_data_set(session, IPSET_OPT_IP, &sin) < 0) {
+-        syslog (LOG_ERR, "Can't set session data to the IPv4 address for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Can't set session data to the IPv4 address for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set session data to the IPv4 address for setname " + ipsetName + ", error: " + ipset_session_error(session));
++        throw std::runtime_error("Can't set session data to the IPv4 address for setname " + ipsetName + ", error: " + ipset_session_report_msg(session));
+     }
+ 
+     if (timeout) {
+         if (ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout) != 0) {
+-            syslog (LOG_ERR, "Ipset: Can't set timeout for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++            syslog (LOG_ERR, "Ipset: Can't set timeout for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+             ipset_session_fini(session);
+-            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_error(session));
++            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_report_msg(session));
+             return false;
+         }
+     }
+     if (ipset_cmd(session, cmd, 0) != 0) {
+         ipset_session_fini(session);
+-        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
+-        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
++        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_commit(session) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     ipset_session_fini(session);
+     return true;
+@@ -287,48 +287,48 @@ bool Ipset::ipset_exec(enum ipset_cmd cmd,  const Tins::IPv6Address &inIpAddress
+         throw std::runtime_error ("Can't set environment option.");
+     }
+     if (ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str()) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     const struct ipset_type *type = ipset_type_get(session, cmd);
+     if (type == NULL) {
+-        syslog (LOG_ERR, "Ipset: Can't get type for set %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't get type for set %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+ 
+     uint8_t family = NFPROTO_IPV6;
+     if (ipset_session_data_set(session, IPSET_OPT_FAMILY, &family) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set session data to IPv6 family for set %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set session data to IPv6 family for set %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set session data for " + ipsetName + " to the IPv6 family, error: " + ipset_session_error(session));
++        throw std::runtime_error("Can't set session data for " + ipsetName + " to the IPv6 family, error: " + ipset_session_report_msg(session));
+     }
+ 
+     unsigned char buf[sizeof(struct in6_addr)];
+     int s = inet_pton(AF_INET6, inIpAddress.to_string().c_str(), buf);
+     if (ipset_session_data_set(session, IPSET_OPT_IP, &buf) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set session data to the IPv4 address for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set session data to the IPv4 address for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set session data to the IPv4 address for setname " + ipsetName + ", error: " + ipset_session_error(session));
++        throw std::runtime_error("Can't set session data to the IPv4 address for setname " + ipsetName + ", error: " + ipset_session_report_msg(session));
+     }
+ 
+     if (timeout) {
+         if (ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout) != 0) {
+-            syslog (LOG_ERR, "Ipset: Can't set timeout for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++            syslog (LOG_ERR, "Ipset: Can't set timeout for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+             ipset_session_fini(session);
+-            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_error(session));
++            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_report_msg(session));
+         }
+     }
+     if (ipset_cmd(session, cmd, 0) != 0) {
+-        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_commit(session) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     ipset_session_fini(session);
+     return true;
+@@ -351,37 +351,37 @@ bool Ipset::ipset_exec(enum ipset_cmd cmd, const std::string Mac, time_t timeout
+         throw std::runtime_error ("Can't set environment option.");
+     }
+     if (ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str()) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     const struct ipset_type *type = ipset_type_get(session, cmd);
+     if (type == NULL) {
+-        syslog (LOG_ERR, "Ipset: Can't get type for set %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't get type for set %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_parse_elem(session, (ipset_opt)type->last_elem_optional, Mac.c_str()) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't call ipset_parse_elem for %s: %s ", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't call ipset_parse_elem for %s: %s ", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't call ipset_parse_elem for ipset " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't call ipset_parse_elem for ipset " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (timeout) {
+         if (ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout) != 0) {
+-            syslog (LOG_ERR, "Ipset: Can't set timeout for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++            syslog (LOG_ERR, "Ipset: Can't set timeout for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+             ipset_session_fini(session);
+-            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_error(session));
++            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_report_msg(session));
+         }
+     }
+     if (ipset_cmd(session, cmd, 0) != 0) {
+-        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_commit(session) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     ipset_session_fini(session);
+     return true;
+--- a/src/Ipset.h
++++ b/src/Ipset.h
+@@ -35,6 +35,7 @@
+ #include <libipset/linux_ip_set.h>
+ #include <libipset/types.h>
+ #include <libipset/session.h>
++#include <libipset/ipset.h>
+ 
+ #include <tins/ip_address.h>
+ #include <tins/ipv6_address.h>
+@@ -113,9 +114,9 @@ public:
+             }
+             int r = ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str());
+             if (ipset_commit(session) < 0) {
+-                syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++                syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+                 ipset_session_fini(session);
+-                throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
++                throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
+             }
+             ipset_session_fini(session);
+             return r == 0;


### PR DESCRIPTION
ipset 7 introduced several API changes. This fixes noddos to at least
compile.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @StevenHessing 
Compile tested: ath79