### PR TITLE
kernel/macremapper: fix compile err on mipsel

### DIFF
--- a/kernel/macremapper/Makefile
+++ b/kernel/macremapper/Makefile
@@ -36,7 +36,7 @@ define KernelPackage/macremapper/description
   Linux kernel module for implementation the DCW filtering mechanism
 endef
 
-MAKE_FLAGS += KERNEL_SRC=$(LINUX_DIR)
+MAKE_FLAGS += KERNEL_SRC=$(LINUX_DIR) ARCH=$(LINUX_KARCH)
 MAKE_PATH:=kernelmod
 
 $(eval $(call KernelPackage,macremapper))


### PR DESCRIPTION
Signed-off-by: Chen Minqiang <ptpt52@gmail.com>
Signed-off-by: Carey Sonsino <csonsino@gmail.com>

Maintainer: me / @csonsino
Compile tested: Atheros AR7xxx/AR9xxx - Atheros AR7161 rev 2, Netgear WNDR3800, OpenWrt master
Run tested: Atheros AR7xxx/AR9xxx - Atheros AR7161 rev 2, Netgear WNDR3800, Configured the Dual Channel Wi-Fi daemon, connected a Raspberry Pi client, and verified functionality.

Description:
This should fix the macremapper kernel module mipsel compile error.  Thanks @ptpt52 