### PR TITLE
freeradius3: allow build without openssl engines

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=release_3_0_17
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive
@@ -380,6 +380,13 @@ define Package/freeradius3-utils
   DEPENDS:=+freeradius3-common
   TITLE:=Misc. client utilities
 endef
+
+# This is a workaround for a bug in configure.ac, that does not check
+# for the openss/rand.h header.  Setting the macro is safe for openwrt,
+# and faster than rebuilding configure.
+# This has been fixed upstream in the 3.0.x branch, and should not be
+# needed in a future release.
+EXTRA_CFLAGS+= -DHAVE_OPENSSL_RAND_H
 
 CONFIGURE_ARGS+= \
 	--libdir=/usr/lib/freeradius3 \

--- a/net/freeradius3/patches/004-tls.c-allow-build-with-no-openssl-engine-support.patch
+++ b/net/freeradius3/patches/004-tls.c-allow-build-with-no-openssl-engine-support.patch
@@ -1,0 +1,24 @@
+From 0b17cf6e39064b008792811a6babf4cd75ac7744 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cote2004-github@yahoo.com>
+Date: Mon, 25 Feb 2019 10:48:48 -0300
+Subject: [PATCH] tls.c: allow build with no openssl engine support
+
+This avoids an ENGINE_cleanup call if openssl was compiled without
+engine support.
+
+Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
+
+diff --git a/src/main/tls.c b/src/main/tls.c
+index 73f0e3a3e8..9726953234 100644
+--- a/src/main/tls.c
++++ b/src/main/tls.c
+@@ -2743,7 +2743,9 @@ void tls_global_cleanup(void)
+ #elif OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	ERR_remove_thread_state(NULL);
+ #endif
++#ifndef OPENSSL_NO_ENGINE
+ 	ENGINE_cleanup();
++#endif
+ 	CONF_modules_unload(1);
+ 	ERR_free_strings();
+ 	EVP_cleanup();


### PR DESCRIPTION
Maintainer: @LucileQ
Compile tested: ath79/mips_24kc & mvebu/arm, openwrt master
Run tested: None - @nasbdh9, can you run-test this, please.

Description:
This applies a patch comitted upstream that avoids a call to `ENGINE_cleanup` when the openssl library was built without engine support.

A workaround for a missing header check was used to silence a warning about the implicit definition of `RAND_load_file`.  A proper fix was submitted and merged upstream as well, and a note was left in the Makefile to check for the proper fix in future releases.

Fixes #8289, and should resolve the bots current failure to build this package.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

PS: upstream was extremely quick at merging my PR, so I've changed the patch to the actual upstream commit.