### PR TITLE
libsodium: Update to 1.0.18

### DIFF
--- a/libs/libsodium/Makefile
+++ b/libs/libsodium/Makefile
@@ -8,20 +8,21 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsodium
-PKG_VERSION:=1.0.17
+PKG_VERSION:=1.0.18
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libsodium.org/libsodium/releases \
 		https://github.com/jedisct1/libsodium/releases/download/$(PKG_VERSION)
-PKG_HASH:=0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1
-
-PKG_FIXUP:=libtool autoreconf
-PKG_USE_MIPS16:=0
-PKG_INSTALL:=1
+PKG_HASH:=6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1
 
 PKG_MAINTAINER:=Damiano Renfer <damiano.renfer@gmail.com>
 PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_USE_MIPS16:=0
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -30,7 +31,6 @@ define Package/libsodium
   CATEGORY:=Libraries
   TITLE:=P(ortable|ackageable) NaCl-based crypto library
   URL:=https://github.com/jedisct1/libsodium
-  MAINTAINER:=Damiano Renfer <damiano.renfer@gmail.com>
 endef
 
 define Package/libsodium/description
@@ -53,7 +53,7 @@ endef
 
 CONFIGURE_ARGS+= \
 	--disable-ssp \
-	$(if $(CONFIG_LIBSODIUM_MINIMAL),--enable-minimal=yes,--enable-minimal=no)
+	$(if $(CONFIG_LIBSODIUM_MINIMAL),--enable,--disable)-minimal
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/sodium


### PR DESCRIPTION
Added PKG_BUILD_PARALLEL for faster compilation.

Several Makefile cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @damianorenfer 
Compile tested: arc700
