### PR TITLE
[18.06] bonnie++: Update to 1.98

### DIFF
--- a/utils/bonnie++/Makefile
+++ b/utils/bonnie++/Makefile
@@ -8,26 +8,29 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bonnie++
-PKG_VERSION:=1.97
+PKG_VERSION:=1.98
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
-PKG_SOURCE_URL:=http://www.coker.com.au/bonnie++/experimental/
-PKG_HASH:=44f5a05937648a6526ba99354555d7d15f2dd392e55d3436f6746da6f6c35982
+PKG_SOURCE_URL:=https://www.coker.com.au/bonnie++/
+PKG_HASH:=6e0bcbc08b78856fd998dd7bcb352d4615a99c26c2dc83d5b8345b102bad0b04
+
+PKG_MAINTAINER:=Florian Fainelli <florian@openwrt.org>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=copyright.txt
-PKG_MAINTAINER:=Florian Fainelli <florian@openwrt.org>
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION).1
+PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
 
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/bonniexx
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libstdcpp +libpthread
+  DEPENDS:=$(CXX_DEPENDS) +libpthread
   TITLE:=Bonnie++ - hard drive bottleneck testing program.
-  URL:=http://www.coker.com.au/bonnie++/
+  URL:=https://www.coker.com.au/bonnie++/
 endef
 
 define Package/bonniexx/description
@@ -35,14 +38,11 @@ define Package/bonniexx/description
   tests of hard drive and file system performance.
 endef
 
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		TARGET_CXX="$(TARGET_CXX)" \
-		TARGET_LINK="$(TARGET_CXX)" \
-		MORECFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CXXFLAGS)" \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		all
-endef
+ifeq ($(CONFIG_USE_UCLIBCXX),y)
+TARGET_LDFLAGS += -nodefaultlibs
+endif
+
+TARGET_CXXFLAGS += -fno-rtti -flto
 
 define Package/bonniexx/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/utils/bonnie++/patches/002-add-verbose-error-messages.patch
+++ b/utils/bonnie++/patches/002-add-verbose-error-messages.patch
@@ -1,6 +1,6 @@
 --- a/bon_file.cpp
 +++ b/bon_file.cpp
-@@ -464,25 +464,37 @@ int COpenTest::delete_sequential(BonTime
+@@ -469,25 +469,37 @@ int COpenTest::delete_sequential(BonTime
      }
      if(m_number_directories != 1)
      {

--- a/utils/bonnie++/patches/010-openwrt-fixes.patch
+++ b/utils/bonnie++/patches/010-openwrt-fixes.patch
@@ -1,0 +1,81 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -7,12 +7,6 @@ SCRIPTS=bon_csv2txt
+ 
+ prefix=@prefix@
+ eprefix=@exec_prefix@
+-#MORE_WARNINGS=-Weffc++
+-WFLAGS=-Wall -W -Wshadow -Wpointer-arith -Wwrite-strings -pedantic -ffor-scope -Wcast-align -Wsign-compare -Wpointer-arith -Wwrite-strings -Wformat-security -Wswitch-enum -Winit-self $(MORE_WARNINGS)
+-CFLAGS=-O2 @debug@ -DNDEBUG $(WFLAGS) $(MORECFLAGS)
+-CXX=@CXX@ $(CFLAGS)
+-LINK=@CXX@
+-THREAD_LFLAGS=@thread_ldflags@
+ 
+ INSTALL=@INSTALL@
+ INSTALL_PROGRAM=@INSTALL_PROGRAM@
+@@ -34,22 +28,22 @@ GETCHSRC=getc_putc_helper.cpp duration.cpp
+ GETCHOBJS=$(GETCHSRC:.cpp=.o)
+ 
+ bonnie++: $(BONOBJS)
+-	$(LINK) -o bonnie++ $(BONOBJS) $(THREAD_LFLAGS)
++	$(CXX) $(CXXFLAGS) -o bonnie++ $(BONOBJS)
+ 
+ zcav: $(ZCAVOBJS)
+-	$(LINK) -o zcav $(ZCAVOBJS) $(THREAD_LFLAGS)
++	$(CXX) $(CXXFLAGS) -o zcav $(ZCAVOBJS)
+ 
+ getc_putc: $(GETCOBJS) getc_putc_helper
+-	$(LINK) -o getc_putc $(GETCOBJS) $(THREAD_LFLAGS)
++	$(CXX) $(CXXFLAGS) -o getc_putc $(GETCOBJS)
+ 
+ getc_putc_helper: $(GETCHOBJS)
+-	$(CXX) -o getc_putc_helper $(GETCHOBJS)
++	$(CXX) $(CXXFLAGS) -o getc_putc_helper $(GETCHOBJS)
+ 
+ bon_csv2html: bon_csv2html.o
+-	$(LINK) bon_csv2html.o -o bon_csv2html
++	$(CXX) $(CXXFLAGS) bon_csv2html.o -o bon_csv2html
+ 
+ generate_randfile: generate_randfile.o
+-	$(LINK) generate_randfile.o -o generate_randfile
++	$(CXX) $(CXXFLAGS) generate_randfile.o -o generate_randfile
+ 
+ install-bin: $(EXE) $(EXES)
+ 	mkdir -p $(eprefix)/bin $(eprefix)/sbin
+@@ -63,7 +57,7 @@ install: install-bin
+ 	@INSTALL_DATA@ $(MAN8) @mandir@/man8
+ 
+ %.o: %.cpp
+-	$(CXX) -c $<
++	$(CXX) $(CXXFLAGS) -c $<
+ 
+ clean:
+ 	rm -f $(EXE) $(EXES) *.o build-stamp install-stamp
+--- a/configure.in
++++ b/configure.in
+@@ -31,7 +31,6 @@ fi
+ 
+ dnl Checks for programs.
+ AC_LANG_CPLUSPLUS
+-AC_PROG_CC
+ AC_PROG_CXX
+ AC_PROG_CXXCPP
+ AC_PROG_INSTALL
+@@ -66,7 +65,7 @@ AC_SUBST(linux_pthread)
+ AC_TRY_COMPILE([#define _GNU_SOURCE
+ #include <pthread.h>
+ ] , [pthread_mutexattr_t attr;
+-    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP);]
++    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);]
+   , linux_pthread="yes")
+ if [[ -n "$linux_pthread" ]]; then
+    linux_pthread="#define LINUX_PTHREAD"
+@@ -83,7 +82,7 @@ void * thread_func(void * param) { return NULL; }
+   , thread_ldflags="-pthread")
+ 
+ AC_SUBST(large_file)
+-AC_TRY_RUN([#ifndef _LARGEFILE64_SOURCE
++AC_TRY_COMPILE([#ifndef _LARGEFILE64_SOURCE
+ #define _LARGEFILE64_SOURCE
+ #endif
+ #include <stdio.h>


### PR DESCRIPTION
This version contains NVME fixes.

Edited the patches to modify the package Makefile directly so as to reduce
hacks in the OpenWrt Makefile.

Added LTO support to lower filesize by ~4KB.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me