### PR TITLE
kea: Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
 PKG_VERSION:=1.5.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)

--- a/net/kea/patches/010-openssl-deprecated.patch
+++ b/net/kea/patches/010-openssl-deprecated.patch
@@ -1,0 +1,11 @@
+--- a/src/lib/cryptolink/openssl_link.cc
++++ b/src/lib/cryptolink/openssl_link.cc
+@@ -79,7 +79,7 @@ CryptoLink::initialize() {
+ 
+ std::string
+ CryptoLink::getVersion() {
+-    return (SSLeay_version(SSLEAY_VERSION));
++    return (OpenSSL_version(OPENSSL_VERSION));
+ }
+ 
+ } // namespace cryptolink


### PR DESCRIPTION
Forgot to add this one to the last pull request.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @rosysong @hbl0307106015
Compile tested: arc700