### PR TITLE
django: bump version to 2.2.7 and fix minor problems

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=2.2.6
+PKG_VERSION:=2.2.7
 PKG_RELEASE:=1
 
 PYPI_NAME:=Django
-PKG_HASH:=a8ca1033acac9f33995eb2209a6bf18a4681c3e5269a878e9a7e0b7384ed1ca3
+PKG_HASH:=16040e1288c6c9f68c6da2fe75ebde83c0a158f6f5d54f4c5177b0c1478c5b86
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -36,13 +36,20 @@ define Package/python3-django
 $(call Package/django/Default)
   DEPENDS:= \
 	+PACKAGE_python3-django:python3 \
-	+PACKAGE_python3-django:python3-pytz
+	+PACKAGE_python3-django:python3-pytz \
+	+PACKAGE_python3-django:python3-sqlparse
   VARIANT:=python3
 endef
 
 define Package/python3-django/description
     The web framework for perfectionists with deadlines (LTS 2.2 series).
     Python3 only.
+endef
+
+define Py3Package/python3-django/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/django-admin.py \
+		$(1)/usr/bin/django-admin
 endef
 
 $(eval $(call Py3Package,python3-django))


### PR DESCRIPTION
Maintainer: Alexandru Ardelean <ardeleanalex@gmail.com>
Compile tested: MIPS 74K, Asus RT-N16, master snapshot
Run tested: MIPS 74K, Asus RT-N16, master snapshot, run django-admin

Description:
This is an update to the newest version. Furthermore, it installs `django-admin.py` as `/usr/bin/django-admin` and adds the dependency on `python3-sqlparse`, which will be imported e.g. by the etesync-server using `db.backends.sqlite3`. 

As @jefferyto gave me the hint for another [package](https://github.com/openwrt/packages/pull/10376#discussion_r341376378), I looked at all the `import`s in the sources:
* From full python3 it is needing:
`python3-cgi` `python3-codecs` `python3-ctypes` `python3-decimal` `python3-distutils` `python3-email` `python3-logging` `python3-multiprocessing` `python3-sqlite3` `python3-unittest` `python3-urllib` `python3-xml`

* So, we could use `python3-light` without the following packages (**not** in this PR):
`python3-asyncio` `python3-dbm` `python3-dev` `python3-gdbm` `python3-lib2to3` `python3-lzma` `python3-ncurses` `python3-openssl` `python3-pip` `python3-pydoc` `python3-setuptools`

* The additional dependencies given also in the `setup.py` are (**done** in this PR): 
`python3-pytz` `python3-sqlparse`

* For the original `/usr/bin/django-admin` we would also need `python3-pkg-resources`. We can prevent that by using the `django-admin.py` instead without compiling it to `django-admin.pyc` (**done** in this PR).

* We could add more dependencies (**not** in this PR) as some parts would `import` also
`python3-docutils` `python3-jinja2` `python3-mysqlclient` `python3-pillow` `python3-yaml`
and the following modules that are not packaged here at Openwrt:
`bpython` `cx_Oracle` `geoip2` `IPython` `memcache` `msvcrt` `numpy` `psycopg2` `pylibmc` `pywatchman` `readline` `selenium` `StringIO` `tblib` `unicodedata`

These are the results of basically grepping for `import` through the source files, I did not look at the imports by the `importlib`.

In this PR I am only adding the dependency on `python3-sqlparse` to the previous dependencies on `python3` and `python3-pytz`. Should we change it further?