### PR TITLE
python,python3: workaround for recursive dependencies

### DIFF
--- a/lang/python/python/Config-python-light.in
+++ b/lang/python/python/Config-python-light.in
@@ -1,3 +1,4 @@
+if USB_SUPPORT
 menu "Configuration"
 
 config PYTHON_BLUETOOTH_SUPPORT
@@ -5,3 +6,4 @@ config PYTHON_BLUETOOTH_SUPPORT
 	default n
 
 endmenu
+endif

--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -12,14 +12,14 @@ include ../python-version.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)
 PKG_HASH:=f222ef602647eecb6853681156d32de4450a2c39f4de93bd5b20235f2e660ed7
 
-PKG_LICENSE:=PSF
-PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
+PKG_LICENSE:=Python/2.0
+PKG_LICENSE_FILES:=LICENSE Doc/license.rst Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE Modules/expat/COPYING
 PKG_CPE_ID:=cpe:/a:python:python
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>
@@ -42,7 +42,9 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_python-setuptools CONFIG_PACKAGE_python-pip \
 	CONFIG_PYTHON_BLUETOOTH_SUPPORT
 
-PKG_BUILD_DEPENDS:=python/host
+# bluez is being added here as a workaround to avoid a circular
+# dependecy.  See comment in EXTRA_DEPENDS below.
+PKG_BUILD_DEPENDS:=python/host bluez
 HOST_BUILD_DEPENDS:=bzip2/host expat/host
 
 include $(INCLUDE_DIR)/host-build.mk
@@ -79,10 +81,17 @@ endef
 define Package/python-light
 $(call Package/python/Default)
   TITLE:=Python $(PYTHON_VERSION) light installation
-  DEPENDS:=+python-base +libffi +libbz2 +PYTHON_BLUETOOTH_SUPPORT:bluez-libs
+  DEPENDS:=+python-base +libffi +libbz2
+  # This is being done instead of adding +PYTHON_BLUETOOTH_SUPPORT above to avoid
+  # a circular dependency because kmod-bluetooth depends on USB_SUPPORT.
+  # If && support is added to the DEPENDS syntax, this can be changed to
+  # to +(PYTHON_BLUETOOTH_SUPPORT&&USB_SUPPORT):bluez-libs in DEPENDS.
+  EXTRA_DEPENDS:=$(if $(CONFIG_PYTHON_BLUETOOTH_SUPPORT),bluez-libs)
 endef
 
+# The select statement below is also part of the circular dependency workaround
 define Package/python-light/config
+  select PACKAGE_bluez-libs if PYTHON_BLUETOOTH_SUPPORT
   source "$(SOURCE)/Config-python-light.in"
 endef
 

--- a/lang/python/python3/Config-python3-light.in
+++ b/lang/python/python3/Config-python3-light.in
@@ -1,3 +1,4 @@
+if USB_SUPPORT
 menu "Configuration"
 
 config PYTHON3_BLUETOOTH_SUPPORT
@@ -5,3 +6,4 @@ config PYTHON3_BLUETOOTH_SUPPORT
 	default n
 
 endmenu
+endif

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -14,15 +14,15 @@ PYTHON_VERSION:=$(PYTHON3_VERSION)
 PYTHON_VERSION_MICRO:=$(PYTHON3_VERSION_MICRO)
 
 PKG_NAME:=python3
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)
 PKG_HASH:=d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb
 
-PKG_LICENSE:=PSF
-PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
+PKG_LICENSE:=Python-2.0
+PKG_LICENSE_FILES:=LICENSE Doc/license.rst Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi_osx/LICENSE Modules/expat/COPYING
 PKG_CPE_ID:=cpe:/a:python:python
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>
@@ -45,7 +45,9 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_python3-setuptools CONFIG_PACKAGE_python3-pip \
 	CONFIG_PYTHON3_BLUETOOTH_SUPPORT
 
-PKG_BUILD_DEPENDS:=python3/host
+# bluez is being added here as a workaround to avoid a circular
+# dependecy.  See comment in EXTRA_DEPENDS below.
+PKG_BUILD_DEPENDS:=python3/host bluez
 HOST_BUILD_DEPENDS:=bzip2/host expat/host libffi/host
 
 include $(INCLUDE_DIR)/host-build.mk
@@ -82,10 +84,17 @@ endef
 define Package/python3-light
 $(call Package/python3/Default)
   TITLE:=Python $(PYTHON_VERSION) light installation
-  DEPENDS:=+python3-base +libffi +libbz2 +PYTHON3_BLUETOOTH_SUPPORT:bluez-libs +libuuid
+  DEPENDS:=+python3-base +libffi +libbz2 +libuuid
+  # This is being done instead of adding +PYTHON_BLUETOOTH_SUPPORT above to avoid
+  # a circular dependency because kmod-bluetooth depends on USB_SUPPORT.
+  # If && support is added to the DEPENDS syntax, this can be changed to
+  # +(PYTHON_BLUETOOTH_SUPPORT&&USB_SUPPORT):bluez-libs in DEPENDS.
+  EXTRA_DEPENDS:=$(if $(CONFIG_PYTHON_BLUETOOTH_SUPPORT),bluez-libs)
 endef
 
+# The select statement below is also part of the circular dependency workaround
 define Package/python3-light/config
+  select PACKAGE_bluez-libs if PYTHON3_BLUETOOTH_SUPPORT
   source "$(SOURCE)/Config-python3-light.in"
 endef
 


### PR DESCRIPTION
Maintainer: @commodo @jefferyto 
Compile tested: mvebu, WRT3200ACM, openwrt master; ar7, TI AR7, openwrt master
Run tested: mvebu, WRT3200ACM, openwrt master

Description:
Bluetooth support depends on `USB_SUPPORT`, but that dependency cannot be properly expressed in the package `DEPENDS`.  This causes apparently random recursive dependencies when python packages are added or sometimes changed.

As a workaround, bluez is added to `PKG_BUILD_DEPENDS` to ensure it gets built ahead of python, and the bluez-libs conditional dependency was added to `PKG_EXTRA_DEPENDS`, so it does not interfere with the `tmp/.config-package.in` file generation; `menuconfig` logic was added to `Package/python[3]-light/config`.

Also, changed `PKG_LICENSE` to the correct SPDX identifier, and updated the `PKG_LICENSE_FILES` list.  Please review this to make sure I got it right.  I have not included license files for modules/tools we do not distribute, such as some MS Windows stuff.

Most of my testing was done with the build procedure, as the binaries did not change with this PR, only the metadata because of the license updates.

There are 3 dependency components in play.
- First, the `menuconfig`, Config.in dependencies.  That's where the recursive dependency is detected.  It involves the `tmp/.config-package.in` file.  I took care of it by adding the `select` line under `Package/python-light/config`, and the `if USB_SUPPORT` line in `config-python[3]-light.in`. The order of the dependencies in `tmp/.config-package.in` actually changes every time it gets rebuilt, so I've edited the files manually so that their order was consistent.  Here are the changes:
```
diff --git a/bin.python.old/config-package.in b/bin.python.new/config-package.in
index 8511a12bbf..82f820042a 100644
--- a/bin.python.old/config-package.in
+++ b/bin.python.new/config-package.in
@@ -2,14 +2,11 @@
                tristate "python-light............................... Python 2.7 light installation"
                default y if DEFAULT_python-light
                default m if ALL
-               select PACKAGE_bluez-libs if PYTHON_BLUETOOTH_SUPPORT
                select PACKAGE_libssp if GCC_LIBSSP
                select PACKAGE_libc
                select PACKAGE_libffi
                select PACKAGE_libpthread if USE_GLIBC
-               depends on !(PYTHON_BLUETOOTH_SUPPORT && USE_RFKILL) || USE_RFKILL
                select PACKAGE_libbz2
-               depends on !(PYTHON_BLUETOOTH_SUPPORT) || USB_SUPPORT
                select PACKAGE_python-base
                select PACKAGE_librt if USE_GLIBC
                help
@@ -20,6 +17,7 @@
                 Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>


+         select PACKAGE_bluez-libs if PYTHON_BLUETOOTH_SUPPORT
          source "feeds/packages/lang/python/python/Config-python-light.in"

        config PACKAGE_python3-light
@@ -30,13 +28,10 @@
                select PACKAGE_libuuid
                select PACKAGE_libc
                select PACKAGE_libffi
-               depends on !(PYTHON3_BLUETOOTH_SUPPORT) || USB_SUPPORT
                select PACKAGE_python3-base
                select PACKAGE_libpthread if USE_GLIBC
-               select PACKAGE_bluez-libs if PYTHON3_BLUETOOTH_SUPPORT
                select PACKAGE_libbz2
                select PACKAGE_librt if USE_GLIBC
-               depends on !(PYTHON3_BLUETOOTH_SUPPORT && USE_RFKILL) || USE_RFKILL
                help
                 This package is essentially the python3-base package plus
                   a few of the rarely used (and big) libraries stripped out
@@ -45,5 +40,5 @@
                 Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>


+         select PACKAGE_bluez-libs if PYTHON3_BLUETOOTH_SUPPORT
          source "feeds/packages/lang/python/python3/Config-python3-light.in"
``` 
As can be seen, I've eliminated the useless USB_SUPPORT checks that cause trouble, and added them to the `PYTHON[3]_BLUETOOTH_SUPPORT` definition.
- The next component is the build dependencies, where `make world` needs to know what to build in which order.  This involves the `tmp/.packagedeps` file.  Here `PKG_BUILD_DEPENDS` comes to play, so I've added `bluez-libs` there so it gets built before python.  Here we have an undesirable side-effect, which is that bluez gets built even if bluetooth support is not selected, since we can't add a conditional expression in `PKG_BUILD_DEPENDS`: it gets generated before `.config` is read.  Here's a word diff of the files:
```
$ git diff --no-index --word-diff bin.python.{old,new}/packagedeps | cat
diff --git a/bin.python.old/packagedeps b/bin.python.new/packagedeps
index 67a6c6eb6e..55724ee9ce 100644
--- a/bin.python.old/packagedeps
+++ b/bin.python.new/packagedeps
@@ -10216,7 +10216,7 @@
$(curdir)/utils/px5g/compile += $(curdir)/libs/mbedtls/compile $(curdir)/libs/toolchain/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile) $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile)
$(curdir)/feeds/packages/pyjwt/compile += $(curdir)/libs/toolchain/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile) $(if $(CONFIG_PACKAGE_python-pyjwt),$(curdir)/feeds/packages/python/compile) $(if $(CONFIG_PACKAGE_python3-pyjwt),$(curdir)/feeds/packages/python3/compile) $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile)
$(curdir)/feeds/packages/pyodbc/compile += $(curdir)/feeds/packages/unixodbc/compile $(curdir)/feeds/packages/unixodbc/host/compile $(curdir)/libs/toolchain/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile) $(if $(CONFIG_PACKAGE_python-pyodbc),$(curdir)/feeds/packages/python/compile) $(if $(CONFIG_PACKAGE_python3-pyodbc),$(curdir)/feeds/packages/python3/compile) $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile) $(if $(CONFIG_USE_LIBSTDCXX),$(curdir)/libs/toolchain/compile) $(if $(CONFIG_USE_UCLIBCXX),$(curdir)/libs/uclibc++/compile)
```
`$(curdir)/feeds/packages/python/compile += `**{+$(curdir)/feeds/packages/bluez/compile+}**` $(curdir)/feeds/packages/db47/compile $(curdir)/feeds/packages/expat/compile $(curdir)/feeds/packages/gdbm/compile $(curdir)/feeds/packages/libffi/compile $(curdir)/feeds/packages/python-pip-conf/compile $(curdir)/feeds/packages/python/host/compile $(curdir)/feeds/packages/sqlite3/compile $(curdir)/libs/ncurses/compile $(curdir)/libs/openssl/compile $(curdir)/libs/toolchain/compile $(curdir)/libs/zlib/compile $(curdir)/utils/bzip2/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile)` **[-$(if $(CONFIG_PYTHON_BLUETOOTH_SUPPORT),$(curdir)/feeds/packages/bluez/compile)-]**` $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile)
```
$(curdir)/feeds/packages/python/host/compile += $(curdir)/feeds/packages/expat/host/compile $(curdir)/utils/bzip2/host/compile
$(curdir)/feeds/packages/python-aiohttp/compile += $(curdir)/feeds/packages/python-async-timeout/compile $(curdir)/feeds/packages/python-attrs/compile $(curdir)/feeds/packages/python-chardet/compile $(curdir)/feeds/packages/python-multidict/compile $(curdir)/feeds/packages/python-yarl/compile $(curdir)/feeds/packages/python3/compile $(curdir)/libs/toolchain/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile) $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile)
$(curdir)/feeds/packages/python-appdirs/compile += $(curdir)/feeds/packages/python3/compile $(curdir)/libs/toolchain/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile) $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile)
@@ -10302,7 +10302,7 @@
$(curdir)/feeds/packages/python-yarl/compile += $(curdir)/feeds/packages/python-idna/compile $(curdir)/feeds/packages/python-multidict/compile $(curdir)/feeds/packages/python3/compile $(curdir)/libs/toolchain/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile) $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile)
$(curdir)/feeds/packages/python-zeroconf/compile += $(curdir)/feeds/packages/python-ifaddr/compile $(curdir)/feeds/packages/python3/compile $(curdir)/libs/toolchain/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile) $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile)
$(curdir)/feeds/packages/python-zope-interface/compile += $(curdir)/libs/toolchain/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile) $(if $(CONFIG_PACKAGE_python-zope-interface),$(curdir)/feeds/packages/python/compile) $(if $(CONFIG_PACKAGE_python3-zope-interface),$(curdir)/feeds/packages/python3/compile) $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile)
```
`$(curdir)/feeds/packages/python3/compile += `**{+$(curdir)/feeds/packages/bluez/compile+}**` $(curdir)/feeds/packages/db47/compile $(curdir)/feeds/packages/gdbm/compile $(curdir)/feeds/packages/libffi/compile $(curdir)/feeds/packages/python-pip-conf/compile $(curdir)/feeds/packages/python3/host/compile $(curdir)/feeds/packages/sqlite3/compile $(curdir)/feeds/packages/xz/compile $(curdir)/libs/ncurses/compile $(curdir)/libs/openssl/compile $(curdir)/libs/toolchain/compile $(curdir)/libs/zlib/compile $(curdir)/utils/bzip2/compile $(curdir)/utils/util-linux/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile) `**[-$(if $(CONFIG_PYTHON3_BLUETOOTH_SUPPORT),$(curdir)/feeds/packages/bluez/compile) -]**` $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile)`
```
$(curdir)/feeds/packages/python3/host/compile += $(curdir)/feeds/packages/expat/host/compile $(curdir)/feeds/packages/libffi/host/compile $(curdir)/utils/bzip2/host/compile
$(curdir)/feeds/packages/python3-bottle/compile += $(curdir)/feeds/packages/python3/compile $(curdir)/libs/toolchain/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile) $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile)
$(curdir)/feeds/packages/python3-netifaces/compile += $(curdir)/feeds/packages/python3/compile $(curdir)/libs/toolchain/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile) $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile)
```
-  The final component that needs to be taken care of is the `opkg` dependency information, handled by the `EXTRA_DEPENDS` line.  The diffs here just show a change in the order of the dependencies, as `EXTRA_DEPENDS` goes first:
```
diff --git a/bin.bt.old/light/control b/bin.bt.new/light/control
index e84b35f7ff..77e680a4a6 100644
--- a/bin.bt.old/light/control
+++ b/bin.bt.new/light/control
@@ -1,10 +1,10 @@
 Package: python-light
-Version: 2.7.16-4
-Depends: libc, python-base, libffi, libbz2-1.0, bluez-libs
+Version: 2.7.16-5
+Depends: bluez-libs, libc, python-base, libffi, libbz2-1.0
 Source: feeds/packages/lang/python/python
 SourceName: python-light
-License: PSF
-LicenseFiles: LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
+License: Python/2.0
+LicenseFiles: LICENSE Doc/license.rst Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE Modules/expat/COPYING
 Section: lang
 Maintainer: Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 Architecture: arm_cortex-a9_vfpv3`
```
When bluetooth is not selected, there is no change to the Depends line.

I've checked that bluetooth option is not shown for a target that does not have USB support, by selecting the `TI AR7` target.

To make sure this does what I intended to do, I've added the conditional `DEPENDS` to `python-requests`, and doing the `DEPENDS` in samba4 like @Andy2244  wanted in #8535 : 
```
diff --git a/lang/python/python-requests/Makefile b/lang/python/python-requests/Makefile
index 1b8b981b0..ec4a2d587 100644
--- a/lang/python/python-requests/Makefile
+++ b/lang/python/python-requests/Makefile
@@ -52,11 +52,11 @@ endef
 define Package/python3-requests
 $(call Package/python-requests/Default)
   DEPENDS:= \
-         +python3-light  \
-         +python3-chardet  \
-         +python3-idna  \
-         +python3-urllib3  \
-         +python3-certifi
+         +PACKAGE_python3-requests:python3-light  \
+         +PACKAGE_python3-requests:python3-chardet  \
+         +PACKAGE_python3-requests:python3-idna  \
+         +PACKAGE_python3-requests:python3-urllib3  \
+         +PACKAGE_python3-requests:python3-certifi
   VARIANT:=python3
 endef

diff --git a/net/samba4/Makefile b/net/samba4/Makefile
index ff37ebd8e..164167f0a 100644
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -69,8 +69,7 @@ endef
 define Package/samba4-server
   $(call Package/samba4/Default)
   TITLE+= server
-  DEPENDS:= +samba4-libs
-  EXTRA_DEPENDS:=$(if $(CONFIG_SAMBA4_SERVER_AD_DC),python-crypto,)
+  DEPENDS:= +samba4-libs +SAMBA4_SERVER_AD_DC:python-crypto
 endef

 define Package/samba4-server/description
```
```
$ make defconfig
Collecting package info: done
tmp/.config-package.in:122021:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:122021:  symbol PACKAGE_samba4-server is selected by PACKAGE_luci-app-samba4
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:71157:   symbol PACKAGE_luci-app-samba4 depends on SAMBA4_SERVER_AD_DC
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
feeds/packages/net/samba4/Config.in:11: symbol SAMBA4_SERVER_AD_DC depends on PACKAGE_samba4-server
tmp/.config-package.in:25584:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:25584:   symbol PACKAGE_python-crypto is selected by PACKAGE_python-crypto
tmp/.config-package.in:29685:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:29685:   symbol PACKAGE_python3-influxdb depends on PACKAGE_python3-requests
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:30860:   symbol PACKAGE_python3-requests is selected by PACKAGE_python3-influxdb
tmp/.config-package.in:29062:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:29062:   symbol PACKAGE_python3-dateutil is selected by PACKAGE_python3-dateutil
tmp/.config-package.in:31141:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:31141:   symbol PACKAGE_python3-six is selected by PACKAGE_python3-six
tmp/.config-package.in:30826:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:30826:   symbol PACKAGE_python3-pytz is selected by PACKAGE_python3-pytz
#
# configuration written to .config
#
```