### PR TITLE
[19.07] wsdd2: update for renamed smbd->ksmbd

### DIFF
--- a/net/wsdd2/Makefile
+++ b/net/wsdd2/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wsdd2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Andy2244/wsdd2.git

--- a/net/wsdd2/files/wsdd2.init
+++ b/net/wsdd2/files/wsdd2.init
@@ -9,12 +9,12 @@ NB_PARM=""
 WG_PARM=""
 BI_PARM=""
 
-. /lib/functions/network.sh
-
 start_service() {
 
-	if [ -e /etc/smbd/smb.conf ] && [ -e /etc/init.d/smbd ] && /etc/init.d/smbd running; then
-		SMB_CONF="/etc/smbd/smb.conf"
+	. /lib/functions/network.sh
+
+	if [ -e /etc/ksmbd/smb.conf ] && [ -e /etc/init.d/ksmbd ] && /etc/init.d/ksmbd running; then
+		SMB_CONF="/etc/ksmbd/smb.conf"
 	fi
 
 	if [ -e /etc/samba/smb.conf ]; then
@@ -26,7 +26,7 @@ start_service() {
 	fi
 	
 	if [ -z "$SMB_CONF" ]; then
-		logger -p daemon.error -t 'wsdd2' "samba36/4 or smbd is not running, can't start wsdd2!"
+		logger -p daemon.error -t 'wsdd2' "samba36/4 or ksmbd is not running, can't start wsdd2!"
 		exit 1
 	fi
 	


### PR DESCRIPTION
Maintainer: me
Compile tested: mips/arm (19.07-master)
Run tested: mips/lantiq (19.07-master)

Description:
* update for renamed smbd->ksmbd
* fix build warning for global network.sh include

depends-on: #11143
