### PR TITLE
squashfs-tools: need to include sys/sysmacros.h

### DIFF
--- a/utils/squashfs-tools/patches/0005-mksquashfs-unsquashfs-fix-compilation-with-glibc-2.2.patch
+++ b/utils/squashfs-tools/patches/0005-mksquashfs-unsquashfs-fix-compilation-with-glibc-2.2.patch
@@ -1,0 +1,47 @@
+From 968aa53dd6d2c0831a9af01873441767c06b88d0 Mon Sep 17 00:00:00 2001
+From: Thomas De Schampheleire <thomas.de_schampheleire@nokia.com>
+Date: Wed, 1 Aug 2018 12:17:10 +0200
+Subject: [PATCH] mksquashfs/unsquashfs: fix compilation with glibc 2.25+
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+From glibc 2.25 release notes:
+https://sourceware.org/ml/libc-alpha/2017-02/msg00079.html
+"* The inclusion of <sys/sysmacros.h> by <sys/types.h> is deprecated.
+  This means that in a future release, the macros “major”, “minor”, and
+  “makedev” will only be available from <sys/sysmacros.h>."
+
+See glibc bug https://sourceware.org/bugzilla/show_bug.cgi?id=19239 .
+---
+ squashfs-tools/mksquashfs.c | 1 +
+ squashfs-tools/unsquashfs.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/squashfs-tools/mksquashfs.c b/squashfs-tools/mksquashfs.c
+index d696a51..8d57c3e 100644
+--- a/squashfs-tools/mksquashfs.c
++++ b/squashfs-tools/mksquashfs.c
+@@ -35,6 +35,7 @@
+ #include <stddef.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <fcntl.h>
+ #include <errno.h>
+ #include <dirent.h>
+diff --git a/squashfs-tools/unsquashfs.c b/squashfs-tools/unsquashfs.c
+index a57f85c..a492b27 100644
+--- a/squashfs-tools/unsquashfs.c
++++ b/squashfs-tools/unsquashfs.c
+@@ -33,6 +33,7 @@
+ #include "fnmatch_compat.h"
+ 
+ #include <sys/sysinfo.h>
++#include <sys/sysmacros.h>
+ #include <sys/types.h>
+ #include <sys/time.h>
+ #include <sys/resource.h>
+-- 
+2.21.0
+


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: arm, WRT3200ACM, openwrt master
Run tested: N/A

Description:
The inclusion of `<sys/sysmacros.h>` by `<sys/types.h>` was deprecated and removed.  This is causing `major`, `minor`, and `makedev` to be undefined.
The patch is an upstream commit fixing it.

Here are the current build failure messages:
```
mksquashfs.c: In function 'create_inode':
mksquashfs.c:996:24: error: called object 'major' is not a function or function pointer
   unsigned int major = major(buf->st_rdev);
                        ^~~~~
mksquashfs.c:996:16: note: declared here
   unsigned int major = major(buf->st_rdev);
                ^~~~~
mksquashfs.c:997:24: error: called object 'minor' is not a function or function pointer
   unsigned int minor = minor(buf->st_rdev);
                        ^~~~~
mksquashfs.c:997:16: note: declared here
   unsigned int minor = minor(buf->st_rdev);
                ^~~~~
mksquashfs.c:1020:24: error: called object 'major' is not a function or function pointer
   unsigned int major = major(buf->st_rdev);
                        ^~~~~
mksquashfs.c:1020:16: note: declared here
   unsigned int major = major(buf->st_rdev);
                ^~~~~
mksquashfs.c:1021:24: error: called object 'minor' is not a function or function pointer
   unsigned int minor = minor(buf->st_rdev);
                        ^~~~~
mksquashfs.c:1021:16: note: declared here
   unsigned int minor = minor(buf->st_rdev);
                ^~~~~
mksquashfs.c: In function 'dir_scan2':
mksquashfs.c:3559:17: warning: implicit declaration of function 'makedev' [-Wimplicit-function-declaration]
   buf.st_rdev = makedev(pseudo_ent->dev->major,
                 ^~~~~~~
<builtin>: recipe for target 'mksquashfs.o' failed
make[4]: *** [mksquashfs.o] Error 1
```

This should not change the final package.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
