### PR TITLE
monit: enable / fix IPv6 detection during build

### DIFF
--- a/admin/monit/Makefile
+++ b/admin/monit/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=monit
 PKG_VERSION:=5.25.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://mmonit.com/monit/dist
@@ -63,6 +63,7 @@ endef
 
 CONFIGURE_ARGS += \
 	--without-pam \
+	ac_cv_ipv6=$(if $(CONFIG_IPV6),yes,no) \
 	libmonit_cv_setjmp_available=yes \
 	libmonit_cv_vsnprintf_c99_conformant=yes
 

--- a/admin/monit/patches/010-openssl-thread-api.patch
+++ b/admin/monit/patches/010-openssl-thread-api.patch
@@ -1,8 +1,6 @@
-diff --git a/src/ssl/Ssl.c b/src/ssl/Ssl.c
-index 6501f25..9c24ad5 100644
 --- a/src/ssl/Ssl.c
 +++ b/src/ssl/Ssl.c
-@@ -302,8 +302,8 @@ static boolean_t _retry(int socket, int *timeout, int (*callback)(int socket, ti
+@@ -302,8 +302,8 @@ static boolean_t _retry(int socket, int
  
  
  #if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)


### PR DESCRIPTION
Maintainer: me
Compile & tested: OpenWrt SNAPSHOT r10847+1-853e4dd306 / GL.iNet GL-AR150
```
root@OpenWrt:~# netstat -laputen | grep monit
tcp        0      0 127.0.0.1:2812          0.0.0.0:*               LISTEN      1384/monit
tcp        0      0 ::1:2812                :::*                    LISTEN      1384/monit
```
Description:
thanks to @val-kulkov for noticing

