### PR TITLE
[19.07] https_dns_proxy: implement dnsmasq integration

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https_dns_proxy
 PKG_VERSION:=2018-04-23
-PKG_RELEASE=3
+PKG_RELEASE=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_MIRROR_HASH:=24b7e4238c37e646f33eee3a374f6b7beb5c167b9c5008cc13b51e5f1f3a44ea
@@ -16,10 +16,12 @@ PKG_LICENSE:=MIT
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
+CMAKE_OPTIONS += -DCLANG_TIDY_EXE=
+
 define Package/https_dns_proxy
   SECTION:=net
   CATEGORY:=Network
-  TITLE:=DNS over HTTPS proxy server
+  TITLE:=DNS over HTTPS Proxy Server
   DEPENDS:=+libcares +libcurl +libev +ca-bundle
 endef
 

--- a/net/https-dns-proxy/files/https_dns_proxy.init
+++ b/net/https-dns-proxy/files/https_dns_proxy.init
@@ -1,7 +1,9 @@
 #!/bin/sh /etc/rc.common
+# Copyright 2019 Stan Grishin (stangri@melmac.net)
+# shellcheck disable=SC2039
 
-START=80
-USE_PROCD=1
+export START=80
+export USE_PROCD=1
 
 PROG=/usr/sbin/https_dns_proxy
 
@@ -19,10 +21,10 @@ append_parm() {
 }
 
 start_instance() {
-	local cfg="$1" param
+	local cfg="$1" param listen_addr listen_port
 
 	append_parm "$cfg" 'listen_addr' '-a' '127.0.0.1'
-	append_parm "$cfg" 'listen_port' '-p' '5053'
+	append_parm "$cfg" 'listen_port' '-p' "$p"
 	append_parm "$cfg" 'bootstrap_dns' '-b'
 	append_parm "$cfg" 'url_prefix' '-r'
 	append_parm "$cfg" 'user' '-u' 'nobody'
@@ -31,16 +33,76 @@ start_instance() {
 	append_parm "$cfg" 'proxy_server' '-t'
 
 	procd_open_instance
+# shellcheck disable=SC2086
 	procd_set_param command ${PROG} ${param}
 	procd_set_param respawn
 	procd_close_instance
+
+	config_get listen_addr "$cfg" 'listen_addr' '127.0.0.1'
+	config_get listen_port "$cfg" 'listen_port' "$p"
+	config_load 'dhcp'
+# shellcheck disable=SC2154
+	config_foreach dnsmasq_add_doh_server 'dnsmasq' "${listen_addr}#${listen_port}"
+	p="$((p+1))"
 }
 
 service_triggers() {
-	procd_add_reload_trigger "https_dns_proxy"
+	procd_add_reload_trigger 'https_dns_proxy'
 }
 
 start_service() {
+	local p=5053
+	dhcp_backup 'create'
 	config_load 'https_dns_proxy'
 	config_foreach start_instance 'https_dns_proxy'
+	if [ -z "$(uci -q get dhcp.@dnsmasq[0].server)" ]; then
+		dhcp_backup 'restore'
+	fi
+	if [ -n "$(uci -q changes dhcp)" ]; then
+		uci -q commit dhcp
+		[ -x /etc/init.d/dnsmasq ] && /etc/init.d/dnsmasq restart >/dev/null 2>&1
+	fi
+}
+
+stop_service() {
+	dhcp_backup 'restore'
+	if [ -n "$(uci -q changes dhcp)" ]; then
+		uci -q commit dhcp
+		[ -x /etc/init.d/dnsmasq ] && /etc/init.d/dnsmasq restart >/dev/null 2>&1
+	fi
+}
+
+dnsmasq_add_doh_server() {
+	local cfg="$1" value="$2"
+	uci -q add_list dhcp."$cfg".server="$value"
+}
+
+dnsmasq_create_server_backup() {
+	local cfg="$1" i
+	if ! uci -q get "dhcp.$cfg.doh_backup_server" >/dev/null; then
+		for i in $(uci -q get "dhcp.$cfg.server"); do
+			uci -q add_list dhcp."$cfg".doh_backup_server="$i"
+		done
+	fi
+	uci -q del "dhcp.$cfg.server"
+}
+
+dnsmasq_restore_server_backup() {
+	local cfg="$1" i
+	if uci -q get "dhcp.$cfg.doh_backup_server" >/dev/null; then
+		uci -q del "dhcp.$cfg.server"
+		for i in $(uci -q get "dhcp.$cfg.doh_backup_server"); do
+			uci -q add_list dhcp."$cfg".server="$i"
+		done
+	fi
+}
+
+dhcp_backup() {
+	config_load 'dhcp'
+	case "$1" in
+		create)
+			config_foreach dnsmasq_create_server_backup 'dnsmasq';;
+		restore)
+			config_foreach dnsmasq_restore_server_backup 'dnsmasq';;
+	esac
 }


### PR DESCRIPTION
Signed-off-by: Stan Grishin <stangri@melmac.net>

Maintainer: @aarond10 
Compile tested: mvebu, WRT3200ACM, 18.06.4
Run tested: mvebu, WRT3200ACM, 18.06.4, start/stop

Description: I have previously implemented the dnsmasq integration in the luci app, but having time to reflect on that, I realize that was a flawed approach. This change implements dnsmasq integration in the init script for the principal app. 

If no dnsmasq/dnsmasq settings exist, this change will not affect the system. If the dnsmasq/dnsmasq settings exist, this change will simplify the usage of the package.

On service start, if no previous backup found, existing dnsmasq server settings are backed up and populated with the entries to refer to the https_dns_proxy instances.

On service stop, if the previous backups exist, they are restored so that dnsmasq is kept operational.
