### PR TITLE
ola: Fix compilation with protobuf 3.7

### DIFF
--- a/net/ola/Makefile
+++ b/net/ola/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ola
 PKG_VERSION:=0.10.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/OpenLightingProject/ola/tar.gz/$(PKG_VERSION)?

--- a/net/ola/patches/100-protobuf-3.7.patch
+++ b/net/ola/patches/100-protobuf-3.7.patch
@@ -1,0 +1,45 @@
+From d311970864a2338d63ce3c22a46bb9ec4bb26bfe Mon Sep 17 00:00:00 2001
+From: Peter Newman <peterjnewman@gmail.com>
+Date: Fri, 8 Mar 2019 15:43:50 +0000
+Subject: [PATCH] Attempt to fix Protobuf 3.7 builds
+
+---
+ configure.ac       |  3 +++
+ protoc/StrUtil.cpp | 10 ++++++++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 9824609b4..4f782847c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -803,6 +803,9 @@ AS_IF([test "${enable_rdm_tests}" = "yes"],
+ AS_IF([test "x$build_java_libs" = xyes],
+       [PROTOBUF_SUPPORT([2.4.0])],
+       [PROTOBUF_SUPPORT([2.3.0])])
++# Version 3.7 and above of protoc require some additional includes
++AC_CHECK_HEADERS([google/protobuf/io/strtod.h google/protobuf/stubs/logging.h \
++                  google/protobuf/stubs/stl_util.h])
+ 
+ 
+ # Doxygen
+diff --git a/protoc/StrUtil.cpp b/protoc/StrUtil.cpp
+index 85891a6a4..2914e82f1 100644
+--- a/protoc/StrUtil.cpp
++++ b/protoc/StrUtil.cpp
+@@ -41,6 +41,16 @@
+ 
+ #include "protoc/StrUtil.h"
+ 
++#ifdef HAVE_GOOGLE_PROTOBUF_IO_STRTOD_H
++#include <google/protobuf/io/strtod.h>
++#endif  // HAVE_GOOGLE_PROTOBUF_IO_STRTOD_H
++#ifdef HAVE_GOOGLE_PROTOBUF_STUBS_LOGGING_H
++#include <google/protobuf/stubs/logging.h>
++#endif  // HAVE_GOOGLE_PROTOBUF_STUBS_LOGGING_H
++#ifdef HAVE_GOOGLE_PROTOBUF_STUBS_STL_UTIL_H
++#include <google/protobuf/stubs/stl_util.h>
++#endif  // HAVE_GOOGLE_PROTOBUF_STUBS_STL_UTIL_H
++
+ #ifdef _WIN32
+ // MSVC has only _snprintf, not snprintf.
+ //

--- a/net/ola/patches/110-add-missing-config.h-incluude.patch
+++ b/net/ola/patches/110-add-missing-config.h-incluude.patch
@@ -1,0 +1,25 @@
+From 409a82f0e35fc33627f16180af7ba8a617347c8e Mon Sep 17 00:00:00 2001
+From: Peter Newman <peterjnewman@gmail.com>
+Date: Sat, 9 Mar 2019 14:08:01 +0000
+Subject: [PATCH] Add the missing config.h include
+
+---
+ protoc/StrUtil.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/protoc/StrUtil.cpp b/protoc/StrUtil.cpp
+index 2914e82f1..d300b71e8 100644
+--- a/protoc/StrUtil.cpp
++++ b/protoc/StrUtil.cpp
+@@ -41,6 +41,11 @@
+ 
+ #include "protoc/StrUtil.h"
+ 
++#if HAVE_CONFIG_H
++#include <config.h>
++#endif  // HAVE_CONFIG_H
++
++// Required for Protobuf 3.7 onwards
+ #ifdef HAVE_GOOGLE_PROTOBUF_IO_STRTOD_H
+ #include <google/protobuf/io/strtod.h>
+ #endif  // HAVE_GOOGLE_PROTOBUF_IO_STRTOD_H

--- a/net/ola/patches/120-compile-fix.patch
+++ b/net/ola/patches/120-compile-fix.patch
@@ -1,0 +1,14 @@
+--- a/protoc/CppFileGenerator.cpp
++++ b/protoc/CppFileGenerator.cpp
+@@ -223,9 +223,9 @@
+     printer->Print(
+       "namespace {\n"
+       "\n"
+-      "GOOGLE_PROTOBUF_DECLARE_ONCE(protobuf_AssignDescriptors_once_);\n"
++      "::google::protobuf::internal::once_flag protobuf_AssignDescriptors_once_;\n"
+       "inline void protobuf_AssignDescriptorsOnce() {\n"
+-      "  ::google::protobuf::GoogleOnceInit(&protobuf_AssignDescriptors_once_,"
++      "  ::google::protobuf::internal::call_once(protobuf_AssignDescriptors_once_,"
+       "\n"
+       "                 &$assigndescriptorsname$);\n"
+       "}\n"


### PR DESCRIPTION
The protobuf 3.7 update broke ola due to API changes. Backported a few
patches from upstream to deal with this.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @bk138 
Compile tested: ramips