### PR TITLE
iodine: Fix compilation with uClibc-ng

### DIFF
--- a/net/iodine/Makefile
+++ b/net/iodine/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iodine
 PKG_VERSION:=0.7.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://code.kryo.se/iodine/

--- a/net/iodine/patches/100-musl-compatibility.patch
+++ b/net/iodine/patches/100-musl-compatibility.patch
@@ -20,7 +20,7 @@ index 2715979..5f0e370 100644
  
  /* daemon(3) exists only in 4.4BSD or later, and in GNU libc */
 -#if !defined(ANDROID) && !defined(WINDOWS32) && !(defined(BSD) && (BSD >= 199306)) && !defined(__GLIBC__)
-+#ifdef __UCLIBC__
++#ifdef __NO_DAEMON__
  static int daemon(int nochdir, int noclose)
  {
   	int fd, i;


### PR DESCRIPTION
daemon is supported now.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mstorchak 
Compile tested: arc700

https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/iodine/compile.txt