### PR TITLE
sysstat: Update init script

### DIFF
--- a/utils/sysstat/Makefile
+++ b/utils/sysstat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sysstat
 PKG_VERSION:=12.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>

--- a/utils/sysstat/files/sysstat.init
+++ b/utils/sysstat/files/sysstat.init
@@ -9,7 +9,7 @@ PROG=/usr/lib/sysstat/sadc
 SYSSTAT_CFG="/etc/sysstat/sysstat"
 
 validate_sysstat_section() {
-	uci_validate_section sysstat sysstat "${1}" \
+	uci_load_validate sysstat sysstat "$1" "$2" \
 		'log_history:uinteger' \
 		'compressafter:uinteger' \
 		'sadc_options:string' \
@@ -18,11 +18,8 @@ validate_sysstat_section() {
 		'enabled:string'
 }
 
-start_service() {
-
-	local log_history compressafter sadc_options sa_dir zip enabled
-
-	validate_sysstat_section sysstat || {
+start_sysstat_instance() {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
@@ -40,6 +37,10 @@ start_service() {
 	procd_set_param command $PROG -S DISK -F -L -
 	procd_set_param file $SYSSTAT_CFG
 	procd_close_instance
+}
+
+start_service() {
+	validate_sysstat_section sysstat start_sysstat_instance
 }
 
 service_triggers()


### PR DESCRIPTION
Maintainer: @ratkaj 
Compile tested: armvirt-32, 2019-02-07 snapshot sdk
Run tested: none

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>