### PR TITLE
findutils: Add missing header

### DIFF
--- a/utils/findutils/Makefile
+++ b/utils/findutils/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (C) 2006-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
@@ -10,12 +10,13 @@ PKG_NAME:=findutils
 PKG_VERSION:=4.6.0
 PKG_RELEASE:=3
 
-PKG_LICENSE:=GPL-3.0+
-
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
 PKG_HASH:=ded4c9f73731cd48fec3b6bdaccce896473b6d8e337e9612e16cf1431bb1169d
+
 PKG_MAINTAINER:=Daniel Dickinson <cshored@thecshore.com>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/utils/findutils/Makefile
+++ b/utils/findutils/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=findutils
 PKG_VERSION:=4.6.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)

--- a/utils/findutils/patches/010-sysmacros.patch
+++ b/utils/findutils/patches/010-sysmacros.patch
@@ -1,0 +1,11 @@
+--- a/gl/lib/mountlist.c
++++ b/gl/lib/mountlist.c
+@@ -33,6 +33,8 @@
+ 
+ #include <unistd.h>
+ 
++#include <sys/sysmacros.h>
++
+ #if HAVE_SYS_PARAM_H
+ # include <sys/param.h>
+ #endif


### PR DESCRIPTION
New version of musl no longer internally includes this header.

Fixed up LICENSE information.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @cshoredaniel 
Compile tested: armeb