### PR TITLE
frp: add uci config integration

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
 PKG_VERSION:=0.27.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v${PKG_VERSION}?
@@ -25,6 +25,7 @@ include ../../lang/golang/golang-package.mk
 define Package/frp/template
   SECTION:=net
   CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
   TITLE:=frp - fast reverse proxy
   URL:=https://github.com/fatedier/frp
   DEPENDS:=$(GO_ARCH_DEPENDS)
@@ -52,8 +53,10 @@ define Package/frp/install
 
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$(2) $(1)/usr/bin/
-	$(INSTALL_DIR) $(1)/etc/frp
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/conf/$(2).ini $(1)/etc/frp/
+	$(INSTALL_DIR) $(1)/etc/frp/$(2).d/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/conf/$(2)_full.ini $(1)/etc/frp/$(2).d/
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) ./files/$(2).config $(1)/etc/config/$(2)
 	$(INSTALL_DIR) $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files/$(2).init $(1)/etc/init.d/$(2)
 endef

--- a/net/frp/files/frpc.config
+++ b/net/frp/files/frpc.config
@@ -1,0 +1,23 @@
+config init
+	option stdout 1
+	option stderr 1
+	option user frpc
+	option group frpc
+	option respawn 1
+#	OS environments pass to frp for config file template, see
+#	https://github.com/fatedier/frp#configuration-file-template
+#	list env 'ENV_NAME=value'
+#	Config files include in temporary config file.
+#	list conf_inc '/etc/frp/frps.d/frpc_full.ini'
+
+config conf 'common'
+	option server_addr 127.0.0.1
+	option server_port 7000
+#	List options with name="_" will be directly appended to config file
+#	list _ '# Key-A=Value-A'
+
+config conf 'ssh'
+	option type tcp
+	option local_ip 127.0.0.1
+	option local_port 22
+	option remote_port 6000

--- a/net/frp/files/frpc.init
+++ b/net/frp/files/frpc.init
@@ -3,14 +3,70 @@
 START=99
 USE_PROCD=1
 
+NAME=frpc
+PROG=/usr/bin/$NAME
+
+_err() {
+	echo "$*" >&2
+	logger -p daemon.err -t "$NAME" "$*"
+}
+
+config_cb() {
+	[ $# -eq 0 ] && return
+
+	local type="$1"
+	local name="$2"
+	if [ "$type" = "conf" ]; then
+		echo "[$name]" >> "$conf_file"
+		option_cb() {
+			local option="$1"
+			local value="$2"
+			echo "$option = $value" >> "$conf_file"
+		}
+		list_cb() {
+			local name="$1"
+			local value="$2"
+			[ "$name" = "_" ] && echo "$value" >> "$conf_file"
+		}
+	else
+		[ "$type" = "init" ] && init_cfg="$name"
+		option_cb() { return 0; }
+		list_cb() { return 0; }
+	fi
+}
+
 start_service() {
+	local init_cfg=" "
+	local conf_file="/var/etc/$NAME.ini"
+
+	> "$conf_file"
+	config_load "$NAME"
+
+	local stdout stderr user group respawn env conf_inc
+	uci_validate_section "$NAME" init "$init_cfg" \
+		'stdout:bool:1' \
+		'stderr:bool:1' \
+		'user:string' \
+		'group:string' \
+		'respawn:bool:1' \
+		'env:list(string)' \
+		'conf_inc:list(string)'
+
+	local err=$?
+	[ $err -ne 0 ] && {
+		_err "uci_validate_section returned $err"
+		return 1
+	}
+
+	[ -n "$conf_inc" ] && config_list_foreach "$init_cfg" conf_inc cat >> "$conf_file"
+
 	procd_open_instance
-	procd_set_param command /usr/bin/frpc -c /etc/frp/frpc.ini
-	procd_set_param file /etc/frp/frpc.ini
-	procd_set_param stdout 1
-	procd_set_param stderr 1
-	procd_set_param user nobody
-	procd_set_param group nogroup
-	procd_set_param respawn
+	procd_set_param command "$PROG" -c "$conf_file"
+	procd_set_param stdout $stdout
+	procd_set_param stderr $stderr
+	[ -n "$user" ] && procd_set_param user "$user"
+	[ -n "$group" ] && procd_set_param group "$group"
+	[ $respawn -eq 1 ] && procd_set_param respawn
+	[ -n "$env" ] && config_list_foreach "$init_cfg" env "procd_append_param env"
 	procd_close_instance
 }

--- a/net/frp/files/frps.config
+++ b/net/frp/files/frps.config
@@ -1,0 +1,16 @@
+config init
+	option stdout 1
+	option stderr 1
+	option user frps
+	option group frps
+	option respawn 1
+#	OS environments pass to frp for config file template, see
+#	https://github.com/fatedier/frp#configuration-file-template
+#	list env 'ENV_NAME=value'
+#	Config files include in temporary config file.
+#	list conf_inc '/etc/frp/frps.d/frps_full.ini'
+
+config conf 'common'
+	option bind_port 7000
+#	List options with name="_" will be directly appended to config file
+#	list _ '# Key-A=Value-A'

--- a/net/frp/files/frps.init
+++ b/net/frp/files/frps.init
@@ -3,14 +3,70 @@
 START=99
 USE_PROCD=1
 
+NAME=frps
+PROG=/usr/bin/$NAME
+
+_err() {
+	echo "$*" >&2
+	logger -p daemon.err -t "$NAME" "$*"
+}
+
+config_cb() {
+	[ $# -eq 0 ] && return
+
+	local type="$1"
+	local name="$2"
+	if [ "$type" = "conf" ]; then
+		echo "[$name]" >> "$conf_file"
+		option_cb() {
+			local option="$1"
+			local value="$2"
+			echo "$option = $value" >> "$conf_file"
+		}
+		list_cb() {
+			local name="$1"
+			local value="$2"
+			[ "$name" = "_" ] && echo "$value" >> "$conf_file"
+		}
+	else
+		[ "$type" = "init" ] && init_cfg="$name"
+		option_cb() { return 0; }
+		list_cb() { return 0; }
+	fi
+}
+
 start_service() {
+	local init_cfg=" "
+	local conf_file="/var/etc/$NAME.ini"
+
+	> "$conf_file"
+	config_load "$NAME"
+
+	local stdout stderr user group respawn env conf_inc
+	uci_validate_section "$NAME" init "$init_cfg" \
+		'stdout:bool:1' \
+		'stderr:bool:1' \
+		'user:string' \
+		'group:string' \
+		'respawn:bool:1' \
+		'env:list(string)' \
+		'conf_inc:list(string)'
+
+	local err=$?
+	[ $err -ne 0 ] && {
+		_err "uci_validate_section returned $err"
+		return 1
+	}
+
+	[ -n "$conf_inc" ] && config_list_foreach "$init_cfg" conf_inc cat >> "$conf_file"
+
 	procd_open_instance
-	procd_set_param command /usr/bin/frps -c /etc/frp/frps.ini
-	procd_set_param file /etc/frp/frps.ini
-	procd_set_param stdout 1
-	procd_set_param stderr 1
-	procd_set_param user nobody
-	procd_set_param group nogroup
-	procd_set_param respawn
+	procd_set_param command "$PROG" -c "$conf_file"
+	procd_set_param stdout $stdout
+	procd_set_param stderr $stderr
+	[ -n "$user" ] && procd_set_param user "$user"
+	[ -n "$group" ] && procd_set_param group "$group"
+	[ $respawn -eq 1 ] && procd_set_param respawn
+	[ -n "$env" ] && config_list_foreach "$init_cfg" env "procd_append_param env"
 	procd_close_instance
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: x86-64 snapshot, mt7621 18.06.2
Run tested: x86-64 snapshot, mt7621 18.06.2

Description:
Add uci config integration for frp. This basically an uci-to-ini converter since the config file is complicated.
Also add `SUBMENU:=Web Servers/Proxies` to `Package/frp/template` (https://github.com/openwrt/packages/pull/9267#issuecomment-505311457).

Description for config file:
frp has a feature of modifying http header, however '-' is not allowed in uci options name.
https://github.com/fatedier/frp/blob/95444ea46b40ca4b7f636a66530f48e8b68969bf/conf/frpc_full.ini#L139-L140
So list options with name="_" will be directly appended to config file to bypass such limit.