### PR TITLE
isc-dhcp: fix confused isc-dhcp-relay-ipv4 description

### DIFF
--- a/net/isc-dhcp/Makefile
+++ b/net/isc-dhcp/Makefile
@@ -60,7 +60,7 @@ define Package/isc-dhcp-relay/description
 endef
 
 define Package/isc-dhcp-relay-ipv4/description
-$(call Package/isc-dhcp-relay-ipv6/description)
+$(call Package/isc-dhcp-relay/description)
  This package is compiled with IPv4 support only.
 endef
 


### PR DESCRIPTION
Maintainer: @pprindeville 
Compile tested: mvebu (cortex-a9), WRT3200ACM, OpenWrt Master
Run tested: mvebu (cortex-a9), WRT3200ACM, OpenWrt Master

Description:
change confused isc-dhcp-relay-ipv4 description
Before:```provides a means for relaying DHCP and BOOTP requests from a subnet to which no DHCP server is directly connected to one or more DHCP servers on other subnets. This package is compiled with IPv4 and IPv6 support. This package is compiled with IPv4 support only.```
After:```provides a means for relaying DHCP and BOOTP requests from a subnet to which no DHCP server is directly connected to one or more DHCP servers on other subnets. This package is compiled with IPv4 support only.```