### PR TITLE
hfsprogs: Fix wide string literal in fsck_hfs

### DIFF
--- a/utils/hfsprogs/patches/0016-Fix-fsckhfs-wide-literal.patch
+++ b/utils/hfsprogs/patches/0016-Fix-fsckhfs-wide-literal.patch
@@ -1,0 +1,13 @@
+Index: diskdev_cmds-332.25/fsck_hfs.tproj/dfalib/SVerify1.c
+===================================================================
+--- diskdev_cmds-332.25.orig/fsck_hfs.tproj/dfalib/SVerify1.c
++++ diskdev_cmds-332.25/fsck_hfs.tproj/dfalib/SVerify1.c
+@@ -2848,7 +2848,7 @@ OSErr	VLockedChk( SGlobPtr GPtr )
+ 	}
+ 	else		//	Because we don't have the unicode converters, just fill it with a dummy name.
+ 	{
+-		CopyMemory( "\x0dPure HFS Plus", calculatedVCB->vcbVN, sizeof(Str27) );
++		CopyMemory( u"\x0dPure HFS Plus", calculatedVCB->vcbVN, sizeof(Str27) );
+ 	}
+ 		
+ 	GPtr->TarBlock = hint;


### PR DESCRIPTION
Maintainer:@ffainelli
Compile tested: mvebu, WRT1200AC, openwrt master
Run tested: mvebu, WRT1200AC
Description: Correctly sizes a string literal in VLockedChk() that was causing bcopy() to bail on platforms with -D_FORTIFY_SOURCE enabled. This resulted in 'Illegal Instruction' errors on some arm platforms even with _FORTIFY_SOURCE=1

Signed-off-by: Henry Cross <51044550+solenoglyph@users.noreply.github.com>