### PR TITLE
[openwrt-19.07] shinit: Add package

### DIFF
--- a/utils/shinit/Makefile
+++ b/utils/shinit/Makefile
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2019 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=shinit
+PKG_VERSION:=0.1.0
+PKG_RELEASE:=1
+
+PKG_LICENSE:=GPL-2.0-only
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/shinit
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Initialization for all interactive shells (login or not)
+  PKGARCH:=all
+endef
+
+define Package/shinit/description
+  This package adds support for /etc/shinit and ~/.shinit files, which
+  contain commands to be run at the start of all interactive shells.
+  (/etc/profile and ~/.profile are read for login shells only.)
+
+  This is useful for those who regularly open non-login, interactive
+  shells, for example users of GNU Screen or tmux.
+endef
+
+define Package/shinit/conffiles
+/etc/shinit
+endef
+
+Build/Prepare:=:
+Build/Configure:=:
+Build/Compile:=:
+
+define Package/shinit/install
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_DATA) ./files/etc/shinit $(1)/etc
+
+	$(INSTALL_DIR) $(1)/etc/profile.d
+	$(INSTALL_DATA) ./files/etc/profile.d/shinit.sh $(1)/etc/profile.d
+endef
+
+$(eval $(call BuildPackage,shinit))

--- a/utils/shinit/files/etc/profile.d/shinit.sh
+++ b/utils/shinit/files/etc/profile.d/shinit.sh
@@ -1,0 +1,1 @@
+export ENV=/etc/shinit

--- a/utils/shinit/files/etc/shinit
+++ b/utils/shinit/files/etc/shinit
@@ -1,0 +1,23 @@
+[ -x /bin/more ] || alias more=less
+[ -x /usr/bin/vim ] && alias vi=vim || alias vim=vi
+
+alias ll='ls -alF --color=auto'
+
+# If you use mksh and want to source /etc/mkshrc for all interactive shells,
+# uncomment the following line and comment out the same line in /etc/profile.
+#[ -z "$KSH_VERSION" -o \! -s /etc/mkshrc ] || . /etc/mkshrc
+
+[ -x /usr/bin/arp -o -x /sbin/arp ] || arp() { cat /proc/net/arp; }
+[ -x /usr/bin/ldd ] || ldd() { LD_TRACE_LOADED_OBJECTS=1 $*; }
+
+service() {
+	[ -f "/etc/init.d/$1" ] || {
+		echo "service "'"'"$1"'"'" not found, the following services are available:"
+		ls "/etc/init.d"
+		return 1
+	}
+	/etc/init.d/$@
+}
+
+[ -n "$KSH_VERSION" -o \! -s "$HOME/.shinit" ] || . "$HOME/.shinit"
+[ -z "$KSH_VERSION" -o \! -s "$HOME/.mkshrc" ] || . "$HOME/.mkshrc"


### PR DESCRIPTION
Maintainer: me
Compile tested: none (cherry picked from #10159)
Run tested: none

Description:
This package adds support for `/etc/shinit` and `~/.shinit` files, which contain commands to be run at the start of all interactive shells. (`/etc/profile` and `~/.profile` are read for login shells only.)

This is useful for those who regularly open non-login, interactive shells, for example users of GNU Screen or tmux.

(This is based on a [patch][1] I submitted for OpenWrt master, but there does not appear to be much interest in merging the change.)

(This package uses the `ENV` shell variable, of which the POSIX standard has a [brief description][2]. The [dash manpage][3] also describes how the `ENV` variable is handled. (dash is the basis for busybox ash.))

[1]: https://patchwork.ozlabs.org/patch/1094493/
[2]: https://pubs.opengroup.org/onlinepubs/9699919799//utilities/V3_chap02.html#tag_18_05_03
[3]: https://manpages.debian.org/buster/dash/dash.1.en.html#Invocation

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from c04dff7965ed84bc57ea957ecad81fb902b7f146)