### PR TITLE
(17.01) libxslt: backport patch for CVE-2019-11068

### DIFF
--- a/libs/libxslt/Makefile
+++ b/libs/libxslt/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxslt
 PKG_VERSION:=1.1.28
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \

--- a/libs/libxslt/patches/0009-Fix-for-type-confusion-in-preprocessing-attributes.patch
+++ b/libs/libxslt/patches/0009-Fix-for-type-confusion-in-preprocessing-attributes.patch
@@ -10,11 +10,9 @@ its namespace
  libxslt/preproc.c | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
-diff --git a/libxslt/preproc.c b/libxslt/preproc.c
-index 0eb80a0..7f69325 100644
 --- a/libxslt/preproc.c
 +++ b/libxslt/preproc.c
-@@ -2249,7 +2249,8 @@ xsltStylePreCompute(xsltStylesheetPtr style, xmlNodePtr inst) {
+@@ -2245,7 +2245,8 @@ xsltStylePreCompute(xsltStylesheetPtr st
  	} else if (IS_XSLT_NAME(inst, "attribute")) {
  	    xmlNodePtr parent = inst->parent;
  
@@ -24,6 +22,3 @@ index 0eb80a0..7f69325 100644
  		((parent->ns != inst->ns) &&
  		 (!xmlStrEqual(parent->ns->href, inst->ns->href))) ||
  		(!xmlStrEqual(parent->name, BAD_CAST "attribute-set"))) {
--- 
-2.8.1
-

--- a/libs/libxslt/patches/0012-Fix-xsltNumberFormatGetMultipleLevel.patch
+++ b/libs/libxslt/patches/0012-Fix-xsltNumberFormatGetMultipleLevel.patch
@@ -21,11 +21,9 @@ insignificant bug.
  create mode 100644 tests/general/bug-186.out
  create mode 100644 tests/general/bug-186.xsl
 
-diff --git a/libxslt/numbers.c b/libxslt/numbers.c
-index e3209e0..184ee6f 100644
 --- a/libxslt/numbers.c
 +++ b/libxslt/numbers.c
-@@ -532,6 +532,43 @@ xsltNumberFormatInsertNumbers(xsltNumberDataPtr data,
+@@ -532,6 +532,43 @@ xsltNumberFormatInsertNumbers(xsltNumber
  }
  
  static int
@@ -69,7 +67,7 @@ index e3209e0..184ee6f 100644
  xsltNumberFormatGetAnyLevel(xsltTransformContextPtr context,
  			    xmlNodePtr node,
  			    xsltCompMatchPtr countPat,
-@@ -562,21 +599,8 @@ xsltNumberFormatGetAnyLevel(xsltTransformContextPtr context,
+@@ -564,21 +601,8 @@ xsltNumberFormatGetAnyLevel(xsltTransfor
  
      while (cur != NULL) {
  	/* process current node */
@@ -93,7 +91,7 @@ index e3209e0..184ee6f 100644
  	if ((fromPat != NULL) &&
  	    xsltTestCompMatchList(context, cur, fromPat)) {
  	    break; /* while */
-@@ -633,30 +657,18 @@ xsltNumberFormatGetMultipleLevel(xsltTransformContextPtr context,
+@@ -637,30 +661,18 @@ xsltNumberFormatGetMultipleLevel(xsltTra
  		xsltTestCompMatchList(context, ancestor, fromPat))
  		break; /* for */
  
@@ -132,9 +130,6 @@ index e3209e0..184ee6f 100644
  		}
  		array[amount++] = (double)cnt;
  		if (amount >= max)
-diff --git a/tests/docs/bug-186.xml b/tests/docs/bug-186.xml
-new file mode 100644
-index 0000000..424db6b
 --- /dev/null
 +++ b/tests/docs/bug-186.xml
 @@ -0,0 +1,4 @@
@@ -142,9 +137,6 @@ index 0000000..424db6b
 +<foo/>
 +<bar/>
 +</top>
-diff --git a/tests/general/bug-186.out b/tests/general/bug-186.out
-new file mode 100644
-index 0000000..01a59f8
 --- /dev/null
 +++ b/tests/general/bug-186.out
 @@ -0,0 +1,5 @@
@@ -153,9 +145,6 @@ index 0000000..01a59f8
 +1111
 +1111
 +
-diff --git a/tests/general/bug-186.xsl b/tests/general/bug-186.xsl
-new file mode 100644
-index 0000000..9c491dd
 --- /dev/null
 +++ b/tests/general/bug-186.xsl
 @@ -0,0 +1,7 @@
@@ -166,6 +155,3 @@ index 0000000..9c491dd
 +  </xsl:for-each>
 + </xsl:template>
 +</xsl:stylesheet>
--- 
-2.8.1
-

--- a/libs/libxslt/patches/0017-Fix-double-free-in-libexslt-hash-functions.patch
+++ b/libs/libxslt/patches/0017-Fix-double-free-in-libexslt-hash-functions.patch
@@ -14,11 +14,9 @@ https://bugzilla.gnome.org/show_bug.cgi?id=765271
  tests/exslt/crypto/hash.1.xml |  5 +++++
  3 files changed, 10 insertions(+), 12 deletions(-)
 
-diff --git a/libexslt/crypto.c b/libexslt/crypto.c
-index 6aa9dd2..e13db8b 100644
 --- a/libexslt/crypto.c
 +++ b/libexslt/crypto.c
-@@ -499,11 +499,8 @@ exsltCryptoMd4Function (xmlXPathParserContextPtr ctxt, int nargs) {
+@@ -498,11 +498,8 @@ exsltCryptoMd4Function (xmlXPathParserCo
      unsigned char hex[MD5_DIGEST_LENGTH * 2 + 1];
  
      str_len = exsltCryptoPopString (ctxt, nargs, &str);
@@ -31,7 +29,7 @@ index 6aa9dd2..e13db8b 100644
  
      PLATFORM_HASH (ctxt, PLATFORM_MD4, (const char *) str, str_len,
  		   (char *) hash);
-@@ -532,11 +529,8 @@ exsltCryptoMd5Function (xmlXPathParserContextPtr ctxt, int nargs) {
+@@ -531,11 +528,8 @@ exsltCryptoMd5Function (xmlXPathParserCo
      unsigned char hex[MD5_DIGEST_LENGTH * 2 + 1];
  
      str_len = exsltCryptoPopString (ctxt, nargs, &str);
@@ -44,7 +42,7 @@ index 6aa9dd2..e13db8b 100644
  
      PLATFORM_HASH (ctxt, PLATFORM_MD5, (const char *) str, str_len,
  		   (char *) hash);
-@@ -565,11 +559,8 @@ exsltCryptoSha1Function (xmlXPathParserContextPtr ctxt, int nargs) {
+@@ -564,11 +558,8 @@ exsltCryptoSha1Function (xmlXPathParserC
      unsigned char hex[SHA1_DIGEST_LENGTH * 2 + 1];
  
      str_len = exsltCryptoPopString (ctxt, nargs, &str);
@@ -57,6 +55,3 @@ index 6aa9dd2..e13db8b 100644
  
      PLATFORM_HASH (ctxt, PLATFORM_SHA1, (const char *) str, str_len,
  		   (char *) hash);
--- 
-2.8.1
-

--- a/libs/libxslt/patches/0020-Fix-heap-overread-in-xsltFormatNumberConversion.patch
+++ b/libs/libxslt/patches/0020-Fix-heap-overread-in-xsltFormatNumberConversion.patch
@@ -12,11 +12,9 @@ Found with afl-fuzz and ASan.
  libxslt/numbers.c | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
-diff --git a/libxslt/numbers.c b/libxslt/numbers.c
-index d1549b4..e78c46b 100644
 --- a/libxslt/numbers.c
 +++ b/libxslt/numbers.c
-@@ -1090,7 +1090,8 @@ xsltFormatNumberConversion(xsltDecimalFormatPtr self,
+@@ -1109,7 +1109,8 @@ xsltFormatNumberConversion(xsltDecimalFo
      }
  
      /* We have finished the integer part, now work on fraction */
@@ -26,6 +24,3 @@ index d1549b4..e78c46b 100644
          format_info.add_decimal = TRUE;
  	the_format += xsltUTF8Size(the_format);	/* Skip over the decimal */
      }
--- 
-2.10.2
-

--- a/libs/libxslt/patches/0021-Check-for-integer-overflow-in-xsltAddTextString.patch
+++ b/libs/libxslt/patches/0021-Check-for-integer-overflow-in-xsltAddTextString.patch
@@ -14,11 +14,9 @@ https://crbug.com/676623
  libxslt/xsltInternals.h |  4 ++--
  2 files changed, 24 insertions(+), 5 deletions(-)
 
-diff --git a/libxslt/transform.c b/libxslt/transform.c
-index 519133fc..02bff34a 100644
 --- a/libxslt/transform.c
 +++ b/libxslt/transform.c
-@@ -813,13 +813,32 @@ xsltAddTextString(xsltTransformContextPtr ctxt, xmlNodePtr target,
+@@ -718,13 +718,32 @@ xsltAddTextString(xsltTransformContextPt
          return(target);
  
      if (ctxt->lasttext == target->content) {
@@ -54,11 +52,9 @@ index 519133fc..02bff34a 100644
  	    newbuf = (xmlChar *) xmlRealloc(target->content,size);
  	    if (newbuf == NULL) {
  		xsltTransformError(ctxt, NULL, target,
-diff --git a/libxslt/xsltInternals.h b/libxslt/xsltInternals.h
-index 060b1783..5ad17719 100644
 --- a/libxslt/xsltInternals.h
 +++ b/libxslt/xsltInternals.h
-@@ -1754,8 +1754,8 @@ struct _xsltTransformContext {
+@@ -1752,8 +1752,8 @@ struct _xsltTransformContext {
       * Speed optimization when coalescing text nodes
       */
      const xmlChar  *lasttext;		/* last text node content */
@@ -69,6 +65,3 @@ index 060b1783..5ad17719 100644
      /*
       * Per Context Debugging
       */
--- 
-2.11.0
-

--- a/libs/libxslt/patches/0022-fix-cve-2019-11068.patch
+++ b/libs/libxslt/patches/0022-fix-cve-2019-11068.patch
@@ -1,0 +1,109 @@
+From e03553605b45c88f0b4b2980adfbbb8f6fca2fd6 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Sun, 24 Mar 2019 09:51:39 +0100
+Subject: [PATCH] Fix security framework bypass
+
+xsltCheckRead and xsltCheckWrite return -1 in case of error but callers
+don't check for this condition and allow access. With a specially
+crafted URL, xsltCheckRead could be tricked into returning an error
+because of a supposedly invalid URL that would still be loaded
+succesfully later on.
+
+Fixes #12.
+
+Thanks to Felix Wilhelm for the report.
+---
+ libxslt/documents.c | 18 ++++++++++--------
+ libxslt/imports.c   |  9 +++++----
+ libxslt/transform.c |  9 +++++----
+ libxslt/xslt.c      |  9 +++++----
+ 4 files changed, 25 insertions(+), 20 deletions(-)
+
+--- a/libxslt/documents.c
++++ b/libxslt/documents.c
+@@ -296,10 +296,11 @@ xsltLoadDocument(xsltTransformContextPtr
+ 	int res;
+ 
+ 	res = xsltCheckRead(ctxt->sec, ctxt, URI);
+-	if (res == 0) {
+-	    xsltTransformError(ctxt, NULL, NULL,
+-		 "xsltLoadDocument: read rights for %s denied\n",
+-			     URI);
++	if (res <= 0) {
++            if (res == 0)
++                xsltTransformError(ctxt, NULL, NULL,
++                     "xsltLoadDocument: read rights for %s denied\n",
++                                 URI);
+ 	    return(NULL);
+ 	}
+     }
+@@ -372,10 +373,11 @@ xsltLoadStyleDocument(xsltStylesheetPtr
+ 	int res;
+ 
+ 	res = xsltCheckRead(sec, NULL, URI);
+-	if (res == 0) {
+-	    xsltTransformError(NULL, NULL, NULL,
+-		 "xsltLoadStyleDocument: read rights for %s denied\n",
+-			     URI);
++	if (res <= 0) {
++            if (res == 0)
++                xsltTransformError(NULL, NULL, NULL,
++                     "xsltLoadStyleDocument: read rights for %s denied\n",
++                                 URI);
+ 	    return(NULL);
+ 	}
+     }
+--- a/libxslt/imports.c
++++ b/libxslt/imports.c
+@@ -131,10 +131,11 @@ xsltParseStylesheetImport(xsltStylesheet
+ 	int secres;
+ 
+ 	secres = xsltCheckRead(sec, NULL, URI);
+-	if (secres == 0) {
+-	    xsltTransformError(NULL, NULL, NULL,
+-		 "xsl:import: read rights for %s denied\n",
+-			     URI);
++	if (secres <= 0) {
++            if (secres == 0)
++                xsltTransformError(NULL, NULL, NULL,
++                     "xsl:import: read rights for %s denied\n",
++                                 URI);
+ 	    goto error;
+ 	}
+     }
+--- a/libxslt/transform.c
++++ b/libxslt/transform.c
+@@ -3416,10 +3416,11 @@ xsltDocumentElem(xsltTransformContextPtr
+      */
+     if (ctxt->sec != NULL) {
+ 	ret = xsltCheckWrite(ctxt->sec, ctxt, filename);
+-	if (ret == 0) {
+-	    xsltTransformError(ctxt, NULL, inst,
+-		 "xsltDocumentElem: write rights for %s denied\n",
+-			     filename);
++	if (ret <= 0) {
++            if (ret == 0)
++                xsltTransformError(ctxt, NULL, inst,
++                     "xsltDocumentElem: write rights for %s denied\n",
++                                 filename);
+ 	    xmlFree(URL);
+ 	    xmlFree(filename);
+ 	    return;
+--- a/libxslt/xslt.c
++++ b/libxslt/xslt.c
+@@ -6729,10 +6729,11 @@ xsltParseStylesheetFile(const xmlChar* f
+ 	int res;
+ 
+ 	res = xsltCheckRead(sec, NULL, filename);
+-	if (res == 0) {
+-	    xsltTransformError(NULL, NULL, NULL,
+-		 "xsltParseStylesheetFile: read rights for %s denied\n",
+-			     filename);
++	if (res <= 0) {
++            if (res == 0)
++                xsltTransformError(NULL, NULL, NULL,
++                     "xsltParseStylesheetFile: read rights for %s denied\n",
++                                 filename);
+ 	    return(NULL);
+ 	}
+     }


### PR DESCRIPTION
Refreshed existing patches.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @jslachta 
Compile tested: ar71xx, 17.01
Run tested: I don't run anything that depends on this lib. But this is a backport from master. Should be fine.

Description:
Add patch for CVE.