### PR TITLE
ddns-scripts: add hsts-file parameter to wget call

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.8
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=

--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -698,7 +698,7 @@ do_transfer() {
 
 	# lets prefer GNU Wget because it does all for us - IPv4/IPv6/HTTPS/PROXY/force IP version
 	if [ -n "$WGET_SSL" -a $USE_CURL -eq 0 ]; then 			# except global option use_curl is set to "1"
-		__PROG="$WGET_SSL -nv -t 1 -O $DATFILE -o $ERRFILE"	# non_verbose no_retry outfile errfile
+		__PROG="$WGET_SSL --hsts-file=/tmp/.wget-hsts -nv -t 1 -O $DATFILE -o $ERRFILE"	# non_verbose no_retry outfile errfile
 		# force network/ip to use for communication
 		if [ -n "$bind_network" ]; then
 			local __BINDIP


### PR DESCRIPTION
Maintainer: None
Compile tested: Turris Omnia (TOS4), OpenWrt 18.06.2
Run tested: Turris Omnia (TOS4), OpenWrt 18.06.2

Description:
This PR  should prevent wget to writing to /root/.wget-hsts  which can lead to flash memory degradation. 

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>
