### PR TITLE
tang: do not build manpages

### DIFF
--- a/utils/tang/Makefile
+++ b/utils/tang/Makefile
@@ -25,6 +25,9 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
+# This avoids generating man pages
+CONFIGURE_VARS += ac_cv_prog_A2X=
+
 define Package/tang
   SECTION:=utils
   TITLE:=tang v$(PKG_VERSION) - daemon for binding data to the presence of a third party


### PR DESCRIPTION
Maintainer: @Tiboris 
Compile tested: arm, WRT3200ACM, openwrt master
Run tested: N/A

Description:
Ensure a2x is not found, so that manpages are not generated. They are currently failing to pass xmllint if a2x is found (tested with a2x 8.6.10, xmllint/libxml version 20909):
```
/bin/mkdir -p $(dirname doc/tang-show-keys.1.roff)
a2x -f manpage doc/tang-show-keys.1.adoc -D ./$(dirname doc/tang-show-keys.1.roff)
a2x: ERROR: "xmllint" --nonet --noout --valid "/home/equeiroz/src/openwrt/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/tang-7/doc/tang-show-keys.1.xml" returned non-zero exit status 4

make[3]: *** [Makefile:1346: doc/tang-show-keys.1.roff] Error 1
```
exit status 4 means a validation error.  With my system-installed `xmllint`, it passes, but fails with the one installed in `staging_dir/hostpkg/bin`.  Anyway, we don't need man pages here.

This should not affect final package, so `PKG_RELEASE` is left untouched.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>