### PR TITLE
Update Makefile

### DIFF
--- a/net/rpcbind/Makefile
+++ b/net/rpcbind/Makefile
@@ -49,7 +49,8 @@ endef
 CONFIGURE_ARGS += \
 	--with-rpcuser=rpc \
 	--without-systemdsystemunitdir \
-	--enable-warmstarts
+	--enable-warmstarts \
+	--enable-rmtcalls
 
 ifeq ($(CONFIG_RPCBIND_LIBWRAP),y)
 	CONFIGURE_ARGS += --enable-libwrap


### PR DESCRIPTION
Maintainer: @ja-pa 
Compile tested: branch master and openwrt-18.06
Run tested: i686, OpenWrt SNAPSHOT, r9915-d6643aca34, OpenWrt 18.06-SNAPSHOT, r7749-e0505cc018 -  tests done.

Description:
Add '--enable-rmtcalls' to 'CONFIGURE_ARGS', otherwise clients can not discover the NFS server.