### PR TITLE
python: Replace utime with utimes

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -12,7 +12,7 @@ include ../python-version.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)

--- a/lang/python/python/patches/025-utime.patch
+++ b/lang/python/python/patches/025-utime.patch
@@ -1,0 +1,11 @@
+--- a/Modules/posixmodule.c
++++ b/Modules/posixmodule.c
+@@ -3070,7 +3070,7 @@ done:
+     if (arg == Py_None) {
+         /* optional time values not given */
+         Py_BEGIN_ALLOW_THREADS
+-        res = utime(path, NULL);
++        res = utimes(path, NULL);
+         Py_END_ALLOW_THREADS
+     }
+     else if (!PyTuple_Check(arg) || PyTuple_Size(arg) != 2) {


### PR DESCRIPTION
Optionally fixes compilation with uClibc-ng.

Based on the surrounding code, this looks like an oversight.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @commodo @jefferyto 
Compile tested: arc700

Even though this will be deprecated soon, I still don't want to carry this patch :).