### PR TITLE
[pcre] Fix compile of libpcrecpp

### DIFF
--- a/libs/pcre/Makefile
+++ b/libs/pcre/Makefile
@@ -55,12 +55,8 @@ CONFIGURE_ARGS += \
 	--enable-unicode-properties \
 	--enable-pcre16 \
 	--with-match-limit-recursion=16000 \
+	--enable-cpp
 
-ifneq ($(CONFIG_PACKAGE_libpcrecpp),)
-  CONFIGURE_ARGS+= --enable-cpp
-else
-  CONFIGURE_ARGS+= --disable-cpp
-endif
 
 MAKE_FLAGS += \
 	CFLAGS="$(TARGET_CFLAGS)"


### PR DESCRIPTION
If the cpp lib is added after pcre is first compiled, pcre will
not be reconfigured and the build will fail.
Fix this by always building the cpp parts.

Maintainer: @heil 
Compile tested: (omap, OpenWrt 18.06.2)

Description:

Adding libpcrecpp gives a build error. Fixed by always building cpp part. As an alternative the flag PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_libpcrecpp could be added.