### PR TITLE
python,python3: Add PYTHON_PKG_SETUP_DIR

### DIFF
--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -115,8 +115,8 @@ define Build/Compile/PyMod
 endef
 
 PYTHON_PKG_SETUP_DIR ?=
-PYTHON_PKG_SETUP_ARGS:=--single-version-externally-managed
-PYTHON_PKG_SETUP_VARS:=
+PYTHON_PKG_SETUP_ARGS ?= --single-version-externally-managed
+PYTHON_PKG_SETUP_VARS ?=
 
 define PyBuild/Compile/Default
 	$(foreach pkg,$(HOST_PYTHON_PACKAGE_BUILD_DEPENDS),

--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -114,6 +114,7 @@ define Build/Compile/PyMod
 		$(3))
 endef
 
+PYTHON_PKG_SETUP_DIR ?=
 PYTHON_PKG_SETUP_ARGS:=--single-version-externally-managed
 PYTHON_PKG_SETUP_VARS:=
 
@@ -121,7 +122,8 @@ define PyBuild/Compile/Default
 	$(foreach pkg,$(HOST_PYTHON_PACKAGE_BUILD_DEPENDS),
 		$(call host_python_pip_install_host,$(pkg))
 	)
-	$(call Build/Compile/PyMod,, \
+	$(call Build/Compile/PyMod, \
+		$(PYTHON_PKG_SETUP_DIR), \
 		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
 		$(PYTHON_PKG_SETUP_ARGS), \
 		$(PYTHON_PKG_SETUP_VARS) \

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -113,6 +113,7 @@ define Build/Compile/Py3Mod
 		$(3))
 endef
 
+PYTHON3_PKG_SETUP_DIR ?=
 PYTHON3_PKG_SETUP_ARGS:=--single-version-externally-managed
 PYTHON3_PKG_SETUP_VARS:=
 
@@ -120,7 +121,8 @@ define Py3Build/Compile/Default
 	$(foreach pkg,$(HOST_PYTHON3_PACKAGE_BUILD_DEPENDS),
 		$(call host_python3_pip_install_host,$(pkg))
 	)
-	$(call Build/Compile/Py3Mod,, \
+	$(call Build/Compile/Py3Mod, \
+		$(PYTHON3_PKG_SETUP_DIR), \
 		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
 		$(PYTHON3_PKG_SETUP_ARGS), \
 		$(PYTHON3_PKG_SETUP_VARS) \

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -114,8 +114,8 @@ define Build/Compile/Py3Mod
 endef
 
 PYTHON3_PKG_SETUP_DIR ?=
-PYTHON3_PKG_SETUP_ARGS:=--single-version-externally-managed
-PYTHON3_PKG_SETUP_VARS:=
+PYTHON3_PKG_SETUP_ARGS ?= --single-version-externally-managed
+PYTHON3_PKG_SETUP_VARS ?=
 
 define Py3Build/Compile/Default
 	$(foreach pkg,$(HOST_PYTHON3_PACKAGE_BUILD_DEPENDS),


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: armvirt-32, 2019-02-20 snapshot sdk
Run tested: none

Description:
This adds a variable (`PYTHON_PKG_SETUP_DIR` / `PYTHON3_PKG_SETUP_DIR`) that allows a Python package Makefile to control the directory where `setup.py` is called (as part of `PyBuild/Compile/Default` / `Py3Build/Compile/Default`).

Signed-off-by: Jeffery To <jeffery.to@gmail.com>