### PR TITLE
mwan3: change and add new mwan3 ubus informations

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.7.13
+PKG_VERSION:=2.8.0
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/uci-defaults/mwan3-migrate-flush_conntrack
+++ b/net/mwan3/files/etc/uci-defaults/mwan3-migrate-flush_conntrack
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+mwan3_migrate_flush_conntrack() {
+	local iface="$1"
+
+	config_get value "${iface}" flush_conntrack
+	case $value in
+		always)
+			uci_remove mwan3 "$iface" flush_conntrack
+			uci_add_list mwan3 "$iface" flush_conntrack ifup
+			uci_add_list mwan3 "$iface" flush_conntrack ifdown
+			;;
+		never)
+			uci_remove mwan3 "$iface" flush_conntrack
+			;;
+	esac
+
+	uci_commit mwan3
+}
+
+config_load mwan3
+config_foreach mwan3_migrate_flush_conntrack interface
+
+exit 0

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -104,10 +104,14 @@ get_mwan3_status() {
 			let offline=time_n-time_d
 		}
 
+		local uptime="0"
+		network_get_uptime uptime "$iface"
+
 		json_add_object "${iface}"
 		json_add_int age "$age"
 		json_add_int online "${online}"
 		json_add_int offline "${offline}"
+		json_add_int uptime "${uptime}"
 		json_add_int "score" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/SCORE")"
 		json_add_int "lost" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/LOST")"
 		json_add_int "turn" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/TURN")"

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -76,7 +76,7 @@ get_mwan3_status() {
 	local age=0
 	local online=0
 	local offline=0
-	local pid device time_p time_n time_u time_d
+	local enabled pid device time_p time_n time_u time_d
 
 	network_get_device device $1
 
@@ -105,6 +105,8 @@ get_mwan3_status() {
 		}
 
 		local uptime="0"
+
+		config_get enabled "$iface" enabled 0
 		network_get_uptime uptime "$iface"
 
 		json_add_object "${iface}"
@@ -116,6 +118,7 @@ get_mwan3_status() {
 		json_add_int "lost" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/LOST")"
 		json_add_int "turn" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/TURN")"
 		json_add_string "status" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/STATUS")"
+		json_add_boolean "enabled" "${enabled}"
 		json_add_boolean "running" "${running}"
 		json_add_array "track_ip"
 		for file in $MWAN3TRACK_STATUS_DIR/${iface}/*; do

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -76,6 +76,7 @@ get_mwan3_status() {
 	local age=0
 	local online=0
 	local offline=0
+	local up="0"
 	local enabled pid device time_p time_n time_u time_d
 
 	network_get_device device $1
@@ -108,6 +109,7 @@ get_mwan3_status() {
 
 		config_get enabled "$iface" enabled 0
 		network_get_uptime uptime "$iface"
+		network_is_up "$iface" && up="1"
 
 		json_add_object "${iface}"
 		json_add_int age "$age"
@@ -120,6 +122,7 @@ get_mwan3_status() {
 		json_add_string "status" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/STATUS")"
 		json_add_boolean "enabled" "${enabled}"
 		json_add_boolean "running" "${running}"
+		json_add_boolean "up" "${up}"
 		json_add_array "track_ip"
 		for file in $MWAN3TRACK_STATUS_DIR/${iface}/*; do
 			track="${file#*/TRACK_}"

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -75,7 +75,7 @@ get_mwan3_status() {
 	local running="0"
 	local age=0
 	local online=0
-	local downtime=0
+	local offline=0
 	local pid device time_p time_n time_u time_d
 
 	network_get_device device $1
@@ -98,16 +98,16 @@ get_mwan3_status() {
 			let online=time_n-time_u
 		}
 
-		time_d="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/DOWNTIME")"
+		time_d="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/OFFLINE")"
 		[ -z "${time_d}" ] || [ "${time_d}" = "0" ] || {
 			time_n="$(get_uptime)"
-			let downtime=time_n-time_d
+			let offline=time_n-time_d
 		}
 
 		json_add_object "${iface}"
 		json_add_int age "$age"
 		json_add_int online "${online}"
-		json_add_int downtime "${downtime}"
+		json_add_int offline "${offline}"
 		json_add_int "score" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/SCORE")"
 		json_add_int "lost" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/LOST")"
 		json_add_int "turn" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/TURN")"

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -74,7 +74,7 @@ get_mwan3_status() {
 	local iface_select="${2}"
 	local running="0"
 	local age=0
-	local uptime=0
+	local online=0
 	local downtime=0
 	local pid device time_p time_n time_u time_d
 
@@ -92,10 +92,10 @@ get_mwan3_status() {
 			let age=time_n-time_p
 		}
 
-		time_u="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/UPTIME")"
+		time_u="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/ONLINE")"
 		[ -z "${time_u}" ] || [ "${time_u}" = "0" ] || {
 			time_n="$(get_uptime)"
-			let uptime=time_n-time_u
+			let online=time_n-time_u
 		}
 
 		time_d="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/DOWNTIME")"
@@ -106,7 +106,7 @@ get_mwan3_status() {
 
 		json_add_object "${iface}"
 		json_add_int age "$age"
-		json_add_int uptime "${uptime}"
+		json_add_int online "${online}"
 		json_add_int downtime "${downtime}"
 		json_add_int "score" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/SCORE")"
 		json_add_int "lost" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/LOST")"

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -114,13 +114,13 @@ main() {
 
 	if [ "$STATUS" = "offline" ]; then
 		echo "offline" > /var/run/mwan3track/$1/STATUS
-		echo "0" > /var/run/mwan3track/$1/UPTIME
+		echo "0" > /var/run/mwan3track/$1/ONLINE
 		echo "$(get_uptime)" > /var/run/mwan3track/$1/DOWNTIME
 		score=0
 	else
 		echo "online" > /var/run/mwan3track/$1/STATUS
 		echo "0" > /var/run/mwan3track/$1/DOWNTIME
-		echo "$(get_uptime)" > /var/run/mwan3track/$1/UPTIME
+		echo "$(get_uptime)" > /var/run/mwan3track/$1/ONLINE
 		env -i ACTION="connected" INTERFACE="$1" DEVICE="$2" /sbin/hotplug-call iface
 	fi
 	while true; do
@@ -261,7 +261,7 @@ main() {
 		if [ "${IFDOWN_EVENT}" -eq 1 ]; then
 			echo "offline" > /var/run/mwan3track/$1/STATUS
 			echo "$(get_uptime)" > /var/run/mwan3track/$1/DOWNTIME
-			echo "0" > /var/run/mwan3track/$1/UPTIME
+			echo "0" > /var/run/mwan3track/$1/ONLINE
 			$LOG notice "Interface $1 ($2) is offline"
 			env -i ACTION="disconnected" INTERFACE="$1" DEVICE="$2" /sbin/hotplug-call iface
 			score=0

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -115,11 +115,11 @@ main() {
 	if [ "$STATUS" = "offline" ]; then
 		echo "offline" > /var/run/mwan3track/$1/STATUS
 		echo "0" > /var/run/mwan3track/$1/ONLINE
-		echo "$(get_uptime)" > /var/run/mwan3track/$1/DOWNTIME
+		echo "$(get_uptime)" > /var/run/mwan3track/$1/OFFLINE
 		score=0
 	else
 		echo "online" > /var/run/mwan3track/$1/STATUS
-		echo "0" > /var/run/mwan3track/$1/DOWNTIME
+		echo "0" > /var/run/mwan3track/$1/OFFLINE
 		echo "$(get_uptime)" > /var/run/mwan3track/$1/ONLINE
 		env -i ACTION="connected" INTERFACE="$1" DEVICE="$2" /sbin/hotplug-call iface
 	fi
@@ -260,7 +260,7 @@ main() {
 
 		if [ "${IFDOWN_EVENT}" -eq 1 ]; then
 			echo "offline" > /var/run/mwan3track/$1/STATUS
-			echo "$(get_uptime)" > /var/run/mwan3track/$1/DOWNTIME
+			echo "$(get_uptime)" > /var/run/mwan3track/$1/OFFLINE
 			echo "0" > /var/run/mwan3track/$1/ONLINE
 			$LOG notice "Interface $1 ($2) is offline"
 			env -i ACTION="disconnected" INTERFACE="$1" DEVICE="$2" /sbin/hotplug-call iface


### PR DESCRIPTION
Maintainer: me 
Compile tested: only script changes
Run tested: x86_64 and lantiq_xrx200, APU3, OpenWrt master, run tests done

Description:

- Add migration script for flush_conntrack config
- Rename ubus uptime to online
- Rename ubus downtime to offline 
- Add interface uptime netifd value to ubus mwan3 status output
- Add enabled info to mwan3 ubus status
- Add netifd up info to mwan3 ubus status output
