### PR TITLE
pkgconf: Add package

### DIFF
--- a/devel/pkg-config/Makefile
+++ b/devel/pkg-config/Makefile
@@ -9,16 +9,18 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pkg-config
 PKG_VERSION:=0.29.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://pkg-config.freedesktop.org/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591
+
 PKG_MAINTAINER:=Heinrich Schuchardt <xypron.glpk@gmx.de>
 PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
-PKG_ASLR_PIE:=1
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -29,6 +31,7 @@ define Package/pkg-config
   TITLE:=pkg-config
   URL:=https://www.freedesktop.org/wiki/Software/pkg-config/
   DEPENDS:=+glib2 $(INTL_DEPENDS)
+  CONFLICTS:=pkgconf
 endef
 
 define Package/pkg-config/description
@@ -38,6 +41,8 @@ define Package/pkg-config/description
   for instance, rather than hard-coding values on where to find glib (or
   other libraries).
 endef
+
+TARGET_CFLAGS += $(FPIC)
 
 define Package/pkg-config/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/devel/pkgconf/Makefile
+++ b/devel/pkgconf/Makefile
@@ -1,0 +1,68 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pkgconf
+PKG_VERSION:=1.6.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://distfiles.dereferenced.org/pkgconf
+PKG_HASH:=61f0b31b0d5ea0e862b454a80c170f57bad47879c0c42bd8de89200ff62ea210
+
+PKG_MAINTAINER:=Rosen Penev <rosenp@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYING
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libpkgconf
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=libpkgconf
+  URL:=http://pkgconf.org/
+endef
+
+define Package/pkgconf
+  SECTION:=devel
+  CATEGORY:=Development
+  TITLE:=pkgconf
+  URL:=http://pkgconf.org/
+  DEPENDS:=+libpkgconf
+endef
+
+define Package/libpkgconf/description
+  libpkgconf is a library which provides access to most of pkgconf’s
+  functionality, to allow other tooling such as compilers and IDEs to
+  discover and use frameworks configured by pkgconf. It features a stable
+  library ABI and API designed for building bindings and other tools.
+endef
+
+define Package/pkgconf/description
+  pkgconf is a program which helps to configure compiler and linker flags
+  for development frameworks. It is similar to pkg-config from
+  freedesktop.org, providing additional functionality while also
+  maintaining compatibility.
+endef
+
+define Package/libpkgconf/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpkgconf.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/share/aclocal/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/aclocal/pkg.m4 \
+	  $(1)/usr/share/aclocal/
+endef
+
+define Package/pkgconf/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/pkgconf $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,libpkgconf))
+$(eval $(call BuildPackage,pkgconf))


### PR DESCRIPTION
pkgconf is a lighterweight alternative to pkg-config that does not require
glib2.

It also seems to be improved in several key areas. See the feature
comparison: http://pkgconf.org/features.html

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me
Compile tested: ath79
