### PR TITLE
prometheus-node-exporter-lua: an unavaliable wifi interface may have …

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,8 +4,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2019.08.14
-PKG_RELEASE:=2
+PKG_VERSION:=2019.10.05
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi.lua
@@ -13,29 +13,31 @@ local function scrape()
   for dev, dev_table in pairs(status) do
     for _, intf in ipairs(dev_table['interfaces']) do
       local ifname = intf['ifname']
-      local iw = iwinfo[iwinfo.type(ifname)]
-      local labels = {
-        channel = iw.channel(ifname),
-        ssid = iw.ssid(ifname),
-        bssid = iw.bssid(ifname),
-        mode = iw.mode(ifname),
-        ifname = ifname,
-        country = iw.country(ifname),
-        frequency = iw.frequency(ifname),
-        device = dev,
-      }
+      if ifname ~= nil then
+        local iw = iwinfo[iwinfo.type(ifname)]
+        local labels = {
+          channel = iw.channel(ifname),
+          ssid = iw.ssid(ifname),
+          bssid = iw.bssid(ifname),
+          mode = iw.mode(ifname),
+          ifname = ifname,
+          country = iw.country(ifname),
+          frequency = iw.frequency(ifname),
+          device = dev,
+        }
 
-      local qc = iw.quality(ifname) or 0
-      local qm = iw.quality_max(ifname) or 0
-      local quality = 0
-      if qc > 0 and qm > 0 then
-        quality = math.floor((100 / qm) * qc)
+        local qc = iw.quality(ifname) or 0
+        local qm = iw.quality_max(ifname) or 0
+        local quality = 0
+        if qc > 0 and qm > 0 then
+          quality = math.floor((100 / qm) * qc)
+        end
+
+        metric_wifi_network_quality(labels, quality)
+        metric_wifi_network_noise(labels, iw.noise(ifname) or 0)
+        metric_wifi_network_bitrate(labels, iw.bitrate(ifname) or 0)
+        metric_wifi_network_signal(labels, iw.signal(ifname) or -255)
       end
-
-      metric_wifi_network_quality(labels, quality)
-      metric_wifi_network_noise(labels, iw.noise(ifname) or 0)
-      metric_wifi_network_bitrate(labels, iw.bitrate(ifname) or 0)
-      metric_wifi_network_signal(labels, iw.signal(ifname) or -255)
     end
   end
 end

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/wifi_stations.lua
@@ -26,42 +26,44 @@ local function scrape()
   for dev, dev_table in pairs(status) do
     for _, intf in ipairs(dev_table['interfaces']) do
       local ifname = intf['ifname']
-      local iw = iwinfo[iwinfo.type(ifname)]
-      local count = 0
+      if ifname ~= nil then
+        local iw = iwinfo[iwinfo.type(ifname)]
+        local count = 0
 
-      local assoclist = iw.assoclist(ifname)
-      for mac, station in pairs(assoclist) do
-        local labels = {
-          ifname = ifname,
-          mac = mac,
-        }
-        if station.signal and station.signal ~= 0 then
-          metric_wifi_station_signal(labels, station.signal)
-        end
-        if station.inactive then
-          metric_wifi_station_inactive(labels, station.inactive)
-        end
-        if station.expected_throughput and station.expected_throughput ~= 0 then
-          metric_wifi_station_exp_thr(labels, station.expected_throughput)
-        end
-        if station.tx_rate and station.tx_rate ~= 0 then
-          metric_wifi_station_tx_bitrate(labels, station.tx_rate)
-        end
-        if station.rx_rate and station.rx_rate ~= 0 then
-          metric_wifi_station_rx_bitrate(labels, station.rx_rate)
-        end
-        metric_wifi_station_tx_packets(labels, station.tx_packets)
-        metric_wifi_station_rx_packets(labels, station.rx_packets)
-        if station.tx_bytes then
-          metric_wifi_station_tx_bytes(labels, station.tx_bytes)
-        end
-        if station.rx_bytes then
-          metric_wifi_station_rx_bytes(labels, station.rx_bytes)
-        end
+        local assoclist = iw.assoclist(ifname)
+        for mac, station in pairs(assoclist) do
+          local labels = {
+            ifname = ifname,
+            mac = mac,
+          }
+          if station.signal and station.signal ~= 0 then
+            metric_wifi_station_signal(labels, station.signal)
+          end
+          if station.inactive then
+            metric_wifi_station_inactive(labels, station.inactive)
+          end
+          if station.expected_throughput and station.expected_throughput ~= 0 then
+            metric_wifi_station_exp_thr(labels, station.expected_throughput)
+          end
+          if station.tx_rate and station.tx_rate ~= 0 then
+            metric_wifi_station_tx_bitrate(labels, station.tx_rate)
+          end
+          if station.rx_rate and station.rx_rate ~= 0 then
+            metric_wifi_station_rx_bitrate(labels, station.rx_rate)
+          end
+          metric_wifi_station_tx_packets(labels, station.tx_packets)
+          metric_wifi_station_rx_packets(labels, station.rx_packets)
+          if station.tx_bytes then
+            metric_wifi_station_tx_bytes(labels, station.tx_bytes)
+          end
+          if station.rx_bytes then
+            metric_wifi_station_rx_bytes(labels, station.rx_bytes)
+          end
 
-        count = count + 1
+          count = count + 1
+        end
+        metric_wifi_stations({ifname = ifname}, count)
       end
-      metric_wifi_stations({ifname = ifname}, count)
     end
   end
 end


### PR DESCRIPTION
…stopped the scraper from functioning

Maintainer:  @champtar 
Compile tested: lua script...no need
Run tested: OpenWrt snapshot on linksys ea8300 r11126-cb289777ca

Description:

my router has 3 wifi interfaces from which 1 is always disabled because of driver issues.
The prometheus target was not able to list the connected wifi clients because there are no information about the disabled interface.

