### PR TITLE
golang: Update for ASLR PIE tristate option change

### DIFF
--- a/lang/golang/golang-package.mk
+++ b/lang/golang/golang-package.mk
@@ -120,10 +120,22 @@ GO_PKG_BUILD_BIN_DIR:=$(GO_PKG_BUILD_DIR)/bin$(if $(GO_HOST_TARGET_DIFFERENT),/$
 
 GO_PKG_BUILD_DEPENDS_SRC:=$(STAGING_DIR)$(GO_PKG_PATH)/src
 
-ifeq ($(CONFIG_PKG_ASLR_PIE),y)
+ifdef CONFIG_PKG_ASLR_PIE_ALL
   ifeq ($(strip $(PKG_ASLR_PIE)),1)
     ifeq ($(GO_TARGET_PIE_SUPPORTED),1)
       GO_PKG_ENABLE_PIE:=1
+    else
+      $(warning PIE buildmode is not supported for $(GO_OS)/$(GO_ARCH))
+    endif
+  endif
+endif
+
+ifdef CONFIG_PKG_ASLR_PIE_REGULAR
+  ifeq ($(strip $(PKG_ASLR_PIE_REGULAR)),1)
+    ifeq ($(GO_TARGET_PIE_SUPPORTED),1)
+      GO_PKG_ENABLE_PIE:=1
+    else
+      $(warning PIE buildmode is not supported for $(GO_OS)/$(GO_ARCH))
     endif
   endif
 endif

--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -92,10 +92,12 @@ BOOTSTRAP_UNPACK:=$(HOST_TAR) -C $(BOOTSTRAP_BUILD_DIR) --strip-components=1 -xz
 RSTRIP:=:
 STRIP:=:
 
-ifeq ($(CONFIG_PKG_ASLR_PIE),y)
+ifdef CONFIG_PKG_ASLR_PIE_ALL
   ifeq ($(GO_TARGET_PIE_SUPPORTED),1)
     PKG_GO_ENABLE_PIE:=1
     PKG_GO_INSTALL_SUFFIX:=$(GO_TARGET_PIE_INSTALL_SUFFIX)
+  else
+    $(warning PIE buildmode is not supported for $(GO_OS)/$(GO_ARCH))
   endif
 endif
 


### PR DESCRIPTION
Maintainer: me
Compile tested: armvirt-32 / malta-be, 2020-01-15 snapshot sdk
Run tested: none

Description:
The ASLR PIE option was changed to a tristate option (openwrt/openwrt@19cbac7d264dfca1f75849de64beb98830fbb1e4). This updates the Go compiler package and golang-package.mk to account for this change.

This also adds warning messages for when the user has selected PIE but Go does not have PIE support for the chosen target.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>

