### PR TITLE
ntpd: Add PKG_CPE_ID for proper CVE tracking

### DIFF
--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -17,6 +17,7 @@ PKG_HASH:=288772cecfcd9a53694ffab108d1825a31ba77f3a8466b0401baeca3bc232a38
 
 PKG_LICENSE:=Unique
 PKG_LICENSE_FILES:=COPYRIGHT html/copyright.html
+PKG_CPE_ID:=cpe:/a:ntp:ntp
 
 PKG_FIXUP:=autoreconf
 PKG_LIBTOOL_PATHS:=. sntp


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: N/A
Run tested: N/A

Description:
This PR adds PKG_CPE_ID for better CVE tracking since the update to version 4.2.8p13 (https://github.com/openwrt/packages/commit/f969e3f0be4a8a7647037691e06c77b1f3059035) 
fixes also [Bug 3565 / CVE-2019-8936](http://support.ntp.org/bin/view/Main/NtpBug3565).

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>





