### PR TITLE
redis: fix compilation for uClibc

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
 PKG_VERSION:=5.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/libs/redis/patches/030-fix-uclibc-compilation.patch
+++ b/libs/redis/patches/030-fix-uclibc-compilation.patch
@@ -1,0 +1,25 @@
+--- a/src/config.h
++++ b/src/config.h
+@@ -30,6 +30,10 @@
+ #ifndef __CONFIG_H
+ #define __CONFIG_H
+
++#if defined(__unix) || defined(__linux__)
++#include <features.h>
++#endif
++
+ #ifdef __APPLE__
+ #include <AvailabilityMacros.h>
+ #endif
+@@ -62,9 +66,9 @@
+ #endif
+
+ /* Test for backtrace() */
+-#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || \
++#if (defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__)) || \
+     defined(__FreeBSD__) || (defined(__OpenBSD__) && defined(USE_BACKTRACE))\
+- || defined(__DragonFly__)
++ || defined(__DragonFly__)) && !defined(__UCLIBC__)
+ #define HAVE_BACKTRACE 1
+ #endif
+


### PR DESCRIPTION

Maintainer: me
Compile tested: arc700 OpenWrt master
Run tested: N/A

Description:
This PR fixes redis compilation for targets with uClibc. It's based on https://github.com/antirez/redis/pull/537/commits/f496c59ba56df6b1afa2b942d30f900d6bc3488d

Fixes https://github.com/openwrt/packages/issues/9717
Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>
