### PR TITLE
sudo: Update to version 1.8.28p1

### DIFF
--- a/admin/sudo/Makefile
+++ b/admin/sudo/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sudo
-PKG_VERSION:=1.8.27
+PKG_VERSION:=1.8.28p1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.sudo.ws/dist
-PKG_HASH:=7beb68b94471ef56d8a1036dbcdc09a7b58a949a68ffce48b83f837dd33e2ec0
+PKG_HASH:=23ba5a84af31e3b5ded58d4be6d3f6939a495a55561fba92c6941b79a6e8b027
 
-PKG_MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
+PKG_MAINTAINER:=
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=doc/LICENSE
 PKG_CPE_ID:=cpe:/a:todd_miller:sudo

--- a/admin/sudo/patches/010-cross-compile-fixes.patch
+++ b/admin/sudo/patches/010-cross-compile-fixes.patch
@@ -1,6 +1,6 @@
 --- a/lib/util/Makefile.in
 +++ b/lib/util/Makefile.in
-@@ -182,10 +182,10 @@ libsudo_util.la: $(LTOBJS) @LT_LDDEP@
+@@ -188,10 +188,10 @@ libsudo_util.la: $(LTOBJS) @LT_LDDEP@
  	esac
  
  siglist.c: mksiglist

--- a/admin/sudo/patches/020-no-owner-change.patch
+++ b/admin/sudo/patches/020-no-owner-change.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -62,7 +62,7 @@ SHELL = @SHELL@
+@@ -64,7 +64,7 @@ SHELL = @SHELL@
  SED = @SED@
  
  INSTALL = $(SHELL) $(top_srcdir)/install-sh -c


### PR DESCRIPTION
Maintainer: @kissg1988 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
Update to version [1.8.28p1](https://www.sudo.ws/stable.html#1.8.28p1), which fixes [CVE-2019-14287](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14287)
- Refreshed patches