### PR TITLE
zabbix: update to version 4.0.6

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -8,13 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
-PKG_VERSION:=4.0.3
+PKG_VERSION:=4.0.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=6b3d3b23c72a7af1958dc0938a566be03f0424cb44df5b2a9f487428f32d0463
 PKG_SOURCE_URL:=@SF/zabbix
+PKG_HASH:=2890851b3a4b0f70f69ef754aa0d07070b42440f56d280113a9474bc4ed75e5b
 
+PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:zabbix:zabbix
@@ -70,10 +71,9 @@ endef
 define Package/zabbix/Default
   SECTION:=admin
   CATEGORY:=Administration
+  SUBMENU:=zabbix
   TITLE:=Zabbix
   URL:=https://www.zabbix.com/
-  SUBMENU:=zabbix
-  MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
   USERID:=zabbix=53:zabbix=53
   DEPENDS += $(ICONV_DEPENDS) +libpcre +zlib +ZABBIX_GNUTLS:libgnutls +ZABBIX_OPENSSL:libopenssl
 endef

--- a/admin/zabbix/patches/010-change-agentd-config.patch
+++ b/admin/zabbix/patches/010-change-agentd-config.patch
@@ -27,7 +27,7 @@
  ### Option: LogFileSize
  #	Maximum size of log file in MB.
  #	0 - disable automatic log rotation.
-@@ -116,6 +113,7 @@ Server=127.0.0.1
+@@ -117,6 +114,7 @@ Server=127.0.0.1
  # Range: 0-100
  # Default:
  # StartAgents=3
@@ -35,7 +35,7 @@
  
  ##### Active checks related
  
-@@ -131,8 +129,6 @@ Server=127.0.0.1
+@@ -132,8 +130,6 @@ Server=127.0.0.1
  # Default:
  # ServerActive=
  
@@ -44,7 +44,7 @@
  ### Option: Hostname
  #	Unique, case sensitive hostname.
  #	Required for active checks and must match hostname as configured on the server.
-@@ -142,8 +138,6 @@ ServerActive=127.0.0.1
+@@ -143,8 +139,6 @@ ServerActive=127.0.0.1
  # Default:
  # Hostname=
  
@@ -53,7 +53,7 @@
  ### Option: HostnameItem
  #	Item used for generating Hostname if it is undefined. Ignored if Hostname is defined.
  #	Does not support UserParameters or aliases.
-@@ -261,8 +255,8 @@ Hostname=Zabbix server
+@@ -262,8 +256,8 @@ Hostname=Zabbix server
  # Include=
  
  # Include=/usr/local/etc/zabbix_agentd.userparams.conf

--- a/admin/zabbix/patches/110-reproducible-builds.patch
+++ b/admin/zabbix/patches/110-reproducible-builds.patch
@@ -1,11 +1,11 @@
 --- a/src/libs/zbxcommon/str.c
 +++ b/src/libs/zbxcommon/str.c
-@@ -52,7 +52,7 @@ static const char	help_message_footer[]
+@@ -54,7 +54,7 @@ static const char	help_message_footer[]
  void	version(void)
  {
  	printf("%s (Zabbix) %s\n", title_message, ZABBIX_VERSION);
 -	printf("Revision %s %s, compilation time: %s %s\n\n", ZABBIX_REVISION, ZABBIX_REVDATE, __DATE__, __TIME__);
 +	printf("Revision %s %s\n\n", ZABBIX_REVISION, ZABBIX_REVDATE);
  	puts(copyright_message);
- }
- 
+ #if defined(HAVE_POLARSSL) || defined(HAVE_GNUTLS) || defined(HAVE_OPENSSL)
+ 	printf("\n");


### PR DESCRIPTION
Maintainer: @champtar 
Compile tested: cortexa53, Turris MOX, OpenWrt master
Run tested: cortexa53, Turris MOX, OpenWrt master

Description:

- update to version 4.0.6. ([release notes](https://www.zabbix.com/rn/rn4.0.6))
- refreshed patches
- reordered stuff in Makefile

