### PR TITLE
[18.06] grilo plugins: fix build errors

### DIFF
--- a/multimedia/grilo-plugins/Makefile
+++ b/multimedia/grilo-plugins/Makefile
@@ -1,6 +1,4 @@
 #
-# Copyright (C) 2006-2015 OpenWrt.org
-#
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
@@ -9,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grilo-plugins
 PKG_VERSION:=0.3.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -20,9 +18,10 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/grilo-plugins/0.3/
 PKG_HASH:=2977827b8ecb3e15535236180e57dc35e85058d111349bdb6a1597e62a5068fb
 
-PKG_BUILD_DEPENDS:=glib2 grilo
-
+PKG_BUILD_DEPENDS:=glib2
+PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk

--- a/multimedia/grilo-plugins/Makefile
+++ b/multimedia/grilo-plugins/Makefile
@@ -53,6 +53,8 @@ CONFIGURE_ARGS += \
         --without-libintl-prefix \
         --without-x \
 
+MAKE_FLAGS += \
+        GLIB_COMPILE_RESOURCES="$(STAGING_DIR_HOSTPKG)/bin/glib-compile-resources"
 define Package/grilo-plugins/install
 	$(INSTALL_DIR) $(1)/usr/lib/grilo-0.3
 endef

--- a/multimedia/grilo-plugins/Makefile
+++ b/multimedia/grilo-plugins/Makefile
@@ -48,9 +48,7 @@ endef
 
 CONFIGURE_ARGS += \
         --enable-static \
-        --without-libiconv-prefix \
-        --without-libintl-prefix \
-        --without-x \
+        --enable-compile-warnings=minimum
 
 MAKE_FLAGS += \
         GLIB_COMPILE_RESOURCES="$(STAGING_DIR_HOSTPKG)/bin/glib-compile-resources"

--- a/multimedia/grilo-plugins/patches/001-remove-docs-gnome-from-configure.ac.patch
+++ b/multimedia/grilo-plugins/patches/001-remove-docs-gnome-from-configure.ac.patch
@@ -1,0 +1,31 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -1316,7 +1316,7 @@ AC_SUBST(DEPS_OPENSUBTITLES_LIBS)
+ # GETTEXT/INTLTOOL
+ # ----------------------------------------------------------
+ 
+-IT_PROG_INTLTOOL([0.40.0])
++IT_PROG_INTLTOOL([0.40.0], [no-xml])
+ GETTEXT_PACKAGE=grilo-plugins
+ AC_SUBST(GETTEXT_PACKAGE)
+ AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [The domain to use with gettext])
+@@ -1334,7 +1334,7 @@ AC_SUBST([builddir])
+ # DOCUMENTATION
+ # ----------------------------------------------------------
+ 
+-YELP_HELP_INIT
++#YELP_HELP_INIT
+ 
+ # ----------------------------------------------------------
+ # OUTPUT
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -10,7 +10,7 @@ include $(top_srcdir)/release.mk
+ 
+ ACLOCAL_AMFLAGS = -I m4
+ 
+-SUBDIRS = src help po tests
++SUBDIRS = src po
+ 
+ MAINTAINERCLEANFILES = \
+ 	$(GITIGNORE_MAINTAINERCLEANFILES_TOPLEVEL) \

--- a/multimedia/grilo-plugins/src/m4/gnome-common.m4
+++ b/multimedia/grilo-plugins/src/m4/gnome-common.m4
@@ -1,0 +1,32 @@
+# gnome-common.m4
+#
+# serial 3
+# 
+
+AU_DEFUN([GNOME_DEBUG_CHECK],
+[
+	AX_CHECK_ENABLE_DEBUG([no],[GNOME_ENABLE_DEBUG])
+],
+[[$0: This macro is deprecated. You should use AX_CHECK_ENABLE_DEBUG instead and
+replace uses of GNOME_ENABLE_DEBUG with ENABLE_DEBUG.
+See: http://www.gnu.org/software/autoconf-archive/ax_check_enable_debug.html#ax_check_enable_debug]])
+
+dnl GNOME_MAINTAINER_MODE_DEFINES ()
+dnl define DISABLE_DEPRECATED
+dnl
+AU_DEFUN([GNOME_MAINTAINER_MODE_DEFINES],
+[
+	AC_REQUIRE([AM_MAINTAINER_MODE])
+
+	DISABLE_DEPRECATED=""
+	if test $USE_MAINTAINER_MODE = yes; then
+	        DOMAINS="GCONF BONOBO BONOBO_UI GNOME LIBGLADE GNOME_VFS WNCK LIBSOUP"
+	        for DOMAIN in $DOMAINS; do
+	               DISABLE_DEPRECATED="$DISABLE_DEPRECATED -D${DOMAIN}_DISABLE_DEPRECATED -D${DOMAIN}_DISABLE_SINGLE_INCLUDES"
+	        done
+	fi
+
+	AC_SUBST(DISABLE_DEPRECATED)
+],
+[[$0: This macro is deprecated. All of the modules it disables deprecations for
+are obsolete. Remove it and all uses of DISABLE_DEPRECATED.]])

--- a/multimedia/grilo-plugins/src/m4/gnome-compiler-flags.m4
+++ b/multimedia/grilo-plugins/src/m4/gnome-compiler-flags.m4
@@ -1,0 +1,184 @@
+# gnome-compiler-flags.m4
+#
+# serial 4
+#
+
+dnl GNOME_COMPILE_WARNINGS
+dnl Turn on many useful compiler warnings and substitute the result into
+dnl WARN_CFLAGS
+dnl For now, only works on GCC
+dnl Pass the default value of the --enable-compile-warnings configure option as
+dnl the first argument to the macro, defaulting to 'yes'.
+dnl Additional warning/error flags can be passed as an optional second argument.
+dnl
+dnl For example: GNOME_COMPILE_WARNINGS([maximum],[-Werror=some-flag -Wfoobar])
+AU_DEFUN([GNOME_COMPILE_WARNINGS],[
+    dnl ******************************
+    dnl More compiler warnings
+    dnl ******************************
+
+    AC_ARG_ENABLE(compile-warnings, 
+                  AS_HELP_STRING([--enable-compile-warnings=@<:@no/minimum/yes/maximum/error@:>@],
+                                 [Turn on compiler warnings]),,
+                  [enable_compile_warnings="m4_default([$1],[yes])"])
+
+    if test "x$GCC" != xyes; then
+	enable_compile_warnings=no
+    fi
+
+    warning_flags=
+    realsave_CFLAGS="$CFLAGS"
+
+    dnl These are warning flags that aren't marked as fatal.  Can be
+    dnl overridden on a per-project basis with -Wno-foo.
+    base_warn_flags=" \
+        -Wall \
+        -Wstrict-prototypes \
+        -Wnested-externs \
+    "
+
+    dnl These compiler flags typically indicate very broken or suspicious
+    dnl code.  Some of them such as implicit-function-declaration are
+    dnl just not default because gcc compiles a lot of legacy code.
+    dnl We choose to make this set into explicit errors.
+    base_error_flags=" \
+        -Werror=missing-prototypes \
+        -Werror=implicit-function-declaration \
+        -Werror=pointer-arith \
+        -Werror=init-self \
+        -Werror=format-security \
+        -Werror=format=2 \
+        -Werror=missing-include-dirs \
+        -Werror=return-type \
+    "
+
+    dnl Additional warning or error flags provided by the module author to
+    dnl allow stricter standards to be imposed on a per-module basis.
+    dnl The author can pass -W or -Werror flags here as they see fit.
+    additional_flags="m4_default([$2],[])"
+
+    case "$enable_compile_warnings" in
+    no)
+        warning_flags="-w"
+        ;;
+    minimum)
+        warning_flags="-Wall"
+        ;;
+    yes|maximum|error)
+        warning_flags="$base_warn_flags $base_error_flags $additional_flags"
+        ;;
+    *)
+        AC_MSG_ERROR(Unknown argument '$enable_compile_warnings' to --enable-compile-warnings)
+        ;;
+    esac
+
+    if test "$enable_compile_warnings" = "error" ; then
+        warning_flags="$warning_flags -Werror"
+    fi
+
+    dnl Check whether GCC supports the warning options
+    for option in $warning_flags; do
+	save_CFLAGS="$CFLAGS"
+	CFLAGS="$CFLAGS $option"
+	AC_MSG_CHECKING([whether gcc understands $option])
+	AC_TRY_COMPILE([], [],
+	    has_option=yes,
+	    has_option=no,)
+	CFLAGS="$save_CFLAGS"
+	AC_MSG_RESULT([$has_option])
+	if test $has_option = yes; then
+	    tested_warning_flags="$tested_warning_flags $option"
+	fi
+	unset has_option
+	unset save_CFLAGS
+    done
+    unset option
+    CFLAGS="$realsave_CFLAGS"
+    AC_MSG_CHECKING(what warning flags to pass to the C compiler)
+    AC_MSG_RESULT($tested_warning_flags)
+
+    AC_ARG_ENABLE(iso-c,
+                  AS_HELP_STRING([--enable-iso-c],
+                                 [Try to warn if code is not ISO C ]),,
+                  [enable_iso_c=no])
+
+    AC_MSG_CHECKING(what language compliance flags to pass to the C compiler)
+    complCFLAGS=
+    if test "x$enable_iso_c" != "xno"; then
+	if test "x$GCC" = "xyes"; then
+	case " $CFLAGS " in
+	    *[\ \	]-ansi[\ \	]*) ;;
+	    *) complCFLAGS="$complCFLAGS -ansi" ;;
+	esac
+	case " $CFLAGS " in
+	    *[\ \	]-pedantic[\ \	]*) ;;
+	    *) complCFLAGS="$complCFLAGS -pedantic" ;;
+	esac
+	fi
+    fi
+    AC_MSG_RESULT($complCFLAGS)
+
+    WARN_CFLAGS="$tested_warning_flags $complCFLAGS"
+    AC_SUBST(WARN_CFLAGS)
+],
+[[$0: This macro is deprecated. You should use AX_COMPILER_FLAGS instead and
+eliminate use of --enable-iso-c.
+See: http://www.gnu.org/software/autoconf-archive/ax_compiler_flags.html#ax_compiler_flags]])
+
+dnl For C++, do basically the same thing.
+
+AU_DEFUN([GNOME_CXX_WARNINGS],[
+  AC_ARG_ENABLE(cxx-warnings,
+                AS_HELP_STRING([--enable-cxx-warnings=@<:@no/minimum/yes@:>@]
+                               [Turn on compiler warnings.]),,
+                [enable_cxx_warnings="m4_default([$1],[minimum])"])
+
+  AC_MSG_CHECKING(what warning flags to pass to the C++ compiler)
+  warnCXXFLAGS=
+  if test "x$GXX" != xyes; then
+    enable_cxx_warnings=no
+  fi
+  if test "x$enable_cxx_warnings" != "xno"; then
+    if test "x$GXX" = "xyes"; then
+      case " $CXXFLAGS " in
+      *[\ \	]-Wall[\ \	]*) ;;
+      *) warnCXXFLAGS="-Wall -Wno-unused" ;;
+      esac
+
+      ## -W is not all that useful.  And it cannot be controlled
+      ## with individual -Wno-xxx flags, unlike -Wall
+      if test "x$enable_cxx_warnings" = "xyes"; then
+	warnCXXFLAGS="$warnCXXFLAGS -Wshadow -Woverloaded-virtual"
+      fi
+    fi
+  fi
+  AC_MSG_RESULT($warnCXXFLAGS)
+
+   AC_ARG_ENABLE(iso-cxx,
+                 AS_HELP_STRING([--enable-iso-cxx],
+                                [Try to warn if code is not ISO C++ ]),,
+                 [enable_iso_cxx=no])
+
+   AC_MSG_CHECKING(what language compliance flags to pass to the C++ compiler)
+   complCXXFLAGS=
+   if test "x$enable_iso_cxx" != "xno"; then
+     if test "x$GXX" = "xyes"; then
+      case " $CXXFLAGS " in
+      *[\ \	]-ansi[\ \	]*) ;;
+      *) complCXXFLAGS="$complCXXFLAGS -ansi" ;;
+      esac
+
+      case " $CXXFLAGS " in
+      *[\ \	]-pedantic[\ \	]*) ;;
+      *) complCXXFLAGS="$complCXXFLAGS -pedantic" ;;
+      esac
+     fi
+   fi
+  AC_MSG_RESULT($complCXXFLAGS)
+
+  WARN_CXXFLAGS="$CXXFLAGS $warnCXXFLAGS $complCXXFLAGS"
+  AC_SUBST(WARN_CXXFLAGS)
+],
+[[$0: This macro is deprecated. You should use AX_COMPILER_FLAGS instead and
+eliminate use of --enable-iso-cxx.
+See: http://www.gnu.org/software/autoconf-archive/ax_compiler_flags.html#ax_compiler_flags]])


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: arm, WRT3200ACM, 18.06-09d63fb0a6
Run tested: N/A - It does not touch actual code; changes are all confined to the `configure` script.

Description:
Compilation is currently failing:
```
checking for XML::Parser... configure: error: XML::Parser perl module is required for intltool
```
This is only the first one.  After cherry-picking a87108f from #7642 to avoid that dependency, it fails because of overly-strict `-Werror=` flags: 
```
In file included from /home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/include/libxml2/libxml/tree.h:15:0,
                 from /home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/include/libxml2/libxml/parser.h:16,
                 from grl-jamendo.c:32:
/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.3.0_musl_eabi/include/fortify/stdio.h: In function 'snprintf':
/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.3.0_musl_eabi/include/fortify/stdio.h:99:2: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
  return __orig_snprintf(__s, __n, __f, __builtin_va_arg_pack());
  ^~~~~~
/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.3.0_musl_eabi/include/fortify/stdio.h: In function 'sprintf':
/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.3.0_musl_eabi/include/fortify/stdio.h:108:3: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
   __r = __orig_snprintf(__s, __b, __f, __builtin_va_arg_pack());
   ^~~
/home/equeiroz/src/openwrt/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.3.0_musl_eabi/include/fortify/stdio.h:112:3: error: format not a string literal, argument types not checked [-Werror=format-nonliteral]
   __r = __orig_sprintf(__s, __f, __builtin_va_arg_pack());
   ^~~
cc1: some warnings being treated as errors
make[6]: *** [Makefile:626: libgrljamendo_la-grl-jamendo.lo] Error 1
```
So, I've adjusted the `CONFIGURE_ARGS` to not treat that warning as an error.
Then it would try to run `glib-compile-resources` built for the target:
```
  GEN      raitvresources.h
/bin/sh: /home/equeiroz/src/openwrt/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/bin/glib-compile-resources: cannot execute binary file: Exec format error
make[6]: *** [Makefile:932: raitvresources.h] Error 126
```
So, finally, I cherry-picked 8e0b797 from #7614 to use the host version.

Even though this PR does not change any code, `PKG_FIXUP:=autoreconf` by itself sometimes changes the binary; since we don't have a "base" package with which to compare, I've incremented `PKG_RELEASE` in the commit that added that line to be safe.

_Edited to include the original PRs to the cherry-pick commit references._