### PR TITLE
treewide: Capitalize submenus

### DIFF
--- a/admin/openwisp-config/Makefile
+++ b/admin/openwisp-config/Makefile
@@ -24,7 +24,7 @@ define Package/openwisp-config/default
 	TITLE:=Remote configuration management agent ($(2) variant)
 	CATEGORY:=Administration
 	SECTION:=admin
-	SUBMENU:=openwisp
+	SUBMENU:=OpenWISP
 	DEPENDS:=+curl +lua +libuci-lua +luafilesystem $(3)
 	VARIANT:=$(1)
 	MAINTAINER:=Federico Capoano <f.capoano@cineca.it>

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -71,7 +71,7 @@ endef
 define Package/zabbix/Default
   SECTION:=admin
   CATEGORY:=Administration
-  SUBMENU:=zabbix
+  SUBMENU:=Zabbix
   TITLE:=Zabbix
   URL:=https://www.zabbix.com/
   USERID:=zabbix=53:zabbix=53

--- a/libs/elektra/Makefile
+++ b/libs/elektra/Makefile
@@ -41,7 +41,7 @@ define Package/libelektra/Default
   CATEGORY:=Libraries
   TITLE:=Elektra
   URL:=http://www.libelektra.org/
-  SUBMENU:=libelektra
+  SUBMENU:=LibElektra
 endef
 
 define Package/libelektra/Default-description

--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -33,7 +33,7 @@ define Package/libpq
   DEPENDS:=+libpthread
   TITLE:=PostgreSQL client library
   URL:=http://www.postgresql.org/
-  SUBMENU:=database
+  SUBMENU:=Database
 endef
 
 define Package/libpq/description
@@ -46,7 +46,7 @@ define Package/pgsql-cli
   DEPENDS:=+libncursesw +libpq +libreadline +librt +zlib
   TITLE:=Command Line Interface (CLI) to PostgreSQL databases
   URL:=http://www.postgresql.org/
-  SUBMENU:=database
+  SUBMENU:=Database
 endef
 
 define Package/pgsql-cli/description
@@ -59,7 +59,7 @@ define Package/pgsql-cli-extra
   DEPENDS:=+libncursesw +libpq +libreadline +librt +zlib
   TITLE:=Command Line extras for PostgreSQL databases
   URL:=http://www.postgresql.org/
-  SUBMENU:=database
+  SUBMENU:=Database
 endef
 
 define Package/pgsql-cli-extra/description
@@ -72,7 +72,7 @@ define Package/pgsql-server
   DEPENDS:=+pgsql-cli
   TITLE:=PostgreSQL databases Server
   URL:=http://www.postgresql.org/
-  SUBMENU:=database
+  SUBMENU:=Database
   USERID:=postgres=5432:postgres=5432
 endef
 

--- a/libs/psqlodbc/Makefile
+++ b/libs/psqlodbc/Makefile
@@ -27,7 +27,7 @@ CONFIGURE_ARGS += \
 	--with-libpq=$(STAGING_DIR)/usr
 
 define Package/psqlodbc/Default
-  SUBMENU:=database
+  SUBMENU:=Database
   URL:=https://odbc.postgresql.org/
   SECTION:=libs
   CATEGORY:=Libraries

--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -42,7 +42,7 @@ PKG_CONFIG_DEPENDS := \
 include $(INCLUDE_DIR)/package.mk
 
 define Package/sqlite3/Default
-  SUBMENU:=database
+  SUBMENU:=Database
   TITLE:=SQLite (v3.x) database engine
   URL:=http://www.sqlite.org/
   MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>

--- a/libs/tdb/Makefile
+++ b/libs/tdb/Makefile
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/kernel.mk
 include $(INCLUDE_DIR)/version.mk
 
 define Package/tdb
-  SUBMENU:=database
+  SUBMENU:=Database
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Trivial Database

--- a/libs/unixodbc/Makefile
+++ b/libs/unixodbc/Makefile
@@ -39,7 +39,7 @@ CONFIGURE_ARGS += \
 	--includedir=$(STAGING_DIR)/usr/include
 
 define Package/unixodbc/Default
-  SUBMENU:=database
+  SUBMENU:=Database
   TITLE:=unixODBC
   URL:=http://www.unixodbc.org
 endef

--- a/net/aircrack-ng/Makefile
+++ b/net/aircrack-ng/Makefile
@@ -49,7 +49,7 @@ define Package/aircrack-ng
   DEPENDS += +libnl-core +libnl-genl +zlib
   TITLE:=WLAN tools (without airmon-ng) for breaking 802.11 WEP/WPA keys
   URL:=https://www.aircrack-ng.org/
-  SUBMENU:=wireless
+  SUBMENU:=Wireless
 endef
 
 define Package/aircrack-ng/description
@@ -66,7 +66,7 @@ define Package/airmon-ng
   DEPENDS:=+wireless-tools +ethtool +procps-ng +CONFIG_PCI_SUPPORT:pciutils +CONFIG_USB_SUPPORT:usbutils
   TITLE:=Bash script designed to turn wireless cards into monitor mode.
   URL:=http://www.aircrack-ng.org/
-  SUBMENU:=wireless
+  SUBMENU:=Wireless
 endef
 
 define Package/airmon-ng/description

--- a/net/dynapoint/Makefile
+++ b/net/dynapoint/Makefile
@@ -18,7 +18,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/dynapoint
     SECTION:=net
     CATEGORY:=Network
-    SUBMENU:=wireless
+    SUBMENU:=Wireless
     DEPENDS:=+lua +libubus-lua +libuci-lua +libubox-lua +luci-lib-nixio
     TITLE:=Dynamic access point manager
     PKGARCH:=all

--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -27,7 +27,7 @@ define Package/hcxdumptool
   DEPENDS:=+libpcap
   TITLE:=hcxdumptool
   URL:=https://github.com/ZerBea/hcxdumptool
-  SUBMENU:=wireless
+  SUBMENU:=Wireless
 endef
 
 define Package/hcxdumptool/description

--- a/net/hcxtools/Makefile
+++ b/net/hcxtools/Makefile
@@ -27,7 +27,7 @@ define Package/hcxtools
   DEPENDS:=+libpthread +libpcap +zlib +libcurl +libopenssl
   TITLE:=hcxtools
   URL:=https://github.com/ZerBea/hcxtools
-  SUBMENU:=wireless
+  SUBMENU:=Wireless
 endef
 
 define Package/hcxtools/description

--- a/net/horst/Makefile
+++ b/net/horst/Makefile
@@ -28,7 +28,7 @@ MAKE_FLAGS += DEBUG=1 LIBNL=tiny
 define Package/horst
 	SECTION:=net
 	CATEGORY:=Network
-	SUBMENU:=wireless
+	SUBMENU:=Wireless
 	DEPENDS:=+libncurses +libnl-tiny
 	MAINTAINER:=Bruno Randolf <br1@einfach.org>
 	TITLE:=Highly Optimized 802.11 Radio Scanning Tool

--- a/net/kismet/Makefile
+++ b/net/kismet/Makefile
@@ -27,7 +27,7 @@ define Package/kismet/Default
   MAINTAINER:=Jean-Michel lacroix <lacroix@lepine-lacroix.info>
   DEPENDS:= $(CXX_DEPENDS) +libnl
   URL:=http://www.kismetwireless.net/
-  SUBMENU:=wireless
+  SUBMENU:=Wireless
 endef
 
 define Package/kismet/Default/description

--- a/net/pixiewps/Makefile
+++ b/net/pixiewps/Makefile
@@ -22,7 +22,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/pixiewps
   SECTION:=net
   CATEGORY:=Network
-  SUBMENU:=wireless
+  SUBMENU:=Wireless
   TITLE:=An offline WPS bruteforce utility
   URL:=https://github.com/wiire-a/pixiewps
   DEPENDS:=+libpthread

--- a/net/reaver/Makefile
+++ b/net/reaver/Makefile
@@ -33,7 +33,7 @@ CONFIGURE_ARGS += --enable-savetocurrent
 define Package/reaver
   SECTION:=net
   CATEGORY:=Network
-  SUBMENU:=wireless
+  SUBMENU:=Wireless
   TITLE:=Efficient brute force attack against Wifi Protected Setup
   URL:=https://github.com/t6x/reaver-wps-fork-t6x
   DEPENDS:=+libpcap

--- a/net/rp-pppoe/Makefile
+++ b/net/rp-pppoe/Makefile
@@ -25,7 +25,7 @@ define Package/rp-pppoe/Default
   CATEGORY:=Network
   TITLE:=PPPoE (PPP over Ethernet)
   URL:=http://roaringpenguin.com/products/pppoe
-  SUBMENU:=dial-in/up
+  SUBMENU:=Dial-in/up
 endef
 
 define Package/rp-pppoe/Default/description

--- a/net/tcpreplay/Makefile
+++ b/net/tcpreplay/Makefile
@@ -28,7 +28,7 @@ TCPREPLAY_MODULES:= \
 	tcpreplay tcpreplay-edit tcprewrite
 
 define Package/tcpreplay/default
-  SUBMENU:=tcprelay
+  SUBMENU:=Tcpreplay
   SECTION:=net
   CATEGORY:=Network
   URL:=http://tcpreplay.appneta.com/

--- a/net/wavemon/Makefile
+++ b/net/wavemon/Makefile
@@ -29,7 +29,7 @@ define Package/wavemon
   CATEGORY:=Network
   TITLE:=N-curses based wireless network devices monitor
   DEPENDS:=+libncurses +libpthread +libnl-genl
-  SUBMENU:=wireless
+  SUBMENU:=Wireless
   URL:=https://github.com/uoaerg/wavemon/releases
 endef
 

--- a/net/wifischedule/Makefile
+++ b/net/wifischedule/Makefile
@@ -24,7 +24,7 @@ PKG_MAINTAINER:=Nils Koenig <openwrt@newk.it>
 include $(INCLUDE_DIR)/package.mk
 
 define Package/wifischedule
-  SUBMENU:=wireless
+  SUBMENU:=Wireless
   TITLE:=Turns WiFi on and off according to a schedule
   SECTION:=net
   CATEGORY:=Network

--- a/utils/fontconfig/Makefile
+++ b/utils/fontconfig/Makefile
@@ -23,7 +23,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/fontconfig
   SECTION:=xorg-util
   CATEGORY:=Xorg
-  SUBMENU:=font-utils
+  SUBMENU:=Font-Utils
   TITLE:=fontconfig
   DEPENDS:=+libpthread +libexpat +libfreetype
   URL:=http://fontconfig.org/

--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -235,7 +235,7 @@ define Package/mariadb/Default
   SECTION:=utils
   CATEGORY:=Utilities
   URL:=https://mariadb.org/
-  SUBMENU:=database
+  SUBMENU:=Database
 endef
 
 define Package/mariadb-client

--- a/utils/rrdtool1/Makefile
+++ b/utils/rrdtool1/Makefile
@@ -61,7 +61,7 @@ define Package/rrdcgi1
 $(call Package/rrdtool1/Default)
   SECTION:=utils
   CATEGORY:=Utilities
-  SUBMENU:=database
+  SUBMENU:=Database
   DEPENDS:=+librrd1
   TITLE+= CGI graphing tool
 endef
@@ -76,7 +76,7 @@ define Package/rrdtool1
 $(call Package/rrdtool1/Default)
   SECTION:=utils
   CATEGORY:=Utilities
-  SUBMENU:=database
+  SUBMENU:=Database
   DEPENDS:=+librrd1
   TITLE+= management tools
 endef


### PR DESCRIPTION
Maintainer: @commodo @adde88 @br101 @dangowrt @pfzim @champtar @haraldg @padre-lacroix @jmccrohan @jow- @ZeroChaos- @micmac1 @heil @ascob @yousong 
Compile tested: `make menuconfig` tested
Run tested: N/A

Description:
Capitalize submenus to keep them consistent and in alphabetical order.
I've run 
```
sed -i -e 's/\(SUBMENU:=\)\([a-z]\)/\1\u\2/' $(git grep -l 'SUBMENU:=[a-z]')
```
**and checked the results**. adjusting OpenWISP and LibElektra to match upstream capitalization, and tcprelay to Tcpre**p**lay, assuming this was a typo.
I did not change anything else in the Makefiles, so `PKG_RELEASE` increment is not needed.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
