### PR TITLE
File sha256sums.asc was renamed for some targets to sha256sums.sig

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,8 @@ jobs:
           working_directory: ~/sdk
           command: |
              curl "https://$SDK_HOST/$SDK_PATH/sha256sums" -sS -o sha256sums
-             curl "https://$SDK_HOST/$SDK_PATH/sha256sums.asc" -sS -o sha256sums.asc
-             gpg --with-fingerprint --verify sha256sums.asc sha256sums
+             curl "https://$SDK_HOST/$SDK_PATH/sha256sums.sig" -sS -o sha256sums.sig
+             gpg --with-fingerprint --verify sha256sums.sig sha256sums
              rsync -av "$SDK_HOST::downloads/$SDK_PATH/$SDK_FILE" .
              sha256sum -c --ignore-missing sha256sums
 


### PR DESCRIPTION
Maintainer: @thess
Description:

On IRC channel #openwrt-devel was mention that jow updated the buildbots a bit and this is just a cosmetic change.

Renamed file:
http://downloads.openwrt.org/snapshots/targets/ath79/generic/sha256sums.sig

Should fix: #9499 
