### PR TITLE
tgt: update to 1.0.76

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -4,26 +4,27 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tgt
-PKG_VERSION:=1.0.75
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.76
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fujita/tgt/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=1c719fdccc6ddc8e5de57a6e546aa64f41056a2fb1d710b8b2a22f65e08f5b90
+PKG_HASH:=fda84ae0cfc71e2b67ca2d073978f60cb52feea5a697601938ff86656bfdd8f9
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0
 
 PKG_USE_MIPS16:=0
+PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
 define Package/tgt
-  SECTION:=net
-  CATEGORY:=Network
-  URL:=http://stgt.sourceforge.net/
-  TITLE:=userspace iSCSI target
-  DEPENDS:=+libpthread +libaio
+	SECTION:=net
+	CATEGORY:=Network
+	URL:=http://stgt.sourceforge.net/
+	TITLE:=userspace iSCSI target
+	DEPENDS:=+libpthread +libaio
 endef
 
 define Package/tgt/description
@@ -34,12 +35,7 @@ a user-space daemon and user-space tools.
 endef
 
 define Build/Compile
-	CC=$(TARGET_CC) CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)" \
-		$(MAKE) -C $(PKG_BUILD_DIR) \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		LD="$(TARGET_CC)" \
-		LDFLAGS="$(TARGET_LDFLAGS)" \
-		install-programs
+	$(call Build/Compile/Default,programs)
 endef
 
 define Package/tgt/conffiles
@@ -50,7 +46,7 @@ define Package/tgt/install
 	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/init.d $(1)/usr/sbin
 	$(INSTALL_DATA) ./files/tgt.config $(1)/etc/config/tgt
 	$(INSTALL_BIN) ./files/tgt.init $(1)/etc/init.d/tgt
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/tgtd $(PKG_INSTALL_DIR)/usr/sbin/tgtadm $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/tgt{d,adm} $(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,tgt))


### PR DESCRIPTION
Signed-off-by: Maxim Storchak <m.storchak@gmail.com>

Maintainer: me
Compile tested: ath79, WNDR3800, r9439+2-fe90e48c39
Run tested: ath79, WNDR3800, r9439+2-fe90e48c39. dd on an ext4-formatted device using both aio and rdwr bstype.

Description:
fix segmentation fault caused by scsi_sprintf, see https://github.com/fujita/tgt/commit/0bf3f6915282dc8df2f02e6da30814951e52d179