### PR TITLE
travelmate: update 1.4.9

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.4.8
+PKG_VERSION:=1.4.9
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-trm_ver="1.4.8"
+trm_ver="1.4.9"
 trm_sysver="unknown"
 trm_enabled=0
 trm_debug=0
@@ -359,6 +359,7 @@ f_jsnup()
 		if [ -z "$(printf "%s" "${faulty_list}" | grep -Fo "${faulty_station}")" ]
 		then
 			faulty_list="$(f_trim "${faulty_list} ${faulty_station}")"
+			last_date="$(/bin/date "+%Y.%m.%d-%H:%M:%S")"
 		fi
 	fi
 	json_add_string "travelmate_status" "${status}"


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL-AR750S, OpenWrt SNAPSHOT, r10443-ea4e1dac71

Description:
* fix a corner case issue with auto expiry of the
  'Faulty Station' list (the last run information was not updated)

Signed-off-by: Dirk Brenken <dev@brenken.org>
