### PR TITLE
dnscrypt-proxy2: add package

### DIFF
--- a/net/dnscrypt-proxy2/Makefile
+++ b/net/dnscrypt-proxy2/Makefile
@@ -1,0 +1,83 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dnscrypt-proxy2
+PKG_VERSION:=2.0.25
+PKG_RELEASE:=1
+
+PKG_SOURCE:=dnscrypt-proxy-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/jedisct1/dnscrypt-proxy/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=774696004c9e306e1723b4cbbe66a961128a335543d318d0786492ce69b906fa
+PKG_BUILD_DIR:=$(BUILD_DIR)/dnscrypt-proxy-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/jedisct1/dnscrypt-proxy
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/dnscrypt-proxy2
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Flexible DNS proxy with encrypted DNS protocols
+  URL:=https://github.com/jedisct1/dnscrypt-proxy
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+  CONFLICTS:=dnscrypt-proxy
+endef
+
+define Package/dnscrypt-proxy2/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/sbin/
+
+	$(INSTALL_DIR) $(1)/etc/dnscrypt-proxy2
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/dnscrypt-proxy/example-dnscrypt-proxy.toml $(1)/etc/dnscrypt-proxy2/dnscrypt-proxy.toml
+	$(INSTALL_CONF) ./files/blacklist.txt $(1)/etc/dnscrypt-proxy2/blacklist.txt
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/dnscrypt-proxy.init $(1)/etc/init.d/dnscrypt-proxy
+
+	sed -i "s/^listen_addresses = .*/listen_addresses = ['127.0.0.53:53']/" $(1)/etc/dnscrypt-proxy2/dnscrypt-proxy.toml
+	sed -i "s/^  # blacklist_file = 'blacklist.txt'/blacklist_file = 'blacklist.txt'/" $(1)/etc/dnscrypt-proxy2/dnscrypt-proxy.toml
+endef
+
+define Package/dnscrypt-proxy2/description
+  A flexible DNS proxy, with support for modern encrypted DNS protocols
+  such as DNSCrypt v2 and DNS-over-HTTPS.
+endef
+
+define Package/dnscrypt-proxy2/conffiles
+/etc/dnscrypt-proxy2/dnscrypt-proxy.toml
+endef
+
+define Package/golang-github-jedisct1-dnscrypt-proxy2-dev
+$(call Package/dnscrypt-proxy2)
+$(call GoPackage/GoSubMenu)
+  TITLE+= (source files)
+  PKGARCH:=all
+endef
+
+define Package/golang-github-jedisct1-dnscrypt-proxy2-dev/description
+$(call Package/dnscrypt-proxy2/description)
+
+  This package provides the source files for the client/bridge program.
+endef
+
+$(eval $(call GoBinPackage,dnscrypt-proxy2))
+$(eval $(call BuildPackage,dnscrypt-proxy2))
+$(eval $(call GoSrcPackage,golang-github-jedisct1-dnscrypt-proxy2-dev))
+$(eval $(call BuildPackage,golang-github-jedisct1-dnscrypt-proxy2-dev))

--- a/net/dnscrypt-proxy2/files/blacklist.txt
+++ b/net/dnscrypt-proxy2/files/blacklist.txt
@@ -1,0 +1,54 @@
+
+###########################
+#        Blacklist        #
+###########################
+
+## Rules for name-based query blocking, one per line
+##
+## Example of valid patterns:
+##
+## ads.*         | matches anything with an "ads." prefix
+## *.example.com | matches example.com and all names within that zone such as www.example.com
+## example.com   | identical to the above
+## =example.com  | block example.com but not *.example.com
+## *sex*         | matches any name containing that substring
+## ads[0-9]*     | matches "ads" followed by one or more digits
+## ads*.example* | *, ? and [] can be used anywhere, but prefixes/suffixes are faster
+
+ad.*
+ads.*
+banner.*
+banners.*
+creatives.*
+oas.*
+oascentral.*
+stats.*
+tag.*
+telemetry.*
+tracker.*
+*.local
+eth0.me
+*.workgroup
+
+*.test
+*.onion
+*.localhost
+*.local
+*.invalid
+*.bind
+*.lan
+*.internal
+*.intranet
+*.private
+*.workgroup
+
+*.10.in-addr.arpa
+*.16.172.in-addr.arpa
+*.168.192.in-addr.arpa
+*.254.169.in-addr.arpa
+*.d.f.ip6.arpa
+
+## Time-based rules
+
+# *.youtube.*  @time-to-sleep
+# facebook.com @work

--- a/net/dnscrypt-proxy2/files/dnscrypt-proxy.init
+++ b/net/dnscrypt-proxy2/files/dnscrypt-proxy.init
@@ -1,0 +1,21 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+# starts before dnsmasq starts
+START=18
+# stops before networking stops
+STOP=89
+
+PROG=/usr/sbin/dnscrypt-proxy
+CONFIGFILE=/etc/dnscrypt-proxy2/dnscrypt-proxy.toml
+
+start_service() {
+        procd_open_instance
+        procd_set_param command "$PROG" -config "$CONFIGFILE"
+        procd_set_param file "$CONFIGFILE"
+        procd_set_param stdout 1
+        procd_set_param stderr 1
+        procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+        procd_close_instance
+}


### PR DESCRIPTION
Maintainer: me, but if anybody else wants to be a maintainer, feel free to re-take.
Compile tested: cortexa53, Turris MOX, OpenWrt master
Run tested: cortexa53, Turris MOX, OpenWrt master

```
Jul  5 12:24:43 turris dnscrypt-proxy[3652]: [2019-07-05 12:24:43] [NOTICE] Network connectivity detected
Jul  5 12:24:43 turris dnscrypt-proxy[3652]: [2019-07-05 12:24:43] [NOTICE] Source [public-resolvers.md] loaded
Jul  5 12:24:43 turris dnscrypt-proxy[3652]: [2019-07-05 12:24:43] [NOTICE] dnscrypt-proxy 2.0.25
Jul  5 12:24:43 turris dnscrypt-proxy[3652]: [2019-07-05 12:24:43] [NOTICE] Now listening to 127.0.0.1:53 [UDP]
Jul  5 12:24:43 turris dnscrypt-proxy[3652]: [2019-07-05 12:24:43] [NOTICE] Now listening to 127.0.0.1:53 [TCP]
Jul  5 12:24:43 turris dnscrypt-proxy[3652]: [2019-07-05 12:24:43] [NOTICE] Now listening to [::1]:53 [UDP]
Jul  5 12:24:43 turris dnscrypt-proxy[3652]: [2019-07-05 12:24:43] [NOTICE] Now listening to [::1]:53 [TCP]
-- shortened ---
Jul  5 12:25:11 turris dnscrypt-proxy[3652]: [2019-07-05 12:25:11] [NOTICE] Server with the lowest initial latency: quad9-dnscrypt-ip4-nofilter-alt (rtt: 13ms)
Jul  5 12:25:11 turris dnscrypt-proxy[3652]: [2019-07-05 12:25:11] [NOTICE] dnscrypt-proxy is ready - live servers: 7
```

Description:

- add [dnscrypt-proxy](https://github.com/jedisct1/dnscrypt-proxy) written in GO.
The .ipk is large 3.5 MB

- init script is created by @etam in https://github.com/etam/DNS-over-HTTPS-for-OpenWRT/commit/6a06c6535f6f44cccbf35f5ac9eb4fe060133ca9

TO-DO:
- [x] Change IP address to `listen_addresses = ['127.0.0.53:53']` as suggested in [wiki](https://github.com/jedisct1/dnscrypt-proxy/wiki/Installation-on-OpenWRT)
