### PR TITLE
setserial: Add missing headers

### DIFF
--- a/utils/setserial/Makefile
+++ b/utils/setserial/Makefile
@@ -2,15 +2,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=setserial
 PKG_VERSION:=2.17
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/setserial
 PKG_HASH:=7e4487d320ac31558563424189435d396ddf77953bb23111a17a3d1487b5794a
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
-PKG_LICENSE:=GPL-2.0
-
+PKG_LICENSE:=GPL-2.0-only
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/utils/setserial/patches/020-musl.patch
+++ b/utils/setserial/patches/020-musl.patch
@@ -1,0 +1,19 @@
+--- a/setserial.c
++++ b/setserial.c
+@@ -11,6 +11,8 @@
+  */
+ 
+ #include <stdio.h>
++#include <stdlib.h>
++#include <unistd.h>
+ #include <fcntl.h>
+ #include <termios.h>
+ #include <string.h>
+@@ -22,6 +24,7 @@
+ #ifdef HAVE_LINUX_HAYESESP_H
+ #include <linux/hayesesp.h>
+ #endif
++#include <sys/ioctl.h>
+ #include <linux/serial.h>
+ 
+ #include "version.h"


### PR DESCRIPTION
Fixes compilation with -Wimplicit-function-declaration

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jow-
Compile tested: arc700