### PR TITLE
libuwifi: add userspace wifi library

### DIFF
--- a/libs/libuwifi/Makefile
+++ b/libs/libuwifi/Makefile
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2016 Bruno Randolf (br1@einfach.org)
+#               2019 Nick Hainke (vincent@systemli.org)
+#
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libuwifi
+PKG_VERSION:=2019-05-27
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/br101/libuwifi.git
+PKG_SOURCE_VERSION:=bb92bc9b041a077488f2fa5a1716902c7bb23e5b
+PKG_MIRROR_HASH:=c6dc795ef6c2cc87d411d3f907974f634a132c3e732db2597f96ff25a05faa05
+
+PKG_MAINTAINER:=Bruno Randolf <br1@einfach.org>, Nick Hainke <vincent@systemli.org>
+PKG_LICENSE:=LGPL-3.0-only
+PKG_LICENSE_FILES:=COPYING
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libuwifi
+	SECTION:=libs
+	CATEGORY:=Libraries
+	DEPENDS:=+libradiotap +libnl-tiny
+	TITLE:=Userspace Wifi Library
+endef
+
+define Package/libuwifi/description
+	Library for parsing, generating and analyzing Wifi (WLAN 802.11) frames in userspace and related functions.
+endef
+
+MAKE_FLAGS += DEBUG=0 LIBNL=tiny BUILD_RADIOTAP=0
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/uwifi
+	$(CP) $(PKG_BUILD_DIR)/include/uwifi/*.h $(1)/usr/include/uwifi
+	$(CP) $(PKG_BUILD_DIR)/ccan $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/build/libuwifi.{a,so*} $(1)/usr/lib/
+endef
+
+define Package/libuwifi/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/build/libuwifi.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libuwifi))


### PR DESCRIPTION
Add library to parse WiFi frames in userspace.

Signed-off-by: Nick Hainke <vincent@systemli.org>

Maintainer: @PolynomialDivision, @br101
Compile tested: OpenWrt@`dfe99645dbdd4460f394beaa3a05091cd40b5942`
Run tested: Will be tested in the future. (Lib is used by horst)

Description:
Libuwifi enables easy userspace handling of WiFi frames.
