### PR TITLE
OpenSSH: Add failsafe support

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
 PKG_VERSION:=8.4p1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
@@ -219,6 +219,8 @@ define Package/openssh-server/install
 	sed -r -i 's,^#(HostKey /etc/ssh/ssh_host_(rsa|ed25519)_key)$$$$,\1,' $(1)/etc/ssh/sshd_config
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/sshd.init $(1)/etc/init.d/sshd
+	$(INSTALL_DIR) $(1)/lib/preinit
+	$(INSTALL_BIN) ./files/sshd.failsafe $(1)/lib/preinit/99_10_failsafe_sshd
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/sshd $(1)/usr/sbin/
 endef

--- a/net/openssh/files/sshd.failsafe
+++ b/net/openssh/files/sshd.failsafe
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+failsafe_sshd () {
+
+	# if dropbear is executable it can handle failsafe
+	[ -x /usr/sbin/dropbear ] && return
+
+	sshd_tmpdir=/tmp/sshd
+	mkdir $sshd_tmpdir
+
+	sed -i 's/^root:.*/root::0:17000:::::/g' /etc/shadow
+
+	for type in ed25519; do
+		key=$sshd_tmpdir/ssh_host_${type}_key
+		ssh-keygen -N '' -t ${type} -f ${key}
+	done
+
+	mkdir -m 0700 -p /var/empty
+
+	cat > $sshd_tmpdir/sshd_config <<EOF
+HostKey $sshd_tmpdir/ssh_host_ed25519_key
+PermitRootLogin	yes
+PermitEmptyPasswords yes
+EOF
+
+	/usr/sbin/sshd -f $sshd_tmpdir/sshd_config -E $sshd_tmpdir/sshd.log
+
+}
+
+boot_hook_add failsafe failsafe_sshd


### PR DESCRIPTION
Maintainer: @neheb @tripolar 
Compile tested: mvebu
Run tested: mvebu

Description:
Adds failsafe support for OpenSSH only systems that don't have dropbear to allow accessing them while in failsafe mode. This is roughly based on an earlier patch which was asked to be split out into two parts.