### PR TITLE
lvm2: Lvm2 at preinit to enable overlays on lvm volumes

### DIFF
--- a/utils/lvm2/Makefile
+++ b/utils/lvm2/Makefile
@@ -90,6 +90,8 @@ define Package/lvm2/install
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/lvm/lvmlocal.conf $(1)/etc/lvm/
 	$(INSTALL_DIR) $(1)/etc/lvm/profile
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/lvm/profile/* $(1)/etc/lvm/profile/
+	$(INSTALL_DIR) $(1)/lib/preinit
+	$(INSTALL_DATA) ./files/lvm2.preinit $(1)/lib/preinit/80_lvm2
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/lvm2.init $(1)/etc/init.d/lvm2
 	$(FIND) $(PKG_INSTALL_DIR)/usr/sbin/ -type l -exec $(CP) -a {} $(1)/sbin/ \;

--- a/utils/lvm2/files/lvm2.preinit
+++ b/utils/lvm2/files/lvm2.preinit
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Copyright (C) 2019 Harrie Rooijackers
+
+# The make proecess copies this file to the /lib/preinit/80_lvm2 
+# As a result it is executed just before 80_mount_root and makes lvm
+# entities available during the mount_root process that handles any
+# overlays.  This allows overlays to be lvm2 partitions.
+
+# Note that /lib/preinit/80_lvm2 needs to be on the initial "lower"
+# partition for this to work.
+
+do_startlvm() {
+        echo "Starting lvm2 during preinit" > /dev/kmsg
+        # The following 3 lines are copied from from the start function
+        # in /etc/rc.d/S15lvm2 which is copyright by Stefan Monnier
+        mkdir -p /tmp/lvm/cache
+        /sbin/lvm vgscan --ignorelockingfailure --mknodes > /dev/kmsg || :
+        /sbin/lvm vgchange -aly --ignorelockingfailure > /dev/kmsg || return 2
+}
+
+# Perform the function only if lvm2 is enabled by the user
+# Not sure if the test is that useful since it tests the existance
+# of /etc/rc.d/S15lvm2 on the initial "lower" partition only so
+# changes made after the overlay is created are not taken into account
+[ -f /etc/rc.d/S15lvm2 ] && boot_hook_add preinit_main do_startlvm


### PR DESCRIPTION
Maintainer: me (?)  /   Daniel Golle <daniel@makrotopia.org>
Compile tested: x86_64, PC Engines APU2, openwrt-18.06
Run tested: x86_64, PC Engines APU2, openwrt-18.06, tested: overlay on lvm2 partition mounts at boot/reboot and works as expected.


Description:  Added a script and updated the Makefile so that lvm2 is activated before mount_root is performed.  This then allows having overlays on lvm2 partitions.
