### PR TITLE
New Python3 packages as dependencies for Bigclown

### DIFF
--- a/lang/python/click-log/Makefile
+++ b/lang/python/click-log/Makefile
@@ -1,0 +1,36 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=click-log
+PKG_VERSION:=0.3.2
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+
+PKG_SOURCE_URL:=https://codeload.github.com/click-contrib/click-log/tar.gz/$(PKG_VERSION)?
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=16babb66a2ebf22c37c1cf38753a84e6027eb8991fcf9a8487971591b8ca9812
+PKG_LICENSE:=MIT
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-click-log
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=http://github.com/mitsuhiko/click
+  TITLE:=python3-click-log
+  DEPENDS:=+PACKAGE_python3-click-log:python3-click
+  VARIANT:=python3
+endef
+
+define Package/python3-click-log/description
+  Simple and beautiful logging for click applications
+endef
+
+$(eval $(call Py3Package,python3-click-log))
+$(eval $(call BuildPackage,python3-click-log))
+$(eval $(call BuildPackage,python3-click-log-src))

--- a/lang/python/python-appdirs/Makefile
+++ b/lang/python/python-appdirs/Makefile
@@ -1,0 +1,37 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-appdirs
+PKG_VERSION:=1.4.3
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/a/appdirs/
+PKG_SOURCE:=appdirs-$(PKG_VERSION).tar.gz
+PKG_HASH:=9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92
+PKG_LICENSE:=MIT
+PKG_BUILD_DIR:=$(BUILD_DIR)/appdirs-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-appdirs
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://github.com/ActiveState/appdirs
+  TITLE:=python3-appdirs
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python-appdirs/description
+  The Universal Character Encoding Detector
+endef
+
+$(eval $(call Py3Package,python3-appdirs))
+$(eval $(call BuildPackage,python3-appdirs))
+$(eval $(call BuildPackage,python3-appdirs-src))

--- a/lang/python/python-contextlib2/Makefile
+++ b/lang/python/python-contextlib2/Makefile
@@ -1,0 +1,36 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-contextlib2
+PKG_VERSION:=0.5.5
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/c/contextlib2/
+PKG_SOURCE:=contextlib2-$(PKG_VERSION).tar.gz
+PKG_HASH:=509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48
+PKG_BUILD_DIR:=$(BUILD_DIR)/contextlib2-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-contextlib2
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=http://contextlib2.readthedocs.org
+  TITLE:=python3-contextlib2
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python-contextlib2/description
+  contextlib2 is a backport of the standard library’s contextlib module to earlier Python versions.
+endef
+
+$(eval $(call Py3Package,python3-contextlib2))
+$(eval $(call BuildPackage,python3-contextlib2))
+$(eval $(call BuildPackage,python3-contextlib2-src))

--- a/lang/python/python-decorator/Makefile
+++ b/lang/python/python-decorator/Makefile
@@ -1,0 +1,32 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-decorator
+PKG_VERSION:=4.3.2
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+
+PKG_SOURCE_URL:=https://codeload.github.com/micheles/decorator/tar.gz/$(PKG_VERSION)?
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=c053ec881270608a5aef624a45a7700ec76ceca9d96689506411e1f319085380
+PKG_BUILD_DIR:=$(BUILD_DIR)/decorator-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-decorator
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://github.com/micheles/decorator
+  TITLE:=python3-decodator
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+$(eval $(call Py3Package,python3-decorator))
+$(eval $(call BuildPackage,python3-decorator))
+$(eval $(call BuildPackage,python3-decorator-src))

--- a/lang/python/python-influxdb/Makefile
+++ b/lang/python/python-influxdb/Makefile
@@ -1,0 +1,37 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-influxdb
+PKG_VERSION:=5.2.1
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/i/influxdb/
+PKG_SOURCE:=influxdb-$(PKG_VERSION).tar.gz
+PKG_HASH:=75d96de25d0d4e9e66e155f64dc9dc2a48de74ac4e77e3a46ad881fba772e3b6
+PKG_LICENSE:=MIT
+PKG_BUILD_DIR:=$(BUILD_DIR)/influxdb-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-influxdb
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://github.com/influxdb/influxdb-python
+  TITLE:=python3-influxdb
+  DEPENDS:=+python3-requests +python3-pytz +python3-six +python3-dateutil
+  VARIANT:=python3
+endef
+
+define Package/python3-influxdb/description
+  Python client for InfluxDB
+endef
+
+$(eval $(call Py3Package,python3-influxdb))
+$(eval $(call BuildPackage,python3-influxdb))
+$(eval $(call BuildPackage,python3-influxdb-src))

--- a/lang/python/python-jsonpath-ng/Makefile
+++ b/lang/python/python-jsonpath-ng/Makefile
@@ -1,0 +1,32 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-jsonpath-ng
+PKG_VERSION:=1.4.3
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/j/jsonpath-ng/
+PKG_SOURCE:=jsonpath-ng-$(PKG_VERSION).tar.gz
+PKG_HASH:=b1fc75b877e9b2f46845a455fbdcfb0f0d9c727c45c19a745d02db620a9ef0be
+PKG_BUILD_DIR:=$(BUILD_DIR)/jsonpath-ng-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-jsonpath-ng
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://github.com/h2non/jsonpath-ng
+  TITLE:=python3-jsonpath-ng
+  DEPENDS:=+python3-ply +python3-six +python3-decorator
+  VARIANT:=python3
+endef
+
+$(eval $(call Py3Package,python3-jsonpath-ng))
+$(eval $(call BuildPackage,python3-jsonpath-ng))
+$(eval $(call BuildPackage,python3-jsonpath-ng-src))

--- a/lang/python/python-paho-mqtt/Makefile
+++ b/lang/python/python-paho-mqtt/Makefile
@@ -1,0 +1,37 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-paho-mqtt
+PKG_VERSION:=1.4.0
+PKG_RELEASE:=1
+PKG_LICENSE:=Eclipse Public License v1.0 / Eclipse Distribution License v1.0
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>, Alexandru Ardelean <ardeleanalex@gmail.com>
+
+PKG_SOURCE:=paho-mqtt-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/25/63/db25e62979c2a716a74950c9ed658dce431b5cb01fde29eb6cba9489a904
+PKG_HASH:=e440a052b46d222e184be3be38676378722072fcd4dfd2c8f509fb861a7b0b79
+PKG_BUILD_DIR:=$(BUILD_DIR)/paho-mqtt-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-paho-mqtt
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=python3-paho-mqtt
+  URL:=http://eclipse.org/paho
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-paho-mqtt/description
+  MQTT version 3.1/3.1.1 client class
+endef
+
+$(eval $(call Py3Package,python3-paho-mqtt))
+$(eval $(call BuildPackage,python3-paho-mqtt))
+$(eval $(call BuildPackage,python3-paho-mqtt-src))

--- a/lang/python/python-schema/Makefile
+++ b/lang/python/python-schema/Makefile
@@ -1,0 +1,36 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-schema
+PKG_VERSION:=0.7.0
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+
+PKG_SOURCE_URL:=https://codeload.github.com/keleshev/schema/tar.gz/v$(PKG_VERSION)?
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=6c6da2154c0f63025127a1ecb3b2f07b95ec8dd029663fc74ab2e972bf770c72
+PKG_BUILD_DIR:=$(BUILD_DIR)/schema-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-schema
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  URL:=https://github.com/keleshev/schema
+  TITLE:=python3-schema
+  DEPENDS:=+python3-light +python3-contextlib2
+  VARIANT:=python3
+endef
+
+define Package/python3-schema/description
+  Schema validation just got Pythonic
+endef
+
+$(eval $(call Py3Package,python3-schema))
+$(eval $(call BuildPackage,python3-schema))
+$(eval $(call BuildPackage,python3-schema-src))


### PR DESCRIPTION
Maintainer: me (review @commodo ?)
Compile tested: Turris Omnia, Mox, OpenWRT defconfig
Run tested: Turris Omnia

Description:
These are new python packages required for new bigclown packages.

This is continuation of PR: #8133 

Note: tests for these are going to fail until #8377 is merged and this rebased on top of it.