### PR TITLE
prometheus: Fix build for mips64/mips64el

### DIFF
--- a/utils/prometheus/Makefile
+++ b/utils/prometheus/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus
 PKG_VERSION:=2.10.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/prometheus/prometheus/tar.gz/v${PKG_VERSION}?

--- a/utils/prometheus/patches/001-update-fsnotify.patch
+++ b/utils/prometheus/patches/001-update-fsnotify.patch
@@ -1,0 +1,27 @@
+fsnotify v1.3.1 uses unix.InotifyInit, which does not exist for mips64/mips64el
+v1.4.2 changed to unix.InotifyInit1, which should exist for all Linux systems
+
+--- a/go.mod
++++ b/go.mod
+@@ -95,7 +95,7 @@ require (
+ 	google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19
+ 	google.golang.org/grpc v1.19.1
+ 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+-	gopkg.in/fsnotify/fsnotify.v1 v1.3.1
++	gopkg.in/fsnotify/fsnotify.v1 v1.4.7
+ 	gopkg.in/inf.v0 v0.9.1 // indirect
+ 	gopkg.in/yaml.v2 v2.2.2
+ 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
+--- a/go.sum
++++ b/go.sum
+@@ -416,8 +416,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-
+ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
+ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+-gopkg.in/fsnotify/fsnotify.v1 v1.3.1 h1:2fkCHbPQZNYRAyRyIV9VX0bpRkxIorlQDiYRmufHnhA=
+-gopkg.in/fsnotify/fsnotify.v1 v1.3.1/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
++gopkg.in/fsnotify/fsnotify.v1 v1.4.7 h1:XNNYLJHt73EyYiCZi6+xjupS9CpvmiDgjPTAjrBlQbo=
++gopkg.in/fsnotify/fsnotify.v1 v1.4.7/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
+ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
+ gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=


### PR DESCRIPTION
Maintainer: @aparcar 
Compile tested: octeon (2019-07-18 snapshot sdk), ath79-generic / x86-generic / armvirt-64 (2019-07-22 snapshot sdk)
Run tested: **none**

Description:
Prometheus uses an older version of fsnotify, which uses a system call (`unix.InotifyInit`) that is not implemented for mips64/mips64el.

This patches Prometheus to use a newer version of fsnotify that uses a different system call (`unix.InotifyInit1`) that should be available on all Linux systems.

Fixes #9494.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>

