### PR TITLE
boost: Copy cmake in InstallDev step

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -499,8 +499,8 @@ define Build/InstallDev
 		# copies _all_ header files - independent of <--with-library>-argument above
 
 	$(INSTALL_DIR) $(1)/usr/lib
-	# copies all compiled archive and shared object files
-	$(CP) -v $(PKG_INSTALL_DIR)/lib/*.{a,so*} $(1)/usr/lib/ || :
+	# copies all cmake files, compiled archive and shared object files
+	$(CP) -v $(PKG_INSTALL_DIR)/lib/{*.{a,so*},cmake} $(1)/usr/lib/ || :
 endef
 
 define Host/Install


### PR DESCRIPTION
Copy the cmake directory in the InstallDev step.
I am currently trying out actual host build for boost i.e. compiling
boost libaries for host tools. When I do that, that step installs the
boost cmake files in staging_dir/host.

This breaks other packages that use cmake to compile and use boost as a
dependency because their compilation step now begins using
staging_dir/host version of Boost, rather than the target version of
boost. Cmake gives priority to cmake version of Boost config, over
finding boost headers manually.

This change resolves that problem by installing the BoostConfig.cmake
file in staging_dir/<target> as well.

Maintainer: @ClaymorePT 

Compile tested: nbg6817