### PR TITLE
ldbus: Update to latest version

### DIFF
--- a/lang/ldbus/Makefile
+++ b/lang/ldbus/Makefile
@@ -7,15 +7,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ldbus
-PKG_RELEASE:=2
-PKG_MIRROR_HASH:=0e39a80e126a77a937226e49ae0246e1fd4600a03dee6bdee5ac822963a234e1
+PKG_SOURCE_DATE:=2019-03-25
+PKG_SOURCE_VERSION:=345d820b0f34bd35ea01dae633d35ea3cf7faf2a
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=f4a1464e915a2313c80fb40c5c40b0bee7583677
-PKG_SOURCE_DATE:=2017-10-03
 PKG_SOURCE_URL=https://github.com/daurnimator/ldbus
+PKG_MIRROR_HASH:=c0f5d1b34bc8b82d0f70bad23ecaca10ef84730c2c3ea318673b5a941f4dfc85
+
 PKG_MAINTAINER:=Enrico Mioso <mrkiko.rs@gmail.com>
 PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_DEPENDS:=luarocks/host
 
@@ -44,18 +46,20 @@ MAKE_FLAGS += \
 	CFLAGS="$(TARGET_CFLAGS)" \
 	LDFLAGS="$(TARGET_LDFLAGS)"
 
-define Package/ldbus/install
-	$(INSTALL_DIR) $(1)/usr/lib/lua
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ldbus.so $(1)/usr/lib/lua
-endef
-
 define Build/Compile
   cd $(PKG_BUILD_DIR) && \
   luarocks make --pack-binary-rock ldbus-scm-0.rockspec \
+    LUA_LIBDIR=$(STAGING_DIR)/usr/lib/lua \
+    LUA_PKGNAME=lua5.1 \
     DBUS_INCDIR=$(STAGING_DIR)/usr/include/dbus-1.0/ \
     DBUS_ARCH_INCDIR=$(STAGING_DIR)/usr/lib/dbus-1.0/include \
     DBUS_LIBDIR=$(STAGING_DIR)/usr/lib \
     CC="$(TARGET_CC)" LD="$(TARGET_CC)"
+endef
+
+define Package/ldbus/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ldbus.so $(1)/usr/lib/lua
 endef
 
 $(eval $(call BuildPackage,ldbus))

--- a/lang/luarocks/Makefile
+++ b/lang/luarocks/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luarocks
 PKG_VERSION:=2.2.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_MIRROR_HASH:=e4cf874c9bce34a5accd41daaf51a3213763b8b6f7f658ca4d13a70a7ddb1c0c

--- a/lang/luarocks/patches/01_dont_modify_bin_shebang.diff
+++ b/lang/luarocks/patches/01_dont_modify_bin_shebang.diff
@@ -6,7 +6,7 @@ diff -rupN luarocks/Makefile luarocks.new/Makefile
  	do \
  	   sed "1d" src/bin/$$f > src/bin/$$f.bak ;\
 -	   echo "#!$(LUA_BINDIR)/lua$(LUA_SUFFIX)" > src/bin/$$f ;\
-+	   echo "#!/usr/bin/env lua" > src/bin/$$f ;\
++	   echo "#!/usr/bin/env lua5.1" > src/bin/$$f ;\
  	   echo "package.path = [[$(LUADIR)/?.lua;]]..package.path" | sed "s,//,/,g" >> src/bin/$$f ;\
  	   cat src/bin/$$f.bak >> src/bin/$$f ;\
  	   chmod +x src/bin/$$f ;\


### PR DESCRIPTION
The only difference is two fixes for cross compilation.

Added those to fix the buildbots as lua5.3 is causing conflicts.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mrkiko
