### PR TITLE
chicken: upgrade to 5.1.0  change Makefile license

### DIFF
--- a/lang/chicken-scheme/Makefile
+++ b/lang/chicken-scheme/Makefile
@@ -1,32 +1,34 @@
 #
 # Copyright (C) 2019 Jerônimo Cordoni Pellegrini <j_p@aleph0.info>
 #
-# This file is free software, licensed under the GNU General Public License v2.
+# This file is free software, licensed under the GNU General Public License v3
+# or later.
 # See /LICENSE for details
 #
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chicken-scheme-interpreter
-PKG_VERSION=5.0.0
+PKG_VERSION=5.1.0
 PKG_RELEASE:=1
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/chicken-$(PKG_VERSION)
 PKG_SOURCE:=chicken-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://code.call-cc.org/releases/5.0.0/
-PKG_HASH:=a8b94bb94c5d6a4348cedd75dc334ac80924bcd9a7a7a3d6af5121e57ef66595
+PKG_SOURCE_URL:=https://code.call-cc.org/releases/$(PKG_VERSION)/
+PKG_HASH:=5c1101a8d8faabfd500ad69101e0c7c8bd826c68970f89c270640470e7b84b4b
+PKG_BUILD_DIR:=$(BUILD_DIR)/chicken-$(PKG_VERSION)
 
+PKG_MAINTAINER:=Jeronimo Pellegrini <j_p@aleph0.info>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
 
 define Package/chicken-scheme-interpreter
-SECTION:=lang
-CATEGORY:=Languages
-TITLE:=Chicken Scheme
-URL:=https://call-cc.org
-MAINTAINER:=Jeronimo Pellegrini <j_p@aleph0.info>
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Chicken Scheme
+  URL:=https://call-cc.org
+  ABI_VERSION:=11
 endef
 
 define Package/chicken-scheme-interpreter/description
@@ -49,12 +51,12 @@ MAKE_FLAGS += PLATFORM=linux C_COMPILER=$(TARGET_CC) LINKER=$(TARGET_CC) PREFIX=
 # - libchicken.a, the static library
 define Package/chicken-scheme-interpreter/install
 	$(INSTALL_DIR)  $(1)/usr/bin
-	$(INSTALL_DIR)  $(1)/usr/lib/chicken/9
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/csi    $(1)/usr/bin/
-	$(CP) $(PKG_BUILD_DIR)/libchicken.so.9 $(1)/usr/lib/
-	$(CP) $(PKG_BUILD_DIR)/libchicken.so   $(1)/usr/lib/
-	$(CP) $(PKG_BUILD_DIR)/*.import.so     $(1)/usr/lib/chicken/9/
-	$(CP) $(PKG_BUILD_DIR)/types.db        $(1)/usr/lib/chicken/9/
+	$(INSTALL_DIR)  $(1)/usr/lib/chicken/$(ABI_VERSION)
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/csi                 $(1)/usr/bin/
+	$(CP) $(PKG_BUILD_DIR)/libchicken.so.$(ABI_VERSION) $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/libchicken.so                $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/*.import.so                  $(1)/usr/lib/chicken/$(ABI_VERSION)/
+	$(CP) $(PKG_BUILD_DIR)/types.db                     $(1)/usr/lib/chicken/$(ABI_VERSION)/
 endef
 
 $(eval $(call BuildPackage,chicken-scheme-interpreter))


### PR DESCRIPTION
* version 5.1.0 of Chicken is out.
* Makefile goes from GPLv2 to GPLv3

Maintainer: me / @jpellegrini 
Compile tested: cross-compiled on x86_64, target was MIPS
Run tested: runs on TP-Link Archer C7 (MIPS 74Kc V5.0), OpenWRT SNAPSHOT, r9547-364ab34

Description:

Chicken Scheme has a new version out, the Makefile was adjusted to use that version (5.1.0).

Also, is it OK to switch the Makefile license from GPLv2 to GPLv3? If not I can make a new PR without changing the license (changing the Makefile license only, not the whole package)