### PR TITLE
pillow: bump to version 6.2.1

### DIFF
--- a/lang/python/pillow/Makefile
+++ b/lang/python/pillow/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pillow
-PKG_VERSION:=6.2.0
+PKG_VERSION:=6.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=Pillow-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/P/Pillow
-PKG_HASH:=4548236844327a718ce3bb182ab32a16fa2050c61e334e959f554cac052fb0df
+PKG_HASH:=bf4e972a88f8841d8fdc6db1a75e0f8d763e66e3754b03006cbc3854d89f1cb1
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-Pillow-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/b49f2113cc750c093d3b55f228f820d8bfe029a9
Run tested: x86 https://github.com/openwrt/openwrt/commit/b49f2113cc750c093d3b55f228f820d8bfe029a9

---------------------------------

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>