### PR TITLE
mosquitto: update to version 1.6.6 (security fix)

### DIFF
--- a/net/mosquitto/Makefile
+++ b/net/mosquitto/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mosquitto
-PKG_VERSION:=1.6.4
+PKG_VERSION:=1.6.6
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.txt
@@ -17,7 +17,7 @@ PKG_CPE_ID:=cpe:/a:eclipse:mosquitto
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://mosquitto.org/files/source/
-PKG_HASH:=a3d5822c249f6a6e13311b1b09eff6807ea01608a5a77934e1769842e9d146ef
+PKG_HASH:=82676bf4201ff102be1511b56b041a9450fbbfeda40b21aa28be0fee56e8de17
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: @karlp 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
Update to version 1.6.6
Fixes
CVE-2019-11778
CVE-2019-11779

Changelog:
http://www.mosquitto.org/ChangeLog.txt

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>