### PR TITLE
luasec: use gcc to link instead of ld

### DIFF
--- a/lang/luasec/Makefile
+++ b/lang/luasec/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luasec
 PKG_VERSION:=0.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/brunoos/luasec/tar.gz/luasec-$(PKG_VERSION)?
@@ -45,6 +45,7 @@ TARGET_CFLAGS += $(FPIC)
 TARGET_LDFLAGS += $(FPIC)
 
 MAKE_FLAGS += \
+	LD="$(TARGET_CC)" \
 	INCDIR="$(TARGET_CPPFLAGS) -I." \
 	LIBDIR="$(TARGET_LDFLAGS) -L./luasocket" \
 	LUACPATH="$(PKG_INSTALL_DIR)/usr/lib/lua" \

--- a/lang/luasec/Makefile
+++ b/lang/luasec/Makefile
@@ -46,8 +46,8 @@ TARGET_LDFLAGS += $(FPIC)
 
 MAKE_FLAGS += \
 	LD="$(TARGET_CC)" \
-	INCDIR="$(TARGET_CPPFLAGS) -I." \
-	LIBDIR="$(TARGET_LDFLAGS) -L./luasocket" \
+	INC_PATH="" \
+	LIB_PATH="" \
 	LUACPATH="$(PKG_INSTALL_DIR)/usr/lib/lua" \
 	LUAPATH="$(PKG_INSTALL_DIR)/usr/lib/lua"
 


### PR DESCRIPTION
Maintainer: @MikePetullo 
Compile tested: ramips (mipsel_74kc), i486_pentium4; openwrt master
Run tested: none

Description:
Linking with ld is not portable and was causing problems for some targets, e.g. i386_pentium4:
```
i486-openwrt-linux-musl-ld -L/opt/buildbot/slaves/lede-slave-tah/i386_pentium4/build/sdk/staging_dir/target-i386_pentium4_musl/usr/lib -L/opt/buildbot/slaves/lede-slave-tah/i386_pentium4/build/sdk/staging_dir/target-i386_pentium4_musl/lib -L/opt/buildbot/slaves/lede-slave-tah/i386_pentium4/build/sdk/staging_dir/toolchain-i386_pentium4_gcc-7.4.0_musl/usr/lib -L/opt/buildbot/slaves/lede-slave-tah/i386_pentium4/build/sdk/staging_dir/toolchain-i386_pentium4_gcc-7.4.0_musl/lib -znow -zrelro -fpic   -shared -L/opt/buildbot/slaves/lede-slave-tah/i386_pentium4/build/sdk/staging_dir/target-i386_pentium4_musl/usr/lib -L/opt/buildbot/slaves/lede-slave-tah/i386_pentium4/build/sdk/staging_dir/target-i386_pentium4_musl/lib -L/opt/buildbot/slaves/lede-slave-tah/i386_pentium4/build/sdk/staging_dir/toolchain-i386_pentium4_gcc-7.4.0_musl/usr/lib -L/opt/buildbot/slaves/lede-slave-tah/i386_pentium4/build/sdk/staging_dir/toolchain-i386_pentium4_gcc-7.4.0_musl/lib -znow -zrelro -fpic -L./luasocket -o ssl.so x509.o context.o ssl.o config.o ec.o -lssl -lcrypto -lluasocket
/opt/buildbot/slaves/lede-slave-tah/i386_pentium4/build/sdk/staging_dir/toolchain-i386_pentium4_gcc-7.4.0_musl/bin/i486-openwrt-linux-musl-ld: x509.o: in function `push_asn1_objname':
x509.c:(.text+0x61): undefined reference to `__stack_chk_fail_local'
/opt/buildbot/slaves/lede-slave-tah/i386_pentium4/build/sdk/staging_dir/toolchain-i386_pentium4_gcc-7.4.0_musl/bin/i486-openwrt-linux-musl-ld: x509.o: in function `meth_digest':
x509.c:(.text+0xaa6): undefined reference to `__stack_chk_fail_local'
/opt/buildbot/slaves/lede-slave-tah/i386_pentium4/build/sdk/staging_dir/toolchain-i386_pentium4_gcc-7.4.0_musl/bin/i486-openwrt-linux-musl-ld: x509.o: in function `meth_extensions':
x509.c:(.text+0xbca): undefined reference to `__stack_chk_fail_local'
/opt/buildbot/slaves/lede-slave-tah/i386_pentium4/build/sdk/staging_dir/toolchain-i386_pentium4_gcc-7.4.0_musl/bin/i486-openwrt-linux-musl-ld: ssl.o: in function `meth_info':
ssl.c:(.text+0x252): undefined reference to `__stack_chk_fail_local'
/opt/buildbot/slaves/lede-slave-tah/i386_pentium4/build/sdk/staging_dir/toolchain-i386_pentium4_gcc-7.4.0_musl/bin/i486-openwrt-linux-musl-ld: ./luasocket/libluasocket.a(buffer.o): in function `buffer_meth_receive':
buffer.c:(.text+0x7d4): undefined reference to `__stack_chk_fail_local'
Makefile:54: recipe for target 'ssl.so' failed
```
There was a ~600-byte increase in package size on ramips.  The library apparently had some more symbols added to it.  I did a diff on their `strings` output (showing the added symbols, not the whole output):
```
+_fini
+__cxa_finalize
+__deregister_frame_info
+__register_frame_info
+libgcc_s.so.1
+libc.so
+GCC_4.2.0
+GLIBC_2.0
+GCC_3.0
```
There were no human-readable subtractions.  I have no idea of what that means, though.
The package defaults to linking with `cc`.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
