### PR TITLE
prometheus-node-exporter-lua: ltq-dsl.lua: use errors_fecs_*

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2019.08.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/ltq-dsl.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/ltq-dsl.lua
@@ -79,8 +79,8 @@ local function scrape()
   dsl_max_datarate({direction="up"}, dsl_stat.max_data_rate_up)
 
   -- dsl errors
-  dsl_error_seconds_total({err="forward error correction",loc="near"}, dsl_stat.errors_fec_near)
-  dsl_error_seconds_total({err="forward error correction",loc="far"}, dsl_stat.errors_fec_far)
+  dsl_error_seconds_total({err="forward error correction",loc="near"}, dsl_stat.errors_fecs_near)
+  dsl_error_seconds_total({err="forward error correction",loc="far"}, dsl_stat.errors_fecs_far)
   dsl_error_seconds_total({err="errored",loc="near"}, dsl_stat.errors_es_near)
   dsl_error_seconds_total({err="errored",loc="far"}, dsl_stat.errors_es_near)
   dsl_error_seconds_total({err="severely errored",loc="near"}, dsl_stat.errors_ses_near)


### PR DESCRIPTION
This is part of the FECS counter fix and related to openwrt/openwrt#2357