### PR TITLE
stubby: fixed duplicate IPv6 address and typo

### DIFF
--- a/net/stubby/files/README.md
+++ b/net/stubby/files/README.md
@@ -388,7 +388,7 @@ the supplied server certificate
 #### `list spki`
 
 This list specifies the SPKI pinset which is verified against the keys in the
-server cerrtificate. The values takes the form `'<digest type>/value>'`, where
+server cerrtificate. The value takes the form `'<digest type>/value>'`, where
 the `digest type` is the hashing algorithm used, and the value is the Base64
 encoded hash of the public key. At present, only `sha256` is
 supported for the digest type.

--- a/net/stubby/files/stubby.yml
+++ b/net/stubby/files/stubby.yml
@@ -17,7 +17,7 @@ dns_transport_list:
 upstream_recursive_servers:
   - address_data: 2606:4700:4700::1111
     tls_auth_name: "cloudflare-dns.com"
-  - address_data: 2606:4700:4700::1111
+  - address_data: 2606:4700:4700::1001
     tls_auth_name: "cloudflare-dns.com"
   - address_data: 1.1.1.1
     tls_auth_name: "cloudflare-dns.com"


### PR DESCRIPTION
Maintainer: @jonathanunderwood

Description:

In `stubby.yml` there was probably a copying mistake, listing the same IPv6 of Cloudflare twice. I fixed that. Besides, a small typo in `README.md` was fixed.