### PR TITLE
btrfs-progs: update to version 5.4.1

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
-PKG_VERSION:=5.4
+PKG_VERSION:=5.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs
-PKG_HASH:=0f973295911224ce15a10f9c9a0d9773d13a7f0d04959afb88783009b65670fa
+PKG_HASH:=f3e07fb248d608bdad5b63973513211de5daba47aaecfa44d29a836f6e7a9d69
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Karel Kočí <karel.koci@nic.cz>


### PR DESCRIPTION
Maintainer: @Cynerd 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
Update to version 5.4.1.
Changelog:
```
btrfs-progs v5.4.1 (Jan 2020)

build: fix docbook5 build
check: do extra verification of extent items, inode items and chunks
qgroup: return ENOTCONN if quotas not running (needs updated kernel)
other: various test fixups
```
https://btrfs.wiki.kernel.org/index.php/Changelog#btrfs-progs_v5.4_.28Dec_2019.29