### PR TITLE
modemmanager: install carrier mapping configuration files

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -117,6 +117,9 @@ define Package/modemmanager/install
 	$(INSTALL_DIR) $(1)/usr/share/dbus-1/system-services
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/dbus-1/system-services/org.freedesktop.ModemManager1.service $(1)/usr/share/dbus-1/system-services
 
+	$(INSTALL_DIR) $(1)/usr/share/ModemManager
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/ModemManager/*.conf $(1)/usr/share/ModemManager
+
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/modemmanager.init $(1)/etc/init.d/modemmanager
 


### PR DESCRIPTION
Since ModemManager 1.10.2, per-device carrier mapping configuration
files may be installed, providing support for automatic carrier config
selection.

Signed-off-by: Aleksander Morgado <aleksander@aleksander.es>

Maintainer: @nickberry17
