### PR TITLE
frp: update to 0.31.1

### DIFF
--- a/net/frp/Makefile
+++ b/net/frp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
-PKG_VERSION:=0.29.0
+PKG_VERSION:=0.31.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/fatedier/frp/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=5d7980b81cfd055e3e5bb7a120098f94342656f647cb906ea075912f63568816
+PKG_HASH:=b1fa893c09e61db084bf6ddc0abcaf105c2828a887ee0fc376bef1a66da9b095
 
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintainer: me
Compile tested: x86-64, snapshot
Run tested: x86-64, snapshot

Description:
Run tested by start frps first then start frpc.
By default the client connects to server at 127.0.0.1.
syslog:
```
Tue Jan 21 14:02:28 2020 daemon.info frps[4036]: 2020/01/21 14:02:28 [1;34m[I] [service.go:152] frps tcp listen on 0.0.0.0:7000[0m
Tue Jan 21 14:02:28 2020 daemon.info frps[4036]: 2020/01/21 14:02:28 [1;34m[I] [root.go:205] start frps success[0m
Tue Jan 21 14:02:35 2020 daemon.info frps[4036]: 2020/01/21 14:02:35 [1;34m[I] [service.go:392] [b561524024468541] client login info: ip [127.0.0.1:60524] version [0.31.1] hostname [] os [linux] arch [amd64][0m
Tue Jan 21 14:02:35 2020 daemon.info frpc[4087]: 2020/01/21 14:02:35 [1;34m[I] [service.go:250] [b561524024468541] login to server success, get run id [b561524024468541], server udp port [0][0m
Tue Jan 21 14:02:35 2020 daemon.info frpc[4087]: 2020/01/21 14:02:35 [1;34m[I] [proxy_manager.go:144] [b561524024468541] proxy added: [ssh][0m
Tue Jan 21 14:02:35 2020 daemon.info frps[4036]: 2020/01/21 14:02:35 [1;34m[I] [tcp.go:63] [b561524024468541] [ssh] tcp proxy listen port [6000][0m
Tue Jan 21 14:02:35 2020 daemon.info frps[4036]: 2020/01/21 14:02:35 [1;34m[I] [control.go:445] [b561524024468541] new proxy [ssh] success[0m
Tue Jan 21 14:02:35 2020 daemon.info frpc[4087]: 2020/01/21 14:02:35 [1;34m[I] [control.go:164] [b561524024468541] [ssh] start proxy success[0m
```