### PR TITLE
boost: Switch to blacklist of targets for context

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.71.0
 PKG_SOURCE_VERSION:=1_71_0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/
@@ -120,7 +120,7 @@ define Package/boost/config
 	# Invisible config dependency
 	config boost-context-exclude
 		bool
-		default y if (mips64 || arc || arc700)
+		default y if (TARGET_arc700 || TARGET_archs38 || TARGET_octeon || TARGET_octeontx)
 		default n
 
 	config boost-coroutine-exclude


### PR DESCRIPTION
Works around a buildbot bug.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ClaymorePT 

https://downloads.openwrt.org/snapshots/faillogs/mips64_octeonplus/packages/libfolly/compile.txt
https://downloads.openwrt.org/snapshots/faillogs/arc_archs/packages/libfolly/compile.txt