### PR TITLE
rtl-ais: Add missing header

### DIFF
--- a/utils/rtl-ais/Makefile
+++ b/utils/rtl-ais/Makefile
@@ -8,14 +8,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtl-ais
 PKG_VERSION:=0.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/dgiardini/rtl-ais/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=01e2b675226ec403c409cec8b55999008f5c7aa9e82d6c0ba085ef13b200ceb1
 
 PKG_MAINTAINER:=Nuno Goncalves <nunojpg@gmail.com>
-PKG_LICENSE:=GPL-2.0+
+PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk

--- a/utils/rtl-ais/patches/010-musl.patch
+++ b/utils/rtl-ais/patches/010-musl.patch
@@ -1,0 +1,10 @@
+--- a/tcp_listener/tcp_listener.c
++++ b/tcp_listener/tcp_listener.c
+@@ -6,6 +6,7 @@
+ #include <string.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <unistd.h>
+ #include <errno.h>
+ #include <stdio.h>
+ #include <pthread.h>


### PR DESCRIPTION
Fixes -Wimplicit-function-declaration

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nunojpg 
Compile tested: arc700