### PR TITLE
golang: ASLR/PIE support and misc updates

### DIFF
--- a/lang/golang/golang-compiler.mk
+++ b/lang/golang/golang-compiler.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Jeffery To
+# Copyright (C) 2018, 2020 Jeffery To
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -51,6 +51,7 @@ endef
 # $(2) destination prefix
 # $(3) go version id
 # $(4) GOOS_GOARCH
+# $(5) install suffix (optional)
 define GoCompiler/Default/Install/Bin
 	$(call GoCompiler/Default/Install/make-dirs,$(2),$(3))
 
@@ -73,7 +74,7 @@ define GoCompiler/Default/Install/Bin
   endif
 
 	$(INSTALL_DIR) $(2)/lib/go-$(3)/pkg
-	$(CP) $(1)/pkg/$(4) $(2)/lib/go-$(3)/pkg/
+	$(CP) $(1)/pkg/$(4)$(if $(5),_$(5)) $(2)/lib/go-$(3)/pkg/
 
 	$(INSTALL_DIR) $(2)/lib/go-$(3)/pkg/tool/$(4)
 	$(INSTALL_BIN) -p $(1)/pkg/tool/$(4)/* $(2)/lib/go-$(3)/pkg/tool/$(4)/
@@ -141,6 +142,7 @@ endef
 # $(3) destination prefix
 # $(4) go version id
 # $(5) GOOS_GOARCH
+# $(6) install suffix (optional)
 define GoCompiler/AddProfile
 
   # $$(1) valid GOOS_GOARCH combinations
@@ -155,7 +157,7 @@ define GoCompiler/AddProfile
 
   # $$(1) override install prefix (optional)
   define GoCompiler/$(1)/Install/Bin
-	$$(call GoCompiler/Default/Install/Bin,$(2),$$(or $$(1),$(3)),$(4),$(5))
+	$$(call GoCompiler/Default/Install/Bin,$(2),$$(or $$(1),$(3)),$(4),$(5),$(6))
   endef
 
   # $$(1) override install prefix (optional)

--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -12,22 +12,91 @@ endif
 include $(GO_INCLUDE_DIR)/golang-version.mk
 
 
+# Unset environment variables
+# There are more magic variables to track down, but ain't nobody got time for that
+
+# From https://golang.org/cmd/go/#hdr-Environment_variables
+
+# General-purpose environment variables:
 unexport \
-  GOARCH GOBIN GOCACHE GOFLAGS GOHOSTARCH GOOS GOPATH GORACE GOROOT GOTMPDIR GCCGO \
-  GOGC GODEBUG GOMAXPROCS GOTRACEBACK \
+  GCCGO \
+  GOARCH \
+  GOBIN \
+  GOCACHE \
+  GODEBUG \
+  GOFLAGS \
+  GOOS \
+  GOPATH \
+  GOROOT \
+  GOTMPDIR
+# Unmodified:
+#   GOPRIVATE
+#   GOPROXY
+#   GONOPROXY
+#   GOSUMDB
+#   GONOSUMDB
+
+# Environment variables for use with cgo:
+unexport \
   CGO_ENABLED \
-  CGO_CFLAGS CGO_CFLAGS_ALLOW CGO_CFLAGS_DISALLOW \
+  CGO_CFLAGS   CGO_CFLAGS_ALLOW   CGO_CFLAGS_DISALLOW \
   CGO_CPPFLAGS CGO_CPPFLAGS_ALLOW CGO_CPPFLAGS_DISALLOW \
   CGO_CXXFLAGS CGO_CXXFLAGS_ALLOW CGO_CXXFLAGS_DISALLOW \
-  CGO_FFLAGS CGO_FFLAGS_ALLOW CGO_FFLAGS_DISALLOW \
-  CGO_LDFLAGS CGO_LDFLAGS_ALLOW CGO_LDFLAGS_DISALLOW \
-  GOARM GO386 GOMIPS GOMIPS64 \
-  GO111MODULE \
-  GOROOT_FINAL GO_EXTLINK_ENABLED GIT_ALLOW_PROTOCOL \
-  CC_FOR_TARGET CXX_FOR_TARGET GO_DISTFLAGS GO_GCFLAGS GO_LDFLAGS GOBUILDTIMELOGFILE GOROOT_BOOTSTRAP \
-  BOOT_GO_GCFLAGS GOEXPERIMENT GOBOOTSTRAP_TOOLEXEC
-  # there are more magic environment variables to track down, but ain't nobody got time for that
-  # deliberately left untouched: GOPROXY GONOPROXY GOSUMDB GONOSUMDB GOPRIVATE
+  CGO_FFLAGS   CGO_FFLAGS_ALLOW   CGO_FFLAGS_DISALLOW \
+  CGO_LDFLAGS  CGO_LDFLAGS_ALLOW  CGO_LDFLAGS_DISALLOW
+
+# Architecture-specific environment variables:
+unexport \
+  GOARM \
+  GO386 \
+  GOMIPS \
+  GOMIPS64
+
+# Special-purpose environment variables:
+unexport \
+  GOROOT_FINAL \
+  GO_EXTLINK_ENABLED \
+  GIT_ALLOW_PROTOCOL
+
+# From https://golang.org/cmd/go/#hdr-Module_support
+unexport \
+  GO111MODULE
+
+# From https://golang.org/pkg/runtime/#hdr-Environment_Variables
+unexport \
+  GOGC \
+  GOMAXPROCS \
+  GORACE \
+  GOTRACEBACK
+
+# From https://golang.org/cmd/cgo/#hdr-Using_cgo_with_the_go_command
+unexport \
+  CC_FOR_TARGET \
+  CXX_FOR_TARGET
+
+# From https://golang.org/doc/install/source#environment
+unexport \
+  GOHOSTARCH
+
+# From https://golang.org/src/make.bash
+unexport \
+  GO_GCFLAGS \
+  GO_LDFLAGS \
+  GO_DISTFLAGS \
+  GOBUILDTIMELOGFILE \
+  GOROOT_BOOTSTRAP
+
+# From https://golang.org/src/cmd/dist/build.go
+unexport \
+  BOOT_GO_GCFLAGS
+
+# From https://golang.org/src/cmd/dist/buildtool.go
+unexport \
+  GOBOOTSTRAP_TOOLEXEC
+
+# From https://golang.org/src/cmd/internal/objabi/util.go
+unexport \
+  GOEXPERIMENT
 
 go_arch=$(subst \
   aarch64,arm64,$(subst \

--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -190,3 +190,29 @@ GO_ARCH_DEPENDS:=@(aarch64||arm||i386||i686||mips||mips64||mips64el||mipsel||pow
 GO_TARGET_PREFIX:=/usr
 GO_TARGET_VERSION_ID:=$(GO_VERSION_MAJOR_MINOR)
 GO_TARGET_ROOT:=$(GO_TARGET_PREFIX)/lib/go-$(GO_TARGET_VERSION_ID)
+
+
+# ASLR/PIE
+
+GO_PIE_SUPPORTED_OS_ARCH:= \
+  android_386 android_amd64 android_arm android_arm64 \
+  linux_386   linux_amd64   linux_arm   linux_arm64 \
+  \
+  darwin_amd64 \
+  freebsd_amd64 \
+  \
+  aix_ppc64 \
+  \
+  linux_ppc64le linux_s390x
+
+go_pie_install_suffix=$(if $(filter $(1),aix_ppc64),,shared)
+
+ifneq ($(filter $(GO_HOST_OS_ARCH),$(GO_PIE_SUPPORTED_OS_ARCH)),)
+  GO_HOST_PIE_SUPPORTED:=1
+  GO_HOST_PIE_INSTALL_SUFFIX:=$(call go_pie_install_suffix,$(GO_HOST_OS_ARCH))
+endif
+
+ifneq ($(filter $(GO_OS_ARCH),$(GO_PIE_SUPPORTED_OS_ARCH)),)
+  GO_TARGET_PIE_SUPPORTED:=1
+  GO_TARGET_PIE_INSTALL_SUFFIX:=$(call go_pie_install_suffix,$(GO_OS_ARCH))
+endif

--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Jeffery To
+# Copyright (C) 2018, 2020 Jeffery To
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -24,6 +24,7 @@ unexport \
   GOBIN \
   GOCACHE \
   GODEBUG \
+  GOENV \
   GOFLAGS \
   GOOS \
   GOPATH \
@@ -38,25 +39,34 @@ unexport \
 
 # Environment variables for use with cgo:
 unexport \
+  AR \
+  CC \
   CGO_ENABLED \
   CGO_CFLAGS   CGO_CFLAGS_ALLOW   CGO_CFLAGS_DISALLOW \
   CGO_CPPFLAGS CGO_CPPFLAGS_ALLOW CGO_CPPFLAGS_DISALLOW \
   CGO_CXXFLAGS CGO_CXXFLAGS_ALLOW CGO_CXXFLAGS_DISALLOW \
   CGO_FFLAGS   CGO_FFLAGS_ALLOW   CGO_FFLAGS_DISALLOW \
-  CGO_LDFLAGS  CGO_LDFLAGS_ALLOW  CGO_LDFLAGS_DISALLOW
+  CGO_LDFLAGS  CGO_LDFLAGS_ALLOW  CGO_LDFLAGS_DISALLOW \
+  CXX \
+  FC
+# Unmodified:
+#   PKG_CONFIG
 
 # Architecture-specific environment variables:
 unexport \
   GOARM \
   GO386 \
   GOMIPS \
-  GOMIPS64
+  GOMIPS64 \
+  GOWASM
 
 # Special-purpose environment variables:
 unexport \
+  GCCGOTOOLDIR \
   GOROOT_FINAL \
-  GO_EXTLINK_ENABLED \
-  GIT_ALLOW_PROTOCOL
+  GO_EXTLINK_ENABLED
+# Unmodified:
+#   GIT_ALLOW_PROTOCOL
 
 # From https://golang.org/cmd/go/#hdr-Module_support
 unexport \
@@ -73,22 +83,33 @@ unexport \
 unexport \
   CC_FOR_TARGET \
   CXX_FOR_TARGET
+# Todo:
+#   CC_FOR_${GOOS}_${GOARCH}
+#   CXX_FOR_${GOOS}_${GOARCH}
 
 # From https://golang.org/doc/install/source#environment
 unexport \
-  GOHOSTARCH
+  GOHOSTOS \
+  GOHOSTARCH \
+  GOPPC64
 
 # From https://golang.org/src/make.bash
 unexport \
   GO_GCFLAGS \
   GO_LDFLAGS \
+  GO_LDSO \
   GO_DISTFLAGS \
   GOBUILDTIMELOGFILE \
   GOROOT_BOOTSTRAP
 
+# From https://golang.org/doc/go1.9#parallel-compile
+unexport \
+  GO19CONCURRENTCOMPILATION
+
 # From https://golang.org/src/cmd/dist/build.go
 unexport \
-  BOOT_GO_GCFLAGS
+  BOOT_GO_GCFLAGS \
+  BOOT_GO_LDFLAGS
 
 # From https://golang.org/src/cmd/dist/buildtool.go
 unexport \

--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -10,7 +10,7 @@ include ../golang-version.mk
 
 PKG_NAME:=golang
 PKG_VERSION:=$(GO_VERSION_MAJOR_MINOR)$(if $(GO_VERSION_PATCH),.$(GO_VERSION_PATCH))
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 GO_SOURCE_URLS:=https://dl.google.com/go/ \
                 https://mirrors.ustc.edu.cn/golang/ \
@@ -92,6 +92,18 @@ BOOTSTRAP_UNPACK:=$(HOST_TAR) -C $(BOOTSTRAP_BUILD_DIR) --strip-components=1 -xz
 RSTRIP:=:
 STRIP:=:
 
+ifeq ($(CONFIG_PKG_ASLR_PIE),y)
+  ifeq ($(GO_TARGET_PIE_SUPPORTED),1)
+    PKG_GO_ENABLE_PIE:=1
+    PKG_GO_INSTALL_SUFFIX:=$(GO_TARGET_PIE_INSTALL_SUFFIX)
+  endif
+endif
+
+ifeq ($(GO_HOST_PIE_SUPPORTED),1)
+  HOST_GO_ENABLE_PIE:=1
+  HOST_GO_INSTALL_SUFFIX:=$(GO_HOST_PIE_INSTALL_SUFFIX)
+endif
+
 define Package/golang/Default
 $(call GoPackage/GoSubMenu)
   TITLE:=Go programming language
@@ -158,8 +170,8 @@ endef
 $(eval $(call Download,golang-bootstrap))
 
 $(eval $(call GoCompiler/AddProfile,Bootstrap,$(BOOTSTRAP_BUILD_DIR),,bootstrap,$(GO_HOST_OS_ARCH)))
-$(eval $(call GoCompiler/AddProfile,Host,$(HOST_BUILD_DIR),$(HOST_GO_PREFIX),$(HOST_GO_VERSION_ID),$(GO_HOST_OS_ARCH)))
-$(eval $(call GoCompiler/AddProfile,Package,$(PKG_BUILD_DIR),$(GO_TARGET_PREFIX),$(GO_TARGET_VERSION_ID),$(GO_OS_ARCH)))
+$(eval $(call GoCompiler/AddProfile,Host,$(HOST_BUILD_DIR),$(HOST_GO_PREFIX),$(HOST_GO_VERSION_ID),$(GO_HOST_OS_ARCH),$(HOST_GO_INSTALL_SUFFIX)))
+$(eval $(call GoCompiler/AddProfile,Package,$(PKG_BUILD_DIR),$(GO_TARGET_PREFIX),$(GO_TARGET_VERSION_ID),$(GO_OS_ARCH),$(PKG_GO_INSTALL_SUFFIX)))
 
 define Host/Prepare
 	$(call Host/Prepare/Default)
@@ -167,6 +179,9 @@ define Host/Prepare
 	$(BOOTSTRAP_UNPACK)
 endef
 
+# when https://github.com/golang/go/issues/31544 is fixed,
+# we should be able to set GO_LDFLAGS=-buildmode=pie for host make
+# instead of doing a rebuild for pie
 define Host/Compile
 	$(call GoCompiler/Bootstrap/CheckHost,$(BOOTSTRAP_GO_VALID_OS_ARCH))
 	$(call GoCompiler/Host/CheckHost,$(HOST_GO_VALID_OS_ARCH))
@@ -181,6 +196,21 @@ define Host/Compile
 		CC=$(HOSTCC_NOCACHE) \
 		CXX=$(HOSTCXX_NOCACHE) \
 	)
+
+  ifneq ($(HOST_GO_ENABLE_PIE),)
+	@echo "Rebuilding host Go with PIE"
+
+	( \
+		cd $(HOST_BUILD_DIR)/bin ; \
+		$(CP) go go-nopie ; \
+		CC=$(HOSTCC_NOCACHE) \
+		CXX=$(HOSTCXX_NOCACHE) \
+		./go-nopie install -a -buildmode=pie std cmd ; \
+		retval=$$$$? ; \
+		rm -f go-nopie ; \
+		exit $$$$retval ; \
+	)
+  endif
 endef
 
 # if host and target os/arch are the same,
@@ -194,7 +224,7 @@ define Host/Install
 
 	$(call GoCompiler/Host/Install/BinLinks,)
 
-	rm -rf $(HOST_GO_ROOT)/pkg/$(GO_HOST_OS_ARCH)
+	rm -rf $(HOST_GO_ROOT)/pkg/$(GO_HOST_OS_ARCH)$(if $(HOST_GO_INSTALL_SUFFIX),_$(HOST_GO_INSTALL_SUFFIX))
 
 	$(INSTALL_DIR) $(HOST_GO_ROOT)/openwrt
 	$(INSTALL_BIN) ./files/go-gcc-helper $(HOST_GO_ROOT)/openwrt/
@@ -247,7 +277,7 @@ define Build/Compile
 		PKG_CONFIG=pkg-config \
 		PATH=$(HOST_GO_ROOT)/openwrt:$$$$PATH \
 		$(call GoPackage/Environment) \
-		./go-host install -a -v std cmd ; \
+		./go-host install -a $(if $(PKG_GO_ENABLE_PIE),-buildmode=pie) std cmd ; \
 		retval=$$$$? ; \
 		rm -f go-host ; \
 		exit $$$$retval ; \

--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 Jeffery To
+# Copyright (C) 2018, 2020 Jeffery To
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -42,18 +42,25 @@ HOST_GO_VERSION_ID:=cross
 HOST_GO_ROOT:=$(HOST_GO_PREFIX)/lib/go-$(HOST_GO_VERSION_ID)
 
 HOST_GO_VALID_OS_ARCH:= \
-                                android_arm \
-  darwin_386   darwin_amd64     darwin_arm   darwin_arm64 \
-               dragonfly_amd64 \
-  freebsd_386  freebsd_amd64    freebsd_arm \
-  linux_386    linux_amd64      linux_arm    linux_arm64 \
-  netbsd_386   netbsd_amd64     netbsd_arm \
-  openbsd_386  openbsd_amd64    openbsd_arm \
-  plan9_386    plan9_amd64 \
-               solaris_amd64 \
+  android_386  android_amd64  android_arm  android_arm64 \
+  darwin_386   darwin_amd64   darwin_arm   darwin_arm64 \
+  linux_386    linux_amd64    linux_arm    linux_arm64 \
+  openbsd_386  openbsd_amd64  openbsd_arm  openbsd_arm64 \
+  \
+  freebsd_386  freebsd_amd64  freebsd_arm \
+  netbsd_386   netbsd_amd64   netbsd_arm \
+  plan9_386    plan9_amd64    plan9_arm \
+  \
   windows_386  windows_amd64 \
   \
-  linux_ppc64 linux_ppc64le linux_mips linux_mipsle linux_mips64 linux_mips64le
+  dragonfly_amd64 \
+  illumos_amd64 \
+  solaris_amd64 \
+  \
+  aix_ppc64 \
+  js_wasm \
+  \
+  linux_ppc64 linux_ppc64le linux_mips linux_mipsle linux_mips64 linux_mips64le linux_s390x
 
 BOOTSTRAP_SOURCE:=go1.4-bootstrap-20171003.tar.gz
 BOOTSTRAP_SOURCE_URL:=$(GO_SOURCE_URLS)


### PR DESCRIPTION
Maintainer: me
Compile tested: armvirt-32 / armvirt-64 / malta-be / x86-generic / x86-64, 2020-01-06 snapshot sdk (compiled host and target Go, and all packages that use golang-package.mk)
Run tested: armvirt-32 / armvirt-64 / malta-be / x86-generic / x86-64, 2020-01-06 snapshot (go build helloworld.go)

Description:
These changes are centered on:
* Add support for building host/target Go with ASLR/PIE
* Make golang-values.mk more readable/maintainable
* Strip whitespace when using GO_PKG / GO_PKG_* variables in golang-package.mk
* Update values for Go 1.13