### PR TITLE
graphicsmagick: optimize compilation to reduce size

### DIFF
--- a/multimedia/graphicsmagick/Makefile
+++ b/multimedia/graphicsmagick/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=graphicsmagick
 PKG_VERSION:=1.3.31
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/GraphicsMagick-$(PKG_VERSION)
 PKG_SOURCE:=GraphicsMagick-$(PKG_VERSION).tar.bz2
@@ -71,6 +71,8 @@ CONFIGURE_ARGS += \
 	--with-zlib \
 	--without-zstd \
 	--without-x
+
+TARGET_CFLAGS += -flto
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
Maintainer: me
Compile tested: ipq806x, TP-Link Archer C2600, OpenWrt SNAPSHOT r9257-5a8d03c; bcm53xx, Buffalo WXR-1900DHP, OpenWrt SNAPSHOT r9257-5a8d03c; x86_64, VirtualBox VM, OpenWrt SNAPSHOT r9257-5a8d03c
Run tested: ipq806x, TP-Link Archer C2600, OpenWrt SNAPSHOT r9257-5a8d03c; bcm53xx, Buffalo WXR-1900DHP, OpenWrt SNAPSHOT r9257-5a8d03c; x86_64, VirtualBox VM, OpenWrt SNAPSHOT r9257-5a8d03c

Description:

GNU's 'flto' compiler option reduces the installation footprint by 24KB-40KB. The use of 'flto' makes no observable difference to the speed of execution or the amount of memory used. The command used in testing was:
```
time -v gm convert img-in.jpg -resize "1200x675>" -quality 66 img-out.jpg
```
img-in.jpg: 2688x1520 pixels, 608 KB.

The reduction in size of the binaries is small compared to the total installation footprint of about 3.8MB, but it is still a noticeable reduction.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>
