### PR TITLE
[OpenWrt 18.06] subversion: update to version 1.10.6

### DIFF
--- a/net/subversion/Makefile
+++ b/net/subversion/Makefile
@@ -8,21 +8,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=subversion
+PKG_VERSION:=1.10.6
 PKG_RELEASE:=1
-PKG_VERSION:=1.10.0
+
 PKG_SOURCE_URL:=@APACHE/subversion
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=2cf23f3abb837dea0585a6b0ebd70e80e01f95bddef7c1aa097c18e3eaa6b584
+PKG_HASH:=18c8e72691e6d2e7d3137ae4ad98b9f8977cca5eb2504fab48d55e584b10eca7
+
+PKG_MAINTAINER:=Val Kulkov <val.kulkov@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Val Kulkov <val.kulkov@gmail.com>
 
 PKG_FIXUP:=autoreconf
 PKG_MACRO_PATHS:=build/ac-macros
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
-
 
 define Package/subversion/Default
   SECTION:=net
@@ -31,15 +32,15 @@ define Package/subversion/Default
   TITLE:=A compelling replacement for CVS
   DEPENDS:=+zlib +libsqlite3 +PACKAGE_unixodbc:unixodbc +libapr +libaprutil +libmagic \
   	$(ICONV_DEPENDS) $(INTL_DEPENDS)
-  URL:=http://subversion.apache.org/
+  URL:=https://subversion.apache.org/
 endef
 
 define Package/subversion/Default/description
-	Subversion is a free/open-source version control system. That is,
-	Subversion manages files and directories, and the changes made to them,
-	over time. This allows you to recover older versions of your data, or
-	examine the history of how your data changed. In this regard, many
-	people think of a version control system as a sort of time machine.
+  Subversion is a free/open-source version control system. That is,
+  Subversion manages files and directories, and the changes made to them,
+  over time. This allows you to recover older versions of your data, or
+  examine the history of how your data changed. In this regard, many
+  people think of a version control system as a sort of time machine.
 endef
 
 define Package/subversion-libs


### PR DESCRIPTION
Maintainer: @val-kulkov 
Compile tested: openwrt-sdk-18.06.4-mvebu-cortexa53_gcc-7.3.0_musl.Linux-x86_64.tar.xz
Run tested: Turris MOX, cortexa53, OpenWrt 18.06.04

Release 1.10 is LTS version instead of regular release like 1.12 (OpenWrt 19.07 and master), which is supported just for 6 month. LTS versions are released once per two years and supported for 4 years.
The next LTS release will be approx. in [April 2020](https://subversion.apache.org/roadmap.html#release-planning).

Changelog between 1.10.0 and 1.10.6 can be found here:
https://svn.apache.org/repos/asf/subversion/tags/1.10.6/CHANGES

**Most interesting changes:**
Fixes CVEs
- [CVE-2018-11782](https://nvd.nist.gov/vuln/detail/CVE-2018-11782)
- [CVE-2019-0203](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-0203)
- [CVE-2018-11803](https://nvd.nist.gov/vuln/detail/CVE-2018-11803)

**Other misc changes:**
- Fixes indentation in Makefile
- Reorder some things in Makefile to be sync with other packages
- Use HTTPS in URL