### PR TITLE
[18.06] libseccomp: update to version 2.4.2

### DIFF
--- a/libs/libseccomp/Makefile
+++ b/libs/libseccomp/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libseccomp
-PKG_VERSION:=2.3.3
+PKG_VERSION:=2.4.2
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/seccomp/libseccomp/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=7fc28f4294cc72e61c529bedf97e705c3acf9c479a8f1a3028d4cd2ca9f3b155
+PKG_HASH:=b54f27b53884caacc932e75e6b44304ac83586e2abe7a83eca6daecc5440585b
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <nmav@gnutls.org>
 
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainer: @nmav 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06.6
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06.6

Description:
Fixes [CVE-2019-9893](https://nvd.nist.gov/vuln/detail/CVE-2019-9893) and as 2.3.3 is no longer supported by upstream, update it to 2.4.2.
Release notes: https://github.com/seccomp/libseccomp/releases
