### PR TITLE
mariadb: prevent building against uClibc

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -173,13 +173,11 @@ include $(INCLUDE_DIR)/nls.mk
 
 MARIADB_COMMON_DEPENDS := \
 	$(ICONV_DEPENDS) \
-	+libopenssl \
-	+zlib
-
-MARIADB_COMMON_DEPENDS_EXE := \
-	$(MARIADB_COMMON_DEPENDS) \
 	+libatomic \
-	+libstdcpp
+	+libopenssl \
+	+libstdcpp \
+	+zlib \
+	@!USE_UCLIBC
 
 # Pass CPPFLAGS in the CFLAGS as otherwise the build system will
 # ignore them.
@@ -235,7 +233,7 @@ define Package/mariadb-client-base
   $(call Package/mariadb/Default)
   TITLE:=MariaDB database client base
   DEPENDS:=mariadb-common \
-	  $(MARIADB_COMMON_DEPENDS_EXE) \
+	  $(MARIADB_COMMON_DEPENDS) \
 	  +libedit
 endef
 
@@ -286,7 +284,7 @@ endef
 define Package/mariadb-server-base
   $(call Package/mariadb/Default)
   DEPENDS:=mariadb-common \
-	  $(MARIADB_COMMON_DEPENDS_EXE) \
+	  $(MARIADB_COMMON_DEPENDS) \
 	  +libaio \
 	  +liblzma \
 	  +libpcre \


### PR DESCRIPTION
MariaDB 10.4 includes some changes in sql/sql_statistics.cc that require
std::fmin and std::fmax. But these functions aren't available when
libstdc++ is compiled against uClibc, because uClibc doesn't pass the
test when libstdc++ checks for C99 math that supports "TR1" facilities
(macro: GLIBCXX_CHECK_C99_TR1).

Hence compilation fails:

```
[ 90%] Building CXX object sql/CMakeFiles/sql.dir/sql_table.cc.o
/builder/shared-workdir/build/sdk/build_dir/target-arc_archs_uClibc/mariadb-10.4.10/sql/sql_statistics.cc: In member function 'void Column_statistics_collected::finish(ha_rows, double)':
/builder/shared-workdir/build/sdk/build_dir/target-arc_archs_uClibc/mariadb-10.4.10/sql/sql_statistics.cc:2533:20: error: 'fmax' is not a member of 'std'
         val = std::fmax(estimate_total_distincts * (rows - nulls) / rows, 1.0);
```

This commit updates package dependencies to prevent a build against
uClibc. There is no reason to waste CPU cycles on the build bots.

The dependencies are also tidied up. In the past it made sense to define
MARIADB_COMMON_DEPENDS and MARIADB_COMMON_DEPENDS_EXE, because the
server had different dependencies compared to the library. But since the
library is now in its own package we can remove the differentiation.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: ath79, master, dir-825-c1, also checked menuconfig behavior with an uClibc target (arc)
Run tested: N/A, no runtime change (hence no rev bump)

Description:
Hi all,

Compiling the server against uClibc is not possible anymore, due to upstream changes that made it into mariadb 10.4. There may be ways to patch this, but I have no drive to get into this, mostly because I doubt that this is a great loss. Most people are using musl anyway, and from the download statistics it seems people usually get OpenWrt's mariadb packages for x86_64 targets ;) So I can live with simply turning mariadb off when USE_UCLIBC=y.

Best regards,
Seb

P.S.: libmariadb is _not_ affected and compiles fine against uClibc.