### PR TITLE
ibrdtnd: Fix compilation with uClibc-ng

### DIFF
--- a/net/ibrdtnd/Makefile
+++ b/net/ibrdtnd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ibrdtnd
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.ibr.cs.tu-bs.de/projects/ibr-dtn/releases

--- a/net/ibrdtnd/patches/010-no-const.patch
+++ b/net/ibrdtnd/patches/010-no-const.patch
@@ -1,0 +1,33 @@
+--- a/src/routing/SchedulingBundleIndex.cpp
++++ b/src/routing/SchedulingBundleIndex.cpp
+@@ -28,7 +28,7 @@ namespace dtn
+ 		void SchedulingBundleIndex::remove(const dtn::data::BundleID &id)
+ 		{
+ 			ibrcommon::MutexLock l(_index_mutex);
+-			for (priority_index::const_iterator iter = _priority_index.begin(); iter != _priority_index.end(); ++iter)
++			for (priority_index::iterator iter = _priority_index.begin(); iter != _priority_index.end(); ++iter)
+ 			{
+ 				const dtn::data::MetaBundle &b = (*iter);
+ 				if (id == (const dtn::data::BundleID&)b) {
+--- a/src/storage/MemoryBundleStorage.cpp
++++ b/src/storage/MemoryBundleStorage.cpp
+@@ -217,7 +217,7 @@ namespace dtn
+ 			ibrcommon::MutexLock l(_bundleslock);
+ 
+ 			// search for the bundle in the bundle list
+-			const bundle_list::const_iterator iter = find(_bundles.begin(), _bundles.end(), id);
++			const bundle_list::iterator iter = find(_bundles.begin(), _bundles.end(), id);
+ 
+ 			// if no bundle was found throw an exception
+ 			if (iter == _bundles.end()) throw NoBundleFoundException();
+--- a/src/storage/MetaStorage.cpp
++++ b/src/storage/MetaStorage.cpp
+@@ -66,7 +66,7 @@ namespace dtn
+ 		{
+ 			std::set<dtn::data::EID> ret;
+ 
+-			for (dtn::data::BundleList::const_iterator iter = begin(); iter != end(); ++iter)
++			for (const_iterator iter = begin(); iter != end(); ++iter)
+ 			{
+ 				const dtn::data::MetaBundle &bundle = (*iter);
+ 

--- a/net/ibrdtnd/patches/020-uClibc-ng.patch
+++ b/net/ibrdtnd/patches/020-uClibc-ng.patch
@@ -1,0 +1,20 @@
+--- a/src/security/SecurityCertificateManager.cpp
++++ b/src/security/SecurityCertificateManager.cpp
+@@ -23,6 +23,7 @@
+ #include "Configuration.h"
+ 
+ #include <cstdlib>
++#include <cstring>
+ 
+ #include <ibrcommon/Logger.h>
+ #include <ibrcommon/ssl/TLSStream.h>
+--- a/src/security/SecurityManager.cpp
++++ b/src/security/SecurityManager.cpp
+@@ -28,6 +28,7 @@
+ #include <ibrdtn/security/PayloadConfidentialBlock.h>
+ #include <ibrdtn/security/ExtensionSecurityBlock.h>
+ #include <ibrcommon/Logger.h>
++#include <cstring>
+ 
+ #ifdef __DEVELOPMENT_ASSERTIONS__
+ #include <cassert>


### PR DESCRIPTION
For some reason, several C++ headers are not included. Include them.

Also added a const fix.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @morgenroth 
Compile tested: arc700