### PR TITLE
libpciaccess: add package

### DIFF
--- a/libs/libpciaccess/Makefile
+++ b/libs/libpciaccess/Makefile
@@ -1,0 +1,58 @@
+# Copyright (C) 2019 Lucian Cristian <lucian.cristian@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libpciaccess
+PKG_VERSION:=0.14
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://www.x.org/releases/individual/lib/
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_HASH:=3df543e12afd41fea8eac817e48cbfde5aed8817b81670a4e9e493bb2f5bf2a4
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+PKG_MAINTAINER:= Lucian Cristian <lucian.cristian@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libpciaccess
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Generic PCI access library
+  URL:=https://xorg.freedesktop.org/
+endef
+
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
+
+CONFIGURE_ARGS += \
+    --prefix=/usr
+
+define Build/InstallDev
+	$(INSTALL_DIR) \
+	  $(1)/usr/include \
+	  $(1)/usr/lib
+
+	$(CP) \
+	  $(PKG_INSTALL_DIR)/usr/include/* \
+	  $(1)/usr/include/
+
+	$(CP) \
+	  $(PKG_INSTALL_DIR)/usr/lib/{pkgconfig,*.so*} \
+	  $(1)/usr/lib/
+endef
+
+define Package/libpciaccess/install
+	$(INSTALL_DIR) \
+	  $(1)/usr/lib
+
+	$(CP) \
+	  $(PKG_INSTALL_DIR)/usr/lib/*.so* \
+	  $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libpciaccess))

--- a/libs/libpciaccess/patches/0004-Don-t-include-sys-io.h-on-arm.patch
+++ b/libs/libpciaccess/patches/0004-Don-t-include-sys-io.h-on-arm.patch
@@ -1,0 +1,28 @@
+From b6df5202306bd71158b482f25ca2e6919645d4dd Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 4 Jun 2015 20:55:06 -0700
+Subject: [PATCH 4/4] Don't include sys/io.h on arm
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+Upstream-Status: Pending
+
+ src/linux_sysfs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/linux_sysfs.c b/src/linux_sysfs.c
+index 3f95e53..1e3aad3 100644
+--- a/src/linux_sysfs.c
++++ b/src/linux_sysfs.c
+@@ -50,7 +50,7 @@
+ #include <dirent.h>
+ #include <errno.h>
+ 
+-#if defined(__i386__) || defined(__x86_64__) || defined(__arm__)
++#if defined(__i386__) || defined(__x86_64__)
+ #include <sys/io.h>
+ #else
+ #define inb(x) -1
+-- 
+2.1.4
+


### PR DESCRIPTION
Generic PCI access library used in Xorg, needed for libdrm

needed by updated libdrm #8677

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Maintainer: me
Compile/Run tested: x86
