### PR TITLE
python-cffi,python-cryptography: Fix build depends

### DIFF
--- a/lang/python/python-cffi/Makefile
+++ b/lang/python/python-cffi/Makefile
@@ -21,11 +21,6 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
-PKG_BUILD_DEPENDS:=libffi/host
-
-HOST_PYTHON_PACKAGE_BUILD_DEPENDS:="cffi==$(PKG_VERSION)"
-HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:="cffi==$(PKG_VERSION)"
-
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk

--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptography
 PKG_VERSION:=2.6.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=cryptography-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/cryptography
@@ -20,6 +20,10 @@ PKG_LICENSE_FILES:=LICENSE.APACHE LICENSE.BSD
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cryptography-$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=libffi/host
+
+HOST_PYTHON_PACKAGE_BUILD_DEPENDS:="cffi>=1.8,!=1.11.3"
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:="cffi>=1.8,!=1.11.3"
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2019-05-27 snapshot sdk
Run tested: none

Description:
python-cryptography's build depends (host cffi, libffi) were transferred to python-cffi at some point; this corrects the situation.

python-cryptography's host Python build depends is copied from its [setup.py](https://github.com/pyca/cryptography/blob/2.6.1/setup.py#L47).

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
