### PR TITLE
liblz4: Update to 1.9.1 and switch to codeload

### DIFF
--- a/libs/liblz4/Config.in
+++ b/libs/liblz4/Config.in
@@ -1,0 +1,7 @@
+config LZ4_OPTIMIZE_SPEED
+	bool "Optimize for speed"
+	depends on PACKAGE_liblz4
+	help
+		This enables additional optimization and
+		increases performance considerably at
+		the expense of binary size.

--- a/libs/liblz4/Makefile
+++ b/libs/liblz4/Makefile
@@ -7,30 +7,38 @@
 
 include $(TOPDIR)/rules.mk
 
-# Although liblz4 exports a major.minor.patch version, it isn't always
-# incremented for new releases. Check the NEWS file and instead use a
-# release tag when appropriate. (eg: PKG_VERSION:=r131)
 PKG_NAME:=liblz4
-PKG_VERSION:=v1.7.5
+PKG_VERSION:=1.9.1
 PKG_RELEASE:=1
 
-PKG_LICENSE:=BSD-2-Clause
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/lz4/lz4/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=f8377c89dad5c9f266edc0be9b73595296ecafd5bfa1000de148096c50052dc4
+PKG_BUILD_DIR:=$(BUILD_DIR)/lz4-$(PKG_VERSION)
+
 PKG_MAINTAINER:=Darik Horn <dajhorn@vanadac.com>
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MIRROR_HASH:=afb362b970816e06dac4997d26dd7d2cdb83168510228d174d25b1044b271e18
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/lz4/lz4.git
-PKG_SOURCE_VERSION:=$(PKG_VERSION)
+PKG_BUILD_PARALLEL:=1
+CMAKE_INSTALL:=1
+CMAKE_SOURCE_SUBDIR:=contrib/cmake_unofficial
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/lz4/Default
+  SUBMENU:=Compression
+  URL:=https://www.lz4.org/
+endef
 
 define Package/liblz4
-	SECTION:=libs
-	CATEGORY:=Libraries
-	TITLE:=Extremely fast compression
-	URL:=http://www.lz4.org/
+$(call Package/lz4/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Extremely fast compression
+  LICENSE:=BSD-2-Clause
+  LICENSE_FILES:=LICENSE lib/LICENSE
+  ABI_VERSION:=$(firstword $(subst .,$(space),$(PKG_VERSION)))
+  MENU:=1
 endef
 
 define Package/liblz4/description
@@ -38,23 +46,45 @@ define Package/liblz4/description
   even faster decoder. This package provides the liblz4 shared library.
 endef
 
-TARGET_CFLAGS += $(FPIC)
-
-define Build/Compile
-	$(MAKE) -C "$(PKG_BUILD_DIR)/lib" $(MAKE_INSTALL_FLAGS) \
-	  CC="$(TARGET_CC)" \
-	  CFLAGS="$(TARGET_CFLAGS)" \
-	  PREFIX="$(CONFIGURE_PREFIX)" \
-	  install
+define Package/liblz4/config
+	source "$(SOURCE)/Config.in"
 endef
 
-define Build/InstallDev
-	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
+define Package/lz4
+$(call Package/lz4/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Extremely fast compression
+  LICENSE:=GPL-2.0-or-later
+  LICENSE_FILES:=LICENSE programs/COPYING
+  DEPENDS:=+liblz4
 endef
+
+define Package/lz4/description
+  LZ4 - Fast real-time compression algorithm.
+  This package provides the lz4 binaries.
+endef
+
+CMAKE_OPTIONS += \
+	-DCMAKE_INSTALL_MANDIR=/dev/null \
+	-DLZ4_BUILD_LEGACY_LZ4C=OFF
+
+ifeq ($(CONFIG_LZ4_OPTIMIZE_SPEED),y)
+	TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS)) -O3
+endif
+
+TARGET_CFLAGS += $(FPIC) -ffunction-sections -fdata-sections -flto
+TARGET_LDFLAGS += -Wl,--gc-sections
 
 define Package/liblz4/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liblz4.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liblz4.so.$(ABI_VERSION)* $(1)/usr/lib/
+endef
+
+define Package/lz4/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/{lz4,lz4cat,unlz4} $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,liblz4))
+$(eval $(call BuildPackage,lz4))


### PR DESCRIPTION
Simplifies the Makefile.

Remove build hacks and use PKG_INSTALL.

Use PKG_BUILD_PARALLEL for faster compilation.

Switch to the Compression submenu to group this with the others.

Added lz4 binaries to be installable.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dajhorn 
Compile tested: arc700