### PR TITLE
spice: Fix compilation with uClibc-ng

### DIFF
--- a/libs/spice/Makefile
+++ b/libs/spice/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spice
 PKG_VERSION:=0.14.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.spice-space.org/download/releases/spice-server
 PKG_HASH:=b203b3882e06f4c7249a3150d90c84e1a90490d41ead255a3d2cede46f4a29a7
@@ -55,5 +55,8 @@ CONFIGURE_ARGS += \
 	--disable-smartcard \
 	--disable-statistics \
 	--without-sasl \
+
+CONFIGURE_VARS += \
+	gl_cv_warn_c__fstack_protector_all=no
 
 $(eval $(call BuildPackage,libspice-server))


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @yousong 
Compile tested: arc700

https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/spice/compile.txt