### PR TITLE
liburcu: Do not build on ARC

### DIFF
--- a/libs/liburcu/Makefile
+++ b/libs/liburcu/Makefile
@@ -31,7 +31,7 @@ define Package/liburcu
 	CATEGORY:=Libraries
 	TITLE:=User-space Read-Copy-Update library
 	URL:=https://lttng.org/
-	DEPENDS:=+libpthread
+	DEPENDS:=+libpthread @!arc
 endef
 
 define Package/liburcu/description


### PR DESCRIPTION
Not supported.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @salzmdan 
Compile tested: arc700

https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/liburcu/compile.txt