### PR TITLE
unrar: Update to 5.7.3

### DIFF
--- a/utils/unrar/Makefile
+++ b/utils/unrar/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unrar
-PKG_VERSION:=5.6.8
+PKG_VERSION:=5.7.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=unrarsrc-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.rarlab.com/rar
-PKG_HASH:=a4cc0ac14a354827751912d2af4a0a09e2c2129df5766576fa7e151791dd3dff
+PKG_HASH:=40e856b78374f258d8a1f5f02c02f828c5392a0118c9300fd169a300b520a444
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>, \
 		Ted Hess <thess@kitschensync.net>
 
@@ -24,6 +24,12 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
+
+ifeq ($(CONFIG_USE_UCLIBCXX),y)
+TARGET_LDFLAGS +=-nodefaultlibs
+endif
+TARGET_CXXFLAGS +=-fno-rtti -flto
+TARGET_LDFLAGS +=$(FPIC) -Wl,--gc-sections
 
 define Package/unrar/Default
   TITLE:=UnRAR
@@ -57,9 +63,6 @@ define Package/libunrar/description
   UnRAR library is a shared library that provides file extraction from RAR
   archives
 endef
-
-MAKE_FLAGS += \
-	LDFLAGS="$(TARGET_LDFLAGS) -lpthread"
 
 ifeq ($(BUILD_VARIANT),lib)
 define Build/Compile

--- a/utils/unrar/patches/100-makefile_fixes.patch
+++ b/utils/unrar/patches/100-makefile_fixes.patch
@@ -1,22 +1,27 @@
 --- a/makefile
 +++ b/makefile
-@@ -2,13 +2,13 @@
+@@ -2,14 +2,14 @@
  # Makefile for UNIX - unrar
  
  # Linux using GCC
 -CXX=c++
 -CXXFLAGS=-O2 -Wno-logical-op-parentheses -Wno-switch -Wno-dangling-else
-+#CXX=c++
-+#CXXFLAGS=-O2 -Wno-logical-op-parentheses -Wno-switch -Wno-dangling-else
- LIBFLAGS=-fPIC
+-LIBFLAGS=-fPIC
++CXX?=c++
++CXXFLAGS?=-O2 -Wno-logical-op-parentheses -Wno-switch -Wno-dangling-else
++LIBFLAGS?=-fPIC
  DEFINES=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DRAR_SMP
- STRIP=strip
- AR=ar
+-STRIP=strip
+-AR=ar
 -LDFLAGS=-pthread
-+LDFLAGS=-lpthread
- DESTDIR=/usr
+-DESTDIR=/usr
++STRIP?=strip
++AR?=ar
++LDFLAGS?=-lpthread
++DESTDIR?=/usr
  
  # Linux using LCC
+ #CXX=lcc
 @@ -166,7 +166,7 @@ uninstall-unrar:
  			rm -f $(DESTDIR)/bin/unrar
  


### PR DESCRIPTION
Added -fno-rtti and -nodefaultlibs for slightly smaller size.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess @Noltari 
Compile tested: mvebu
Run tested: Turris Omnia

edit: Forgot to mention. This version probably has some fixes for the recently discovered CVEs, such as CVE-2018-20252