### PR TITLE
mdnsresponder: Fix compilation with uClibc-ng

### DIFF
--- a/net/mdnsresponder/Makefile
+++ b/net/mdnsresponder/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mDNSResponder
 PKG_VERSION:=IETF104
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=mDNSResponder-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://opensource.apple.com/tarballs/mDNSResponder/IETF/

--- a/net/mdnsresponder/patches/010-uclibc.patch
+++ b/net/mdnsresponder/patches/010-uclibc.patch
@@ -1,0 +1,13 @@
+--- a/mDNSShared/PlatformCommon.c
++++ b/mDNSShared/PlatformCommon.c
+@@ -43,6 +43,10 @@
+ typedef unsigned int socklen_t;
+ #endif
+ 
++#ifndef TCP_NOTSENT_LOWAT
++#define TCP_NOTSENT_LOWAT 25
++#endif
++
+ #if MDNS_MALLOC_DEBUGGING
+ // We ONLY want this for malloc debugging--on a running production system we want to deal with
+ // malloc failures, not just die.   There is a small performance penalty for enabling these options


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: noboddy
Compile tested: arc700
