### PR TITLE
Netopeer2: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/Netopeer2/Makefile
+++ b/net/Netopeer2/Makefile
@@ -11,19 +11,18 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Netopeer2
 PKG_VERSION:=0.7-r1
-PKG_RELEASE:=2
-
-PKG_LICENSE:=BSD-3-Clause
-PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/CESNET/Netopeer2/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=040013d1e315c62c496b704475665165578c374ffb387cbbff422cf8898d3a12
 
-CMAKE_INSTALL:=1
+PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
+CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -36,7 +35,7 @@ define Package/netopeer2-server
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=NETCONF server
-  URL:=$(PKG_SOURCE_URL)
+  URL:=https://github.com/CESNET/Netopeer2
   DEPENDS:=+libcurl +libpthread +libyang +libnetconf2 +netopeer2-keystored +libsysrepo +sysrepocfg +sysrepoctl +sysrepo
   MENU:=1
 endef
@@ -45,7 +44,7 @@ define Package/netopeer2-cli
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Netopeer2 cli tool
-  URL:=$(PKG_SOURCE_URL)
+  URL:=https://github.com/CESNET/Netopeer2
   DEPENDS:=+libpthread +libyang +libnetconf2 +libopenssl
 endef
 
@@ -53,7 +52,7 @@ define Package/netopeer2-keystored
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Netopeer2 key store management
-  URL:=$(PKG_SOURCE_URL)
+  URL:=https://github.com/CESNET/Netopeer2
   DEPENDS:=+libopenssl +libsysrepo +sysrepo +sysrepocfg +sysrepoctl +SSH_KEYS:openssh-keygen
   MENU:=1
 endef

--- a/net/Netopeer2/patches/010-openssl-deprecated.patch
+++ b/net/Netopeer2/patches/010-openssl-deprecated.patch
@@ -1,0 +1,14 @@
+--- a/cli/commands.c
++++ b/cli/commands.c
+@@ -1659,7 +1659,11 @@ parse_cert(const char *name, const char *path)
+     BIO_printf(bio_out, "\n");
+ 
+     BIO_printf(bio_out, "Valid until: ");
++#if OPENSSL_VERSION_NUMBER < 0x10100000L // < 1.1.0
+     ASN1_TIME_print(bio_out, X509_get_notAfter(cert));
++#else
++    ASN1_TIME_print(bio_out, X509_get0_notAfter(cert));
++#endif
+     BIO_printf(bio_out, "\n");
+ 
+     has_san = 0;


### PR DESCRIPTION
Reorganized Makefile for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mislavn
Compile tested: powerpc8540