### PR TITLE
unbound: Make ECDSA support explicit

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,15 +9,16 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.9.1
-PKG_RELEASE:=1
-
-PKG_LICENSE:=BSD-3-Clause
-PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.unbound.net/downloads
+PKG_SOURCE_URL:=https://www.unbound.net/downloads
 PKG_HASH:=c3c0bf9b86ccba4ca64f93dd4fe7351308ab54293f297a67de5a8914c1dc59c5
+
+PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:nlnetlabs:unbound
 
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf
@@ -27,8 +28,8 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/unbound/Default
   TITLE:=Validating Recursive DNS Server
-  URL:=http://www.unbound.net/
-  DEPENDS:=+libopenssl
+  URL:=https://www.unbound.net/
+  DEPENDS:=+libopenssl @OPENSSL_WITH_EC
 endef
 
 define Package/unbound
@@ -113,6 +114,7 @@ CONFIGURE_ARGS += \
 	--disable-dsa \
 	--disable-gost \
 	--enable-allsymbols \
+	--enable-ecdsa \
 	--enable-tfo-client \
 	--enable-tfo-server \
 	--with-libexpat="$(STAGING_DIR)/usr" \


### PR DESCRIPTION
Added a dependency to OPENSSL_WITH_EC to prevent any build failures.

Switched URLs to HTTPS.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @EricLuehrsen 
