### PR TITLE
pciutils: Use MIPS16

### DIFF
--- a/utils/pciutils/Makefile
+++ b/utils/pciutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pciutils
 PKG_VERSION:=3.6.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/utils/pciutils
@@ -19,7 +19,6 @@ PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 
-PKG_USE_MIPS16:=0
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 


### PR DESCRIPTION
There's no real computation going on. Slims the package slightly.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Noltari 
Compile tested: ramips