### PR TITLE
boost: Release update with minor fix

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.69.0
 PKG_SOURCE_VERSION:=1_69_0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/
@@ -500,7 +500,7 @@ define Build/InstallDev
 
 	$(INSTALL_DIR) $(1)/usr/lib
 	# copies all compiled archive and shared object files
-	$(CP) -v $(PKG_INSTALL_DIR)/lib/*.{a,so*} $(1)/usr/lib/
+	$(CP) -v $(PKG_INSTALL_DIR)/lib/*.{a,so*} $(1)/usr/lib/ || :
 endef
 
 define Host/Install


### PR DESCRIPTION
Maintainer: @ClaymorePT 
Compile tested: Raspberry Pi 3 on OpenWRT https://github.com/openwrt/openwrt/commit/5fd68d60e422492dfad0d4f77f1bef3d0ea079ba
Run tested: N/A

Description:
This commit fixes the bug described in issue #8146 , where the
package fails to build if the boost package is selected without
selecting any of the internal non-header-only libraries.

Signed-off-by: Carlos Miguel Ferreira <carlosmf.pt@gmail.com>
