### PR TITLE
snort3: ignore liblzma if present

### DIFF
--- a/net/snort3/Makefile
+++ b/net/snort3/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=snort3
 PKG_VERSION:=3.0.0-beta
 PKG_VERSION_SHORT:=3.0.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>

--- a/net/snort3/patches/002-ignore-liblzma.patch
+++ b/net/snort3/patches/002-ignore-liblzma.patch
@@ -1,0 +1,11 @@
+diff -u --recursive snort-3.0.0-vanilla/cmake/include_libraries.cmake snort-3.0.0/cmake/include_libraries.cmake
+--- snort-3.0.0-vanilla/cmake/include_libraries.cmake	2018-08-28 02:01:02.000000000 -0400
++++ snort-3.0.0/cmake/include_libraries.cmake	2019-04-18 21:25:25.627070082 -0400
+@@ -14,7 +14,6 @@
+ endif (ENABLE_UNIT_TESTS)
+ 
+ # optional libraries
+-find_package(LibLZMA QUIET)
+ find_package(Asciidoc QUIET)
+ find_package(DBLATEX QUIET)
+ find_package(Ruby QUIET 1.8.7)


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64
Description:
snort3: ignore liblzma if present