### PR TITLE
opendkim: Fix compilation with uClibc-ng

### DIFF
--- a/mail/opendkim/Makefile
+++ b/mail/opendkim/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opendkim
 PKG_VERSION:=2.10.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)

--- a/mail/opendkim/patches/020-uclibc.patch
+++ b/mail/opendkim/patches/020-uclibc.patch
@@ -1,0 +1,20 @@
+--- a/libopendkim/dkim-dns.c
++++ b/libopendkim/dkim-dns.c
+@@ -163,6 +163,9 @@ int
+ dkim_res_query(void *srv, int type, unsigned char *query, unsigned char *buf,
+                size_t buflen, void **qh)
+ {
++#ifdef __UCLIBC__
++	return DKIM_DNS_ERROR;
++#else
+ 	int n;
+ 	int ret;
+ 	struct dkim_res_qh *rq;
+@@ -209,6 +212,7 @@ dkim_res_query(void *srv, int type, unsigned char *query, unsigned char *buf,
+ 	*qh = (void *) rq;
+ 
+ 	return DKIM_DNS_SUCCESS;
++#endif // __UCLIBC__
+ }
+ 
+ /*


### PR DESCRIPTION
res_nsend and res_send are both not available in uClibc-ng as configured
in OpenWrt. Having this function return an error is the only sensible way
to fix.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @val-kulkov 
Compile tested: arc700