### PR TITLE
[18.06] psqlodbc: bump to 10.03.0000, fix --with-unixodbc

### DIFF
--- a/libs/psqlodbc/Makefile
+++ b/libs/psqlodbc/Makefile
@@ -6,8 +6,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=psqlodbc
 PKG_RELEASE:=1
-PKG_VERSION:=09.06.0310
-PKG_HASH:=6c42078af094d61baca2c8bd1dc4d137a77377198ef94e4eda5989bdce3474c3
+PKG_VERSION:=10.03.0000
+PKG_HASH:=0d2ff2d10d9347ef6ce83c7ca24f4cb20b4044eeef9638c8ae3bc8107e9e92f8
 
 PKG_SOURCE_URL:=https://ftp.postgresql.org/pub/odbc/versions/src/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -21,7 +21,7 @@ PKG_BUILD_DEPENDS:=unixodbc/host
 include $(INCLUDE_DIR)/package.mk
 
 CONFIGURE_ARGS += \
-	--with-unixodbc=$(STAGING_DIR)/usr \
+	--with-unixodbc=$(STAGING_DIR_HOST)/bin/odbc_config \
 	--with-libpq=$(STAGING_DIR)/usr
 
 define Package/psqlodbc/Default

--- a/libs/psqlodbc/Makefile
+++ b/libs/psqlodbc/Makefile
@@ -5,18 +5,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=psqlodbc
+PKG_VERSION:=11.00.0000
 PKG_RELEASE:=1
-PKG_VERSION:=10.03.0000
-PKG_HASH:=0d2ff2d10d9347ef6ce83c7ca24f4cb20b4044eeef9638c8ae3bc8107e9e92f8
 
-PKG_SOURCE_URL:=https://ftp.postgresql.org/pub/odbc/versions/src/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://ftp.postgresql.org/pub/odbc/versions/src
+PKG_HASH:=703e6b87022f95ffa00d9f86c8f0a877f8a55b9b3be0942081f382e794112a86
 
+PKG_MAINTAINER:=
 PKG_LICENSE:=LGPL-2.0+
 PKG_LICENSE_FILES:=license.txt
 
-PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=unixodbc/host
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Update to 10.03.0000.

--with-unixodbc should point to the odbc_config binary, not to the top
of the install directory $(STAGING_DIR)/usr.

Acked-by: Rosen Penev <rosenp@gmail.com>
Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

Maintainer: @dangowrt 

Fixes: https://downloads.openwrt.org/releases/faillogs/arm_xscale/packages/psqlodbc/compile.txt
