### PR TITLE
zstd: Use CP instead of INSTALL_BIN

### DIFF
--- a/utils/zstd/Makefile
+++ b/utils/zstd/Makefile
@@ -2,23 +2,24 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zstd
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/facebook/zstd/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=63be339137d2b683c6d19a9e34f4fb684790e864fee13c7dd40e197a64c705c1
 
+PKG_MAINTAINER:=Amol Bhave <ambhave@fb.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
-
-include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/host-build.mk
-include $(INCLUDE_DIR)/cmake.mk
 
 PKG_BUILD_PARALLEL:=1
 HOST_BUILD_PARALLEL:=1
 CMAKE_SOURCE_SUBDIR:=build/cmake
 CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 ifeq ($(CONFIG_ZSTD_OPTIMIZE_O3),y)
 	TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS))
@@ -30,7 +31,6 @@ endif
 define Package/zstd/Default
 	SUBMENU:=Compression
 	URL:=https://github.com/facebook/zstd
-	MAINTAINER:=Amol Bhave <ambhave@fb.com>
 endef
 
 define Package/libzstd
@@ -68,12 +68,12 @@ endef
 
 define Package/libzstd/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libzstd.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libzstd.so* $(1)/usr/lib/
 endef
 
 define Package/zstd/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{unzstd,zstd,zstdcat,zstdmt} $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/{unzstd,zstd,zstdcat,zstdmt} $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,libzstd))


### PR DESCRIPTION
INSTALL_BIN turns symlinks into actual files, which increases the total
size for no reason.

Small Makefile cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ammubhave 
Compile tested: ramips