### PR TITLE
boost: ignore site config during host build

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -384,7 +384,7 @@ define Host/Compile
 				headers \
 				$(foreach lib,$(BOOST_LIBS), \
 					$(if $(findstring python,$(lib)),,$(if $(CONFIG_boost-host-build-$(lib)),$(lib)))))) ; \
-		./b2 install )
+		./b2 --ignore-site-config install )
 endef
 
 CONFIGURE_PREFIX:=$(PKG_INSTALL_DIR)

--- a/libs/boost/patches/010-uclibc-ng.patch
+++ b/libs/boost/patches/010-uclibc-ng.patch
@@ -15,7 +15,7 @@
  #include <boost/asio/detail/cstdint.hpp>
  #include <boost/asio/detail/eventfd_select_interrupter.hpp>
  #include <boost/asio/detail/throw_error.hpp>
-@@ -46,14 +46,14 @@ eventfd_select_interrupter::eventfd_select_interrupter()
+@@ -46,14 +46,14 @@ eventfd_select_interrupter::eventfd_sele
  
  void eventfd_select_interrupter::open_descriptors()
  {
@@ -32,7 +32,7 @@
  # if defined(EFD_CLOEXEC) && defined(EFD_NONBLOCK)
    write_descriptor_ = read_descriptor_ =
      ::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
-@@ -70,7 +70,7 @@ void eventfd_select_interrupter::open_descriptors()
+@@ -70,7 +70,7 @@ void eventfd_select_interrupter::open_de
        ::fcntl(read_descriptor_, F_SETFD, FD_CLOEXEC);
      }
    }

--- a/libs/boost/patches/100-fix-apply_visitor-on-lvalue-variant.patch
+++ b/libs/boost/patches/100-fix-apply_visitor-on-lvalue-variant.patch
@@ -8,8 +8,6 @@ Ensures that we can e.g. call apply_visitor on a lvalue variant
  boost/variant/detail/apply_visitor_unary.hpp | 9 +++++----
  1 file changed, 5 insertions(+), 4 deletions(-)
 
-diff --git a/boost/variant/detail/apply_visitor_unary.hpp b/boost/variant/detail/apply_visitor_unary.hpp
-index 71610cb6..c3a741ef 100644
 --- a/boost/variant/detail/apply_visitor_unary.hpp
 +++ b/boost/variant/detail/apply_visitor_unary.hpp
 @@ -23,6 +23,7 @@
@@ -46,7 +44,7 @@ index 71610cb6..c3a741ef 100644
      };
  
      typedef typename deduce_impl<begin_it>::type type;
-@@ -132,7 +133,7 @@ inline decltype(auto) apply_visitor(Visitor&& visitor, Visitable&& visitable,
+@@ -132,7 +133,7 @@ inline decltype(auto) apply_visitor(Visi
          boost::detail::variant::has_result_type<Visitor>
      >::type* = 0)
  {
@@ -55,21 +53,9 @@ index 71610cb6..c3a741ef 100644
      return ::boost::forward<Visitable>(visitable).apply_visitor(cpp14_vis);
  }
  
-
-From 7331d648f46b6008138cbd22087b8c5c61ff7926 Mon Sep 17 00:00:00 2001
-From: Ed Catmur <ed@catmur.uk>
-Date: Sun, 21 Apr 2019 00:50:00 +0100
-Subject: [PATCH 2/2] Add test.
-
----
- libs/variant/test/const_ref_apply_visitor.cpp | 44 ++++++++++++++++++++++++++++++++
- 1 file changed, 44 insertions(+)
-
-diff --git a/libs/variant/test/const_ref_apply_visitor.cpp b/libs/variant/test/const_ref_apply_visitor.cpp
-index 0ec77bd4..72afff9e 100644
 --- a/libs/variant/test/const_ref_apply_visitor.cpp
 +++ b/libs/variant/test/const_ref_apply_visitor.cpp
-@@ -224,6 +224,44 @@ void test_cpp14_visitor(const variant_type& test_var, const variant_type& test_v
+@@ -217,6 +217,44 @@ void test_cpp14_visitor(const variant_ty
  #endif
  }
  
@@ -114,7 +100,7 @@ index 0ec77bd4..72afff9e 100644
  void test_cpp14_visitor(variant_type&& test_var)
  {
      std::cout << "Testing rvalue visitable for c++14\n";
-@@ -344,8 +382,14 @@ void run_cpp14_mixed_tests()
+@@ -333,8 +371,14 @@ void run_cpp14_mixed_tests()
  void run_cpp14_tests()
  {
  #ifndef BOOST_NO_CXX14_DECLTYPE_AUTO


### PR DESCRIPTION
Maintainer: @ClaymorePT 
Compile tested: OpenWrt master r10127-3209f5ae3d x86/64

Description:
Without this, the host build picks up the site config in
/usr/share/boost-build/site-config.jam which causes a build failure on
Gentoo where a custom optimization value "none" is used.

Fixes #9152 