### PR TITLE
libxml2/host: revert xml2-config prefix fix

### DIFF
--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxml2
 PKG_VERSION:=2.9.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://xmlsoft.org/sources/
@@ -184,11 +184,6 @@ define Package/libxml2-utils/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/xmllint $(1)/usr/bin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/xmlcatalog $(1)/usr/bin/
-endef
-
-define Host/Install
-	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' $(HOST_BUILD_DIR)/xml2-config
-	$(call Host/Install/Default)
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
Commit 218f0229a4594b32d9db6ad0678cdce7e2663e27 added a workaround for a
problem. The host compile overwrote xml2-config in
"$(STAGING_DIR)/host/bin". The workaround fixed the issue for regular
target packages. But it didn't leave a proper xml2-config script for
host packages.

Times have changed. Host packages are now installed in
"$(STAGING_DIR_HOSTPKG). So there is no longer any danger of the host
package overwriting the xml2-config script for target packages. So
revert the mentioned commit, leaving us with two proper xml2-config
scripts, one for target package builds and one for host package builds.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @mhei 
Compile tested: libxslt/host asterisk-16.x/menuconfig
Run tested: libxslt/host asterisk-16.x/menuconfig

Description:
Stumbled over this when looking into adding host libxml2 support for libxslt host build.

Regards,
Seb

