### PR TITLE
python3-bottle: update to version 0.12.16

### DIFF
--- a/lang/python/python3-bottle/Makefile
+++ b/lang/python/python3-bottle/Makefile
@@ -8,20 +8,24 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-bottle
-PKG_VERSION:=0.12.13
+PKG_VERSION:=0.12.16
 PKG_RELEASE:=1
 
 PKG_LICENSE:=MIT
-PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>
+PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:bottlepy:bottle
+
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 
 PKG_SOURCE:=bottle-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/b/bottle
-PKG_HASH:=39b751aee0b167be8dffb63ca81b735bbf1dd0905b3bc42761efedee8f123355
-PKG_BUILD_DIR:=$(BUILD_DIR)/bottle-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+PKG_HASH:=9c310da61e7df2b6ac257d8a90811899ccb3a9743e77e947101072a2e3186726
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-bottle-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
+
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python3-bottle
 	SECTION:=lang

--- a/lang/python/python3-bottle/Makefile
+++ b/lang/python/python3-bottle/Makefile
@@ -30,6 +30,7 @@ define Package/python3-bottle
 	TITLE:=Bottle is a fast, simple and lightweight WSGI micro web-framework for Python
 	URL:=https://bottlepy.org
 	DEPENDS:=+python3
+	VARIANT:=python3
 endef
 
 define Package/python3-bottle/description
@@ -38,15 +39,6 @@ define Package/python3-bottle/description
  Python Standard Library.
 endef
 
-define Build/Configure
-endef
-
-define Build/Compile
-endef
-
-define Package/python3-bottle/install
-	$(INSTALL_DIR) $(1)$(PYTHON3_PKG_DIR)
-	$(CP) $(PKG_BUILD_DIR)/bottle.py $(1)$(PYTHON3_PKG_DIR)
-endef
-
+$(eval $(call Py3Package,python3-bottle))
 $(eval $(call BuildPackage,python3-bottle))
+$(eval $(call BuildPackage,python3-bottle-src))


### PR DESCRIPTION
Maintainer: @lperkov 
cc Python maintainers: @jefferyto and @commodo
___
Compile tested: mvebu (cortex-a9_vfpv3) , Turris Omnia, OpenWrt master
Run tested: mvebu (cortex-a9_vfpv3) , Turris Omnia, OpenWrt SNAPSHOT, r9420-c17a68c
together with test "Hello World"
![Screenshot from 2019-03-13 17-09-08](https://user-images.githubusercontent.com/4096468/54295191-ddd91f00-45b2-11e9-9607-d71a090eb440.png)
![Screenshot from 2019-03-13 17-09-36](https://user-images.githubusercontent.com/4096468/54295197-dfa2e280-45b2-11e9-9f12-0aec7ed3947f.png)

Description:

- use Py3Package for installation
- update to version 0.12.16 (as included also in Commit message added CPE ID and LICENSE file)