### PR TITLE
libmbim: remove PKG_FIXUP to fix compilation if autoconf-archive is not installed on the build host

### DIFF
--- a/libs/libmbim/Makefile
+++ b/libs/libmbim/Makefile
@@ -20,8 +20,6 @@ PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
-PKG_FIXUP:=autoreconf
-
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 


### PR DESCRIPTION
Maintainer: @nickberry17
Compile tested: x86_64,  APU3, OpenWrt latest master
Run tested: x86_64,  APU3, OpenWrt latest master

Test:
Staring modemmanager

> Thu Jan 23 11:00:55 2020 daemon.info [16305]: <info>  ModemManager (version 1.12.4) starting in system bus...
> Thu Jan 23 11:00:56 2020 user.notice ModemManager: hotplug: checking if ModemManager is available...

Description:

As discussed in https://github.com/openwrt/packages/pull/11065#issuecomment-576595852, the compilation breaks, if I do not have installed **autoconf-archive** on my debian 10 build host. @aleksander0m explains that a re autoconf is not necessary if we do not need a new configure script. If I remove the line PKG_FIXUP=autoreconf from the OpenWrt makefile, then the compilation works.

The other option would be to install autoconf-archive on my debian 10 build host. But I think the compilation should have less host build dependency as possible. I think the way removing and have less build host dependency is the way to go.

