### PR TITLE
evtest: Fix compilation with musl

### DIFF
--- a/utils/evtest/Makefile
+++ b/utils/evtest/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=evtest
 PKG_VERSION:=1.34
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cgit.freedesktop.org/evtest/snapshot

--- a/utils/evtest/patches/010-musl.patch
+++ b/utils/evtest/patches/010-musl.patch
@@ -1,0 +1,24 @@
+From 12d5ea5ca2d9a47a1cab06caf2b36967667a3daf Mon Sep 17 00:00:00 2001
+From: Leo <thinkabit.ukim@gmail.com>
+Date: Sun, 24 Nov 2019 20:58:20 +0100
+Subject: [PATCH] Add missing include of limits.h for PATH_MAX
+
+---
+ evtest.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/evtest.c b/evtest.c
+index 548c203..be5e42c 100644
+--- a/evtest.c
++++ b/evtest.c
+@@ -59,6 +59,7 @@
+ #include <sys/time.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#include <limits.h> /* PATH_MAX */
+ 
+ #define BITS_PER_LONG (sizeof(long) * 8)
+ #define NBITS(x) ((((x)-1)/BITS_PER_LONG)+1)
+-- 
+2.22.0
+


### PR DESCRIPTION
Backported upstream patch.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @psidhu 
Compile tested: mvebu