### PR TITLE
[openwrt-19.07] golang: Format TARGET_LDFLAGS for gcc

### DIFF
--- a/lang/golang/golang-package.mk
+++ b/lang/golang/golang-package.mk
@@ -275,7 +275,7 @@ define GoPackage/Build/Compile
 			mips|mipsle)     installsuffix="$(GO_MIPS)" ;; \
 			mips64|mips64le) installsuffix="$(GO_MIPS64)" ;; \
 			esac ; \
-			ldflags="-linkmode external -extldflags '$(TARGET_LDFLAGS)'" ; \
+			ldflags="-linkmode external -extldflags '$(TARGET_LDFLAGS:-z%=-Wl,-z,%)'" ; \
 			pkg_gcflags="$(GO_PKG_GCFLAGS)" ; \
 			pkg_ldflags="$(GO_PKG_LDFLAGS)" ; \
 			for def in $(GO_PKG_LDFLAGS_X); do \


### PR DESCRIPTION
Maintainer: me
Compile tested: none (cherry picked from #10896)
Run tested: N/A

Description:
go invokes the external linker by calling gcc, so `-zxxx` options in `TARGET_LDFLAGS` (in golang-package.mk) need to be formatted as `-Wl,z,xxx`.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from dbd6f224c38367fb3a26b1ed0b76dd5e284a98a7)