### PR TITLE
python3-pytest: add new package

### DIFF
--- a/lang/python/python-atomicwrites/Makefile
+++ b/lang/python/python-atomicwrites/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-atomicwrites
+PKG_VERSION:=1.3.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=atomicwrites-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/a/atomicwrites/
+PKG_HASH:=75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(atomicwrites-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-atomicwrites
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Atomic file writes
+  URL:=https://github.com/untitaker/python-atomicwrites
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-atomicwrites/description
+  Python library for atomic file writes.
+endef
+
+$(eval $(call Py3Package,python3-atomicwrites))
+$(eval $(call BuildPackage,python3-atomicwrites))
+$(eval $(call BuildPackage,python3-atomicwrites-src))

--- a/lang/python/python-importlib-metadata/Makefile
+++ b/lang/python/python-importlib-metadata/Makefile
@@ -1,0 +1,40 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-importlib_metadata
+PKG_VERSION:=0.19
+PKG_RELEASE:=1
+
+PKG_SOURCE:=importlib_metadata-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/i/importlib_metadata
+PKG_HASH:=23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/importlib_metadata-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-importlib-metadata
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Read metadata from Python packages
+  URL:=https://gitlab.com/python-devs/importlib_metadata
+  DEPENDS=+python3-light +python3-zipp
+  VARIANT:=python3
+endef
+
+PYTHON3_PKG_SETUP_VARS:= \
+        PKG_VERSION="$(PKG_VERSION)"
+
+define Package/python3-importlib-metadata/description
+  importlib_metadata is a library to access the metadata for a Python package.
+  It is intended to be ported to Python 3.8.
+endef
+
+$(eval $(call Py3Package,python3-importlib-metadata))
+$(eval $(call BuildPackage,python3-importlib-metadata))
+$(eval $(call BuildPackage,python3-importlib-metadata-src))

--- a/lang/python/python-importlib-metadata/patches/001-fix-scm-version.patch
+++ b/lang/python/python-importlib-metadata/patches/001-fix-scm-version.patch
@@ -1,0 +1,8 @@
+--- a/setup.py
++++ b/setup.py
+@@ -1,3 +1,4 @@
+ from setuptools import setup
++import os
+
+-setup(use_scm_version=True)
++setup(version=os.getenv('PKG_VERSION'))

--- a/lang/python/python-more-itertools/Makefile
+++ b/lang/python/python-more-itertools/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-more-itertools
+PKG_VERSION:=7.1.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=more-itertools-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/m/more-itertools
+PKG_HASH:=8bb43d1f51ecef60d81854af61a3a880555a14643691cc4b64a6ee269c78f09a
+PKG_BUILD_DIR:=$(BUILD_DIR)/more-itertools-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-more-itertools
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=More routines for operating on iterables, beyond itertools
+  URL:=https://github.com/erikrose/more-itertools
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-more-itertools/description
+  more-itertools library collects additional building blocks,
+  recipes, and routines for working with Python iterables.
+endef
+
+
+$(eval $(call Py3Package,python3-more-itertools))
+$(eval $(call BuildPackage,python3-more-itertools))
+$(eval $(call BuildPackage,python3-more-itertools-src))

--- a/lang/python/python-packaging/Makefile
+++ b/lang/python/python-packaging/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2019 CZ.NIC z.s.p.o. (http://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-packaging
+PKG_VERSION:=19.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=packaging-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/packaging/
+PKG_HASH:=0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af
+PKG_BUILD_DIR:=$(BUILD_DIR)/packaging-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=BSD-2-Clause Apache-2.0
+PKG_LICENSE_FILES:=LICENSE LICENSE.APACHE LICENSE.BSD
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-packaging
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Core utilities for Python packages
+  URL:=https://github.com/pypa/packaging
+  DEPENDS:=+python3-light +python3-pyparsing +python3-six
+  VARIANT:=python3
+endef
+
+define Package/python3-packaging/description
+  Core utilities for Python packages
+endef
+
+$(eval $(call Py3Package,python3-packaging))
+$(eval $(call BuildPackage,python3-packaging))
+$(eval $(call BuildPackage,python3-packaging-src))

--- a/lang/python/python-pluggy/Makefile
+++ b/lang/python/python-pluggy/Makefile
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pluggy
+PKG_VERSION:=0.12.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=pluggy-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pluggy/
+PKG_HASH:=0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc
+PKG_BUILD_DIR:=$(BUILD_DIR)/pluggy-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+PYTHON3_PKG_SETUP_VARS:= \
+        PKG_VERSION="$(PKG_VERSION)"
+
+define Package/python3-pluggy
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Plugin and hook calling mechanisms for Python
+  URL:=https://github.com/pytest-dev/pluggy
+  DEPENDS:=+python3-light +python3-importlib-metadata
+  VARIANT:=python3
+endef
+
+define Package/python3-pluggy/description
+  A minimalist production ready plugin system for python
+endef
+
+define Py3Build/Compile
+	echo "version = \"$(PKG_VERSION)\"" > $(PKG_BUILD_DIR)/src/pluggy/_version.py
+	$(call Py3Build/Compile/Default)
+endef
+
+$(eval $(call Py3Package,python3-pluggy))
+$(eval $(call BuildPackage,python3-pluggy))
+$(eval $(call BuildPackage,python3-pluggy-src))

--- a/lang/python/python-pluggy/patches/001-do-not-use-setuptools-scm.patch
+++ b/lang/python/python-pluggy/patches/001-do-not-use-setuptools-scm.patch
@@ -1,0 +1,18 @@
+--- a/setup.py
++++ b/setup.py
+@@ -1,4 +1,5 @@
+ from setuptools import setup
++import os
+
+ classifiers = [
+     "Development Status :: 4 - Beta",
+@@ -29,8 +30,7 @@ def main():
+         name="pluggy",
+         description="plugin and hook calling mechanisms for python",
+         long_description=long_description,
+-        use_scm_version={"write_to": "src/pluggy/_version.py"},
+-        setup_requires=["setuptools-scm"],
++        version=os.getenv('PKG_VERSION'),
+         license="MIT license",
+         platforms=["unix", "linux", "osx", "win32"],
+         author="Holger Krekel",

--- a/lang/python/python-py/Makefile
+++ b/lang/python/python-py/Makefile
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-py
+PKG_VERSION:=1.8.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=py-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/py/
+PKG_HASH:=dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53
+PKG_BUILD_DIR:=$(BUILD_DIR)/py-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+PYTHON3_PKG_SETUP_VARS:= \
+	PKG_VERSION="$(PKG_VERSION)"
+
+define Package/python3-py
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=py
+  URL:=https://github.com/pytest-dev/py
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-py/description
+  Library with cross-python path, ini-parsing, io, code, log facilities
+endef
+
+define Py3Build/Compile
+	echo "version = \"$(PKG_VERSION)\"" > $(PKG_BUILD_DIR)/py/_version.py
+	$(call Py3Build/Compile/Default)
+endef
+
+$(eval $(call Py3Package,python3-py))
+$(eval $(call BuildPackage,python3-py))
+$(eval $(call BuildPackage,python3-py-src))

--- a/lang/python/python-py/patches/001-do-not-use-setuptools.patch
+++ b/lang/python/python-py/patches/001-do-not-use-setuptools.patch
@@ -1,0 +1,17 @@
+--- a/setup.py
++++ b/setup.py
+@@ -1,3 +1,4 @@
++import os
+ from setuptools import setup, find_packages
+
+
+@@ -6,8 +7,7 @@ def main():
+         name='py',
+         description='library with cross-python path, ini-parsing, io, code, log facilities',
+         long_description=open('README.rst').read(),
+-        use_scm_version={"write_to": "py/_version.py"},
+-        setup_requires=["setuptools-scm"],
++        version=os.getenv('PKG_VERSION'),
+         url='http://py.readthedocs.io/',
+         license='MIT license',
+         platforms=['unix', 'linux', 'osx', 'cygwin', 'win32'],

--- a/lang/python/python-pyparsing/Makefile
+++ b/lang/python/python-pyparsing/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2019 CZ.NIC z.s.p.o. (http://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pyparsing
+PKG_VERSION:=2.4.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=pyparsing-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyparsing/
+PKG_HASH:=1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a
+PKG_BUILD_DIR:=$(BUILD_DIR)/pyparsing-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pyparsing
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Library for constructing grammar directly in python
+  URL:=https://github.com/pyparsing/pyparsing/
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-pyparsing/description
+  The pyparsing module is an alternative approach to creating
+  and executing simple grammars, vs. the traditional lex/yacc
+  approach, or the use of regular expressions.
+  The pyparsing module provides a library of classes that
+  client code uses to construct the grammar directly in Python code.
+endef
+
+$(eval $(call Py3Package,python3-pyparsing))
+$(eval $(call BuildPackage,python3-pyparsing))
+$(eval $(call BuildPackage,python3-pyparsing-src))

--- a/lang/python/python-pytest/Makefile
+++ b/lang/python/python-pytest/Makefile
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pytest
+PKG_VERSION:=5.0.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=pytest-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pytest/
+PKG_HASH:=95b700cf21ed5b7e91bce7a6b5a573b2e3ef7b3643d00f681d8f9c4672f9fbdf
+PKG_BUILD_DIR:=$(BUILD_DIR)/pytest-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+PYTHON3_PKG_SETUP_VARS:= \
+        PKG_VERSION="$(PKG_VERSION)"
+
+PKG_BUILD_DEPENDS:=+python3-setuptools
+
+define Package/python3-pytest
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Python testing framework
+  URL:=https://docs.pytest.org/en/latest/
+  DEPENDS:= \
+	+python3-light \
+	+python3-atomicwrites \
+	+python3-more-itertools \
+	+python3-py \
+	+python3-attrs \
+	+python3-pluggy \
+	+python3-importlib-metadata \
+	+python3-packaging \
+	+python3-wcwidth
+  VARIANT:=python3
+endef
+
+define Py3Build/Compile
+	echo "version = \"$(PKG_VERSION)\"" > $(PKG_BUILD_DIR)/src/_pytest/_version.py
+	$(call Py3Build/Compile/Default)
+endef
+
+define Package/python3-pytest/description
+  The pytest framework makes it easy to write small tests, yet scales to support
+  complex functional testing for applications and libraries.
+endef
+
+$(eval $(call Py3Package,python3-pytest))
+$(eval $(call BuildPackage,python3-pytest))
+$(eval $(call BuildPackage,python3-pytest-src))

--- a/lang/python/python-pytest/patches/001-do-not-use-setuptools-scm.patch
+++ b/lang/python/python-pytest/patches/001-do-not-use-setuptools-scm.patch
@@ -1,0 +1,19 @@
+--- a/setup.py
++++ b/setup.py
+@@ -1,4 +1,5 @@
+ from setuptools import setup
++import os
+
+ # TODO: if py gets upgrade to >=1.6,
+ #       remove _width_of_current_line in terminal.py
+@@ -18,8 +19,8 @@ INSTALL_REQUIRES = [
+
+ def main():
+     setup(
+-        use_scm_version={"write_to": "src/_pytest/_version.py"},
+-        setup_requires=["setuptools-scm", "setuptools>=40.0"],
++        version=os.getenv('PKG_VERSION'),
++        setup_requires=["setuptools>=40.0"],
+         package_dir={"": "src"},
+         # fmt: off
+         extras_require={

--- a/lang/python/python-wcwidth/Makefile
+++ b/lang/python/python-wcwidth/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2019 CZ.NIC z.s.p.o. (http://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-wcwidth
+PKG_VERSION:=0.1.7
+PKG_RELEASE:=1
+
+PKG_SOURCE:=wcwidth-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/w/wcwidth/
+PKG_HASH:=3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e
+PKG_BUILD_DIR:=$(BUILD_DIR)/wcwidth-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.txt
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-wcwidth
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Terminal width calculation library
+  URL:=https://github.com/jquast/wcwidth
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-wcwidth/description
+  Python library that measures the width of unicode strings rendered to a terminal
+endef
+
+$(eval $(call Py3Package,python3-wcwidth))
+$(eval $(call BuildPackage,python3-wcwidth))
+$(eval $(call BuildPackage,python3-wcwidth-src))

--- a/lang/python/python-zipp/Makefile
+++ b/lang/python/python-zipp/Makefile
@@ -1,0 +1,38 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-zipp
+PKG_VERSION:=0.5.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=zipp-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/z/zipp/
+PKG_HASH:=4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a
+PKG_BUILD_DIR:=$(BUILD_DIR)/zipp-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-zipp
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Zipfile object wrapper
+  URL:=https://github.com/jaraco/zipp
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+PYTHON3_PKG_SETUP_VARS:= \
+	PKG_VERSION="$(PKG_VERSION)"
+
+define Package/python3-zipp/description
+  Backport of pathlib-compatible object wrapper for zip files
+endef
+
+$(eval $(call Py3Package,python3-zipp))
+$(eval $(call BuildPackage,python3-zipp))
+$(eval $(call BuildPackage,python3-zipp-src))

--- a/lang/python/python-zipp/patches/001-fix-scm-version.patch
+++ b/lang/python/python-zipp/patches/001-fix-scm-version.patch
@@ -1,0 +1,11 @@
+--- a/setup.py
++++ b/setup.py
+@@ -1,6 +1,7 @@
+ #!/usr/bin/env python
+
+ import setuptools
++import os
+
+ if __name__ == "__main__":
+-    setuptools.setup(use_scm_version=True)
++    setuptools.setup(version=os.getenv('PKG_VERSION'))

--- a/lang/python/python3-zipp/Makefile
+++ b/lang/python/python3-zipp/Makefile
@@ -1,0 +1,37 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=zipp
+PKG_VERSION:=0.5.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/z/zipp/
+PKG_HASH:=4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-zipp
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Zipfile object wrapper
+  URL:=https://github.com/jaraco/zipp
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+PYTHON3_PKG_SETUP_VARS:= \
+	PKG_VERSION="$(PKG_VERSION)"
+
+define Package/python3-zipp/description
+  Backport of pathlib-compatible object wrapper for zip files
+endef
+
+$(eval $(call Py3Package,python3-zipp))
+$(eval $(call BuildPackage,python3-zipp))
+$(eval $(call BuildPackage,python3-zipp-src))

--- a/lang/python/python3-zipp/patches/001-fix-scm-version.patch
+++ b/lang/python/python3-zipp/patches/001-fix-scm-version.patch
@@ -1,0 +1,11 @@
+--- a/setup.py
++++ b/setup.py
+@@ -1,6 +1,7 @@
+ #!/usr/bin/env python
+
+ import setuptools
++import os
+
+ if __name__ == "__main__":
+-    setuptools.setup(use_scm_version=True)
++    setuptools.setup(version=os.getenv('PKG_VERSION'))


### PR DESCRIPTION
Maintainer: me  @ja-pa
Compile tested: Turris Omnia (TOS4), OpenWrt 18.06.2
Run tested: Turris Omnia (TOS4), OpenWrt 18.06.2

Description:
Pytest is a popular testing framework for python.  It allows to write scalable and complex test set. It also supports multiple useful plugins like xdist  pytest-django and more (see http://plugincompat.herokuapp.com)

I runtested package with examples provided in [docs](https://docs.pytest.org/en/latest/usage.html#detailed-summary-report)

This PR also adds python dependency required by pytest
- **pluggy**
- **atomicwrites** 
- **more-itertools**
- **py**
- **python3-importlib-metadata**
- **python3-wcwidth**
- **python3-zipp**
- **python3-packaging**
- **python3-pyparsing**

Why add this package:
* Pytest is a dependency for Deckard (https://gitlab.labs.nic.cz/knot/deckard/ )  utility, which tests DNS resolvers on the network to let users know when their ISP is mishandling DNS.  I would like to submit Deckard in some future PR.
* It's nice to have pytest on a router for testing new python packages and also updates.