### PR TITLE
libgcrypt: Update to 1.8.5

### DIFF
--- a/libs/libgcrypt/Makefile
+++ b/libs/libgcrypt/Makefile
@@ -8,19 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgcrypt
-PKG_VERSION:=1.8.4
+PKG_VERSION:=1.8.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/libgcrypt/
-PKG_HASH:=f638143a0672628fde0cad745e9b14deb85dffb175709cacc1f4fe24b93f2227
+PKG_HASH:=3b4a2a94cb637eff5bdebbcaf46f4d95c4f25206f459809339cdada0eb577ac3
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
-PKG_LICENSE:=LGPL-2.1+ GPL-2.0+
-PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:gnupg:libgcrypt
 
-PKG_FIXUP:=autoreconf patch-libtool
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
@@ -32,6 +29,8 @@ define Package/libgcrypt
   DEPENDS:=+libgpg-error
   TITLE:=GNU crypto library
   URL:=https://www.gnupg.org/related_software/libgcrypt/
+  LICENSE:=LGPL-2.1-or-later
+  LICENSE_FILES:=COPYING.LIB
 endef
 
 define Package/libgcrypt/description


### PR DESCRIPTION
Fixed up license information. Only the library is packaged.

Signed-off-by: Rosen Penev <rosenp@gmail.com>
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me

Description:
Cherry pick to fix CVE-2019-12904.