### PR TITLE
shadowsocks-libev: Update init script

### DIFF
--- a/net/shadowsocks-libev/Makefile
+++ b/net/shadowsocks-libev/Makefile
@@ -14,7 +14,7 @@ include $(TOPDIR)/rules.mk
 #
 PKG_NAME:=shadowsocks-libev
 PKG_VERSION:=3.2.3
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$(PKG_VERSION)

--- a/net/shadowsocks-libev/files/shadowsocks-libev.init
+++ b/net/shadowsocks-libev/files/shadowsocks-libev.init
@@ -12,6 +12,24 @@ START=99
 ss_confdir=/var/etc/shadowsocks-libev
 ss_bindir=/usr/bin
 
+ss_validate() {
+	uci_load_validate shadowsocks-libev "$@"
+}
+
+add_common_validate_options_() {
+	"$@" \
+		'disabled:bool:0' \
+		'fast_open:bool:0' \
+		'ipv6_first:bool:0' \
+		'no_delay:bool:0' \
+		'reuse_port:bool:0' \
+		'verbose:bool:0' \
+		'mode:or("tcp_only", "udp_only", "tcp_and_udp"):tcp_only' \
+		'mtu:uinteger' \
+		'timeout:uinteger' \
+		'user:string'
+}
+
 ss_mkjson_common_conf() {
 	json_add_boolean fast_open "$fast_open"
 	json_add_boolean ipv6_first "$ipv6_first"
@@ -20,6 +38,19 @@ ss_mkjson_common_conf() {
 	[ -z "$mtu" ] || json_add_int mtu "$mtu"
 	[ -z "$timeout" ] || json_add_int timeout "$timeout"
 	[ -z "$user" ] || json_add_string user "$user"
+}
+
+validate_common_server_options_() {
+	local stream_methods='"table", "rc4", "rc4-md5", "aes-128-cfb", "aes-192-cfb", "aes-256-cfb", "aes-128-ctr", "aes-192-ctr", "aes-256-ctr", "bf-cfb", "camellia-128-cfb", "camellia-192-cfb", "camellia-256-cfb", "salsa20", "chacha20", "chacha20-ietf"'
+	local aead_methods='"aes-128-gcm", "aes-192-gcm", "aes-256-gcm", "chacha20-ietf-poly1305", "xchacha20-ietf-poly1305"'
+
+	ss_validate "$@" \
+		'disabled:bool:0' \
+		'server:host' \
+		'server_port:port' \
+		'password:string' \
+		'key:string' \
+		"method:or($stream_methods, $aead_methods)"
 }
 
 ss_mkjson_common_server_conf() {
@@ -34,12 +65,24 @@ ss_mkjson_common_server_conf() {
 	[ -z "$method" ] || json_add_string method "$method"
 }
 
+validate_server_section() {
+	validate_common_server_options_ server "$1" "$2"
+}
+
 ss_mkjson_server_conf() {
 	local cfgserver
 
 	config_get cfgserver "$cfg" server
 	[ -n "$cfgserver" ] || return 1
 	validate_server_section "$cfgserver" ss_mkjson_common_server_conf
+}
+
+validate_common_client_options_() {
+	add_common_validate_options_ \
+		ss_validate "$@" \
+		'server:uci("shadowsocks-libev", "@server")' \
+		'local_address:host:0.0.0.0' \
+		'local_port:port'
 }
 
 ss_mkjson_common_client_conf() {
@@ -50,17 +93,36 @@ ss_mkjson_common_client_conf() {
 	[ -z "$local_port" ] || json_add_int local_port "$local_port"
 }
 
+validate_ss_local_section() {
+	validate_common_client_options_ ss_local "$1" "$2"
+}
+
 ss_mkjson_ss_local_conf() {
 	ss_mkjson_common_client_conf
+}
+
+validate_ss_redir_section() {
+	validate_common_client_options_ ss_redir "$1" "$2"
 }
 
 ss_mkjson_ss_redir_conf() {
 	ss_mkjson_common_client_conf
 }
 
+validate_ss_server_section() {
+	add_common_validate_options_ \
+		validate_common_server_options_ ss_server "$1" "$2" \
+		'bind_address:ipaddr'
+}
+
 ss_mkjson_ss_server_conf() {
 	ss_mkjson_common_conf
 	ss_mkjson_common_server_conf "$cfg" 0
+}
+
+validate_ss_tunnel_section() {
+	validate_common_client_options_ ss_tunnel "$1" "$2" \
+		'tunnel_address:regex(".+\:[0-9]+")'
 }
 
 ss_mkjson_ss_tunnel_conf() {
@@ -109,6 +171,26 @@ ss_rules_cb() {
 			eval "ss_rules_redir_udp_$cfg=$local_port"
 		fi
 	fi
+}
+
+validate_ss_rules_section() {
+	ss_validate ss_rules "$1" "$2" \
+		'disabled:bool:0' \
+		'redir_tcp:uci("shadowsocks-libev", "@ss_redir")' \
+		'redir_udp:uci("shadowsocks-libev", "@ss_redir")' \
+		'src_ips_bypass:or(ipaddr,cidr)' \
+		'src_ips_forward:or(ipaddr,cidr)' \
+		'src_ips_checkdst:or(ipaddr,cidr)' \
+		'dst_ips_bypass_file:file' \
+		'dst_ips_bypass:or(ipaddr,cidr)' \
+		'dst_ips_forward_file:file' \
+		'dst_ips_forward:or(ipaddr,cidr)' \
+		'src_default:or("bypass", "forward", "checkdst"):checkdst' \
+		'dst_default:or("bypass", "forward"):bypass' \
+		'local_default:or("bypass", "forward", "checkdst"):bypass' \
+		'dst_forward_recentrst:bool:0' \
+		'ifnames:maxlength(15)' \
+		'ipt_args:string'
 }
 
 ss_rules() {
@@ -186,86 +268,4 @@ service_triggers() {
 	validate_ss_server_section
 	validate_ss_tunnel_section
 	procd_close_validate
-}
-
-ss_validate() {
-	uci_load_validate shadowsocks-libev "$@"
-}
-
-validate_common_server_options_() {
-	local stream_methods='"table", "rc4", "rc4-md5", "aes-128-cfb", "aes-192-cfb", "aes-256-cfb", "aes-128-ctr", "aes-192-ctr", "aes-256-ctr", "bf-cfb", "camellia-128-cfb", "camellia-192-cfb", "camellia-256-cfb", "salsa20", "chacha20", "chacha20-ietf"'
-	local aead_methods='"aes-128-gcm", "aes-192-gcm", "aes-256-gcm", "chacha20-ietf-poly1305", "xchacha20-ietf-poly1305"'
-
-	ss_validate "$@" \
-		'disabled:bool:0' \
-		'server:host' \
-		'server_port:port' \
-		'password:string' \
-		'key:string' \
-		"method:or($stream_methods, $aead_methods)"
-}
-
-validate_common_client_options_() {
-	add_common_validate_options_ \
-		ss_validate "$@" \
-		'server:uci("shadowsocks-libev", "@server")' \
-		'local_address:host:0.0.0.0' \
-		'local_port:port'
-}
-
-add_common_validate_options_() {
-	"$@" \
-		'disabled:bool:0' \
-		'fast_open:bool:0' \
-		'ipv6_first:bool:0' \
-		'no_delay:bool:0' \
-		'reuse_port:bool:0' \
-		'verbose:bool:0' \
-		'mode:or("tcp_only", "udp_only", "tcp_and_udp"):tcp_only' \
-		'mtu:uinteger' \
-		'timeout:uinteger' \
-		'user:string'
-}
-
-validate_server_section() {
-	validate_common_server_options_ server "$1" "$2"
-}
-
-validate_ss_local_section() {
-	validate_common_client_options_ ss_local "$1" "$2"
-}
-
-validate_ss_redir_section() {
-	validate_common_client_options_ ss_redir "$1" "$2"
-}
-
-validate_ss_rules_section() {
-	ss_validate ss_rules "$1" "$2" \
-		'disabled:bool:0' \
-		'redir_tcp:uci("shadowsocks-libev", "@ss_redir")' \
-		'redir_udp:uci("shadowsocks-libev", "@ss_redir")' \
-		'src_ips_bypass:or(ipaddr,cidr)' \
-		'src_ips_forward:or(ipaddr,cidr)' \
-		'src_ips_checkdst:or(ipaddr,cidr)' \
-		'dst_ips_bypass_file:file' \
-		'dst_ips_bypass:or(ipaddr,cidr)' \
-		'dst_ips_forward_file:file' \
-		'dst_ips_forward:or(ipaddr,cidr)' \
-		'src_default:or("bypass", "forward", "checkdst"):checkdst' \
-		'dst_default:or("bypass", "forward"):bypass' \
-		'local_default:or("bypass", "forward", "checkdst"):bypass' \
-		'dst_forward_recentrst:bool:0' \
-		'ifnames:maxlength(15)' \
-		'ipt_args:string'
-}
-
-validate_ss_server_section() {
-	add_common_validate_options_ \
-		validate_common_server_options_ ss_server "$1" "$2" \
-		'bind_address:ipaddr'
-}
-
-validate_ss_tunnel_section() {
-	validate_common_client_options_ ss_tunnel "$1" "$2" \
-		'tunnel_address:regex(".+\:[0-9]+")'
 }

--- a/net/shadowsocks-libev/files/shadowsocks-libev.init
+++ b/net/shadowsocks-libev/files/shadowsocks-libev.init
@@ -11,85 +11,63 @@ START=99
 
 ss_confdir=/var/etc/shadowsocks-libev
 ss_bindir=/usr/bin
-q='"'
-
-ss_mkjson() {
-	echo "{" >"$confjson"
-	if ss_mkjson_ "$@" >>$confjson; then
-		sed -i -e '/^\s*$/d' -e '2,$s/^/\t/' -e '$s/,$//' "$confjson"
-		echo "}" >>"$confjson"
-	else
-		rm -f "$confjson"
-		return 1
-	fi
-}
-
-ss_mkjson_() {
-	local func
-
-	for func in "$@"; do
-		"$func" || return 1
-	done
-}
 
 ss_mkjson_server_conf() {
 	local cfgserver
 
 	config_get cfgserver "$cfg" server
 	[ -n "$cfgserver" ] || return 1
-	validate_server_section "$cfgserver" ss_mkjson_server_conf_
+	validate_server_section "$cfgserver" ss_mkjson_common_server_conf
 }
 
-ss_mkjson_server_conf_() {
+ss_mkjson_common_server_conf() {
 	[ "$2" = 0 ] || return 1
 	[ "$disabled" = 0 ] || return 1
 	[ -n "$server_port" ] || return 1
-	password="${password//\"/\\\"}"
-	cat <<-EOF
-		${server:+${q}server${q}: ${q}$server${q},}
-		"server_port": $server_port,
-		${method:+${q}method${q}: ${q}$method${q},}
-		${key:+${q}key${q}: ${q}$key${q},}
-		${password:+${q}password${q}: ${q}$password${q},}
-	EOF
+
+	[ -z "$server" ] || json_add_string server "$server"
+	json_add_int server_port $server_port
+	[ -z "$password" ] || json_add_string password "$password"
+	[ -z "$key" ] || json_add_string key "$key"
+	[ -z "$method" ] || json_add_string method "$method"
+}
+
+ss_mkjson_common_client_conf() {
+	ss_mkjson_common_conf
+	ss_mkjson_server_conf || return 1
+
+	json_add_string local_address "$local_address"
+	[ -z "$local_port" ] || json_add_int local_port "$local_port"
 }
 
 ss_mkjson_common_conf() {
-	[ "$ipv6_first" = 0 ] && ipv6_first=false || ipv6_first=true
-	[ "$fast_open" = 0 ] && fast_open=false || fast_open=true
-	[ "$reuse_port" = 0 ] && reuse_port=false || reuse_port=true
-	cat <<-EOF
-		"use_syslog": true,
-		"ipv6_first": $ipv6_first,
-		"fast_open": $fast_open,
-		"reuse_port": $reuse_port,
-		${local_address:+${q}local_address${q}: ${q}$local_address${q},}
-		${local_port:+${q}local_port${q}: $local_port,}
-		${mode:+${q}mode${q}: ${q}$mode${q},}
-		${mtu:+${q}mtu${q}: $mtu,}
-		${timeout:+${q}timeout${q}: $timeout,}
-		${user:+${q}user${q}: ${q}$user${q},}
-	EOF
+	json_add_boolean fast_open "$fast_open"
+	json_add_boolean ipv6_first "$ipv6_first"
+	json_add_boolean reuse_port "$reuse_port"
+	json_add_string mode "$mode"
+	[ -z "$mtu" ] || json_add_int mtu "$mtu"
+	[ -z "$timeout" ] || json_add_int timeout "$timeout"
+	[ -z "$user" ] || json_add_string user "$user"
 }
 
 ss_mkjson_ss_local_conf() {
-	ss_mkjson_server_conf
+	ss_mkjson_common_client_conf
 }
 
 ss_mkjson_ss_redir_conf() {
-	ss_mkjson_server_conf
+	ss_mkjson_common_client_conf
 }
 
 ss_mkjson_ss_server_conf() {
-	ss_mkjson_server_conf_ "$cfg" 0
+	ss_mkjson_common_conf
+	ss_mkjson_common_server_conf "$cfg" 0
 }
 
 ss_mkjson_ss_tunnel_conf() {
-	ss_mkjson_server_conf || return 1
+	ss_mkjson_common_client_conf || return 1
 	[ -n "$tunnel_address" ] || return 1
-	cat <<-EOF
-		${tunnel_address:+${q}tunnel_address${q}: ${q}$tunnel_address${q},}
-	EOF
+
+	json_add_string tunnel_address "$tunnel_address"
 }
 
 ss_xxx() {
@@ -101,20 +79,20 @@ ss_xxx() {
 	[ "$2" = 0 ] || return 1
 	[ "$disabled" = 0 ] || return
 
-	if ss_mkjson \
-			ss_mkjson_common_conf \
-			ss_mkjson_${cfgtype}_conf \
-			; then
-		procd_open_instance "$cfgtype.$cfg"
-		procd_set_param command "$bin" -c "$confjson"
-		[ "$verbose" = 0 ] || procd_append_param command -v
-		[ "$no_delay" = 0 ] || procd_append_param command --no-delay
-		[ -z "$bind_address" ] || procd_append_param command -b "$bind_address"
-		procd_set_param file "$confjson"
-		procd_set_param respawn
-		procd_close_instance
-		ss_rules_cb
-	fi
+	json_init
+	json_add_boolean use_syslog 1
+	eval "ss_mkjson_${cfgtype}_conf" || return 1
+	json_dump -i > "$confjson"
+
+	procd_open_instance "$cfgtype.$cfg"
+	procd_set_param command "$bin" -c "$confjson"
+	[ "$verbose" = 0 ] || procd_append_param command -v
+	[ "$no_delay" = 0 ] || procd_append_param command --no-delay
+	[ -z "$bind_address" ] || procd_append_param command -b "$bind_address"
+	procd_set_param file "$confjson"
+	procd_set_param respawn
+	procd_close_instance
+	ss_rules_cb
 }
 
 ss_rules_cb() {

--- a/net/shadowsocks-libev/files/shadowsocks-libev.init
+++ b/net/shadowsocks-libev/files/shadowsocks-libev.init
@@ -12,12 +12,14 @@ START=99
 ss_confdir=/var/etc/shadowsocks-libev
 ss_bindir=/usr/bin
 
-ss_mkjson_server_conf() {
-	local cfgserver
-
-	config_get cfgserver "$cfg" server
-	[ -n "$cfgserver" ] || return 1
-	validate_server_section "$cfgserver" ss_mkjson_common_server_conf
+ss_mkjson_common_conf() {
+	json_add_boolean fast_open "$fast_open"
+	json_add_boolean ipv6_first "$ipv6_first"
+	json_add_boolean reuse_port "$reuse_port"
+	json_add_string mode "$mode"
+	[ -z "$mtu" ] || json_add_int mtu "$mtu"
+	[ -z "$timeout" ] || json_add_int timeout "$timeout"
+	[ -z "$user" ] || json_add_string user "$user"
 }
 
 ss_mkjson_common_server_conf() {
@@ -32,22 +34,20 @@ ss_mkjson_common_server_conf() {
 	[ -z "$method" ] || json_add_string method "$method"
 }
 
+ss_mkjson_server_conf() {
+	local cfgserver
+
+	config_get cfgserver "$cfg" server
+	[ -n "$cfgserver" ] || return 1
+	validate_server_section "$cfgserver" ss_mkjson_common_server_conf
+}
+
 ss_mkjson_common_client_conf() {
 	ss_mkjson_common_conf
 	ss_mkjson_server_conf || return 1
 
 	json_add_string local_address "$local_address"
 	[ -z "$local_port" ] || json_add_int local_port "$local_port"
-}
-
-ss_mkjson_common_conf() {
-	json_add_boolean fast_open "$fast_open"
-	json_add_boolean ipv6_first "$ipv6_first"
-	json_add_boolean reuse_port "$reuse_port"
-	json_add_string mode "$mode"
-	[ -z "$mtu" ] || json_add_int mtu "$mtu"
-	[ -z "$timeout" ] || json_add_int timeout "$timeout"
-	[ -z "$user" ] || json_add_string user "$user"
 }
 
 ss_mkjson_ss_local_conf() {

--- a/net/shadowsocks-libev/files/shadowsocks-libev.init
+++ b/net/shadowsocks-libev/files/shadowsocks-libev.init
@@ -37,13 +37,12 @@ ss_mkjson_server_conf() {
 
 	config_get cfgserver "$cfg" server
 	[ -n "$cfgserver" ] || return 1
-	eval "$(validate_server_section "$cfg" ss_validate_mklocal)"
-	validate_server_section "$cfgserver" || return 1
-	[ "$disabled" = 0 ] || return 1
-	ss_mkjson_server_conf_ "$cfgserver"
+	validate_server_section "$cfgserver" ss_mkjson_server_conf_
 }
 
 ss_mkjson_server_conf_() {
+	[ "$2" = 0 ] || return 1
+	[ "$disabled" = 0 ] || return 1
 	[ -n "$server_port" ] || return 1
 	password="${password//\"/\\\"}"
 	cat <<-EOF
@@ -82,7 +81,7 @@ ss_mkjson_ss_redir_conf() {
 }
 
 ss_mkjson_ss_server_conf() {
-	ss_mkjson_server_conf_
+	ss_mkjson_server_conf_ "$cfg" 0
 }
 
 ss_mkjson_ss_tunnel_conf() {
@@ -95,13 +94,11 @@ ss_mkjson_ss_tunnel_conf() {
 
 ss_xxx() {
 	local cfg="$1"
-	local cfgtype="$2"
 	local bin="$ss_bindir/${cfgtype/_/-}"
 	local confjson="$ss_confdir/$cfgtype.$cfg.json"
 
 	[ -x "$bin" ] || return
-	eval "$("validate_${cfgtype}_section" "$cfg" ss_validate_mklocal)"
-	"validate_${cfgtype}_section" "$cfg" || return 1
+	[ "$2" = 0 ] || return 1
 	[ "$disabled" = 0 ] || return
 
 	if ss_mkjson \
@@ -137,9 +134,7 @@ ss_rules_cb() {
 }
 
 ss_rules() {
-	local cfg="ss_rules"
 	local bin="$ss_bindir/ss-rules"
-	local cfgtype
 	local local_port_tcp local_port_udp
 	local args
 
@@ -147,11 +142,7 @@ ss_rules() {
 	"$bin" -f
 	"$bin" -6 -f
 
-	config_get cfgtype "$cfg" TYPE
-	[ "$cfgtype" = ss_rules ] || return 1
-
-	eval "$(validate_ss_rules_section "$cfg" ss_validate_mklocal)"
-	validate_ss_rules_section "$cfg" || return 1
+	[ "$2" = 0 ] || return 1
 	[ "$disabled" = 0 ] || return 0
 
 	eval local_port_tcp="\$ss_rules_redir_tcp_$redir_tcp"
@@ -191,9 +182,9 @@ start_service() {
 	mkdir -p "$ss_confdir"
 	config_load shadowsocks-libev
 	for cfgtype in ss_local ss_redir ss_server ss_tunnel; do
-		config_foreach ss_xxx "$cfgtype" "$cfgtype"
+		config_foreach validate_${cfgtype}_section $cfgtype ss_xxx
 	done
-	ss_rules
+	validate_ss_rules_section ss_rules ss_rules
 }
 
 stop_service() {
@@ -219,28 +210,15 @@ service_triggers() {
 	procd_close_validate
 }
 
-ss_validate_mklocal() {
-	local tuple opts
-
-	shift 2
-	for tuple in "$@"; do
-		opts="${tuple%%:*} $opts"
-	done
-	[ -z "$opts" ] || echo "local $opts"
-}
-
 ss_validate() {
-	uci_validate_section shadowsocks-libev "$@"
+	uci_load_validate shadowsocks-libev "$@"
 }
 
 validate_common_server_options_() {
-	local cfgtype="$1"; shift
-	local cfg="$1"; shift
-	local func="$1"; shift
 	local stream_methods='"table", "rc4", "rc4-md5", "aes-128-cfb", "aes-192-cfb", "aes-256-cfb", "aes-128-ctr", "aes-192-ctr", "aes-256-ctr", "bf-cfb", "camellia-128-cfb", "camellia-192-cfb", "camellia-256-cfb", "salsa20", "chacha20", "chacha20-ietf"'
 	local aead_methods='"aes-128-gcm", "aes-192-gcm", "aes-256-gcm", "chacha20-ietf-poly1305", "xchacha20-ietf-poly1305"'
 
-	"${func:-ss_validate}" "$cfgtype" "$cfg" "$@" \
+	ss_validate "$@" \
 		'disabled:bool:0' \
 		'server:host' \
 		'server_port:port' \
@@ -250,18 +228,15 @@ validate_common_server_options_() {
 }
 
 validate_common_client_options_() {
-	validate_common_options_ "$@" \
+	add_common_validate_options_ \
+		ss_validate "$@" \
 		'server:uci("shadowsocks-libev", "@server")' \
 		'local_address:host:0.0.0.0' \
 		'local_port:port'
 }
 
-validate_common_options_() {
-	local cfgtype="$1"; shift
-	local cfg="$1"; shift
-	local func="$1"; shift
-
-	"${func:-ss_validate}" "$cfgtype" "$cfg" "$@" \
+add_common_validate_options_() {
+	"$@" \
 		'disabled:bool:0' \
 		'fast_open:bool:0' \
 		'ipv6_first:bool:0' \
@@ -287,7 +262,7 @@ validate_ss_redir_section() {
 }
 
 validate_ss_rules_section() {
-	"${2:-ss_validate}" ss_rules "$1" \
+	ss_validate ss_rules "$1" "$2" \
 		'disabled:bool:0' \
 		'redir_tcp:uci("shadowsocks-libev", "@ss_redir")' \
 		'redir_udp:uci("shadowsocks-libev", "@ss_redir")' \
@@ -307,14 +282,12 @@ validate_ss_rules_section() {
 }
 
 validate_ss_server_section() {
-	validate_common_server_options_ ss_server "$1" \
-		validate_common_options_ \
-		"$2" \
+	add_common_validate_options_ \
+		validate_common_server_options_ ss_server "$1" "$2" \
 		'bind_address:ipaddr'
 }
 
 validate_ss_tunnel_section() {
-	validate_common_client_options_ ss_tunnel "$1" \
-		"$2" \
+	validate_common_client_options_ ss_tunnel "$1" "$2" \
 		'tunnel_address:regex(".+\:[0-9]+")'
 }

--- a/net/shadowsocks-libev/files/shadowsocks-libev.init
+++ b/net/shadowsocks-libev/files/shadowsocks-libev.init
@@ -33,6 +33,7 @@ add_common_validate_options_() {
 ss_mkjson_common_conf() {
 	json_add_boolean fast_open "$fast_open"
 	json_add_boolean ipv6_first "$ipv6_first"
+	json_add_boolean no_delay "$no_delay"
 	json_add_boolean reuse_port "$reuse_port"
 	json_add_string mode "$mode"
 	[ -z "$mtu" ] || json_add_int mtu "$mtu"
@@ -149,7 +150,6 @@ ss_xxx() {
 	procd_open_instance "$cfgtype.$cfg"
 	procd_set_param command "$bin" -c "$confjson"
 	[ "$verbose" = 0 ] || procd_append_param command -v
-	[ "$no_delay" = 0 ] || procd_append_param command --no-delay
 	[ -z "$bind_address" ] || procd_append_param command -b "$bind_address"
 	procd_set_param file "$confjson"
 	procd_set_param respawn


### PR DESCRIPTION
Maintainer: @yousong 
Compile tested: armvirt-32, 2019-02-16 snapshot sdk
Run tested: armvirt-32, 2019-02-16 snapshot

Description:
These changes do a few things:
* Replace `uci_validate_section()` (and `ss_validate_mklocal()`) with `uci_load_validate()`
* Replace custom json output with built-in json functions
* Refactor/reposition `ss_mkjson_*` and `validate_*` functions
* Move `no_delay` option from the command-line into json config (from the [documentation](https://github.com/shadowsocks/shadowsocks-libev/blob/c33cf3efc075fd8732b4e466d622f803fb0ee931/doc/shadowsocks-libev.asciidoc#config-file) this appears to be valid)

There isn't a strong technical reason for refactoring/repositioning the `ss_mkjson_*` and `validate_*` functions, but I hope it makes the script easier to understand. By understanding the flow of `validate_*`, it should be very easy to understand the flow of `ss_mkjson_*` (or vice versa).