### PR TITLE
libredblack: Update to 1.3

### DIFF
--- a/libs/libredblack/Makefile
+++ b/libs/libredblack/Makefile
@@ -8,23 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libredblack
-PKG_VERSION:=0.2.3
-PKG_RELEASE=$(PKG_SOURCE_VERSION)
+PKG_VERSION:=1.3
+PKG_RELEASE:=1
 
-PKG_LICENSE:=GPL-2.0+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@SF/libredblack
+PKG_HASH:=a0ecc59b0aae2df01558a6950532c711a782a099277b439a51d270003092f44f
+
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=a399310d99b61eec4d3c0677573ab5dddcf9395d
-PKG_MIRROR_HASH:=71b05e70988b97865f734c698dd5564e349680556ccb8634a5bddf344012f22a
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/sysrepo/libredblack.git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION)
-
-PKG_BUILD_ROOT:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
-PKG_BUILD_DIR:=$(PKG_BUILD_ROOT)
-
-PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
@@ -35,12 +29,14 @@ define Package/libredblack
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=RedBlack tree library
-  URL:=$(PKG_SOURCE_URL)
+  URL:=http://libredblack.sourceforge.net/
 endef
 
 define Package/libredblack/description
  RedBlack Balanced Tree Searching and Sorting Library.
 endef
+
+CONFIGURE_ARGS += --without-rbgen
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
Technically the same version, but this uses the normal tarball instead of
a random GitHub repository.

Cleaned up Makefile as a result.

Removed Python dependency. rbgen is not used for the package.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mislavn
Compile tested: arc700

This python usage is causing long range build failures since the switch to Python 3.

https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/libredblack/compile.txt
https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/sysrepo/compile.txt
https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/Netopeer2/compile.txt
