### PR TITLE
keepalived: update to version 2.0.14

### DIFF
--- a/net/keepalived/Config.in
+++ b/net/keepalived/Config.in
@@ -1,0 +1,164 @@
+if PACKAGE_keepalived
+
+menu "Configuration"
+
+config KEEPALIVED_BFD
+	bool
+	default n
+	prompt "Enable BFD support"
+	help
+		Builds support for BFD
+
+config KEEPALIVED_SHA1
+	bool
+	default y
+	prompt "Enable SHA1 support in genhash"
+	help
+		Builds support for using SHA1 with genhash
+
+config KEEPALIVED_LVS
+	bool
+	default y
+	prompt "Enable IPVS support"
+	help
+		Builds support for IPVS
+
+config KEEPALIVED_LVS_SYNCD
+	depends on KEEPALIVED_LVS
+	bool
+	default y
+	prompt "Enable IPVS syncd daemon control"
+	help
+		Builds support for configuring IPVS syncd daemon
+
+config KEEPALIVED_LVS_64BIT_STATS
+	depends on KEEPALIVED_LVS
+	bool
+	default y
+	prompt "Enable IPVS 64 bit stats"
+	help
+		Builds support for IPVS 64 bit stats
+
+config KEEPALIVED_FWMARK
+	depends on KEEPALIVED_LVS
+	bool
+	default y
+	prompt "Enable support for setting FWMARK on sockets"
+	help
+		Builds support for setting firewall mark on checker sockets
+
+config KEEPALIVED_SNMP_CHECKER
+	depends on KEEPALIVED_LVS
+	bool
+	default n
+	prompt "Enable SNMP support for checker (LVS)"
+	help
+		Builds support for using SNMP with LVS
+
+config KEEPALIVED_VRRP
+	bool
+	default y
+	prompt "Enable VRRP support"
+	help
+		Builds support for VRRP
+
+config KEEPALIVED_IPTABLES
+	depends on KEEPALIVED_VRRP
+	bool
+	default y
+	prompt "Enable iptables for VIP filtering"
+	help
+		Builds support for using iptables/ipsets for filtering packets
+		to VIPs
+
+config KEEPALIVED_SNMP_VRRP
+	depends on KEEPALIVED_VRRP
+	bool
+	default n
+	prompt "Enable SNMP support for VRRP"
+	help
+		Builds support for using SNMP with VRRP
+
+config KEEPALIVED_SNMP_RFC2
+	depends on KEEPALIVED_VRRP
+	bool
+	default n
+	prompt "Enable SNMP support for VRRPv2 (RFC2787)"
+	help
+		Builds support for using RFC2787 SNMP support for VRRPv2
+
+config KEEPALIVED_SNMP_RFC3
+	depends on KEEPALIVED_VRRP
+	bool
+	default n
+	prompt "Enable SNMP support for VRRPv3 (RFC6527)"
+	help
+		Builds support for using RFC6527 SNMP support for VRRPv3
+
+config KEEPALIVED_SNMP_REPLY_V3_FOR_V2
+	depends on KEEPALIVED_SNMP_RFC3
+	bool
+	default n
+	prompt "Enable SNMP v3 responses for VRRPv2 instances"
+	help
+		Builds support for using SNMP v3 responses for VRRPv2 instances
+
+config KEEPALIVED_DBUS
+	depends on KEEPALIVED_VRRP
+	bool
+	default n
+	prompt "Enable DBus support"
+	help
+		Builds support for using DBus with VRRP
+
+config KEEPALIVED_JSON
+	depends on KEEPALIVED_VRRP
+	bool
+	default n
+	prompt "Enable JSON support with VRRP"
+	help
+		Builds support for using JSON output for VRRP
+
+config KEEPALIVED_VRRP_AUTH
+	depends on KEEPALIVED_VRRP
+	bool
+	default y
+	prompt "Enable (removed) VRRPv2 authentication"
+	help
+		Builds support for using (removed) VRRPv2 authentication
+		Note: authentication was removed from the VRRPv2 specification
+		by RFC3768 in 2004.
+		Use of this option is non-compliant and can cause problems.
+		Avoid using if possible, except when using unicast, where it
+		can be helpful.
+
+config KEEPALIVED_CHECKSUM_COMPAT
+	depends on KEEPALIVED_VRRP
+	bool
+	default y
+	prompt "Enable checksum compatibility"
+	help
+		Builds support for interworking with instances using
+		old(incorrect) checksum method
+
+config KEEPALIVED_ROUTES
+	depends on KEEPALIVED_VRRP
+	bool
+	default y
+	prompt "Enable support for VRRP instances managing routes and rules"
+	help
+		Builds support for VRRP instances adding and removing IP
+		routes and rules
+
+config KEEPALIVED_LINKBEAT
+	depends on KEEPALIVED_VRRP
+	bool
+	default y
+	prompt "Enable support for linkbeat"
+	help
+		Builds support for using linkbeat polling to monitor the state
+		of interfaces
+
+endmenu
+
+endif # PACKAGE_keepalived

--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
-PKG_VERSION:=2.0.10
+PKG_VERSION:=2.0.14
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.keepalived.org/software
-PKG_HASH:=40e0e55afed9ca313d621a9c5878579696fafb5504dab521aadaf20ba6e7f597
+PKG_HASH:=1bf586e56ee38b47b82f2a27b27e04d0e5b23f1810db6a8e801bde9d3eb8617b
 
 PKG_CPE_ID:=cpe:/a:keepalived:keepalived
 PKG_LICENSE:=GPL-2.0+
@@ -21,30 +21,61 @@ PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Ben Kelly <ben@benjii.net> \
 		Florian Eckert <fe@dev.tdt.de>
 
+PKG_CONFIG_DEPENDS += \
+	KEEPALIVED_VRRP \
+	KEEPALIVED_LVS \
+	KEEPALIVED_IPTABLES \
+	KEEPALIVED_BFD \
+	KEEPALIVED_SNMP_VRRP \
+	KEEPALIVED_SNMP_CHECKER \
+	KEEPALIVED_SNMP_RFC2 \
+	KEEPALIVED_SNMP_RFC3 \
+	KEEPALIVED_SNMP_REPLY_V3_FOR_V2 \
+	KEEPALIVED_DBUS \
+	KEEPALIVED_JSON \
+	KEEPALIVED_ROUTES \
+	IPV6
+
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/kernel.mk
 
+define Package/keepalived/config
+	source "$(SOURCE)/Config.in"
+endef
+
+# specifying +(IPV6&&KEEPALIVED_IPTABLES) in the DEPENDS definition doesn't work
+ifeq ($(CONFIG_KEEPALIVED_IPTABLES)$(CONFIG_IPV6),yy)
+  KEEPALIVED_DEPENDS_LIBIP6TC=+libip6tc
+endif
+
+# The +kmod-nf-ipvs line should be +KEEPALIVED_LVS:kmod-nf-ipvs,
+# but make menuconfig then reports :error: recursive dependency detected!
+# !!FIXME DEPENDS:= +KEEPALIVED_LVS:kmod-nf-ipvs
 define Package/keepalived
   SECTION:=net
   CATEGORY:=Network
-  TITLE:=Failover and monitoring daemon for LVS clusters
+  TITLE:=VRRP with failover and monitoring daemon for LVS clusters
   URL:=http://www.keepalived.org/
   DEPENDS:= \
-    +libopenssl \
-    +libip4tc \
-    +IPV6:libip6tc \
-    +libxtables \
-    +kmod-macvlan \
+    +libnl-genl \
     +libmagic \
-    +libnl-route \
-    +libnfnetlink \
-    +kmod-nf-ipvs
+    +KEEPALIVED_VRRP:kmod-macvlan \
+    +KEEPALIVED_VRRP:libnl-route \
+    +KEEPALIVED_VRRP:libnfnetlink \
+    +KEEPALIVED_SHA1:libopenssl \
+    +KEEPALIVED_IPTABLES:libip4tc \
+    $(KEEPALIVED_DEPENDS_LIBIP6TC) \
+    +KEEPALIVED_IPTABLES:libxtables \
+    +KEEPALIVED_IPTABLES:libipset \
+    +(KEEPALIVED_SNMP_VRRP||KEEPALIVED_SNMP_CHECKER||KEEPALIVED_SNMP_RFC2||KEEPALIVED_SNMP_RFC3):libnetsnmp \
+    +KEEPALIVED_JSON:libjson-c \
+    +KEEPALIVED_DBUS:glib2
 endef
 
 define Package/keepalived/description
- Failover and monitoring daemon for Linux Virtual Server (LVS) clusters.
+ VRRP with failover and monitoring daemon for Linux Virtual Server (LVS) clusters.
 endef
 
 define Package/keepalived/conffiles
@@ -54,31 +85,182 @@ define Package/keepalived/conffiles
 endef
 
 CONFIGURE_ARGS+= \
-	--disable-libipset \
-	--disable-libnl \
-	--enable-sha1 \
-	--disable-snmp \
-	--with-kernel-dir="$(LINUX_DIR)/$(LINUX_UAPI_DIR)" \
-	--with-init=SYSV
+	--with-init=SYSV \
+	--disable-nftables
 
-MAKE_FLAGS += \
-		STRIP="/bin/true" \
+ifeq ($(CONFIG_KEEPALIVED_VRRP),)
+CONFIGURE_ARGS += \
+	--disable-vrrp
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_LVS),)
+CONFIGURE_ARGS += \
+	--disable-lvs
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_BFD),y)
+CONFIGURE_ARGS += \
+	--enable-bfd
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SHA1),y)
+CONFIGURE_ARGS += \
+	--enable-sha1
+endif
+
+
+ifeq ($(CONFIG_KEEPALIVED_VRRP),y)
+ifeq ($(CONFIG_KEEPALIVED_IPTABLES),)
+CONFIGURE_ARGS += \
+	--disable-iptables
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_IPSETS),)
+CONFIGURE_ARGS += \
+	--disable-libipset-dynamic
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_VRRP),y)
+CONFIGURE_ARGS += \
+	--enable-snmp-vrrp
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_RFC2),y)
+CONFIGURE_ARGS += \
+	--enable-snmp-rfcv2
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_RFC3),y)
+CONFIGURE_ARGS += \
+	--enable-snmp-rfcv3
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_RFC3),y)
+ifeq ($(CONFIG_KEEPALIVED_SNMP_REPLY_V3_FOR_V2),)
+CONFIGURE_ARGS += \
+	--disable-snmp-reply-v3-for-v2
+endif
+endif # CONFIG_KEEPALIVED_SNMP_RFC3
+
+ifeq ($(CONFIG_KEEPALIVED_JSON),y)
+CONFIGURE_ARGS += \
+	--enable-json
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_VRRP_AUTH),)
+CONFIGURE_ARGS += \
+	--disable-vrrp-auth
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_CHECKSUM_COMPAT),)
+CONFIGURE_ARGS += \
+	--disable-checksum-compat
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_DBUS),y)
+CONFIGURE_ARGS += \
+	--enable-dbus
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_LINKBEAT),)
+CONFIGURE_ARGS += \
+	--disable-linkbeat
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_ROUTES),)
+CONFIGURE_ARGS += \
+	--disable-routes
+endif
+endif # CONFIG_KEEPALIVED_VRRP
+
+
+ifeq ($(CONFIG_KEEPALIVED_LVS),y)
+ifeq ($(CONFIG_KEEPALIVED_LVS_SYNCD),)
+CONFIGURE_ARGS += \
+	--disable-lvs-syncd
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_LVS_64BIT_STATS),)
+CONFIGURE_ARGS += \
+	--disable-lvs-64bit-stats
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_FWMARK),)
+CONFIGURE_ARGS += \
+	--disable-fwmark
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_CHECKER),y)
+CONFIGURE_ARGS += \
+	--enable-snmp-checker
+endif
+
+endif # CONFIG_KEEPALIVED_LVS
+
+
+MAKE_FLAGS += STRIP="/bin/true"
+TARGET_CFLAGS += -I$(LINUX_DIR)
 
 define Package/keepalived/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/keepalived $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/keepalived \
+		$(1)/usr/sbin/
+
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/genhash $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/genhash \
+		$(1)/usr/bin/
+
 	$(INSTALL_DIR) $(1)/etc/keepalived
-	$(CP) $(PKG_INSTALL_DIR)/etc/keepalived/keepalived.conf $(1)/etc/keepalived/
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/keepalived/keepalived.conf \
+		$(1)/etc/keepalived/
+
 	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) ./files/keepalived.init $(1)/etc/init.d/keepalived
+	$(INSTALL_BIN) ./files/keepalived.init \
+		$(1)/etc/init.d/keepalived
+
 	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_CONF) ./files/keepalived.config $(1)/etc/config/keepalived
+	$(INSTALL_CONF) ./files/keepalived.config \
+		$(1)/etc/config/keepalived
+
 	$(INSTALL_DIR) $(1)/etc
-	$(INSTALL_CONF) ./files/keepalived.user $(1)/etc/keepalived.user
+	$(INSTALL_CONF) ./files/keepalived.user \
+		$(1)/etc/keepalived.user
+
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/keepalived
-	$(INSTALL_DATA) ./files/hotplug-user $(1)/etc/hotplug.d/keepalived/01-user
+	$(INSTALL_DATA) ./files/hotplug-user \
+		$(1)/etc/hotplug.d/keepalived/01-user
+
+ifneq ($(CONFIG_KEEPALIVED_SNMP_VRRP)$(CONFIG_KEEPALIVED_SNMP_CHECKER)$(CONFIG_KEEPALIVED_SNMP_RFC2)$(CONFIG_KEEPALIVED_SNMP_RFC3),)
+	$(INSTALL_DIR) $(1)/usr/share/snmp/mibs
+endif
+
+ifneq ($(CONFIG_KEEPALIVED_SNMP_VRRP)$(CONFIG_KEEPALIVED_SNMP_CHECKER),)
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/snmp/mibs/KEEPALIVED-MIB.txt \
+		$(1)/usr/share/snmp/mibs/KEEPALIVED-MIB.txt
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_RFC2),y)
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/snmp/mibs/VRRP-MIB.txt \
+		$(1)/usr/share/snmp/mibs/VRRP-MIB.txt
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_RFC3),y)
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/snmp/mibs/VRRPv3-MIB.txt \
+		$(1)/usr/share/snmp/mibs/VRRPv3-MIB.txt
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_DBUS),y)
+	$(INSTALL_DIR) $(1)/etc/dbus-1/system.d
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/dbus-1/system.d/org.keepalived.Vrrp1.conf \
+		$(1)/etc/dbus-1/system.d/org.keepalived.Vrrp1.conf
+
+	$(INSTALL_DIR) $(1)/usr/share/dbus-1/interfaces
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Instance.xml \
+		$(1)/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Instance.xml
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Vrrp.xml \
+		$(1)/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Vrrp.xml
+endif
+
 endef
 
 $(eval $(call BuildPackage,keepalived))

--- a/net/keepalived/files/keepalived.config
+++ b/net/keepalived/files/keepalived.config
@@ -10,6 +10,7 @@ config global_defs
 #	option vrrp_mcast_group4	"224.0.0.18" # optional, default 224.0.0.18
 #	option vrrp_mcast_group6	"f02::12"    # optional, default ff02::12
 #	option linkbeat_use_polling	"1"
+#	option vrrp_startup_delay	"5"
 
 #config ipaddress
 #	option name	"ipaddress0"

--- a/net/keepalived/files/keepalived.init
+++ b/net/keepalived/files/keepalived.init
@@ -105,8 +105,14 @@ global_defs() {
 	config_get notification_email $1 notification_email
 	print_list_indent notification_email
 
-	print_elems_indent $1 $INDENT_1 notification_email_from smtp_server smtp_connect_timeout \
-	           router_id vrrp_mcast_group4 vrrp_mcast_group6
+	print_elems_indent $1 $INDENT_1 \
+		notification_email_from \
+		smtp_server \
+		smtp_connect_timeout \
+		router_id \
+		vrrp_mcast_group4 \
+		vrrp_mcast_group6 \
+		vrrp_startup_delay
 }
 
 print_ipaddress_indent() {

--- a/net/keepalived/patches/001-fix-systemd.patch
+++ b/net/keepalived/patches/001-fix-systemd.patch
@@ -1,0 +1,212 @@
+--- a/configure.ac	2019-03-30 12:47:15.935627522 +0000
++++ b/configure.ac	2019-03-30 12:47:55.590028792 +0000
+@@ -272,8 +272,7 @@ AC_ARG_ENABLE(Werror,
+   [AS_HELP_STRING([--enable-Werror], [compile with warnings being errors])])
+ 
+ AC_ARG_WITH([systemdsystemunitdir],
+-	AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
+-	[], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
++	AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files])])
+ 
+ # Set the kernel headers path
+ if test -n "$kernel_src_path"; then
+@@ -551,7 +550,7 @@ do
+       eval $LOCAL_WARN_VAR=yes
+       add_to_var([KA_CFLAGS], [-W$WARN])
+       AC_DEFINE_UNQUOTED([$WARN_VAR], [ 1 ])
+-      AS_IF([test -z $WARN_VAR_SHORT], [],
++      AS_IF([test -z "$WARN_VAR_SHORT"], [],
+ 	    [AC_DEFINE_UNQUOTED([$WARN_VAR_SHORT], [ 1 ])]
+ 	   )
+     ],
+@@ -2451,41 +2450,39 @@ AM_CONDITIONAL([RPM_BIP], [test $RPM_NO_
+ 
+ dnl ----[ Determine system init type]----
+ INIT_TYPE=
+-if test -z $init_type; then
++AS_IF(
++  [test -n "$init_type"], [INIT_TYPE=$init_type],
++  [test -n "$with_systemdsystemunitdir"], [INIT_TYPE=systemd],
++  [
+   /sbin/init --version 2>/dev/null | grep -q upstart
+-  if test $? -eq 0; then
+-    INIT_TYPE=upstart
+-  else
++    AS_IF(
++      [test $? -eq 0], [INIT_TYPE=upstart],
++      [
+     init_path=`which systemctl 2>/dev/null`
+-    if test \( $? -eq 0 -a -x "$init_path" \); then
++        AS_IF([test \( $? -eq 0 -a -x "$init_path" \)],
++	  [
+       systemctl | grep -q -- "-\.mount"
+-      if test $? -eq 0; then
+-	INIT_TYPE=systemd
+-      fi
+-    fi
+-    if test \( -z "$INIT_TYPE" -a -f /etc/init.d/networking \); then
++	    AS_IF([test $? -eq 0], [INIT_TYPE=systemd])
++          ])
++        AS_IF([test \( -z "$INIT_TYPE" -a -f /etc/init.d/networking \)],
++	  [
+       init_path=`which openrc-run 2>/dev/null`
+-      if test \( $? -eq 0 -a -x "$init_path" \); then
++	    AS_IF([test \( $? -eq 0 -a -x "$init_path" \)],
++	      [
+ 	head -1 /etc/init.d/networking | grep -q "^#! */.*/openrc-run$"
+-	if test $? -eq 0; then
+-	  INIT_TYPE=openrc
+-	fi
+-      fi
+-    fi
+-    if test \( -z "$INIT_TYPE" -a -f /etc/init.d/cron -a ! -h /etc/init.d/cron \); then
+-      INIT_TYPE=SYSV
+-    fi
+-  fi
+-else
+-  INIT_TYPE=$init_type
+-fi
++		AS_IF([test $? -eq 0], [INIT_TYPE=openrc])
++	      ])
++          ])
++        AS_IF([test \( -z "$INIT_TYPE" -a -f /etc/init.d/cron -a ! -h /etc/init.d/cron \)], [INIT_TYPE=SYSV])
++      ])
++  ])
++AS_IF([test \( .$INIT_TYPE = .systemd -a -z "$with_systemdsystemunitdir" \)], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+ 
+ dnl ----[Default keepalived configuration file]----
+ AS_IF([test $default_config_file],
+   [
+     AS_IF([test $default_config_file = yes -o $default_config_file = no],
+-          AC_MSG_ERROR([A filename must be specified for default-config-file])
+-      ])
++	  [AC_MSG_ERROR([A filename must be specified for default-config-file])])
+     CONFIG_FILE=$default_config_file
+     add_config_opt([DEFAULT_CONFIG_FILE=${default_config_file}])
+   ],
+@@ -2493,7 +2490,7 @@ AS_IF([test $default_config_file],
+ AC_DEFINE_UNQUOTED([DEFAULT_CONFIG_FILE], ["$default_config_file"], [The default configuration file])
+ AC_SUBST([DEFAULT_CONFIG_FILE], [$default_config_file])
+ 
+-if test -z $INIT_TYPE; then
++if test -z "$INIT_TYPE"; then
+   INIT_TYPE=undetected
+ elif test $INIT_TYPE = systemd; then
+   AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
+--- a/configure	2019-03-30 12:47:25.313485929 +0000
++++ b/configure	2019-03-30 12:48:08.009841269 +0000
+@@ -1631,7 +1631,7 @@ Optional Packages:
+   --with-default-config-file=FILE
+                           Default configuration file
+   --with-systemdsystemunitdir=DIR
+-                          Directory for systemd service files
++                          Directory for systemd service files]
+ 
+ Some influential environment variables:
+   PKG_CONFIG  path to pkg-config utility
+@@ -3858,8 +3858,6 @@ fi
+ # Check whether --with-systemdsystemunitdir was given.
+ if test "${with_systemdsystemunitdir+set}" = set; then :
+   withval=$with_systemdsystemunitdir;
+-else
+-  with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)
+ fi
+ 
+ 
+@@ -5931,7 +5929,7 @@ $as_echo "yes" >&6; }
+ #define $WARN_VAR  1
+ _ACEOF
+ 
+-      if test -z $WARN_VAR_SHORT; then :
++      if test -z "$WARN_VAR_SHORT"; then :
+ 
+ else
+   cat >>confdefs.h <<_ACEOF
+@@ -12520,44 +12518,58 @@ fi
+ 
+ 
+ INIT_TYPE=
+-if test -z $init_type; then
++if test -n "$init_type"; then :
++  INIT_TYPE=$init_type
++elif test -n "$with_systemdsystemunitdir"; then :
++  INIT_TYPE=systemd
++else
++
+   /sbin/init --version 2>/dev/null | grep -q upstart
+-  if test $? -eq 0; then
++    if test $? -eq 0; then :
+     INIT_TYPE=upstart
+-  else
++else
++
+     init_path=`which systemctl 2>/dev/null`
+-    if test \( $? -eq 0 -a -x "$init_path" \); then
++        if test \( $? -eq 0 -a -x "$init_path" \); then :
++
+       systemctl | grep -q -- "-\.mount"
+-      if test $? -eq 0; then
++	    if test $? -eq 0; then :
+ 	INIT_TYPE=systemd
+-      fi
+-    fi
+-    if test \( -z "$INIT_TYPE" -a -f /etc/init.d/networking \); then
++fi
++
++fi
++        if test \( -z "$INIT_TYPE" -a -f /etc/init.d/networking \); then :
++
+       init_path=`which openrc-run 2>/dev/null`
+-      if test \( $? -eq 0 -a -x "$init_path" \); then
++	    if test \( $? -eq 0 -a -x "$init_path" \); then :
++
+ 	head -1 /etc/init.d/networking | grep -q "^#! */.*/openrc-run$"
+-	if test $? -eq 0; then
++		if test $? -eq 0; then :
+ 	  INIT_TYPE=openrc
+-	fi
+-      fi
+-    fi
+-    if test \( -z "$INIT_TYPE" -a -f /etc/init.d/cron -a ! -h /etc/init.d/cron \); then
++fi
++
++fi
++
++fi
++        if test \( -z "$INIT_TYPE" -a -f /etc/init.d/cron -a ! -h /etc/init.d/cron \); then :
+       INIT_TYPE=SYSV
+-    fi
+-  fi
+-else
+-  INIT_TYPE=$init_type
++fi
++
++fi
++
++fi
++if test \( .$INIT_TYPE = .systemd -a -z "$with_systemdsystemunitdir" \); then :
++  with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)
+ fi
+ 
+ if test $default_config_file; then :
+ 
+     if test $default_config_file = yes -o $default_config_file = no; then :
+   as_fn_error $? "A filename must be specified for default-config-file" "$LINENO" 5
+-
+ fi
+     CONFIG_FILE=$default_config_file
+     CONFIG_OPTIONS="$CONFIG_OPTIONS DEFAULT_CONFIG_FILE=${default_config_file}"
+-  ]
++
+ else
+   default_config_file="/etc/$PACKAGE/$PACKAGE.conf"
+ fi
+@@ -12569,7 +12581,7 @@ _ACEOF
+ DEFAULT_CONFIG_FILE=$default_config_file
+ 
+ 
+-if test -z $INIT_TYPE; then
++if test -z "$INIT_TYPE"; then
+   INIT_TYPE=undetected
+ elif test $INIT_TYPE = systemd; then
+   systemdsystemunitdir=$with_systemdsystemunitdir


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64 lantiq_xrx200, APU3, OpenWrt master
Run tested: x86_64 lantiq_xrx200, APU3, OpenWrt master, Failover

Description:
* Update to version 2.0.14
* add new vrrp_startup_delay option
