### PR TITLE
travelmate: bugfix 1.4.1

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.4.0
+PKG_VERSION:=1.4.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL-AR750S, OpenWrt SNAPSHOT r9460-889b6423b7

Description:
* fix for #8357
* fix unexpectedy calling option_cb() during wireless config_load
* react immediately when the current active uplink configuration
  gets deleted

Signed-off-by: Dirk Brenken <dev@brenken.org>
