### PR TITLE
python,python3: Use ensurepip=upgrade for host Python

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -295,7 +295,7 @@ HOST_CONFIGURE_ARGS+= \
 	--prefix=$(HOST_PYTHON_DIR) \
 	--exec-prefix=$(HOST_PYTHON_DIR) \
 	--with-system-expat=$(STAGING_DIR_HOSTPKG) \
-	--with-ensurepip=install \
+	--with-ensurepip=upgrade \
 	CONFIG_SITE=
 
 define Host/Compile

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -289,7 +289,7 @@ HOST_CONFIGURE_ARGS+= \
 	--prefix=$(HOST_PYTHON3_DIR) \
 	--exec-prefix=$(HOST_PYTHON3_DIR) \
 	--with-system-expat=$(STAGING_DIR_HOSTPKG) \
-	--with-ensurepip=install \
+	--with-ensurepip=upgrade \
 	CONFIG_SITE=
 
 define Host/Compile


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2019-05-27 snapshot sdk
Run tested: manually installed/uninstalled host Python

Description:
This changes `--with-ensurepip=install` to `upgrade`, to upgrade host versions of setuptools and pip to the Python-bundled versions.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
