### PR TITLE
xtables-addons: fix compilation when ARCH != LINUX_KARCH

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
 PKG_VERSION:=2.14
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 PKG_HASH:=d215a9a8b8e66aae04b982fa2e1228e8a71e7dfe42320df99e34e5000cbdf152
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -41,11 +41,31 @@ CONFIGURE_ARGS+= \
 	--with-kbuild="$(LINUX_DIR)" \
 	--with-xtlibdir="/usr/lib/iptables"
 
-MAKE_FLAGS += \
+ifdef CONFIG_EXTERNAL_TOOLCHAIN
+MAKE_FLAGS:= \
+	$(patsubst ARCH=%,ARCH=$(LINUX_KARCH),$(MAKE_FLAGS)) \
 	DEPMOD="/bin/true"
 
-MAKE_INSTALL_FLAGS += \
+MAKE_INSTALL_FLAGS:= \
+	$(patsubst ARCH=%,ARCH=$(LINUX_KARCH),$(MAKE_FLAGS)) \
 	DEPMOD="/bin/true"
+else
+define Build/Compile
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+		$(KERNEL_MAKE_FLAGS) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		DEPMOD="/bin/true" \
+		all
+endef
+
+define Build/Install
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		$(KERNEL_MAKE_FLAGS) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		DEPMOD="/bin/true" \
+		install
+endef
+endif
 
 # 1: extension/module suffix used in package name
 # 2: extension/module display name used in package title/description


### PR DESCRIPTION
Maintainer: @jow-
Compile tested: bcm47xx/mipsel && mvebu/arm; openwrt master
Run tested: none, checked resulting binaries for the arches above were the same as before 32aaaaa, with the default toolchain.

Description:
Commit 32aaaaa led to failures when openwrt `ARCH` did not match kernel `ARCH`, and this may not be its only side-effect.  

This restores the previous `Build/Compile` and `Build/Install`, using the default ones only when using external toolchain; in this case, `ARCH` is set to `LINUX_KARCH`.

I'm being cautious here.  On the archs I tested this on, the binaries where the same with the default scripts (after setting `ARCH` to `LINUX_KARCH`).

I don't have an external toolchain to test that case, so @AmarOk1412, please test this.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>