### PR TITLE
node: support ppc32 musl

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
 PKG_VERSION:=v8.15.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=node-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/${PKG_VERSION}
 PKG_HASH:=6b6486a3f452624941f6e11dd5f878c298d43e9c21b5f43ca1721dc7ce25add1

--- a/lang/node/patches/005-powerpc32_musl_support.patch
+++ b/lang/node/patches/005-powerpc32_musl_support.patch
@@ -1,0 +1,16 @@
+--- a/deps/v8/src/libsampler/sampler.cc
++++ b/deps/v8/src/libsampler/sampler.cc
+@@ -456,8 +456,12 @@
+       reinterpret_cast<void*>(ucontext->uc_mcontext.regs->gpr[PT_R1]);
+   state->fp =
+       reinterpret_cast<void*>(ucontext->uc_mcontext.regs->gpr[PT_R31]);
+-#else
++#elif V8_TARGET_ARCH_32_BIT
+   // Some C libraries, notably Musl, define the regs member as a void pointer
++  state->pc = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[32]);
++  state->sp = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[1]);
++  state->fp = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[31]);
++#else
+   state->pc = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[32]);
+   state->sp = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[1]);
+   state->fp = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[31]);


### PR DESCRIPTION
Maintainer: @blogic @ianchi
 Compile tested: head r9874-d599890, powerpc_464fp_gcc-7.4.0_musl
Run tested: NONE

Description:
support powerpc32 musl
https://downloads.openwrt.org/snapshots/faillogs/powerpc_464fp/packages/node/compile.txt

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
