### PR TITLE
[openwrt-19.07] net: seahub: remove inexistent deps

### DIFF
--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-seahub
 PKG_VERSION:=6.3.4
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/haiwen/seahub/tar.gz/v$(PKG_VERSION)-server?
@@ -38,7 +38,6 @@ define Package/seafile-seahub
   TITLE:=Seafile server - seahub component
   URL:=https://seafile.com/
   DEPENDS:=+python \
-	+django-simple-captcha +django-statici18n +django-webpack-loader \
 	+python-flup +gunicorn +openpyxl \
 	$(foreach dep,$(SEAFILE_PYTHON_DEPENDS),+python-$(dep))
 endef


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A ; did a make menuconfig/defconfig to make sure this goes away
Run tested: N/A

----------------------------------------------------

This looks like something was not cherry-picked, or was cherry-picked
incorrectly. Those packages don't exist.

Warnings are:
```
WARNING: Makefile 'package/feeds/packages/seafile-seahub/Makefile' has a dependency on 'django-simple-captcha', which does not exist
WARNING: Makefile 'package/feeds/packages/seafile-seahub/Makefile' has a dependency on 'django-statici18n', which does not exist
WARNING: Makefile 'package/feeds/packages/seafile-seahub/Makefile' has a dependency on 'django-webpack-loader', which does not exist
```

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>