### PR TITLE
mariadb: security bump + init script brush-up

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
-PKG_VERSION:=10.2.22
+PKG_VERSION:=10.2.24
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -18,10 +18,12 @@ PKG_SOURCE_URL := \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/$(PKG_NAME)-$(PKG_VERSION)/source \
 	https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
 
-PKG_HASH:=42f4c54c29b7c196bd105bbf4d2ea721f869b14cb7ba436c3566e6dd2760614c
+PKG_HASH:=97f4d924e69f77abb2f650116785c2f5ef356230442534ebcbaadb51d9bb8bc4
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 PKG_LICENSE:=GPL-2.0 LGPL-2.1
 PKG_LICENSE_FILES:=COPYING libmariadb/COPYING.LIB
+
+PKG_CPE_ID:=cpe:/a:mariadb:mariadb
 
 HOST_BUILD_PARALLEL:=1
 PKG_BUILD_PARALLEL:=1
@@ -200,10 +202,7 @@ define Package/mariadb/install/plugin
 endef
 
 define Package/mariadb/description/Default
-MariaDB is a fast, stable and true multi-user, multi-threaded SQL
-database server. SQL (Structured Query Language) is the most popular
-database query language in the world. The main goals of MariaDB are
-speed, robustness and ease of use.
+MariaDB is a very fast and robust SQL database server.
 endef
 
 define Package/libmariadb/Default

--- a/utils/mariadb/files/mysqld.init
+++ b/utils/mariadb/files/mysqld.init
@@ -10,7 +10,7 @@ USE_PROCD=1
 
 NAME=mysqld
 
-LOGGER="/usr/bin/logger -p user.err -s -t $NAME"
+LOGGER="/usr/bin/logger -p user.err -s -t $NAME --"
 COMMAND=/usr/bin/$NAME
 
 mysqld_get_param() {
@@ -24,7 +24,10 @@ mysqld_get_param() {
 start_service() {
 	local conf=/etc/mysql/my.cnf
 	local dir
-	local user=mariadb
+	local user
+	local group
+
+	local logfile
 
 	local datadir
 	local logdir=/var/log/mysql
@@ -35,6 +38,8 @@ start_service() {
 	local log_stderr
 	local log_stdout
 	local options
+
+	local hint="please fix your server configuration in /etc/mysql/"
 
 	if [ ! -x $COMMAND ]; then
 		$LOGGER $COMMAND is missing
@@ -60,30 +65,80 @@ start_service() {
 	config_get options general options
 
 	datadir=$(mysqld_get_param datadir)
+	logfile=$(mysqld_get_param general_log_file)
 	tmpdir=$(mysqld_get_param tmpdir)
+	user=$(mysqld_get_param user)
 
 	if [ -z "$datadir" ]; then
 		$LOGGER datadir is not set
+		$LOGGER $hint
 		exit 1
 	fi
 
 	if [ -z "$tmpdir" ]; then
-		$LOGGER tmpdir is not set.
+		$LOGGER tmpdir is not set
+		$LOGGER $hint
 		exit 1
 	fi
 
-	[ -e "$datadir" ] || mkdir -p "$datadir"
+	if [ -z "$user" ]; then
+		$LOGGER user is not set
+		$LOGGER $hint
+		exit 1
+	fi
 
-	for dir in "$logdir" "$rundir" "$tmpdir"; do
-		if [ ! -e "$dir" ]; then
-			mkdir -p "$dir"
-			chown $user "$dir"
-		fi
-	done
+	user_exists "$user" || {
+		$LOGGER user \""$user"\" does not exist
+		$LOGGER $hint
+		exit 1
+	}
+
+	group=$(id -g -n "$user")
+
+	group_exists "$group" || {
+		$LOGGER group \""$group"\" does not exist
+		$LOGGER user \""$user"\" not configured correctly
+		exit 1
+	}
+
+	[ -n "$logfile" ] && logdir=$(dirname "$logfile")
+
+	# do not touch directories that already exist
+	# posix shell does not support arrays, hence using awk
+	awk \
+	  -v user="$user" \
+	  -v group="$group" \
+	  -v a="$datadir" \
+	  -v b="$logdir" \
+	  -v c="$rundir" \
+	  -v d="$tmpdir" \
+	  '
+	    BEGIN {
+	      dir[0]=a
+	      dir[1]=b
+	      dir[2]=c
+	      dir[3]=d
+	      for (x in dir) {
+	        if (system("test ! -e \"" dir[x] "\"" )) {
+	          delete dir[x]
+	        }
+	      }
+	      for (x in dir) {
+	        system("mkdir -p \"" dir[x] "\"" )
+	        system("chmod 750 \"" dir[x] "\"" )
+	        system("chown \"" user "\":\"" group "\" \"" dir[x] "\"" )
+	      }
+	    }
+	  '
 
 	if [ ! -f "$datadir/mysql/tables_priv.MYD" ]; then
-		$LOGGER "cannot detect privileges table, you might need to"
-		$LOGGER "run 'mysql_install_db --force' to initialize the system tables"
+		local args="--force"
+		local basedir=$(mysqld_get_param basedir)
+		[ -n "$basedir" ] && args="$args --basedir=$basedir"
+
+		$LOGGER Cannot detect privileges table. You might need to run
+		$LOGGER \'mysql_install_db $args\'
+		$LOGGER to initialize the system tables.
 		exit 1
 	fi
 

--- a/utils/mariadb/patches/100-fix_hostname.patch
+++ b/utils/mariadb/patches/100-fix_hostname.patch
@@ -1,6 +1,6 @@
 --- a/scripts/mysql_install_db.sh
 +++ b/scripts/mysql_install_db.sh
-@@ -399,7 +399,7 @@ fi
+@@ -403,7 +403,7 @@ fi
  
  
  # Try to determine the hostname

--- a/utils/mariadb/patches/170-ppc-remove-glibc-dep.patch
+++ b/utils/mariadb/patches/170-ppc-remove-glibc-dep.patch
@@ -53,7 +53,7 @@ directly was the first solution adopted in MariaDB [2].
  #  define UT_RESUME_PRIORITY_CPU() ((void)0)
 --- a/storage/innobase/include/ut0ut.h
 +++ b/storage/innobase/include/ut0ut.h
-@@ -70,9 +70,8 @@ typedef time_t	ib_time_t;
+@@ -71,9 +71,8 @@ typedef time_t	ib_time_t;
     the YieldProcessor macro defined in WinNT.h. It is a CPU architecture-
     independent way by using YieldProcessor. */
  # define UT_RELAX_CPU() YieldProcessor()
@@ -65,7 +65,7 @@ directly was the first solution adopted in MariaDB [2].
  #else
  # define UT_RELAX_CPU() do { \
       volatile int32	volatile_var; \
-@@ -90,9 +89,8 @@ typedef time_t	ib_time_t;
+@@ -91,9 +90,8 @@ typedef time_t	ib_time_t;
  #endif
  
  #if defined(HAVE_HMT_PRIORITY_INSTRUCTION)


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79 + archs, master
Run tested: ath79, dlink dir-825-c1, master, usual tests (create db & user, create table, insert/read)

Description:
Hi all,

MariaDB update to address:

    CVE-2019-2614
    CVE-2019-2627
    CVE-2019-2628

Added an update of init script that I had been preparing.

Thanks for committing this for me!

Kind regards,
Seb