### PR TITLE
protobuf: add -std=c++11 to CXXFLAGS to fix compilation issue.

### DIFF
--- a/libs/protobuf/Makefile
+++ b/libs/protobuf/Makefile
@@ -65,7 +65,7 @@ This package provides the libprotobuf-lite library.
 
 endef
 
-CONFIGURE_ARGS += --with-protoc=$(STAGING_DIR_HOSTPKG)/bin/protoc
+CONFIGURE_ARGS += --with-protoc=$(STAGING_DIR_HOSTPKG)/bin/protoc CXXFLAGS='-std=c++11'
 
 define Build/InstallDev
 	$(INSTALL_DIR) \


### PR DESCRIPTION
After updated protobuf to 3.7.1, -std=c++11 is necessary for
compilation.

Signed-off-by: Ma Tao <matao403@163.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
