### PR TITLE
tor: fix wrong CPE ID

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=d5c56603942a8927670f50a4a469fb909e29d3571fdd013389d567e57abc0b47
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE
-PKG_CPE_ID:=cpe:/:a:torproject:tor
+PKG_CPE_ID:=cpe:/a:torproject:tor
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested:  N/A
Run tested: N/A

Description:
This PR fixes wrong CPE ID  (introduced in https://github.com/openwrt/packages/commit/9754ee1dcc8d99a21fc10924c21dd763b95bcf35 )

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>
