### PR TITLE
atop: fix build error

### DIFF
--- a/admin/atop/patches/010-makefile-missing-cflags.patch
+++ b/admin/atop/patches/010-makefile-missing-cflags.patch
@@ -1,0 +1,22 @@
+diff --git a/Makefile b/Makefile
+index 3bf5929..e065577 100644
+--- a/Makefile
++++ b/Makefile
+@@ -32,7 +32,7 @@ VERS     = $(shell ./atop -V 2>/dev/null| sed -e 's/^[^ ]* //' -e 's/ .*//')
+ all: 		atop atopsar atopacctd atopconvert
+ 
+ atop:		atop.o    $(ALLMODS) Makefile
+-		$(CC) -c version.c
++		$(CC) $(CFLAGS) -c version.c
+ 		$(CC) atop.o $(ALLMODS) -o atop -lncurses -lz -lm -lrt $(LDFLAGS)
+ 
+ atopsar:	atop
+@@ -45,7 +45,7 @@ atopconvert:	atopconvert.o
+ 		$(CC) atopconvert.o -o atopconvert -lz $(LDFLAGS)
+ 
+ netlink.o:	netlink.c
+-		$(CC) -I. -Wall -c netlink.c
++		$(CC) $(CFLAGS) -I. -Wall -c netlink.c
+ 
+ clean:
+ 		rm -f *.o atop atopacctd atopconvert


### PR DESCRIPTION
Signed-off-by: Toni Uhlig matzeton@googlemail.com

Maintainer: me
Compile tested: x86_64, debian-stable, OpenWrt SNAPSHOT, r9640+8-e7a7749a3c
Run tested: mvebu, linksys3200ac, OpenWrt SNAPSHOT, r9640+8-e7a7749a3c

Description:
Some Makefile targets did not honor CFLAGS.
This can lead to a build error or a SIGSEGV atop exeuctable during shlib loading.