### PR TITLE
motion: Update to 4.2.2

### DIFF
--- a/multimedia/motion/Makefile
+++ b/multimedia/motion/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=motion
-PKG_VERSION:=4.2.1
-PKG_RELEASE:=2
+PKG_VERSION:=4.2.2
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>
 PKG_LICENSE:=GPLv2
@@ -17,7 +17,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-release-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/Motion-Project/motion/tar.gz/release-$(PKG_VERSION)?
-PKG_HASH:=d97ec6ae766adfd478b6f7f9cc0da5f2fe21faa9366d98664be255714c1cf81d
+PKG_HASH:=c8d40976b41da8eb9f9f7128599403a312fc26b7226bf3787d75f78cb5a6cc6e
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-release-$(PKG_VERSION)
 
 PKG_BUILD_PARALLEL:=1
@@ -45,14 +45,14 @@ CONFIGURE_ARGS+= \
 	--without-mysql \
 	--without-pgsql \
 	--without-sqlite3 \
-	--without-bktr
+	--without-bktr \
+	--without-webp
 
 define Package/motion/install
 	$(INSTALL_DIR) $(1)/etc
 	$(CP) $(PKG_BUILD_DIR)/motion-dist.conf $(1)/etc/motion.conf
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/motion $(1)/usr/bin/
-
 endef
 
 $(eval $(call BuildPackage,motion))


### PR DESCRIPTION
Removed webp support. motion picks it up now that it's in the tree.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @roger- 