### PR TITLE
lcdringer: Remove libcheck dependency to fix compilation

### DIFF
--- a/net/lcdringer/Makefile
+++ b/net/lcdringer/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lcdringer
 PKG_VERSION:=0.0.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -23,6 +23,7 @@ PKG_BUILD_DEPENDS:=vala
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk

--- a/net/lcdringer/patches/010-disable-check.patch
+++ b/net/lcdringer/patches/010-disable-check.patch
@@ -1,0 +1,12 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -87,9 +87,6 @@ fi
+ AC_SUBST(GSTREAMER_CFLAGS)
+ AC_SUBST(GSTREAMER_LIBS)
+ 
+-PKG_CHECK_MODULES([CHECK], [check >= 0.9.4],have_check=yes,have_check=no)
+-AM_CONDITIONAL(HAVE_CHECK, test x"$have_check" = "xyes")
+-
+ AM_PROG_VALAC([0.11.4])
+ AM_CONDITIONAL(HAVE_VALAC, test -x "$VALAC")
+ 


### PR DESCRIPTION
libcheck is some kind of testing framework. it is not only unnecessary, it
is not even used in the code.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
