### PR TITLE
cgi-io: fix various errors

### DIFF
--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_LICENSE:=GPL-2.0-or-later
 


### PR DESCRIPTION
Currently cgi-io try to read data after the data ended.
- Adds "-" to whitelist char
- In main_upload is tried to consume the buffer while it's already readed by the while loop before

To fix this we check if the readed block is equal to the max block and stop if we readed less byte

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>