### PR TITLE
stunnel: update version to 5.51

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.50
+PKG_VERSION:=5.51
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0+
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=951d92502908b852a297bd9308568f7c36598670b84286d3e05d4a3a550c0149
+PKG_HASH:=77437cdd1aef1a621824bb3607e966534642fe90c69f4d2279a9da9fa36c3253
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool

--- a/net/stunnel/files/stunnel.init
+++ b/net/stunnel/files/stunnel.init
@@ -52,12 +52,13 @@ validate_service_options() {
 		'checkHost:list(host)' \
 		'checkIP:list(ipaddr)' \
 		'ciphers:list(string)' \
+		'ciphersuites:list(string)' \
 		'client:bool' \
 		'config:list(string)' \
 		'connect:list(string)' \
 		'CRLfile:string' \
 		'CRLpath:string' \
-		'curve:string' \
+		'curves:list(string)' \
 		'debug:or(range(0,7),string)' \
 		'delay:bool' \
 		'engineId:string' \
@@ -232,7 +233,6 @@ print_service_options() {
 		cert \
 		CRLfile \
 		CRLpath \
-		curve \
 		debug \
 		logId \
 		engineId \
@@ -294,6 +294,8 @@ print_service_options() {
 
 	print_lists_reduce : \
 		ciphers \
+		curves \
+		ciphersuites \
 		;
 
 	print_host_port \


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64 (APU3) lantiq_xrx200, OpenWrt master
Run tested: x86_64 (APU3) lantiq_xrx200, OpenWrt master, default config load

Description:

* Update to version 5.51
* Replace curve option with curves option list which is valid since openssl version 1.1.0.
  curve option is not supported anymore (no upgrade script now added)
* Add new ciphersuites option to control the list of permitted TLS 1.3 ciphersuites.