### PR TITLE
haproxy: Fix issue #9294 & update patches

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
 PKG_VERSION:=2.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=haproxy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/2.0/src/
@@ -91,10 +91,14 @@ ENABLE_LUA:=y
 ENABLE_REGPARM:=n
 
 ifeq ($(CONFIG_TARGET_x86),y)
-  ENABLE_REGPARM:=y
+	ENABLE_REGPARM:=y
 endif
 
-LINUX_TARGET:=linux-glibc
+ifeq ($(CONFIG_USE_UCLIBC),y)
+	LINUX_TARGET:=linux-uclibc
+else
+	LINUX_TARGET:=linux-glibc
+endif
 
 ifeq ($(BUILD_VARIANT),ssl)
 	ADDON+=USE_OPENSSL=1
@@ -139,7 +143,7 @@ define Build/Compile
 		VERSION="$(PKG_VERSION)" SUBVERS="-$(PKG_RELEASE)" \
 		VERDATE="$(shell date -d @$(SOURCE_DATE_EPOCH) '+%Y/%m/%d')" IGNOREGIT=1 \
 		$(ADDON) \
-		CFLAGS="$(TARGET_CFLAGS) -fno-strict-aliasing -Wdeclaration-after-statement -fwrapv -Wno-format-truncation -Wno-unused-label -Wno-sign-compare -Wno-unused-parameter -Wno-old-style-declaration -Wno-ignored-qualifiers -Wno-clobbered -Wno-missing-field-initializers -Wno-implicit-fallthrough -Wno-stringop-overflow -Wtype-limits -Wshift-negative-value -Wshift-overflow=2 -Wduplicated-cond -Wnull-dereference" \
+		CFLAGS="$(TARGET_CFLAGS) -fno-strict-aliasing -Wdeclaration-after-statement -fwrapv -Wno-format-truncation -Wno-unused-label -Wno-sign-compare -Wno-unused-parameter -Wno-old-style-declaration -Wno-ignored-qualifiers -Wno-clobbered -Wno-missing-field-initializers -Wno-implicit-fallthrough -Wno-stringop-overflow -Wno-cast-function-type -Wtype-limits -Wshift-negative-value -Wshift-overflow=2 -Wduplicated-cond -Wnull-dereference" \
 		LD="$(TARGET_CC)" \
 		LDFLAGS="$(TARGET_LDFLAGS) -latomic" \
 		EXTRA_OBJS="contrib/prometheus-exporter/service-prometheus.o"

--- a/net/haproxy/patches/009-BUG-MAJOR-sample-Wrong-stick-table-name-parsing-in-if-unless-ACL-condition.patch
+++ b/net/haproxy/patches/009-BUG-MAJOR-sample-Wrong-stick-table-name-parsing-in-if-unless-ACL-condition.patch
@@ -1,0 +1,40 @@
+commit 9eae8935663bc0b27c23018e8cc24ae9a3e31732
+Author: Frédéric Lécaille <flecaille@haproxy.com>
+Date:   Thu Jun 20 09:31:04 2019 +0200
+
+    BUG/MAJOR: sample: Wrong stick-table name parsing in "if/unless" ACL condition.
+    
+    This bug was introduced by 1b8e68e commit which supposed the stick-table was always
+    stored in struct arg at parsing time. This is never the case with the usage of
+    "if/unless" conditions in stick-table declared as backends. In this case, this is
+    the name of the proxy which must be considered as the stick-table name.
+    
+    This must be backported to 2.0.
+    
+    (cherry picked from commit 9417f4534ad742eda35c4cc3d1ccb390f75ea4b1)
+    Signed-off-by: Willy Tarreau <w@1wt.eu>
+
+diff --git a/src/sample.c b/src/sample.c
+index 67f59e84..77ec9b1e 100644
+--- a/src/sample.c
++++ b/src/sample.c
+@@ -1245,15 +1245,11 @@ int smp_resolve_args(struct proxy *p)
+ 			break;
+ 
+ 		case ARGT_TAB:
+-			if (!arg->data.str.data) {
+-				ha_alert("parsing [%s:%d] : missing table name in arg %d of %s%s%s%s '%s' %s proxy '%s'.\n",
+-					 cur->file, cur->line,
+-					 cur->arg_pos + 1, conv_pre, conv_ctx, conv_pos, ctx, cur->kw, where, p->id);
+-				cfgerr++;
+-				continue;
+-			}
++			if (arg->data.str.data)
++				stktname = arg->data.str.area;
++			else
++				stktname = px->id;
+ 
+-			stktname = arg->data.str.area;
+ 			t = stktable_find_by_name(stktname);
+ 			if (!t) {
+ 				ha_alert("parsing [%s:%d] : unable to find table '%s' referenced in arg %d of %s%s%s%s '%s' %s proxy '%s'.\n",

--- a/net/haproxy/patches/010-add-uclibc-support.patch
+++ b/net/haproxy/patches/010-add-uclibc-support.patch
@@ -1,0 +1,18 @@
+--- a/Makefile
++++ b/Makefile
+@@ -327,6 +327,15 @@ ifeq ($(TARGET),linux-glibc)
+     USE_GETADDRINFO)
+ endif
+ 
++# For linux >= 2.6.28 and uclibc
++ifeq ($(TARGET),linux-uclibc)
++  set_target_defaults = $(call default_opts, \
++    USE_POLL USE_TPROXY USE_DL USE_RT USE_NETFILTER                           \
++    USE_CPU_AFFINITY USE_THREAD USE_EPOLL USE_FUTEX USE_LINUX_TPROXY          \
++    USE_ACCEPT4 USE_LINUX_SPLICE USE_PRCTL USE_THREAD_DUMP USE_NS USE_TFO     \
++    USE_GETADDRINFO)
++endif
++
+ # Solaris 8 and above
+ ifeq ($(TARGET),solaris)
+   # We also enable getaddrinfo() which works since solaris 8.


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com>
Compile tested: mips, mipsel, mvebu, arc700
Run tested: mvebu (wrt1900acs)

Description: Fix issue #9294 & update patches
The arc700 target (and probably others) uses uClibc as it's c-library. However,
uClibc's libcrypt seems to not support the crypt_data struct which broke
the build. This fix adds a new build-target to haproxy which does not use
libcrypt. Summing up, this commit does:
- Add support for uclibc to haproxy with libcrypt disabled
- Add detection of c-library to configure the correct build-target
- Silence additional warnings
- Update patches