### PR TITLE
simple-adblock: bugfix and improvements (check description)

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.8.1
-PKG_RELEASE:=7
+PKG_RELEASE:=11
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/README.md
+++ b/net/simple-adblock/files/README.md
@@ -161,6 +161,22 @@ If you specify ```google.com``` as a domain to be whitelisted, you will have acc
 
 In general, whatever domain is specified to be whitelisted; it, along with with its subdomains will be whitelisted, but not any fake domains containing it.
 
+## How It Does Not Work
+
+For most of the [DNS Resolution Options](#dns-resolution-option) to work, your local LAN clients need to be set to use your router's DNS (by default ```192.168.1.1```). The ```dnsmasq.addnhosts``` is the only option which can help you block ads if your local LAN clients are NOT using your router's DNS. There are multiple ways your local LAN clients can be set to NOT use your router's DNS:
+
+  1. Hardcoded on the device. Some Android Lollipop 5.0 phones, some media-centric tablets and some streaming devices for example are known to have hardcoded DNS servers and they ignore your router's DNS settings. You can fix this by either:
+      - Rooting your device and changing it from hardcoded DNS servers to obtaining DNS servers from DHCP.
+      - Enabling ```simple-adblock```'s ```force_dns``` setting to override the hardcoded DNS on your device.
+  2. Manually set on the device. Instead of setting your device to obtain the DNS settings via DHCP, you can set the DNS servers manually. There are some guides online which recommend manually changing the DNS servers on your computer to Google's (8.8.8.8) or Cloudflare's (1.1.1.1) or OpenDNS (208.67.222.222). You can fix this by either:
+      - Changing the on-device DNS settings from manual to obtaining DNS servers from DHCP and changing your [router's DNS settings](https://openwrt.org/docs/guide-user/base-system/dhcp#all_options) to use the DNS from Google, Cloudflare or OpenDNS respectively.
+      - Enabling ```simple-adblock```'s ```force_dns``` setting to override the hardcoded DNS on your device.
+  3. Sent to your device from router via [DHCP Options](https://openwrt.org/docs/guide-user/base-system/dhcp_configuration#dhcp_options). You can fix this by either:
+      - Removing [DHCP Options](https://openwrt.org/docs/guide-user/base-system/dhcp_configuration#dhcp_options) 5 and 6 from your router's ```/etc/config/dhcp``` file.
+      - Enabling ```simple-adblock```'s ```force_dns``` setting to override the hardcoded DNS on your device.
+  4. By using the DNS-over-TLS, DNS-over-HTTPS or DNSCrypt on your local device or (if supported) by browser on your local device. You can fix this only by:
+      - Stopping/removing/disabling DNS-over-TLS, DNS-over-HTTPS or DNSCrypt on your local device and using the secure DNS on your router instead. There are merits to all three of the options above, I can recommend the ```https_dns_proxy``` and ```luci-app-https_dns_proxy``` packages for enabling DNS-over-HTTPS on your router.
+
 ## Documentation / Discussion
 
 Please head to [OpenWrt Forum](https://forum.openwrt.org/t/simple-adblock-fast-lean-and-fully-uci-luci-configurable-adblocking/1327/) for discussion of this package.

--- a/net/simple-adblock/files/simple-adblock.conf
+++ b/net/simple-adblock/files/simple-adblock.conf
@@ -12,22 +12,74 @@ config simple-adblock 'config'
 	option debug '0'
 	option compressed_cache '0'
   list whitelist_domain 'raw.githubusercontent.com'
-#	list blacklist_hosts_url 'http://support.it-mate.co.uk/downloads/hosts.txt'
-#	list blacklist_hosts_url 'https://hostsfile.mine.nu/Hosts'
-#	list blacklist_hosts_url 'https://hosts-file.net/ad_servers.txt'
-#	list blacklist_hosts_url 'http://sysctl.org/cameleon/hosts'
-	list blacklist_hosts_url 'http://winhelp2002.mvps.org/hosts.txt'
-	list blacklist_hosts_url 'https://pgl.yoyo.org/as/serverlist.php?hostformat=hosts&showintro=1&mimetype=plaintext'
-	list blacklist_hosts_url 'https://www.malwaredomainlist.com/hostslist/hosts.txt'
-	list blacklist_hosts_url 'https://adaway.org/hosts.txt'
-	list blacklist_hosts_url 'https://someonewhocares.org/hosts/hosts'
-	list blacklist_hosts_url 'https://raw.githubusercontent.com/hoshsadiq/adblock-nocoin-list/master/hosts.txt'
-	list blacklist_domains_url 'https://mirror1.malwaredomains.com/files/justdomains'
-	list blacklist_domains_url 'https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt'
-	list blacklist_domains_url 'https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt'
-	list blacklist_domains_url 'https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt'
-	list blacklist_domains_url 'https://ransomwaretracker.abuse.ch/downloads/RW_DOMBL.txt'
-	list blacklist_domains_url 'https://ssl.bblck.me/blacklists/domain-list.txt'
-	list blacklist_domains_url 'https://dshield.org/feeds/suspiciousdomains_High.txt'
-#	list blacklist_domains_url 'https://dshield.org/feeds/suspiciousdomains_Medium.txt'
-#	list blacklist_domains_url 'https://dshield.org/feeds/suspiciousdomains_Low.txt'
+
+# Thu Oct  3 17:54:04 PDT 2019
+# File size: 4.0K
+  list blacklist_domains_url 'https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt'
+
+# File size: 4.0K
+  list blacklist_domains_url 'https://dshield.org/feeds/suspiciousdomains_High.txt'
+
+# File size: 12.0K
+  list blacklist_domains_url 'https://ssl.bblck.me/blacklists/domain-list.txt'
+
+# File size: 44.0K
+  list blacklist_domains_url 'https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt'
+
+# File size: 44.0K
+  list blacklist_domains_url 'https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt'
+
+# File size: 52.0K
+  list blacklist_domains_url 'https://ransomwaretracker.abuse.ch/downloads/RW_DOMBL.txt'
+
+# File size: 60.0K
+# use just one of the dshield.org blocklists
+#  list blacklist_domains_url 'https://dshield.org/feeds/suspiciousdomains_Medium.txt'
+
+# File size: 64.0K
+# use just one of the dshield.org blocklists
+#  list blacklist_domains_url 'https://dshield.org/feeds/suspiciousdomains_Low.txt'
+
+# File size: 584.0K
+# blocklist too big for most routers
+#  list blacklist_domains_url 'https://mirror1.malwaredomains.com/files/justdomains'
+
+# File size: 20.0K
+  list blacklist_hosts_url 'https://raw.githubusercontent.com/hoshsadiq/adblock-nocoin-list/master/hosts.txt'
+
+# File size: 36.0K
+  list blacklist_hosts_url 'https://www.malwaredomainlist.com/hostslist/hosts.txt'
+
+# File size: 80.0K
+  list blacklist_hosts_url 'https://pgl.yoyo.org/as/serverlist.php?hostformat=hosts&showintro=1&mimetype=plaintext'
+
+# File size: 388.0K
+# blocklist may be too big for some routers
+  list blacklist_hosts_url 'https://raw.githubusercontent.com/jawz101/MobileAdTrackers/master/hosts'
+
+# File size: 424.0K
+# blocklist may be too big for some routers
+  list blacklist_hosts_url 'http://winhelp2002.mvps.org/hosts.txt'
+
+# File size: 432.0K
+# blocklist may be too big for some routers
+  list blacklist_hosts_url 'https://someonewhocares.org/hosts/hosts'
+
+# File size: 624.0K
+# blocklist too big for most routers
+#  list blacklist_hosts_url 'http://sysctl.org/cameleon/hosts'
+
+# File size: 1.7M
+# blocklist too big for most routers
+#  list blacklist_hosts_url 'https://hosts-file.net/ad_servers.txt'
+
+# File size: 3.1M
+# blocklist too big for most routers
+#  list blacklist_hosts_url 'https://hostsfile.mine.nu/Hosts'
+
+# site was down on last check
+#  list blacklist_domains_url 'https://adaway.org/hosts.txt'
+
+# site was down on last check
+#  list blacklist_domains_url 'http://support.it-mate.co.uk/downloads/hosts.txt'
+

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -8,9 +8,10 @@ export START=94
 export USE_PROCD=1
 export LC_ALL=C
 
-export EXTRA_COMMANDS='check dl killcache status'
+export EXTRA_COMMANDS='check dl killcache sizes status'
 export EXTRA_HELP='	check	Checks if specified domain is found in current blacklist
 	dl	Force-redownloads all the list
+	sizes	Shows the file-sizes of enabled block-lists (by downloading them one by one)
 	status	Shows the service last-run status'
 
 readonly packageName='simple-adblock'
@@ -918,7 +919,7 @@ start_service() {
 		case "$1" in
 			download) action='download';;
 			restart|*)
-				if [ -s "$outputFile" ] && [ -n "$status" ]; then
+				if [ -s "$outputFile" ] && [ -n "$status" ] && [ -z "$error" ]; then
 					status
 					exit 0
 				elif [ ! -s "$outputFile" ] && ! cacheOps 'test' && ! cacheOps 'testGzip'; then
@@ -1083,4 +1084,47 @@ check() {
 	else
 		echo "The $string is not found in current blacklist ('$outputFile')."
 	fi
+}
+
+sizes() {
+	local i
+	load_package_config
+	echo "# $(date)"
+
+	for i in $blacklist_domains_urls; do
+		[ "${i//melmac}" != "$i" ] && continue
+		if $dl_command "$i" $dl_flag /tmp/sast 2>/dev/null && [ -s /tmp/sast ]; then
+			echo "# File size: $(du -sh /tmp/sast | awk '{print $1}')"
+			if compare_versions "$(du -sk /tmp/sast)" "500"; then
+				echo "# blocklist too big for most routers"
+			elif compare_versions "$(du -sk /tmp/sast)" "100"; then
+				echo "# blocklist may be too big for some routers"
+			fi
+			rm -rf /tmp/sast
+			echo "  list blacklist_domains_url '$i'"
+			echo ""
+		else
+			echo "# site was down on last check"
+			echo "#  list blacklist_domains_url '$i'"
+			echo ""
+		fi
+	done
+
+	for i in $blacklist_hosts_urls; do
+		if $dl_command "$i" $dl_flag /tmp/sast 2>/dev/null && [ -s /tmp/sast ]; then
+			echo "# File size: $(du -sh /tmp/sast | awk '{print $1}')"
+			if compare_versions "$(du -sk /tmp/sast)" "500"; then
+				echo "# blocklist too big for most routers"
+			elif compare_versions "$(du -sk /tmp/sast)" "100"; then
+				echo "# blocklist may be too big for some routers"
+			fi
+			rm -rf /tmp/sast
+			echo "  list blacklist_hosts_url '$i'"
+			echo ""
+		else
+			echo "# site was down on last check"
+			echo "#  list blacklist_hosts_url '$i'"
+			echo ""
+		fi
+	done
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, WRT3200, 18.06
Run tested: mvebu, WRT3200, 18.06
  - run /etc/init.d/simple-adblock restart|reload when errors were collected in previous run
  - run /etc/init.d/simple-adblock sizes

Description: 
Bugfix: 
  - This change causes force-redownload on restart/reload if an error was encountered during previous run, so that reload|restart work as intended/declared.

Improvements:
  - Updated README.
  - Updated config file to reflect sites which are down and display file sizes and other comments for block-lists.
  - Added the ```sizes``` parameter which prints file sizes for enabled block-lists which can then be copy-pasted into config.