### PR TITLE
mini_snmpd: Allow up to 8 network interfaces

### DIFF
--- a/net/mini_snmpd/Makefile
+++ b/net/mini_snmpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mini_snmpd
 PKG_VERSION:=1.4-rc1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_MAINTAINER:=Marcin Jurkowski <marcin1j@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING

--- a/net/mini_snmpd/files/mini_snmpd.init
+++ b/net/mini_snmpd/files/mini_snmpd.init
@@ -77,7 +77,7 @@ append_interface() {
 	# for the purposes of snmp monitoring it doesn't need to be up, it just needs to exist in /proc/net/dev
 	network_get_device netdev "$name"
 	if [ -n "$netdev" ] && grep -qF "$netdev" /proc/net/dev ]; then
-		[ $netdev_count -ge 4 ] && {
+		[ $netdev_count -ge 8 ] && {
 			_err "$cfg: too many network interfaces configured, ignoring $name"
 			return
 		}


### PR DESCRIPTION
Maintainer: Marcin Jurkowski <marcin1j@gmail.com>
Compile tested: untested
Run tested: mips, TP-Link TD-W8980, openwrt-18.06, tested with 7 interfaces

Description:
This changes the init script to allow to monitor up to 8 network
interfaces.  The support for up to 8 network interfaces was added to
mini_snmpd release 1.3 in November 2015.
