### PR TITLE
lmdb: add new package

### DIFF
--- a/libs/lmdb/Makefile
+++ b/libs/lmdb/Makefile
@@ -1,0 +1,97 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=lmdb
+PKG_VERSION:=0.9.23
+PKG_RELEASE:=1
+
+PKG_SOURCE:=LMDB_$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/LMDB/lmdb/tar.gz/LMDB_$(PKG_VERSION)?
+PKG_HASH:=abf42e91f046787ed642d9eb21812a5c473f3ba5854124484d16eadbe0aa9c81
+PKG_BUILD_DIR:=$(BUILD_DIR)/lmdb-LMDB_$(PKG_VERSION)
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=OLDAP-2.8
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+MAKE_PATH:=libraries/liblmdb
+
+define Package/lmdb/Default
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Lightning Memory-Mapped Database
+  URL:=https://symas.com/lmdb/
+endef
+
+define Package/lmdb
+	$(call Package/lmdb/Default)
+  TITLE+= shared library
+endef
+
+define Package/lmdb/description
+  LMDB is an ultra-fast, ultra-compact key-value
+  embedded data store developed for the OpenLDAP Project.
+endef
+
+define Package/lmdb-utils
+	$(call Package/lmdb/Default)
+  TITLE+= utils
+  MDEPENDS+= lmdb
+endef
+
+define Package/lmdb-utils/description
+  LMDB environment status and copy tool
+endef
+
+define Package/lmdb-test
+	$(call Package/lmdb/Default)
+  TITLE+= test
+  MDEPENDS+= lmdb
+endef
+
+define Package/lmdb-test/description
+  LMDB test application
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(SED) 's,%%PKG_VERSION%%,$(PKG_VERSION),g' $(PKG_BUILD_DIR)/liblmdb.pc
+endef
+
+define Build/Compile
+	$(MAKE) -C "$(PKG_BUILD_DIR)/$(MAKE_PATH)/" \
+		CC="$(TARGET_CC)" \
+		CFLAGS+="$(TARGET_CFLAGS)" \
+		LDFLAGS+="$(TARGET_LDFLAGS)" \
+		FPIC="$(FPIC)"
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lmdb.h $(1)/usr/include
+	$(CP) $(PKG_BUILD_DIR)/$(MAKE_PATH)/liblmdb.{a,so} $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig/
+	$(CP) $(PKG_BUILD_DIR)/liblmdb.pc $(1)/usr/lib/pkgconfig/lmdb.pc
+endef
+
+define Package/lmdb/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/local/lib/*.so $(1)/usr/lib
+endef
+
+define Package/lmdb-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/local/bin/mdb_{stat,copy,dump,load} $(1)/usr/bin
+endef
+
+define Package/lmdb-test/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/mtest $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,lmdb))
+$(eval $(call BuildPackage,lmdb-utils))
+$(eval $(call BuildPackage,lmdb-test))

--- a/libs/lmdb/patches/010-fix-makefile.patch
+++ b/libs/lmdb/patches/010-fix-makefile.patch
@@ -1,0 +1,23 @@
+--- a/libraries/liblmdb/Makefile
++++ b/libraries/liblmdb/Makefile
+@@ -34,6 +34,7 @@ libdir = $(exec_prefix)/lib
+ includedir = $(prefix)/include
+ datarootdir = $(prefix)/share
+ mandir = $(datarootdir)/man
++FPIC ?= -fPIC
+
+ ########################################################################
+
+@@ -86,10 +87,10 @@ midl.o: midl.c midl.h
+ 	$(CC) $(CFLAGS) $(CPPFLAGS) -c midl.c
+
+ mdb.lo: mdb.c lmdb.h midl.h
+-	$(CC) $(CFLAGS) -fPIC $(CPPFLAGS) -c mdb.c -o $@
++	$(CC) $(CFLAGS) $(FPIC) $(CPPFLAGS) -c mdb.c -o $@
+
+ midl.lo: midl.c midl.h
+-	$(CC) $(CFLAGS) -fPIC $(CPPFLAGS) -c midl.c -o $@
++	$(CC) $(CFLAGS) $(FPIC) $(CPPFLAGS) -c midl.c -o $@
+
+ %:	%.o
+ 	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(LDLIBS) -o $@

--- a/libs/lmdb/src/liblmdb.pc
+++ b/libs/lmdb/src/liblmdb.pc
@@ -1,0 +1,12 @@
+prefix=/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+
+Name: Lightning Memory-Mapped Database
+Description: Lightning Memory-Mapped Database
+Version: %%PKG_VERSION%%
+Requires:
+Libs: -L${libdir} -llmdb
+Cflags: -I${includedir}


### PR DESCRIPTION
Maintainer: me 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR adds new package with lmdb (https://symas.com/lmdb/). The main reason is that it's dependency for knot-resolver which should be upstreamed in future PR. 

Fixes https://github.com/openwrt/packages/issues/5930

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>