### PR TITLE
quassel-irssi: refresh patches to avoid fuzz

### DIFF
--- a/net/quassel-irssi/patches/002-use-cc-var.patch
+++ b/net/quassel-irssi/patches/002-use-cc-var.patch
@@ -1,6 +1,6 @@
 --- a/core/Makefile
 +++ b/core/Makefile
-@@ -49,7 +49,7 @@ irssi/network-openssl.o: CFLAGS:=$(IRSSI_CFLAGS)
+@@ -49,7 +49,7 @@ irssi/network-openssl.o: CFLAGS:=$(IRSSI
  quasselc-connector.o: CFLAGS:=$(CFLAGS)
  
  $(TARGET): $(OBJECTS)

--- a/net/quassel-irssi/patches/003-use-pkgconfig-ldflags-quasselc.patch
+++ b/net/quassel-irssi/patches/003-use-pkgconfig-ldflags-quasselc.patch
@@ -8,4 +8,4 @@
 +    LDFLAGS += $(shell pkg-config --libs quasselc)
  endif
  
- CFLAGS+=-std=gnu11 -Wall -Wextra -Werror -g $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations
+ CFLAGS+=-std=gnu11 -Wall -Wextra -g $(IRSSI_CFLAGS) $(QUASSELC_FLAGS) -Wmissing-prototypes -Wmissing-declarations

--- a/net/quassel-irssi/patches/010-Get-compatible-with-potential-irssi-abi-8-and-drop-p.patch
+++ b/net/quassel-irssi/patches/010-Get-compatible-with-potential-irssi-abi-8-and-drop-p.patch
@@ -8,11 +8,9 @@ Subject: [PATCH] Get compatible with potential irssi abi 8, and drop polling
  core/quassel-net.c | 64 ++++++++++++++++++++++++++++++++++++++--------
  2 files changed, 53 insertions(+), 10 deletions(-)
 
-diff --git a/core/Makefile b/core/Makefile
-index c1c65fc..987bd7b 100644
 --- a/core/Makefile
 +++ b/core/Makefile
-@@ -16,7 +16,6 @@ SSL_CFLAGS=$(shell pkg-config --cflags openssl)
+@@ -16,7 +16,6 @@ SSL_CFLAGS=$(shell pkg-config --cflags o
  SSL_LDLAGS=$(shell pkg-config --libs openssl)
  OBJECTS:=quasselc-connector.o quassel-core.o
  OBJECTS+=quassel-net.o quassel-msgs.o quassel-cmds.o
@@ -20,11 +18,9 @@ index c1c65fc..987bd7b 100644
  OBJECTS+=quassel-fe-window.o quassel-fe-level.o quassel-cfg.o
  
  LDFLAGS ?=
-diff --git a/core/quassel-net.c b/core/quassel-net.c
-index 8a6eb55..5db7fe0 100644
 --- a/core/quassel-net.c
 +++ b/core/quassel-net.c
-@@ -132,10 +132,10 @@ static SERVER_REC* quassel_server_init_connect(SERVER_CONNECT_REC* conn) {
+@@ -132,10 +132,10 @@ static SERVER_REC* quassel_server_init_c
  	ret->got = 0;
  	server_connect_ref(SERVER_CONNECT(conn));
  
@@ -37,7 +33,7 @@ index 8a6eb55..5db7fe0 100644
  
  	ret->channels_join = quassel_irssi_channels_join;
  	ret->send_message = quassel_irssi_send_message;
-@@ -161,12 +161,59 @@ void quassel_net_init(CHAT_PROTOCOL_REC* rec) {
+@@ -161,12 +161,59 @@ void quassel_net_init(CHAT_PROTOCOL_REC*
  	signal_add_first("server connected", (SIGNAL_FUNC) sig_connected);
  }
  
@@ -113,6 +109,3 @@ index 8a6eb55..5db7fe0 100644
  }
  
  void quassel_irssi_init_nack(void *arg) {
--- 
-2.17.1
-


### PR DESCRIPTION
Maintainer: @TC01
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: N/A

Description:
```
Applying ./patches/003-use-pkgconfig-ldflags-quasselc.patch using plaintext: 
patching file core/Makefile
Hunk #1 succeeded at 25 with fuzz 1.
```