### PR TITLE
netdata: update to version 1.14.0

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,15 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.13.0
+PKG_VERSION:=1.14.0
 PKG_RELEASE:=1
-PKG_MAINTAINER:=
+
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
 PKG_LICENSE:=GPL-3.0+
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:my-netdata:netdata
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/netdata/netdata/releases/download/v$(PKG_VERSION)
-PKG_HASH:=258e64a945bf80e91c4bffab35e7f2d8930025246814038f541ff0ac403a666c
+PKG_HASH:=f3768f6927e3712dce73794c6943a12f4454410c872eb3dfd19af4f52296187a
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_INSTALL:=1
@@ -37,8 +39,8 @@ define Package/netdata/description
   netdata is a highly optimized Linux daemon providing real-time performance
   monitoring for Linux systems, applications and SNMP devices over the web.
 
- If you want to use Python plugins install python3, python3-yaml and
- python3-urllib3
+  If you want to use Python plugins install python3, python3-yaml and
+  python3-urllib3
 endef
 
 TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS))

--- a/admin/netdata/patches/002-force-python3.patch
+++ b/admin/netdata/patches/002-force-python3.patch
@@ -1,10 +1,14 @@
 --- a/collectors/python.d.plugin/python.d.plugin.in
 +++ b/collectors/python.d.plugin/python.d.plugin.in
-@@ -1,6 +1,4 @@
+@@ -1,10 +1,4 @@
 -#!/usr/bin/env bash
--'''':; exec "$(command -v python || command -v python3 || command -v python2 ||
+-'''':;
+-if [[ "$OSTYPE" == "darwin"* ]]; then
+-    export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+-fi
+-exec "$(command -v python || command -v python3 || command -v python2 ||
 -echo "ERROR python IS NOT AVAILABLE IN THIS SYSTEM")" "$0" "$@" # '''
 +#!/usr/bin/python3
- 
+
  # -*- coding: utf-8 -*-
  # Description:


### PR DESCRIPTION
Maintainer: N/A (@diizzyy what do you think that both of us will become maintainers of this package?)
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:
- update to version [1.14.0](https://github.com/netdata/netdata/releases/tag/v1.14.0)
- add PKG_CPE_ID