### PR TITLE
cifsd: update to git (2019-12-17), cifsd-tools: build static, fix init

### DIFF
--- a/kernel/cifsd/Makefile
+++ b/kernel/cifsd/Makefile
@@ -5,9 +5,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/cifsd-team/cifsd.git
-PKG_SOURCE_DATE:=2019-11-27
-PKG_SOURCE_VERSION:=b8675c8ac144ece00f3e6bcc5436c8ace99e23e9
-PKG_MIRROR_HASH:=3d67af87f30d837f95510663efc42f1451651dc235987408924b56cb277fc8e8
+PKG_SOURCE_DATE:=2019-12-17
+PKG_SOURCE_VERSION:=60c1556d71b74daa5d1707b8cd0859eeef458793
+PKG_MIRROR_HASH:=f73d79798cc74180ad3e5cd9df0321c9a32fcbfaecee646bd3af548332040b0f
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -37,7 +37,8 @@ define KernelPackage/fs-cifsd
 endef
 
 define KernelPackage/fs-cifsd/description
-	Kernel module for a CIFS/SMBv2,3 fileserver.
+  Cifsd is an In-kernel SMB3/CIFS fileserver.
+  It's an implementation of SMB/CIFS protocol in kernel space for sharing files and IPC services over network.
 endef
 
 # broken atm (needs CONFIG_KEYS=y)

--- a/kernel/cifsd/patches/01-keep_kmod_metadata.patch
+++ b/kernel/cifsd/patches/01-keep_kmod_metadata.patch
@@ -1,0 +1,10 @@
+--- a/glob.h	2019-12-08
++++ b/glob.h	2019-12-08
+@@ -7,6 +7,8 @@
+ #ifndef __CIFSD_GLOB_H
+ #define __CIFSD_GLOB_H
+ 
++#undef CONFIG_MODULE_STRIPPED
++
+ #include <linux/ctype.h>
+ #include <linux/version.h>

--- a/net/cifsd-tools/Makefile
+++ b/net/cifsd-tools/Makefile
@@ -5,9 +5,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/cifsd-team/cifsd-tools.git
-PKG_SOURCE_DATE:=2019-11-27
-PKG_SOURCE_VERSION:=06fd4153a5d5af1f96a20234f397bd149a8e4832
-PKG_MIRROR_HASH:=2849d2af471e327abc8d67afc91ca767c410e2b307d6554531a0b387d9ad909a
+PKG_SOURCE_DATE:=2019-12-17
+PKG_SOURCE_VERSION:=f0f5979fd00d7097eddec7dae3027dff0a34935b
+PKG_MIRROR_HASH:=afc67d94ca4c2e16d0774a1a25f3d94ccebbecd76bdd78521129181b724ef466
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -18,28 +18,74 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 PKG_REMOVE_FILES:=autogen.sh
 
+PKG_BUILD_DEPENDS:=glib2
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
-define Package/cifsd-tools
+define Package/cifsd-tools/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Filesystem
-  TITLE:=Kernel CIFS/SMB server support and userspace tools
+  TITLE:=Kernel SMB/CIFS
   URL:=https://github.com/cifsd-team/cifsd-tools
-  DEPENDS:=+kmod-fs-cifsd +glib2 +libnl-core +libnl-genl
+  DEPENDS:= $(ICONV_DEPENDS) $(INTL_DEPENDS)
 endef
 
-define Package/cifsd-tools/description
-  Userspace tools (cifsd, cifsuseradd, cifsshareadd) for the CIFS/SMB kernel fileserver.
+define Package/cifsd-tools/Default/description
+  Userspace tools for the SMB/CIFS kernel fileserver (cifsd.ko).
   The config file location is /etc/cifs/smb.conf
 endef
 
-define Package/cifsd-tools/install
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcifsdtools.so* $(1)/usr/lib/
+define Package/cifsd-server
+  $(call Package/cifsd-tools/Default)
+  TITLE+= server
+  DEPENDS+= +kmod-fs-cifsd +libnl-core +libnl-genl
+endef
+
+define Package/cifsd-server/description
+  installs: cifsd
+
+  This provides the basic fileserver service and is the minimum needed to serve 'guest only' file shares or use a existing cifsdpwd.db.
+endef
+
+define Package/cifsd-server/config
+  select PACKAGE_wsdd2
+endef
+
+define Package/cifsd-utils
+  $(call Package/cifsd-tools/Default)
+  TITLE+= user management-util
+endef
+
+define Package/cifsd-utils/description
+  installs: cifsuseradd (cifsshareadd)
+
+  Tool needed to create the cifsdpwd.db, to manage per user share passwords.
+  NOTE: Not needed for 'guest only' shares.
+endef
+
+define Package/cifsd-utils/config
+	config CIFSD_UTILS_SHAREADD
+		bool "Add cifsshareadd util"
+		depends on PACKAGE_cifsd-utils
+		help
+			Add the cifsshareadd tool, to directly manipulate the /etc/cifs/smb.conf.
+		default n
+endef
+
+CONFIGURE_ARGS += \
+	--disable-shared \
+	--enable-static
+
+CONFIGURE_VARS += GLIB_LIBS="$(STAGING_DIR)/usr/lib/libglib-2.0.a"
+
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed -liconv $(if $(INTL_FULL),-lintl)
+
+define Package/cifsd-server/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/{cifsuseradd,cifsshareadd,cifsd} $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/cifsd $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/cifs $(1)/etc/init.d
 	$(INSTALL_CONF) ./files/cifsd.config $(1)/etc/config/cifsd
 	$(INSTALL_DATA) ./files/smb.conf.template $(1)/etc/cifs/
@@ -49,11 +95,20 @@ define Package/cifsd-tools/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/Documentation/configuration.txt $(1)/etc/cifs/
 endef
 
-define Package/cifsd-tools/conffiles
+define Package/cifsd-utils/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/cifsuseradd $(1)/usr/sbin/
+ifeq ($(CONFIG_CIFSD_UTILS_SHAREADD),y)
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/cifsshareadd $(1)/usr/sbin/
+endif
+endef
+
+define Package/cifsd-server/conffiles
 /etc/config/cifsd
 /etc/cifs/smb.conf.template
 /etc/cifs/smb.conf
 /etc/cifs/cifsdpwd.db
 endef
 
-$(eval $(call BuildPackage,cifsd-tools))
+$(eval $(call BuildPackage,cifsd-server))
+$(eval $(call BuildPackage,cifsd-utils))

--- a/net/cifsd-tools/files/cifsd.config
+++ b/net/cifsd-tools/files/cifsd.config
@@ -1,2 +1,3 @@
 config globals
+	option 'workgroup'		'WORKGROUP'
 	option 'description'	'Cifsd on OpenWrt'

--- a/net/cifsd-tools/files/cifsd.init
+++ b/net/cifsd-tools/files/cifsd.init
@@ -39,7 +39,7 @@ smb_header()
 	[ -e /etc/cifs/smb.conf ] || ln -nsf /var/etc/cifs/smb.conf /etc/cifs/smb.conf
 
 	if [ ! -L /etc/cifs/smb.conf ]; then
-		logger -t 'cifsd' "Local custom /etc/cifs/smb.conf file detected, all UCI/Luci config settings are ignored!"
+		logger -p daemon.warn -t 'cifsd' "Local custom /etc/cifs/smb.conf file detected, all UCI/Luci config settings are ignored!"
 	fi
 }
 
@@ -130,7 +130,7 @@ init_config()
 
 service_triggers()
 {
-	PROCD_RELOAD_DELAY=2000
+	# PROCD_RELOAD_DELAY=1000
 
 	procd_add_reload_trigger "dhcp" "system" "cifsd"
 
@@ -140,64 +140,56 @@ service_triggers()
 	done
 }
 
+kill_server()
+{
+	if [ -e /sys/module/cifsd ]; then
+		if [ -e /sys/class/cifsd-control/kill_server ]; then
+			logger -p daemon.info -t 'cifsd' "triggering kill_server"
+			echo hard > /sys/class/cifsd-control/kill_server
+		fi
+	fi
+}
+
 start_service()
 {
 	init_config
 
 	if [ ! -e /etc/cifs/smb.conf ]; then
-		logger -t 'cifsd' "missing config /etc/cifs/smb.conf, needs to-be created manually!"
+		logger -p daemon.error -t 'cifsd' "missing config /etc/cifs/smb.conf!"
 		exit 1
-	fi
-
-	if [ -e /sys/module/cifsd ]; then
-		if [ -e /sys/class/cifsd-control/kill_server ]; then
-			# upstream "BUG": ensure changes in smb.conf are reflected on a running kernel-server
-			echo hard > /sys/class/cifsd-control/kill_server
-			# we need a extra timeout for the reset
-			sleep 5
-		fi
 	fi
 	
-	modprobe cifsd 2> /dev/null
+	# NOTE: We don't do a soft-reload via signal, since [global] smb.conf setting changes will be ignored, so always reset hard.
+	kill_server
+	
+	[ ! -e /sys/module/cifsd ] && modprobe cifsd 2> /dev/null
 	if [ ! -e /sys/module/cifsd ]; then
-		logger -t 'cifsd' "modprobe of cifsd module failed, can\'t start cifsd!"
+		logger -p daemon.error -t 'cifsd' "modprobe of cifsd module failed, can\'t start cifsd!"
 		exit 1
 	fi
 
-	logger -t 'cifsd' "Starting CIFS/SMB userspace service."
+	logger -p daemon.notice -t 'cifsd' "Starting CIFS/SMB userspace service."
 	procd_open_instance
+	procd_add_mdns "smb" "tcp" "445"
 	procd_set_param command /usr/sbin/cifsd --n
-	procd_set_param file /var/etc/cifs/smb.conf
+	procd_set_param file /etc/cifs/smb.conf
+	procd_set_param limits nofile=16384
 	procd_close_instance
 }
 
 stop_service()
 {
-	logger -t 'cifsd' "Stopping CIFSD userspace service."
+	logger -p daemon.notice -t 'cifsd' "Stopping CIFSD userspace service."
 	killall cifsd > /dev/null 2>&1
 	
 	[ -e /sys/module/cifsd ] && rmmod cifsd > /dev/null 2>&1
-	# With open smb connections rmmod is not possible, without waiting for the long 'ipc timeout', so we use 'kill_server'!
-	if [ -e /sys/module/cifsd ]; then
-		logger -t 'cifsd' "triggering kill_server"
-		if [ -e /sys/class/cifsd-control/kill_server ]; then
-			echo hard > /sys/class/cifsd-control/kill_server
-			# we need a extra timeout for the reset
-			sleep 5
-		fi
-	fi
+	# kill server if we cant rmmod
+	[ -e /sys/module/cifsd ] && kill_server
 	# next try
-	[ -e /sys/module/cifsd ] && rmmod cifsd > /dev/null 2>&1
-	# check again
-	if [ -e /sys/module/cifsd ]; then
-		# wait more...
-		sleep 3
-	fi
-	# last try
 	[ -e /sys/module/cifsd ] && rmmod cifsd > /dev/null 2>&1
 	
 	if [ -e /sys/module/cifsd ]; then
-		logger -t 'cifsd' "module still loaded after 8s timeout"
+		logger -p daemon.error -t 'cifsd' "module still loaded after kill_server?"
 	fi
 	[ -f /tmp/cifsd.lock ] && rm /tmp/cifsd.lock
 }

--- a/net/cifsd-tools/files/smb.conf.template
+++ b/net/cifsd-tools/files/smb.conf.template
@@ -7,3 +7,8 @@
 	ipc timeout = 20
 	deadtime = 15
 	map to guest = Bad User
+	smb2 max read = 64K
+	smb2 max write = 64K
+	smb2 max trans = 64K
+	cache read buffers = no
+	cache trans buffers = no


### PR DESCRIPTION
Maintainer: me
Compile tested: arm/mips/mipsel/x86_64 (master)
Run tested: arm/mvebu, mips/lantiq (master)

Description:
* cifsd: update to git (2019-12-07)
* cifsd: add patch to keep version metadata in kmod
* cifsd: add synchrous kill_server patches
* cifsd-tools: update to git (2019-11-30)
* cifsd-tools: split package into server/utils (reducce size)
* cifsd-tools: build static
* cifsd-tools: fix init (luci save&apply)
* cifsd-tools: remove kill_server related timeouts

NOTE: I switched to a static build, since this reduces the total size of cifsd-server.ipk to just 100kb, without needing any extra depends. All you need is the cifsd.ko + cifsd binary.
This allows to get a modern smb3 (Win10) compatible share working out of the box, on any device.

NOTE: depends on #10780