### PR TITLE
cache-domains: added game cache DNS config service

### DIFF
--- a/utils/cache-domains/Makefile
+++ b/utils/cache-domains/Makefile
@@ -1,0 +1,52 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cache-domains
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/cache-domains/default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Game content cache DNS
+  URL:=https://github.com/uklans/cache-domains
+  DEPENDS:=+jq +bash +dnsmasq +ca-bundle
+endef
+
+define Package/cache-domains/description/default
+Service to dynamically configure the local DNS (dnsmasq) to redirect game content servers to a LAN cache.
+Definitive list dynamically obtained from https://github.com/uklans/cache-domains.
+endef
+
+define Package/cache-domains/install/default
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/cache-domains.init $(1)/etc/init.d/cache-domains
+endef
+
+Build/Compile=# Nothing to compile, just install the scripts
+
+
+define Package/cache-domains-openssl
+  $(Package/cache-domains/default)
+  TITLE += (openssl)
+  DEPENDS += +libustream-openssl
+  VARIANT:=openssl
+endef
+Package/cache-domains-openssl/description = $(Package/cache-domains/description/default)
+Package/cache-domains-openssl/install = $(Package/cache-domains/install/default)
+
+define Package/cache-domains-mbedtls
+  $(Package/cache-domains/default)
+  TITLE += (mbedtls)
+  DEPENDS += +libustream-mbedtls
+  VARIANT:=mbedtls
+  DEFAULT_VARIANT:=1
+endef
+Package/cache-domains-mbedtls/description = $(Package/cache-domains/description/default)
+Package/cache-domains-mbedtls/install = $(Package/cache-domains/install/default)
+
+$(eval $(call BuildPackage,cache-domains-openssl))
+$(eval $(call BuildPackage,cache-domains-mbedtls))

--- a/utils/cache-domains/README.md
+++ b/utils/cache-domains/README.md
@@ -1,0 +1,30 @@
+# cache-domains
+
+Service to dynamically configure the local DNS (dnsmasq) to redirect game content servers to a LAN cache. Definitive list dynamically obtained from https://github.com/uklans/cache-domains.
+
+## Configuration
+Configuration file follows the same [syntax as the upsteam file](https://github.com/uklans/cache-domains/blob/master/scripts/config.example.json). The key for each `cache_domain` member matches the name of one of the `.txt` files in the [upstream root directory](https://github.com/uklans/cache-domains/blob/master/), except for the `default` key which matches the all the unreferenced `.txt` files. The value of each `cache_domain` member maps to one of the keys of the `ips` members, Thus mapping a cached domain to a list of IP addresses/LAN cache server.
+
+```json
+{
+	"ips": {
+		"server1":	["10.10.3.10", "10.10.3.11"],
+		"server2":	"10.10.3.12",
+		"server3":	"10.10.3.13"
+	},
+	"cache_domains": {
+		"default":	"server2",
+		"blizzard":	"server1",
+		"origin":	"server1",
+		"steam":	"server1",
+		"wsus":		"server3",
+		"xboxlive":	"server3"
+	}
+}
+```
+
+## Startup/Shutdown
+On start the local DNS (dnsmasq) will be configured to redirect the configured cache domains and on stop the redirection will be removed.
+
+## Testing
+With the above configuration set and the service running `nslookup swcdn.apple.com` would return `10.10.3.12`

--- a/utils/cache-domains/files/cache-domains.init
+++ b/utils/cache-domains/files/cache-domains.init
@@ -1,0 +1,42 @@
+#!/bin/sh /etc/rc.common
+
+START=24
+SERVICE_NAME=cache-domains
+CACHE_DOMAINS_DIR="/var/${SERVICE_NAME}"
+CACHE_DOMAINS_SRC="https://api.github.com/repos/uklans/cache-domains/tarball/master"
+CONFIG_FILE="/etc/${SERVICE_NAME}.json"
+
+start() {
+	mkdir -p ${CACHE_DOMAINS_DIR}
+	rm -fr ${CACHE_DOMAINS_DIR}/*
+
+	if ! wget -qO - ${CACHE_DOMAINS_SRC} | tar -xzC ${CACHE_DOMAINS_DIR}; then
+		echo "ERROR: Could not retrieve ${CACHE_DOMAINS_SRC}"
+		return 1
+	fi
+
+	INITIAL_DIR="$(pwd)"
+	cd ${CACHE_DOMAINS_DIR}/*/scripts/
+
+	if [ ! -f ${CONFIG_FILE} ]; then
+		cp config.example.json ${CONFIG_FILE}
+		echo "Using example config file ${CONFIG_FILE}"
+	fi
+
+	cp ${CONFIG_FILE} config.json
+	./create-dnsmasq.sh
+	cp ./output/dnsmasq/* /tmp/dnsmasq.d/
+
+	cd ${INITIAL_DIR}
+
+	/etc/init.d/dnsmasq restart
+}
+
+stop() {
+	# leave dnsmasq in a clean state
+	for FILE in ${CACHE_DOMAINS_DIR}/*/scripts/output/dnsmasq/*; do
+		rm -f /tmp/dnsmasq.d/$(basename ${FILE})
+	done
+
+	/etc/init.d/dnsmasq restart
+}


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: x86_x64, Hyper-V, OpenWrt Master
Run tested: x86_x64, Hyper-V, OpenWrt Master

Description:
Service to dynamically configure the local DNS (dnsmasq) to redirect game content servers to a LAN cache.
Definitive list dynamically obtained from https://github.com/uklans/cache-domains.

Trimmed down from https://github.com/openwrt/packages/pull/10026
