### PR TITLE
glib2: fix mips16 build, add size reducing static link, fpic CFLAGS

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.58.3
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_BUILD_DIR:=$(BUILD_DIR)/glib-$(PKG_VERSION)
@@ -21,7 +21,6 @@ HOST_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=gettext
 HOST_BUILD_DEPENDS:=gettext-full/host libiconv/host libffi/host
 PKG_INSTALL:=1
-PKG_USE_MIPS16:=0
 
 PKG_CPE_ID:=cpe:/a:gnome:glib
 
@@ -45,6 +44,8 @@ endef
 define Package/glib2/description
   The GLib library of C routines
 endef
+
+TARGET_CFLAGS += $(FPIC) -ffunction-sections -fdata-sections -flto
 
 HOST_CONFIGURE_ARGS += \
 	--disable-libelf \

--- a/libs/glib2/patches/003-valgrind.h-mips16-fix.patch
+++ b/libs/glib2/patches/003-valgrind.h-mips16-fix.patch
@@ -1,0 +1,11 @@
+--- a/glib/valgrind.h	2019-12-12 14:53:26.000200499 +0100
++++ b/glib/valgrind.h	2019-12-12 14:49:45.056163300 +0100
+@@ -157,7 +157,7 @@
+ #  define PLAT_s390x_linux 1
+ #elif defined(__linux__) && defined(__mips__) && (__mips==64)
+ #  define PLAT_mips64_linux 1
+-#elif defined(__linux__) && defined(__mips__) && (__mips!=64)
++#elif defined(__linux__) && defined(__mips__) && (__mips!=64) && !defined(__mips16)
+ #  define PLAT_mips32_linux 1
+ #elif defined(__sun) && defined(__i386__)
+ #  define PLAT_x86_solaris 1


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: mips/arm (master)
Run tested: mips/lantiq, arm/mvebu (master)

Description:
* allows building as mips16 (fixes broken mips16/32 mixed static linking)
* add some static link related flags to reduce target binary size

PS: I did test static glib2 via cifsd static build and shared via Midnight Commander package on both platforms and had no issues.