### PR TITLE
[openwrt-19.07] golang: Fix ldflags when GO_PKG_LDFLAGS is set

### DIFF
--- a/lang/golang/golang-package.mk
+++ b/lang/golang/golang-package.mk
@@ -275,7 +275,7 @@ define GoPackage/Build/Compile
 			mips|mipsle)     installsuffix="$(GO_MIPS)" ;; \
 			mips64|mips64le) installsuffix="$(GO_MIPS64)" ;; \
 			esac ; \
-			ldflags="all=-linkmode external -extldflags '$(TARGET_LDFLAGS)'" ; \
+			ldflags="-linkmode external -extldflags '$(TARGET_LDFLAGS)'" ; \
 			pkg_gcflags="$(GO_PKG_GCFLAGS)" ; \
 			pkg_ldflags="$(GO_PKG_LDFLAGS)" ; \
 			for def in $(GO_PKG_LDFLAGS_X); do \
@@ -284,10 +284,10 @@ define GoPackage/Build/Compile
 			go install \
 				$$$${installsuffix:+-installsuffix $$$$installsuffix} \
 				-trimpath \
-				-ldflags "$$$$ldflags" \
+				-ldflags "all=$$$$ldflags" \
 				-v \
 				$$$${pkg_gcflags:+-gcflags "$$$$pkg_gcflags"} \
-				$$$${pkg_ldflags:+-ldflags "$$$$pkg_ldflags"} \
+				$$$${pkg_ldflags:+-ldflags "$$$$pkg_ldflags $$$$ldflags"} \
 				$(1) \
 				$$$$targets ; \
 			retval=$$$$? ; \


### PR DESCRIPTION
Maintainer: me
Compile tested: none (cherry picked from #10874)
Run tested: none

Description:
`go build/install` supports multiple `-ldflags` arguments, but they are not combined; for each package, the [latest match on the command line][1] is used.

Previously, the main executable would not be affected by the default ldflags if `GO_PKG_LDFLAGS` or `GO_PKG_LDFLAGS_X` were set. (The default ldflags instructs go to use the external linker.)

This fixes golang-package.mk so that the default ldflags take effect in all cases.

[1]: https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from 4827bc7509f221a2a3585ba99ef9d7c331356db2)