### PR TITLE
travelmate: 1.4.4

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.4.3
+PKG_VERSION:=1.4.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL-AR750s

Description:
* refine captive portal detection/rebind protection handling,
  heavily tested with Deutsche Bahn hotspots ... ;-)
* add rebind whitelist logging

Signed-off-by: Dirk Brenken <dev@brenken.org>