### PR TITLE
mutt: bump to 1.12.1

### DIFF
--- a/mail/mutt/Makefile
+++ b/mail/mutt/Makefile
@@ -8,16 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mutt
-PKG_VERSION:=1.12.0
+PKG_VERSION:=1.12.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://bitbucket.org/mutt/mutt/downloads/ \
 		http://ftp.mutt.org/pub/mutt/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=ca12448784ed7b6c86d498921e18bc7b152d45494a452df56a7a0c8aaf13f98f
+PKG_HASH:=01c565406ec4ffa85db90b45ece2260b25fac3646cc063bbc20a242c6ed4210c
 
 PKG_MAINTAINER:=Phil Eichinger <phil@zankapfel.net>
-PKG_LICENSE:=GPL-2.0+
+PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=GPL
 
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Signed-off-by: Phil Eichinger phil@zankapfel.net
 
Maintainer: me 
Compile tested: (ar71xx, TL-WDR4300, 18.06.2) 
Run tested: (ar71xx, TL-WDR4300, 18.06.2)

