### PR TITLE
python-more-itertools: add new package

### DIFF
--- a/lang/python/python-more-itertools/Makefile
+++ b/lang/python/python-more-itertools/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-more-itertools
+PKG_VERSION:=7.2.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=more-itertools
+PKG_HASH:=409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-more-itertools
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=More routines for operating on iterables, beyond itertools
+  URL:=https://github.com/erikrose/more-itertools
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-more-itertools/description
+  more-itertools library collects additional building blocks,
+  recipes, and routines for working with Python iterables.
+endef
+
+$(eval $(call Py3Package,python3-more-itertools))
+$(eval $(call BuildPackage,python3-more-itertools))
+$(eval $(call BuildPackage,python3-more-itertools-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR is based on #8562 . It splits new packages to individuals PR.

Run tested with simple example:

Test example
```
from more_itertools import flatten
iterable = [(0, 1), (2, 3)]
list(flatten(iterable))
[0, 1, 2, 3]
```

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>