### PR TITLE
[OpenWrt 18.06] bind: Update to version 9.11.14

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.11.13
+PKG_VERSION:=9.11.14
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -21,7 +21,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=fd3f3cc9fcfcdaa752db35eb24598afa1fdcc2509d3227fc90a8631b7b400f7d
+PKG_HASH:=d93b30425996b074a5f9659323b6feae3408e0d325f029f114dfff96ea5e63df
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/patches/010-fix-variable-name-in-conditional-block.patch
+++ b/net/bind/patches/010-fix-variable-name-in-conditional-block.patch
@@ -1,0 +1,27 @@
+From 261c84d91d1b4581df9f7f0ec031908299de7726 Mon Sep 17 00:00:00 2001
+From: Mark Andrews <marka@isc.org>
+Date: Thu, 19 Dec 2019 09:27:44 +1100
+Subject: [PATCH] fix variable name in conditional block
+
+Origin: upstream, https://gitlab.isc.org/isc-projects/bind9/commit/261c84d91d1b4581df9f7f0ec031908299de7726
+
+---
+ lib/isc/stats.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/isc/stats.c b/lib/isc/stats.c
+index 5bce3c1100..a7ab97ce53 100644
+--- a/lib/isc/stats.c
++++ b/lib/isc/stats.c
+@@ -297,7 +297,7 @@ setcounter(isc_stats_t *stats,
+ 	isc_atomic_store((int32_t *)&stats->counters[counter].lo,
+ 			 (uint32_t)(value & 0xffffffff));
+ # else
+-	stats->counters[counter] = val;
++	stats->counters[counter] = value;
+ # endif
+ #endif
+ }
+-- 
+2.22.2
+


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: Turris 1.1, p2020, OpenWrt 18.06.05
Run tested: Turris 1.1, p2020, OpenWrt 18.06.05

Description:
Update to 9.11.14:
```
-  Fixed a bug that caused named to leak memory on reconfiguration when any GeoIP2 database was in use. [GL #1445]
-  Fixed several possible race conditions discovered by Thread Sanitizer.
```

and added [patch](https://gitlab.isc.org/isc-projects/bind9/commit/e8ba9397ebc1a09479237487152fc65cb713cca0), which fixes compilation