### PR TITLE
addrwatch: Add missing limits header for PATH_MAX

### DIFF
--- a/net/addrwatch/Makefile
+++ b/net/addrwatch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=addrwatch
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fln/addrwatch/tar.gz/v$(PKG_VERSION)?

--- a/net/addrwatch/patches/010-limits.patch
+++ b/net/addrwatch/patches/010-limits.patch
@@ -1,0 +1,10 @@
+--- a/src/addrwatch.c
++++ b/src/addrwatch.c
+@@ -4,6 +4,7 @@
+ #include <signal.h>
+ #include <strings.h>
+ #include <unistd.h>
++#include <limits.h>
+ #include <pwd.h>
+ #include <grp.h>
+ #include <argp.h>


### PR DESCRIPTION
Fixes compilation on musl.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @oskar456 
Compile tested: mvebu