### PR TITLE
fish: Convert to CMake

### DIFF
--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -6,19 +6,22 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fish
 PKG_VERSION:=3.0.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/fish-shell/fish-shell/releases/download/$(PKG_VERSION)
 PKG_HASH:=14728ccc6b8e053d01526ebbd0822ca4eb0235e6487e832ec1d0d22f1395430e
+
 PKG_MAINTAINER:=Curtis Jiang <jqqqqqqqqqq@gmail.com>, Hao Dong <halbertdong@gmail.com>
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:fishshell:fish
 
-PKG_FIXUP:=autoreconf
-PKG_INSTALL:=1
+CMAKE_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/fish
   SECTION:=utils
@@ -36,9 +39,6 @@ define Package/fish/description
   configuration required.
 endef
 
-CONFIGURE_VARS += ac_cv_file__proc_self_stat=yes
-TARGET_CXXFLAGS += -std=c++0x
-
 define Package/fish/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fish $(1)/usr/bin
@@ -55,7 +55,7 @@ grep fish $${IPKG_INSTROOT}/etc/shells || \
     echo "/usr/bin/fish" >> $${IPKG_INSTROOT}/etc/shells
 
     # Backwards compatibility
-    if [[ -e /bin/fish ]] && ([[ ! -L /bin/fish ]] || [[ "$(readlink -fn $${IPKG_INSTROOT}/bin/fish)" != "../$(CONFIGURE_PREFIX)/bin/fish" ]]); then
+    if [ -e /bin/fish ] && { [ ! -L /bin/fish ] || [ "$(readlink -fn $${IPKG_INSTROOT}/bin/fish)" != "../$(CONFIGURE_PREFIX)/bin/fish" ]; }; then
         ln -fs "../$(CONFIGURE_PREFIX)/bin/fish" "$${IPKG_INSTROOT}/bin/fish"
     fi
 endef


### PR DESCRIPTION
CMake is faster and allows to simplify the Makefile slightly. It also
creates a slightly smaller package for some reason.

Fixed license information.

Ran postinst through shellcheck. It was using bashisms.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @haodong 
Compile tested: ath79