### PR TITLE
[18.06] apcupsd: preset shutdown binary

### DIFF
--- a/net/apcupsd/Makefile
+++ b/net/apcupsd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apcupsd
 PKG_VERSION:=3.14.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0
@@ -38,6 +38,8 @@ define Package/apcupsd-cgi
   TITLE:=UPS control software CGI module
   URL:=http://www.apcupsd.org/
 endef
+
+CONFIGURE_VARS += SHUTDOWN=/sbin/halt
 
 define Build/Configure
 	$(CP) $(SCRIPT_DIR)/config.* $(PKG_BUILD_DIR)/autoconf/

--- a/net/apcupsd/files/apccontrol
+++ b/net/apcupsd/files/apccontrol
@@ -20,7 +20,7 @@ exec_prefix=/usr
 
 APCPID=/var/run/apcupsd.pid
 APCUPSD=/usr/sbin/apcupsd
-SHUTDOWN=/sbin/shutdown
+SHUTDOWN=/sbin/halt
 SCRIPTSHELL=/bin/sh
 SCRIPTDIR=/etc/apcupsd
 WALL=true
@@ -101,11 +101,11 @@ case "$1" in
     ;;
     doreboot)
 	echo "UPS ${2} initiating Reboot Sequence" | ${WALL}
-	${SHUTDOWN} -r now "apcupsd UPS ${2} initiated reboot"
+	echo "apcupsd UPS ${2} initiated reboot" && /sbin/reboot
     ;;
     doshutdown)
 	echo "UPS ${2} initiated Shutdown Sequence" | ${WALL}
-	${SHUTDOWN} -h now "apcupsd UPS ${2} initiated shutdown"
+	echo "apcupsd UPS ${2} initiated shutdown" && /sbin/halt
     ;;
     annoyme)
 	echo "Power problems with UPS ${2}. Please logoff." | ${WALL}

--- a/net/apcupsd/patches/015-drop-doc.patch
+++ b/net/apcupsd/patches/015-drop-doc.patch
@@ -1,0 +1,10 @@
+--- a/Makefile.orig	2019-04-04 18:19:45.007668656 +0200
++++ a/Makefile	2019-04-04 18:23:00.723165465 +0200
+@@ -1,6 +1,6 @@
+ topdir:=.
+
+-SUBDIRS=src platforms doc
++SUBDIRS=src platforms
+ include autoconf/targets.mak
+
+ # Force platforms/ to build after src/


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

Maintainer: @tru7 

Fixes: https://downloads.openwrt.org/releases/faillogs/powerpc_464fp/packages/apcupsd/compile.txt

Cherry-picked from master.