### PR TITLE
adblock: update 3.8.6

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.8.5
-PKG_RELEASE:=2
+PKG_VERSION:=3.8.6
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -106,7 +106,7 @@ status()
 
 service_triggers()
 {
-	local trigger="$(uci_get adblock global adb_trigger)" 
+	local trigger="$(uci_get adblock global adb_trigger)"
 	local delay="$(uci_get adblock extra adb_triggerdelay "2")"
 
 	PROCD_RELOAD_DELAY=$((delay*1000))


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL.iNet GL-AR750S, OpenWrt SNAPSHOT r11009-1cf2495d48

Description:
* refine stop logic to prevent needless dns backend restarts and other oddities
* cosmetics

Signed-off-by: Dirk Brenken <dev@brenken.org>