### PR TITLE
forked-daapd: Fix compilation with newer alsa-libs

### DIFF
--- a/sound/forked-daapd/Makefile
+++ b/sound/forked-daapd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=forked-daapd
 PKG_VERSION:=26.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ejurgensen/$(PKG_NAME)/releases/download/$(PKG_VERSION)/

--- a/sound/forked-daapd/patches/010-alsa.patch
+++ b/sound/forked-daapd/patches/010-alsa.patch
@@ -1,0 +1,36 @@
+From 20f5118f7505e2e82be3504624ac934b8837d25b Mon Sep 17 00:00:00 2001
+From: Scott Shambarger <devel@shambarger.net>
+Date: Tue, 11 Jun 2019 20:10:04 -0700
+Subject: [PATCH] [alsa] asoundlib.h should be alsa/asoundlib.h
+
+---
+ configure.ac       | 2 +-
+ src/outputs/alsa.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 9ec5eb101..98068bf11 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -238,7 +238,7 @@ AC_CHECK_SIZEOF([void *])
+ dnl --- Begin configuring the options ---
+ dnl ALSA
+ FORK_ARG_WITH_CHECK([FORKED_OPTS], [ALSA support], [alsa], [ALSA],
+-	[alsa], [snd_mixer_open], [asoundlib.h])
++	[alsa], [snd_mixer_open], [alsa/asoundlib.h])
+ AM_CONDITIONAL([COND_ALSA], [[test "x$with_alsa" = "xyes"]])
+ 
+ dnl PULSEAUDIO
+diff --git a/src/outputs/alsa.c b/src/outputs/alsa.c
+index b696f0c3d..1a32aad19 100644
+--- a/src/outputs/alsa.c
++++ b/src/outputs/alsa.c
+@@ -30,7 +30,7 @@
+ #include <inttypes.h>
+ 
+ #include <event2/event.h>
+-#include <asoundlib.h>
++#include <alsa/asoundlib.h>
+ 
+ #include "misc.h"
+ #include "conffile.h"


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ejurgensen 
Compile tested: ath79

patch is an upstream backport.