### PR TITLE
canutils: Switch to autotools instead of regular Makefile

### DIFF
--- a/utils/canutils/Makefile
+++ b/utils/canutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=canutils
 PKG_VERSION:=2018.02.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/linux-can/can-utils/tar.gz/v$(PKG_VERSION)?
@@ -19,6 +19,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/can-utils-$(PKG_VERSION)
 PKG_MAINTAINER:=Anton Glukhov <anton.a.glukhov@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
@@ -58,13 +59,6 @@ FILES:=canbusload can-calc-bit-timing candump \
 
 
 $(foreach a,$(FILES),$(eval $(call GenPlugin,$(a))))
-
-MAKE_FLAGS += \
-	PREFIX="$(CONFIGURE_PREFIX)"
-
-define Package/canutils/install
-	true
-endef
 
 define PartInstall
 define Package/canutils-$(1)/install


### PR DESCRIPTION
The regular Makefile is totally broken and does not pass CFLAGS. This
breaks compilation with PKG_ASLR_PIE and also does not pass -Os.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @toxxin 
Compile tested: ath79

Fixes: https://github.com/openwrt/packages/issues/10983