### PR TITLE
python-sentry-sdk: Update to version 0.11.2

### DIFF
--- a/lang/python/python-sentry-sdk/Makefile
+++ b/lang/python/python-sentry-sdk/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-sentry-sdk
-PKG_VERSION:=0.11.1
+PKG_VERSION:=0.11.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=sentry-sdk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/s/sentry-sdk/
-PKG_HASH:=79e8352b5097aa06014871c6daad0933f59d1fcccc586339464ea86e4877b2ab
+PKG_HASH:=b4edcb1296fee107439345d0f8b23432b8732b7e28407f928367d0a4a36301a9
 PKG_BUILD_DIR:=$(BUILD_DIR)/sentry-sdk-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- Update to version [0.11.2](https://github.com/getsentry/sentry-python/releases/tag/0.11.2).