### PR TITLE
dovecot: Disable libunwind support

### DIFF
--- a/mail/dovecot/Makefile
+++ b/mail/dovecot/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot
 PKG_VERSION:=2.3.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dovecot.org/releases/2.3
@@ -69,6 +69,7 @@ endef
 
 CONFIGURE_ARGS += \
 	--libexecdir=/usr/libexec \
+	--without-libunwind \
 	--without-pam \
 	--with-notify=dnotify \
 	--without-lzma \


### PR DESCRIPTION
Fixes missing dependency error.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: mvebu