### PR TITLE
cifsd: add package cifsd [backport]

### DIFF
--- a/kernel/cifsd/Makefile
+++ b/kernel/cifsd/Makefile
@@ -1,0 +1,53 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cifsd
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/cifsd-team/cifsd.git
+PKG_SOURCE_DATE:=2019-10-31
+PKG_SOURCE_VERSION:=ee91a4ff3472a8953c2d3cf6d3ecaaf93696222c
+PKG_MIRROR_HASH:=0e3661ebe6ae44990f64632969057c21a49f71878b894180dde088a4166e1720
+
+PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/fs-cifsd
+	SUBMENU:=Filesystems
+	TITLE:=CIFS/SMB kernel server support
+	URL:=https://github.com/cifsd-team/cifsd
+	FILES:=$(PKG_BUILD_DIR)/cifsd.ko
+	DEPENDS:= \
+		+kmod-nls-base \
+		+kmod-nls-utf8 \
+		+kmod-crypto-md4 \
+		+kmod-crypto-md5 \
+		+kmod-crypto-hmac \
+		+kmod-crypto-ecb \
+		+kmod-crypto-des \
+		+kmod-crypto-sha256 \
+		+kmod-crypto-cmac \
+		+kmod-crypto-sha512 \
+		+kmod-crypto-aead \
+		+kmod-crypto-ccm
+endef
+
+define KernelPackage/fs-cifsd/description
+	Kernel module for a CIFS/SMBv2,3 fileserver.
+endef
+
+# broken atm (needs CONFIG_KEYS=y)
+#EXTRA_CFLAGS+=-DCONFIG_CIFSD_ACL
+
+define Build/Compile
+	$(KERNEL_MAKE) SUBDIRS="$(PKG_BUILD_DIR)" \
+	EXTRA_CFLAGS="$(EXTRA_CFLAGS)" \
+	CONFIG_CIFS_SERVER=m \
+	modules
+endef
+
+$(eval $(call KernelPackage,fs-cifsd))

--- a/net/cifsd-tools/Makefile
+++ b/net/cifsd-tools/Makefile
@@ -1,0 +1,59 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cifsd-tools
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/cifsd-team/cifsd-tools.git
+PKG_SOURCE_DATE:=2019-11-13
+PKG_SOURCE_VERSION:=0e17afffe8725fabe6e9209e34d8c7c2759353e4
+PKG_MIRROR_HASH:=8ecf590047d30913488d9d2026448131e151df44159623c0aa69c910b74fd646
+
+PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+PKG_REMOVE_FILES:=autogen.sh
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/cifsd-tools
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Filesystem
+  TITLE:=Kernel CIFS/SMB server support and userspace tools
+  URL:=https://github.com/cifsd-team/cifsd-tools
+  DEPENDS:=+kmod-fs-cifsd +glib2 +libnl-core +libnl-genl
+endef
+
+define Package/cifsd-tools/description
+  Userspace tools (cifsd, cifsuseradd, cifsshareadd) for the CIFS/SMB kernel fileserver.
+  The config file location is /etc/cifs/smb.conf
+endef
+
+define Package/cifsd-tools/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcifsdtools.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/{cifsuseradd,cifsshareadd,cifsd} $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/cifs $(1)/etc/init.d
+	$(INSTALL_CONF) ./files/cifsd.config $(1)/etc/config/cifsd
+	$(INSTALL_DATA) ./files/smb.conf.template $(1)/etc/cifs/
+	$(INSTALL_BIN) ./files/cifsd.init $(1)/etc/init.d/cifsd
+	# copy examples until we have a wiki page
+	$(INSTALL_DATA) ./files/cifsd.config.example $(1)/etc/cifs/
+	$(INSTALL_DATA) ./files/smb.conf.help $(1)/etc/cifs/
+endef
+
+define Package/cifsd-tools/conffiles
+/etc/config/cifsd
+/etc/cifs/smb.conf.template
+/etc/cifs/smb.conf
+/etc/cifs/cifsdpwd.db
+endef
+
+$(eval $(call BuildPackage,cifsd-tools))

--- a/net/cifsd-tools/files/cifsd.config
+++ b/net/cifsd-tools/files/cifsd.config
@@ -1,0 +1,2 @@
+config globals
+	option 'description'	'Cifsd on OpenWrt'

--- a/net/cifsd-tools/files/cifsd.config.example
+++ b/net/cifsd-tools/files/cifsd.config.example
@@ -1,0 +1,11 @@
+config globals
+	option 'description'	'Cifsd on OpenWrt'
+
+config share
+	option name 'testshare'
+	option path '/tmp'
+	option guest_ok 'yes'
+	option create_mask '0666'
+	option dir_mask '0777'
+	option writeable 'yes'
+	option force_root '1'

--- a/net/cifsd-tools/files/cifsd.init
+++ b/net/cifsd-tools/files/cifsd.init
@@ -1,0 +1,183 @@
+#!/bin/sh /etc/rc.common
+
+START=98
+USE_PROCD=1
+
+CIFSD_IFACE=""
+
+smb_header()
+{
+	config_get CIFSD_IFACE $1 interface "lan"
+
+	# resolve interfaces
+	local interfaces
+	interfaces=$(
+		. /lib/functions/network.sh
+
+		local net
+		for net in $CIFSD_IFACE; do
+			local device
+			network_is_up $net || continue
+			network_get_device device "$net"
+			echo -n "${device:-$net} "
+		done
+	)
+
+	local workgroup description
+	local hostname
+	hostname="$(cat /proc/sys/kernel/hostname)"
+
+	config_get workgroup		$1 workgroup	"WORKGROUP"
+	config_get description		$1 description	"Cifsd on OpenWrt"
+
+	sed -e "s#|NAME|#$hostname#g" \
+	    -e "s#|WORKGROUP|#$workgroup#g" \
+	    -e "s#|DESCRIPTION|#$description#g" \
+	    -e "s#|INTERFACES|#$interfaces#g" \
+	    /etc/cifs/smb.conf.template > /var/etc/cifs/smb.conf
+
+	[ -e /etc/cifs/smb.conf ] || ln -nsf /var/etc/cifs/smb.conf /etc/cifs/smb.conf
+
+	if [ ! -L /etc/cifs/smb.conf ]; then
+		logger -t 'cifsd' "Local custom /etc/cifs/smb.conf file detected, all UCI/Luci config settings are ignored!"
+	fi
+}
+
+smb_add_share()
+{
+	local name
+	local path
+	local comment
+	local users
+	local create_mask
+	local dir_mask
+	local browseable
+	local read_only
+	local writeable
+	local guest_ok
+	local force_root
+	local write_list
+	local read_list
+	local hide_dot_files
+	local veto_files
+	local inherit_owner
+	local force_create_mode
+	local force_directory_mode
+
+	config_get name $1 name
+	config_get path $1 path
+	config_get comment $1 comment
+	config_get users $1 users
+	config_get create_mask $1 create_mask
+	config_get dir_mask $1 dir_mask
+	config_get browseable $1 browseable
+	config_get read_only $1 read_only
+	config_get writeable $1 writeable
+	config_get guest_ok $1 guest_ok
+	config_get_bool force_root	$1 force_root	0
+	config_get write_list $1 write_list
+	config_get read_list $1 read_list
+	config_get_bool hide_dot_files	$1 hide_dot_files	0
+	config_get veto_files $1 veto_files
+	config_get inherit_owner $1 inherit_owner
+	config_get force_create_mode $1 force_create_mode
+	config_get force_directory_mode $1 force_directory_mode
+
+	[ -z "$name" ] || [ -z "$path" ] && return
+
+	{
+		printf "\n[%s]\n\tpath = %s\n" "$name" "$path"
+		[ -n "$comment" ] && printf "\tcomment = %s\n" "$comment"
+
+		if [ "$force_root" -eq 1 ]; then
+			printf "\tforce user = %s\n" "root"
+			printf "\tforce group = %s\n" "root"
+		else
+			[ -n "$users" ] && printf "\tvalid users = %s\n" "$users"
+		fi
+
+		[ -n "$create_mask" ] && printf "\tcreate mask = %s\n" "$create_mask"
+		[ -n "$dir_mask" ] && printf "\tdirectory mask = %s\n" "$dir_mask"
+		[ -n "$force_create_mode" ] && printf "\tforce create mode = %s\n" "$force_create_mode"
+		[ -n "$force_directory_mode" ] && printf "\tforce directory mode = %s\n" "$force_directory_mode"
+
+		[ -n "$browseable" ] && printf "\tbrowseable = %s\n" "$browseable"
+		[ -n "$read_only" ] && printf "\tread only = %s\n" "$read_only"
+		[ -n "$writeable" ] && printf "\twriteable = %s\n" "$writeable"
+		[ -n "$guest_ok" ] && printf "\tguest ok = %s\n" "$guest_ok"
+		[ -n "$inherit_owner" ] && printf "\tinherit owner = %s\n" "$inherit_owner"
+
+		[ -n "$write_list" ] && printf "\twrite list = %s\n" "$write_list"
+		[ -n "$read_list" ] && printf "\tread list = %s\n" "$read_list"
+
+		[ "$hide_dot_files" -eq 1 ] && printf "\thide dot files = %s\n" "yes"
+		[ -n "$veto_files" ] && printf "\tveto files = %s\n" "$veto_files"
+	} >> /var/etc/cifs/smb.conf
+}
+
+init_config()
+{
+	mkdir -p /var/etc/cifs
+
+	config_load cifsd
+	# allow copy&paste from samba UCI configs (we dont have a cifsd wiki yet)
+	config_foreach smb_header globals
+	config_foreach smb_header samba
+	config_foreach smb_add_share share
+	config_foreach smb_add_share sambashare
+}
+
+service_triggers()
+{
+	PROCD_RELOAD_DELAY=2000
+
+	procd_add_reload_trigger "dhcp" "system" "cifsd"
+
+	local i
+	for i in $CIFSD_IFACE; do
+		procd_add_reload_interface_trigger $i
+	done
+}
+
+start_service()
+{
+	init_config
+
+	if [ ! -e /etc/cifs/smb.conf ]; then
+		logger -t 'cifsd' "missing config /etc/cifs/smb.conf, needs to-be created manually!"
+		exit 1
+	fi
+
+	modprobe cifsd 2> /dev/null
+	if [ ! -e /sys/module/cifsd ]; then
+		logger -t 'cifsd' "modprobe of cifsd module failed, can\'t start cifsd!"
+		exit 1
+	fi
+
+	logger -t 'cifsd' "Starting CIFS/SMB userspace service."
+	procd_open_instance
+	procd_set_param command /usr/sbin/cifsd --n
+	procd_close_instance
+}
+
+stop_service()
+{
+	logger -t 'cifsd' "Stopping CIFSD userspace service."
+	killall cifsd > /dev/null 2>&1
+	sleep 1
+	[ -e /sys/class/cifsd-control/kill_server ] && echo hard > /sys/class/cifsd-control/kill_server
+	sleep 2
+	[ -e /sys/module/cifsd ] && rmmod cifsd > /dev/null 2>&1
+	# With open smb connections rmmod takes longer
+	if [ -e /sys/module/cifsd ]; then
+		sleep 5
+		rmmod cifsd > /dev/null 2>&1
+	fi
+	[ -f /tmp/cifsd.lock ] && rm /tmp/cifsd.lock
+}
+
+reload_service() {
+	stop_service "$@"
+	sleep 1
+	start_service "$@"
+}

--- a/net/cifsd-tools/files/smb.conf.help
+++ b/net/cifsd-tools/files/smb.conf.help
@@ -1,0 +1,173 @@
+;******************************************************************************
+; File to define cifsd configuration parameters which are comparable with
+; samba's ones
+;
+; Supported [global] level parameters list:
+;	- server string
+;		This controls what string will show up in browse lists next
+;		to the machine name
+;	- workgroup
+;		This controls what workgroup your server will appear to be
+;		in when queried by clients
+;	- netbios name
+;		This sets the NetBIOS name by which a SMB server is known.
+;		By default it is the same as the first component of the host's
+;		DNS name. If a machine is a browse server or logon server this
+;		name (or the first component of the hosts DNS name) will be
+;		the name that these services are advertised under.
+;	- server min protocol
+;		This setting controls the minimum protocol version that the
+;		server will allow the client to use.
+;	- server max protocol
+;		The value of the parameter (a string) is the highest protocol
+;		level that will be supported by the server.
+;	- server signing
+;		This controls whether the client is allowed or required to use
+;		SMB1 and SMB2 signing. Possible values are default, auto,
+;		mandatory and disabled.
+;	- guest account
+;		This is a username which will be used for access to services
+;		which are specified as guest ok.
+;	- max active sessions
+;		This option allows the number of simultaneous connections to
+;		a service to be limited.
+;	- ipc timeout
+;		This option specifies the number of seconds server will wait
+;		for the userspace to reply to heartbeat frames. If user space
+;		is down for more than `ipc timeout` seconds the server will
+;		reset itself - close all sessions and all TCP connections.
+;	- restrict anonymous
+;		The setting of this parameter determines whether user and
+;		group list information is returned for an anonymous connection.
+;	- map to guest
+;		This parameter can take four different values, which tell cifsd
+;		what to do with user login requests.(bad user
+;	- bind interfaces only
+;		This global parameter allows the cifsd admin to limit what
+;		interfaces on a machine will serve SMB requests.
+;	- interfaces
+;		This option allows you to override the default network
+;		interfaces list that cifsd will use for browsing. The option
+;		takes only list of interface name.
+;	- deadtime
+;		The value of the parameter (a decimal integer) represents
+;		the number of minutes of inactivity before a connection is
+;		considered dead, and it is disconnected. The deadtime only
+;		takes effect if the number of open files is zero.
+;	- root directory
+;		Sets up a root (base) directory for all shares. In some
+;		sense it's equal to chroot(). When this option set all shares'
+;               paths become relative to root directory, IOW the file name
+;               lookup resolves '/root directory/share path/file path' path.
+;
+; Supported [share] level parameters list:
+;	- comment
+;		comment string to associate with the new share
+;	- path
+;		This parameter specifies a directory to which the user of the
+;		service is to be given access.
+;	- guest ok
+;		If this parameter is yes for a service, then no password is
+;		required to connect to the service.
+;	- read only
+;		If this parameter is yes, then users of a service may not
+;		create or modify files in the service's directory.
+;	- browseable
+;		This controls whether this share is seen in the list of
+;		available shares in a net view and in the browse list.
+;	- write ok
+;	- writeable
+;		Inverted synonym for read only.
+;	- store dos attributes
+;		If this parameter is set cifsd attempts to first read DOS
+;		attributes (SYSTEM, HIDDEN, ARCHIVE or READ-ONLY) from a
+;		filesystem extended attribute, before mapping DOS attributes
+;		to UNIX permission bits (such as occurs with map hidden and
+;		map readonly).
+;	- oplocks
+;		This boolean option tells cifsd whether to issue oplocks
+;		(opportunistic locks) to file open requests on this share.
+;	- create mask
+;		When a file is created, the necessary permissions are calculated
+;		according to the mapping from DOS modes to UNIX permissions, and
+;		the resulting UNIX mode is then bit-wise 'AND'ed with this
+;		parameter.
+;	- directory mask
+;		This parameter is the octal modes which are used when converting
+;		DOS modes to UNIX modes when creating UNIX directories.
+;	- force group
+;		This specifies a UNIX group name that will be assigned as
+;		the default primary group for all users connecting to this
+;		service.
+;	- force user
+;		This specifies a UNIX user name that will be assigned as
+;		the default user for all users connecting to this service.
+;	- hide dot files
+;		This is a boolean parameter that controls whether files starting
+;		with a dot appear as hidden files.
+;	- hosts allow
+;		This parameter is a comma, space, or tab delimited set of hosts
+;		which are permitted to access a service
+;	- hosts deny
+;		The opposite of allow hosts - hosts listed here are NOT
+;		permitted access to services unless the specific services have
+;		their own lists to override this one. Where the lists conflict,
+;		the allow list takes precedence.
+;	- valid users
+;		This is a list of users that should be allowed to login to this
+;		service
+;	- invalid users
+;		This is a list of users that should not be allowed to login to
+;		this service.
+;	- read list
+;		This is a list of users that are given read-only access to
+;		a service.
+;	- write list
+;		This is a list of users that are given read-write access to
+;		a service.
+;	- max connections
+;		This option allows the number of simultaneous connections to
+;		a service to be limited.
+;	- veto files
+;		This is a list of files and directories that are neither visible
+;		nor accessible.
+;
+;		Veto any files containing the word Security,
+;		any ending in .tmp, and any directory containing the
+;		word root.
+;		veto files = /*Security*/*.tmp/*root*/
+;
+;		Veto the Apple specific files that a NetAtalk server
+;		creates.
+;		veto files = /.AppleDouble/.bin/.AppleDesktop/Network Trash Folder/
+;	- inherit owner
+;		The ownership for new files and directories should be controlled
+;		by the ownership of the parent directory.
+;		Valid options are yes or no.
+;	- inherit smack
+;		This parameter can be used to ensure that if smack label exist
+;		on parent directories.
+;		Valid options are yes or no.
+;	- force create mode
+;		This parameter specifies a set of UNIX mode bit permissions
+;		that will always be set on a file created by cifsd.
+;	- force directory mode
+;		This parameter specifies a set of UNIX mode bit permissions
+;		that will always be set on a directory created by cifsd.
+;
+; Rules to update this file:
+;	- Every [share] definition should start on new line
+;	- Every parameter should be indented with single tab
+;	- There should be single spaces around equal (eg: " = ")
+;	- Multiple parameters should be separated with comma
+;		eg: "invalid users = usr1,usr2,usr3"
+;
+; Make sure to configure the server after making changes to this file.
+;******************************************************************************
+
+[global]
+	netbios name = CIFSD
+
+[homes]
+	comment = content server share
+	path = /tmp

--- a/net/cifsd-tools/files/smb.conf.template
+++ b/net/cifsd-tools/files/smb.conf.template
@@ -1,0 +1,9 @@
+[global]
+	netbios name = |NAME|
+	server string = |DESCRIPTION|
+	workgroup = |WORKGROUP|
+	interfaces = |INTERFACES|
+	bind interfaces only = yes
+	ipc timeout = 8
+	deadtime = 15
+	map to guest = Bad User


### PR DESCRIPTION
Maintainer: me
Compile tested: arm, mips (lantiq/xway) (19.07-master)
Run tested: lantiq/xway (19.07-master)

Description:
* backport of cifsd