### PR TITLE
omxplayer: add new package for Raspberry Pi

### DIFF
--- a/multimedia/ffmpeg-omx/Makefile
+++ b/multimedia/ffmpeg-omx/Makefile
@@ -1,0 +1,124 @@
+#
+# Copyright (C) 2017-2019 Ian Leonard <antonlacon@gmail.com>
+# Copyright (C) 2018 Ted Hess <thess@kitschensync.net>
+# Copyright (C) 2019 Álvaro Fernández Rojas <noltari@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ffmpeg-omx
+PKG_VERSION:=4.2.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=ffmpeg-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://ffmpeg.org/releases/
+PKG_HASH:=cb754255ab0ee2ea5f66f8850e1bd6ad5cac1cd855d0a2f4990fb8c668b0d29c
+
+PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later LGPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING.GPLv2 COPYING.GPLv3 COPYING.LGPLv2.1 COPYING.LGPLv3
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+TAR_OPTIONS:=--strip-components 1 $(TAR_OPTIONS)
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
+
+FFMPEG_CONFIGURE := \
+	CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS) $(FPIC)" \
+	LDFLAGS="$(TARGET_LDFLAGS)" \
+	./configure \
+	--enable-cross-compile \
+	--cross-prefix="$(TARGET_CROSS)" \
+	--arch="$(ARCH)" \
+	$(if $(REAL_CPU_TYPE),--cpu=$(call qstrip,$(REAL_CPU_TYPE)),) \
+	--target-os=linux \
+	--prefix=$(CONFIGURE_PREFIX) \
+	--pkg-config="pkg-config" \
+	--disable-all \
+	--disable-armv5te \
+	--disable-autodetect \
+	--disable-debug \
+	--disable-network \
+	--disable-protocols \
+	--disable-runtime-cpudetect \
+	--disable-static \
+	--enable-avcodec \
+	--enable-avformat \
+	--enable-bzlib \
+	--enable-hardcoded-tables \
+	--enable-decoder=ac3 \
+	--enable-decoder=dca \
+	--enable-decoder=eac3 \
+	--enable-decoder=flac \
+	--enable-decoder=h263 \
+	--enable-decoder=h264 \
+	--enable-decoder=mlp \
+	--enable-decoder=mjpeg \
+	--enable-decoder=mjpegb \
+	--enable-decoder=mpegvideo \
+	--enable-decoder=mpeg1video \
+	--enable-decoder=mpeg2video \
+	--enable-decoder=mpeg4 \
+	--enable-decoder=opus \
+	--enable-decoder=theora \
+	--enable-decoder=truehd \
+	--enable-decoder=vc1 \
+	--enable-decoder=vp3 \
+	--enable-decoder=vp6 \
+	--enable-decoder=vp6f \
+	--enable-decoder=vp8 \
+	--enable-decoder=wmv3 \
+	--enable-demuxers \
+	--enable-parsers \
+	--enable-pthreads \
+	--enable-shared \
+	--enable-swresample \
+	--enable-swscale \
+	--enable-zlib
+
+define Package/libffmpeg-omx
+  TITLE:=FFmpeg OMX libraries
+  URL:=https://ffmpeg.org/
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=@TARGET_brcm2708 +libpthread +zlib +libbz2
+endef
+
+define Package/libffmpeg-omx/description
+  FFmpeg is a a software package that can record, convert and stream digital
+  audio and video in numerous formats.
+
+  FFmpeg licensing / patent issues are complex. It is the reponsibility of the
+  user to understand any requirements in this regard with its usage. See:
+  https://ffmpeg.org/legal.html for further information.
+endef
+
+define Package/libffmpeg-omx/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avformat,avutil,swresample,swscale}.so.* $(1)/usr/lib
+endef
+
+define Build/Configure
+	( cd $(PKG_BUILD_DIR); $(FFMPEG_CONFIGURE) )
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		all install
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/lib{avcodec,avformat,avutil,swresample,swscale} $(1)/usr/include
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{avcodec,avformat,avutil,swresample,swscale}.so* $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/lib{avcodec,avformat,avutil,swresample,swscale}.pc $(1)/usr/lib/pkgconfig
+endef
+
+$(eval $(call BuildPackage,libffmpeg-omx))

--- a/multimedia/omxplayer/Makefile
+++ b/multimedia/omxplayer/Makefile
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2019 Álvaro Fernández Rojas <noltari@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=omxplayer
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/popcornmix/omxplayer.git
+PKG_SOURCE_VERSION:=ecd446d2de7eb86a43acaae59807a8e5c173f80d
+PKG_MIRROR_HASH:=03ccbd4b64944b417749aa5e2f3efad6bf5480efb52cdc4f51b4dcf490e5cd15
+
+PKG_FLAGS:=nonshared
+
+PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+TARGET_CFLAGS += \
+	-I$(STAGING_DIR)/usr/include/freetype2 \
+	-I$(STAGING_DIR)/usr/include/dbus-1.0 \
+	-I$(STAGING_DIR)/usr/lib/dbus-1.0/include
+
+define Build/Prepare
+	$(call Build/Prepare/Default,)
+	$(CP) files/* $(PKG_BUILD_DIR)/
+endef
+
+define Package/omxplayer
+  TITLE:=Raspberry Pi command line OMX player
+  SECTION:=multimedia
+  CATEGORY:=Multimedia
+  DEPENDS:=@(TARGET_brcm2708_bcm2708||TARGET_brcm2708_bcm2709) \
+	+brcm2708-userland +alsa-lib +libffmpeg-omx +libpcre +libdbus \
+	+boost +boost-libs +libfreetype +libdbus \
+	+dejavu-fonts-ttf-DejaVuSans +dejavu-fonts-ttf-DejaVuSans-Oblique
+endef
+
+define Package/omxplayer/description
+  OMXPlayer is a command-line video player for the Raspberry Pi.
+  It can play video directly from the command line and does not require a
+  desktop.
+  OMXPlayer leverages the OpenMAX API to make use of the hardware video
+  decoder in the GPU. Hardware acceleration along with direct command-line
+  use on ARM silicon allows ultra low overhead, low power video playback.
+  OMXPlayer was developed as a testbed for the XBMC Raspberry Pi
+  implementation and is quite handy to use standalone.
+endef
+
+define Package/omxplayer/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/omxplayer.bin $(1)/usr/bin/omxplayer
+endef
+
+$(eval $(call BuildPackage,omxplayer))

--- a/multimedia/omxplayer/files/CMakeLists.txt
+++ b/multimedia/omxplayer/files/CMakeLists.txt
@@ -1,0 +1,100 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(omxplayer)
+
+add_definitions(-D__STDC_CONSTANT_MACROS)
+add_definitions(-D__STDC_LIMIT_MACROS)
+add_definitions(-DTARGET_POSIX)
+add_definitions(-DTARGET_LINUX)
+add_definitions(-D_REENTRANT)
+add_definitions(-D_LARGEFILE64_SOURCE)
+add_definitions(-D_FILE_OFFSET_BITS=64)
+add_definitions(-DHAVE_CMAKE_CONFIG)
+add_definitions(-D__VIDEOCORE4__)
+add_definitions(-DHAVE_OMXLIB)
+add_definitions(-DUSE_EXTERNAL_FFMPEG)
+add_definitions(-DHAVE_LIBAVCODEC_AVCODEC_H)
+add_definitions(-DHAVE_LIBAVUTIL_OPT_H)
+add_definitions(-DHAVE_LIBAVUTIL_MEM_H)
+add_definitions(-DHAVE_LIBAVUTIL_AVUTIL_H)
+add_definitions(-DHAVE_LIBAVFORMAT_AVFORMAT_H)
+add_definitions(-DHAVE_LIBAVFILTER_AVFILTER_H)
+add_definitions(-DHAVE_LIBSWRESAMPLE_SWRESAMPLE_H)
+add_definitions(-DOMX)
+add_definitions(-DOMX_SKIP64BIT)
+add_definitions(-DUSE_EXTERNAL_OMX)
+add_definitions(-DTARGET_RASPBERRY_PI)
+add_definitions(-DUSE_EXTERNAL_LIBBCM_HOST)
+
+include_directories(.)
+include_directories(linux)
+include_directories(utils)
+
+add_custom_command(OUTPUT help.h
+	COMMAND awk
+	ARGS '/SYNOPSIS/{p=1\;print\;next} p&&/KEY BINDINGS/{p=0}\;p' README.md | sed -e '1,3 d' -e 's/^/\"/' -e 's/$$/\\\\n\"/' > help.h
+	DEPENDS README.md)
+
+add_custom_command(OUTPUT keys.h
+	COMMAND awk
+	ARGS '/KEY BINDINGS/{p=1\;print\;next} p&&/KEY CONFIG/{p=0}\;p' README.md | sed -e '1,3 d' -e 's/^/\"/' -e 's/$$/\\\\n\"/' > keys.h
+	DEPENDS README.md)
+
+add_custom_command(OUTPUT version.h
+	COMMAND gen_version.sh
+	ARGS > keys.h)
+
+set_property(SOURCE omxplayer.cpp APPEND PROPERTY OBJECT_DEPENDS help.h keys.h version.h)
+
+add_executable(omxplayer.bin
+	linux/XMemUtils.cpp
+	linux/OMXAlsa.cpp
+	utils/log.cpp
+	DynamicDll.cpp
+	utils/PCMRemap.cpp
+	utils/RegExp.cpp
+	OMXSubtitleTagSami.cpp
+	OMXOverlayCodecText.cpp
+	BitstreamConverter.cpp
+	linux/RBP.cpp
+	OMXThread.cpp
+	OMXReader.cpp
+	OMXStreamInfo.cpp
+	OMXAudioCodecOMX.cpp
+	OMXCore.cpp
+	OMXVideo.cpp
+	OMXAudio.cpp
+	OMXClock.cpp
+	File.cpp
+	OMXPlayerVideo.cpp
+	OMXPlayerAudio.cpp
+	OMXPlayerSubtitles.cpp
+	SubtitleRenderer.cpp
+	Unicode.cpp
+	Srt.cpp
+	KeyConfig.cpp
+	OMXControl.cpp
+	Keyboard.cpp
+	omxplayer.cpp
+	revision.cpp)
+
+target_link_libraries(omxplayer.bin
+	brcmGLESv2
+	brcmEGL
+	bcm_host
+	openmaxil
+	freetype
+	asound
+	vchiq_arm
+	vchostif
+	vcos
+	dbus-1
+	pcre
+	avcodec
+	avformat
+	avutil
+	swresample
+	swscale)
+
+install(TARGETS omxplayer.bin
+	RUNTIME DESTINATION bin)

--- a/multimedia/omxplayer/files/version.h
+++ b/multimedia/omxplayer/files/version.h
@@ -1,0 +1,7 @@
+#ifndef __VERSION_H__
+#define __VERSION_H__
+#define VERSION_DATE "Sun, 30 Sep 2019 17:15:00 +0100"
+#define VERSION_HASH "ecd446d"
+#define VERSION_BRANCH "master"
+#define VERSION_REPO "https://github.com/popcornmix/omxplayer.git"
+#endif

--- a/multimedia/omxplayer/patches/001-omxplayer-dejavu-fonts.patch
+++ b/multimedia/omxplayer/patches/001-omxplayer-dejavu-fonts.patch
@@ -1,0 +1,13 @@
+--- a/omxplayer.cpp
++++ b/omxplayer.cpp
+@@ -84,8 +84,8 @@ bool              m_osd
+ bool              m_no_keys             = false;
+ std::string       m_external_subtitles_path;
+ bool              m_has_external_subtitles = false;
+-std::string       m_font_path           = "/usr/share/fonts/truetype/freefont/FreeSans.ttf";
+-std::string       m_italic_font_path    = "/usr/share/fonts/truetype/freefont/FreeSansOblique.ttf";
++std::string       m_font_path           = "/usr/share/fonts/ttf-dejavu/DejaVuSans.ttf";
++std::string       m_italic_font_path    = "/usr/share/fonts/ttf-dejavu/DejaVuSans-Oblique.ttf";
+ std::string       m_dbus_name           = "org.mpris.MediaPlayer2.omxplayer";
+ bool              m_asked_for_font      = false;
+ bool              m_asked_for_italic_font = false;

--- a/multimedia/omxplayer/patches/002-omxplayersubtitles-fix.patch
+++ b/multimedia/omxplayer/patches/002-omxplayersubtitles-fix.patch
@@ -1,0 +1,14 @@
+--- a/OMXPlayerSubtitles.cpp
++++ b/OMXPlayerSubtitles.cpp
+@@ -43,9 +43,9 @@ OMXPlayerSubtitles::OMXPlayerSubtitles()
+   m_centered(),
+   m_ghost_box(),
+   m_lines(),
+-  m_av_clock(),
++  m_av_clock()
+ #ifndef NDEBUG
+-  m_open()
++  , m_open()
+ #endif
+ {}
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: brcm2708/bcm2708 brcm2708/bcm2709
Run tested: brcm2708/bcm2709 on RPi 3B and RPi 4B. Successfully played H264 sample video through hdmi.
Description: It may be a bit hacky, specially the part of linking a custom version of ffmpeg, so feedback would be much appreciated.
It won’t work on bcm2710 and bcm2711 since it doesn’t build for arm64.
