### PR TITLE
modemmanager: fix compilation

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.10.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
@@ -22,6 +22,10 @@ LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+
+PKG_BUILD_DEPENDS:=glib2/host libxslt/host
+
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -73,6 +77,10 @@ define Build/Prepare
 	( cd "$(PKG_BUILD_DIR)"; \
 		printf "all:\ninstall:\n" >po/Makefile.in.in; \
 	)
+	$(SED) 's|^\(GLIB_MKENUMS\)=.*|\1=$(STAGING_DIR_HOSTPKG)/bin/glib-mkenums|' \
+		$(PKG_BUILD_DIR)/configure.ac
+	$(SED) 's|^\(GDBUS_CODEGEN\)=.*|\1=$(STAGING_DIR_HOSTPKG)/bin/gdbus-codegen|' \
+		$(PKG_BUILD_DIR)/configure.ac
 endef
 
 define Build/InstallDev
@@ -124,9 +132,5 @@ define Package/modemmanager/install
 	$(INSTALL_DIR) $(1)/lib/netifd/proto
 	$(INSTALL_BIN) ./files/modemmanager.proto $(1)/lib/netifd/proto/modemmanager.sh
 endef
-
-$(eval $(call RequireCommand,xsltproc, \
-        $(PKG_NAME) requires xsltproc installed on the host-system. \
-))
 
 $(eval $(call BuildPackage,modemmanager))


### PR DESCRIPTION
MM has a problem with cross-compiling. It needs to run some tools during
compilation (glib-mkenums & gdbus-codegen) but uses pkg-config to detect
them. But like this it finds the wrong tools, the ones in
$(STAGING_DIR). The correct tools are in $(STAGING_DIR_HOSTPKG)/bin.

As a workaround this commit patches configure.ac so the correct tools
are used, the ones from glib2/host. The latter is also added to
PKG_BUILD_DEPENDS to reflect this.

libxslt/host is also added to PKG_BUILD_DEPENDS and the related
RequireCommand call is removed. This is OK to do since we have
libxslt/host available since a few days ago.

Resolves #10249

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @nickberry17 
Compile tested: ath79 master
Run tested: Don't have a modem. Maybe @feckert or maintainer can runtest.

Description:
Hi all,

Saw that there's some problem with MM compile.

Regards,
Seb