### PR TITLE
ldbus: Pass CFLAGS to luarocks

### DIFF
--- a/lang/ldbus/Makefile
+++ b/lang/ldbus/Makefile
@@ -7,19 +7,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ldbus
-PKG_SOURCE_DATE:=2019-03-25
-PKG_SOURCE_VERSION:=345d820b0f34bd35ea01dae633d35ea3cf7faf2a
+PKG_SOURCE_DATE:=2019-08-15
+PKG_SOURCE_VERSION:=9e176fe851006037a643610e6d8f3a8e597d4073
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/daurnimator/ldbus
-PKG_MIRROR_HASH:=c0f5d1b34bc8b82d0f70bad23ecaca10ef84730c2c3ea318673b5a941f4dfc85
+PKG_MIRROR_HASH:=65fc7c975a17cfd3929b54973558205354fc285b6bd88a732c045e8444000d44
 
 PKG_MAINTAINER:=Enrico Mioso <mrkiko.rs@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_DEPENDS:=luarocks/host
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -28,6 +29,7 @@ define Package/ldbus
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=ldbus Lua DBus bindings
+  URL:=https://github.com/daurnimator/ldbus
   DEPENDS:=+dbus +lua
 endef
 
@@ -38,14 +40,6 @@ define Package/ldbus/description
   for details.
 endef
 
-TARGET_CFLAGS += \
-	-I$(STAGING_DIR)/usr/include
-
-MAKE_FLAGS += \
-	FPIC="$(FPIC)" \
-	CFLAGS="$(TARGET_CFLAGS)" \
-	LDFLAGS="$(TARGET_LDFLAGS)"
-
 define Build/Compile
   cd $(PKG_BUILD_DIR) && \
   luarocks make --pack-binary-rock ldbus-scm-0.rockspec \
@@ -54,7 +48,9 @@ define Build/Compile
     DBUS_INCDIR=$(STAGING_DIR)/usr/include/dbus-1.0/ \
     DBUS_ARCH_INCDIR=$(STAGING_DIR)/usr/lib/dbus-1.0/include \
     DBUS_LIBDIR=$(STAGING_DIR)/usr/lib \
-    CC="$(TARGET_CC)" LD="$(TARGET_CC)"
+    CC="$(TARGET_CC)" LD="$(TARGET_CC)" \
+    CFLAGS="$(TARGET_CFLAGS) $(FPIC)" \
+    LDFLAGS="$(TARGET_LDFLAGS)"
 endef
 
 define Package/ldbus/install


### PR DESCRIPTION
Otherwise, it doesn't get OpenWrt's cflags like -Os.

Added patch to fix build in C11 mode. strerror_s is a Microsoft
extension and not available with musl.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mrkiko 
Compile tested: mips64