### PR TITLE
aircrack-ng: Update to git commit 42f2b48d

### DIFF
--- a/net/aircrack-ng/Makefile
+++ b/net/aircrack-ng/Makefile
@@ -9,13 +9,16 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aircrack-ng
 PKG_VERSION:=1.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=$(PKG_SOURCE_VERSION)
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/aircrack-ng/aircrack-ng/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=7e03f9828495a3a1a781ad79e41805971bf7347c092df852820232bca866a19b
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/aircrack-ng/aircrack-ng.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=42f2b48d7f46b39e0d5d2f2a64cbf63f87416a70
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
+PKG_MIRROR_HASH:=17893e05278635675a77a3cb0927202ec4df2fc9a742689a7a88e4a8f27a69b6
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -33,12 +36,13 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_AIRCRACK_NG_HWLOC \
 	CONFIG_AIRCRACK_NG_SQLITE3
 
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/aircrack-ng
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+AIRCRACK_NG_HWLOC:libhwloc +libpcap +libpcre +libpthread +libstdcpp
+  DEPENDS:=+AIRCRACK_NG_HWLOC:libhwloc +libpcap +libpcre +libpthread $(CXX_DEPENDS)
   DEPENDS += +AIRCRACK_NG_OPENSSL:libopenssl
   DEPENDS += +AIRCRACK_NG_GCRYPT:libgcrypt
   DEPENDS += +AIRCRACK_NG_SQLITE3:libsqlite3
@@ -69,6 +73,11 @@ define Package/airmon-ng/description
   Bash script designed to turn wireless cards into monitor mode.
 endef
 
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	echo "$(PKG_VERSION)_rev$(PKG_SOURCE_VERSION)" > $(PKG_BUILD_DIR)/VERSION
+endef
+
 CONFIGURE_ARGS += \
 	--disable-silent-rules \
 	--enable-shared \
@@ -79,10 +88,10 @@ CONFIGURE_ARGS += \
 	\
 	PYTHON=$(PYTHON) \
 	\
-	$(if $(CONFIG_AIRCRACK_NG_OPENSSL),--with-openssl,--without-openssl) \
+	$(if $(CONFIG_AIRCRACK_NG_OPENSSL),,--without-openssl) \
 	$(if $(CONFIG_AIRCRACK_NG_GCRYPT),--with-gcrypt,--without-gcrypt) \
 	$(if $(CONFIG_AIRCRACK_NG_HWLOC),--enable-hwloc,--disable-hwloc) \
-	$(if $(CONFIG_AIRCRACK_NG_SQLITE3),--with-sqlite3,--without-sqlite3)
+	$(if $(CONFIG_AIRCRACK_NG_SQLITE3),--with-sqlite3=$(STAGING_DIR)/usr,--without-sqlite3)
 
 TARGET_CFLAGS += -Wall -Wextra -ffunction-sections -fdata-sections
 


### PR DESCRIPTION
Maintainer: Rick Farina zerochaos@gentoo.org @ZeroChaos-
Compile tested: mips_24kc_musl for GL-AR150 with master openwrt
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:

This patch updates the aircrack-ng package to their git revision
42f2b48d. This commit is the latest for the upcoming 1.6 release.