### PR TITLE
perl: fixed host compilation of static perl on MacOS

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \

--- a/lang/perl/patches/301-fix_macos_static_linking.patch
+++ b/lang/perl/patches/301-fix_macos_static_linking.patch
@@ -1,0 +1,19 @@
+--- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Unix.pm
++++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Unix.pm
+@@ -2738,14 +2738,14 @@ sub _find_static_libs {
+ 
+ Called by a utility method of makeaperl. Checks whether a given file
+ is an XS library by seeing whether it defines any symbols starting
+-with C<boot_>.
++with C<boot_> (with an optional leading underscore – needed on MacOS).
+ 
+ =cut
+ 
+ sub xs_static_lib_is_xs {
+     my ($self, $libfile) = @_;
+     my $devnull = File::Spec->devnull;
+-    return `nm $libfile 2>$devnull` =~ /\bboot_/;
++    return `nm $libfile 2>$devnull` =~ /\b_?boot_/;
+ }
+ 
+ =item makefile (o)


### PR DESCRIPTION
Maintainer: @pprindeville
Compile tested: x86_64 (macOS host) OpenWRT master
Run tested: x86_64 (macOS host, compilation of target perl) OpenWRT 18.06

Description:

Host Perl is not built correctly (#6844) on macOS which results in a failure to build Perl for the target. The problem is that the statically linked host Perl is missing the List::Util extension (in fact it does not have any standard extensions linkedin apart from `Socket`). This is a regression which was introduced between 5.26 and 5.28 by [this commit to the MakeMaker module](https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/commit/1f048db1461de67d34b13f8bfcf4683d8d735b9d). Perl searches for extensions to link statically by looking for `boot_*` symbols inside `.a` archives. This does not work on macOS since symbols are prefixed with `_` so a `_boot_*` pattern is needed.

This is a rebase of https://github.com/openwrt/packages/pull/9791 . It is already merged upstream: https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/pull/339.