### PR TITLE
pdns: Explicitly define lua implementation

### DIFF
--- a/net/pdns/Makefile
+++ b/net/pdns/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns
 PKG_VERSION:=4.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
@@ -175,6 +175,7 @@ CONFIGURE_ARGS+= \
 	--sysconfdir=/etc/powerdns \
 	--libdir=/usr/lib/powerdns  \
 	--with-dynmodules="$(foreach backend,$(PDNS_BACKENDS),$(if $(CONFIG_PACKAGE_pdns-backend-$(backend)),$(PDNS_BACKEND_$(backend)_LIB),))" \
+	--with-lua="lua" \
 	--with-modules="bind random" \
 	--with-mysql-lib=$(STAGING_DIR)/usr \
 	--with-mysql-includes=$(STAGING_DIR)/usr \


### PR DESCRIPTION
Maintainer: me

Compile Tested: yes, selects lua as implementation and doesn't pick up luajit
Run Tested: no, minor change

Description:
On some architectures PowerDNS was preferring Luajit over Lua, which wasn't added
as a dependency. On previous versions this was controlled by passing `--with-lua`
and `--without-luajit` however the latter isn't functional anymore.

On the 4.2 series, it is instead possible to define the lua implementation to be
used by passing `--with-lua=[implementation]` ie `--with-lua=lua`

Signed-off-by: James Taylor <james@jtaylor.id.au>

Fixes: #10006 