### PR TITLE
scripts: add python-maintainer

### DIFF
--- a/scripts/python-maintainer/README.md
+++ b/scripts/python-maintainer/README.md
@@ -1,0 +1,52 @@
+# pip package to OpenWrt porter
+
+This tools helps maintainers of Python packages which are also available within
+`pip` to port and update them as OpenWrt packages.
+
+Below an example configuration porting multiple packages to OpenWrt.
+
+```json
+{
+    "maintainer": "Paul Spooren <mail@aparcar.org>",
+    "packages": {
+        "pytest": {
+            "depends": "+python3 +python3-py +python3-attrs +python3-six +python3-pluggy +python3-zipp +python3-more-itertools +python3-setuptools"
+        },
+        "py": {},
+        "attrs": {},
+        "six": {},
+        "pluggy": {},
+        "zipp": {},
+        "more-itertools": {}
+    }
+}
+```
+
+## Configuration
+
+Must be a `dict` containing the `maintainer` string and a sub-`dict` called
+`packages`. Each *package* supports `depends` which is a string added to
+`DEPENDS:=` as well as `openwrt_name` which renames the package, if unset the
+ouput is `python3-<pkg_name>`.
+
+## Requirements
+
+```sh
+python3 -m pip install jinja2
+```
+
+## Run
+
+Running the script overwrites all existing packages with the same name,
+therefore also usable to upgrade existing packages.
+
+```sh
+python3 generate_python_package.py -c config.json -o ~/src/packages/lang/python/
+```
+
+## Credits
+
+* Script was created by @lynxis
+* Updated to Python3 by @aparcar
+* pypi CLI is by Steven Loria
+

--- a/scripts/python-maintainer/generate_python_package.py
+++ b/scripts/python-maintainer/generate_python_package.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import pypi_cli
+from jinja2 import Template
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-o", "--output", help="output directory",
+                    default="feeds")
+parser.add_argument("-c", "--config", help="config json file")
+parser.add_argument("-v", "--verbose", help="verbose")
+args = parser.parse_args()
+
+with open(args.config, "r") as config_file:
+    config = json.load(config_file)
+
+localdir = os.path.dirname(os.path.abspath(__file__))
+template = open(localdir + '/makefile_template.jinja2').read()
+target_dir = args.output
+
+try:
+    os.mkdir(target_dir)
+except FileExistsError:
+    pass
+
+# generate template
+templ = Template(template)
+
+class NoVersionFound(RuntimeError):
+    pass
+
+def get_release_info(release, ver):
+    """ data -> release_data - containing a list of tuple
+    """
+
+    for release in release:
+        # check if this is the correct version
+        if release[0] != ver:
+            continue
+
+        # correct version found
+        # search for source
+        for sub in release[1]:
+            if sub['python_version'] == 'source':
+                return sub
+
+    raise NoVersionFound("Not found")
+
+def make_package(pkg, config, maintainer):
+    if 'openwrt_name' in config:
+        openwrt_name = config['openwrt_name']
+    else:
+        openwrt_name = 'python3-' + pkg
+
+    pkg_dir = target_dir + '/' + openwrt_name
+
+    # create directory
+    try:
+        os.mkdir(pkg_dir)
+    except FileExistsError:
+        pass
+
+    # prepare render variables
+    pypi = pypi_cli.Package(pkg)
+    print(str(pypi))
+    version = pypi.data['info']['version']
+
+    release_info = get_release_info(pypi.release_info, version)
+
+    render = {}
+    render['input'] = "%s: %s" % (pkg, config)
+    render['openwrt_name'] = openwrt_name
+    render['package'] = pypi.name
+    render['version'] = version
+
+    render['sha256'] = release_info['digests']['sha256']
+    render['filename'] = release_info['filename']
+    render['maintainer'] = maintainer
+    render['first_char'] = pypi.name[0]
+    render['license'] = pypi.license
+    render['description'] = pypi.summary
+    render['depends'] = ''
+    if 'depends' in config:
+        render['depends'] = config['depends']
+
+    render['is_egg'] = True
+    if 'egg' in config:
+        render['is_egg'] = config['egg']
+
+    # write out template
+    with open(pkg_dir + '/Makefile', 'w') as makefile:
+        makefile.write(templ.render(render))
+
+for pkg in config["packages"]:
+    print("Package: %s" % pkg)
+    make_package(pkg, config["packages"][pkg], config["maintainer"])

--- a/scripts/python-maintainer/makefile_template.jinja2
+++ b/scripts/python-maintainer/makefile_template.jinja2
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:={{ openwrt_name }}
+PKG_VERSION:={{ version }}
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:={{ maintainer }}
+PKG_LICENSE:={{ license }}
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:={{ filename }}
+PKG_SOURCE_URL:=https://pypi.python.org/packages/source/{{ first_char }}/{{ package }}/
+PKG_HASH:={{ sha256 }}
+PKG_BUILD_DIR:=$(BUILD_DIR)/{{ package }}-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:={{ openwrt_name }}
+  URL:=http://pypi.python.org/{{ package }}
+  DEPENDS:=+python3-light {{ depends }}
+  VARIANT:=python3
+endef
+
+define Package/$(PKG_NAME)/description
+	{{ description }}
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)-src))

--- a/scripts/python-maintainer/pypi_cli.py
+++ b/scripts/python-maintainer/pypi_cli.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2014 Steven Loria
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+    pypi_cli
+    ~~~~~~~~
+
+    A command line interface to the Python Package Index.
+
+    :copyright: (c) 2014 by Steven Loria.
+    :license: MIT, see LICENSE for more details.
+"""
+from __future__ import division, print_function
+import re
+import sys
+import time
+import textwrap
+import math
+from collections import OrderedDict
+PY2 = int(sys.version[0]) == 2
+if PY2:
+    from xmlrpclib import ServerProxy
+    from urllib import quote as urlquote
+else:
+    from xmlrpc.client import ServerProxy
+    from urllib.parse import quote as urlquote
+
+import requests
+
+__version__ = '0.4.1'
+__author__ = 'Steven Loria'
+__license__ = 'MIT'
+
+DATE_FORMAT = "%y/%m/%d"
+MARGIN = 3
+DEFAULT_SEARCH_RESULTS = 100
+
+TICK = '*'
+DEFAULT_PYPI = 'https://pypi.python.org/pypi'
+PYPI_RE = re.compile('''^(?:(?P<pypi>https?://[^/]+/pypi)/)?
+                        (?P<name>[-A-Za-z0-9_.]+)
+                        (?:/(?P<version>[-A-Za-z0-9.]+))?$''', re.X)
+SEARCH_URL = 'https://pypi.python.org/pypi?%3Aaction=search&term={query}'
+
+# Number of characters added by bold formatting
+_BOLD_LEN = 8
+# Number of characters added by color formatting
+_COLOR_LEN = 9
+
+def get_package(name_or_url, client=None):
+    m = PYPI_RE.match(name_or_url)
+    if not m:
+        return None
+    pypi_url = m.group('pypi') or DEFAULT_PYPI
+    name = m.group('name')
+    return Package(name, pypi_url=pypi_url, client=client)
+
+# Utilities
+# #########
+
+def lazy_property(fn):
+    """Decorator that makes a property lazy-evaluated."""
+    attr_name = '_lazy_' + fn.__name__
+
+    @property
+    def _lazy_property(self):
+        if not hasattr(self, attr_name):
+            setattr(self, attr_name, fn(self))
+        return getattr(self, attr_name)
+    return _lazy_property
+
+class PackageError(Exception):
+    pass
+
+
+class NotFoundError(PackageError):
+    pass
+
+
+# API Wrapper
+# ###########
+
+class Package(object):
+
+    def __init__(self, name, client=None, pypi_url=DEFAULT_PYPI):
+        self.client = client or requests.Session()
+        self.name = name
+        self.url = '{pypi_url}/{name}/json'.format(pypi_url=pypi_url,
+                                                   name=name)
+
+    @lazy_property
+    def data(self):
+        resp = self.client.get(self.url)
+        if resp.status_code == 404:
+            raise NotFoundError('Package not found')
+        return resp.json()
+
+    @lazy_property
+    def versions(self):
+        """Return a list of versions, sorted by release datae."""
+        return [k for k, v in self.release_info]
+
+    @lazy_property
+    def version_downloads(self):
+        """Return a dictionary of version:download_count pairs."""
+        ret = OrderedDict()
+        for release, info in self.release_info:
+            download_count = sum(file_['downloads'] for file_ in info)
+            ret[release] = download_count
+        return ret
+
+    @property
+    def release_info(self):
+        release_info = self.data['releases']
+        # filter out any versions that have no releases
+        filtered = [(ver, releases) for ver, releases in release_info.items()
+                    if len(releases) > 0]
+        # sort by first upload date of each release
+        return sorted(filtered, key=lambda x: x[1][0]['upload_time'])
+
+    @lazy_property
+    def downloads(self):
+        """Total download count.
+
+        :return: A tuple of the form (version, n_downloads)
+        """
+        return sum(self.version_downloads.values())
+
+    @lazy_property
+    def max_version(self):
+        """Version with the most downloads.
+
+        :return: A tuple of the form (version, n_downloads)
+        """
+        data = self.version_downloads
+        if not data:
+            return None, 0
+        return max(data.items(), key=lambda item: item[1])
+
+    @lazy_property
+    def min_version(self):
+        """Version with the fewest downloads."""
+        data = self.version_downloads
+        if not data:
+            return (None, 0)
+        return min(data.items(), key=lambda item: item[1])
+
+    @lazy_property
+    def average_downloads(self):
+        """Average number of downloads."""
+        return int(self.downloads / len(self.versions))
+
+    @property
+    def author(self):
+        return self.data['info'].get('author')
+
+    @property
+    def description(self):
+        return self.data['info'].get('description')
+
+    @property
+    def summary(self):
+        return self.data['info'].get('summary')
+
+    @property
+    def author_email(self):
+        return self.data['info'].get('author_email')
+
+    @property
+    def maintainer(self):
+        return self.data['info'].get('maintainer')
+
+    @property
+    def maintainer_email(self):
+        return self.data['info'].get('maintainer_email')
+
+    @property
+    def license(self):
+        return self.data['info'].get('license')
+
+    @property
+    def downloads_last_day(self):
+        return self.data['info']['downloads']['last_day']
+
+    @property
+    def downloads_last_week(self):
+        return self.data['info']['downloads']['last_week']
+
+    @property
+    def downloads_last_month(self):
+        return self.data['info']['downloads']['last_month']
+
+    @property
+    def package_url(self):
+        return self.data['info']['package_url']
+
+    @property
+    def home_page(self):
+        return self.data['info'].get('home_page')
+
+    @property
+    def docs_url(self):
+        return self.data['info'].get('docs_url')
+
+    def __repr__(self):
+        return '<Package(name={0!r})>'.format(self.name)
+


### PR DESCRIPTION
This script allows to easily add and updated packages to OpenWrt which
are also available via `pip`. A template is used to create `Makefiles`
and `pypi_cli.py` automatically fetches checksum and latest version.

Signed-off-by: Paul Spooren <mail@aparcar.org>
