### PR TITLE
lcdproc: add serdisplib dependency

### DIFF
--- a/utils/lcdproc/Makefile
+++ b/utils/lcdproc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lcdproc
 PKG_VERSION:=0.5.9
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lcdproc/lcdproc/releases/download/v$(PKG_VERSION)/
@@ -89,7 +89,7 @@ define Package/lcdproc-drivers
   $(call Package/lcdproc/Default)
   TITLE:=LCD Display extra drivers
   DEPENDS:=+lcdproc-server +libncurses +libusb-1.0 +libusb-compat +libftdi1 \
-	+GPIO_SUPPORT:libugpio
+	+GPIO_SUPPORT:libugpio +serdisplib
 endef
 
 define LCDPROC_OTHER_DRIVERS_TEXT


### PR DESCRIPTION
It gets picked up when it is existing.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @haraldg @pprindeville 
Compile tested: malta