### PR TITLE
btrfs-progs: Update to version 5.3

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
-PKG_VERSION:=5.2.2
+PKG_VERSION:=5.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs
-PKG_HASH:=821321dbf17087e1172023fa35656ce52d342fbfe210fb8ea01fc57b65dfb1c6
+PKG_HASH:=1763ec7d102632663ac497739bfbab332bebb9fac70bd8718c131f6156583b8e
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Karel Kočí <karel.koci@nic.cz>


### PR DESCRIPTION
Maintainer: @Cynerd 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- Update to [version 5.3](https://btrfs.wiki.kernel.org/index.php/Changelog#btrfs-progs_v5.3_.28Oct_2019.29)

```
btrfs-progs-5.3 (2019-10-21)
  * mkfs:
    * new option to specify checksum algorithm (only crc32c)
    * fix xattr enumeration
  * dump-tree: BFS (breadth-first) traversal now default
  * libbtrfsutil: remove stale BTRFS_DEV_REPLACE_ITEM_STATE_x defines
  * ci: add support for gitlab
  * other:
    * preparatory work for more checksum algorithms
    * docs update
    * switch to docbook5 backend for asciidoc
    * fix build on uClibc due to missing backtrace()
    * lots of printf format fixups

```

When it will be approved, I'm going to cherry-pick it also to `openwrt-19.07` branch.