### PR TITLE
mwan3: fix logical/typo bug in mwan3rtmon

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.7.11
+PKG_VERSION:=2.7.12
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -32,6 +32,8 @@ MM_BLACKHOLE=""
 MMX_UNREACHABLE=""
 MM_UNREACHABLE=""
 
+# return true(=0) if has any mwan3 interface enabled
+# otherwise return false
 mwan3_rtmon_ipv4()
 {
 	local tid=1
@@ -61,6 +63,8 @@ mwan3_rtmon_ipv4()
 	return $ret
 }
 
+# return true(=0) if has any mwan3 interface enabled
+# otherwise return false
 mwan3_rtmon_ipv6()
 {
 	local tid=1

--- a/net/mwan3/files/usr/sbin/mwan3rtmon
+++ b/net/mwan3/files/usr/sbin/mwan3rtmon
@@ -25,14 +25,14 @@ main() {
 	sleep 3
 	while true; do
 		mwan3_lock "service" "mwan3rtmon"
-		[ mwan3_remon_ipv4 = "1" ] || \
-		[ mwan3_rtmon_ipv6 = "1" ] && break
+		mwan3_rtmon_ipv4 || mwan3_rtmon_ipv6
+		ret=$?
 		mwan3_unlock "service" "mwan3rtmon"
+		[ "$ret" = "0" ] || break
 		[ "$rtmon_interval" = "0" ] && break
 		sleep "$rtmon_interval" &
 		wait
 	done
-	mwan3_unlock "service" "mwan3rtmon"
 }
 
 main "$@"


### PR DESCRIPTION
This bug was introduced since dd206b7d0bc4a7de739b6dbccbac5b5ffcae9024
mwan3_remon_ipv4 and mwan3_remon_ipv6 is command to run not a variable
I add some comments on them hopefully people will notice it

Maintainer: me / @feckert 
Compile tested: x86
Run tested: x86

Description:
