### PR TITLE
tessdata: reorganize menu

### DIFF
--- a/utils/tessdata/Makefile
+++ b/utils/tessdata/Makefile
@@ -36,7 +36,6 @@ endef
 
 
 define Package/tesseract-data-default
-  SUBMENU:=Tesseract
   SECTION:=utils
   CATEGORY:=Utilities
   DEPENDS:=tesseract
@@ -44,7 +43,7 @@ endef
 
 define generate-tesseract-data-package
   define Package/tesseract-data-$(1)
-    TITLE:=Tesseract training data for $(1) language
+    TITLE:=Training data for $(1) language
     $(call Package/tesseract-data-default)
   endef
 


### PR DESCRIPTION
Maintainer: @vk496 
Compile tested: `make menuconfig` tested
Run tested: N/A

Description:
Move language data menu under the package itself, and shorten the titles
so that all of them show up in the menu.

This fixes an oversight on my part when I reviewed #8589. :disappointed: 

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>