### PR TITLE
botan: Do not build on ARC

### DIFF
--- a/libs/botan/Makefile
+++ b/libs/botan/Makefile
@@ -41,7 +41,7 @@ define Package/libbotan
   CATEGORY:=Libraries
   TITLE+= (library)
   ABI_VERSION:=$(PKG_VERSION)-$(PKG_RELEASE)
-  DEPENDS:=+libstdcpp +libpthread
+  DEPENDS:=+libstdcpp +libpthread @!arc
 endef
 
 define Package/libbotan/description


### PR DESCRIPTION
Not supported.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @hbl0307106015

https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/botan/compile.txt