### PR TITLE
lua-rs232: Update to latest git version

### DIFF
--- a/lang/lua-rs232/Makefile
+++ b/lang/lua-rs232/Makefile
@@ -8,19 +8,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lua-rs232
-PKG_VERSION:=1.0.3
-PKG_RELEASE:=2
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/srdgame/librs232
+PKG_SOURCE_DATE:=2019-09-17
+PKG_SOURCE_VERSION:=1c29a279484ee4850611b76a6571566e0ec133bb
+PKG_MIRROR_HASH:=c9063a729935135278f17dd98ca31757acfd4405bdf9f6e49d77ed0df8ddc823
+
 PKG_MAINTAINER:=Dirk Chang <dirk@kooiot.com>
 PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYING
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MIRROR_HASH:=fb2f6453537e10beb2cd99d30eb1b4259ab75452992ca8a65d621186cf320960
-PKG_SOURCE_URL:=https://github.com/srdgame/librs232.git
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=a9d463181e7f7034fe6a55bc38e845fb04fa93ba
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=lua/host
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -37,27 +40,25 @@ define Package/lua-rs232/description
   multiplatform library for serial communications over RS-232
 endef
 
-CONFIGURE_ARGS += \
-	--with-lua-inc=$(STAGING_DIR)/usr/include \
-	--with-lua-lib=$(STAGING_DIR)/usr/lib
+TARGET_CFLAGS += -ffunction-sections -fdata-sections
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
-#define Build/Configure
-#	( cd "$(PKG_BUILD_DIR)"; ./autogen.sh )
-#	$(call Build/Configure/Default)
-#endef
-define Build/Configure
-endef
-
-define Build/Compile
-	(cd "$(PKG_BUILD_DIR)"; $(TARGET_CC)  src/rs232.c src/rs232_posix.c bindings/lua/luars232.c -DLUAROCKS_HACK -std=gnu99 -I./include -I$(STAGING_DIR)/usr/include -L$(STAGING_DIR)/usr/lib -fPIC -shared -o luars232.so)
-endef
-
-define Build/Install
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/librs232
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/librs232/rs232* $(1)/usr/include/librs232
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/librs232* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/lua/5.1
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/lua/5.1/luars232* $(1)/usr/lib/lua/5.1
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/librs232.pc $(1)/usr/lib/pkgconfig
 endef
 
 define Package/lua-rs232/install
-	$(INSTALL_DIR) $(1)/usr/lib/lua
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/luars232.so $(1)/usr/lib/lua/
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/librs232.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/lua/5.1
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/lua/5.1/luars232* $(1)/usr/lib/lua/5.1
 endef
 
 $(eval $(call BuildPackage,lua-rs232))

--- a/lang/lua-rs232/patches/100-remove-build-timestamps.patch
+++ b/lang/lua-rs232/patches/100-remove-build-timestamps.patch
@@ -1,7 +1,5 @@
-Index: lua-rs232-1.0.3/bindings/lua/luars232.c
-===================================================================
---- lua-rs232-1.0.3.orig/bindings/lua/luars232.c	2014-06-05 09:48:23.000000000 +0200
-+++ lua-rs232-1.0.3/bindings/lua/luars232.c	2017-12-03 13:03:51.008917783 +0100
+--- a/bindings/lua/luars232.c
++++ b/bindings/lua/luars232.c
 @@ -31,7 +31,6 @@
  
  #include "librs232/rs232.h"
@@ -10,7 +8,7 @@ Index: lua-rs232-1.0.3/bindings/lua/luars232.c
  #define MODULE_NAMESPACE "luars232"
  #define MODULE_VERSION "1.0.3"
  #define MODULE_BUILD "$Id: luars232.c 15 2011-02-23 09:02:20Z sp $"
-@@ -483,9 +482,6 @@
+@@ -552,9 +551,6 @@
  	lua_pushstring(L, MODULE_BUILD);
  	lua_setfield(L, -2, "_BUILD");
  

--- a/lang/lua-rs232/patches/110-add-static.patch
+++ b/lang/lua-rs232/patches/110-add-static.patch
@@ -1,0 +1,31 @@
+--- a/bindings/lua/luars232.c
++++ b/bindings/lua/luars232.c
+@@ -529,7 +529,7 @@ static void create_metatables(lua_State *L, const char *name, const luaL_reg *me
+ #endif
+ }
+ 
+-RS232_LIB int luaopen_luars232(lua_State *L)
++RS232_LIB static int luaopen_luars232(lua_State *L)
+ {
+ 	int i;
+ 	create_metatables(L, MODULE_NAMESPACE, port_methods);
+@@ -560,6 +560,7 @@ RS232_LIB int luaopen_luars232(lua_State *L)
+ 	return 1;
+ }
+ 
+-RS232_LIB int luaopen_rs232_core(lua_State *L){
++__attribute__((unused))
++RS232_LIB static int luaopen_rs232_core(lua_State *L){
+ 	return luaopen_luars232(L);
+ }
+--- a/include/librs232/rs232.h
++++ b/include/librs232/rs232.h
+@@ -134,7 +134,7 @@ enum rs232_flow_e {
+ 
+ enum rs232_status_e {
+ 	RS232_PORT_CLOSED,
+-	RS232_PORT_OPEN,
++	RS232_PORT_OPEN
+ };
+ 
+ enum rs232_dtr_e {


### PR DESCRIPTION
Last release was from 2012. Latest git has many additions.

Cleaned up Makefile and eliminated build hacks.

Added InstallDev section.

Added PKG_BUILD_PARALLEL for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @srdgame 
Compile tested: ath79

