### PR TITLE
seafile-seahub: adjust to flup rename

### DIFF
--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-seahub
 PKG_VERSION:=6.3.4
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_LICENSE:=Apache-2.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -35,7 +35,7 @@ define Package/seafile-seahub
 	+django-compressor +django-formtools +django-jsonfield \
 	+django-picklefield +django-postoffice +django-restframework \
 	+django-simple-captcha +django-statici18n +django-webpack-loader \
-	+flup +gunicorn +openpyxl \
+	+python-flup +gunicorn +openpyxl \
 	$(foreach dep,$(SEAFILE_PYTHON_DEPENDS),+python-$(dep))
 endef
 


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: `make menu` tested (this is a trivial change)
Run tested: none

Description:
This adjusts seafile-seahub DEPENDS to flup package rename to python-flup.  Increasing `PKG_RELEASE` since this changes the package's install-time dependencies.

Fixes #9326 

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>