### PR TITLE
[OpenWrt 18.06] python-urllib3: updated to 1.25.2 and added a python3 variant

### DIFF
--- a/lang/python/python-urllib3/Makefile
+++ b/lang/python/python-urllib3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-urllib3
-PKG_VERSION:=1.24.3
+PKG_VERSION:=1.25.2
 PKG_RELEASE:=1
 
 PKG_LICENSE:=MIT
@@ -16,27 +16,52 @@ PKG_LICENSE_FILES:=LICENSE.txt
 
 PKG_SOURCE:=urllib3-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/u/urllib3
-PKG_HASH:=2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4
+PKG_HASH:=a53063d8b9210a7bdec15e7b272776b9d42b2fd6816401a0d43006ad2f9902db
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/urllib3-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-urllib3-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
-define Package/python-urllib3
-  SUBMENU:=Python
-  SECTION:=lang
+PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+define Package/python-urllib3/Default
+  SECTION:=lang-python
   CATEGORY:=Languages
+  SUBMENU:=Python
   TITLE:=Sanity-friendly HTTP client
   URL:=https://urllib3.readthedocs.io/
-  DEPENDS:=+python
+endef
+
+define Package/python-urllib3
+$(call Package/python-urllib3/Default)
+  TITLE:=python-urllib3
+  DEPENDS:=+PACKAGE_python-urllib3:python-light
   VARIANT:=python
+endef
+
+define Package/python3-urllib3
+$(call Package/python-urllib3/Default)
+  TITLE:=python3-urllib3
+  DEPENDS:=+PACKAGE_python3-urllib3:python3-light
+  VARIANT:=python3
 endef
 
 define Package/python-urllib3/description
   HTTP library with thread-safe connection pooling, file post, and more.
 endef
 
+define Package/python3-urllib3/description
+$(call Package/python-urllib3/description)
+.
+(Variant for Python3)
+endef
+
 $(eval $(call PyPackage,python-urllib3))
 $(eval $(call BuildPackage,python-urllib3))
 $(eval $(call BuildPackage,python-urllib3-src))
+
+$(eval $(call Py3Package,python3-urllib3))
+$(eval $(call BuildPackage,python3-urllib3))
+$(eval $(call BuildPackage,python3-urllib3-src))


### PR DESCRIPTION
Maintainer: @commodo (sorry if you are not the best person to tag)
Compile & run tested: OpenWRT 18.06 target-aarch64_cortex-a53_musl NanoPi Neo Core 2
