### PR TITLE
libmraa: Fix faulty depends

### DIFF
--- a/libs/libmraa/Makefile
+++ b/libs/libmraa/Makefile
@@ -53,7 +53,7 @@ endef
 define Package/libmraa
   $(call Package/libmraa/Default)
   TITLE:=Intel IoT lowlevel IO C/C++ library
-  DEPENDS:=+libstdcpp +libjson-c @!arc @!armeb @!ppc
+  DEPENDS:=+libstdcpp +libjson-c @!arc @!armeb @!powerpc
 endef
 
 define Package/libmraa/description


### PR DESCRIPTION
@ppc is actually @powerpc.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nxhack 

https://downloads.openwrt.org/snapshots/faillogs/powerpc_464fp/packages/libmraa/compile.txt

Looks like powerpc is the proper one.