### PR TITLE
adblock: update 3.8.1

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.8.0
+PKG_VERSION:=3.8.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: dnsmasq/unbound with OpenWrt SNAPSHOT, r10773-ebbec2fdc6

Description:
* fix a possible race condition during DNS file reset on slow hardware
* optimize DNS restart behaviour in 'null' blocking mode
* mute useless warnings

Signed-off-by: Dirk Brenken <dev@brenken.org>

