### PR TITLE
coova-chili: Fix compilation with newer GCC

### DIFF
--- a/net/coova-chilli/Config.in
+++ b/net/coova-chilli/Config.in
@@ -38,8 +38,8 @@ choice
 config COOVACHILLI_NOSSL
 	bool "No SSL support"
 
-config COOVACHILLI_CYASSL
-	bool "CyaSSL"
+config COOVACHILLI_WOLFSSL
+	bool "wolfSSL"
 
 config COOVACHILLI_OPENSSL
 	bool "OpenSSL"

--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -9,18 +9,21 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coova-chilli
 PKG_VERSION:=1.4
-PKG_MAINTAINER:=Jaehoon You <teslamint@gmail.com>
-PKG_LICENSE:=GPL-2.0+
-PKG_LICENSE_FILES:=COPYING
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coova/coova-chilli/tar.gz/$(PKG_VERSION)?
 PKG_HASH:=987647a4c8efe7b1e2d7108d56068e3bd7830d326680f0eaa2c705e4c59c46d9
 
-PKG_INSTALL:=1
+PKG_MAINTAINER:=Jaehoon You <teslamint@gmail.com>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
-PKG_CONFIG_DEPENDS := \
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+PKG_CONFIG_DEPENDS:= \
   COOVACHILLI_MINIPORTAL \
   COOVACHILLI_REDIR \
   COOVACHILLI_USERAGENT \
@@ -28,7 +31,7 @@ PKG_CONFIG_DEPENDS := \
   COOVACHILLI_UAMDOMAINFILE \
   COOVACHILLI_LARGELIMITS \
   COOVACHILLI_NOSSL \
-  COOVACHILLI_CYASSL \
+  COOVACHILLI_WOLFSSL \
   COOVACHILLI_OPENSSL
 
 include $(INCLUDE_DIR)/package.mk
@@ -38,7 +41,7 @@ define Package/coova-chilli
   SUBMENU:=Captive Portals
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+kmod-tun +librt +COOVACHILLI_CYASSL:libcyassl +COOVACHILLI_OPENSSL:libopenssl
+  DEPENDS:=+kmod-tun +librt +COOVACHILLI_WOLFSSL:libwolfssl +COOVACHILLI_OPENSSL:libopenssl
   TITLE:=Wireless LAN HotSpot controller (Coova Chilli Version)
   URL:=https://coova.github.io/
   MENU:=1
@@ -75,7 +78,7 @@ endef
 
 DISABLE_NLS=
 
-TARGET_CFLAGS += $(FPIC)
+TARGET_CFLAGS += $(FPIC) -Wno-address-of-packed-member
 
 CONFIGURE_VARS += \
        ARCH="$(LINUX_KARCH)" \
@@ -109,7 +112,7 @@ define Build/Configure
 	$(if $(CONFIG_COOVACHILLI_LARGELIMITS),--enable,--disable)-largelimits \
 	$(if $(CONFIG_COOVACHILLI_UAMDOMAINFILE),--enable,--disable)-uamdomainfile \
 	$(if $(CONFIG_IPV6),--with,--without)-ipv6 \
-	$(if $(CONFIG_COOVACHILLI_CYASSL),--with,--without)-cyassl \
+	$(if $(CONFIG_COOVACHILLI_WOLFSSL),--with,--without)-cyassl \
 	$(if $(CONFIG_COOVACHILLI_OPENSSL),--with,--without)-openssl \
 	$(if $(CONFIG_PACKAGE_kmod-ipt-coova),--with-nfcoova) \
 	)

--- a/net/coova-chilli/patches/300-openssl-deprecated.patch
+++ b/net/coova-chilli/patches/300-openssl-deprecated.patch
@@ -1,0 +1,84 @@
+--- a/src/ms_chap.c
++++ b/src/ms_chap.c
+@@ -96,18 +96,18 @@ MakeKey(u_char *key, u_char *des_key)
+   des_key[6] = Get7Bits(key, 42);
+   des_key[7] = Get7Bits(key, 49);
+ 
+-  des_set_odd_parity((des_cblock *)des_key);
++  DES_set_odd_parity((DES_cblock *)des_key);
+ }
+ 
+ static void /* IN 8 octets IN 7 octest OUT 8 octets */
+ DesEncrypt(u_char *clear, u_char *key, u_char *cipher)
+ {
+-  des_cblock		des_key;
+-  des_key_schedule	key_schedule;
++  DES_cblock		des_key;
++  DES_key_schedule	key_schedule;
+ 
+   MakeKey(key, des_key);
+-  des_set_key(&des_key, key_schedule);
+-  des_ecb_encrypt((des_cblock *)clear, (des_cblock *)cipher, key_schedule, 1);
++  DES_set_key(&des_key, &key_schedule);
++  DES_ecb_encrypt((DES_cblock *)clear, (DES_cblock *)cipher, &key_schedule, 1);
+ }
+ 
+ #define LENGTH 20
+--- a/src/ssl.c
++++ b/src/ssl.c
+@@ -35,11 +35,13 @@ openssl_env * initssl() {
+     if (openssl_init == 0) {
+       openssl_init = 1;
+ #ifdef HAVE_OPENSSL
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+       if (_options.debug) {
+ 	SSL_load_error_strings();
+       }
+       SSL_library_init();
+       OpenSSL_add_all_algorithms();
++#endif
+ #else
+       matrixSslOpen();
+       syslog(LOG_DEBUG, "%s(%d): MatrixSslOpen()", __FUNCTION__, __LINE__);
+@@ -55,11 +57,13 @@ openssl_env * initssl_cli() {
+     if (openssl_init == 0) {
+       openssl_init = 1;
+ #ifdef HAVE_OPENSSL
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+       if (_options.debug) {
+ 	SSL_load_error_strings();
+       }
+       SSL_library_init();
+       OpenSSL_add_all_algorithms();
++#endif
+ #else
+       matrixSslOpen();
+       syslog(LOG_DEBUG, "%s(%d): MatrixSslOpen()", __FUNCTION__, __LINE__);
+@@ -132,7 +136,7 @@ _openssl_env_init(openssl_env *env, char *engine, int server) {
+   if (_options.sslciphers) {
+     SSL_CTX_set_cipher_list(env->ctx, _options.sslciphers);
+   }
+-#ifdef HAVE_OPENSSL_ENGINE
++#ifndef OPENSSL_NO_ENGINE
+   if (engine) {
+  retry:
+     if ((env->engine = ENGINE_by_id(engine)) == NULL) {
+@@ -609,7 +613,7 @@ openssl_env_free(openssl_env *env) {
+ #endif
+ #ifdef HAVE_OPENSSL
+   if (env->ctx) SSL_CTX_free(env->ctx);
+-#ifdef HAVE_OPENSSL_ENGINE
++#ifndef OPENSSL_NO_ENGINE
+   if (env->engine) ENGINE_free(env->engine);
+ #endif
+ #endif
+--- a/src/ssl.h
++++ b/src/ssl.h
+@@ -41,6 +41,7 @@ typedef struct {
+ #include <openssl/ssl.h>
+ #include <openssl/pem.h>
+ #include <openssl/engine.h>
++#include <openssl/err.h>
+ #elif HAVE_CYASSL
+ #include <stdio.h>
+ #include <stdlib.h>

--- a/net/coova-chilli/patches/400-wolfssl.patch
+++ b/net/coova-chilli/patches/400-wolfssl.patch
@@ -1,0 +1,53 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -397,7 +397,7 @@ AC_ARG_WITH([cyassl],
+  [AS_HELP_STRING([--with-cyassl], [enable support for cyassl])],[],[with_cyassl=no])
+ 
+ AS_IF([test x"$with_cyassl" != xno],
+-  [AC_CHECK_LIB([cyassl], [CyaSSL_Init],
++  [AC_CHECK_LIB([cyassl], [wolfSSL_Init],
+               [AC_SUBST([LIBSSL], ["-lcyassl"])
+                AC_DEFINE([HAVE_CYASSL], [1],
+                          [Define if you have cyassl])
+--- a/src/ippool.c
++++ b/src/ippool.c
+@@ -35,6 +35,7 @@ int ippool_print(int fd, struct ippool_t *this) {
+   char * sep = "-- %-15s ------------------------------------------------------------\n";
+ 
+ #define ERR 0
++#undef USED /* defined in <wolfssl/wolfcrypt/integer.h> */
+ #define USED 1
+ #define FREE 2
+ #define LIST 3
+--- a/src/md5.h
++++ b/src/md5.h
+@@ -35,7 +35,6 @@
+ #define MD5Update MD5_Update
+ #define MD5Final MD5_Final
+ 
+-typedef struct CYASSL_MD5_CTX MD5_CTX;
+ #else
+ 
+ struct MD5Context {
+--- a/src/ssl.c
++++ b/src/ssl.c
+@@ -131,7 +131,7 @@ _openssl_env_init(openssl_env *env, char *engine, int server) {
+    */
+   const long options = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION;
+   env->meth = SSLv23_method();
+-  env->ctx = SSL_CTX_new(env->meth);
++  env->ctx = SSL_CTX_new((void *)env->meth);
+   SSL_CTX_set_options(env->ctx, options);
+   if (_options.sslciphers) {
+     SSL_CTX_set_cipher_list(env->ctx, _options.sslciphers);
+--- a/src/ssl.h
++++ b/src/ssl.h
+@@ -48,6 +48,8 @@ typedef struct {
+ #include <time.h>
+ #include <string.h>
+ 
++#define OPENSSL_NO_ENGINE
++#include <cyassl/options.h>
+ #include <cyassl/ssl.h>
+ #include <cyassl/openssl/bio.h>
+ #include <cyassl/openssl/crypto.h>

--- a/net/coova-chilli/patches/500-redir.patch
+++ b/net/coova-chilli/patches/500-redir.patch
@@ -1,0 +1,44 @@
+--- a/src/redir.c
++++ b/src/redir.c
+@@ -3358,14 +3358,17 @@ int redir_main(struct redir_t *redir,
+   }
+ 
+ #define redir_memcopy(msgtype)                                          \
++  do {                                                                  \
+   redir_challenge(challenge);                                           \
+   redir_chartohex(challenge, hexchal, REDIR_MD5LEN);                    \
+   msg.mtype = msgtype;                                                  \
+   memcpy(conn.s_state.redir.uamchal, challenge, REDIR_MD5LEN);          \
+-  if (_options.debug) syslog(LOG_DEBUG, "%s(%d): ---->>> resetting challenge: %s", __FUNCTION__, __LINE__, hexchal)
++  if (_options.debug) syslog(LOG_DEBUG, "%s(%d): ---->>> resetting challenge: %s", __FUNCTION__, __LINE__, hexchal); \
++  } while (0)
+ 
+ #ifdef USING_IPC_UNIX
+ #define redir_msg_send(msgopt)                                          \
++  do {                                                                  \
+   msg.mdata.opt = msgopt;                                               \
+   memcpy(&msg.mdata.address, address, sizeof(msg.mdata.address));       \
+   memcpy(&msg.mdata.baddress, baddress, sizeof(msg.mdata.baddress));    \
+@@ -3375,9 +3378,11 @@ int redir_main(struct redir_t *redir,
+     syslog(LOG_ERR, "%s: write() failed! msgfd=%d type=%ld len=%d",     \
+            strerror(errno), redir->msgfd, msg.mtype, (int)sizeof(msg.mdata)); \
+     return redir_main_exit(&socket, forked, rreq);                      \
+-  }
++  }                                                                     \
++  } while (0)
+ #else
+ #define redir_msg_send(msgopt)                                          \
++  do {                                                                  \
+   msg.mdata.opt = msgopt;                                               \
+   memcpy(&msg.mdata.address, address, sizeof(msg.mdata.address));       \
+   memcpy(&msg.mdata.baddress, baddress, sizeof(msg.mdata.baddress));    \
+@@ -3387,7 +3392,8 @@ int redir_main(struct redir_t *redir,
+     syslog(LOG_ERR, "%s: msgsnd() failed! msgid=%d type=%ld len=%d",    \
+            strerror(errno), redir->msgid, msg.mtype, (int)sizeof(msg.mdata)); \
+     return redir_main_exit(&socket, forked, rreq);                      \
+-  }
++  }                                                                     \
++  } while (0)
+ #endif
+ 
+   /*


### PR DESCRIPTION
Added -Wno-error to fix.

Also added patch to fix compilation without deprecated OpenSSL APIs.

Added PKG_BUILD_PARALLEL for faster compilation.

Switched libcyassl to libwolfssl.

Reorganized makefile for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @teslamint 
Compile tested: powerpc8540