### PR TITLE
i2c-tools: don't build python if not needed

### DIFF
--- a/utils/i2c-tools/Makefile
+++ b/utils/i2c-tools/Makefile
@@ -17,6 +17,7 @@ PKG_HASH:=57b219efd183795bd545dd5a60d9eabbe9dcb6f8fb92bc7ba2122b87f98527d5
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=PACKAGE_python-smbus:python
+PKG_BUILD_DEPENDS:=PACKAGE_python3-smbus:python3
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPLv2
@@ -135,7 +136,11 @@ endef
 
 $(eval $(call BuildPackage,libi2c))
 $(eval $(call BuildPackage,i2c-tools))
+ifdef CONFIG_PACKAGE_python-smbus
 $(eval $(call PyPackage,python-smbus))
 $(eval $(call BuildPackage,python-smbus))
+endif
+ifdef CONFIG_PACKAGE_python3-smbus
 $(eval $(call PyPackage,python3-smbus))
 $(eval $(call BuildPackage,python3-smbus))
+endif


### PR DESCRIPTION
If only i2c-tools is configured still python (and a bunch of other packages)
is being build. This is not needed and uses up storage and build time.

Added conditionals on the pyPackage and BuildPackage lines to avoid this.
Also added a missing PKG_BUILD_DEPENDS for PACKAGE_python3-smbus:python3

Signed-off-by: Frans Meulenbroeks <fransmeulenbroeks@yahoo.com>
I
Maintainer: @dangowrt
Compile tested: Lantiq XRX350, OpenWRT tip
Run tested: checkek dl directory after clean build. Python tarballs are not present (they were present when clean-building without this patch
