### PR TITLE
node-hid: update to 1.1.0

### DIFF
--- a/lang/node-hid/Makefile
+++ b/lang/node-hid/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NPM_NAME:=node-hid
 PKG_NAME:=$(PKG_NPM_NAME)
-PKG_VERSION:=0.7.9
+PKG_VERSION:=1.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://registry.npmjs.org/$(PKG_NPM_NAME)/-/
-PKG_HASH:=a13710ebff0a2d0e60e08442db192a4e891db89d535306d461b8a95ede7dbd90
+PKG_HASH:=a128331388b9a0ac443fb55493e37a9b8043f34699c60453f395ad37b7d5f145
 
 PKG_BUILD_DEPENDS:=node/host
 PKG_USE_MIPS16:=0
@@ -24,6 +24,7 @@ PKG_LICENSE:=MIT or X11
 PKG_LICENSE_FILES:=
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/node-hid
   SUBMENU:=Node.js
@@ -31,7 +32,7 @@ define Package/node-hid
   CATEGORY:=Languages
   TITLE:=Node.js package to access HID devices
   URL:=https://github.com/node-hid/node-hid
-  DEPENDS:=+node +node-npm +libusb-1.0 +hidapi +libudev-fbsd
+  DEPENDS:=+node +node-npm +libusb-1.0 +hidapi +libudev-fbsd $(ICONV_DEPENDS)
 endef
 
 define Package/node-hid/description
@@ -45,6 +46,7 @@ NODEJS_CPU:=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst
 TMPNPM:=$(shell mktemp -u XXXXXXXXXX)
 
 TARGET_CFLAGS+=$(FPIC) -I$(STAGING_DIR)/usr/include/libusb-1.0
+TARGET_LDFLAGS+=$(if $(ICONV_FULL),-liconv)
 
 define Build/Compile
 	git init $(PKG_BUILD_DIR)
@@ -71,7 +73,7 @@ define Package/node-hid/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/$(PKG_NPM_NAME)/{node_modules,src} \
 		$(1)/usr/lib/node/$(PKG_NPM_NAME)/
 	$(INSTALL_DIR) $(1)/usr/lib/node/$(PKG_NPM_NAME)/build/Release
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/$(PKG_NPM_NAME)/build/Release/HID.node \
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/$(PKG_NPM_NAME)/build/Release/HID*.node \
 		$(1)/usr/lib/node/$(PKG_NPM_NAME)/build/Release/
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(LN) ../lib/node/node-hid/src/show-devices.js $(1)/usr/bin/hid-showdevices

--- a/lang/node-hid/patches/000-support_musl.patch
+++ b/lang/node-hid/patches/000-support_musl.patch
@@ -1,0 +1,11 @@
+diff -urN a/hidapi/linux/hid.c b/hidapi/linux/hid.c
+--- a/hidapi/linux/hid.c	1985-10-26 17:15:00.000000000 +0900
++++ b/hidapi/linux/hid.c	2019-12-12 11:15:11.164454207 +0900
+@@ -24,6 +24,7 @@
+ /* C */
+ #include <stdio.h>
+ #include <string.h>
++#include <stdarg.h>
+ #include <stdlib.h>
+ #include <locale.h>
+ #include <errno.h>


### PR DESCRIPTION
Maintainer: me 
Compile tested: head r11589-3f5cf38, aarch64, x86_64
Run tested: aarch64 (qemu), x86_64

Description:
Now uses libusb/hidapi! This should fix several outstanding issues.
Added support for Electron v7.
Up to Node v12 is supported (Node v13 isn't in node-abi yet, so prebuild can't make prebuilt binaries for it)
Includes updated hidapi that allows Macs to see devices with multiple usages/usagePages
Prebuilds now include Node v13 and Electron v6

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>

