### PR TITLE
seafile-seahub: update dependency to python-mysqlclient

### DIFF
--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python-package.mk
 
 SEAFILE_PYTHON_DEPENDS:= \
-	simplejson chardet dateutil mysql pytz qrcode requests requests-oauthlib \
+	simplejson chardet dateutil mysqlclient pytz qrcode requests requests-oauthlib \
 	django django-constance django-appconf django-compressor django-formtools \
 	django-jsonfield django-picklefield django-postoffice django-restframework \
 	pillow django-simple-captcha django-statici18n django-webpack-loader


### PR DESCRIPTION
Maintainer: me 
Compile tested: n/a
Run tested: n/a

-------------------------------------------------

The `python-mysql` package was updated with PR https://github.com/openwrt/packages/pull/9705

For seahub this was omitted, since the Python dependencies are prefixed
with `python-`, so it was missed during the grep search.
And grepping just for `mysql` yields many results.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>