### PR TITLE
frr: update to 7.2

### DIFF
--- a/net/frr/Config.in
+++ b/net/frr/Config.in
@@ -1,0 +1,18 @@
+
+if PACKAGE_frr
+comment "SSL support"
+
+choice
+        prompt "Selected SSL MD5 library"
+        default FRR_INTERNAL
+
+        config FRR_OPENSSL
+                bool "OpenSSL"
+
+        config FRR_INTERNAL
+                bool "internal SSL support"
+endchoice
+
+comment Packages
+
+endif

--- a/net/frr/Makefile
+++ b/net/frr/Makefile
@@ -7,35 +7,42 @@
 
 include $(TOPDIR)/rules.mk
 PKG_NAME:=frr
-PKG_VERSION:=7.1
-PKG_RELEASE:=2
+PKG_VERSION:=7.2
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://github.com/FRRouting/frr/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=2a4210565e7b41d366f7b9f5f745917d67a0b159f3b6bd49d75f9e730557db2f
+PKG_HASH:=6cd5bfb6975133ccf23cc3f3a1c1c9a3f6d6a6c792c763b3ea010db75b3de5b3
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
+
+PKG_DAEMON_AVAILABLE:= \
+	babeld \
+	bfdd \
+	bgpd \
+	eigrpd \
+	fabricd \
+	isisd \
+	ldpd \
+	nhrpd \
+	ospfd \
+	ospf6d \
+	pbrd \
+	pimd \
+	ripd \
+	ripngd \
+	staticd \
+	vrrpd
+
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_IPV6 \
-	CONFIG_PACKAGE_frr-babeld \
-	CONFIG_PACKAGE_frr-bfdd \
-	CONFIG_PACKAGE_frr-bgpd \
-	CONFIG_PACKAGE_frr-eigrpd \
-	CONFIG_PACKAGE_frr-fabricd \
-	CONFIG_PACKAGE_frr-isisd \
-	CONFIG_PACKAGE_frr-ldpd \
+	CONFIG_FRR_OPENSSL \
+	CONFIG_FRR_INTERNAL \
 	CONFIG_PACKAGE_frr-libfrr \
-	CONFIG_PACKAGE_frr-nhrpd \
-	CONFIG_PACKAGE_frr-ospfd \
-	CONFIG_PACKAGE_frr-ospf6d \
-	CONFIG_PACKAGE_frr-pbrd \
-	CONFIG_PACKAGE_frr-pimd \
-	CONFIG_PACKAGE_frr-ripd \
-	CONFIG_PACKAGE_frr-ripngd \
-	CONFIG_PACKAGE_frr-staticd \
 	CONFIG_PACKAGE_frr-vtysh \
 	CONFIG_PACKAGE_frr-watchfrr \
-	CONFIG_PACKAGE_frr-zebra
+	CONFIG_PACKAGE_frr-zebra \
+	$(patsubst %,CONFIG_PACKAGE_frr-%,$(PKG_DAEMON_AVAILABLE)) \
 
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=python3/host
@@ -45,18 +52,22 @@ PKG_LICENSE:=GPL-2.0
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 
+define Package/frr-libfrr/config
+  source "$(SOURCE)/Config.in"
+endef
+
 define Package/frr/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Routing and Redirection
-  DEPENDS:=frr
-  TITLE:=The FRRouting (FRR) Software Routing Suite
   URL:=https://www.frrouting.org/
+  DEPENDS:=frr
 endef
 
 define Package/frr
   $(call Package/frr/Default)
   DEPENDS:=+librt
+  TITLE:=The FRRouting (FRR) Software Routing Suite
   MENU:=1
 endef
 
@@ -65,117 +76,20 @@ define Package/frr/description
   routing protocols.
 
   Currently FRRouting supports BGP4, BGP4+, OSPFv2, OSPFv3, RIPv1, RIPv2, RIPng,
-  IS-IS, PIM-SM/MSDP, LDP and Babel as well as very early support for EIGRP and
+  IS-IS, PIM-SM/MSDP, LDP, VRRP and Babel as well as very early support for EIGRP and
   NHRP.
-endef
-
-define Package/frr-babeld
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr
-  TITLE:=BABEL routing engine
-endef
-
-define Package/frr-bfdd
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr
-  TITLE:=BFD routing engine
-  CONFLICTS:=bfdd
-endef
-
-define Package/frr-bgpd
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr
-  TITLE:=BGPv4, BGPv4+, BGPv4- routing engine
-  CONFLICTS:=quagga-bgpd
-endef
-
-define Package/frr-eigrpd
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr
-  TITLE:=EIGRPD routing engine
-endef
-
-define Package/frr-fabricd
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr
-  TITLE:=OpenFabric routing engine
-endef
-
-define Package/frr-isisd
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr
-  TITLE:=IS-IS routing engine
-  CONFLICTS:=quagga-isisd
-endef
-
-define Package/frr-ldpd
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr
-  TITLE:=LDP routing engine
 endef
 
 define Package/frr-libfrr
   $(call Package/frr/Default)
   TITLE:=zebra library
-  DEPENDS+=+libjson-c +libyang
+  DEPENDS+=+librt +libjson-c +libyang +FRR_OPENSSL:libopenssl
   CONFLICTS:=quagga-libzebra
-endef
-
-define Package/frr-nhrpd
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr +libcares
-  TITLE:=NHRP routing engine
-endef
-
-define Package/frr-ospfd
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr
-  TITLE:=OSPFv2 routing engine
-  CONFLICTS:=quagga-ospfd
-endef
-
-define Package/frr-ospf6d
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr @IPV6
-  TITLE:=OSPFv3 routing engine
-  CONFLICTS:=quagga-ospf6d
-endef
-
-define Package/frr-pbrd
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr
-  TITLE:=PBRD routing daemon
-endef
-
-define Package/frr-pimd
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr
-  TITLE:=PIM routing engine
-endef
-
-define Package/frr-ripd
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr
-  TITLE:=RIP routing engine
-  CONFLICTS:=quagga-ripd
-endef
-
-define Package/frr-ripngd
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr @IPV6
-  TITLE:=RIPNG routing engine
-  CONFLICTS:=quagga-ripngd
-endef
-
-define Package/frr-staticd
-  $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr
-  TITLE:=STATICD routing engine
 endef
 
 define Package/frr-vtysh
   $(call Package/frr/Default)
-  DEPENDS+=+frr-libfrr +libreadline +libncurses
+  DEPENDS+=+frr-libfrr +libreadline +libncurses +more
   TITLE:=integrated shell for frr routing software
   CONFLICTS:=quagga-vtysh
 endef
@@ -195,19 +109,49 @@ define Package/frr-zebra
   CONFLICTS:=quagga-zebra
 endef
 
+##Migrate from quagga
+##should test file exists and link in frr folder
+#define Package/frr/postinst
+##!/bin/sh
+#if [ -f /etc/quagga/ospfd.conf ]; then
+#    ls to /etc/frr
+#    sed enable ospfd daemon
+#fi
+#exit 0
+#endef
+
+define BuildDaemon
+    define Package/frr-$(1)
+	$$(call Package/frr/Default)
+	TITLE:= $(1) routing engine
+	DEPENDS+=frr-libfrr $(2)
+    endef
+
+    define Package/frr-$(1)/install
+	$(INSTALL_DIR) $$(1)/usr/sbin
+	if [ "$(1)" != "fabricd" ]; then \
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/$(1)/.libs/$(1) $$(1)/usr/sbin/; \
+	else \
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/isisd/.libs/$(1) $$(1)/usr/sbin/; fi
+	if [ "$(1)" == "nhrpd" ]; then \
+	$(INSTALL_DIR) $$(1)/usr/lib; \
+	$(CP) $(PKG_BUILD_DIR)/build/lib/.libs/libfrrcares.so* $$(1)/usr/lib/; fi
+    endef
+
+    $$(eval $$(call BuildPackage,frr-$(1)))
+endef
+
 define Package/frr-libfrr/conffiles
 /etc/frr/
 endef
 
 define Build/Prepare
 	$(Build/Prepare/Default)
-	mkdir -p $(PKG_BUILD_DIR)/build/lib
-	$(CP) $(PKG_BUILD_DIR)/lib/command.h $(PKG_BUILD_DIR)/build/lib/
+	mkdir -p $(PKG_BUILD_DIR)/build
 endef
 
 define Build/Configure
     ( cd $(PKG_BUILD_DIR)/build/ ; \
-    cd build ; \
     ../configure \
 	--host="$(GNU_TARGET_NAME)" \
 	--build="$(GNU_HOST_NAME)" \
@@ -229,26 +173,11 @@ define Build/Configure
 	--disable-ospfclient \
 	--disable-doc \
 	--disable-backtrace \
-	--with-vtysh-pager=cat \
 	--localstatedir=/var/run/frr \
 	--sysconfdir=/etc/frr/ \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-babeld,babeld) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-bfdd,bfdd) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-bgpd,bgpd) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-eigrpd,eigrpd) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-fabricd,fabricd) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-isisd,isisd) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-ldpd,ldpd) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-nhrpd,nhrpd) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-ospfd,ospfd) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-ospf6d,ospf6d) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-pbrd,pbrd) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-pimd,pimd) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-staticd,staticd) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-ripd,ripd) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-ripngd,ripngd) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-vtysh,vtysh) \
-	$(call autoconf_bool,CONFIG_PACKAGE_frr-libfrr,zebra) \
+	$(if $(CONFIG_FRR_OPENSSL),--with-crypto=openssl,) \
+	$(foreach m,$(PKG_DAEMON_AVAILABLE), \
+	$(if $(CONFIG_PACKAGE_frr-$(m)),--enable-$(m),--disable-$(m)) ) \
 )
 endef
 
@@ -277,91 +206,6 @@ define Package/frr-zebra/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/zebra/.libs/zebra $(1)/usr/sbin/
 endef
 
-define Package/frr-babeld/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/babeld/.libs/babeld $(1)/usr/sbin/
-endef
-
-define Package/frr-bfdd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/bfdd/.libs/bfdd $(1)/usr/sbin/
-endef
-
-define Package/frr-bgpd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/bgpd/.libs/bgpd $(1)/usr/sbin/
-endef
-
-define Package/frr-eigrpd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/eigrpd/.libs/eigrpd $(1)/usr/sbin/
-endef
-
-define Package/frr-fabricd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/isisd/.libs/fabricd $(1)/usr/sbin/
-endef
-
-define Package/frr-isisd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/isisd/.libs/isisd $(1)/usr/sbin/
-endef
-
-define Package/frr-ldpd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/ldpd/.libs/ldpd $(1)/usr/sbin/
-endef
-
-define Package/frr-nhrpd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/nhrpd/.libs/nhrpd $(1)/usr/sbin/
-endef
-
-define Package/frr-ospfd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/ospfd/.libs/ospfd $(1)/usr/sbin/
-endef
-
-define Package/frr-ospf6d/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/ospf6d/.libs/ospf6d $(1)/usr/sbin/
-endef
-
-define Package/frr-pbrd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/pbrd/.libs/pbrd $(1)/usr/sbin/
-endef
-
-define Package/frr-pimd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/pimd/.libs/pimd $(1)/usr/sbin/
-endef
-
-define Package/frr-ripd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/ripd/.libs/ripd $(1)/usr/sbin/
-endef
-
-define Package/frr-ripngd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/ripngd/.libs/ripngd $(1)/usr/sbin/
-endef
-
-define Package/frr-staticd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/staticd/.libs/staticd $(1)/usr/sbin/
-endef
-
-define Package/frr-vrrpd/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/vrrpd/.libs/vrrpd $(1)/usr/sbin/
-endef
-
-define Package/frr-vtysh/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/build/vtysh/.libs/vtysh $(1)/usr/bin/
-endef
-
 define Package/frr-libfrr/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_BUILD_DIR)/build/lib/.libs/libfrr.so* $(1)/usr/lib/
@@ -372,22 +216,23 @@ endef
 
 $(eval $(call HostBuild))
 $(eval $(call BuildPackage,frr))
-$(eval $(call BuildPackage,frr-babeld))
-$(eval $(call BuildPackage,frr-bfdd))
-$(eval $(call BuildPackage,frr-bgpd))
-$(eval $(call BuildPackage,frr-eigrpd))
-$(eval $(call BuildPackage,frr-fabricd))
-$(eval $(call BuildPackage,frr-isisd))
-$(eval $(call BuildPackage,frr-ldpd))
 $(eval $(call BuildPackage,frr-libfrr))
-$(eval $(call BuildPackage,frr-nhrpd))
-$(eval $(call BuildPackage,frr-ospfd))
-$(eval $(call BuildPackage,frr-ospf6d))
-$(eval $(call BuildPackage,frr-pbrd))
-$(eval $(call BuildPackage,frr-pimd))
-$(eval $(call BuildPackage,frr-ripd))
-$(eval $(call BuildPackage,frr-ripngd))
-$(eval $(call BuildPackage,frr-staticd))
-$(eval $(call BuildPackage,frr-vtysh))
 $(eval $(call BuildPackage,frr-watchfrr))
 $(eval $(call BuildPackage,frr-zebra))
+$(eval $(call BuildPackage,frr-vtysh))
+$(eval $(call BuildDaemon,babeld,))
+$(eval $(call BuildDaemon,bfdd,))
+$(eval $(call BuildDaemon,bgpd,))
+$(eval $(call BuildDaemon,eigrpd,))
+$(eval $(call BuildDaemon,fabricd,))
+$(eval $(call BuildDaemon,isisd,))
+$(eval $(call BuildDaemon,ldpd,))
+$(eval $(call BuildDaemon,nhrpd,+libcares))
+$(eval $(call BuildDaemon,ospfd,))
+$(eval $(call BuildDaemon,ospf6d,@IPV6))
+$(eval $(call BuildDaemon,pbrd,))
+$(eval $(call BuildDaemon,pimd,))
+$(eval $(call BuildDaemon,ripd,))
+$(eval $(call BuildDaemon,ripngd,@IPV6))
+$(eval $(call BuildDaemon,staticd,))
+$(eval $(call BuildDaemon,vrrpd,))

--- a/net/frr/patches/001-vti_interface_fix.patch
+++ b/net/frr/patches/001-vti_interface_fix.patch
@@ -1,0 +1,26 @@
+--- a/zebra/zebra_nhg.c	2019-10-18 01:59:17.582282539 +0300
++++ b/zebra/zebra_nhg.c	2019-10-18 02:00:17.501997253 +0300
+@@ -253,20 +253,9 @@
+ 	while (rn) {
+ 		route_unlock_node(rn);
+ 
+-		/* Lookup should halt if we've matched against ourselves ('top',
+-		 * if specified) - i.e., we cannot have a nexthop NH1 is
+-		 * resolved by a route NH1. The exception is if the route is a
+-		 * host route.
+-		 */
+-		if (top && rn == top)
+-			if (((afi == AFI_IP) && (rn->p.prefixlen != 32))
+-			    || ((afi == AFI_IP6) && (rn->p.prefixlen != 128))) {
+-				if (IS_ZEBRA_DEBUG_RIB_DETAILED)
+-					zlog_debug(
+-						"\t%s: Matched against ourself and prefix length is not max bit length",
+-						__PRETTY_FUNCTION__);
+-				return 0;
+-			}
++		/* If lookup self prefix return immediately. */
++		if (rn == top)
++		    return 0;
+ 
+ 		/* Pick up selected route. */
+ 		/* However, do not resolve over default route unless explicitly

--- a/net/frr/patches/002-bgp_clippy_typo.patch
+++ b/net/frr/patches/002-bgp_clippy_typo.patch
@@ -1,0 +1,11 @@
+--- a/bgpd/bgp_bmp.c	2019-10-19 00:10:05.038017045 +0300
++++ b/bgpd/bgp_bmp.c	2019-10-19 00:10:46.661847536 +0300
+@@ -1762,7 +1762,7 @@
+ #define BMP_STR "BGP Monitoring Protocol\n"
+ 
+ #ifndef VTYSH_EXTRACT_PL
+-#include "bgp_bmp_clippy.c"
++#include "bgpd/bgp_bmp_clippy.c"
+ #endif
+ 
+ DEFPY_NOSH(bmp_targets_main,

--- a/net/frr/patches/003-corss_cares_fix.patch
+++ b/net/frr/patches/003-corss_cares_fix.patch
@@ -1,0 +1,53 @@
+From 2163a630eb737b9afe3277dccf44070ef55dea12 Mon Sep 17 00:00:00 2001
+From: Lucian Cristian <lucian.cristian@gmail.com>
+Date: Fri, 13 Sep 2019 07:12:34 +0300
+Subject: [PATCH] clippy: CARES fail only if !enable_clippy_only test for CARES
+ otherwise config will fail with conditional "CARES" not defined
+
+Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
+---
+ configure.ac | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 6c1b35b5f2..9f37b3e9a9 100755
+--- a/configure.ac
++++ b/configure.ac
+@@ -1452,6 +1452,12 @@ if test "x$enable_pcreposix" = "xyes"; then
+ fi
+ AC_SUBST([HAVE_LIBPCREPOSIX])
+ 
++dnl ##########################################################################
++dnl test "${enable_clippy_only}" != "yes"
++fi
++dnl END OF LARGE if block
++dnl ##########################################################################
++
+ dnl ------------------
+ dnl check C-Ares library
+ dnl ------------------
+@@ -1462,12 +1468,6 @@ PKG_CHECK_MODULES([CARES], [libcares], [
+ ])
+ AM_CONDITIONAL([CARES], [$c_ares_found])
+ 
+-dnl ##########################################################################
+-dnl test "${enable_clippy_only}" != "yes"
+-fi
+-dnl END OF LARGE if block
+-dnl ##########################################################################
+-
+ 
+ dnl ----------------------------------------------------------------------------
+ dnl figure out if domainname is available in the utsname struct (GNU extension).
+@@ -1535,9 +1535,11 @@ case "$host_os" in
+       no)
+         ;;
+       yes)
++	if test "${enable_clippy_only}" != "yes"; then
+         if test "$c_ares_found" != "true" ; then
+           AC_MSG_ERROR([nhrpd requires libcares.  Please install c-ares and its -dev headers.])
+         fi
++	fi
+         NHRPD="nhrpd"
+         ;;
+       *)

--- a/net/frr/patches/004-cross_libcap_fix.patch
+++ b/net/frr/patches/004-cross_libcap_fix.patch
@@ -1,0 +1,27 @@
+From 2cd3abe419dab2ee32227c0870f96f805d870fe6 Mon Sep 17 00:00:00 2001
+From: Lucian Cristian <lucian.cristian@gmail.com>
+Date: Fri, 13 Sep 2019 07:16:18 +0300
+Subject: [PATCH] clippy: fail libcap test only when !enable_clippy_only when
+ building native clippy we don't need libcap
+
+Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
+---
+ configure.ac | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 9f37b3e9a9..be3a9c763d 100755
+--- a/configure.ac
++++ b/configure.ac
+@@ -2043,9 +2043,11 @@ if test "${enable_capabilities}" != "no"; then
+ 
+   case "$host_os" in
+   linux*)
++    if test "${enable_clippy_only}" != "yes"; then
+     if test "$frr_ac_lcaps" != "yes"; then
+       AC_MSG_ERROR([libcap and/or its headers were not found.  Running FRR without libcap support built in causes a huge performance penalty.])
+     fi
++    fi
+     ;;
+   esac
+ else

--- a/net/frr/patches/005-fix_OSPF_BFD.patch
+++ b/net/frr/patches/005-fix_OSPF_BFD.patch
@@ -1,0 +1,71 @@
+From eb3e472904e30f35825f08319608217082d4af21 Mon Sep 17 00:00:00 2001
+From: Radhika Mahankali <radhika@cumulusnetworks.com>
+Date: Mon, 9 Apr 2018 15:30:32 -0700
+Subject: [PATCH] ospf: BFD down not tearing down OSPF adjacency for
+ point-to-point network
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Root Cause:
+Lookup for the point-to-point neighbor was failing because the neighbor
+lookup was based on neighbor interface IP address. But, for point-to-point
+neighbor the key is router-id for lookup. Lookup failure was causing the
+BFD updates from PTM to get dropped.
+
+Fix:
+Added walk of the neighbor list if the network type is point-to-point to
+find the appropriate neighbor. The match is based on source IP address of
+the neighbor since that’s the address registered with BFD for monitoring.
+
+Ticket: CM-20411
+Signed-off-by: Radhika Mahankali <radhika@cumulusnetworks.com>
+---
+ ospfd/ospf_bfd.c | 26 ++++++++++++++++++++++++--
+ 1 file changed, 24 insertions(+), 2 deletions(-)
+
+diff --git a/ospfd/ospf_bfd.c b/ospfd/ospf_bfd.c
+index a17975270a..05ec4991e5 100644
+--- a/ospfd/ospf_bfd.c
++++ b/ospfd/ospf_bfd.c
+@@ -202,8 +202,9 @@ static int ospf_bfd_interface_dest_update(ZAPI_CALLBACK_ARGS)
+ 	struct interface *ifp;
+ 	struct ospf_interface *oi;
+ 	struct ospf_if_params *params;
+-	struct ospf_neighbor *nbr;
++	struct ospf_neighbor *nbr = NULL;
+ 	struct route_node *node;
++	struct route_node *n_node;
+ 	struct prefix p;
+ 	int status;
+ 	int old_status;
+@@ -231,7 +232,28 @@ static int ospf_bfd_interface_dest_update(ZAPI_CALLBACK_ARGS)
+ 		if ((oi = node->info) == NULL)
+ 			continue;
+ 
+-		nbr = ospf_nbr_lookup_by_addr(oi->nbrs, &p.u.prefix4);
++		/* walk the neighbor list for point-to-point network */
++		if (oi->type == OSPF_IFTYPE_POINTOPOINT) {
++			for (n_node = route_top(oi->nbrs); n_node;
++				n_node = route_next(n_node)) {
++				nbr = n_node->info;
++				if (nbr) {
++					/* skip myself */
++					if (nbr == oi->nbr_self) {
++						nbr = NULL;
++						continue;
++					}
++
++					/* Found the matching neighbor */
++					if (nbr->src.s_addr ==
++						p.u.prefix4.s_addr)
++						break;
++				}
++			}
++		} else {
++			nbr = ospf_nbr_lookup_by_addr(oi->nbrs, &p.u.prefix4);
++		}
++
+ 		if (!nbr || !nbr->bfd_info)
+ 			continue;
+ 


### PR DESCRIPTION
Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Maintainer: me
Tested: x86

With this, quagga can pe deprecated, I tracked down the problems with inactive routes (seems that is still being worked on)
this is WIP because ~~release links are faulty and they will be fixed and also~~ waiting for the VTI interfaces final fix, but based on my tests everything is fine