### PR TITLE
[19.07] apfree-wifidog: Update to v3.11.1716

### DIFF
--- a/net/apfree-wifidog/Makefile
+++ b/net/apfree-wifidog/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apfree-wifidog
-PKG_VERSION:=3.8.1588
+PKG_VERSION:=3.11.1716
 PKG_RELEASE=1
 
 PKG_LICENSE:=GPL-3.0-or-later
@@ -19,9 +19,7 @@ PKG_MAINTAINER:=Dengfeng Liu <liudf0716@gmail.com>
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/liudf0716/apfree_wifidog.git
 PKG_SOURCE_VERSION:=$(PKG_VERSION)
-PKG_MIRROR_HASH:=0d10ad5a29358a7124ba75570894f48998af841519b0f295e3fcbed66ee7bccc
-
-PKG_INSTALL:=1
+PKG_MIRROR_HASH:=76eda57e40b919091281305344bc57fc732a779d7944f57bd5de87914ba127d1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -31,8 +29,7 @@ define Package/apfree-wifidog
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+zlib +iptables-mod-extra +iptables-mod-ipopt +kmod-ipt-nat +iptables-mod-nat-extra \
-           +libjson-c +ipset +libip4tc +libevent2 +libevent2-openssl \
-           +fping +libmosquitto +libuci +px5g
+           +libjson-c +ipset +libip4tc +libevent2 +libevent2-openssl +libuci +px5g 
   TITLE:=Apfree's wireless captive portal solution
   URL:=https://github.com/liudf0716/apfree_wifidog
 endef
@@ -41,16 +38,13 @@ define Package/apfree-wifidog/description
   The ApFree Wifidog project is a complete and embeddable captive portal
   solution for wireless community groups or individuals who wish to open a free
   Hotspot while still preventing abuse of their Internet connection.
-
   It's enhanced wifidog
 endef
 
 define Package/apfree-wifidog/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wifidog $(1)/usr/bin/wifidogx
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wdctl $(1)/usr/bin/wdctlx
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libhttpd.so* $(1)/usr/lib/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wifidogx $(1)/usr/bin/wifidogx
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wdctlx $(1)/usr/bin/wdctlx
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) ./files/wdping $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc

--- a/net/apfree-wifidog/files/wifidogx.conf
+++ b/net/apfree-wifidog/files/wifidogx.conf
@@ -1,13 +1,9 @@
 config wifidog
-	option	gateway_interface	'br-lan'
-	option	auth_server_hostname	'change wifidog.kunteng.org.cn to your auth server domain or ip'
-	option	auth_server_port	8001
-	option	auth_server_path	'/wifidog/'
-	option	check_interval		60
-	option	client_timeout		5
-	option	httpd_max_conn		200
-	option	pool_mode			1
-	option	thread_number		5
-	option	queue_size			20
-	option	wired_passed		0
-	option	enable		0
+	option gateway_interface 'br-lan'
+	option auth_server_hostname 'change wifidog.kunteng.org.cn to your auth server domain or ip'
+	option auth_server_port 443
+	option auth_server_path '/wifidog/'
+	option check_interval 60
+	option client_timeout 5
+	option wired_passed 0
+	option disabled 1

--- a/net/apfree-wifidog/files/wifidogx.init
+++ b/net/apfree-wifidog/files/wifidogx.init
@@ -7,7 +7,7 @@ START=99
 
 USE_PROCD=1
 PROG=/usr/bin/wifidogx
-CONFIGFILE=/tmp/wifidog.conf
+CONFIGFILE=/tmp/wifidogx.conf
 
 EXTRA_COMMANDS="status"
 EXTRA_HELP="        status Print the status of the service"
@@ -75,7 +75,6 @@ prepare_wifidog_conf() {
 	local delta_traffic
 	local check_interval
 	local client_timeout
-	local httpd_max_conn
 	local trusted_domains
 	local js_filter
 	local trusted_maclist
@@ -97,8 +96,11 @@ prepare_wifidog_conf() {
 
 	[ -f ${CONFIGFILE} ] && rm -f ${CONFIGFILE}
 
-	config_get enable "${cfg}" "enable" 0
-	[ "${enable}" = "1" ] || return
+	config_get enable "${cfg}" "disabled" 0
+	[ "${enable}" = "0" ] || {
+		echo "wifidogx disabled in /etc/config/wifidogx file, please set disabled to 0 to enable it" >&2
+		return
+	}
 
 	default_gateway_id=$(sed -e 's/://g' /sys/class/net/br-lan/address)
 
@@ -118,7 +120,6 @@ prepare_wifidog_conf() {
 	config_get check_interval "${cfg}" "check_interval" "60"
 	config_get js_filter "${cfg}" "js_filter" 1
 	config_get client_timeout "${cfg}" "client_timeout"	"5"
-	config_get httpd_max_conn "${cfg}" "httpd_max_conn"	"200"
 	config_get trusted_domains "${cfg}" "trusted_domains"
 	config_get trusted_maclist "${cfg}" "trusted_maclist"
 	config_get untrusted_maclist "${cfg}" "untrusted_maclist"
@@ -201,31 +202,15 @@ prepare_wifidog_conf() {
 		ClientTimeout $client_timeout
 		JsFilter $js_filter
 		WiredPassed $wired_passed
-
-		HTTPDMaxConn $httpd_max_conn
-
-		PoolMode $pool_mode
-		ThreadNumber $thread_number
-		QueueSize $queue_size
-
 		$set_trusted_domains
-
 		$set_untrusted_maclist
-
 		$set_trusted_maclist
-
 		$set_trusted_iplist
-
 		$set_trusted_pan_domains
-
 		$set_proxy_port
-
 		$set_no_auth
-
 		$set_apple_cna
-
 		$set_update_domain_interval
-
 		$set_dns_timeout
 
 		FirewallRuleSet global {
@@ -266,8 +251,7 @@ init_config() {
 	config_foreach prepare_wifidog_conf wifidog
 
 	[ ! -f ${CONFIGFILE} ] && {
-		echo "no wifidog.conf, exit..."
-		stop
+		echo "no wifidogx.conf, exit..." >&2
 		exit
 	}
 
@@ -276,8 +260,7 @@ init_config() {
 	}
 
 	[ -s ${APFREE_KEY} -a -s ${APFREE_CERT} ] || {
-		echo "no cert or key, exit..."
-		stop
+		echo "no cert or key, exit..." >&2
 		exit
 	}
 


### PR DESCRIPTION
Maintainer: Dengfeng Liu / @liudf0716
Compile tested: i386_pentium4, VMware® Workstation, 19.07
Run tested: VMware® Workstation

Change log for v3.11.1716:
[IMP] Replaced libhttpd with libevent
[IMP] Added REQUEST_TYPE_COUNTERS_V2 to wifidog protocol
[IMP] Sent online and offline client's counter info to auth server
[IMP] Some change in wifidogx's config file:
1, change option enable to disabled
2, delete all option about thread pool such as pool_mode, thread_number, queue_size
3, delete httpd_max_conn which was useless

[FIX] Fixed missing setting online_time parameter bug

Signed-off-by: Dengfeng Liu liudf0716@gmail.com