### PR TITLE
[OpenWrt 18.06] Jinja2: Update to 2.10

### DIFF
--- a/lang/python/Jinja2/Makefile
+++ b/lang/python/Jinja2/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Jinja2
-PKG_VERSION:=2.9.6
+PKG_VERSION:=2.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/90/61/f820ff0076a2599dd39406dcb858ecb239438c02ce706c8e91131ab9c7f1/
-PKG_HASH:=ddaa01a212cd6d641401cb01b605f4a4d9f37bfc93043d7f760ec70fb99ff9ff
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/J/Jinja2
+PKG_HASH:=f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4
 PKG_BUILD_DEPENDS:=python3
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @dangowrt 

Compile tested:
mvebu (cortex-a9_vfpv3) , Turris Omnia, OpenWrt 18.06.02
cortexa53, Turris MOX, OpenWrt 18.06.02
Run tested:
mvebu (cortex-a9_vfpv3) , Turris Omnia, OpenWrt 18.06.02
cortexa53, Turris MOX, OpenWrt 18.06.02

Description:
- backport update [Jinja2 to version 2.10](https://github.com/pallets/jinja/releases) from [OpenWrt master](https://github.com/openwrt/packages/pull/7385) to OpenWrt 18.06.02.
