### PR TITLE
python-asn1crypto: bump to version 1.3.0 + rework

### DIFF
--- a/lang/python/python-asn1crypto/Makefile
+++ b/lang/python/python-asn1crypto/Makefile
@@ -8,60 +8,35 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-asn1crypto
-PKG_VERSION:=1.2.0
+PKG_VERSION:=1.3.0
 PKG_RELEASE:=1
 
-PKG_SOURCE:=asn1crypto-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://pypi.io/packages/source/a/asn1crypto
-PKG_HASH:=87620880a477123e01177a1f73d0f327210b43a3cdbd714efcd2fa49a8d7b384
+PYPI_NAME:=asn1crypto
+PKG_HASH:=5a215cb8dc12f892244e3a113fe05397ee23c5c4ca7a69cd6e69811755efc42d
 
-PKG_LICENSE:=MIT
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-asn1crypto-$(PKG_VERSION)
-
+include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
-include ../python-package.mk
 include ../python3-package.mk
 
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
-define Package/python-asn1crypto/Default
+define Package/python3-asn1crypto
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   URL:=https://github.com/wbond/asn1crypto
-endef
-
-define Package/python-asn1crypto
-$(call Package/python-asn1crypto/Default)
-  TITLE:=python-asn1crypto
-  DEPENDS:=+PACKAGE_python-asn1crypto:python-light
-  VARIANT:=python
-endef
-
-define Package/python3-asn1crypto
-$(call Package/python-asn1crypto/Default)
-  TITLE:=python3-asn1crypto
-  DEPENDS:=+PACKAGE_python3-asn1crypto:python3-light
+  TITLE:=Fast pure Python lib for ASN1 structures
+  DEPENDS:=+python3-light
   VARIANT:=python3
 endef
 
-define Package/python-asn1crypto/description
+define Package/python3-asn1crypto/description
 Fast ASN.1 parser and serializer with definitions for
 private keys, public keys, certificates, CRL, OCSP,
 CMS, PKCS#3, PKCS#7, PKCS#8, PKCS#12, PKCS#5, X.509 and TSP
 endef
-
-define Package/python3-asn1crypto/description
-$(call Package/python-asn1crypto/description)
-.
-(Variant for Python3)
-endef
-
-$(eval $(call PyPackage,python-asn1crypto))
-$(eval $(call BuildPackage,python-asn1crypto))
-$(eval $(call BuildPackage,python-asn1crypto-src))
 
 $(eval $(call Py3Package,python3-asn1crypto))
 $(eval $(call BuildPackage,python3-asn1crypto))


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/openwrt/openwrt/commit/99dd2709b855baa9e68c7c7106743a7c4a91ee0c  x86
Run tested: https://github.com/openwrt/openwrt/commit/99dd2709b855baa9e68c7c7106743a7c4a91ee0c  x86

--------------------------------------------------

This change:
* bumps the version 1.3.0
* switches to pypi.org download
* removes the python2 variant

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>