### PR TITLE
Voluptuous & Voluptuous Serialize: update to their latest versions

### DIFF
--- a/lang/python/python-voluptuous-serialize/Makefile
+++ b/lang/python/python-voluptuous-serialize/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=voluptuous-serialize
-PKG_VERSION:=2.1.0
-PKG_RELEASE:=2
+PKG_VERSION:=2.2.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/v/voluptuous-serialize/
-PKG_HASH:=d30fef4f1aba251414ec0b315df81a06da7bf35201dcfb1f6db5253d738a154f
+PKG_HASH:=8b31660c7efdba0eb97ba65390b63cc62cc99ae3cd25d00e1873b183b38ef13d
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=Apache-2.0

--- a/lang/python/python-voluptuous/Makefile
+++ b/lang/python/python-voluptuous/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-voluptuous
-PKG_VERSION:=0.11.5
+PKG_VERSION:=0.11.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=voluptuous-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/v/voluptuous/
-PKG_HASH:=567a56286ef82a9d7ae0628c5842f65f516abcb496e74f3f59f1d7b28df314ef
+PKG_HASH:=2abc341dbc740c5e2302c7f9b8e2e243194fb4772585b991931cb5b22e9bf456
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-voluptuous-$(PKG_VERSION)
 
@@ -66,4 +66,3 @@ $(eval $(call BuildPackage,python-voluptuous-src))
 $(eval $(call Py3Package,python3-voluptuous))
 $(eval $(call BuildPackage,python3-voluptuous))
 $(eval $(call BuildPackage,python3-voluptuous-src))
-


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- Voluptuous
Update to version [0.11.7](https://github.com/alecthomas/voluptuous/blob/master/CHANGELOG.md).
- Voluptuous Serialize
Update to version 2.2.0 - Just one change in this release and its:
`Convert Email, Url, and FqdnUrl to corresponding lowercase format`