### PR TITLE
[19.07] prometheus-node-exporter-lua: add target & system to OpenWrt collector

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2019.04.12
+PKG_VERSION:=2019.08.14
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
@@ -79,7 +79,7 @@ endef
 define Package/prometheus-node-exporter-lua-openwrt
   $(call Package/prometheus-node-exporter-lua/Default)
   TITLE+= (openwrt collector)
-  DEPENDS:=prometheus-node-exporter-lua
+  DEPENDS:=prometheus-node-exporter-lua +libubus-lua
 endef
 
 define Package/prometheus-node-exporter-lua-ltq-dsl

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/openwrt.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/openwrt.lua
@@ -1,20 +1,20 @@
+local ubus = require "ubus"
+local u = ubus.connect()
+local b = u:call("system", "board", {})
+
 local labels = {
-    id = "",
-    release = "",
-    revision = "",
-    model = string.sub(get_contents("/tmp/sysinfo/model"), 1, -2),
-    board_name = string.sub(get_contents("/tmp/sysinfo/board_name"), 1, -2)
+    board_name = b.board_name,
+    id = b.release.distribution,
+    model = b.model,
+    release = b.release.version,
+    revision = b.release.revision,
+    system = b.system,
+    target = b.release.target
 }
 
-for k, v in string.gmatch(get_contents("/etc/openwrt_release"), "(DISTRIB_%w+)='(.-)'\n") do
-    if k == "DISTRIB_ID" then
-        labels["id"] = v
-    elseif k == "DISTRIB_RELEASE" then
-        labels["release"] = v
-    elseif k == "DISTRIB_REVISION" then
-        labels["revision"] = v
-    end
-end
+b = nil
+u = nil
+ubus = nil
 
 local function scrape()
     metric("node_openwrt_info", "gauge", labels, 1)


### PR DESCRIPTION
Maintainer: me
Compile & run tested: GL.iNet GL-AR150 / OpenWrt 19.07-SNAPSHOT r10306+1-d97c6d9f09

Description:

Before:
node_openwrt_info{revision="r10756+1-7546be6007",model="GL.iNet GL-AR150",id="OpenWrt",board_name="glinet,gl-ar150",release="SNAPSHOT"} 1

After:
node_openwrt_info{revision="r10756+1-7546be6007",target="ath79/generic",board_name="glinet,gl-ar150",id="OpenWrt",model="GL.iNet GL-AR150",release="SNAPSHOT",system="Atheros AR9330 rev 1"} 1

Fixes #9730, replace #9735

Signed-off-by: Etienne Champetier <champetier.etienne@gmail.com>
(cherry picked from commit a14bed1bc959116617b0eb75d2d9a46551a480e6)


