### PR TITLE
aria2: Build with MIPS16

### DIFF
--- a/net/aria2/Makefile
+++ b/net/aria2/Makefile
@@ -8,14 +8,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aria2
 PKG_VERSION:=1.35.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/aria2/aria2/releases/download/release-$(PKG_VERSION)/
 PKG_HASH:=1e2b7fd08d6af228856e51c07173cfcf987528f1ac97e04c5af4a47642617dfd
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_USE_MIPS16:=0
 
 PKG_MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>, \
 	Hsing-Wang Liao <kuoruan@gmail.com>


### PR DESCRIPTION
All the computationally expensive stuff is in the libraries, not the
package itself.

Saves several kilobytes.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @kuoruan 
Compile tested: ramips