### PR TITLE
bind: Update to version 9.14.5

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.14.5
+PKG_VERSION:=9.14.6
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=12d0672cb83d985b57038ce7eb8a71c6bc7ebd379d67109c5f966f7527988045
+PKG_HASH:=8967a040ed900e1800293b9874357fc2f267f33c723aa617268e163bd921edfe
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,19 +9,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.14.4
+PKG_VERSION:=9.14.5
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
-PKG_LICENSE := MPL-2.0
+PKG_LICENSE:=MPL-2.0
+PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:isc:bind
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=312efb82a6889074f31ef2849af498b3ec97ca69acd5c4e5e4b4045a8fe6b83f
+PKG_HASH:=12d0672cb83d985b57038ce7eb8a71c6bc7ebd379d67109c5f966f7527988045
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: @nmeyerhans
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Tests: libs, dig, server, client

Description:
- Update to version 9.14.5
```
Changelog:

5277.	[bug]		Cache DB statistics could underflow when serve-stale
			was in use, because of a bug in counter maintenance
			when RRsets become stale.

			Functions for dumping statistics have been updated
			to dump active, stale, and ancient statistic
			counters.  Ancient RRset counters are prefixed
			with '~'; stale RRset counters are still prefixed
			with '#'. [GL #602]

5275.	[bug]		Mark DS records included in referral messages
			with trust level "pending" so that they can be
			validated and cached immediately, with no need to
			re-query. [GL #964]

5274.	[bug]		Address potential use after free race when shutting
			down rpz. [GL #1175]

5273.	[bug]		Check that bits [64..71] of a dns64 prefix are zero.
			[GL #1159]

5269.	[port]		cygwin: can return ETIMEDOUT on connect() with a
			non-blocking socket. [GL #1133]

5268.	[bug]		named could crash during configuration if
			configured to use "geoip continent" ACLs with
			legacy GeoIP. [GL #1163]

5266.	[bug]		named-checkconf failed to report dnstap-output
			missing from named.conf when dnstap was specified.
			[GL #1136]

5265.	[bug]		DNS64 and RPZ nodata (CNAME *.) rules interacted badly
			[GL #1106]

5264.	[func]		New DNS Cookie algorithm - siphash24 - has been added
			to BIND 9. [GL #605]

5236.	[func]		Add SipHash 2-4 implementation in lib/isc/siphash.c
			and switch isc_hash_function() to use SipHash 2-4.
			[GL #605]
```
- Add PKG_LICENSE_FILES
