### PR TITLE
yggdrasil: fix: #8457 depends on HAS_FPU or KERNEL_MIPS_FPU_EMULATOR

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
 PKG_VERSION:=0.3.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -23,7 +23,7 @@ define Package/yggdrasil
 	SUBMENU:=Routing and Redirection
 	TITLE:=Yggdrasil supports end-to-end encrypted IPv6 networks
 	URL:=https://yggdrasil-network.github.io/
-	DEPENDS:=$(GO_ARCH_DEPENDS) @IPV6 +kmod-tun +@(mips):KERNEL_MIPS_FPU_EMULATOR
+	DEPENDS:=$(GO_ARCH_DEPENDS) @IPV6 +kmod-tun @(HAS_FPU||KERNEL_MIPS_FPU_EMULATOR)
 endef
 
 define Package/yggdrasil/description


### PR DESCRIPTION
Maintainer: @wfleurant 
Compile tested: WDR3500 / mips32r2 and x86_64
Run tested: Logic checks out in buildroot. 

Description:
Logic correctly looks to at target FPU support, or if FPU emulation is toggled, if so then the package can be selected.