### PR TITLE
Add Edgescale packages

### DIFF
--- a/net/eds-bootstrap-enroll/Makefile
+++ b/net/eds-bootstrap-enroll/Makefile
@@ -1,0 +1,38 @@
+#
+# Copyright 2019 NXP
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=eds-bootstrap-enroll
+PKG_VERSION:=lsdk-1903
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/NXP/qoriq-eds-bootstrap.git
+PKG_SOURCE_VERSION:=385ec26acec4e1dc891c1d0e63ed577485a85f46
+PKG_MIRROR_HASH:=4245eb260c0fbde2ec870ba50346004c968ad3729ae7cbfa334ca1db821d4598
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+define Package/bootstrap-enroll
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Edgescale for edge computing
+  TITLE:=Bootstrap certificate enroll tool
+  DEPENDS:=@(arm||aarch64) +bash +curl +dnsmasq
+endef
+
+define Build/Compile
+endef
+
+define Package/bootstrap-enroll/install
+	$(INSTALL_DIR) $(1)/usr/local/edgescale/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(LINUX_KARCH)/bootstrap-enroll $(1)/usr/local/edgescale/bin
+endef
+
+$(eval $(call BuildPackage,bootstrap-enroll))

--- a/net/eds-kubelet/Config.in
+++ b/net/eds-kubelet/Config.in
@@ -1,0 +1,21 @@
+config EDGESCALE_KUBELET_KERNEL_SUPPORT
+	bool "Kernel support for Edgescale Kubelet"
+	depends on PACKAGE_edgescale-kubelet
+	select KERNEL_NAMESPACES
+	select KERNEL_NET_NS
+	select KERNEL_PID_NS
+	select KERNEL_IPC_NS
+	select KERNEL_UTS_NS
+	select KERNEL_CGROUPS
+	select KERNEL_CGROUP_CPUACCT
+	select KERNEL_CGROUP_DEVICE
+	select KERNEL_CGROUP_FREEZER
+	select KERNEL_CGROUP_SCHED
+	select KERNEL_CPUSETS
+	select KERNEL_MEMCG
+	select KERNEL_KEYS
+	select KERNEL_LXC_MISC
+	select KERNEL_POSIX_MQUEUE
+	default y
+	help
+	  This enables kerenl options required by Edgescale Kubelet.

--- a/net/eds-kubelet/Makefile
+++ b/net/eds-kubelet/Makefile
@@ -1,0 +1,70 @@
+#
+# Copyright 2019 NXP
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=eds-kubelet
+PKG_VERSION:=lsdk-1903
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/NXP/qoriq-eds-kubelet.git
+PKG_SOURCE_VERSION:=cf5175b3186e1308cc29a6295fb7bd012b614a22
+PKG_MIRROR_HASH:=5cd302bc73a1ab21245bdcd2009e5c39c0e244f62c78904fd940fca6ea0a8ca2
+
+HOST_GO_PREFIX:=$(STAGING_DIR_HOSTPKG)
+HOST_GO_VERSION_ID:=cross
+HOST_GO_ROOT:=$(HOST_GO_PREFIX)/lib/go-$(HOST_GO_VERSION_ID)
+TARGET_GO_PATH:=$(STAGING_DIR)/usr/share/gocode
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+define Package/edgescale-kubelet
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Edgescale for edge computing
+  TITLE:=Edgescale Kubelet
+  DEPENDS:=@(arm||aarch64) +edgescale \
+    +kmod-veth +kmod-br-netfilter +kmod-nf-ipvs +kmod-nf-nat +kmod-ipt-extra \
+    +iptables +iptables-mod-extra +haveged +resize2fs
+endef
+
+define Package/edgescale-kubelet/config
+	source "$(SOURCE)/Config.in"
+endef
+
+define Build/Compile
+	cd $(BUILD_DIR); \
+	export PATH=$(HOST_GO_ROOT)/bin:$(PATH); \
+	export GOROOT=$(HOST_GO_ROOT); \
+	export GOPATH=$(TARGET_GO_PATH); \
+	if [ ! -d $(TARGET_GO_PATH)/src/k8s.io ]; then \
+		mkdir -p $(TARGET_GO_PATH)/src/k8s.io; \
+	fi; \
+	mkdir -p $(TARGET_GO_PATH)/images; \
+	if [ ! -f $(TARGET_GO_PATH)/src/k8s.io/kubernetes/pkg/version/version.go ]; then  \
+		wget -c https://github.com/kubernetes/kubernetes/archive/v1.7.0.tar.gz; \
+		tar -xf v1.7.0.tar.gz; \
+		mv kubernetes-1.7.0 $(TARGET_GO_PATH)/src/k8s.io/kubernetes; \
+		rm v1.7.0.tar.gz; \
+	fi; \
+	export CGO_ENABLED=1 GOOS=linux GOARCH=$(LINUX_KARCH); \
+	export CC=$(KERNEL_CROSS)gcc; \
+	cd $(TARGET_GO_PATH)/src/k8s.io/kubernetes; \
+	go env; \
+	go build -o $(TARGET_GO_PATH)/images/kubelet --ldflags="-w -s" cmd/kubelet/kubelet.go
+endef
+
+define Package/edgescale-kubelet/install
+	$(INSTALL_DIR) $(1)/usr/local/edgescale/bin
+	$(INSTALL_BIN) $(TARGET_GO_PATH)/images/kubelet $(1)/usr/local/edgescale/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/scripts/* $(1)/usr/local/edgescale/bin/
+	sed -i s/pause-arm64/pause-$(LINUX_KARCH)/g $(1)/usr/local/edgescale/bin/k8s.sh
+endef
+
+$(eval $(call BuildPackage,edgescale-kubelet))

--- a/net/eds-kubelet/patches/0001-Specify-to-use-bash-in-top-line.patch
+++ b/net/eds-kubelet/patches/0001-Specify-to-use-bash-in-top-line.patch
@@ -1,0 +1,31 @@
+From 028758daf58337ca700411e10cd18d3d40be6a02 Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Thu, 7 Mar 2019 16:50:00 +0800
+Subject: [PATCH 1/3] Specify to use bash in top line
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ scripts/k8s.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/scripts/k8s.sh b/scripts/k8s.sh
+index 0cbe8c5..1a99c4e 100755
+--- a/scripts/k8s.sh
++++ b/scripts/k8s.sh
+@@ -1,11 +1,11 @@
++#!/bin/bash
++
+ #####################################
+ #
+ # Copyright 2017 NXP
+ #
+ #####################################
+ 
+-#!/bin/bash
+-
+ echo "Start kubelet"
+ 
+ podpause="edgerepos/pause-arm64:3.0"
+-- 
+2.17.1
+

--- a/net/eds-kubelet/patches/0002-Convert-to-use-kubelet-as-root-dir.patch
+++ b/net/eds-kubelet/patches/0002-Convert-to-use-kubelet-as-root-dir.patch
@@ -1,0 +1,26 @@
+From a1b6557ed4377ee63ee9fb81b707c6007e35803e Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Thu, 7 Mar 2019 16:53:54 +0800
+Subject: [PATCH 2/3] Convert to use /kubelet as root-dir
+
+The default root-dir is in /var which is a link to /tmp.
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ scripts/k8s.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/k8s.sh b/scripts/k8s.sh
+index 1a99c4e..10b485c 100755
+--- a/scripts/k8s.sh
++++ b/scripts/k8s.sh
+@@ -19,5 +19,5 @@ mkdir -p /dev/kubelet; mkdir -p /var/lib/kubelet/;mkdir -p /var/log/edgescale
+ export PATH=/usr/local/edgescale/bin/:$PATH
+ 
+ 
+-kubelet --address=127.0.0.1 --pod-infra-container-image=$podpause --image-gc-high-threshold=99 --image-gc-low-threshold=95 --image-pull-progress-deadline=10m --pod-manifest-path=/dev/kubelet/ --allow-privileged=true --logtostderr=true  --v=1 > /var/log/edgescale/kubelet.log 2>&1 &
++kubelet --root-dir=/kubelet/ --address=127.0.0.1 --pod-infra-container-image=$podpause --image-gc-high-threshold=99 --image-gc-low-threshold=95 --image-pull-progress-deadline=10m --pod-manifest-path=/dev/kubelet/ --allow-privileged=true --logtostderr=true  --v=1 > /var/log/edgescale/kubelet.log 2>&1 &
+ 
+-- 
+2.17.1
+

--- a/net/eds-kubelet/patches/0003-Add-shell-file-to-set-up-docker.patch
+++ b/net/eds-kubelet/patches/0003-Add-shell-file-to-set-up-docker.patch
@@ -1,0 +1,72 @@
+From 09a9ef9575d8a3d947411ce860935adde2431aa2 Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Fri, 8 Mar 2019 11:31:34 +0800
+Subject: [PATCH] Add shell file to set up docker
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ scripts/docker-setup.sh | 37 +++++++++++++++++++++++++++++++++++++
+ scripts/k8s.sh          |  3 +++
+ 2 files changed, 40 insertions(+)
+ create mode 100755 scripts/docker-setup.sh
+
+diff --git a/scripts/docker-setup.sh b/scripts/docker-setup.sh
+new file mode 100755
+index 0000000..8442f2b
+--- /dev/null
++++ b/scripts/docker-setup.sh
+@@ -0,0 +1,37 @@
++#!/bin/bash
++
++DOCKER_URL=https://download.docker.com/linux/static/stable
++DOCKER_VER=18.09.3
++DOCKER_PKG=docker.tgz
++
++which docker 1>/dev/null 2>/dev/null
++if [ $? -ne 0 ];then
++	ARCH=$(uname -m)
++	if [ ${ARCH} == "aarch64" ];then
++		ARCH=aarch64
++	elif [ ${ARCH} == "arm" ];then
++		ARCH=armhf
++	else
++		echo "${ARCH}: docker is not supported now!"
++		exit 1
++	fi
++
++	echo "Download and install docker for ${ARCH}..."
++
++	curl ${DOCKER_URL}/${ARCH}/docker-${DOCKER_VER}.tgz -o /tmp/${DOCKER_PKG}
++	tar zxvf /tmp/${DOCKER_PKG} -C /tmp 1>/dev/null 2>/dev/null
++	mv /tmp/docker/* /usr/bin
++	rm /tmp/${DOCKER_PKG} /tmp/docker -rf
++fi
++
++docker info 1>/dev/null 2>/dev/null
++while [ $? -ne 0 ]
++do
++	echo "Restart up docker..."
++	killall -9 dockerd 1>/dev/null 2>/dev/null
++	dockerd --data-root /docker/lib --exec-root /docker/run 1>/dev/null 2>/var/log/docker-err.log &
++	sleep 3
++	docker info 1>/dev/null 2>/dev/null
++done
++
++echo "Docker started up!"
+diff --git a/scripts/k8s.sh b/scripts/k8s.sh
+index 10b485c..fc76ab5 100755
+--- a/scripts/k8s.sh
++++ b/scripts/k8s.sh
+@@ -6,6 +6,9 @@
+ #
+ #####################################
+ 
++echo "Set up docker"
++/usr/local/edgescale/bin/docker-setup.sh
++
+ echo "Start kubelet"
+ 
+ podpause="edgerepos/pause-arm64:3.0"
+-- 
+2.17.1
+

--- a/net/eds/Config.in
+++ b/net/eds/Config.in
@@ -1,0 +1,16 @@
+config EDGESCALE_BUSYBOX_SUPPORT
+	bool "Busybox support for Edgescale"
+	depends on PACKAGE_edgescale
+	select BUSYBOX_CUSTOM
+	select BUSYBOX_CONFIG_HOSTNAME
+	default y
+	help
+	  This enables Busybox options required by Edgescale.
+
+config EDGESCALE_KERNEL_SUPPORT
+	bool "Kernel support for Edgescale"
+	depends on PACKAGE_edgescale
+	select KERNEL_DEVMEM
+	default y
+	help
+	  This enables kerenl options required by Edgescale.

--- a/net/eds/Makefile
+++ b/net/eds/Makefile
@@ -1,0 +1,77 @@
+#
+# Copyright 2019 NXP
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=eds
+PKG_VERSION:=lsdk-1903
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/NXP/qoriq-edgescale-eds.git
+PKG_SOURCE_VERSION:=7d70a8767941aed135d609300a0594dfdc60e5ea
+PKG_MIRROR_HASH:=6add268eee57dd9b1fd8acfcafd529caf921b7c7b3c8a1fd0bd84b3a44d613d2
+
+HOST_GO_PREFIX:=$(STAGING_DIR_HOSTPKG)
+HOST_GO_VERSION_ID:=cross
+HOST_GO_ROOT:=$(HOST_GO_PREFIX)/lib/go-$(HOST_GO_VERSION_ID)
+TARGET_GO_PATH:=$(STAGING_DIR)/usr/share/gocode
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+define Package/edgescale
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Edgescale for edge computing
+  TITLE:=Edgescale agent
+  DEPENDS:=@(arm||aarch64) +bootstrap-enroll \
+    +fdisk +e2fsprogs +mount-utils +kmod-loop +badblocks \
+    +golang-src \
+    +coreutils +coreutils-date \
+    +ethtool +ca-certificates
+endef
+
+define Package/edgescale/config
+	source "$(SOURCE)/Config.in"
+endef
+
+define Build/Compile
+	export PATH=$(HOST_GO_ROOT)/bin:$(PATH); \
+	export GOROOT=$(HOST_GO_ROOT); \
+	export GOPATH=$(TARGET_GO_PATH); \
+	cd $(PKG_BUILD_DIR)/cert-agent; \
+	go get github.com/edgeiot/est-client-go; \
+	go get github.com/go-yaml/yaml; \
+	env CGO_ENABLED=1 GOOS=linux GOARCH=$(LINUX_KARCH) CC=$(KERNEL_CROSS)gcc \
+	    go build -o cert-agent --ldflags="-w -s" --tags "default"; \
+	cd $(PKG_BUILD_DIR)/mq-agent; \
+	go get github.com/sirupsen/logrus; \
+	go get github.com/sigma/systemstat; \
+	go get github.com/eclipse/paho.mqtt.golang; \
+	go get github.com/shirou/gopsutil/disk; \
+	env GOOS=linux GOARCH=$(LINUX_KARCH) CGO_ENABLED=1  CC=$(KERNEL_CROSS)gcc \
+	    go build --ldflags="-w -s" --tags "default"
+endef
+
+define Package/edgescale/install
+	$(INSTALL_DIR) $(1)/usr/local/edgescale/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/cert-agent/cert-agent $(1)/usr/local/edgescale/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/mq-agent/mq-agent $(1)/usr/local/edgescale/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/startup/env.sh $(1)/usr/local/edgescale/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/startup/startup.sh $(1)/usr/local/edgescale/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/startup/ota-updateSet $(1)/usr/local/edgescale/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/startup/ota-statuscheck $(1)/usr/local/edgescale/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/startup/mmc-check.sh $(1)/usr/local/edgescale/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/startup/factory_reset.sh $(1)/usr/local/edgescale/bin/
+	$(INSTALL_DIR) $(1)/usr/local/edgescale/conf
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/etc/edgescale-version $(1)/usr/local/edgescale/conf/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/etc/edgescale $(1)/etc/init.d/
+endef
+
+$(eval $(call BuildPackage,edgescale))

--- a/net/eds/README
+++ b/net/eds/README
@@ -1,0 +1,202 @@
+
+Edgescale Quick Start
+
+1. What's Edgescale
+-------------------
+EdgeScale is a unified, scalable, and secure device management solution
+for Edge Computing applications. It enables OEMs and developers to
+leverage cloud compute frameworks like AWS Greengrass, Azure IoT, and
+Aliyun on Layerscape devices.
+
+EdgeScale provides the missing piece of device security and management
+needed for customers to securely deploy and manage many Edge computing
+devices from the cloud. End-users and developers can use the EdgeScale
+cloud dashboard to securely enroll Edge devices, monitor their health,
+attest, and deploy container applications and firmware updates.
+
+EdgeScale can also be used as a development environment to build
+containers and generate firmware.
+
+Edgescale website:
+https://www.nxp.com/support/developer-resources/run-time-software/
+linux-software-and-development-tools/edgescale-for-secure-edge-computing:EDGESCALE
+
+2. Supported features
+---------------------
+  * EdgeScale dashboard for users
+  * Secure device enrolment
+  * Secure key/certificate provisioning
+  * OTA: firmware update
+  * Device status monitoring on the cloud
+  * Dynamic deployment of container-based applications
+
+Note: OTA of Edgescale is currently not supported for OpenWrt.
+
+3. Supported targets
+--------------------
+NXP Edgescale aims at not only NXP Layerscape targets. It could be
+extended and deployed to any other targets easily even with different
+architecture.
+
+To support dynamic deployment of container-based applications, Edgescale
+requires large free storage space in rootfs partition. So it's recommended
+to use SD for rootfs storage.
+
+Below are two Layerscape boards which had been verified.
+
+  * LS1043ARDB SD card boot
+  * LS1046ARDB SD card boot
+
+4. Build
+--------
+
+Refer to OpenWrt documentation for build steps. In menuconfig stage, besides
+the options required for target build in menuconfig, just select all options
+in "Edgescale for edge computing".
+
+* Target build options
+Here is an example for LS1043ARDB SD card boot.
+
+  +--------------------------------------------------------------+
+  | Target System (NXP Layerscape)  --->                         |
+  | Subtarget (ARMv8 64-bit based boards)  --->                  |
+  | Target Profile (LS1043ARDB (SD Card Boot))  --->             |
+  | Target Images  --->                                          |
+  |   [*] ext4  --->                                             |
+  |       (0)   Percentage of reserved blocks in root filesystem |
+  |       Root filesystem block size (1k)  --->                  |
+  |       [ ]   Create a journaling filesystem                   |
+  |   (512) Root filesystem partition size (in MB)               |
+  +--------------------------------------------------------------+
+
+Note: Make sure enough space for rootfs. Here we use 512MB rootfs
+partition on SD card. We could resized the partition to enlarge it 
+online with fdisk/resize2fs in OpenWrt when Edgescale needs.
+
+* Edgescale options
+
+  +------------------------------------------------+
+  | Network  --->                                  |
+  |   Edgescale for edge computing  --->           |
+  |     -*- bootstrap-enroll                       |
+  |     -*- edgescale                              |
+  |     [*]   Busybox support for Edgescale        |
+  |     <*> edgescale-kubelet                      |
+  |     [*]   Kernel support for Edgescale Kubelet |
+  +------------------------------------------------+
+
+5. Run Edgescale
+----------------
+
+After flashing OpenWrt firmware to SD card, please refer to "Getting Started"
+chapter of Edgescale documentation (v0.5), for connecting to cloud and
+deploying APP.
+  - https://doc.edgescale.org/quickstart.html#
+
+The only difference on OpenWrt are the steps in "Prepare Devices". After step 1
+and step 2, just start up OpenWrt from SD card.
+  1. Create Device
+  2. Download & Provision Device Identity
+
+And follow new steps below.
+  3. Enlarge rootfs partition (See 7. Resizing partition log)
+
+     - Delete origin rootfs partition, and create a new larger partition
+       instead, with same start sector number.
+       $ fdisk /dev/mmcblk0
+
+     - Resize the partition
+       $ resize2fs /dev/mmcblk0p1
+     
+  4. Connect WAN port to Internet
+
+     - Check current WAN port and connect to Internet.
+       $ uci get network.wan.ifname
+
+     - If want to change WAN port for Internet accessing, use commands below.
+       $ uci set network.wan.ifname=ethx
+       $ uci set network.wan6.ifname=ethx
+       $ /etc/init.d/network restart
+
+     - Ping test.
+       $ ping www.baidu.com
+
+  5. Bringing the Device On-line
+
+     Run Edgescale with below command, and refresh "My Devices" in Edgescale
+     Dashboard showing the device as online.
+
+     $ /etc/init.d/edgescale start
+
+6. Known issues
+---------------
+NA
+
+7. Resizing partition log
+-------------------------
+
+============================= Log =================================
+root@OpenWrt:/# df -h
+Filesystem                Size      Used Available Use% Mounted on
+/dev/root               471.8M    249.5M    208.1M  55% /
+tmpfs                   942.4M     48.0K    942.4M   0% /tmp
+tmpfs                   512.0K         0    512.0K   0% /dev
+root@OpenWrt:/# fdisk /dev/mmcblk0
+
+Welcome to fdisk (util-linux 2.33).
+Changes will remain in memory only, until you decide to write them.
+Be careful before using the write command.
+
+
+Command (m for help): p
+Disk /dev/mmcblk0: 29.8 GiB, 32015122432 bytes, 62529536 sectors
+Units: sectors of 1 * 512 = 512 bytes
+Sector size (logical/physical): 512 bytes / 512 bytes
+I/O size (minimum/optimal): 512 bytes / 512 bytes
+Disklabel type: dos
+Disk identifier: 0x5452574f
+
+Device         Boot  Start        End    Sectors  Size Id Type
+/dev/mmcblk0p1 *    131072 1073872895 1073741824  512G 83 Linux
+
+Command (m for help): d
+Selected partition 1
+Partition 1 has been deleted.
+
+Command (m for help): n
+Partition type
+   p   primary (0 primary, 0 extended, 4 free)
+   e   extended (container for logical partitions)
+Select (default p):
+
+Using default response p.
+Partition number (1-4, default 1):
+First sector (2048-62529535, default 2048): 131072
+Last sector, +/-sectors or +/-size{K,M,G,T,P} (131072-62529535, default 62529535): 8529535
+
+Created a new partition 1 of type 'Linux' and of size 4 GiB.
+Partition #1 contains a ext4 signature.
+
+Do you want to remove the signature? [Y]es/[N]o: N
+
+Command (m for help): w
+
+The partition table has been altered.
+Syncing disks.
+
+root@OpenWrt:/# resize2fs /dev/mmcblk0p1
+resize2fs 1.44.5 (15-Dec-2018)
+Filesystem at /d[   81.708322] EXT4-fs (mmcblk0p1): resizing filesystem from 524288 to 4199232 blocks
+ev/mmcblk0p1 is mounted on /; on-line resizing required
+old_desc_blocks = 2, new_desc_blocks = 17
+[   81.960715] EXT4-fs (mmcblk0p1): resized filesystem to 4199232
+The filesystem on /dev/mmcblk0p1 is now 4199232 (1k) blocks long.
+
+root@OpenWrt:/# df -h
+Filesystem                Size      Used Available Use% Mounted on
+/dev/root                 3.7G    250.3M      3.5G   7% /
+tmpfs                   942.4M     64.0K    942.3M   0% /tmp
+tmpfs                   512.0K         0    512.0K   0% /dev
+root@OpenWrt:/#
+
+================================ Log End ==============================

--- a/net/eds/patches/0001-startup-adapt-start-stop-daemon-using-for-OpenWrt.patch
+++ b/net/eds/patches/0001-startup-adapt-start-stop-daemon-using-for-OpenWrt.patch
@@ -1,0 +1,33 @@
+From 6ae73cd6a108a03b9b82be53b9b4df89d9c52bc7 Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Wed, 6 Mar 2019 11:38:30 +0800
+Subject: [PATCH 1/3] startup: adapt start-stop-daemon using for OpenWrt
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ startup/startup.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/startup/startup.sh b/startup/startup.sh
+index 083fffd..3a52b38 100755
+--- a/startup/startup.sh
++++ b/startup/startup.sh
+@@ -24,7 +24,7 @@ cd /usr/local/edgescale/bin/
+ mkdir -p /data
+ 
+ ./env.sh
+-start-stop-daemon --start --startas /bin/tee-supplicant --name tee-supplicant -m --pidfile /var/run/tee-supplicant.pid -b
++start-stop-daemon -S -a /bin/tee-supplicant -n tee-supplicant -m -p /var/run/tee-supplicant.pid -b
+ ./cert-agent
+ 
+ . /data/config.env
+@@ -55,5 +55,5 @@ if [ $? -eq 0 ];then
+     ./mmc-check.sh &
+ 
+     # starting mq-agent
+-    start-stop-daemon --start --startas /usr/local/edgescale/bin/mq-agent --name mq-agent -m --pidfile /var/run/mq-agent.pid -b
++    start-stop-daemon -S -a /usr/local/edgescale/bin/mq-agent -n mq-agent -m -p /var/run/mq-agent.pid -b
+ fi
+-- 
+2.17.1
+

--- a/net/eds/patches/0002-startup-show-warning-if-no-Internet-access.patch
+++ b/net/eds/patches/0002-startup-show-warning-if-no-Internet-access.patch
@@ -1,0 +1,61 @@
+From ad256482d886a87fe768de44265bb434777f20f5 Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Wed, 6 Mar 2019 11:56:50 +0800
+Subject: [PATCH 2/3] startup: show warning if no Internet access
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ startup/env.sh | 37 +++++++------------------------------
+ 1 file changed, 7 insertions(+), 30 deletions(-)
+
+diff --git a/startup/env.sh b/startup/env.sh
+index 49b268b..50940ab 100755
+--- a/startup/env.sh
++++ b/startup/env.sh
+@@ -84,36 +84,13 @@ httpdate() {
+ 
+ curl -k --connect-timeout 10 $testserver >/dev/null 2>&1
+ if [ $? -ne 0 ];then
+-	ok=0
+-	ethlist=$(ip -o link show|awk -F ":" '{print $2}'|sed 's/\ //g'|grep -ie fm -ie ^e)
+-	for eth in $ethlist;do
+-		ifconfig $eth down
+-	done
+-	
+-	for eth in $ethlist;do
+-		echo "Checking for ethernet port $eth" 
+-		ifconfig $eth up;sleep 10
+-	
+-		if ethtool $eth|grep "Link detected: yes";then
+-			if [ -z $udhcpc ];then
+-				dhclient -r $eth; dhclient $eth
+-			else
+-				udhcpc -i $eth
+-			fi
+-
+-			ip r |grep "default"
+-			if [ $? -ne 0 ];then
+-				ifconfig $eth down;continue
+-			fi
+-				
+-		else
+-			ifconfig $eth down;continue
+-		fi
+-	
+-		curl -k --connect-timeout 30 $testserver >/dev/null 2>&1 && \
+-		ok=1;echo "network ethernet port is $eth"; ifconfig $eth; ip r;break
+-	done
+-	
++	ethwan=$(uci get network.wan.ifname)
++	echo "Please make sure Internet access to WAN port ${ethwan}!"
++	echo "Or reconfigure new WAN port:"
++	echo "    uci set network.wan.ifname=ethx"
++	echo "    uci set network.wan6.ifname=ethx"
++	echo "    /etc/init.d/network restart"
++	exit 1
+ fi
+ #for a in `seq 5`; do
+ for a in 1 2 3 4 5;do
+-- 
+2.17.1
+

--- a/net/eds/patches/0003-startup-create-run-directory-before-using.patch
+++ b/net/eds/patches/0003-startup-create-run-directory-before-using.patch
@@ -1,0 +1,25 @@
+From 9599490f67dbcdd61355bb30f5cd566233b87084 Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Wed, 6 Mar 2019 13:50:08 +0800
+Subject: [PATCH 3/3] startup: create /run directory before using
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ startup/startup.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/startup/startup.sh b/startup/startup.sh
+index 3a52b38..b9295a2 100755
+--- a/startup/startup.sh
++++ b/startup/startup.sh
+@@ -22,6 +22,7 @@ push_publicip() {
+ 
+ cd /usr/local/edgescale/bin/
+ mkdir -p /data
++mkdir -p /run
+ 
+ ./env.sh
+ start-stop-daemon -S -a /bin/tee-supplicant -n tee-supplicant -m -p /var/run/tee-supplicant.pid -b
+-- 
+2.17.1
+

--- a/net/eds/patches/0004-startup-move-bin-bash-to-file-top.patch
+++ b/net/eds/patches/0004-startup-move-bin-bash-to-file-top.patch
@@ -1,0 +1,109 @@
+From f53ade17f9e27bc040f1eac68f447cc8adc71c44 Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Wed, 6 Mar 2019 15:39:01 +0800
+Subject: [PATCH] startup: move "#!/bin/bash" to file top
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ startup/env.sh          | 4 ++--
+ startup/mmc-check.sh    | 6 +++---
+ startup/ota-statuscheck | 4 ++--
+ startup/ota-updateSet   | 4 ++--
+ startup/startup.sh      | 4 ++--
+ 5 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/startup/env.sh b/startup/env.sh
+index 50940ab..a335da5 100755
+--- a/startup/env.sh
++++ b/startup/env.sh
+@@ -1,11 +1,11 @@
++#!/bin/bash
++
+ #####################################
+ #
+ # Copyright 2017-2018 NXP
+ #
+ #####################################
+ 
+-#!/bin/bash
+-
+ testserver="https://www.linux.org"
+ ok=1
+ which dhclient||udhcpc=1
+diff --git a/startup/mmc-check.sh b/startup/mmc-check.sh
+index b2aa8d5..781b8a6 100755
+--- a/startup/mmc-check.sh
++++ b/startup/mmc-check.sh
+@@ -1,12 +1,12 @@
++#!/bin/bash
++# check the MMC blocks health status
++
+ #####################################
+ #
+ #Copyright 2017-2018 NXP
+ #
+ #####################################
+ 
+-#!/bin/bash
+-# check the MMC blocks health status
+-
+ check_list="mmc"
+ 
+ mmc::badblocks(){
+diff --git a/startup/ota-statuscheck b/startup/ota-statuscheck
+index afce6c5..65fd129 100755
+--- a/startup/ota-statuscheck
++++ b/startup/ota-statuscheck
+@@ -1,11 +1,11 @@
++#!/bin/bash
++
+ #####################################
+ #
+ # Copyright 2017-2018 NXP
+ #
+ #####################################
+ 
+-#!/bin/bash
+-
+ dd if=/dev/mmcblk0 of=/tmp/ota-info bs=512 skip=129024 count=1
+ updateStatus=`cat /tmp/ota-info | awk '{print $1}'`
+ platform=`cat /tmp/ota-info | awk '{print $2}'`
+diff --git a/startup/ota-updateSet b/startup/ota-updateSet
+index 7e4f9e0..67515df 100755
+--- a/startup/ota-updateSet
++++ b/startup/ota-updateSet
+@@ -1,11 +1,11 @@
++#!/bin/bash
++
+ #####################################
+ #
+ # Copyright 2017-2018 NXP
+ #
+ #####################################
+ 
+-#!/bin/bash
+-
+ /usr/local/edgescale/bin/cert-agent
+ . /data/config.env
+ 
+diff --git a/startup/startup.sh b/startup/startup.sh
+index b9295a2..2d9b241 100755
+--- a/startup/startup.sh
++++ b/startup/startup.sh
+@@ -1,11 +1,11 @@
++#!/bin/bash
++
+ #####################################
+ #
+ # Copyright 2017-2018 NXP
+ #
+ #####################################
+ 
+-#!/bin/bash
+-
+ export version=`cat /usr/local/edgescale/conf/edgescale-version`
+ 
+ push_publicip() {
+-- 
+2.17.1
+

--- a/net/eds/patches/0005-startup-disable-update-ca-certificates.patch
+++ b/net/eds/patches/0005-startup-disable-update-ca-certificates.patch
@@ -1,0 +1,32 @@
+From b8c649531c0faf31303ea18351925350f88e586f Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Wed, 6 Mar 2019 16:11:37 +0800
+Subject: [PATCH] startup: disable update-ca-certificates
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ startup/startup.sh | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/startup/startup.sh b/startup/startup.sh
+index 2d9b241..a75eed5 100755
+--- a/startup/startup.sh
++++ b/startup/startup.sh
+@@ -36,10 +36,11 @@ done
+ 
+ if [ -z $ES_OEM_TRUST_CA ] ; then
+ 		rm -rf /usr/local/share/ca-certificates/es-oem-trust.crt
+-		update-ca-certificates
++		# update-ca-certificates
+ else
+-		echo -n $ES_OEM_TRUST_CA | base64 -d > /usr/local/share/ca-certificates/es-oem-trust.crt
+-		update-ca-certificates
++		echo "update-ca-certificates is not supported now!"
++		# echo -n $ES_OEM_TRUST_CA | base64 -d > /usr/local/share/ca-certificates/es-oem-trust.crt
++		# update-ca-certificates
+ fi
+ 
+ if [ $? -eq 0 ];then
+-- 
+2.17.1
+

--- a/net/eds/patches/0006-startup-adapt-badblocks-command-to-OpenWrt.patch
+++ b/net/eds/patches/0006-startup-adapt-badblocks-command-to-OpenWrt.patch
@@ -1,0 +1,26 @@
+From 74185826adb365b76e7230b2e5b4d5204a889a60 Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Wed, 6 Mar 2019 16:53:48 +0800
+Subject: [PATCH] startup: adapt badblocks command to OpenWrt
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ startup/mmc-check.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/startup/mmc-check.sh b/startup/mmc-check.sh
+index 781b8a6..aef4c8c 100755
+--- a/startup/mmc-check.sh
++++ b/startup/mmc-check.sh
+@@ -13,7 +13,7 @@ mmc::badblocks(){
+         for b in $(find /dev/ -regex '/dev/mmcblk.*p.*')
+         do
+                 echo Checking $b
+-                badblocks -sv $b -o /var/log/edgescale/badblocks-$(basename $b).log
++                badblocks -o /var/log/edgescale/badblocks-$(basename $b).log -sv $b
+         done
+ }
+ 
+-- 
+2.17.1
+

--- a/net/eds/patches/0007-etc-Fix-PATH-to-use-binaries-in-usr-first.patch
+++ b/net/eds/patches/0007-etc-Fix-PATH-to-use-binaries-in-usr-first.patch
@@ -1,0 +1,26 @@
+From be76616bfec469f1465138fde3a44707ee28dfe5 Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Fri, 8 Mar 2019 17:27:43 +0800
+Subject: [PATCH] etc: Fix PATH to use binaries in /usr first
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ etc/edgescale | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/etc/edgescale b/etc/edgescale
+index 8036afa..37c5d2a 100755
+--- a/etc/edgescale
++++ b/etc/edgescale
+@@ -6,7 +6,7 @@
+ #
+ #####################################
+ 
+-PATH=/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/edgescale/bin
++PATH=/usr/local/edgescale/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ DESC="edgescale service"
+ NAME="edgescale"
+ STARTUP="/usr/local/edgescale/bin/startup.sh"
+-- 
+2.17.1
+

--- a/net/eds/patches/0008-cert-agent-convert-to-use-github-url-for-yaml.patch
+++ b/net/eds/patches/0008-cert-agent-convert-to-use-github-url-for-yaml.patch
@@ -1,0 +1,40 @@
+From 5ab30bd1ff991466bb99a2d09c12f000ec08bdd5 Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Thu, 18 Apr 2019 12:09:22 +0800
+Subject: [PATCH] cert-agent: convert to use github url for yaml
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ cert-agent/Makefile | 2 +-
+ cert-agent/mft.go   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cert-agent/Makefile b/cert-agent/Makefile
+index 475b938..2a30ddb 100644
+--- a/cert-agent/Makefile
++++ b/cert-agent/Makefile
+@@ -21,7 +21,7 @@ GOBUILDTAGS ?= default
+ 
+ all:
+ 	go get github.com/edgeiot/est-client-go
+-	go get gopkg.in/yaml.v2
++	go get github.com/go-yaml/yaml
+ 	env CGO_ENABLED=1 GOOS=linux GOARCH=${ARCH} CC=${CC} CGO_CFLAGS="${CGO_CFLAGS}" CGO_LDFLAGS="${CGO_LDFLAGS}" go build -o cert-agent --ldflags="-w -s" --tags "${GOBUILDTAGS}"
+ 
+ clean:
+diff --git a/cert-agent/mft.go b/cert-agent/mft.go
+index c4d21e5..7b816dc 100644
+--- a/cert-agent/mft.go
++++ b/cert-agent/mft.go
+@@ -15,7 +15,7 @@ import (
+ 	"encoding/pem"
+ 	"errors"
+ 	"fmt"
+-	yaml "gopkg.in/yaml.v2"
++	yaml "github.com/go-yaml/yaml"
+ 	"io/ioutil"
+ 	"math/big"
+ 	"net/http"
+-- 
+2.17.1
+

--- a/net/eds/patches/0009-startup-disable-firewall.patch
+++ b/net/eds/patches/0009-startup-disable-firewall.patch
@@ -1,0 +1,23 @@
+From 2c672f0fbbde903655389a637cdcff58c6e5d662 Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Thu, 18 Apr 2019 14:38:44 +0800
+Subject: [PATCH] startup: disable firewall
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ startup/env.sh | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/startup/env.sh b/startup/env.sh
+index a335da5..0394f60 100755
+--- a/startup/env.sh
++++ b/startup/env.sh
+@@ -103,3 +103,5 @@ for a in 1 2 3 4 5;do
+     done
+     sleep 2
+ done
++
++/etc/init.d/firewall stop
+-- 
+2.17.1
+


### PR DESCRIPTION
EdgeScale is a unified, scalable, and secure device management solution
for Edge Computing applications. It enables OEMs and developers to
leverage cloud compute frameworks like AWS Greengrass, Azure IoT, and
Aliyun on Layerscape devices.

NXP Edgescale aims at not only NXP Layerscape targets. It could be
extended and deployed to any other targets easily even with different
architecture.

Here is Edgescale website and document.
https://www.nxp.com/applications/solutions/industrial/human-machine-interfaces-hmi/handheld-scanner/edgescale-for-secure-edge-computing:EDGESCALE
https://doc.edgescale.org/
Edgescale quick start for OpenWrt which is in the pull request
https://github.com/yangbolu1991/packages/blob/master/net/eds/README

I have done build and function test for the code on latest openwrt source code on layerscape ls1046ardb-sdboot device.
3032bf7 lantiq: unify Fritz!Box LED mappings

Please help to review and hope for your comments.
Thanks!