### PR TITLE
[openwrt-19.07] python-cffi: bump to version 1.13.1

### DIFF
--- a/lang/python/python-cffi/Makefile
+++ b/lang/python/python-cffi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cffi
-PKG_VERSION:=1.13.0
+PKG_VERSION:=1.13.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=cffi-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/cffi
-PKG_HASH:=8fe230f612c18af1df6f348d02d682fe2c28ca0a6c3856c99599cdacae7cf226
+PKG_HASH:=558b3afef987cf4b17abd849e7bedf64ee12b28175d564d05b628a0f9355599b
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cffi-$(PKG_VERSION)
 


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: none (cherry-picked from #10387)
Run tested: none

Description:
Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>
(cherry picked from dff2fe2963e029419046031e65d0dab6f2952012)