### PR TITLE
pdns: bump version to 4.1.13

### DIFF
--- a/net/pdns/Makefile
+++ b/net/pdns/Makefile
@@ -1,17 +1,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns
-PKG_VERSION:=4.1.10
-PKG_RELEASE:=2
+PKG_VERSION:=4.1.13
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=5a46cfde92caaaa2e85af9a15acb9ad81b56f4c8a8255c457e6938d8c0cb15c7
+PKG_HASH:=e7ea9c628a03652d2ca9e048525d44ac5628a9fede45e510ff9ba756ae2f5f25
 
 PKG_MAINTAINER:=James Taylor <james@jtaylor.id.au>
 PKG_LICENCE:=GPL-2.0-only
 PKG_LICENCE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:powerdns:authoritative_server
+PKG_CPE_ID:=cpe:/a:powerdns:authoritative
 
 PKG_FIXUP:=autoreconf
 

--- a/net/pdns/files/pdns.conf-dist
+++ b/net/pdns/files/pdns.conf-dist
@@ -92,7 +92,7 @@
 #################################
 # config-dir	Location of configuration directory (pdns.conf)
 #
-# config-dir=/usr/local/etc
+# config-dir=/etc/powerdns
 
 #################################
 # config-name	Name of this virtual configuration - will rename the binary image
@@ -377,7 +377,7 @@
 #################################
 # module-dir	Default directory for modules
 #
-# module-dir=/usr/local/lib/pdns
+# module-dir=/usr/lib/powerdns/pdns
 
 #################################
 # negquery-cache-ttl	Seconds to store negative query results in the QueryCache
@@ -530,6 +530,11 @@
 # socket-dir=
 
 #################################
+# superslave	Act as a superslave
+#
+# superslave=yes
+
+#################################
 # tcp-control-address	If set, PowerDNS can be controlled over TCP on this address
 #
 # tcp-control-address=
@@ -618,3 +623,5 @@
 # xfr-max-received-mbytes	Maximum number of megabytes received from an incoming XFR
 #
 # xfr-max-received-mbytes=100
+
+


### PR DESCRIPTION
Maintainer: me
Compile tested: armv7 OpenWRT buildroot
Run tested: armv7 Linksys WRT1900ACS

Description:
Bump PowerDNS Authoritative Nameserver to latest upstream 4.1.13 including security fixes from 4.1.11

Includes updated PostgreSQL schema for PowerDNS Security Advisory 2019-06 (CVE-2019-10203).

Upgrading is not enough - you need to manually apply the schema change: ALTER TABLE domains ALTER notified_serial TYPE bigint USING CASE WHEN notified_serial >= 0 THEN notified_serial::bigint END;

Signed-off-by: James Taylor <james@jtaylor.id.au>