### PR TITLE
libmbim: bump libmbim to 1.20.4

### DIFF
--- a/libs/libmbim/Makefile
+++ b/libs/libmbim/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmbim
-PKG_VERSION:=1.20.2
-PKG_RELEASE:=3
+PKG_VERSION:=1.20.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libmbim
-PKG_HASH:=550fb69e5e57f7646f8eb9ed8d24e44ea869ad846be9c162893f12e43528059b
+PKG_HASH:=ac2708a409b09f1f6f1786a8a9e39c36619aa8d6f285ea943daa7a48ea36d3e8
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas.smith@telcoantennas.com.au>

Maintainer: me
Compile tested: ath79 CF-E5 master
Run tested: ath79, CF-E5 master
Description:
* libmbim-glib:
  * Fixed memleak when processing responses with multiple fragments.
  * Fixed memleak when processing failed Open operations.
  * Removed redundant method declaration in UUID header.
