### PR TITLE
cyrus-sasl: install pkg-config file and fine-tune installed files

### DIFF
--- a/libs/cyrus-sasl/Makefile
+++ b/libs/cyrus-sasl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cyrus-sasl
 PKG_VERSION:=2.1.27
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -101,13 +101,15 @@ define Build/InstallDev
 	ln -sf libsasl2.so $(1)/usr/lib/libsasl.so
 	$(INSTALL_DIR) $(1)/usr/lib/sasl2
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/sasl2/lib*.{a,so*} $(1)/usr/lib/sasl2/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libsasl2.pc $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/libsasl2/install
 	$(INSTALL_DIR) $(1)/usr/lib/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsasl2.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsasl2.so.* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/sasl2
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/sasl2/lib*.so* $(1)/usr/lib/sasl2/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/sasl2/lib*.so.* $(1)/usr/lib/sasl2/
 endef
 
 $(eval $(call BuildPackage,libsasl2))


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: mxs
Run tested: no

Description:

Installing the .pc files helps other programs to detect
the presence of libsasl2.

While at, reduce the glob pattern a little bit to not
include unneeded symlinks.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
