### PR TITLE
[18.06] unixodbc: Fix compilation

### DIFF
--- a/libs/unixodbc/Makefile
+++ b/libs/unixodbc/Makefile
@@ -127,6 +127,7 @@ endef
 define Host/Configure
 	$(call Host/Configure/Default)
 	cp $(PKG_BUILD_DIR)/config.h $(HOST_BUILD_DIR)
+	sed -i -e 's!\(LIB_PREFIX \).*$$$$!\1"$(STAGING_DIR)/usr/lib"!' $(HOST_BUILD_DIR)/config.h
 	cp $(PKG_BUILD_DIR)/unixodbc_conf.h $(HOST_BUILD_DIR)
 endef
 

--- a/libs/unixodbc/Makefile
+++ b/libs/unixodbc/Makefile
@@ -93,7 +93,10 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/$(STAGING_DIR)/usr/include/*.h $(1)/usr/include/
 	# Save autoconf config.h file for host build
-	$(CP) $(PKG_BUILD_DIR)/config.h $(1)/usr/include/unixodbc_ac_config.h
+	# copy target autoconf config.h and unixodbc_conf.h file for host build
+	$(INSTALL_DIR) $(1)/tmp/unixodbc
+	$(CP) $(PKG_BUILD_DIR)/config.h $(1)/tmp/unixodbc/
+	$(CP) $(PKG_BUILD_DIR)/unixodbc_conf.h $(1)/tmp/unixodbc/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/etc
@@ -128,10 +131,9 @@ endef
 
 define Host/Configure
 	$(call Host/Configure/Default)
-	# copy target autoconf config.h file for host build
-	cp $(STAGING_DIR)/usr/include/unixodbc_ac_config.h $(HOST_BUILD_DIR)
+	cp $(STAGING_DIR)/tmp/unixodbc/config.h $(HOST_BUILD_DIR)
 	sed -i -e 's!\(LIB_PREFIX \).*$$$$!\1"$(STAGING_DIR)/usr/lib"!' $(HOST_BUILD_DIR)/config.h
-	cp $(PKG_BUILD_DIR)/unixodbc_conf.h $(HOST_BUILD_DIR)
+	cp $(STAGING_DIR)/tmp/unixodbc/unixodbc_conf.h $(HOST_BUILD_DIR)
 endef
 
 define Host/Compile

--- a/libs/unixodbc/Makefile
+++ b/libs/unixodbc/Makefile
@@ -92,6 +92,8 @@ endef
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/$(STAGING_DIR)/usr/include/*.h $(1)/usr/include/
+	# Save autoconf config.h file for host build
+	$(CP) $(PKG_BUILD_DIR)/config.h $(1)/usr/include/unixodbc_ac_config.h
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/etc
@@ -126,7 +128,8 @@ endef
 
 define Host/Configure
 	$(call Host/Configure/Default)
-	cp $(PKG_BUILD_DIR)/config.h $(HOST_BUILD_DIR)
+	# copy target autoconf config.h file for host build
+	cp $(STAGING_DIR)/usr/include/unixodbc_ac_config.h $(HOST_BUILD_DIR)
 	sed -i -e 's!\(LIB_PREFIX \).*$$$$!\1"$(STAGING_DIR)/usr/lib"!' $(HOST_BUILD_DIR)/config.h
 	cp $(PKG_BUILD_DIR)/unixodbc_conf.h $(HOST_BUILD_DIR)
 endef


### PR DESCRIPTION
Maintainer: @heil 

Buildbots are failing on this: https://downloads.openwrt.org/releases/faillogs/mipsel_24kc_24kf/packages/unixodbc/compile.txt

Backported patches that fix the issue. ping @cotequeiroz 