### PR TITLE
Fix "Sign your work" link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ All packages you commit or submit by pull-request should follow these simple gui
 * Have a useful description prefixed with the package name
     (E.g.: "foopkg: Add libzot dependency")
 * Include Signed-off-by tag in the commit comments.
-    See: [Sign your work](https://openwrt.org/docs/guide-developer/submittingpatches-tomerge?s[]=sign#sign_your_work)
+    See: [Sign your work](https://openwrt.org/submitting-patches#sign_your_work)
 
 ### Advice on pull requests:
 


### PR DESCRIPTION
This was linking to a non-existent page in the wiki.

Signed-off-by: Alex Tomlins <alex@tomlins.org.uk>