### PR TITLE
hcxtools: Added both hcxtools and hcxdumptool to openwrt-19.07 branch.

### DIFF
--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2019 Andreas Nilsen <adde88@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=hcxdumptool
+PKG_VERSION:=5.2.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxdumptool/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=9da9c8c20b93f6a0a262436a862e376bd3cfd05fb879efcf480ad962a14496c7
+
+PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=license.txt
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/hcxdumptool
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpcap
+  TITLE:=hcxdumptool
+  URL:=https://github.com/ZerBea/hcxdumptool
+  SUBMENU:=Wireless
+endef
+
+define Package/hcxdumptool/description
+  Small tool to capture packets from wlan devices. After capturing, upload
+  the "uncleaned" cap here (https://wpa-sec.stanev.org/?submit)
+  to see if your ap or the client is vulnerable by using common wordlists.
+  Convert the cap to hccapx and/or to WPA-PMKID-PBKDF2 hashline (16800) with hcxpcaptool (hcxtools)
+  and check if wlan-key or plainmasterkey was transmitted unencrypted.
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR)/ \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS="$(TARGET_CFLAGS)"
+endef
+
+define Package/hcxdumptool/install
+	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxdumptool $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,hcxdumptool))

--- a/net/hcxtools/Makefile
+++ b/net/hcxtools/Makefile
@@ -1,0 +1,66 @@
+#
+# Copyright (C) 2019 Andreas Nilsen <adde88@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=hcxtools
+PKG_VERSION:=5.2.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxtools/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=1e8120c5451a38645ade0be4255d3c7f4a837b7611b44d4a5a066e563ad8a112
+
+PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=license.txt
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/hcxtools
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpthread +libpcap +zlib +libcurl +libopenssl
+  TITLE:=hcxtools
+  URL:=https://github.com/ZerBea/hcxtools
+  SUBMENU:=Wireless
+endef
+
+define Package/hcxtools/description
+  Set of tools convert packets from captures (h = hash, c = capture, convert and calculate candidates, x = different hashtypes)
+  for the use with latest hashcat or John the Ripper.
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR)/ \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS="$(TARGET_CFLAGS)"
+endef
+
+define Package/hcxtools/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanwkp2hcx	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanpmk2hcx	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcxmnc	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcx2essid	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanjohn2hcx	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpcaptool	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcx2john	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpsktool	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancow2hcxpmk	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcxinfo	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhash2cap	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhashcattool	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhashhcx	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhc2hcx	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxwltool	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/whoismac	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,hcxtools))


### PR DESCRIPTION
Maintainer: me / @adde88 (find it by checking history of the package Makefile)
Compile tested: (ar71xx,Hak5 WiFi Pineapple NANO, OpenWRT 19.07)
Run tested: (ar71xx,Hak5 WiFi Pineapple NANO, OpenWRT 19.07, tested both packages)

Description: Add hcxtools and hcxdumptool to the openwrt-19.07 branch.