### PR TITLE
travelmate: add support for optional args in auto-login script

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.4.12
+PKG_VERSION:=1.4.13
 PKG_RELEASE:=2
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/generic-user-pass.login
+++ b/net/travelmate/files/generic-user-pass.login
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+cmd="$(command -v curl)"
+url="http://example.com/"
+success_string="Thank you!"
+
+if [ ! -x "${cmd}" ]
+then
+	exit 1
+fi
+
+
+response="$("${cmd}" $url -d "password=$2&pwd=$2&username=$1" \
+	--header "Content-Type:application/x-www-form-urlencoded" -s)"
+
+if echo "${response}" | grep -q "${success_string}";
+then
+	exit 0
+else
+	exit 2
+fi

--- a/net/travelmate/files/travelmate.sh
+++ b/net/travelmate/files/travelmate.sh
@@ -13,7 +13,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-trm_ver="1.4.12"
+trm_ver="1.4.13"
 trm_enabled=0
 trm_debug=0
 trm_iface="trm_wwan"
@@ -185,7 +185,7 @@ f_net()
 #
 f_check()
 {
-	local IFS ifname radio dev_status config sta_essid sta_bssid result uci_essid uci_bssid login_command wait_time mode="${1}" status="${2:-"false"}" cp_domain="${3:-"false"}"
+	local IFS ifname radio dev_status config sta_essid sta_bssid result uci_essid uci_bssid login_command login_command_args wait_time mode="${1}" status="${2:-"false"}" cp_domain="${3:-"false"}"
 
 	if [ "${mode}" != "initial" ] && [ "${status}" = "false" ]
 	then
@@ -293,9 +293,10 @@ f_check()
 								login_command="$(uci_get "travelmate" "${uci_essid}${uci_bssid}" "command")"
 								if [ -x "${login_command}" ]
 								then
-									"${login_command}" >/dev/null 2>&1
+									login_command_args="$(uci_get "travelmate" "${uci_essid}${uci_bssid}" "command_args")"
+									"${login_command}" ${login_command_args} >/dev/null 2>&1
 									rc=${?}
-									f_log "info" "captive portal login '${login_command:0:40}' for '${cp_domain}' has been executed with rc '${rc}'"
+									f_log "info" "captive portal login '${login_command:0:40} ${login_command_args}' for '${cp_domain}' has been executed with rc '${rc}'"
 									if [ "${rc}" -eq 0 ]
 									then
 										result="$(f_net)"


### PR DESCRIPTION
Maintainer: @dibdot 
Compile tested: /
Run tested: QCA9533, GL.iNet GL-AR300M (NAND), OpenWrt SNAPSHOT r10759+12-b133e466b0 / LuCI Master (git-19.261.22678-982b08f) , Tested editing existing connections and adding new ones with a login script with additional arguments

Description: This can be helpful for example in hotels where you need to
enter a new user/password combination every week. Another PR will be opened in luci.
