### PR TITLE
[OpenWrt 18.06] libgcrypt: backport fix for CVE-2019-13627

### DIFF
--- a/libs/libgcrypt/Makefile
+++ b/libs/libgcrypt/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgcrypt
 PKG_VERSION:=1.6.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.gnupg.org/ftp/gcrypt/libgcrypt/

--- a/libs/libgcrypt/patches/001-no_docs_tests.patch
+++ b/libs/libgcrypt/patches/001-no_docs_tests.patch
@@ -1,7 +1,6 @@
-diff -u --recursive libgcrypt-1.6.1-vanilla/Makefile.am libgcrypt-1.6.1/Makefile.am
---- libgcrypt-1.6.1-vanilla/Makefile.am	2014-07-18 00:31:21.020329371 -0400
-+++ libgcrypt-1.6.1/Makefile.am	2014-07-18 00:31:49.076314616 -0400
-@@ -25,8 +25,8 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -24,8 +24,8 @@ DISTCHECK_CONFIGURE_FLAGS = --disable-ra
  # (A suitable gitlog-to-changelog script can be found in GnuPG master.)
  GITLOG_TO_CHANGELOG=gitlog-to-changelog
  
@@ -12,10 +11,9 @@ diff -u --recursive libgcrypt-1.6.1-vanilla/Makefile.am libgcrypt-1.6.1/Makefile
  
  EXTRA_DIST = autogen.sh autogen.rc README.GIT LICENSES      	           \
               ChangeLog-2011 build-aux/ChangeLog-2011 doc/ChangeLog-2011    \
-diff -u --recursive libgcrypt-1.6.1-vanilla/Makefile.in libgcrypt-1.6.1/Makefile.in
---- libgcrypt-1.6.1-vanilla/Makefile.in	2014-07-18 00:31:21.020329371 -0400
-+++ libgcrypt-1.6.1/Makefile.in	2014-07-18 00:31:54.974311498 -0400
-@@ -331,8 +331,8 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -394,8 +394,8 @@ DISTCHECK_CONFIGURE_FLAGS = --disable-ra
  
  # (A suitable gitlog-to-changelog script can be found in GnuPG master.)
  GITLOG_TO_CHANGELOG = gitlog-to-changelog

--- a/libs/libgcrypt/patches/002-Add-configure-option-enable-build-timestamp.patch
+++ b/libs/libgcrypt/patches/002-Add-configure-option-enable-build-timestamp.patch
@@ -16,11 +16,9 @@ Signed-off-by: Werner Koch <wk@gnupg.org>
  configure.ac | 11 ++++++++++-
  1 file changed, 10 insertions(+), 1 deletion(-)
 
-diff --git a/configure.ac b/configure.ac
-index 48e217947287..2acfa3630cac 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2272,7 +2272,16 @@ changequote([,])dnl
+@@ -1994,7 +1994,16 @@ changequote([,])dnl
  BUILD_FILEVERSION="${BUILD_FILEVERSION}mym4_revision_dec"
  AC_SUBST(BUILD_FILEVERSION)
  
@@ -38,6 +36,3 @@ index 48e217947287..2acfa3630cac 100644
  AC_SUBST(BUILD_TIMESTAMP)
  AC_DEFINE_UNQUOTED(BUILD_TIMESTAMP, "$BUILD_TIMESTAMP",
                     [The time this package was configured for a build])
--- 
-2.15.1
-

--- a/libs/libgcrypt/patches/003-dsa-ecdsa-Fix-use-of-nonce-use-larger-one.patch
+++ b/libs/libgcrypt/patches/003-dsa-ecdsa-Fix-use-of-nonce-use-larger-one.patch
@@ -1,0 +1,103 @@
+From 93718eeee932b95cbf6cea6ca0002554fd4583be Mon Sep 17 00:00:00 2001
+From: NIIBE Yutaka <gniibe@fsij.org>
+Date: Thu, 8 Aug 2019 17:42:02 +0900
+Subject: [PATCH] dsa,ecdsa: Fix use of nonce, use larger one.
+
+* cipher/dsa-common.c (_gcry_dsa_modify_k): New.
+* cipher/pubkey-internal.h (_gcry_dsa_modify_k): New.
+* cipher/dsa.c (sign): Use _gcry_dsa_modify_k.
+* cipher/ecc-ecdsa.c (_gcry_ecc_ecdsa_sign): Likewise.
+* cipher/ecc-gost.c (_gcry_ecc_gost_sign): Likewise.
+
+--
+
+Cherry-picked master commit of:
+	7c2943309d14407b51c8166c4dcecb56a3628567
+
+CVE-id: CVE-2019-13627
+GnuPG-bug-id: 4626
+Signed-off-by: NIIBE Yutaka <gniibe@fsij.org>
+---
+ cipher/dsa-common.c      | 24 ++++++++++++++++++++++++
+ cipher/dsa.c             |  2 ++
+ cipher/ecc-ecdsa.c       |  2 ++
+ cipher/ecc-gost.c        |  2 ++
+ cipher/pubkey-internal.h |  1 +
+ 5 files changed, 31 insertions(+)
+
+--- a/cipher/dsa-common.c
++++ b/cipher/dsa-common.c
+@@ -30,6 +30,30 @@
+ 
+ 
+ /*
++ * Modify K, so that computation time difference can be small,
++ * by making K large enough.
++ *
++ * Originally, (EC)DSA computation requires k where 0 < k < q.  Here,
++ * we add q (the order), to keep k in a range: q < k < 2*q (or,
++ * addming more q, to keep k in a range: 2*q < k < 3*q), so that
++ * timing difference of the EC multiply (or exponentiation) operation
++ * can be small.  The result of (EC)DSA computation is same.
++ */
++void
++_gcry_dsa_modify_k (gcry_mpi_t k, gcry_mpi_t q, int qbits)
++{
++  gcry_mpi_t k1 = mpi_new (qbits+2);
++
++  mpi_resize (k, (qbits+2+BITS_PER_MPI_LIMB-1) / BITS_PER_MPI_LIMB);
++  k->nlimbs = k->alloced;
++  mpi_add (k, k, q);
++  mpi_add (k1, k, q);
++  mpi_set_cond (k, k1, !mpi_test_bit (k, qbits));
++
++  mpi_free (k1);
++}
++
++/*
+  * Generate a random secret exponent K less than Q.
+  * Note that ECDSA uses this code also to generate D.
+  */
+--- a/cipher/dsa.c
++++ b/cipher/dsa.c
+@@ -606,6 +606,8 @@ sign (gcry_mpi_t r, gcry_mpi_t s, gcry_m
+       k = _gcry_dsa_gen_k (skey->q, GCRY_STRONG_RANDOM);
+     }
+ 
++  _gcry_dsa_modify_k (k, skey->q, qbits);
++
+   /* r = (a^k mod p) mod q */
+   mpi_powm( r, skey->g, k, skey->p );
+   mpi_fdiv_r( r, r, skey->q );
+--- a/cipher/ecc-ecdsa.c
++++ b/cipher/ecc-ecdsa.c
+@@ -103,6 +103,8 @@ _gcry_ecc_ecdsa_sign (gcry_mpi_t input,
+           else
+             k = _gcry_dsa_gen_k (skey->E.n, GCRY_STRONG_RANDOM);
+ 
++          _gcry_dsa_modify_k (k, skey->E.n, qbits);
++
+           _gcry_mpi_ec_mul_point (&I, k, &skey->E.G, ctx);
+           if (_gcry_mpi_ec_get_affine (x, NULL, &I, ctx))
+             {
+--- a/cipher/ecc-gost.c
++++ b/cipher/ecc-gost.c
+@@ -94,6 +94,8 @@ _gcry_ecc_gost_sign (gcry_mpi_t input, E
+           mpi_free (k);
+           k = _gcry_dsa_gen_k (skey->E.n, GCRY_STRONG_RANDOM);
+ 
++          _gcry_dsa_modify_k (k, skey->E.n, qbits);
++
+           _gcry_mpi_ec_mul_point (&I, k, &skey->E.G, ctx);
+           if (_gcry_mpi_ec_get_affine (x, NULL, &I, ctx))
+             {
+--- a/cipher/pubkey-internal.h
++++ b/cipher/pubkey-internal.h
+@@ -80,6 +80,7 @@ _gcry_rsa_pss_verify (gcry_mpi_t value,
+ 
+ 
+ /*-- dsa-common.c --*/
++void _gcry_dsa_modify_k (gcry_mpi_t k, gcry_mpi_t q, int qbits);
+ gcry_mpi_t _gcry_dsa_gen_k (gcry_mpi_t q, int security_level);
+ gpg_err_code_t _gcry_dsa_gen_rfc6979_k (gcry_mpi_t *r_k,
+                                         gcry_mpi_t dsa_q, gcry_mpi_t dsa_x,


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06, Turris MOX, cortexa53, OpenWrt 18.06.
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06

Description:
- Add patch, which fixes [CVE-2019-13627](https://nvd.nist.gov/vuln/detail/CVE-2019-13627)
- Refresh patches due to offsets

Supersedes PR #9996