### PR TITLE
passlib: Update passlib to 1.7.2

### DIFF
--- a/lang/python/passlib/Makefile
+++ b/lang/python/passlib/Makefile
@@ -4,12 +4,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=passlib
-PKG_VERSION:=1.7.1
+PKG_VERSION:=1.7.2
 PKG_RELEASE:=1
 PKG_LICENSE:=BSD-3-Clause
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=3d948f64138c25633613f303bcc471126eae67c04d5e3f6b7b8ce6242f8653e0
+PKG_HASH:=8d666cef936198bc2ab47ee9b0410c94adf2ba798e5a84bf220be079ae7ab6a8
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Relevant bits of upstream changelog

New Features

    argon2: Support more hashes
    scrypt: Now uses python 3.6 stdlib’s hashlib.scrypt() as backend, if present (issue 86).

Bugfixes

    Python 3.8 compatibility fixes
    passlib.apache.HtpasswdFile: improve compatibility with Apache 2.4's htpasswd
    passlib.totp: fix some compatibility issues with older TOTP clients (issue 92)
    Fixed error in argon2.parsehash() (issue 97)

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: me
Compile tested: brcm2708, rpi (b+), openwrt master (less the broken ubus/ubox/ucert commits), packages master, luci master
Run tested: same, configured radicale2 using luci-app-radicale2, create a user and password using the luci app (which uses passlib underneath), logged into radicale2, logged out, etc.
