### PR TITLE
Bosst change to HOSTPKG

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.70.0
 PKG_SOURCE_VERSION:=1_70_0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/
@@ -294,16 +294,6 @@ define Package/boost/config
 		)
 	endmenu
 
-	menu "Select Boost libraries for Host build"
-		comment  "Libraries for Host build"
-
-		$(foreach lib,$(BOOST_LIBS), \
-		config boost-host-build-$(lib)
-			bool "Boost $(lib) $(if $(findstring python,$(lib)),$(paren_left)v$(if $(findstring 3,$(lib)),$(BOOST_PYTHON3_VER),$(BOOST_PYTHON_VER))$(paren_right) ,)library."
-			default n
-		)
-	endmenu
-
 endef
 
 PKG_CONFIG_DEPENDS:= CONFIG_PACKAGE_boost-test
@@ -326,7 +316,6 @@ define DefineBoostLibrary
 
   BOOST_DEPENDS+= +$(if $(4),$(4):boost-$(1),boost-$(1))
   PKG_CONFIG_DEPENDS+= CONFIG_PACKAGE_boost-$(1)
-  HOST_CONFIG_DEPENDS+= CONFIG_boost-host-build-$(1)
 
   BOOST_LIBS+= $(1)
 
@@ -379,11 +368,8 @@ define Host/Compile
 	( cd $(HOST_BUILD_DIR)/tools/build/src/engine ; ./build.sh gcc )
 
 	( cd $(HOST_BUILD_DIR) ; \
-		./bootstrap.sh --prefix=$(STAGING_DIR_HOST) \
-			--with-libraries=$(subst $() $(),$(comma),$(strip \
-				headers \
-				$(foreach lib,$(BOOST_LIBS), \
-					$(if $(findstring python,$(lib)),,$(if $(CONFIG_boost-host-build-$(lib)),$(lib)))))) ; \
+		./bootstrap.sh --prefix=$(STAGING_DIR_HOSTPKG) \
+			--with-libraries=atomic,chrono,date_time,filesystem,headers,thread,system ;\
 		./b2 --ignore-site-config install )
 endef
 

--- a/libs/fbthrift/Makefile
+++ b/libs/fbthrift/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fbthrift
 PKG_VERSION:=2019.06.10.00
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/facebook/fbthrift/tar.gz/v$(PKG_VERSION)?
@@ -12,10 +12,9 @@ PKG_MAINTAINER:=Amol Bhave <ambhave@fb.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-HOST_BUILD_DEPENDS:=boost/host libmstch/host
+HOST_BUILD_DEPENDS:=libmstch/host
 PKG_BUILD_DEPENDS:=fbthrift/host
 
-HOST_BUILD_PREFIX:=$(STAGING_DIR_HOST)
 HOST_BUILD_PARALLEL:=1
 PKG_BUILD_PARALLEL:=1
 CMAKE_INSTALL:=1
@@ -28,9 +27,7 @@ define Package/fbthrift
 	SECTION:=libs
 	CATEGORY:=Libraries
 	TITLE:=Facebook's branch of Apache Thrift, including a new C++ server.
-	DEPENDS:=+libwangle +libfmt +libmstch +librsocket-cpp \
-		+@boost-host-build-chrono +@boost-host-build-date_time +@boost-host-build-atomic \
-		+@boost-host-build-thread +@boost-host-build-system +@boost-host-build-filesystem
+	DEPENDS:=+libwangle +libfmt +librsocket-cpp
 endef
 
 define Package/fbthrift/description
@@ -39,17 +36,17 @@ endef
 
 CMAKE_HOST_OPTIONS += \
 	-DBoost_NO_BOOST_CMAKE=ON \
-	-Dcompiler_only=ON \
 	-DCMAKE_SKIP_RPATH=FALSE \
-	-DCMAKE_INSTALL_RPATH="${STAGING_DIR_HOST}/lib" \
+	-DCMAKE_INSTALL_RPATH="${STAGING_DIR_HOSTPKG}/lib" \
+	-Dcompiler_only=ON
 
 CMAKE_OPTIONS += \
 	-DBoost_NO_BOOST_CMAKE=ON \
 	-DBUILD_SHARED_LIBS=ON \
 	-DCMAKE_POSITION_INDEPENDENT_CODE=ON \
 	-Dlib_only=ON \
-	-DTHRIFT1="$(STAGING_DIR_HOST)/bin/thrift1" \
-	-DTHRIFT_COMPILER_INCLUDE="$(STAGING_DIR_HOST)/include/"
+	-DTHRIFT1="$(STAGING_DIR_HOSTPKG)/bin/thrift1" \
+	-DTHRIFT_COMPILER_INCLUDE="$(STAGING_DIR_HOSTPKG)/include/"
 
 define Package/fbthrift/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/fbzmq/Makefile
+++ b/libs/fbzmq/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fbzmq
 PKG_VERSION:=2019.06.10.00
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/facebook/fbzmq/tar.gz/v$(PKG_VERSION)?
@@ -12,6 +12,7 @@ PKG_MAINTAINER:=Amol Bhave <ambhave@fb.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
+CMAKE_SOURCE_SUBDIR:=fbzmq
 PKG_BUILD_PARALLEL:=1
 CMAKE_INSTALL:=1
 
@@ -29,13 +30,12 @@ define Package/fbzmq/description
 	Facebook ZeroMQ wrappers.
 endef
 
-CMAKE_SOURCE_SUBDIR:=fbzmq
-CMAKE_OPTIONS:= \
+CMAKE_OPTIONS += \
 	-DCMAKE_POSITION_INDEPENDENT_CODE=ON \
 	-DBUILD_TESTS=OFF \
 	-DBUILD_SHARED_LIBS=ON \
-	-DTHRIFT1="$(STAGING_DIR_HOST)/bin/thrift1" \
-	-DTHRIFT_COMPILER_INCLUDE="$(STAGING_DIR_HOST)/include/"
+	-DTHRIFT1="$(STAGING_DIR_HOSTPKG)/bin/thrift1" \
+	-DTHRIFT_COMPILER_INCLUDE="$(STAGING_DIR_HOSTPKG)/include/"
 
 define Package/fbzmq/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/libfolly/Makefile
+++ b/libs/libfolly/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libfolly
 PKG_VERSION:=2019.06.10.00
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/facebook/folly/tar.gz/v$(PKG_VERSION)?

--- a/libs/libfolly/patches/103-arm-yield.patch
+++ b/libs/libfolly/patches/103-arm-yield.patch
@@ -1,0 +1,11 @@
+--- a/folly/portability/Asm.h
++++ b/folly/portability/Asm.h
+@@ -38,7 +38,7 @@ inline void asm_volatile_pause() {
+   ::_mm_pause();
+ #elif defined(__i386__) || FOLLY_X64
+   asm volatile("pause");
+-#elif FOLLY_AARCH64 || defined(__arm__)
++#elif FOLLY_AARCH64 || (defined(__arm__) && !(__ARM_ARCH < 7))
+   asm volatile("yield");
+ #elif FOLLY_PPC64
+   asm volatile("or 27,27,27");

--- a/libs/libmstch/Makefile
+++ b/libs/libmstch/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmstch
 PKG_VERSION:=1.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/no1msd/mstch/tar.gz/$(PKG_VERSION)?
@@ -10,23 +10,17 @@ PKG_HASH:=811ed61400d4e9d4f9ae0f7679a2ffd590f0b3c06b16f2798e1f89ab917cba6c
 PKG_BUILD_DIR:=$(BUILD_DIR)/mstch-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/mstch-$(PKG_VERSION)
 
+PKG_MAINTAINER:=Amol Bhave <ambhave@fb.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
-HOST_BUILD_DEPENDS:=boost boost/host
-
-PKG_BUILD_DEPENDS:=boost
+HOST_BUILD_DEPENDS:=boost/host
+PKG_BUILD_PARALLEL:=1
+CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk
-
-HOST_BUILD_PREFIX:=$(STAGING_DIR_HOST)
-
-PKG_BUILD_PARALLEL:=1
-CMAKE_INSTALL:=1
-CMAKE_OPTIONS:= \
-	-DCMAKE_POSITION_INDEPENDENT_CODE=True
 
 define Package/libmstch
 	SECTION:=libs
@@ -34,12 +28,14 @@ define Package/libmstch
 	TITLE:=Complete implementation of {{mustache}} templates using modern C++
 	DEPENDS:=+boost +boost-container
 	URL:=https://github.com/no1msd/mstch
-	MAINTAINER:=Amol Bhave <ambhave@fb.com>
 endef
 
 define Package/libmstch/description
 	mstch is a complete implementation of {{mustache}} templates using modern C++
 endef
+
+CMAKE_OPTIONS += \
+	-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE
 
 $(eval $(call BuildPackage,libmstch))
 $(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: @ClaymorePT @ammubhave 
Compile tested: arc700

Explanation is in IRC log below.

@ammubhave I made a change to folly that fixes compilation on some older ARM platforms. Please check.

https://downloads.openwrt.org/snapshots/faillogs/arm_fa526/packages/libfolly/compile.txt

Full IRC log here:
```
10:29 < mangix> jow: fbthrift fails on the buildbots in some weird way. Buildbots don't build the host packages for some reason. Actually the way the host
                libraries are handled is a bit special
10:29 < mangix> Definitely needs review
10:30 < jow> mangix: sounds like it implies new prereqs
10:33 < mangix> I mean these two lines: https://github.com/openwrt/packages/blob/master/libs/fbthrift/Makefile#L32 . Usually these are listed in
                PKG_BUILD_DEPENDS
10:34 < jow> yeah, looks very weird and wrong
10:34 < jow> why not just PKG_BUILD_DEPENDS := boost/host or whatever
10:34 < mangix> It's already there. But boost is modular
10:35 < jow> well the host build shouldn't be
10:36 < mangix> right, the commit that added this tried to match what Boost the target package was doing
10:38 < mangix> I also do not understand this line: https://github.com/openwrt/packages/blob/master/libs/fbthrift/Makefile#L18 . Why is HOST_BUILD_PREFIX
                normally set to _HOSTPKG?
10:39 < jow> I have no idea
10:39 < jow> too much black magic for my taste
10:41 < mangix> This sets it: https://github.com/openwrt/openwrt/blob/master/include/host-build.mk#L30 . I don't understand the if condition
10:41 < jow> packages are supposed to use _HOSTPKG, non-packages (tools/*) not
10:41 < jow> fbthrift violates this requirement
10:42 < mangix> That's bizarre since boost/host gets installed to _HOST not _HOSTPKG
10:43 < jow> then something is wrong about it
10:44 < mangix> hmmm I'm not seeing anything that specifies _HOST in the Boost Makefile
10:44 < jow> line 382 is the problem
10:45 < jow> https://github.com/openwrt/packages/blob/master/libs/boost/Makefile#L382
10:49 < mangix> hmmm OK. I will think about this.
10:50 < mangix> I know that net/kea was depending on boost/host before this commit, but boost/host probably was only running this line:
                https://github.com/openwrt/packages/blob/master/libs/boost/Makefile#L379
10:51 < jow> in any case boost should stage in _HOSTPKG, not _HOST
10:52 < jow> reasoning: multiple targets (e.g. x86, ath79, ...) may share the same buildroot and the same tools
10:52 < jow> Each target however may have differently configured host builds of its respective packages
10:53 < jow> so you can have an x86 boost/host and a differently configured ath79 boost/host
10:55 < mangix> Right. As for those host dependencies, I think I will hardcode them.
```