### PR TITLE
nginx-util: fix PROVIDES variable and failure with ipv6 disabled

### DIFF
--- a/net/nginx-util/Makefile
+++ b/net/nginx-util/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx-util
 PKG_VERSION:=1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -13,13 +13,14 @@ define Package/nginx-util
   SUBMENU:=Web Servers/Proxies
   TITLE:=Builder of LAN listen directives for Nginx
   DEPENDS:=+libstdcpp +libubus +libubox +libpthread
-  PROVIDES:=nginx-util
 endef
 
 define Package/nginx-ssl-util/default
   $(Package/nginx-util)
   TITLE+= and manager of its SSL certificates
-  DEPENDS+=+libopenssl
+  DEPENDS+= +libopenssl
+  CONFLICTS:=nginx-util
+  PROVIDES:=nginx-ssl-util
 endef
 
 define Package/nginx-ssl-util-nopcre
@@ -30,7 +31,7 @@ endef
 define Package/nginx-ssl-util
   $(Package/nginx-ssl-util/default)
   TITLE+= (using PCRE)
-  DEPENDS+=+libpcre
+  DEPENDS+= +libpcre
 endef
 
 define Package/nginx-util/description

--- a/net/nginx-util/src/ubus-cxx.hpp
+++ b/net/nginx-util/src/ubus-cxx.hpp
@@ -31,7 +31,7 @@ extern "C" { //TODO(pst): remove when in upstream
 // std::cout<<std::endl;
 
 // // example for exploring:
-// ubus::strings keys{"ipv4-address", "", "*"};
+// ubus::strings keys{"ipv4-address", "", ""};
 // for (auto x : ubus::call("network.interface.lan", "status").filter(keys)) {
 //     std::cout<<blobmsg_name(x)<<": ";
 //     switch (blob_id(x)) {
@@ -173,8 +173,7 @@ private:
 
 public:
 
-
-    explicit iterator(const blob_attr * msg, const strings & filter)
+    explicit iterator(const blob_attr * msg, const strings & filter={""})
     : keys{filter}, n{keys.size()-1}, pos{msg}, cur{this}
     {
         if (pos!=nullptr) {


### PR DESCRIPTION
Maintainer: me
Compile tested: MIPS 74K, Asus RT-N16, master snapshot
Run tested: MIPS 74K, Asus RT-N16, master snapshot, run nginx-util [init_lan|get_env]

Description:
nginx-ssl-util and nginx-ssl-util-nopcre are replacements for each other,
but cannot replace nginx-util (instead conflict with it).

The hard coded [::1] could lead to a nginx error if build without IPv6 (cf. #6905).
So, get the loopback addresses dynamically.