### PR TITLE
[openwrt-19.07] CI fixes and improvement

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -6,6 +6,7 @@ FROM debian:9
 # v1.0.1 - Run as non-root, add unzip, xz-utils
 # v1.0.2 - Add bzr
 # v1.0.3 - Verify usign signatures
+# v1.0.4 - Add support for Python3
 
 RUN apt update && apt install -y \
 build-essential \
@@ -18,6 +19,7 @@ git \
 libncurses5-dev \
 libssl-dev \
 python \
+python3 \
 signify-openbsd \
 subversion \
 time \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: docker.io/openwrtorg/packages-cci:v1.0.3
+      - image: docker.io/openwrtorg/packages-cci:v1.0.4
     environment:
       - SDK_HOST: "downloads.openwrt.org"
       - SDK_PATH: "snapshots/targets/ath79/generic"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,11 @@ jobs:
           working_directory: ~/build_dir
           command: |
              tar Jxf ~/sdk/$SDK_FILE --strip=1
+             touch .config
+             make prepare-tmpinfo scripts/config/conf
+             ./scripts/config/conf --defconfig=.config Config.in
+             make prereq
+             rm .config
              cat > feeds.conf <<EOF
              src-git base https://github.com/openwrt/openwrt.git;$BRANCH
              src-link packages $HOME/openwrt_packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,11 @@ jobs:
 
              for PKG in $PKGS ; do
                  echo_blue "===+ Building: $PKG"
-                 make "package/$PKG/compile" -j3 V=s
+                 make "package/$PKG/compile" -j3 V=s || {
+                        RET=$?
+                        echo_red "===+ Building: $PKG failed, rebuilding with -j1 for human readable error log"
+                        make "package/$PKG/compile" -j1 V=s; exit $RET
+                 }
              done
 
       - store_artifacts:


### PR DESCRIPTION
Maintainer: N/A
Compile tested: N/A
Run tested: N/A

Description:
These commits are cherry-picked from #9659. From that PR's description:

* add missing python3 package to the Docker image
* make package build failures more human readable
* use Docker image v1.0.4 with Python3 by default
* provide prereq output in the build log
