### PR TITLE
openvswitch: python3 transition

### DIFF
--- a/lang/python/python-six/Makefile
+++ b/lang/python/python-six/Makefile
@@ -21,7 +21,7 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
-HOST_BUILD_DEPENDS:=python/host
+HOST_BUILD_DEPENDS:=python/host python3/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -66,6 +66,7 @@ endef
 
 define Host/Compile
 	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
+	$(call Build/Compile/HostPy3Mod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
 endef
 
 Host/Install:=

--- a/lang/python/python-six/Makefile
+++ b/lang/python/python-six/Makefile
@@ -21,7 +21,7 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
-HOST_BUILD_DEPENDS:=python/host python3/host
+HOST_BUILD_DEPENDS:=python3/host
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -65,7 +65,6 @@ $(call Package/python-six/description)
 endef
 
 define Host/Compile
-	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
 	$(call Build/Compile/HostPy3Mod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
 endef
 

--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -35,6 +35,7 @@ PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python-host.mk
 include ../../lang/python/python-package.mk
+include ../../lang/python/python3-package.mk
 
 
 ovs_kmod_packages:=
@@ -281,6 +282,16 @@ define ovs_python_install
 	$$(CP) $$(PKG_INSTALL_DIR)/usr/share/openvswitch/python/ovs $$(1)$$(PYTHON_PKG_DIR)
 endef
 $(eval $(call OvsPackageTemplate,python))
+
+
+ovs_python3_title:=Open vSwitch (Python3 library)
+ovs_python3_hidden:=
+ovs_python3_depends:=+PACKAGE_openvswitch-python3:python3 +PACKAGE_openvswitch-python3:python3-six
+define ovs_python3_install
+	$$(INSTALL_DIR) $$(1)$$(PYTHON3_PKG_DIR)
+	$$(CP) $$(PKG_INSTALL_DIR)/usr/share/openvswitch/python/ovs $$(1)$$(PYTHON3_PKG_DIR)
+endef
+$(eval $(call OvsPackageTemplate,python3))
 
 
 CONFIGURE_ARGS+= \

--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -16,7 +16,7 @@ include $(INCLUDE_DIR)/kernel.mk
 #
 PKG_NAME:=openvswitch
 PKG_VERSION:=2.11.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.openvswitch.org/releases/
 PKG_HASH:=f4b01d7376d7298bc6e7fa7a6067229ca7c7e299394e5ea9aff651d52edfdbee
@@ -24,7 +24,7 @@ PKG_HASH:=f4b01d7376d7298bc6e7fa7a6067229ca7c7e299394e5ea9aff651d52edfdbee
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DEPENDS:=python/host python-six/host
+PKG_BUILD_DEPENDS+=python3/host python-six/host
 PKG_USE_MIPS16:=0
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf
@@ -33,7 +33,7 @@ PKG_INSTALL:=1
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 
 include $(INCLUDE_DIR)/package.mk
-include ../../lang/python/python-host.mk
+include ../../lang/python/python3-host.mk
 include ../../lang/python/python-package.mk
 include ../../lang/python/python3-package.mk
 
@@ -301,10 +301,10 @@ CONFIGURE_ARGS+= \
 
 CONFIGURE_VARS += \
 	ovs_cv_flake8=no \
-	ovs_cv_python3=no \
+	ovs_cv_python=$(PYTHON3) \
+	ovs_cv_python_host=$(HOST_PYTHON3_BIN) \
 	ovs_cv_sphinx=no \
-	ovs_cv_python=$(PYTHON) \
-	ovs_cv_python_host=$(HOST_PYTHON_BIN) \
+	ovs_cv_python2=no \
 	KARCH=$(LINUX_KARCH) \
 
 ovs_intree_kmod_configs:=CONFIG_PACKAGE_kmod-openvswitch-intree
@@ -315,7 +315,7 @@ ifneq ($(ovs_intree_kmod_enabled),)
 endif
 
 TARGET_CFLAGS += -flto -std=gnu99
-MAKE_VARS += PYTHONPATH="$(HOST_PYTHONPATH)"
+MAKE_VARS += PYTHONPATH="$(HOST_PYTHON3PATH)"
 
 $(foreach p,$(ovs_kmod_packages),\
   $(eval $(call KernelPackage,$(p)))\


### PR DESCRIPTION
Maintainer: me
Compile tested: malta/be, OpenWrt current master
Run tested: malta/be on QEMU

```
root@OpenWrt:/# python3 -c 'import ovs; print(ovs.__file__)'
/usr/lib/python3.7/site-packages/ovs/__init__.py
root@OpenWrt:/# python -c 'import ovs; print(ovs.__file__)'
/usr/lib/python2.7/site-packages/ovs/__init__.py
```

Hi @jefferyto , please consider updating the google docs when this got merged.  Thank you for the efforts ;)

Also cc-ing @commodo for code review and comments ;)