### PR TITLE
libjpeg: Install pkg-config metadata file in Build/InstallDev

### DIFF
--- a/libs/libjpeg/Makefile
+++ b/libs/libjpeg/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=jpeg
 PKG_VERSION:=9c
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)src.v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.ijg.org/files
@@ -74,6 +74,8 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/j{config,error,morecfg}.h $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libjpeg.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libjpeg.pc $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/libjpeg/install


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: armvirt-32, 2019-04-29 snapshot sdk
Run tested: none (manually examined $(STAGING_DIR)/usr/lib/pkgconfig)

Description:
Some programs use pkg-config to discover installed libraries.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>