### PR TITLE
dnscrypt-proxy2: Update to version 2.0.27

### DIFF
--- a/net/dnscrypt-proxy2/Makefile
+++ b/net/dnscrypt-proxy2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy2
-PKG_VERSION:=2.0.25
+PKG_VERSION:=2.0.27
 PKG_RELEASE:=1
 
 PKG_SOURCE:=dnscrypt-proxy-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jedisct1/dnscrypt-proxy/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=774696004c9e306e1723b4cbbe66a961128a335543d318d0786492ce69b906fa
+PKG_HASH:=a501f44af39cb43e00489ef9e6678aa8adba2bc98f9042dd61ce60e9ad074d5a
 PKG_BUILD_DIR:=$(BUILD_DIR)/dnscrypt-proxy-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris MOX, cortexa53, OpenWrt master
Run tested: Turris MOX, cortexa53, OpenWrt master

Description:

- Update to version 2.0.27
Changelog:
https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.0.26
https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.0.27