### PR TITLE
libv4l: Update to 1.16.6. Fix missing includes patch

### DIFF
--- a/libs/libv4l/Makefile
+++ b/libs/libv4l/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v4l-utils
-PKG_VERSION:=1.16.5
+PKG_VERSION:=1.16.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.linuxtv.org/downloads/v4l-utils
-PKG_HASH:=ed80242510385017a1dc566e17a285a77222bb301f5bc19386badfcc2c19df1b
+PKG_HASH:=f9dac1878e3d5636eab7f56bb209fdfc66b94ee8a2aae54dcb4282fe63a678ae
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=GPL-2.0 LGPL-2.1

--- a/libs/libv4l/patches/020-add-missing-includes.patch
+++ b/libs/libv4l/patches/020-add-missing-includes.patch
@@ -20,11 +20,10 @@
  #include <linux/cec-funcs.h>
 --- a/utils/common/media-info.cpp
 +++ b/utils/common/media-info.cpp
-@@ -20,7 +20,7 @@
- 
+@@ -21,6 +21,7 @@
  #include <linux/media.h>
  
--#include <fstream>
+ #include <fstream>
 +#include <iostream>
  #include <media-info.h>
  
@@ -42,22 +41,20 @@
  #include <map>
 --- a/utils/v4l2-compliance/media-info.cpp
 +++ b/utils/v4l2-compliance/media-info.cpp
-@@ -20,7 +20,7 @@
- 
+@@ -21,6 +21,7 @@
  #include <linux/media.h>
  
--#include <fstream>
+ #include <fstream>
 +#include <iostream>
  #include <media-info.h>
  
  static std::string num2s(unsigned num, bool is_hex = true)
 --- a/utils/v4l2-ctl/media-info.cpp
 +++ b/utils/v4l2-ctl/media-info.cpp
-@@ -20,7 +20,7 @@
- 
+@@ -21,6 +21,7 @@
  #include <linux/media.h>
  
--#include <fstream>
+ #include <fstream>
 +#include <iostream>
  #include <media-info.h>
  

--- a/libs/libv4l/patches/030-getsubopt.patch
+++ b/libs/libv4l/patches/030-getsubopt.patch
@@ -3,11 +3,9 @@ musl libs will set value to NULL which leads to crash.
 
 Simply avoid getsubopt, since we cannot rely on it.
 
-diff --git a/utils/v4l2-ctl/v4l2-ctl-common.cpp b/utils/v4l2-ctl/v4l2-ctl-common.cpp
-index 3ea6cd3..291fb3e 100644
 --- a/utils/v4l2-ctl/v4l2-ctl-common.cpp
 +++ b/utils/v4l2-ctl/v4l2-ctl-common.cpp
-@@ -692,16 +692,17 @@ static bool parse_subset(char *optarg)
+@@ -679,16 +679,17 @@ static bool parse_subset(char *optarg)
  
  static bool parse_next_subopt(char **subs, char **value)
  {


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu with libstdc++ and uclibc++
Run tested: N/A

Description:
Use latest released version 1.16.6
Update/add missing includes -- fixes #8463

Signed-off-by: Ted Hess \<thess@kitschensync.net\>
