### PR TITLE
[18.06] loudmouth: Disable debug and fix compilation

### DIFF
--- a/libs/loudmouth/Makefile
+++ b/libs/loudmouth/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=loudmouth
 PKG_VERSION:=1.5.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -41,8 +41,10 @@ define Package/loudmouth/description
 endef
 
 CONFIGURE_ARGS += \
-	--with-ssl=openssl \
-	--with-idn=no
+	--disable-debug \
+	--without-compile-warnings \
+	--without-idn \
+	--with-ssl=openssl
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/


### PR DESCRIPTION
Reduces size and and eliminates -Werror

Signed-off-by: Rosen Penev <rosenp@gmail.com>
(cherry-picked from 788fda356e209a17095e185c166cd8f3f9a61688)

Maintainer: @MikePetullo 

Fixes: https://downloads.openwrt.org/releases/faillogs/mipsel_24kc/packages/loudmouth/compile.txt