### PR TITLE
lcdgrilo: Fix compilation with newer Vala

### DIFF
--- a/multimedia/lcdgrilo/Makefile
+++ b/multimedia/lcdgrilo/Makefile
@@ -9,20 +9,20 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lcdgrilo
 PKG_VERSION:=0.0.12
-PKG_RELEASE:=2
-
-PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
-
-PKG_LICENSE:=GPL-2.0
-PKG_LICENSE_FILES:=COPYING
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.flyn.org/projects/lcdgrilo
 PKG_HASH:=2e5028fff7a90b1a3688c466f048e978a52d9a4da20a382546d5e5bd42e2fc6a
-PKG_BUILD_DEPENDS:=vala/host
 
-PKG_INSTALL:=1
+PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
 PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=vala/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -32,7 +32,7 @@ define Package/lcdgrilo
   CATEGORY:=Multimedia
   DEPENDS:=+grilo +grilo-plugins +libgee +libgstreamer1
   TITLE:=lcdgrilo
-  URL:=http://www.flyn.org/projects/lcdgrilo/
+  URL:=https://www.flyn.org/projects/lcdgrilo/
 endef
 
 define Package/lcdgrilo/decription

--- a/multimedia/lcdgrilo/patches/020-vala.patch
+++ b/multimedia/lcdgrilo/patches/020-vala.patch
@@ -1,0 +1,11 @@
+--- a/src/lcdgrilo.vala
++++ b/src/lcdgrilo.vala
+@@ -47,7 +47,7 @@ private class LCDPlayer {
+ 	private int current = 0;
+ 	private Transitions transitions;
+ 	private MainLoop loop;
+-	private Gee.ArrayList<Grl.Source> sources = new Gee.ArrayList<unowned Grl.Source> ();
++	private Gee.ArrayList<weak Grl.Source> sources = new Gee.ArrayList<unowned Grl.Source> ();
+ 	private uint watch_id = 0;
+ 
+ 	public LCDPlayer () {


### PR DESCRIPTION
It seems semantics changed slightly.

Cleaned up Makefile for consistency between packages.

Added PKG_BUILD_PARALLEL for faster compilation.

Fixed license information.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @flyn-org 
Compile tested: ath79

https://downloads.openwrt.org/snapshots/faillogs/arm_mpcore_vfp/packages/lcdgrilo/compile.txt