### PR TITLE
nextdns: add DNS over HTTPS with NextDNS integration

### DIFF
--- a/net/nextdns/Makefile
+++ b/net/nextdns/Makefile
@@ -1,0 +1,75 @@
+#
+# Copyright (C) 2019 NextDNS Inc
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nextdns
+PKG_VERSION:=1.1.1
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/nextdns/nextdns.git
+PKG_MIRROR_HASH:=7dba6ed825913fe05ae699ab3b7137dfc0231c23ac6f554410b311c507d837bd
+
+PKG_MAINTAINER:=Olivier Poitrey <rs@nextdns.io>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/nextdns/nextdns
+GO_PKG_LDFLAGS:=-s -w
+GO_PKG_LDFLAGS_X:=main.version=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/nextdns
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=NextDNS DNS over HTTPS Proxy
+  URL:=https://github.com/nextdns/nextdns
+  DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+endef
+
+define Package/nextdns/install
+	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
+
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nextdns $(1)/usr/sbin/
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/nextdns.init $(1)/etc/init.d/nextdns
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/nextdns.config $(1)/etc/config/nextdns
+endef
+
+define Package/nextdns/description
+  Official NextDNS DNS over HTTPS Proxy.
+endef
+
+define Package/golang-github-nextdns-nextdns-dev
+$(call Package/nextdns)
+$(call GoPackage/GoSubMenu)
+  TITLE+= (source files)
+  PKGARCH:=all
+endef
+
+define Package/golang-github-nextdns-nextdns-dev/description
+$(call Package/nextdns/description)
+
+  This package provides the source files for the client/bridge program.
+endef
+
+$(eval $(call GoBinPackage,nextdns))
+$(eval $(call BuildPackage,nextdns))
+$(eval $(call GoSrcPackage,golang-github-nextdns-nextdns-dev))
+$(eval $(call BuildPackage,golang-github-nextdns-nextdns-dev))

--- a/net/nextdns/files/nextdns.config
+++ b/net/nextdns/files/nextdns.config
@@ -1,0 +1,21 @@
+config nextdns main
+    option enabled '1'
+
+    # NextDNS custom configuration id (create on on https://nextdns.io).
+    # If not defined, this package will act as a non-logging, non-filtering
+    # DNS over HTTPS resolver.
+    # option config abcdef
+
+    # Listen on a custom local port so a DNS front (like dnsmasq) can use us as
+    # a forwarder.
+    option listen '127.0.0.1:5342'
+
+    # Expose LAN clients information in NextDNS analytics.
+    option report_client_info '1'
+
+    # When enabled, use DNS servers located in jurisdictions with strong privacy laws.
+    # Available locations are: Switzerland, Iceland, Finland, Panama and Hong Kong.
+    option hardened_privacy '0'
+
+    # Log individual queries to system log.
+    option log_queries '0'

--- a/net/nextdns/files/nextdns.init
+++ b/net/nextdns/files/nextdns.init
@@ -1,0 +1,69 @@
+#!/bin/sh /etc/rc.common
+
+# shellcheck disable=SC2034 disable=SC2154
+
+USE_PROCD=1
+
+# starts after network starts
+START=21
+# stops before networking stops
+STOP=89
+
+PROG=/usr/sbin/nextdns
+
+add_dnsmasq_opt() {
+        mkdir -p /tmp/dnsmasq.d
+        echo "$1" >> /tmp/dnsmasq.d/nextdns.conf
+}
+
+dnsmasq_reload() {
+        # Reload dnsmasq is already running.
+        if /etc/init.d/dnsmasq running; then
+                /etc/init.d/dnsmasq reload
+        fi
+}
+
+start_service() {
+        config_load nextdns
+        config_get_bool enabled main enabled "1"
+        rm -f /tmp/dnsmasq.d/nextdns.conf
+        if [ "$enabled" = "1" ]; then
+                config_get config main config ""
+                config_get listen main listen "127.0.0.1:5342"
+                config_get_bool report_client_info main report_client_info "1"
+                config_get_bool hardened_privacy main hardened_privacy "0"
+                config_get_bool log_queries main log_queries "0"
+
+                # Add a custom configuration for dnsmasq.
+                server=$(echo "$listen" | sed -e 's/:/#/')
+                add_dnsmasq_opt "server=$server"
+                add_dnsmasq_opt "no-resolv"
+                if [ "$report_client_info" = "1" ]; then
+                        add_dnsmasq_opt "add-mac"
+                        add_dnsmasq_opt "add-subnet=32,128"
+                fi
+
+                procd_open_instance
+                procd_set_param command "$PROG" run \
+                        -listen="$listen" \
+                        -config="$config" \
+                        -report-client-info="$report_client_info" \
+                        -hardened-privacy="$hardened_privacy" \
+                        -log-queries="$log_queries"
+                procd_set_param stdout 1
+                procd_set_param stderr 1
+                procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
+                procd_close_instance
+        fi
+
+        dnsmasq_reload
+}
+
+stop_service() {
+        rm -f /tmp/dnsmasq.d/nextdns.conf
+        dnsmasq_reload
+}
+
+service_triggers() {
+        procd_add_reload_trigger "nextdns"
+}


### PR DESCRIPTION
Maintainer: @rs

Signed-off-by: Olivier Poitrey <rs@nextdns.io>

Description:

Adding support for [NextDNS](https://nextdns.io), a DNS over HTTPS service that provides customized block-lists (ad-block, malware protection, kid safety) as well advanced analytics amongst other things.