### PR TITLE
wsdd2: fix build error

### DIFF
--- a/net/wsdd2/files/wsdd2.init
+++ b/net/wsdd2/files/wsdd2.init
@@ -9,9 +9,9 @@ NB_PARM=""
 WG_PARM=""
 BI_PARM=""
 
-. /lib/functions/network.sh
-
 start_service() {
+
+	. /lib/functions/network.sh
 
 	if [ -e /etc/smbd/smb.conf ] && [ -e /etc/init.d/smbd ] && /etc/init.d/smbd running; then
 		SMB_CONF="/etc/smbd/smb.conf"


### PR DESCRIPTION
On build install this error is reported
./etc/init.d/wsdd2: line 12: /lib/functions/network.sh: No such file or directory
Fix this moving the include script in the start_service function

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>