### PR TITLE
meson: fix building host binaries with ccache

### DIFF
--- a/devel/meson/meson.mk
+++ b/devel/meson/meson.mk
@@ -42,8 +42,8 @@ endef
 
 define Meson/CreateNativeFile
 	$(STAGING_DIR_HOST)/bin/sed \
-		-e "s|@CC@|$(HOSTCC)|" \
-		-e "s|@CXX@|$(HOSTCXX)|" \
+		-e "s|@CC@|$(foreach BIN,$(HOSTCC),'$(BIN)',)|" \
+		-e "s|@CXX@|$(foreach BIN,$(HOSTCXX),'$(BIN)',)|" \
 		-e "s|@PKGCONFIG@|$(PKG_CONFIG)|" \
 		-e "s|@CFLAGS@|$(foreach FLAG,$(HOST_CFLAGS) $(HOST_CPPFLAGS),'$(FLAG)',)|" \
 		-e "s|@CXXFLAGS@|$(foreach FLAG,$(HOST_CXXFLAGS) $(HOST_CPPFLAGS),'$(FLAG)',)|" \
@@ -55,8 +55,8 @@ endef
 
 define Meson/CreateCrossFile
 	$(STAGING_DIR_HOST)/bin/sed \
-		-e "s|@CC@|$(TARGET_CC)|" \
-		-e "s|@CXX@|$(TARGET_CXX)|" \
+		-e "s|@CC@|$(foreach BIN,$(TARGET_CC),'$(BIN)',)|" \
+		-e "s|@CXX@|$(foreach BIN,$(TARGET_CXX),'$(BIN)',)|" \
 		-e "s|@AR@|$(TARGET_AR)|" \
 		-e "s|@STRIP@|$(TARGET_CROSS)strip|" \
 		-e "s|@NM@|$(TARGET_NM)|" \

--- a/devel/meson/src/openwrt-cross.txt.in
+++ b/devel/meson/src/openwrt-cross.txt.in
@@ -1,6 +1,6 @@
 [binaries]
-c = '@CC@'
-cpp = '@CXX@'
+c = [@CC@]
+cpp = [@CXX@]
 ar = '@AR@'
 strip = '@STRIP@'
 nm = '@NM@'

--- a/devel/meson/src/openwrt-native.txt.in
+++ b/devel/meson/src/openwrt-native.txt.in
@@ -1,6 +1,6 @@
 [binaries]
-c = '@CC@'
-cpp = '@CXX@'
+c = [@CC@]
+cpp = [@CXX@]
 pkgconfig = '@PKGCONFIG@'
 
 [properties]


### PR DESCRIPTION
Maintainer: me
Compile tested: sunxi, master
Run tested: -

Description:
With CONFIG_CCACHE, $HOSTCC is 'ccache gcc' while $TARGET_CC points to a
single wrapper script. Compiling target binaries with ccache works, but
doesn't for host binaries, because we need to supply an argv array for
argc > 1 in the meson cross file.

Always pass an array for the c and c++ compiler, and while at it, do it
for the target as well - just to be on the safe side if that ever
changes.

Fixes #10982.

Signed-off-by: Andre Heider <a.heider@gmail.com>