### PR TITLE
yggdrasil: bump to 0.3.11

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
-PKG_VERSION:=0.3.9
+PKG_VERSION:=0.3.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=34780dbdbcb486320097274ef9d3c606165c44132f250e481671f99686c77b73
+PKG_HASH:=a831ee7ae5b7cf58950eac5f9cfab24688990db8d91b250624d9bae58da3cfb9
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-go-$(PKG_VERSION)
 
 PKG_MAINTAINER:=William Fleurant <meshnet@protonmail.com>


### PR DESCRIPTION
Signed-off-by: William Fleurant <meshnet@protonmail.com>

Maintainer: @wfleurant 
Compile tested: x86/64 snapshots with SDK
Description: https://github.com/yggdrasil-network/yggdrasil-go/releases/tag/v0.3.11