### PR TITLE
oniguruma: fix CVE-2019-13224 & CVE-2019-13225

### DIFF
--- a/libs/oniguruma/Makefile
+++ b/libs/oniguruma/Makefile
@@ -6,13 +6,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oniguruma
 PKG_VERSION:=6.9.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=onig-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/kkos/oniguruma/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=3b568a9050839e7828b2f2d5bc9cd3650979b6b54a080f54c515320dddda06b0
 
-PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com.br>
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:oniguruma_project:oniguruma
@@ -27,7 +27,6 @@ define Package/oniguruma
     CATEGORY:=Libraries
     TITLE:=Regular expression library for different character encodings
     URL:=https://github.com/kkos/oniguruma
-    DEPENDS:=
     ABI_VERSION:=5
 endef
 

--- a/libs/oniguruma/patches/001-Fix-CVE-2019-13225-problem-in-converting-if-then-els.patch
+++ b/libs/oniguruma/patches/001-Fix-CVE-2019-13225-problem-in-converting-if-then-els.patch
@@ -1,0 +1,66 @@
+From c509265c5f6ae7264f7b8a8aae1cfa5fc59d108c Mon Sep 17 00:00:00 2001
+From: "K.Kosako" <kosako@sofnec.co.jp>
+Date: Thu, 27 Jun 2019 14:11:55 +0900
+Subject: [PATCH] Fix CVE-2019-13225: problem in converting if-then-else
+ pattern to bytecode.
+
+
+diff --git a/src/regcomp.c b/src/regcomp.c
+index c2c04a4..ff3431f 100644
+--- a/src/regcomp.c
++++ b/src/regcomp.c
+@@ -1307,8 +1307,9 @@ compile_length_bag_node(BagNode* node, regex_t* reg)
+         len += tlen;
+       }
+ 
++      len += SIZE_OP_JUMP + SIZE_OP_ATOMIC_END;
++
+       if (IS_NOT_NULL(Else)) {
+-        len += SIZE_OP_JUMP;
+         tlen = compile_length_tree(Else, reg);
+         if (tlen < 0) return tlen;
+         len += tlen;
+@@ -1455,7 +1456,7 @@ compile_bag_node(BagNode* node, regex_t* reg, ScanEnv* env)
+ 
+   case BAG_IF_ELSE:
+     {
+-      int cond_len, then_len, jump_len;
++      int cond_len, then_len, else_len, jump_len;
+       Node* cond = NODE_BAG_BODY(node);
+       Node* Then = node->te.Then;
+       Node* Else = node->te.Else;
+@@ -1472,8 +1473,7 @@ compile_bag_node(BagNode* node, regex_t* reg, ScanEnv* env)
+       else
+         then_len = 0;
+ 
+-      jump_len = cond_len + then_len + SIZE_OP_ATOMIC_END;
+-      if (IS_NOT_NULL(Else)) jump_len += SIZE_OP_JUMP;
++      jump_len = cond_len + then_len + SIZE_OP_ATOMIC_END + SIZE_OP_JUMP;
+ 
+       r = add_op(reg, OP_PUSH);
+       if (r != 0) return r;
+@@ -1490,11 +1490,20 @@ compile_bag_node(BagNode* node, regex_t* reg, ScanEnv* env)
+       }
+ 
+       if (IS_NOT_NULL(Else)) {
+-        int else_len = compile_length_tree(Else, reg);
+-        r = add_op(reg, OP_JUMP);
+-        if (r != 0) return r;
+-        COP(reg)->jump.addr = else_len + SIZE_INC_OP;
++        else_len = compile_length_tree(Else, reg);
++        if (else_len < 0) return else_len;
++      }
++      else
++        else_len = 0;
+ 
++      r = add_op(reg, OP_JUMP);
++      if (r != 0) return r;
++      COP(reg)->jump.addr = SIZE_OP_ATOMIC_END + else_len + SIZE_INC_OP;
++
++      r = add_op(reg, OP_ATOMIC_END);
++      if (r != 0) return r;
++
++      if (IS_NOT_NULL(Else)) {
+         r = compile_tree(Else, reg, env);
+       }
+     }

--- a/libs/oniguruma/patches/002-Fix-CVE-2019-13224-don-t-allow-different-encodings-f.patch
+++ b/libs/oniguruma/patches/002-Fix-CVE-2019-13224-don-t-allow-different-encodings-f.patch
@@ -1,0 +1,38 @@
+From 0f7f61ed1b7b697e283e37bd2d731d0bd57adb55 Mon Sep 17 00:00:00 2001
+From: "K.Kosako" <kosako@sofnec.co.jp>
+Date: Thu, 27 Jun 2019 17:25:26 +0900
+Subject: [PATCH] Fix CVE-2019-13224: don't allow different encodings for
+ onig_new_deluxe()
+
+
+diff --git a/src/regext.c b/src/regext.c
+index fa4b360..965c793 100644
+--- a/src/regext.c
++++ b/src/regext.c
+@@ -29,6 +29,7 @@
+ 
+ #include "regint.h"
+ 
++#if 0
+ static void
+ conv_ext0be32(const UChar* s, const UChar* end, UChar* conv)
+ {
+@@ -158,6 +159,7 @@ conv_encoding(OnigEncoding from, OnigEncoding to, const UChar* s, const UChar* e
+ 
+   return ONIGERR_NOT_SUPPORTED_ENCODING_COMBINATION;
+ }
++#endif
+ 
+ extern int
+ onig_new_deluxe(regex_t** reg, const UChar* pattern, const UChar* pattern_end,
+@@ -169,9 +171,7 @@ onig_new_deluxe(regex_t** reg, const UChar* pattern, const UChar* pattern_end,
+   if (IS_NOT_NULL(einfo)) einfo->par = (UChar* )NULL;
+ 
+   if (ci->pattern_enc != ci->target_enc) {
+-    r = conv_encoding(ci->pattern_enc, ci->target_enc, pattern, pattern_end,
+-                      &cpat, &cpat_end);
+-    if (r != 0) return r;
++    return ONIGERR_NOT_SUPPORTED_ENCODING_COMBINATION;
+   }
+   else {
+     cpat     = (UChar* )pattern;


### PR DESCRIPTION
Maintainer: me
Compile tested: arm, WRT3200ACM, openwrt master
Run tested: arm, WRT3200ACM, openwrt master, tested with seafile-server, uploading & downloading a file (these actions use libevhtp, which in turn uses libonig).

Description:
The patches were taken from upstream commits.
I will cherry-pick this to 19.07.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>