### PR TITLE
nss: Replace usleep with nanosleep

### DIFF
--- a/libs/nss/Makefile
+++ b/libs/nss/Makefile
@@ -8,15 +8,18 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nss
 PKG_VERSION:=3.45
-PKG_RELEASE:=1
-PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
-PKG_LICENCE:=MPL-2.0
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
     https://download.cdn.mozilla.net/pub/security/$(PKG_NAME)/releases/NSS_$(subst .,_,$(PKG_VERSION))_RTM/src \
     https://archive.mozilla.org/pub/security/$(PKG_NAME)/releases/NSS_$(subst .,_,$(PKG_VERSION))_RTM/src
 PKG_HASH:=112f05223d1fde902c170966bfc6f011b24a838be16969b110ecf2bb7bc24e8b
+
+PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
+PKG_LICENCE:=MPL-2.0
+PKG_LICENSE_FILES:=nss/COPYING
+PKG_CPE_ID:=cpe:/a:mozilla:network_security_services
 
 PKG_BUILD_PARALLEL:=0
 
@@ -40,7 +43,7 @@ define Package/nss-utils
 endef
 
 define Package/libnss/description
-  Network Security Services (NSS) is a set of libraries designed to support 
+  Network Security Services (NSS) is a set of libraries designed to support
   cross-platform development of security-enabled client and server applications.
   Applications built with NSS can support SSL v2 and v3, TLS, PKCS 5, PKCS 7,
   PKCS 11, PKCS 12, S/MIME, X.509 v3 certificates, and other security standards.

--- a/libs/nss/patches/010-nanosleep.patch
+++ b/libs/nss/patches/010-nanosleep.patch
@@ -1,0 +1,33 @@
+--- a/nss/lib/freebl/stubs.c
++++ b/nss/lib/freebl/stubs.c
+@@ -503,7 +503,8 @@ extern PRStatus
+ PR_Sleep_stub(PRIntervalTime ticks)
+ {
+     STUB_SAFE_CALL1(PR_Sleep, ticks);
+-    usleep(ticks * 1000);
++    const struct timespec req = {0, ticks * 1000 * 1000};
++    nanosleep(&req, NULL);
+     return PR_SUCCESS;
+ }
+ 
+--- a/nss/lib/sqlite/sqlite3.c
++++ b/nss/lib/sqlite/sqlite3.c
+@@ -33761,7 +33761,8 @@ static int proxyConchLock(unixFile *pFile, uuid_t myHostID, int lockType){
+       
+       if( nTries==1 ){
+         conchModTime = buf.st_mtimespec;
+-        usleep(500000); /* wait 0.5 sec and try the lock again*/
++        const struct timespec req = {0, 500 * 1000 * 1000};
++        nanosleep(&req, NULL); /* wait 0.5 sec and try the lock again*/
+         continue;  
+       }
+ 
+@@ -33787,7 +33788,7 @@ static int proxyConchLock(unixFile *pFile, uuid_t myHostID, int lockType){
+           /* don't break the lock on short read or a version mismatch */
+           return SQLITE_BUSY;
+         }
+-        usleep(10000000); /* wait 10 sec and try the lock again */
++        sleep(10); /* wait 10 sec and try the lock again */
+         continue; 
+       }
+       


### PR DESCRIPTION
usleep is deprecated and is optionally not available with uClibc-ng.

Added PKG_LICENSE_FILES.

Added PKG_CPE_ID for proper CVE tracking.

Other minor cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: arc700