### PR TITLE
lxc, libsseccomp: workaround recursive dependency

### DIFF
--- a/libs/libseccomp/Makefile
+++ b/libs/libseccomp/Makefile
@@ -26,6 +26,11 @@ PKG_CONFIG_DEPENDS:= \
 
 include $(INCLUDE_DIR)/package.mk
 
+# This is done instead of DEPENDS:=@!arc to avoid a recursive dependency when
+# the library is conditionally selected by util/lxc.
+define Package/libseccomp/config
+  depends on !arc
+endef
 
 define Package/libseccomp/Default
   SUBMENU:=
@@ -33,7 +38,6 @@ define Package/libseccomp/Default
   CATEGORY:=Libraries
   TITLE:=seccomp
   URL:=https://github.com/seccomp/libseccomp/wiki
-  DEPENDS:=@!arc
 endef
 
 define Package/libseccomp/Default/description
@@ -47,7 +51,6 @@ endef
 define Package/libseccomp
 $(call Package/libseccomp/Default)
   TITLE+= (library)
-  DEPENDS+=
 endef
 
 define Package/scmp_sys_resolver

--- a/utils/lxc/Config.in
+++ b/utils/lxc/Config.in
@@ -38,6 +38,7 @@ config LXC_BUSYBOX_OPTIONS
 config LXC_SECCOMP
 	bool "Enable support for seccomp in LXC"
 	default KERNEL_SECCOMP
+	depends on !arc
 	help
 	  Build LXC with support for seccomp filters.
 	  Select libseccomp which also pulls-in the needed kernel features.


### PR DESCRIPTION
Maintainer: @nmav, @ratkaj 
Compile tested: none
Run tested: none
This was tested with `make menuconfig`, with arc and non-arc platforms, as it should not affect the actual build.  `PKG_RELEASE` is untouched because of this.
Description:
These commits fix a current recursive dependency error introduced in c60624de45488d6c8d438b5a05fd304313c70cc4, caused by the addition of `DEPENDS:=@!arc`.
```
$ make defconfig
Collecting package info: done
Collecting target info: done
tmp/.config-package.in:71778:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:71778:   symbol PACKAGE_luci-app-lxc depends on LXC_SECCOMP
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
/home/equeiroz/src/openwrt/feeds/packages/utils/lxc/Config.in:38:       symbol LXC_SECCOMP depends on PACKAGE_lxc
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:133884:  symbol PACKAGE_lxc is selected by PACKAGE_luci-app-lxc
tmp/.config-package.in:114115:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:114115:  symbol PACKAGE_ocserv is selected by PACKAGE_luci-app-ocserv
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:71923:   symbol PACKAGE_luci-app-ocserv depends on OCSERV_SECCOMP
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
/home/equeiroz/src/openwrt/feeds/packages/net/ocserv/Config.in:10:      symbol OCSERV_SECCOMP depends on PACKAGE_ocserv
```
What happens is that lxc depends on libseccomp conditionally, using the `LXC_SECCOMP` symbol (`+LXC_SECCOMP:libseccomp`).  While making it depend on `!arc` in `Config.in`should be enough to fix it, `scripts/package-metadata.pl` works with `DEPENDS` separately than `Config.in`, and there's no way to express it in `DEPENDS`.  It would take  `+(LXC_SECCOMP&&!arc):libsseccomp` to make it work, but the build system does not support this syntax, even with https://patchwork.ozlabs.org/patch/1090516/ applied: `!` is not supported inside the condition, only to negate the whole condition.

ping @ja-pa 