### PR TITLE
mutt: bump to version 1.11.4

### DIFF
--- a/mail/mutt/Makefile
+++ b/mail/mutt/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mutt
-PKG_VERSION:=1.11.2
+PKG_VERSION:=1.11.4
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=ftp://ftp.mutt.org/pub/mutt/ \
 		https://bitbucket.org/mutt/mutt/downloads/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=da5cd4c39f228914d3933d8cf3a017c8271fdd9b9d81c6e4fc42ad22e1a28723
+PKG_HASH:=b651357ea6c8762178080493991c77ecb111d916d171d422500257ab48be2801
 
 PKG_MAINTAINER:=Phil Eichinger <phil@zankapfel.net>
 PKG_LICENSE:=GPL-2.0+


### PR DESCRIPTION
Signed-off-by: Phil Eichinger <phil@zankapfel.net>

Maintainer: me
Compile tested: (ar71xx, TL-WDR4300, 18.06.2)
Run tested: (ar71xx, TL-WDR4300, 18.06.2)
