### PR TITLE
tor: update to 0.4.1.6

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.1.5
+PKG_VERSION:=0.4.1.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=a864e0b605fb933fcc167bf242eed4233949e8a1bf23ac8e0381b106cd920425
+PKG_HASH:=2a88524ce426079fb9b828bc1b789f2c8ade3ed53c130851102debc3518bed71
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates Tor to latest stable release

Notes from changelog
```
Changes in version 0.4.1.6 - 2019-09-19
  This release backports several bugfixes to improve stability and
  correctness.  Anyone experiencing build problems or crashes with 0.4.1.5,
  or experiencing reliability issues with single onion services, should
  upgrade.
```

