### PR TITLE
botan: Disable NEON when soft float is disabled

### DIFF
--- a/libs/botan/Makefile
+++ b/libs/botan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=botan
 PKG_VERSION:=2.10.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=BangLang Huang <banglang.huang@foxmail.com>
 
 PKG_SOURCE:=Botan-$(PKG_VERSION).tgz
@@ -68,6 +68,9 @@ CONFIGURE_ARGS = \
 	--optimize-for-size \
 	$(DISABLE_IPV6)
 
+ifeq ($(CONFIG_SOFT_FLOAT),y)
+CONFIGURE_ARGS += --disable-neon
+endif
 
 TARGET_LDFLAGS += \
 	-Wl,--gc-sections,--as-needed \


### PR DESCRIPTION
For some reason, the build system enables NEON on platforms
that is should not. Fixes compilation on several ARM targets.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @hbl0307106015