### PR TITLE
libidn2: Update to 2.3.0

### DIFF
--- a/libs/libidn2/Makefile
+++ b/libs/libidn2/Makefile
@@ -8,17 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libidn2
-PKG_VERSION:=2.0.5
+PKG_VERSION:=2.3.0
 PKG_RELEASE:=1
-PKG_LICENSE:=GPL-2.0-or-later LGPL-3.0-or-later
-PKG_LICENSE_FILES:=COPYING COPYINGv2 COPYING.LESSERv3
-PKG_CPE_ID:=cpe:/a:libidn2_project:libidn2
 
 PKG_SOURCE_URL:=@GNU/libidn
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=53f69170886f1fa6fa5b332439c7a77a7d22626a82ef17e2c1224858bb4ca2b8
+PKG_HASH:=e1cb1db3d2e249a6a3eb6f0946777c2e892d5c5dc7bd91c74394fc3a01cab8b5
+
+PKG_MAINTAINER:=
+PKG_CPE_ID:=cpe:/a:libidn2_project:libidn2
 
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -42,6 +43,8 @@ define Package/idn2
   SUBMENU:=IP Addresses and Names
   TITLE:=GNU IDN2 (Internationalized Domain Name) tool
   DEPENDS:=+libidn2
+  LICENSE:=GPL-2.0-or-later
+  LICENSE_FILES:=COPYINGv2
 endef
 
 define Package/idn2/description
@@ -57,6 +60,8 @@ define Package/libidn2
   DEPENDS:=+libunistring $(ICONV_DEPENDS) $(INTL_DEPENDS)
   TITLE:=International domain name library (IDNA2008, Punycode and TR46)
   URL:=https://www.gnu.org/software/libidn/#libidn2
+  LICENSE:=LGPL-3.0-or-later
+  LICENSE_FILES:=COPYING.LESSERv3
 endef
 
 define Package/libidn2/description


### PR DESCRIPTION
Fixed license information.

Several Makefile cleanups for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: none
Compile tested: mvebu