### PR TITLE
tor: Add PKG_CPE_ID for proper CVE tracking.

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -18,6 +18,7 @@ PKG_HASH:=d5c56603942a8927670f50a4a469fb909e29d3571fdd013389d567e57abc0b47
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/:a:torproject:tor
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: N/A
Run tested: N/A

Description:
Tor update to version was  0.3.5.8 (https://github.com/openwrt/packages/commit/03caca8e18c67b50ab52d25caddc3fefd3bf54ce)  fixed also CVE-2019-8955.  It would be better to have PKG_CPE_ID in place for better CVE tracking.

Changelog: https://gitweb.torproject.org/tor.git/plain/ChangeLog?h=tor-0.3.4.11

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>