### PR TITLE
syslog-ng: improve init and fix service stop

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.21.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=LGPL-2.1+

--- a/admin/syslog-ng/files/syslog-ng.init
+++ b/admin/syslog-ng/files/syslog-ng.init
@@ -1,5 +1,5 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2006-2016 OpenWrt.org
+# Copyright (C) 2006-2019 OpenWrt.org
 
 START=50
 
@@ -8,11 +8,6 @@ USE_PROCD=1
 start_service() {
 	[ -f /etc/syslog-ng.conf ] || return 1
 	procd_open_instance
-	procd_set_param command /usr/sbin/syslog-ng
+	procd_set_param command /usr/sbin/syslog-ng --foreground
 	procd_close_instance
-}
-
-reload_service() {
-        stop
-        start
 }


### PR DESCRIPTION
Maintainer: @BKPepe 
Compile tested:
Run tested: Turris Mox/Omnia

Description:
This fixes service stop. Problem was that in default syslog-ng forks to
background which causes procd to loose track of it. It no longer has in
such case PID of syslog-ng process and is unable to stop it. This means
that instance for such process hangs in procd and also it is not
possible to stop it as daemon. Fix is simple. syslog-ng is now
instructed to run in foreground.

This commit also drops unnecessary reload section. In default reload
calls restart and restart in default is implemented as calling stop and
start. This means that effectively it is implemented same as in case of
this init reload service implementation.