### PR TITLE
logrotate: move config option to menu

### DIFF
--- a/utils/logrotate/Makefile
+++ b/utils/logrotate/Makefile
@@ -31,11 +31,12 @@ define Package/logrotate
 endef
 
 define Package/logrotate/config
-config LOGROTATE_ACL
-	bool
-	prompt "Enable ACL support"
-	default y if USE_FS_ACL_ATTR
-	default n
+	if PACKAGE_logrotate
+		config LOGROTATE_ACL
+			bool
+			prompt "Enable ACL support"
+			default y if USE_FS_ACL_ATTR
+	endif
 endef
 
 define Package/logrotate/description


### PR DESCRIPTION
Maintainer: @bk138 
Compile tested: `make menuconfig` tested
Run tested: N/A

Description:
Sorry @neheb, I did not pay close enough attention to it in #9373 :disappointed: .  Please don't get mad. :angel: 
If you don't surround the option with if/endif, it ends up outside of the menu.
I took the liberty of removing the `default n` line, since it is unnecessary.

No need to increase `PKG_RELEASE`.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

