### PR TITLE
oniguruma: bump to version 6.9.4

### DIFF
--- a/libs/oniguruma/Makefile
+++ b/libs/oniguruma/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oniguruma
-PKG_VERSION:=6.9.3
+PKG_VERSION:=6.9.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=onig-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/kkos/oniguruma/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=dc6dec742941e24b761cea1b9a2f12e750879107ae69fd80ae1046459d4fb1db
+PKG_HASH:=aea68e5843b627f5fe6d3d6b598845b7f3622910e0568408e7cc2fa6b3690b87
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: WRT3200ACM, mvebu arm, openwrt master
Run tested: WRT3200ACM, lightly tested with seafile

Description:
This version adds a new RegSet API, and fixes the following:
 - CVE-2019-19012
 - CVE-2019-19203
 - CVE-2019-19204
 - CVE-2019-19246
 - some problems (found by libFuzzer test)

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

--
This should be cherry-picked to 19.07