### PR TITLE
atftp: Update to 0.7.2

### DIFF
--- a/net/atftp/Makefile
+++ b/net/atftp/Makefile
@@ -7,14 +7,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=atftp
-PKG_VERSION:=0.7.1
-PKG_RELEASE:=5
-PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
-PKG_LICENSE:=GPL-2.0
+PKG_VERSION:=0.7.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
-PKG_HASH:=ae4c6f09cadb8d2150c3ce32d88f19036a54e8211f22d723e97864bb5e18f92d
+PKG_HASH:=1ad080674e9f974217b3a703e7356c6c8446dc5e7b2014d0d06e1bfaa11b5041
+
+PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -38,17 +43,18 @@ define Package/atftpd
 endef
 
 CONFIGURE_ARGS += \
+	--disable-debug \
 	--disable-libwrap
 
 define Package/atftp/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/atftp $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/atftp $(1)/usr/bin/
 endef
 
 define Package/atftpd/install
 	$(INSTALL_DIR) $(1)/etc
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/atftpd $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)//usr/sbin/atftpd $(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,atftp))


### PR DESCRIPTION
Fixes issue where CFLAGS were not being passed. This was breaking ASLR
builds.

Added PKG_BUILD_PARALLEL for faster compilation.

Added PKG_INSTALL. Changed install paths based on PKG_INSTALL paths.

Added --disable-debug to make sure debug code is disabled.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dddaniel
Compile tested: mvebu