### PR TITLE
python-setuptools,python-pip: Installation changes

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -170,7 +170,10 @@ endef
 
 ifdef CONFIG_PACKAGE_python-setuptools
 define Build/Compile/python-setuptools
-	$(STAGING_DIR_HOSTPKG)/bin/pip install \
+	$(HOST_PYTHON_PIP) \
+		--disable-pip-version-check \
+		--cache-dir "$(DL_DIR)/pip-cache" \
+		install \
 		--ignore-installed \
 		--root=$(PKG_BUILD_DIR)/install-setuptools --prefix=. \
 		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/setuptools-$(PYTHON_SETUPTOOLS_VERSION)-py2.py3-none-any.whl
@@ -180,7 +183,10 @@ endif # CONFIG_PACKAGE_python-setuptools
 
 ifdef CONFIG_PACKAGE_python-pip
 define Build/Compile/python-pip
-	$(STAGING_DIR_HOSTPKG)/bin/pip install \
+	$(HOST_PYTHON_PIP) \
+		--disable-pip-version-check \
+		--cache-dir "$(DL_DIR)/pip-cache" \
+		install \
 		--ignore-installed \
 		--root=$(PKG_BUILD_DIR)/install-pip --prefix=. \
 		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/pip-$(PYTHON_PIP_VERSION)-py2.py3-none-any.whl

--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -175,9 +175,10 @@ define Build/Compile/python-setuptools
 		--cache-dir "$(DL_DIR)/pip-cache" \
 		install \
 		--ignore-installed \
-		--root=$(PKG_BUILD_DIR)/install-setuptools --prefix=. \
+		--root=$(PKG_BUILD_DIR)/install-setuptools \
+		--prefix=/usr \
 		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/setuptools-$(PYTHON_SETUPTOOLS_VERSION)-py2.py3-none-any.whl
-	$(call PatchDir,$(PKG_BUILD_DIR)/install-setuptools/lib/python$(PYTHON_VERSION)/site-packages,./patches-setuptools,)
+	$(call PatchDir,$(PKG_BUILD_DIR)/install-setuptools/usr/lib/python$(PYTHON_VERSION)/site-packages,./patches-setuptools,)
 endef
 endif # CONFIG_PACKAGE_python-setuptools
 
@@ -188,9 +189,10 @@ define Build/Compile/python-pip
 		--cache-dir "$(DL_DIR)/pip-cache" \
 		install \
 		--ignore-installed \
-		--root=$(PKG_BUILD_DIR)/install-pip --prefix=. \
+		--root=$(PKG_BUILD_DIR)/install-pip \
+		--prefix=/usr \
 		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/pip-$(PYTHON_PIP_VERSION)-py2.py3-none-any.whl
-	$(call PatchDir,$(PKG_BUILD_DIR)/install-pip/lib/python$(PYTHON_VERSION)/site-packages,./patches-pip,)
+	$(call PatchDir,$(PKG_BUILD_DIR)/install-pip/usr/lib/python$(PYTHON_VERSION)/site-packages,./patches-pip,)
 endef
 endif # CONFIG_PACKAGE_python-pip
 

--- a/lang/python/python/files/python-package-pip.mk
+++ b/lang/python/python/files/python-package-pip.mk
@@ -17,10 +17,10 @@ endef
 
 define PyPackage/python-pip/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/lib/python$(PYTHON_VERSION)/site-packages
-	$(CP) $(PKG_BUILD_DIR)/install-pip/bin/* $(1)/usr/bin
+	$(CP) $(PKG_BUILD_DIR)/install-pip/usr/bin/* $(1)/usr/bin
 	$(CP) \
-		$(PKG_BUILD_DIR)/install-pip/lib/python$(PYTHON_VERSION)/site-packages/pip \
-		$(PKG_BUILD_DIR)/install-pip/lib/python$(PYTHON_VERSION)/site-packages/pip-$(PYTHON_PIP_VERSION).dist-info \
+		$(PKG_BUILD_DIR)/install-pip/usr/lib/python$(PYTHON_VERSION)/site-packages/pip \
+		$(PKG_BUILD_DIR)/install-pip/usr/lib/python$(PYTHON_VERSION)/site-packages/pip-$(PYTHON_PIP_VERSION).dist-info \
 		$(1)/usr/lib/python$(PYTHON_VERSION)/site-packages/
 endef
 

--- a/lang/python/python/files/python-package-setuptools.mk
+++ b/lang/python/python/files/python-package-setuptools.mk
@@ -17,12 +17,12 @@ endef
 
 define PyPackage/python-setuptools/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/lib/python$(PYTHON_VERSION)/site-packages
-	$(CP) $(PKG_BUILD_DIR)/install-setuptools/bin/* $(1)/usr/bin
+	$(CP) $(PKG_BUILD_DIR)/install-setuptools/usr/bin/* $(1)/usr/bin
 	$(CP) \
-		$(PKG_BUILD_DIR)/install-setuptools/lib/python$(PYTHON_VERSION)/site-packages/pkg_resources \
-		$(PKG_BUILD_DIR)/install-setuptools/lib/python$(PYTHON_VERSION)/site-packages/setuptools \
-		$(PKG_BUILD_DIR)/install-setuptools/lib/python$(PYTHON_VERSION)/site-packages/setuptools-$(PYTHON_SETUPTOOLS_VERSION).dist-info \
-		$(PKG_BUILD_DIR)/install-setuptools/lib/python$(PYTHON_VERSION)/site-packages/easy_install.py \
+		$(PKG_BUILD_DIR)/install-setuptools/usr/lib/python$(PYTHON_VERSION)/site-packages/pkg_resources \
+		$(PKG_BUILD_DIR)/install-setuptools/usr/lib/python$(PYTHON_VERSION)/site-packages/setuptools \
+		$(PKG_BUILD_DIR)/install-setuptools/usr/lib/python$(PYTHON_VERSION)/site-packages/setuptools-$(PYTHON_SETUPTOOLS_VERSION).dist-info \
+		$(PKG_BUILD_DIR)/install-setuptools/usr/lib/python$(PYTHON_VERSION)/site-packages/easy_install.py \
 		$(1)/usr/lib/python$(PYTHON_VERSION)/site-packages
 endef
 

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -174,7 +174,10 @@ endef
 
 ifdef CONFIG_PACKAGE_python3-setuptools
 define Build/Compile/python3-setuptools
-	$(STAGING_DIR_HOSTPKG)/bin/pip3 install \
+	$(HOST_PYTHON3_PIP) \
+		--disable-pip-version-check \
+		--cache-dir "$(DL_DIR)/pip-cache" \
+		install \
 		--ignore-installed \
 		--root=$(PKG_BUILD_DIR)/install-setuptools --prefix=. \
 		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/setuptools-$(PYTHON3_SETUPTOOLS_VERSION)-py2.py3-none-any.whl
@@ -184,7 +187,10 @@ endif # CONFIG_PACKAGE_python3-setuptools
 
 ifdef CONFIG_PACKAGE_python3-pip
 define Build/Compile/python3-pip
-	$(STAGING_DIR_HOSTPKG)/bin/pip3 install \
+	$(HOST_PYTHON3_PIP) \
+		--disable-pip-version-check \
+		--cache-dir "$(DL_DIR)/pip-cache" \
+		install \
 		--ignore-installed \
 		--root=$(PKG_BUILD_DIR)/install-pip --prefix=. \
 		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/pip-$(PYTHON3_PIP_VERSION)-py2.py3-none-any.whl

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -179,9 +179,10 @@ define Build/Compile/python3-setuptools
 		--cache-dir "$(DL_DIR)/pip-cache" \
 		install \
 		--ignore-installed \
-		--root=$(PKG_BUILD_DIR)/install-setuptools --prefix=. \
+		--root=$(PKG_BUILD_DIR)/install-setuptools \
+		--prefix=/usr \
 		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/setuptools-$(PYTHON3_SETUPTOOLS_VERSION)-py2.py3-none-any.whl
-	$(call PatchDir,$(PKG_BUILD_DIR)/install-setuptools/lib/python$(PYTHON3_VERSION)/site-packages,./patches-setuptools,)
+	$(call PatchDir,$(PKG_BUILD_DIR)/install-setuptools/usr/lib/python$(PYTHON3_VERSION)/site-packages,./patches-setuptools,)
 endef
 endif # CONFIG_PACKAGE_python3-setuptools
 
@@ -192,9 +193,10 @@ define Build/Compile/python3-pip
 		--cache-dir "$(DL_DIR)/pip-cache" \
 		install \
 		--ignore-installed \
-		--root=$(PKG_BUILD_DIR)/install-pip --prefix=. \
+		--root=$(PKG_BUILD_DIR)/install-pip \
+		--prefix=/usr \
 		$(PKG_BUILD_DIR)/Lib/ensurepip/_bundled/pip-$(PYTHON3_PIP_VERSION)-py2.py3-none-any.whl
-	$(call PatchDir,$(PKG_BUILD_DIR)/install-pip/lib/python$(PYTHON3_VERSION)/site-packages,./patches-pip,)
+	$(call PatchDir,$(PKG_BUILD_DIR)/install-pip/usr/lib/python$(PYTHON3_VERSION)/site-packages,./patches-pip,)
 endef
 endif # CONFIG_PACKAGE_python3-pip
 

--- a/lang/python/python3/files/python3-package-pip.mk
+++ b/lang/python/python3/files/python3-package-pip.mk
@@ -22,10 +22,8 @@ define Py3Package/python3-pip/install
 		$(PKG_BUILD_DIR)/install-pip/usr/lib/python$(PYTHON3_VERSION)/site-packages/pip \
 		$(PKG_BUILD_DIR)/install-pip/usr/lib/python$(PYTHON3_VERSION)/site-packages/pip-$(PYTHON3_PIP_VERSION).dist-info \
 		$(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/
-	for _ in \$(seq 1 10) ; do \
-		find $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/ -name __pycache__ -exec rm -rf {} \; || continue ; \
-		break ; \
-	done
+	find $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/ -path '*/__pycache__/*' -delete
+	find $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/ -type d -name __pycache__ -delete
 endef
 
 $(eval $(call Py3BasePackage,python3-pip, \

--- a/lang/python/python3/files/python3-package-pip.mk
+++ b/lang/python/python3/files/python3-package-pip.mk
@@ -17,10 +17,10 @@ endef
 
 define Py3Package/python3-pip/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages
-	$(CP) $(PKG_BUILD_DIR)/install-pip/bin/pip3* $(1)/usr/bin
+	$(CP) $(PKG_BUILD_DIR)/install-pip/usr/bin/pip3* $(1)/usr/bin
 	$(CP) \
-		$(PKG_BUILD_DIR)/install-pip/lib/python$(PYTHON3_VERSION)/site-packages/pip \
-		$(PKG_BUILD_DIR)/install-pip/lib/python$(PYTHON3_VERSION)/site-packages/pip-$(PYTHON3_PIP_VERSION).dist-info \
+		$(PKG_BUILD_DIR)/install-pip/usr/lib/python$(PYTHON3_VERSION)/site-packages/pip \
+		$(PKG_BUILD_DIR)/install-pip/usr/lib/python$(PYTHON3_VERSION)/site-packages/pip-$(PYTHON3_PIP_VERSION).dist-info \
 		$(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/
 	for _ in \$(seq 1 10) ; do \
 		find $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/ -name __pycache__ -exec rm -rf {} \; || continue ; \

--- a/lang/python/python3/files/python3-package-setuptools.mk
+++ b/lang/python/python3/files/python3-package-setuptools.mk
@@ -25,10 +25,8 @@ define Py3Package/python3-setuptools/install
 		$(PKG_BUILD_DIR)/install-setuptools/usr/lib/python$(PYTHON3_VERSION)/site-packages/setuptools-$(PYTHON3_SETUPTOOLS_VERSION).dist-info \
 		$(PKG_BUILD_DIR)/install-setuptools/usr/lib/python$(PYTHON3_VERSION)/site-packages/easy_install.py \
 		$(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages
-	for _ in \$(seq 1 10) ; do \
-		find $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/ -name __pycache__ -exec rm -rf {} \; || continue ; \
-		break ; \
-	done
+	find $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/ -path '*/__pycache__/*' -delete
+	find $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/ -type d -name __pycache__ -delete
 endef
 
 $(eval $(call Py3BasePackage,python3-setuptools, \

--- a/lang/python/python3/files/python3-package-setuptools.mk
+++ b/lang/python/python3/files/python3-package-setuptools.mk
@@ -17,13 +17,13 @@ endef
 
 define Py3Package/python3-setuptools/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages
-	$(CP) $(PKG_BUILD_DIR)/install-setuptools/bin/easy_install-* $(1)/usr/bin
+	$(CP) $(PKG_BUILD_DIR)/install-setuptools/usr/bin/easy_install-* $(1)/usr/bin
 	$(LN) easy_install-$(PYTHON3_VERSION) $(1)/usr/bin/easy_install-3
 	$(CP) \
-		$(PKG_BUILD_DIR)/install-setuptools/lib/python$(PYTHON3_VERSION)/site-packages/pkg_resources \
-		$(PKG_BUILD_DIR)/install-setuptools/lib/python$(PYTHON3_VERSION)/site-packages/setuptools \
-		$(PKG_BUILD_DIR)/install-setuptools/lib/python$(PYTHON3_VERSION)/site-packages/setuptools-$(PYTHON3_SETUPTOOLS_VERSION).dist-info \
-		$(PKG_BUILD_DIR)/install-setuptools/lib/python$(PYTHON3_VERSION)/site-packages/easy_install.py \
+		$(PKG_BUILD_DIR)/install-setuptools/usr/lib/python$(PYTHON3_VERSION)/site-packages/pkg_resources \
+		$(PKG_BUILD_DIR)/install-setuptools/usr/lib/python$(PYTHON3_VERSION)/site-packages/setuptools \
+		$(PKG_BUILD_DIR)/install-setuptools/usr/lib/python$(PYTHON3_VERSION)/site-packages/setuptools-$(PYTHON3_SETUPTOOLS_VERSION).dist-info \
+		$(PKG_BUILD_DIR)/install-setuptools/usr/lib/python$(PYTHON3_VERSION)/site-packages/easy_install.py \
 		$(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages
 	for _ in \$(seq 1 10) ; do \
 		find $(1)/usr/lib/python$(PYTHON3_VERSION)/site-packages/ -name __pycache__ -exec rm -rf {} \; || continue ; \


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2019-05-27 snapshot sdk
Run tested: none

Description:
These changes aim to make the "installation" of target setuptools and pip better:

* * *

688825f37a44f08623e93df9abb008a7199dfe5c: python-setuptools,python-pip: Set pip cache dir, disable version check

This adds `--cache-dir` and `--disable-pip-version-check` options for host pip, when "installing" target setuptools and pip.

This also changes the pip command to use `$(HOST_PYTHON[3]_PIP)` from python[3]-host.mk.

* * *

be751236aac05cb0df7fc184691cf7d9cfe173d4: python-setuptools,python-pip: Change prefix to `/usr`

This changes the `--prefix` option, passed to host pip when "installing" target setuptools and pip, to `/usr`, in case the prefix is recorded in the packages.

* * *

b8e7a197db135c2b8749ed3c7bf94b3e712e1283: python3-setuptools,python3-pip: Use more predictable pycache cleanup

This uses two `find` commands to delete `__pycache__` contents then the `__pycache__` directories, rather than a `for` loop.

The second command omits a `-empty` test, so that if the first command doesn't remove all directory contents for some reason, the second command will return an error (`find` will not delete a non-empty directory).

* * *

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
