### PR TITLE
samba4: update to version 4.9.13 (security fix)

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,8 +2,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.9.11
-PKG_RELEASE:=3
+PKG_VERSION:=4.9.13
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.heanet.ie/mirrors/ftp.samba.org/stable/ \
@@ -12,7 +12,7 @@ PKG_SOURCE_URL:=https://ftp.heanet.ie/mirrors/ftp.samba.org/stable/ \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=bb736624d16f7369e395de2f15fec153b554f76f95864015b4ce1f2ae53e817b
+PKG_HASH:=ab18331e37766b13dbb07d1f115bda3d794917baf502d0ca2b2b8fff014b88f2
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -211,9 +211,9 @@ start_service() {
 	fi
 	# lower priority using renice (if found)
 	if [ -x /usr/bin/renice ]; then
-		[ -x /usr/sbin/samba ] && renice -n 2 "$(pidof samba)"
-		[ -x /usr/sbin/smbd ] && renice -n 2 "$(pidof smbd)"
-		[ -x /usr/sbin/nmbd ] && renice -n 2 "$(pidof nmbd)"
-		[ -x /usr/sbin/winbindd ] && renice -n 2 "$(pidof winbindd)"
+		[ -x /usr/sbin/samba ] && renice -n 2 $(pidof samba)
+		[ -x /usr/sbin/smbd ] && renice -n 2 $(pidof smbd)
+		[ -x /usr/sbin/nmbd ] && renice -n 2 $(pidof nmbd)
+		[ -x /usr/sbin/winbindd ] && renice -n 2 $(pidof winbindd)
 	fi
 }


### PR DESCRIPTION

Maintainer: @Andy2244 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates samba4 to version 4.9.13 to fix CVE-2019-10197 https://www.samba.org/samba/security/CVE-2019-10197.html

Changelog for 4.9.13 https://www.samba.org/samba/history/samba-4.9.13.html

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>