### PR TITLE
[OpenWrt 18.06] zeromq: update to version 4.1.7 (security fix)

### DIFF
--- a/libs/zmq/Makefile
+++ b/libs/zmq/Makefile
@@ -11,13 +11,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zeromq
 PKG_VERSION:=4.1.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Dirk Chang <dirk@kooiot.com>
 PKG_LICENSE:=GPL-3.0+
 PKG_LICENSE_FILES:=LICENCE.txt
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:= https://github.com/zeromq/zeromq4-1/releases/download/v$(PKG_VERSION)/
+PKG_SOURCE_URL:=https://github.com/zeromq/zeromq4-1/releases/download/v$(PKG_VERSION)/
 PKG_HASH:=e99f44fde25c2e4cb84ce440f87ca7d3fe3271c2b8cfbc67d55e4de25e6fe378
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
@@ -32,7 +32,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/libzmq/default
   TITLE:=ZeroMQ - Message Queue engine
-  URL:=http://www.zeromq.org/
+  URL:=https://www.zeromq.org/
   SECTION:=libs
   CATEGORY:=Libraries
   DEPENDS:=+libuuid +libpthread +librt $(CXX_DEPENDS)

--- a/libs/zmq/patches/050-CVE-2019-13132.patch
+++ b/libs/zmq/patches/050-CVE-2019-13132.patch
@@ -1,0 +1,100 @@
+From 6e24ae09d020ab505c1aab96e5ae91cca360e856 Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <luca.boccassi@microsoft.com>
+Date: Tue, 2 Jul 2019 12:17:02 +0100
+Subject: [PATCH] Problem: application metadata not parsed correctly when using
+ CURVE
+
+Solution: create buffers large enough to contain arbitrary metadata
+---
+ src/curve_server.cpp | 34 ++++++++++++++++++++++++----------
+ 1 file changed, 24 insertions(+), 10 deletions(-)
+
+diff --git a/src/curve_server.cpp b/src/curve_server.cpp
+index e85b10b8..82915131 100644
+--- a/src/curve_server.cpp
++++ b/src/curve_server.cpp
+@@ -439,8 +439,12 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
+     const size_t clen = (msg_->size () - 113) + crypto_box_BOXZEROBYTES;
+ 
+     uint8_t initiate_nonce [crypto_box_NONCEBYTES];
+-    uint8_t initiate_plaintext [crypto_box_ZEROBYTES + 128 + 256];
+-    uint8_t initiate_box [crypto_box_BOXZEROBYTES + 144 + 256];
++    uint8_t *initiate_plaintext =
++      static_cast<uint8_t *> (malloc (crypto_box_ZEROBYTES + clen));
++    alloc_assert (initiate_plaintext);
++    uint8_t *initiate_box =
++      static_cast<uint8_t *> (malloc (crypto_box_BOXZEROBYTES + clen));
++    alloc_assert (initiate_box);
+ 
+     //  Open Box [C + vouch + metadata](C'->S')
+     memset (initiate_box, 0, crypto_box_BOXZEROBYTES);
+@@ -451,17 +455,18 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
+     memcpy (initiate_nonce + 16, initiate + 105, 8);
+     cn_peer_nonce = get_uint64(initiate + 105);
+ 
++    const uint8_t *client_key = initiate_plaintext + crypto_box_ZEROBYTES;
++
+     rc = crypto_box_open (initiate_plaintext, initiate_box,
+                           clen, initiate_nonce, cn_client, cn_secret);
+     if (rc != 0) {
+         //  Temporary support for security debugging
+         puts ("CURVE I: cannot open client INITIATE");
+         errno = EPROTO;
+-        return -1;
++        rc = -1;
++        goto exit;
+     }
+ 
+-    const uint8_t *client_key = initiate_plaintext + crypto_box_ZEROBYTES;
+-
+     uint8_t vouch_nonce [crypto_box_NONCEBYTES];
+     uint8_t vouch_plaintext [crypto_box_ZEROBYTES + 64];
+     uint8_t vouch_box [crypto_box_BOXZEROBYTES + 80];
+@@ -482,7 +487,8 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
+         //  Temporary support for security debugging
+         puts ("CURVE I: cannot open client INITIATE vouch");
+         errno = EPROTO;
+-        return -1;
++        rc = -1;
++        goto exit;
+     }
+ 
+     //  What we decrypted must be the client's short-term public key
+@@ -490,7 +496,8 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
+         //  Temporary support for security debugging
+         puts ("CURVE I: invalid handshake from client (public key)");
+         errno = EPROTO;
+-        return -1;
++        rc = -1;
++        goto exit;
+     }
+ 
+     //  Precompute connection secret from client key
+@@ -509,14 +516,21 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
+         else
+         if (errno == EAGAIN)
+             state = expect_zap_reply;
+-        else
+-            return -1;
++        else {
++            rc = -1;
++            goto exit;
++        }
+     }
+     else
+         state = send_ready;
+ 
+-    return parse_metadata (initiate_plaintext + crypto_box_ZEROBYTES + 128,
++    rc = parse_metadata (initiate_plaintext + crypto_box_ZEROBYTES + 128,
+                            clen - crypto_box_ZEROBYTES - 128);
++
++exit:
++    free (initiate_plaintext);
++    free (initiate_box);
++    return rc;
+ }
+ 
+ int zmq::curve_server_t::produce_ready (msg_t *msg_)
+-- 
+2.20.1
+


### PR DESCRIPTION
Maintainer: @srdgame 
Compile tested: Turris Omnia (TOS4), OpenWrt 18.06.4
Run tested: Turris Omnia (TOS4), OpenWrt 18.06.4

Description:
Backport from master fixes CVE-2019-13132

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>
