### PR TITLE
python-markdown: add a new package

### DIFF
--- a/lang/python/python-markdown/Makefile
+++ b/lang/python/python-markdown/Makefile
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-markdown
+PKG_VERSION:=3.1.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=Markdown-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/m/markdown/
+PKG_HASH:=2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/Markdown-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE.md
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-markdown
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Markdown implementation in Python
+  URL:=https://python-markdown.github.io/
+  DEPENDS:= \
+	+python3-light \
+	+python3-setuptools \
+	+python3-logging
+  VARIANT:=python3
+endef
+
+define Package/python3-markdown/description
+  A fast and complete Python implementation of Markdown.
+endef
+
+$(eval $(call Py3Package,python3-markdown))
+$(eval $(call BuildPackage,python3-markdown))
+$(eval $(call BuildPackage,python3-markdown-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master with example in their [documentation](https://python-markdown.github.io/cli/)

Description:

- add [python-markdown](https://pypi.org/project/Markdown/)

About python3-setuptools dependency:
If I didn't have installed Python3 on the router and when I just installed this package, then it says:
```
root@turris:~# opkg install python3-markdown_3.1.1-3.7-1_aarch64_cortex-a53.ipk 
Configuring python3-base.
Configuring python3-light.
Configuring python3-markdown.
root@turris:~# python3
Python 3.7.2 (default, Jun 11 2019, 00:02:42) 
[GCC 7.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import markdown
Traceback (most recent call last):
  File "/util.py", line 98, in <module>
ModuleNotFoundError: No module named 'xml.etree.cElementTree'

```
Then:
`AttributeError: module 'logging' has no attribute 'getLogger'` as well with `ModuleNotFoundError: No module named 'packaging'`

Also, setuptools is mention in their [setup.py](https://github.com/Python-Markdown/markdown/blob/master/setup.py#L98) as install_requires.

In any case, I would appreciate when @commodo and @jefferyto will look at it.