### PR TITLE
qemu: vnc and spice ui support

### DIFF
--- a/libs/spice-protocol/Makefile
+++ b/libs/spice-protocol/Makefile
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2019 Yousong Zhou <yszhou4tech@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=spice-protocol
+PKG_VERSION:=0.12.15
+PKG_RELEASE:=1
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://www.spice-space.org/download/releases
+PKG_HASH:=8b4db23baa4b1337a50d049d9bf43f932331dd95f204836c0ce46c4962306419
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=COPYING
+PKG_INSTALL:=1
+PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+
+define Package/spice-protocol
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=SPICE - headers defining protocols
+  URL:=https://www.spice-space.org/index.html
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/pkgconfig/* $(1)/usr/lib/pkgconfig
+endef
+
+$(eval $(call BuildPackage,spice-protocol))

--- a/libs/spice/Makefile
+++ b/libs/spice/Makefile
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2019 Yousong Zhou <yszhou4tech@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=spice
+PKG_VERSION:=0.14.1
+PKG_RELEASE:=1
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://www.spice-space.org/download/releases/spice-server
+PKG_HASH:=1ead5de63d06eededed4017db37240f07bef0abffbaf621899647e7e685a1519
+PKG_LICENSE:=LGPL-2.1-only
+PKG_LICENSE_FILES:=COPYING
+PKG_INSTALL:=1
+PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
+
+PKG_BUILD_DEPENDS+=spice-protocol
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libspice-server
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=SPICE server library
+  URL:=https://www.spice-space.org/index.html
+  DEPENDS:=+glib2 +libjpeg +libopenssl +pixman +zlib
+endef
+
+define Package/libspice-server/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libspice-server.so* $(1)/usr/lib
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib
+endef
+
+# audio codec
+CONFIGURE_ARGS += \
+	--disable-opus \
+	--disable-celt051 \
+
+CONFIGURE_ARGS += \
+	--disable-lz4 \
+	--disable-manual \
+	--disable-gstreamer \
+	--disable-smartcard \
+	--disable-statistics \
+
+$(eval $(call BuildPackage,libspice-server))

--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qemu
 PKG_VERSION:=4.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_HASH:=656e60218689bdeec69903087fd7582d5d3e72238d02f4481d8dc6d79fd909c6
 PKG_SOURCE_URL:=http://download.qemu.org/
@@ -147,6 +147,20 @@ qemu-firmware-efi-title:=QEMU build of iPXE EFI roms
 qemu-firmware-efi-files:=efi-*.rom
 $(eval $(call qemu-firmware,efi))
 
+define Package/qemu-keymaps
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Virtualization
+  TITLE:=QEMU reverse keymaps for use with -k argument
+  URL:=http://www.qemu.org
+  DEPENDS:=$(QEMU_DEPS_IN_HOST)
+endef
+
+define Package/qemu-keymaps/install
+	$(INSTALL_DIR) $(1)/usr/share/qemu/keymaps
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/qemu/keymaps/* $(1)/usr/share/qemu/keymaps
+endef
+
 
 # Naming rules used in qemu Makefile.target
 define qemu-prog_
@@ -175,6 +189,10 @@ define qemu-target
     TITLE:=QEMU target $(1)
     URL:=http://www.qemu.org
     DEPENDS:= +glib2 +libpthread +zlib $(CXX_DEPENDS) $(QEMU_DEPS_IN_HOST) $(qemu-target-$(1)-deps) \
+	+QEMU_UI_VNC:qemu-keymaps \
+	+QEMU_UI_VNC_JPEG:libjpeg \
+	+QEMU_UI_VNC_PNG:libpng \
+	+QEMU_UI_VNC_SASL:libsasl2 \
 	$(if $(filter %-softmmu,$(1)),+libncurses +libfdt +pixman +qemu-firmware-efi $(ICONV_DEPENDS))
   endef
 
@@ -211,6 +229,30 @@ qemu-target-x86_64-softmmu-extra-files:= \
 $(foreach target,$(qemu-target-list), \
   $(eval $(call qemu-target,$(target))) \
 )
+
+define Package/qemu-$(firstword $(qemu-target-list))/config
+if $(subst $(space),||,$(foreach target,$(qemu-target-list),PACKAGE_qemu-$(target)))
+config QEMU_UI_VNC
+	bool "QEMU VNC support"
+	default y
+
+config QEMU_UI_VNC_JPEG
+	bool "QEMU VNC jpeg tight encoding support"
+	default n
+	depends on QEMU_UI_VNC
+
+config QEMU_UI_VNC_PNG
+	bool "QEMU VNC png tight encoding support"
+	default n
+	depends on QEMU_UI_VNC
+
+config QEMU_UI_VNC_SASL
+	bool "QEMU VNC SASL auth support"
+	default n
+	depends on QEMU_UI_VNC
+
+endif
+endef
 
 
 # QEMU configure script does not recognize these options
@@ -279,10 +321,10 @@ CONFIGURE_ARGS +=			\
 	--disable-sdl-image		\
 	--disable-spice			\
 	--disable-virglrenderer		\
-	--disable-vnc			\
-	--disable-vnc-jpeg		\
-	--disable-vnc-png		\
-	--disable-vnc-sasl		\
+	--$(if $(CONFIG_QEMU_UI_VNC),enable,disable)-vnc			\
+	--$(if $(CONFIG_QEMU_UI_VNC_JPEG),enable,disable)-vnc-jpeg		\
+	--$(if $(CONFIG_QEMU_UI_VNC_PNG),enable,disable)-vnc-png		\
+	--$(if $(CONFIG_QEMU_UI_VNC_SASL),enable,disable)-vnc-sasl		\
 	--disable-vte			\
 	--enable-curses			\
 	--enable-iconv			\
@@ -389,6 +431,7 @@ $(eval $(call BuildPackage,qemu-ga))
 $(eval $(call BuildPackage,qemu-bridge-helper))
 $(eval $(call BuildPackage,qemu-img))
 $(eval $(call BuildPackage,qemu-nbd))
+$(eval $(call BuildPackage,qemu-keymaps))
 $(foreach p,$(QEMU_PACKAGES), \
   $(eval $(call BuildPackage,$(p))) \
 )

--- a/utils/qemu/Makefile
+++ b/utils/qemu/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qemu
 PKG_VERSION:=4.1.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_HASH:=656e60218689bdeec69903087fd7582d5d3e72238d02f4481d8dc6d79fd909c6
 PKG_SOURCE_URL:=http://download.qemu.org/
@@ -23,10 +23,11 @@ PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 PKG_USE_MIPS16:=0
 
+PKG_BUILD_DEPENDS+=spice-protocol
+
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/package.mk
-
 
 QEMU_DEPS_IN_GUEST := @(TARGET_x86_64||TARGET_armvirt||TARGET_arm64||TARGET_malta)
 QEMU_DEPS_IN_HOST := @(TARGET_x86_64||TARGET_sunxi)
@@ -193,6 +194,7 @@ define qemu-target
 	+QEMU_UI_VNC_JPEG:libjpeg \
 	+QEMU_UI_VNC_PNG:libpng \
 	+QEMU_UI_VNC_SASL:libsasl2 \
+	+QEMU_UI_SPICE:libspice-server \
 	$(if $(filter %-softmmu,$(1)),+libncurses +libfdt +pixman +qemu-firmware-efi $(ICONV_DEPENDS))
   endef
 
@@ -250,6 +252,9 @@ config QEMU_UI_VNC_SASL
 	bool "QEMU VNC SASL auth support"
 	default n
 	depends on QEMU_UI_VNC
+
+config QEMU_UI_SPICE
+	bool "QEMU SPICE ui support"
 
 endif
 endef
@@ -319,7 +324,7 @@ CONFIGURE_ARGS +=			\
 	--disable-gtk			\
 	--disable-sdl			\
 	--disable-sdl-image		\
-	--disable-spice			\
+	--$(if $(CONFIG_QEMU_UI_SPICE),enable,disable)-spice			\
 	--disable-virglrenderer		\
 	--$(if $(CONFIG_QEMU_UI_VNC),enable,disable)-vnc			\
 	--$(if $(CONFIG_QEMU_UI_VNC_JPEG),enable,disable)-vnc-jpeg		\


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64
Run tested: x86_64

Description:

- basic vnc enabled by default
- advanced vnc features and spice support are off by default

Resolves #10360 