### PR TITLE
lshw: Add a new package

### DIFF
--- a/utils/lshw/Makefile
+++ b/utils/lshw/Makefile
@@ -1,0 +1,36 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=lshw
+PKG_VERSION:=B.02.18
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://www.ezix.org/software/files/
+PKG_HASH:=ae22ef11c934364be4fd2a0a1a7aadf4495a0251ec6979da280d342a89ca3c2f
+
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/lshw
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=HardWare LiSter
+  URL:=https://ezix.org/project/wiki/HardwareLiSter
+  DEPENDS:=+libstdcpp
+endef
+
+define Package/lshw/description
+  lshw is a small tool to provide detailed information on the hardware configuration of the machine.
+  It can report exact memory configuration, firmware version, mainboard configuration, CPU version and speed,
+  cache configuration, bus speed, etc.
+endef
+
+define Package/lshw/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_BUILD_DIR)/src/lshw $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,lshw))

--- a/utils/lshw/patches/0001-sysfs-Fix-basename-build-with-musl.patch
+++ b/utils/lshw/patches/0001-sysfs-Fix-basename-build-with-musl.patch
@@ -1,0 +1,87 @@
+From c0170103e5c15a77575cc1aa65ef1b393733dd0e Mon Sep 17 00:00:00 2001
+From: Krzysztof Kozlowski <krzk@kernel.org>
+Date: Wed, 6 Jun 2018 12:47:02 +0200
+Subject: [PATCH] sysfs: Fix basename() build with musl
+
+musl provides only standard basename() which accepts non-const string.
+This fixes build error with musl C library:
+
+    | sysfs.cc: In function 'std::__cxx11::string sysfs_getbustype(const string&)':
+    | sysfs.cc:102:21: error: 'basename' was not declared in this scope
+    |        "/devices/" + basename(path.c_str());
+    |                      ^~~~~~~~
+
+Signed-off-by: Krzysztof Kozlowski <krzk@kernel.org>
+
+Github PR: https://github.com/lyonel/lshw/pull/38
+
+---
+ src/core/dasd.cc  | 3 ++-
+ src/core/sysfs.cc | 9 +++++----
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+--- a/src/core/dasd.cc
++++ b/src/core/dasd.cc
+@@ -2,6 +2,7 @@
+ #include "osutils.h"
+ #include "dasd.h"
+ #include <glob.h>
++#include <libgen.h>
+ #include <string.h>
+ #include <fcntl.h>
+ #include <unistd.h>
+@@ -42,7 +43,7 @@ bool scan_dasd(hwNode & n)
+   {
+     for(dev_num=0;dev_num<devices.gl_pathc;dev_num++)
+     {
+-      dev_name = basename(devices.gl_pathv[dev_num]);
++      dev_name = basename(const_cast<char *>(devices.gl_pathv[dev_num]));
+       for (std::vector<std::string>::iterator it = sysfs_attribs.begin(); it != sysfs_attribs.end(); ++it)
+       {
+         std::string attrib_fname = std::string(SYSFS_PREFIX) + dev_name + "/device/" + *it;
+--- a/src/core/sysfs.cc
++++ b/src/core/sysfs.cc
+@@ -7,6 +7,7 @@
+ #include "version.h"
+ #include "sysfs.h"
+ #include "osutils.h"
++#include <libgen.h>
+ #include <limits.h>
+ #include <unistd.h>
+ #include <stdlib.h>
+@@ -99,7 +100,7 @@ static string sysfs_getbustype(const str
+   {
+     devname =
+       string(fs.path + "/bus/") + string(namelist[i]->d_name) +
+-      "/devices/" + basename(path.c_str());
++      "/devices/" + basename(const_cast<char *>(path.c_str()));
+ 
+     if (samefile(devname, path))
+       return string(namelist[i]->d_name);
+@@ -139,7 +140,7 @@ static string sysfstobusinfo(const strin
+ 
+   if (bustype == "virtio")
+   {
+-    string name = basename(path.c_str());
++    string name = basename(const_cast<char *>(path.c_str()));
+     if (name.compare(0, 6, "virtio") == 0)
+       return "virtio@" + name.substr(6);
+     else
+@@ -207,7 +208,7 @@ string entry::driver() const
+   string driverlink = This->devpath + "/driver";
+   if (!exists(driverlink))
+     return "";
+-  return basename(readlink(driverlink).c_str());
++  return basename(const_cast<char *>(readlink(driverlink).c_str()));
+ }
+ 
+ 
+@@ -288,7 +289,7 @@ string entry::name_in_class(const string
+ 
+ string entry::name() const
+ {
+-  return basename(This->devpath.c_str());
++  return basename(const_cast<char *>(This->devpath.c_str()));
+ }
+ 
+ 

--- a/utils/lshw/patches/0002-add-json-option-in-help-output.patch
+++ b/utils/lshw/patches/0002-add-json-option-in-help-output.patch
@@ -1,0 +1,25 @@
+From 503c76a35a9e97a098af7c1ac793a7e13c07ce70 Mon Sep 17 00:00:00 2001
+From: Chandni Verma <chandni@linux.vnet.ibm.com>
+Date: Thu, 8 Sep 2016 14:29:08 +0530
+Subject: [PATCH] Adding -json option in -help output
+
+-json works perfectly and is a recognized lshw option already.
+It was only missed in printing. Nothing more needs to be done.
+
+Signed-off-by: Chandni Verma <chandni@linux.vnet.ibm.com>
+
+Github PR: https://github.com/lyonel/lshw/pull/20
+---
+ src/lshw.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/src/lshw.cc
++++ b/src/lshw.cc
+@@ -28,6 +28,7 @@ void usage(const char *progname)
+   fprintf(stderr, _("\nformat can be\n"));
+   fprintf(stderr, _("\t-html           output hardware tree as HTML\n"));
+   fprintf(stderr, _("\t-xml            output hardware tree as XML\n"));
++  fprintf(stderr, _("\t-json           output hardware tree as a JSON object\n"));
+   fprintf(stderr, _("\t-short          output hardware paths\n"));
+   fprintf(stderr, _("\t-businfo        output bus information\n"));
+   if(getenv("DISPLAY") && exists(SBINDIR"/gtk-lshw"))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master and Turris MOX, cortexa53, OpenWrt 19.07
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master and Turris MOX, cortexa53, OpenWrt 19.07

Description:

- Add [lshw](https://ezix.org/project/wiki/HardwareLiSter) package

> lshw (Hardware Lister) is a small tool to provide detailed information on the hardware configuration of the machine. It can report exact memory configuration, firmware version, mainboard configuration, CPU version and speed, cache configuration, bus speed, etc.

Two patches are included. One of them is required and the second one is nice to have.
In all of them in commit message, I included URLs for pull request.