### PR TITLE
Add required new depends for luci-app-sqm

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -10,11 +10,11 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sqm-scripts
 PKG_SOURCE_VERSION:=ab763cba8b1516b3afa99760e0ca884f8b8d93b8
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPLv2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_RELEASE).tar.xz
-PKG_MIRROR_HASH:=00bc93f667ad417d4ba9bea4a01d87e3c670a294f61de13348a0f71e7700241f
+PKG_MIRROR_HASH:=6e8ce29ba398c14fe679ea95fe03c785d7b5357d515b988360b4cc8be68b7e59
 PKG_SOURCE_URL:=https://github.com/tohojo/sqm-scripts.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_RELEASE)
@@ -51,7 +51,7 @@ define Package/luci-app-sqm
   TITLE:=SQM Scripts - LuCI interface
   MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
   PKGARCH:=all
-  DEPENDS:= +lua +luci-base +sqm-scripts
+  DEPENDS:= +lua +luci-base +luci-compat +sqm-scripts
   SUBMENU:=3. Applications
 endef
 


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: openwrt master
Run tested: luci-app-sqm failed to run without luci-compat selected, worked after selecting it.

Description:
The new luci-compat package is required to be able to run luci-app-sqm, see:
https://github.com/openwrt/luci/commit/d5dff8f9a5ca85d197cbb6037f95053bc55941e5