### PR TITLE
mariadb (18.06): security bump to 10.1.41

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
-PKG_VERSION:=10.1.39
+PKG_VERSION:=10.1.41
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -18,7 +18,7 @@ PKG_SOURCE_URL := \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/$(PKG_NAME)-$(PKG_VERSION)/source \
 	https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
 
-PKG_HASH:=6ebaa9424707b8f45ad45eaad37df0d39e77fc965309786d298d6baf3bd93a7e
+PKG_HASH:=2b47c3afdae81eab2b9c29ba6a10328acb8d07166e8112744f6d704cc70100f2
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING

--- a/utils/mariadb/patches/100-fix_hostname.patch
+++ b/utils/mariadb/patches/100-fix_hostname.patch
@@ -1,6 +1,6 @@
 --- a/scripts/mysql_install_db.sh
 +++ b/scripts/mysql_install_db.sh
-@@ -398,7 +398,7 @@ fi
+@@ -405,7 +405,7 @@ fi
  
  
  # Try to determine the hostname

--- a/utils/mariadb/patches/130-c11_atomics.patch
+++ b/utils/mariadb/patches/130-c11_atomics.patch
@@ -46,7 +46,7 @@ Author: Vicențiu Ciorbaru <vicentiu@mariadb.org>
 +++ b/include/atomic/gcc_builtins.h
 @@ -16,6 +16,7 @@
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335  USA */
  
 +#if defined (HAVE_GCC_ATOMIC_BUILTINS)
  #define make_atomic_add_body(S)                     \
@@ -76,7 +76,7 @@ Author: Vicențiu Ciorbaru <vicentiu@mariadb.org>
 --- a/include/atomic/nolock.h
 +++ b/include/atomic/nolock.h
 @@ -17,7 +17,7 @@
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335  USA */
  
  #if defined(__i386__) || defined(_MSC_VER) || defined(__x86_64__)   \
 -    || defined(HAVE_GCC_ATOMIC_BUILTINS) \

--- a/utils/mariadb/patches/140-mips-connect-unaligned.patch
+++ b/utils/mariadb/patches/140-mips-connect-unaligned.patch
@@ -189,7 +189,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
    CheckType(pv)
    TYPE *lp = ((TYPBLK*)pv)->Typp;
  
--  for (register int i = k; i < n; i++)          // TODO
+-  for (int i = k; i < n; i++)          // TODO
 -    Typp[i] = lp[i];
 +  memcpy(Typp + k, lp + k, sizeof(TYPE) * n);
  

--- a/utils/mariadb/patches/170-ppc-remove-glibc-dep.patch
+++ b/utils/mariadb/patches/170-ppc-remove-glibc-dep.patch
@@ -27,7 +27,7 @@ directly was the first solution adopted in MariaDB [2].
 
 --- a/storage/xtradb/include/ut0ut.h
 +++ b/storage/xtradb/include/ut0ut.h
-@@ -86,8 +86,7 @@ private:
+@@ -84,8 +84,7 @@ private:
     independent way by using YieldProcessor. */
  #  define UT_RELAX_CPU() YieldProcessor()
  # elif defined(__powerpc__)
@@ -37,7 +37,7 @@ directly was the first solution adopted in MariaDB [2].
  # else
  #  define UT_RELAX_CPU() ((void)0) /* avoid warning for an empty statement */
  # endif
-@@ -101,9 +100,8 @@ private:
+@@ -99,9 +98,8 @@ private:
  #endif
  
  # if defined(HAVE_HMT_PRIORITY_INSTRUCTION)
@@ -51,7 +51,7 @@ directly was the first solution adopted in MariaDB [2].
  #  define UT_RESUME_PRIORITY_CPU() ((void)0)
 --- a/storage/innobase/include/ut0ut.h
 +++ b/storage/innobase/include/ut0ut.h
-@@ -89,8 +89,7 @@ private:
+@@ -87,8 +87,7 @@ private:
     independent way by using YieldProcessor. */
  #  define UT_RELAX_CPU() YieldProcessor()
  # elif defined(__powerpc__)
@@ -61,7 +61,7 @@ directly was the first solution adopted in MariaDB [2].
  # else
  #  define UT_RELAX_CPU() ((void)0) /* avoid warning for an empty statement */
  # endif
-@@ -104,9 +103,8 @@ private:
+@@ -102,9 +101,8 @@ private:
  #endif
  
  # if defined(HAVE_HMT_PRIORITY_INSTRUCTION)


### PR DESCRIPTION
New upstream release. Addresses:

  CVE-2019-2805
  CVE-2019-2740
  CVE-2019-2739
  CVE-2019-2737

Package updates:

  - refreshes patches

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: ar71xx, 18.06, dir-825-c1
Run tested: N/A, no 18.06 device for testing available right now. But I don't expect any surprise in this minor version bump.
Description:
Hi all, security bump for mariadb.

Kind regards,
Seb