### PR TITLE
libxslt/host: depend on libxml2/host

### DIFF
--- a/libs/libxslt/Makefile
+++ b/libs/libxslt/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxslt
 PKG_VERSION:=1.1.33
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -25,6 +25,8 @@ PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+
+HOST_BUILD_DEPENDS:=libxml2/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
@@ -130,6 +132,7 @@ endef
 HOST_CONFIGURE_ARGS+= \
 	--disable-silent-rules \
 	--enable-static \
+	--with-libxml-prefix=$(STAGING_DIR_HOSTPKG) \
 	--without-python \
 	--without-crypto \
 	--without-debug \


### PR DESCRIPTION
The host build requires libxml2-dev. This commit adds the dependency for
libxml2/host, as the host system may not have it installed. This also
avoids using the host's xml2-config (in /usr/bin for instance) while
linking to libraries in staging_dir/hostpkg.

ldd staging_dir/hostpkg/bin/xsltproc | grep xml2
	libxml2.so.2 => /home/sk/tmp/openwrt/staging_dir/hostpkg/lib/libxml2.so.2 (0x00007fcc0644c000)

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @jslachta 
Compile tested: ath79 master
Run tested: Just a dependency fix for host package
Description:
Hi Jiri,

Nothing major, I just feel this is the right thing to do.

Kind regards,
Seb