### PR TITLE
redis: add new package

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,0 +1,94 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=redis
+PKG_VERSION:=5.0.5
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=http://download.redis.io/releases/
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=2139009799d21d8ff94fc40b7f36ac46699b9e1254086299f8d3b223ca54a375
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=COPYING
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+MAKE_FLAGS+= \
+	MALLOC="libc" \
+	USE_JEMALLOC="no" \
+	PREFIX="$(PKG_INSTALL_DIR)/usr" \
+	ARCH=""
+
+define Package/redis/Default
+  SUBMENU:=Database
+  SECTION:=libs
+  CATEGORY:=Libraries
+  URL:=https://redis.io
+endef
+
+define Package/redis-server
+$(call  Package/redis/Default)
+  TITLE:=Redis server
+  DEPENDS:=+libpthread
+endef
+
+define Package/redis-cli
+$(call  Package/redis/Default)
+  TITLE:=Redis cli
+endef
+
+define Package/redis-utils
+$(call  Package/redis/Default)
+  TITLE:=Redis utilities
+  DEPENDS:=+redis-server
+endef
+
+define Package/redis-full
+$(call  Package/redis/Default)
+  TITLE:=All Redis binaries (server,cli and utils)
+  DEPENDS:=+redis-utils +redis-cli
+endef
+
+define Package/redis-full/description
+  Redis is an open source, BSD licensed, advanced key-value cache and store.
+  It is often referred to as a data structure server since keys can contain
+  strings, hashes, lists, sets, sorted sets, bitmaps and hyperloglogs.
+endef
+
+define Package/redis-server/conffiles
+/etc/redis.conf
+endef
+
+define Build/Compile
+	$(MAKE) -C "$(PKG_BUILD_DIR)/deps/hiredis" static $(MAKE_FLAGS)  $(MAKE_VARS)
+	$(MAKE) -C "$(PKG_BUILD_DIR)/deps/linenoise" $(MAKE_FLAGS)  $(MAKE_VARS)
+	$(MAKE) -C "$(PKG_BUILD_DIR)/deps/lua" posix $(MAKE_FLAGS)  $(MAKE_VARS) AR="${AR} ru"
+	$(call Build/Compile/Default)
+endef
+
+define Package/redis-server/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/redis-server $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/redis.init $(1)/etc/init.d/redis
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/redis.conf $(1)/etc/
+	$(SED) "s|^dir .*|dir /var/lib/redis|" $(1)/etc/redis.conf
+endef
+
+define Package/redis-cli/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/redis-cli $(1)/usr/bin/
+endef
+
+define Package/redis-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/redis-{check-aof,benchmark} $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,redis-full))
+$(eval $(call BuildPackage,redis-server))
+$(eval $(call BuildPackage,redis-cli))
+$(eval $(call BuildPackage,redis-utils))

--- a/libs/redis/files/redis.init
+++ b/libs/redis/files/redis.init
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=95
+STOP=10
+
+REDIS_BIN="/usr/bin/redis-server"
+REDIS_CONFIG="/etc/redis.conf"
+REDIS_PID="/var/run/redis.pid"
+REDIS_DATA="/var/lib/redis"
+
+start_service() {
+	mkdir -p "$REDIS_DATA"
+	procd_open_instance redis
+	procd_set_param command "$REDIS_BIN" "$REDIS_CONFIG"
+	procd_close_instance
+}

--- a/libs/redis/patches/020-fix-atomicvar.patch
+++ b/libs/redis/patches/020-fix-atomicvar.patch
@@ -1,0 +1,22 @@
+Index: redis-5.0.0/src/atomicvar.h
+===================================================================
+--- redis-5.0.0.orig/src/atomicvar.h
++++ redis-5.0.0/src/atomicvar.h
+@@ -68,7 +68,7 @@
+  * is reported. */
+ // #define __ATOMIC_VAR_FORCE_SYNC_MACROS
+
+-#if !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && defined(__ATOMIC_RELAXED) && !defined(__sun) && (!defined(__clang__) || !defined(__APPLE__) || __apple_build_version__ > 4210057)
++#if defined(CONFIG_EDAC_ATOMIC_SCRUB) &&  !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && defined(__ATOMIC_RELAXED) && !defined(__sun) && (!defined(__clang__) || !defined(__APPLE__) || __apple_build_version__ > 4210057)
+ /* Implementation using __atomic macros. */
+
+ #define atomicIncr(var,count) __atomic_add_fetch(&var,(count),__ATOMIC_RELAXED)
+@@ -82,7 +82,7 @@
+ #define atomicSet(var,value) __atomic_store_n(&var,value,__ATOMIC_RELAXED)
+ #define REDIS_ATOMIC_API "atomic-builtin"
+
+-#elif defined(HAVE_ATOMIC)
++#elif defined(CONFIG_EDAC_ATOMIC_SCRUB) && defined(HAVE_ATOMIC)
+ /* Implementation using __sync macros. */
+
+ #define atomicIncr(var,count) __sync_add_and_fetch(&var,(count))


### PR DESCRIPTION
Maintainer:  me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR adds new package with redis database. It's based on @p3x-robot package and fixes issue https://github.com/openwrt/packages/issues/8711

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>


