### PR TITLE
lm-sensors: add conditionals to perl dependencies

### DIFF
--- a/utils/lm-sensors/Makefile
+++ b/utils/lm-sensors/Makefile
@@ -42,7 +42,12 @@ define Package/lm-sensors-detect
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=lm-sensors-detect
-  DEPENDS+=+lm-sensors +perl +perlbase-essential +perlbase-fcntl +perlbase-file +perlbase-xsloader
+  DEPENDS+=+lm-sensors \
+	+PACKAGE_lm-sensors-detect:perl \
+	+PACKAGE_lm-sensors-detect:perlbase-essential \
+	+PACKAGE_lm-sensors-detect:perlbase-fcntl \
+	+PACKAGE_lm-sensors-detect:perlbase-file \
+	+PACKAGE_lm-sensors-detect:perlbase-xsloader
 endef
 
 define Package/libsensors


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: mvebu, WRT3200ACM, openwrt master
Run tested: none, package does not change.

Description:
This will avoid building perl if lm-sensors-detect is not selected, simplifying the build of just `lm-sensors` from this
```
 make[1] package/lm-sensors/compile
 make[2] -C package/libs/toolchain compile
 make[2] -C package/libs/sysfsutils compile
 make[2] -C package/libs/zlib compile
 make[2] -C feeds/packages/libs/libxml2 compile
 make[2] -C package/libs/uclibc++ compile
 make[2] -C feeds/packages/libs/db47 compile
 make[2] -C package/libs/gettext-full host-compile
 make[2] -C feeds/packages/libs/gdbm compile
 make[2] -C feeds/packages/lang/perl host-compile
 make[2] -C feeds/packages/lang/perl clean-build
 make[2] -C feeds/packages/lang/perl compile
 make[2] -C feeds/packages/utils/lm-sensors clean-build
 make[2] -C feeds/packages/utils/lm-sensors compile
```
to
```
 make[1] package/lm-sensors/compile
 make[2] -C package/libs/toolchain compile
 make[2] -C package/libs/sysfsutils clean-build
 make[2] -C package/libs/sysfsutils compile
 make[2] -C feeds/packages/utils/lm-sensors clean-build
 make[2] -C feeds/packages/utils/lm-sensors compile
```

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>