### PR TITLE
libtasn1: Update to 4.14

### DIFF
--- a/libs/libtasn1/Makefile
+++ b/libs/libtasn1/Makefile
@@ -8,19 +8,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtasn1
-PKG_VERSION:=4.13
-PKG_RELEASE:=2
+PKG_VERSION:=4.14
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
-PKG_HASH:=7e528e8c317ddd156230c4e31d082cd13e7ddeb7a54824be82632209550c8cca
+PKG_HASH:=9e604ba5c5c8ea403487695c2e407405820d98540d9de884d6e844f9a9c5ba08
 
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
-PKG_LICENSE:=LGPLv2.1+
+PKG_LICENSE:=LGPLv2.1-or-later
 PKG_LICENSE_FILES:=COPYING.LIB
 
 #PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -36,6 +37,7 @@ define Package/libtasn1/description
  Distinguish Encoding Rules (DER) manipulation.
 endef
 
+TARGET_CFLAGS += -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections
 
 CONFIGURE_ARGS += \


### PR DESCRIPTION
Fixes CVE-2018-1000654

Minor cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmav 
Compile tested: ath79