### PR TITLE
redis: update to version 5.0.7

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=5.0.6
+PKG_VERSION:=5.0.7
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=6624841267e142c5d5d5be292d705f8fb6070677687c5aad1645421a936d22b3
+PKG_HASH:=61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
Redis update to version 5.0.7. [Changelog](https://raw.githubusercontent.com/antirez/redis/5.0/00-RELEASENOTES)  
Upgrade urgency level HIGH

   

