### PR TITLE
[19.07] stubby: switch to ca-bundle

### DIFF
--- a/net/stubby/Makefile
+++ b/net/stubby/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stubby
 PKG_VERSION:=0.2.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYING
@@ -35,7 +35,7 @@ define Package/stubby
 	SUBMENU:=IP Addresses and Names
 	TITLE+= - (daemon that uses getdns)
 	USERID:=stubby=410:stubby=410
-	DEPENDS:= +libyaml +getdns +ca-certificates
+	DEPENDS:= +libyaml +getdns +ca-certs
 endef
 
 define Package/stubby/description

--- a/net/stubby/files/README.md
+++ b/net/stubby/files/README.md
@@ -24,7 +24,7 @@ Stubby](https://dnsprivacy.org/wiki/display/DP/About+Stubby) page.
 Installation of this package can be achieved at the command line using `opkg
 install stubby`, or via the LUCI Web Interface. Installing the stubby package
 will also install the required dependency packages, including the
-`ca-certificates` package.
+`ca-bundle` package.
 
 ## Configuration
 


### PR DESCRIPTION
Signed-off-by: Maxim Storchak <m.storchak@gmail.com>

Maintainer: @jonathanunderwood
Compile tested: not tested, see #10745 
Run tested: N/A
Description: ca-bundle provides the same set of CA certificates as ca-certificates, but is more compact in terms of filesystem space.

This a a backport of #10745 
