### PR TITLE
gst1-plugins-bad: Make HLS crypto explicit

### DIFF
--- a/multimedia/gst1-plugins-bad/Makefile
+++ b/multimedia/gst1-plugins-bad/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gst1-plugins-bad
 PKG_VERSION:=1.16.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org> \
 		Ted Hess <thess@kitschensync.net>
@@ -155,6 +155,7 @@ CONFIGURE_ARGS += \
 	--disable-zbar \
 	--disable-srtp \
 	\
+	--with-hls-crypto=nettle \
 	--without-html-dir \
 	--without-libiconv-prefix \
 	--without-libintl-prefix \


### PR DESCRIPTION
It's normally set to auto. When nettle is missing, it tries to use the
other libraries.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @flyn-org 
Compile tested: ipx400