### PR TITLE
samba4: remove double quotes for renice

### DIFF
--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -211,9 +211,9 @@ start_service() {
 	fi
 	# lower priority using renice (if found)
 	if [ -x /usr/bin/renice ]; then
-		[ -x /usr/sbin/samba ] && renice -n 2 "$(pidof samba)"
-		[ -x /usr/sbin/smbd ] && renice -n 2 "$(pidof smbd)"
-		[ -x /usr/sbin/nmbd ] && renice -n 2 "$(pidof nmbd)"
-		[ -x /usr/sbin/winbindd ] && renice -n 2 "$(pidof winbindd)"
+		[ -x /usr/sbin/samba ] && renice -n 2 $(pidof samba)
+		[ -x /usr/sbin/smbd ] && renice -n 2 $(pidof smbd)
+		[ -x /usr/sbin/nmbd ] && renice -n 2 $(pidof nmbd)
+		[ -x /usr/sbin/winbindd ] && renice -n 2 $(pidof winbindd)
 	fi
 }


### PR DESCRIPTION
The shell does not expand the list of PIDs if the list is quoted, and treats it as a single string, therefore, renice will fail. If the list is not quoted, the shell will expand the list as single arguments for renice and will work. Currently, the renice command is not effective if there is more than one process running in the system.