### PR TITLE
uwsgi-cgi: Remove reference to python-package.mk

### DIFF
--- a/net/uwsgi-cgi/Makefile
+++ b/net/uwsgi-cgi/Makefile
@@ -16,7 +16,6 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>
 
 include $(INCLUDE_DIR)/package.mk
-include $(TOPDIR)/feeds/packages/lang/python/python-package.mk
 
 define Package/uwsgi-cgi
   SECTION:=net


### PR DESCRIPTION
Maintainer: @Ansuel 
Compile tested: armvirt-32, 2019-04-29 snapshot sdk
Run tested: none

Description:
Since no Python packages are produced by this package, including python-package.mk is unnecessary.

This removes the reference to python-package.mk. (`PKG_RELEASE` is unchanged as this should have no effect on the build.)

Signed-off-by: Jeffery To <jeffery.to@gmail.com>