### PR TITLE
nut: Switch to pkgconfig for finding libgd

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=17
+PKG_RELEASE:=18
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/patches/010-libgd-pkgconfig.patch
+++ b/net/nut/patches/010-libgd-pkgconfig.patch
@@ -1,0 +1,79 @@
+--- a/m4/nut_check_libgd.m4
++++ b/m4/nut_check_libgd.m4
+@@ -9,37 +9,27 @@ if test -z "${nut_have_libgd_seen}"; then
+ 	nut_have_libgd_seen=yes
+ 
+ 	CFLAGS_ORIG="${CFLAGS}"
+-	LDFLAGS_ORIG="${LDFLAGS}"
+ 	LIBS_ORIG="${LIBS}"
+ 
+-	dnl Initial defaults. These are only used if gdlib-config is
+-	dnl unusable and the user fails to pass better values in --with
+-	dnl arguments
+-	CFLAGS=""
+-	LDFLAGS="-L/usr/X11R6/lib"
+-	LIBS="-lgd -lpng -lz -ljpeg -lfreetype -lm -lXpm -lX11"
+-
+-	AC_MSG_CHECKING(for gd version via gdlib-config)
+-	GD_VERSION=`gdlib-config --version 2>/dev/null`
+-	if test "$?" != "0" -o -z "${GD_VERSION}"; then
+-		GD_VERSION="none"
++	AC_MSG_CHECKING(for gd version via pkg-config)
++	GD_VERSION=`pkg-config --silence-errors --modversion gdlib 2>/dev/null`
++	if test "$?" != "0" -a -n "${GD_VERSION}"; then
++		CFLAGS"`pkg-config --silence-errors --cflags gdllib 2>/dev/null`"
++		LIBS="`pkg-config --silence-errors --libs gdlib 2>/dev/null`"
++	else
++		AC_MSG_CHECKING(via gdlib-config)
++		GD_VERSION="`gdlib-config --version 2>/dev/null`"
++		if test "$?" = "0" -a -n "${GD_VERSION}"; then
++			CFLAGS="`gdlib-config --cflags 2>/dev/null`"
++			LIBS="`gdlib-config --libs 2>/dev/null`"
++		else
++			GD_VERSION="none"
++			CFLAGS=""
++			LIBS="-lgd"
++		fi
+ 	fi
+ 	AC_MSG_RESULT(${GD_VERSION} found)
+ 
+-	case "${GD_VERSION}" in
+-	none)
+-		;;
+-	2.0.5 | 2.0.6 | 2.0.7)
+-		AC_MSG_WARN([[gd ${GD_VERSION} detected, unable to use gdlib-config script]])
+-		AC_MSG_WARN([[If gd detection fails, upgrade gd or use --with-gd-includes and --with-gd-libs]])
+-		;;
+-	*)
+-		CFLAGS="`gdlib-config --includes 2>/dev/null`"
+-		LDFLAGS="`gdlib-config --ldflags 2>/dev/null`"
+-		LIBS="`gdlib-config --libs 2>/dev/null`"
+-		;;
+-	esac
+-
+ 	dnl Now allow overriding gd settings if the user knows best
+ 	AC_MSG_CHECKING(for gd include flags)
+ 	AC_ARG_WITH(gd-includes,
+@@ -70,7 +60,7 @@ if test -z "${nut_have_libgd_seen}"; then
+ 			;;
+ 		esac
+ 	], [])
+-	AC_MSG_RESULT([${LDFLAGS} ${LIBS}])
++	AC_MSG_RESULT([${LIBS}])
+ 
+ 	dnl check if gd is usable
+ 	AC_CHECK_HEADERS(gd.h gdfontmb.h, [nut_have_libgd=yes], [nut_have_libgd=no], [AC_INCLUDES_DEFAULT])
+@@ -79,12 +69,11 @@ if test -z "${nut_have_libgd_seen}"; then
+ 	if test "${nut_have_libgd}" = "yes"; then
+ 		AC_DEFINE(HAVE_LIBGD, 1, [Define if you have Boutell's libgd installed])
+ 		LIBGD_CFLAGS="${CFLAGS}"
+-		LIBGD_LDFLAGS="${LDFLAGS} ${LIBS}"
++		LIBGD_LDFLAGS="${LIBS}"
+ 	fi
+ 
+ 	dnl put back the original versions
+ 	CFLAGS="${CFLAGS_ORIG}"
+-	LDFLAGS="${LDFLAGS_ORIG}"
+ 	LIBS="${LIBS_ORIG}"
+ fi
+ ])


### PR DESCRIPTION
nut uses gdlib-config to find libgd, which happens to be deprecated. This
switches it to use pkgconfig and allows a fallback to gdlib-config, same
as the libusb check.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @cshoredaniel 
Compile tested: arc700