### PR TITLE
python-pillow: bump to version 6.2.0

### DIFF
--- a/lang/python/pillow/Makefile
+++ b/lang/python/pillow/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pillow
-PKG_VERSION:=6.1.0
+PKG_VERSION:=6.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=Pillow-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/P/Pillow
-PKG_HASH:=0804f77cb1e9b6dbd37601cee11283bba39a8d44b9ddb053400c58e0c0d7d9de
+PKG_HASH:=4548236844327a718ce3bb182ab32a16fa2050c61e334e959f554cac052fb0df
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-Pillow-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/273a6cb562b1b993666670f32350c6d7ef51b49b
Run tested: x86 https://github.com/openwrt/openwrt/commit/273a6cb562b1b993666670f32350c6d7ef51b49b

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>