### PR TITLE
python-sentry-sdk: Update to version 0.10.2

### DIFF
--- a/lang/python/python-sentry-sdk/Makefile
+++ b/lang/python/python-sentry-sdk/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-sentry-sdk
-PKG_VERSION:=0.10.1
+PKG_VERSION:=0.10.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=sentry-sdk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/s/sentry-sdk/
-PKG_HASH:=7e24f3ec1f4c909306d1b97373fe5caa942f54009acdcfa4d1ee6671f626bbe9
+PKG_HASH:=d491aa6399eaa3eded433972751a9770180730fd8b4c225b0b7f49c4fa2af70b
 PKG_BUILD_DIR:=$(BUILD_DIR)/sentry-sdk-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:
- Update to version [0.10.2](https://github.com/getsentry/sentry-python/releases/tag/0.10.2)