### PR TITLE
knot: update to version 2.9.2

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=2.9.1
+PKG_VERSION:=2.9.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=f19121956caa360c387923654f13e4c97b3fb9093d242e110d7e0916b8d8a04d
+PKG_HASH:=298cdf33aa7589b50df7e5833694b24cd2de8b6d17cee7e1673873fe576db6ee
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Signed-off-by: Jan Hak <jan.hak@nic.cz>

Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.0-dev
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.0-dev, all tests successful (1 skipped)