### PR TITLE
opencv: Fix tarball URL to fix compilation

### DIFF
--- a/libs/opencv/Makefile
+++ b/libs/opencv/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opencv
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).zip
 PKG_SOURCE_URL:=http://sourceforge.net/projects/opencvlibrary/files/opencv-unix/$(PKG_VERSION)/

--- a/libs/opencv/patches/010-fix-url.patch
+++ b/libs/opencv/patches/010-fix-url.patch
@@ -1,0 +1,11 @@
+--- a/3rdparty/ippicv/downloader.cmake
++++ b/3rdparty/ippicv/downloader.cmake
+@@ -64,7 +64,7 @@ function(_icv_downloader)
+       if(DEFINED ENV{OPENCV_ICV_URL})
+         set(OPENCV_ICV_URL $ENV{OPENCV_ICV_URL})
+       else()
+-        set(OPENCV_ICV_URL "https://raw.githubusercontent.com/Itseez/opencv_3rdparty/${IPPICV_BINARIES_COMMIT}/ippicv")
++        set(OPENCV_ICV_URL "https://raw.githubusercontent.com/opencv/opencv_3rdparty/${IPPICV_BINARIES_COMMIT}/ippicv")
+       endif()
+     endif()
+ 


### PR DESCRIPTION
The github repository URL changed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lijpsummer ?

https://downloads.openwrt.org/snapshots/faillogs/x86_64/packages/opencv/compile.txt