### PR TITLE
cgi-io: close pipe descriptors early

### DIFF
--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=15
+PKG_RELEASE:=16
 
 PKG_LICENSE:=GPL-2.0-or-later
 

--- a/net/cgi-io/src/main.c
+++ b/net/cgi-io/src/main.c
@@ -778,6 +778,8 @@ main_backup(int argc, char **argv)
 		return -1;
 
 	default:
+		close(fds[1]);
+
 		now = time(NULL);
 		strftime(datestr, sizeof(datestr) - 1, "%Y-%m-%d", localtime(&now));
 
@@ -798,7 +800,6 @@ main_backup(int argc, char **argv)
 		waitpid(pid, &status, 0);
 
 		close(fds[0]);
-		close(fds[1]);
 
 		return 0;
 	}
@@ -1010,6 +1011,8 @@ main_exec(int argc, char **argv)
 		return -1;
 
 	default:
+		close(fds[1]);
+
 		printf("Status: 200 OK\r\n");
 		printf("Content-Type: %s\r\n",
 		       fields[7] ? fields[7] : "application/octet-stream");
@@ -1028,7 +1031,6 @@ main_exec(int argc, char **argv)
 		waitpid(pid, &status, 0);
 
 		close(fds[0]);
-		close(fds[1]);
 		free(args);
 
 		return 0;


### PR DESCRIPTION
Maintainer: @blogic 
Compile tested: x86/64, r11686-27d69d2561
Run tested: x86/64, r11032-4cb5f29625
Description:

In the command read side, close the superfluous write end of the pipe
early to ensure that EOF is reliably detected. Without that change, splice
calls to read from the pipe will occasionally hang until the CGI process
is eventually killed due to timeout.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>
