### PR TITLE
Bigclown

### DIFF
--- a/utils/bigclown/bigclown-control-tool/Makefile
+++ b/utils/bigclown/bigclown-control-tool/Makefile
@@ -1,0 +1,36 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bigclown-control-tool
+PKG_VERSION:=0.2.0
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://codeload.github.com/bigclownlabs/bch-control-tool/tar.gz/v$(PKG_VERSION)?
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=c79a76e0940958e4ddcf51e57fadfb127f568b6c1ceb02033c3630bab2dee612
+PKG_LICENSE:=MIT
+PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_BUILD_DIR:=$(BUILD_DIR)/bch-control-tool-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../../lang/python/python3-package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=BigClown
+  URL:=https://github.com/bigclownlabs/bch-control-tool
+  TITLE:=BigCLown control tool
+  DEPENDS:=+python3-click-log +python3-paho-mqtt +python3-pyserial +python3-yaml +python3-simplejson
+endef
+
+define Build/Compile
+	sed -i 's/@@VERSION@@/$(PKG_VERSION)/' "$(PKG_BUILD_DIR)/setup.py"
+	$(call Py3Build/Compile/Default)
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/utils/bigclown/bigclown-gateway/Makefile
+++ b/utils/bigclown/bigclown-gateway/Makefile
@@ -1,0 +1,59 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bigclown-gateway
+PKG_VERSION:=1.16.2
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://codeload.github.com/bigclownlabs/bch-gateway/tar.gz/v$(PKG_VERSION)?
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=9d3208bf4cffec507d992485104fcbba2b9bc02cf7b290dfe13f98e5916ee1ca
+PKG_LICENSE:=MIT
+PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_BUILD_DIR:=$(BUILD_DIR)/bch-gateway-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../../lang/python/python3-package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=BigClown
+  URL:=https://github.com/bigclownlabs/bch-gateway
+  TITLE:=BigCLown gateway
+  DEPENDS:= \
+    +kmod-usb-serial-ftdi \
+    +kmod-usb-acm \
+    +python3-click-log \
+    +python3-paho-mqtt \
+    +python3-pyserial \
+    +python3-yaml \
+    +python3-simplejson \
+    +python3-schema \
+    +python3-appdirs
+endef
+
+define Py3Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/config $(1)/etc/config/bigclown-gateway
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/init $(1)/etc/init.d/bigclown-gateway
+endef
+
+define Package/$(PKG_NAME)/conffiles
+/etc/config/bigclown-gateway
+endef
+
+define Build/Compile
+	sed -i 's/@@VERSION@@/$(PKG_VERSION)/' "$(PKG_BUILD_DIR)/setup.py"
+	$(call Py3Build/Compile/Default)
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/utils/bigclown/bigclown-gateway/files/config
+++ b/utils/bigclown/bigclown-gateway/files/config
@@ -1,0 +1,10 @@
+
+config gateway 'gateway'
+	option enabled '0'
+	option name 'usb-dongle'
+	option device '/dev/ttyUSB0'
+	option automatic_rename_kit_nodes '1'
+
+config mqtt 'mqtt'
+	option host 'localhost'
+	option port '1883'

--- a/utils/bigclown/bigclown-gateway/files/init
+++ b/utils/bigclown/bigclown-gateway/files/init
@@ -1,0 +1,58 @@
+#!/bin/sh /etc/rc.common
+
+START=98
+STOP=1
+
+USE_PROCD=1
+
+PROG=/usr/bin/bcg
+CONF=/tmp/etc/bigclown-gateway.conf
+
+append() {
+	local cfg="$1"
+	local uci_name="$2"
+	local out_name="$3"
+	local default="$4"
+	config_get val $cfg $uci_name $default
+	if [ -n "$val" ]; then
+	  echo "$out_name $val" >> $CONF
+	fi
+}
+
+start_service() {
+	config_load bigclown-gateway
+
+	local enabled
+	config_get_bool enabled gateway enabled "0"
+	[ "$enabled" = "1" ] || {
+		echo "Bigclown gateway service disabled"
+		exit 1
+	}
+
+	rm -rf $CONF
+	echo "Generating bigclown-gateway config file in $CONF"
+
+	append gateway name 'name:' usb-dongle
+	# TODO add hotplug script and use different default here
+	append gateway device 'device:' /dev/ttyUSB0
+	append gateway automatic_rename_kit_nodes 'automatic_rename_kit_nodes:' 1
+	append gateway base_topic_prefix 'base_topic_prefix:'
+
+	echo "mqtt:" >> $CONF
+	append mqtt host '  host:' localhost
+	append mqtt port '  port:' 1883
+	append mqtt cafile '  cafile:'
+	append mqtt certfile '  certfile:'
+	append mqtt keyfile '  keyfile:'
+
+	procd_open_instance
+	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+	procd_set_param command "$PROG" -c "$CONF"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger 'bigclown-gateway'
+}

--- a/utils/bigclown/bigclown-mqtt2influxdb/Makefile
+++ b/utils/bigclown/bigclown-mqtt2influxdb/Makefile
@@ -1,0 +1,49 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bigclown-mqtt2influxdb
+PKG_VERSION:=1.1.0
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://codeload.github.com/bigclownlabs/bch-mqtt2influxdb/tar.gz/v$(PKG_VERSION)?
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=5be14132311e85215abbfd732fe6cd652522ea0a343ee8ba7abab3ec7578eb99
+PKG_LICENSE:=MIT
+PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_BUILD_DIR:=$(BUILD_DIR)/bch-mqtt2influxdb-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../../lang/python/python3-package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=BigClown
+  URL:=https://github.com/bigclownlabs/bch-mqtt2influxdb
+  TITLE:=BigCLown MQTT to Influxdb bridge
+  DEPENDS:=+python3-paho-mqtt +python3-yaml +python3-influxdb +python3-jsonpath-ng +python3-schema
+endef
+
+define Py3Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/init $(1)/etc/init.d/bigclown-mqtt2influxdb
+	$(INSTALL_DATA) ./files/config.yml $(1)/etc/bigclown-mqtt2influxdb.yml
+endef
+
+define Package/$(PKG_NAME)/conffiles
+/etc/bigclown-mqtt2influxdb.yml
+endef
+
+define Build/Compile
+	sed -i 's/@@VERSION@@/$(PKG_VERSION)/' "$(PKG_BUILD_DIR)/setup.py"
+	$(call Py3Build/Compile/Default)
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/utils/bigclown/bigclown-mqtt2influxdb/files/config.yml
+++ b/utils/bigclown/bigclown-mqtt2influxdb/files/config.yml
@@ -1,0 +1,67 @@
+## Example bigclown-mqtt2influxdb configuration
+
+# MQTT configuration
+mqtt:
+  #host: 127.0.0.1
+  #port: 1883
+
+# InfluxDB configuration
+influxdb:
+  #host: 127.0.0.1
+  #port: 8086
+  #database: node
+
+# This is default configuration used to mirror all values produced by default
+# BigClown modules firmware. You might want to add your topics or drop those for
+# modules you don't own.
+points:
+  - measurement: temperature
+    topic: node/+/thermometer/+/temperature
+    fields:
+      value: $.payload
+    tags:
+      id: $.topic[1]
+      channel: $.topic[3]
+
+  - measurement: relative-humidity
+    topic: node/+/hygrometer/0:4/relative-humidity
+    fields:
+      value: $.payload
+    tags:
+      id: $.topic[1]
+
+  - measurement: illuminance
+    topic: node/+/lux-meter/0:0/illuminance
+    fields:
+      value: $.payload
+    tags:
+      id: $.topic[1]
+
+  - measurement: pressure
+    topic: node/+/barometer/0:0/pressure
+    fields:
+      value: $.payload
+    tags:
+      id: $.topic[1]
+
+  - measurement: co2
+    topic: node/+/co2-meter/-/concentration
+    fields:
+      value: $.payload
+    tags:
+      id: $.topic[1]
+
+  - measurement: voltage
+    topic: node/+/battery/+/voltage
+    fields:
+      value: $.payload
+    tags:
+      id: $.topic[1]
+
+  - measurement: button
+    topic: node/+/push-button/+/event-count
+    fields:
+      value: $.payload
+    tags:
+      id: $.topic[1]
+      channel: $.topic[3]

--- a/utils/bigclown/bigclown-mqtt2influxdb/files/init
+++ b/utils/bigclown/bigclown-mqtt2influxdb/files/init
@@ -1,0 +1,22 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=1
+
+USE_PROCD=1
+
+PROG=/usr/bin/mqtt2influxdb
+CONF=/etc/bigclown-mqtt2influxdb.yml
+
+start_service() {
+	procd_open_instance
+	procd_set_param respawn 3600 5 5
+	procd_set_param command "$PROG" -c "$CONF"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+stop_service() {
+	service_stop "$PROG"
+}


### PR DESCRIPTION
Maintainer: me (review @commodo, @karlp ?)
Compile tested: Turris Omnia, Mox
Run tested: Turris Omnia

Description:
This is minimal set of packages to allow OpenWRT router to be used a gateway for Bigclown.

This is continuation of #8133 

Note: this PR requires a lot of new Python packages and those are pulled separately in PR #8378. This means that until those are merged and this rebase on top of them, the tests are going to be failing.