### PR TITLE
libevhtp: Add onigiruma.h to install

### DIFF
--- a/libs/libevhtp/Makefile
+++ b/libs/libevhtp/Makefile
@@ -12,7 +12,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libevhtp
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/criticalstack/libevhtp/tar.gz/$(PKG_VERSION)?

--- a/libs/libevhtp/patches/040-oniguruma.patch
+++ b/libs/libevhtp/patches/040-oniguruma.patch
@@ -1,0 +1,7 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -241,3 +241,4 @@ endif()
+ install (FILES evhtp.h DESTINATION include)
+ install (FILES htparse/htparse.h DESTINATION include)
+ install (FILES evthr/evthr.h DESTINATION include)
++install (FILES oniguruma/onigposix.h DESTINATION include)


### PR DESCRIPTION
For some reason from 1.1.7 to 1.2.0, oniguruma no longer gets installed by
default. Fix that to fix compilation with seafile.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: mips64

https://downloads.openwrt.org/snapshots/faillogs/mipsel_24kc/packages/seafile-server/compile.txt