### PR TITLE
pdns-recursor: add temporary depends to fix build

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -25,7 +25,7 @@ define Package/pdns-recursor
   SUBMENU:=IP Addresses and Names
   USERID:=pdns:pdns
   TITLE:=PowerDNS Recursor
-  DEPENDS:=+boost +boost-context +libatomic +liblua +libopenssl +protobuf
+  DEPENDS:=+boost +boost-context +boost-thread +libatomic +liblua +libopenssl +protobuf
   URL:=https://www.powerdns.com/recursor.html
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A (Dependency is not used)
Run tested: N/A (Dependency is not used)

Description:

There is an issue with the included build scripts which improperly check for a
requirement on libboost-thread where another implementation is available.

This only affects the bundled boost.m4 from https://github.com/tsuna/boost.m4 which is distributed
along with pdns-recursor. I will be working on a separate fix for the M4 macro later.

Signed-off-by: James Taylor <james@jtaylor.id.au>

Fixes #10273.
