### PR TITLE
phantap: new version

### DIFF
--- a/net/phantap/Makefile
+++ b/net/phantap/Makefile
@@ -11,9 +11,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/nccgroup/phantap
-PKG_SOURCE_DATE:=2019.07.30
-PKG_SOURCE_VERSION:=dccee924f005213c8b1c84e05900ed0bbfac5736
-PKG_MIRROR_HASH:=456adfcc0147f3b47d2fad26938e2896096919f053f871c1319218e7d37c6d27
+PKG_SOURCE_DATE:=2019.08.04
+PKG_SOURCE_VERSION:=f104742cf489b2b916a2cf9e2ee980259b89efe7
+PKG_MIRROR_HASH:=ebe090dbfeb0ef928b28a15c17290abbcdee043e77f38bd38acaabe38f2b685e
 
 PKG_MAINTAINER:=Diana Dragusin <diana.dragusin@nccgroup.com>, \
     Etienne Champetier <champetier.etienne@gmail.com>


### PR DESCRIPTION
Maintainer: me
Compile & run tested: ar71xx GL-AR150 / OpenWrt SNAPSHOT r10675+1-c070662980

Description:
```
This includes a major bug fix (2ed9c76) and some minor fixes/improvements

f104742 phantap-learn: do not use proto for ip neigh
9849b0f phantap-learn: cleanup
159653d Readme.md: update install instructions
ff3acc2 phantap: add support for talking to victim.
2ed9c76 phantap: Fix MAC snat
f6f2d2d Phantap: fix dns configuration
40fa14b phantap: look at DNS response instead of request
0d62deb Improve Readme
```

(running the checks then merging)