### PR TITLE
 qemu: explicitly disable dependency on libpmem, libudev, libxml2

### DIFF
--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -193,68 +193,72 @@ CONFIGURE_ARGS +=			\
 	--disable-fortify-source	\
 	--disable-stack-protector	\
 
+# Make a list from QEMU source code for reference
+#
+#	grep -E '^\s*--disable-[^)]+\)' configure | cut -f1 -d')' | sort -u
+#
 CONFIGURE_ARGS +=			\
 	--audio-drv-list=''		\
+	--disable-attr			\
+	--disable-bluez			\
+	--disable-brlapi		\
+	--disable-bsd-user		\
+	--disable-bzip2			\
+	--disable-cap-ng		\
+	--disable-cocoa			\
+	--disable-curl			\
 	--disable-debug-info		\
-	--disable-modules		\
-	--disable-sdl			\
-	--disable-qom-cast-debug	\
-	--disable-virtfs		\
-	--disable-vnc			\
 	--disable-debug-tcg		\
+	--disable-docs			\
+	--disable-gcrypt		\
+	--disable-glusterfs		\
+	--disable-gnutls		\
+	--disable-gtk			\
+	--disable-guest-agent-msi	\
+	--disable-jemalloc		\
+	--disable-libiscsi		\
+	--disable-libnfs		\
+	--disable-libssh2		\
+	--disable-libusb		\
+	--disable-linux-aio		\
+	--disable-lzo			\
+	--disable-modules		\
+	--disable-netmap		\
+	--disable-nettle		\
+	--disable-numa			\
+	--disable-opengl		\
+	--disable-qom-cast-debug	\
+	--disable-rbd			\
+	--disable-rdma			\
+	--disable-sdl			\
+	--disable-seccomp		\
+	--disable-smartcard		\
+	--disable-snappy		\
 	--disable-sparse		\
+	--disable-spice			\
 	--disable-strip			\
-	--disable-vnc-sasl		\
-	--disable-vnc-jpeg		\
-	--disable-vnc-png		\
+	--disable-strip			\
+	--disable-tcg-interpreter	\
+	--disable-tcmalloc		\
+	--disable-tools			\
+	--disable-tpm			\
+	--disable-usb-redir		\
 	--disable-uuid			\
 	--disable-vde			\
-	--disable-netmap		\
+	--disable-vhdx			\
+	--disable-virglrenderer		\
+	--disable-virtfs		\
+	--disable-vnc			\
+	--disable-vnc-jpeg		\
+	--disable-vnc-png		\
+	--disable-vnc-sasl		\
+	--disable-vte			\
+	--disable-werror		\
 	--disable-xen			\
 	--disable-xen-pci-passthrough	\
 	--disable-xen-pv-domain-build	\
-	--disable-brlapi		\
-	--disable-bluez			\
-	--disable-tcg-interpreter	\
-	--disable-cap-ng		\
-	--disable-spice			\
-	--disable-libiscsi		\
-	--disable-libnfs		\
-	--disable-cocoa			\
-	--disable-bsd-user		\
-	--disable-curl			\
-	--disable-linux-aio		\
-	--disable-attr			\
-	--disable-docs			\
-	--disable-opengl		\
-	--disable-rbd			\
 	--disable-xfsctl		\
-	--disable-smartcard		\
-	--disable-libusb		\
-	--disable-usb-redir		\
 	--disable-zlib-test		\
-	--disable-lzo			\
-	--disable-snappy		\
-	--disable-bzip2			\
-	--disable-guest-agent-msi	\
-	--disable-tools			\
-	--disable-seccomp		\
-	--disable-glusterfs		\
-	--disable-gtk			\
-	--disable-gnutls		\
-	--disable-nettle		\
-	--disable-gcrypt		\
-	--disable-rdma			\
-	--disable-vte			\
-	--disable-virglrenderer		\
-	--disable-tpm			\
-	--disable-libssh2		\
-	--disable-vhdx			\
-	--disable-numa			\
-	--disable-tcmalloc		\
-	--disable-jemalloc		\
-	--disable-strip			\
-	--disable-werror		\
 
 CONFIGURE_ARGS += --target-list='$(foreach target,$(QEMU_TARGET_LIST),$(if $(CONFIG_PACKAGE_qemu-$(target)),$(target)))'
 CONFIGURE_ARGS += $(if $(CONFIG_PACKAGE_qemu-ga),--enable-guest-agent)

--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qemu
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_HASH:=6a0508df079a0a33c2487ca936a56c12122f105b8a96a44374704bef6c69abfc
 PKG_SOURCE_URL:=http://download.qemu.org/
@@ -218,8 +218,11 @@ CONFIGURE_ARGS +=			\
 	--disable-jemalloc		\
 	--disable-libiscsi		\
 	--disable-libnfs		\
+	--disable-libpmem		\
 	--disable-libssh2		\
+	--disable-libudev		\
 	--disable-libusb		\
+	--disable-libxml2		\
 	--disable-linux-aio		\
 	--disable-lzo			\
 	--disable-modules		\
@@ -236,7 +239,6 @@ CONFIGURE_ARGS +=			\
 	--disable-snappy		\
 	--disable-sparse		\
 	--disable-spice			\
-	--disable-strip			\
 	--disable-strip			\
 	--disable-tcg-interpreter	\
 	--disable-tcmalloc		\

--- a/utils/qemu/patches/0001-configure-allow-disable-fortify_source.patch
+++ b/utils/qemu/patches/0001-configure-allow-disable-fortify_source.patch
@@ -1,7 +1,7 @@
-From 0b4011cd0983ced6e065f397049f967656494793 Mon Sep 17 00:00:00 2001
+From 82d1bb429533dcab4278ed21afc19ee303d7d3f5 Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <yszhou4tech@gmail.com>
 Date: Sat, 24 Feb 2018 13:43:19 +0800
-Subject: [PATCH 1/3] configure: allow disable fortify_source
+Subject: [PATCH 1/4] configure: allow disable fortify_source
 
 Tell build system of qemu to not add _FORTIFY_SOURCE options and let the
 OpenWrt base build system decide flavor of fortify_source to use
@@ -10,18 +10,15 @@ OpenWrt base build system decide flavor of fortify_source to use
  1 file changed, 2 insertions(+)
 
 diff --git a/configure b/configure
-index 0c6e757..8ea3fdd 100755
+index 0a3c6a72c3..d274df816c 100755
 --- a/configure
 +++ b/configure
-@@ -1313,6 +1313,8 @@ for opt do
+@@ -1491,6 +1491,8 @@ for opt do
    ;;
-   --disable-git-update) git_update=no
+   --disable-libpmem) libpmem=no
    ;;
 +  --disable-fortify-source) fortify_source="no"
 +  ;;
    *)
        echo "ERROR: unknown option $opt"
        echo "Try '$0 --help' for more information"
--- 
-1.8.3.1
-

--- a/utils/qemu/patches/0002-configure-allow-enabling-disabling-libudev-from-comm.patch
+++ b/utils/qemu/patches/0002-configure-allow-enabling-disabling-libudev-from-comm.patch
@@ -1,0 +1,25 @@
+From 4d7955f069922c482886e03e5cd352281dbce146 Mon Sep 17 00:00:00 2001
+From: Yousong Zhou <yszhou4tech@gmail.com>
+Date: Tue, 2 Apr 2019 06:31:31 +0000
+Subject: [PATCH 2/4] configure: allow enabling/disabling libudev from command
+ line
+
+---
+ configure | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/configure b/configure
+index d274df816c..a138faeb72 100755
+--- a/configure
++++ b/configure
+@@ -1491,6 +1491,10 @@ for opt do
+   ;;
+   --disable-libpmem) libpmem=no
+   ;;
++  --enable-libudev) libudev=yes
++  ;;
++  --disable-libudev) libudev=no
++  ;;
+   --disable-fortify-source) fortify_source="no"
+   ;;
+   *)

--- a/utils/qemu/patches/0003-disas-fix-compilation-failure-when-isnan-is-a-macro.patch
+++ b/utils/qemu/patches/0003-disas-fix-compilation-failure-when-isnan-is-a-macro.patch
@@ -1,14 +1,14 @@
-From 83e72b93889fbcbbfff281b0dbcc58c5a7455257 Mon Sep 17 00:00:00 2001
+From c480c25cf9265fe8e90c2c26d65c8a2fa174b0ea Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <yszhou4tech@gmail.com>
 Date: Sat, 24 Feb 2018 13:45:25 +0800
-Subject: [PATCH 2/3] disas: fix compilation failure when isnan is a macro
+Subject: [PATCH 3/4] disas: fix compilation failure when isnan is a macro
 
 ---
  disas/libvixl/vixl/utils.h | 16 +++++++++++-----
  1 file changed, 11 insertions(+), 5 deletions(-)
 
 diff --git a/disas/libvixl/vixl/utils.h b/disas/libvixl/vixl/utils.h
-index 5ab134e..df30663 100644
+index 5ab134e240..df30663df8 100644
 --- a/disas/libvixl/vixl/utils.h
 +++ b/disas/libvixl/vixl/utils.h
 @@ -118,11 +118,17 @@ double double_pack(uint64_t sign, uint64_t exp, uint64_t mantissa);
@@ -64,6 +64,3 @@ index 5ab134e..df30663 100644
    return rawbits_to_float(float_to_rawbits(num) | kFP32QuietNaNMask);
  }
  
--- 
-1.8.3.1
-

--- a/utils/qemu/patches/0004-pc-bios-fix-compilation-when-AS-is-actually-gcc-driv.patch
+++ b/utils/qemu/patches/0004-pc-bios-fix-compilation-when-AS-is-actually-gcc-driv.patch
@@ -1,7 +1,7 @@
-From b6d4bff30f2bdc3a6f26c9f6c7f32e352270d119 Mon Sep 17 00:00:00 2001
+From e030d1c14119e880a52788dd04325d489cf455ae Mon Sep 17 00:00:00 2001
 From: Yousong Zhou <yszhou4tech@gmail.com>
 Date: Sat, 24 Feb 2018 13:46:31 +0800
-Subject: [PATCH 3/3] pc-bios: fix compilation when $(AS) is actually gcc
+Subject: [PATCH 4/4] pc-bios: fix compilation when $(AS) is actually gcc
  driver
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 3/3] pc-bios: fix compilation when $(AS) is actually gcc
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/pc-bios/optionrom/Makefile b/pc-bios/optionrom/Makefile
-index a9a9e5e..f88b3ee 100644
+index a9a9e5e7eb..f88b3ee446 100644
 --- a/pc-bios/optionrom/Makefile
 +++ b/pc-bios/optionrom/Makefile
 @@ -34,7 +34,7 @@ endif
@@ -30,6 +30,3 @@ index a9a9e5e..f88b3ee 100644
  
  %.img: %.o
  	$(call quiet-command,$(LD) $(LDFLAGS_NOPIE) -m $(LD_I386_EMULATION) -T $(SRC_PATH)/pc-bios/optionrom/flat.lds -s -o $@ $<,"BUILD","$(TARGET_DIR)$@")
--- 
-1.8.3.1
-


### PR DESCRIPTION
Maintainer: me
Compile tested: x86/64, OpenWrt master
Run tested: x86/64 with QEMU, qemu-system-x86_64 --version


Description:

Supersedes #8571 
