### PR TITLE
rpcbind: Add PKG_CPE_ID for proper CVE tracking

### DIFF
--- a/net/rpcbind/Makefile
+++ b/net/rpcbind/Makefile
@@ -10,6 +10,7 @@ PKG_HASH:=2ce360683963b35c19c43f0ee2c7f18aa5b81ef41c3fdbd15ffcb00b8bffda7a
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
+PKG_CPE_ID:=cpe:/a:rpcbind_project:rpcbind
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=autogen.sh aclocal.m4


### PR DESCRIPTION
Maintainer: @Andy2244 
Compile tested: N/A
Run tested: N/A

Description:
This PR adds PKG_CPE_ID for CVE tracking. 

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>