### PR TITLE
gddrescue: Add uClibc-ng support

### DIFF
--- a/utils/gddrescue/Makefile
+++ b/utils/gddrescue/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gddrescue
 PKG_VERSION:=1.23
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.xz
 PKG_SOURCE_URL:=http://http.debian.net/debian/pool/main/g/$(PKG_NAME)
@@ -27,7 +27,7 @@ define Package/gddrescue
   CATEGORY:=Utilities
   TITLE:=Data recovery tool
   URL:=https://www.gnu.org/software/ddrescue/
-  DEPENDS:=$(CXX_DEPENDS) @!USE_UCLIBC
+  DEPENDS:=$(CXX_DEPENDS)
 endef
 
 define Package/gddrescue/description

--- a/utils/gddrescue/patches/010-fix-uclibcxx.patch
+++ b/utils/gddrescue/patches/010-fix-uclibcxx.patch
@@ -1,0 +1,102 @@
+--- a/fillbook.cc
++++ b/fillbook.cc
+@@ -31,6 +31,9 @@
+ #include "block.h"
+ #include "mapbook.h"
+ 
++#ifdef __UCLIBCXX_MAJOR__
++#undef fputc
++#endif
+ 
+ // Return values: 1 write error, 0 OK.
+ //
+--- a/genbook.cc
++++ b/genbook.cc
+@@ -31,6 +31,9 @@
+ #include "block.h"
+ #include "mapbook.h"
+ 
++#ifdef __UCLIBCXX_MAJOR__
++#undef fputc
++#endif
+ 
+ const char * format_time( const long t, const bool low_prec )
+   {
+--- a/loggers.cc
++++ b/loggers.cc
+@@ -25,6 +25,9 @@
+ #include "block.h"
+ #include "loggers.h"
+ 
++#ifdef __UCLIBCXX_MAJOR__
++#undef fputc
++#endif
+ 
+ namespace {
+ 
+--- a/main.cc
++++ b/main.cc
+@@ -46,6 +46,11 @@
+ #include "non_posix.h"
+ #include "rescuebook.h"
+ 
++#ifdef __UCLIBCXX_MAJOR__
++#undef fgetc
++#undef fputc
++#endif
++
+ #ifndef O_BINARY
+ #define O_BINARY 0
+ #endif
+--- a/main_common.cc
++++ b/main_common.cc
+@@ -15,6 +15,10 @@
+     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#ifdef __UCLIBCXX_MAJOR__
++#undef fputc
++#endif
++
+ int verbosity = 0;
+ 
+ namespace {
+--- a/mapbook.cc
++++ b/mapbook.cc
+@@ -32,6 +32,10 @@
+ #include "block.h"
+ #include "mapbook.h"
+ 
++#ifdef __UCLIBCXX_MAJOR__
++#undef fgetc
++#undef fputc
++#endif
+ 
+ namespace {
+ 
+--- a/mapfile.cc
++++ b/mapfile.cc
+@@ -29,6 +29,11 @@
+ 
+ #include "block.h"
+ 
++#ifdef __UCLIBCXX_MAJOR__
++#undef fgetc
++#undef ferror
++#undef feof
++#endif
+ 
+ namespace {
+ 
+--- a/rescuebook.cc
++++ b/rescuebook.cc
+@@ -36,6 +36,9 @@
+ #include "mapbook.h"
+ #include "rescuebook.h"
+ 
++#ifdef __UCLIBCXX_MAJOR__
++#undef fputc
++#endif
+ 
+ namespace {
+ 


### PR DESCRIPTION
It turns out, this breaks only when compiling with both uClibc-ng and
uClibc++. If the libc or libc++ gets swapped out, it compiles fine.

libstdcpp is fine because it already undefs these macros. The actual
bug is probably in uClibc-ng but this is a fine workaround.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: arc700