### PR TITLE
node: add mips64 support

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
 PKG_VERSION:=v8.16.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=node-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/${PKG_VERSION}
 PKG_HASH:=3515e8e01568a5dc4dff3d91a76ebc6724f5fa2fbb58b4b0c5da7b178a2f7340
@@ -39,7 +39,6 @@ define Package/node
   URL:=https://nodejs.org/
   DEPENDS:=@(HAS_FPU||KERNEL_MIPS_FPU_EMULATOR) @!arc @!armeb \
 	   +libstdcpp +libopenssl +zlib +libnghttp2 +libuv +libhttp-parser \
-	   +USE_UCLIBC:libpthread +USE_UCLIBC:librt \
 	   +NODEJS_ICU:icu
 endef
 

--- a/lang/node/patches/006-mips64_support.patch
+++ b/lang/node/patches/006-mips64_support.patch
@@ -1,0 +1,30 @@
+--- a/configure
++++ b/configure
+@@ -60,7 +60,7 @@
+ 
+ valid_os = ('win', 'mac', 'solaris', 'freebsd', 'openbsd', 'linux',
+             'android', 'aix')
+-valid_arch = ('arm', 'arm64', 'ia32', 'mips', 'mipsel', 'mips64el', 'ppc',
++valid_arch = ('arm', 'arm64', 'ia32', 'mips', 'mipsel', 'mips64', 'mips64el', 'ppc',
+               'ppc64', 'x32','x64', 'x86', 'x86_64', 's390', 's390x')
+ valid_arm_float_abi = ('soft', 'softfp', 'hard')
+ valid_arm_fpu = ('vfp', 'vfpv3', 'vfpv3-d16', 'neon')
+@@ -795,6 +795,9 @@
+   if rtn == 'mipsel' and '_LP64' in k:
+     rtn = 'mips64el'
+ 
++  if rtn == 'mips' and '_LP64' in k:
++    rtn = 'mips64'
++
+   return rtn
+ 
+ 
+@@ -877,7 +880,7 @@
+ 
+   if target_arch == 'arm':
+     configure_arm(o)
+-  elif target_arch in ('mips', 'mipsel', 'mips64el'):
++  elif target_arch in ('mips', 'mipsel', 'mips64', 'mips64el'):
+     configure_mips(o)
+ 
+   if flavor == 'aix':


### PR DESCRIPTION
Maintainer: @blogic @ianchi & @cotequeiroz 
Compile tested: head r9945-bc85640, mips64_octeonplus_64_gcc-7.4.0_musl
Run tested: NONE

Description:
Add mips64 support code.
V8 engine seems to support mips64 (mips64el & mips64eb)

ref: https://github.com/openwrt/packages/pull/8796

Could anyone test on the target?
 
Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
