### PR TITLE
ddns-scripts: use $interface for $ip_interface if available

### DIFF
--- a/net/ddns-scripts/files/dynamic_dns_updater.sh
+++ b/net/ddns-scripts/files/dynamic_dns_updater.sh
@@ -193,6 +193,7 @@ ERR_LAST=$?	# save return code - equal 0 if SECTION_ID found
 [ "$ip_source" = "network" -a -z "$ip_network" -a $use_ipv6 -eq 1 ] && ip_network="wan6" # IPv6: default wan6
 [ "$ip_source" = "web" -a -z "$ip_url" -a $use_ipv6 -eq 0 ] && ip_url="http://checkip.dyndns.com"
 [ "$ip_source" = "web" -a -z "$ip_url" -a $use_ipv6 -eq 1 ] && ip_url="http://checkipv6.dyndns.com"
+[ "$ip_source" = "interface" -a -z "$ip_interface" -a -n "$interface" ] && ip_interface="$interface"
 [ "$ip_source" = "interface" -a -z "$ip_interface" ] && ip_interface="eth1"
 
 # url encode username (might be email or something like this)


### PR DESCRIPTION
the current luci-app-ddns sets interface, not ip_interface, which
caused configuring ddns by interface via luci to break.

Maintainer: oh it's empty, that is unfortunate
Compile tested: n/a
Run tested: r7800 / interface: wwan0

I wonder if it's the luci-app-ddns that needs fixing instead... the interface dropdown isn't working correctly for it either (it's missing most of my interfaces)

I really have no idea what it **should** be in /etc/config/ddns, ip_interface *or* interface *or* both options.