### PR TITLE
netifyd: Don't build on uClibc-ng

### DIFF
--- a/net/netifyd/Makefile
+++ b/net/netifyd/Makefile
@@ -28,7 +28,7 @@ define Package/netifyd
   CATEGORY:=Network
   TITLE:=Netify Agent
   URL:=http://www.netify.ai/
-  DEPENDS:=+libcurl +libmnl +libnetfilter-conntrack +libjson-c +libpcap +zlib +libpthread
+  DEPENDS:=+libcurl +libmnl +libnetfilter-conntrack +libjson-c +libpcap +zlib +libpthread @!USE_UCLIBC
   # Explicitly depend on libstdcpp rather than $(CXX_DEPENDS).  At the moment
   # std::unordered_map is only available via libstdcpp which is required for
   # performance reasons.


### PR DESCRIPTION
This absolutely needs symbols from libresolv, which uClibc-ng does not
support.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dsokoloski 

edit: https://downloads.openwrt.org/snapshots/faillogs/arc_archs/packages/netifyd/compile.txt