### PR TITLE
syslog-ng: add missing libmaxminddb dependency

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.24.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
@@ -27,7 +27,7 @@ define Package/syslog-ng
   CATEGORY:=Administration
   TITLE:=A powerful syslog daemon
   URL:=https://www.syslog-ng.com/products/open-source-log-management/
-  DEPENDS:=+libpcre +glib2 +libopenssl +libpthread +librt +zlib +libdbi +libjson-c +libcurl +libuuid
+  DEPENDS:=+libpcre +glib2 +libopenssl +libpthread +librt +zlib +libdbi +libjson-c +libcurl +libuuid +libmaxminddb
 endef
 
 define Package/syslog-ng/description


### PR DESCRIPTION
Maintainer: @BKPepe 
Compile tested: Turris Omnia, 1.x, Mox (master, openwrt-19.07)
Run tested: Turris Omnia, 1.x, Mox (master, openwrt-19.07)

Description:
Packages feed now contains libmaxminddb and syslog-ng has it as an
optional dependency. When syslog-ng is build after libmaxminddb it
detects it, uses it and fails on dependency check later on.

libmaxminddb seems to be required for geoip2 module.
