### PR TITLE
intltool: fix broken compile on WSL

### DIFF
--- a/libs/intltool/Makefile
+++ b/libs/intltool/Makefile
@@ -23,7 +23,7 @@ include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 
 HOST_CONFIGURE_VARS+= \
-        PATH=$(STAGING_DIR_HOSTPKG)/bin:$(STAGING_DIR_HOSTPKG)/usr/bin:$(PATH)
+        PATH="$(STAGING_DIR_HOSTPKG)/bin:$(STAGING_DIR_HOSTPKG)/usr/bin:$(PATH)"
 
 define Package/intltool
   SECTION:=libs


### PR DESCRIPTION
If PATH contains space, like in WSL where you have also Windows dir, compilation of this package is broken.
@thess 

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
