### PR TITLE
p11-kit: Update to 0.23.15

### DIFF
--- a/libs/p11-kit/Makefile
+++ b/libs/p11-kit/Makefile
@@ -8,13 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=p11-kit
-PKG_VERSION:=0.23.14
+PKG_VERSION:=0.23.15
 PKG_RELEASE:=1
-PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=1cb9fa6d237539f25f62f4c3d4ec71a1c8e0772957ec45ec5af92134129e0d70
-PKG_SOURCE_URL:=https://github.com/p11-glue/$(PKG_NAME)/releases/download/$(PKG_VERSION)
+PKG_HASH:=f7c139a0c77a1f0012619003e542060ba8f94799a0ef463026db390680e4d798
+PKG_SOURCE_URL:=https://github.com/p11-glue/p11-kit/releases/download/$(PKG_VERSION)
+
+PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
+PKG_LICENSE:=BSD-3c
+PKG_LICENSE_FILES:=COPYING
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -35,9 +38,12 @@ define Package/p11-kit/description
   way that they are discoverable.
 endef
 
+TARGET_LDFLAGS += -Wl,--gc-sections
+
 CONFIGURE_ARGS+= \
-	--without-libffi \
-	--disable-trust-module
+	--disable-debug \
+	--disable-trust-module \
+	--without-libffi
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/p11-kit-1/p11-kit/


### PR DESCRIPTION
Disable debug to save some space: 163689 vs. 155034 bytes.

Add -Wl,--gc-sections. Down to 138627 bytes.

Miscellaneous cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmav 
Compile tested: ramips

Note: -flto actually increases filesize to 143674