### PR TITLE
zerotier: add /etc/config/zerotier as configuration file

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
 PKG_VERSION:=1.2.12
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=GPL-3.0
 
@@ -55,6 +55,10 @@ endef
 # Make binary smaller
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections
+
+define Package/zerotier/conffiles
+/etc/config/zerotier
+endef
 
 define Package/zerotier/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Maintainer: @mwarning
Compile tested: Turris Omnia, mvebu, OpenWrt 18.06.
Run tested: N/A

Description:

When zerotier is updated, it overwrites content of the file `/etc/config/zerotier` with default settings.
Bug report on Turris forum: https://forum.turris.cz/t/zerotier-config-overwritten-after-upgrade/12100

`/etc/config/zerotier` is already configuration file in OpenWrt 19.07 and OpenWrt master.