### PR TITLE
nginx: fix missing cgi-exec definition

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.17.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/

--- a/net/nginx/files-luci-support/luci_uwsgi.conf
+++ b/net/nginx/files-luci-support/luci_uwsgi.conf
@@ -5,7 +5,7 @@ location /cgi-bin/luci {
 		uwsgi_modifier1 9;
 		uwsgi_pass unix:////var/run/luci-webui.socket;
 }
-location ~ /cgi-bin/cgi-(backup|download|upload) {
+location ~ /cgi-bin/cgi-(backup|download|upload|exec) {
 		include uwsgi_params;
 		uwsgi_param SERVER_ADDR $server_addr;
 		uwsgi_modifier1 9;


### PR DESCRIPTION
Add missing cgi-io exec definition to fix broken
luci webui as now it does actually use it.

@hnyman Can you merge this?

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
