### PR TITLE
[18.06] luasec: backport build fixes

### DIFF
--- a/lang/luasec/Makefile
+++ b/lang/luasec/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luasec
 PKG_VERSION:=0.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/brunoos/luasec/archive/
@@ -44,6 +44,7 @@ TARGET_CFLAGS += $(FPIC)
 TARGET_LDFLAGS += $(FPIC)
 
 MAKE_FLAGS += \
+	LD="$(TARGET_CC)" \
 	INCDIR="$(TARGET_CPPFLAGS) -I." \
 	LIBDIR="$(TARGET_LDFLAGS) -L./luasocket" \
 	LUACPATH="$(PKG_INSTALL_DIR)/usr/lib/lua" \

--- a/lang/luasec/Makefile
+++ b/lang/luasec/Makefile
@@ -45,8 +45,8 @@ TARGET_LDFLAGS += $(FPIC)
 
 MAKE_FLAGS += \
 	LD="$(TARGET_CC)" \
-	INCDIR="$(TARGET_CPPFLAGS) -I." \
-	LIBDIR="$(TARGET_LDFLAGS) -L./luasocket" \
+	INC_PATH="" \
+	LIB_PATH="" \
 	LUACPATH="$(PKG_INSTALL_DIR)/usr/lib/lua" \
 	LUAPATH="$(PKG_INSTALL_DIR)/usr/lib/lua"
 

--- a/lang/luasec/Makefile
+++ b/lang/luasec/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luasec
 PKG_VERSION:=0.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/brunoos/luasec/archive/
@@ -39,6 +39,9 @@ endef
 
 define Build/Configure
 endef
+
+TARGET_CFLAGS += $(FPIC)
+TARGET_LDFLAGS += $(FPIC)
 
 MAKE_FLAGS += \
 	INCDIR="$(TARGET_CPPFLAGS) -I." \

--- a/lang/luasec/patches/100-fix-compilation.patch
+++ b/lang/luasec/patches/100-fix-compilation.patch
@@ -1,0 +1,13 @@
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -13,8 +13,8 @@ WARN=-Wall -pedantic
+ BSD_CFLAGS=-O2 -fPIC $(WARN) $(INCDIR) $(DEFS)
+ BSD_LDFLAGS=-O -fPIC -shared $(LIBDIR)
+ 
+-LNX_CFLAGS=-O2 -fPIC $(WARN) $(INCDIR) $(DEFS)
+-LNX_LDFLAGS=-O -fPIC -shared $(LIBDIR)
++LNX_CFLAGS=$(INCDIR) $(DEFS)
++LNX_LDFLAGS=-shared $(LIBDIR)
+ 
+ MAC_ENV=env MACOSX_DEPLOYMENT_TARGET='$(MACVER)'
+ MAC_CFLAGS=-O2 -fno-common $(WARN) $(INCDIR) $(DEFS)


### PR DESCRIPTION
Maintainer: @MikePetullo 

Fixes: https://downloads.openwrt.org/releases/faillogs/powerpc_464fp/packages/luasec/compile.txt for example.

Fixed compilation by backporting linking fixes.