### PR TITLE
hcxtools: update to v5.2.2

### DIFF
--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hcxdumptool
-PKG_VERSION:=5.2.0
+PKG_VERSION:=5.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxdumptool/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=9da9c8c20b93f6a0a262436a862e376bd3cfd05fb879efcf480ad962a14496c7
+PKG_HASH:=b091171fe5e6f926ace3997219dfc5a84ce6d1f2080d3320d456f88282019057
 
 PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 PKG_LICENSE:=MIT

--- a/net/hcxtools/Makefile
+++ b/net/hcxtools/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hcxtools
-PKG_VERSION:=5.2.0
+PKG_VERSION:=5.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxtools/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=1e8120c5451a38645ade0be4255d3c7f4a837b7611b44d4a5a066e563ad8a112
+PKG_HASH:=a2dd9559e1cc541f07f7a4c2451c295896355a94cfc970dc5cdceb40e605ee7e
 
 PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Pineapple-NANO - OpenWRT-19.07
Run tested: (ar71xx, pineapple-nano, OpenWrt 19.07, tested both tools)

Description: Updated both tools to v5.2.2