### PR TITLE
perl: Do not build on ARC

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -63,7 +63,7 @@ define Package/perl
   CATEGORY:=Languages
   TITLE:=The Perl intepreter
   URL:=http://www.perl.com/
-  DEPENDS:=+USE_GLIBC:libbsd +PERL_THREADS:libpthread
+  DEPENDS:=+USE_GLIBC:libbsd +PERL_THREADS:libpthread @!arc
 endef
 
 define Package/perl/description


### PR DESCRIPTION
Not supported.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @pprindeville @Naoir 

https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/perl/compile.txt