### PR TITLE
fbzmq: Add fbzmq library

### DIFF
--- a/libs/fbzmq/Makefile
+++ b/libs/fbzmq/Makefile
@@ -1,0 +1,45 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fbzmq
+PKG_VERSION:=2019.06.10.00
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/facebook/fbzmq/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=9bb9b2bd42951fa3458b5d6d25f3364c14a7efa3b78bef68a6c00ee6fcba5813
+
+PKG_MAINTAINER:=Amol Bhave <ambhave@fb.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=1
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/fbzmq
+	SECTION:=libs
+	CATEGORY:=Libraries
+	TITLE:=Facebook ZeroMQ wrappers.
+	DEPENDS:=+fbthrift +libzmq +libsigar
+endef
+
+define Package/fbzmq/description
+	Facebook ZeroMQ wrappers.
+endef
+
+CMAKE_SOURCE_SUBDIR:=fbzmq
+CMAKE_OPTIONS:= \
+	-DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+	-DBUILD_TESTS=OFF \
+	-DBUILD_SHARED_LIBS=ON \
+	-DTHRIFT1="$(STAGING_DIR_HOST)/bin/thrift1" \
+	-DTHRIFT_COMPILER_INCLUDE="$(STAGING_DIR_HOST)/include/"
+
+define Package/fbzmq/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfbzmq.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,fbzmq))


### PR DESCRIPTION
fbzmq provides a framework for writing services in C++ while leveraging libzmq (message passing semantics).

[Dependency of openr]

Compile tested: nbg6817, master

Maintainer: me

Signed-off-by: Amol Bhave <ambhave@fb.com>
