### PR TITLE
flup: migrate to Python3 and add src package

### DIFF
--- a/lang/python/flup/Makefile
+++ b/lang/python/flup/Makefile
@@ -9,39 +9,62 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=flup
 PKG_VERSION:=1.0.3
-PKG_RELEASE:=2
-PKG_LICENSE:=BSD-3-Clause
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/f/flup
 PKG_HASH:=5eb09f26eb0751f8380d8ac43d1dfb20e1d42eca0fa45ea9289fa532a79cd159
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-flup-$(PKG_VERSION)
+
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=PKG-INFO
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/flup
-  SUBMENU:=Python
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/flup/Default
   SECTION:=lang
   CATEGORY:=Languages
+  SUBMENU:=Python
   TITLE:=Random assortment of WSGI servers
   URL:=https://www.saddi.com/software/flup/
-  DEPENDS:=+python
 endef
 
-define Package/flup/description
-  Random assortment of WSGI servers
+define Package/python-flup
+$(call Package/flup/Default)
+  DEPENDS+= \
+      +PACKAGE_python-flup:python-light \
+      +PACKAGE_python-flup:python-logging
+  VARIANT:=python
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-flup
+$(call Package/flup/Default)
+  DEPENDS+= \
+      +PACKAGE_python3-flup:python3-light \
+      +PACKAGE_python3-flup:python3-logging
+  VARIANT:=python3
 endef
 
-define Package/flup/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
+define Package/python-flup/description
+  Random assortment of WSGI servers.
 endef
 
-$(eval $(call BuildPackage,flup))
+define Package/python3-flup/description
+$(call Package/python-flup/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-flup))
+$(eval $(call BuildPackage,python-flup))
+$(eval $(call BuildPackage,python-flup-src))
+
+$(eval $(call Py3Package,python3-flup))
+$(eval $(call BuildPackage,python3-flup))
+$(eval $(call BuildPackage,python3-flup-src))


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master
Tests: Example from their website
```
def myapp(environ, start_response):
    start_response('200 OK', [('Content-Type', 'text/plain')])
    return ['Hello World!\n']

if __name__ == '__main__':
    from flup.server.fcgi import WSGIServer
    WSGIServer(myapp).run()
```

Description:
- Add PKG_LICENSE_FILES
- Reorder things in Makefile
- Add dependency python3-logging otherwise I cannot import
flup.server.ajp
flup.server.scgi

```
>>> import flup.server.ajp
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/ajp.py", line 91, in <module>
  File "/ajp_base.py", line 150, in <module>
AttributeError: module 'logging' has no attribute 'StreamHandler'
>>> import flup.server.fcgi
>>> import flup.server.scgi
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/scgi.py", line 76, in <module>
  File "/scgi_base.py", line 55, in <module>
AttributeError: module 'logging' has no attribute 'StreamHandler'
```

Once I installed python3-logging, it works.