### PR TITLE
libxslt: add host build

### DIFF
--- a/libs/libxslt/Makefile
+++ b/libs/libxslt/Makefile
@@ -27,6 +27,7 @@ PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 
 define Package/libxslt
   SECTION:=libs
@@ -126,6 +127,15 @@ define Build/InstallDev
 	 $(if $(CONFIG_PACKAGE_libexslt),$(call Build/InstallDev/Exslt,$(1),$(2)))
 endef
 
+HOST_CONFIGURE_ARGS+= \
+	--disable-silent-rules \
+	--enable-static \
+	--without-python \
+	--without-crypto \
+	--without-debug \
+	--without-mem-debug \
+	--without-debugger
+
 define Package/libxslt/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) \
@@ -150,3 +160,4 @@ endef
 $(eval $(call BuildPackage,libxslt))
 $(eval $(call BuildPackage,libexslt))
 $(eval $(call BuildPackage,xsltproc))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: @jslachta @micmac1 @neheb
Compile tested: x86_64 and lantiq_xrx200, APU3, OpenWrt master
Run tested: Only execution of xsltproc on the buildsystem

Description:

This commit adds the host build for xsltproc.
This is needed my the modemmanager package.
The modemmanager checks if xlstproc is installed on the build system.
With the following check:

```
$(eval $(call RequireCommand,xsltproc, \
        $(PKG_NAME) requires xsltproc installed on the host-system. \
)
```

This is not needed anymore if the openwrt buildsystem builds his own xsltproc.
This will also a build host dependency.