### PR TITLE
io: Open /dev/mem with O_SYNC for uncached access

### DIFF
--- a/utils/io/Makefile
+++ b/utils/io/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=io
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/utils/io/src/io.c
+++ b/utils/io/src/io.c
@@ -343,7 +343,7 @@ main (int argc, char **argv)
 		printf("Attempting to map 0x%lx bytes at address 0x%08lx\n",
 			real_len, real_addr);
 
-	mfd = open("/dev/mem", (memfunc == MEM_READ) ? O_RDONLY : O_RDWR);
+	mfd = open("/dev/mem", (memfunc == MEM_READ) ? (O_RDONLY | O_SYNC) : (O_RDWR | O_SYNC));
 	if (mfd == -1) {
 		perror("open /dev/mem");
 		fprintf(stderr, "Is CONFIG_DEVMEM activated?\n");


### PR DESCRIPTION
Maintainer: me
Compile tested: lantiq, master
Run tested: lantiq, master

Description:

Only when /dev/mem is opened with O_SYNC the write and *read* is done
uncached. We saw wrong values read out from the hardware without setting
O_SYNC, the busybox devmem tool showed different values, when O_SYNC is
also set for the io tool, it reads out the same values as devmem.
When looking at the drivers/char/mem.c file in the kernel it is behaving
differently based on the O_DSYNC flag.

Signed-off-by: Hauke Mehrtens <hauke.mehrtens@intel.com>