### PR TITLE
gcc: Require package and toolchain versions to be the same, correct typo, …

### DIFF
--- a/devel/gcc/Config.in
+++ b/devel/gcc/Config.in
@@ -9,7 +9,7 @@ menu "Libraries"
 			very large package
 		default n
 	config INCLUDE_STATIC_LIBPTHREAD
-		bool "Include static libptread on target"
+		bool "Include static libpthread on target"
 		help
 			Copies libpthread.a to target device
 			Increases the size of an already
@@ -27,8 +27,13 @@ menu "Libraries"
 		bool "Generate spec file for easy static c++ linking on target"
 		help
 			Creates a spec file for gcc to eliminate the need for
-			-lstdc++, libgcc_pic and -static-libstdc flags when
+			-lstdc++, -libgcc_pic and -static-libstdc flags when
 			statically linking c++ programs
+			This doesn't work if the package is built into the
+			image, you need to generate the spec file after
+			installing the image. For example run:
+			g++ -dumpspecs |sed s/--start-group}\ %G\ %L\ /--start-group}\ %G\ %L\ -lstdc++\ -lgcc_pic\ / >/usr/lib/gcc/x86_64-openwrt-linux-musl/7.4.0/specs
+			on a x86_64 system
 		default n
 endmenu
 

--- a/devel/gcc/Makefile
+++ b/devel/gcc/Makefile
@@ -17,14 +17,14 @@ define Package/gcc
   CATEGORY:=Development
   TITLE:=gcc
   MAINTAINER:=Noble Pepper <gccmaintain@noblepepper.com>
-  DEPENDS:= +binutils +libstdcpp @!arc
+  DEPENDS:= +binutils +libstdcpp @!arc @GCC_VERSION=7.4.0
   MENU:=1
 endef
 
 PKG_NAME:=gcc
 # PKG_VERSION=7.3.0
 PKG_VERSION=7.4.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_SOURCE_URL:=@GNU/gcc/gcc-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_INSTALL:=1
@@ -58,8 +58,10 @@ ifeq ($(CONFIG_INCLUDE_STATIC_LIBSTDC),y)
 endif
 
 ifeq ($(CONFIG_INCLUDE_STATIC_LINK_SPEC),y)
-	INSTALL_STATIC_SPEC=g++ -dumpspecs |sed s/--start-group}\ %G\ %L\ /--start-group}\ %G\ %L\ -lstdc++\ -lgcc_pic\ / >/usr/lib/$(PKG_NAME)/$(REAL_GNU_TARGET_NAME)/$(PKG_VERSION)/specs
-	REMOVE_STATIC_SPEC=rm /usr/lib/$(PKG_NAME)/$(REAL_GNU_TARGET_NAME)/$(PKG_VERSION)/specs
+	ifeq ($(CONFIG_PACKAGE_gcc),m)
+		INSTALL_STATIC_SPEC=g++ -dumpspecs |sed s/--start-group}\ %G\ %L\ /--start-group}\ %G\ %L\ -lstdc++\ -lgcc_pic\ / >/usr/lib/$(PKG_NAME)/$(REAL_GNU_TARGET_NAME)/$(PKG_VERSION)/specs
+		REMOVE_STATIC_SPEC=rm /usr/lib/$(PKG_NAME)/$(REAL_GNU_TARGET_NAME)/$(PKG_VERSION)/specs
+	endif
 endif
 
 include $(INCLUDE_DIR)/package.mk

--- a/devel/gcc/patches/020-disable-check-for-sys-sdt-h.patch
+++ b/devel/gcc/patches/020-disable-check-for-sys-sdt-h.patch
@@ -1,0 +1,45 @@
+diff --git a/gcc/configure b/gcc/configure
+index 3793681..bcda752 100755
+--- a/gcc/configure
++++ b/gcc/configure
+@@ -26876,19 +26876,6 @@ $as_echo "#define TARGET_LIBC_PROVIDES_SSP 1" >>confdefs.h
+ 
+ fi
+ 
+-# Test for <sys/sdt.h> on the target.
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking sys/sdt.h in the target C library" >&5
+-$as_echo_n "checking sys/sdt.h in the target C library... " >&6; }
+-have_sys_sdt_h=no
+-if test -f $target_header_dir/sys/sdt.h; then
+-  have_sys_sdt_h=yes
+-
+-$as_echo "#define HAVE_SYS_SDT_H 1" >>confdefs.h
+-
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_sys_sdt_h" >&5
+-$as_echo "$have_sys_sdt_h" >&6; }
+ 
+ # Check if TFmode long double should be used by default or not.
+ # Some glibc targets used DFmode long double, but with glibc 2.4
+diff --git a/gcc/configure.ac b/gcc/configure.ac
+index 3ee1d67..e321218 100644
+--- a/gcc/configure.ac
++++ b/gcc/configure.ac
+@@ -4796,16 +4796,6 @@ if test x$gcc_cv_libc_provides_ssp = xyes; then
+ 	    [Define if your target C library provides stack protector support])
+ fi
+ 
+-# Test for <sys/sdt.h> on the target.
+-GCC_TARGET_TEMPLATE([HAVE_SYS_SDT_H])
+-AC_MSG_CHECKING(sys/sdt.h in the target C library)
+-have_sys_sdt_h=no
+-if test -f $target_header_dir/sys/sdt.h; then
+-  have_sys_sdt_h=yes
+-  AC_DEFINE(HAVE_SYS_SDT_H, 1,
+-            [Define if your target C library provides sys/sdt.h])
+-fi
+-AC_MSG_RESULT($have_sys_sdt_h)
+ 
+ # Check if TFmode long double should be used by default or not.
+ # Some glibc targets used DFmode long double, but with glibc 2.4


### PR DESCRIPTION
…restore sdt.h patch

Signed-off-by: Noble Pepper <noblepepper@gmail.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
Should fix issues [10255](https://github.com/openwrt/packages/issues/10255), [10198](https://github.com/openwrt/packages/issues/10198) and this [comment](https://github.com/openwrt/packages/pull/9418#issuecomment-542450016)