### PR TITLE
hwloc: Add PCI support

### DIFF
--- a/libs/hwloc/Makefile
+++ b/libs/hwloc/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hwloc
 PKG_VERSION:=2.0.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.open-mpi.org/release/$(PKG_NAME)/v2.0
@@ -56,6 +56,7 @@ $(call Package/hwloc/Default)
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE+= libraries
+  DEPENDS+=+libpciaccess
 endef
 
 define Package/libhwloc/description


### PR DESCRIPTION
Since libpciaccess got added, hwloc is picking it up.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @MikePetullo 
Compile tested: arc700