### PR TITLE
libgd: fix version in generated pkg-config .pc file

### DIFF
--- a/libs/libgd/Makefile
+++ b/libs/libgd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgd
 PKG_VERSION:=2.2.5
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/gd-$(PKG_VERSION)/

--- a/libs/libgd/patches/300-gdlib.pc-cmake.patch
+++ b/libs/libgd/patches/300-gdlib.pc-cmake.patch
@@ -1,0 +1,11 @@
+--- a/config/gdlib.pc.cmake
++++ b/config/gdlib.pc.cmake
+@@ -5,7 +5,7 @@ includedir=${prefix}/@CMAKE_INSTALL_INCL
+ 
+ Name: gd
+ Description: GD graphics library
+-Version: @GDLIB_VERSION@
++Version: @GD_VERSION@
+ Cflags: -I${includedir}
+ Libs.private: @LIBGD_DEP_LIBS@
+ Libs: -L${libdir} -lgd


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: mxs
Run tested: -not necessary-

Description:

With the previous change to cmake, the generated pkg-config .pc
file does not contain the library version anymore. This breaks
programs which checks for a specific version, e.g. upcoming PHP 7.4.

The version is not filled because of a variable misnaming,
which was not covered by the imported upstream patch.

To not mangle the upstream patch, add an additional patch to
fix things up.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
