### PR TITLE
routing-yggdrasil: add package

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -1,0 +1,112 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=yggdrasil
+PKG_VERSION:=0.3.5
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=2c69029adeb053ad049e90f1e4b7efa986094779868da77464d3c869984e861b
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-go-$(PKG_VERSION)
+
+PKG_LICENSE:=GPL-3.0
+PKG_MAINTAINER:=William Fleurant <meshnet@protonmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/yggdrasil
+	SECTION:=net
+	CATEGORY:=Network
+	SUBMENU:=Routing and Redirection
+	TITLE:=Yggdrasil supports end-to-end encrypted IPv6 networks
+	URL:=https://yggdrasil-network.github.io/
+	DEPENDS:=$(GO_ARCH_DEPENDS) @IPV6 +kmod-tun +@(mips):KERNEL_MIPS_FPU_EMULATOR
+	PKGARCH:=all
+endef
+
+define Package/yggdrasil/description
+ Yggdrasil builds end-to-end encrypted networks with IPv6.
+ Beyond the similarities with cjdns is a different routing
+ algorithm. This globally-agreed spanning tree uses greedy
+ routing in a metric space. Back-pressure routing techniques
+ allow advanced link aggregation bonding on per-stream basis.
+ In turn, a single stream will span across multiple network
+ interfaces simultaneously with much greater throughput.
+endef
+
+ifeq ($(ARCH),aarch64)
+	GOARCH:=arm64
+endif
+
+ifeq ($(ARCH),arc)
+	GOARCH:=risc
+endif
+
+ifeq ($(ARCH),arc)
+	GOARCH:=risc
+endif
+
+ifeq ($(ARCH),arm)
+	GOARCH:=arm
+endif
+
+ifeq ($(ARCH),armeb)
+	GOARCH:=armbe
+endif
+
+ifeq ($(ARCH),i386)
+	GOARCH:=386
+endif
+
+ifeq ($(ARCH),mips)
+	GOARCH:=mips
+endif
+
+ifeq ($(ARCH),mips64)
+	GOARCH:=mips64
+endif
+
+ifeq ($(ARCH),mipsel)
+	GOARCH:=mipsle
+endif
+
+ifeq ($(ARCH),powerpc)
+	GOARCH:=ppc64
+endif
+
+define Build/Compile
+	cd $(PKG_BUILD_DIR) && \
+	GOOS="linux" \
+	GOARCH="$(GOARCH)" \
+	PKGVER="$(PKG_VERSION)" \
+	PKGNAME="yggdrasil-openwrt" \
+	$(PKG_BUILD_DIR)/build
+endef
+
+define Package/yggdrasil/install
+	$(INSTALL_DIR) \
+		$(1)/etc/init.d \
+		$(1)/etc/uci-defaults \
+		$(1)/usr/sbin
+
+	$(INSTALL_BIN) \
+		$(PKG_BUILD_DIR)/yggdrasil \
+		$(1)/usr/sbin
+
+	$(INSTALL_BIN) \
+		$(PKG_BUILD_DIR)/yggdrasilctl \
+		$(1)/usr/sbin
+
+	$(INSTALL_BIN) \
+		./files/yggdrasil.defaults \
+		$(1)/etc/uci-defaults/yggdrasil
+
+	$(INSTALL_BIN) \
+		./files/yggdrasil.init \
+		$(1)/etc/init.d/yggdrasil
+endef
+
+$(eval $(call BuildPackage,yggdrasil))

--- a/net/yggdrasil/files/yggdrasil.defaults
+++ b/net/yggdrasil/files/yggdrasil.defaults
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+yggConfig="/etc/yggdrasil.conf"
+
+if [ ! -e ${yggConfig} ]; then
+
+  yggdrasil -genconf -json > ${yggConfig}
+
+  # create the firewall zone
+  uci -q batch <<-EOF >/dev/null
+    add firewall zone
+    set firewall.@zone[-1].name=yggdrasil
+    add_list firewall.@zone[-1].network=yggdrasil
+    set firewall.@zone[-1].input=REJECT
+    set firewall.@zone[-1].output=ACCEPT
+    set firewall.@zone[-1].forward=REJECT
+    set firewall.@zone[-1].conntrack=1
+    set firewall.@zone[-1].family=ipv6
+EOF
+
+  # allow ICMP from yggdrasil zone, e.g. ping6
+  uci -q batch <<-EOF >/dev/null
+    add firewall rule
+    set firewall.@rule[-1].name='Allow-ICMPv6-yggdrasil'
+    set firewall.@rule[-1].src=yggdrasil
+    set firewall.@rule[-1].proto=icmp
+    add_list firewall.@rule[-1].icmp_type=echo-request
+    add_list firewall.@rule[-1].icmp_type=echo-reply
+    add_list firewall.@rule[-1].icmp_type=destination-unreachable
+    add_list firewall.@rule[-1].icmp_type=packet-too-big
+    add_list firewall.@rule[-1].icmp_type=time-exceeded
+    add_list firewall.@rule[-1].icmp_type=bad-header
+    add_list firewall.@rule[-1].icmp_type=unknown-header-type
+    set firewall.@rule[-1].limit='1000/sec'
+    set firewall.@rule[-1].family=ipv6
+    set firewall.@rule[-1].target=ACCEPT
+EOF
+
+  # allow SSH from yggdrasil zone, needs to be explicitly enabled
+  uci -q batch <<-EOF >/dev/null
+    add firewall rule
+    set firewall.@rule[-1].enabled=0
+    set firewall.@rule[-1].name='Allow-SSH-yggdrasil'
+    set firewall.@rule[-1].src=yggdrasil
+    set firewall.@rule[-1].proto=tcp
+    set firewall.@rule[-1].dest_port=22
+    set firewall.@rule[-1].target=ACCEPT
+EOF
+
+  # allow LuCI access from yggdrasil zone, needs to be explicitly enabled
+  uci -q batch <<-EOF >/dev/null
+    add firewall rule
+    set firewall.@rule[-1].enabled=0
+    set firewall.@rule[-1].name='Allow-HTTP-yggdrasil'
+    set firewall.@rule[-1].src=yggdrasil
+    set firewall.@rule[-1].proto=tcp
+    set firewall.@rule[-1].dest_port=80
+    set firewall.@rule[-1].target=ACCEPT
+EOF
+
+
+else
+  :
+fi
+
+exit 0

--- a/net/yggdrasil/files/yggdrasil.init
+++ b/net/yggdrasil/files/yggdrasil.init
@@ -1,0 +1,33 @@
+#!/bin/sh /etc/rc.common
+
+START=90
+STOP=85
+
+USE_PROCD=1
+
+start_service()
+{
+	[ -f /etc/uci-defaults/yggdrasil ] && ( . /etc/uci-defaults/yggdrasil )
+
+	procd_open_instance
+	procd_set_param respawn
+	procd_set_param command /usr/sbin/yggdrasil -useconffile /etc/yggdrasil.conf
+    procd_set_param command /bin/ash -c "/usr/sbin/yggdrasil -useconffile /etc/yggdrasil.conf | logger -t yggdrasil"
+
+	procd_close_instance
+}
+
+stop_service()
+{
+	killall yggdrasil
+}
+
+reload_service()
+{
+	restart
+}
+
+service_triggers()
+{
+	procd_add_reload_trigger yggdrasil
+}


### PR DESCRIPTION
Maintainer: @wfleurant

Description:

Yggdrasil builds end-to-end encrypted networks with IPv6. Beyond the
similarities with cjdns is a different routing algorithm. This
globally-agreed spanning tree uses greedy routing in a metric space.
Back-pressure routing techniques allow advanced link aggregation bonding
on per-stream basis.  In turn, a single stream will span across multiple
network interfaces simultaneously with much greater throughput.

Authored by: William Fleurant <meshnet@protonmail.com>
Signed-off-by: Paul Spooren <mail@aparcar.org>