### PR TITLE
python[3]-simplejson: drop tests from simplejson package

### DIFF
--- a/lang/python/python-simplejson/Makefile
+++ b/lang/python/python-simplejson/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-simplejson
 PKG_VERSION:=3.16.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=MIT
 PKG_CPE_ID:=cpe:/a:simplejson_project:simplejson
 
@@ -54,6 +54,16 @@ define Package/python3-simplejson/description
 $(call Package/python-simplejson/description)
 .
 (Variant for Python3)
+endef
+
+define PyPackage/python-simplejson/filespec
++|$(PYTHON_PKG_DIR)
+-|$(PYTHON_PKG_DIR)/simplejson/tests
+endef
+
+define Py3Package/python3-simplejson/filespec
++|$(PYTHON3_PKG_DIR)
+-|$(PYTHON3_PKG_DIR)/simplejson/tests
 endef
 
 $(eval $(call PyPackage,python-simplejson))


### PR DESCRIPTION
Maintainer: me
Compile tested: x86  https://github.com/openwrt/openwrt/commit/273a6cb562b1b993666670f32350c6d7ef51b49b
Run tested: x86  https://github.com/openwrt/openwrt/commit/273a6cb562b1b993666670f32350c6d7ef51b49b

These tests take-up a bit of space. And they aren't typically needed.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>