### PR TITLE
bluez: install kmod-bluetooth only w/ USB_SUPPORT

### DIFF
--- a/utils/bluez/Makefile
+++ b/utils/bluez/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bluez
 PKG_VERSION:=5.50
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/bluetooth/
@@ -47,7 +47,7 @@ $(call Package/bluez/Default)
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE+= library
-  DEPENDS:=+libpthread +kmod-bluetooth
+  DEPENDS:=+libpthread +USB_SUPPORT:kmod-bluetooth
 endef
 
 define Package/bluez-utils


### PR DESCRIPTION
Maintainer: none
Compile tested: current master: mvebu, WRT3200ACM for a case with bluetooth & ar7, TI AR7 for one without it
Run tested: none (verified that final package binaries are unchanged)

Description:
`kmod-bluetooth` depends on `USB_SUPPORT`.  If the dependency is not checked here, it will cause recursive dependency in python packages.

The change in final package is that, when built without `USB_SUPPORT`, the impossible-to-fullfill `kmod-bluetooth` dependency will not appear in the final package `control file`.  While it may not make much sense to use a bluetooth library in a router without bluetooth support, it allows them to use the same binaries.  The package is currently built in such systems (even though actual installation will fail), so I left it this way.  This can be changed by adding a `@USB_SUPPORT` dependency instead.

This obsoletes #9012.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>