### PR TITLE
libgpiod: remove dependency to kernel version

### DIFF
--- a/libs/libgpiod/Makefile
+++ b/libs/libgpiod/Makefile
@@ -34,7 +34,7 @@ define Package/libgpiod
   CATEGORY:=Libraries
   URL:=https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
   TITLE:=Library for interacting with Linux's GPIO character device
-  DEPENDS:=@GPIO_SUPPORT @(LINUX_4_9||LINUX_4_14)
+  DEPENDS:=@GPIO_SUPPORT
 endef
 
 define Package/libgpiod/description


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: x86_64

Description:
Now that we only use kernel versions that support libgpiod,
we can remove the dependency on the kernel version.

This enables libgpiod to be used with linux 4.19.
