### PR TITLE
mwan3: change flush_conntrack handling to use uci list element

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.7.12
+PKG_VERSION:=2.7.13
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/15-mwan3
@@ -79,7 +79,6 @@ case "$ACTION" in
 		fi
 		mwan3_set_policies_iptables
 		mwan3_set_user_rules
-		mwan3_flush_conntrack $INTERFACE $DEVICE "ifup"
 	;;
 	ifdown)
 		mwan3_set_iface_hotplug_state $INTERFACE "offline"
@@ -87,7 +86,6 @@ case "$ACTION" in
 		mwan3_track_signal $INTERFACE $DEVICE
 		mwan3_set_policies_iptables
 		mwan3_set_user_rules
-		mwan3_flush_conntrack $INTERFACE $DEVICE "ifdown"
 	;;
 esac
 

--- a/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
+++ b/net/mwan3/files/etc/hotplug.d/iface/16-mwan3
@@ -14,4 +14,9 @@ if [ "$ACTION" == "ifup" ]; then
 	mwan3_unlock "$ACTION" "mwan3rtmon"
 fi
 
+config_get enabled $INTERFACE enabled 0
+[ "${enabled}" = "0" ] || {
+	mwan3_flush_conntrack "$INTERFACE" "$ACTION"
+}
+
 exit 0

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -1251,34 +1251,21 @@ mwan3_report_rules_v6()
 
 mwan3_flush_conntrack()
 {
-	local flush_conntrack
+	local interface="$1"
+	local action="$2"
 
-	config_get flush_conntrack $1 flush_conntrack never
+	handle_flush() {
+		local flush_conntrack="$1"
+		local action="$2"
+
+		if [ "$action" = "$flush_conntrack" ]; then
+			echo f > ${CONNTRACK_FILE}
+			$LOG info "Connection tracking flushed for interface '$interface' on action '$action'"
+		fi
+	}
 
 	if [ -e "$CONNTRACK_FILE" ]; then
-		case $flush_conntrack in
-			ifup)
-				[ "$3" = "ifup" ] && {
-					echo f > ${CONNTRACK_FILE}
-					$LOG info "connection tracking flushed on interface $1 ($2) $3"
-				}
-				;;
-			ifdown)
-				[ "$3" = "ifdown" ] && {
-					echo f > ${CONNTRACK_FILE}
-					$LOG info "connection tracking flushed on interface $1 ($2) $3"
-				}
-				;;
-			always)
-				echo f > ${CONNTRACK_FILE}
-				$LOG info "connection tracking flushed on interface $1 ($2) $3"
-				;;
-			never)
-				$LOG info "connection tracking not flushed on interface $1 ($2) $3"
-				;;
-		esac
-	else
-		$LOG warning "connection tracking not enabled"
+		config_list_foreach "$interface" flush_conntrack handle_flush "$action"
 	fi
 }
 


### PR DESCRIPTION
Maintainer: me
Compile tested: not needed script changes
Run tested: x86_64, APU3, OpenWrt master

Description:
With this change it is now possible to combine interface action events.
If an interface action is generated by netifd or mwan3 for example ifup,
ifdown, connectd or disconnected and this action is configured in the inteface
uci section, then the conntrack table is flushed by mwan3.
