### PR TITLE
domoticz: Fix compilation with newer python

### DIFF
--- a/utils/domoticz/Makefile
+++ b/utils/domoticz/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION_MAJOR:=4
 PKG_VERSION_PATCH:=10717
 PKG_COMMIT:=
 PKG_VERSION:=$(PKG_VERSION_MAJOR).$(PKG_VERSION_PATCH)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 ifeq ($(PKG_COMMIT),)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -54,6 +54,7 @@ define Package/domoticz
 	+libopenzwave \
 	+libsqlite3 \
 	+libstdcpp \
+	+telldus-core \
 	+zlib
 endef
 

--- a/utils/domoticz/patches/010-python.patch
+++ b/utils/domoticz/patches/010-python.patch
@@ -1,0 +1,64 @@
+From e9bd383ceb63db7cfe8a284014f0cdf8c2bfe4f0 Mon Sep 17 00:00:00 2001
+From: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+Date: Fri, 1 Nov 2019 10:54:11 +0100
+Subject: [PATCH] DelayedLink.h: fix build with python 3.8
+
+Fix build with python 3.8 by copy/pasting the vim workaround from
+https://github.com/vim/vim/commit/13a1f3fb0c9d08bba6109fe2131c9524e6ba7e15
+
+Fix 3703
+
+Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+---
+ hardware/plugins/DelayedLink.h | 38 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 38 insertions(+)
+
+diff --git a/hardware/plugins/DelayedLink.h b/hardware/plugins/DelayedLink.h
+index 4bf1973281..c90a7d8e69 100644
+--- a/hardware/plugins/DelayedLink.h
++++ b/hardware/plugins/DelayedLink.h
+@@ -14,6 +14,44 @@
+ #include <frameobject.h>
+ #include "../../main/Helper.h"
+ 
++#if PY_VERSION_HEX >= 0x030800f0
++static inline void
++py3__Py_DECREF(const char *filename, int lineno, PyObject *op)
++{
++	(void)filename; /* may be unused, shut up -Wunused-parameter */
++	(void)lineno; /* may be unused, shut up -Wunused-parameter */
++	_Py_DEC_REFTOTAL;
++	if (--op->ob_refcnt != 0)
++	{
++#ifdef Py_REF_DEBUG
++	if (op->ob_refcnt < 0)
++	{
++		_Py_NegativeRefcount(filename, lineno, op);
++	}
++#endif
++	}
++	else
++	{
++		_Py_Dealloc(op);
++	}
++}
++
++#undef Py_DECREF
++#define Py_DECREF(op) py3__Py_DECREF(__FILE__, __LINE__, _PyObject_CAST(op))
++
++static inline void
++py3__Py_XDECREF(PyObject *op)
++{
++	if (op != NULL)
++	{
++		Py_DECREF(op);
++	}
++}
++
++#undef Py_XDECREF
++#define Py_XDECREF(op) py3__Py_XDECREF(_PyObject_CAST(op))
++#endif
++
+ namespace Plugins {
+ 
+ #ifdef WIN32


### PR DESCRIPTION
Backported upstream patch.

Added telldus-core dependency as it picks it up now.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @stintel 
Compile tested: ath79