### PR TITLE
libevhtp: Update to 1.2.0

### DIFF
--- a/libs/libevhtp/Makefile
+++ b/libs/libevhtp/Makefile
@@ -11,39 +11,34 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libevhtp
-PKG_VERSION:=1.1.6
-PKG_RELEASE:=3
-PKG_LICENSE:=BSD-3-Clause
+PKG_VERSION:=1.2.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/criticalstack/libevhtp/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=725dd0a32237b2a097cdc2003d09278a082ccce310aaba7441a5fd8fa8f26635
+PKG_HASH:=d8d98072693f5f68ccd74d327dedfa2f6add4446ac2799689c2f58dd480aa301
 
-PKG_INSTALL:=1
+PKG_MAINTAINER:=
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/libevhtp
     SECTION:=libs
     CATEGORY:=Libraries
     TITLE:=A more flexible replacement for libevent's httpd API
-    MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
-    URL:=https://github.com/ellzey/libevhtp
-    DEPENDS:=+libevent2 +libevent2-openssl +libevent2-pthreads +libopenssl +libpthread
+    URL:=https://github.com/criticalstack/libevhtp
+    DEPENDS:=+libevent2 +libevent2-openssl +libevent2-pthreads
 endef
 
 define Package/libevhtp/description
    Libevhtp was created as a replacement API for Libevent's current HTTP API.
    The reality of libevent's http interface is that it was created as a JIT server,
    meaning the developer never thought of it being used for creating a full-fledged HTTP service.
-endef
-
-include $(INCLUDE_DIR)/cmake.mk
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/{include,lib}
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libevhtp))

--- a/libs/libevhtp/patches/020-openssl-1.1-compatibility.patch
+++ b/libs/libevhtp/patches/020-openssl-1.1-compatibility.patch
@@ -1,6 +1,6 @@
 --- a/evhtp.c
 +++ b/evhtp.c
-@@ -1686,16 +1686,15 @@ _evhtp_ssl_thread_lock(int mode, int typ
+@@ -1817,16 +1817,15 @@ _evhtp_ssl_thread_lock(int mode, int typ
  #endif
  static void
  _evhtp_ssl_delete_scache_ent(evhtp_ssl_ctx_t * ctx, evhtp_ssl_sess_t * sess) {
@@ -22,7 +22,7 @@
  
      if (cfg->scache_del) {
          (cfg->scache_del)(htp, sid, slen);
-@@ -1706,14 +1705,17 @@ static int
+@@ -1837,14 +1836,17 @@ static int
  _evhtp_ssl_add_scache_ent(evhtp_ssl_t * ssl, evhtp_ssl_sess_t * sess) {
      evhtp_connection_t * connection;
      evhtp_ssl_cfg_t    * cfg;
@@ -44,7 +44,7 @@
  
      SSL_set_timeout(sess, cfg->scache_timeout);
  
-@@ -1725,7 +1727,7 @@ _evhtp_ssl_add_scache_ent(evhtp_ssl_t *
+@@ -1856,7 +1858,7 @@ _evhtp_ssl_add_scache_ent(evhtp_ssl_t *
  }
  
  static evhtp_ssl_sess_t *
@@ -53,7 +53,7 @@
      evhtp_connection_t * connection;
      evhtp_ssl_cfg_t    * cfg;
      evhtp_ssl_sess_t   * sess;
-@@ -1767,12 +1769,12 @@ _evhtp_ssl_servername(evhtp_ssl_t * ssl,
+@@ -1898,12 +1900,12 @@ _evhtp_ssl_servername(evhtp_ssl_t * ssl,
          connection->vhost_via_sni = 1;
  
          SSL_set_SSL_CTX(ssl, evhtp_vhost->ssl_ctx);
@@ -69,7 +69,7 @@
          }
  
          return SSL_TLSEXT_ERR_OK;
-@@ -3017,15 +3019,21 @@ evhtp_ssl_init(evhtp_t * htp, evhtp_ssl_
+@@ -3197,15 +3199,21 @@ evhtp_ssl_init(evhtp_t * htp, evhtp_ssl_
          return -1;
      }
  
@@ -91,7 +91,7 @@
  
  #if OPENSSL_VERSION_NUMBER >= 0x10000000L
      SSL_CTX_set_options(htp->ssl_ctx, SSL_MODE_RELEASE_BUFFERS);
-@@ -3062,7 +3070,11 @@ evhtp_ssl_init(evhtp_t * htp, evhtp_ssl_
+@@ -3242,7 +3250,11 @@ evhtp_ssl_init(evhtp_t * htp, evhtp_ssl_
      SSL_CTX_set_verify(htp->ssl_ctx, cfg->verify_peer, cfg->x509_verify_cb);
  
      if (cfg->x509_chk_issued_cb != NULL) {
@@ -117,7 +117,7 @@
  #else
  typedef void                      evhtp_ssl_sess_t;
  typedef void                      evhtp_ssl_t;
-@@ -154,9 +159,9 @@ typedef int (*evhtp_headers_iterator)(ev
+@@ -157,9 +162,9 @@ typedef int (*evhtp_headers_iterator)(ev
  typedef int (*evhtp_ssl_verify_cb)(int pre_verify, evhtp_x509_store_ctx_t * ctx);
  typedef int (*evhtp_ssl_chk_issued_cb)(evhtp_x509_store_ctx_t * ctx, evhtp_x509_t * x, evhtp_x509_t * issuer);
  
@@ -129,4 +129,4 @@
 +typedef evhtp_ssl_sess_t * (*evhtp_ssl_scache_get)(evhtp_connection_t * connection, evhtp_ssl_data_t * sid, int sid_len);
  typedef void * (*evhtp_ssl_scache_init)(evhtp_t *);
  
- #define EVHTP_VERSION           "1.1.6"
+ #define EVHTP_VERSION           "1.2.0"

--- a/libs/libevhtp/patches/021-openssl-thread.patch
+++ b/libs/libevhtp/patches/021-openssl-thread.patch
@@ -1,21 +1,40 @@
-diff --git a/evhtp.c b/evhtp.c
-index 24687be..b646925 100644
 --- a/evhtp.c
 +++ b/evhtp.c
-@@ -1667,9 +1667,9 @@ _evhtp_accept_cb(evserv_t * serv, int fd, struct sockaddr * s, int sl, void * ar
+@@ -1797,10 +1797,10 @@ _evhtp_accept_cb(evserv_t * serv, int fd, struct sockaddr * s, int sl, void * ar
+ }
  
  #ifndef EVHTP_DISABLE_SSL
- #ifndef EVHTP_DISABLE_EVTHR
+-#ifndef EVHTP_DISABLE_EVTHR
 -static unsigned long
 -_evhtp_ssl_get_thread_id(void) {
 -    return (unsigned long)pthread_self();
++#if !defined(EVHTP_DISABLE_EVTHR) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
 +static void
 +_evhtp_ssl_get_thread_id(CRYPTO_THREADID *id) {
 +    CRYPTO_THREADID_set_numeric(id, (unsigned long)pthread_self());
  }
  
  static void
-@@ -2999,7 +2999,7 @@ evhtp_ssl_use_threads(void) {
+@@ -3050,7 +3050,9 @@ evhtp_use_threads(evhtp_t * htp, evhtp_thread_init_cb init_cb, int nthreads, voi
+     htp->thread_init_cbarg = arg;
+ 
+ #ifndef EVHTP_DISABLE_SSL
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     evhtp_ssl_use_threads();
++#endif
+ #endif
+ 
+     if (!(htp->thr_pool = evthr_pool_new(nthreads, _evhtp_thread_init, htp))) {
+@@ -3161,7 +3163,7 @@ evhtp_set_post_accept_cb(evhtp_t * htp, evhtp_post_accept_cb cb, void * arg) {
+ }
+ 
+ #ifndef EVHTP_DISABLE_SSL
+-#ifndef EVHTP_DISABLE_EVTHR
++#if !defined(EVHTP_DISABLE_EVTHR) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
+ int
+ evhtp_ssl_use_threads(void) {
+     int i;
+@@ -3179,7 +3181,7 @@ evhtp_ssl_use_threads(void) {
          pthread_mutex_init(&(ssl_locks[i]), NULL);
      }
  

--- a/libs/libevhtp/patches/030-uclibc.patch
+++ b/libs/libevhtp/patches/030-uclibc.patch
@@ -1,0 +1,12 @@
+--- a/test_proxy.c
++++ b/test_proxy.c
+@@ -5,6 +5,9 @@
+ #include <errno.h>
+ #include <evhtp.h>
+ 
++#ifndef SIGTERM
++#define SIGTERM	15
++#endif
+ 
+ int
+ make_request(evbase_t         * evbase,


### PR DESCRIPTION
In the tree, libevhtp is used only for Seafile. This is the most recent
version that Haiwen lists as working.

Updated threads patch for OpenSSL 1.1.

Removed Maintainer as he is inactive.

Simplified Makefile a little bit and reorganized for consistency between
packages.

Fixed compilation with uClibc-ng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: none
Compile tested: arc700
