### PR TITLE
ddns-scripts: various fixes

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.8
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=

--- a/net/ddns-scripts/files/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/update_cloudflare_com_v4.sh
@@ -29,6 +29,7 @@
 # used variables
 local __HOST __DOMAIN __TYPE __URLBASE __PRGBASE __RUNPROG __DATA __IPV6 __ZONEID __RECID __PROXIED
 local __URLBASE="https://api.cloudflare.com/client/v4"
+local __TTL=120
 
 # split __HOST __DOMAIN from $domain
 # given data:
@@ -127,7 +128,6 @@ fi
 __PRGBASE="$__PRGBASE --header 'X-Auth-Email: $username' "
 __PRGBASE="$__PRGBASE --header 'X-Auth-Key: $password' "
 __PRGBASE="$__PRGBASE --header 'Content-Type: application/json' "
-# __PRGBASE="$__PRGBASE --header 'Accept: application/json' "
 
 # read zone id for registered domain.TLD
 __RUNPROG="$__PRGBASE --request GET '$__URLBASE/zones?name=$__DOMAIN'"
@@ -182,7 +182,7 @@ __PROXIED=$(grep -o '"proxied":[^",]*' $DATFILE | grep -o '[^:]*$')
 
 # use file to work around " needed for json
 cat > $DATFILE << EOF
-{"id":"$__ZONEID","type":"$__TYPE","name":"$__HOST","content":"$__IP","proxied":$__PROXIED}
+{"id":"$__ZONEID","type":"$__TYPE","name":"$__HOST","content":"$__IP","ttl":$__TTL,"proxied":$__PROXIED}
 EOF
 
 # let's complete transfer command


### PR DESCRIPTION
Maintainer: -
Compile tested: -
Run tested: -

Description:
* use '$ddns_rundir' in 'get_service_data' for pipe creation, fix #8971
* add missing local variables in 'get_service_data'
* change DNS server verification with drill in 'verify_host_port', fix/supersed #8935
* remove needless cat calls in 'verify_host_port'
* set cloudfare TTL to min. 120 seconds, fix #7745
* bump/align package version number

Signed-off-by: Dirk Brenken <dev@brenken.org>
