### PR TITLE
circleci: Change SDK download host to cdn.openwrt.org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       - image: docker.io/openwrtorg/packages-cci:v1.0.5
     environment:
-      - SDK_HOST: "downloads.openwrt.org"
+      - SDK_HOST: "cdn.openwrt.org"
       - SDK_PATH: "snapshots/targets/ath79/generic"
       - SDK_FILE: "openwrt-sdk-ath79-generic_*.Linux-x86_64.tar.xz"
       - BRANCH: "master"
@@ -86,7 +86,9 @@ jobs:
                      exit 1
                  fi
              fi
-             rsync -av "$SDK_HOST::downloads/$SDK_PATH/$SDK_FILE" .
+             PATTERN=$(echo "$SDK_FILE\$" | sed -e 's/\./\\./g' -e 's/\*/.*/g')
+             FILENAME=$(grep -m1 -o "$PATTERN" sha256sums)
+             curl "https://$SDK_HOST/$SDK_PATH/$FILENAME" -sS -o "$FILENAME"
              sha256sum -c --ignore-missing sha256sums
 
       - run:


### PR DESCRIPTION
Maintainer: @champtar @thess 
Compile tested: N/A
Run tested: N/A

Description:
This also switches from rsync to curl to download the SDK archive.

Fixes #10358.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>