### PR TITLE
libgpg-error: Add ARC support

### DIFF
--- a/libs/libgpg-error/Makefile
+++ b/libs/libgpg-error/Makefile
@@ -9,13 +9,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgpg-error
 PKG_VERSION:=1.36
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=https://ftp.bit.nl/mirror/gnupg/ \
-		https://ftp.nluug.nl/security/gnupg/ \
-		http://ring.ksc.gr.jp/archives/net/gnupg/libgpg-error/ \
-		https://www.gnupg.org/ftp/gcrypt/libgpg-error/
+PKG_SOURCE_URL:=https://mirrors.dotsrc.org/gcrypt/libgpg-error \
+		http://ring.ksc.gr.jp/archives/net/gnupg/libgpg-error \
+		https://www.gnupg.org/ftp/gcrypt/libgpg-error
 PKG_HASH:=babd98437208c163175c29453f8681094bcaf92968a15cafb1a276076b33c97c
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>

--- a/libs/libgpg-error/patches/010-add-arc-support.patch
+++ b/libs/libgpg-error/patches/010-add-arc-support.patch
@@ -1,0 +1,71 @@
+From: Mylene Josserand <mylene.josserand at bootlin.com>
+
+DesignWare ARC Processors are a family of 32-bit CPUs from Synopsys.
+This change allows us to build for and use libgpg-error on ARC cores.
+
+These values were obtained from a test application executed on ARC
+in simulation this way:
+
+1. Instructions for cross-compilation used are here:
+   http://git.gnupg.org/cgi-bin/gitweb.cgi?p=libgpg-error.git;a=blob;f=README
+
+2. Commands used on host:
+   # build="$(build-aux/config.guess)"
+   # ./configure --prefix=build/tmp-uclibc/sysroots/nsimhs/usr/ --host=arc-oe-linux-uclibc --build=$build
+   # cd src
+   # make gen-posix-lock-obj
+
+3. Commands used on target:
+   # ./gen-posix-lock-obj
+
+Signed-off-by: Mylene Josserand <mylene.josserand at bootlin.com>
+Signed-off-by: Alexey Brodkin <abrodkin at synopsys.com>
+---
+ src/Makefile.am                               |  1 +
+ .../lock-obj-pub.arc-unknown-linux-gnu.h      | 23 +++++++++++++++++++
+ 2 files changed, 24 insertions(+)
+ create mode 100644 src/syscfg/lock-obj-pub.arc-unknown-linux-gnu.h
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 380ea7c09c04..bd00961c2f27 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -48,6 +48,7 @@ lock_obj_pub = \
+         syscfg/lock-obj-pub.aarch64-unknown-linux-gnu_ilp32.h \
+ 	syscfg/lock-obj-pub.aarch64-apple-darwin.h          \
+         syscfg/lock-obj-pub.alpha-unknown-linux-gnu.h       \
++        syscfg/lock-obj-pub.arc-unknown-linux-gnu.h         \
+         syscfg/lock-obj-pub.arm-unknown-linux-androideabi.h \
+         syscfg/lock-obj-pub.arm-unknown-linux-gnueabi.h     \
+ 	syscfg/lock-obj-pub.arm-apple-darwin.h              \
+diff --git a/src/syscfg/lock-obj-pub.arc-unknown-linux-gnu.h b/src/syscfg/lock-obj-pub.arc-unknown-linux-gnu.h
+new file mode 100644
+index 000000000000..3b1a8fadf8a7
+--- /dev/null
++++ b/src/syscfg/lock-obj-pub.arc-unknown-linux-gnu.h
+@@ -0,0 +1,23 @@
++## lock-obj-pub.arc-oe-linux-uclibc.h
++## File created by gen-posix-lock-obj - DO NOT EDIT
++## To be included by mkheader into gpg-error.h
++
++typedef struct
++{
++  long _vers;
++  union {
++    volatile char _priv[24];
++    long _x_align;
++    long *_xp_align;
++  } u;
++} gpgrt_lock_t;
++
++#define GPGRT_LOCK_INITIALIZER {1,{{0,0,0,0,0,0,0,0, \
++                                    0,0,0,0,0,0,0,0, \
++                                    0,0,0,0,0,0,0,0}}}
++##
++## Local Variables:
++## mode: c
++## buffer-read-only: t
++## End:
++##
+-- 
+2.17.1


### PR DESCRIPTION
Patch was posted on the mailing list. Awaits inclusion looks like. Fixes
long range build failures on the platform.

Updated Mirror list. The first two seem to not work.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
Compile tested: arc700