### PR TITLE
python-cryptography: Update to 2.8

### DIFF
--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptography
-PKG_VERSION:=2.7
-PKG_RELEASE:=2
+PKG_VERSION:=2.8
+PKG_RELEASE:=1
 
 PKG_SOURCE:=cryptography-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/cryptography
-PKG_HASH:=e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6
+PKG_HASH:=3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651
 
 PKG_LICENSE:=Apache-2.0 BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.APACHE LICENSE.BSD
@@ -47,7 +47,6 @@ $(call Package/python-cryptography/Default)
       +PACKAGE_python-cryptography:python-cffi \
       +PACKAGE_python-cryptography:python-enum34 \
       +PACKAGE_python-cryptography:python-ipaddress \
-      +PACKAGE_python-cryptography:python-asn1crypto \
       +PACKAGE_python-cryptography:python-six
   VARIANT:=python
 endef
@@ -57,7 +56,6 @@ $(call Package/python-cryptography/Default)
   DEPENDS+= \
       +PACKAGE_python3-cryptography:python3 \
       +PACKAGE_python3-cryptography:python3-cffi \
-      +PACKAGE_python3-cryptography:python3-asn1crypto \
       +PACKAGE_python3-cryptography:python3-six
   VARIANT:=python3
 endef


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2019-10-18 snapshot sdk
Run tested: none

Description:
With this update, the package [no longer depends][1] on python-asn1crypto.

[1]: https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst#28---2019-10-16

Signed-off-by: Jeffery To <jeffery.to@gmail.com>