### PR TITLE
banIP: update 0.3.8

### DIFF
--- a/net/banip/Makefile
+++ b/net/banip/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=banip
-PKG_VERSION:=0.3.7
+PKG_VERSION:=0.3.8
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/banip/files/banip.hotplug
+++ b/net/banip/files/banip.hotplug
@@ -1,7 +1,10 @@
 #!/bin/sh
 #
-
 [ "${ACTION}" != "add" ] && exit 0
+
+ban_iface="wan"
+[ -r "/lib/functions/network.sh" ] && { . "/lib/functions/network.sh"; network_find_wan ban_iface; }
+[ "${INTERFACE}" != "${ban_iface}" ] && exit 0
 
 ban_pidfile="/var/run/banip.pid"
 ban_enabled="$(/etc/init.d/banip enabled; printf "%u" "${?}")"

--- a/net/banip/files/banip.sh
+++ b/net/banip/files/banip.sh
@@ -13,7 +13,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-ban_ver="0.3.7"
+ban_ver="0.3.8"
 ban_basever=""
 ban_enabled=0
 ban_automatic="1"


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL.iNet GL-AR300M (NOR), OpenWrt SNAPSHOT r11447-f098c612b6

Description:
* limit firewall hotplug trigger to certain wan 'INTERFACE' as well,
  to prevent possible race conditions during boot

Signed-off-by: Dirk Brenken <dev@brenken.org>

