### PR TITLE
Python evdev bump

### DIFF
--- a/lang/python/python-evdev/Makefile
+++ b/lang/python/python-evdev/Makefile
@@ -63,19 +63,14 @@ $(call Package/python-evdev/description)
 (Variant for Python3)
 endef
 
-define PyBuild/Compile
-	$(call Build/Compile/PyMod,, build \
-		build_ecodes  --evdev-headers="$(LINUX_DIR)/include/uapi/linux/input.h:$(LINUX_DIR)/include/uapi/linux/input-event-codes.h" \
-		build_ext \
-		install --root="$(PKG_INSTALL_DIR)" --prefix="/usr")
-endef
+LINUX_EVDEV_HEADERS="$(LINUX_DIR)/include/uapi/linux/input.h:$(LINUX_DIR)/include/uapi/linux/input-event-codes.h"
 
-define Py3Build/Compile
-	$(call Build/Compile/Py3Mod,, build \
-		build_ecodes  --evdev-headers="$(LINUX_DIR)/include/uapi/linux/input.h:$(LINUX_DIR)/include/uapi/linux/input-event-codes.h" \
-		build_ext \
-		install --root="$(PKG_INSTALL_DIR)" --prefix="/usr")
-endef
+PYTHON3_PKG_SETUP_GLOBAL_ARGS:= \
+	build build_ecodes \
+	--evdev-headers="$(LINUX_EVDEV_HEADERS)" \
+	build_ext
+
+PYTHON_PKG_SETUP_GLOBAL_ARGS:=$(PYTHON3_PKG_SETUP_GLOBAL_ARGS)
 
 $(eval $(call PyPackage,python-evdev))
 $(eval $(call BuildPackage,python-evdev))

--- a/lang/python/python-evdev/Makefile
+++ b/lang/python/python-evdev/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=python-evdev
-PKG_VERSION:=1.1.2
+PKG_VERSION:=1.2.0
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
@@ -17,7 +17,7 @@ PKG_MAINTAINER:=Paulo Costa <me@paulo.costa.nom.br>, Alexandru Ardelean <ardelea
 
 PKG_SOURCE:=evdev-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/e/evdev
-PKG_HASH:=2dd67291be20e70643e8ef6f2381efc10e0c6e44a32abb3c1db74996ea3b0351
+PKG_HASH:=b03f5e1be5b4a5327494a981b831d251a142b09e8778eda1a8b53eba91100166
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-evdev-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: @paulo-raca , me
Compile tested: http://github.com/openwrt/openwrt/commit/13ffdf44824e8e8d276c2cb3b1cc181471c33101  x86
Run tested: http://github.com/openwrt/openwrt/commit/13ffdf44824e8e8d276c2cb3b1cc181471c33101  x86

----------------------------------

Bump to version 1.2.0
Cosmetic update : use PYTHON[3]_PKG_SETUP_GLOBAL_ARGS

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>