### PR TITLE
sstp-client: Update to 1.0.13

### DIFF
--- a/net/sstp-client/Makefile
+++ b/net/sstp-client/Makefile
@@ -8,17 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sstp-client
-PKG_VERSION:=1.0.12
-PKG_RELEASE:=3
+PKG_VERSION:=1.0.13
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/sstp-client/$(PKG_VERSION)
-PKG_HASH:=487eb406579689803ce0397f6102b18641e4572ac7bc9b9e5f3027c84dcf67ff
-PKG_LICENSE=GPLv2
+PKG_HASH:=961258fca0795d8ad60b047942cf7cb53d025d353fd1e4ba08c2b75799f5321b
+
+PKG_MAINTAINER:=Federico Di Marco <fededim@gmail.com>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
-
-TARGET_CPPFLAGS += -I$(PKG_BUILD_DIR)/include
 
 define Package/sstp-client
   SECTION:=net
@@ -27,7 +28,6 @@ define Package/sstp-client
   DEPENDS=+libevent2 +libopenssl +ppp +resolveip
   TITLE:=SSTP-Client is a SSTP client for Linux.
   URL:=http://sstp-client.sourceforge.net/
-  MAINTAINER:=Federico Di Marco <fededim@gmail.com>
 endef
 
 define Package/sstp-client/description
@@ -48,14 +48,16 @@ define Package/sstp-client/conffiles
 /etc/ppp/peers/peer-sstp-example.txt
 endef
 
+TARGET_CPPFLAGS += -I$(PKG_BUILD_DIR)/include
+
 define Package/sstp-client/install
 	$(INSTALL_DIR) $(1)/usr/{bin,lib}
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/.libs/sstpc $(1)/usr/bin/
 	$(CP) $(PKG_BUILD_DIR)/src/libsstp-api/.libs/*.so* $(1)/usr/lib/
 	$(CP) $(PKG_BUILD_DIR)/src/pppd-plugin/.libs/*.so* $(1)/usr/lib/
-	
+
 	$(INSTALL_DIR) $(1)/etc
-	$(CP) files/etc $(1) 
+	$(CP) files/etc $(1)
 	$(INSTALL_DIR) $(1)/lib/netifd/proto
 	$(INSTALL_BIN) ./files/lib/netifd/proto/sstp.sh $(1)/lib/netifd/proto
 endef

--- a/net/sstp-client/patches/200-openssl-deprecated.patch
+++ b/net/sstp-client/patches/200-openssl-deprecated.patch
@@ -8,11 +8,13 @@
      /* Initialize the OpenSSL library */
      status = SSL_library_init();
      if (status != 1)
-@@ -487,6 +488,7 @@ static status_t sstp_init_ssl(sstp_client_st *client, sstp_option_st *opt)
- 
-     /* Load all error strings */
-     SSL_load_error_strings();
-+#endif
+@@ -490,6 +491,9 @@ static status_t sstp_init_ssl(sstp_client_st *client, sstp_option_st *opt)
  
      /* Create a new crypto context */
      client->ssl_ctx = SSL_CTX_new(SSLv23_client_method());
++#else
++    client->ssl_ctx = SSL_CTX_new(TLS_client_method());
++#endif
+     if (client->ssl_ctx == NULL)
+     {
+         log_err("Could not get SSL crypto context");


### PR DESCRIPTION
Edited deprecated OpenSSL patch slightly.

Fixed up license information.

Reorganized Makefile for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @fededim 