### PR TITLE
kcptun: bump to v20190924, add new config options

### DIFF
--- a/net/kcptun/Makefile
+++ b/net/kcptun/Makefile
@@ -1,12 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kcptun
-PKG_VERSION:=20190809
+PKG_VERSION:=20190924
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/xtaci/kcptun/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=79dc1c31320552fcd76a31a83a515debb9ab7dbcf831c39346512f590d6b150d
+PKG_SOURCE_DATE:=2019-09-24
+PKG_HASH:=40d24575b1604bb046f713aebed4f722990b8b2e245f1ad385fb51df956d3a24
 
 PKG_MAINTAINER:=Dengfeng Liu <liudf0716@gmail.com>, Chao Liu <expiron18@gmail.com>
 PKG_LICENSE:=MIT
@@ -28,7 +29,7 @@ define Package/kcptun-config
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
-  TITLE:=kcptun config scripts
+  TITLE:=Kcptun Config Scripts
   URL:=https://github.com/xtaci/kcptun
 endef
 

--- a/net/kcptun/README.md
+++ b/net/kcptun/README.md
@@ -20,7 +20,9 @@ Every section has a `disabled` option to temporarily turn off the instance.
 | dscp | integer | --dscp | set DSCP(6bit) (default: 0) |
 | nocomp | boolean | --nocomp | disable compression |
 | sockbuf | integer | --sockbuf | per-socket buffer in bytes (default: 4194304) |
+| smuxver | integer | --smuxver | specify smux version, available 1,2 (default: 1) |
 | smuxbuf | integer | --smuxbuf | the overall de-mux buffer in bytes (default: 4194304) |
+| streambuf | integer | --streambuf | per stream receive buffer in bytes, for smux v2+ (default: 2097152) |
 | keepalive | integer | --keepalive | seconds between heartbeats (default: 10) |
 | snmplog | string | --snmplog | collect snmp to file, aware of timeformat in golang, like: ./snmp-20060102.log |
 | snmpperiod | integer | --snmpperiod | snmp collect period, in seconds (default: 60) |

--- a/net/kcptun/files/kcptun.config
+++ b/net/kcptun/files/kcptun.config
@@ -34,7 +34,9 @@ config client
 	option rcvwnd 512
 	option nocomp 1
 	option sockbuf 4194304
+	option smuxver 1
 	option smuxbuf 4194304
+	option streambuf 2097152
 	option keepalive 10
 	option quiet 1
 	option gogc 20

--- a/net/kcptun/files/kcptun.init
+++ b/net/kcptun/files/kcptun.init
@@ -58,7 +58,9 @@ kcptun() {
 	[ -z "$dscp" ] || json_add_int dscp "$dscp"
 	json_add_boolean nocomp "$nocomp"
 	[ -z "$sockbuf" ] || json_add_int sockbuf "$sockbuf"
+	[ -z "$smuxver" ] || json_add_int smuxver "$smuxver"
 	[ -z "$smuxbuf" ] || json_add_int smuxbuf "$smuxbuf"
+	[ -z "$streambuf" ] || json_add_int streambuf "$streambuf"
 	[ -z "$keepalive" ] || json_add_int keepalive "$keepalive"
 	[ -z "$snmplog" ] || json_add_string snmplog "$snmplog"
 	[ -z "$snmpperiod" ] || json_add_int snmpperiod "$snmpperiod"
@@ -132,7 +134,9 @@ validate_common_options() {
 		'dscp:uinteger' \
 		'nocomp:bool' \
 		'sockbuf:uinteger' \
+		'smuxver:uinteger' \
 		'smuxbuf:uinteger' \
+		'streambuf:uinteger' \
 		'keepalive:uinteger' \
 		'snmplog:string' \
 		'snmpperiod:uinteger' \


### PR DESCRIPTION
This commit updates:
- bump version to v20190924
- add new options for latest release
  (https://github.com/xtaci/kcptun/releases/tag/v20190924)

Signed-off-by: Chao Liu <expiron18@gmail.com>

Maintainer: me 
Compile tested: Ubuntu 18.04 LTS, OpenWRT ar71xx
Run tested: OpenWRT ar71xx