### PR TITLE
libfolly: Fix folly missing deps

### DIFF
--- a/libs/libfolly/Makefile
+++ b/libs/libfolly/Makefile
@@ -35,7 +35,7 @@ define Package/libfolly
 	DEPENDS:=+libstdcpp +boost +boost-context +boost-system +boost-thread \
 		+boost-date_time +boost-filesystem +boost-program_options +boost-regex \
 		+libbz2 +libopenssl +libdouble-conversion +libevent2 +glog +zlib +libzstd \
-		+gflags +libsodium +liblzma +libaio
+		+gflags +libsodium +liblzma +libaio +liblz4 +libunwind +libatomic
 endef
 
 define Package/libfolly/description


### PR DESCRIPTION
Description: folly automatically picks up lz4 and unwind if they are found
by its cmake build script. This is causing buildbot failure.
Include these libraries in DEPENDS as well.

Test Plan:
 - build packages liblz4 and libunwind
 - build folly, and check that it throws an error
 - add this patch, and rebuild
 - verify that it succeeds this time around

Compile Tested: nbg6817, openwrt master

Maintainer: me