### PR TITLE
[OpenWrt 18.06] clamav: update to version 0.100.3

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clamav
-PKG_VERSION:=0.100.0
+PKG_VERSION:=0.100.3
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
@@ -17,7 +17,7 @@ PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr> \
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.clamav.net/downloads/production/
-PKG_HASH:=c5c5edaf75a3c53ac0f271148fd6447310bce53f448ec7e6205124a25918f65c
+PKG_HASH:=5160cdf876c761a7d611f158b7c774ebbbe25856b7c230d9c4e142015e8d3024
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -31,7 +31,7 @@ define Package/clamav/Default
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
   TITLE:=ClamAV
-  URL:=http://www.clamav.net/
+  URL:=https://www.clamav.net/
 endef
 
 define Package/clamav

--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -11,13 +11,15 @@ PKG_NAME:=clamav
 PKG_VERSION:=0.100.3
 PKG_RELEASE:=1
 
-PKG_LICENSE:=GPL-2.0
-PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr> \
-		Lucian Cristian <lucian.cristian@gmail.com>
-
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.clamav.net/downloads/production/
 PKG_HASH:=5160cdf876c761a7d611f158b7c774ebbbe25856b7c230d9c4e142015e8d3024
+
+PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr> \
+		Lucian Cristian <lucian.cristian@gmail.com>
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING*
+PKG_CPE_ID:=cpe:/a:clamav:clamav
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -56,33 +58,35 @@ endef
 define Package/clamav/conffiles
 endef
 
+CONFIGURE_ARGS += \
+	--sysconfdir=/etc/clamav/ \
+	--disable-bzip2 \
+	--disable-check \
+	--disable-clamdtop \
+	--disable-rpath \
+	--disable-xml \
+	--disable-zlib-vcheck \
+	--with-user=nobody \
+	--with-group=nogroup \
+	--with-libcurl="$(STAGING_DIR)/usr/" \
+	--with-libjson="$(STAGING_DIR)/usr/" \
+	--with-openssl="$(STAGING_DIR)/usr/" \
+	--with-pcre="$(STAGING_DIR)/usr/" \
+	--with-zlib="$(STAGING_DIR)/usr/" \
+	--without-xml \
+	--without-iconv \
+	--without-libncurses-prefix
+
 CONFIGURE_VARS += \
-	INCLUDES="" \
-	CXXFLAGS="$$$$CXXFLAGS -fno-rtti" \
-	$(if $(CONFIG_USE_MUSL),LIBS="-lpthread -lfts",LIBS="-lpthread") \
+	ax_cv_uname_syscall=yes \
+	ac_cv_c_mmap_private=yes \
+	have_cv_gai=yes \
+	ac_cv_sys_file_offset_bits=no
 
-define Build/Configure
-	$(call Build/Configure/Default, \
-		--sysconfdir=/etc/clamav/ \
-		--prefix=/usr/ \
-		--exec-prefix=/usr/ \
-		--disable-xml \
-		--disable-bzip2 \
-		--with-user nobody \
-		--with-group nogroup \
-		--with-pcre="$(STAGING_DIR)/usr/" \
-		--with-openssl="$(STAGING_DIR)/usr/" \
-		--with-zlib="$(STAGING_DIR)/usr/" \
-		--disable-zlib-vcheck \
-		--disable-clamdtop \
-	)
-endef
+CONFIGURE_VARS += $(if $(CONFIG_IPV6),have_cv_ipv6=yes)
 
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		all install
-endef
+TARGET_CXXFLAGS += -ffunction-sections -fdata-sections -fno-rtti -flto
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed $(if $(CONFIG_USE_MUSL),-lfts)
 
 define Package/clamav/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
Maintainers: @ratkaj , @lucize 
Compile tested: Turris MOX, cortexa53, OpenWrt 18.06.04
Run tested: Turris MOX, cortexa53, OpenWrt 18.06.04

Description:
- Update to version 0.100.3.

Fixes CVEs:
[0.100.1](https://blog.clamav.net/2018/07/clamav-01001-has-been-released.html)
- [CVE-2017-16932](https://nvd.nist.gov/vuln/detail/CVE-2017-16932)
- [CVE-2018-0360](https://nvd.nist.gov/vuln/detail/CVE-2018-0360)
- [CVE-2018-0361](https://nvd.nist.gov/vuln/detail/CVE-2018-0361)

[0.100.2](https://blog.clamav.net/2018/10/clamav-01002-has-been-released.html)
- [CVE-2018-15378](https://nvd.nist.gov/vuln/detail/CVE-2018-15378)
- [CVE-2018-14680](https://nvd.nist.gov/vuln/detail/CVE-2018-14680)
- [CVE-2018-14681](https://nvd.nist.gov/vuln/detail/CVE-2018-14681)
- [CVE-2018-14682](https://nvd.nist.gov/vuln/detail/CVE-2018-14682)

[0.100.3](https://blog.clamav.net/2019/03/clamav-01012-and-01003-patches-have.html)
- [CVE-2019-1787](https://nvd.nist.gov/vuln/detail/CVE-2019-1787)
- [CVE-2019-1788](https://nvd.nist.gov/vuln/detail/CVE-2019-1788)
- [CVE-2019-1789](https://nvd.nist.gov/vuln/detail/CVE-2019-1789)

Use HTTPS in URL

