### PR TITLE
bcrypt: Update to version 3.1.7

### DIFF
--- a/lang/python/bcrypt/Makefile
+++ b/lang/python/bcrypt/Makefile
@@ -12,19 +12,17 @@ PKG_RELEASE:=1
 PKG_SOURCE:=bcrypt-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= https://files.pythonhosted.org/packages/source/b/$(PKG_NAME)
 PKG_HASH:=44636759d222baa62806bbceb20e96f75a015a6381690d1bc2eda91c01ec02ea
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-bcrypt-$(PKG_VERSION)
 
+PKG_MAINTAINER:=Daniel Dickinson <cshored@thecshore.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Daniel Dickinson <cshored@thecshore.com>
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-bcrypt-$(PKG_VERSION)
 
 PKG_BUILD_DEPENDS:=libffi/host
 HOST_PYTHON_PACKAGE_BUILD_DEPENDS:="cffi>=1.1"
 HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:="cffi>=1.1"
 
 include $(INCLUDE_DIR)/package.mk
-
 include ../python-package.mk
 include ../python3-package.mk
 
@@ -34,27 +32,30 @@ define Package/bcrypt/Default
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=Modern password hashing
   URL:=https://github.com/pyca/bcrypt/
 endef
 
 define Package/python-bcrypt
 $(call Package/bcrypt/Default)
-  TITLE:=BCrypt
-  DEPENDS+=+PACKAGE_python-bcrypt:python +PACKAGE_python-bcrypt:python-cffi \
-	   +PACKAGE_python-bcrypt:python-six
+  DEPENDS:= \
+	+PACKAGE_python-bcrypt:python \
+	+PACKAGE_python-bcrypt:python-cffi \
+	+PACKAGE_python-bcrypt:python-six
   VARIANT:=python
 endef
 
 define Package/python3-bcrypt
 $(call Package/bcrypt/Default)
-  TITLE:=BCrypt
-  DEPENDS+=+PACKAGE_python3-bcrypt:python3 +PACKAGE_python3-bcrypt:python3-cffi \
-	   +PACKAGE_python3-bcrypt:python3-six
+  DEPENDS:= \
+	+PACKAGE_python3-bcrypt:python3 \
+	+PACKAGE_python3-bcrypt:python3-cffi \
+	+PACKAGE_python3-bcrypt:python3-six
   VARIANT:=python3
 endef
 
 define Package/python-bcrypt/description
-Good password hashing for your software and your servers
+  Good password hashing for your software and your servers.
 endef
 
 define Package/python3-bcrypt/description
@@ -64,9 +65,9 @@ $(call Package/python-bcrypt/description)
 endef
 
 $(eval $(call PyPackage,python-bcrypt))
-$(eval $(call Py3Package,python3-bcrypt))
-
 $(eval $(call BuildPackage,python-bcrypt))
 $(eval $(call BuildPackage,python-bcrypt-src))
+
+$(eval $(call Py3Package,python3-bcrypt))
 $(eval $(call BuildPackage,python3-bcrypt))
 $(eval $(call BuildPackage,python3-bcrypt-src))

--- a/lang/python/bcrypt/Makefile
+++ b/lang/python/bcrypt/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcrypt
-PKG_VERSION:=3.1.6
+PKG_VERSION:=3.1.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bcrypt-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= https://files.pythonhosted.org/packages/source/b/$(PKG_NAME)
-PKG_HASH:=44636759d222baa62806bbceb20e96f75a015a6381690d1bc2eda91c01ec02ea
+PKG_HASH:=0b0069c752ec14172c5f78208f1863d7ad6755a6fae6fe76ec2c80d13be41e42
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-bcrypt-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Dickinson <cshored@thecshore.com>


### PR DESCRIPTION
Maintainer: @cshoredaniel
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:

- Update bcrypt to version [3.1.7](https://github.com/pyca/bcrypt/commit/af4d070e8f5919652485db5940f5970d7d1d699f#diff-88b99bb28683bd5b7e3a204826ead112)
- Reorder stuff in Makefile
- Improve TITLE