### PR TITLE
forked-daapd: update to 26.5

### DIFF
--- a/sound/forked-daapd/Makefile
+++ b/sound/forked-daapd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=forked-daapd
-PKG_VERSION:=26.4
+PKG_VERSION:=26.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ejurgensen/$(PKG_NAME)/releases/download/$(PKG_VERSION)/
-PKG_HASH:=c37012faf56238544fc7274ad0ade7bf16c15a9ae6af9ef4ba56ba88e508fffa
+PKG_HASH:=6d12e5c1c078ff406413a08a65327c3b23d80605a997d3b219322a5c6a05923c
 
 PKG_FIXUP:=autoreconf
 PKG_USE_MIPS16:=0


### PR DESCRIPTION
Signed-off-by: Espen Jürgensen <espenjurgensen+openwrt@gmail.com>

Maintainer: me
Compile tested: yes (AR7xxx, trunk)
Run tested: no

Description:
Update to 26.5