### PR TITLE
hcxtools: Updated to v5.2.0. 

### DIFF
--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hcxdumptool
-PKG_VERSION:=5.1.7
+PKG_VERSION:=5.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxdumptool/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=6ac996a506cb312a5f1c5987f30a4a80c793993908750f69f2df51056f961269
+PKG_HASH:=9da9c8c20b93f6a0a262436a862e376bd3cfd05fb879efcf480ad962a14496c7
 
 PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 PKG_LICENSE:=MIT
@@ -45,8 +45,8 @@ define Build/Compile
 endef
 
 define Package/hcxdumptool/install
-	$(INSTALL_DIR) $(1)/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxdumptool $(1)/sbin/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxdumptool $(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,hcxdumptool))

--- a/net/hcxtools/Makefile
+++ b/net/hcxtools/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hcxtools
-PKG_VERSION:=5.1.6
+PKG_VERSION:=5.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxtools/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=19d2800c6f9339dd552ebc3e7195860f208a9856340b4db1aeaeb4a234557ca6
+PKG_HASH:=1e8120c5451a38645ade0be4255d3c7f4a837b7611b44d4a5a066e563ad8a112
 
 PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 PKG_LICENSE:=MIT
@@ -42,26 +42,26 @@ define Build/Compile
 endef
 
 define Package/hcxtools/install
-	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/etc
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanwkp2hcx	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanpmk2hcx	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcxmnc	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcx2essid	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanjohn2hcx	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpcaptool	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcx2john	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpsktool	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancow2hcxpmk	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcxinfo	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhash2cap	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhashcattool	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhashhcx	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhc2hcx	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxwltool	$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/whoismac		$(1)/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanwkp2hcx	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanpmk2hcx	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcxmnc	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcx2essid	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanjohn2hcx	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpcaptool	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcx2john	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpsktool	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancow2hcxpmk	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcxinfo	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhash2cap	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhashcattool	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhashhcx	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhc2hcx	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxwltool	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/whoismac	$(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,hcxtools))


### PR DESCRIPTION
Also modified default install dir to /usr/sbin

Signed-off-by: Andreas Nilsen <adde88@gmail.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
