### PR TITLE
python-slugify: Update to version 3.0.3

### DIFF
--- a/lang/python/python-slugify/Makefile
+++ b/lang/python/python-slugify/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-slugify
-PKG_VERSION:=3.0.2
+PKG_VERSION:=3.0.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/python-slugify/
-PKG_HASH:=57163ffb345c7e26063435a27add1feae67fa821f1ef4b2f292c25847575d758
+PKG_HASH:=a9f468227cb11e20e251670d78e1b5f6b0b15dd37bbd5c9814a25a904e44ff66
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=MIT
@@ -28,16 +28,16 @@ define Package/python3-slugify
   SUBMENU:=Python
   TITLE:=Slugify application that handles Unicode
   URL:=https://github.com/un33k/python-slugify
-  DEPENDS+= \
-      +python3-light \
-      +python3-codecs \
-      +python3-setuptools \
-      +python3-text-unidecode
+  DEPENDS:= \
+    +python3-light \
+    +python3-codecs \
+    +python3-setuptools \
+    +python3-text-unidecode
   VARIANT:=python3
 endef
 
 define Package/python3-slugify/description
-A Python slugify application that handles unicode.
+  A Python slugify application that handles unicode.
 endef
 
 $(eval $(call Py3Package,python3-slugify))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- Update to version [3.0.3](https://github.com/un33k/python-slugify/blob/master/CHANGELOG.md).