### PR TITLE
python-paho-mqtt: Update to version 1.5.0

### DIFF
--- a/lang/python/python-paho-mqtt/Makefile
+++ b/lang/python/python-paho-mqtt/Makefile
@@ -5,13 +5,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-paho-mqtt
-PKG_VERSION:=1.4.0
+PKG_VERSION:=1.5.0
 PKG_RELEASE:=1
-PKG_LICENSE:=Eclipse Public License v1.0 / Eclipse Distribution License v1.0
+
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>, Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=EPL-1.0 Eclipse Distribution License v1.0
+PKG_LICENSE_FILES:=epl-v10 edl-v10
 
 PYPI_NAME:=paho-mqtt
-PKG_HASH:=e440a052b46d222e184be3be38676378722072fcd4dfd2c8f509fb861a7b0b79
+PKG_HASH:=e3d286198baaea195c8b3bc221941d25a3ab0e1507fc1779bdb7473806394be4
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainers: me and @commodo 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:

- Update to version [1.5.0](https://github.com/eclipse/paho.mqtt.python/blob/4240002ac8d1ea4156ea1135ae89d717341a6372/ChangeLog.txt)
- Try to fix license according to SPDX.
- Add PKG_LICENSE_FILES.


