### PR TITLE
python,python3: Include python-config for target Python in InstallDev

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -12,7 +12,7 @@ include ../python-version.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)
@@ -195,6 +195,8 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib $(1)/usr/lib/pkgconfig
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON_VERSION)-openwrt
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/include/python$(PYTHON_VERSION) \
 		$(1)/usr/include/
@@ -205,6 +207,15 @@ define Build/InstallDev
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/python*.pc \
 		$(1)/usr/lib/pkgconfig
+	$(INSTALL_BIN) \
+		./files/python-config.in \
+		$(1)/usr/bin/python$(PYTHON_VERSION)-config
+	$(SED) \
+		's|@EXENAME@|$(HOST_PYTHON_DIR)/bin/python$(PYTHON_VERSION)|' \
+		$(1)/usr/bin/python$(PYTHON_VERSION)-config
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/_sysconfigdata.py \
+		$(1)/usr/lib/python$(PYTHON_VERSION)-openwrt/_sysconfigdatatarget.py
 endef
 
 PYTHON_BASE_LIB_FILES:= \

--- a/lang/python/python/files/python-config.in
+++ b/lang/python/python/files/python-config.in
@@ -1,0 +1,81 @@
+#!@EXENAME@
+
+import sys
+import os
+import getopt
+from distutils import sysconfig
+
+# start changes
+host_prefix = sysconfig.PREFIX
+
+target_bin_dir = os.path.dirname(os.path.abspath(__file__))
+target_prefix = os.path.normpath(os.path.join(target_bin_dir, '..'))
+
+target_data_dir = os.path.join(target_prefix, 'lib', 'python' + sysconfig.get_config_var('VERSION') + '-openwrt')
+sys.path.append(target_data_dir)
+
+try:
+    from _sysconfigdatatarget import build_time_vars
+    sysconfig._config_vars = {}
+    sysconfig._config_vars.update(build_time_vars)
+except ImportError:
+    print >>sys.stderr, "Could not import target data from %s" % (target_data_dir)
+    sys.exit(1)
+# end changes
+# plus .replace(host_prefix, target_prefix) below
+
+valid_opts = ['prefix', 'exec-prefix', 'includes', 'libs', 'cflags',
+              'ldflags', 'help']
+
+def exit_with_usage(code=1):
+    print >>sys.stderr, "Usage: %s [%s]" % (sys.argv[0],
+                                            '|'.join('--'+opt for opt in valid_opts))
+    sys.exit(code)
+
+try:
+    opts, args = getopt.getopt(sys.argv[1:], '', valid_opts)
+except getopt.error:
+    exit_with_usage()
+
+if not opts:
+    exit_with_usage()
+
+pyver = sysconfig.get_config_var('VERSION')
+getvar = sysconfig.get_config_var
+
+opt_flags = [flag for (flag, val) in opts]
+
+if '--help' in opt_flags:
+    exit_with_usage(code=0)
+
+for opt in opt_flags:
+    if opt == '--prefix':
+        #print sysconfig.PREFIX
+        print target_prefix
+
+    elif opt == '--exec-prefix':
+        #print sysconfig.EXEC_PREFIX
+        print target_prefix
+
+    elif opt in ('--includes', '--cflags'):
+        flags = ['-I' + sysconfig.get_python_inc(),
+                 '-I' + sysconfig.get_python_inc(plat_specific=True)]
+        if opt == '--cflags':
+            flags.extend(getvar('CFLAGS').split())
+        #print ' '.join(flags)
+        print ' '.join(flags).replace(host_prefix, target_prefix)
+
+    elif opt in ('--libs', '--ldflags'):
+        libs = ['-lpython' + pyver]
+        libs += getvar('LIBS').split()
+        libs += getvar('SYSLIBS').split()
+        # add the prefix/lib/pythonX.Y/config dir, but only if there is no
+        # shared library in prefix/lib/.
+        if opt == '--ldflags':
+            if not getvar('Py_ENABLE_SHARED'):
+                libs.insert(0, '-L' + getvar('LIBPL'))
+            if not getvar('PYTHONFRAMEWORK'):
+                libs.extend(getvar('LINKFORSHARED').split())
+        #print ' '.join(libs)
+        print ' '.join(libs).replace(host_prefix, target_prefix)
+

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -14,7 +14,7 @@ PYTHON_VERSION:=$(PYTHON3_VERSION)
 PYTHON_VERSION_MICRO:=$(PYTHON3_VERSION_MICRO)
 
 PKG_NAME:=python3
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -199,6 +199,7 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib $(1)/usr/lib/pkgconfig
+	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/include/python$(PYTHON_VERSION) \
 		$(1)/usr/include/
@@ -209,6 +210,9 @@ define Build/InstallDev
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/python*.pc \
 		$(1)/usr/lib/pkgconfig
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/bin/python$(PYTHON_VERSION)-config \
+		$(1)/usr/bin/
 endef
 
 PYTHON3_BASE_LIB_FILES:= \


### PR DESCRIPTION
Maintainer: me / @commodo 
Compile tested: armvirt-32, 2019-03-21 snapshot sdk
Run tested: manual calls to the installed python-config scripts

Description:
This installs `python{2.7,3.7}-config` in `$(STAGING_DIR)/usr/bin` as part of `Build/InstallDev`, to be used by other packages to get build configuration for target Python.

The treatment for Python 2 and 3 are a bit different:

* For Python 2, python-config is a Python script that is expected to be run with, and return data for, the installed Python interpreter. This installs a modified version of this script, to be run using host Python, and read/return data for target Python.

* Python 3 includes a shell script version of python-config (expected to be used in cross-compilation scenarios). This simply installs the script into the right place.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>