### PR TITLE
h2o: update wslay link patch to upstream

### DIFF
--- a/libs/h2o/Makefile
+++ b/libs/h2o/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=h2o
 PKG_VERSION:=2.2.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://codeload.github.com/h2o/h2o/tar.gz/v${PKG_VERSION}?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/libs/h2o/patches/200-libh2o-evloop_wslay-link.patch
+++ b/libs/h2o/patches/200-libh2o-evloop_wslay-link.patch
@@ -1,9 +1,45 @@
---- a/libh2o-evloop.pc.in
-+++ b/libh2o-evloop.pc.in
-@@ -7,5 +7,5 @@
- Description: An optimized HTTP/1.x & HTTP/2 library
- URL: https://h2o.examp1e.net/
- Version: @LIBRARY_VERSION_MAJOR@.@LIBRARY_VERSION_MINOR@.@LIBRARY_VERSION_PATCH@
--Libs: -L${libdir} -lh2o-evloop
-+Libs: -L${libdir} -lh2o-evloop -lwslay
- Cflags: -I${includedir}
+From f7d5cb83826c7e2b1a3dc618b434d85df130a4d5 Mon Sep 17 00:00:00 2001
+From: James Taylor <james@jtaylor.id.au>
+Date: Tue, 10 Dec 2019 21:58:45 +1100
+Subject: [PATCH] Explicitly link against WSLAY when available
+
+When other libraries attempt to link against libh2o and libh2o-evloop that was
+compiled with libwslay available, there are errors from missing symbols
+associated with code which makes use of the wslay library. To rectify this,
+explicitly link against libwslay during the build process.
+
+Fixes #2105
+
+Signed-off-by: James Taylor <james@jtaylor.id.au>
+---
+ CMakeLists.txt | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a68613081..13c2f8a9f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -519,13 +519,21 @@ SET_TARGET_PROPERTIES(libh2o PROPERTIES
+     OUTPUT_NAME h2o
+     VERSION ${LIBRARY_VERSION}
+     SOVERSION ${LIBRARY_SOVERSION})
+-TARGET_LINK_LIBRARIES(libh2o ${LIBUV_LIBRARIES} ${EXTRA_LIBS})
++IF (WSLAY_FOUND)
++    TARGET_LINK_LIBRARIES(libh2o ${WSLAY_LIBRARIES} ${LIBUV_LIBRARIES} ${EXTRA_LIBS})
++ELSE ()
++    TARGET_LINK_LIBRARIES(libh2o ${LIBUV_LIBRARIES} ${EXTRA_LIBS})
++ENDIF (WSLAY_FOUND)
+ SET_TARGET_PROPERTIES(libh2o-evloop PROPERTIES
+     OUTPUT_NAME h2o-evloop
+     COMPILE_FLAGS "-DH2O_USE_LIBUV=0"
+     VERSION ${LIBRARY_VERSION}
+     SOVERSION ${LIBRARY_SOVERSION})
+-TARGET_LINK_LIBRARIES(libh2o-evloop ${EXTRA_LIBS})
++IF (WSLAY_FOUND)
++    TARGET_LINK_LIBRARIES(libh2o-evloop ${WSLAY_LIBRARIES} ${EXTRA_LIBS})
++ELSE ()
++    TARGET_LINK_LIBRARIES(libh2o-evloop ${EXTRA_LIBS})
++ENDIF (WSLAY_FOUND)
+ 
+ TARGET_INCLUDE_DIRECTORIES(libh2o PUBLIC ${OPENSSL_INCLUDE_DIR})
+ TARGET_INCLUDE_DIRECTORIES(libh2o-evloop PUBLIC ${OPENSSL_INCLUDE_DIR})


### PR DESCRIPTION
Maintainer: me
Compile tested: Ubuntu w/ OpenWrt Buildroot SNAPSHOT
Run tested: Linksys WRT1900ACS armv7 - SNAPSHOT

Description:
Update wslay link patch with upstream fix from h2o/h2o#2196

Signed-off-by: James Taylor <james@jtaylor.id.au>