### PR TITLE
noddos: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/noddos/Makefile
+++ b/net/noddos/Makefile
@@ -9,18 +9,20 @@ include $(TOPDIR)/rules.mk
 
 # Name and release number of this package
 PKG_NAME:=noddos
-PKG_RELEASE:=3
-PKG_LICENSE:=GPLv3
-PKG_MAINTAINER:=Steven Hessing <steven.hessing@gmail.com>
+PKG_VERSION:=0.5.5
+PKG_RELEASE:=4
 
-PKG_SOURCE_VERSION:=0.5.5
-PKG_SOURCE_URL:=https://github.com/noddos/noddos/releases/download/v$(PKG_SOURCE_VERSION)/
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.xz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/noddos/noddos/releases/download/v$(PKG_VERSION)/
 PKG_HASH:=1f5be0c1015b0407036eecc8449d60d2abcacec442bba55db85fc32e89f754db
 
-PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
+PKG_MAINTAINER:=Steven Hessing <steven.hessing@gmail.com>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE.md
 
+PKG_BUILD_PARALLEL:=1
 CMAKE_INSTALL:=1
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
@@ -29,7 +31,7 @@ define Package/noddos
 	CATEGORY:=Network
 	TITLE:=noddos -- device-aware cloud-powered firewall
 	URL:=https://www.noddos.io/
-	DEPENDS:=+libstdcpp +libnetfilter-conntrack +libcurl +libopenssl +openssl-util +ca-bundle +ca-certificates +wget +bzip2 +libtins +ipset +libpthread +libyaml-cpp
+	DEPENDS:=+libstdcpp +libnetfilter-conntrack +libcurl +libopenssl +openssl-util +ca-bundle +wget +bzip2 +libtins +ipset +libpthread +libyaml-cpp
 endef
 
 define Package/noddos/description

--- a/net/noddos/patches/040-openssl-deprecated.patch
+++ b/net/noddos/patches/040-openssl-deprecated.patch
@@ -1,0 +1,14 @@
+--- a/src/opensslfingerprint.cxx
++++ b/src/opensslfingerprint.cxx
+@@ -73,9 +73,11 @@ std::string getCertFingerprint(const std::string certfile, const bool Debug = fa
+ 	// closes file
+ 	close(fd);
+ 
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+ 	// initialize OpenSSL
+ 	SSL_load_error_strings();
+ 	SSL_library_init();
++#endif
+ 
+ 	// creates BIO buffer
+ 	BIO * bio = BIO_new_mem_buf(buff, len);


### PR DESCRIPTION
Rearranged Makefile for consistency between packages.

Added PKG_BUILD_PARALLEL for faster compilation.

Removed ca-certificates dependency. ca-bundle is enough.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @StevenHessing 
Compile tested: powerpc8540