### PR TITLE
foolism: Update to 1.0.13

### DIFF
--- a/net/foolsm/Makefile
+++ b/net/foolsm/Makefile
@@ -8,12 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=foolsm
-PKG_VERSION:=1.0.10
+PKG_VERSION:=1.0.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://lsm.foobar.fi/download
-PKG_HASH:=33210209ca38b3bfef1a9180f765266a134fc811dea8bc06450a3bd48d1d083e
+PKG_HASH:=4eeda0e666e8ee93aab9b9c6709e9695e042dc391fb0999280874c8a73bce476
+
+PKG_MAINTAINER:=
+PKG_LICENSE:=GPL-2.0-only
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -26,17 +32,23 @@ define Package/foolsm
 endef
 
 define Package/foolsm/description
-	foolsm is a link state monitor for carrying out actions when a link
-	transistions from the up to down state or vice versa.
+  foolsm is a link state monitor for carrying out actions when a link
+  transistions from the up to down state or vice versa.
 endef
 
 define Package/foolsm/conffiles
 /etc/foolsm/foolsm.conf
 endef
 
+MAKE_FLAGS += \
+	PREFIX="$(CONFIGURE_PREFIX)"
+
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
+
 define Package/foolsm/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/foolsm $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/foolsm $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/foolsm/script.d
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DATA) ./files/connections.conf $(1)/etc/foolsm/connections.conf


### PR DESCRIPTION
Switched to standard PKG_INSTALL.

Added PKG_BUILD_PARALLEL for faster compilation.

Added some size optimizations.

Added license information.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: mips64