### PR TITLE
ntpclient: Fix NTP_RUNNING command to work when procps-ng is installed

### DIFF
--- a/net/ntpclient/Makefile
+++ b/net/ntpclient/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntpclient
 PKG_VERSION:=2015_365
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://doolittle.icarus.com/ntpclient

--- a/net/ntpclient/files/ntpclient.hotplug
+++ b/net/ntpclient/files/ntpclient.hotplug
@@ -9,7 +9,7 @@ unset INTERVAL
 unset COUNT
 unset INTERFACE_GLOBAL
 
-NTPC=`which ntpclient`
+NTPC=$(command -v ntpclient)
 
 check_server() {
 	local hostname
@@ -52,12 +52,12 @@ stop_ntpclient() {
 load_settings() {
 	local interval
 	local count
-	local iface
-	
+	local interface
+
 	config_get interval $1 interval
 	config_get count $1 count
 	config_get interface $1 interface
-	
+
 	[ -n "$count" ] && COUNT=$count
 	[ -n "$interval" ] && INTERVAL=$interval
 	[ -n "$interface" ] && INTERFACE_GLOBAL=$interface
@@ -66,13 +66,13 @@ load_settings() {
 config_load ntpclient
 config_foreach load_settings ntpclient
 
-NTP_RUNNING=`ps  | grep $NTPC | grep -v grep`
+NTP_RUNNING=$(busybox ps | grep $NTPC | grep -v grep)
 
 case "${ACTION:-ifup}" in
 	ifup)
-		[ -z "$NTP_RUNNING" ] && start_ntpclient 
+		[ -z "$NTP_RUNNING" ] && start_ntpclient
 	;;
 	ifdown)
-		[ -n "$NTP_RUNNING" ] && stop_ntpclient 
+		[ -n "$NTP_RUNNING" ] && stop_ntpclient
 	;;
 esac


### PR DESCRIPTION
busybox ps and procps-ng ps have different outputs. Force busybox ps usage
to fix this.

Also cleaned up the script using shellcheck.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 