### PR TITLE
meson: Update to version 0.52.1

### DIFF
--- a/devel/meson/Makefile
+++ b/devel/meson/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=meson
-PKG_VERSION:=0.52.0
+PKG_VERSION:=0.52.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/mesonbuild/meson/releases/download/$(PKG_VERSION)/
-PKG_HASH:=d60f75f0dedcc4fd249dbc7519d6f3ce6df490033d276ef1cf27453ef4938d32
+PKG_HASH:=0c277472e49950a5537e3de3e60c57b80dbf425788470a1a8ed27446128fc035
 
 PKG_MAINTAINER:=Andre Heider <a.heider@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: @dhewg 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- Update to version 0.52.1
Tag: https://github.com/mesonbuild/meson/releases/tag/0.52.1
