### PR TITLE
modemmanager: fix bearer disconnection logic

### DIFF
--- a/net/modemmanager/files/modemmanager.proto
+++ b/net/modemmanager/files/modemmanager.proto
@@ -375,7 +375,7 @@ proto_modemmanager_teardown() {
 	}
 
 	# load bearer connection method
-	bearerstatus=$(mmcli --bearer "${bearerpath}")
+	bearerstatus=$(mmcli --bearer "${bearerpath}" --output-keyvalue)
 	bearermethod=$(modemmanager_get_field "${bearerstatus}" "bearer.ipv4-config.method")
 	[ -n "${bearermethod}" ] || {
 		echo "couldn't load bearer method"


### PR DESCRIPTION
The bearer status wasn't being loaded in key/value mode, and therefore
would always fail to load the IPv4 config method.

Signed-off-by: Aleksander Morgado <aleksander@aleksander.es>

Maintainer: @nickberry17 
