### PR TITLE
net-snmp: reload firewall only when needed

### DIFF
--- a/net/net-snmp/files/snmpd.init
+++ b/net/net-snmp/files/snmpd.init
@@ -337,7 +337,8 @@ start_service() {
 }
 
 stop_service() {
-	[ -f "$CONFIGFILE" ] && rm -f "$CONFIGFILE"
+	[ -f "$CONFIGFILE" ] || return
+	rm -f "$CONFIGFILE"
 	procd_set_config_changed firewall
 }
 
@@ -353,5 +354,6 @@ service_triggers(){
 }
 
 service_started() {
+	[ "$snmp_enabled" -eq 0 ] && return
 	procd_set_config_changed firewall
 }


### PR DESCRIPTION
Firewall needs to be reloaded in the following cases:
 - on service start when snmpd.general.enabled=1
 - when snmpd daemon is stopped

Signed-off-by: Alin Nastac <alin.nastac@gmail.com>

Maintainer: Stijn Tintel <stijn@linux-ipv6.be>
Run tested: on master branch by start/stop/reload snmpd service with snmpd.general.enabled set to 0 and 1
