### PR TITLE
[OpenWrt 18.06] python-urllib3: update to 1.24.3

### DIFF
--- a/lang/python/python-urllib3/Makefile
+++ b/lang/python/python-urllib3/Makefile
@@ -8,14 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-urllib3
-PKG_VERSION:=1.22
+PKG_VERSION:=1.24.3
 PKG_RELEASE:=1
+
 PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.txt
 
 PKG_SOURCE:=urllib3-$(PKG_VERSION).tar.gz
-PKG_BUILD_DIR:=$(BUILD_DIR)/urllib3-$(PKG_VERSION)/
-PKG_SOURCE_URL:=https://pypi.python.org/packages/ee/11/7c59620aceedcc1ef65e156cc5ce5a24ef87be4107c2b74458464e437a5d/
-PKG_HASH:=cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/u/urllib3
+PKG_HASH:=2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/urllib3-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
@@ -24,25 +27,16 @@ define Package/python-urllib3
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
-  TITLE:=HTTP library with thread-safe connection pooling, file post, and more.
+  TITLE:=Sanity-friendly HTTP client
   URL:=https://urllib3.readthedocs.io/
   DEPENDS:=+python
+  VARIANT:=python
 endef
 
 define Package/python-urllib3/description
   HTTP library with thread-safe connection pooling, file post, and more.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/python-urllib3/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,python-urllib3))
 $(eval $(call BuildPackage,python-urllib3))
+$(eval $(call BuildPackage,python-urllib3-src))


### PR DESCRIPTION
Maintainer: none
Compile tested: Xiaomi Mi WiFi R3G, ramips, mt7621, OpenWrt 18.06.02
Run tested: Xiaomi Mi WiFi R3G, ramips, mt7621, OpenWrt 18.06.02

Proof of run tested:
![Screenshot from 2019-04-23 15-53-37](https://user-images.githubusercontent.com/4096468/56586618-52ef3980-65e0-11e9-9fae-f6789f2cb181.png)

Description:
- Update to version 1.25 ([changelog](https://github.com/urllib3/urllib3/blob/master/CHANGES.rst))

Most interesting changes:
- Fixes CVE-2019-11324
- RFC 3986 compliant
- Fix TITLE, which was too long for make menuconfig
- Add PKG_LICENSE_FILES
- Remove current maintainer
