### PR TITLE
prometheus-node-exporter-lua: Add more wifi_station metrics

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,8 +4,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2018.12.30
-PKG_RELEASE:=6
+PKG_VERSION:=2019.04.12
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
@@ -3,9 +3,22 @@ local iwinfo = require "iwinfo"
 
 local function scrape()
   local metric_wifi_stations = metric("wifi_stations", "gauge")
+
   local metric_wifi_station_signal = metric("wifi_station_signal_dbm","gauge")
-  local metric_wifi_station_tx_packets = metric("wifi_station_tx_packets_total","counter")
-  local metric_wifi_station_rx_packets = metric("wifi_station_rx_packets_total","counter")
+
+  local metric_wifi_station_inactive = metric('wifi_station_inactive_milliseconds', 'gauge')
+
+  local metric_wifi_station_exp_thr = metric('wifi_station_expected_throughput_kilobits_per_second', 'gauge')
+
+  local metric_wifi_station_tx_bitrate = metric('wifi_station_transmit_kilobits_per_second', 'gauge')
+  local metric_wifi_station_rx_bitrate = metric('wifi_station_receive_kilobits_per_second', 'gauge')
+
+  local metric_wifi_station_tx_packets = metric("wifi_station_transmit_packets_total","counter")
+  local metric_wifi_station_rx_packets = metric("wifi_station_receive_packets_total","counter")
+
+  local metric_wifi_station_tx_bytes = metric('wifi_station_transmit_bytes_total', 'counter')
+  local metric_wifi_station_rx_bytes = metric('wifi_station_receive_bytes_total', 'counter')
+
 
   local u = ubus.connect()
   local status = u:call("network.wireless", "status", {})
@@ -22,9 +35,30 @@ local function scrape()
           ifname = ifname,
           mac = mac,
         }
-        metric_wifi_station_signal(labels, station.signal)
+        if station.signal and station.signal ~= 0 then
+          metric_wifi_station_signal(labels, station.signal)
+        end
+        if station.inactive then
+          metric_wifi_station_inactive(labels, station.inactive)
+        end
+        if station.expected_throughput and station.expected_throughput ~= 0 then
+          metric_wifi_station_exp_thr(labels, station.expected_throughput)
+        end
+        if station.tx_rate and station.tx_rate ~= 0 then
+          metric_wifi_station_tx_bitrate(labels, station.tx_rate)
+        end
+        if station.rx_rate and station.rx_rate ~= 0 then
+          metric_wifi_station_rx_bitrate(labels, station.rx_rate)
+        end
         metric_wifi_station_tx_packets(labels, station.tx_packets)
         metric_wifi_station_rx_packets(labels, station.rx_packets)
+        if station.tx_bytes then
+          metric_wifi_station_tx_bytes(labels, station.tx_bytes)
+        end
+        if station.rx_bytes then
+          metric_wifi_station_rx_bytes(labels, station.rx_bytes)
+        end
+
         count = count + 1
       end
       metric_wifi_stations({ifname = ifname}, count)


### PR DESCRIPTION
prometheus-node-exporter-lua: Add more wifi_station metrics and fix naming according to original wifi_linux.go node exporter


Maintainer: Etienne CHAMPETIER <champetier.etienne@gmail.com>
Compile tested: ath79, UniFi AP AC Lite, OpenWrt master c8a8294f6e64367b7dc92eda6edca28efbb82053
Run tested: ath79, UniFi AP AC Lite, OpenWrt master c8a8294f6e64367b7dc92eda6edca28efbb82053. Simple Prometheus monitoring with native UI. Working normal.

Description:

Sometimes people need to gather tx/rx bytes and count the average throughput of some stations (for example). Moreover, if we are talking about Wi-Fi monitoring, bitrate statistics and inactivity time are "must have" features.
Also some drivers (ath9k and mt76) export expected_throughput metric so it is possible to monitor it too. Why not?
