### PR TITLE
madplay: Pass CFLAGS properly

### DIFF
--- a/sound/madplay/Makefile
+++ b/sound/madplay/Makefile
@@ -9,19 +9,20 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=madplay
 PKG_VERSION:=0.15.2b
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/mad \
 	ftp://ftp.mars.org/pub/mpeg/
 PKG_HASH:=5a79c7516ff7560dffc6a14399a389432bc619c905b13d3b73da22fa65acede0
-PKG_LICENSE:=GPL-2.0+
-PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Simon Peter <probono@puredarwin.org>
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_MAINTAINER:=Simon Peter <probono@puredarwin.org>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -45,40 +46,39 @@ define Package/madplay/description
 	full support for ID3 tags.
 endef
 
-define Build/Configure
-	$(call Build/Configure/Default, \
-		--enable-shared \
-		--disable-static \
-		--disable-debugging \
-		--disable-profiling \
-		--disable-experimental \
-		--without-libiconv-prefix \
-		--without-libintl-prefix \
-		--without-esd \
-		, \
-		LIBS="-lz" \
-	)
-endef
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--disable-static \
+	--disable-debugging \
+	--disable-profiling \
+	--disable-experimental \
+	--without-libiconv-prefix \
+	--without-libintl-prefix \
+	--without-esd \
+
+CONFIGURE_VARS += \
+	lt_prog_compiler_pic=$(FPIC)
+
+MAKE_FLAGS += CFLAGS="$(TARGET_CFLAGS)"
 
 ifeq ($(BUILD_VARIANT),alsa)
 	CONFIGURE_ARGS += \
 		--without-oss \
 		--with-alsa
-endif
-
-ifeq ($(BUILD_VARIANT),oss)
+else
 	CONFIGURE_ARGS += \
-		--without-alsa
+		--without-alsa \
+		--with-oss
 endif
 
 define Package/madplay/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/madplay $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/madplay $(1)/usr/bin/
 endef
 
 define Package/madplay-alsa/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/madplay $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/madplay $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,madplay-alsa))


### PR DESCRIPTION
CFLAGS were not being passed which was breaking ASLR builds.

Fixed license header.

Added PKG_BUILD_PARALLEL for faster compilation.

Added PKG_INSTALL for consistency.

Passed proper $(FPIC) value.

Several other Makefile cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @probonopd 
Compile tested: mvebu
