### PR TITLE
unbound: Remove WAN ip address from private addresses

### DIFF
--- a/net/unbound/files/unbound.sh
+++ b/net/unbound/files/unbound.sh
@@ -1022,7 +1022,6 @@ unbound_hostname() {
             {
               # Create a static zone for WAN host record only (singular)
               echo "  domain-insecure: $ifarpa"
-              echo "  private-address: $ifaddr"
               echo "  local-zone: $ifarpa static"
               echo "  local-data: \"$ifarpa. $UB_XSOA\""
               echo "  local-data: \"$ifarpa. $UB_XNS\""


### PR DESCRIPTION
Maintainer: Eric Luehrsen <ericluehrsen@gmail.com>
Compile tested: snapshot, 18.06, mvebu
Run tested: rango, 18.06

Description: remove WAN ip address from private addresses.
