### PR TITLE
dnsdist: Move into IP Adresses and Names

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -40,8 +40,9 @@ endchoice
 endef
 
 define Package/dnsdist
-  SECTION:=base
+  SECTION:=net
   CATEGORY:=Network
+  SUBMENU:=IP Addresses and Names
   TITLE:=dnsdist DNS-, DOS- and abuse-aware loadbalancer
   DEPENDS:=+DNSDIST_OPENSSL:libopenssl +DNSDIST_GNUTLS:libgnutls +protobuf +re2 +libedit +libfstrm +libsodium +lua +boost +libnetsnmp +libatomic
   URL:=https://dnsdist.org/


### PR DESCRIPTION
Maintainer: me

Description:
Moving the DNSDIST package into the IP Addresses and Names subcategory under Network. This will make it easier to find since it will be with other DNS tools.

Signed-off-by: James Taylor <james@jtaylor.id.au>