### PR TITLE
python-pluggy: add new package

### DIFF
--- a/lang/python/python-pluggy/Makefile
+++ b/lang/python/python-pluggy/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pluggy
+PKG_VERSION:=0.13.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=pluggy
+PKG_HASH:=15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=setuptools-scm
+
+define Package/python3-pluggy
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Plugin and hook calling mechanisms for Python
+  URL:=https://github.com/pytest-dev/pluggy
+  DEPENDS:=+python3-light
+  VARIANT:=python3
+endef
+
+define Package/python3-pluggy/description
+  A minimalist production ready plugin system for python
+endef
+
+$(eval $(call Py3Package,python3-pluggy))
+$(eval $(call BuildPackage,python3-pluggy))
+$(eval $(call BuildPackage,python3-pluggy-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS4), OpenWrt master
Run tested: Turris Omnia (TOS4), OpenWrt 19.07

Description:

This PR is based on #8562 . It splits new packages to individuals PR.

Run tested with example from https://github.com/pytest-dev/pluggy/blob/master/README.rst

~~Note: package  depends on https://github.com/openwrt/packages/pull/10443~~