### PR TITLE
collectd: enable threshold plugin

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -176,6 +176,7 @@ COLLECTD_PLUGINS_SELECTED:= \
 	teamspeak2 \
 	ted \
 	thermal \
+	threshold \
 	unixsock \
 	uptime \
 	users \
@@ -418,6 +419,7 @@ $(eval $(call BuildPlugin,teamspeak2,TeamSpeak2 input,teamspeak2,))
 $(eval $(call BuildPlugin,ted,The Energy Detective input,ted,))
 $(eval $(call BuildPlugin,tcpconns,TCP connection tracking input,tcpconns,))
 $(eval $(call BuildPlugin,thermal,system temperatures input,thermal,))
+$(eval $(call BuildPlugin,threshold,Notifications and thresholds,threshold,))
 $(eval $(call BuildPlugin,unixsock,unix socket output,unixsock,))
 $(eval $(call BuildPlugin,uptime,uptime status input,uptime,))
 $(eval $(call BuildPlugin,users,user logged in status input,users,))


### PR DESCRIPTION
Maintainer: @hnyman 
Compile tested: x86_64 and lantiq_xrx200, APU3, OpenWrt master
Run tested: x86_64 and lantiq_xrx200, APU3, OpenWrt master, notifcation generation done

Description:

The only action the Threshold plugin takes itself is to generate and
dispatch a notification. Other plugins can register to receive
notifications and perform appropriate further actions.