### PR TITLE
boost: Fixes makefile host tools compile

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -384,7 +384,7 @@ define Host/Compile
 				headers \
 				$(foreach lib,$(BOOST_LIBS), \
 					$(if $(findstring python,$(lib)),,$(if $(CONFIG_boost-host-build-$(lib)),$(lib)))))) ; \
-		./b2 install )
+		./b2 variant=release visibility=hidden install )
 endef
 
 CONFIGURE_PREFIX:=$(PKG_INSTALL_DIR)


### PR DESCRIPTION
Maintainer: @ClaymorePT
Compile tested: None
Run tested: None

Description:
This commit fixes the issue where the host tools were not compiling for gentoo [1].

[1]: https://github.com/openwrt/packages/issues/9152

Signed-off-by: Carlos Ferreira <carlosmf.pt@gmail.com>