### PR TITLE
irqbalance: add init script

### DIFF
--- a/utils/irqbalance/Makefile
+++ b/utils/irqbalance/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=irqbalance
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_PROTO:=git
@@ -47,6 +47,8 @@ CONFIGURE_ARGS+= \
 define Package/irqbalance/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/irqbalance $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/irqbalance.init $(1)/etc/init.d/irqbalance
 endef
 
 $(eval $(call BuildPackage,irqbalance))

--- a/utils/irqbalance/files/irqbalance.init
+++ b/utils/irqbalance/files/irqbalance.init
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+
+START=11
+USE_PROCD=1
+
+start_service() {
+  procd_open_instance "irqbalance"
+  procd_set_param command /usr/sbin/irqbalance -f
+  procd_set_param respawn
+  procd_close_instance
+}
+


### PR DESCRIPTION
Maintainer: @hnyman 
Compile tested: ZyXEL NBG6817 (ipq806x), OpenWrt SNAPSHOT r9919-08802d93e2 
Run tested: ZyXEL NBG6817 (ipq806x), OpenWrt SNAPSHOT r9919-08802d93e2: irqbalance starts on boot

Description:
Add init script for irqbalance