### PR TITLE
libseccomp: update to version 2.4.1

### DIFF
--- a/libs/libseccomp/Makefile
+++ b/libs/libseccomp/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libseccomp
-PKG_VERSION:=2.4.0
+PKG_VERSION:=2.4.1
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/seccomp/libseccomp/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=2e74c7e8b54b340ad5d472e59286c6758e1e1e96c6b43c3dbdc8ddafbf0e525d
+PKG_HASH:=1ca3735249af66a1b2f762fe6e710fcc294ad7185f1cc961e5bd83f9988006e8
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
 
 PKG_BUILD_PARALLEL:=1
@@ -33,6 +33,7 @@ define Package/libseccomp/Default
   CATEGORY:=Libraries
   TITLE:=seccomp
   URL:=https://github.com/seccomp/libseccomp/wiki
+  DEPENDS:=@!arc
 endef
 
 define Package/libseccomp/Default/description


### PR DESCRIPTION

Maintainer: @nmav 
Compile tested: Turris Omnia (TOS4), OpenWrt master
Run tested: Turris Omnia (TOS4), OpenWrt 18.06.2

Description:
This PR updates libseccomp to 2.4.1 which fixes BPF generation bug.
Run tested with scmp_sys_resolver

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>