### PR TITLE
OpenVSwitch 2.12 build fix for kernel 4.14

### DIFF
--- a/net/openvswitch/Makefile
+++ b/net/openvswitch/Makefile
@@ -75,8 +75,8 @@ ovs_kmod_openvswitch_depends:=\
 	  +IPV6:kmod-nf-nat6 \
 	  +kmod-nf-conntrack \
 	  +IPV6:kmod-nf-conntrack6 \
-	  +(!LINUX_4_9&&!LINUX_4.14):kmod-nsh \
-	  +(!LINUX_4_9&&!LINUX_4.14):kmod-ipt-conntrack-extra \
+	  +(!LINUX_4_9&&!LINUX_4_14):kmod-nsh \
+	  +(!LINUX_4_9&&!LINUX_4_14):kmod-ipt-conntrack-extra \
 
 ovs_kmod_openvswitch_files:=$(ovs_kmod_upstream_dir)/openvswitch.ko
 $(eval $(call OvsKmodPackageTemplate,openvswitch))
@@ -120,11 +120,11 @@ ovs_kmod_openvswitch-intree_depends:=\
 	  +kmod-nf-nat \
 	  +IPV6:kmod-nf-nat6 \
 	  +kmod-nf-conntrack \
-	  +(IPV6&&(LINUX_4_9||LINUX_4.14)):kmod-nf-conntrack6 \
-	  +(LINUX_4_9||LINUX_4.14):kmod-gre \
-	  +(IPV6&&(LINUX_4_9||LINUX_4.14)):kmod-gre6 \
-	  +(!LINUX_4_9&&!LINUX_4.14):kmod-udptunnel4 \
-	  +(!LINUX_4_9&&!LINUX_4.14):kmod-ipt-conntrack-extra \
+	  +(IPV6&&(LINUX_4_9||LINUX_4_14)):kmod-nf-conntrack6 \
+	  +(LINUX_4_9||LINUX_4_14):kmod-gre \
+	  +(IPV6&&(LINUX_4_9||LINUX_4_14)):kmod-gre6 \
+	  +(!LINUX_4_9&&!LINUX_4_14):kmod-udptunnel4 \
+	  +(!LINUX_4_9&&!LINUX_4_14):kmod-ipt-conntrack-extra \
 
 ovs_kmod_openvswitch-intree_files:= $(ovs_kmod_intree_dir)/openvswitch.ko
 $(eval $(call OvsKmodPackageTemplate,openvswitch-intree))


### PR DESCRIPTION
Maintainer: @yousong  
Compile tested: ar71xx master, TP-Link TL-WDR4300, kernel 4.14.164

Description:
After update to OpenVSwtich 2.12.0 it depends against kmod-iptunnel6 if on kernel 4.14
Also, I discovered (likely) a typo in the config symbol used to check for kernel 4.14, which contained a dot instead of an underscore, so it wasn't effective, but despite this fact, builds for kernel 4.14 worked for some reason unknown to me, before the update.
