### PR TITLE
subversion: partial revert of b32f8d4ff0

### DIFF
--- a/net/subversion/Makefile
+++ b/net/subversion/Makefile
@@ -79,6 +79,8 @@ define Package/subversion-server/conffiles
 endef
 
 TARGET_CFLAGS += $(FPIC)
+APU_LIBS=$(shell $(STAGING_DIR)/usr/bin/apu-1-config --link-libtool --libs)
+TARGET_LDFLAGS += $(APU_LIBS)
 
 CONFIGURE_ARGS += \
 	--with-apr="$(STAGING_DIR)/usr/bin/apr-1-config" \


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm53xx, Buffalo WXR-1900DHP, OpenWrt SNAPSHOT r9992-86fd8cb

Description:

Commit b32f8d4ff035272706a1d559992cfd6bc1ffe560 broke compilation of Subversion on systems where unixodbc package is present. The issue is documented in #8975. This partial revert fixes issue #8975.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>
