### PR TITLE
utils: sysstat: bump to 12.0.5

### DIFF
--- a/utils/sysstat/Makefile
+++ b/utils/sysstat/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sysstat
-PKG_VERSION:=12.0.2
-PKG_RELEASE:=2
+PKG_VERSION:=12.0.5
+PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://pagesperso-orange.fr/sebastien.godard/
-PKG_HASH:=2d30947c8fabbb5015c229fbc149f2891db4926cdf165e5f099310795d8dac80
+PKG_HASH:=58583b0776b9addec69e42eebd6dd1a8e976da8a36bad2422659a1ad6c1a2600
 
 PKG_INSTALL:=1
 

--- a/utils/sysstat/patches/100-musl-compat.patch
+++ b/utils/sysstat/patches/100-musl-compat.patch
@@ -1,6 +1,6 @@
 --- a/sa_common.c
 +++ b/sa_common.c
-@@ -28,6 +28,7 @@
+@@ -29,6 +29,7 @@
  #include <dirent.h>
  #include <fcntl.h>
  #include <libgen.h>


### PR DESCRIPTION
Maintainer: me / @ratkaj 
Compile tested: OpenWrt master, mvebu, wrt1200ac
Run tested: OpenWrt master, mvebu, wrt1200ac

Description:
Version bump from 12.0.2 to 12.0.5

Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>