### PR TITLE
vpn-policy-routing: bugfix: remove conflict with vpnbypass

### DIFF
--- a/net/vpn-policy-routing/Makefile
+++ b/net/vpn-policy-routing/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vpn-policy-routing
 PKG_VERSION:=0.2.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 
@@ -16,7 +16,6 @@ define Package/vpn-policy-routing
 	CATEGORY:=Network
 	TITLE:=VPN Policy-Based Routing Service
 	DEPENDS:=+ipset +iptables +resolveip +kmod-ipt-ipset +iptables-mod-ipopt +!BUSYBOX_CONFIG_IP:ip-full
-	CONFLICTS:=vpnbypass
 	PKGARCH:=all
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, WRT3200ACM, 19.07.0
Run tested: mvebu, WRT3200ACM, 19.07.0, start/stop

Description:
1. Remove conflicts statement from the makefile
2. Update README

@jow- please cherry-pick this for 19.07 tree as well.

Signed-off-by: Stan Grishin <stangri@melmac.net>
