### PR TITLE
ntpd: create config_file directory

### DIFF
--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntp
 PKG_VERSION:=4.2.8p13
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/

--- a/net/ntpd/files/ntpd.init
+++ b/net/ntpd/files/ntpd.init
@@ -40,6 +40,8 @@ start_ntpd_instance() {
 	# since some of them might be dynamic interfaces (like IPsec
 	# tunnels) which aren't known by ubus.
 
+	mkdir -p "$(dirname "$config_file")"
+
 	trunc
 	emit "driftfile /var/lib/ntp/ntp.drift\n"
 


### PR DESCRIPTION
ntpd's configuration is stored in /var/etc, but the init script doesn't
create this directory. To be fair this folder is used by other packages
as well, for instance dnsmasq. Still, it's better not to rely on other
packages to create it.

Fixes: #10636

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @tripolar 
Compile tested: ath79 master
Run tested: 19.07 rc1 ath79

Description:
One-line init script improvement :)