### PR TITLE
treewide: fix service status

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
 PKG_VERSION:=11.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
 PKG_CPE_ID:=cpe:/a:postgresql:postgresql

--- a/libs/postgresql/files/postgresql.init
+++ b/libs/postgresql/files/postgresql.init
@@ -6,9 +6,6 @@ PROG=/usr/bin/postmaster
 
 USE_PROCD=1
 
-EXTRA_COMMANDS="status"
-EXTRA_HELP="        status  Show current status of the PostgreSQL server"
-
 fix_hosts() {
 	# make sure localhost (without a dot) is in /etc/hosts
 	grep -q 'localhost$' /etc/hosts || echo '127.0.0.1 localhost' >> /etc/hosts
@@ -71,7 +68,7 @@ stop_service() {
 	/usr/bin/pg_ctl stop -U postgres -D "${pgdata}" -s
 }
 
-status() {
+status_service() {
 	config_load "postgresql"
 	config_get pgdata config PGDATA
 	/usr/bin/pg_ctl status -U postgres -D "${pgdata}"

--- a/net/apfree-wifidog/Makefile
+++ b/net/apfree-wifidog/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apfree-wifidog
 PKG_VERSION:=3.11.1716
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/liudf0716/apfree_wifidog.git

--- a/net/apfree-wifidog/files/wifidogx.init
+++ b/net/apfree-wifidog/files/wifidogx.init
@@ -280,6 +280,6 @@ start_service() {
 	procd_close_instance
 }
 
-status() {
+status_service() {
 	/usr/bin/wdctlx status
 }

--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.8.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -1028,9 +1028,9 @@ killcache() {
 	return 0
 }
 
-status() {
+status_service() {
 	local status="$(tmpfs get status)" error="$(tmpfs get error)" message="$(tmpfs get message)"
-	if [ -n "$status" ] && [ -n "$message" ]; then 
+	if [ -n "$status" ] && [ -n "$message" ]; then
 		status="${status}: $message"
 	fi
 	[ -n "$status" ] && output "$serviceName $status\\n"

--- a/net/wifidog/Makefile
+++ b/net/wifidog/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifidog
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/wifidog/wifidog-gateway

--- a/net/wifidog/files/wifidog.init
+++ b/net/wifidog/files/wifidog.init
@@ -17,6 +17,6 @@ start_service() {
     procd_close_instance
 }
 
-status() {
+status_service() {
     /usr/bin/wdctl status
 }


### PR DESCRIPTION
Maintainer:  @danwrt, @dibdot, @liudf0716, @mhaas
Compile tested: n/a
Run tested: n/a
Description:

  Fix breaking change introduced in the main tree with a commit
  openwrt/openwrt@7519a36774ca ("base-files,procd: add generic service status") where the
  old service `status` function doesn't work anymore and needs to be
  renamed to `status_service`.
