### PR TITLE
boost: Update host libraries

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.71.0
 PKG_SOURCE_VERSION:=1_71_0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/
@@ -130,7 +130,7 @@ define Package/boost/config
 
 	config boost-fiber-exclude
 		bool
-		default y if (TARGET_brcm47xx_generic || TARGET_brcm47xx_legacy || mips32 || mips64 || boost-coroutine-exclude)
+		default y if (TARGET_ar7 || TARGET_brcm47xx_generic || TARGET_brcm47xx_legacy || TARGET_lantiq_ase || TARGET_rb532 || mips32 || mips64 || boost-coroutine-exclude)
 		default n
 
 	menu "Select Boost Options"
@@ -367,7 +367,7 @@ define Host/Compile
 
 	( cd $(HOST_BUILD_DIR) ; \
 		./bootstrap.sh --prefix=$(STAGING_DIR_HOSTPKG) \
-			--with-libraries=atomic,chrono,date_time,filesystem,headers,thread,system ;\
+			--with-libraries=atomic,context,date_time,filesystem,headers,program_options,regex,system,thread ;\
 		./b2 --ignore-site-config install )
 endef
 


### PR DESCRIPTION
It seems newer versions of fbthrift require more libraries.

Also added AR7 and RB532 to fiber exclusion.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ClaymorePT 
Compile tested: ath79

https://github.com/openwrt/packages/blob/master/libs/fbthrift/patches/010-boost.patch
https://downloads.openwrt.org/snapshots/faillogs/mipsel_mips32/packages/boost/compile.txt
https://downloads.openwrt.org/snapshots/faillogs/mips_mips32/packages/boost/compile.txt
https://downloads.openwrt.org/snapshots/faillogs/arm_arm1176jzf-s_vfp/packages/fbthrift/host-compile.txt
