### PR TITLE
Bigclown firmware tool

### DIFF
--- a/lang/python/python-intelhex/Makefile
+++ b/lang/python/python-intelhex/Makefile
@@ -1,0 +1,42 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-intelhex
+PKG_VERSION:=2.2.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=intelhex-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/i/intelhex/
+PKG_HASH:=009d8511e0d50639230c39af9607deee771cf026f67ef7507a8c3fd4fa927832
+PKG_BUILD_DIR:=$(BUILD_DIR)/intelhex-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE.txt
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-intelhex
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=python3-intelhex
+  URL:=https://github.com/bialix/intelhex
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-intelhex/description
+  This work implements an intelhex Python library to read, write, create from
+  scratch and manipulate data from Intel HEX file format.
+endef
+
+PYTHON3_PKG_SETUP_ARGS:=
+
+$(eval $(call Py3Package,python3-intelhex))
+$(eval $(call BuildPackage,python3-intelhex))
+$(eval $(call BuildPackage,python3-intelhex-src))

--- a/utils/bigclown/bigclown-firmware-tool/Makefile
+++ b/utils/bigclown/bigclown-firmware-tool/Makefile
@@ -1,0 +1,46 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bigclown-firmware-tool
+PKG_VERSION:=1.3.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/bigclownlabs/bch-firmware-tool/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=2ba459148a5f23773ab14d0f5d5cc381c441d758cb9f23cdbec18b30b07675ab
+PKG_BUILD_DIR:=$(BUILD_DIR)/bch-firmware-tool-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../../../lang/python/python3-package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=BigClown
+  TITLE:=BigCLown firmware tool
+  URL:=https://github.com/bigclownlabs/bch-firmware-tool
+  DEPENDS:= \
+    +python3-appdirs \
+    +python3-pyserial \
+    +python3-colorama \
+    +python3-yaml \
+    +python3-schema \
+    +python3-requests \
+    +python3-click \
+    +python3-intelhex
+endef
+
+define Build/Compile
+	sed -i 's/@@VERSION@@/$(PKG_VERSION)/' "$(PKG_BUILD_DIR)/setup.py"
+	$(call Py3Build/Compile/Default)
+endef
+
+$(eval $(call Py3Package,$(PKG_NAME)))
+$(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
Maintainer: me 
Compile tested: Turris Mox, Omnia
Run tested: Turris Omnia

Description:
This is additional tool for Bigclown. It is simple Python package. Only complication is new python dependency intelhex. I am adding it as part of this PR as well. I marked myself as maintainer of both packages.