### PR TITLE
cache-domains: Changed to hotplug script

### DIFF
--- a/utils/cache-domains/Makefile
+++ b/utils/cache-domains/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cache-domains
-PKG_VERSION:=1.0.0
+PKG_VERSION:=2.0.0
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
@@ -17,13 +17,16 @@ define Package/cache-domains/default
 endef
 
 define Package/cache-domains/description/default
-Service to dynamically configure the local DNS (dnsmasq) to redirect game content servers to a LAN cache.
+hotplug script to dynamically configure the local DNS (dnsmasq) to redirect game content servers to a LAN cache.
 Definitive list dynamically obtained from https://github.com/uklans/cache-domains.
 endef
 
 define Package/cache-domains/install/default
-	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) ./files/cache-domains.init $(1)/etc/init.d/cache-domains
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) ./files/cache-domains $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface/
+	$(INSTALL_BIN) ./files/30-cache-domains $(1)/etc/hotplug.d/iface/
 endef
 
 Build/Compile=# Nothing to compile, just install the scripts

--- a/utils/cache-domains/README.md
+++ b/utils/cache-domains/README.md
@@ -1,6 +1,6 @@
 # cache-domains
 
-Service to dynamically configure the local DNS (dnsmasq) to redirect game content servers to a LAN cache. Definitive list dynamically obtained from https://github.com/uklans/cache-domains.
+hotplug script to dynamically configure the local DNS (dnsmasq) to redirect game content servers to a LAN cache. Definitive list dynamically obtained from https://github.com/uklans/cache-domains.
 
 ## Configuration
 Configuration file follows the same [syntax as the upsteam file](https://github.com/uklans/cache-domains/blob/master/scripts/config.example.json). The key for each `cache_domain` member matches the name of one of the `.txt` files in the [upstream root directory](https://github.com/uklans/cache-domains/blob/master/), except for the `default` key which matches the all the unreferenced `.txt` files. The value of each `cache_domain` member maps to one of the keys of the `ips` members, Thus mapping a cached domain to a list of IP addresses/LAN cache server.
@@ -23,8 +23,8 @@ Configuration file follows the same [syntax as the upsteam file](https://github.
 }
 ```
 
-## Startup/Shutdown
-On start the local DNS (dnsmasq) will be configured to redirect the configured cache domains and on stop the redirection will be removed.
+## Configure/Cleanup
+`/usr/bin/cache-domains configure` will configure the local DNS (dnsmasq) to redirect the configured cache domains. `/usr/bin/cache-domains cleanup` will cleanup redirection. The hotplug script calls `/usr/bin/cache-domains configure` when the WAN interface is brought up.
 
 ## Testing
 With the above configuration set and the service running `nslookup swcdn.apple.com` would return `10.10.3.12`

--- a/utils/cache-domains/files/30-cache-domains
+++ b/utils/cache-domains/files/30-cache-domains
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+source /lib/functions/network.sh
+network_find_wan WAN_IFACE
+
+if [ "${ACTION}" == "ifup" ] && [ "${INTERFACE}" == "${WAN_IFACE}" ] && [ ! -d /var/cache-domains ]; then
+	/usr/bin/cache-domains configure
+fi

--- a/utils/cache-domains/files/cache-domains
+++ b/utils/cache-domains/files/cache-domains
@@ -1,12 +1,10 @@
-#!/bin/sh /etc/rc.common
+#!/bin/sh
 
-START=24
-SERVICE_NAME=cache-domains
-CACHE_DOMAINS_DIR="/var/${SERVICE_NAME}"
+CACHE_DOMAINS_DIR="/var/cache-domains"
 CACHE_DOMAINS_SRC="https://api.github.com/repos/uklans/cache-domains/tarball/master"
-CONFIG_FILE="/etc/${SERVICE_NAME}.json"
+CONFIG_FILE="/etc/cache-domains.json"
 
-start() {
+configure() {
 	mkdir -p ${CACHE_DOMAINS_DIR}
 	rm -fr ${CACHE_DOMAINS_DIR}/*
 
@@ -25,14 +23,14 @@ start() {
 
 	cp ${CONFIG_FILE} config.json
 	./create-dnsmasq.sh
-	cp ./output/dnsmasq/* /tmp/dnsmasq.d/
+	cp ./output/dnsmasq/* /var/dnsmasq.d/
 
 	cd ${INITIAL_DIR}
 
 	/etc/init.d/dnsmasq restart
 }
 
-stop() {
+cleanup() {
 	# leave dnsmasq in a clean state
 	for FILE in ${CACHE_DOMAINS_DIR}/*/scripts/output/dnsmasq/*; do
 		rm -f /tmp/dnsmasq.d/$(basename ${FILE})
@@ -40,3 +38,15 @@ stop() {
 
 	/etc/init.d/dnsmasq restart
 }
+
+case ${1} in
+	config*)
+		configure
+		;;
+	clean*)
+		cleanup
+		;;
+	*)
+		echo "${0} <configure|cleanup>"
+		;;
+esac


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: x86_x64, Hyper-V, OpenWrt Master
Run tested: x86_x64, Hyper-V, OpenWrt Master

Description:
Since we have to restart dnsmasq to reload the config anyway, this
package doesn't need to run before anything. We do however need to
wait for the network so I've changed this service to be a hotplug
script and utility script.
