### PR TITLE
Jinja2: add missing dependency on markupsafe

### DIFF
--- a/lang/python/Jinja2/Makefile
+++ b/lang/python/Jinja2/Makefile
@@ -28,7 +28,7 @@ define Package/python3-jinja2
   SUBMENU:=Python
   URL:=http://jinja.pocoo.org/
   TITLE:=python3-jinja2
-  DEPENDS:=+python3-light
+  DEPENDS:=+python3-light +python3-markupsafe
   VARIANT:=python3
 endef
 


### PR DESCRIPTION
Signed-off-by: Karel Kočí <karel.koci@nic.cz>

Maintainer: @dangowrt @danwrt 
Compile tested: Turris
Run tested: Turris

Description:
https://github.com/pallets/jinja/blob/78d2f672149e5b9b7d539c575d2c1bfc12db67a9/setup.py#L73

18.06 PR: https://github.com/openwrt/packages/pull/8346