### PR TITLE
ruamel-yaml: update to version 0.15.97

### DIFF
--- a/lang/python/ruamel-yaml/Makefile
+++ b/lang/python/ruamel-yaml/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruamel-yaml
-PKG_VERSION:=0.15.94
+PKG_VERSION:=0.15.97
 PKG_RELEASE:=1
 
 PKG_SOURCE:=ruamel.yaml-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/r/ruamel.yaml/
-PKG_HASH:=0939bcb399ad037ef903d74ccf2f8a074f06683bc89133ad19305067d34487c8
+PKG_HASH:=17dbf6b7362e7aee8494f7a0f5cffd44902a6331fe89ef0853b855a7930ab845
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-ruamel.yaml-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:

- update to version [0.15.97](https://bitbucket.org/ruamel/yaml/src/default/CHANGES)