### PR TITLE
collectd: wait for NTP time sync

### DIFF
--- a/utils/collectd/files/collectd.init
+++ b/utils/collectd/files/collectd.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2006-2016 OpenWrt.org
 
-START=80
+START=99
 STOP=10
 
 USE_PROCD=1
@@ -339,6 +339,7 @@ service_triggers()
 }
 
 start_service() {
+	[ ! -z "$(uci get system.ntp.server)" ] && while [ ! -f "/var/state/dnsmasqsec" ]; do sleep 1; done
 	process_config
 
 	procd_open_instance

--- a/utils/collectd/files/collectd.init
+++ b/utils/collectd/files/collectd.init
@@ -339,7 +339,7 @@ service_triggers()
 }
 
 start_service() {
-	[ ! -z "$(uci get system.ntp.server)" ] && while [ ! -f "/var/state/dnsmasqsec" ]; do sleep 1; done
+	[ ! -z "$(uci get dhcp.@dnsmasq[0])" ] && [ ! -z "$(uci get system.ntp.server)" ] && while [ ! -f "/var/state/dnsmasqsec" ]; do sleep 1; done
 	process_config
 
 	procd_open_instance


### PR DESCRIPTION
Signed-off-by: Michał Kuncewicz percy@poczta.fm

Maintainer: @feckert, me
Compile tested: x64, latest master branch
Run tested: ARMv7, R7800, OpenWrt master based on @hnyman build

Description:

This is my first proposed change. It depends on existence of /etc/hotplug.d/ntp/25-dnsmasqsec. Probably can be achieved also without such a dependency.
The goal is to get rid of long list of error messages thrown at bootup:
daemon.err collectd[4662]: rrdtool plugin: rrd_update_r failed: /mnt/sdb1/tmp/rrd/router/conntrack/conntrack-max.rrd: illegal attempt to update using time 1572040854 when last update time is 1572042817 (minimum one second step)
