### PR TITLE
mwan3: add mwan3-led status trigger

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0
 

--- a/net/mwan3/files/etc/hotplug.d/iface/17-mwan3-led
+++ b/net/mwan3/files/etc/hotplug.d/iface/17-mwan3-led
@@ -1,0 +1,89 @@
+#!/bin/sh
+#
+# Copyright (C) 2019 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See https://www.gnu.org/licenses/gpl-2.0.txt for more information.
+#
+
+. /usr/share/libubox/jshn.sh
+. /lib/functions/leds.sh
+
+[ "$ACTION" = "connected" ] || [ "$ACTION" = "disconnected" ] || exit 1
+[ -n "$INTERFACE" ] || exit 2
+
+MWAN3_LED_SELECTED=0
+MWAN3_OFFLINE=0
+MWAN3_ONLINE=0
+MWAN3_STATUS="OFFLINE"
+SYSFS=""
+
+check_status() {
+	local cfg="$1"
+	local iface="$2"
+
+	local trigger sysfs mwan3_status keys key
+	local status running
+
+	config_get trigger "$cfg" trigger
+	config_get sysfs "$cfg" sysfs
+
+	[ "$trigger" = "mwan3_status" ] && [ -n "$sysfs" ] || return
+	MWAN3_LED_SELECTED=1
+	SYSFS=$sysfs
+
+	mwan3_status=$(ubus -S call mwan3 status)
+	[ -n "$mwan3_status" ] && {
+		json_load "$mwan3_status"
+		json_select "interfaces"
+
+		json_get_keys keys
+		for key in ${keys}; do
+			json_select "${key}"
+			json_get_vars status running
+			json_select ..
+			[ $running -eq 1 ] && {
+				[ "$status" = "online" ] && {
+					MWAN3_ONLINE=1
+				}
+				[ "$status" = "offline" ] && {
+					MWAN3_OFFLINE=1
+				}
+			}
+		done
+		json_select ..
+
+		if [ $MWAN3_OFFLINE -eq 1 ] && [ $MWAN3_ONLINE -eq 1 ]; then
+			MWAN3_STATUS="BACKUP"
+		elif [ $MWAN3_ONLINE -eq 1 ]; then
+			MWAN3_STATUS="ONLINE"
+		elif [ $MWAN3_OFFLINE -eq 1 ]; then
+			MWAN3_STATUS="OFFLINE"
+		else
+			MWAN3_STATUS="OFFLINE"
+		fi
+	}
+}
+
+main() {
+	local iface="$INTERFACE"
+
+	config_load system
+	config_foreach check_status led "$iface"
+
+	if [ $MWAN3_LED_SELECTED -eq 1 ]; then
+		case $MWAN3_STATUS in
+			"ONLINE")
+				led_off "$SYSFS"
+				;;
+			"BACKUP")
+				led_timer "$SYSFS" "500" "500"
+				;;
+			"OFFLINE")
+				led_on "$SYSFS"
+				;;
+		esac
+	fi
+}
+
+main "$@"


### PR DESCRIPTION
Maintainer: me
Compile tested: only scripts
Run tested: x86_64, APU3, OpenWrt master

Description:

In some situations it is useful to have LED triggers for appliacation events.
With this change we can show the state of mwan3 on a LED. This script
is called on interface events /etc/hotplug.d/iface and checks the state
of mwan3 and configure a LED.

The following LED mwan3 status and the corresponding LED triggers.

* If all mwan3 connections are connected, then the LED is off
  (kernel trigger -> none).

* If all mwan3 connections are not connected (failure), then the LED is on
  (kernel trigger -> default-on).

* If one of the mwan3 connections is not connected (backup), the LED flashes
  (kernel trigger -> timer).

The Trigger must be set to mwan3_status.

Example for /etc/config/system

config led 'led_alarm'
	option name 'Alarm'
	option sysfs 'apu3:green:1'
	option default '0'
	option trigger 'mwan3_status'