### PR TITLE
seafile-server: fix build with libssp & non-musl libc

### DIFF
--- a/net/seafile-server/Makefile
+++ b/net/seafile-server/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-server
 PKG_VERSION:=6.3.4
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_LICENSE:=GPL-3.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -76,6 +76,10 @@ ifdef CONFIG_USE_MIPS16
 endif
 TARGET_LDFLAGS += -Wl,-rpath-link=$(STAGING_DIR)/usr/lib -liconv \
 		    -L$(STAGING_DIR)/usr/lib/mysql -lmysqlclient -lz -levent_openssl -levent
+
+ifdef CONFIG_GCC_LIBSSP
+TARGET_LDFLAGS += -lssp
+endif
 
 define Package/seafile-server/conffiles
 /etc/config/seafile


### PR DESCRIPTION
Maintainer: me
Compile tested: ARC https://github.com/openwrt/openwrt/commit/bc47285cb3c0125424e628521f905f1f0d7b4cef
Run tested: N/A

--------------------------------------------------------------

Fixes: https://github.com/openwrt/packages/issues/9255

This seems to fail the build for this package only.
So, this change patches the build, to add `-lssp` to the LDFLAGS of this
package, in case the build uses GCC's libssp.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>