### PR TITLE
uwsgi-cgi: update to 2.0.18 and use official tarball

### DIFF
--- a/net/uwsgi-cgi/Makefile
+++ b/net/uwsgi-cgi/Makefile
@@ -1,12 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uwsgi-cgi
-PKG_VERSION:=2.0.17.1
-PKG_RELEASE:=5
+PKG_VERSION:=2.0.18
+PKG_RELEASE:=1
 
-PKG_SOURCE_URL=https://codeload.github.com/unbit/uwsgi/tar.gz/$(PKG_VERSION)?
+PKG_SOURCE_URL= \
+	https://projects.unbit.it/downloads \
+	https://codeload.github.com/unbit/uwsgi/tar.gz/$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=d2318235c74665a60021a4fc7770e9c2756f9fc07de7b8c22805efe85b5ab277
+PKG_HASH:=4972ac538800fb2d421027f49b4a1869b66048839507ccf0aa2fda792d99f583
 PKG_BUILD_DIR:=$(BUILD_DIR)/uwsgi-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-2.0-or-later
@@ -21,7 +23,7 @@ define Package/uwsgi-cgi
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
   TITLE:=The uWSGI server
-  URL:=http://unbit.com/
+  URL:=https://projects.unbit.it/uwsgi
   DEPENDS:=+libcap +jansson +libuuid
 endef
 
@@ -30,7 +32,6 @@ define Package/uwsgi-cgi-luci-support
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
   TITLE:=Support files for LuCI on Nginx
-  URL:=http://unbit.com/
   DEPENDS:=+uwsgi-cgi
 endef
 


### PR DESCRIPTION
Maintainer: @Ansuel 
Compile tested: mvebu
Run tested: mvebu

Description:
Update to 2.0.18 and use official tarball