### PR TITLE
gst1-plugins-good: update to 1.16.1

### DIFF
--- a/multimedia/gst1-plugins-good/Makefile
+++ b/multimedia/gst1-plugins-good/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-good
-PKG_VERSION:=1.16.0
+PKG_VERSION:=1.16.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
@@ -21,7 +21,7 @@ PKG_CPE_ID:=cpe:/a:gstreamer:good_plug-ins
 PKG_BUILD_DIR:=$(BUILD_DIR)/gst-plugins-good-$(PKG_VERSION)
 PKG_SOURCE:=gst-plugins-good-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://gstreamer.freedesktop.org/src/gst-plugins-good/
-PKG_HASH:=654adef33380d604112f702c2927574cfc285e31307b79e584113858838bb0fd
+PKG_HASH:=9fbabe69018fcec707df0b71150168776040cde6c1a26bb5a82a136755fa8f1f
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_gst1-mod-lame \


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64 master bba6646b
Description:

Requires https://github.com/openwrt/packages/pull/10223.