### PR TITLE
python-yaml: update to version 5.1

### DIFF
--- a/lang/python/python-yaml/Makefile
+++ b/lang/python/python-yaml/Makefile
@@ -8,59 +8,68 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=PyYAML
-PKG_VERSION:=3.13
+PKG_VERSION:=5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/P/PyYAML
-PKG_HASH:=3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/P/PyYAML
+PKG_HASH:=436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95
 
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=MIT
-PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Nicolas Thill <nico@openwrt.org>
+PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:pyyaml_project:pyyaml
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
 
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
 define Package/python-yaml/Default
-  SUBMENU:=Python
   SECTION:=lang
+  SUBMENU:=Python
   CATEGORY:=Languages
-  URL:=https://pyyaml.org/wiki/PyYAML
+  TITLE:=YAML parser and emitter for Python
+  URL:=https://github.com/yaml/pyyaml
   DEPENDS:=+libyaml
 endef
 
 define Package/python-yaml
 $(call Package/python-yaml/Default)
-  TITLE:=YAML parser and emitter for Python
-  DEPENDS+=+PACKAGE_python-yaml:python-light +PACKAGE_python-yaml:python-codecs
+  DEPENDS+= \
+	+PACKAGE_python-yaml:python-light \
+	+PACKAGE_python-yaml:python-codecs
   VARIANT:=python
 endef
 
 define Package/python3-yaml
 $(call Package/python-yaml/Default)
-  TITLE:=YAML parser and emitter for Python3
   DEPENDS+=+PACKAGE_python3-yaml:python3-light
   VARIANT:=python3
 endef
 
-define PyBuild/Compile
-	$(call Build/Compile/PyMod,,\
-		--with-libyaml install --prefix="$(PKG_INSTALL_DIR)/usr" \
-	)
+define Package/python-yaml/description
+PyYAML is a YAML parser and emitter for the Python programming language.
 endef
 
-define Py3Build/Compile
-	$(call Build/Compile/Py3Mod,,\
-		--with-libyaml install --prefix="$(PKG_INSTALL_DIR)/usr" \
-	)
+define Package/python3-yaml/description
+$(call Package/python-yaml/description)
+.
+(Variant for Python3)
 endef
+
+PYTHON_PKG_SETUP_GLOBAL_ARGS:=--with-libyaml
+PYTHON_PKG_SETUP_ARGS:=
+PYTHON3_PKG_SETUP_GLOBAL_ARGS:=--with-libyaml
+PYTHON3_PKG_SETUP_ARGS:=
 
 $(eval $(call PyPackage,python-yaml))
 $(eval $(call BuildPackage,python-yaml))
+$(eval $(call BuildPackage,python-yaml-src))
+
 $(eval $(call Py3Package,python3-yaml))
 $(eval $(call BuildPackage,python3-yaml))
+$(eval $(call BuildPackage,python3-yaml-src))


### PR DESCRIPTION
Maintainer: @psycho-nico
Compile tested: Turris Omnia, mvebu (cortex-a9_vfpv3), OpenWrt SNAPSHOT, r9681-503edc913b
Run tested: Turris Omnia, mvebu (cortex-a9_vfpv3), OpenWrt SNAPSHOT, r9681-503edc913b

Description (It is also included in Commit message):

- COPYING as a license is no longer available. It's LICENSE
- Add a description
- Add me as maintainer as the previous maintainer is inactive in OpenWrt
- Changed URL to Git repository, where you can find more details
- Moved TITLE to Default