### PR TITLE
libtirpc: fix compilation with newer musl

### DIFF
--- a/libs/libtirpc/Makefile
+++ b/libs/libtirpc/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtirpc
 PKG_VERSION:=1.2.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=@SF/libtirpc
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -10,10 +10,10 @@ PKG_HASH:=f3b6350c7e9c3cd9c58fc7a5e5f8e6be469cc571bb5eb31eb9790b3e675186ca
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=COPYING
 
-PKG_FIXUP:=autoreconf
-PKG_REMOVE_FILES:=autogen.sh aclocal.m4
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk

--- a/libs/libtirpc/patches/010-xdr_float-do-not-include-bits-endian.h.patch
+++ b/libs/libtirpc/patches/010-xdr_float-do-not-include-bits-endian.h.patch
@@ -1,0 +1,31 @@
+From d04f4d6f0e682f16b0ce96839ab4eadade591eb1 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 21 Jan 2020 11:51:16 -0500
+Subject: [PATCH] xdr_float: do not include bits/endian.h
+
+bits/endian.h is an internal header. endian.h should be included.
+
+Fixes compilation with recent musl.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+Signed-off-by: Steve Dickson <steved@redhat.com>
+---
+ src/xdr_float.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/xdr_float.c b/src/xdr_float.c
+index 26bc865..349d48f 100644
+--- a/src/xdr_float.c
++++ b/src/xdr_float.c
+@@ -83,7 +83,7 @@ static struct sgl_limits {
+ };
+ #else
+ 
+-#include <bits/endian.h>
++#include <endian.h>
+ #define IEEEFP
+ 
+ #endif /* vax */
+-- 
+2.20.1
+


### PR DESCRIPTION
Backported upstream patch.

Added PKG_BUILD_PARALLEL for faster compilation.

Added PKG_LICENSE_FILES.

Cleaned up Makefile slightly,.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Andy2244 
Compile tested: malta
