### PR TITLE
protobuf: add -std=c++11 to fix protobuf compilation failure. signed-off-by: Ma Tao <matao403@163.com>

### DIFF
--- a/libs/protobuf/Makefile
+++ b/libs/protobuf/Makefile
@@ -65,7 +65,7 @@ This package provides the libprotobuf-lite library.
 
 endef
 
-CONFIGURE_ARGS += --with-protoc=$(STAGING_DIR_HOSTPKG)/bin/protoc
+CONFIGURE_ARGS += --with-protoc=$(STAGING_DIR_HOSTPKG)/bin/protoc CXXFLAGS='-std=c++11'
 
 define Build/InstallDev
 	$(INSTALL_DIR) \


### PR DESCRIPTION

lib/protobuf/Makefile:  add -std=c++11 to fix compilation failure.

Signed-off-by: dadaba <matao403@163.com>
