### PR TITLE
lcd4linux: Add limits header for PATH_MAX

### DIFF
--- a/utils/lcd4linux/Makefile
+++ b/utils/lcd4linux/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lcd4linux
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/feckert/lcd4linux

--- a/utils/lcd4linux/patches/200-musl.patch
+++ b/utils/lcd4linux/patches/200-musl.patch
@@ -1,0 +1,10 @@
+--- a/plugin_i2c_sensors.c
++++ b/plugin_i2c_sensors.c
+@@ -68,6 +68,7 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <dirent.h>
++#include <limits.h>
+ 
+ #include "debug.h"
+ #include "plugin.h"


### PR DESCRIPTION
Fixes compilation on musl.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @feckert 
Compile tested: mvebu