### PR TITLE
libupnp: add large file defines to CFLAGS

### DIFF
--- a/libs/libupnp/Makefile
+++ b/libs/libupnp/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libupnp
 PKG_VERSION:=1.8.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/pupnp
@@ -45,7 +45,7 @@ define Package/libupnp-sample/description
 TVcontrolpoint & tvdevice sample applications run inside /etc/upnp-tvdevice/
 endef
 
-TARGET_CFLAGS += -flto
+TARGET_CFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -flto
 TARGET_LDFLAGS += -flto
 
 CONFIGURE_VARS += ac_cv_lib_compat_ftime=no


### PR DESCRIPTION
Maintainer: @thess
Compile tested: mxs
Run tested: -

Description:
This fixes compilation with glibc and uClibc for the included
sample programs as reported by builtbots for e.g. arc target:

-snip-
In file included from ../../upnp/inc/upnp.h:402:0,
                 from common/sample_util.h:49,
                 from common/sample_util.c:42:
../../upnp/inc/FileInfo.h:22:2: error: #error libupnp uses large file support, so users must do that, too
 #error libupnp uses large file support, so users must do that, too
  ^~~~~
Makefile:577: recipe for target 'common/tv_ctrlpt-sample_util.o' failed
-snap-

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
