### PR TITLE
mac-telnet: announce OpenWrt as the platform

### DIFF
--- a/net/mac-telnet/Makefile
+++ b/net/mac-telnet/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mac-telnet
 PKG_VERSION:=2015-09-02
-PKG_RELEASE=$(PKG_SOURCE_VERSION)
+PKG_RELEASE=$(PKG_SOURCE_VERSION).r2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/jow-/MAC-Telnet.git

--- a/net/mac-telnet/patches/010-openwrt-name.patch
+++ b/net/mac-telnet/patches/010-openwrt-name.patch
@@ -1,0 +1,11 @@
+--- a/config.h
++++ b/config.h
+@@ -42,7 +42,7 @@
+ #define PLATFORM_NAME "BSD/OS"
+
+ #elif defined(linux) || defined(__linux__)
+-#define PLATFORM_NAME "Linux"
++#define PLATFORM_NAME "OpenWrt"
+
+ #elif defined(sun)
+ #define PLATFORM_NAME "Solaris"


### PR DESCRIPTION
MAC-Telnet-Server: Announce "OpenWrt" instead of "Linux"

Maintainer: (original) Jo-Philipp Wich jo@mein.io / me for the Patch
Compile tested: x86_64
Run tested: 18.06

Description:
With this simple patch the Platform advertized by the MAC Telnet announcer is "OpenWRT" instead of "Linux". Useful if you have a lot of devices in the network.

Based on discussion at #8408

Signed-off-by: Lars The <lars18th@users.noreply.github.com>