### PR TITLE
php7: facilitate running php7-fastcgi without listening on TCP socket

### DIFF
--- a/lang/php7/files/php7-fastcgi.init
+++ b/lang/php7/files/php7-fastcgi.init
@@ -11,12 +11,12 @@ start_instance() {
 	local port
 
 	config_get_bool enabled "$section" 'enabled' 0
-	config_get port "$section" 'port' 1026
+	config_get port "$section" 'port'
 
 	[ $enabled -gt 0 ] || return 1
 
 	PHP_FCGI_CHILDREN='' \
-	service_start /usr/bin/php-fcgi -b $port
+	service_start /usr/bin/php-fcgi ${port:+-b $port}
 }
 
 start() {


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: @mhei
Compile tested: x86_64
Run tested: x86_64

Description:
The init.d script for php7-fastcgi no longer invokes php7-fastcgi with the '-b' flag when 'port' does not appear in /etc/config/php7-fastcgi. This causes php7-fastcgi to communicate using only a Unix socket.