### PR TITLE
 scons: move host build tool to a proper place

### DIFF
--- a/devel/scons/Makefile
+++ b/devel/scons/Makefile
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2011-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=scons
+PKG_VERSION:=3.1.1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@SF/scons \
+		https://fossies.org/linux/misc/
+PKG_HASH:=4cea417fdd7499a36f407923d03b4b7000b0f9e8fd7b31b316b9ce7eba9143a5
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+
+define Package/scons
+  SECTION:=devel
+  CATEGORY:=Development
+  TITLE:=scons
+  HIDDEN:=1
+endef
+
+define Package/scons/description
+  SCons is an Open Source software construction tool—that is, a
+  next-generation build tool. Think of SCons as an improved, cross-platform
+  substitute for the classic Make utility with integrated functionality
+  similar to autoconf/automake and compiler caches such as ccache. In short,
+  SCons is an easier, more reliable and faster way to build software.
+endef
+
+define Host/Configure
+endef
+
+define Host/Compile
+endef
+
+define Host/Install
+	./files/pywrap.sh $(HOST_BUILD_DIR)/setup.py install --prefix=$(STAGING_DIR_HOST)
+	rm -f $(STAGING_DIR_HOST)/bin/scons*.py
+	for bin in $(STAGING_DIR_HOST)/bin/scons*; do \
+		mv "$$$$bin" "$$$$bin.py";                \
+		cp ./files/pywrap.sh "$$$$bin";           \
+	done
+endef
+
+$(eval $(call BuildPackage,scons))
+$(eval $(call HostBuild))

--- a/devel/scons/files/pywrap.sh
+++ b/devel/scons/files/pywrap.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+case "${0##*/}" in
+	pywrap.sh) arg1="";;
+	*) arg1="$0.py" ;;
+esac
+
+for bin in python python3; do
+    case "$($bin -V 2>&1)" in
+        "Python 3"*) exec $bin $arg1 "$@" ;;
+    esac
+done
+
+echo "Unable to find a Python 3.x interpreter for executing ${arg1:+$arg1 }$* !" >&2
+exit 1

--- a/devel/scons/patches/001-platform_env.patch
+++ b/devel/scons/patches/001-platform_env.patch
@@ -1,0 +1,11 @@
+--- a/engine/SCons/Platform/__init__.py
++++ b/engine/SCons/Platform/__init__.py
+@@ -65,6 +65,8 @@ def platform_default():
+     care about the machine architecture.
+     """
+     osname = os.name
++    if 'PLATFORM' in os.environ:
++        return os.environ['PLATFORM']
+     if osname == 'java':
+         osname = os._osType
+     if osname == 'posix':

--- a/devel/scons/scons.mk
+++ b/devel/scons/scons.mk
@@ -1,0 +1,23 @@
+export PLATFORM=posix
+
+SCONS_VARS = \
+	CC="$(TARGET_CC_NOCACHE)" \
+	CXX="$(TARGET_CXX_NOCACHE)" \
+	CFLAGS="$(TARGET_CFLAGS) $(EXTRA_CFLAGS)" \
+	CXXFLAGS="$(TARGET_CXXFLAGS) $(EXTRA_CXXFLAGS)" \
+	CPPFLAGS="$(TARGET_CPPFLAGS) $(EXTRA_CPPFLAGS)" \
+	LDFLAGS="$(TARGET_LDFLAGS) $(EXTRA_LDFLAGS)" \
+	DESTDIR="$(PKG_INSTALL_DIR)"
+
+define Build/Configure/Default
+	(cd $(PKG_BUILD_DIR); \
+		$(SCONS_VARS) \
+		scons \
+			prefix=/usr \
+			$(SCONS_OPTIONS) \
+		install \
+	)
+endef
+
+define Build/Compile
+endef

--- a/net/iotivity/Makefile
+++ b/net/iotivity/Makefile
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=http://mirrors.kernel.org/${PKG_NAME}/${PKG_VERSION}/
 PKG_HASH:=7dcd9f0f48263c6b27a2c3d085dd7278b5c0feed1dfec8872a04899707fa23d8
 PKG_USE_MIPS16:=0
 
-PKG_BUILD_DEPENDS:=boost python/host
+PKG_BUILD_DEPENDS:=boost python/host scons/host
 
 PKG_MAINTAINER:=Hauke Mehrtens <hauke.mehrtens@intel.com>
 
@@ -37,7 +37,7 @@ PKG_CONFIG_DEPENDS := \
 	CONFIG_PACKAGE_iotivity_SECURE
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/scons.mk
+include ../../devel/scons/scons.mk
 
 
 define Package/iotivity

--- a/net/smartsnmpd/Makefile
+++ b/net/smartsnmpd/Makefile
@@ -23,7 +23,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_BUILD_DEPENDS:=scons/host
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/scons.mk
+include ../../devel/scons/scons.mk
 
 define Package/smartsnmpd
   SECTION:=net

--- a/utils/gpsd/Makefile
+++ b/utils/gpsd/Makefile
@@ -15,12 +15,14 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SAVANNAH/$(PKG_NAME)
 PKG_HASH:=27dd24d45b2ac69baab7933da2bf6ae5fb0be90130f67e753c110a3477155f39
 
+PKG_BUILD_DEPENDS:=scons/host
+
 PKG_MAINTAINER:=Pushpal Sidhu <psidhu.devel@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/scons.mk
+include ../../devel/scons/scons.mk
 
 define Package/gpsd/Default
   DEPENDS+= +libusb-1.0


### PR DESCRIPTION
Maintainer: n/a
Compile tested: ath79, master
Run tested: none

Description: move scons host build tool to appropriate place, removal in the master tree is prepared https://github.com/ynezz/openwrt/commit/83c5c3811a49e60c47ac64a2e5952a58c7c17abf