### PR TITLE
node-serialport: fix powerpc build fail

### DIFF
--- a/lang/node-serialport/Makefile
+++ b/lang/node-serialport/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=serialport
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=7.1.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://registry.npmjs.org/$(PKG_NPM_NAME)/-/
@@ -31,7 +31,7 @@ define Package/node-serialport
   CATEGORY:=Languages
   TITLE:=Node.js package to access serial ports
   URL:=https://serialport.io/
-  DEPENDS:=+node +node-npm
+  DEPENDS:=+node +node-npm +node-serialport-bindings
 endef
 
 define Package/node-serialport/description

--- a/lang/node-serialport/patches/001-turn_off_depends.patch
+++ b/lang/node-serialport/patches/001-turn_off_depends.patch
@@ -1,0 +1,10 @@
+--- a/package.json
++++ b/package.json
+@@ -41,7 +41,6 @@
+   ],
+   "dependencies": {
+     "@serialport/binding-mock": "^2.0.5",
+-    "@serialport/bindings": "^2.0.8",
+     "@serialport/parser-byte-length": "^2.0.2",
+     "@serialport/parser-cctalk": "^2.0.2",
+     "@serialport/parser-delimiter": "^2.0.2",


### PR DESCRIPTION
Maintainer: me 
Compile tested: r10061-0f6b944, powerpc_464fp_gcc-7.4.0_musl, aarch64_cortex-a53_gcc-7.4.0_musl
Run tested: aarch64 (ec2 a1 docker)

Description:
fix powerpc 'node-serialport' package build fail
divide node-serialport' into node-serialport' and node-serialport-bindings
node-serialport-bindings PR : https://github.com/openwrt/packages/pull/9045

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
