### PR TITLE
samba4: update to 4.10.2 [Testing][Issue]

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.9.7
+PKG_VERSION:=4.10.2
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
@@ -16,10 +16,10 @@ PKG_SOURCE_URL:=https://ftp.heanet.ie/mirrors/ftp.samba.org/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=44e5bc58dcae6d86ca8d5f269fa927f20ff91bce97cde86fe4e83addcb89c001
+PKG_HASH:=878cfdc51b74fafb604399c381c690b325061eb63fc17a188a505e96fa8f5e84
 
 # samba4=(asn1_compile) e2fsprogs=(compile_et) nfs-kernel-server=(rpcgen)
-HOST_BUILD_DEPENDS:=nfs-kernel-server/host e2fsprogs/host
+HOST_BUILD_DEPENDS:=python3/host nfs-kernel-server/host e2fsprogs/host
 PKG_BUILD_DEPENDS:=samba4/host
 
 PKG_CONFIG_DEPENDS:= \
@@ -35,6 +35,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_kmod-fs-xfs
 
 include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/kernel.mk
 include $(INCLUDE_DIR)/version.mk
@@ -63,7 +64,7 @@ define Package/samba4-libs
 	+SAMBA4_SERVER_VFS:attr \
 	+SAMBA4_SERVER_ACL:acl +SAMBA4_SERVER_ACL:attr \
 	+SAMBA4_SERVER_AVAHI:libavahi-client \
-	+SAMBA4_SERVER_AD_DC:python-base +SAMBA4_SERVER_AD_DC:libopenssl +SAMBA4_SERVER_AD_DC:libgnutls +SAMBA4_SERVER_AD_DC:libopenldap +SAMBA4_SERVER_AD_DC:jansson +SAMBA4_SERVER_AD_DC:libarchive
+	+SAMBA4_SERVER_AD_DC:python3-base +SAMBA4_SERVER_AD_DC:libopenssl +SAMBA4_SERVER_AD_DC:libgnutls +SAMBA4_SERVER_AD_DC:libopenldap +SAMBA4_SERVER_AD_DC:jansson +SAMBA4_SERVER_AD_DC:libarchive
 endef
 
 define Package/samba4-server
@@ -207,8 +208,8 @@ HOST_CONFIGURE_ARGS += \
 		--without-gpgme
 
 HOST_CONFIGURE_ARGS += --disable-avahi --without-quotas --without-acl-support --without-winbind \
-	--without-ad-dc --without-json-audit --without-libarchive --disable-python --nopyc --nopyo \
-	--disable-gnutls --without-dnsupdate --without-ads --without-ldap
+	--without-ad-dc --without-json --without-libarchive --disable-python --nopyc --nopyo \
+	--without-dnsupdate --without-ads --without-ldap
 HOST_CONFIGURE_VARS += python_LDFLAGS="" python_LIBDIR=""
 
 # Optional AES-NI support - https://lists.samba.org/archive/samba-technical/2017-September/122738.html
@@ -242,9 +243,9 @@ else
 endif
 ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
 	CONFIGURE_ARGS += --enable-gnutls --with-dnsupdate --with-ads --with-ldap
-	TARGET_CFLAGS := -I$(STAGING_DIR)/usr/include/python2.7 $(TARGET_CFLAGS)
+	TARGET_CFLAGS := -I$(STAGING_DIR)/usr/include/python3 $(TARGET_CFLAGS)
 else
-	CONFIGURE_ARGS += --without-ad-dc --without-json-audit --without-libarchive --disable-python --nopyc --nopyo \
+	CONFIGURE_ARGS += --without-ad-dc --without-json --without-libarchive --disable-python --nopyc --nopyo \
 		--disable-gnutls --without-dnsupdate --without-ads --without-ldap
 	CONFIGURE_VARS += \
 		python_LDFLAGS="" \
@@ -409,8 +410,8 @@ define Package/samba4-libs/install
 		$(CP) $(PKG_INSTALL_DIR)/usr/lib/samba/krb5 $(1)/usr/lib/samba/; \
 	fi
 ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
-	$(INSTALL_DIR) $(1)/usr/lib/python2.7
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/python2.7 $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/python3
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/python3 $(1)/usr/lib/
 endif
 endef
 

--- a/net/samba4/patches/100-do-not-import-target-module-while-cross-compile.patch
+++ b/net/samba4/patches/100-do-not-import-target-module-while-cross-compile.patch
@@ -8,10 +8,10 @@ Signed-off-by: Bian Naimeng <biannm@cn.fujitsu.com>
 @@ -2,6 +2,7 @@
  
  import sys
- import Build, Options, Logs
+ from waflib import Build, Options, Logs
 +import imp, os
- from Configure import conf
- from samba_utils import TO_LIST
+ from waflib.Configure import conf
+ from wafsamba import samba_utils
  
 @@ -249,17 +250,32 @@ def CHECK_BUNDLED_SYSTEM_PYTHON(conf, li
      # versions


### PR DESCRIPTION
Maintainer: me
Compile tested: arm (crash)
Run tested:

Description:
* update to 4.10.2
* switch to python3

I get a build crash around the `Checking simple C program` WAF configure stage, the setup and dirs look fine to me, but i have problems debugging, fixing this issue. I suspect it might be actually related to the python3 switch of the 4.10 branch and not some gcc compile failure.

So if someone can reproduce this crash and want to give it a go on fixing it, help would be appreciated, since i don't have this much time atm.

```
Setting top to                           : /root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2
Setting out to                           : /root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/bin
Checking for 'gcc' (C compiler)          : arm-openwrt-linux-muslgnueabi-gcc
Checking for program 'git'               : /root/openwrt/staging_dir/host/bin/git
Checking for c flags '-MMD'              : yes
Checking for program 'gdb'               : /usr/bin/gdb
Checking for header sys/utsname.h        : yes
Checking uname sysname type              : not found
Checking uname machine type              : not found
Checking uname release type              : not found
Checking uname version type              : not found
Checking for header stdio.h              : yes
Checking simple C program                : not found
The configuration failed
(complete log in /root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/bin/config.log)
make[2]: *** [Makefile:550: /root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/.configured_ca74c75cc4847820459b7aa4dfee01e2] Error 1
make[2]: Leaving directory '/root/openwrt/feeds/extra/samba4'
time: package/feeds/extra/samba4/compile#2.86#0.61#1.52
make[1]: *** [package/Makefile:109: package/feeds/extra/samba4/compile] Error 2
make[1]: Leaving directory '/root/openwrt'
make: *** [/root/openwrt/include/toplevel.mk:218: package/samba4/compile] Error 2
```

The log shows this as first fail:
[config.log](https://github.com/openwrt/packages/files/3166414/config.log)


```
Checking uname sysname type
==>
#define CONFIG_H_IS_FROM_SAMBA 1
#define _SAMBA_BUILD_ 4
#define HAVE_CONFIG_H 1
#define SRCDIR "/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2"
#define HAVE_SYS_UTSNAME_H 1

#include <sys/utsname.h>

 int main(void) { 
                               int printf(const char *format, ...);
                               struct utsname n;
                               if (uname(&n) == -1) return -1;
                               printf("%s", n.sysname);
                               ; return 0; }

<==
[1/3] Compiling [32mbin/.conf_check_6306725d3195b16cb2f8188095608dad/test.c[0m

['arm-openwrt-linux-muslgnueabi-gcc', '-D_SAMBA_BUILD_=4', '-DHAVE_CONFIG_H=1', '-Os', '-pipe', '-fno-caller-saves', '-fno-plt', '-fhonour-copts', '-Wno-error=unused-but-set-variable', '-Wno-error=unused-result', '-mfloat-abi=hard', '-iremap/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2:samba-4.10.2', '-Wformat', '-Werror=format-security', '-fstack-protector', '-D_FORTIFY_SOURCE=1', '-Wl,-z,now', '-Wl,-z,relro', '-ffunction-sections', '-fdata-sections', '-MMD', '-I.', '-I../..', '-I.', '-I../..', '../../test.c', '-c', '-o/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/bin/.conf_check_6306725d3195b16cb2f8188095608dad/testbuild/default/test.c.1.o', '-I/root/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/include', '-I/root/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/include', '-I/root/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/usr/include', '-I/root/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/include/fortify', '-I/root/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/include']
[2/3] Linking [33mbin/.conf_check_6306725d3195b16cb2f8188095608dad/testbuild/default/testprog[0m

['arm-openwrt-linux-muslgnueabi-gcc', 'test.c.1.o', '-o/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/bin/.conf_check_6306725d3195b16cb2f8188095608dad/testbuild/default/testprog', '-Wl,-Bstatic', '-Wl,-Bdynamic', '-L/root/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/lib', '-L/root/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/lib', '-L/root/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/usr/lib', '-L/root/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/lib', '-znow', '-zrelro', '-Wl,--gc-sections']
[3/3] Processing [35mbin/.conf_check_6306725d3195b16cb2f8188095608dad/testbuild/default/testprog[0m

['/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/bin/.conf_check_6306725d3195b16cb2f8188095608dad/testbuild/default/testprog']
from /root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/buildtools/wafsamba: Test does not build: Traceback (most recent call last):
  File "/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/third_party/waf/waflib/Utils.py", line 814, in wrap
    return cache[k]
KeyError: (<samba_waf18.ConfigurationContext object at 0x559bbcec7118>,)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/third_party/waf/waflib/Utils.py", line 814, in wrap
    return cache[k]
KeyError: (<samba_waf18.ConfigurationContext object at 0x559bbcec7118>,)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/third_party/waf/waflib/Configure.py", line 584, in run_build
    bld.compile()
  File "/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/third_party/waf/waflib/Build.py", line 355, in compile
    raise Errors.BuildError(self.producer.error)
waflib.Errors.BuildError: Build failed
Traceback (most recent call last):
  File "/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/third_party/waf/waflib/Context.py", line 442, in cmd_and_log
    ret, out, err = Utils.run_process(cmd, kw, cargs)
  File "/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/third_party/waf/waflib/Utils.py", line 978, in run_process
    return run_prefork_process(cmd, kwargs, cargs)
  File "/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/third_party/waf/waflib/Utils.py", line 905, in run_prefork_process
    raise OSError(trace)
OSError: ['/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/bin/.conf_check_6306725d3195b16cb2f8188095608dad/testbuild/default/testprog']
Traceback (most recent call last):
  File "<string>", line 33, in run
  File "/root/openwrt/staging_dir/hostpkg/lib/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "/root/openwrt/staging_dir/hostpkg/lib/python3.7/subprocess.py", line 1522, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
OSError: [Errno 8] Exec format error: '/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/bin/.conf_check_6306725d3195b16cb2f8188095608dad/testbuild/default/testprog'


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/third_party/waf/waflib/Task.py", line 320, in process
    ret = self.run()
  File "/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/third_party/waf/waflib/Tools/c_config.py", line 674, in run
    self.generator.bld.retval = self.generator.bld.cmd_and_log([self.inputs[0].abspath()], env=env)
  File "/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/third_party/waf/waflib/Context.py", line 444, in cmd_and_log
    raise Errors.WafError('Execution failure: %s' % str(e), ex=e)
waflib.Errors.WafError: Execution failure: ['/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/bin/.conf_check_6306725d3195b16cb2f8188095608dad/testbuild/default/testprog']
Traceback (most recent call last):
  File "<string>", line 33, in run
  File "/root/openwrt/staging_dir/hostpkg/lib/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "/root/openwrt/staging_dir/hostpkg/lib/python3.7/subprocess.py", line 1522, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
OSError: [Errno 8] Exec format error: '/root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/bin/.conf_check_6306725d3195b16cb2f8188095608dad/testbuild/default/testprog'



from /root/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/samba-4.10.2/buildtools/wafsamba: The configuration failed
not found
```