### PR TITLE
obfs4proxy: Remove build dependencies

### DIFF
--- a/net/obfs4proxy/Makefile
+++ b/net/obfs4proxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=obfs4proxy
 PKG_VERSION:=0.0.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=obfs4-$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gitlab.com/yawning/obfs4/-/archive/$(PKG_NAME)-$(PKG_VERSION)/
@@ -45,12 +45,6 @@ define Package/golang-gitlab-yawning-obfs4-dev
 $(call Package/obfs4proxy/Default)
 $(call GoPackage/GoSubMenu)
   TITLE+= (source files)
-  DEPENDS+= \
-    +golang-github-agl-ed25519-dev \
-    +golang-github-dchest-siphash-dev \
-    +golang-golang-x-crypto-dev \
-    +golang-golang-x-net-dev \
-    +golang-torproject-pluggable-transports-goptlib-dev
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: armvirt-32, 2019-03-18 snapshot sdk
Run tested: none

Description:
The Go compiler can now manage the build dependencies by itself, as obfs4proxy has been ported to a Go module.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>