### PR TITLE
patch: apply upstream patch for CVE-2019-13638

### DIFF
--- a/devel/patch/Makefile
+++ b/devel/patch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=patch
 PKG_VERSION:=2.7.6
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/patch

--- a/devel/patch/patches/060-CVE-2019-13638.patch
+++ b/devel/patch/patches/060-CVE-2019-13638.patch
@@ -1,0 +1,38 @@
+From 3fcd042d26d70856e826a42b5f93dc4854d80bf0 Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruen@gnu.org>
+Date: Fri, 6 Apr 2018 19:36:15 +0200
+Subject: Invoke ed directly instead of using the shell
+
+* src/pch.c (do_ed_script): Invoke ed directly instead of using a shell
+command to avoid quoting vulnerabilities.
+---
+ src/pch.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/src/pch.c b/src/pch.c
+index 4fd5a05..16e001a 100644
+--- a/src/pch.c
++++ b/src/pch.c
+@@ -2459,9 +2459,6 @@ do_ed_script (char const *inname, char const *outname,
+ 	    *outname_needs_removal = true;
+ 	    copy_file (inname, outname, 0, exclusive, instat.st_mode, true);
+ 	  }
+-	sprintf (buf, "%s %s%s", editor_program,
+-		 verbosity == VERBOSE ? "" : "- ",
+-		 outname);
+ 	fflush (stdout);
+ 
+ 	pid = fork();
+@@ -2470,7 +2467,8 @@ do_ed_script (char const *inname, char const *outname,
+ 	else if (pid == 0)
+ 	  {
+ 	    dup2 (tmpfd, 0);
+-	    execl ("/bin/sh", "sh", "-c", buf, (char *) 0);
++	    assert (outname[0] != '!' && outname[0] != '-');
++	    execlp (editor_program, editor_program, "-", outname, (char  *) NULL);
+ 	    _exit (2);
+ 	  }
+ 	else
+-- 
+cgit v1.0-41-gc330
+


### PR DESCRIPTION
GNU patch through 2.7.6 is vulnerable to OS shell command injection that
can be exploited by opening a crafted patch file that contains an ed style
diff payload with shell metacharacters. The ed editor does not need to be
present on the vulnerable system. This is different from CVE-2018-1000156.

https://nvd.nist.gov/vuln/detail/CVE-2019-13638

Signed-off-by: Russell Senior <russell@personaltelco.net>

Maintainer: me / @RussellSenior
Compile tested: ath79, Buffalo WZR-HP-AG300H/WZR-600DHP, openwrt reboot-10740-g920abb9b58
Run tested: ath79, Buffalo WZR-HP-AG300H/WZR-600DHP, openwrt reboot-10740-g920abb9b58
