### PR TITLE
uwsgi-cgi: Fix compilation under uClibc-ng

### DIFF
--- a/net/uwsgi-cgi/Makefile
+++ b/net/uwsgi-cgi/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uwsgi-cgi
 PKG_VERSION:=2.0.18
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL= \
 	https://projects.unbit.it/downloads \

--- a/net/uwsgi-cgi/patches/010-uclibc-ng.patch
+++ b/net/uwsgi-cgi/patches/010-uclibc-ng.patch
@@ -1,0 +1,11 @@
+--- a/core/uwsgi.c
++++ b/core/uwsgi.c
+@@ -1820,7 +1820,7 @@ void uwsgi_plugins_atexit(void) {
+ 
+ void uwsgi_backtrace(int depth) {
+ 
+-#if defined(__GLIBC__) || (defined(__APPLE__) && !defined(NO_EXECINFO)) || defined(UWSGI_HAS_EXECINFO)
++#if (!defined(__UCLIBC__) && defined(__GLIBC__)) || (defined(__APPLE__) && !defined(NO_EXECINFO)) || defined(UWSGI_HAS_EXECINFO)
+ 
+ #include <execinfo.h>
+ 


### PR DESCRIPTION
execinfo.h is missing.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Ansuel 
Compile tested: arc700

edit: https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/uwsgi-cgi/compile.txt