### PR TITLE
seafile-server: depend on libevent2-threads

### DIFF
--- a/net/seafile-server/Makefile
+++ b/net/seafile-server/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-server
 PKG_VERSION:=6.3.4
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_LICENSE:=GPL-3.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -40,8 +40,8 @@ define Package/seafile-server
     TITLE:=Seafile server
     URL:=https://seafile.com/
     DEPENDS:=+libarchive +libopenssl +glib2 +libsearpc +seafile-ccnet +seafile-seahub +sqlite3-cli \
-		+python-mysqlclient +python-urllib3 \
-		+jansson +libevent2 +libevent2-openssl +zlib +libzdb +libsqlite3 +libmysqlclient +oniguruma \
+		+python-mysqlclient +python-urllib3 +jansson +libevent2 +libevent2-openssl \
+		+libevent2-pthreads +zlib +libzdb +libsqlite3 +libmysqlclient +oniguruma \
 		+libpthread +libuuid +bash +procps-ng +procps-ng-pkill +SEAFILE_FUSE_SUPPORT:libfuse $(ICONV_DEPENDS)
     MENU:=1
 endef


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: mvebu, WRT3200ACM, openwrt master
Run tested: mvebu, WRT3200ACM, openwrt master; run seafile-server, login, upload & download some files.

Description:
seafile-server uses libevhtp pthreads support.  libevhtp needs libevent2-pthreads for that. However, since there is no installable package for libevhtp--the library is build static-only--then
seafile-server, its consumer, needs to add the dependecy.

There are calls to thread functions in , and by looking at the libevhtp code, they are turned to noop, so libevhtp needs to be built with threads.  Apparently, the thread code is linked statically, so in theory, there should be no need to include the shared library.  However, I don't know a way to force it to be built, other than to include `libevent2-pthreads` as a dependency.  I can't see a scenario where one would install seafile in a space-constrained device  (seahub itself is over 20MB), so a 2.7kB extra won't make that much difference.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
