### PR TITLE
cgi-io: require whitelisting upload locations

### DIFF
--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_LICENSE:=GPL-2.0+
 


### PR DESCRIPTION
Maintainer: @blogic 
Compile tested: OpenWrt ramips/mt7621 SDK dated 2019-08-29
Run tested: Xiaomi Mi Router 3G, snapshot build r10831-164037983d

Description:

Introduce further ACL checks to verify that the request-supplied
upload location may be written to. This prevents overwriting things
like /bin/busybox and allows to confine uploads to specific directories.

To setup the required ACLs, the following ubus command may be used
on the command line:

ubus call session grant '{
  "ubus_rpc_session": "d41d8cd98f00b204e9800998ecf8427e",
  "scope": "cgi-io",
  "objects": [
    [ "/etc/certificates/*", "write" ],
    [ "/var/uploads/*", "write" ]
  ]
}'

Signed-off-by: Jo-Philipp Wich <jo@mein.io>
