### PR TITLE
minisatip: add new package

### DIFF
--- a/multimedia/minisatip/Makefile
+++ b/multimedia/minisatip/Makefile
@@ -1,0 +1,61 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=minisatip
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/catalinii/minisatip.git
+PKG_SOURCE_VERSION:=b9fcb51b207f3b26b32b9b7c0e633cffea82274d
+PKG_SOURCE_DATE:=2019-07-08
+PKG_MIRROR_HASH:=468ef84a491a6c7601e683cf166d95a97ea5e617d98b44e0d3393b194b28f692
+
+PKG_MAINTAINER:=Daniel Kucera <github@danman.eu>
+PKG_LICENSE:=GPL-2.0-or-later
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/minisatip
+  TITLE:=SATIP server
+  URL:=https://github.com/catalinii/minisatip
+  SECTION:=multimedia
+  CATEGORY:=Multimedia
+  DEPENDS:=+MINISATIP_AES:libopenssl
+endef
+
+define Package/minisatip/config
+	if PACKAGE_minisatip
+
+		config MINISATIP_AES
+			bool "OpenSSL (AES as part of DVBAPI)"
+			default n
+
+		config MINISATIP_CLIENT
+			bool "SatIP Client"
+			default y
+
+	endif
+endef
+
+ifeq ($(CONFIG_MINISATIP_AES),)
+	CONFIGURE_ARGS += --disable-dvbaes
+endif
+
+ifeq ($(CONFIG_MINISATIP_CLIENT),)
+	CONFIGURE_ARGS += --disable-satipc
+endif
+
+define Package/minisatip/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/minisatip $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/share/minisatip/html/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/html/* $(1)/usr/share/minisatip/html
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/minisatip.init $(1)/etc/init.d/minisatip
+endef
+
+$(eval $(call BuildPackage,minisatip))

--- a/multimedia/minisatip/files/minisatip.init
+++ b/multimedia/minisatip/files/minisatip.init
@@ -1,0 +1,16 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=99
+
+start_service() {
+	procd_open_instance minisatip
+	procd_set_param command /usr/bin/minisatip -f -R /usr/share/minisatip/html
+
+	procd_set_param respawn
+
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+


### PR DESCRIPTION
Maintainer: @danielkucera
Compile tested: ramips, u7621-06-256M-16M, v18.06.1
Run tested: ramips, UniElec U7621-06 (256M RAM/16M flash), OpenWrt 18.06.4, r7808-ef686b7292

Description:

Minisatip is a multi-threaded satip server version 1.2 that runs
under Linux and it was tested with DVB-S, DVB-S2, DVB-T, DVB-T2,
DVB-C, DVB-C2, ATSC and ISDB-T cards.

https://github.com/catalinii/minisatip

Followup PR on https://github.com/openwrt/packages/pull/6325