### PR TITLE
[WIP] postgresql: Explicity build SSL and no-SSL versions

### DIFF
--- a/libs/postgresql-ssl/;
+++ b/libs/postgresql-ssl/;
@@ -1,0 +1,277 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=postgresql-ssl
+PKG_BASE_NAME:=postgresql
+PKG_VERSION:=9.6.13
+PKG_RELEASE:=2
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_LICENSE:=PostgreSQL
+
+PKG_SOURCE:=$(PKG_BASE_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=\
+	https://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
+	http://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
+	ftp://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
+
+PKG_HASH:=ecbed20056296a65b6a4f5526c477e3ae5cc284cb01a15507785ddb23831e9a4
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/$(PKG_BASE_NAME)-$(PKG_VERSION)
+
+PKG_USE_MIPS16:=0
+PKG_FIXUP:=autoreconf
+PKG_MACRO_PATHS:=config
+PKG_BUILD_DEPENDS:=readline/host postgresql/host
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libpq-ssl
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=PostgreSQL client library (SSL)
+  URL:=http://www.postgresql.org/
+  SUBMENU:=database
+  DEPENDS:=+libpthread +libopenssl
+  PROVIDES:=libpq
+endef
+
+define Package/libpq-ssl/description
+PostgreSQL client library.
+
+This is the SSL-enabled version
+endef
+
+define Package/pgsql-ssl-cli
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libncursesw +libreadline +librt +zlib +libpq-ssl
+  TITLE:=CLI to PostgreSQL databases (SSL)
+  URL:=http://www.postgresql.org/
+  SUBMENU:=database
+  PROVIDES:=pgsql-cli
+endef
+
+define Package/pgsql-ssl-cli/description
+Command Line Interface (CLI) to PostgreSQL databases.
+
+This is the SSL-enabled version
+endef
+
+define Package/pgsql-ssl-cli-extra/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libncursesw +libreadline +librt +zlib +libpq-ssl
+  TITLE:=Command Line extras for PostgreSQL databases (SSL)
+  URL:=http://www.postgresql.org/
+  SUBMENU:=database
+  PROVIDES:=pgsql-cli-extra
+endef
+
+define Package/pgsql-ssl-cli-extra/description
+Command Line extras for PostgreSQL databases.
+
+This is the SSL-enabled version
+endef
+
+define Package/pgsql-ssl-server/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=PostgreSQL databases Server (SSL)
+  URL:=http://www.postgresql.org/
+  SUBMENU:=database
+  DEPENDS:=+pgsql-ssl-cli +pgsql-common-server
+  PROVIDES:=pgsql-server
+endef
+
+define Package/pgsql-ssl-server/description
+PostgreSQL databases Server.
+
+This is the SSL-enabled version
+endef
+
+PGSQL_SERVER_BIN := \
+	pg_archivecleanup \
+	pg_basebackup \
+	pg_controldata \
+	pg_ctl \
+	pg_dump \
+	pg_dumpall \
+	pg_isready \
+	pg_receivexlog \
+	pg_recvlogical \
+	pg_resetxlog \
+	pg_restore \
+	pg_standby \
+	pg_upgrade \
+	pg_xlogdump \
+	postgres \
+	initdb
+
+PGSQL_CLI_EXTRA_BIN := \
+	clusterdb	\
+	createdb	\
+	createlang	\
+	createuser	\
+	dropdb		\
+	droplang	\
+	dropuser	\
+	pgbench		\
+	reindexdb	\
+	vacuumdb
+
+PGSQL_CONFIG_VARS:= \
+	pgac_cv_snprintf_long_long_int_format="%lld" \
+	pgac_cv_snprintf_size_t_support=yes
+
+ifeq ($(CONFIG_USE_UCLIBC),y)
+# PostgreSQL does not build against uClibc with locales
+# enabled, due to an uClibc bug, see
+# http://lists.uclibc.org/pipermail/uclibc/2014-April/048326.html
+# so overwrite automatic detection and disable locale support
+PGSQL_CONFIG_VARS+= \
+		pgac_cv_type_locale_t=no
+endif
+
+TARGET_CONFIGURE_OPTS+=$(PGSQL_CONFIG_VARS)
+
+HOST_CONFIGURE_ARGS += \
+		       	--libdir=$(STAGING_DIR_HOSTPKG)/usr/lib/pgsql-ssl
+		       	--includedir=$(STAGING_DIR_HOSTPKG)/usr/include/pgsql-ssl
+			--disable-nls \
+			--disable-rpath \
+			--without-bonjour \
+			--without-gssapi \
+			--without-ldap \
+			--without-pam \
+			--without-perl \
+			--without-python \
+			--without-readline \
+			--without-tcl \
+		  	--with-includes=$(STAGING_DIR_HOST)/include \
+		  	--with-libraries=$(STAGING_DIR_HOST)/lib \
+			--with-openssl \
+			--with-zlib="yes" \
+			--enable-depend
+
+CONFIGURE_ARGS += \
+			$(DISABLE_NLS) \
+			--disable-rpath \
+			--without-bonjour \
+			--without-gssapi \
+			--without-ldap \
+			--without-pam \
+			--without-perl \
+			--without-python \
+			--without-tcl \
+			--with-extra-version=ssl \
+			--with-extra-libname=ssl \
+			--with-includes=$(STAGING_DIR)/usr/include \
+		  	--with-libraries=$(STAGING_DIR)/usr/lib \
+			--with-openssl \
+			--with-zlib="yes" \
+			--enable-depend
+endif
+
+CONFIGURE_VARS += \
+		  PG_CONFIG=$(STAGING_DIR_HOSTPKG)/lib/pgsql-ssl/pg_config
+
+# Need a native ecpg, pg_config and zic for build
+define Host/Compile
+	$(MAKE) -C $(HOST_BUILD_DIR)/src/bin/pg_config CC="$(HOSTCC)" PG_CONFIG="$(STAGING_DIR_HOSTPKG)/lib/pgsql-ssl/pg_config
+	$(MAKE) -C $(HOST_BUILD_DIR)/src/interfaces/ecpg/preproc CC="$(HOSTCC)" PG_CONFIG="$(STAGING_DIR_HOSTPKG)/lib/pgsql-ssl/pg_config
+	$(MAKE) -C $(HOST_BUILD_DIR)/src/timezone CC="$(HOSTCC)" PG_CONFIG="$(STAGING_DIR_HOSTPKG)/lib/pgsql-ssl/pg_config
+endef
+
+define Host/Install
+	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/lib/pgsql-ssl
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/common/libpgcommon.a $(STAGING_DIR_HOSTPKG)/lib/pgsql-ssl
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/port/libpgport.a $(STAGING_DIR_HOSTPKG)/lib/pgsql-ssl
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/bin/pg_config/pg_config $(STAGING_DIR_HOSTPKG)/lib/pgsql-ssl
+	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/bin/pgsql-ssl
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/interfaces/ecpg/preproc/ecpg $(STAGING_DIR_HOSTPKG)/bin
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/timezone/zic $(STAGING_DIR_HOSTPKG)/bin
+endef
+
+define Build/Configure
+	$(Build/Configure/Default)
+	$(SED) 's@ECPG = ../../preproc/ecpg@ECPG = $(STAGING_DIR_HOSTPKG)/bin/ecpg@' $(PKG_BUILD_DIR)/src/interfaces/ecpg/test/Makefile.regress
+endef
+
+# because PROFILE means something else in the project Makefile
+unexport PROFILE
+
+define Package/libpq-ssl/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpqssl.so.* $(1)/usr/lib/
+endef
+
+define Package/pgsql-ssl-cli/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/psql $(1)/usr/bin/
+endef
+
+define Package/pgsql-ssl-cli-extra/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(foreach bin,$(PGSQL_CLI_EXTRA_BIN),$(PKG_INSTALL_DIR)/usr/bin/$(bin)) $(1)/usr/bin/
+endef
+
+define Package/pgsql-ssl-server/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(foreach bin,$(PGSQL_SERVER_BIN),$(PKG_INSTALL_DIR)/usr/bin/$(bin)) $(1)/usr/bin/
+
+	ln -sf postgres $(1)/usr/bin/postmaster
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/postgresql \
+		$(1)/usr/lib/
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(STAGING_DIR_HOSTPKG)/lib/pg_config $(1)/usr/bin/pg_configssl
+	$(INSTALL_DIR) $(1)/host/bin/
+	$(LN) $(STAGING_DIR)/usr/bin/pg_configssl $(1)/host/bin
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/pgsql-ssl/libpq $(1)/usr/include/pgsql-ssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/pgsql-ssl/libpq-fe.h $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/pgsql-ssl/pg_config.h $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/pg_config_manual.h $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/postgres_ext.h $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/pg_config_ext.h $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/postgresql $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpq.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpq.pc $(1)/usr/lib/pkgconfig/
+endef
+else
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(STAGING_DIR_HOSTPKG)/lib/pg_config $(1)/usr/bin/pg_configssl
+	$(INSTALL_DIR) $(1)/host/bin/
+	$(LN) $(STAGING_DIR)/usr/bin/pg_config $(1)/host/bin/pg_configssl
+	$(INSTALL_DIR) $(1)/usr/include/libpqssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libpq $(1)/usr/include/libpqssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libpq-fe.h $(1)/usr/include/libpqssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/pg_config.h $(1)/usr/include/libpqssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/pg_config_manual.h $(1)/usr/include/libpqssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/postgres_ext.h $(1)/usr/include/libpqssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/pg_config_ext.h $(1)/usr/include/libpqssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/postgresql $(1)/usr/include/libpqssl
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpqssl.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpqssl.pc $(1)/usr/lib/pkgconfig/
+	$(SED)'s,/usr/include$$$$,/usr/include/libpqssl,g' $(1)/usr/lib/pkgconfig/libpqssl.pc
+endef
+endif
+
+$(eval $(call HostBuild))
+$(eval $(call BuildPackage,libpq-ssl))
+$(eval $(call BuildPackage,pgsql-ssl-cli))
+$(eval $(call BuildPackage,pgsql-ssl-cli-extra))
+$(eval $(call BuildPackage,pgsql-ssl-server))

--- a/libs/postgresql-ssl/Makefile
+++ b/libs/postgresql-ssl/Makefile
@@ -4,19 +4,21 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=postgresql
+PKG_NAME:=postgresql-ssl
+PKG_BASE_NAME:=postgresql
 PKG_VERSION:=9.6.13
 PKG_RELEASE:=2
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE:=$(PKG_BASE_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=\
 	https://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
 	http://ftp.postgresql.org/pub/source/v$(PKG_VERSION) \
 	ftp://ftp.postgresql.org/pub/source/v$(PKG_VERSION)
 
 PKG_HASH:=ecbed20056296a65b6a4f5526c477e3ae5cc284cb01a15507785ddb23831e9a4
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/$(PKG_BASE_NAME)-$(PKG_VERSION)
 
 PKG_USE_MIPS16:=0
 PKG_FIXUP:=autoreconf
@@ -27,71 +29,64 @@ PKG_INSTALL:=1
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 
-define Package/libpq
+define Package/libpq-ssl
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libpthread
-  TITLE:=PostgreSQL client library
+  TITLE:=PostgreSQL client library (SSL)
   URL:=http://www.postgresql.org/
   SUBMENU:=database
+  DEPENDS:=+libpthread +libopenssl
 endef
 
-define Package/libpq/description
+define Package/libpq-ssl/description
 PostgreSQL client library.
+
+This is the SSL-enabled version
 endef
 
-define Package/pgsql-cli
+define Package/pgsql-ssl-cli
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libncursesw +libpq +libreadline +librt +zlib
-  TITLE:=Command Line Interface (CLI) to PostgreSQL databases
+  DEPENDS:=+libncursesw +libreadline +librt +zlib +libpq-ssl
+  TITLE:=CLI to PostgreSQL databases (SSL)
   URL:=http://www.postgresql.org/
   SUBMENU:=database
 endef
 
-define Package/pgsql-cli/description
+define Package/pgsql-ssl-cli/description
 Command Line Interface (CLI) to PostgreSQL databases.
+
+This is the SSL-enabled version
 endef
 
-define Package/pgsql-cli-extra
+define Package/pgsql-ssl-cli-extra
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libncursesw +libpq +libreadline +librt +zlib
-  TITLE:=Command Line extras for PostgreSQL databases
+  DEPENDS:=+libncursesw +libreadline +librt +zlib +libpq-ssl
+  TITLE:=Command Line extras for PostgreSQL databases (SSL)
   URL:=http://www.postgresql.org/
   SUBMENU:=database
 endef
 
-define Package/pgsql-cli-extra/description
+define Package/pgsql-ssl-cli-extra/description
 Command Line extras for PostgreSQL databases.
+
+This is the SSL-enabled version
 endef
 
-define Package/pgsql-common-server
+define Package/pgsql-ssl-server
   SECTION:=utils
   CATEGORY:=Utilities
-  TITLE:=PostgreSQL databases servers common files
+  TITLE:=PostgreSQL databases Server (SSL)
   URL:=http://www.postgresql.org/
   SUBMENU:=database
-  USERID:=postgres=5432:postgres=5432
+  DEPENDS:=+pgsql-ssl-cli +pgsql-common-server
 endef
 
-define Package/pgsql-common-server/description
-Common files for PostgreSQL databases Servers.
-This package contains common files between the non-ssl-enabled
-server and the ssl-enabled server.
-endef
-
-define Package/pgsql-server
-  SECTION:=utils
-  CATEGORY:=Utilities
-  DEPENDS:=+pgsql-cli +pgsql-common-server
-  TITLE:=PostgreSQL databases Server
-  URL:=http://www.postgresql.org/
-  SUBMENU:=database
-endef
-
-define Package/pgsql-server/description
+define Package/pgsql-ssl-server/description
 PostgreSQL databases Server.
+
+This is the SSL-enabled version
 endef
 
 PGSQL_SERVER_BIN := \
@@ -140,50 +135,61 @@ endif
 TARGET_CONFIGURE_OPTS+=$(PGSQL_CONFIG_VARS)
 
 HOST_CONFIGURE_ARGS += \
+		       	--libdir=$(STAGING_DIR_HOSTPKG)/usr/lib/psql-ssl \
+		       	--includedir=$(STAGING_DIR_HOSTPKG)/usr/include/psql-ssl \
 			--disable-nls \
 			--disable-rpath \
 			--without-bonjour \
 			--without-gssapi \
 			--without-ldap \
-			--without-openssl \
 			--without-pam \
 			--without-perl \
 			--without-python \
 			--without-readline \
 			--without-tcl \
+		  	--with-includes=$(STAGING_DIR_HOST)/include \
+		  	--with-libraries=$(STAGING_DIR_HOST)/lib \
+			--with-openssl \
 			--with-zlib="yes" \
 			--enable-depend
 
 CONFIGURE_ARGS += \
+		       	--includedir=$(CONFIGURE_PREFIX)/include/psql-ssl \
 			$(DISABLE_NLS) \
 			--disable-rpath \
 			--without-bonjour \
 			--without-gssapi \
 			--without-ldap \
-			--without-openssl \
 			--without-pam \
 			--without-perl \
 			--without-python \
 			--without-tcl \
+			--with-extra-version=ssl \
+			--with-extra-libname=ssl \
+			--with-includes=$(STAGING_DIR)/usr/include \
+		  	--with-libraries=$(STAGING_DIR)/usr/lib \
+			--with-openssl \
 			--with-zlib="yes" \
-			--enable-depend \
-			$(if $(CONFIG_arc),--disable-spinlocks)
+			--enable-depend
+
+CONFIGURE_VARS += \
+		  PG_CONFIG=$(STAGING_DIR_HOSTPKG)/lib/psql-ssl/pg_config
 
 # Need a native ecpg, pg_config and zic for build
 define Host/Compile
-	$(MAKE) -C $(HOST_BUILD_DIR)/src/bin/pg_config CC="$(HOSTCC)"
-	$(MAKE) -C $(HOST_BUILD_DIR)/src/interfaces/ecpg/preproc CC="$(HOSTCC)"
-	$(MAKE) -C $(HOST_BUILD_DIR)/src/timezone CC="$(HOSTCC)"
+	$(MAKE) -C $(HOST_BUILD_DIR)/src/bin/pg_config CC="$(HOSTCC)" PG_CONFIG="$(STAGING_DIR_HOSTPKG)/lib/psql-ssl/pg_config
+	$(MAKE) -C $(HOST_BUILD_DIR)/src/interfaces/ecpg/preproc CC="$(HOSTCC)" PG_CONFIG="$(STAGING_DIR_HOSTPKG)/lib/psql-ssl/pg_config
+	$(MAKE) -C $(HOST_BUILD_DIR)/src/timezone CC="$(HOSTCC)" PG_CONFIG="$(STAGING_DIR_HOSTPKG)/lib/psql-ssl/pg_config
 endef
 
 define Host/Install
-	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/lib/
-	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/common/libpgcommon.a $(STAGING_DIR_HOSTPKG)/lib/
-	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/port/libpgport.a $(STAGING_DIR_HOSTPKG)/lib/
-	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/bin/pg_config/pg_config $(STAGING_DIR_HOSTPKG)/lib/
-	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/bin/
-	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/interfaces/ecpg/preproc/ecpg $(STAGING_DIR_HOSTPKG)/bin/
-	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/timezone/zic $(STAGING_DIR_HOSTPKG)/bin/
+	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/lib/psql-ssl
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/common/libpgcommon.a $(STAGING_DIR_HOSTPKG)/lib/psql-ssl
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/port/libpgport.a $(STAGING_DIR_HOSTPKG)/lib/psql-ssl
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/bin/pg_config/pg_config $(STAGING_DIR_HOSTPKG)/lib/psql-ssl
+	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/bin/psql-ssl
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/interfaces/ecpg/preproc/ecpg $(STAGING_DIR_HOSTPKG)/bin
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/src/timezone/zic $(STAGING_DIR_HOSTPKG)/bin
 endef
 
 define Build/Configure
@@ -194,37 +200,22 @@ endef
 # because PROFILE means something else in the project Makefile
 unexport PROFILE
 
-define Package/libpq/install
+define Package/libpq-ssl/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpq.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpqssl.so.* $(1)/usr/lib/
 endef
 
-define Package/pgsql-cli/install
+define Package/pgsql-ssl-cli/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/psql $(1)/usr/bin/
 endef
 
-define Package/pgsql-cli-extra/install
+define Package/pgsql-ssl-cli-extra/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(foreach bin,$(PGSQL_CLI_EXTRA_BIN),$(PKG_INSTALL_DIR)/usr/bin/$(bin)) $(1)/usr/bin/
 endef
 
-define Package/pgsql-common-server/install
-	$(INSTALL_DIR) $(1)/usr/share/postgresql
-	$(CP) $(PKG_INSTALL_DIR)/usr/share/postgresql/* \
-		$(1)/usr/share/postgresql
-
-	$(INSTALL_DIR) $(1)/lib/functions
-	$(INSTALL_BIN) ./files/postgresql.sh $(1)/lib/functions/
-
-	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_DATA) ./files/postgresql.config $(1)/etc/config/postgresql
-
-	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) ./files/postgresql.init $(1)/etc/init.d/postgresql
-endef
-
-define Package/pgsql-server/install
+define Package/pgsql-ssl-server/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(foreach bin,$(PGSQL_SERVER_BIN),$(PKG_INSTALL_DIR)/usr/bin/$(bin)) $(1)/usr/bin/
 
@@ -237,26 +228,25 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(STAGING_DIR_HOSTPKG)/lib/pg_config $(1)/usr/bin
+	$(CP) $(STAGING_DIR_HOSTPKG)/lib/pg_config $(1)/usr/bin/pg_configssl
 	$(INSTALL_DIR) $(1)/host/bin/
-	$(LN) $(STAGING_DIR)/usr/bin/pg_config $(1)/host/bin
+	$(LN) $(STAGING_DIR)/usr/bin/pg_configssl $(1)/host/bin/pg_configssl
 	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/libpq $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/libpq-fe.h $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/pg_config.h $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/pg_config_manual.h $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/postgres_ext.h $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/pg_config_ext.h $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/postgresql $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/psql-ssl/libpq $(1)/usr/include/psql-ssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/psql-ssl/libpq-fe.h $(1)/usr/include/pgql-ssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/psql-ssl/pg_config.h $(1)/usr/include/psql-ssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/psql-ssl/pg_config_manual.h $(1)/usr/include/psql-ssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/psql-ssl/postgres_ext.h $(1)/usr/include/psql-ssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/psql-ssl/pg_config_ext.h $(1)/usr/include/psql-ssl
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/psql-ssl/postgresql $(1)/usr/include/psql-ssl
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpq.{a,so*} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpqssl.{a,so*} $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpq.pc $(1)/usr/lib/pkgconfig/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libpqssl.pc $(1)/usr/lib/pkgconfig/
 endef
 
 $(eval $(call HostBuild))
-$(eval $(call BuildPackage,libpq))
-$(eval $(call BuildPackage,pgsql-cli))
-$(eval $(call BuildPackage,pgsql-cli-extra))
-$(eval $(call BuildPackage,pgsql-common-server))
-$(eval $(call BuildPackage,pgsql-server))
+$(eval $(call BuildPackage,libpq-ssl))
+$(eval $(call BuildPackage,pgsql-ssl-cli))
+$(eval $(call BuildPackage,pgsql-ssl-cli-extra))
+$(eval $(call BuildPackage,pgsql-ssl-server))

--- a/libs/postgresql-ssl/files/postgresql.config
+++ b/libs/postgresql-ssl/files/postgresql.config
@@ -1,0 +1,2 @@
+config postgresql config
+	option PGDATA	/var/postgresql/data

--- a/libs/postgresql-ssl/files/postgresql.init
+++ b/libs/postgresql-ssl/files/postgresql.init
@@ -1,0 +1,78 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2006-2015 OpenWrt.org
+START=50
+
+PROG=/usr/bin/postmaster
+
+USE_PROCD=1
+
+EXTRA_COMMANDS="status"
+EXTRA_HELP="        status  Show current status of the PostgreSQL server"
+
+fix_hosts() {
+	# make sure localhost (without a dot) is in /etc/hosts
+	grep -q 'localhost$' /etc/hosts || echo '127.0.0.1 localhost' >> /etc/hosts
+}
+
+fix_perms() {
+	# for whatever reason, /dev/null gets wrong perms
+	chmod a+w /dev/null
+}
+
+cleanup() {
+	if [ -f "$1/postmaster.pid" ]; then
+		rm "$1/postmaster.pid"
+	fi
+}
+
+start_service() {
+	. /lib/functions/postgresql.sh
+
+	config_load "postgresql"
+	config_get pgdata config PGDATA
+	config_get pgopts config PGOPTS
+
+	user_exists postgres 5432 || user_add postgres 5432
+	group_exists postgres 5432 || group_add postgres 5432
+
+	fix_perms
+	fix_hosts
+
+	if [ ! -d "${pgdata}" ]; then
+		pg_init_data ${pgdata}
+		[ $? -gt 0 ] && return 1
+	fi
+
+	cleanup "${pgdata}"
+
+	procd_open_instance
+	procd_set_param user postgres
+	procd_set_param command $PROG
+	procd_append_param command -D "${pgdata}"
+	[ -n "${pgopts}" ] && procd_append_param command -o "${pgopts}"
+	procd_set_param respawn retry=60
+	procd_close_instance
+
+	procd_open_instance
+	procd_set_param user postgres
+	procd_set_param command /lib/functions/postgresql.sh init "${pgdata}"
+	procd_close_instance
+}
+
+reload_service() {
+	config_load "postgresql"
+	config_get pgdata config PGDATA
+	/usr/bin/pg_ctl reload -U postgres -D "${pgdata}" -s
+}
+
+stop_service() {
+	config_load "postgresql"
+	config_get pgdata config PGDATA
+	/usr/bin/pg_ctl stop -U postgres -D "${pgdata}" -s
+}
+
+status() {
+	config_load "postgresql"
+	config_get pgdata config PGDATA
+	/usr/bin/pg_ctl status -U postgres -D "${pgdata}"
+}

--- a/libs/postgresql-ssl/files/postgresql.sh
+++ b/libs/postgresql-ssl/files/postgresql.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+PSQL="/usr/bin/psql"
+
+free_megs() {
+	fsdir=$1
+	while [ ! -d "$fsdir" ]; do
+		fsdir=$(dirname $fsdir)
+	done
+	df -m $fsdir | while read fs bl us av cap mnt; do [ "$av" = "Available" ] || echo $av; done
+}
+
+pg_init_data() {
+	# make sure we got at least 50MB of free space
+	[ $(free_megs $1) -lt 50 ] && return 1
+	pg_ctl initdb -U postgres -D $1
+}
+
+pg_server_ready() {
+	t=0
+	while [ $t -le 90 ]; do
+		pg_ctl status -U postgres -D $1 2>/dev/null >/dev/null && return 0
+		t=$((t+1))
+		sleep 1
+	done
+	return 1
+}
+
+
+pg_test_db() {
+	if [ "$3" ]; then
+		echo "SHOW ALL;" | env PGPASSWORD="$3" $PSQL -U "$2" -d "$1" -q 2>/dev/null >/dev/null
+		return $?
+	else
+		echo "SHOW ALL;" | $PSQL -w -U "$2" -d "$1" -q 2>/dev/null >/dev/null
+		return $?
+	fi
+}
+
+pg_include_sql() {
+	if [ "$3" ]; then
+		env PGPASSWORD="$3" $PSQL -U "$2" -d "$1" -e -f "$4"
+		return $?
+	else
+		$PSQL -w -U "$2" -d "$1" -e -f "$4"
+		return $?
+	fi
+}
+
+# $1: dbname, $2: username, $3: password, $4: sql populate script
+pg_require_db() {
+	local ret
+
+	pg_test_db $@ && return 0
+	( echo "CREATE DATABASE $1;"
+	echo -n "CREATE USER $2"
+	[ "$3" ] && echo -n " WITH PASSWORD '$3'"
+	echo " NOCREATEDB NOSUPERUSER NOCREATEROLE NOINHERIT;"
+	echo "GRANT ALL PRIVILEGES ON DATABASE \"$1\" TO $2;" ) |
+		$PSQL -U postgres -d template1 -e
+	ret=$?
+	[ "$ret" = "0" ] || return $ret
+
+	if [ "$4" ]; then
+		pg_include_sql "$@"
+		ret=$?
+	fi
+
+	return $ret
+}
+
+uci_require_db() {
+	local dbname dbuser dbpass dbscript
+	config_get dbname $1 name
+	config_get dbuser $1 user
+	config_get dbpass $1 pass
+	config_get dbscript $1 script
+	pg_require_db "$dbname" "$dbuser" "$dbpass" "$dbscript"
+}
+
+[ "$1" = "init" ] && {
+	. /lib/functions.sh
+	pg_server_ready $2 || exit 1
+	config_load postgresql
+	config_foreach uci_require_db postgres-db
+}

--- a/libs/postgresql-ssl/patches/001-configure_fixes.patch
+++ b/libs/postgresql-ssl/patches/001-configure_fixes.patch
@@ -1,0 +1,11 @@
+--- a/configure.in
++++ b/configure.in
+@@ -25,7 +25,7 @@ recommended.  You can remove the check f
+ your responsibility whether the result works or not.])])
+ AC_COPYRIGHT([Copyright (c) 1996-2016, PostgreSQL Global Development Group])
+ AC_CONFIG_SRCDIR([src/backend/access/common/heaptuple.c])
+-AC_CONFIG_AUX_DIR(config)
++AC_CONFIG_AUX_DIR([config])
+ AC_PREFIX_DEFAULT(/usr/local/pgsql)
+ AC_SUBST(configure_args, [$ac_configure_args])
+ 

--- a/libs/postgresql-ssl/patches/050-build-contrib.patch
+++ b/libs/postgresql-ssl/patches/050-build-contrib.patch
@@ -1,0 +1,11 @@
+--- a/GNUmakefile.in
++++ b/GNUmakefile.in
+@@ -8,7 +8,7 @@ subdir =
+ top_builddir = .
+ include $(top_builddir)/src/Makefile.global
+ 
+-$(call recurse,all install,src config)
++$(call recurse,all install,src config contrib)
+ 
+ all:
+ 	+@echo "All of PostgreSQL successfully made. Ready to install."

--- a/libs/postgresql-ssl/patches/060-configure-extra-version-soname.patch
+++ b/libs/postgresql-ssl/patches/060-configure-extra-version-soname.patch
@@ -1,0 +1,401 @@
+Index: postgresql-9.6.13/configure.in
+===================================================================
+--- postgresql-9.6.13.orig/configure.in
++++ postgresql-9.6.13/configure.in
+@@ -38,6 +38,12 @@ PGAC_ARG_REQ(with, extra-version, [STRIN
+              [PG_VERSION="$PACKAGE_VERSION"])
+ AC_DEFINE_UNQUOTED(PG_VERSION, "$PG_VERSION", [PostgreSQL version as a string])
+ 
++PGAC_ARG_REQ(with, extra-libname, [STRING], [append STRING to library names],
++             [PG_SOEXTRA="$withval"],
++             [PG_SOEXTRA=""])
++AC_DEFINE_UNQUOTED(PG_SOEXTRA, "$PG_SOEXTRA", [Extra version for library names])
++AC_SUBST(PG_SOEXTRA)
++
+ AC_CANONICAL_HOST
+ 
+ template=
+Index: postgresql-9.6.13/src/Makefile.shlib
+===================================================================
+--- postgresql-9.6.13.orig/src/Makefile.shlib
++++ postgresql-9.6.13/src/Makefile.shlib
+@@ -19,6 +19,7 @@
+ # variables:
+ #
+ # NAME                  Name of library to build (no suffix nor "lib" prefix)
++# SOEXTRA               Extra name (appended to $(NAME))
+ # OBJS                  List of object files to include in library
+ # SHLIB_LINK            Stuff to append to library's link command
+ #                       (typically, -L and -l switches for external libraries)
+@@ -74,24 +75,24 @@
+ COMPILER = $(CC) $(CFLAGS)
+ LINK.static = $(AR) $(AROPT)
+ 
+-LDFLAGS_INTERNAL += $(SHLIB_LINK_INTERNAL)
++LDFLAGS_INTERNAL += $(foreach intshlib,$(SHLIB_LINK_INTERNAL),$(if $(filter -l,$(intshlib)),-l$(instshlib)$(SOEXTRA),$(instshlib)))
+ 
+ 
+ 
+ ifdef SO_MAJOR_VERSION
+ # Default library naming convention used by the majority of platforms
+-shlib		= lib$(NAME)$(DLSUFFIX).$(SO_MAJOR_VERSION).$(SO_MINOR_VERSION)
+-shlib_major	= lib$(NAME)$(DLSUFFIX).$(SO_MAJOR_VERSION)
+-shlib_bare	= lib$(NAME)$(DLSUFFIX)
++shlib		= lib$(NAME)$(SOEXTRA)$(DLSUFFIX).$(SO_MAJOR_VERSION).$(SO_MINOR_VERSION)
++shlib_major	= lib$(NAME)$(SOEXTRA)$(DLSUFFIX).$(SO_MAJOR_VERSION)
++shlib_bare	= lib$(NAME)$(SOEXTRA)$(DLSUFFIX)
+ # Testing the soname variable is a reliable way to determine whether a
+ # linkable library is being built.
+ soname		= $(shlib_major)
+ pkgconfigdir = $(libdir)/pkgconfig
+ else
+ # Naming convention for dynamically loadable modules
+-shlib		= $(NAME)$(DLSUFFIX)
++shlib		= $(NAME)$(SOEXTRA)$(DLSUFFIX)
+ endif
+-stlib		= lib$(NAME).a
++stlib		= lib$(NAME)$(SOEXTRA).a
+ 
+ ifndef soname
+ # additional flags for backend modules
+@@ -113,11 +114,11 @@ endif
+ 
+ ifeq ($(PORTNAME), aix)
+   ifdef SO_MAJOR_VERSION
+-    shlib		= lib$(NAME)$(DLSUFFIX).$(SO_MAJOR_VERSION)
++    shlib		= lib$(NAME)$(SOEXTRA)$(DLSUFFIX).$(SO_MAJOR_VERSION)
+   endif
+   haslibarule   = yes
+   # $(exports_file) is also usable as an import file
+-  exports_file		= lib$(NAME).exp
++  exports_file		= lib$(NAME)$(SOEXTRA).exp
+ endif
+ 
+ ifeq ($(PORTNAME), darwin)
+@@ -127,9 +128,9 @@ ifeq ($(PORTNAME), darwin)
+     ifneq ($(SO_MAJOR_VERSION), 0)
+       version_link	= -compatibility_version $(SO_MAJOR_VERSION) -current_version $(SO_MAJOR_VERSION).$(SO_MINOR_VERSION)
+     endif
+-    LINK.shared		= $(COMPILER) -dynamiclib -install_name '$(libdir)/lib$(NAME).$(SO_MAJOR_VERSION)$(DLSUFFIX)' $(version_link) $(exported_symbols_list) -multiply_defined suppress
+-    shlib		= lib$(NAME).$(SO_MAJOR_VERSION).$(SO_MINOR_VERSION)$(DLSUFFIX)
+-    shlib_major		= lib$(NAME).$(SO_MAJOR_VERSION)$(DLSUFFIX)
++    LINK.shared		= $(COMPILER) -dynamiclib -install_name '$(libdir)/lib$(NAME)$(SOEXTRA).$(SO_MAJOR_VERSION)$(DLSUFFIX)' $(version_link) $(exported_symbols_list) -multiply_defined suppress
++    shlib		= lib$(NAME)$(SOEXTRA).$(SO_MAJOR_VERSION).$(SO_MINOR_VERSION)$(DLSUFFIX)
++    shlib_major		= lib$(NAME)$(SOEXTRA).$(SO_MAJOR_VERSION)$(DLSUFFIX)
+   else
+     # loadable module
+     DLSUFFIX		= .so
+@@ -157,7 +158,7 @@ endif
+ ifeq ($(PORTNAME), freebsd)
+   ifdef ELF_SYSTEM
+     ifdef SO_MAJOR_VERSION
+-      shlib		= lib$(NAME)$(DLSUFFIX).$(SO_MAJOR_VERSION)
++      shlib		= lib$(NAME)$(SOEXTRA)$(DLSUFFIX).$(SO_MAJOR_VERSION)
+     endif
+     LINK.shared		= $(COMPILER) -shared
+     ifdef soname
+@@ -165,7 +166,7 @@ ifeq ($(PORTNAME), freebsd)
+     endif
+   else
+     ifdef SO_MAJOR_VERSION
+-      shlib		= lib$(NAME)$(DLSUFFIX).$(SO_MAJOR_VERSION).$(SO_MINOR_VERSION)
++      shlib		= lib$(NAME)$(SOEXTRA)$(DLSUFFIX).$(SO_MAJOR_VERSION).$(SO_MINOR_VERSION)
+     endif
+     LINK.shared		= $(LD) -x -Bshareable -Bforcearchive
+   endif
+@@ -184,7 +185,7 @@ endif
+ 
+ ifeq ($(PORTNAME), hpux)
+   ifdef SO_MAJOR_VERSION
+-    shlib			= lib$(NAME)$(DLSUFFIX).$(SO_MAJOR_VERSION)
++    shlib			= lib$(NAME)$(SOEXTRA)$(DLSUFFIX).$(SO_MAJOR_VERSION)
+   endif
+   ifeq ($(with_gnu_ld), yes)
+     LINK.shared		= $(CC) -shared
+@@ -269,14 +270,14 @@ endif
+ ifeq ($(PORTNAME), cygwin)
+   LINK.shared		= $(CC) -shared
+   ifdef SO_MAJOR_VERSION
+-    shlib		= cyg$(NAME)$(DLSUFFIX)
++    shlib		= cyg$(NAME)$(SOEXTRA)$(DLSUFFIX)
+   endif
+   haslibarule   = yes
+ endif
+ 
+ ifeq ($(PORTNAME), win32)
+   ifdef SO_MAJOR_VERSION
+-    shlib		= lib$(NAME)$(DLSUFFIX)
++    shlib		= lib$(NAME)$(SOEXTRA)$(DLSUFFIX)
+   endif
+   haslibarule   = yes
+ endif
+@@ -293,7 +294,7 @@ all-lib: all-shared-lib
+ ifdef soname
+ # no static library when building a dynamically loadable module
+ all-lib: all-static-lib
+-all-lib: lib$(NAME).pc
++all-lib: lib$(NAME)$(SOEXTRA).pc
+ endif
+ 
+ all-static-lib: $(stlib)
+@@ -399,7 +400,7 @@ ifeq (,$(SHLIB_EXPORTS))
+ $(shlib): $(OBJS) | $(SHLIB_PREREQS)
+ 	$(CC) $(CFLAGS)  -shared -static-libgcc -o $@  $(OBJS) $(LDFLAGS) $(LDFLAGS_SL) $(SHLIB_LINK) $(LIBS) -Wl,--export-all-symbols -Wl,--out-implib=$(stlib)
+ else
+-DLL_DEFFILE = lib$(NAME)dll.def
++DLL_DEFFILE = lib$(NAME)$(SOEXTRA)dll.def
+ 
+ $(shlib): $(OBJS) $(DLL_DEFFILE) | $(SHLIB_PREREQS)
+ 	$(CC) $(CFLAGS)  -shared -static-libgcc -o $@  $(OBJS) $(DLL_DEFFILE) $(LDFLAGS) $(LDFLAGS_SL) $(SHLIB_LINK) $(LIBS) -Wl,--out-implib=$(stlib)
+@@ -410,14 +411,14 @@ endif # PORTNAME == cygwin || PORTNAME =
+ 
+ 
+ %.pc: $(MAKEFILE_LIST)
+-	echo 'Name: lib$(NAME)' >$@
+-	echo 'Description: PostgreSQL lib$(NAME) library' >>$@
++	echo 'Name: lib$(NAME)$(SOEXTRA)' >$@
++	echo 'Description: PostgreSQL lib$(NAME)$(SOEXTRA) library' >>$@
+ 	echo 'Url: http://www.postgresql.org/' >>$@
+ 	echo 'Version: $(VERSION)' >>$@
+ 	echo 'Requires: ' >>$@
+ 	echo 'Requires.private: $(PKG_CONFIG_REQUIRES_PRIVATE)' >>$@
+ 	echo 'Cflags: -I$(includedir)' >>$@
+-	echo 'Libs: -L$(libdir) -l$(NAME)' >>$@
++	echo 'Libs: -L$(libdir) -l$(NAME)$(SOEXTRA)' >>$@
+ # Record -L flags that the user might have passed in to the PostgreSQL
+ # build to locate third-party libraries (e.g., ldap, ssl).  Filter out
+ # those that point inside the build or source tree.  Use sort to
+@@ -433,23 +434,23 @@ endif # PORTNAME == cygwin || PORTNAME =
+ # tarballs.
+ 
+ ifneq (,$(SHLIB_EXPORTS))
+-distprep: lib$(NAME)dll.def lib$(NAME)ddll.def blib$(NAME)dll.def
++distprep: lib$(NAME)$(SOEXTRA)dll.def lib$(NAME)$(SOEXTRA)ddll.def blib$(NAME)$(SOEXTRA)dll.def
+ 
+-UC_NAME = $(shell echo $(NAME) | tr 'abcdefghijklmnopqrstuvwxyz' 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')
++UC_NAME = $(shell echo $(NAME)$(SOEXTRA) | tr 'abcdefghijklmnopqrstuvwxyz' 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+ 
+-lib$(NAME)dll.def: $(SHLIB_EXPORTS)
++lib$(NAME)$(SOEXTRA)dll.def: $(SHLIB_EXPORTS)
+ 	echo '; DEF file for win32.mak release build and for Makefile.shlib (MinGW)' >$@
+ 	echo 'LIBRARY LIB$(UC_NAME).dll' >>$@
+ 	echo 'EXPORTS' >>$@
+ 	sed -e '/^#/d' -e 's/^\(.*[ 	]\)\([0-9][0-9]*\)/    \1@ \2/' $< >>$@
+ 
+-lib$(NAME)ddll.def: $(SHLIB_EXPORTS)
++lib$(NAME)$(SOEXTRA)ddll.def: $(SHLIB_EXPORTS)
+ 	echo '; DEF file for win32.mak debug build' >$@
+ 	echo 'LIBRARY LIB$(UC_NAME)D.dll' >>$@
+ 	echo 'EXPORTS' >>$@
+ 	sed -e '/^#/d' -e 's/^\(.*[ 	]\)\([0-9][0-9]*\)/    \1@ \2/' $< >>$@
+ 
+-blib$(NAME)dll.def: $(SHLIB_EXPORTS)
++blib$(NAME)$(SOEXTRA)dll.def: $(SHLIB_EXPORTS)
+ 	echo '; DEF file for bcc32.mak (Borland C++ Builder)' >$@
+ 	echo 'LIBRARY BLIB$(UC_NAME)' >>$@
+ 	echo 'EXPORTS' >>$@
+@@ -471,8 +472,8 @@ install-lib: install-lib-static
+ install-lib: install-lib-pc
+ endif
+ 
+-install-lib-pc: lib$(NAME).pc installdirs-lib
+-	$(INSTALL_DATA) $< '$(DESTDIR)$(pkgconfigdir)/lib$(NAME).pc'
++install-lib-pc: lib$(NAME)$(SOEXTRA).pc installdirs-lib
++	$(INSTALL_DATA) $< '$(DESTDIR)$(pkgconfigdir)/lib$(NAME)$(SOEXTRA).pc'
+ 
+ install-lib-static: $(stlib) installdirs-lib
+ 	$(INSTALL_STLIB) $< '$(DESTDIR)$(libdir)/$(stlib)'
+@@ -529,7 +530,7 @@ ifdef soname
+ 	rm -f '$(DESTDIR)$(libdir)/$(shlib_bare)' \
+ 	  '$(DESTDIR)$(libdir)/$(shlib_major)' \
+ 	  '$(DESTDIR)$(libdir)/$(shlib)' $(if $(findstring $(PORTNAME),win32 cygwin),'$(DESTDIR)$(bindir)/$(shlib)') \
+-	  '$(DESTDIR)$(pkgconfigdir)/lib$(NAME).pc'
++	  '$(DESTDIR)$(pkgconfigdir)/lib$(NAME)$(SOEXTRA).pc'
+ else # no soname
+ 	rm -f '$(DESTDIR)$(pkglibdir)/$(shlib)'
+ endif # no soname
+@@ -541,9 +542,9 @@ endif # no soname
+ 
+ .PHONY: clean-lib
+ clean-lib:
+-	rm -f $(shlib) $(shlib_bare) $(shlib_major) $(stlib) $(exports_file) lib$(NAME).pc
++	rm -f $(shlib) $(shlib_bare) $(shlib_major) $(stlib) $(exports_file) lib$(NAME)$(SOEXTRA).pc
+ 
+ ifneq (,$(SHLIB_EXPORTS))
+ maintainer-clean-lib:
+-	rm -f lib$(NAME)dll.def lib$(NAME)ddll.def blib$(NAME)dll.def
++	rm -f lib$(NAME)$(SOEXTRA)dll.def lib$(NAME)$(SOEXTRA)ddll.def blib$(NAME)$(SOEXTRA)dll.def
+ endif
+Index: postgresql-9.6.13/src/Makefile.global.in
+===================================================================
+--- postgresql-9.6.13.orig/src/Makefile.global.in
++++ postgresql-9.6.13/src/Makefile.global.in
+@@ -39,6 +39,7 @@ all:
+ VERSION = @PACKAGE_VERSION@
+ MAJORVERSION = @PG_MAJORVERSION@
+ VERSION_NUM = @PG_VERSION_NUM@
++SOEXTRA = @PG_SOEXTRA@
+ 
+ # Set top_srcdir, srcdir, and VPATH.
+ ifdef PGXS
+@@ -496,7 +497,7 @@ endif
+ 
+ # This macro is for use by libraries linking to libpq.  (Because libpgport
+ # isn't created with the same link flags as libpq, it can't be used.)
+-libpq = -L$(libpq_builddir) -lpq
++libpq = -L$(libpq_builddir) -lpq$(SOEXTRA)
+ 
+ # This macro is for use by client executables (not libraries) that use libpq.
+ # We force clients to pull symbols from the non-shared libraries libpgport
+@@ -506,9 +507,9 @@ libpq = -L$(libpq_builddir) -lpq
+ # pgport before libpq.  This does cause duplicate -lpgport's to appear
+ # on client link lines.
+ ifdef PGXS
+-libpq_pgport = -L$(libdir) -lpgcommon -lpgport $(libpq)
++libpq_pgport = -L$(libdir) -lpgcommon$(SOEXTRA) -lpgport$(SOEXTRA) $(libpq)
+ else
+-libpq_pgport = -L$(top_builddir)/src/common -lpgcommon -L$(top_builddir)/src/port -lpgport $(libpq)
++libpq_pgport = -L$(top_builddir)/src/common -lpgcommon$(SOEXTRA) -L$(top_builddir)/src/port -lpgport$(SOEXTRA) $(libpq)
+ endif
+ 
+ # Cygwin seems to need ldap libraries to be mentioned here, too
+@@ -634,7 +635,7 @@ LIBOBJS = @LIBOBJS@
+ # files needed for the chosen CRC-32C implementation
+ PG_CRC32C_OBJS = @PG_CRC32C_OBJS@
+ 
+-LIBS := -lpgcommon -lpgport $(LIBS)
++LIBS := -lpgcommon$(SOEXTRA) -lpgport$(SOEXTRA) $(LIBS)
+ 
+ # to make ws2_32.lib the last library
+ ifeq ($(PORTNAME),win32)
+Index: postgresql-9.6.13/src/common/Makefile
+===================================================================
+--- postgresql-9.6.13.orig/src/common/Makefile
++++ postgresql-9.6.13/src/common/Makefile
+@@ -44,19 +44,19 @@ OBJS_FRONTEND = $(OBJS_COMMON) fe_memuti
+ 
+ OBJS_SRV = $(OBJS_COMMON:%.o=%_srv.o)
+ 
+-all: libpgcommon.a libpgcommon_srv.a
++all: libpgcommon$(SOEXTRA).a libpgcommon_srv$(SOEXTRA).a
+ 
+ # libpgcommon is needed by some contrib
+ install: all installdirs
+-	$(INSTALL_STLIB) libpgcommon.a '$(DESTDIR)$(libdir)/libpgcommon.a'
++	$(INSTALL_STLIB) libpgcommon$(SOEXTRA).a '$(DESTDIR)$(libdir)/libpgcommon$(SOEXTRA).a'
+ 
+ installdirs:
+ 	$(MKDIR_P) '$(DESTDIR)$(libdir)'
+ 
+ uninstall:
+-	rm -f '$(DESTDIR)$(libdir)/libpgcommon.a'
++	rm -f '$(DESTDIR)$(libdir)/libpgcommon$(SOEXTRA).a'
+ 
+-libpgcommon.a: $(OBJS_FRONTEND)
++libpgcommon$(SOEXTRA).a: $(OBJS_FRONTEND)
+ 	rm -f $@
+ 	$(AR) $(AROPT) $@ $^
+ 
+@@ -64,7 +64,7 @@ libpgcommon.a: $(OBJS_FRONTEND)
+ # Server versions of object files
+ #
+ 
+-libpgcommon_srv.a: $(OBJS_SRV)
++libpgcommon_srv$(SOEXTRA).a: $(OBJS_SRV)
+ 	rm -f $@
+ 	$(AR) $(AROPT) $@ $^
+ 
+@@ -94,4 +94,4 @@ keywords.o: $(top_srcdir)/src/include/pa
+ keywords_srv.o: $(top_builddir)/src/include/parser/gram.h $(top_srcdir)/src/include/parser/kwlist.h
+ 
+ clean distclean maintainer-clean:
+-	rm -f libpgcommon.a libpgcommon_srv.a $(OBJS_FRONTEND) $(OBJS_SRV)
++	rm -f libpgcommon$(SOEXTRA).a libpgcommon_srv$(SOEXTRA).a $(OBJS_FRONTEND) $(OBJS_SRV)
+Index: postgresql-9.6.13/src/port/Makefile
+===================================================================
+--- postgresql-9.6.13.orig/src/port/Makefile
++++ postgresql-9.6.13/src/port/Makefile
+@@ -38,19 +38,19 @@ OBJS = $(LIBOBJS) $(PG_CRC32C_OBJS) chkl
+ # foo_srv.o and foo.o are both built from foo.c, but only foo.o has -DFRONTEND
+ OBJS_SRV = $(OBJS:%.o=%_srv.o)
+ 
+-all: libpgport.a libpgport_srv.a
++all: libpgport$(SOEXTRA).a libpgport_srv$(SOEXTRA).a
+ 
+ # libpgport is needed by some contrib
+ install: all installdirs
+-	$(INSTALL_STLIB) libpgport.a '$(DESTDIR)$(libdir)/libpgport.a'
++	$(INSTALL_STLIB) libpgport$(SOEXTRA).a '$(DESTDIR)$(libdir)/libpgport$(SOEXTRA).a'
+ 
+ installdirs:
+ 	$(MKDIR_P) '$(DESTDIR)$(libdir)'
+ 
+ uninstall:
+-	rm -f '$(DESTDIR)$(libdir)/libpgport.a'
++	rm -f '$(DESTDIR)$(libdir)/libpgport$(SOEXTRA).a'
+ 
+-libpgport.a: $(OBJS)
++libpgport$(SOEXTRA).a: $(OBJS)
+ 	rm -f $@
+ 	$(AR) $(AROPT) $@ $^
+ 
+@@ -65,7 +65,7 @@ pg_crc32c_sse42_srv.o: CFLAGS+=$(CFLAGS_
+ # Server versions of object files
+ #
+ 
+-libpgport_srv.a: $(OBJS_SRV)
++libpgport_srv$(SOEXTRA).a: $(OBJS_SRV)
+ 	rm -f $@
+ 	$(AR) $(AROPT) $@ $^
+ 
+@@ -110,4 +110,4 @@ pg_config_paths.h: $(top_builddir)/src/M
+ 	echo "#define MANDIR \"$(mandir)\"" >>$@
+ 
+ clean distclean maintainer-clean:
+-	rm -f libpgport.a libpgport_srv.a $(OBJS) $(OBJS_SRV) pg_config_paths.h
++	rm -f libpgport$(SOEXTRA).a libpgport_srv$(SOEXTRA).a $(OBJS) $(OBJS_SRV) pg_config_paths.h
+Index: postgresql-9.6.13/src/backend/Makefile
+===================================================================
+--- postgresql-9.6.13.orig/src/backend/Makefile
++++ postgresql-9.6.13/src/backend/Makefile
+@@ -35,12 +35,12 @@ LOCALOBJS += utils/probes.o
+ endif
+ endif
+ 
+-OBJS = $(SUBDIROBJS) $(LOCALOBJS) $(top_builddir)/src/port/libpgport_srv.a \
+-       $(top_builddir)/src/common/libpgcommon_srv.a
++OBJS = $(SUBDIROBJS) $(LOCALOBJS) $(top_builddir)/src/port/libpgport_srv$(SOEXTRA).a \
++       $(top_builddir)/src/common/libpgcommon_srv$(SOEXTRA).a
+ 
+ # We put libpgport and libpgcommon into OBJS, so remove it from LIBS; also add
+ # libldap
+-LIBS := $(filter-out -lpgport -lpgcommon, $(LIBS)) $(LDAP_LIBS_BE)
++LIBS := $(filter-out -lpgport$(SOEXTRA) -lpgcommon$(SOEXTRA), $(LIBS)) $(LDAP_LIBS_BE)
+ 
+ # The backend doesn't need everything that's in LIBS, however
+ LIBS := $(filter-out -lz -lreadline -ledit -ltermcap -lncurses -lcurses, $(LIBS))
+@@ -117,7 +117,7 @@ submake-errcodes: $(top_builddir)/src/in
+ 
+ .PHONY: submake-errcodes
+ 
+-$(top_builddir)/src/port/libpgport_srv.a: | submake-libpgport
++$(top_builddir)/src/port/libpgport_srv$(SOEXTRA).a: | submake-libpgport
+ 
+ 
+ # The postgres.o target is needed by the rule in Makefile.global that
+Index: postgresql-9.6.13/src/backend/storage/lmgr/Makefile
+===================================================================
+--- postgresql-9.6.13.orig/src/backend/storage/lmgr/Makefile
++++ postgresql-9.6.13/src/backend/storage/lmgr/Makefile
+@@ -21,9 +21,9 @@ ifdef TAS
+ TASPATH = $(top_builddir)/src/backend/port/tas.o
+ endif
+ 
+-s_lock_test: s_lock.c $(top_builddir)/src/port/libpgport.a
++s_lock_test: s_lock.c $(top_builddir)/src/port/libpgport$(SOEXTRA).a
+ 	$(CC) $(CPPFLAGS) $(CFLAGS) -DS_LOCK_TEST=1 $(srcdir)/s_lock.c \
+-		$(TASPATH) -L $(top_builddir)/src/port -lpgport -o s_lock_test
++		$(TASPATH) -L $(top_builddir)/src/port -lpgport$(SOEXTRA) -o s_lock_test
+ 
+ # see notes in src/backend/parser/Makefile
+ lwlocknames.c: lwlocknames.h

--- a/libs/postgresql-ssl/patches/200-ranlib.patch
+++ b/libs/postgresql-ssl/patches/200-ranlib.patch
@@ -1,0 +1,12 @@
+Index: postgresql-9.6.13/src/port/Makefile
+===================================================================
+--- postgresql-9.6.13.orig/src/port/Makefile
++++ postgresql-9.6.13/src/port/Makefile
+@@ -53,6 +53,7 @@ uninstall:
+ libpgport$(SOEXTRA).a: $(OBJS)
+ 	rm -f $@
+ 	$(AR) $(AROPT) $@ $^
++	$(RANLIB) libpgport$(SOEXTRA).a
+ 
+ # thread.o needs PTHREAD_CFLAGS (but thread_srv.o does not)
+ thread.o: CFLAGS+=$(PTHREAD_CFLAGS)

--- a/libs/postgresql-ssl/patches/800-busybox-default-pager.patch
+++ b/libs/postgresql-ssl/patches/800-busybox-default-pager.patch
@@ -1,0 +1,14 @@
+--- a/src/include/fe_utils/print.h
++++ b/src/include/fe_utils/print.h
+@@ -17,11 +17,7 @@
+ 
+ 
+ /* This is not a particularly great place for this ... */
+-#ifndef __CYGWIN__
+-#define DEFAULT_PAGER "more"
+-#else
+ #define DEFAULT_PAGER "less"
+-#endif
+ 
+ enum printFormat
+ {

--- a/libs/postgresql-ssl/patches/900-pg_ctl-setuid.patch
+++ b/libs/postgresql-ssl/patches/900-pg_ctl-setuid.patch
@@ -1,0 +1,107 @@
+--- a/src/bin/pg_ctl/pg_ctl.c
++++ b/src/bin/pg_ctl/pg_ctl.c
+@@ -88,6 +88,7 @@ static char *event_source = NULL;
+ static char *register_servicename = "PostgreSQL";		/* FIXME: + version ID? */
+ static char *register_username = NULL;
+ static char *register_password = NULL;
++static char *username = "";
+ static char *argv0 = NULL;
+ static bool allow_core_files = false;
+ static time_t start_time;
+@@ -1930,6 +1931,9 @@ do_help(void)
+ #endif
+ 	printf(_("  -s, --silent           only print errors, no informational messages\n"));
+ 	printf(_("  -t, --timeout=SECS     seconds to wait when using -w option\n"));
++#if !defined(WIN32) && !defined(__CYGWIN__)
++	printf(_("  -U, --username=NAME    user name of account PostgreSQL server is running as\n"));
++#endif
+ 	printf(_("  -V, --version          output version information, then exit\n"));
+ 	printf(_("  -w                     wait until operation completes\n"));
+ 	printf(_("  -W                     do not wait until operation completes\n"));
+@@ -2126,6 +2130,7 @@ main(int argc, char **argv)
+ 		{"pgdata", required_argument, NULL, 'D'},
+ 		{"silent", no_argument, NULL, 's'},
+ 		{"timeout", required_argument, NULL, 't'},
++		{"username", required_argument, NULL, 'U'},
+ 		{"core-files", no_argument, NULL, 'c'},
+ 		{NULL, 0, NULL, 0}
+ 	};
+@@ -2166,20 +2171,6 @@ main(int argc, char **argv)
+ 		}
+ 	}
+ 
+-	/*
+-	 * Disallow running as root, to forestall any possible security holes.
+-	 */
+-#ifndef WIN32
+-	if (geteuid() == 0)
+-	{
+-		write_stderr(_("%s: cannot be run as root\n"
+-					   "Please log in (using, e.g., \"su\") as the "
+-					   "(unprivileged) user that will\n"
+-					   "own the server process.\n"),
+-					 progname);
+-		exit(1);
+-	}
+-#endif
+ 
+ 	env_wait = getenv("PGCTLTIMEOUT");
+ 	if (env_wait != NULL)
+@@ -2265,11 +2256,15 @@ main(int argc, char **argv)
+ 					wait_seconds_arg = true;
+ 					break;
+ 				case 'U':
++#if defined(WIN32) || defined(__CYGWIN__)
+ 					if (strchr(optarg, '\\'))
+ 						register_username = pg_strdup(optarg);
+ 					else
+ 						/* Prepend .\ for local accounts */
+ 						register_username = psprintf(".\\%s", optarg);
++#else
++					username = pg_strdup(optarg);
++#endif
+ 					break;
+ 				case 'w':
+ 					do_wait = true;
+@@ -2351,6 +2346,41 @@ main(int argc, char **argv)
+ 		exit(1);
+ 	}
+ 
++	/*
++	 * Disallow running as root, to forestall any possible security holes.
++	 */
++#if !defined(WIN32) && !defined(__CYGWIN__)
++	if (geteuid() == 0)
++	{
++		struct passwd *p;
++		if (!username || !strlen(username)) {
++			fprintf(stderr,
++					_("%s: when run as root, username needs to be provided\n"),
++					progname);
++			exit(1);
++		}
++		p = getpwnam(username);
++		if (!p) {
++			fprintf(stderr,
++					_("%s: invalid username: %s\n"),
++					progname, username);
++			exit(1);
++		}
++		if (!p->pw_uid) {
++			fprintf(stderr,
++					_("%s: user needs to be non-root\n"),
++					progname);
++			exit(1);
++		}
++		if (setgid(p->pw_gid) || setuid(p->pw_uid)) {
++			fprintf(stderr,
++					_("%s: failed to set user id %d: %d (%s)\n"),
++					progname, p->pw_uid, errno, strerror(errno));
++			exit(1);
++		}
++	}
++#endif
++
+ 	/* Note we put any -D switch into the env var above */
+ 	pg_config = getenv("PGDATA");
+ 	if (pg_config)


### PR DESCRIPTION
Currently PostgreSQL is built without SSL support on OpenWrt.
We now build and SSL-enabled variant (which is the not default,
and currently the not one that package which depend on libpq
will pick up unless they specifically target the ssl version),
which we distinguish from the nossl version via
--with-extra-version and (added) --with-extra-libname which
adds ssl to the SONAME so that ssl and non-ssl libraries can
coexist on the same build system.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: @dangowrt 
Compile tested: ath79, netgear wndr3800, current snapshot, current master
Run tested: working on it. 

Description:
@dangowrt  Wondering if what you think of this -- would you want me to be a co-maintainer, maintain the (current) non-ssl version and the ssl version yourself, or I take on mainainership of the SSL version?  Comments/criticisms?