### PR TITLE
acme: Patch 1

### DIFF
--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -219,8 +219,6 @@ issue_cert()
         uci set uhttpd.main.cert="$STATE_DIR/${main_domain}/fullchain.cer"
         # commit and reload is in post_checks
     fi
-
-    post_checks
 }
 
 load_vars()
@@ -248,6 +246,7 @@ fi
 
 trap err_out HUP TERM
 trap int_out INT
+trap post_checks EXIT
 
 config_foreach issue_cert cert
 

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -44,7 +44,7 @@ debug()
 
 get_listeners()
 {
-    netstat -nptl 2>/dev/null | awk 'match($4, /:80$/){split($7, parts, "/"); print parts[2];}' | uniq | tr "\n" " "
+    netstat -nptl 2>/dev/null | awk 'match($4, /:80$/){split($7, parts, "/"); print parts[2];}' | uniq | tr -d '\n'
 }
 
 pre_checks()


### PR DESCRIPTION
Maintainer: Toke Høiland-Jørgensen <toke@toke.dk>
Compile tested: n/a
Run tested: ARMv7, WRT3200ACM, OpenWrt 18.06.2

Ran ACME run script when no certificate existed (successfully), and then ran again when renewal was unnecessary (early return).

Description:

See commits.