### PR TITLE
seafile-server: fix install, django 1.11 patch, enhance seafile-seahub version dependency

### DIFF
--- a/net/seafile-server/Config.in
+++ b/net/seafile-server/Config.in
@@ -9,8 +9,4 @@ config SEAFILE_FUSE_SUPPORT
 config SEAFILE_CONSOLE_SUPPORT
 	bool "Enable seafile server console"
 	default n
-
-config SEAFILE_RIAK_SUPPORT
-	bool "Enable support for riak backend"
-	default n
 endmenu

--- a/net/seafile-server/Makefile
+++ b/net/seafile-server/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-server
 PKG_VERSION:=6.3.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-3.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -24,6 +24,15 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 include ../../lang/python/python-package.mk
 
+# Check that the actual Makefile version-relase match the above.
+$(eval $(shell awk '/^PKG_VERSION.*=/ { print "SEAHUB_" $$$$0 }' ../seafile-seahub/Makefile))
+ifneq ($(PKG_VERSION),$(SEAHUB_PKG_VERSION))
+    $(error $(if $(SEAHUB_PKG_VERSION), \
+		Version mismatch between seafile-seahub ($(SEAHUB_PKG_VERSION)) and \
+		seafile-server ($(PKG_VERSION)), \
+		Could not get PKG_VERSION from seafile-seahub Makefile))
+endif
+
 define Package/seafile-server
     SECTION:=net
     CATEGORY:=Network
@@ -33,7 +42,6 @@ define Package/seafile-server
     DEPENDS:=+libarchive +libopenssl +glib2 +libsearpc +seafile-ccnet +seafile-seahub +sqlite3-cli +python-mysql +python-urllib3 \
 		+jansson +libevent2 +libevent2-openssl +zlib +libzdb +libsqlite3 +libmysqlclient \
 		+libpthread +libuuid +bash +procps-ng +procps-ng-pkill +SEAFILE_FUSE_SUPPORT:libfuse $(ICONV_DEPENDS)
-    EXTRA_DEPENDS:=seafile-seahub (=6.3.4-1)
     MENU:=1
 endef
 
@@ -45,11 +53,7 @@ define Package/seafile-server/description
    Open source cloud storage with advanced features on privacy protection and teamwork.
 endef
 
-CONFIGURE_ARGS += --disable-client \
-		    --enable-server \
-		    --enable-python \
-		    --disable-static-build \
-		    --disable-server-pkg
+CONFIGURE_ARGS += --enable-python
 
 ifeq ($(CONFIG_SEAFILE_FUSE_SUPPORT),y)
 	CONFIGURE_ARGS += --enable-fuse
@@ -62,12 +66,6 @@ ifeq ($(CONFIG_SEAFILE_CONSOLE_SUPPORT),y)
 	CONFIGURE_ARGS += --enable-console
 else
 	CONFIGURE_ARGS += --disable-console
-endif
-
-ifeq ($(CONFIG_SEAFILE_RIAK_SUPPORT),y)
-	CONFIGURE_ARGS += --enable-riak
-else
-	CONFIGURE_ARGS += --disable-riak
 endif
 
 PKG_BUILD_DEPENDS:=vala/host libevhtp

--- a/net/seafile-server/patches/090-django-11-compat.patch
+++ b/net/seafile-server/patches/090-django-11-compat.patch
@@ -1,17 +1,56 @@
+From 115a4583deb9ae11adbc419ea87c990d0b8572fe Mon Sep 17 00:00:00 2001
+From: Joffrey Darcq <j-off@live.fr>
+Date: Sat, 28 Apr 2018 22:27:28 +0200
+Subject: [PATCH 1/2] fix django version 1.11
+
+---
+ tools/seafile-admin | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
 diff --git a/tools/seafile-admin b/tools/seafile-admin
-index 495ceab..72b6a07 100755
+index 5e3658b..38e7288 100755
 --- a/tools/seafile-admin
 +++ b/tools/seafile-admin
-@@ -502,7 +502,7 @@ def init_seahub():
+@@ -518,10 +518,10 @@ def init_seahub():
+ 
+ 
+ def check_django_version():
+-    '''Requires django 1.8'''
++    '''Requires django 1.11'''
+     import django
+-    if django.VERSION[0] != 1 or django.VERSION[1] != 8:
+-        error('Django 1.8 is required')
++    if django.VERSION[0] != 1 or django.VERSION[1] != 11:
++        error('Django 1.11 is required')
+     del django
+ 
+ 
+
+From bf69ff1cf1080081eae5d8115842c26468746736 Mon Sep 17 00:00:00 2001
+From: Joffrey Darcq <j-off@live.fr>
+Date: Sun, 3 Jun 2018 15:51:54 +0200
+Subject: [PATCH 2/2] fix django version 1.11
+
+---
+ tools/seafile-admin | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tools/seafile-admin b/tools/seafile-admin
+index 38e7288..c16aab6 100755
+--- a/tools/seafile-admin
++++ b/tools/seafile-admin
+@@ -499,8 +499,8 @@ def init_seahub():
      # create seahub_settings.py
      create_seahub_settings_py()
  
 -    argv = [PYTHON, 'manage.py', 'syncdb']
+-    # Set proper PYTHONPATH before run django syncdb command
 +    argv = [PYTHON, 'manage.py', 'migrate']
-     # Set proper PYTHONPATH before run django syncdb command
++    # Set proper PYTHONPATH before run django migrate command
      env = get_seahub_env()
  
-@@ -512,7 +512,7 @@ def init_seahub():
+     print
+@@ -509,7 +509,7 @@ def init_seahub():
      print
  
      if run_argv(argv, cwd=seahub_dir, env=env) != 0:


### PR DESCRIPTION
Maintainer: @kissg1988 
Compile tested: mvebu, wrt3200acm, openwrt master
Run tested: mvebu, wrt3200acm, openwrt master, tested basic file creation/upload/download, using web interface.

Description:
Current package does not get installed because it pulls up an incorrect seafile-seahub release, resulting in:
```
Collected errors:
 * satisfy_dependencies_for: Cannot satisfy the following dependencies for seafile-server:
 *      seafile-seahub (= 6.3.4-1)
 * opkg_install_cmd: Cannot install package seafile-server.
```
Added a build-time check in seafile-server to error out if the versions don't match, instead of a static install-time check.

Django 1.11 is supported (required?), see https://manual.seafile.com/changelog/server-changelog.html), but the current patch does not fix a bug in the `seafile-admin` script that causes it to still look for v. 1.8.  Replaced current patch for django-1.11 with the patch from haiwen/seafile-server#147, which fixes this, avoiding this error message when setting up:
```
*** Installation completed, running configuration script...
-----------------------------------------------------------------
This script will guide you to config and setup your seafile server.
Make sure you have read seafile server manual at

        https://github.com/haiwen/seafile/wiki

Press [ENTER] to continue
-----------------------------------------------------------------


check python modules ...
Error: Django 1.8 is required
```

Cleaned up unsupported configure options, including riak backend, for which we don't have a package.  Here's the build message:
```
configure: WARNING: unrecognized options: --disable-nls, --disable-client, --enable-server, --disable-static-build, --disable-server-pkg, --disable-riak
```
Notice that you can try to build the riak backend by defining `RIAK_BACKEND` in `CFLAGS`.  However, it would fail to build since we don't package the riak client library (or anything that installs `riak-client.h`).

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>