### PR TITLE
ffmpeg: update to 3.4.7

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=3.4.6
-PKG_RELEASE:=5
+PKG_VERSION:=3.4.7
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
-PKG_HASH:=3572279cb139d9e39dcfbc23edf438ff5311ec3fc5d0dcb3558e49591e5cb83e
+PKG_HASH:=efd01782fd29b62505c973f5b61a65632d7b435dc9f4a6c97e92e6afd36cf5c8
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Ian Leonard <antonlacon@gmail.com>
 


### PR DESCRIPTION
Maintainer: me & @thess
Compile tested: arm/mvebu git HEAD as of 2019-12-12
Run tested: arm/mvebu git HEAD as of 2019-12-12

Description: Update ffmpeg to 3.4.7.

@thess time for ffmpeg 4+? This means no more ffserver.

@micmac1 requested avresample to be added to ffmpeg some time ago. libavresample has been deprecated for close to 2 years and I expect it to be purged in the near future. Please check if your usecase updated to libswresample.
