### PR TITLE
transmission: add PKGARCH:=all for transmission-web

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -86,6 +86,7 @@ define Package/transmission-web
   $(call Package/transmission/template)
   TITLE+= (webinterface)
   DEPENDS:=@(PACKAGE_transmission-daemon-openssl||PACKAGE_transmission-daemon-mbedtls)
+  PKGARCH:=all
 endef
 
 


### PR DESCRIPTION
Maintainer: @neheb
Compile tested: no
Run tested: no

Description:
transmission-web contains no binary files, add `PKGARCH:=all`.