### PR TITLE
smartmontools: fix packaging of drivedb.h

### DIFF
--- a/utils/smartmontools/Makefile
+++ b/utils/smartmontools/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/uclibc++.mk
 
 PKG_NAME:=smartmontools
 PKG_VERSION:=7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/smartmontools
@@ -28,13 +28,13 @@ include $(INCLUDE_DIR)/package.mk
 define Package/smartmontools/Default
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=$(CXX_DEPENDS)
   TITLE:=S.M.A.R.T Monitoring
   URL:=http://smartmontools.sourceforge.net/
 endef
 
 define Package/smartmontools
   $(call Package/smartmontools/Default)
+  DEPENDS:=$(CXX_DEPENDS)
   TITLE+= Tool
 endef
 
@@ -47,6 +47,7 @@ endef
 
 define Package/smartd
   $(call Package/smartmontools/Default)
+  DEPENDS:=$(CXX_DEPENDS)
   TITLE+= Daemon
 endef
 
@@ -55,6 +56,16 @@ define Package/smartd/description
   control/monitor storage systems using the Self-Monitoring, Analysis
   and Reporting Technology System (S.M.A.R.T.) built into most modern
   ATA and SCSI disks. It is derived from smartsuite.
+endef
+
+define Package/smartmontools-drivedb
+  $(call Package/smartmontools/Default)
+  TITLE+= Drive database
+  PKGARCH=all
+endef
+
+define Package/smartmontools-drivedb/description
+  database of known drives for smartctl and smartd
 endef
 
 ifeq ($(CONFIG_USE_UCLIBCXX),y)
@@ -83,8 +94,6 @@ CONFIGURE_VARS += \
 define Package/smartmontools/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/smartctl $(1)/usr/sbin/
-	$(INSTALL_DIR) $(1)/usr/share
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/smartmontools/drivedb.h $(1)/usr/share/smartmontools
 endef
 
 define Package/smartd/install
@@ -96,9 +105,15 @@ define Package/smartd/install
 	$(INSTALL_BIN) ./files/smartd.init $(1)/etc/init.d/smartd
 endef
 
+define Package/smartmontools-drivedb/install
+	$(INSTALL_DIR) $(1)/usr/share/smartmontools/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/smartmontools/drivedb.h $(1)/usr/share/smartmontools/
+endef
+
 define Package/smartd/conffiles
 /etc/smartd.conf
 endef
 
 $(eval $(call BuildPackage,smartmontools))
 $(eval $(call BuildPackage,smartd))
+$(eval $(call BuildPackage,smartmontools-drivedb))

--- a/utils/smartmontools/patches/001-use-external-drivedb.patch
+++ b/utils/smartmontools/patches/001-use-external-drivedb.patch
@@ -1,0 +1,92 @@
+diff --git i/knowndrives.cpp w/knowndrives.cpp
+index 072160a..d57417b 100644
+--- i/knowndrives.cpp
++++ w/knowndrives.cpp
+@@ -40,11 +40,84 @@ const char * knowndrives_cpp_cvsid = "$Id: knowndrives.cpp 4842 2018-12-02 16:07
+ // see read_default_drive_databases() below.
+ // The drive_settings structure is described in drivedb.h.
+ const drive_settings builtin_knowndrives[] = {
+-#include "drivedb.h"
++  { "DEFAULT",
++    "-", "-",
++    "Default settings",
++    "-v 1,raw48,Raw_Read_Error_Rate "
++    "-v 2,raw48,Throughput_Performance "
++    "-v 3,raw16(avg16),Spin_Up_Time "
++    "-v 4,raw48,Start_Stop_Count "
++    "-v 5,raw16(raw16),Reallocated_Sector_Ct "
++    "-v 6,raw48,Read_Channel_Margin,HDD "
++    "-v 7,raw48,Seek_Error_Rate,HDD "
++    "-v 8,raw48,Seek_Time_Performance,HDD "
++    "-v 9,raw24(raw8),Power_On_Hours "
++    "-v 10,raw48,Spin_Retry_Count,HDD "
++    "-v 11,raw48,Calibration_Retry_Count,HDD "
++    "-v 12,raw48,Power_Cycle_Count "
++    "-v 13,raw48,Read_Soft_Error_Rate "
++    //  14-174 Unknown_Attribute
++    "-v 175,raw48,Program_Fail_Count_Chip,SSD "
++    "-v 176,raw48,Erase_Fail_Count_Chip,SSD "
++    "-v 177,raw48,Wear_Leveling_Count,SSD "
++    "-v 178,raw48,Used_Rsvd_Blk_Cnt_Chip,SSD "
++    "-v 179,raw48,Used_Rsvd_Blk_Cnt_Tot,SSD "
++    "-v 180,raw48,Unused_Rsvd_Blk_Cnt_Tot,SSD "
++    "-v 181,raw48,Program_Fail_Cnt_Total "
++    "-v 182,raw48,Erase_Fail_Count_Total,SSD "
++    "-v 183,raw48,Runtime_Bad_Block "
++    "-v 184,raw48,End-to-End_Error "
++    //  185-186 Unknown_Attribute
++    "-v 187,raw48,Reported_Uncorrect "
++    "-v 188,raw48,Command_Timeout "
++    "-v 189,raw48,High_Fly_Writes,HDD "
++    "-v 190,tempminmax,Airflow_Temperature_Cel "
++    "-v 191,raw48,G-Sense_Error_Rate,HDD "
++    "-v 192,raw48,Power-Off_Retract_Count "
++    "-v 193,raw48,Load_Cycle_Count,HDD "
++    "-v 194,tempminmax,Temperature_Celsius "
++    "-v 195,raw48,Hardware_ECC_Recovered "
++    "-v 196,raw16(raw16),Reallocated_Event_Count "
++    "-v 197,raw48,Current_Pending_Sector "
++    "-v 198,raw48,Offline_Uncorrectable "
++    "-v 199,raw48,UDMA_CRC_Error_Count "
++    "-v 200,raw48,Multi_Zone_Error_Rate,HDD "
++    "-v 201,raw48,Soft_Read_Error_Rate,HDD "
++    "-v 202,raw48,Data_Address_Mark_Errs,HDD "
++    "-v 203,raw48,Run_Out_Cancel "
++    "-v 204,raw48,Soft_ECC_Correction "
++    "-v 205,raw48,Thermal_Asperity_Rate "
++    "-v 206,raw48,Flying_Height,HDD "
++    "-v 207,raw48,Spin_High_Current,HDD "
++    "-v 208,raw48,Spin_Buzz,HDD "
++    "-v 209,raw48,Offline_Seek_Performnce,HDD "
++    //  210-219 Unknown_Attribute
++    "-v 220,raw48,Disk_Shift,HDD "
++    "-v 221,raw48,G-Sense_Error_Rate,HDD "
++    "-v 222,raw48,Loaded_Hours,HDD "
++    "-v 223,raw48,Load_Retry_Count,HDD "
++    "-v 224,raw48,Load_Friction,HDD "
++    "-v 225,raw48,Load_Cycle_Count,HDD "
++    "-v 226,raw48,Load-in_Time,HDD "
++    "-v 227,raw48,Torq-amp_Count,HDD "
++    "-v 228,raw48,Power-off_Retract_Count "
++    //  229 Unknown_Attribute
++    "-v 230,raw48,Head_Amplitude,HDD "
++    "-v 231,raw48,Temperature_Celsius "
++    "-v 232,raw48,Available_Reservd_Space "
++    "-v 233,raw48,Media_Wearout_Indicator,SSD "
++    //  234-239 Unknown_Attribute
++    "-v 240,raw24(raw8),Head_Flying_Hours,HDD "
++    "-v 241,raw48,Total_LBAs_Written "
++    "-v 242,raw48,Total_LBAs_Read "
++    //  243-249 Unknown_Attribute
++    "-v 250,raw48,Read_Error_Retry_Rate "
++    //  251-253 Unknown_Attribute
++    "-v 254,raw48,Free_Fall_Sensor,HDD"
++  },
+ };
+ 
+-const unsigned builtin_knowndrives_size =
+-  sizeof(builtin_knowndrives) / sizeof(builtin_knowndrives[0]);
++const unsigned builtin_knowndrives_size = 1;
+ 
+ /// Drive database class. Stores custom entries read from file.
+ /// Provides transparent access to concatenation of custom and


### PR DESCRIPTION
Signed-off-by: Maxim Storchak <m.storchak@gmail.com>

Maintainer: me
Compile tested: ath79, WNDR3800, r9305-0c24b363a6
Run tested: ar71xx, r5501-30e18c8, tested in a chroot, userspace version corresponded to the compile-time tests. Output from smartctl --xall is the same with drivedb.h present or not.

Description: drivedb.h is installed as /usr/share/smartmontools instead of /usr/share/smartmontools/drivedb.h
