### PR TITLE
modemmanager: depend on ppp explicitly

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.12.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
@@ -42,6 +42,7 @@ define Package/modemmanager
 	$(INTL_DEPENDS) \
 	+glib2 \
 	+dbus \
+	+ppp \
 	+MODEMMANAGER_WITH_MBIM:libmbim \
 	+MODEMMANAGER_WITH_QMI:libqmi
 endef


### PR DESCRIPTION
The ModemManager protocol handler checks for the pppd daemon during
the initialization, and if it doesn't exist, the protocol handler is
not even loaded by netifd.

This is because the IP method to use on the connection of a given
modem is not known until ModemManager reports via its interfaces how
the modem should be connected (either using PPP, with DHCP, or with
explicit IP settings).

Fixes https://github.com/openwrt/packages/issues/10802

Signed-off-by: Aleksander Morgado <aleksander@aleksander.es>

Maintainer: @nickberry17 