### PR TITLE
[openwrt-18.06] golang: Fix selection of GOARM value

### DIFF
--- a/lang/golang/golang-values.mk
+++ b/lang/golang/golang-values.mk
@@ -53,7 +53,37 @@ GO_HOST_TARGET_DIFFERENT:=$(if $(GO_HOST_TARGET_SAME),,1)
 # ensure binaries can run on older CPUs
 GO_386:=387
 
-GO_ARM:=$(if $(CONFIG_arm_v7),7,$(if $(CONFIG_arm_v6),6,$(if $(findstring $(GO_ARCH),arm),5,)))
+ifeq ($(GO_ARCH),arm)
+  GO_TARGET_FPU:=$(word 2,$(subst +,$(space),$(call qstrip,$(CONFIG_CPU_TYPE))))
+
+  # FPU names from https://gcc.gnu.org/onlinedocs/gcc-8.3.0/gcc/ARM-Options.html#index-mfpu-1
+  # see also https://github.com/gcc-mirror/gcc/blob/gcc-8_3_0-release/gcc/config/arm/arm-cpus.in
+  #
+  # Assumptions:
+  #
+  # * -d16 variants (16 instead of 32 double-precision registers) acceptable
+  #   Go doesn't appear to check the HWCAP_VFPv3D16 flag in
+  #   https://github.com/golang/go/blob/release-branch.go1.13/src/runtime/os_linux_arm.go
+  #
+  # * Double-precision required
+  #   Based on no evidence(!)
+  #   Excludes vfpv3xd, vfpv3xd-fp16, fpv4-sp-d16, fpv5-sp-d16
+
+  GO_ARM_7_FPUS:= \
+    vfpv3 vfpv3-fp16 vfpv3-d16 vfpv3-d16-fp16 neon neon-vfpv3 neon-fp16 \
+    vfpv4 vfpv4-d16 neon-vfpv4 \
+    fpv5-d16 fp-armv8 neon-fp-armv8 crypto-neon-fp-armv8
+
+  GO_ARM_6_FPUS:=vfp vfpv2
+
+  ifneq ($(filter $(GO_TARGET_FPU),$(GO_ARM_7_FPUS)),)
+    GO_ARM:=7
+  else ifneq ($(filter $(GO_TARGET_FPU),$(GO_ARM_6_FPUS)),)
+    GO_ARM:=6
+  else
+    GO_ARM:=5
+  endif
+endif
 
 GO_MIPS:=$(if $(filter $(GO_ARCH),mips mipsle),$(if $(CONFIG_HAS_FPU),hardfloat,softfloat),)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: at91-legacy / brcm2708-bcm2708 / mvebu-cortexa9 / at91-sama5d2 / imx6-generic / armvirt-32, 18.06.6 release sdk
Run tested: none

Description:
This fixes how `GOARM` is selected for arm platforms, based on support for VFP/VFPv3 rather than CPU version.

Fixes #10967.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>