### PR TITLE
isc-dhcp: Remove --disable-tracing from configure args

### DIFF
--- a/net/isc-dhcp/Makefile
+++ b/net/isc-dhcp/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=isc-dhcp
 UPSTREAM_NAME:=dhcp
 PKG_VERSION:=4.4.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -161,7 +161,6 @@ $(call Package/isc-dhcp-omshell/description)
 endef
 
 CONFIGURE_ARGS += \
-	--disable-tracing 		\
 	--enable-paranoia		\
 	--disable-dependency-tracking	\
 	--with-randomdev=/dev/urandom \


### PR DESCRIPTION
Maintainer: 
Compile tested: x86-64-generic; ar71xx-generic-ubnt-rspro
Run tested: x86-64-generic; ar71xx-generic-ubnt-rspro

Description:
This fixes a crash that happens when dhcpd is configured with a failover
peer, and the failover peer goes down. The crash is due to a dereference
of a freed object. When tracing is enabled (which is the default) the
object in question is referenced by the tracing code and so doesn't get
freed prematurely. I have observed this crash on two different target
platforms (mips and x86_64), and it is reproducible on non-OpenWRT
distros by building isc-dhcpd using --disable-tracing.

This has been reported to ISC, but their response was that it's a low
priority as the simple work-around is to leave tracing enabled.

Re-enabling the tracing code only increases the size of the executable
by about 24KB.

