### PR TITLE
nut: fix other/otherflag custom variables in nut-server.init

### DIFF
--- a/net/nut/Makefile
+++ b/net/nut/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nut
 PKG_VERSION:=2.7.4
-PKG_RELEASE:=19
+PKG_RELEASE:=20
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.networkupstools.org/source/2.7/

--- a/net/nut/files/nut-server.init
+++ b/net/nut/files/nut-server.init
@@ -203,8 +203,8 @@ build_driver_config() {
 		fi
 	}
 
-	config_list_foreach "$cfg" other other
-	config_list_foreach "$cfg" other otherflag
+	config_list_foreach "$cfg" other other other
+	config_list_foreach "$cfg" otherflag other otherflag
 	echo "" >>$UPS_C
 	havedriver=1
 }


### PR DESCRIPTION
This allows custom config parameters to be added to the generated config
files, enabling the original intended functionality per
https://openwrt.org/docs/guide-user/services/ups/software.nut.
    
Example usage from /etc/config/nut_server:

    config driver 'apc'
        option driver 'snmp-ups'
        option snmp_version 'v3'
        option port '172.16.100.5'
        list other 'secLevel'
        list other 'secName'
        list other 'authPassword'
        list otherflag 'notransferoids'

    config other 'other_secLevel'
        option value 'authNoPriv'

    config other 'other_secName'
	    option value 'some_username'

    config other 'other_authPassword'
        option value 'some_password'

    config other 'otherflag_notransferoids'
        option value '1'

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>

Maintainer: @cshoredaniel 
Compile tested: x86_64, openwrt-19.07
Run tested: x86_64, openwrt-19.07