### PR TITLE
[OpenWrt 18.06] squid: update to version 3.5.28

### DIFF
--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
-PKG_VERSION:=3.5.27
+PKG_VERSION:=3.5.28
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
@@ -18,7 +18,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www3.us.squid-cache.org/Versions/v3/3.5/ \
 	http://www2.pl.squid-cache.org/Versions/v3/3.5/ \
 	http://www.squid-cache.org/Versions/v3/3.5/
-PKG_HASH:=5ddb4367f2dc635921f9ca7a59d8b87edb0412fa203d1543393ac3c7f9fef0ec
+PKG_HASH:=fd41b622e65c661ada9a98b0338c59e6f2d2ffdb367fe5c8c7212c535e298ed8
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1

--- a/net/squid/patches/0001-digest-auth-parameter-parsing.patch
+++ b/net/squid/patches/0001-digest-auth-parameter-parsing.patch
@@ -1,0 +1,74 @@
+commit 5730c2b5cb56e7639dc423dd62651c8736a54e35 (refs/remotes/origin/v3.5)
+Author: Amos Jeffries <yadij@users.noreply.github.com>
+Date:   2019-07-05 03:17:26 +0000
+
+    Bug 4957: Multiple XSS issues in cachemgr.cgi (#429)
+    
+    The cachemgr.cgi web module of the squid proxy is vulnerable
+    to XSS issue. The vulnerable parameters "user_name" and "auth"
+    have insufficient sanitization in place.
+
+diff --git a/tools/cachemgr.cc b/tools/cachemgr.cc
+index 0c67538..9aecaa9 100644
+--- a/tools/cachemgr.cc
++++ b/tools/cachemgr.cc
+@@ -354,7 +354,7 @@ auth_html(const char *host, int port, const char *user_name)
+ 
+     printf("<TR><TH ALIGN=\"left\">Manager name:</TH><TD><INPUT NAME=\"user_name\" ");
+ 
+-    printf("size=\"30\" VALUE=\"%s\"></TD></TR>\n", user_name);
++    printf("size=\"30\" VALUE=\"%s\"></TD></TR>\n", rfc1738_escape(user_name));
+ 
+     printf("<TR><TH ALIGN=\"left\">Password:</TH><TD><INPUT TYPE=\"password\" NAME=\"passwd\" ");
+ 
+@@ -418,7 +418,7 @@ menu_url(cachemgr_request * req, const char *action)
+              script_name,
+              req->hostname,
+              req->port,
+-             safe_str(req->user_name),
++             rfc1738_escape(safe_str(req->user_name)),
+              action,
+              safe_str(req->pub_auth));
+     return url;
+@@ -1073,8 +1073,8 @@ make_pub_auth(cachemgr_request * req)
+     const int bufLen = snprintf(buf, sizeof(buf), "%s|%d|%s|%s",
+                                 req->hostname,
+                                 (int) now,
+-                                req->user_name ? req->user_name : "",
+-                                req->passwd);
++                                rfc1738_escape(safe_str(req->user_name)),
++                                rfc1738_escape(req->passwd));
+     debug("cmgr: pre-encoded for pub: %s\n", buf);
+ 
+     const int encodedLen = base64_encode_len(bufLen);
+@@ -1089,8 +1089,6 @@ decode_pub_auth(cachemgr_request * req)
+     char *buf;
+     const char *host_name;
+     const char *time_str;
+-    const char *user_name;
+-    const char *passwd;
+ 
+     debug("cmgr: decoding pub: '%s'\n", safe_str(req->pub_auth));
+     safe_free(req->passwd);
+@@ -1119,17 +1117,21 @@ decode_pub_auth(cachemgr_request * req)
+ 
+     debug("cmgr: decoded time: '%s' (now: %d)\n", time_str, (int) now);
+ 
++    char *user_name;
+     if ((user_name = strtok(NULL, "|")) == NULL) {
+         xfree(buf);
+         return;
+     }
++    rfc1738_unescape(user_name);
+ 
+     debug("cmgr: decoded uname: '%s'\n", user_name);
+ 
++    char *passwd;
+     if ((passwd = strtok(NULL, "|")) == NULL) {
+         xfree(buf);
+         return;
+     }
++    rfc1738_unescape(passwd);
+ 
+     debug("cmgr: decoded passwd: '%s'\n", passwd);
+ 

--- a/net/squid/patches/0002-fix-memory-leak-SNMP-packet.patch
+++ b/net/squid/patches/0002-fix-memory-leak-SNMP-packet.patch
@@ -1,0 +1,22 @@
+commit bc9786119f058a76ddf0625424bc33d36460b9a2 (refs/remotes/origin/v3.5)
+Author: flozilla <fishyflow@gmail.com>
+Date:   2018-10-24 14:12:01 +0200
+
+    Fix memory leak when parsing SNMP packet (#313)
+    
+    SNMP queries denied by snmp_access rules and queries with certain
+    unsupported SNMPv2 commands were leaking a few hundred bytes each. Such
+    queries trigger "SNMP agent query DENIED from..." WARNINGs in cache.log.
+
+diff --git a/src/snmp_core.cc b/src/snmp_core.cc
+index c4d21c1..16c2993 100644
+--- a/src/snmp_core.cc
++++ b/src/snmp_core.cc
+@@ -409,6 +409,7 @@ snmpDecodePacket(SnmpRequest * rq)
+             snmpConstructReponse(rq);
+         } else {
+             debugs(49, DBG_IMPORTANT, "WARNING: SNMP agent query DENIED from : " << rq->from);
++            snmp_free_pdu(PDU);
+         }
+         xfree(Community);
+ 

--- a/net/squid/patches/0003-fix-XSS-issues-cachemgr.patch
+++ b/net/squid/patches/0003-fix-XSS-issues-cachemgr.patch
@@ -1,0 +1,30 @@
+commit ec0d0f39cf28da14eead0ba5e777e95855bc2f67
+Author: Amos Jeffries <yadij@users.noreply.github.com>
+Date:   2019-06-08 21:09:23 +0000
+
+    Fix Digest auth parameter parsing (#415)
+    
+    Only remove quoting if the domain=, uri= or qop= parameter
+    value is surrounded by double-quotes.
+
+diff --git a/src/auth/digest/Config.cc b/src/auth/digest/Config.cc
+index 674dd93..d2cd2e9 100644
+--- a/src/auth/digest/Config.cc
++++ b/src/auth/digest/Config.cc
+@@ -781,14 +781,14 @@ Auth::Digest::Config::decode(char const *proxy_auth, const char *aRequestRealm)
+             if (keyName == SBuf("domain",6) || keyName == SBuf("uri",3)) {
+                 // domain is Special. Not a quoted-string, must not be de-quoted. But is wrapped in '"'
+                 // BUG 3077: uri= can also be sent to us in a mangled (invalid!) form like domain
+-                if (*p == '"' && *(p + vlen -1) == '"') {
++                if (vlen > 1 && *p == '"' && *(p + vlen -1) == '"') {
+                     value.limitInit(p+1, vlen-2);
+                 }
+             } else if (keyName == SBuf("qop",3)) {
+                 // qop is more special.
+                 // On request this must not be quoted-string de-quoted. But is several values wrapped in '"'
+                 // On response this is a single un-quoted token.
+-                if (*p == '"' && *(p + vlen -1) == '"') {
++                if (vlen > 1 && *p == '"' && *(p + vlen -1) == '"') {
+                     value.limitInit(p+1, vlen-2);
+                 } else {
+                     value.limitInit(p, vlen);

--- a/net/squid/patches/0004-fix-certificate-fields-injection.patch
+++ b/net/squid/patches/0004-fix-certificate-fields-injection.patch
@@ -1,0 +1,72 @@
+commit f1657a9decc820f748fa3aff68168d3145258031
+Author: Christos Tsantilas <christos@chtsanti.net>
+Date:   2018-10-17 15:14:07 +0000
+
+    Certificate fields injection via %D in ERR_SECURE_CONNECT_FAIL (#306)
+    
+    %ssl_subject, %ssl_ca_name, and %ssl_cn values were not properly escaped when %D code was expanded in HTML context of the ERR_SECURE_CONNECT_FAIL template. This bug affects all
+    ERR_SECURE_CONNECT_FAIL page templates containing %D, including the default template.
+    
+    Other error pages are not vulnerable because Squid does not populate %D with certificate details in other contexts (yet).
+    
+    Thanks to Nikolas Lohmann [eBlocker] for identifying the problem.
+    
+    TODO: If those certificate details become needed for ACL checks or other non-HTML purposes, make their HTML-escaping conditional.
+    
+    This is a Measurement Factory project.
+
+diff --git a/src/ssl/ErrorDetail.cc b/src/ssl/ErrorDetail.cc
+index b5030e3..314e998 100644
+--- a/src/ssl/ErrorDetail.cc
++++ b/src/ssl/ErrorDetail.cc
+@@ -8,6 +8,8 @@
+ 
+ #include "squid.h"
+ #include "errorpage.h"
++#include "fatal.h"
++#include "html_quote.h"
+ #include "ssl/ErrorDetail.h"
+ 
+ #include <climits>
+@@ -432,8 +434,11 @@ const char  *Ssl::ErrorDetail::subject() const
+ {
+     if (broken_cert.get()) {
+         static char tmpBuffer[256]; // A temporary buffer
+-        if (X509_NAME_oneline(X509_get_subject_name(broken_cert.get()), tmpBuffer, sizeof(tmpBuffer)))
+-            return tmpBuffer;
++        if (X509_NAME_oneline(X509_get_subject_name(broken_cert.get()), tmpBuffer, sizeof(tmpBuffer))) {
++            // quote to avoid possible html code injection through
++            // certificate subject
++            return html_quote(tmpBuffer);
++        }
+     }
+     return "[Not available]";
+ }
+@@ -461,8 +466,11 @@ const char *Ssl::ErrorDetail::cn() const
+         static String tmpStr;  ///< A temporary string buffer
+         tmpStr.clean();
+         Ssl::matchX509CommonNames(broken_cert.get(), &tmpStr, copy_cn);
+-        if (tmpStr.size())
+-            return tmpStr.termedBuf();
++        if (tmpStr.size()) {
++            // quote to avoid possible html code injection through
++            // certificate subject
++            return html_quote(tmpStr.termedBuf());
++        }
+     }
+     return "[Not available]";
+ }
+@@ -474,8 +482,11 @@ const char *Ssl::ErrorDetail::ca_name() const
+ {
+     if (broken_cert.get()) {
+         static char tmpBuffer[256]; // A temporary buffer
+-        if (X509_NAME_oneline(X509_get_issuer_name(broken_cert.get()), tmpBuffer, sizeof(tmpBuffer)))
+-            return tmpBuffer;
++        if (X509_NAME_oneline(X509_get_issuer_name(broken_cert.get()), tmpBuffer, sizeof(tmpBuffer))) {
++            // quote to avoid possible html code injection through
++            // certificate issuer subject
++            return html_quote(tmpBuffer);
++        }
+     }
+     return "[Not available]";
+ }


### PR DESCRIPTION
Maintainer: @ratkaj
Compile tested: Turris MOX, cortexa53, OpenWrt 18.06.04
Run tested: Turris MOX, cortexa53, OpenWrt 18.06.04

I was thinking if it would be better to update it to 4.x release, but as OpenWrt 18.06 should receive only security updates, which shouldn't bring incompatibility changes that's why I decided to stick with 3.x release.

Description:
- Update to version [3.5.28](http://squid-web-proxy-cache.1019090.n4.nabble.com/squid-announce-Squid-3-5-28-is-available-td4686141.html), which fixes:
CVE-2018-1000024
CVE-2018-1000027
CVE-2018-1172

- Add patches from Squid Proxy Cache Security Update Advisory:
http://www.squid-cache.org/Advisories/SQUID-2018_4.txt
Fixes CVE-2018-19131
http://www.squid-cache.org/Advisories/SQUID-2018_5.txt
Fixes CVE-2018-19132
http://www.squid-cache.org/Advisories/SQUID-2019_3.txt
Fixes CVE-2019-12525
http://www.squid-cache.org/Advisories/SQUID-2019_6.txt
Fixes CVE-2019-13345
