### PR TITLE
[18.06] wifidog: Change to use TLS above 1.0

### DIFF
--- a/net/wifidog/Makefile
+++ b/net/wifidog/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifidog
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 
 PKG_LICENSE:=GPL-2.0

--- a/net/wifidog/patches/010-use-tls-above-1.patch
+++ b/net/wifidog/patches/010-use-tls-above-1.patch
@@ -1,0 +1,38 @@
+diff --git a/configure.in b/configure.in
+index bf5463a..43ec27c 100644
+--- a/configure.in
++++ b/configure.in
+@@ -96,8 +96,8 @@ if test "x$enable_cyassl" = xyes; then
+         # the use the new naming scheme below as cyassl/ssl.h is not available for
+         # AC_SEARCH_LIBS
+         AC_CHECK_HEADERS(cyassl/ssl.h)
+-        AC_SEARCH_LIBS([CyaTLSv1_client_method], [cyassl], [], [
+-            AC_SEARCH_LIBS([wolfTLSv1_client_method], [wolfssl], [], [
++        AC_SEARCH_LIBS([CyaSSLv23_client_method], [cyassl], [], [
++            AC_SEARCH_LIBS([wolfSSLv23_client_method], [wolfssl], [], [
+                             AC_MSG_ERROR([unable to locate SSL lib: either wolfSSL or CyaSSL needed.])
+             ])
+         ])
+@@ -110,7 +110,7 @@ if test "x$enable_cyassl" = xyes; then
+         ]], [[
+                 CYASSL_CTX *ctx;
+                 CyaSSL_Init();
+-                ctx = CyaSSL_CTX_new(CyaTLSv1_client_method());
++                ctx = CyaSSL_CTX_new(CyaSSLv23_client_method());
+                 CyaSSL_CTX_UseSNI(ctx, CYASSL_SNI_HOST_NAME, "wifidog.org", 11);
+         ]])], [enabled_sni=yes], [enabled_sni=no])
+ 
+diff --git a/src/simple_http.c b/src/simple_http.c
+index f0e27ee..7271021 100644
+--- a/src/simple_http.c
++++ b/src/simple_http.c
+@@ -162,8 +162,7 @@ get_cyassl_ctx(const char *hostname)
+     if (NULL == cyassl_ctx) {
+         CyaSSL_Init();
+         /* Create the CYASSL_CTX */
+-        /* Allow TLSv1.0 up to TLSv1.2 */
+-        if ((cyassl_ctx = CyaSSL_CTX_new(CyaTLSv1_client_method())) == NULL) {
++        if ((cyassl_ctx = CyaSSL_CTX_new(CyaSSLv23_client_method())) == NULL) {
+             debug(LOG_ERR, "Could not create CYASSL context.");
+             UNLOCK_CYASSL_CTX();
+             return NULL;


### PR DESCRIPTION
This should fix compilation as wolfSSL currently does not define
wolfTLSv1_client_method. And as the comment suggests, this is only TLS 1,
not 1.0 and above.

SSLv23 is TLS 1.1 and above as currently configured in the wolfssl package

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mhaas 

Fixes buildbot issue: https://downloads.openwrt.org/releases/faillogs/mipsel_24kc_24kf/packages/wifidog/tls/compile.txt

@dangowrt backported wolfssl 3.15 to 18.06 so this applies.

This is a direct backport.