### PR TITLE
lcdproc: Fix non x86 platforms on musl

### DIFF
--- a/utils/lcdproc/Makefile
+++ b/utils/lcdproc/Makefile
@@ -9,17 +9,16 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lcdproc
 PKG_VERSION:=0.5.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lcdproc/lcdproc/releases/download/v$(PKG_VERSION)/
 PKG_HASH:=d48a915496c96ff775b377d2222de3150ae5172bfb84a6ec9f9ceab962f97b83
+
 PKG_MAINTAINER:=Harald Geyer <harald@ccbib.org>, \
 		Philip Prindeville <philipp@redfish-solutions.com>
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING
-
-PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -109,19 +108,12 @@ This package contains display drivers with external dependencies:
 $(LCDPROC_OTHER_DRIVERS_TEXT)
 endef
 
-
-# not everything groks --disable-nls
-DISABLE_NLS:=
-
 CONFIGURE_ARGS += \
 	--disable-libX11 \
 	--disable-libhid \
 	--disable-libpng \
 	--disable-freetype \
 	--enable-drivers='all,!g15,!g15driver,!glcdlib,!irman,!lirc,!mdm166a,!mx5000,!svga,!xosd'
-
-# can't use -Wformat=2 because MUSL is somewhat broken
-TARGET_CFLAGS+=-Wall
 
 MAKE_FLAGS += \
         CFLAGS="$(TARGET_CFLAGS)" \

--- a/utils/lcdproc/patches/110-in-outb.patch
+++ b/utils/lcdproc/patches/110-in-outb.patch
@@ -1,0 +1,11 @@
+--- a/server/drivers/port.h
++++ b/server/drivers/port.h
+@@ -94,7 +94,7 @@ static inline int port_deny_multiple(unsigned short port, unsigned short count);
+ /*  ---------------------------- Linux ------------------------------------ */
+ /*  Use ioperm, inb and outb in <sys/io.h> (Linux) */
+ /*  And iopl for higher addresses of PCI LPT cards */
+-#if defined HAVE_IOPERM
++#if defined(__GLIBC__) || (defined(__x86__) || defined(__x86_64__))
+ 
+ /* Glibc2 and Glibc1 */
+ # ifdef HAVE_SYS_IO_H


### PR DESCRIPTION
Musl only specifies in/outb for x86/x86. Use the fallback path in case
musl is used.

This should fail compilation during the linking stage but for some reason
does not. Will do if -Werror=implicit-function-declaration is specified.

Fixed up license information.

Other small cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @haraldg 
Compile tested: armeb

Fixes: https://github.com/openwrt/packages/issues/9637