### PR TITLE
yggdrasil: uci firewall Section name and cover both IP versions

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
 PKG_VERSION:=0.3.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?

--- a/net/yggdrasil/files/yggdrasil.defaults
+++ b/net/yggdrasil/files/yggdrasil.defaults
@@ -41,14 +41,13 @@ EOF
 
   # create the firewall zone
   uci -q batch <<-EOF >/dev/null
-    add firewall zone
-    set firewall.@zone[-1].name=yggdrasil
-    add_list firewall.@zone[-1].network=yggdrasil
-    set firewall.@zone[-1].input=REJECT
-    set firewall.@zone[-1].output=ACCEPT
-    set firewall.@zone[-1].forward=REJECT
-    set firewall.@zone[-1].conntrack=1
-    set firewall.@zone[-1].family=ipv6
+    set firewall.yggdrasil=zone
+    set firewall.yggdrasil.name=yggdrasil
+    add_list firewall.yggdrasil.network=yggdrasil
+    set firewall.yggdrasil.input=REJECT
+    set firewall.yggdrasil.output=ACCEPT
+    set firewall.yggdrasil.forward=REJECT
+    set firewall.yggdrasil.conntrack=1
 EOF
 
   # allow ICMP from yggdrasil zone, e.g. ping6


### PR DESCRIPTION
Maintainer: @wfleurant 
Run tested: globalscale,espressobin | OpenWrt SNAPSHOT r10173-6b762dd
Description:

- rename the section instance to yggdrasil (feat. request)
- allow zone to cover both ip4 and ip6 fam

Signed-off-by: William Fleurant <meshnet@protonmail.com>
