### PR TITLE
xerces-c: Use libstdcpp instead of uclibc++

### DIFF
--- a/libs/libxerces-c/Makefile
+++ b/libs/libxerces-c/Makefile
@@ -8,9 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xerces-c
-PKG_MAIN_VER:=3.2
 PKG_VERSION:=3.2.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@APACHE/xerces/c/3/sources
@@ -24,33 +23,25 @@ PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
-include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/package.mk
 
-CONFIGURE_ARGS += \
-	--disable-pretty-make \
-	--enable-transcoder-iconv \
-	--enable-netaccessor-socket \
-	--enable-msgloader-inmemory
-
-TARGET_LDFLAGS += \
-	-lm
-
-define Package/libxerces-c
+define Package/libxerces-c/Default
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Validating XML parser library for C++
-  URL:=http://xerces.apache.org/
-  DEPENDS:=$(CXX_DEPENDS) $(ICONV_DEPENDS) +libc +libpthread
+  URL:=https://xerces.apache.org/
+endef
+
+define Package/libxerces-c
+$(call Package/libxerces-c/Default)
+  DEPENDS:=$(ICONV_DEPENDS) +libstdcpp
 endef
 
 define Package/libxerces-c-samples
-  SECTION:=libs
-  CATEGORY:=Libraries
-  TITLE:=Validating XML parser library for C++ (samples)
-  URL:=http://xerces.apache.org/
-  DEPENDS:=+libxerces-c
+$(call Package/libxerces-c/Default)
+  TITLE+= (samples)
+  DEPENDS+=+libxerces-c
 endef
 
 define Package/libxerces-c/description
@@ -69,18 +60,28 @@ define Package/libxerces-c-samples/description
   Validating XML parser library for C++ (samples)
 endef
 
+CONFIGURE_ARGS += \
+	--disable-rpath \
+	--enable-msgloader-inmemory \
+	--enable-netaccessor-socket \
+	--enable-transcoder-iconv \
+	--without-pic
+
+TARGET_CFLAGS += $(FPIC)
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/xercesc/
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/xercesc/* $(1)/usr/include/xercesc/
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/{libxerces-c.a,libxerces-c-$(PKG_MAIN_VER).so,libxerces-c.so} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/{*.a,*.so} $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/xerces-c.pc $(1)/usr/lib/pkgconfig/xerces-c.pc
 endef
 
 define Package/libxerces-c/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/{libxerces-c-$(PKG_MAIN_VER).so,libxerces-c.so} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so $(1)/usr/lib/
 endef
 
 define Package/libxerces-c-samples/install

--- a/libs/libxerces-c/patches/0001-fix-configure-cross-compiling.patch
+++ b/libs/libxerces-c/patches/0001-fix-configure-cross-compiling.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -194,7 +194,7 @@ AC_COMPILE_IFELSE(  [AC_LANG_PROGRAM([[#
+@@ -228,7 +228,7 @@ AC_COMPILE_IFELSE(  [AC_LANG_PROGRAM([[#
                      ]
                   )
  AC_MSG_CHECKING([for wcsrtombs])
@@ -9,7 +9,7 @@
  #include <string.h>]],
                                   [[
  mbstate_t st;
-@@ -216,7 +216,7 @@ else
+@@ -250,7 +250,7 @@ else
                      ]
                   )
  AC_MSG_CHECKING([for mbsrtowcs])


### PR DESCRIPTION
Both dependent packages (sumo and libelektra) use (and must use) libstdcpp

Two libc++ cannot be linked against each other at the same time. I believe
this causes xerces-c to not be used even though it is listed as a
dependency.

Took the time to clean up the Makefile. Also replaced -fPIC with -fpic to
eliminate potential issues.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Noltari 
Compile tested: mips64
