### PR TITLE
deluge: add package (and add also rblibtorrent and pyxdg)

### DIFF
--- a/lang/python/python-pyxdg/Makefile
+++ b/lang/python/python-pyxdg/Makefile
@@ -1,0 +1,38 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pyxdg
+PKG_VERSION:=0.26
+PKG_RELEASE:=1
+
+PKG_SOURCE:=pyxdg-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyxdg
+PKG_HASH:=fe2928d3f532ed32b39c32a482b54136fe766d19936afc96c8f00645f9da1a06
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pyxdg-$(PKG_VERSION)
+
+PKG_MAINTAINER:= Sergey Pushilin <pushilin@gmail.com>
+PKG_LICENSE:=LGPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+PYTHON_PKG_SETUP_ARGS:=
+
+define Package/python-pyxdg
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=pyxdg
+  URL:=https://freedesktop.org/wiki/Software/pyxdg
+  DEPENDS:=+python
+  VARIANT:=python
+endef
+
+define Package/python-pyxdg/description
+  A Python module to deal with freedesktop.org specifications
+endef
+
+$(eval $(call PyPackage,python-pyxdg))
+$(eval $(call BuildPackage,python-pyxdg))

--- a/libs/rblibtorrent/Makefile
+++ b/libs/rblibtorrent/Makefile
@@ -1,0 +1,68 @@
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rblibtorrent
+PKG_VERSION:=1.1.12
+PKG_RELEASE:=1
+PKG_MAINTAINER:= Sergey Pushilin <pushilin@gmail.com>
+
+PKG_SOURCE:=libtorrent-rasterbar-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/arvidn/libtorrent/releases/download/libtorrent_1_1_12/
+PKG_HASH:=a5937134edf3ca8c109403a47f5a5fc93f7b8dca4e97f1a629a8c84288bee7a7
+PKG_BUILD_DIR:=$(BUILD_DIR)/libtorrent-rasterbar-$(PKG_VERSION)
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/rblibtorrent
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Rasterbar BitTorrent library
+  URL:=http://www.rasterbar.com/products/libtorrent/
+  DEPENDS:=+boost +boost-python +boost-filesystem +boost-regex +boost-thread +boost-program_options +boost-system +boost-random +zlib +libopenssl
+endef
+
+define Package/rblibtorrent/description
+Rasterbar libtorrent is a C++ library that aims to be a good alternative to
+all the other bittorrent implementations around. It is a library and not a
+full featured client, although it comes with a working example client.
+endef
+
+TARGET_CFLAGS +=-I$(STAGING_DIR)/usr/include/python2.7/
+
+CONFIGURE_ARGS+= \
+	--enable-shared \
+	--disable-debug \
+	--enable-python-binding \
+	--with-ssl=$(STAGING_DIR)/usr \
+	--with-boost=$(STAGING_DIR)/usr/include \
+	--with-boost-libdir=$(STAGING_DIR)/usr/lib \
+	--with-zlib=detect \
+	--with-boost-system \
+	--with-boost-filesystem \
+	--with-boost-thread \
+	--with-boost-regex \
+	--with-boost-python \
+	--with-boost-program_options
+
+CONFIGURE_VARS+=CC="$(TARGET_CXX)"
+
+EXTRA_LDFLAGS+=-lz -lpthread
+
+define Build/InstallDev
+	mkdir -p $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libtorrent $(1)/usr/include/
+	mkdir -p $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+	mkdir -p $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libtorrent-rasterbar.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/rblibtorrent/install
+	$(INSTALL_DIR) $(1)/usr/lib $(1)/usr/lib/python2.7/site-packages/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/python2.7/site-packages/*.so* $(1)/usr/lib/python2.7/site-packages/
+endef
+
+$(eval $(call BuildPackage,rblibtorrent))

--- a/net/deluge/Makefile
+++ b/net/deluge/Makefile
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2008-2011 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=deluge
+PKG_VERSION:=1.3.15
+PKG_RELEASE:=1
+PKG_MAINTAINER:= Sergey Pushilin <pushilin@gmail.com>
+PKG_LICENSE:=GPL-3.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=http://download.deluge-torrent.org/source
+PKG_HASH:=a96405140e3cbc569e6e056165e289a5e9ec66e036c327f3912c73d049ccf92c
+
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/python/python-package.mk
+
+define Package/deluge
+	SUBMENU:=BitTorrent
+	SECTION:=net
+	CATEGORY:=Network
+	TITLE:=A lightweight BitTorrent client
+	URL:=https://deluge-torrent.org
+	DEPENDS:=+python +rblibtorrent +python-chardet +python-pyxdg +python-twisted +python-pyopenssl +python-setuptools +python-service-identity
+	VARIANT:=python
+endef
+
+define Package/deluge/description
+BitTorrent client with a client/server model.
+endef
+
+define Package/deluge/conffiles
+/etc/config/deluge
+endef
+
+define PyPackage/deluge/filespec
+  +|$(PYTHON_PKG_DIR)
+  -|$(PYTHON_PKG_DIR)/deluge/ui/gtkui
+  -|$(PYTHON_PKG_DIR)/deluge/ui/web
+endef
+
+define PyPackage/deluge/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) \
+	    $(PKG_INSTALL_DIR)/usr/bin/* \
+	    $(1)/usr/bin/
+	rm -rf $(1)/usr/bin/deluge-gtk
+	rm -rf $(1)/usr/bin/deluge-web
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/deluge.config $(1)/etc/config/deluge
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/deluge.init $(1)/etc/init.d/deluge
+endef
+
+$(eval $(call PyPackage,deluge))
+$(eval $(call BuildPackage,deluge))

--- a/net/deluge/files/deluge.config
+++ b/net/deluge/files/deluge.config
@@ -1,0 +1,5 @@
+config global deluged
+	option 'user' 'deluge:deluge'
+	option 'home' ''
+	option 'options' '-p 58846'
+	option 'enabled' 1

--- a/net/deluge/files/deluge.init
+++ b/net/deluge/files/deluge.init
@@ -1,0 +1,60 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2010 OpenWrt.org
+# Copyright (C) 2010 Alexander Sulfrian
+
+NAME=deluge
+PIDFILE=/var/run/deluged.pid
+START=50
+STOP=50
+
+load_config()
+{
+	config_get_bool enabled $1 enabled 0
+	[ "${enabled}" -eq 0 ] && return 1
+
+	config_get user $1 user
+	if [ "${user}" == "" ]; then
+		echo "Please check your uci config. User for '$1' should not be empty."
+		return 1
+	fi
+
+	username=$(echo ${user} | cut -d ':' -f 1)
+	group=$(echo ${user} | cut -d ':' -f 2)
+
+	if ! $(cut -d ':' -f 1 /etc/passwd | grep -sq "${username}"); then
+		echo "Please check your uci config. User for '$1' should exist."
+		return 1
+	fi
+
+	if [ "${group}" != "" ]; then
+		if ! $(cut -d ':' -f 1 /etc/passwd | grep -sq "${group}"); then
+			echo "Please check your uci config. Group for '$1' should exist."
+	                return 1
+		fi
+	fi
+}
+
+start()
+{
+	config_load "${NAME}"
+	load_config deluged || return $?
+
+	config_get options deluged options
+
+	config_get home deluged home
+	if [ "${home}" == "" ]; then
+		home=$(grep "^${username}:" /etc/passwd | cut -d ':' -f 6)
+	fi
+
+	HOME="${home}" /sbin/start-stop-daemon -S -u "${username}" \
+		-p "${PIDFILE}" -b -m -x "/usr/bin/python2.7" \
+		-c "${user}" -- /usr/bin/deluged --do-not-daemonize ${options}
+}
+
+stop()
+{
+	config_load "${NAME}"
+	load_config deluged || return $?
+
+	/sbin/start-stop-daemon -K -u "${username}" -p "${PIDFILE}"
+}


### PR DESCRIPTION
Signed-off-by: Sergey Pushilin <pushilin@gmail.com>

Maintainer: me 
Compile tested: openwrt-sdk-18.06.2-ramips-mt7621_gcc-7.3.0_musl.Linux-x86_64, OpenWrt master
Run tested: mipsel_24kc_musl, Xiaomi Mi Router 3G, openwrt-18.06.2

Description:
add package deluge and dependencies: pyxdg, rblibtorrent
