### PR TITLE
[19.07] glib2: don't use libelf during host build

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.58.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_BUILD_DIR:=$(BUILD_DIR)/glib-$(PKG_VERSION)
@@ -47,6 +47,7 @@ endef
 TARGET_CFLAGS += -Wno-error=implicit-function-declaration
 
 HOST_CONFIGURE_ARGS += \
+	--disable-libelf \
 	--disable-selinux \
 	--with-libiconv=gnu \
 	--with-pcre=internal \


### PR DESCRIPTION
Since commit 2e490e7e46a4f6fbf66fa930a25c2991e24c0f83 tools/libelf
installs a pkgconfig file, which in turn is picked up during the glib2
host build. On the build bots the same occurs, although it so happens
that (sometimes?) libelf.h is not found and the host build fails. This
may be a timing issue specific to the build bots, as the header is in
fact installed by tools/libelf and I can't reproduce this here on my own
computer.

In any case, libelf (if detected) is only used by gresource. gresource
can be used without it. gresource is not used by OpenWrt's build system
(also not in openwrt/packages). So adding "--disable-libelf" to the host
configure args is not detrimental in any way and works around the issue
described above.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @tripolar 
Compile tested: master
Run tested: N/A, only related to host build

Description:
Hi all,

As per comment from @neheb in PR #9936 the same change is needed for 19.07.

Regards,
Seb