### PR TITLE
stunnel: update to version 5.56

### DIFF
--- a/net/stunnel/Makefile
+++ b/net/stunnel/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stunnel
-PKG_VERSION:=5.55
-PKG_RELEASE:=2
+PKG_VERSION:=5.56
+PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
@@ -23,7 +23,7 @@ PKG_SOURCE_URL:= \
 	https://www.usenix.org.uk/mirrors/stunnel/archive/$(word 1, $(subst .,$(space),$(PKG_VERSION))).x/
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=90de69f41c58342549e74c82503555a6426961b29af3ed92f878192727074c62
+PKG_HASH:=7384bfb356b9a89ddfee70b5ca494d187605bb516b4fff597e167f97e2236b22
 
 PKG_FIXUP:=autoreconf
 PKG_FIXUP:=patch-libtool


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64 lantiq_xrx200, APU3, OpenWrt master
Run tested: x86_64, APU3, OpenWrt master
Started with default config
> 2019.11.28 12:20:08 LOG5[ui]: stunnel 5.56 on x86_64-openwrt-linux-gnu platform
> 2019.11.28 12:20:08 LOG5[ui]: Compiled/running with OpenSSL 1.1.1d  10 Sep 2019
> 2019.11.28 12:20:08 LOG5[ui]: Threading:PTHREAD Sockets:POLL,IPv6 TLS:ENGINE,FIPS,OCSP,PSK,SNI
> 2019.11.28 12:20:08 LOG5[ui]: Reading configuration from file /etc/stunnel/stunnel.conf
> 2019.11.28 12:20:08 LOG5[ui]: UTF-8 byte order mark not detected
> 2019.11.28 12:20:08 LOG5[ui]: FIPS mode disabled
> 2019.11.28 12:20:08 LOG4[ui]: Service [dummy] needs authentication to prevent MITM attacks
> 2019.11.28 12:20:08 LOG5[ui]: Configuration successful

Description:
Update to version 5.56