### PR TITLE
phython-requests-oauthlib: bump to v1.3.0

### DIFF
--- a/lang/python/python-requests-oauthlib/Makefile
+++ b/lang/python/python-requests-oauthlib/Makefile
@@ -6,15 +6,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-requests-oauthlib
-PKG_VERSION:=1.2.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.3.0
+PKG_RELEASE:=1
 
-PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=LICENSE
 
 PYPI_NAME:=requests-oauthlib
-PKG_HASH:=bd6533330e8748e94bf0b214775fed487d309b8b8fe823dc45641ebcd9a32f57
+PKG_HASH:=b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, WRT3200ACM, openwrt master
Run tested: mvebu, WRT3200ACM, openwrt master, run seafile-server, login using github (uses requests-oauthlib), upload/download files (uses libevhtp)

Description:

#### Changes in requests-oauthlib 1.3.0:
- Instagram compliance fix
- Added force_querystring argument to fetch_token() method on  OAuth2Session
---
#### PS:
Never mind the noise abouth libevent2-pthreads.  It's still there, but it must be selected to be built and used by libevhtp.  At least in the basic case it works without it, but I haven't tested it--and can't really study it--deeply enough to figure out what it misses out (if anything).  The bots will always build `libevent2-phtreads`, so for most people, libevhtp has always been built with it.

I will keep this simple, and leave it as the python-requests-oauthlib bump, and then open another one for the seafile-server changes--it is the one that needs to select `libevent2-pthreads`, since `libevhtp` is not a selectable package, so it's dependencies do not force the package's selection.

~This was originally only the `python-requests-oauthlib` bump, but then I realized `libevhtp` was not building, so I ended creating a series for it.  I maintain both affected packages, and changes are slim, so it should not be too bad to review.~
~seafile-server links to libevhtp statically, so it gets a `PKG_RELEASE` bump as well, and nothing more than that--ok this brushes @commodo, but I do hope it won't bother him too much.~

#### ~Changes in libevhtp & seafile-server packages:~
~- The `libevhtp` change just empties `LIBEVENT_THREAD`, so it does not try to find the now non-existent `libevent2-pthreads` in current version of libevent (2.1.11).~

~- Note that `libevhtp` does not generate an installable package.  Instead, it ends up statically linked to `seafile-server`, so that's the package that gets changed by the update, and hence its `PKG_RELEASE` bump.~
