### PR TITLE
xz: Use relative paths in pkg-config metadata file

### DIFF
--- a/utils/xz/Makefile
+++ b/utils/xz/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xz
 PKG_VERSION:=5.2.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/lzmautils

--- a/utils/xz/patches/001-relative-pkg-config-paths.patch
+++ b/utils/xz/patches/001-relative-pkg-config-paths.patch
@@ -1,0 +1,13 @@
+--- a/src/liblzma/liblzma.pc.in
++++ b/src/liblzma/liblzma.pc.in
+@@ -7,8 +7,8 @@
+ 
+ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+-libdir=@libdir@
+-includedir=@includedir@
++libdir=${exec_prefix}/lib
++includedir=${prefix}/include
+ 
+ Name: liblzma
+ Description: General purpose data compression library


### PR DESCRIPTION
Maintainer: none
Compile tested: armvirt-32, 2019-04-29 snapshot sdk
Run tested: none (manually examined $(STAGING_DIR)/usr/lib/pkgconfig/liblzma.pc)

Description:
By default, the liblzma pkg-config file (liblzma.pc) is generated with absolute paths, which $(STAGING_DIR_HOST)/bin/pkg-config is unable to override.

This patches the file to use paths relative to `${prefix}` and `${exec_prefix}`.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>