### PR TITLE
luajit: Enable build on arm64

### DIFF
--- a/lang/luajit/Makefile
+++ b/lang/luajit/Makefile
@@ -24,7 +24,7 @@ define Package/luajit
  CATEGORY:=Languages
  TITLE:=LuaJIT
  URL:=https://www.luajit.org
- DEPENDS:=@(i386||x86_64||arm||armeb||powerpc||mips||mipsel)
+ DEPENDS:=@(i386||x86_64||arm||armeb||powerpc||mips||mipsel||aarch64)
 endef
 
 define Package/luajit/description


### PR DESCRIPTION
Maintainer: @milani
Compile tested: Turris Mox
Run tested: Turris Mox

Description:
Luajit is compatible with aarch64.