### PR TITLE
python-aiohttp: update to version 3.6.1

### DIFF
--- a/lang/python/python-aiohttp/Makefile
+++ b/lang/python/python-aiohttp/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+# Copyright (C) 2019-2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aiohttp
-PKG_VERSION:=3.5.4
+PKG_VERSION:=3.6.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=9c4c83f4fa1938377da32bc2d59379025ceeee8e24b89f72fcbccd8ca22dc9bf
+PKG_HASH:=fc55b1fec0e4cc1134ffb09ea3970783ee2906dc5dfd7cd16917913f2cfed65b
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -44,7 +44,7 @@ define Package/python3-aiohttp
 endef
 
 define Package/python3-aiohttp/description
-Asynchronous HTTP client/server framework for asyncio and Python3
+  Asynchronous HTTP client/server framework for asyncio and Python3.
 endef
 
 $(eval $(call Py3Package,python3-aiohttp))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
Update to version [3.6.1](https://github.com/aio-libs/aiohttp/blob/3.6/CHANGES.rst). Home Assistant is having some issues with the latest version, so let's use 3.6.1 version for now.

- Update copyright
- Add two spaces as indentation for description
