### PR TITLE
libxml2: install xml2-config with host triplet

### DIFF
--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxml2
 PKG_VERSION:=2.9.9
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://xmlsoft.org/sources/
@@ -136,8 +136,11 @@ HOST_CONFIGURE_ARGS += \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(2)/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/xml2-config $(2)/bin/
-	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' $(2)/bin/xml2-config
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/xml2-config \
+		$(2)/bin/$(GNU_TARGET_NAME)-xml2-config
+	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' \
+		$(2)/bin/$(GNU_TARGET_NAME)-xml2-config
+	$(LN) $(GNU_TARGET_NAME)-xml2-config $(2)/bin/xml2-config
 
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libxml2 $(1)/usr/include/
@@ -154,6 +157,12 @@ define Build/InstallDev
 
 	$(INSTALL_DIR) $(2)/share/aclocal/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/aclocal/* $(2)/share/aclocal
+endef
+
+define Host/Install
+	$(call Host/Install/Default)
+	mv $(1)/bin/xml2-config $(1)/bin/$(GNU_HOST_NAME)-xml2-config
+	$(LN) $(GNU_HOST_NAME)-xml2-config $(1)/bin/xml2-config
 endef
 
 define Package/libxml2/install


### PR DESCRIPTION
Currently only xml2-config is installed, for both the normal libxml2
package as well as the host package. The problem with that is that due
to multilib considerations the build host may have xml2-config installed
with a host triplet prefix, like x86_64-pc-linux-gnu-xml2-config (and
xml2-config as a symbolic link to it). Gentoo for instance sets it up
like this.

Packages may actually search for a prefixed xml2-config before searching
for xml2-config. An example would be Asterisk:

checking for x86_64-pc-linux-gnu-xml2-config... /usr/bin/x86_64-pc-linux-gnu-xml2-config

This then introduces wrong information into the build, for instance
bad includes:

~/tmp/openwrt $ /usr/bin/x86_64-pc-linux-gnu-xml2-config --cflags
-I/usr/include/libxml2

When the intention is to use OpenWrt's own (host) libxml2 one would like
to see this output used instead:

~/tmp/openwrt $ ./staging_dir/hostpkg/bin/xml2-config --cflags
-I/home/sk/tmp/openwrt/staging_dir/hostpkg/include/libxml2

This commit addresses this by installing xml2-config with a suitable
prefix and creating a symbolic link xml2-config. This is done for both
the host package and the normal package. The latter also needs this fix
because the target may use the same triplet as the host system (for
instance x86_64 cross-compiling for x86_64).

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @mhei 
Compile tested: ath79 master
Run tested: ath79 master, tested with Asterisk compile, both mips triplet and x86_86 triplet (menuconfig).

Description:
Hi all,

This has been a thorn in my eye for a while now. Let's fix this.

Kind regards,
Seb