### PR TITLE
python,python3: Clear more fields for src packages

### DIFF
--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -40,7 +40,11 @@ define PyPackage
   define Package/$(1)-src
     $(call Package/$(1))
     DEPENDS:=
+    CONFLICTS:=
+    PROVIDES:=
+    EXTRA_DEPENDS:=
     TITLE+= (sources)
+    USERID:=
   endef
 
   define Package/$(1)-src/description

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -39,7 +39,11 @@ define Py3Package
   define Package/$(1)-src
     $(call Package/$(1))
     DEPENDS:=
+    CONFLICTS:=
+    PROVIDES:=
+    EXTRA_DEPENDS:=
     TITLE+= (sources)
+    USERID:=
   endef
 
   define Package/$(1)-src/description


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2019-05-27 snapshot sdk
Run tested: none (control for src package manually examined)

Description:
This clears the `CONFLICTS`, `PROVIDES`, `EXTRA_DEPENDS`, and `USERID` fields for -src packages.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>

