### PR TITLE
youtube-dl: update to version 2019.4.30

### DIFF
--- a/multimedia/youtube-dl/Makefile
+++ b/multimedia/youtube-dl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=youtube-dl
-PKG_VERSION:=2019.4.24
+PKG_VERSION:=2019.4.30
 PKG_RELEASE:=1
 
 PKG_SOURCE:=youtube_dl-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/y/youtube_dl/
-PKG_HASH:=b20d110e1bed8d16f5771bb938ab6e5da67f08af62b599af65301cca290f2e15
+PKG_HASH:=31844229a4f4d7003e03ab309ff2caff1b16ce0acbd3cfb7a13276058af13056
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/youtube_dl-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainers: @ianchi , @BKPepe
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:

- update to version [2019.4.30](https://github.com/ytdl-org/youtube-dl/releases/tag/2019.04.30)
