### PR TITLE
nft-qos: Update init script

### DIFF
--- a/net/nft-qos/Makefile
+++ b/net/nft-qos/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nft-qos
 PKG_VERSION:=1.0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0
 
 PKG_MAINTAINER:=Rosy Song <rosysong@rosinson.com>

--- a/net/nft-qos/files/lib/dynamic.sh
+++ b/net/nft-qos/files/lib/dynamic.sh
@@ -5,6 +5,14 @@
 
 . /lib/nft-qos/core.sh
 
+qosdef_validate_dynamic() {
+	uci_load_validate nft-qos default "$1" "$2" \
+		'limit_enable:bool:0' \
+		'limit_type:maxlength(8)' \
+		'dynamic_bw_up:uinteger:100' \
+		'dynamic_bw_down:uinteger:100'
+}
+
 # return average rate for dhcp leases
 qosdef_dynamic_rate() { # <bandwidth>
 	local c=0 c6=0
@@ -55,16 +63,9 @@ qosdef_flush_dynamic() {
 
 # init dynamic qos
 qosdef_init_dynamic() {
-	local dynamic_bw_up dynamic_bw_down limit_enable limit_type
 	local hook_ul="prerouting" hook_dl="postrouting"
 
-	uci_validate_section nft-qos default default \
-		'limit_enable:bool:0' \
-		'limit_type:maxlength(8)' \
-		'dynamic_bw_up:uinteger:100' \
-		'dynamic_bw_down:uinteger:100'
-
-	[ $? -ne 0 ] && {
+	[ "$2" = 0 ] || {
 		logger -t nft-qos-dynamic "validation failed"
 		return 1
 	}

--- a/net/nft-qos/files/lib/priority.sh
+++ b/net/nft-qos/files/lib/priority.sh
@@ -9,6 +9,12 @@
 P1=""; P2=""; P3=""; P4=""; P5=""; P6="";
 P7=""; P8=""; P9=""; P10=""; P11="";
 
+qosdef_validate_priority() {
+	uci_load_validate nft-qos default "$1" "$2" \
+		'priority_enable:bool:0' \
+		'priority_netdev:maxlength(8)'
+}
+
 _qosdef_handle_protox() { # <priority> <rule>
 	case "$1" in
 		-400) P1="$P1""$2";;
@@ -61,13 +67,9 @@ qosdef_remove_priority() {
 
 # init traffic priority
 qosdef_init_priority() {
-	local priority_enable priority_netdev ifname="br-lan"
+	local ifname="br-lan"
 
-	uci_validate_section nft-qos default default \
-		'priority_enable:bool:0' \
-		'priority_netdev:maxlength(8)'
-
-	[ $? -ne 0 ] && {
+	[ "$2" = 0 ] || {
 		logger -t nft-qos-priority "validation failed"
 		return 1
 	}

--- a/net/nft-qos/files/lib/static.sh
+++ b/net/nft-qos/files/lib/static.sh
@@ -5,6 +5,16 @@
 
 . /lib/nft-qos/core.sh
 
+qosdef_validate_static() {
+	uci_load_validate nft-qos default "$1" "$2" \
+		'limit_enable:bool:0' \
+		'limit_type:maxlength(8)' \
+		'static_unit_dl:string:kbytes' \
+		'static_unit_ul:string:kbytes' \
+		'static_rate_dl:uinteger:50' \
+		'static_rate_ul:uinteger:50'
+}
+
 # append rule for static qos
 qosdef_append_rule_sta() { # <section> <operator> <default-unit> <default-rate>
 	local ipaddr unit rate
@@ -42,18 +52,9 @@ qosdef_flush_static() {
 
 # static limit rate init
 qosdef_init_static() {
-	local unit_dl unit_ul rate_dl rate_ul
-	local limit_enable limit_type hook_ul="prerouting" hook_dl="postrouting"
+	local hook_ul="prerouting" hook_dl="postrouting"
 
-	uci_validate_section nft-qos default default \
-		'limit_enable:bool:0' \
-		'limit_type:maxlength(8)' \
-		'static_unit_dl:string:kbytes' \
-		'static_unit_ul:string:kbytes' \
-		'static_rate_dl:uinteger:50' \
-		'static_rate_ul:uinteger:50'
-
-	[ $? -ne 0 ] && {
+	[ "$2" = 0 ] || {
 		logger -t nft-qos-static "validation failed"
 		return 1
 	}
@@ -67,7 +68,7 @@ qosdef_init_static() {
 	}
 
 	qosdef_appendx "table $NFT_QOS_INET_FAMILY nft-qos-static {\n"
-	qosdef_append_chain_sta $hook_ul upload upload $unit_ul $rate_ul
-	qosdef_append_chain_sta $hook_dl download download $unit_dl $rate_dl
+	qosdef_append_chain_sta $hook_ul upload upload $static_unit_ul $static_rate_ul
+	qosdef_append_chain_sta $hook_dl download download $static_unit_dl $static_rate_dl
 	qosdef_appendx "}\n"
 }

--- a/net/nft-qos/files/nft-qos-dynamic.hotplug
+++ b/net/nft-qos/files/nft-qos-dynamic.hotplug
@@ -11,13 +11,7 @@ export initscript="nft-qos-dynamic"
 
 NFT_QOS_DYNAMIC_ON=
 
-qosdef_validate_section_dynamic() {
-	local limit_enable limit_type
-
-	uci_validate_section nft-qos default default \
-		'limit_enable:bool:0' \
-		'limit_type:maxlength(8)'
-
+qosdef_check_if_dynamic() {
 	[ $limit_enable -eq 1 -a \
 	  "$limit_type" = "dynamic" ] && \
 	    NFT_QOS_DYNAMIC_ON="y"
@@ -28,14 +22,14 @@ logger -t nft-qos-dynamic "ACTION=$ACTION, MACADDR=$MACADDR, IPADDR=$IPADDR, HOS
 
 case "$ACTION" in
 	add | update | remove)
-		qosdef_validate_section_dynamic
+		qosdef_validate_dynamic default qosdef_check_if_dynamic
 		[ -z "$NFT_QOS_DYNAMIC_ON" ] && return
 
 		qosdef_init_env
 		qosdef_flush_dynamic
 
 		qosdef_init_header
-		qosdef_init_dynamic
+		qosdef_validate_dynamic default qosdef_init_dynamic
 		qosdef_init_done
 		qosdef_start
 		;;

--- a/net/nft-qos/files/nft-qos.init
+++ b/net/nft-qos/files/nft-qos.init
@@ -14,6 +14,12 @@ USE_PROCD=1
 
 service_triggers() {
 	procd_add_reload_trigger nft-qos
+
+	procd_open_validate
+	qosdef_validate_dynamic
+	qosdef_validate_static
+	qosdef_validate_priority
+	procd_close_validate
 }
 
 start_service() {
@@ -26,9 +32,9 @@ start_service() {
 
 	qosdef_init_header
 	qosdef_init_monitor
-	qosdef_init_dynamic
-	qosdef_init_static
-	qosdef_init_priority
+	qosdef_validate_dynamic default qosdef_init_dynamic
+	qosdef_validate_static default qosdef_init_static
+	qosdef_validate_priority default qosdef_init_priority
 	qosdef_init_done
 	qosdef_start
 }


### PR DESCRIPTION
Maintainer: @rosysong 
Compile tested: armvirt-32, 2019-02-12 snapshot sdk
Run tested: none

Description:
This replaces the use of `uci_validate_section()` with `uci_load_validate()`, which removes the need to declare local variables for every config option.

This also adds a validate section to `service_triggers()`, and fixes some variable name typos in `qosdef_init_static()`.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>