### PR TITLE
nfs-kernel-server: Fix compile with uClibc-ng

### DIFF
--- a/net/nfs-kernel-server/Makefile
+++ b/net/nfs-kernel-server/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfs-kernel-server
 PKG_VERSION:=2.3.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_HASH:=8a6bafd5a33c4259e6e5093d126384cbe33acb10135578b5faa60c40f2f5e995
 
 PKG_SOURCE_URL:=@SF/nfs

--- a/net/nfs-kernel-server/patches/102-uclibc-ns-maxmsg.patch
+++ b/net/nfs-kernel-server/patches/102-uclibc-ns-maxmsg.patch
@@ -1,0 +1,13 @@
+--- a/support/nfsidmap/libnfsidmap.c
++++ b/support/nfsidmap/libnfsidmap.c
+@@ -89,6 +89,10 @@ gid_t nobody_gid = (gid_t)-1;
+ #define NFS4DNSTXTREC "_nfsv4idmapdomain"
+ #endif
+ 
++#ifndef NS_MAXMSG
++#define NS_MAXMSG 65535
++#endif
++
+ /* Default logging fuction */
+ static void default_logger(const char *fmt, ...)
+ {


### PR DESCRIPTION
NS_MAXMSG is not defined.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: arc700