### PR TITLE
cifs-utils: Update to 6.9

### DIFF
--- a/net/cifs-utils/Makefile
+++ b/net/cifs-utils/Makefile
@@ -8,18 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cifs-utils
-PKG_VERSION:=6.8
+PKG_VERSION:=6.9
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=https://download.samba.org/pub/linux-cifs/cifs-utils/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=e7d1f6050c43f21f82cd77e288eb756755effd22f0c310fc2c525df9d41dff79
+PKG_SOURCE_URL:=https://download.samba.org/pub/linux-cifs/cifs-utils/
+PKG_HASH:=18d8f1bf92c13c4d611502dbd6759e3a766ddc8467ec8a2eda3f589e40b9ac9c
 
 PKG_MAINTAINER:=Florian Fainelli <florian@openwrt.org>
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
-
-PKG_FIXUP:=libtool
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -28,22 +26,23 @@ define Package/cifsmount
   CATEGORY:=Network
   DEPENDS:=+kmod-fs-cifs
   TITLE:=CIFS mount utilities
-  URL:=http://wiki.samba.org/index.php/LinuxCIFS_utils
+  URL:=https://wiki.samba.org/index.php/LinuxCIFS_utils
 endef
 
-TARGET_CFLAGS += -Wno-error
+TARGET_CFLAGS += $(FPIC) -ffunction-sections -flto
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 CONFIGURE_ARGS += \
-	--exec-prefix=/usr \
-	--prefix=/ \
-	--with-libcap=no \
 	--disable-cifsupcall \
 	--disable-cifscreds \
 	--disable-cifsidmap \
 	--disable-cifsacl \
 	--disable-pam \
+	--disable-pie \
+	--disable-relro \
 	--disable-systemd \
-	--disable-man
+	--disable-man \
+	--without-libcap
 
 define Package/cifsmount/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
Reorganized and cleaned up Makefile for consistency between packages.

Disabled relro and pie. The build system already handles those.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ffainelli 
Compile tested: ramips
Run tested: GnuBee PC1
