### PR TITLE
libid3tag: add pkg-config file

### DIFF
--- a/libs/libid3tag/Makefile
+++ b/libs/libid3tag/Makefile
@@ -42,6 +42,11 @@ TARGET_CFLAGS += $(FPIC)
 
 CONFIGURE_VARS += CC="$(TARGET_CC) $(TARGET_CFLAGS)"
 
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(SED) 's,@VERSION@,$(PKG_VERSION),g' $(PKG_BUILD_DIR)/id3tag.pc
+endef
+
 define Build/Configure
 	$(call Build/Configure/Default, \
 		--enable-shared \
@@ -56,6 +61,8 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/id3tag.h $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libid3tag.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig/
+	$(CP) $(PKG_BUILD_DIR)/id3tag.pc $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/libid3tag/install

--- a/libs/libid3tag/src/id3tag.pc
+++ b/libs/libid3tag/src/id3tag.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: id3tag
+Description: ID3 tag reading library
+Requires:
+Version: @VERSION@
+Libs: -L${libdir} -lid3tag -lz
+Cflags: -I${includedir}


### PR DESCRIPTION
Required for meson to find this library in a sane way.

Maintainer: @thess 