### PR TITLE
libhttp-parser: fix build error on macos

### DIFF
--- a/libs/libhttp-parser/Makefile
+++ b/libs/libhttp-parser/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libhttp-parser
 PKG_VERSION:=2.9.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/nodejs/http-parser/tar.gz/v$(PKG_VERSION)?
@@ -41,18 +41,19 @@ define Package/libhttp-parser/description
   (in a web server that is per connection).
 endef
 
-MAKE_FLAGS+=library
+MAKE_FLAGS+=library \
+	PREFIX=/usr
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/local/include/http_parser.h $(1)/usr/include/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/http_parser.h $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/local/lib/libhttp_parser.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libhttp_parser.so* $(1)/usr/lib/
 endef
 
 define Package/libhttp-parser/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/local/lib/libhttp_parser.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libhttp_parser.so* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libhttp-parser))

--- a/libs/libhttp-parser/patches/000-fix_darwin_error.patch
+++ b/libs/libhttp-parser/patches/000-fix_darwin_error.patch
@@ -1,0 +1,51 @@
+--- a/Makefile
++++ b/Makefile
+@@ -25,11 +25,7 @@
+ SOMAJOR = 2
+ SOMINOR = 9
+ SOREV   = 2
+-ifeq (darwin,$(PLATFORM))
+-SOEXT ?= dylib
+-SONAME ?= $(SOLIBNAME).$(SOMAJOR).$(SOMINOR).$(SOEXT)
+-LIBNAME ?= $(SOLIBNAME).$(SOMAJOR).$(SOMINOR).$(SOREV).$(SOEXT)
+-else ifeq (wine,$(PLATFORM))
++ifeq (wine,$(PLATFORM))
+ CC = winegcc
+ BINEXT = .exe.so
+ HELPER = wine
+@@ -65,12 +61,8 @@
+ LIBDIR = $(PREFIX)/lib
+ INCLUDEDIR = $(PREFIX)/include
+ 
+-ifeq (darwin,$(PLATFORM))
+-LDFLAGS_LIB += -Wl,-install_name,$(LIBDIR)/$(SONAME)
+-else
+ # TODO(bnoordhuis) The native SunOS linker expects -h rather than -soname...
+ LDFLAGS_LIB += -Wl,-soname=$(SONAME)
+-endif
+ 
+ test: test_g test_fast
+ 	$(HELPER) ./test_g$(BINEXT)
+@@ -131,14 +123,18 @@
+ 	ctags $^
+ 
+ install: library
+-	$(INSTALL) -D  http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
+-	$(INSTALL) -D $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
++	$(INSTALL) -d $(DESTDIR)$(INCLUDEDIR)
++	$(INSTALL) -d $(DESTDIR)$(LIBDIR)
++	$(INSTALL)    http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
++	$(INSTALL)    $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
+ 	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+ 	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
+ 
+ install-strip: library
+-	$(INSTALL) -D  http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
+-	$(INSTALL) -D -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
++	$(INSTALL) -d $(DESTDIR)$(INCLUDEDIR)
++	$(INSTALL) -d $(DESTDIR)$(LIBDIR)
++	$(INSTALL)    http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
++	$(INSTALL) -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
+ 	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+ 	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
+ 


### PR DESCRIPTION
Maintainer: @ageekymonk, me
Compile tested: head r10622-e09da01,ath79,arm_cortex-a9+vfpv3,mipsel
Run tested: mipsel

Description:
fix build error on macos

https://github.com/openwrt/packages/issues/9587

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
