### PR TITLE
libtins: Update to 4.2

### DIFF
--- a/libs/libtins/Makefile
+++ b/libs/libtins/Makefile
@@ -8,44 +8,48 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtins
-PKG_VERSION:=4.0
-PKG_RELEASE:=3
-
-PKG_MAINTAINER:= Steven Hessing <steven.hessing@gmail.com>
+PKG_VERSION:=4.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mfontanini/libtins/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=2a758d1bed51760bbd57fcaa00610534e0cc3a6d55d91983724e5f46739d66b8
+PKG_HASH:=a9fed73e13f06b06a4857d342bb30815fa8c359d00bd69547e567eecbbb4c3a1
 
+PKG_MAINTAINER:= Steven Hessing <steven.hessing@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_PARALLEL:=1
-
 CMAKE_INSTALL:=1
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
-CMAKE_OPTIONS += -D_RUN_RESULT_VAR=FORCE
-CMAKE_OPTIONS += -DLIBTINS_ENABLE_WPA2=0
-CMAKE_OPTIONS += -DLIBTINS_ENABLE_CXX11=1
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include/ $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/tins $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtins* $(1)/usr/lib/
-endef
 
 define Package/libtins
-	SECTION:=net
-	CATEGORY:=Libraries
-	TITLE:=libtins
-	URL:=https://libtins.github.io/
-	DEPENDS:=+libstdcpp +libpcap
+  SECTION:=net
+  CATEGORY:=Libraries
+  TITLE:=libtins
+  URL:=https://libtins.github.io/
+  DEPENDS:=+libstdcpp +libpcap
 endef
 
 define Package/libtins/description
-libtins is a high-level, multiplatform C++ network packet sniffing and crafting library.
+  libtins is a high-level, multiplatform C++ network packet sniffing and crafting library.
 endef
+
+CMAKE_OPTIONS += \
+	-D_RUN_RESULT_VAR=FORCE \
+	-DLIBTINS_BUILD_EXAMPLES=OFF \
+	-DLIBTINS_BUILD_TESTS=OFF \
+	-DLIBTINS_ENABLE_ACK_TRACKER=OFF \
+	-DLIBTINS_ENABLE_CXX11=ON \
+	-DLIBTINS_ENABLE_DOT11=OFF \
+	-DLIBTINS_ENABLE_PCAP=ON \
+	-DLIBTINS_ENABLE_TCP_STREAM_CUSTOM_DATA=OFF \
+	-DLIBTINS_ENABLE_WPA2=OFF
+
+TARGET_CXXFLAGS += -fno-rtti -ffunction-sections -fdata-sections -flto
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 define Package/libtins/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/libtins/patches/010-pkgconfig.patch
+++ b/libs/libtins/patches/010-pkgconfig.patch
@@ -1,0 +1,10 @@
+--- a/libtins.pc.in
++++ b/libtins.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@pkgconfig_prefix@
+ exec_prefix=@pkgconfig_exec_prefix@
+-libdir=@pkgconfig_libdir@
++libdir=${exec_prefix}/lib
+ includedir=${prefix}/include
+ 
+ Name: libtins


### PR DESCRIPTION
Added size optimizations.

Added explicit options to make sure Boost doesn't get included.

Several Makefile cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @StevenHessing 
Compile tested: mips64