### PR TITLE
measurement-kit: update to version 0.10.3

### DIFF
--- a/libs/measurement-kit/Makefile
+++ b/libs/measurement-kit/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=measurement-kit
-PKG_VERSION:=0.10.1
+PKG_VERSION:=0.10.3
 PKG_RELEASE=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/measurement-kit/measurement-kit/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=4caf856ebbb28633c7593a9b5b8ee79f0c0436d05ae7391cc59e8d72b260911a
+PKG_HASH:=04bc1832fbaa54a9fde4923e8f44a2f99610a862c228dd05977c36f54870d80f
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf

--- a/libs/measurement-kit/patches/003-fix-openssl-depredecated-api.patch
+++ b/libs/measurement-kit/patches/003-fix-openssl-depredecated-api.patch
@@ -1,0 +1,28 @@
+From 45904ae4548c848d053bea20e2f3e38189043c3a Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 3 May 2019 23:37:10 -0700
+Subject: [PATCH] Fix compilation without deprecated OpenSSL APIs (#1785)
+
+Initialization is deprecated and causes compile errors with OpenSSL 1.1 when
+deprecated APIs are disabled.
+---
+ src/libmeasurement_kit/net/libssl.hpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/libmeasurement_kit/net/libssl.hpp b/src/libmeasurement_kit/net/libssl.hpp
+index eacee86ae..d1cecebbb 100644
+--- a/src/libmeasurement_kit/net/libssl.hpp
++++ b/src/libmeasurement_kit/net/libssl.hpp
+@@ -38,10 +38,12 @@ static inline void libssl_init_once(SharedPtr<Logger> logger) {
+         static bool initialized = false;
+         if (!initialized) {
+             logger->debug2("initializing libssl once");
++#if OPENSSL_VERSION_NUMBER < 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+             SSL_library_init();
+             ERR_load_crypto_strings();
+             SSL_load_error_strings();
+             OpenSSL_add_all_algorithms();
++#endif
+             initialized = true;
+         }
+     });


### PR DESCRIPTION
Maintainer: me @ja-pa 
Compile tested: Turris Omnia (TOS4), OpenWrt master
Run tested: Turris Omnia (TOS4), OpenWrt master

Description:
This PR updates measurement-kit and backports patch from @neheb which was merged into master but is not part of 0.10.3 release.

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>