### PR TITLE
python3-unidecode: Update to version 1.1.0

### DIFF
--- a/lang/python/python3-unidecode/Makefile
+++ b/lang/python/python3-unidecode/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-unidecode
-PKG_VERSION:=1.0.23
+PKG_VERSION:=1.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=Unidecode-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/u/unidecode/
-PKG_HASH:=8b85354be8fd0c0e10adbf0675f6dc2310e56fda43fa8fe049123b6c475e52fb
+PKG_HASH:=8c698f567aa098aeacfbad2d4a416f9803236bdc5ece09653b6e6dfe3f03f102
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/Unidecode-$(PKG_VERSION)
 
@@ -35,7 +35,7 @@ define Package/python3-unidecode
 endef
 
 define Package/python-unidecode/description
-Unidecode, lossy ASCII transliterations of Unicode text
+  Unidecode, lossy ASCII transliterations of Unicode text
 endef
 
 $(eval $(call Py3Package,$(PKG_NAME)))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Tests:
https://github.com/avian2/unidecode/blob/master/tests/test_unidecode.py
```
root@turris:~# python3 test_unidecode.py 
.s.............s.............s............
----------------------------------------------------------------------
Ran 42 tests in 9.437s

OK (skipped=3)

```


Description:
- Update to version 1.1.0
Changelog: https://github.com/avian2/unidecode/commit/7bf69d4776466c0127dc1658228bad8f2cceb54f