### PR TITLE
keepalived: fix run errors on non x86_64 architectures

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.0.19
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software
@@ -86,7 +86,8 @@ endef
 
 CONFIGURE_ARGS+= \
 	--with-init=SYSV \
-	--disable-nftables
+	--disable-nftables \
+	--disable-track-process
 
 ifeq ($(CONFIG_KEEPALIVED_VRRP),)
 CONFIGURE_ARGS += \

--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.0.19
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software
@@ -87,7 +87,8 @@ endef
 CONFIGURE_ARGS+= \
 	--with-init=SYSV \
 	--disable-nftables \
-	--disable-track-process
+	--disable-track-process \
+	--with-run-dir="/var/run"
 
 ifeq ($(CONFIG_KEEPALIVED_VRRP),)
 CONFIGURE_ARGS += \


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64 / lantiq_xrx200, APU3, OpenWrt master
Run tested: x86_64 / lantiq_xrx200, APU3, OpenWrt master, failover run test with lantiq_xrx200 and x86_64

Description:
This fixes issue for non x86_64 architecture which was reported in https://github.com/openwrt/packages/pull/10317#issuecomment-549193754