### PR TITLE
[18.06] grilo: Remove build dependency on perl-xml-parser

### DIFF
--- a/multimedia/grilo/Makefile
+++ b/multimedia/grilo/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grilo
 PKG_VERSION:=0.3.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 

--- a/multimedia/grilo/patches/010-remove-xml-parser.patch
+++ b/multimedia/grilo/patches/010-remove-xml-parser.patch
@@ -1,0 +1,19 @@
+--- a/configure
++++ b/configure
+@@ -14434,16 +14434,6 @@ else
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $IT_PERL_VERSION" >&5
+ $as_echo "$IT_PERL_VERSION" >&6; }
+ fi
+-if test "x" != "xno-xml"; then
+-   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for XML::Parser" >&5
+-$as_echo_n "checking for XML::Parser... " >&6; }
+-   if `$INTLTOOL_PERL -e "require XML::Parser" 2>/dev/null`; then
+-       { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
+-$as_echo "ok" >&6; }
+-   else
+-       as_fn_error $? "XML::Parser perl module is required for intltool" "$LINENO" 5
+-   fi
+-fi
+ 
+ # Substitute ALL_LINGUAS so we can use it in po/Makefile
+ 


### PR DESCRIPTION
Given that we don't enable a bunch of stuff, we can patch this out.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 

Fixes https://downloads.openwrt.org/releases/faillogs/mipsel_24kc/packages/grilo/compile.txt

and probably https://downloads.openwrt.org/releases/faillogs/mipsel_24kc/packages/grilo-plugins/compile.txt