### PR TITLE
tgt: Fix compilation with uClibc-ng

### DIFF
--- a/net/tgt/Makefile
+++ b/net/tgt/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tgt
 PKG_VERSION:=1.0.76
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fujita/tgt/tar.gz/v$(PKG_VERSION)?

--- a/net/tgt/patches/200-uclib-ng-compat.patch
+++ b/net/tgt/patches/200-uclib-ng-compat.patch
@@ -1,0 +1,19 @@
+--- a/usr/iscsi/iscsi_tcp.c
++++ b/usr/iscsi/iscsi_tcp.c
+@@ -26,6 +26,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <unistd.h>
++#include <malloc.h>
+ #include <arpa/inet.h>
+ #include <netinet/in.h>
+ #include <netinet/tcp.h>
+@@ -578,7 +579,7 @@ static void iscsi_tcp_free_task(struct iscsi_task *task)
+ 
+ static void *iscsi_tcp_alloc_data_buf(struct iscsi_connection *conn, size_t sz)
+ {
+-	return valloc(sz);
++	return memalign(sysconf(_SC_PAGESIZE),sz);
+ }
+ 
+ static void iscsi_tcp_free_data_buf(struct iscsi_connection *conn, void *buf)


### PR DESCRIPTION
valloc is deprecated and not compiled in. Switched to functions suggested
in the valloc man page.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mstorchak 
Compile tested: arc700

Submitted upstream. ARC will not compile this for different reasons (linking) but will work elsewhere.

edit: https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/tgt/compile.txt
