### PR TITLE
lang/python/python*-package.mk: fix python modules compilation on arm64

### DIFF
--- a/lang/python/python-package.mk
+++ b/lang/python/python-package.mk
@@ -35,6 +35,10 @@ ifdef CONFIG_USE_MIPS16
   TARGET_CFLAGS += -mno-mips16 -mno-interlink-mips16
 endif
 
+ifeq ($(ARCH),aarch64)
+  TARGET_CFLAGS += -fPIC
+endif
+
 define PyShebang
 $(SED) "1"'!'"b;s,^#"'!'".*python.*,#"'!'"/usr/bin/python2," -i --follow-symlinks $(1)
 endef

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -34,6 +34,10 @@ ifdef CONFIG_USE_MIPS16
   TARGET_CFLAGS += -mno-mips16 -mno-interlink-mips16
 endif
 
+ifeq ($(ARCH),aarch64)
+  TARGET_CFLAGS += -fPIC
+endif
+
 define Py3Shebang
 $(SED) "1"'!'"b;s,^#"'!'".*python.*,#"'!'"/usr/bin/python3," -i --follow-symlinks $(1)
 endef


### PR DESCRIPTION
Maintainer:  @commodo & @jefferyto
Compile tested: ARM64, nanoPi Neo Core 2, master
Run tested: ARM64, nanoPi Neo Core 2, master

Description:

The linker error message without this change was: ```relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `_Py_FalseStruct' which may bind externally can not be used when making a shared object; recompile with -fPIC```