### PR TITLE
Add dependency xsltproc for Travis and use the latest Ubuntu LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ git:
   quiet: true
 
 language: c
-dist: trusty
+dist: bionic
 sudo: false
 cache:
   directories:

--- a/.travis_do.sh
+++ b/.travis_do.sh
@@ -5,7 +5,7 @@
 set -e
 
 SDK_HOME="$HOME/sdk"
-SDK_PATH=https://downloads.lede-project.org/snapshots/targets/ar71xx/generic/
+SDK_PATH=https://downloads.openwrt.org/snapshots/targets/ar71xx/generic/
 SDK=-sdk-ar71xx-generic_
 PACKAGES_DIR="$PWD"
 


### PR DESCRIPTION
Maintainers: @champtar , @lynxis and ping also @yousong 
Compile tested packages: youtube-dl

Description:
I'm using Travis CI in my branch for testing packages compiling them against `ar71xx` target, but I recently found that Travis is failing due to missing dependency xsltproc, which is required by modemmanager. Caused by this https://github.com/openwrt/packages/pull/9137#issuecomment-539542086.

While at it, I noticed that there is used distro Ubuntu Trusty 14.04 LTS for travis, which ended standard support a few months ago and it isnt still End of Life, but let's use the latest LTS, which is currently 18.04. Also, updated link, where to download SDK.

Failed build log before this PR:
https://travis-ci.org/BKPepe/packages/builds/598663581

```
Checking 'xsltproc'... failed.
modemmanager: modemmanager requires xsltproc installed on the host-system.
/tmp/tmp.AajxNidYPT/include/prereq.mk:12: recipe for target 'prereq' failed

```
Passed build log with this PR:
https://travis-ci.org/BKPepe/packages/builds/598669668