### PR TITLE
wget: Add PKG_CPE_ID for proper CVE tracking

### DIFF
--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -18,6 +18,8 @@ PKG_MAINTAINER:=Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE:=GPL-3.0+
 PKG_LICENSE_FILES:=COPYING
 
+PKG_CPE_ID:=cpe:/a:gnu:wget
+
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION


Maintainer: @tripolar
Compile tested: N/A
Run tested: N/A

Description:
This PR adds PKG_CPE_ID for CVE tracking.
[wget version 1.20.3](https://github.com/ja-pa/packages/commit/3ea31d9646eed9f2cd6d0bace847b49c71a8de7e) fixed CVE-2019-5953  

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>