### PR TITLE
lmdb: InstallDev: dont rename pkg-config file

### DIFF
--- a/libs/lmdb/Makefile
+++ b/libs/lmdb/Makefile
@@ -75,6 +75,7 @@ define Build/InstallDev
 	$(CP) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lmdb.h $(1)/usr/include
 	$(CP) $(PKG_BUILD_DIR)/$(MAKE_PATH)/liblmdb.{a,so} $(1)/usr/lib
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig/
+	$(CP) $(PKG_BUILD_DIR)/liblmdb.pc $(1)/usr/lib/pkgconfig/
 	$(CP) $(PKG_BUILD_DIR)/liblmdb.pc $(1)/usr/lib/pkgconfig/lmdb.pc
 endef
 


### PR DESCRIPTION
Maintainer: @ja-pa 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested with Knot Resolver: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:

**Before this change**:
When I was compiling Knot Resolver and wanted to run tested it shows me:
```
root@turris:~# kresd
Error loading shared library /home/pepe/work/turrisos/master-omnia/build/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/lib/liblmdb.so: No such file or directory (needed by /usr/lib/libkres.so.9)
```

**After this change**:
No error with Knot Resolver anymore.

On another hand, some GNU/Linux distributions ship it as lmdb.pc. This file is not large. But I don't like the idea to ship this file twice.