### PR TITLE
Docker Community Edition --init and --publish options

### DIFF
--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -1,17 +1,31 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-ce
-PKG_VERSION:=18.09.6
+PKG_VERSION:=18.09.8
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=components/cli/LICENSE components/engine/LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/docker/docker-ce/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=e8d2dd41e09e838e9043d4a5cf8433d8860afa20a611025621f7817b7ab16012
-PKG_SOURCE_VERSION:=481bc77156
+PKG_HASH:=33dfaf3cf296f8e9011ec6ed2de0125dfeaf8a938126f0218b0218a156c14014
+PKG_SOURCE_VERSION:=0dd43dd87f
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
+
+define CheckExpectedSrcVer
+	$(eval SRC_VER:=$(shell grep --only-matching --perl-regexp '(?<=PKG_SOURCE_VERSION:=)(.*)' $(1)))
+	$(if $(subst $(2),,$(SRC_VER)), \
+		$(error ERROR: Expected $(1) source version '$(2)', found '$(SRC_VER)'), \
+		$(info OK: Expected $(1) source version '$(2)', found '$(SRC_VER)') \
+	)
+endef
+
+# values from respective '.installer' files at https://github.com/docker/docker-ce/blob/v$(PKG_VERSION)/components/engine/hack/dockerfile/install/
+$(eval $(call CheckExpectedSrcVer,../containerd/Makefile,894b81a4b802e4eb2a91d1ce216b8817763c29fb))
+$(eval $(call CheckExpectedSrcVer,../libnetwork/Makefile,e7933d41e7b206756115aa9df5e0599fc5169742))
+$(eval $(call CheckExpectedSrcVer,../runc/Makefile,425e105d5a03fabd737a126ad93d62a9eeede87f))
+$(eval $(call CheckExpectedSrcVer,../tini/Makefile,fec3683b971d9c3ef73f284f176672c44b448662))
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
@@ -30,8 +44,8 @@ define Package/docker-ce
   CATEGORY:=Utilities
   TITLE:=Docker Community Edition
   URL:=https://www.docker.com/
-  DEPENDS:=$(GO_ARCH_DEPENDS) @TARGET_x86_64 +btrfs-progs +libdevmapper +containerd +cgroupfs-mount +ca-certificates +iptables-mod-extra +DOCKER_SECCOMP:libseccomp \
-           +kmod-ikconfig +kmod-veth +kmod-br-netfilter +kmod-nf-ipvs
+  DEPENDS:=$(GO_ARCH_DEPENDS) @TARGET_x86_64 +btrfs-progs +ca-certificates +cgroupfs-mount +containerd +libdevmapper +libnetwork +tini \
+           +DOCKER_SECCOMP:libseccomp +iptables-mod-extra +kmod-br-netfilter +kmod-ikconfig +kmod-nf-ipvs +kmod-veth
   USERID:=docker:docker
   MENU:=1
 endef

--- a/utils/libnetwork/Makefile
+++ b/utils/libnetwork/Makefile
@@ -1,0 +1,50 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libnetwork
+PKG_VERSION:=0.8.0-dev.2
+PKG_RELEASE:=1
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+GO_PKG:=github.com/docker/libnetwork
+GO_PKG_BUILD_PKG:= \
+  $(GO_PKG)/cmd/proxy \
+  $(GO_PKG)/cmd/dnet
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://$(GO_PKG)
+PKG_SOURCE_VERSION:=e7933d41e7b206756115aa9df5e0599fc5169742
+PKG_MIRROR_HASH:=48638648bfd2b249f8e9cc32b5ec295a64e61fcb7cf635ca1a88809662167374
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
+
+PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/libnetwork
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=networking for containers
+  URL:=https://github.com/docker/libnetwork
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+endef
+
+define Package/libnetwork/description
+Libnetwork provides a native Go implementation for connecting containers.
+The goal of libnetwork is to deliver a robust Container Network Model that provides a consistent programming interface and the required network abstractions for applications.
+endef
+
+define Package/libnetwork/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/dnet $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/proxy $(1)/usr/bin/docker-proxy
+endef
+
+$(eval $(call GoBinPackage,libnetwork))
+$(eval $(call BuildPackage,libnetwork))

--- a/utils/tini/Makefile
+++ b/utils/tini/Makefile
@@ -1,0 +1,43 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tini
+PKG_VERSION:=0.18.0
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/krallin/tini/tar.gz/v${PKG_VERSION}?
+PKG_HASH:=1097675352d6317b547e73f9dc7c6839fd0bb0d96dafc2e5c95506bb324049a2
+PKG_SOURCE_VERSION:=fec3683b971d9c3ef73f284f176672c44b448662
+
+PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
+
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/tini
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=simplest init utility
+  URL:=https://github.com/krallin/tini
+  DEPENDS:=
+endef
+
+define Package/tini/description
+A tiny but valid init process for containers.
+endef
+
+# static version seemes to be effected by https://www.openwall.com/lists/musl/2018/07/18/8 so we use the workaround
+TARGET_CFLAGS += -Wl,--build-id
+
+define Package/tini/install
+	$(INSTALL_DIR) $(1)/usr/bin
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tini-static $(1)/usr/bin/docker-init
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tini $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,tini))


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: x86_x64, Hyper-V, OpenWrt Master
Run tested: x86_x64, Hyper-V, OpenWrt Master

Description:
Following up on https://github.com/openwrt/packages/pull/8397#issuecomment-508442087.
Adds support for `--init` and `--publish` in Docker Community Edition via tini and libnetwork  dependencies. 