### PR TITLE
fbzmq: Fix compilation with newer GCC

### DIFF
--- a/libs/fbzmq/Makefile
+++ b/libs/fbzmq/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fbzmq
 PKG_VERSION:=2019.06.10.00
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/facebook/fbzmq/tar.gz/v$(PKG_VERSION)?
@@ -36,6 +36,8 @@ CMAKE_OPTIONS += \
 	-DBUILD_SHARED_LIBS=ON \
 	-DTHRIFT1="$(STAGING_DIR_HOSTPKG)/bin/thrift1" \
 	-DTHRIFT_COMPILER_INCLUDE="$(STAGING_DIR_HOSTPKG)/include/"
+
+TARGET_CXXFLAGS += -faligned-new
 
 define Package/fbzmq/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/fbzmq/patches/010-move.patch
+++ b/libs/fbzmq/patches/010-move.patch
@@ -1,0 +1,31 @@
+--- a/fbzmq/zmq/Message.cpp
++++ b/fbzmq/zmq/Message.cpp
+@@ -35,7 +35,7 @@ Message::allocate(size_t size) noexcept {
+   if (rc != 0) {
+     return folly::makeUnexpected(Error());
+   }
+-  return std::move(msg);
++  return msg;
+ }
+ 
+ folly::Expected<Message, Error>
+@@ -58,7 +58,7 @@ Message::wrapBuffer(std::unique_ptr<folly::IOBuf> buf) noexcept {
+     delete ptr;
+     return folly::makeUnexpected(Error());
+   }
+-  return std::move(msg);
++  return msg;
+ }
+ 
+ Message&
+--- a/fbzmq/zmq/Socket.cpp
++++ b/fbzmq/zmq/Socket.cpp
+@@ -449,7 +449,7 @@ SocketImpl::recv(int flags) const noexcept {
+   while (true) {
+     const int n = zmq_msg_recv(&(msg.msg_), ptr_, flags);
+     if (n >= 0) {
+-      return std::move(msg);
++      return msg;
+     }
+ 
+     const int err = zmq_errno();


### PR DESCRIPTION
Added -faligned-new to fix compilation.

As fbzmq is passing -Werror, fixed compilation with newer GCC versions.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ammubhave 
Compile tested: powerpc 8540