### PR TITLE
python,python3: do not package binary files to base packages

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -106,6 +106,7 @@ define PyBasePackage
       -|/usr/lib/python$(PYTHON_VERSION)/*/tests
     endif
   endef
+  PyPackage/$(1)/install?=:
 endef
 
 include ./files/python-package-*.mk
@@ -262,6 +263,9 @@ define PyPackage/python-base/install
 	$(LN) python$(PYTHON_VERSION) $(1)/usr/bin/python2
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON_VERSION).so* $(1)/usr/lib/
 endef
+
+PyPackage/python-light/install:=:
+PyPackage/python/install:=:
 
 define PyPackage/python/filespec
 -|$(PYTHON_PKG_DIR)

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -110,6 +110,7 @@ define Py3BasePackage
       -|/usr/lib/python$(PYTHON_VERSION)/*/tests
     endif
   endef
+  Py3Package/$(1)/install?=:
 endef
 
 include ./files/python3-package-*.mk
@@ -263,6 +264,9 @@ define Py3Package/python3-base/install
 	$(LN) python$(PYTHON_VERSION) $(1)/usr/bin/python3
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON_VERSION).so* $(1)/usr/lib/
 endef
+
+Py3Package/python3-light/install:=:
+Py3Package/python3/install:=:
 
 define Py3Package/python3/filespec
 -|$(PYTHON3_PKG_DIR)


### PR DESCRIPTION
Thanks to fix 200a5a2eec896b2d34f1114d14df66d810c1f4bd all base packages
now contain all binaries that are generated as part of python
installation. That causes collision between those packages with package
managers that consider this such as Turris updater-ng. This is also just
wrong. Those binaries were not included and should not be after
mentioned fix as well.

This just adds empty install definition. The idea is to override the
default one that is otherwise used.

Maintainer: @commodo 
Compile tested: Will update
Run tested: Will update 
