### PR TITLE
python,python3: add Jeffery To as co-maintainer

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -21,6 +21,8 @@ PKG_HASH:=22d9b1ac5b26135ad2b8c2901a9413537e08749a753356ee913c84dbd2df5574
 PKG_LICENSE:=PSF
 PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
 
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>
+
 # This file provides the necsessary host build variables
 include ../python-host.mk
 
@@ -51,7 +53,6 @@ define Package/python/Default
   CATEGORY:=Languages
   TITLE:=Python $(PYTHON_VERSION) programming language
   URL:=https://www.python.org/
-  MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 endef
 
 define Package/python/Default/description

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -24,6 +24,8 @@ PKG_HASH:=d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb
 PKG_LICENSE:=PSF
 PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
 
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>
+
 # This file provides the necsessary host build variables
 include ../python3-host.mk
 
@@ -54,7 +56,6 @@ define Package/python3/Default
   CATEGORY:=Languages
   TITLE:=Python $(PYTHON_VERSION) programming language
   URL:=https://www.python.org/
-  MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 endef
 
 define Package/python3/Default/description


### PR DESCRIPTION
Maintainer: me / @jefferyto ?
Compile tested: N/A
Run tested: N/A

---------------------------------------------------------------

For a while now, Jeffery has helped quite a lot with Python, and is now
unofficial go-to guy [for problems] with Python packages.

This change adds him as co-maintainer [if he also agrees].

I'm not going away; I'll be still doing the same work for Python.
This change serves to recognize Jeffery in an official way, since he's
already taking on these things. And 2 co-maintainers is better in case one
kicks the bucket [by accident].

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>