### PR TITLE
python-egenix-mx-base: Makefile polishing

### DIFF
--- a/lang/python/python-egenix-mx-base/Makefile
+++ b/lang/python/python-egenix-mx-base/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-egenix-mx-base
 PKG_VERSION:=3.2.9
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=egenix-mx-base-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.egenix.com/python
@@ -17,19 +17,20 @@ PKG_HASH:=1c6b67688e7a231c6c1da09b7a6a2210745c3f2507bdda70e2639faedbf68977
 PKG_BUILD_DIR:=$(BUILD_DIR)/egenix-mx-base-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Dmitry Trefilov <the-alien@live.ru>
-PKG_LICENSE:=eGenix.com
+PKG_LICENSE:=eGenix
 PKG_LICENSE_FILES:=LICENSE COPYRIGHT
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 
 define Package/python-egenix-mx-base
-  SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  DEPENDS:=+python
   TITLE:=Egenix mxBase
+  SUBMENU:=Python
   URL:=https://www.egenix.com/products/python/mxBase/
+  DEPENDS:=+python-light
+  VARIANT:=python
 endef
 
 define Package/python-egenix-mx-base/description
@@ -39,16 +40,8 @@ define Package/python-egenix-mx-base/description
  date/time processing and high speed data types.
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix="$(PKG_INSTALL_DIR)/usr")
-endef
-
-define PyPackage/python-egenix-mx-base/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
+PYTHON_PKG_SETUP_ARGS:=
 
 $(eval $(call PyPackage,python-egenix-mx-base))
 $(eval $(call BuildPackage,python-egenix-mx-base))
+$(eval $(call BuildPackage,python-egenix-mx-base-src))


### PR DESCRIPTION
Maintainer: @dtrefilo-Quest
Compile tested: cortexa53, Turris MOX, OpenWrt master
Run tested: cortexa53, Turris MOX, OpenWrt master

Description:
- more Makefile polishing than in https://github.com/openwrt/packages/pull/9478