### PR TITLE
irssi: update to version 1.2.1 (security fix)

### DIFF
--- a/net/irssi/Makefile
+++ b/net/irssi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=irssi
-PKG_VERSION:=1.2.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.2.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/irssi/irssi/releases/download/1.2.0/
-PKG_HASH:=1643fca1d8b35e5a5d7b715c9c889e1e9cdb7e578e06487901ea959e6ab3ebe5
+PKG_SOURCE_URL:=https://github.com/irssi/irssi/releases/download/1.2.1/
+PKG_HASH:=5466a1ed9612cfa707d9a37d60b29d027b4ac7d83c74ceb1a410e2b59edba92c
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: @tripolar
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR  updates irssi to version 1.2.1 It is security release related to CVE-2019-13045


CVE-2019-13045  - https://irssi.org/security/html/irssi_sa_2019_06/
Changelog - https://irssi.org/NEWS/#v1-2-1


Signed-off-by: Jan Pavlinec jan.pavlinec@nic.cz