### PR TITLE
python-xmltodict: add a new package

### DIFF
--- a/lang/python/xmltodict/Makefile
+++ b/lang/python/xmltodict/Makefile
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-xmltodict
+PKG_VERSION:=0.12.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=xmltodict-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/x/xmltodict/
+PKG_HASH:=50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/xmltodict-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-xmltodict
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Work with XML like JSON
+  URL:=https://github.com/martinblech/xmltodict
+  DEPENDS:= \
+	+python3-light \
+	+python3-xml \
+	+python3-urllib
+  VARIANT:=python3
+endef
+
+define Package/python3-xmltodict/description
+  xmltodict is a Python module that makes working with XML feel like you are working with JSON.
+endef
+
+$(eval $(call Py3Package,python3-xmltodict))
+$(eval $(call BuildPackage,python3-xmltodict))
+$(eval $(call BuildPackage,python3-xmltodict-src))


### PR DESCRIPTION
Maintainer: me (@BKPepe)
Compile tested: Turris MOX, cortexa53, OpenWrt master and Turris Omnia, mvebu, OpenWrt SNAPSHOT r9420-c17a68c
Run tested: Turris MOX, cortexa53, OpenWrt master and Turris Omnia, mvebu, OpenWrt SNAPSHOT r9420-c17a68c

Proof of run tested:
![Screenshot from 2019-04-21 03-34-20](https://user-images.githubusercontent.com/4096468/56464307-62a32e00-63e6-11e9-826a-5f46c85a5565.png)

Description:

- add [xmltodict](https://github.com/martinblech/xmltodict)