### PR TITLE
treewide: replace old wiki links

### DIFF
--- a/admin/backuppc/Makefile
+++ b/admin/backuppc/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=backuppc
 PKG_VERSION:=3.3.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=BackupPC-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/backuppc

--- a/admin/backuppc/files/backuppc.init
+++ b/admin/backuppc/files/backuppc.init
@@ -49,7 +49,7 @@ preconfigure() {
         echo "pass: ${PASS}"
         echo
         echo "It is also recommended to follow the steps in"
-        echo "https://wiki.openwrt.org/doc/uci/uhttpd#securing_uhttpd"
+        echo "https://openwrt.org/docs/guide-user/services/webserver/uhttpd#securing_uhttpd"
         echo "to secure access to uhttpd."
     fi
 }

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=4.0.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/zabbix

--- a/admin/zabbix/files/mac80211
+++ b/admin/zabbix/files/mac80211
@@ -1,7 +1,7 @@
-#see http://wiki.openwrt.org/doc/howto/zabbix for ready to use templates
+#see https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use templates
 
 # If you want to know the exact meaning of an UserParameter, you can search in the ieee80211 standard:
-# http://standards.ieee.org/getieee802/download/802.11-2012.pdf
+# https://standards.ieee.org/getieee802/download/802.11-2012.pdf
 # example: for mac80211.ACKFailureCount search for dot11ACKFailureCount (page 2145)
 
 # mac80211 phy discovery (like 'phy0')

--- a/admin/zabbix/files/network
+++ b/admin/zabbix/files/network
@@ -1,4 +1,4 @@
-#see http://wiki.openwrt.org/doc/howto/zabbix for ready to use templates
+#see https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use templates
 
 # network interface discovery
 # example: {"data":[{"{#IF}":"lo", "{#NET}":"loopback"},{"{#IF}":"br-lan", "{#NET}":"lan"},{"{#IF}":"eth0.1", "{#NET}":"wan"}]}

--- a/admin/zabbix/files/wifi
+++ b/admin/zabbix/files/wifi
@@ -1,4 +1,4 @@
-#see http://wiki.openwrt.org/doc/howto/zabbix for ready to use templates
+#see https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use templates
 
 # wifi interface discovery
 # example: {"data":[{"{#IF}":"wlan0", "{#MODE}":"ap", "{#SSID}":"Openwrt", "{#NET}":"lan", "{#DEV}":"radio0", "{#ENC}":"psk2+ccmp", "{#TYPE}":"mac80211", "{#HWMODE}":"11ng", "{#CHANNEL}":"11", "{#BSSID}":"xx:xx:xx:xx:xx:xx"}]}

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.8
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=
@@ -36,7 +36,7 @@ define Package/ddns-scripts
 endef
 # shown in LuCI package description
 define Package/ddns-scripts/description
-    Dynamic DNS Client scripts (with IPv6 support) - Info: http://wiki.openwrt.org/doc/howto/ddns.client
+    Dynamic DNS Client scripts (with IPv6 support) - Info: https://openwrt.org/docs/guide-user/services/ddns/client
 endef
 # shown in menuconfig <Help>
 define Package/ddns-scripts/config
@@ -50,7 +50,7 @@ define Package/ddns-scripts/config
 		  - log file support
 		  - support to run once
 		Version: $(PKG_VERSION)-$(PKG_RELEASE)
-		Info   : http://wiki.openwrt.org/doc/howto/ddns.client
+		Info   : https://openwrt.org/docs/guide-user/services/ddns/client
 endef
 
 ###### *************************************************************************

--- a/net/ddns-scripts/files/ddns.config
+++ b/net/ddns-scripts/files/ddns.config
@@ -1,5 +1,5 @@
 #
-# Please read http://wiki.openwrt.org/doc/uci/ddns
+# Please read https://openwrt.org/docs/guide-user/base-system/ddns
 #
 config ddns "global"
 	option ddns_dateformat "%F %R"

--- a/net/xl2tpd/Makefile
+++ b/net/xl2tpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xl2tpd
 PKG_VERSION:=1.3.15
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE

--- a/net/xl2tpd/README.md
+++ b/net/xl2tpd/README.md
@@ -34,7 +34,7 @@ netifd will not do the check and retry.
 
 The following are generic ppp options and should have the same format and
 semantics as with other ppp-related protocols.  See
-[uci/network#protocol_ppp](https://wiki.openwrt.org/doc/uci/network#protocol_ppp_ppp_over_modem)
+[uci/network#protocol_ppp](https://openwrt.org/docs/guide-user/network/wan/wan_interface_protocols#protocol_ppp_ppp_over_modem)
 for details.
 
 	username


### PR DESCRIPTION
Maintainers: @champtar @nonicknamewasleftforme @yousong
Compile tested: N/A
Run tested: N/A

Description:
Replaced all references to "wiki.openwrt.org" with links to the latest wiki pages.

Signed-off-by: Leong Hui Wong <leonghui@users.noreply.github.com>