### PR TITLE
libimobiledevice: Remove reference to python-package.mk

### DIFF
--- a/libs/libimobiledevice/Makefile
+++ b/libs/libimobiledevice/Makefile
@@ -27,7 +27,6 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
-include ../../lang/python/python-package.mk
 
 define Package/libimobiledevice/Default
   TITLE:=A library that talks to Apple devices.


### PR DESCRIPTION
Maintainer: @lukbaj 
Compile tested: armvirt-32, 2019-04-29 snapshot sdk
Run tested: none

Description:
Since no Python packages are produced by this package, including python-package.mk is unnecessary.

This removes the reference to python-package.mk. (`PKG_RELEASE` is unchanged as this should have no effect on the build.)

Signed-off-by: Jeffery To <jeffery.to@gmail.com>