### PR TITLE
python-cachetools: add a new package

### DIFF
--- a/lang/python/python-cachetools/Makefile
+++ b/lang/python/python-cachetools/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-cachetools
+PKG_VERSION:=3.1.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=cachetools-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/cachetools/
+PKG_HASH:=8ea2d3ce97850f31e4a08b0e2b5e6c34997d7216a9d2c98e0f3978630d4da69a
+PKG_BUILD_DIR:=$(BUILD_DIR)/cachetools-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-cachetools
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Extensible memoizing collections and decorators
+  URL:=https://github.com/tkem/cachetools
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-cachetools/description
+  This module provides various memoizing collections and decorators, including variants of the Python 3 Standard Library lru_cache function decorator.
+endef
+
+$(eval $(call Py3Package,python3-cachetools))
+$(eval $(call BuildPackage,python3-cachetools))
+$(eval $(call BuildPackage,python3-cachetools-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: cortexa53, Turris MOX, OpenWrt master
Run tested: cortexa53, Turris MOX, OpenWrt master

Description:
- add [python-cachetools](https://pypi.org/project/cachetools/)

cc: @commodo , @jefferyto 