### PR TITLE
libdouble-conversion: Update to 3.1.4

### DIFF
--- a/libs/libdouble-conversion/Makefile
+++ b/libs/libdouble-conversion/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdouble-conversion
-PKG_VERSION:=3.1.1
+PKG_VERSION:=3.1.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=double-conversion-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/google/double-conversion/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c49a6b3fa9c917f827b156c8e0799ece88ae50440487a99fc2f284cfd357a5b9
+PKG_HASH:=95004b65e43fefc6100f337a25da27bb99b9ef8d4071a36a33b5e83eb1f82021
 PKG_BUILD_DIR:=$(BUILD_DIR)/double-conversion-$(PKG_VERSION)
 
 PKG_MAINTAINER:=

--- a/libs/libdouble-conversion/patches/010-armeb.patch
+++ b/libs/libdouble-conversion/patches/010-armeb.patch
@@ -1,0 +1,11 @@
+--- a/double-conversion/utils.h
++++ b/double-conversion/utils.h
+@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
+     defined(_POWER) || defined(_ARCH_PPC) || defined(_ARCH_PPC64) || \
+     defined(__sparc__) || defined(__sparc) || defined(__s390__) || \
+     defined(__SH4__) || defined(__alpha__) || \
+-    defined(_MIPS_ARCH_MIPS32R2) || \
++    defined(_MIPS_ARCH_MIPS32R2) || defined(__ARMEB__) || \
+     defined(__AARCH64EL__) || defined(__aarch64__) || defined(__AARCH64EB__) || \
+     defined(__riscv) || \
+     defined(__or1k__) || defined(__arc__) || \


### PR DESCRIPTION
Added patch to fix compilation on big endian ARM.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody

@mhei This should fix the php problem on armeb.
