### PR TITLE
softethervpn: Pass FLAGS to CC for hamcorebuilder

### DIFF
--- a/net/softethervpn/Makefile
+++ b/net/softethervpn/Makefile
@@ -58,7 +58,8 @@ define Host/Compile
 
 	# Build hamcorebuilder using host compiler and let it generate
 	# the hamcore.se2 archive file
-	CC="$(HOSTCC)" $(MAKE) $(HOST_MAKE_FLAGS) \
+	# CFLAGS, CPPFLAGS & LDFLAGS need to be passed with CC because they are being ingored
+	CC="$(HOSTCC) $(HOST_CFLAGS) $(HOST_CPPFLAGS) $(HOST_LDFLAGS)" $(MAKE) $(HOST_MAKE_FLAGS) \
 		src/bin/BuiltHamcoreFiles/unix/hamcore.se2
 endef
 


### PR DESCRIPTION
CFLAGS, CPPFLAGS & LDFLAGS need to be passed with CC because they are being ingored.
This is already contained in the master branch but was missing in 18.06. Without these flags the compilation fails.

Compile tested: Atheros AR7xxx/AR9xxx, TP-LINK Archer C7 v2, 18.06.4

Signed-off-by: Philipp Schuster <philippschuster@gmx.com>
