### PR TITLE
youtube-dl: update to version 2019.7.27

### DIFF
--- a/multimedia/youtube-dl/Makefile
+++ b/multimedia/youtube-dl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=youtube-dl
-PKG_VERSION:=2019.7.16
+PKG_VERSION:=2019.7.27
 PKG_RELEASE:=1
 
 PKG_SOURCE:=youtube_dl-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/y/youtube_dl/
-PKG_HASH:=867651dbfc0cefd19bfa0750ce97c43e8436b2de414675d3211615840d6833ca
+PKG_HASH:=82c4b4df4eca070e59fb0b2e4046596764efead8e3b59fc530232f51159d44b5
 PKG_BUILD_DIR:=$(BUILD_DIR)/youtube_dl-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Adrian Panella <ianchi74@outlook.com>, Josef Schlehofer <pepe.schlehofer@gmail.com>


### PR DESCRIPTION
Maintainer: me
Compile tested: cortexa53, Turris MOX, OpenWrt master
Run tested: cortexa53, Turris MOX, OpenWrt master

Description:

- Update to version [2019.7.27](https://github.com/ytdl-org/youtube-dl/releases/tag/2019.07.27)