### PR TITLE
irssi: Fix OpenSSL without deprecated APIs compilation

### DIFF
--- a/net/irssi/Makefile
+++ b/net/irssi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=irssi
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/irssi/irssi/releases/download/1.2.0/
@@ -17,10 +17,10 @@ PKG_HASH:=1643fca1d8b35e5a5d7b715c9c889e1e9cdb7e578e06487901ea959e6ab3ebe5
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
-
 PKG_CPE_ID:=cpe:/a:irssi:irssi
 
 PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -40,16 +40,14 @@ define Package/irssi/description
 	Irssi is a terminal based IRC client for UNIX systems.
 endef
 
+TARGET_LDFLAGS += -Wl,--gc-sections
+
 CONFIGURE_ARGS += \
-	--with-perl=no \
-	--with-glib-prefix="$(STAGING_DIR)/usr" \
-	--with-ssl="$(STAGING_DIR)/usr" \
+	--disable-glibtest \
 	--with-textui \
 	--without-bot \
-	--disable-proxy
-
-EXTRA_CFLAGS+=$(TARGET_CPPFLAGS)
-EXTRA_LDFLAGS+=-lncurses
+	--without-perl \
+	--without-proxy
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/irssi

--- a/net/irssi/patches/010-Fix-finding-OpenSSL-when-1.1-with-deprecated-APIs-di.patch
+++ b/net/irssi/patches/010-Fix-finding-OpenSSL-when-1.1-with-deprecated-APIs-di.patch
@@ -1,0 +1,27 @@
+From cff1385b398b59c74c535d6c0cd9deec561101fd Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 15 Feb 2019 15:02:34 -0800
+Subject: [PATCH] Fix finding OpenSSL when 1.1 with deprecated APIs disabled
+
+SSL_library_init is a deprecated function. OPENSSL_init_ssl is not in 1.0.2.
+SSL_CTX_new is in both.
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index e8290dfd..8dde6095 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -319,7 +319,7 @@ PKG_CHECK_MODULES([OPENSSL], [openssl], [
+ 	CFLAGS="$CFLAGS $OPENSSL_CFLAGS"
+ 	LIBS="$LIBS $OPENSSL_LIBS"
+ ], [
+-	AC_CHECK_LIB([ssl], [SSL_library_init], [
++	AC_CHECK_LIB([ssl], [SSL_CTX_new], [
+ 		LIBS="$LIBS -lssl -lcrypto"
+ 	], [
+ 		AC_MSG_ERROR([The OpenSSL library was not found])
+-- 
+2.17.1
+


### PR DESCRIPTION
When OpenSSL is built without deprecated APIs, pkg-config first tries
OpenSSL in the staging directory but fails as it cannot find the
deprecated SSL_library_init function and ends up finding the system one.

Added PKG_BUILD_PARALLEL for faster compilation.

Added -Wl,--gc-sections to LDFLAGS to save ~10KB from the resulting ipk.

Reworked configure section as some of those options were renamed or
removed.

Removed EXTRA_* hacks that are no longer necessary.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: ramips
Run tested: ramips