### PR TITLE
btrfs-progs: Several fixes

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
 PKG_VERSION:=4.20.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs
@@ -41,7 +41,12 @@ define Package/btrfs-progs/description
 endef
 
 progs = btrfs btrfs-find-root btrfs-image btrfs-map-logical \
-	btrfs-select-super btrfstune fsck.btrfs mkfs.btrfs
+	btrfs-select-super btrfstune mkfs.btrfs
+
+TARGET_CFLAGS += -ffunction-sections -fdata-sections
+TARGET_LDFLAGS += -Wl,--gc-sections -Wl,--as-needed
+
+EXTRA_CFLAGS=$(TARGET_CPPFLAGS)
 
 CONFIGURE_ARGS += \
 	--disable-backtrace \
@@ -50,24 +55,16 @@ CONFIGURE_ARGS += \
 	--disable-python \
 	--disable-zstd
 
-TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
-TARGET_LDFLAGS += -Wl,--gc-sections -flto
-
-EXTRA_CFLAGS=$(TARGET_CPPFLAGS)
-
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/include/* \
-		$(1)/usr/include/
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/libbtrfs.{a,so*} \
-		$(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libbtrfs* $(1)/usr/lib/
 endef
 
 define Package/btrfs-progs/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libbtrfs.so* $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libbtrfs.so* $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libbtrfsutil.so* $(1)/usr/lib
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(addprefix $(PKG_INSTALL_DIR)/usr/bin/, $(progs)) $(1)/usr/bin/
 	$(LN) btrfs $(1)/usr/bin/btrfsck


### PR DESCRIPTION
Remove LTO. It causes an increase in size.

Remove fsck.btrfs. It's just a script that says to run btrfs check.

Replace INSTALL_BIN with CP to avoid copying what should be a symlink.

Install libbtrfsutil. This is needed by a few of the tools.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me
Compile tested: ramips
Run tested: GnuBee PC1

Saves around ~5KB.