### PR TITLE
misc python packages: fix circular dependencies

### DIFF
--- a/lang/python/click-log/Makefile
+++ b/lang/python/click-log/Makefile
@@ -23,7 +23,7 @@ define Package/python3-click-log
   SUBMENU:=Python
   URL:=http://github.com/mitsuhiko/click
   TITLE:=python3-click-log
-  DEPENDS:=+PACKAGE_python3-click-log:python3-click
+  DEPENDS:=+python3-click
   VARIANT:=python3
 endef
 

--- a/lang/python/python-chardet/Makefile
+++ b/lang/python/python-chardet/Makefile
@@ -23,7 +23,7 @@ include ../python3-package.mk
 
 PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
-define Package/python-chardet/Defaults
+define Package/python-chardet/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages

--- a/lang/python/python-ply/Makefile
+++ b/lang/python/python-ply/Makefile
@@ -44,7 +44,7 @@ endef
 
 define Package/python3-ply
 $(call Package/python-ply/Default)
-  DEPENDS:=+PACKAGE_python3-ply:python3-light
+  DEPENDS:=+python3-light
   VARIANT:=python3
 endef
 

--- a/lang/python/python-requests/Makefile
+++ b/lang/python/python-requests/Makefile
@@ -25,11 +25,11 @@ include ../python3-package.mk
 
 PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
-define Package/python-requests/Defaults
+define Package/python-requests/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>, Alexandru Ardelean <ardeleanalex@gmail.com>
+  MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>, Alexandru Ardelean <ardeleanalex@gmail.com>
   URL:=http://python-requests.org/
 endef
 
@@ -49,11 +49,11 @@ define Package/python3-requests
 $(call Package/python-requests/Default)
   TITLE:=HTTP library for Python3
   DEPENDS:= \
-	  +PACKAGE_python3-requests:python3-light  \
-	  +PACKAGE_python3-requests:python3-chardet  \
-	  +PACKAGE_python3-requests:python3-idna  \
-	  +PACKAGE_python3-requests:python3-urllib3  \
-	  +PACKAGE_python3-requests:python3-certifi
+	  +python3-light  \
+	  +python3-chardet  \
+	  +python3-idna  \
+	  +python3-urllib3  \
+	  +python3-certifi
   VARIANT:=python3
 endef
 

--- a/lang/python/python-simplejson/Makefile
+++ b/lang/python/python-simplejson/Makefile
@@ -34,7 +34,7 @@ endef
 define Package/python-simplejson
 $(call Package/python-simplejson/Default)
   TITLE:=Simple, fast, extensible JSON encoder/decoder for Python 2
-  DEPENDS:=+PACKAGE_python-simplejson:python-light
+  DEPENDS:=+python-light
   VARIANT:=python
 endef
 


### PR DESCRIPTION
Maintainers: @commodo, @Cynerd, @BKPepe, @jefferyto 
Compile tested: none (checked dependencies with a `make defconfig`)
Run tested: none

Description:
After the addition of several python packages, as well as python version additions to existing packages, the build system was filled with circular dependencies.  This was reported in #8392, with a log of the error messages.  They are all caused by conditional dependencies to the packages themselves.  See my comment in #8392.  It is a build-time optimization to avoid the need to compile both versions of python when you're interested in only one.  The resulting packages should not be affected.

I walked down the commits, and performed a "minimal fix": if the package had python & python3 versions, but only one of them was affected, I only changed the latter.  It **may** be possible to edit some other package and obtain the same result, but I haven't investigated that option.

I'm opening just one PR, and adding multiple commits, as the changes themselves are trivial.  If someone opposes to this, I will open individual PRs.  I also found a couple of typos in Makefiles, and I've fixed them here as well.

I don't expect these changes to affect compilation, as the optimization I'm cancelling only avoids to build an unnecessary package. For that reason, I'm not incrementing package revisions, and haven't run a full compile test yet, but I'm working on it, and will post any anomalies.

Fixes #8392