### PR TITLE
[19.07] adblock: update 3.8.6

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,9 +6,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.8.5
+PKG_VERSION:=3.8.6
 PKG_RELEASE:=1
-PKG_LICENSE:=GPL-3.0+
+PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -106,7 +106,7 @@ status()
 
 service_triggers()
 {
-	local trigger="$(uci_get adblock global adb_trigger)" 
+	local trigger="$(uci_get adblock global adb_trigger)"
 	local delay="$(uci_get adblock extra adb_triggerdelay "2")"
 
 	PROCD_RELOAD_DELAY=$((delay*1000))


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL-AR750S, OpenWrt SNAPSHOT r11029-bc5db7364d

Description:
* refine stop logic to prevent needless dns backend restarts
  and other oddities
* cosmetics

Signed-off-by: Dirk Brenken <dev@brenken.org>


