### PR TITLE
libdaq: update to 2.2.2

### DIFF
--- a/libs/libdaq/Makefile
+++ b/libs/libdaq/Makefile
@@ -8,17 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdaq
-PKG_VERSION:=2.0.6
-PKG_RELEASE:=2
+PKG_VERSION:=2.2.2
+PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=https://www.snort.org/downloads/snort/ \
-	@SF/snort
+PKG_SOURCE_URL:=https://www.snort.org/downloads/snortplus/
 PKG_SOURCE:=daq-$(PKG_VERSION).tar.gz
-PKG_HASH:=d41da5f7793e66044e6927dd868c0525e7ee4ec1a3515bf74ef9a30cd9273af0
+PKG_HASH:=7cd818cabb1ad35360e83076e54775f07165ee71407dc672d147e27d3cd37f7b
 PKG_BUILD_DIR:=$(BUILD_DIR)/daq-$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+
+PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -42,14 +43,6 @@ CONFIGURE_ARGS+= \
 	--with-dnet-libraries="$(STAGING_DIR)/usr/lib" \
 	--with-libpcap-includes="$(STAGING_DIR)/usr/include" \
 	--with-libpcap-libraries="$(STAGING_DIR)/usr/lib" \
-
-define Build/Compile
-	$(MAKE) $(MAKE_FLAGS) -C $(PKG_BUILD_DIR)
-endef
-
-define Build/Install
-	$(MAKE) $(MAKE_FLAGS) -C $(PKG_BUILD_DIR) install DESTDIR=$(PKG_INSTALL_DIR)
-endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(STAGING_DIR)/usr/include

--- a/libs/libdaq/patches/001-compile.patch
+++ b/libs/libdaq/patches/001-compile.patch
@@ -1,6 +1,7 @@
---- a/configure
-+++ b/configure
-@@ -13552,10 +13552,11 @@ if ${daq_cv_libpcap_version_1x+:} false;
+diff -u --recursive daq-2.2.2-vanilla/configure daq-2.2.2/configure
+--- daq-2.2.2-vanilla/configure	2017-07-05 15:58:03.000000000 -0400
++++ daq-2.2.2/configure	2018-09-01 17:18:56.774898034 -0400
+@@ -13244,10 +13244,11 @@
  else
  
      if test "$cross_compiling" = yes; then :

--- a/libs/libdaq/patches/100-musl-compat.patch
+++ b/libs/libdaq/patches/100-musl-compat.patch
@@ -1,5 +1,6 @@
---- a/os-daq-modules/daq_ipfw.c
-+++ b/os-daq-modules/daq_ipfw.c
+diff -u --recursive daq-2.2.2-vanilla/os-daq-modules/daq_ipfw.c daq-2.2.2/os-daq-modules/daq_ipfw.c
+--- daq-2.2.2-vanilla/os-daq-modules/daq_ipfw.c	2017-02-08 17:04:18.000000000 -0500
++++ daq-2.2.2/os-daq-modules/daq_ipfw.c	2018-09-01 17:21:10.608181841 -0400
 @@ -23,10 +23,10 @@
  #include <stdlib.h>
  #include <string.h>
@@ -12,8 +13,9 @@
  
  #include <netinet/in.h>
  #include <sys/socket.h>
---- a/os-daq-modules/daq_ipq.c
-+++ b/os-daq-modules/daq_ipq.c
+diff -u --recursive daq-2.2.2-vanilla/os-daq-modules/daq_ipq.c daq-2.2.2/os-daq-modules/daq_ipq.c
+--- daq-2.2.2-vanilla/os-daq-modules/daq_ipq.c	2017-02-08 17:04:18.000000000 -0500
++++ daq-2.2.2/os-daq-modules/daq_ipq.c	2018-09-01 17:21:23.162208457 -0400
 @@ -24,10 +24,10 @@
  #include <stdio.h>
  #include <stdlib.h>
@@ -26,8 +28,9 @@
  
  #include <netinet/ip.h>
  
---- a/os-daq-modules/daq_nfq.c
-+++ b/os-daq-modules/daq_nfq.c
+diff -u --recursive daq-2.2.2-vanilla/os-daq-modules/daq_nfq.c daq-2.2.2/os-daq-modules/daq_nfq.c
+--- daq-2.2.2-vanilla/os-daq-modules/daq_nfq.c	2017-02-08 17:04:18.000000000 -0500
++++ daq-2.2.2/os-daq-modules/daq_nfq.c	2018-09-01 17:21:35.202233988 -0400
 @@ -24,10 +24,10 @@
  #include <stdio.h>
  #include <stdlib.h>


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64 master
Run tested: x86_64 master

Description:
This is incompatible with the current snort version 2 package, but it is required by snort 3. I will propose an update to snort 3.0.0-beta in a separate pull request.