### PR TITLE
ntpd: Include sntp binary only with ntp-utils

### DIFF
--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntp
 PKG_VERSION:=4.2.8p13
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/
@@ -33,7 +33,7 @@ define Package/ntpd/Default
   TITLE:=ISC ntp
   MAINTAINER:=Peter Wagner <tripolar@gmx.at>
   URL:=http://www.ntp.org/
-  DEPENDS:=+libopenssl +libpthread +libcap +libevent2-pthreads
+  DEPENDS:=+libopenssl +libpthread +libcap
 endef
 
 define Package/ntpd/Default/description
@@ -69,17 +69,19 @@ endef
 define Package/ntp-utils
 $(call Package/ntpd/Default)
   TITLE+= utilities
+  DEPENDS+= +libevent2-pthreads
 endef
 
 define Package/ntp-utils/description
 $(call Package/ntpd/Default/description)
  .
- This package contains ntpdc, ntpq and ntptime.
+ This package contains ntpdc, ntpq, ntptime and sntp.
 endef
 
 define Package/ntp-keygen
 $(call Package/ntpd/Default)
   TITLE+=keygen
+  DEPENDS+= +libevent2-core
 endef
 
 define Package/ntp-keygen/description
@@ -107,6 +109,7 @@ CONFIGURE_ARGS += \
 	--enable-linuxcaps \
 	--with-yielding-select=yes \
 	--with-crypto \
+	$(if $(CONFIG_PACKAGE_ntp-utils),--with-sntp,--without-sntp) \
 	--with-openssl-incdir="$(STAGING_DIR)/usr/include" \
 	--with-openssl-libdir="$(STAGING_DIR)/usr/lib"
 
@@ -145,6 +148,7 @@ define Package/ntp-utils/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ntpdc/ntpdc $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ntpq/ntpq $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/util/ntptime $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/sntp/sntp $(1)/usr/sbin/
 endef
 
 define Package/ntp-keygen/install


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: openwrt/openwrt @ 6170c46
Run tested: Zyxel NBG6817

Description:

This PR includes the sntp binary in the ntp-utils package while removing it with it's unnecessary libevent dependencies from the other ntp packages. 

Fixes openwrt#10307