### PR TITLE
[OpenWrt 18.06] tor: update to version 4.1.6

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2016 OpenWrt.org
+# Copyright (C) 2008-2019 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,17 +8,21 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.3.2.10
+PKG_VERSION:=0.4.1.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=60df77c31dcf94fdd686c8ca8c34f3b70243b33a7344ecc0b719d5ca2617cbee
-PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de>
+PKG_HASH:=2a88524ce426079fb9b828bc1b789f2c8ade3ed53c130851102debc3518bed71
+PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
+		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:torproject:tor
 
 PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -67,7 +71,7 @@ endef
 
 define Package/tor-resolve/description
 $(call Package/tor/Default/description)
- Resolve a hostname to an IP address via tor 
+ Resolve a hostname to an IP address via tor
 endef
 
 define Package/tor-geoip
@@ -89,25 +93,25 @@ endef
 
 CONFIGURE_ARGS += \
 	--with-libevent-dir="$(STAGING_DIR)/usr" \
-	--with-ssl-dir="$(STAGING_DIR)/usr" \
 	--with-openssl-dir="$(STAGING_DIR)/usr" \
 	--with-zlib-dir="$(STAGING_DIR)/usr" \
 	--disable-asciidoc \
 	--disable-seccomp \
 	--disable-libscrypt \
 	--disable-unittests \
-	--disable-largefile \
 	--disable-lzma \
+	--disable-zstd \
 	--with-tor-user=tor \
 	--with-tor-group=tor
 
-EXTRA_CFLAGS += -std=gnu99
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
+TARGET_LDFLAGS += -Wl,--gc-sections -flto
 
 ifneq ($(CONFIG_SSP_SUPPORT),y)
 	CONFIGURE_ARGS += \
 		--disable-gcc-hardening
 else
-	EXTRA_CFLAGS += -fPIC
+	EXTRA_CFLAGS += $(FPIC)
 endif
 
 CONFIGURE_VARS += \
@@ -116,7 +120,6 @@ CONFIGURE_VARS += \
 define Package/tor/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tor $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/torify $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/tor.init $(1)/etc/init.d/tor
 	$(INSTALL_DIR) $(1)/etc/tor
@@ -135,8 +138,10 @@ endef
 
 define Package/tor-geoip/install
 	$(INSTALL_DIR) $(1)/usr/share/tor
-	$(CP) $(PKG_INSTALL_DIR)/usr/share/tor/geoip $(1)/usr/share/tor/
-	$(CP) $(PKG_INSTALL_DIR)/usr/share/tor/geoip6 $(1)/usr/share/tor/
+	$(INSTALL_DATA) \
+	  $(PKG_INSTALL_DIR)/usr/share/tor/geoip \
+	  $(PKG_INSTALL_DIR)/usr/share/tor/geoip6 \
+	$(1)/usr/share/tor/
 endef
 
 $(eval $(call BuildPackage,tor))

--- a/net/tor/files/tor.init
+++ b/net/tor/files/tor.init
@@ -7,19 +7,15 @@ STOP=50
 USE_PROCD=1
 
 start_service() {
-	[ -f /var/run/tor.pid ] || {
-		touch /var/run/tor.pid
-		chown tor:tor /var/run/tor.pid
-	}
-	[ -d /var/lib/tor ] || {
-		mkdir -m 0755 -p /var/lib/tor
-		chmod 0700 /var/lib/tor
-		chown tor:tor /var/lib/tor
-	}
-	[ -d /var/log/tor ] || {
-		mkdir -m 0755 -p /var/log/tor
-		chown tor:tor /var/log/tor
-	}
+	touch /var/run/tor.pid
+	chown tor:tor /var/run/tor.pid
+
+	mkdir -m 0700 -p /var/lib/tor
+	chown -R tor:tor /var/lib/tor
+
+	mkdir -m 0755 -p /var/log/tor
+	chown -R tor:tor /var/log/tor
+
 	procd_open_instance
 	procd_set_param command /usr/sbin/tor --runasdaemon 0
 	procd_close_instance

--- a/net/tor/patches/001-torrc.patch
+++ b/net/tor/patches/001-torrc.patch
@@ -18,7 +18,7 @@
  
  ## The port on which Tor will listen for local connections from Tor
  ## controller applications, as documented in control-spec.txt.
-@@ -227,3 +227,4 @@
+@@ -238,3 +238,4 @@
  #%include /etc/torrc.d/
  #%include /etc/torrc.custom
  


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS4), OpenWrt 18.06
Run tested: Turris Omnia (TOS4), OpenWrt 18.06


Description:
This PR updates Tor package to version 4.1.6 and adds changes from master package.
According to https://blog.torproject.org/removing-end-life-relays-network version 0.3.2.10 is EOL
