### PR TITLE
[OpenWrt 19.07] youtube-dl: Update to version 2019.9.12.1

### DIFF
--- a/multimedia/youtube-dl/Makefile
+++ b/multimedia/youtube-dl/Makefile
@@ -8,18 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=youtube-dl
-PKG_VERSION:=2019.7.2
+PKG_VERSION:=2019.9.12.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=youtube_dl-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/y/youtube_dl/
-PKG_HASH:=829fc833d8cc4a24c883fa49fd450d06b29fb17cddcb885314af92da220234f1
-
+PKG_HASH:=d61dd64e81a4cc026726b25981faf8ef8453363598483d51f7dc6f6d5580a78f
 PKG_BUILD_DIR:=$(BUILD_DIR)/youtube_dl-$(PKG_VERSION)
 
+PKG_MAINTAINER:=Adrian Panella <ianchi74@outlook.com>, Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Unlicense
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Adrian Panella <ianchi74@outlook.com>, Josef Schlehofer <pepe.schlehofer@gmail.com>
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07

Description:

- Update to version 2019.9.12.1
Changelog:
https://github.com/ytdl-org/youtube-dl/releases/tag/2019.09.12.1
https://github.com/ytdl-org/youtube-dl/releases/tag/2019.09.12
https://github.com/ytdl-org/youtube-dl/releases/tag/2019.09.01
https://github.com/ytdl-org/youtube-dl/releases/tag/2019.08.13
https://github.com/ytdl-org/youtube-dl/releases/tag/2019.08.02
https://github.com/ytdl-org/youtube-dl/releases/tag/2019.07.30
https://github.com/ytdl-org/youtube-dl/releases/tag/2019.07.27
https://github.com/ytdl-org/youtube-dl/releases/tag/2019.07.16
https://github.com/ytdl-org/youtube-dl/releases/tag/2019.07.14
https://github.com/ytdl-org/youtube-dl/releases/tag/2019.07.12


Makefile changes:
- Move PKG_MAINTAINER above PKG_LICENSE
- PKG_HASH and PKG_BUILD_DIR should be together in one section
