### PR TITLE
syslog-ng: listen not globally but just locally

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.25.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -27,7 +27,7 @@ source src {
 };
 
 source net {
-	udp(ip(0.0.0.0) port(514));
+	network(ip("::1") port(514) transport(udp) ip-protocol(6));
 };
 
 source s_network {


### PR DESCRIPTION
Beside that, listen not only on IPv4 but also on IPv6 = Dual Stack.