### PR TITLE
libnopoll: fix compile error when we use nopoll develop

### DIFF
--- a/libs/libnopoll/Makefile
+++ b/libs/libnopoll/Makefile
@@ -45,6 +45,8 @@ CONFIGURE_ARGS += \
 	--enable-nopoll-doc=no
 
 define Build/InstallDev
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/include/nopoll
+	$(CP) $(PKG_BUILD_DIR)/src/*.h $(STAGING_DIR)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/{lib,include}
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnopoll.{a,so*} $(1)/usr/lib/


### PR DESCRIPTION
compile error msg is "nopoll.h can't find nopoll_decl.h"

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
