### PR TITLE
tvheadend: Fix compilation on GCC8

### DIFF
--- a/multimedia/tvheadend/Makefile
+++ b/multimedia/tvheadend/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tvheadend
 PKG_VERSION:=4.0.10
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tvheadend/tvheadend/tar.gz/v$(PKG_VERSION)?
@@ -71,8 +71,6 @@ CONFIGURE_ARGS += \
 	--disable-dbus_1 \
 	--disable-libav \
 	--enable-bundle
-
-TARGET_CFLAGS += -Wno-error=pointer-compare
 
 define Build/Prepare
 	$(call Build/Prepare/Default)

--- a/multimedia/tvheadend/patches/020-strncpy-issue.patch
+++ b/multimedia/tvheadend/patches/020-strncpy-issue.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 8c5e380..baef144 100644
+--- a/Makefile
++++ b/Makefile
+@@ -28,7 +28,7 @@ PROG    := $(BUILDDIR)/tvheadend
+ #
+ 
+ CFLAGS  += -g -O2 -Wunused-result
+-CFLAGS  += -Wall -Werror -Wwrite-strings -Wno-deprecated-declarations
++#CFLAGS  += -Wall -Werror -Wwrite-strings -Wno-deprecated-declarations
+ CFLAGS  += -Wmissing-prototypes
+ CFLAGS  += -fms-extensions -funsigned-char -fno-strict-aliasing
+ CFLAGS  += -D_FILE_OFFSET_BITS=64


### PR DESCRIPTION
New string warnings were introduced. Adding -Wno-error to TARGET_CFLAGS
does not work so patch it out.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @sairon 
Compile tested: arc700

edit: https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/tvheadend/compile.txt

I tried fixing the actual warnings but they were too numerous. This is easier.