### PR TITLE
gptfdisk: Switch to using uClibc++

### DIFF
--- a/utils/gptfdisk/Makefile
+++ b/utils/gptfdisk/Makefile
@@ -9,26 +9,27 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gptfdisk
 PKG_VERSION:=1.0.4
-PKG_RELEASE:=1
-
-PKG_MAINTAINER:=Alif M. Ahmad <alive4ever@live.com>
-PKG_LICENSE:=GPL-2.0
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
 PKG_HASH:=b663391a6876f19a3cd901d862423a16e2b5ceaa2f4a3b9bb681e64b9c7ba78d
 
+PKG_MAINTAINER:=Alif M. Ahmad <alive4ever@live.com>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
 PKG_BUILD_PARALLEL:=1
 
-include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/gptfdisk/Default
   SECTION:=utils
   CATEGORY:=Utilities
   SUBMENU:=Disc
-  URL:=http://www.rodsbooks.com/gdisk
-  DEPENDS:= +libstdcpp
+  URL:=https://www.rodsbooks.com/gdisk
+  DEPENDS:=$(CXX_DEPENDS)
 endef
 
 define Package/gdisk
@@ -71,6 +72,12 @@ define Package/fixparts/description
   a text-mode menu-driven program for repairing certain types of problems with
   Master Boot Record (MBR) partition tables
 endef
+
+TARGET_CXXFLAGS += -std=c++11 -ffunction-sections -fdata-sections -fno-rtti -flto
+TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lm) -Wl,--gc-sections,--as-needed
+ifeq ($(CONFIG_USE_UCLIBCXX),y)
+TARGET_LDFLAGS += -nodefaultlibs
+endif
 
 define Package/gdisk/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/utils/gptfdisk/patches/010-gptcurses-Add-missing-header.patch
+++ b/utils/gptfdisk/patches/010-gptcurses-Add-missing-header.patch
@@ -1,0 +1,27 @@
+From 9e6016b07ff6d1de5143d3dfefb58fb4268a78e1 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Mon, 7 Oct 2019 15:34:43 -0700
+Subject: [PATCH 1/4] gptcurses: Add missing header
+
+Needed with uClibc++ as it doesn't implicitly include it.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ gptcurses.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gptcurses.cc b/gptcurses.cc
+index 3e9b240..4ebfde1 100644
+--- a/gptcurses.cc
++++ b/gptcurses.cc
+@@ -19,6 +19,7 @@
+  *
+  */
+ 
++#include <clocale>
+ #include <iostream>
+ #include <string>
+ #include <sstream>
+-- 
+2.17.1
+

--- a/utils/gptfdisk/patches/020-support-Flush-cout-in-GetYN.patch
+++ b/utils/gptfdisk/patches/020-support-Flush-cout-in-GetYN.patch
@@ -1,0 +1,28 @@
+From 5542b160fa73e5e81e83c2d8dd1b79c3023094ee Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Mon, 7 Oct 2019 15:36:31 -0700
+Subject: [PATCH 2/4] support: Flush cout in GetYN
+
+uClibc++ does not implicitly flush cout before getline.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ support.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/support.cc b/support.cc
+index d47965a..5ab8a23 100644
+--- a/support.cc
++++ b/support.cc
+@@ -101,7 +101,7 @@ char GetYN(void) {
+    do {
+       if ( again ) { cout << "Your option? " ; }
+       again = 1 ;
+-      cout << "(Y/N): ";
++      cout << "(Y/N): " << flush;
+       line = ReadString();
+       response = toupper(line[0]);
+    } while ((response != 'Y') && (response != 'N'));
+-- 
+2.17.1
+

--- a/utils/gptfdisk/patches/030-support-flush-cout-in-GetNumber.patch
+++ b/utils/gptfdisk/patches/030-support-flush-cout-in-GetNumber.patch
@@ -1,0 +1,28 @@
+From 31d1f45cd63ec142fc559ea4f8a70bd4a1151c42 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Mon, 7 Oct 2019 15:39:14 -0700
+Subject: [PATCH 3/4] support: flush cout in GetNumber
+
+uClibc++ does not implicitly do this before getline.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ support.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/support.cc b/support.cc
+index 5ab8a23..1107993 100644
+--- a/support.cc
++++ b/support.cc
+@@ -73,7 +73,7 @@ uint64_t GetNumber(uint64_t low, uint64_t high, uint64_t def, const string & pro
+ 
+    if (low != high) { // bother only if low and high differ...
+       do {
+-         cout << prompt;
++         cout << prompt << flush;
+          cin.getline(line, 255);
+          if (!cin.good())
+             exit(5);
+-- 
+2.17.1
+

--- a/utils/gptfdisk/patches/040-support-flush-cout-in-ReadString.patch
+++ b/utils/gptfdisk/patches/040-support-flush-cout-in-ReadString.patch
@@ -1,0 +1,27 @@
+From 185f73b1084936f85beddd4523a302cb1f906234 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Mon, 7 Oct 2019 15:41:53 -0700
+Subject: [PATCH 4/4] support: flush cout in ReadString
+
+uClibc++ does not implicitly do this.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ support.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/support.cc b/support.cc
+index 1107993..891caad 100644
+--- a/support.cc
++++ b/support.cc
+@@ -55,6 +55,7 @@ string ReadString(void) {
+ string ReadString(void) {
+    string inString;
+ 
++   cout << flush;
+    getline(cin, inString);
+    if (!cin.good())
+       exit(5);
+-- 
+2.17.1
+

--- a/utils/gptfdisk/patches/050-Add-some-extra-flushes-before-getline-cin.patch
+++ b/utils/gptfdisk/patches/050-Add-some-extra-flushes-before-getline-cin.patch
@@ -1,0 +1,79 @@
+From b33f93bea332211afae037e4b6f379f0876302d1 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 8 Oct 2019 20:51:54 -0700
+Subject: [PATCH] Add some extra flushes before getline/cin
+
+These are not covered by the previous commits.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ diskio-unix.cc | 2 +-
+ gptcurses.cc   | 4 ++--
+ parttypes.cc   | 2 +-
+ support.cc     | 2 +-
+ 4 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/diskio-unix.cc b/diskio-unix.cc
+index d9f8b8d..c38fda5 100644
+--- a/diskio-unix.cc
++++ b/diskio-unix.cc
+@@ -92,7 +92,7 @@ int DiskIO::OpenForRead(void) {
+ #if defined(__linux__) && !defined(EFI)
+          if (isOpen && realFilename.substr(0,4) == "/dev") {
+             ostringstream modelNameFilename;
+-            modelNameFilename << "/sys/block" << realFilename.substr(4,512) << "/device/model";
++            modelNameFilename << "/sys/block" << realFilename.substr(4,512) << "/device/model" << flush;
+             ifstream modelNameFile(modelNameFilename.str().c_str());
+             if (modelNameFile.is_open()) {
+                getline(modelNameFile, modelName);
+diff --git a/gptcurses.cc b/gptcurses.cc
+index 4ebfde1..ca6f4ea 100644
+--- a/gptcurses.cc
++++ b/gptcurses.cc
+@@ -418,7 +418,7 @@ void GPTDataCurses::Verify(void) {
+    def_prog_mode();
+    endwin();
+    GPTData::Verify();
+-   cout << "\nPress the <Enter> key to continue: ";
++   cout << "\nPress the <Enter> key to continue: " << flush;
+    cin.get(junk);
+    reset_prog_mode();
+    refresh();
+@@ -816,7 +816,7 @@ void ShowTypes(void) {
+    def_prog_mode();
+    endwin();
+    tempType.ShowAllTypes(LINES - 3);
+-   cout << "\nPress the <Enter> key to continue: ";
++   cout << "\nPress the <Enter> key to continue: " << flush;
+    cin.get(junk);
+    reset_prog_mode();
+    refresh();
+diff --git a/parttypes.cc b/parttypes.cc
+index cd225d1..6c2c8c6 100644
+--- a/parttypes.cc
++++ b/parttypes.cc
+@@ -524,7 +524,7 @@ void PartType::ShowAllTypes(int maxLines) const {
+             if (thisType->next) {
+                cout << "\n";
+                if ((maxLines > 0) && (lineCount++ % maxLines) == 0) {
+-                  cout << "Press the <Enter> key to see more codes: ";
++                  cout << "Press the <Enter> key to see more codes: " << flush;
+                   getline(cin, line);
+                } // if reached screen line limit
+             } // if there's another entry following this one
+diff --git a/support.cc b/support.cc
+index 891caad..645ef5d 100644
+--- a/support.cc
++++ b/support.cc
+@@ -123,7 +123,7 @@ uint64_t GetSectorNum(uint64_t low, uint64_t high, uint64_t def, uint64_t sSize,
+    char line[255];
+ 
+    do {
+-      cout << prompt;
++      cout << prompt << flush;
+       cin.getline(line, 255);
+       if (!cin.good())
+          exit(5);
+-- 
+2.17.1
+


### PR DESCRIPTION
Added patches sent upstream to fix usage with uClibc++.

Cleaned up license information.

Added several size optimizations.

Several other Makefile cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @alive4ever 
Compile tested: ath79 aarch64
Run tested: Archer C7v3