### PR TITLE
ecdsautils: Cleanup Makefile to modern standards

### DIFF
--- a/utils/ecdsautils/Makefile
+++ b/utils/ecdsautils/Makefile
@@ -10,14 +10,17 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ecdsautils
 PKG_VERSION:=0.3.2.20160630
 PKG_RELEASE:=1
-PKG_REV:=07538893fb6c2a9539678c45f9dbbf1e4f222b46
-PKG_MAINTAINER:=Matthias Schiffer <mschiffer@universe-factory.net>
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MIRROR_HASH:=397395a471c0b5af1a173666ba21a5bedb4c3423a6e37c545c3627bed73dcb76
-PKG_SOURCE_URL:=git://github.com/tcatm/$(PKG_NAME).git
-PKG_SOURCE_VERSION:=$(PKG_REV)
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+
 PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/freifunk-gluon/ecdsautils
+PKG_SOURCE_VERSION:=07538893fb6c2a9539678c45f9dbbf1e4f222b46
+PKG_MIRROR_HASH:=397395a471c0b5af1a173666ba21a5bedb4c3423a6e37c545c3627bed73dcb76
+
+PKG_MAINTAINER:=Matthias Schiffer <mschiffer@universe-factory.net>
+PKG_LICENSE_FILES:=COPYRIGHT
+
+PKG_BUILD_PARALLEL:=1
+CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -28,6 +31,7 @@ define Package/libecdsautil
   DEPENDS:=+libuecc
   TITLE:=ECDSA library
   URL:=https://github.com/tcatm/ecdsautils
+  LICENSE:=MIT
 endef
 
 define Package/ecdsautils
@@ -36,11 +40,8 @@ define Package/ecdsautils
   DEPENDS:=+libecdsautil +libuecc
   TITLE:=ECDSA Utilities
   URL:=https://github.com/tcatm/ecdsautils
+  LICENSE:=BSD-2-Clause
 endef
-
-CMAKE_OPTIONS += \
-  -DCMAKE_BUILD_TYPE:String="MINSIZEREL" \
-
 
 define Package/libecdsautil/description
  Library to sign and verify checksums using ECDSA.
@@ -49,6 +50,9 @@ endef
 define Package/ecdsautils/description
  Utilities to sign and verify checksums using ECDSA.
 endef
+
+CMAKE_OPTIONS += \
+	-DCMAKE_BUILD_TYPE:String="MINSIZEREL"
 
 define Package/libecdsautil/install
 	$(INSTALL_DIR) $(1)/usr/lib/
@@ -61,12 +65,6 @@ define Package/ecdsautils/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ecdsakeygen $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ecdsasign $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ecdsaverify $(1)/usr/bin/
-endef
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include $(1)/usr/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib $(1)/usr/
 endef
 
 $(eval $(call BuildPackage,libecdsautil))


### PR DESCRIPTION
Replaced git:// with https:// as it gets through firewalls easier.

Moved URL to new home.

Added LICENSE information.

Replaced InstallDev section with CMAKE_INSTALL.

Added PKG_BUILD_PARALLEL for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @NeoRaider 
Compile tested: arc700