### PR TITLE
coova-chilli: fix build error

### DIFF
--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.4
 PKG_MAINTAINER:=Jaehoon You <teslamint@gmail.com>
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coova/coova-chilli/tar.gz/$(PKG_VERSION)?
@@ -139,7 +139,6 @@ define Package/coova-chilli/install
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) files/chilli.config $(1)/etc/config/chilli
 	$(INSTALL_DIR) $(1)/lib/firewall
-	$(CP) files/chilli.firewall $(1)/lib/firewall/chilli.sh
 endef
 
 $(eval $(call BuildPackage,coova-chilli))


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A
Run tested: N/A

Description:
#4911 removes `files/chilli.firewall` file, but not remove the copy command on Makefile that causes build error.

This commit removes that copy command to fix build error.

