### PR TITLE
Openwrt: syncthing Missing USE_PROCD=1

### DIFF
--- a/utils/syncthing/files/etc/init.d/syncthing
+++ b/utils/syncthing/files/etc/init.d/syncthing
@@ -1,5 +1,7 @@
 #!/bin/sh /etc/rc.common
 
+USE_PROCD=1
+
 START=99
 
 PROG=/usr/bin/syncthing


### PR DESCRIPTION
syncthing: init script failed to start on latest build

Maintainer: me / @tmoore22
Compile tested: 	OpenWrt SNAPSHOT r0+10645-c8e761b5bd / LuCI Master (git-19.211.64022-e6f30bb)
Run tested: 	OpenWrt SNAPSHOT r0+10645-c8e761b5bd / LuCI Master (git-19.211.64022-e6f30bb) 	MediaTek MT7621 ver:1 eco:3
Description:
