### PR TITLE
samba4: tmsize patch, build with netbios by default

### DIFF
--- a/net/samba4/Config.in
+++ b/net/samba4/Config.in
@@ -76,7 +76,7 @@ config SAMBA4_SERVER_NETBIOS
 		WSD (Web Services for Devices) replaces the functionality of NetBIOS and is provided by the wsdd2 package (selected by default).
 		Note: As of Windows 10 Fall Creators Update (1709) NetBIOS isn't supported unless the old SMB1 feature is reinstalled (not recommended).
 		Network shares can be directly accessed via network paths '\\hostname\sharename' and mounted via 'map network drive' without NetBIOS or WSD.
-	default n
+	default y
 
 config SAMBA4_SERVER_WINBIND
 	bool "Winbind support"

--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
 PKG_VERSION:=4.9.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/samba4/patches/104-tmsize-overflow-check.patch
+++ b/net/samba4/patches/104-tmsize-overflow-check.patch
@@ -1,0 +1,32 @@
+diff --git a/source3/modules/vfs_fruit.c b/source3/modules/vfs_fruit.c
+index 14d7a797451..1982f128cb3 100644
+--- a/source3/modules/vfs_fruit.c
++++ b/source3/modules/vfs_fruit.c
+@@ -119,6 +119,18 @@ static struct global_fruit_config {
+ #define AFPRESOURCE_EA_NETATALK "user." NETATALK_RSRC_XATTR
+ #endif
+ 
++#ifndef OFF_T_MAX
++#if SIZEOF_OFF_T == SIZEOF_INT8_T
++#define OFF_T_MAX INT8_MAX
++#elif SIZEOF_OFF_T == SIZEOF_INT16_T
++#define OFF_T_MAX INT16_MAX
++#elif SIZEOF_OFF_T == SIZEOF_INT32_T
++#define OFF_T_MAX INT32_MAX
++#elif SIZEOF_OFF_T == SIZEOF_INT64_T
++#define OFF_T_MAX INT64_MAX
++#endif
++#endif
++
+ enum apple_fork {APPLE_FORK_DATA, APPLE_FORK_RSRC};
+ 
+ enum fruit_rsrc {FRUIT_RSRC_STREAM, FRUIT_RSRC_ADFILE, FRUIT_RSRC_XATTR};
+@@ -6867,7 +6879,7 @@ static bool fruit_tmsize_do_dirent(vfs_handle_struct *handle,
+ 		return true;
+ 	}
+ 
+-	if (bandsize > SIZE_MAX/nbands) {
++	if (bandsize > OFF_T_MAX/nbands) {
+ 		DBG_ERR("tmsize overflow: bandsize [%zu] nbands [%zu]\n",
+ 			bandsize, nbands);
+ 		return false;


### PR DESCRIPTION
Maintainer: me
Compile tested: arm/mvebu (snapshots)
Run tested: arm/mvebu (snapshots)

Description:
* add patch for tmsize overflow (https://bugzilla.samba.org/show_bug.cgi?id=13622)
* re-enable netbios by default
(Some users still need netbios and its just a minor size increase 50kb)