### PR TITLE
[OpenWrt 19.07] django: update to version 1.11.27

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=1.11.26
+PKG_VERSION:=1.11.27
 PKG_RELEASE:=1
 
 PKG_SOURCE:=Django-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/D/Django
-PKG_HASH:=861db7f82436ab43e1411832ed8dca81fc5fc0f7c2039c7e07a080a63092fb44
+PKG_HASH:=20111383869ad1b11400c94b0c19d4ab12975316cd058eabd17452e0546169b8
 PKG_BUILD_DIR=$(BUILD_DIR)/Django-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07

Description:
Update to version [1.11.27](https://www.djangoproject.com/weblog/2019/dec/18/security-releases/)

Fixes: [CVE-2019-19844](https://nvd.nist.gov/vuln/detail/CVE-2019-19844)