### PR TITLE
unbound: fix library double packing

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
 PKG_VERSION:=1.9.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound
@@ -221,7 +221,7 @@ Package/unbound-daemon-heavy/install = $(Package/unbound-daemon/install)
 
 define Package/libunbound/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libunbound.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libunbound.so.* $(1)/usr/lib/
 endef
 
 Package/libunbound-heavy/install = $(Package/libunbound/install)


### PR DESCRIPTION
Maintainer: @EricLuehrsen,
Compile tested: @Entware,
Run tested: mipsel soft float feed,
Description: pack symlink instead of library copy.

Package contents before PR:
```
$ ls -la opt/lib/*
-rw-r--r-- 1 ryzhovau ryzhovau 1035756 May 29 00:14 opt/lib/libunbound.so.8
-rw-r--r-- 1 ryzhovau ryzhovau 1035756 May 29 00:14 opt/lib/libunbound.so.8.1.1
```
after:
```
$ ls -la opt/lib/*                                                                       
lrwxrwxrwx 1 ryzhovau ryzhovau      19 Jun  6 20:17 opt/lib/libunbound.so.8 -> libunbound.so.8.1.1
-rwxr-xr-x 1 ryzhovau ryzhovau 1035756 Jun  6 20:17 opt/lib/libunbound.so.8.1.1
```