### PR TITLE
node: fix host build error on macOS

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
 PKG_VERSION:=v8.16.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_SOURCE:=node-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/${PKG_VERSION}
 PKG_HASH:=3515e8e01568a5dc4dff3d91a76ebc6724f5fa2fbb58b4b0c5da7b178a2f7340
@@ -103,7 +103,7 @@ CONFIGURE_ARGS:= \
 HOST_CONFIGURE_VARS:=
 
 HOST_CONFIGURE_ARGS:= \
-	--dest-os=linux \
+	--dest-os=$(if $(findstring Darwin,$(HOST_OS)),mac,linux) \
 	--without-snapshot \
 	--prefix=$(STAGING_DIR_HOSTPKG)
 

--- a/lang/node/patches/007-fix_host_build_on_macos.patch
+++ b/lang/node/patches/007-fix_host_build_on_macos.patch
@@ -1,0 +1,11 @@
+--- a/tools/gyp/pylib/gyp/generator/make.py
++++ b/tools/gyp/pylib/gyp/generator/make.py
+@@ -174,7 +174,7 @@
+ 
+ LINK_COMMANDS_MAC = """\
+ quiet_cmd_alink = LIBTOOL-STATIC $@
+-cmd_alink = rm -f $@ && ./gyp-mac-tool filter-libtool libtool $(GYP_LIBTOOLFLAGS) -static -o $@ $(filter %.o,$^)
++cmd_alink = rm -f $@ && ./gyp-mac-tool filter-libtool /usr/bin/libtool $(GYP_LIBTOOLFLAGS) -static -o $@ $(filter %.o,$^)
+ 
+ quiet_cmd_link = LINK($(TOOLSET)) $@
+ cmd_link = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o "$@" $(LD_INPUTS) $(LIBS)


### PR DESCRIPTION
node: fix host build error on macOS

Maintainer: @blogic @ianchi
Compile tested: head r10641-1d2b2e744e, arm_cortex-a9+vfpv3, mipsel
Run tested: mipsel

Description:
fix host build error on macOS
reference: https://github.com/openwrt/packages/issues/9616

Related: https://github.com/openwrt/packages/issues/7171
(This correspondence is necessary to build with macOS.)

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
