### PR TITLE
yggdrasil: fix startup and generate nodeInfo info

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
 PKG_VERSION:=0.3.5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/yggdrasil/files/yggdrasil.defaults
+++ b/net/yggdrasil/files/yggdrasil.defaults
@@ -2,9 +2,42 @@
 
 yggConfig="/etc/yggdrasil.conf"
 
-if [ ! -e ${yggConfig} ]; then
+first_boot_genConfig()
+{
+  . /usr/share/libubox/jshn.sh
+  boardcfg=$(ubus call system board)
+  yggcfg=$(yggdrasil -genconf -json | grep NodeInfo -v)
 
-  yggdrasil -genconf -json > ${yggConfig}
+  json_load "$boardcfg"
+  json_get_var kernel     kernel
+  json_get_var hostname   hostname
+  json_get_var system     system
+  json_get_var model      model
+  json_get_var board_name board_name
+
+  json_load "$yggcfg"
+  json_add_string "IfName" "ygg0"
+  json_add_object "NodeInfo"
+  json_add_string "kernel"      "$kernel"
+  json_add_string "hostname"    "$hostname"
+  json_add_string "system"      "$system"
+  json_add_string "model"       "$model"
+  json_add_string "board_name"  "$board_name"
+  json_close_object
+  json_dump
+}
+
+if [ ! -e ${yggConfig} ]; then
+  echo "first_boot: adding system board details to NodeInfo[] in NEW config: ${yggConfig}" | logger -t yggdrasil
+
+  first_boot_genConfig > ${yggConfig}
+
+  # create the network interface
+  uci -q batch <<-EOF >/dev/null
+    set network.yggdrasil=interface
+    set network.yggdrasil.ifname=ygg0
+    set network.yggdrasil.proto=none
+EOF
 
   # create the firewall zone
   uci -q batch <<-EOF >/dev/null
@@ -58,6 +91,8 @@ EOF
     set firewall.@rule[-1].target=ACCEPT
 EOF
 
+  uci commit firewall
+  uci commit network
 
 else
   :

--- a/net/yggdrasil/files/yggdrasil.init
+++ b/net/yggdrasil/files/yggdrasil.init
@@ -11,7 +11,6 @@ start_service()
 
 	procd_open_instance
 	procd_set_param respawn
-	procd_set_param command /usr/sbin/yggdrasil -useconffile /etc/yggdrasil.conf
 	procd_set_param command /bin/ash -c "/usr/sbin/yggdrasil -useconffile /etc/yggdrasil.conf | logger -t yggdrasil"
 
 	procd_close_instance


### PR DESCRIPTION
Maintainer: @wfleurant
Compile tested: n/a
Run tested: tested on-device 

Description:
These changes "publish" some details about the router. The nodeInfo section provides a type of whois response upon interrogation.

Example of a nodeInfo response:

```json
{
  "kernel": "4.14.107",
  "hostname": "fsf-apu",
  "system": "AMD G-T40E Processor",
  "model": "PC Engines APU",
  "board_name": "pc-engines-apu"
}
```

 
