### PR TITLE
perl-www-curl: curl 7.66.0 compatibility

### DIFF
--- a/lang/perl-www-curl/Makefile
+++ b/lang/perl-www-curl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-www-curl
 PKG_VERSION:=4.17
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_URL:=http://www.cpan.org/authors/id/S/SZ/SZBALINT/
 PKG_SOURCE:=WWW-Curl-$(PKG_VERSION).tar.gz

--- a/lang/perl-www-curl/patches/210-curl_7.66_compat.patch
+++ b/lang/perl-www-curl/patches/210-curl_7.66_compat.patch
@@ -1,0 +1,56 @@
+--- a/Curl.xs
++++ b/Curl.xs
+@@ -70,7 +70,7 @@
+ 
+ 
+ typedef struct {
+-#ifdef __CURL_MULTI_H
++#ifdef CURLINC_MULTI_H
+     struct CURLM *curlm;
+ #else
+     struct void *curlm;
+@@ -234,7 +234,7 @@
+ {
+     perl_curl_multi *self;
+     Newz(1, self, 1, perl_curl_multi);
+-#ifdef __CURL_MULTI_H
++#ifdef CURLINC_MULTI_H
+     self->curlm=curl_multi_init();
+ #else
+     croak("curl version too old to support curl_multi_init()");
+@@ -245,7 +245,7 @@
+ /* delete the multi */
+ static void perl_curl_multi_delete(perl_curl_multi *self)
+ {
+-#ifdef __CURL_MULTI_H
++#ifdef CURLINC_MULTI_H
+     if (self->curlm) 
+         curl_multi_cleanup(self->curlm);
+     Safefree(self);
+@@ -1065,7 +1065,7 @@
+     WWW::Curl::Multi curlm
+     WWW::Curl::Easy curl
+     CODE:
+-#ifdef __CURL_MULTI_H
++#ifdef CURLINC_MULTI_H
+         curl_multi_add_handle(curlm->curlm, curl->curl);
+ #endif
+ 
+@@ -1074,7 +1074,7 @@
+     WWW::Curl::Multi curlm
+     WWW::Curl::Easy curl
+     CODE:
+-#ifdef __CURL_MULTI_H
++#ifdef CURLINC_MULTI_H
+         curl_multi_remove_handle(curlm->curlm, curl->curl);
+ #endif
+ 
+@@ -1149,7 +1149,7 @@
+     PREINIT:
+         int remaining;
+     CODE:
+-#ifdef __CURL_MULTI_H
++#ifdef CURLINC_MULTI_H
+         while(CURLM_CALL_MULTI_PERFORM ==
+             curl_multi_perform(self->curlm, &remaining));
+ 	    RETVAL = remaining;


### PR DESCRIPTION
Maintainer: @Naoir, @jow- 
Compile tested: Debian 10 stable, Entware repo
Run tested: Entware repo, mipsel feed
Description: Curl package was [updated recenlty](https://github.com/openwrt/openwrt/commit/71cf4a272c9cf7d6e604e6327d0c94aeceac26e7) and some internal definitions was [renamed](https://github.com/curl/curl/commit/32d64b2e875f0d74cd433dff8bda9f8a98dcd44e#diff-a539134a8261490f653400a3a99df731) in curl headers. This patch changes `perl-www-curl` sources to reflect this changes. Otherwise, build will fail:
```
make[3]: Entering directory '/home/Entware/build_dir/target-mipsel_mips32r2_glibc-2.27/perl/WWW-Curl-4.17'
cp lib/WWW/Curl/Form.pm blib/lib/WWW/Curl/Form.pm
cp lib/WWW/Curl/Share.pm blib/lib/WWW/Curl/Share.pm
cp lib/WWW/Curl/Easy.pm blib/lib/WWW/Curl/Easy.pm
cp lib/WWW/Curl.pm blib/lib/WWW/Curl.pm
cp lib/WWW/Curl/Multi.pm blib/lib/WWW/Curl/Multi.pm
Running Mkbootstrap for Curl ()
chmod 644 "Curl.bs"
"/home/Entware/staging_dir/hostpkg/usr/bin/perl5.28.1" "-Iinc" -MExtUtils::Command::MM -e 'cp_nonempty' -- Curl.bs blib/arch/auto/WWW/Curl/Curl.bs 644
"/home/Entware/staging_dir/hostpkg/usr/bin/perl5.28.1" "-Iinc" "/home/Entware/staging_dir/hostpkg/usr/lib/perl5/5.28.1/ExtUtils/xsubpp"  -typemap '/home/Entware/staging_dir/hostpkg/usr/lib/perl5/5.28.1/ExtUtils/typemap' -typemap '/home/Entware/build_dir/target-mipsel_mips32r2_glibc-2.27/perl/WWW-Curl-4.17/typemap'  Curl.xs > Curl.xsc
mv Curl.xsc Curl.c
mipsel-openwrt-linux-gcc -c  -I/home/Entware/staging_dir/target-mipsel_mips32r2_glibc-2.27/opt/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -O2 -pipe -mno-branch-likely -mips32r2 -mtune=mips32r2 -fno-caller-saves -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float  -I/home/Entware/staging_dir/target-mipsel_mips32r2_glibc-2.27/opt/include -I/home/Entware/staging_dir/toolchain-mipsel_mips32r2_gcc-7.4.0_glibc-2.27/include -D_REENTRANT -D_GNU_SOURCE -O2   -DVERSION=\"4.17\" -DXS_VERSION=\"4.17\" -fPIC "-I/home/Entware/staging_dir/target-mipsel_mips32r2_glibc-2.27/opt/lib/perl5/5.28/CORE/"   Curl.c
Curl.xs:76:12: error: expected '{' before 'void'
     struct void *curlm;
            ^~~~
Curl.xs:76:12: error: two or more data types in declaration specifiers

```

