### PR TITLE
nut: nutmon+fsd fixes

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=15
+PKG_RELEASE:=16
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -148,7 +148,6 @@ nut_upsmon_add() {
 }
 
 build_config() {
-	local runas=nutmon
 	mkdir -m 0750 -p "$(dirname "$UPSMON_C")"
 
 	config_load nut_monitor
@@ -193,6 +192,7 @@ interface_triggers() {
 }
 
 start_service() {
+	local runas=nutmon
 	local havemon havems
 	build_config
 
@@ -210,21 +210,18 @@ start_service() {
 	return 0
 }
 
-restart() {
-	trap '' TERM
-	stop "$@"
-	sleep 2
-	trap - TERM
-	start "$@"
-}
-
 reload_service() {
 	if pgrep upsmon >/dev/null 2>/dev/null; then
+		local runas=nutmon
 		build_config
 		/usr/sbin/upsmon -c reload
 	else
 		restart
 	fi
+}
+
+stop_service() {
+	upsmon -c stop
 }
 
 service_triggers() {

--- a/net/nut/files/nutshutdown
+++ b/net/nut/files/nutshutdown
@@ -47,3 +47,5 @@ do_fsd() {
 		poweroff
 	fi
 }
+
+do_fsd


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, current snapshot
Run tested: same, generic -- tested using dummy-ups in an OpenStack (KVM) VM.

Description:

This fixes a major functionality glitch (UPS wouldn't actually shutdown due to missing function call in shutdown script) and a persistent significant bug with nutmon ending up with an orphan child.

Since I finally found the dummy-ups driver I can maintain this package much more effectively (combined with having resolved local technical difficulties) and intend to do so even if I'm not around for much else (except other specific packages).
