### PR TITLE
gcc: fix build on x86 targets

### DIFF
--- a/devel/gcc/Makefile
+++ b/devel/gcc/Makefile
@@ -24,7 +24,7 @@ endef
 PKG_NAME:=gcc
 # PKG_VERSION=7.3.0
 PKG_VERSION=7.4.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_SOURCE_URL:=@GNU/gcc/gcc-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_INSTALL:=1
@@ -147,6 +147,7 @@ define Build/Configure
 			--disable-libvtv \
 			--disable-libcilkrts \
 			--disable-libmudflap \
+			--disable-libmpx \
 			--disable-multilib \
 			--disable-libgomp \
 			--disable-libquadmath \


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (mips, arm, i386 openwrt-19.07))

Description:
disable libmpx so package will build on x86 targets
fixes https://github.com/openwrt/packages/issues/9526
