### PR TITLE
[18.06]git: fix cross compilation on macOS

### DIFF
--- a/net/git/Makefile
+++ b/net/git/Makefile
@@ -87,7 +87,8 @@ MAKE_FLAGS := \
 	GITWEB_JS="/gitweb/gitweb.js" \
 	GITWEB_CSS="/gitweb/gitweb.css" \
 	GITWEB_LOGO="/gitweb/gitweb-logo.png" \
-	GITWEB_FAVICON="/gitweb/gitweb-favicon.png"
+	GITWEB_FAVICON="/gitweb/gitweb-favicon.png" \
+	uname_S="Linux" \
 
 CONFIGURE_ARGS += \
 	--without-iconv \

--- a/net/git/patches/310-fix-uname-detection-for-crosscompiling
+++ b/net/git/patches/310-fix-uname-detection-for-crosscompiling
@@ -1,0 +1,44 @@
+From 9dcf7e679c441b877b63ff8e6dfc3865af6c6720 Mon Sep 17 00:00:00 2001
+From: Mauro Condarelli <mc5686 at mclink.it>
+Date: Sun, 22 May 2016 20:44:26 +0200
+Subject: [PATCH 1/1] Fix config.mak.uname to allow cross-compilation
+
+Current implementation imperatively sets variables from "uname" output.
+This breaks cross-compilation because uname is run on host while target
+configuration may be different.
+
+Make current behavior a non-imperative default, so it's possible to
+force different values setting make variables.
+
+To cross-compile it will be necessary to explicitly set the various
+uname_X variables to values compatible with target.
+No change is needed with normal host compilation.
+Patch is trivial.
+
+Signed-off-by: Mauro Condarelli <mc5686 at mclink.it>
+---
+ config.mak.uname | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/config.mak.uname b/config.mak.uname
+index 40d6b29..d933b23 100644
+--- a/config.mak.uname
++++ b/config.mak.uname
+@@ -1,11 +1,11 @@
+ # Platform specific Makefile tweaks based on uname detection
+ 
+-uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+-uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
+-uname_O := $(shell sh -c 'uname -o 2>/dev/null || echo not')
+-uname_R := $(shell sh -c 'uname -r 2>/dev/null || echo not')
+-uname_P := $(shell sh -c 'uname -p 2>/dev/null || echo not')
+-uname_V := $(shell sh -c 'uname -v 2>/dev/null || echo not')
++uname_S ?= $(shell sh -c 'uname -s 2>/dev/null || echo not')
++uname_M ?= $(shell sh -c 'uname -m 2>/dev/null || echo not')
++uname_O ?= $(shell sh -c 'uname -o 2>/dev/null || echo not')
++uname_R ?= $(shell sh -c 'uname -r 2>/dev/null || echo not')
++uname_P ?= $(shell sh -c 'uname -p 2>/dev/null || echo not')
++uname_V ?= $(shell sh -c 'uname -v 2>/dev/null || echo not')
+ 
+ ifdef MSVC
+   # avoid the MingW and Cygwin configuration sections


### PR DESCRIPTION
Maintainer: @tripolar
Compile & run tested: OpenWRT 18.06 target-aarch64_cortex-a53_musl NanoPi Neo Core 2

Based on: http://lists.busybox.net/pipermail/buildroot/2016-May/161696.html

Signed-off-by: Mauro Condarelli <mc5686@mclink.it>
Signed-off-by: Jakub Piotr Cłapa <jpc@loee.pl>
