### PR TITLE
nss: Fix compilation with uClibc-ng

### DIFF
--- a/libs/nss/Makefile
+++ b/libs/nss/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nss
 PKG_VERSION:=3.48
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -62,6 +62,7 @@ ifeq ($(CONFIG_CPU_TYPE),"xscale")
 TARGET_CFLAGS+= -mfloat-abi=softfp
 endif
 
+TARGET_CFLAGS += -D_GNU_SOURCE
 TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 export CROSS_COMPILE=1


### PR DESCRIPTION
_GNU_SOURCE is needed for fdopen, sigaction, and probably more.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: arc700