### PR TITLE
vim/host: fix build failures

### DIFF
--- a/utils/vim/Makefile
+++ b/utils/vim/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vim
 PKG_VERSION:=8.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 VIMVER:=81
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -20,6 +20,8 @@ PKG_CPE_ID:=cpe:/a:vim:vim
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)$(VIMVER)
 PKG_BUILD_PARALLEL:=1
+
+HOST_BUILD_DEPENDS:=libiconv/host
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)$(VIMVER)
 HOST_BUILD_PARALLEL:=1
@@ -109,6 +111,15 @@ define Package/xxd/description
  xxd creates a hex dump of a given file or standard input, it can also convert
  a hex dump back to its original binary form.
 endef
+
+HOST_CONFIGURE_ARGS += \
+	--disable-acl \
+	--disable-gpm \
+	--disable-nls \
+	--disable-selinux \
+	--enable-gui=no \
+	--with-features=normal \
+	--without-x
 
 CONFIGURE_ARGS += \
 	--disable-gui \


### PR DESCRIPTION
Indeterminably vim/host fails on the build bots:

```
objects/fileio.o: In function `readfile':
fileio.c:(.text+0x5b3f): undefined reference to `libiconv_close'
fileio.c:(.text+0x61ad): undefined reference to `libiconv_close'
fileio.c:(.text+0x62f6): undefined reference to `libiconv'
fileio.c:(.text+0x6794): undefined reference to `libiconv_close'
objects/fileio.o: In function `buf_write_bytes':
fileio.c:(.text+0xa1fe): undefined reference to `libiconv'
fileio.c:(.text+0xa54a): undefined reference to `libiconv'
objects/fileio.o: In function `buf_write':
fileio.c:(.text+0xaf48): undefined reference to `libiconv_close'
objects/mbyte.o: In function `my_iconv_open.part.18':
mbyte.c:(.text+0x2ced): undefined reference to `libiconv_open'
mbyte.c:(.text+0x2d3a): undefined reference to `libiconv'
mbyte.c:(.text+0x2d5f): undefined reference to `libiconv_close'
objects/mbyte.o: In function `convert_setup_ext':
mbyte.c:(.text+0x33bf): undefined reference to `libiconv_close'
objects/mbyte.o: In function `string_convert_ext':
mbyte.c:(.text+0x363c): undefined reference to `libiconv'
collect2: error: ld returned 1 exit status
link.sh: Linking failed
Makefile:1949: recipe for target 'vim' failed
```

This is addressed by pulling in libiconv/host. Also configure switches
are added that keep external dependencies to a minimum, for instance
avoiding to link to X11 or gettext.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @ratkaj 
Compile tested: x86_64
Run tested: The only packages depending on vim/host are ttyd & device-observatory. I was able to compile them fine with the changes of this pull request. How or why they (presumably) use vim/host I have not checked.

Description:
Hi all,

This should fix the sporadic compile failures for vim/host on the build bots.

Regards,
Seb