### PR TITLE
Werkzeug: Update to version 0.16.0

### DIFF
--- a/lang/python/Werkzeug/Makefile
+++ b/lang/python/Werkzeug/Makefile
@@ -5,20 +5,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Werkzeug
-PKG_VERSION:=0.15.2
+PKG_VERSION:=0.16.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/W/Werkzeug
-PKG_HASH:=0a73e8bb2ff2feecfc5d56e6f458f5b99290ef34f565ffb2665801ff7de6af7a
+PKG_HASH:=7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
-PKG_LICENSE_FILES:=LICENSE
-
-PKG_BUILD_DEPENDS:=python python3
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+PKG_LICENSE_FILES:=LICENSE.rst
 
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
@@ -27,17 +23,16 @@ define Package/python3-werkzeug
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=Werkzeug
   URL:=https://palletsprojects.com/p/werkzeug/
-  TITLE:=python3-werkzeug
   DEPENDS:=+python3-light +python3-email
   VARIANT:=python3
 endef
 
 define Package/python3-werkzeug/description
-Werkzeug
-
-The Python WSGI Utility Library
+ The comprehensive WSGI web application library.
 endef
 
 $(eval $(call Py3Package,python3-werkzeug))
 $(eval $(call BuildPackage,python3-werkzeug))
+$(eval $(call BuildPackage,python3-werkzeug-src))


### PR DESCRIPTION
Maintainer: @dangowrt
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- Update to version [0.16.0](https://github.com/pallets/werkzeug/blob/0.16.x/CHANGES.rst)

Makefile:
- Remove PKG_BUILD_DEPENDS as it is no longer necessary.
- The Python3 is already included in DEPENDS.
- Remove PKG_BUILD_DIR and PKG_UNPACK was for dual Python version.
- Change TITLE and description
- Add source package
