### PR TITLE
yggdrasil: bump to 0.3.8

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
-PKG_VERSION:=0.3.7
+PKG_VERSION:=0.3.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=a0fc98f7d479fb44943fe85f223fbd9c5de529baa6f66887e37e904117e18a6a
+PKG_HASH:=56eebbb63cf2d14897141ce037fb9aec407430718908cfeeb34fff355f08f9af
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-go-$(PKG_VERSION)
 
 PKG_MAINTAINER:=William Fleurant <meshnet@protonmail.com>


### PR DESCRIPTION
Signed-off-by: William Fleurant <meshnet@protonmail.com>

Maintainer: me / @wfleurant 
Compile tested: aarch64_cortex-a72 / snapshots
Description: https://github.com/yggdrasil-network/yggdrasil-go/releases/tag/v0.3.8
