### PR TITLE
banip: update 0.1.5

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.1.4
+PKG_VERSION:=0.1.5
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/banip/files/README.md
+++ b/net/banip/files/README.md
@@ -14,8 +14,8 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 * supports blocking by ASN numbers
 * supports blocking by iso country codes
 * supports local white & blacklist (IPv4, IPv6 & CIDR notation), located by default in /etc/banip/banip.whitelist and /etc/banip/banip.blacklist
-* auto-add unsuccessful ssh login attempts to local blacklist
-* auto-add the uplink subnet to local whitelist
+* auto-add unsuccessful ssh login attempts to local blacklist (see 'ban_autoblacklist' option)
+* auto-add the uplink subnet to local whitelist (see 'ban_autowhitelist' option)
 * per source configuration of SRC (incoming) and DST (outgoing)
 * integrated IPSet-Lookup
 * integrated RIPE-Lookup
@@ -54,7 +54,7 @@ IP address blocking is commonly used to protect against brute force attacks, pre
     * ban\_iface => space separated list of WAN network interface(s)/device(s) used by banIP (default: automatically set by banIP ('ban_automatic'))
 
 * the following options apply to the 'extra' config section:
-    * ban\_debug => enable/disable banIP debug output (default: '0', disabled)
+    * ban\_debug => enable/disable banIP debug output (bool/default: '0', disabled)
     * ban\_nice => set the nice level of the banIP process and all sub-processes (int/default: '0', standard priority)
     * ban\_triggerdelay => additional trigger delay in seconds before banIP processing begins (int/default: '2')
     * ban\_backup => create compressed blocklist backups, they will be used in case of download errors or during startup in 'backup mode' (bool/default: '0', disabled)
@@ -62,6 +62,8 @@ IP address blocking is commonly used to protect against brute force attacks, pre
     * ban\_backupboot => do not automatically update blocklists during startup, use their backups instead (bool/default: '0', disabled)
     * ban\_maxqueue => size of the download queue to handle downloads & IPSet processing in parallel (int/default: '8')
     * ban\_fetchparm => special config options for the download utility (default: not set)
+    * ban\_autoblacklist => store auto-addons temporary in ipset and permanently in local blacklist as well (bool/default: '1', enabled)
+    * ban\_autowhitelist => store auto-addons temporary in ipset and permanently in local whitelist as well (bool/default: '1', enabled)
 
 ## Examples
 **receive banIP runtime information:**

--- a/net/banip/files/banip.conf
+++ b/net/banip/files/banip.conf
@@ -1,5 +1,3 @@
-# banIP configuration, for further information
-# see 'https://github.com/openwrt/packages/blob/master/net/banip/files/README.md'
 
 config banip 'global'
 	option ban_enabled '0'
@@ -88,14 +86,6 @@ config source 'yoyo'
 	option ban_src 'http://pgl.yoyo.org/adservers/iplist.php?ipformat=plain&showintro=0&mimetype=plaintext'
 	option ban_src_desc 'IP blocklist provided by Peter Lowe (IPv4)'
 	option ban_src_rset '/^(([0-9]{1,3}\.){3}[0-9]{1,3})([[:space:]]|$)/{print \"add yoyo \"\$1}'
-	option ban_src_settype 'ip'
-	option ban_src_ruletype 'src'
-	option ban_src_on '0'
-
-config source 'zeus'
-	option ban_src 'https://zeustracker.abuse.ch/blocklist.php?download=ipblocklist'
-	option ban_src_desc 'Zeus Tracker by abuse.ch (IPv4)'
-	option ban_src_rset '/^(([0-9]{1,3}\.){3}[0-9]{1,3})([[:space:]]|$)/{print \"add zeus \"\$1}'
 	option ban_src_settype 'ip'
 	option ban_src_ruletype 'src'
 	option ban_src_on '0'

--- a/net/banip/files/banip.init
+++ b/net/banip/files/banip.init
@@ -50,7 +50,6 @@ reload_service()
 stop_service()
 {
 	rc_procd "${ban_script}" stop
-	rc_procd start_service
 }
 
 status()

--- a/net/banip/files/banip.sh
+++ b/net/banip/files/banip.sh
@@ -10,7 +10,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-ban_ver="0.1.4"
+ban_ver="0.1.5"
 ban_sysver="unknown"
 ban_enabled=0
 ban_automatic="1"
@@ -21,6 +21,8 @@ ban_backup=0
 ban_backupboot=0
 ban_backupdir="/mnt"
 ban_maxqueue=4
+ban_autoblacklist=1
+ban_autowhitelist=1
 ban_fetchutil="uclient-fetch"
 ban_ip="$(command -v ip)"
 ban_ipt="$(command -v iptables)"
@@ -623,7 +625,11 @@ f_main()
 						if [ -z "$(grep -F "${ip}" "${src_url}")" ]
 						then
 							printf '%s\n' "${ip}" >> "${tmp_load}"
-							printf '%s\n' "${ip}" >> "${src_url}"
+							if { [ "${src_name//_*/}" = "blacklist" ] && [ "${ban_autoblacklist}" -eq 1 ]; } || \
+								{ [ "${src_name//_*/}" = "whitelist" ] && [ "${ban_autowhitelist}" -eq 1 ]; }
+							then
+								printf '%s\n' "${ip}" >> "${src_url}"
+							fi
 						fi
 					done
 				elif [ -n "${src_cat}" ]


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL.iNet GL-AR750S, OpenWrt SNAPSHOT r10644-cb49e46a8a

Description:
* add extra options to control auto-addons to
  blacklist & whitelist ('ban_autoblacklist' & 'ban_autowhitelist',
  both enabled by default). If disabled auto-addons are only stored
  temporary in the black/whitelist ipset but not in the list itself, fixes #9631
* remove old, no longer needed procd workaround
* remove 'zeus' source from default config (discontinued)

Signed-off-by: Dirk Brenken <dev@brenken.org>