### PR TITLE
net: dhcpcd: bump to 7.2.2

### DIFF
--- a/net/dhcpcd/Makefile
+++ b/net/dhcpcd/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dhcpcd
-PKG_VERSION:=7.0.8
+PKG_VERSION:=7.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=ftp://roy.marples.name/pub/dhcpcd \
     http://roy.marples.name/downloads/dhcpcd
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=96968e883369ab4afd11eba9dfd9bb109f5dfff65b2814ce6c432f36362dc9b5
+PKG_HASH:=3db7ff18cba9274da1d2176fb3c7cbe23926a8e58d5c8e244ad55c62d38ba09e
 
 PKG_LICENSE:=BSD-2c
 PKG_LICENSE_FILES:=


### PR DESCRIPTION
Maintainer: me / @ratkaj 
Compile tested: OpenWrt master, mvebu, wrt1200ac
Run tested: OpenWrt master, mvebu, wrt1200ac

Description:
Version bump from 7.0.8 to 7.2.2

Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>