### PR TITLE
[OpenWrt 18.06] keepalived: update version to 2.0.18 (security fix)

### DIFF
--- a/net/keepalived/Config.in
+++ b/net/keepalived/Config.in
@@ -1,0 +1,164 @@
+if PACKAGE_keepalived
+
+menu "Configuration"
+
+config KEEPALIVED_BFD
+	bool
+	default n
+	prompt "Enable BFD support"
+	help
+		Builds support for BFD
+
+config KEEPALIVED_SHA1
+	bool
+	default y
+	prompt "Enable SHA1 support in genhash"
+	help
+		Builds support for using SHA1 with genhash
+
+config KEEPALIVED_LVS
+	bool
+	default y
+	prompt "Enable IPVS support"
+	help
+		Builds support for IPVS
+
+config KEEPALIVED_LVS_SYNCD
+	depends on KEEPALIVED_LVS
+	bool
+	default y
+	prompt "Enable IPVS syncd daemon control"
+	help
+		Builds support for configuring IPVS syncd daemon
+
+config KEEPALIVED_LVS_64BIT_STATS
+	depends on KEEPALIVED_LVS
+	bool
+	default y
+	prompt "Enable IPVS 64 bit stats"
+	help
+		Builds support for IPVS 64 bit stats
+
+config KEEPALIVED_FWMARK
+	depends on KEEPALIVED_LVS
+	bool
+	default y
+	prompt "Enable support for setting FWMARK on sockets"
+	help
+		Builds support for setting firewall mark on checker sockets
+
+config KEEPALIVED_SNMP_CHECKER
+	depends on KEEPALIVED_LVS
+	bool
+	default n
+	prompt "Enable SNMP support for checker (LVS)"
+	help
+		Builds support for using SNMP with LVS
+
+config KEEPALIVED_VRRP
+	bool
+	default y
+	prompt "Enable VRRP support"
+	help
+		Builds support for VRRP
+
+config KEEPALIVED_IPTABLES
+	depends on KEEPALIVED_VRRP
+	bool
+	default y
+	prompt "Enable iptables for VIP filtering"
+	help
+		Builds support for using iptables/ipsets for filtering packets
+		to VIPs
+
+config KEEPALIVED_SNMP_VRRP
+	depends on KEEPALIVED_VRRP
+	bool
+	default n
+	prompt "Enable SNMP support for VRRP"
+	help
+		Builds support for using SNMP with VRRP
+
+config KEEPALIVED_SNMP_RFC2
+	depends on KEEPALIVED_VRRP
+	bool
+	default n
+	prompt "Enable SNMP support for VRRPv2 (RFC2787)"
+	help
+		Builds support for using RFC2787 SNMP support for VRRPv2
+
+config KEEPALIVED_SNMP_RFC3
+	depends on KEEPALIVED_VRRP
+	bool
+	default n
+	prompt "Enable SNMP support for VRRPv3 (RFC6527)"
+	help
+		Builds support for using RFC6527 SNMP support for VRRPv3
+
+config KEEPALIVED_SNMP_REPLY_V3_FOR_V2
+	depends on KEEPALIVED_SNMP_RFC3
+	bool
+	default n
+	prompt "Enable SNMP v3 responses for VRRPv2 instances"
+	help
+		Builds support for using SNMP v3 responses for VRRPv2 instances
+
+config KEEPALIVED_DBUS
+	depends on KEEPALIVED_VRRP
+	bool
+	default n
+	prompt "Enable DBus support"
+	help
+		Builds support for using DBus with VRRP
+
+config KEEPALIVED_JSON
+	depends on KEEPALIVED_VRRP
+	bool
+	default n
+	prompt "Enable JSON support with VRRP"
+	help
+		Builds support for using JSON output for VRRP
+
+config KEEPALIVED_VRRP_AUTH
+	depends on KEEPALIVED_VRRP
+	bool
+	default y
+	prompt "Enable (removed) VRRPv2 authentication"
+	help
+		Builds support for using (removed) VRRPv2 authentication
+		Note: authentication was removed from the VRRPv2 specification
+		by RFC3768 in 2004.
+		Use of this option is non-compliant and can cause problems.
+		Avoid using if possible, except when using unicast, where it
+		can be helpful.
+
+config KEEPALIVED_CHECKSUM_COMPAT
+	depends on KEEPALIVED_VRRP
+	bool
+	default y
+	prompt "Enable checksum compatibility"
+	help
+		Builds support for interworking with instances using
+		old(incorrect) checksum method
+
+config KEEPALIVED_ROUTES
+	depends on KEEPALIVED_VRRP
+	bool
+	default y
+	prompt "Enable support for VRRP instances managing routes and rules"
+	help
+		Builds support for VRRP instances adding and removing IP
+		routes and rules
+
+config KEEPALIVED_LINKBEAT
+	depends on KEEPALIVED_VRRP
+	bool
+	default y
+	prompt "Enable support for linkbeat"
+	help
+		Builds support for using linkbeat polling to monitor the state
+		of interfaces
+
+endmenu
+
+endif # PACKAGE_keepalived

--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -8,39 +8,74 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
-PKG_VERSION:=1.4.4
+PKG_VERSION:=2.0.18
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.keepalived.org/software
-PKG_HASH:=147c2b3b782223128551fd0a1564eaa30ed84a94b68c50ec5087747941314704
+PKG_SOURCE_URL:=https://www.keepalived.org/software
+PKG_HASH:=1423a2b1b8e541211029b9e1e1452e683bbe5f4b0b287eddd609aaf5ff024fd0
 
+PKG_CPE_ID:=cpe:/a:keepalived:keepalived
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Ben Kelly <ben@benjii.net> \
 		Florian Eckert <fe@dev.tdt.de>
+
+PKG_CONFIG_DEPENDS += \
+	KEEPALIVED_VRRP \
+	KEEPALIVED_LVS \
+	KEEPALIVED_IPTABLES \
+	KEEPALIVED_BFD \
+	KEEPALIVED_SNMP_VRRP \
+	KEEPALIVED_SNMP_CHECKER \
+	KEEPALIVED_SNMP_RFC2 \
+	KEEPALIVED_SNMP_RFC3 \
+	KEEPALIVED_SNMP_REPLY_V3_FOR_V2 \
+	KEEPALIVED_DBUS \
+	KEEPALIVED_JSON \
+	KEEPALIVED_ROUTES \
+	IPV6
 
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/kernel.mk
 
+define Package/keepalived/config
+	source "$(SOURCE)/Config.in"
+endef
+
+# specifying +(IPV6&&KEEPALIVED_IPTABLES) in the DEPENDS definition doesn't work
+ifeq ($(CONFIG_KEEPALIVED_IPTABLES)$(CONFIG_IPV6),yy)
+  KEEPALIVED_DEPENDS_LIBIP6TC=+libip6tc
+endif
+
+# The +kmod-nf-ipvs line should be +KEEPALIVED_LVS:kmod-nf-ipvs,
+# but make menuconfig then reports :error: recursive dependency detected!
+# !!FIXME DEPENDS:= +KEEPALIVED_LVS:kmod-nf-ipvs
 define Package/keepalived
   SECTION:=net
   CATEGORY:=Network
-  TITLE:=Failover and monitoring daemon for LVS clusters
+  TITLE:=VRRP with failover and monitoring daemon for LVS clusters
   URL:=http://www.keepalived.org/
   DEPENDS:= \
-    +PACKAGE_libnl-genl:libnl-genl \
-    +libopenssl \
-    +libip4tc \
-    +IPV6:libip6tc \
-    +libxtables \
-    +kmod-macvlan
+    +libnl-genl \
+    +libmagic \
+    +KEEPALIVED_VRRP:kmod-macvlan \
+    +KEEPALIVED_VRRP:libnl-route \
+    +KEEPALIVED_VRRP:libnfnetlink \
+    +KEEPALIVED_SHA1:libopenssl \
+    +KEEPALIVED_IPTABLES:libip4tc \
+    $(KEEPALIVED_DEPENDS_LIBIP6TC) \
+    +KEEPALIVED_IPTABLES:libxtables \
+    +KEEPALIVED_IPTABLES:libipset \
+    +(KEEPALIVED_SNMP_VRRP||KEEPALIVED_SNMP_CHECKER||KEEPALIVED_SNMP_RFC2||KEEPALIVED_SNMP_RFC3):libnetsnmp \
+    +KEEPALIVED_JSON:libjson-c \
+    +KEEPALIVED_DBUS:glib2
 endef
 
 define Package/keepalived/description
- Failover and monitoring daemon for Linux Virtual Server (LVS) clusters.
+ VRRP with failover and monitoring daemon for Linux Virtual Server (LVS) clusters.
 endef
 
 define Package/keepalived/conffiles
@@ -50,30 +85,182 @@ define Package/keepalived/conffiles
 endef
 
 CONFIGURE_ARGS+= \
-	--enable-sha1 \
-	--disable-lvs \
-	--disable-lvs-syncd \
-	--disable-snmp \
-	--with-kernel-dir="$(LINUX_DIR)/$(LINUX_UAPI_DIR)"
+	--with-init=SYSV \
+	--disable-nftables
 
-MAKE_FLAGS += \
-		STRIP="/bin/true" \
+ifeq ($(CONFIG_KEEPALIVED_VRRP),)
+CONFIGURE_ARGS += \
+	--disable-vrrp
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_LVS),)
+CONFIGURE_ARGS += \
+	--disable-lvs
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_BFD),y)
+CONFIGURE_ARGS += \
+	--enable-bfd
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SHA1),y)
+CONFIGURE_ARGS += \
+	--enable-sha1
+endif
+
+
+ifeq ($(CONFIG_KEEPALIVED_VRRP),y)
+ifeq ($(CONFIG_KEEPALIVED_IPTABLES),)
+CONFIGURE_ARGS += \
+	--disable-iptables
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_IPSETS),)
+CONFIGURE_ARGS += \
+	--disable-libipset-dynamic
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_VRRP),y)
+CONFIGURE_ARGS += \
+	--enable-snmp-vrrp
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_RFC2),y)
+CONFIGURE_ARGS += \
+	--enable-snmp-rfcv2
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_RFC3),y)
+CONFIGURE_ARGS += \
+	--enable-snmp-rfcv3
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_RFC3),y)
+ifeq ($(CONFIG_KEEPALIVED_SNMP_REPLY_V3_FOR_V2),)
+CONFIGURE_ARGS += \
+	--disable-snmp-reply-v3-for-v2
+endif
+endif # CONFIG_KEEPALIVED_SNMP_RFC3
+
+ifeq ($(CONFIG_KEEPALIVED_JSON),y)
+CONFIGURE_ARGS += \
+	--enable-json
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_VRRP_AUTH),)
+CONFIGURE_ARGS += \
+	--disable-vrrp-auth
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_CHECKSUM_COMPAT),)
+CONFIGURE_ARGS += \
+	--disable-checksum-compat
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_DBUS),y)
+CONFIGURE_ARGS += \
+	--enable-dbus
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_LINKBEAT),)
+CONFIGURE_ARGS += \
+	--disable-linkbeat
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_ROUTES),)
+CONFIGURE_ARGS += \
+	--disable-routes
+endif
+endif # CONFIG_KEEPALIVED_VRRP
+
+
+ifeq ($(CONFIG_KEEPALIVED_LVS),y)
+ifeq ($(CONFIG_KEEPALIVED_LVS_SYNCD),)
+CONFIGURE_ARGS += \
+	--disable-lvs-syncd
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_LVS_64BIT_STATS),)
+CONFIGURE_ARGS += \
+	--disable-lvs-64bit-stats
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_FWMARK),)
+CONFIGURE_ARGS += \
+	--disable-fwmark
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_CHECKER),y)
+CONFIGURE_ARGS += \
+	--enable-snmp-checker
+endif
+
+endif # CONFIG_KEEPALIVED_LVS
+
+
+MAKE_FLAGS += STRIP="/bin/true"
+TARGET_CFLAGS += -I$(LINUX_DIR)
 
 define Package/keepalived/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/keepalived $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/keepalived \
+		$(1)/usr/sbin/
+
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/genhash $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/genhash \
+		$(1)/usr/bin/
+
 	$(INSTALL_DIR) $(1)/etc/keepalived
-	$(CP) $(PKG_INSTALL_DIR)/etc/keepalived/keepalived.conf $(1)/etc/keepalived/
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/keepalived/keepalived.conf \
+		$(1)/etc/keepalived/
+
 	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) ./files/keepalived.init $(1)/etc/init.d/keepalived
+	$(INSTALL_BIN) ./files/keepalived.init \
+		$(1)/etc/init.d/keepalived
+
 	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_CONF) ./files/keepalived.config $(1)/etc/config/keepalived
+	$(INSTALL_CONF) ./files/keepalived.config \
+		$(1)/etc/config/keepalived
+
 	$(INSTALL_DIR) $(1)/etc
-	$(INSTALL_CONF) ./files/keepalived.user $(1)/etc/keepalived.user
+	$(INSTALL_CONF) ./files/keepalived.user \
+		$(1)/etc/keepalived.user
+
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/keepalived
-	$(INSTALL_DATA) ./files/hotplug-user $(1)/etc/hotplug.d/keepalived/01-user
+	$(INSTALL_DATA) ./files/hotplug-user \
+		$(1)/etc/hotplug.d/keepalived/01-user
+
+ifneq ($(CONFIG_KEEPALIVED_SNMP_VRRP)$(CONFIG_KEEPALIVED_SNMP_CHECKER)$(CONFIG_KEEPALIVED_SNMP_RFC2)$(CONFIG_KEEPALIVED_SNMP_RFC3),)
+	$(INSTALL_DIR) $(1)/usr/share/snmp/mibs
+endif
+
+ifneq ($(CONFIG_KEEPALIVED_SNMP_VRRP)$(CONFIG_KEEPALIVED_SNMP_CHECKER),)
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/snmp/mibs/KEEPALIVED-MIB.txt \
+		$(1)/usr/share/snmp/mibs/KEEPALIVED-MIB.txt
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_RFC2),y)
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/snmp/mibs/VRRP-MIB.txt \
+		$(1)/usr/share/snmp/mibs/VRRP-MIB.txt
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_SNMP_RFC3),y)
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/snmp/mibs/VRRPv3-MIB.txt \
+		$(1)/usr/share/snmp/mibs/VRRPv3-MIB.txt
+endif
+
+ifeq ($(CONFIG_KEEPALIVED_DBUS),y)
+	$(INSTALL_DIR) $(1)/etc/dbus-1/system.d
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/dbus-1/system.d/org.keepalived.Vrrp1.conf \
+		$(1)/etc/dbus-1/system.d/org.keepalived.Vrrp1.conf
+
+	$(INSTALL_DIR) $(1)/usr/share/dbus-1/interfaces
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Instance.xml \
+		$(1)/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Instance.xml
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Vrrp.xml \
+		$(1)/usr/share/dbus-1/interfaces/org.keepalived.Vrrp1.Vrrp.xml
+endif
+
 endef
 
 $(eval $(call BuildPackage,keepalived))

--- a/net/keepalived/files/keepalived.config
+++ b/net/keepalived/files/keepalived.config
@@ -10,6 +10,7 @@ config global_defs
 #	option vrrp_mcast_group4	"224.0.0.18" # optional, default 224.0.0.18
 #	option vrrp_mcast_group6	"f02::12"    # optional, default ff02::12
 #	option linkbeat_use_polling	"1"
+#	option vrrp_startup_delay	"5"
 
 #config ipaddress
 #	option name	"ipaddress0"
@@ -144,4 +145,58 @@ config global_defs
 #	option weight		"10"
 #	option fall		"2"
 #	option rise		"3"
+
+#config virtual_server
+#	option enabled			"1"
+#	option ipaddr			"192.168.200.2"
+#	option port			"80"
+#	option fwmark			"0x42"
+#	option delay_loop		"30"
+# valid values for lb_algo rr|wrr|lc|wlc
+#	option lb_algo			"rr"
+# valid values for lb_kind NAT|DR|TUN
+#	option lb_kind			"NAT"
+#	option persistence_timeout	"50"
+#	option persistence_granularity	"192.168.110.2"
+#	option virtualhost		"www.domain1.com"
+# valid values for protocol TCP|UDP
+#	option protocol			"TCP"
+#	option sorry_server_ip		"192.168.100.100"
+#	option sorry_server_port	"80"
+#	list real_server		"Server1"
+#	list real_server		"Server2"
+
+#config real_server
+#	option enabled			"1"
+#	option name			"Server1"
+#	option weight			"2"
+#	option check			"HTTP_GET"
+# only for check TCP_CHECK|HTTP_GET|SSL_GET
+#	option connect_port		"80"
+#	option connect_timeout		"3"
+# only for check MISC_CHECK
+#	option misc_path		"<user-defined-check-script>"
+# only  for check HTTP_GET | SSL_GET
+#	list url			"url1"
+#	list url			"url2"
+#	option nb_get_retry		"3"
+#	option delay_before_retry	"2"
+
+#config real_server
+#	option enabled			"1"
+#	option name			"Server2"
+#	option weight			"2"
+#	option check			"TCP_CHECK"
+#	option connect_port		"80"
+#	option connect_timeout		"3"
+
+#config url
+#	option name	"url1"
+#	option path	"/testurl/test1.jsp"
+#	option digest	"11"
+
+#config url
+#	option name	"url2"
+#	option path	"/testurl/test2.jsp"
+#	option digest	"22"
 

--- a/net/keepalived/files/keepalived.init
+++ b/net/keepalived/files/keepalived.init
@@ -8,229 +8,239 @@ USE_PROCD=1
 
 KEEPALIVED_CONF=/tmp/keepalived.conf
 
-INDENT_1=\\t
-INDENT_2=$INDENT_1$INDENT_1
+INDENT_1="\t"
+INDENT_2="${INDENT_1}${INDENT_1}"
+INDENT_3="${INDENT_1}${INDENT_1}${INDENT_1}"
+INDENT_4="${INDENT_1}${INDENT_1}${INDENT_1}${INDENT_1}"
 
 config_section_open() {
-	local tag=$1
-	local name=$2
+	local tag="$1"
+	local name="$2"
 
-	printf "$tag" >> $KEEPALIVED_CONF
-	[ -n "$name" ] && printf " $name" >> $KEEPALIVED_CONF
-	printf " {\n" >> $KEEPALIVED_CONF
+	printf '%s' "$tag" >> "$KEEPALIVED_CONF"
+	[ -n "$name" ] && printf ' %s' "$name" >> "$KEEPALIVED_CONF"
+	printf ' {\n' >> "$KEEPALIVED_CONF"
 }
 
 config_section_close() {
-	printf "}\n\n" >> $KEEPALIVED_CONF
+	printf '}\n\n' >> "$KEEPALIVED_CONF"
 }
 
 config_foreach_wrapper() {
-	local section=$1
-	local function=$1
+	local section="$1"
+	local function="$1"
 
 	# Convention is that 'function' and 'section' are the same
-	config_foreach $function $section
+	config_foreach "$function" "$section"
 }
 
 print_elems_indent() {
-	local config=$1
+	local config="$1"
 	shift
-	local indent=$1
+	local indent="$1"
 	shift
+
 	[ -z "$indent" ] && indent="$INDENT_1"
-	for opt in $*; do
-		local $opt
+	for opt in "$@"; do
+		local "$opt"
+		local optval
 		local no_val=0
-		if [ ${opt:0:7} == "no_val_" ]; then
-			opt=${opt:7}
+		if [ "${opt:0:7}" = "no_val_" ]; then
+			opt="${opt:7}"
 			no_val=1
 		fi
-		config_get $opt $config $opt
-		eval optval=\$$opt
+		config_get "$opt" "$config" "$opt"
+		eval optval=\$"$opt"
 		[ -z "$optval" ] && continue
-		printf "$indent$opt" >> $KEEPALIVED_CONF
-		[ "$no_val" == "0" ] && {
-			local words=$(echo "$optval" | wc -w)
-			if [ $words -gt 1 ]; then
-				printf " \"$optval\"" >> $KEEPALIVED_CONF
+		printf '%b%s' "$indent" "$opt" >> "$KEEPALIVED_CONF"
+		[ "$no_val" = "0" ] && {
+			local words=0
+			words="$(echo "$optval" | wc -w)"
+			if [ "$words" -gt 1 ]; then
+				printf ' "%s"' "$optval" >> "$KEEPALIVED_CONF"
 			else
-				printf " $optval" >> $KEEPALIVED_CONF
+				printf ' %s' "$optval" >> "$KEEPALIVED_CONF"
 			fi
 		}
-		printf "\n" >> $KEEPALIVED_CONF
+		printf '\n' >> "$KEEPALIVED_CONF"
 	done
 	unset optval
 }
 
 print_list_indent() {
-	local lst=$1
-	local indent=$2
+	local lst="$1"
+	local indent="$2"
 	local lst_elems
-	[ -z "$indent" ] && indent=$INDENT_1
+	[ -z "$indent" ] && indent="$INDENT_1"
 
-	eval lst_elems=\$$lst
+	eval lst_elems=\$"$lst"
 	[ -z "$lst_elems" ] && return 0
 
-	printf "$indent$lst {\n" >> $KEEPALIVED_CONF
+	printf '%b%s {\n' "$indent" "$lst" >> "$KEEPALIVED_CONF"
 	for e in $lst_elems; do
-		[ -n "$eval_item_func" ]
-		printf "$indent$INDENT_1$e\n" >> $KEEPALIVED_CONF
+		printf '%b%s\n' "${indent}${INDENT_1}" "$e">> "$KEEPALIVED_CONF"
 	done
-	printf "$indent}\n" >> $KEEPALIVED_CONF
+	printf '%b}\n' "$indent" >> "$KEEPALIVED_CONF"
 }
 
 print_notify() {
-	local type=$1
+	local type="$1"
 	shift
-	local name=$1
+	local name="$1"
 	shift
-	for notify in $*; do
-		printf "$INDENT_1$notify" >> $KEEPALIVED_CONF
-		notify=$(echo $notify | tr 'a-z' 'A-Z')
-		printf " \"/bin/busybox env -i ACTION=$notify TYPE=$type NAME=$name /sbin/hotplug-call keepalived\"\n" >> $KEEPALIVED_CONF
+	for notify in "$@"; do
+		printf '%b%s' "${INDENT_1}" "$notify">> "$KEEPALIVED_CONF"
+		notify="$(echo "$notify" | tr 'a-z' 'A-Z')"
+		printf ' "/bin/busybox env -i ACTION=%s TYPE=%s NAME=%s /sbin/hotplug-call keepalived"\n' "$notify" "$type" "$name" >> "$KEEPALIVED_CONF"
 	done
 }
 
 global_defs() {
 	local linkbeat_use_polling notification_email
 
-	config_get alt_config_file $1 alt_config_file
+	config_get alt_config_file "$1" alt_config_file
 	[ -z "$alt_config_file" ] || return 0
 
-	config_get_bool linkbeat_use_polling $1 linkbeat_use_polling 0
-	[ $linkbeat_use_polling -gt 0 ] && printf "linkbeat_use_polling\n\n" >> $KEEPALIVED_CONF
+	config_get_bool linkbeat_use_polling "$1" linkbeat_use_polling 0
+	[ "$linkbeat_use_polling" -gt 0 ] && printf 'linkbeat_use_polling\n\n' >> "$KEEPALIVED_CONF"
 
-	config_get notification_email $1 notification_email
+	config_get notification_email "$1" notification_email
 	print_list_indent notification_email
 
-	print_elems_indent $1 $INDENT_1 notification_email_from smtp_server smtp_connect_timeout \
-	           router_id vrrp_mcast_group4 vrrp_mcast_group6
+	print_elems_indent "$1" "$INDENT_1" \
+		notification_email_from \
+		smtp_server \
+		smtp_connect_timeout \
+		router_id \
+		vrrp_mcast_group4 \
+		vrrp_mcast_group6 \
+		vrrp_startup_delay
 }
 
 print_ipaddress_indent() {
-	local section=$1
-	local curr_ipaddr=$2
-	local indent=$3
+	local section="$1"
+	local curr_ipaddr="$2"
+	local indent="$3"
 
 	local address device scope name
-	config_get name    $section name
+	config_get name "$section" name
 	[ "$name" != "$curr_ipaddr" ] && return 0
 
-	config_get address $section address
-	config_get device  $section device
-	config_get scope   $section scope
+	config_get address "$section" address
+	config_get device "$section" device
+	config_get scope "$section" scope
 
 	# Default indent
-	[ -z "$indent" ] && indent=$INDENT_1
+	[ -z "$indent" ] && indent="$INDENT_1"
 
 	# If no address exit
 	[ -z "$address" ] && return 0
 
 	if [ -z "$device" ]; then
-		printf "$indent$address" >> $KEEPALIVED_CONF
+		printf '%b%s' "$indent" "$address" >> "$KEEPALIVED_CONF"
 	else
 		# Add IP address/netmask and device
-		printf "$indent$address dev $device" >> $KEEPALIVED_CONF
+		printf '%b%s dev %s' "$indent" "$address" "$device">> "$KEEPALIVED_CONF"
 		# Add scope
-		[ -n "$scope" ] && printf " scope $scope" >> $KEEPALIVED_CONF
+		[ -n "$scope" ] && printf ' scope %s' "$scope" >> "$KEEPALIVED_CONF"
 	fi
 
-	printf "\n" >> $KEEPALIVED_CONF
+	printf '\n' >> "$KEEPALIVED_CONF"
 }
 
 static_ipaddress() {
 	local address
 	config_get address "$1" address
 	for a in $address; do
-		config_foreach print_ipaddress_indent ipaddress $a
+		config_foreach print_ipaddress_indent ipaddress "$a"
 	done
 }
 
 print_route_indent() {
-	local section=$1
-	local curr_route=$2
-	local indent=$3
+	local section="$1"
+	local curr_route="$2"
+	local indent="$3"
 
 	local name blackhole address src_addr gateway device scope table
 
-	config_get name           $section name
+	config_get name "$section" name
 	[ "$name" != "$curr_route" ] && return 0
 
-	config_get_bool blackhole $section blackhole 0
-	config_get address        $section address
-	config_get src_addr       $section src_addr
-	config_get gateway        $section gateway
-	config_get device         $section device
-	config_get table          $section table
+	config_get_bool blackhole "$section" blackhole 0
+	config_get address "$section" address
+	config_get src_addr "$section" src_addr
+	config_get gateway "$section" gateway
+	config_get device "$section" device
+	config_get table "$section" table
 
 	# If no address exit
 	[ -z "$address" ] && return 0
 
 	# Default indent
-	[ -z "$indent" ] && indent=$INDENT_1
+	[ -z "$indent" ] && indent="$INDENT_1"
 
-	[ $blackhole -gt 0 ] && {
-		printf "${indent}blackhole $address\n" >> $KEEPALIVED_CONF
+	[ "$blackhole" -gt 0 ] && {
+		printf '%bblackhole %s\n' "$indent" "$address" >> "$KEEPALIVED_CONF"
 		return 0
 	}
 	# Add src addr or address
 	if [ -n "$src_addr" ]; then
-		printf "${indent}src $src_addr $address" >> $KEEPALIVED_CONF
+		printf '%bsrc %s %s' "$indent" "$src_addr" "$address" >> "$KEEPALIVED_CONF"
 	else
 		[ -z "$device" ] && return 0
-		printf "$indent$address" >> $KEEPALIVED_CONF
+		printf '%b%s' "$indent" "$address" >> "$KEEPALIVED_CONF"
 	fi
 	# Add route/gateway
-	[ -n "$gateway" ] && printf " via $gateway" >> $KEEPALIVED_CONF
+	[ -n "$gateway" ] && printf ' via %s' "$gateway" >> "$KEEPALIVED_CONF"
 	# Add device
-	printf " dev $device" >> $KEEPALIVED_CONF
+	printf ' dev %s' "$device" >> "$KEEPALIVED_CONF"
 	# Add scope
-	[ -n "$scope" ] && printf " scope $scope" >> $KEEPALIVED_CONF
+	[ -n "$scope" ] && printf ' scope %s' "$scope" >> "$KEEPALIVED_CONF"
 	# Add table
-	[ -n "$table" ] && printf " table $table" >> $KEEPALIVED_CONF
-	printf "\n" >> $KEEPALIVED_CONF
+	[ -n "$table" ] && printf ' table %s' "$table" >> "$KEEPALIVED_CONF"
+	printf '\n' >> "$KEEPALIVED_CONF"
 
 }
 
 print_track_elem_indent() {
-	local section=$1
-	local curr_track_elem=$2
-	local indent=$3
+	local section="$1"
+	local curr_track_elem="$2"
+	local indent="$3"
 
-	local script name value
-	config_get name    $section name
+	local name value
+	config_get name "$section" name
 	[ "$name" != "$curr_track_elem" ] && return 0
 
-	config_get value  $section value
-	config_get weight $section weight
+	config_get value "$section" value
+	config_get weight "$section" weight
 
 	[ -z "$value" ] && return 0
 
-	printf "$indent$value" >> $KEEPALIVED_CONF
-	[ -n "$weight" ] && printf " weight $weight" >> $KEEPALIVED_CONF
-	printf "\n" >> $KEEPALIVED_CONF
+	printf '%b%s' "$indent" "$value" >> "$KEEPALIVED_CONF"
+	[ -n "$weight" ] && printf ' weight %s' "$weight" >> "$KEEPALIVED_CONF"
+	printf '\n' >> "$KEEPALIVED_CONF"
 }
 
 static_routes() {
 	local route
 	config_get route "$1" route
 	for r in $route; do
-		config_foreach print_route_indent route $r
+		config_foreach print_route_indent route "$r"
 	done
 }
 
 # Count 'vrrp_instance' with the given name ; called by vrrp_instance_check()
 vrrp_instance_name_count() {
 	local name
-	config_get name $1 name
-	[ "$name" == "$2" ] && count=$((count + 1))
+	config_get name "$1" name
+	[ "$name" = "$2" ] && count="$((count + 1))"
 }
 
 # Check if there's a 'vrrp_instance' section with the given name
 vrrp_instance_check() {
-	local count=0
-	local name=$1
-	config_foreach vrrp_instance_name_count vrrp_instance $name
+	local count="0"
+	local name="$1"
+	config_foreach vrrp_instance_name_count vrrp_instance "$name"
 	[ $count -gt 0 ] && return 0 || return 1
 }
 
@@ -239,17 +249,17 @@ vrrp_sync_group() {
 	local valid_group
 
 	# No name for group, exit
-	config_get name $1 name
+	config_get name "$1" name
 	[ -z "$name" ] && return 0
 
 	# No members for group, exit
-	config_get group $1 group
+	config_get group "$1" group
 	[ -z "$group" ] && return 0
 
 	# Check if we have 'vrrp_instance's defined for 
 	# each member and remove names with not vrrp_instance defined
 	for m in $group; do
-		vrrp_instance_check $m && valid_group="$valid_group $m"
+		vrrp_instance_check "$m" && valid_group="$valid_group $m"
 	done
 	[ -z "$valid_group" ] && return 0
 
@@ -258,7 +268,7 @@ vrrp_sync_group() {
 	group="$valid_group"
 	print_list_indent group
 
-	print_elems_indent $1 $INDENT_1 no_val_smtp_alert no_val_global_tracking
+	print_elems_indent "$1" "$INDENT_1" no_val_smtp_alert no_val_global_tracking
 
 	print_notify "GROUP" "$name" notify_backup notify_master \
 		notify_fault notify
@@ -269,21 +279,21 @@ vrrp_sync_group() {
 vrrp_instance() {
 	local name auth_type auth_pass
 
-	config_get name $1 name
+	config_get name "$1" name
 	[ -z "$name" ] && return 0
 
 	config_section_open "vrrp_instance" "$name"
 
-	config_get auth_type $1 auth_type
-	config_get auth_pass $1 auth_pass
-	[ -n "$auth_type" -a -n "$auth_pass" ] && {
-		printf "${INDENT_1}authentication {\n" >> $KEEPALIVED_CONF
-		printf "${INDENT_2}auth_type $auth_type\n" >> $KEEPALIVED_CONF
-		printf "${INDENT_2}auth_pass $auth_pass\n" >> $KEEPALIVED_CONF
-		printf "$INDENT_1}\n" >> $KEEPALIVED_CONF
+	config_get auth_type "$1" auth_type
+	config_get auth_pass "$1" auth_pass
+	[ -n "$auth_type" ] && [ -n "$auth_pass" ] && {
+		printf '%bauthentication {\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
+		printf '%bauth_type %s\n' "${INDENT_2}" "$auth_type" >> "$KEEPALIVED_CONF"
+		printf '%bauth_pass %s\n' "${INDENT_2}" "$auth_pass" >> "$KEEPALIVED_CONF"
+		printf '%b}\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
 	}
 
-	print_elems_indent $1 $INDENT_1 state interface \
+	print_elems_indent "$1" "$INDENT_1" state interface \
 		mcast_src_ip unicast_src_ip virtual_router_id version priority \
 		advert_int preempt_delay debug \
 		lvs_sync_daemon_interface garp_master_delay garp_master_refresh \
@@ -297,56 +307,56 @@ vrrp_instance() {
 
 	# Handle virtual_ipaddress & virtual_ipaddress_excluded lists
 	for opt in virtual_ipaddress virtual_ipaddress_excluded; do
-		config_get $opt $1 $opt
+		config_get "$opt" "$1" "$opt"
 		eval optval=\$$opt
 		[ -z "$optval" ] && continue
-		printf "$INDENT_1$opt {\n" >> $KEEPALIVED_CONF
+		printf '%b%s {\n' "${INDENT_1}" "$opt" >> "$KEEPALIVED_CONF"
 		for a in $optval; do
-			config_foreach print_ipaddress_indent ipaddress $a $INDENT_2
+			config_foreach print_ipaddress_indent ipaddress "$a" "$INDENT_2"
 		done
-		printf "$INDENT_1}\n" >> $KEEPALIVED_CONF
+		printf '%b}\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
 	done
 
 	# Handle virtual_routes
 	for opt in virtual_routes; do
-		config_get $opt $1 $opt
+		config_get "$opt" "$1" "$opt"
 		eval optval=\$$opt
 		[ -z "$optval" ] && continue
-		printf "$INDENT_1$opt {\n" >> $KEEPALIVED_CONF
+		printf '%b%s {\n' "${INDENT_1}" "$opt" >> "$KEEPALIVED_CONF"
 		for r in $optval; do
-			config_foreach print_route_indent route $r $INDENT_2
+			config_foreach print_route_indent route "$r" "$INDENT_2"
 		done
-		printf "$INDENT_1}\n" >> $KEEPALIVED_CONF
+		printf '%b}\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
 	done
 
 	# Handle track_script lists
 	for opt in track_script; do
-		config_get $opt $1 $opt
+		config_get "$opt" "$1" "$opt"
 		eval optval=\$$opt
 		[ -z "$optval" ] && continue
-		printf "$INDENT_1$opt {\n" >> $KEEPALIVED_CONF
+		printf '%b%s {\n' "${INDENT_1}" "$opt" >> "$KEEPALIVED_CONF"
 		for t in $optval; do
-			printf "$INDENT_2$optval\n" >> $KEEPALIVED_CONF
+			printf '%b%s\n' "${INDENT_2}" "$optval" >> "$KEEPALIVED_CONF"
 		done
-		printf "$INDENT_1}\n" >> $KEEPALIVED_CONF
+		printf '%b}\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
 	done
 
 	# Handle track_interface lists
 	for opt in track_interface; do
-		config_get $opt $1 $opt
+		config_get "$opt" "$1" "$opt"
 		eval optval=\$$opt
 		[ -z "$optval" ] && continue
-		printf "$INDENT_1$opt {\n" >> $KEEPALIVED_CONF
+		printf '%b%s {\n' "${INDENT_1}" "$opt" >> "$KEEPALIVED_CONF"
 		for t in $optval; do
-			config_foreach print_track_elem_indent track_interface $t $INDENT_2
+			config_foreach print_track_elem_indent track_interface "$t" "$INDENT_2"
 		done
-		printf "$INDENT_1}\n" >> $KEEPALIVED_CONF
+		printf '%b}\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
 	done
 
 	# Handle simple lists of strings (with no spaces in between)
 	for opt in unicast_peer; do
-		config_get $opt $1 $opt
-		print_list_indent $opt
+		config_get "$opt" "$1" "$opt"
+		print_list_indent "$opt"
 	done
 	unset optval
 
@@ -356,12 +366,119 @@ vrrp_instance() {
 vrrp_script() {
 	local name
 
-	config_get name $1 name
+	config_get name "$1" name
 	[ -z "$name" ] && return 0
 
 	config_section_open "vrrp_script" "$name"
 
-	print_elems_indent $1 $INDENT_1 script interval weight fall rise
+	print_elems_indent "$1" "$INDENT_1" script interval weight fall rise
+
+	config_section_close
+}
+
+url() {
+	local url="$2"
+
+	local name path digest
+
+	config_get name "$1" name
+	[ "$url" = "$name" ] || return 0
+
+	config_get path "$1" path
+	config_get digest "$1" digest
+
+	[ -n "$digest" ] && [ -n "$path" ] && {
+		printf '%burl {\n' "${INDENT_3}" >> "$KEEPALIVED_CONF"
+		printf '%bpath %s\n' "${INDENT_4}" "$path" >> "$KEEPALIVED_CONF"
+		printf '%bdigest %s\n' "${INDENT_4}" "$digest" >> "$KEEPALIVED_CONF"
+		printf '%b}\n' "${INDENT_3}" >> "$KEEPALIVED_CONF"
+	}
+}
+
+url_list() {
+	config_foreach url url "$1"
+}
+
+real_server() {
+	local server="$2"
+
+	local enabled name weight ipaddr port check
+
+	config_get_bool enabled "$1" enabled 1
+	[ "$enabled" -eq 1 ] || return 0
+
+	config_get name "$1" name
+	[ "$server" = "$name" ] || return 0
+
+	config_get weight "$1" weight
+	[ -n "$weight" ] || return 0
+
+	config_get ipaddr "$1" ipaddr
+	config_get port "$1" port
+	config_get check "$1" check
+
+	[ -n "$ipaddr" ] && [ -n "$port" ] && {
+		printf '%breal_server %s %d {\n' "${INDENT_1}" "$ipaddr" "$port" >> "$KEEPALIVED_CONF"
+		printf '%bweight %d\n' "${INDENT_2}" "$weight" >> "$KEEPALIVED_CONF"
+		case "$check" in
+			TCP_CHECK)
+				printf '%b%s {\n' "${INDENT_2}" "$check" >> "$KEEPALIVED_CONF"
+				print_elems_indent "$1" "$INDENT_3" connect_timeout \
+					connect_port
+				printf '%b}\n' "${INDENT_2}" >> "$KEEPALIVED_CONF"
+				;;
+			MISC_CHECK)
+				printf '%b%s {\n' "${INDENT_2}" "$check" >> "$KEEPALIVED_CONF"
+				print_elems_indent "$1" "$INDENT_3" misc_path
+				printf '%b}\n' "${INDENT_2}" >> "$KEEPALIVED_CONF"
+				;;
+			HTTP_GET | SSL_GET)
+				printf '%b%s {\n' "${INDENT_2}" "$check" >> "$KEEPALIVED_CONF"
+				print_elems_indent "$1" "$INDENT_3" connect_timeout \
+					connect_port nb_get_retry delay_before_retry
+				# Handle url list
+				config_list_foreach "$1" url url_list
+				printf '%b}\n' "${INDENT_2}" >> "$KEEPALIVED_CONF"
+				;;
+		esac
+		printf '%b}\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
+	}
+}
+
+real_server_list() {
+	config_foreach real_server real_server "$1"
+}
+
+virtual_server() {
+	local enabled ipaddr port lb_algo sorry_server_ip sorry_server_port
+
+	config_get_bool enabled "$1" enabled 1
+	[ "$enabled" -eq 1 ] || return 0
+
+	config_get ipaddr "$1" ipaddr
+	[ -z "$ipaddr" ] && return 0
+	config_get port "$1" port
+	[ -z "$port" ] && return 0
+
+	config_section_open "virtual_server" "$ipaddr $port"
+
+	print_elems_indent "$1" "$INDENT_1" fwmark delay_loop \
+		lb_kind persistence_timeout persistence_granularity \
+		virtualhost protocol
+
+	config_get lb_algo "$1" lb_algo
+	[ -z "$lb_algo" ] && lb_algo="rr"
+	modprobe ip_vs_${lb_algo} 1>/dev/null 2>&1
+	printf '%blb_algo %s\n' "${INDENT_1}" "${lb_algo}" >> "$KEEPALIVED_CONF"
+
+	config_get sorry_server_ip "$1" sorry_server_ip
+	config_get sorry_server_port "$1" sorry_server_port
+	[ -n "$sorry_server_ip" ] && [ -n "$sorry_server_port" ] && {
+		printf '%bsorry_server %s %s\n' "${INDENT_1}" "$sorry_server_ip" "$sorry_server_port" >> "$KEEPALIVED_CONF"
+	}
+
+	# Handle real_server list
+	config_list_foreach "$1" real_server real_server_list
 
 	config_section_close
 }
@@ -369,11 +486,11 @@ vrrp_script() {
 process_config() {
 	local alt_config_file
 
-	rm -f $KEEPALIVED_CONF
+	rm -f "$KEEPALIVED_CONF"
 
 	# First line
-	printf "! Configuration file for keepalived (autogenerated via init script)\n" > $KEEPALIVED_CONF
-	printf "! Written %s\n\n" "$(date +'%c')" >> $KEEPALIVED_CONF
+	printf '! Configuration file for keepalived (autogenerated via init script)\n' > "$KEEPALIVED_CONF"
+	printf '! Written %s\n\n' "$(date +'%c')" >> "$KEEPALIVED_CONF"
 
 	[ -f /etc/config/keepalived ] || return 0
 	config_load 'keepalived'
@@ -384,9 +501,9 @@ process_config() {
 
 	# If "alt_config_file" specified, use that instead
 	[ -n "$alt_config_file" ] && [ -f "$alt_config_file" ] && {
-		rm -f $KEEPALIVED_CONF
+		rm -f "$KEEPALIVED_CONF"
 		# Symlink "alt_config_file" since it's a bit easier and safer
-		ln -s $alt_config_file $KEEPALIVED_CONF
+		ln -s "$alt_config_file" "$KEEPALIVED_CONF"
 		return 0
 	}
 
@@ -401,6 +518,7 @@ process_config() {
 	config_foreach_wrapper vrrp_script
 	config_foreach_wrapper vrrp_sync_group
 	config_foreach_wrapper vrrp_instance
+	config_foreach_wrapper virtual_server
 	return 0
 }
 


### PR DESCRIPTION
Maintainer: @FlorianFieber 
Compile tested: N/A
Run tested:  N/A

Description:
This PR updates keepalived version to 2.0.18 because of CVE-2018-19046
