### PR TITLE
temperusb: package update to 2.3

### DIFF
--- a/utils/temperusb/Makefile
+++ b/utils/temperusb/Makefile
@@ -6,16 +6,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=temperusb
-PKG_VERSION:=2.0
+PKG_VERSION:=2.3
 PKG_RELEASE:=1
 PKG_CONFIG_DEPENDS:=libusb
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/temperv14-$(PKG_VERSION)
 PKG_SOURCE_URL:=https://codeload.github.com/Arduous/temperv14/tar.gz/v${PKG_VERSION}?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=a8f4ef76a2def5a2e3ec351828a042ce8f7a0963eaa6d9d8ce0c8313e2b54526
-PKG_LICENSE:=BSD-1-Clause
-PKG_LICENSE_FILES:=temperv14.c
+PKG_HASH:=3319026e0d5c42aebe9a75a23593f181c29d0ec9d544fac90b7ba886269ff246
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_MAINTAINER := Samuel Progin <samuel.progin@gmail.com>
 
@@ -30,12 +30,12 @@ endef
 
 define Package/temperusb/description
   RDing TEMPer v1.4 USB thermometer are cheap devices that can be sourced everywhere on
-  the Internet. This package allow to operate them from user space.
+  the Internet. This package allows to operate them from user space.
 endef
 
 define Package/temperusb/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/temperv14 $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/temperusb $(1)/usr/bin
 endef
 
 $(eval $(call BuildPackage,temperusb))


### PR DESCRIPTION
Signed-off-by: Samuel Progin <samuel.progin@gmail.com>

Maintainer: me / @Arduous 
Compile tested: 
- mips_24kc ar71xx/generic
- mipsel_mips32 brcm47xx/generic
Run tested: (put here arch, model, OpenWrt version, tests done)
- mips_24kc ar71xx/generic OpenWrt 18.06.0 r7188-b0b5c64c22 execution of the binary with a device and verify that a correct reading is retrieved
- mipsel_mips32 brcm47xx/generic OpenWrt SNAPSHOT r9916-a9190ee3a4 execution of the binary with a device and verify that a correct reading is retrieved

Description: Package is updated to the latest available one. Update on the package itself are:
- correction of a deprecated call to libusb-1.0
- revamp of Makefile to streamline the production of executable
- revamp of the license and history organisation
- pretty printing
