### PR TITLE
[19.07] afalg_engine: bump to v1.1.0

### DIFF
--- a/libs/afalg_engine/Makefile
+++ b/libs/afalg_engine/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=afalg_engine
-PKG_VERSION:=1.0.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.1.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/cotequeiroz/afalg_engine/archive/v$(PKG_VERSION)
-PKG_HASH:=ef3ee1ba3cb4e9145f9a0dea5bc6d3fe6cb7b5b9e68053d474829e84dc1c4988
+PKG_HASH:=0c0304558e9450752656522a8f9036130f4e745c4818f02f92cb8d6c99357ed6
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -56,6 +56,7 @@ endef
 
 CMAKE_OPTIONS += \
 	-DOPENSSL_ENGINES_DIR=/usr/lib/$(ENGINES_DIR) \
+	-DUSE_CRYPTOUSER=OFF \
 	-DUSE_ZERO_COPY=$(if $(CONFIG_AFALG_ZERO_COPY),ON,OFF)
 
 define Package/libopenssl-afalg_sync/install


### PR DESCRIPTION
Maintainer: me
Compile tested: ramips, mipsel_74kc, openwrt 19.07
Run tested: ramips, mipsel_74kc, openwrt 19.07, tested with openssl-util, performing encryption/decryption operations (aes-cbc & aes-ctr), and `openssl engine -pre DUMP_INFO`

Description:
This version is up to 20% faster than 1.0.1.
Build without cryptouser information, which is not available in 19.07.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>