### PR TITLE
[18.06]haproxy: Remove unnecessary OpenSSL depends

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
 PKG_VERSION:=1.8.4
-PKG_RELEASE:=01
+PKG_RELEASE:=02
 
 PKG_SOURCE:=haproxy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/1.8/src/
@@ -53,7 +53,7 @@ define Package/haproxy/Default/description
 endef
 
 define Package/haproxy
-  DEPENDS+= +libpcre +libltdl +zlib +libpthread +libopenssl +libncursesw +libreadline +libatomic +@OPENSSL_WITH_DEPRECATED +@OPENSSL_WITH_EC +@OPENSSL_WITH_EC2M  +@OPENSSL_WITH_DTLS +@OPENSSL_WITH_COMPRESSION +@OPENSSL_WITH_NPN  +@OPENSSL_WITH_PSK +@OPENSSL_WITH_SRP +@OPENSSL_ENGINE_DIGEST +@OPENSSL_ENGINE_CRYPTO
+  DEPENDS+= +libpcre +libltdl +zlib +libpthread +libopenssl +libncursesw +libreadline +libatomic +@OPENSSL_WITH_COMPRESSION +@OPENSSL_WITH_DTLS +@OPENSSL_ENGINE_CRYPTO
 
   TITLE+= (with SSL support)
   VARIANT:=ssl

--- a/net/haproxy/patches/0004-BUG-MEDIUM-ssl-sample-ssl_bc_-fetch-keywords-are-broken.patch
+++ b/net/haproxy/patches/0004-BUG-MEDIUM-ssl-sample-ssl_bc_-fetch-keywords-are-broken.patch
@@ -18,7 +18,7 @@ diff --git a/src/ssl_sock.c b/src/ssl_sock.c
 index 4d0d5db..d832d76 100644
 --- a/src/ssl_sock.c
 +++ b/src/ssl_sock.c
-@@ -6580,8 +6580,8 @@ smp_fetch_ssl_x_key_alg(const struct arg *args, struct sample *smp, const char *
+@@ -6565,8 +6565,8 @@ smp_fetch_ssl_x_key_alg(const struct arg *args, struct sample *smp, const char *
  static int
  smp_fetch_ssl_fc(const struct arg *args, struct sample *smp, const char *kw, void *private)
  {
@@ -29,7 +29,7 @@ index 4d0d5db..d832d76 100644
  
  	smp->data.type = SMP_T_BOOL;
  	smp->data.u.sint = (conn && conn->xprt == &ssl_sock);
-@@ -6625,8 +6625,8 @@ smp_fetch_ssl_fc_is_resumed(const struct arg *args, struct sample *smp, const ch
+@@ -6610,8 +6610,8 @@ smp_fetch_ssl_fc_is_resumed(const struct arg *args, struct sample *smp, const ch
  static int
  smp_fetch_ssl_fc_cipher(const struct arg *args, struct sample *smp, const char *kw, void *private)
  {
@@ -40,7 +40,7 @@ index 4d0d5db..d832d76 100644
  
  	smp->flags = 0;
  	if (!conn || !conn->xprt_ctx || conn->xprt != &ssl_sock)
-@@ -6651,9 +6651,8 @@ smp_fetch_ssl_fc_cipher(const struct arg *args, struct sample *smp, const char *
+@@ -6636,9 +6636,8 @@ smp_fetch_ssl_fc_cipher(const struct arg *args, struct sample *smp, const char *
  static int
  smp_fetch_ssl_fc_alg_keysize(const struct arg *args, struct sample *smp, const char *kw, void *private)
  {
@@ -52,7 +52,7 @@ index 4d0d5db..d832d76 100644
  	int sint;
  
  	smp->flags = 0;
-@@ -6676,8 +6675,8 @@ smp_fetch_ssl_fc_alg_keysize(const struct arg *args, struct sample *smp, const c
+@@ -6661,8 +6660,8 @@ smp_fetch_ssl_fc_alg_keysize(const struct arg *args, struct sample *smp, const c
  static int
  smp_fetch_ssl_fc_use_keysize(const struct arg *args, struct sample *smp, const char *kw, void *private)
  {
@@ -63,7 +63,7 @@ index 4d0d5db..d832d76 100644
  
  	smp->flags = 0;
  	if (!conn || !conn->xprt_ctx || conn->xprt != &ssl_sock)
-@@ -6747,8 +6746,8 @@ smp_fetch_ssl_fc_alpn(const struct arg *args, struct sample *smp, const char *kw
+@@ -6732,8 +6731,8 @@ smp_fetch_ssl_fc_alpn(const struct arg *args, struct sample *smp, const char *kw
  static int
  smp_fetch_ssl_fc_protocol(const struct arg *args, struct sample *smp, const char *kw, void *private)
  {
@@ -74,7 +74,7 @@ index 4d0d5db..d832d76 100644
  
  	smp->flags = 0;
  	if (!conn || !conn->xprt_ctx || conn->xprt != &ssl_sock)
-@@ -6773,9 +6772,8 @@ static int
+@@ -6758,9 +6757,8 @@ static int
  smp_fetch_ssl_fc_session_id(const struct arg *args, struct sample *smp, const char *kw, void *private)
  {
  #if OPENSSL_VERSION_NUMBER > 0x0090800fL
@@ -86,7 +86,7 @@ index 4d0d5db..d832d76 100644
  	SSL_SESSION *ssl_sess;
  
  	smp->flags = SMP_F_CONST;
-@@ -6917,9 +6915,8 @@ static int
+@@ -6902,9 +6900,8 @@ static int
  smp_fetch_ssl_fc_unique_id(const struct arg *args, struct sample *smp, const char *kw, void *private)
  {
  #if OPENSSL_VERSION_NUMBER > 0x0090800fL

--- a/net/haproxy/patches/012-deprecated-openssl.patch
+++ b/net/haproxy/patches/012-deprecated-openssl.patch
@@ -1,0 +1,107 @@
+--- a/src/ssl_sock.c
++++ b/src/ssl_sock.c
+@@ -39,6 +39,7 @@
+ #include <netdb.h>
+ #include <netinet/tcp.h>
+ 
++#include <openssl/bn.h>
+ #include <openssl/crypto.h>
+ #include <openssl/ssl.h>
+ #include <openssl/x509.h>
+@@ -61,6 +62,17 @@
+ #include <openssl/async.h>
+ #endif
+ 
++#ifndef OPENSSL_VERSION
++#define OPENSSL_VERSION		SSLEAY_VERSION
++#define OpenSSL_version(x)	SSLeay_version(x)
++#define OpenSSL_version_num	SSLeay
++#endif
++
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#define X509_getm_notBefore X509_get_notBefore
++#define X509_getm_notAfter X509_get_notAfter
++#endif
++
+ #include <import/lru.h>
+ #include <import/xxhash.h>
+ 
+@@ -206,7 +218,7 @@ static struct {
+ 	.capture_cipherlist = 0,
+ };
+ 
+-#ifdef USE_THREAD
++#if defined(USE_THREAD) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
+ 
+ static HA_RWLOCK_T *ssl_rwlocks;
+ 
+@@ -1675,8 +1687,8 @@ ssl_sock_do_create_cert(const char *servername, struct bind_conf *bind_conf, SSL
+ 	ASN1_INTEGER_set(X509_get_serialNumber(newcrt), HA_ATOMIC_ADD(&ssl_ctx_serial, 1));
+ 
+ 	/* Set duration for the certificate */
+-	if (!X509_gmtime_adj(X509_get_notBefore(newcrt), (long)-60*60*24) ||
+-	    !X509_gmtime_adj(X509_get_notAfter(newcrt),(long)60*60*24*365))
++	if (!X509_gmtime_adj(X509_getm_notBefore(newcrt), (long)-60*60*24) ||
++	    !X509_gmtime_adj(X509_getm_notAfter(newcrt),(long)60*60*24*365))
+ 		goto mkcert_error;
+ 
+ 	/* set public key in the certificate */
+@@ -6226,7 +6238,7 @@ smp_fetch_ssl_x_notafter(const struct arg *args, struct sample *smp, const char
+ 		goto out;
+ 
+ 	smp_trash = get_trash_chunk();
+-	if (ssl_sock_get_time(X509_get_notAfter(crt), smp_trash) <= 0)
++	if (ssl_sock_get_time(X509_getm_notAfter(crt), smp_trash) <= 0)
+ 		goto out;
+ 
+ 	smp->data.u.str = *smp_trash;
+@@ -6326,7 +6338,7 @@ smp_fetch_ssl_x_notbefore(const struct arg *args, struct sample *smp, const char
+ 		goto out;
+ 
+ 	smp_trash = get_trash_chunk();
+-	if (ssl_sock_get_time(X509_get_notBefore(crt), smp_trash) <= 0)
++	if (ssl_sock_get_time(X509_getm_notBefore(crt), smp_trash) <= 0)
+ 		goto out;
+ 
+ 	smp->data.u.str = *smp_trash;
+@@ -8777,10 +8789,12 @@ static void __ssl_sock_init(void)
+ 		global_ssl.connect_default_ciphers = strdup(global_ssl.connect_default_ciphers);
+ 
+ 	xprt_register(XPRT_SSL, &ssl_sock);
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	SSL_library_init();
++#endif
+ 	cm = SSL_COMP_get_compression_methods();
+ 	sk_SSL_COMP_zero(cm);
+-#ifdef USE_THREAD
++#if defined(USE_THREAD) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
+ 	ssl_locking_init();
+ #endif
+ #if (OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined OPENSSL_NO_TLSEXT && !defined OPENSSL_IS_BORINGSSL && !defined LIBRESSL_VERSION_NUMBER)
+@@ -8808,8 +8822,8 @@ static void __ssl_sock_init(void)
+ #else /* OPENSSL_IS_BORINGSSL */
+ 	        OPENSSL_VERSION_TEXT
+ 		"\nRunning on OpenSSL version : %s%s",
+-	       SSLeay_version(SSLEAY_VERSION),
+-	       ((OPENSSL_VERSION_NUMBER ^ SSLeay()) >> 8) ? " (VERSIONS DIFFER!)" : "");
++	       OpenSSL_version(OPENSSL_VERSION),
++	       ((OPENSSL_VERSION_NUMBER ^ OpenSSL_version_num()) >> 8) ? " (VERSIONS DIFFER!)" : "");
+ #endif
+ 	memprintf(&ptr, "%s\nOpenSSL library supports TLS extensions : "
+ #if OPENSSL_VERSION_NUMBER < 0x00907000L
+@@ -8900,12 +8914,14 @@ static void __ssl_sock_deinit(void)
+ 	}
+ #endif
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+         ERR_remove_state(0);
+         ERR_free_strings();
+ 
+         EVP_cleanup();
++#endif
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x00907000L
++#if OPENSSL_VERSION_NUMBER >= 0x00907000L && OPENSSL_VERSION_NUMBER < 0x10100000L
+         CRYPTO_cleanup_all_ex_data();
+ #endif
+ }


### PR DESCRIPTION
All of these are either not needed or not valid.

Added a patch to remove the OPENSSL_WITH_DEPRECATED dependency.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @heil @gladiac1337 