### PR TITLE
[OpenWrt 18.06] perlmod: fix ability to build module out-of-feed

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \

--- a/lang/perl/perlmod.mk
+++ b/lang/perl/perlmod.mk
@@ -1,7 +1,11 @@
 # This makefile simplifies perl module builds.
 #
 
-include ../perl/perlver.mk
+ifeq ($(origin PERL_INCLUDE_DIR),undefined)
+  PERL_INCLUDE_DIR:=$(dir $(lastword $(MAKEFILE_LIST)))
+endif
+
+include $(PERL_INCLUDE_DIR)/perlver.mk
 
 ifneq ($(PKG_NAME),perl)
   PKG_VERSION:=$(PKG_VERSION)+perl$(PERL_VERSION2)


### PR DESCRIPTION
Maintainers: @pprindeville and @Naoir
Compile tested: Xiaomi Mi WiFi R3G, ramips, mt7621, OpenWrt 18.06.02
using **openwrt-sdk-18.06.2-ramips-mt7621_gcc-7.3.0_musl.Linux-x86_64**

Fixes https://github.com/openwrt/telephony/issues/364 a lot of users met this issue

While running `  ./scripts/feeds update -a ` it says:

> ERROR: please fix feeds/telephony/net/freeswitch/Makefile - see logs/feeds/telephony/net/freeswitch/dump.txt for details

In dump.txt, there is:
/home/openwrt/openwrt-sdk-18.06.2-ramips-mt7621_gcc-7.3.0_musl.Linux-x86_64/feeds/packages/lang/perl/perlmod.mk:4: ../perl/perlver.mk: No such file or directory

I see, it is fixed in master from @pprindeville and I just cherry-pick it from PR https://github.com/openwrt/packages/pull/7089, which I applied it, it works without a hassle.