### PR TITLE
python,python3: Add pypi makefile

### DIFF
--- a/lang/python/pypi.mk
+++ b/lang/python/pypi.mk
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2019 Jeffery To <jeffery.to@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+ifndef DUMP
+  ifdef __package_mk
+    $(warning pypi.mk should be included before package.mk)
+  endif
+endif
+
+ifneq ($(strip $(PYPI_NAME)),)
+  PYPI_SOURCE_EXT?=tar.gz
+  PYPI_NAME_FIRST_LETTER?=$(strip $(foreach a,$(chars_lower) $(chars_upper) 0 1 2 3 4 5 6 7 8 9 _ -,$(if $(PYPI_NAME:$a%=),,$a)))
+
+  PKG_SOURCE?=$(PYPI_NAME)-$(PKG_VERSION).$(PYPI_SOURCE_EXT)
+  PKG_SOURCE_URL?=https://files.pythonhosted.org/packages/source/$(PYPI_NAME_FIRST_LETTER)/$(PYPI_NAME)
+
+  PKG_BUILD_DIR:=$(BUILD_DIR)/pypi/$(if $(BUILD_VARIANT),$(PKG_NAME)-$(BUILD_VARIANT)/)$(PYPI_NAME)$(if $(PKG_VERSION),-$(PKG_VERSION))
+  HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/pypi/$(PYPI_NAME)$(if $(PKG_VERSION),-$(PKG_VERSION))
+endif


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2019-10-04 snapshot sdk (tested with python-six, python-twisted)
Run tested: N/A

Description:
This adds `pypi.mk`, which can be included in Python packages that download their sources from PyPI, to auto-fill various `PKG_*` variables based on the value of `PYPI_NAME`.

This makefile should be included after `$(TOPDIR)/rules.mk` but before `$(INCLUDE_DIR)/package.mk` (and `$(INCLUDE_DIR)/host-build.mk`).

Signed-off-by: Jeffery To <jeffery.to@gmail.com>