### PR TITLE
icu: use our own python3 for host-compilation

### DIFF
--- a/libs/icu/Makefile
+++ b/libs/icu/Makefile
@@ -28,6 +28,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_BUILD_DEPENDS:=icu/host
+HOST_BUILD_DEPENDS:=python3/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk


### PR DESCRIPTION
Maintainer: @nxhack, @neheb 
Compile tested: Debian stable, Entware repo ([commit](https://github.com/Entware/entware-packages/commit/ff95a999410a6f74367dd4ce7064edbace77df1e))
Run tested: Entware repo, mipsel feed

Description: `icu` host compilation uses available python3 at Host/Configure stage. So it fails on hosts without `distutils` python module. It can be reproduced on Clean Debian 10.1 stable:
```
…
config.status: creating samples/Makefile
config.status: creating samples/date/Makefile
config.status: creating samples/cal/Makefile
config.status: creating samples/layout/Makefile
Not rebuilding data/rules.mk, assuming prebuilt data in data/in
Spawning Python to generate test/testdata/rules.mk...
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/Entware/build_dir/hostpkg/icu4c-64.2/data/buildtool/__main__.py", line 19, in <module>
    import BUILDRULES
  File "/home/Entware/build_dir/hostpkg/icu4c-64.2/test/testdata/BUILDRULES.py", line 4, in <module>
    from distutils.sysconfig import parse_makefile
ModuleNotFoundError: No module named 'distutils.sysconfig'
configure: error: Python failed to run; see above error.
./runConfigureICU: ./configure failed
make[2]: *** [Makefile:161: /home/Entware/build_dir/hostpkg/icu4c-64.2/.configured] Error 1
make[2]: Leaving directory '/home/Entware/feeds/packages/libs/icu'
```
I leaved `PKG_RELEASE` unchanged because package content stays the same.