### PR TITLE
msmtp-scripts: Update to new official upstream; coexist with msmtp

### DIFF
--- a/mail/msmtp-scripts/Makefile
+++ b/mail/msmtp-scripts/Makefile
@@ -41,7 +41,7 @@ endef
 
 define Package/msmtpq-ng
 $(call Package/msmtp-scripts/Default)
-  DEPENDS+= @(PACKAGE_msmtp||PACKAGE_msmtp-nossl)
+  DEPENDS+= +msmtp
   TITLE+= (msmtpq-ng wrappers)
 endef
 
@@ -61,6 +61,12 @@ $(call Package/msmtp-scripts/Default)
   TITLE+= (as MTA)
   DEPENDS+=+msmtpq-ng
   USERID:=msmtp=482:msmtp=482
+  ALTERNATIVES:=\
+    400:/usr/sbin/sendmail:/usr/bin/msmtpq-ng-mta \
+    400:/usr/lib/sendmail:/usr/bin/msmtpq-ng-mta \
+    400:/usr/sbin/mailq:/usr/bin/msmtpq-ng-queue-mta \
+    400:/usr/sbin/postqueue:/usr/bin/msmtpq-ng-queue-mta \
+    400:/usr/sbin/postsuper:/usr/sin/msmtpq-ng-queue-mta
 endef
 
 define Package/msmtp-queue-mta/conffiles
@@ -126,11 +132,6 @@ define Package/msmtpq-ng-mta/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/msmtpq-ng-mta/msmtpq-ng-queue-mta $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/etc/crontabs
 	$(INSTALL_BIN) ./files/msmtpq-ng-mta.init $(1)/etc/init.d/msmtpq-ng-mta
-	ln -sf ../bin/msmtpq-ng-mta $(1)/usr/sbin/sendmail
-	ln -sf ../bin/msmtpq-ng-mta $(1)/usr/lib/sendmail
-	ln -sf ../bin/msmtpq-ng-queue-mta $(1)/usr/sbin/mailq
-	ln -sf ../bin/msmtpq-ng-queue-mta $(1)/usr/sbin/postqueue
-	ln -sf ../bin/msmtpq-ng-queue-mta $(1)/usr/sbin/postsuper
 endef
 
 define Package/msmtpq-ng-mta-smtpd/install

--- a/mail/msmtp-scripts/Makefile
+++ b/mail/msmtp-scripts/Makefile
@@ -1,7 +1,6 @@
 #
 # Copyright (C) 2009 David Cooper <dave@kupesoft.com>
-# Copyright (C) 2009-2015 OpenWrt.org
-# Copyright (C) 2016 Daniel Dickinson <cshored@thecshore.com>
+# Copyright (C) 2016-2019 Daniel Dickinson <cshored@thecshore.com>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -17,7 +16,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/msmtp-scripts
 PKG_HASH:=2aec48d47b02facf2a33cf97a7434e969c1a054224406e6c55320d825c7902b2
 
-PKG_LICENSE:=GPL-3.0+
+PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk

--- a/mail/msmtp-scripts/Makefile
+++ b/mail/msmtp-scripts/Makefile
@@ -9,12 +9,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=msmtp-scripts
-PKG_VERSION:=1.0.8
+PKG_VERSION:=1.2.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/msmtp-scripts
-PKG_HASH:=2aec48d47b02facf2a33cf97a7434e969c1a054224406e6c55320d825c7902b2
+PKG_SOURCE_URL:=https://launchpad.net/$(PKG_NAME)/1.2/$(PKG_VERSION)/+download
+PKG_HASH:=fc85ab8ed1348be584adfc1feb89f51daed7404e9e8643652ff31d2af00f1cf5
+PKG_MAINTAINER:=Daniel F. Dickinson <cshored@thecshore.com>
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
@@ -24,24 +25,20 @@ include $(INCLUDE_DIR)/package.mk
 define Package/msmtp-scripts/Default
   SECTION:=mail
   CATEGORY:=Mail
-  TITLE:=DEPRECATED: Simple sendmail SMTP queueing and forwarding
-  URL:=http://msmtp-scripts.sourceforge.net/
+  TITLE:=Forwarding only SMTP with queuing
+  URL:=https://msmtp-scripts.thecshore.com
 endef
 
 define Package/msmtp-scripts/Default/description
- DEPRECATED: SourceForge project is abandonded; and upstream (on GitHub)
- has deprecated this project. See:
- https://github.com/cshore-history/msmtp-scripts#deprecation-notice
-
  msmtp-scripts are scripts wrappers around the msmtp SMTP client that
- add queueing, logging to syslog or file, a subset of sendmail/postfix
+ add queueing, logging to syslog or file, and a subset of sendmail/postfix
  mailq/postsuper/postqueue commands implemented in a compatible fashion.
 endef
 
 define Package/msmtpq-ng
 $(call Package/msmtp-scripts/Default)
   DEPENDS+= +msmtp
-  TITLE+= (msmtpq-ng wrappers)
+  TITLE+= (common)
 endef
 
 define Package/msmtpq-ng/conffiles
@@ -59,16 +56,15 @@ define Package/msmtpq-ng-mta
 $(call Package/msmtp-scripts/Default)
   TITLE+= (as MTA)
   DEPENDS+=+msmtpq-ng
-  USERID:=msmtp=482:msmtp=482
   ALTERNATIVES:=\
-    400:/usr/sbin/sendmail:/usr/bin/msmtpq-ng-mta \
-    400:/usr/lib/sendmail:/usr/bin/msmtpq-ng-mta \
-    400:/usr/sbin/mailq:/usr/bin/msmtpq-ng-queue-mta \
-    400:/usr/sbin/postqueue:/usr/bin/msmtpq-ng-queue-mta \
-    400:/usr/sbin/postsuper:/usr/sin/msmtpq-ng-queue-mta
+    400:/usr/sbin/sendmail:/usr/sbin/msmtpq-ng-mta \
+    400:/usr/lib/sendmail:/usr/sbin/msmtpq-ng-mta \
+    400:/usr/sbin/mailq:/usr/sbin/msmtpq-ng-queue-mta \
+    400:/usr/sbin/postqueue:/usr/sbin/msmtpq-ng-queue-mta \
+    400:/usr/sbin/postsuper:/usr/sbin/msmtpq-ng-queue-mta
 endef
 
-define Package/msmtp-queue-mta/conffiles
+define Package/msmtpq-ng-mta/conffiles
 /etc/msmtpq-ng-mta.rc
 endef
 
@@ -83,7 +79,8 @@ endef
 define Package/msmtpq-ng-mta-smtpd
 $(call Package/msmtp-scripts/Default)
   DEPENDS+= +msmtpq-ng-mta +xinetd
-  TITLE+= (basic SMTP server)
+  TITLE+= (localhost SMTPd)
+  USERID:=msmtp=482:msmtp=482
 endef
 
 define Package/msmtp-ng-mta-smtpd/description
@@ -97,13 +94,13 @@ define Package/msmtp-ng-mta-smtpd/description
  the hold queue before it can be delivered.
 endef
 
-define Package/msmtpq-ng-mta/postinst
-	mkdir -p $${IPKG_INSTROOT}/etc/crontabs
-	if ! grep -q msmtpq-ng-mta $${IPKG_INSTROOT}/etc/crontabs/root; then echo $$'\n'"*/60 * * * * /usr/bin/msmtpq-ng-mta -q" >>$${IPKG_INSTROOT}/etc/crontabs/root; fi
+define Package/msmtpq-ng-mta-smtpd/conffiles
+/etc/xinetd.d/ms-mta-smtpd
 endef
 
-define Package/msmtp-queue-mta/prerm
-	if grep -q msmtpq-ng-mta $${IPKG_INSTROOT}/etc/crontabs/root; then grep -v '\*/60 \* \* \* \* /usr/bin/msmtpq-ng-mta -q' $${IPKG_INSTROOT}/etc/crontabs/root >$${IPKG_INSTROOT}/etc/crontabs/root.new; mv -f $${IPKG_INSTROOT}/etc/crontabs/root.new $${IPKG_INSTROOT}/etc/crontabs; fi
+define Package/msmtpq-ng-mta/postinst
+	mkdir -p $${IPKG_INSTROOT}/etc/crontabs
+	if ! grep -q msmtpq-ng-mta $${IPKG_INSTROOT}/etc/crontabs/root 2>/dev/null; then echo $$'\n'"*/60 * * * * /usr/bin/msmtpq-ng-mta -q" >>$${IPKG_INSTROOT}/etc/crontabs/root; fi
 endef
 
 define Build/Configure
@@ -116,26 +113,24 @@ endef
 
 define Package/msmtpq-ng/install
 	$(INSTALL_DIR) $(1)/etc
-	$(INSTALL_CONF) ./files/msmtpq-ng.rc $(1)/etc/msmtpq-ng.rc
+	$(INSTALL_DATA) ./files/msmtpq-ng.rc $(1)/etc/msmtpq-ng.rc
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_BUILD_DIR)/msmtpq-ng/msmtpq-ng $(1)/usr/bin/
-	$(SED) 's/logger -i/logger/' $(1)/usr/bin/msmtpq-ng
-	$(CP) $(PKG_BUILD_DIR)/msmtpq-ng/msmtpq-ng-queue $(1)/usr/bin/
+	$(CP) $(PKG_BUILD_DIR)/src/usr/bin/msmtpq-ng $(1)/usr/bin/
+	$(CP) $(PKG_BUILD_DIR)/src/usr/bin/msmtpq-ng-queue $(1)/usr/bin/
 endef
 
 define Package/msmtpq-ng-mta/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/sbin $(1)/usr/lib $(1)/etc/init.d
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/msmtpq-ng-mta/msmtpq-ng-mta.rc $(1)/etc/
-	echo 'MSMTP_LOCK_DIR=/var/lock/msmtp' >>$(1)/etc/msmtpq-ng-mta.rc
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/msmtpq-ng-mta/msmtpq-ng-mta $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/msmtpq-ng-mta/msmtpq-ng-queue-mta $(1)/usr/bin/
+	$(INSTALL_DATA) ./files/msmtpq-ng-mta.rc $(1)/etc/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/usr/sbin/msmtpq-ng-mta $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/usr/sbin//msmtpq-ng-queue-mta $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/crontabs
 	$(INSTALL_BIN) ./files/msmtpq-ng-mta.init $(1)/etc/init.d/msmtpq-ng-mta
 endef
 
 define Package/msmtpq-ng-mta-smtpd/install
 	$(INSTALL_DIR) $(1)/etc/xinetd.d
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/msmtpq-ng-mta/sendmail-bs.xinetd $(1)/etc/xinetd.d/msmtpq-ng-mta-smtpd
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/etc/xinetd.d/ms-mta-smtpd $(1)/etc/xinetd.d/ms-mta-smtpd
 endef
 
 

--- a/mail/msmtp-scripts/files/msmtpq-ng-mta.init
+++ b/mail/msmtp-scripts/files/msmtpq-ng-mta.init
@@ -5,13 +5,11 @@ START=90
 
 boot() {
 	[ ! -d /var/spool/msmtp ] && {
-		mkdir -m 0770 -p /var/spool/msmtp
-		chown msmtp:msmtp /var/spool/msmtp
+		mkdir -m1777 -p /var/spool/msmtp
 	}
 
 	[ ! -d /var/lock/msmtp ] && {
-		mkdir -m 0770 -p /var/lock/msmtp
-		chown msmtp:msmtp /var/lock/msmtp
+		mkdir -m1777 -p /var/lock/msmtp
 	}
 }
 

--- a/mail/msmtp-scripts/files/msmtpq-ng-mta.rc
+++ b/mail/msmtp-scripts/files/msmtpq-ng-mta.rc
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+#Q=/var/spool/msmtp/"$(id -un)"
+#LOG=syslog
+#MAXLOGLEVEL=7
+#MSMTP_LOCK_DIR=/var/lock/msmtp/"$(id -un)"
+#MSMTP_UMASK=077
+#MSMTP_LOG_UMASK=007
+#MSMTP_QUEUE_QUIET=true
+#MSMTP_IGNORE_NO_RECIPIENTS=true
+#MSMTP_QUEUE_ONLY=false
+#MSMTP_SEND_DELAY=0
+#MSMTP_MAXIMUM_QUEUE_LIFETIME=345600    # Four days
+#MSMTPQ_NG=msmtpq-ng
+#MSMTPQ_NG_QUEUE=msmtpq-ng-queue
+#MSMTP_CONF=/etc/msmtprc
+#EMAIL_CONN_TEST=p
+EMAIL_CONN_TEST_PING=openwrt.org
+#EMAIL_CONN_TEST_IP=8.8.8.8
+#EMAIL_CONN_TEST_SITE=www.debian.org
+#MSMTP_HOLD_SMTP_MAIL=true
+#MSMTP_HOLD_CLI_MAIL=false

--- a/mail/msmtp-scripts/files/msmtpq-ng.rc
+++ b/mail/msmtp-scripts/files/msmtpq-ng.rc
@@ -1,14 +1,17 @@
+#!/bin/sh
+
 #Q=~/msmtp.queue
 #LOG=~/log/.msmtp.queue.log
 #MAXLOGLEVEL=7
-#MSMTP_LOCKDIR=/var/lock
+#MSMTP_LOCK_DIR=~/.msmtp.lock
 EMAIL_CONN_TEST=p
-EMAIL_CONN_TEST_SITE=www.lede-project.org
+EMAIL_CONN_TEST_PING=openwrt.org
 #EMAIL_CONN_TEST_IP=8.8.8.8
+#EMAIL_CONN_TEST_SITE=www.debian.org
 #MSMTP_UMASK=077
 #MSMTP_LOG_UMASK=077
 #MSMTP_QUEUE_QUIET=false
-#MSMTP_IGNORE_NO_RECIPIENTS=false
+#MSMTP_IGNORE_NO_RECIPIENTS=true
 #MSMTP_QUEUE_ONLY=false
 #MSMTP_SEND_DELAY=0
 #MSMTP_MAXIMUM_QUEUE_LIFETIME=345600	# Four days
@@ -16,3 +19,5 @@ EMAIL_CONN_TEST_SITE=www.lede-project.org
 #MSMTPQ_NG_QUEUE=msmtpq-ng-queue
 #MSMTP_HOLD_SMTP_MAIL=true
 #MSMTP_HOLD_CLI_MAIL=false
+#MSMTP_CONF=/etc/msmtprc
+#LOCK_CMD=flock

--- a/mail/msmtp/Makefile
+++ b/mail/msmtp/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=msmtp
 PKG_VERSION:=1.8.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://marlam.de/msmtp/releases
@@ -49,6 +49,7 @@ $(call Package/msmtp/Default)
   DEPENDS+= +libgnutls +ca-bundle
   TITLE+= (with SSL support)
   VARIANT:=ssl
+  DEFAULT_VARIANT:=1
 endef
 
 define Package/msmtp/conffiles
@@ -64,6 +65,7 @@ define Package/msmtp-nossl
 $(call Package/msmtp/Default)
   TITLE+= (without SSL support)
   VARIANT:=nossl
+  PROVIDES:=msmtp
 endef
 
 define Package/msmtp-nossl/description
@@ -74,7 +76,10 @@ endef
 define Package/msmtp-mta
 $(call Package/msmtp/Default)
   TITLE+= (as MTA)
-  DEPENDS+=@(PACKAGE_msmtp||PACKAGE_msmtp-nossl)
+  DEPENDS+=+msmtp
+  ALTERNATIVES:=\
+	100:/usr/sbin/sendmail:/usr/bin/msmtp \
+	100:/usr/lib/sendmail:/usr/bin/msmtp
 endef
 
 define Package/msmtp-mta/description
@@ -85,7 +90,7 @@ endef
 
 define Package/msmtp-queue
 $(call Package/msmtp/Default)
-  DEPENDS+= +bash @(PACKAGE_msmtp||PACKAGE_msmtp-nossl)
+  DEPENDS+= +bash +msmtp
   TITLE+= (queue scripts)
 endef
 
@@ -119,8 +124,6 @@ endef
 
 define Package/msmtp-mta/install
 	$(INSTALL_DIR) $(1)/usr/sbin $(1)/usr/lib
-	ln -sf ../bin/msmtp $(1)/usr/sbin/sendmail
-	ln -sf ../bin/msmtp $(1)/usr/lib/sendmail
 endef
 
 Package/msmtp-nossl/conffiles = $(Package/msmtp/conffiles)


### PR DESCRIPTION
Maintainer: me / @neheb (for msmtp change)
Compile tested: ath79, CR5000, current snapshot and master packages
Run tested: same, tested queuing and sending mail from queue, tested localhost smtpd, used msmtpq-ng-mta as MTA for nut-upsmon-sendmail-notify.

Description:
The project has been revived upstream and a user has convinced me
there is a valid use case for this package in openwrt, so remove
deprecation notice, adjust links to upstream (it's moved) and
update to latest version.  Sync behavior with that expected upstream.

AND

Use the PROVIDES mechanism so that msmtp and msmtp-nossl can be be
+depended-on and avoid generating a file level conflict.  Also use
alternatives for msmtp-mta and msmtpq-ng-mta with msmtp-mta since
we can only have one sendmail at a time.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>