### PR TITLE
dmapd: Fix compilation under uClibc-ng

### DIFF
--- a/net/dmapd/Makefile
+++ b/net/dmapd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dmapd
 PKG_VERSION:=0.0.79
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 

--- a/net/dmapd/patches/010-uClibc-ng.patch
+++ b/net/dmapd/patches/010-uClibc-ng.patch
@@ -1,0 +1,10 @@
+--- a/src/dmapd.c
++++ b/src/dmapd.c
+@@ -29,6 +29,7 @@
+ #include <grp.h>
+ #include <glib.h>
+ #include <libdmapsharing/dmap.h>
++#include <sys/stat.h>
+ 
+ #include "dmapd-dmap-container-record.h"
+ #include "dmapd-dmap-container-db.h"


### PR DESCRIPTION
Missing header.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
Compile tested: arc700

edit: https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/dmapd/compile.txt