### PR TITLE
openssh: adjust engine support to openssl 1.1.1

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
 PKG_VERSION:=7.9p1
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
@@ -180,7 +180,7 @@ CONFIGURE_ARGS += \
 	--without-pam
 endif
 
-ifeq ($(CONFIG_OPENSSL_ENGINE_CRYPTO),y)
+ifeq ($(CONFIG_OPENSSL_ENGINE),y)
 CONFIGURE_ARGS+= \
 	--with-ssl-engine
 endif


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: mvebu, WRT3200ACM, openwrt master
Run tested: mvebu, WRT3200ACM, openwrt master, tested openssh-server/client

Description:
Openssl 1.1.1 package in openwrt enabled more than just the devcrypto
engine, so the engine support in openssh should be enabled when general
engine support is enabled in openssl.  Also, there's a patch vouching to allow devcrypto engine to be build dinamically, where the option name changes.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>