### PR TITLE
Added tor-geoip-tiny package

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -75,13 +75,29 @@ endef
 
 define Package/tor-geoip
 $(call Package/tor/Default)
-  TITLE:=GeoIP db for tor
+  TITLE:=GeoIP db for tor (full version)
   DEPENDS:=+tor
 endef
 
 define Package/tor-geoip/description
 $(call Package/tor/Default/description)
  This package contains a GeoIP database mapping IP addresses to countries.
+ If you want to save space at the cost of excluding some possible relays,
+ please take a look at the tor-geoip-tiny package.
+endef
+
+define Package/tor-geoip-tiny
+$(call Package/tor/Default)
+  TITLE:=GeoIP db for tor (tiny version)
+  DEPENDS:=+tor
+  PROVIDES:=tor-geoip
+endef
+
+define Package/tor-geoip-tiny/description
+$(call Package/tor/Default/description)
+ This package contains a GeoIP database mapping IP addresses to countries.
+ This database has been reduced to ~15% of its original size by excluding
+ too-small networks. It still covers more than 90% of IP addresses.
 endef
 
 define Package/tor/conffiles
@@ -142,7 +158,17 @@ define Package/tor-geoip/install
 	$(1)/usr/share/tor/
 endef
 
+define Package/tor-geoip-tiny/install
+	$(INSTALL_DIR) $(1)/usr/share/tor
+	perl ./files/reduce-geoip $(PKG_INSTALL_DIR)/usr/share/tor/geoip \
+		> $(1)/usr/share/tor/geoip
+	perl ./files/reduce-geoip6 $(PKG_INSTALL_DIR)/usr/share/tor/geoip6 \
+		> $(1)/usr/share/tor/geoip6
+	chmod 0644 $(1)/usr/share/tor/geoip $(1)/usr/share/tor/geoip6
+endef
+
 $(eval $(call BuildPackage,tor))
 $(eval $(call BuildPackage,tor-gencert))
 $(eval $(call BuildPackage,tor-resolve))
 $(eval $(call BuildPackage,tor-geoip))
+$(eval $(call BuildPackage,tor-geoip-tiny))

--- a/net/tor/files/reduce-geoip
+++ b/net/tor/files/reduce-geoip
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+# Print only blocks of size /18 or bigger
+# This reduces the file to approximately 10% size
+
+my $total = 0;
+my $covered = 0;
+
+print "# This file has been reduced by reduce-geoip in OpenWRT\n";
+while (<>) {
+  if (/^#/) {
+    print;
+    next;
+  }
+  my ($start, $end, $country) = split ",";
+  my $size = $end - $start + 1;
+  $total += $size;
+  next if $size < 2 ** (32 - 18);
+  $covered += $size;
+  print;
+}
+my $coverage = int(100 * $covered / $total);
+print "# Covered $covered addresses out of $total ($coverage%)\n";

--- a/net/tor/files/reduce-geoip6
+++ b/net/tor/files/reduce-geoip6
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Socket qw(AF_INET6 inet_pton);
+
+sub ipv6_to_bin($) {
+  return unpack("B128", inet_pton(AF_INET6, @_));
+}
+
+sub common_bits($$) {
+  my ($a, $b) = @_;
+  my $ret = 0;
+  $ret++ while $ret < 128 and substr($a, $ret, 1) == substr($b, $ret, 1);
+  return $ret;
+}
+
+# Print only blocks of size /31 (approximately) or bigger
+# This reduces the file to approximately 20% size
+
+my $total = 0;
+my $covered = 0;
+
+print "# This file has been reduced by reduce-geoip6 in OpenWRT\n";
+while (<>) {
+  if (/^#/) {
+    print;
+    next;
+  }
+  my ($start, $end, $country) = split ",";
+  $start = ipv6_to_bin($start);
+  $end = ipv6_to_bin($end);
+  my $common = common_bits($start, $end);
+  my $size = ($common <= 48) ? 1 << (48 - $common) : 0;
+  $total += $size;
+  next if $common > 31;
+  $covered += $size;
+  print;
+}
+
+my $coverage = int(100 * $covered / $total);
+print "# Covered $covered /48 networks out of $total ($coverage%)\n";


### PR DESCRIPTION
Maintainer: @hauke 
Compile tested: mips_24kc, ar71xx, TP-Link Archer C7 v2, today's git snapshot.
Run tested: same as above. Tested that tor can still bootstrap the Tor circuit and pass traffic while avoiding specific countries. Tested both over IPv4 and IPv6.

Description: A new tiny variant of tor-geoip package is created by post-processing existing geoip files (which are too big for common routers) with perl scripts. The result takes 15% of disk space as compared to the original, and provides 90% of original network coverage.
