### PR TITLE
python-*: Update package data

### DIFF
--- a/lang/python/python-attrs/Makefile
+++ b/lang/python/python-attrs/Makefile
@@ -31,19 +31,18 @@ define Package/python-attrs/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=Classes Without Boilerplate
   URL:=http://www.attrs.org/
 endef
 
 define Package/python-attrs
 $(call Package/python-attrs/Default)
-  TITLE:=Classes Without Boilerplate
   DEPENDS:=+PACKAGE_python-attrs:python-light
   VARIANT:=python
 endef
 
 define Package/python3-attrs
 $(call Package/python-attrs/Default)
-  TITLE:=Classes Without Boilerplate
   DEPENDS:=+PACKAGE_python3-attrs:python3-light
   VARIANT:=python3
 endef

--- a/lang/python/python-constantly/Makefile
+++ b/lang/python/python-constantly/Makefile
@@ -31,19 +31,18 @@ define Package/python-constantly/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=Symbolic constants in Python
   URL:=https://github.com/twisted/constantly
 endef
 
 define Package/python-constantly
 $(call Package/python-constantly/Default)
-  TITLE:=Symbolic constants in Python
   DEPENDS:=+PACKAGE_python-constantly:python-light
   VARIANT:=python
 endef
 
 define Package/python3-constantly
 $(call Package/python-constantly/Default)
-  TITLE:=Symbolic constants in Python
   DEPENDS:=+PACKAGE_python3-constantly:python3-light
   VARIANT:=python3
 endef

--- a/lang/python/python-enum34/Makefile
+++ b/lang/python/python-enum34/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-enum34
 PKG_VERSION:=1.1.6
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=enum34-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/bf/3e/31d502c25302814a7c2f1d3959d2a3b3f78e509002ba91aea64993936876
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/e/enum34
 PKG_HASH:=8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-enum34-$(PKG_VERSION)
@@ -30,12 +30,12 @@ define Package/python-enum34/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  URL:=https://pypi.python.org/pypi/enum34/
+  TITLE:=Backported Python 3.4 enum
+  URL:=https://bitbucket.org/stoneleaf/enum34
 endef
 
 define Package/python-enum34
 $(call Package/python-enum34/Default)
-  TITLE:=python-enum34
   DEPENDS:=+PACKAGE_python-enum34:python-light
   VARIANT:=python
 endef

--- a/lang/python/python-hyperlink/Makefile
+++ b/lang/python/python-hyperlink/Makefile
@@ -31,12 +31,12 @@ define Package/python-hyperlink/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=Pure-Python immutable URLs
   URL:=https://github.com/python-hyper/hyperlink
 endef
 
 define Package/python-hyperlink
 $(call Package/python-hyperlink/Default)
-  TITLE:=Pure-Python immutable URLs
   DEPENDS:= \
       +PACKAGE_python-hyperlink:python-light \
       +PACKAGE_python-hyperlink:python-idna
@@ -45,7 +45,6 @@ endef
 
 define Package/python3-hyperlink
 $(call Package/python-hyperlink/Default)
-  TITLE:=Pure-Python immutable URLs
   DEPENDS:= \
       +PACKAGE_python3-hyperlink:python3-light \
       +PACKAGE_python3-hyperlink:python3-idna

--- a/lang/python/python-idna/Makefile
+++ b/lang/python/python-idna/Makefile
@@ -9,16 +9,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-idna
 PKG_VERSION:=2.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=idna-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/i/idna
 PKG_HASH:=c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407
+
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-idna-$(PKG_VERSION)
 
-PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
@@ -30,20 +31,23 @@ define Package/python-idna/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=IDNA library
   URL:=https://github.com/kjd/idna
 endef
 
 define Package/python-idna
 $(call Package/python-idna/Default)
-  TITLE:=python-idna
-  DEPENDS:=+PACKAGE_python-idna:python-light +PACKAGE_python-idna:python-codecs
+  DEPENDS:= \
+      +PACKAGE_python-idna:python-light \
+      +PACKAGE_python-idna:python-codecs
   VARIANT:=python
 endef
 
 define Package/python3-idna
 $(call Package/python-idna/Default)
-  TITLE:=python3-idna
-  DEPENDS:=+PACKAGE_python3-idna:python3-light +PACKAGE_python3-idna:python3-codecs
+  DEPENDS:= \
+      +PACKAGE_python3-idna:python3-light \
+      +PACKAGE_python3-idna:python3-codecs
   VARIANT:=python3
 endef
 

--- a/lang/python/python-incremental/Makefile
+++ b/lang/python/python-incremental/Makefile
@@ -31,19 +31,18 @@ define Package/python-incremental/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=Versions your Python projects
   URL:=https://github.com/twisted/incremental
 endef
 
 define Package/python-incremental
 $(call Package/python-incremental/Default)
-  TITLE:=Versions your Python projects
   DEPENDS:=+PACKAGE_python-incremental:python-light
   VARIANT:=python
 endef
 
 define Package/python3-incremental
 $(call Package/python-incremental/Default)
-  TITLE:=Versions your Python projects
   DEPENDS:=+PACKAGE_python3-incremental:python3-light
   VARIANT:=python3
 endef

--- a/lang/python/python-ipaddress/Makefile
+++ b/lang/python/python-ipaddress/Makefile
@@ -29,12 +29,12 @@ define Package/python-ipaddress/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=Python 3.3+'s ipaddress
   URL:=https://github.com/phihag/ipaddress
 endef
 
 define Package/python-ipaddress
 $(call Package/python-ipaddress/Default)
-  TITLE:=Python 3.3+'s ipaddress
   DEPENDS:=+PACKAGE_python-ipaddress:python-light
   VARIANT:=python
 endef

--- a/lang/python/python-ply/Makefile
+++ b/lang/python/python-ply/Makefile
@@ -32,19 +32,18 @@ define Package/python-ply/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=lex and yacc for Python
   URL:=http://www.dabeaz.com/ply/
 endef
 
 define Package/python-ply
 $(call Package/python-ply/Default)
-  TITLE:=lex and yacc for Python
   DEPENDS:=+PACKAGE_python-ply:python-light
   VARIANT:=python
 endef
 
 define Package/python3-ply
 $(call Package/python-ply/Default)
-  TITLE:=lex and yacc for Python
   DEPENDS:=+PACKAGE_python3-ply:python3-light
   VARIANT:=python3
 endef

--- a/lang/python/python-pyasn1-modules/Makefile
+++ b/lang/python/python-pyasn1-modules/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyasn1-modules
 PKG_VERSION:=0.2.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=pyasn1-modules-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyasn1-modules
@@ -31,25 +31,24 @@ define Package/python-pyasn1-modules/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  URL:=http://sourceforge.net/projects/pyasn1/
+  TITLE:=Collection of ASN.1 modules
+  URL:=https://github.com/etingof/pyasn1-modules
 endef
 
 define Package/python-pyasn1-modules
 $(call Package/python-pyasn1-modules/Default)
-  TITLE:=python-pyasn1-modules
-  VARIANT:=python
   DEPENDS:= \
       +PACKAGE_python-pyasn1-modules:python-light \
       +PACKAGE_python-pyasn1-modules:python-pyasn1
+  VARIANT:=python
 endef
 
 define Package/python3-pyasn1-modules
 $(call Package/python-pyasn1-modules/Default)
-  TITLE:=python3-pyasn1-modules
-  VARIANT:=python3
   DEPENDS:= \
       +PACKAGE_python3-pyasn1-modules:python3-light \
       +PACKAGE_python3-pyasn1-modules:python3-pyasn1
+  VARIANT:=python3
 endef
 
 define Package/python-pyasn1-modules/description

--- a/lang/python/python-pyasn1/Makefile
+++ b/lang/python/python-pyasn1/Makefile
@@ -31,19 +31,18 @@ define Package/python-pyasn1/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=ASN.1 library for Python
   URL:=https://github.com/etingof/pyasn1
 endef
 
 define Package/python-pyasn1
 $(call Package/python-pyasn1/Default)
-  TITLE:=ASN.1 library for Python
   DEPENDS:=+PACKAGE_python-pyasn1:python-light
   VARIANT:=python
 endef
 
 define Package/python3-pyasn1
 $(call Package/python-pyasn1/Default)
-  TITLE:=ASN.1 library for Python
   DEPENDS:=+PACKAGE_python3-pyasn1:python3-light
   VARIANT:=python3
 endef

--- a/lang/python/python-pycparser/Makefile
+++ b/lang/python/python-pycparser/Makefile
@@ -9,11 +9,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pycparser
 PKG_VERSION:=2.19
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=pycparser-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pycparser
 PKG_HASH:=a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3
+
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pycparser-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-3-Clause
@@ -33,20 +34,23 @@ define Package/python-pycparser/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=C parser in Python
   URL:=https://github.com/eliben/pycparser
 endef
 
 define Package/python-pycparser
 $(call Package/python-pycparser/Default)
-  TITLE:=python-pycparser
-  DEPENDS:=+PACKAGE_python-pycparser:python-light +PACKAGE_python-pycparser:python-ply
+  DEPENDS:= \
+      +PACKAGE_python-pycparser:python-light \
+      +PACKAGE_python-pycparser:python-ply
   VARIANT:=python
 endef
 
 define Package/python3-pycparser
 $(call Package/python-pycparser/Default)
-  TITLE:=python3-pycparser
-  DEPENDS:=+PACKAGE_python3-pycparser:python3-light +PACKAGE_python3-pycparser:python3-ply
+  DEPENDS:= \
+      +PACKAGE_python3-pycparser:python3-light \
+      +PACKAGE_python3-pycparser:python3-ply
   VARIANT:=python3
 endef
 

--- a/lang/python/python-pyptlib/Makefile
+++ b/lang/python/python-pyptlib/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyptlib
 PKG_VERSION:=0.0.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=pyptlib-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pyptlib
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyptlib
 PKG_HASH:=b98472e3d9e8f4689d3913ca8f89afa5e6cc5383dcd8686987606166f9dac607
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pyptlib-$(PKG_VERSION)
@@ -30,12 +30,12 @@ define Package/python-pyptlib/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  URL:=https://pypi.python.org/pypi/pyptlib
+  TITLE:=Pluggable Transports for Tor
+  URL:=https://pypi.org/project/pyptlib/
 endef
 
 define Package/python-pyptlib
 $(call Package/python-pyptlib/Default)
-  TITLE:=python-pyptlib
   DEPENDS:=+PACKAGE_python-pyptlib:python-light
   VARIANT:=python
 endef

--- a/lang/python/python-six/Makefile
+++ b/lang/python/python-six/Makefile
@@ -9,16 +9,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-six
 PKG_VERSION:=1.12.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=six-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/s/six
 PKG_HASH:=d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73
+
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-six-$(PKG_VERSION)
 
-PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
 HOST_BUILD_DEPENDS:=python/host
 
@@ -34,19 +35,18 @@ define Package/python-six/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=Python 2 and 3 compatibility library
   URL:=https://github.com/benjaminp/six
 endef
 
 define Package/python-six
 $(call Package/python-six/Default)
-  TITLE:=python-six
   DEPENDS:=+PACKAGE_python-six:python-light
   VARIANT:=python
 endef
 
 define Package/python3-six
 $(call Package/python-six/Default)
-  TITLE:=python3-six
   DEPENDS:=+PACKAGE_python3-six:python3-light
   VARIANT:=python3
 endef

--- a/lang/python/python-twisted/Makefile
+++ b/lang/python/python-twisted/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-twisted
 PKG_VERSION:=18.9.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=Twisted-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/T/Twisted
@@ -32,12 +32,12 @@ define Package/python-twisted/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  URL:=http://twistedmatrix.com/
+  TITLE:=Asynchronous networking framework
+  URL:=https://twistedmatrix.com/
 endef
 
 define Package/python-twisted
 $(call Package/python-twisted/Default)
-  TITLE:=Python networking engine
   DEPENDS:= \
       +PACKAGE_python-twisted:python-light \
       +PACKAGE_python-twisted:python-attrs \
@@ -52,7 +52,6 @@ endef
 
 define Package/python3-twisted
 $(call Package/python-twisted/Default)
-  TITLE:=Python3 networking engine
   DEPENDS:= \
       +PACKAGE_python3-twisted:python3-light \
       +PACKAGE_python3-twisted:python3-attrs \

--- a/lang/python/python-txsocksx/Makefile
+++ b/lang/python/python-txsocksx/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-txsocksx
 PKG_VERSION:=1.15.0.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=txsocksx-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/t/txsocksx
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/t/txsocksx
 PKG_HASH:=4f79b5225ce29709bfcee45e6f726e65b70fd6f1399d1898e54303dbd6f8065f
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-txsocksx-$(PKG_VERSION)
@@ -33,12 +33,12 @@ define Package/python-txsocksx/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=SOCKS client endpoints for Twisted
   URL:=https://github.com/habnabit/txsocksx
 endef
 
 define Package/python-txsocksx
 $(call Package/python-txsocksx/Default)
-  TITLE:=python-txsocksx
   DEPENDS:= \
       +PACKAGE_python-txsocksx:python-light \
       +PACKAGE_python-txsocksx:python-parsley \

--- a/lang/python/python-zope-interface/Makefile
+++ b/lang/python/python-zope-interface/Makefile
@@ -31,19 +31,18 @@ define Package/python-zope-interface/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=Interfaces for Python
   URL:=https://github.com/zopefoundation/zope.interface
 endef
 
 define Package/python-zope-interface
 $(call Package/python-zope-interface/Default)
-  TITLE:=Interfaces for Python
   DEPENDS:=+PACKAGE_python-zope-interface:python-light
   VARIANT:=python
 endef
 
 define Package/python3-zope-interface
 $(call Package/python-zope-interface/Default)
-  TITLE:=Interfaces for Python
   DEPENDS:=+PACKAGE_python3-zope-interface:python3-light
   VARIANT:=python3
 endef


### PR DESCRIPTION
Maintainer: me / @commodo 
Compile tested: armvirt-32, 2019-02-19 snapshot sdk
Run tested: none

Description:
This updates the Python 2 and 3 versions of each package to share the same title field. (For packages that only had this change, their `PKG_RELEASE` were not incremented.)

This also updates the package title, url and source urls, where necessary.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>