### PR TITLE
zstd: Fix compilation on uClibc-ng

### DIFF
--- a/utils/zstd/Makefile
+++ b/utils/zstd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zstd
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/facebook/zstd/tar.gz/v$(PKG_VERSION)?

--- a/utils/zstd/patches/010-uClibc-ng.patch
+++ b/utils/zstd/patches/010-uClibc-ng.patch
@@ -1,0 +1,11 @@
+--- a/programs/fileio.c
++++ b/programs/fileio.c
+@@ -175,7 +175,7 @@ static void clearHandler(void)
+ 
+ #if !defined(BACKTRACE_ENABLE)
+ /* automatic detector : backtrace enabled by default on linux+glibc and osx */
+-#  if (defined(__linux__) && defined(__GLIBC__)) \
++#  if (defined(__linux__) && (defined(__GLIBC__) && !defined(__UCLIBC__))) \
+      || (defined(__APPLE__) && defined(__MACH__))
+ #    define BACKTRACE_ENABLE 1
+ #  else


### PR DESCRIPTION
uClibc-ng defines __GLIBCC__ and does not compile in execinfo.h. Disable
it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ammubhave 
Compile tested: arc700