### PR TITLE
socat: Fix compilation when usleep is missing

### DIFF
--- a/net/socat/Makefile
+++ b/net/socat/Makefile
@@ -7,14 +7,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=socat
 PKG_VERSION:=1.7.3.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.dest-unreach.org/socat/download
 PKG_HASH:=0dd63ffe498168a4aac41d307594c5076ff307aa0ac04b141f8f1cec6594d04a
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
-PKG_LICENSE:=GPL-2.0 OpenSSL
+PKG_LICENSE:=GPL-2.0-or-later OpenSSL
 PKG_LICENSE_FILES:=COPYING COPYING.OpenSSL
 
 PKG_INSTALL:=1

--- a/net/socat/patches/100-usleep.patch
+++ b/net/socat/patches/100-usleep.patch
@@ -1,0 +1,18 @@
+--- a/sycls.c
++++ b/sycls.c
+@@ -1329,6 +1329,7 @@ unsigned int Sleep(unsigned int seconds) {
+    return retval;
+ }
+ 
++#if 0
+ /* obsolete by POSIX.1-2001 */
+ void Usleep(unsigned long usec) {
+    Debug1("usleep(%lu)", usec);
+@@ -1336,6 +1337,7 @@ void Usleep(unsigned long usec) {
+    Debug("usleep() ->");
+    return;
+ }
++#endif
+ 
+ #if HAVE_NANOSLEEP
+ unsigned int Nanosleep(const struct timespec *req, struct timespec *rem) {


### PR DESCRIPTION
usleep is a legacy function that was removed in POSIX-2008. uClibc-ng can
be configured to compile without it. if out the code as it's not used.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: arc700