### PR TITLE
libmraa: Don't build on ARC, ARMEB, and PPC

### DIFF
--- a/libs/libmraa/Makefile
+++ b/libs/libmraa/Makefile
@@ -53,7 +53,7 @@ endef
 define Package/libmraa
   $(call Package/libmraa/Default)
   TITLE:=Intel IoT lowlevel IO C/C++ library
-  DEPENDS:=+libstdcpp +libjson-c
+  DEPENDS:=+libstdcpp +libjson-c @!arc @!armeb @!ppc
 endef
 
 define Package/libmraa/description


### PR DESCRIPTION
Not supported.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nxhack 