### PR TITLE
libs/libx264: Update to 20190324 and rework Makefile

### DIFF
--- a/libs/libx264/Makefile
+++ b/libs/libx264/Makefile
@@ -8,55 +8,49 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=x264
-PKG_VERSION:=snapshot-20181006-2245
+PKG_VERSION:=snapshot-20190324-2245
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.videolan.org/x264/snapshots/
 PKG_MAINTAINER:=Adrian Panella <ianchi74@outlook.com>
-PKG_HASH:=eae60e969958c0759554d5e338dea9b91f1f1fe85d9523c152c2259d8546f469
+PKG_HASH:=68010057edaadffc7593933d13084e8d32e041c42b17c089513d88c917f2ad54
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 
-PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-TARGET_CFLAGS:=$(filter-out -O%,$(TARGET_CFLAGS)) -std=gnu99 -fPIC -O3 -ffast-math -I.
-MAKE_FLAGS+= LD="$(TARGET_CC) -o"
+TARGET_CFLAGS:=$(filter-out -O%,$(TARGET_CFLAGS))
+MAKE_FLAGS:=$(filter-out LD=%,$(MAKE_FLAGS)) LD="$(TARGET_CC) -o"
 
-# ARM ASM depends on ARM1156 or later, blacklist earlier or incompatible cores
-# AMD Geode LX and i486 do not have SSE
-CPU_ASM_BLACKLIST:=geode i486 arm920t arm926ej-s arm1136j-s arm1176jzf-s fa526 mpcore xscale \
-		   464fp mips32 24kc 34kc 74kc octeon mips64
+# Instead of blacklisting a boatload of platforms just enable
+# optimization where it makes sense (matters) ie ARMv7+ and x86_64
 
-ifneq ($(CONFIG_SOFT_FLOAT)$(findstring $(call qstrip,$(CONFIG_CPU_TYPE)),$(CPU_ASM_BLACKLIST)),)
-  CONFIGURE_VARS+= AS= 
-  MAKE_FLAGS+= AS= 
-  CONFIGURE_ARGS += --disable-asm
-else
+ifneq ($(findstring cortex-a,$(CPU_TYPE)),)
   CONFIGURE_ARGS += --enable-lto
-ifneq ($(CONFIG_TARGET_x86),)
-ifeq ($(CONFIG_NASM),y)
-  CONFIGURE_VARS+= AS=nasm
-  MAKE_FLAGS+= AS=nasm
-else
-  CONFIGURE_VARS+= AS= 
-  MAKE_FLAGS+= AS= 
-  CONFIGURE_ARGS += --disable-asm
-endif
-endif
+  else
+  ifneq ($(CONFIG_TARGET_x86_64),)
+    CONFIGURE_ARGS += --enable-lto
+    ifeq ($(CONFIG_NASM),y)
+      CONFIGURE_VARS+= AS=nasm
+      MAKE_FLAGS+= AS=nasm
+    endif
+    else
+    CONFIGURE_ARGS += --disable-asm
+  endif
 endif
 
 CONFIGURE_ARGS += \
-		--enable-shared \
-		--enable-pic \
-		--enable-strip \
 		--disable-cli \
+		--enable-shared \
+		--disable-opencl \
+		--enable-pic \
 		--disable-avs \
 		--disable-ffms \
+		--disable-gpac \
 		--disable-lsmash
 
 define Package/libx264

--- a/libs/libx264/patches/001-fix-x32-build-by-disabling-asm.patch
+++ b/libs/libx264/patches/001-fix-x32-build-by-disabling-asm.patch
@@ -1,0 +1,48 @@
+From 66b120079fb21ed38cab0900c63360b0a7853eaa Mon Sep 17 00:00:00 2001
+From: Christopher Larson <chris_larson@mentor.com>
+Date: Tue, 13 Dec 2016 14:22:32 -0700
+Subject: [PATCH] Fix X32 build by disabling asm
+
+This applies gentoo's x32 patch, adjusted slightly, which disables asm support
+for x32 as well as correcting -m.
+
+Debian has a different patch which does the same, and there's a superior yet
+out of date patch series on the x264 list which keeps asm support enabled, but
+doesn't successfully build at this time, and my assembly is very rusty.
+
+Upstream-Status: Pending
+Signed-off-by: Christopher Larson <chris_larson@mentor.com>
+---
+ configure | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+--- a/configure
++++ b/configure
+@@ -736,7 +736,13 @@ case $host_cpu in
+         AS_EXT=".asm"
+         ASFLAGS="$ASFLAGS -DARCH_X86_64=1 -I\$(SRCPATH)/common/x86/"
+         stack_alignment=16
+-        [ $compiler = GNU ] && CFLAGS="-m64 $CFLAGS" && LDFLAGS="-m64 $LDFLAGS"
++        if [ $compiler = GNU ]; then
++            if cpp_check "" "" "__ILP32__" ; then
++                CFLAGS="-mx32 $CFLAGS" && LDFLAGS="-mx32 $LDFLAGS"
++            else
++                CFLAGS="-m64 $CFLAGS" && LDFLAGS="-m64 $LDFLAGS"
++            fi
++        fi
+         if [ "$SYS" = MACOSX ]; then
+             ASFLAGS="$ASFLAGS -f macho64 -DPREFIX"
+             if cc_check '' "-arch x86_64"; then
+@@ -755,7 +761,11 @@ case $host_cpu in
+                 RCFLAGS="--target=pe-x86-64 $RCFLAGS"
+             fi
+         else
+-            ASFLAGS="$ASFLAGS -f elf64"
++            if cpp_check "" "" "__ILP32__" ; then
++                asm=no
++            else
++                ASFLAGS="$ASFLAGS -f elf64"
++            fi
+         fi
+         ;;
+     powerpc*)

--- a/libs/libx264/patches/002-dont-default-to-cortex-a9-with-neon.patch
+++ b/libs/libx264/patches/002-dont-default-to-cortex-a9-with-neon.patch
@@ -1,0 +1,28 @@
+From a72bf499a0674fc75eedf15008b424e28f67e4bd Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@gherzan.ro>
+Date: Fri, 2 Feb 2018 15:10:08 +0200
+Subject: [PATCH] dont default to cortex-a9 with neon
+
+-march flag is not in CFLAGS so this will always default to
+ -mcpu=cortex-a8 -mfpu=neon.
+
+Upstream-Status: Pending
+
+Signed-off-by: Andrei Gherzan <andrei@gherzan.ro>
+Signed-off-by: Maxin B. John <maxin.john@intel.com>
+---
+ configure | 3 ---
+ 1 file changed, 3 deletions(-)
+
+--- a/configure
++++ b/configure
+@@ -940,9 +940,6 @@ if [ $asm = auto -a \( $ARCH = X86 -o $A
+ fi
+ 
+ if [ $asm = auto -a $ARCH = ARM ] ; then
+-    # set flags so neon is built by default
+-    [ $compiler == CL ] || echo $CFLAGS | grep -Eq '(-mcpu|-march|-mfpu)' || CFLAGS="$CFLAGS -mcpu=cortex-a8 -mfpu=neon"
+-
+     cc_check '' '' '__asm__("add r0, r1, r2");' && define HAVE_ARM_INLINE_ASM
+     if [ $compiler = CL ] && cpp_check '' '' 'defined(_M_ARM) && _M_ARM >= 7' ; then
+         define HAVE_ARMV6


### PR DESCRIPTION
Maintainer: @ianchi 
Compile tested: ipx40xx, Linksys EA8350v3, OpenWrt master + x86, x86_64 Generic, OpenWrt master
Run tested: ipx40xx, Linksys EA8350v3, OpenWrt master

Description:
* Update (lib)x264 to 20190324
* Stop using GNU Autotools and use libx264's own
  configuration facility
* Drop hardcoded CFLAGS, x264 will handle those fine on its own
  This will override toolchain optimizaion and set -O3
  irregardless of setting.
* Rework LTO and ASM optmization selection to make it more
  compact and readable. This drops optimization for x86 32-bit
  which is being deprecated in favour of x86_64 in general and
  the very few systems still in use that doesn't support 64-bit
  are too slow to be usable anyway.
* Import patches to fix compilation on ARM and x86 (32-bit)
  from OpenEmbedded
* Minor style fixes to Makefile

Source: http://cgit.openembedded.org/openembedded-core/tree/meta/recipes-multimedia/x264/x264

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>