### PR TITLE
[OpenWrt 18.06] libarchive: update to version 3.4.0 (security fix)

### DIFF
--- a/libs/libarchive/Makefile
+++ b/libs/libarchive/Makefile
@@ -8,12 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libarchive
-PKG_VERSION:=3.3.2
+PKG_VERSION:=3.4.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.libarchive.org/downloads
-PKG_HASH:=ed2dbd6954792b2c054ccf8ec4b330a54b85904a80cef477a1c74643ddafa0ce
+PKG_SOURCE_URL:=https://codeload.github.com/libarchive/libarchive/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=c160d3c45010a51a924208f13f6b7b956dabdf8c5c60195df188a599028caa7c
+
 PKG_MAINTAINER:=Johannes Morgenroth <morgenroth@ibr.cs.tu-bs.de>
 PKG_LICENSE:=BSD-2-Clause
 
@@ -23,38 +24,49 @@ PKG_FIXUP:=autoreconf
 include $(INCLUDE_DIR)/package.mk
 
 define Package/libarchive/Default
-	SECTION:=libs
-	CATEGORY:=Libraries
-	DEPENDS:=+zlib +liblzma +libbz2 +libexpat
-	TITLE:=Multi-format archive and compression library
-	URL:=http://www.libarchive.org/
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+zlib +liblzma +libbz2 +libexpat
+  TITLE:=Multi-format archive and compression library
+  URL:=https://www.libarchive.org/
 endef
 
 define Package/libarchive
 	$(call Package/libarchive/Default)
-	DEPENDS += +libopenssl
+  DEPENDS += +libopenssl
 endef
 
 define Package/libarchive-noopenssl
 	$(call Package/libarchive/Default)
-	TITLE += (without OpenSSL dependency)
-	VARIANT:=noopenssl
+  TITLE += (without OpenSSL dependency)
+  VARIANT:=noopenssl
+endef
+
+define Package/bsdtar/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Compression
+  TITLE:=tar BSD variant
+  URL:=https://www.libarchive.org/
 endef
 
 define Package/bsdtar
-	SECTION:=utils
-	CATEGORY:=Utilities
-	SUBMENU:=Compression
-	DEPENDS:=+libarchive-noopenssl
-	TITLE:=BSD variant that supports various file compression formats
-	URL:=http://www.libarchive.org/
+	$(call Package/bsdtar/Default)
+  DEPENDS:= +libarchive
+endef
+
+define Package/bsdtar-noopenssl
+	$(call Package/bsdtar/Default)
+  TITLE += (without OpenSSL dependency)
+  DEPENDS:= +libarchive-noopenssl
+  VARIANT:=noopenssl
 endef
 
 define Package/bsdtar/description
-	Reads a variety of formats including tar, pax, zip, xar, lha, ar,
-	cab, mtree, rar, warc, 7z and ISO images. Writes tar, pax, zip,
-	xar, ar, ISO, mtree and shar archives. Automatically handles
-	archives compressed with gzip, bzip2, lzip, xz, lzma or compress.
+  Reads a variety of formats including tar, pax, zip, xar, lha, ar,
+  cab, mtree, rar, warc, 7z and ISO images. Writes tar, pax, zip,
+  xar, ar, ISO, mtree and shar archives. Automatically handles
+  archives compressed with gzip, bzip2, lzip, xz, lzma or compress.
 endef
 
 CONFIGURE_ARGS += \
@@ -91,7 +103,9 @@ define Package/bsdtar/install
 endef
 
 Package/libarchive-noopenssl/install = $(Package/libarchive/install)
+Package/bsdtar-noopenssl/install = $(Package/bsdtar/install)
 
 $(eval $(call BuildPackage,libarchive))
 $(eval $(call BuildPackage,libarchive-noopenssl))
 $(eval $(call BuildPackage,bsdtar))
+$(eval $(call BuildPackage,bsdtar-noopenssl))


### PR DESCRIPTION
Maintainer: @morgenroth 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06.04
Run tested: N/A

Description:
This PR backports libarchive from master to 18.06 because of security vulnerabilities in 3.3.2 version.

Fixes:
- CVE-2019-1000019
- CVE-2019-1000020
- CVE-2018-1000880
- CVE-2018-1000879
- CVE-2018-1000878
- CVE-2018-1000877

Changes:
- add bsdtar libopenssl variant
- switch to github codeload
- polish tab/spaces

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>


