### PR TITLE
utils/bash: Import upstream patches for 5.0

### DIFF
--- a/utils/bash/Makefile
+++ b/utils/bash/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bash
 PKG_VERSION:=5.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/bash

--- a/utils/bash/patches/101-bash50-001.patch
+++ b/utils/bash/patches/101-bash50-001.patch
@@ -1,0 +1,166 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.0
+Patch-ID:	bash50-001
+
+Bug-Reported-by:	axel@freakout.de
+Bug-Reference-ID:	<201901082050.x08KoShS006731@bongo.freakout.de>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2019-01/msg00079.html
+
+Bug-Description:
+
+Under certain circumstances, the glob expansion code did not remove
+backslashes escaping characters in directory names (or portions of a
+pattern preceding a slash).
+
+Patch (apply with `patch -p0'):
+
+*** a/bashline.c	2018-11-27 13:20:16.000000000 -0500
+--- b/bashline.c	2019-01-16 16:06:03.000000000 -0500
+***************
+*** 232,235 ****
+--- 232,236 ----
+  static int bash_possible_command_completions __P((int, int));
+  
++ static int completion_glob_pattern __P((char *));
+  static char *glob_complete_word __P((const char *, int));
+  static int bash_glob_completion_internal __P((int));
+***************
+*** 1742,1746 ****
+    /* This could be a globbing pattern, so try to expand it using pathname
+       expansion. */
+!   if (!matches && glob_pattern_p (text))
+      {
+        matches = rl_completion_matches (text, glob_complete_word);
+--- 1743,1747 ----
+    /* This could be a globbing pattern, so try to expand it using pathname
+       expansion. */
+!   if (!matches && completion_glob_pattern ((char *)text))
+      {
+        matches = rl_completion_matches (text, glob_complete_word);
+***************
+*** 1851,1855 ****
+  	}
+  
+!       globpat = glob_pattern_p (hint_text);
+  
+        /* If this is an absolute program name, do not check it against
+--- 1852,1856 ----
+  	}
+  
+!       globpat = completion_glob_pattern ((char *)hint_text);
+  
+        /* If this is an absolute program name, do not check it against
+***************
+*** 3714,3717 ****
+--- 3715,3773 ----
+  }
+  
++ static int
++ completion_glob_pattern (string)
++      char *string;
++ {
++   register int c;
++   char *send;
++   int open;
++ 
++   DECLARE_MBSTATE;
++ 
++   open = 0;
++   send = string + strlen (string);
++ 
++   while (c = *string++)
++     {
++       switch (c)
++ 	{
++ 	case '?':
++ 	case '*':
++ 	  return (1);
++ 
++ 	case '[':
++ 	  open++;
++ 	  continue;
++ 
++ 	case ']':
++ 	  if (open)
++ 	    return (1);
++ 	  continue;
++ 
++ 	case '+':
++ 	case '@':
++ 	case '!':
++ 	  if (*string == '(')	/*)*/
++ 	    return (1);
++ 	  continue;
++ 
++ 	case '\\':
++ 	  if (*string == 0)
++ 	    return (0);	 	  
++ 	}
++ 
++       /* Advance one fewer byte than an entire multibyte character to
++ 	 account for the auto-increment in the loop above. */
++ #ifdef HANDLE_MULTIBYTE
++       string--;
++       ADVANCE_CHAR_P (string, send - string);
++       string++;
++ #else
++       ADVANCE_CHAR_P (string, send - string);
++ #endif
++     }
++   return (0);
++ }
++ 
+  static char *globtext;
+  static char *globorig;
+***************
+*** 3878,3882 ****
+      }      
+  
+!   if (t && glob_pattern_p (t) == 0)
+      rl_explicit_arg = 1;	/* XXX - force glob_complete_word to append `*' */
+    FREE (t);
+--- 3934,3938 ----
+      }      
+  
+!   if (t && completion_glob_pattern (t) == 0)
+      rl_explicit_arg = 1;	/* XXX - force glob_complete_word to append `*' */
+    FREE (t);
+*** a/lib/glob/glob_loop.c	2018-12-31 13:35:15.000000000 -0500
+--- b/lib/glob/glob_loop.c	2019-01-09 09:44:36.000000000 -0500
+***************
+*** 55,59 ****
+  
+        case L('\\'):
+- #if 0
+  	/* Don't let the pattern end in a backslash (GMATCH returns no match
+  	   if the pattern ends in a backslash anyway), but otherwise return 1,
+--- 55,58 ----
+***************
+*** 61,69 ****
+  	   and it can be removed. */
+  	return (*p != L('\0'));
+- #else
+- 	/* The pattern may not end with a backslash. */
+- 	if (*p++ == L('\0'))
+- 	  return 0;
+- #endif
+        }
+  
+--- 60,63 ----
+*** a/patchlevel.h	2016-06-22 14:51:03.000000000 -0400
+--- b/patchlevel.h	2016-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 0
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 1
+  
+  #endif /* _PATCHLEVEL_H_ */

--- a/utils/bash/patches/102-bash50-002.patch
+++ b/utils/bash/patches/102-bash50-002.patch
@@ -1,0 +1,113 @@
+			     BASH PATCH REPORT
+			     =================
+
+Bash-Release:	5.0
+Patch-ID:	bash50-002
+
+Bug-Reported-by:	Ante Peric <synthmeat@gmail.com>
+Bug-Reference-ID:	<B7E3B567-2467-4F7B-B6B9-CA4E75A9C93F@gmail.com>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-bash/2019-01/msg00095.html
+
+Bug-Description:
+
+When an alias value ends with an unquoted literal tab (not part of a quoted
+string or comment), alias expansion cannot correctly detect the end of the
+alias value after expanding it.
+
+Patch (apply with `patch -p0'):
+
+*** a/parser.h	2018-12-28 19:11:18.000000000 -0500
+--- b/parser.h	2019-01-11 15:13:03.000000000 -0500
+***************
+*** 48,51 ****
+--- 48,52 ----
+  #define PST_REDIRLIST	0x080000	/* parsing a list of redirections preceding a simple command name */
+  #define PST_COMMENT	0x100000	/* parsing a shell comment; used by aliases */
++ #define PST_ENDALIAS	0x200000	/* just finished expanding and consuming an alias */
+  
+  /* Definition of the delimiter stack.  Needed by parse.y and bashhist.c. */
+*** a/parse.y	2019-01-02 13:57:34.000000000 -0500
+--- b/parse.y	2019-01-14 08:23:31.000000000 -0500
+***************
+*** 2558,2567 ****
+        pushed_string_list->flags != PSH_DPAREN &&
+        (parser_state & PST_COMMENT) == 0 &&
+        shell_input_line_index > 0 &&
+!       shell_input_line[shell_input_line_index-1] != ' ' &&
+        shell_input_line[shell_input_line_index-1] != '\n' &&
+        shellmeta (shell_input_line[shell_input_line_index-1]) == 0 &&
+        (current_delimiter (dstack) != '\'' && current_delimiter (dstack) != '"'))
+      {
+        return ' ';	/* END_ALIAS */
+      }
+--- 2558,2569 ----
+        pushed_string_list->flags != PSH_DPAREN &&
+        (parser_state & PST_COMMENT) == 0 &&
++       (parser_state & PST_ENDALIAS) == 0 &&	/* only once */
+        shell_input_line_index > 0 &&
+!       shellblank (shell_input_line[shell_input_line_index-1]) == 0 &&
+        shell_input_line[shell_input_line_index-1] != '\n' &&
+        shellmeta (shell_input_line[shell_input_line_index-1]) == 0 &&
+        (current_delimiter (dstack) != '\'' && current_delimiter (dstack) != '"'))
+      {
++       parser_state |= PST_ENDALIAS;
+        return ' ';	/* END_ALIAS */
+      }
+***************
+*** 2572,2575 ****
+--- 2574,2578 ----
+    if (uc == 0 && pushed_string_list && pushed_string_list->flags != PSH_SOURCE)
+      {
++       parser_state &= ~PST_ENDALIAS;
+        pop_string ();
+        uc = shell_input_line[shell_input_line_index];
+*** a/y.tab.c	2019-01-02 13:57:43.000000000 -0500
+--- b/y.tab.c	2019-01-14 08:39:23.000000000 -0500
+***************
+*** 4874,4883 ****
+        pushed_string_list->flags != PSH_DPAREN &&
+        (parser_state & PST_COMMENT) == 0 &&
+        shell_input_line_index > 0 &&
+!       shell_input_line[shell_input_line_index-1] != ' ' &&
+        shell_input_line[shell_input_line_index-1] != '\n' &&
+        shellmeta (shell_input_line[shell_input_line_index-1]) == 0 &&
+        (current_delimiter (dstack) != '\'' && current_delimiter (dstack) != '"'))
+      {
+        return ' ';	/* END_ALIAS */
+      }
+--- 4874,4885 ----
+        pushed_string_list->flags != PSH_DPAREN &&
+        (parser_state & PST_COMMENT) == 0 &&
++       (parser_state & PST_ENDALIAS) == 0 &&	/* only once */
+        shell_input_line_index > 0 &&
+!       shellblank (shell_input_line[shell_input_line_index-1]) == 0 &&
+        shell_input_line[shell_input_line_index-1] != '\n' &&
+        shellmeta (shell_input_line[shell_input_line_index-1]) == 0 &&
+        (current_delimiter (dstack) != '\'' && current_delimiter (dstack) != '"'))
+      {
++       parser_state |= PST_ENDALIAS;
+        return ' ';	/* END_ALIAS */
+      }
+***************
+*** 4888,4891 ****
+--- 4890,4894 ----
+    if (uc == 0 && pushed_string_list && pushed_string_list->flags != PSH_SOURCE)
+      {
++       parser_state &= ~PST_ENDALIAS;
+        pop_string ();
+        uc = shell_input_line[shell_input_line_index];
+*** a/patchlevel.h	2016-06-22 14:51:03.000000000 -0400
+--- b/patchlevel.h	2016-10-01 11:01:28.000000000 -0400
+***************
+*** 26,30 ****
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 1
+  
+  #endif /* _PATCHLEVEL_H_ */
+--- 26,30 ----
+     looks for to find the patch level (for the sccs version string). */
+  
+! #define PATCHLEVEL 2
+  
+  #endif /* _PATCHLEVEL_H_ */


### PR DESCRIPTION
Maintainer: @Naoir 
Compile tested: ramips, MqMaker WiTi board, OpenWrt master
Run tested: ramips, MqMaker WiTi board, OpenWrt master

Description:
Source:
ftp://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-001
ftp://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-002

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>