### PR TITLE
python-oauthlib: bump to 3.1.0

### DIFF
--- a/lang/python/python-oauthlib/Makefile
+++ b/lang/python/python-oauthlib/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-oauthlib
-PKG_VERSION:=3.0.2
+PKG_VERSION:=3.1.0
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
@@ -15,7 +15,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=oauthlib-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/o/oauthlib
-PKG_HASH:=b4d99ae8ccfb7d33ba9591b59355c64eef5241534aa3da2e4c0435346b84bc8e
+PKG_HASH:=bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-oauthlib-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: arm, WRT3200ACM, current master
Run tested: arm, WRT3200ACM, current master, tested logging into seafile-seahub using github account.

Description:
This is a feature release including improvement to OIDC and security enhancements, as well as bugfixes.

Upstream changelog:
>
>#### OAuth2.0 Provider - Features
>* OIDC add support of nonce, c_hash, at_hash fields
>  - New RequestValidator.fill_id_token method
>  - Deprecated RequestValidator.get_id_token method
>* OIDC add UserInfo endpoint
>  - New RequestValidator.get_userinfo_claims method
>
>#### OAuth2.0 Provider - Security
>* Enhance data leak to logs
>  - New default to not expose request content in logs
>  - New function `oauthlib.set_debug(True)`
>* Disabling query parameters for POST requests
>
>#### OAuth2.0 Provider - Bugfixes
>* Fix validate_authorization_request to return the new PKCE fields
>* Fix token_type to be case-insensitive (bearer and Bearer)
>
>#### OAuth2.0 Client - Bugfixes
>* Fix Authorization Code's errors processing
>* BackendApplication.Client.prepare_request_body use the "scope" argument as intended.
>* Fix edge case when expires_in=Null
>
>#### OAuth1.0 Client
>* Add case-insensitive headers to oauth1 BaseEndpoint

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>