### PR TITLE
libfolly: Update to 2019.09.02

### DIFF
--- a/libs/libfolly/Makefile
+++ b/libs/libfolly/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libfolly
-PKG_VERSION:=2019.06.10.00
-PKG_RELEASE:=2
+PKG_VERSION:=2019.09.09.00
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/facebook/folly/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=afecd68815a83865d95a3a6b861abe8096beefae45c89566e0d510279b631b57
+PKG_HASH:=1aac1bb5c2e22fea68780734069ee73188523c5ede8cd210e3fa81a1ae56bfe0
 PKG_BUILD_DIR:=$(BUILD_DIR)/folly-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Amol Bhave <ambhave@fb.com>
@@ -20,32 +20,38 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 define Package/libfolly
-	SECTION:=libs
-	CATEGORY:=Libraries
-	TITLE:=An open-source C++ library developed and used at Facebook.
-	URL:=https://github.com/facebook/folly
-	DEPENDS:=+boost +boost-context +boost-date_time +boost-filesystem +boost-program_options +boost-regex \
-		+libopenssl +libdouble-conversion +libevent2 +glog +libsodium +libaio +libatomic \
-		+libbz2 +zlib +libzstd +liblzma +liblz4 +PACKAGE_libunwind:libunwind
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=An open-source C++ library developed and used at Facebook.
+  URL:=https://github.com/facebook/folly
+  DEPENDS:=+boost +boost-context +boost-date_time +boost-filesystem +boost-program_options +boost-regex \
+	+libopenssl +libdouble-conversion +libevent2 +glog +libsodium +libaio +libatomic \
+	+libbz2 +zlib +libzstd +liblzma +liblz4 +PACKAGE_libunwind:libunwind
 endef
 
 define Package/libfolly/description
-	An open-source C++ library developed and used at Facebook.
-	Folly (acronymed loosely after Facebook Open Source Library) is a library of
-	C++14 components designed with practicality and efficiency in mind.
-	Folly contains a variety of core library components used extensively at Facebook.
-	This package includes the shared library.
+  An open-source C++ library developed and used at Facebook.
+  Folly (acronymed loosely after Facebook Open Source Library) is a library of
+  C++14 components designed with practicality and efficiency in mind.
+  Folly contains a variety of core library components used extensively at Facebook.
+  This package includes the shared library.
 endef
 
 CMAKE_OPTIONS += \
 	-DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-	-DCXX_STD=gnu++14 \
+	-DCXX_STD=c++14 \
 	-DFOLLY_HAVE_UNALIGNED_ACCESS_EXITCODE=OFF \
+	-DFOLLY_HAVE_UNALIGNED_ACCESS_EXITCODE__TRYRUN_OUTPUT=OFF \
 	-DFOLLY_HAVE_LINUX_VDSO_EXITCODE=OFF \
+	-DFOLLY_HAVE_LINUX_VDSO_EXITCODE__TRYRUN_OUTPUT=OFF \
 	-DFOLLY_HAVE_WCHAR_SUPPORT_EXITCODE=OFF \
+	-DFOLLY_HAVE_WCHAR_SUPPORT_EXITCODE__TRYRUN_OUTPUT=OFF \
 	-DHAVE_VSNPRINTF_ERRORS_EXITCODE=OFF \
-	-DFOLLY_HAVE_XSI_STRERROR_R_EXITCODE=0 \
+	-DHAVE_VSNPRINTF_ERRORS_EXITCODE__TRYRUN_OUTPUT=OFF \
 	-DBUILD_SHARED_LIBS=ON
+
+TARGET_CXXFLAGS += -ffunction-sections -fdata-sections -flto
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 define Package/libfolly/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/libfolly/patches/100-cmake-fix-regex-match-path.patch
+++ b/libs/libfolly/patches/100-cmake-fix-regex-match-path.patch
@@ -29,7 +29,7 @@ Index: folly-2019.05.06.00/CMakeLists.txt
      "Benchmark.cpp$"
      "Test.cpp$"
  )
-@@ -169,7 +171,7 @@ list(APPEND hfiles
+@@ -172,7 +174,7 @@ list(APPEND hfiles
  if (NOT FOLLY_USE_SYMBOLIZER)
    REMOVE_MATCHES_FROM_LISTS(files hfiles
      MATCHES

--- a/libs/libfolly/patches/101-remove-undefined-dcheck.patch
+++ b/libs/libfolly/patches/101-remove-undefined-dcheck.patch
@@ -1,8 +1,6 @@
-Index: folly-2019.05.06.00/folly/stats/detail/BufferedStat-defs.h
-===================================================================
---- folly-2019.05.06.00.orig/folly/stats/detail/BufferedStat-defs.h
-+++ folly-2019.05.06.00/folly/stats/detail/BufferedStat-defs.h
-@@ -74,7 +74,6 @@ void BufferedStat<DigestT, ClockT>::doUp
+--- a/folly/stats/detail/BufferedStat-inl.h
++++ b/folly/stats/detail/BufferedStat-inl.h
+@@ -69,7 +69,6 @@ void BufferedStat<DigestT, ClockT>::doUpdate(
      TimePoint now,
      const std::unique_lock<SharedMutex>& g,
      UpdateMode updateMode) {


### PR DESCRIPTION
Several optimizations to reduce size. ~35KB. Mostly because of LTO.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ammubhave 
Compile tested: armeb