### PR TITLE
django packages: create django submenu

### DIFF
--- a/lang/python/django-appconf/Makefile
+++ b/lang/python/django-appconf/Makefile
@@ -39,8 +39,9 @@ define Package/python-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python-$(PKG_NAME):python \
-	+PACKAGE_python-$(PKG_NAME):python-django
+	python-django
   VARIANT:=python
+  MDEPENDS:=python-django
 endef
 
 define Package/python-$(PKG_NAME)/description
@@ -51,8 +52,9 @@ define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
-	+PACKAGE_python3-$(PKG_NAME):python3-django
+	python3-django
   VARIANT:=python3
+  MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-compressor/Makefile
+++ b/lang/python/django-compressor/Makefile
@@ -39,10 +39,11 @@ define Package/python-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python-$(PKG_NAME):python \
-	+PACKAGE_python-$(PKG_NAME):python-django \
+	python-django \
 	+PACKAGE_python-$(PKG_NAME):python-django-appconf \
 	+PACKAGE_python-$(PKG_NAME):python-rcssmin
   VARIANT:=python
+  MDEPENDS:=python-django
 endef
 
 define Package/python-$(PKG_NAME)/description
@@ -56,10 +57,11 @@ define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
-	+PACKAGE_python3-$(PKG_NAME):python3-django \
+	python3-django \
 	+PACKAGE_python3-$(PKG_NAME):python3-django-appconf \
 	+PACKAGE_python3-$(PKG_NAME):python3-rcssmin
   VARIANT:=python3
+  MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-constance/Makefile
+++ b/lang/python/django-constance/Makefile
@@ -37,8 +37,9 @@ define Package/python-django-constance
 $(call Package/python-django-constance/Default)
   DEPENDS:= \
 	+PACKAGE_python-django-constance:python \
-	+PACKAGE_python-django-constance:python-django
+	python-django
   VARIANT:=python
+  MDEPENDS:=python-django
 endef
 
 define Package/python-django-constance/description
@@ -49,8 +50,9 @@ define Package/python3-django-constance
 $(call Package/python-django-constance/Default)
   DEPENDS:= \
 	+PACKAGE_python3-django-constance:python3 \
-	+PACKAGE_python3-django-constance:python3-django
+	python3-django
   VARIANT:=python3
+  MDEPENDS:=python3-django
 endef
 
 define Package/python3-django-constance/description

--- a/lang/python/django-formtools/Makefile
+++ b/lang/python/django-formtools/Makefile
@@ -37,8 +37,9 @@ define Package/python-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python-$(PKG_NAME):python \
-	+PACKAGE_python-$(PKG_NAME):python-django
+	python-django
   VARIANT:=python
+  MDEPENDS:=python-django
 endef
 
 define Package/python-$(PKG_NAME)/description
@@ -50,8 +51,9 @@ define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
-	+PACKAGE_python3-$(PKG_NAME):python3-django
+	python3-django
   VARIANT:=python3
+  MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-jsonfield/Makefile
+++ b/lang/python/django-jsonfield/Makefile
@@ -39,8 +39,9 @@ define Package/python-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python-$(PKG_NAME):python \
-	+PACKAGE_python-$(PKG_NAME):python-django
+	python-django
   VARIANT:=python
+  MDEPENDS:=python-django
 endef
 
 define Package/python-$(PKG_NAME)/description
@@ -51,8 +52,9 @@ define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
-	+PACKAGE_python3-$(PKG_NAME):python3-django
+	python3-django
   VARIANT:=python3
+  MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-picklefield/Makefile
+++ b/lang/python/django-picklefield/Makefile
@@ -39,8 +39,9 @@ define Package/python-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python-$(PKG_NAME):python \
-	+PACKAGE_python-$(PKG_NAME):python-django
+	python-django
   VARIANT:=python
+  MDEPENDS:=python-django
 endef
 
 define Package/python-$(PKG_NAME)/description
@@ -51,8 +52,9 @@ define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
-	+PACKAGE_python3-$(PKG_NAME):python3-django
+	python3-django
   VARIANT:=python3
+  MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-postoffice/Makefile
+++ b/lang/python/django-postoffice/Makefile
@@ -39,9 +39,10 @@ define Package/python-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python-$(PKG_NAME):python \
-	+PACKAGE_python-$(PKG_NAME):python-django \
+	python-django \
 	+PACKAGE_python-$(PKG_NAME):python-django-jsonfield
   VARIANT:=python
+  MDEPENDS:=python-django
 endef
 
 define Package/python-$(PKG_NAME)/description
@@ -53,9 +54,10 @@ define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
-	+PACKAGE_python3-$(PKG_NAME):python3-django \
+	python3-django \
 	+PACKAGE_python3-$(PKG_NAME):python3-django-jsonfield
   VARIANT:=python3
+  MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-ranged-response/Makefile
+++ b/lang/python/django-ranged-response/Makefile
@@ -37,8 +37,9 @@ define Package/python-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python-$(PKG_NAME):python \
-	+PACKAGE_python-$(PKG_NAME):python-django
+	python-django
   VARIANT:=python
+  MDEPENDS:=python-django
 endef
 
 define Package/python-$(PKG_NAME)/description
@@ -49,8 +50,9 @@ define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
-	+PACKAGE_python3-$(PKG_NAME):python3-django
+	python3-django
   VARIANT:=python3
+  MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-restframework/Makefile
+++ b/lang/python/django-restframework/Makefile
@@ -39,8 +39,9 @@ define Package/python-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python-$(PKG_NAME):python \
-	+PACKAGE_python-$(PKG_NAME):python-django
+	python-django
   VARIANT:=python
+  MDEPENDS:=python-django
 endef
 
 define Package/python-$(PKG_NAME)/description
@@ -51,8 +52,9 @@ define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
-	+PACKAGE_python3-$(PKG_NAME):python3-django
+	python3-django
   VARIANT:=python3
+  MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-simple-captcha/Makefile
+++ b/lang/python/django-simple-captcha/Makefile
@@ -40,10 +40,11 @@ $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python-$(PKG_NAME):python \
 	+PACKAGE_python-$(PKG_NAME):python-six \
-	+PACKAGE_python-$(PKG_NAME):python-django \
+	python-django \
 	+PACKAGE_python-$(PKG_NAME):python-pillow \
 	+PACKAGE_python-$(PKG_NAME):python-django-ranged-response
   VARIANT:=python
+  MDEPENDS:=python-django
 endef
 
 define Package/python-$(PKG_NAME)/description
@@ -56,10 +57,11 @@ $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
 	+PACKAGE_python3-$(PKG_NAME):python3-six \
-	+PACKAGE_python3-$(PKG_NAME):python3-django \
+	python3-django \
 	+PACKAGE_python3-$(PKG_NAME):python3-pillow \
 	+PACKAGE_python3-$(PKG_NAME):python3-django-ranged-response
   VARIANT:=python3
+  MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-statici18n/Makefile
+++ b/lang/python/django-statici18n/Makefile
@@ -39,8 +39,9 @@ define Package/python-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python-$(PKG_NAME):python \
-	+PACKAGE_python-$(PKG_NAME):python-django
+	python-django
   VARIANT:=python
+  MDEPENDS:=python-django
 endef
 
 define Package/python-$(PKG_NAME)/description
@@ -51,8 +52,9 @@ define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
-	+PACKAGE_python3-$(PKG_NAME):python3-django
+	python3-django
   VARIANT:=python3
+  MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-webpack-loader/Makefile
+++ b/lang/python/django-webpack-loader/Makefile
@@ -37,8 +37,9 @@ define Package/python-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python-$(PKG_NAME):python \
-	+PACKAGE_python-$(PKG_NAME):python-django
+	python-django
   VARIANT:=python
+  MDEPENDS:=python-django
 endef
 
 define Package/python-$(PKG_NAME)/description
@@ -49,8 +50,9 @@ define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
-	+PACKAGE_python3-$(PKG_NAME):python3-django
+	python3-django
   VARIANT:=python3
+  MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -35,6 +35,7 @@ define Package/django/Default
   CATEGORY:=Languages
   TITLE:=The web framework for perfectionists with deadlines.
   URL:=https://www.djangoproject.com/
+  MENU:=1
 endef
 
 define Package/python-django

--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -45,6 +45,7 @@ define PyPackage
     EXTRA_DEPENDS:=
     TITLE+= (sources)
     USERID:=
+    MENU:=
   endef
 
   define Package/$(1)-src/description

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -44,6 +44,7 @@ define Py3Package
     EXTRA_DEPENDS:=
     TITLE+= (sources)
     USERID:=
+    MENU:=
   endef
 
   define Package/$(1)-src/description


### PR DESCRIPTION
Maintainer: me, @commodo, @jefferyto 
Compile tested: `make menuconfig` tested
Run tested: N/A

Description:
This changes the python[3]-django dependencies in packages to be non-selecting, and adds an MDEPENDS line so that the *-src packages get placed inside the django menu as well.

Added `MENU:=` to the src-package definitions in python[3]-package.mk, so it does not import that setting from the binary package.

This does not change the final package binaries.

A side-effect of creating the menu is that if we are to add a source package for python-django (currently we don't have one), we need to add it inside the menu as well, otherwise packages listed after -src (they are listed in alphabetical order)  will be placed outside of the menu as well.  To do that, we must add `MDEPENDS:=python[3]-django` to the `-src` package definition, which must be done after the call to `PyPackage`--and don't forget the empty line that avoids appending to the last line of the original definition--so it will look weird:
```make
$(eval $(call PyPackage,python-django))
define Package/python-django-src +=

        MDEPENDS:=python-django
endef
$(eval $(call BuildPackage,python-django))
$(eval $(call BuildPackage,python-django-src))

$(eval $(call Py3Package,python3-django))
define Package/python3-django-src +=

        MDEPENDS:=python3-django
endef
$(eval $(call BuildPackage,python3-django))
$(eval $(call BuildPackage,python3-django-src))
```

It may be worth adding some variables like `PY_SRCPKG_MDEPENDS` to `python[3]-package.mk` and use them when defining python `-src` packages to have more control over them.  I may do that later, unless someone tell me I'm crazy.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

Ping @BKPepe @neheb 
##### PS:
About the ptyhon/python3 conditional dependencies I'm omitting: they create recursive dependencies, but also: if a package have the same dependency (`python-django`) in both `python` and `python3` variants, there is no need to add the python-version-conditionals (`+PACKAGE_python_$(PKG_NAME):python-django`/`+PACKAGE_python_$(PKG_NAME):python3-django`), since both variants need `package/feeds/packages/django/compile`.  Leaving the conditional adds the same dependency twice inside `if` statements. 

Take `django-appconf` in `tmp/.packagedeps` for example:
`$(curdir)/feeds/packages/django-appconf/compile += $(curdir)/libs/toolchain/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile)`**`$(if $(CONFIG_PACKAGE_python-django-appconf),$(curdir)/feeds/packages/django/compile)`**`$(if $(CONFIG_PACKAGE_python-django-appconf),$(curdir)/feeds/packages/python/compile)`**`$(if $(CONFIG_PACKAGE_python3-django-appconf),$(curdir)/feeds/packages/django/compile)`**`$(if $(CONFIG_PACKAGE_python3-django-appconf),$(curdir)/feeds/packages/python3/compile) $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile)`

If you omit the conditionals, it becomes:

`$(curdir)/feeds/packages/django-appconf/compile +=`**`$(curdir)/feeds/packages/django/compile`**`$(curdir)/libs/toolchain/compile $(if $(CONFIG_GCC_LIBSSP),$(curdir)/libs/toolchain/compile) $(if $(CONFIG_PACKAGE_python-django-appconf),$(curdir)/feeds/packages/python/compile) $(if $(CONFIG_PACKAGE_python3-django-appconf),$(curdir)/feeds/packages/python3/compile) $(if $(CONFIG_USE_GLIBC),$(curdir)/libs/toolchain/compile)`

Of course, `python[-light]` adds `package/feeds/packages/python/compile`, while `python3[-light]` adds `package/feeds/packages/python3/compile`, as they are handled by different Makefiles, so it makes sense to add the conditionals there to avoid needlessly compiling the other python version.

I'm only removing conditionals from `django` because of the recursive dependency.  If indeed more people think it is a good idea, then I can do them all.