### PR TITLE
nut: Sync with 19.07 to unbreak NUT

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -15,8 +15,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/
 PKG_HASH:=980e82918c52d364605c0703a5dcf01f74ad2ef06e3d365949e43b7d406d25a7
 PKG_MAINTAINER:=Daniel Dickinson <cshored@thecshore.com>
-PKG_LICENSE:=GPL-2.0
-PKG_LICENSE_FILES:=LICENSE-GPL2
+PKG_LICENSE:=GPL-2.0+ GPL-3.0+ GPL-1.0+ Artistic-1.0-Perl
+PKG_LICENSE_FILES:=LICENSE-GPL2 LICENSE-GPL3 COPYING
 PKG_FIXUP:=autoreconf
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
@@ -73,12 +73,23 @@ define Package/nut-server/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/nut/cmdvartab $(1)/usr/share/nut/
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nut_server $(1)/etc/config/nut_server
-	ln -sf /var/etc/nut/upsd.users  $(1)/etc/nut/upsd.users
-	ln -sf /var/etc/nut/upsd.conf $(1)/etc/nut/upsd.conf
+	ln -sf ../../var/etc/nut/upsd.users  $(1)/etc/nut/upsd.users
+	ln -sf ../../var/etc/nut/upsd.conf $(1)/etc/nut/upsd.conf
 	# Driver common portion
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/upsdrvctl $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/share/nut/driver.list $(1)/usr/share/nut/
-	ln -sf /var/etc/nut/ups.conf $(1)/etc/nut/ups.conf
+	ln -sf ../../var/etc/nut/ups.conf $(1)/etc/nut/ups.conf
+	# Mangle libhid.usermap into a format (hotplug shell script) useful for OpenWrt
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/usb
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/tty
+	$(INSTALL_BIN) ./files/30-libhid-ups.head $(1)/etc/hotplug.d/usb/30-libhid-ups
+	$(CP) $(PKG_INSTALL_DIR)/etc/hotplug/usb/libhid.usermap $(PKG_BUILD_DIR)/30-libhid-ups.middle
+	$(SED) '/^$$$$/d' \
+		-e '/^#/d' \
+		-E -e 's:^[^ ][^ ]*  *0x0003  *0x0{0,3}([^ ][^ ]*)  *0x0{0,3}*([^ ][^ ]*).*:\1/\2/* | \\:' \
+		$(PKG_BUILD_DIR)/30-libhid-ups.middle
+	tail -n+2 $(PKG_BUILD_DIR)/30-libhid-ups.middle >>$(1)/etc/hotplug.d/usb/30-libhid-ups
+	cat ./files/30-libhid-ups.tail >>$(1)/etc/hotplug.d/usb/30-libhid-ups
 endef
 
 define Package/nut-common
@@ -87,8 +98,7 @@ define Package/nut-common
 	DEPENDS:= nut \
 		+NUT_DRIVER_SNMP:libnetsnmp \
 		+NUT_DRIVER_USB:libusb-compat \
-		+NUT_SSL:libopenssl \
-		+PACKAGE_libwrap:libwrap
+		+NUT_SSL:libopenssl
 endef
 
 define Package/nut-common/description
@@ -134,7 +144,7 @@ define Package/nut-upsmon
   $(call Package/nut/Default)
 	TITLE+= (monitor)
 	DEPENDS:=nut +nut-common
-	USERID:=nut=113:nut=113
+	USERID:=nutmon=114:nutmon=114
 endef
 
 define Package/nut-upsmon/description
@@ -192,7 +202,7 @@ define Package/nut-upsc/description
 $(call Package/nut/description/Default)
 upsc is provided as a quick way to poll the status of a UPS server. It
 can be used inside shell scripts and other programs that need UPS data
-but don not want to include the full interface.
+but do not want to include the full interface.
 endef
 
 define Package/nut-upsc/install
@@ -318,12 +328,15 @@ define Package/nut-web-cgi/install
 	$(INSTALL_CONF) ./files/add_nut_httpd_conf $(1)/etc/uci-defaults/add_nut_httpd_conf
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/upsstats.html.sample $(1)/etc/nut/upsstats.html
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/upsstats-single.html.sample $(1)/etc/nut/upsstats-single.html
-	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/upsset.conf.sample $(1)/etc/nut/upsset.conf
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/upsset.conf.sample $(1)/etc/nut/upsset.conf.disable
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/nut/upsset.conf.sample $(1)/etc/nut/upsset.conf.enable
+	$(SED) 's/### \?//' $(1)/etc/nut/upsset.conf.enable
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nut_cgi $(1)/etc/config/nut_cgi
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/nut-cgi.init $(1)/etc/init.d/nut-cgi
 	ln -sf /var/etc/nut/hosts.conf $(1)/etc/nut/hosts.conf
+	ln -sf /var/etc/nut/upsset.conf $(1)/etc/nut/upsset.conf
 endef
 
 define Package/nut-avahi-service
@@ -362,10 +375,10 @@ define DriverPackage
 	# new version of nut we will need to provide descriptions for any new
 	# drivers.
         define Package/nut-driver-$(2)/description
-		
+
         endef
         define Package/nut-driver-$(2)/install
-        	$(INSTALL_DIR) $$(1)/lib/nut
+		$(INSTALL_DIR) $$(1)/lib/nut
 		$(CP) $$(PKG_INSTALL_DIR)/lib/nut/$(2) $$(1)/lib/nut/
 		$(if $(filter $(2),clone),$(CP) $$(PKG_INSTALL_DIR)/lib/nut/$(2)-outlet $$(1)/lib/nut/)
         endef
@@ -512,9 +525,11 @@ CONFIGURE_ARGS += \
 	--without-avahi \
 	--$(if $(CONFIG_NUT_DRIVER_SNMP),with,without)-snmp \
 	--$(if $(CONFIG_NUT_DRIVER_SERIAL),with,without)-serial \
+	--without-doc \
 	--without-neon \
 	--without-powerman \
 	--without-wrap \
+	--with-hotplug-dir=/etc/hotplug \
 	--with-cgi \
 	--without-ipmi \
 	--without-freeipmi \

--- a/net/nut/files/30-libhid-ups.head
+++ b/net/nut/files/30-libhid-ups.head
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+nut_driver_config() {
+	local cfg="$1"
+	local nomatch="$2"
+
+	config_get runas "$cfg" runas "nut"
+	config_get vendorid "$cfg" vendorid
+	config_get productid "$cfg" productid
+
+	[ "$ACTION" = "add" ] && [ -n "$DEVNAME" ] && {
+		chmod 0660 /dev/"$DEVNAME"
+		chown "${runas:-root}":"$(id -gn "${runas:-root}")" /dev/"$DEVNAME"
+	}
+
+	if [ "$nomatch" = "1" ]; then
+		[ "$ACTION" = "add" ] && {
+			/etc/init.d/nut-server start "$cfg"
+		}
+	elif [ "$(printf "%04x" 0x"$pvendid")" = "$vendorid" ] && \
+		[ "$(printf "%04x" 0x"$pprodid")" = "$productid" ]; then
+			[ "$ACTION" = "add" ] && {
+				/etc/init.d/nut-server start "$cfg"
+			}
+			[ "$ACTION" = "remove" ] && {
+				/etc/init.d/nut-server stop "$cfg"
+			}
+			found=1
+	fi
+}
+
+perform_libhid_action() {
+	. /lib/functions.sh
+
+	local vendorid productid runas
+	local pvendid pprodid found
+
+	pvendid=${PRODUCT%/*}
+	pvendid=${pvendid%/*}
+	pprodid=${PRODUCT%/*}
+	pprodid=${pprodid##*/}
+
+	config_load nut_server
+	config_foreach nut_driver_config driver 0
+	[ "$found" != "1" ] && config_foreach nut_driver_config driver 1
+	/etc/init.d/nut-server start upsd
+}
+
+[ -n "$PRODUCT" ] && case "$PRODUCT" in

--- a/net/nut/files/30-libhid-ups.tail
+++ b/net/nut/files/30-libhid-ups.tail
@@ -1,0 +1,5 @@
+"")
+	[ -f /var/run/nut/disable-hotplug ] || \
+		/etc/init.d/nut-server enabled && perform_libhid_action
+	;;
+esac

--- a/net/nut/files/nut-cgi.init
+++ b/net/nut/files/nut-cgi.init
@@ -4,10 +4,26 @@
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
-START=51
+START=87
+STOP=23
+USE_PROCD=1
 
 DEFAULT=/etc/default/nut
 UPSCGI_C=/var/etc/nut/hosts.conf
+UPSCGI_S=/var/etc/nut/upsset.conf
+
+nut_upscgi_upsset() {
+	local cfg="$1"
+	local enable
+
+	config_get_bool enable "$cfg" enable 0
+
+	if [ "$enable" -eq 1 ]; then
+		ln -sf /etc/nut/upsset.conf.enable "$UPSCGI_S"
+	else
+		ln -sf /etc/nut/upsset.conf.disable "$UPSCGI_S"
+	fi
+}
 
 nut_upscgi_add() {
 	local cfg="$1"
@@ -28,17 +44,33 @@ nut_upscgi_add() {
 	echo "MONITOR $system \"$displayname\"" >> "$UPSCGI_C"
 }
 
-start() {
-	rm -f $UPSCGI_C
+service_reload() {
+	mkdir -m 0755 -p "$(dirname "$UPSCGI_C")"
+	rm -f "$UPSCGI_C"
+	rm -f "$UPSCGI_S"
 
 	config_load nut_cgi
 
 	config_foreach nut_upscgi_add host
+	config_foreach nut_upscgi_upsset upsset
 
-	chmod 640 /var/etc/nut/hosts.conf
+	[ -s "$UPSCGI_C" ] && chmod 640 "$UPSCGI_C"
 }
 
-stop() {
-	rm -f $UPSCGI_C
+start_service() {
+	service_reload
 }
 
+reload_service() {
+	service_reload
+}
+
+stop_service() {
+	rm -f "$UPSCGI_C"
+	rm -f "$UPSCGI_S"
+	ln -sf /etc/nut/upsset.conf.disable "$UPSCGI_S"
+}
+
+service_triggers() {
+	procd_add_reload_trigger "nut_cgi"
+}

--- a/net/nut/files/nut-monitor.init
+++ b/net/nut/files/nut-monitor.init
@@ -1,16 +1,19 @@
 #!/bin/sh /etc/rc.common
 
-START=51
+START=82
+STOP=28
 USE_PROCD=1
 UPSMON_C=/var/etc/nut/upsmon.conf
 
 nut_upsmon_conf() {
 	local cfg="$1"
+	local RUNAS val optval
 
 	echo "# Config file automatically generated from UCI config" > "$UPSMON_C"
 
-	config_get runas "$cfg" runas
-	[ -n "$runas" ] && echo "RUN_AS_USER $runas" >> $UPSMON_C
+	config_get RUNAS "$cfg" runas "nutmon"
+	[ -n "$RUNAS" ] && echo "RUN_AS_USER $RUNAS" >> "$UPSMON_C"
+	runas="$RUNAS"
 
 	config_get val "$cfg" minsupplies 1
 	echo "MINSUPPLIES $val" >> "$UPSMON_C"
@@ -84,16 +87,18 @@ nut_upsmon_conf() {
 	val=""
 	config_list_foreach "$cfg" defaultnotify notifylist
 	default="$optval"
-	echo "NOTIFYFLAG ONLINE $(setnotify "$cfg" onlinenotify)" >> "$UPSMON_C"
-	echo "NOTIFYFLAG ONBATT $(setnotify "$cfg" onbattnotify)" >> "$UPSMON_C"
-	echo "NOTIFYFLAG LOWBATT $(setnotify "$cfg" lowbatnotify)" >> "$UPSMON_C"
-	echo "NOTIFYFLAG FSD $(setnotify "$cfg" fsdnotify)" >> "$UPSMON_C"
-	echo "NOTIFYFLAG COMMOK $(setnotify "$cfg" commoknotify)" >> "$UPSMON_C"
-	echo "NOTIFYFLAG COMMBAD $(setnotify "$cfg" commbadnotify)" >> "$UPSMON_C"
-	echo "NOTIFYFLAG SHUTDOWN $(setnotify "$cfg" shutdownnotify)" >> "$UPSMON_C"
-	echo "NOTIFYFLAG REPLBATT $(setnotify "$cfg" repolbattnotify)" >> "$UPSMON_C"
-	echo "NOTIFYFLAG NOCOMM $(setnotify "$cfg" nocommnotify)" >> "$UPSMON_C"
-	echo "NOTIFYFLAG NOPARENT $(setnotify "$cfg" noparentnotify)" >> "$UPSMON_C"
+	{
+		echo "NOTIFYFLAG ONLINE $(setnotify "$cfg" onlinenotify)" ; \
+		echo "NOTIFYFLAG ONBATT $(setnotify "$cfg" onbattnotify)" ; \
+		echo "NOTIFYFLAG LOWBATT $(setnotify "$cfg" lowbatnotify)" ; \
+		echo "NOTIFYFLAG FSD $(setnotify "$cfg" fsdnotify)" ; \
+		echo "NOTIFYFLAG COMMOK $(setnotify "$cfg" commoknotify)" ; \
+		echo "NOTIFYFLAG COMMBAD $(setnotify "$cfg" commbadnotify)" ; \
+		echo "NOTIFYFLAG SHUTDOWN $(setnotify "$cfg" shutdownnotify)" ; \
+		echo "NOTIFYFLAG REPLBATT $(setnotify "$cfg" repolbattnotify)" ; \
+		echo "NOTIFYFLAG NOCOMM $(setnotify "$cfg" nocommnotify)" ; \
+		echo "NOTIFYFLAG NOPARENT $(setnotify "$cfg" noparentnotify)" ; \
+	} >> "$UPSMON_C"
 
 	config_get val "$cfg" rbwarntime 43200
 	echo "RBWARNTIME $val" >> "$UPSMON_C"
@@ -143,7 +148,6 @@ nut_upsmon_add() {
 }
 
 build_config() {
-	local runas
 	mkdir -m 0750 -p "$(dirname "$UPSMON_C")"
 
 	config_load nut_monitor
@@ -151,42 +155,77 @@ build_config() {
 	config_foreach nut_upsmon_add master master
 	config_foreach nut_upsmon_add slave slave
 
-	[ ! -s "$(cat /var/etc/nut/nut.conf)" ] && {
+	[ ! -s /var/etc/nut/nut.conf ] && {
 		echo "MODE=netclient" >>/var/etc/nut/nut.conf
 		chmod 640 /var/etc/nut/nut.conf
-		chgrp $(id -gn ${runas:-root}) /var/etc/nut/nut.conf
+		chgrp "$(id -gn "${runas:-nutmon}")" /var/etc/nut/nut.conf
 	}
 
 	[ -s "$UPSMON_C" ] && chmod 640 "$UPSMON_C"
-	[ -s "$UPSMON_C" ] && chgrp $(id -gn ${runas:-root}) "$UPSMON_C"
+	[ -s "$UPSMON_C" ] && chgrp "$(id -gn "${runas:-nutmon}")" "$UPSMON_C"
+}
+
+interface_triggers() {
+	local action="$1"
+	local triggerlist trigger
+
+	config_get triggerlist "upsmon" triggerlist
+
+	. "${IPKG_INSTROOT}"/lib/functions/network.sh
+
+	if [ -n "$triggerlist" ]; then
+		for trigger in $triggerlist; do
+			if [ "$action" = "add_trigger" ]; then
+				procd_add_interface_trigger "interface.*" "$trigger" /etc/init.d/nut-monitor restart
+			else
+				network_is_up "$trigger" && return 0
+			fi
+		done
+	else
+		if [ "$action" = "add_trigger" ]; then
+			procd_add_raw_trigger "interface.*.up" 2000 /etc/init.d/nut-monitor restart
+		else
+			ubus call network.device status | grep -q '"up": true' && return 0
+		fi
+	fi
+	[ "$action" = "add_trigger" ] || return 1
 }
 
 start_service() {
+	local runas=nutmon
 	local havemon havems
 	build_config
 
-	[ "$havemon" != 1 ] && return
-	[ "$havems" != 1 ] && return
+	[ "$havemon" != 1 ] && return 1
+	[ "$havems" != 1 ] && return 1
+	interface_triggers "check_interface_up" || return 0
 
 	procd_open_instance "upsmon"
-	procd_set_param respawn
-	procd_set_param stderr 0
-	procd_set_param stdout 1
+	procd_set_param respawn 10 20 6
+	procd_set_param stderr 1
+	procd_set_param stdout 0
 	procd_set_param command /usr/sbin/upsmon -D
 	procd_close_instance
+
+	return 0
 }
 
 reload_service() {
 	if pgrep upsmon >/dev/null 2>/dev/null; then
+		local runas=nutmon
 		build_config
 		/usr/sbin/upsmon -c reload
 	else
-		stop
-		sleep 2
-		start_service
+		restart
 	fi
 }
 
+stop_service() {
+	upsmon -c stop
+}
+
 service_triggers() {
+	config_load nut_monitor
+	interface_triggers "add_trigger"
 	procd_add_reload_trigger "nut_monitor"
 }

--- a/net/nut/files/nut-sendmail-notify
+++ b/net/nut/files/nut-sendmail-notify
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-/usr/sbin/sendmail root <<EOF
+{
+exec /usr/sbin/sendmail root <<EOF
 From: root
 To: root
 Subject: UPS $NOTIFYTYPE Notification
@@ -8,3 +9,4 @@ Subject: UPS $NOTIFYTYPE Notification
 $1
 .
 EOF
+} &

--- a/net/nut/files/nut-sendmail-notify.default
+++ b/net/nut/files/nut-sendmail-notify.default
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. /lib/functions.sh
+. "${IPKG_INSTROOT}"/lib/functions.sh
 
 REMOVEDEFAULTNOTIFY=0
 SKIPADDSYSLOG=0

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -4,7 +4,8 @@
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
-START=50
+START=70
+STOP=30
 
 USERS_C=/var/etc/nut/upsd.users
 UPSD_C=/var/etc/nut/upsd.conf
@@ -31,20 +32,18 @@ get_write_driver_config() {
 }
 
 upsd_statepath() {
-	local cfg="$1"
 	local statepath
 
-	config_get statepath "$cfg" statepath "/var/run/nut"
+	config_get statepath upsd statepath /var/run/nut
 	STATEPATH="$statepath"
 }
 
 upsd_runas() {
-	local cfg="$1"
 	local runas
 
-	[ -n "$RUNAS" ] && return
+	[ -n "$RUNAS" ] && return 0
 
-	config_get runas "$cfg" runas
+	config_get runas upsd runas nut
 	RUNAS="$runas"
 }
 
@@ -62,10 +61,10 @@ upsd_config() {
 
     # Note runas support requires you make sure USB device file is readable by
     # the runas user
-    config_get runas "$cfg" runas
+    config_get runas "$cfg" runas nut
     RUNAS="$runas"
 
-    config_get statepath "$cfg" statepath "/var/run/nut"
+    config_get statepath "$cfg" statepath /var/run/nut
     STATEPATH="$statepath"
 
     config_get maxage "$cfg" maxage
@@ -111,7 +110,8 @@ nut_user_add() {
 }
 
 build_server_config() {
-        mkdir -m 0755 -p "$(dirname "$UPSD_C")"
+        mkdir -p "$(dirname "$UPSD_C")"
+	chmod 0640 "$UPS_C"
 	rm -f "$USERS_C"
 	rm -f "$UPSD_C"
 	rm -f /var/etc/nut/nut.conf
@@ -129,13 +129,14 @@ build_server_config() {
 	chmod 0644 /var/etc/nut/nut.conf
 
 	[ -d "${STATEPATH}" ] || {
-		mkdir -m 0750 -p "${STATEPATH}"
+		mkdir -p "${STATEPATH}"
+		chmod 0750 "${STATEPATH}"
 	}
 
 	if [ -n "$RUNAS" ]; then
-		chown $RUNAS:$(id -gn $RUNAS) "${STATEPATH}"
-		chgrp $(id -gn $RUNAS) "$USERS_C"
-		chgrp $(id -gn $RUNAS) "$UPSD_C"
+		chown "$RUNAS":"$(id -gn "$RUNAS")" "${STATEPATH}"
+		chgrp "$(id -gn "$RUNAS")" "$USERS_C"
+		chgrp "$(id -gn "$RUNAS")" "$UPSD_C"
 	fi
 	haveserver=1
 }
@@ -145,42 +146,41 @@ build_driver_config() {
 
 	echo "[$cfg]" >>"$UPS_C"
 
-	get_write_driver_config "$cfg" driver "usbhid-ups"
-	get_write_driver_config "$cfg" port "auto"
-	get_write_driver_config "$cfg" sdorder
-	get_write_driver_config "$cfg" desc
-	get_write_driver_config "$cfg" nolock 0 1
-	get_write_driver_config "$cfg" ignorelb 0 1
-	get_write_driver_config "$cfg" mfr
-	get_write_driver_config "$cfg" model
-	get_write_driver_config "$cfg" serial
-	get_write_driver_config "$cfg" sdtime
-	get_write_driver_config "$cfg" offdelay
-	get_write_driver_config "$cfg" ondelay
-	get_write_driver_config "$cfg" pollfreq
-	get_write_driver_config "$cfg" vendor
-	get_write_driver_config "$cfg" product
 	get_write_driver_config "$cfg" bus
+	get_write_driver_config "$cfg" community
+	get_write_driver_config "$cfg" desc
+	get_write_driver_config "$cfg" driver "usbhid-ups"
+	get_write_driver_config "$cfg" ignorelb 0 1
 	get_write_driver_config "$cfg" interruptonly 0 1
 	get_write_driver_config "$cfg" interruptsize
 	get_write_driver_config "$cfg" maxreport
-	get_write_driver_config "$cfg" vendorid
+	get_write_driver_config "$cfg" maxstartdelay
+	get_write_driver_config "$cfg" mfr
+	get_write_driver_config "$cfg" model
+	get_write_driver_config "$cfg" nolock 0 1
+	get_write_driver_config "$cfg" notransferoids 0 1
+	get_write_driver_config "$cfg" offdelay
+	get_write_driver_config "$cfg" ondelay
+	get_write_driver_config "$cfg" pollfreq
+	get_write_driver_config "$cfg" port "auto"
+	get_write_driver_config "$cfg" product
 	get_write_driver_config "$cfg" productid
-	get_write_driver_config "$cfg" community
+	get_write_driver_config "$cfg" retrydelay
+	get_write_driver_config "$cfg" sdorder
+	get_write_driver_config "$cfg" sdtime
+	get_write_driver_config "$cfg" serial
 	get_write_driver_config "$cfg" snmp_version
 	get_write_driver_config "$cfg" snmp_retries
 	get_write_driver_config "$cfg" snmp_timeout
-	get_write_driver_config "$cfg" notransferoids 0 1
-	get_write_driver_config "$cfg" maxstartdelay
-	get_write_driver_config "$cfg" retrydelay
 	get_write_driver_config "$cfg" synchronous
-	get_write_driver_config "$cfg" other
-	get_write_driver_config "$cfg" otherflag
+	get_write_driver_config "$cfg" vendor
+	get_write_driver_config "$cfg" vendorid
 
 	defoverride() {
 		local overvar="$1"
 		local defover="$2"
 		local overtype="$(echo "$overvar" | tr '.' '_')"
+		local overval
 
 		config_get overval "${defover}_${overtype}" value
 		[ -n "$overval" ] && echo "${defover}.${overvar} = $overval" >>"$UPS_C"
@@ -192,20 +192,19 @@ build_driver_config() {
 	other() {
 		local othervar="$1"
 		local othervarflag="$2"
+		local otherval
 
 		if [ "$othervarflag" = "otherflag" ]; then
-			config_get_bool otherval "${othervarflag}_${overtype}" value
-			[ "$otherval" = "1" ] && echo "${othervarflag}_${othervar}" >>"$UPS_C"
+			config_get_bool otherval "${othervarflag}_${othervar}" value
+			[ "$otherval" = "1" ] && echo "${othervar}" >>"$UPS_C"
 		else
-			config_get otherval "${othervarflag}_${overtype}" value
-			[ -n "$otherval" ] && echo "${othervarflag}_${othervar} = $otherval" >>"$UPS_C"
+			config_get otherval "${othervarflag}_${othervar}" value
+			[ -n "$otherval" ] && echo "${othervar} = $otherval" >>"$UPS_C"
 		fi
 	}
 
-	config_list_foreach "$cfg" override defoverride override
-	config_list_foreach "$cfg" default defoverride default
-	config_list_foreach "$cfg" default other other
-	config_list_foreach "$cfg" default other otherflag
+	config_list_foreach "$cfg" other other
+	config_list_foreach "$cfg" other otherflag
 	echo "" >>$UPS_C
 	havedriver=1
 }
@@ -221,29 +220,28 @@ build_global_driver_config() {
 	get_write_driver_config "$cfg" retrydelay
 	get_write_driver_config "$cfg" pollinterval
 	get_write_driver_config "$cfg" synchronous
-	config_get runas "$cfg" user
+	config_get runas "$cfg" user nut
 	RUNAS="$runas"
-	upsd_runas
 
-	echo "" >>$UPS_C
+	echo "" >>"$UPS_C"
 }
 
 build_config() {
 	local STATEPATH=/var/run/nut
 
-        mkdir -m 0755 -p "$(dirname "$UPS_C")"
+        mkdir -p "$(dirname "$UPS_C")"
 	rm -f "$UPS_C"
 	echo "# Config file automatically generated from UCI config" > "$UPS_C"
 	chmod 0640 "$UPS_C"
 
 	config_load nut_server
-	config_foreach upsd_statepath upsd
 
+	upsd_runas
 	config_foreach build_global_driver_config driver_global
 	config_foreach build_driver_config driver
-	[ -n "$RUNAS" ] && chgrp $(id -gn $RUNAS) "$UPS_C"
-
+	upsd_statepath
 	build_server_config
+	[ -n "$RUNAS" ] && chgrp "$(id -gn "$RUNAS")" "$UPS_C"
 }
 
 start_driver_instance() {
@@ -251,27 +249,31 @@ start_driver_instance() {
 	local requested="$2"
 	local driver
 	local STATEPATH=/var/run/nut
-	local RUNAS
+	local RUNAS=nut
 
 	[ "$havedriver" != 1 ] && return
 
 	# If wanting a specific instance, only start it
-	[ "$requested" != "$cfg" ] && [ x"$requested" != x ] && return 0
+	if [ "$requested" != "$cfg" ] && [ "$request" != "" ]; then
+		return 0
+	fi
 
-	mkdir -m 0755 -p "$(dirname "$UPS_C")"
+	mkdir -p "$(dirname "$UPS_C")"
+	chmod 0755 "$UPS_C"
 
-	[ ! -s "$UPS_C" ] && build_config
+	upsd_statepath
+	build_config
 
 	# Avoid hotplug inadvertenly restarting driver during
 	# forced shutdown
 	[ -f /var/run/killpower ] && return 0
-	[ -d /var/run/nut ] && [ -f /var/run/nut/disable-hotplug ] && return 0
-
-
-	config_foreach upsd_statepath upsd
+	if [ -d /var/run/nut ] && [ -f /var/run/nut/disable-hotplug ]; then
+	       return 0
+	fi
 
 	if [ -n "$RUNAS" ]; then
-		chown $RUNAS:$(id -gn $RUNAS) "${STATEPATH}"
+		chown "$RUNAS":"$(id -gn "$RUNAS")" "${STATEPATH}"
+		chgrp "$(id -gn "$RUNAS")" "$UPS_C"
 	fi
 
 	config_get driver "$cfg" driver "usbhid-ups"
@@ -279,49 +281,83 @@ start_driver_instance() {
 	procd_set_param respawn
 	procd_set_param stderr 0
 	procd_set_param stdout 1
-	procd_set_param command /lib/nut/${driver} -D -a "$cfg" ${RUNAS:+-u $RUNAS}
+	procd_set_param command /lib/nut/"${driver}" -D -a "$cfg" ${RUNAS:+-u "$RUNAS"}
 	procd_close_instance
 }
 
+interface_triggers() {
+	local action="$1"
+	local triggerlist trigger
+
+	config_get triggerlist upsd triggerlist
+
+	. /lib/functions/network.sh
+
+	if [ -n "$triggerlist" ]; then
+		for trigger in $triggerlist; do
+			if [ "$action" = "add_trigger" ]; then
+				procd_add_interface_trigger "interface.*" "$trigger" /etc/init.d/nut-server reload
+			else
+				network_is_up "$trigger" && return 0
+			fi
+		done
+	else
+		if [ "$action" = "add_trigger" ]; then
+			procd_add_raw_trigger "interface.*.up" 2000 /etc/init.d/nut-server reload
+		else
+			ubus call network.device status | grep -q '"up": true' && return 0
+		fi
+	fi
+	[ "$action" = "add_trigger" ] || return 1
+}
+
 start_server_instance() {
-	local RUNAS
-	build_config
+	local cfg="$1"
 
 	[ "$haveserver" != 1 ] && return
+	interface_triggers "check_interface_up" || return
 
-	procd_open_instance "upsd"
+	procd_open_instance "$cfg"
 	procd_set_param respawn
 	procd_set_param stderr 0
 	procd_set_param stdout 1
-	procd_set_param command /usr/sbin/upsd -D ${RUNAS:+-u $RUNAS}
+	procd_set_param command /usr/sbin/upsd -D ${RUNAS:+-u "$RUNAS"}
 	procd_close_instance
 }
 
 start_service() {
-	local havedriver haveserver
 	local STATEPATH=/var/run/nut
-	local RUNAS
 
 	# Avoid hotplug inadvertenly restarting driver during
 	# forced shutdown
 	[ -f /var/run/killpower ] && return 0
-	[ -f /var/run/nut/disable-hotplug ] && return 0
 
 	config_load nut_server
-
 	build_config
-	config_foreach start_driver_instance driver "$@"
 
-	start_server_instance "upsd"
+	case $@ in
+	"")
+		config_foreach start_driver_instance driver "$@"
+		start_server_instance upsd
+		;;
+	*upsd*)
+		start_server_instance upsd
+		;;
+	*)
+		config_foreach start_driver_instance driver "$@"
+		;;
+	esac
 }
 
 reload_service() {
-	stop
+	stop_service "$@"
 	sleep 2
-	local havedriver haveserver
-	start
+	start_service "$@"
 }
 
 service_triggers() {
+	config_load nut_server
+
+	interface_triggers "add_trigger"
 	procd_add_reload_trigger "nut_server"
 }

--- a/net/nut/files/nut_cgi
+++ b/net/nut/files/nut_cgi
@@ -4,3 +4,5 @@
 #	option port # optional port number
 #	option displayname "Display Name"
 
+config upsset
+	option enable 0

--- a/net/nut/files/nut_monitor
+++ b/net/nut/files/nut_monitor
@@ -1,5 +1,5 @@
 #config upsmon 'upsmon'
-#	option runas run-as-user
+#	option runas nutmon
 #	option minsupplies 1
 #	option shutdowncmd '/usr/sbin/nutshutdown'
 #	option notifycmd /path/to/cmd

--- a/net/nut/files/nut_server
+++ b/net/nut/files/nut_server
@@ -1,8 +1,9 @@
+#config driver_global 'driver_global'
+#	option user nut
+
 #config driver 'upsname'
 #	option driver usbhid-ups
 #	option port auto
-#	option other other-value
-#	option runas root
 
 #config user
 #	option username upsuser

--- a/net/nut/files/nutshutdown
+++ b/net/nut/files/nutshutdown
@@ -4,11 +4,6 @@
 # See /LICENSE for more information.
 #
 
-. /lib/functions.sh
-
-mount -o remount,ro /overlay /overlay
-mount -o remount,ro / /
-
 stop_instance() {
 	/etc/init.d/nut-server stop "$1"
 }
@@ -16,26 +11,41 @@ stop_instance() {
 shutdown_instance() {
 	local cfg="$1"
 	config_get driver "$cfg" driver "usbhid-ups"
-	/lib/nut/${driver} -a "$cfg" -k
+
+	# Only FSD if killpower was indicated
+	if [ -f /var/run/killpower ]; then
+		/lib/nut/"${driver}" -a "$cfg" -k
+	fi
 }
 
-[ -f /var/run/killpower ] && {
-	[ -f /etc/config/nut_server ] && {
-		config_load nut_server
+do_fsd() {
+	if [ -f /var/run/killpower ]; then
+		# Only make FS readonly if we are doing an FSD
+		mount -o remount,ro /overlay /overlay
+		mount -o remount,ro / /
 
-		# Can't FSD unless drivers are stopped
-		config_foreach stop_instance driver
-		# Driver will  wait 'offdelay' before shutting down
-		config_foreach shutdown_instance driver
-		# So this can happen
+		. ${IPKG_INSTOOT}/lib/functions.sh
+
+		if [ -f /etc/config/nut_server ]; then
+			config_load nut_server
+
+			# Can't FSD unless drivers are stopped
+			config_foreach stop_instance driver
+			# Driver will  wait 'offdelay' before shutting down
+			config_foreach shutdown_instance driver
+			# So this can happen
+			rm -f /var/run/killpower
+			poweroff
+			# And just in case
+			sleep 120
+			# Uh-oh failed to poweroff UPS
+			reboot -f
+		else
+			poweroff
+		fi
+	else
 		poweroff
-		# And just in case
-		sleep 120
-		# Uh-oh failed to poweroff UPS
-		reboot -f
-	} || {
-		poweroff
-	}
-} || {
-	poweroff
+	fi
 }
+
+do_fsd


### PR DESCRIPTION
This commit grabs a copy of NUT as it exists in 19.07 & master, except for
the change to enabling serial port drivers by default (and related support).

This finally fixes nut on 18.06 (19.07/master is already working well for me,
and, now that I know about it, via testing in a VM with the dummy UPS driver).

I had though these changes had been backported already but unfortunately folks
are still seeing the broken version.  I apologize for the weak showing for 18.06
on the nut front; life was strange, but is better now and I'm more able to focus
on getting things like this right.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: me
Compile tested: ar71xx, CR5000, current openwrt-18.06 branch
Run tested: ar71xx, CR500, current openwrt-18.06 branch

Testing in progress -- wanted to query if this is possible for a backport.
