### PR TITLE
php7-pecl-krb5: fix build error and runtime loading

### DIFF
--- a/lang/php7-pecl-krb5/Makefile
+++ b/lang/php7-pecl-krb5/Makefile
@@ -9,7 +9,7 @@ PECL_NAME:=krb5
 PECL_LONGNAME:=Bindings for the Kerberos library
 
 PKG_VERSION:=1.1.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_HASH:=3301e047fc7dc3574da19b2a4b18e15feca5ad39db9335c3353a8e16b855c35b
 
 PKG_NAME:=php7-pecl-krb5
@@ -31,7 +31,9 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 include ../php7/pecl.mk
 
-CONFIGURE_ARGS+= --with-krb5=shared,"$(STAGING_DIR)/usr"
+CONFIGURE_ARGS+= \
+	--with-krb5=shared,"$(STAGING_DIR)/usr" \
+	--with-krb5config=$(STAGING_DIR)/usr/bin/krb5-config
 
 $(eval $(call PECLPackage,krb5,$(PECL_LONGNAME),+krb5-libs,30))
 $(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: mxs
Run tested: mxs (i2SE Duckbill)

Description:
The build throws several (non-fatal) build errors:
-snip-
...
checking for kerberos support... yes, shared
checking path to krb5config tool... no
checking for kerberos KADM5 support... no
checking whether we have krb5config...
./configure: line 3974: --libs: command not found
./configure: line 3975: --cflags: command not found
checking for required linker flags...
checking for required compiler flags...
./configure: line 3988: --version: command not found
checking for kerberos library version...
checking for krb5_free_string... no
checking for krb5_chpw_message... no
checking for krb5_principal_get_realm... no
checking how to print strings... printf
...
-snap-

To fix this give configure the path to krb5-config tool.

The runtime error which is fixed by the change is:
PHP Warning:  PHP Startup: Unable to load dynamic library 'krb5.so'
 (tried: /usr/lib/php/krb5.so (Error relocating
 /usr/lib/php/krb5.so: krb5_get_init_creds_opt_free: symbol not found),
 ...

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
