### PR TITLE
asu: Change Python 2 dependencies to Python 3

### DIFF
--- a/devel/asu/Makefile
+++ b/devel/asu/Makefile
@@ -23,7 +23,7 @@ IMAGEBUILDER_DEPENDS:= \
     @x86_64 +bash +bzip2 +coreutils +coreutils-stat +diffutils +file \
     +gawk +gcc +getopt +git +git-http +libncurses +make +patch +perl \
     +perlbase-attributes +perlbase-findbin +perlbase-getopt \
-    +perlbase-thread +python-light +tar +unzip +wget +xz +xzdiff \
+    +perlbase-thread +python3-light +tar +unzip +wget +xz +xzdiff \
     +xzgrep +xzless +xz-utils +zlib-dev
 
 define Package/asu
@@ -34,7 +34,7 @@ define Package/asu
     URL:=http://github.com/aparcar/gsoc17-attended-sysupgrade/
     DEPENDS:=$(IMAGEBUILDER_DEPENDS) +pgsql-server +psqlodbcw \
              +python3-ctypes +python3-distutils +python3-flask \
-             +gunicorn +python3-openssl +python3-pyodbc +python3-yaml \
+             +gunicorn3 +python3-openssl +python3-pyodbc +python3-yaml \
              +libustream-mbedtls +ca-certificates +gnupg
     USERID:=asu:asu
     VARIANT:=python3

--- a/devel/asu/files/asu.init
+++ b/devel/asu/files/asu.init
@@ -28,7 +28,7 @@ start_service() {
     procd_open_instance asu_main
     procd_set_param user asu
     procd_set_param group asu
-    procd_set_param command gunicorn asu:app
+    procd_set_param command gunicorn3 asu:app
     procd_close_instance
 
     procd_open_instance main_worker


### PR DESCRIPTION
Maintainer: @aparcar (also ping @dangowrt)
Compile tested: x86-64, 2020-01-06 snapshot sdk
Run tested: **none**

Description:
I believe the move to Python 3 in OpenWrt core has been completed, so the imagebuilder dependency change should be okay. Also, gunicorn3 should provide the same functionality as gunicorn.

Still, this has not been run tested - I suggest the maintainer test this.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>

