### PR TITLE
collectd: update to 5.9.2

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
-PKG_VERSION:=5.9.0
-PKG_RELEASE:=7
+PKG_VERSION:=5.9.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \
 	https://github.com/collectd/collectd/releases/download/collectd-$(PKG_VERSION)
-PKG_HASH:=7b220f8898a061f6e7f29a8c16697d1a198277f813da69474a67911097c0626b
+PKG_HASH:=917c483608b9b38438b121737b510c3d68f335c091bc286aa6ebcc0c8e372a09
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libltdl/aclocal.m4

--- a/utils/collectd/patches/0001-fix-5.9.2-version-string.patch
+++ b/utils/collectd/patches/0001-fix-5.9.2-version-string.patch
@@ -1,0 +1,11 @@
+--- a/version-gen.sh
++++ b/version-gen.sh
+@@ -1,6 +1,6 @@
+ #!/bin/sh
+ 
+-DEFAULT_VERSION="5.9.0.git"
++DEFAULT_VERSION="5.9.2"
+ 
+ if [ -d .git ]; then
+ 	VERSION="`git describe --dirty=+ --abbrev=7 2> /dev/null | grep collectd | sed -e 's/^collectd-//' -e 's/-/./g'`"
+

--- a/utils/collectd/patches/300-delay-first-read-cycle.patch
+++ b/utils/collectd/patches/300-delay-first-read-cycle.patch
@@ -1,6 +1,6 @@
 --- a/src/daemon/plugin.c
 +++ b/src/daemon/plugin.c
-@@ -1085,7 +1085,7 @@ static int plugin_insert_read(read_func_
+@@ -1087,7 +1087,7 @@ static int plugin_insert_read(read_func_
    int status;
    llentry_t *le;
  

--- a/utils/collectd/patches/600-fix-libmodbus-detection.patch
+++ b/utils/collectd/patches/600-fix-libmodbus-detection.patch
@@ -18,7 +18,7 @@ Reversed patch to be applied:
 
 --- a/configure.ac
 +++ b/configure.ac
-@@ -3399,9 +3399,9 @@ if test "x$with_libmodbus" = "xyes"; the
+@@ -3393,9 +3393,9 @@ if test "x$with_libmodbus" = "xyes"; the
    SAVE_CPPFLAGS="$CPPFLAGS"
    CPPFLAGS="$CPPFLAGS $with_libmodbus_cflags"
  

--- a/utils/collectd/patches/700-disable-sys-capability-check.patch
+++ b/utils/collectd/patches/700-disable-sys-capability-check.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -531,11 +531,7 @@ if test "x$ac_system" = "xLinux"; then
+@@ -532,11 +532,7 @@ if test "x$ac_system" = "xLinux"; then
      [have_cpuid_h="no (cpuid.h not found)"]
    )
  

--- a/utils/collectd/patches/900-add-iwinfo-plugin.patch
+++ b/utils/collectd/patches/900-add-iwinfo-plugin.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -721,6 +721,11 @@ AC_CACHE_CHECK([whether clock_boottime a
+@@ -712,6 +712,11 @@ AC_CACHE_CHECK([whether clock_boottime a
    ]
  )
  
@@ -12,7 +12,7 @@
  
  #
  # Checks for typedefs, structures, and compiler characteristics.
-@@ -6392,6 +6397,7 @@ plugin_ipc="no"
+@@ -6394,6 +6399,7 @@ plugin_ipc="no"
  plugin_ipmi="no"
  plugin_ipvs="no"
  plugin_irq="no"
@@ -20,7 +20,7 @@
  plugin_load="no"
  plugin_log_logstash="no"
  plugin_mcelog="no"
-@@ -6826,6 +6832,7 @@ AC_PLUGIN([ipmi],                [$plugi
+@@ -6828,6 +6834,7 @@ AC_PLUGIN([ipmi],                [$plugi
  AC_PLUGIN([iptables],            [$with_libiptc],             [IPTables rule counters])
  AC_PLUGIN([ipvs],                [$plugin_ipvs],              [IPVS connection statistics])
  AC_PLUGIN([irq],                 [$plugin_irq],               [IRQ statistics])
@@ -28,7 +28,7 @@
  AC_PLUGIN([java],                [$with_java],                [Embed the Java Virtual Machine])
  AC_PLUGIN([load],                [$plugin_load],              [System load])
  AC_PLUGIN([log_logstash],        [$plugin_log_logstash],      [Logstash json_event compatible logging])
-@@ -7193,6 +7200,7 @@ AC_MSG_RESULT([    libyajl . . . . . . .
+@@ -7197,6 +7204,7 @@ AC_MSG_RESULT([    libyajl . . . . . . .
  AC_MSG_RESULT([    oracle  . . . . . . . $with_oracle])
  AC_MSG_RESULT([    protobuf-c  . . . . . $have_protoc_c])
  AC_MSG_RESULT([    protoc 3  . . . . . . $have_protoc3])
@@ -36,7 +36,7 @@
  AC_MSG_RESULT()
  AC_MSG_RESULT([  Features:])
  AC_MSG_RESULT([    daemon mode . . . . . $enable_daemon])
-@@ -7253,6 +7261,7 @@ AC_MSG_RESULT([    ipmi  . . . . . . . .
+@@ -7257,6 +7265,7 @@ AC_MSG_RESULT([    ipmi  . . . . . . . .
  AC_MSG_RESULT([    iptables  . . . . . . $enable_iptables])
  AC_MSG_RESULT([    ipvs  . . . . . . . . $enable_ipvs])
  AC_MSG_RESULT([    irq . . . . . . . . . $enable_irq])
@@ -252,7 +252,7 @@
 +}
 --- a/src/types.db
 +++ b/src/types.db
-@@ -240,6 +240,7 @@ voltage_threshold       value:GAUGE:U:U,
+@@ -240,6 +240,7 @@ snr                     value:GAUGE:0:U
  spam_check              value:GAUGE:0:U
  spam_score              value:GAUGE:U:U
  spl                     value:GAUGE:U:U
@@ -262,7 +262,7 @@
  tcp_connections         value:GAUGE:0:4294967295
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -1149,6 +1149,14 @@ irq_la_LDFLAGS = $(PLUGIN_LDFLAGS)
+@@ -1150,6 +1150,14 @@ irq_la_LDFLAGS = $(PLUGIN_LDFLAGS)
  irq_la_LIBADD = libignorelist.la
  endif
  


### PR DESCRIPTION
Update collectd to 5.9.2
Mainly bug fixes: https://github.com/collectd/collectd/blob/dfb9dd09fe3a6864c8cf85eb92e826c289e6d6d2/ChangeLog

Note that the moment of writing this, there seems to be some confusion at the upstream collectd about their own release process.  (discussion at https://github.com/collectd/collectd/issues/3293) Currently the downloadable source archive files are different on github and collectd.org sites, and I have defined the hash according to the apparently correct file on Github. 

For that reason I did not commit this directly, but issued a PR for a few days. Let's see how the situation upstream plays out.

I have compile tested all plugins and run-tested the most frequently used ones.

Maintainer: me 
Run tested: ipqq806x/R7800

