### PR TITLE
modemmanager: add ModemManager to packages

### DIFF
--- a/libs/libmbim/Makefile
+++ b/libs/libmbim/Makefile
@@ -1,0 +1,88 @@
+#
+# Copyright (C) 2016 Velocloud Inc.
+# Copyright (C) 2016 Aleksander Morgado <aleksander@aleksander.es>
+#
+# This is free software, licensed under the GNU General Public License v2.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libmbim
+PKG_VERSION:=1.20.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://www.freedesktop.org/software/libmbim
+PKG_HASH=2cf7c6c7aa9e962a589f61bff2766035b61792ef961131a21fcbbe043f91a866
+
+PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+CONFIGURE_ARGS += \
+	--disable-static \
+	--disable-gtk-doc \
+	--disable-gtk-doc-html \
+	--disable-gtk-doc-pdf
+
+define Package/libmbim
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+glib2
+  TITLE:=Helper library and utils to talk to MBIM enabled modems
+  URL:=https://www.freedesktop.org/wiki/Software/libmbim
+  LICENSE:=LGPL-2.0-or-later
+  LICENSE_FILES:=COPYING.LIB
+endef
+
+define Package/libmbim/description
+  Helper library to talk to MBIM enabled modems.
+  Add mbim-utils for extra utilities.
+endef
+
+define Package/mbim-utils
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libmbim
+  TITLE:=Utilities to talk to MBIM enabled modems
+  URL:=https://www.freedesktop.org/wiki/Software/libmbim
+  LICENSE:=GPL-2.0-or-later
+  LICENSE_FILES:=COPYING
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/include/libmbim-glib \
+		$(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/libmbim*.so* \
+		$(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/mbim-glib.pc \
+		$(1)/usr/lib/pkgconfig
+endef
+
+define Package/libmbim/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/libmbim*.so.* \
+		$(1)/usr/lib/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/mbim-proxy $(1)/usr/lib/
+endef
+
+define Package/mbim-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mbimcli $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mbim-network $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,libmbim))
+$(eval $(call BuildPackage,mbim-utils))

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -1,0 +1,97 @@
+#
+# Copyright (C) 2016 Velocloud Inc.
+# Copyright (C) 2016 Aleksander Morgado <aleksander@aleksander.es>
+#
+# This is free software, licensed under the GNU General Public License v2.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libqmi
+PKG_VERSION:=1.22.6
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
+PKG_HASH=755bbea2a330ac16d56678fbcdd09201ddb14779059ecc895edfac388551d5de
+
+PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libqmi
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+glib2 +libmbim
+  TITLE:=Helper library to talk to QMI enabled modems
+  URL:=https://www.freedesktop.org/wiki/Software/libqmi
+  LICENSE:=LGPL-2.0-or-later
+  LICENSE_FILES:=COPYING.LIB
+endef
+
+define Package/libqmi/description
+  Helper library talk to QMI enabled modems.
+  Add qmi-utils for extra utilities.
+endef
+
+define Package/qmi-utils
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libqmi
+  TITLE:=Utilities to talk to QMI enabled modems
+  URL:=https://www.freedesktop.org/wiki/Software/libqmi
+  LICENSE:=GPL-2.0-or-later
+  LICENSE_FILES:=COPYING
+endef
+
+define Package/libqmi-utils/description
+  Utils to talk to QMI enabled modems
+endef
+
+CONFIGURE_ARGS += \
+	--disable-static \
+	--disable-gtk-doc \
+	--disable-gtk-doc-html \
+	--disable-gtk-doc-pdf \
+	--enable-mbim-qmux \
+	--enable-firmware-update \
+	--without-udev
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/include/libqmi-glib \
+		$(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/libqmi*.so* \
+		$(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/qmi-glib.pc \
+		$(1)/usr/lib/pkgconfig
+endef
+
+define Package/libqmi/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/libqmi*.so.* \
+		$(1)/usr/lib/
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/qmi-proxy $(1)/usr/lib/
+endef
+
+define Package/qmi-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/qmicli $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/qmi-network $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/qmi-firmware-update $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,libqmi))
+$(eval $(call BuildPackage,qmi-utils))

--- a/net/modemmanager/Config.in
+++ b/net/modemmanager/Config.in
@@ -1,0 +1,15 @@
+menu "Configuration"
+depends on PACKAGE_modemmanager
+
+	config MODEMMANAGER_WITH_MBIM
+		bool "Include MBIM support"
+		default n
+		help
+		  Compile ModemManager with MBIM support
+
+	config MODEMMANAGER_WITH_QMI
+		bool "Include QMI support"
+		default n
+		help
+		  Compile ModemManager with QMI support
+endmenu

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -1,0 +1,136 @@
+#
+# Copyright (C) 2016 Velocloud Inc.
+# Copyright (C) 2016 Aleksander Morgado <aleksander@aleksander.es>
+#
+# This is free software, licensed under the GNU General Public License v2.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=modemmanager
+PKG_VERSION:=1.10.6
+PKG_RELEASE:=1
+
+PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
+PKG_HASH=3c2ca73782215664141042422759899ca9846440fc26d6223c7cf7ea4dd3c996
+PKG_BUILD_DIR:=$(BUILD_DIR)/ModemManager-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
+LICENSE:=GPL-2.0-or-later
+LICENSE_FILES:=COPYING
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/modemmanager/config
+  source "$(SOURCE)/Config.in"
+endef
+
+define Package/modemmanager
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Control utility for any kind of mobile broadband modem
+  URL:=https://www.freedesktop.org/wiki/Software/ModemManager
+  DEPENDS:= \
+	$(INTL_DEPENDS) \
+	+glib2 \
+	+dbus \
+	+MODEMMANAGER_WITH_MBIM:libmbim \
+	+MODEMMANAGER_WITH_QMI:libqmi
+endef
+
+define Package/modemmanager/description
+  ModemManager is a D-Bus-activated service which allows controlling mobile
+  broadband modems. Add kernel modules for your modems as needed.
+  Select Utilities/usb-modeswitch if needed.
+endef
+
+CONFIGURE_ARGS += \
+	--without-polkit \
+	--without-udev \
+	--without-suspend-resume \
+	--with-systemdsystemunitdir=no \
+	--disable-rpath \
+	--disable-gtk-doc 
+
+ifdef CONFIG_MODEMMANAGER_WITH_MBIM
+  CONFIGURE_ARGS += --with-mbim
+else
+  CONFIGURE_ARGS += --without-mbim
+endif
+
+ifdef CONFIG_MODEMMANAGER_WITH_QMI
+  CONFIGURE_ARGS += --with-qmi
+else
+  CONFIGURE_ARGS += --without-qmi
+endif
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	( cd "$(PKG_BUILD_DIR)"; \
+		printf "all:\ninstall:\n" >po/Makefile.in.in; \
+	)
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/ModemManager
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/ModemManager/*.h $(1)/usr/include/ModemManager
+	$(INSTALL_DIR) $(1)/usr/include/libmm-glib
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libmm-glib/*.h $(1)/usr/include/libmm-glib
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmm-glib.so* $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/ModemManager.pc $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/mm-glib.pc $(1)/usr/lib/pkgconfig
+endef
+
+define Package/modemmanager/install
+	$(INSTALL_DIR) $(1)/lib/udev/rules.d
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/lib/udev/rules.d/*.rules $(1)/lib/udev/rules.d
+
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ModemManager $(1)/usr/sbin
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/mmcli $(1)/usr/bin
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmm-glib.so.* $(1)/usr/lib
+
+	$(INSTALL_DIR) $(1)/usr/lib/ModemManager
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/ModemManager/libmm-plugin-*.so* $(1)/usr/lib/ModemManager
+
+	$(INSTALL_DIR) $(1)/etc/dbus-1/system.d
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/dbus-1/system.d/org.freedesktop.ModemManager1.conf $(1)/etc/dbus-1/system.d
+
+	$(INSTALL_DIR) $(1)/usr/share/dbus-1/system-services
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/dbus-1/system-services/org.freedesktop.ModemManager1.service $(1)/usr/share/dbus-1/system-services
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/modemmanager.init $(1)/etc/init.d/modemmanager
+
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/net
+	$(INSTALL_DATA) ./files/25-modemmanager-net $(1)/etc/hotplug.d/net
+
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/tty
+	$(INSTALL_DATA) ./files/25-modemmanager-tty $(1)/etc/hotplug.d/tty
+
+	$(INSTALL_DIR) $(1)/etc/modemmanager
+	$(INSTALL_DATA) ./files/modemmanager.common $(1)/etc/modemmanager/modemmanager.common
+
+	$(INSTALL_DIR) $(1)/lib/netifd/proto
+	$(INSTALL_BIN) ./files/modemmanager.proto $(1)/lib/netifd/proto/modemmanager.sh
+endef
+
+$(eval $(call RequireCommand,xsltproc, \
+        $(PKG_NAME) requires xsltproc installed on the host-system. \
+))
+
+$(eval $(call RequireCommand,intltoolize, \
+        $(PKG_NAME) requires intltool installed on the host-system. \
+))
+
+$(eval $(call BuildPackage,modemmanager))

--- a/net/modemmanager/README.md
+++ b/net/modemmanager/README.md
@@ -1,0 +1,22 @@
+# OpenWrt ModemManager
+
+## Description
+
+Cellular modem control and connectivity
+
+Optional libraries libmbim and libqmi are available.  Optional mbim-utils and qmi-utils are available.
+Your modem may require additional kernel modules.
+
+## Usage
+
+# Once installed, you can configure the 2G/3G/4G modem connections directly in
+   /etc/config/network as in the following example:
+
+    config interface 'broadband'
+        option device   '/sys/devices/platform/soc/20980000.usb/usb1/1-1/1-1.2/1-1.2.1'
+        option proto    'modemmanager'
+        option apn      'ac.vodafone.es'
+        option username 'vodafone'
+        option password 'vodafone'
+        option pincode  '7423'
+        option lowpower '1'

--- a/net/modemmanager/files/25-modemmanager-net
+++ b/net/modemmanager/files/25-modemmanager-net
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Copyright (C) 2016 Velocloud Inc
+# Copyright (C) 2016 Aleksander Morgado <aleksander@aleksander.es>
+
+# Load common utilities
+. /etc/modemmanager/modemmanager.common
+
+# We require a interface name
+[ -n "${INTERFACE}" ] || exit
+
+# Always make sure the rundir exists
+mkdir -m 0755 -p "${MODEMMANAGER_RUNDIR}"
+
+# Report network interface
+mm_log "${ACTION} network interface ${INTERFACE}: event processed"
+mm_report_event "${ACTION}" "${INTERFACE}" "net" "/sys${DEVPATH}"
+
+# Look for an associated cdc-wdm interface
+
+cdcwdm=""
+
+case "${ACTION}" in
+	"add")	  cdcwdm=$(mm_track_cdcwdm "${INTERFACE}") ;;
+	"remove") cdcwdm=$(mm_untrack_cdcwdm "${INTERFACE}") ;;
+esac
+
+# Report cdc-wdm device, if any
+[ -n "${cdcwdm}" ] && {
+	mm_log "${ACTION} cdc interface ${cdcwdm}: custom event processed"
+	mm_report_event "${ACTION}" "${cdcwdm}" "usbmisc" "/sys${DEVPATH}"
+}

--- a/net/modemmanager/files/25-modemmanager-tty
+++ b/net/modemmanager/files/25-modemmanager-tty
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Copyright (C) 2016 Velocloud Inc
+# Copyright (C) 2016 Aleksander Morgado <aleksander@aleksander.es>
+
+# Load hotplug common utilities
+. /etc/modemmanager/modemmanager.common
+
+# We require a device name
+[ -n "$DEVNAME" ] || exit
+
+# Always make sure the rundir exists
+mkdir -m 0755 -p "${MODEMMANAGER_RUNDIR}"
+
+# Report TTY
+mm_log "${ACTION} serial interface ${DEVNAME}: event processed"
+mm_report_event "${ACTION}" "${DEVNAME}" "tty" "/sys${DEVPATH}"

--- a/net/modemmanager/files/modemmanager.common
+++ b/net/modemmanager/files/modemmanager.common
@@ -1,0 +1,328 @@
+#!/bin/sh
+# Copyright (C) 2016 Velocloud Inc
+# Copyright (C) 2016 Aleksander Morgado <aleksander@aleksander.es>
+
+################################################################################
+
+. /lib/functions.sh
+. /lib/netifd/netifd-proto.sh
+
+################################################################################
+# Runtime state
+
+MODEMMANAGER_RUNDIR="/var/run/modemmanager"
+MODEMMANAGER_CDCWDM_CACHE="${MODEMMANAGER_RUNDIR}/cdcwdm.cache"
+MODEMMANAGER_SYSFS_CACHE="${MODEMMANAGER_RUNDIR}/sysfs.cache"
+MODEMMANAGER_EVENTS_CACHE="${MODEMMANAGER_RUNDIR}/events.cache"
+
+################################################################################
+# Common logging
+
+mm_log() {
+	logger -t "ModemManager" "hotplug: $*"
+}
+
+################################################################################
+# Receives as input argument the full sysfs path of the device
+# Returns the physical device sysfs path
+
+mm_find_physdev_sysfs_path() {
+	local tmp_path="$1"
+
+	while true; do
+		tmp_path=$(dirname "${tmp_path}")
+
+		# avoid infinite loops iterating
+		[ -z "${tmp_path}" ] || [ "${tmp_path}" = "/" ] && return
+
+		# the physical device will be that with a idVendor and idProduct pair of files
+		[ -f "${tmp_path}"/idVendor ] && [ -f "${tmp_path}"/idProduct ] && {
+			tmp_path=$(readlink -f "$tmp_path")
+			echo "${tmp_path}"
+			return
+		}
+	done
+}
+
+################################################################################
+
+# Returns the cdc-wdm name retrieved from sysfs
+mm_track_cdcwdm() {
+	local wwan="$1"
+	local cdcwdm
+
+	cdcwdm=$(ls "/sys/class/net/${wwan}/device/usbmisc/")
+	[ -n "${cdcwdm}" ] || return
+
+	# We have to cache it for later, as we won't be able to get the
+	# associated cdc-wdm device on a remove event
+	echo "${wwan} ${cdcwdm}" >> "${MODEMMANAGER_CDCWDM_CACHE}"
+
+	echo "${cdcwdm}"
+}
+
+# Returns the cdc-wdm name retrieved from the cache
+mm_untrack_cdcwdm() {
+	local wwan="$1"
+	local cdcwdm
+
+	# Look for the cached associated cdc-wdm device
+	[ -f "${MODEMMANAGER_CDCWDM_CACHE}" ] || return
+
+	cdcwdm=$(awk -v wwan="${wwan}" '!/^#/ && $0 ~ wwan { print $2 }' "${MODEMMANAGER_CDCWDM_CACHE}")
+	[ -n "${cdcwdm}" ] || return
+
+	# Remove from cache
+	sed -i "/${wwan} ${cdcwdm}/d" "${MODEMMANAGER_CDCWDM_CACHE}"
+
+	echo "${cdcwdm}"
+}
+
+################################################################################
+# ModemManager needs some time from the ports being added until a modem object
+# is exposed in DBus. With the logic here we do an explicit wait of N seconds
+# for ModemManager to expose the new modem object, making sure that the wait is
+# unique per device (i.e. per physical device sysfs path).
+
+# Gets the modem wait status as retrieved from the cache
+mm_get_modem_wait_status() {
+	local sysfspath="$1"
+
+	# If no sysfs cache file, we're done
+	[ -f "${MODEMMANAGER_SYSFS_CACHE}" ] || return
+
+	# Get status of the sysfs path
+	awk -v sysfspath="${sysfspath}" '!/^#/ && $0 ~ sysfspath { print $2 }' "${MODEMMANAGER_SYSFS_CACHE}"
+}
+
+# Sets the modem wait status in the cache
+mm_set_modem_wait_status() {
+	local sysfspath="$1"
+	local status="$2"
+
+	# Remove sysfs line before adding the new one with the new state
+	[ -f "${MODEMMANAGER_SYSFS_CACHE}" ] &&
+		sed -i "/${sysfspath}/d" "${MODEMMANAGER_SYSFS_CACHE}"
+
+	# Add the new status
+	echo "${sysfspath} ${status}" >> "${MODEMMANAGER_SYSFS_CACHE}"
+}
+
+# Callback for config_foreach()
+mm_get_modem_config_foreach_cb() {
+	local cfg="$1"
+	local sysfspath="$2"
+
+	local proto
+	config_get proto "${cfg}" proto
+	[ "${proto}" = modemmanager ] || return 0
+
+	local dev
+	dev=$(uci_get network "${cfg}" device)
+	[ "${dev}" = "${sysfspath}" ] || return 0
+
+	echo "${cfg}"
+}
+
+# Returns the name of the interface configured for this device
+mm_get_modem_config() {
+	local sysfspath="$1"
+
+	# Look for configuration for the given sysfs path
+	config_load network
+	config_foreach mm_get_modem_config_foreach_cb interface "${sysfspath}"
+}
+
+# Wait for a modem in the specified sysfspath
+mm_wait_for_modem() {
+	local cfg="$1"
+	local sysfspath="$2"
+
+	# TODO: config max wait
+	local n=45
+	local step=5
+
+	while [ $n -ge 0 ]; do
+		[ -d "${sysfspath}" ] || {
+			mm_log "error: ignoring modem detection request: no device at ${sysfspath}"
+			proto_set_available "${cfg}" 0
+			return 1
+		}
+
+		# Check if the modem exists at the given sysfs path
+		if ! mmcli -m "${sysfspath}" > /dev/null 2>&1
+		then
+			mm_log "error: modem not detected at sysfs path"
+		else
+			mm_log "modem exported successfully at ${sysfspath}"
+			mm_log "setting interface '${cfg}' as available"
+			proto_set_available "${cfg}" 1
+			return 0
+		fi
+
+		sleep $step
+		n=$((n-step))
+	done
+
+	mm_log "error: timed out waiting for the modem to get exported at ${sysfspath}"
+	proto_set_available "${cfg}" 0
+	return 2
+}
+
+mm_report_modem_wait() {
+	local action=$1
+	local sysfspath=$2
+
+	local parent_sysfspath status
+
+	parent_sysfspath=$(mm_find_physdev_sysfs_path "$sysfspath")
+	[ -n "${parent_sysfspath}" ] || {
+		mm_log "error: parent device sysfspath not found"
+		return
+	}
+
+	status=$(mm_get_modem_wait_status "${parent_sysfspath}")
+
+	[ "$action" = "add" ] && {
+		case "${status}" in
+			"")
+				local cfg
+
+				cfg=$(mm_get_modem_config "${parent_sysfspath}")
+				if [ -n "${cfg}" ]; then
+					mm_log "interface '${cfg}' is set to configure device '${parent_sysfspath}'"
+					mm_log "now waiting for modem at sysfs path ${parent_sysfspath}"
+					mm_set_modem_wait_status "${parent_sysfspath}" "processed"
+					# Launch subshell for the explicit wait
+					( mm_wait_for_modem "${cfg}" "${parent_sysfspath}" ) > /dev/null 2>&1 &
+				else
+					mm_log "no need to wait for modem at sysfs path ${parent_sysfspath}"
+					mm_set_modem_wait_status "${parent_sysfspath}" "ignored"
+				fi
+				;;
+			"processed")
+				mm_log "already waiting for modem at sysfs path ${parent_sysfspath}"
+				;;
+			"ignored")
+				;;
+			*)
+				mm_log "error: unknown status read for device at sysfs path ${parent_sysfspath}"
+				;;
+		esac
+		return
+	}
+
+	[ "$action" = "remove" ] && {
+		local cfg
+
+		[ -n "$status" ] && {
+			local cfg
+
+			mm_log "cleanup wait for modem at sysfs path ${parent_sysfspath}"
+			mm_set_modem_wait_status "${parent_sysfspath}" ""
+
+			cfg=$(mm_get_modem_config "${parent_sysfspath}")
+			[ -n "${cfg}" ] && {
+				mm_log "setting interface '$cfg' as unavailable"
+				proto_set_available "${cfg}" 0
+			}
+		}
+		return
+	}
+}
+
+################################################################################
+# Cleanup interfaces
+
+mm_cleanup_interface_cb() {
+	local cfg="$1"
+
+	local proto
+	config_get proto "${cfg}" proto
+	[ "${proto}" = modemmanager ] || return 0
+
+	proto_set_available "${cfg}" 0
+}
+
+mm_cleanup_interfaces() {
+	config_load network
+	config_foreach mm_cleanup_interface_cb interface
+}
+
+################################################################################
+# Event reporting
+
+# Receives as input the action, the device name and the subsystem
+mm_report_event() {
+	local action="$1"
+	local name="$2"
+	local subsystem="$3"
+	local sysfspath="$4"
+
+	# Track/untrack events in cache
+	case "${action}" in
+		"add")
+			# On add events, store event details in cache (if not exists yet)
+			grep -qs "${name},${subsystem}" "${MODEMMANAGER_EVENTS_CACHE}" || \
+				echo "${action},${name},${subsystem},${sysfspath}" >> "${MODEMMANAGER_EVENTS_CACHE}"
+			;;
+		"remove")
+			# On remove events, remove old events from cache (match by subsystem+name)
+			sed -i "/${name},${subsystem}/d" "${MODEMMANAGER_EVENTS_CACHE}"
+			;;
+	esac
+
+	# Report the event
+	mm_log "event reported: action=${action}, name=${name}, subsystem=${subsystem}"
+	mmcli --report-kernel-event="action=${action},name=${name},subsystem=${subsystem}" 1>/dev/null 2>&1 &
+
+	# Wait for modem if a sysfspath is given
+	[ -n "${sysfspath}" ] && mm_report_modem_wait "${action}" "${sysfspath}"
+}
+
+mm_report_event_from_cache_line() {
+	local event_line="$1"
+
+	local action name subsystem sysfspath
+	action=$(echo "${event_line}" | awk -F ',' '{ print $1 }')
+	name=$(echo "${event_line}" | awk -F ',' '{ print $2 }')
+	subsystem=$(echo "${event_line}" | awk -F ',' '{ print $3 }')
+	sysfspath=$(echo "${event_line}" | awk -F ',' '{ print $4 }')
+
+	mm_log "cached event found: action=${action}, name=${name}, subsystem=${subsystem}, sysfspath=${sysfspath}"
+	mm_report_event "${action}" "${name}" "${subsystem}" "${sysfspath}"
+}
+
+mm_report_events_from_cache() {
+	# Remove the sysfs cache
+	rm -f "${MODEMMANAGER_SYSFS_CACHE}"
+
+	local n=10
+	local step=1
+	local mmrunning=0
+
+	# Wait for ModemManager to be available in the bus
+	while [ $n -ge 0 ]; do
+		sleep $step
+		mm_log "checking if ModemManager is available..."
+
+		if ! mmcli -L >/dev/null 2>&1
+		then
+			mm_log "ModemManager not yet available"
+		else
+			mmrunning=1
+			break
+		fi
+		n=$((n-step))
+	done
+
+	[ ${mmrunning} -eq 1 ] || {
+		mm_log "error: couldn't report initial kernel events: ModemManager not running"
+		return
+	}
+
+	# Report cached kernel events
+	while IFS= read -r event_line; do
+		mm_report_event_from_cache_line "${event_line}"
+	done < ${MODEMMANAGER_EVENTS_CACHE}
+}

--- a/net/modemmanager/files/modemmanager.init
+++ b/net/modemmanager/files/modemmanager.init
@@ -1,0 +1,33 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2016 Aleksander Morgado <aleksander@aleksander.es>
+
+USE_PROCD=1
+START=70
+
+stop_service() {
+	# Load common utils
+	. /etc/modemmanager/modemmanager.common
+	# Set all configured interfaces as unavailable
+	mm_cleanup_interfaces
+}
+
+start_service() {
+	# Load common utils
+	. /etc/modemmanager/modemmanager.common
+
+	# Always make sure the rundir exists
+	mkdir -m 0755 -p "${MODEMMANAGER_RUNDIR}"
+
+	# Initially set all configured interfaces as unavailable
+	mm_cleanup_interfaces
+
+	# Report cached events (will wait for MM to be launched)
+	( mm_report_events_from_cache ) >/dev/null 2>&1 &
+
+	# Setup ModemManager service
+	procd_open_instance
+	procd_set_param command /usr/sbin/ModemManager
+	procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
+	procd_set_param pidfile "${MODEMMANAGER_PID_FILE}"
+	procd_close_instance
+}

--- a/net/modemmanager/files/modemmanager.proto
+++ b/net/modemmanager/files/modemmanager.proto
@@ -1,0 +1,413 @@
+#!/bin/sh
+# Copyright (C) 2016-2019 Aleksander Morgado <aleksander@aleksander.es>
+
+[ -x /usr/bin/mmcli ] || exit 0
+[ -x /usr/sbin/pppd ] || exit 0
+
+[ -n "$INCLUDE_ONLY" ] || {
+	. /lib/functions.sh
+	. ../netifd-proto.sh
+	. ./ppp.sh
+	init_proto "$@"
+}
+
+cdr2mask ()
+{
+	# Number of args to shift, 255..255, first non-255 byte, zeroes
+	set -- $(( 5 - ($1 / 8) )) 255 255 255 255 $(( (255 << (8 - ($1 % 8))) & 255 )) 0 0 0
+	if [ "$1" -gt 1 ]
+	then
+		shift "$1" 
+	else 
+		shift
+	fi
+	echo "${1-0}"."${2-0}"."${3-0}"."${4-0}"
+}
+
+# This method expects as first argument a list of key-value pairs, as returned by mmcli --output-keyvalue
+# The second argument must be exactly the name of the field to read
+#
+# Sample output:
+#     $ mmcli -m 0 -K
+#     modem.dbus-path                                 : /org/freedesktop/ModemManager1/Modem/0
+#     modem.generic.device-identifier                 : ed6eff2e3e0f90463da1c2a755b2acacd1335752
+#     modem.generic.manufacturer                      : Dell Inc.
+#     modem.generic.model                             : DW5821e Snapdragon X20 LTE
+#     modem.generic.revision                          : T77W968.F1.0.0.4.0.GC.009\n026
+#     modem.generic.carrier-configuration             : GCF
+#     modem.generic.carrier-configuration-revision    : 08E00009
+#     modem.generic.hardware-revision                 : DW5821e Snapdragon X20 LTE
+#     ....
+modemmanager_get_field() {
+	local list=$1
+	local field=$2
+	local value=""
+
+	[ -z "${list}" ] || [ -z "${field}" ] && return
+
+	# there is always at least a whitespace after each key, and we use that as part of the
+	# key matching we do (e.g. to avoid getting 'modem.generic.state-failed-reason' as a result
+	# when grepping for 'modem.generic.state'.
+	line=$(echo "${list}" | grep "${field} ")
+	value=$(echo ${line#*:})
+
+	# not found?
+	[ -n "${value}" ] || return 2
+
+	# only print value if set
+	[ "${value}" != "--" ] && echo "${value}"
+	return 0
+}
+
+# build a comma-separated list of values from the list
+modemmanager_get_multivalue_field() {
+	local list=$1
+	local field=$2
+	local value=""
+	local length idx item
+
+	[ -z "${list}" ] || [ -z "${field}" ] && return
+
+	length=$(modemmanager_get_field "${list}" "${field}.length")
+	[ -n "${length}" ] || return 0
+	[ "$length" -ge 1 ] || return 0
+
+	idx=1
+	while [ $idx -le "$length" ]; do
+		item=$(modemmanager_get_field "${list}" "${field}.value\[$idx\]")
+		[ -n "${item}" ] && [ "${item}" != "--" ] && {
+			[ -n "${value}" ] && value="${value}, "
+			value="${value}${item}"
+		}
+		idx=$((idx + 1))
+	done
+
+	# nothing built?
+	[ -n "${value}" ] || return 2
+
+	# only print value if set
+	echo "${value}"
+	return 0
+}
+
+modemmanager_cleanup_connection() {
+	local modemstatus="$1"
+
+	local bearercount idx bearerpath
+
+	bearercount=$(modemmanager_get_field "${modemstatus}" "modem.generic.bearers.length")
+
+	# do nothing if no bearers reported
+	[ -n "${bearercount}" ] && [ "$bearercount" -ge 1 ] && {
+		# explicitly disconnect just in case
+		mmcli --modem="${device}" --simple-disconnect >/dev/null 2>&1
+		# and remove all bearer objects, if any found
+		idx=1
+		while [ $idx -le "$bearercount" ]; do
+			bearerpath=$(modemmanager_get_field "${modemstatus}" "modem.generic.bearers.value\[$idx\]")
+			mmcli --modem "${device}" --delete-bearer="${bearerpath}" >/dev/null 2>&1
+			idx=$((idx + 1))
+		done
+	}
+}
+
+modemmanager_connected_method_ppp() {
+	local interface="$1"
+	local ttyname="$2"
+	local username="$3"
+	local password="$4"
+
+	proto_run_command "${interface}" /usr/sbin/pppd \
+		"${ttyname}" \
+		115200 \
+		nodetach \
+		noaccomp \
+		nobsdcomp \
+		nopcomp \
+		novj \
+		noauth \
+		${username:+ user $username} \
+		${password:+ password $password} \
+		lcp-echo-failure 5 \
+		lcp-echo-interval 15 \
+		lock \
+		crtscts \
+		nodefaultroute \
+		usepeerdns \
+		ipparam "${interface}" \
+		ip-up-script /lib/netifd/ppp-up \
+		ip-down-script /lib/netifd/ppp-down
+}
+
+modemmanager_disconnected_method_ppp() {
+	local interface="$1"
+
+	echo "running disconnection (ppp method)"
+
+	[ -n "${ERROR}" ] && {
+		local errorstring
+		errorstring=$(ppp_exitcode_tostring "${ERROR}")
+		case "$ERROR" in
+			0)
+				;;
+			2)
+				proto_notify_error "$interface" "$errorstring"
+				proto_block_restart "$interface"
+				;;
+			*)
+				proto_notify_error "$interface" "$errorstring"
+				;;
+		esac
+	} || echo "pppd result code not given"
+
+	proto_kill_command "$interface"
+}
+
+modemmanager_connected_method_dhcp() {
+	local interface="$1"
+	local wwan="$2"
+	local metric="$3"
+
+	proto_init_update "${wwan}" 1
+	proto_send_update "${interface}"
+
+	json_init
+	json_add_string name "${interface}_4"
+	json_add_string ifname "@${interface}"
+	json_add_string proto "dhcp"
+	[ -n "$metric" ] && json_add_int metric "${metric}"
+	ubus call network add_dynamic "$(json_dump)"
+}
+
+modemmanager_disconnected_method_dhcp() {
+	local interface="$1"
+
+	echo "running disconnection (dhcp method)"
+
+	proto_init_update "*" 0
+	proto_send_update "${interface}"
+}
+
+modemmanager_connected_method_static() {
+	local interface="$1"
+	local wwan="$2"
+	local address="$3"
+	local prefix="$4"
+	local gateway="$5"
+	local mtu="$6"
+	local dns1="$7"
+	local dns2="$8"
+	local metric="$9"
+
+	local mask=""
+
+	[ -n "${address}" ] || {
+		proto_notify_error "${interface}" ADDRESS_MISSING
+		return
+	}
+
+	[ -n "${prefix}" ] || {
+		proto_notify_error "${interface}" PREFIX_MISSING
+		return
+	}
+
+	mask=$(cdr2mask "${prefix}")
+
+	# TODO: mtu reporting in proto handler
+
+	proto_init_update "${wwan}" 1
+	echo "adding IPv4 address ${address}, netmask ${mask}"
+	proto_add_ipv4_address "${address}" "${mask}"
+	[ -n "${gateway}" ] && {
+		echo "adding default IPv4 route via ${gateway}"
+		proto_add_ipv4_route "0.0.0.0" "0" "${gateway}" "${address}"
+	}
+	[ -n "${dns1}" ] && {
+		echo "adding primary DNS at ${dns1}"
+		proto_add_dns_server "${dns1}"
+	}
+	[ -n "${dns2}" ] && {
+		echo "adding secondary DNS at ${dns2}"
+		proto_add_dns_server "${dns2}"
+	}
+	[ -n "$metric" ] && json_add_int metric "${metric}"
+	proto_send_update "${interface}"
+}
+
+modemmanager_disconnected_method_static() {
+	local interface="$1"
+
+	echo "running disconnection (static method)"
+
+	proto_init_update "*" 0
+	proto_send_update "${interface}"
+}
+
+proto_modemmanager_init_config() {
+	proto_config_add_string	 "device:device"
+	proto_config_add_string	 apn
+	proto_config_add_string	 username
+	proto_config_add_string	 password
+	proto_config_add_string	 pincode
+	proto_config_add_string	 iptype
+	proto_config_add_boolean lowpower
+}
+
+proto_modemmanager_setup() {
+	local interface="$1"
+
+	local modempath modemstatus bearercount bearerpath connectargs bearerstatus beareriface
+	local operatorname operatorid registration accesstech signalquality
+
+	local device apn username password pincode iptype metric
+	
+	local address prefix gateway mtu dns1 dns2
+
+	json_get_vars device apn username password pincode iptype metric
+
+	# validate sysfs path given in config
+	[ -n "${device}" ] || {
+		echo "No device specified"
+		proto_notify_error "${interface}" NO_DEVICE
+		proto_set_available "${interface}" 0
+		return 1
+	}
+	[ -e "${device}" ] || {
+		echo "Device not found in sysfs"
+		proto_set_available "${interface}" 0
+		return 1
+	}
+
+	# validate that ModemManager is handling the modem at the sysfs path
+	modemstatus=$(mmcli --modem="${device}" --output-keyvalue)
+	modempath=$(modemmanager_get_field "${modemstatus}" "modem.dbus-path")
+	[ -n "${modempath}" ] || {
+		echo "Device not managed by ModemManager"
+		proto_notify_error "${interface}" DEVICE_NOT_MANAGED
+		proto_set_available "${interface}" 0
+		return 1
+	}
+	echo "modem available at ${modempath}"
+
+	# always cleanup before attempting a new connection, just in case
+	modemmanager_cleanup_connection "${modemstatus}"
+
+	# setup connect args; APN mandatory (even if it may be empty)
+	echo "starting connection with apn '${apn}'..."
+	connectargs="apn=${apn}${username:+,user=${username}}${password:+,password=${password}}${pincode:+,pin=${pincode}}${iptype:+,ip-type=${iptype}}"
+	mmcli --modem="${device}" --timeout 120 --simple-connect="${connectargs}" || {
+		proto_notify_error "${interface}" CONNECT_FAILED
+		proto_block_restart "${interface}"
+		return 1
+	}
+
+	# log additional useful information
+	modemstatus=$(mmcli --modem="${device}" --output-keyvalue)
+	operatorname=$(modemmanager_get_field "${modemstatus}" "modem.3gpp.operator-name")
+	[ -n "${operatorname}" ] && echo "network operator name: ${operatorname}"
+	operatorid=$(modemmanager_get_field "${modemstatus}" "modem.3gpp.operator-code")
+	[ -n "${operatorid}" ] && echo "network operator MCCMNC: ${operatorid}"
+	registration=$(modemmanager_get_field "${modemstatus}" "modem.3gpp.registration-state")
+	[ -n "${registration}" ] && echo "registration type: ${registration}"
+	accesstech=$(modemmanager_get_multivalue_field "${modemstatus}" "modem.generic.access-technologies")
+	[ -n "${accesstech}" ] && echo "access technology: ${accesstech}"
+	signalquality=$(modemmanager_get_field "${modemstatus}" "modem.generic.signal-quality.value")
+	[ -n "${signalquality}" ] && echo "signal quality: ${signalquality}%"
+
+	# we won't like it if there are more than one bearers, as that would mean the
+	# user manually created them, and that's unsupported by this proto
+	bearercount=$(modemmanager_get_field "${modemstatus}" "modem.generic.bearers.length")
+	[ -n "${bearercount}" ] && [ "$bearercount" -eq 1 ] || {
+		proto_notify_error "${interface}" INVALID_BEARER_LIST
+		return 1
+	}
+
+	# load connected bearer information
+	bearerpath=$(modemmanager_get_field "${modemstatus}" "modem.generic.bearers.value\[1\]")
+	bearerstatus=$(mmcli --bearer "${bearerpath}" --output-keyvalue)
+
+	# load network interface and method information
+	beareriface=$(modemmanager_get_field "${bearerstatus}" "bearer.status.interface")
+	bearermethod=$(modemmanager_get_field "${bearerstatus}" "bearer.ipv4-config.method")
+	echo "connection setup required in interface ${beareriface}: ${bearermethod}"
+
+	case "${bearermethod}" in
+	"dhcp")
+		modemmanager_connected_method_dhcp "${interface}" "${beareriface}" "${metric}"
+		;;
+	"static")
+		address=$(modemmanager_get_field "${bearerstatus}" "bearer.ipv4-config.address")
+		prefix=$(modemmanager_get_field "${bearerstatus}" "bearer.ipv4-config.prefix")
+		gateway=$(modemmanager_get_field "${bearerstatus}" "bearer.ipv4-config.gateway")
+		mtu=$(modemmanager_get_field "${bearerstatus}" "bearer.ipv4-config.mtu")
+		dns1=$(modemmanager_get_field "${bearerstatus}" "bearer.ipv4-config.dns.value\[1\]")
+		dns2=$(modemmanager_get_field "${bearerstatus}" "bearer.ipv4-config.dns.value\[2\]")
+		modemmanager_connected_method_static "${interface}" "${beareriface}" "${address}" "${prefix}" "${gateway}" "${mtu}" "${dns1}" "${dns2}" "${metric}"
+		;;
+	"ppp")
+		modemmanager_connected_method_ppp "${interface}" "${beareriface}" "${username}" "${password}"
+		;;
+	*)
+		proto_notify_error "${interface}" UNKNOWN_METHOD
+		return 1
+		;;
+	esac
+
+	return 0
+}
+
+proto_modemmanager_teardown() {
+	local interface="$1"
+
+	local modemstatus bearerpath errorstring
+
+	local device lowpower
+	json_get_vars device lowpower
+
+	echo "stopping network"
+
+	# load connected bearer information, just the first one should be ok
+	modemstatus=$(mmcli --modem="${device}" --output-keyvalue)
+	bearerpath=$(modemmanager_get_field "${modemstatus}" "modem.generic.bearers.value\[1\]")
+	[ -n "${bearerpath}" ] || {
+		echo "couldn't load bearer path"
+		return
+	}
+
+	# load bearer connection method
+	bearerstatus=$(mmcli --bearer "${bearerpath}")
+	bearermethod=$(modemmanager_get_field "${bearerstatus}" "bearer.ipv4-config.method")
+	[ -n "${bearermethod}" ] || {
+		echo "couldn't load bearer method"
+		return
+	}
+
+	case "${bearermethod}" in
+	"dhcp")
+		modemmanager_disconnected_method_dhcp "${interface}"
+		;;
+	"static")
+		modemmanager_disconnected_method_static "${interface}"
+		;;
+	"ppp")
+		modemmanager_disconnected_method_ppp "${interface}"
+		;;
+	*)
+		;;
+	esac
+
+	# disconnect
+	mmcli --modem="${device}" --simple-disconnect ||
+		proto_notify_error "${interface}" DISCONNECT_FAILED
+
+	# disable
+	mmcli --modem="${device}" --disable
+
+	# low power, only if requested
+	[ "${lowpower:-0}" -lt 1 ] ||
+		mmcli --modem="${device}" --set-power-state-low
+}
+
+[ -n "$INCLUDE_ONLY" ] || {
+	add_protocol modemmanager
+}


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas.smith@telcoantennas.com.au>

Maintainer: @nickberry17
Compile tested: mips, telco-electronics-x1, 18.06.2 + 18.06.4 + master; ath79, cf-e5, 18.06.2 + 18.06.4 + master
Run tested: mips, telco-electronics-x1, 18.06.2 + 18.06.4 + master, ran all basic functions; ath79, cf-e5, 18.06.2 + 18.06.4 + master, ran all basic functions

Description: ModemManager 1.10.6, libmbim 1.20.0 and libqmi 1.22.6
