### PR TITLE
collectd: add routeros-plugin and depending librouteros

### DIFF
--- a/libs/librouteros/Makefile
+++ b/libs/librouteros/Makefile
@@ -1,0 +1,54 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=librouteros
+PKG_SOURCE_DATE:=2018-07-19
+PKG_SOURCE_VERSION:=c485c777ffbbbd87c3d72d843af36ba016803cae
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Sven Roederer <devel-sven@geroedel.de>
+PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=COPYING
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_DATE).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/octo/librouteros/tar.gz/$(PKG_SOURCE_VERSION)?
+PKG_HASH:=427e071fe270ff6c08e32a10e5beff2add4205e6c864b142f950efdb8d2245a4
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/librouteros
+  TITLE:=A library that talks to MikroTik devices.
+  URL:=https://octo.github.io/librouteros/
+  SECTION:=libs
+  CATEGORY:=Libraries
+endef
+
+define Package/librouteros/description
+  librouteros is a library to communicate with RouterOS, the operating system of MikroTik's RouterBoards.
+  It uses the API port provided by those systems to connect and talk to the devices. librouteros is a
+  low-level library in that it abstracts the network protocol used but has next to no knowledge about the
+  commands and responses available
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/routeros_*.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/librouteros.{a,la,so*} $(1)/usr/lib/
+endef
+
+define Package/librouteros/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/librouteros.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,librouteros))

--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.9.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \
@@ -83,7 +83,6 @@ COLLECTD_PLUGINS_DISABLED:= \
 	pinba \
 	python \
 	redis \
-	routeros \
 	rrdcached \
 	serial \
 	sigrok \
@@ -165,6 +164,7 @@ COLLECTD_PLUGINS_SELECTED:= \
 	powerdns \
 	processes \
 	protocols \
+	routeros \
 	rrdtool \
 	sensors \
 	snmp \
@@ -406,6 +406,7 @@ $(eval $(call BuildPlugin,postgresql,PostgreSQL status input,postgresql,+PACKAGE
 $(eval $(call BuildPlugin,powerdns,PowerDNS server status input,powerdns,))
 $(eval $(call BuildPlugin,processes,process status input,processes,+PACKAGE_collectd-mod-processes:libmnl))
 $(eval $(call BuildPlugin,protocols,network protocols input,protocols,))
+$(eval $(call BuildPlugin,routeros,MikroTik RouterOS input,routeros,+PACKAGE_collectd-mod-routeros:librouteros))
 $(eval $(call BuildPlugin,rrdtool,RRDtool output,rrdtool,+PACKAGE_collectd-mod-rrdtool:librrd1))
 $(eval $(call BuildPlugin,sensors,lm_sensors input,sensors,+PACKAGE_collectd-mod-sensors:libsensors))
 $(eval $(call BuildPlugin,snmp,SNMP input,snmp,+PACKAGE_collectd-mod-snmp:libnetsnmp))


### PR DESCRIPTION
Maintainer: @hnyman, @jow- 
Compile tested: 
* targets: ar71xx-(generic|mikrotik), ath79-generic, ramips-(mt7620|7621|76x8), x86-generic, ipq40xx-generic
* OpenWrt master & 19.07
Run tested: ramips-mt76x8, TP-link WR841v13; OpenWrt-master, was sending Wireless-statistics to communities collectd-server)

Description:
This enables build of the routeros-plugin for collectd. As this plugin depends on the librouteros I added this package and put me as maintainer.