### PR TITLE
youtube-dl: Update to version 2019.8.13

### DIFF
--- a/multimedia/youtube-dl/Makefile
+++ b/multimedia/youtube-dl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=youtube-dl
-PKG_VERSION:=2019.8.2
+PKG_VERSION:=2019.8.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=youtube_dl-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/y/youtube_dl/
-PKG_HASH:=73b8528782f507dc506422557c940842e1e514ffaf0b010d82642cb2ceeefdf7
+PKG_HASH:=ff65a10f81b64d8e0d1872a89bee0d075370ba6e4c658193e56e6f93e5ca46ba
 PKG_BUILD_DIR:=$(BUILD_DIR)/youtube_dl-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Adrian Panella <ianchi74@outlook.com>, Josef Schlehofer <pepe.schlehofer@gmail.com>


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:

- Update to version [2019.8.13](https://github.com/ytdl-org/youtube-dl/releases/tag/2019.08.13).

