### PR TITLE
sudo: update to version 1.8.27

### DIFF
--- a/admin/sudo/Makefile
+++ b/admin/sudo/Makefile
@@ -8,13 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sudo
-PKG_VERSION:=1.8.26
+PKG_VERSION:=1.8.27
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sudo.ws/dist
-PKG_HASH:=40da219a6f0341ccb22d04a98988e27f09b831d2561b14c6154067a49ef3fee2
+PKG_HASH:=7beb68b94471ef56d8a1036dbcdc09a7b58a949a68ffce48b83f837dd33e2ec0
 
+PKG_MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=doc/LICENSE
 PKG_CPE_ID:=cpe:/a:todd_miller:sudo
@@ -31,7 +32,6 @@ define Package/sudo
   CATEGORY:=Administration
   TITLE:=Delegate authority to run commands
   URL:=https://www.sudo.ws/
-  MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
 endef
 
 define Package/sudo/description


### PR DESCRIPTION
Maintainer: @kissg1988
Compile tested: Turris Omnia, mvebu (cortex-a9_vfpv3), OpenWrt SNAPSHOT, r9681-503edc913b
Run tested: Turris Omnia, mvebu (cortex-a9_vfpv3), OpenWrt SNAPSHOT, r9681-503edc913b

Description:

- update to version 1.8.27 ([release notes](https://www.sudo.ws/stable.html#1.8.27))
- use PKG_MAINTAINER instead of MAINTAINER 