### PR TITLE
tor: update to version 0.4.1.5

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.0.5
+PKG_VERSION:=0.4.1.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=b5a2cbf0dcd3f1df2675dbd5ec10bbe6f8ae995c41b68cebe2bc95bffc90696e
+PKG_HASH:=a864e0b605fb933fcc167bf242eed4233949e8a1bf23ac8e0381b106cd920425
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION

Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS5), OpenWrt Master
Run tested: Turris Omnia (TOS5), OpenWrt Master

Description:
This PR updates tor to version 0.4.1.5 . It's first stable release from 0.4.1.x series.
 https://blog.torproject.org/new-release-tor-0415

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>