### PR TITLE
coova-chilli: more fixes and improvements

### DIFF
--- a/net/coova-chilli/Config.in
+++ b/net/coova-chilli/Config.in
@@ -18,10 +18,6 @@ config COOVACHILLI_USERAGENT
 	bool "Enable recording user-agent"
 	default n
 
-config COOVACHILLI_DNSLOG
-	bool "Enable support to log DNS name queries"
-	default n
-
 config COOVACHILLI_UAMDOMAINFILE
 	bool "Enable loading of mass uamdomains from file"
 	default n

--- a/net/coova-chilli/Config.in
+++ b/net/coova-chilli/Config.in
@@ -1,11 +1,10 @@
 # CoovaChilli advanced configuration
 
-menu "Configuration"
-	depends on PACKAGE_coova-chilli
+if PACKAGE_coova-chilli
 
 config COOVACHILLI_PROXY
-        bool "Enable support for chilli proxy. Required for AAA Proxy through http"
-        default n
+	bool "Enable support for chilli proxy. Required for AAA Proxy through http"
+	default n
 
 config COOVACHILLI_REDIR
 	bool "Enable support for redir server. Required for uamregex"
@@ -46,4 +45,4 @@ config COOVACHILLI_OPENSSL
 
 endchoice
 
-endmenu
+endif

--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -27,7 +27,6 @@ PKG_CONFIG_DEPENDS:= \
   COOVACHILLI_MINIPORTAL \
   COOVACHILLI_REDIR \
   COOVACHILLI_USERAGENT \
-  COOVACHILLI_DNSLOG \
   COOVACHILLI_UAMDOMAINFILE \
   COOVACHILLI_LARGELIMITS \
   COOVACHILLI_NOSSL \
@@ -106,7 +105,6 @@ define Build/Configure
 	$(call Build/Configure/Default, \
 	$(if $(CONFIG_COOVACHILLI_PROXY),--enable,--disable)-chilliproxy \
 	$(if $(CONFIG_COOVACHILLI_REDIR),--enable,--disable)-chilliredir \
-	$(if $(CONFIG_COOVACHILLI_DNSLOG),--enable,--disable)-dnslog \
 	$(if $(CONFIG_COOVACHILLI_MINIPORTAL),--enable,--disable)-miniportal \
 	$(if $(CONFIG_COOVACHILLI_USERAGENT),--enable,--disable)-useragent \
 	$(if $(CONFIG_COOVACHILLI_LARGELIMITS),--enable,--disable)-largelimits \

--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -42,7 +42,8 @@ define Package/coova-chilli
   SUBMENU:=Captive Portals
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+kmod-tun +librt +COOVACHILLI_WOLFSSL:libwolfssl +COOVACHILLI_OPENSSL:libopenssl
+  DEPENDS:=+kmod-tun +librt +COOVACHILLI_MINIPORTAL:haserl \
+  +COOVACHILLI_WOLFSSL:libwolfssl +COOVACHILLI_OPENSSL:libopenssl
   TITLE:=Wireless LAN HotSpot controller (Coova Chilli Version)
   URL:=https://coova.github.io/
   MENU:=1

--- a/net/coova-chilli/Makefile
+++ b/net/coova-chilli/Makefile
@@ -24,14 +24,16 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=0
 
 PKG_CONFIG_DEPENDS:= \
-  COOVACHILLI_MINIPORTAL \
-  COOVACHILLI_REDIR \
-  COOVACHILLI_USERAGENT \
-  COOVACHILLI_UAMDOMAINFILE \
   COOVACHILLI_LARGELIMITS \
+  COOVACHILLI_MINIPORTAL \
   COOVACHILLI_NOSSL \
+  COOVACHILLI_OPENSSL \
+  COOVACHILLI_PROXY \
+  COOVACHILLI_REDIR \
+  COOVACHILLI_UAMDOMAINFILE \
+  COOVACHILLI_USERAGENT \
   COOVACHILLI_WOLFSSL \
-  COOVACHILLI_OPENSSL
+  IPV6
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/kernel.mk
@@ -139,7 +141,6 @@ define Package/coova-chilli/install
 	$(INSTALL_BIN) files/chilli.init $(1)/etc/init.d/chilli
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) files/chilli.config $(1)/etc/config/chilli
-	$(INSTALL_DIR) $(1)/lib/firewall
 endef
 
 $(eval $(call BuildPackage,coova-chilli))

--- a/net/coova-chilli/files/chilli.config
+++ b/net/coova-chilli/files/chilli.config
@@ -12,19 +12,12 @@ config chilli
     # name of network interface
     option network ''
 
-    # Include this flag if process is to run in the foreground
-    #option fg
-
     # Include this flag to include debug information.
     #option debug 1
 
     # Re-read configuration file at this interval. Will also cause new domain
     # name lookups to be performed. Value is given in seconds.
     #option interval 3600
-
-    # File to store information about the process id of the program.
-    # The program must have write access to this file/directory.
-    #option pidfile /var/run/chilli.pid
 
     # Directory to use for nonvolatile storage.
     # The program must have write access to this directory.

--- a/net/coova-chilli/files/chilli.init
+++ b/net/coova-chilli/files/chilli.init
@@ -49,7 +49,7 @@ start_chilli() {
 	local cfg="$1"
 	local base="/var/run/chilli_${cfg}"
 
-	config_get_bool disabled "$1" 'disabled' 1
+	config_get_bool disabled "$1" 'disabled' 0
 	[ $disabled = 1 ] && return
 
 	procd_open_instance "$cfg"


### PR DESCRIPTION
Maintainer: @teslamint 
Compile tested: brcm2708
Run tested: brcm2708

Description:
- simplify configuration menu definition
- remove COOVACHILLI_DNSLOG option
- clean up Makefile
- add dependency for MINIPORTAL
- remove options already in use
- enable by default