### PR TITLE
logrotate version bump 3.15.1

### DIFF
--- a/utils/logrotate/Makefile
+++ b/utils/logrotate/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=logrotate
-PKG_VERSION:=3.15.0
-PKG_RELEASE:=2
+PKG_VERSION:=3.15.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= https://github.com/logrotate/logrotate/releases/download/$(PKG_VERSION)


### PR DESCRIPTION
* upstream release notes https://github.com/logrotate/logrotate/releases/tag/3.15.1
* closes https://github.com/openwrt/packages/issues/10634

Maintainer: @bk138
Compile tested: untested
Run tested: untested

Description:
maintenance dot release