### PR TITLE
libsigar: Remove deprecated rindex function

### DIFF
--- a/libs/libsigar/Makefile
+++ b/libs/libsigar/Makefile
@@ -3,13 +3,13 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=libsigar
 PKG_SOURCE_DATE:=2017-02-21
 PKG_SOURCE_VERSION:=a6c61edf8c64e013411e8c9d753165cd03102c6e
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_DATE).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/boundary/sigar/tar.gz/$(PKG_SOURCE_VERSION)?
-PKG_HASH:=5232f0fa994ab60ad4622364fad0297c0054e04f0cfec9c586b14e33bbc387da
-PKG_BUILD_DIR:=$(BUILD_DIR)/sigar-$(PKG_SOURCE_VERSION)
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/boundary/sigar
+PKG_MIRROR_HASH:=5f017e10ab1d929c9dfb2937fef16a45962b60958cd1569573d18f00fcea290f
 
+PKG_MAINTAINER:=Amol Bhave <ambhave@fb.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILE:=LICENSE
 
@@ -25,7 +25,6 @@ define Package/libsigar
 	TITLE:=System Information Gatherer And Reporter
 	URL:=https://github.com/boundary/sigar
 	DEPENDS:=+libtirpc
-	MAINTAINER:=Amol Bhave <ambhave@fb.com>
 endef
 
 define Package/libsigar/description

--- a/libs/libsigar/patches/010-rindex.patch
+++ b/libs/libsigar/patches/010-rindex.patch
@@ -1,0 +1,18 @@
+--- a/src/sigar_util.c
++++ b/src/sigar_util.c
+@@ -954,14 +954,10 @@ int sigar_file2str(const char *fname, char *buffer, int buflen)
+ #define vsnprintf _vsnprintf
+ #endif
+ 
+-#ifdef WIN32
+-#   define rindex strrchr
+-#endif
+-
+ static int proc_module_get_self(void *data, char *name, int len)
+ {
+     sigar_t *sigar = (sigar_t *)data;
+-    char *ptr = rindex(name, '/');
++    char *ptr = strrchr(name, '/');
+ 
+     if (!ptr) {
+         return SIGAR_OK;


### PR DESCRIPTION
Optionally unavailable with uClibc-ng.

Switched to local tarballs. .xz is smaller.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ammubhave 
Compile tested: arc700