### PR TITLE
minidlna: create UUID in config if it is empty

### DIFF
--- a/multimedia/minidlna/files/minidlna.config
+++ b/multimedia/minidlna/files/minidlna.config
@@ -15,6 +15,6 @@ config minidlna config
 	option serial '12345678'
 	option model_number '1'
 	option root_container '.'
-	option uuid '019f9a56-ff60-44c0-9edc-eae88d09fa05'
+	option uuid ''
 	list media_dir '/mnt'
 	option album_art_names 'Cover.jpg/cover.jpg/AlbumArtSmall.jpg/albumartsmall.jpg/AlbumArt.jpg/albumart.jpg/Album.jpg/album.jpg/Folder.jpg/folder.jpg/Thumb.jpg/thumb.jpg'

--- a/multimedia/minidlna/files/minidlna.init
+++ b/multimedia/minidlna/files/minidlna.init
@@ -81,14 +81,18 @@ start() {
 	local db_dir
 	local log_dir
 	local user
+	local var
 
 	config_load 'minidlna'
 	config_get_bool enabled config 'enabled' '0'
 
 	[ "$enabled" -gt 0 ] || return 1
 
+	config_get val "config" uuid
+	[ "$val" = '' ] && uci set  minidlna.config.uuid=$(cat /proc/sys/kernel/random/uuid) && uci commit
+
 	minidlna_create_config config || return 1
-	
+
 	config_get db_dir config 'db_dir' '/var/run/minidlna'
 	config_get log_dir config 'log_dir' '/var/log/minidlna'
 	config_get user config 'user' 'root'


### PR DESCRIPTION
better solution than using a static UUID by default

keep the default uuid empty then generate and save
a unique UUID on first start of minidlna service.

Signed-off-by: Alberto Bursi <bobafetthotmail@gmail.com>

Maintainer:  @medaved 

also @diizzyy  and @neheb 