### PR TITLE
transmission: fix command param issue and use default respawn settings

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=2.94
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -114,12 +114,12 @@ transmission() {
 
 	procd_open_instance
 	procd_set_param command "/usr/bin/transmission-daemon"
-	procd_append_param command "-f --log-error -g $config_dir"
+	procd_append_param command -f --log-error -g "$config_dir"
 	procd_set_param user "$user"
 	procd_set_param group "$group"
 	procd_set_param nice "$nice"
 	procd_set_param stderr 1
-	procd_set_param respawn retry=60
+	procd_set_param respawn
 
 	if [ -z "$USE" ]; then
 		procd_set_param limits core="0 0"


### PR DESCRIPTION
Maintainer: @neheb 
Compile tested: mt7621 snapshot
Run tested: mt7621 snapshot

Description:
Use default respawn settings to prevent from restarting again and again in case of something wrong.