### PR TITLE
python-requests-oauthlib: update to 1.2.0; python-oauthlib: update to 3.0.1

### DIFF
--- a/lang/python/python-oauthlib/Makefile
+++ b/lang/python/python-oauthlib/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-oauthlib
-PKG_VERSION:=2.1.0
-PKG_RELEASE:=2
+PKG_VERSION:=3.0.1
+PKG_RELEASE:=1
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=oauthlib-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/o/oauthlib
-PKG_HASH:=ac35665a61c1685c56336bda97d5eefa246f1202618a1d6f34fccb1bdd404162
+PKG_HASH:=0ce32c5d989a1827e3f1148f98b9085ed2370fc939bf524c9c851d8714797298
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-oauthlib-$(PKG_VERSION)
 PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 

--- a/lang/python/python-requests-oauthlib/Makefile
+++ b/lang/python/python-requests-oauthlib/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-requests-oauthlib
-PKG_VERSION:=1.0.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.2.0
+PKG_RELEASE:=1
 PKG_LICENSE:=ISC
 
 PKG_SOURCE:=requests-oauthlib-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/r/requests-oauthlib
-PKG_HASH:=8886bfec5ad7afb391ed5443b1f697c6f4ae98d0e5620839d8b4499c032ada3f
+PKG_HASH:=bd6533330e8748e94bf0b214775fed487d309b8b8fe823dc45641ebcd9a32f57
 PKG_BUILD_DIR:=$(BUILD_DIR)/requests-oauthlib-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, wrt3200acm, openwrt master
Run tested: mvebu, wrt3200acm, openwrt master; tested with seafile-server, using oauth to authenticate

Description:
These updates should be done simultaneously to avoid interoperability problems.  They are used by the seafile-server package.