### PR TITLE
fish: Update to 3.0.2

### DIFF
--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -5,18 +5,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fish
-PKG_VERSION:=3.0.0
-PKG_RELEASE:=3
+PKG_VERSION:=3.0.2
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/fish-shell/fish-shell/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=a16b0ff31111167ef4f3831ef428bb236bef592b7f49a2867bf42405ee95ff33
-PKG_MAINTAINER:=Curtis Jiang <jqqqqqqqqqq@gmail.com>
+PKG_SOURCE_URL:=https://github.com/fish-shell/fish-shell/releases/download/$(PKG_VERSION)
+PKG_HASH:=14728ccc6b8e053d01526ebbd0822ca4eb0235e6487e832ec1d0d22f1395430e
+PKG_MAINTAINER:=Curtis Jiang <jqqqqqqqqqq@gmail.com>, Hao Dong <halbertdong@gmail.com>
 PKG_LICENSE:=GPL-2.0
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
-PKG_BUILD_DIR:=$(BUILD_DIR)/fish-shell-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Signed-off-by: Hao Dong <halbertdong@gmail.com>

Maintainer: @jqqqqqqqqqq , @haodong
Compile tested: bcm53xx, Snapshot
Run tested: Well done.

Description: 
- Update fish to v3.0.2,
- Use new source URL recommended officially to avoid errors during compiling.