### PR TITLE
adblock: update 3.8.12

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
-PKG_VERSION:=3.8.11
+PKG_VERSION:=3.8.12
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -13,7 +13,7 @@
 #
 LC_ALL=C
 PATH="/usr/sbin:/usr/bin:/sbin:/bin"
-adb_ver="3.8.11"
+adb_ver="3.8.12"
 adb_basever=""
 adb_enabled=0
 adb_debug=0
@@ -536,6 +536,7 @@ f_dnsup()
 		else
 			"/etc/init.d/${adb_dns}" restart >/dev/null 2>&1
 		fi
+		sleep 5
 
 		while [ "${cnt}" -le 10 ]
 		do
@@ -565,7 +566,6 @@ f_dnsup()
 					;;
 				esac
 				out_rc=0
-				sleep 1
 				break
 			fi
 			cnt=$((cnt+1))


### PR DESCRIPTION
Maintainer: me / @dibdot
Compile tested: -
Run tested: GL.iNet GL-AR300M (NAND), OpenWrt SNAPSHOT r11546-a74095c68c

Description:
* fix possible dns restart issue with DNS File Reset (race condition) reported in the forum

Signed-off-by: Dirk Brenken <dev@brenken.org>

