### PR TITLE
nut: Fix NUT CGI startup script

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/files/nut-cgi.init
+++ b/net/nut/files/nut-cgi.init
@@ -29,7 +29,8 @@ nut_upscgi_add() {
 }
 
 start() {
-	rm -f $UPSCGI_C
+	mkdir -m 0755 -p "$(dirname "$UPSCGI_C")"
+	rm -f "$UPSCGI_C"
 
 	config_load nut_cgi
 


### PR DESCRIPTION
Commit c1aa1f784c737283b281da7a541921a88a81e684 which backported
a number of fixes from master, missed one fix for nut-cgi.  If
nut-cgi is installed standalone or nut-cgi starts before nut-server
(the default in 18.04.5) then the configuration file directory does
not get create and therefore there is no CGI configuration file.
This commit fixes that.

Closes: #10687

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: me
Compile tested: x86-64, Libvirt VM, 18.06-SNAPSHOT Dec 12 2019 
Run tested: same, brought up a separate VM for each of:

* nut-server (using dummy-ups  and data from my real UPS)
* nut-monitor
* nut-cgi

1) I configured each NUT piece and started NUT.
2) I verified on the NUT-server that it was getting output from the driver
3) I verified NUT monitor was connecting the server and getting / sending events
4) I verified that (the actual fix) NUT CGI works out of the box (once configured).  (I connected the CGI to the server and browsed to the CGI and verified the CGI pages worked).
