### PR TITLE
treewide: add PACKAGE_* DEPENDS conditionals to python packages building both variants, update README.md

### DIFF
--- a/lang/python/README.md
+++ b/lang/python/README.md
@@ -228,9 +228,9 @@ endef
 Some considerations here (based on the example above):
 * be sure to make sure that `DEPENDS` are correct for both variants; as seen in the example above, `python-codecs` is needed only for `python-lxml` (see **[note-encodings](#note-encodings)**)
 * consider adding conditional DEPENDS for each variant ; so for each Python[3] package add `+PACKAGE_python-lxml:<dep>` as seen in the above example ; the reason for this is build-time reduction ; if you want to build Python3 only packages, this won't build Python & Python packages + dependencies ; this is a known functionality of OpenWrt build deps
-  * there is an exception to the above consideration: if adding `+PACKAGE_python-lxml` conditional deps creates circular dependencies [for some weird reason], then this can be omitted
+  * this should not happen anymore, but if adding `+PACKAGE_python-lxml` conditional deps creates circular dependencies, then open an issue so this can be resolved again.
 * `VARIANT=python` or `VARIANT=python3` must be added
-* typically each variant package is named `Package/python3-<something>` & `Package/python3-<something>` ; this convention makes things easier to follow, though it could work without naming things this this
+* typically each variant package is named `Package/python-<something>` & `Package/python3-<something>` ; this convention makes things easier to follow, though it could work without naming things this way
 * `TITLE` can be something a bit more verbose/neat ; typically the name is short as seen above
 
 <a name="note-encodings">**note-encodings**</a>: That's because some character encodings are needed, which are present in `python3-base` but not in `python-light` (but are present in `python-codecs`) ; this is because Python3 is designed to be more Unicode friendly than Python2 (it's one of the fundamental differences between the 2), and Python3 won't start without those encodings being present.
@@ -272,12 +272,12 @@ These packages will contain byte-codes and binaries (shared libs & other stuff).
 If a user wishes to ship source code, adding 2 more lines creates 2 more packages that ship Python source code:
 ```
 $(eval $(call PyPackage,python-lxml))
-$(eval $(call PyPackage,python-lxml-src))
 $(eval $(call BuildPackage,python-lxml))
+$(eval $(call BuildPackage,python-lxml-src))
 
 $(eval $(call Py3Package,python3-lxml))
-$(eval $(call Py3Package,python3-lxml-src))
 $(eval $(call BuildPackage,python3-lxml))
+$(eval $(call BuildPackage,python3-lxml-src))
 ```
 
 The name `*-src` must be the Python package name; so for `python-lxml-src` a equivalent `python-lxml` name must exist.

--- a/lang/python/python-awscli/Makefile
+++ b/lang/python/python-awscli/Makefile
@@ -28,27 +28,27 @@ endef
 
 define Package/python-awscli
 $(call Package/python-awscli/Default)
-  DEPENDS:=+python \
-	+python-yaml \
-	+python-pyasn1 \
-	+python-botocore \
-	+python-rsa \
-	+python-colorama \
-	+python-docutils \
-	+python-s3transfer
+  DEPENDS:=+PACKAGE_python-awscli:python \
+	+PACKAGE_python-awscli:python-yaml \
+	+PACKAGE_python-awscli:python-pyasn1 \
+	+PACKAGE_python-awscli:python-botocore \
+	+PACKAGE_python-awscli:python-rsa \
+	+PACKAGE_python-awscli:python-colorama \
+	+PACKAGE_python-awscli:python-docutils \
+	+PACKAGE_python-awscli:python-s3transfer
   VARIANT:=python
 endef
 
 define Package/python3-awscli
 $(call Package/python-awscli/Default)
-  DEPENDS:=+python3 \
-	+python3-yaml \
-	+python3-pyasn1 \
-	+python3-botocore \
-	+python3-rsa \
-	+python3-colorama \
-	+python3-docutils \
-	+python3-s3transfer
+  DEPENDS:=+PACKAGE_python3-awscli:python3 \
+	+PACKAGE_python3-awscli:python3-yaml \
+	+PACKAGE_python3-awscli:python3-pyasn1 \
+	+PACKAGE_python3-awscli:python3-botocore \
+	+PACKAGE_python3-awscli:python3-rsa \
+	+PACKAGE_python3-awscli:python3-colorama \
+	+PACKAGE_python3-awscli:python3-docutils \
+	+PACKAGE_python3-awscli:python3-s3transfer
   VARIANT:=python3
 endef
 

--- a/lang/python/python-botocore/Makefile
+++ b/lang/python/python-botocore/Makefile
@@ -28,23 +28,23 @@ endef
 
 define Package/python-botocore
 $(call Package/python-botocore/Default)
-  DEPENDS:=+python \
-	+python-urllib3 \
-	+python-docutils \
-	+python-dateutil \
-	+python-jmespath \
-	+python-requests
+  DEPENDS:=+PACKAGE_python-botocore:python \
+	+PACKAGE_python-botocore:python-urllib3 \
+	+PACKAGE_python-botocore:python-docutils \
+	+PACKAGE_python-botocore:python-dateutil \
+	+PACKAGE_python-botocore:python-jmespath \
+	+PACKAGE_python-botocore:python-requests
   VARIANT:=python
 endef
 
 define Package/python3-botocore
 $(call Package/python-botocore/Default)
-  DEPENDS:=+python3 \
-	+python3-urllib3 \
-	+python3-docutils \
-	+python3-dateutil \
-	+python3-jmespath \
-	+python3-requests
+  DEPENDS:=+PACKAGE_python3-botocore:python3 \
+	+PACKAGE_python3-botocore:python3-urllib3 \
+	+PACKAGE_python3-botocore:python3-docutils \
+	+PACKAGE_python3-botocore:python3-dateutil \
+	+PACKAGE_python3-botocore:python3-jmespath \
+	+PACKAGE_python3-botocore:python3-requests
   VARIANT:=python3
 endef
 

--- a/lang/python/python-colorama/Makefile
+++ b/lang/python/python-colorama/Makefile
@@ -28,13 +28,13 @@ endef
 
 define Package/python-colorama
 $(call Package/python-colorama/Default)
-  DEPENDS:=+python
+  DEPENDS:=+PACKAGE_python-colorama:python
   VARIANT:=python
 endef
 
 define Package/python3-colorama
 $(call Package/python-colorama/Default)
-  DEPENDS:=+python3
+  DEPENDS:=+PACKAGE_python3-colorama:python3
   VARIANT:=python3
 endef
 

--- a/lang/python/python-docutils/Makefile
+++ b/lang/python/python-docutils/Makefile
@@ -28,13 +28,13 @@ endef
 
 define Package/python-docutils
 $(call Package/python-docutils/Default)
-  DEPENDS:=+python
+  DEPENDS:=+PACKAGE_python-docutils:python
   VARIANT:=python
 endef
 
 define Package/python3-docutils
 $(call Package/python-docutils/Default)
-  DEPENDS:=+python3
+  DEPENDS:=+PACKAGE_python3-docutils:python3
   VARIANT:=python3
 endef
 

--- a/lang/python/python-jmespath/Makefile
+++ b/lang/python/python-jmespath/Makefile
@@ -28,13 +28,13 @@ endef
 
 define Package/python-jmespath
 $(call Package/python-jmespath/Default)
-  DEPENDS:=+python
+  DEPENDS:=+PACKAGE_python-jmespath:python
   VARIANT:=python
 endef
 
 define Package/python3-jmespath
 $(call Package/python-jmespath/Default)
-  DEPENDS:=+python3
+  DEPENDS:=+PACKAGE_python3-jmespath:python3
   VARIANT:=python3
 endef
 

--- a/lang/python/python-ply/Makefile
+++ b/lang/python/python-ply/Makefile
@@ -44,7 +44,7 @@ endef
 
 define Package/python3-ply
 $(call Package/python-ply/Default)
-  DEPENDS:=+python3-light
+  DEPENDS:=+PACKAGE_python3-ply:python3-light
   VARIANT:=python3
 endef
 

--- a/lang/python/python-pyserial/Makefile
+++ b/lang/python/python-pyserial/Makefile
@@ -36,14 +36,14 @@ endef
 define Package/python-pyserial
 $(call Package/python-pyserial/Default)
   TITLE:=python-pyserial
-  DEPENDS:=+python-light
+  DEPENDS:=+PACKAGE_python-pyserial:python-light
   VARIANT:=python
 endef
 
 define Package/python3-pyserial
 $(call Package/python-pyserial/Default)
   TITLE:=python3-pyserial
-  DEPENDS:=+python3-light
+  DEPENDS:=+PACKAGE_python3-pyserial:python3-light
   VARIANT:=python3
 endef
 

--- a/lang/python/python-requests/Makefile
+++ b/lang/python/python-requests/Makefile
@@ -52,11 +52,11 @@ endef
 define Package/python3-requests
 $(call Package/python-requests/Default)
   DEPENDS:= \
-	  +python3-light  \
-	  +python3-chardet  \
-	  +python3-idna  \
-	  +python3-urllib3  \
-	  +python3-certifi
+	  +PACKAGE_python3-requests:python3-light  \
+	  +PACKAGE_python3-requests:python3-chardet  \
+	  +PACKAGE_python3-requests:python3-idna  \
+	  +PACKAGE_python3-requests:python3-urllib3  \
+	  +PACKAGE_python3-requests:python3-certifi
   VARIANT:=python3
 endef
 

--- a/lang/python/python-rsa/Makefile
+++ b/lang/python/python-rsa/Makefile
@@ -28,13 +28,13 @@ endef
 
 define Package/python-rsa
 $(call Package/python-rsa/Default)
-  DEPENDS:=+python +python-pyasn1
+  DEPENDS:=+PACKAGE_python-rsa:python +PACKAGE_python-rsa:python-pyasn1
   VARIANT:=python
 endef
 
 define Package/python3-rsa
 $(call Package/python-rsa/Default)
-  DEPENDS:=+python3 +python3-pyasn1
+  DEPENDS:=+PACKAGE_python3-rsa:python3 +PACKAGE_python3-rsa:python3-pyasn1
   VARIANT:=python3
 endef
 

--- a/lang/python/python-s3transfer/Makefile
+++ b/lang/python/python-s3transfer/Makefile
@@ -28,13 +28,18 @@ endef
 
 define Package/python-s3transfer
 $(call Package/python-s3transfer/Default)
-  DEPENDS:=+python +python-botocore +python-futures
+  DEPENDS:= \
+	+PACKAGE_python-s3transfer:python \
+	+PACKAGE_python-s3transfer:python-botocore \
+	+PACKAGE_python-s3transfer:python-futures
   VARIANT:=python
 endef
 
 define Package/python3-s3transfer
 $(call Package/python-s3transfer/Default)
-  DEPENDS:=+python3 +python3-botocore
+  DEPENDS:= \
+	+PACKAGE_python3-s3transfer:python3 \
+	+PACKAGE_python3-s3transfer:python3-botocore
   VARIANT:=python3
 endef
 

--- a/lang/python/python-simplejson/Makefile
+++ b/lang/python/python-simplejson/Makefile
@@ -34,7 +34,7 @@ endef
 define Package/python-simplejson
 $(call Package/python-simplejson/Default)
   TITLE:=Simple, fast, extensible JSON encoder/decoder for Python 2
-  DEPENDS:=+python-light
+  DEPENDS:=+PACKAGE_python-simplejson:python-light
   VARIANT:=python
 endef
 


### PR DESCRIPTION
Maintainer: @jefferyto @commodo @dddaniel @mickeprag @BKPepe 
Compile tested: mvebu, WRT3200ACM, openwrt master
Run tested: none - just ensured that there was no _relevant*_ binary changes

Description:
Since the problem causing those random circular dependencies has been fixed, there's no reason to leave out the python version conditionals that avoid always compiling both versions of python, even if only one is needed.
I've updated README.md as well, but instead of removing the entire reference to the circular dependencies, I left it as a note to open a new issue if it happens.  I am not sure this is the best thing to do--it seems too obvious.  I stumbled upon a couple of errors, which I'm fixing here as well.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>

_*_ As for an _irrelevant_ binary change, it seems that `usr/lib/python3.7/site-packages/requests-2.22.0-py3.7.egg-info/PKG-INFO` does not like reproducible builds:
```
--- build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/python3-requests-2.22.0/.pkgdir/python3-requests/usr/lib/python3.7/site-packages/requests-2.22.0-py3.7.egg-info/PKG-INFO 2019-05-20 15:19:06.572208624 -0300
+++ tmp/new/usr/lib/python3.7/site-packages/requests-2.22.0-py3.7.egg-info/PKG-INFO     2019-05-09 08:51:38.000000000 -0300
@@ -130,5 +130,5 @@
 Classifier: Programming Language :: Python :: Implementation :: PyPy
 Requires-Python: >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 Description-Content-Type: text/markdown
-Provides-Extra: security
 Provides-Extra: socks
+Provides-Extra: security
```
Rebuild same package:
```
~/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/python3-requests-2.22.0 $ diff -u {.pkgdir/python3-requests,../../../tmp/new}/usr/lib/python3.7/site-packages/requests-2.22.0-py3.7.egg-info/PKG-INFO
~/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/python3-requests-2.22.0 $
```
I haven't checked the python2 version every single time, but for at least 3 builds they have matched.