### PR TITLE
boost: Fix uClibc-ng compilation again

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.70.0
 PKG_SOURCE_VERSION:=1_70_0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/

--- a/libs/boost/patches/uclibc-ng-2.patch
+++ b/libs/boost/patches/uclibc-ng-2.patch
@@ -1,0 +1,21 @@
+--- a/boost/math/tools/roots.hpp
++++ b/boost/math/tools/roots.hpp
+@@ -665,8 +665,8 @@ namespace detail
+     inline T discriminant(T const & a, T const & b, T const & c)
+     {
+         T w = 4*a*c;
+-        T e = std::fma(-c, 4*a, w);
+-        T f = std::fma(b, b, -w);
++        T e = fma(-c, 4*a, w);
++        T f = fma(b, b, -w);
+         return f + e;
+     }
+ }
+@@ -674,7 +674,6 @@ namespace detail
+ template<class T>
+ auto quadratic_roots(T const& a, T const& b, T const& c)
+ {
+-    using std::copysign;
+     using std::sqrt;
+     if constexpr (std::is_integral<T>::value)
+     {


### PR DESCRIPTION
Several math functions are not defined in math.h and therefore cannot be
used.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ClaymorePT 
Compile tested: arc700

This time I compiled all of the boost libraries to make sure they all compile.

https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/boost/compile.txt