### PR TITLE
iotivity: force use of python2 for scons

### DIFF
--- a/net/iotivity/Makefile
+++ b/net/iotivity/Makefile
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=http://mirrors.kernel.org/${PKG_NAME}/${PKG_VERSION}/
 PKG_HASH:=7dcd9f0f48263c6b27a2c3d085dd7278b5c0feed1dfec8872a04899707fa23d8
 PKG_USE_MIPS16:=0
 
-PKG_BUILD_DEPENDS:=boost
+PKG_BUILD_DEPENDS:=boost python/host
 
 PKG_MAINTAINER:=Hauke Mehrtens <hauke.mehrtens@intel.com>
 
@@ -227,7 +227,7 @@ endef
 define Build/Configure
 	(cd $(PKG_BUILD_DIR); \
 		$(SCONS_VARS) \
-		scons \
+		python2.7 $(STAGING_DIR_HOST)/bin/scons.py \
 			$(SCONS_OPTIONS) \
 	)
 endef


### PR DESCRIPTION
Maintainer: @hauke 
Compile tested: arm, WRT3200ACM, openwrt master
Run tested: none, as this should not have changed the final package

Description:
iotivity's scons build script is not compatible with python3, so use python2.7 from python/host to run it.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

Migration of the scripts to python3 is not trivial (it's not all just adding `()` to `print`).  Here's a failure log:
```
scons: Reading SConscript files ...
  File "/builder/shared-workdir/build/sdk/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/iotivity-1.2.1/build_common/SConscript", line 40

    print "\nError: Current system (%s) isn't supported\n" % host

                                                         ^

SyntaxError: invalid syntax

Makefile:305: recipe for target '/builder/shared-workdir/build/sdk/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/iotivity-1.2.1/.configured_c2813c0fe0b88d47eeaf5ea5f0a831a2' failed
make[3]: *** [/builder/shared-workdir/build/sdk/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/iotivity-1.2.1/.configured_c2813c0fe0b88d47eeaf5ea5f0a831a2] Error 2
```