### PR TITLE
cifs-utils: Add smbinfo utility

### DIFF
--- a/net/cifs-utils/Makefile
+++ b/net/cifs-utils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cifs-utils
 PKG_VERSION:=6.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://download.samba.org/pub/linux-cifs/cifs-utils/
@@ -20,18 +20,26 @@ PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:debian:cifs-utils
 
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/cifsmount
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+kmod-fs-cifs
-  TITLE:=CIFS mount utilities
+  TITLE:=CIFS mount
   URL:=https://wiki.samba.org/index.php/LinuxCIFS_utils
 endef
 
-TARGET_CFLAGS += $(FPIC) -ffunction-sections -flto
-TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
+define Package/smbinfo
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+kmod-fs-cifs
+  TITLE:=SMB info
+  URL:=https://wiki.samba.org/index.php/LinuxCIFS_utils
+endef
 
 CONFIGURE_ARGS += \
 	--disable-cifsupcall \
@@ -45,9 +53,23 @@ CONFIGURE_ARGS += \
 	--disable-man \
 	--without-libcap
 
+TARGET_CFLAGS += $(FPIC) -ffunction-sections -flto
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/include/cifsidmap.h $(1)/usr/include/
+endef
+
 define Package/cifsmount/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/mount.cifs $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/mount.cifs $(1)/usr/sbin/
+endef
+
+define Package/smbinfo/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/smbinfo $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,cifsmount))
+$(eval $(call BuildPackage,smbinfo))


### PR DESCRIPTION
Switched to PKG_INSTALL for simplicity.

Added PKG_BUILD_PARALLEL for faster compilation.

Added InstallDev section.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ffainelli 
Compile tested: ath79
Run tested: archer c7v2