### PR TITLE
pymysql: add new package (only Py3 variant)

### DIFF
--- a/lang/python/pymysql/Makefile
+++ b/lang/python/pymysql/Makefile
@@ -1,0 +1,41 @@
+#
+# Copyright (C) Alexandru Ardelean <ardeleanalex@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pymysql
+PKG_VERSION:=0.9.3
+PKG_RELEASE:=1
+
+PYPI_NAME:=PyMySQL
+PKG_HASH:=d8c059dcd81dedb85a9f034d5e22dcb4442c0b201908bede99e306d65ea7c8e7
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pymysql
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Pure Python MySQL Client
+  URL:=https://pymysql.readthedocs.io/
+  DEPENDS:=+python3 +python3-cryptography
+  VARIANT:=python3
+endef
+
+define Package/python3-pymysql/description
+  This package contains a pure-Python MySQL client library, based on PEP 249.
+endef
+
+$(eval $(call Py3Package,python3-pymysql))
+$(eval $(call BuildPackage,python3-pymysql))
+$(eval $(call BuildPackage,python3-pymysql-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/openwrt/openwrt/commit/99dd2709b855baa9e68c7c7106743a7c4a91ee0c  x86
Run tested: https://github.com/openwrt/openwrt/commit/99dd2709b855baa9e68c7c7106743a7c4a91ee0c  x86

----------------------------------------------------------

This change adds support for the pymysql package, which is a pure Python
MySQL client. This package will replace the current python-mysqlclient.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>