### PR TITLE
kea: update package to 1.6.0

### DIFF
--- a/net/kea/Makefile
+++ b/net/kea/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kea
-PKG_VERSION:=1.5.0
-PKG_RELEASE:=5
+PKG_VERSION:=1.6.0
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.isc.org/isc/kea/$(PKG_VERSION)
-PKG_HASH:=edce4fab68ca7af607cf7f5bc86596e04fe0ef4b8e88906e339cdefcf21daaec
+PKG_HASH:=44ed48c729e4618fffcf0086529b469f7232990983187b2f71fce89f1ac6e270
 
 PKG_MAINTAINER:=BangLang Huang<banglang.huang@foxmail.com>, Rosy Song<rosysong@rosinson.com>
 PKG_LICENSE:=MPL-2.0
@@ -149,7 +149,8 @@ HOST_CONFIGURE_ARGS += \
 	--with-log4cplus="$(STAGING_DIR_HOSTPKG)" \
 	--with-openssl="$(STAGING_DIR)/usr" \
 	--enable-boost-headers-only \
-	--enable-static-link
+	--enable-static-link \
+	--enable-generate-messages
 
 HOST_LDFLAGS += \
 	 -Wl,--gc-sections,--as-needed
@@ -229,7 +230,6 @@ define Package/kea-ctrl/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/kea-ctrl-agent $(1)/usr/sbin/kea-ctrl-agent
 	$(CP) $(PKG_INSTALL_DIR)/etc/kea/keactrl.conf $(1)/etc/kea/
 	$(CP) $(PKG_INSTALL_DIR)/etc/kea/kea-ctrl-agent.conf $(1)/etc/kea/
-	$(CP) $(PKG_INSTALL_DIR)/etc/kea/kea-netconf.conf $(1)/etc/kea/
 endef
 
 define Package/kea-lfc/install

--- a/net/kea/patches/001-fix-cross-compile.patch
+++ b/net/kea/patches/001-fix-cross-compile.patch
@@ -1,8 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -580,10 +580,10 @@ AC_TRY_COMPILE([
-         AC_MSG_RESULT(no))
- 
+@@ -542,8 +542,8 @@ AC_TRY_COMPILE([
  AC_MSG_CHECKING(for usuable C++11 regex)
 -AC_TRY_RUN([
 +AC_TRY_COMPILE([

--- a/net/kea/patches/003-no-test-compile.patch
+++ b/net/kea/patches/003-no-test-compile.patch
@@ -3,7 +3,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  # Install kea-admin in sbin.
  sbin_SCRIPTS  = kea-admin
 --- a/src/bin/agent/Makefile.am
@@ -11,7 +11,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/d2/Makefile.am
@@ -19,7 +19,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/dhcp4/Makefile.am
@@ -27,7 +27,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/dhcp6/Makefile.am
@@ -35,7 +35,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/keactrl/Makefile.am
@@ -43,7 +43,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  # Install keactrl in sbin and the keactrl.conf required by the keactrl
  # in etc. keactrl will look for its configuration file in the etc folder.
 --- a/src/bin/lfc/Makefile.am
@@ -51,7 +51,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/netconf/Makefile.am
@@ -59,7 +59,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/perfdhcp/Makefile.am
@@ -67,7 +67,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -I$(top_srcdir)/src/bin -I$(top_builddir)/src/bin
 --- a/src/bin/shell/Makefile.am
@@ -75,15 +75,15 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  pkgpython_PYTHON = kea_conn.py kea_connector2.py kea_connector3.py
- 
+
 --- a/src/hooks/dhcp/high_availability/Makefile.am
 +++ b/src/hooks/dhcp/high_availability/Makefile.am
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/hooks/dhcp/lease_cmds/Makefile.am
@@ -91,7 +91,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/hooks/dhcp/stat_cmds/Makefile.am
@@ -99,7 +99,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/hooks/dhcp/user_chk/Makefile.am
@@ -107,7 +107,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/asiodns/Makefile.am
@@ -115,7 +115,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/asiolink/Makefile.am
@@ -123,7 +123,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . testutils tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/cc/Makefile.am
@@ -131,7 +131,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/cfgrpt/Makefile.am
@@ -139,7 +139,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CXXFLAGS  = $(KEA_CXXFLAGS)
 --- a/src/lib/config/Makefile.am
@@ -147,7 +147,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/config_backend/Makefile.am
@@ -155,7 +155,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/cql/Makefile.am
@@ -163,7 +163,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . testutils tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES) $(CQL_CPPFLAGS)
 --- a/src/lib/cryptolink/Makefile.am
@@ -171,7 +171,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES) $(CRYPTO_CFLAGS) $(CRYPTO_INCLUDES)
 --- a/src/lib/database/Makefile.am
@@ -179,7 +179,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . testutils tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/dhcp/Makefile.am
@@ -187,7 +187,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/dhcp_ddns/Makefile.am
@@ -195,27 +195,27 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/dhcpsrv/Makefile.am
 +++ b/src/lib/dhcpsrv/Makefile.am
 @@ -1,6 +1,6 @@
  AUTOMAKE_OPTIONS = subdir-objects
- 
+
 -SUBDIRS = . testutils tests benchmarks
 +SUBDIRS = . benchmarks
- 
+
  dhcp_data_dir = @localstatedir@/@PACKAGE@
  kea_lfc_location = @prefix@/sbin/kea-lfc
 --- a/src/lib/dns/Makefile.am
 +++ b/src/lib/dns/Makefile.am
 @@ -1,6 +1,6 @@
  AUTOMAKE_OPTIONS = subdir-objects
- 
+
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/eval/Makefile.am
@@ -223,7 +223,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/exceptions/Makefile.am
@@ -231,7 +231,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CXXFLAGS=$(KEA_CXXFLAGS)
 --- a/src/lib/hooks/Makefile.am
@@ -239,7 +239,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/http/Makefile.am
@@ -247,17 +247,15 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/log/Makefile.am
 +++ b/src/lib/log/Makefile.am
-@@ -2,7 +2,6 @@ SUBDIRS = interprocess .
- if !CROSS_COMPILING
- SUBDIRS += compiler
- endif
--SUBDIRS += tests
- 
+@@ -1,4 +1,4 @@
+-SUBDIRS = interprocess . compiler tests
++SUBDIRS = interprocess . compiler
+
  AM_CPPFLAGS = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/log/interprocess/Makefile.am
@@ -265,7 +263,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += -DLOCKFILE_DIR=\"$(localstatedir)/run/$(PACKAGE_NAME)\"
 --- a/src/lib/mysql/Makefile.am
@@ -273,7 +271,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . testutils tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES) $(MYSQL_CPPFLAGS)
 --- a/src/lib/pgsql/Makefile.am
@@ -281,7 +279,7 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . testutils tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES) $(PGSQL_CPPFLAGS)
 --- a/src/lib/process/Makefile.am
@@ -289,25 +287,25 @@
 @@ -1,4 +1,4 @@
 -SUBDIRS = . testutils tests
 +SUBDIRS = .
- dhcp_data_dir = @localstatedir@/@PACKAGE@
+ # DATA_DIR is the directory where to put PID files.
+ dhcp_data_dir = @runstatedir@/@PACKAGE@
  AM_CPPFLAGS  = -I$(top_builddir)/src/lib -I$(top_srcdir)/src/lib
- AM_CPPFLAGS += -DDATA_DIR="\"$(dhcp_data_dir)\""
 --- a/src/lib/stats/Makefile.am
 +++ b/src/lib/stats/Makefile.am
 @@ -1,4 +1,4 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/util/Makefile.am
 +++ b/src/lib/util/Makefile.am
 @@ -1,6 +1,6 @@
  AUTOMAKE_OPTIONS = subdir-objects
- 
+
 -SUBDIRS = . io unittests tests python threads
 +SUBDIRS = . io python threads
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES)
 --- a/src/lib/util/threads/Makefile.am
@@ -316,13 +314,13 @@
 -SUBDIRS = . tests
 +SUBDIRS = .
  AM_CXXFLAGS = $(KEA_CXXFLAGS)
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
 --- a/src/lib/yang/Makefile.am
 +++ b/src/lib/yang/Makefile.am
 @@ -1,4 +1,4 @@
 -SUBDIRS = . testutils pretests tests
 +SUBDIRS = .
- 
+
  AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_builddir)/src/lib
  AM_CPPFLAGS += $(BOOST_INCLUDES) $(SYSREPO_CPPFLAGS)


### PR DESCRIPTION
Maintainer: BangLang Huang<banglang.huang@foxmail.com>, Rosy Song<rosysong@rosinson.com>
Compile tested: Ubuntu 19.04 Openwrt trunk
Run tested: WRT3200ACM Openwrt trunk

Description:

Update kea to the latest stable verion (1.6.0).
