### PR TITLE
netdata: update to version 1.16.0

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,17 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.14.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.16.0
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
-PKG_LICENSE:=GPL-3.0+
+PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:my-netdata:netdata
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/netdata/netdata/releases/download/v$(PKG_VERSION)
-PKG_HASH:=f3768f6927e3712dce73794c6943a12f4454410c872eb3dfd19af4f52296187a
+PKG_HASH:=d62ae89c7b9e93d40feca6edd26b77c6e27e17caa2f90a50a1a7a677f6cc8b4f
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_INSTALL:=1
@@ -30,9 +30,9 @@ include $(INCLUDE_DIR)/package.mk
 define Package/netdata
   SECTION:=admin
   CATEGORY:=Administration
-  DEPENDS:=+zlib +libuuid +libmnl
+  DEPENDS:=+zlib +libuuid +libmnl +libopenssl +liblz4
   TITLE:=Real-time performance monitoring tool
-  URL:=https://my-netdata.io/
+  URL:=https://www.netdata.cloud/
 endef
 
 define Package/netdata/description

--- a/admin/netdata/patches/002-force-python3.patch
+++ b/admin/netdata/patches/002-force-python3.patch
@@ -9,6 +9,6 @@
 -exec "$(command -v python || command -v python3 || command -v python2 ||
 -echo "ERROR python IS NOT AVAILABLE IN THIS SYSTEM")" "$0" "$@" # '''
 +#!/usr/bin/python3
-
+ 
  # -*- coding: utf-8 -*-
  # Description:


### PR DESCRIPTION
Maintainers: me and @diizzyy 
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:

- Update to version [1.16.0](https://github.com/netdata/netdata/releases/tag/v1.16.0)
Add dependencies: libopenssl and liblz4

It was not necessary to refresh patches

Otherwise, compilations end up:

```
Package netdata is missing dependencies for the following libraries:
libcrypto.so.1.1
liblz4.so.1
libssl.so.1.1

```

Proof of run tested:
![Screenshot from 2019-05-27 23-39-39](https://user-images.githubusercontent.com/4096468/58440205-c4873f80-80d8-11e9-9a74-48d89b440dad.png)

![Screenshot from 2019-05-27 23-39-27](https://user-images.githubusercontent.com/4096468/58440204-c4873f80-80d8-11e9-8d77-f28fd2e07344.png)
