### PR TITLE
prometheus-node-exporter-lua: fix missing conntrack values

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2018.12.30
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/conntrack.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/conntrack.lua
@@ -1,8 +1,12 @@
 local function scrape()
-  metric("node_nf_conntrack_entries", "gauge", nil,
-    string.sub(get_contents("/proc/sys/net/netfilter/nf_conntrack_count"), 1, -2))
-  metric("node_nf_conntrack_entries_limit", "gauge", nil,
-    string.sub(get_contents("/proc/sys/net/netfilter/nf_conntrack_max"), 1, -2))
+  local count = get_contents("/proc/sys/net/netfilter/nf_conntrack_count")
+  local max = get_contents("/proc/sys/net/netfilter/nf_conntrack_max")
+  if count ~= "" then
+    metric("node_nf_conntrack_entries", "gauge", nil, string.sub(count, 1, -2))
+  end
+  if max ~= "" then
+    metric("node_nf_conntrack_entries_limit", "gauge", nil, string.sub(max, 1, -2))
+  end
 end
 
 return { scrape = scrape }


### PR DESCRIPTION
If the `/proc/sys/net/netfilter/nc_conntrack_*` files are not present,
this exporter was outputting a blank value, which is invalid. These
files will not be present when using an image that doesn't include the
iptables and firewall packages (eg a minimal access-point type image).

This updates the collector to only output the metrics if the
corresponding `/proc` files are present.

Signed-off-by: Alex Tomlins <alex@tomlins.org.uk>

Maintainer: @champtar 
Run tested: (ar71xx, TP-Link WA901-nd, OpenWrt 18.06.2):
Patched file, and tested the served metrics endpoint with and without the conntrack support present.