### PR TITLE
yajl: Update to modern standards

### DIFF
--- a/libs/yajl/Makefile
+++ b/libs/yajl/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (C) 2014, 2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
@@ -9,18 +9,19 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yajl
 PKG_VERSION:=2.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/lloyd/yajl
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
+PKG_MIRROR_HASH:=0cd74320be0270a07931e42d2f14f87a8b3fb664ecb5db58b0e838886211ab1f
+
 PKG_MAINTAINER:=Charles Southerland <charlie@stuphlabs.com>
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=COPYING
-PKG_REV:=66cb08ca2ad8581080b626a75dfca266a890afb2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MIRROR_HASH:=95bfdb37f864318fc3c2ee736a747d4902d279a88f361770c89e60ff5e1d6f63
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=$(PKG_REV)
-PKG_SOURCE_URL:=git://github.com/lloyd/yajl.git
-PKG_SOURCE_PROTO:=git
+PKG_BUILD_PARALLEL:=1
+CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -29,7 +30,7 @@ define Package/yajl
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Yet Another JSON Library
-  URL:=http://lloyd.github.io/yajl
+  URL:=https://lloyd.github.io/yajl
 endef
 
 define Package/yajl/description
@@ -38,18 +39,6 @@ JSON parser written in ANSI C, and a small validating JSON generator.
 YAJL is released under the ISC license.
 
   YAJL was created by Lloyd Hilaiel.
-endef
-
-PKG_INSTALL:=1
-
-CMAKE_OPTIONS += \
-	-DCMAKE_BUILD_TYPE:String="Release" 
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/yajl $(1)/usr/include/
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libyajl.so* $(1)/usr/lib/
 endef
 
 define Package/yajl/install


### PR DESCRIPTION
Replaced git:// link with https:// which gets through firewalls easier.

Replaced archive with .xz. The one currently in the mirrors has the wrong
hash. .xz is also smaller than .gz.

Eliminated already default CMake option.

Eliminated Build/InstallDev with CMAKE_INSTALL.

Added PKG_BUILD_PARALLEL for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @proidiot 
Compile tested: arc700