### PR TITLE
libmbim and libqmi: fix compiles on build bots

### DIFF
--- a/libs/libmbim/Makefile
+++ b/libs/libmbim/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmbim
 PKG_VERSION:=1.20.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libmbim
@@ -20,6 +20,8 @@ PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
+PKG_FIXUP:=autoreconf
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
@@ -27,7 +29,9 @@ CONFIGURE_ARGS += \
 	--disable-static \
 	--disable-gtk-doc \
 	--disable-gtk-doc-html \
-	--disable-gtk-doc-pdf
+	--disable-gtk-doc-pdf \
+	--disable-silent-rules \
+	--enable-more-warnings=yes
 
 define Package/libmbim
   SECTION:=libs

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
 PKG_VERSION:=1.24.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
@@ -19,6 +19,8 @@ PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -57,8 +59,10 @@ CONFIGURE_ARGS += \
 	--disable-gtk-doc \
 	--disable-gtk-doc-html \
 	--disable-gtk-doc-pdf \
-	--enable-mbim-qmux \
+	--disable-silent-rules \
 	--enable-firmware-update \
+	--enable-mbim-qmux \
+	--enable-more-warnings=yes \
 	--without-udev \
 	--without-udev-base-dir
 


### PR DESCRIPTION
Maintainer: @nickberry17 
Compile tested: ath79 master
Run tested: N/A, don't have modem, maybe maintainer or @feckert can runtest
Description:
This fixes compile issue observed on build bots, mentioned in #10217. Once this gets merged you can think about merging the change proposed in the mentioned PR.

Kind regards,
Seb
