### PR TITLE
[OpenWrt 18.06] sudo: Update to version 1.8.28p1

### DIFF
--- a/admin/sudo/Makefile
+++ b/admin/sudo/Makefile
@@ -8,14 +8,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sudo
-PKG_VERSION:=1.8.21p2
+PKG_VERSION:=1.8.28p1
 PKG_RELEASE:=1
-PKG_LICENSE:=ISC
-PKG_LICENSE_FILES:=doc/LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.sudo.ws/dist
-PKG_HASH:=74c5746cd33a814e2431c39faf0d76f7f8a697379bd073862e3b156cf0d76368
+PKG_SOURCE_URL:=https://www.sudo.ws/dist/
+PKG_HASH:=23ba5a84af31e3b5ded58d4be6d3f6939a495a55561fba92c6941b79a6e8b027
+
+PKG_MAINTAINER:=
+PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=doc/LICENSE
+PKG_CPE_ID:=cpe:/a:todd_miller:sudo
 
 PKG_INSTALL:=1
 
@@ -27,8 +30,7 @@ define Package/sudo
   SECTION:=admin
   CATEGORY:=Administration
   TITLE:=Delegate authority to run commands
-  URL:=http://www.sudo.ws/
-  MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
+  URL:=https://www.sudo.ws/
 endef
 
 define Package/sudo/description

--- a/admin/sudo/patches/010-cross-compile-fixes.patch
+++ b/admin/sudo/patches/010-cross-compile-fixes.patch
@@ -1,7 +1,6 @@
-diff -rupN sudo-1.8.11p2.orig/lib/util/Makefile.in sudo-1.8.11p2/lib/util/Makefile.in
---- sudo-1.8.11p2.orig/lib/util/Makefile.in	2014-10-07 22:26:20.000000000 +0200
-+++ sudo-1.8.11p2/lib/util/Makefile.in	2014-12-09 21:44:35.610041162 +0100
-@@ -142,10 +142,10 @@ libsudo_util.la: $(LTOBJS) @LT_LDDEP@
+--- a/lib/util/Makefile.in
++++ b/lib/util/Makefile.in
+@@ -188,10 +188,10 @@ libsudo_util.la: $(LTOBJS) @LT_LDDEP@
  	esac
  
  siglist.c: mksiglist
@@ -13,4 +12,4 @@ diff -rupN sudo-1.8.11p2.orig/lib/util/Makefile.in sudo-1.8.11p2/lib/util/Makefi
 +	mksigname > $@
  
  mksiglist: $(srcdir)/mksiglist.c $(srcdir)/mksiglist.h $(incdir)/sudo_compat.h $(top_builddir)/config.h
- 	$(CC) $(CPPFLAGS) $(CFLAGS) $(DEFS) $(srcdir)/mksiglist.c -o $@
+ 	$(CC) $(CPPFLAGS) $(CFLAGS) $(srcdir)/mksiglist.c -o $@

--- a/admin/sudo/patches/020-no-owner-change.patch
+++ b/admin/sudo/patches/020-no-owner-change.patch
@@ -1,7 +1,6 @@
-diff -rupN sudo-1.8.11p2.orig/Makefile.in sudo-1.8.11p2/Makefile.in
---- sudo-1.8.11p2.orig/Makefile.in	2014-10-07 22:26:20.000000000 +0200
-+++ sudo-1.8.11p2/Makefile.in	2014-12-09 22:00:27.256934143 +0100
-@@ -62,7 +62,7 @@ SHELL = @SHELL@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -64,7 +64,7 @@ SHELL = @SHELL@
  SED = @SED@
  
  INSTALL = $(SHELL) $(top_srcdir)/install-sh -c

--- a/admin/sudo/patches/030-musl-fix-missing-header.patch
+++ b/admin/sudo/patches/030-musl-fix-missing-header.patch
@@ -1,9 +1,8 @@
-diff -rupN sudo-1.8.14p3.orig/include/sudo_util.h sudo-1.8.14p3/include/sudo_util.h
---- sudo-1.8.14p3.orig/include/sudo_util.h	2015-07-22 14:22:49.000000000 +0200
-+++ sudo-1.8.14p3/include/sudo_util.h	2015-08-30 18:41:24.509814946 +0200
-@@ -23,6 +23,8 @@
- # include "compat/stdbool.h"
- #endif /* HAVE_STDBOOL_H */
+--- a/include/sudo_util.h
++++ b/include/sudo_util.h
+@@ -33,6 +33,8 @@
+ # endif
+ #endif
  
 +#include <sys/types.h>
 +


### PR DESCRIPTION
Maintainer: @kissg1988 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06.04
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06.04

Description:

**Update to version [1.8.28p1](https://www.sudo.ws/stable.html#1.8.21p2)**
- Use HTTPS for downloading tarball and for their website
- Add PKG_CPE_ID
- Refreshed patches
Fixes: [CVE-2019-14287](https://www.sudo.ws/alerts/minus_1_uid.html)
