### PR TITLE
libcap: copy pkgconfig file in staging directory

### DIFF
--- a/libs/libcap/Makefile
+++ b/libs/libcap/Makefile
@@ -71,6 +71,7 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/lib/* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
 endef
 
 define Package/libcap/install


### PR DESCRIPTION
This file is needed to enable libcap support in other packages,
such as iproute2's ip-full.

Signed-off-by: Alin Nastac <alin.nastac@gmail.com>

Maintainer: Paul Wassi <p.wassi@gmx.at>
@dedeckeh : FYI
