### PR TITLE
python-cryptodome: update to 3.8.2.

### DIFF
--- a/lang/python/python-cryptodome/Makefile
+++ b/lang/python/python-cryptodome/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptodome
-PKG_VERSION:=3.8.1
+PKG_VERSION:=3.8.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=pycryptodome-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pycryptodome
-PKG_HASH:=68ad0ce4a374577a26bb7f458575abe3c2a342818b5280de6e5738870b7761b3
+PKG_HASH:=5bc40f8aa7ba8ca7f833ad2477b9d84e1bfd2630b22a46d9bbd221982f8c3ac0
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cryptodome-$(PKG_VERSION)
 

--- a/lang/python/python-cryptodomex/Makefile
+++ b/lang/python/python-cryptodomex/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptodomex
-PKG_VERSION:=3.8.1
+PKG_VERSION:=3.8.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=pycryptodomex-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pycryptodomex
-PKG_HASH:=9251b3f6254d4274caa21b79bd432bf07afa3567c6f02f11861659fb6245139a
+PKG_HASH:=e50b15af6bbdc6b5f8bd70d818cb846b15303ffa6c371b799db561a403a21607
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cryptodomex-$(PKG_VERSION)
 


### PR DESCRIPTION
Signed-off-by: Richard Yu <yurichard3839@gmail.com>

Maintainer: me
Compile tested: sunxi-cortexa7 snapshots
Run tested: Passed on sun8i-h2-plus-orangepi-zero
```
# python3 -m Crypto.SelfTest
Skipping AESNI tests
Skipping test of PCLMULDQD in AES GCM
...
----------------------------------------------------------------------
Ran 23760 tests in 2184.103s

OK
```