### PR TITLE
nfs-kernel-server: allow running without NFSv3 daemons

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -164,7 +164,7 @@ define Host/Install
 endef
 
 define Package/nfs-kernel-server/install
-	$(INSTALL_DIR) $(1)/etc/init.d $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/etc/init.d $(1)/usr/sbin $(1)/etc/config
 	$(INSTALL_DATA) ./files/nfsd.exports $(1)/etc/exports
 	$(INSTALL_BIN) ./files/nfsd.init $(1)/etc/init.d/nfsd
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/statd/sm-notify $(1)/usr/sbin/
@@ -172,6 +172,7 @@ define Package/nfs-kernel-server/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/nfsd/nfsd $(1)/usr/sbin/rpc.nfsd
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/mountd/mountd $(1)/usr/sbin/rpc.mountd
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/utils/exportfs/exportfs $(1)/usr/sbin/
+	$(INSTALL_CONF) ./files/nfs.config $(1)/etc/config/nfs
 endef
 
 define Package/nfs-kernel-server-utils/install

--- a/net/nfs-kernel-server/files/nfs.config
+++ b/net/nfs-kernel-server/files/nfs.config
@@ -1,0 +1,2 @@
+config nfs 'nfs'
+	option minversion '3'

--- a/net/nfs-kernel-server/files/nfsd.init
+++ b/net/nfs-kernel-server/files/nfsd.init
@@ -11,7 +11,12 @@ RECOVERY_D=$NFS_D/v4recovery
 LOCK_D=/var/lib/nfs/sm
 VAR_NFS=/var/lib/nfs
 
-start_service() {
+validate_nfs_section() {
+	uci_load_validate nfs nfs "$1" "$2" \
+		'minversion:string'
+}
+
+start_nfs_instance() {
 	grep -q /proc/fs/nfsd /proc/mounts || \
 		mount -t nfsd nfsd /proc/fs/nfsd
 	mkdir -p $NFS_D
@@ -24,16 +29,24 @@ start_service() {
 
         sysctl -w fs.nfs.nlm_tcpport=32777 fs.nfs.nlm_udpport=32777 > /dev/null
 
-	procd_open_instance
-	procd_set_param command /usr/sbin/rpc.statd -p 32778 -o 32779 -F
-	procd_close_instance
+	if [ x"$minversion" = x3 ]; then
+		procd_open_instance
+		procd_set_param command /usr/sbin/rpc.statd -p 32778 -o 32779 -F
+		procd_close_instance
+	else
+		disable_v3="-N 3"
+	fi
 
 	/usr/sbin/exportfs -r
-	/usr/sbin/rpc.nfsd --grace-time 10
+	/usr/sbin/rpc.nfsd -s $disable_v3 --grace-time 10
 
 	procd_open_instance
 	procd_set_param command /usr/sbin/rpc.mountd -p 32780 -F
 	procd_close_instance
+}
+
+start_service() {
+	validate_nfs_section nfs start_nfs_instance
 }
 
 stop_service() {


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo mike@flyn.org

Maintainer: @tripolar
Compile tested: x86_64
Run tested: x86_64

Description:
This allows running NFS without rpc.statd and rpc.mountd, which are not needed for NFSv4. This reduces memory use and the attack surface of unnecessary network software. I was not sure the best way to do this without breaking backwards compatibility. I settled on adding /etc/config/nfs and option_minversion, which is '3' by default. Changing this to '4' prevents the daemons from running.

It might also be nice to move the NFSv3 daemons to a sub-package, but this might cause confusion to those who presently use the NFSv3 support.