### PR TITLE
tor: add respawn to init script

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
 PKG_VERSION:=0.4.2.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \

--- a/net/tor/files/tor.init
+++ b/net/tor/files/tor.init
@@ -18,5 +18,6 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param command /usr/sbin/tor --runasdaemon 0
+	procd_set_param respawn
 	procd_close_instance
 }


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR adds respawn to tor init script. It should fix cases when the connection to the Internet is established after tor daemon starts. In that case, tor daemon end during unusefully tor circuit build and it's necessary to start it with /etc/init.d/tor start

