### PR TITLE
nyx: Terminal status monitor for Tor

### DIFF
--- a/admin/nyx/Makefile
+++ b/admin/nyx/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nyx
+PKG_VERSION:=2.1.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=nyx
+PKG_HASH:=88521488d1c9052e457b9e66498a4acfaaa3adf3adc5a199892632f129a5390b
+
+PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
+PKG_LICENSE:=GPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE
+
+include ../../lang/python/pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/python/python3-package.mk
+
+define Package/nyx
+  SECTION:=admin
+  CATEGORY:=Administration
+  URL:=https://nyx.torproject.org/
+  TITLE:=Terminal status monitor for Tor
+  DEPENDS:=+python3 +python3-stem
+  VARIANT:=python3
+endef
+
+define Package/nyx/description
+  Nyx is a command-line monitor for Tor. With this you can get detailed real-time
+  information about your relay such as bandwidth usage, connections, logs, and
+  much more.
+endef
+
+$(eval $(call Py3Package,nyx))
+$(eval $(call BuildPackage,nyx))
+$(eval $(call BuildPackage,nyx-src))

--- a/lang/python/python-stem/Makefile
+++ b/lang/python/python-stem/Makefile
@@ -1,0 +1,37 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-stem
+PKG_VERSION:=1.8.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=stem
+PKG_HASH:=a0b48ea6224e95f22aa34c0bc3415f0eb4667ddeae3dfb5e32a6920c185568c2
+
+PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
+PKG_LICENSE:=LGPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE
+
+PYTHON3_PKG_SETUP_ARGS:=
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-stem
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=A controller library for Tor
+  URL:=https://stem.torproject.org/
+  DEPENDS:=+python3
+  VARIANT:=python3
+endef
+
+define Package/python3-stem/description
+  Stem is a Python controller library for Tor. With it you can use Tor's control
+  protocol to script against the Tor process, or build things such as Nyx.
+endef
+
+$(eval $(call Py3Package,python3-stem))
+$(eval $(call BuildPackage,python3-stem))
+$(eval $(call BuildPackage,python3-stem-src))


### PR DESCRIPTION
Signed-off-by: 

Maintainer: Javier Marcet <javier@marcet.info>
Compile tested: x86-64
Run tested: x86-64

Description:

New package nyx: Terminal status monitor for Tor