### PR TITLE
python3-unidecode: add package

### DIFF
--- a/lang/python/python3-unidecode/Makefile
+++ b/lang/python/python3-unidecode/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-unidecode
+PKG_VERSION:=1.0.23
+PKG_RELEASE:=1
+
+PKG_SOURCE:=Unidecode-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/u/unidecode/
+PKG_HASH:=8b85354be8fd0c0e10adbf0675f6dc2310e56fda43fa8fe049123b6c475e52fb
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/Unidecode-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-unidecode
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=ASCII transliterations of Unicode text
+  URL:=https://github.com/avian2/unidecode
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python-unidecode/description
+Unidecode, lossy ASCII transliterations of Unicode text
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)-src))


### PR DESCRIPTION
Maintainer: me (@BKPepe)
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:

- add [Unidecode](https://github.com/avian2/unidecode) for Python3
There is already Text-Unidecode, but this one is licensed under GPL-2.0. It should have also better memory usage together with transliteration quality.

URL points to Github repository, which isn't mentioned on [pypi.org](https://pypi.org/project/Unidecode/) and there are not many details as on Github.

___

cc Python maintainers: @jefferyto , @commodo 