### PR TITLE
python3-flask: update to version 1.0.3

### DIFF
--- a/lang/python/Flask/Makefile
+++ b/lang/python/Flask/Makefile
@@ -5,19 +5,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Flask
-PKG_VERSION:=1.0.2
+PKG_VERSION:=1.0.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/F/Flask
-PKG_HASH:=2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48
-PKG_BUILD_DEPENDS:=python python3
+PKG_HASH:=ad7c6d841e64296b962296c2c2dabc6543752985727af86a975072dea984b6f3
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
@@ -26,8 +23,8 @@ define Package/python3-flask
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  URL:=http://github.com/pallets/flask/
   TITLE:=python3-flask
+  URL:=https://github.com/pallets/flask/
   DEPENDS:=+python3-asyncio +python3-click +python3-codecs +python3-decimal \
            +python3-itsdangerous +python3-jinja2 +python3 +python3-logging \
            +python3-markupsafe +python3-multiprocessing +python3-setuptools \


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: Turris Omnia (TOS4), OpenWrt master
Run tested: Turris Omnia (TOS4), OpenWrt master

Description:
Update Flask to version 1.0.3  Part of update is also small Makefile cleanup.

Tested with Hello world example http://flask.pocoo.org/docs/1.0/quickstart/

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>