### PR TITLE
django1: bump to 1.11.27 and add Py3 variant

### DIFF
--- a/lang/python/django-appconf/Makefile
+++ b/lang/python/django-appconf/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-appconf
 PKG_VERSION:=1.0.2
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=6a4d9aea683b4c224d97ab8ee11ad2d29a37072c0c6c509896dd9857466fb261
@@ -47,10 +47,12 @@ endef
 define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
-	+PACKAGE_python3-$(PKG_NAME):python3 \
-	python3-django
+	+PACKAGE_python3-$(PKG_NAME):python3
+  # FIXME: restore these when django1 goes away; for now, this avoids
+  #        some circular deps, which require a bit more work to fix
+  #	python3-django
   VARIANT:=python3
-  MDEPENDS:=python3-django
+  #MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-compressor/Makefile
+++ b/lang/python/django-compressor/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-compressor
 PKG_VERSION:=2.2
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PYPI_NAME:=$(PKG_NAME)
 PYPI_SOURCE_NAME:=django_compressor
@@ -54,11 +54,13 @@ define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
-	python3-django \
 	+PACKAGE_python3-$(PKG_NAME):python3-django-appconf \
 	+PACKAGE_python3-$(PKG_NAME):python3-rcssmin
+  # FIXME: restore these when django1 goes away; for now, this avoids
+  #        some circular deps, which require a bit more work to fix
+  #	python3-django
   VARIANT:=python3
-  MDEPENDS:=python3-django
+  #MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-constance/Makefile
+++ b/lang/python/django-constance/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-constance
 PKG_VERSION:=2.3.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=a49735063b2c30015d2e52a90609ea9798da722ed070f091de51714758a5d018
@@ -46,10 +46,12 @@ endef
 define Package/python3-django-constance
 $(call Package/python-django-constance/Default)
   DEPENDS:= \
-	+PACKAGE_python3-django-constance:python3 \
-	python3-django
+	+PACKAGE_python3-django-constance:python3
+  # FIXME: restore these when django1 goes away; for now, this avoids
+  #        some circular deps, which require a bit more work to fix
+  #	python3-django
   VARIANT:=python3
-  MDEPENDS:=python3-django
+  #MDEPENDS:=python3-django
 endef
 
 define Package/python3-django-constance/description

--- a/lang/python/django-formtools/Makefile
+++ b/lang/python/django-formtools/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-formtools
 PKG_VERSION:=2.1
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=7703793f1675aa6e871f9fed147e8563816d7a5b9affdc5e3459899596217f7c
@@ -46,10 +46,12 @@ endef
 define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
-	+PACKAGE_python3-$(PKG_NAME):python3 \
-	python3-django
+	+PACKAGE_python3-$(PKG_NAME):python3
+  # FIXME: restore these when django1 goes away; for now, this avoids
+  #        some circular deps, which require a bit more work to fix
+  #	python3-django
   VARIANT:=python3
-  MDEPENDS:=python3-django
+  #MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-jsonfield/Makefile
+++ b/lang/python/django-jsonfield/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-jsonfield
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=6c0afd5554739365b55d86e285cf966cc3a45682fff963463364ea1f6511ca3e
@@ -47,10 +47,12 @@ endef
 define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
-	+PACKAGE_python3-$(PKG_NAME):python3 \
-	python3-django
+	+PACKAGE_python3-$(PKG_NAME):python3
+  # FIXME: restore these when django1 goes away; for now, this avoids
+  #        some circular deps, which require a bit more work to fix
+  #	python3-django
   VARIANT:=python3
-  MDEPENDS:=python3-django
+  #MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-picklefield/Makefile
+++ b/lang/python/django-picklefield/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-picklefield
 PKG_VERSION:=1.1.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=ce7fee5c6558fe5dc8924993d994ccde75bb75b91cd82787cbd4c92b95a69f9c
@@ -47,10 +47,12 @@ endef
 define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
-	+PACKAGE_python3-$(PKG_NAME):python3 \
-	python3-django
+	+PACKAGE_python3-$(PKG_NAME):python3
+  # FIXME: restore these when django1 goes away; for now, this avoids
+  #        some circular deps, which require a bit more work to fix
+  #	python3-django
   VARIANT:=python3
-  MDEPENDS:=python3-django
+  #MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-postoffice/Makefile
+++ b/lang/python/django-postoffice/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-postoffice
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PYPI_NAME:=django-post-office
 PYPI_SOURCE_NAME:=django-post_office
@@ -51,10 +51,12 @@ define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
-	python3-django \
 	+PACKAGE_python3-$(PKG_NAME):python3-django-jsonfield
+  # FIXME: restore these when django1 goes away; for now, this avoids
+  #        some circular deps, which require a bit more work to fix
+  #	python3-django
   VARIANT:=python3
-  MDEPENDS:=python3-django
+  #MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-ranged-response/Makefile
+++ b/lang/python/django-ranged-response/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-ranged-response
 PKG_VERSION:=0.2.0
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=f71fff352a37316b9bead717fc76e4ddd6c9b99c4680cdf4783b9755af1cf985
@@ -45,10 +45,12 @@ endef
 define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
-	+PACKAGE_python3-$(PKG_NAME):python3 \
-	python3-django
+	+PACKAGE_python3-$(PKG_NAME):python3
+  # FIXME: restore these when django1 goes away; for now, this avoids
+  #        some circular deps, which require a bit more work to fix
+  #	python3-django
   VARIANT:=python3
-  MDEPENDS:=python3-django
+  #MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-restframework/Makefile
+++ b/lang/python/django-restframework/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-restframework
 PKG_VERSION:=3.9.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PYPI_NAME:=djangorestframework
 PKG_HASH:=607865b0bb1598b153793892101d881466bd5a991de12bd6229abb18b1c86136
@@ -47,10 +47,12 @@ endef
 define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
-	+PACKAGE_python3-$(PKG_NAME):python3 \
-	python3-django
+	+PACKAGE_python3-$(PKG_NAME):python3
+  # FIXME: restore these when django1 goes away; for now, this avoids
+  #        some circular deps, which require a bit more work to fix
+  #	python3-django
   VARIANT:=python3
-  MDEPENDS:=python3-django
+  #MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-simple-captcha/Makefile
+++ b/lang/python/django-simple-captcha/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-simple-captcha
 PKG_VERSION:=0.5.12
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mbi/django-simple-captcha/tar.gz/v$(PKG_VERSION)?
@@ -57,11 +57,13 @@ $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
 	+PACKAGE_python3-$(PKG_NAME):python3 \
 	+PACKAGE_python3-$(PKG_NAME):python3-six \
-	python3-django \
 	+PACKAGE_python3-$(PKG_NAME):python3-pillow \
 	+PACKAGE_python3-$(PKG_NAME):python3-django-ranged-response
+  # FIXME: restore these when django1 goes away; for now, this avoids
+  #        some circular deps, which require a bit more work to fix
+  # 	python3-django
   VARIANT:=python3
-  MDEPENDS:=python3-django
+  #MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-statici18n/Makefile
+++ b/lang/python/django-statici18n/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-statici18n
 PKG_VERSION:=1.8.2
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=ba9eeb3c4517027922645999359f8335fbb9fea04c457123cfbd6b4a36cbeda4
@@ -47,10 +47,12 @@ endef
 define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
-	+PACKAGE_python3-$(PKG_NAME):python3 \
-	python3-django
+	+PACKAGE_python3-$(PKG_NAME):python3
+  # FIXME: restore these when django1 goes away; for now, this avoids
+  #        some circular deps, which require a bit more work to fix
+  #	python3-django
   VARIANT:=python3
-  MDEPENDS:=python3-django
+  #MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django-webpack-loader/Makefile
+++ b/lang/python/django-webpack-loader/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-webpack-loader
 PKG_VERSION:=0.6.0
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=60bab6b9a037a5346fad12d2a70a6bc046afb33154cf75ed640b93d3ebd5f520
@@ -45,10 +45,12 @@ endef
 define Package/python3-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
   DEPENDS:= \
-	+PACKAGE_python3-$(PKG_NAME):python3 \
-	python3-django
+	+PACKAGE_python3-$(PKG_NAME):python3
+  # FIXME: restore these when django1 goes away; for now, this avoids
+  #        some circular deps, which require a bit more work to fix
+  #	python3-django
   VARIANT:=python3
-  MDEPENDS:=python3-django
+  #MDEPENDS:=python3-django
 endef
 
 define Package/python3-$(PKG_NAME)/description

--- a/lang/python/django1/Makefile
+++ b/lang/python/django1/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django1
-PKG_VERSION:=1.11.26
+PKG_VERSION:=1.11.27
 PKG_RELEASE:=1
 
 PYPI_NAME:=Django
-PKG_HASH:=861db7f82436ab43e1411832ed8dca81fc5fc0f7c2039c7e07a080a63092fb44
+PKG_HASH:=20111383869ad1b11400c94b0c19d4ab12975316cd058eabd17452e0546169b8
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -22,6 +22,7 @@ PKG_CPE_ID:=cpe:/a:djangoproject:django
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python-package.mk
+include ../python3-package.mk
 
 define Package/django1/Default
   SUBMENU:=Python
@@ -29,7 +30,6 @@ define Package/django1/Default
   CATEGORY:=Languages
   TITLE:=The web framework for perfectionists with deadlines.
   URL:=https://www.djangoproject.com/
-  MENU:=1
 endef
 
 define Package/python-django1
@@ -38,12 +38,26 @@ $(call Package/django1/Default)
 	+PACKAGE_python-django1:python \
 	+PACKAGE_python-django1:python-pytz
   VARIANT:=python
-  CONFLICTS:=python3-django
+  MENU:=1
+  CONFLICTS:=python3-django python3-django1
+endef
+
+define Package/python3-django1
+$(call Package/django1/Default)
+  DEPENDS:= \
+	+PACKAGE_python3-django1:python3 \
+	+PACKAGE_python3-django1:python3-pytz
+  VARIANT:=python3
 endef
 
 define Package/python-django1/description
     The web framework for perfectionists with deadlines (LTS 1.11 series).
-    Python2 only.
+endef
+
+define Package/python3-django1/description
+$(call Package/python-django1/description)
+.
+Variant for Python3.
 endef
 
 $(eval $(call PyPackage,python-django1))
@@ -53,3 +67,7 @@ define Package/python-django1-src +=
 endef
 $(eval $(call BuildPackage,python-django1))
 $(eval $(call BuildPackage,python-django1-src))
+
+$(eval $(call Py3Package,python3-django1))
+$(eval $(call BuildPackage,python3-django1))
+$(eval $(call BuildPackage,python3-django1-src))


### PR DESCRIPTION
Maintainer: me, @cotequeiroz 
Compile tested: x86 https://github.com/openwrt/openwrt/commit/0d28e5d6440d2a37841a207f943e6e5a23172883
Run tested: x86 https://github.com/openwrt/openwrt/commit/0d28e5d6440d2a37841a207f943e6e5a23172883

--------------------------------------------------------------------------

This change bumps to version django1 1.11.27 and introduces a Py3 variant.
This complicates things a bit, as it is a bit tricky to make all Django
packages depend on either `django` or `django1` without having some
circular dependency.

It also means that `python-django` conflicts with `python3-django1` and
`python3-django` and all 3 conflict with each other.
That means, each package will need to select it's own version of Django or
Django1 (which should be happening now).

This is an intermediate step into removing the Py2 variants, and also
upgrading Seafile until then.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>