### PR TITLE
https-dns-proxy: avoid picking up host clang-tidy

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -16,6 +16,8 @@ PKG_LICENSE:=MIT
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
+CMAKE_OPTIONS += -DCLANG_TIDY_EXE=
+
 define Package/https_dns_proxy
   SECTION:=net
   CATEGORY:=Network


### PR DESCRIPTION
Maintainer: @aarond10 
Compile tested: arm, WRT3200ACM, openwrt master
Run tested: N/A

Description:
Otherwise compilation fails when clang-tidy is found in the host:


`-- Detecting CXX compile features`
`-- Detecting CXX compile features - done`
**`-- clang-tidy found: /usr/lib/llvm/7/bin/clang-tidy`**
`-- Configuring done`
`-- Generating done`
Then
```
[ 30%] Building C object CMakeFiles/https_dns_proxy.dir/src/dns_poller.c.o
/home/equeiroz/src/openwrt/staging_dir/host/bin/cmake -E __run_co_compile --tidy="/usr/lib/llvm/7/bin/clang-tidy;-fix;-checks=*,-clang-analyzer-alpha.*,-misc-unused-parameters,-cert-err34-c,-google-readability-todo" --source=/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/https_dns_proxy-2018-04-23/src/dns_poller.c -- /home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.4.0_musl_eabi/bin/arm-openwrt-linux-muslgnueabi-gcc  -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/include -I/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/https_dns_proxy-2018-04-23/src -I/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/https_dns_proxy-2018-04-23/lib  -Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -mfloat-abi=hard -iremap/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/https_dns_proxy-2018-04-23:https_dns_proxy-2018-04-23 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -g   -o CMakeFiles/https_dns_proxy.dir/src/dns_poller.c.o   -c /home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/https_dns_proxy-2018-04-23/src/dns_poller.c
warning: optimization flag '-fno-caller-saves' is not supported [clang-diagnostic-ignored-optimization-argument]
error: unknown argument: '-fhonour-copts' [clang-diagnostic-error]
error: unknown argument: '-iremap/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/https_dns_proxy-2018-04-23:https_dns_proxy-2018-04-23' [clang-diagnostic-error]
```
This should not change the final package, so `PKG_RELEASE` is not being increased.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>