### PR TITLE
python-urllib3: update to version 1.25.3

### DIFF
--- a/lang/python/python-urllib3/Makefile
+++ b/lang/python/python-urllib3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-urllib3
-PKG_VERSION:=1.25.2
+PKG_VERSION:=1.25.3
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
@@ -18,7 +18,7 @@ PKG_CPE_ID:=cpe:/a:urllib3_project:urllib3
 
 PKG_SOURCE:=urllib3-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/u/urllib3
-PKG_HASH:=a53063d8b9210a7bdec15e7b272776b9d42b2fd6816401a0d43006ad2f9902db
+PKG_HASH:=dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-urllib3-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:

- Update to version [1.25.3
](https://github.com/urllib3/urllib3/commit/337992aba77104fb84e7b14f5a2c9aa1d3039415)

Proof of run tested:
![Screenshot from 2019-05-27 22-45-21](https://user-images.githubusercontent.com/4096468/58438973-1c6e7800-80d2-11e9-8b8c-ea47effe8bdd.png)
