### PR TITLE
travelmate: 1.4.3

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.4.2
+PKG_VERSION:=1.4.3
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: TP-LINK RE450, OpenWrt SNAPSHOT r9650-8568dcd931

Description:
* remove leftover from last commit
* enhance rebind protection whitelisting: support multiple,
  cascaded captive portal domains

Signed-off-by: Dirk Brenken <dev@brenken.org>