### PR TITLE
php7: Update to version 7.2.25

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -6,8 +6,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=7.2.23
-PKG_RELEASE:=2
+PKG_VERSION:=7.2.25
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
 
@@ -17,7 +17,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14
+PKG_HASH:=746efeedc38e6ff7b1ec1432440f5fa801537adf6cd21e4afb3f040e5b0760a9
 
 PKG_FIXUP:=libtool autoreconf
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- Refreshed patches
- Fixes [CVE-2019-11043](https://nvd.nist.gov/vuln/detail/CVE-2019-11043) (fixed in 7.2.24)

Should be cherry-picked into the `openwrt-19.07` branch. 

In OpenWrt 18.06, there's version 7.2.19. It should be updated to the latest version as well. I see you were doing cherry-picks, so it's up to you. I don't mind to create a pull request. As in the version 7.2.21, there were fixed two CVEs: [CVE-2019-11042](https://nvd.nist.gov/vuln/detail/CVE-2019-11042), [CVE-2019-11041](https://nvd.nist.gov/vuln/detail/CVE-2019-11041)
