### PR TITLE
python-certify: bump to 2019.11.28

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
-PKG_VERSION:=2019.9.11
+PKG_VERSION:=2019.11.28
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
@@ -14,7 +14,7 @@ PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PYPI_NAME:=certifi
-PKG_HASH:=e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50
+PKG_HASH:=25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: arm, WRT3200ACM, openwrt master
Run tested: arm, WRT3200ACM, openwrt master, tested by running `python -m certifi`

Description:
This is a regular Mozilla's CA bundle update.