### PR TITLE
django-cors-headers: add python3 package

### DIFF
--- a/lang/python/python3-django-cors-headers/Makefile
+++ b/lang/python/python3-django-cors-headers/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=django-cors-headers
+PKG_VERSION:=3.1.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=django-cors-headers
+PKG_HASH:=5762ec9c2d59f38c76828dc1d4308baca4bc0d3e1d6f217683e7a24a1c4611a3
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django-cors-headers
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS).
+  URL:=https://github.com/ottoyiu/django-cors-headers
+  DEPENDS:=python3-django +python3-urllib +python3-light
+  VARIANT:=python3
+  MDEPENDS:=python3-django
+endef
+
+define Package/python3-django-cors-headers/description
+  Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS).
+endef
+
+$(eval $(call Py3Package,python3-django-cors-headers))
+$(eval $(call BuildPackage,python3-django-cors-headers))
+$(eval $(call BuildPackage,python3-django-cors-headers-src))


### PR DESCRIPTION
Maintainer: Peter Stadler <peter.stadler@student.uibk.ac.at>
Compile tested: MIPS 74K, Asus RT-N16, master snapshot
Run tested: MIPS 74K, Asus RT-N16, master snapshot, used by etesync-server

Description: This is a dependency for the [etesync-server](https://github.com/openwrt/packages/pull/9865) (I will update the linked PR later) and needs the [sqlparse](https://github.com/openwrt/packages/pull/10375) PR.
