### PR TITLE
ddns-scripts: Fixed HE(hurricane electric) to tunnelbroker

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.8
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=14
+PKG_RELEASE:=15
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -116,8 +116,6 @@
 
 "google.com"		"https://[USERNAME]:[PASSWORD]@domains.google.com/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
 
-"he.net"		"http://[DOMAIN]:[PASSWORD]@dyn.dns.he.net/nic/update?hostname=[DOMAIN]&myip=[IP]"	"good|nochg"
-
 "inwx.de"		"http://[USERNAME]:[PASSWORD]@dyndns.inwx.com/nic/update?myip=[IP]"	"good|nochg"
 
 "joker.com"		"http://svc.joker.com/nic/update?username=[USERNAME]&password=[PASSWORD]&myip=[IP]&hostname=[DOMAIN]"	"good|nochg"
@@ -165,6 +163,8 @@
 "system-ns.com"		"http://system-ns.com/api?type=dynamic&command=set&domain=[DOMAIN]&token=[PASSWORD]&ip=[IP]"	"0"
 
 "thatip.com"		"http://update.dnsmax.com/update/?username=[USERNAME]&password=[PASSWORD]&resellerid=2&clientname=openwrt&clientversion=8.09&protocolversion=2.0&updatehostname=[DOMAIN]&ip=[IP]"
+
+"tunnelbroker.net"      "http://[USERNAME]:[PASSWORD]@ipv4.tunnelbroker.net/nic/update?hostname=[DOMAIN]&myip=[IP]"     "good|nochg"
 
 "twodns.de"		"http://[USERNAME]:[PASSWORD]@update.twodns.de/update?hostname=[DOMAIN]&ip=[IP]"
 


### PR DESCRIPTION
Run and live on:
DISTRIB_RELEASE='18.06.5'
DISTRIB_REVISION='r7897-9d401013fc'
DISTRIB_TARGET='ipq806x/generic'
DISTRIB_ARCH='arm_cortex-a15_neon-vfpv4'

Description:
Hurricane Electric provides a free IPv6inIPv4 tunnel. It changed its ipv4 ddns service, fully needed to keep the ipv6 tunnel up,  to the domain tunnelbroker.net. Besides, the old he.net script was bugged because it doesn't had a [USERNAME] placement but instead two [DOMAIN].  The new tunnelbroker.net update URL, still provided by Hurricane Electric, is https://[USERNAME]:[PASSWORD]@ipv4.tunnelbroker.net/nic/update?hostname=[DOMAIN]&myip=[IP] and it gets the response good or nochg

Signed-off-by: Euler Alves <euler(at)alves.pro.br>
