### PR TITLE
Samba4: Rework URLs

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -9,12 +9,12 @@ PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only
 PKG_LICENSE_FILES:=COPYING
 
-PKG_SOURCE_URL:=https://fossies.org/linux/misc/ \
-				ftp://mirrors.dotsrc.org/samba/ \
-				https://ftp.gwdg.de/pub/samba/stable/ \
-				https://ftp.yz.yamagata-u.ac.jp/pub/network/samba/ \
-				http://ftp.uni-bayreuth.de/netsoftware/samba/ \
-				https://www.samba.org/ftp/samba/stable/
+PKG_SOURCE_URL:=https://ftp.heanet.ie/mirrors/ftp.samba.org/stable/ \
+		https://ftp.gwdg.de/pub/samba/stable/ \
+		https://ftp.riken.jp/net/samba/samba/stable/ \
+		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
+		http://samba.mirror.bit.nl/samba/ftp/stable/ \
+		https://download.samba.org/pub/samba/stable/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=c9205a651a83d69e200fec9dd65e9fa360f0c75ab3275b3dcb74e5cbaec60807
 


### PR DESCRIPTION
Maintainer: @Andy2244 
Compile tested: Not needed
Run tested: Not needed

Description:
Avoid Hetzner hosted servers due to availability (.ru users)
and try to keep availability as good as possible without
sacrificing performance for the majority of users.
Update upstream project download URL

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>
