### PR TITLE
docker: fix openwrt modprobe warning

### DIFF
--- a/utils/docker-ce/patches/201-kmodloader.patch
+++ b/utils/docker-ce/patches/201-kmodloader.patch
@@ -1,0 +1,28 @@
+--- a/components/engine/vendor/github.com/docker/libnetwork/ns/init_linux.go
++++ b/components/engine/vendor/github.com/docker/libnetwork/ns/init_linux.go
+@@ -100,10 +100,10 @@ func getSupportedNlFamilies() []int {
+ }
+ 
+ func loadXfrmModules() error {
+-	if out, err := exec.Command("modprobe", "-va", "xfrm_user").CombinedOutput(); err != nil {
++	if out, err := exec.Command("modprobe", "xfrm_user").CombinedOutput(); err != nil {
+ 		return fmt.Errorf("Running modprobe xfrm_user failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+ 	}
+-	if out, err := exec.Command("modprobe", "-va", "xfrm_algo").CombinedOutput(); err != nil {
++	if out, err := exec.Command("modprobe", "xfrm_algo").CombinedOutput(); err != nil {
+ 		return fmt.Errorf("Running modprobe xfrm_algo failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+ 	}
+ 	return nil
+@@ -120,10 +120,10 @@ func checkXfrmSocket() error {
+ }
+ 
+ func loadNfConntrackModules() error {
+-	if out, err := exec.Command("modprobe", "-va", "nf_conntrack").CombinedOutput(); err != nil {
++	if out, err := exec.Command("modprobe", "nf_conntrack").CombinedOutput(); err != nil {
+ 		return fmt.Errorf("Running modprobe nf_conntrack failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+ 	}
+-	if out, err := exec.Command("modprobe", "-va", "nf_conntrack_netlink").CombinedOutput(); err != nil {
++	if out, err := exec.Command("modprobe", "nf_conntrack_netlink").CombinedOutput(); err != nil {
+ 		return fmt.Errorf("Running modprobe nf_conntrack_netlink failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+ 	}
+ 	return nil

--- a/utils/docker-ce/patches/202-kmodloader.patch
+++ b/utils/docker-ce/patches/202-kmodloader.patch
@@ -1,0 +1,11 @@
+--- a/components/engine/vendor/github.com/docker/libnetwork/ipvs/netlink.go
++++ b/components/engine/vendor/github.com/docker/libnetwork/ipvs/netlink.go
+@@ -61,7 +61,7 @@ func (f *ipvsFlags) Len() int {
+ func setup() {
+ 	ipvsOnce.Do(func() {
+ 		var err error
+-		if out, err := exec.Command("modprobe", "-va", "ip_vs").CombinedOutput(); err != nil {
++		if out, err := exec.Command("modprobe", "ip_vs").CombinedOutput(); err != nil {
+ 			logrus.Warnf("Running modprobe ip_vs failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+ 		}
+ 

--- a/utils/docker-ce/patches/203-kmodloader.patch
+++ b/utils/docker-ce/patches/203-kmodloader.patch
@@ -1,0 +1,11 @@
+--- a/components/engine/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
++++ b/components/engine/vendor/github.com/docker/libnetwork/drivers/bridge/bridge.go
+@@ -346,7 +346,7 @@ func (d *driver) configure(option map[st
+ 
+ 	if config.EnableIPTables {
+ 		if _, err := os.Stat("/proc/sys/net/bridge"); err != nil {
+-			if out, err := exec.Command("modprobe", "-va", "bridge", "br_netfilter").CombinedOutput(); err != nil {
++			if out, err := exec.Command("modprobe", "bridge", "br_netfilter").CombinedOutput(); err != nil {
+ 				logrus.Warnf("Running modprobe bridge br_netfilter failed with message: %s, error: %v", out, err)
+ 			}
+ 		}

--- a/utils/docker-ce/patches/204-kmodloader.patch
+++ b/utils/docker-ce/patches/204-kmodloader.patch
@@ -1,0 +1,15 @@
+--- a/components/engine/vendor/github.com/docker/libnetwork/iptables/iptables.go
++++ b/components/engine/vendor/github.com/docker/libnetwork/iptables/iptables.go
+@@ -72,10 +72,10 @@ func (e ChainError) Error() string {
+ }
+ 
+ func probe() {
+-	if out, err := exec.Command("modprobe", "-va", "nf_nat").CombinedOutput(); err != nil {
++	if out, err := exec.Command("modprobe", "nf_nat").CombinedOutput(); err != nil {
+ 		logrus.Warnf("Running modprobe nf_nat failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+ 	}
+-	if out, err := exec.Command("modprobe", "-va", "xt_conntrack").CombinedOutput(); err != nil {
++	if out, err := exec.Command("modprobe", "xt_conntrack").CombinedOutput(); err != nil {
+ 		logrus.Warnf("Running modprobe xt_conntrack failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+ 	}
+ }

--- a/utils/libnetwork/patches/201-kmodloader.patch
+++ b/utils/libnetwork/patches/201-kmodloader.patch
@@ -1,0 +1,28 @@
+--- a/ns/init_linux.go
++++ b/ns/init_linux.go
+@@ -100,10 +100,10 @@ func getSupportedNlFamilies() []int {
+ }
+ 
+ func loadXfrmModules() error {
+-	if out, err := exec.Command("modprobe", "-va", "xfrm_user").CombinedOutput(); err != nil {
++	if out, err := exec.Command("modprobe", "xfrm_user").CombinedOutput(); err != nil {
+ 		return fmt.Errorf("Running modprobe xfrm_user failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+ 	}
+-	if out, err := exec.Command("modprobe", "-va", "xfrm_algo").CombinedOutput(); err != nil {
++	if out, err := exec.Command("modprobe", "xfrm_algo").CombinedOutput(); err != nil {
+ 		return fmt.Errorf("Running modprobe xfrm_algo failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+ 	}
+ 	return nil
+@@ -120,10 +120,10 @@ func checkXfrmSocket() error {
+ }
+ 
+ func loadNfConntrackModules() error {
+-	if out, err := exec.Command("modprobe", "-va", "nf_conntrack").CombinedOutput(); err != nil {
++	if out, err := exec.Command("modprobe", "nf_conntrack").CombinedOutput(); err != nil {
+ 		return fmt.Errorf("Running modprobe nf_conntrack failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+ 	}
+-	if out, err := exec.Command("modprobe", "-va", "nf_conntrack_netlink").CombinedOutput(); err != nil {
++	if out, err := exec.Command("modprobe", "nf_conntrack_netlink").CombinedOutput(); err != nil {
+ 		return fmt.Errorf("Running modprobe nf_conntrack_netlink failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
+ 	}
+ 	return nil


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503 @yousong
Compile tested: x86_64, APU3, OpenWrt master
Run tested: x86_64, APU3, OpenWrt master, checked if warnings still present -> NO

Description:
Fix openwrt modprobe loading
