### PR TITLE
stunnel: update to version 5.53

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.51
+PKG_VERSION:=5.53
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0+
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=77437cdd1aef1a621824bb3607e966534642fe90c69f4d2279a9da9fa36c3253
+PKG_HASH:=80439896ee14269eb70bc8bc669433c7d619018a62c9f9c5c760a24515302585
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool


### PR DESCRIPTION
Maintainer: me 
Compile tested: lantiq_xrx200 x86_64, APU3, master
Run tested: lantiq_xrx200 x86_64, APU3, master, binary started with default config

Description:
Update to the newest version.
