### PR TITLE
noddos: add libipset-7, uclient-fetch compatiblity

### DIFF
--- a/net/noddos/Makefile
+++ b/net/noddos/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 # Name and release number of this package
 PKG_NAME:=noddos
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPLv3
 PKG_MAINTAINER:=Steven Hessing <steven.hessing@gmail.com>
 

--- a/net/noddos/patches/020-Ipset.cxx-update-libipset-API-to-version-7.patch
+++ b/net/noddos/patches/020-Ipset.cxx-update-libipset-API-to-version-7.patch
@@ -1,0 +1,431 @@
+From 5200105f412ceefa0784bf914aa215146fd067b0 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cote2004-github@yahoo.com>
+Date: Wed, 26 Dec 2018 16:45:47 -0200
+Subject: [PATCH] Ipset.cxx: update libipset API to version 7
+
+Old API compatibility was kept with a compatibility shim.
+
+Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
+
+diff --git a/src/Ipset.cxx b/src/Ipset.cxx
+index 9333fe6..da97f93 100644
+--- a/src/Ipset.cxx
++++ b/src/Ipset.cxx
+@@ -90,23 +90,19 @@ void Ipset::Open (const std::string inIpsetName, std::string inIpsetType, bool i
+     isIpsetv4 = inisIpsetv4;
+     ipset_load_types();
+ 
+-    struct ipset_session *session = ipset_session_init(printf);
++    struct ipset_session *session = noddos_ipset_session_init();
+     if (session == nullptr) {
+         syslog (LOG_ERR, "Ipset: Cannot initialize ipset session.");
+         ipset_session_fini(session);
+         throw std::runtime_error ("Cannot initialize ipset session.");
+     }
+ 
+-    if (ipset_envopt_parse(session, IPSET_ENV_EXIST, NULL) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set environment option.");
+-        ipset_session_fini(session);
+-        throw std::runtime_error ("Can't set environment option.");
+-    }
++    ipset_envopt_set(session, IPSET_ENV_EXIST);
+     int r = ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str());
+     if ( r < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
+     } else if (r > 0) {
+         if (Debug == true) {
+             syslog (LOG_DEBUG, "Ipset: Not creating set %s as it already exists", ipsetName.c_str());
+@@ -115,27 +111,27 @@ void Ipset::Open (const std::string inIpsetName, std::string inIpsetType, bool i
+         return;
+     }
+     if (ipset_session_data_set(session, IPSET_OPT_TYPENAME, ipsetType.c_str()) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s to type %s: %s", ipsetName.c_str(), ipsetType.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s to type %s: %s", ipsetName.c_str(), ipsetType.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set type " + ipsetType + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set type " + ipsetType + ": " + ipset_session_report_msg(session));
+     }
+     const struct ipset_type *type = ipset_type_get(session, IPSET_CMD_CREATE);
+     if (type == NULL) {
+-        syslog (LOG_ERR, "Ipset: Can't set create ip %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set create ip %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't create ipset " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't create ipset " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+ 
+     uint32_t timeout = 0; /* default to infinity */
+     if (ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s to timeout %d: %s", ipsetName.c_str(), timeout, ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s to timeout %d: %s", ipsetName.c_str(), timeout, ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set time-out " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set time-out " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_session_data_set(session, IPSET_OPT_TYPE, type)) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s option type: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s option type: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set ipset type: " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set ipset type: " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     uint8_t family = 0;
+     if (ipsetType == "hash:ip" && isIpsetv4 == true) {
+@@ -149,20 +145,20 @@ void Ipset::Open (const std::string inIpsetName, std::string inIpsetType, bool i
+         throw std::invalid_argument("Unknown ipset data type " + ipsetType);
+     }
+     if (ipset_session_data_set(session, IPSET_OPT_FAMILY, &family) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s address family %d: %s", ipsetName.c_str(), family, ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s address family %d: %s", ipsetName.c_str(), family, ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Cannot set ipset family: " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Cannot set ipset family: " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+ 
+     if (ipset_cmd(session, IPSET_CMD_CREATE, /*lineno*/ 0) != 0) {
+-        syslog (LOG_ERR, "Ipset: Can't create setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't create setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Failed to create ipset " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Failed to create ipset " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_commit(session) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     ipset_session_fini(session);
+ }
+@@ -173,33 +169,29 @@ bool Ipset::ipset_exec(enum ipset_cmd cmd) {
+     if (Debug == true) {
+         syslog(LOG_DEBUG, "Ipset: received command %d for ipset %s", cmd, ipsetName.c_str());
+     }
+-    struct ipset_session *session = ipset_session_init(printf);
++    struct ipset_session *session = noddos_ipset_session_init();
+     if (session == nullptr) {
+         syslog (LOG_ERR, "Ipset: Cannot initialize ipset session.");
+         ipset_session_fini(session);
+         throw std::runtime_error ("Cannot initialize ipset session.");
+     }
+ 
+-    if (ipset_envopt_parse(session, IPSET_ENV_EXIST, NULL) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set environment option.");
+-        ipset_session_fini(session);
+-        throw std::runtime_error ("Can't set environment option.");
+-    }
++    ipset_envopt_set(session, IPSET_ENV_EXIST);
+     if (ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str()) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+ 
+     if (ipset_cmd(session, cmd, 0) != 0) {
+         ipset_session_fini(session);
+-        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
+-        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
++        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_commit(session) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     ipset_session_fini(session);
+     return true;
+@@ -210,61 +202,57 @@ bool Ipset::ipset_exec(enum ipset_cmd cmd,  const Tins::IPv4Address &inIpAddress
+     if (Debug == true) {
+         syslog(LOG_DEBUG, "Ipset: received command %d for IP address %s for ipset %s", cmd, inIpAddress.to_string().c_str(), ipsetName.c_str());
+     }
+-    struct ipset_session *session = ipset_session_init(printf);
++    struct ipset_session *session = noddos_ipset_session_init();
+     if (session == nullptr) {
+         syslog (LOG_ERR, "Ipset: Cannot initialize ipset session.");
+         ipset_session_fini(session);
+         throw std::runtime_error ("Cannot initialize ipset session.");
+     }
+ 
+-    if (ipset_envopt_parse(session, IPSET_ENV_EXIST, NULL) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set environment option.");
+-        ipset_session_fini(session);
+-        throw std::runtime_error ("Can't set environment option.");
+-    }
++    ipset_envopt_set(session, IPSET_ENV_EXIST);
+     if (ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str()) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     const struct ipset_type *type = ipset_type_get(session, cmd);
+     if (type == NULL) {
+-        syslog (LOG_ERR, "Ipset: Can't get type for set %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't get type for set %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+ 
+     uint8_t family = NFPROTO_IPV4;
+     if (ipset_session_data_set(session, IPSET_OPT_FAMILY, &family) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set session data to IPv4 family for set %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set session data to IPv4 family for set %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set session data for " + ipsetName + " to the IPv4 family, error: " + ipset_session_error(session));
++        throw std::runtime_error("Can't set session data for " + ipsetName + " to the IPv4 family, error: " + ipset_session_report_msg(session));
+     }
+     struct in_addr sin;
+     inet_aton (inIpAddress.to_string().c_str(), &sin);
+     if (ipset_session_data_set(session, IPSET_OPT_IP, &sin) < 0) {
+-        syslog (LOG_ERR, "Can't set session data to the IPv4 address for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Can't set session data to the IPv4 address for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set session data to the IPv4 address for setname " + ipsetName + ", error: " + ipset_session_error(session));
++        throw std::runtime_error("Can't set session data to the IPv4 address for setname " + ipsetName + ", error: " + ipset_session_report_msg(session));
+     }
+ 
+     if (timeout) {
+         if (ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout) != 0) {
+-            syslog (LOG_ERR, "Ipset: Can't set timeout for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++            syslog (LOG_ERR, "Ipset: Can't set timeout for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+             ipset_session_fini(session);
+-            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_error(session));
++            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_report_msg(session));
+             return false;
+         }
+     }
+     if (ipset_cmd(session, cmd, 0) != 0) {
+         ipset_session_fini(session);
+-        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
+-        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
++        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_commit(session) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     ipset_session_fini(session);
+     return true;
+@@ -274,61 +262,57 @@ bool Ipset::ipset_exec(enum ipset_cmd cmd,  const Tins::IPv6Address &inIpAddress
+     if (Debug == true) {
+         syslog(LOG_DEBUG, "Ipset: received command %d for IP address %s for ipset %s", cmd, inIpAddress.to_string().c_str(), ipsetName.c_str());
+     }
+-    struct ipset_session *session = ipset_session_init(printf);
++    struct ipset_session *session = noddos_ipset_session_init();
+     if (session == nullptr) {
+         syslog (LOG_ERR, "Ipset: Cannot initialize ipset session.");
+         ipset_session_fini(session);
+         throw std::runtime_error ("Cannot initialize ipset session.");
+     }
+ 
+-    if (ipset_envopt_parse(session, IPSET_ENV_EXIST, NULL) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set environment option.");
+-        ipset_session_fini(session);
+-        throw std::runtime_error ("Can't set environment option.");
+-    }
++    ipset_envopt_set(session, IPSET_ENV_EXIST);
+     if (ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str()) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     const struct ipset_type *type = ipset_type_get(session, cmd);
+     if (type == NULL) {
+-        syslog (LOG_ERR, "Ipset: Can't get type for set %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't get type for set %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+ 
+     uint8_t family = NFPROTO_IPV6;
+     if (ipset_session_data_set(session, IPSET_OPT_FAMILY, &family) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set session data to IPv6 family for set %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set session data to IPv6 family for set %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set session data for " + ipsetName + " to the IPv6 family, error: " + ipset_session_error(session));
++        throw std::runtime_error("Can't set session data for " + ipsetName + " to the IPv6 family, error: " + ipset_session_report_msg(session));
+     }
+ 
+     unsigned char buf[sizeof(struct in6_addr)];
+     int s = inet_pton(AF_INET6, inIpAddress.to_string().c_str(), buf);
+     if (ipset_session_data_set(session, IPSET_OPT_IP, &buf) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set session data to the IPv4 address for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set session data to the IPv4 address for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set session data to the IPv4 address for setname " + ipsetName + ", error: " + ipset_session_error(session));
++        throw std::runtime_error("Can't set session data to the IPv4 address for setname " + ipsetName + ", error: " + ipset_session_report_msg(session));
+     }
+ 
+     if (timeout) {
+         if (ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout) != 0) {
+-            syslog (LOG_ERR, "Ipset: Can't set timeout for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++            syslog (LOG_ERR, "Ipset: Can't set timeout for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+             ipset_session_fini(session);
+-            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_error(session));
++            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_report_msg(session));
+         }
+     }
+     if (ipset_cmd(session, cmd, 0) != 0) {
+-        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_commit(session) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     ipset_session_fini(session);
+     return true;
+@@ -338,50 +322,46 @@ bool Ipset::ipset_exec(enum ipset_cmd cmd, const std::string Mac, time_t timeout
+     if (Debug == true) {
+         syslog(LOG_DEBUG, "Ipset: received command %d for MAC address %s for ipset %s", cmd, Mac.c_str(), ipsetName.c_str());
+     }
+-    struct ipset_session *session = ipset_session_init(printf);
++    struct ipset_session *session = noddos_ipset_session_init();
+     if (session == nullptr) {
+         syslog (LOG_ERR, "Ipset: Cannot initialize ipset session.");
+         ipset_session_fini(session);
+         throw std::runtime_error ("Cannot initialize ipset session.");
+     }
+ 
+-    if (ipset_envopt_parse(session, IPSET_ENV_EXIST, NULL) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set environment option.");
+-        ipset_session_fini(session);
+-        throw std::runtime_error ("Can't set environment option.");
+-    }
++    ipset_envopt_set(session, IPSET_ENV_EXIST);
+     if (ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str()) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't set setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't set setname " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     const struct ipset_type *type = ipset_type_get(session, cmd);
+     if (type == NULL) {
+-        syslog (LOG_ERR, "Ipset: Can't get type for set %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't get type for set %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't get type for set " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_parse_elem(session, (ipset_opt)type->last_elem_optional, Mac.c_str()) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't call ipset_parse_elem for %s: %s ", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't call ipset_parse_elem for %s: %s ", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't call ipset_parse_elem for ipset " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't call ipset_parse_elem for ipset " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (timeout) {
+         if (ipset_session_data_set(session, IPSET_OPT_TIMEOUT, &timeout) != 0) {
+-            syslog (LOG_ERR, "Ipset: Can't set timeout for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++            syslog (LOG_ERR, "Ipset: Can't set timeout for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+             ipset_session_fini(session);
+-            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_error(session));
++            throw std::runtime_error("Can't set timeout for " + ipsetName + ": " + ipset_session_report_msg(session));
+         }
+     }
+     if (ipset_cmd(session, cmd, 0) != 0) {
+-        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't exec ipset cmd for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't exec ipset cmd for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     if (ipset_commit(session) < 0) {
+-        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++        syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+         ipset_session_fini(session);
+-        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
++        throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
+     }
+     ipset_session_fini(session);
+     return true;
+diff --git a/src/Ipset.h b/src/Ipset.h
+index 2c5f7b2..eb180da 100644
+--- a/src/Ipset.h
++++ b/src/Ipset.h
+@@ -41,6 +41,31 @@
+ 
+ #include "MacAddress.h"
+ 
++#if IPSET_PROTOCOL < 7
++/* compatibility shims */
++
++inline void ipset_envopt_set(struct ipset_session *session, enum ipset_envopt opt)
++{
++    ipset_envopt_parse(session, opt, NULL);
++}
++
++inline const char * ipset_session_report_msg(const struct ipset_session *session)
++{
++  return ipset_session_error(session);
++}
++
++static inline struct ipset_session *noddos_ipset_session_init(void)
++{
++  return ipset_session_init(printf);
++}
++
++#else
++
++static inline struct ipset_session *noddos_ipset_session_init(void)
++{
++  return ipset_session_init(NULL, NULL);
++}
++#endif
+ 
+ std::string getIpsetUuid (std::string inUuid);
+ std::string getIpsetName (std::string inUuid, bool inSrc, bool inIpv4 = true);
+@@ -99,23 +124,19 @@ public:
+     }
+     bool Exists() {
+         try {
+-            struct ipset_session *session = ipset_session_init(printf);
++            struct ipset_session *session = noddos_ipset_session_init();
+             if (session == nullptr) {
+                 syslog (LOG_ERR, "Ipset: Cannot initialize ipset session.");
+                 ipset_session_fini(session);
+                 throw std::runtime_error ("Cannot initialize ipset session.");
+             }
+ 
+-            if (ipset_envopt_parse(session, IPSET_ENV_EXIST, NULL) < 0) {
+-                syslog (LOG_ERR, "Ipset: Can't set environment option.");
+-                ipset_session_fini(session);
+-                throw std::runtime_error ("Can't set environment option.");
+-            }
++            ipset_envopt_set(session, IPSET_ENV_EXIST);
+             int r = ipset_session_data_set(session, IPSET_SETNAME, ipsetName.c_str());
+             if (ipset_commit(session) < 0) {
+-                syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_error(session));
++                syslog (LOG_ERR, "Ipset: Can't commit for setname %s: %s", ipsetName.c_str(), ipset_session_report_msg(session));
+                 ipset_session_fini(session);
+-                throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_error(session));
++                throw std::runtime_error("Can't call ipset_commit for " + ipsetName + ": " + ipset_session_report_msg(session));
+             }
+             ipset_session_fini(session);
+             return r == 0;

--- a/net/noddos/patches/030-getnoddosdeviceprofiles-wget-timestamping-check.patch
+++ b/net/noddos/patches/030-getnoddosdeviceprofiles-wget-timestamping-check.patch
@@ -1,0 +1,28 @@
+From eb1730afff9377a5f167d0738ad0b3aeba9634d0 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cote2004-github@yahoo.com>
+Date: Tue, 19 Mar 2019 18:27:10 -0300
+Subject: [PATCH] getnoddosdeviceprofiles: wget timestamping check
+
+Check if the --timestamping option is available to avoid an error in
+openwrt when wget is handled by uclient-fetch.
+
+Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
+
+diff --git a/tools/getnoddosdeviceprofiles b/tools/getnoddosdeviceprofiles
+index 337e351..174034f 100755
+--- a/tools/getnoddosdeviceprofiles
++++ b/tools/getnoddosdeviceprofiles
+@@ -86,7 +86,12 @@ fi
+ # That's also why we don't delete the downloaded file
+ if [ "$WGET" != "" ]
+ then
+-    GETURL="$WGET --quiet --timestamping"
++    GETURL="$WGET --quiet"
++    # Make sure wget accepts --timestamping
++    if wget --help 2>&1 | egrep timestamping > /dev/null
++    then
++        GETURL="$GETURL --timestamping"
++    fi
+ else
+     if [ "$CURL" != "" ]
+     then


### PR DESCRIPTION
Maintainer: @StevenHessing 
Compile tested: mipsel-74kc, Asus RT-56U; arm, WRT3200ACM - master
Run tested: WRT3200ACM; basic testing done; service runs, but I'm not sure it does what's intended to do, but it does map the devices in the network.

Fixes #8349 
Description:
Old API compatibility was kept with a compatiblity shim.

Detect wget --timestamping support to make it compatible with uclient-fetch implementation of wget.

Patches were submitted upstream, but no response was received yet.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>