### PR TITLE
port-mirroring: Update to 1.4.4

### DIFF
--- a/net/port-mirroring/Makefile
+++ b/net/port-mirroring/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=port-mirroring
 PKG_VERSION:=1.4.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mmaraya/port-mirroring/tar.gz/v$(PKG_VERSION)?

--- a/net/port-mirroring/patches/010-snprintf-to-strncpy.patch
+++ b/net/port-mirroring/patches/010-snprintf-to-strncpy.patch
@@ -1,0 +1,20 @@
+--- a/src/main.c
++++ b/src/main.c
+@@ -90,7 +90,7 @@ int loadCfg(const char *fpath)
+                 }
+                 else
+                 {
+-                    snprintf(cfg.dst_if, IFNAMSIZ, "%s", value);
++                    strncpy(cfg.dst_if, value, IFNAMSIZ);
+                     cfg.flags |= PM_DST_IF;
+                 }
+             }
+@@ -104,7 +104,7 @@ int loadCfg(const char *fpath)
+             }
+             else if (strcmp(option, "filter") == 0)
+             {
+-                snprintf(cfg.pfe, PFE_MAX, "%s", value);
++                strncpy(cfg.pfe, value, PFE_MAX);
+             }
+             else if (strcmp(option, "promiscuous") == 0)
+             {


### PR DESCRIPTION
Remove upstreamed patches and add patch to fix GCC8 compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mmaraya 
Compile tested: arc700
