### PR TITLE
[19.07] uwsgi-cgi: use python3 hostpkg not system python3

### DIFF
--- a/net/uwsgi-cgi/Makefile
+++ b/net/uwsgi-cgi/Makefile
@@ -15,6 +15,8 @@ PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>
 
+PKG_BUILD_DEPENDS:=python3/host
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/uwsgi-cgi
@@ -39,7 +41,8 @@ define Package/uwsgi-cgi/description
 endef
 
 MAKE_VARS+=\
-	CPP=$(TARGET_CROSS)cpp
+	CPP=$(TARGET_CROSS)cpp \
+	PYTHON=$(STAGING_DIR_HOSTPKG)/bin/python3
 
 define Build/Compile
 	$(call Build/Compile/Default,PROFILE=cgi)

--- a/net/uwsgi-cgi/patches/020-uwsgiconfig-system-python3.patch
+++ b/net/uwsgi-cgi/patches/020-uwsgiconfig-system-python3.patch
@@ -1,0 +1,10 @@
+Index: uwsgi-2.0.18/Makefile
+===================================================================
+--- uwsgi-2.0.18.orig/Makefile
++++ uwsgi-2.0.18/Makefile
+@@ -1,4 +1,4 @@
+-PYTHON := python
++PYTHON ?= python3
+ 
+ all:
+ 	$(PYTHON) uwsgiconfig.py --build $(PROFILE)


### PR DESCRIPTION
On a Debian system without python3-distutils installed, uwsgi-cgi was
failing to build because it couldn't import sysconfig from distutils.
OpenWrt packages should be using the OpenWrt python not the system
python. In addition we need to use python3 not python2, even when
both are available.

(cherry-pick c387d0923c8ced06f685b487f84ae0836d7f3e9b from master)

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer:  @Ansuel 
Compile tested: ath79, CR5000, r10528-78d0d13c86 (Sep 12 19.07-SNAPSHOT)
Run tested: same, used luci-ssl-nginx with client certificate verification enabled (requires uwsgi-cgi to function).  LuCI operates normally.
