### PR TITLE
[serdisplib] Update Makefile to fix build issue

### DIFF
--- a/libs/serdisplib/Makefile
+++ b/libs/serdisplib/Makefile
@@ -11,6 +11,8 @@ PKG_LICENSE:=GPL-2.0
 PLG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 
+PKG_BUILD_DEPENDS:=libusb-compat
+
 PKG_FIXUP:=libtool
 
 include $(INCLUDE_DIR)/package.mk
@@ -22,7 +24,6 @@ define Package/serdisplib
   CATEGORY:=Libraries
   TITLE:=serdisplib
   URL:=http://serdisplib.sourceforge.net/
-  DEPENDS:=+libusb-compat
 endef
 
 define Package/serdisplib/description

--- a/libs/serdisplib/Makefile
+++ b/libs/serdisplib/Makefile
@@ -22,6 +22,7 @@ define Package/serdisplib
   CATEGORY:=Libraries
   TITLE:=serdisplib
   URL:=http://serdisplib.sourceforge.net/
+  DEPENDS:=+libusb-compat
 endef
 
 define Package/serdisplib/description


### PR DESCRIPTION
Using the unpatched file causes a build error:

```
In file included from serdisp_specific_ddusbt.c:51:
../include/serdisplib/serdisp_connect_usb.h:35:10: fatal error: usb.h: No such file or directory
   35 | #include <usb.h>
      |          ^~~~~~~
compilation terminated.
```

Adding the `libusb-compat` dependency fixes this issue.

Maintainer: me / @\<dangowrt>
Compile tested: mips-32, EasyBox 904xDSL, serdisplib-2.01, OpenWRT master
Run tested: mips-32, EasyBox 904xDSL, serdisplib-2.01, OpenWRT master

Description:
