### PR TITLE
node-mozilla-iot-gateway: fix i386 build fail

### DIFF
--- a/lang/node-mozilla-iot-gateway/Makefile
+++ b/lang/node-mozilla-iot-gateway/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=mozilla-iot-gateway
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=0.7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mozilla-iot/gateway/tar.gz/v$(PKG_VERSION)?
@@ -48,6 +48,8 @@ define Package/node-mozilla-iot-gateway/config
 endef
 
 CPU:=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))))
+
+TARGET_CFLAGS+=$(FPIC)
 
 define Build/Compile
 	$(MAKE_VARS) \


### PR DESCRIPTION
Maintainer: @ratkaj
 Compile tested: head r9877-e762f5d, i386_pentium4_gcc-7.4.0_musl
Run tested: NONE

Description:
more stability for parallel build

https://downloads.openwrt.org/snapshots/faillogs/i386_pentium4/packages/node-mozilla-iot-gateway/compile.txt

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
