### PR TITLE
mwan3: fix disconnected event generation in mwan3track

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.7.10
+PKG_VERSION:=2.7.11
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -221,11 +221,7 @@ main() {
 
 			if [ $score -eq $up ]; then
 				echo "offline" > /var/run/mwan3track/$1/STATUS
-				echo "0" > /var/run/mwan3track/$1/UPTIME
-				echo "$(get_uptime)" > /var/run/mwan3track/$1/DOWNTIME
-				$LOG notice "Interface $1 ($2) is offline"
 				env -i ACTION=ifdown INTERFACE=$1 DEVICE=$2 /sbin/hotplug-call iface
-				env -i ACTION="disconnected" INTERFACE="$1" DEVICE="$2" /sbin/hotplug-call iface
 				score=0
 			fi
 		else


### PR DESCRIPTION
Maintainer: me
Compile tested: only script changes
Run tested: x86_64, APU3, OpenWrt master

Description:
Before this change two disconnected events were generated. This is wrong!
The disconnected event is impliciet generated by the hotplug script on ifdown
event. The mwan3track script is notified by a USR1 signal which
generates the disconnectd event. The additional "disconnectd" event on
ifdown is not required.
