### PR TITLE
mwan3: add https ping possibility and a minor fix

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
-PKG_LICENSE:=GPLv2
+PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.1
+PKG_VERSION:=2.8.2
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -1004,7 +1004,7 @@ mwan3_set_user_iptables_rule()
 			case $proto in
 				tcp|udp)
 				[ "$global_logging" = "1" ] && [ "$rule_logging" = "1" ] && {
-					$IPT -A mwan3_rules \
+					$IPT4 -A mwan3_rules \
 						-p $proto \
 						-s $src_ip \
 						-d $dest_ip $ipset \

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -61,7 +61,7 @@ main() {
 	local recovery_interval down up size
 	local keep_failure_interval check_quality failure_latency
 	local recovery_latency failure_loss recovery_loss
-	local max_ttl
+	local max_ttl httping_ssl
 
 	[ -z "$5" ] && echo "Error: should not be started manually" && exit 0
 
@@ -75,6 +75,7 @@ main() {
 
 	config_load mwan3
 	config_get track_method $1 track_method ping
+	config_get_bool httping_ssl $1 httping_ssl 0
 	validate_track_method $track_method $SRC_IP || {
 		track_method=ping
 		if validate_track_method $track_method; then
@@ -149,7 +150,11 @@ main() {
 						result=$?
 					;;
 					httping)
-						httping -y $SRC_IP -c $count -t $timeout -q $track_ip &> /dev/null
+						if [ "$httping_ssl" -eq 1 ]; then
+							httping -y $SRC_IP -c $count -t $timeout -q "https://$track_ip" &> /dev/null
+						else
+							httping -y $SRC_IP -c $count -t $timeout -q "http://$track_ip" &> /dev/null
+						fi
 						result=$?
 					;;
 					nping-tcp)


### PR DESCRIPTION
Maintainer: me
Compile tested: not needed only script changes
Run tested: x86_64, APU3

Description:
With this change it is possible to ping https targets if tracking method httping is selected for tracking