### PR TITLE
luasocket: variant for lua5.1 and lua5.3

### DIFF
--- a/lang/luasocket/Makefile
+++ b/lang/luasocket/Makefile
@@ -22,20 +22,44 @@ PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/luasocket
+define Package/luasocket/default
   SUBMENU:=Lua
   SECTION:=lang
   CATEGORY:=Languages
   URL:=http://w3.impa.br/~diego/software/luasocket
-  TITLE:=LuaSocket
-  DEPENDS:=+lua
 endef
 
-define Package/luasocket/description
+define Package/luasocket
+  $(Package/luasocket/default)
+  TITLE:=LuaSocket
+  DEPENDS:=+lua
+  VARIANT:=lua-51
+  DEFAULT_VARIANT:=1
+endef
+
+define Package/luasocket5.3
+  $(Package/luasocket/default)
+  TITLE:=LuaSocket 5.3
+  DEPENDS:=+liblua5.3
+  VARIANT:=lua-53
+endef
+
+ifeq ($(BUILD_VARIANT),lua-51)
+  LUA_VERSION=5.1
+endif
+
+ifeq ($(BUILD_VARIANT),lua-53)
+  LUA_VERSION=5.3
+endif
+
+
+define Package/luasocket/default/description
   LuaSocket is the most comprehensive networking support
   library for the Lua language. It provides easy access to
   TCP, UDP, DNS, SMTP, FTP, HTTP, MIME and much more.
 endef
+Package/luasocket/description     = $(Package/luasocket/default/description)
+Package/luasocket5.3/description = $(Package/luasocket/default/description)
 
 define Build/Configure
 endef
@@ -45,7 +69,7 @@ define Build/Compile
 		LIBDIR="$(TARGET_LDFLAGS)" \
 		CC="$(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_CPPFLAGS) $(FPIC)" \
 		LD="$(TARGET_CROSS)ld -shared" \
-		LUAV=5.1 LUAINC_linux_base=$(STAGING_DIR)/usr/include \
+		LUAV=$(LUA_VERSION) LUAINC_linux_base=$(STAGING_DIR)/usr/include \
 		all
 endef
 
@@ -62,4 +86,14 @@ define Package/luasocket/install
 	ln -sf ../socket-3.0-rc1.so $(1)/usr/lib/lua/socket/core.so
 endef
 
+
+define Package/luasocket5.3/install
+	$(MAKE) -C $(PKG_BUILD_DIR)/src \
+		DESTDIR="$(1)" \
+		LUAV=$(LUA_VERSION) \
+		install
+endef
+
+
 $(eval $(call BuildPackage,luasocket))
+$(eval $(call BuildPackage,luasocket5.3))

--- a/lang/luasocket/Makefile
+++ b/lang/luasocket/Makefile
@@ -8,15 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luasocket
-PKG_SOURCE_VERSION:=6d5e40c324c84d9c1453ae88e0ad5bdd0a631448
-PKG_VERSION:=3.0-rc1-20130909
-PKG_RELEASE:=5
+PKG_SOURCE_DATE:=2019-04-21
+PKG_SOURCE_VERSION:=733af884f1aa18ff469bf3c4d18810e815853211
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_MIRROR_HASH:=d2fa075d8bd026c41e0eb1a634ac2ad8115dee8abb070720e8e91fab51f86ee4
-PKG_SOURCE_URL:=https://github.com/diegonehab/luasocket.git
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/diegonehab/luasocket
+PKG_MIRROR_HASH:=60aef7544426cae3e6c7560a6e4ad556a04b879ca0ad0311645b2c513c872128
+
+PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -24,9 +26,8 @@ define Package/luasocket
   SUBMENU:=Lua
   SECTION:=lang
   CATEGORY:=Languages
+  URL:=http://w3.impa.br/~diego/software/luasocket
   TITLE:=LuaSocket
-  URL:=http://luasocket.luaforge.net/
-  MAINTAINER:=W. Michael Petullo <mike@flyn.org>
   DEPENDS:=+lua
 endef
 
@@ -44,21 +45,21 @@ define Build/Compile
 		LIBDIR="$(TARGET_LDFLAGS)" \
 		CC="$(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_CPPFLAGS) $(FPIC)" \
 		LD="$(TARGET_CROSS)ld -shared" \
+		LUAV=5.1 LUAINC_linux_base=$(STAGING_DIR)/usr/include \
 		all
 endef
-
 
 define Package/luasocket/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/src/{ltn12,mime,socket}.lua $(1)/usr/lib/lua
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/mime.so.1.0.3 $(1)/usr/lib/lua
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/socket.so.3.0-rc1 $(1)/usr/lib/lua
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/mime-1.0.3.so $(1)/usr/lib/lua
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/socket-3.0-rc1.so $(1)/usr/lib/lua
 	$(INSTALL_DIR) $(1)/usr/lib/lua/mime
-	ln -sf ../mime.so.1.0.3 $(1)/usr/lib/lua/mime/core.so
+	ln -sf ../mime-1.0.3.so $(1)/usr/lib/lua/mime/core.so
 	$(INSTALL_DIR) $(1)/usr/lib/lua/socket
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/src/{ftp,http,smtp,tp,url,headers}.lua $(1)/usr/lib/lua/socket
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/unix.so $(1)/usr/lib/lua/socket
-	ln -sf ../socket.so.3.0-rc1 $(1)/usr/lib/lua/socket/core.so
+	ln -sf ../socket-3.0-rc1.so $(1)/usr/lib/lua/socket/core.so
 endef
 
 $(eval $(call BuildPackage,luasocket))

--- a/lang/luasocket/patches/0001-Add-interface-support.patch
+++ b/lang/luasocket/patches/0001-Add-interface-support.patch
@@ -18,7 +18,7 @@ new file mode 100644
 index 0000000..db231aa
 --- /dev/null
 +++ b/src/if.c
-@@ -0,0 +1,113 @@
+@@ -0,0 +1,117 @@
 +/*
 + * $Id: if.c $
 + *
@@ -55,7 +55,11 @@ index 0000000..db231aa
 +{
 +    lua_pushstring(L, "iface");
 +    lua_newtable(L);
++#if LUA_VERSION_NUM < 503
 +    luaL_openlib(L, NULL, func, 0);
++#else
++    luaL_setfuncs(L, func, 0);
++#endif
 +    lua_settable(L, -3);
 +    return 0;
 +}
@@ -169,7 +173,7 @@ diff --git a/src/luasocket.c b/src/luasocket.c
 index e6ee747..85d41a6 100644
 --- a/src/luasocket.c
 +++ b/src/luasocket.c
-@@ -31,6 +31,7 @@
+@@ -21,6 +21,7 @@
  #include "tcp.h"
  #include "udp.h"
  #include "select.h"
@@ -177,7 +181,7 @@ index e6ee747..85d41a6 100644
  
  /*-------------------------------------------------------------------------*\
  * Internal function prototypes
-@@ -51,6 +52,7 @@ static const luaL_Reg mod[] = {
+@@ -41,6 +42,7 @@ static const luaL_Reg mod[] = {
      {"tcp", tcp_open},
      {"udp", udp_open},
      {"select", select_open},
@@ -189,15 +193,16 @@ diff --git a/src/makefile b/src/makefile
 index 8d3521e..09d4882 100644
 --- a/src/makefile
 +++ b/src/makefile
-@@ -262,6 +262,7 @@ SOCKET_OBJS= \
- 	auxiliar.$(O) \
+
+@@ -303,6 +303,7 @@ SOCKET_OBJS= \
+ 	compat.$(O) \
  	options.$(O) \
  	inet.$(O) \
 +	if.$(O) \
  	$(SOCKET) \
  	except.$(O) \
  	select.$(O) \
-@@ -387,6 +388,7 @@ auxiliar.$(O): auxiliar.c auxiliar.h
+@@ -440,6 +441,7 @@ auxiliar.$(O): auxiliar.c auxiliar.h
  buffer.$(O): buffer.c buffer.h io.h timeout.h
  except.$(O): except.c except.h
  inet.$(O): inet.c inet.h socket.h io.h timeout.h usocket.h
@@ -209,17 +214,19 @@ diff --git a/src/options.c b/src/options.c
 index 8ac2a14..1c73e6f 100644
 --- a/src/options.c
 +++ b/src/options.c
-@@ -3,6 +3,9 @@
- * LuaSocket toolkit
- \*=========================================================================*/
- #include <string.h> 
+@@ -7,7 +7,10 @@
+ #include "options.h"
+ #include "inet.h"
+ #include <string.h>
+-
 +#include <sys/types.h>
 +#include <sys/socket.h>
 +#include <net/if.h>
- 
- #include "lauxlib.h"
- 
-@@ -285,6 +288,12 @@ static int opt_ip6_setmembership(lua_State *L, p_socket ps, int level, int name)
++ 
+ /*=========================================================================*\
+ * Internal functions prototypes
+ \*=========================================================================*/
+@@ -388,6 +391,12 @@ static int opt_ip6_setmembership(lua_Sta
      if (!lua_isnil(L, -1)) {
          if (lua_isnumber(L, -1)) {
              val.ipv6mr_interface = (unsigned int) lua_tonumber(L, -1);
@@ -232,6 +239,5 @@ index 8ac2a14..1c73e6f 100644
          } else
            luaL_argerror(L, -1, "number 'interface' field expected");
      }
--- 
+--
 1.8.4.rc3
-

--- a/lang/luasocket/patches/0301-Fix-mpc85xx-build.patch
+++ b/lang/luasocket/patches/0301-Fix-mpc85xx-build.patch
@@ -1,6 +1,6 @@
 --- a/src/makefile
 +++ b/src/makefile
-@@ -345,18 +345,18 @@ none:
+@@ -397,18 +398,18 @@ none:
  all: $(SOCKET_SO) $(MIME_SO)
  
  $(SOCKET_SO): $(SOCKET_OBJS)
@@ -21,5 +21,5 @@
 -	$(LD) $(SERIAL_OBJS) $(LDFLAGS)$@
 +	$(CC) $(SERIAL_OBJS) $(LDFLAGS)$@
  
- install: 
+ install:
  	$(INSTALL_DIR) $(INSTALL_TOP_LDIR)

--- a/lang/luasocket/patches/040-remove-fpic-and-warnings.patch
+++ b/lang/luasocket/patches/040-remove-fpic-and-warnings.patch
@@ -1,14 +1,14 @@
 --- a/src/makefile
 +++ b/src/makefile
-@@ -163,9 +163,8 @@ DEF_linux=-DLUASOCKET_$(DEBUG) -DLUA_$(COMPAT)_MODULE \
- 	-DLUASOCKET_API='__attribute__((visibility("default")))' \
- 	-DUNIX_API='__attribute__((visibility("default")))' \
- 	-DMIME_API='__attribute__((visibility("default")))'
--CFLAGS_linux= -I$(LUAINC) $(DEF) -pedantic -Wall -Wshadow -Wextra \
--	-Wimplicit -O2 -ggdb3 -fpic -fvisibility=hidden
+@@ -174,9 +174,8 @@ SO_linux=so
+ O_linux=o
+ CC_linux=gcc
+ DEF_linux=-DLUASOCKET_$(DEBUG)
+-CFLAGS_linux=$(LUAINC:%=-I%) $(DEF) -Wall -Wshadow -Wextra \
+-	-Wimplicit -O2 -ggdb3 -fpic
 -LDFLAGS_linux=-O -shared -fpic -o 
-+CFLAGS_linux= -I$(LUAINC) $(DEF) -fvisibility=hidden
-+LDFLAGS_linux=-shared -o
++CFLAGS_linux=$(LUAINC:%=-I%) $(DEF) -O2 
++LDFLAGS_linux=-O -shared -o 
  LD_linux=gcc
  SOCKET_linux=usocket.o
  


### PR DESCRIPTION
Updating luasocket package that is compatible with, and built against,
lua version 5.3 and 5.1.

I made the following modifications:

Makefile - Updated the upstream version. Set the LUAV environment
variable in the build variant. Set an include path in the lua build so
that that lua headers could be found. Also using the make install
target as everything is put in the correct place automatically for
the lua 5.3 build.  The lua 5.1 build still uses the old install method
because when I was testing using the "install" target the lua5.1
interpreter was unable to locate resources.  So that is why there are
two install methods.  I also updated the release number and moved to a
source date version to identify the source.

0001-Add-interface-support.patch - ported this patch which included
replacing one deprecated call for 5.3. Validated that the interface
functionality added by the patch is working and functional. The
following lua script line was functional: print(socket.iface.indextoname(2))

0301-Fix-mpc85xx-build.patch - Just fixed the offsets and fuzz in the
patch

040-remove-fpic-and-warnings.patch - ported this patch. I did make one
change. The patch name is called remove fpic and warnings, but the
patch was also removing optimization. I ported the removal of fpic and
warnings, however I left optimization in.

Built and tested on BCM5301X.

Signed-off-by: Colby Whitney colby.whitney@luxul.com

Maintainer: @flyn-org 
Built and Run tested on BCM5301X on Luxul Router on OpenWRT 17.01.  I verified the luasocket code by doing an http.request("http://www.google.com") and verifying proper download, as well as the additional iface code from patch 0001 as mentioned above.
