### PR TITLE
cgi-io: various improvements

### DIFF
--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_LICENSE:=GPL-2.0-or-later
 
@@ -37,7 +37,7 @@ endef
 define Package/cgi-io/install
 	$(INSTALL_DIR) $(1)/usr/libexec $(1)/www/cgi-bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/cgi-io $(1)/usr/libexec
-	$(LN) ../../usr/libexec/cgi-io $(1)/www/cgi-bin/cgi-upload 
+	$(LN) ../../usr/libexec/cgi-io $(1)/www/cgi-bin/cgi-upload
 	$(LN) ../../usr/libexec/cgi-io $(1)/www/cgi-bin/cgi-backup
 endef
 

--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_LICENSE:=GPL-2.0-or-later
 
@@ -38,6 +38,7 @@ define Package/cgi-io/install
 	$(INSTALL_DIR) $(1)/usr/libexec $(1)/www/cgi-bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/cgi-io $(1)/usr/libexec
 	$(LN) ../../usr/libexec/cgi-io $(1)/www/cgi-bin/cgi-upload
+	$(LN) ../../usr/libexec/cgi-io $(1)/www/cgi-bin/cgi-download
 	$(LN) ../../usr/libexec/cgi-io $(1)/www/cgi-bin/cgi-backup
 endef
 

--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_LICENSE:=GPL-2.0-or-later
 

--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_LICENSE:=GPL-2.0-or-later
 


### PR DESCRIPTION
Maintainer: @blogic 
Compile tested: OpenWrt SDK master r10936-ac418ddecc ramips/mt7621
Run tested: Xiaomi Mi Router 3G running OpenWrt SNAPSHOT r10831-164037983d

Description:

This PR adds a series of enhancements to `cgi-io` in order to prepare it for more comprehensive use in LuCI and other UIs which might want to up- and download files outside of the size limits imposed by ubus-rpc:

 - Change the scope for path access acl rules from `cgi-io` to `file` in order to allow sharing rules with `rpcd-mod-file`
 - Implement a `cgi-download` applet analogous to the existing `cgi-upload` one
 - Rework error reporting to use appropriate HTTP response codes instead of unconditionally reporting `500` for any error
 - Rework the `cgi-backup` applet to use the `splice(2)` syscall to stream the backup archive