### PR TITLE
node-javascript-obfuscator: add package

### DIFF
--- a/lang/node-javascript-obfuscator/Makefile
+++ b/lang/node-javascript-obfuscator/Makefile
@@ -1,0 +1,85 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NPM_NAME:=javascript-obfuscator
+PKG_NAME:=node-$(PKG_NPM_NAME)
+PKG_VERSION:=0.18.1
+PKG_RELEASE:=3
+
+PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
+PKG_SOURCE_URL:=http://registry.npmjs.org/$(PKG_NPM_NAME)/-/
+PKG_HASH:=3f53199ed892e3faf4ab5726a70181b970b1d1b239f4e6a13d6272cbee02d7cb
+PKG_BUILD_DEPENDS:=node/host
+HOST_BUILD_DEPENDS:=node/host
+PKG_USE_MIPS16:=0
+
+PKG_MAINTAINER:=Zbynek Kocur <zbynek.kocur@fel.cvut.cz>
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/package.mk
+
+define Package/node-javascript-obfuscator
+  SUBMENU:=Node.js
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=JavaScript obfuscator
+  URL:=https://www.npmjs.org/package/javascript-obfuscator
+  DEPENDS:=+node
+endef
+
+define Package/node-javascript-obfuscator/description
+ JavaScript obfuscator is a powerful free obfuscator for JavaScript with a wide number of features which provides protection for your source code.
+endef
+
+NODEJS_CPU:=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))))
+
+define Build/Prepare
+	$(INSTALL_DIR) $(PKG_BUILD_DIR)
+endef
+
+define Build/Compile
+	$(MAKE_VARS) \
+	$(MAKE_FLAGS) \
+	npm_config_arch=$(NODEJS_CPU) \
+	npm_config_target_arch=$(NODEJS_CPU) \
+	npm_config_build_from_source=true \
+	npm_config_nodedir=$(STAGING_DIR)/usr/ \
+	npm_config_prefix=$(PKG_INSTALL_DIR)/usr/ \
+	npm_config_cache=$(TMP_DIR)/npm-cache \
+	npm_config_tmp=$(TMP_DIR)/npm-tmp \
+	npm install -g $(DL_DIR)/$(PKG_SOURCE)
+	rm -rf $(TMP_DIR)/npm-tmp
+	rm -rf $(TMP_DIR)/npm-cache
+endef
+
+define Package/node-javascript-obfuscator/install
+	$(INSTALL_DIR) $(1)/usr/lib/node
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/* $(1)/usr/lib/node/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(LN) ../lib/node/javascript-obfuscator/bin/javascript-obfuscator $(1)/usr/bin/javascript-obfuscator
+endef
+
+define Host/Prepare
+	$(INSTALL_DIR) $(HOST_BUILD_DIR)
+endef
+
+define Host/Compile
+	npm_config_nodedir=$(STAGING_DIR)/usr/ \
+	npm_config_prefix=$(STAGING_DIR_HOSTPKG)/ \
+	npm_config_cache=$(TMP_DIR)/npm-cache \
+	npm_config_tmp=$(TMP_DIR)/npm-tmp \
+	npm install -g $(DL_DIR)/$(PKG_SOURCE)
+	rm -rf $(TMP_DIR)/npm-tmp
+	rm -rf $(TMP_DIR)/npm-cache
+endef
+
+define Host/Install
+endef
+
+$(eval $(call HostBuild))
+$(eval $(call BuildPackage,node-javascript-obfuscator))

--- a/multimedia/mjpg-streamer/Makefile
+++ b/multimedia/mjpg-streamer/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mjpg-streamer
 PKG_VERSION:=2018-10-25
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Roger D <rogerdammit@gmail.com>, \
 		Ted Hess <thess@kitschensync.net>
 
@@ -225,6 +225,8 @@ define Package/mjpg-streamer/install
 	$(INSTALL_BIN) ./files/mjpg-streamer.init $(1)/etc/init.d/mjpg-streamer
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/usb
 	$(INSTALL_DATA) ./files/mjpg-streamer.hotplug $(1)/etc/hotplug.d/usb/20-mjpg-streamer
+	$(INSTALL_DIR) $(1)/etc/profile.d/
+	echo "export LD_LIBRARY_PATH=/usr/lib/mjpg-streamer/" > $(1)/etc/profile.d/mjpg-streamer.sh
 endef
 
 define Package/mjpg-streamer-input-file/install

--- a/multimedia/mjpg-streamer/files/mjpg-streamer.init
+++ b/multimedia/mjpg-streamer/files/mjpg-streamer.init
@@ -109,6 +109,7 @@ start_instance() {
 	fi
 
 	procd_open_instance
+	procd_set_param env LD_LIBRARY_PATH=/usr/lib/mjpg-streamer
 	procd_set_param command "$PROG" --input "$input_arg" --output "$output_arg"
 	[ "x$output" = 'xhttp' ] && procd_add_mdns "http" "tcp" "$port" "daemon=mjpg-streamer"
 	procd_close_instance


### PR DESCRIPTION
Maintainer: me

Compile tested: x86-64, KVM, master/19.07

Description:
This adds a node javascript obfuscator package. JavaScript obfuscator
is a powerful free obfuscator for JavaScript with a wide number of
features that provides protection for your source code.
