### PR TITLE
protobuf-c: Switch to CMake

### DIFF
--- a/libs/protobuf-c/Makefile
+++ b/libs/protobuf-c/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libprotobuf-c
 PKG_VERSION:=1.3.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=protobuf-c-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/protobuf-c/protobuf-c/releases/download/v$(PKG_VERSION)
@@ -21,14 +21,17 @@ PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DEPENDS:=protobuf-c/host
+PKG_BUILD_DEPENDS:=protobuf
 HOST_BUILD_DEPENDS:=protobuf/host
 
-PKG_INSTALL:=1
+HOST_BUILD_PARALLEL:=1
 PKG_BUILD_PARALLEL:=1
+CMAKE_INSTALL:=1
+CMAKE_SOURCE_SUBDIR:=build-cmake
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/libprotobuf-c
   TITLE:=Protocol Buffers library
@@ -44,23 +47,12 @@ define Package/libprotobuf-c/description
   internal RPC protocols and file formats.
 endef
 
-CONFIGURE_ARGS += \
-	--enable-shared \
-	--enable-static \
-	--disable-protoc
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libprotobuf-c.{a,la,so*} $(1)/usr/lib/
-	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/* $(1)/usr/lib/pkgconfig/
-endef
+CMAKE_OPTIONS += \
+	-DBUILD_SHARED_LIBS=ON
 
 define Package/libprotobuf-c/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libprotobuf-c.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libprotobuf-c.so* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libprotobuf-c))


### PR DESCRIPTION
Allows PKG_BUILD_PARALLEL to work properly.

Replaced InstallDev section with CMAKE_INSTALL.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me
Compile tested: arc700 with umurmur and ola