### PR TITLE
bind: Update to version 9.14.7

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.14.6
+PKG_VERSION:=9.14.7
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=8967a040ed900e1800293b9874357fc2f267f33c723aa617268e163bd921edfe
+PKG_HASH:=cea0f54e5908f77ffd21eb312ee9dd4f3f8f93ca312c6118f27d6c0fba45291d
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- Update to version 9.14.7
```
	--- 9.14.7 released ---

5299.	[security]	A flaw in DNSSEC verification when transferring
			mirror zones could allow data to be incorrectly
			marked valid. (CVE-2019-6475) [GL #16P]

5298.	[security]	Named could assert if a forwarder returned a
			referral, rather than resolving the query, when QNAME
			minimization was enabled. (CVE-2019-6476) [GL #1051]

5297.	[bug]		Check whether a previous QNAME minimization fetch
			is still running before starting a new one; return
			SERVFAIL and log an error if so. [GL #1191]

5294.	[func]		Fallback to ACE name on output in locale, which does not
			support converting it to unicode.  [GL #846]

5293.	[bug]		On Windows, named crashed upon any attempt to fetch XML
			statistics from it. [GL #1245]

5292.	[bug]		Queue 'rndc nsec3param' requests while signing inline
			zone changes. [GL #1205]
```

Fixes [CVE-2019-6475](https://kb.isc.org/docs/cve-2019-6475) and [CVE-2019-6476](https://kb.isc.org/docs/cve-2019-6476)
