### PR TITLE
libgd: Properly disable iconv support

### DIFF
--- a/libs/libgd/Makefile
+++ b/libs/libgd/Makefile
@@ -9,16 +9,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgd
 PKG_VERSION:=2.2.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/gd-$(PKG_VERSION)/
 PKG_HASH:=8c302ccbf467faec732f0741a859eef4ecae22fea2d2ab87467be940842bde51
+
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
-
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
@@ -29,7 +30,7 @@ define Package/libgd
   CATEGORY:=Libraries
   DEPENDS:=+libjpeg +libpng +LIBGD_TIFF:libtiff +LIBGD_FREETYPE:libfreetype
   TITLE:=The GD graphics library
-  URL:=http://www.libgd.org/
+  URL:=https://libgd.github.io/
   MENU:=1
 endef
 
@@ -84,7 +85,9 @@ else
 endif
 
 CONFIGURE_VARS += \
-	ac_cv_header_iconv_h=no
+	ac_cv_header_iconv_h=no \
+	am_cv_func_iconv_works=no \
+	am_func_iconv=no
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
HAVE_ICONV and HAVE_ICONV_H are two different headers that both need to
evaluate to false. Added the extra CONFIGURE_VARS.

This can be verified by passing -Werror=implicit-function-declaration

Added PKG_LICENSE_FILES

Updated homepage URL.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jow- 
Compile tested: arc700 ath79
