### PR TITLE
p11-kit: update to 0.23.18.1

### DIFF
--- a/libs/p11-kit/Makefile
+++ b/libs/p11-kit/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=p11-kit
-PKG_VERSION:=0.23.17
+PKG_VERSION:=0.23.18.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/p11-glue/p11-kit/releases/download/$(PKG_VERSION)
-PKG_HASH:=5447b25d66c05f86cce5bc8856f7a074be84c186730e32c74069ca03386d7c1e
+PKG_HASH:=34c3bd8c0050dd7c4e6228aecf0f168de0a1b34562ddbf74a1c70904c2523c6f
 
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: @nmav 
Compile tested: ipq40xx
Run tested: ipq40xx, with OpenConnect

Description:
Update p11-kit to 0.23.18.1