### PR TITLE
Revert "xtables-addons: pass correct flags to compile and install"

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
 PKG_VERSION:=2.14
-PKG_RELEASE:=7
+PKG_RELEASE:=6
 PKG_HASH:=d215a9a8b8e66aae04b982fa2e1228e8a71e7dfe42320df99e34e5000cbdf152
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -39,13 +39,23 @@ endef
 
 CONFIGURE_ARGS+= \
 	--with-kbuild="$(LINUX_DIR)" \
-	--with-xtlibdir="/usr/lib/iptables"
+	--with-xtlibdir="/usr/lib/iptables" \
 
-MAKE_FLAGS += \
-	DEPMOD="/bin/true"
+define Build/Compile
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+		$(KERNEL_MAKE_FLAGS) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		DEPMOD="/bin/true" \
+		all
+endef
 
-MAKE_INSTALL_FLAGS += \
-	DEPMOD="/bin/true"
+define Build/Install
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		$(KERNEL_MAKE_FLAGS) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		DEPMOD="/bin/true" \
+		install
+endef
 
 # 1: extension/module suffix used in package name
 # 2: extension/module display name used in package title/description


### PR DESCRIPTION
Maintainer: @jow-
Compile tested: ramips
Run tested: ramips

Description:
This reverts commit 32aaaaa7d37980de7482a49a729009cad6b3e28d (author: @AmarOk1412)
which causes build error on mipsel targets:

make[7]: *** No rule to make target 'arch/mipsel/Makefile'.  Stop.
https://downloads.openwrt.org/snapshots/faillogs/mipsel_24kc/packages/xtables-addons/compile.txt