### PR TITLE
gstreamer1: revert addition of --disable-option-parsing

### DIFF
--- a/multimedia/gstreamer1/Makefile
+++ b/multimedia/gstreamer1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gstreamer1
 PKG_VERSION:=1.16.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
 		Ted Hess <thess@kitschensync.net>
@@ -131,7 +131,6 @@ CONFIGURE_ARGS += \
 	--disable-gst-tracer-hooks \
 	--disable-gst-debug \
 	--disable-gtk-doc-html \
-	--disable-option-parsing \
 	--disable-rpath \
 	--disable-tests \
 	--disable-valgrind \


### PR DESCRIPTION
The --disable-option-parsing flag breaks applications (such as dmapd)
that assume gst_init_get_option_group() initializes GStreamer. The
gst_init_get_option_group() function returns NULL and does nothing to
initialize GStreamer in this case. The --disable-option-parsing is meant
only for very specialized instances.

See also https://gitlab.freedesktop.org/gstreamer/gstreamer/issues/388.

Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64
Run tested: x86_64

Description:
