### PR TITLE
keepalived: update version to 2.0.19

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
-PKG_VERSION:=2.0.18
-PKG_RELEASE:=2
+PKG_VERSION:=2.0.19
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software
-PKG_HASH:=1423a2b1b8e541211029b9e1e1452e683bbe5f4b0b287eddd609aaf5ff024fd0
+PKG_HASH:=0e2f8454765bc6a5fa26758bd9cec18aae42882843cdd24848aff0ae65ce4ca7
 
 PKG_CPE_ID:=cpe:/a:keepalived:keepalived
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, APU3, OpenWrt master
Run tested: x86_64, APU3

Description:
Update to new version 2.0.19

```

keepalived --version
Keepalived v2.0.19 (10/17,2019), git commit reboot-11348-gdb12f25c05

Copyright(C) 2001-2019 Alexandre Cassen, <acassen@gmail.com>

Built with kernel headers for Linux 4.19.79
Running on Linux 4.19.78 #0 SMP Wed Oct 16 09:18:23 2019

configure options: --target=x86_64-openwrt-linux --host=x86_64-openwrt-linux --build=x86_64-pc-linux-gnu --program-prefix= --program-suffix= --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --libexecdir=/usr/lib --sysconfdir=/etc --datadir=/usr/share --localstatedir=/var --mandir=/usr/man --infodir=/usr/info --disable-nls --with-init=SYSV --disable-nftables --enable-sha1 --disable-libipset-dynamic build_alias=x86_64-pc-linux-gnu host_alias=x86_64-openwrt-linux target_alias=x86_64-openwrt-linux PKG_CONFIG=/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/host/bin/pkg-config PKG_CONFIG_PATH=/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/target-x86_64_musl/usr/lib/pkgconfig:/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/target-x86_64_musl/usr/share/pkgconfig PKG_CONFIG_LIBDIR=/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/target-x86_64_musl/usr/lib/pkgconfig:/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/target-x86_64_musl/usr/share/pkgconfig CC=x86_64-openwrt-linux-musl-gcc CFLAGS=-Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -ffile-prefix-map=/home/feckert/workspace/lede/LDM-master-64/build/openwrt/build_dir/target-x86_64_musl/keepalived-2.0.19=keepalived-2.0.19 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -I/home/feckert/workspace/lede/LDM-master-64/build/openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-4.19.79  LDFLAGS=-L/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/target-x86_64_musl/usr/lib -L/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/target-x86_64_musl/lib -L/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/toolchain-x86_64_gcc-8.3.0_musl/usr/lib -L/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/toolchain-x86_64_gcc-8.3.0_musl/lib -znow -zrelro  CPPFLAGS=-I/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/target-x86_64_musl/usr/include -I/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/target-x86_64_musl/include -I/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/toolchain-x86_64_gcc-8.3.0_musl/usr/include -I/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/toolchain-x86_64_gcc-8.3.0_musl/include/fortify -I/home/feckert/workspace/lede/LDM-master-64/build/openwrt/staging_dir/toolchain-x86_64_gcc-8.3.0_musl/include

Config options:  LIBIPTC LIBIPSET LVS VRRP VRRP_AUTH OLD_CHKSUM_COMPAT FIB_ROUTING

System options:  PIPE2 SIGNALFD INOTIFY_INIT1 VSYSLOG EPOLL_CREATE1 IPV4_DEVCONF IPV6_ADVANCED_API LIBNL3 RTA_ENCAP RTA_EXPIRES RTA_NEWDST RTA_PREF FRA_SUPPRESS_PREFIXLEN FRA_SUPPRESS_IFGROUP FRA_TUN_ID RTAX_CC_ALGO RTAX_QUICKACK RTEXT_FILTER_SKIP_STATS FRA_L3MDEV FRA_UID_RANGE RTAX_FASTOPEN_NO_COOKIE RTA_VIA FRA_OIFNAME FRA_PROTOCOL FRA_IP_PROTO FRA_SPORT_RANGE FRA_DPORT_RANGE RTA_TTL_PROPAGATE IFA_FLAGS IP_MULTICAST_ALL LWTUNNEL_ENCAP_MPLS LWTUNNEL_ENCAP_ILA LIBIPTC NET_LINUX_IF_H_COLLISION NETINET_LINUX_IF_ETHER_H_COLLISION LIBIPVS_NETLINK IPVS_DEST_ATTR_ADDR_FAMILY IPVS_SYNCD_ATTRIBUTES IPVS_64BIT_STATS VRRP_VMAC VRRP_IPVLAN IFLA_LINK_NETNSID CN_PROC SOCK_NONBLOCK SOCK_CLOEXEC O_PATH INET6_ADDR_GEN_MODE VRF SO_MARK SCHED_RT SCHED_RESET_ON_FORK
```
