### PR TITLE
pulseaudio: fix recursive dependencies

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pulseaudio
 PKG_VERSION:=12.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://freedesktop.org/software/pulseaudio/releases/
@@ -84,7 +84,7 @@ endef
 define Package/pulseaudio-tools
   SECTION:=sound
   CATEGORY:=Sound
-  DEPENDS:=+libsndfile +pulseaudio
+  DEPENDS:=+libsndfile pulseaudio
   TITLE:=Tools for Pulseaudio
   URL:=http://www.pulseaudio.org
   VARIANT:=noavahi
@@ -93,7 +93,7 @@ endef
 define Package/pulseaudio-profiles
   SECTION:=sound
   CATEGORY:=Sound
-  DEPENDS:=+pulseaudio
+  DEPENDS:=pulseaudio
   TITLE:=Profiles for Pulseaudio
   URL:=http://www.pulseaudio.org
 endef


### PR DESCRIPTION
Since OpenWrt commit e82a4d9cfb ("config: regenerate *_shipped sources")
a few recursive dependencies have been discovered that were not visible
before.

$ make menuconfig
tmp/.config-package.in:103098:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:103098:	symbol PACKAGE_baresip-mod-pulse depends on PACKAGE_baresip-mod-pulse
tmp/.config-package.in:121863:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:121863:	symbol PACKAGE_pulseaudio-profiles depends on PACKAGE_pulseaudio-profiles
tmp/.config-package.in:121878:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:121878:	symbol PACKAGE_pulseaudio-tools depends on PACKAGE_pulseaudio-tools

This commit addresses the pulseaudio package's own recursive
dependencies and partially resolves #9300 (baresip will be handled in
telephony repository).

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @tripolar
Compile tested: master/ath79
Run tested: N/A (just dependency fix)

Description:
Fix recursive dependencies