### PR TITLE
uvcdynctrl: Fix compilation with uClibc-ng

### DIFF
--- a/utils/uvcdynctrl/Makefile
+++ b/utils/uvcdynctrl/Makefile
@@ -9,23 +9,27 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uvcdynctrl
 PKG_VERSION:=0.2.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=libwebcam-src-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/libwebcam
 PKG_HASH:=3ca5199c7b8398b655a7c38e3ad4191bb053b1486503287f20d30d141bda9d41
-PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
-
 PKG_BUILD_DIR:=$(BUILD_DIR)/libwebcam-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
+CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/uvcdynctrl
   SECTION:=utils
   CATEGORY:=Utilities
   DEPENDS:=+libwebcam
   TITLE:=Manage dynamic controls in uvcvideo
+  LICENSE:=GPL-3.0-or-later
+  LICENSE_FILES:=uvcdynctrl/COPYING
   URL:=https://sourceforge.net/projects/libwebcam/
   MENU:=1
 endef
@@ -39,17 +43,16 @@ endef
 define Package/libwebcam
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libxml2 +libiconv-full
+  DEPENDS:=+libxml2 $(ICONV_DEPENDS)
   TITLE:=Webcam library
+  LICENSE:=LGPL-3.0-or-later
+  LICENSE_FILES:=libwebcam/COPYING.LESSER
   URL:=https://sourceforge.net/projects/libwebcam/
 endef
 
 define Package/libwebcam/description
   $(call Package/uvcdynctrl/description)
 endef
-
-TARGET_CFLAGS += -I$(STAGING_DIR)/usr/lib/libiconv-full/include -liconv
-TARGET_LDFLAGS += -L$(STAGING_DIR)/usr/lib/libiconv-full/lib
 
 define Package/uvcdynctrl/install
 	$(INSTALL_DIR) $(1)/usr/{bin,share}
@@ -60,12 +63,6 @@ endef
 define Package/libwebcam/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libwebcam.so* $(1)/usr/lib/
-endef
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/{include,lib}
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libwebcam.{a,so*} $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,uvcdynctrl))

--- a/utils/uvcdynctrl/patches/010-iconv.patch
+++ b/utils/uvcdynctrl/patches/010-iconv.patch
@@ -1,0 +1,11 @@
+--- a/uvcdynctrl/CMakeLists.txt
++++ b/uvcdynctrl/CMakeLists.txt
+@@ -77,7 +77,7 @@ include_directories (../common/include)
+ include_directories (${CMAKE_CURRENT_BINARY_DIR})
+ link_directories (${LIBWEBCAM_BINARY_DIR}/webcam)
+ 
+-target_link_libraries (uvcdynctrl webcam)
++target_link_libraries (uvcdynctrl webcam iconv)
+ 
+ # Compiler flags
+ set_target_properties (uvcdynctrl PROPERTIES


### PR DESCRIPTION
Got rid of libiconv-full dependency. Relying on nls.mk

Fixed up the license information.

Added CMAKE_INSTALL to get rid of the InstallDev section.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @roger- 
Compile tested: arc700