### PR TITLE
apcupsd: Preset binaries used on target system

### DIFF
--- a/net/apcupsd/Makefile
+++ b/net/apcupsd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apcupsd
 PKG_VERSION:=3.14.14
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0
@@ -40,7 +40,7 @@ define Package/apcupsd-cgi
   URL:=http://www.apcupsd.org/
 endef
 
-CONFIGURE_VARS += SHUTDOWN=/sbin/halt
+CONFIGURE_VARS += SHUTDOWN=/sbin/halt SCRIPTSHELL=/bin/sh WALL=/bin/true APCUPSD_MAIL=/bin/true
 
 define Build/Configure
 	$(CP) $(SCRIPT_DIR)/config.* $(PKG_BUILD_DIR)/autoconf/


### PR DESCRIPTION
Maintainer: @tru7
Compile tested: ipq806x, Netgear R7800, master @ 862510a251d1c4216255d49428796eea69ddbba6
Run tested: N/A

Description:

apcupsd's configure script looks up paths to sh, wall and mail on the
host system, but intends to use them on the target system. OpenWrt
replaces apcupsd's scripts by its own versions, so those paths don't
really matter, however, if the host system doesn't have wall installed,
the build fails. This is the case on Gentoo when util-linux is built
with USE=-tty-helpers (default). Prevent such failures by providing
explicit stub paths to sh, wall and mail to configure script.