### PR TITLE
python: Support building without OpenSSL deprecated APIs

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -12,7 +12,7 @@ include ../python-version.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)

--- a/lang/python/python/patches/014-ssl-module-emulate-tls-methods.patch
+++ b/lang/python/python/patches/014-ssl-module-emulate-tls-methods.patch
@@ -1,0 +1,194 @@
+From 991f0176e188227647bf4c993d8da81cf794b3ae Mon Sep 17 00:00:00 2001
+From: Christian Heimes <christian@python.org>
+Date: Sun, 25 Feb 2018 20:03:07 +0100
+Subject: [PATCH] bpo-30008: SSL module: emulate tls methods
+
+OpenSSL 1.1 compatility: emulate version specific TLS methods with
+SSL_CTX_set_min/max_proto_version().
+---
+ .../2018-02-25-20-05-51.bpo-30008.6Bmyhr.rst       |   4 +
+ Modules/_ssl.c                                     | 134 ++++++++++++++++-----
+ 2 files changed, 108 insertions(+), 30 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Library/2018-02-25-20-05-51.bpo-30008.6Bmyhr.rst
+
+--- /dev/null
++++ b/Misc/NEWS.d/next/Library/2018-02-25-20-05-51.bpo-30008.6Bmyhr.rst
+@@ -0,0 +1,4 @@
++The ssl module no longer uses function that are deprecated since OpenSSL
++1.1.0. The version specific TLS methods are emulated with TLS_method() plus
++SSL_CTX_set_min/max_proto_version(). Pseudo random numbers are generated
++with RAND_bytes().
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -57,14 +57,6 @@
+ #include <arpa/inet.h>
+ #endif
+ 
+-/* Don't warn about deprecated functions */
+-#ifdef __GNUC__
+-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+-#endif
+-#ifdef __clang__
+-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+-#endif
+-
+ /* Include OpenSSL header files */
+ #include "openssl/rsa.h"
+ #include "openssl/crypto.h"
+@@ -168,6 +160,7 @@ struct py_ssl_library_code {
+ #ifndef PY_OPENSSL_1_1_API
+ /* OpenSSL 1.1 API shims for OpenSSL < 1.1.0 and LibreSSL < 2.7.0 */
+ 
++#define ASN1_STRING_get0_data ASN1_STRING_data
+ #define TLS_method SSLv23_method
+ 
+ static int X509_NAME_ENTRY_set(const X509_NAME_ENTRY *ne)
+@@ -1028,8 +1021,9 @@ _get_peer_alt_names (X509 *certificate) {
+                     goto fail;
+                 }
+                 PyTuple_SET_ITEM(t, 0, v);
+-                v = PyString_FromStringAndSize((char *)ASN1_STRING_data(as),
+-                                               ASN1_STRING_length(as));
++                v = PyString_FromStringAndSize(
++                    (char *)ASN1_STRING_get0_data(as),
++                    ASN1_STRING_length(as));
+                 if (v == NULL) {
+                     Py_DECREF(t);
+                     goto fail;
+@@ -2181,7 +2175,7 @@ context_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+     int proto_version = PY_SSL_VERSION_TLS;
+     long options;
+     SSL_CTX *ctx = NULL;
+-    int result;
++    int result = 0;
+ 
+     if (!PyArg_ParseTupleAndKeywords(
+         args, kwds, "i:_SSLContext", kwlist,
+@@ -2189,34 +2183,112 @@ context_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+         return NULL;
+ 
+     PySSL_BEGIN_ALLOW_THREADS
+-    if (proto_version == PY_SSL_VERSION_TLS1)
++    switch (proto_version) {
++#if OPENSSL_VERSION_NUMBER <= 0x10100000L
++    /* OpenSSL < 1.1.0 or not LibreSSL
++     * Use old-style methods for OpenSSL 1.0.2
++     */
++#if defined(SSL2_VERSION) && !defined(OPENSSL_NO_SSL2)
++    case PY_SSL_VERSION_SSL2:
++        ctx = SSL_CTX_new(SSLv2_method());
++        break;
++#endif
++#if defined(SSL3_VERSION) && !defined(OPENSSL_NO_SSL3)
++    case PY_SSL_VERSION_SSL3:
++        ctx = SSL_CTX_new(SSLv3_method());
++        break;
++#endif
++#if defined(TLS1_VERSION) && !defined(OPENSSL_NO_TLS1)
++    case PY_SSL_VERSION_TLS1:
+         ctx = SSL_CTX_new(TLSv1_method());
+-#if HAVE_TLSv1_2
+-    else if (proto_version == PY_SSL_VERSION_TLS1_1)
++        break;
++#endif
++#if defined(TLS1_1_VERSION) && !defined(OPENSSL_NO_TLS1_1)
++    case PY_SSL_VERSION_TLS1_1:
+         ctx = SSL_CTX_new(TLSv1_1_method());
+-    else if (proto_version == PY_SSL_VERSION_TLS1_2)
++        break;
++#endif
++#if defined(TLS1_2_VERSION) && !defined(OPENSSL_NO_TLS1_2)
++    case PY_SSL_VERSION_TLS1_2:
+         ctx = SSL_CTX_new(TLSv1_2_method());
++        break;
+ #endif
+-#ifndef OPENSSL_NO_SSL3
+-    else if (proto_version == PY_SSL_VERSION_SSL3)
+-        ctx = SSL_CTX_new(SSLv3_method());
++#else
++    /* OpenSSL >= 1.1 or LibreSSL
++     * create context with TLS_method for all protocols
++     * no SSLv2_method in OpenSSL 1.1.
++     */
++#if defined(SSL3_VERSION) && !defined(OPENSSL_NO_SSL3)
++    case PY_SSL_VERSION_SSL3:
++        ctx = SSL_CTX_new(TLS_method());
++        if (ctx != NULL) {
++            /* OpenSSL 1.1.0 sets SSL_OP_NO_SSLv3 for TLS_method by default */
++            SSL_CTX_clear_options(ctx, SSL_OP_NO_SSLv3);
++            if (!SSL_CTX_set_min_proto_version(ctx, SSL3_VERSION))
++                result = -2;
++            if (!SSL_CTX_set_max_proto_version(ctx, SSL3_VERSION))
++                result = -2;
++        }
++        break;
+ #endif
+-#ifndef OPENSSL_NO_SSL2
+-    else if (proto_version == PY_SSL_VERSION_SSL2)
+-        ctx = SSL_CTX_new(SSLv2_method());
++#if defined(TLS1_VERSION) && !defined(OPENSSL_NO_TLS1)
++    case PY_SSL_VERSION_TLS1:
++        ctx = SSL_CTX_new(TLS_method());
++        if (ctx != NULL) {
++            SSL_CTX_clear_options(ctx, SSL_OP_NO_TLSv1);
++            if (!SSL_CTX_set_min_proto_version(ctx, TLS1_VERSION))
++                result = -2;
++            if (!SSL_CTX_set_max_proto_version(ctx, TLS1_VERSION))
++                result = -2;
++        }
++        break;
+ #endif
+-    else if (proto_version == PY_SSL_VERSION_TLS)
++#if defined(TLS1_1_VERSION) && !defined(OPENSSL_NO_TLS1_1)
++    case PY_SSL_VERSION_TLS1_1:
+         ctx = SSL_CTX_new(TLS_method());
+-    else
+-        proto_version = -1;
++        if (ctx != NULL) {
++            SSL_CTX_clear_options(ctx, SSL_OP_NO_TLSv1_1);
++            if (!SSL_CTX_set_min_proto_version(ctx, TLS1_1_VERSION))
++                result = -2;
++            if (!SSL_CTX_set_max_proto_version(ctx, TLS1_1_VERSION))
++                result = -2;
++        }
++        break;
++#endif
++#if defined(TLS1_2_VERSION) && !defined(OPENSSL_NO_TLS1_2)
++    case PY_SSL_VERSION_TLS1_2:
++        ctx = SSL_CTX_new(TLS_method());
++        if (ctx != NULL) {
++            SSL_CTX_clear_options(ctx, SSL_OP_NO_TLSv1_2);
++            if (!SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION))
++                result = -2;
++            if (!SSL_CTX_set_max_proto_version(ctx, TLS1_2_VERSION))
++                result = -2;
++        }
++        break;
++#endif
++#endif /* OpenSSL >= 1.1 */
++    case PY_SSL_VERSION_TLS:
++        /* SSLv23 */
++        ctx = SSL_CTX_new(TLS_method());
++        break;
++    default:
++        result = -1;
++        break;
++    }
+     PySSL_END_ALLOW_THREADS
+ 
+-    if (proto_version == -1) {
++    if (result == -1) {
+         PyErr_SetString(PyExc_ValueError,
+                         "invalid protocol version");
+         return NULL;
+     }
+-    if (ctx == NULL) {
++    else if (result == -2) {
++        PyErr_SetString(PyExc_ValueError,
++                        "protocol configuration error");
++        return NULL;
++    }
++    else if (ctx == NULL) {
+         _setSSLError(NULL, 0, __FILE__, __LINE__);
+         return NULL;
+     }

--- a/lang/python/python/patches/015-openssl-deprecated.patch
+++ b/lang/python/python/patches/015-openssl-deprecated.patch
@@ -1,0 +1,67 @@
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -94,13 +94,13 @@ struct py_ssl_library_code {
+ #include "_ssl_data.h"
+ 
+ #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+-#  define OPENSSL_VERSION_1_1 1
+-#  define PY_OPENSSL_1_1_API 1
++# define OPENSSL_VERSION_1_1 1
++# define PY_OPENSSL_1_1_API 1
+ #endif
+ 
+ /* LibreSSL 2.7.0 provides necessary OpenSSL 1.1.0 APIs */
+ #if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL
+-#  define PY_OPENSSL_1_1_API 1
++# define PY_OPENSSL_1_1_API 1
+ #endif
+ 
+ /* Openssl comes with TLSv1.1 and TLSv1.2 between 1.0.0h and 1.0.1
+@@ -162,6 +162,11 @@ struct py_ssl_library_code {
+ 
+ #define ASN1_STRING_get0_data ASN1_STRING_data
+ #define TLS_method SSLv23_method
++#define X509_getm_notBefore X509_get_notBefore
++#define X509_getm_notAfter X509_get_notAfter
++#define OpenSSL_version_num SSLeay
++#define OpenSSL_version SSLeay_version
++#define OPENSSL_VERSION SSLEAY_VERSION
+ 
+ static int X509_NAME_ENTRY_set(const X509_NAME_ENTRY *ne)
+ {
+@@ -1327,7 +1332,7 @@ _decode_certificate(X509 *certificate) {
+     Py_DECREF(sn_obj);
+ 
+     (void) BIO_reset(biobuf);
+-    notBefore = X509_get_notBefore(certificate);
++    notBefore = X509_getm_notBefore(certificate);
+     ASN1_TIME_print(biobuf, notBefore);
+     len = BIO_gets(biobuf, buf, sizeof(buf)-1);
+     if (len < 0) {
+@@ -1344,7 +1349,7 @@ _decode_certificate(X509 *certificate) {
+     Py_DECREF(pnotBefore);
+ 
+     (void) BIO_reset(biobuf);
+-    notAfter = X509_get_notAfter(certificate);
++    notAfter = X509_getm_notAfter(certificate);
+     ASN1_TIME_print(biobuf, notAfter);
+     len = BIO_gets(biobuf, buf, sizeof(buf)-1);
+     if (len < 0) {
+@@ -4584,7 +4589,7 @@ init_ssl(void)
+     /* SSLeay() gives us the version of the library linked against,
+        which could be different from the headers version.
+     */
+-    libver = SSLeay();
++    libver = OpenSSL_version_num();
+     r = PyLong_FromUnsignedLong(libver);
+     if (r == NULL)
+         return;
+@@ -4594,7 +4599,7 @@ init_ssl(void)
+     r = Py_BuildValue("IIIII", major, minor, fix, patch, status);
+     if (r == NULL || PyModule_AddObject(m, "OPENSSL_VERSION_INFO", r))
+         return;
+-    r = PyString_FromString(SSLeay_version(SSLEAY_VERSION));
++    r = PyString_FromString(OpenSSL_version(OPENSSL_VERSION));
+     if (r == NULL || PyModule_AddObject(m, "OPENSSL_VERSION", r))
+         return;
+ 


### PR DESCRIPTION
Backported upstream pull request with the missing stuff added at the end.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @commodo / @jefferyto 
Compile tested: mvebu
Run tested: Turris Omnia

Description:
First patch is an upstream pull request that has been stalled for over a year: https://github.com/python/cpython/pull/3934

Second adds the missing stuff.