### PR TITLE
telldus-core: Doxygen in-file was not found.

### DIFF
--- a/utils/telldus-core/patches/900-openwrt_fixes_cmake.patch
+++ b/utils/telldus-core/patches/900-openwrt_fixes_cmake.patch
@@ -43,3 +43,14 @@ Adopted to OpenWrt target. Most likely these changes go elsewhere when done righ
  ENDIF (APPLE)
  
  
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -62,7 +62,7 @@ IF(DOXYGEN_FOUND)
+ 	SET(DOXY_CONFIG ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+ 
+ 	CONFIGURE_FILE(
+-		"${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in"
++		"${CMAKE_CURRENT_SOURCE_DIR}/CMakeDoxyfile.in"
+ 		${DOXY_CONFIG} @ONLY
+ 	)
+ 


### PR DESCRIPTION
@neheb @stintel 
Signed-off-by: Peter Liedholm <PeterFromSwe884@gmail.com>

Maintainer: me
Compile tested: x86/64, OpenWrt latest, d22c175)
Run tested: doxygen build only

Description: Filename of doxygen file was wrong.
