### PR TITLE
kea: remove python3 dependency of kea-admin

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -76,7 +76,7 @@ endef
 define Package/kea-admin
 	$(call Package/kea/Default)
 	TITLE+= Admin
-	DEPENDS:= +kea-libs +python3
+	DEPENDS:= +kea-libs
 endef
 
 define Package/kea-ctrl


### PR DESCRIPTION
fix https://github.com/openwrt/packages/issues/9495

Signed-off-by: Rosy Song <rosysong@rosinson.com>

Maintainer: me
Compile tested: ath79, wr818, master
Run tested: ath79, wr818, master
