### PR TITLE
frp: update to 0.28.0

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
-PKG_VERSION:=0.27.0
-PKG_RELEASE:=2
+PKG_VERSION:=0.28.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=5d2efd5d924c7a7f84a9f2838de6ab9b7d5ca070ab243edd404a5ca80237607c
+PKG_HASH:=61afbd0e84fc1ab92eacce5a642e2590d1b8c1a972a78f6499165c1778aa62cf
 
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/net/frp/files/frpc.config
+++ b/net/frp/files/frpc.config
@@ -8,7 +8,7 @@ config init
 #	https://github.com/fatedier/frp#configuration-file-template
 #	list env 'ENV_NAME=value'
 #	Config files include in temporary config file.
-#	list conf_inc '/etc/frp/frps.d/frpc_full.ini'
+#	list conf_inc '/etc/frp/frpc.d/frpc_full.ini'
 
 config conf 'common'
 	option server_addr 127.0.0.1


### PR DESCRIPTION
Maintainer: me
Compile tested: mt7621, x86-64 snapshot
Run tested: x86-64 snapshot, starts with default config

Description:
frp: update to 0.28.0
and fix a typo in frpc.config