### PR TITLE
p910nd: Run as non-root by default

### DIFF
--- a/net/p910nd/Makefile
+++ b/net/p910nd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=p910nd
 PKG_VERSION:=0.97
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/p910nd
@@ -28,6 +28,7 @@ define Package/p910nd
   SUBMENU:=Printing
   TITLE:=A small non-spooling printer server
   URL:=http://p910nd.sourceforge.net
+  USERID:=p910nd=393:lp=7
 endef
 
 define Package/p910nd/conffiles
@@ -54,6 +55,8 @@ define Package/p910nd/install
 	$(INSTALL_DATA) ./files/p910nd.config $(1)/etc/config/p910nd
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/p910nd.init $(1)/etc/init.d/p910nd
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/usbmisc
+	$(INSTALL_BIN) ./files/p910nd.hotplug $(1)/etc/hotplug.d/usbmisc/20-p910nd
 endef
 
 $(eval $(call BuildPackage,p910nd))

--- a/net/p910nd/files/p910nd.config
+++ b/net/p910nd/files/p910nd.config
@@ -5,6 +5,8 @@ config p910nd
 	option port          0
 	option bidirectional 1
 	option enabled       0
+	# Override running as user p910nd, group lp
+	option runas_root    0
 
 	# mDNS support - see Bonjour Printing Specification for details concerning the values
 	# Be aware that you can only advertise one printer on this host via mDNS

--- a/net/p910nd/files/p910nd.hotplug
+++ b/net/p910nd/files/p910nd.hotplug
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+case "$ACTION" in
+        add)
+		[ -n "${DEVNAME}" ] && [ "${DEVNAME##usb/lp*}" = "" ] && {
+			chmod 660 /dev/"$DEVNAME"
+			chgrp lp /dev/"$DEVNAME"
+		}
+                ;;
+        remove)
+                # device is gone
+                ;;
+esac

--- a/net/p910nd/files/p910nd.init
+++ b/net/p910nd/files/p910nd.init
@@ -28,7 +28,7 @@ start_service() {
 
 
 start_p910nd() {
-	local section="$1"
+	local section="$1" runas_root
 	config_get_bool "enabled" "$section" "enabled" '1'
 	if [ "$enabled" -gt 0 ]; then
 		args="-d "
@@ -41,6 +41,9 @@ start_p910nd() {
 		procd_open_instance $name
 		procd_set_param command /usr/sbin/p910nd $args
 		procd_set_param respawn
+
+		config_get_bool runas_root "$section" runas_root 0
+		[ "$runas_root" -ne 1 ] && procd_set_param user p910nd
 
 		config_get_bool "mdns" "$section" "mdns" '0'
 		config_get mdns_note "$section" mdns_note


### PR DESCRIPTION
We add the necessary Makefile, hotplug, config, and init bits
so that p910nd daemon runs as user:group lp:lp by default.
This eliminates an unnecessary root daemon.

The hotplug script sets the permissions of the USB lp
device(s) to read-write owner and group and no access to
anyone else, and sets owner root, group lp.

This is allows sufficient privileges to p910nd
to do it's job.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: @pkerling (for related saned-backends: @luizluca  )
Compile tested: ath79, CR5000, Current snapshot SDK (2019-07-26 02:00 -0500 or so)
Run tested: same, configured as usual (see below), scanned and printed (scan using sane-backends changes so that HP all-in-one (printer+scanner) can use saned and p910nd without conflicts; those changes are not required for this PR to be effective).

Also, as you can see I bind to IPv6 so that IPv4+IPv6 dual stack works.

/etc/config/p910nd
```
config p910nd
        option device        /dev/usb/lp0
        # Actual TCP port is 9100 plus this value
        # Valid values are 0,1,2
        option port          0
        option bidirectional 1
        option enabled       1
        option bind         '::'
        option user         lp

        # mDNS support - see Bonjour Printing Specification for details concerning the values
        # Be aware that you can only advertise one printer on this host via mDNS
        # Set to 1 to enable
        option mdns          0
        # Human-readable printer make and model
        option mdns_ty       'My Printer Manufacturer/Model'
        # Human-readable location
        option mdns_note     'Basement'
        # Post-Script product string, including parenthesis
        option mdns_product  ''
        # IEEE-1284 Device ID MANUFACTURER/MFG string
        option mdns_mfg      ''
        # IEEE-1284 Device ID MODEL/MDL string
        option mdns_mdl      ''
        # IEEE-1284 Device ID COMMAND SET/CMD string
        option mdns_cmd      ''
```