### PR TITLE
measurement-kit: update to version 0.10.5

### DIFF
--- a/libs/measurement-kit/Makefile
+++ b/libs/measurement-kit/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=measurement-kit
-PKG_VERSION:=0.10.4
+PKG_VERSION:=0.10.5
 PKG_RELEASE=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/measurement-kit/measurement-kit/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6ca0d9e7a9c1ff0ea8713bf59fde9f87365acdc4b784a5a4bb3f35a77bc4b775
+PKG_HASH:=8b83f04f4d3c653f93bcee5a6cc5e32e6595a3feb99526017d78099fd90d4a75
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Maintainer: me  
Compile tested: Turris Omnia (TOS5), OpenWrt Master
Run tested: Turris Omnia (TOS5), OpenWrt Master

Description:
This PR updates measuremnt-kit to version 0.10.5 It mainly contains updates of measurement test

Changelog https://github.com/measurement-kit/measurement-kit/releases/tag/v0.10.5

 Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>
