### PR TITLE
libnetconf2: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/libs/libnetconf2/Makefile
+++ b/libs/libnetconf2/Makefile
@@ -9,19 +9,18 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetconf2
 PKG_VERSION:=0.12-r1
-PKG_RELEASE:=3
-
-PKG_LICENSE:=BSD-3-Clause
-PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/CESNET/libnetconf2/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=86269d3f1bc85bb17d8823d214f9a676ee3b14ee18a0b87a230380df8503e8f5
 
-CMAKE_INSTALL:=1
+PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
+CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -30,7 +29,7 @@ define Package/libnetconf2
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=NETCONF library
-  URL:=$(PKG_SOURCE_URL)
+  URL:=https://github.com/CESNET/libnetconf2
   DEPENDS:= +libyang +libssh +libopenssl +libpthread
 endef
 
@@ -44,21 +43,6 @@ endef
 CMAKE_OPTIONS += \
 	-DCMAKE_INSTALL_PREFIX:PATH=/usr \
 	-DCMAKE_BUILD_TYPE:STRING=Release
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include/libnetconf2
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/libnetconf2/*.h $(1)/usr/include/libnetconf2/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
-
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetconf2.so* $(1)/usr/lib/
-
-	$(INSTALL_DIR) $(1)/usr/include/libnetconf2
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/include/libnetconf2/* $(1)/usr/include/libnetconf2/
-
-	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libnetconf2.pc $(1)/usr/lib/pkgconfig/
-endef
 
 define Package/libnetconf2/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/libnetconf2/patches/020-openssl-deprecated.patch
+++ b/libs/libnetconf2/patches/020-openssl-deprecated.patch
@@ -1,0 +1,160 @@
+--- a/src/session.c
++++ b/src/session.c
+@@ -1372,11 +1372,11 @@ tls_thread_id_func(CRYPTO_THREADID *tid)
+ static void
+ nc_tls_init(void)
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L // < 1.1.0
+     SSL_load_error_strings();
+     ERR_load_BIO_strings();
+     SSL_library_init();
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L // < 1.1.0
+     int i;
+ 
+     tls_locks = malloc(CRYPTO_num_locks() * sizeof *tls_locks);
+@@ -1400,6 +1400,7 @@ nc_tls_init(void)
+ static void
+ nc_tls_destroy(void)
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L // < 1.1.0
+     FIPS_mode_set(0);
+     CRYPTO_cleanup_all_ex_data();
+     nc_thread_destroy();
+@@ -1411,7 +1412,6 @@ nc_tls_destroy(void)
+     SSL_COMP_free_compression_methods();
+ #endif
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L // < 1.1.0
+     int i;
+ 
+     CRYPTO_THREADID_set_callback(NULL);
+@@ -1434,13 +1434,13 @@ nc_tls_destroy(void)
+ static void
+ nc_ssh_tls_init(void)
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L // < 1.1.0
+     SSL_load_error_strings();
+     ERR_load_BIO_strings();
+     SSL_library_init();
+ 
+     nc_ssh_init();
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L // < 1.1.0
+     CRYPTO_set_dynlock_create_callback(tls_dyn_create_func);
+     CRYPTO_set_dynlock_lock_callback(tls_dyn_lock_func);
+     CRYPTO_set_dynlock_destroy_callback(tls_dyn_destroy_func);
+@@ -1450,6 +1450,7 @@ nc_ssh_tls_init(void)
+ static void
+ nc_ssh_tls_destroy(void)
+ {
++#if OPENSSL_VERSION_NUMBER < 0x10100000L // < 1.1.0
+     ERR_free_strings();
+ #if OPENSSL_VERSION_NUMBER < 0x10002000L // < 1.0.2
+     sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
+@@ -1459,7 +1460,6 @@ nc_ssh_tls_destroy(void)
+ 
+     nc_ssh_destroy();
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L // < 1.1.0
+     CRYPTO_set_dynlock_create_callback(NULL);
+     CRYPTO_set_dynlock_lock_callback(NULL);
+     CRYPTO_set_dynlock_destroy_callback(NULL);
+--- a/src/session_client_tls.c
++++ b/src/session_client_tls.c
+@@ -29,6 +29,10 @@
+ #include "session_client_ch.h"
+ #include "libnetconf.h"
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#define X509_STORE_CTX_get_by_subject X509_STORE_get_by_subject
++#endif
++
+ struct nc_client_context *nc_client_context_location(void);
+ int nc_session_new_ctx( struct nc_session *session, struct ly_ctx *ctx);
+ 
+@@ -74,7 +78,7 @@ tlsauth_verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx)
+     store_ctx = X509_STORE_CTX_new();
+     obj = X509_OBJECT_new();
+     X509_STORE_CTX_init(store_ctx, opts->crl_store, NULL, NULL);
+-    rc = X509_STORE_get_by_subject(store_ctx, X509_LU_CRL, subject, obj);
++    rc = X509_STORE_CTX_get_by_subject(store_ctx, X509_LU_CRL, subject, obj);
+     X509_STORE_CTX_free(store_ctx);
+     crl = X509_OBJECT_get0_X509_CRL(obj);
+     if (rc > 0 && crl) {
+@@ -113,7 +117,7 @@ tlsauth_verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx)
+     store_ctx = X509_STORE_CTX_new();
+     obj = X509_OBJECT_new();
+     X509_STORE_CTX_init(store_ctx, opts->crl_store, NULL, NULL);
+-    rc = X509_STORE_get_by_subject(store_ctx, X509_LU_CRL, issuer, obj);
++    rc = X509_STORE_CTX_get_by_subject(store_ctx, X509_LU_CRL, issuer, obj);
+     X509_STORE_CTX_free(store_ctx);
+     crl = X509_OBJECT_get0_X509_CRL(obj);
+     if (rc > 0 && crl) {
+@@ -169,7 +173,7 @@ tlsauth_verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx)
+      * the current certificate in order to verify it's integrity */
+     memset((char *)&obj, 0, sizeof obj);
+     X509_STORE_CTX_init(&store_ctx, opts->crl_store, NULL, NULL);
+-    rc = X509_STORE_get_by_subject(&store_ctx, X509_LU_CRL, subject, &obj);
++    rc = X509_STORE_CTX_get_by_subject(&store_ctx, X509_LU_CRL, subject, &obj);
+     X509_STORE_CTX_cleanup(&store_ctx);
+     crl = obj.data.crl;
+     if (rc > 0 && crl) {
+@@ -207,7 +211,7 @@ tlsauth_verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx)
+      * the current certificate in order to check for revocation */
+     memset((char *)&obj, 0, sizeof obj);
+     X509_STORE_CTX_init(&store_ctx, opts->crl_store, NULL, NULL);
+-    rc = X509_STORE_get_by_subject(&store_ctx, X509_LU_CRL, issuer, &obj);
++    rc = X509_STORE_CTX_get_by_subject(&store_ctx, X509_LU_CRL, issuer, &obj);
+     X509_STORE_CTX_cleanup(&store_ctx);
+     crl = obj.data.crl;
+     if (rc > 0 && crl) {
+--- a/src/session_server_tls.c
++++ b/src/session_server_tls.c
+@@ -28,6 +28,10 @@
+ #include "session_server_ch.h"
+ #include "libnetconf.h"
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#define X509_STORE_CTX_get_by_subject X509_STORE_get_by_subject
++#endif
++
+ struct nc_server_tls_opts tls_ch_opts;
+ pthread_mutex_t tls_ch_opts_lock = PTHREAD_MUTEX_INITIALIZER;
+ extern struct nc_server_opts server_opts;
+@@ -563,7 +567,7 @@ nc_tlsclb_verify(int preverify_ok, X509_STORE_CTX *x509_ctx)
+         store_ctx = X509_STORE_CTX_new();
+         obj = X509_OBJECT_new();
+         X509_STORE_CTX_init(store_ctx, opts->crl_store, NULL, NULL);
+-        rc = X509_STORE_get_by_subject(store_ctx, X509_LU_CRL, subject, obj);
++        rc = X509_STORE_CTX_get_by_subject(store_ctx, X509_LU_CRL, subject, obj);
+         X509_STORE_CTX_free(store_ctx);
+         crl = X509_OBJECT_get0_X509_CRL(obj);
+         if (rc > 0 && crl) {
+@@ -616,7 +620,7 @@ nc_tlsclb_verify(int preverify_ok, X509_STORE_CTX *x509_ctx)
+         store_ctx = X509_STORE_CTX_new();
+         obj = X509_OBJECT_new();
+         X509_STORE_CTX_init(store_ctx, opts->crl_store, NULL, NULL);
+-        rc = X509_STORE_get_by_subject(store_ctx, X509_LU_CRL, issuer, obj);
++        rc = X509_STORE_CTX_get_by_subject(store_ctx, X509_LU_CRL, issuer, obj);
+         X509_STORE_CTX_free(store_ctx);
+         crl = X509_OBJECT_get0_X509_CRL(obj);
+         if (rc > 0 && crl) {
+@@ -776,7 +780,7 @@ nc_tlsclb_verify(int preverify_ok, X509_STORE_CTX *x509_ctx)
+          * the current certificate in order to verify it's integrity */
+         memset((char *)&obj, 0, sizeof(obj));
+         X509_STORE_CTX_init(&store_ctx, opts->crl_store, NULL, NULL);
+-        rc = X509_STORE_get_by_subject(&store_ctx, X509_LU_CRL, subject, &obj);
++        rc = X509_STORE_CTX_get_by_subject(&store_ctx, X509_LU_CRL, subject, &obj);
+         X509_STORE_CTX_cleanup(&store_ctx);
+         crl = obj.data.crl;
+         if (rc > 0 && crl) {
+@@ -828,7 +832,7 @@ nc_tlsclb_verify(int preverify_ok, X509_STORE_CTX *x509_ctx)
+          * the current certificate in order to check for revocation */
+         memset((char *)&obj, 0, sizeof(obj));
+         X509_STORE_CTX_init(&store_ctx, opts->crl_store, NULL, NULL);
+-        rc = X509_STORE_get_by_subject(&store_ctx, X509_LU_CRL, issuer, &obj);
++        rc = X509_STORE_CTX_get_by_subject(&store_ctx, X509_LU_CRL, issuer, &obj);
+         X509_STORE_CTX_cleanup(&store_ctx);
+         crl = obj.data.crl;
+         if (rc > 0 && crl) {


### PR DESCRIPTION
Reorganized Makefile for consistency between packages.

Removed InstallDev section. It is already implied by CMAKE_INSTALL

Added PKG_BUILD_PARALLEL for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mislavn
Compile tested: powerpc8540
