### PR TITLE
libmicrohttpd: Prevent Recursive Dependency

### DIFF
--- a/libs/libmicrohttpd/Makefile
+++ b/libs/libmicrohttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmicrohttpd
 PKG_VERSION:=0.9.62
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Alexander Couzens <lynxis@fe80.eu>
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING

--- a/libs/libmicrohttpd/Makefile
+++ b/libs/libmicrohttpd/Makefile
@@ -42,7 +42,6 @@ $(call Package/libmicrohttpd/default)
   TITLE+= with SSL support
   VARIANT:=ssl
   DEPENDS:=+libgcrypt +libgnutls +libgpg-error
-  CONFLICTS:=libmicrohttpd-no-ssl
   PROVIDES:=libmicrohttpd
 endef
 


### PR DESCRIPTION
Maintainer: Alexander Couzens `lynxis@fe80.eu`

Compile Tested: Snapshot SDK

Run Tested: target - ath79, hardware - gl-ar300m16, package - nodogsplash v3.2.1 and nodogsplash v3.3.1, Openwrt Snapshot.

Description: If a package depends on libmicrohttpd but does not specify which variant,
a recursive dependency error occurs caused by the superfluous CONFLICTS line.
With this change, a package will get the named variant, or default to the
no-ssl variant if only libmicrohttpd is specified.

Signed-off-by: Rob White `<rob@blue-wave.net>`
