### PR TITLE
stunnel: update version to 5.54

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.53
+PKG_VERSION:=5.54
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0+
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=80439896ee14269eb70bc8bc669433c7d619018a62c9f9c5c760a24515302585
+PKG_HASH:=5e8588a6c274b46b1d63e1b50f0725f4908dec736f6588eb48d1eb3d20c87902
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool

--- a/net/stunnel/files/stunnel.init
+++ b/net/stunnel/files/stunnel.init
@@ -101,6 +101,8 @@ validate_service_options() {
 		'socket:list(string)' \
 		'sslVersion:or("all","SSLv2","SSLv3","TLSv1","TLSv1.1","TLSv1.2")' \
 		'stack:uinteger' \
+		'ticketKeySecret:string' \
+		'ticketMacSecret:string' \
 		'TIMEOUTbusy:uinteger' \
 		'TIMEOUTclose:uinteger' \
 		'TIMEOUTconnect:uinteger' \
@@ -259,6 +261,8 @@ print_service_options() {
 		setuid \
 		sslVersion \
 		stack \
+		ticketKeySecret \
+		ticketMacSecret \
 		TIMEOUTbusy \
 		TIMEOUTclose \
 		TIMEOUTconnect \


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64 xrx200_lantiq, APU3, OpenWrt master
Run tested: x86_64, APU3, OpenWrt master, start service with default config

Description:

- Update to latest stable release 5.54
- Add new options ticketKeySecret and ticketMacSecret to uci validation

 @jefferyto could you please have a look if the new options `ticketKeySecret` and `ticketMacSecret`
which were add with the new version are correct validated by /sbin/validate_data