### PR TITLE
libssh: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/libs/libssh/Makefile
+++ b/libs/libssh/Makefile
@@ -12,7 +12,7 @@ PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 
 PKG_NAME:=libssh
 PKG_VERSION:=0.7.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.libssh.org/files/0.7/

--- a/libs/libssh/patches/010-openssl-11-deprecated.patch
+++ b/libs/libssh/patches/010-openssl-11-deprecated.patch
@@ -1,0 +1,39 @@
+--- a/src/dh.c
++++ b/src/dh.c
+@@ -131,11 +131,15 @@ int ssh_get_random(void *where, int len, int strong){
+ 
+   return 1;
+ #elif defined HAVE_LIBCRYPTO
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+   if (strong) {
+     return RAND_bytes(where,len);
+   } else {
+     return RAND_pseudo_bytes(where,len);
+   }
++#else
++    return RAND_bytes(where,len);
++#endif
+ #endif
+ 
+   /* never reached */
+@@ -198,7 +202,9 @@ int ssh_crypto_init(void) {
+     }
+     bignum_bin2bn(p_group14_value, P_GROUP14_LEN, p_group14);
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     OpenSSL_add_all_algorithms();
++#endif
+ 
+ #endif
+ 
+@@ -219,8 +225,10 @@ void ssh_crypto_finalize(void) {
+ #ifdef HAVE_LIBGCRYPT
+     gcry_control(GCRYCTL_TERM_SECMEM);
+ #elif defined HAVE_LIBCRYPTO
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     EVP_cleanup();
+     CRYPTO_cleanup_all_ex_data();
++#endif
+ #endif
+     ssh_crypto_initialized=0;
+   }

--- a/libs/libssh/patches/020-openssl-threads.patch
+++ b/libs/libssh/patches/020-openssl-threads.patch
@@ -1,0 +1,28 @@
+--- a/src/threads.c
++++ b/src/threads.c
+@@ -106,6 +106,8 @@ static int libgcrypt_thread_init(void){
+ 
+ static void **libcrypto_mutexes;
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++
+ static void libcrypto_lock_callback(int mode, int i, const char *file, int line){
+ 	(void)file;
+ 	(void)line;
+@@ -160,6 +162,16 @@ static void libcrypto_thread_finalize(void){
+ 
+ }
+ 
++#else
++
++static int libcrypto_thread_init(void){
++	return SSH_OK;
++}
++
++static void libcrypto_thread_finalize(void){
++}
++#endif
++
+ #endif
+ 
+ /** @internal


### PR DESCRIPTION
Last patch was already fixed upstream. First patch was sent.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mislavn
Compile tested: mips64