### PR TITLE
xtables-addons: disable ASLR PIE

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -24,6 +24,7 @@ PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=GPL-2.0
 
 PKG_FIXUP:=autoreconf
+PKG_ASLR_PIE:=0
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: (lantiq/xrx200, own, latest openwrt-19.07)

Description:
This package uses ld for linking and therefor does not support the
-specs option.
