### PR TITLE
adblock: update 3.8.5

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.8.4
+PKG_VERSION:=3.8.5
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -113,6 +113,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 * **runtime information:** the adblock status is available via _/etc/init.d/adblock status_ (see example below)
 * **debug logging:** for script debugging please set the config option 'adb\_debug' to '1' and check the runtime output with _logread -e "adblock"_
 * **storage expansion:** to process and store all blocklist sources at once it might be helpful to enlarge your temp directory with a swap partition => see [OpenWrt Wiki](https://openwrt.org/docs/guide-user/storage/fstab) for further details
+* **coreutils sort:** To speedup adblock processing in particular with many enabled blocklist sources it's recommended to install the additional package 'coreutils-sort'
 * **add white- / blacklist entries:** add domain black- or whitelist entries to always-deny or -allow certain (sub) domains, by default both lists are empty and located in _/etc/adblock_. Please add one domain per line - ip addresses, wildcards & regex are _not_ allowed (see example below). You need to refresh your blocklists after changes to these static lists.
 * **download queue size:** for further download & list processing performance improvements you can raise the 'adb\_maxqueue' value, e.g. '8' or '16' should be safe
 * **scheduled list updates:** for a scheduled call of the adblock service add an appropriate crontab entry (see example below)
@@ -146,6 +147,9 @@ A lot of people already use adblocker plugins within their desktop browsers, but
     * adb\_blacklist => full path to the static blacklist file (default: '/etc/adblock/adblock.blacklist')
     * adb\_whitelist => full path to the static whitelist file (default: '/etc/adblock/adblock.whitelist')
     * adb\_triggerdelay => additional trigger delay in seconds before adblock processing begins (int/default: '2')
+    * adb\_maxtld => disable the tld compression, if the number of blocked domains is greater than this value (int/default: '100000')
+    * adb\_portlist => space separated list of fw ports which should be redirected locally (default: '53 853 5353')
+    * adb\_dnsinotify => disable adblock triggered restarts and the 'DNS File Reset' for dns backends with autoload features (bool/default: 'false', disabled)
     * adb\_dnsflush => flush DNS cache after adblock processing, i.e. enable the old restart behavior (bool/default: '0', disabled)
     * adb\_repiface => reporting interface used by tcpdump, set to 'any' for multiple interfaces (default: 'br-lan')
     * adb\_replisten => space separated list of reporting port(s) used by tcpdump (default: '53')

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -23,7 +23,7 @@ boot()
 
 start_service()
 {
-	if [ $("${adb_init}" enabled; printf "%u" ${?}) -eq 0 ]
+	if [ "$("${adb_init}" enabled; printf "%u" ${?})" -eq 0 ]
 	then
 		if [ -n "${adb_boot}" ]
 		then
@@ -33,11 +33,11 @@ start_service()
 				return 0
 			fi
 		fi
-		local nice="$(uci_get adblock extra adb_nice)"
+		local nice="$(uci_get adblock extra adb_nice "0")"
 		procd_open_instance "adblock"
 		procd_set_param command "${adb_script}" "${@}"
 		procd_set_param pidfile "${adb_pidfile}"
-		procd_set_param nice ${nice:-0}
+		procd_set_param nice "${nice}"
 		procd_set_param stdout 1
 		procd_set_param stderr 1
 		procd_close_instance
@@ -85,9 +85,9 @@ report()
 
 status()
 {
-	local key keylist value rtfile="$(uci_get adblock extra adb_rtfile)"
+	local key keylist value 
+	local rtfile="$(uci_get adblock extra adb_rtfile "/tmp/adb_runtime.json")"
 
-	rtfile="${rtfile:-"/tmp/adb_runtime.json"}"
 	if [ -s "${rtfile}" ]
 	then
 		printf "%s\\n" "::: adblock runtime information"
@@ -106,13 +106,16 @@ status()
 
 service_triggers()
 {
-	local trigger="$(uci_get adblock global adb_trigger)"
-	local delay="$(uci_get adblock extra adb_triggerdelay)"
+	local trigger="$(uci_get adblock global adb_trigger)" 
+	local delay="$(uci_get adblock extra adb_triggerdelay "2")"
 
-	if [ "${trigger}" != "none" ] && [ "${trigger}" != "timed" ]
+	PROCD_RELOAD_DELAY=$((delay*1000))
+	if [ -n "${trigger}" ] && [ "${trigger}" != "none" ] && [ "${trigger}" != "timed" ]
 	then
-		PROCD_RELOAD_DELAY=$((${delay:-2} * 1000))
 		procd_add_interface_trigger "interface.*.up" "${trigger}" "${adb_init}" start
+	elif [ -z "${trigger}" ]
+	then
+		procd_add_raw_trigger "interface.*.up" ${PROCD_RELOAD_DELAY} "${adb_init}" start
 	fi
 	procd_add_reload_trigger "adblock"
 }

--- a/net/adblock/files/adblock.mail
+++ b/net/adblock/files/adblock.mail
@@ -1,5 +1,4 @@
 #!/bin/sh
-#
 # send mail script for adblock notifications
 # written by Dirk Brenken (dev@brenken.org)
 # Please note: you have to manually install and configure the package 'msmtp' before using this script


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: OpenWrt Master & Turris OS 4.0b9 with dnsmasq, unbound and kresd

Description:
* use raw procd interface trigger as last resort, if the
  adblock config is not available during startup
* fix selective subdomain whitelisting for dnsmasq
* fix a kresd restart issue with 'DNS File Reset'
* fix a suspend/resume cornercase
* disable the tld compression, if the number of blocked domains
  is greater than 'adb_maxtld' (default: 100000)
* made the fw portlist configurable (default '53 853 5353')
* preliminary support for inotify-like autoload features
  of dns backends like kresd in future Turris OS. If 'adb_dnsinotify'
  is set to 'true', all adblock related restarts and the
  'DNS File Reset' will be disabled

Signed-off-by: Dirk Brenken <dev@brenken.org>
