### PR TITLE
[openwrt-18.06] gammu: Fix lib symlinks

### DIFF
--- a/utils/gammu/Makefile
+++ b/utils/gammu/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gammu
 PKG_VERSION:=1.38.4
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_URL:=http://dl.cihar.com/gammu/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -58,7 +58,7 @@ define Package/gammu/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gammu $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gammu-{smsd,smsd-inject,smsd-monitor} $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/lib{Gammu*,gsmsd*} $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{Gammu*,gsmsd*} $(1)/usr/lib
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/gammu $(1)/etc/config/gammu


### PR DESCRIPTION
Maintainer: @aTanW 
Compile tested: ar71xx, 18.06.4 sdk
Run tested: none

Description:
This fixes the symlinks for `libGammu.so` and `libgsmsd.so`. Previously, the symlinks were overwritten by `$(INSTALL_BIN)` with copies of their sources.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>