### PR TITLE
python,python3: Add PYPI_SOURCE_NAME to pypi.mk

### DIFF
--- a/lang/python/pypi.mk
+++ b/lang/python/pypi.mk
@@ -12,12 +12,13 @@ ifndef DUMP
 endif
 
 ifneq ($(strip $(PYPI_NAME)),)
+  PYPI_SOURCE_NAME?=$(PYPI_NAME)
   PYPI_SOURCE_EXT?=tar.gz
   PYPI_NAME_FIRST_LETTER?=$(strip $(foreach a,$(chars_lower) $(chars_upper) 0 1 2 3 4 5 6 7 8 9 _ -,$(if $(PYPI_NAME:$a%=),,$a)))
 
-  PKG_SOURCE?=$(PYPI_NAME)-$(PKG_VERSION).$(PYPI_SOURCE_EXT)
+  PKG_SOURCE?=$(PYPI_SOURCE_NAME)-$(PKG_VERSION).$(PYPI_SOURCE_EXT)
   PKG_SOURCE_URL?=https://files.pythonhosted.org/packages/source/$(PYPI_NAME_FIRST_LETTER)/$(PYPI_NAME)
 
-  PKG_BUILD_DIR:=$(BUILD_DIR)/pypi/$(if $(BUILD_VARIANT),$(PKG_NAME)-$(BUILD_VARIANT)/)$(PYPI_NAME)$(if $(PKG_VERSION),-$(PKG_VERSION))
-  HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/pypi/$(PYPI_NAME)$(if $(PKG_VERSION),-$(PKG_VERSION))
+  PKG_BUILD_DIR:=$(BUILD_DIR)/pypi/$(if $(BUILD_VARIANT),$(PKG_NAME)-$(BUILD_VARIANT)/)$(PYPI_SOURCE_NAME)$(if $(PKG_VERSION),-$(PKG_VERSION))
+  HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/pypi/$(PYPI_SOURCE_NAME)$(if $(PKG_VERSION),-$(PKG_VERSION))
 endif


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2019-10-18 snapshot sdk
Run tested: N/A

Description:
This adds a new (optional) variable, `PYPI_SOURCE_NAME`, to `pypi.mk`.

For some PyPi packages (e.g. aiohttp_cors, click, django-compressor), the name of the package and the source tarball name are slightly different (usually by capitalisation or hyphen/underscore change).

This new variable is to make this difference explicit. `PYPI_NAME` is meant for the "official" package name, whereas `PYPI_SOURCE_NAME` is meant for the source tarball name.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>

