### PR TITLE
python-(automat|crypto|gmpy2|parsley): Use default compile

### DIFF
--- a/lang/python/python-automat/Makefile
+++ b/lang/python/python-automat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-automat
 PKG_VERSION:=0.7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=Automat-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/A/Automat
@@ -27,16 +27,21 @@ include ../python3-package.mk
 
 PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
+PYTHON_PKG_SETUP_VARS:= \
+  PKG_VERSION="$(PKG_VERSION)"
+PYTHON3_PKG_SETUP_VARS:= \
+  PKG_VERSION="$(PKG_VERSION)"
+
 define Package/python-automat/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=Concise, idiomatic finite-state automata
   URL:=https://github.com/glyph/Automat
 endef
 
 define Package/python-automat
 $(call Package/python-automat/Default)
-  TITLE:=Concise, idiomatic finite-state automata
   DEPENDS:= \
       +PACKAGE_python-automat:python-light \
       +PACKAGE_python-automat:python-attrs \
@@ -46,7 +51,6 @@ endef
 
 define Package/python3-automat
 $(call Package/python-automat/Default)
-  TITLE:=Concise, idiomatic finite-state automata
   DEPENDS:= \
       +PACKAGE_python3-automat:python3-light \
       +PACKAGE_python3-automat:python3-attrs \
@@ -74,20 +78,6 @@ endef
 define Py3Package/python3-automat/filespec
 +|$(PYTHON3_PKG_DIR)
 -|$(PYTHON3_PKG_DIR)/automat/_visualize.py
-endef
-
-define PyBuild/Compile
-	$(call Build/Compile/PyMod,, \
-		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)", \
-		PKG_VERSION="$(PKG_VERSION)" \
-	)
-endef
-
-define Py3Build/Compile
-	$(call Build/Compile/Py3Mod,, \
-		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)", \
-		PKG_VERSION="$(PKG_VERSION)" \
-	)
 endef
 
 $(eval $(call PyPackage,python-automat))

--- a/lang/python/python-crypto/Makefile
+++ b/lang/python/python-crypto/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-crypto
 PKG_VERSION:=2.6.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=pycrypto-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pycrypto
@@ -28,24 +28,32 @@ include ../python3-package.mk
 
 PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
+PYTHON_PKG_SETUP_ARGS:=
+PYTHON_PKG_SETUP_VARS:= \
+  CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)"
+
+PYTHON3_PKG_SETUP_ARGS:=
+PYTHON3_PKG_SETUP_VARS:= \
+  CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)"
+
 define Package/python-crypto/Default
   SECTION:=lang-python
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=Python Cryptography Toolkit
   URL:=https://www.dlitz.net/software/pycrypto/
+  DEPENDS:=+libgmp
 endef
 
 define Package/python-crypto
 $(call Package/python-crypto/Default)
-  TITLE:=python-crypto
-  DEPENDS:=+libgmp +PACKAGE_python-crypto:python
+  DEPENDS+=+PACKAGE_python-crypto:python
   VARIANT:=python
 endef
 
 define Package/python3-crypto
 $(call Package/python-crypto/Default)
-  TITLE:=python3-crypto
-  DEPENDS:=+libgmp +PACKAGE_python3-crypto:python3
+  DEPENDS+=+PACKAGE_python3-crypto:python3
   VARIANT:=python3
 endef
 
@@ -58,20 +66,6 @@ define Package/python3-crypto/description
 $(call Package/python-crypto/description)
 .
 (Variant for Python3)
-endef
-
-define PyBuild/Compile
-	$(call Build/Compile/PyMod,,\
-		install --prefix=/usr --root=$(PKG_INSTALL_DIR),\
-		CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)" \
-	)
-endef
-
-define Py3Build/Compile
-	$(call Build/Compile/Py3Mod,,\
-		install --prefix=/usr --root=$(PKG_INSTALL_DIR),\
-		CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)" \
-	)
 endef
 
 $(eval $(call PyPackage,python-crypto))

--- a/lang/python/python-gmpy2/Makefile
+++ b/lang/python/python-gmpy2/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-gmpy2
 PKG_VERSION:=2.0.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=gmpy2-$(PKG_VERSION).zip
-PKG_SOURCE_URL:=https://pypi.python.org/packages/90/f4/9a2e384b325b69bc5827b9a6510a8fb4a51698c915c06a3f25a86458892a
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/g/gmpy2
 PKG_HASH:=dd233e3288b90f21b0bb384bcc7a7e73557bb112ccf0032ad52aa614eb373d3f
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-gmpy2-$(PKG_VERSION)
@@ -27,24 +27,27 @@ include ../python3-package.mk
 
 PKG_UNPACK:=unzip -q -d $(PKG_BUILD_DIR) $(DL_DIR)/$(PKG_SOURCE); mv -f $(PKG_BUILD_DIR)/gmpy2-$(PKG_VERSION)/* $(PKG_BUILD_DIR)
 
+PYTHON_PKG_SETUP_ARGS:=--nompfr
+PYTHON3_PKG_SETUP_ARGS:=--nompfr
+
 define Package/python-gmpy2/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  URL:=http://code.google.com/p/gmpy/
+  TITLE:=GMP/MPIR, MPFR, and MPC interface
+  URL:=https://github.com/aleaxit/gmpy
+  DEPENDS:=+libgmp
 endef
 
 define Package/python-gmpy2
 $(call Package/python-gmpy2/Default)
-  TITLE:=python-gmpy2
-  DEPENDS:=+libgmp +PACKAGE_python-gmpy2:python-light
+  DEPENDS+=+PACKAGE_python-gmpy2:python-light
   VARIANT:=python
 endef
 
 define Package/python3-gmpy2
 $(call Package/python-gmpy2/Default)
-  TITLE:=python3-gmpy2
-  DEPENDS:=+libgmp +PACKAGE_python3-gmpy2:python3-light
+  DEPENDS+=+PACKAGE_python3-gmpy2:python3-light
   VARIANT:=python3
 endef
 
@@ -64,16 +67,10 @@ $(call Package/python-gmpy2/description)
 (Variant for Python3)
 endef
 
-define PyBuild/Compile
-	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" --nompfr)
-endef
-
-define Py3Build/Compile
-	$(call Build/Compile/Py3Mod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" --nompfr)
-endef
-
 $(eval $(call PyPackage,python-gmpy2))
 $(eval $(call BuildPackage,python-gmpy2))
+$(eval $(call BuildPackage,python-gmpy2-src))
 
 $(eval $(call Py3Package,python3-gmpy2))
 $(eval $(call BuildPackage,python3-gmpy2))
+$(eval $(call BuildPackage,python3-gmpy2-src))

--- a/lang/python/python-parsley/Makefile
+++ b/lang/python/python-parsley/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-parsley
 PKG_VERSION:=1.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=Parsley-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/P/Parsley
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/P/Parsley
 PKG_HASH:=9444278d47161d5f2be76a767809a3cbe6db4db822f46a4fd7481d4057208d41
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-parsley-$(PKG_VERSION)
@@ -27,23 +27,25 @@ include ../python3-package.mk
 
 PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
+PYTHON_PKG_SETUP_ARGS:=
+PYTHON3_PKG_SETUP_ARGS:=
+
 define Package/python-parsley/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=Parsing and pattern matching
   URL:=http://launchpad.net/parsley
 endef
 
 define Package/python-parsley
 $(call Package/python-parsley/Default)
-  TITLE:=python-parsley
   DEPENDS:=+PACKAGE_python-parsley:python-light
   VARIANT:=python
 endef
 
 define Package/python3-parsley
 $(call Package/python-parsley/Default)
-  TITLE:=python3-parsley
   DEPENDS:=+PACKAGE_python3-parsley:python3-light
   VARIANT:=python3
 endef
@@ -56,14 +58,6 @@ define Package/python3-parsley/description
 $(call Package/python-parsley/description)
 .
 (Variant for Python3)
-endef
-
-define PyBuild/Compile
-	$(call Build/Compile/PyMod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
-endef
-
-define Py3Build/Compile
-	$(call Build/Compile/Py3Mod,,install --prefix="/usr" --root="$(PKG_INSTALL_DIR)")
 endef
 
 $(eval $(call PyPackage,python-parsley))


### PR DESCRIPTION
Maintainer: me
Compile tested: armvirt-32, 2019-02-19 snapshot sdk
Run tested: none

Description:
This updates these packages to use the default `PyBuild/Compile`, instead of defining their own `Build/Compile`.

This also updates the Python 2 and 3 versions to use the same TITLE.

This also updates the source url and adds src packages for python-gmpy2.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>