### PR TITLE
luaposix: disable documentation build

### DIFF
--- a/lang/luaposix/patches/900-disable-ldoc.patch
+++ b/lang/luaposix/patches/900-disable-ldoc.patch
@@ -1,0 +1,13 @@
+diff --git a/lukefile b/lukefile
+index 2d4bb2f..1e48540 100644
+--- a/lukefile
++++ b/lukefile
+@@ -29,8 +29,6 @@ incdirs  = {
+    '$LUA_INCDIR',
+ }
+ 
+-ldocs    = 'build-aux/config.ld.in'
+-
+ modules  = {
+    ['posix']               = 'lib/posix/init.lua',
+    ['posix._base']         = 'lib/posix/_base.lua',


### PR DESCRIPTION
Lost when luaposix converted their upstream build system.
Required to prevent the build from attempting to invoke "ldoc" on the
host and also simply to speed it up.

Signed-of-by: Karl Palsson <karlp@etactica.com>

Maintainer: @mstorchak 
Compile tested: sunxi, master
Run tested: nothing

Description:  I'd prefer a method of just modifying our makefile to figure out the right invocation of luarocks or similar, but this is simple and works well too.
