### PR TITLE
WIP talloc python3/cross-compilation issues

### DIFF
--- a/libs/libtalloc/Makefile
+++ b/libs/libtalloc/Makefile
@@ -6,18 +6,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=talloc
-PKG_VERSION:=2.1.14
+PKG_VERSION:=2.3.1
 MAJOR_VERSION:=2
-PKG_RELEASE:=3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.samba.org/ftp/talloc
-PKG_HASH:=b185602756a628bac507fa8af8b9df92ace69d27c0add5dab93190ad7c3367ce
+PKG_HASH:=ef4822d2fdafd2be8e0cabc3ec3c806ae29b8268e932c5e9a4cd5585f37f9f77
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=LGPL-3.0-or-later
 
 PKG_BUILD_PARALLEL:=0
+
+HOST_BUILD_DEPENDS:=python/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/kernel.mk
@@ -35,42 +37,18 @@ define Package/libtalloc/description
 endef
 
 CROSS = " \
-	\nChecking simple C program: OK \
-	\nrpath library support: OK \
-	\n-Wl,--version-script support: OK \
+	\nChecking simple C program: \"hello world\" \
+	\nrpath library support: (127, \"\") \
+	\n-Wl,--version-script support: (127, \"\") \
 	\nChecking getconf LFS_CFLAGS: NO \
 	\nChecking for large file support without additional flags: OK \
-	\nChecking for -D_LARGE_FILES: OK \
-	\nChecking correct behavior of strtoll: NO \
-	\nChecking for working strptime: OK \
-	\nChecking for C99 vsnprintf: OK \
-	\nChecking for HAVE_SHARED_MMAP: OK \
-	\nChecking for HAVE_MREMAP: OK \
-	\nChecking for HAVE_INCOHERENT_MMAP: NO \
+	\nChecking correct behavior of strtoll: OK \
+	\nChecking for working strptime: NO \
+	\nChecking for C99 vsnprintf: \"1\" \
+	\nChecking for HAVE_SHARED_MMAP: NO \
+	\nChecking for HAVE_MREMAP: NO \
+	\nChecking for HAVE_INCOHERENT_MMAP: (2, \"\") \
 	\nChecking for HAVE_SECURE_MKSTEMP: OK \
-	\nChecking for HAVE_IFACE_GETIFADDRS: OK \
-	\nChecking for kernel change notify support: OK \
-	\nChecking for Linux kernel oplocks: OK \
-	\nChecking for kernel share modes: OK \
-	\nChecking if can we convert from CP850 to UCS-2LE: OK \
-	\nChecking if can we convert from UTF-8 to UCS-2LE: OK \
-	\nChecking whether we can use Linux thread-specific credentials with 32-bit system calls: OK \
-	\nChecking whether we can use Linux thread-specific credentials: OK \
-	\nChecking whether setreuid is available: OK \
-	\nChecking whether setresuid is available: OK \
-	\nChecking whether seteuid is available: OK \
-	\nChecking whether fcntl locking is available: OK \
-	\nChecking for the maximum value of the 'time_t' type: OK \
-	\nChecking whether the realpath function allows a NULL argument: OK \
-	\nChecking whether POSIX capabilities are available: OK \
-	\nChecking for ftruncate extend: OK \
-	\nvfs_fileid checking for statfs() and struct statfs.f_fsid: OK \
-	\ngetcwd takes a NULL argument: OK \
-	\nChecking value of NSIG: \"65\" \
-	\nChecking value of _NSIG: \"65\" \
-	\nChecking value of SIGRTMAX: \"64\" \
-	\nChecking value of SIGRTMIN: \"34\" \
-	\nChecking if toolchain accepts -fstack-protector: OK \
 	\n"
 
 define Build/Configure
@@ -88,7 +66,8 @@ define Build/Configure
 			--localstatedir=/var \
 			--with-libiconv="$(ICONV_PREFIX)" \
 			--cross-compile \
-			--cross-answers=$(PKG_BUILD_DIR)/cache.txt \
+			--cross-answers=cache.txt \
+			--disable-python \
 			--disable-rpath \
 			--disable-rpath-install \
 	)

--- a/libs/libtalloc/patches/100-Remove_libbsd_dependency_check.patch
+++ b/libs/libtalloc/patches/100-Remove_libbsd_dependency_check.patch
@@ -1,6 +1,6 @@
 --- a/lib/replace/wscript
 +++ b/lib/replace/wscript
-@@ -340,22 +340,13 @@ def configure(conf):
+@@ -416,22 +416,13 @@ def configure(conf):
  
      conf.CHECK_FUNCS('prctl dirname basename')
  
@@ -29,7 +29,7 @@
  
      conf.CHECK_CODE('''
                  struct ucred cred;
-@@ -698,9 +689,6 @@ def configure(conf):
+@@ -808,9 +799,6 @@ def configure(conf):
  
      # look for a method of finding the list of network interfaces
      for method in ['HAVE_IFACE_GETIFADDRS', 'HAVE_IFACE_AIX', 'HAVE_IFACE_IFCONF', 'HAVE_IFACE_IFREQ']:
@@ -39,8 +39,8 @@
          if conf.CHECK_CODE('''
                             #define %s 1
                             #define NO_CONFIG_H 1
-@@ -713,7 +701,7 @@ def configure(conf):
-                            #include "test/getifaddrs.c"
+@@ -823,7 +811,7 @@ def configure(conf):
+                            #include "tests/getifaddrs.c"
                             ''' % method,
                             method,
 -                           lib='nsl socket' + bsd_for_strlcpy,
@@ -48,11 +48,11 @@
                             addmain=False,
                             execute=True):
              break
-@@ -761,7 +749,6 @@ def build(bld):
+@@ -871,7 +859,6 @@ def build(bld):
                  break
  
      extra_libs = ''
 -    if bld.CONFIG_SET('HAVE_LIBBSD'): extra_libs += ' bsd'
+     if bld.CONFIG_SET('HAVE_LIBRT'): extra_libs += ' rt'
+     if bld.CONFIG_SET('REPLACE_REQUIRES_LIBSOCKET_LIBNSL'): extra_libs += ' socket nsl'
  
-     bld.SAMBA_SUBSYSTEM('LIBREPLACE_HOSTCC',
-         REPLACE_HOSTCC_SOURCE,


### PR DESCRIPTION
Maintainer: Ted Hess <thess@kitschensync.net>

we've waited for an update to libtallic to fix builds with python3.
this PR builds the updated version.

if you urgently need libtalloc and have python2 installed locally, just use this hack:
```
.. build until it fails
ln -sf /usr/bin/python2 staging_dir/host/bin/python
make package/libtalloc/{clean,compile}
ln -sf /usr/bin/python3 staging_dir/host/bin/python
.. continue build
```