### PR TITLE
https_dns_proxy: Added optional ipv4 resolvers

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2019-12-03
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy

--- a/net/https-dns-proxy/files/https-dns-proxy.config
+++ b/net/https-dns-proxy/files/https-dns-proxy.config
@@ -5,6 +5,8 @@ config https-dns-proxy
 	option listen_port '5053'
 	option user 'nobody'
 	option group 'nogroup'
+	option ipv4_resolvers '1'
+	option verbosity '0' # fatal = 0, error = 1, warning = 2, info = 3, debug = 4
 
 config https-dns-proxy
 	option bootstrap_dns '1.1.1.1,1.0.0.1'
@@ -13,3 +15,5 @@ config https-dns-proxy
 	option listen_port '5054'
 	option user 'nobody'
 	option group 'nogroup'
+	option ipv4_resolvers '1'
+	option verbosity '0' # fatal = 0, error = 1, warning = 2, info = 3, debug = 4

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -31,16 +31,6 @@ append_parm() {
 	xappend "$switch $_loctmp"
 }
 
-append_match() {
-	local section="$1"
-	local option="$2"
-	local value="$3"
-	local match="$4"
-	local _loctmp
-	config_get_bool _loctmp "$section" "$option"
-	[ "$_loctmp" = "$match" ] && xappend "$value"
-}
-
 start_instance() {
 	local cfg="$1" param listen_addr listen_port
 
@@ -54,19 +44,34 @@ start_instance() {
 	append_parm "$cfg" 'proxy_server' '-t'
 	append_parm "$cfg" 'logfile' '-l'
 	append_bool "$cfg" 'use_http1' '-x'
-	append_match "$cfg" 'verbosity' '-v' '1'
-	append_match "$cfg" 'verbosity' '-vv' '2'
-	append_match "$cfg" 'verbosity' '-vvv' '3'
-	append_match "$cfg" 'verbosity' '-vvvv' '4'
+	append_bool "$cfg" 'ipv4_resolvers' '-4'
+
+	config_get verbosity "$cfg" 'verbosity' "0"
+	for i in $(seq 1 $verbosity); do
+		xappend "-v"
+	done
 
 	procd_open_instance
 # shellcheck disable=SC2086
-	procd_set_param command ${PROG} -4 ${param}
+	procd_set_param command ${PROG} ${param}
+	procd_set_param stderr 1
+	procd_set_param stdout 1
 	procd_set_param respawn
 	procd_close_instance
 
 	config_get listen_addr "$cfg" 'listen_addr' '127.0.0.1'
 	config_get listen_port "$cfg" 'listen_port' "$p"
+
+	# Don't add the any address to dnsmasq
+	case $listen_addr in
+		0.0.0.0|::ffff:0.0.0.0)
+			listen_addr='127.0.0.1'
+			;;
+		::)
+			listen_addr='::1'
+			;;
+	esac
+
 	config_load 'dhcp'
 # shellcheck disable=SC2154
 	config_foreach dnsmasq_add_doh_server 'dnsmasq' "${listen_addr}#${listen_port}"


### PR DESCRIPTION
Maintainer: @aarond10 
Compile tested: x86_x64, Hyper-V, OpenWrt Master
Run tested: x86_x64, Hyper-V, OpenWrt Master

Description:

* Added optional ipv4 resolvers UCI config option
* Added logging to logd
* Refactored verbosity UCI config option
* Filtered out any address from being added to dnsmasq
