### PR TITLE
python3-pytest: add package

### DIFF
--- a/lang/python/python3-atomicwrites/Makefile
+++ b/lang/python/python3-atomicwrites/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-atomicwrites
+PKG_VERSION:=1.3.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=atomicwrites-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/a/atomicwrites
+PKG_HASH:=75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6
+PKG_BUILD_DIR:=$(BUILD_DIR)/atomicwrites-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-atomicwrites
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Atomic file writes
+  URL:=https://github.com/untitaker/python-atomicwrites
+  DEPENDS=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-atomicwrites/description
+  Powerful Python library for atomic file writes.
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)-src))

--- a/lang/python/python3-attrs/Makefile
+++ b/lang/python/python3-attrs/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-attrs
+PKG_VERSION:=19.1.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=attrs-19.1.0.tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/a/attrs/
+PKG_HASH:=f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399
+PKG_BUILD_DIR:=$(BUILD_DIR)/attrs-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=python3-attrs
+  URL:=http://pypi.python.org/attrs
+  DEPENDS:=+python3-light 
+  VARIANT:=python3
+endef
+
+define Package/$(PKG_NAME)/description
+	Classes Without Boilerplate
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)-src))

--- a/lang/python/python3-importlib-metadata/Makefile
+++ b/lang/python/python3-importlib-metadata/Makefile
@@ -1,0 +1,36 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-importlib-metadata
+PKG_VERSION:=0.15
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=importlib_metadata-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/i/importlib_metadata
+PKG_HASH:=027cfc6524613de726789072f95d2e4cc64dd1dee8096d42d13f2ead5bd302f5
+PKG_BUILD_DIR:=$(BUILD_DIR)/importlib_metadata-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-importlib-metadata
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Like importlib_resources only for metadata.
+  URL:=https://gitlab.com/python-devs/importlib_metadata
+  DEPENDS=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-importlib-metadata/description
+  importlib_metadata is a library to access the metadata for a Python package.
+  It is intended to be ported to Python 3.8.
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)-src))

--- a/lang/python/python3-more-itertools/Makefile
+++ b/lang/python/python3-more-itertools/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-more-itertools
+PKG_VERSION:=7.0.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=more-itertools-7.0.0.tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/m/more-itertools/
+PKG_HASH:=c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a
+PKG_BUILD_DIR:=$(BUILD_DIR)/more-itertools-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=python3-more-itertools
+  URL:=http://pypi.python.org/more-itertools
+  DEPENDS:=+python3-light 
+  VARIANT:=python3
+endef
+
+define Package/$(PKG_NAME)/description
+	More routines for operating on iterables, beyond itertools
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)-src))

--- a/lang/python/python3-pluggy/Makefile
+++ b/lang/python/python3-pluggy/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-pluggy
+PKG_VERSION:=0.12.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=MIT license
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=pluggy-0.12.0.tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pluggy/
+PKG_HASH:=0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc
+PKG_BUILD_DIR:=$(BUILD_DIR)/pluggy-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=python3-pluggy
+  URL:=http://pypi.python.org/pluggy
+  DEPENDS:=+python3-light 
+  VARIANT:=python3
+endef
+
+define Package/$(PKG_NAME)/description
+	plugin and hook calling mechanisms for python
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)-src))

--- a/lang/python/python3-py/Makefile
+++ b/lang/python/python3-py/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-py
+PKG_VERSION:=1.8.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=MIT license
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=py-1.8.0.tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/py/
+PKG_HASH:=dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53
+PKG_BUILD_DIR:=$(BUILD_DIR)/py-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=python3-py
+  URL:=http://pypi.python.org/py
+  DEPENDS:=+python3-light 
+  VARIANT:=python3
+endef
+
+define Package/$(PKG_NAME)/description
+	library with cross-python path, ini-parsing, io, code, log facilities
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)-src))

--- a/lang/python/python3-pytest/Makefile
+++ b/lang/python/python3-pytest/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-pytest
+PKG_VERSION:=4.5.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=MIT license
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=pytest-4.5.0.tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/p/pytest/
+PKG_HASH:=1a8aa4fa958f8f451ac5441f3ac130d9fc86ea38780dd2715e6d5c5882700b24
+PKG_BUILD_DIR:=$(BUILD_DIR)/pytest-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=python3-pytest
+  URL:=http://pypi.python.org/pytest
+  DEPENDS:=+python3 +python3-py +python3-attrs +python3-six +python3-pluggy +python3-zipp +python3-more-itertools +python3-setuptools
+  VARIANT:=python3
+endef
+
+define Package/$(PKG_NAME)/description
+	pytest: simple powerful testing with Python
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)-src))

--- a/lang/python/python3-six/Makefile
+++ b/lang/python/python3-six/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-six
+PKG_VERSION:=1.12.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=six-1.12.0.tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/s/six/
+PKG_HASH:=d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73
+PKG_BUILD_DIR:=$(BUILD_DIR)/six-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=python3-six
+  URL:=http://pypi.python.org/six
+  DEPENDS:=+python3-light 
+  VARIANT:=python3
+endef
+
+define Package/$(PKG_NAME)/description
+	Python 2 and 3 compatibility utilities
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)-src))

--- a/lang/python/python3-zipp/Makefile
+++ b/lang/python/python3-zipp/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python3-zipp
+PKG_VERSION:=0.5.1
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=zipp-0.5.1.tar.gz
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/z/zipp/
+PKG_HASH:=ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3
+PKG_BUILD_DIR:=$(BUILD_DIR)/zipp-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=python3-zipp
+  URL:=http://pypi.python.org/zipp
+  DEPENDS:=+python3-light 
+  VARIANT:=python3
+endef
+
+define Package/$(PKG_NAME)/description
+	Backport of pathlib-compatible object wrapper for zip files
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: x86/64
Run tested: x86/64

Description:

Adds python3-pytest and it's dependencies as OpenWrt packages. No python2.7 packages are created.