### PR TITLE
Flask: Update to version 1.1.1

### DIFF
--- a/lang/python/Flask/Makefile
+++ b/lang/python/Flask/Makefile
@@ -5,16 +5,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Flask
-PKG_VERSION:=1.0.3
+PKG_VERSION:=1.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/F/Flask
-PKG_HASH:=ad7c6d841e64296b962296c2c2dabc6543752985727af86a975072dea984b6f3
+PKG_HASH:=13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
-PKG_LICENSE_FILES:=LICENSE
+PKG_LICENSE_FILES:=LICENSE.rst
 PKG_CPE_ID:=cpe:/a:palletsprojects:flask
 
 include $(INCLUDE_DIR)/package.mk
@@ -24,8 +24,8 @@ define Package/python3-flask
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  TITLE:=python3-flask
-  URL:=https://github.com/pallets/flask/
+  TITLE:=Flask
+  URL:=https://palletsprojects.com/p/flask/
   DEPENDS:=+python3-asyncio +python3-click +python3-codecs +python3-decimal \
            +python3-itsdangerous +python3-jinja2 +python3 +python3-logging \
            +python3-markupsafe +python3-multiprocessing +python3-setuptools \
@@ -34,9 +34,10 @@ define Package/python3-flask
 endef
 
 define Package/python3-flask/description
-Flask is a microframework for Python based on Werkzeug, Jinja 2 and good
-intentions. And before you ask: It.s BSD licensed!
+  Flask is a microframework for Python based on Werkzeug, Jinja 2 and good
+  intentions. And before you ask: It.s BSD licensed!
 endef
 
 $(eval $(call Py3Package,python3-flask))
 $(eval $(call BuildPackage,python3-flask))
+$(eval $(call BuildPackage,python3-flask-src))


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
Update to version [1.1.1](https://github.com/pallets/flask/blob/1.1.x/CHANGES.rst)
- Change TITLE and URL to better one
- Add source package

