### PR TITLE
pcre: remove unnecessary dependency on C++ lib

### DIFF
--- a/libs/pcre/Makefile
+++ b/libs/pcre/Makefile
@@ -23,6 +23,8 @@ PKG_FIXUP:=autoreconf
 
 PKG_INSTALL:=1
 
+PKG_CONFIG_DEPENDS := CONFIG_PACKAGE_libpcrecpp
+
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
@@ -30,7 +32,6 @@ define Package/libpcre/default
   SECTION:=libs
   CATEGORY:=Libraries
   URL:=https://www.pcre.org/
-  DEPENDS:=$(CXX_DEPENDS)
 endef
 
 define Package/libpcre
@@ -46,7 +47,7 @@ endef
 define Package/libpcrecpp
   $(call Package/libpcre/default)
   TITLE:=C++ wrapper for Perl Compatible Regular Expression library
-  DEPENDS:=+libpcre
+  DEPENDS:=+libpcre $(CXX_DEPENDS)
 endef
 
 TARGET_CFLAGS += $(FPIC)
@@ -56,8 +57,7 @@ CONFIGURE_ARGS += \
 	--enable-unicode-properties \
 	--enable-pcre16 \
 	--with-match-limit-recursion=16000 \
-	--enable-cpp
-
+	$(if $(CONFIG_PACKAGE_libpcrecpp),--enable,--disable)-cpp
 
 MAKE_FLAGS += \
 	CFLAGS="$(TARGET_CFLAGS)"


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: ramips
Run tested: ramips

Description:
Add libpcrecpp to `PKG_CONFIG_DEPENDS` to properly trigger
reconfiguration, avoiding unnecessary dependency.

This reverts commit 17090fecf18c795f5bfa5e1ea375ccd65d24f227.
This reverts commit ec138f51ab54873252bbe3e848f5fa9c20de78b9.
