### PR TITLE
[18.06] Prosody: backport changes from master

### DIFF
--- a/net/prosody/Makefile
+++ b/net/prosody/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prosody
 PKG_VERSION:=0.11.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://prosody.im/downloads/source
@@ -30,7 +30,7 @@ define Package/prosody
   SUBMENU:=Instant Messaging
   DEPENDS:=+luafilesystem +libidn +luaexpat +luasec +libopenssl +libidn +liblua +luabitop
   TITLE:=XMPP server
-  URL:=http://prosody.im/
+  URL:=https://prosody.im/
   USERID:=prosody=54:prosody=54
 endef
 
@@ -44,10 +44,10 @@ define Package/prosody/conffiles
 /etc/prosody/prosody.cfg.lua
 endef
 
-TARGET_CFLAGS += $(FPIC) 
+TARGET_CFLAGS += $(FPIC) -std=gnu99
+TARGET_LDFLAGS += -shared
 
-TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib 
-
+MAKE_FLAGS += LD="$(TARGET_CC)"
 
 define Build/Configure
 	# this is *NOT* GNU autoconf stuff
@@ -57,17 +57,11 @@ define Build/Configure
 		--with-lua-include="$(STAGING_DIR)/usr/include" \
 		--with-lua-lib="$(STAGING_DIR)/usr/lib" \
 		--cflags="$(TARGET_CFLAGS)" \
-		--ldflags="$(TARGET_LDFLAGS) -llua -lm -ldl -shared" \
+		--ldflags="$(TARGET_LDFLAGS)" \
 		--c-compiler="$(CC)" \
-		--linker="$(LD)" \
 		--datadir="/etc/prosody/data" \
 	)
 endef
-#	LDFLAGS="$(TARGET_LDFLAGS) -llua -lm -ldl" \
-
-MAKE_FLAGS += \
-	CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) -std=gnu99" \
-	PREFIX="/usr" \
 
 define Package/prosody/install
 	$(INSTALL_DIR) $(1)/etc/init.d
@@ -124,7 +118,7 @@ define Package/prosody/postinst
 		paxctl  -v /usr/bin/ > /dev/null  2>&1
 		[ $$? -ne 0 ] && {
 			cp /usr/bin/lua /tmp
-			paxctl -c -m /tmp/lua > /dev/null  2>&1 
+			paxctl -c -m /tmp/lua > /dev/null  2>&1
 			cp -f /tmp/lua /usr/bin/lua
 		}
 	}

--- a/net/prosody/Makefile
+++ b/net/prosody/Makefile
@@ -8,14 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prosody
-PKG_VERSION:=0.9.12
+PKG_VERSION:=0.11.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://prosody.im/downloads/source
-PKG_HASH:=1a59a322b71928a21985522aa00d0eab3552208d7bf9ecb318542a1b2fee3e8d
+PKG_SOURCE_URL:=https://prosody.im/downloads/source
+PKG_HASH:=8911f6dc29b9e0c4edf9e61dc23fa22d77bc42c4caf28b809ab843b2f08e4831
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=MIT/X11
+PKG_BUILD_DEPENDS:=lua/host
+PKG_CPE_ID:=cpe:/a:prosody:prosody
+HOST_BUILD_DEPENDS:=$(PKG_BUILD_DEPENDS)
 
 PKG_INSTALL:=1
 
@@ -25,7 +28,7 @@ define Package/prosody
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Instant Messaging
-  DEPENDS:=+luafilesystem +libidn +luaexpat +luasec +libopenssl +libidn +liblua 
+  DEPENDS:=+luafilesystem +libidn +luaexpat +luasec +libopenssl +libidn +liblua +luabitop
   TITLE:=XMPP server
   URL:=http://prosody.im/
   USERID:=prosody=54:prosody=54
@@ -50,7 +53,7 @@ define Build/Configure
 	# this is *NOT* GNU autoconf stuff
 	(cd $(PKG_BUILD_DIR); ./configure \
 		--prefix=/usr \
-		--with-lua="$(STAGING_DIR_HOSTPKG)/bin" \
+		--with-lua="$(STAGING_DIR_HOSTPKG)" \
 		--with-lua-include="$(STAGING_DIR)/usr/include" \
 		--with-lua-lib="$(STAGING_DIR)/usr/lib" \
 		--cflags="$(TARGET_CFLAGS)" \
@@ -81,7 +84,7 @@ define Package/prosody/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/prosody/prosody.version $(1)/usr/lib/prosody/
 	$(INSTALL_DIR) $(1)/usr/lib/prosody/core
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/core/*.lua $(1)/usr/lib/prosody/core/
-	$(INSTALL_DIR) $(1)/usr/lib/prosody/fallbacks
+	#$(INSTALL_DIR) $(1)/usr/lib/prosody/fallbacks
 	#$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/fallbacks/*.lua $(1)/usr/lib/prosody/fallbacks/
 	$(INSTALL_DIR) $(1)/usr/lib/prosody/modules
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/modules/*.lua $(1)/usr/lib/prosody/modules/
@@ -91,12 +94,20 @@ define Package/prosody/install
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/modules/mod_s2s/*.lua $(1)/usr/lib/prosody/modules/mod_s2s/
 	$(INSTALL_DIR) $(1)/usr/lib/prosody/modules/muc
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/modules/muc/*.lua $(1)/usr/lib/prosody/modules/muc/
-	$(INSTALL_DIR) $(1)/usr/lib/prosody/modules/storage
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/modules/storage/*.lua $(1)/usr/lib/prosody/modules/storage/
+	$(INSTALL_DIR) $(1)/usr/lib/prosody/modules/mod_pubsub
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/modules/mod_pubsub/*.lua $(1)/usr/lib/prosody/modules/mod_pubsub/
+	$(INSTALL_DIR) $(1)/usr/lib/prosody/modules/mod_mam
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/modules/mod_mam/*.lua $(1)/usr/lib/prosody/modules/mod_mam/
+	#$(INSTALL_DIR) $(1)/usr/lib/prosody/modules/storage
+	#$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/modules/storage/*.lua $(1)/usr/lib/prosody/modules/storage/
 	$(INSTALL_DIR) $(1)/usr/lib/prosody/net
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/net/*.lua $(1)/usr/lib/prosody/net/
 	$(INSTALL_DIR) $(1)/usr/lib/prosody/net/http
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/net/http/*.lua $(1)/usr/lib/prosody/net/http/
+	$(INSTALL_DIR) $(1)/usr/lib/prosody/net/resolvers
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/net/resolvers/*.lua $(1)/usr/lib/prosody/net/resolvers/
+	$(INSTALL_DIR) $(1)/usr/lib/prosody/net/websocket
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/net/websocket/*.lua $(1)/usr/lib/prosody/net/websocket/
 	$(INSTALL_DIR) $(1)/usr/lib/prosody/util
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/prosody/util/*.lua $(1)/usr/lib/prosody/util/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/prosody/util/*.so $(1)/usr/lib/prosody/util/

--- a/net/prosody/files/prosody.cfg.lua
+++ b/net/prosody/files/prosody.cfg.lua
@@ -1,10 +1,11 @@
 -- Prosody Example Configuration File
 --
 -- Information on configuring Prosody can be found on our
--- website at http://prosody.im/doc/configure
+-- website at https://prosody.im/doc/configure
 --
 -- Tip: You can check that the syntax of this file is correct
--- when you have finished by running: luac -p prosody.cfg.lua
+-- when you have finished by running this command:
+--     prosodyctl check config
 -- If there are any errors, it will let you know what and where
 -- they are, otherwise it will keep quiet.
 --
@@ -18,13 +19,18 @@
 
 -- This is a (by default, empty) list of accounts that are admins
 -- for the server. Note that you must create the accounts separately
--- (see http://prosody.im/doc/creating_accounts for info)
+-- (see https://prosody.im/doc/creating_accounts for info)
 -- Example: admins = { "user1@example.com", "user2@example.net" }
 admins = { }
 
 -- Enable use of libevent for better performance under high load
--- For more information see: http://prosody.im/doc/libevent
---use_libevent = true;
+-- For more information see: https://prosody.im/doc/libevent
+--use_libevent = true
+
+-- Prosody will always look in its source directory for modules, but
+-- this option allows you to specify additional locations where Prosody
+-- will look for modules first. For community modules, see https://modules.prosody.im/
+--plugin_paths = {}
 
 -- This is the list of modules Prosody will load on startup.
 -- It looks for mod_modulename.lua in the plugins folder, so make sure that exists too.
@@ -39,74 +45,91 @@ modules_enabled = {
 		"disco"; -- Service discovery
 
 	-- Not essential, but recommended
+		"carbons"; -- Keep multiple clients in sync
+		"pep"; -- Enables users to publish their avatar, mood, activity, playing music and more
 		"private"; -- Private XML storage (for room bookmarks, etc.)
-		"vcard"; -- Allow users to set vCards
-		--"privacy"; -- Support privacy lists
-		--"compression"; -- Stream compression
+		"blocklist"; -- Allow users to block communications with other users
+		"vcard4"; -- User profiles (stored in PEP)
+		"vcard_legacy"; -- Conversion between legacy vCard and PEP Avatar, vcard
 
 	-- Nice to have
-		"legacyauth"; -- Legacy authentication. Only used by some old clients and bots.
 		"version"; -- Replies to server version requests
 		"uptime"; -- Report how long server has been running
 		"time"; -- Let others know the time here on this server
 		"ping"; -- Replies to XMPP pings with pongs
-		"pep"; -- Enables users to publish their mood, activity, playing music and more
 		"register"; -- Allow users to register on this server using a client and change passwords
-		"adhoc"; -- Support for "ad-hoc commands" that can be executed with an XMPP client
+		--"mam"; -- Store messages in an archive and allow users to access it
+		--"csi_simple"; -- Simple Mobile optimizations
 
 	-- Admin interfaces
 		"admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands
 		--"admin_telnet"; -- Opens telnet console interface on localhost port 5582
 
-	-- Other specific functionality
-		"posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
+	-- HTTP modules
 		--"bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
-		--"httpserver"; -- Serve static files from a directory over HTTP
+		--"websocket"; -- XMPP over WebSockets
+		--"http_files"; -- Serve static files from a directory over HTTP
+
+	-- Other specific functionality
+		--"limits"; -- Enable bandwidth limiting for XMPP connections
 		--"groups"; -- Shared roster support
+		--"server_contact_info"; -- Publish contact information for this service
 		--"announce"; -- Send announcement to all online users
 		--"welcome"; -- Welcome users who register accounts
 		--"watchregistrations"; -- Alert admins of registrations
 		--"motd"; -- Send a message to users when they log in
-};
+		--"legacyauth"; -- Legacy authentication. Only used by some old clients and bots.
+		--"proxy65"; -- Enables a file transfer proxy service which clients behind NAT can use
+}
 
--- These modules are auto-loaded, should you
--- (for some mad reason) want to disable
--- them then uncomment them below
+-- These modules are auto-loaded, but should you want
+-- to disable them then uncomment them here:
 modules_disabled = {
-	-- "presence"; -- Route user/contact status information
-	-- "message"; -- Route messages
-	-- "iq"; -- Route info queries
 	-- "offline"; -- Store offline messages
-};
+	-- "c2s"; -- Handle client connections
+	-- "s2s"; -- Handle server-to-server connections
+	-- "posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
+}
 
 -- Disable account creation by default, for security
--- For more information see http://prosody.im/doc/creating_accounts
-allow_registration = false;
+-- For more information see https://prosody.im/doc/creating_accounts
+allow_registration = false
 
--- Only allow encrypted streams? Encryption is already used when
--- available. These options will cause Prosody to deny connections that
--- are not encrypted. Note that some servers do not support s2s
--- encryption or have it disabled, including gmail.com and Google Apps
--- domains.
+-- Force clients to use encrypted connections? This option will
+-- prevent clients from authenticating unless they are using encryption.
 
---c2s_require_encryption = false
---s2s_require_encryption = false
+c2s_require_encryption = true
+
+-- Force servers to use encrypted connections? This option will
+-- prevent servers from authenticating unless they are using encryption.
+
+s2s_require_encryption = true
+
+-- Force certificate authentication for server-to-server connections?
+
+s2s_secure_auth = false
+
+-- Some servers have invalid or self-signed certificates. You can list
+-- remote domains here that will not be required to authenticate using
+-- certificates. They will be authenticated using DNS instead, even
+-- when s2s_secure_auth is enabled.
+
+--s2s_insecure_domains = { "insecure.example" }
+
+-- Even if you disable s2s_secure_auth, you can still require valid
+-- certificates for some domains by specifying a list here.
+
+--s2s_secure_domains = { "jabber.org" }
 
 -- Select the authentication backend to use. The 'internal' providers
 -- use Prosody's configured data storage to store the authentication data.
--- To allow Prosody to offer secure authentication mechanisms to clients, the
--- default provider stores passwords in plaintext. If you do not trust your
--- server please see http://prosody.im/doc/modules/mod_auth_internal_hashed
--- for information about using the hashed backend.
--- See http://prosody.im/doc/authentication for other possibilities including
--- Cyrus SASL.
 
-authentication = "internal_plain"
+authentication = "internal_hashed"
 
 -- Select the storage backend to use. By default Prosody uses flat files
 -- in its configured data directory, but it also supports more backends
 -- through modules. An "sql" backend is included by default, but requires
--- additional dependencies. See http://prosody.im/doc/storage for more info.
+-- additional dependencies. See https://prosody.im/doc/storage for more info.
 
 --storage = "sql" -- Default is "internal"
 
@@ -114,6 +137,17 @@ authentication = "internal_plain"
 --sql = { driver = "SQLite3", database = "prosody.sqlite" } -- Default. 'database' is the filename.
 --sql = { driver = "MySQL", database = "prosody", username = "prosody", password = "secret", host = "localhost" }
 --sql = { driver = "PostgreSQL", database = "prosody", username = "prosody", password = "secret", host = "localhost" }
+
+-- Archiving configuration
+-- If mod_mam is enabled, Prosody will store a copy of every message. This
+-- is used to synchronize conversations between multiple clients, even if
+-- they are offline. This setting controls how long Prosody will keep
+-- messages in the archive before removing them.
+
+archive_expires_after = "1w" -- Remove archived messages after 1 week
+
+-- You can also configure messages to be stored in-memory only. For more
+-- archiving options, see https://prosody.im/doc/modules/mod_mam
 
 -- Logging configuration
 -- For advanced logging see http://prosody.im/doc/logging
@@ -124,12 +158,29 @@ log = {
 	-- "*console"; -- Log to the console, useful for debugging with daemonize=false
 }
 
+-- Uncomment to enable statistics
+-- For more info see https://prosody.im/doc/statistics
+-- statistics = "internal"
+
 -- Pidfile, used by prosodyctl and the init.d script
 pidfile = "/var/run/prosody/prosody.pid"
 
 -- User and group, used for daemon
 prosody_user = "prosody"
 prosody_group = "prosody"
+
+-- Certificates
+-- Every virtual host and component needs a certificate so that clients and
+-- servers can securely verify its identity. Prosody will automatically load
+-- certificates/keys from the directory specified here.
+-- For more information, including how to use 'prosodyctl' to auto-import certificates
+-- (from e.g. Let's Encrypt) see https://prosody.im/doc/certificates
+
+-- Location of directory to find certificates in (relative to main config file):
+--certificates = "certs"
+
+-- HTTPS currently only supports a single certificate, specify it here:
+--https_certificate = "certs/localhost.crt"
 
 ----------- Virtual hosts -----------
 -- You need to add a VirtualHost entry for each domain you wish Prosody to serve.
@@ -156,9 +207,10 @@ VirtualHost "example.com"
 
 ---Set up a MUC (multi-user chat) room server on conference.example.com:
 --Component "conference.example.com" "muc"
-
 -- Set up a SOCKS5 bytestream proxy for server-proxied file transfers:
 --Component "proxy.example.com" "proxy65"
+--- Store MUC messages in an archive and allow users to access it
+--modules_enabled = { "muc_mam" }
 
 ---Set up an external component (default component port is 5347)
 --


### PR DESCRIPTION
Maintainer: @LAGonauta 

Fixes: https://downloads.openwrt.org/releases/faillogs/powerpc_464fp/packages/prosody/compile.txt

Decided to also backport the version update as it is a CVE fix.