### PR TITLE
tiff: Install pkg-config metadata file in Build/InstallDev

### DIFF
--- a/libs/tiff/Makefile
+++ b/libs/tiff/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tiff
 PKG_VERSION:=4.0.10
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.osgeo.org/libtiff
@@ -84,8 +84,9 @@ define Build/InstallDev/hxx
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/{lib,include}
+	$(INSTALL_DIR) $(1)/usr/{lib,include} $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc $(1)/usr/lib/pkgconfig/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
 	$(if $(CONFIG_PACKAGE_libtiffxx), $(call Build/InstallDev/hxx,$(1)))
 endef


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: armvirt-32, 2019-04-29 snapshot sdk
Run tested: none (manually examined $(STAGING_DIR)/usr/lib/pkgconfig)

Description:
Some programs use pkg-config to discover installed libraries.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>