### PR TITLE
powertop: Switch to uClibc++

### DIFF
--- a/utils/powertop/Makefile
+++ b/utils/powertop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=powertop
 PKG_VERSION:=2.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://01.org/sites/default/files/downloads/
@@ -22,12 +22,14 @@ PKG_LICENSE:=GPL-2.0
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/powertop
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libpci +libncursesw +libnl-genl +libstdcpp
+  DEPENDS:=$(CXX_DEPENDS) $(INTL_DEPENDS) +libpci +libncursesw +libnl-genl
   TITLE:=Power consumption monitor
   URL:=https://01.org/powertop
 endef
@@ -36,6 +38,8 @@ define Package/powertop/description
  PowerTOP is a Linux tool to diagnose issues with power consumption
  and power management.
 endef
+
+TARGET_LDFLAGS += $(if $(INTL_FULL),-lintl)
 
 define Package/powertop/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
Now that the uClibc++ update has been included, we can switch to it. Basic
testing shows it as working.

Also fixed compilation with uClibc-ng.

libiconv-stub must be used as uClibc-ng does not provide those headers.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: arc700