### PR TITLE
python-dns: Add Python3 variant, update to 1.16.0

### DIFF
--- a/lang/python/python-dns/Makefile
+++ b/lang/python/python-dns/Makefile
@@ -8,37 +8,58 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dns
-PKG_RELEASE:=2
-PKG_VERSION:=1.15.0
-PKG_SOURCE_URL:=http://www.dnspython.org/kits/$(PKG_VERSION)
-PKG_HASH:=11598ae5735746e63921f8eebdfdee4a2e7d0ba842ebd57ba02682d4aed8244b
+PKG_VERSION:=1.16.0
+PKG_RELEASE:=1
+
 PKG_SOURCE:=dnspython-$(PKG_VERSION).tar.gz
-PKG_MAINTAINER:=Denis Shulyaka <Shulyaka@gmail.com>
+PKG_SOURCE_URL:=http://www.dnspython.org/kits/1.16.0/
+PKG_HASH:=4bf5c5c12a4478ee7860ab176659cf64c4899ee76752d826b082f8af723c5cf9
+
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=LICENSE
-PKG_BUILD_DIR:=$(BUILD_DIR)/dnspython-$(PKG_VERSION)
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-dnspython-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-dns/Default
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=dnspython
+  URL:=http://www.dnspython.org/
+endef
 
 define Package/python-dns
-	SECTION:=language-python
-	CATEGORY:=Languages
-	SUBMENU:=Python
-	TITLE:=dnspython
-	URL:=http://www.dnspython.org/
-	DEPENDS:=+python
+$(call Package/python-dns/Default)
+  DEPENDS:=+PACKAGE_python-dns:python
+  VARIANT:=python
 endef
 
 define Package/python-dns/description
  dnspython is a DNS toolkit for Python. It supports almost all record types. It can be used for queries, zone transfers, and dynamic updates. It supports TSIG authenticated messages and EDNS0.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,\
-		install --prefix=/usr --root="$(PKG_INSTALL_DIR)" \
-	)
+define Package/python3-dns
+$(call Package/python-dns/Default)
+  DEPENDS:=+PACKAGE_python3-dns:python3
+  VARIANT:=python3
+endef
+
+define Package/python3-dns/description
+$(call Package/python-dns/description)
+.
+(Variant for Python3)
 endef
 
 $(eval $(call PyPackage,python-dns))
 $(eval $(call BuildPackage,python-dns))
+$(eval $(call BuildPackage,python-dns-src))
+$(eval $(call Py3Package,python3-dns))
+$(eval $(call BuildPackage,python3-dns))
+$(eval $(call BuildPackage,python3-dns-src))


### PR DESCRIPTION
Maintainer: @Shulyaka (Are you still interested to maintain it?)
Compile tested: mvebu (cortex-a9_vfpv3) , Turris Omnia, OpenWrt master
Run tested: mvebu (cortex-a9_vfpv3) , Turris Omnia, OpenWrt SNAPSHOT, r9420-c17a68c

Description:

- update to version 1.16.0
> Python 2.x support ends with the release of 1.16.0, unless there are critical bugs in 1.16.0. Future versions of dnspython will only support Python 3.
- add Python3 variant together with source packages
- resorted things in Makefile
