### PR TITLE
syslog-ng: disable geoip2 for now

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -60,6 +60,7 @@ CONFIGURE_ARGS +=  \
 	--disable-redis \
 	--disable-dependency-tracking \
 	--disable-python \
+	--disable-geoip2 \
 	--disable-java \
 	--disable-java-modules \
 	--with-librabbitmq-client=no \


### PR DESCRIPTION
Maintainer: me (@BKPepe)
Compile tested: 
- cortexa53, Turris MOX, OpenWrt master
- mvebu (cortex-a9_vfpv3), Turris Omnia, OpenWrt master

Run tested: 

- cortexa53, Turris MOX, OpenWrt master

Description:

Recently to OpenWrt repository was added package [libmaxminddb](https://github.com/openwrt/packages/blob/master/libs/libmaxminddb/Makefile). 
This package provides C library for reading MaxMind DB files including GeoIP2 databases. As it was added, it enabled GeoIP support automatically for syslog-ng.

> --enable-geoip Enable GEOIP support, required for the geoip2 template function and the geoip2-parser (enabled automatically if the libmaxminddb library is detected).
[Source](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.17/administration-guide/11)

Thus it fails as it cannot find the dependency. 
```
Package syslog-ng is missing dependencies for the following libraries:
libmaxminddb.so.0
```

I haven't tested GeoIP support yet as I'd like to separate syslog-ng packages to sub packages as it has e.g. SUSE. It doesn't break Slack integration, so it's fine. :-)

Thanks, @Cynerd for reporting and fixing it!