### PR TITLE
btrfs-progs: make zstd optional

### DIFF
--- a/utils/btrfs-progs/Config.in
+++ b/utils/btrfs-progs/Config.in
@@ -1,0 +1,10 @@
+if PACKAGE_btrfs-progs
+
+config BTRFS_PROGS_ZSTD
+	bool "Build with zstd support"
+	depends on PACKAGE_libzstd
+	default n
+	help
+		This allows you to manage BTRFS with zstd compression
+
+endif

--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
 PKG_VERSION:=4.20.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs
@@ -28,7 +28,7 @@ define Package/btrfs-progs
   SECTION:=utils
   CATEGORY:=Utilities
   SUBMENU:=Filesystem
-  DEPENDS:=+libattr +libuuid +zlib +zstd +libblkid +liblzo +libpthread
+  DEPENDS:=+libattr +libuuid +zlib +libblkid +liblzo +libpthread +BTRFS_PROGS_ZSTD:libzstd
   TITLE:=Btrfs filesystems utilities
   URL:=https://btrfs.wiki.kernel.org/
 endef
@@ -38,6 +38,10 @@ define Package/btrfs-progs/description
  advanced features while focusing on fault tolerance, repair and easy
  administration. Initially developed by Oracle, Btrfs is licensed under the
  GPL and open for contribution from anyone.
+endef
+
+define Package/btrfs-progs/config
+	source "$(SOURCE)/Config.in"
 endef
 
 progs = btrfs btrfs-find-root btrfs-image btrfs-map-logical \
@@ -53,6 +57,9 @@ CONFIGURE_ARGS += \
 	--disable-convert \
 	--disable-documentation \
 	--disable-python
+ifneq ($(CONFIG_BTRFS_PROGS_ZSTD),y)
+CONFIGURE_ARGS += --disable-zstd
+endif
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, defconfig (master)
Run tested: Turris Omnia

Description:
This adds choice to compile support for zstd or not.
