### PR TITLE
node: don't build on unsupported cpus, remove menu

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -37,7 +37,10 @@ define Package/node
   SUBMENU:=Node.js
   TITLE:=Node.js is a platform built on Chrome's JavaScript runtime
   URL:=https://nodejs.org/
-  DEPENDS:=@(HAS_FPU||KERNEL_MIPS_FPU_EMULATOR) +libstdcpp +libopenssl +zlib +libnghttp2 +libuv +libhttp-parser +USE_UCLIBC:libpthread +USE_UCLIBC:librt +NODEJS_ICU:icu
+  DEPENDS:=@(HAS_FPU||KERNEL_MIPS_FPU_EMULATOR) @!arc @!armeb \
+	   +libstdcpp +libopenssl +zlib +libnghttp2 +libuv +libhttp-parser \
+	   +USE_UCLIBC:libpthread +USE_UCLIBC:librt \
+	   +NODEJS_ICU:icu
 endef
 
 define Package/node/description
@@ -60,13 +63,13 @@ define Package/node-npm/description
 endef
 
 define Package/node/config
-	menu "Module Selection"
+	if PACKAGE_node
 
 	config NODEJS_ICU
 		bool "enable i18n features"
 		default n
 
-	endmenu
+	endif
 endef
 
 NODEJS_CPU:=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))))


### PR DESCRIPTION
Maintainer: @blogic @ianchi 
Compile tested: none, tested with make menuconfig and selecting unsupported targets to ensure node package was disabled.
Run tested: none

Description:
Node does not support arc or armeb.  Error message below is for mips64, but @nxhack is about to open a PR supporting it, so I'll leave it out of the list.
```
Usage: configure [options]

configure: error: option --dest-cpu: invalid choice: 'mips64' (choose from 'arm', 'arm64', 'ia32', 'mips', 'mipsel', 'mips64el', 'ppc', 'ppc64', 'x32', 'x64', 'x86', 'x86_64', 's390', 's390x')
Makefile:131: recipe for target '/opt/buildbot/slaves/lede-slave-tah/mips64_octeonplus/build/sdk/build_dir/target-mips64_octeonplus_64_musl/node-v8.16.0/.configured_68b329da9893e34099c7d8ad5cb9c940' failed
make[3]: *** [/opt/buildbot/slaves/lede-slave-tah/mips64_octeonplus/build/sdk/build_dir/target-mips64_octeonplus_64_musl/node-v8.16.0/.configured_68b329da9893e34099c7d8ad5cb9c940] Error 2
time: package/feeds/packages/node/compile#0.80#0.38#11.19
```
Moved i18 option to straight under node instead of on its own menu:
```
{M} node.......... Node.js is a platform built on Chrome's JavaScript runtime
[ ]   enable i18n features
```
instead of
```
{M} node.......... Node.js is a platform built on Chrome's JavaScript runtime
    Module Selection  --->
```
and only after entering `Module Selection`
```
[ ]   enable i18n features
```

This does not change the package for platforms where build was working, so `PKG_RELEASE` was left untouched.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
