### PR TITLE
banip: update 0.3.0

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.2.1
+PKG_VERSION:=0.3.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
@@ -17,7 +17,7 @@ define Package/banip
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=Ban incoming and/or outgoing ip adresses via ipsets
-	DEPENDS:=+jshn +jsonfilter +ip +ipset +iptables
+	DEPENDS:=+jshn +jsonfilter +ip +ipset +iptables +ca-bundle
 	PKGARCH:=all
 endef
 
@@ -45,7 +45,7 @@ endef
 
 define Package/banip/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) ./files/banip.sh $(1)/usr/bin/
+	$(INSTALL_BIN) ./files/banip.sh $(1)/usr/bin
 
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/banip.init $(1)/etc/init.d/banip
@@ -54,9 +54,10 @@ define Package/banip/install
 	$(INSTALL_CONF) ./files/banip.conf $(1)/etc/config/banip
 
 	$(INSTALL_DIR) $(1)/etc/banip
-	$(INSTALL_CONF) ./files/banip.blacklist $(1)/etc/banip/
-	$(INSTALL_CONF) ./files/banip.whitelist $(1)/etc/banip/
-	
+	$(INSTALL_BIN) ./files/banip.service $(1)/etc/banip
+	$(INSTALL_CONF) ./files/banip.blacklist $(1)/etc/banip
+	$(INSTALL_CONF) ./files/banip.whitelist $(1)/etc/banip
+
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/firewall
 	$(INSTALL_DATA) ./files/banip.hotplug $(1)/etc/hotplug.d/firewall/30-banip
 endef

--- a/net/banip/files/README.md
+++ b/net/banip/files/README.md
@@ -1,20 +1,21 @@
 # banIP - ban incoming and/or outgoing ip adresses via ipsets
 
 ## Description
-IP address blocking is commonly used to protect against brute force attacks, prevent disruptive or unautherized address(es) from access or it can be used to restrict access to or from a particular geographic area — for example.  
+IP address blocking is commonly used to protect against brute force attacks, prevent disruptive or unauthorized address(es) from access or it can be used to restrict access to or from a particular geographic area — for example.  
 
 ## Main Features
 * support many IP blocklist sources (free for private usage, for commercial use please check their individual licenses):
 * zero-conf like automatic installation & setup, usually no manual changes needed
-* supports four different download utilities: uclient-fetch, wget, curl, aria2c
+* automatically selects one of the following download utilities: aria2c, curl, uclient-fetch, wget
 * Really fast downloads & list processing as they are handled in parallel as background jobs in a configurable 'Download Queue'
 * full IPv4 and IPv6 support
 * ipsets (one per source) are used to ban a large number of IP addresses
 * supports blocking by ASN numbers
 * supports blocking by iso country codes
 * supports local white & blacklist (IPv4, IPv6 & CIDR notation), located by default in /etc/banip/banip.whitelist and /etc/banip/banip.blacklist
-* auto-add unsuccessful ssh login attempts to 'dropbear' or 'sshd' to local blacklist (see 'ban_autoblacklist' option)
+* auto-add unsuccessful LuCI and ssh login attempts via 'dropbear' or 'sshd' to local blacklist (see 'ban_autoblacklist' option)
 * auto-add the uplink subnet to local whitelist (see 'ban_autowhitelist' option)
+* provides a small background log monitor to ban unsuccessful login attempts in real-time
 * per source configuration of SRC (incoming) and DST (outgoing)
 * integrated IPSet-Lookup
 * integrated RIPE-Lookup
@@ -29,8 +30,7 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 
 ## Prerequisites
 * [OpenWrt](https://openwrt.org), tested with the stable release series (19.07) and with the latest snapshot
-* a download utility:
-    * to support all blocklist sources a full version with ssl support of 'wget', 'uclient-fetch' with one of the 'libustream-*' ssl libraries, 'aria2c' or 'curl' is required
+* download utility: 'uclient-fetch' with one of the 'libustream-*' ssl libraries, 'wget',  'aria2c' or 'curl' is required
 
 ## Installation & Usage
 * install 'banip' (_opkg install banip_)
@@ -47,8 +47,8 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 * the following options apply to the 'global' config section:
     * ban\_enabled => main switch to enable/disable banIP service (bool/default: '0', disabled)
     * ban\_automatic => determine the L2/L3 WAN network device automatically (bool/default: '1', enabled)
-    * ban\_fetchutil => name of the used download utility: 'uclient-fetch', 'wget', 'curl', 'aria2c', 'wget-nossl'. 'busybox' (default: 'uclient-fetch')
-    * ban\_iface => space separated list of WAN network interface(s)/device(s) used by banIP (default: automatically set by banIP ('ban_automatic'))
+    * ban\_iface => space separated list of WAN network interface(s)/device(s) used by banIP (default: not set, automatically detected)
+    * ban\_realtime => a small log/banIP background monitor to block SSH/LuCI brute force attacks in realtime (bool/default: 'false', disabled)
 
 * the following options apply to the 'extra' config section:
     * ban\_debug => enable/disable banIP debug output (bool/default: '0', disabled)
@@ -56,8 +56,9 @@ IP address blocking is commonly used to protect against brute force attacks, pre
     * ban\_triggerdelay => additional trigger delay in seconds before banIP processing begins (int/default: '2')
     * ban\_backupdir => target directory for banIP backups (default: '/tmp')
     * ban\_sshdaemon => select the SSH daemon for logfile parsing, 'dropbear' or 'sshd' (default: 'dropbear')
-    * ban\_starttype => select the used start type during boot, 'start' or 'reload' (default: 'start')
+    * ban\_starttype => select the used start type during boot, 'start', 'refresh' or 'reload' (default: 'start')
     * ban\_maxqueue => size of the download queue to handle downloads & IPSet processing in parallel (int/default: '4')
+    * ban\_fetchutil => name of the used download utility: 'uclient-fetch', 'wget', 'curl', 'aria2c' (default: not set, automatically detected)
     * ban\_fetchparm => special config options for the download utility (default: not set)
     * ban\_autoblacklist => store auto-addons temporary in ipset and permanently in local blacklist as well (bool/default: '1', enabled)
     * ban\_autowhitelist => store auto-addons temporary in ipset and permanently in local whitelist as well (bool/default: '1', enabled)
@@ -69,12 +70,12 @@ IP address blocking is commonly used to protect against brute force attacks, pre
 /etc/init.d/banip status
 ::: banIP runtime information
   + status     : enabled
-  + version    : 0.2.0
-  + fetch_info : /bin/uclient-fetch (libustream-ssl)
-  + ipset_info : 11 IPSets with overall 118359 IPs/Prefixes
+  + version    : 0.3.0
+  + util_info  : /usr/bin/aria2c, true
+  + ipset_info : 10 IPSets with overall 106729 IPs/Prefixes
   + backup_dir : /tmp
-  + last_run   : 09.09.2019 16:49:40
-  + system     : UBNT-ERX, OpenWrt SNAPSHOT r10962-c19b9f9a26
+  + last_run   : 03.10.2019 19:15:25
+  + system     : UBNT-ERX, OpenWrt SNAPSHOT r11102-ced4c0e635
 </code></pre>
   
 **cronjob for a regular IPSet blocklist update (/etc/crontabs/root):**

--- a/net/banip/files/banip.conf
+++ b/net/banip/files/banip.conf
@@ -1,9 +1,9 @@
 
 config banip 'global'
 	option ban_enabled '0'
+	option ban_basever '0.3'
 	option ban_automatic '1'
-	option ban_fetchutil 'uclient-fetch'
-	option ban_iface 'wan'
+	option ban_realtime 'false'
 
 config banip 'extra'
 	option ban_debug '0'

--- a/net/banip/files/banip.init
+++ b/net/banip/files/banip.init
@@ -5,7 +5,7 @@ START=30
 USE_PROCD=1
 
 EXTRA_COMMANDS="refresh status"
-EXTRA_HELP="	refresh	Refresh ipsets only (no new download!)
+EXTRA_HELP="	refresh	Refresh ipsets without new list downloads
 	status	Print runtime information"
 
 ban_init="/etc/init.d/banip"
@@ -53,9 +53,9 @@ stop_service()
 	rc_procd "${ban_script}" stop
 }
 
-status()
+status_service()
 {
-	local key keylist value 
+	local key keylist value
 	local rtfile="$(uci_get banip global ban_rtfile "/tmp/ban_runtime.json")"
 
 	json_load_file "${rtfile}" >/dev/null 2>&1
@@ -76,14 +76,14 @@ status()
 
 service_triggers()
 {
-	local ban_iface="$(uci_get banip global ban_iface)"
+	local iface iface_list="$(uci_get banip global ban_iface)"
 	local delay="$(uci_get banip extra ban_triggerdelay "2")"
 	local type="$(uci_get banip extra ban_starttype "start")"
 
 	PROCD_RELOAD_DELAY=$((${delay}*1000))
-	if [ -n "${ban_iface}" ]
+	if [ -n "${iface_list}" ]
 	then
-		for iface in ${ban_iface}
+		for iface in ${iface_list}
 		do
 			procd_add_interface_trigger "interface.*.up" "${iface}" "${ban_init}" "${type}"
 		done

--- a/net/banip/files/banip.service
+++ b/net/banip/files/banip.service
@@ -1,0 +1,27 @@
+#!/bin/sh
+# log service to trace failed ssh/luci logins and conditionally refresh banIP
+# written by Dirk Brenken (dev@brenken.org)
+
+# This is free software, licensed under the GNU General Public License v3.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+LC_ALL=C
+PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+
+if [ -r "/lib/functions.sh" ]
+then
+	. "/lib/functions.sh"
+	ban_sshdaemon="$(uci_get banip extra ban_sshdaemon "dropbear")"
+fi
+ban_ver="${1}"
+ban_log="$(command -v logread)"
+
+if [ -x "${ban_log}" ]
+then
+	logger -p "info" -t "banIP-${ban_ver}[${$}]" "log/banIP service started"
+	"${ban_log}" -f -e "${ban_sshdaemon}\|luci: failed login" | \
+		{ grep -qE "Exit before auth|luci: failed login|[0-9]+ \[preauth\]$"; [ $? -eq 0 ] && /etc/init.d/banip refresh; }
+else
+	logger -p "err" -t "banIP-${ban_ver}[${$}]" "can't start log/banIP service"
+fi


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: UBNT-ERX, OpenWrt SNAPSHOT r11102-ced4c0e635

Description:
* new 'ca-bundle' dependency as all https connections are now validated by default
* automatically select the download utility: 'aria2', 'curl', 'uclient-fetch' with libustream-* or wget are supported
* track & ban failed LuCI login attempts as well
* add a small log/banIP background monitor to block SSH/LuCI brute force attacks in realtime (disabled by default)
* add a config version check (please update your default config!)
* made the automatic wan detection more stable
* fix the IPv6 logfile parser
* fix the service status message
* update readme
* update LuCI frontend (separate PR)

Signed-off-by: Dirk Brenken <dev@brenken.org>
