### PR TITLE
measurement-kit: update to version 0.9.4

### DIFF
--- a/libs/measurement-kit/Makefile
+++ b/libs/measurement-kit/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=measurement-kit
-PKG_VERSION:=0.9.2
+PKG_VERSION:=0.9.4
 PKG_RELEASE=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/measurement-kit/measurement-kit/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=b8e2624ba496c47164f3c15d35bb5e0a6c0f5e03b603e60ed9769156b1c7d82d
+PKG_HASH:=d095c28fa7283c546dcf513b9c60156f5ab7690f33f2de346372cd5328072d36
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf

--- a/libs/measurement-kit/patches/001-remove-ca-download.patch
+++ b/libs/measurement-kit/patches/001-remove-ca-download.patch
@@ -1,0 +1,20 @@
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -3,7 +3,7 @@
+ set -e
+ export LC_ALL=C  # Stable sorting regardless of the locale
+
+-. script/autogen.d/ca-bundle
++#. script/autogen.d/ca-bundle
+ . script/autogen.d/geoip
+
+ no_geoip=0
+@@ -82,7 +82,7 @@ gen_executables noinst_PROGRAMS example
+ gen_executables ALL_TESTS test libtest_main.la                   >> include.am
+
+ if [ $no_geoip -ne 1 ]; then
+-    autogen_get_ca_bundle
++    #autogen_get_ca_bundle
+     autogen_get_geoip
+ fi
+

--- a/libs/measurement-kit/patches/002-replace-curl-with-wget.patch
+++ b/libs/measurement-kit/patches/002-replace-curl-with-wget.patch
@@ -1,0 +1,18 @@
+--- a/script/autogen.d/geoip
++++ b/script/autogen.d/geoip
+@@ -5,13 +5,13 @@ autogen_get_geoip() {
+     echo "* Fetching geoip databases"
+     base=https://geolite.maxmind.com/download/geoip/database
+     if [ ! -f "country.mmdb" ]; then
+-        curl -fsSLO $base/GeoLite2-Country.tar.gz
++        command -v curl && curl -fsSLO $base/GeoLite2-Country.tar.gz || wget $base/GeoLite2-Country.tar.gz
+         tar -xf GeoLite2-Country.tar.gz
+         mv GeoLite2-Country_20??????/GeoLite2-Country.mmdb country.mmdb
+         rm -rf GeoLite2-Country_20??????
+     fi
+     if [ ! -f "asn.mmdb" ]; then
+-        curl -fsSLO $base/GeoLite2-ASN.tar.gz
++        command -v curl && curl -fsSLO $base/GeoLite2-ASN.tar.gz || wget $base/GeoLite2-ASN.tar.gz
+         tar -xf GeoLite2-ASN.tar.gz
+         mv GeoLite2-ASN_20??????/GeoLite2-ASN.mmdb asn.mmdb
+         rm -rf GeoLite2-ASN_20??????


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS4), OpenWrt Master
Run tested: Turris Omnia (TOS4), OpenWrt Master

Description:
This PR adds patches for fixing autogen.sh script for some platforms and updates measurement-kit to version 0.9.4 (version 0.9.5 contains bug for DASH test).

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>


