### PR TITLE
samba4: fix selection without depend "libcap"

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -50,8 +50,8 @@ endef
 define Package/samba4-libs
   $(call Package/samba4/Default)
   TITLE+= libs
-  DEPENDS:= +zlib +libtirpc +krb5-libs +libpopt \
-	+PACKAGE_libcap:libcap +PACKAGE_libpthread:libpthread +PACKAGE_libnettle:libnettle \
+  DEPENDS:= +zlib +libtirpc +krb5-libs +libpopt +libcap \
+	+PACKAGE_libpthread:libpthread +PACKAGE_libnettle:libnettle \
 	+PACKAGE_libgcrypt:libgcrypt +PACKAGE_libpam:libpam +PACKAGE_dbus:dbus +PACKAGE_libavahi-client:libavahi-client \
 	+SAMBA4_SERVER_VFS:attr \
 	+SAMBA4_SERVER_ACL:acl +SAMBA4_SERVER_ACL:attr \


### PR DESCRIPTION
The depend "libcap" would not be auto-selected and could cause error like:
```
Package samba4-libs is missing dependencies for the following libraries:
libcap.so.2
Makefile:394: recipe for target '/home/hd/master/bin/packages/arm_cortex-a9/packages/samba4-libs_4.9.4-2_arm_cortex-a9.ipk' failed
make[3]: *** [/home/hd/master/bin/packages/arm_cortex-a9/packages/samba4-libs_4.9.4-2_arm_cortex-a9.ipk] Error 1
make[3]: Leaving directory '/home/hd/openwrt-feeds/packages-master/net/samba4'
time: package/feeds/packages/samba4/compile#0.11#0.13#0.61
package/Makefile:107: recipe for target 'package/feeds/packages/samba4/compile' failed
make[2]: *** [package/feeds/packages/samba4/compile] Error 2
make[2]: Leaving directory '/home/hd/master'
package/Makefile:103: recipe for target '/home/hd/master/staging_dir/target-arm_cortex-a9_musl_eabi/stamp/.package_compile' failed
make[1]: *** [/home/hd/master/staging_dir/target-arm_cortex-a9_musl_eabi/stamp/.package_compile] Error 2
make[1]: Leaving directory '/home/hd/master'
/home/hd/master/include/toplevel.mk:216: recipe for target 'world' failed
make: *** [world] Error 2
```

This can help selecting libcap and fixing the problem.

Signed-off-by: Hao Dong <halbertdong@gmail.com>

Maintainer: @Andy2244 
Compile tested: OpenWrt Snapshot
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
