### PR TITLE
getdns: fix library double packing (18.06 branch)

### DIFF
--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=getdns
 PKG_VERSION:=1.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -72,7 +72,7 @@ endef
 
 define Package/getdns/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libgetdns.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgetdns.so.* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/getdns_query $(1)/usr/sbin/getdns_query
 endef


### PR DESCRIPTION
Maintainer: @jonathanunderwood,
Compile tested: @Entware,
Run tested: mipsel soft float feed,
Description: pack symlink instead of library copy.

This is the same PR as https://github.com/openwrt/packages/pull/9173 against 18.06 branch.