### PR TITLE
modemmanager: remove check for unneeded host dependency intltool

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -129,8 +129,4 @@ $(eval $(call RequireCommand,xsltproc, \
         $(PKG_NAME) requires xsltproc installed on the host-system. \
 ))
 
-$(eval $(call RequireCommand,intltoolize, \
-        $(PKG_NAME) requires intltool installed on the host-system. \
-))
-
 $(eval $(call BuildPackage,modemmanager))


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas.smith@telcoantennas.com.au>