### PR TITLE
libndpi: update to 2.8.0

### DIFF
--- a/libs/libndpi/Makefile
+++ b/libs/libndpi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libndpi
-PKG_VERSION:=2.6
+PKG_VERSION:=2.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ntop/nDPI/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=efdfb68940385b18079920330528978765dc2a90c8163d10f63301bddadbf91e
+PKG_HASH:=f98def4d0e43818317b20e2887ce500b2d6a5a9c8ddb28cf57ae51caae0f33cc
 PKG_BUILD_DIR:=$(BUILD_DIR)/nDPI-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Banglang Huang <banglang.huang@foxmail.com>
@@ -21,9 +21,9 @@ PKG_LICENSE:=LGPLv3
 PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
+PKG_REMOVE_FILES:=autogen.sh
 PKG_BUILD_DEPENDS:=libpcap
 PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
@@ -41,36 +41,37 @@ define Package/libndpi/description
   Based on OpenDPI it includes ntop extensions.
 endef
 
-define Build/Configure
-	( cd $(PKG_BUILD_DIR); ./autogen.sh )
-	$(call Build/Configure/Default)
+define Build/Prepare
+	$(PKG_UNPACK)
+	$(Build/Patch)
+	mv $(PKG_BUILD_DIR)/configure.seed $(PKG_BUILD_DIR)/configure.ac
+	$(SED) "s/@NDPI_MAJOR@/2/g" \
+		-e "s/@NDPI_MINOR@/8/g" \
+		-e "s/@NDPI_PATCH@/0/g" \
+		-e "s/@NDPI_VERSION_SHORT@/2.8.0/g" \
+		$(PKG_BUILD_DIR)/configure.ac
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include/
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/local/include/ndpi \
-		$(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/include/ndpi
+	$(CP) $(PKG_BUILD_DIR)/src/include/*.h \
+		$(1)/usr/include/ndpi/
 
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/local/lib/libndpi.so* \
+	$(CP) $(PKG_BUILD_DIR)/src/lib/libndpi.so* \
 		$(1)/usr/lib/
 
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/libdata/pkgconfig/libndpi.pc \
+	$(CP) $(PKG_BUILD_DIR)/libndpi.pc \
 		$(1)/usr/lib/pkgconfig/
 endef
 
 define Package/libndpi/install
 	$(INSTALL_DIR) $(1)/usr/lib/
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/local/lib/libndpi.so* \
+	$(CP) $(PKG_BUILD_DIR)/src/lib/libndpi.so* \
 		$(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/bin/
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/local/bin/ndpiReader \
+	$(CP) $(PKG_BUILD_DIR)/example/ndpiReader \
 		$(1)/usr/bin/
 endef
 


### PR DESCRIPTION
Signed-off-by: Toni Uhlig <matzeton@googlemail.com>

Maintainer: Banglang Huang <banglang.huang@foxmail.com>
Compile tested: x86_64, debian-stable, OpenWrt SNAPSHOT, r9640+8-e7a7749a3c
Run tested: mvebu, linksys3200ac, OpenWrt SNAPSHOT, r9640+8-e7a7749a3c

Description:
The nDPI autogen.sh is broken and can lead to configure/compile issues. Fixed.
Also removed PKG_INSTALL since it produces invalid symlinks to \*.so\* shlibs.

(autogen.sh does not use OpenWrt host-autotools)