### PR TITLE
python-rcssmin: restore & update removed package, add depend to django-compressor

### DIFF
--- a/lang/python/django-compressor/Makefile
+++ b/lang/python/django-compressor/Makefile
@@ -9,14 +9,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-compressor
 PKG_VERSION:=2.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=django_compressor-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://pypi.python.org/packages/82/76/1355459f90714517c52f264aa7245b52e59a273ec16e8f8d505fa6c342f8/
-PKG_BUILD_DIR:=$(BUILD_DIR)/django_compressor-$(PKG_VERSION)/
 PKG_HASH:=9616570e5b08e92fa9eadc7a1b1b49639cce07ef392fc27c74230ab08075b30f
-PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/django_compressor-$(PKG_VERSION)/
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
@@ -25,24 +28,19 @@ define Package/django-compressor
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  TITLE:=Compresses linked and inline JavaScript or CSS into single cached files.
+  TITLE:=Compress CSS/JS into single cached files
   URL:=http://django-compressor.readthedocs.org/
-  DEPENDS:=+python +django
+  DEPENDS:=+python +django +django-appconf +python-rcssmin
+  VARIANT:=python
 endef
 
 define Package/django-compressor/description
   Compresses linked and inline JavaScript or CSS into single cached files.
+  Note that the JavaScript filter is not being installed as a dependency.
+  You'll need to build the rjsmin module (it is not par of the openwrt standard
+  feeds) to use JavaScript functionality.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
-endef
-
-define Package/django-compressor/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,django-compressor))
 $(eval $(call BuildPackage,django-compressor))
+$(eval $(call BuildPackage,django-compressor-src))

--- a/lang/python/python-rcssmin/Makefile
+++ b/lang/python/python-rcssmin/Makefile
@@ -1,0 +1,71 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-rcssmin
+PKG_VERSION:=1.0.6
+PKG_RELEASE=1
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Eneas U de Queiroz <cote2004-github@yahoo.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=rcssmin-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/r/rcssmin
+PKG_HASH:=ca87b695d3d7864157773a61263e5abb96006e9ff0e021eff90cbe0e1ba18270
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-rcssmin-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python-package.mk
+include ../python3-package.mk
+
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-rcssmin/Default
+    SUBMENU:=Python
+    SECTION:=lang
+    CATEGORY:=Languages
+    TITLE:=Fast CSS minifier for Python
+    URL:=http://opensource.perlig.de/rcssmin/
+endef
+
+define Package/python-rcssmin
+    $(call Package/python-rcssmin/Default)
+    DEPENDS:= \
+	+PACKAGE_python-rcssmin:python-light \
+	+PACKAGE_python-rcssmin:python-codecs
+    VARIANT:=python
+endef
+
+define Package/python3-rcssmin
+    $(call Package/python-rcssmin/Default)
+    DEPENDS:= \
+	+PACKAGE_python3-rcssmin:python3-light
+    VARIANT:=python3
+endef
+
+define Package/python-rcssmin/description
+    This module is a re-implementation aiming for speed instead of maximum compression,
+    so it can be used at runtime (rather than during a preprocessing step).
+    RCSSmin does syntactical compression only (removing spaces, comments and possibly
+    semicolons). It does not provide semantic compression (like removing empty blocks,
+    collapsing redundant properties etc).
+endef
+
+define Package/python3-rcssmin/description
+$(call Package/python-rcssmin/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-rcssmin))
+$(eval $(call BuildPackage,python-rcssmin))
+$(eval $(call BuildPackage,python-rcssmin-src))
+
+$(eval $(call Py3Package,python3-rcssmin))
+$(eval $(call BuildPackage,python3-rcssmin))
+$(eval $(call BuildPackage,python3-rcssmin-src))


### PR DESCRIPTION
Maintainer: me / @commodo (django-compressor)
Compile tested: mvebu, WRT3200ACM, openwrt master
Run tested: mvebu, WRT3200ACM, openwrt master, running:
```
python3 -mrcssmin </www/luci-static/bootstrap/cascade.css
python -mrcssmin </www/luci-static/bootstrap/cascade.css
```

Description:
The package was removed in b57a79dd2c6ab1a07a4d63b74be2bc40753bcf83 because it was not a dependency of seafile.  It is however, a dependency of django-compressor, so I'm restoring it to the feed.  I took over as maintainer (@commodo, feel free to replace or join me).
Compared to the previous package, I've renamed it, reworked the Makefile, added a python3 version, and minimized its dependencies (it used to be full python).
I've added a separate commit adding python-rcssmin as a django-compressor dependency.