### PR TITLE
dnsdist: Fix several issues

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsdist
 PKG_VERSION:=1.3.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
@@ -66,6 +66,7 @@ CONFIGURE_ARGS+= \
 	--enable-libsodium \
 	--enable-protobuf \
 	--enable-re2 \
+	--with-lua=lua \
 	--with-net-snmp \
         $(if $(CONFIG_DNSDIST_GNUTLS),--enable,--disable)-gnutls \
         $(if $(CONFIG_DNSDIST_OPENSSL),--enable,--disable)-libssl

--- a/net/dnsdist/patches/200-libatomic-detect.patch
+++ b/net/dnsdist/patches/200-libatomic-detect.patch
@@ -1,0 +1,34 @@
+--- a/m4/pdns_check_os.m4
++++ b/m4/pdns_check_os.m4
+@@ -35,16 +35,21 @@
+   AM_CONDITIONAL([HAVE_LINUX], [test "x$have_linux" = "xyes"])
+   AM_CONDITIONAL([HAVE_SOLARIS], [test "x$have_solaris" = "xyes"])
+
+-  case "$host" in
+-  mips* | powerpc-* )
+-    AC_MSG_CHECKING([whether the linker accepts -latomic])
+-    LDFLAGS="-latomic $LDFLAGS"
+-    AC_LINK_IFELSE([m4_default([],[AC_LANG_PROGRAM()])],
+-      [AC_MSG_RESULT([yes])],
+-      [AC_MSG_ERROR([Unable to link against libatomic, cannot continue])]
+-    )
+-    ;;
+-  esac
++  AC_MSG_CHECKING([whether -latomic is needed for __atomic builtins])
++  AC_LINK_IFELSE(
++    [AC_LANG_PROGRAM([[#include <stdint.h>]],
++       [[uint64_t val = 0; __atomic_add_fetch(&val, 1, __ATOMIC_RELAXED);]]
++    )],
++    [AC_MSG_RESULT([no])],
++    [LIBS="$LIBS -latomic"
++     AC_LINK_IFELSE(
++       [AC_LANG_PROGRAM([[#include <stdint.h>]],
++               [[uint64_t val = 0; __atomic_add_fetch(&val, 1, __ATOMIC_RELAXED);]]
++       )],
++       [AC_MSG_RESULT([yes])],
++       [AC_MSG_FAILURE([libatomic needed, but linking with -latomic failed, cannot continue])]
++    )]
++  )
+
+   AC_SUBST(THREADFLAGS)
+   AC_SUBST([DYNLINKFLAGS], [-export-dynamic])

--- a/net/dnsdist/patches/300-openssl-deprecated.patch
+++ b/net/dnsdist/patches/300-openssl-deprecated.patch
@@ -1,0 +1,29 @@
+--- a/tcpiohandler.cc
++++ b/tcpiohandler.cc
+@@ -369,8 +369,10 @@ public:
+     }
+ 
+     if (s_users.fetch_add(1) == 0) {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+       ERR_load_crypto_strings();
+       OpenSSL_add_ssl_algorithms();
++#endif
+       openssl_thread_setup();
+ 
+       s_ticketsKeyIndex = SSL_CTX_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr);
+@@ -439,6 +441,7 @@ public:
+     d_tlsCtx.reset();
+ 
+     if (s_users.fetch_sub(1) == 1) {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+       ERR_free_strings();
+ 
+       EVP_cleanup();
+@@ -448,6 +451,7 @@ public:
+       CONF_modules_unload(1);
+ 
+       CRYPTO_cleanup_all_ex_data();
++#endif
+       openssl_thread_cleanup();
+     }
+   }


### PR DESCRIPTION
Add -latomic to ARC platform as it is needed there.

Fix compilation without deprecated OpenSSL APIs.

Hard-code lua to avoid luajit dependency.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @James-TR 
Compile tested: arc700

ping @cotequeiroz 