### PR TITLE
gcc: fix build with 8.3.0

### DIFF
--- a/devel/gcc/patches/020-disable-check-for-sys-sdt-h.patch
+++ b/devel/gcc/patches/020-disable-check-for-sys-sdt-h.patch
@@ -1,0 +1,46 @@
+@@ -0,0 +1,45 @@
+diff --git a/gcc/configure b/gcc/configure
+index 3793681..bcda752 100755
+--- a/gcc/configure
++++ b/gcc/configure
+@@ -26876,19 +26876,6 @@ $as_echo "#define TARGET_LIBC_PROVIDES_SSP 1" >>confdefs.h
+
+ fi
+
+-# Test for <sys/sdt.h> on the target.
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking sys/sdt.h in the target C library" >&5
+-$as_echo_n "checking sys/sdt.h in the target C library... " >&6; }
+-have_sys_sdt_h=no
+-if test -f $target_header_dir/sys/sdt.h; then
+-  have_sys_sdt_h=yes
+-
+-$as_echo "#define HAVE_SYS_SDT_H 1" >>confdefs.h
+-
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_sys_sdt_h" >&5
+-$as_echo "$have_sys_sdt_h" >&6; }
+
+ # Check if TFmode long double should be used by default or not.
+ # Some glibc targets used DFmode long double, but with glibc 2.4
+diff --git a/gcc/configure.ac b/gcc/configure.ac
+index 3ee1d67..e321218 100644
+--- a/gcc/configure.ac
++++ b/gcc/configure.ac
+@@ -4796,16 +4796,6 @@ if test x$gcc_cv_libc_provides_ssp = xyes; then
+ 	    [Define if your target C library provides stack protector support])
+ fi
+
+-# Test for <sys/sdt.h> on the target.
+-GCC_TARGET_TEMPLATE([HAVE_SYS_SDT_H])
+-AC_MSG_CHECKING(sys/sdt.h in the target C library)
+-have_sys_sdt_h=no
+-if test -f $target_header_dir/sys/sdt.h; then
+-  have_sys_sdt_h=yes
+-  AC_DEFINE(HAVE_SYS_SDT_H, 1,
+-            [Define if your target C library provides sys/sdt.h])
+-fi
+-AC_MSG_RESULT($have_sys_sdt_h)
+
+ # Check if TFmode long double should be used by default or not.
+ # Some glibc targets used DFmode long double, but with glibc 2.4

--- a/devel/gcc/patches/970-replace-memcpy-memset.patch
+++ b/devel/gcc/patches/970-replace-memcpy-memset.patch
@@ -1,0 +1,44 @@
+diff --recursive -u gcc-7.4.0-vanilla/libitm/beginend.cc gcc-7.4.0/libitm/beginend.cc
+--- gcc-7.4.0-vanilla/libitm/beginend.cc	2017-01-01 07:07:43.905435000 -0500
++++ gcc-7.4.0/libitm/beginend.cc	2019-11-09 00:31:10.093128945 -0500
+@@ -431,7 +431,7 @@
+   // Save everything that we might have to restore on restarts or aborts.
+   jb = tx->jb;
+   undolog_size = tx->undolog.size();
+-  memcpy(&alloc_actions, &tx->alloc_actions, sizeof(alloc_actions));
++  alloc_actions = tx->alloc_actions;
+   user_actions_size = tx->user_actions.size();
+   id = tx->id;
+   prop = tx->prop;
+@@ -449,7 +449,7 @@
+   // commits of nested transactions. Allocation actions must be committed
+   // before committing the snapshot.
+   tx->jb = jb;
+-  memcpy(&tx->alloc_actions, &alloc_actions, sizeof(alloc_actions));
++  tx->alloc_actions = alloc_actions;
+   tx->id = id;
+   tx->prop = prop;
+ }
+@@ -485,7 +485,7 @@
+       prop = cp->prop;
+       if (cp->disp != abi_disp())
+ 	set_abi_disp(cp->disp);
+-      memcpy(&alloc_actions, &cp->alloc_actions, sizeof(alloc_actions));
++      alloc_actions = cp->alloc_actions;
+       nesting = cp->nesting;
+     }
+   else
+diff --recursive -u gcc-7.4.0-vanilla/libitm/method-ml.cc gcc-7.4.0/libitm/method-ml.cc
+--- gcc-7.4.0-vanilla/libitm/method-ml.cc	2017-01-01 07:07:43.905435000 -0500
++++ gcc-7.4.0/libitm/method-ml.cc	2019-11-09 01:12:58.674388557 -0500
+@@ -138,7 +138,9 @@
+     // This store is only executed while holding the serial lock, so relaxed
+     // memory order is sufficient here.  Same holds for the memset.
+     time.store(0, memory_order_relaxed);
+-    memset(orecs, 0, sizeof(atomic<gtm_word>) * L2O_ORECS);
++    void *p = orecs;
++    memset(p, 0, sizeof(atomic<gtm_word>) * L2O_ORECS);
++
+   }
+ };
+ 


### PR DESCRIPTION
Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: @noblepepper
Compile tested: x86_64 master

Description:
Seems to resolve https://github.com/openwrt/packages/issues/10198. This could fix the GCC package build until it is updated to match the toolchain version.