### PR TITLE
luasocket5.3 : initial add

### DIFF
--- a/lang/luasocket5.3/Makefile
+++ b/lang/luasocket5.3/Makefile
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2009-2013 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=luasocket
+PKG_SOURCE_DATE:=2019-04-21
+PKG_SOURCE_VERSION:=733af884f1aa18ff469bf3c4d18810e815853211
+PKG_RELEASE:=1
+
+PKG_MIRROR_HASH:=60aef7544426cae3e6c7560a6e4ad556a04b879ca0ad0311645b2c513c872128
+PKG_SOURCE_URL:=https://github.com/diegonehab/luasocket
+PKG_SOURCE_PROTO:=git
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/luasocket5.3
+  SUBMENU:=Lua
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=LuaSocket 5.3
+  URL:=http://w3.impa.br/~diego/software/luasocket
+  DEPENDS:=+liblua5.3
+endef
+
+define Package/luasocket5.3/description
+  LuaSocket is the most comprehensive networking support
+  library for the Lua language. It provides easy access to
+  TCP, UDP, DNS, SMTP, FTP, HTTP, MIME and much more.  This
+  version supports lua5.3
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR)/ \
+		LIBDIR="$(TARGET_LDFLAGS)" \
+		CC="$(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_CPPFLAGS) $(FPIC)" \
+		LD="$(TARGET_CROSS)ld -shared" \
+		LUAV=5.3 LUAINC_linux_base=$(STAGING_DIR)/usr/include \
+		all
+endef
+
+define Package/luasocket5.3/install
+	$(MAKE) -C $(PKG_BUILD_DIR)/src \
+		DESTDIR="$(1)" \
+		LUAV=5.3 \
+		install
+endef
+
+$(eval $(call BuildPackage,luasocket5.3))

--- a/lang/luasocket5.3/patches/0001-Add-interface-support.patch
+++ b/lang/luasocket5.3/patches/0001-Add-interface-support.patch
@@ -1,0 +1,239 @@
+From 96fdf07acf78ecfc9be76a8b0591f38fe6f1a875 Mon Sep 17 00:00:00 2001
+From: Steven Barth <steven@midlink.org>
+Date: Sat, 9 Nov 2013 12:01:42 +0100
+Subject: [PATCH] Add interface resolving
+
+---
+ src/if.c        | 113 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ src/if.h        |  27 ++++++++++++++
+ src/luasocket.c |   2 +
+ src/makefile    |   2 +
+ src/options.c   |   9 +++++
+ 5 files changed, 153 insertions(+)
+ create mode 100644 src/if.c
+ create mode 100644 src/if.h
+
+diff --git a/src/if.c b/src/if.c
+new file mode 100644
+index 0000000..db231aa
+--- /dev/null
++++ b/src/if.c
+@@ -0,0 +1,113 @@
++/*
++ * $Id: if.c $
++ *
++ * Author: Markus Stenberg <fingon@iki.fi>
++ *
++ * Copyright (c) 2012 cisco Systems, Inc.
++ *
++ * Created:       Tue Dec  4 14:50:34 2012 mstenber
++ * Last modified: Wed Dec  5 18:51:08 2012 mstenber
++ * Edit time:     24 min
++ *
++ */
++
++#include <sys/types.h>
++#include <sys/socket.h>
++#include <net/if.h>
++
++#include "if.h"
++
++#include "lauxlib.h"
++
++static int if_global_indextoname(lua_State *L);
++static int if_global_nametoindex(lua_State *L);
++static int if_global_nameindex(lua_State *L);
++
++static luaL_Reg func[] = {
++    { "indextoname", if_global_indextoname},
++    { "nametoindex", if_global_nametoindex},
++    { "nameindex", if_global_nameindex},
++    { NULL, NULL}
++};
++
++int if_open(lua_State *L)
++{
++    lua_pushstring(L, "iface");
++    lua_newtable(L);
++    luaL_setfuncs(L, func, 0);
++    lua_settable(L, -3);
++    return 0;
++}
++
++int if_global_indextoname(lua_State *L)
++{
++  unsigned int ifnumber;
++  const char *name;
++  char buf[IF_NAMESIZE+1];
++
++  if (!lua_isnumber(L, 1))
++    {
++      lua_pushnil(L);
++      lua_pushstring(L, "indextoname expects only number argument");
++      return 2;
++    }
++  ifnumber = lua_tonumber(L, 1);
++  if (!(name = if_indextoname(ifnumber, buf)))
++    {
++      lua_pushnil(L);
++      lua_pushstring(L, "nonexistent interface");
++      return 2;
++    }
++  lua_pushstring(L, name);
++  return 1;
++}
++
++int if_global_nametoindex(lua_State *L)
++{
++  unsigned int ifnumber;
++  if (!lua_isstring(L, 1))
++    {
++      lua_pushnil(L);
++      lua_pushstring(L, "nametoindex expects only string argument");
++      return 2;
++    }
++  if (!(ifnumber = if_nametoindex(lua_tostring(L, 1))))
++    {
++      lua_pushnil(L);
++      lua_pushstring(L, "nonexistent interface");
++      return 2;
++    }
++  lua_pushnumber(L, ifnumber);
++  return 1;
++}
++
++int if_global_nameindex(lua_State *L)
++{
++  struct if_nameindex *ni, *oni;
++  int i = 1;
++  oni = ni = if_nameindex();
++  lua_newtable(L);
++  while (ni && ni->if_index && *(ni->if_name))
++    {
++      /* at result[i], we store.. */
++      lua_pushnumber(L, i);
++
++      /* new table with two items - index, name*/
++      lua_newtable(L);
++      lua_pushstring(L, "index");
++      lua_pushnumber(L, ni->if_index);
++      lua_settable(L, -3);
++
++      lua_pushstring(L, "name");
++      lua_pushstring(L, ni->if_name);
++      lua_settable(L, -3);
++
++      /* Then, actually store it */
++      lua_settable(L, -3);
++
++      i++;
++      ni++;
++    }
++  if_freenameindex(oni);
++  return 1;
++}
+diff --git a/src/if.h b/src/if.h
+new file mode 100644
+index 0000000..dc7faf8
+--- /dev/null
++++ b/src/if.h
+@@ -0,0 +1,27 @@
++/*
++ * $Id: if.h $
++ *
++ * Author: Markus Stenberg <fingon@iki.fi>
++ *
++ *  Copyright (c) 2012 cisco Systems, Inc.
++ *
++ * Created:       Tue Dec  4 14:37:24 2012 mstenber
++ * Last modified: Tue Dec  4 14:51:43 2012 mstenber
++ * Edit time:     7 min
++ *
++ */
++
++/* This module provides Lua wrapping for the advanced socket API
++ * defined in RFC3542, or mainly, the access to the system's interface
++ * list. It is necessary for use of recvmsg/sendmsg.
++ *
++ * TODO - Do something clever with Windows?
++ */
++#ifndef IF_H
++#define IF_H
++
++#include "lua.h"
++
++int if_open(lua_State *L);
++
++#endif /* IF_H */
+diff --git a/src/luasocket.c b/src/luasocket.c
+index e6ee747..85d41a6 100644
+--- a/src/luasocket.c
++++ b/src/luasocket.c
+@@ -21,6 +21,7 @@
+ #include "tcp.h"
+ #include "udp.h"
+ #include "select.h"
++#include "if.h"
+ 
+ /*-------------------------------------------------------------------------*\
+ * Internal function prototypes
+@@ -41,6 +42,7 @@ static const luaL_Reg mod[] = {
+     {"tcp", tcp_open},
+     {"udp", udp_open},
+     {"select", select_open},
++    {"iface", if_open},
+     {NULL, NULL}
+ };
+ 
+diff --git a/src/makefile b/src/makefile
+index 8d3521e..09d4882 100644
+--- a/src/makefile
++++ b/src/makefile
+
+@@ -303,6 +303,7 @@ SOCKET_OBJS= \
+ 	compat.$(O) \
+ 	options.$(O) \
+ 	inet.$(O) \
++	if.$(O) \
+ 	$(SOCKET) \
+ 	except.$(O) \
+ 	select.$(O) \
+@@ -440,6 +441,7 @@ auxiliar.$(O): auxiliar.c auxiliar.h
+ buffer.$(O): buffer.c buffer.h io.h timeout.h
+ except.$(O): except.c except.h
+ inet.$(O): inet.c inet.h socket.h io.h timeout.h usocket.h
++if.$(O): if.c if.h
+ io.$(O): io.c io.h timeout.h
+ luasocket.$(O): luasocket.c luasocket.h auxiliar.h except.h \
+ 	timeout.h buffer.h io.h inet.h socket.h usocket.h tcp.h \
+diff --git a/src/options.c b/src/options.c
+index 8ac2a14..1c73e6f 100644
+--- a/src/options.c
++++ b/src/options.c
+@@ -7,7 +7,10 @@
+ #include "options.h"
+ #include "inet.h"
+ #include <string.h>
+-
++#include <sys/types.h>
++#include <sys/socket.h>
++#include <net/if.h>
++ 
+ /*=========================================================================*\
+ * Internal functions prototypes
+ \*=========================================================================*/
+@@ -388,6 +391,12 @@ static int opt_ip6_setmembership(lua_Sta
+     if (!lua_isnil(L, -1)) {
+         if (lua_isnumber(L, -1)) {
+             val.ipv6mr_interface = (unsigned int) lua_tonumber(L, -1);
++        } else if (lua_isstring(L, -1)) {
++            if (!(val.ipv6mr_interface = if_nametoindex(lua_tostring(L, -1)))) {
++                lua_pushnil(L);
++                lua_pushstring(L, "nonexistent interface");
++                return 2;
++            }
+         } else
+           luaL_argerror(L, -1, "number 'interface' field expected");
+     }
+--
+1.8.4.rc3

--- a/lang/luasocket5.3/patches/0301-Fix-mpc85xx-build.patch
+++ b/lang/luasocket5.3/patches/0301-Fix-mpc85xx-build.patch
@@ -1,0 +1,25 @@
+--- a/src/makefile
++++ b/src/makefile
+@@ -397,18 +398,18 @@ none:
+ all: $(SOCKET_SO) $(MIME_SO)
+ 
+ $(SOCKET_SO): $(SOCKET_OBJS)
+-	$(LD) $(SOCKET_OBJS) $(LDFLAGS)$@
++	$(CC) $(SOCKET_OBJS) $(LDFLAGS)$@
+ 
+ $(MIME_SO): $(MIME_OBJS)
+-	$(LD) $(MIME_OBJS) $(LDFLAGS)$@
++	$(CC) $(MIME_OBJS) $(LDFLAGS)$@
+ 
+ all-unix: all $(UNIX_SO) $(SERIAL_SO)
+ 
+ $(UNIX_SO): $(UNIX_OBJS)
+-	$(LD) $(UNIX_OBJS) $(LDFLAGS)$@
++	$(CC) $(UNIX_OBJS) $(LDFLAGS)$@
+ 
+ $(SERIAL_SO): $(SERIAL_OBJS)
+-	$(LD) $(SERIAL_OBJS) $(LDFLAGS)$@
++	$(CC) $(SERIAL_OBJS) $(LDFLAGS)$@
+ 
+ install:
+ 	$(INSTALL_DIR) $(INSTALL_TOP_LDIR)

--- a/lang/luasocket5.3/patches/040-remove-fpic-and-warnings.patch
+++ b/lang/luasocket5.3/patches/040-remove-fpic-and-warnings.patch
@@ -1,0 +1,14 @@
+--- a/src/makefile
++++ b/src/makefile
+@@ -174,9 +174,8 @@ SO_linux=so
+ O_linux=o
+ CC_linux=gcc
+ DEF_linux=-DLUASOCKET_$(DEBUG)
+-CFLAGS_linux=$(LUAINC:%=-I%) $(DEF) -Wall -Wshadow -Wextra \
+-	-Wimplicit -O2 -ggdb3 -fpic
+-LDFLAGS_linux=-O -shared -fpic -o 
++CFLAGS_linux=$(LUAINC:%=-I%) $(DEF) -O2 
++LDFLAGS_linux=-O -shared -o 
+ LD_linux=gcc
+ SOCKET_linux=usocket.o
+ 


### PR DESCRIPTION
Creating a luasocket package that is compatible with, and built against,
lua version 5.3.  The base of this package started from the luasocket
package and I made the following modifications:

Makefile - Updated the upstream version.  Set the LUAV environment
variable in the build to 5.3.  Set an include path in the lua build so
that that lua5.3 headers could be found.  Also using the make install
target as everything is put in the correct place automatically.

0001-Add-interface-support.patch - ported this patch which included
replacing one deprecated call.  Validated that the interface
functionality added by the patch is working and functional.  The
following lua script line was functional: print(socket.iface.indextoname(2))

0301-Fix-mpc85xx-build.patch - Just fixed the offsets and fuzz in the
patch

040-remove-fpic-and-warnings.patch - ported this patch.  I did make one
change.  The patch name is called remove fpic and warnings, but the
patch was also removing optimization.  I ported the removal of fpic and
warnings, however I left optimization in.

Built and tested on BCM5301X.

Signed-off-by: Colby Whitney <colby.whitney@luxul.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
