### PR TITLE
[openwrt-19.07] CircleCI: Change BRANCH to "openwrt-19.07"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - SDK_HOST: "downloads.openwrt.org"
       - SDK_PATH: "snapshots/targets/ath79/generic"
       - SDK_FILE: "openwrt-sdk-ath79-generic_*.Linux-x86_64.tar.xz"
-      - BRANCH: "master"
+      - BRANCH: "openwrt-19.07"
     steps:
       - checkout:
           path: ~/openwrt_packages


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: N/A
Run tested: N/A

Description:
This still uses the snapshot SDK, but should allow CI to continue.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>