### PR TITLE
(18.06) sqlite3: fix arm endian issue

### DIFF
--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqlite
 PKG_VERSION:=3260000
-PKG_RELEASE:=2
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-autoconf-$(PKG_VERSION).tar.gz
 PKG_HASH:=5daa6a3fb7d1e8c767cd59c4ded8da6e4b00c61d3b466d0685e35c4dd6d7bf5d

--- a/libs/sqlite3/patches/01-sqlite-arm-endian.patch
+++ b/libs/sqlite3/patches/01-sqlite-arm-endian.patch
@@ -1,0 +1,21 @@
+--- a/sqlite3.c
++++ b/sqlite3.c
+@@ -13895,12 +13895,13 @@ typedef INT16_TYPE LogEst;
+ ** at run-time.
+ */
+ #ifndef SQLITE_BYTEORDER
+-# if defined(i386)     || defined(__i386__)   || defined(_M_IX86) ||    \
+-     defined(__x86_64) || defined(__x86_64__) || defined(_M_X64)  ||    \
+-     defined(_M_AMD64) || defined(_M_ARM)     || defined(__x86)   ||    \
+-     defined(__arm__)  || defined(_M_ARM64)
++# if defined(i386)      || defined(__i386__)      || defined(_M_IX86) ||    \
++     defined(__x86_64)  || defined(__x86_64__)    || defined(_M_X64)  ||    \
++     defined(_M_AMD64)  || defined(_M_ARM)        || defined(__x86)   ||    \
++     defined(__ARMEL__) || defined(__AARCH64EL__) || defined(_M_ARM64)
+ #   define SQLITE_BYTEORDER    1234
+-# elif defined(sparc)    || defined(__ppc__)
++# elif defined(sparc)     || defined(__ppc__) || \
++       defined(__ARMEB__) || defined(__AARCH64EB__)
+ #   define SQLITE_BYTEORDER    4321
+ # else
+ #   define SQLITE_BYTEORDER 0


### PR DESCRIPTION
Maintainer: me
Compile tested: i386, arm, armeb, aarch64
Run tested: arm (qemu), armeb (done by forum user portuquesa), aarch64 (qemu)

Description:
Backport arm endian fix from master.

The revision is raised to 4 instead of 3. The reason is that portuquesa from the forum run-tested some ipks I sent him, and the last one had revision 4. I wouldn't like him to miss out on a future upgrade just because of him having revision 4 installed already. I hope nobody minds.

Thanks!
Seb