### PR TITLE
smartdns: add new package

### DIFF
--- a/net/smartdns/Makefile
+++ b/net/smartdns/Makefile
@@ -1,0 +1,59 @@
+#
+# Copyright (c) 2018-2019 Nick Peng (pymumu@gmail.com)
+# This is free software, licensed under the GNU General Public License v3.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=smartdns
+PKG_VERSION:=1.2020.28
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://www.github.com/pymumu/smartdns.git
+PKG_SOURCE_VERSION:=2322a9dbd03de284acca388119f00a9bc7d9bec2
+PKG_MIRROR_HASH:=1698c0fc16fd67b72f1a588aad06427afd919541356e445ab75c26f5ce296e86
+
+PKG_MAINTAINER:=Nick Peng <pymumu@gmail.com>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+MAKE_VARS += VER=$(PKG_VERSION) 
+MAKE_PATH:=src
+
+define Package/smartdns
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=smartdns server
+  DEPENDS:=+libpthread +libopenssl
+  URL:=https://www.github.com/pymumu/smartdns/
+endef
+
+define Package/smartdns/description
+SmartDNS is a local DNS server which accepts DNS query requests from local network clients,
+get DNS query results from multiple upstream DNS servers concurrently, and returns the fastest IP to clients.
+Unlike dnsmasq's all-servers, smartdns returns the fastest IP. 
+endef
+
+define Package/smartdns/conffiles
+/etc/config/smartdns
+/etc/smartdns/address.conf
+/etc/smartdns/blacklist-ip.conf
+/etc/smartdns/custom.conf
+endef
+
+define Package/smartdns/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/config $(1)/etc/init.d $(1)/etc/smartdns
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/smartdns $(1)/usr/sbin/smartdns
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/package/openwrt/files/etc/init.d/smartdns $(1)/etc/init.d/smartdns
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/package/openwrt/address.conf $(1)/etc/smartdns/address.conf
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/package/openwrt/blacklist-ip.conf $(1)/etc/smartdns/blacklist-ip.conf
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/package/openwrt/custom.conf $(1)/etc/smartdns/custom.conf
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/package/openwrt/files/etc/config/smartdns $(1)/etc/config/smartdns
+endef
+
+$(eval $(call BuildPackage,smartdns))


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
ARCH: arm, mips, mipsel, x86, x86_64, aarch64
Model: K3, K3P
Openwrt: 18.0x, 19.0x
Run tested: (put here arch, model, OpenWrt version, tests done)
Model: K3, K3P
Openwrt: 18.0x, 19.0x

Description:
SmartDNS is a local DNS server which accepts DNS query requests from local network clients,
get DNS query results from multiple upstream DNS servers concurrently, and returns the fastest IP to clients.
Unlike dnsmasq's all-servers, smartdns returns the fastest IP. 

Signed-off-by: Nick Peng <pymumu@gmail.com>