### PR TITLE
[19.07] btrfs-progs: Update to version 5.2.1

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -44,8 +44,8 @@ define Package/btrfs-progs/config
 	source "$(SOURCE)/Config.in"
 endef
 
-progs = btrfs btrfs-find-root btrfs-image btrfs-map-logical \
-	btrfs-select-super btrfstune mkfs.btrfs
+boxprogs = btrfsck mkfs.btrfs btrfs-image btrfstune btrfs-find-root
+progs = btrfs-map-logical btrfs-select-super
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections -Wl,--as-needed
@@ -61,6 +61,10 @@ ifneq ($(CONFIG_BTRFS_PROGS_ZSTD),y)
 CONFIGURE_ARGS += --disable-zstd
 endif
 
+MAKE_INSTALL_FLAGS += BUILD_PROGRAMS=0
+
+Build/Compile=$(call Build/Compile/Default,btrfs.box $(progs))
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
@@ -72,8 +76,9 @@ define Package/btrfs-progs/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libbtrfs.so* $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libbtrfsutil.so* $(1)/usr/lib
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(addprefix $(PKG_INSTALL_DIR)/usr/bin/, $(progs)) $(1)/usr/bin/
-	$(LN) btrfs $(1)/usr/bin/btrfsck
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/btrfs.box $(1)/usr/bin/btrfs
+	$(foreach prog,$(boxprogs),$(LN) btrfs $(1)/usr/bin/$(prog);)
+	$(foreach prog,$(progs),$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(prog) $(1)/usr/bin/;)
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/btrfs-scan.init $(1)/etc/init.d/btrfs-scan
 endef

--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -79,8 +79,8 @@ define Package/btrfs-progs/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/btrfs.box $(1)/usr/bin/btrfs
 	$(foreach prog,$(boxprogs),$(LN) btrfs $(1)/usr/bin/$(prog);)
 	$(foreach prog,$(progs),$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(prog) $(1)/usr/bin/;)
-	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) ./files/btrfs-scan.init $(1)/etc/init.d/btrfs-scan
+	$(INSTALL_DIR) $(1)/lib/preinit
+	$(INSTALL_BIN) ./files/btrfs-scan.init $(1)/lib/preinit/85_btrfs_scan
 endef
 
 $(eval $(call BuildPackage,btrfs-progs))

--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -6,16 +6,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
-PKG_VERSION:=4.20.2
-PKG_RELEASE:=3
+PKG_VERSION:=5.2.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs
-PKG_HASH:=890f8b7e162f2bbfaa5c7b23e8b6f791fd3f325239a0510871fa4b45e4a80e7c
+PKG_HASH:=36ac4a0198ffff79d5800c537ea4b19769a8fd3ad870f75413d25b20e2d83233
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Karel Kočí <karel.koci@nic.cz>
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
@@ -28,9 +28,9 @@ define Package/btrfs-progs
   SECTION:=utils
   CATEGORY:=Utilities
   SUBMENU:=Filesystem
-  DEPENDS:=+libattr +libuuid +zlib +libblkid +liblzo +libpthread +BTRFS_PROGS_ZSTD:libzstd
   TITLE:=Btrfs filesystems utilities
   URL:=https://btrfs.wiki.kernel.org/
+  DEPENDS:=+libattr +libuuid +zlib +libblkid +liblzo +libpthread +BTRFS_PROGS_ZSTD:libzstd
 endef
 
 define Package/btrfs-progs/description

--- a/utils/btrfs-progs/files/btrfs-scan.init
+++ b/utils/btrfs-progs/files/btrfs-scan.init
@@ -1,9 +1,7 @@
-#!/bin/sh /etc/rc.common
-# Copyright (C) 2014 OpenWrt.org
+#!/bin/sh
 
-START=19
-
-start() {
-	grep -q btrfs /proc/filesystems && /usr/bin/btrfs device scan
+preinit_btrfs_scan() {
+	grep -vq btrfs /proc/filesystems || btrfs device scan
 }
 
+boot_hook_add preinit_main preinit_btrfs_scan


### PR DESCRIPTION
Maintainer: @Cynerd 
Compile tested: Turris MOX, cortexa53, OpenWrt 19.07
Run tested: Turris MOX, cortexa53, OpenWrt 19.07

Description:

- Bump to version 5.2.1
Changes: https://git.kernel.org/pub/scm/linux/kernel/git/kdave/btrfs-progs.git/tree/CHANGES
- Move Depends under URL
- Fix PKG_LICENSE to use correct SPDX License Identifier instead of
deprecated one


