### PR TITLE
python-pyotp: add new package for Python3

### DIFF
--- a/lang/python/python-pyotp/Makefile
+++ b/lang/python/python-pyotp/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pyotp
+PKG_VERSION:=2.2.7
+PKG_RELEASE:=1
+
+PKG_SOURCE:=pyotp-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyotp
+PKG_HASH:=be0ffeabddaa5ee53e7204e7740da842d070cf69168247a3d0c08541b84de602
+
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pyotp
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Python One-Time Password Library
+  URL:=https://github.com/pyauth/pyotp
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-pyotp/description
+  PyOTP is a Python library for generating and verifying one-time passwords.
+  It can be used to implement two-factor (2FA) or multi-factor (MFA) authentication methods
+  in web applications and in other systems that require users to log in.
+endef
+
+$(eval $(call Py3Package,python3-pyotp))
+$(eval $(call BuildPackage,python3-pyotp))
+$(eval $(call BuildPackage,python3-pyotp-src))


### PR DESCRIPTION
Maintainer: me (@BKPepe)
Compile tested: 
OpenWrt 18.06.02 - Xiaomi Mi WiFi R3G, ramips, mt7621
OpenWrt master - Turris MOX, mvebu, cortexa53
Run tested: 
OpenWrt 18.06.02 - Xiaomi Mi WiFi R3G, ramips, mt7621
OpenWrt master - Turris MOX, mvebu, cortexa53

![image](https://user-images.githubusercontent.com/4096468/55288942-b5795f00-53bf-11e9-8000-dad4eb665196.png)
![image](https://user-images.githubusercontent.com/4096468/55289938-093e7500-53cd-11e9-9353-4640e2a9c3c6.png)

Description:
add new package: [PyOTP - The Python One-Time Password Library](https://github.com/pyauth/pyotp)

CC: @jefferyto , @commodo 