### PR TITLE
znc: Update deprecated API patch

### DIFF
--- a/net/znc/Makefile
+++ b/net/znc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=znc
 PKG_VERSION:=1.7.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://znc.in/releases \

--- a/net/znc/patches/120-openssl-deprecated.patch
+++ b/net/znc/patches/120-openssl-deprecated.patch
@@ -1,3 +1,14 @@
+--- a/src/Utils.cpp
++++ b/src/Utils.cpp
+@@ -29,7 +29,7 @@
+ #include <openssl/ssl.h>
+ #include <openssl/bn.h>
+ #include <openssl/rsa.h>
+-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || (LIBRESSL_VERSION_NUMBER < 0x20700000L)
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+ #define X509_getm_notBefore X509_get_notBefore
+ #define X509_getm_notAfter X509_get_notAfter
+ #endif
 --- a/third_party/Csocket/Csocket.cc
 +++ b/third_party/Csocket/Csocket.cc
 @@ -47,10 +47,16 @@
@@ -18,11 +29,15 @@
  #define HAVE_ERR_REMOVE_STATE
  #ifdef OPENSSL_VERSION_NUMBER
  # if OPENSSL_VERSION_NUMBER >= 0x10000000
-@@ -594,9 +600,11 @@ void ShutdownCsocket()
- #ifndef OPENSSL_IS_BORINGSSL
- 	CONF_modules_unload( 1 );
- #endif
+@@ -583,6 +589,7 @@ bool InitCsocket()
+ void ShutdownCsocket()
+ {
+ #ifdef HAVE_LIBSSL
 +#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ #if defined( HAVE_ERR_REMOVE_THREAD_STATE )
+ 	ERR_remove_thread_state( NULL );
+ #elif defined( HAVE_ERR_REMOVE_STATE )
+@@ -597,6 +604,7 @@ void ShutdownCsocket()
  	ERR_free_strings();
  	EVP_cleanup();
  	CRYPTO_cleanup_all_ex_data();


### PR DESCRIPTION
ENGINE_cleanup is unavailable when deprecated APIs and ENGINE support are
disabled. The cleanup functions are unnecessary with OpenSSL 1.1.

The getm functions use a faulty if directive. Work around it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @KanjiMonster 
Compile tested: ramips