### PR TITLE
luasql: fix variants LDFLAGS

### DIFF
--- a/lang/luasql/Makefile
+++ b/lang/luasql/Makefile
@@ -82,21 +82,19 @@ TARGET_CFLAGS += $(FPIC) -std=gnu99
 TARGET_CPPFLAGS += -DLUA_USE_LINUX
 
 ifeq ($(BUILD_VARIANT),mysql)
-  TARGET_CPPFLAGS += -I$(STAGING_DIR)/usr/include/mysql
-  TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib/mysql -lmysqlclient -lz
+  MAKE_FLAGS += DRIVER_INCS_mysql='-I$(STAGING_DIR)/usr/include/mysql' \
+		DRIVER_LIBS_mysql='$(TARGET_LDFLAGS) -L$(STAGING_DIR)/usr/lib/mysql -lmysqlclient -lz'
 endif
 
 ifeq ($(BUILD_VARIANT),postgres)
-  TARGET_LDFLAGS += -lpq
+  MAKE_FLAGS += DRIVER_LIBS_postgres='$(TARGET_LDFLAGS) -lpq'
 endif
 
 ifeq ($(BUILD_VARIANT),sqlite3)
-  TARGET_LDFLAGS += -lsqlite3 -lpthread
+  MAKE_FLAGS += DRIVER_LIBS_sqlite='$(TARGET_LDFLAGS) -lsqlite3 -lpthread'
 endif
 
 MAKE_FLAGS += \
-	DRIVER_INCS="$(TARGET_CPPFLAGS)" \
-	DRIVER_LIBS="$(TARGET_LDFLAGS)" \
 	CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)" \
 	$(BUILD_VARIANT)
 


### PR DESCRIPTION
Maintainer: none
Compile tested: mvebu, WRT3200ACM, openwrt master
Run tested:  none

Description:
The driver flags should be passed in `DRIVER_INCS_variant`, and `DRIVER_LIBS_variant`.
Otherwise, it may pick up the system libraries, leading to compilation error such as:
```
arm-openwrt-linux-muslgnueabi-gcc -Os -pipe -mcpu=cortex-a9 -mfpu=vfpv3-d16 -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -mfloat-abi=hard -iremap/home/equeiroz/src/openwrt-wrt3200acm/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/luasql-mysql/luasql-2.4.0:luasql-2.4.0 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -fpic -std=gnu99 -I/home/equeiroz/src/openwrt-wrt3200acm/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/include -I/home/equeiroz/src/openwrt-wrt3200acm/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/include -I/home/equeiroz/src/openwrt-wrt3200acm/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/usr/include -I/home/equeiroz/src/openwrt-wrt3200acm/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/include/fortify -I/home/equeiroz/src/openwrt-wrt3200acm/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/include -DLUA_USE_LINUX -I/home/equeiroz/src/openwrt-wrt3200acm/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/include/mysql src/ls_mysql.c -o src/mysql.so -shared src/luasql.o -I/usr/include/mysql -L/usr/lib -lmysqlclient -lz
/usr/lib/libmysqlclient.so: file not recognized: file format not recognized
collect2: error: ld returned 1 exit status
```
This does not change binaries, so package revision is left unchanged.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>