### PR TITLE
luajit: switch to moonjit 2.1.2

### DIFF
--- a/lang/luajit/Makefile
+++ b/lang/luajit/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luajit
-PKG_VERSION:=2.1.0-beta3
-PKG_RELEASE:=3
+PKG_VERSION:=2.1.2
+PKG_RELEASE:=1
 
-PKG_SOURCE:=LuaJIT-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://luajit.org/download
-PKG_HASH:=1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3
-PKG_BUILD_DIR:=$(BUILD_DIR)/LuaJIT-$(PKG_VERSION)
+PKG_SOURCE:=moonjit-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/moonjit/moonjit/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=c3de8e29aa617fc594c043f57636ab9ad71af2b4a3a513932b05f5cdaa4320b2
+PKG_BUILD_DIR:=$(BUILD_DIR)/moonjit-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Morteza Milani <milani@pichak.co>
 PKG_LICENSE:=MIT
@@ -23,7 +23,7 @@ define Package/luajit
  SECTION:=lang
  CATEGORY:=Languages
  TITLE:=LuaJIT
- URL:=https://www.luajit.org
+ URL:=https://github.com/moonjit/moonjit
  DEPENDS:=@(i386||x86_64||arm||armeb||aarch64||powerpc||mips||mipsel)
 endef
 

--- a/lang/luajit/patches/0001-Have-powerpc-use-fake-GOT-like-MIPS.patch
+++ b/lang/luajit/patches/0001-Have-powerpc-use-fake-GOT-like-MIPS.patch
@@ -1,0 +1,111 @@
+From 712a43ac6f54fd3eb683c9b57bb304cf87cbd388 Mon Sep 17 00:00:00 2001
+From: Clint Bland <bland.cr@gmail.com>
+Date: Wed, 13 Mar 2019 19:19:16 -0700
+Subject: [PATCH] Have powerpc use fake GOT like MIPS
+
+Fixes: https://github.com/LuaJIT/LuaJIT/issues/481
+Pull request: https://github.com/LuaJIT/LuaJIT/pull/486
+---
+ src/lj_dispatch.c | 15 +++++++++++++++
+ src/lj_dispatch.h | 17 ++++++++++++++++-
+ src/vm_ppc.dasc   |  9 ++++++++-
+ 3 files changed, 39 insertions(+), 2 deletions(-)
+
+diff --git a/src/lj_dispatch.c b/src/lj_dispatch.c
+index 5d6795f8..ab39f7c6 100644
+--- a/src/lj_dispatch.c
++++ b/src/lj_dispatch.c
+@@ -56,6 +56,18 @@ static const ASMFunction dispatch_got[] = {
+ #undef GOTFUNC
+ #endif
+ 
++#if LJ_TARGET_PPC
++#include <math.h>
++LJ_FUNCA_NORET void LJ_FASTCALL lj_ffh_coroutine_wrap_err(lua_State *L,
++							  lua_State *co);
++
++#define GOTFUNC(name)	(ASMFunction)name,
++static const ASMFunction dispatch_got[] = {
++  GOTDEF(GOTFUNC)
++};
++#undef GOTFUNC
++#endif
++
+ /* Initialize instruction dispatch table and hot counters. */
+ void lj_dispatch_init(GG_State *GG)
+ {
+@@ -77,6 +89,9 @@ void lj_dispatch_init(GG_State *GG)
+ #if LJ_TARGET_MIPS
+   memcpy(GG->got, dispatch_got, LJ_GOT__MAX*sizeof(ASMFunction *));
+ #endif
++#if LJ_TARGET_PPC
++  memcpy(GG->got, dispatch_got, LJ_GOT__MAX*4);
++#endif
+ }
+ 
+ #if LJ_HASJIT
+diff --git a/src/lj_dispatch.h b/src/lj_dispatch.h
+index 5bda51a2..23f937fc 100644
+--- a/src/lj_dispatch.h
++++ b/src/lj_dispatch.h
+@@ -66,6 +66,21 @@ GOTDEF(GOTENUM)
+ };
+ #endif
+ 
++#if LJ_TARGET_PPC
++/* Need our own global offset table for the dreaded MIPS calling conventions. */
++#define GOTDEF(_) \
++  _(floor) _(ceil) _(trunc) _(log) _(log10) _(exp) _(sin) _(cos) _(tan) \
++  _(asin) _(acos) _(atan) _(sinh) _(cosh) _(tanh) _(frexp) _(modf) _(atan2) \
++  _(pow) _(fmod) _(ldexp) _(sqrt)
++
++enum {
++#define GOTENUM(name) LJ_GOT_##name,
++GOTDEF(GOTENUM)
++#undef GOTENUM
++  LJ_GOT__MAX
++};
++#endif
++
+ /* Type of hot counter. Must match the code in the assembler VM. */
+ /* 16 bits are sufficient. Only 0.0015% overhead with maximum slot penalty. */
+ typedef uint16_t HotCount;
+@@ -89,7 +104,7 @@ typedef uint16_t HotCount;
+ typedef struct GG_State {
+   lua_State L;				/* Main thread. */
+   global_State g;			/* Global state. */
+-#if LJ_TARGET_MIPS
++#if LJ_TARGET_MIPS || LJ_TARGET_PPC
+   ASMFunction got[LJ_GOT__MAX];		/* Global offset table. */
+ #endif
+ #if LJ_HASJIT
+diff --git a/src/vm_ppc.dasc b/src/vm_ppc.dasc
+index c63f15c3..810e6ac9 100644
+--- a/src/vm_ppc.dasc
++++ b/src/vm_ppc.dasc
+@@ -51,7 +51,12 @@
+ |.macro blex, target; bl extern target; nop; .endmacro
+ |.macro .toc, a, b; a, b; .endmacro
+ |.else
+-|.macro blex, target; bl extern target@plt; .endmacro
++|.macro blex, target
++|  lwz TMP0, DISPATCH_GOT(target)(DISPATCH)
++|  mtctr TMP0
++|  bctrl
++|  //bl extern target@plt
++|.endmacro
+ |.macro .toc, a, b; .endmacro
+ |.endif
+ |.if OPD
+@@ -578,6 +583,8 @@
+ |// Assumes DISPATCH is relative to GL.
+ #define DISPATCH_GL(field)	(GG_DISP2G + (int)offsetof(global_State, field))
+ #define DISPATCH_J(field)	(GG_DISP2J + (int)offsetof(jit_State, field))
++#define GG_DISP2GOT		(GG_OFS(got) - GG_OFS(dispatch))
++#define DISPATCH_GOT(name)	(GG_DISP2GOT + 4*LJ_GOT_##name)
+ |
+ #define PC2PROTO(field)  ((int)offsetof(GCproto, field)-(int)sizeof(GCproto))
+ |
+-- 
+2.24.1
+

--- a/lang/luajit/patches/010-lua-path.patch
+++ b/lang/luajit/patches/010-lua-path.patch
@@ -8,6 +8,6 @@
 -#define LUA_LUADIR	"/lua/5.1/"
 +#define LUA_LROOT	"/usr"
 +#define LUA_LUADIR	"/lua/"
- #define LUA_LJDIR	"/luajit-2.1.0-beta3/"
- 
+ #define LUA_LJDIR	"/luajit-2.1.2/"
+
  #ifdef LUA_ROOT


### PR DESCRIPTION
Maintainer: @milani
Compile tested: 
- Turris Omnia, mvebu (cortex-a9), OpenWrt master
- Turris 1.1, powerpc_8540, OpenWrt 18.06.05
Run tested:
- Turris Omnia, mvebu (cortex-a9), OpenWrt master with Knot Resolver and Suricata

Description:

Buildroot switched to [moonjit fork](https://git.busybox.net/buildroot/commit/package?id=2ca0accc21a090874ac6e97670b47153a1f0a0b5)

What are the improvements from luajit to moonjit:
- fork of inactive development
- can be compiled for powerpc (verified) instead of luajit, which currently on [buildbots](https://downloads.openwrt.org/releases/faillogs-19.07/powerpc_8540/packages/luajit/compile.txt) and locally fails, because of this:
```
lj_arch.h:422:2: error: #error "No support for PowerPC CPUs without double-precision FPU"
 #error "No support for PowerPC CPUs without double-precision FPU"
  ^~~~~
lj_arch.h:431:2: error: #error "No support for PPC/e500 anymore (use LuaJIT 2.0)"
 #error "No support for PPC/e500 anymore (use LuaJIT 2.0)"
  ^~~~~
```