### PR TITLE
python-certifi: Update to 2019.3.9

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
-PKG_VERSION:=2018.11.29
+PKG_VERSION:=2019.3.9
 PKG_RELEASE:=1
 PKG_LICENSE:=MPL-2.0
 
 PKG_SOURCE:=certifi-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/certifi
-PKG_HASH:=47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7
+PKG_HASH:=b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-certifi-$(PKG_VERSION)
 PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: WRT3200ACS(mvebu/armv9)/openwrt master
Run tested: WRT3200ACS(mvebu/armv9)/openwrt master, tested the only provided function, `certifi.where()`

Description:
Updates the certificate bundle to the latest version from mozilla

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

