### PR TITLE
[19.07] restic-rest-server: add package

### DIFF
--- a/net/restic-rest-server/Makefile
+++ b/net/restic-rest-server/Makefile
@@ -1,0 +1,49 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=restic-rest-server
+PKG_VERSION:=0.9.7
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/rest-server-$(PKG_VERSION)
+PKG_SOURCE:=rest-server-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/restic/rest-server/tar.gz/v${PKG_VERSION}?
+PKG_HASH:=922811cfc49879f7086fe559d25ec1bb4169b2c4a5df3559b499e6292f435661
+
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Markus Weippert <markus@gekmihesg.de>
+
+PKG_BUILD_DEPENDS:=golang/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/restic/rest-server/
+GO_PKG_BUILD_PKG:=github.com/restic/rest-server/cmd/rest-server/
+GO_PKG_LDFLAGS:=-s -w
+GO_PKG_LDFLAGS_X:=main.version=$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/restic-rest-server
+  TITLE:=restic REST server
+  URL:=http://github.com/restic/rest-server
+  DEPENDS:=$(GO_ARCH_DEPENDS)
+  SECTION:=net
+  CATEGORY:=Network
+endef
+
+define Package/restic-rest-server/description
+Rest Server is a high performance HTTP server that implements restic's REST backend
+API. It provides secure and efficient way to backup data remotely, using restic
+backup client via the rest: URL.
+endef
+
+define Package/restic-rest-server/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/rest-server $(1)/usr/bin/restic-rest-server
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call GoBinPackage,restic-rest-server))
+$(eval $(call BuildPackage,restic-rest-server))

--- a/net/restic-rest-server/files/etc/config/restic-rest-server
+++ b/net/restic-rest-server/files/etc/config/restic-rest-server
@@ -1,0 +1,13 @@
+config rest-server
+	option enabled '0'
+	option path '/mnt/backup'			# data directory (default "/tmp/restic")
+	#option append-only '1'				# enable append only mode
+	#option cpuprofile '/mnt/backup/cpuprofile'	# write CPU profile to file
+	#option debug '1'				# output debug messages
+	#option listen ':8000'				# listen address (default ":8000")
+	#option log '/mnt/backup/http.log'		# log HTTP requests in the combined log format
+	#option private-repos '1'			# users can only access their private repo
+	#option prometheus '1'				# enable Prometheus metrics
+	#option tls '1'					# turn on TLS support
+	#option tls-cert '/mnt/backup/public_key'	# TLS certificate path
+	#option tls-key '/mnt/backup/private_key'	# TLS key path

--- a/net/restic-rest-server/files/etc/init.d/restic-rest-server
+++ b/net/restic-rest-server/files/etc/init.d/restic-rest-server
@@ -1,0 +1,40 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+USE_PROCD=1
+
+PROG=/usr/bin/restic-rest-server
+
+start_instance() {
+	local cfg="$1"
+	local var
+	local val
+
+	config_get_bool val "$cfg" 'enabled' '0'
+	[ "$val" = 0 ] && return 1
+
+	procd_open_instance "$cfg"
+	procd_set_param command "$PROG"
+	for var in append_only debug private_repos prometheus tls; do
+		config_get_bool val "$cfg" "$var" 0
+		[ "$val" = 0 ] || procd_append_param command "--${var//_/-}"
+	done
+	for var in cpuprofile listen log path tls_cert tls_key; do
+		config_get val "$cfg" "$var"
+		[ -z "$val" ] || procd_append_param command "--${var//_/-}" "$val"
+	done
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn
+	procd_close_instance
+}
+
+
+service_triggers() {
+	procd_add_reload_trigger restic-rest-server
+}
+
+start_service() {
+	config_load restic-rest-server
+	config_foreach start_instance rest-server
+}


### PR DESCRIPTION
Maintainer: me / @gekmihesg
Compile tested: arm_cortex-a9_vfpv3, WRT3200ACM, master/19.07
Run tested: arm_cortex-a9_vfpv3, WRT3200ACM, master/19.07/18.06

Description:
Adds a package for restic/rest-server@2209f14
Already in master in #10824 