### PR TITLE
measurement-kit: Fix compilation with uClibc-ng

### DIFF
--- a/libs/measurement-kit/Makefile
+++ b/libs/measurement-kit/Makefile
@@ -9,20 +9,19 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=measurement-kit
 PKG_VERSION:=0.10.5
-PKG_RELEASE=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/measurement-kit/measurement-kit/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=8b83f04f4d3c653f93bcee5a6cc5e32e6595a3feb99526017d78099fd90d4a75
 
-PKG_INSTALL:=1
-PKG_FIXUP:=autoreconf
-PKG_BUILD_PARALLEL:=1
-
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/libs/measurement-kit/patches/010-nextafter.patch
+++ b/libs/measurement-kit/patches/010-nextafter.patch
@@ -1,0 +1,14 @@
+--- a/include/private/catch.hpp
++++ b/include/private/catch.hpp
+@@ -11095,7 +11095,11 @@ bool almostEqualUlps(FP lhs, FP rhs, int maxUlpDiff) {
+ template <typename FP>
+ FP step(FP start, FP direction, int steps) {
+     for (int i = 0; i < steps; ++i) {
++#ifndef __UCLIBC__
+         start = std::nextafter(start, direction);
++#else
++        start = ::nextafterf(start, direction);
++#endif
+     }
+     return start;
+ }


### PR DESCRIPTION
nextafter is not included in std with uClibc-ng. Don't use the std version

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ja-pa 
Compile tested: arc700

Closes: #9825
