### PR TITLE
python3-netifaces: add a new package

### DIFF
--- a/lang/python/python3-netifaces/Makefile
+++ b/lang/python/python3-netifaces/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-netifaces
+PKG_VERSION:=0.10.9
+PKG_RELEASE:=1
+
+PKG_SOURCE:=netifaces-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/n/netifaces/
+PKG_HASH:=2dee9ffdd16292878336a58d04a20f0ffe95555465fee7c9bd23b3490ef2abf3
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/netifaces-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-netifaces
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Portable network interface information
+  URL:=https://github.com/al45tair/netifaces
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-netifaces/description
+  Portable network interface information.
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)-src))


### PR DESCRIPTION
Maintainer: me (@BKPepe)
Compile tested: Turris Omnia, mvebu, OpenWrt SNAPSHOT r9420-c17a68c
Run tested: Turris Omnia, mvebu, OpenWrt SNAPSHOT r9420-c17a68c

Proof of run tested:
![Screenshot from 2019-04-21 15-33-13](https://user-images.githubusercontent.com/4096468/56470822-1b02bd80-644b-11e9-8e2f-7b6294cabd20.png)

Description:

- add [python3-netifaces](https://pypi.org/project/netifaces/)

____

cc: Python maintainers @jefferyto , @commodo 