### PR TITLE
libssh2 (17.01): version bump/CVE fixes

### DIFF
--- a/libs/libssh2/Makefile
+++ b/libs/libssh2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libssh2
-PKG_VERSION:=1.7.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.8.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.libssh2.org/download
-PKG_MD5SUM:=b01662a210e94cccf2f76094db7dac5c
+PKG_HASH:=40b517f35b1bb869d0075b15125c7a015557f53a5a3a6a8bffb89b69fd70f159
 
 PKG_INSTALL:=1
 
@@ -35,12 +35,11 @@ define Package/libssh2/description
  libssh2 is a client-side C library implementing the SSH2 protocol.
 endef
 
-TARGET_CFLAGS += $(FPIC)
-
 CONFIGURE_ARGS += \
 	--disable-examples-build \
 	--with-libssl-prefix=$(STAGING_DIR)/usr \
-	--with-libz-prefix=$(STAGING_DIR)/usr
+	--with-libz-prefix=$(STAGING_DIR)/usr \
+	--with-openssl
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
- CVE-2019-3855
  Possible integer overflow in transport read allows out-of-bounds write

- CVE-2019-3856
  Possible integer overflow in keyboard interactive handling allows
  out-of-bounds write

- CVE-2019-3857
  Possible integer overflow leading to zero-byte allocation and out-of-bounds
  write

- CVE-2019-3858
  Possible zero-byte allocation leading to an out-of-bounds read

- CVE-2019-3859
  Out-of-bounds reads with specially crafted payloads due to unchecked use of
  `_libssh2_packet_require` and `_libssh2_packet_requirev`

- CVE-2019-3860
  Out-of-bounds reads with specially crafted SFTP packets

- CVE-2019-3861
  Out-of-bounds reads with specially crafted SSH packets

- CVE-2019-3862
  Out-of-bounds memory comparison

- CVE-2019-3863
  Integer overflow in user authenicate keyboard interactive allows
  out-of-bounds writes

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @jslachta 
Compile tested: ar71xx, 17.01
Run tested: sort of, on master, same as with the other pull requests

Description:
Hello Jiri,

I tried to apply the 9 upstream patches from the [announcement](https://www.openwall.com/lists/oss-security/2019/03/18/3).  But some of these didn't apply properly and then there was compile failure. So I'd suggest that the version is bumped from 1.7.0 to 1.8.1. This shouldn't be a problem because ABI didn't change, see [here](https://abi-laboratory.pro/?view=timeline&l=libssh2).

Anyway, just a suggestion.

Kind regards,
Seb