### PR TITLE
mjpg-streamer: Fix of the mjpg-streamer path to modules.

### DIFF
--- a/multimedia/mjpg-streamer/Makefile
+++ b/multimedia/mjpg-streamer/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mjpg-streamer
 PKG_VERSION:=2018-10-25
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>, \
 		Ted Hess <thess@kitschensync.net>
 
@@ -25,6 +25,7 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 PKG_BUILD_DEPENDS:=MJPG_STREAMER_V4L2:libv4l zmq protobuf-c/host
+CMAKE_OPTIONS+=-DCMAKE_SKIP_RPATH=FALSE
 
 define Package/mjpg-streamer
   SECTION:=multimedia

--- a/multimedia/mjpg-streamer/Makefile
+++ b/multimedia/mjpg-streamer/Makefile
@@ -226,6 +226,8 @@ define Package/mjpg-streamer/install
 	$(INSTALL_BIN) ./files/mjpg-streamer.init $(1)/etc/init.d/mjpg-streamer
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/usb
 	$(INSTALL_DATA) ./files/mjpg-streamer.hotplug $(1)/etc/hotplug.d/usb/20-mjpg-streamer
+	$(INSTALL_DIR) $(1)/etc/profile.d/
+	echo "export LD_LIBRARY_PATH=/usr/lib/mjpg-streamer/" > $(1)/etc/profile.d/mjpg-streamer.sh
 endef
 
 define Package/mjpg-streamer-input-file/install

--- a/multimedia/mjpg-streamer/files/mjpg-streamer.init
+++ b/multimedia/mjpg-streamer/files/mjpg-streamer.init
@@ -109,6 +109,7 @@ start_instance() {
 	fi
 
 	procd_open_instance
+	procd_set_param env LD_LIBRARY_PATH=/usr/lib/mjpg-streamer
 	procd_set_param command "$PROG" --input "$input_arg" --output "$output_arg"
 	[ "x$output" = 'xhttp' ] && procd_add_mdns "http" "tcp" "$port" "daemon=mjpg-streamer"
 	procd_close_instance


### PR DESCRIPTION
LD_LIBRARY_PATH variable is now defined in the global system profile.
Procd init script now uses LD_LIBRARY_PATH variable.

Fix partially resolve reported issue #10254.

Signed-off-by: Zbyněk Kocur <zbynek.kocur@fel.cvut.cz>

Maintainer: Rosen Penev <rosenp@gmail.com>
Compile tested: aarch64_cortex-a53
Run tested: aarch64_cortex-a53