### PR TITLE
libtasn1: Optimize compilation for size

### DIFF
--- a/libs/libtasn1/Makefile
+++ b/libs/libtasn1/Makefile
@@ -9,11 +9,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtasn1
 PKG_VERSION:=4.13
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
 PKG_HASH:=7e528e8c317ddd156230c4e31d082cd13e7ddeb7a54824be82632209550c8cca
+
+PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
 PKG_LICENSE:=LGPLv2.1+
 PKG_LICENSE_FILES:=COPYING.LIB
 
@@ -26,7 +28,6 @@ define Package/libtasn1
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=An ASN.1 and DER structures manipulation library
-  MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
   URL:=https://www.gnu.org/software/libtasn1/
 endef
 
@@ -35,12 +36,13 @@ define Package/libtasn1/description
  Distinguish Encoding Rules (DER) manipulation.
 endef
 
-TARGET_CFLAGS += $(FPIC)
+TARGET_LDFLAGS += -Wl,--gc-sections
 
 CONFIGURE_ARGS += \
-		--enable-shared \
-		--disable-gcc-warnings \
-		--enable-static
+	--disable-doc \
+	--disable-gcc-warnings \
+	--disable-ld-version-script \
+	--disable-valgrind-tests
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Disabled doc and valgrind tests to speed up compilation.

Added --disable-ld-version-script to reduce compiled size.

Added -Wl,--gc-sections to reduce compiled size.

From 28339 to 27700 bytes.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmav
Compile tested: ramips