### PR TITLE
python-cffi: bump to version 1.13.1

### DIFF
--- a/lang/python/python-cffi/Makefile
+++ b/lang/python/python-cffi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cffi
-PKG_VERSION:=1.13.0
+PKG_VERSION:=1.13.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=cffi-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/cffi
-PKG_HASH:=8fe230f612c18af1df6f348d02d682fe2c28ca0a6c3856c99599cdacae7cf226
+PKG_HASH:=558b3afef987cf4b17abd849e7bedf64ee12b28175d564d05b628a0f9355599b
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cffi-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/b49f2113cc750c093d3b55f228f820d8bfe029a9
Run tested: x86 https://github.com/openwrt/openwrt/commit/b49f2113cc750c093d3b55f228f820d8bfe029a9

---------------------------------

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>