### PR TITLE
python3-maxminddb: Update to version 1.5.1

### DIFF
--- a/lang/python/python3-maxminddb/Makefile
+++ b/lang/python/python3-maxminddb/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=maxminddb
-PKG_VERSION:=1.4.1
+PKG_VERSION:=1.5.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/m/maxminddb/
-PKG_HASH:=df1451bcd848199905ac0de4631b3d02d6a655ad28ba5e5a4ca29a23358db712
+PKG_HASH:=449a1713d37320d777d0db286286ab22890f0a176492ecf3ad8d9319108f2f79
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: @ja-pa 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
```
root@turris:~# python3
Python 3.7.4 (default, Sep 30 2019, 09:07:11) 
[GCC 7.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import maxminddb
>>> reader = maxminddb.open_database('GeoLite2-City.mmdb')
>>> reader.get('1.1.1.1')
{'continent': {'code': 'OC', 'geoname_id': 6255151, 'names': {'de': 'Ozeanien', 'en': 'Oceania', 'es}
>>> reader.get_with_prefix_len('1.1.1.1')
({'continent': {'code': 'OC', 'geoname_id': 6255151, 'names': {'de': 'Ozeanien', 'en': 'Oceania', 'e)
>>> reader.close()

```
Description:
Update to version [1.5.1](https://github.com/maxmind/MaxMind-DB-Reader-python/blob/master/HISTORY.rst)