### PR TITLE
avro: Replace PKG_INSTALL with CMAKE_INSTALL

### DIFF
--- a/libs/avro/Makefile
+++ b/libs/avro/Makefile
@@ -9,19 +9,18 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avro-c
 PKG_VERSION:=1.8.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@APACHE/avro/avro-$(PKG_VERSION)/c
 PKG_HASH:=4639982b2b8fbd91fc7128fef672207129c959bb7900dd64b077ce4206edf10e
 
 PKG_MAINTAINER:=John Clark <inindev@gmail.com>
-
-PKG_INSTALL:=1
-PKG_BUILD_PARALLEL:=1
-
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
+
+CMAKE_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -36,15 +35,6 @@ endef
 
 define Package/avro-c/description
   This package contains the Apache Avro C library.
-endef
-
-CMAKE_OPTIONS += \
-        -DCMAKE_BUILD_TYPE:STRING=MINSIZEREL
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/{lib,include}
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libavro.{a,so*} $(1)/usr/lib/
 endef
 
 define Package/avro-c/install

--- a/libs/avro/patches/010-pkgconfig.patch
+++ b/libs/avro/patches/010-pkgconfig.patch
@@ -1,0 +1,30 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -121,9 +121,8 @@ endif(WIN32)
+ 
+ # Install pkg-config file
+ 
+-set(prefix ${CMAKE_INSTALL_PREFIX})
+ set(VERSION ${AVRO_VERSION})
+-configure_file(avro-c.pc.in avro-c.pc)
++configure_file(avro-c.pc.in avro-c.pc @ONLY)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/avro-c.pc
+         DESTINATION lib/pkgconfig)
+ 
+--- a/src/avro-c.pc.in
++++ b/src/avro-c.pc.in
+@@ -1,7 +1,12 @@
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=@CMAKE_INSTALL_PREFIX@
++libdir=${exec_prefix}/lib
++includedir=${prefix}/include
++
+ Name: avro-c
+ Description: C library for parsing Avro data
+ Version: @VERSION@
+ URL: http://avro.apache.org/
+-Libs: -L@prefix@/lib -lavro
+-Cflags: -I@prefix@/include
++Libs: -L${libdir} -lavro
++Cflags: -I${includedir}
+ Requires: @CODEC_PKG@


### PR DESCRIPTION
Allows removal of the InstallDev section as it's now implicit.

PKG_INSTALL is already defined in cmake.mk

This also installs a pkgconfig file. Added a patch to fix it up.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @inindev 
Compile tested: ath79