### PR TITLE
tor: add basic uci config

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
 PKG_VERSION:=0.4.2.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
@@ -89,6 +89,7 @@ define Package/tor/conffiles
 /etc/tor/torrc
 /var/lib/tor/fingerprint
 /var/lib/tor/keys/*
+/etc/config/tor
 endef
 
 CONFIGURE_ARGS += \
@@ -124,6 +125,8 @@ define Package/tor/install
 	$(INSTALL_BIN) ./files/tor.init $(1)/etc/init.d/tor
 	$(INSTALL_DIR) $(1)/etc/tor
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/tor/torrc.sample $(1)/etc/tor/torrc
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/tor.conf $(1)/etc/config/tor
 endef
 
 define Package/tor-gencert/install

--- a/net/tor/files/tor.conf
+++ b/net/tor/files/tor.conf
@@ -1,0 +1,5 @@
+config tor conf
+	option default "/etc/tor/torrc"
+	option generated "/tmp/torrc"
+	#list head_include "/full/path/to/file"
+	#list tail_include "/full/path/to/file"

--- a/net/tor/files/tor.init
+++ b/net/tor/files/tor.init
@@ -6,18 +6,48 @@ STOP=50
 
 USE_PROCD=1
 
-start_service() {
-	touch /var/run/tor.pid
-	chown tor:tor /var/run/tor.pid
+TORRC_GEN="/tmp/torrc"
 
+handle_conf_file() {
+	local conf_path="$1"
+	if [ -f "$conf_path" ] || [ -d "$conf_path" ]; then
+		echo "%include $conf_path"
+	fi
+}
+
+generate_conf() {
+	local default_conf generated_conf
+
+	config_load tor
+	config_get default_conf conf default "/etc/tor/torrc"
+	config_get generated_conf conf generated "/tmp/torrc"
+	TORRC_GEN="$generated_conf"
+
+	{
+	echo "## This file was automatically generated please do not edit here !"
+	config_list_foreach "conf" head_include handle_conf_file
+	echo "%include $default_conf"
+	config_list_foreach "conf" tail_include handle_conf_file
+	} > "$TORRC_GEN"
+}
+
+reload_service() {
+	procd_send_signal /usr/sbin/tor
+}
+
+start_service() {
 	mkdir -m 0700 -p /var/lib/tor
 	chown -R tor:tor /var/lib/tor
 
 	mkdir -m 0755 -p /var/log/tor
 	chown -R tor:tor /var/log/tor
 
+	generate_conf
+
 	procd_open_instance
 	procd_set_param command /usr/sbin/tor --runasdaemon 0
+	procd_append_param command -f "$TORRC_GEN"
 	procd_set_param respawn
+	procd_set_param pidfile /var/run/tor.pid
 	procd_close_instance
 }


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR adds a simple tor UCI configuration. 

**How it works:**
Init script generates tor configuration in specific location (option generated "/tmp/torrc")
the structure of this file is following

First it contains list of included configuration defined in head_include (list head_include "/full/path/to/file")
Then is included default config file (option default "/etc/tor/torrc").
Last is included list of tail_include configuration (list tail_include "/full/path/to/file")


**Example of /etc/config/tor:**
```
config tor conf
	option default "/etc/tor/torrc"
	option generated "/tmp/torrc"
	list head_include "/head/full/path/to/file1"
	list head_include "/head/full/path/to/file2"
	list head_include "/head/full/path/to/file3"
	list tail_include "/tail/full/path/to/file1"
	list tail_include "/tail/full/path/to/file2"
	list tail_include "/tail/full/path/to/file3"
```

**Generated config file for tor:**
```
## This file was automatically generated please do not edit here !

%include /head/full/path/to/file1
%include /head/full/path/to/file2
%include /head/full/path/to/file3
%include /etc/tor/torrc
%include /tail/full/path/to/file1
%include /tail/full/path/to/file2
%include /tail/full/path/to/file3
```

**The idea behind it:**
This approach should help other packages extend tor configuration via UCI without any need to change default Tor configuration. 
It could be used by obfs4proxy package or by [hidden service configuration package](https://github.com/ja-pa/tor-hs/) which I'm working on (it should be upstreamed after solving this configuration issue).

**Compatibility with the older setting:**
This solution should not break backward compatibility with older setting. Since default config is set to /etc/tor/torrc 

