### PR TITLE
python-voluptuous-serialize: update to version 2.3.0

### DIFF
--- a/lang/python/python-voluptuous-serialize/Makefile
+++ b/lang/python/python-voluptuous-serialize/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+# Copyright (C) 2019-2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=voluptuous-serialize
-PKG_VERSION:=2.2.0
+PKG_VERSION:=2.3.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=8b31660c7efdba0eb97ba65390b63cc62cc99ae3cd25d00e1873b183b38ef13d
+PKG_HASH:=740cd00ce2ecf0f3345d550163fdd2f20de2e0a60c3c678450e68314c2f592f5
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=Apache-2.0
@@ -35,7 +35,7 @@ define Package/python3-voluptuous-serialize
 endef
 
 define Package/python3-voluptuous-serialize/description
-Convert Voluptuous schemas to dictionaries so they can be serialized.
+  Convert Voluptuous schemas to dictionaries so they can be serialized.
 endef
 
 $(eval $(call Py3Package,python3-voluptuous-serialize))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- Update to version [2.3.0](https://github.com/balloob/voluptuous-serialize/releases/tag/2.3.0)