### PR TITLE
canutils: fix canutils makefile dependency

### DIFF
--- a/utils/canutils/Makefile
+++ b/utils/canutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=canutils
 PKG_VERSION:=2018.02.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/linux-can/can-utils/tar.gz/v$(PKG_VERSION)?

--- a/utils/canutils/Makefile
+++ b/utils/canutils/Makefile
@@ -40,7 +40,6 @@ endef
 define GenPlugin
   define Package/$(addprefix canutils-,$(1))
     $(call Package/canutils/Default)
-    DEPENDS:=canutils
     TITLE:=Utility $(1) from the CAN utilities
   endef
 


### PR DESCRIPTION
DEPENDS attribute makes canutils fail on installation procedure

Removing it makes a successful build

Signed-off-by: Paulo Machado <pffmachado@yahoo.com>