### PR TITLE
nnn: Add a new package

### DIFF
--- a/utils/nnn/Makefile
+++ b/utils/nnn/Makefile
@@ -1,0 +1,38 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nnn
+PKG_VERSION:=2.7
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/jarun/nnn/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=0592c7cbcf2cf66cacac49e9204636480820b1bc74e4187dd7ee06945a6d07c5
+
+PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/nnn
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Full-featured terminal file manager
+  URL:=https://github.com/jarun/nnn
+  DEPENDS:=+libncurses +libreadline +findutils-xargs
+endef
+
+define Package/nnn/description
+  nnn is full-featured tiny terminal file manager and
+  disk usage analyzer, fuzzy app launcher, batch file renamer
+  and file picker.
+endef
+
+define Package/nnn/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nnn $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,nnn))


### PR DESCRIPTION
Maintainer: me and if somebody is interested in this package, feel free to take maintainership of this package
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:

This package was requested on [Reddit](https://www.reddit.com/r/openwrt/comments/dx4aep/request_to_port_nnn_to_openwrt/) to be ported for OpenWrt and as well on [forum OpenWrt](https://forum.openwrt.org/t/nnn-is-a-full-featured-terminal-file-manager/47614). It is an alternative to the mc (Midnight Commander).

The compiled package has size 31,6 kB and for comparison with mc, which has 431,7 kB.

Github repository: https://github.com/jarun/nnn
Some YT video, which shows basic stuff and how to use nnn file-manager: https://www.youtube.com/watch?v=U2n5aGqou9E

Proof of run test:
![Screenshot from 2019-11-17 10-40-34](https://user-images.githubusercontent.com/4096468/69006007-cd3f2c80-0929-11ea-9f92-577113925f5e.png)

The first impression for the user is always important and for it, there is added dependency findutils-xargs, which is required (tested) and listed in [README](https://github.com/jarun/nnn#utility-dependencies). cp, mv, rm works with busybox.

I will create issue in nnn repository to support busybox xargs, because it doesn't recognize option a.