### PR TITLE
attr: Backport upstream patch fixing compilation without bzero

### DIFF
--- a/utils/attr/Makefile
+++ b/utils/attr/Makefile
@@ -9,18 +9,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=attr
 PKG_VERSION:=2.4.48
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://git.savannah.nongnu.org/cgit/attr.git/snapshot
 PKG_HASH:=095699f71230ace37e5bc680c6f9d15cf8e53eb38d00b2c46db5cc7e0712e5f3
+
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 
-PKG_LICENSE:=LGPL-2.1 GPL-2.0
-PKG_LICENSE_FILES:=doc/COPYING doc/COPYING.LGPL
-
-PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -39,6 +38,8 @@ $(call Package/attr/Default)
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE+=utils
+  LICENSE:=GPL-2.0-or-later
+  LICENSE_FILES:=doc/COPYING
   DEPENDS:=+libattr
 endef
 
@@ -47,6 +48,8 @@ $(call Package/attr/Default)
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE+=library
+  LICENSE:=LGPL-2.1-or-later
+  LICENSE_FILES:=doc/COPYING.LGPL
 endef
 
 define Package/libattr/description
@@ -81,8 +84,8 @@ define Package/attr/conffiles
 endef
 
 define Build/InstallDev
-	mkdir -p $(1)/usr/include
-	mkdir -p $(1)/usr/lib/pkgconfig
+	$(INSTALL_DIR) $(1)/usr/include
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/{include,lib} $(1)/usr/
 endef
 

--- a/utils/attr/patches/110-Replace-bzero-with-memset.patch
+++ b/utils/attr/patches/110-Replace-bzero-with-memset.patch
@@ -1,0 +1,69 @@
+From 0ce120a140dadaa56875af2efc66ff805d37925b Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sun, 11 Aug 2019 16:17:11 -0700
+Subject: [PATCH] attr: Replace bzero with memset
+
+bzero is a deprecated function that is optionally unavailable with
+uClibc-ng.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ include/attributes.h | 4 ++--
+ libattr/libattr.c    | 4 ++--
+ tools/attr.c         | 2 +-
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/include/attributes.h b/include/attributes.h
+index 14beb8f..039c817 100644
+--- a/include/attributes.h
++++ b/include/attributes.h
+@@ -91,9 +91,9 @@ typedef struct attrlist_ent {	/* data from attr_list() */
+  * Implement a "cursor" for use in successive attr_list() calls.
+  * It provides a way to find the last attribute that was returned in the
+  * last attr_list() call so that we can get the next one without missing
+- * any.  This should be bzero()ed before use and whenever it is desired to
++ * any.  This should be zeroed before use and whenever it is desired to
+  * start over from the beginning of the attribute list.  The only valid
+- * operation on a cursor is to bzero() it.
++ * operation on a cursor is to zero it.
+  */
+ typedef struct attrlist_cursor {
+ 	uint32_t	opaque[4];	/* an opaque cookie */
+diff --git a/libattr/libattr.c b/libattr/libattr.c
+index d550e10..2ebd1c5 100644
+--- a/libattr/libattr.c
++++ b/libattr/libattr.c
+@@ -298,7 +298,7 @@ attr_list(const char *path, char *buffer, const int buffersize, int flags,
+ 		errno = EINVAL;
+ 		return -1;
+ 	}
+-	bzero(buffer, sizeof(attrlist_t));
++	memset(buffer, 0, sizeof(attrlist_t));
+ 
+ 	if (flags & ATTR_DONTFOLLOW)
+ 		length = llistxattr(path, lbuf, sizeof(lbuf));
+@@ -348,7 +348,7 @@ attr_listf(int fd, char *buffer, const int buffersize, int flags,
+ 		errno = EINVAL;
+ 		return -1;
+ 	}
+-	bzero(buffer, sizeof(attrlist_t));
++	memset(buffer, 0, sizeof(attrlist_t));
+ 
+ 	length = flistxattr(fd, lbuf, sizeof(lbuf));
+ 	if (length < 0)
+diff --git a/tools/attr.c b/tools/attr.c
+index c8aa0b4..312aef1 100644
+--- a/tools/attr.c
++++ b/tools/attr.c
+@@ -228,7 +228,7 @@ main(int argc, char **argv)
+ 			perror("malloc");
+ 			exit(1);
+ 		}
+-		bzero((char *)&cursor, sizeof(cursor));
++		memset(&cursor, 0, sizeof(cursor));
+ 		do {
+ 			error = attr_list(filename, buffer, BUFSIZE,
+ 					  attrflags, &cursor);
+-- 
+2.17.1
+


### PR DESCRIPTION
Fixed up License information.

Added PKG_BUILD_PARALLEL for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mstorchak 
Compile tested: arc700