### PR TITLE
python,python3: Record PKG_RELEASE for host setuptools/pip

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -311,18 +311,32 @@ define Host/Compile
 endef
 
 define Host/Install
+	$(if $(wildcard $(HOST_PYTHON_PKG_DIR)/.setuptools_installed_$(PYTHON_SETUPTOOLS_VERSION)-$(PYTHON_SETUPTOOLS_PKG_RELEASE)),,
+		rm -rf \
+			$(HOST_PYTHON_PKG_DIR)/easy_install.py \
+			$(HOST_PYTHON_PKG_DIR)/pkg_resources \
+			$(HOST_PYTHON_PKG_DIR)/setuptools \
+			$(HOST_PYTHON_PKG_DIR)/setuptools-* \
+			$(HOST_PYTHON_PKG_DIR)/.setuptools-patched* \
+			$(HOST_PYTHON_PKG_DIR)/.setuptools_installed_*
+	)
+	$(if $(wildcard $(HOST_PYTHON_PKG_DIR)/.pip_installed_$(PYTHON_PIP_VERSION)-$(PYTHON_PIP_PKG_RELEASE)),,
+		rm -rf \
+			$(HOST_PYTHON_PKG_DIR)/pip \
+			$(HOST_PYTHON_PKG_DIR)/pip-* \
+			$(HOST_PYTHON_PKG_DIR)/.pip-patched* \
+			$(HOST_PYTHON_PKG_DIR)/.pip_installed_*
+	)
 	$(MAKE) -C $(HOST_BUILD_DIR) install
 	$(INSTALL_DIR) $(HOST_PYTHON_DIR)/bin/
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/Parser/pgen $(HOST_PYTHON_DIR)/bin/pgen2
-	$(if $(wildcard $(HOST_PYTHON_PKG_DIR)/.setuptools-patched-$(PYTHON_SETUPTOOLS_VERSION)),,
+	$(if $(wildcard $(HOST_PYTHON_PKG_DIR)/.setuptools_installed_$(PYTHON_SETUPTOOLS_VERSION)-$(PYTHON_SETUPTOOLS_PKG_RELEASE)),,
 		$(call HostPatchDir,$(HOST_PYTHON_PKG_DIR),./patches-setuptools,)
-		rm -f $(HOST_PYTHON_PKG_DIR)/.setuptools-patched-*
-		touch $(HOST_PYTHON_PKG_DIR)/.setuptools-patched-$(PYTHON_SETUPTOOLS_VERSION)
+		touch $(HOST_PYTHON_PKG_DIR)/.setuptools_installed_$(PYTHON_SETUPTOOLS_VERSION)-$(PYTHON_SETUPTOOLS_PKG_RELEASE)
 	)
-	$(if $(wildcard $(HOST_PYTHON_PKG_DIR)/.pip-patched-$(PYTHON_PIP_VERSION)),,
+	$(if $(wildcard $(HOST_PYTHON_PKG_DIR)/.pip_installed_$(PYTHON_PIP_VERSION)-$(PYTHON_PIP_PKG_RELEASE)),,
 		$(call HostPatchDir,$(HOST_PYTHON_PKG_DIR),./patches-pip,)
-		rm -f $(HOST_PYTHON_PKG_DIR)/.pip-patched-*
-		touch $(HOST_PYTHON_PKG_DIR)/.pip-patched-$(PYTHON_PIP_VERSION)
+		touch $(HOST_PYTHON_PKG_DIR)/.pip_installed_$(PYTHON_PIP_VERSION)-$(PYTHON_PIP_PKG_RELEASE)
 	)
 endef
 

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -306,18 +306,32 @@ define Host/Compile
 endef
 
 define Host/Install
+	$(if $(wildcard $(HOST_PYTHON3_PKG_DIR)/.setuptools_installed_$(PYTHON3_SETUPTOOLS_VERSION)-$(PYTHON3_SETUPTOOLS_PKG_RELEASE)),,
+		rm -rf \
+			$(HOST_PYTHON3_PKG_DIR)/easy_install.py \
+			$(HOST_PYTHON3_PKG_DIR)/pkg_resources \
+			$(HOST_PYTHON3_PKG_DIR)/setuptools \
+			$(HOST_PYTHON3_PKG_DIR)/setuptools-* \
+			$(HOST_PYTHON3_PKG_DIR)/.setuptools-patched* \
+			$(HOST_PYTHON3_PKG_DIR)/.setuptools_installed_*
+	)
+	$(if $(wildcard $(HOST_PYTHON3_PKG_DIR)/.pip_installed_$(PYTHON3_PIP_VERSION)-$(PYTHON3_PIP_PKG_RELEASE)),,
+		rm -rf \
+			$(HOST_PYTHON3_PKG_DIR)/pip \
+			$(HOST_PYTHON3_PKG_DIR)/pip-* \
+			$(HOST_PYTHON3_PKG_DIR)/.pip-patched* \
+			$(HOST_PYTHON3_PKG_DIR)/.pip_installed_*
+	)
 	$(MAKE) -C $(HOST_BUILD_DIR) install
 	$(INSTALL_DIR) $(HOST_PYTHON3_DIR)/bin/
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/Parser/pgen $(HOST_PYTHON3_DIR)/bin/pgen3
-	$(if $(wildcard $(HOST_PYTHON3_PKG_DIR)/.setuptools-patched-$(PYTHON3_SETUPTOOLS_VERSION)),,
+	$(if $(wildcard $(HOST_PYTHON3_PKG_DIR)/.setuptools_installed_$(PYTHON3_SETUPTOOLS_VERSION)-$(PYTHON3_SETUPTOOLS_PKG_RELEASE)),,
 		$(call HostPatchDir,$(HOST_PYTHON3_PKG_DIR),./patches-setuptools,)
-		rm -f $(HOST_PYTHON3_PKG_DIR)/.setuptools-patched-*
-		touch $(HOST_PYTHON3_PKG_DIR)/.setuptools-patched-$(PYTHON3_SETUPTOOLS_VERSION)
+		touch $(HOST_PYTHON3_PKG_DIR)/.setuptools_installed_$(PYTHON3_SETUPTOOLS_VERSION)-$(PYTHON3_SETUPTOOLS_PKG_RELEASE)
 	)
-	$(if $(wildcard $(HOST_PYTHON3_PKG_DIR)/.pip-patched-$(PYTHON3_PIP_VERSION)),,
+	$(if $(wildcard $(HOST_PYTHON3_PKG_DIR)/.pip_installed_$(PYTHON3_PIP_VERSION)-$(PYTHON3_PIP_PKG_RELEASE)),,
 		$(call HostPatchDir,$(HOST_PYTHON3_PKG_DIR),./patches-pip,)
-		rm -f $(HOST_PYTHON3_PKG_DIR)/.pip-patched-*
-		touch $(HOST_PYTHON3_PKG_DIR)/.pip-patched-$(PYTHON3_PIP_VERSION)
+		touch $(HOST_PYTHON3_PKG_DIR)/.pip_installed_$(PYTHON3_PIP_VERSION)-$(PYTHON3_PIP_PKG_RELEASE)
 	)
 endef
 


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2019-05-27 snapshot sdk
Run tested: none

Description:
This changes the "patched" indicator files for host setuptools and pip to include their `PKG_RELEASE` values. This also removes host setuptools and/or pip before host install, if the installed copy does not match the version (and `PKG_RELEASE`) of the copy to be installed.

This will allow added or removed patches to affect host setuptools / pip, since these changes will cause `PKG_RELEASE` to be incremented.

This also fixes the [host install error](https://github.com/openwrt/packages/pull/9100#issuecomment-497780186), when the install tries to patch an already patched copy of setuptools. (This error occurs because the existing indicator files do not have version numbers in their file names, whereas host install expected version numbers to be present.)

Signed-off-by: Jeffery To <jeffery.to@gmail.com>