### PR TITLE
rpcbind: fix warmstart option, CVE-2017-8779

### DIFF
--- a/net/rpcbind/Makefile
+++ b/net/rpcbind/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rpcbind
 PKG_VERSION:=1.2.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=@SF/rpcbind
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -16,8 +16,7 @@ PKG_REMOVE_FILES:=autogen.sh aclocal.m4
 PKG_INSTALL:=1
 
 PKG_CONFIG_DEPENDS:= \
-	CONFIG_RPCBIND_LIBWRAP \
-	CONFIG_RPCBIND_WARMSTARTS
+	CONFIG_RPCBIND_LIBWRAP
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -43,26 +42,18 @@ if PACKAGE_rpcbind
 	config RPCBIND_LIBWRAP
 		bool "Enable libwrap (TCP wrappers) support."
 		default y
-
-	config RPCBIND_WARMSTARTS
-		bool "Enable warmstarts support"
-		default y
-		help
-		  The warmstart feature saves RPC registrations on termination.
 endif
 endef
 
 CONFIGURE_ARGS += \
 	--with-rpcuser=rpc \
-	--without-systemdsystemunitdir
+	--without-systemdsystemunitdir \
+	--enable-warmstarts
 
 ifeq ($(CONFIG_RPCBIND_LIBWRAP),y)
 	CONFIGURE_ARGS += --enable-libwrap
 else
 	CONFIGURE_ARGS += --disable-libwrap
-endif
-ifeq ($(CONFIG_RPCBIND_WARMSTARTS),y)
-	CONFIGURE_ARGS += --enable-warmstarts
 endif
 
 define Package/rpcbind/install

--- a/net/rpcbind/patches/001-CVE-2017-8779-dos-via-memory-consumption.patch
+++ b/net/rpcbind/patches/001-CVE-2017-8779-dos-via-memory-consumption.patch
@@ -1,0 +1,29 @@
+Submitted By: Ken Moffat <ken at linuxfromscratch dot org>
+Date: 2017-05-29
+Initial Package Version: 0.2.4 (also affects earlier versions)
+Upstream Status: Unknown
+Origin: Guido Vranken
+Description: Fixes CVE-2017-8779 (DOS by remote attackers - memory consumption
+without subsequent free).
+
+diff --git a/src/rpcb_svc_com.c b/src/rpcb_svc_com.c
+index 5862c26..e11f61b 100644
+--- a/src/rpcb_svc_com.c
++++ b/src/rpcb_svc_com.c
+@@ -48,6 +48,7 @@
+ #include <rpc/rpc.h>
+ #include <rpc/rpcb_prot.h>
+ #include <rpc/svc_dg.h>
++#include <rpc/rpc_com.h>
+ #include <netconfig.h>
+ #include <errno.h>
+ #include <syslog.h>
+@@ -432,7 +433,7 @@ rpcbproc_taddr2uaddr_com(void *arg, struct svc_req *rqstp /*__unused*/,
+ static bool_t
+ xdr_encap_parms(XDR *xdrs, struct encap_parms *epp)
+ {
+-	return (xdr_bytes(xdrs, &(epp->args), (u_int *) &(epp->arglen), ~0));
++	return (xdr_bytes(xdrs, &(epp->args), (u_int *) &(epp->arglen), RPC_MAXDATASIZE));
+ }
+ 
+ /*


### PR DESCRIPTION
Maintainer: me
Compile tested: arm (snapshots)
Run tested: (arm qemu)

Description:
* always build with warmstart option
* fix CVE-2017-8779