### PR TITLE
libzip: fix musl-fts failure

### DIFF
--- a/libs/libzip/Makefile
+++ b/libs/libzip/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libzip
 PKG_VERSION:=1.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://libzip.org/download/
@@ -50,7 +50,7 @@ define Package/zipcmp
   SECTION:=utils
   CATEGORY:=Utilities
   SUBMENU:=Compression
-  DEPENDS:=+libzip
+  DEPENDS:=+libzip +USE_MUSL:musl-fts
 endef
 
 define Package/zipcmp/description

--- a/libs/libzip/patches/01-link-fts.patch
+++ b/libs/libzip/patches/01-link-fts.patch
@@ -1,0 +1,42 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -6,7 +6,7 @@ IF(NOT HAVE_GETOPT)
+ ENDIF(NOT HAVE_GETOPT)
+ 
+ ADD_EXECUTABLE(zipcmp zipcmp.c ${SRC_EXTRA_FILES})
+-TARGET_LINK_LIBRARIES(zipcmp zip)
++TARGET_LINK_LIBRARIES(zipcmp zip ${FTS_LIB})
+ INSTALL(TARGETS zipcmp RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+ 
+ ADD_EXECUTABLE(zipmerge zipmerge.c ${SRC_EXTRA_FILES})
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,6 +22,7 @@ OPTION(BUILD_DOC "Build documentation" O
+ 
+ INCLUDE(CheckFunctionExists)
+ INCLUDE(CheckIncludeFiles)
++INCLUDE(CheckLibraryExists)
+ INCLUDE(CheckSymbolExists)
+ INCLUDE(CheckTypeSize)
+ INCLUDE(CheckCSourceRuns)
+@@ -158,6 +159,20 @@ CHECK_FUNCTION_EXISTS(strtoll HAVE_STRTO
+ CHECK_FUNCTION_EXISTS(strtoull HAVE_STRTOULL)
+ 
+ CHECK_INCLUDE_FILES("sys/types.h;sys/stat.h;fts.h" HAVE_FTS_H)
++# fts functions may be in external library
++IF(HAVE_FTS_H)
++  CHECK_FUNCTION_EXISTS(fts_open HAVE_FTS_OPEN)
++  IF(NOT HAVE_FTS_OPEN)
++    CHECK_LIBRARY_EXISTS(fts fts_open "" HAVE_LIB_FTS)
++  ENDIF(NOT HAVE_FTS_OPEN)
++ENDIF(HAVE_FTS_H)
++
++IF(HAVE_LIB_FTS)
++  SET(FTS_LIB fts)
++ELSE()
++  SET(FTS_LIB "")
++ENDIF()
++
+ CHECK_INCLUDE_FILES(stdbool.h HAVE_STDBOOL_H)
+ CHECK_INCLUDE_FILES(strings.h HAVE_STRINGS_H)
+ CHECK_INCLUDE_FILES(unistd.h HAVE_UNISTD_H)


### PR DESCRIPTION
musl doesn't support fts. But with the extra package musl-fts installed,
libzip picks up the fts header and fails at the linking stage:

zipcmp.c:(.text.startup+0x130): undefined reference to `fts_open'
/home/sk/tmp/openwrt/staging_dir/toolchain-mips_24kc_gcc-8.3.0_musl/lib/gcc/mips-openwrt-linux-musl/8.3.0/../../../../mips-openwrt-linux-musl/bin/ld: zipcmp.c:(.text.startup+0x172): undefined reference to `fts_read'

So with musl-fts we need to link in libfts. To address that this commits
patches the cmake setup to check if fts is available in libc itself or
in any external libfts.

So when musl-fts is installed on the system the setup will be the
following:

musl: use libfts
uclibc: use fts from libc
glibc: like uclibc

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @mhei 
Compile tested: ath79 musl, arc uclibc
Run tested: N/A

Description:
Hello Michael,

Saw that libzip has a problem on build bots for musl targets, when musl-fts is installed. Here's a patch suggestion.

Kind regards,
Seb