### PR TITLE
python-pytz: update to 2019.03

### DIFF
--- a/lang/python/python-pytz/Makefile
+++ b/lang/python/python-pytz/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pytz
-PKG_VERSION:=2019.2
+PKG_VERSION:=2019.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=pytz-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pytz
-PKG_HASH:=26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32
+PKG_HASH:=b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pytz-$(PKG_VERSION)
 


### PR DESCRIPTION
Signed-off-by: Fabian Lipken <dynasticorpheus@gmail.com>
Maintainer: @commodo  @neheb 
Description: python-pytz: update to 2019.03
