### PR TITLE
alsa-lib: fix includes in staging

### DIFF
--- a/libs/alsa-lib/Makefile
+++ b/libs/alsa-lib/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alsa-lib
 PKG_VERSION:=1.1.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=ftp://ftp.alsa-project.org/pub/lib/ \
@@ -55,10 +55,16 @@ CONFIGURE_ARGS+= \
 		--with-versioned=no
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/include/sys/
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/include/alsa \
 		$(1)/usr/include/
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)/usr/include/asoundlib.h \
+		$(1)/usr/include/
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)/usr/include/sys/asoundlib.h \
+		$(1)/usr/include/sys/
 
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) \


### PR DESCRIPTION
Recently alsa-lib was upgraded from 1.1.8 to 1.1.9. Upstream changed the
header handling somewhat. The .pc file no longer adds
"${includedir}/alsa" to the includes. Instead "asoundlib.h" is installed
into "${includedir}". This way they're able to display a warning if
applications still include "<asoundlib.h>" rather than
"<alsa/asoundlib.h>" (like pulseaudio, which currently fails to build).

To go along with upstream this commit copies "asoundlib.h" to
"${includedir}". "${includedir}/sys/asoundlib.h" is also copied for
completeness' sake. Now software using deprecated header locations can
compile again.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @thess @tripolar 
Compile tested: master ath79
Run tested: N/A, just a compile fix

Description:
Hi all,

Header handling is currently not as per upstream's "gusto" and some applications are unable to find the alsa headers. This fixes that.

Kind regards,
Seb