### PR TITLE
yggdrasil: bump to 0.3.6

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -1,16 +1,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
-PKG_VERSION:=0.3.5
-PKG_RELEASE:=4
+PKG_VERSION:=0.3.6
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=2c69029adeb053ad049e90f1e4b7efa986094779868da77464d3c869984e861b
+PKG_HASH:=dc1699064319f19a64ac57bac366a15d718008fdb75ef03bf4252d3552dff4eb
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-go-$(PKG_VERSION)
 
-PKG_LICENSE:=GPL-3.0
 PKG_MAINTAINER:=William Fleurant <meshnet@protonmail.com>
+PKG_LICENSE:=GPL-3.0-or-later
 
 PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Signed-off-by: William Fleurant <meshnet@protonmail.com>

Maintainer: @wfleurant
Compile tested: x86/64, snapshots
Run tested: x86/64, snapshots

Description: bump version to 0.3.6
