### PR TITLE
python-cryptography: Remove NPN

### DIFF
--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptography
 PKG_VERSION:=2.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=cryptography-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/cryptography

--- a/lang/python/python-cryptography/patches/010-remove-npn.patch
+++ b/lang/python/python-cryptography/patches/010-remove-npn.patch
@@ -1,0 +1,41 @@
+From eec1f066476eccf7135af0a4cfef9e1c883795b3 Mon Sep 17 00:00:00 2001
+From: Paul Kehrer <paul.l.kehrer@gmail.com>
+Date: Mon, 25 Feb 2019 10:55:16 +0800
+Subject: [PATCH] remove NPN bindings -- you should be using ALPN!
+
+pyOpenSSL consumed these, but we've marked it as deprecated and it
+already handles the case where the bindings are not available.
+---
+ src/_cffi_src/openssl/ssl.py | 16 ----------------
+ 1 file changed, 16 deletions(-)
+
+diff --git a/src/_cffi_src/openssl/ssl.py b/src/_cffi_src/openssl/ssl.py
+index da21f3ce90..0e8610f988 100644
+--- a/src/_cffi_src/openssl/ssl.py
++++ b/src/_cffi_src/openssl/ssl.py
+@@ -431,25 +431,9 @@
+ 
+ long SSL_session_reused(SSL *);
+ 
+-void SSL_CTX_set_next_protos_advertised_cb(SSL_CTX *,
+-                                           int (*)(SSL *,
+-                                                   const unsigned char **,
+-                                                   unsigned int *,
+-                                                   void *),
+-                                           void *);
+-void SSL_CTX_set_next_proto_select_cb(SSL_CTX *,
+-                                      int (*)(SSL *,
+-                                              unsigned char **,
+-                                              unsigned char *,
+-                                              const unsigned char *,
+-                                              unsigned int,
+-                                              void *),
+-                                      void *);
+ int SSL_select_next_proto(unsigned char **, unsigned char *,
+                           const unsigned char *, unsigned int,
+                           const unsigned char *, unsigned int);
+-void SSL_get0_next_proto_negotiated(const SSL *,
+-                                    const unsigned char **, unsigned *);
+ 
+ int sk_SSL_CIPHER_num(Cryptography_STACK_OF_SSL_CIPHER *);
+ const SSL_CIPHER *sk_SSL_CIPHER_value(Cryptography_STACK_OF_SSL_CIPHER *, int);

--- a/lang/python/python-cryptography/patches/020-disable-npn.patch
+++ b/lang/python/python-cryptography/patches/020-disable-npn.patch
@@ -1,0 +1,23 @@
+From d7293d64d503fcbde442d69a3e11c55bf6f1374a Mon Sep 17 00:00:00 2001
+From: Paul Kehrer <paul.l.kehrer@gmail.com>
+Date: Mon, 25 Feb 2019 11:05:46 +0800
+Subject: [PATCH] set Cryptography_HAS_NEXTPROTONEG to 0 for pyOpenSSL
+
+we can remove this symbol in like...5 years.
+---
+ src/_cffi_src/openssl/ssl.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/_cffi_src/openssl/ssl.py b/src/_cffi_src/openssl/ssl.py
+index 0e8610f988..e3a7790ee1 100644
+--- a/src/_cffi_src/openssl/ssl.py
++++ b/src/_cffi_src/openssl/ssl.py
+@@ -623,7 +623,7 @@
+ static const long Cryptography_HAS_SSL_OP_MSIE_SSLV2_RSA_PADDING = 1;
+ static const long Cryptography_HAS_SSL_OP_NO_TICKET = 1;
+ static const long Cryptography_HAS_SSL_SET_SSL_CTX = 1;
+-static const long Cryptography_HAS_NEXTPROTONEG = 1;
++static const long Cryptography_HAS_NEXTPROTONEG = 0;
+ 
+ /* SSL_get0_param was added in OpenSSL 1.0.2. */
+ #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_102 && !CRYPTOGRAPHY_LIBRESSL_27_OR_GREATER

--- a/lang/python/python-cryptography/patches/030-remove-npn.patch
+++ b/lang/python/python-cryptography/patches/030-remove-npn.patch
@@ -1,0 +1,22 @@
+From b0b50b6bbbdf3abadc70b64c56e25b872721a7f3 Mon Sep 17 00:00:00 2001
+From: Paul Kehrer <paul.l.kehrer@gmail.com>
+Date: Mon, 25 Feb 2019 11:12:10 +0800
+Subject: [PATCH] remove another NPN related definition
+
+---
+ src/_cffi_src/openssl/ssl.py | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/_cffi_src/openssl/ssl.py b/src/_cffi_src/openssl/ssl.py
+index e3a7790ee1..f98f576838 100644
+--- a/src/_cffi_src/openssl/ssl.py
++++ b/src/_cffi_src/openssl/ssl.py
+@@ -139,8 +139,6 @@
+ static const long TLS_ST_BEFORE;
+ static const long TLS_ST_OK;
+ 
+-static const long OPENSSL_NPN_NEGOTIATED;
+-
+ typedef ... SSL_METHOD;
+ typedef ... SSL_CTX;
+ 


### PR DESCRIPTION
Upstream backport. It seems the holdup is on python-twisted.

Without this, it fails with
SSL_get0_next_proto_negotiated: symbol not found

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jefferyto @commodo 
Compile tested: i386