### PR TITLE
Python/python3: refresh license information

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -12,14 +12,14 @@ include ../python-version.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)
 PKG_HASH:=f222ef602647eecb6853681156d32de4450a2c39f4de93bd5b20235f2e660ed7
 
-PKG_LICENSE:=PSF
-PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
+PKG_LICENSE:=Python/2.0
+PKG_LICENSE_FILES:=LICENSE Doc/copyright.rst Doc/license.rst Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Modules/expat/COPYING
 PKG_CPE_ID:=cpe:/a:python:python
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -14,15 +14,15 @@ PYTHON_VERSION:=$(PYTHON3_VERSION)
 PYTHON_VERSION_MICRO:=$(PYTHON3_VERSION_MICRO)
 
 PKG_NAME:=python3
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)
 PKG_HASH:=d83fe8ce51b1bb48bbcf0550fd265b9a75cdfdfa93f916f9e700aef8444bf1bb
 
-PKG_LICENSE:=PSF
-PKG_LICENSE_FILES:=LICENSE Modules/_ctypes/libffi_msvc/LICENSE Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi/LICENSE Modules/_ctypes/libffi_osx/LICENSE Tools/pybench/LICENSE
+PKG_LICENSE:=Python/2.0
+PKG_LICENSE_FILES:=LICENSE Doc/copyright.rst Doc/license.rst Modules/_ctypes/darwin/LICENSE Modules/_ctypes/libffi_osx/LICENSE Modules/expat/COPYING
 PKG_CPE_ID:=cpe:/a:python:python
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>


### PR DESCRIPTION
Maintainers: @commodo @jefferyto
Compile tested: mvebu, WRT3200ACM, openwrt master
Run tested: not needed

Description:
While looking for a SPDX tag for defusedxml, I looked at these as examples, but found out they had an incorrect SPDX tag, so I changed them. While at it, I looked into the `PKG_LICENSE_FILES`, and got into trouble.  There were non-existing files, files related to windows stuff we don't use/distribute, and packages we are adding to the build, so I'm trying to get these right.

I've run this to find license-related files from the source:
```
Python-2.7.16 $ find . -iregex '.*\(copy\|licens\|notice\|gpl\).*' -a -not -iregex '.*\.\(py\|c\|decTest\|js\)' | egrep -v Doc.library
./Modules/_ctypes/libffi_osx/LICENSE
./Modules/_ctypes/darwin/LICENSE
./Modules/_ctypes/libffi/LICENSE
./Modules/_ctypes/libffi_msvc/LICENSE
./Modules/expat/COPYING
./Tools/pybench/LICENSE
./Tools/pynche/X/xlicense.txt
./Tools/msi/crtlicense.txt
./LICENSE
./Doc/copyright.rst
./Doc/license.rst
./Mac/BuildScript/resources/License.rtf
./Mac/Demo/applescript/Disk_Copy
```
./Modules/_ctypes/libffi_msvc/LICENSE, ./Tools/msi/crtlicense.txt, ./Mac/BuildScript/resources/License.rtf & ./Mac/Demo/applescript/Disk_Copy are obviously not needed, since we're not using any of this.
The Tools are not being built/used either, so I left them out as well.
The most complete of the files above is `Doc/license.rst`, which includes expat, and libffi licenses, so to me, it could be the only one needed to be listed.  I'm no expert, so I'm not minimizing this unless told.
However, after building, the list grows with the inclusion of pip & setuptools: 
```
./install-setuptools/lib/python2.7/site-packages/setuptools-40.6.2.dist-info/LICENSE
./install-pip/lib/python2.7/site-packages/pip-18.1.dist-info/LICENSE.txt
```
I don't know how to handle the multiple source "bundles" inside inside a single Makefile.  I did not touch them at all, since they seem to be versioned (and thus subject to change) but their licenses are both MIT, btw.  It seems to me, if we are looking exclusively at the licensing point of view, that we should be separating them so they each get their own license tags and files, but just bundling them together should be an acceptable compromise.

Here's the same run in Python 3.7:
```
find . -iregex '.*\(copy\|licens\|notice\|gpl\).*' -a -not -iregex '.*\.\(py\|c\|decTest\|js\)' | egrep -v Doc.library
./Modules/_ctypes/libffi_osx/LICENSE
./Modules/_ctypes/darwin/LICENSE
./Modules/_ctypes/libffi_msvc/LICENSE
./Modules/expat/COPYING
./Tools/pynche/X/xlicense.txt
./Tools/msi/bundle/bootstrap/LICENSE.txt
./Tools/msi/exe/crtlicense.txt
./LICENSE
./Doc/copyright.rst
./Doc/license.rst
./Mac/BuildScript/resources/License.rtf
```
and
```
./install-setuptools/lib/python3.7/site-packages/setuptools-40.6.2.dist-info/LICENSE
./install-pip/lib/python3.7/site-packages/pip-18.1.dist-info/LICENSE.txt
```