### PR TITLE
django: Add pytz dependency

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
 PKG_VERSION:=1.11.17
-PKG_RELEASE=2
+PKG_RELEASE=3
 
 PKG_SOURCE:=Django-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/D/Django
@@ -30,7 +30,7 @@ define Package/django
     CATEGORY:=Languages
     TITLE:=The web framework for perfectionists with deadlines.
     URL:=https://www.djangoproject.com/
-    DEPENDS:=+python
+    DEPENDS:=+python +python-pytz
 endef
 
 define Package/django/description


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: mvebu, wrt3200acm, openwrt master
Run tested: mvebu, wrt3200acm, openwrt master, run `python -m django --version`

Description:
pytz is a run-time dependency of django.

django fails to load without pytz:
```
# python -m django --version
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
  File "/usr/lib/python2.7/site-packages/django/__main__.py", line 6, in <module>
    from django.core import management
  File "/usr/lib/python2.7/site-packages/django/core/management/__init__.py", line 13, in <module>
    from django.core.management.base import (
  File "/usr/lib/python2.7/site-packages/django/core/management/base.py", line 17, in <module>
    from django.db.migrations.exceptions import MigrationSchemaMissing
  File "/usr/lib/python2.7/site-packages/django/db/migrations/__init__.py", line 2, in <module>
    from .operations import *  # NOQA
  File "/usr/lib/python2.7/site-packages/django/db/migrations/operations/__init__.py", line 1, in <module>
    from .fields import AddField, AlterField, RemoveField, RenameField
  File "/usr/lib/python2.7/site-packages/django/db/migrations/operations/fields.py", line 4, in <module>
    from django.db.models.fields import NOT_PROVIDED
  File "/usr/lib/python2.7/site-packages/django/db/models/__init__.py", line 3, in <module>
    from django.db.models.aggregates import *  # NOQA
  File "/usr/lib/python2.7/site-packages/django/db/models/aggregates.py", line 5, in <module>
    from django.db.models.expressions import Func, Star
  File "/usr/lib/python2.7/site-packages/django/db/models/expressions.py", line 5, in <module>
    from django.db.backends import utils as backend_utils
  File "/usr/lib/python2.7/site-packages/django/db/backends/utils.py", line 11, in <module>
    from django.utils.timezone import utc
  File "/usr/lib/python2.7/site-packages/django/utils/timezone.py", line 8, in <module>
    import pytz
ImportError: No module named pytz
```
v2:
Removed the change of maintainer, as #8761 was merged.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>