### PR TITLE
protobuf: fix libdir handling for host build

### DIFF
--- a/libs/protobuf/Makefile
+++ b/libs/protobuf/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=protobuf
 PKG_VERSION:=3.8.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-cpp-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/google/protobuf/releases/download/v$(PKG_VERSION)
@@ -72,6 +72,7 @@ CMAKE_HOST_OPTIONS += \
 	-Dprotobuf_BUILD_TESTS=OFF \
 	-DBUILD_SHARED_LIBS=ON \
 	-DCMAKE_SKIP_RPATH=OFF \
+	-DCMAKE_INSTALL_LIBDIR=lib \
 	-DCMAKE_INSTALL_RPATH="${STAGING_DIR_HOSTPKG}/lib"
 
 CMAKE_OPTIONS += \


### PR DESCRIPTION
On some host machines (example: Gentoo amd64 no-multilib) by default
cmake will install libraries to lib64. But in OpenWrt the correct libdir
is lib (for instance the RPATH is set to lib). So you may end up with
libraries in lib64 while RPATH points to lib:

```
sk@darth ~/tmp/openwrt $ ldd staging_dir/hostpkg/bin/protoc
	linux-vdso.so.1 (0x00007ffc741ea000)
	libprotoc.so.3.8.0.0 => not found
	libprotobuf.so.3.8.0.0 => not found
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f0a8f7ea000)
	libstdc++.so.6 => /usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/libstdc++.so.6 (0x00007f0a8f572000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f0a8f427000)
	libgcc_s.so.1 => /usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/libgcc_s.so.1 (0x00007f0a8f40d000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f0a8f23c000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f0a8f827000)
sk@darth ~/tmp/openwrt $

```
Fix this by specifying the libdir during host builds.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: noone
Compile tested: x86_64
Run tested: x86_64

Description:
Hi all,

Found protoc host tool not working due to missing libs on my build host.

Kind regards,
Seb