### PR TITLE
smartmontools: provide smartd_warning.sh

### DIFF
--- a/utils/smartmontools/Makefile
+++ b/utils/smartmontools/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/uclibc++.mk
 
 PKG_NAME:=smartmontools
 PKG_VERSION:=7.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/smartmontools
@@ -68,6 +68,17 @@ define Package/smartmontools-drivedb/description
   Database of known drives and USB bridges for smartctl and smartd.
 endef
 
+define Package/smartd-mail
+  $(call Package/smartmontools/Default)
+  TITLE+= Email notifications
+  PKGARCH=all
+  DEPENDS+= +smartd, +nail, +msmtp-mta
+endef
+
+define Package/smartd-mail/description
+  A script for mailing about SMART issues
+endef
+
 ifeq ($(CONFIG_USE_UCLIBCXX),y)
 TARGET_LDFLAGS +=-nodefaultlibs
 else
@@ -110,6 +121,11 @@ define Package/smartmontools-drivedb/install
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/smartmontools/drivedb.h $(1)/usr/share/smartmontools/
 endef
 
+define Package/smartd-mail/install
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/etc/smartd_warning.sh $(1)/etc
+endef
+
 define Package/smartd/conffiles
 /etc/smartd.conf
 endef
@@ -117,3 +133,4 @@ endef
 $(eval $(call BuildPackage,smartmontools))
 $(eval $(call BuildPackage,smartd))
 $(eval $(call BuildPackage,smartmontools-drivedb))
+$(eval $(call BuildPackage,smartd-mail))

--- a/utils/smartmontools/patches/002-os_mailer-is-mailx.patch
+++ b/utils/smartmontools/patches/002-os_mailer-is-mailx.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 6f442b3..5803c83 100755
+--- a/configure
++++ b/configure
+@@ -6988,7 +6988,7 @@ releaseversion='${PACKAGE}-${VERSION}'
+ # Set platform-specific modules and symbols
+ os_libs=
+ os_dltools='curl wget lynx svn'
+-os_mailer=mail
++os_mailer=mailx
+ os_hostname="'hostname'"
+ os_dnsdomainname=
+ os_nisdomainname="'domainname'"


### PR DESCRIPTION
Maintainer: me
Compile tested: ath97, WNDR3800, r11896+3-411a666df2
Run tested: ath97, WNDR3800, r11896+3-411a666df2. smartd is able to send a test email.

Description:
    A separate package which depdens on msmtp-mta and nail is introduced.
    Once more packages provide `sendmail` and `mail` interfaces, this
    dependency can be made more flexible.

This PR depends on #10948 and addresses #10911 