### PR TITLE
knot: update to version 2.9.0

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=2.8.4
+PKG_VERSION:=2.9.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=541e7e43503765c91405c5797b3838103bb656154712e69b3f959c6ab0e700a9
+PKG_HASH:=df7434eaefbabbf7cca2d6cba5038be48a4668e508215ca197532bac7c9b21a2
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Signed-off-by: Jan Hák <jan.hak@nic.cz>

Maintainer: Daniel Salzman / @salzmdan
Compile tested: cortexa9, Turris Omnia, TurrisOS 5.0
Run tested: cortexa9, Turris Omnia, TurrisOS 5.0, all tests successful (1 skipped)