### PR TITLE
minidlna: run as an unprivileged user

### DIFF
--- a/multimedia/minidlna/Makefile
+++ b/multimedia/minidlna/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=minidlna
 PKG_VERSION:=1.2.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=@SF/minidlna
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -36,6 +36,7 @@ define Package/minidlna
   DEPENDS:= +libpthread +libexif +libjpeg +libsqlite3 +libffmpeg \
   	+libid3tag +libflac +libvorbis +libuuid \
   	$(ICONV_DEPENDS) $(INTL_DEPENDS)
+  USERID:=minidlna:minidlna
 endef
 
 define Package/minidlna/description

--- a/multimedia/minidlna/files/minidlna.config
+++ b/multimedia/minidlna/files/minidlna.config
@@ -1,10 +1,11 @@
 config minidlna config
-	option 'enabled' '1'
+	option 'enabled' '0'
+	option user 'minidlna'
 	option port '8200'
 	option interface 'br-lan'
 	option friendly_name 'OpenWrt DLNA Server'
 	option db_dir '/var/run/minidlna'
-	option log_dir '/var/log'
+	option log_dir '/var/log/minidlna'
 	option inotify '1'
 	option enable_tivo '0'
 	option wide_links '0'

--- a/multimedia/minidlna/files/minidlna.init
+++ b/multimedia/minidlna/files/minidlna.init
@@ -6,7 +6,7 @@ START=50
 SERVICE_USE_PID=1
 SERVICE_PID_FILE=/var/run/minidlna/minidlna.pid
 
-MINIDLNA_CONFIG_FILE="/tmp/minidlna.conf"
+MINIDLNA_CONFIG_FILE="/var/etc/minidlna.conf"
 
 minidlna_cfg_append() {
 	echo "$1" >> "$MINIDLNA_CONFIG_FILE"
@@ -35,7 +35,6 @@ minidlna_cfg_addstr() {
 
 minidlna_cfg_add_media_dir() {
 	local val=$1
-
 	minidlna_cfg_append "media_dir=$val"
 }
 
@@ -44,31 +43,33 @@ minidlna_create_config() {
 	local port
 	local interface
 
-	config_get port $cfg port
-	config_get interface $cfg interface
+	config_get port "$cfg" port
+	config_get interface "$cfg" interface
 
 	[ -z "$interface" -o -t "$port" ] && return 1
 
+	mkdir -p /var/etc
 	echo "# this file is generated automatically, don't edit" > "$MINIDLNA_CONFIG_FILE"
 
 	minidlna_cfg_append "port=$port"
 	minidlna_cfg_append "network_interface=$interface"
 
-	minidlna_cfg_addstr $cfg friendly_name
-	minidlna_cfg_addstr $cfg db_dir
-	minidlna_cfg_addstr $cfg log_dir
-	minidlna_cfg_addstr $cfg log_level 'error'
-	minidlna_cfg_addbool $cfg inotify '1'
-	minidlna_cfg_addbool $cfg enable_tivo '0'
-	minidlna_cfg_addbool $cfg wide_links '0'
-	minidlna_cfg_addbool $cfg strict_dlna '0'
-	minidlna_cfg_addstr $cfg album_art_names
-	minidlna_cfg_addstr $cfg presentation_url
-	minidlna_cfg_addstr $cfg notify_interval '900'
-	minidlna_cfg_addstr $cfg serial '12345678'
-	minidlna_cfg_addstr $cfg model_number '1'
-	minidlna_cfg_addstr $cfg minissdpsocket
-	minidlna_cfg_addstr $cfg root_container '.'
+	minidlna_cfg_addstr "$cfg" friendly_name
+	minidlna_cfg_addstr "$cfg" user
+	minidlna_cfg_addstr "$cfg" db_dir
+	minidlna_cfg_addstr "$cfg" log_dir
+	minidlna_cfg_addstr "$cfg" log_level 'error'
+	minidlna_cfg_addbool "$cfg" inotify '1'
+	minidlna_cfg_addbool "$cfg" enable_tivo '0'
+	minidlna_cfg_addbool "$cfg" wide_links '0'
+	minidlna_cfg_addbool "$cfg" strict_dlna '0'
+	minidlna_cfg_addstr "$cfg" album_art_names
+	minidlna_cfg_addstr "$cfg" presentation_url
+	minidlna_cfg_addstr "$cfg" notify_interval '900'
+	minidlna_cfg_addstr "$cfg" serial '12345678'
+	minidlna_cfg_addstr "$cfg" model_number '1'
+	minidlna_cfg_addstr "$cfg" minissdpsocket
+	minidlna_cfg_addstr "$cfg" root_container '.'
 	config_list_foreach "$cfg" "media_dir" minidlna_cfg_add_media_dir
 
 	return 0
@@ -78,6 +79,7 @@ start() {
 	local enabled
 	local db_dir
 	local log_dir
+	local user
 
 	config_load 'minidlna'
 	config_get_bool enabled config 'enabled' '0'
@@ -87,10 +89,12 @@ start() {
 	minidlna_create_config config || return 1
 	
 	config_get db_dir config 'db_dir' '/var/run/minidlna'
-	config_get log_dir config 'log_dir' '/var/log'
+	config_get log_dir config 'log_dir' '/var/log/minidlna'
+	config_get user config 'user' 'root'
 
-	mkdir -m 0755 -p $db_dir
-	mkdir -m 0755 -p $log_dir
+	mkdir -m 0755 -p "$db_dir" "$log_dir"
+	chown -R "$user" "$db_dir" "$log_dir"
+
 	service_start /usr/bin/minidlna -f "$MINIDLNA_CONFIG_FILE"
 }
 


### PR DESCRIPTION
Signed-off-by: Maxim Storchak <m.storchak@gmail.com>

Maintainer: @medaved 
Compile tested: ath79, WNDR3800, r9439+2-fe90e48c39
Run tested: ath79, WNDR3800, r9439+2-fe90e48c39. Works, can find and announce content.

Description:
- run as unprivileged user by default
- move generated config to /var/run (/tmp/run in fact)
- disable service until it's configured: there is no way to reliably guess
  where files to be shared are located