### PR TITLE
itsdangerous: Makefile polishing

### DIFF
--- a/lang/python/itsdangerous/Makefile
+++ b/lang/python/itsdangerous/Makefile
@@ -6,18 +6,15 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=itsdangerous
 PKG_VERSION:=1.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/i/itsdangerous
 PKG_HASH:=321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19
-PKG_BUILD_DEPENDS:=python python3
+
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
@@ -26,15 +23,17 @@ define Package/python3-itsdangerous
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  URL:=http://github.com/mitsuhiko/itsdangerous
-  TITLE:=python3-itsdangerous
+  TITLE:=ItsDangerous
+  URL:=https://palletsprojects.com/p/itsdangerous/
   DEPENDS:=+python3-light
   VARIANT:=python3
 endef
 
 define Package/python3-itsdangerous/description
-Various helpers to pass trusted data to untrusted environments and back.
+  Various helpers to pass trusted data to untrusted environments and back.
 endef
 
 $(eval $(call Py3Package,python3-itsdangerous))
 $(eval $(call BuildPackage,python3-itsdangerous))
+$(eval $(call BuildPackage,python3-itsdangerous-src))
+


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master with [example](https://palletsprojects.com/p/itsdangerous/) on their website

Description:
- Makefile polishing
Removed: PKG_UNPACK, PKG_BUILD_DIR, PKG_BUILD_DEPENDS