### PR TITLE
vim: patch security issue

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vim
 PKG_VERSION:=8.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 VIMVER:=81
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/utils/vim/patches/003-CVE-2019-12735.patch
+++ b/utils/vim/patches/003-CVE-2019-12735.patch
@@ -1,0 +1,15 @@
+--- a/src/getchar.c
++++ b/src/getchar.c
+@@ -1407,6 +1407,12 @@ openscript(
+ 	emsg(_(e_nesting));
+ 	return;
+     }
++
++    // Disallow sourcing a file in the sandbox, the commands would be executed
++    // later, possibly outside of the sandbox.
++    if (check_secure())
++	return;
++
+ #ifdef FEAT_EVAL
+     if (ignore_script)
+ 	/* Not reading from script, also don't open one.  Warning message? */


### PR DESCRIPTION
Maintainer: @ratkaj  
Compile tested: Turris Omnia (TOS4), OpenWrt master
Run tested: Turris Omnia (TOS4), OpenWrt master

Description:
This PR backports patch from [upstream](https://github.com/vim/vim/commit/53575521406739cf20bbe4e384d88e7dca11f040) for [CVE-2019-12735.](https://nvd.nist.gov/vuln/detail/CVE-2019-12735)

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>