### PR TITLE
adblock: Update README.md

### DIFF
--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -269,7 +269,9 @@ Finally enable email support and add a valid email address in LuCI.
 [...]
 ```
   
-**Cronjob for a regular block list update (`/etc/crontabs/root`):**
+**Cronjob for regular block list updates (`/etc/crontabs/root`):**
+
+The following command as a cron job updates each individual block list from their source so that they hold the most current IPs/domains to block:
 
 ```
 0 06 * * *    /etc/init.d/adblock reload


### PR DESCRIPTION
Clarified the `reload` call for updating the block list contents. Fixes #10251

Maintainer: @dibdot 
Compile tested: N/A (docu)
Run tested: N/A (docu)

Description: Clarifying the documentation on updating list of block lists vs. block list contents.
