### PR TITLE
net/nmap: build ssl variant of nping

### DIFF
--- a/net/nmap/Makefile
+++ b/net/nmap/Makefile
@@ -14,7 +14,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nmap
 PKG_VERSION:=7.70
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Nuno Goncalves <nunojpg@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -74,6 +74,13 @@ $(call Package/nmap/default)
   DEPENDS:=$(NPING_DEPENDS)
   VARIANT:=nossl
   TITLE:=Network packet generation tool / ping utility
+endef
+
+define Package/nping-ssl
+$(call Package/nmap/default)
+  DEPENDS:=$(NPING_DEPENDS) +libopenssl
+  VARIANT:=ssl
+  TITLE:=Network packet generation tool / ping utility (with OpenSSL support)
 endef
 
 define Package/ndiff
@@ -136,10 +143,15 @@ define Package/nping/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nping $(1)/usr/bin/
 endef
 
+define Package/nping-ssl/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nping $(1)/usr/bin/
+endef
 
 $(eval $(call BuildPackage,nmap))
 $(eval $(call BuildPackage,nmap-ssl))
 $(eval $(call BuildPackage,ncat))
 $(eval $(call BuildPackage,ncat-ssl))
 $(eval $(call BuildPackage,nping))
+$(eval $(call BuildPackage,nping-ssl))
 $(eval $(call BuildPackage,ndiff))


### PR DESCRIPTION
nping-ssl can authenticate and protect a --echo-server/--echo-client
session.

Signed-off-by: Henrique de Moraes Holschuh <henrique@nic.br>

Maintainer: Nuno Goncalves <nunojpg@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
Compile tested: ar71xx
Run tested: ar71xx archer-c7-v4, nping --echo-server and nping --echo-client.

Description:
Enables SSL variant of the nping package, to enable echo cilent/server control channel authentication/protection.