### PR TITLE
libgd: avoid using host headers

### DIFF
--- a/libs/libgd/patches/220-exclude_host_headers.patch
+++ b/libs/libgd/patches/220-exclude_host_headers.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -89,8 +89,6 @@
+ 	GV_LT(VERSION GDLIB_LIB_VERSION)
+ 	MESSAGE(STATUS "gd shared lib version ${GDLIB_LIB_SOVERSION} (${GDLIB_LIB_VERSION})")
+ 
+-	SET(CMAKE_REQUIRED_INCLUDES "/usr/include" "/usr/local/include")
+-
+ 	include(CheckIncludeFiles)
+ 	include(CheckIncludeFile)
+ 


### PR DESCRIPTION
Maintainer: @jow-, @neheb 
Compile tested: Clean Debian 10 stable host, Entware repo, mipsel feed ([commit](https://github.com/Entware/entware-packages/commit/f36048de24fa365ce1e173c57bca0855fd1e8cc8)).
Run tested: Entware repo

Description: This PR removes host paths from CFLAGS, regression introduced after [switch to CMake](https://github.com/openwrt/packages/commit/3e44ecbafa3b5fd49224bd516ad1011ab632d04a#diff-9725f7e8452e0d9b0f0a16a961367d28). Otherwise, `libgd` fails diring CMake tests:
```
make[5]: Entering directory '/home/Entware/build_dir/target-mipsel_mips 32r2_glibc-2.27/libgd-2.2.5/CMakeFiles/CMakeTmp'
Building C object CMakeFiles/cmTC_0b835.dir/HAVE_STDINT_H.c.o
/home/Entware/staging_dir/toolchain-mipsel_mips32r2_gcc-7.4.0_glibc-2.2 7/bin/mipsel-openwrt-linux-gnu-gcc  -I/usr/include -I/usr/local/include  -O2 -pi pe -mno-branch-likely -mips32r2 -mtune=mips32r2 -fno-caller-saves -fhonour-copts  -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float  -fpic  -ffunction-sections -fdata-sections -flto    -o CMakeFiles/cmTC_0b835.dir/HAVE_ STDINT_H.c.o   -c /home/Entware/build_dir/target-mipsel_mips32r2_glibc- 2.27/libgd-2.2.5/CMakeFiles/CheckIncludeFiles/HAVE_STDINT_H.c
In file included from /home/Entware/build_dir/target-mipsel_mips32r2_gl ibc-2.27/libgd-2.2.5/CMakeFiles/CheckIncludeFiles/HAVE_STDINT_H.c:2:0:
/usr/include/stdint.h:43:9: error: unknown type name '__int_least8_t'
 typedef __int_least8_t int_least8_t;
         ^~~~~~~~~~~~~~
/usr/include/stdint.h:44:9: error: unknown type name '__int_least16_t'
 typedef __int_least16_t int_least16_t;
         ^~~~~~~~~~~~~~~
/usr/include/stdint.h:45:9: error: unknown type name '__int_least32_t'
 typedef __int_least32_t int_least32_t;
         ^~~~~~~~~~~~~~~
/usr/include/stdint.h:46:9: error: unknown type name '__int_least64_t'
 typedef __int_least64_t int_least64_t;
```
