### PR TITLE
gammu: Remove python dependency, fix lib symlinks

### DIFF
--- a/utils/gammu/Makefile
+++ b/utils/gammu/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gammu
 PKG_VERSION:=1.41.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://dl.cihar.com/gammu/releases
@@ -33,7 +33,7 @@ define Package/gammu
 	TITLE:=Cell phone/modem SMS and control tool
 	URL:=https://wammu.eu/gammu/
 	DEPENDS:=+libpthread +libcurl +glib2 $(ICONV_DEPENDS) $(INTL_DEPENDS)
-	DEPENDS+=+PACKAGE_python3:python3 +PACKAGE_bluez-libs:bluez-libs
+	DEPENDS+=+PACKAGE_bluez-libs:bluez-libs
 	DEPENDS+=+PACKAGE_libmariadb:libmariadb +PACKAGE_unixodbc:unixodbc +PACKAGE_libpq:libpq
 	DEPENDS+=+PACKAGE_libusb-1.0:libusb-1.0
 endef
@@ -54,7 +54,7 @@ define Package/gammu/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gammu $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gammu-{smsd,smsd-inject,smsd-monitor} $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/lib{Gammu*,gsmsd*} $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{Gammu*,gsmsd*} $(1)/usr/lib
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/gammu $(1)/etc/config/gammu


### PR DESCRIPTION
Maintainer: @aTanW 
Compile tested: armvirt-64, 2019-10-04 snapshot sdk
Run tested: none

Description:
This removes the python dependency from the package; according to the maintainer ([1][1], [2][2]) the software does not depend on python.

This also fixes the symlinks for `libGammu.so` and `libgsmsd.so`. Previously, the symlinks were overwritten by `$(INSTALL_BIN)` with copies of their sources.

[1]: https://github.com/openwrt/packages/issues/8893#issuecomment-539136531
[2]: https://github.com/openwrt/packages/issues/8893#issuecomment-539152794

I don't know how this software is suppose to work, so I would appreciate if someone (@aTanW / @neheb / @micmac1?) can do a run-test.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>