### PR TITLE
[18.06] unbound: update to 1.9.6

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.9.5
+PKG_VERSION:=1.9.6
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
@@ -17,7 +17,7 @@ PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound
-PKG_HASH:=8a8d400f697c61d73d109c250743a1b6b79848297848026d82b43e831045db57
+PKG_HASH:=1d98fc6ea99197a20b4a0e540e87022cf523085786e0fc26de6ebb2720f5aaf0
 
 PKG_BUILD_PARALLEL:=1
 PKG_FIXUP:=autoreconf


### PR DESCRIPTION
Maintainer: me
Tested: TL-Archer-C7 openwrt-18.06
Description: 
Cherry-pick from PR #10813.
Unbound received CVE fixes and potential bug fixes after third party audit.