### PR TITLE
django packages: convert to python packaging format + add python3 variant

### DIFF
--- a/lang/python/django-appconf/Makefile
+++ b/lang/python/django-appconf/Makefile
@@ -9,39 +9,62 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-appconf
 PKG_VERSION:=1.0.2
-PKG_RELEASE:=3
-PKG_LICENSE:=BSD-3-Clause
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/34/b9/d07195652ab494b026f7cb0341dd6e5f2e6e39be177abe05e2cec8bd46e4/
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/$(PKG_NAME)/
 PKG_HASH:=6a4d9aea683b4c224d97ab8ee11ad2d29a37072c0c6c509896dd9857466fb261
+
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/django-appconf
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/$(PKG_NAME)/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  TITLE:=A helper class for handling configuration defaults of packaged apps gracefully.
-  URL:=http://django-appconf.readthedocs.org/
-  DEPENDS:=+python +python-django
+  TITLE:=Helper class for handling config defaults
+  URL:=https://$(PKG_NAME).readthedocs.io
 endef
 
-define Package/django-appconf/description
-  A helper class for handling configuration defaults of packaged apps gracefully.
+define Package/python-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python-$(PKG_NAME):python \
+	+PACKAGE_python-$(PKG_NAME):python-django
+  VARIANT:=python
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python-$(PKG_NAME)/description
+  A helper class for handling configuration defaults of packaged apps gracefully
 endef
 
-define Package/django-appconf/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
+define Package/python3-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python3-$(PKG_NAME):python3 \
+	+PACKAGE_python3-$(PKG_NAME):python3-django
+  VARIANT:=python3
 endef
 
-$(eval $(call BuildPackage,django-appconf))
+define Package/python3-$(PKG_NAME)/description
+$(call define Package/python-$(PKG_NAME)/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)-src))
+
+$(eval $(call Py3Package,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)-src))

--- a/lang/python/django-compressor/Makefile
+++ b/lang/python/django-compressor/Makefile
@@ -9,38 +9,69 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-compressor
 PKG_VERSION:=2.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
+
+PKG_SOURCE:=django_compressor-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/$(PKG_NAME)/
+PKG_HASH:=9616570e5b08e92fa9eadc7a1b1b49639cce07ef392fc27c74230ab08075b30f
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_SOURCE:=django_compressor-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/82/76/1355459f90714517c52f264aa7245b52e59a273ec16e8f8d505fa6c342f8/
-PKG_HASH:=9616570e5b08e92fa9eadc7a1b1b49639cce07ef392fc27c74230ab08075b30f
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/django_compressor-$(PKG_VERSION)/
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/django-compressor
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/$(PKG_NAME)/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Compress CSS/JS into single cached files
-  URL:=http://django-compressor.readthedocs.org/
-  DEPENDS:=+python +python-django +django-appconf +python-rcssmin
+  URL:=https://$(PKG_NAME).readthedocs.io
+endef
+
+define Package/python-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python-$(PKG_NAME):python \
+	+PACKAGE_python-$(PKG_NAME):python-django \
+	+PACKAGE_python-$(PKG_NAME):python-django-appconf \
+	+PACKAGE_python-$(PKG_NAME):python-rcssmin
   VARIANT:=python
 endef
 
-define Package/django-compressor/description
+define Package/python-$(PKG_NAME)/description
   Compresses linked and inline JavaScript or CSS into single cached files.
   Note that the JavaScript filter is not being installed as a dependency.
   You'll need to build the rjsmin module (it is not par of the openwrt standard
   feeds) to use JavaScript functionality.
 endef
 
-$(eval $(call PyPackage,django-compressor))
-$(eval $(call BuildPackage,django-compressor))
-$(eval $(call BuildPackage,django-compressor-src))
+define Package/python3-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python3-$(PKG_NAME):python3 \
+	+PACKAGE_python3-$(PKG_NAME):python3-django \
+	+PACKAGE_python3-$(PKG_NAME):python3-django-appconf \
+	+PACKAGE_python3-$(PKG_NAME):python3-rcssmin
+  VARIANT:=python3
+endef
+
+define Package/python3-$(PKG_NAME)/description
+$(call define Package/python-$(PKG_NAME)/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)-src))
+
+$(eval $(call Py3Package,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)-src))

--- a/lang/python/django-formtools/Makefile
+++ b/lang/python/django-formtools/Makefile
@@ -7,34 +7,63 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-formtools
 PKG_VERSION:=2.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
-PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/$(PKG_NAME)/
+PKG_HASH:=7703793f1675aa6e871f9fed147e8563816d7a5b9affdc5e3459899596217f7c
+
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/${PKG_NAME}
-PKG_HASH:=7703793f1675aa6e871f9fed147e8563816d7a5b9affdc5e3459899596217f7c
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/django-formtools
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/$(PKG_NAME)/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=High-level abstractions for Django forms
-  URL:=https://django-formtools.readthedocs.io/en/latest/
-  DEPENDS:=+python +python-django
+  URL:=https://$(PKG_NAME).readthedocs.io
+endef
+
+define Package/python-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python-$(PKG_NAME):python \
+	+PACKAGE_python-$(PKG_NAME):python-django
   VARIANT:=python
 endef
 
-define Package/django-formtools/description
+define Package/python-$(PKG_NAME)/description
   Django "formtools" is a set of high-level abstractions for Django forms.
   Currently for form previews and multi-step forms.
 endef
 
-$(eval $(call PyPackage,django-formtools))
-$(eval $(call BuildPackage,django-formtools))
-$(eval $(call BuildPackage,django-formtools-src))
+define Package/python3-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python3-$(PKG_NAME):python3 \
+	+PACKAGE_python3-$(PKG_NAME):python3-django
+  VARIANT:=python3
+endef
+
+define Package/python3-$(PKG_NAME)/description
+$(call define Package/python-$(PKG_NAME)/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)-src))
+
+$(eval $(call Py3Package,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)-src))

--- a/lang/python/django-jsonfield/Makefile
+++ b/lang/python/django-jsonfield/Makefile
@@ -9,39 +9,62 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-jsonfield
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=3
-PKG_LICENSE:=BSD-3-Clause
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/e4/b2/a079f0a2218e0eb7892edbf404e0bbfbb281a6bbf06966b775f5142ed159/
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/$(PKG_NAME)/
 PKG_HASH:=6c0afd5554739365b55d86e285cf966cc3a45682fff963463364ea1f6511ca3e
+
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/django-jsonfield
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/$(PKG_NAME)/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=JSONField for django models
-  URL:=https://github.com/bradjasper/django-jsonfield
-  DEPENDS:=+python +python-django
+  URL:=https://github.com/adamchainz/django-jsonfield
 endef
 
-define Package/django-jsonfield/description
+define Package/python-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python-$(PKG_NAME):python \
+	+PACKAGE_python-$(PKG_NAME):python-django
+  VARIANT:=python
+endef
+
+define Package/python-$(PKG_NAME)/description
   JSONField for django models
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python3-$(PKG_NAME):python3 \
+	+PACKAGE_python3-$(PKG_NAME):python3-django
+  VARIANT:=python3
 endef
 
-define Package/django-jsonfield/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
+define Package/python3-$(PKG_NAME)/description
+$(call define Package/python-$(PKG_NAME)/description)
+.
+(Variant for Python3)
 endef
 
-$(eval $(call BuildPackage,django-jsonfield))
+$(eval $(call PyPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)-src))
+
+$(eval $(call Py3Package,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)-src))

--- a/lang/python/django-picklefield/Makefile
+++ b/lang/python/django-picklefield/Makefile
@@ -10,38 +10,61 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=django-picklefield
 PKG_VERSION:=1.1.0
 PKG_RELEASE:=3
-PKG_LICENSE:=MIT
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/django-picklefield
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/$(PKG_NAME)/
 PKG_HASH:=ce7fee5c6558fe5dc8924993d994ccde75bb75b91cd82787cbd4c92b95a69f9c
+
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/django-picklefield
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/$(PKG_NAME)/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Pickled object field for Django
-  URL:=https://github.com/gintas/django-picklefield
-  DEPENDS:=+python +python-django
+  URL:=https://github.com/gintas/django-picklefield/
 endef
 
-define Package/django-picklefield/description
+define Package/python-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python-$(PKG_NAME):python \
+	+PACKAGE_python-$(PKG_NAME):python-django
+  VARIANT:=python
+endef
+
+define Package/python-$(PKG_NAME)/description
   Pickled object field for Django
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python3-$(PKG_NAME):python3 \
+	+PACKAGE_python3-$(PKG_NAME):python3-django
+  VARIANT:=python3
 endef
 
-define Package/django-picklefield/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
+define Package/python3-$(PKG_NAME)/description
+$(call define Package/python-$(PKG_NAME)/description)
+.
+(Variant for Python3)
 endef
 
-$(eval $(call BuildPackage,django-picklefield))
+$(eval $(call PyPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)-src))
+
+$(eval $(call Py3Package,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)-src))

--- a/lang/python/django-postoffice/Makefile
+++ b/lang/python/django-postoffice/Makefile
@@ -9,40 +9,65 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-postoffice
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=3
-PKG_LICENSE:=MIT
+PKG_RELEASE:=4
 
 PKG_SOURCE:=django-post_office-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/django-post_office
 PKG_HASH:=827937a944fe47cea393853069cd9315d080298c8ddb0faf787955d6aa51a030
-PKG_BUILD_DIR:=$(BUILD_DIR)/django-post_office-$(PKG_VERSION)
+
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.txt
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/django-postoffice
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/$(PKG_NAME)/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  TITLE:=A Django app to monitor and send mail asynchronously, complete with template support.
-  URL:=https://github.com/ui/django-postoffice
-  DEPENDS:=+python +python-django +django-jsonfield
+  TITLE:=A Django app to monitor and send mail asynchronously
+  URL:=https://github.com/ui/django-post_office
 endef
 
-define Package/django-postoffice/description
-  A Django app to monitor and send mail asynchronously, complete with template support.
+define Package/python-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python-$(PKG_NAME):python \
+	+PACKAGE_python-$(PKG_NAME):python-django \
+	+PACKAGE_python-$(PKG_NAME):python-django-jsonfield
+  VARIANT:=python
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python-$(PKG_NAME)/description
+  A Django app to monitor and send mail asynchronously, complete with template
+  support
 endef
 
-define Package/django-postoffice/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
+define Package/python3-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python3-$(PKG_NAME):python3 \
+	+PACKAGE_python3-$(PKG_NAME):python3-django \
+	+PACKAGE_python3-$(PKG_NAME):python3-django-jsonfield
+  VARIANT:=python3
 endef
 
-$(eval $(call BuildPackage,django-postoffice))
+define Package/python3-$(PKG_NAME)/description
+$(call define Package/python-$(PKG_NAME)/description)
+.
+(Variant for Python3)
+endef
+
+$(eval $(call PyPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)-src))
+
+$(eval $(call Py3Package,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)-src))

--- a/lang/python/django-restframework/Makefile
+++ b/lang/python/django-restframework/Makefile
@@ -9,40 +9,62 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-restframework
 PKG_VERSION:=3.9.0
-PKG_RELEASE:=3
-PKG_LICENSE:=BSD-3-Clause
+PKG_RELEASE:=4
 
 PKG_SOURCE:=djangorestframework-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/djangorestframework
 PKG_HASH:=607865b0bb1598b153793892101d881466bd5a991de12bd6229abb18b1c86136
-PKG_BUILD_DIR:=$(BUILD_DIR)/djangorestframework-$(PKG_VERSION)
+
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE.md
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/django-restframework
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/$(PKG_NAME)/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Web APIs for Django, made easy.
   URL:=https://www.django-rest-framework.org
-  DEPENDS:=+python +python-django
 endef
 
-define Package/django-restframework/description
+define Package/python-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python-$(PKG_NAME):python \
+	+PACKAGE_python-$(PKG_NAME):python-django
+  VARIANT:=python
+endef
+
+define Package/python-$(PKG_NAME)/description
   Web APIs for Django, made easy.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root=$(PKG_INSTALL_DIR))
+define Package/python3-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS:= \
+	+PACKAGE_python3-$(PKG_NAME):python3 \
+	+PACKAGE_python3-$(PKG_NAME):python3-django
+  VARIANT:=python3
 endef
 
-define Package/django-restframework/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
+define Package/python3-$(PKG_NAME)/description
+$(call define Package/python-$(PKG_NAME)/description)
+.
+(Variant for Python3)
 endef
 
-$(eval $(call BuildPackage,django-restframework))
+$(eval $(call PyPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)))
+$(eval $(call BuildPackage,python-$(PKG_NAME)-src))
+
+$(eval $(call Py3Package,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)))
+$(eval $(call BuildPackage,python3-$(PKG_NAME)-src))

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -25,7 +25,7 @@ include ../../lang/python/python-package.mk
 SEAFILE_PYTHON_DEPENDS:= \
 	simplejson chardet dateutil mysql pytz qrcode requests requests-oauthlib \
 	django django-constance django-appconf django-compressor django-formtools \
-	django-jsonfield
+	django-jsonfield django-picklefield 
 
 define Package/seafile-seahub
   SECTION:=net
@@ -33,7 +33,7 @@ define Package/seafile-seahub
   TITLE:=Seafile server - seahub component
   URL:=https://seafile.com/
   DEPENDS:=+python +pillow \
-	+django-picklefield +django-postoffice +django-restframework \
+	+django-postoffice +django-restframework \
 	+django-simple-captcha +django-statici18n +django-webpack-loader \
 	+python-flup +gunicorn +openpyxl \
 	$(foreach dep,$(SEAFILE_PYTHON_DEPENDS),+python-$(dep))

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -25,7 +25,7 @@ include ../../lang/python/python-package.mk
 SEAFILE_PYTHON_DEPENDS:= \
 	simplejson chardet dateutil mysql pytz qrcode requests requests-oauthlib \
 	django django-constance django-appconf django-compressor django-formtools \
-	django-jsonfield django-picklefield django-postoffice
+	django-jsonfield django-picklefield django-postoffice django-restframework
 
 define Package/seafile-seahub
   SECTION:=net
@@ -33,7 +33,6 @@ define Package/seafile-seahub
   TITLE:=Seafile server - seahub component
   URL:=https://seafile.com/
   DEPENDS:=+python +pillow \
-	+django-restframework \
 	+django-simple-captcha +django-statici18n +django-webpack-loader \
 	+python-flup +gunicorn +openpyxl \
 	$(foreach dep,$(SEAFILE_PYTHON_DEPENDS),+python-$(dep))

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -24,7 +24,7 @@ include ../../lang/python/python-package.mk
 
 SEAFILE_PYTHON_DEPENDS:= \
 	simplejson chardet dateutil mysql pytz qrcode requests requests-oauthlib \
-	django django-constance django-appconf django-compressor
+	django django-constance django-appconf django-compressor django-formtools
 
 define Package/seafile-seahub
   SECTION:=net
@@ -32,7 +32,7 @@ define Package/seafile-seahub
   TITLE:=Seafile server - seahub component
   URL:=https://seafile.com/
   DEPENDS:=+python +pillow \
-	+django-formtools +django-jsonfield \
+	+django-jsonfield \
 	+django-picklefield +django-postoffice +django-restframework \
 	+django-simple-captcha +django-statici18n +django-webpack-loader \
 	+python-flup +gunicorn +openpyxl \

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -9,15 +9,19 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-seahub
 PKG_VERSION:=6.3.4
-PKG_RELEASE:=5
-PKG_LICENSE:=Apache-2.0
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/haiwen/seahub/tar.gz/v$(PKG_VERSION)-server?
 PKG_HASH:=53a9efdb6791fd3a2a191e89cb0f133632056046ec08adbb2ad72088e6161430
-PKG_BUILD_DIR:=$(BUILD_DIR)/seahub-$(PKG_VERSION)-server
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE.txt
 
 HOST_PYTHON_PACKAGE_BUILD_DEPENDS:="django>=1.11"
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/seahub-$(PKG_VERSION)-server
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python-package.mk

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -24,14 +24,14 @@ include ../../lang/python/python-package.mk
 
 SEAFILE_PYTHON_DEPENDS:= \
 	simplejson chardet dateutil mysql pytz qrcode requests requests-oauthlib \
-	django django-constance
+	django django-constance django-appconf
 
 define Package/seafile-seahub
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Seafile server - seahub component
   URL:=https://seafile.com/
-  DEPENDS:=+python +pillow +django-appconf \
+  DEPENDS:=+python +pillow \
 	+django-compressor +django-formtools +django-jsonfield \
 	+django-picklefield +django-postoffice +django-restframework \
 	+django-simple-captcha +django-statici18n +django-webpack-loader \

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -24,7 +24,8 @@ include ../../lang/python/python-package.mk
 
 SEAFILE_PYTHON_DEPENDS:= \
 	simplejson chardet dateutil mysql pytz qrcode requests requests-oauthlib \
-	django django-constance django-appconf django-compressor django-formtools
+	django django-constance django-appconf django-compressor django-formtools \
+	django-jsonfield
 
 define Package/seafile-seahub
   SECTION:=net
@@ -32,7 +33,6 @@ define Package/seafile-seahub
   TITLE:=Seafile server - seahub component
   URL:=https://seafile.com/
   DEPENDS:=+python +pillow \
-	+django-jsonfield \
 	+django-picklefield +django-postoffice +django-restframework \
 	+django-simple-captcha +django-statici18n +django-webpack-loader \
 	+python-flup +gunicorn +openpyxl \

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -24,7 +24,7 @@ include ../../lang/python/python-package.mk
 
 SEAFILE_PYTHON_DEPENDS:= \
 	simplejson chardet dateutil mysql pytz qrcode requests requests-oauthlib \
-	django django-constance django-appconf
+	django django-constance django-appconf django-compressor
 
 define Package/seafile-seahub
   SECTION:=net
@@ -32,7 +32,7 @@ define Package/seafile-seahub
   TITLE:=Seafile server - seahub component
   URL:=https://seafile.com/
   DEPENDS:=+python +pillow \
-	+django-compressor +django-formtools +django-jsonfield \
+	+django-formtools +django-jsonfield \
 	+django-picklefield +django-postoffice +django-restframework \
 	+django-simple-captcha +django-statici18n +django-webpack-loader \
 	+python-flup +gunicorn +openpyxl \

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -25,7 +25,7 @@ include ../../lang/python/python-package.mk
 SEAFILE_PYTHON_DEPENDS:= \
 	simplejson chardet dateutil mysql pytz qrcode requests requests-oauthlib \
 	django django-constance django-appconf django-compressor django-formtools \
-	django-jsonfield django-picklefield 
+	django-jsonfield django-picklefield django-postoffice
 
 define Package/seafile-seahub
   SECTION:=net
@@ -33,7 +33,7 @@ define Package/seafile-seahub
   TITLE:=Seafile server - seahub component
   URL:=https://seafile.com/
   DEPENDS:=+python +pillow \
-	+django-postoffice +django-restframework \
+	+django-restframework \
 	+django-simple-captcha +django-statici18n +django-webpack-loader \
 	+python-flup +gunicorn +openpyxl \
 	$(foreach dep,$(SEAFILE_PYTHON_DEPENDS),+python-$(dep))


### PR DESCRIPTION
Maintainer: me / @cotequeiroz 
Compile tested: https://github.com/openwrt/openwrt/commit/bc47285cb3c0125424e628521f905f1f0d7b4cef  x86
Run tested: N/A

These changes convert a bunch of django packages to the python packaging format + adding python3 variants.
The aim is to have them ready to be able to switch seafile/seahub to Python3 (at a later point in time).

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>