### PR TITLE
intltool: depend on hostpkg first

### DIFF
--- a/libs/intltool/Makefile
+++ b/libs/intltool/Makefile
@@ -7,18 +7,23 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=intltool
 PKG_VERSION:=0.51.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://launchpad.net/intltool/trunk/$(PKG_VERSION)/+download
 PKG_HASH:=67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
+
+HOST_BUILD_DEPENDS:=perl/host
 PKG_HOST_ONLY:=1
 HOST_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
+
+HOST_CONFIGURE_VARS+= \
+        PATH=$(STAGING_DIR_HOSTPKG)/bin:$(STAGING_DIR_HOSTPKG)/usr/bin:$(PATH)
 
 define Package/intltool
   SECTION:=libs


### PR DESCRIPTION
The scripts will use the $(STAGING_DIR)/bin/perl which is a simlink to native
perl, using $(STAGING_DIR_HOSTPKG) first will use the "perl/host" that has
multiple modules availabe to be built as host like perl-xml-parser

Using the $(STAGING_DIR)/bin/perl pakages that depend on "perl-xml-parser/host"
will fail with:

You must have XML::Parser installed to run
[...]/staging_dir/hostpkg/bin/intltool-merge

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Maintainer: @thess 
Compile/Run tested: x86

Description:
this is an alternative to #8131
