### PR TITLE
DockerCE: Fix too many open files

### DIFF
--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -4,7 +4,11 @@ USE_PROCD=1
 START=25
 
 start_service() {
+	local nofile
+	nofile=`cat /proc/sys/fs/nr_open`
+
 	procd_open_instance
 	procd_set_param command /usr/bin/dockerd
+	procd_set_param limits nofile="${nofile} ${nofile}"
 	procd_close_instance
 }


### PR DESCRIPTION
When using procd, 'nofile' was limited to 1024(soft) and 4096(hard) by default, it's not compatible for docker large range port mapping.
So we expand this limit as large as possible.
TEST CASE: 
docker run -d --name=alpine --publish=30022:22 -p 31000-35000:31000-35000 --env ROOT_PASSWORD=root hermsi/alpine-sshd
PS: enable `--userland-proxy=false` was recommended
