### PR TITLE
nginx: change luci dependency and fix luci nossl

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.17.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
@@ -324,7 +324,7 @@ define Package/nginx-mod-luci/default
   SUBMENU:=Web Servers/Proxies
   TITLE:=Support file for Nginx
   URL:=http://nginx.org/
-  DEPENDS:=+uwsgi-cgi +uwsgi-cgi-luci-support
+  DEPENDS:=+uwsgi-cgi-luci-support
 endef
 
 define Package/nginx-mod-luci

--- a/net/nginx/files-luci-support/luci_nginx.conf
+++ b/net/nginx/files-luci-support/luci_nginx.conf
@@ -1,5 +1,5 @@
 
-user nobody nogroup;
+user root;
 worker_processes  1;
 
 #error_log  logs/error.log;


### PR DESCRIPTION
Luci nginx config file for non ssl varian had user as nobody nogroup. This cause some problem with ubus use.
Luci file support package depends on uwsgi-cgi. As this package will be renamed shortly to a more generic version, make the subpackage depends on the uwsgi subpackage only.

@hnyman 

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
