### PR TITLE
zabbix: Specify zlib location to fix buildbots

### DIFF
--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=4.0.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/zabbix
@@ -159,6 +159,7 @@ CONFIGURE_ARGS+= \
 	$(if $(CONFIG_ZABBIX_POSTGRESQL),--with-postgresql) \
 	--with-libevent=$(STAGING_DIR)/usr/include/libevent \
 	--with-libpcre=$(STAGING_DIR)/usr/include \
+	--with-zlib=$(STAGING_DIR)/usr/include \
 	$(if $(CONFIG_ZABBIX_GNUTLS),--with-gnutls="$(STAGING_DIR)/usr") \
 	$(if $(CONFIG_ZABBIX_OPENSSL),--with-openssl="$(STAGING_DIR)/usr")
 


### PR DESCRIPTION
The buildbots do not have zlib installed and therefore cannot build zabbix

checking for zlib support... no
configure: error: Unable to use zlib (zlib check failed)

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @champtar @Rixerx maybe.

https://downloads.openwrt.org/snapshots/faillogs/mips_24kc/packages/zabbix/compile.txt