### PR TITLE
tor: update to version 0.4.2.5

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.1.6
+PKG_VERSION:=0.4.2.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=2a88524ce426079fb9b828bc1b789f2c8ade3ed53c130851102debc3518bed71
+PKG_HASH:=4d5975862e7808faebe9960def6235669fafeeac844cb76965501fa7af79d8c2
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates tor to the new stable release. It contains new interesting features (rate-limiting against DDoS, etc) and a lot of bug fixes.

 https://blog.torproject.org/new-release-0425-also-0417-0406-and-0359
