### PR TITLE
fish: Fix compilation with libcxx

### DIFF
--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fish
 PKG_VERSION:=3.0.2
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/fish-shell/fish-shell/releases/download/$(PKG_VERSION)
@@ -54,10 +54,10 @@ define Package/fish/postinst
 grep fish $${IPKG_INSTROOT}/etc/shells || \
     echo "/usr/bin/fish" >> $${IPKG_INSTROOT}/etc/shells
 
-    # Backwards compatibility
-    if [ -e /bin/fish ] && { [ ! -L /bin/fish ] || [ "$(readlink -fn $${IPKG_INSTROOT}/bin/fish)" != "../$(CONFIGURE_PREFIX)/bin/fish" ]; }; then
-        ln -fs "../$(CONFIGURE_PREFIX)/bin/fish" "$${IPKG_INSTROOT}/bin/fish"
-    fi
+# Backwards compatibility
+if [ -e /bin/fish ] && { [ ! -L /bin/fish ] || [ "$(readlink -fn $${IPKG_INSTROOT}/bin/fish)" != "../$(CONFIGURE_PREFIX)/bin/fish" ]; }; then
+    ln -fs "../$(CONFIGURE_PREFIX)/bin/fish" "$${IPKG_INSTROOT}/bin/fish"
+fi
 endef
 
 define Package/fish/postrm

--- a/utils/fish/patches/010-cxx.patch
+++ b/utils/fish/patches/010-cxx.patch
@@ -1,0 +1,27 @@
+From c132a2aa53f3a4ca0ab26395a4936ecf3fd030f2 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 13 Dec 2019 21:50:06 -0800
+Subject: [PATCH] common.cpp: Don't always include cxxabi.h
+
+cxxabi.h is not available with LLVM's libcxx
+---
+ src/common.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/common.cpp b/src/common.cpp
+index cfa4cb0d81..96873f17a9 100644
+--- a/src/common.cpp
++++ b/src/common.cpp
+@@ -1,8 +1,11 @@
+ // Various functions, mostly string utilities, that are used by most parts of fish.
+ #include "config.h"
+ 
+-#include <ctype.h>
++#ifdef HAVE_BACKTRACE_SYMBOLS
+ #include <cxxabi.h>
++#endif
++
++#include <ctype.h>
+ #include <dlfcn.h>
+ #include <errno.h>
+ #include <fcntl.h>


### PR DESCRIPTION
cxxabi.h is a useless header that libcxx does not include.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @haodong 
Compile tested: ath79