### PR TITLE
[OpenWrt 18.06] Luajit: copy versioned library and add .hhp to InstallDev

### DIFF
--- a/lang/luajit/Makefile
+++ b/lang/luajit/Makefile
@@ -59,7 +59,7 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/luajit-2.1
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/luajit-2.1/*.h $(1)/usr/include/luajit-2.1
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/luajit-2.1/*.{h,hpp} $(1)/usr/include/luajit-2.1
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.{a,so*} $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig

--- a/lang/luajit/Makefile
+++ b/lang/luajit/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luajit
 PKG_VERSION:=2017-01-17-71ff7ef
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Morteza Milani <milani@pichak.co>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYRIGHT
@@ -69,7 +69,7 @@ endef
 
 define Package/luajit/install
 	$(INSTALL_DIR) $(1)/usr/lib/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/luajit-2.1.0-beta2 $(1)/usr/bin/$(PKG_NAME)
 endef


### PR DESCRIPTION
Maintainer: @milani
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06.
Tested: contents of the package verified and run tested on Turris Omnia, 18.06. 

Description:

The second commit:
Before:
![image](https://user-images.githubusercontent.com/4096468/70330311-9e87e800-183d-11ea-96dc-b566fc8166ef.png)

After:
![image](https://user-images.githubusercontent.com/4096468/70330321-a21b6f00-183d-11ea-90d5-f53d7d7e33e3.png)

Cherry-picked from PRs:
https://github.com/openwrt/packages/pull/6695
https://github.com/openwrt/packages/pull/6722
