### PR TITLE
netifyd: Updated to v2.99

### DIFF
--- a/net/netifyd/Makefile
+++ b/net/netifyd/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016-2019 eGloo, Incorporated
+# Copyright (C) 2016-2020 eGloo, Incorporated
 #
 # This is free software, licensed under the GNU General Public License v2.
 
@@ -16,10 +16,10 @@ PKG_INSTALL:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://gitlab.com/netify.ai/public/netify-agent.git
-PKG_SOURCE_DATE:=2019-12-07
-PKG_SOURCE_VERSION:=v2.98
-#PKG_SOURCE_VERSION:=a204805151bc5c35ad09e21913dac25deed13f95
-PKG_MIRROR_HASH:=d235df7f77380e188db75fb885491bf46b2a7a3454f7bf2c85269aeff8f92220
+PKG_SOURCE_DATE:=2020-01-28
+PKG_SOURCE_VERSION:=v2.99
+#PKG_SOURCE_VERSION:=39e4fa272d8a4c83391e1b7d34cd8e071caef317
+PKG_MIRROR_HASH:=86106fc526ffcb3631ee306504874491646e7b2baa273b8e7ea8c411f83ac99d
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/netifyd/README.md
+++ b/net/netifyd/README.md
@@ -1,69 +1,62 @@
-Netify Agent
-============
-Copyright ©2015-2019 eGloo Incorporated ([www.egloo.ca](https://www.egloo.ca))
+# Netify Agent
+Copyright ©2015-2020 eGloo Incorporated ([www.egloo.ca](https://www.egloo.ca))
 
-Network Intelligence - Simplified
----------------------------------
-
+## Network Intelligence - Simplified
 The [Netify Agent](https://www.netify.ai/) is a deep-packet inspection server.  The Agent is built on top of [nDPI](http://www.ntop.org/products/deep-packet-inspection/ndpi/) (formerly OpenDPI) to detect network protocols and applications.  Detections can be saved locally, served over a UNIX or TCP socket, and/or "pushed" (via HTTP POSTs) to a remote third-party server.  Flow metadata, network statistics, and detection classifications are stored using JSON encoding.
 
 Optionally, the Netify Agent can be coupled with a [Netify Cloud](https://www.netify.ai/) subscription for further cloud processing, historical storage, machine-learning analysis, event notifications, device detection/identification, along with the option (on supported platforms) to take an active role in policing/bandwidth-shaping specific network protocols and applications.
 
-Runtime Requirements
---------------------
+## Download Packages
+Supported platforms with installation instructions can be found [here](https://www.netify.ai/get-netify).
 
-Ensure that the nfnetlink and nf_conntrack_netlink kernel modules are loaded.
+Alternatively, binary packages are available for the following OS distributions (manual install):
+- [CentOS](http://download.netify.ai/netify/centos/)
+- [ClearOS](http://download.netify.ai/netify/clearos/)
+- [Debian](http://download.netify.ai/netify/debian/)
+- [FreeBSD](http://download.netify.ai/netify/freebsd/)
+- [NethServer](http://download.netify.ai/netify/nethserver/)
+- [OpenWrt/LEDE](https://downloads.openwrt.org/snapshots/packages/)
+- [pfSense](http://download.netify.ai/netify/pfsense/)
+- [Raspbian](https://software.opensuse.org//download.html?project=home%3Aegloo&package=netifyd)
+- [RHEL](http://download.netify.ai/netify/rhel/)
+- [Ubuntu](http://download.netify.ai/netify/ubuntu/)
 
-Build Requirements
-------------------
+### Runtime Requirements
+- [Linux] Ensure that the nfnetlink and nf_conntrack_netlink kernel modules are loaded if NAT detection is enabled.
 
-Netify requires the following third-party packages:
-- libcurl
-- libjson-c
-- libmnl
-- libnetfilter-conntrack
-- libpcap
-- zlib
-
-Optional:
-- libtcmalloc (gperftools)
-
-Download Source
----------------
-
+## Download Source
 When cloning the source tree, ensure you use `--recursive` to include all
 sub-modules.
 
-Download Packages
------------------
+### Build Requirements
+Netify requires the following third-party packages:
+- libcurl
+- libpcap
+- zlib
+- [Linux] libmnl
+- [Linux] libnetfilter-conntrack
 
-Currently you can download binary packages for the following OS distributions:
-- [ClearOS](https://www.clearos.com/products/purchase/clearos-marketplace-apps#cloud)
-- [CentOS](http://software.opensuse.org/download.html?project=home%3Aegloo&package=netifyd)
-- [Debian](http://software.opensuse.org/download.html?project=home%3Aegloo&package=netifyd)
-- [Fedora](http://software.opensuse.org/download.html?project=home%3Aegloo&package=netifyd)
-- [Ubuntu](http://software.opensuse.org/download.html?project=home%3Aegloo&package=netifyd)
+Optional:
+- google-perftools/gperftools/libtcmalloc (will use bundled version when not available)
 
-Developer Documentation
------------------------
-
-Further developer documentation can be found [here](https://www.netify.ai/developer/netify-agent).
-
-Configuring/Building From Source
---------------------------------
-
-Read the appropriate documentation in the doc directory, prefixed with: BUILD-*
+### Configuring/Building From Source
+Read the appropriate documentation in the doc directory, prefixed with: `BUILD-*`
 
 Generally the process is:
-```
-# ./autogen.sh
-# ./configure
-# make
+```sh
+./autogen.sh
+./configure
+make
 ```
 
-License
--------
-```
+## Online Documentation
+Further user and developer documentation can be found [here](https://www.netify.ai/resources).
+
+## License
+This software is licenced under the [GPLv3](https://www.gnu.org/licenses/gpl-3.0.txt):
+>>>
+Copyright (C) 2015-2020 eGloo Incorporated
+
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
@@ -73,5 +66,4 @@ This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
-```
-
+>>>


### PR DESCRIPTION
Maintainer: Darryl Sokoloski / @dsokoloski
Compile tested: arm_cortex-a15_neon-vfpv4, TP-Link Archer C2600, master
Run tested: TP-Link Archer C2600

Change log for v2.99:

[FIX] Fixed broken JSON parsing (include missing uuid_site).
[FIX] FreeBSD: Fixed 10x support.
[FIX] OPNsense: Fixed path to xmllint.

[IMP] Switched to libtcmalloc minimal.
[IMP] Added metadata extraction from SSDP queries/responses.
[IMP] Added automatic building of bundled gperftools when enabled.
[IMP] Removed bundled packages that are no longer needed.
[IMP] Always display JSON status even when stale.
[IMP] CentOS: Added support for CentOS 8.
[IMP] CentOS: Removed support for CentOS 6.
[IMP] OPNsense: Added support for OPNsense 19x.

Signed-off-by: Darryl Sokoloski <darryl@sokoloski.ca>
