### PR TITLE
[OpenWrt 18.06] keepalived: Update to version 1.4.5

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
-PKG_VERSION:=1.4.4
+PKG_VERSION:=1.4.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.keepalived.org/software
-PKG_HASH:=147c2b3b782223128551fd0a1564eaa30ed84a94b68c50ec5087747941314704
+PKG_SOURCE_URL:=https://www.keepalived.org/software
+PKG_HASH:=c7be18f6f90c8da6cc18cd8a90971b7a7da3823df091fcc7500d130fdb010c4d
 
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
@@ -29,7 +29,7 @@ define Package/keepalived
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Failover and monitoring daemon for LVS clusters
-  URL:=http://www.keepalived.org/
+  URL:=https://www.keepalived.org/
   DEPENDS:= \
     +PACKAGE_libnl-genl:libnl-genl \
     +libopenssl \

--- a/net/keepalived/patches/010-Fix-buffer-overflow-in-extract_status_code.patch
+++ b/net/keepalived/patches/010-Fix-buffer-overflow-in-extract_status_code.patch
@@ -1,0 +1,57 @@
+From f28015671a4b04785859d1b4b1327b367b6a10e9 Mon Sep 17 00:00:00 2001
+From: Quentin Armitage <quentin@armitage.org.uk>
+Date: Tue, 24 Jul 2018 09:28:43 +0100
+Subject: [PATCH] Fix buffer overflow in extract_status_code()
+
+Issue #960 identified that the buffer allocated for copying the
+HTTP status code could overflow if the http response was corrupted.
+
+This commit changes the way the status code is read, avoids copying
+data, and also ensures that the status code is three digits long,
+is non-negative and occurs on the first line of the response.
+
+Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>
+---
+ lib/html.c | 23 +++++++++--------------
+ 1 file changed, 9 insertions(+), 14 deletions(-)
+
+diff --git a/lib/html.c b/lib/html.c
+index 5a3eaeac..69d3bd2d 100644
+--- a/lib/html.c
++++ b/lib/html.c
+@@ -58,23 +58,18 @@ size_t extract_content_length(char *buffer, size_t size)
+  */
+ int extract_status_code(char *buffer, size_t size)
+ {
+-	char *buf_code;
+-	char *begin;
+ 	char *end = buffer + size;
+-	size_t inc = 0;
+-	int code;
+-
+-	/* Allocate the room */
+-	buf_code = (char *)MALLOC(10);
++	unsigned long code;
+ 
+ 	/* Status-Code extraction */
+-	while (buffer < end && *buffer++ != ' ') ;
+-	begin = buffer;
+-	while (buffer < end && *buffer++ != ' ')
+-		inc++;
+-	strncat(buf_code, begin, inc);
+-	code = atoi(buf_code);
+-	FREE(buf_code);
++	while (buffer < end && *buffer != ' ' && *buffer != '\r')
++		buffer++;
++	buffer++;
++	if (buffer + 3 >= end || *buffer == ' ' || buffer[3] != ' ')
++		return 0;
++	code = strtoul(buffer, &end, 10);
++	if (buffer + 3 != end)
++		return 0;
+ 	return code;
+ }
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
Maintainers: @scrpi, @feckert 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06.04
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06.04

Description:
- This one is follow up of #9794 which was made by my colleague. 
The first commit updates it to version 1.4.5. While I was at it, I changed URLs to use HTTPS.
```
Changelog: 
* Update snapcraft.yaml for 1.4.x+git
* Fix generation of git-commit.h with git commit number.
* Set virtual server address family correctly.
* Set virtual server address family correctly when using tunnelled
  real servers.
* Fix handling of virtual servers with no real servers at config time.
* Add warning if virtual and real servers are different address families.
  Although normally the virtual server and real servers must have the
  same address family, if a real server is tunnelled, the address families
  can be different. However, the kernel didn't support that until 3.18,
  so add a check that the address families are the same if different
  address families are not supported by the kernel.
* Send correct status in Dbus VrrpStatusChange notification.
  When an instance transitioned from BACKUP to FAULT, the Dbus
  status change message reported the old status (BACKUP) rather than
  the new status (FAULT). This commit attempts to resolved that.
```

- Most important is the second commit.
It backports commit from keepalived repository, which fixes [CVE-2018-19115](https://nvd.nist.gov/vuln/detail/CVE-2018-19115). This patch can be found in Linux distributions like Ubuntu and also Debian.