### PR TITLE
pulseaudio: Backport upstream patch

### DIFF
--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pulseaudio
 PKG_VERSION:=12.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://freedesktop.org/software/pulseaudio/releases/
@@ -117,6 +117,7 @@ CONFIGURE_ARGS += \
 	--disable-jack \
 	--disable-asyncns \
 	--disable-lirc \
+	--disable-tests \
 	--disable-udev \
 	--without-fftw \
 	--without-soxr \

--- a/sound/pulseaudio/patches/010-also-include.patch
+++ b/sound/pulseaudio/patches/010-also-include.patch
@@ -1,0 +1,130 @@
+From 993d3fd89e5611997f1e165bf03edefb0204b0a4 Mon Sep 17 00:00:00 2001
+From: Olaf Hering <olaf@aepfle.de>
+Date: Wed, 27 Mar 2019 09:35:05 +0100
+Subject: [PATCH] alsa: Use correct header path
+
+Consumers are expected to use <alsa/asoundlib.h> instead of
+<asoundlib.h>.
+
+This is in preparation of an change to pkgconfig(alsa) to
+not pollute CFLAGS with -I/usr/include/alsa anymore.
+
+Signed-off-by: Olaf Hering <olaf@aepfle.de>
+---
+ src/modules/alsa/alsa-mixer.c         | 2 +-
+ src/modules/alsa/alsa-mixer.h         | 2 +-
+ src/modules/alsa/alsa-sink.c          | 2 +-
+ src/modules/alsa/alsa-source.c        | 2 +-
+ src/modules/alsa/alsa-ucm.c           | 2 +-
+ src/modules/alsa/alsa-util.c          | 2 +-
+ src/modules/alsa/alsa-util.h          | 2 +-
+ src/modules/alsa/module-alsa-source.c | 2 +-
+ 8 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/src/modules/alsa/alsa-mixer.c b/src/modules/alsa/alsa-mixer.c
+index 5cb99c8fd..cd99a75f8 100644
+--- a/src/modules/alsa/alsa-mixer.c
++++ b/src/modules/alsa/alsa-mixer.c
+@@ -23,7 +23,7 @@
+ #endif
+ 
+ #include <sys/types.h>
+-#include <asoundlib.h>
++#include <alsa/asoundlib.h>
+ #include <math.h>
+ 
+ #ifdef HAVE_VALGRIND_MEMCHECK_H
+diff --git a/src/modules/alsa/alsa-mixer.h b/src/modules/alsa/alsa-mixer.h
+index 3ea4d7329..65b071165 100644
+--- a/src/modules/alsa/alsa-mixer.h
++++ b/src/modules/alsa/alsa-mixer.h
+@@ -21,7 +21,7 @@
+   along with PulseAudio; if not, see <http://www.gnu.org/licenses/>.
+ ***/
+ 
+-#include <asoundlib.h>
++#include <alsa/asoundlib.h>
+ 
+ #include <pulse/sample.h>
+ #include <pulse/mainloop-api.h>
+diff --git a/src/modules/alsa/alsa-sink.c b/src/modules/alsa/alsa-sink.c
+index 28143402a..4b46708ce 100644
+--- a/src/modules/alsa/alsa-sink.c
++++ b/src/modules/alsa/alsa-sink.c
+@@ -25,7 +25,7 @@
+ #include <signal.h>
+ #include <stdio.h>
+ 
+-#include <asoundlib.h>
++#include <alsa/asoundlib.h>
+ 
+ #ifdef HAVE_VALGRIND_MEMCHECK_H
+ #include <valgrind/memcheck.h>
+diff --git a/src/modules/alsa/alsa-source.c b/src/modules/alsa/alsa-source.c
+index 8129220b0..c8bf649e1 100644
+--- a/src/modules/alsa/alsa-source.c
++++ b/src/modules/alsa/alsa-source.c
+@@ -25,7 +25,7 @@
+ #include <signal.h>
+ #include <stdio.h>
+ 
+-#include <asoundlib.h>
++#include <alsa/asoundlib.h>
+ 
+ #include <pulse/rtclock.h>
+ #include <pulse/timeval.h>
+diff --git a/src/modules/alsa/alsa-ucm.c b/src/modules/alsa/alsa-ucm.c
+index 341c8012e..0a40ca8fe 100644
+--- a/src/modules/alsa/alsa-ucm.c
++++ b/src/modules/alsa/alsa-ucm.c
+@@ -27,7 +27,7 @@
+ #include <ctype.h>
+ #include <sys/types.h>
+ #include <limits.h>
+-#include <asoundlib.h>
++#include <alsa/asoundlib.h>
+ 
+ #ifdef HAVE_VALGRIND_MEMCHECK_H
+ #include <valgrind/memcheck.h>
+diff --git a/src/modules/alsa/alsa-util.c b/src/modules/alsa/alsa-util.c
+index e8d712e72..bd0a47e50 100644
+--- a/src/modules/alsa/alsa-util.c
++++ b/src/modules/alsa/alsa-util.c
+@@ -23,7 +23,7 @@
+ #endif
+ 
+ #include <sys/types.h>
+-#include <asoundlib.h>
++#include <alsa/asoundlib.h>
+ 
+ #include <pulse/sample.h>
+ #include <pulse/xmalloc.h>
+diff --git a/src/modules/alsa/alsa-util.h b/src/modules/alsa/alsa-util.h
+index 6b27339ec..4ceaa06ee 100644
+--- a/src/modules/alsa/alsa-util.h
++++ b/src/modules/alsa/alsa-util.h
+@@ -21,7 +21,7 @@
+   along with PulseAudio; if not, see <http://www.gnu.org/licenses/>.
+ ***/
+ 
+-#include <asoundlib.h>
++#include <alsa/asoundlib.h>
+ 
+ #include <pulse/sample.h>
+ #include <pulse/channelmap.h>
+diff --git a/src/modules/alsa/module-alsa-source.c b/src/modules/alsa/module-alsa-source.c
+index af6800dd2..747ba9342 100644
+--- a/src/modules/alsa/module-alsa-source.c
++++ b/src/modules/alsa/module-alsa-source.c
+@@ -24,7 +24,7 @@
+ 
+ #include <stdio.h>
+ 
+-#include <asoundlib.h>
++#include <alsa/asoundlib.h>
+ 
+ #ifdef HAVE_VALGRIND_MEMCHECK_H
+ #include <valgrind/memcheck.h>
+-- 
+2.22.0
+


### PR DESCRIPTION
Fixes compilation with recent alsa-libs.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: ath79