### PR TITLE
nginx-util: fix ubus::~iterator() and minor issues

### DIFF
--- a/net/nginx-util/Makefile
+++ b/net/nginx-util/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx-util
-PKG_VERSION:=1.0
+PKG_VERSION:=1.1
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/net/nginx-util/src/CMakeLists.txt
+++ b/net/nginx-util/src/CMakeLists.txt
@@ -9,7 +9,7 @@ FIND_LIBRARY(ubox NAMES ubox)
 FIND_LIBRARY(ubus NAMES ubus)
 INCLUDE_DIRECTORIES(${ubus_include_dir})
 
-ADD_DEFINITIONS(-Os -Wall -Werror -Wextra --std=c++17 -g3)
+ADD_DEFINITIONS(-Os -Wall -Werror -Wextra --std=c++2a -g3)
 ADD_DEFINITIONS(-Wno-unused-parameter -Wmissing-declarations)
 
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")

--- a/net/nginx-util/src/nginx-ssl-util.cpp
+++ b/net/nginx-util/src/nginx-ssl-util.cpp
@@ -100,7 +100,7 @@ void del_ssl_directives_from(const std::string & name, bool isdefault);
 void del_ssl(const std::string & name);
 
 
-static constexpr auto _begin = _Line{
+constexpr auto _begin = _Line{
     [](const std::string & /*param*/, const std::string & begin) -> std::string
     { return begin; },
 
@@ -110,7 +110,7 @@ static constexpr auto _begin = _Line{
 };
 
 
-static constexpr auto _space = _Line{
+constexpr auto _space = _Line{
     [](const std::string & /*param*/, const std::string & /*begin*/)
         -> std::string
     { return std::string{" "}; },
@@ -121,7 +121,7 @@ static constexpr auto _space = _Line{
 };
 
 
-static constexpr auto _newline = _Line{
+constexpr auto _newline = _Line{
     [](const std::string & /*param*/, const std::string & /*begin*/)
         -> std::string
     { return std::string{"\n"}; },
@@ -132,7 +132,7 @@ static constexpr auto _newline = _Line{
 };
 
 
-static constexpr auto _end = _Line{
+constexpr auto _end = _Line{
     [](const std::string & /*param*/, const std::string & /*begin*/)
         -> std::string
     { return std::string{";"}; },
@@ -144,7 +144,7 @@ static constexpr auto _end = _Line{
 
 
 template<char clim='\0'>
-static constexpr auto _capture = _Line{
+constexpr auto _capture = _Line{
     [](const std::string & param, const std::string & /*begin*/) -> std::string
     { return '\'' + param + '\''; },
 
@@ -159,10 +159,14 @@ static constexpr auto _capture = _Line{
 
 
 template<const std::string_view & strptr, char clim='\0'>
-static constexpr auto _escape = _Line{
+constexpr auto _escape = _Line{
     [](const std::string &  /*param*/, const std::string & /*begin*/)
         -> std::string
-    { return clim + std::string{strptr.data()} + clim; },
+    {
+        return clim=='\0' ?
+            std::string{strptr.data()} :
+            clim + std::string{strptr.data()} + clim;
+    },
 
     [](const std::string & /*param*/, const std::string & /*begin*/)
         -> std::string
@@ -184,17 +188,17 @@ static constexpr auto _escape = _Line{
 };
 
 
-static constexpr std::string_view _server_name = "server_name";
+constexpr std::string_view _server_name = "server_name";
 
-static constexpr std::string_view _include = "include";
+constexpr std::string_view _include = "include";
 
-static constexpr std::string_view _ssl_certificate = "ssl_certificate";
+constexpr std::string_view _ssl_certificate = "ssl_certificate";
 
-static constexpr std::string_view _ssl_certificate_key = "ssl_certificate_key";
+constexpr std::string_view _ssl_certificate_key = "ssl_certificate_key";
 
-static constexpr std::string_view _ssl_session_cache = "ssl_session_cache";
+constexpr std::string_view _ssl_session_cache = "ssl_session_cache";
 
-static constexpr std::string_view _ssl_session_timeout = "ssl_session_timeout";
+constexpr std::string_view _ssl_session_timeout = "ssl_session_timeout";
 
 
 // For a compile time regex lib, this must be fixed, use one of these options:

--- a/net/nginx-util/src/nginx-util.cpp
+++ b/net/nginx-util/src/nginx-util.cpp
@@ -91,7 +91,8 @@ void get_env()
     std::cout<<"LAN_LISTEN="<<"'"<<LAN_LISTEN<<"'"<<std::endl;
 #ifdef NGINX_OPENSSL
     std::cout<<"LAN_SSL_LISTEN="<<"'"<<LAN_SSL_LISTEN<<"'"<<std::endl;
-    std::cout<<"SSL_SESSION_CACHE_ARG="<<"'"<<LAN_NAME<<"'"<<std::endl;
+    std::cout<<"SSL_SESSION_CACHE_ARG="<<"'"<<SSL_SESSION_CACHE_ARG(LAN_NAME)<<
+        "'"<<std::endl;
     std::cout<<"SSL_SESSION_TIMEOUT_ARG="<<"'"<<SSL_SESSION_TIMEOUT_ARG<<"'\n";
     std::cout<<"ADD_SSL_FCT="<<"'"<<ADD_SSL_FCT<<"'"<<std::endl;
 #endif

--- a/net/nginx-util/src/px5g.cpp
+++ b/net/nginx-util/src/px5g.cpp
@@ -1,9 +1,9 @@
+#include "px5g-openssl.hpp"
 #include <array>
 #include <iostream>
 #include <string>
 #include <string_view>
 #include <unistd.h>
-#include "px5g-openssl.hpp"
 
 
 class argv_view { // TODO(pst): use std::span when available.


### PR DESCRIPTION
Maintainer: me
Compile tested: MIPS 74K, Asus RT-N16, master snapshot
Run tested: MIPS 74K, Asus RT-N16, master snapshot, run nginx-util [init_lan|get_env [name]|add_ssl _lan] using the file /etc/nginx/conf.d/_lan.conf:
```
server {
    server_name _lan;
    include conf.d/*.locations;
}
```
Description:
Sorry, I could test the latest changes just right now and had to fix some problems:
* Do not destroy the ubus::iterator twice if `cur==this` (segfault).
* Do not add the delimiter `clim=='\0'` when creating the SSL directives.
* Set the right SSL_SESSION_CACHE_ARG for `nginx-util get_env`.

Additionaly, I made some minor improvements:
* Remove `static` from the `constexpr` that are used only for `Line::build`.
* Concat strings instead of appending them for not using a non-const ref
(to remove some warnings of `clang-tidy -checks=google-runtime-references`)
* Cosmetic cleanup `using msg_ptr = std::shared_ptr<const blob_attr>;`
