### PR TITLE
[openwrt-19.07] python-simplejson: Fix python[3]-decimal dependency

### DIFF
--- a/lang/python/python-simplejson/Makefile
+++ b/lang/python/python-simplejson/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-simplejson
 PKG_VERSION:=3.16.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=MIT
 PKG_CPE_ID:=cpe:/a:simplejson_project:simplejson
 
@@ -35,14 +35,14 @@ endef
 define Package/python-simplejson
 $(call Package/python-simplejson/Default)
   TITLE:=Simple, fast, extensible JSON encoder/decoder for Python 2
-  DEPENDS:=+PACKAGE_python-simplejson:python-light
+  DEPENDS:=+PACKAGE_python-simplejson:python-light +PACKAGE_python-simplejson:python-decimal
   VARIANT:=python
 endef
 
 define Package/python3-simplejson
 $(call Package/python-simplejson/Default)
   TITLE:=Simple, fast, extensible JSON encoder/decoder for Python3
-  DEPENDS:=+PACKAGE_python3-simplejson:python3-light
+  DEPENDS:=+PACKAGE_python3-simplejson:python3-light +PACKAGE_python3-simplejson:python3-decimal
   VARIANT:=python3
 endef
 


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: none (cherry-picked from #10148)
Run tested: none

Description:
simplejson depends on the decimal module ([1][1], [2][2]). This adds python[3]-decimal to the package's DEPENDS.

[1]: https://github.com/simplejson/simplejson/blob/v3.16.0/simplejson/__init__.py#L110
[2]: https://github.com/simplejson/simplejson/blob/v3.16.0/simplejson/encoder.py#L7

Signed-off-by: Jeffery To <jeffery.to@gmail.com>