### PR TITLE
krb5: update to 1.17

### DIFF
--- a/net/krb5/Makefile
+++ b/net/krb5/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=krb5
-PKG_VERSION:=1.16.2
+PKG_VERSION:=1.17
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -17,8 +17,8 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=NOTICE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://web.mit.edu/kerberos/dist/krb5/1.16
-PKG_HASH:=9f721e1fe593c219174740c71de514c7228a97d23eb7be7597b2ae14e487f027
+PKG_SOURCE_URL:=https://web.mit.edu/kerberos/dist/krb5/1.17
+PKG_HASH:=5a6e2284a53de5702d3dc2be3b9339c963f9b5397d3fbbc53beb249380a781f5
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -134,6 +134,10 @@ define Package/krb5-server/install
 #	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kpropd $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/krb5kdc $(1)/usr/sbin
 #	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/sim_server $(1)/usr/sbin
+endef
+
+define Package/krb5-server/postinst
+touch $${IPKG_INSTROOT}/etc/krb5kdc/kadm5.acl
 endef
 
 $(eval $(call BuildPackage,krb5-libs))


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_65 master
Run tested: x86_64 master

Description:
krb5: update to 1.17
