### PR TITLE
syslog-ng: update to version 3.21.1

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
-PKG_VERSION:=3.20.1
+PKG_VERSION:=3.21.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
@@ -11,7 +11,7 @@ PKG_CPE_ID:=cpe:/a:balabit:syslog-ng
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/balabit/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_HASH:=a65858afe9c649119a23ff61669945cab8692a045ee8259e8ee666445c8fbda0
+PKG_HASH:=8d163da5ad79cf3a5f043b2ed0fe18a4888d0d740542703bf2508f0b9996cd25
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -4,7 +4,7 @@
 # More details about these settings can be found here:
 # https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.16/release-notes/global-options
 
-@version: 3.19
+@version: 3.21
 @include "scl.conf"
 @include "/etc/syslog-ng.d/" # Put any customization files in this directory
 


### PR DESCRIPTION
Maintainer: me 
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:

- update to version 3.21.1 ([release notes](https://github.com/balabit/syslog-ng/releases/tag/syslog-ng-3.21.1))