### PR TITLE
python,python3: Allow upgraded host setuptools/pip to be patched

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -306,14 +306,16 @@ define Host/Install
 	$(MAKE) -C $(HOST_BUILD_DIR) install
 	$(INSTALL_DIR) $(HOST_PYTHON_DIR)/bin/
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/Parser/pgen $(HOST_PYTHON_DIR)/bin/pgen2
-  ifeq ($(wildcard $(HOST_PYTHON_PKG_DIR)/.setuptools-patched),)
-	$(call HostPatchDir,$(HOST_PYTHON_PKG_DIR),./patches-setuptools,)
-	touch $(HOST_PYTHON_PKG_DIR)/.setuptools-patched
-  endif
-  ifeq ($(wildcard $(HOST_PYTHON_PKG_DIR)/.pip-patched),)
-	$(call HostPatchDir,$(HOST_PYTHON_PKG_DIR),./patches-pip,)
-	touch $(HOST_PYTHON_PKG_DIR)/.pip-patched
-  endif
+	$(if $(wildcard $(HOST_PYTHON_PKG_DIR)/.setuptools-patched-$(PYTHON_SETUPTOOLS_VERSION)),,
+		$(call HostPatchDir,$(HOST_PYTHON_PKG_DIR),./patches-setuptools,)
+		rm -f $(HOST_PYTHON_PKG_DIR)/.setuptools-patched-*
+		touch $(HOST_PYTHON_PKG_DIR)/.setuptools-patched-$(PYTHON_SETUPTOOLS_VERSION)
+	)
+	$(if $(wildcard $(HOST_PYTHON_PKG_DIR)/.pip-patched-$(PYTHON_PIP_VERSION)),,
+		$(call HostPatchDir,$(HOST_PYTHON_PKG_DIR),./patches-pip,)
+		rm -f $(HOST_PYTHON_PKG_DIR)/.pip-patched-*
+		touch $(HOST_PYTHON_PKG_DIR)/.pip-patched-$(PYTHON_PIP_VERSION)
+	)
 endef
 
 $(eval $(call HostBuild))

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -301,14 +301,16 @@ define Host/Install
 	$(MAKE) -C $(HOST_BUILD_DIR) install
 	$(INSTALL_DIR) $(HOST_PYTHON3_DIR)/bin/
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/Parser/pgen $(HOST_PYTHON3_DIR)/bin/pgen3
-  ifeq ($(wildcard $(HOST_PYTHON3_PKG_DIR)/.setuptools-patched),)
-	$(call HostPatchDir,$(HOST_PYTHON3_PKG_DIR),./patches-setuptools,)
-	touch $(HOST_PYTHON3_PKG_DIR)/.setuptools-patched
-  endif
-  ifeq ($(wildcard $(HOST_PYTHON3_PKG_DIR)/.pip-patched),)
-	$(call HostPatchDir,$(HOST_PYTHON3_PKG_DIR),./patches-pip,)
-	touch $(HOST_PYTHON3_PKG_DIR)/.pip-patched
-  endif
+	$(if $(wildcard $(HOST_PYTHON3_PKG_DIR)/.setuptools-patched-$(PYTHON3_SETUPTOOLS_VERSION)),,
+		$(call HostPatchDir,$(HOST_PYTHON3_PKG_DIR),./patches-setuptools,)
+		rm -f $(HOST_PYTHON3_PKG_DIR)/.setuptools-patched-*
+		touch $(HOST_PYTHON3_PKG_DIR)/.setuptools-patched-$(PYTHON3_SETUPTOOLS_VERSION)
+	)
+	$(if $(wildcard $(HOST_PYTHON3_PKG_DIR)/.pip-patched-$(PYTHON3_PIP_VERSION)),,
+		$(call HostPatchDir,$(HOST_PYTHON3_PKG_DIR),./patches-pip,)
+		rm -f $(HOST_PYTHON3_PKG_DIR)/.pip-patched-*
+		touch $(HOST_PYTHON3_PKG_DIR)/.pip-patched-$(PYTHON3_PIP_VERSION)
+	)
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2019-05-27 snapshot sdk
Run tested: none

Description:
This adds the current setuptools/pip version numbers to the indicator files' names, which should allow upgraded versions to be patched.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
