### PR TITLE
[openwrt-19.07] wifidog: fix getting ip from interface, cleanup

### DIFF
--- a/net/wifidog/Makefile
+++ b/net/wifidog/Makefile
@@ -9,27 +9,20 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifidog
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=3
-
-
-PKG_LICENSE:=GPL-2.0
-# Note: Packaging is maintained upstream at
-# https://github.com/wifidog/packages
-PKG_MAINTAINER:=Michael Haas <haas@computerlinguist.org>
-PKG_LICENSE_FILES:=COPYING
-
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/wifidog/wifidog-gateway
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=1.3.0
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
 PKG_MIRROR_HASH:=9ffd9f3ae54baceb723abb7a04e27a9b6a3ff1479f8a3bfda9b8a496e8b4050f
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Michael Haas <haas@computerlinguist.org>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
-# do not run make install
 PKG_INSTALL:=0
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -49,7 +42,7 @@ endef
 
 define Package/wifidog-tls
 $(call Package/wifidog/Default)
-  DEPENDS+= +libcyassl
+  DEPENDS+= +PACKAGE_wifidog-tls:libwolfssl
   VARIANT:=tls
 endef
 
@@ -73,11 +66,6 @@ endef
 
 Package/wifidog-tls/conffiles = $(Package/wifidog/conffiles)
 
-
-define Package/wifidog/configure
-	$(call Build/Configure/Default)
-endef
-
 ifeq ($(BUILD_VARIANT),tls)
 
 CONFIGURE_ARGS += \
@@ -90,7 +78,7 @@ define Package/wifidog/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wifidog $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/wdctl $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libhttpd.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libhttpd.so.* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/etc
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/wifidog.conf $(1)/etc/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/wifidog-msg.html $(1)/etc/

--- a/net/wifidog/patches/020-Modify-get-ip-from-iface-method.patch
+++ b/net/wifidog/patches/020-Modify-get-ip-from-iface-method.patch
@@ -1,0 +1,28 @@
+From 37b2dda9b1d62eb91028f6d590beddd36f7b79c8 Mon Sep 17 00:00:00 2001
+From: Nathan Samson <nathan@nathansamson.be>
+Date: Mon, 1 Feb 2016 21:37:22 +0100
+Subject: [PATCH] Modify get ip from iface method.
+
+This used to use a RAW socket, while now it used a DGRAM socket.
+Previously it failed with operation not permitted, while this version
+seems to work reliably.
+
+diff --git a/src/util.c b/src/util.c
+index 46ec5a2..426ba13 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -174,11 +174,13 @@ get_iface_ip(const char *ifname)
+     u_int32_t ip;
+ 
+     /* Create a socket */
+-    if ((sockd = socket(AF_INET, SOCK_RAW, htons(0x8086))) < 0) {
++    if ((sockd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+         debug(LOG_ERR, "socket(): %s", strerror(errno));
+         return NULL;
+     }
+ 
++     /* I want to get an IPv4 IP address */
++    if_data.ifr_addr.sa_family = AF_INET;
+     /* Get IP of internal interface */
+     strncpy(if_data.ifr_name, ifname, 15);
+     if_data.ifr_name[15] = '\0';


### PR DESCRIPTION
Maintainer: @mhaas 
Compile tested: arm, WRT3200ACM, openwrt master
Run tested: same as above, basic testing, see #9432 

Description:
Patch taken from upstream fixes an Invalid argument error while trying
to get the IP address of an interface.
Makefile was updated to current style.
(cherry-picked from 5ab9f3e3576d7fd28cf55ac604dbf485eb1b0de3)

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
