### PR TITLE
mariadb (19.07): security bump to 10.2.26

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
-PKG_VERSION:=10.2.24
+PKG_VERSION:=10.2.26
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -18,10 +18,10 @@ PKG_SOURCE_URL := \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/$(PKG_NAME)-$(PKG_VERSION)/source \
 	https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
 
-PKG_HASH:=97f4d924e69f77abb2f650116785c2f5ef356230442534ebcbaadb51d9bb8bc4
+PKG_HASH:=152fe941c4f2a352b2b3a4db1ef64e70235fd9ff055af62ad7bda9f2b2191528
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 PKG_LICENSE:=GPL-2.0 LGPL-2.1
-PKG_LICENSE_FILES:=COPYING libmariadb/COPYING.LIB
+PKG_LICENSE_FILES:=COPYING THIRDPARTY libmariadb/COPYING.LIB
 
 PKG_CPE_ID:=cpe:/a:mariadb:mariadb
 
@@ -65,7 +65,6 @@ MARIADB_SERVER_PLUGINS := \
 	auth_ed25519 \
 	auth_gssapi \
 	auth_pam \
-	client_ed25519 \
 	disks \
 	feedback \
 	file_key_management \
@@ -98,7 +97,6 @@ plugin-auth_gssapi_client       := PLUGIN_AUTH_GSSAPI_CLIENT
 plugin-auth_ed25519             := PLUGIN_AUTH_ED25519
 plugin-auth_gssapi              := PLUGIN_AUTH_GSSAPI
 plugin-auth_pam                 := PLUGIN_AUTH_PAM
-plugin-client_ed25519           := PLUGIN_CLIENT_ED25519
 plugin-disks                    := PLUGIN_DISKS
 plugin-feedback                 := PLUGIN_FEEDBACK
 plugin-file_key_management      := PLUGIN_FILE_KEY_MANAGEMENT
@@ -523,6 +521,7 @@ define Package/libmariadb/install
 	$(INSTALL_DIR) $(1)$(PLUGIN_DIR)
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{mariadb,mysqlclient}*.so* $(1)/usr/lib
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/caching_sha2_password.so $(1)$(PLUGIN_DIR)
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/client_ed25519.so $(1)$(PLUGIN_DIR)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/dialog.so $(1)$(PLUGIN_DIR)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/mysql_clear_password.so $(1)$(PLUGIN_DIR)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(PLUGIN_DIR)/sha256_password.so $(1)$(PLUGIN_DIR)
@@ -617,7 +616,6 @@ $(eval $(call BuildPlugin,libmariadb,auth_gssapi_client,+krb5-libs))
 $(eval $(call BuildPlugin,mariadb-server,auth_ed25519,))
 $(eval $(call BuildPlugin,mariadb-server,auth_gssapi,+krb5-libs))
 $(eval $(call BuildPlugin,mariadb-server,auth_pam,+libpam))
-$(eval $(call BuildPlugin,mariadb-server,client_ed25519,))
 $(eval $(call BuildPlugin,mariadb-server,disks,))
 $(eval $(call BuildPlugin,mariadb-server,feedback,))
 $(eval $(call BuildPlugin,mariadb-server,file_key_management,))

--- a/utils/mariadb/patches/100-fix_hostname.patch
+++ b/utils/mariadb/patches/100-fix_hostname.patch
@@ -1,6 +1,6 @@
 --- a/scripts/mysql_install_db.sh
 +++ b/scripts/mysql_install_db.sh
-@@ -403,7 +403,7 @@ fi
+@@ -410,7 +410,7 @@ fi
  
  
  # Try to determine the hostname

--- a/utils/mariadb/patches/130-c11_atomics.patch
+++ b/utils/mariadb/patches/130-c11_atomics.patch
@@ -46,7 +46,7 @@ Author: Vicențiu Ciorbaru <vicentiu@mariadb.org>
 +++ b/include/atomic/gcc_builtins.h
 @@ -16,6 +16,7 @@
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335  USA */
  
 +#if defined (HAVE_GCC_ATOMIC_BUILTINS)
  #define make_atomic_add_body(S)                     \

--- a/utils/mariadb/patches/140-mips-connect-unaligned.patch
+++ b/utils/mariadb/patches/140-mips-connect-unaligned.patch
@@ -189,7 +189,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
    CheckType(pv)
    TYPE *lp = ((TYPBLK*)pv)->Typp;
  
--  for (register int i = k; i < n; i++)          // TODO
+-  for (int i = k; i < n; i++)          // TODO
 -    Typp[i] = lp[i];
 +  memcpy(Typp + k, lp + k, sizeof(TYPE) * n);
  

--- a/utils/mariadb/patches/170-ppc-remove-glibc-dep.patch
+++ b/utils/mariadb/patches/170-ppc-remove-glibc-dep.patch
@@ -27,7 +27,7 @@ directly was the first solution adopted in MariaDB [2].
 
 --- a/storage/xtradb/include/ut0ut.h
 +++ b/storage/xtradb/include/ut0ut.h
-@@ -85,9 +85,8 @@ private:
+@@ -83,9 +83,8 @@ private:
     the YieldProcessor macro defined in WinNT.h. It is a CPU architecture-
     independent way by using YieldProcessor. */
  #  define UT_RELAX_CPU() YieldProcessor()
@@ -39,7 +39,7 @@ directly was the first solution adopted in MariaDB [2].
  # else
  #  define UT_RELAX_CPU() ((void)0) /* avoid warning for an empty statement */
  # endif
-@@ -101,9 +100,8 @@ private:
+@@ -99,9 +98,8 @@ private:
  #endif
  
  # if defined(HAVE_HMT_PRIORITY_INSTRUCTION)
@@ -53,7 +53,7 @@ directly was the first solution adopted in MariaDB [2].
  #  define UT_RESUME_PRIORITY_CPU() ((void)0)
 --- a/storage/innobase/include/ut0ut.h
 +++ b/storage/innobase/include/ut0ut.h
-@@ -71,9 +71,8 @@ typedef time_t	ib_time_t;
+@@ -68,9 +68,8 @@ Created 1/20/1994 Heikki Tuuri
     the YieldProcessor macro defined in WinNT.h. It is a CPU architecture-
     independent way by using YieldProcessor. */
  # define UT_RELAX_CPU() YieldProcessor()
@@ -65,7 +65,7 @@ directly was the first solution adopted in MariaDB [2].
  #else
  # define UT_RELAX_CPU() do { \
       volatile int32	volatile_var; \
-@@ -91,9 +90,8 @@ typedef time_t	ib_time_t;
+@@ -88,9 +87,8 @@ Created 1/20/1994 Heikki Tuuri
  #endif
  
  #if defined(HAVE_HMT_PRIORITY_INSTRUCTION)

--- a/utils/mariadb/patches/180-libedit.patch
+++ b/utils/mariadb/patches/180-libedit.patch
@@ -24,7 +24,7 @@ Date:   Sun Dec 9 21:19:24 2018 +0100
 
 --- a/client/mysql.cc
 +++ b/client/mysql.cc
-@@ -2577,7 +2577,7 @@ C_MODE_END
+@@ -2578,7 +2578,7 @@ C_MODE_END
    if not.
  */
  
@@ -33,7 +33,7 @@ Date:   Sun Dec 9 21:19:24 2018 +0100
  static int fake_magic_space(int, int);
  extern "C" char *no_completion(const char*,int)
  #elif defined(USE_LIBEDIT_INTERFACE)
-@@ -2659,7 +2659,7 @@ static int not_in_history(const char *li
+@@ -2660,7 +2660,7 @@ static int not_in_history(const char *li
  }
  
  
@@ -42,7 +42,7 @@ Date:   Sun Dec 9 21:19:24 2018 +0100
  static int fake_magic_space(int, int)
  #else
  static int fake_magic_space(const char *, int)
-@@ -2676,7 +2676,7 @@ static void initialize_readline (char *n
+@@ -2677,7 +2677,7 @@ static void initialize_readline (char *n
    rl_readline_name = name;
  
    /* Tell the completer that we want a crack first. */
@@ -51,7 +51,7 @@ Date:   Sun Dec 9 21:19:24 2018 +0100
    rl_attempted_completion_function= (rl_completion_func_t*)&new_mysql_completion;
    rl_completion_entry_function= (rl_compentry_func_t*)&no_completion;
  
-@@ -2706,7 +2706,7 @@ static char **new_mysql_completion(const
+@@ -2707,7 +2707,7 @@ static char **new_mysql_completion(const
                                     int end __attribute__((unused)))
  {
    if (!status.batch && !quick)


### PR DESCRIPTION
mariadb: security bump to 10.2.26

New upstream release. Addresses:

  CVE-2019-2805
  CVE-2019-2740
  CVE-2019-2739
  CVE-2019-2737
  CVE-2019-2758

Package updates:

  - includes "THIRDPARTY" in PKG_LICENSE_FILES
  - drops client_ed25519 as a dynamic plugin and install it with the lib
    as per upstream decision
  - refreshes patches

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: ath79, master, dir-825-c1
Run tested: ath79, master, dir-825-c1, create table, create user, add data into table, read from table
Description:
Hi all, security bump for mariadb.

Kind regards,
Seb