### PR TITLE
python,python3: Fix overridden usr/bin symlinks

### DIFF
--- a/lang/python/python-package-install.sh
+++ b/lang/python/python-package-install.sh
@@ -58,6 +58,8 @@ python="$4"
 mode="$5"
 filespec="$6"
 
+SED="${SED:-sed -e}"
+
 find "$src_dir" -name "*\.exe" -exec rm -f {} \;
 
 process_filespec "$src_dir" "$dst_dir" "$filespec" || {
@@ -68,7 +70,7 @@ process_filespec "$src_dir" "$dst_dir" "$filespec" || {
 usr_bin_dir="$dst_dir/usr/bin"
 
 if [ -d "$usr_bin_dir" ] ; then
-	sed "1"'!'"b;s,^#"'!'".*python.*,#"'!'"/usr/bin/python${ver}," -i $usr_bin_dir/*
+	$SED "1"'!'"b;s,^#"'!'".*python.*,#"'!'"/usr/bin/python${ver}," -i --follow-symlinks $usr_bin_dir/*
 fi
 
 if [ "$mode" == "sources" ] ; then

--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -69,6 +69,7 @@ define PyPackage
 
   define Package/$(1)/install
 	$$(call PyPackage/$(1)/install,$$(1))
+	SED="$(SED)" \
 	$(SHELL) $(python_mk_path)python-package-install.sh "2" \
 		"$(PKG_INSTALL_DIR)" "$$(1)" \
 		"$(HOST_PYTHON_BIN)" "$$(2)" \

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -68,6 +68,7 @@ define Py3Package
 
   define Package/$(1)/install
 	$$(call Py3Package/$(1)/install,$$(1))
+	SED="$(SED)" \
 	$(SHELL) $(python3_mk_path)python-package-install.sh "3" \
 		"$(PKG_INSTALL_DIR)" "$$(1)" \
 		"$(HOST_PYTHON3_BIN)" "$$(2)" \


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-32, 2019-03-30 snapshot sdk
Run tested: none (ipks were extracted to examine the results)

Description:
Currently, all files in usr/bin (presumably all Python scripts) are run through sed to replace the shebang; sed will overwrite the file whether or not a match is found. This causes symlinks to be overridden and made into copies of their targets. python[3]-base and python[3]-dev are affected by this.

~~This changes the logic to first test if the file is not a symlink, and if it actually contains a replaceable shebang, before using sed to replace the shebang. This also makes the sed script simpler and the pattern slightly more specific.~~

This adds the `--follow-symlinks` flag to sed, in addition to using `$(SED)`, so that symlinks are not overridden.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>