### PR TITLE
[OpenWrt 18.06] bind: update to version 9.11.13 (security fix)

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.11.11
+PKG_VERSION:=9.11.13
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -21,7 +21,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=615230336645e494d0125a3e92cf1c0f956b7408378aca66667b44eaa9de8a6b
+PKG_HASH:=fd3f3cc9fcfcdaa752db35eb24598afa1fdcc2509d3227fc90a8631b7b400f7d
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: Turris Omnia (TOS4), OpenWrt 18.06
Run tested: Turris Omnia (TOS4), OpenWrt 18.06

Description:
Fixes CVE-2019-6477

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>
