### PR TITLE
check: Update to 0.13.0

### DIFF
--- a/libs/check/Makefile
+++ b/libs/check/Makefile
@@ -8,20 +8,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=check
-PKG_VERSION:=0.12.0
-PKG_RELEASE:=2
+PKG_VERSION:=0.13.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/libcheck/check/releases/download/$(PKG_VERSION)
-PKG_HASH:=464201098bee00e90f5c4bdfa94a5d3ead8d641f9025b560a27755a83b824234
+PKG_HASH:=c4336b31447acc7e3266854f73ec188cdb15554d0edd44739631da174a569909
 
+PKG_MAINTAINER:=Eduardo Abinader <eduardoabinader@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING.LESSER
-PKG_MAINTAINER:=Eduardo Abinader <eduardoabinader@gmail.com>
 
-PKG_INSTALL:=1
+CMAKE_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/check
   SECTION:=libs
@@ -39,19 +41,9 @@ define Package/check/description
   code editors and IDEs.
 endef
 
-TARGET_CFLAGS += $(FPIC)
-CONFIGURE_VARS += \
-	hw_cv_func_snprintf_c99=yes \
-	hw_cv_func_vsnprintf_c99=yes \
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/check*.h $(1)/usr/include/
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcheck.{a,so*} $(1)/usr/lib/
-	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/check.pc $(1)/usr/lib/pkgconfig/
-endef
+CMAKE_OPTIONS += \
+	-DBUILD_TESTING=OFF \
+	-DCMAKE_POSITION_INDEPENDENT_CODE=ON
 
 define Package/check/install
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
Switch to CMake. Allows to simplify the Makefile.

Replaced InstallDev section with CMAKE_INSTALL.

Added PKG_BUILD_PARALLEL for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @eduardoabinader 
Compile tested: arc700