### PR TITLE
wifidog: fix getting ip from interface, cleanup

### DIFF
--- a/net/wifidog/Makefile
+++ b/net/wifidog/Makefile
@@ -9,27 +9,20 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifidog
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=3
-
-
-PKG_LICENSE:=GPL-2.0
-# Note: Packaging is maintained upstream at
-# https://github.com/wifidog/packages
-PKG_MAINTAINER:=Michael Haas <haas@computerlinguist.org>
-PKG_LICENSE_FILES:=COPYING
-
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/wifidog/wifidog-gateway
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=1.3.0
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
 PKG_MIRROR_HASH:=9ffd9f3ae54baceb723abb7a04e27a9b6a3ff1479f8a3bfda9b8a496e8b4050f
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Michael Haas <haas@computerlinguist.org>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
-# do not run make install
 PKG_INSTALL:=0
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -49,7 +42,7 @@ endef
 
 define Package/wifidog-tls
 $(call Package/wifidog/Default)
-  DEPENDS+= +libcyassl
+  DEPENDS+= +PACKAGE_wifidog-tls:libwolfssl
   VARIANT:=tls
 endef
 
@@ -73,11 +66,6 @@ endef
 
 Package/wifidog-tls/conffiles = $(Package/wifidog/conffiles)
 
-
-define Package/wifidog/configure
-	$(call Build/Configure/Default)
-endef
-
 ifeq ($(BUILD_VARIANT),tls)
 
 CONFIGURE_ARGS += \
@@ -90,7 +78,7 @@ define Package/wifidog/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wifidog $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wdctl $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libhttpd.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libhttpd.so.* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/etc
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/wifidog.conf $(1)/etc/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/wifidog-msg.html $(1)/etc/

--- a/net/wifidog/patches/020-Modify-get-ip-from-iface-method.patch
+++ b/net/wifidog/patches/020-Modify-get-ip-from-iface-method.patch
@@ -1,0 +1,28 @@
+From 37b2dda9b1d62eb91028f6d590beddd36f7b79c8 Mon Sep 17 00:00:00 2001
+From: Nathan Samson <nathan@nathansamson.be>
+Date: Mon, 1 Feb 2016 21:37:22 +0100
+Subject: [PATCH] Modify get ip from iface method.
+
+This used to use a RAW socket, while now it used a DGRAM socket.
+Previously it failed with operation not permitted, while this version
+seems to work reliably.
+
+diff --git a/src/util.c b/src/util.c
+index 46ec5a2..426ba13 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -174,11 +174,13 @@ get_iface_ip(const char *ifname)
+     u_int32_t ip;
+ 
+     /* Create a socket */
+-    if ((sockd = socket(AF_INET, SOCK_RAW, htons(0x8086))) < 0) {
++    if ((sockd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+         debug(LOG_ERR, "socket(): %s", strerror(errno));
+         return NULL;
+     }
+ 
++     /* I want to get an IPv4 IP address */
++    if_data.ifr_addr.sa_family = AF_INET;
+     /* Get IP of internal interface */
+     strncpy(if_data.ifr_name, ifname, 15);
+     if_data.ifr_name[15] = '\0';


### PR DESCRIPTION
Maintainer: @mhaas 
Compile tested: arm, WRT3200ACM, openwrt master
Run tested: arm, WRT3200ACM, openwrt master, very "soft" test, made sure it ran and got a response from auth server.

Description:
Patch taken from upstream fixes an Invalid argument error while trying to get the IP address of an interface.
```
# wifidog -f -d 7
```
```
[7][Tue Jul  9 08:24:48 2019][23653](gateway.c:375) Finding IP address of br-lan
[3][Tue Jul  9 08:24:48 2019][23653](util.c:178) socket(): Invalid argument
[3][Tue Jul  9 08:24:48 2019][23653](gateway.c:377) Could not get IP address information of br-lan, exiting...
```
With the patch applied, the IP was correctly returned.  I don't use the package, so I can attest it is fully functional, but it got beyond the failure, at least to the point of getting a response from the auth server:
```
# wifidog -f -d 7
```
```
[7][Tue Jul  9 08:35:35 2019][23670](gateway.c:375) Finding IP address of br-lan
[7][Tue Jul  9 08:35:35 2019][23670](gateway.c:380) br-lan = 192.168.6.252
[7][Tue Jul  9 08:35:35 2019][23670](gateway.c:386) Finding MAC address of br-lan
```
```
[7][Tue Jul  9 08:35:36 2019][23670](simple_http.c:77) Sending HTTP request to auth server: [GET /ping/?gw_id=26F5A22D4738&sys_uptime=783065&sys_memfree=235012&sys_load=0.08&wifidog_uptime=1 HTTP/1.0
User-Agent: WiFiDog 1.3.0
Host: auth.ilesansfil.org

]

[7][Tue Jul  9 08:35:36 2019][23670](simple_http.c:87) Reading response
[7][Tue Jul  9 08:35:36 2019][23670](simple_http.c:111) Read 253 bytes
[7][Tue Jul  9 08:35:36 2019][23670](simple_http.c:124) HTTP Response from Server: [HTTP/1.1 200 OK
Date: Tue, 09 Jul 2019 11:35:36 GMT
Server: Apache
X-Powered-By: PHP/5.4.45-0+deb7u11
Set-Cookie: authpuppy=qgkfk2c2bi7phhv60fmbj2fn36; path=/
Vary: Accept-Encoding
Connection: close
Content-Type: text/html; charset=utf-8

Pong
]
[7][Tue Jul  9 08:35:36 2019][23670](ping_thread.c:198) Auth Server Says: Pong
```
It was reported here #9358; I'll close it with PRs to 18.06 and 19.07, to be done after this is merged.

Makefile was updated to current style, including changes to avoid copying the unversioned `.so` file, and to build wolfssl only when the tls version is selected.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>