### PR TITLE
byobu: Add new package and dependencies

### DIFF
--- a/libs/newt/Makefile
+++ b/libs/newt/Makefile
@@ -1,0 +1,128 @@
+#
+# Copyright (C) 2006-2011 OpenWrt.org
+# Copyright (C) 2011 SMBPhone Inc.
+# Copyright (C) 2019 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=newt
+PKG_VERSION:=0.52.20
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://releases.pagure.org/newt
+PKG_HASH:=8d66ba6beffc3f786d4ccfee9d2b43d93484680ef8db9397a4fb70b5adbb6dbc
+
+PKG_LICENSE:=LGPL-2.0
+PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:fedorahosted:newt
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/python/python3-package.mk
+
+define Package/newt/Default
+  TITLE:=Newt
+  URL:=https://pagure.io/newt
+endef
+
+define Package/newt/Default/description
+  Newt is a programming library for color text mode, widget based user
+  interfaces.  Newt can be used to add stacked windows, entry widgets,
+  checkboxes, radio buttons, labels, plain text fields, scrollbars, etc.,
+  to text mode user interfaces.  Newt is based on the slang library.
+endef
+
+define Package/libnewt
+$(call Package/newt/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE+= library
+  DEPENDS:=+libslang2
+endef
+
+define Package/libnewt/description
+$(call Package/newt/Default/description)
+endef
+
+define Package/whiptail
+$(call Package/newt/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Display dialog boxes from shell scripts
+  DEPENDS:=+libnewt +libpopt +libslang2
+endef
+
+define Package/whiptail/description
+  A lightweight replacement for the dialog command (dialog boxes from shell
+  scripts), based on libnewt.
+endef
+
+define Package/python3-newt
+$(call Package/newt/Default)
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE+= module for Python
+  DEPENDS:=+libnewt +python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-newt/description
+$(call Package/newt/Default/description)
+
+  This is the Newt module for Python 3.
+endef
+
+TARGET_CFLAGS+= $(FPIC)
+
+CONFIGURE_ARGS+= \
+	--enable-largefile \
+	--with-python \
+	--without-tcl \
+	--without-gpm-support \
+	--with-colorsfile=/etc/newt/palette
+
+CONFIGURE_VARS+= PYTHONVERS="python$(PYTHON3_VERSION)"
+
+MAKE_VARS+= PYTHON_CONFIG_PATH="$(STAGING_DIR)/usr/bin"
+
+Build/Compile=$(call Build/Compile/Default,)
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/newt.h $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnewt.{a,so*} $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libnewt.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libnewt/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnewt.so* $(1)/usr/lib/
+endef
+
+define Package/whiptail/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/whiptail $(1)/usr/bin/
+endef
+
+# Don't install files from usr/bin
+Py3Package/python3-newt/install:=:
+
+$(eval $(call BuildPackage,libnewt))
+$(eval $(call BuildPackage,whiptail))
+
+$(eval $(call Py3Package,python3-newt))
+$(eval $(call BuildPackage,python3-newt))
+$(eval $(call BuildPackage,python3-newt-src))

--- a/libs/newt/patches/001-pythonvers.patch
+++ b/libs/newt/patches/001-pythonvers.patch
@@ -1,0 +1,10 @@
+--- a/configure
++++ b/configure
+@@ -3957,7 +3957,6 @@ if test "x$with_python" = "xno"; then
+ $as_echo "skipped" >&6; }
+   PYTHONVERS=
+ else
+-  PYTHONVERS=$(ls /usr/include/python*/Python.h 2> /dev/null | sed 's|.*\(python[0-9]*\.[0-9]*\).*|\1|g' | tr '\n' ' ')
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHONVERS" >&5
+ $as_echo "$PYTHONVERS" >&6; }
+ fi

--- a/libs/newt/patches/002-use-target-ar-python-config.patch
+++ b/libs/newt/patches/002-use-target-ar-python-config.patch
@@ -1,0 +1,25 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -84,12 +84,7 @@ showkey:	showkey.o $(LIBNEWT)
+ 
+ _snack.$(SOEXT):   snack.c $(LIBNEWTSH)
+ 	@[ -n "$(PYTHONVERS)" ] && for ver in $(PYTHONVERS); do \
+-		pyconfig=$$ver-config; \
+-		if ! $$pyconfig --cflags > /dev/null 2>&1 && \
+-				python-config --cflags > /dev/null 2>&1; then \
+-			echo $$pyconfig not found, using python-config; \
+-			pyconfig=python-config; \
+-		fi; \
++		pyconfig=$(PYTHON_CONFIG_PATH)/$$ver-config; \
+ 		mkdir -p $$ver; \
+ 		PCFLAGS=`$$pyconfig --cflags`; \
+ 		PIFLAGS=`$$pyconfig --includes`; \
+@@ -109,7 +104,7 @@ whiptcl.$(SOEXT): $(WHIPTCLOBJS) $(LIBNE
+ 	$(CC) -shared $(SHCFLAGS) $(LDFLAGS) -o whiptcl.$(SOEXT) $(WHIPTCLOBJS) -L. -lnewt  $(LIBTCL) -lpopt $(LIBS)
+ 
+ $(LIBNEWT): $(LIBOBJS)
+-	ar rv $@ $^
++	$(AR) rv $@ $^
+ 
+ newt.o $(SHAREDDIR)/newt.o: newt.c Makefile
+ 

--- a/libs/newt/patches/python_init_once.patch
+++ b/libs/newt/patches/python_init_once.patch
@@ -1,0 +1,24 @@
+Author: Alastair McKinstry <mckinstry@debian.org>
+Description: newtInit() should only be called once
+Bug-Debian: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=557960
+Forwarded: no
+Last-Updated: 2014-06-11
+
+--- a/snack.c
++++ b/snack.c
+@@ -377,10 +377,15 @@ static snackWidget * snackWidgetNew (voi
+ }
+ 
+ static PyObject * initScreen(PyObject * s, PyObject * args) {
++    static int init_newt = 1;
+     suspend.cb = NULL;
+     suspend.data = NULL;
+     
+     newtInit();
++    if (init_newt) { 
++	newtInit();
++	init_newt = 0;
++    }
+     newtCls();
+ 
+     Py_INCREF(Py_None);

--- a/libs/newt/patches/python_memory_allocation.patch
+++ b/libs/newt/patches/python_memory_allocation.patch
@@ -1,0 +1,35 @@
+Author: Thomas Viehmann <tv@beamnet.de>
+Description: Fix for python memory handling
+Bug-Debian: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=445392
+Last-Updated: 2014-06-11
+Forwarded: no
+
+--- a/snack.c
++++ b/snack.c
+@@ -366,7 +366,7 @@ static PyTypeObject snackWidgetType = {
+ static snackWidget * snackWidgetNew (void) {
+     snackWidget * widget;
+      
+-    widget = PyObject_NEW(snackWidget, &snackWidgetType);
++    widget = PyObject_New(snackWidget, &snackWidgetType);
+     if (!widget)
+ 	return NULL;
+ 
+@@ -937,7 +937,7 @@ static snackForm * formCreate(PyObject *
+     if (help == Py_None)
+ 	help = NULL;
+ 
+-    form = PyObject_NEW(snackForm, &snackFormType);
++    form = PyObject_New(snackForm, &snackFormType);
+     form->fo = newtForm(NULL, help, 0);
+ 
+     return form;
+@@ -949,7 +949,7 @@ static snackGrid * gridCreate(PyObject *
+ 
+     if (!PyArg_ParseTuple(args, "ii", &cols, &rows)) return NULL;
+ 
+-    grid = PyObject_NEW(snackGrid, &snackGridType);
++    grid = PyObject_New(snackGrid, &snackGridType);
+     grid->grid = newtCreateGrid(cols, rows);
+ 
+     return grid;

--- a/libs/slang2/Makefile
+++ b/libs/slang2/Makefile
@@ -1,0 +1,176 @@
+#
+# Copyright (C) 2006-2011 Openwrt.org
+# Copyright (C) 2011 SMBPhone Inc.
+# Copyright (C) 2019 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=slang
+PKG_VERSION:=2.3.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://www.jedsoft.org/releases/slang \
+	https://www.jedsoft.org/releases/slang/old
+PKG_HASH:=fc9e3b0fc4f67c3c1f6d43c90c16a5c42d117b8e28457c5b46831b8b5d3ae31a
+
+PKG_LICENSE:=GPL-2.0+
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_BUILD_PARALLEL:=1
+
+SLANG_MODULES:= base64 chksum csv fcntl fork histogram iconv json pcre png \
+	rand select slsmg socket stats sysconf termios varray zlib
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libslang2/Default
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=S-Lang Programmer's Library
+  URL:=https://www.jedsoft.org/slang/
+endef
+
+define Package/libslang2/Default/description
+  Multi-platform programmer's library providing facilities for interactive
+  applications.  Includes such things as display/screen management,
+  keyboard input, keymaps, etc.  Includes the embeddable S-Lang interpreter.
+endef
+
+define Package/libslang2
+$(call Package/libslang2/Default)
+  DEPENDS:=+terminfo
+endef
+
+define Package/libslang2/description
+$(call Package/libslang2/Default/description)
+endef
+
+define Package/libslang2-modules
+$(call Package/libslang2/Default)
+  TITLE+= (all modules)
+  DEPENDS:=$(foreach mod,$(SLANG_MODULES),+libslang2-mod-$(mod))
+endef
+
+define Package/libslang2-modules/description
+$(call Package/libslang2/Default/description)
+
+  This installs all of S-Lang's bundled modules.
+endef
+
+define Package/libslang2-mod-pcre
+$(call Package/libslang2/Default)
+  TITLE+= (pcre module)
+  DEPENDS:=+libpcre
+endef
+
+define Package/libslang2-mod-png
+$(call Package/libslang2/Default)
+  TITLE+= (png module)
+  DEPENDS:=+libpng
+endef
+
+define Package/libslang2-mod-zlib
+$(call Package/libslang2/Default)
+  TITLE+= (zlib module)
+  DEPENDS:=+zlib
+endef
+
+define Package/slsh
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=S-Lang shell
+  URL:=https://www.jedsoft.org/slang/slsh.html
+  DEPENDS:=+libslang2 +libslang2-modules
+endef
+
+define Package/slsh/description
+  This is a shell which is mostly just a wrapper around the S-Lang Interpreter,
+  which is part of the S-Lang Library.
+endef
+
+TARGET_CFLAGS+= $(FPIC)
+
+CONFIGURE_ARGS+= \
+	--enable-largefile \
+	--enable-warnings \
+	--with-terminfo=default \
+	--with-readline=slang \
+	--with-pcre="$(STAGING_DIR)/usr" \
+	--with-png="$(STAGING_DIR)/usr" \
+	--with-z="$(STAGING_DIR)/usr" \
+	--without-onig \
+	--without-x
+
+define Build/Compile
+	$(call Build/Compile/Default,)
+	$(call Build/Compile/Default,static)
+endef
+
+# Default install last, so that the dynamic slsh is installed
+define Build/Install
+	$(call Build/Install/Default,install-static)
+	$(call Build/Install/Default,)
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libslang.{a,so*} $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/slang.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libslang2/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libslang.so* $(1)/usr/lib/
+endef
+
+Package/libslang2-modules/install:=:
+
+define Package/slsh/install
+	$(INSTALL_DIR) $(1)/etc
+	$(CP) $(PKG_INSTALL_DIR)/etc/slsh.rc $(1)/etc/
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/slsh $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/usr/share
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/slsh/ $(1)/usr/share/
+endef
+
+define BuildModule
+  ifndef Package/libslang2-mod-$(1)
+    define Package/libslang2-mod-$(1)
+    $$(call Package/libslang2/Default)
+      TITLE+= ($(1) module)
+    endef
+  endif
+
+  define Package/libslang2-mod-$(1)/description
+  $$(call Package/libslang2/Default/description)
+
+    This contains the $(1) module.
+  endef
+
+  define Package/libslang2-mod-$(1)/install
+	$$(INSTALL_DIR) $$(1)/usr/lib/slang/v2/modules
+	$$(CP) $$(PKG_INSTALL_DIR)/usr/lib/slang/v2/modules/$(1)-module.so $$(1)/usr/lib/slang/v2/modules/
+  endef
+
+  $$(eval $$(call BuildPackage,libslang2-mod-$(1)))
+endef
+
+$(foreach mod,$(SLANG_MODULES),$(eval $(call BuildModule,$(mod))))
+
+$(eval $(call BuildPackage,libslang2))
+$(eval $(call BuildPackage,libslang2-modules))
+$(eval $(call BuildPackage,slsh))

--- a/libs/slang2/patches/001-skip-terminfo-dir-test.patch
+++ b/libs/slang2/patches/001-skip-terminfo-dir-test.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -7029,7 +7029,7 @@ TERMCAP=-ltermcap
+ 
+ for terminfo_dir in $JD_Terminfo_Dirs
+ do
+-   if test -d $terminfo_dir
++   if true
+    then
+       { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ $as_echo "yes" >&6; }

--- a/libs/slang2/patches/002-use-target-ar.patch
+++ b/libs/slang2/patches/002-use-target-ar.patch
@@ -1,0 +1,11 @@
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -73,7 +73,7 @@ INSTALL_DATA	= @INSTALL_DATA@
+ MKINSDIR	= @CONFIG_DIR@/autoconf/mkinsdir.sh
+ RM 		= rm -f
+ RM_R		= rm -rf
+-AR_CR 		= ar cr
++AR_CR 		= $(AR) cr
+ RMDIR 		= rmdir
+ LN 		= /bin/ln -sf
+ CP 		= cp

--- a/utils/byobu/Makefile
+++ b/utils/byobu/Makefile
@@ -1,0 +1,102 @@
+#
+# Copyright (C) 2009 Sharim At Work, Ltd.
+# Copyright (C) 2019 Jeffery To
+# Author: Xiangfu Liu <xiangfu@sharism.cc>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=byobu
+PKG_VERSION:=5.127
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
+PKG_SOURCE_URL:=https://launchpad.net/byobu/trunk/$(PKG_VERSION)/+download
+PKG_HASH:=4bafc7cb69ff5b0ab6998816d58cd1ef7175e5de75abc1dd7ffd6d5288a4f63b
+
+PKG_LICENSE:=GPL-3.0
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/byobu/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  URL:=http://byobu.org/
+  PKGARCH:=all
+endef
+
+define Package/byobu
+$(call Package/byobu/Default)
+  TITLE:=Text-based window manager and terminal multiplexer
+  DEPENDS:=+python3-light +python3-newt
+endef
+
+define Package/byobu-utils
+$(call Package/byobu/Default)
+  TITLE:=Utilities included with byobu
+endef
+
+define Package/byobu/description
+  Byobu is a GPLv3 open source text-based window manager and terminal
+  multiplexer. It was originally designed to provide elegant enhancements
+  to the otherwise functional, plain, practical GNU Screen, for the Ubuntu
+  server distribution. Byobu now includes an enhanced profiles, convenient
+  keybindings, configuration utilities, and toggle-able system status
+  notifications for both the GNU Screen window manager and the more modern
+  Tmux terminal multiplexer, and works on most Linux, BSD, and Mac
+  distributions.
+endef
+
+define Package/byobu-utils/description
+$(call Package/byobu/description)
+
+  These are the "bikeshed" utilities bundled with byobu:
+  * col1..col9, NF
+  * ctail
+  * manifest
+  * purge-old-kernels
+  * vigpg
+  * wifi-status
+endef
+
+define Package/byobu/install
+	$(INSTALL_DIR) $(1)/etc
+	$(CP) $(PKG_INSTALL_DIR)/etc/* $(1)/etc/
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/byobu* $(1)/usr/bin/
+	$(LN) byobu $(1)/usr/bin/byobu-screen
+	$(LN) byobu $(1)/usr/bin/byobu-tmux
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/byobu $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/share/byobu
+	for i in keybindings profiles status windows; do \
+		$(CP) $(PKG_INSTALL_DIR)/usr/share/byobu/$$$$i $(1)/usr/share/byobu/ ; \
+	done
+
+	$(INSTALL_DIR) $(1)/usr/share/doc
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/doc/byobu $(1)/usr/share/doc/
+endef
+
+define Package/byobu-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	for i in col1 ctail manifest purge-old-kernels vigpg wifi-status; do \
+		$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$$$$i $(1)/usr/bin/ ; \
+	done
+	for i in col2 col3 col4 col5 col6 col7 col8 col9 NF; do \
+		$(LN) col1 $(1)/usr/bin/$$$$i ; \
+	done
+endef
+
+$(eval $(call BuildPackage,byobu))
+$(eval $(call BuildPackage,byobu-utils))

--- a/utils/byobu/patches/001-hardcode-utf-8-charmap.patch
+++ b/utils/byobu/patches/001-hardcode-utf-8-charmap.patch
@@ -1,0 +1,11 @@
+--- a/usr/bin/byobu.in
++++ b/usr/bin/byobu.in
+@@ -46,7 +46,7 @@ if [ -z "${BYOBU_PREFIX}" ]; then
+ 		. "$HOME/.byoburc"
+ 	fi
+ fi
+-export BYOBU_CHARMAP=$(locale charmap)
++export BYOBU_CHARMAP=UTF-8
+ [ -r "$HOME/.byoburc" ] && . "$HOME/.byoburc"
+ [ -z "${BYOBU_PREFIX}" ] && export BYOBU_PREFIX="@prefix@" || export BYOBU_PREFIX
+ . "${BYOBU_PREFIX}/lib/${PKG}/include/common"

--- a/utils/byobu/patches/002-fix-missing-tty-arm-serial-autolaunch.patch
+++ b/utils/byobu/patches/002-fix-missing-tty-arm-serial-autolaunch.patch
@@ -1,0 +1,24 @@
+--- a/usr/bin/byobu.in
++++ b/usr/bin/byobu.in
+@@ -62,7 +62,7 @@ esac
+ export BYOBU_BACKEND
+ 
+ # Store the parent tty
+-export BYOBU_TTY=$(tty)
++export BYOBU_TTY=$(readlink /proc/$$/fd/0)
+ 
+ # Get the default window name
+ [ -n "$BYOBU_WINDOW_NAME" ] || BYOBU_WINDOW_NAME=-
+--- a/usr/bin/byobu-launch.in
++++ b/usr/bin/byobu-launch.in
+@@ -30,8 +30,8 @@
+ #    or edit your sshd_config, ssh_config, and set:
+ #      $HOME/.bashrc:  export BYOBU_DISABLE=1
+ 
+-_tty=$(tty)
+-if [ "${_tty#/dev/ttyS}" != "$_tty" ]; then
++_tty=$(readlink /proc/$$/fd/0)
++if [ "${_tty#/dev/ttyS}" != "$_tty" ] && [ "${_tty#/dev/ttyAMA}" != "$_tty" ]; then
+ 	# Don't autolaunch byobu on serial consoles
+ 	# You can certainly run 'byobu' manually, though
+ 	echo

--- a/utils/byobu/patches/003-fix-missing-install.patch
+++ b/utils/byobu/patches/003-fix-missing-install.patch
@@ -1,0 +1,11 @@
+--- a/usr/bin/byobu-janitor.in
++++ b/usr/bin/byobu-janitor.in
+@@ -41,7 +41,7 @@ DEFAULT_PROFILE="light"
+ PROFILE="$BYOBU_CONFIG_DIR/profile"
+ 
+ # Create byobu-exchange buffer file, with secure permissions, if it doesn't exist
+-[ -e "$BYOBU_RUN_DIR/printscreen" ] || install -m 600 /dev/null "$BYOBU_RUN_DIR/printscreen"
++[ -e "$BYOBU_RUN_DIR/printscreen" ] || { cp /dev/null "$BYOBU_RUN_DIR/printscreen"; chmod 600 "$BYOBU_RUN_DIR/printscreen"; }
+ 
+ # Affects: users who launched using sudo, such that their config dir
+ # is not writable by them

--- a/utils/byobu/patches/004-skip-python-test.patch
+++ b/utils/byobu/patches/004-skip-python-test.patch
@@ -1,0 +1,10 @@
+--- a/usr/lib/byobu/include/constants
++++ b/usr/lib/byobu/include/constants
+@@ -58,6 +58,7 @@ $BYOBU_SED --follow-symlinks "s///" /dev
+ eval $BYOBU_TEST ulimit >/dev/null 2>&1 && export BYOBU_ULIMIT="ulimit" || export BYOBU_ULIMIT="false"
+ 
+ # Find a suitable python interpreter, if undefined
++export BYOBU_PYTHON="python3"
+ if [ -z "$BYOBU_PYTHON" ]; then
+ 	if python3 -c "import snack" >/dev/null 2>&1; then
+ 		export BYOBU_PYTHON="python3"

--- a/utils/byobu/patches/005-monitor-overlay.patch
+++ b/utils/byobu/patches/005-monitor-overlay.patch
@@ -1,0 +1,28 @@
+--- a/usr/lib/byobu/disk
++++ b/usr/lib/byobu/disk
+@@ -26,7 +26,10 @@ __disk_detail() {
+ __disk() {
+ 	local out="" MP="" size="" pct="" unit=""
+ 	# Default to /, but let users override
+-	[ -z "$MONITORED_DISK" ] && MP="/" || MP="$MONITORED_DISK"
++	MP="$MONITORED_DISK"
++	[ -n "$MP" ] || {
++		grep -q ' /overlay ' /proc/mounts && MP=/overlay || MP=/
++	}
+ 	case $MP in
+ 		/dev/*) MP=$(awk '$1 == m { print $2; exit(0); }' "m=$MP" /proc/mounts);;
+ 	esac
+--- a/usr/lib/byobu/disk_io
++++ b/usr/lib/byobu/disk_io
+@@ -42,7 +42,10 @@ getdisk() {
+ __disk_io() {
+ 	local part= i=
+ 	# Default to disk providing /, but let users override with MONITORED_DISK
+-	[ -z "$MONITORED_DISK" ] && mount_point="/" ||  mount_point="$MONITORED_DISK"
++	local mount_point="$MONITORED_DISK"
++	[ -n "$mount_point" ] || {
++		grep -q ' /overlay ' /proc/mounts && mount_point=/overlay || mount_point=/
++	}
+ 	# By default, we won't bug the user with the display of network traffic
+ 	# below DISK_IO_THRESHOLD in kB/s; override in $BYOBU_CONFIG_DIR/status
+ 	[ -n "$DISK_IO_THRESHOLD" ] || DISK_IO_THRESHOLD=50

--- a/utils/byobu/patches/006-pgrep-services.patch
+++ b/utils/byobu/patches/006-pgrep-services.patch
@@ -1,0 +1,13 @@
+--- a/usr/lib/byobu/services
++++ b/usr/lib/byobu/services
+@@ -24,7 +24,9 @@ __services_detail() {
+ }
+ 
+ service_running() {
+-	if [ -f "/etc/init/$1.conf" ]; then
++	if pgrep "$1" >/dev/null; then
++		true
++	elif [ -f "/etc/init/$1.conf" ]; then
+ 		# Use upstart
+ 		case "$(status $1 2>/dev/null)" in
+ 			*running*)

--- a/utils/byobu/patches/007-count-dropbear-users.patch
+++ b/utils/byobu/patches/007-count-dropbear-users.patch
@@ -1,0 +1,33 @@
+--- a/usr/lib/byobu/users
++++ b/usr/lib/byobu/users
+@@ -22,20 +22,26 @@
+ #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ __users_detail() {
+-	ps -ef | grep "sshd:.*@" | grep -v grep
++	ps -ef 2>/dev/null | grep "sshd:.*@" | grep -v grep
+ }
+ 
+ __users() {
+-	local count=0
++	local count=0 f pid
++	for f in /var/run/dropbear.*.pid; do
++		read pid < "$f"
++		count=$(($count + $(pgrep -P "$pid" | wc -l)))
++	done
++	if [ $count -eq 0 ]; then
+ 	if [ "$USERS_DISTINCT" = "1" ]; then
+ 		count=$(pgrep -fl 'sshd:.*@' | cut -f3 -d\ | cut -f1 -d@ | sort -u | wc -l)
+ 	else
+ 		# Note: we'd like to use pgrep -c, however, this isn't available in
+ 		# busybox and some distro's pgrep (and it doesn't exit non-zero).
+-		count=$(pgrep -f "^sshd:.*@|^/usr/sbin/sshd -i" | wc -l) || return
++		count=$(pgrep -f "^sshd:.*@|^/usr/sbin/sshd -i" | wc -l)
++	fi
+ 	fi
+ 	if [ $count -gt 0 ]; then
+-		color b w r; printf "%d" "$count"; color -; color w r; printf "#"; color --
++		color b w r; printf "%d" "$count"; color -; color w r; printf "##"; color --
+ 	else
+ 		rm -f "$BYOBU_RUN_DIR/status.$BYOBU_BACKEND/users"*
+ 	fi

--- a/utils/byobu/patches/008-no-gettext.patch
+++ b/utils/byobu/patches/008-no-gettext.patch
@@ -1,0 +1,22 @@
+--- a/usr/bin/byobu-export.in
++++ b/usr/bin/byobu-export.in
+@@ -22,7 +22,7 @@ PKG="byobu"
+ [ -z "${BYOBU_PREFIX}" ] && export BYOBU_PREFIX="@prefix@" || export BYOBU_PREFIX
+ . "${BYOBU_PREFIX}/lib/${PKG}/include/common"
+ 
+-gettext "
++echo "
+ The byobu-export utility is now deprecated.
+ 
+ To install byobu on a system for which byobu is not packaged, or
+--- a/usr/lib/byobu/menu
++++ b/usr/lib/byobu/menu
+@@ -35,7 +35,7 @@ __menu() {
+ 	else
+ 		key="F9"
+ 	fi
+-	text=$(gettext "Menu" 2>/dev/null) || text="Menu"
++	text="Menu"
+ 	color k w; printf "%s:<" "$text"; color -; color b k w; printf "%s" "$key"; color k w; printf ">"
+ }
+ 

--- a/utils/byobu/patches/100-check-if-bashrc-exists.patch
+++ b/utils/byobu/patches/100-check-if-bashrc-exists.patch
@@ -1,0 +1,29 @@
+--- a/usr/bin/byobu-disable-prompt.in
++++ b/usr/bin/byobu-disable-prompt.in
+@@ -17,6 +17,8 @@
+ #    You should have received a copy of the GNU General Public License
+ #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
++[ -w "$HOME/.bashrc" ] || exit 1
++
+ PKG="byobu"
+ [ -r "$HOME/.byoburc" ] && . "$HOME/.byoburc"
+ [ -z "${BYOBU_PREFIX}" ] && export BYOBU_PREFIX="@prefix@" || export BYOBU_PREFIX
+--- a/usr/bin/byobu-janitor.in
++++ b/usr/bin/byobu-janitor.in
+@@ -112,6 +112,7 @@ killall -u $USER byobu-statusd >/dev/nul
+ rm -f "$FLAG" "/var/run/screen/S-$USER/$PKG.reload-required"
+ 
+ # Affects: Upgrades from <= byobu 5.50, install byobu prompt if using stock bashrc
++if [ -r /etc/skel/.bashrc ] && [ -r "$HOME/.bashrc" ] && [ -w "$HOME/.bashrc" ]; then
+ if ! (grep -qs "#byobu-prompt#$" "$HOME/.bashrc") && ! [ -e "$BYOBU_CONFIG_DIR/prompt" ]; then
+ 	if eval $BYOBU_TEST diff >/dev/null 2>&1; then
+ 		if  diff /etc/skel/.bashrc "$HOME/.bashrc" >/dev/null 2>&1; then
+@@ -123,6 +124,7 @@ if ! (grep -qs "#byobu-prompt#$" "$HOME/
+ 		fi
+ 	fi
+ fi
++fi
+ [ -r "$BYOBU_CONFIG_DIR/prompt" ] || printf "[ -r ${BYOBU_PREFIX}/share/${PKG}/profiles/bashrc ] && . ${BYOBU_PREFIX}/share/${PKG}/profiles/bashrc  #byobu-prompt#\n" > "$BYOBU_CONFIG_DIR/prompt"
+ 
+ # Affects: Upgrades from <= byobu 5.126, clear out ec2/rcs cost statuses

--- a/utils/byobu/patches/101-fix-tmux-2.8-new-window.patch
+++ b/utils/byobu/patches/101-fix-tmux-2.8-new-window.patch
@@ -1,0 +1,34 @@
+--- a/usr/share/byobu/keybindings/f-keys.tmux
++++ b/usr/share/byobu/keybindings/f-keys.tmux
+@@ -26,8 +26,8 @@ source $BYOBU_PREFIX/share/byobu/keybind
+ 
+ # Byobu's Keybindings
+ # Documented in: $BYOBU_PREFIX/share/doc/byobu/help.tmux.txt
+-bind-key -n F1 new-window -k -n config byobu-config
+-bind-key -n S-F1 new-window -k -n help "sh -c '$BYOBU_PAGER $BYOBU_PREFIX/share/doc/byobu/help.tmux.txt'"
++bind-key -n F1 new-window -n config byobu-config
++bind-key -n S-F1 new-window -n help "sh -c '$BYOBU_PAGER $BYOBU_PREFIX/share/doc/byobu/help.tmux.txt'"
+ bind-key -n F2 new-window -c "#{pane_current_path}" \; rename-window "-"
+ bind-key -n C-F2 display-panes \; split-window -h -c "#{pane_current_path}"
+ bind-key -n S-F2 display-panes \; split-window -v -c "#{pane_current_path}"
+@@ -54,7 +54,7 @@ bind-key -n M-S-Left resize-pane -L
+ bind-key -n M-S-Right resize-pane -R
+ bind-key -n F5 source $BYOBU_PREFIX/share/byobu/profiles/tmuxrc
+ bind-key -n M-F5 run-shell '$BYOBU_PREFIX/lib/byobu/include/toggle-utf8' \; source $BYOBU_PREFIX/share/byobu/profiles/tmuxrc
+-bind-key -n S-F5 new-window -k "$BYOBU_PREFIX/lib/byobu/include/cycle-status" \; source $BYOBU_PREFIX/share/byobu/profiles/tmuxrc
++bind-key -n S-F5 new-window "$BYOBU_PREFIX/lib/byobu/include/cycle-status" \; source $BYOBU_PREFIX/share/byobu/profiles/tmuxrc
+ bind-key -n C-F5 send-keys ". $BYOBU_PREFIX/bin/byobu-reconnect-sockets" \; send-keys Enter
+ bind-key -n C-S-F5 new-window -d "byobu-select-profile -r"
+ bind-key -n F6 detach
+@@ -68,9 +68,9 @@ bind-key -n M-PPage copy-mode \; send-ke
+ bind-key -n F8 command-prompt -p "(rename-window) " "rename-window '%%'"
+ bind-key -n C-F8 command-prompt -p "(rename-session) " "rename-session '%%'"
+ bind-key -n S-F8 next-layout
+-bind-key -n M-S-F8 new-window -k "byobu-layout restore; clear; $SHELL"
++bind-key -n M-S-F8 new-window "byobu-layout restore; clear; $SHELL"
+ bind-key -n C-S-F8 command-prompt -p "Save byobu layout as:" "run-shell \"byobu-layout save '%%'\""
+-bind-key -n F9 new-window -k -n config byobu-config
++bind-key -n F9 new-window -n config byobu-config
+ bind-key -n S-F9 command-prompt -p "Send command to all panes:" "run-shell \"$BYOBU_PREFIX/lib/byobu/include/tmux-send-command-to-all-panes '%%'\""
+ bind-key -n C-F9 command-prompt -p "Send command to all windows:" "run-shell \"$BYOBU_PREFIX/lib/byobu/include/tmux-send-command-to-all-windows '%%'\""
+ bind-key -n M-F9 display-panes \; setw synchronize-panes

--- a/utils/byobu/patches/102-ensure-disk-exists.patch
+++ b/utils/byobu/patches/102-ensure-disk-exists.patch
@@ -1,0 +1,10 @@
+--- a/usr/lib/byobu/disk_io
++++ b/usr/lib/byobu/disk_io
+@@ -53,6 +53,7 @@ __disk_io() {
+ 		/dev/*) part="${mount_point}";;
+ 		*) part=$(awk '$2 == mp { print $1 ; exit(0); }' "mp=$mount_point" /etc/mtab);;
+ 	esac
++	[ -e "$part" ] || return
+ 	getdisk "$part"
+ 	local disk=${_RET}
+ 	local t2=$(date +%s) t1=

--- a/utils/byobu/patches/103-add-hostname-fallback.patch
+++ b/utils/byobu/patches/103-add-hostname-fallback.patch
@@ -1,0 +1,21 @@
+--- a/usr/lib/byobu/hostname
++++ b/usr/lib/byobu/hostname
+@@ -20,12 +20,16 @@
+ #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ __hostname_detail() {
+-	hostname -f
++	hostname -f 2>/dev/null
+ }
+ 
+ __hostname() {
+ 	local h=
+-	h=$(hostname -s 2>/dev/null || hostname)
++	if eval $BYOBU_TEST hostname >/dev/null 2>&1; then
++		h=$(hostname -s 2>/dev/null || hostname)
++	elif [ -r /proc/sys/kernel/hostname ]; then
++		read h < /proc/sys/kernel/hostname
++	fi
+ 	if metadata_available; then
+ 		local cache="$BYOBU_RUN_DIR/cache.$BYOBU_BACKEND/hostname"
+ 		# Background a retrieval of our public hostname

--- a/utils/byobu/patches/104-add-custom-logo.patch
+++ b/utils/byobu/patches/104-add-custom-logo.patch
@@ -1,0 +1,13 @@
+--- a/usr/lib/byobu/logo
++++ b/usr/lib/byobu/logo
+@@ -111,6 +111,10 @@ __logo() {
+ 			logo=" lm "
+ 			$MARKUP && printf "$(color g w)$logo$(color -)$(color g w)$(color -) " || printf "$logo"
+ 		;;
++		*openwrt*)
++			logo="OWrt"
++			$MARKUP && printf "$(color b colour66 W)%s$(color -)" "$logo" || printf "$logo"
++		;;
+ 		*red*hat*|*rhel*)
+ 			logo=" RH "
+ 			$MARKUP && printf "$(color R k)%s$(color -)" "$logo" || printf "$logo"

--- a/utils/byobu/patches/105-handle-processes-stderr.patch
+++ b/utils/byobu/patches/105-handle-processes-stderr.patch
@@ -1,0 +1,21 @@
+--- a/usr/lib/byobu/processes
++++ b/usr/lib/byobu/processes
+@@ -20,15 +20,15 @@
+ #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ __processes_detail() {
+-	ps -ej
++	ps -ej 2>/dev/null
+ }
+ 
+ __processes() {
+ 	local count=
+ 	if [ -r /proc ]; then
+-		count=$(ls -d /proc/[0-9]* 2>/dev/null| wc -l)
++		count=$(ls -d /proc/[0-9]* 2>/dev/null | wc -l)
+ 	else
+-		count=$(ps -ef | wc -l | awk '{print $1}')
++		count=$(ps -ef | wc -l)
+ 	fi
+ 	[ -n "$count" ] || return
+ 	color b y w; printf "%s" "$count"; color -; color y w; printf "&"; color --

--- a/utils/byobu/patches/106-fix-release-typo.patch
+++ b/utils/byobu/patches/106-fix-release-typo.patch
@@ -1,0 +1,11 @@
+--- a/usr/lib/byobu/release
++++ b/usr/lib/byobu/release
+@@ -30,7 +30,7 @@ __release() {
+ 		true
+ 	elif [ -r "/etc/os-release" ]; then
+ 		# lsb_release is *really* slow;  try to use /etc/os-release
+-		release=$(. /etc/os-release && echo "$VERSION_ID")
++		RELEASE=$(. /etc/os-release && echo "$VERSION_ID")
+ 	elif [ -r "/etc/issue" ]; then
+ 		# next try /etc/issue first
+ 		local issue

--- a/utils/byobu/patches/107-fix-SERVICES.patch
+++ b/utils/byobu/patches/107-fix-SERVICES.patch
@@ -1,0 +1,11 @@
+--- a/usr/lib/byobu/services
++++ b/usr/lib/byobu/services
+@@ -45,7 +45,7 @@ service_running() {
+ }
+ 
+ __services() {
+-	local services=
++	local services="$SERVICES"
+ 	# Users can define a list of services to monitor in $BYOBU_CONFIG_DIR/status
+ 	if [ -z "$services" ]; then
+ 		if [ -f "/etc/eucalyptus/eucalyptus.conf" ]; then

--- a/utils/byobu/patches/108-custom-updates-available.patch
+++ b/utils/byobu/patches/108-custom-updates-available.patch
@@ -1,0 +1,39 @@
+--- a/usr/lib/byobu/updates_available
++++ b/usr/lib/byobu/updates_available
+@@ -67,9 +67,16 @@ ___update_cache() {
+ 	elif eval $BYOBU_TEST pacman >/dev/null; then
+ 		# If pacman (Archlinux) exists, use it
+ 		LC_ALL=C flock -xn "$flock" pacman -Sup | grep -vc "^\(::\| \)" >$mycache 2>/dev/null &
++	elif eval $BYOBU_TEST opkg >/dev/null; then
++		# If opkg (OpenWrt) exists, use it, also background if flock exists
++		if eval $BYOBU_TEST flock >/dev/null; then
++			flock -xn "$flock" opkg list-upgradable | wc -l >$mycache 2>/dev/null &
++		else
++			opkg list-upgradable | wc -l >$mycache &
++		fi
+ 	elif eval $BYOBU_TEST brew >/dev/null; then
+ 		# If homebrew (Mac OSX) exists, use it, also background if flock exists
+-		if eval $BYOBU_TEST flock; then
++		if eval $BYOBU_TEST flock >/dev/null; then
+ 			flock -xn "$flock" brew outdated | wc -l >$mycache 2>/dev/null &
+ 		else
+ 			brew outdated | wc -l >$mycache &
+@@ -106,6 +113,18 @@ ___update_needed() {
+ 			[ "$db" -nt "$mycache" ] && return 0
+ 		done
+ 		return 1
++	elif eval $BYOBU_TEST opkg >/dev/null; then
++		# OpenWrt
++		[ ! -e /var/lock/opkg.lock ] || return 1
++		if [ -d /var/opkg-lists ]; then
++			[ /var/opkg-lists -nt "$mycache" ]
++			return $?
++		else
++			local u s
++			read u s < "$mycache"
++			[ "$u" -gt 0 ]
++			return $?
++		fi
+ 	elif eval $BYOBU_TEST brew >/dev/null; then
+ 		# Mac OSX
+ 		# check if any new versions have been installed since

--- a/utils/byobu/patches/109-add-whoami-fallback.patch
+++ b/utils/byobu/patches/109-add-whoami-fallback.patch
@@ -1,0 +1,33 @@
+--- a/usr/lib/byobu/whoami
++++ b/usr/lib/byobu/whoami
+@@ -19,12 +19,28 @@
+ #    You should have received a copy of the GNU General Public License
+ #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
++___get_user() {
++	if eval $BYOBU_TEST whoami >/dev/null 2>&1; then
++		whoami
++	elif eval $BYOBU_TEST id >/dev/null 2>&1; then
++		id -un
++	fi
++}
++
+ __whoami_detail() {
+-	getent -- passwd "$USER"
++	local user=$(___get_user)
++	[ -n "$user" ] || return
++	if eval $BYOBU_TEST getent >/dev/null 2>&1; then
++		getent -- passwd "$user"
++	else
++		grep "^$user:" /etc/passwd
++	fi
+ }
+ 
+ __whoami() {
+-	color bold2; printf "%s@" "$(whoami)"; color -
++	local user=$(___get_user)
++	[ -n "$user" ] || return
++	color bold2; printf "%s@" "$user"; color -
+ }
+ 
+ # vi: syntax=sh ts=4 noexpandtab

--- a/utils/byobu/patches/110-wifi-quality.patch
+++ b/utils/byobu/patches/110-wifi-quality.patch
@@ -1,0 +1,82 @@
+--- a/usr/lib/byobu/wifi_quality
++++ b/usr/lib/byobu/wifi_quality
+@@ -19,32 +19,61 @@
+ #    You should have received a copy of the GNU General Public License
+ #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
++___get_dev_list() {
++	if [ -n "$MONITORED_NETWORK" ]; then
++		echo "$MONITORED_NETWORK"
++	else
++		iw dev | grep Interface | cut -f2 -d\ 
++	fi
++}
++
+ __wifi_quality_detail() {
+-	/sbin/iwconfig 2>/dev/null
++	if eval $BYOBU_TEST iw >/dev/null 2>&1; then
++		local dev
++		for dev in $(___get_dev_list); do
++			iw dev "$dev" info
++			iw dev "$dev" link
++			echo
++		done
++	elif eval $BYOBU_TEST iwconfig >/dev/null 2>&1; then
++		iwconfig 2>/dev/null
++	fi
+ }
+ 
+ __wifi_quality() {
+ 	local out bitrate quality
+-	# iwconfig is expected to output lines like:
+-	#    Bit Rate=54 Mb/s   Tx-Power=15 dBm
+-	#    Link Quality=60/70  Signal level=-50 dBm
+-	# the awk below tokenizes the output and prints shell evalable results
+-	out=`iwconfig $MONITORED_NETWORK 2>/dev/null |
+-		awk '$0 ~ /[ ]*Link Quality./ {
+-   sub(/.*=/,"",$2); split($2,a,"/");
+-   printf "quality=%.0f\n", 100*a[1]/a[2] };
+-   $0 ~ /[ ]*Bit Rate/ { sub(/.*[:=]/,"",$2); printf("bitrate=%s\n", $2); }
+-   '`
+-	eval "$out"
+-	[ -z "$bitrate" ] && bitrate="0"
+-	if [ -z "$quality" ] || [ "$quality" = "0" ]; then
+-		quality="0"
++	if eval $BYOBU_TEST iw >/dev/null 2>&1; then
++		local dev
++		for dev in $(___get_dev_list); do
++			# signal to quality: https://superuser.com/a/1360447
++			out=`iw dev "$dev" link 2>/dev/null |
++				awk '$0 ~ /^\s*signal:/ { a = 100 * ($2 + 110) / 70;
++				    printf "quality=%.0f\n", (a > 100) ? 100 : ((a < 0) ? 0 : a); }
++				    $0 ~ /^\s*tx bitrate:/ { printf "bitrate=%s\n", $3; }
++				    '`
++			eval "$out"
++			[ -z "$bitrate" ] || [ -z "$quality" ] || break
++		done
++	elif eval $BYOBU_TEST iwconfig >/dev/null 2>&1; then
++		# iwconfig is expected to output lines like:
++		#    Bit Rate=54 Mb/s   Tx-Power=15 dBm
++		#    Link Quality=60/70  Signal level=-50 dBm
++		# the awk below tokenizes the output and prints shell evalable results
++		out=`iwconfig $MONITORED_NETWORK 2>/dev/null |
++			awk '$0 ~ /[ ]*Link Quality./ {
++			    sub(/.*=/,"",$2); split($2,a,"/");
++			    printf "quality=%.0f\n", 100*a[1]/a[2] };
++			    $0 ~ /[ ]*Bit Rate/ { sub(/.*[:=]/,"",$2); printf("bitrate=%s\n", $2); }
++			    '`
++		eval "$out"
+ 	fi
+-	if [ "$bitrate" = "0" ] || [ "$quality" = "0" ] || [ -z "$bitrate" ] || [ -z "$quality"]; then
++	[ -n "$bitrate" ] || bitrate=0
++	[ -n "$quality" ] || quality=0
++	if [ "$bitrate" -gt 0 ] && [ "$quality" -gt 0 ]; then
++		printf "${ICON_WIFI}"; color b C k; printf "%s" "$bitrate"; color -; color C k; printf "%s" "$ICON_MBPS"; color -; color b C k; printf "%s" "$quality"; color -; color C k; printf "%s" "$PCT"; color --
++	else
+ 		rm -f "$BYOBU_RUN_DIR/status.$BYOBU_BACKEND/wifi_quality"*
+-		return
+ 	fi
+-	printf "${ICON_WIFI}"; color b C k; printf "%s" "$bitrate"; color -; color C k; printf "%s" "$ICON_MBPS"; color -; color b C k; printf "%s" "$quality"; color -; color C k; printf "%s" "$PCT"; color --
+ }
+ 
+ # vi: syntax=sh ts=4 noexpandtab

--- a/utils/byobu/patches/111-ensure-proc-mdstat-exists.patch
+++ b/utils/byobu/patches/111-ensure-proc-mdstat-exists.patch
@@ -1,0 +1,10 @@
+--- a/usr/lib/byobu/raid
++++ b/usr/lib/byobu/raid
+@@ -24,6 +24,7 @@ __raid_detail() {
+ }
+ 
+ __raid() {
++	[ -r /proc/mdstat ] || return
+ 	while read line; do
+ 		local p msg
+ 		# Errors in your raid

--- a/utils/byobu/patches/112-fix-session-regex.patch
+++ b/utils/byobu/patches/112-fix-session-regex.patch
@@ -1,0 +1,11 @@
+--- a/usr/lib/byobu/session
++++ b/usr/lib/byobu/session
+@@ -34,7 +34,7 @@ __session() {
+ 			fi
+ 		;;
+ 		screen)
+-			local count=$(screen -ls | grep "^        .*\)$" | wc -l)
++			local count=$(screen -ls | grep "^\s\+.*)$" | wc -l)
+ 			if [ $count -gt 1 ]; then
+ 				color u W k; printf "${ICON_SESSION}%S"; color --
+ 			else


### PR DESCRIPTION
Maintainer: me
Compile tested: armvirt-32/64 / malta-be / x86-generic, 2019-04-29 snapshot sdk; ar71xx, 18.06.2 sdk (with 8de8ff4f25e2660b8fe2f76ed4f00d550bc45ff2 applied)
Run tested: armvirt-64 / x86-generic (qemu), 2019-04-29 snapshot; ar71xx (GL-AR750), 18.06.2

Description:
From byobu's website:
Byobu is a GPLv3 open source text-based window manager and terminal multiplexer. It was originally designed to provide elegant enhancements to the otherwise functional, plain, practical GNU Screen, for the Ubuntu server distribution. Byobu now includes an enhanced profiles, convenient keybindings, configuration utilities, and toggle-able system status notifications for both the GNU Screen window manager and the more modern Tmux terminal multiplexer, and works on most Linux, BSD, and Mac distributions.

This includes byobu and its dependencies (libnewt, libslang2), based on their packages from the old packages feed:
* https://git.openwrt.org/?p=openwrt/svn-archive/packages.git;a=tree;f=libs/slang2
* https://git.openwrt.org/?p=openwrt/svn-archive/packages.git;a=tree;f=libs/newt
* https://git.openwrt.org/?p=openwrt/svn-archive/packages.git;a=tree;f=utils/byobu

The number of patches required for byobu is a bit high; the 0xx patches are things I think are OpenWrt-specific, 1xx patches are more general that I plan on submitting upstream. I'm hoping to have this reviewed/merged while I work on submitting changes to upstream.

Note that byobu also depends on either tmux or screen. I wasn't sure how to do this either-or dependency so I left it out; I can add it if possible.