### PR TITLE
miniupnpd: Update to 2.1.20190408

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -8,14 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
-PKG_VERSION:=2.1.20180706
+PKG_VERSION:=2.1.20190408
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=fc2d2fd044d8c3f8d02b63d70489bb35ece836a4fc1b6386865ac8fbe8d8b006
+PKG_HASH:=4175d588f600e2877503c781c5d75320dfce572669fcab7604434b07ec5c0d5d
 
 PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/version.mk
@@ -38,9 +39,9 @@ define Build/Prepare
 	echo "$(VERSION_NUMBER)" | tr '() ' '_' >$(PKG_BUILD_DIR)/os.openwrt
 endef
 
-TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS))
-TARGET_CFLAGS += -flto -ffunction-sections -fdata-sections -O2
-TARGET_LDFLAGS += $(FPIC) -flto -Wl,--gc-sections
+TARGET_CFLAGS += $(FPIC) -flto
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
+
 MAKE_FLAGS += \
 	TARGET_OPENWRT=1 TEST=0 LIBS="" \
 	CC="$(TARGET_CC) -DIPTABLES_143 -lip4tc -luuid \

--- a/net/miniupnpd/patches/100-build-on-OpenWrt.patch
+++ b/net/miniupnpd/patches/100-build-on-OpenWrt.patch
@@ -21,14 +21,14 @@
 +		if grep uuid_generate /usr/include/uuid/uuid.h > /dev/null 2>&1 ; then
 +			echo "#define LIB_UUID" >> ${CONFIGFILE}
 +		fi
-+		;;
++	;;
 +esac
  
  # set V6SOCKETS_ARE_V6ONLY to 0 if it was not set above
  if [ -z "$V6SOCKETS_ARE_V6ONLY" ] ; then
 --- a/Makefile.linux
 +++ b/Makefile.linux
-@@ -74,7 +74,10 @@ CPPFLAGS += -DIPTABLES_143
+@@ -77,7 +77,10 @@ CPPFLAGS += -DIPTABLES_143
  endif
  
  CFLAGS  += $(shell $(PKG_CONFIG) --cflags libiptc)
@@ -39,7 +39,7 @@
  LDFLAGS += $(shell $(PKG_CONFIG) --libs-only-L libiptc)
  LDFLAGS += $(shell $(PKG_CONFIG) --libs-only-other libiptc)
  else
-@@ -154,6 +157,8 @@ LDLIBS += $(shell $(PKG_CONFIG) --static
+@@ -157,6 +160,8 @@ LDLIBS += $(shell $(PKG_CONFIG) --static
  LDLIBS += $(shell $(PKG_CONFIG) --static --libs-only-l libnetfilter_conntrack)
  endif # ($(TEST),1)
  
@@ -48,11 +48,11 @@
  LDLIBS += $(shell $(PKG_CONFIG) --static --libs-only-l libssl)
  
  TEST := $(shell $(PKG_CONFIG) --exists uuid && echo 1)
-@@ -162,6 +167,7 @@ LDLIBS += $(shell $(PKG_CONFIG) --static
+@@ -165,6 +170,7 @@ LDLIBS += $(shell $(PKG_CONFIG) --static
  else
  $(info please install uuid-dev package / libuuid)
  endif # ($(TEST),1)
 +endif # ($(TARGET_OPENWRT,)
  
- TESTUPNPDESCGENOBJS = testupnpdescgen.o upnpdescgen.o
- 
+ GLIBC_VERSION := $(shell ldd --version | head -n 1 | sed 's/^.* //')
+ GLIBC_VERSION_MAJOR = $(shell echo $(GLIBC_VERSION) | cut -f 1 -d . )

--- a/net/miniupnpd/patches/200-remove-default-cflags.patch
+++ b/net/miniupnpd/patches/200-remove-default-cflags.patch
@@ -1,0 +1,27 @@
+--- a/Makefile.linux
++++ b/Makefile.linux
+@@ -23,16 +23,16 @@
+ #
+ #CFLAGS = -O -g -DDEBUG
+ CFLAGS ?= -Os
+-CFLAGS += -fno-strict-aliasing
+-CFLAGS += -fno-common
+-CFLAGS += -fstack-protector -fPIE
+-CFLAGS += -D_FORTIFY_SOURCE=2
+-CPPFLAGS += -D_GNU_SOURCE
+-CFLAGS += -Wall
+-CFLAGS += -Wextra -Wstrict-prototypes -Wdeclaration-after-statement
++#CFLAGS += -fno-strict-aliasing
++#CFLAGS += -fno-common
++#CFLAGS += -fstack-protector -fPIE
++#CFLAGS += -D_FORTIFY_SOURCE=2
++#CPPFLAGS += -D_GNU_SOURCE
++#CFLAGS += -Wall
++#CFLAGS += -Wextra -Wstrict-prototypes -Wdeclaration-after-statement
+ #CFLAGS += -Wno-missing-field-initializers
+ #CFLAGS += -ansi	# iptables headers does use typeof which is a gcc extension
+-LDFLAGS += -Wl,-z,now -Wl,-z,relro -pie
++LDFLAGS ?= -Wl,-z,now -Wl,-z,relro -pie
+ CC ?= gcc
+ RM = rm -f
+ INSTALL = install


### PR DESCRIPTION
Refreshed patch.

Added --as-needed linker flag for smaller size.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ath79
Run tested: Archer C7 v2