### PR TITLE
[OpenWrt 18.06] bind: update to version 9.11.10

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.11.9
+PKG_VERSION:=9.11.10
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -20,7 +20,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=963bf048354795b85b8f3dbe3ff5ba524d3f5b14b86a4cc733fcf971b43ac50e
+PKG_HASH:=b2bb840cda20e6771ae8c054007b4ec12e1bb6aa6bfe79102890eb94956a70c3
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06.04
Run tested: libs, dig, server, client.

Description:

- Update to version 9.11.10
Release notes:
```
5275.	[bug]		Mark DS records included in referral messages
			with trust level "pending" so that they can be
			validated and cached immediately, with no need to
			re-query. [GL #964]

5273.	[bug]		Check that bits [64..71] of a dns64 prefix are zero.
			[GL #1159]

5269.	[port]		cygwin: can return ETIMEDOUT on connect() with a
			non-blocking socket. [GL #1133]

5268.	[bug]		named could crash during configuration if
			configured to use "geoip continent" ACLs with
			legacy GeoIP. [GL #1163]

5266.	[bug]		named-checkconf failed to report dnstap-output
			missing from named.conf when dnstap was specified.
			[GL #1136]

5265.	[bug]		DNS64 and RPZ nodata (CNAME *.) rules interacted badly
			[GL #1106]

5264.	[func]		New DNS Cookie algorithm - siphash24 - has been added to
			BIND 9. [GL #605]
```