### PR TITLE
net-snmp: disable support for perl

### DIFF
--- a/net/net-snmp/Makefile
+++ b/net/net-snmp/Makefile
@@ -206,6 +206,9 @@ CONFIGURE_ARGS += \
 	--without-zlib \
 	--with-nl \
 	 $(call autoconf_bool,CONFIG_IPV6,ipv6) \
+	--disable-perl-cc-checks \
+	--disable-embedded-perl \
+	--without-perl-modules
 
 CONFIGURE_VARS += \
 	ac_cv_header_netlink_netlink_h=yes \


### PR DESCRIPTION
Using an external toolchain, it was discovered that net-snmp would
link with the Perl library (-lperl) from the host rather than from the
target.

Since we do not provide Perl as a dependency to net-snmp, the solution
is to disable support for it.

Fixes issue #8217.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
