### PR TITLE
python,python3: Move python-config to $(STAGING_DIR)/host

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -205,7 +205,7 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib $(1)/usr/lib/pkgconfig
-	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(2)/bin
 	$(INSTALL_DIR) $(1)/usr/lib/python$(PYTHON_VERSION)-openwrt
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/include/python$(PYTHON_VERSION) \
@@ -219,10 +219,11 @@ define Build/InstallDev
 		$(1)/usr/lib/pkgconfig
 	$(INSTALL_BIN) \
 		./files/python-config.in \
-		$(1)/usr/bin/python$(PYTHON_VERSION)-config
+		$(2)/bin/python$(PYTHON_VERSION)-config
 	$(SED) \
 		's|@EXENAME@|$(HOST_PYTHON_DIR)/bin/python$(PYTHON_VERSION)|' \
-		$(1)/usr/bin/python$(PYTHON_VERSION)-config
+		-e 's|@TARGET_PREFIX@|$(PYTHON_DIR)|' \
+		$(2)/bin/python$(PYTHON_VERSION)-config
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/_sysconfigdata.py \
 		$(1)/usr/lib/python$(PYTHON_VERSION)-openwrt/_sysconfigdatatarget.py

--- a/lang/python/python/files/python-config.in
+++ b/lang/python/python/files/python-config.in
@@ -8,8 +8,7 @@ from distutils import sysconfig
 # start changes
 host_prefix = sysconfig.PREFIX
 
-target_bin_dir = os.path.dirname(os.path.abspath(__file__))
-target_prefix = os.path.normpath(os.path.join(target_bin_dir, '..'))
+target_prefix = '@TARGET_PREFIX@'
 
 target_data_dir = os.path.join(target_prefix, 'lib', 'python' + sysconfig.get_config_var('VERSION') + '-openwrt')
 sys.path.append(target_data_dir)

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -209,7 +209,7 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib $(1)/usr/lib/pkgconfig
-	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(2)/bin
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/include/python$(PYTHON_VERSION) \
 		$(1)/usr/include/
@@ -222,7 +222,10 @@ define Build/InstallDev
 		$(1)/usr/lib/pkgconfig
 	$(INSTALL_BIN) \
 		$(PKG_INSTALL_DIR)/usr/bin/python$(PYTHON_VERSION)-config \
-		$(1)/usr/bin/
+		$(2)/bin/
+	$(SED) \
+		's|^prefix_real=.*$$$$|prefix_real="$(PYTHON3_DIR)"|' \
+		$(2)/bin/python$(PYTHON_VERSION)-config
 endef
 
 PYTHON3_BASE_LIB_FILES:= \


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2019-06-07 snapshot sdk
Run tested: ran python[3]-config manually

Description:
`Build/InstallDev` is passed a second argument, a path where host binaries should be placed (ultimately `$(STAGING_DIR)/host`).

This change moves python[3]-config to that directory.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>