### PR TITLE
getdns: update to version 1.5.2

### DIFF
--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=getdns
-PKG_VERSION:=1.5.0
+PKG_VERSION:=1.5.2
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
@@ -14,7 +14,7 @@ PKG_MAINTAINER:=Jonathan Underwood <jonathan.underwood@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://getdnsapi.net/dist/
-PKG_HASH:=577182c3ace919ee70cee5629505581a10dc530bd53fe5c241603ea91c84fa84
+PKG_HASH:=1826a6a221ea9e9301f2c1f5d25f6f5588e841f08b967645bf50c53b970694c0
 
 PKG_FIXUP:=autoreconf
 


### PR DESCRIPTION
Signed-off-by: Jonathan G. Underwood <jonathan.underwood@gmail.com>

Maintainer: me 
Compile tested: x86_64
Run tested: x86_64

Description:
Update to version 1.5.2.

