### PR TITLE
modemmanager: release 1.12.4

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
-PKG_VERSION:=1.12.2
-PKG_RELEASE:=2
+PKG_VERSION:=1.12.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
-PKG_HASH:=4f76d2bdd0ed6780837cdde886eaf535f9770f9daa1ff92e63658d06aa5d25ea
+PKG_HASH:=852d61755e0c1a8d0c609b17192d742b324fdd2e513f3ed64b228befb859a95b
 PKG_BUILD_DIR:=$(BUILD_DIR)/ModemManager-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>


### PR DESCRIPTION
New stable release with lots of fixes, including some severe memory
leaks happening when GPS management is used in QMI-based devices.

https://lists.freedesktop.org/archives/modemmanager-devel/2020-January/007670.html

Signed-off-by: Aleksander Morgado <aleksander@aleksander.es>

Maintainer: @nickberry17
