### PR TITLE
node-serialport-bindings: add new package - fix powerpc build fail

### DIFF
--- a/lang/node-serialport-bindings/Makefile
+++ b/lang/node-serialport-bindings/Makefile
@@ -1,0 +1,74 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NPM_SCOPE:=serialport
+PKG_NPM_NAME:=bindings
+PKG_NAME:=node-$(PKG_NPM_SCOPE)-$(PKG_NPM_NAME)
+PKG_VERSION:=2.0.8
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
+PKG_SOURCE_URL:=https://registry.npmjs.org/@$(PKG_NPM_SCOPE)/$(PKG_NPM_NAME)/-/
+PKG_HASH:=2e0d0ca6168ba104fe60692e33c76ec44ff9533bf7b657dfc6e00da410728df4
+
+PKG_BUILD_DEPENDS:=node/host
+PKG_USE_MIPS16:=0
+
+PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/node-serialport-bindings
+  SUBMENU:=Node.js
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=SerialPort Bindings
+  URL:=https://www.npmjs.com/package/@serialport/bindings
+  DEPENDS:=+node
+endef
+
+define Package/node-serialport-bindings/description
+ The Binding is how Node-SerialPort talks to the underlying system. By default, we auto detect Windows, Linux and OS X, and load the appropriate module for your system. You can assign SerialPort.Binding to any binding you like.
+endef
+
+TAR_OPTIONS+= --strip-components 1
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
+
+NODEJS_CPU:=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))))
+TMPNPM:=$(shell mktemp -u XXXXXXXXXX)
+
+TARGET_CFLAGS+=$(FPIC)
+TARGET_CPPFLAGS+=$(FPIC)
+
+define Build/Compile
+	$(MAKE_VARS) \
+	$(MAKE_FLAGS) \
+	npm_config_arch=$(NODEJS_CPU) \
+	npm_config_target_arch=$(NODEJS_CPU) \
+	npm_config_build_from_source=true \
+	npm_config_nodedir=$(STAGING_DIR)/usr/ \
+	npm_config_prefix=$(PKG_INSTALL_DIR)/usr/ \
+	npm_config_cache=$(TMP_DIR)/npm-cache-$(TMPNPM) \
+	npm_config_tmp=$(TMP_DIR)/npm-tmp-$(TMPNPM) \
+	npm install -g --build-from-source $(PKG_BUILD_DIR)
+	rm -rf $(TMP_DIR)/npm-tmp-$(TMPNPM)
+	rm -rf $(TMP_DIR)/npm-cache-$(TMPNPM)
+endef
+
+define Package/node-serialport-bindings/install
+	$(INSTALL_DIR) $(1)/usr/lib/node/@$(PKG_NPM_SCOPE)/$(PKG_NPM_NAME)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/@$(PKG_NPM_SCOPE)/$(PKG_NPM_NAME)/{package.json,LICENSE,*.md} \
+		$(1)/usr/lib/node/@$(PKG_NPM_SCOPE)/$(PKG_NPM_NAME)
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/@$(PKG_NPM_SCOPE)/$(PKG_NPM_NAME)/{node_modules,lib} \
+		$(1)/usr/lib/node/@$(PKG_NPM_SCOPE)/$(PKG_NPM_NAME)
+	$(INSTALL_DIR) $(1)/usr/lib/node/@$(PKG_NPM_SCOPE)/$(PKG_NPM_NAME)/build/Release
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/@$(PKG_NPM_SCOPE)/$(PKG_NPM_NAME)/build/Release/bindings.node \
+		$(1)/usr/lib/node/@$(PKG_NPM_SCOPE)/$(PKG_NPM_NAME)/build/Release/
+endef
+
+$(eval $(call BuildPackage,node-serialport-bindings))

--- a/lang/node-serialport-bindings/patches/000-powerpc_termios_header.patch
+++ b/lang/node-serialport-bindings/patches/000-powerpc_termios_header.patch
@@ -1,0 +1,16 @@
+--- a/src/serialport_linux.cpp
++++ b/src/serialport_linux.cpp
+@@ -1,8 +1,13 @@
+ #if defined(__linux__)
+ 
+ #include <sys/ioctl.h>
++#if defined(__powerpc__) || defined(__powerpc64__)
++#include <asm-generic/ioctls.h>
++#include <asm-generic/termbits.h>
++#else
+ #include <asm/ioctls.h>
+ #include <asm/termbits.h>
++#endif
+ 
+ // Uses the termios2 interface to set nonstandard baud rates
+ int linuxSetCustomBaudRate(const int fd, const unsigned int baudrate) {


### PR DESCRIPTION
Maintainer: me 
Compile tested: r10061-0f6b944, powerpc_464fp_gcc-7.4.0_musl, aarch64_cortex-a53_gcc-7.4.0_musl
Run tested: aarch64 (ec2 a1 docker)

Description:
fix powerpc 'node-serialport' package build fail
divide node-serialport' into node-serialport' and node-serialport-bindings

powerpc termios2 issue ref: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1619446

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
