### PR TITLE
Make mjpg-streamer init script recognize file output plugin

### DIFF
--- a/multimedia/mjpg-streamer/Makefile
+++ b/multimedia/mjpg-streamer/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mjpg-streamer
 PKG_VERSION:=2018-10-25
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>, \
 		Ted Hess <thess@kitschensync.net>
 

--- a/multimedia/mjpg-streamer/files/mjpg-streamer.init
+++ b/multimedia/mjpg-streamer/files/mjpg-streamer.init
@@ -80,6 +80,29 @@ start_instance() {
 		[ -n "$username" ] && [ -n "$password" ] && output_arg="${output_arg} --credentials $username:$password"
 	fi
 
+	if [ "x$output" = 'xfile' ]; then
+		output_arg="output_file.so"
+
+		config_get folder "$s" 'folder'
+		[ -n "$folder" ] && output_arg="${output_arg} --folder $folder"
+
+		config_get delay "$s" 'delay'
+		[ -n "$delay" ] && output_arg="${output_arg} --delay $delay"
+
+		config_get link "$s" 'link'
+		[ -n "$link" ] && output_arg="${output_arg} --link $link"
+
+		config_get ringbuffer "$s" 'ringbuffer'
+		[ -n "$ringbuffer" ] && output_arg="${output_arg} --size $ringbuffer"
+
+		config_get exceed "$s" 'exceed'
+		[ -n "$exceed" ] && output_arg="${output_arg} --exceed $exceed"
+
+		config_get command "$s" 'command'
+		[ -n "$command" ] && output_arg="${output_arg} --command $command"
+
+	fi
+
 	if [ -z "$output_arg" ]; then
 		error "unsuported output option '$output' in section '$s'"
 		return 1


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: n/a
Run tested: armv7l, Turris Omnia, Turris OS based on OpenWrt 15.05 r47055

Description:
Luci includes two output modules by default: http and file. This change is to allow file module options to be recognized by mjpg-streamer init script.
