### PR TITLE
gst1-libav: Add a hack to get it to build on mips64

### DIFF
--- a/multimedia/gst1-libav/Makefile
+++ b/multimedia/gst1-libav/Makefile
@@ -142,8 +142,13 @@ LIBAV_CONFIGURE_DEMUXERS:=$(call FILTER_CONFIG,DEMUXER,demuxer,$(LIBAV_DEMUXERS)
 LIBAV_CONFIGURE_PARSERS:=$(call FILTER_CONFIG,PARSER,parser,$(LIBAV_PARSERS))
 LIBAV_CONFIGURE_PROTOCOLS:=$(call FILTER_CONFIG,PROTOCOL,protocol,$(LIBAV_PROTOCOLS))
 
-# Strip off FPU notation
-REAL_CPU_TYPE:=$(firstword $(subst +, ,$(CONFIG_CPU_TYPE)))
+#hack to build on mips64
+ifeq ($(CONFIG_CPU_TYPE),octeonplus)
+  REAL_CPU_TYPE:=octeon+
+else
+  # Strip off FPU notation
+  REAL_CPU_TYPE:=$(firstword $(subst +, ,$(CONFIG_CPU_TYPE)))
+endif
 
 CONFIGURE_ARGS += \
 	--disable-Bsymbolic \


### PR DESCRIPTION
octeonplus is being passed to gcc, which is incorrect and causes build
failure. This works around it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo @thess 
Compile tested: mips64