### PR TITLE
python-certifi: bump to 2019.6.16

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
-PKG_VERSION:=2019.3.9
-PKG_RELEASE:=2
+PKG_VERSION:=2019.6.16
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=MPL-2.0
@@ -15,7 +15,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=certifi-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/certifi
-PKG_HASH:=b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae
+PKG_HASH:=945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-certifi-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: arm, WRT3200ACM, openwrt master
Run tested: arm, WRT3200ACM, openwrt master, run `python -m certifi`

Description:
This updates the mozilla bundle to the latest version.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>