### PR TITLE
zoneinfo: Updated to the latest release.

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2007-2018 OpenWrt.org
+# Copyright (C) 2007-2019 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2018i
+PKG_VERSION:=2019a
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=82c45ef84ca3bc01d0a4a397ba8adeb8f7f199c6550740587c6ac5a7108c00d9
+PKG_HASH:=90366ddf4aa03e37a16cd49255af77f801822310b213f195e2206ead48c59772
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=aaacdb876ca6fb9d58e244b462cbc7578a496b1b10994381b4b32b9f2ded32dc
+   HASH:=8739f162bc30cdfb482435697f969253abea49595541a0afd5f443fbae433ff5
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT/LEDE master
Run tested: n/a

Description:

   Briefly:

     Palestine "springs forward" on 2019-03-30 instead of 2019-03-23.
     Metlakatla "fell back" to rejoin Alaska Time on 2019-01-20 at 02:00.

   Changes to past and future timestamps

     Palestine will not start DST until 2019-03-30, instead of 2019-03-23 as
     previously predicted.  Adjust our prediction by guessing that spring
     transitions will be between 24 and 30 March, which matches recent practice
     since 2016.  (Thanks to Even Scharning and Tim Parenti.)

     Metlakatla ended its observance of Pacific standard time,
     rejoining Alaska Time, on 2019-01-20 at 02:00.  (Thanks to Ryan
     Stanley and Tim Parenti.)

   Changes to past timestamps

     Israel observed DST in 1980 (08-02/09-13) and 1984 (05-05/08-25).
     (Thanks to Alois Treindl and Isaac Starkman.)

   Changes to time zone abbreviations

     Etc/UCT is now a backward-compatibility link to Etc/UTC, instead
     of being a separate zone that generates the abbreviation "UCT",
     which nowadays is typically a typo.  (Problem reported by Isiah
     Meadows.)

   Changes to code

     zic now has an -r option to limit the time range of output data.
     For example, 'zic -r @1000000000' limits the output data to
     timestamps starting 1000000000 seconds after the Epoch.
     This helps shrink output size and can be useful for applications
     not needing the full timestamp history, such as TZDIST truncation;
     see Internet RFC 8536 section 5.1.  (Inspired by a feature request
     from Christopher Wong, helped along by bug reports from Wong and
     from Tim Parenti.)

   Changes to documentation

     Mention Internet RFC 8536 (February 2019), which documents TZif.

     tz-link.html now cites tzdata-meta
     <https://tzdata-meta.timtimeonline.com/>.