### PR TITLE
cyrus-sasl: install module symbolic links of form libX.so

### DIFF
--- a/libs/cyrus-sasl/Makefile
+++ b/libs/cyrus-sasl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cyrus-sasl
 PKG_VERSION:=2.1.27
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 
@@ -109,7 +109,7 @@ define Package/libsasl2/install
 	$(INSTALL_DIR) $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsasl2.so.* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/sasl2
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/sasl2/lib*.so.* $(1)/usr/lib/sasl2/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/sasl2/lib*.so* $(1)/usr/lib/sasl2/
 endef
 
 $(eval $(call BuildPackage,libsasl2))


### PR DESCRIPTION
I was too aggressive in recommending that we remove the module symbolic
links of form libX.so as part of commit c9ce769b. It turns out that at
least Postfix relies on these, and I suspect any application that makes
use of libsasl2 will require them too.

Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me

Description:
See also issue #11009.