### PR TITLE
rng-tools: Update to 6.7

### DIFF
--- a/utils/rng-tools/Makefile
+++ b/utils/rng-tools/Makefile
@@ -8,20 +8,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rng-tools
-PKG_VERSION:=6.6
+PKG_VERSION:=6.7
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/nhorman/rng-tools.git
-PKG_SOURCE_VERSION:=4ebc21d6f387bb7b4b3f6badc429e27b21c0a6ee
-PKG_MIRROR_HASH:=d942283b7482337d40a4933f7b24a5d1361518dacf9c87928f5ea06d492e95b0
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
-PKG_LICENSE:=GPLv2
+PKG_SOURCE_URL:=https://github.com/nhorman/rng-tools
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_MIRROR_HASH:=05cb68b8600025f362ea0875f5966b60f8195f91ed89b431996a48cd88b1e5b0
+
 PKG_MAINTAINER:=Nathaniel Wesley Filardo <nwfilardo@gmail.com>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
-
-PKG_BUILD_DEPENDS:=USE_UCLIBC:argp-standalone USE_MUSL:argp-standalone
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -34,24 +36,19 @@ define Package/rng-tools
 endef
 
 define Package/rng-tools/description
-Daemon for adding entropy to kernel entropy pool. By default it uses
-/dev/urandom as the source but the init script can be modified
-to use a hardware source like /dev/hwrng if present
+  Daemon for adding entropy to kernel entropy pool. By default it uses
+  /dev/urandom as the source but the init script can be modified
+  to use a hardware source like /dev/hwrng if present
 endef
-
-ifdef CONFIG_USE_UCLIBC
-CONFIGURE_VARS += \
-    LIBS="-largp"
-endif
-
-ifdef CONFIG_USE_MUSL
-CONFIGURE_VARS += \
-    LIBS="-largp"
-endif
 
 CONFIGURE_ARGS += \
 	--without-libgcrypt \
-	--without-nistbeacon
+	--without-nistbeacon \
+	--without-pkcs11
+
+ifndef CONFIG_USE_GLIBC
+	CONFIGURE_VARS += LIBS="-largp"
+endif
 
 define Build/Prepare
 	$(call Build/Prepare/Default)
@@ -64,9 +61,9 @@ define Package/rng-tools/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/rngd.uci_defaults $(1)/etc/uci-defaults/rngd
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/rngtest $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/rngtest $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/rngd $(1)/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/rngd $(1)/sbin/
 endef
 
 $(eval $(call BuildPackage,rng-tools))


### PR DESCRIPTION
Cleanup Makefile to get rid of random hacks and to simplify for
consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nwf
Compile tested: ath79