### PR TITLE
libudev: Clean up Makefile

### DIFF
--- a/libs/libudev-fbsd/Makefile
+++ b/libs/libudev-fbsd/Makefile
@@ -5,21 +5,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libudev-fbsd
-
-PKG_RELEASE:=1
-PKG_VERSION:=20171216
+PKG_SOURCE_DATE:=2017-12-16
 PKG_SOURCE_VERSION:=fa190fdf0b22a41b5f42e3a722f754c08ad7b337
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
-PKG_MIRROR_HASH:=d4638099fd288a293a165304541eb9c01e828bb358a0091caa02c1327c20964b
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/jiixyj/libudev-fbsd.git
+PKG_MIRROR_HASH:=dac2d960191fe970c974f022d008ef3b712ad331e2426a51debd5aa2e208f02b
 
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 
-PKG_INSTALL:=1
+CMAKE_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -32,15 +31,6 @@ define Package/libudev-fbsd
   DEPENDS:=+libevdev
   PROVIDES:=libudev
   CONFLICTS:=libudev eudev udev
-endef
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
-	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/* $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/libudev-fbsd/install


### PR DESCRIPTION
Switch to standard PKG_SOURCE_VERSION/DATE instead of defining PKG_VERSION

Removed PKG_SOURCE. It's implicit.

Replaced IntallDev section with CMAKE_INSTALL.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: ath79