### PR TITLE
softethervpn5: Fix compilation with libiconv-full

### DIFF
--- a/net/softethervpn5/Makefile
+++ b/net/softethervpn5/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=softethervpn5
 PKG_VERSION:=5.01.9670
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0
@@ -106,6 +106,8 @@ endef
 
 define Build/Install
 endef
+
+TARGET_LDFLAGS += -liconv
 
 define Package/softethervpn5-libs/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/net/softethervpn5/patches/110-iconv.patch
+++ b/net/softethervpn5/patches/110-iconv.patch
@@ -1,0 +1,11 @@
+--- SoftEtherVPN-5.01.9671/src/Mayaqua/Mayaqua.h.orig	2019-07-10 13:16:07.267152861 -0700
++++ SoftEtherVPN-5.01.9671/src/Mayaqua/Mayaqua.h	2019-07-10 13:16:25.211025882 -0700
+@@ -178,7 +178,7 @@
+ #include <ifaddrs.h>
+ #endif	// MAYAQUA_SUPPORTS_GETIFADDRS
+ 
+-#ifdef	UNIX_LINUX
++#if 0
+ typedef void *iconv_t;
+ iconv_t iconv_open (__const char *__tocode, __const char *__fromcode);
+ size_t iconv (iconv_t __cd, char **__restrict __inbuf,

--- a/net/softethervpn5/patches/120-libiconv.patch
+++ b/net/softethervpn5/patches/120-libiconv.patch
@@ -1,0 +1,11 @@
+--- SoftEtherVPN-5.01.9671/src/Mayaqua/CMakeLists.txt.orig	2019-07-10 13:46:12.794229786 -0700
++++ SoftEtherVPN-5.01.9671/src/Mayaqua/CMakeLists.txt	2019-07-10 13:52:32.077845446 -0700
+@@ -63,7 +63,7 @@
+ 
+   find_library(LIB_RT rt)
+ 
+-  target_link_libraries(mayaqua PRIVATE OpenSSL::SSL OpenSSL::Crypto Threads::Threads ZLIB::ZLIB)
++  target_link_libraries(mayaqua PRIVATE iconv OpenSSL::SSL OpenSSL::Crypto Threads::Threads ZLIB::ZLIB)
+ 
+   if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv7l|aarch64|s390x)$" OR NOT HAVE_SYS_AUXV)
+     add_definitions(-DSKIP_CPU_FEATURES)


### PR DESCRIPTION
softethervpn overrides nls.mk instead of just including the header for
some reason. if it out.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Andy2244 
Compile tested: arc700