### PR TITLE
python-curl: remove hardcoded dependency on mbedtls

### DIFF
--- a/lang/python/python-curl/Makefile
+++ b/lang/python/python-curl/Makefile
@@ -55,8 +55,20 @@ $(call Package/python-curl/description)
 (Variant for Python3)
 endef
 
-PYTHON_PKG_SETUP_ARGS:=--with-mbedtls
-PYTHON3_PKG_SETUP_ARGS:=--with-mbedtls
+ifdef CONFIG_LIBCURL_OPENSSL
+  PYTHON_PKG_SETUP_ARGS:=--with-openssl
+  PYTHON3_PKG_SETUP_ARGS:=--with-openssl
+endif
+
+ifdef CONFIG_LIBCURL_GNUTLS
+  PYTHON_PKG_SETUP_ARGS:=--with-gnutls
+  PYTHON3_PKG_SETUP_ARGS:=--with-gnutls
+endif
+
+ifdef CONFIG_LIBCURL_MBEDTLS
+  PYTHON_PKG_SETUP_ARGS:=--with-mbedtls
+  PYTHON3_PKG_SETUP_ARGS:=--with-mbedtls
+endif
 
 $(eval $(call PyPackage,python-curl))
 $(eval $(call BuildPackage,python-curl))


### PR DESCRIPTION
Maintainer: @valdi74 
Attention: @BKPepe 
Compile tested: bcm53xx, Buffalo WXR-1900DHP, OpenWrt SNAPSHOT r9992-86fd8cb

Description:

Fixes issue #8978. If libcurl's SSL library is set to an SSL library other than libmbedtls, compilation fails. This patch configures python-curl to use the currently selected SSL library for libcurl.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>
