### PR TITLE
mwan3 - `json_load` fails with some data

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.0
-PKG_RELEASE:=2
+PKG_VERSION:=2.8.1
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2
 

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -63,7 +63,7 @@ ifup()
 
 	status=$(ubus -S call network.interface.$1 status)
 	[ -n "$status" ] && {
-		json_load $status
+		json_load "$status"
 		json_get_vars up l3_device 
 	}
 


### PR DESCRIPTION
In my system `ubus -S call network.interface.wan status` returns the following data:
```
{"up":true,"pending":false,"available":true,"autostart":true,"dynamic":false,"uptime":2437,"l3_device":"eth0.2","proto":"dhcp","device":"eth0.2","metric":30,"dns_metric":0,"delegation":true,"ipv4-address":[{"address":"84.248.177.219","mask":20}],"ipv6-address":[],"ipv6-prefix":[],"ipv6-prefix-assignment":[],"route":[{"target":"0.0.0.0","mask":0,"nexthop":"84.248.176.1","source":"84.248.177.219\/32"}],"dns-server":["193.210.18.18","193.210.19.19"],"dns-search":[],"inactive":{"ipv4-address":[],"ipv6-address":[],"route":[],"dns-server":[],"dns-search":[]},"data":{"hostname":"OpenWrt","leasetime":1200,"ntpserver":"192.89.123.26 192.89.123.230"}}
```
For some reason which I did not figure out, this cause `json_load` to return `Failed to parse message data` error. 

The end result is `mwan3` using wrong interface name... as explained here:
https://forum.openwrt.org/t/mwan3-interface-wan-is-offline-and-tracking-is-down

The fix is to simply put `$status` into quotes `"$status"`. I found out that in all other OpenWRT scripts the data is inside quotes when calling `json_load`

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
