### PR TITLE
ntpd: Fix libevent dependencies

### DIFF
--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntp
 PKG_VERSION:=4.2.8p13
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/
@@ -33,7 +33,7 @@ define Package/ntpd/Default
   TITLE:=ISC ntp
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
   URL:=http://www.ntp.org/
-  DEPENDS:=+libopenssl +libpthread +libcap
+  DEPENDS:=+libopenssl +libpthread +libcap +libevent2-pthreads
 endef
 
 define Package/ntpd/Default/description
@@ -80,7 +80,6 @@ endef
 define Package/ntp-keygen
 $(call Package/ntpd/Default)
   TITLE+=keygen
-  DEPENDS+= +libevent2-core
 endef
 
 define Package/ntp-keygen/description


### PR DESCRIPTION
Add required libevent2-pthreads dependency for all ntpd
subpackages.

Remove keygen-specific libevent2-core support as it is
automatically selected by the libevent2-pthreads dependency.

Fixes: openwrt/packages#10307

Signed-off-by: Kenneth J. Miller <ken@miller.ec>

Maintainer: @tripolar 
Compile tested: OpenWRT snapshot r11266-34939711a5 - packages @ fa790f0
Run tested: ZyXEL NBG6817 w/ OpenWRT snapshot r11266-34939711a5