### PR TITLE
minidlna: add static uuid in config

### DIFF
--- a/multimedia/minidlna/Makefile
+++ b/multimedia/minidlna/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=minidlna
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.code.sf.net/p/minidlna/git

--- a/multimedia/minidlna/files/minidlna.config
+++ b/multimedia/minidlna/files/minidlna.config
@@ -15,5 +15,6 @@ config minidlna config
 	option serial '12345678'
 	option model_number '1'
 	option root_container '.'
+	option uuid '019f9a56-ff60-44c0-9edc-eae88d09fa05'
 	list media_dir '/mnt'
 	option album_art_names 'Cover.jpg/cover.jpg/AlbumArtSmall.jpg/albumartsmall.jpg/AlbumArt.jpg/albumart.jpg/Album.jpg/album.jpg/Folder.jpg/folder.jpg/Thumb.jpg/thumb.jpg'

--- a/multimedia/minidlna/files/minidlna.init
+++ b/multimedia/minidlna/files/minidlna.init
@@ -70,6 +70,7 @@ minidlna_create_config() {
 	minidlna_cfg_addstr "$cfg" model_number '1'
 	minidlna_cfg_addstr "$cfg" minissdpsocket
 	minidlna_cfg_addstr "$cfg" root_container '.'
+	minidlna_cfg_addstr "$cfg" uuid '019f9a56-ff60-44c0-9edc-eae88d09fa05'
 	config_list_foreach "$cfg" "media_dir" minidlna_cfg_add_media_dir
 
 	return 0


### PR DESCRIPTION
minidlna uses UUID to uniquely identify the media server
by default, if the "uuid" option is not specified in
its setting file it will try to autogenerate it by
reading MAC address.

This seems to fail on some devices resulting in random
UUID on reboot, and this causes confusion and issues as
for clients this is a new server and must be added to
the list.
In OpenWrt there are also devices where the system can't
read the true MAC address and it is therefore randomized
on reboot.

So, add a static UUID in the settings file.
Since each mindlna server should have a different UUID,
if the user has more than one OpenWrt device with
minidlna, he should change the UUID of the
additional devices.

Signed-off-by: Alberto Bursi <bobafetthotmail@gmail.com>

Maintainer: @medaved  (find it by checking history of the package Makefile)
