### PR TITLE
jq: compile with _GNU_SOURCE (fixes #7785)

### DIFF
--- a/utils/jq/Makefile
+++ b/utils/jq/Makefile
@@ -24,7 +24,7 @@ ifdef CONFIG_USE_MIPS16
   TARGET_CFLAGS += -fno-ipa-sra
 endif
 
-TARGET_CFLAGS += -std=c99
+TARGET_CFLAGS += -std=c99 -D_GNU_SOURCE
 
 CONFIGURE_ARGS+= \
 	--disable-docs \


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: @ratkaj
Compile tested: x86_64
Run tested: x86_64

Description:
Compile with _GNU_SOURCE (fixes #7785)