### PR TITLE
python-urllib3: update to version 1.24.2

### DIFF
--- a/lang/python/python-urllib3/Makefile
+++ b/lang/python/python-urllib3/Makefile
@@ -8,17 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-urllib3
-PKG_VERSION:=1.24.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.24.2
+PKG_RELEASE:=1
+
 PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.txt
 
 PKG_SOURCE:=urllib3-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/u/urllib3
-PKG_HASH:=de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22
+PKG_HASH:=9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3
+
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-urllib3-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
-
 include ../python-package.mk
 include ../python3-package.mk
 
@@ -28,7 +30,7 @@ define Package/python-urllib3/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  TITLE:=HTTP library with thread-safe connection pooling, file post, and more.
+  TITLE:=Sanity-friendly HTTP client
   URL:=https://urllib3.readthedocs.io/
 endef
 
@@ -57,6 +59,7 @@ endef
 $(eval $(call PyPackage,python-urllib3))
 $(eval $(call BuildPackage,python-urllib3))
 $(eval $(call BuildPackage,python-urllib3-src))
+
 $(eval $(call Py3Package,python3-urllib3))
 $(eval $(call BuildPackage,python3-urllib3))
 $(eval $(call BuildPackage,python3-urllib3-src))


### PR DESCRIPTION
Maintainer: none
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:
- update to version [1.24.2](https://github.com/urllib3/urllib3/blob/1efadf43dc63317cd9eaa3e0fdb9e05ab07254b1/CHANGES.rst)

