### PR TITLE
[19.07] p910nd: Run as non-root by default

### DIFF
--- a/net/p910nd/Makefile
+++ b/net/p910nd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=p910nd
 PKG_VERSION:=0.97
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/p910nd
@@ -28,6 +28,7 @@ define Package/p910nd
   SUBMENU:=Printing
   TITLE:=A small non-spooling printer server
   URL:=http://p910nd.sourceforge.net
+  USERID:=p910nd=393:lp=7
 endef
 
 define Package/p910nd/conffiles
@@ -54,6 +55,8 @@ define Package/p910nd/install
 	$(INSTALL_DATA) ./files/p910nd.config $(1)/etc/config/p910nd
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/p910nd.init $(1)/etc/init.d/p910nd
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/usbmisc
+	$(INSTALL_BIN) ./files/p910nd.hotplug $(1)/etc/hotplug.d/usbmisc/20-p910nd
 endef
 
 $(eval $(call BuildPackage,p910nd))

--- a/net/p910nd/files/p910nd.config
+++ b/net/p910nd/files/p910nd.config
@@ -5,6 +5,8 @@ config p910nd
 	option port          0
 	option bidirectional 1
 	option enabled       0
+	# Override running as user p910nd, group lp
+	option runas_root    0
 
 	# mDNS support - see Bonjour Printing Specification for details concerning the values
 	# Be aware that you can only advertise one printer on this host via mDNS

--- a/net/p910nd/files/p910nd.hotplug
+++ b/net/p910nd/files/p910nd.hotplug
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+case "$ACTION" in
+        add)
+		[ -n "${DEVNAME}" ] && [ "${DEVNAME##usb/lp*}" = "" ] && {
+			chmod 660 /dev/"$DEVNAME"
+			chgrp lp /dev/"$DEVNAME"
+		}
+                ;;
+        remove)
+                # device is gone
+                ;;
+esac

--- a/net/p910nd/files/p910nd.init
+++ b/net/p910nd/files/p910nd.init
@@ -28,7 +28,7 @@ start_service() {
 
 
 start_p910nd() {
-	local section="$1"
+	local section="$1" runas_root
 	config_get_bool "enabled" "$section" "enabled" '1'
 	if [ "$enabled" -gt 0 ]; then
 		args="-d "
@@ -41,6 +41,9 @@ start_p910nd() {
 		procd_open_instance $name
 		procd_set_param command /usr/sbin/p910nd $args
 		procd_set_param respawn
+
+		config_get_bool runas_root "$section" runas_root 0
+		[ "$runas_root" -ne 1 ] && procd_set_param user p910nd
 
 		config_get_bool "mdns" "$section" "mdns" '0'
 		config_get mdns_note "$section" mdns_note


### PR DESCRIPTION
We add the necessary Makefile, hotplug, config, and init bits
so that p910nd daemon runs as user:group p910nd:lp by default.
This eliminates an unnecessary root daemon.

The hotplug script sets the permissions of the USB lp
device(s) to read-write owner and group and no access to
anyone else, and sets owner root, group lp.

This is allows sufficient privileges to p910nd
to do it's job.

(cherry-pick 932c76fa740acb0d68a46b78e2bc0eafd5fe13d6)

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: @pkerling 
Compile tested: ath79, CR5000, r10528-78d0d13c86 (Sep 12 19.07-SNAPSHOT)
Run tested: same, after upgrading firmware, did a scan and then printed using an HP All-in-One printer.
