### PR TITLE
libglog: Switch to nanosleep

### DIFF
--- a/libs/libglog/Makefile
+++ b/libs/libglog/Makefile
@@ -2,31 +2,29 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glog
 PKG_VERSION:=0.4.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/google/glog/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=f28359aeba12f30d73d9e4711ef356dc842886968112162bc73002645139c39c
 
+PKG_MAINTAINER:=Amir Sabbaghi <asaba90@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
-
 PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
-
-PKG_BUILD_DEPENDS:=libgflags
+CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/glog
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=C++ implementation of the Google logging module
-  DEPENDS:= +libstdcpp +libpthread +gflags
+  DEPENDS:=+libstdcpp +libpthread +gflags
   URL:=https://github.com/google/glog
-  MAINTAINER:=Amir Sabbaghi <amir@pichak.co>
 endef
 
 define Package/glog/description
@@ -34,23 +32,13 @@ define Package/glog/description
   module.  Documentation for the implementation is in doc/.
 endef
 
-CONFIGURE_VARS+=ac_cv_header_libunwind_h=0
+CMAKE_OPTIONS += \
+	-DBUILD_SHARED_LIBS=ON \
+	-DBUILD_TESTING=OFF \
+	-DUNWIND_LIBRARY=OFF
 
-TARGET_CXXFLAGS+=-std=c++11
-TARGET_LDFLAGS+=-lpthread
-
-define Build/Configure
-	$(call Build/Configure/Default,)
-endef
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include/glog
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/glog/*.h $(1)/usr/include/glog
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libglog.{a,so*} $(1)/usr/lib
-	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libglog.pc $(1)/usr/lib/pkgconfig/
-endef
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
+TARGET_CFLAGS += -Wl,--gc-sections
 
 define Package/glog/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/libglog/patches/110-nanosleep.patch
+++ b/libs/libglog/patches/110-nanosleep.patch
@@ -1,0 +1,24 @@
+From d7b02b6929baf5b21ee6e15a700b4fc82d962e9c Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Thu, 25 Jul 2019 19:14:42 -0700
+Subject: [PATCH] googletest: Switch to nanosleep
+
+usleep is deprecated and optionally not available with uClibc-ng.
+---
+ src/googletest.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/googletest.h b/src/googletest.h
+index 49ddbc0a..39fb29fb 100644
+--- a/src/googletest.h
++++ b/src/googletest.h
+@@ -574,7 +574,8 @@ class Thread {
+ 
+ static inline void SleepForMilliseconds(int t) {
+ #ifndef OS_WINDOWS
+-  usleep(t * 1000);
++  const struct timespec req = {0, t * 1000 * 1000};
++  nanosleep(&req, NULL);
+ #else
+   Sleep(t);
+ #endif


### PR DESCRIPTION
Optionally fixes compilation with uClibc-ng.

Also switched to CMake. Allows removal of InstallDev as well as further
simplification. Also 100KB smaller package.

Added some C/LDFLAGS to further reduce the size.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @amir-sabbaghi 
Compile tested: arc700