### PR TITLE
procps-ng: Remove DEFAULT line

### DIFF
--- a/utils/procps-ng/Makefile
+++ b/utils/procps-ng/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=procps-ng
 PKG_VERSION:=3.3.15
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/procps-ng
 PKG_HASH:=10bd744ffcb3de2d591d2f6acf1a54a7ba070fdcc432a855931a5057149f0465
 
-PKG_MAINTAINER:=Gergely Kiss <mail.gery@gmail.com>
-PKG_LICENSE:=GPL-2.0
+PKG_MAINTAINER:=
+PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING COPYING.LIB
 
 PKG_BUILD_PARALLEL:=1
@@ -73,7 +73,6 @@ define GenPlugin
    $(call Package/procps-ng/Default)
    DEPENDS:=procps-ng
    TITLE:=Applet $(2) from the procps-ng package
-   DEFAULT:=n
    ALTERNATIVES:=200:$(3)/$(2):$(3)/$(1)
  endef
 


### PR DESCRIPTION
The intended behavior is to has the buildbot select all the applets
as well as packages only selecting what they need. This should do it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: none

ping @micmac1 
