### PR TITLE
geth: Update to 1.9.6

### DIFF
--- a/net/geth/Makefile
+++ b/net/geth/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=go-ethereum
-PKG_VERSION:=1.9.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.9.6
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ethereum/go-ethereum/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=7394ae0eeac4b2aafa4bd56eef18c077088770bbce0962b215607b44369a5430
+PKG_HASH:=3000f787735ee302088d17d406eafc2ec26eaffc083d876b2fa07ec7dfbb94f9
 
 PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
 PKG_LICENSE:=GPL-3.0-or-later LGPL-3.0-or-later


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mislavn
Compile tested: ath79
