### PR TITLE
Openpyxl version bump, dependency fixes (new packages added)

### DIFF
--- a/lang/python/openpyxl/Makefile
+++ b/lang/python/openpyxl/Makefile
@@ -7,41 +7,70 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=openpyxl
-PKG_VERSION:=2.5.9
-PKG_RELEASE:=2
-PKG_LICENSE:=MIT
+PKG_NAME:=python-openpyxl
+PKG_VERSION:=2.6.2
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/o/openpyxl
-PKG_HASH:=022c0f3fa1e873cc0ba20651c54dd5e6276fc4ff150b4060723add4fc448645e
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENCE.rst
+
+PKG_SOURCE:=openpyxl-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/o/openpyxl
+PKG_HASH:=1d2af392cef8c8227bd2ac3ebe3a28b25aba74fd4fa473ce106065f0b73bfe2e
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-openpyxl-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/openpyxl
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-openpyxl/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=A Python library to read/write Excel 2010 xlsx/xlsm files
   URL:=https://openpyxl.readthedocs.org/
-  DEPENDS:=+python +django
 endef
 
-define Package/openpyxl/description
+define Package/python-openpyxl
+  $(call Package/python-openpyxl/Default)
+  DEPENDS:= \
+	+PACKAGE_python-openpyxl:python \
+	+PACKAGE_python-openpyxl:python-defusedxml \
+	+PACKAGE_python-openpyxl:python-et_xmlfile \
+	+PACKAGE_python-openpyxl:python-jdcal
+  VARIANT:=python
+  # The PROVIDES below is deprecated and should be dropped with the next version.
+  PROVIDES:=openpyxl
+endef
+
+define Package/python3-openpyxl
+  $(call Package/python-openpyxl/Default)
+  DEPENDS:= \
+	+PACKAGE_python3-openpyxl:python3 \
+	+PACKAGE_python3-openpyxl:python3-defusedxml \
+	+PACKAGE_python3-openpyxl:python3-et_xmlfile \
+	+PACKAGE_python3-openpyxl:python3-jdcal
+  VARIANT:=python3
+endef
+
+define Package/python-openpyxl/description
   A Python library to read/write Excel 2010 xlsx/xlsm files
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-openpyxl/description
+$(call Package/python-openpyxl/description)
+.
+(Variant for Python3)
 endef
 
-define Package/openpyxl/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
+$(eval $(call PyPackage,python-openpyxl))
+$(eval $(call BuildPackage,python-openpyxl))
+$(eval $(call BuildPackage,python-openpyxl-src))
 
-$(eval $(call BuildPackage,openpyxl))
+$(eval $(call Py3Package,python3-openpyxl))
+$(eval $(call BuildPackage,python3-openpyxl))
+$(eval $(call BuildPackage,python3-openpyxl-src))

--- a/lang/python/python-et_xmlfile/Makefile
+++ b/lang/python/python-et_xmlfile/Makefile
@@ -1,0 +1,69 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-et_xmlfile
+PKG_VERSION:=1.0.1
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Eneas U de Queiroz <cote2004-github@yahoo.com>
+PKG_LICENSE:=MIT
+
+PKG_SOURCE:=et_xmlfile-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/e/et_xmlfile
+PKG_HASH:=614d9722d572f6246302c4491846d2c393c199cfa4edc9af593437691683335b
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-et_xmlfile-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-et_xmlfile/Default
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Low memory library for creating large XML files.
+  URL:=https://bitbucket.org/openpyxl/et_xmlfile
+endef
+
+define Package/python-et_xmlfile
+$(call Package/python-et_xmlfile/Default)
+  DEPENDS:= \
+	+PACKAGE_python-et_xmlfile:python-light \
+	+PACKAGE_python-et_xmlfile:python-lxml
+  VARIANT:=python
+endef
+
+define Package/python3-et_xmlfile
+$(call Package/python-et_xmlfile/Default)
+  DEPENDS:= \
+	+python3-light \
+	+python3-lxml
+  VARIANT:=python3
+endef
+
+define Package/python-et_xmlfile/description
+  An implementation of lxml.xmlfile for the standard library.
+  It is based upon the xmlfile module from lxml with the aim of
+  allowing code to be developed that will work with both libraries.
+endef
+
+define Package/python3-et_xmlfile/description
+$(call Package/python-et_xmlfile/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-et_xmlfile))
+$(eval $(call BuildPackage,python-et_xmlfile))
+$(eval $(call BuildPackage,python-et_xmlfile-src))
+
+$(eval $(call Py3Package,python3-et_xmlfile))
+$(eval $(call BuildPackage,python3-et_xmlfile))
+$(eval $(call BuildPackage,python3-et_xmlfile-src))

--- a/lang/python/python-jdcal/Makefile
+++ b/lang/python/python-jdcal/Makefile
@@ -1,0 +1,64 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-jdcal
+PKG_VERSION:=1.4.1
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Eneas U de Queiroz <cote2004-github@yahoo.com>
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE.txt
+
+PKG_SOURCE:=jdcal-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/j/jdcal
+PKG_HASH:=472872e096eb8df219c23f2689fc336668bdb43d194094b5cc1707e1640acfc8
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-jdcal-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-jdcal/Default
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Julian dates from proleptic Gregorian and Julian calendars
+  URL:=https://github.com/phn/jdcal
+endef
+
+define Package/python-jdcal
+$(call Package/python-jdcal/Default)
+  DEPENDS:= +PACKAGE_python-jdcal:python-light
+  VARIANT:=python
+endef
+
+define Package/python3-jdcal
+$(call Package/python-jdcal/Default)
+  DEPENDS:= +PACKAGE_python3-jdcal:python3-light
+  VARIANT:=python3
+endef
+
+define Package/python-jdcal/description
+  This module contains functions for converting between Julian dates and calendar dates.
+endef
+
+define Package/python3-jdcal/description
+$(call Package/python-jdcal/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-jdcal))
+$(eval $(call BuildPackage,python-jdcal))
+$(eval $(call BuildPackage,python-jdcal-src))
+
+$(eval $(call Py3Package,python3-jdcal))
+$(eval $(call BuildPackage,python3-jdcal))
+$(eval $(call BuildPackage,python3-jdcal-src))


### PR DESCRIPTION
Maintainer: @commodo / me for the new packages
Compile tested: mvebu, wrt3200acm, openwrt master
Run tested: mvebu, wrt3200acm, openwrt master, ran the commands in this tutorial: https://openpyxl.readthedocs.io/en/stable/tutorial.html

Description:
The current openpyxl package does not work at all due to important missing dependencies.
```
>>> from openpyxl import Workbook
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/openpyxl/__init__.py", line 6, in <module>
    from openpyxl.workbook import Workbook
  File "/usr/lib/python2.7/site-packages/openpyxl/workbook/__init__.py", line 5, in <module>
    from .workbook import Workbook
  File "/usr/lib/python2.7/site-packages/openpyxl/workbook/workbook.py", line 7, in <module>
    from openpyxl.worksheet import Worksheet
  File "/usr/lib/python2.7/site-packages/openpyxl/worksheet/__init__.py", line 4, in <module>
    from .worksheet import Worksheet
  File "/usr/lib/python2.7/site-packages/openpyxl/worksheet/worksheet.py", line 35, in <module>
    from openpyxl.cell import Cell
  File "/usr/lib/python2.7/site-packages/openpyxl/cell/__init__.py", line 4, in <module>
    from .cell import Cell, WriteOnlyCell
  File "/usr/lib/python2.7/site-packages/openpyxl/cell/cell.py", line 31, in <module>
    from openpyxl.utils.datetime  import (
  File "/usr/lib/python2.7/site-packages/openpyxl/utils/datetime.py", line 13, in <module>
    from jdcal import (
ImportError: No module named jdcal
```
Notes:
- Even though `requirements.txt` lists more dependencies, I took the ones from `setup.py`:
```
 install_requires=[
        'jdcal', 'et_xmlfile',
        ],
```
- django is not used at all, even though there is a function with it in mind.  The only place I found a django string was in the description of the deprecated `save_virtual_workbook` function in `writer/excel.py`.
- One of the important changes with the version upgrade is the ability to use defusedxml.  I am not including it here, as it is optional.  In my opinion, It should be required, since it avoids an easy way to bring down a router (it is extremely simple if the router has seafile enabled, for example).  My intention is to add the package in a separate PR, at which point I can add the dependency.  If I get enough people yelling at me, I can easily add the commits here instead.
- I hope I don't get in trouble with #8520 rules.  I'm not deliberately adding new python2 packages.  They should have been here for a long time, if anyone had run-tested this package thoroughly--it fails the first step of a basic tutorial from the package docs.  In my opinion, I'm fixing an existing python2 package, and adding python3 support to it as well.
- I did try to run it with python(3)-light, but it needs at least xml, decimal, and logging modules just to complete `import Workbook`.  There may be more but I stopped there, as I judged to be enough to warrant a full python dependency, to avoid having to check corner cases, or to deal with changes in a version update and have wrong dependencies again.  Testing record for this has been poor.
- `DEPENDS` for python3-et_xmlfile is not conditional to avoid a recursive dependency error.  Hopefully someone (@jow- can you help me with it?) will look at https://patchwork.ozlabs.org/project/openwrt/list/?series=104503 and this will be in the past.
- Anyone wanting to maintain/co-maintain the new packages, please let me know.