### PR TITLE
lcdproc: Fix libftdi include path

### DIFF
--- a/utils/lcdproc/Makefile
+++ b/utils/lcdproc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lcdproc
 PKG_VERSION:=0.5.9
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lcdproc/lcdproc/releases/download/v$(PKG_VERSION)/

--- a/utils/lcdproc/patches/120-libftdi-include.patch
+++ b/utils/lcdproc/patches/120-libftdi-include.patch
@@ -1,0 +1,44 @@
+--- a/server/drivers/hd44780-low.h
++++ b/server/drivers/hd44780-low.h
+@@ -26,7 +26,7 @@
+ #endif
+ 
+ #ifdef HAVE_LIBFTDI
+-# include <ftdi.h>
++# include <libftdi1/ftdi.h>
+ #endif
+ 
+ #include "i2c.h"
+--- a/server/drivers/i2500vfd.c
++++ b/server/drivers/i2500vfd.c
+@@ -32,7 +32,7 @@
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <string.h>
+-#include <ftdi.h>
++#include <libftdi1/ftdi.h>
+ 
+ #include "lcd.h"
+ #include "i2500vfd.h"
+--- a/server/drivers/lis.c
++++ b/server/drivers/lis.c
+@@ -41,7 +41,7 @@
+ #include <errno.h>
+ #include <pthread.h>
+ 
+-#include <ftdi.h>
++#include <libftdi1/ftdi.h>
+ 
+ #include "lcd.h"
+ #include "lis.h"
+--- a/server/drivers/ula200.c
++++ b/server/drivers/ula200.c
+@@ -30,7 +30,7 @@
+ #include <string.h>
+ #include <errno.h>
+ 
+-#include <ftdi.h>
++#include <libftdi1/ftdi.h>
+ 
+ #include "lcd.h"
+ #include "ula200.h"


### PR DESCRIPTION
The CMake conversion of the latter changed the path.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @haraldg @pprindeville 
Compile tested: ath79

https://downloads.openwrt.org/snapshots/faillogs/arm_mpcore_vfp/packages/lcdproc/compile.txt