### PR TITLE
Added hcxdumptool and hcxtools, created by @ZerBea

### DIFF
--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2009-2014 OpenWrt.org
+# Copyright (C) 2019 Andreas Nilsen <adde88@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=hcxdumptool
+PKG_VERSION:=5.1.7
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/github.com/ZerBea/hcxdumptool/releases/download/v$(PKG_VERSION)
+PKG_HASH:=6ac996a506cb312a5f1c5987f30a4a80c793993908750f69f2df51056f961269
+
+PKG_BUILD_PARALLEL:=1
+
+PKG_USE_MIPS16:=0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/hcxdumptool
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpcap
+  TITLE:=hcxdumptool
+  URL:=https://github.com/ZerBea/hcxdumptool.git
+  SUBMENU:=wireless
+  MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
+endef
+
+define Package/hcxdumptool/description
+  Small tool to capture packets from wlan devices. After capturing, upload
+  the "uncleaned" cap here (https://wpa-sec.stanev.org/?submit)
+  to see if your ap or the client is vulnerable by using common wordlists.
+  Convert the cap to hccapx and/or to WPA-PMKID-PBKDF2 hashline (16800) with hcxpcaptool (hcxtools)
+  and check if wlan-key or plainmasterkey was transmitted unencrypted.
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR)/ \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS="$(TARGET_CFLAGS)"
+endef
+
+define Package/hcxdumptool/install
+	$(INSTALL_DIR) $(1)/sbin
+	$(CP) $(PKG_BUILD_DIR)/hcxdumptool $(1)/sbin/
+endef
+
+$(eval $(call BuildPackage,hcxdumptool))

--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -1,5 +1,4 @@
 #
-# Copyright (C) 2009-2014 OpenWrt.org
 # Copyright (C) 2019 Andreas Nilsen <adde88@gmail.com>
 #
 # This is free software, licensed under the GNU General Public License v2.
@@ -12,13 +11,13 @@ PKG_NAME:=hcxdumptool
 PKG_VERSION:=5.1.7
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/ZerBea/$(PKG_NAME)/archive/
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxdumptool/tar.gz/$(PKG_VERSION)?
 PKG_HASH:=6ac996a506cb312a5f1c5987f30a4a80c793993908750f69f2df51056f961269
 
-PKG_BUILD_PARALLEL:=1
-
-PKG_USE_MIPS16:=0
+PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILE:=license.txt
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -27,9 +26,8 @@ define Package/hcxdumptool
   CATEGORY:=Network
   DEPENDS:=+libpcap
   TITLE:=hcxdumptool
-  URL:=https://github.com/ZerBea/hcxdumptool.git
+  URL:=https://github.com/ZerBea/hcxdumptool
   SUBMENU:=wireless
-  MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 endef
 
 define Package/hcxdumptool/description
@@ -48,7 +46,7 @@ endef
 
 define Package/hcxdumptool/install
 	$(INSTALL_DIR) $(1)/sbin
-	$(CP) $(PKG_BUILD_DIR)/hcxdumptool $(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxdumptool $(1)/sbin/
 endef
 
 $(eval $(call BuildPackage,hcxdumptool))

--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -12,8 +12,8 @@ PKG_NAME:=hcxdumptool
 PKG_VERSION:=5.1.7
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/github.com/ZerBea/hcxdumptool/releases/download/v$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/ZerBea/$(PKG_NAME)/archive/
 PKG_HASH:=6ac996a506cb312a5f1c5987f30a4a80c793993908750f69f2df51056f961269
 
 PKG_BUILD_PARALLEL:=1

--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -17,7 +17,7 @@ PKG_HASH:=6ac996a506cb312a5f1c5987f30a4a80c793993908750f69f2df51056f961269
 
 PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 PKG_LICENSE:=MIT
-PKG_LICENSE_FILE:=license.txt
+PKG_LICENSE_FILES:=license.txt
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/hcxtools/Makefile
+++ b/net/hcxtools/Makefile
@@ -11,8 +11,8 @@ PKG_NAME:=hcxtools
 PKG_VERSION:=5.1.6
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/github.com/ZerBea/hcxtools/releases/download/v$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/ZerBea/$(PKG_NAME)/archive/
 PKG_HASH:=19d2800c6f9339dd552ebc3e7195860f208a9856340b4db1aeaeb4a234557ca6
 
 PKG_BUILD_PARALLEL:=1

--- a/net/hcxtools/Makefile
+++ b/net/hcxtools/Makefile
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2009-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=hcxtools
+PKG_VERSION:=5.1.6
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/github.com/ZerBea/hcxtools/releases/download/v$(PKG_VERSION)
+PKG_HASH:=19d2800c6f9339dd552ebc3e7195860f208a9856340b4db1aeaeb4a234557ca6
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/hcxtools
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpthread +libpcap +zlib +libcurl +libopenssl
+  TITLE:= hcxtools
+  URL:=https://github.com/ZerBea/hcxtools.git
+  SUBMENU:=wireless
+  MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
+endef
+
+define Package/hcxtools/description
+  Set of tools convert packets from captures (h = hash, c = capture, convert and calculate candidates, x = different hashtypes)
+  for the use with latest hashcat or John the Ripper.
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR)/ \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS="$(TARGET_CFLAGS)"
+endef
+
+define Package/hcxtools/install
+	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_DIR) $(1)/etc
+	$(CP) $(PKG_BUILD_DIR)/wlanwkp2hcx	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/wlanpmk2hcx	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/wlanhcxmnc	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/wlanhcx2essid	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/wlanjohn2hcx	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/hcxpcaptool	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/wlanhcx2john	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/hcxpsktool	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/wlancow2hcxpmk	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/wlanhcxinfo	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/hcxhash2cap	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/hcxhashcattool	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/wlanhashhcx	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/wlanhc2hcx	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/hcxwltool	$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/whoismac		$(1)/sbin/
+	$(CP) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/sbin/
+#	$(CP) $(PKG_BUILD_DIR)/usefulscripts/hcxgrep.py	$(1)/sbin/hcxgrep
+endef
+
+$(eval $(call BuildPackage,hcxtools))

--- a/net/hcxtools/Makefile
+++ b/net/hcxtools/Makefile
@@ -17,7 +17,7 @@ PKG_HASH:=19d2800c6f9339dd552ebc3e7195860f208a9856340b4db1aeaeb4a234557ca6
 
 PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 PKG_LICENSE:=MIT
-PKG_LICENSE_FILE:=license.txt
+PKG_LICENSE_FILES:=license.txt
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/hcxtools/Makefile
+++ b/net/hcxtools/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2009-2014 OpenWrt.org
+# Copyright (C) 2019 Andreas Nilsen <adde88@gmail.com>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -11,11 +11,13 @@ PKG_NAME:=hcxtools
 PKG_VERSION:=5.1.6
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/ZerBea/$(PKG_NAME)/archive/
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxtools/tar.gz/$(PKG_VERSION)?
 PKG_HASH:=19d2800c6f9339dd552ebc3e7195860f208a9856340b4db1aeaeb4a234557ca6
 
-PKG_BUILD_PARALLEL:=1
+PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILE:=license.txt
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -23,10 +25,9 @@ define Package/hcxtools
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+libpthread +libpcap +zlib +libcurl +libopenssl
-  TITLE:= hcxtools
-  URL:=https://github.com/ZerBea/hcxtools.git
+  TITLE:=hcxtools
+  URL:=https://github.com/ZerBea/hcxtools
   SUBMENU:=wireless
-  MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 endef
 
 define Package/hcxtools/description
@@ -43,25 +44,24 @@ endef
 define Package/hcxtools/install
 	$(INSTALL_DIR) $(1)/sbin
 	$(INSTALL_DIR) $(1)/etc
-	$(CP) $(PKG_BUILD_DIR)/wlanwkp2hcx	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/wlanpmk2hcx	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/wlanhcxmnc	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/wlanhcx2essid	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/wlanjohn2hcx	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/hcxpcaptool	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/wlanhcx2john	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/hcxpsktool	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/wlancow2hcxpmk	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/wlanhcxinfo	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/hcxhash2cap	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/hcxhashcattool	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/wlanhashhcx	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/wlanhc2hcx	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/hcxwltool	$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/whoismac		$(1)/sbin/
-	$(CP) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/sbin/
-#	$(CP) $(PKG_BUILD_DIR)/usefulscripts/hcxgrep.py	$(1)/sbin/hcxgrep
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanwkp2hcx	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanpmk2hcx	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcxmnc	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcx2essid	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanjohn2hcx	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpcaptool	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcx2john	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpsktool	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancow2hcxpmk	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcxinfo	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhash2cap	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhashcattool	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhashhcx	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhc2hcx	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxwltool	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/whoismac		$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/sbin/
 endef
 
 $(eval $(call BuildPackage,hcxtools))


### PR DESCRIPTION
Maintainer: me / @adde88
Compile tested: ar71xx, WIFI-PINEAPPLE-NANO, OpenWrt Snapshot + Chaos Calmer
Run tested: ar71xx, WIFI-PINEAPPLE-NANO, OpenWrt Snapshot + Chaos Calmer, i've tested both projects over a long period. 

Description:
hcxtools is a set of tools for capturing wlan traffic and conversion to hashcat formats, and John The Ripper formats.

hcxdumptool lets the user capture packets from wlan devices. Convert the capture to hccapx and/or to WPA-PMKID-PBKDF2 hashline (16800) with hcxpcaptool (hcxtools) and check if the wlan-key or plainmasterkey was transmitted unencrypted.