### PR TITLE
libgpiod: add package for the Python binding (fixes #11096)

### DIFF
--- a/libs/libgpiod/Makefile
+++ b/libs/libgpiod/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgpiod
 PKG_VERSION:=1.4.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/libs/libgpiod/
@@ -24,9 +24,18 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include ../../lang/python/python3-package.mk
 
 ifneq ($(CONFIG_PACKAGE_gpiod-tools),)
 CONFIGURE_ARGS += --enable-tools
+endif
+
+ifneq ($(CONFIG_PACKAGE_python3-gpiod),)
+CONFIGURE_ARGS += --enable-bindings-python
+CONFIGURE_VARS += \
+	PYTHON="$(STAGING_DIR_HOSTPKG)/bin/$(PYTHON3)" \
+	PYTHON_CPPFLAGS="$(shell $(STAGING_DIR)/host/bin/$(PYTHON3)-config --includes)" \
+	PYTHON_LIBS="$(shell $(STAGING_DIR)/host/bin/$(PYTHON3)-config --libs)"
 endif
 
 define Package/libgpiod
@@ -54,6 +63,19 @@ define Package/gpiod-tools/description
   (gpiod stands for GPIO device).
 endef
 
+define Package/python3-gpiod
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=Python bindings for libgpiod
+  URL:=https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
+  DEPENDS:=+python3-light +libgpiod
+endef
+
+define Package/python3-gpiod/description
+  This package contains the Python bindings for libgpiod.
+endef
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/gpiod.h $(1)/usr/include/
@@ -75,5 +97,11 @@ define Package/gpiod-tools/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
 endef
 
+define Package/python3-gpiod/install
+	$(INSTALL_DIR) $(1)/$(PYTHON3_PKG_DIR)
+	$(CP) $(PKG_INSTALL_DIR)/$(PYTHON3_PKG_DIR)/gpiod.so $(1)/$(PYTHON3_PKG_DIR)
+endef
+
 $(eval $(call BuildPackage,libgpiod))
 $(eval $(call BuildPackage,gpiod-tools))
+$(eval $(call BuildPackage,python3-gpiod))


### PR DESCRIPTION
Maintainer: me
Compile tested: mxs
Run tested: mxs/duckbill

Description:

This add a package which contains the python bindings for libgpiod.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
