### PR TITLE
[OpenWrt 18.06] bind: Update to version 9.11.11

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,18 +9,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.11.10
+PKG_VERSION:=9.11.11
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
-PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE:=MPL-2.0
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=b2bb840cda20e6771ae8c054007b4ec12e1bb6aa6bfe79102890eb94956a70c3
+PKG_HASH:=615230336645e494d0125a3e92cf1c0f956b7408378aca66667b44eaa9de8a6b
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06.04
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06.04

Description:

- Update to version 9.11.11
Changelog:
```
	--- 9.11.11 released ---

5291.	[cleanup]	Revert change #4825 as it was not appropriate for 9.11.
			[GL #1213]

5290.	[bug]		Address potential NULL pointer dereference in
			isc_ht_find. [GL #1211]

5287.	[bug]		Address potential NULL pointer dereference. [GL #1208]

5286.	[contrib]	Address potential NULL pointer dereferences in
			dlz_mysqldyn_mod.c. [GL #1207]

5285.	[port]		win32: implement "-T maxudpXXX". [GL #837]

5282.	[bug]		Fixed a bug in searching for possible wildcard matches
			for query names in the RPZ summary database. [GL #1146]

5281.	[cleanup]	Don't escape commas when reporting named's command
			line. [GL #1189]

5280.	[protocol]	Add support for displaying EDNS option LLQ. [GL #1201]

5279.	[bug]		When loading, reject zones containing CDS or CDNSKEY
			RRsets at the zone apex if they would cause DNSSEC
			validation failures if published in the parent zone
			as the DS RRset.  [GL #1187]
```

- Change License to MPL-2.0 and add PKG_LICENSE_FILES.

For more details look at https://www.isc.org/blogs/bind9-adopts-the-mpl-2-0-license-with-bind-9-11-0/