### PR TITLE
[OpenWrt 18.06] python-pyserial: added python3 variant

### DIFF
--- a/lang/python/python-pyserial/Makefile
+++ b/lang/python/python-pyserial/Makefile
@@ -17,34 +17,51 @@ PKG_SOURCE:=pyserial-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://pypi.python.org/packages/3c/d8/a9fa247ca60b02b3bebbd61766b4f321393b57b13c53b18f6f62cf172c08/
 PKG_HASH:=d657051249ce3cbd0446bcfb2be07a435e1029da4d63f53ed9b4cdde7373364c
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/pyserial-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pyserial-$(PKG_VERSION)
+
 PKG_BUILD_DEPENDS:=python
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/python-pyserial
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-pyserial/Default
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  TITLE:=python-pyserial
   URL:=http://pyserial.sourceforge.net
-  DEPENDS:=+python-light
+endef
+
+define Package/python-pyserial
+$(call Package/python-pyserial/Default)
+  TITLE:=python-pyserial
+  DEPENDS:=+PACKAGE_python-pyserial:python-light
+  VARIANT:=python
+endef
+
+define Package/python3-pyserial
+$(call Package/python-pyserial/Default)
+  TITLE:=python3-pyserial
+  DEPENDS:=+PACKAGE_python3-pyserial:python3-light
+  VARIANT:=python3
 endef
 
 define Package/python-pyserial/description
 	serial port python bindings
 endef
 
-define Build/Compile
-	$(call Build/Compile/PyMod,,install --prefix=/usr --root="$(PKG_INSTALL_DIR)")
+define Package/python3-pyserial/description
+$(call Package/python-pyserial/description)
+.
+(Variant for Python3)
 endef
 
-define Package/python-pyserial/install
-	$(INSTALL_DIR) $(1)$(PYTHON_PKG_DIR)
-	$(CP) \
-	    $(PKG_INSTALL_DIR)$(PYTHON_PKG_DIR)/* \
-	    $(1)$(PYTHON_PKG_DIR)
-endef
-
+$(eval $(call PyPackage,python-pyserial))
 $(eval $(call BuildPackage,python-pyserial))
+$(eval $(call BuildPackage,python-pyserial-src))
+
+$(eval $(call Py3Package,python3-pyserial))
+$(eval $(call BuildPackage,python3-pyserial))
+$(eval $(call BuildPackage,python3-pyserial-src))


### PR DESCRIPTION
Signed-off-by: Jakub Piotr Cłapa <jpc@loee.pl>

Maintainer: @mickeprag
Compile & run tested: OpenWRT 18.06 target-aarch64_cortex-a53_musl NanoPi Neo Core 2