### PR TITLE
seafile-server: release bump due to libevhtp bump

### DIFF
--- a/libs/libevhtp/Makefile
+++ b/libs/libevhtp/Makefile
@@ -13,6 +13,9 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=libevhtp
 PKG_VERSION:=1.2.0
 PKG_RELEASE:=2
+# This package is building a static library, used by seafile-server
+# Every time the built library changes (metadata changes are exempt),
+# seafile-server needs a release bump to ensure the update is used.
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/criticalstack/libevhtp/tar.gz/$(PKG_VERSION)?

--- a/net/seafile-server/Makefile
+++ b/net/seafile-server/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-server
 PKG_VERSION:=6.3.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-3.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: mvebu, WRT3200ACM, openwrt master
Run tested: mvebu, WRT3200ACM, openwrt master; started server, created a file, downloaded the file using the web interface.  This sequence tests libevhtp, btw.  It is not working with the (upstream) latest version (yet).

Description:
Libevhtp is building a static library, used by seafile-server.
Every time the libevhtp binary changes, seafile-server needs a release bump.
Leave a note in the libevhtp Makefile, as a reminder.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>