### PR TITLE
Update README.md to add info about wpad

### DIFF
--- a/net/travelmate/files/README.md
+++ b/net/travelmate/files/README.md
@@ -24,6 +24,7 @@ To avoid these kind of deadlocks, travelmate set all station interfaces in an "a
 * [OpenWrt](https://openwrt.org), tested with the stable release series (18.06.x) and with the latest OpenWrt snapshot
 * iwinfo for wlan scanning, uclient-fetch for captive portal detection
 * optional: qrencode 4.x for QR code support
+* optional: wpad (the full version, not wpad-mini) to use Enterprise WiFi
 
 ## Installation & Usage
 * download the package [here](https://downloads.openwrt.org/snapshots/packages/x86_64/packages)


### PR DESCRIPTION
Add info about wpad (full) for Enterprise WiFi

Maintainer: @dibdot
Compile tested: NOT APPLICABLE (README.md)
Run tested: NOT APPLICABLE (README.md)

Description:
Update README.md to add info about wpad.
I tested this on 18.06.2 and I could only use Enterprise WiFi with travelmate once I installed the full version of wpad (and removed wpad-mini).