### PR TITLE
[openwrt-19.07] python,python3: Fix host Python compilation for macOS

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -290,11 +290,16 @@ define PyPackage/python/filespec
 endef
 
 HOST_LDFLAGS += \
-	$$$$(pkg-config --static --libs libcrypto libssl) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib
+	-Wl$(comma)-rpath$(comma)$(STAGING_DIR_HOSTPKG)/lib
 
 ifeq ($(HOST_OS),Linux)
 HOST_LDFLAGS += \
 	-Wl,--no-as-needed -lrt
+endif
+
+ifeq ($(HOST_OS),Darwin)
+HOST_CONFIGURE_VARS += \
+	ac_cv_header_libintl_h=no
 endif
 
 HOST_CONFIGURE_ARGS+= \

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -285,11 +285,16 @@ define Py3Package/python3/filespec
 endef
 
 HOST_LDFLAGS += \
-	$$$$(pkg-config --static --libs libcrypto libssl) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib
+	-Wl$(comma)-rpath$(comma)$(STAGING_DIR_HOSTPKG)/lib
 
 ifeq ($(HOST_OS),Linux)
 HOST_LDFLAGS += \
 	-Wl,--no-as-needed -lrt
+endif
+
+ifeq ($(HOST_OS),Darwin)
+HOST_CONFIGURE_VARS += \
+	ac_cv_header_libintl_h=no
 endif
 
 HOST_CONFIGURE_ARGS+= \


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: none (cherry-picked from #9760)
Run tested: none

Description:
* Remove `$$$$(pkg-config --static --libs libcrypto libssl)` from `HOST_LDFLAGS`

  Having this leads to an `unknown type name 'u_int'` error on Mac. Removing it doesn't appear to affect Python's ability to find buildroot LibreSSL.

* Change `-Wl,-rpath=...` to `-Wl,-rpath,...` in `HOST_LDFLAGS`

  The equals sign version is not supported by the Mac linker (appears to be an GNU extension). The comma version is supported; `-rpath` and its argument will be separated by a space when passed to the linker.

* Add `ac_cv_header_libintl_h=no` to `HOST_CONFIGURE_VARS` for Mac

  Python on Mac doesn't expect to use libintl, but if gettext-full is compiled for host, it will try, leading to undefined symbol errors during compilation. This prevents configure from finding libintl.h.

Fixes #7171.
Fixes #9621.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>