### PR TITLE
[18.06] libiio: add missing dependency to zlib

### DIFF
--- a/libs/libiio/Makefile
+++ b/libs/libiio/Makefile
@@ -52,6 +52,7 @@ define Package/libiio
   TITLE:=Library for interfacing with Linux IIO devices
   URL:=https://github.com/analogdevicesinc/libiio
   DEPENDS:=\
+           +zlib \
            +LIBIIO_USB_BACKEND:libusb-1.0 \
            +LIBIIO_NETWORK_BACKEND:libavahi-client \
            +LIBIIO_XML_BACKEND:libxml2


### PR DESCRIPTION
Signed-off-by: Martin Schiller <ms@dev.tdt.de>

Maintainer: @mhei 

Buildbots are currently failing on this: https://downloads.openwrt.org/releases/faillogs/mipsel_24kc_24kf/packages/libiio/compile.txt

This is a direct backport. ping @sch-m