### PR TITLE
glib2: Disable Werror

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.58.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_BUILD_DIR:=$(BUILD_DIR)/glib-$(PKG_VERSION)
@@ -46,8 +46,6 @@ define Package/glib2/description
   The GLib library of C routines
 endef
 
-TARGET_CFLAGS += -Wno-error=implicit-function-declaration
-
 HOST_CONFIGURE_ARGS += \
 	--disable-libelf \
 	--disable-selinux \
@@ -64,6 +62,7 @@ CONFIGURE_ARGS += \
 	--disable-fam \
 	--disable-gtk-doc-html \
 	--disable-man \
+	--disable-compile-warnings \
 	--with-libiconv=gnu \
 	--with-pcre=internal
 


### PR DESCRIPTION
On GCC9, it throws a Wformat-nonliteral error. Unfortunately, there's no
easy was to fix it as it is fortify-headers where the warning ultimately
comes from.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: ath79
