### PR TITLE
libcoap: Update to 4.2.0 and switch to codeload

### DIFF
--- a/libs/libcoap/Makefile
+++ b/libs/libcoap/Makefile
@@ -8,24 +8,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libcoap
-PKG_VERSION:=v4.1.2
+PKG_VERSION:=4.2.0
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/obgm/libcoap
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)
-PKG_SOURCE_VERSION:=fa5248603049ddf95cc84608aad569120763bf2b
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MIRROR_HASH:=0ab4bc9569a78904743cc3074fd1c0fc9c78c85fd510fef5145dd872523619e6
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/obgm/libcoap/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=9523e38da6ee8b2a8f5ce83ded64107dd1e514c7ad00cd74ccfe3454b679c271
 
 PKG_MAINTAINER:=Anton Glukhov <anton.a.glukhov@gmail.com>
 PKG_LICENSE:=GPL-2.0+ BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING LICENSE.GPL LICENSE.BSD
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
-
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -33,7 +29,8 @@ define Package/libcoap
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=CoAP (RFC 7252) library
-  URL:=http://libcoap.net/
+  URL:=https://libcoap.net/
+  ABI_VERSION:=2
 endef
 
 define Package/libcoap/description
@@ -66,11 +63,11 @@ TARGET_CFLAGS += $(FPIC)
 
 CONFIGURE_ARGS += \
 	--enable-examples \
-	--disable-documentation
-
-ifeq ($(CONFIG_BIG_ENDIAN),y)
-TARGET_CFLAGS += -DWORDS_BIGENDIAN
-endif
+	--disable-documentation \
+	--disable-doxygen \
+	--disable-dtls \
+	--disable-gcov \
+	--disable-tests
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
@@ -82,7 +79,7 @@ endef
 
 define Package/libcoap/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcoap-1.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcoap-$(ABI_VERSION).so* $(1)/usr/lib/
 endef
 
 define Package/coap-client/install


### PR DESCRIPTION
Simplifies the Makefile.

Added PKG_BUILD_PARALLEL for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @toxxin 
Compile tested: arc700

ping @dedeckeh 