### PR TITLE
MAC-Telnet-Server: Announce "OpenWRT" instead of "Linux"

### DIFF
--- a/net/mac-telnet/Makefile
+++ b/net/mac-telnet/Makefile
@@ -65,6 +65,7 @@ define Package/mac-telnet-server/install-extra
 	$(INSTALL_DATA) ./files/mactelnet.config $$(1)/etc/config/mactelnet
 endef
 
+
 $(eval $(call BuildPlugin,server,mactelnetd))
 $(eval $(call BuildPlugin,client,mactelnet))
 $(eval $(call BuildPlugin,ping,macping))

--- a/net/mac-telnet/Makefile
+++ b/net/mac-telnet/Makefile
@@ -65,7 +65,6 @@ define Package/mac-telnet-server/install-extra
 	$(INSTALL_DATA) ./files/mactelnet.config $$(1)/etc/config/mactelnet
 endef
 
-
 $(eval $(call BuildPlugin,server,mactelnetd))
 $(eval $(call BuildPlugin,client,mactelnet))
 $(eval $(call BuildPlugin,ping,macping))

--- a/net/mac-telnet/patches/010-openwrt-name.patch
+++ b/net/mac-telnet/patches/010-openwrt-name.patch
@@ -1,0 +1,11 @@
+--- a/config.h
++++ b/config.h
+@@ -42,7 +42,7 @@
+ #define PLATFORM_NAME "BSD/OS"
+
+ #elif defined(linux) || defined(__linux__)
+-#define PLATFORM_NAME "Linux"
++#define PLATFORM_NAME "OpenWRT"
+
+ #elif defined(sun)
+ #define PLATFORM_NAME "Solaris"

--- a/net/mac-telnet/patches/010-openwrt-name.patch
+++ b/net/mac-telnet/patches/010-openwrt-name.patch
@@ -5,7 +5,7 @@
 
  #elif defined(linux) || defined(__linux__)
 -#define PLATFORM_NAME "Linux"
-+#define PLATFORM_NAME "OpenWRT"
++#define PLATFORM_NAME "OpenWrt"
 
  #elif defined(sun)
  #define PLATFORM_NAME "Solaris"


### PR DESCRIPTION
Maintainer: (original) Jo-Philipp Wich <jo@mein.io> / me for the Patch
Compile tested: x86_64
Run tested: 18.06

Description:
With this simple patch the Platform advertized by the MAC Telnet announcer is "OpenWRT" instead of "Linux". Useful if you have a lot of devices in the network.

Based on discussion at https://github.com/openwrt/packages/issues/8408
