### PR TITLE
ipfs-http-client: add package

### DIFF
--- a/libs/ipfs-http-client/Makefile
+++ b/libs/ipfs-http-client/Makefile
@@ -1,0 +1,73 @@
+# 
+# This is free software, licensed under the GNU General Public License v2.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ipfs-http-client
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Leonid Esman <leonid.esman@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.MIT
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/vasild/cpp-ipfs-http-client.git
+PKG_SOURCE_DATE:=2019-11-05
+PKG_SOURCE_VERSION:=763e59ad698f3e3846f85df11e01c18ef3fbc401
+PKG_MIRROR_HASH:=a2b5721faf0d43ddb4a892245ef382666149c83f3f97e558e1a6acf2402fb9fd
+PKG_BUILD_DEPENDS:=nlohmannjson
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/ipfs-http-client/Default/description
+  IPFS (the InterPlanetary File System) is the Distributed Web. 
+  Specs, docs, sources, links: https://ipfs.io/ and https://github.com/ipfs.
+  This is Vasil Dimov's C++ IPFS HTTP API client library.
+endef
+
+define Package/libipfs-http-client
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=IPFS client library
+  URL:=https://github.com/vasild/cpp-ipfs-http-client
+  DEPENDS:= +libcurl +libstdcpp
+endef
+
+define Package/libipfs-http-client/description
+	$(call Package/ipfs-http-client/Default/description)
+  This package contains shared library.
+endef
+
+define Package/ipfs-http-client-tests
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=IPFS client library tests
+  URL:=https://github.com/vasild/cpp-ipfs-http-client
+  DEPENDS:=+libipfs-http-client +libcurl
+endef
+
+define Package/ipfs-http-client-tests/description
+	$(call Package/ipfs-http-client/Default/description)
+  This package contains library tests.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/include/* $(1)/usr/include
+	$(CP) $(PKG_BUILD_DIR)/libipfs-http-client.a $(1)/usr/lib
+endef
+
+define Package/libipfs-http-client/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/libipfs-http-client.so* $(1)/usr/lib
+endef
+
+define Package/ipfs-http-client-tests/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/test/ipfs-* $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,libipfs-http-client))
+$(eval $(call BuildPackage,ipfs-http-client-tests))

--- a/libs/ipfs-http-client/patches/001-add-srv-addr.patch
+++ b/libs/ipfs-http-client/patches/001-add-srv-addr.patch
@@ -1,0 +1,247 @@
+--- a/test/block.cc	2019-11-22 18:16:53.973272202 +0300
++++ b/test/block.cc	2019-11-22 18:16:58.245249328 +0300
+@@ -24,9 +24,16 @@
+ #include <sstream>
+ #include <stdexcept>
+ 
+-int main(int, char**) {
++int main(int argc, char** argv) {
++  char addr127001[]="127.0.0.1";
++  char *srvaddr;
++  if (argc<2)
++    srvaddr=addr127001;
++  else
++    srvaddr=argv[1];
++
+   try {
+-    ipfs::Client client("localhost", 5001);
++    ipfs::Client client(srvaddr, 5001);
+ 
+     /** [ipfs::Client::BlockPut] */
+     ipfs::Json block;
+--- a/test/config.cc	2019-11-22 18:16:53.973272202 +0300
++++ b/test/config.cc	2019-11-22 18:16:58.245249328 +0300
+@@ -23,9 +23,16 @@
+ #include <iostream>
+ #include <stdexcept>
+ 
+-int main(int, char**) {
++int main(int argc, char** argv) {
++  char addr127001[]="127.0.0.1";
++  char *srvaddr;
++  if (argc<2)
++    srvaddr=addr127001;
++  else
++    srvaddr=argv[1];
++
+   try {
+-    ipfs::Client client("localhost", 5001);
++    ipfs::Client client(srvaddr, 5001);
+ 
+     /** [ipfs::Client::ConfigSet] */
+     client.ConfigSet("Datastore.StorageMax", "20GB");
+--- a/test/dht.cc	2019-11-22 18:16:53.973272202 +0300
++++ b/test/dht.cc	2019-11-22 18:16:58.245249328 +0300
+@@ -23,9 +23,16 @@
+ #include <iostream>
+ #include <stdexcept>
+ 
+-int main(int, char**) {
++int main(int argc, char** argv) {
++  char addr127001[]="127.0.0.1";
++  char *srvaddr;
++  if (argc<2)
++    srvaddr=addr127001;
++  else
++    srvaddr=argv[1];
++
+   try {
+-    ipfs::Client client("localhost", 5001);
++    ipfs::Client client(srvaddr, 5001);
+ 
+     ipfs::Json add_result;
+     client.FilesAdd(
+--- a/test/error.cc	2019-11-22 18:16:53.973272202 +0300
++++ b/test/error.cc	2019-11-22 18:16:58.245249328 +0300
+@@ -35,16 +35,23 @@
+ }
+ }  // namespace ipfs
+ 
+-int main(int, char**) {
++int main(int argc, char** argv) {
++  char addr127001[]="127.0.0.1";
++  char *srvaddr;
++  if (argc<2)
++    srvaddr=addr127001;
++  else
++    srvaddr=argv[1];
++
+   try {
+-    ipfs::Client client_cant_connect("localhost", 57);
++    ipfs::Client client_cant_connect(srvaddr, 57);
+ 
+     ipfs::test::must_fail("client.Version()", [&client_cant_connect]() {
+       ipfs::Json version;
+       client_cant_connect.Version(&version);
+     });
+ 
+-    ipfs::Client client("localhost", 5001);
++    ipfs::Client client(srvaddr, 5001);
+ 
+     std::string object_id;
+     client.ObjectNew(&object_id);
+--- a/test/files.cc	2019-11-22 18:16:53.973272202 +0300
++++ b/test/files.cc	2019-11-22 18:16:58.245249328 +0300
+@@ -24,9 +24,16 @@
+ #include <sstream>
+ #include <stdexcept>
+ 
+-int main(int, char**) {
++int main(int argc, char** argv) {
++  char addr127001[]="127.0.0.1";
++  char *srvaddr;
++  if (argc<2)
++    srvaddr=addr127001;
++  else
++    srvaddr=argv[1];
++
+   try {
+-    ipfs::Client client("localhost", 5001);
++    ipfs::Client client(srvaddr, 5001);
+ 
+     /** [ipfs::Client::FilesGet] */
+     std::stringstream contents;
+--- a/test/generic.cc	2019-11-22 18:16:53.973272202 +0300
++++ b/test/generic.cc	2019-11-22 18:16:58.245249328 +0300
+@@ -24,16 +24,23 @@
+ #include <stdexcept>
+ #include <utility>
+ 
+-int main(int, char**) {
++int main(int argc, char** argv) {
++  char addr127001[]="127.0.0.1";
++  char *srvaddr;
++  if (argc<2)
++    srvaddr=addr127001;
++  else
++    srvaddr=argv[1];
++
+   try {
+     /** [ipfs::Client::Client] */
+-    ipfs::Client client("localhost", 5001);
++    ipfs::Client client(srvaddr, 5001);
+     /** [ipfs::Client::Client] */
+ 
+     ipfs::Client clientA(client);
+     clientA = client;
+     ipfs::Client clientB(std::move(clientA));
+-    ipfs::Client clientC("localhost", 5001);
++    ipfs::Client clientC(srvaddr, 5001);
+     clientC = std::move(clientB);
+ 
+ #pragma GCC diagnostic push
+--- a/test/key.cc	2019-11-22 18:16:53.973272202 +0300
++++ b/test/key.cc	2019-11-22 18:16:58.245249328 +0300
+@@ -26,9 +26,16 @@
+ 
+ using Json = nlohmann::json;
+ 
+-int main(int, char**) {
++int main(int argc, char** argv) {
++  char addr127001[]="127.0.0.1";
++  char *srvaddr;
++  if (argc<2)
++    srvaddr=addr127001;
++  else
++    srvaddr=argv[1];
++
+   try {
+-    ipfs::Client client("localhost", 5001);
++    ipfs::Client client(srvaddr, 5001);
+ 
+     /** [ipfs::Client::KeyGen] */
+     std::string key_id;
+--- a/test/name.cc	2019-11-22 18:16:53.973272202 +0300
++++ b/test/name.cc	2019-11-22 18:16:58.245249328 +0300
+@@ -24,9 +24,16 @@
+ #include <sstream>
+ #include <stdexcept>
+ 
+-int main(int, char**) {
++int main(int argc, char** argv) {
++  char addr127001[]="127.0.0.1";
++  char *srvaddr;
++  if (argc<2)
++    srvaddr=addr127001;
++  else
++    srvaddr=argv[1];
++
+   try {
+-    ipfs::Client client("localhost", 5001);
++    ipfs::Client client(srvaddr, 5001);
+ 
+     // We need a key here, so as not to clobber the "self" key.
+     std::string key_id;
+--- a/test/object.cc	2019-11-22 18:16:53.973272202 +0300
++++ b/test/object.cc	2019-11-22 18:16:58.245249328 +0300
+@@ -24,9 +24,16 @@
+ #include <stdexcept>
+ #include <string>
+ 
+-int main(int, char**) {
++int main(int argc, char** argv) {
++  char addr127001[]="127.0.0.1";
++  char *srvaddr;
++  if (argc<2)
++    srvaddr=addr127001;
++  else
++    srvaddr=argv[1];
++
+   try {
+-    ipfs::Client client("localhost", 5001);
++    ipfs::Client client(srvaddr, 5001);
+ 
+     /** [ipfs::Client::ObjectNew] */
+     std::string object_id;
+--- a/test/pin.cc	2019-11-22 18:16:53.973272202 +0300
++++ b/test/pin.cc	2019-11-23 23:09:57.507400418 +0300
+@@ -23,9 +23,16 @@
+ #include <stdexcept>
+ #include <string>
+ 
+-int main(int, char**) {
++int main(int argc, char** argv) {
++  char addr127001[]="127.0.0.1";
++  char *srvaddr;
++  if (argc<2)
++    srvaddr=addr127001;
++  else
++    srvaddr=argv[1];
++
+   try {
+-    ipfs::Client client("localhost", 5001);
++    ipfs::Client client(srvaddr, 5001);
+ 
+     std::string object_id;
+ 
+--- a/test/swarm.cc	2019-11-22 18:16:53.973272202 +0300
++++ b/test/swarm.cc	2019-11-23 23:10:07.199342933 +0300
+@@ -23,9 +23,16 @@
+ #include <stdexcept>
+ #include <string>
+ 
+-int main(int, char**) {
++int main(int argc, char** argv) {
++  char addr127001[]="127.0.0.1";
++  char *srvaddr;
++  if (argc<2)
++    srvaddr=addr127001;
++  else
++    srvaddr=argv[1];
++
+   try {
+-    ipfs::Client client("localhost", 5001);
++    ipfs::Client client(srvaddr, 5001);
+ 
+     /** [ipfs::Client::SwarmAddrs] */
+     ipfs::Json addresses;

--- a/libs/ipfs-http-client/src/Makefile
+++ b/libs/ipfs-http-client/src/Makefile
@@ -1,0 +1,46 @@
+#
+# IPFS C++ HTTP API client library
+#
+VER_MAJOR:=0
+VER_MINOR:=4
+VER_PATCH:=0
+VERSION:=$(VER_MAJOR).$(VER_MINOR).$(VER_PATCH)
+
+HEADERS := include/ipfs/client.h include/ipfs/http/transport-curl.h include/ipfs/http/transport.h
+TESTPROGS := ipfs-block ipfs-dht ipfs-files ipfs-key ipfs-object ipfs-swarm ipfs-config ipfs-generic ipfs-name ipfs-pin
+CXXFLAGS := -Wall -Wpedantic -Wextra -Werror -Os -std=gnu++11 -I./include
+
+.PHONY: testprogs lib all clean
+
+all: lib testprogs test/ipfs-demo
+
+lib: libipfs-http-client.a libipfs-http-client.so.$(VERSION)
+
+libipfs-http-client.a: src/client.o src/http/transport-curl.o
+	$(AR) rc libipfs-http-client.a src/client.o src/http/transport-curl.o
+
+libipfs-http-client.so.$(VERSION): src/client.o src/http/transport-curl.o
+	$(CXX) $(CXXFLAGS) -shared -Wl,-soname,libipfs-http-client.so.$(VER_MAJOR) -o libipfs-http-client.so.$(VERSION) src/client.o src/http/transport-curl.o
+	ln -sf libipfs-http-client.so.$(VERSION) libipfs-http-client.so.$(VER_MAJOR)
+	ln -sf libipfs-http-client.so.$(VER_MAJOR) libipfs-http-client.so
+
+testprogs: $(addprefix test/,$(TESTPROGS))
+
+$(addprefix test/,$(TESTPROGS)):test/ipfs-%:test/%.cc   include/ipfs/client.h include/ipfs/test/utils.h  libipfs-http-client.a
+	$(CXX) $(CXXFLAGS) $< -L. -lipfs-http-client -lcurl -o $@
+
+src/client.o: src/client.cc $(HEADERS)
+	$(CXX) $(CXXFLAGS) -fPIC -o src/client.o -c src/client.cc
+
+src/http/transport-curl.o: src/http/transport-curl.cc $(HEADERS) include/ipfs/test/utils.h
+	$(CXX) $(CXXFLAGS) -fPIC -o src/http/transport-curl.o -c src/http/transport-curl.cc
+
+test/ipfs-demo: test/demo.cpp
+	$(CXX) -std=c++11 -I./include -L. test/demo.cpp -lipfs-http-client -lcurl -o test/ipfs-demo
+#	$(CXX) -std=c++11 -I./include -L. -Wl,-rpath,. test/demo.cpp  -lipfs-http-client -lcurl -o test/ipfs-demo
+#	$(CXX) -std=c++11 -I./include test/demo.cpp ./libipfs-http-client.a -lcurl -o test/ipfs-demo
+
+clean:
+	$(RM) src/client.o src/http/transport-curl.o libipfs-http-client.a libipfs-http-client.so* $(addprefix test/,$(TESTPROGS)) test/ipfs-demo
+
+

--- a/libs/ipfs-http-client/src/test/demo.cpp
+++ b/libs/ipfs-http-client/src/test/demo.cpp
@@ -1,0 +1,23 @@
+// g++  -std=c++11  -I./include  test1.cpp  libipfs-http-client.a -lcurl -o ipfs-test
+// g++  -std=c++11  -I./include  test1.cpp  -lipfs-http-client -lcurl -o ipfs-test
+// g++  -std=c++11  -I./include -L. -Wl,-rpath,.  test1.cpp  -lipfs-http-client -lcurl -o ipfs-test
+
+#include <iostream>
+#include <sstream>
+#include <ipfs/client.h>
+
+int main(int argc, char** argv)
+{
+  std::stringstream contents;
+  char addr127001[]="127.0.0.1";
+  char *addr;
+  if (argc<2)
+    addr=addr127001;
+  else
+    addr=argv[1];
+  ipfs::Client client(addr, 5001);
+  client.FilesGet("/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/readme", &contents);
+  std::cout << contents.str() << std::endl;
+  return 0;
+}
+

--- a/libs/nlohmannjson/Makefile
+++ b/libs/nlohmannjson/Makefile
@@ -1,0 +1,38 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nlohmannjson
+PKG_VERSION:=3.7.3
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Leonid Esman <leonid.esman@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.MIT
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/json-$(PKG_VERSION)
+PKG_SOURCE:=json-$(PKG_VERSION).zip
+PKG_SOURCE_URL:=https://codeload.github.com/nlohmann/json/zip/v$(PKG_VERSION)?
+PKG_HASH:=e109cd4a9d1d463a62f0a81d7c6719ecd780a52fb80a22b901ed5b6fe43fb45b
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/nlohmannjson
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=JSON for Modern C++
+  URL:=https://nlohmann.github.io/json/
+endef
+
+define Package/nlohmannjson/description
+  Niels Lohmann's JSON headers-only library for modern C++
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_BUILD_DIR)/include/nlohmann $(1)/usr/include
+endef
+
+$(eval $(call BuildPackage,nlohmannjson))


### PR DESCRIPTION
Maintainer: me
Compile and Run tested: TL-MR3020 v3 (mt76x8), OpenWrt current. 

Description:
There are two packages: ipfs-http-client and nlohmannjson.
Package ipfs-http-client is IPFS C++ HTTP API client library, which allows C++ applications to communicate with an IPFS node. It implements IPFS API bindings for C++. Not all methods are implemented. Homepage https://github.com/vasild/cpp-ipfs-http-client
Package nlohmannjson is JSON library for modern C++, yet another JSON library, C++11 header-only. Design goals: intuitive syntax, trivial integration, serious testing. 
Homepage https://github.com/nlohmann/json
API documentation https://nlohmann.github.io/json/
ipfs-http-client depends on this library.
