### PR TITLE
mariadb: add dependency on libaio for arc as well

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
 PKG_VERSION:=10.2.24
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := \
@@ -327,7 +327,7 @@ define Package/mariadb-server-base
   $(call Package/mariadb/Default)
   DEPENDS:=mariadb-common \
 	  $(MARIADB_COMMON_DEPENDS_EXE) \
-	  +!arc:libaio \
+	  +libaio \
 	  +liblzma \
 	  +libpcre \
 	  +resolveip


### PR DESCRIPTION
Now that libaio compiles on arc targets we need to add the dependency to
libaio on these targets as well.

resolves #9298

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: no, dependency-fix only
Run tested: N/A

Description:
Hi @neheb,

Thanks for noticing and raising the issue.

Kind regards,
Seb