### PR TITLE
Adding awscli to python packages

### DIFF
--- a/lang/python/python-awscli/Makefile
+++ b/lang/python/python-awscli/Makefile
@@ -1,0 +1,71 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=awscli
+PKG_VERSION:=1.16.75
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/a/awscli
+PKG_HASH:=8d96ec0de325ea8271cc6aa95b7392bbf548ec4aabd3ffbcdc0619b64edd4a45
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-awscli-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
+PKG_LICENSE:=MIT
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-awscli/Default
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=awscli
+  URL:=https://github.com/aws/aws-cli
+endef
+
+define Package/python-awscli
+$(call Package/python-awscli/Default)
+  DEPENDS:=+python \
+	+python-yaml \
+	+python-pyasn1 \
+	+python-botocore \
+	+python-rsa \
+	+python-colorama \
+	+python-docutils \
+	+python-s3transfer
+  VARIANT:=python
+endef
+
+define Package/python3-awscli
+$(call Package/python-awscli/Default)
+  DEPENDS:=+python3 \
+	+python3-yaml \
+	+python3-pyasn1 \
+	+python3-botocore \
+	+python3-rsa \
+	+python3-colorama \
+	+python3-docutils \
+	+python3-s3transfer
+  VARIANT:=python3
+endef
+
+define Package/python-awscli/description
+This package provides a unified command line interface to Amazon Web Services.
+endef
+
+define Package/python3-awscli/description
+$(call Package/python-awscli/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-awscli))
+$(eval $(call BuildPackage,python-awscli))
+$(eval $(call BuildPackage,python-awscli-src))
+
+$(eval $(call Py3Package,python3-awscli))
+$(eval $(call BuildPackage,python3-awscli))
+$(eval $(call BuildPackage,python3-awscli-src))

--- a/lang/python/python-botocore/Makefile
+++ b/lang/python/python-botocore/Makefile
@@ -1,0 +1,68 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=botocore
+PKG_VERSION:=1.12.66
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/b/botocore
+PKG_HASH:=25c39ecc71356287cf79d66981ec77deca374e28043b19b2f818d48aa34272a1
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-botocore-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
+PKG_LICENSE:=MIT
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-botocore/Default
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=botocore
+  URL:=https://github.com/boto/botocore
+endef
+
+define Package/python-botocore
+$(call Package/python-botocore/Default)
+  DEPENDS:=+python \
+	+python-urllib3 \
+	+python-docutils \
+	+python-dateutil \
+	+python-jmespath \
+	+python-requests
+  VARIANT:=python
+endef
+
+define Package/python3-botocore
+$(call Package/python-botocore/Default)
+  DEPENDS:=+python3 \
+	+python3-urllib3 \
+	+python3-docutils \
+	+python3-dateutil \
+	+python3-jmespath \
+	+python3-requests
+  VARIANT:=python3
+endef
+
+define Package/python-botocore/description
+A low-level interface to a growing number of Amazon Web Services.
+The botocore package is the foundation for the AWS CLI as well as boto3.
+endef
+
+define Package/python3-botocore/description
+$(call Package/python-botocore/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-botocore))
+$(eval $(call BuildPackage,python-botocore))
+$(eval $(call BuildPackage,python-botocore-src))
+
+$(eval $(call Py3Package,python3-botocore))
+$(eval $(call BuildPackage,python3-botocore))
+$(eval $(call BuildPackage,python3-botocore-src))

--- a/lang/python/python-colorama/Makefile
+++ b/lang/python/python-colorama/Makefile
@@ -1,0 +1,58 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=colorama
+PKG_VERSION:=0.4.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/colorama
+PKG_HASH:=05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-colorama-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
+PKG_LICENSE:=MIT
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-colorama/Default
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=colorama
+  URL:=https://github.com/tartley/colorama
+endef
+
+define Package/python-colorama
+$(call Package/python-colorama/Default)
+  DEPENDS:=+python
+  VARIANT:=python
+endef
+
+define Package/python3-colorama
+$(call Package/python-colorama/Default)
+  DEPENDS:=+python3
+  VARIANT:=python3
+endef
+
+define Package/python-colorama/description
+Makes ANSI escape character sequences
+(for producing colored terminal text and cursor positioning) work under MS Windows.
+endef
+
+define Package/python3-colorama/description
+$(call Package/python-colorama/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-colorama))
+$(eval $(call BuildPackage,python-colorama))
+$(eval $(call BuildPackage,python-colorama-src))
+
+$(eval $(call Py3Package,python3-colorama))
+$(eval $(call BuildPackage,python3-colorama))
+$(eval $(call BuildPackage,python3-colorama-src))

--- a/lang/python/python-docutils/Makefile
+++ b/lang/python/python-docutils/Makefile
@@ -1,0 +1,62 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=docutils
+PKG_VERSION:=0.14
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/docutils
+PKG_HASH:=51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-docutils-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
+PKG_LICENSE:=MIT
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-docutils/Default
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=docutils
+  URL:=http://docutils.sourceforge.net
+endef
+
+define Package/python-docutils
+$(call Package/python-docutils/Default)
+  DEPENDS:=+python
+  VARIANT:=python
+endef
+
+define Package/python3-docutils
+$(call Package/python-docutils/Default)
+  DEPENDS:=+python3
+  VARIANT:=python3
+endef
+
+define Package/python-docutils/description
+Docutils is a modular system for processing documentation into useful formats,
+such as HTML, XML, and LaTeX. For input Docutils supports reStructuredText,
+an easy-to-read, what-you-see-is-what-you-get plaintext markup syntax.
+endef
+
+define Package/python3-docutils/description
+$(call Package/python-docutils/description)
+.
+(Variant for Python3)
+endef
+
+PYTHON_PKG_SETUP_ARGS:=
+PYTHON3_PKG_SETUP_ARGS:=
+
+$(eval $(call PyPackage,python-docutils))
+$(eval $(call BuildPackage,python-docutils))
+$(eval $(call BuildPackage,python-docutils-src))
+
+$(eval $(call Py3Package,python3-docutils))
+$(eval $(call BuildPackage,python3-docutils))
+$(eval $(call BuildPackage,python3-docutils-src))

--- a/lang/python/python-futures/Makefile
+++ b/lang/python/python-futures/Makefile
@@ -1,0 +1,38 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=futures
+PKG_VERSION:=3.2.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/f/futures
+PKG_HASH:=9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-futures-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
+PKG_LICENSE:=MIT
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-futures
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=futures
+  URL:=https://github.com/agronholm/pythonfutures
+  DEPENDS:=+python
+  VARIANT:=python
+endef
+
+define Package/python-futures/description
+  This is a backport of the concurrent.futures standard library module to Python 2.
+  It should not be installed on Python 3, although there should be no harm in doing so,
+  as the standard library takes precedence over third party libraries.
+endef
+
+$(eval $(call PyPackage,python-futures))
+$(eval $(call BuildPackage,python-futures))
+$(eval $(call BuildPackage,python-futures-src))

--- a/lang/python/python-jmespath/Makefile
+++ b/lang/python/python-jmespath/Makefile
@@ -1,0 +1,58 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=jmespath
+PKG_VERSION:=0.9.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/j/jmespath
+PKG_HASH:=6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-jmespath-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
+PKG_LICENSE:=MIT
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-jmespath/Default
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=jmespath
+  URL:=https://github.com/jmespath/jmespath.py
+endef
+
+define Package/python-jmespath
+$(call Package/python-jmespath/Default)
+  DEPENDS:=+python
+  VARIANT:=python
+endef
+
+define Package/python3-jmespath
+$(call Package/python-jmespath/Default)
+  DEPENDS:=+python3
+  VARIANT:=python3
+endef
+
+define Package/python-jmespath/description
+  JMESPath (pronounced “james path”) allows you to declaratively specify how to extract
+  elements from a JSON document.
+endef
+
+define Package/python3-jmespath/description
+$(call Package/python-jmespath/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-jmespath))
+$(eval $(call BuildPackage,python-jmespath))
+$(eval $(call BuildPackage,python-jmespath-src))
+
+$(eval $(call Py3Package,python3-jmespath))
+$(eval $(call BuildPackage,python3-jmespath))
+$(eval $(call BuildPackage,python3-jmespath-src))

--- a/lang/python/python-rsa/Makefile
+++ b/lang/python/python-rsa/Makefile
@@ -1,0 +1,59 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rsa
+PKG_VERSION:=4.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/r/rsa
+PKG_HASH:=1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-rsa-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
+PKG_LICENSE:=MIT
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-rsa/Default
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=rsa
+  URL:=https://stuvel.eu/rsa
+endef
+
+define Package/python-rsa
+$(call Package/python-rsa/Default)
+  DEPENDS:=+python +python-pyasn1
+  VARIANT:=python
+endef
+
+define Package/python3-rsa
+$(call Package/python-rsa/Default)
+  DEPENDS:=+python3 +python3-pyasn1
+  VARIANT:=python3
+endef
+
+define Package/python-rsa/description
+  Is a pure-Python RSA implementation. It supports encryption and decryption,
+  signing and verifying signatures, and key generation according to PKCS#1 version 1.5.
+  It can be used as a Python library as well as on the commandline. 
+endef
+
+define Package/python3-rsa/description
+$(call Package/python-rsa/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-rsa))
+$(eval $(call BuildPackage,python-rsa))
+$(eval $(call BuildPackage,python-rsa-src))
+
+$(eval $(call Py3Package,python3-rsa))
+$(eval $(call BuildPackage,python3-rsa))
+$(eval $(call BuildPackage,python3-rsa-src))

--- a/lang/python/python-s3transfer/Makefile
+++ b/lang/python/python-s3transfer/Makefile
@@ -1,0 +1,57 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=s3transfer
+PKG_VERSION:=0.2.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/s/s3transfer
+PKG_HASH:=f23d5cb7d862b104401d9021fc82e5fa0e0cf57b7660a1331425aab0c691d021
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-s3transfer-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
+PKG_LICENSE:=MIT
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-s3transfer/Default
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=s3transfer
+  URL:=https://github.com/boto/s3transfer
+endef
+
+define Package/python-s3transfer
+$(call Package/python-s3transfer/Default)
+  DEPENDS:=+python +python-botocore +python-futures
+  VARIANT:=python
+endef
+
+define Package/python3-s3transfer
+$(call Package/python-s3transfer/Default)
+  DEPENDS:=+python3 +python3-botocore
+  VARIANT:=python3
+endef
+
+define Package/python-s3transfer/description
+S3transfer is a Python library for managing Amazon S3 transfers.
+endef
+
+define Package/python3-s3transfer/description
+$(call Package/python-s3transfer/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-s3transfer))
+$(eval $(call BuildPackage,python-s3transfer))
+$(eval $(call BuildPackage,python-s3transfer-src))
+
+$(eval $(call Py3Package,python3-s3transfer))
+$(eval $(call BuildPackage,python3-s3transfer))
+$(eval $(call BuildPackage,python3-s3transfer-src))


### PR DESCRIPTION
Maintainer: Daniel Danzberger <daniel@dd-wrt.com>
Compile tested: x86, openwrt master
Run tested: x86, openwrt master

Description:
This pull request add's awscli with all it's dependencies.
AWSCLI is a python cmdline interface for accessing Amazon Web Services.

Signed-off-by: Daniel Danzberger <daniel@dd-wrt.com>