### PR TITLE
attendedsyuspgrade-common: add key and set server

### DIFF
--- a/utils/attendedsysupgrade-common/Makefile
+++ b/utils/attendedsysupgrade-common/Makefile
@@ -5,8 +5,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=attendedsysupgrade-common
-PKG_VERSION:=0.1
-PKG_RELEASE:=2
+PKG_VERSION:=0.2
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk
@@ -51,6 +51,9 @@ endef
 define Package/attendedsysupgrade-common/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults/
 	$(INSTALL_BIN) ./files/attendedsysupgrade.defaults $(1)/etc/uci-defaults/attendedsysupgrade
+
+	$(INSTALL_DIR) $(1)/etc/opkg/keys/
+	$(INSTALL_BIN) ./files/c06d891233ba699 $(1)/etc/opkg/keys/c06d891233ba699
 endef
 
 $(eval $(call BuildPackage,attendedsysupgrade-common))

--- a/utils/attendedsysupgrade-common/files/attendedsysupgrade.defaults
+++ b/utils/attendedsysupgrade-common/files/attendedsysupgrade.defaults
@@ -6,7 +6,7 @@ touch /etc/config/attendedsysupgrade
 
 uci -q batch <<EOF
 set attendedsysupgrade.server=server
-set attendedsysupgrade.server.url='https://example.org'
+set attendedsysupgrade.server.url='https://chef.libremesh.org'
 
 set attendedsysupgrade.client=client
 set attendedsysupgrade.client.upgrade_packages='1'

--- a/utils/attendedsysupgrade-common/files/c06d891233ba699
+++ b/utils/attendedsysupgrade-common/files/c06d891233ba699
@@ -1,0 +1,2 @@
+untrusted comment: public key c06d891233ba699
+RWQMBtiRIzummeTc81jtKdJ3XwnaZGtHLRwjls0ovGsKoTnTmS7fj4Na


### PR DESCRIPTION
Maintainer: me

In collaboration with @dangowrt the server makes use of `ucert`.  Active
workers sign created firmware and clients check if the signature is
valid. Certs of *hacked* or inactive workers can be revoked.  Private CA
key is **not** stored on the upgrade server.

Only for devices already supporting ucert via firmware metadata.