### PR TITLE
 python-evdev: bump to version 1.2.0 & drop Python variant

### DIFF
--- a/lang/python/python-evdev/Makefile
+++ b/lang/python/python-evdev/Makefile
@@ -38,12 +38,12 @@ define Package/python3-evdev/description
   Bindings to the Linux input handling subsystem
 endef
 
-define Py3Build/Compile
-	$(call Build/Compile/Py3Mod,, build \
-		build_ecodes  --evdev-headers="$(LINUX_DIR)/include/uapi/linux/input.h:$(LINUX_DIR)/include/uapi/linux/input-event-codes.h" \
-		build_ext \
-		install --root="$(PKG_INSTALL_DIR)" --prefix="/usr")
-endef
+LINUX_EVDEV_HEADERS="$(LINUX_DIR)/include/uapi/linux/input.h:$(LINUX_DIR)/include/uapi/linux/input-event-codes.h"
+
+PYTHON3_PKG_SETUP_GLOBAL_ARGS:= \
+	build build_ecodes \
+	--evdev-headers="$(LINUX_EVDEV_HEADERS)" \
+	build_ext
 
 $(eval $(call Py3Package,python3-evdev))
 $(eval $(call BuildPackage,python3-evdev))

--- a/lang/python/python-evdev/Makefile
+++ b/lang/python/python-evdev/Makefile
@@ -19,55 +19,23 @@ PKG_SOURCE:=evdev-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/e/evdev
 PKG_HASH:=b03f5e1be5b4a5327494a981b831d251a142b09e8778eda1a8b53eba91100166
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-evdev-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/evdev-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
-include ../python-package.mk
 include ../python3-package.mk
 
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
-define Package/python-evdev/Default
+define Package/python3-evdev
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   URL:=https://github.com/gvalkov/python-evdev
-endef
-
-define Package/python-evdev
-$(call Package/python-evdev/Default)
-  TITLE:=python-evdev
-  DEPENDS:= \
-     +PACKAGE_python-evdev:python-light \
-     +PACKAGE_python-evdev:python-ctypes
-  VARIANT:=python
-endef
-
-define Package/python3-evdev
-$(call Package/python-evdev/Default)
-  TITLE:=python3-evdev
-  DEPENDS:= \
-      +PACKAGE_python3-evdev:python3-light \
-      +PACKAGE_python3-evdev:python3-ctypes
+  TITLE:=Bindings to the Linux input handling subsystem
+  DEPENDS:= +python3-light +python3-ctypes
   VARIANT:=python3
 endef
 
-
-define Package/python-evdev/description
-	Bindings to the Linux input handling subsystem
-endef
-
 define Package/python3-evdev/description
-$(call Package/python-evdev/description)
-.
-(Variant for Python3)
-endef
-
-define PyBuild/Compile
-	$(call Build/Compile/PyMod,, build \
-		build_ecodes  --evdev-headers="$(LINUX_DIR)/include/uapi/linux/input.h:$(LINUX_DIR)/include/uapi/linux/input-event-codes.h" \
-		build_ext \
-		install --root="$(PKG_INSTALL_DIR)" --prefix="/usr")
+  Bindings to the Linux input handling subsystem
 endef
 
 define Py3Build/Compile
@@ -77,7 +45,5 @@ define Py3Build/Compile
 		install --root="$(PKG_INSTALL_DIR)" --prefix="/usr")
 endef
 
-$(eval $(call PyPackage,python-evdev))
-$(eval $(call BuildPackage,python-evdev))
 $(eval $(call Py3Package,python3-evdev))
 $(eval $(call BuildPackage,python3-evdev))

--- a/lang/python/python-evdev/Makefile
+++ b/lang/python/python-evdev/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=python-evdev
-PKG_VERSION:=1.1.2
+PKG_VERSION:=1.2.0
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
@@ -17,7 +17,7 @@ PKG_MAINTAINER:=Paulo Costa <me@paulo.costa.nom.br>, Alexandru Ardelean <ardelea
 
 PKG_SOURCE:=evdev-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/e/evdev
-PKG_HASH:=2dd67291be20e70643e8ef6f2381efc10e0c6e44a32abb3c1db74996ea3b0351
+PKG_HASH:=b03f5e1be5b4a5327494a981b831d251a142b09e8778eda1a8b53eba91100166
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-evdev-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: @paulo-raca , me
Compile tested: http://github.com/openwrt/openwrt/commit/13ffdf44824e8e8d276c2cb3b1cc181471c33101  x86
Run tested: http://github.com/openwrt/openwrt/commit/13ffdf44824e8e8d276c2cb3b1cc181471c33101  x86

----------------------------------

Bump to version 1.2.0
Drop Python variant ; this is inline with migrating everything to Python3 and making Python obsolete.
Cosmetic update : use PYTHON3_PKG_SETUP_GLOBAL_ARGS

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>