### PR TITLE
rtl-ais: Update init script

### DIFF
--- a/utils/rtl-ais/Makefile
+++ b/utils/rtl-ais/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtl-ais
 PKG_VERSION:=0.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/dgiardini/rtl-ais/tar.gz/v$(PKG_VERSION)?

--- a/utils/rtl-ais/files/rtl_ais.init
+++ b/utils/rtl-ais/files/rtl_ais.init
@@ -6,7 +6,7 @@ USE_PROCD=1
 PROG=/usr/bin/rtl_ais
 
 validate_rtl_ais_section() {
-	uci_validate_section "rtl_ais" "rtl_ais" "$1" \
+	uci_load_validate "rtl_ais" "rtl_ais" "$1" "$2" \
 		'enabled:bool' \
 		'ppm:range(-100,100):0'
 }
@@ -14,22 +14,21 @@ validate_rtl_ais_section() {
 load_rtl_ais() {
 	local cfg="$1"
 
-	local enabled ppm
-	validate_rtl_ais_section "$cfg" || { echo "validation failed"; return 1; }
+	[ "$2" = 0 ] || { echo "validation failed"; return 1; }
 
 	[ "$enabled" = "1" ] || return 1
 
-        procd_open_instance
-        procd_set_param command "$PROG" -p "$ppm"
+	procd_open_instance
+	procd_set_param command "$PROG" -p "$ppm"
 	procd_set_param stdout 1
 	procd_set_param stderr 1
-        procd_set_param respawn
-        procd_close_instance
+	procd_set_param respawn
+	procd_close_instance
 }
 
 start_service() {
 	config_load "rtl_ais"
-	config_foreach load_rtl_ais "rtl_ais"
+	config_foreach validate_rtl_ais_section "rtl_ais" load_rtl_ais
 }
 
 service_triggers() {


### PR DESCRIPTION
Maintainer: @nunojpg 
Compile tested: armvirt-32, 2019-02-07 snapshot sdk
Run tested: armvirt-32, 2019-02-07 snapshot

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

This also fixes some space-indented lines to use tabs.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>