### PR TITLE
radicale-py3: Add python3-urllib dependency

### DIFF
--- a/net/radicale/Makefile
+++ b/net/radicale/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale
 PKG_VERSION:=1.1.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=
 
 PKG_LICENSE:=GPL-3.0
@@ -48,7 +48,7 @@ define Package/radicale-py3
   $(call Package/radicale/Default)
   TITLE+= (Python 3)
   VARIANT:=3
-  DEPENDS:=+python3-logging +python3-openssl +python3-xml +python3-codecs +python3-email
+  DEPENDS:=+python3-logging +python3-openssl +python3-xml +python3-codecs +python3-urllib
 endef
 
 # shown in LuCI package description


### PR DESCRIPTION
Depend on python3-urllib instead of python3-email (python3-urllib has
python3-email as a dependency).

Signed-off-by: Dennis Dast <mail@ddast.de>

Maintainer: @jefferyto
Compile tested: -
Run tested: TP-Link Archer C2600, ipq806x, OpenWrt 19.07.0. Confirmed that with the current dependencies radicale-py3 only starts after manually installing python3-urllib.

Description:
Radicale does not start with the current dependencies since urllib is missing.  After installing python3-urllib, radicale-py3 works.
This was already fixed in master in commit 9c5a97c, however, branch 19.07 does not yet have python3-urllib as a dependecy.
Closes #11062 