### PR TITLE
Jinja2: update to version 2.10.1

### DIFF
--- a/lang/python/Jinja2/Makefile
+++ b/lang/python/Jinja2/Makefile
@@ -5,19 +5,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Jinja2
-PKG_VERSION:=2.10
+PKG_VERSION:=2.10.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/J/Jinja2
-PKG_HASH:=f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4
-PKG_BUILD_DEPENDS:=python3
+PKG_HASH:=065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
@@ -26,8 +23,8 @@ define Package/python3-jinja2
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=Jinja2
   URL:=http://jinja.pocoo.org/
-  TITLE:=python3-jinja2
   DEPENDS:=+python3-light +python3-markupsafe
   VARIANT:=python3
 endef
@@ -40,3 +37,4 @@ endef
 
 $(eval $(call Py3Package,python3-jinja2))
 $(eval $(call BuildPackage,python3-jinja2))
+$(eval $(call BuildPackage,python3-jinja2-src))


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:
- Reordered things in Makefile
- Removed PKG_BUILD_DIR and PKG_UNPACK as it isn't necessary
- Changed TITLE from python3-jinja2 to Jinja2
- Added src package