### PR TITLE
shadow: change default encryption method from DES to SHA512

### DIFF
--- a/utils/shadow/Makefile
+++ b/utils/shadow/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shadow
 PKG_VERSION:=4.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/shadow-maint/shadow/releases/download/$(PKG_VERSION)

--- a/utils/shadow/patches/005-set-encrypt-method-sha512.patch
+++ b/utils/shadow/patches/005-set-encrypt-method-sha512.patch
@@ -1,0 +1,11 @@
+--- a/etc/login.defs
++++ b/etc/login.defs
+@@ -317,7 +317,7 @@ CHFN_RESTRICT		rwh
+ # Note: If you use PAM, it is recommended to use a value consistent with
+ # the PAM modules configuration.
+ #
+-#ENCRYPT_METHOD DES
++ENCRYPT_METHOD SHA512
+ 
+ #
+ # Only works if ENCRYPT_METHOD is set to SHA256 or SHA512.


### PR DESCRIPTION
Maintainer: @sbyx 
Compile tested: Turris Omnia, 1.x, Mox (master, openwrt-19.07)
Run tested: Turris Omnia, 1.x, Mox (master, openwrt-19.07)

Description:
Busybox in default uses SHA512 as well.

On big ditribution this default is sourced from PAM. That means that
shadow reads pam settings and uses that. OpenWrt in most cases does not
have PAM installed and in such case shadow fallbacks to its own default
which is DES. This just changes that default to SHA512 which is
consistent with rest of the system.