### PR TITLE
[openwrt-19.07] cgi-io backports

### DIFF
--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_LICENSE:=GPL-2.0-or-later
 

--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_LICENSE:=GPL-2.0-or-later
 
@@ -38,6 +38,7 @@ define Package/cgi-io/install
 	$(INSTALL_DIR) $(1)/usr/libexec $(1)/www/cgi-bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/cgi-io $(1)/usr/libexec
 	$(LN) ../../usr/libexec/cgi-io $(1)/www/cgi-bin/cgi-upload
+	$(LN) ../../usr/libexec/cgi-io $(1)/www/cgi-bin/cgi-download
 	$(LN) ../../usr/libexec/cgi-io $(1)/www/cgi-bin/cgi-backup
 endef
 

--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_LICENSE:=GPL-2.0-or-later
 

--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_LICENSE:=GPL-2.0-or-later
 

--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=13
+PKG_RELEASE:=14
 
 PKG_LICENSE:=GPL-2.0-or-later
 

--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=7
+PKG_RELEASE:=9
 
 PKG_LICENSE:=GPL-2.0-or-later
 

--- a/net/cgi-io/src/CMakeLists.txt
+++ b/net/cgi-io/src/CMakeLists.txt
@@ -9,7 +9,8 @@ FIND_LIBRARY(ubox NAMES ubox)
 FIND_LIBRARY(ubus NAMES ubus)
 INCLUDE_DIRECTORIES(${ubus_include_dir})
 
-ADD_DEFINITIONS(-Os -Wall -Werror --std=gnu99 -g3 -Wmissing-declarations)
+ADD_DEFINITIONS(-Os -Wall -Werror -Wextra --std=gnu99 -g3)
+ADD_DEFINITIONS(-Wno-unused-parameter -Wmissing-declarations)
 
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 

--- a/net/cgi-io/src/CMakeLists.txt
+++ b/net/cgi-io/src/CMakeLists.txt
@@ -5,6 +5,8 @@ PROJECT(cgi-io C)
 INCLUDE(CheckFunctionExists)
 
 FIND_PATH(ubus_include_dir libubus.h)
+FIND_LIBRARY(ubox NAMES ubox)
+FIND_LIBRARY(ubus NAMES ubus)
 INCLUDE_DIRECTORIES(${ubus_include_dir})
 
 ADD_DEFINITIONS(-Os -Wall -Werror --std=gnu99 -g3 -Wmissing-declarations)
@@ -17,6 +19,6 @@ IF(APPLE)
 ENDIF()
 
 ADD_EXECUTABLE(cgi-io main.c multipart_parser.c)
-TARGET_LINK_LIBRARIES(cgi-io ubox ubus)
+TARGET_LINK_LIBRARIES(cgi-io ${ubox} ${ubus})
 
 INSTALL(TARGETS cgi-io RUNTIME DESTINATION sbin)


### PR DESCRIPTION
Maintainer: @blogic
Compile tested: ath79
Run tested: n/a
Cc: @jow- 

Description:

Backport of following commits:

* 22be9a1c0173 cgi-io: require whitelisting upload locations
* c8a86c8c8e19 cgi-io: use different acl scopes for path and command permissions
* ab2a2b080d41 cgi-io: add download operation
* 8c22db653158 cgi-io: pass appropriate HTTP error codes to failure()
* a8b4a2837264 cgi-io: use splice() to stream backup archive
* 535b2b6bd8a7 cgi-io: fix read after end errors
* fd47e99be4fc cgi-io: cmake: fix libraries lookup
* 4e7411a8d0a4 cgi-io: cmake: enable extra compiler warnings
* bb6cdb804cc4 cgi-io: iron out extra compiler warnings