### PR TITLE
libuv: update to 1.32.0

### DIFF
--- a/libs/libuv/Makefile
+++ b/libs/libuv/Makefile
@@ -8,31 +8,33 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuv
-PKG_VERSION:=1.29.1
+PKG_VERSION:=1.32.0
 PKG_RELEASE:=1
-
-PKG_LICENSE_FILES:=LICENSE
-
-PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://dist.libuv.org/dist/v$(PKG_VERSION)/
-PKG_HASH:=1486043da5ccaf86d451a5fe93920c5b66770b132d92b6d0a15d636346ca570c
-
+PKG_HASH:=203927683d53d1b82eee766c8ffecfa8ed0e392679c15d5ad3a23504eda0ed1f
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
+
+PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:libuv_project:libuv
+
+CMAKE_INSTALL:=1
+CMAKE_BINARY_SUBDIR:=out/cmake
 PKG_BUILD_PARALLEL:=1
 
-PKG_INSTALL:=1
-PKG_FIXUP:=autoreconf
-
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/libuv
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Cross-platform asychronous I/O library
-  URL:=https://github.com/libuv/libuv
+  URL:=https://libuv.org/
   DEPENDS:=+libpthread +librt
+  ABI_VERSION:=1
 endef
 
 define Package/libuv/description
@@ -41,36 +43,17 @@ define Package/libuv/description
  pyuv, and others.
 endef
 
-define Build/Configure
-	( cd $(PKG_BUILD_DIR); ./autogen.sh )
-	$(call Build/Configure/Default)
-endef
+CMAKE_OPTIONS += -DBUILD_TESTING=OFF
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include/
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/include/* \
-		$(1)/usr/include/
-
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/libuv.so* \
-		$(1)/usr/lib/
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/libuv.a \
-		$(1)/usr/lib/
-
-	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libuv.pc \
-		$(1)/usr/lib/pkgconfig/
+	$(call Build/InstallDev/cmake,$(1))
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libuv.pc
+	$(SED) 's,/usr/lib,$$$${prefix}/lib,g' $(1)/usr/lib/pkgconfig/libuv.pc
 endef
 
 define Package/libuv/install
 	$(INSTALL_DIR) $(1)/usr/lib/
-	$(CP) \
-		$(PKG_INSTALL_DIR)/usr/lib/libuv.so* \
-		$(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libuv.so* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libuv))


### PR DESCRIPTION
Maintainer: @ratkaj 
Compile tested: head r11001-ce6311d3, mipsel 
Run tested: mipsel

Description:
update to 1.32.0

Update is required to build the latest node.js v12.x.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>