### PR TITLE
mosquitto: fix config option for password_file

### DIFF
--- a/net/mosquitto/files/etc/init.d/mosquitto
+++ b/net/mosquitto/files/etc/init.d/mosquitto
@@ -82,7 +82,7 @@ convert_mosq_general() {
 	append_if "$1" max_queued_bytes
 	append_if "$1" max_queued_messages
 	append_if "$1" message_size_limit
-	append_if "$1" passwd_file
+	append_if "$1" password_file
 	append_if "$1" pid_file
 	append_if "$1" psk_file
 	append_optional_bool "$1" queue_qos0_messages


### PR DESCRIPTION
Maintainer: @karlp
Compile tested: N/A
Run tested: Turris OS (OpenWRT-based)

Description: config option passwd_file is not recognized by mosquitto and it fails to start. The correct option name is password_file as per documentation.

Signed-off-by: Denis Shulyaka <Shulyaka@gmail.com>