### PR TITLE
libwebsockets: enable unix socket support in the full build

### DIFF
--- a/libs/libwebsockets/Makefile
+++ b/libs/libwebsockets/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libwebsockets
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
@@ -86,6 +86,7 @@ ifeq ($(BUILD_VARIANT),full)
     CMAKE_OPTIONS += -DLWS_WITH_SERVER_STATUS=ON
     CMAKE_OPTIONS += -DLWS_WITH_ACCESS_LOG=ON
     CMAKE_OPTIONS += -DLWS_WITH_CGI=ON
+    CMAKE_OPTIONS += -DLWS_UNIX_SOCK=ON
 endif
 
 define Package/libwebsockets/install


### PR DESCRIPTION
This functionality can be used by downstream applications such as
``ttyd`` to present their HTTP service as a unix domain socket rather
than a TCP server.

Signed-off-by: Mathew McBride <matt@traverse.com.au>

Maintainer: @karlp
Compile-tested: armv8/layerscape
Run-tested: armv8/layerscape 

Example use: ttyd behind an nginx reverse proxy: ``ttyd -i /tmp/ttyd.sock`` and ``proxy_pass http://unix:/tmp/ttyd.sock`` in nginx
