### PR TITLE
[18.06] darkstat: Remove libbsd dependency

### DIFF
--- a/net/darkstat/Makefile
+++ b/net/darkstat/Makefile
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/darkstat
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libpcap +zlib +USE_GLIBC:libbsd
+  DEPENDS:=+libpcap +zlib
   TITLE:=Network bandwidth monitor
   URL:=http://unix4lyfe.org/darkstat/
 endef
@@ -44,7 +44,10 @@ CONFIGURE_ARGS += \
 	--disable-debug \
 	--with-chroot-dir=/var/empty
 
-TARGET_CFLAGS += -std=gnu99
+CONFIGURE_VARS += \
+	ac_cv_search_setproctitle=no \
+	ac_cv_search_strlcpy=no \
+	ac_cv_search_strlcat=no
 
 define Build/Compile
 	$(HOSTCC) $(PKG_BUILD_DIR)/static/c-ify.c \


### PR DESCRIPTION
darkstat includes its own strlcat and strlcpy, making the dependency
somewhat pointless.

Fixes compilation ever since glibc dependency on libbsd was removed.

Also removed std=gnu99 as it's not needed with GCC7.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @padre-lacroix 

Fixes: https://downloads.openwrt.org/releases/faillogs/arm_cortex-a5_vfpv4/packages/darkstat/compile.txt