### PR TITLE
transmission: Fix compilation under uClibc-ng

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=2.94
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master
@@ -134,14 +134,12 @@ CONFIGURE_ARGS += \
 	--without-systemd-daemon
 
 ifeq ($(BUILD_VARIANT),mbedtls)
-  CONFIGURE_ARGS += \
-	--with-crypto=polarssl
+  CONFIGURE_ARGS += --with-crypto=polarssl
   CONFIGURE_VARS += \
 	MBEDTLS_CFLAGS="-I$(STAGING_DIR)/usr/include/mbedtls" \
 	MBEDTLS_LIBS="-lmbedtls -lmbedcrypto"
 else
-  CONFIGURE_ARGS += \
-	--with-crypto=openssl
+  CONFIGURE_ARGS += --with-crypto=openssl
 endif
 
 define Package/transmission-daemon-openssl/install

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -65,9 +65,11 @@ transmission() {
 	config_get nice "$cfg" nice 0
 	config_get web_home "$cfg" 'web_home'
 
-	local MEM=$(sed -ne 's!^MemTotal:[[:space:]]*\([0-9]*\) kB$!\1!p' /proc/meminfo)
+	local MEM
+
+	MEM=$(sed -ne 's!^MemTotal:[[:space:]]*\([0-9]*\) kB$!\1!p' /proc/meminfo)
 	if test "$MEM" -gt 1;then
-		USE=$(expr $MEM \* $mem_percentage \* 10)
+		USE=$((MEM * mem_percentage * 10))
 	fi
 
 	config_file="$config_dir/settings.json"
@@ -78,7 +80,7 @@ transmission() {
 		[ -z "$user" ] || chown -R "$user:$group" $config_dir
 	}
 
-	[ "$config_overwrite" == 0 ] || {
+	[ "$config_overwrite" = 0 ] || {
 
 		echo "{" > $config_file
 

--- a/net/transmission/patches/070-uClibc-ng-since-1.0.18-has-sys-quota.h-synced-with-G.patch
+++ b/net/transmission/patches/070-uClibc-ng-since-1.0.18-has-sys-quota.h-synced-with-G.patch
@@ -1,0 +1,25 @@
+From e24f7c6653ec385c8af7eb6499d924994e78e42d Mon Sep 17 00:00:00 2001
+From: Waldemar Brodkorb <wbx@uclibc-ng.org>
+Date: Wed, 19 Oct 2016 19:33:35 +0200
+Subject: [PATCH] uClibc-ng since 1.0.18 has sys/quota.h synced with GNU libc
+
+---
+ libtransmission/platform-quota.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libtransmission/platform-quota.c b/libtransmission/platform-quota.c
+index e7d1f6d4f..bb1f9d9b9 100644
+--- a/libtransmission/platform-quota.c
++++ b/libtransmission/platform-quota.c
+@@ -285,7 +285,7 @@ getquota (const char * device)
+       spaceused = (int64_t) dq.dqb_curblocks >> 1;
+ #elif defined(__APPLE__)
+       spaceused = (int64_t) dq.dqb_curbytes;
+-#elif defined(__UCLIBC__)
++#elif defined (__UCLIBC__) && !TR_UCLIBC_CHECK_VERSION (1, 0, 18)
+       spaceused = (int64_t) btodb(dq.dqb_curblocks);
+ #elif defined(__sun) || (defined(_LINUX_QUOTA_VERSION) && _LINUX_QUOTA_VERSION < 2)
+       spaceused = (int64_t) dq.dqb_curblocks >> 1;
+-- 
+2.17.1
+


### PR DESCRIPTION
Upstream has a patch for this dated 2016.

Also ran the init script through shellcheck.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me
Compile tested: ramips arc700
Run tested: GnuBee PC1

edit: https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/transmission/openssl/compile.txt