### PR TITLE
Bigclown version bump

### DIFF
--- a/utils/bigclown/bigclown-firmware-tool/Makefile
+++ b/utils/bigclown/bigclown-firmware-tool/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bigclown-firmware-tool
-PKG_VERSION:=1.3.0
+PKG_VERSION:=1.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/bigclownlabs/bch-firmware-tool/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2ba459148a5f23773ab14d0f5d5cc381c441d758cb9f23cdbec18b30b07675ab
+PKG_HASH:=076acd25af717fa9cc0ce180e2e863cfce8957d00cc24e982f44c91bae10f956
 PKG_BUILD_DIR:=$(BUILD_DIR)/bch-firmware-tool-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>

--- a/utils/bigclown/bigclown-mqtt2influxdb/Makefile
+++ b/utils/bigclown/bigclown-mqtt2influxdb/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bigclown-mqtt2influxdb
-PKG_VERSION:=1.1.0
+PKG_VERSION:=1.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/bigclownlabs/bch-mqtt2influxdb/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=5be14132311e85215abbfd732fe6cd652522ea0a343ee8ba7abab3ec7578eb99
+PKG_HASH:=60a3ba8a3d76356ed46fbb7bcbedaf439b7edc2dfc2d43232c9250db80c77387
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 PKG_BUILD_DIR:=$(BUILD_DIR)/bch-mqtt2influxdb-$(PKG_VERSION)

--- a/utils/bigclown/bigclown-mqtt2influxdb/files/init
+++ b/utils/bigclown/bigclown-mqtt2influxdb/files/init
@@ -10,8 +10,7 @@ CONF=/etc/bigclown-mqtt2influxdb.yml
 
 start_service() {
 	procd_open_instance
-	procd_set_param respawn 3600 5 5
-	procd_set_param command "$PROG" -c "$CONF"
+	procd_set_param command "$PROG" -d -c "$CONF"
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_close_instance


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia
Run tested:

Description:
This introduces few changes to software itself. They are mostly incremental and fixup releases. Changes are not that long:
* https://github.com/bigclownlabs/bch-mqtt2influxdb/compare/v1.1.0...v1.2.0
* https://github.com/bigclownlabs/bch-firmware-tool/compare/v1.3.0...v1.4.1

The primary change here is usage of new `-d` option in bigclown-mqtt2influxdb service.