### PR TITLE
adblock: update 3.8.2

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.8.1
+PKG_VERSION:=3.8.2
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/adblock.service
+++ b/net/adblock/files/adblock.service
@@ -21,7 +21,7 @@ if [ -x "${adb_ubus}" ] && [ -n "${adb_dns}" ]
 then
 	logger -p "info" -t "adblock-${adb_basever}  [${$}]" "ubus/adblock service started"
 	"${adb_ubus}" -S -M r -m invoke monitor | \
-		{ grep -qF "\"method\":\"set\",\"data\":{\"name\":\"${adb_dns}\""; [ $? -eq 0 ] && /etc/init.d/adblock start; }
+		{ grep -qE "\"method\":\"(set|signal)\",\"data\":\{\"name\":\"${adb_dns}\""; [ $? -eq 0 ] && /etc/init.d/adblock start; }
 else
 	logger -p "err" -t "adblock-${adb_basever}  [${$}]" "can't start ubus/adblock service"
 fi


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: OpenWrt SNAPSHOT, r10773-ebbec2fdc6

Description:
* background service: no longer miss "signal" events for the
  dns backend (to trigger adblock)
* fix a dns backend reload issue during switch between
  different blocking modes
* domain query: report found domains only once in
  "null" blocking mode with IPv4 & IPv6 list entries

Signed-off-by: Dirk Brenken <dev@brenken.org>

