### PR TITLE
libftdi: Fix compilation with most recent CMake

### DIFF
--- a/libs/libftdi/Makefile
+++ b/libs/libftdi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libftdi
 PKG_VERSION:=0.20
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.intra2net.com/en/developer/libftdi/download/
@@ -38,6 +38,8 @@ define Package/libftdi/description
   libFTDI is an open source library to talk to FTDI chips: FT232BM, FT245BM, FT2232C, FT2232H, FT4232H, FT2232D and FT245R, including the popular bitbang mode. 
   The library is linked with your program in userspace, no kernel driver required.
 endef
+
+CMAKE_OPTIONS += -DBoost_NO_BOOST_CMAKE=ON
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/


### PR DESCRIPTION
Description from Amol Bhave:

This package fails to compile with boost 1.70 when the boost cmake
config gets used.
As far as I can tell, Boost 1.70 introduced
BoostConfigVersion.cmake. In that file, the value of PACKAGE_VERSION is
set to 1.70. This makes CMake auto set the variable Boost_VERSION to
1.70. Historically, Boost_VERSION has been using the format like 170000,
and not 1.70. Some package cmake files still depend on this behavior
and make assertions such as Boost_VERSION > 168000. This is incompatible
with the new scheme.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Noltari 
Compile tested: mips64