### PR TITLE
node-homebridge: fix i386 build fail

### DIFF
--- a/lang/node-homebridge/Makefile
+++ b/lang/node-homebridge/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=homebridge
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=0.4.48
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=http://registry.npmjs.org/$(PKG_NPM_NAME)/-/
@@ -38,6 +38,8 @@ endef
 
 NODEJS_CPU:=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))))
 TMPNPM:=$(shell mktemp -u XXXXXXXXXX)
+
+TARGET_CFLAGS+=$(FPIC)
 
 define Build/Prepare
 	$(INSTALL_DIR) $(PKG_BUILD_DIR)


### PR DESCRIPTION
Maintainer: me 
Compile tested: head r9877-e762f5d, i386_pentium4_gcc-7.4.0_musl
Run tested: NONE

Description:
more stability for parallel build

https://downloads.openwrt.org/snapshots/faillogs/i386_pentium4/packages/node-homebridge/compile.txt

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
