### PR TITLE
davix: a new package

### DIFF
--- a/net/davix/Makefile
+++ b/net/davix/Makefile
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2007-2020 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=davix
+PKG_VERSION:=0.7.5
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/cern-fts/davix/releases/download/R_0_7_5/
+PKG_HASH:=d920ca976846875d83af4dc50c99280bb3741fcf8351d5733453e70fa5fe6fc8
+
+PKG_BUILD_PARALLEL:=1
+
+PKG_MAINTAINER:=Yury Martynov <email@linxon.ru>
+PKG_LICENSE:=LGPL-2.1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/davix
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libxml2 +libuuid +libopenssl
+  TITLE:=High-performance file management over WebDAV/HTTP
+  URL:=https://dmc.web.cern.ch/projects/davix
+endef
+
+TARGET_LDFLAGS+= \
+	-static-libstdc++
+
+CMAKE_OPTIONS += \
+	-DDAVIX_TESTS=OFF \
+	-DBENCH_TESTS=OFF \
+	-DENABLE_TOOLS=ON \
+	-DENABLE_TCP_NODELAY=ON
+
+CMAKE_OPTIONS += $(if $(CONFIG_IPV6),-DENABLE_IPV6=ON,-DENABLE_IPV6=OFF)
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdavix*.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/davix.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/davix/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$(PKG_NAME)-* $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdavix*.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,davix))


### PR DESCRIPTION
Maintainer: Yury Martynov / @linxon (email@linxon.ru)
Compile tested: 18.06 / 19.07  / [last commit](https://github.com/openwrt/openwrt/commit/1e3bfbafd37ccb32d0ed6618f4886e1dec6643d2)
Run tested: Broadcom BCM63xx

Description:
[Davix](https://github.com/cern-fts/davix) aims to make the task of managing files over HTTP-based protocols simple. It is being developed by IT-ST at CERN, and while the project's purpose is its use on the CERN grid, the functionality offered is generic.

Homepage: https://davix.web.cern.ch https://github.com/cern-fts/davix 