### PR TITLE
smcroute: disable libcap support

### DIFF
--- a/net/smcroute/Makefile
+++ b/net/smcroute/Makefile
@@ -38,6 +38,9 @@ define Package/smcroute/conffiles
 	/etc/smcroute.conf
 endef
 
+CONFIGURE_ARGS += \
+	--without-libcap
+
 define Package/smcroute/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
smcroute does not find libcap.so.2

Signed-off-by: Moritz Warning <moritzwarning@web.de>

Maintainer: me
Compile tested: target-powerpc_8540_musl / OpenWrt master
Run tested: Not necessary.
