### PR TITLE
[19.07] mwan3: add migration script for flush_conntrack config

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.7.13
+PKG_VERSION:=2.7.14
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/etc/uci-defaults/mwan3-migrate-flush_conntrack
+++ b/net/mwan3/files/etc/uci-defaults/mwan3-migrate-flush_conntrack
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+mwan3_migrate_flush_conntrack() {
+	local iface="$1"
+
+	config_get value "${iface}" flush_conntrack
+	case $value in
+		always)
+			uci_remove mwan3 "$iface" flush_conntrack
+			uci_add_list mwan3 "$iface" flush_conntrack ifup
+			uci_add_list mwan3 "$iface" flush_conntrack ifdown
+			;;
+		never)
+			uci_remove mwan3 "$iface" flush_conntrack
+			;;
+	esac
+
+	uci_commit mwan3
+}
+
+config_load mwan3
+config_foreach mwan3_migrate_flush_conntrack interface
+
+exit 0


### PR DESCRIPTION
Maintainer: me
Compile tested: not needed -> scripts
Run tested: x86_64 lantiq_xrx200, APU3

Description:
Since commit  https://github.com/openwrt/packages/commit/171cb17694e931feb462e31c56a7c72b35cb322e#diff-db38cab1d9dd8aa229f35ff66d7570f6 the option **flush_conntrack** is now a list value.
Add a migration script to migrate the **option** value to a **list** value to have the same behavior as before the change.
