### PR TITLE
dtc: Add missing dependency to -utils

### DIFF
--- a/libs/dtc/Makefile
+++ b/libs/dtc/Makefile
@@ -46,6 +46,7 @@ define Package/fdt-utils
   CATEGORY:=Utilities
   TITLE:=Flat Device Tree Utilities
   URL:=https://git.kernel.org/pub/scm/utils/dtc/dtc.git
+  DEPENDS:=+libfdt
 endef
 
 define Package/fdt-utils/install


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @yousong 

https://downloads.openwrt.org/snapshots/faillogs/mips64_octeonplus/packages/dtc/compile.txt