### PR TITLE
python-requests-oauthlib: add python3 package, remove unnecessary dependencies

### DIFF
--- a/lang/python/python-requests-oauthlib/Makefile
+++ b/lang/python/python-requests-oauthlib/Makefile
@@ -1,6 +1,4 @@
 #
-# Copyright (C) 2007-2016 OpenWrt.org
-#
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
@@ -9,32 +7,65 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-requests-oauthlib
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
+
+PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=requests-oauthlib-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/r/requests-oauthlib
 PKG_HASH:=bd6533330e8748e94bf0b214775fed487d309b8b8fe823dc45641ebcd9a32f57
-PKG_BUILD_DIR:=$(BUILD_DIR)/requests-oauthlib-$(PKG_VERSION)
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-requests-oauthlib-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/python-requests-oauthlib
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-requests-oauthlib/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
-  TITLE:=OAuthlib authentication support for Requests.
+  TITLE:=OAuthlib auth for Requests
   URL:=https://github.com/requests/requests-oauthlib
-  DEPENDS:=+python +python-requests +python-oauthlib +python-cryptography +python-pyjwt
+endef
+
+define Package/python-requests-oauthlib
+  $(call Package/python-requests-oauthlib/Default)
+  DEPENDS:= \
+	+PACKAGE_python-requests-oauthlib:python \
+	+PACKAGE_python-requests-oauthlib:python-oauthlib \
+	+PACKAGE_python-requests-oauthlib:python-requests
   VARIANT:=python
 endef
 
+define Package/python3-requests-oauthlib
+  $(call Package/python-requests-oauthlib/Default)
+  DEPENDS:= \
+	+PACKAGE_python3-requests-oauthlib:python3 \
+	+PACKAGE_python3-requests-oauthlib:python3-oauthlib \
+	+PACKAGE_python3-requests-oauthlib:python3-requests
+  VARIANT:=python3
+endef
+
 define Package/python-requests-oauthlib/description
-  This project provides first-class OAuth library support for Requests.
+  This python package provides first-class OAuth library support
+  for Requests.
+endef
+
+define Package/python3-requests-oauthlib/description
+$(call Package/python-requests-oauthlib/description)
+.
+(Variant for Python3)
 endef
 
 $(eval $(call PyPackage,python-requests-oauthlib))
 $(eval $(call BuildPackage,python-requests-oauthlib))
 $(eval $(call BuildPackage,python-requests-oauthlib-src))
+
+$(eval $(call Py3Package,python3-requests-oauthlib))
+$(eval $(call BuildPackage,python3-requests-oauthlib))
+$(eval $(call BuildPackage,python3-requests-oauthlib-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, WRT3200ACM, openwrt master
Run tested: mvebu, WRT3200ACM, openwrt master, ran the code in the package README under python3.

Description:
Added a python3 variant, and removed python-cryptography, and pyjwt from the dependencies.  They are required only to run one test, that is not even being installed.
Also updated the Makefile to fit current python-package style.  

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>