### PR TITLE
coova-chilli fixes and improvements

### DIFF
--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coova-chilli
 PKG_VERSION:=1.4
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coova/coova-chilli/tar.gz/$(PKG_VERSION)?

--- a/net/coova-chilli/files/chilli.config
+++ b/net/coova-chilli/files/chilli.config
@@ -16,7 +16,7 @@ config chilli
     #option fg
 
     # Include this flag to include debug information.
-    #option debug 9
+    #option debug 1
 
     # Re-read configuration file at this interval. Will also cause new domain
     # name lookups to be performed. Value is given in seconds.

--- a/net/coova-chilli/files/chilli.init
+++ b/net/coova-chilli/files/chilli.init
@@ -26,15 +26,17 @@ option_cb() {
 			echo "dhcpif=\"$ifname\"" >> "$chilli_conf"
 			;;
 		# boolean settings
-		debug|dhcpbroadcast|nodynip|vlanlocation|locationstopstart|locationcopycalled|\
-		locationimmediateupdate|locationopt82|coanoipcheck|noradallow|proxymacaccept|\
-		proxyonacct|dhcpmacset|dhcpradius|noc2c|eapolenable|uamanydns|uamanyip|uamnatanyip|\
-		nouamsuccess|nowispr1|nowispr2|domaindnslocal|radsec|macauth|macreauth|macauthdeny|\
-		macallowlocal|strictmacauth|strictdhcp|ieee8021q|only8021q|radiusoriginalurl|swapoctets|\
-		statusfilesave|wpaguests|openidauth|papalwaysok|mschapv2|chillixml|acctupdate|dnsparanoia|\
-		seskeepalive|usetap|noarpentries|framedservice|scalewin|redir|injectwispr|redirurl|\
-		routeonetone|nousergardendata|uamgardendata|uamotherdata|withunixipc|uamallowpost|redirssl|\
-		uamuissl|layer3|patricia|redirdnsreq|dhcpnotidle|ipv6|ipv6only)
+		acctupdate|chillixml|coanoipcheck|debug|dhcpbroadcast|dhcpmacset|dhcpnotidle|\
+		dhcpradius|dnsparanoia|domaindnslocal|eapolenable|fg|forgiving|framedservice|\
+		ieee8021q|injectwispr|ipv6|ipv6only|layer3|locationcopycalled|\
+		locationimmediateupdate|locationopt82|locationstopstart|macallowlocal|\
+		macauth|macauthdeny|macreauth|mmapring|mschapv2|noarpentries|noc2c|nochallenge|\
+		nodynip|noradallow|nosystemdns|nouamsuccess|nousergardendata|nowispr1|nowispr2|\
+		only8021q|openidauth|papalwaysok|patricia|postauthproxyssl|proxymacaccept|\
+		proxyonacct|radiusoriginalurl|radsec|redir|redirdnsreq|redirssl|redirurl|reload|\
+		routeonetone|scalewin|seskeepalive|statusfilesave|strictdhcp|strictmacauth|\
+		swapoctets|uamallowpost|uamanydns|uamanyip|uamauthedallowed|uamgardendata|\
+		uamnatanyip|uamotherdata|uamuissl|usetap|vlanlocation|wpaguests)
 			[ "$2" = "true" -o "$2" = "1" ] && echo "$1" >> "$chilli_conf"
 			;;
 		*)

--- a/net/coova-chilli/files/chilli.init
+++ b/net/coova-chilli/files/chilli.init
@@ -9,27 +9,21 @@ service_triggers() {
 }
 
 config_cb() {
-	local chilli_inst="$2"
-	if [ "$chilli_inst" != "" ]; then
-		chilli_conf="/var/run/chilli_${chilli_inst}.conf"
-		if [ -e "$chilli_conf" ]; then
-			rm -f "$chilli_conf"
-		fi
-		eval "start_chilli_$chilli_inst=1"
-	fi
+	chilli_conf="/var/run/chilli_${2}.conf"
+	[ -e "$chilli_conf" ] && rm -f "$chilli_conf"
 }
 
 option_cb() {
 	case "$1" in
+		# ignored/internal settings
+		disabled)
+			;;
 		# UCI settings
 		network)
 			. /lib/functions/network.sh
 			local ifname
 			network_get_device ifname "$2"
 			echo "dhcpif=\"$ifname\"" >> "$chilli_conf"
-			;;
-		disabled)
-			[ "$(config_get_bool "$1")" = "1" ] && eval "start_chilli_$chilli_inst=0"
 			;;
 		# boolean settings
 		debug|dhcpbroadcast|nodynip|vlanlocation|locationstopstart|locationcopycalled|\
@@ -51,13 +45,14 @@ option_cb() {
 
 start_chilli() {
 	local cfg="$1"
-	local start_chilli=$(eval "echo \$start_chilli_$cfg")
-	[ "$start_chilli" = "0" ] && return
 	local base="/var/run/chilli_${cfg}"
+
+	config_get_bool disabled "$1" 'disabled' 1
+	[ $disabled = 1 ] && return
 
 	procd_open_instance "$cfg"
 	procd_set_param command /usr/sbin/chilli
-	procd_set_param file "${base}.conf"
+	procd_set_param file "$chilli_conf"
 	procd_append_param command \
 		--fg \
 		--conf "${base}.conf" \

--- a/net/coova-chilli/files/chilli.init
+++ b/net/coova-chilli/files/chilli.init
@@ -32,7 +32,15 @@ option_cb() {
 			[ "$(config_get_bool "$1")" = "1" ] && eval "start_chilli_$chilli_inst=0"
 			;;
 		# boolean settings
-		debug|dhcpbroadcast|nodynip|vlanlocation|locationstopstart|locationcopycalled|locationimmediateupdate|locationopt82|coanoipcheck|noradallow|proxymacaccept|proxyonacct|dhcpmacset|dhcpradius|noc2c|eapolenable|uamanydns|uamanyip|uamnatanyip|nouamsuccess|nowispr1|nowispr2|domaindnslocal|radsec|macauth|macreauth|macauthdeny|macallowlocal|strictmacauth|strictdhcp|ieee8021q|only8021q|radiusoriginalurl|swapoctets|statusfilesave|wpaguests|openidauth|papalwaysok|mschapv2|chillixml|acctupdate|dnsparanoia|seskeepalive|usetap|noarpentries|framedservice|scalewin|redir|injectwispr|redirurl|routeonetone|nousergardendata|uamgardendata|uamotherdata|withunixipc|uamallowpost|redirssl|uamuissl|layer3|patricia|redirdnsreq|dhcpnotidle|ipv6|ipv6only)
+		debug|dhcpbroadcast|nodynip|vlanlocation|locationstopstart|locationcopycalled|\
+		locationimmediateupdate|locationopt82|coanoipcheck|noradallow|proxymacaccept|\
+		proxyonacct|dhcpmacset|dhcpradius|noc2c|eapolenable|uamanydns|uamanyip|uamnatanyip|\
+		nouamsuccess|nowispr1|nowispr2|domaindnslocal|radsec|macauth|macreauth|macauthdeny|\
+		macallowlocal|strictmacauth|strictdhcp|ieee8021q|only8021q|radiusoriginalurl|swapoctets|\
+		statusfilesave|wpaguests|openidauth|papalwaysok|mschapv2|chillixml|acctupdate|dnsparanoia|\
+		seskeepalive|usetap|noarpentries|framedservice|scalewin|redir|injectwispr|redirurl|\
+		routeonetone|nousergardendata|uamgardendata|uamotherdata|withunixipc|uamallowpost|redirssl|\
+		uamuissl|layer3|patricia|redirdnsreq|dhcpnotidle|ipv6|ipv6only)
 			[ "$2" = "true" -o "$2" = "1" ] && echo "$1" >> "$chilli_conf"
 			;;
 		*)
@@ -50,7 +58,12 @@ start_chilli() {
 	procd_open_instance "$cfg"
 	procd_set_param command /usr/sbin/chilli
 	procd_set_param file "${base}.conf"
-	procd_append_param command --fg --conf "${base}.conf" --pidfile "${base}.pid" --cmdsocket "${base}.sock" --unixipc "${base}.ipc"
+	procd_append_param command \
+		--fg \
+		--conf "${base}.conf" \
+		--pidfile "${base}.pid" \
+		--cmdsocket "${base}.sock" \
+		--unixipc "${base}.ipc"
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1


### PR DESCRIPTION
Maintainer:  @teslamint
Compile tested: x86,ath79,mt7620
Run tested: x86,ath79,mt7620
Description:
  
* coova-chilli: Fix debug flag config example and synchronize bool options
* coova-chilli: Fix unwanted startup of disabled instances
* coova-chilli: Wrap excessively long lines