### PR TITLE
jamvm: Add host build

### DIFF
--- a/lang/jamvm/Makefile
+++ b/lang/jamvm/Makefile
@@ -9,29 +9,30 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=jamvm
 PKG_VERSION:=2.0.0
-PKG_RELEASE:=2
-PKG_LICENSE:=GPL-2.0+
-PKG_MAINTAINER:=Dana H. Myers <k6jq@comcast.net>
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
 PKG_HASH:=76428e96df0ae9dd964c7a7c74c1e9a837e2f312c39e9a357fa8178f7eff80da
 
-PKG_USE_MIPS16:=0
+PKG_MAINTAINER:=Dana H. Myers <k6jq@comcast.net>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_USE_MIPS16:=0
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 
 define Package/jamvm
   SUBMENU:=Java
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=A compact Java Virtual Machine
-  URL:=http://sourceforge.net/projects/jamvm
-  DEPENDS:=+zlib +libpthread +librt +classpath \
-	  @(i386||i686||x86_64||arm||armeb||mips||mipsel||powerpc||powerpc64) +CONFIG_powerpc64:libffi
+  URL:=http://jamvm.sourceforge.net/
+  DEPENDS:=+zlib +libpthread +librt +CONFIG_powerpc64:libffi @!arc
 endef
 
 define Package/jamvm/description
@@ -66,3 +67,4 @@ define Build/InstallDev
 endef
 
 $(eval $(call BuildPackage,jamvm))
+$(eval $(call HostBuild))

--- a/lang/jamvm/patches/010-musl.patch
+++ b/lang/jamvm/patches/010-musl.patch
@@ -1,0 +1,12 @@
+--- a/src/os/linux/os.c
++++ b/src/os/linux/os.c
+@@ -26,6 +26,9 @@
+ #include <sys/sysinfo.h>
+ 
+ #define __USE_GNU
++#ifndef _GNU_SOURCE
++#define _GNU_SOURCE
++#endif
+ #include <dlfcn.h>
+ #include <pthread.h>
+ 


### PR DESCRIPTION
Needed for classpath. GCJ is also needed but that can be dealt with
separately.

Fix compilation with musl by defining _GNU_SOURCE. What's funny here is
that if __USE_GNU gets replaced, the host build fails. The man page says
_GNU_SOURCE for pthread_getattr_np but glibc violates that statement.

Fixed License information.

Various other cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @danak6jq 
Compile tested: ath79

ping @daniel-santos since you seem to use this.