### PR TITLE
python-maxminddb: update to version 1.5.2

### DIFF
--- a/lang/python/python3-maxminddb/Makefile
+++ b/lang/python/python3-maxminddb/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 CZ.NIC z.s.p.o. (http://www.nic.cz/)
+# Copyright (C) 2019-2020 CZ.NIC z.s.p.o. (http://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,11 +9,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=maxminddb
-PKG_VERSION:=1.5.1
+PKG_VERSION:=1.5.2
 PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=449a1713d37320d777d0db286286ab22890f0a176492ecf3ad8d9319108f2f79
+PKG_HASH:=d0ce131d901eb11669996b49a59f410efd3da2c6dbe2c0094fe2fef8d85b6336
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Maintiner: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run testd: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates maxminddb to version 1.5.2

Tested with 
```
import maxminddb
reader = maxminddb.open_database('GeoLite2-Country.mmdb')

>>> import maxminddb
>>> reader = maxminddb.open_database('GeoLite2-Country.mmdb')
>>> reader.get('1.1.1.1')
{'continent': {'code': 'OC', 'geoname_id': 6255151, 'names': {'de': 'Ozeanien', 'en': 'Oceania', 'es': 'Ocean�ía', 'fr': 'Oc�é}>>> 
```
