### PR TITLE
freeradius3: Update to 3.0.20

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2016 OpenWrt.org
+# Copyright (C) 2008-2020 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
-PKG_VERSION:=release_3_0_19
-PKG_RELEASE:=2
+PKG_VERSION:=release_3_0_20
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive
-PKG_HASH:=34c50ac47a683b13eae1a02f2d0263c0bd51a83f01b99c02c5fe25df07a1ee77
+PKG_HASH:=8177fe550af6685a040884dbe3df28431bdc5a8d3a48a9f4f88bdb49f2d0e90c
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0

--- a/net/freeradius3/patches/002-disable-session-cache-CVE-2017-9148.patch
+++ b/net/freeradius3/patches/002-disable-session-cache-CVE-2017-9148.patch
@@ -3,22 +3,13 @@ Description: disable session caching in the server (as opposed to in the
  https://security-tracker.debian.org/tracker/CVE-2017-9148
 Author: Michael Stapelberg <stapelberg@debian.org>
 Forwarded: not-needed
-Last-Update: 2017-05-30
+Last-Update: 2020-01-24
 
 ---
 
 --- a/src/main/tls.c
 +++ b/src/main/tls.c
-@@ -594,7 +594,7 @@ tls_session_t *tls_new_session(TALLOC_CT
- 	 *
- 	 *	FIXME: Also do it every N sessions?
- 	 */
--	if (conf->session_cache_enable &&
-+	if (/*conf->session_cache_enable*/0 &&
- 	    ((conf->session_last_flushed + ((int)conf->session_timeout * 1800)) <= request->timestamp)){
- 		RDEBUG2("Flushing SSL sessions (of #%ld)", SSL_CTX_sess_number(conf->ctx));
- 
-@@ -689,7 +689,7 @@ tls_session_t *tls_new_session(TALLOC_CT
+@@ -675,7 +675,7 @@ tls_session_t *tls_new_session(TALLOC_CTX *ctx, fr_tls_server_conf_t *conf, REQU
  		state->mtu = vp->vp_integer;
  	}
  
@@ -27,7 +18,7 @@ Last-Update: 2017-05-30
  
  	return state;
  }
-@@ -3277,7 +3277,7 @@ post_ca:
+@@ -3292,7 +3292,7 @@ post_ca:
  	/*
  	 *	Callbacks, etc. for session resumption.
  	 */
@@ -36,7 +27,7 @@ Last-Update: 2017-05-30
  		/*
  		 *	Cache sessions on disk if requested.
  		 */
-@@ -3347,7 +3347,7 @@ post_ca:
+@@ -3362,7 +3362,7 @@ post_ca:
  	/*
  	 *	Setup session caching
  	 */
@@ -45,3 +36,12 @@ Last-Update: 2017-05-30
  		/*
  		 *	Create a unique context Id per EAP-TLS configuration.
  		 */
+@@ -3531,7 +3531,7 @@ fr_tls_server_conf_t *tls_server_conf_parse(CONF_SECTION *cs)
+ 		goto error;
+ 	}
+ 
+-	if (conf->session_cache_enable) {
++	if (/*conf->session_cache_enable*/0) {
+ 		CONF_SECTION	*subcs;
+ 		CONF_ITEM	*ci;
+ 


### PR DESCRIPTION
Maintainer: no maintainer at this time
Compile tested: ARM, Linksys EA3500, master
Run tested: ARM, Linksys EA3500, master

Description:
freeradius3: Update to 3.0.20

Latest stable release, contains security fixes for EAP-PWD (side-channel leak), logrotate settings (CVE-2019-10143) and a DoS issue due to multithreaded BN_CTX access (CVE-2019-17185).

Also refreshed patches/002-disable-session-cache-CVE-2017-9148.patch due to the following changes/commits in freeradius:
https://github.com/FreeRADIUS/freeradius-server/commit/bf1a1eda2387745bbe538998f3d2e6514f981bfd
https://github.com/FreeRADIUS/freeradius-server/commit/a3c46544b38ab46218c385d0ee197538fad5b3da