### PR TITLE
opennhrp: return

### DIFF
--- a/net/opennhrp/Makefile
+++ b/net/opennhrp/Makefile
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2009-2015 OpenWrt.org
+# Copyright (C) 2009 Jakob Pfeiffer
+# Copyright (C) 2014 Artem Makhutov
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=opennhrp
+PKG_VERSION:=0.14.1
+PKG_RELEASE:=2
+PKG_MAINTAINER:=Artem Makhutov <artem@makhutov.org>
+PKG_LICENSE:=MIT License
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=@SF/opennhrp
+PKG_HASH:=1517d53d688ffc165a1da20c344d96b4c53e60f34bd73c64e60cb67cfca4e9ab
+
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/opennhrp
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=VPN
+  DEPENDS:=+libcares +ip +kmod-gre
+  KCONFIG:=CONFIG_ARPD=y
+  TITLE:=NBMA Next Hop Resolution Protocol
+  URL:=http://opennhrp.sourceforge.net/
+endef
+
+define Package/opennhrp/description
+  OpenNHRP implements NBMA Next Hop Resolution Protocol (as defined in RFC 2332).
+  It makes it possible to create dynamic multipoint VPN Linux router using NHRP,
+  GRE and IPsec. It aims to be Cisco DMVPN compatible.
+endef
+
+define Package/opennhrp/conffiles
+/etc/opennhrp/opennhrp.conf
+endef
+
+define Package/opennhrp/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/opennhrp{,ctl} $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/opennhrp
+	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/opennhrp/opennhrp.conf $(1)/etc/opennhrp/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/etc/opennhrp/opennhrp-script $(1)/etc/opennhrp/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/opennhrp.init $(1)/etc/init.d/opennhrp
+endef
+
+$(eval $(call BuildPackage,opennhrp))

--- a/net/opennhrp/files/opennhrp.init
+++ b/net/opennhrp/files/opennhrp.init
@@ -1,0 +1,15 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2009-2011 OpenWrt.org
+# Copyright (C) 2009 Jakob Pfeiffer
+
+START=50
+
+SERVICE_USE_PID=1
+
+start() {
+	service_start /usr/sbin/opennhrp -d
+}
+
+stop() {
+	service_stop /usr/sbin/opennhrp
+}

--- a/net/opennhrp/patches/100-musl-compat.patch
+++ b/net/opennhrp/patches/100-musl-compat.patch
@@ -1,0 +1,20 @@
+--- a/nhrp/opennhrp.c
++++ b/nhrp/opennhrp.c
+@@ -9,6 +9,7 @@
+ #include <ctype.h>
+ #include <stdio.h>
+ #include <errno.h>
++#include <fcntl.h>
+ #include <malloc.h>
+ #include <stddef.h>
+ #include <string.h>
+--- a/nhrp/nhrp_common.h
++++ b/nhrp/nhrp_common.h
+@@ -12,6 +12,7 @@
+ #include <stdint.h>
+ #include <stdlib.h>
+ #include <sys/time.h>
++#include <sys/types.h>
+ #include <linux/if_ether.h>
+ 
+ struct nhrp_interface;

--- a/net/opennhrp/patches/200-remove-racoon.patch
+++ b/net/opennhrp/patches/200-remove-racoon.patch
@@ -1,0 +1,17 @@
+--- a/etc/opennhrp-script
++++ b/etc/opennhrp-script
+@@ -13,14 +13,9 @@ peer-up)
+ 		ip route add $ARGS proto 42 mtu $NHRP_DESTMTU
+ 	fi
+ 	echo "Create link from $NHRP_SRCADDR ($NHRP_SRCNBMA) to $NHRP_DESTADDR ($NHRP_DESTNBMA)"
+-	racoonctl establish-sa -w isakmp inet $NHRP_SRCNBMA $NHRP_DESTNBMA || exit 1
+-	racoonctl establish-sa -w esp inet $NHRP_SRCNBMA $NHRP_DESTNBMA gre || exit 1 
+ 	;;
+ peer-down)
+ 	echo "Delete link from $NHRP_SRCADDR ($NHRP_SRCNBMA) to $NHRP_DESTADDR ($NHRP_DESTNBMA)"
+-	if [ "$NHRP_PEER_DOWN_REASON" != "lower-down" ]; then
+-		racoonctl delete-sa isakmp inet $NHRP_SRCNBMA $NHRP_DESTNBMA
+-	fi
+ 	ip route del $NHRP_DESTNBMA src $NHRP_SRCNBMA proto 42
+ 	;;
+ route-up)


### PR DESCRIPTION
And removing ipsec-tools dependencies
OpenNHRP can work with strongswan or libreswan
and completely without IPSec.

This partialy reverts commit 4dcb01af8dd2eef7c6edcbc2d224940e1cb03065.

Signed-off-by: Vasya Borisov <vasy@vasy.ru>

Compile tested: (mips, x86_64, OpenWrt master)
Run tested: (mips, x86_64, OpenWrt master, tests done)
