### PR TITLE
kcptun: Fix GO_ARCH_DEPENDS

### DIFF
--- a/net/kcptun/Makefile
+++ b/net/kcptun/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kcptun
 PKG_VERSION:=20191112
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/xtaci/kcptun/tar.gz/v${PKG_VERSION}?
@@ -31,6 +31,7 @@ define Package/kcptun-config
   SUBMENU:=Web Servers/Proxies
   TITLE:=Kcptun Config Scripts
   URL:=https://github.com/xtaci/kcptun
+  DEPENDS:=$(GO_ARCH_DEPENDS)
 endef
 
 define Package/kcptun-config/install
@@ -47,7 +48,7 @@ define Package/kcptun/Default
     SUBMENU:=Web Servers/Proxies
     TITLE:=KCP-based Secure Tunnel $(1)
     URL:=https://github.com/xtaci/kcptun
-    DEPENDS:=+kcptun-config $$(GO_ARCH_DEPENDS)
+    DEPENDS:=+kcptun-config
   endef
 
   define Package/kcptun-$(1)/description


### PR DESCRIPTION
Right now, the buildbots are trying to build this on ARC, which is totally
unsupported.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @liudf0716 @expiron 
Compile tested: arc700

https://downloads.openwrt.org/snapshots/faillogs/arc_archs/packages/kcptun/compile.txt

ping @jefferyto 