### PR TITLE
irssi: update to version 1.2.2 (security fix)

### DIFF
--- a/net/irssi/Makefile
+++ b/net/irssi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=irssi
-PKG_VERSION:=1.2.1
+PKG_VERSION:=1.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/irssi/irssi/releases/download/1.2.1/
-PKG_HASH:=5466a1ed9612cfa707d9a37d60b29d027b4ac7d83c74ceb1a410e2b59edba92c
+PKG_SOURCE_URL:=https://github.com/irssi/irssi/releases/download/$(PKG_VERSION)/
+PKG_HASH:=6727060c918568ba2ff4295ad736128dba0b995d7b20491bca11f593bd857578
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates irssi to version 1.2.2 to fix CVE-2019-15717 (https://irssi.org/security/html/irssi_sa_2019_08/)

Changelog for new version https://irssi.org/NEWS/#v1-2-2

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>