### PR TITLE
libwangle: Update to 2019.09.02

### DIFF
--- a/libs/libwangle/Makefile
+++ b/libs/libwangle/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libwangle
-PKG_VERSION:=2019.06.10.00
+PKG_VERSION:=2019.09.09.00
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/facebook/wangle/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=3721c003aa5fce889699b0301705eced7a0ea4ab2e7e12af543dab3493ba8be9
+PKG_HASH:=b790ba6b975b90d7935e4ae12f84c77d6be9f9a94308a3e0b974d83cf0e01d8b
 PKG_BUILD_DIR:=$(BUILD_DIR)/wangle-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Amol Bhave <ambhave@fb.com>
@@ -14,6 +14,7 @@ PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=libfizz
 CMAKE_SOURCE_SUBDIR:=wangle
 CMAKE_INSTALL:=1
 
@@ -21,23 +22,16 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 define Package/libwangle
-	SECTION:=libs
-	CATEGORY:=Libraries
-	TITLE:=Wangle: C++ networking library
-	DEPENDS:=+libfizz
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Wangle: C++ networking library
+  URL:=https://github.com/facebook/wangle
 endef
 
-define Package/libwangle/description
-	Wangle is a framework providing a set of common client/server abstractions for building services in a consistent, modular, and composable way.
-	This package includes the shared library.
-endef
+CMAKE_OPTIONS += \
+	-DBoost_NO_BOOST_CMAKE=ON
 
-CMAKE_OPTIONS:= \
-	-DBUILD_SHARED_LIBS=ON
-
-define Package/libwangle/install
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libwangle.so* $(1)/usr/lib/
-endef
+TARGET_CXXFLAGS += -ffunction-sections -fdata-sections -flto
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 $(eval $(call BuildPackage,libwangle))

--- a/libs/libwangle/patches/010-c++14.patch
+++ b/libs/libwangle/patches/010-c++14.patch
@@ -1,0 +1,11 @@
+--- a/wangle/CMakeLists.txt
++++ b/wangle/CMakeLists.txt
+@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.0.2)
+ 
+ project("wangle" VERSION 1.0.0 LANGUAGES CXX C)
+ 
+-add_compile_options(-std=c++1z)
++add_compile_options(-std=c++14)
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ set(CMAKE_MODULE_PATH
+   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/"


### PR DESCRIPTION
Several size optimizations. Savings of ~68KB.

Remove shared build. libwangle is only used by fbthrift. Just use the
static version.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ammubhave 
Compile tested: ath79