### PR TITLE
pymysql: make python3-cryptography optional

### DIFF
--- a/lang/python/pymysql/Config.in
+++ b/lang/python/pymysql/Config.in
@@ -1,0 +1,11 @@
+menu "Configuration"
+	depends on PACKAGE_python3-pymysql
+
+config PYTHON3_PYMYSQL_SHA_PASSWORD_SUPPORT
+	bool "Enable support for SHA password authentication"
+	help
+	  To use “sha256_password” or “caching_sha2_password” for authentication
+	  this symbol needs to be enabled, to also install python3-cryptography.
+	default n
+
+endmenu

--- a/lang/python/pymysql/Makefile
+++ b/lang/python/pymysql/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pymysql
 PKG_VERSION:=0.9.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=PyMySQL
 PKG_HASH:=d8c059dcd81dedb85a9f034d5e22dcb4442c0b201908bede99e306d65ea7c8e7
@@ -17,6 +17,8 @@ PKG_HASH:=d8c059dcd81dedb85a9f034d5e22dcb4442c0b201908bede99e306d65ea7c8e7
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
+
+PKG_CONFIG_DEPENDS:=CONFIG_PYTHON3_PYMYSQL_SHA_PASSWORD_SUPPORT
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
@@ -28,8 +30,12 @@ define Package/python3-pymysql
   CATEGORY:=Languages
   TITLE:=Pure Python MySQL Client
   URL:=https://pymysql.readthedocs.io/
-  DEPENDS:=+python3 +python3-cryptography
+  DEPENDS:=+python3 +PYTHON3_PYMYSQL_SHA_PASSWORD_SUPPORT:python3-cryptography
   VARIANT:=python3
+endef
+
+define Package/python3-pymysql/config
+  source "$(SOURCE)/Config.in"
 endef
 
 define Package/python3-pymysql/description


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/1e3bfbafd37ccb32d0ed6618f4886e1dec6643d2
Run tested: x86 https://github.com/openwrt/openwrt/commit/1e3bfbafd37ccb32d0ed6618f4886e1dec6643d2

-------------------------------------------------------------------

According to the installation guide [1], the support for "sha256_password"
or "caching_sha2_password" for authentication is optional.

This change makes it optional for the OpenWrt package by providing a build
option to enable it.
By default it won't be enabled, and packages can choose to enable it.

[1] https://pymysql.readthedocs.io/en/latest/user/installation.html

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>