### PR TITLE
google-authenticator-libpam: Update to version 1.06

### DIFF
--- a/libs/google-authenticator-libpam/Makefile
+++ b/libs/google-authenticator-libpam/Makefile
@@ -4,17 +4,18 @@
 #
 
 include $(TOPDIR)/rules.mk
+
 PKG_NAME:=google-authenticator-libpam
-PKG_SOURCE_DATE:=2019-01-03
+PKG_VERSION:=1.06
 PKG_RELEASE:=1
 
-PKG_SOURCE_VERSION:=60207b6c4cebf825863043e963bf67f6a0520076
-PKG_SOURCE_URL:=https://codeload.github.com/google/google-authenticator-libpam/tar.gz/$(PKG_SOURCE_VERSION)?
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_DATE).tar.gz
-PKG_HASH:=39267ba837f870b3f4cbf9166a76eed35879d3f87d058740f2c0a5e16570bce3
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/google/google-authenticator-libpam/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=52f03ec746e8deb1af37911697d096f0fa87583491b7cc460cdf09a6ef0d6b06
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
-
+PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf
@@ -28,7 +29,6 @@ define Package/google-authenticator-libpam
   DEPENDS:=+libpam +libqrencode
   TITLE:=Google Authenticator PAM module
   URL:=https://github.com/google/google-authenticator-libpam
-  MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 endef
 
 define Package/google-authenticator-libpam/description


### PR DESCRIPTION
Simplifies the Makefile slightly. This also uses a proper release instead
of a random git commit.

Added LICENSE Information.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: arc700