### PR TITLE
fish: Do not build with uClibc-ng

### DIFF
--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -25,7 +25,7 @@ define Package/fish
   CATEGORY:=Utilities
   SUBMENU:=Shells
   TITLE:=A smart and user-friendly command line shell
-  DEPENDS:=+libncurses +libstdcpp +librt +libpcre2-32
+  DEPENDS:=+libncurses +libstdcpp +librt +libpcre2-32 @!UCLIBC
   URL:=https://fishshell.com
 endef
 


### PR DESCRIPTION
fish requires locale_t, which uClibc-ng does not enable by default.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @haodong 
Compile tested: arc700

https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/fish/compile.txt