### PR TITLE
[OpenWrt 18.06] lighttpd: mark module configuration files

### DIFF
--- a/net/lighttpd/Makefile
+++ b/net/lighttpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lighttpd
 PKG_VERSION:=1.4.48
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.lighttpd.net/lighttpd/releases-1.4.x
@@ -175,6 +175,10 @@ define BuildPlugin
       DEPENDS+= $(3)
     endif
     TITLE:=$(2) module
+  endef
+
+  define Package/lighttpd-mod-$(1)/conffiles
+/etc/lighttpd/conf.d/$(4)-$(1).conf
   endef
 
  ifneq ($(SDK)$(CONFIG_PACKAGE_lighttpd-mod-$(1)),)


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: Xiaomi Mi WiFi R3G, ramips, mt7621, OpenWrt 18.06.4
Run tested: N/A
Just prevent it to happen in the future. It is already included in `openwrt-19.07` and `master`.

Description:
Fixes:  https://github.com/openwrt/packages/issues/9935 (and as well it was created on [forum](https://forum.openwrt.org/t/urgent-the-latest-lighttpd-update-package-have-some-problem-undefined-config-variable-var-home-dir/44170/5))
cross-reference: https://github.com/openwrt/packages/pull/8791