### PR TITLE
freeradius3: update to 3.0.19, workaround fifo error, and fix libpcre dependency

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
-PKG_VERSION:=release_3_0_18
+PKG_VERSION:=release_3_0_19
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive
-PKG_HASH:=c6802e3ec675b1cf59c850b0f01ed088e2983c5c4daa7f64cc22be4e6ad13ae5
+PKG_HASH:=34c50ac47a683b13eae1a02f2d0263c0bd51a83f01b99c02c5fe25df07a1ee77
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0
@@ -35,7 +35,7 @@ endef
 define Package/freeradius3/Default
   SECTION:=net
   CATEGORY:=Network
-  URL:=http://freeradius.org/
+  URL:=https://freeradius.org/
   SUBMENU:=FreeRADIUS (version 3)
 endef
 

--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -54,7 +54,7 @@ endef
 define Package/freeradius3-common
   $(call Package/freeradius3/Default)
   TITLE:=common files
-  DEPENDS:=+USE_GLIBC:libpthread +FREERADIUS3_OPENSSL:libopenssl +libcap +libpcap +libncurses +PACKAGE_libpcre:libpcre +libreadline +libtalloc +libatomic
+  DEPENDS:=+USE_GLIBC:libpthread +FREERADIUS3_OPENSSL:libopenssl +libcap +libpcap +libncurses +libpcre +libreadline +libtalloc +libatomic
 endef
 
 define Package/freeradius3-default

--- a/net/freeradius3/files/radiusd.init
+++ b/net/freeradius3/files/radiusd.init
@@ -19,7 +19,7 @@ start_service()
 	mkdir -p /var/db/radacct
 
 	procd_open_instance
-	procd_set_param command $PROG -f
+	procd_set_param command $PROG -s
 	procd_set_param env LD_LIBRARY_PATH=/usr/lib/freeradius3
 	[ -n "$IPADDR" ] && procd_append_param command -i $IPADDR
 	[ -n "$OPTIONS" ] && procd_append_param command $OPTIONS


### PR DESCRIPTION
Maintainer: no maintainer at this time
Compile tested: ARM, Linksys EA3500, master
Run tested: ARM, Linksys EA3500, master

Description:
- Fix the libpcre dependency in Makefile. This closes #8648.
- Workaround the fifo error introduced by the update to 3.0.18
- Update to 3.0.19: Latest stable release, contains security fixes for EAP-PWD.