### PR TITLE
collectd: enable cpufreq plugin also for ipq40xx and brcm2708

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -341,7 +341,7 @@ $(eval $(call BuildPlugin,chrony,chrony status input,chrony,))
 $(eval $(call BuildPlugin,conntrack,connection tracking table size input,conntrack,))
 $(eval $(call BuildPlugin,contextswitch,context switch input,contextswitch,))
 $(eval $(call BuildPlugin,cpu,CPU input,cpu,))
-$(eval $(call BuildPlugin,cpufreq,CPU Freq input,cpufreq,@(TARGET_x86||TARGET_x86_64||TARGET_mvebu||TARGET_ipq806x||TARGET_armvirt))) # Only enable on x86 mvebu ipq806x armvirt
+$(eval $(call BuildPlugin,cpufreq,CPU Freq input,cpufreq,@(TARGET_x86||TARGET_x86_64||TARGET_mvebu||TARGET_ipq806x||TARGET_armvirt||TARGET_ipq40xx||TARGET_brcm2708))) # Only enable on x86 mvebu ipq806x armvirt ipq40xx brcm2708
 $(eval $(call BuildPlugin,csv,CSV output,csv,))
 $(eval $(call BuildPlugin,curl,cURL input,curl,+PACKAGE_collectd-mod-curl:libcurl))
 #$(eval $(call BuildPlugin,dbi,relational database input,dbi,+PACKAGE_collectd-mod-dbi:libdbi))


### PR DESCRIPTION


Maintainer: @hnyman @jow-
Compile tested: OpenWrt master
Run tested: ipq40xx,brcm2708, OpenWrt master
Run-tested with Netgear ex6100 v2 and Raspberry Pi 3 Plus

Description:
Enable cpufreq plugin on ipq40xx and brcm2708

Signed-off-by: Jeff Collins jeffcollins9292@gmail.com
