### PR TITLE
libredblack: pass CFLAGS properly

### DIFF
--- a/libs/libredblack/Makefile
+++ b/libs/libredblack/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libredblack
 PKG_VERSION:=1.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/libredblack
@@ -39,6 +39,7 @@ endef
 
 CONFIGURE_ARGS += --without-rbgen
 CONFIGURE_VARS += lt_cv_prog_cc_pic=$(FPIC)
+MAKE_FLAGS += CFLAGS="$(TARGET_CFLAGS)"
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
Maintainer: @mislavn
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master and 19.07
Run tested: later

Description:

With enabled ASLR PIE, this package does not build on **arm_cortex-a9+vfpv3_musl_eabi** and **aarch64_cortex-a53_musl**. Tested with master build and as well with OpenWrt 19.07.

Faillogs:

1) arm_cortex-a9+vfpv3_musl_eabi
```
make[4]: Entering directory '/mypath/build/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/libredblack-1.3'
/bin/bash ./libtool  --tag=CC   --mode=link ccache_cc  -Wall  -L/mypath/build/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/lib -L/mypath/build/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/lib -L/mypath/build/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.5.0_musl_eabi/usr/lib -L/mypath/build/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.5.0_musl_eabi/lib -fpic -specs=/mypath/build/include/hardened-ld-pie.specs -znow -zrelro  -o example example.o libredblack.la 
OpenWrt-libtool: link: ccache_cc -Wall -fpic -specs=/mypath/build/include/hardened-ld-pie.specs -znow -zrelro -o .libs/example example.o  -L/mypath/build/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/usr/lib -L/mypath/build/staging_dir/target-arm_cortex-a9+vfpv3_musl_eabi/lib -L/mypath/build/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.5.0_musl_eabi/usr/lib -L/mypath/build/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.5.0_musl_eabi/lib ./.libs/libredblack.so
/mypath/build/staging_dir/toolchain-arm_cortex-a9+vfpv3_gcc-7.5.0_musl_eabi/lib/gcc/arm-openwrt-linux-muslgnueabi/7.5.0/../../../../arm-openwrt-linux-muslgnueabi/bin/ld: example.o: relocation R_ARM_MOVW_ABS_NC against `stderr' can not be used when making a shared object; recompile with -fPIC
example.o: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
Makefile:510: recipe for target 'example' failed
make[4]: *** [example] Error 1
```

2) aarch64_cortex-a53_musl
```
/bin/bash ./libtool  --tag=CC   --mode=link ccache_cc  -Wall  -L/mypath/build/staging_dir/target-aarch64_cortex-a53_musl/usr/lib -L/mypath/build/staging_dir/target-aarch64_cortex-a53_musl/lib -L/mypath/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.5.0_musl/usr/lib -L/mypath/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.5.0_musl/lib -fpic -specs=/mypath/build/include/hardened-ld-pie.specs -znow -zrelro  -o example example.o libredblack.la 
OpenWrt-libtool: link: ccache_cc -Wall -fpic -specs=/mypath/build/include/hardened-ld-pie.specs -znow -zrelro -o .libs/example example.o  -L/mypath/build/staging_dir/target-aarch64_cortex-a53_musl/usr/lib -L/mypath/build/staging_dir/target-aarch64_cortex-a53_musl/lib -L/mypath/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.5.0_musl/usr/lib -L/mypath/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.5.0_musl/lib ./.libs/libredblack.so
/mypath/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.5.0_musl/lib/gcc/aarch64-openwrt-linux-musl/7.5.0/../../../../aarch64-openwrt-linux-musl/bin/ld: example.o: relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `stderr' which may bind externally can not be used when making a shared object; recompile with -fPIC
/mypath/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.5.0_musl/lib/gcc/aarch64-openwrt-linux-musl/7.5.0/../../../../aarch64-openwrt-linux-musl/bin/ld: example.o(.text+0x2c): unresolvable R_AARCH64_ADR_PREL_PG_HI21 relocation against symbol `stderr'
/mypath/build/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.5.0_musl/lib/gcc/aarch64-openwrt-linux-musl/7.5.0/../../../../aarch64-openwrt-linux-musl/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
Makefile:510: recipe for target 'example' failed
make[4]: *** [example] Error 1
```

I found that by adding `MAKE_FLAGS += CFLAGS="$(TARGET_CFLAGS)"` suggested in #9852 (ping @neheb) it compiles and that same approach is being used in `madplay` and `crconf` Makefiles.