### PR TITLE
google-authenticator-libpam: fix install section

### DIFF
--- a/libs/google-authenticator-libpam/Makefile
+++ b/libs/google-authenticator-libpam/Makefile
@@ -40,7 +40,7 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/security/* $(1)/lib/security/
 endef
 
-define Package/libpam-google-authenticator/install
+define Package/google-authenticator-libpam/install
 	$(INSTALL_DIR) $(1)/usr/lib/security
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/security/*.so* \
 	    $(1)/usr/lib/security/


### PR DESCRIPTION
Maintainer: @lucize, @neheb 
Compile tested: Clean Debian 10 host, Entware repo ([commit](https://github.com/Entware/entware-packages/commit/646575c9957e80f0e77ce8684ecae7ec1b2c3f1a)) 
Run tested: Entware, mipsel feed

Description: Looks like this package compiled but never packed into IPK since birth. We [discovered](https://github.com/Entware/Entware/issues/354) that when IPK disappeared after [replacing](https://github.com/Entware/rtndev/commit/0774fba91cfce8efef541eb2c4b84aadfd758934) our own `google-authenticator-libpam` package with this one.
