### PR TITLE
python3-pip: fix install rule

### DIFF
--- a/lang/python/python3/files/python3-package-pip.mk
+++ b/lang/python/python3/files/python3-package-pip.mk
@@ -12,7 +12,7 @@ $(call Package/python3/Default)
   DEPENDS:=+python3 +python3-setuptools +python-pip-conf
 endef
 
-define Package/python3-pip/install
+define Py3Package/python3-pip/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages
 	$(CP) $(PKG_BUILD_DIR)/install-pip/bin/pip3* $(1)/usr/bin
 	$(CP) \


### PR DESCRIPTION
Maintainer: me
Compile tested: x86   https://github.com/openwrt/openwrt/commit/b7f2adbdd3ed76e9c844b99d0171c9bfe5809cba
Run tested: N/A

Fixes: https://github.com/openwrt/packages/issues/8301

This seems to have slipped for some time. No idea if it ever worked.
It could be that this worked at some point.

In any case, the shebang is properly updated now.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>