### PR TITLE
golang: Add the ability to custom build environment

### DIFF
--- a/lang/golang/golang-package.mk
+++ b/lang/golang/golang-package.mk
@@ -147,7 +147,7 @@ define GoPackage/GoSubMenu
   CATEGORY:=Languages
 endef
 
-define GoPackage/Environment
+define GoPackage/Environment/Default
 	GOOS=$(GO_OS) \
 	GOARCH=$(GO_ARCH) \
 	GO386=$(GO_386) \
@@ -159,6 +159,8 @@ define GoPackage/Environment
 	CGO_CPPFLAGS="$(TARGET_CPPFLAGS)" \
 	CGO_CXXFLAGS="$(filter-out $(GO_CFLAGS_TO_REMOVE),$(TARGET_CXXFLAGS))"
 endef
+
+GoPackage/Environment=$(call GoPackage/Environment/Default,)
 
 # false if directory does not exist
 GoPackage/is_dir_not_empty=$$$$($(FIND) $(1) -maxdepth 0 -type d \! -empty 2>/dev/null)


### PR DESCRIPTION
by overwrite the GoPackage/Environment definition

Signed-off-by: Xingwang Liao <kuoruan@gmail.com>

Maintainer: Jeffery To <jeffery.to@gmail.com>
Compile tested: x86_64
Run tested: x86_64

Description:
There are some other Go environment such as GOPROXY, we need a way to define it.