### PR TITLE
avrdude: Fix GPIO path building

### DIFF
--- a/utils/avrdude/Makefile
+++ b/utils/avrdude/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avrdude
 PKG_VERSION:=6.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SAVANNAH/$(PKG_NAME)
 PKG_HASH:=0f9f731b6394ca7795b88359689a7fa1fba818c6e1d962513eb28da670e0a196
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
@@ -30,7 +30,7 @@ define Package/avrdude
   CATEGORY:=Utilities
   SUBMENU:=Microcontroller programming
   TITLE:=AVR Downloader/UploaDEr
-  URL:=http://www.nongnu.org/avrdude/
+  URL:=https://www.nongnu.org/avrdude/
   DEPENDS:=+libncurses +libreadline +libusb-compat +libftdi1 +libelf
 endef
 

--- a/utils/avrdude/patches/110-ud-to-u.patch
+++ b/utils/avrdude/patches/110-ud-to-u.patch
@@ -1,0 +1,38 @@
+--- a/linuxgpio.c
++++ b/linuxgpio.c
+@@ -66,7 +66,7 @@ static int linuxgpio_export(unsigned int gpio)
+     return fd;
+   }
+ 
+-  len = snprintf(buf, sizeof(buf), "%ud", gpio);
++  len = snprintf(buf, sizeof(buf), "%u", gpio);
+   r = write(fd, buf, len);
+   close(fd);
+ 
+@@ -84,7 +84,7 @@ static int linuxgpio_unexport(unsigned int gpio)
+     return fd;
+   }
+ 
+-  len = snprintf(buf, sizeof(buf), "%ud", gpio);
++  len = snprintf(buf, sizeof(buf), "%u", gpio);
+   r = write(fd, buf, len);
+   close(fd);
+ 
+@@ -95,7 +95,7 @@ static int linuxgpio_openfd(unsigned int gpio)
+ {
+   char filepath[60];
+ 
+-  snprintf(filepath, sizeof(filepath), "/sys/class/gpio/gpio%ud/value", gpio);
++  snprintf(filepath, sizeof(filepath), "/sys/class/gpio/gpio%u/value", gpio);
+   return (open(filepath, O_RDWR));
+ }
+ 
+@@ -104,7 +104,7 @@ static int linuxgpio_dir(unsigned int gpio, unsigned int dir)
+   int fd, r;
+   char buf[60];
+ 
+-  snprintf(buf, sizeof(buf), "/sys/class/gpio/gpio%ud/direction", gpio);
++  snprintf(buf, sizeof(buf), "/sys/class/gpio/gpio%u/direction", gpio);
+ 
+   fd = open(buf, O_WRONLY);
+   if (fd < 0) {


### PR DESCRIPTION
%ud is a GNU extension. It's not really supported elsewhere.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 

https://github.com/openwrt/packages/issues/9194
