### PR TITLE
libgphoto2: libgphoto2_port.pc needed by dev

### DIFF
--- a/libs/libgphoto2/Makefile
+++ b/libs/libgphoto2/Makefile
@@ -476,7 +476,7 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgphoto2{,_port}.{a,so*} $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libgphoto2.pc $(1)/usr/lib/pkgconfig/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libgphoto2{,_port}.pc $(1)/usr/lib/pkgconfig/
 	$(SED) 's,-I$$$${prefix}/include/gphoto2,,g' $(1)/usr/bin/gphoto2{,-port}-config
 	$(SED) 's,-I$$$${prefix}/include,,g' $(1)/usr/bin/gphoto2{,-port}-config
 	# remove annoying recursive symlink


### PR DESCRIPTION
'pkg-config --exists libgphoto2' fails without libgphoto2_port.pc.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Maintainer: @DocLM 
Compile tested: master for mips_24k
Run tested: none, installdev only