### PR TITLE
pdns-auth: Bump version to 4.1.10

### DIFF
--- a/net/pdns/Makefile
+++ b/net/pdns/Makefile
@@ -1,16 +1,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns
-PKG_VERSION:=4.1.8
+PKG_VERSION:=4.1.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=94561132f46c08f646399511b680ce8cda150fd2b8e3d38c0b90b4187163e617
+PKG_HASH:=5a46cfde92caaaa2e85af9a15acb9ad81b56f4c8a8255c457e6938d8c0cb15c7
 
 PKG_MAINTAINER:=James Taylor <james@jtaylor.id.au>
 PKG_LICENCE:=GPL-2.0-only
 PKG_LICENCE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:powerdns:authoritative_server
 
 PKG_FIXUP:=autoreconf
 

--- a/net/pdns/patches/400-gen-version.patch
+++ b/net/pdns/patches/400-gen-version.patch
@@ -1,0 +1,43 @@
+--- a/build-aux/gen-version
++++ b/build-aux/gen-version
+@@ -1,39 +1,4 @@
+ #!/bin/sh
+-VERSION="unknown"
+-
+-DIRTY=""
+-git status | grep -q clean || DIRTY='.dirty'
+-
+-# Special environment variable to signal that we are building a release, as this
+-# has consequences for the version number.
+-if [ "${IS_RELEASE}" = "YES" ]; then
+-  TAG="$(git describe --tags --exact-match 2> /dev/null | cut -d- -f 2-)"
+-  if [ -n "${TAG}" ]; then
+-    # We're on a tag
+-    echo "${TAG}${DIRTY}" > .version
+-    printf "${TAG}${DIRTY}"
+-    exit 0
+-  fi
+-  echo 'This is not a tag, either tag this commit or do not set $IS_RELEASE' >&2
+-  exit 1
+-fi
+-
+-#
+-# Generate the version number based on the branch
+-#
+-if [ ! -z "$(git rev-parse --abbrev-ref HEAD 2> /dev/null)" ]; then
+-  if $(git rev-parse --abbrev-ref HEAD | grep -q 'rel/'); then
+-    REL_TYPE="$(git rev-parse --abbrev-ref HEAD | cut -d/ -f 2 | cut -d- -f 1)"
+-    VERSION="$(git describe --match=${REL_TYPE}-* --tags --dirty=.dirty | cut -d- -f 2-)"
+-  else
+-    GIT_VERSION=$(git show --no-patch --format=format:%h HEAD)
+-    BRANCH=".$(git rev-parse --abbrev-ref HEAD | perl -p -e 's/[^[:alnum:]]//g;')"
+-    [ "${BRANCH}" = ".master" ] && BRANCH=''
+-    VERSION="0.0${BRANCH}.${PDNS_BUILD_NUMBER}g${GIT_VERSION}${DIRTY}"
+-  fi
+-  echo "$VERSION" > .version
+-elif [ -f .version ]; then
+-  VERSION="$(cat .version)"
+-fi
++VERSION="$(cat .version)"
+
+ printf $VERSION

--- a/net/pdns/patches/500-fix-uclibc-pretending-to-be-glibc.patch
+++ b/net/pdns/patches/500-fix-uclibc-pretending-to-be-glibc.patch
@@ -1,0 +1,41 @@
+From 7ac0df2a59ddd6e92ede2bca590ec0c76eb67559 Mon Sep 17 00:00:00 2001
+From: James Taylor <james@jtaylor.id.au>
+Date: Tue, 25 Jun 2019 19:33:04 +1000
+Subject: [PATCH] auth: make sure we really are using glibc
+
+Make sure we're using glibc and not uclibc pretending to be glibc
+---
+ pdns/receiver.cc | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/pdns/receiver.cc b/pdns/receiver.cc
+index e6686787b3..209db7af89 100644
+--- a/pdns/receiver.cc
++++ b/pdns/receiver.cc
+@@ -354,7 +354,7 @@ static int guardian(int argc, char **argv)
+   }
+ }
+ 
+-#ifdef __GLIBC__
++#ifdef __GLIBC__ && !defined(__UCLIBC__)
+ #include <execinfo.h>
+ static void tbhandler(int num)
+ {
+@@ -386,7 +386,7 @@ int main(int argc, char **argv)
+   s_programname="pdns";
+   s_starttime=time(0);
+ 
+-#ifdef __GLIBC__
++#ifdef __GLIBC__ && !defined(__UCLIBC__)
+   signal(SIGSEGV,tbhandler);
+   signal(SIGFPE,tbhandler);
+   signal(SIGABRT,tbhandler);
+@@ -450,7 +450,7 @@ int main(int argc, char **argv)
+     
+     // we really need to do work - either standalone or as an instance
+ 
+-#ifdef __GLIBC__
++#ifdef __GLIBC__ && !defined(__UCLIBC__)
+     if(!::arg().mustDo("traceback-handler")) {
+       g_log<<Logger::Warning<<"Disabling traceback handler"<<endl;
+       signal(SIGSEGV,SIG_DFL);


### PR DESCRIPTION
Maintainer: me
Compile tested: OpenWRT SDK
Run tested: armv7l WRT1900ACS OpenWrt SNAPSHOT r9987-655fff1571

Description:
PowerDNS released two new versions which together add some features and address security issues.
Changelog: https://doc.powerdns.com/authoritative/changelog/4.1.html

This release and 4.1.9 together fix the following security advisories:

PowerDNS Security Advisory 2019-04 (CVE-2019-10162)
PowerDNS Security Advisory 2019-05 (CVE-2019-10163)

Signed-off-by: James Taylor <james@jtaylor.id.au>
