### PR TITLE
treewide: Use pypi.mk for Python packages

### DIFF
--- a/devel/asu/Makefile
+++ b/devel/asu/Makefile
@@ -10,15 +10,12 @@ PKG_RELEASE=2
 
 PKG_LICENSE:=GPL-3.0
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/a/asu/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=e60027cd531cc5b9b20d3321acc06fdf0cdd894004919800575b8235343ba8ef
 
 PKG_BUILD_DEPENDS:=python3
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
+include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
 

--- a/lang/python/Flask/Makefile
+++ b/lang/python/Flask/Makefile
@@ -8,8 +8,7 @@ PKG_NAME:=Flask
 PKG_VERSION:=1.1.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/F/Flask
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
@@ -17,6 +16,7 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 PKG_CPE_ID:=cpe:/a:palletsprojects:flask
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/Jinja2/Makefile
+++ b/lang/python/Jinja2/Makefile
@@ -8,8 +8,7 @@ PKG_NAME:=Jinja2
 PKG_VERSION:=2.10.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/J/Jinja2
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
@@ -17,6 +16,7 @@ PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:pocoo:jinja2
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/MarkupSafe/Makefile
+++ b/lang/python/MarkupSafe/Makefile
@@ -8,16 +8,14 @@ PKG_NAME:=MarkupSafe
 PKG_VERSION:=1.1.1
 PKG_RELEASE:=2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/M/MarkupSafe
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/Werkzeug/Makefile
+++ b/lang/python/Werkzeug/Makefile
@@ -8,14 +8,14 @@ PKG_NAME:=Werkzeug
 PKG_VERSION:=0.16.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/W/Werkzeug
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/bcrypt/Makefile
+++ b/lang/python/bcrypt/Makefile
@@ -9,10 +9,8 @@ PKG_NAME:=bcrypt
 PKG_VERSION:=3.1.7
 PKG_RELEASE:=1
 
-PKG_SOURCE:=bcrypt-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:= https://files.pythonhosted.org/packages/source/b/$(PKG_NAME)
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=0b0069c752ec14172c5f78208f1863d7ad6755a6fae6fe76ec2c80d13be41e42
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-bcrypt-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Dickinson <cshored@thecshore.com>
 PKG_LICENSE:=Apache-2.0
@@ -22,11 +20,10 @@ PKG_BUILD_DEPENDS:=libffi/host
 HOST_PYTHON_PACKAGE_BUILD_DEPENDS:="cffi>=1.1"
 HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:="cffi>=1.1"
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/bcrypt/Default
   SECTION:=lang

--- a/lang/python/click/Makefile
+++ b/lang/python/click/Makefile
@@ -8,16 +8,15 @@ PKG_NAME:=click
 PKG_VERSION:=7.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=Click-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/click
+PYPI_NAME:=$(PKG_NAME)
+PYPI_SOURCE_NAME:=Click
 PKG_HASH:=5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/Click-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/django-appconf/Makefile
+++ b/lang/python/django-appconf/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=django-appconf
 PKG_VERSION:=1.0.2
 PKG_RELEASE:=5
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/$(PKG_NAME)/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=6a4d9aea683b4c224d97ab8ee11ad2d29a37072c0c6c509896dd9857466fb261
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/$(PKG_NAME)/Default
   SUBMENU:=Python

--- a/lang/python/django-compressor/Makefile
+++ b/lang/python/django-compressor/Makefile
@@ -11,21 +11,18 @@ PKG_NAME:=django-compressor
 PKG_VERSION:=2.2
 PKG_RELEASE:=6
 
-PKG_SOURCE:=django_compressor-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/$(PKG_NAME)/
+PYPI_NAME:=$(PKG_NAME)
+PYPI_SOURCE_NAME:=django_compressor
 PKG_HASH:=9616570e5b08e92fa9eadc7a1b1b49639cce07ef392fc27c74230ab08075b30f
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/$(PKG_NAME)/Default
   SUBMENU:=Python

--- a/lang/python/django-constance/Makefile
+++ b/lang/python/django-constance/Makefile
@@ -11,20 +11,16 @@ PKG_NAME:=django-constance
 PKG_VERSION:=2.3.1
 PKG_RELEASE:=4
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/django-constance
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=a49735063b2c30015d2e52a90609ea9798da722ed070f091de51714758a5d018
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-django-constance-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-django-constance/Default
   SUBMENU:=Python

--- a/lang/python/django-formtools/Makefile
+++ b/lang/python/django-formtools/Makefile
@@ -9,21 +9,17 @@ PKG_NAME:=django-formtools
 PKG_VERSION:=2.1
 PKG_RELEASE:=6
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/$(PKG_NAME)/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=7703793f1675aa6e871f9fed147e8563816d7a5b9affdc5e3459899596217f7c
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/$(PKG_NAME)/Default
   SUBMENU:=Python

--- a/lang/python/django-jsonfield/Makefile
+++ b/lang/python/django-jsonfield/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=django-jsonfield
 PKG_VERSION:=1.0.1
 PKG_RELEASE:=5
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/$(PKG_NAME)/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=6c0afd5554739365b55d86e285cf966cc3a45682fff963463364ea1f6511ca3e
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/$(PKG_NAME)/Default
   SUBMENU:=Python

--- a/lang/python/django-picklefield/Makefile
+++ b/lang/python/django-picklefield/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=django-picklefield
 PKG_VERSION:=1.1.0
 PKG_RELEASE:=4
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/$(PKG_NAME)/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=ce7fee5c6558fe5dc8924993d994ccde75bb75b91cd82787cbd4c92b95a69f9c
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/$(PKG_NAME)/Default
   SUBMENU:=Python

--- a/lang/python/django-postoffice/Makefile
+++ b/lang/python/django-postoffice/Makefile
@@ -11,21 +11,18 @@ PKG_NAME:=django-postoffice
 PKG_VERSION:=3.1.0
 PKG_RELEASE:=5
 
-PKG_SOURCE:=django-post_office-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/django-post_office
+PYPI_NAME:=django-post-office
+PYPI_SOURCE_NAME:=django-post_office
 PKG_HASH:=827937a944fe47cea393853069cd9315d080298c8ddb0faf787955d6aa51a030
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/$(PKG_NAME)/Default
   SUBMENU:=Python

--- a/lang/python/django-ranged-response/Makefile
+++ b/lang/python/django-ranged-response/Makefile
@@ -9,21 +9,17 @@ PKG_NAME:=django-ranged-response
 PKG_VERSION:=0.2.0
 PKG_RELEASE:=6
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/$(PKG_NAME)/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=f71fff352a37316b9bead717fc76e4ddd6c9b99c4680cdf4783b9755af1cf985
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/$(PKG_NAME)/Default
   SUBMENU:=Python

--- a/lang/python/django-restframework/Makefile
+++ b/lang/python/django-restframework/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=django-restframework
 PKG_VERSION:=3.9.0
 PKG_RELEASE:=5
 
-PKG_SOURCE:=djangorestframework-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/djangorestframework
+PYPI_NAME:=djangorestframework
 PKG_HASH:=607865b0bb1598b153793892101d881466bd5a991de12bd6229abb18b1c86136
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.md
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/$(PKG_NAME)/Default
   SUBMENU:=Python

--- a/lang/python/django-statici18n/Makefile
+++ b/lang/python/django-statici18n/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=django-statici18n
 PKG_VERSION:=1.8.2
 PKG_RELEASE:=5
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/django-statici18n
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=ba9eeb3c4517027922645999359f8335fbb9fea04c457123cfbd6b4a36cbeda4
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/$(PKG_NAME)/Default
   SUBMENU:=Python

--- a/lang/python/django-webpack-loader/Makefile
+++ b/lang/python/django-webpack-loader/Makefile
@@ -9,21 +9,17 @@ PKG_NAME:=django-webpack-loader
 PKG_VERSION:=0.6.0
 PKG_RELEASE:=6
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/${PKG_NAME}
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=60bab6b9a037a5346fad12d2a70a6bc046afb33154cf75ed640b93d3ebd5f520
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/$(PKG_NAME)/Default
   SUBMENU:=Python

--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -11,20 +11,17 @@ PKG_NAME:=django
 PKG_VERSION:=2.2.6
 PKG_RELEASE:=1
 
-PKG_SOURCE:=Django-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/D/Django
+PYPI_NAME:=Django
 PKG_HASH:=a8ca1033acac9f33995eb2209a6bf18a4681c3e5269a878e9a7e0b7384ed1ca3
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-django-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE LICENSE.python
 PKG_CPE_ID:=cpe:/a:djangoproject:django
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/django/Default
   SUBMENU:=Python

--- a/lang/python/django1/Makefile
+++ b/lang/python/django1/Makefile
@@ -11,20 +11,17 @@ PKG_NAME:=django1
 PKG_VERSION:=1.11.25
 PKG_RELEASE:=1
 
-PKG_SOURCE:=Django-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/D/Django
+PYPI_NAME:=Django
 PKG_HASH:=5314e8586285d532b7aa5c6d763b0248d9a977a37efec86d30f0212b82e8ef66
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-django-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE LICENSE.python
 PKG_CPE_ID:=cpe:/a:djangoproject:django
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/django1/Default
   SUBMENU:=Python

--- a/lang/python/flup/Makefile
+++ b/lang/python/flup/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=flup
 PKG_VERSION:=1.0.3
 PKG_RELEASE:=3
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/f/flup
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=5eb09f26eb0751f8380d8ac43d1dfb20e1d42eca0fa45ea9289fa532a79cd159
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-flup-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=PKG-INFO
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/flup/Default
   SECTION:=lang

--- a/lang/python/gunicorn/Makefile
+++ b/lang/python/gunicorn/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=gunicorn
 PKG_VERSION:=19.9.0
 PKG_RELEASE=2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/g/gunicorn
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=fa2662097c66f920f53f70621c6c58ca4a3c4d3434205e608e121b5b3b71f4f3
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/gunicorn/Default
   SUBMENU:=Python

--- a/lang/python/itsdangerous/Makefile
+++ b/lang/python/itsdangerous/Makefile
@@ -8,14 +8,14 @@ PKG_NAME:=itsdangerous
 PKG_VERSION:=1.1.0
 PKG_RELEASE:=2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/i/itsdangerous
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/openpyxl/Makefile
+++ b/lang/python/openpyxl/Makefile
@@ -15,17 +15,13 @@ PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENCE.rst
 
-PKG_SOURCE:=openpyxl-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/o/openpyxl
+PYPI_NAME:=openpyxl
 PKG_HASH:=1d2af392cef8c8227bd2ac3ebe3a28b25aba74fd4fa473ce106065f0b73bfe2e
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-openpyxl-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-openpyxl/Default
   SUBMENU:=Python

--- a/lang/python/passlib/Makefile
+++ b/lang/python/passlib/Makefile
@@ -8,17 +8,14 @@ PKG_VERSION:=1.7.1
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD-3-Clause
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/passlib
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=3d948f64138c25633613f303bcc471126eae67c04d5e3f6b7b8ce6242f8653e0
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-passlib-$(PKG_VERSION)
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/passlib/Default
   SUBMENU:=Python

--- a/lang/python/pillow/Makefile
+++ b/lang/python/pillow/Makefile
@@ -10,21 +10,18 @@ PKG_NAME:=pillow
 PKG_VERSION:=6.2.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=Pillow-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/P/Pillow
+PYPI_NAME:=Pillow
 PKG_HASH:=bf4e972a88f8841d8fdc6db1a75e0f8d763e66e3754b03006cbc3854d89f1cb1
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-Pillow-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=HPND
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:python:pillow
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-pillow/Default
   SUBMENU:=Python

--- a/lang/python/pyjwt/Makefile
+++ b/lang/python/pyjwt/Makefile
@@ -13,17 +13,13 @@ PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_SOURCE:=PyJWT-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/P/PyJWT
+PYPI_NAME:=PyJWT
 PKG_HASH:=8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-PyJWT-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-pyjwt/Default
   SUBMENU:=Python

--- a/lang/python/pyodbc/Makefile
+++ b/lang/python/pyodbc/Makefile
@@ -8,19 +8,16 @@ PKG_NAME:=pyodbc
 PKG_VERSION:=4.0.26
 PKG_RELEASE:=2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyodbc
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=e52700b5d24a846483b5ab80acd9153f8e593999c9184ffea11596288fb33de3
 PKG_BUILD_DEPENDS:=python python3 unixodbc
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
 PKG_BUILD_DEPENDS:=unixodbc/host
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk

--- a/lang/python/python-aiohttp-cors/Makefile
+++ b/lang/python/python-aiohttp-cors/Makefile
@@ -11,14 +11,15 @@ PKG_NAME:=aiohttp-cors
 PKG_VERSION:=0.7.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=aiohttp-cors-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/a/aiohttp_cors/
+PYPI_NAME:=aiohttp_cors
+PYPI_SOURCE_NAME:=aiohttp-cors
 PKG_HASH:=4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-aiohttp/Makefile
+++ b/lang/python/python-aiohttp/Makefile
@@ -11,8 +11,7 @@ PKG_NAME:=aiohttp
 PKG_VERSION:=3.5.4
 PKG_RELEASE:=1
 
-PKG_SOURCE:=aiohttp-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/a/aiohttp/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=9c4c83f4fa1938377da32bc2d59379025ceeee8e24b89f72fcbccd8ca22dc9bf
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
@@ -20,6 +19,7 @@ PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:aio-libs_project:aiohttp
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-appdirs/Makefile
+++ b/lang/python/python-appdirs/Makefile
@@ -9,12 +9,11 @@ PKG_VERSION:=1.4.3
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/a/appdirs/
-PKG_SOURCE:=appdirs-$(PKG_VERSION).tar.gz
+PYPI_NAME:=appdirs
 PKG_HASH:=9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92
 PKG_LICENSE:=MIT
-PKG_BUILD_DIR:=$(BUILD_DIR)/appdirs-$(PKG_VERSION)
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-astral/Makefile
+++ b/lang/python/python-astral/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-astral
 PKG_VERSION:=1.10.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=astral-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/a/astral/
+PYPI_NAME:=astral
 PKG_HASH:=d2a67243c4503131c856cafb1b1276de52a86e5b8a1d507b7e08bee51cb67bf1
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-astral-$(PKG_VERSION)
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-astral/Default
   SECTION:=lang

--- a/lang/python/python-async-timeout/Makefile
+++ b/lang/python/python-async-timeout/Makefile
@@ -11,14 +11,15 @@ PKG_NAME:=async-timeout
 PKG_VERSION:=3.0.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=async-timeout-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/a/async-timeout/
+PYPI_NAME:=async_timeout
+PYPI_SOURCE_NAME:=async-timeout
 PKG_HASH:=0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-attrs/Makefile
+++ b/lang/python/python-attrs/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-attrs
 PKG_VERSION:=19.3.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=attrs-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/a/attrs
+PYPI_NAME:=attrs
 PKG_HASH:=f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-attrs-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-attrs/Default
   SECTION:=lang

--- a/lang/python/python-automat/Makefile
+++ b/lang/python/python-automat/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-automat
 PKG_VERSION:=0.8.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=Automat-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/A/Automat
+PYPI_NAME:=Automat
 PKG_HASH:=269a09dfb063a3b078983f4976d83f0a0d3e6e7aaf8e27d8df1095e09dc4a484
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-automat-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 PYTHON_PKG_SETUP_VARS:= \
   PKG_VERSION="$(PKG_VERSION)"

--- a/lang/python/python-awscli/Makefile
+++ b/lang/python/python-awscli/Makefile
@@ -4,19 +4,16 @@ PKG_NAME:=awscli
 PKG_VERSION:=1.16.75
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/a/awscli
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=8d96ec0de325ea8271cc6aa95b7392bbf548ec4aabd3ffbcdc0619b64edd4a45
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-awscli-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
 PKG_LICENSE:=MIT
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-awscli/Default
   SUBMENU:=Python

--- a/lang/python/python-boto3/Makefile
+++ b/lang/python/python-boto3/Makefile
@@ -4,15 +4,14 @@ PKG_NAME:=boto3
 PKG_VERSION:=1.9.135
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/b/boto3
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=5e5805992e873e5687b5ef3b4c56c386ccb4df1c3364f8b8601d289e2f275be1
-PKG_BUILD_DIR:=$(BUILD_DIR)/boto3-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-botocore/Makefile
+++ b/lang/python/python-botocore/Makefile
@@ -4,19 +4,16 @@ PKG_NAME:=botocore
 PKG_VERSION:=1.12.66
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/b/botocore
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=25c39ecc71356287cf79d66981ec77deca374e28043b19b2f818d48aa34272a1
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-botocore-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
 PKG_LICENSE:=MIT
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-botocore/Default
   SUBMENU:=Python

--- a/lang/python/python-cachelib/Makefile
+++ b/lang/python/python-cachelib/Makefile
@@ -8,15 +8,14 @@ PKG_NAME:=python-cachelib
 PKG_VERSION:=0.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=cachelib-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/cachelib
+PYPI_NAME:=cachelib
 PKG_HASH:=8b889b509d372095357b8705966e1282d40835c4126d7c2b07fd414514d8ae8d
-PKG_BUILD_DIR:=$(BUILD_DIR)/cachelib-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Stepan Henek <stepan.henek@nic.cz>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-cachetools/Makefile
+++ b/lang/python/python-cachetools/Makefile
@@ -11,15 +11,14 @@ PKG_NAME:=python-cachetools
 PKG_VERSION:=3.1.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=cachetools-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/cachetools/
+PYPI_NAME:=cachetools
 PKG_HASH:=8ea2d3ce97850f31e4a08b0e2b5e6c34997d7216a9d2c98e0f3978630d4da69a
-PKG_BUILD_DIR:=$(BUILD_DIR)/cachetools-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -13,17 +13,13 @@ PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_SOURCE:=certifi-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/certifi
+PYPI_NAME:=certifi
 PKG_HASH:=e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-certifi-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-certifi/Default
   SUBMENU:=Python

--- a/lang/python/python-cffi/Makefile
+++ b/lang/python/python-cffi/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-cffi
 PKG_VERSION:=1.13.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=cffi-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/cffi
+PYPI_NAME:=cffi
 PKG_HASH:=558b3afef987cf4b17abd849e7bedf64ee12b28175d564d05b628a0f9355599b
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cffi-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-cffi/Default
   SECTION:=lang

--- a/lang/python/python-chardet/Makefile
+++ b/lang/python/python-chardet/Makefile
@@ -12,16 +12,13 @@ PKG_VERSION:=3.0.4
 PKG_RELEASE:=2
 PKG_LICENSE:=LGPL-2.1
 
-PKG_SOURCE:=chardet-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/
+PYPI_NAME:=chardet
 PKG_HASH:=84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-chardet-$(PKG_VERSION)
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-chardet/Default
   SUBMENU:=Python

--- a/lang/python/python-colorama/Makefile
+++ b/lang/python/python-colorama/Makefile
@@ -4,19 +4,16 @@ PKG_NAME:=colorama
 PKG_VERSION:=0.4.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/colorama
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-colorama-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
 PKG_LICENSE:=MIT
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-colorama/Default
   SUBMENU:=Python

--- a/lang/python/python-constantly/Makefile
+++ b/lang/python/python-constantly/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-constantly
 PKG_VERSION:=15.1.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=constantly-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/constantly
+PYPI_NAME:=constantly
 PKG_HASH:=586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-constantly-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-constantly/Default
   SECTION:=lang

--- a/lang/python/python-contextlib2/Makefile
+++ b/lang/python/python-contextlib2/Makefile
@@ -9,11 +9,10 @@ PKG_VERSION:=0.5.5
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/c/contextlib2/
-PKG_SOURCE:=contextlib2-$(PKG_VERSION).tar.gz
+PYPI_NAME:=contextlib2
 PKG_HASH:=509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48
-PKG_BUILD_DIR:=$(BUILD_DIR)/contextlib2-$(PKG_VERSION)
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-crcmod/Makefile
+++ b/lang/python/python-crcmod/Makefile
@@ -13,13 +13,12 @@ PKG_RELEASE:=1
 PKG_MAINTAINER:=Micke Prag <micke.prag@telldus.se>
 PKG_LICENSE:=MIT
 
-PKG_SOURCE:=crcmod-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://pypi.python.org/packages/source/c/crcmod/
+PYPI_NAME:=crcmod
 PKG_HASH:=dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/crcmod-$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=python
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 

--- a/lang/python/python-crypto/Makefile
+++ b/lang/python/python-crypto/Makefile
@@ -11,22 +11,18 @@ PKG_NAME:=python-crypto
 PKG_VERSION:=2.6.1
 PKG_RELEASE:=4
 
-PKG_SOURCE:=pycrypto-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pycrypto
+PYPI_NAME:=pycrypto
 PKG_HASH:=f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-crypto-$(PKG_VERSION)
 
 PKG_LICENSE:=Public Domain
 PKG_LICENSE_FILES:=COPYRIGHT
 PKG_CPE_ID:=cpe:/a:dlitz:pycrypto
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 PYTHON_PKG_SETUP_ARGS:=
 PYTHON_PKG_SETUP_VARS:= \

--- a/lang/python/python-cryptodome/Makefile
+++ b/lang/python/python-cryptodome/Makefile
@@ -8,22 +8,18 @@ PKG_NAME:=python-cryptodome
 PKG_VERSION:=3.9.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=pycryptodome-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pycryptodome
+PYPI_NAME:=pycryptodome
 PKG_HASH:=dbeb08ad850056747aa7d5f33273b7ce0b9a77910604a1be7b7a6f2ef076213f
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cryptodome-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 PKG_CPE_ID:=cpe:/a:pycryptodome:pycryptodome
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 PYTHON_PKG_SETUP_ARGS:=
 PYTHON_PKG_SETUP_VARS:= \

--- a/lang/python/python-cryptodomex/Makefile
+++ b/lang/python/python-cryptodomex/Makefile
@@ -8,21 +8,17 @@ PKG_NAME:=python-cryptodomex
 PKG_VERSION:=3.9.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=pycryptodomex-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pycryptodomex
+PYPI_NAME:=pycryptodomex
 PKG_HASH:=8b604f4fa1de456d6d19771b01c2823675a75a2c60e51a6b738f71fdfe865370
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cryptodomex-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 PYTHON_PKG_SETUP_ARGS:=
 PYTHON_PKG_SETUP_VARS:= \

--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -11,25 +11,22 @@ PKG_NAME:=python-cryptography
 PKG_VERSION:=2.8
 PKG_RELEASE:=1
 
-PKG_SOURCE:=cryptography-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/cryptography
+PYPI_NAME:=cryptography
 PKG_HASH:=3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651
 
 PKG_LICENSE:=Apache-2.0 BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.APACHE LICENSE.BSD
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-cryptography-$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=libffi/host
 
 HOST_PYTHON_PACKAGE_BUILD_DEPENDS:="cffi>=1.8,!=1.11.3"
 HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:="cffi>=1.8,!=1.11.3"
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-cryptography/Default
   SECTION:=lang

--- a/lang/python/python-curl/Makefile
+++ b/lang/python/python-curl/Makefile
@@ -8,21 +8,17 @@ PKG_NAME:=pycurl
 PKG_VERSION:=7.43.0.3
 PKG_RELEASE:=1
 
-PKG_SOURCE:=pycurl-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pycurl
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=6f08330c5cf79fa8ef68b9912b9901db7ffd34b63e225dce74db56bb21deda8e
 
 PKG_MAINTAINER:=Waldemar Konik <informatyk74@interia.pl>
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING-LGPL
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-curl-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-curl/Default
   CATEGORY:=Languages

--- a/lang/python/python-dateutil/Makefile
+++ b/lang/python/python-dateutil/Makefile
@@ -12,18 +12,15 @@ PKG_VERSION:=2.8.0
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD-2-Clause
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/python-dateutil
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-dateutil-$(PKG_VERSION)
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-dateutil/Default
   SUBMENU:=Python

--- a/lang/python/python-defusedxml/Makefile
+++ b/lang/python/python-defusedxml/Makefile
@@ -13,17 +13,13 @@ PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=Python-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_SOURCE:=defusedxml-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/defusedxml
+PYPI_NAME:=defusedxml
 PKG_HASH:=f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-defusedxml-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-defusedxml/Default
   SUBMENU:=Python

--- a/lang/python/python-docutils/Makefile
+++ b/lang/python/python-docutils/Makefile
@@ -4,19 +4,16 @@ PKG_NAME:=docutils
 PKG_VERSION:=0.14
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/docutils
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-docutils-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
 PKG_LICENSE:=MIT
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-docutils/Default
   SUBMENU:=Python

--- a/lang/python/python-dpkt/Makefile
+++ b/lang/python/python-dpkt/Makefile
@@ -11,15 +11,14 @@ PKG_NAME:=python-dpkt
 PKG_VERSION:=1.9.2
 PKG_RELEASE:=1
 
-PKG_SOURCE:=dpkt-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/d/dpkt
+PYPI_NAME:=dpkt
 PKG_HASH:=52a92ecd5ca04d5bd852bb11cb2eac4bbe38b42a7c472e0d950eeb9f82a81e54
-PKG_BUILD_DIR:=$(BUILD_DIR)/dpkt-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Andrew McConachie <andrew@depht.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 

--- a/lang/python/python-enum34/Makefile
+++ b/lang/python/python-enum34/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-enum34
 PKG_VERSION:=1.1.6
 PKG_RELEASE:=4
 
-PKG_SOURCE:=enum34-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/e/enum34
+PYPI_NAME:=enum34
 PKG_HASH:=8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-enum34-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=enum/LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_CPE_ID:=cpe:/a:python:enum34
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-enum34/Default
   SECTION:=lang

--- a/lang/python/python-et_xmlfile/Makefile
+++ b/lang/python/python-et_xmlfile/Makefile
@@ -12,17 +12,13 @@ PKG_RELEASE:=1
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=MIT
 
-PKG_SOURCE:=et_xmlfile-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/e/et_xmlfile
+PYPI_NAME:=et_xmlfile
 PKG_HASH:=614d9722d572f6246302c4491846d2c393c199cfa4edc9af593437691683335b
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-et_xmlfile-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-et_xmlfile/Default
   SUBMENU:=Python

--- a/lang/python/python-evdev/Makefile
+++ b/lang/python/python-evdev/Makefile
@@ -15,17 +15,13 @@ PKG_RELEASE:=1
 PKG_LICENSE:=BSD-3-Clause
 PKG_MAINTAINER:=Paulo Costa <me@paulo.costa.nom.br>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
-PKG_SOURCE:=evdev-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/e/evdev
+PYPI_NAME:=evdev
 PKG_HASH:=b03f5e1be5b4a5327494a981b831d251a142b09e8778eda1a8b53eba91100166
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-evdev-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-evdev/Default
   SUBMENU:=Python

--- a/lang/python/python-futures/Makefile
+++ b/lang/python/python-futures/Makefile
@@ -4,18 +4,15 @@ PKG_NAME:=futures
 PKG_VERSION:=3.2.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/f/futures
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-futures-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
 PKG_LICENSE:=MIT
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-futures
   SUBMENU:=Python

--- a/lang/python/python-gmpy2/Makefile
+++ b/lang/python/python-gmpy2/Makefile
@@ -11,21 +11,18 @@ PKG_NAME:=python-gmpy2
 PKG_VERSION:=2.0.8
 PKG_RELEASE:=4
 
-PKG_SOURCE:=gmpy2-$(PKG_VERSION).zip
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/g/gmpy2
+PYPI_NAME:=gmpy2
+PYPI_SOURCE_EXT:=zip
 PKG_HASH:=dd233e3288b90f21b0bb384bcc7a7e73557bb112ccf0032ad52aa614eb373d3f
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-gmpy2-$(PKG_VERSION)
 
 PKG_LICENSE:=LGPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING.LESSER
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=unzip -q -d $(PKG_BUILD_DIR) $(DL_DIR)/$(PKG_SOURCE); mv -f $(PKG_BUILD_DIR)/gmpy2-$(PKG_VERSION)/* $(PKG_BUILD_DIR)
 
 PYTHON_PKG_SETUP_ARGS:=--nompfr
 PYTHON3_PKG_SETUP_ARGS:=--nompfr

--- a/lang/python/python-gnupg/Makefile
+++ b/lang/python/python-gnupg/Makefile
@@ -8,8 +8,7 @@ PKG_NAME:=python-gnupg
 PKG_VERSION:=0.4.4
 PKG_RELEASE:=2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/python-gnupg
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=45daf020b370bda13a1429c859fcdff0b766c0576844211446f9266cae97fb0e
 
 PKG_LICENSE:=GPL-3.0-or-later
@@ -17,9 +16,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_CPE_ID:=cpe:/a:python-gnupg_project:python-gnupg
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk

--- a/lang/python/python-hyperlink/Makefile
+++ b/lang/python/python-hyperlink/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-hyperlink
 PKG_VERSION:=19.0.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=hyperlink-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/h/hyperlink
+PYPI_NAME:=hyperlink
 PKG_HASH:=4288e34705da077fada1111a24a0aa08bb1e76699c9ce49876af722441845654
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-hyperlink-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-hyperlink/Default
   SECTION:=lang

--- a/lang/python/python-idna/Makefile
+++ b/lang/python/python-idna/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-idna
 PKG_VERSION:=2.8
 PKG_RELEASE:=2
 
-PKG_SOURCE:=idna-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/i/idna
+PYPI_NAME:=idna
 PKG_HASH:=c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-idna-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.rst
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-idna/Default
   SECTION:=lang

--- a/lang/python/python-ifaddr/Makefile
+++ b/lang/python/python-ifaddr/Makefile
@@ -11,16 +11,14 @@ PKG_NAME:=python-ifaddr
 PKG_VERSION:=0.1.6
 PKG_RELEASE:=1
 
-PKG_SOURCE:=ifaddr-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/i/ifaddr/
+PYPI_NAME:=ifaddr
 PKG_HASH:=c19c64882a7ad51a394451dabcbbed72e98b5625ec1e79789924d5ea3e3ecb93
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/ifaddr-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-incremental/Makefile
+++ b/lang/python/python-incremental/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-incremental
 PKG_VERSION:=17.5.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=incremental-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/i/incremental
+PYPI_NAME:=incremental
 PKG_HASH:=7b751696aaf36eebfab537e458929e194460051ccad279c72b755a167eebd4b3
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-incremental-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-incremental/Default
   SECTION:=lang

--- a/lang/python/python-influxdb/Makefile
+++ b/lang/python/python-influxdb/Makefile
@@ -9,12 +9,11 @@ PKG_VERSION:=5.2.2
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/i/influxdb/
-PKG_SOURCE:=influxdb-$(PKG_VERSION).tar.gz
+PYPI_NAME:=influxdb
 PKG_HASH:=afeff28953a91b4ea1aebf9b5b8258a4488d0e49e2471db15ea43fd2c8533143
 PKG_LICENSE:=MIT
-PKG_BUILD_DIR:=$(BUILD_DIR)/influxdb-$(PKG_VERSION)
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-intelhex/Makefile
+++ b/lang/python/python-intelhex/Makefile
@@ -8,15 +8,15 @@ PKG_NAME:=python-intelhex
 PKG_VERSION:=2.2.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=intelhex-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/i/intelhex/
+PYPI_NAME:=IntelHex
+PYPI_SOURCE_NAME:=intelhex
 PKG_HASH:=009d8511e0d50639230c39af9607deee771cf026f67ef7507a8c3fd4fa927832
-PKG_BUILD_DIR:=$(BUILD_DIR)/intelhex-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.txt
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-ipaddress/Makefile
+++ b/lang/python/python-ipaddress/Makefile
@@ -11,19 +11,15 @@ PKG_NAME:=python-ipaddress
 PKG_VERSION:=1.0.23
 PKG_RELEASE:=1
 
-PKG_SOURCE:=ipaddress-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/i/ipaddress
+PYPI_NAME:=ipaddress
 PKG_HASH:=b7f8e0369580bb4a24d5ba1d7cc29660a4a6987763faf1d8a8046830e020e7e2
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-ipaddress-$(PKG_VERSION)
 
 PKG_LICENSE:=Python-2.0
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-ipaddress/Default
   SECTION:=lang

--- a/lang/python/python-jdcal/Makefile
+++ b/lang/python/python-jdcal/Makefile
@@ -13,17 +13,13 @@ PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Eneas U de Queiroz 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE.txt
 
-PKG_SOURCE:=jdcal-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/j/jdcal
+PYPI_NAME:=jdcal
 PKG_HASH:=472872e096eb8df219c23f2689fc336668bdb43d194094b5cc1707e1640acfc8
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-jdcal-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-jdcal/Default
   SUBMENU:=Python

--- a/lang/python/python-jmespath/Makefile
+++ b/lang/python/python-jmespath/Makefile
@@ -4,19 +4,16 @@ PKG_NAME:=jmespath
 PKG_VERSION:=0.9.3
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/j/jmespath
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-jmespath-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
 PKG_LICENSE:=MIT
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-jmespath/Default
   SUBMENU:=Python

--- a/lang/python/python-jsonpath-ng/Makefile
+++ b/lang/python/python-jsonpath-ng/Makefile
@@ -9,11 +9,10 @@ PKG_VERSION:=1.4.3
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/j/jsonpath-ng/
-PKG_SOURCE:=jsonpath-ng-$(PKG_VERSION).tar.gz
+PYPI_NAME:=jsonpath-ng
 PKG_HASH:=b1fc75b877e9b2f46845a455fbdcfb0f0d9c727c45c19a745d02db620a9ef0be
-PKG_BUILD_DIR:=$(BUILD_DIR)/jsonpath-ng-$(PKG_VERSION)
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-ldap/Makefile
+++ b/lang/python/python-ldap/Makefile
@@ -14,10 +14,10 @@ PKG_MAINTAINER:=Dmitry Trefilov <the-alien@live.ru>
 PKG_LICENSE:=Python-style
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/python-ldap
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=41975e79406502c092732c57ef0c2c2eb318d91e8e765f81f5d4ab6c1db727c5
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 

--- a/lang/python/python-lxml/Makefile
+++ b/lang/python/python-lxml/Makefile
@@ -11,18 +11,15 @@ PKG_NAME:=python-lxml
 PKG_VERSION:=4.4.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=lxml-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/l/lxml
+PYPI_NAME:=lxml
 PKG_HASH:=c81cb40bff373ab7a7446d6bbca0190bccc5be3448b47b51d729e37799bb5692
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-lxml-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 PKG_LICENSE:=BSD
 PKG_LICENSE_FILES:=LICENSES.txt
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_CPE_ID:=cpe:/a:lxml:lxml
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk

--- a/lang/python/python-markdown/Makefile
+++ b/lang/python/python-markdown/Makefile
@@ -11,16 +11,14 @@ PKG_NAME:=python-markdown
 PKG_VERSION:=3.1.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=Markdown-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/m/markdown/
+PYPI_NAME:=Markdown
 PKG_HASH:=2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/Markdown-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE.md
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-multidict/Makefile
+++ b/lang/python/python-multidict/Makefile
@@ -11,14 +11,14 @@ PKG_NAME:=multidict
 PKG_VERSION:=4.5.2
 PKG_RELEASE:=1
 
-PKG_SOURCE:=multidict-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/m/multidict/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=024b8129695a952ebd93373e45b5d341dbb87c17ce49637b34000093f243dd4f
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-mysqlclient/Makefile
+++ b/lang/python/python-mysqlclient/Makefile
@@ -12,19 +12,16 @@ PKG_VERSION:=1.4.4
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0
 
-PKG_SOURCE:=mysqlclient-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/m/mysqlclient
+PYPI_NAME:=mysqlclient
 PKG_HASH:=9c737cc55a5dc8dd3583a942d5a9b21be58d16f00f5fefca4e575e7d9682e98c
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-mysqlclient-$(PKG_VERSION)
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
 # python-mysqlclient needs iconv
 include $(INCLUDE_DIR)/nls.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-mysqlclient/Default
   SUBMENU:=Python

--- a/lang/python/python-netdisco/Makefile
+++ b/lang/python/python-netdisco/Makefile
@@ -11,16 +11,14 @@ PKG_NAME:=python-netdisco
 PKG_VERSION:=2.6.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=netdisco-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/n/netdisco
+PYPI_NAME:=netdisco
 PKG_HASH:=2b3aca14a1807712a053f11fd80dc251dd821ee4899aefece515287981817762
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/netdisco-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.md
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-oauthlib/Makefile
+++ b/lang/python/python-oauthlib/Makefile
@@ -13,16 +13,13 @@ PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_SOURCE:=oauthlib-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/o/oauthlib
+PYPI_NAME:=oauthlib
 PKG_HASH:=bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-oauthlib-$(PKG_VERSION)
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-oauthlib/Default
   SUBMENU:=Python

--- a/lang/python/python-paho-mqtt/Makefile
+++ b/lang/python/python-paho-mqtt/Makefile
@@ -10,11 +10,10 @@ PKG_RELEASE:=1
 PKG_LICENSE:=Eclipse Public License v1.0 / Eclipse Distribution License v1.0
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
-PKG_SOURCE:=paho-mqtt-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/25/63/db25e62979c2a716a74950c9ed658dce431b5cb01fde29eb6cba9489a904
+PYPI_NAME:=paho-mqtt
 PKG_HASH:=e440a052b46d222e184be3be38676378722072fcd4dfd2c8f509fb861a7b0b79
-PKG_BUILD_DIR:=$(BUILD_DIR)/paho-mqtt-$(PKG_VERSION)
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-parsley/Makefile
+++ b/lang/python/python-parsley/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-parsley
 PKG_VERSION:=1.3
 PKG_RELEASE:=4
 
-PKG_SOURCE:=Parsley-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/P/Parsley
+PYPI_NAME:=Parsley
 PKG_HASH:=9444278d47161d5f2be76a767809a3cbe6db4db822f46a4fd7481d4057208d41
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-parsley-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 PYTHON_PKG_SETUP_ARGS:=
 PYTHON3_PKG_SETUP_ARGS:=

--- a/lang/python/python-pcapy/Makefile
+++ b/lang/python/python-pcapy/Makefile
@@ -11,14 +11,13 @@ PKG_NAME:=python-pcapy
 PKG_VERSION:=0.11.4
 PKG_RELEASE:=2
 
-PKG_SOURCE:=pcapy-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pcapy
+PYPI_NAME:=pcapy
 PKG_HASH:=aa239913678d7ba116e66057a37f914de7726aecd11d00db470127df115c4e78
-PKG_BUILD_DIR:=$(BUILD_DIR)/pcapy-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Andrew McConachie <andrew@depht.com>
 PKG_LICENSE:=Apache-1.1
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk

--- a/lang/python/python-ply/Makefile
+++ b/lang/python/python-ply/Makefile
@@ -11,22 +11,17 @@ PKG_NAME:=python-ply
 PKG_VERSION:=3.11
 PKG_RELEASE:=1
 
-PKG_SOURCE:=ply-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.dabeaz.com/ply \
-                https://files.pythonhosted.org/packages/source/p/ply
+PYPI_NAME:=ply
 PKG_HASH:=00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-ply-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=README.md
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-ply/Default
   SECTION:=lang

--- a/lang/python/python-psycopg2/Makefile
+++ b/lang/python/python-psycopg2/Makefile
@@ -11,10 +11,8 @@ PKG_NAME:=python-psycopg2
 PKG_VERSION:=2.7.6.1
 PKG_RELEASE:=2
 
-PKG_SOURCE:=psycopg2-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/psycopg2
+PYPI_NAME:=psycopg2
 PKG_HASH:=27959abe64ca1fc6d8cd11a71a1f421d8287831a3262bd4cacd43bbf43cc3c82
-PKG_BUILD_DIR:=$(BUILD_DIR)/psycopg2-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Dmitry Trefilov <the-alien@live.ru>
 PKG_LICENSE:=LGPL-3.0-or-later
@@ -22,6 +20,7 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_DEPENDS:=python/host
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 

--- a/lang/python/python-pyasn1-modules/Makefile
+++ b/lang/python/python-pyasn1-modules/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-pyasn1-modules
 PKG_VERSION:=0.2.7
 PKG_RELEASE:=1
 
-PKG_SOURCE:=pyasn1-modules-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyasn1-modules
+PYPI_NAME:=pyasn1-modules
 PKG_HASH:=0c35a52e00b672f832e5846826f1fb7507907f7d52fba6faa9e3c4cbe874fe4b
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pyasn1-modules-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-pyasn1-modules/Default
   SECTION:=lang

--- a/lang/python/python-pyasn1/Makefile
+++ b/lang/python/python-pyasn1/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-pyasn1
 PKG_VERSION:=0.4.7
 PKG_RELEASE:=1
 
-PKG_SOURCE:=pyasn1-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyasn1
+PYPI_NAME:=pyasn1
 PKG_HASH:=a9495356ca1d66ed197a0f72b41eb1823cf7ea8b5bd07191673e8147aecf8604
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pyasn1-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-pyasn1/Default
   SECTION:=lang

--- a/lang/python/python-pycparser/Makefile
+++ b/lang/python/python-pycparser/Makefile
@@ -11,11 +11,8 @@ PKG_NAME:=python-pycparser
 PKG_VERSION:=2.19
 PKG_RELEASE:=2
 
-PKG_SOURCE:=pycparser-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pycparser
+PYPI_NAME:=pycparser
 PKG_HASH:=a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pycparser-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -24,11 +21,10 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 HOST_PYTHON_PACKAGE_BUILD_DEPENDS:="ply==3.10"
 HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:="ply==3.10"
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-pycparser/Default
   SECTION:=lang

--- a/lang/python/python-pyopenssl/Makefile
+++ b/lang/python/python-pyopenssl/Makefile
@@ -11,8 +11,7 @@ PKG_NAME:=python-pyopenssl
 PKG_VERSION:=19.0.0
 PKG_RELEASE:=2
 
-PKG_SOURCE:=pyOpenSSL-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyOpenSSL
+PYPI_NAME:=pyOpenSSL
 PKG_HASH:=aeca66338f6de19d1aa46ed634c3b9ae519a64b458f8468aec688e7e3c20f200
 
 PKG_LICENSE:=Apache-2.0
@@ -20,13 +19,10 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_CPE_ID:=cpe:/a:pyopenssl_project:pyopenssl
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pyopenssl-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-pyopenssl/Default
   SECTION:=lang

--- a/lang/python/python-pyotp/Makefile
+++ b/lang/python/python-pyotp/Makefile
@@ -11,14 +11,14 @@ PKG_NAME:=pyotp
 PKG_VERSION:=2.2.7
 PKG_RELEASE:=1
 
-PKG_SOURCE:=pyotp-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyotp
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=be0ffeabddaa5ee53e7204e7740da842d070cf69168247a3d0c08541b84de602
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-pyptlib/Makefile
+++ b/lang/python/python-pyptlib/Makefile
@@ -11,20 +11,16 @@ PKG_NAME:=python-pyptlib
 PKG_VERSION:=0.0.6
 PKG_RELEASE:=3
 
-PKG_SOURCE:=pyptlib-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyptlib
+PYPI_NAME:=pyptlib
 PKG_HASH:=b98472e3d9e8f4689d3913ca8f89afa5e6cc5383dcd8686987606166f9dac607
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pyptlib-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-pyptlib/Default
   SECTION:=lang

--- a/lang/python/python-pyrsistent/Makefile
+++ b/lang/python/python-pyrsistent/Makefile
@@ -11,15 +11,14 @@ PKG_NAME:=python-pyrsistent
 PKG_VERSION:=0.15.4
 PKG_RELEASE:=1
 
-PKG_SOURCE:=pyrsistent-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyrsistent/
+PYPI_NAME:=pyrsistent
 PKG_HASH:=34b47fa169d6006b32e99d4b3c4031f155e6e68ebcc107d6454852e8e0ee6533
-PKG_BUILD_DIR:=$(BUILD_DIR)/pyrsistent-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.mit
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-pyserial/Makefile
+++ b/lang/python/python-pyserial/Makefile
@@ -11,20 +11,16 @@ PKG_NAME:=python-pyserial
 PKG_VERSION:=3.4
 PKG_RELEASE:=1
 
-PKG_SOURCE:=pyserial-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/cc/74/11b04703ec416717b247d789103277269d567db575d2fd88f25d9767fe3d/
+PYPI_NAME:=pyserial
 PKG_HASH:=6e2d401fdee0eab996cf734e67773a0143b932772ca8b42451440cfed942c627
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pyserial-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD
 PKG_MAINTAINER:=Micke Prag <micke.prag@telldus.se>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-pyserial/Default
   SECTION:=lang-python

--- a/lang/python/python-pytz/Makefile
+++ b/lang/python/python-pytz/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-pytz
 PKG_VERSION:=2019.3
 PKG_RELEASE:=1
 
-PKG_SOURCE:=pytz-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pytz
+PYPI_NAME:=pytz
 PKG_HASH:=b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-pytz-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-pytz/Default
   SUBMENU:=Python

--- a/lang/python/python-qrcode/Makefile
+++ b/lang/python/python-qrcode/Makefile
@@ -9,21 +9,17 @@ PKG_NAME:=python-qrcode
 PKG_VERSION:=6.1
 PKG_RELEASE:=2
 
-PKG_SOURCE:=qrcode-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/q/qrcode/
+PYPI_NAME:=qrcode
 PKG_HASH:=505253854f607f2abf4d16092c61d4e9d511a3b4392e60bff957a68592b04369
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-qrcode-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-qrcode/Default
   SECTION:=lang

--- a/lang/python/python-rcssmin/Makefile
+++ b/lang/python/python-rcssmin/Makefile
@@ -13,17 +13,13 @@ PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Eneas U de Queiroz 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_SOURCE:=rcssmin-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/r/rcssmin
+PYPI_NAME:=rcssmin
 PKG_HASH:=ca87b695d3d7864157773a61263e5abb96006e9ff0e021eff90cbe0e1ba18270
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-rcssmin-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-rcssmin/Default
     SUBMENU:=Python

--- a/lang/python/python-requests-oauthlib/Makefile
+++ b/lang/python/python-requests-oauthlib/Makefile
@@ -13,17 +13,13 @@ PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_SOURCE:=requests-oauthlib-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/r/requests-oauthlib
+PYPI_NAME:=requests-oauthlib
 PKG_HASH:=bd6533330e8748e94bf0b214775fed487d309b8b8fe823dc45641ebcd9a32f57
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-requests-oauthlib-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-requests-oauthlib/Default
   SUBMENU:=Python

--- a/lang/python/python-requests/Makefile
+++ b/lang/python/python-requests/Makefile
@@ -16,17 +16,13 @@ PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:python-requests:requests
 
-PKG_SOURCE:=requests-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/r/requests
+PYPI_NAME:=requests
 PKG_HASH:=11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-requests-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-requests/Default
   SUBMENU:=Python

--- a/lang/python/python-rsa/Makefile
+++ b/lang/python/python-rsa/Makefile
@@ -4,19 +4,16 @@ PKG_NAME:=rsa
 PKG_VERSION:=4.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/r/rsa
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-rsa-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
 PKG_LICENSE:=MIT
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-rsa/Default
   SUBMENU:=Python

--- a/lang/python/python-s3transfer/Makefile
+++ b/lang/python/python-s3transfer/Makefile
@@ -4,19 +4,16 @@ PKG_NAME:=s3transfer
 PKG_VERSION:=0.2.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/s/s3transfer
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=f23d5cb7d862b104401d9021fc82e5fa0e0cf57b7660a1331425aab0c691d021
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-s3transfer-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Daniel Danzberger <daniel@dd-wrt.com>
 PKG_LICENSE:=MIT
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-s3transfer/Default
   SECTION:=lang

--- a/lang/python/python-schedule/Makefile
+++ b/lang/python/python-schedule/Makefile
@@ -11,15 +11,14 @@ PKG_NAME:=python-schedule
 PKG_VERSION:=0.6.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=schedule-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/s/schedule/
+PYPI_NAME:=schedule
 PKG_HASH:=f9fb5181283de4db6e701d476dd01b6a3dd81c38462a54991ddbb9d26db857c9
-PKG_BUILD_DIR:=$(BUILD_DIR)/schedule-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-sentry-sdk/Makefile
+++ b/lang/python/python-sentry-sdk/Makefile
@@ -11,15 +11,14 @@ PKG_NAME:=python-sentry-sdk
 PKG_VERSION:=0.12.3
 PKG_RELEASE:=1
 
-PKG_SOURCE:=sentry-sdk-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/s/sentry-sdk/
+PYPI_NAME:=sentry-sdk
 PKG_HASH:=15e51e74b924180c98bcd636cb4634945b0a99a124d50b433c3a9dc6a582e8db
-PKG_BUILD_DIR:=$(BUILD_DIR)/sentry-sdk-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-service-identity/Makefile
+++ b/lang/python/python-service-identity/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-service-identity
 PKG_VERSION:=18.1.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=service_identity-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/s/service_identity
+PYPI_NAME:=service_identity
 PKG_HASH:=0858a54aabc5b459d1aafa8a518ed2081a285087f349fe3e55197989232e2e2d
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-service-identity-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-service-identity/Default
   SECTION:=lang

--- a/lang/python/python-simplejson/Makefile
+++ b/lang/python/python-simplejson/Makefile
@@ -13,16 +13,13 @@ PKG_RELEASE:=3
 PKG_LICENSE:=MIT
 PKG_CPE_ID:=cpe:/a:simplejson_project:simplejson
 
-PKG_SOURCE:=simplejson-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/s/simplejson
+PYPI_NAME:=simplejson
 PKG_HASH:=b1f329139ba647a9548aa05fb95d046b4a677643070dc2afc05fa2e975d09ca5
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-simplejson-$(PKG_VERSION)
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-simplejson/Default
   SUBMENU:=Python

--- a/lang/python/python-six/Makefile
+++ b/lang/python/python-six/Makefile
@@ -11,11 +11,8 @@ PKG_NAME:=python-six
 PKG_VERSION:=1.12.0
 PKG_RELEASE:=2
 
-PKG_SOURCE:=six-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/s/six
+PYPI_NAME:=six
 PKG_HASH:=d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-six-$(PKG_VERSION)
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -23,13 +20,11 @@ PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>, Alexandru Ardelean <ardeleana
 
 HOST_BUILD_DEPENDS:=python3/host
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-HOST_UNPACK:=$(HOST_TAR) -C $(HOST_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-six/Default
   SECTION:=lang

--- a/lang/python/python-slugify/Makefile
+++ b/lang/python/python-slugify/Makefile
@@ -11,14 +11,14 @@ PKG_NAME:=python-slugify
 PKG_VERSION:=3.0.3
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/python-slugify/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=a9f468227cb11e20e251670d78e1b5f6b0b15dd37bbd5c9814a25a904e44ff66
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-sqlalchemy/Makefile
+++ b/lang/python/python-sqlalchemy/Makefile
@@ -11,16 +11,15 @@ PKG_NAME:=python-sqlalchemy
 PKG_VERSION:=1.3.7
 PKG_RELEASE:=1
 
-PKG_SOURCE:=SQLAlchemy-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/S/SQLAlchemy/
+PYPI_NAME:=SQLAlchemy
 PKG_HASH:=0459bf0ea6478f3e904de074d65769a11d74cdc34438ab3159250c96d089aef0
-PKG_BUILD_DIR:=$(BUILD_DIR)/SQLAlchemy-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:sqlalchemy:sqlalchemy
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-twisted/Makefile
+++ b/lang/python/python-twisted/Makefile
@@ -11,11 +11,10 @@ PKG_NAME:=python-twisted
 PKG_VERSION:=19.7.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=Twisted-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/T/Twisted
+PYPI_NAME:=Twisted
+PYPI_SOURCE_EXT:=tar.bz2
 PKG_HASH:=d5db93026568f60cacdc0615fcd21d46f694a6bfad0ef3ff53cde2b4bb85a39d
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-twisted-$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=libtirpc
 
 PKG_LICENSE:=MIT
@@ -23,11 +22,10 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_CPE_ID:=cpe:/a:twistedmatrix:twisted
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xjf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-twisted/Default
   SECTION:=lang

--- a/lang/python/python-txsocksx/Makefile
+++ b/lang/python/python-txsocksx/Makefile
@@ -11,20 +11,16 @@ PKG_NAME:=python-txsocksx
 PKG_VERSION:=1.15.0.2
 PKG_RELEASE:=4
 
-PKG_SOURCE:=txsocksx-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/t/txsocksx
+PYPI_NAME:=txsocksx
 PKG_HASH:=4f79b5225ce29709bfcee45e6f726e65b70fd6f1399d1898e54303dbd6f8065f
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-txsocksx-$(PKG_VERSION)
 
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 PYTHON_PKG_SETUP_VARS:= \
   PKG_VERSION="$(PKG_VERSION)"

--- a/lang/python/python-urllib3/Makefile
+++ b/lang/python/python-urllib3/Makefile
@@ -16,17 +16,13 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_CPE_ID:=cpe:/a:urllib3_project:urllib3
 
-PKG_SOURCE:=urllib3-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/u/urllib3
+PYPI_NAME:=urllib3
 PKG_HASH:=9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-urllib3-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-urllib3/Default
   SUBMENU:=Python

--- a/lang/python/python-voluptuous-serialize/Makefile
+++ b/lang/python/python-voluptuous-serialize/Makefile
@@ -11,14 +11,14 @@ PKG_NAME:=voluptuous-serialize
 PKG_VERSION:=2.2.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/v/voluptuous-serialize/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=8b31660c7efdba0eb97ba65390b63cc62cc99ae3cd25d00e1873b183b38ef13d
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=COPYING
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-voluptuous/Makefile
+++ b/lang/python/python-voluptuous/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-voluptuous
 PKG_VERSION:=0.11.7
 PKG_RELEASE:=1
 
-PKG_SOURCE:=voluptuous-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/v/voluptuous/
+PYPI_NAME:=voluptuous
 PKG_HASH:=2abc341dbc740c5e2302c7f9b8e2e243194fb4772585b991931cb5b22e9bf456
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-voluptuous-$(PKG_VERSION)
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-voluptuous/Default
   SECTION:=lang

--- a/lang/python/python-yaml/Makefile
+++ b/lang/python/python-yaml/Makefile
@@ -11,8 +11,7 @@ PKG_NAME:=python-yaml
 PKG_VERSION:=5.1.2
 PKG_RELEASE:=1
 
-PKG_SOURCE:=PyYAML-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/P/PyYAML
+PYPI_NAME:=PyYAML
 PKG_HASH:=01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
@@ -20,13 +19,10 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:pyyaml_project:pyyaml
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-PyYAML-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-yaml/Default
   SECTION:=lang

--- a/lang/python/python-yarl/Makefile
+++ b/lang/python/python-yarl/Makefile
@@ -11,14 +11,14 @@ PKG_NAME:=yarl
 PKG_VERSION:=1.3.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=yarl-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/y/yarl/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=024ecdc12bc02b321bc66b41327f930d1c2c543fa9a561b39861da9388ba7aa9
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-zeroconf/Makefile
+++ b/lang/python/python-zeroconf/Makefile
@@ -11,16 +11,14 @@ PKG_NAME:=python-zeroconf
 PKG_VERSION:=0.23.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=zeroconf-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.python.org/packages/source/z/zeroconf/
+PYPI_NAME:=zeroconf
 PKG_HASH:=e0c333b967c48f8b2e5cc94a1d4d28893023fb06dfd797ee384a94cdd1d0eef5
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/zeroconf-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=COPYING
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python-zope-interface/Makefile
+++ b/lang/python/python-zope-interface/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-zope-interface
 PKG_VERSION:=4.6.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=zope.interface-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/z/zope.interface
+PYPI_NAME:=zope.interface
 PKG_HASH:=1b3d0dcabc7c90b470e59e38a9acaa361be43b3a6ea644c0063951964717f0e5
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-zope-interface-$(PKG_VERSION)
 
 PKG_LICENSE:=ZPL-2.1
 PKG_LICENSE_FILES:=LICENSE.txt
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-zope-interface/Default
   SECTION:=lang

--- a/lang/python/python3-bottle/Makefile
+++ b/lang/python/python3-bottle/Makefile
@@ -11,16 +11,15 @@ PKG_NAME:=python3-bottle
 PKG_VERSION:=0.12.17
 PKG_RELEASE:=1
 
-PKG_SOURCE:=bottle-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/b/bottle
+PYPI_NAME:=bottle
 PKG_HASH:=e9eaa412a60cc3d42ceb42f58d15864d9ed1b92e9d630b8130c871c5bb16107c
-PKG_BUILD_DIR:=$(BUILD_DIR)/bottle-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:bottlepy:bottle
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python3-flask-login/Makefile
+++ b/lang/python/python3-flask-login/Makefile
@@ -12,14 +12,14 @@ PKG_NAME:=Flask-Login
 PKG_VERSION:=0.4.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/f/flask-login/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=c815c1ac7b3e35e2081685e389a665f2c74d7e077cb93cecabaea352da4752ec
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python3-maxminddb/Makefile
+++ b/lang/python/python3-maxminddb/Makefile
@@ -12,14 +12,14 @@ PKG_NAME:=maxminddb
 PKG_VERSION:=1.5.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/m/maxminddb/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=449a1713d37320d777d0db286286ab22890f0a176492ecf3ad8d9319108f2f79
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python3-netifaces/Makefile
+++ b/lang/python/python3-netifaces/Makefile
@@ -11,16 +11,14 @@ PKG_NAME:=python3-netifaces
 PKG_VERSION:=0.10.9
 PKG_RELEASE:=1
 
-PKG_SOURCE:=netifaces-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/n/netifaces/
+PYPI_NAME:=netifaces
 PKG_HASH:=2dee9ffdd16292878336a58d04a20f0ffe95555465fee7c9bd23b3490ef2abf3
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/netifaces-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python3-pyroute2/Makefile
+++ b/lang/python/python3-pyroute2/Makefile
@@ -11,16 +11,14 @@ PKG_NAME:=python3-pyroute2
 PKG_VERSION:=0.5.6
 PKG_RELEASE:=1
 
-PKG_SOURCE:=pyroute2-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyroute2
+PYPI_NAME:=pyroute2
 PKG_HASH:=deae0e6191a04c3ee213c6fae6ed779602ef5da5ca5e2fa533f27bc04326bfbe
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/pyroute2-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Martin Matějek <martin.matejek@nic.cz>
 PKG_LICENSE:=GPL-2.0-or-later Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.GPL.v2 LICENSE.Apache.v2
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/python3-unidecode/Makefile
+++ b/lang/python/python3-unidecode/Makefile
@@ -11,16 +11,14 @@ PKG_NAME:=python3-unidecode
 PKG_VERSION:=1.1.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=Unidecode-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/u/unidecode/
+PYPI_NAME:=Unidecode
 PKG_HASH:=2b6aab710c2a1647e928e36d69c21e76b453cd455f4e2621000e54b2a9b8cce8
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/Unidecode-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/lang/python/ruamel-yaml/Makefile
+++ b/lang/python/ruamel-yaml/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=ruamel-yaml
 PKG_VERSION:=0.15.100
 PKG_RELEASE:=1
 
-PKG_SOURCE:=ruamel.yaml-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/r/ruamel.yaml/
+PYPI_NAME:=ruamel.yaml
 PKG_HASH:=8e42f3067a59e819935a2926e247170ed93c8f0b2ab64526f888e026854db2e4
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-ruamel.yaml-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/ruamel-yaml/Default
   SECTION:=lang

--- a/lang/python/text-unidecode/Makefile
+++ b/lang/python/text-unidecode/Makefile
@@ -11,21 +11,17 @@ PKG_NAME:=python-text-unidecode
 PKG_VERSION:=1.2
 PKG_RELEASE:=1
 
-PKG_SOURCE:=text-unidecode-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/t/text-unidecode/
+PYPI_NAME:=text-unidecode
 PKG_HASH:=5a1375bb2ba7968740508ae38d92e1f889a0832913cb1c447d5e2046061a396d
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-text-unidecode-$(PKG_VERSION)
 
 PKG_LICENSE:=Artistic-1.0-cl8
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-text-unidecode/Default
   SECTION:=lang

--- a/lang/python/vobject/Makefile
+++ b/lang/python/vobject/Makefile
@@ -8,17 +8,14 @@ PKG_VERSION:=0.9.6.1
 PKG_RELEASE:=1
 PKG_LICENSE:=Apache-2.0
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/v/vobject
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=96512aec74b90abb71f6b53898dd7fe47300cc940104c4f79148f0671f790101
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-vobject-$(PKG_VERSION)
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 
 include ../python-package.mk
 include ../python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/python-vobject/Default
   SUBMENU:=Python

--- a/lang/python/xmltodict/Makefile
+++ b/lang/python/xmltodict/Makefile
@@ -11,16 +11,14 @@ PKG_NAME:=python-xmltodict
 PKG_VERSION:=0.12.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=xmltodict-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/x/xmltodict/
+PYPI_NAME:=xmltodict
 PKG_HASH:=50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/xmltodict-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 

--- a/multimedia/youtube-dl/Makefile
+++ b/multimedia/youtube-dl/Makefile
@@ -11,15 +11,14 @@ PKG_NAME:=youtube-dl
 PKG_VERSION:=2019.10.29
 PKG_RELEASE:=1
 
-PKG_SOURCE:=youtube_dl-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/y/youtube_dl/
+PYPI_NAME:=youtube_dl
 PKG_HASH:=0b6611807b0bb978a0384ddebf215ea1f974ecf73d80d04e9f614ff30b1443f0
-PKG_BUILD_DIR:=$(BUILD_DIR)/youtube_dl-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Adrian Panella <ianchi74@outlook.com>, Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Unlicense
 PKG_LICENSE_FILES:=LICENSE
 
+include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
 

--- a/net/obfsproxy/Makefile
+++ b/net/obfsproxy/Makefile
@@ -11,14 +11,14 @@ PKG_NAME:=obfsproxy
 PKG_VERSION:=0.2.13
 PKG_RELEASE:=3
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/o/obfsproxy
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=1e26c2faef1cfcf856ddf60e9647058a7c78fb0d47f05b58a0f847ed7cc41a66
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 
+include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python-package.mk
 

--- a/net/radicale/Makefile
+++ b/net/radicale/Makefile
@@ -10,17 +10,15 @@ PKG_NAME:=radicale
 PKG_VERSION:=1.1.6
 PKG_RELEASE:=3
 
-PKG_SOURCE:=Radicale-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/R/Radicale
+PYPI_NAME:=Radicale
 PKG_HASH:=c007198ea45ef797344672c681d4c13f8b4aa85c15c41a1156225767a405c92b
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/Radicale-$(PKG_VERSION)
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:radicale:radicale
 
+include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
 

--- a/net/radicale2/Makefile
+++ b/net/radicale2/Makefile
@@ -12,15 +12,12 @@ PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:radicale:radicale
 
-PKG_SOURCE:=Radicale-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/R/Radicale/
+PYPI_NAME:=Radicale
 PKG_HASH:=02273fcc6ae10e0f74aa12652e24d0001eec8dbf467d54ddb4dfcc2af7d7a5db
-PKG_BUILD_DIR:=$(BUILD_DIR)/radicale2-$(BUILD_VARIANT)-$(PKG_VERSION)
 
+include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
-
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
 
 define Package/radicale2/Default
   SECTION:=net


### PR DESCRIPTION
Maintainers: see below
Compile tested: armvirt-64, 2019-10-18 snapshot sdk (asu failed to build because the gcc target package failed to build)
Run tested: none

Description:
This updates all Python packages that download their source from PyPi to use `pypi.mk`.

This will allow future improvements/changes to `pypi.mk` to affect all relevant packages.

This also makes it easier for future Python packages to start using `pypi.mk`, when it's clear how it is used in existing packages.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>

Maintainers:
@ianchi 
@commodo 
@smutt 
Daniel Danzberger <daniel@dd-wrt.com>
@cshoredaniel 
@dangowrt 
@dtrefilo-Quest 
@cotequeiroz 
@ja-pa 
me
@BKPepe 
@Cynerd 
@mmtj 
@mickeprag 
@paulo-raca 
@aparcar 
@ysc3839 
@shenek 
@valdi74 