### PR TITLE
linknx: Fix compilation with libiconv

### DIFF
--- a/net/linknx/Makefile
+++ b/net/linknx/Makefile
@@ -9,28 +9,29 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linknx
 PKG_VERSION:=0.0.1.37
-PKG_RELEASE:=1
-
-PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
-PKG_LICENSE:=GPL-2.0+
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-${PKG_VERSION}.tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/linknx/linknx/tar.gz/$(PKG_VERSION)?
 PKG_HASH:=3c3aaf8c409538153b15f5fb975a4485e58c4820cfea289a3f20777ba69782ab
 
-PKG_BUILD_DEPENDS:=argp-standalone
-PKG_FORTIFY_SOURCE:=1
+PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=LICENSE
 
+PKG_BUILD_DEPENDS:=USE_UCLIBC:argp-standalone USE_MUSL:argp-standalone
 PKG_FIXUP:=autoreconf
 
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/linknx
   SECTION:=net
   CATEGORY:=Network
   TITLE:=KNX home automation platform
   URL:=https://github.com/linknx/linknx
-  DEPENDS:=+pthsem +lua +luac +libstdcpp +libcurl +libesmtp
+  DEPENDS:=+pthsem +lua +luac +libcurl +libesmtp $(CXX_DEPENDS) $(ICONV_DEPENDS)
 endef
 
 CONFIGURE_ARGS+= \

--- a/net/linknx/patches/010-iconv.patch
+++ b/net/linknx/patches/010-iconv.patch
@@ -1,0 +1,19 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -10,6 +10,7 @@ PKG_CONFIG=`which pkg-config`
+ AC_PROG_CXX
+ AC_PROG_CC
+ AC_PROG_RANLIB
++AM_ICONV
+ AC_CHECK_PTHSEM(2.0.4,yes,yes,no)
+ AC_CHECK_HEADER(argp.h,,[AC_MSG_ERROR([argp_parse not found])])
+ AC_SEARCH_LIBS(argp_parse,argp,,[AC_MSG_ERROR([argp_parse not found])])
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -7,5 +7,5 @@ B64_CFLAGS=
+ B64_LIBS=
+ endif
+ AM_CPPFLAGS=-I$(top_srcdir)/include -I$(top_srcdir)/ticpp $(B64_CFLAGS) $(PTH_CPPFLAGS) $(LIBCURL_CPPFLAGS) $(LOG4CPP_CFLAGS) $(LUA_CFLAGS) $(MYSQL_CFLAGS) $(ESMTP_CFLAGS)
+-linknx_LDADD=$(top_srcdir)/ticpp/libticpp.a $(B64_LIBS) $(PTH_LDFLAGS) $(PTH_LIBS) $(LIBCURL) $(LOG4CPP_LIBS) $(LUA_LIBS) $(MYSQL_LIBS) $(ESMTP_LIBS) -lm
++linknx_LDADD=$(top_srcdir)/ticpp/libticpp.a $(LIBICONV) $(B64_LIBS) $(PTH_LDFLAGS) $(PTH_LIBS) $(LIBCURL) $(LOG4CPP_LIBS) $(LUA_LIBS) $(MYSQL_LIBS) $(ESMTP_LIBS) -lm
+ linknx_SOURCES=linknx.cpp logger.cpp ruleserver.cpp objectcontroller.cpp eibclient.c threads.cpp timermanager.cpp  persistentstorage.cpp xmlserver.cpp smsgateway.cpp emailgateway.cpp knxconnection.cpp services.cpp suncalc.cpp  luacondition.cpp ioport.cpp ruleserver.h objectcontroller.h threads.h timermanager.h persistentstorage.h xmlserver.h smsgateway.h emailgateway.h knxconnection.h services.h suncalc.h luacondition.h ioport.h logger.h


### PR DESCRIPTION
This applies to uClibc-ng and libiconv-full

Fixed license information.

Fixed BUILD_DEPENDS.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tru7 
Compile tested: arc700