### PR TITLE
samba4: update to 4.9.5, switch to embedded heimdal build

### DIFF
--- a/net/samba4/Config.in
+++ b/net/samba4/Config.in
@@ -1,7 +1,6 @@
 config SAMBA4_SERVER_ACL
 	bool "ACL support (xattr)"
 	depends on PACKAGE_samba4-server
-	select PACKAGE_acl
 	help
 		installs: sharesec
 			modules: vfs_acl_xattr vfs_acl_tdb vfs_posixacl
@@ -12,13 +11,9 @@ config SAMBA4_SERVER_ACL
 config SAMBA4_SERVER_AD_DC
 	bool "Active Directory Domain Controller support (requires krb5-server) (EXPERIMENTAL)"
 	depends on PACKAGE_samba4-server
-	select PACKAGE_python-base
 	select PACKAGE_python-crypto
-	select PACKAGE_libopenssl
-	select PACKAGE_libgnutls
-	select PACKAGE_libopenldap
 	help
-		installs: samba (meta-daemon) python-crypt ntlm_auth
+		installs: samba (meta-daemon) python-crypto ntlm_auth
 			scripts: samba-tool
 
 		Run as a Active Directory Domain Controller
@@ -31,7 +26,6 @@ config SAMBA4_SERVER_AVAHI
 	bool "Avahi support"
 	depends on PACKAGE_samba4-server
 	select SAMBA4_SERVER_VFS
-	select PACKAGE_libavahi-client
 	help
 		Announce Samba resources via DNS/DNS-SD using the Avahi daemon, for Linux/Mac clients.
 	default y
@@ -81,7 +75,6 @@ config SAMBA4_SERVER_NETBIOS
 config SAMBA4_SERVER_WINBIND
 	bool "Winbind support"
 	depends on PACKAGE_samba4-server
-	depends on SAMBA4_SERVER_AD_DC
 	help
 		installs: winbindd (daemon) wbinfo
 

--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,19 +2,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.9.4
-PKG_RELEASE:=3
+PKG_VERSION:=4.9.5
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=COPYING
 
-PKG_SOURCE_URL:=https://download.samba.org/pub/samba/stable/
+PKG_SOURCE_URL:=https://download.samba.org/pub/samba/stable/ \
+				https://ftp5.gwdg.de/pub/samba/stable/ \
+				https://ftp.yz.yamagata-u.ac.jp/pub/network/samba/ \
+				http://ftp.uni-bayreuth.de/netsoftware/samba/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=6d98a8d8bcccbe788e4bbb406362e6676311aca711a3f3cc9b3a404bb9ff0b4f
+PKG_HASH:=078956d2d98e22011265afd4b7221efe4861067dcba4a031583b01f34d423700
 
-# Buildroot bug? Can't add target deps via '+SAMBA4_SERVER_AD_DC:python-crypto' (as work-around we select via config.in)
-PKG_BUILD_DEPENDS:=SAMBA4_SERVER_AD_DC:python-crypto nfs-kernel-server/host
+# samba4=(asn1_compile) e2fsprogs=(compile_et) nfs-kernel-server=(rpcgen)
+PKG_BUILD_DEPENDS:=samba4/host e2fsprogs/host nfs-kernel-server/host 
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_SAMBA4_SERVER_NETBIOS \
@@ -29,6 +32,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_kmod-fs-xfs
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/kernel.mk
 include $(INCLUDE_DIR)/version.mk
 
@@ -50,7 +54,7 @@ endef
 define Package/samba4-libs
   $(call Package/samba4/Default)
   TITLE+= libs
-  DEPENDS:= +zlib +libtirpc +krb5-libs +libpopt \
+  DEPENDS:= +zlib +libtirpc +libpopt +libcomerr \
 	+PACKAGE_libcap:libcap +PACKAGE_libpthread:libpthread +PACKAGE_libnettle:libnettle \
 	+PACKAGE_libgcrypt:libgcrypt +PACKAGE_libpam:libpam +PACKAGE_dbus:dbus +PACKAGE_libavahi-client:libavahi-client \
 	+SAMBA4_SERVER_VFS:attr \
@@ -63,15 +67,17 @@ define Package/samba4-server
   $(call Package/samba4/Default)
   TITLE+= server
   DEPENDS:= +samba4-libs
+  EXTRA_DEPENDS:=$(if $(CONFIG_SAMBA4_SERVER_AD_DC),python-crypto,)
 endef
 
 define Package/samba4-server/description
-  installs: smbd (daemon) smbpasswd pdbedit testparm
+  installs: smbd, nmbd (daemon) smbpasswd pdbedit testparm
 
-    This provides the basic fileserver service and is the minimum needed to serve file shares.
-    HINT: https://fitzcarraldoblog.wordpress.com/2016/10/17/a-correct-method-of-configuring-samba-for-browsing-smb-shares-in-a-home-network/
+  This provides the basic fileserver service and is the minimum needed to serve file shares.
+  HINT: https://fitzcarraldoblog.wordpress.com/2016/10/17/a-correct-method-of-configuring-samba-for-browsing-smb-shares-in-a-home-network/
 endef
 
+# BUG: We cant add DEPENDS:= +SAMBA4_SERVER_AD_DC:python-crypto, so this only happens here via select!
 define Package/samba4-server/config
   select PACKAGE_wsdd2
   source "$(SOURCE)/Config.in"
@@ -120,15 +126,32 @@ CONFIGURE_VARS += \
 	CPP="$(TARGET_CROSS)cpp"
 
 CONFIGURE_CMD = ./buildtools/bin/waf
+HOST_CONFIGURE_CMD = ./buildtools/bin/waf
 
 # Strip options that WAF configure script does not recognize
 CONFIGURE_ARGS:=$(filter-out	\
-	--host=%		\
-	--build=%		\
-	--program-suffix=%	\
+	--target=%			\
+	--host=%			\
+	--build=%			\
+	--program-prefix=%	\
+	--program-suffix=% 	\
 	--disable-nls		\
 	--disable-ipv6		\
 	, $(CONFIGURE_ARGS))
+
+HOST_CONFIGURE_ARGS:=$(filter-out	\
+	--target=%			\
+	--host=%			\
+	--build=%			\
+	--program-prefix=%	\
+	--program-suffix=% 	\
+	--disable-nls		\
+	--disable-ipv6		\
+	, $(HOST_CONFIGURE_ARGS))
+
+# Waf needs the "configure" argument
+CONFIGURE_ARGS:=configure $(CONFIGURE_ARGS)
+HOST_CONFIGURE_ARGS:=configure $(HOST_CONFIGURE_ARGS)
 
 CONFIGURE_ARGS += \
 		--hostcc="$(HOSTCC)" \
@@ -156,6 +179,35 @@ CONFIGURE_ARGS += \
 		--without-regedit \
 		--without-gpgme
 
+HOST_CONFIGURE_ARGS += \
+		--hostcc="$(HOSTCC)" \
+		--disable-cups \
+		--disable-iprint \
+		--disable-cephfs \
+		--disable-fault-handling \
+		--disable-glusterfs \
+		--disable-rpath \
+		--disable-rpath-install \
+		--disable-rpath-private-install \
+		--enable-fhs \
+		--without-automount \
+		--without-iconv \
+		--without-lttng \
+		--without-ntvfs-fileserver \
+		--without-pam \
+		--without-systemd \
+		--without-utmp \
+		--without-dmapi \
+		--without-fam \
+		--without-gettext \
+		--without-regedit \
+		--without-gpgme
+
+HOST_CONFIGURE_ARGS += --disable-avahi --without-quotas --without-acl-support --without-winbind \
+	--without-ad-dc --without-json-audit --without-libarchive --disable-python --nopyc --nopyo \
+	--disable-gnutls --without-dnsupdate --without-ads --without-ldap
+HOST_CONFIGURE_VARS += python_LDFLAGS="" python_LIBDIR=""
+
 # Optional AES-NI support - https://lists.samba.org/archive/samba-technical/2017-September/122738.html
 # Support for Nettle wasn't comitted
 ifdef CONFIG_TARGET_x86_64
@@ -169,13 +221,6 @@ CONFIGURE_ARGS += \
 		--with-logfilebase=/var/log \
 		--with-piddir=/var/run \
 		--with-privatedir=/etc/samba
-
-CONFIGURE_ARGS += \
-		--with-system-mitkrb5 "$(STAGING_DIR)/usr" \
-		--with-system-mitkdc=/usr/sbin/krb5kdc
-
-		## embedded-heimdal
-		# --bundled-libraries=talloc,tevent,tdb,ldb,com_err,cmocka,roken,wind,hx509,asn1,heimbase,hcrypto,krb5,gssapi,heimntlm,hdb,kdc,NONE
 
 ifeq ($(CONFIG_SAMBA4_SERVER_AVAHI),y)
 	CONFIGURE_ARGS += --enable-avahi
@@ -193,10 +238,11 @@ else
 	CONFIGURE_ARGS += --without-acl-support
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
-	CONFIGURE_ARGS += --enable-gnutls --with-dnsupdate --with-ads --with-ldap --with-experimental-mit-ad-dc
+	CONFIGURE_ARGS += --enable-gnutls --with-dnsupdate --with-ads --with-ldap
 	TARGET_CFLAGS := -I$(STAGING_DIR)/usr/include/python2.7 $(TARGET_CFLAGS)
 else
-	CONFIGURE_ARGS += --without-ad-dc --without-json-audit --without-libarchive --disable-python --nopyc --nopyo --disable-gnutls --without-dnsupdate --without-ads --without-ldap
+	CONFIGURE_ARGS += --without-ad-dc --without-json-audit --without-libarchive --disable-python --nopyc --nopyo \
+		--disable-gnutls --without-dnsupdate --without-ads --without-ldap
 	CONFIGURE_VARS += \
 		python_LDFLAGS="" \
 		python_LIBDIR=""
@@ -212,45 +258,54 @@ SAMBA4_IDMAP_MODULES_SHARED :=
 SAMBA4_PDB_MODULES :=pdb_smbpasswd,pdb_tdbsam,
 SAMBA4_AUTH_MODULES :=auth_builtin,auth_sam,auth_unix,auth_script,
 SAMBA4_VFS_MODULES :=vfs_default,
+SAMBA4_VFS_MODULES_SHARED :=
 ifeq ($(CONFIG_SAMBA4_SERVER_VFS),y)
-	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_fruit,vfs_shadow_copy2,vfs_recycle,vfs_fake_perms,vfs_readonly,vfs_cap,vfs_offline,vfs_crossrename,vfs_catia,vfs_streams_xattr,vfs_xattr_tdb,
+	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_fruit,vfs_shadow_copy2,vfs_recycle,vfs_fake_perms,vfs_readonly,vfs_cap,vfs_offline,vfs_crossrename,vfs_catia,vfs_streams_xattr,vfs_xattr_tdb,
 ifeq ($(CONFIG_PACKAGE_kmod-fs-btrfs),y)
-	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_btrfs,
+	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_btrfs,
 endif
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_VFSX),y)
-	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_virusfilter,vfs_shell_snap,vfs_commit,vfs_worm,vfs_aio_fork,vfs_aio_pthread,vfs_netatalk,vfs_dirsort,vfs_fileid,
+	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_virusfilter,vfs_shell_snap,vfs_commit,vfs_worm,vfs_aio_fork,vfs_aio_pthread,vfs_netatalk,vfs_dirsort,vfs_fileid,
 ifeq ($(CONFIG_PACKAGE_kmod-fs-xfs),y)
-	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_linux_xfs_sgid,
+	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_linux_xfs_sgid,
 endif
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_QUOTAS),y)
-	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_default_quota,
+	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_default_quota,
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_ACL),y)
-	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_posixacl,vfs_acl_xattr,vfs_acl_tdb,
+	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_posixacl,
+	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_acl_xattr,vfs_acl_tdb,
 	# vfs_zfsacl needs https://github.com/zfsonlinux/zfs/tree/master/include/sys/zfs_acl.h
 	# vfs_nfs4acl_xattr needs https://github.com/notriddle/libdrpc/blob/master/rpc/xdr.h
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
-	SAMBA4_PDB_MODULES :=$(SAMBA4_PDB_MODULES)pdb_samba_dsdb,
+	SAMBA4_PDB_MODULES :=$(SAMBA4_PDB_MODULES)pdb_samba_dsdb,pdb_ldapsam,
 	SAMBA4_AUTH_MODULES :=$(SAMBA4_AUTH_MODULES)auth_samba4,
-	SAMBA4_VFS_MODULES :=$(SAMBA4_VFS_MODULES)vfs_audit,vfs_extd_audit,vfs_full_audit,
+	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_audit,vfs_extd_audit,vfs_full_audit,
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_WINBIND),y)
-	SAMBA4_IDMAP_MODULES :=$(SAMBA4_IDMAP_MODULES)idmap_passdb,idmap_nss,idmap_tdb,idmap_tdb2,idmap_script,nss_info_template,
-	SAMBA4_IDMAP_MODULES_SHARED :=$(SAMBA4_IDMAP_MODULES_SHARED)idmap_autorid,idmap_rid,idmap_ad,idmap_rfc2307,
+	SAMBA4_IDMAP_MODULES :=$(SAMBA4_IDMAP_MODULES)idmap_tdb,idmap_passdb,idmap_nss,nss_info_template,
+	SAMBA4_IDMAP_MODULES_SHARED :=$(SAMBA4_IDMAP_MODULES_SHARED)idmap_autorid,idmap_rid,idmap_hash,idmap_tdb2,idmap_script,
+ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
+	SAMBA4_IDMAP_MODULES_SHARED :=$(SAMBA4_IDMAP_MODULES_SHARED)idmap_ad,idmap_ldap,idmap_rfc2307,
 	# idmap_ad needs --with-ads
 	# idmap_rfc2307 needs ldap headers
+endif
 	SAMBA4_AUTH_MODULES :=$(SAMBA4_AUTH_MODULES)auth_winbind,
 endif
 
-SAMBA4_MODULES :=${SAMBA4_AUTH_MODULES}${SAMBA4_PDB_MODULES}${SAMBA4_IDMAP_MODULES}${SAMBA4_VFS_MODULES}
-SAMBA4_MODULES_SHARDED :=${SAMBA4_IDMAP_MODULES_SHARED}
+SAMBA4_MODULES :=${SAMBA4_VFS_MODULES}${SAMBA4_AUTH_MODULES}${SAMBA4_PDB_MODULES}${SAMBA4_IDMAP_MODULES}
+SAMBA4_MODULES_SHARDED :=${SAMBA4_VFS_MODULES_SHARED}${SAMBA4_IDMAP_MODULES_SHARED}
 
 CONFIGURE_ARGS += \
 		--with-static-modules=$(SAMBA4_MODULES)!DEFAULT,!FORCED \
 		--with-shared-modules=$(SAMBA4_MODULES_SHARDED)!DEFAULT,!FORCED
+
+HOST_CONFIGURE_ARGS += \
+		--with-static-modules=!DEFAULT,!FORCED \
+		--with-shared-modules=!DEFAULT,!FORCED
 
 # Setup build/install targets
 # CONFIG_PACKAGE_samba4-server
@@ -263,7 +318,7 @@ ifeq ($(CONFIG_SAMBA4_SERVER_NETBIOS),y)
 	BUILD_TARGETS_SERVER :=$(BUILD_TARGETS_SERVER),nmbd
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
-	BUILD_TARGETS_SERVER :=$(BUILD_TARGETS_SERVER),samba,nsstest,ntlm_auth
+	BUILD_TARGETS_SERVER :=$(BUILD_TARGETS_SERVER),samba,nsstest,ntlm_auth,samba4kinit,samba4kgetcred,samba4kpasswd,samba4ktutil
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_WINBIND),y)
 	BUILD_TARGETS_SERVER :=$(BUILD_TARGETS_SERVER),winbindd,wbinfo,winbind_krb5_locator
@@ -271,20 +326,35 @@ endif
 # CONFIG_PACKAGE_samba4-client
 BUILD_TARGETS_CLIENT :=client/smbclient,client/cifsdd
 # CONFIG_PACKAGE_samba4-admin
-BUILD_TARGETS_ADMIN :=net,smbcontrol,profiles,rpcclient,smbcacls,smbcquotas
+BUILD_TARGETS_ADMIN :=net,smbcontrol,profiles,rpcclient,smbcacls,smbcquotas,eventlogadm
 # CONFIG_PACKAGE_samba4-utils
 BUILD_TARGETS_UTILS :=smbstatus,smbtree,smbget,mvxattr,nmblookup
 
 # lib bundling
 # NOTE: bundle + make private, we want to avoid version configuration (build, link) conflicts
-CONFIGURE_ARGS += --builtin-libraries=talloc,tevent,texpect,tdb,ldb,tdr,cmocka,replace
-#CONFIGURE_ARGS += --nonshared-binary=$(BUILD_TARGETS_SERVER)
+CONFIGURE_ARGS += --builtin-libraries=talloc,tevent,tevent-util,texpect,tdb,ldb,tdr,cmocka
+HOST_CONFIGURE_ARGS += --builtin-libraries=replace --nonshared-binary=asn1_compile
+
 ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
-CONFIGURE_ARGS += --bundled-libraries=talloc,tevent,texpect,tdb,ldb,tdr,cmocka,replace,pytalloc-util,pyldb-util,NONE
+CONFIGURE_ARGS += --bundled-libraries=talloc,tevent,tevent-util,texpect,tdb,ldb,tdr,cmocka,replace,pytalloc-util,pyldb-util,roken,wind,hx509,asn1,heimbase,hcrypto,krb5,gssapi,heimntlm,hdb,kdc,NONE
 else
-CONFIGURE_ARGS += --bundled-libraries=talloc,tevent,texpect,tdb,ldb,tdr,cmocka,replace,NONE
+CONFIGURE_ARGS += --bundled-libraries=talloc,tevent,tevent-util,texpect,tdb,ldb,tdr,cmocka,replace,roken,wind,hx509,asn1,heimbase,hcrypto,krb5,gssapi,heimntlm,hdb,kdc,NONE
 endif
-CONFIGURE_ARGS += --private-libraries=talloc,tevent,texpect,tdb,ldb,tdr,cmocka,replace
+# BUG: --private-libraries, Does not work for System possible libs, will not get "samba4" suffix!
+CONFIGURE_ARGS += --private-libraries=talloc,tevent,tevent-util,texpect,tdb,ldb,tdr,cmocka,replace
+# CONFIGURE_ARGS += --disable-symbol-versions
+
+define Host/Compile
+	(cd $(HOST_BUILD_DIR); \
+		./buildtools/bin/waf build \
+		--targets=asn1_compile \
+	)
+endef
+
+define Host/Install
+	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/bin/
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/bin/asn1_compile $(STAGING_DIR_HOSTPKG)/bin/
+endef
 
 define Build/Prepare
 	$(Build/Prepare/Default)
@@ -303,15 +373,16 @@ define Build/Configure
 	echo 'Checking uname version type: "$(VERSION_DIST) Linux-$(LINUX_VERSION) $(shell date +%Y-%m-%d)"' >> $(PKG_BUILD_DIR)/cross-answers.txt
 	# NOTE: For some unknown reason this answer is not needed on some hosts/distros, yet needed on others?
 	echo 'Checking whether POSIX capabilities are available: OK' >> $(PKG_BUILD_DIR)/cross-answers.txt
-	$(call Build/Configure/Default,configure)
+	$(call Build/Configure/Default)
 endef
 
 # BUG: We need to use "waf install --targets=" otherwise a "make install" or "waf install" will retrigger a full recompile of all possible targets!
 define Build/Compile
 	(cd $(PKG_BUILD_DIR); \
-		./buildtools/bin/waf install -j$(shell nproc) \
-		--targets=$(SAMBA4_MODULES)$(SAMBA4_MODULES_SHARDED)$(BUILD_TARGETS_SERVER),$(BUILD_TARGETS_UTILS),$(BUILD_TARGETS_ADMIN),$(BUILD_TARGETS_CLIENT) \
+		./buildtools/bin/waf install \
+		--jobs=$(shell nproc) \
 		--destdir="$(PKG_INSTALL_DIR)" \
+		--targets=$(SAMBA4_MODULES)$(SAMBA4_MODULES_SHARDED)$(BUILD_TARGETS_SERVER),$(BUILD_TARGETS_UTILS),$(BUILD_TARGETS_ADMIN),$(BUILD_TARGETS_CLIENT) \
 	)
 endef
 
@@ -323,6 +394,21 @@ define Package/samba4-libs/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/samba/*.so* $(1)/usr/lib/
+	
+	$(INSTALL_DIR) $(1)/usr/lib/samba/vfs $(1)/usr/lib/samba/idmap $(1)/usr/lib/samba/ldb $(1)/usr/lib/samba/krb5
+	if [ -d $(PKG_INSTALL_DIR)/usr/lib/samba/idmap ]; then \
+		$(CP) $(PKG_INSTALL_DIR)/usr/lib/samba/idmap $(1)/usr/lib/samba/; \
+	fi
+	if [ -d $(PKG_INSTALL_DIR)/usr/lib/samba/vfs ]; then \
+		$(CP) $(PKG_INSTALL_DIR)/usr/lib/samba/vfs $(1)/usr/lib/samba/; \
+	fi
+	if [ -d $(PKG_INSTALL_DIR)/usr/lib/samba/krb5 ]; then \
+		$(CP) $(PKG_INSTALL_DIR)/usr/lib/samba/krb5 $(1)/usr/lib/samba/; \
+	fi
+ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
+	$(INSTALL_DIR) $(1)/usr/lib/python2.7
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/python2.7 $(1)/usr/lib/
+endif
 endef
 
 define Package/samba4-client/install
@@ -333,6 +419,8 @@ endef
 define Package/samba4-admin/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{net,smbcontrol,profiles,rpcclient,smbcacls,smbcquotas} $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/eventlogadm $(1)/usr/sbin/
 endef
 
 define Package/samba4-utils/install
@@ -341,27 +429,15 @@ define Package/samba4-utils/install
 endef
 
 define Package/samba4-server/install
-	$(INSTALL_DIR) $(1)/usr/lib/samba
-	if [ -d $(PKG_INSTALL_DIR)/usr/lib/samba/idmap ]; then \
-		$(CP) $(PKG_INSTALL_DIR)/usr/lib/samba/idmap $(1)/usr/lib/samba/; \
-	fi
-	if [ -d $(PKG_INSTALL_DIR)/usr/lib/samba/auth ]; then \
-		$(CP) $(PKG_INSTALL_DIR)/usr/lib/samba/auth $(1)/usr/lib/samba/; \
-	fi
-	if [ -d $(PKG_INSTALL_DIR)/usr/lib/samba/vfs ]; then \
-		$(CP) $(PKG_INSTALL_DIR)/usr/lib/samba/vfs $(1)/usr/lib/samba/; \
-	fi
-	if [ -d $(PKG_INSTALL_DIR)/usr/lib/samba/pdb ]; then \
-		$(CP) $(PKG_INSTALL_DIR)/usr/lib/samba/pdb $(1)/usr/lib/samba/; \
-	fi
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{smbpasswd,pdbedit,testparm} $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/smbd $(1)/usr/sbin/
 ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/python2.7 $(1)/usr/lib/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{samba-tool,ntlm_auth,smbtar} $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/{samba,samba-gpupdate,samba_dnsupdate,samba_kcc,samba_spnupdate,samba_upgradedns} $(1)/usr/sbin/
+	# waf does not install those?
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bin/{samba4kinit,samba4kgetcred,samba4kpasswd,samba4ktutil} $(1)/usr/bin/
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_NETBIOS),y)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/nmbd $(1)/usr/sbin/
@@ -389,8 +465,10 @@ define Package/samba4-server/conffiles
 /etc/samba/idmap.ldb
 /etc/samba/lmhosts
 /etc/nsswitch.conf
+/etc/krb5.conf
 endef
 
+$(eval $(call HostBuild))
 $(eval $(call BuildPackage,samba4-libs))
 $(eval $(call BuildPackage,samba4-server))
 $(eval $(call BuildPackage,samba4-client))

--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -59,7 +59,12 @@ smb_header() {
 EOT
 	}
 
-	[ -L /etc/samba/smb.conf ] || ln -nsf /var/etc/smb.conf /etc/samba/smb.conf
+	[ -e /etc/samba/smb.conf ] || ln -nsf /var/etc/smb.conf /etc/samba/smb.conf
+	
+	if [ -f /etc/samba/smb.conf ]; then
+		logger -t 'samba4-server' "Local custom /etc/samba/smb.conf file detected, all luci/config settings are ignored!"
+	fi
+	
 }
 
 smb_add_share() {


### PR DESCRIPTION
Maintainer: me
Compile tested: arm/mips (snapshots)
Run tested: arm, mips(qemu) (snapshots)

Description:
* update to 4.9.5
* use embedded heimdal build
* remove mitkrb5 deps
* add AD-DC tools (samba4kinit samba4kgetcred samba4kpasswd samba4ktutil)
* add eventlogadm to ADMIN tools
* build VFS modules shared
* preserve custom smb.conf after reboots
* add missing lib/samba/? private dirs, even if empty
* handle python-crypto via EXTRA_DEPENDS
* fix CONFIGURE_CMD argument order
* move python install to libs
* remove redundant Config.in selects

NOTE: MIT Kerberos support was relegated to experimental status and it seems the samba.org team does not want to support it in the future, so i switched to the embedded Heimdal build option. 
I picked this option over adding a new separate external Heimdal package, to avoid a similar problem in the future.

@val-kulkov I remember you asking for this option, so maybe you can also test this version with your setup.