### PR TITLE
xz: Compile with PIC to fix linking errors

### DIFF
--- a/utils/xz/Makefile
+++ b/utils/xz/Makefile
@@ -10,15 +10,16 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xz
 PKG_VERSION:=5.2.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/lzmautils
 PKG_HASH:=3313fd2a95f43d88e44264e6b015e7d03053e681860b0d5d3f9baca79c57b7bf
 
+PKG_MAINTAINER:=
 PKG_LICENSE:=Public-Domain LGPL-2.1+ GPL-2.0+ GPL-3.0+
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Nicolas Thill <nico@openwrt.org>
+PKG_CPE_ID:=cpe:/a:tukaani:xz
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -69,16 +70,18 @@ define BuildSubPackage
   $$(eval $$(call BuildPackage,$(1)))
 endef
 
+TARGET_LDFLAGS += -Wl,--gc-sections -flto
 
 CONFIGURE_ARGS += \
 	--enable-small \
 	--enable-assume-ram=4 \
 	--disable-assembler \
+	--disable-debug \
+	--disable-doc \
+	--disable-rpath \
+	--disable-symbol-versions \
 	--disable-werror \
-
-# API uses "restrict" keyword introduced in C99 standard
-TARGET_CFLAGS += \
-	-std=c99 \
+	--with-pic
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
While researching CircleCI build failures, I came across a linking error
relating to liblzma, where ld instructs to recompile with fPIC.

Unfortunately, this increases filesize. Added some configure flags to try
to mitigate is somewhat.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ramips

Error: https://gist.github.com/neheb/9d3d0a2583e6e190e7254db078128640