### PR TITLE
libsigar: Add missing header

### DIFF
--- a/libs/libsigar/Makefile
+++ b/libs/libsigar/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=libsigar
 PKG_SOURCE_DATE:=2017-02-21
 PKG_SOURCE_VERSION:=a6c61edf8c64e013411e8c9d753165cd03102c6e
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/boundary/sigar

--- a/libs/libsigar/patches/020-sysmacros.patch
+++ b/libs/libsigar/patches/020-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/src/os/linux/linux_sigar.c
++++ b/src/os/linux/linux_sigar.c
+@@ -23,6 +23,7 @@
+ #include <linux/param.h>
+ #include <sys/param.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <sys/times.h>
+ #include <sys/utsname.h>
+ #include <mntent.h>


### PR DESCRIPTION
The new version of musl does not include this header internally anymore.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ammubhave 
Compile tested: armeb

https://downloads.openwrt.org/snapshots/faillogs/armeb_xscale/packages/libsigar/compile.txt