### PR TITLE
libreswan: Replace usleep with nanosleep

### DIFF
--- a/net/libreswan/Makefile
+++ b/net/libreswan/Makefile
@@ -14,8 +14,10 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libreswan.org/
 PKG_HASH:=d60e4160f43272b6307b697a13f79f56b5ec2bca61d83097ddadd8586a58ab3e
 
-PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING LICENSE
+PKG_CPE_ID:=cpe:/a:libreswan:libreswan
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/net/libreswan/patches/010-nanosleep.patch
+++ b/net/libreswan/patches/010-nanosleep.patch
@@ -1,0 +1,21 @@
+--- a/programs/pluto/send.c
++++ b/programs/pluto/send.c
+@@ -26,7 +26,7 @@
+  *
+  */
+ 
+-#include <unistd.h>	/* for usleep() */
++#include <time.h>	/* for nanosleep() */
+ #include <errno.h>
+ 
+ #include "defs.h"
+@@ -173,7 +173,8 @@ bool send_chunks(const char *where, bool just_a_keepalive,
+ 	/* Send a duplicate packet when this impair is enabled - used for testing */
+ 	if (IMPAIR(JACOB_TWO_TWO)) {
+ 		/* sleep for half a second, and second another packet */
+-		usleep(500000);
++		const struct timespec req = {0, 500 * 1000 * 1000};
++		nanosleep(&req, NULL);
+ 		ip_endpoint_buf b;
+ 
+ 		DBG_log("JACOB 2-2: resending %zu bytes for %s through %s:%d to %s:",


### PR DESCRIPTION
usleep is optionally unavailable with uClibc-ng.

Added PKG_LICENSE_FILES

Added PKG_CPE_ID for proper CVE tracking.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: arc700