### PR TITLE
[openwrt-18.06] unbound: update to 1.9.1

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.8.1
+PKG_VERSION:=1.9.1
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
@@ -17,7 +17,7 @@ PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.unbound.net/downloads
-PKG_HASH:=c362b3b9c35d1b8c1918da02cdd5528d729206c14c767add89ae95acae363c5d
+PKG_HASH:=c3c0bf9b86ccba4ca64f93dd4fe7351308ab54293f297a67de5a8914c1dc59c5
 
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Maintainer: me
Tested: WRT-3200ACM (18.06)
Description: Substantial improvement of OpenSSL 1.0.2 use including removing deprecated API, DNS/TLS host name verification, and bug fixes.
