### PR TITLE
cgi-io: fixes and improvements

### DIFF
--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=13
+PKG_RELEASE:=14
 
 PKG_LICENSE:=GPL-2.0-or-later
 

--- a/net/cgi-io/src/CMakeLists.txt
+++ b/net/cgi-io/src/CMakeLists.txt
@@ -9,7 +9,8 @@ FIND_LIBRARY(ubox NAMES ubox)
 FIND_LIBRARY(ubus NAMES ubus)
 INCLUDE_DIRECTORIES(${ubus_include_dir})
 
-ADD_DEFINITIONS(-Os -Wall -Werror --std=gnu99 -g3 -Wmissing-declarations)
+ADD_DEFINITIONS(-Os -Wall -Werror -Wextra --std=gnu99 -g3)
+ADD_DEFINITIONS(-Wno-unused-parameter -Wmissing-declarations)
 
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 

--- a/net/cgi-io/src/CMakeLists.txt
+++ b/net/cgi-io/src/CMakeLists.txt
@@ -5,6 +5,8 @@ PROJECT(cgi-io C)
 INCLUDE(CheckFunctionExists)
 
 FIND_PATH(ubus_include_dir libubus.h)
+FIND_LIBRARY(ubox NAMES ubox)
+FIND_LIBRARY(ubus NAMES ubus)
 INCLUDE_DIRECTORIES(${ubus_include_dir})
 
 ADD_DEFINITIONS(-Os -Wall -Werror --std=gnu99 -g3 -Wmissing-declarations)
@@ -17,6 +19,6 @@ IF(APPLE)
 ENDIF()
 
 ADD_EXECUTABLE(cgi-io main.c multipart_parser.c)
-TARGET_LINK_LIBRARIES(cgi-io ubox ubus)
+TARGET_LINK_LIBRARIES(cgi-io ${ubox} ${ubus})
 
 INSTALL(TARGETS cgi-io RUNTIME DESTINATION sbin)


### PR DESCRIPTION
Maintainer: @blogic
Compile tested: x86/64, ath79
Run tested: n/a
Cc: @jow- 

Description:

* 48f2a3a929b9 cgi-io: iron out extra compiler warnings
* 98aa18d073f6 cgi-io: cmake: enable extra compiler warnings
* a0305e6d379f cgi-io: cmake: fix libraries lookup
