### PR TITLE
php7: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
 PKG_VERSION:=7.2.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 

--- a/lang/php7/patches/0032-Use-system-timezone.patch
+++ b/lang/php7/patches/0032-Use-system-timezone.patch
@@ -17,7 +17,7 @@ diff --git a/ext/date/php_date.c b/ext/date/php_date.c
 index cbe6e91..1999c83 100644
 --- a/ext/date/php_date.c
 +++ b/ext/date/php_date.c
-@@ -1003,6 +1003,23 @@ static char* guess_timezone(const timelib_tzdb *tzdb)
+@@ -1016,6 +1016,23 @@ static char* guess_timezone(const timelib_tzdb *tzdb)
  		DATEG(timezone_valid) = 1;
  		return DATEG(default_timezone);
  	}

--- a/lang/php7/patches/0041-Add-patch-to-remove-build-timestamps-from-generated-.patch
+++ b/lang/php7/patches/0041-Add-patch-to-remove-build-timestamps-from-generated-.patch
@@ -47,7 +47,7 @@ Subject: Add patch to remove build timestamps from generated binaries.
    *aix*)
 --- a/sapi/cgi/cgi_main.c
 +++ b/sapi/cgi/cgi_main.c
-@@ -2427,9 +2427,9 @@ consult the installation file that came
+@@ -2442,9 +2442,9 @@ consult the installation file that came
  								SG(request_info).no_headers = 1;
  							}
  #if ZEND_DEBUG

--- a/lang/php7/patches/0050-remove-build-timestamps.patch
+++ b/lang/php7/patches/0050-remove-build-timestamps.patch
@@ -1,6 +1,6 @@
 --- a/ext/opcache/ZendAccelerator.c
 +++ b/ext/opcache/ZendAccelerator.c
-@@ -2456,11 +2456,6 @@ static void accel_gen_system_id(void)
+@@ -2484,11 +2484,6 @@ static void accel_gen_system_id(void)
  	PHP_MD5Update(&context, PHP_VERSION, sizeof(PHP_VERSION)-1);
  	PHP_MD5Update(&context, ZEND_EXTENSION_BUILD_ID, sizeof(ZEND_EXTENSION_BUILD_ID)-1);
  	PHP_MD5Update(&context, ZEND_BIN_ID, sizeof(ZEND_BIN_ID)-1);
@@ -14,7 +14,7 @@
  		c = digest[i] >> 4;
 --- a/sapi/litespeed/lsapi_main.c
 +++ b/sapi/litespeed/lsapi_main.c
-@@ -1034,9 +1034,9 @@ static int cli_main( int argc, char * ar
+@@ -1057,9 +1057,9 @@ static int cli_main( int argc, char * ar
              case 'v':
                  if (php_request_startup() != FAILURE) {
  #if ZEND_DEBUG

--- a/lang/php7/patches/1001-ext-opcache-fix-detection-of-shm-mmap.patch
+++ b/lang/php7/patches/1001-ext-opcache-fix-detection-of-shm-mmap.patch
@@ -22,9 +22,9 @@ diff --git a/ext/opcache/config.m4 b/ext/opcache/config.m4
 index b7e4835..7b6c0aa 100644
 --- a/ext/opcache/config.m4
 +++ b/ext/opcache/config.m4
-@@ -11,127 +11,13 @@ if test "$PHP_OPCACHE" != "no"; then
-     AC_DEFINE(HAVE_MPROTECT, 1, [Define if you have mprotect() function])
-   ])
+@@ -28,127 +28,13 @@ if test "$PHP_OPCACHE" != "no"; then
+ 
+   AC_CHECK_HEADERS([unistd.h sys/uio.h])
  
 -  AC_MSG_CHECKING(for sysvipc shared memory support)
 -  AC_TRY_RUN([

--- a/lang/php7/patches/1004-disable-phar-command.patch
+++ b/lang/php7/patches/1004-disable-phar-command.patch
@@ -11,7 +11,7 @@
  
 --- a/configure.ac	2016-09-20 22:26:38.000000000 +0200
 +++ b/configure.ac	2016-09-20 22:42:30.380101556 +0200
-@@ -1448,13 +1448,13 @@
+@@ -1454,13 +1454,13 @@
  INLINE_CFLAGS="$INLINE_CFLAGS $standard_libtool_flag"
  CXXFLAGS="$CXXFLAGS $standard_libtool_flag \$(PROF_FLAGS)"
  

--- a/lang/php7/patches/1006-multiline-syslog.patch
+++ b/lang/php7/patches/1006-multiline-syslog.patch
@@ -23,7 +23,7 @@ diff --git a/configure.ac b/configure.ac
 index cb95d86..a63354f 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1443,7 +1443,7 @@ PHP_ADD_SOURCES(main, main.c snprintf.c spprintf.c php_sprintf.c \
+@@ -1478,7 +1478,7 @@ PHP_ADD_SOURCES(main, main.c snprintf.c spprintf.c php_sprintf.c \
         php_ini.c SAPI.c rfc1867.c php_content_types.c strlcpy.c \
         strlcat.c explicit_bzero.c mergesort.c reentrancy.c php_variables.c php_ticks.c \
         network.c php_open_temporary_file.c \
@@ -166,7 +166,7 @@ diff --git a/win32/build/config.w32 b/win32/build/config.w32
 index 6cbb18b..71cf491 100644
 --- a/win32/build/config.w32
 +++ b/win32/build/config.w32
-@@ -244,7 +244,8 @@ ADD_FLAG("CFLAGS_BD_ZEND", "/D ZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+@@ -241,7 +241,8 @@ ADD_FLAG("CFLAGS_BD_ZEND", "/D ZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
  ADD_SOURCES("main", "main.c snprintf.c spprintf.c getopt.c fopen_wrappers.c \
  	php_scandir.c php_ini.c SAPI.c rfc1867.c php_content_types.c strlcpy.c \
  	strlcat.c mergesort.c reentrancy.c php_variables.c php_ticks.c network.c \

--- a/lang/php7/patches/1012-php_iconv_string-null-out-pointer.patch
+++ b/lang/php7/patches/1012-php_iconv_string-null-out-pointer.patch
@@ -1,26 +1,3 @@
-commit 31e53f07c26e5ac75ec2c2d99497439323dbdaf7
-Author: Philip Prindeville <philipp@redfish-solutions.com>
-Date:   Wed Jan 24 18:47:19 2018 -0700
-
-    Be consistent in clearing out in php_iconv_string()
-    
-    Also, don't bother checking returned point in error case since it
-    will always be NULL (and not require free()ing, obviously).
-
-diff --git a/ext/iconv/iconv.c b/ext/iconv/iconv.c
-index 35dafd4..4289242 100644
---- a/ext/iconv/iconv.c
-+++ b/ext/iconv/iconv.c
-@@ -559,6 +559,8 @@ PHP_ICONV_API php_iconv_err_t php_iconv_string(const char *in_p, size_t in_len,
- 	size_t result;
- 	zend_string *ret, *out_buffer;
- 
-+	*out = NULL;
-+
- 	/*
- 	  This is not the right way to get output size...
- 	  This is not space efficient for large text.
-
 commit 3763c8f1645983b5abc37c60597e1ecc1bf89019
 Author: Philip Prindeville <philipp@redfish-solutions.com>
 Date:   Thu Jan 25 14:18:00 2018 -0700
@@ -31,7 +8,7 @@ diff --git a/ext/iconv/iconv.c b/ext/iconv/iconv.c
 index 4289242..807bb14 100644
 --- a/ext/iconv/iconv.c
 +++ b/ext/iconv/iconv.c
-@@ -697,6 +697,7 @@ PHP_ICONV_API php_iconv_err_t php_iconv_string(const char *in_p, size_t in_len,
+@@ -699,6 +699,7 @@ PHP_ICONV_API php_iconv_err_t php_iconv_string(const char *in_p, size_t in_len,
  	iconv_close(cd);
  
  	if (result == (size_t)(-1)) {
@@ -39,7 +16,7 @@ index 4289242..807bb14 100644
  		switch (errno) {
  			case EINVAL:
  				retval = PHP_ICONV_ERR_ILLEGAL_CHAR;
-@@ -713,7 +714,6 @@ PHP_ICONV_API php_iconv_err_t php_iconv_string(const char *in_p, size_t in_len,
+@@ -715,7 +716,6 @@ PHP_ICONV_API php_iconv_err_t php_iconv_string(const char *in_p, size_t in_len,
  
  			default:
  				/* other error */
@@ -47,7 +24,7 @@ index 4289242..807bb14 100644
  				return PHP_ICONV_ERR_UNKNOWN;
  		}
  	}
-@@ -986,9 +986,6 @@ static php_iconv_err_t _php_iconv_strpos(size_t *pretval,
+@@ -988,9 +988,6 @@ static php_iconv_err_t _php_iconv_strpos(size_t *pretval,
  	err = php_iconv_string(ndl, ndl_nbytes, &ndl_buf, GENERIC_SUPERSET_NAME, enc);
  
  	if (err != PHP_ICONV_ERR_SUCCESS) {
@@ -57,7 +34,7 @@ index 4289242..807bb14 100644
  		return err;
  	}
  
-@@ -2465,9 +2462,6 @@ PHP_NAMED_FUNCTION(php_if_iconv)
+@@ -2494,9 +2491,6 @@ PHP_NAMED_FUNCTION(php_if_iconv)
  	if (err == PHP_ICONV_ERR_SUCCESS && out_buffer != NULL) {
  		RETVAL_STR(out_buffer);
  	} else {

--- a/lang/php7/patches/1020-openssl-deprecated.patch
+++ b/lang/php7/patches/1020-openssl-deprecated.patch
@@ -1,0 +1,169 @@
+--- a/ext/ftp/php_ftp.c
++++ b/ext/ftp/php_ftp.c
+@@ -320,12 +320,14 @@ static void ftp_destructor_ftpbuf(zend_resource *rsrc)
+ PHP_MINIT_FUNCTION(ftp)
+ {
+ #ifdef HAVE_FTP_SSL
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	SSL_library_init();
+ 	OpenSSL_add_all_ciphers();
+ 	OpenSSL_add_all_digests();
+ 	OpenSSL_add_all_algorithms();
+ 
+ 	SSL_load_error_strings();
++#endif
+ #endif
+ 
+ 	le_ftpbuf = zend_register_list_destructors_ex(ftp_destructor_ftpbuf, NULL, le_ftpbuf_name, module_number);
+--- a/ext/openssl/openssl.c
++++ b/ext/openssl/openssl.c
+@@ -683,6 +683,12 @@ static const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *asn1)
+ 	return M_ASN1_STRING_data(asn1);
+ }
+ 
++#define OpenSSL_version		OpenSSL_version
++#define OPENSSL_VERSION		OPENSSL_VERSION
++#define X509_getm_notBefore	X509_get_notBefore
++#define X509_getm_notAfter	X509_get_notAfter
++#define EVP_CIPHER_CTX_reset	EVP_CIPHER_CTX_cleanup
++
+ #if PHP_OPENSSL_API_VERSION < 0x10002
+ 
+ static int X509_get_signature_nid(const X509 *x)
+@@ -1587,7 +1593,7 @@ PHP_MINFO_FUNCTION(openssl)
+ {
+ 	php_info_print_table_start();
+ 	php_info_print_table_row(2, "OpenSSL support", "enabled");
+-	php_info_print_table_row(2, "OpenSSL Library Version", SSLeay_version(SSLEAY_VERSION));
++	php_info_print_table_row(2, "OpenSSL Library Version", OpenSSL_version(OPENSSL_VERSION));
+ 	php_info_print_table_row(2, "OpenSSL Header Version", OPENSSL_VERSION_TEXT);
+ 	php_info_print_table_row(2, "Openssl default config", default_ssl_conf_filename);
+ 	php_info_print_table_end();
+@@ -2361,11 +2367,11 @@ PHP_FUNCTION(openssl_x509_parse)
+ 	add_assoc_string(return_value, "serialNumberHex", hex_serial);
+ 	OPENSSL_free(hex_serial);
+ 
+-	php_openssl_add_assoc_asn1_string(return_value, "validFrom", 	X509_get_notBefore(cert));
+-	php_openssl_add_assoc_asn1_string(return_value, "validTo", 		X509_get_notAfter(cert));
++	php_openssl_add_assoc_asn1_string(return_value, "validFrom", 	X509_getm_notBefore(cert));
++	php_openssl_add_assoc_asn1_string(return_value, "validTo", 		X509_getm_notAfter(cert));
+ 
+-	add_assoc_long(return_value, "validFrom_time_t", php_openssl_asn1_time_to_time_t(X509_get_notBefore(cert)));
+-	add_assoc_long(return_value, "validTo_time_t",  php_openssl_asn1_time_to_time_t(X509_get_notAfter(cert)));
++	add_assoc_long(return_value, "validFrom_time_t", php_openssl_asn1_time_to_time_t(X509_getm_notBefore(cert)));
++	add_assoc_long(return_value, "validTo_time_t",  php_openssl_asn1_time_to_time_t(X509_getm_notAfter(cert)));
+ 
+ 	tmpstr = (char *)X509_alias_get0(cert, NULL);
+ 	if (tmpstr) {
+@@ -3455,8 +3461,8 @@ PHP_FUNCTION(openssl_csr_sign)
+ 		php_openssl_store_errors();
+ 		goto cleanup;
+ 	}
+-	X509_gmtime_adj(X509_get_notBefore(new_cert), 0);
+-	X509_gmtime_adj(X509_get_notAfter(new_cert), 60*60*24*(long)num_days);
++	X509_gmtime_adj(X509_getm_notBefore(new_cert), 0);
++	X509_gmtime_adj(X509_getm_notAfter(new_cert), 60*60*24*(long)num_days);
+ 	i = X509_set_pubkey(new_cert, key);
+ 	if (!i) {
+ 		php_openssl_store_errors();
+@@ -6072,7 +6078,7 @@ PHP_FUNCTION(openssl_seal)
+ 
+ 	/* allocate one byte extra to make room for \0 */
+ 	buf = emalloc(data_len + EVP_CIPHER_CTX_block_size(ctx));
+-	EVP_CIPHER_CTX_cleanup(ctx);
++	EVP_CIPHER_CTX_reset(ctx);
+ 
+ 	if (EVP_SealInit(ctx, cipher, eks, eksl, &iv_buf[0], pkeys, nkeys) <= 0 ||
+ 			!EVP_SealUpdate(ctx, buf, &len1, (unsigned char *)data, (int)data_len) ||
+@@ -6622,7 +6628,7 @@ PHP_FUNCTION(openssl_encrypt)
+ 	if (free_iv) {
+ 		efree(iv);
+ 	}
+-	EVP_CIPHER_CTX_cleanup(cipher_ctx);
++	EVP_CIPHER_CTX_reset(cipher_ctx);
+ 	EVP_CIPHER_CTX_free(cipher_ctx);
+ }
+ /* }}} */
+@@ -6709,7 +6715,7 @@ PHP_FUNCTION(openssl_decrypt)
+ 	if (base64_str) {
+ 		zend_string_release(base64_str);
+ 	}
+-	EVP_CIPHER_CTX_cleanup(cipher_ctx);
++	EVP_CIPHER_CTX_reset(cipher_ctx);
+ 	EVP_CIPHER_CTX_free(cipher_ctx);
+ }
+ /* }}} */
+--- a/ext/openssl/xp_ssl.c
++++ b/ext/openssl/xp_ssl.c
+@@ -56,8 +56,21 @@
+ #define HAVE_SSL3 1
+ #endif
+ 
++#if PHP_OPENSSL_API_VERSION >= 0x10100
++#define HAVE_TLS 1
++#endif
++
++#ifndef OPENSSL_NO_TLS1_METHOD
++#define HAVE_TLS1 1
++#endif
++
++#ifndef OPENSSL_NO_TLS1_1_METHOD
+ #define HAVE_TLS11 1
++#endif
++
++#ifndef OPENSSL_NO_TLS1_2_METHOD
+ #define HAVE_TLS12 1
++#endif
+ 
+ #ifndef OPENSSL_NO_ECDH
+ #define HAVE_ECDH 1
+@@ -78,9 +91,10 @@
+ #define STREAM_CRYPTO_IS_CLIENT            (1<<0)
+ #define STREAM_CRYPTO_METHOD_SSLv2         (1<<1)
+ #define STREAM_CRYPTO_METHOD_SSLv3         (1<<2)
+-#define STREAM_CRYPTO_METHOD_TLSv1_0       (1<<3)
+-#define STREAM_CRYPTO_METHOD_TLSv1_1       (1<<4)
+-#define STREAM_CRYPTO_METHOD_TLSv1_2       (1<<5)
++#define STREAM_CRYPTO_METHOD_TLS           (1<<3)
++#define STREAM_CRYPTO_METHOD_TLSv1_0       (1<<4)
++#define STREAM_CRYPTO_METHOD_TLSv1_1       (1<<5)
++#define STREAM_CRYPTO_METHOD_TLSv1_2       (1<<6)
+ 
+ /* Simplify ssl context option retrieval */
+ #define GET_VER_OPT(name) \
+@@ -960,9 +974,23 @@ static const SSL_METHOD *php_openssl_select_crypto_method(zend_long method_value
+ 		php_error_docref(NULL, E_WARNING,
+ 				"SSLv3 unavailable in the OpenSSL library against which PHP is linked");
+ 		return NULL;
++#endif
++	} else if (method_value == STREAM_CRYPTO_METHOD_TLS) {
++#ifdef HAVE_TLS
++		return is_client ? TLS_client_method() : TLS_server_method();
++#else
++		php_error_docref(NULL, E_WARNING,
++				"TLS unavailable in the OpenSSL library against which PHP is linked");
++		return NULL;
+ #endif
+ 	} else if (method_value == STREAM_CRYPTO_METHOD_TLSv1_0) {
++#ifdef HAVE_TLS1
+ 		return is_client ? TLSv1_client_method() : TLSv1_server_method();
++#else
++		php_error_docref(NULL, E_WARNING,
++				"TLSv1 unavailable in the OpenSSL library against which PHP is linked");
++		return NULL;
++#endif
+ 	} else if (method_value == STREAM_CRYPTO_METHOD_TLSv1_1) {
+ #ifdef HAVE_TLS11
+ 		return is_client ? TLSv1_1_client_method() : TLSv1_1_server_method();
+@@ -1014,9 +1042,11 @@ static int php_openssl_get_crypto_method_ctx_flags(int method_flags) /* {{{ */
+ 		ssl_ctx_options |= SSL_OP_NO_SSLv3;
+ 	}
+ #endif
++#ifdef HAVE_TLS1
+ 	if (!(method_flags & STREAM_CRYPTO_METHOD_TLSv1_0)) {
+ 		ssl_ctx_options |= SSL_OP_NO_TLSv1;
+ 	}
++#endif
+ #ifdef HAVE_TLS11
+ 	if (!(method_flags & STREAM_CRYPTO_METHOD_TLSv1_1)) {
+ 		ssl_ctx_options |= SSL_OP_NO_TLSv1_1;


### PR DESCRIPTION
Refreshed patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mhei 
Compile tested: mips64