### PR TITLE
ssmpt: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/mail/ssmtp/Makefile
+++ b/mail/ssmtp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ssmtp
 PKG_VERSION:=2.64
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 PKG_LICENSE:=GPL-2.0+
 

--- a/mail/ssmtp/patches/020-openssl-deprecated.patch
+++ b/mail/ssmtp/patches/020-openssl-deprecated.patch
@@ -1,0 +1,13 @@
+--- a/ssmtp.c
++++ b/ssmtp.c
+@@ -1046,8 +1046,10 @@ int smtp_open(char *host, int port)
+ 	/* Init SSL stuff */
+ 	SSL_CTX *ctx = NULL;
+ 	X509 *server_cert;
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	SSL_load_error_strings();
+ 	SSLeay_add_ssl_algorithms();
++#endif
+ 	ctx = SSL_CTX_new(SSLv23_client_method());
+ 	if(!ctx) {
+ 		log_event(LOG_ERR, "No SSL support initiated\n");


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dibdot 
Compile tested: mips64