### PR TITLE
python-schedule: Add a new package

### DIFF
--- a/lang/python/python-schedule/Makefile
+++ b/lang/python/python-schedule/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-schedule
+PKG_VERSION:=0.6.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=schedule-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/s/schedule/
+PKG_HASH:=f9fb5181283de4db6e701d476dd01b6a3dd81c38462a54991ddbb9d26db857c9
+PKG_BUILD_DIR:=$(BUILD_DIR)/schedule-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.txt
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-schedule
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Job scheduling for humans
+  URL:=https://github.com/dbader/schedule
+  DEPENDS:=+python3-light +python3-logging
+  VARIANT:=python3
+endef
+
+define Package/python3-schedule/description
+  An in-process scheduler for periodic jobs that uses the builder pattern for configuration.
+  The Schedule lets you run Python functions (or any other callable)
+  periodically at predetermined intervals using a simple, human-friendly syntax.
+endef
+
+$(eval $(call Py3Package,python3-schedule))
+$(eval $(call BuildPackage,python3-schedule))
+$(eval $(call BuildPackage,python3-schedule-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:

- Add [python-schedule](https://pypi.org/project/schedule/) package
Fixes: #9252

- It requires python3-logging as dependency otherwise it throws this error:
```
  File "/usr/lib/python3.7/site-packages/schedule/__init__.py", line 48, in <module>
    logger = logging.getLogger('schedule')
AttributeError: module 'logging' has no attribute 'getLogger'
```

____

CC for review Python maintainters: @jefferyto , @commodo 