### PR TITLE
dnsdist: add package

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -1,0 +1,84 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dnsdist
+PKG_VERSION:=1.3.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
+PKG_HASH:=9fb24f9032025955169f3c6e9b0a05b6aa9d6441ec47da08d22de1c1aa23e8cf
+
+PKG_MAINTAINER:=James Taylor <james@jtaylor.id.au>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+
+PKG_INSTALL:=1
+
+PKG_CONFIG_DEPENDS:= \
+  CONFIG_DNSDIST_GNUTLS \
+  CONFIG_DNSDIST_OPENSSL
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/dnsdist/config
+comment "SSL support"
+
+choice
+        prompt "Selected SSL library"
+        default DNSDIST_OPENSSSL
+
+        config DNSDIST_OPENSSL
+                bool "OpenSSL"
+
+        config DNSDIST_GNUTLS
+                bool "GnuTLS"
+
+        config DNSDIST_NOSSL
+                bool "No SSL support"
+
+endchoice
+endef
+
+define Package/dnsdist
+  SECTION:=base
+  CATEGORY:=Network
+  TITLE:=dnsdist DNS-, DOS- and abuse-aware loadbalancer
+  DEPENDS:=+DNSDIST_OPENSSL:libopenssl +DNSDIST_GNUTLS:libgnutls +protobuf +re2 +libedit +libfstrm +libsodium +lua +boost +libnetsnmp
+  URL:=https://dnsdist.org/
+endef
+
+define Package/dnsdist/description
+  dnsdist is a highly DNS-, DoS- and abuse-aware loadbalancer. Its goal in life
+  is to route traffic to the best server, delivering top performance to legitimate
+  users while shunting or blocking abusive traffic.
+endef
+
+define Package/dnsdist/conffiles
+/etc/dnsdist.conf
+/etc/config/dnsdist
+/etc/init.d/dnsdist
+endef
+
+CONFIGURE_ARGS+= \
+	--enable-dnscrypt \
+	$(if $(CONFIG_DNSDIST_NOSSL),,--enable-dns-over-tls) \
+	--enable-fstrm \
+	--enable-libsodium \
+	--enable-protobuf \
+	--enable-re2 \
+	--with-net-snmp \
+        $(if $(CONFIG_DNSDIST_GNUTLS),--enable,--disable)-gnutls \
+        $(if $(CONFIG_DNSDIST_OPENSSL),--enable,--disable)-libssl
+
+define Package/dnsdist/install
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_CONF) ./files/dnsdist.conf $(1)/etc/dnsdist.conf
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/dnsdist.config $(1)/etc/config/dnsdist
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/dnsdist.init $(1)/etc/init.d/dnsdist
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dnsdist $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,dnsdist))

--- a/net/dnsdist/files/dnsdist.config
+++ b/net/dnsdist/files/dnsdist.config
@@ -1,0 +1,2 @@
+config 'dnsdist' 'general'
+        option enabled '0'

--- a/net/dnsdist/files/dnsdist.init
+++ b/net/dnsdist/files/dnsdist.init
@@ -1,0 +1,20 @@
+#!/bin/sh /etc/rc.common
+START=99
+
+USE_PROCD=1
+
+start_service() {
+	config_load dnsdist
+	local cfg=general
+	local enabled
+
+	config_get_bool enabled "$cfg" 'enabled' 1
+
+	[ $enabled -gt 0 ] || return 1
+
+	procd_open_instance
+	procd_set_param command dnsdist --supervised -C /etc/dnsdist.conf
+	procd_set_param file /etc/dnsdist.conf
+	procd_set_param respawn
+	procd_close_instance
+}

--- a/net/dnsdist/patches/100-net-snmp-config-Use-netsnmp_agent_libs-instead-of-agent_libs.patch
+++ b/net/dnsdist/patches/100-net-snmp-config-Use-netsnmp_agent_libs-instead-of-agent_libs.patch
@@ -1,0 +1,23 @@
+From d73bc006c62e4340ab56dd4baba5bc8eb8e1db49 Mon Sep 17 00:00:00 2001
+From: Remi Gacogne <remi.gacogne@powerdns.com>
+Date: Mon, 13 May 2019 16:01:06 +0200
+Subject: [PATCH] SNMP: Use net-snmp-config --netsnmp-agent-libs instead of
+ --agent-libs
+
+---
+ m4/pdns_with_net_snmp.m4 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/m4/pdns_with_net_snmp.m4 b/m4/pdns_with_net_snmp.m4
+index 8040672e6c..2da80c75fc 100644
+--- a/m4/pdns_with_net_snmp.m4
++++ b/m4/pdns_with_net_snmp.m4
+@@ -10,7 +10,7 @@ AC_DEFUN([PDNS_WITH_NET_SNMP], [
+   AS_IF([test "x$with_net_snmp" != "xno"], [
+     AS_IF([test "x$with_net_snmp" = "xyes" -o "x$with_net_snmp" = "xauto"], [
+       AC_CHECK_PROG([NET_SNMP_CFLAGS], [net-snmp-config], [`net-snmp-config --cflags`])
+-      AC_CHECK_PROG([NET_SNMP_LIBS], [net-snmp-config], [`net-snmp-config --agent-libs`])
++      AC_CHECK_PROG([NET_SNMP_LIBS], [net-snmp-config], [`net-snmp-config --netsnmp-agent-libs`])
+       AC_CHECK_DECLS([snmp_select_info2], [ : ], [ : ],
+         [AC_INCLUDES_DEFAULT
+           #include <net-snmp/net-snmp-config.h>


### PR DESCRIPTION
Maintainer: me
Compile tested: armv7l, OpenWRT SDK
Run tested: armv7l  Linksys WRT1900ACS, OpenWrt SNAPSHOT, r9987-655fff1571 -
confirmed dnsdist links correctly against dependencies and doesn't experience
errors at run-time when enabling features.

Description:
dnsdist is a highly DNS-, DoS- and abuse-aware loadbalancer. Its goal in life is
to route traffic to the best server, delivering top performance to legitimate
users while shunting or blocking abusive traffic.

dnsdist is dynamic, its configuration language is Lua and it can be changed at
runtime, and its statistics can be queried from a console-like interface or an
HTTP API.

https://dnsdist.org/

Closes: PowerDNS/pdns#3294

Signed-off-by: James Taylor <james@jtaylor.id.au>