### PR TITLE
modemmanager: enable mbim/qmi support by default

### DIFF
--- a/net/modemmanager/Config.in
+++ b/net/modemmanager/Config.in
@@ -3,13 +3,13 @@ depends on PACKAGE_modemmanager
 
 	config MODEMMANAGER_WITH_MBIM
 		bool "Include MBIM support"
-		default n
+		default y
 		help
 		  Compile ModemManager with MBIM support
 
 	config MODEMMANAGER_WITH_QMI
 		bool "Include QMI support"
-		default n
+		default y
 		help
 		  Compile ModemManager with QMI support
 endmenu

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,11 +9,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.10.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
-PKG_HASH=3c2ca73782215664141042422759899ca9846440fc26d6223c7cf7ea4dd3c996
+PKG_HASH:=3c2ca73782215664141042422759899ca9846440fc26d6223c7cf7ea4dd3c996
 PKG_BUILD_DIR:=$(BUILD_DIR)/ModemManager-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>


### PR DESCRIPTION
MBIM and QMI support (necessary for modern and
high-performance LTE modems) should be default
y otherwise the only way to use modemmanager
with these protocols is to recompile the package.
This is very inconvenient for most end users.

Also fix typo in PKG_HASH definition.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>

Maintainer: @nickberry17 

this is a resend of PR https://github.com/openwrt/packages/pull/10217 