### PR TITLE
bfdd: add BFD package

### DIFF
--- a/net/bfdd/Makefile
+++ b/net/bfdd/Makefile
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2019 Lucian Cristian <lucian.cristian@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bfdd
+PKG_SOURCE_DATE:=2019-08-22
+PKG_RELEASE:=1
+
+PKG_SOURCE_VERSION:=c54534beb524afc3972039f57b56ec65332b43f7
+PKG_SOURCE_URL:=https://codeload.github.com/rzalamena/bfdd/tar.gz/$(PKG_SOURCE_VERSION)?
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_DATE).tar.gz
+PKG_HASH:=8b65f502163aacfe43bb897464f3bf44bc5af4cc85d23b7c644e329abf89cc5f
+
+PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
+PKG_LICENSE:=GPL-2.0-or-later
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/bfdd
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  TITLE:=BFD daemon
+  URL:=https://github.com/rzalamena/bfdd
+  DEPENDS:=+libevent2 +libjson-c
+endef
+
+define Package/bfdd/description
+  A port of Cumulus BFD daemon to a more portable daemon.
+
+  Bidirectional Forwarding Detection (BFD) is a network protocol that is used to
+  detect faults between two forwarding engines connected by a link. It provides
+  low-overhead detection of faults even on physical media that doesn't support
+  failure detection of any kind, such as Ethernet, virtual circuits, tunnels and
+  MPLS Label Switched Paths.
+endef
+
+define Package/bfdd/conffiles
+/etc/bfdd/bfdd.json
+endef
+
+define Package/bfdd/install
+	$(INSTALL_DIR) \
+	 $(1)/usr/sbin \
+	 $(1)/etc/bfdd \
+	 $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/{bfdd,bfdctl} $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/bfdd.init $(1)/etc/init.d/bfdd
+	$(INSTALL_CONF) ./files/bfdd.template.json $(1)/etc/bfdd/bfdd.json
+endef
+
+$(eval $(call BuildPackage,bfdd))

--- a/net/bfdd/files/bfdd.init
+++ b/net/bfdd/files/bfdd.init
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=10
+USE_PROCD=1
+
+PROG="/usr/sbin/bfdd"
+CONF="/etc/bfdd/bfdd.json"
+
+start_service() {
+    procd_open_instance
+    procd_set_param command $PROG -c $CONF
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_set_param respawn
+    procd_close_instance
+}

--- a/net/bfdd/files/bfdd.template.json
+++ b/net/bfdd/files/bfdd.template.json
@@ -1,0 +1,57 @@
+{
+  "ipv4": [
+    {
+      "_create-only": "optional, defaults to false",
+      "_create-only-help": "If create-only is true then bfdd will return failure if a peer with the same target exists",
+      "create-only": true,
+
+      "_multihop": "optional defaults to false",
+      "multihop": false,
+
+      "_peer-address": "mandatory",
+      "peer-address": "127.0.0.1",
+
+      "_local-address": "mandatory on multihop",
+      "local-address": "127.0.0.1",
+
+      "_local-interface": "optional",
+      "local-interface": "enp0s3",
+
+      "_label": "optional",
+      "label": "peer1",
+
+      "_vxlan": "optional, defaults to 0",
+      "vxlan": 100,
+
+      "_vrf-name": "optional",
+      "vrf-name": "netns1",
+
+      "_detect-multiplier": "optional, defaults to 3",
+      "detect-multiplier": 3,
+
+      "_receive-interval": "optional, defaults to 300 milliseconds",
+      "receive-interval": 300,
+
+      "_transmit-interval": "optional, defaults to 300 milliseconds",
+      "transmit-interval": 300,
+
+      "_echo-interval": "optional, defaults to 50 milliseconds",
+      "echo-interval": 50,
+
+      "_echo-mode": "optional, defaults to false",
+      "echo-mode": false,
+
+      "_shutdown": "optional, defaults to false",
+      "shutdown": false
+    }
+  ],
+  "ipv6": [
+  ],
+  "label": [
+    {
+      "_label": "mandatory to identify the peer without addresses",
+      "_label-help": "peer must have been already created in ipv4 or ipv6",
+      "label": "peer1",
+    }
+  ]
+}

--- a/net/bfdd/patches/002-ipv6_musl_fix.patch
+++ b/net/bfdd/patches/002-ipv6_musl_fix.patch
@@ -1,0 +1,10 @@
+--- a/bfd_packet.c	2019-08-15 02:45:47.270120616 +0300
++++ b/bfd_packet.c	2019-08-15 02:44:38.266117706 +0300
+@@ -34,7 +34,6 @@
+ #include <linux/if_packet.h>
+ #include <linux/udp.h>
+ #include <linux/ip.h>
+-#include <linux/ipv6.h>
+ 
+ #include <arpa/inet.h>
+ #include <sys/types.h>


### PR DESCRIPTION
Bidirectional Forwarding Detection (BFD) is a network protocol that is used to
detect faults between two forwarding engines connected by a link.

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Description: useful in sub 1 second link fault detection for routing quick convergence
