### PR TITLE
smartmontools: update to 7.1

### DIFF
--- a/utils/smartmontools/Makefile
+++ b/utils/smartmontools/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/uclibc++.mk
 
 PKG_NAME:=smartmontools
-PKG_VERSION:=7.0
-PKG_RELEASE:=3
+PKG_VERSION:=7.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/smartmontools
-PKG_HASH:=e5e1ac2786bc87fdbd6f92d0ee751b799fbb3e1a09c0a6a379f9eb64b3e8f61c
+PKG_HASH:=3f734d2c99deb1e4af62b25d944c6252de70ca64d766c4c7294545a2e659b846
 
 PKG_MAINTAINER:=Maxim Storchak <m.storchak@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Signed-off-by: Maxim Storchak <m.storchak@gmail.com>

Maintainer: me
Compile tested: ath97, WNDR3800, r11896+3-411a666df2
Run tested: ath97, WNDR3800, r11896+3-411a666df2. smartctl can read SMART data

Description:
Update to 7.1