### PR TITLE
ostiary: Initial package creation

### DIFF
--- a/net/ostiary/Makefile
+++ b/net/ostiary/Makefile
@@ -1,0 +1,47 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ostiary
+PKG_VERSION:=4.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://ingles.homeunix.net/software/ost/latest/
+PKG_HASH:=1b6a0a8a17fd3aa0f6511cdda81558d54f11023a0c953201ddaaef35f56a82c4
+
+PKG_MAINTAINER:=Chris Geraghty <cgretski@hotmail.com>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ostiary
+  SECTION:=base
+  CATEGORY:=Network
+  TITLE:=Secure remote execution utility
+  URL:=http://ingles.homeunix.net/software/ost/index.html
+endef
+
+define Package/ostiary/description
+ Replay-resistent predefined remote-command trigger
+endef
+
+define Package/ostiary/conffiles
+/etc/ostiary.cfg
+endef
+
+MAKE_FLAGS += all
+
+define Package/ostiary/install
+	 $(INSTALL_DIR) $(1)/usr/bin
+	 $(INSTALL_BIN) $(PKG_BUILD_DIR)/ostiaryd $(1)/usr/bin/
+	 $(INSTALL_BIN) $(PKG_BUILD_DIR)/ostclient $(1)/usr/bin/
+	 $(INSTALL_DIR) $(1)/etc
+	 $(INSTALL_CONF) $(PKG_BUILD_DIR)/tests/ostiary.cfg $(1)/etc/ostiary.cfg
+	 $(INSTALL_DIR) $(1)/etc/init.d
+	 $(INSTALL_BIN) ./files/ostiaryd.init $(1)/etc/init.d/ostiary
+endef
+
+
+$(eval $(call BuildPackage,ostiary))

--- a/net/ostiary/files/ostiaryd.init
+++ b/net/ostiary/files/ostiaryd.init
@@ -1,0 +1,19 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=85
+
+USE_PROCD=1
+
+start_service()
+{
+
+	procd_open_instance
+	procd_set_param command /usr/bin/ostiaryd -c /etc/ostiary.cfg 
+	procd_close_instance
+}
+
+
+reload_service() {
+         procd_send_signal ostiaryd
+}


### PR DESCRIPTION
Signed-off-by: Chris Geraghty <CGretski@hotmail.com>

Maintainer: me
Compile tested: Master on mips_24kc and mipsel_74kc
Run tested: r7890-40eb9bda44 on mips_24kc: installed, defined listening-port and password/command in config file; successfully executed command using local ostclient and remote android app.

Description:
Ostiary is a small daemon to execute predefined commands when receiving a hashed password.
Coded to be resistent to replay attacks and buffer overflows.

https://openwrt.org/docs/guide-user/services/remote_control/ostiary.server
