### PR TITLE
mosquitto: backport upstream patches to fix compilation

### DIFF
--- a/net/mosquitto/Makefile
+++ b/net/mosquitto/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mosquitto
 PKG_VERSION:=1.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_CPE_ID:=cpe:/a:eclipse:mosquitto

--- a/net/mosquitto/patches/001-backport-getrandom-fix-b1298dff.patch
+++ b/net/mosquitto/patches/001-backport-getrandom-fix-b1298dff.patch
@@ -1,0 +1,21 @@
+From b1298dff5420990a14333bae952f27461982b8e4 Mon Sep 17 00:00:00 2001
+From: "Roger A. Light" <roger@atchoo.org>
+Date: Thu, 16 May 2019 15:03:40 +0100
+Subject: [PATCH] Fix use of getrandom() for Linux and WITH_TLS=no.
+
+Fix random number generation if compiling using WITH_TLS=no and on Linux
+with glibc >= 2.25. Without this fix, no random numbers would be generated
+for e.g. on broker client id generation, and so clients connecting expecting
+this feature would be unable to connect.
+
+--- a/lib/util_mosq.c
++++ b/lib/util_mosq.c
+@@ -326,7 +326,7 @@ int util__random_bytes(void *bytes, int count)
+ 		rc = MOSQ_ERR_SUCCESS;
+ 	}
+ #elif defined(__GLIBC__) && __GLIBC_PREREQ(2, 25)
+-	if(getrandom(bytes, count, 0) == 0){
++	if(getrandom(bytes, count, 0) == count){
+ 		rc = MOSQ_ERR_SUCCESS;
+ 	}
+ #elif defined(WIN32)

--- a/net/mosquitto/patches/002-backport-glibc-fix-d05bd95881.patch
+++ b/net/mosquitto/patches/002-backport-glibc-fix-d05bd95881.patch
@@ -1,0 +1,31 @@
+From d05bd958813b7ead344f66653ce9b13b00e67595 Mon Sep 17 00:00:00 2001
+From: "Roger A. Light" <roger@atchoo.org>
+Date: Thu, 16 May 2019 22:12:18 +0100
+Subject: [PATCH] Fix compilation problem related to getrandom() on non-glibc systems.
+
+Fix compilation problem related to getrandom() on non-glibc systems.
+
+--- a/lib/util_mosq.c
++++ b/lib/util_mosq.c
+@@ -28,9 +28,10 @@ and the Eclipse Distribution License is available at
+ #  include <sys/stat.h>
+ #endif
+ 
+-#if !defined(WITH_TLS) && defined(__linux__)
+-#  if defined(__GLIBC__) && __GLIBC_PREREQ(2, 25)
++#if !defined(WITH_TLS) && defined(__linux__) && defined(__GLIBC__)
++#  if __GLIBC_PREREQ(2, 25)
+ #    include <sys/random.h>
++#    define HAVE_GETRANDOM 1
+ #  endif
+ #endif
+ 
+@@ -325,7 +326,7 @@ int util__random_bytes(void *bytes, int count)
+ 	if(RAND_bytes(bytes, count) == 1){
+ 		rc = MOSQ_ERR_SUCCESS;
+ 	}
+-#elif defined(__GLIBC__) && __GLIBC_PREREQ(2, 25)
++#elif defined(HAVE_GETRANDOM)
+ 	if(getrandom(bytes, count, 0) == count){
+ 		rc = MOSQ_ERR_SUCCESS;
+ 	}


### PR DESCRIPTION
Maintainer: @karlp 

Fix compilation problems by backporting two upstream commits. Patches fix the glibc detection related compilation problems (and random number generation with glibc and without TLS).

Reference to issue #9005

Compile tested: ipq806x/R7800,  OpenWrt master
Run tested: -

Karl, any objections for applying the upstream glibc related fix that you seemed to acknowledge a month ago in #9005 ?  Mosquitto has been broken in buildbot for a month, now.  I noticed this in the collectd version update discussion, so I though to fix it to enable proper compilation of all collectd modules.

References:
bug report #9005 

Upstream discussion:
https://github.com/eclipse/mosquitto/issues/1291

Upstream commits:
https://github.com/eclipse/mosquitto/commit/d05bd958813b7ead344f66653ce9b13b00e67595
https://github.com/eclipse/mosquitto/commit/b1298dff5420990a14333bae952f27461982b8e4
