### PR TITLE
python-requests: allow urllib3 1.25.x

### DIFF
--- a/lang/python/python-requests/Makefile
+++ b/lang/python/python-requests/Makefile
@@ -10,11 +10,16 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=python-requests
 PKG_VERSION:=2.21.0
 PKG_RELEASE:=3
+
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:python-requests:requests
 
 PKG_SOURCE:=requests-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/r/requests
 PKG_HASH:=502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e
+
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-requests-$(PKG_VERSION)
 
 PKG_CPE_ID:=cpe:/a:python-requests:requests
@@ -29,13 +34,12 @@ define Package/python-requests/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>, Alexandru Ardelean <ardeleanalex@gmail.com>
-  URL:=http://python-requests.org/
+  TITLE:=HTTP library for Python
+  URL:=https://2.python-requests.org/
 endef
 
 define Package/python-requests
 $(call Package/python-requests/Default)
-  TITLE:=HTTP library for Python
   DEPENDS:= \
 	  +PACKAGE_python-requests:python \
 	  +PACKAGE_python-requests:python-chardet \
@@ -47,7 +51,6 @@ endef
 
 define Package/python3-requests
 $(call Package/python-requests/Default)
-  TITLE:=HTTP library for Python3
   DEPENDS:= \
 	  +python3-light  \
 	  +python3-chardet  \
@@ -58,7 +61,7 @@ $(call Package/python-requests/Default)
 endef
 
 define Package/python-requests/description
-  Requests is the only Non-GMO HTTP library for Python, safe for human consumption.
+  Requests is the only Non-GMO HTTP library for Python, safe for human consumption
 endef
 
 define Package/python3-requests/description

--- a/lang/python/python-requests/Makefile
+++ b/lang/python/python-requests/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-requests
 PKG_VERSION:=2.21.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=Apache-2.0
 
 PKG_SOURCE:=requests-$(PKG_VERSION).tar.gz

--- a/lang/python/python-requests/patches/0001-Allow-urllib3-125x.patch
+++ b/lang/python/python-requests/patches/0001-Allow-urllib3-125x.patch
@@ -1,0 +1,33 @@
+Commit in requests repository - urllib1.25 branch: https://github.com/kennethreitz/requests/commit/d6b5b401e8d6141bcefa4a70ff1c836aa085120b
+Pull request: https://github.com/kennethreitz/requests/pull/5063
+
+diff --git a/requests/__init__.py b/requests/__init__.py
+index bc168ee..9a899df 100644
+--- a/requests/__init__.py
++++ b/requests/__init__.py
+@@ -57,10 +57,10 @@ def check_compatibility(urllib3_version, chardet_version):
+     # Check urllib3 for compatibility.
+     major, minor, patch = urllib3_version  # noqa: F811
+     major, minor, patch = int(major), int(minor), int(patch)
+-    # urllib3 >= 1.21.1, <= 1.24
++    # urllib3 >= 1.21.1, <= 1.25
+     assert major == 1
+     assert minor >= 21
+-    assert minor <= 24
++    assert minor <= 25
+
+     # Check chardet for compatibility.
+     major, minor, patch = chardet_version.split('.')[:3]
+diff --git a/setup.py b/setup.py
+index 10ce2c6..0d5d0cc 100755
+--- a/setup.py
++++ b/setup.py
+@@ -44,7 +44,7 @@ packages = ['requests']
+ requires = [
+     'chardet>=3.0.2,<3.1.0',
+     'idna>=2.5,<2.9',
+-    'urllib3>=1.21.1,<1.25',
++    'urllib3>=1.21.1,<1.26,!=1.25.0',
+     'certifi>=2017.4.17'
+
+ ]


### PR DESCRIPTION
Maintainer: me and @commodo 
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:
- Add patch, which allows [urllib3 1.25.x](https://github.com/kennethreitz/requests/pull/5063)
Version 1.25 of urllib3 was merged to master 2 days ago, which fixes CVE-2019-11324, but requests is still using the older version. AFAIK, there's no mention, when requests will release a new version.
I found on [their website](https://2.python-requests.org/en/master/):
> Requests 2.x is officially in maintinence-mode only. This means we only respond to CVE-level tickets. All of our limited available attention / energy is being allocated towards the development of Requests III. 


- Add PKG_CPE_ID
- Add PKG_LICENSE_FILES
- Update URL