### PR TITLE
libaio: Backport DESTDIR patch to simplify the Makefile

### DIFF
--- a/libs/libaio/Makefile
+++ b/libs/libaio/Makefile
@@ -9,18 +9,19 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libaio
 PKG_VERSION:=0.3.111
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://releases.pagure.org/libaio
 PKG_HASH:=62cf871ad8fd09eb3418f00aca7a7d449299b8e1de31c65f28bf6a2ef1fa502a
+
 PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
-PKG_LICENSE:=LGPL-2.1
+PKG_LICENSE:=LGPL-2.1-only
+PKG_LICENSE_FILES:=COPYING
 
-PKG_ASLR_PIE:=1
 PKG_BUILD_PARALLEL:=1
-
 PKG_USE_MIPS16:=0
+PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -29,24 +30,6 @@ define Package/libaio
   CATEGORY:=Libraries
   TITLE:=Linux kernel AIO interface access library
   URL:=http://lse.sourceforge.net/io/aio.html
-endef
-
-define Build/Configure
-endef
-
-LIBAIO_CFLAGS:=-nostdlib -nostartfiles -I. $(TARGET_CFLAGS) $(TARGET_CPPFLAGS) $(FPIC)
-
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		$(TARGET_CONFIGURE_OPTS) \
-		ARCH="$(ARCH)" \
-		CC="$(TARGET_CROSS)gcc" \
-		LD="$(TARGET_CROSS)ld" \
-		CFLAGS="$(LIBAIO_CFLAGS)" \
-		all
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		prefix="$(PKG_INSTALL_DIR)/usr" \
-		install
 endef
 
 define Build/InstallDev

--- a/libs/libaio/patches/005_destdir.patch
+++ b/libs/libaio/patches/005_destdir.patch
@@ -1,0 +1,34 @@
+From 4059161333a14a0c705efecc5765b6cb2a29ae02 Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Oct 22 2018 18:43:14 +0000
+Subject: Makefile: add missing DESTDIR variable use
+
+
+Patch borrowed from OpenEmbedded, available at
+recipes/libaio/libaio-0.3.106/destdir.patch in their source tree.
+
+It just adds support for the traditional DESTDIR variable to install
+the library in a different sysroot than the normal /.
+
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+[JEM: I couldn't verify the initial author of this change, but it's
+ trivial.  For information on the DESTDIR convention, see:
+ https://www.gnu.org/prep/standards/html_node/DESTDIR.html]
+Signed-off-by: Jeff Moyer <jmoyer@redhat.com>
+
+---
+
+diff --git a/Makefile b/Makefile
+index e9dbdb0..c1fb831 100644
+--- a/Makefile
++++ b/Makefile
+@@ -14,7 +14,7 @@ all:
+ 	@$(MAKE) -C src
+ 
+ install:
+-	@$(MAKE) -C src install prefix=$(prefix) includedir=$(includedir) libdir=$(libdir)
++	@$(MAKE) -C src install prefix=$(DESTDIR)$(prefix) includedir=$(DESTDIR)$(includedir) libdir=$(DESTDIR)$(libdir)
+ 
+ check:
+ 	@$(MAKE) -C harness check
+


### PR DESCRIPTION
Fixes issue where OpenWrt CFLAGS like relro were not being passed.

Updated license information.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @sbyx 
Compile tested: powerpc_8540