### PR TITLE
luajit: permit building on macos host

### DIFF
--- a/lang/luajit/Makefile
+++ b/lang/luajit/Makefile
@@ -43,12 +43,14 @@ define Build/Compile
 		CROSS="$(TARGET_CROSS)" \
 		DPREFIX=$(PKG_INSTALL_DIR)/usr \
 		PREFIX=/usr \
+		TARGET_SYS=Linux \
 		TARGET_CFLAGS="$(TARGET_CFLAGS)"
 	rm -rf $(PKG_INSTALL_DIR)
 	mkdir -p $(PKG_INSTALL_DIR)
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		DPREFIX=$(PKG_INSTALL_DIR)/usr \
 		PREFIX=/usr \
+		TARGET_SYS=Linux \
 		install
 endef
 


### PR DESCRIPTION

Maintainer: @milani 
Compile tested: x86

Description:

luajit didn't understand completely that it was building in a cross
compiled environment for Linux target.  This would cause issues when
building under openwrt on macos.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>