### PR TITLE
python: Fix filespec example in readme

### DIFF
--- a/lang/python/README.md
+++ b/lang/python/README.md
@@ -376,13 +376,13 @@ define PyPackage/python-example/filespec
 endef
 ```
 
-If there is an `examples` directory and `test_*.py` files that can be omitted to save space, this can be specified as:
+If the package installs a `example_package` directory inside `PYTHON_PKG_DIR`, and there is an `examples` directory and `test_*.py` files that can be omitted to save space, this can be specified as:
 
 ```
 define PyPackage/python-example/filespec
 +|$(PYTHON_PKG_DIR)
--|$(PYTHON_PKG_DIR)/examples
--|$(PYTHON_PKG_DIR)/test_*.py
+-|$(PYTHON_PKG_DIR)/example_package/examples
+-|$(PYTHON_PKG_DIR)/example_package/test_*.py
 endef
 ```
 


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: N/A
Run tested: N/A

Description:
While the filespec example is technically correct, the more likely scenario is that the files to be omitted would be inside of a package subdirectory.

This adds an example_package directory into the example to illustrate this case.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>