### PR TITLE
gst1-plugins-base: update to 1.15.2

### DIFF
--- a/multimedia/gst1-plugins-base/Makefile
+++ b/multimedia/gst1-plugins-base/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-base
-PKG_VERSION:=1.14.4
+PKG_VERSION:=1.15.2
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
@@ -20,7 +20,7 @@ PKG_LICENSE_FILES:=COPYING.LIB COPYING
 PKG_BUILD_DIR:=$(BUILD_DIR)/gst-plugins-base-$(PKG_VERSION)
 PKG_SOURCE:=gst-plugins-base-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://gstreamer.freedesktop.org/src/gst-plugins-base
-PKG_HASH:=ca6139490e48863e7706d870ff4e8ac9f417b56f3b9e4b3ce490c13b09a77461
+PKG_HASH:=6952be988abe67b5affd46b194e97863b160cd58846199873b4315fe5e1cdbf0
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_gst1-mod-alsa \
@@ -148,6 +148,8 @@ CONFIGURE_ARGS += \
 	--without-x \
 	\
 	--with-audioresample-format=int \
+
+TARGET_CFLAGS += -Wno-format-nonliteral
 
 EXTRA_LDFLAGS+= \
 	-Wl,-rpath-link=$(STAGING_DIR)/usr/lib \

--- a/multimedia/gst1-plugins-base/patches/001-no-translations.patch
+++ b/multimedia/gst1-plugins-base/patches/001-no-translations.patch
@@ -1,24 +1,7 @@
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -13,7 +13,6 @@ SUBDIRS = 			\
- 	tools 			\
- 	tests 			\
- 	docs			\
--	po 			\
- 	common 			\
- 	m4
- 
-@@ -24,7 +23,6 @@ DIST_SUBDIRS = 			\
- 	gst sys ext		\
- 	tools 			\
- 	tests 			\
--	po 			\
- 	common 			\
- 	m4
- 
---- a/configure.ac
-+++ b/configure.ac
-@@ -1030,7 +1030,6 @@ docs/Makefile
+diff -u --recursive gst-plugins-base-1.15.2-vanilla/configure.ac gst-plugins-base-1.15.2/configure.ac
+--- gst-plugins-base-1.15.2-vanilla/configure.ac	2019-02-26 06:39:03.000000000 -0500
++++ gst-plugins-base-1.15.2/configure.ac	2019-03-16 13:30:18.212618930 -0400
+@@ -1044,7 +1044,6 @@
  docs/libs/Makefile
  docs/plugins/Makefile
  docs/version.entities
@@ -26,3 +9,22 @@
  common/Makefile
  common/m4/Makefile
  m4/Makefile
+diff -u --recursive gst-plugins-base-1.15.2-vanilla/Makefile.am gst-plugins-base-1.15.2/Makefile.am
+--- gst-plugins-base-1.15.2-vanilla/Makefile.am	2019-01-26 13:51:01.000000000 -0500
++++ gst-plugins-base-1.15.2/Makefile.am	2019-03-16 13:30:03.006572636 -0400
+@@ -13,7 +13,6 @@
+ 	tools 			\
+ 	tests 			\
+ 	docs			\
+-	po 			\
+ 	common 			\
+ 	m4
+ 
+@@ -24,7 +23,6 @@
+ 	gst sys ext		\
+ 	tools 			\
+ 	tests 			\
+-	po 			\
+ 	common 			\
+ 	m4
+ 

--- a/multimedia/gst1-plugins-base/patches/002-no-tests.patch
+++ b/multimedia/gst1-plugins-base/patches/002-no-tests.patch
@@ -1,24 +1,7 @@
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -11,7 +11,6 @@ SUBDIRS = 			\
- 	gst-libs 		\
- 	gst sys $(SUBDIRS_EXT) 	\
- 	tools 			\
--	tests 			\
- 	docs			\
- 	common 			\
- 	m4
-@@ -22,7 +21,6 @@ DIST_SUBDIRS = 			\
- 	gst-libs		\
- 	gst sys ext		\
- 	tools 			\
--	tests 			\
- 	common 			\
- 	m4
- 
---- a/configure.ac
-+++ b/configure.ac
-@@ -992,40 +992,6 @@ pkgconfig/gstreamer-gl.pc
+diff -u --recursive gst-plugins-base-1.15.2-vanilla/configure.ac gst-plugins-base-1.15.2/configure.ac
+--- gst-plugins-base-1.15.2-vanilla/configure.ac	2019-03-16 13:40:28.843441622 -0400
++++ gst-plugins-base-1.15.2/configure.ac	2019-03-16 13:41:14.880578949 -0400
+@@ -1005,41 +1005,6 @@
  pkgconfig/gstreamer-gl-uninstalled.pc
  pkgconfig/gstreamer-plugins-base.pc
  pkgconfig/gstreamer-plugins-base-uninstalled.pc
@@ -27,6 +10,7 @@
 -tests/examples/Makefile
 -tests/examples/app/Makefile
 -tests/examples/audio/Makefile
+-tests/examples/compositor/Makefile
 -tests/examples/decodebin_next/Makefile
 -tests/examples/dynamic/Makefile
 -tests/examples/encoding/Makefile
@@ -47,8 +31,8 @@
 -tests/examples/gl/gtk/filtervideooverlay/Makefile
 -tests/examples/gl/cocoa/Makefile
 -tests/examples/gl/sdl/Makefile
--tests/examples/gl/clutter/Makefile
 -tests/examples/overlay/Makefile
+-tests/examples/overlaycomposition/Makefile
 -tests/examples/seek/Makefile
 -tests/examples/snapshot/Makefile
 -tests/examples/playback/Makefile
@@ -59,3 +43,22 @@
  docs/Makefile
  docs/libs/Makefile
  docs/plugins/Makefile
+diff -u --recursive gst-plugins-base-1.15.2-vanilla/Makefile.am gst-plugins-base-1.15.2/Makefile.am
+--- gst-plugins-base-1.15.2-vanilla/Makefile.am	2019-03-16 13:40:28.864441684 -0400
++++ gst-plugins-base-1.15.2/Makefile.am	2019-03-16 13:41:27.970617996 -0400
+@@ -11,7 +11,6 @@
+ 	gst-libs 		\
+ 	gst sys $(SUBDIRS_EXT) 	\
+ 	tools 			\
+-	tests 			\
+ 	docs			\
+ 	common 			\
+ 	m4
+@@ -22,7 +21,6 @@
+ 	gst-libs		\
+ 	gst sys ext		\
+ 	tools 			\
+-	tests 			\
+ 	common 			\
+ 	m4
+ 


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64 master
Run tested: x86_64 master

Description:
gst1-plugins-base: update to 1.15.2