### PR TITLE
libv4l: avoid libelf dependency

### DIFF
--- a/libs/libv4l/Makefile
+++ b/libs/libv4l/Makefile
@@ -76,6 +76,7 @@ TARGET_CFLAGS += -flto
 TARGET_LDFLAGS += -largp -Wl,--gc-sections
 
 CONFIGURE_ARGS+= \
+	--disable-bpf \
 	--disable-doxygen-doc \
 	--disable-libdvbv5 \
 	--disable-qv4l2 \


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: mvebu, wrt3200acm, openwrt master
Run tested: none, but checked resulting binaries, with and without the patch (making sure libelf was not built), and they match.

Description:
Explicitly disable bpf support to avoid picking up libelf dependency.
Otherwise, package fails to build with
```
Package v4l-utils is missing dependencies for the following libraries:
libelf.so.1
```
I've checked the resulting binaries, before and after the patch (making sure libelf was not built), and they match.

Note that bpf support is dependent on libelf, so one can't have it built without creating the libelf dependency (from `configure`):
```
 if test x$enable_bpf != xno -a x$libelf_pkgconfig = xyes -a x$CLANG = xclang; then
  WITH_BPF_TRUE=
  WITH_BPF_FALSE='#'
else
  WITH_BPF_TRUE='#'
  WITH_BPF_FALSE=
fi
```
Therefore, we don't need to increase PKG_RELEASE.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
