### PR TITLE
apr-util: clean up reverse depends (and fix subversion dep)

### DIFF
--- a/libs/apr-util/Makefile
+++ b/libs/apr-util/Makefile
@@ -9,14 +9,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apr-util
 PKG_VERSION:=1.6.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@APACHE/apr/
 PKG_HASH:=d3e12f7b6ad12687572a3a39475545a072608f4ba03a6ce8a3778f607dd0035b
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Sebastian Kemper <sebastian_ml@gmx.net>
-PKG_LICENSE:=Apache License
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
 PKG_CPE_ID:=cpe:/a:apache:apr-util
 
 PKG_BUILD_PARALLEL:=1

--- a/libs/apr-util/patches/004-avoid_ldap_by_defaut.patch
+++ b/libs/apr-util/patches/004-avoid_ldap_by_defaut.patch
@@ -1,0 +1,34 @@
+From: Ryan Niebur <ryanryan52@gmail.com>
+Subject: by default --avoid-ldap since apache2 is the only user, and we don't
+ want to add extra dependencies to other apr-utils rdepends
+
+--- a/apu-config.in
++++ b/apu-config.in
+@@ -30,7 +30,8 @@ includedir="@includedir@"
+ LIBS="@APRUTIL_EXPORT_LIBS@"
+ INCLUDES="@APRUTIL_INCLUDES@"
+ LDFLAGS="@APRUTIL_LDFLAGS@"
+-LDAP_LIBS="@LDADD_ldap@"
++ORIG_LDAP_LIBS="@LDADD_ldap@"
++LDAP_LIBS=""
+ DBM_LIBS="@LDADD_dbm_db@ @LDADD_dbm_gdbm@ @LDADD_dbm_ndbm@"
+ 
+ APRUTIL_LIBNAME="@APRUTIL_LIBNAME@"
+@@ -55,7 +56,7 @@ Known values for OPTION are:
+   --includedir      print location where headers are installed
+   --ldflags         print linker flags
+   --libs            print library information
+-  --avoid-ldap      do not include ldap library information with --libs
++  --avoid-ldap      do not include ldap library information with --libs (default on OpenWrt)
+   --ldap-libs       print library information to link with ldap
+   --avoid-dbm       do not include DBM library information with --libs
+   --dbm-libs        print additional library information to link with DBM
+@@ -121,7 +122,7 @@ while test $# -gt 0; do
+     flags="$flags $LDAP_LIBS $DBM_LIBS $LIBS"
+     ;;
+     --ldap-libs)
+-    flags="$flags $LDAP_LIBS"
++    flags="$flags $ORIG_LDAP_LIBS"
+     ;;
+     --dbm-libs)
+     flags="$flags $DBM_LIBS"

--- a/libs/apr-util/patches/005-apu_config_dont_list_indep_libs.patch
+++ b/libs/apr-util/patches/005-apu_config_dont_list_indep_libs.patch
@@ -1,0 +1,31 @@
+From: Peter Samuelson <peter@p12n.org>
+Subject: Prevent recursive linking of dependent libraries by apr-util users.
+
+---
+ apr-util.pc.in |    5 +++--
+ apu-config.in  |    2 +-
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+--- a/apr-util.pc.in
++++ b/apr-util.pc.in
+@@ -8,6 +8,7 @@ Name: APR Utils
+ Description: Companion library for APR
+ Version: @APRUTIL_DOTTED_VERSION@
+ # assume that apr-util requires libapr of same major version
+-Requires: apr-@APRUTIL_MAJOR_VERSION@
+-Libs: -L${libdir} -l@APRUTIL_LIBNAME@ @LDADD_ldap@ @APRUTIL_EXPORT_LIBS@
++Requires.private: apr-@APRUTIL_MAJOR_VERSION@
++Libs: -L${libdir} -l@APRUTIL_LIBNAME@ @LDADD_ldap@
++Libs.private: @APRUTIL_EXPORT_LIBS@
+ Cflags: -I${includedir}
+--- a/apu-config.in
++++ b/apu-config.in
+@@ -27,7 +27,7 @@ bindir="@bindir@"
+ libdir="@libdir@"
+ includedir="@includedir@"
+ 
+-LIBS="@APRUTIL_EXPORT_LIBS@"
++LIBS=
+ INCLUDES="@APRUTIL_INCLUDES@"
+ LDFLAGS="@APRUTIL_LDFLAGS@"
+ ORIG_LDAP_LIBS="@LDADD_ldap@"

--- a/libs/apr-util/patches/006-avoid_db_by-default.patch
+++ b/libs/apr-util/patches/006-avoid_db_by-default.patch
@@ -1,0 +1,35 @@
+From: Stefan Fritsch <sf@debian.org>
+Subject: Make apu-config not output dbm libs by default. See #622081
+
+--- a/apu-config.in
++++ b/apu-config.in
+@@ -32,7 +32,8 @@ INCLUDES="@APRUTIL_INCLUDES@"
+ LDFLAGS="@APRUTIL_LDFLAGS@"
+ ORIG_LDAP_LIBS="@LDADD_ldap@"
+ LDAP_LIBS=""
+-DBM_LIBS="@LDADD_dbm_db@ @LDADD_dbm_gdbm@ @LDADD_dbm_ndbm@"
++ORIG_DBM_LIBS="@LDADD_dbm_db@ @LDADD_dbm_gdbm@ @LDADD_dbm_ndbm@"
++DBM_LIBS=""
+ 
+ APRUTIL_LIBNAME="@APRUTIL_LIBNAME@"
+ 
+@@ -58,8 +59,8 @@ Known values for OPTION are:
+   --libs            print library information
+   --avoid-ldap      do not include ldap library information with --libs (default on OpenWrt)
+   --ldap-libs       print library information to link with ldap
+-  --avoid-dbm       do not include DBM library information with --libs
+-  --dbm-libs        print additional library information to link with DBM
++  --avoid-dbm       do not include DBM library information with --libs (default on OpenWrt)
++  --dbm-libs        print library information to link with DBM
+   --srcdir          print APR-util source directory
+   --link-ld         print link switch(es) for linking to APR-util
+   --link-libtool    print the libtool inputs for linking to APR-util
+@@ -125,7 +126,7 @@ while test $# -gt 0; do
+     flags="$flags $ORIG_LDAP_LIBS"
+     ;;
+     --dbm-libs)
+-    flags="$flags $DBM_LIBS"
++    flags="$flags $ORIG_DBM_LIBS"
+     ;;
+     --includedir)
+     if test "$location" = "installed"; then

--- a/net/apache/Makefile
+++ b/net/apache/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apache
 PKG_VERSION:=2.4.41
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_SOURCE_NAME:=httpd
 
 PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.bz2
@@ -40,8 +40,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_apache-mod-session-crypto \
 	CONFIG_PACKAGE_apache-mod-suexec \
 	CONFIG_PACKAGE_apache-mod-webdav \
-	CONFIG_PACKAGE_apache-suexec \
-	CONFIG_PACKAGE_libaprutil-dbm-gdbm
+	CONFIG_PACKAGE_apache-suexec
 
 PKG_FIXUP:=autoreconf
 
@@ -68,7 +67,7 @@ endef
 define Package/apache
 $(call Package/apache/Default)
   USERID:=apache=377:apache=377
-  DEPENDS:=+PACKAGE_libaprutil-dbm-gdbm:libgdbm +libapr +libaprutil +libpcre
+  DEPENDS:=+libapr +libaprutil +libpcre
 endef
 
 define Package/apache/description

--- a/net/subversion/Makefile
+++ b/net/subversion/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=subversion
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=1.13.0
 PKG_SOURCE_URL:=@APACHE/subversion
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -31,7 +31,7 @@ define Package/subversion/Default
   CATEGORY:=Network
   SUBMENU:=Version Control Systems
   TITLE:=A compelling replacement for CVS
-  DEPENDS:=+PACKAGE_unixodbc:unixodbc +libaprutil +libmagic $(ICONV_DEPENDS) $(INTL_DEPENDS)
+  DEPENDS:=+PACKAGE_unixodbc:unixodbc +libaprutil +libmagic +libsqlite3 $(ICONV_DEPENDS) $(INTL_DEPENDS)
   URL:=https://subversion.apache.org/
 endef
 


### PR DESCRIPTION
subversion maintainer: @val-kulkov 
apr-util and apache maintainers: @heil & me
Compile tested: ath79 master
Run tested: ath79 19.07, tested subversion-client (checking out svn://svn.code.sf.net/p/pcapsipdump/code/trunk) as well as apache web server

Description:
Hi Val et al,

Currently packaging of subversion fails like this:

```
Package subversion-libs is missing dependencies for the following libraries:
libgdbm.so.6
liblber-2.4.so.2
libldap-2.4.so.2
libsqlite3.so.0
```

This is due to recent apr-util updates, where more functionality were added (mostly modular). libgdbm gets linked in automatically by apr-util users when libaprutil-dbm-gdbm is built. sqlite3 is no longer a dep of apr-util, so this needs to be added to subversion package.

The other libs (ldap, libiconv, expat) are not required by apr-util users (exception would be apache, but that works out fine). I've copied patches from Debian into apr-util that sort out apu-1-config to prevent the unnecessary rdepends.

Thanks!
Seb