### PR TITLE
libsoxr: Fix pkgconfig files

### DIFF
--- a/libs/libsoxr/Makefile
+++ b/libs/libsoxr/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsoxr
 PKG_VERSION:=0.1.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=@SF/project/soxr/
 PKG_SOURCE:=soxr-$(PKG_VERSION)-Source.tar.xz
@@ -17,13 +17,12 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/soxr-$(PKG_VERSION)-Source
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Mike Brady <mikebrady@eircom.net>
-
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=LICENCE
 PKG_CPE_ID:=cpe:/a:sox:sox
 
+CMAKE_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -32,7 +31,7 @@ define Package/libsoxr
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=The SoX Resampler library
-  URL:=http://sourceforge.net/projects/soxr/
+  URL:=https://sourceforge.net/projects/soxr/
   DEPENDS:= +libpthread
 endef
 
@@ -44,14 +43,6 @@ endef
 CMAKE_OPTIONS:= -DBUILD_TESTS=0 -DBUILD_EXAMPLES=0
 CMAKE_OPTIONS+= -DHAVE_WORDS_BIGENDIAN_EXITCODE=$(if $(CONFIG_BIG_ENDIAN),0,1)
 CMAKE_OPTIONS+= -DWITH_OPENMP=0
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/soxr.h $(1)/usr/include/
-	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsoxr.so* $(1)/usr/lib/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/soxr.pc $(1)/usr/lib/pkgconfig/
-endef
 
 define Package/libsoxr/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/libsoxr/patches/020-pkgconfig.patch
+++ b/libs/libsoxr/patches/020-pkgconfig.patch
@@ -1,0 +1,56 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -88,7 +88,7 @@ if (BUILD_FRAMEWORK)
+   set_target_properties (${PROJECT_NAME} PROPERTIES FRAMEWORK TRUE)
+ elseif (NOT WIN32)
+   set (TARGET_PCS ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc)
+-  configure_file (${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.pc.in ${TARGET_PCS})
++  configure_file (${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.pc.in ${TARGET_PCS} @ONLY)
+   install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+ endif ()
+ 
+@@ -112,7 +112,7 @@ if (WITH_LSR_BINDINGS)
+     set_target_properties (${LSR} PROPERTIES FRAMEWORK TRUE)
+   elseif (NOT WIN32)
+     set (TARGET_PCS "${TARGET_PCS} ${CMAKE_CURRENT_BINARY_DIR}/${LSR}.pc")
+-    configure_file (${CMAKE_CURRENT_SOURCE_DIR}/${LSR}.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${LSR}.pc)
++    configure_file (${CMAKE_CURRENT_SOURCE_DIR}/${LSR}.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${LSR}.pc @ONLY)
+     install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${LSR}.pc DESTINATION ${LIB_INSTALL_DIR}/pkgconfig)
+   endif ()
+ endif ()
+--- a/src/soxr-lsr.pc.in
++++ b/src/soxr-lsr.pc.in
+@@ -1,5 +1,10 @@
+-Name: ${LSR}
+-Description: ${DESCRIPTION_SUMMARY} (with libsamplerate-like bindings)
+-Version: ${PROJECT_VERSION}
+-Libs: -L${LIB_INSTALL_DIR} -l${LSR}
+-Cflags: -I${INCLUDE_INSTALL_DIR}
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=@CMAKE_INSTALL_PREFIX@
++libdir=${exec_prefix}/lib
++includedir=${prefix}/include
++
++Name: @LSR@
++Description: @DESCRIPTION_SUMMARY@ (with libsamplerate-like bindings)
++Version: @PROJECT_VERSION@
++Libs: -L${libdir} -l@LSR@
++Cflags: -I${includedir}
+--- a/src/soxr.pc.in
++++ b/src/soxr.pc.in
+@@ -1,5 +1,10 @@
+-Name: ${PROJECT_NAME}
+-Description: ${DESCRIPTION_SUMMARY}
+-Version: ${PROJECT_VERSION}
+-Libs: -L${LIB_INSTALL_DIR} -l${PROJECT_NAME}
+-Cflags: -I${INCLUDE_INSTALL_DIR}
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=@CMAKE_INSTALL_PREFIX@
++libdir=${exec_prefix}/lib
++includedir=${prefix}/include
++
++Name: @PROJECT_NAME@
++Description: @DESCRIPTION_SUMMARY@
++Version: @PROJECT_VERSION@
++Libs: -L${libdir} -l@PROJECT_NAME@
++Cflags: -I${includedir}


### PR DESCRIPTION
Replaced InstallDev section with CMAKE_INSTALL.

Adjusted all of the paths to be more consistent with other packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess @mikebrady 
Compile tested: ath79
