### PR TITLE
log4cplus: install host libraries into lib

### DIFF
--- a/libs/log4cplus/Makefile
+++ b/libs/log4cplus/Makefile
@@ -42,6 +42,9 @@ define Package/log4cplus/description
   configuration. It is modeled after the Java log4j API.
 endef
 
+CMAKE_HOST_OPTIONS += \
+	-DCMAKE_INSTALL_LIBDIR:PATH=lib
+
 CMAKE_OPTIONS += \
 	-DLOG4CPLUS_BUILD_LOGGINGSERVER:BOOL=OFF \
 	-DLOG4CPLUS_BUILD_TESTING:BOOL=OFF \


### PR DESCRIPTION
Maintainer: @rosysong, BangLang Huang (couldn't find github username)
Compile tested: host-compiled on gentoo x86_64, compiled kea/host to test
Run tested: N/A

Description:
Default host build for the package uses lib64, but dependents expect
libraries to be in $(STAGING_DIR_HOSTPKG)/lib.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

This is causing `kea/host/compile` to fail:
```
checking log4cplus/logger.h usability... yes
checking log4cplus/logger.h presence... yes
checking for log4cplus/logger.h... yes
checking for log4cplus library... no
configure: error: Needs log4cplus library
make[2]: *** [Makefile:200: /home/equeiroz/src/openwrt/build_dir/hostpkg/kea-1.5.0/.configured] Error 1
```
from `configure.log`:
```
configure:19009: g++ -o conftest -g -O2 -I/home/equeiroz/src/openwrt/staging_dir/hostpkg/include -I/home/equeiroz/src/openwrt/staging_dir/host/include -I/home/equeiroz/src/openwrt/staging_dir/hostpkg/include -I/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/host/include -DOS_LINUX -L/home/equeiroz/src/openwrt/staging_dir/host/lib -L/home/equeiroz/src/openwrt/staging_dir/hostpkg/lib -L/home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/host/lib -Wl,--gc-sections,--as-needed conftest.cpp -L/home/equeiroz/src/openwrt/staging_dir/hostpkg/lib -llog4cplus -pthread -ldl  >&5
/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -llog4cplus
collect2: error: ld returned 1 exit status
configure:19009: $? = 1
```
It looks like it is on its own installing to lib64, so instead of adding lib64 to kea/host, it's best to use lib here like everyone else:
```
$ ls -l staging_dir/hostpkg/lib64
total 2048
drwxr-xr-x 3 equeiroz users    4096 augo  9 18:58 cmake/
lrwxrwxrwx 1 equeiroz users      17 ago  9 18:58 liblog4cplus.so -> liblog4cplus.so.0*
lrwxrwxrwx 1 equeiroz users      21 ago  9 18:58 liblog4cplus.so.0 -> liblog4cplus.so.2.0.4*
-rwxr-xr-x 1 equeiroz users 2089408 ago  9 18:58 liblog4cplus.so.2.0.4*
```

This does not affect target compilation, so `PKG_RELEASE` was left untouched.