### PR TITLE
gddrescue: Do not build with uClibc-ng

### DIFF
--- a/utils/gddrescue/Makefile
+++ b/utils/gddrescue/Makefile
@@ -27,7 +27,7 @@ define Package/gddrescue
   CATEGORY:=Utilities
   TITLE:=Data recovery tool
   URL:=https://www.gnu.org/software/ddrescue/
-  DEPENDS:=$(CXX_DEPENDS)
+  DEPENDS:=$(CXX_DEPENDS) @!USE_UCLIBC
 endef
 
 define Package/gddrescue/description


### PR DESCRIPTION
From the developer:

It seems that uClibc-ng is defining fgetc, fputc, feof, and ferror as
macros and not including them in std.

IMO this is a bug in uClibc-ng (maybe caused by lack of clarity in the
C++ standard), because even the C functions that are alowed to be
defined as macros (putc, getc) should be included in std for
consistency. Just imagine the chaos if std::getc were defined or
undefined depending on how it is implemented.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 