### PR TITLE
telldus-core: Fix compilation without usleep

### DIFF
--- a/utils/telldus-core/Makefile
+++ b/utils/telldus-core/Makefile
@@ -7,14 +7,19 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telldus-core
 PKG_VERSION:=2.1.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
-PKG_LICENSE:=LGPL-2.1
-PKG_BUILD_DEPENDS:=argp-standalone
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.telldus.com/TellStick/Software/telldus-core/
 PKG_HASH:=a20f6c74814afc23312d2c93ebbb37fdea9deaaee05ae7b6a6275e11e4662014
-PKG_INSTALL:=1
+
+PKG_MAINTAINER:=Peter Liedholm <PeterFromSwe884@gmail.com>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+CMAKE_INSTALL:=1
+PKG_BUILD_PARALLEL:=0
+PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -24,8 +29,7 @@ define Package/telldus-core
 	SECTION:=utils
 	CATEGORY:=Utilities
 	TITLE:=Telldus TellStick USB interface
-	URL:=http://www.telldus.com
-	MAINTAINER:=Peter Liedholm <PeterFromSwe884@gmail.com>
+	URL:=https://telldus.com
 	DEPENDS:=+confuse +libftdi +libstdcpp $(ICONV_DEPENDS)
 endef
 
@@ -34,17 +38,17 @@ define Package/telldus-core/description
 	MUST be built with full language support, (don't know how to DEPEND that)
 endef
 
+define Package/telldus-core/conffiles
+/etc/tellstick.conf
+endef
+
 CMAKE_OPTIONS+=\
 	-DBUILD_LIBTELLDUS-CORE=1 \
 	-DBUILD_TDTOOL=1 \
 	-DGENERATE_MAN=0 \
 	-DICONV_LIBRARY=-liconv
 
-TARGET_CXXFLAGS += -fpermissive
-
-define Package/telldus-core/conffiles
-/etc/tellstick.conf
-endef
+TARGET_CXXFLAGS += $(if $(ICONV_FULL),-D_FREEBSD)
 
 define Package/telldus-core/install
 	$(INSTALL_DIR)  $(1)/usr/bin

--- a/utils/telldus-core/patches/930-usleep.patch
+++ b/utils/telldus-core/patches/930-usleep.patch
@@ -1,0 +1,40 @@
+--- a/common/common.h
++++ b/common/common.h
+@@ -25,15 +25,13 @@
+ #ifdef _WINDOWS
+ #include <fstream>  // NOLINT(readability/streams)
+ #endif
++#include <chrono>
+ #include <string>
++#include <thread>
+ #include "common/Strings.h"
+ 
+ inline void msleep( const int msec) {
+-#ifdef _WINDOWS
+-	Sleep(msec);
+-#else
+-	usleep(msec*1000);
+-#endif
++	std::this_thread::sleep_for(std::chrono::milliseconds(msec));
+ }
+ 
+ inline void dlog(const char *fmt, ...) {
+--- a/service/TellStick_libftdi.cpp
++++ b/service/TellStick_libftdi.cpp
+@@ -8,7 +8,6 @@
+ #include <string.h>
+ #include <stdlib.h>
+ #include <stdio.h>
+-#include <unistd.h>
+ #include <list>
+ #include <string>
+ 
+@@ -231,7 +230,7 @@ int TellStick::send( const std::string &strMessage ) {
+ 				return TELLSTICK_SUCCESS;
+ 			}
+ 		} else if(ret == 0) {  // No data available
+-			usleep(100);
++			std::this_thread::sleep_for(std::chrono::microseconds(100));
+ 		} else {  // Error
+ 			Log::debug("Broken pipe on read");
+ 			return TELLSTICK_ERROR_BROKEN_PIPE;


### PR DESCRIPTION
Makefile cleanups

Fixed license information.

Add PKG_BUILD_PARALLEL for faster compilation.

Fixed build depends to apply only to non glibc.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @PeterFromSweden 
Compile tested: archs