### PR TITLE
clamav: avoid host pickup of libxml2

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -23,6 +23,7 @@ PKG_CPE_ID:=cpe:/a:clamav:clamav
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
@@ -74,7 +75,6 @@ CONFIGURE_ARGS += \
 	--with-openssl="$(STAGING_DIR)/usr/" \
 	--with-pcre="$(STAGING_DIR)/usr/" \
 	--with-zlib="$(STAGING_DIR)/usr/" \
-	--without-xml \
 	--without-iconv \
 	--without-libncurses-prefix
 

--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clamav
 PKG_VERSION:=0.101.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.clamav.net/downloads/production/
@@ -93,18 +93,14 @@ define Package/clamav/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/clamd $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/clamav-milter $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/clamav-config $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/clambc $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/clamconf $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/clamdscan $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/clamscan $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sigtool $(1)/usr/sbin/
 
-	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/clamav.h $(1)/usr/include/
-
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib*/* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib*/lib*.so.* $(1)/usr/lib/
 
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/clamav.config $(1)/etc/config/clamav

--- a/net/clamav/patches/002-Avoid-libxml-checks-if-disable-xml-is-used.patch
+++ b/net/clamav/patches/002-Avoid-libxml-checks-if-disable-xml-is-used.patch
@@ -1,0 +1,167 @@
+From de943f313fa5c17bf9cbd560a7578796991b24b5 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cotequeiroz@gmail.com>
+Date: Sat, 10 Aug 2019 19:43:20 -0300
+Subject: [PATCH] Avoid libxml checks if --disable-xml is used
+
+Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
+---
+ m4/reorganization/libs/xml.m4 | 126 +++++++++++++++++-----------------
+ 1 file changed, 62 insertions(+), 64 deletions(-)
+
+diff --git a/m4/reorganization/libs/xml.m4 b/m4/reorganization/libs/xml.m4
+index 77b2c13a8..0709d2914 100644
+--- a/m4/reorganization/libs/xml.m4
++++ b/m4/reorganization/libs/xml.m4
+@@ -12,87 +12,85 @@ if test "X$want_xml" != "Xno"; then
+                     @<:@default=/usr/local or /usr if not found in /usr/local@:>@]),
+     [with_xml_val=$withval]
+   )
+-fi
+-
+-AS_IF([test "x$with_xml_val" = "xno"], [XML_HOME=""],
+-  [test "x$with_xml_val" = "xyes"], [XML_HOME="/usr/local"],
+-  [XML_HOME="$with_xml_val"])
+ 
+-AS_IF([test "x$XML_HOME" != "x"], [
+-   AS_IF([test ! -x "$XML_HOME/bin/xml2-config"], [XML_HOME=""])
+-   ])
++  AS_IF([test "x$with_xml_val" = "xno"], [XML_HOME=""],
++    [test "x$with_xml_val" = "xyes"], [XML_HOME="/usr/local"],
++    [XML_HOME="$with_xml_val"])
+ 
+-AS_IF([test "x$XML_HOME" = "x" -a "x$with_xml_val" = "xyes"], [
+-   AS_IF([test -x "/usr/bin/xml2-config"], [XML_HOME="/usr"])
+-   ])
++  AS_IF([test "x$XML_HOME" != "x"], [
++     AS_IF([test ! -x "$XML_HOME/bin/xml2-config"], [XML_HOME=""])
++     ])
+ 
+-if test "x$XML_HOME" != "x"; then
+-  AC_MSG_RESULT([$XML_HOME])
+-else
+-  AC_MSG_RESULT([not found])
+-fi
++  AS_IF([test "x$XML_HOME" = "x" -a "x$with_xml_val" = "xyes"], [
++     AS_IF([test -x "/usr/bin/xml2-config"], [XML_HOME="/usr"])
++     ])
+ 
+-found_xml="no"
+-XMLCONF_VERSION=""
+-XML_CPPFLAGS=""
+-XML_LIBS=""
+-if test "x$XML_HOME" != "x"; then
+-  AC_MSG_CHECKING([xml2-config version])
+-  XMLCONF_VERSION="`$XML_HOME/bin/xml2-config --version`"
+-  if test "x%XMLCONF_VERSION" != "x"; then
+-    AC_MSG_RESULT([$XMLCONF_VERSION])
+-    found_xml="yes"
+-    XML_CPPFLAGS="`$XML_HOME/bin/xml2-config --cflags`"
+-    XML_LIBS="`$XML_HOME/bin/xml2-config --libs`"
+-    AS_ECHO("$XML_CPPFLAGS")
+-    AS_ECHO("$XML_LIBS")
++  if test "x$XML_HOME" != "x"; then
++    AC_MSG_RESULT([$XML_HOME])
+   else
+-    AC_MSG_ERROR([xml2-config failed])
++    AC_MSG_RESULT([not found])
++  fi
++
++  found_xml="no"
++  XMLCONF_VERSION=""
++  XML_CPPFLAGS=""
++  XML_LIBS=""
++  if test "x$XML_HOME" != "x"; then
++    AC_MSG_CHECKING([xml2-config version])
++    XMLCONF_VERSION="`$XML_HOME/bin/xml2-config --version`"
++    if test "x%XMLCONF_VERSION" != "x"; then
++      AC_MSG_RESULT([$XMLCONF_VERSION])
++      found_xml="yes"
++      XML_CPPFLAGS="`$XML_HOME/bin/xml2-config --cflags`"
++      XML_LIBS="`$XML_HOME/bin/xml2-config --libs`"
++      AS_ECHO("$XML_CPPFLAGS")
++      AS_ECHO("$XML_LIBS")
++    else
++      AC_MSG_ERROR([xml2-config failed])
++    fi
+   fi
+-fi
+ 
+-working_xml="no"
+-if test "X$found_xml" != "Xno"; then
+-  AC_MSG_CHECKING([for xmlreader.h in $XML_HOME])
++  working_xml="no"
++  if test "X$found_xml" != "Xno"; then
++    AC_MSG_CHECKING([for xmlreader.h in $XML_HOME])
+ 
+-  if test ! -f "$XML_HOME/include/libxml2/libxml/xmlreader.h"; then
+-    AC_MSG_RESULT([not found])
+-  else
+-    AC_MSG_RESULT([found])
+-    save_LIBS="$LIBS"
+-    save_CPPFLAGS="$CPPFLAGS"
+-    CPPFLAGS="$CPPFLAGS $XML_CPPFLAGS"
+-    save_LDFLAGS="$LDFLAGS"
+-    LDFLAGS="$LDFLAGS $XML_LIBS"
++    if test ! -f "$XML_HOME/include/libxml2/libxml/xmlreader.h"; then
++      AC_MSG_RESULT([not found])
++    else
++      AC_MSG_RESULT([found])
++      save_LIBS="$LIBS"
++      save_CPPFLAGS="$CPPFLAGS"
++      CPPFLAGS="$CPPFLAGS $XML_CPPFLAGS"
++      save_LDFLAGS="$LDFLAGS"
++      LDFLAGS="$LDFLAGS $XML_LIBS"
+ 
+-    AS_ECHO("CPPFLAGS: $CPPFLAGS")
+-    AS_ECHO("LD_FLAGS: $LDFLAGS")
++      AS_ECHO("CPPFLAGS: $CPPFLAGS")
++      AS_ECHO("LD_FLAGS: $LDFLAGS")
+ 
+-    AC_CHECK_LIB([xml2], [xmlTextReaderRead], [working_xml="yes"], [working_xml="no"], [$XML_LIBS])
++      AC_CHECK_LIB([xml2], [xmlTextReaderRead], [working_xml="yes"], [working_xml="no"], [$XML_LIBS])
+ 
+-    CPPFLAGS="$save_CPPFLAGS"
+-    LDFLAGS="$save_LDFLAGS"
+-    LIBS="$save_LIBS"
++      CPPFLAGS="$save_CPPFLAGS"
++      LDFLAGS="$save_LDFLAGS"
++      LIBS="$save_LIBS"
++    fi
+   fi
+-fi
+ 
+-if test "$working_xml" = "yes"; then
+-  AC_DEFINE([HAVE_LIBXML2],1,[Define to 1 if you have the 'libxml2' library (-lxml2).])
+-  AC_SUBST(XML_CPPFLAGS)
+-  AC_SUBST(XML_LIBS)
+-  AC_MSG_NOTICE([Compiling and linking with libxml2 from $XML_HOME])
+-else
+-  if test "$want_xml" = "yes"; then
+-     AC_MSG_ERROR([****** Please install libxml2 packages!])
++  if test "$working_xml" = "yes"; then
++    AC_DEFINE([HAVE_LIBXML2],1,[Define to 1 if you have the 'libxml2' library (-lxml2).])
++    AC_SUBST(XML_CPPFLAGS)
++    AC_SUBST(XML_LIBS)
++    AC_MSG_NOTICE([Compiling and linking with libxml2 from $XML_HOME])
+   else
+-    if test "$want_xml" != "no"; then
++    if test "$want_xml" = "yes"; then
++      AC_MSG_ERROR([****** Please install libxml2 packages!])
++    else
+       AC_MSG_NOTICE([****** libxml2 support unavailable])
+     fi
++    XML_CPPFLAGS=""
++    XML_LIBS=""
++    AC_SUBST(XML_CPPFLAGS)
++    AC_SUBST(XML_LIBS)
+   fi
+-  XML_CPPFLAGS=""
+-  XML_LIBS=""
+-  AC_SUBST(XML_CPPFLAGS)
+-  AC_SUBST(XML_LIBS)
+ fi
+ 
+ AM_CONDITIONAL([HAVE_LIBXML2], test "x$HAVE_LIBXML2" = "xyes")
+-- 
+2.21.0
+


### PR DESCRIPTION
Maintainer: @ratkaj @lucize 
Compile tested: arm, WRT3200ACM, openwrt master
Run tested: arm, WRT3200ACM, openwrt master, run `freshclam`, and `clamscan /sbin/logread` (it took almost one hour to run both)

Description:
If libxml2 is installed in the host, then the host library is used and compilation fails: 
```
libtool: link: arm-openwrt-linux-muslgnueabi-gcc -shared  -fPIC -DPIC  .libs/libclamav_la-matcher-ac.o .libs/libclamav_la-matcher-bm.o .libs/libclamav_la-matcher-hash.o .libs/libclamav_la-matcher.o .libs/libclamav_la-others.o .libs/libclamav_la-readdb.o .libs/libclamav_la-cvd.o .libs/libclamav_la-dsig.o .libs/libclamav_la-scanners.o .libs/libclamav_la-textdet.o .libs/libclamav_la-filetypes.o .libs/libclamav_la-rtf.o .libs/libclamav_la-blob.o .libs/libclamav_la-mbox.o .libs/libclamav_la-message.o .libs/libclamav_la-table.o .libs/libclamav_la-text.o .libs/libclamav_la-ole2_extract.o .libs/libclamav_la-vba_extract.o .libs/libclamav_la-msexpand.o .libs/libclamav_la-pe.o .libs/libclamav_la-pe_icons.o .libs/libclamav_la-disasm.o .libs/libclamav_la-upx.o .libs/libclamav_la-htmlnorm.o .libs/libclamav_la-libmspack.o .libs/libclamav_la-rebuildpe.o .libs/libclamav_la-petite.o .libs/libclamav_la-wwunpack.o .libs/libclamav_la-unsp.o .libs/libclamav_la-aspack.o .libs/libclamav_la-packlibs.o .libs/libclamav_la-fsg.o .libs/libclamav_la-mew.o .libs/libclamav_la-upack.o .libs/libclamav_la-line.o .libs/libclamav_la-untar.o .libs/libclamav_la-unzip.o .libs/libclamav_la-ooxml.o .libs/libclamav_la-inflate64.o .libs/libclamav_la-special.o .libs/libclamav_la-binhex.o .libs/libclamav_la-is_tar.o .libs/libclamav_la-tnef.o .libs/libclamav_la-autoit.o .libs/libclamav_la-unarj.o .libs/libclamav_la-bzlib.o .libs/libclamav_la-nulsft.o .libs/libclamav_la-infblock.o .libs/libclamav_la-pdf.o .libs/libclamav_la-pdfng.o .libs/libclamav_la-pdfdecode.o .libs/libclamav_la-spin.o .libs/libclamav_la-yc.o .libs/libclamav_la-elf.o .libs/libclamav_la-sis.o .libs/libclamav_la-uuencode.o .libs/libclamav_la-phishcheck.o .libs/libclamav_la-phish_domaincheck_db.o .libs/libclamav_la-phish_whitelist.o .libs/libclamav_la-regex_list.o .libs/libclamav_la-regex_suffix.o .libs/libclamav_la-entconv.o .libs/libclamav_la-hashtab.o .libs/libclamav_la-dconf.o .libs/libclamav_la-lzma_iface.o .libs/libclamav_la-7z_iface.o .libs/libclamav_la-7zAlloc.o .libs/libclamav_la-7zBuf.o .libs/libclamav_la-7zBuf2.o .libs/libclamav_la-7zCrc.o .libs/libclamav_la-7zDec.o .libs/libclamav_la-7zFile.o .libs/libclamav_la-7zIn.o .libs/libclamav_la-7zStream.o .libs/libclamav_la-Bcj2.o .libs/libclamav_la-Bra.o .libs/libclamav_la-Bra86.o .libs/libclamav_la-Lzma2Dec.o .libs/libclamav_la-LzmaDec.o .libs/libclamav_la-Ppmd7.o .libs/libclamav_la-Ppmd7Dec.o .libs/libclamav_la-Xz.o .libs/libclamav_la-XzCrc64.o .libs/libclamav_la-XzDec.o .libs/libclamav_la-XzIn.o .libs/libclamav_la-Delta.o .libs/libclamav_la-BraIA64.o .libs/libclamav_la-CpuArch.o .libs/libclamav_la-7zCrcOpt.o .libs/libclamav_la-explode.o .libs/libclamav_la-textnorm.o .libs/libclamav_la-dlp.o .libs/libclamav_la-js-norm.o .libs/libclamav_la-uniq.o .libs/libclamav_la-version.o .libs/libclamav_la-mpool.o .libs/libclamav_la-filtering.o .libs/libclamav_la-fmap.o .libs/libclamav_la-perflogging.o .libs/libclamav_la-bytecode.o .libs/libclamav_la-bytecode_vm.o .libs/libclamav_la-cpio.o .libs/libclamav_la-macho.o .libs/libclamav_la-ishield.o .libs/libclamav_la-bytecode_api.o .libs/libclamav_la-bytecode_api_decl.o .libs/libclamav_la-cache.o .libs/libclamav_la-bytecode_detect.o .libs/libclamav_la-events.o .libs/libclamav_la-adc.o .libs/libclamav_la-dmg.o .libs/libclamav_la-xar.o .libs/libclamav_la-xdp.o .libs/libclamav_la-mbr.o .libs/libclamav_la-gpt.o .libs/libclamav_la-apm.o .libs/libclamav_la-prtn_intxn.o .libs/libclamav_la-json_api.o .libs/libclamav_la-xz_iface.o .libs/libclamav_la-sf_base64decode.o .libs/libclamav_la-hfsplus.o .libs/libclamav_la-swf.o .libs/libclamav_la-jpeg.o .libs/libclamav_la-png.o .libs/libclamav_la-iso9660.o .libs/libclamav_la-arc4.o .libs/libclamav_la-rijndael.o .libs/libclamav_la-crtmgr.o .libs/libclamav_la-asn1.o .libs/libclamav_la-fpu.o .libs/libclamav_la-stats.o .libs/libclamav_la-www.o .libs/libclamav_la-stats_json.o .libs/libclamav_la-hostid.o .libs/libclamav_la-openioc.o .libs/libclamav_la-msdoc.o .libs/libclamav_la-matcher-pcre.o .libs/libclamav_la-regex_pcre.o .libs/libclamav_la-msxml.o .libs/libclamav_la-msxml_parser.o .libs/libclamav_la-tiff.o .libs/libclamav_la-hwp.o .libs/libclamav_la-lzwdec.o .libs/libclamav_la-matcher-byte-comp.o .libs/libclamav_la-yara_arena.o .libs/libclamav_la-yara_compiler.o .libs/libclamav_la-yara_exec.o .libs/libclamav_la-yara_hash.o .libs/libclamav_la-yara_grammar.o .libs/libclamav_la-yara_lexer.o .libs/libclamav_la-yara_parser.o .libs/libclamav_la-fp_add.o .libs/libclamav_la-fp_add_d.o .libs/libclamav_la-fp_addmod.o .libs/libclamav_la-fp_cmp.o .libs/libclamav_la-fp_cmp_d.o .libs/libclamav_la-fp_cmp_mag.o .libs/libclamav_la-fp_sub.o .libs/libclamav_la-fp_sub_d.o .libs/libclamav_la-fp_submod.o .libs/libclamav_la-s_fp_add.o .libs/libclamav_la-s_fp_sub.o .libs/libclamav_la-fp_radix_size.o .libs/libclamav_la-fp_read_radix.o .libs/libclamav_la-fp_read_signed_bin.o .libs/libclamav_la-fp_read_unsigned_bin.o .libs/libclamav_la-fp_reverse.o .libs/libclamav_la-fp_s_rmap.o .libs/libclamav_la-fp_signed_bin_size.o .libs/libclamav_la-fp_to_signed_bin.o .libs/libclamav_la-fp_to_unsigned_bin.o .libs/libclamav_la-fp_toradix.o .libs/libclamav_la-fp_toradix_n.o .libs/libclamav_la-fp_unsigned_bin_size.o .libs/libclamav_la-fp_cnt_lsb.o .libs/libclamav_la-fp_count_bits.o .libs/libclamav_la-fp_div_2.o .libs/libclamav_la-fp_div_2d.o .libs/libclamav_la-fp_lshd.o .libs/libclamav_la-fp_mod_2d.o .libs/libclamav_la-fp_rshd.o .libs/libclamav_la-fp_div.o .libs/libclamav_la-fp_div_d.o .libs/libclamav_la-fp_mod.o .libs/libclamav_la-fp_mod_d.o .libs/libclamav_la-fp_2expt.o .libs/libclamav_la-fp_exptmod.o .libs/libclamav_la-fp_ident.o .libs/libclamav_la-fp_set.o .libs/libclamav_la-fp_montgomery_calc_normalization.o .libs/libclamav_la-fp_montgomery_reduce.o .libs/libclamav_la-fp_montgomery_setup.o .libs/libclamav_la-fp_mul.o .libs/libclamav_la-fp_mul_comba.o .libs/libclamav_la-fp_mul_2.o .libs/libclamav_la-fp_mul_2d.o .libs/libclamav_la-fp_mul_comba_12.o .libs/libclamav_la-fp_mul_comba_17.o .libs/libclamav_la-fp_mul_comba_20.o .libs/libclamav_la-fp_mul_comba_24.o .libs/libclamav_la-fp_mul_comba_28.o .libs/libclamav_la-fp_mul_comba_3.o .libs/libclamav_la-fp_mul_comba_32.o .libs/libclamav_la-fp_mul_comba_4.o .libs/libclamav_la-fp_mul_comba_48.o .libs/libclamav_la-fp_mul_comba_6.o .libs/libclamav_la-fp_mul_comba_64.o .libs/libclamav_la-fp_mul_comba_7.o .libs/libclamav_la-fp_mul_comba_8.o .libs/libclamav_la-fp_mul_comba_9.o .libs/libclamav_la-fp_mul_comba_small_set.o .libs/libclamav_la-fp_mul_d.o .libs/libclamav_la-fp_mulmod.o .libs/libclamav_la-fp_invmod.o .libs/libclamav_la-fp_sqr.o .libs/libclamav_la-fp_sqr_comba_12.o .libs/libclamav_la-fp_sqr_comba_17.o .libs/libclamav_la-fp_sqr_comba_20.o .libs/libclamav_la-fp_sqr_comba_24.o .libs/libclamav_la-fp_sqr_comba_28.o .libs/libclamav_la-fp_sqr_comba_3.o .libs/libclamav_la-fp_sqr_comba_32.o .libs/libclamav_la-fp_sqr_comba_4.o .libs/libclamav_la-fp_sqr_comba_48.o .libs/libclamav_la-fp_sqr_comba_6.o .libs/libclamav_la-fp_sqr_comba_64.o .libs/libclamav_la-fp_sqr_comba_7.o .libs/libclamav_la-fp_sqr_comba_8.o .libs/libclamav_la-fp_sqr_comba_9.o .libs/libclamav_la-fp_sqr_comba_generic.o .libs/libclamav_la-fp_sqr_comba_small_set.o .libs/libclamav_la-fp_sqrmod.o .libs/libclamavS.o -Wl,--whole-archive ./.libs/libclamav_nocxx.a ./.libs/libclamav_internal_utils.a -Wl,--no-whole-archive  -Wl,-rpath -Wl,/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/clamav-0.101.2/libclamav/.libs -L/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr//lib -lxml2 -L/usr/lib64 -ldl -L/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/lib -L/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/lib -L/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/usr/lib -L/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/lib -lltdl /home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/clamav-0.101.2/libclamav/.libs/libclammspack.so -lfts -lssl -lcrypto -lz -ljson-c -lpcre2-8 -lpthread -lm  -Os -mfloat-abi=hard -fstack-protector -Wl,-z -Wl,now -Wl,-z -Wl,relro -Wl,--version-script -Wl,../libclamav/libclamav.map -Wl,--gc-sections -Wl,--as-needed   -Wl,-soname -Wl,libclamav.so.9 -o .libs/libclamav.so.9.0.2
/usr/lib64/libdl.so: file not recognized: file format not recognized
collect2: error: ld returned 1 exit status
make[7]: *** [Makefile:1515: libclamav.la] Error 1
```
Here are relevant `configure` output showing where the problem is:
```
checking for sysctlbyname... no
/usr
checking xml2-config version... 2.9.9
-I/usr/include/libxml2
-lxml2 -L/usr/lib64 -lz -lm -ldl
checking for xmlreader.h in /usr... found
CPPFLAGS: -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/include -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/include -I/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/usr/include -I/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/include/fortify -I/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/include  -I/usr/include/libxml2
LD_FLAGS: -L/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/lib -L/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/lib -L/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/usr/lib -L/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/lib -znow -zrelro -Wl,--gc-sections,--as-needed -lfts  -lxml2 -L/usr/lib64 -lz -lm -ldl
checking for xmlTextReaderRead in -lxml2... yes
configure: Compiling and linking with libxml2 from /usr
```
```
configure: Summary of detected features follows
              OS          : linux-gnu
              pthreads    : yes (-lpthread)
configure: Summary of miscellaneous features
              check       : no (disabled)
              fanotify    : yes
              fdpassing   : 0
              IPv6        : yes
configure: Summary of optional tools
              clamdtop    :  (disabled)
              milter      : yes
              clamsubmit  : yes (libjson-c-dev found at /home/equeiroz/src/openwrt/staging_dir/target-a
rm_cortex-a9+vfpv3_musl_eabi/usr/), libcurl-devel found at /home/equeiroz/src/openwrt/staging_dir/targe
t-arm_cortex-a9+vfpv3_musl_eabi/usr/)
configure: Summary of engine performance features
              release mode: yes
              llvm        : no (7.1.0), from /usr/lib/llvm/7/bin/llvm-config () (auto)
              mempool     : yes
configure: Summary of engine detection features
              bzip2       : ok (disabled)
              zlib        : /home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/
              unrar       : yes
              preclass    : yes (libjson-c-dev found at /home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/)
              pcre        : /usr
              libmspack   : yes (Internal)
              libxml2     : yes, from /usr
              yara        : yes
              fts         : yes (libc)
```

Notice it picks up more libs from host, but they do not cause failures, at least not here.

An alternative workaround that avoids the need to run `autoreconf` is to add `ac_cv_lib_xml2_xmlTextReaderRead=no` to `CONFIGURE_VARS`.  Since I submitted the patch upstream https://github.com/Cisco-Talos/clamav-devel/pull/103, I think applying the patch will make an easier transition when the bug is fixed upstream.

Not increasing `PKG_RELEASE` since it does not alter the final package if the host does not have libxml2; if the host does have libxml2, then it just fails.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
**Edited to add run-test**