### PR TITLE
[18.06]openssh: fix pthread functions redefine with pam module

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
 PKG_VERSION:=7.7p1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
@@ -189,6 +189,7 @@ CONFIGURE_VARS += LD="$(TARGET_CC)"
 
 ifeq ($(BUILD_VARIANT),with-pam)
 TARGET_LDFLAGS += -lpthread
+TARGET_CFLAGS += -DUNSUPPORTED_POSIX_THREADS_HACK
 endif
 
 define Build/Compile


### PR DESCRIPTION
we should pass -DUNSUPPORTED_POSIX_THREADS_HACK to CFLAGS to openssh
to prevent function redefine, I don't know why pam module use
micro UNSUPPORTED_POSIX_THREADS_HACK to detect whether define
pthread functions, but not detect whether define
UNSUPPORTED_POSIX_THREADS_HACK.

Signed-off-by: Guo Li <uxgood.org@gmail.com>

Maintainer: @tripolar 

This was fixed upstream in later versions. But this is still an issue in 18.06: https://downloads.openwrt.org/releases/faillogs-18.06/arc_arc700/packages/openssh/with-pam/compile.txt