### PR TITLE
yggdrasil: patch: feature: -address and -subnet

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
 PKG_VERSION:=0.3.11
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?

--- a/net/yggdrasil/patches/001-getaddr-getsnet.patch
+++ b/net/yggdrasil/patches/001-getaddr-getsnet.patch
@@ -1,0 +1,148 @@
+diff --git a/cmd/yggdrasil/main.go b/cmd/yggdrasil/main.go
+index 91cea9a..6158fd9 100644
+--- a/cmd/yggdrasil/main.go
++++ b/cmd/yggdrasil/main.go
+@@ -2,11 +2,13 @@ package main
+ 
+ import (
+ 	"bytes"
++	"crypto/sha512"
+ 	"encoding/hex"
+ 	"encoding/json"
+ 	"flag"
+ 	"fmt"
+ 	"io/ioutil"
++	"net"
+ 	"os"
+ 	"os/signal"
+ 	"strings"
+@@ -20,6 +22,7 @@ import (
+ 	"github.com/kardianos/minwinsvc"
+ 	"github.com/mitchellh/mapstructure"
+ 
++	"github.com/yggdrasil-network/yggdrasil-go/src/address"
+ 	"github.com/yggdrasil-network/yggdrasil-go/src/admin"
+ 	"github.com/yggdrasil-network/yggdrasil-go/src/config"
+ 	"github.com/yggdrasil-network/yggdrasil-go/src/crypto"
+@@ -142,6 +145,8 @@ func main() {
+ 	ver := flag.Bool("version", false, "prints the version of this build")
+ 	logging := flag.String("logging", "info,warn,error", "comma-separated list of logging levels to enable")
+ 	logto := flag.String("logto", "stdout", "file path to log to, \"syslog\" or \"stdout\"")
++	getaddr := flag.Bool("address", false, "returns the IPv6 address as derived from the supplied configuration")
++	getsnet := flag.Bool("subnet", false, "returns the IPv6 subnet as derived from the supplied configuration")
+ 	flag.Parse()
+ 
+ 	var cfg *config.NodeConfig
+@@ -188,6 +193,26 @@ func main() {
+ 	if cfg == nil {
+ 		return
+ 	}
++	// Have we been asked for the node address yet? If so, print it and then stop.
++	switch {
++	case *getaddr:
++		if pubkey, err := hex.DecodeString(cfg.EncryptionPublicKey); err == nil {
++			nodeid := sha512.Sum512(pubkey)
++			fromnodeid := address.AddrForNodeID((*crypto.NodeID)(&nodeid))
++			fmt.Println(net.IP(fromnodeid[:]).String())
++		}
++		return
++	case *getsnet:
++		if pubkey, err := hex.DecodeString(cfg.EncryptionPublicKey); err == nil {
++			nodeid := sha512.Sum512(pubkey)
++			fromnodeid := address.SubnetForNodeID((*crypto.NodeID)(&nodeid))
++			subnet := append(fromnodeid[:], 0, 0, 0, 0, 0, 0, 0, 0)
++			ipnet := net.IPNet{IP: subnet, Mask: net.CIDRMask(64, 128)}
++			fmt.Println(ipnet.String())
++		}
++		return
++	default:
++	}
+ 	// Create a new logger that logs output to stdout.
+ 	var logger *log.Logger
+ 	switch *logto {
+diff --git a/src/multicast/multicast.go b/src/multicast/multicast.go
+index 206edab..4e0b4f3 100644
+--- a/src/multicast/multicast.go
++++ b/src/multicast/multicast.go
+@@ -124,7 +124,9 @@ func (m *Multicast) _stop() error {
+ 	if m.platformhandler != nil {
+ 		m.platformhandler.Stop()
+ 	}
+-	m.sock.Close()
++	if m.sock != nil {
++		m.sock.Close()
++	}
+ 	return nil
+ }
+ 
+diff --git a/src/yggdrasil/search.go b/src/yggdrasil/search.go
+index caa8df7..f52dcbe 100644
+--- a/src/yggdrasil/search.go
++++ b/src/yggdrasil/search.go
+@@ -192,7 +192,7 @@ func (sinfo *searchInfo) checkDHTRes(res *dhtRes) bool {
+ 	finishSearch := func(sess *sessionInfo, err error) {
+ 		if sess != nil {
+ 			// FIXME (!) replay attacks could mess with coords? Give it a handle (tstamp)?
+-			sess.coords = res.Coords
++			sess.Act(sinfo.searches.router, func() { sess.coords = res.Coords })
+ 			sess.ping(sinfo.searches.router)
+ 		}
+ 		if err != nil {
+diff --git a/src/yggdrasil/tcp.go b/src/yggdrasil/tcp.go
+index 7d5b80b..9cca419 100644
+--- a/src/yggdrasil/tcp.go
++++ b/src/yggdrasil/tcp.go
+@@ -299,6 +299,7 @@ func (t *tcp) call(saddr string, options interface{}, sintf string, upgrade *Tcp
+ 				Timeout: time.Second * 5,
+ 			}
+ 			if sintf != "" {
++				dialer.Control = t.getControl(sintf)
+ 				ief, err := net.InterfaceByName(sintf)
+ 				if err != nil {
+ 					return
+diff --git a/src/yggdrasil/tcp_darwin.go b/src/yggdrasil/tcp_darwin.go
+index 9d55a1d..3d0626c 100644
+--- a/src/yggdrasil/tcp_darwin.go
++++ b/src/yggdrasil/tcp_darwin.go
+@@ -26,3 +26,7 @@ func (t *tcp) tcpContext(network, address string, c syscall.RawConn) error {
+ 		return control
+ 	}
+ }
++
++func (t *tcp) getControl(sintf string) func(string, string, syscall.RawConn) error {
++	return t.tcpContext
++}
+diff --git a/src/yggdrasil/tcp_linux.go b/src/yggdrasil/tcp_linux.go
+index 7eda3b5..9ec3c10 100644
+--- a/src/yggdrasil/tcp_linux.go
++++ b/src/yggdrasil/tcp_linux.go
+@@ -29,3 +29,17 @@ func (t *tcp) tcpContext(network, address string, c syscall.RawConn) error {
+ 	// Return nil because errors here are not considered fatal for the connection, it just means congestion control is suboptimal
+ 	return nil
+ }
++
++func (t *tcp) getControl(sintf string) func(string, string, syscall.RawConn) error {
++	return func(network, address string, c syscall.RawConn) error {
++		var err error
++		btd := func(fd uintptr) {
++			err = unix.BindToDevice(int(fd), sintf)
++		}
++		c.Control(btd)
++		if err != nil {
++			t.link.core.log.Debugln("Failed to set SO_BINDTODEVICE:", sintf)
++		}
++		return t.tcpContext(network, address, c)
++	}
++}
+diff --git a/src/yggdrasil/tcp_other.go b/src/yggdrasil/tcp_other.go
+index 44c3d76..7ee4197 100644
+--- a/src/yggdrasil/tcp_other.go
++++ b/src/yggdrasil/tcp_other.go
+@@ -11,3 +11,7 @@ import (
+ func (t *tcp) tcpContext(network, address string, c syscall.RawConn) error {
+ 	return nil
+ }
++
++func (t *tcp) getControl(sintf string) func(string, string, syscall.RawConn) error {
++	return t.tcpContext
++}


### PR DESCRIPTION
Maintainer: @wfleurant 
Compile tested: brcm2708/bcm2711 with SDK
Run tested: tested on rpi4 device

simple feature to output the underlining tunnel prefix (/7 address) and the corresponding routed /64 prefix   

#### /7 network
```
root@meshctl-box042:~# yggdrasil -useconffile /etc/yggdrasil.conf -address
201:4522:2663:d5a6:6198:d6fe:f423:5c44
```
#### /64 network (mesh access for devices without yggdrasil routing daemon) 
```
root@meshctl-box042:~# yggdrasil -useconffile /etc/yggdrasil.conf -subnet
301:4522:2663:d5a6::/64
```
