### PR TITLE
Io tool fixes

### DIFF
--- a/utils/io/Makefile
+++ b/utils/io/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=io
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -25,7 +25,8 @@ define Package/io/description
 endef
 
 define Build/Compile
-	$(TARGET_CC) $(TARGET_CFLAGS) -Wall $(PKG_BUILD_DIR)/io.c -o $(PKG_BUILD_DIR)/$(PKG_NAME)
+	$(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_LDFLAGS) -Wall \
+		$(PKG_BUILD_DIR)/io.c -o $(PKG_BUILD_DIR)/$(PKG_NAME)
 endef
 
 define Package/io/install

--- a/utils/io/Makefile
+++ b/utils/io/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=io
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/utils/io/src/io.c
+++ b/utils/io/src/io.c
@@ -68,7 +68,7 @@ memread_memory(unsigned long phys_addr, void *addr, int len, int iosize)
 				printf(" %04x", *(unsigned short *)addr);
 				break;
 			case 4:
-				printf(" %08lx", *(unsigned long *)addr);
+				printf(" %08x", *(unsigned int *)addr);
 				break;
 			}
 			i += iosize;


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu_cortexa53, lantiq
Run tested: lantiq

Description:

This contains two unrelated fixes for the io tool.

**io: Fix printing 4 bytes memory on 64 bit systems**
    
On 64 bit Linux systems long is 8 bytes long, on 32 bit Linux systems it
is 4 bytes long. Here we want to print 4 bytes and not 8 bytes, use int
instead of long.
    
This fixes printing 4 bytes on 64 bit systems.

**io: Add TARGET_LDFLAGS to fix PIE**
    
Add the OpenWrt TARGET_LDFLAGS to the compile command to activate PIE support
for the io tool when it is activated globally in OpenWrt.
