### PR TITLE
set2net: Remove false depends

### DIFF
--- a/net/ser2net/Makefile
+++ b/net/ser2net/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ser2net
 PKG_VERSION:=3.5.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/ser2net
@@ -28,8 +28,7 @@ define Package/ser2net
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Serial to Network Proxy
-  URL:=http://sourceforge.net/projects/ser2net/
-  DEPENDS:=+USE_UCLIBC:libpthread +USE_UCLIBC:librt
+  URL:=https://sourceforge.net/projects/ser2net/
 endef
 
 define Package/ser2net/description


### PR DESCRIPTION
These depends actually have the effect of disabling ser2net when uClibc-ng
is selected. Remove them.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mhei 
Compile tested: arc700
