### PR TITLE
nnn: Update to version 2.8.1

### DIFF
--- a/utils/nnn/Makefile
+++ b/utils/nnn/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nnn
-PKG_VERSION:=2.7
+PKG_VERSION:=2.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jarun/nnn/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=0592c7cbcf2cf66cacac49e9204636480820b1bc74e4187dd7ee06945a6d07c5
+PKG_HASH:=cadf9cf8038433aeeb50a777180ad4b309ac7d2fec81c7da177ddca515812f06
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
@@ -21,7 +21,7 @@ define Package/nnn
   CATEGORY:=Utilities
   TITLE:=Full-featured terminal file manager
   URL:=https://github.com/jarun/nnn
-  DEPENDS:=+libncurses +libreadline +findutils-xargs
+  DEPENDS:=+libncurses +libreadline
 endef
 
 define Package/nnn/description


### PR DESCRIPTION
Maintainer: me
Compile and run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run test: moving, copying, deleting

Description:
- Removed findutils-xargs dependency due to added busybox support in version 2.8

Changelog for version 2.8:
https://github.com/jarun/nnn/releases/tag/v2.8

Changelog for version 2.8.1:
https://github.com/jarun/nnn/releases/tag/v2.8.1
