### PR TITLE
subversion: polish Makefile

### DIFF
--- a/net/subversion/Makefile
+++ b/net/subversion/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=subversion
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=1.12.2
 PKG_SOURCE_URL:=@APACHE/subversion
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -14,6 +14,7 @@ PKG_HASH:=3bd0b5c8e4c5175263dc9a92fd9aef94ce917e80af034f26fe5c45fde7e0f771
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Val Kulkov <val.kulkov@gmail.com>
+PKG_CPE_ID:=cpe:/a:apache:subversion
 
 PKG_FIXUP:=autoreconf
 PKG_MACRO_PATHS:=build/ac-macros
@@ -35,11 +36,11 @@ define Package/subversion/Default
 endef
 
 define Package/subversion/Default/description
-	Subversion is a free/open-source version control system. That is,
-	Subversion manages files and directories, and the changes made to them,
-	over time. This allows you to recover older versions of your data, or
-	examine the history of how your data changed. In this regard, many
-	people think of a version control system as a sort of time machine.
+  Subversion is a free/open-source version control system. That is,
+  Subversion manages files and directories, and the changes made to them,
+  over time. This allows you to recover older versions of your data, or
+  examine the history of how your data changed. In this regard, many
+  people think of a version control system as a sort of time machine.
 endef
 
 define Package/subversion-libs


### PR DESCRIPTION
Maintainer: @val-kulkov 
Compile tested: N/A
Run tested: N/A

Description:
This PR adds PKG_CPE_ID to Makefile variables since version  1.12.2 fixed two security issues 
[Release note](https://lists.apache.org/thread.html/a11ea71fec1a1bc5bd31951911f1db05b17a173c730ea0fdf116b319@%3Cannounce.subversion.apache.org%3E) and polishes Makefile similarly to https://github.com/openwrt/packages/pull/9666

Changes:
Polish variable order 
Add PKG_CPE_ID

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>

