### PR TITLE
[openwrt-19.07] python-ipaddress: Update to 1.0.23

### DIFF
--- a/lang/python/python-ipaddress/Makefile
+++ b/lang/python/python-ipaddress/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-ipaddress
-PKG_VERSION:=1.0.22
+PKG_VERSION:=1.0.23
 PKG_RELEASE:=1
 
 PKG_SOURCE:=ipaddress-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/i/ipaddress
-PKG_HASH:=b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c
+PKG_HASH:=b7f8e0369580bb4a24d5ba1d7cc29660a4a6987763faf1d8a8046830e020e7e2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-ipaddress-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: none (cherry-picked from #10302)
Run tested: none

Description:
Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from 21858952976aad8ad92cbe76351c5535c39a3f2f)