### PR TITLE
seafile-seahub,django: cleanup seafile a bit, add python3 variants for django & django-constance

### DIFF
--- a/lang/python/django-appconf/Makefile
+++ b/lang/python/django-appconf/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-appconf
 PKG_VERSION:=1.0.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -26,7 +26,7 @@ define Package/django-appconf
   CATEGORY:=Languages
   TITLE:=A helper class for handling configuration defaults of packaged apps gracefully.
   URL:=http://django-appconf.readthedocs.org/
-  DEPENDS:=+python +django
+  DEPENDS:=+python +python-django
 endef
 
 define Package/django-appconf/description

--- a/lang/python/django-compressor/Makefile
+++ b/lang/python/django-compressor/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-compressor
 PKG_VERSION:=2.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
@@ -30,7 +30,7 @@ define Package/django-compressor
   CATEGORY:=Languages
   TITLE:=Compress CSS/JS into single cached files
   URL:=http://django-compressor.readthedocs.org/
-  DEPENDS:=+python +django +django-appconf +python-rcssmin
+  DEPENDS:=+python +python-django +django-appconf +python-rcssmin
   VARIANT:=python
 endef
 

--- a/lang/python/django-constance/Makefile
+++ b/lang/python/django-constance/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-constance
 PKG_VERSION:=2.3.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -26,7 +26,7 @@ define Package/django-constance
   CATEGORY:=Languages
   TITLE:=Django live settings with pluggable backends, including Redis.
   URL:=https://github.com/jazzband/django-constance
-  DEPENDS:=+python +django
+  DEPENDS:=+python +python-django
 endef
 
 define Package/django-constance/description

--- a/lang/python/django-constance/Makefile
+++ b/lang/python/django-constance/Makefile
@@ -17,31 +17,49 @@ PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/django-constanc
 PKG_HASH:=a49735063b2c30015d2e52a90609ea9798da722ed070f091de51714758a5d018
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-django-constance-$(PKG_VERSION)
+
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/django-constance
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-django-constance/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Django live settings with pluggable backends, including Redis.
   URL:=https://github.com/jazzband/django-constance
-  DEPENDS:=+python +python-django
 endef
 
-define Package/django-constance/description
+define Package/python-django-constance
+$(call Package/python-django-constance/Default)
+  DEPENDS:= \
+	+PACKAGE_python-django-constance:python \
+	+PACKAGE_python-django-constance:python-django
+  VARIANT:=python
+endef
+
+define Package/python-django-constance/description
   Django live settings with pluggable backends, including Redis.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-django-constance
+$(call Package/python-django-constance/Default)
+  DEPENDS:= \
+	+PACKAGE_python3-django-constance:python3 \
+	+PACKAGE_python3-django-constance:python3-django
+  VARIANT:=python3
 endef
 
-define Package/django-constance/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
+define Package/python3-django-constance/description
+$(call define Package/python-django-constance/description)
+.
+(Variant for Python3)
 endef
 
-$(eval $(call BuildPackage,django-constance))
+$(eval $(call PyPackage,python-django-constance))
+$(eval $(call BuildPackage,python-django-constance))
+$(eval $(call Py3Package,python3-django-constance))
+$(eval $(call BuildPackage,python3-django-constance))

--- a/lang/python/django-formtools/Makefile
+++ b/lang/python/django-formtools/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-formtools
 PKG_VERSION:=2.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -26,7 +26,7 @@ define Package/django-formtools
   CATEGORY:=Languages
   TITLE:=High-level abstractions for Django forms
   URL:=https://django-formtools.readthedocs.io/en/latest/
-  DEPENDS:=+python +django
+  DEPENDS:=+python +python-django
   VARIANT:=python
 endef
 

--- a/lang/python/django-jsonfield/Makefile
+++ b/lang/python/django-jsonfield/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-jsonfield
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -26,7 +26,7 @@ define Package/django-jsonfield
   CATEGORY:=Languages
   TITLE:=JSONField for django models
   URL:=https://github.com/bradjasper/django-jsonfield
-  DEPENDS:=+python +django
+  DEPENDS:=+python +python-django
 endef
 
 define Package/django-jsonfield/description

--- a/lang/python/django-picklefield/Makefile
+++ b/lang/python/django-picklefield/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-picklefield
 PKG_VERSION:=1.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -26,7 +26,7 @@ define Package/django-picklefield
   CATEGORY:=Languages
   TITLE:=Pickled object field for Django
   URL:=https://github.com/gintas/django-picklefield
-  DEPENDS:=+python +django
+  DEPENDS:=+python +python-django
 endef
 
 define Package/django-picklefield/description

--- a/lang/python/django-postoffice/Makefile
+++ b/lang/python/django-postoffice/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-postoffice
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=MIT
 
 PKG_SOURCE:=django-post_office-$(PKG_VERSION).tar.gz
@@ -27,7 +27,7 @@ define Package/django-postoffice
   CATEGORY:=Languages
   TITLE:=A Django app to monitor and send mail asynchronously, complete with template support.
   URL:=https://github.com/ui/django-postoffice
-  DEPENDS:=+python +django +django-jsonfield
+  DEPENDS:=+python +python-django +django-jsonfield
 endef
 
 define Package/django-postoffice/description

--- a/lang/python/django-ranged-response/Makefile
+++ b/lang/python/django-ranged-response/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-ranged-response
 PKG_VERSION:=0.2.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=MIT
@@ -25,7 +25,7 @@ define Package/django-ranged-response
   CATEGORY:=Languages
   TITLE:=Add Content-Range: to FileResponse
   URL:=https://github.com/wearespindle/django-ranged-fileresponse
-  DEPENDS:=+python +django
+  DEPENDS:=+python +python-django
   VARIANT:=python
 endef
 

--- a/lang/python/django-restframework/Makefile
+++ b/lang/python/django-restframework/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-restframework
 PKG_VERSION:=3.9.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=djangorestframework-$(PKG_VERSION).tar.gz
@@ -27,7 +27,7 @@ define Package/django-restframework
   CATEGORY:=Languages
   TITLE:=Web APIs for Django, made easy.
   URL:=https://www.django-rest-framework.org
-  DEPENDS:=+python +django
+  DEPENDS:=+python +python-django
 endef
 
 define Package/django-restframework/description

--- a/lang/python/django-simple-captcha/Makefile
+++ b/lang/python/django-simple-captcha/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-simple-captcha
 PKG_VERSION:=0.5.11
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=MIT
@@ -28,7 +28,7 @@ define Package/django-simple-captcha
   CATEGORY:=Languages
   TITLE:=Simple Django captcha application
   URL:=https://github.com/mbi/django-simple-captcha
-  DEPENDS:=+python +python-six +django +pillow +django-ranged-response
+  DEPENDS:=+python +python-six +python-django +pillow +django-ranged-response
   VARIANT:=python
 endef
 

--- a/lang/python/django-statici18n/Makefile
+++ b/lang/python/django-statici18n/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-statici18n
 PKG_VERSION:=1.8.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=BSD-3-Clause
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -26,7 +26,7 @@ define Package/django-statici18n
   CATEGORY:=Languages
   TITLE:=A Django app that provides helper for generating JavaScript catalog to static files.
   URL:=https://django-statici18n.readthedocs.org/
-  DEPENDS:=+python +django
+  DEPENDS:=+python +python-django
 endef
 
 define Package/django-statici18n/description

--- a/lang/python/django-webpack-loader/Makefile
+++ b/lang/python/django-webpack-loader/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-webpack-loader
 PKG_VERSION:=0.6.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=MIT
@@ -26,7 +26,7 @@ define Package/django-webpack-loader
   CATEGORY:=Languages
   TITLE:=Transparently use webpack in django
   URL:=https://github.com/owais/django-webpack-loader
-  DEPENDS:=+python +django
+  DEPENDS:=+python +python-django
   VARIANT:=python
 endef
 

--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
 PKG_VERSION:=1.11.17
-PKG_RELEASE=3
+PKG_RELEASE=4
 
 PKG_SOURCE:=Django-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/D/Django
@@ -21,46 +21,50 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE LICENSE.python
 PKG_CPE_ID:=cpe:/a:djangoproject:django
 
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-django-$(PKG_VERSION)
+
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/django
-    SUBMENU:=Python
-    SECTION:=lang
-    CATEGORY:=Languages
-    TITLE:=The web framework for perfectionists with deadlines.
-    URL:=https://www.djangoproject.com/
-    DEPENDS:=+python +python-pytz
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/django/Default
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=The web framework for perfectionists with deadlines.
+  URL:=https://www.djangoproject.com/
 endef
 
-define Package/django/description
+define Package/python-django
+$(call Package/django/Default)
+  DEPENDS:= \
+	+PACKAGE_python-django:python \
+	+PACKAGE_python-django:python-pytz
+  VARIANT:=python
+endef
+
+define Package/python-django/description
     The web framework for perfectionists with deadlines.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-django
+$(call Package/django/Default)
+  DEPENDS:= \
+	+PACKAGE_python3-django:python3 \
+	+PACKAGE_python3-django:python3-pytz
+  VARIANT:=python3
 endef
 
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/django-admin.py \
-	    $(1)/usr/bin
+define Package/python3-django/description
+$(call Package/python-django/description)
+.
+(Variant for Python3)
 endef
 
-define Package/django/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/django-admin.py \
-	    $(1)/usr/bin
-	# fix python exec path
-	sed -i 's/#!.*/#!\/usr\/bin\/python/g' $(1)/usr/bin/django-admin.py
-endef
+$(eval $(call PyPackage,python-django))
+$(eval $(call BuildPackage,python-django))
 
-$(eval $(call BuildPackage,django))
+$(eval $(call Py3Package,python3-django))
+$(eval $(call BuildPackage,python3-django))

--- a/lang/python/python-pytz/Makefile
+++ b/lang/python/python-pytz/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pytz
 PKG_VERSION:=2019.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=pytz-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pytz
@@ -21,15 +21,11 @@ PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
 
-HOST_BUILD_DEPENDS:=python/host
-
-include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
 
 PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-HOST_UNPACK:=$(HOST_TAR) -C $(HOST_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-pytz/Default
   SUBMENU:=Python
@@ -61,14 +57,6 @@ $(call Package/python-pytz/description)
 .
 (Variant for Python3)
 endef
-
-define Host/Compile
-	$(call Build/Compile/HostPyMod,,install --prefix="" --root="$(STAGING_DIR_HOSTPKG)")
-endef
-
-Host/Install:=
-
-$(eval $(call HostBuild))
 
 $(eval $(call PyPackage,python-pytz))
 $(eval $(call BuildPackage,python-pytz))

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -17,7 +17,7 @@ PKG_SOURCE_URL:=https://codeload.github.com/haiwen/seahub/tar.gz/v$(PKG_VERSION)
 PKG_HASH:=53a9efdb6791fd3a2a191e89cb0f133632056046ec08adbb2ad72088e6161430
 PKG_BUILD_DIR:=$(BUILD_DIR)/seahub-$(PKG_VERSION)-server
 
-PKG_BUILD_DEPENDS:=python-pytz/host
+HOST_PYTHON_PACKAGE_BUILD_DEPENDS:="django>=1.11"
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python-package.mk
@@ -41,7 +41,12 @@ endef
 define Build/Configure
 endef
 
+MAKE_VARS += \
+	PYTHON="$(HOST_PYTHON_BIN)" \
+	DJANGO_ADMIN_PY="$(STAGING_DIR_HOSTPKG)/bin/django-admin"
+
 define Build/Compile
+	$(call Build/Compile/HostPyPipInstall,$(HOST_PYTHON_PACKAGE_BUILD_DEPENDS))
 	$(call Build/Compile/Default,locale)
 endef
 

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -27,16 +27,16 @@ SEAFILE_PYTHON_DEPENDS:= \
 	django django-constance
 
 define Package/seafile-seahub
-    SECTION:=net
-    CATEGORY:=Network
-    TITLE:=Seafile server - seahub component
-    URL:=https://seafile.com/
-    DEPENDS:=+python +pillow +django-appconf \
-		+django-compressor +django-formtools +django-jsonfield \
-		+django-picklefield +django-postoffice +django-restframework \
-		+django-simple-captcha +django-statici18n +django-webpack-loader \
-		+flup +gunicorn +openpyxl \
-		$(foreach dep,$(SEAFILE_PYTHON_DEPENDS),+python-$(dep))
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Seafile server - seahub component
+  URL:=https://seafile.com/
+  DEPENDS:=+python +pillow +django-appconf \
+	+django-compressor +django-formtools +django-jsonfield \
+	+django-picklefield +django-postoffice +django-restframework \
+	+django-simple-captcha +django-statici18n +django-webpack-loader \
+	+flup +gunicorn +openpyxl \
+	$(foreach dep,$(SEAFILE_PYTHON_DEPENDS),+python-$(dep))
 endef
 
 define Build/Configure

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -24,7 +24,7 @@ include ../../lang/python/python-package.mk
 
 SEAFILE_PYTHON_DEPENDS:= \
 	simplejson chardet dateutil mysql pytz qrcode requests requests-oauthlib \
-	django
+	django django-constance
 
 define Package/seafile-seahub
     SECTION:=net
@@ -32,7 +32,7 @@ define Package/seafile-seahub
     TITLE:=Seafile server - seahub component
     URL:=https://seafile.com/
     DEPENDS:=+python +pillow +django-appconf \
-		+django-compressor +django-constance +django-formtools +django-jsonfield \
+		+django-compressor +django-formtools +django-jsonfield \
 		+django-picklefield +django-postoffice +django-restframework \
 		+django-simple-captcha +django-statici18n +django-webpack-loader \
 		+flup +gunicorn +openpyxl \

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-seahub
 PKG_VERSION:=6.3.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=Apache-2.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -22,17 +22,20 @@ PKG_BUILD_DEPENDS:=python-pytz/host
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python-package.mk
 
+SEAFILE_PYTHON_DEPENDS:= \
+	simplejson chardet dateutil mysql pytz qrcode requests requests-oauthlib
+
 define Package/seafile-seahub
     SECTION:=net
     CATEGORY:=Network
     TITLE:=Seafile server - seahub component
     URL:=https://seafile.com/
-    DEPENDS:=+python-simplejson +python +pillow +python-chardet +django +django-appconf \
+    DEPENDS:=+python +pillow +django +django-appconf \
 		+django-compressor +django-constance +django-formtools +django-jsonfield \
 		+django-picklefield +django-postoffice +django-restframework \
 		+django-simple-captcha +django-statici18n +django-webpack-loader \
-		+flup +gunicorn +openpyxl +python-dateutil +python-mysql \
-		+python-qrcode +python-requests +python-requests-oauthlib +python-pytz
+		+flup +gunicorn +openpyxl \
+		$(foreach dep,$(SEAFILE_PYTHON_DEPENDS),+python-$(dep))
 endef
 
 define Build/Configure

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -23,14 +23,15 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python-package.mk
 
 SEAFILE_PYTHON_DEPENDS:= \
-	simplejson chardet dateutil mysql pytz qrcode requests requests-oauthlib
+	simplejson chardet dateutil mysql pytz qrcode requests requests-oauthlib \
+	django
 
 define Package/seafile-seahub
     SECTION:=net
     CATEGORY:=Network
     TITLE:=Seafile server - seahub component
     URL:=https://seafile.com/
-    DEPENDS:=+python +pillow +django +django-appconf \
+    DEPENDS:=+python +pillow +django-appconf \
 		+django-compressor +django-constance +django-formtools +django-jsonfield \
 		+django-picklefield +django-postoffice +django-restframework \
 		+django-simple-captcha +django-statici18n +django-webpack-loader \

--- a/net/seafile-seahub/patches/020-Makefile-fixes.patch
+++ b/net/seafile-seahub/patches/020-Makefile-fixes.patch
@@ -1,8 +1,8 @@
 --- a/Makefile
 +++ b/Makefile
 @@ -1,3 +1,6 @@
-+include $(TOPDIR)/rules.mk
-+include $(TOPDIR)/feeds/packages/lang/python/python-package.mk
++PYTHON ?= python
++DJANGO_ADMIN_PY ?= django-admin.py
 +
  PROJECT=seahub
  
@@ -12,7 +12,7 @@
  locale:
  	@echo "--> Compile locales"
 -	django-admin.py compilemessages
-+	$(call HostPython,,$(STAGING_DIR)/usr/bin/django-admin.py compilemessages)
++	$(DJANGO_ADMIN_PY) compilemessages
  	@echo ""
  
  uglify:
@@ -21,19 +21,19 @@
  statici18n:
  	@echo "--> Generate JS locale files in static/scripts/i18n"
 -	python manage.py compilejsi18n
-+	$(call HostPython,,manage.py compilejsi18n)
++	$(PYTHON) manage.py compilejsi18n
  
  collectstatic:
  	@echo "--> Collect django static files to media/assets"
  	rm -rf media/assets 2> /dev/null
 -	python manage.py collectstatic --noinput -i admin -i termsandconditions -i app -i sysadmin-app -i build.js
-+	$(call HostPython,,manage.py collectstatic --noinput -i admin -i termsandconditions -i app -i sysadmin-app -i build.js)
++	$(PYTHON) manage.py collectstatic --noinput -i admin -i termsandconditions -i app -i sysadmin-app -i build.js
  
  compressstatic:
  	@echo "--> Compress static files(css) to media/CACHE"
  	rm -rf media/CACHE 2> /dev/null
 -	python manage.py compress
-+	$(call HostPython,,manage.py compress)
++	$(PYTHON) manage.py compress
  
  clean:
  	@echo '--> Cleaning media/static cache & dist'


### PR DESCRIPTION
Maintainer: me
Compile tested: http://github.com/openwrt/openwrt/commit/3209f5ae3d54e6f028e2e54314180a1be5b4896e x96
Run tested: http://github.com/openwrt/openwrt/commit/3209f5ae3d54e6f028e2e54314180a1be5b4896e x96

----------------------------------------------------------------------------

Description:

This change mostly focuses on decoupling django-admin from seafile-seahub.
And re-organizing some dependencies in a cleaner way.

A side effect is to also add python3-django. and python3-django-constance.
This is just a start, since all django packages will be converted.
The idea is to have the switch to Python3 (for seafile-seahub) be a one-liner if possible.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>