### PR TITLE
python-aiohttp-cors: add package

### DIFF
--- a/lang/python/python-aiohttp-cors/Makefile
+++ b/lang/python/python-aiohttp-cors/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=aiohttp-cors
+PKG_VERSION:=0.7.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=aiohttp-cors-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/a/aiohttp_cors/
+PKG_HASH:=4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d
+
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-aiohttp-cors
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=CORS support for aiohttp
+  URL:=https://github.com/aio-libs/aiohttp-cors
+  DEPENDS:= \
+	+python3-aiohttp \
+	+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-aiohttp-cors/description
+  Implements Cross Origin Resource Sharing (CORS) support for aiohttp asyncio-powered asynchronous HTTP server.
+endef
+
+$(eval $(call Py3Package,python3-aiohttp-cors))
+$(eval $(call BuildPackage,python3-aiohttp-cors))
+$(eval $(call BuildPackage,python3-aiohttp-cors-src))


### PR DESCRIPTION
Maintainer: me (@BKPepe)
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:

- Add package [aiohttp-cors](https://pypi.org/project/aiohttp_cors/)
It is a dependency for Home Assistant 
```
2019-04-20 20:42:57 ERROR (MainThread) [homeassistant.setup] Error during setup of component http
Traceback (most recent call last):
  File "/setup.py", line 153, in _async_setup_component
  File "/__init__.py", line 171, in async_setup
  File "/__init__.py", line 223, in __init__
  File "/cors.py", line 16, in setup_cors
ModuleNotFoundError: No module named 'aiohttp_cors'
```
Once you have this package, you can access the web of Home Assistant. :-)

![Screenshot from 2019-04-20 22-00-45](https://user-images.githubusercontent.com/4096468/56461739-fc9fb200-63b7-11e9-9c09-c3ea77ec9b69.png)

