### PR TITLE
pps-tools: install timepps.h in location specified by RFC 2783

### DIFF
--- a/utils/pps-tools/Makefile
+++ b/utils/pps-tools/Makefile
@@ -34,7 +34,7 @@ TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/sys
-	$(CP) $(PKG_BUILD_DIR)/timepps.h $(1)/usr/include/sys/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/timepps.h $(1)/usr/include/sys/
 endef
 
 define Package/pps-tools/install

--- a/utils/pps-tools/Makefile
+++ b/utils/pps-tools/Makefile
@@ -33,8 +33,8 @@ endef
 TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_BUILD_DIR)/timepps.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/include/sys
+	$(CP) $(PKG_BUILD_DIR)/timepps.h $(1)/usr/include/sys/
 endef
 
 define Package/pps-tools/install


### PR DESCRIPTION
This is need by eg. gpsd to build with proper PPS support.
It was already submitted once in #2892 which ended in a stalemate.
Signed-off-by: Wolfgang Breyha <wbreyha@gmx.net>

Maintainer: @wigyori
Compile tested: (arm_cortex-a9_vfpv3, OpenWrt 18.06.04, Turris OS 4.0.1)
Run tested: (arm_cortex-a9_vfpv3, OpenWrt 18.06.04, Turris OS 4.0.1, tests done)

Description:
I wanted to build a proper gspd with PPS support. gpsd build process seeks timepps.h in /usr/include/sys/ instead of the outdated location in /usr/include