### PR TITLE
zsh: fix invalid postrm script and little refactor of scripts

### DIFF
--- a/utils/zsh/Makefile
+++ b/utils/zsh/Makefile
@@ -92,7 +92,7 @@ grep zsh $${IPKG_INSTROOT}/etc/shells || \
 	echo "/usr/bin/zsh" >> $${IPKG_INSTROOT}/etc/shells
 
 # Backwards compatibility
-if [[ -e /bin/zsh ]] && ([[ ! -L /bin/zsh ]] || [[ "$(readlink -fn $${IPKG_INSTROOT}/bin/zsh)" != "../$(CONFIGURE_PREFIX)/bin/zsh" ]]); then
+if [ -e /bin/zsh ] && { [ ! -L /bin/zsh ] || [ "$(readlink -fn $${IPKG_INSTROOT}/bin/zsh)" != "../$(CONFIGURE_PREFIX)/bin/zsh" ]; }; then
 	ln -fs "../$(CONFIGURE_PREFIX)/bin/zsh" "$${IPKG_INSTROOT}/bin/zsh"
 fi
 endef

--- a/utils/zsh/Makefile
+++ b/utils/zsh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zsh
 PKG_VERSION:=5.6.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/zsh
@@ -91,10 +91,10 @@ define Package/zsh/postinst
 grep zsh $${IPKG_INSTROOT}/etc/shells || \
 	echo "/usr/bin/zsh" >> $${IPKG_INSTROOT}/etc/shells
 
-	# Backwards compatibility
-	if [[ -e /bin/zsh ]] && ([[ ! -L /bin/zsh ]] || [[ "$(readlink -fn $${IPKG_INSTROOT}/bin/zsh)" != "../$(CONFIGURE_PREFIX)/bin/zsh" ]]); then
-		ln -fs "../$(CONFIGURE_PREFIX)/bin/zsh" "$${IPKG_INSTROOT}/bin/zsh"
-	fi
+# Backwards compatibility
+if [[ -e /bin/zsh ]] && ([[ ! -L /bin/zsh ]] || [[ "$(readlink -fn $${IPKG_INSTROOT}/bin/zsh)" != "../$(CONFIGURE_PREFIX)/bin/zsh" ]]); then
+	ln -fs "../$(CONFIGURE_PREFIX)/bin/zsh" "$${IPKG_INSTROOT}/bin/zsh"
+fi
 endef
 
 define Package/zsh/install
@@ -107,7 +107,8 @@ define Package/zsh/install
 endef
 
 define Package/zsh/postrm
-	rm -rf "$${IPKG_INSTROOT}/$(CONFIGURE_PREFIX)/share/zsh/$(PKG_VERSION)"
+#!/bin/sh
+rm -rf "$${IPKG_INSTROOT}/$(CONFIGURE_PREFIX)/share/zsh/$(PKG_VERSION)"
 endef
 
 $(eval $(call BuildPackage,zsh))


### PR DESCRIPTION
Maintainer: @msva @neheb 
Compile tested: Turris Omnia (master, openwrt-19.07)
Run tested:

Description:
The postrm script was missing shebang. Postrm scripts are packaged and
executed directly and not sourced by default script (as in case of prerm
and postinst).

Also move some indents around to not confuse reader. The section in
postinst was indented to same level as grep "condition" but is on same
level as initial grep (not part of that "condition").

Can this be cherry-picked to openwrt-19.07 as well?