### PR TITLE
dnsdist: add missing dependency on libcap

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsdist
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
@@ -66,7 +66,7 @@ define Package/dnsdist
   CATEGORY:=Network
   SUBMENU:=IP Addresses and Names
   TITLE:=dnsdist DNS-, DOS- and abuse-aware loadbalancer
-  DEPENDS:=+DNSDIST_OPENSSL:libopenssl +DNSDIST_GNUTLS:libgnutls +protobuf +re2 +libedit +libfstrm +lua +boost +libnetsnmp +libatomic +libsodium +DNSDIST_DNS_OVER_HTTPS:libh2o-evloop
+  DEPENDS:=+DNSDIST_OPENSSL:libopenssl +DNSDIST_GNUTLS:libgnutls +protobuf +re2 +libcap +libedit +libfstrm +lua +boost +libnetsnmp +libatomic +libsodium +DNSDIST_DNS_OVER_HTTPS:libh2o-evloop
   URL:=https://dnsdist.org/
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: Ubuntu w/ OpenWrt buildroot SNAPSHOT
Run tested: Linksys WRT1900ACS armv7 - still runs

Description:
When present on the build system dnsdist will try to make use of libcap. This
change adds an explicit dependency to ensure it's present at build time, to
prevent build failures when another package brings the dependency in.

Signed-off-by: James Taylor <james@jtaylor.id.au>
