### PR TITLE
 prometheus-node-exporter-lua: Add wifi_station_count metric

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2018.12.30
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
@@ -3,8 +3,8 @@ local iwinfo = require "iwinfo"
 
 local function scrape()
   local metric_wifi_station_signal = metric("wifi_station_signal_dbm","gauge")
-  local metric_wifi_station_tx_packets = metric("wifi_station_tx_packets_total","gauge")
-  local metric_wifi_station_rx_packets = metric("wifi_station_rx_packets_total","gauge")
+  local metric_wifi_station_tx_packets = metric("wifi_station_tx_packets_total","counter")
+  local metric_wifi_station_rx_packets = metric("wifi_station_rx_packets_total","counter")
 
   local u = ubus.connect()
   local status = u:call("network.wireless", "status", {})

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
@@ -2,6 +2,7 @@ local ubus = require "ubus"
 local iwinfo = require "iwinfo"
 
 local function scrape()
+  local metric_wifi_stations = metric("wifi_stations", "gauge")
   local metric_wifi_station_signal = metric("wifi_station_signal_dbm","gauge")
   local metric_wifi_station_tx_packets = metric("wifi_station_tx_packets_total","counter")
   local metric_wifi_station_rx_packets = metric("wifi_station_rx_packets_total","counter")
@@ -13,6 +14,7 @@ local function scrape()
     for _, intf in ipairs(dev_table['interfaces']) do
       local ifname = intf['ifname']
       local iw = iwinfo[iwinfo.type(ifname)]
+      local count = 0
 
       local assoclist = iw.assoclist(ifname)
       for mac, station in pairs(assoclist) do
@@ -23,7 +25,9 @@ local function scrape()
         metric_wifi_station_signal(labels, station.signal)
         metric_wifi_station_tx_packets(labels, station.tx_packets)
         metric_wifi_station_rx_packets(labels, station.rx_packets)
+        count = count + 1
       end
+      metric_wifi_stations({ifname = ifname}, count)
     end
   end
 end


### PR DESCRIPTION
Description:
This adds a `wifi_stations` gauge to report the number of connected wifi clients. I wasn't 100% sure what the best name for this metric is, so open to suggestions if you think there's a better name.

I've also fixed the `wifi_station_{tx,rx}_packets_total` metrics to be counters instead of gauges (similar to #7813 for the netdev collector)

Maintainer:  @champtar 
Compile tested: n/a
Run tested: (lantiq xrx200, BT Homehub 5a, 18.06.2):
Applied patched version of this file. Configured Prometheus to scrape it. All looks good.
