### PR TITLE
adblock: update 3.8.7

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.8.6
-PKG_RELEASE:=2
+PKG_VERSION:=3.8.7
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -15,6 +15,11 @@ adb_init="/etc/init.d/adblock"
 adb_script="/usr/bin/adblock.sh"
 adb_pidfile="/var/run/adblock.pid"
 
+if [ -s "${adb_pidfile}" ] && [ "${action}" != "help" ] && [ "${action}" != "status" ]
+then
+	exit 1
+fi
+
 boot()
 {
 	adb_boot=1
@@ -61,25 +66,21 @@ restart()
 
 suspend()
 {
-	[ -s "${adb_pidfile}" ] && return 1
 	rc_procd start_service suspend
 }
 
 resume()
 {
-	[ -s "${adb_pidfile}" ] && return 1
 	rc_procd start_service resume
 }
 
 query()
 {
-	[ -s "${adb_pidfile}" ] && return 1
 	rc_procd "${adb_script}" query "${1}"
 }
 
 report()
 {
-	[ -s "${adb_pidfile}" ] && return 1
 	rc_procd "${adb_script}" report "${1:-"+"}" "${2:-"50"}" "${3:-"false"}" "${4:-"true"}"
 }
 
@@ -106,16 +107,29 @@ status_service()
 
 service_triggers()
 {
-	local trigger="$(uci_get adblock global adb_trigger)"
+	local trigger trigger_list="$(uci_get adblock global adb_trigger)"
 	local delay="$(uci_get adblock extra adb_triggerdelay "2")"
+	local type="$(uci_get adblock extra adb_starttype "start")"
 
 	PROCD_RELOAD_DELAY=$((delay*1000))
-	if [ -n "${trigger}" ] && [ "${trigger}" != "none" ] && [ "${trigger}" != "timed" ]
+	
+	if [ -z "${trigger_list}" ] && [ -r "/lib/functions/network.sh" ]
 	then
-		procd_add_interface_trigger "interface.*.up" "${trigger}" "${adb_init}" start
-	elif [ -z "${trigger}" ]
+		. "/lib/functions/network.sh"
+		network_find_wan trigger_list
+	fi
+
+	if [ -n "${trigger_list}" ]
 	then
-		procd_add_raw_trigger "interface.*.up" ${PROCD_RELOAD_DELAY} "${adb_init}" start
+		for trigger in ${trigger_list}
+		do
+			if [ "${trigger}" != "none" ] && [ "${trigger}" != "timed" ]
+			then
+				procd_add_interface_trigger "interface.*.up" "${trigger}" "${adb_init}" "${type}"
+			fi
+		done
+	else
+		procd_add_raw_trigger "interface.*.up" ${PROCD_RELOAD_DELAY} "${adb_init}" "${type}"
 	fi
 	procd_add_reload_trigger "adblock"
 }

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -13,7 +13,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-adb_ver="3.8.6-2"
+adb_ver="3.8.7"
 adb_basever=""
 adb_enabled=0
 adb_debug=0


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL.iNet GL-AR300M (NOR), OpenWrt SNAPSHOT r11362-4bf9bec361

Description:
* prevent forced parallel adblock service starts
* refine service trigger

Signed-off-by: Dirk Brenken <dev@brenken.org>
