### PR TITLE
pdns-recursor: update to 4.2.1

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=4.2.0
+PKG_VERSION:=4.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=f03c72c1816fdcc645cc539d8c16721d2ec294feac9b5179e78c3db311b7c2c2
+PKG_HASH:=8d8c3235cc5281f0fc51946129f22758778f4c50bfda095d5856feb4c756891f
 
 PKG_MAINTAINER:=James Taylor <james@jtaylor.id.au>
 PKG_LICENCE:=GPL-2.0-only
@@ -25,7 +25,7 @@ define Package/pdns-recursor
   SUBMENU:=IP Addresses and Names
   USERID:=pdns:pdns
   TITLE:=PowerDNS Recursor
-  DEPENDS:=+boost +boost-context +boost-thread +libatomic +liblua +libopenssl +protobuf
+  DEPENDS:=+boost +boost-context +libatomic +liblua +libopenssl +protobuf
   URL:=https://www.powerdns.com/recursor.html
 endef
 

--- a/net/pdns-recursor/files/recursor.conf-dist
+++ b/net/pdns-recursor/files/recursor.conf-dist
@@ -612,7 +612,7 @@
 #################################
 # version-string	string reported on version.pdns or version.bind
 #
-# version-string=PowerDNS Recursor 4.2.0 (built May 18 2019 15:59:49 by jamestk@zanzabar.cybase.for-no-reason.net)
+# version-string=PowerDNS Recursor 4.2.1
 
 #################################
 # webserver	Start a webserver (for REST API)

--- a/net/pdns-recursor/patches/200-boost_thread_fix.patch
+++ b/net/pdns-recursor/patches/200-boost_thread_fix.patch
@@ -1,0 +1,24 @@
+--- a/m4/boost.m4
++++ b/m4/boost.m4
+@@ -667,12 +667,15 @@
+ BOOST_DEFUN([Context],
+ [boost_context_save_LIBS=$LIBS
+  boost_context_save_LDFLAGS=$LDFLAGS
+-if test $boost_major_version -ge 157; then
+-  BOOST_THREAD([$1], [$2])
+-  m4_pattern_allow([^BOOST_THREAD_(LIBS|LDFLAGS)$])dnl
+-  LIBS="$LIBS $BOOST_THREAD_LIBS"
+-  LDFLAGS="$LDFLAGS $BOOST_THREAD_LDFLAGS"
+-fi
++# This check is flawed and doesn't actually verify if BOOST::THREAD
++# is required on the system, producing only false positives on the
++# platforms supported by OpenWRT.
++#if test $boost_major_version -ge 157; then
++#  BOOST_THREAD([$1], [$2])
++#  m4_pattern_allow([^BOOST_THREAD_(LIBS|LDFLAGS)$])dnl
++#  LIBS="$LIBS $BOOST_THREAD_LIBS"
++#  LDFLAGS="$LDFLAGS $BOOST_THREAD_LDFLAGS"
++#fi
+ 
+ if test $boost_major_version -ge 161; then
+ BOOST_FIND_LIB([context], [$1],


### PR DESCRIPTION
Maintainer: me
Compile tested: Ubuntu w/ Openwrt buildroot SNAPSHOT
Run tested: Linksys WRT1900ACS armv7 - Snapshot. pdns_recursor runs correctly with no errors

Description:
Updates pdns-recursor to current stable 4.2.1. Also includes more complete fix
for boost.m4 BOOST::THREAD detection, removing dependency on boost-thread.

Signed-off-by: James Taylor <james@jtaylor.id.au>