### PR TITLE
[18.06] quasselc: Update to latest version

### DIFF
--- a/libs/quasselc/Makefile
+++ b/libs/quasselc/Makefile
@@ -8,23 +8,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=quasselc
+PKG_SOURCE_DATE:=2017-01-11
+PKG_SOURCE_VERSION:=a0a1e6bd87d3eac68b5369972d1c2035cfe47e94
+PKG_RELEASE:=1
 
-# quasselc upstream doesn't release versions (at least, at the moment),
-# so use commit date for PKG_VERSION and embed commit hash into PKG_RELEASE.
-PKG_VERSION:=2015-04-06
-PKG_SOURCE_VERSION:=fcd966966924e3d9af0954db56117e2f48767ea1
-PKG_RELEASE:=1.$(PKG_SOURCE_VERSION)
-
-PKG_LICENSE:=GPL-3.0+
-
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/phhusson/QuasselC
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.bz2
-PKG_MIRROR_HASH:=80ca463c20f934a3730fb51c69f5299e2d35ca53a06f0ca746d3de97dbfc360b
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_DATE).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/phhusson/QuasselC/tar.gz/$(PKG_SOURCE_VERSION)?
+PKG_HASH:=fe7b48a13c0e6dad81cdae18069d4f5607af64d73a3201f42d79548170dde510
+PKG_BUILD_DIR:=$(BUILD_DIR)/QuasselC-$(PKG_SOURCE_VERSION)
 
 PKG_MAINTAINER:=Ben Rosser <rosser.bjr@gmail.com>
+PKG_LICENSE:=LGPL-3.0
+PKG_LICENSE_FILES:=COPYING.LESSER
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/libs/quasselc/patches/001-respect-cflags-ldflags.patch
+++ b/libs/quasselc/patches/001-respect-cflags-ldflags.patch
@@ -1,5 +1,3 @@
-diff --git a/Makefile b/Makefile
-index 7994eea..b1f8d83 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -2,11 +2,11 @@ prefix ?= /usr/local

--- a/net/quassel-irssi/Makefile
+++ b/net/quassel-irssi/Makefile
@@ -8,23 +8,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=quassel-irssi
+PKG_SOURCE_DATE:=2017-11-30
+PKG_SOURCE_VERSION:=079be662dde374a383646256108a4974c2bc7796
+PKG_RELEASE:=1
 
-# quassel-irssi upstream doesn't release versions (at least, at the moment),
-# so use commit date for PKG_VERSION and embed commit hash into PKG_RELEASE.
-PKG_VERSION:=2016-09-11
-PKG_SOURCE_VERSION:=cbd9bd7f4ac44260d9fcafb809fdf153cde193e5
-PKG_RELEASE:=1.$(PKG_SOURCE_VERSION)
-
-PKG_LICENSE:=GPL-3.0+
-
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/phhusson/quassel-irssi
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.bz2
-PKG_MIRROR_HASH:=fd13b2497e3b0d0779e0ce3d8b27c37e207d2a73b5b6dc0cb2799bd4472fc5e1
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_DATE).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/phhusson/quassel-irssi/tar.gz/$(PKG_SOURCE_VERSION)?
+PKG_HASH:=c276a92a47f8edf5ae1d9db0e72a69d078f2f3f80e055853fc6d06099d898966
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
 
 PKG_MAINTAINER:=Ben Rosser <rosser.bjr@gmail.com>
+PKG_LICENSE:=GPL-3.0+
+PKG_LICENSE_FILES:=core/COPYING
 
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/quassel-irssi/patches/001-respect-cflags.patch
+++ b/net/quassel-irssi/patches/001-respect-cflags.patch
@@ -1,5 +1,3 @@
-diff --git a/core/Makefile b/core/Makefile
-index 6133087..389855c 100644
 --- a/core/Makefile
 +++ b/core/Makefile
 @@ -3,7 +3,7 @@ DESTDIR ?=
@@ -11,12 +9,12 @@ index 6133087..389855c 100644
  IRSSI_LIB?=$(DESTDIR)/$(LIBDIR)/irssi
  IRSSI_CFLAGS+=-I$(IRSSI_INCLUDE)/src/
  IRSSI_CFLAGS+=-I$(IRSSI_INCLUDE)/src/core/
-@@ -26,7 +26,7 @@ else
+@@ -28,7 +28,7 @@ else
      LDFLAGS += -lquasselc
  endif
  
 -CFLAGS=-std=gnu11 -Wall -Wextra -Werror -g -O2 $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations
 +CFLAGS+=-std=gnu11 -Wall -Wextra -Werror -g $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations
  
- TARGET=libquassel_core.so
- 
+ CFLAGS += $(SSL_CFLAGS)
+ LDFLAGS+= $(SSL_LDLAGS)

--- a/net/quassel-irssi/patches/002-use-cc-var.patch
+++ b/net/quassel-irssi/patches/002-use-cc-var.patch
@@ -1,8 +1,6 @@
-diff --git a/core/Makefile b/core/Makefile
-index 389855c..2f81417 100644
 --- a/core/Makefile
 +++ b/core/Makefile
-@@ -44,7 +44,7 @@ irssi/network-openssl.o: CFLAGS:=$(IRSSI_CFLAGS)
+@@ -49,7 +49,7 @@ irssi/network-openssl.o: CFLAGS:=$(IRSSI_CFLAGS)
  quasselc-connector.o: CFLAGS:=$(CFLAGS)
  
  $(TARGET): $(OBJECTS)

--- a/net/quassel-irssi/patches/003-use-pkgconfig-ldflags-quasselc.patch
+++ b/net/quassel-irssi/patches/003-use-pkgconfig-ldflags-quasselc.patch
@@ -1,8 +1,6 @@
-diff --git a/core/Makefile b/core/Makefile
-index 2f81417..aa62201 100644
 --- a/core/Makefile
 +++ b/core/Makefile
-@@ -23,7 +23,7 @@ ifndef SYSTEM_QUASSELC
+@@ -25,7 +25,7 @@ ifndef SYSTEM_QUASSELC
      QUASSELC_FLAGS:=-Ilib
  else
      QUASSELC_FLAGS:=$(shell pkg-config --cflags quasselc)
@@ -10,4 +8,4 @@ index 2f81417..aa62201 100644
 +    LDFLAGS += $(shell pkg-config --libs quasselc)
  endif
  
- CFLAGS+=-std=gnu11 -Wall -Wextra -Werror -g -O2 $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations
+ CFLAGS+=-std=gnu11 -Wall -Wextra -Werror -g $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations

--- a/net/quassel-irssi/patches/010-Get-compatible-with-potential-irssi-abi-8-and-drop-p.patch
+++ b/net/quassel-irssi/patches/010-Get-compatible-with-potential-irssi-abi-8-and-drop-p.patch
@@ -1,0 +1,118 @@
+From 19e810405789a35b92026b56ea49d01a3f544b07 Mon Sep 17 00:00:00 2001
+From: Pierre-Hugues Husson <phh@phh.me>
+Date: Tue, 17 Jan 2017 23:09:24 +0100
+Subject: [PATCH] Get compatible with potential irssi abi 8, and drop polling
+
+---
+ core/Makefile      |  1 -
+ core/quassel-net.c | 64 ++++++++++++++++++++++++++++++++++++++--------
+ 2 files changed, 53 insertions(+), 10 deletions(-)
+
+diff --git a/core/Makefile b/core/Makefile
+index c1c65fc..987bd7b 100644
+--- a/core/Makefile
++++ b/core/Makefile
+@@ -16,7 +16,6 @@ SSL_CFLAGS=$(shell pkg-config --cflags openssl)
+ SSL_LDLAGS=$(shell pkg-config --libs openssl)
+ OBJECTS:=quasselc-connector.o quassel-core.o
+ OBJECTS+=quassel-net.o quassel-msgs.o quassel-cmds.o
+-OBJECTS+=irssi/network-openssl.o
+ OBJECTS+=quassel-fe-window.o quassel-fe-level.o quassel-cfg.o
+ 
+ LDFLAGS ?=
+diff --git a/core/quassel-net.c b/core/quassel-net.c
+index 8a6eb55..5db7fe0 100644
+--- a/core/quassel-net.c
++++ b/core/quassel-net.c
+@@ -132,10 +132,10 @@ static SERVER_REC* quassel_server_init_connect(SERVER_CONNECT_REC* conn) {
+ 	ret->got = 0;
+ 	server_connect_ref(SERVER_CONNECT(conn));
+ 
+-	if(conn->use_ssl) {
++	if(conn->use_tls) {
+ 		ret->ssl = 1;
+ 	}
+-	ret->connrec->use_ssl = 0;
++	ret->connrec->use_tls = 0;
+ 
+ 	ret->channels_join = quassel_irssi_channels_join;
+ 	ret->send_message = quassel_irssi_send_message;
+@@ -161,12 +161,59 @@ void quassel_net_init(CHAT_PROTOCOL_REC* rec) {
+ 	signal_add_first("server connected", (SIGNAL_FUNC) sig_connected);
+ }
+ 
+-GIOChannel *irssi_ssl_get_iochannel(GIOChannel *handle, int port, SERVER_REC *server);
++static void quassel_net_final_setup(SERVER_REC* server, GIOChannel *handle) {
++	quassel_login(handle, server->connrec->nick, server->connrec->password);
++	server->handle->handle = handle;
++
++	server->readtag =
++		g_input_add(handle,
++			    G_INPUT_READ,
++			    (GInputFunction) quassel_parse_incoming, server);
++}
++
++static void quassel_net_ssl_callback(SERVER_REC *server, GIOChannel *handle) {
++	int error;
++
++	g_return_if_fail(IS_SERVER(server));
++
++	error = irssi_ssl_handshake(handle);
++	if (error == -1) {
++		server->connection_lost = TRUE;
++		server_connect_failed(server, NULL);
++		return;
++	}
++	if (error & 1) {
++		if (server->connect_tag != -1)
++			g_source_remove(server->connect_tag);
++		server->connect_tag = g_input_add(handle, error == 1 ? G_INPUT_READ : G_INPUT_WRITE,
++						  (GInputFunction)
++						  quassel_net_ssl_callback,
++						  server);
++		return;
++	}
++
++	if (server->connect_tag != -1) {
++		g_source_remove(server->connect_tag);
++		server->connect_tag = -1;
++	}
++
++	quassel_net_final_setup(server, handle);
++}
++
+ void quassel_irssi_init_ack(void *arg) {
+ 	Quassel_SERVER_REC *server = (Quassel_SERVER_REC*)arg;
+-	if(!server->ssl)
+-		goto login;
+-	GIOChannel* ssl_handle = irssi_ssl_get_iochannel(server->handle->handle, 1337, SERVER(server));
++	GIOChannel* ssl_handle = net_start_ssl((SERVER_REC*)server);
++
++	if(server->readtag != -1) {
++		g_source_remove(server->readtag);
++		server->readtag = -1;
++	}
++
++	if(!server->ssl) {
++		quassel_net_final_setup((SERVER_REC*)server, server->handle->handle);
++		return;
++	}
++
+ 	int error;
+ 	//That's polling, and that's really bad...
+ 	while( (error=irssi_ssl_handshake(ssl_handle)) & 1) {
+@@ -175,10 +222,7 @@ void quassel_irssi_init_ack(void *arg) {
+ 			return;
+ 		}
+ 	}
+-	server->handle->handle = ssl_handle;
+-
+-login:
+-	quassel_login(server->handle->handle, server->connrec->nick, server->connrec->password);
++	quassel_net_ssl_callback((SERVER_REC*)server, ssl_handle);
+ }
+ 
+ void quassel_irssi_init_nack(void *arg) {
+-- 
+2.17.1
+


### PR DESCRIPTION
Maintainer: @TC01 

These are just backports to fix compilation. Both packages seem dead upstream.

https://downloads.openwrt.org/releases/faillogs/arm_cortex-a5_vfpv4/packages/quassel-irssi/compile.txt