### PR TITLE
ap51-flash: upgrade package to latest release 2019.0

### DIFF
--- a/utils/ap51-flash/Makefile
+++ b/utils/ap51-flash/Makefile
@@ -7,15 +7,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ap51-flash
-PKG_VERSION:=2018.0
+PKG_VERSION:=2019.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/ap51-flash/ap51-flash/releases/download/v$(PKG_VERSION)
-PKG_HASH:=e38e48a12d7c7b8e189f5538b78bbf00548044414d9ededa18ec9a5b5886afaa
+PKG_HASH:=e7992b2151721cc6f5db91f443ad7fc83cb5604c08cd11fca3e78ecd6b538e57
 PKG_MAINTAINER:=Russell Senior <russell@personaltelco.net>
-PKG_LICENSE:=GPL-3.0+
-PKG_LICENSE_FILES:=LICENSES/preferred/GPL-3.0
+PKG_LICENSE:=GPL-3.0+ CC0-1.0
+PKG_LICENSE_FILES:=LICENSES/GPL-3.0-or-later.txt LICENSES/CC0-1.0.txt
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Maintainer: @RussellSenior
Compile tested: ath79, x86
Run tested: x86, master

Description:

* improved Zyxel firmware detection
* introduced optional MAC address filtering
* added support for:
  - Plasma Cloud PA300
  - Plasma Cloud PA1200
  - Plasma Cloud PA2200
