### PR TITLE
libftdi1: Fix compilation with most recent CMake

### DIFF
--- a/libs/libftdi1/Makefile
+++ b/libs/libftdi1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libftdi1
 PKG_VERSION:=1.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.intra2net.com/en/developer/libftdi/download/
@@ -21,8 +21,6 @@ PKG_LICENSE_FILES:=COPYING.LIB
 
 PKG_INSTALL:=1
 PKG_USE_MIPS16:=0
-
-CMAKE_OPTIONS:=-DBUILD_TESTS=OFF
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -59,6 +57,10 @@ define Package/ftdi_eeprom/description
   You have to unplug and replug your device to get the new values to be
   read. Otherwise, you will still get the old values.
 endef
+
+CMAKE_OPTIONS:= \
+	-DBUILD_TESTS=OFF \
+	-DBoost_NO_BOOST_CMAKE=ON
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/libftdi1/


### PR DESCRIPTION
Description from Amol Bhave:

This package fails to compile with boost 1.70 when the boost cmake
config gets used.
As far as I can tell, Boost 1.70 introduced
BoostConfigVersion.cmake. In that file, the value of PACKAGE_VERSION is
set to 1.70. This makes CMake auto set the variable Boost_VERSION to
1.70. Historically, Boost_VERSION has been using the format like 170000,
and not 1.70. Some package cmake files still depend on this behavior
and make assertions such as Boost_VERSION > 168000. This is incompatible
with the new scheme.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Noltari 
Compile tested: mips64