### PR TITLE
node-serialport: update to 7.1.4

### DIFF
--- a/lang/node-serialport/Makefile
+++ b/lang/node-serialport/Makefile
@@ -9,18 +9,18 @@ include $(TOPDIR)/rules.mk
 
 PKG_NPM_NAME:=serialport
 PKG_NAME:=node-$(PKG_NPM_NAME)
-PKG_VERSION:=6.1.1
-PKG_RELEASE:=2
+PKG_VERSION:=7.1.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
-PKG_SOURCE_URL:=http://registry.npmjs.org/$(PKG_NPM_NAME)/-/
-PKG_HASH:=b58c326d217fb0af1639e4ea834d9fca4be16934c486499e2ddac6e52b8dd560
+PKG_SOURCE_URL:=https://registry.npmjs.org/$(PKG_NPM_NAME)/-/
+PKG_HASH:=d6f60bd81fe94578dee8e82887a66c5b007ec3f346b13d8156dd94a46f2b4849
 
 PKG_BUILD_DEPENDS:=node/host
-PKG_NODE_VERSION:=`$(STAGING_DIR_HOSTPKG)/bin/node --version`
+PKG_USE_MIPS16:=0
 
-PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>
-PKG_LICENSE:=Custom
+PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>
+PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
@@ -29,8 +29,8 @@ define Package/node-serialport
   SUBMENU:=Node.js
   SECTION:=lang
   CATEGORY:=Languages
-  TITLE:=Node.js package to access serial ports for reading and writing
-  URL:=https://www.npmjs.org/package/serialport
+  TITLE:=Node.js package to access serial ports
+  URL:=https://serialport.io/
   DEPENDS:=+node +node-npm
 endef
 
@@ -38,39 +38,34 @@ define Package/node-serialport/description
  Node.js package to access serial ports for reading and writing OR Welcome your robotic JavaScript overlords. Better yet, program them!
 endef
 
-define Build/Prepare
-	/bin/tar xzf $(DL_DIR)/$(PKG_SOURCE) -C $(PKG_BUILD_DIR) --strip-components 1
-	$(Build/Patch)
-endef
+TAR_OPTIONS+= --strip-components 1
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
-CPU:=$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))
-
-EXTRA_LDFLAGS="-L$(TOOLCHAIN_DIR)/lib/ -Wl,-rpath-link $(TOOLCHAIN_DIR)/lib/" \
+NODEJS_CPU:=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))))
 
 define Build/Compile
-	cd $(PKG_BUILD_DIR) ; \
+	$(MAKE_VARS) \
 	$(MAKE_FLAGS) \
-	npm_config_arch=$(CONFIG_ARCH) \
-	npm_config_nodedir=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/ \
-	npm_config_cache=$(BUILD_DIR)/node-$(PKG_NODE_VERSION)/npm-cache \
-	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
-	npm install --build-from-source --target_arch=$(CPU) -g \
-		`npm pack $(PKG_BUILD_DIR) | tail -n 1`
+	npm_config_arch=$(NODEJS_CPU) \
+	npm_config_target_arch=$(NODEJS_CPU) \
+	npm_config_build_from_source=true \
+	npm_config_nodedir=$(STAGING_DIR)/usr/ \
+	npm_config_prefix=$(PKG_INSTALL_DIR)/usr/ \
+	npm_config_cache=$(TMP_DIR)/npm-cache \
+	npm_config_tmp=$(TMP_DIR)/npm-tmp \
+	npm install -g --build-from-source $(PKG_BUILD_DIR)
+	rm -rf $(TMP_DIR)/npm-tmp
+	rm -rf $(TMP_DIR)/npm-cache
 endef
 
 define Package/node-serialport/install
-	mkdir -p $(1)/usr/lib/node/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/* $(1)/usr/lib/node/
-	$(RM) -rf $(1)/usr/lib/node/node-hid/patches \
-		  $(1)/usr/lib/node/node-hid/.p* \
-		  $(1)/usr/lib/node/node-hid/.quilt* \
-		  $(1)/usr/lib/node/node-hid/.built* \
-		  $(1)/usr/lib/node/node-hid/.config*
-	# Strip PKG_BUILD_DIR from useless metadata inserted by npm install
-	# https://github.com/npm/npm/issues/10393
-	# https://github.com/npm/npm/issues/12110
-	find $(1)/usr/lib/node -name package.json -exec sed -i -e 's,$(PKG_BUILD_DIR),,g' {} +
+	$(INSTALL_DIR) $(1)/usr/lib/node/$(PKG_NPM_NAME)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/$(PKG_NPM_NAME)/{package.json,LICENSE,*.md} \
+		$(1)/usr/lib/node/$(PKG_NPM_NAME)/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/$(PKG_NPM_NAME)/test.js \
+		$(1)/usr/lib/node/$(PKG_NPM_NAME)/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/$(PKG_NPM_NAME)/{node_modules,lib} \
+		$(1)/usr/lib/node/$(PKG_NPM_NAME)/
 endef
 
 $(eval $(call BuildPackage,node-serialport))
-


### PR DESCRIPTION
Maintainer: me  ( @blogic )
 Compile tested: head r9773-6e060bd, aarch64_cortex-a53_gcc-7.4.0_musl
Run tested: aarch64 (ec2 a1 docker)

Description:
update to 7.1.4
Takeover of PKG_MAINTAINER
Major Makefile Updates

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
