### PR TITLE
btrfs-progs: drop unnecessary Kconfig dependency

### DIFF
--- a/utils/btrfs-progs/Config.in
+++ b/utils/btrfs-progs/Config.in
@@ -2,7 +2,6 @@ if PACKAGE_btrfs-progs
 
 config BTRFS_PROGS_ZSTD
 	bool "Build with zstd support"
-	depends on PACKAGE_libzstd
 	default n
 	help
 		This allows you to manage BTRFS with zstd compression


### PR DESCRIPTION
Signed-off-by: Karel Kočí <cynerd@email.cz>

Maintainer: me 
Compile tested: OpenWRT master
Run tested: not required

Description:
Error reported in https://github.com/openwrt/packages/pull/8576