### PR TITLE
python,python3: Fix calling default PyPackage/install

### DIFF
--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -68,7 +68,7 @@ define PyPackage
   $(call shexport,PyPackage/$(1)/filespec)
 
   define Package/$(1)/install
-	$(call PyPackage/$(1)/install,$$(1))
+	$$(call PyPackage/$(1)/install,$$(1))
 	$(SHELL) $(python_mk_path)python-package-install.sh "2" \
 		"$(PKG_INSTALL_DIR)" "$$(1)" \
 		"$(HOST_PYTHON_BIN)" "$$(2)" \

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -67,7 +67,7 @@ define Py3Package
   $(call shexport,Py3Package/$(1)/filespec)
 
   define Package/$(1)/install
-	$(call Py3Package/$(1)/install,$$(1))
+	$$(call Py3Package/$(1)/install,$$(1))
 	$(SHELL) $(python3_mk_path)python-package-install.sh "3" \
 		"$(PKG_INSTALL_DIR)" "$$(1)" \
 		"$(HOST_PYTHON3_BIN)" "$$(2)" \


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: armvirt-32, 2019-02-16 snapshot sdk
Run tested: none

Description:
This fixes `Package/*/install` to call `PyPackage/*/install` correctly. Previously, if a package used the default `PyPackage/*/install`, then it would not called. (A custom-defined `PyPackage/*/install` would be called with no issue.)

Signed-off-by: Jeffery To <jeffery.to@gmail.com>