### PR TITLE
mutt: switch to https instead of ftp

### DIFF
--- a/mail/mutt/Makefile
+++ b/mail/mutt/Makefile
@@ -11,8 +11,8 @@ PKG_NAME:=mutt
 PKG_VERSION:=1.12.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=ftp://ftp.mutt.org/pub/mutt/ \
-		https://bitbucket.org/mutt/mutt/downloads/
+PKG_SOURCE_URL:=https://bitbucket.org/mutt/mutt/downloads/ \
+		http://ftp.mutt.org/pub/mutt/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=ca12448784ed7b6c86d498921e18bc7b152d45494a452df56a7a0c8aaf13f98f
 


### PR DESCRIPTION
Since https is preferred master site with http is used as second choice.

Signed-off-by: Phil Eichinger <phil@zankapfel.net>

Maintainer: me
Compile tested: (ar71xx, TL-WDR4300, 18.06.2)
Run tested: (ar71xx, TL-WDR4300, 18.06.2)