### PR TITLE
python: cachelib package added

### DIFF
--- a/lang/python/python-cachelib/Makefile
+++ b/lang/python/python-cachelib/Makefile
@@ -1,0 +1,40 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-cachelib
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=cachelib-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/cachelib
+PKG_HASH:=8b889b509d372095357b8705966e1282d40835c4126d7c2b07fd414514d8ae8d
+PKG_BUILD_DIR:=$(BUILD_DIR)/cachelib-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Stepan Henek <stepan.henek@nic.cz>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-cachelib
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=cachelib
+  URL:=https://github.com/pallets/cachelib
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-cachelib/description
+  A collection of cache libraries in the same API interface.
+  Extracted from werkzeug.
+endef
+
+$(eval $(call Py3Package,python3-cachelib))
+$(eval $(call BuildPackage,python3-cachelib))
+$(eval $(call BuildPackage,python3-cachelib-src))


### PR DESCRIPTION
In Werkzeug 0.15.0 `werkzeug.cache` module was moved into a separate package called `cachelib`. 

This MR adds the cachelib so that original functions from `werkzeug.cache` can be used in the newer version of openwrt packages.

see https://github.com/pallets/werkzeug/blob/master/CHANGES.rst#version-0150