### PR TITLE
luasec: Replace -fPIC with $(FPIC)

### DIFF
--- a/lang/luasec/Makefile
+++ b/lang/luasec/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luasec
 PKG_VERSION:=0.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/brunoos/luasec/tar.gz/luasec-$(PKG_VERSION)?
@@ -40,6 +40,9 @@ endef
 
 define Build/Configure
 endef
+
+TARGET_CFLAGS += $(FPIC)
+TARGET_LDFLAGS += $(FPIC)
 
 MAKE_FLAGS += \
 	INCDIR="$(TARGET_CPPFLAGS) -I." \

--- a/lang/luasec/patches/100-fix-compilation.patch
+++ b/lang/luasec/patches/100-fix-compilation.patch
@@ -1,7 +1,16 @@
-diff --git a/src/Makefile b/src/Makefile
-index 9be2f14..93d1dc4 100644
 --- a/src/Makefile
 +++ b/src/Makefile
+@@ -15,8 +15,8 @@ WARN=-Wall -pedantic
+ BSD_CFLAGS=-O2 -fPIC $(WARN) $(INCDIR) $(DEFS)
+ BSD_LDFLAGS=-O -fPIC -shared $(LIBDIR)
+ 
+-LNX_CFLAGS=-O2 -fPIC $(WARN) $(INCDIR) $(DEFS)
+-LNX_LDFLAGS=-O -fPIC -shared $(LIBDIR)
++LNX_CFLAGS=$(INCDIR) $(DEFS)
++LNX_LDFLAGS=-shared $(LIBDIR)
+ 
+ MAC_ENV=env MACOSX_DEPLOYMENT_TARGET='$(MACVER)'
+ MAC_CFLAGS=-O2 -fno-common $(WARN) $(INCDIR) $(DEFS)
 @@ -33,10 +33,10 @@ LDFLAGS += $(MYLDFLAGS)
  all:
  


### PR DESCRIPTION
Currently i386 and the PPC targets have issues linking issues.

https://github.com/openwrt/packages/issues/3319

says that replacing -fPIC with -fpic works.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
