### PR TITLE
golang: Use new -trimpath option when compiling Go packages

### DIFF
--- a/lang/golang/golang-package.mk
+++ b/lang/golang/golang-package.mk
@@ -275,7 +275,6 @@ define GoPackage/Build/Compile
 			mips|mipsle)     installsuffix="$(GO_MIPS)" ;; \
 			mips64|mips64le) installsuffix="$(GO_MIPS64)" ;; \
 			esac ; \
-			trimpath="all=-trimpath=$(GO_PKG_BUILD_DIR)" ; \
 			ldflags="all=-linkmode external -extldflags '$(TARGET_LDFLAGS)'" ; \
 			pkg_gcflags="$(GO_PKG_GCFLAGS)" ; \
 			pkg_ldflags="$(GO_PKG_LDFLAGS)" ; \
@@ -284,8 +283,7 @@ define GoPackage/Build/Compile
 			done ; \
 			go install \
 				$$$${installsuffix:+-installsuffix $$$$installsuffix} \
-				-gcflags "$$$$trimpath" \
-				-asmflags "$$$$trimpath" \
+				-trimpath \
 				-ldflags "$$$$ldflags" \
 				-v \
 				$$$${pkg_gcflags:+-gcflags "$$$$pkg_gcflags"} \

--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -27,6 +27,7 @@ unexport \
   CC_FOR_TARGET CXX_FOR_TARGET GO_DISTFLAGS GO_GCFLAGS GO_LDFLAGS GOBUILDTIMELOGFILE GOROOT_BOOTSTRAP \
   BOOT_GO_GCFLAGS GOEXPERIMENT GOBOOTSTRAP_TOOLEXEC
   # there are more magic environment variables to track down, but ain't nobody got time for that
+  # deliberately left untouched: GOPROXY GONOPROXY GOSUMDB GONOSUMDB GOPRIVATE
 
 go_arch=$(subst \
   aarch64,arm64,$(subst \


### PR DESCRIPTION
Maintainer: me
Compile tested: armvirt-64, 2019-09-12 snapshot sdk
Run tested: compiled Go packages (obfs4proxy, tor-fw-helper) and examined the compiled binaries

Description:
Go 1.13 added a new [`-trimpath`](https://golang.org/doc/go1.13#trimpath) option to the "go build" command that removes system paths from compiled executables. This replaces the previous `-trimpath` flags.

There are still system paths in the compiled executable (for `crti.o` and `crtn.o`, when cross-compiling); these appear to be stripped during the packaging process.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>