### PR TITLE
btrfs-progs: add support for zstd

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
 PKG_VERSION:=4.20.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs
@@ -28,7 +28,7 @@ define Package/btrfs-progs
   SECTION:=utils
   CATEGORY:=Utilities
   SUBMENU:=Filesystem
-  DEPENDS:=+libattr +libuuid +zlib +libblkid +liblzo +libpthread
+  DEPENDS:=+libattr +libuuid +zlib +zstd +libblkid +liblzo +libpthread
   TITLE:=Btrfs filesystems utilities
   URL:=https://btrfs.wiki.kernel.org/
 endef
@@ -52,8 +52,7 @@ CONFIGURE_ARGS += \
 	--disable-backtrace \
 	--disable-convert \
 	--disable-documentation \
-	--disable-python \
-	--disable-zstd
+	--disable-python
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib


### PR DESCRIPTION
This allows BTRFS encryption using zstd. Using zstd can increase
performance.

This change increases size of btrfs-progs only by 4K. The real effect on
size is only size of libzstd which is around 500K. This should be fine
on system requiring BTRFS so no variant without zstd was added.

Signed-off-by: Karel Kočí <karel.koci@nic.cz>

Maintainer: me
Compile tested: Turris Omnia, Mox, 1.x (master, openwrt-18.06)
Run tested: Turris Omnia (master)

Description:
I haven't tested zstd compressed FS per say. I just tested that btrfs-progs do work with this option enabled. That means that new subvolumes can be created and removed, stats can be queried. I have no idea about possible performance gain or anything like that but that is outside of this merge request I think. This just adds ability to manage btrfs with `zstd` mount option.