### PR TITLE
protobuf-c: fix x86 build fail

### DIFF
--- a/libs/protobuf-c/Makefile
+++ b/libs/protobuf-c/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libprotobuf-c
 PKG_VERSION:=1.3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=protobuf-c-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/protobuf-c/protobuf-c/releases/download/v$(PKG_VERSION)

--- a/libs/protobuf-c/patches/001-t-generated-code2-cxx-generate-packed-data-fix.patch
+++ b/libs/protobuf-c/patches/001-t-generated-code2-cxx-generate-packed-data-fix.patch
@@ -1,0 +1,13 @@
+Index: protobuf-c-1.3.1/t/generated-code2/cxx-generate-packed-data.cc
+===================================================================
+--- protobuf-c-1.3.1.orig/t/generated-code2/cxx-generate-packed-data.cc
++++ protobuf-c-1.3.1/t/generated-code2/cxx-generate-packed-data.cc
+@@ -998,7 +998,7 @@ static void dump_test_packed_repeated_en
+ static void dump_test_unknown_fields (void)
+ {
+   EmptyMess mess;
+-  const google::protobuf::Message::Reflection *reflection = mess.GetReflection();
++  const google::protobuf::Reflection *reflection = mess.GetReflection();
+   google::protobuf::UnknownFieldSet *fs = reflection->MutableUnknownFields(&mess);
+ 
+ #if GOOGLE_PROTOBUF_VERSION >= 2001000


### PR DESCRIPTION
Maintainer: @neheb 
Compile tested: (x86, x86_64, OpenWrt 18.06)

Description:
While building for the x86 architecture protobuf-c package build fails reporting the following:
```
t/generated-code2/cxx-generate-packed-data.cc:1001:36: error: 'Reflection' in 'class google::protobuf::Message' does not name a type
   const google::protobuf::Message::Reflection *reflection = mess.GetReflection();
                                    ^~~~~~~~~~
t/generated-code2/cxx-generate-packed-data.cc:1002:43: error: 'reflection' was not declared in this scope
   google::protobuf::UnknownFieldSet *fs = reflection->MutableUnknownFields(&mess);
                                           ^~~~~~~~~~
t/generated-code2/cxx-generate-packed-data.cc:1002:43: note: suggested alternative: 'sigaction'
   google::protobuf::UnknownFieldSet *fs = reflection->MutableUnknownFields(&mess);
```
This PR solved the issue and the build finished without errors.