### PR TITLE
openldap: update to 2.4.48

### DIFF
--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
 PKG_VERSION:=2.4.47
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://gpl.savoirfairelinux.net/pub/mirrors/openldap/openldap-release/ \

--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -12,11 +12,11 @@ PKG_VERSION:=2.4.45
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
-PKG_SOURCE_URL:=ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/ \
-	ftp://sunsite.cnlab-switch.ch/mirror/OpenLDAP/openldap-release/ \
-	ftp://ftp.nl.uu.net/pub/unix/db/openldap/openldap-release/ \
-	ftp://ftp.plig.org/pub/OpenLDAP/openldap-release/
-PKG_HASH:=cdd6cffdebcd95161a73305ec13fc7a78e9707b46ca9f84fb897cd5626df3824
+PKG_SOURCE_URL:=https://gpl.savoirfairelinux.net/pub/mirrors/openldap/openldap-release/ \
+	http://mirror.eu.oneandone.net/software/openldap/openldap-release/ \
+	http://mirror.switch.ch/ftp/software/mirror/OpenLDAP/openldap-release/ \
+	https://www.openldap.org/software/download/OpenLDAP/openldap-release/
+PKG_HASH:=9a90dcb86b99ae790ccab93b7585a31fbcbeec8c94bf0f7ab0ca0a87ea0c4b2d
 PKG_LICENSE:=OLDAP-2.8
 PKG_LICENSE_FILES:=LICENSE
 

--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
-PKG_VERSION:=2.4.47
-PKG_RELEASE:=2
+PKG_VERSION:=2.4.48
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://gpl.savoirfairelinux.net/pub/mirrors/openldap/openldap-release/ \
 	http://mirror.eu.oneandone.net/software/openldap/openldap-release/ \
 	http://mirror.switch.ch/ftp/software/mirror/OpenLDAP/openldap-release/ \
 	https://www.openldap.org/software/download/OpenLDAP/openldap-release/
-PKG_HASH:=f54c5877865233d9ada77c60c0f69b3e0bfd8b1b55889504c650047cc305520b
+PKG_HASH:=d9523ffcab5cd14b709fcf3cb4d04e8bc76bb8970113255f372bc74954c6074d
 PKG_LICENSE:=OLDAP-2.8
 PKG_LICENSE_FILES:=LICENSE
 

--- a/libs/openldap/Makefile
+++ b/libs/openldap/Makefile
@@ -8,44 +8,72 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openldap
-PKG_VERSION:=2.4.45
-PKG_RELEASE:=2
+PKG_VERSION:=2.4.47
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://gpl.savoirfairelinux.net/pub/mirrors/openldap/openldap-release/ \
 	http://mirror.eu.oneandone.net/software/openldap/openldap-release/ \
 	http://mirror.switch.ch/ftp/software/mirror/OpenLDAP/openldap-release/ \
 	https://www.openldap.org/software/download/OpenLDAP/openldap-release/
-PKG_HASH:=9a90dcb86b99ae790ccab93b7585a31fbcbeec8c94bf0f7ab0ca0a87ea0c4b2d
+PKG_HASH:=f54c5877865233d9ada77c60c0f69b3e0bfd8b1b55889504c650047cc305520b
 PKG_LICENSE:=OLDAP-2.8
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_FIXUP:=autoreconf
 
+PKG_CONFIG_DEPENDS := \
+        CONFIG_OPENLDAP_DEBUG \
+        CONFIG_OPENLDAP_MONITOR \
+        CONFIG_OPENLDAP_DB47 \
+        CONFIG_OPENLDAP_ICU
+
 include $(INCLUDE_DIR)/package.mk
 
-define Package/openldap/Default
-  TITLE:=LDAP implementation
+define Package/libopenldap/Default
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=OpenLDAP
+  TITLE:=LDAP directory suite
   URL:=http://www.openldap.org/
   MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 endef
 
-define Package/openldap/Default/description
-	OpenLDAP Software is an open source implementation of the
-	Lightweight Directory Access Protocol (LDAP).
-endef
-
 define Package/libopenldap
-  $(call Package/openldap/Default)
-  SECTION:=libs
-  CATEGORY:=Libraries
-  DEPENDS:=+libopenssl +libsasl2 +libpthread
+  $(call Package/libopenldap/Default)
+  MENU:=1
+  DEPENDS:=+libopenssl +libsasl2 +libpthread +OPENLDAP_DB47:libdb47 +OPENLDAP_ICU:icu
   TITLE+= (libraries)
 endef
 
+define Package/libopenldap/config
+  config OPENLDAP_DEBUG
+	bool "Enable debugging information"
+	default y
+	help
+		Enable debugging information. This option must be enabled
+		for the loglevel directive to work.
+  config OPENLDAP_MONITOR
+	bool "Enable monitor backend"
+	default n
+	help
+		Enable monitor backend to obtain information about the running
+		status of the daemon. See OpenLDAP documentation for more
+		information.
+  config OPENLDAP_DB47
+	bool "Berkeley DB support"
+	default n
+	help
+		Enable Berkeley DB support (BDB).
+  config OPENLDAP_ICU
+	bool "ICU support"
+	default n
+	help
+		Enable ICU (International Components for Unicode) support.
+endef
+
 define Package/libopenldap/description
-	$(call Package/openldap/Default/description)
-	This package contains the shared LDAP client libraries, needed by other programs.
+OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol (LDAP). This package contains the shared LDAP client libraries, needed by other programs.
 endef
 
 define Package/libopenldap/conffiles
@@ -53,33 +81,28 @@ define Package/libopenldap/conffiles
 endef
 
 define Package/openldap-utils
-  $(call Package/openldap/Default)
-  SECTION:=utils
-  CATEGORY:=Utilities
+  $(call Package/libopenldap/Default)
   DEPENDS:=+libopenldap
   TITLE+= (utilities)
 endef
 
 define Package/openldap-utils/description
-	$(call Package/openldap/Default/description)
-	This package contains client programs required to access LDAP servers.
+This package contains client programs required to access LDAP servers.
 endef
 
 define Package/openldap-server
-  $(call Package/openldap/Default)
-  SECTION:=net
-  CATEGORY:=Network
+  $(call Package/libopenldap/Default)
   DEPENDS:=+libopenldap +libuuid
   TITLE+= (server)
 endef
 
 define Package/openldap-server/description
-	$(call Package/openldap/Default/description)
-	This package contains server programs required to provide LDAP services.
+This package contains server programs required to provide LDAP services.
 endef
 
 define Package/openldap-server/conffiles
 /etc/openldap/slapd.conf
+/etc/init.d/ldap
 endef
 
 TARGET_CFLAGS += $(FPIC) -lpthread
@@ -87,44 +110,60 @@ TARGET_CFLAGS += $(FPIC) -lpthread
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
-	--disable-debug \
 	--enable-dynamic \
 	--enable-syslog \
-	--disable-local \
-	--disable-slurpd \
 	--with-cyrus-sasl \
-	--without-fetch \
 	--with-threads \
 	--with-tls \
 	--with-yielding_select="yes" \
-	--without-threads \
 	--enable-null \
-	--disable-bdb \
-	--disable-hdb \
-	--disable-monitor \
 	--disable-relay
 
-CONFIGURE_VARS += \
-	ol_cv_lib_icu="no"
+
+ifdef CONFIG_OPENLDAP_MONITOR
+	CONFIGURE_ARGS+= --enable-monitor
+else
+	CONFIGURE_ARGS+= --disable-monitor
+endif
+
+ifdef CONFIG_OPENLDAP_DEBUG
+	CONFIGURE_ARGS+= --enable-debug
+else
+	CONFIGURE_ARGS+= --disable-debug
+endif
+
+ifdef CONFIG_OPENLDAP_DB47
+	CONFIGURE_ARGS+= \
+		--enable-bdb \
+		--enable-hdb
+else
+	CONFIGURE_ARGS+= \
+		--disable-bdb \
+		--disable-hdb
+endif
+
+ifndef CONFIG_OPENLDAP_ICU
+	CONFIGURE_VARS += \
+		ol_cv_lib_icu="no"
+endif
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		DESTDIR="$(PKG_INSTALL_DIR)" \
 		HOSTCC="$(HOSTCC)" \
 		depend all install
+	cd $(PKG_BUILD_DIR)/libraries/liblmdb && $(MAKE) $(CONFIGURE_VARS)
 endef
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/{lber,ldap}*.h $(1)/usr/include/
-	$(INSTALL_DIR) $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/{lber,ldap}*.h $(1)/usr/include/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{lber,ldap}*.{a,so*} $(1)/usr/lib/
 endef
 
 define Package/libopenldap/install
-	$(INSTALL_DIR) $(1)/etc/openldap
-	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/openldap/ldap.conf $(1)/etc/openldap/
-	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/etc/openldap $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/etc/openldap/ldap.conf $(1)/etc/openldap/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{lber,ldap}*.so.* $(1)/usr/lib/
 endef
 
@@ -137,15 +176,15 @@ define Package/openldap-server/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/ldap.init $(1)/etc/init.d/ldap
 	$(INSTALL_DIR) $(1)/etc/openldap/schema
-	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/openldap/schema/* $(1)/etc/openldap/schema/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/openldap/schema/* $(1)/etc/openldap/schema/
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/openldap/slapd.conf $(1)/etc/openldap/
 	$(INSTALL_DIR) $(1)/usr/sbin
-	# XXX: OpenLDAP installs slapd into libexecdir, not sbindir:
+	# NB: OpenLDAP installs slapd into libexecdir, not sbindir
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/slapd $(1)/usr/sbin/
-	# XXX: switch default backend to ldif, since bdb is disabled
-	$(SED) 's|^\(database\)\([ \t]\+\)bdb|\1\2ldif|g' \
-	    -e 's|^\(index\)|#\1|g' \
-	    $(1)/etc/openldap/slapd.conf
+	$(eval SLAPTOOLS := slapadd slapcat slapdn slapindex slappasswd slaptest slapauth slapacl slapschema)
+	for i in $(SLAPTOOLS); do \
+		$(LN) ./slapd $(1)/usr/sbin/$$$$i; \
+	done
 endef
 
 $(eval $(call BuildPackage,libopenldap))

--- a/libs/openldap/patches/001-automake-compat.patch
+++ b/libs/openldap/patches/001-automake-compat.patch
@@ -286,7 +286,7 @@
 +SHELL = @SHELL@
 +
  SRCS	= init.c config.c opensock.c search.c bind.c unbind.c add.c \
- 		delete.c modify.c modrdn.c compare.c result.c
+ 		delete.c modify.c modrdn.c compare.c result.c extended.c
  OBJS	= init.lo config.lo opensock.lo search.lo bind.lo unbind.lo add.lo \
 --- a/servers/slapd/back-sql/Makefile.in
 +++ b/servers/slapd/back-sql/Makefile.in

--- a/libs/openldap/patches/110-reproducible-builds.patch
+++ b/libs/openldap/patches/110-reproducible-builds.patch
@@ -1,16 +1,19 @@
-Index: openldap-2.4.45/build/mkversion
-===================================================================
---- openldap-2.4.45.orig/build/mkversion
-+++ openldap-2.4.45/build/mkversion
-@@ -50,7 +50,6 @@ if test $# != 1 ; then
+--- a/build/mkversion
++++ b/build/mkversion
+@@ -50,12 +50,6 @@ if test $# != 1 ; then
  fi
  
  APPLICATION=$1
--WHOWHERE="$USER@`uname -n`:`pwd`"
+-# Reproducible builds set SOURCE_DATE_EPOCH, want constant strings
+-if [ -n "${SOURCE_DATE_EPOCH}" ]; then
+-   WHOWHERE="openldap"
+-else
+-   WHOWHERE="$USER@$(uname -n):$(pwd)"
+-fi
  
  cat << __EOF__
  /* This work is part of OpenLDAP Software <http://www.openldap.org/>.
-@@ -72,7 +71,6 @@ static const char copyright[] =
+@@ -77,7 +71,6 @@ static const char copyright[] =
  "COPYING RESTRICTIONS APPLY\n";
  
  $static $const char $SYMBOL[] =

--- a/libs/openldap/patches/800-implicit.patch
+++ b/libs/openldap/patches/800-implicit.patch
@@ -1,0 +1,10 @@
+--- a/libraries/libldap/tls2.c
++++ b/libraries/libldap/tls2.c
+@@ -41,6 +41,7 @@ static tls_impl *tls_imp = &ldap_int_tls_impl;
+ #define HAS_TLS( sb )	ber_sockbuf_ctrl( sb, LBER_SB_OPT_HAS_IO, \
+ 				(void *)tls_imp->ti_sbio )
+ 
++static int ldap_pvt_tls_check_hostname( LDAP *ld, void *s, const char *name_in );
+ #endif /* HAVE_TLS */
+ 
+ #ifdef LDAP_DEVEL

--- a/libs/openldap/patches/901-reduce-slapd-default-mem-usage.patch
+++ b/libs/openldap/patches/901-reduce-slapd-default-mem-usage.patch
@@ -1,0 +1,11 @@
+--- a/servers/slapd/slapd.conf
++++ b/servers/slapd/slapd.conf
+@@ -50,7 +50,7 @@ argsfile	%LOCALSTATEDIR%/run/slapd.args
+ #######################################################################
+ 
+ database	mdb
+-maxsize		1073741824
++maxsize		8388608
+ suffix		"dc=my-domain,dc=com"
+ rootdn		"cn=Manager,dc=my-domain,dc=com"
+ # Cleartext passwords, especially for the rootdn, should


### PR DESCRIPTION
Fixes CVE-2019-13565.

Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me

Description:
Cherry pick to fix CVE-2019-13565.