### PR TITLE
vpnc: fix IPv6-triggered inoperability

### DIFF
--- a/net/vpnc/Makefile
+++ b/net/vpnc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=vpnc
 PKG_REV:=550
 PKG_VERSION:=0.5.3.r$(PKG_REV)
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://svn.unix-ag.uni-kl.de/vpnc/trunk/

--- a/net/vpnc/files/vpnc.sh
+++ b/net/vpnc/files/vpnc.sh
@@ -42,7 +42,7 @@ proto_vpnc_setup() {
 
 	logger -t vpnc "initializing..."
 	serv_addr=
-	for ip in $(resolveip -t 10 "$server"); do
+	for ip in $(resolveip -4t 10 "$server"); do
 		( proto_add_host_dependency "$config" "$ip" $interface )
 		serv_addr=1
 	done


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A -- shell script change only
Run tested: GL.iNet GL-AR750S 18.06 (by user Kugelfang on the forum)
Description:
When the server hostname resolved to both IPv4 and IPv6 addresses,
connecting would fail with nothing in syslog. This corrects that oversight.

Signed-off-by: Daniel Gimpelevich <daniel@gimpelevich.san-francisco.ca.us>