### PR TITLE
libnetwork: Exclude unsupported architectures

### DIFF
--- a/utils/libnetwork/Makefile
+++ b/utils/libnetwork/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetwork
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
@@ -29,7 +29,7 @@ define Package/libnetwork
   CATEGORY:=Utilities
   TITLE:=networking for containers
   URL:=https://github.com/docker/libnetwork
-  DEPENDS:=$(GO_ARCH_DEPENDS)
+  DEPENDS:=$(GO_ARCH_DEPENDS) @TARGET_x86_64
 endef
 
 define Package/libnetwork/description


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: x86_x64, Hyper-V, OpenWrt Master
Run tested: x86_x64, Hyper-V, OpenWrt Master

Description:
As brought up in https://github.com/openwrt/packages/issues/9546, libnetwork was failing to compile for MIPS. Given libnetwork's dependencies on docker-ce libnetwork is unsupported on MIPS and have added `@TARGET_x86_64`.