### PR TITLE
opennhrp: remove dependency on ipsec-tools

### DIFF
--- a/net/opennhrp/Makefile
+++ b/net/opennhrp/Makefile
@@ -29,7 +29,7 @@ define Package/opennhrp
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=VPN
-  DEPENDS:=+libcares +ipsec-tools +ip +kmod-gre
+  DEPENDS:=+libcares +ip +kmod-gre
   KCONFIG:=CONFIG_ARPD=y
   TITLE:=NBMA Next Hop Resolution Protocol
   URL:=http://opennhrp.sourceforge.net/


### PR DESCRIPTION
ipsec-tools package was dropped, remove it
from the list of dependencies of this package

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.com>

Maintainer: @DerArtem 