### PR TITLE
radicale2: Document suggested use of passlib and bcrypt

### DIFF
--- a/net/radicale2/Makefile
+++ b/net/radicale2/Makefile
@@ -49,8 +49,14 @@ endef
 
 define Package/radicale2/description
 $(call Package/radicale2-meta/description)
-.
+
 This package contains the python files.
+
+Note that md5 encryption of passwords requires passlib, and
+bcrypt encryption requires passlib + bcrypt.  These are not
+added as hard dependencies as users may be running radicale2
+with a web server doing the authentication instead of radicale2.
+
 endef
 
 define Package/radicale2-examples/description


### PR DESCRIPTION
PKG_RELEASE not bumped because this only affects package description.
We document that passlib and bcrypt are needed if one wishes to use
bcrypt encryption of passwords.  These have not been added as dependencies
as Radicale2 can have a frontend webserver authenticate users rather than
radicale itself.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

Maintainer: me
Compile tested: brcm2708, openwrt master (less broken ubus/ubox/ucert commits), packages master
Run tested: N/A
