### PR TITLE
atop: update to version 2.5.0

### DIFF
--- a/admin/atop/Makefile
+++ b/admin/atop/Makefile
@@ -7,10 +7,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=atop
 PKG_RELEASE:=1
-PKG_VERSION:=2.4.0
-PKG_LICENSE:=GPL-2.0
+PKG_VERSION:=2.5.0
+PKG_LICENSE:=GPL-2.0-or-later
 PKG_SOURCE_URL:=https://www.atoptool.nl/download/
-PKG_HASH:=be1c010a77086b7d98376fce96514afcd73c3f20a8d1fe01520899ff69a73d69
+PKG_HASH:=4b911057ce50463b6e8b3016c5963d48535c0cddeebc6eda817e292b22f93f33
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_MAINTAINER:=Toni Uhlig <matzeton@googlemail.com>


### PR DESCRIPTION
Signed-off-by: Toni Uhlig matzeton@googlemail.com

Maintainer: me
Compile tested: x86_64, debian-stable, OpenWrt SNAPSHOT r10907+8-6cea9688af
Run tested: mvebu, linksys3200ac, OpenWrt SNAPSHOT r10907+8-6cea9688af

Description: