### PR TITLE
travelmate: update 1.5.2

### DIFF
--- a/net/travelmate/Makefile
+++ b/net/travelmate/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=travelmate
-PKG_VERSION:=1.5.1
+PKG_VERSION:=1.5.2
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/travelmate/files/travelmate.init
+++ b/net/travelmate/files/travelmate.init
@@ -23,6 +23,7 @@ start_service()
 		procd_open_instance "travelmate"
 		procd_set_param command "${trm_script}" "${@}"
 		procd_set_param pidfile "${trm_pidfile}"
+		procd_set_param nice "$(uci_get travelmate extra trm_nice "0")"
 		procd_set_param stdout 1
 		procd_set_param stderr 1
 		procd_close_instance


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: TP-Link RE450 v1, OpenWrt SNAPSHOT r11398-6f3a293532

Description:
* print to stdout if 'logger' is not available
* add support to set the service nice level (default is 0)
* small fixes / polish up for forthcoming 19.07 release

Signed-off-by: Dirk Brenken <dev@brenken.org>

