### PR TITLE
tor: enable sandboxing if seccomp is detected

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -45,6 +45,17 @@ define Package/tor
 $(call Package/tor/Default)
   TITLE:=An anonymous Internet communication system
   DEPENDS:=+libevent2 +libopenssl +libpthread +librt +zlib +libcap
+  VARIANT:=normal
+endef
+
+define Package/tor-seccomp
+$(call Package/tor/Default)
+  TITLE:=An anonymous Internet communication system with seccomp sandboxing
+  DEPENDS:=\
+	+libevent2 +libopenssl +libpthread +librt +zlib +libcap \
+	+libseccomp @(aarch64||arm||x86_64)
+  VARIANT:=seccomp
+  PROVIDES:=tor
 endef
 
 define Package/tor/description
@@ -52,10 +63,13 @@ $(call Package/tor/Default/description)
  This package contains the tor daemon.
 endef
 
+Package/tor-seccomp/description = $(Package/tor/description)
+
 define Package/tor-gencert
 $(call Package/tor/Default)
   TITLE:=Tor certificate generation
   DEPENDS:=+tor
+  VARIANT:=normal
 endef
 
 define Package/tor-gencert/description
@@ -67,6 +81,7 @@ define Package/tor-resolve
 $(call Package/tor/Default)
   TITLE:=tor hostname resolve
   DEPENDS:=+tor
+  VARIANT:=normal
 endef
 
 define Package/tor-resolve/description
@@ -78,6 +93,7 @@ define Package/tor-geoip
 $(call Package/tor/Default)
   TITLE:=GeoIP db for tor
   DEPENDS:=+tor
+  VARIANT:=normal
 endef
 
 define Package/tor-geoip/description
@@ -92,12 +108,13 @@ define Package/tor/conffiles
 /etc/config/tor
 endef
 
+Package/tor-seccomp/conffiles = $(Package/tor/conffiles)
+
 CONFIGURE_ARGS += \
 	--with-libevent-dir="$(STAGING_DIR)/usr" \
 	--with-openssl-dir="$(STAGING_DIR)/usr" \
 	--with-zlib-dir="$(STAGING_DIR)/usr" \
 	--disable-asciidoc \
-	--disable-seccomp \
 	--disable-libscrypt \
 	--disable-unittests \
 	--disable-lzma \
@@ -105,6 +122,12 @@ CONFIGURE_ARGS += \
 	--with-tor-user=tor \
 	--with-tor-group=tor \
 	--with-pic
+
+ifeq ($(BUILD_VARIANT),seccomp)
+CONFIGURE_ARGS += --enable-seccomp
+else
+CONFIGURE_ARGS += --disable-seccomp
+endif
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
 TARGET_LDFLAGS += -Wl,--gc-sections -flto
@@ -122,6 +145,8 @@ define Package/tor/install
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/tor.conf $(1)/etc/config/tor
 endef
+
+Package/tor-seccomp/install = $(Package/tor/install)
 
 define Package/tor-gencert/install
 	$(INSTALL_DIR) $(1)/usr/sbin
@@ -142,6 +167,7 @@ define Package/tor-geoip/install
 endef
 
 $(eval $(call BuildPackage,tor))
+$(eval $(call BuildPackage,tor-seccomp))
 $(eval $(call BuildPackage,tor-gencert))
 $(eval $(call BuildPackage,tor-resolve))
 $(eval $(call BuildPackage,tor-geoip))


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master


Description:
~~This PR enables sandboxing in tor in case that seccomp is enabled in kernel.~~ Fixes https://github.com/openwrt/packages/issues/10635
Update:
PR creates tor packages variant with enabled seccomp support.

