### PR TITLE
xtables-addons: pass correct flags to compile and install

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
 PKG_VERSION:=2.14
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_HASH:=d215a9a8b8e66aae04b982fa2e1228e8a71e7dfe42320df99e34e5000cbdf152
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -39,23 +39,13 @@ endef
 
 CONFIGURE_ARGS+= \
 	--with-kbuild="$(LINUX_DIR)" \
-	--with-xtlibdir="/usr/lib/iptables" \
+	--with-xtlibdir="/usr/lib/iptables"
 
-define Build/Compile
-	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
-		$(KERNEL_MAKE_FLAGS) \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		DEPMOD="/bin/true" \
-		all
-endef
+MAKE_FLAGS += \
+	DEPMOD="/bin/true"
 
-define Build/Install
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		$(KERNEL_MAKE_FLAGS) \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		DEPMOD="/bin/true" \
-		install
-endef
+MAKE_INSTALL_FLAGS += \
+	DEPMOD="/bin/true"
 
 # 1: extension/module suffix used in package name
 # 2: extension/module display name used in package title/description


### PR DESCRIPTION
The Makefile currently redefine the Compile and Install functions.
This is not working when using an external toolchain because some
flags are not interpreted, like CROSS_COMPILE. It is possible to
override the MAKE_FLAGS and MAKE_INSTALL_FLAGS instead.

Maintainer: Jo-Philipp Wich / @jow-
Compile tested: x86, custom, 12.04
Run tested: x86, custom, 12.04

Description:
My environment is a bit weird, but:
1. I dockerize my build into an old Ubuntu where /bin/gcc = 4.8.5
2. I build the kernel 4.19 for the board
3. I use a custom toolchain with a patched gcc 6.3.0

During my build `xtables-addons` failed with "-fstack-protector-strong" flag unrecognized. In fact, the `CROSS_COMPILE` flag is currently not given to the kernel, so instead of taking my external toolchain (`${CROSS_COMPILE}gcc`), the basic `gcc` is taken. This patch solve the build by using default compile/install functions. 