### PR TITLE
libgd: fix building with freetype support

### DIFF
--- a/libs/libgd/Makefile
+++ b/libs/libgd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgd
 PKG_VERSION:=2.2.5
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/gd-$(PKG_VERSION)/
@@ -79,6 +79,7 @@ endif
 
 ifdef CONFIG_LIBGD_FREETYPE
 	CMAKE_OPTIONS += \
+		-DFREETYPE_INCLUDE_DIRS=$(STAGING_DIR)/usr/include/freetype2/ \
 		-DENABLE_FREETYPE=ON
 else
 	CMAKE_OPTIONS += \


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: arm/mxs (by @mhei )
Run tested: -

Description:

Freetype support is required for php7-mod-gd as of commit 0f10c8c8,
which causes the PHP7 package to build using this external libgd library.
This commit adds FREETYPE_INCLUDE_DIRS to the definition of CMAKE_OPTIONS.
Without this, libgd does not build freetype support as shown by
this message:

....
Build libgd:
-- Could NOT find Freetype (missing:  FREETYPE_INCLUDE_DIRS)
-- Configuring done
-- Generating done
....

Signed-off-by: W. Michael Petullo <mike@flyn.org>
