### PR TITLE
python-cryptodome: update to 3.8.1

### DIFF
--- a/lang/python/python-cryptodome/Makefile
+++ b/lang/python/python-cryptodome/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptodome
-PKG_VERSION:=3.7.3
+PKG_VERSION:=3.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=pycryptodome-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pycryptodome
-PKG_HASH:=1a222250e43f3c659b4ebd5df3e11c2f112aab6aef58e38af55ef5678b9f0636
+PKG_HASH:=68ad0ce4a374577a26bb7f458575abe3c2a342818b5280de6e5738870b7761b3
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cryptodome-$(PKG_VERSION)
 

--- a/lang/python/python-cryptodome/patches/002-omit-tests.patch
+++ b/lang/python/python-cryptodome/patches/002-omit-tests.patch
@@ -1,50 +1,12 @@
 --- a/setup.py
 +++ b/setup.py
-@@ -245,16 +245,6 @@
-     "Crypto.Signature",
-     "Crypto.Util",
-     "Crypto.Math",
--    "Crypto.SelfTest",
--    "Crypto.SelfTest.Cipher",
--    "Crypto.SelfTest.Hash",
--    "Crypto.SelfTest.IO",
--    "Crypto.SelfTest.Protocol",
--    "Crypto.SelfTest.PublicKey",
--    "Crypto.SelfTest.Random",
--    "Crypto.SelfTest.Signature",
--    "Crypto.SelfTest.Util",
--    "Crypto.SelfTest.Math",
- ]
- package_dir = {"Crypto": "lib/Crypto"}
- package_data = {
-@@ -268,30 +258,6 @@
-     "Crypto.Signature" : [ "*.pyi" ],
-     "Crypto.IO" : [ "*.pyi" ],
-     "Crypto.Util" : [ "*.pyi" ],
--    "Crypto.SelfTest.Cipher" : [
--        "test_vectors/AES/*.rsp",
--        "test_vectors/TDES/*.rsp",
--        "test_vectors/wycheproof/*.json",
--    ],
--    "Crypto.SelfTest.Hash" : [
--        "test_vectors/SHA1/*.rsp",
--        "test_vectors/SHA2/*.rsp",
--        "test_vectors/SHA3/*.txt",
--        "test_vectors/keccak/*.txt",
--        "test_vectors/BLAKE2s/*.txt",
--        "test_vectors/BLAKE2b/*.txt",
--        "test_vectors/wycheproof/*.json",
--    ],
--    "Crypto.SelfTest.Signature" : [
--        "test_vectors/DSA/*.*",
--        "test_vectors/ECDSA/*.*",
--        "test_vectors/PKCS1-v1.5/*.*",
--        "test_vectors/PKCS1-PSS/*.*",
--        "test_vectors/wycheproof/*.json",
--    ],
--    "Crypto.SelfTest.PublicKey" : [
--        "test_vectors/ECC/*.*",
--    ],
+@@ -293,6 +293,9 @@ package_data = {
+     ],
  }
  
- system_bits = 8 * struct.calcsize("P")
++packages = [i for i in packages if not i.startswith('Crypto.SelfTest')]
++package_data = {k: v for k, v in package_data.items() if not k.startswith('Crypto.SelfTest')}
++
+ ext_modules = [
+     # Hash functions
+     Extension("Crypto.Hash._MD2",

--- a/lang/python/python-cryptodomex/Makefile
+++ b/lang/python/python-cryptodomex/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptodomex
-PKG_VERSION:=3.7.3
+PKG_VERSION:=3.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=pycryptodomex-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pycryptodomex
-PKG_HASH:=b70fe991564e178af02ccf89435a8f9e8d052707a7c4b95bf6027cb785da3175
+PKG_HASH:=9251b3f6254d4274caa21b79bd432bf07afa3567c6f02f11861659fb6245139a
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cryptodomex-$(PKG_VERSION)
 

--- a/lang/python/python-cryptodomex/patches/002-omit-tests.patch
+++ b/lang/python/python-cryptodomex/patches/002-omit-tests.patch
@@ -1,50 +1,12 @@
 --- a/setup.py
 +++ b/setup.py
-@@ -245,16 +245,6 @@
-     "Crypto.Signature",
-     "Crypto.Util",
-     "Crypto.Math",
--    "Crypto.SelfTest",
--    "Crypto.SelfTest.Cipher",
--    "Crypto.SelfTest.Hash",
--    "Crypto.SelfTest.IO",
--    "Crypto.SelfTest.Protocol",
--    "Crypto.SelfTest.PublicKey",
--    "Crypto.SelfTest.Random",
--    "Crypto.SelfTest.Signature",
--    "Crypto.SelfTest.Util",
--    "Crypto.SelfTest.Math",
- ]
- package_dir = {"Crypto": "lib/Crypto"}
- package_data = {
-@@ -268,30 +258,6 @@
-     "Crypto.Signature" : [ "*.pyi" ],
-     "Crypto.IO" : [ "*.pyi" ],
-     "Crypto.Util" : [ "*.pyi" ],
--    "Crypto.SelfTest.Cipher" : [
--        "test_vectors/AES/*.*",
--        "test_vectors/TDES/*.*",
--        "test_vectors/wycheproof/*.*",
--    ],
--    "Crypto.SelfTest.Hash" : [
--        "test_vectors/SHA1/*.*",
--        "test_vectors/SHA2/*.*",
--        "test_vectors/SHA3/*.*",
--        "test_vectors/keccak/*.*",
--        "test_vectors/BLAKE2s/*.*",
--        "test_vectors/BLAKE2b/*.*",
--        "test_vectors/wycheproof/*.*",
--    ],
--    "Crypto.SelfTest.Signature" : [
--        "test_vectors/DSA/*.*",
--        "test_vectors/ECDSA/*.*",
--        "test_vectors/PKCS1-v1.5/*.*",
--        "test_vectors/PKCS1-PSS/*.*",
--        "test_vectors/wycheproof/*.*",
--    ],
--    "Crypto.SelfTest.PublicKey" : [
--        "test_vectors/ECC/*.*",
--    ],
+@@ -293,6 +293,9 @@ package_data = {
+     ],
  }
  
- system_bits = 8 * struct.calcsize("P")
++packages = [i for i in packages if not i.startswith('Crypto.SelfTest')]
++package_data = {k: v for k, v in package_data.items() if not k.startswith('Crypto.SelfTest')}
++
+ ext_modules = [
+     # Hash functions
+     Extension("Crypto.Hash._MD2",


### PR DESCRIPTION
Maintainer: me
Compile tested: [openwrt-sdk-sunxi-cortexa7_gcc-7.4.0_musl_eabi.Linux-x86_64](https://downloads.openwrt.org/snapshots/targets/sunxi/cortexa7/openwrt-sdk-sunxi-cortexa7_gcc-7.4.0_musl_eabi.Linux-x86_64.tar.xz), snapshot
Run tested: sun8i-h2-plus-orangepi-zero, snapshot
Tested with python3 -m Crypto.SelfTest
Test output:
```
Skipping AESNI tests
Skipping test of PCLMULDQD in AES GCM
...
Ran 23760 tests in 2186.056s
OK
```