### PR TITLE
newt: Update python3-config path

### DIFF
--- a/libs/newt/Makefile
+++ b/libs/newt/Makefile
@@ -89,7 +89,7 @@ CONFIGURE_ARGS+= \
 	--without-gpm-support \
 	--with-colorsfile=/etc/newt/palette
 
-MAKE_VARS+= PYTHON_CONFIG_PATH="$(STAGING_DIR)/usr/bin"
+MAKE_VARS+= PYTHON_CONFIG_PATH="$(STAGING_DIR)/host/bin"
 
 Build/Compile=$(call Build/Compile/Default,)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: armvirt-64, 2019-06-07 snapshot sdk
Run tested: none

Description:
The path where python3-config is installed was changed in 64959a1d. This updates that path for this package.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
