### PR TITLE
travelmate: update 1.4.8

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.4.7
+PKG_VERSION:=1.4.8
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL-AR750S, OpenWrt SNAPSHOT, r10353-3f68cffd27

Description:
* optimize the main scan/iwinfo call (performance & system load):
  - remove a needless f_trim function call
  - remove a redundant awk call
  - reduce the scan buffer size and
    make it configurable (trm_scanbuffer, default 1024 bytes)
* cosmetics

Signed-off-by: Dirk Brenken <dev@brenken.org>
