### PR TITLE
expat: update to version 2.2.7 (security fix)

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -6,20 +6,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
-PKG_VERSION:=2.2.6
+PKG_VERSION:=2.2.7
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/expat
-PKG_HASH:=17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2
-PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>, \
-		Ted Hess <thess@kitschensync.net>
+PKG_HASH:=30e3f40acf9a8fdbd5c379bdcc8d1178a1d9af306de29fc8ece922bc4c57bef8
 
+PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:libexpat:expat
 
 PKG_FIXUP:=autoreconf
-
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 


### PR DESCRIPTION
Maintainer: @sbyx and @thess 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master


Description:
Fixes CVE-2018-20843 and adds CPE ID

- Changelog - https://github.com/libexpat/libexpat/blob/R_2_2_7/expat/Changes
- CVE-2018-20843 - https://nvd.nist.gov/vuln/detail/CVE-2018-20843

Runtested with xmlwf using expat_2.2.7

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>