### PR TITLE
device-observatory: Fix compilation with uClibc-ng

### DIFF
--- a/utils/device-observatory/Makefile
+++ b/utils/device-observatory/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=device-observatory
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://codeload.github.com/mwarning/device-observatory/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/utils/device-observatory/patches/010-uClibc-ng.patch
+++ b/utils/device-observatory/patches/010-uClibc-ng.patch
@@ -1,0 +1,22 @@
+--- a/src/parse_ether.c
++++ b/src/parse_ether.c
+@@ -21,10 +21,18 @@
+ #include "parse_ether.h"
+ 
+ /* tcpdump header (ether.h) defines ETHER_HDRLEN) */
+-#ifndef ETHER_HDRLEN 
++#ifndef ETHER_HDRLEN
+ #define ETHER_HDRLEN 14
+ #endif
+ 
++/* uClibc-ng compatibility */
++#ifndef IPPROTO_BEETPH
++#define IPPROTO_BEETPH	94
++#endif
++
++#ifndef IPPROTO_MPLS
++#define IPPROTO_MPLS	137
++#endif
+ 
+ const char *ip_protcol_str(int p)
+ {


### PR DESCRIPTION
Two protocol definitions are missing. Took values from Musl.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mwarning 
Compile tested: arc700