### PR TITLE
luajit: fix building for 64-bit targets

### DIFF
--- a/lang/luajit/Makefile
+++ b/lang/luajit/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luajit
 PKG_VERSION:=2.1.0-beta3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=LuaJIT-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://luajit.org/download
@@ -24,7 +24,7 @@ define Package/luajit
  CATEGORY:=Languages
  TITLE:=LuaJIT
  URL:=https://www.luajit.org
- DEPENDS:=@(i386||x86_64||arm||armeb||powerpc||mips||mipsel)
+ DEPENDS:=@(i386||x86_64||arm||armeb||aarch64||powerpc||mips||mipsel)
 endef
 
 define Package/luajit/description
@@ -32,7 +32,7 @@ define Package/luajit/description
 endef
 
 ifeq ($(HOST_ARCH),x86_64)
-  ifeq ($(CONFIG_x86_64),)
+  ifeq ($(CONFIG_ARCH_64BIT),)
     HOST_BITS := -m32
   endif
 endif


### PR DESCRIPTION
Host and target architectures need to have the same pointer size.
When building on x86_64, do not force 32-bit host binaries if the target
architecture is also 64-bit.

See http://luajit.org/install.html#cross

Add 64-bit arm (aarch64) to the list of architectures.

Signed-off-by: Eric Kinzie <ekinzie@labn.net>

Maintainer: @milani 
Compile tested: x86, generic, current master
Run tested: aarch64, cortex-a53, current master

Description: Cross-compile luajit for 64-bit targets
