### PR TITLE
[OpenWrt 19.07] youtube-dl: update to version 2019.12.25

### DIFF
--- a/multimedia/youtube-dl/Makefile
+++ b/multimedia/youtube-dl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=youtube-dl
-PKG_VERSION:=2019.10.29
+PKG_VERSION:=2019.12.25
 PKG_RELEASE:=1
 
 PKG_SOURCE:=youtube_dl-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/y/youtube_dl/
-PKG_HASH:=0b6611807b0bb978a0384ddebf215ea1f974ecf73d80d04e9f614ff30b1443f0
+PKG_HASH:=5f73e8c66c07d632b0fc69f715247fe76f38a28c0c5f13bd0651ecd193c2f1c6
 PKG_BUILD_DIR:=$(BUILD_DIR)/youtube_dl-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Adrian Panella <ianchi74@outlook.com>, Josef Schlehofer <pepe.schlehofer@gmail.com>


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07

Description:
- Changelog: https://github.com/ytdl-org/youtube-dl/blob/2019.12.25/ChangeLog