### PR TITLE
wget: do not provide itself

### DIFF
--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.20.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -29,7 +29,7 @@ define Package/wget/Default
   SUBMENU:=File Transfer
   TITLE:=Non-interactive network downloader
   URL:=https://www.gnu.org/software/wget/index.html
-  PROVIDES:=wget
+  PROVIDES:=gnu-wget
 endef
 
 define Package/wget/Default/description
@@ -46,7 +46,6 @@ $(call Package/wget/Default)
   DEPENDS+= +libopenssl +librt
   TITLE+= (with SSL support)
   VARIANT:=ssl
-  PROVIDES+=gnu-wget
   ALTERNATIVES:=300:/usr/bin/wget:/usr/bin/wget-ssl
 endef
 
@@ -59,7 +58,7 @@ define Package/wget-nossl
 $(call Package/wget/Default)
   TITLE+= (without SSL support)
   VARIANT:=nossl
-  PROVIDES+=gnu-wget
+  PROVIDES+=wget
   ALTERNATIVES:=300:/usr/bin/wget:/usr/bin/wget-nossl
 endef
 


### PR DESCRIPTION
Maintainer: @tripolar @yousong 
Compile tested: Turris Omnia, 1.x, Mox (master, openwrt-19.07)
Run tested: Turris Omnia, 1.x, Mox (master, openwrt-19.07)

Description:
The package wget should not say that it provides itself.

This also make gnu-wget provide general so it is not written in Makefile
twice.