### PR TITLE
squid: Fix compilation with GCC9

### DIFF
--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -9,16 +9,16 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
 PKG_VERSION:=4.6
-PKG_RELEASE:=1
-
-PKG_LICENSE:=GPL-2.0
-PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www3.us.squid-cache.org/Versions/v4/ \
 	http://www2.pl.squid-cache.org/Versions/v4/ \
 	http://www.squid-cache.org/Versions/v4/
 PKG_HASH:=015bade5d3a4905142c4c605df5c4216471e3d8338079955e0e44b0ae0303d41
+
+PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
+PKG_LICENSE:=GPL-2.0-or-later
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -116,6 +116,9 @@ CONFIGURE_ARGS += \
 CONFIGURE_VARS += \
 	ac_cv_header_linux_netfilter_ipv4_h=yes \
 	ac_cv_epoll_works=yes
+
+TARGET_CFLAGS += -Wno-error
+TARGET_LDFLAGS += -latomic
 
 define Build/Compile
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/lib all


### PR DESCRIPTION
by passing -Werror. Also added -latomic as some platforms need it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ratkaj 
Compile tested: arc700