### PR TITLE
subversion: update to the latest stable release

### DIFF
--- a/net/subversion/Makefile
+++ b/net/subversion/Makefile
@@ -18,6 +18,8 @@ PKG_MAINTAINER:=Val Kulkov <val.kulkov@gmail.com>
 PKG_FIXUP:=autoreconf
 PKG_MACRO_PATHS:=build/ac-macros
 PKG_BUILD_DEPENDS:=apr-util
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -28,9 +30,8 @@ define Package/subversion/Default
   CATEGORY:=Network
   SUBMENU:=Version Control Systems
   TITLE:=A compelling replacement for CVS
-  DEPENDS:=+zlib +libsqlite3 +PACKAGE_unixodbc:unixodbc +libapr +libaprutil +libmagic \
-  	$(ICONV_DEPENDS) $(INTL_DEPENDS)
-  URL:=http://subversion.apache.org/
+  DEPENDS:=+PACKAGE_unixodbc:unixodbc +libaprutil +libmagic $(ICONV_DEPENDS) $(INTL_DEPENDS)
+  URL:=https://subversion.apache.org/
 endef
 
 define Package/subversion/Default/description
@@ -78,8 +79,6 @@ define Package/subversion-server/conffiles
 endef
 
 TARGET_CFLAGS += $(FPIC)
-TARGET_CPPFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
-APU_LIBS=$(shell $(STAGING_DIR)/usr/bin/apu-1-config --link-libtool --libs)
 
 CONFIGURE_ARGS += \
 	--with-apr="$(STAGING_DIR)/usr/bin/apr-1-config" \
@@ -101,17 +100,6 @@ ifdef $(INTL_FULL)
 else
 	CONFIGURE_ARGS += --disable-nls
 endif
-
-CONFIGURE_VARS += \
-	LDFLAGS="$(TARGET_LDFLAGS) $(APU_LIBS) -lcrypt -lm \
-		-lz -lpthread $(if $(INTL_FULL),-lintl)"
-	CPPFLAGS="$(TARGET_CPPFLAGS)"
-
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		all local-install
-endef
 
 define Package/subversion-libs/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/net/subversion/Makefile
+++ b/net/subversion/Makefile
@@ -1,6 +1,4 @@
 #
-# Copyright (C) 2007-2017 OpenWrt.org
-#
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
@@ -9,10 +7,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=subversion
 PKG_RELEASE:=1
-PKG_VERSION:=1.11.1
+PKG_VERSION:=1.12.0
 PKG_SOURCE_URL:=@APACHE/subversion
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=9efd2750ca4d72ec903431a24b9c732b6cbb84aad9b7563f59dd96dea5be60bb
+PKG_HASH:=7fae7c73d8a007c107c0ae5eb372bc0bb013dbfe966fcd5c59cd5a195a5e2edf
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Val Kulkov <val.kulkov@gmail.com>

--- a/net/subversion/patches/301-cross-compilation-macos.patch
+++ b/net/subversion/patches/301-cross-compilation-macos.patch
@@ -1,10 +1,8 @@
---- a/build/ac-macros/macosx.m4	2016-02-09 01:24:13.181409245 -0500
-+++ b/build/ac-macros/macosx.m4	2016-02-09 01:25:15.873408288 -0500
-@@ -17,94 +17,4 @@ dnl   specific language governing permis
- dnl   under the License.
- dnl ===================================================================
+--- a/build/ac-macros/macosx.m4
++++ b/build/ac-macros/macosx.m4
+@@ -19,80 +19,3 @@ dnl ====================================
  dnl
--dnl  Mac OS X specific checks
+ dnl  Mac OS X specific checks
  
 -dnl SVN_LIB_MACHO_ITERATE
 -dnl Check for _dyld_image_name and _dyld_image_header availability
@@ -42,19 +40,8 @@
 -    #error ProperyList API unavailable.
 -    #endif
 -  ]],[[]])],[
--    dnl ### Hack.  We should only need to pass the -framework options when
--    dnl linking libsvn_subr, since it is the only library that uses Keychain.
--    dnl
--    dnl Unfortunately, libtool 1.5.x doesn't track transitive dependencies for
--    dnl OS X frameworks like it does for normal libraries, so we need to
--    dnl explicitly pass the option to all the users of libsvn_subr to allow
--    dnl static builds to link successfully.
--    dnl
--    dnl This does mean that all executables we link will be linked directly
--    dnl to these frameworks - even when building shared libraries - but that
--    dnl shouldn't cause any problems.
--
--    LIBS="$LIBS -framework CoreFoundation"
+-    SVN_MACOS_PLIST_LIBS="-framework CoreFoundation"
+-    AC_SUBST(SVN_MACOS_PLIST_LIBS)
 -    AC_DEFINE([SVN_HAVE_MACOS_PLIST], [1],
 -              [Is Mac OS property list API available?])
 -    AC_MSG_RESULT([yes])
@@ -84,9 +71,8 @@
 -      #error KeyChain API unavailable.
 -      #endif
 -    ]],[[]])],[
--      dnl ### Hack, see SVN_LIB_MACOS_PLIST
--      LIBS="$LIBS -framework Security"
--      LIBS="$LIBS -framework CoreServices"
+-      SVN_MACOS_KEYCHAIN_LIBS="-framework Security -framework CoreServices"
+-      AC_SUBST(SVN_MACOS_KEYCHAIN_LIBS)
 -      AC_DEFINE([SVN_HAVE_KEYCHAIN_SERVICES], [1], [Is Mac OS KeyChain support enabled?])
 -      AC_MSG_RESULT([yes])
 -    ],[
@@ -95,3 +81,16 @@
 -    ])
 -  fi
 -])
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -56,8 +56,8 @@ SVN_XML_LIBS = @SVN_XML_LIBS@
+ SVN_ZLIB_LIBS = @SVN_ZLIB_LIBS@
+ SVN_LZ4_LIBS = @SVN_LZ4_LIBS@
+ SVN_UTF8PROC_LIBS = @SVN_UTF8PROC_LIBS@
+-SVN_MACOS_PLIST_LIBS = @SVN_MACOS_PLIST_LIBS@
+-SVN_MACOS_KEYCHAIN_LIBS = @SVN_MACOS_KEYCHAIN_LIBS@
++SVN_MACOS_PLIST_LIBS =
++SVN_MACOS_KEYCHAIN_LIBS =
+ 
+ LIBS = @LIBS@
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm53xx, Buffalo WXR-1900DHP, OpenWrt SNAPSHOT r9908-17cb490
Run tested: bcm53xx, Buffalo WXR-1900DHP, OpenWrt SNAPSHOT r9908-17cb490

Description:
Update to v1.12.0, the latest stable release.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>
