### PR TITLE
[18.06] pianod: Update to 174.09 release (removes BSD dependencies)

### DIFF
--- a/sound/pianod/Makefile
+++ b/sound/pianod/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pianod
-PKG_VERSION:=174.07
+PKG_VERSION:=174.09
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://github.com/thess/pianod-sc/releases/download/$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=eee969926c095497893fbd28711258a31efb2d2301da87563dbcd101d8771bff
+PKG_HASH:=744c833ee17a7c95068c6925f4301f342bcad838ad8e48b40a19fd6739533eac
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 


### PR DESCRIPTION
Signed-off-by: Ted Hess <thess@kitschensync.net>

Maintainer: @thess 

Fixes: https://downloads.openwrt.org/releases/faillogs/x86_64/packages/pianod/compile.txt
