### PR TITLE
python-more-itertools: update to version 8.1.0

### DIFF
--- a/lang/python/python-more-itertools/Makefile
+++ b/lang/python/python-more-itertools/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+# Copyright (C) 2019-2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-more-itertools
-PKG_VERSION:=7.2.0
+PKG_VERSION:=8.1.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=more-itertools
-PKG_HASH:=409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832
+PKG_HASH:=c468adec578380b6281a114cb8a5db34eb1116277da92d7c46f904f0b52d3288
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt maser

Description:
This PR updates more itertools to version 8.1.0  [Changelog](https://github.com/erikrose/more-itertools/blob/ba499fc5f38c7441271c3f147cfd9abbc587556d/docs/versions.rst)
