### PR TITLE
bcrypt: add python-cffi/host build dependency

### DIFF
--- a/lang/python/bcrypt/Makefile
+++ b/lang/python/bcrypt/Makefile
@@ -19,6 +19,10 @@ PKG_MAINTAINER:=Daniel Dickinson <cshored@thecshore.com>
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-bcrypt-$(PKG_VERSION)
 
+PKG_BUILD_DEPENDS:=libffi/host
+HOST_PYTHON_PACKAGE_BUILD_DEPENDS:="cffi>=1.1"
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:="cffi>=1.1"
+
 include $(INCLUDE_DIR)/package.mk
 
 include ../python-package.mk


### PR DESCRIPTION
Maintainer: @cshoredaniel 
Compile tested: arm, WRT3200ACM, master
Run tested: arm, WRT3200ACM, master, ran the example in the project's README.rst

Description:
Since c94c98efcaa0d85aa74c3db1b8ef08978f84699d removed host cffi dependency from pyhton-cffi, bcrypt fails to compile if host cffi was not built ahead of bcrypt.  It happens here from a clean build, `make clean` will not remove host cffi:
```
Installed /home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/python-bcrypt-3.1.6/.eggs/pycparser-2.19-py2.7.egg
Traceback (most recent call last):
  File "./setup.py", line 240, in <module>
    **keywords_with_side_effects(sys.argv)
  File "/home/equeiroz/src/openwrt/staging_dir/hostpkg/lib/python2.7/site-packages/setuptools/__init__.py", line 143, in setup
    return distutils.core.setup(**attrs)
  File "/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/lib/python2.7/distutils/core.py", line 111, in setup
    _setup_distribution = dist = klass(attrs)
  File "/home/equeiroz/src/openwrt/staging_dir/hostpkg/lib/python2.7/site-packages/setuptools/dist.py", line 442, in __init__
    k: v for k, v in attrs.items()
  File "/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/lib/python2.7/distutils/dist.py", line 287, in __init__
    self.finalize_options()
  File "/home/equeiroz/src/openwrt/staging_dir/hostpkg/lib/python2.7/site-packages/setuptools/dist.py", line 601, in finalize_options
    ep.load()(self, ep.name, value)
  File "/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/python-bcrypt-3.1.6/.eggs/cffi-1.12.3-py2.7-linux2.egg/cffi/setuptools_ext.py", line 217, in cffi_modules
    add_cffi_module(dist, cffi_module)
  File "/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/python-bcrypt-3.1.6/.eggs/cffi-1.12.3-py2.7-linux2.egg/cffi/setuptools_ext.py", line 49, in add_cffi_module
    execfile(build_file_name, mod_vars)
  File "/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/python-bcrypt-3.1.6/.eggs/cffi-1.12.3-py2.7-linux2.egg/cffi/setuptools_ext.py", line 25, in execfile
    exec(code, glob, glob)
  File "src/build_bcrypt.py", line 21, in <module>
    ffi = FFI()
  File "/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/python-bcrypt-3.1.6/.eggs/cffi-1.12.3-py2.7-linux2.egg/cffi/api.py", line 48, in __init__
    import _cffi_backend as backend
ImportError: /home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/python-bcrypt-3.1.6/.eggs/cffi-1.12.3-py2.7-linux2.egg/_cffi_backend.so: wrong ELF class: ELFCLASS32
make[2]: *** [Makefile:70: /home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/python-bcrypt-3.1.6/.built] Error 1
```
This commit does not change generated package, so I'm not increasing `PKG_RELEASE`.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>