### PR TITLE
nfs-kernel-server: use portmap as dependency instead of rpcbind

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=2.3.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_HASH:=3c8c63611c7e78b7a3b2f8a28b9928a5b5e66d5e9ad09a1e54681508884320a4
 
 PKG_SOURCE_URL:=@SF/nfs
@@ -37,7 +37,7 @@ endef
 define Package/nfs-kernel-server
   $(call Package/nfs-kernel-server/Default)
   TITLE:=Kernel NFS server support
-  DEPENDS+= +kmod-fs-nfsd +kmod-fs-nfs +rpcbind
+  DEPENDS+= +kmod-fs-nfsd +kmod-fs-nfs +portmap
 endef
 
 define Package/nfs-kernel-server/description

--- a/net/nfs-kernel-server/files/nfsd.exports
+++ b/net/nfs-kernel-server/files/nfsd.exports
@@ -1,1 +1,1 @@
-/mnt	*(ro,all_squash,insecure,sync)
+/mnt	*(ro,all_squash,no_subtree_check,insecure,sync)


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: 
- Turris MOX, cortexa53, OpenWrt 18.06.02
- Turris Omnia, mvebu, OpenWrt 18.06.02
- Xiaomi Mi WiFi R3G, ramips, mt7621, OpenWrt 18.06.02

Run tested: Xiaomi Mi WiFi R3G, ramips, mt7621, OpenWrt 18.06.02

Description:
- Fixes #8838 (rpcbind is not in OpenWrt 18.06.02)

Also when you install nfs-kernel-server (also on OpenWrt master), it says:
```
exportfs: /etc/exports [1]: Neither 'subtree_check' or 'no_subtree_check' specified for export "*:/mnt".
  Assuming default behaviour ('no_subtree_check').
  NOTE: this default has changed since nfs-utils version 1.0.x
```

I will update it to [OpenWrt documentation](https://openwrt.org/docs/guide-user/services/nas/nfs.server) as well.