### PR TITLE
travelmate: update 1.3.5

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.3.4
+PKG_VERSION:=1.3.5
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -31,8 +31,20 @@ start_service()
 
 reload_service()
 {
-	[ -s "${trm_pidfile}" ] && return 1
-	rc_procd start_service
+	local ppid pid
+
+	if [ -s "${trm_pidfile}" ]
+	then
+		ppid="$(cat "${trm_pidfile}" 2>/dev/null)"
+		if [ -n "${ppid}" ]
+		then
+			pid="$(pgrep sleep -P ${ppid} 2>/dev/null)"
+			if [ -n "${pid}" ]
+			then
+				kill -INT ${pid} 2>/dev/null
+			fi
+		fi
+	fi
 }
 
 stop_service()
@@ -68,5 +80,5 @@ service_triggers()
 
 	PROCD_RELOAD_DELAY=$((${delay:-2} * 1000))
 	procd_add_interface_trigger "interface.*.down" "${trigger}" "${trm_init}" reload
-	procd_add_reload_trigger "travelmate"
+	procd_add_config_trigger "config.change" "travelmate" "${trm_init}" restart
 }


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL-AR750S, OpenWrt SNAPSHOT r9354-c35d7f3f8a

Description:
* rework procd trigger handling
	- react immediately on if down network events
	- remove needless apply hook in LuCI

Signed-off-by: Dirk Brenken <dev@brenken.org>
