### PR TITLE
libev: update to 4.27

### DIFF
--- a/libs/libev/Makefile
+++ b/libs/libev/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libev
-PKG_VERSION:=4.25
+PKG_VERSION:=4.27
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://dist.schmorp.de/libev/Attic/
-PKG_HASH:=78757e1c27778d2f3795251d9fe09715d51ce0422416da4abb34af3929c02589
+PKG_HASH:=2d5526fc8da4f072dd5c73e18fbb1666f5ef8ed78b73bba12e195cfdd810344e
 PKG_LICENSE:=BSD-2-Clause
 PKG_MAINTAINER:=Karl Palsson <karlp@tweak.net.au>
 


### PR DESCRIPTION
Maintainer: @karlp 
Compile tested: ramips
Run tested: ramips w/shadowsocks-libev

Description:
Update libev to 4.27