### PR TITLE
Various fixes for acme package

### DIFF
--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -180,6 +180,7 @@ issue_cert()
     local failed_dir
     local webroot
     local dns
+    local ret
 
     config_get_bool enabled "$section" enabled 0
     config_get_bool use_staging "$section" use_staging
@@ -211,8 +212,9 @@ issue_cert()
             moved_staging=1
         else
             log "Found previous cert config. Issuing renew."
-            $ACME --home "$STATE_DIR" --renew -d "$main_domain" $acme_args || return 1
-            return 0
+            $ACME --home "$STATE_DIR" --renew -d "$main_domain" $acme_args && ret=0 || ret=1
+            post_checks
+            return $ret
         fi
     fi
 
@@ -231,6 +233,7 @@ issue_cert()
     else
         if [ ! -d "$webroot" ]; then
             err "$main_domain: Webroot dir '$webroot' does not exist!"
+            post_checks
             return 1
         fi
         log "Using webroot dir: $webroot"

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -132,9 +132,9 @@ post_checks()
     if [ -e /etc/init.d/uhttpd ] && ( [ -n "$UHTTPD_LISTEN_HTTP" ] || [ $UPDATE_UHTTPD -eq 1 ] ); then
         if [ -n "$UHTTPD_LISTEN_HTTP" ]; then
             uci set uhttpd.main.listen_http="$UHTTPD_LISTEN_HTTP"
-            uci commit uhttpd
             UHTTPD_LISTEN_HTTP=
         fi
+        uci commit uhttpd
         /etc/init.d/uhttpd reload
     fi
 


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: n/a, shell script
Run tested: ar71xx, OpenWrt 18.06.2, issue and renew certificate

Description:
* Firewall configuration is not restored when certificate is renewed
* uhttpd configuration is only updated when uhttpd was listening on http port

My configuration: target domain only have AAAA record, uhttpd doesn't listen on http port.