### PR TITLE
python-py: add new package

### DIFF
--- a/lang/python/python-py/Makefile
+++ b/lang/python/python-py/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-py
+PKG_VERSION:=1.8.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=py
+PKG_HASH:=dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=setuptools-scm
+
+define Package/python3-py
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=py
+  URL:=https://github.com/pytest-dev/py
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-py/description
+  Library with cross-python path, ini-parsing, io, code, log facilities
+endef
+
+$(eval $(call Py3Package,python3-py))
+$(eval $(call BuildPackage,python3-py))
+$(eval $(call BuildPackage,python3-py-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR is based on #8562 . It splits new packages to individuals PR. This version gets rid of setup.py patch introduces in #8562 PR.

Tested with examples from:
https://py.readthedocs.io/en/latest/path.html