### PR TITLE
python,python3: Add PYTHON[3]_PKG_SETUP_GLOBAL_ARGS

### DIFF
--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -116,6 +116,7 @@ define Build/Compile/PyMod
 endef
 
 PYTHON_PKG_SETUP_DIR ?=
+PYTHON_PKG_SETUP_GLOBAL_ARGS ?=
 PYTHON_PKG_SETUP_ARGS ?= --single-version-externally-managed
 PYTHON_PKG_SETUP_VARS ?=
 
@@ -125,6 +126,7 @@ define PyBuild/Compile/Default
 	)
 	$(call Build/Compile/PyMod, \
 		$(PYTHON_PKG_SETUP_DIR), \
+		$(PYTHON_PKG_SETUP_GLOBAL_ARGS) \
 		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
 		$(PYTHON_PKG_SETUP_ARGS), \
 		$(PYTHON_PKG_SETUP_VARS) \

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -115,6 +115,7 @@ define Build/Compile/Py3Mod
 endef
 
 PYTHON3_PKG_SETUP_DIR ?=
+PYTHON3_PKG_SETUP_GLOABL_ARGS ?=
 PYTHON3_PKG_SETUP_ARGS ?= --single-version-externally-managed
 PYTHON3_PKG_SETUP_VARS ?=
 
@@ -124,6 +125,7 @@ define Py3Build/Compile/Default
 	)
 	$(call Build/Compile/Py3Mod, \
 		$(PYTHON3_PKG_SETUP_DIR), \
+		$(PYTHON3_PKG_SETUP_GLOBAL_ARGS) \
 		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
 		$(PYTHON3_PKG_SETUP_ARGS), \
 		$(PYTHON3_PKG_SETUP_VARS) \


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-32, 2019-04-01 snapshot sdk
Run tested: none

Description:
Some packages (PyYAML, https://github.com/openwrt/packages/pull/8482#discussion_r270692276) recognize "global" options to setup.py; these must appear before the `install` command on the command line.

This adds `PYTHON[3]_PKG_SETUP_GLOBAL_ARGS`, which let packages set these global options.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>