### PR TITLE
liburcu: Update to 0.11.1

### DIFF
--- a/libs/liburcu/Makefile
+++ b/libs/liburcu/Makefile
@@ -9,17 +9,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=liburcu
-PKG_VERSION:=0.9.5
+PKG_VERSION:=0.11.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
-PKG_LICENSE:=LGPL-2.1 GPL-2.0 GPL-3.0 MIT
+PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later MIT
+PKG_LICENSE_FILES:=lgpl-2.1.txt gpl-2.0.txt lgpl-relicensing.txt
 
 PKG_SOURCE:=userspace-rcu-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://lttng.org/files/urcu/
-PKG_HASH:=d948250f1b365f052b29a4c017b7d67066c905f6ab529892cc6bc35c503a38a6
-
+PKG_HASH:=92b9971bf3f1c443edd6c09e7bf5ff3b43531e778841f16377a812c8feeb3350
 PKG_BUILD_DIR:=$(BUILD_DIR)/userspace-rcu-$(PKG_VERSION)
+
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Cleanup Makefile for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @salzmdan
Compile tested: ath79