### PR TITLE
python-qrcode: bump to 6.1, fix dependencies

### DIFF
--- a/lang/python/python-qrcode/Makefile
+++ b/lang/python/python-qrcode/Makefile
@@ -8,14 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-qrcode
-PKG_VERSION:=6.0
+PKG_VERSION:=6.1
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=qrcode-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/8d/b6/beed3d50e1047a2aa6437d3a653e5f31feb7f4de8bc054299dc205682e41
-PKG_HASH:=037b0db4c93f44586e37f84c3da3f763874fcac85b2974a69a98e399ac78e1bf
-PKG_BUILD_DIR:=$(BUILD_DIR)/qrcode-$(PKG_VERSION)
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/q/qrcode/
+PKG_HASH:=505253854f607f2abf4d16092c61d4e9d511a3b4392e60bff957a68592b04369
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-oauthlib-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
@@ -27,22 +28,14 @@ define Package/python-qrcode
   MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
   TITLE:=QR Code image generator
   URL:=https://github.com/lincolnloop/python-qrcode
-  DEPENDS:=+python +python-six
+  DEPENDS:=+python +python-six +python-setuptools +pillow
+  VARIANT:=python
 endef
 
 define Package/python-qrcode/description
   Pure python QR Code generator
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/python-qrcode/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,python-qrcode))
 $(eval $(call BuildPackage,python-qrcode))
+$(eval $(call BuildPackage,python-qrcode-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, wrt3200acm, openwrt master
Run tested: mvebu, wrt3200acm, openwrt master, tested with seafile, and also `qr "Some text" > test.png` as done by @BKPepe 

Description:
The package was missing dependencies on pillow and python-setuptools.
While there's #8337 with the intent to update and also add python3 compatibility, this one is ready to go with just the version bump.

The Makefile was simplified.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

