### PR TITLE
[18.06] treewide: replace old wiki links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing Guidelines  
-(See <http://wiki.openwrt.org/doc/devel/packages> for overall format and construction)
+(See <https://openwrt.org/docs/guide-developer/packages> for overall format and construction)
 
 
 ### Basic guidelines
@@ -29,7 +29,7 @@ All packages you commit or submit by pull-request should follow these simple gui
 * Have a useful description prefixed with the package name
     (E.g.: "foopkg: Add libzot dependency")
 * Include Signed-off-by in the comment
-    (See <https://dev.openwrt.org/wiki/SubmittingPatches#a10.Signyourwork>)
+    (See <https://openwrt.org/submitting-patches#sign_your_work>)
 
 ### Advice on pull requests:
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 This is the OpenWrt "packages"-feed containing community-maintained build scripts, options and patches for applications, modules and libraries used within OpenWrt.
 
-Installation of pre-built packages is handled directly by the **opkg** utility within your running OpenWrt system or by using the [OpenWrt SDK](http://wiki.openwrt.org/doc/howto/obtain.firmware.sdk) on a build system.
+Installation of pre-built packages is handled directly by the **opkg** utility within your running OpenWrt system or by using the [OpenWrt SDK](https://openwrt.org/docs/guide-developer/using_the_sdk) on a build system.
 
 ## Usage
 
-This repository is intended to be layered on-top of an OpenWrt buildroot. If you do not have an OpenWrt buildroot installed, see the documentation at: [OpenWrt Buildroot – Installation](http://wiki.openwrt.org/doc/howto/buildroot.exigence) on the OpenWrt support site.
+This repository is intended to be layered on-top of an OpenWrt buildroot. If you do not have an OpenWrt buildroot installed, see the documentation at: [OpenWrt Buildroot – Installation](https://openwrt.org/docs/guide-developer/build-system/install-buildsystem) on the OpenWrt support site.
 
 This feed is enabled by default. To install all its package definitions, run:
 ```

--- a/admin/zabbix/Makefile
+++ b/admin/zabbix/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zabbix
 PKG_VERSION:=3.2.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=3ea0c299bd69bc728177128740f0476bc1a2c1de438330df5bbd8f5fc6090712
@@ -84,19 +84,19 @@ endef
 define Package/zabbix-extra-mac80211/description
 An extra package for zabbix-agentd that adds a discovery rule for mac80211 wifi phy and many userparameters.
 It contains an suid helper to allow zabbix-agentd to still run as zabbix user and not as root.
-See http://wiki.openwrt.org/doc/howto/zabbix for ready to use zabbix templates.
+See https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use zabbix templates.
 endef
 
 define Package/zabbix-extra-network/description
 An extra package for zabbix-agentd that adds a discovery rule for openwrt network interfaces.
 The idea here is to discover only interfaces listed in /etc/config/network (discover br-lan and not eth0.1 and wlan0)
-See http://wiki.openwrt.org/doc/howto/zabbix for ready to use zabbix templates.
+See https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use zabbix templates.
 endef
 
 define Package/zabbix-extra-wifi/description
 An extra package for zabbix-agentd that adds a discovery rule for wifi interfaces and many userparameters.
 As it uses libiwinfo, it works with all wifi devices supported by openwrt.
-See http://wiki.openwrt.org/doc/howto/zabbix for ready to use zabbix templates.
+See https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use zabbix templates.
 endef
 
 CONFIGURE_ARGS+= \

--- a/admin/zabbix/files/mac80211
+++ b/admin/zabbix/files/mac80211
@@ -1,7 +1,7 @@
-#see http://wiki.openwrt.org/doc/howto/zabbix for ready to use templates
+#see https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use templates
 
 # If you want to know the exact meaning of an UserParameter, you can search in the ieee80211 standard:
-# http://standards.ieee.org/getieee802/download/802.11-2012.pdf
+# https://standards.ieee.org/standard/802_11-2016.html
 # example: for mac80211.ACKFailureCount search for dot11ACKFailureCount (page 2145)
 
 # mac80211 phy discovery (like 'phy0')

--- a/admin/zabbix/files/network
+++ b/admin/zabbix/files/network
@@ -1,4 +1,4 @@
-#see http://wiki.openwrt.org/doc/howto/zabbix for ready to use templates
+#see https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use templates
 
 # network interface discovery
 # example: {"data":[{"{#IF}":"lo", "{#NET}":"loopback"},{"{#IF}":"br-lan", "{#NET}":"lan"},{"{#IF}":"eth0.1", "{#NET}":"wan"}]}

--- a/admin/zabbix/files/wifi
+++ b/admin/zabbix/files/wifi
@@ -1,4 +1,4 @@
-#see http://wiki.openwrt.org/doc/howto/zabbix for ready to use templates
+#see https://openwrt.org/docs/guide-user/services/network_monitoring/zabbix for ready to use templates
 
 # wifi interface discovery
 # example: {"data":[{"{#IF}":"wlan0", "{#MODE}":"ap", "{#SSID}":"Openwrt", "{#NET}":"lan", "{#DEV}":"radio0", "{#ENC}":"psk2+ccmp", "{#TYPE}":"mac80211", "{#HWMODE}":"11ng", "{#CHANNEL}":"11", "{#BSSID}":"xx:xx:xx:xx:xx:xx"}]}

--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=3.5.5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-3.0+
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -118,7 +118,7 @@ A lot of people already use adblocker plugins within their desktop browsers, but
 ## Tweaks
 * **runtime information:** the adblock status is available via _/etc/init.d/adblock status_ (see example below)
 * **debug logging:** for script debugging please set the config option 'adb\_debug' to '1' and check the runtime output with _logread -e "adblock"_
-* **storage expansion:** to process and store all blocklist sources at once it might helpful to enlarge your temp directory with a swap partition => see [OpenWrt Wiki](https://wiki.openwrt.org/doc/uci/fstab) for further details
+* **storage expansion:** to process and store all blocklist sources at once it might helpful to enlarge your temp directory with a swap partition => see [OpenWrt Wiki](https://openwrt.org/docs/guide-user/storage/fstab) for further details
 * **add white- / blacklist entries:** add domain white- or blacklist entries to always-allow or -deny certain (sub) domains, by default both lists are empty and located in _/etc/adblock_. Please add one domain per line - ip addresses, wildcards & regex are _not_ allowed (see example below)
 * **backup & restore blocklists:** enable this feature, to restore automatically the latest compressed backup of your blocklists in case of any processing error (e.g. a single blocklist source is not available during update). Please use an (external) solid partition and _not_ your volatile router temp directory for this
 * **download queue size:** for further download & list processing performance improvements you can raise the 'adb\_maxqueue' value, e.g. '8' or '16' should be safe

--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.8
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=
@@ -36,7 +36,7 @@ define Package/ddns-scripts
 endef
 # shown in LuCI package description
 define Package/ddns-scripts/description
-    Dynamic DNS Client scripts (with IPv6 support) - Info: http://wiki.openwrt.org/doc/howto/ddns.client
+    Dynamic DNS Client scripts (with IPv6 support) - Info: https://openwrt.org/docs/guide-user/services/ddns/client
 endef
 # shown in menuconfig <Help>
 define Package/ddns-scripts/config
@@ -50,7 +50,7 @@ define Package/ddns-scripts/config
 		  - log file support
 		  - support to run once
 		Version: $(PKG_VERSION)-$(PKG_RELEASE)
-		Info   : http://wiki.openwrt.org/doc/howto/ddns.client
+		Info   : https://openwrt.org/docs/guide-user/services/ddns/client
 endef
 
 ###### *************************************************************************

--- a/net/ddns-scripts/files/ddns.config
+++ b/net/ddns-scripts/files/ddns.config
@@ -1,5 +1,5 @@
 #
-# Please read http://wiki.openwrt.org/doc/uci/ddns
+# Please read https://openwrt.org/docs/guide-user/base-system/ddns
 #
 config ddns "global"
 	option ddns_dateformat "%F %R"

--- a/net/xl2tpd/Makefile
+++ b/net/xl2tpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xl2tpd
 PKG_VERSION:=1.3.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE

--- a/net/xl2tpd/README.md
+++ b/net/xl2tpd/README.md
@@ -34,7 +34,7 @@ netifd will not do the check and retry.
 
 The following are generic ppp options and should have the same format and
 semantics as with other ppp-related protocols.  See
-[uci/network#protocol_ppp](https://wiki.openwrt.org/doc/uci/network#protocol_ppp_ppp_over_modem)
+[uci/network#protocol_ppp](https://openwrt.org/docs/guide-user/network/wan/wan_interface_protocols#protocol_ppp_ppp_over_modem)
 for details.
 
 	username


### PR DESCRIPTION
Backport of #10762, fixes #10740 

Maintainers: @champtar @yousong @dibdot 
Compile tested: N/A
Run tested: N/A

Description:
Replaced all references to "wiki.openwrt.org" with links to the latest wiki pages.

Signed-off-by: Leong Hui Wong <wong.leonghui@gmail.com>