### PR TITLE
snort3: new package

### DIFF
--- a/net/snort/patches/001-compile.patch
+++ b/net/snort/patches/001-compile.patch
@@ -119,7 +119,7 @@ diff -u --recursive snort-2.9.11.1-vanilla/configure.in snort-2.9.11.1/configure
 -]])],
 -[have_daq_ext_modflow="yes"],
 -[have_daq_ext_modflow="no"])
-+have_daq_ext_modflow="no"
++have_daq_ext_modflow="yes"
  AC_MSG_RESULT($have_daq_ext_modflow)
  if test "x$have_daq_ext_modflow" = "xyes"; then
      CCONFIGFLAGS="${CCONFIGFLAGS} -DHAVE_DAQ_EXT_MODFLOW"
@@ -160,7 +160,7 @@ diff -u --recursive snort-2.9.11.1-vanilla/configure.in snort-2.9.11.1/configure
 -]])],
 -[have_daq_data_channel_flags="yes"],
 -[have_daq_data_channel_flags="no"])
-+have_daq_data_channel_flags="no"
++have_daq_data_channel_flags="yes"
  AC_MSG_RESULT($have_daq_data_channel_flags)
  if test "x$have_daq_data_channel_flags" = "xyes"; then
      CCONFIGFLAGS="${CCONFIGFLAGS} -DHAVE_DAQ_DATA_CHANNEL_PARAMS"
@@ -180,7 +180,7 @@ diff -u --recursive snort-2.9.11.1-vanilla/configure.in snort-2.9.11.1/configure
 -]])],
 -[have_daq_data_channel_separate_ip_versions="yes"],
 -[have_daq_data_channel_separate_ip_versions="no"])
-+have_daq_data_channel_separate_ip_versions="no"
++have_daq_data_channel_separate_ip_versions="yes"
  AC_MSG_RESULT($have_daq_data_channel_separate_ip_versions)
  if test "x$have_daq_data_channel_separate_ip_versions" = "xyes"; then
      CCONFIGFLAGS="${CCONFIGFLAGS} -DHAVE_DAQ_DATA_CHANNEL_SEPARATE_IP_VERSIONS"


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64 master
Run tested: x86_64

Description:
Snort 3.0.0-beta represents a more modern implementation of Snort. The folks behind Snort have not yet published a release schedule, and so I packages the beta version. This requires pull request #8490, which provides an updated libdaq.