### PR TITLE
rtl_433: Update to 18.12

### DIFF
--- a/utils/rtl_433/Makefile
+++ b/utils/rtl_433/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (C) 2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
@@ -7,17 +7,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtl_433
-PKG_VERSION:=18.05
+PKG_VERSION:=18.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/merbanan/rtl_433/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=4710105234e3b71ae839e2d3f2628d6c12879fcda9c849fffe847d4de42a74f3
+PKG_HASH:=8d9a0d57155430b03d299effd48b43b7e072f49868485f0fc79294a28402d654
 
-CMAKE_INSTALL:=1
-
+PKG_MAINTAINER:=Jasper Scholte <NightNL@outlook.com>
 PKG_LICENSE:=GPLv2
 PKG_LICENSE_FILES:=COPYING
+
+CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -28,7 +29,6 @@ define Package/rtl_433
   CATEGORY:=Utilities
   DEPENDS:=+librtlsdr +rtl-sdr +libtool-bin
   URL:=https://github.com/merbanan/rtl_433
-  MAINTAINER:=Jasper Scholte <NightNL@outlook.com>
 endef
 
 define Package/rtl-sdr/description

--- a/utils/rtl_433/patches/010-gnu-source.patch
+++ b/utils/rtl_433/patches/010-gnu-source.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -50,7 +50,7 @@ if (("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" MATCHES
+     ADD_DEFINITIONS(-std=c99)
+     ADD_DEFINITIONS(-pedantic)
+     # for strdup, setenv
+-    ADD_DEFINITIONS(-D_POSIX_C_SOURCE=200809)
++    ADD_DEFINITIONS(-D_GNU_SOURCE)
+     #http://gcc.gnu.org/wiki/Visibility
+     add_definitions(-fvisibility=hidden)
+ 


### PR DESCRIPTION
Added a patch to fix compilation under uClibc-ng.

Reorganized Makefile for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @TimelessNL 
Compile tested: arc700

Patch was upstreamed.