### PR TITLE
clamav: update to version 0.101.3

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -8,16 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clamav
-PKG_VERSION:=0.101.2
-PKG_RELEASE:=3
+PKG_VERSION:=0.101.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.clamav.net/downloads/production/
-PKG_HASH:=0a12ebdf6ff7a74c0bde2bdc2b55cae33449e6dd953ec90824a9e01291277634
+PKG_HASH:=68d42aac4a9cbde293288533a9a3c3d55863de38f2b8707c1ef2d987b1260338
 
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr> \
 		Lucian Cristian <lucian.cristian@gmail.com>
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING*
 PKG_CPE_ID:=cpe:/a:clamav:clamav
 


### PR DESCRIPTION
Maintainers: @ratkaj , @lucize
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:
- update to version [0.101.3](https://blog.clamav.net/2019/08/clamav-01013-security-patch-release-and.html)

> ClamAV 0.101.3 is a patch release to address a vulnerability to non-recursive zip bombs.
More details about it [here](https://bugzilla.clamav.net/show_bug.cgi?id=12356)

- correct SPDX License Identifier