### PR TITLE
DockerCE: Fix can't mapping large range ports (too many open files)

### DIFF
--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-ce
 PKG_VERSION:=19.03.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=components/cli/LICENSE components/engine/LICENSE
 

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -4,7 +4,10 @@ USE_PROCD=1
 START=25
 
 start_service() {
+	local nofile=$(cat /proc/sys/fs/nr_open)
+	
 	procd_open_instance
 	procd_set_param command /usr/bin/dockerd
+	procd_set_param limits nofile="${nofile} ${nofile}"
 	procd_close_instance
 }


### PR DESCRIPTION
Expand nofile from 1024(soft) 4096(hard) as large as possible when using procd.
```
local nofile=$(cat /proc/sys/fs/nr_open)

...

procd_set_param limits nofile="${nofile} ${nofile}"
```

Signed-off-by: Fuying Wang <805447391@qq.com>
Compile tested: x86_64, musl and glibc