### PR TITLE
boost: Remove several host libraries

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.71.0
 PKG_SOURCE_VERSION:=1_71_0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/
@@ -367,7 +367,7 @@ define Host/Compile
 
 	( cd $(HOST_BUILD_DIR) ; \
 		./bootstrap.sh --prefix=$(STAGING_DIR_HOSTPKG) \
-			--with-libraries=atomic,context,date_time,filesystem,headers,program_options,regex,system,thread ;\
+			--with-libraries=context,filesystem,program_options,regex,system ;\
 		./b2 --ignore-site-config install )
 endef
 

--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -332,7 +332,7 @@ endef
 $(eval $(call DefineBoostLibrary,atomic,system))
 $(eval $(call DefineBoostLibrary,chrono,system))
 $(eval $(call DefineBoostLibrary,container))
-$(eval $(call DefineBoostLibrary,context,chrono system thread,,!boost-context-exclude))
+$(eval $(call DefineBoostLibrary,context,chrono system,,!boost-context-exclude))
 $(eval $(call DefineBoostLibrary,contract,system))
 $(eval $(call DefineBoostLibrary,coroutine,system chrono context thread,,!boost-coroutine-exclude))
 $(eval $(call DefineBoostLibrary,date_time))


### PR DESCRIPTION
The facebook people have been working on removing Boost dependencies from
their projects. This is the current state.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ClaymorePT 
Compile tested: ath79

I'd like some clarification on boost dependencies.

The host libraries here are identical to the target ones. However for the target, boost-atomic and boost-chrono are additionally selected. From looking at the Makefile, thread depends on atomic and chrono.

I tried removing those dependencies and was successful in getting everything to compile.

Are these dependencies outdated or are they actually needed?