### PR TITLE
django2: add django version 2 and packages needed by etesync [RFC]

### DIFF
--- a/lang/python/django2-cors-headers/Makefile
+++ b/lang/python/django2-cors-headers/Makefile
@@ -1,0 +1,34 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django2-cors-headers
+PKG_VERSION:=3.1.0
+PKG_RELEASE:=1
+PKG_LICENSE:=MIT
+PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
+
+PKG_SOURCE:=django-cors-headers-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/django-cors-headers/
+PKG_HASH:=e69b1c909f2eddc7ef2a24f071583bc22b73b871731ea3370ac52b3318c43b3c
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/django2-cors-headers-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/django2-cors-headers
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS).
+  URL:=https://github.com/ottoyiu/django-cors-headers
+  DEPENDS:=+django2
+  VARIANT:=python3
+endef
+
+define Package/django2-cors-headers/description
+  Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS).
+endef
+
+$(eval $(call Py3Package,django2-cors-headers))
+$(eval $(call BuildPackage,django2-cors-headers))

--- a/lang/python/django2/Makefile
+++ b/lang/python/django2/Makefile
@@ -30,12 +30,5 @@ define Package/django2/description
   The web framework for perfectionists with deadlines.
 endef
 
-define Py3Package/xxx/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/django-admin.py $(1)/usr/bin/
-	# fix python exec path
-	sed -i 's_#!.*_#!/usr/bin/python3_g' $(1)/usr/bin/django-admin.py
-endef
-
 $(eval $(call Py3Package,django2))
 $(eval $(call BuildPackage,django2))

--- a/lang/python/django2/Makefile
+++ b/lang/python/django2/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django2
-PKG_VERSION:=2.2.4
+PKG_VERSION:=2.2.5
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD-3-Clause
 PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
 
 PKG_SOURCE:=Django-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/D/Django/
-PKG_HASH:=16a5d54411599780ac9dfe3b9b38f90f785c51259a584e0b24b6f14a7f69aae8
+PKG_HASH:=deb70aa038e59b58593673b15e9a711d1e5ccd941b5973b30750d5d026abfd56
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/django2-$(PKG_VERSION)
 PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
@@ -22,7 +22,7 @@ define Package/django2
   CATEGORY:=Languages
   TITLE:=The web framework for perfectionists with deadlines.
   URL:=https://www.djangoproject.com/
-  DEPENDS:=+python3-base +python3-distutils +python3-urllib +python3-pytz +python3-logging +python3-cgi +python3-decimal +python3-codecs +sqlparse +python3-sqlite3 +python3-unittest +python3-xml +python3-openssl
+  DEPENDS:=+python3-base +python3-distutils +python3-urllib +python3-pytz +python3-logging +python3-cgi +python3-decimal +python3-codecs +python3-sqlparse +python3-sqlite3 +python3-unittest +python3-xml +python3-openssl
   VARIANT:=python3
 endef 
 

--- a/lang/python/django2/Makefile
+++ b/lang/python/django2/Makefile
@@ -1,0 +1,41 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django2
+PKG_VERSION:=2.2.4
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD-3-Clause
+PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
+
+PKG_SOURCE:=Django-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/D/Django/
+PKG_HASH:=16a5d54411599780ac9dfe3b9b38f90f785c51259a584e0b24b6f14a7f69aae8
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/django2-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/django2
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=The web framework for perfectionists with deadlines.
+  URL:=https://www.djangoproject.com/
+  DEPENDS:=+python3-base +python3-distutils +python3-urllib +python3-pytz +python3-logging +python3-cgi +python3-decimal +python3-codecs +sqlparse +python3-sqlite3 +python3-unittest +python3-xml +python3-openssl
+  VARIANT:=python3
+endef 
+
+define Package/django2/description
+  The web framework for perfectionists with deadlines.
+endef
+
+define Py3Package/xxx/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/django-admin.py $(1)/usr/bin/
+	# fix python exec path
+	sed -i 's_#!.*_#!/usr/bin/python3_g' $(1)/usr/bin/django-admin.py
+endef
+
+$(eval $(call Py3Package,django2))
+$(eval $(call BuildPackage,django2))

--- a/lang/python/django2restframework/Makefile
+++ b/lang/python/django2restframework/Makefile
@@ -1,0 +1,34 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django2restframework
+PKG_VERSION:=3.10.2
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD-3-Clause
+PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
+
+PKG_SOURCE:=djangorestframework-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/djangorestframework/
+PKG_HASH:=aedb48010ebfab9651aaab1df5fd3b4848eb4182afc909852a2110c24f89a359
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/django2restframework-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/django2restframework
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Web APIs for Django, made easy.
+  URL:=https://www.django-rest-framework.org/
+  DEPENDS:=+django2
+  VARIANT:=python3
+endef
+
+define Package/django2restframework/description
+  Web APIs for Django, made easy.
+endef
+
+$(eval $(call Py3Package,django2restframework))
+$(eval $(call BuildPackage,django2restframework))

--- a/lang/python/drf-nested-routers/Makefile
+++ b/lang/python/drf-nested-routers/Makefile
@@ -1,0 +1,34 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=drf-nested-routers
+PKG_VERSION:=0.91
+PKG_RELEASE:=1
+PKG_LICENSE:=Apache
+PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
+
+PKG_SOURCE:=drf-nested-routers-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/drf-nested-routers/
+PKG_BUILD_DIR:=$(BUILD_DIR)/drf-nested-routers-$(PKG_VERSION)
+PKG_HASH:=46e5c3abc15c782cafafd7d75028e8f9121bbc6228e3599bbb48a3daa4585034
+
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/drf-nested-routers
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Nested resources for the Django Rest Framework
+  URL:=https://github.com/alanjds/drf-nested-routers
+  DEPENDS:=+django2
+  VARIANT:=python3
+endef
+
+define Package/drf-nested-routers/description
+  Nested resources for the Django Rest Framework
+endef
+
+$(eval $(call Py3Package,drf-nested-routers))
+$(eval $(call BuildPackage,drf-nested-routers))

--- a/lang/python/python3-sqlparse/Makefile
+++ b/lang/python/python3-sqlparse/Makefile
@@ -1,6 +1,6 @@
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=sqlparse
+PKG_NAME:=python3-sqlparse
 PKG_VERSION:=0.3.0
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD
@@ -16,7 +16,7 @@ PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/sqlparse
+define Package/python3-sqlparse
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
@@ -26,9 +26,9 @@ define Package/sqlparse
   VARIANT:=python3
 endef
 
-define Package/sqlparse/description
+define Package/python3-sqlparse/description
   A non-validating SQL parser module. It provides support for parsing, splitting and formatting SQL statements.
 endef
 
-$(eval $(call Py3Package,sqlparse))
-$(eval $(call BuildPackage,sqlparse))
+$(eval $(call Py3Package,python3-sqlparse))
+$(eval $(call BuildPackage,python3-sqlparse))

--- a/lang/python/sqlparse/Makefile
+++ b/lang/python/sqlparse/Makefile
@@ -1,0 +1,34 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=sqlparse
+PKG_VERSION:=0.3.0
+PKG_RELEASE:=1
+PKG_LICENSE:=BSD
+PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
+
+PKG_SOURCE:=sqlparse-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/s/sqlparse
+PKG_HASH:=7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/sqlparse-$(BUILD_VARIANT)-$(PKG_VERSION)
+PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/sqlparse
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Non-validating SQL parser module.
+  URL:=https://github.com/andialbrecht/sqlparse
+  DEPENDS:=python3-base 
+  VARIANT:=python3
+endef
+
+define Package/sqlparse/description
+  A non-validating SQL parser module. It provides support for parsing, splitting and formatting SQL statements.
+endef
+
+$(eval $(call Py3Package,sqlparse))
+$(eval $(call BuildPackage,sqlparse))


### PR DESCRIPTION
Maintainer: Peter Stadler <peter.stadler@student.uibk.ac.at>
Compile tested: MIPS 74K, Asus RT-N16, master snapshot
Run tested: MIPS 74K, Asus RT-N16, master snapshot, open http://ro.ut.er.ip:8001/ in browser while running:
```
python3 /usr/bin/django-admin.pyc startproject mysite && \
cd mysite && \
echo 'STATIC_ROOT = os.path.join(BASE_DIR, "static/")' \
    >> mysite/settings.py && \
sed -i "s/ALLOWED_HOSTS = \[.*\]/ALLOWED_HOSTS = \[\"$(uci get network.lan.ipaddr)\"\]/" \
    mysite/settings.py && \
python3 ./manage.py collectstatic && \
python3 ./manage.py runserver 0.0.0.0:8001 && \
cd .. && rm -r mysite
```


Description: 
The following five packages will allow to run etesync as django app:
1. sqlparse: is a dependency for django2
2. django2: is version 2.x of django for python3 and can superseed python3-django (version 1.x) if its other dependent packages are ported to use it, too.
3. django2-cors-headers: is a dependency for django2-etesync-journal
4. django2restframework: is a dependency for django2-etesync-journal
5. drf-nested-routers: is a dependency for django2-etesync-journal

Se my other [PR for etesync-server](https://github.com/openwrt/packages/pull/9865) that contains django2-etesync-journal and a configuration for running it with uwsgi on nginx (etesync-uwsgi).
