### PR TITLE
python3-unidecode: update to version 1.1.1

### DIFF
--- a/lang/python/python3-unidecode/Makefile
+++ b/lang/python/python3-unidecode/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-unidecode
-PKG_VERSION:=1.1.0
+PKG_VERSION:=1.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=Unidecode-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/u/unidecode/
-PKG_HASH:=8c698f567aa098aeacfbad2d4a416f9803236bdc5ece09653b6e6dfe3f03f102
+PKG_HASH:=2b6aab710c2a1647e928e36d69c21e76b453cd455f4e2621000e54b2a9b8cce8
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/Unidecode-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Tests:
```
root@turris:~# python3 test_unidecode.py 
.s.............s.............s............
----------------------------------------------------------------------
Ran 42 tests in 9.550s

OK (skipped=3)
```

Description:

Update to version 1.1.1
- Changelog: https://github.com/avian2/unidecode/commit/632af82e0f8bfe32cf73720459703655d16e6250