### PR TITLE
fft-eval: update to the version with ath11k support

### DIFF
--- a/utils/fft-eval/Makefile
+++ b/utils/fft-eval/Makefile
@@ -15,7 +15,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/$(PKG_NAME)
 	SECTION:=utils
 	CATEGORY:=Utilities
-	MAINTAINER:=Nicolas Pace <nicopace@altermundi.net>
+	MAINTAINER:=Kirill Lukonin <klukonin@gmail.com>
 	URL:=https://github.com/simonwunderlich/FFT_eval
 	TITLE:=Evaluates FFT samples from ath9k, ath10k or ath11k driver
 	DEPENDS:=@PACKAGE_ATH_DEBUG @PACKAGE_ATH_SPECTRAL

--- a/utils/fft-eval/Makefile
+++ b/utils/fft-eval/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fft-eval
-PKG_VERSION:=2017-06-28
+PKG_VERSION:=2019-11-27
 PKG_RELEASE=$(PKG_SOURCE_VERSION)
 
-PKG_SOURCE_VERSION:=3cc175570379da172b0b2bcdbb8d2a42f83dad88
+PKG_SOURCE_VERSION:=4d3b6faee428e3bd9f44ab6a3d70585ec50484a1
 PKG_SOURCE:=FFT_eval-$(PKG_SOURCE_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/simonwunderlich/FFT_eval/tar.gz/$(PKG_SOURCE_VERSION)?
-PKG_HASH:=9d70125fffc83918e6613d5938c4a9925aea07323e09470cf059cf0026e5937c
+PKG_HASH:=fb34ed5691af6c3ec09c41a6689ae64a1a12d770347a4effd48e4b30aef1eb22
 PKG_BUILD_DIR:=$(BUILD_DIR)/FFT_eval-$(PKG_SOURCE_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
@@ -17,23 +17,25 @@ define Package/$(PKG_NAME)
 	CATEGORY:=Utilities
 	MAINTAINER:=Nicolas Pace <nicopace@altermundi.net>
 	URL:=https://github.com/simonwunderlich/FFT_eval
-	TITLE:=Evaluates FFT samples from ath9k driver
-	DEPENDS:= +libc @PACKAGE_ATH_DEBUG @PACKAGE_ATH_SPECTRAL
+	TITLE:=Evaluates FFT samples from ath9k, ath10k or ath11k driver
+	DEPENDS:=@PACKAGE_ATH_DEBUG @PACKAGE_ATH_SPECTRAL
 endef
 
 define Package/$(PKG_NAME)/description
 	Evaluates FFT samples from diferent wifi boards drivers
 endef
 
-TARGET_CFLAGS  += -ffunction-sections -fdata-sections -flto
+TARGET_CFLAGS  += -Wall -W -std=gnu99 -fno-strict-aliasing -MD -MP
+TARGET_CPPFLAGS += -D_DEFAULT_SOURCE
+
 
 define Build/Compile
-	$(TARGET_CC) -D__NOSDL__ $(PKG_BUILD_DIR)/fft_eval.c -o $(PKG_BUILD_DIR)/fft_eval -lm
+	$(call Build/Compile/Default,CONFIG_fft_eval_sdl=n)
 endef
 
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/fft_eval $(1)/usr/bin/fft_eval
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/fft_eval_json $(1)/usr/bin/fft_eval
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
Latest fft-eval has some extra features such as ath11k support, double precision in json signal calculation, and cleanups (batctl references, minor bugfixes, etc )
This commit is a version and makefile update. Now the native project Makefile do the job (compilation and linking).

Maintainer: Nicolas Pace nicopace@altermundi.net 

Compile tested: Ubuntu 19.10, current OpenWrt master) 
Run tested: Unifi AP AC Mesh, current OpenWrt master, tests done) 

Description: Latest fft-eval has some extra features such as ath11k  support, double precision in json signal calculation,   and cleanups  (batctl references, minor bugfixes, etc ) This commit is a version and makefile update. Now the native project Makefile do the job (compilation and linking).