### PR TITLE
dnscrypt-proxy2: Update to version 2.0.34

### DIFF
--- a/net/dnscrypt-proxy2/Makefile
+++ b/net/dnscrypt-proxy2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnscrypt-proxy2
-PKG_VERSION:=2.0.29
+PKG_VERSION:=2.0.34
 PKG_RELEASE:=1
 
 PKG_SOURCE:=dnscrypt-proxy-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/jedisct1/dnscrypt-proxy/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=5c18f0c9d6a89b64d532c98e2bd976f98211a715399c7a1ee81a22c5485673b9
+PKG_SOURCE_URL:=https://codeload.github.com/DNSCrypt/dnscrypt-proxy/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=38ec7df2bdeff6d094d8975c0005c1d896a63b529cba417381b63fcf51d42303
 PKG_BUILD_DIR:=$(BUILD_DIR)/dnscrypt-proxy-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
@@ -24,7 +24,7 @@ PKG_BUILD_DEPENDS:=golang/host
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
-GO_PKG:=github.com/jedisct1/dnscrypt-proxy
+GO_PKG:=github.com/DNSCrypt/dnscrypt-proxy
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
@@ -33,7 +33,7 @@ define Package/dnscrypt-proxy2
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Flexible DNS proxy with encrypted DNS protocols
-  URL:=https://github.com/jedisct1/dnscrypt-proxy
+  URL:=https://github.com/DNSCrypt/dnscrypt-proxy
   DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
   CONFLICTS:=dnscrypt-proxy
 endef


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- Changelogs:
https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.0.30
https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.0.31
https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.0.32
https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.0.30
https://github.com/DNSCrypt/dnscrypt-proxy/releases/tag/2.0.34

- Repository was renamed to github.com/DNSCrypt/dnscrypt-proxy

