### PR TITLE
libmodbus: backport RS485 fixes

### DIFF
--- a/libs/libmodbus/Makefile
+++ b/libs/libmodbus/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmodbus
 PKG_VERSION:=3.1.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://libmodbus.org/releases

--- a/libs/libmodbus/patches/0001-Only-set-SER_RS485_ENABLED-bit-of-existing-RS485-set.patch
+++ b/libs/libmodbus/patches/0001-Only-set-SER_RS485_ENABLED-bit-of-existing-RS485-set.patch
@@ -1,0 +1,43 @@
+From 1c5d969f46ccd5333f602dfbe2b0a1295650b9b0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?St=C3=A9phane=20Raimbault?= <stephane.raimbault@gmail.com>
+Date: Wed, 25 Oct 2017 20:35:47 +0200
+Subject: [PATCH 1/2] Only set SER_RS485_ENABLED bit of existing RS485 settings
+
+Thanks to @JCWren
+---
+ src/modbus-rtu.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/modbus-rtu.c b/src/modbus-rtu.c
+index 8d9f386..f2911d6 100644
+--- a/src/modbus-rtu.c
++++ b/src/modbus-rtu.c
+@@ -909,9 +909,13 @@ int modbus_rtu_set_serial_mode(modbus_t *ctx, int mode)
+ #if HAVE_DECL_TIOCSRS485
+         modbus_rtu_t *ctx_rtu = ctx->backend_data;
+         struct serial_rs485 rs485conf;
+-        memset(&rs485conf, 0x0, sizeof(struct serial_rs485));
+ 
+         if (mode == MODBUS_RTU_RS485) {
++            // Get
++            if (ioctl(ctx->s, TIOCGRS485, &rs485conf) < 0) {
++                return -1;
++            }
++            // Set
+             rs485conf.flags = SER_RS485_ENABLED;
+             if (ioctl(ctx->s, TIOCSRS485, &rs485conf) < 0) {
+                 return -1;
+@@ -923,6 +927,10 @@ int modbus_rtu_set_serial_mode(modbus_t *ctx, int mode)
+             /* Turn off RS485 mode only if required */
+             if (ctx_rtu->serial_mode == MODBUS_RTU_RS485) {
+                 /* The ioctl call is avoided because it can fail on some RS232 ports */
++                if (ioctl(ctx->s, TIOCGRS485, &rs485conf) < 0) {
++                    return -1;
++                }
++                rs485conf.flags &= ~SER_RS485_ENABLED;
+                 if (ioctl(ctx->s, TIOCSRS485, &rs485conf) < 0) {
+                     return -1;
+                 }
+-- 
+2.21.0
+

--- a/libs/libmodbus/patches/0002-Oops-fix-OR-on-RS485-settings-1c5d969.patch
+++ b/libs/libmodbus/patches/0002-Oops-fix-OR-on-RS485-settings-1c5d969.patch
@@ -1,0 +1,25 @@
+From 91a1d74f76c64e7b35bfb10114e1a4a6ff351656 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?St=C3=A9phane=20Raimbault?= <stephane.raimbault@gmail.com>
+Date: Thu, 26 Oct 2017 11:10:31 +0200
+Subject: [PATCH 2/2] Oops fix OR on RS485 settings (1c5d969)
+
+---
+ src/modbus-rtu.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/modbus-rtu.c b/src/modbus-rtu.c
+index f2911d6..190298e 100644
+--- a/src/modbus-rtu.c
++++ b/src/modbus-rtu.c
+@@ -916,7 +916,7 @@ int modbus_rtu_set_serial_mode(modbus_t *ctx, int mode)
+                 return -1;
+             }
+             // Set
+-            rs485conf.flags = SER_RS485_ENABLED;
++            rs485conf.flags |= SER_RS485_ENABLED;
+             if (ioctl(ctx->s, TIOCSRS485, &rs485conf) < 0) {
+                 return -1;
+             }
+-- 
+2.21.0
+


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: ramips/mt76x8
Run tested: ramips/mt76x8 (wrtnode2r)

Description:
Import two patches from upstream in order to fix Modbus-RTU over RS485:
 1c5d969 Only set SER_RS485_ENABLED bit of existing RS485 settings
 91a1d74 Oops fix OR on RS485 settings (1c5d969)

Signed-off-by: Daniel Golle <daniel@makrotopia.org>