### PR TITLE
click: update to version 7.0

### DIFF
--- a/lang/python/click/Makefile
+++ b/lang/python/click/Makefile
@@ -5,19 +5,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=click
-PKG_VERSION:=6.7
+PKG_VERSION:=7.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/
-PKG_HASH:=f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b
-PKG_BUILD_DEPENDS:=python python3
+PKG_SOURCE:=Click-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/click
+PKG_HASH:=5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/Click-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
@@ -26,15 +25,16 @@ define Package/python3-click
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  URL:=http://github.com/mitsuhiko/click
-  TITLE:=python3-click
+  TITLE:=Click
+  URL:=https://palletsprojects.com/p/click/
   DEPENDS:=+python3-light
   VARIANT:=python3
 endef
 
 define Package/python3-click/description
-A simple wrapper around optparse for powerful command line utilities.
+  Composable command line interface toolkit
 endef
 
 $(eval $(call Py3Package,python3-click))
 $(eval $(call BuildPackage,python3-click))
+$(eval $(call BuildPackage,python3-click-src))


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master with test [hello.py](https://click.palletsprojects.com/en/7.x/).

Description:
- Change URL of the website
- Change TITLE and description
- Remove PKG_BUILD_DEPENDS, PKG_UNPACK it is not necessary
- Add src package
