### PR TITLE
pcre: Depending on C++ now

### DIFF
--- a/libs/pcre/Makefile
+++ b/libs/pcre/Makefile
@@ -30,6 +30,7 @@ define Package/libpcre/default
   SECTION:=libs
   CATEGORY:=Libraries
   URL:=https://www.pcre.org/
+  DEPENDS:=$(CXX_DEPENDS)
 endef
 
 define Package/libpcre
@@ -45,7 +46,7 @@ endef
 define Package/libpcrecpp
   $(call Package/libpcre/default)
   TITLE:=C++ wrapper for Perl Compatible Regular Expression library
-  DEPENDS:=+libpcre $(CXX_DEPENDS)
+  DEPENDS:=+libpcre
 endef
 
 TARGET_CFLAGS += $(FPIC)


### PR DESCRIPTION
Must depend on cpp for the unconditional --enable-cpp, or the build can
fail when CONFIG_PACKAGE_libpcrecpp is unset and nothing else has built
the c++ toolchain:

 configure: error: Invalid C++ compiler or C++ compiler flags
 Makefile:97: recipe for target '/usr/local/src/lede/build_dir/target-mipsel_24kc_musl/pcre-8.42/.configured_68b329da9893e34099c7d8ad5cb9c940' failed
 make[3]: *** [/usr/local/src/lede/build_dir/target-mipsel_24kc_musl/pcre-8.42/.configured_68b329da9893e34099c7d8ad5cb9c940] Error 1
 make[3]: Leaving directory '/usr/local/src/lede/feeds/packages/libs/pcre'
 time: package/feeds/packages/pcre/compile#4.48#0.30#6.88
 package/Makefile:107: recipe for target 'package/feeds/packages/pcre/compile' failed

Fixes: 17090fecf18c ("pcre: Fix compile of libpcrecpp")
Signed-off-by: Bjørn Mork <bjorn@mork.no>