### PR TITLE
rpcd-mod-poe: add package

### DIFF
--- a/utils/rpcd-mod-poe/Makefile
+++ b/utils/rpcd-mod-poe/Makefile
@@ -1,0 +1,41 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rpcd-mod-poe
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/rpcd-mod-poe
+  SECTION:=utils
+  CATEGORY:=Base system
+  TITLE:=OpenWrt ubus PoE interface
+  MAINTAINER:=Paul Spooren <mail@aparcar.org>
+  DEPENDS:=+rpcd +kmod-i2c-gpio-custom
+endef
+
+define Package/rpcd-mod-poe/description
+	Expose ubus procedures to query, enable and disable the per-port PoE power
+	on Ubiquity devices and similar platforms.
+endef
+
+define Build/Compile
+endef
+
+define Build/Configure
+endef
+
+define Package/rpcd-mod-poe/install
+	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d/
+	$(INSTALL_BIN) ./files/poe.acl $(1)/usr/share/rpcd/acl.d/poe.json
+
+	$(INSTALL_DIR) $(1)/usr/libexec/rpcd/
+	$(INSTALL_BIN) ./files/poe.rpcd $(1)/usr/libexec/rpcd/poe
+endef
+
+$(eval $(call BuildPackage,rpcd-mod-poe))

--- a/utils/rpcd-mod-poe/files/poe.acl
+++ b/utils/rpcd-mod-poe/files/poe.acl
@@ -1,0 +1,22 @@
+{
+	"poe": {
+		"description": "manipulate gpio pins to enable/disable poe",
+		"read": {
+			"ubus": {
+				"poe": [
+					"status",
+					"list"
+				]
+			}
+		},
+		"write": {
+			"ubus": {
+				"poe": [
+					"on",
+					"off",
+					"powercycle"
+				]
+			}
+		}
+	}
+}

--- a/utils/rpcd-mod-poe/files/poe.rpcd
+++ b/utils/rpcd-mod-poe/files/poe.rpcd
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+. /usr/share/libubox/jshn.sh
+
+print_active()
+{
+	json_init
+	json_add_string "active" "$(uci get system.poe_power_port${port}.value)"
+	json_dump
+}
+
+
+json_port()
+{
+	json_add_object "poe_power_port${1}"
+	json_add_string "name" "$(uci get system.poe_power_port${1}.name)"
+	json_add_int "gpio_pin" "$(uci get system.poe_power_port${1}.gpio_pin)"
+	json_add_int "active" "$(uci get system.poe_power_port${1}.value)"
+	json_close_object
+}
+
+case "$1" in
+list)
+	json_init
+	json_add_object "on"
+	json_add_int "port"
+	json_close_object
+	json_add_object "off"
+	json_add_int "port"
+	json_close_object
+	json_add_object "powercycle"
+	json_add_int "port"
+	json_close_object
+	json_add_object "status"
+	json_add_int "port"
+	json_close_object
+	json_add_object "list"
+	json_close_object
+	json_dump
+	;;
+call)
+	read input
+	json_load "$input"
+	json_get_var port port
+
+	uci get system.poe_power_port${port}.value 2>/dev/null 1>/dev/null || {
+		json_init
+		json_add_string "error" "gpio $gpio not found"
+		json_dump
+	}
+
+	case "$2" in
+	on)
+		uci set system.poe_power_port${port}.value=1
+		uci commit system
+		/etc/init.d/gpio_switch restart
+		print_active
+		;;
+	off)
+		uci set system.poe_power_port${port}.value=0
+		uci commit system
+		/etc/init.d/gpio_switch restart
+		print_active
+		;;
+	powercycle)
+		uci set system.poe_power_port${port}.value=0
+		/etc/init.d/gpio_switch restart
+		sleep 1
+		uci set system.poe_power_port${port}.value=1
+		uci commit system
+		/etc/init.d/gpio_switch restart
+		print_active
+		;;
+	status)
+		# in future version additional status information like voltage
+		# and current should follow
+		print_active
+		;;
+	list)
+		json_init
+		port=0;
+		while uci show system.@gpio_switch[$port] 2>/dev/null 1>/dev/null; do
+			json_port $port
+			port=$((port+1))
+		done
+		json_dump
+		;;
+	esac
+esac


### PR DESCRIPTION
Maintainer: me

simple package to manipulate gpio pins via the web interface. This was
tested on a UBNT EdgePing R6 turining on and off the 4 PoE ports
(496-500).

A better solution would be to have a mapping like the following

    eth0 -> 496
    eth1 -> 497
    eth2 -> 498
    eth3 -> 499
    eth4 -> 500

in `target/linux/ramips/dts/UBNT-ERX-SFP.dts` and then use a command like 

    ubus call poe off { "port": "eth1" }

Signed-off-by: Paul Spooren <mail@aparcar.org>