### PR TITLE
python-chardet: Rename Python 3 script

### DIFF
--- a/lang/python/python-chardet/Makefile
+++ b/lang/python/python-chardet/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-chardet
 PKG_VERSION:=3.0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=LGPL-2.1
 
 PKG_SOURCE:=chardet-$(PKG_VERSION).tar.gz
@@ -53,6 +53,14 @@ define Package/python3-chardet/description
 $(call Package/python-chardet/description)
 .
 (Variant for Python3)
+endef
+
+define Py3Package/python3-chardet/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	for bin in $(1)/usr/bin/*; do \
+		mv $$$$bin $$$${bin}3 ; \
+	done
 endef
 
 $(eval $(call PyPackage,python-chardet))


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-32, 2019-05-23 snapshot sdk
Run tested: none (package contents manually examined)

Description:
The Python 2 and 3 versions of chardet both install a script with the same name (/usr/bin/chardetect). This is the issue identified in https://github.com/openwrt/packages/pull/9006#issuecomment-493709812.

This renames the Python 3 script to chardetect3.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>