### PR TITLE
libmicrohttpd: Revert to Named no-ssl Version

### DIFF
--- a/libs/libmicrohttpd/Makefile
+++ b/libs/libmicrohttpd/Makefile
@@ -30,10 +30,12 @@ define Package/libmicrohttpd/default
   URL:=http://www.gnu.org/software/libmicrohttpd/
 endef
 
-define Package/libmicrohttpd
+define Package/libmicrohttpd-no-ssl
 $(call Package/libmicrohttpd/default)
   VARIANT:=nossl
+  DEFAULT_VARIANT:=1
   CONFLICTS:=libmicrohttpd-ssl
+  PROVIDES:=libmicrohttpd
 endef
 
 define Package/libmicrohttpd-ssl
@@ -41,6 +43,7 @@ $(call Package/libmicrohttpd/default)
   TITLE+= with SSL support
   VARIANT:=ssl
   DEPENDS:=+libgcrypt +libgnutls +libgpg-error
+  CONFLICTS:=libmicrohttpd-no-ssl
   PROVIDES:=libmicrohttpd
 endef
 
@@ -76,7 +79,7 @@ define Build/InstallDev
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libmicrohttpd.pc $(1)/usr/lib/pkgconfig/
 endef
 
-define Package/libmicrohttpd/install
+define Package/libmicrohttpd-no-ssl/install
 	$(INSTALL_DIR) $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmicrohttpd.so* $(1)/usr/lib/
 endef
@@ -86,5 +89,5 @@ define Package/libmicrohttpd-ssl/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmicrohttpd.so* $(1)/usr/lib/
 endef
 
-$(eval $(call BuildPackage,libmicrohttpd))
+$(eval $(call BuildPackage,libmicrohttpd-no-ssl))
 $(eval $(call BuildPackage,libmicrohttpd-ssl))


### PR DESCRIPTION
Maintainer: Alexander Couzens lynxis@fe80.eu

Compile Tested: Snapshot SDK

Run Tested: target - ath79, hardware - gl-ar300m16, package - nodogsplash v3.2.1 and nodogsplash v3.3.1-beta, Openwrt Snapshot.

Description: Fix for issue #8180 and resubmitted PR #8563  - Any package with a dependency on the non-ssl version of libmicrohttpd ends up with the ssl version along with libgcrypt, libgnutls, .. This fix reverts the no-ssl version name from libmicrohttpd back to libmicrohttpd-no-ssl as it was in previous versions.
The two package names will now be libmicrohttpd-no-ssl and libmicrohttpd-ssl.

Signed-off-by: Rob White rob@blue-wave.net
