### PR TITLE
vnstat2: add package

### DIFF
--- a/net/vnstat2/Makefile
+++ b/net/vnstat2/Makefile
@@ -1,0 +1,107 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=vnstat2
+PKG_VERSION:=2.4
+PKG_RELEASE:=1
+
+PKG_SOURCE:=vnstat-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://humdi.net/vnstat
+PKG_HASH:=a0955999abd56d5463d257ffdccc9b1e9ad9ea504de81e64ba4c197f1245abaa
+
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Jan Hoffmann <jan@3e8.eu>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/vnstat-${PKG_VERSION}
+
+PKG_INSTALL:=1
+
+PKG_BUILD_DEPENDS:=libgd
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/vnstat2/Default
+  SECTION:=net
+  CATEGORY:=Network
+  URL:=https://humdi.net/vnstat/
+  DEPENDS:=+libsqlite3
+  CONFLICTS:=vnstat
+endef
+
+define Package/vnstat2
+$(call Package/vnstat2/Default)
+  TITLE:=Console-based network traffic monitor
+endef
+
+define Package/vnstat2/description
+	vnStat is a network traffic monitor for Linux that keeps a log of daily
+	network traffic for the selected interface(s). vnStat isn't a packet
+	sniffer. The traffic information is analyzed from the /proc -filesystem,
+	so vnStat can be used without root permissions.
+endef
+
+define Package/vnstati2
+$(call Package/vnstat2/Default)
+  DEPENDS+=vnstat2 +libgd
+  TITLE:=PNG image output support for vnStat
+endef
+
+define Package/vnstati2/description
+	The purpose of vnstati is to provide image output support for statistics
+	collected using vnstat. However, the image file format is limited to
+	png. All basic outputs of vnStat are supported excluding live traffic
+	features. The image can be outputted either to a file or to standard
+	output.
+endef
+
+define Package/vnstat2/conffiles
+/etc/vnstat.conf
+/etc/config/vnstat
+endef
+
+define Build/Compile/vnstat2
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS="$(TARGET_CFLAGS)" \
+		LDFLAGS="$(TARGET_LDFLAGS)"
+endef
+
+define Build/Compile/vnstati2
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+		$(TARGET_CONFIGURE_OPTS) \
+		CFLAGS="$(TARGET_CFLAGS) -I$(STAGING_DIR)/usr/include" \
+		LDFLAGS="$(TARGET_LDFLAGS) -Wl,-rpath-link,$(STAGING_DIR)/usr/lib" \
+		all
+endef
+
+define Build/Compile
+$(call Build/Compile/vnstat2)
+$(call Build/Compile/vnstati2)
+endef
+
+define Package/vnstat2/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/vnstat $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/vnstatd $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/cfg/vnstat.conf $(1)/etc/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/vnstat.config $(1)/etc/config/vnstat
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/vnstat.init $(1)/etc/init.d/vnstat
+endef
+
+define Package/vnstati2/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/vnstati $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,vnstat2))
+$(eval $(call BuildPackage,vnstati2))

--- a/net/vnstat2/files/vnstat.config
+++ b/net/vnstat2/files/vnstat.config
@@ -1,0 +1,2 @@
+config vnstat
+#	list interface		br-lan

--- a/net/vnstat2/files/vnstat.init
+++ b/net/vnstat2/files/vnstat.init
@@ -1,0 +1,61 @@
+#!/bin/sh /etc/rc.common
+
+START=60
+STOP=50
+
+USE_PROCD=1
+
+vnstat_option() {
+	sed -ne "s/^[[:space:]]*$1[[:space:]]*['\"]\([^'\"]*\)['\"].*/\1/p" \
+		/etc/vnstat.conf
+}
+
+init_database() {
+	local lib="$(vnstat_option DatabaseDir)"
+
+	local database_count="$(ls "$lib" 2>/dev/null | wc -l)"
+
+	if [ "$database_count" -eq "0" ]; then
+		/usr/sbin/vnstatd -n --noadd >/dev/null 
+	fi
+}
+
+init_ifaces() {
+	local cfg="$1"
+
+	init_iface() {
+		local ifn="$1"
+
+		/usr/bin/vnstat --add -i "$ifn" >/dev/null
+	}
+
+	config_list_foreach "$cfg" interface init_iface
+
+	return 1
+}
+
+start_service() {
+	init_database
+
+	config_load vnstat
+	config_foreach init_ifaces vnstat
+
+	procd_open_instance
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param command /usr/sbin/vnstatd --nodaemon
+	procd_set_param file /etc/vnstat.conf
+	procd_set_param respawn
+	procd_close_instance
+}
+
+reload_service() {
+	config_load vnstat
+	config_foreach init_ifaces vnstat
+
+	procd_send_signal vnstat
+}
+
+service_triggers() {
+	procd_add_reload_trigger vnstat
+}

--- a/net/vnstat2/patches/990-remove-default-interface.patch
+++ b/net/vnstat2/patches/990-remove-default-interface.patch
@@ -1,0 +1,11 @@
+--- a/cfg/vnstat.conf
++++ b/cfg/vnstat.conf
+@@ -2,7 +2,7 @@
+ ##
+ 
+ # default interface (leave empty for automatic selection)
+-Interface ""
++#Interface ""
+ 
+ # location of the database directory
+ DatabaseDir "/var/lib/vnstat"


### PR DESCRIPTION
**Maintainer:** me

**Compile tested:**
 - x86-64, KVM, master/19.07
 - ipq40xx, AVM FRITZ!Box 4040, 19.07

**Run tested:**
 - x86-64, KVM, master/19.07
   (tested in default configuration and with persistent database, import from vnStat 1.x works)
 - ipq40xx, AVM FRITZ!Box 4040, 19.07
   (running for 2 weeks now with imported data from vnStat 1.x)

**Description:**

This adds an additional package for vnStat 2.x which uses an SQLite database instead of struct dumps and supports a shorter 5-minute resolution as well as longer data retention than vnStat 1.x.

The UCI configuration from previous versions is partially supported: Configured interfaces are added to the vnStat database on start/reload. Other options (symlink, backup, download) are not implemented.