### PR TITLE
(18.06) mariadb: bump to 10.1.39

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
-PKG_VERSION:=10.1.38
+PKG_VERSION:=10.1.39
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -18,10 +18,12 @@ PKG_SOURCE_URL := \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/$(PKG_NAME)-$(PKG_VERSION)/source \
 	https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
 
-PKG_HASH:=caf1f4fc237d143343995b6625375aef911dfc366433645d400727e7063f077f
+PKG_HASH:=6ebaa9424707b8f45ad45eaad37df0d39e77fc965309786d298d6baf3bd93a7e
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
+
+PKG_CPE_ID:=cpe:/a:mariadb:mariadb
 
 HOST_BUILD_PARALLEL:=1
 PKG_BUILD_PARALLEL:=1

--- a/utils/mariadb/patches/100-fix_hostname.patch
+++ b/utils/mariadb/patches/100-fix_hostname.patch
@@ -1,6 +1,6 @@
 --- a/scripts/mysql_install_db.sh
 +++ b/scripts/mysql_install_db.sh
-@@ -394,7 +394,7 @@ fi
+@@ -398,7 +398,7 @@ fi
  
  
  # Try to determine the hostname


### PR DESCRIPTION
Fixes CVE-2019-2614 and CVE-2019-2627.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: ar71xx
Run tested: ar71xx, dir-825-c1, usual stuff tested, creating tables, insertion, extraction.
Description: Security bump.

Thanks for applying!

Kind regards,
Seb
