### PR TITLE
pcre: Add JIT-support for select architectures

### DIFF
--- a/libs/pcre/Config.in
+++ b/libs/pcre/Config.in
@@ -1,0 +1,11 @@
+config PCRE_JIT_ENABLED
+	bool
+	depends on PACKAGE_libpcre && (arm || i386 || i686 || x86_64 || mips || mipsel || powerpc || sparc)
+	default y if (arm || i686 || x86_64)
+	prompt "Enable JIT compiler support"
+	help
+		Enable JIT (Just-In-Time) compiler support.
+
+		Enabling this option can give an about 10x performance increase on JIT operations. It can be desireable for e.g. high performance Apache mod_rewrite or HA-Proxy reqrep operations.
+
+		However, JIT should _only_ be enabled on architectures that are supported. Enabling JIT on unsupported platforms will result in a compilation failure. A list of supported architectures can be found here: https://pcre.org/original/doc/html/pcrejit.html#SEC3 .

--- a/libs/pcre/Makefile
+++ b/libs/pcre/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pcre
 PKG_VERSION:=8.43
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)
@@ -24,7 +24,9 @@ PKG_FIXUP:=autoreconf
 
 PKG_INSTALL:=1
 
-PKG_CONFIG_DEPENDS := CONFIG_PACKAGE_libpcrecpp
+PKG_CONFIG_DEPENDS:=\
+	CONFIG_PACKAGE_libpcrecpp \
+	CONFIG_PCRE_JIT_ENABLED
 
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
@@ -33,6 +35,10 @@ define Package/libpcre/default
   SECTION:=libs
   CATEGORY:=Libraries
   URL:=https://www.pcre.org/
+endef
+
+define Package/libpcre/config
+  source "$(SOURCE)/Config.in"
 endef
 
 define Package/libpcre
@@ -57,6 +63,7 @@ CONFIGURE_ARGS += \
 	--enable-utf8 \
 	--enable-unicode-properties \
 	--enable-pcre16 \
+	$(if $(CONFIG_PCRE_JIT_ENABLED),--enable-jit,--disable-jit) \
 	--with-match-limit-recursion=16000 \
 	$(if $(CONFIG_PACKAGE_libpcrecpp),--enable,--disable)-cpp
 


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>
Compile tested: ipq806x, x86
Run tested: ipq806x (r7800)

Description: Add JIT (Just-in-Time) compiler support for select architectures
- This commit adds a config-option for JIT in libpcre(1).

- According to research published on https://rust-leipzig.github.io/regex/2017/03/28/comparison-of-regex-engines/ this should give a 10x performance increase on JIT operations which can be desireable for high performance Apache mod_rewrite or haproxy reqrep operations.

- This option is available on all officially supported architecutres which are listed on https://pcre.org/original/doc/html/pcrejit.html#SEC3. Furthermore, it is enabled by default on the following
  architectures: arm, i686, x86_64.