### PR TITLE
cmdpad: Fix compilation with musl

### DIFF
--- a/utils/cmdpad/Makefile
+++ b/utils/cmdpad/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmdpad
 PKG_VERSION:=0.0.3
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=@SF/cmdpad
@@ -27,8 +27,6 @@ define Package/cmdpad
   TITLE:=execute commands when key is pressed/released/held down
   URL:=http://cmdpad.sourceforge.net/index.php
 endef
-
-TARGET_CFLAGS += -std=gnu89
 
 CONFIGURE_ARGS += \
 	--enable-static \

--- a/utils/cmdpad/patches/150-header.patch
+++ b/utils/cmdpad/patches/150-header.patch
@@ -1,0 +1,49 @@
+--- a/src/command.c
++++ b/src/command.c
+@@ -43,6 +43,7 @@
+ 
+ #include <linux/input.h>
+ #include <linux/ioctl.h>
++#include <sys/wait.h>
+ #include <stdlib.h>
+ #include <fcntl.h>
+ #include <unistd.h>
+--- a/src/main.c
++++ b/src/main.c
+@@ -54,6 +54,7 @@
+ 
+ #include "debug.h"
+ #include "command.h"
++#include "parse.h"
+ 
+ #define DEBUGNAME         "MAIN: "
+ 
+--- a/src/parse.c
++++ b/src/parse.c
+@@ -58,7 +58,7 @@
+ extern char * pchProgramName ;
+ extern char * pchEventDevice ;
+ 
+-inline void ltrim( char * pchText)
++static void ltrim( char * pchText)
+ {
+ 	if( pchText) {
+ 		char * pchTxt = pchText ;
+@@ -67,7 +67,7 @@ inline void ltrim( char * pchText)
+   	}
+ }
+ 
+-inline void rtrim( char * pchText)
++static void rtrim( char * pchText)
+ {
+   	if( pchText)
+   	{
+@@ -77,7 +77,7 @@ inline void rtrim( char * pchText)
+  	}
+ }
+ 
+-inline void trim( char * pchText) 
++static void trim( char * pchText)
+ {
+   	ltrim( pchText) ;
+   	rtrim( pchText) ;


### PR DESCRIPTION
When passing -Wimplicit-function-declaration

Also got rid of std=gnu89. It's easy to patch out.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess
Compile tested: ath79