### PR TITLE
libxerces-c: Switch to using -fPIC

### DIFF
--- a/libs/libxerces-c/Makefile
+++ b/libs/libxerces-c/Makefile
@@ -9,13 +9,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xerces-c
 PKG_VERSION:=3.2.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@APACHE/xerces/c/3/sources
 PKG_HASH:=6daca3b23364d8d883dc77a73f681242f69389e3564543287ed3d073007e0a8e
-PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 
+PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -65,9 +65,8 @@ CONFIGURE_ARGS += \
 	--enable-msgloader-inmemory \
 	--enable-netaccessor-socket \
 	--enable-transcoder-iconv \
-	--without-pic
+	--with-pic
 
-TARGET_CFLAGS += $(FPIC)
 TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 define Build/InstallDev


### PR DESCRIPTION
-fpic is failing on AArch64.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Noltari 

https://downloads.openwrt.org/snapshots/faillogs/aarch64_cortex-a53/packages/libxerces-c/compile.txt