### PR TITLE
[openwrt-19.07] CircleCI: Add support for usign signatures

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -5,9 +5,11 @@ FROM debian:9
 # v1.0   - Initial version by Etienne Champetier
 # v1.0.1 - Run as non-root, add unzip, xz-utils
 # v1.0.2 - Add bzr
+# v1.0.3 - Verify usign signatures
 
 RUN apt update && apt install -y \
 build-essential \
+bzr \
 curl \
 jq \
 gawk \
@@ -16,13 +18,13 @@ git \
 libncurses5-dev \
 libssl-dev \
 python \
+signify-openbsd \
 subversion \
-bzr \
 time \
-wget \
-zlib1g-dev \
 unzip \
+wget \
 xz-utils \
+zlib1g-dev \
 && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -c "OpenWrt Builder" -m -d /home/build -s /bin/bash build
@@ -40,3 +42,7 @@ RUN curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=gpg/D52BBB6B.asc
 # OpenWrt Release Builder (18.06 Signing Key)
 RUN curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=gpg/17E1CE16.asc' | gpg --import \
  && echo '6768C55E79B032D77A28DA5F0F20257417E1CE16:6:' | gpg --import-ownertrust
+
+# LEDE Build System (LEDE usign key for unattended build jobs)
+RUN curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=usign/b5043e70f9a75cde' --create-dirs \
+ -o /home/build/usign/b5043e70f9a75cde

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: docker.io/openwrtorg/packages-cci:v1.0.2
+      - image: docker.io/openwrtorg/packages-cci:v1.0.3
     environment:
       - SDK_HOST: "downloads.openwrt.org"
       - SDK_PATH: "snapshots/targets/ath79/generic"
@@ -64,8 +64,28 @@ jobs:
           working_directory: ~/sdk
           command: |
              curl "https://$SDK_HOST/$SDK_PATH/sha256sums" -sS -o sha256sums
-             curl "https://$SDK_HOST/$SDK_PATH/sha256sums.asc" -sS -o sha256sums.asc
-             gpg --with-fingerprint --verify sha256sums.asc sha256sums
+             curl "https://$SDK_HOST/$SDK_PATH/sha256sums.asc" -fs -o sha256sums.asc || true
+             curl "https://$SDK_HOST/$SDK_PATH/sha256sums.sig" -fs -o sha256sums.sig || true
+             if [ ! -f sha256sums.asc ] && [ ! -f sha256sums.sig ]; then
+                 echo_red "Missing sha256sums signature files"
+                 exit 1
+             fi
+             [ ! -f sha256sums.asc ] || gpg --with-fingerprint --verify sha256sums.asc sha256sums
+             if [ -f sha256sums.sig ]; then
+                 VERIFIED=
+                 for KEY in ~/usign/*; do
+                     echo "Trying $KEY..."
+                     if signify-openbsd -V -q -p "$KEY" -x sha256sums.sig -m sha256sums; then
+                         echo "...verified"
+                         VERIFIED=1
+                         break
+                     fi
+                 done
+                 if [ -z "$VERIFIED" ]; then
+                     echo_red "Could not verify usign signature"
+                     exit 1
+                 fi
+             fi
              rsync -av "$SDK_HOST::downloads/$SDK_PATH/$SDK_FILE" .
              sha256sum -c --ignore-missing sha256sums
 


### PR DESCRIPTION
Maintainer: @thess @champtar 
Compile tested: built Docker image locally
Run tested: manually ran updated commands inside Docker container

Description:
It appears snapshot target builds have switched from GPG signatures (`sha256sums.asc`) to usign signatures (`sha256sums.sig`).

This adds support for verifying these usign signatures. (GPG signatures will also be verified if found.)

This also restores the alphabetical ordering of packages to be installed by apt-get.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>