### PR TITLE
librsocket-cpp: Add new package librsocket-cpp

### DIFF
--- a/libs/librsocket-cpp/Makefile
+++ b/libs/librsocket-cpp/Makefile
@@ -1,0 +1,61 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=librsocket-cpp
+PKG_SOURCE_DATE:=2019-05-08
+PKG_SOURCE_VERSION:=ddc80392b17a3fadcbea09f82ea5f6936f0fd459
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/rsocket/rsocket-cpp/tar.gz/$(PKG_SOURCE_VERSION)?
+PKG_HASH:=b9b5177be57f6cd23ff3592845b11209167f679b683cb73acbf351e7a3550a76
+PKG_BUILD_DIR:=$(BUILD_DIR)/rsocket-cpp-$(PKG_SOURCE_VERSION)
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+PKG_BUILD_PARALLEL:=1
+CMAKE_BINARY_SUBDIR:=builddir
+CMAKE_OPTIONS:= \
+	-DBUILD_BENCHMARKS=OFF \
+	-DBUILD_EXAMPLES=OFF \
+	-DBUILD_TESTS=OFF \
+	-DBUILD_SHARED_LIBS=ON
+CMAKE_INSTALL:=1
+
+define Package/librsocket-cpp
+	SECTION:=libs
+	CATEGORY:=Libraries
+	TITLE:=C++ implementation of RSocket
+	DEPENDS:=+libfolly +gflags +glog +libopenssl +libyarpl
+endef
+
+define Package/libyarpl
+	SECTION:=libs
+	CATEGORY:=Libraries
+	TITLE:=yarpl: Yet Another Reactive Programming Library
+	DEPENDS:=+libfolly +gflags +glog +libatomic
+endef
+
+define Package/librsocket-cpp/description
+	C++ implementation of RSocket, and Application protocol providing Reactive Streams semantics
+endef
+
+define Package/libyarpl/description
+	C++ implementation of reactive functional programming including both Observable and Flowable types.
+endef
+
+define Package/librsocket-cpp/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libReactiveSocket.so* $(1)/usr/lib/
+endef
+
+define Package/libyarpl/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libyarpl*.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,librsocket-cpp))
+$(eval $(call BuildPackage,libyarpl))

--- a/libs/librsocket-cpp/patches/100-fix-momit-leaf-frame-pointer-error.patch
+++ b/libs/librsocket-cpp/patches/100-fix-momit-leaf-frame-pointer-error.patch
@@ -1,0 +1,16 @@
+diff --git a/yarpl/CMakeLists.txt b/yarpl/CMakeLists.txt
+--- a/yarpl/CMakeLists.txt       Fri May 03 07:45:18 2019 -0700
++++ b/yarpl/CMakeLists.txt       Tue May 07 02:03:23 2019 -0700
+@@ -21,7 +21,11 @@
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-weak-vtables -Wno-padded")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -momit-leaf-frame-pointer")
++  include(CheckCXXCompilerFlag)
++  CHECK_CXX_COMPILER_FLAG("-momit-leaf-frame-pointer" HAVE_OMIT_LEAF_FRAME_POINTER)
++  if(HAVE_OMIT_LEAF_FRAME_POINTER)
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -momit-leaf-frame-pointer")
++  endif()
+ endif()
+
+ if(YARPL_WRAP_SHARED_IN_LOCK)

--- a/libs/librsocket-cpp/patches/101-do-not-use-gold.patch
+++ b/libs/librsocket-cpp/patches/101-do-not-use-gold.patch
@@ -1,0 +1,11 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -67,7 +67,6 @@
+   if (RSOCKET_ASAN)
+     set(ASAN_FLAGS -fsanitize=address,undefined)
+   endif ()
+-  set(EXTRA_LINK_FLAGS ${EXTRA_LINK_FLAGS} -fuse-ld=gold)
+
+ elseif (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
+   if (RSOCKET_ASAN)


### PR DESCRIPTION
[Depends on https://github.com/openwrt/packages/pull/7876, will rebase after it is merged]

C++ implementation of RSocket
RSocket is a binary protocol for use on byte stream transports such as
TCP, WebSockets, and Aeron. (https://rsocket.io/)

This ships with two separate libraries, yarpl and rsocket

Patch 100 is already upstream
(https://github.com/rsocket/rsocket-cpp/commit/862202c6e99a49a8cbd304644d98d3f419b429d8).
Patch 101 in process of upstreaming as it needs to made compatible with
using both gold and ld.

[Dependency of https://github.com/facebook/openr]

Maintainer: me
Compile tested: openwrt master - nbg6817, arc700

Signed-off-by: Amol Bhave <ambhave@fb.com>