### PR TITLE
python-evdev: bump to version 1.3.0

### DIFF
--- a/lang/python/python-evdev/Makefile
+++ b/lang/python/python-evdev/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=python-evdev
-PKG_VERSION:=1.2.0
+PKG_VERSION:=1.3.0
 PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_MAINTAINER:=Paulo Costa <me@paulo.costa.nom.br>, Alexandru Ardelean <ardeleanalex@gmail.com>
 
 PYPI_NAME:=evdev
-PKG_HASH:=b03f5e1be5b4a5327494a981b831d251a142b09e8778eda1a8b53eba91100166
+PKG_HASH:=b1c649b4fed7252711011da235782b2c260b32e004058d62473471e5cd30634d
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me, @paulo-raca 
Compile tested: https://github.com/openwrt/openwrt/commit/99dd2709b855baa9e68c7c7106743a7c4a91ee0c  x86
Run tested: https://github.com/openwrt/openwrt/commit/99dd2709b855baa9e68c7c7106743a7c4a91ee0c  x86

----------------------------------------------------------

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>