### PR TITLE
python,python3: Better isolate host Python

### DIFF
--- a/lang/python/python-host.mk
+++ b/lang/python/python-host.mk
@@ -71,16 +71,15 @@ endef
 
 # Note: I shamelessly copied this from Yousong's logic (from python-packages);
 HOST_PYTHON_PIP:=$(STAGING_DIR_HOSTPKG)/bin/pip$(PYTHON_VERSION)
-define host_python_pip_install
-	$(call host_python_settings) \
-	$(HOST_PYTHON_PIP) install \
-		--root=$(1) \
-		--prefix=$(2) \
-		$(3)
-endef
 
-define host_python_pip_install_host
-$(call host_python_pip_install,$(STAGING_DIR_HOSTPKG),"",$(1))
+# $(1) => packages to install
+define Build/Compile/HostPyPipInstall
+	$(call host_python_settings) \
+	$(HOST_PYTHON_PIP) \
+		--disable-pip-version-check \
+		--cache-dir "$(DL_DIR)/pip-cache" \
+		install \
+		$(1)
 endef
 
 # $(1) => build subdir

--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -121,8 +121,8 @@ PYTHON_PKG_SETUP_ARGS ?= --single-version-externally-managed
 PYTHON_PKG_SETUP_VARS ?=
 
 define PyBuild/Compile/Default
-	$(foreach pkg,$(HOST_PYTHON_PACKAGE_BUILD_DEPENDS),
-		$(call host_python_pip_install_host,$(pkg))
+	$(if $(HOST_PYTHON_PACKAGE_BUILD_DEPENDS),
+		$(call Build/Compile/HostPyPipInstall,$(HOST_PYTHON_PACKAGE_BUILD_DEPENDS))
 	)
 	$(call Build/Compile/PyMod, \
 		$(PYTHON_PKG_SETUP_DIR), \

--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -298,6 +298,11 @@ HOST_CONFIGURE_ARGS+= \
 	--with-ensurepip=install \
 	CONFIG_SITE=
 
+define Host/Configure
+	$(SED) 's/^ENABLE_USER_SITE = None$$$$/ENABLE_USER_SITE = False/' $(HOST_BUILD_DIR)/Lib/site.py
+	$(call Host/Configure/Default)
+endef
+
 define Host/Compile
 	$(call Host/Compile/Default,python Parser/pgen sharedmods)
 endef

--- a/lang/python/python3-host.mk
+++ b/lang/python/python3-host.mk
@@ -71,16 +71,15 @@ endef
 
 # Note: I shamelessly copied this from Yousong's logic (from python-packages);
 HOST_PYTHON3_PIP:=$(STAGING_DIR_HOSTPKG)/bin/pip$(PYTHON3_VERSION)
-define host_python3_pip_install
-	$(call host_python3_settings) \
-	$(HOST_PYTHON3_PIP) install \
-		--root=$(1) \
-		--prefix=$(2) \
-		$(3)
-endef
 
-define host_python3_pip_install_host
-$(call host_python3_pip_install,$(STAGING_DIR_HOSTPKG),"",$(1))
+# $(1) => packages to install
+define Build/Compile/HostPy3PipInstall
+	$(call host_python3_settings) \
+	$(HOST_PYTHON3_PIP) \
+		--disable-pip-version-check \
+		--cache-dir "$(DL_DIR)/pip-cache" \
+		install \
+		$(1)
 endef
 
 # $(1) => build subdir

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -120,8 +120,8 @@ PYTHON3_PKG_SETUP_ARGS ?= --single-version-externally-managed
 PYTHON3_PKG_SETUP_VARS ?=
 
 define Py3Build/Compile/Default
-	$(foreach pkg,$(HOST_PYTHON3_PACKAGE_BUILD_DEPENDS),
-		$(call host_python3_pip_install_host,$(pkg))
+	$(if $(HOST_PYTHON3_PACKAGE_BUILD_DEPENDS),
+		$(call Build/Compile/HostPy3PipInstall,$(HOST_PYTHON3_PACKAGE_BUILD_DEPENDS))
 	)
 	$(call Build/Compile/Py3Mod, \
 		$(PYTHON3_PKG_SETUP_DIR), \

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -292,6 +292,11 @@ HOST_CONFIGURE_ARGS+= \
 	--with-ensurepip=install \
 	CONFIG_SITE=
 
+define Host/Configure
+	$(SED) 's/^ENABLE_USER_SITE = None$$$$/ENABLE_USER_SITE = False/' $(HOST_BUILD_DIR)/Lib/site.py
+	$(call Host/Configure/Default)
+endef
+
 define Host/Compile
 	+$(HOST_MAKE_VARS) $(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) python Parser/pgen
 	+$(HOST_MAKE_VARS) $(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) sharedmods


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2019-05-27 snapshot sdk
Run tested: none

Description:
These changes are meant to better isolate host Python from the build user's environment:

* * *

ae80ddc7ab1486a2e4788a8bd4b9c1643ce29c29: python,python3: Update host pip[3] install functions

* Add `--cache-dir` option to set the pip cache to a directory in `$(DL_DIR)`, instead of pip's default (build user's `~/.cache/pip`), fixes #9066

* Add `--disable-pip-version-check` option, since the version check only prints a message saying a new version is available

* Combine `host_python_pip_install` and `host_python_pip_install_host` into `Build/Compile/HostPy[3]PipInstall`

* Remove `--root` and `--prefix` options, since this function is only used to install packages to host Python's default site-packages directory (setting these may serve to confuse pip)

* Pass all of `$(HOST_PYTHON[3]_PACKAGE_BUILD_DEPENDS)` to the function, since pip can handle multiple arguments/packages

* * *

87a31e49f77ea252e454eeb780fee8342119bab0: python,python3: Disable user site-packages for host Python

Normally, Python will include the user's site-packages directory (`~/.local/lib/python$(PYTHON_VERSION)/site-packages`) in it's internal search path for modules.

This disables this default inclusion for host Python.

This change is applied during `Host/Configure` instead of as a patch to keep this setting unchanged for target Python.

* * *

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
