### PR TITLE
faad2: Remove uClibc hack

### DIFF
--- a/libs/faad2/Makefile
+++ b/libs/faad2/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=faad2
 PKG_VERSION:=2.8.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/faac/faad2-src/$(PKG_NAME)-2.8.0
@@ -62,10 +62,6 @@ CONFIGURE_ARGS+= --without-xmms
 ifeq ($(CONFIG_SOFT_FLOAT),y)
 	TARGET_CFLAGS+= -DFIXED_POINT
 	CONFIGURE_ARGS+= -nfp
-endif
-
-ifeq ($(CONFIG_USE_UCLIBC),y)
-	CONFIGURE_VARS+= CPPFLAGS="-fno-builtin-cos -fno-builtin-sin -fno-builtin-log"
 endif
 
 define Build/InstallDev


### PR DESCRIPTION
OpenWrt uses uClibc-ng now, and it seems that these are no longer needed
as it seems faad2 automatically renames these functions.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: arc700