### PR TITLE
samba4: add UCI option 'disable_async_io'

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
 PKG_VERSION:=4.9.15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.heanet.ie/mirrors/ftp.samba.org/stable/ \

--- a/net/samba4/files/samba.config
+++ b/net/samba4/files/samba.config
@@ -2,5 +2,3 @@ config samba
 	option 'workgroup'		'WORKGROUP'
 	option 'description'	'Samba on OpenWrt'
 	option 'charset' 		'UTF-8'
-	option 'homes'			'0'
-

--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -33,6 +33,7 @@ smb_header() {
 	config_get_bool DISABLE_NETBIOS	$1 disable_netbios	0
 	config_get_bool DISABLE_AD_DC	$1 disable_ad_dc	0
 	config_get_bool DISABLE_WINBIND	$1 disable_winbind	0
+	config_get_bool DISABLE_ASYNC_IO $1 disable_async_io	0
 
 	mkdir -p /var/etc
 	sed -e "s#|NAME|#$hostname#g" \
@@ -47,20 +48,13 @@ smb_header() {
 		if [ "$DISABLE_NETBIOS" -eq 1 ] || [ ! -x /usr/sbin/nmbd ]; then
 			printf "\tdisable netbios = yes\n"
 		fi
-
-		local homes
-		config_get_bool homes $1 homes 0
-		[ $homes -gt 0 ] && {
-			cat <<EOT
-
-[homes]
-	comment     = Home Directories
-	browsable   = no
-	writable = yes
-	read only   = no
-	create mask = 0750
-EOT
-		}
+		
+		if [ "$DISABLE_ASYNC_IO" -eq 1 ]; then
+			printf "\taio read size = 0\n"
+			printf "\taio write size = 0\n"
+			# sendfile bug: https://bugzilla.samba.org/show_bug.cgi?id=14095
+			printf "\tuse sendfile = no\n"
+		fi
 	} >> /var/etc/smb.conf
 
 	[ -e /etc/samba/smb.conf ] || ln -nsf /var/etc/smb.conf /etc/samba/smb.conf


### PR DESCRIPTION
Maintainer: me
Compile tested: arm (master/ba31208e)
Run tested: arm

Description:
* add UCI option 'disable_async_io'
* remove [homes] options

NOTE: I removed the [homes] options because cifsd is not offering one and openwrt is not designed as a multiuser environment, while we also don't provide any [homes] share related options. So if needed this can still be added to the template, but i think otherwise may just confuse users.