### PR TITLE
zerotier: remove ARM32 conservative CFLAGS

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
 PKG_VERSION:=1.2.12
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-3.0
 

--- a/net/zerotier/patches/0002-remove-pie.patch
+++ b/net/zerotier/patches/0002-remove-pie.patch
@@ -13,7 +13,7 @@ diff --git a/make-linux.mk b/make-linux.mk
 index 0cd955d1..add1d3ae 100644
 --- a/make-linux.mk
 +++ b/make-linux.mk
-@@ -71,11 +71,11 @@ ifeq ($(ZT_DEBUG),1)
+@@ -63,11 +63,11 @@ ifeq ($(ZT_DEBUG),1)
  	# C25519 in particular is almost UNUSABLE in -O0 even on a 3ghz box!
  node/Salsa20.o node/SHA512.o node/C25519.o node/Poly1305.o: CXXFLAGS=-Wall -O2 -g -pthread $(INCLUDES) $(DEFS)
  else

--- a/net/zerotier/patches/0003-remove-arm32-conservative-CFLAGS.patch
+++ b/net/zerotier/patches/0003-remove-arm32-conservative-CFLAGS.patch
@@ -1,0 +1,11 @@
+--- a/make-linux.mk
++++ b/make-linux.mk
+@@ -231,7 +231,7 @@ ifeq ($(ZT_OFFICIAL),1)
+ endif
+ 
+ # ARM32 hell -- use conservative CFLAGS
+-ifeq ($(ZT_ARCHITECTURE),3)
++ifeq (0,3)
+ 	ifeq ($(shell if [ -e /usr/bin/dpkg ]; then dpkg --print-architecture; fi),armel)
+ 		override CFLAGS+=-march=armv5 -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
+ 		override CXXFLAGS+=-march=armv5 -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm

--- a/net/zerotier/patches/0004-accept-external-linker-flags.patch
+++ b/net/zerotier/patches/0004-accept-external-linker-flags.patch
@@ -11,7 +11,7 @@ diff --git a/make-linux.mk b/make-linux.mk
 index 49e14f70..8e766bfb 100644
 --- a/make-linux.mk
 +++ b/make-linux.mk
-@@ -75,7 +75,7 @@ else
+@@ -67,7 +67,7 @@ else
  	override CFLAGS+=-Wall -Wno-deprecated -pthread $(INCLUDES) -DNDEBUG $(DEFS)
  	CXXFLAGS?=-O3 -fstack-protector
  	override CXXFLAGS+=-Wall -Wno-deprecated -std=c++11 -pthread $(INCLUDES) -DNDEBUG $(DEFS)


### PR DESCRIPTION
OpenWrt toolchains already use correct CFLAGS for every ARM target
There is no reason to use conservative CFLAGS now
It also causes compile error with GCC 9.1.0

Maintainer: @mwarning 
Compile tested: mvebu
Run tested: mvebu