### PR TITLE
knot: update to version 2.9.1

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=2.9.0
+PKG_VERSION:=2.9.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=df7434eaefbabbf7cca2d6cba5038be48a4668e508215ca197532bac7c9b21a2
+PKG_HASH:=f19121956caa360c387923654f13e4c97b3fb9093d242e110d7e0916b8d8a04d
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Signed-off-by: Jan Hak <jan.hak@nic.cz>

Maintainer: Daniel Salzman / @salzmdan
Compile tested: arm_cortex-a9_vfpv3, Turris Omnia, TurrisOS 5.0-dev 052d1c6
Run tested: arm_cortex-a9_vfpv3, Turris Omnia, TurrisOS 5.0-dev 052d1c6, all tests successful (1 skipped)