### PR TITLE
libtirpc: Remove deprecated b functions

### DIFF
--- a/libs/libtirpc/Makefile
+++ b/libs/libtirpc/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (C) 2006-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtirpc
 PKG_VERSION:=1.1.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=@SF/libtirpc
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/libs/libtirpc/patches/010-b-functions.patch
+++ b/libs/libtirpc/patches/010-b-functions.patch
@@ -1,0 +1,66 @@
+--- a/src/auth_des.c
++++ b/src/auth_des.c
+@@ -396,7 +396,7 @@ authdes_validate(AUTH *auth, struct opaque_auth *rverf)
+ 	/*
+ 	 * validate
+ 	 */
+-	if (bcmp((char *)&ad->ad_timestamp, (char *)&verf.adv_timestamp,
++	if (memcmp((char *)&ad->ad_timestamp, (char *)&verf.adv_timestamp,
+ 		 sizeof(struct timeval)) != 0) {
+ 		LIBTIRPC_DEBUG(1, ("authdes_validate: verifier mismatch"));
+ 		return (FALSE);
+--- a/src/auth_time.c
++++ b/src/auth_time.c
+@@ -104,7 +104,7 @@ static int uaddr_to_sockaddr(uaddr, sin)
+ 	p_bytes[1] = (unsigned char)a[5] & 0x000000FF;
+ 
+ 	sin->sin_family = AF_INET; /* always */
+-	bcopy((char *)&p_bytes, (char *)&sin->sin_port, 2);
++	memcpy((char *)&sin->sin_port, (char *)&p_bytes, 2);
+ 
+ 	return (0);
+ }
+--- a/src/crypt_client.c
++++ b/src/crypt_client.c
+@@ -75,8 +75,8 @@ _des_crypt_call(buf, len, dparms)
+ 	des_crypt_1_arg.desbuf.desbuf_val = buf;
+ 	des_crypt_1_arg.des_dir = dparms->des_dir;
+ 	des_crypt_1_arg.des_mode = dparms->des_mode;
+-	bcopy(dparms->des_ivec, des_crypt_1_arg.des_ivec, 8);
+-	bcopy(dparms->des_key, des_crypt_1_arg.des_key, 8);
++	memcpy(des_crypt_1_arg.des_ivec, dparms->des_ivec, 8);
++	memcpy(des_crypt_1_arg.des_key, dparms->des_key, 8);
+ 
+ 	result_1 = des_crypt_1(&des_crypt_1_arg, clnt);
+ 	if (result_1 == (desresp *) NULL) {
+@@ -88,8 +88,8 @@ _des_crypt_call(buf, len, dparms)
+ 
+ 	if (result_1->stat == DESERR_NONE ||
+ 	    result_1->stat == DESERR_NOHWDEVICE) {
+-		bcopy(result_1->desbuf.desbuf_val, buf, len);
+-		bcopy(result_1->des_ivec, dparms->des_ivec, 8);
++		memcpy(buf, result_1->desbuf.desbuf_val, len);
++		memcpy(dparms->des_ivec, result_1->des_ivec, 8);
+ 	}
+ 
+ 	clnt_freeres(clnt, (xdrproc_t)xdr_desresp, result_1);
+--- a/src/svc_auth_des.c
++++ b/src/svc_auth_des.c
+@@ -145,7 +145,7 @@ _svcauth_des(rqst, msg)
+ 			return (AUTH_BADCRED);
+ 		}
+ 		cred->adc_fullname.name = area->area_netname;
+-		bcopy((char *)ixdr, cred->adc_fullname.name, 
++		memcpy(cred->adc_fullname.name, (char *)ixdr,
+ 			(u_int)namelen);
+ 		cred->adc_fullname.name[namelen] = 0;
+ 		ixdr += (RNDUP(namelen) / BYTES_PER_XDR_UNIT);
+@@ -419,7 +419,7 @@ cache_spot(key, name, timestamp)
+ 		if (cp->key.key.high == hi && 
+ 		    cp->key.key.low == key->key.low &&
+ 		    cp->rname != NULL &&
+-		    bcmp(cp->rname, name, strlen(name) + 1) == 0) {
++		    memcmp(cp->rname, name, strlen(name) + 1) == 0) {
+ 			if (BEFORE(timestamp, &cp->laststamp)) {
+ 				svcauthdes_stats.ncachereplays++;
+ 				return (-1); /* replay */


### PR DESCRIPTION
Optionally fixes compilation with uClibc-ng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Andy2244 
Compile tested: arc700