### PR TITLE
[19.07] glib2: fix mips16 build, add size reducing static link, fpic CFLAGS

### DIFF
--- a/libs/glib2/Makefile
+++ b/libs/glib2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=glib2
 PKG_VERSION:=2.58.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=glib-$(PKG_VERSION).tar.xz
 PKG_BUILD_DIR:=$(BUILD_DIR)/glib-$(PKG_VERSION)
@@ -18,10 +18,9 @@ PKG_HASH:=8f43c31767e88a25da72b52a40f3301fefc49a665b56dc10ee7cc9565cbe7481
 
 PKG_BUILD_PARALLEL:=1
 HOST_BUILD_PARALLEL:=1
-PKG_BUILD_DEPENDS:=glib2/host gettext
+PKG_BUILD_DEPENDS:=gettext
 HOST_BUILD_DEPENDS:=gettext-full/host libiconv/host libffi/host
 PKG_INSTALL:=1
-PKG_USE_MIPS16:=0
 
 PKG_CPE_ID:=cpe:/a:gnome:glib
 
@@ -46,7 +45,7 @@ define Package/glib2/description
   The GLib library of C routines
 endef
 
-TARGET_CFLAGS += -Wno-error=implicit-function-declaration
+TARGET_CFLAGS += $(FPIC) -ffunction-sections -fdata-sections -flto
 
 HOST_CONFIGURE_ARGS += \
 	--disable-libelf \
@@ -64,6 +63,7 @@ CONFIGURE_ARGS += \
 	--disable-fam \
 	--disable-gtk-doc-html \
 	--disable-man \
+	--disable-compile-warnings \
 	--with-libiconv=gnu \
 	--with-pcre=internal
 

--- a/libs/glib2/patches/003-valgrind.h-mips16-fix.patch
+++ b/libs/glib2/patches/003-valgrind.h-mips16-fix.patch
@@ -1,0 +1,11 @@
+--- a/glib/valgrind.h	2019-12-12 14:53:26.000200499 +0100
++++ b/glib/valgrind.h	2019-12-12 14:49:45.056163300 +0100
+@@ -157,7 +157,7 @@
+ #  define PLAT_s390x_linux 1
+ #elif defined(__linux__) && defined(__mips__) && (__mips==64)
+ #  define PLAT_mips64_linux 1
+-#elif defined(__linux__) && defined(__mips__) && (__mips!=64)
++#elif defined(__linux__) && defined(__mips__) && (__mips!=64) && !defined(__mips16)
+ #  define PLAT_mips32_linux 1
+ #elif defined(__sun) && defined(__i386__)
+ #  define PLAT_x86_solaris 1


### PR DESCRIPTION
Maintainer: @tripolar cc: @neheb
Compile tested: mips/arm (19.07-master)
Run tested: mips/lantiq (19.07-master)

Description:
* fix mips16 build, add size reducing static link, fpic CFLAGS
* Disable Werror
* remove dependency on own host build

PS: Run-tested static glib2 via ksmbd, shared via midnight commander.