### PR TITLE
php7: Add PKG_CPE_ID for proper CVE tracking

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -13,6 +13,7 @@ PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 
 PKG_LICENSE:=PHPv3.01
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: N/A
Run tested:  N/A

Description:
This PR adds PKG_CPE_ID for CVE tracking since version 7.2.14 also fixed  multiple security issues http://php.net/ChangeLog-7.php#7.2.14

GD module:
CVE-2016-10166, CVE-2019-6977

Mbstring module:
CVE-2019-9023, CVE-2019-9023, CVE-2019-9023, CVE-2019-9023, CVE-2019-9023, CVE-2019-9023 and CVE-2019-9023

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>