### PR TITLE
arp-scan: update to 1.9.6

### DIFF
--- a/net/arp-scan/Makefile
+++ b/net/arp-scan/Makefile
@@ -25,13 +25,17 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/arp-scan
+define Package/arp-scan/default
+  SUBMENU:=arp-scan
   SECTION:=net
   CATEGORY:=Network
+  URL:=https://github.com/royhills/arp-scan
+endef
+
+define Package/arp-scan
+$(call Package/arp-scan/default)
   TITLE:=ARP scanner
   DEPENDS:=+libpcap
-  URL:=https://github.com/royhills/arp-scan
-  PKG_MAINTAINER:=Sergey Urushkin <urusha.v1.0@gmail.com>
 endef
 
 define Package/arp-scan/description
@@ -43,4 +47,36 @@ define Package/arp-scan/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/arp-scan $(1)/usr/bin/
 endef
 
+define Package/arp-scan/postinst
+cat <<EOF
+
+Please install the arp-scan-database package in order to let arp-scan
+display additional information about vendor/manufacturer for each
+discovered device.
+
+EOF
+endef
+
 $(eval $(call BuildPackage,arp-scan))
+
+define Package/arp-scan-database
+$(call Package/arp-scan/default)
+  TITLE:=MAC database for ARP scanner
+endef
+
+define Package/arp-scan-database/description
+    MAC database for ARP scanner
+endef
+
+define Package/arp-scan-database/install
+	$(INSTALL_DIR) $(1)/usr/share/arp-scan
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ieee-iab.txt $(1)/usr/share/arp-scan/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ieee-oui.txt $(1)/usr/share/arp-scan/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/mac-vendor.txt $(1)/usr/share/arp-scan/
+endef
+
+define Package/arp-scan-database/postrm
+	$(RM) -rf $(1)/usr/share/arp-scan
+endef
+
+$(eval $(call BuildPackage,arp-scan-database))

--- a/net/arp-scan/Makefile
+++ b/net/arp-scan/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=arp-scan
-PKG_VERSION:=1.9.5
+PKG_VERSION:=1.9.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/royhills/arp-scan/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=aa9498af84158a315b7e0ea6c2cddfa746660ca3987cbe7e32c0c90f5382d9d2
+PKG_HASH:=971b45c3369816467994797fbcd0076eb8f0ffb9c42764ea6dba25ab3fd490da
 
 PKG_MAINTAINER:=Sergey Urushkin <urusha.v1.0@gmail.com>
-PKG_LICENSE:=GPL-3.0
+PKG_LICENSE:=GPL-3.0-or-later
 
 PKG_FIXUP:=autoreconf
 


### PR DESCRIPTION
Signed-off-by: Andrei Belov <defanator@gmail.com>

Maintainer: @urusha 
Compile tested: ar71xx / Archer C7 / OpenWrt 18.06.4
Run tested: ar71xx / Archer C7 / OpenWrt 18.06.4

Previous versions do not work with libpcap 1.9.1, see these reports for details:
https://github.com/royhills/arp-scan/issues/42
https://github.com/royhills/arp-scan/issues/2