### PR TITLE
iputils: Move the iputils tools to the packages feed

### DIFF
--- a/net/iputils/Config_ping.in
+++ b/net/iputils/Config_ping.in
@@ -1,0 +1,17 @@
+if PACKAGE_iputils-ping
+
+config PING_LEGACY_SYMLINKS
+	bool
+	default n
+	prompt "Install legacy ping4 and ping6 symlinks"
+	help
+		Iputils previously generated separate "ping" and "ping6"
+		binaries for supporting IPv4 and IPv6 communication,
+		respectively.  Recent versions of iputils have merged
+		support for both address families into a single program.
+		Select this option to install "ping6" and "ping4" symlinks
+		to the unified binary to support compatibility with
+		existing tools that may still expect to find the old
+		names.
+
+endif

--- a/net/iputils/Config_tracepath.in
+++ b/net/iputils/Config_tracepath.in
@@ -1,0 +1,16 @@
+if PACKAGE_iputils-tracepath
+
+config TRACEPATH_LEGACY_SYMLINKS
+	bool
+	default n
+	prompt "Install legacy tracepath4 and tracepath6 symlinks"
+	help
+		Iputils previously generated separate "tracepath" and
+		"tracepath6" binaries for supporting IPv4 and IPv6
+		communication, respectively.  Recent versions of iputils
+		have merged support for both address families into a
+		single tracepath program.  Select this option to install
+		"tracepath6" and "tracepath4" symlinks to the unified
+		binary to support compatibility with existing tools that
+		may still expect to find the old names.
+endif

--- a/net/iputils/Makefile
+++ b/net/iputils/Makefile
@@ -1,0 +1,150 @@
+#
+# Copyright (C) 2006-2010 OpenWrt.org
+# Copyright (C) 2019 Noah Meyerhans <frodo@morgul.net>
+#
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=iputils
+PKG_VERSION:=20190709
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/iputils/iputils/tar.gz/s$(PKG_VERSION)?
+PKG_HASH:=a15720dd741d7538dd2645f9f516d193636ae4300ff7dbc8bfca757bf166490a
+
+PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:iputils_project:iputils
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/iputils-s$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=meson/host
+include $(INCLUDE_DIR)/package.mk
+include ../../devel/meson/meson.mk
+
+MESON_ARGS:=-DBUILD_MANS=false \
+            -DBUILD_HTML_MANS=false \
+            -DUSE_CAP=false \
+            -DUSE_CRYPTO=kernel \
+            -DUSE_IDN=false \
+            -DUSE_GETTEXT=false \
+            -DNO_SETCAP_OR_SUID=true \
+            -DBUILD_PING=true \
+            -DBUILD_ARPING=true \
+            -DBUILD_CLOCKDIFF=true \
+            -DBUILD_TRACEPATH=true \
+            -DBUILD_TFTPD=true
+
+define Package/iputils/Default
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=iputils
+  URL:=https://github.com/iputils/iputils
+endef
+
+### ping
+
+define Package/iputils-ping
+  $(call Package/iputils/Default)
+  TITLE:=iputils-ping
+  DEPENDS:=+kmod-crypto-md5
+endef
+
+define Package/iputils-ping/config
+	source "$(SOURCE)/Config_ping.in"
+endef
+
+define Package/iputils-ping/description
+  Send ICMP_ECHOREQUEST packets to IP hosts and report on replies
+endef
+
+define Package/iputils-ping/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_SUID) $(MESON_BUILD_DIR)/ping $(1)/usr/bin/
+ifdef CONFIG_PING_LEGACY_SYMLINKS
+	ln -s ping $(1)/usr/bin/ping4
+	ln -s ping $(1)/usr/bin/ping6
+endif
+endef
+
+### arping
+
+define Package/iputils-arping
+  $(call Package/iputils/Default)
+  TITLE:=iputils-arping
+endef
+
+define Package/iputils-arping/description
+  Send ARP REQUEST packets to a neighbor host
+endef
+
+define Package/iputils-arping/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(MESON_BUILD_DIR)/arping $(1)/usr/bin/
+endef
+
+### clockdiff
+
+define Package/iputils-clockdiff
+  $(call Package/iputils/Default)
+  TITLE:=iputils-clockdiff
+endef
+
+define Package/iputils-clockdiff/description
+  Measure the clock difference between two hosts
+endef
+
+define Package/iputils-clockdiff/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(MESON_BUILD_DIR)/clockdiff $(1)/usr/bin/
+endef
+
+### tracepath
+
+define Package/iputils-tracepath
+  $(call Package/iputils/Default)
+  TITLE:=iputils-tracepath
+endef
+
+define Package/iputils-tracepath/description
+  trace network path to a host, discovering PMTU
+endef
+
+define Package/iputils-tracepath/config
+	source "$(SOURCE)/Config_tracepath.in"
+endef
+
+define Package/iputils-tracepath/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(MESON_BUILD_DIR)/tracepath $(1)/usr/bin/
+ifdef CONFIG_TRACEPATH_LEGACY_SYMLINKS
+	ln -s tracepath $(1)/usr/bin/tracepath4
+	ln -s tracepath $(1)/usr/bin/tracepath6
+endif
+endef
+
+### tftp
+
+define Package/iputils-tftpd
+  $(call Package/iputils/Default)
+  TITLE:=iputils-tftpd
+endef
+
+define Package/iputils-tftpd/description
+  Trivial File Transfer Protocol server
+endef
+
+define Package/iputils-tftpd/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(MESON_BUILD_DIR)/tftpd $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,iputils-ping))
+$(eval $(call BuildPackage,iputils-arping))
+$(eval $(call BuildPackage,iputils-clockdiff))
+$(eval $(call BuildPackage,iputils-tracepath))
+$(eval $(call BuildPackage,iputils-tftpd))


### PR DESCRIPTION
Per discussion in openwrt/openwrt#1804, iputils is moving from the main openwrt repository to the packages feed, and is switching from the abandoned skbuff.net upstream to github.com/iputils/iputils

This change import iputils into packages. A subsequent change to openwrt will drop iputils from that repository once this one is merged.

Maintainer: me
Compile tested: armv7l (linksys 1900acs)
Run tested: armv7l (linksys 1900acs), openwrt master

