### PR TITLE
wtmcu: add initial version 0.1.0

### DIFF
--- a/utils/wtmcu/Makefile
+++ b/utils/wtmcu/Makefile
@@ -1,0 +1,56 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=wtmcu
+PKG_VERSION:=0.1.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://gitlab.com/evgenyz/$(PKG_NAME)/-/archive/v$(PKG_VERSION)
+PKG_HASH:=557f8b6a9771dcee094692da4480274695ec2af53871a3ddea069ee94e207509
+
+PKG_LICENSE:=BSD-2-Clause
+PKG_MAINTAINER:=Evgeny Kolesnikov <evgenyz@gmail.com>
+
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
+
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/wtmcu
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=Weltrend MCU control daemon and console tool
+	MENU:=1
+	ABI_VERSION:=$(PKG_VERSION)
+	DEPENDS:=+libubox +libubus
+endef
+
+define Package/wtmcu/description
+	This package provides facilities to control Weltrend MCU.
+endef
+
+define Package/wtmcu/conffiles
+	/etc/config/wtmcu
+endef
+
+TARGET_CFLAGS+=-std=gnu99
+
+#define Build/Prepare
+#	mkdir -p $(PKG_BUILD_DIR)
+#	$(CP) ./src/* $(PKG_BUILD_DIR)/
+#endef
+
+define Package/wtmcu/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/wtmcud.init $(1)/etc/init.d/wtmcud
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/wtmcu.config $(1)/etc/config/wtmcu
+	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wtmcuctl $(1)/sbin/wtmcuctl
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wtmcud $(1)/sbin/wtmcud
+endef
+
+$(eval $(call BuildPackage,wtmcu))

--- a/utils/wtmcu/files/wtmcu.config
+++ b/utils/wtmcu/files/wtmcu.config
@@ -1,0 +1,10 @@
+config common 'common'
+	option device /dev/ttyS1
+
+config daemon 'daemon'
+	option delay 10
+	option t_max 80
+	option t_min 50
+	option t_hyst 3
+	option wol 1
+	option log_level 'W'

--- a/utils/wtmcu/files/wtmcud.init
+++ b/utils/wtmcu/files/wtmcud.init
@@ -1,0 +1,31 @@
+#!/bin/sh /etc/rc.common
+
+START=10
+
+USE_PROCD=1
+NAME=wtmcud
+PROG=/sbin/wtmcud
+
+start_service() {
+	local lan=$(uci -q get network.lan.ifname)
+
+	local device=$(uci -q get wtmcu.common.device)
+	local delay=$(uci -q get wtmcu.daemon.delay)
+	local tmin=$(uci -q get wtmcu.daemon.t_min)
+	local tmax=$(uci -q get wtmcu.daemon.t_max)
+	local thyst=$(uci -q get wtmcu.daemon.t_hyst)
+	local logl=$(uci -q get wtmcu.daemon.log_level)
+	local wol=$(uci -q get wtmcu.daemon.wol)
+
+	procd_open_instance
+	procd_set_param command "$PROG" ${device:+-d "$device"} ${delay:+-u "$delay"} ${tmin:+-t "$tmin"} ${tmax:+-T "$tmax"} ${thyst:+-h "$thyst"} ${logl:+-l "$logl"} ${wol:+-w "$lan"}
+	procd_close_instance
+}
+
+stop() {
+	service_stop /sbin/wtmcud
+}
+
+reload() {
+	service_reload /sbin/wtmcud
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu (cortext-a9), OpenWrt SNAPSHOT, r9945-bc85640cdc
Run tested: mvebu (cortext-a9), OpenWrt SNAPSHOT, r9945-bc85640cdc

Description:
Weltrend MCU control facilities. This is a supporting package for wdmc (WD My Cloud) device(es) (openwrt/openwrt#2040).