### PR TITLE
python3: fix build when Blake2 not enabled in OpenSSL

### DIFF
--- a/lang/python/python3/patches/002-fix-blake2-detection.patch
+++ b/lang/python/python3/patches/002-fix-blake2-detection.patch
@@ -5,7 +5,7 @@
  #endif
  
 -#ifdef NID_blake2b512
-+#ifndef OPENSSL_NO_BLAKE2
++#if defined(NID_blake2b512) && !defined(OPENSSL_NO_BLAKE2)
  #define PY_OPENSSL_HAS_BLAKE2 1
  #endif
  


### PR DESCRIPTION
Maintainer: Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>
Compile tested: macOS
Run tested: macOS

This fixes build when Blake2 not enabled in OpenSSL, see the following links for more details:

- Python Issue: https://bugs.python.org/issue38684
- Commit: https://github.com/python/cpython/commit/7c20888e71304ecbf4bd3d595f364b7c691d30a0
