### PR TITLE
exfat-nofuse: drop BUILD_PATENTED

### DIFF
--- a/kernel/exfat-nofuse/Makefile
+++ b/kernel/exfat-nofuse/Makefile
@@ -29,7 +29,7 @@ define KernelPackage/fs-exfat
 	TITLE:=ExFAT Kernel driver
 	FILES:=$(PKG_BUILD_DIR)/exfat.ko
 	AUTOLOAD:=$(call AutoLoad,30,exfat,1)
-	DEPENDS:=+kmod-nls-base @BUILD_PATENTED
+	DEPENDS:=+kmod-nls-base
 endef
 
 define KernelPackage/fs-exfat/description


### PR DESCRIPTION
Maintainer: @yousong

Description:
Microsoft has published technical specification for exFAT [1]
and the driver has been added to Linux staging tree [2].

It's now safe to drop BUILD_PATENTED label.

[1] https://docs.microsoft.com/windows/win32/fileio/exfat-specification
[2] http://lkml.iu.edu/hypermail/linux/kernel/1908.3/04254.html