### PR TITLE
dnsdist: fix missing quote in menu

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -41,7 +41,7 @@ menu "Configuration"
 
 	endchoice
 
-	comment "DNS over HTTPS/TLS Support
+	comment "DNS over HTTPS/TLS Support"
 	depends on !DNSDIST_NOSSL
 
 	config DNSDIST_DNS_OVER_HTTPS


### PR DESCRIPTION
Maintainer: me
Compile tested: no
Run tested: no

Description:
Fixes missing double quote in menu

Signed off by: James Taylor <james@jtaylor.id.au>
