### PR TITLE
ffmpeg: install ffserver and ffprobe when using custom versions

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=3.4.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
@@ -752,10 +752,14 @@ define Package/ffprobe/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ffprobe $(1)/usr/bin/
 endef
 
+Package/ffprobe-custom/install = $(Package/ffprobe/install)
+
 define Package/ffserver/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ffserver $(1)/usr/bin/
 endef
+
+Package/ffserver-custom/install = $(Package/ffserver/install)
 
 define Package/libffmpeg-custom/install
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
Maintainer: me & @thess 
Compile tested: arm/mvebu at openwrt HEAD
Run tested: n/a; verified ipk contents

Description:
When compiling ffserver-custom and ffprobe-custom, it was not being installed into device's filesystem. Correct that. Resolves #9157.