### PR TITLE
django: Update to 1.11.24

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,20 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=1.11.17
-PKG_RELEASE=4
+PKG_VERSION:=1.11.24
+PKG_RELEASE:=1
 
 PKG_SOURCE:=Django-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/D/Django
-PKG_HASH:=a787ee66f4b4cf8ed753661cabcec603989677fa3a107fcb7f15511a44bdb483
-PKG_BUILD_DIR=$(BUILD_DIR)/Django-$(PKG_VERSION)
+PKG_HASH:=215c27453f775b6b1add83a185f76c2e2ab711d17786a6704bd62eabd93f89e3
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-django-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE LICENSE.python
 PKG_CPE_ID:=cpe:/a:djangoproject:django
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-django-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk


### PR DESCRIPTION
Fixes a whole bunchs of CVEs:

CVE-2019-3498
CVE-2019-6975
CVE-2019-12308
CVE-2019-12781
CVE-2019-14232
CVE-2019-14233
CVE-2019-14234
CVE-2019-14235

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @commodo 

I'm guessing the double PKG_BUILD_DIR is a bug?