### PR TITLE
Add Python packages (ifaddr, zeroconf, netdisco)

### DIFF
--- a/lang/python/python-ifaddr/Makefile
+++ b/lang/python/python-ifaddr/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-ifaddr
+PKG_VERSION:=0.1.6
+PKG_RELEASE:=1
+
+PKG_SOURCE:=ifaddr-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/i/ifaddr/
+PKG_HASH:=c19c64882a7ad51a394451dabcbbed72e98b5625ec1e79789924d5ea3e3ecb93
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/ifaddr-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.txt
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-ifaddr
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Enumerate IP addresses on network adapters
+  URL:=https://github.com/pydron/ifaddr
+  DEPENDS:= \
+	+python3-light \
+	+python3-ctypes
+  VARIANT:=python3
+endef
+
+define Package/python3-ifaddr/description
+  ifaddr is a small Python library that allows you to find all the IPv4 and IPv6 addresses of the computer.
+endef
+
+$(eval $(call Py3Package,python3-ifaddr))
+$(eval $(call BuildPackage,python3-ifaddr))
+$(eval $(call BuildPackage,python3-ifaddr-src))

--- a/lang/python/python-netdisco/Makefile
+++ b/lang/python/python-netdisco/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-netdisco
+PKG_VERSION:=2.6.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=netdisco-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/n/netdisco
+PKG_HASH:=2b3aca14a1807712a053f11fd80dc251dd821ee4899aefece515287981817762
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/netdisco-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE.md
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-netdisco
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Discover devices on your local network
+  URL:=https://github.com/home-assistant/netdisco
+  DEPENDS:= \
+	  +python3-light \
+	  +python3-requests \
+	  +python3-zeroconf
+  VARIANT:=python3
+endef
+
+define Package/python3-netdisco/description
+  NetDisco is a Python 3 library to discover local devices and services.
+  It allows to scan on demand or offer a service that will scan the network in the background in a set interval.
+endef
+
+$(eval $(call Py3Package,python3-netdisco))
+$(eval $(call BuildPackage,python3-netdisco))
+$(eval $(call BuildPackage,python3-netdisco-src))

--- a/lang/python/python-zeroconf/Makefile
+++ b/lang/python/python-zeroconf/Makefile
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-zeroconf
+PKG_VERSION:=0.21.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=zeroconf-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/z/zeroconf/
+PKG_HASH:=5b52dfdf4e665d98a17bf9aa50dea7a8c98e25f972d9c1d7660e2b978a1f5713
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/zeroconf-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-zeroconf
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Multicast DNS Service Discovery Library
+  URL:=https://github.com/jstasiak/python-zeroconf
+  DEPENDS:= \
+	  +python3-light \
+	  +python3-logging \
+	  +python3-ifaddr
+  VARIANT:=python3
+endef
+
+define Package/python3-zeroconf/description
+  Pure Python Multicast DNS Service Discovery Library (Bonjour/Avahi compatible)
+endef
+
+$(eval $(call Py3Package,python3-zeroconf))
+$(eval $(call BuildPackage,python3-zeroconf))
+$(eval $(call BuildPackage,python3-zeroconf-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu, OpenWrt SNAPSHOT r9420-c17a68c
Run tested: Turris Omnia, mvebu, OpenWrt SNAPSHOT r9420-c17a68c

Description:

- Add [ifaddr](https://pypi.org/project/ifaddr/), [zeroconf](https://pypi.org/project/zeroconf/), [netdisco](https://pypi.org/project/netdisco/)

____

CC Python maintainers: @jefferyto , @commodo 