### PR TITLE
softethervpn: Fix compilation with full/stub iconv

### DIFF
--- a/net/softethervpn/Makefile
+++ b/net/softethervpn/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=softethervpn
 PKG_VERSION:=4.28-9669
 PKG_VERREL:=beta
 PKG_VERDATE:=2018.09.11
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=softether-src-v$(PKG_VERSION)-$(PKG_VERREL).tar.gz
 PKG_SOURCE_URL:=http://www.softether-download.com/files/softether/v$(PKG_VERSION)-$(PKG_VERREL)-$(PKG_VERDATE)-tree/Source_Code/
@@ -62,6 +62,9 @@ endef
 TARGET_CFLAGS += \
 	$(if $(CONFIG_OPENSSL_WITH_SSL3),,-DSSL_OP_NO_SSLv3) \
 	$(if $(filter mips mipsel,$(ARCH)),-minterlink-mips16)
+
+TARGET_LDFLAGS += \
+	-liconv
 
 # Select 32 or 64 bit Makefile for target build depending on 64bit config symbol
 MAKE_FLAGS += \

--- a/net/softethervpn/patches/120-openssl-deprecated.patch
+++ b/net/softethervpn/patches/120-openssl-deprecated.patch
@@ -1,0 +1,212 @@
+diff --git a/src/Mayaqua/Encrypt.c b/src/Mayaqua/Encrypt.c
+index f3b3908..06b7fea 100644
+--- a/src/Mayaqua/Encrypt.c
++++ b/src/Mayaqua/Encrypt.c
+@@ -129,6 +129,7 @@
+ #include <openssl/rand.h>
+ #include <openssl/engine.h>
+ #include <openssl/bio.h>
++#include <openssl/bn.h>
+ #include <openssl/x509.h>
+ #include <openssl/pkcs7.h>
+ #include <openssl/pkcs12.h>
+@@ -137,6 +138,7 @@
+ #include <openssl/md4.h>
+ #include <openssl/hmac.h>
+ #include <openssl/sha.h>
++#include <openssl/rsa.h>
+ #include <openssl/des.h>
+ #include <openssl/aes.h>
+ #include <openssl/dh.h>
+@@ -634,7 +636,7 @@ UINT CipherProcess(CIPHER *c, void *iv, void *dest, void *src, UINT size)
+ 		return 0;
+ 	}
+ 
+-	if (EVP_CipherFinal(c->Ctx, ((UCHAR *)dest) + (UINT)r, &r2) == 0)
++	if (EVP_CipherFinal_ex(c->Ctx, ((UCHAR *)dest) + (UINT)r, &r2) == 0)
+ 	{
+ 		return 0;
+ 	}
+@@ -933,6 +935,7 @@ BUF *BigNumToBuf(const BIGNUM *bn)
+ // Initialization of the lock of OpenSSL
+ void OpenSSL_InitLock()
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	UINT i;
+ 
+ 	// Initialization of the lock object
+@@ -946,11 +949,13 @@ void OpenSSL_InitLock()
+ 	// Setting the lock function
+ 	CRYPTO_set_locking_callback(OpenSSL_Lock);
+ 	CRYPTO_set_id_callback(OpenSSL_Id);
++#endif
+ }
+ 
+ // Release of the lock of OpenSSL
+ void OpenSSL_FreeLock()
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	UINT i;
+ 
+ 	for (i = 0;i < ssl_lock_num;i++)
+@@ -962,11 +967,13 @@ void OpenSSL_FreeLock()
+ 
+ 	CRYPTO_set_locking_callback(NULL);
+ 	CRYPTO_set_id_callback(NULL);
++#endif
+ }
+ 
+ // Lock function for OpenSSL
+ void OpenSSL_Lock(int mode, int n, const char *file, int line)
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	LOCK *lock = ssl_lock_obj[n];
+ 
+ 	if (mode & CRYPTO_LOCK)
+@@ -979,12 +986,15 @@ void OpenSSL_Lock(int mode, int n, const char *file, int line)
+ 		// Unlock
+ 		Unlock(lock);
+ 	}
++#endif
+ }
+ 
+ // Return the thread ID
+ unsigned long OpenSSL_Id(void)
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	return (unsigned long)ThreadId();
++#endif
+ }
+ 
+ // Get the display name of the certificate
+@@ -1908,8 +1918,8 @@ X509 *NewX509(K *pub, K *priv, X *ca, NAME *name, UINT days, X_SERIAL *serial)
+ 	X509_set_version(x509, 2L);
+ 
+ 	// Set the Expiration
+-	t1 = X509_get_notBefore(x509);
+-	t2 = X509_get_notAfter(x509);
++	t1 = X509_getm_notBefore(x509);
++	t2 = X509_getm_notAfter(x509);
+ 	if (!UINT64ToAsn1Time(t1, notBefore))
+ 	{
+ 		FreeX509(x509);
+@@ -2050,8 +2060,8 @@ X509 *NewRootX509(K *pub, K *priv, NAME *name, UINT days, X_SERIAL *serial)
+ 	X509_set_version(x509, 2L);
+ 
+ 	// Set the Expiration
+-	t1 = X509_get_notBefore(x509);
+-	t2 = X509_get_notAfter(x509);
++	t1 = X509_getm_notBefore(x509);
++	t2 = X509_getm_notAfter(x509);
+ 	if (!UINT64ToAsn1Time(t1, notBefore))
+ 	{
+ 		FreeX509(x509);
+@@ -2677,6 +2687,43 @@ bool RsaCheckEx()
+ 
+ 	return false;
+ }
++
++// RSA key generation
++static RSA *RsaGenKey(UINT bit, BN_ULONG e)
++{
++	RSA *rsa = NULL;
++	char errbuf[MAX_SIZE];
++	BIGNUM *bne = NULL;
++
++	if ((bne = BN_new()) == NULL)
++	{
++		Debug("BN_new: err=%s\n", ERR_error_string(ERR_get_error(), errbuf));
++		return NULL;
++	}
++	if (BN_set_word(bne, e) == 0)
++	{
++		Debug("BN_set_word: err=%s\n", ERR_error_string(ERR_get_error(), errbuf));
++		goto fail;
++	}
++	if ((rsa = RSA_new()) == NULL)
++	{
++		Debug("RSA_new: err=%s\n", ERR_error_string(ERR_get_error(), errbuf));
++		goto fail;
++	}
++	if (RSA_generate_key_ex(rsa, bit, bne, NULL) == 0)
++	{
++		Debug("RSA_generate_key_ex: err=%s\n", ERR_error_string(ERR_get_error(), errbuf));
++		goto fail;
++	}
++	BN_free(bne);
++	return rsa;
++
++fail:
++	RSA_free(rsa);
++	BN_free(bne);
++	return NULL;
++}
++
+ bool RsaCheck()
+ {
+ 	RSA *rsa;
+@@ -2690,12 +2737,11 @@ bool RsaCheck()
+ 	// Key generation
+ 	Lock(openssl_lock);
+ 	{
+-		rsa = RSA_generate_key(bit, RSA_F4, NULL, NULL);
++		rsa = RsaGenKey(bit, RSA_F4);
+ 	}
+ 	Unlock(openssl_lock);
+ 	if (rsa == NULL)
+ 	{
+-		Debug("RSA_generate_key: err=%s\n", ERR_error_string(ERR_get_error(), errbuf));
+ 		return false;
+ 	}
+ 
+@@ -2760,12 +2806,11 @@ bool RsaGen(K **priv, K **pub, UINT bit)
+ 	// Key generation
+ 	Lock(openssl_lock);
+ 	{
+-		rsa = RSA_generate_key(bit, RSA_F4, NULL, NULL);
++		rsa = RsaGenKey(bit, RSA_F4);
+ 	}
+ 	Unlock(openssl_lock);
+ 	if (rsa == NULL)
+ 	{
+-		Debug("RSA_generate_key: err=%s\n", ERR_error_string(ERR_get_error(), errbuf));
+ 		return false;
+ 	}
+ 
+@@ -3875,7 +3920,7 @@ X *X509ToX(X509 *x509)
+ 				{
+ 					if (OBJ_obj2nid(ad->method) == NID_ad_ca_issuers && ad->location->type == GEN_URI)
+ 					{
+-						char *uri = (char *)ASN1_STRING_data(ad->location->d.uniformResourceIdentifier);
++						char *uri = (char *)ASN1_STRING_get0_data(ad->location->d.uniformResourceIdentifier);
+ 
+ 						if (IsEmptyStr(uri) == false)
+ 						{
+@@ -4088,7 +4133,9 @@ void Rand(void *buf, UINT size)
+ // Delete a thread-specific information that OpenSSL has holded
+ void FreeOpenSSLThreadState()
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	ERR_remove_state(0);
++#endif
+ }
+ 
+ // Release the Crypt library
+@@ -4110,13 +4157,16 @@ void InitCryptLibrary()
+ 	CheckIfIntelAesNiSupportedInit();
+ //	RAND_Init_For_SoftEther()
+ 	openssl_lock = NewLock();
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	SSL_library_init();
+ 	//OpenSSL_add_all_algorithms();
+ 	OpenSSL_add_all_ciphers();
+ 	OpenSSL_add_all_digests();
+ 	ERR_load_crypto_strings();
+ 	SSL_load_error_strings();
+-
++#else
++	OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
++#endif
+ #ifdef	OS_UNIX
+ 	{
+ 		char *name1 = "/dev/random";


### PR DESCRIPTION
Needs -liconv.

Also fixed compilation without deprecated OpenSSL APIs.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @fededim 
Compile tested: arc700

@cotequeiroz RSA_generate_key must be converted to the _ex variant. I haven't been able to figure it out though. My naive attempt makes the host build fail.