### PR TITLE
btrfs-progs: update to 4.20.2

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -6,15 +6,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
-PKG_VERSION:=4.20.1
-PKG_RELEASE:=2
+PKG_VERSION:=4.20.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs
-PKG_HASH:=562f5d1ff1d17867c4c2be2768c653b62f1f257c42f9bb3e1a36380c02ec4fcd
+PKG_HASH:=890f8b7e162f2bbfaa5c7b23e8b6f791fd3f325239a0510871fa4b45e4a80e7c
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
-PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
+PKG_MAINTAINER:=Karel Kočí <karel.koci@nic.cz>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris
Run tested: Turris {mox,omnia}

Description:
Update to latest fixup for btrfs-progs. I am also retaking maintenance of this package.

Closes #4491 