### PR TITLE
netdata: Add patch to disable optional libraries

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
 PKG_VERSION:=1.16.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
 PKG_LICENSE:=GPL-3.0-or-later

--- a/admin/netdata/patches/003-disable-optional-libraries-PR6658.patch
+++ b/admin/netdata/patches/003-disable-optional-libraries-PR6658.patch
@@ -1,0 +1,85 @@
+From 893bfc98d3f33d02ce6d6a3a48fb02c964156fb5 Mon Sep 17 00:00:00 2001
+From: Markos Fountoulakis <markos.fountoulakis.senior@gmail.com>
+Date: Wed, 14 Aug 2019 11:55:50 +0300
+Subject: [PATCH] Stop configure.ac from linking against dbengine and https
+ libraries when dbengine or https are disabled
+
+---
+ configure.ac | 28 +++++++++++++---------------
+ 1 file changed, 13 insertions(+), 15 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 56e484cc2c..8dbdcaa17f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -280,9 +280,6 @@ AC_CHECK_LIB(
+     [UV_LIBS="-luv"]
+ )
+ 
+-OPTIONAL_UV_CFLAGS="${UV_CFLAGS}"
+-OPTIONAL_UV_LIBS="${UV_LIBS}"
+-
+ 
+ # -----------------------------------------------------------------------------
+ # lz4 Extremely Fast Compression algorithm
+@@ -293,9 +290,6 @@ AC_CHECK_LIB(
+     [LZ4_LIBS="-llz4"]
+ )
+ 
+-OPTIONAL_LZ4_CFLAGS="${LZ4_CFLAGS}"
+-OPTIONAL_LZ4_LIBS="${LZ4_LIBS}"
+-
+ 
+ # -----------------------------------------------------------------------------
+ # Judy General purpose dynamic array
+@@ -306,9 +300,6 @@ AC_CHECK_LIB(
+     [JUDY_LIBS="-lJudy"]
+ )
+ 
+-OPTIONAL_JUDY_CFLAGS="${JUDY_CFLAGS}"
+-OPTIONAL_JUDY_LIBS="${JUDY_LIBS}"
+-
+ 
+ # -----------------------------------------------------------------------------
+ # zlib
+@@ -356,9 +347,6 @@ AC_CHECK_LIB(
+     [SSL_LIBS="-lcrypto -lssl"]
+ )
+ 
+-OPTIONAL_SSL_CFLAGS="${SSL_CFLAGS}"
+-OPTIONAL_SSL_LIBS="${SSL_LIBS}"
+-
+ # -----------------------------------------------------------------------------
+ # JSON-C library
+ 
+@@ -391,6 +379,14 @@ AC_MSG_CHECKING([if netdata dbengine should be used])
+ if test "${enable_dbengine}" != "no" -a "${UV_LIBS}" -a "${LZ4_LIBS}" -a "${JUDY_LIBS}" -a "${SSL_LIBS}"; then
+     enable_dbengine="yes"
+     AC_DEFINE([ENABLE_DBENGINE], [1], [netdata dbengine usability])
++    OPTIONAL_UV_CFLAGS="${UV_CFLAGS}"
++    OPTIONAL_UV_LIBS="${UV_LIBS}"
++    OPTIONAL_LZ4_CFLAGS="${LZ4_CFLAGS}"
++    OPTIONAL_LZ4_LIBS="${LZ4_LIBS}"
++    OPTIONAL_JUDY_CFLAGS="${JUDY_CFLAGS}"
++    OPTIONAL_JUDY_LIBS="${JUDY_LIBS}"
++    OPTIONAL_SSL_CFLAGS="${SSL_CFLAGS}"
++    OPTIONAL_SSL_LIBS="${SSL_LIBS}"
+ else
+     enable_dbengine="no"
+ fi
+@@ -399,10 +395,12 @@ AM_CONDITIONAL([ENABLE_DBENGINE], [test "${enable_dbengine}" = "yes"])
+ 
+ AC_MSG_CHECKING([if netdata https should be used])
+ if test "${enable_https}" != "no" -a "${SSL_LIBS}"; then
+-	enable_https="yes"
+-	AC_DEFINE([ENABLE_HTTPS], [1], [netdata HTTPS usability])
++    enable_https="yes"
++    AC_DEFINE([ENABLE_HTTPS], [1], [netdata HTTPS usability])
++    OPTIONAL_SSL_CFLAGS="${SSL_CFLAGS}"
++    OPTIONAL_SSL_LIBS="${SSL_LIBS}"
+ else
+-	enable_https="no"
++    enable_https="no"
+ fi
+ AC_MSG_RESULT([${enable_https}])
+ AM_CONDITIONAL([ENABLE_HTTPS], [test "${enable_https}" = "yes"])


### PR DESCRIPTION
Maintainer: me and @BKPepe 
Compile tested: mvebu, Linksys WRT3200ACM, OpenWrt master
Run tested: N/A (not needed)

Description:
Netdata adds optional libraries if found, add patch (PR#6658) to avoid pulling in unnecessary libraries.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>