### PR TITLE
syslog-ng: superseded current maintainer by me

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -4,7 +4,7 @@ PKG_NAME:=syslog-ng
 PKG_VERSION:=3.20.1
 PKG_RELEASE:=1
 
-PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=LGPL-2.1+
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:balabit:syslog-ng


### PR DESCRIPTION
Maintainer: @MikePetullo 

Compile tested: N/A, will be done if requested
Run tested: N/A, will be done if requested

Description:
- This PR will replace current maintainer of syslog-ng with me, which was approved by @yousong in https://github.com/openwrt/packages/pull/8335 but would be nice if current maintainer could give me approval as well.