### PR TITLE
net: mstpd: update service hooks based on review

### DIFF
--- a/net/mstpd/Makefile
+++ b/net/mstpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mstpd
 PKG_VERSION:=0.0.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mstpd/mstpd/tar.gz/$(PKG_VERSION)?

--- a/net/mstpd/files/etc/config/mstpd
+++ b/net/mstpd/files/etc/config/mstpd
@@ -1,0 +1,21 @@
+# [1] For this option, refer also to mstpctl.
+# Also, mstpctl does the validation for this option.
+# These option types show up as set<option> commands in mstpctl.
+
+#config bridge 'switch0'
+#	option index		0	# all ports attached to this switch must reference this index
+#	option name		'switch0'	# name is currently just informative; not used in mstpd
+#	option enable		0	# this will add/remove the bridge to mstpd
+#	option treeprio		7	# STP bridge priority (0-15) [1]
+#	option maxage		6	# Bridge max age (6-40) [1]
+#	option fdelay		4	# Bridge Forward Delay (4-30) [1]
+#	option maxhops		6	# Bridge Max Hops (6-40) [1]
+#	option hello		1	# Bridge Hello Time (1-10) [1]
+#	option ageing		10	# Bridge Aging Time (10-1000000) [1]
+#	option forcevers	'rstp'	# Force STP protocol version ('stp', 'rstp', 'mstp'). Default is 'rstp' [1]
+#	option txholdcount	1	# Bridge Tx Hold Count (1-10) [1]
+
+#config bridge_port 'switch0_port0'
+#	option br_index		0	# must point to a valid bridge index; see 'index' option in bridge section
+#	option port_name	'some_port_name'	# name is currently just informative; not used in mstpd
+#	option bpduguard	1	# Bridge Port - Enable BPDU guard [1]

--- a/net/mstpd/files/etc/init.d/mstpd.init
+++ b/net/mstpd/files/etc/init.d/mstpd.init
@@ -90,7 +90,7 @@ start_service() {
 
 	# reload config on respawn
 	procd_open_trigger
-	procd_add_raw_trigger "instance.start" 2000 "/etc/init.d/mstpd" "reload"
+	procd_add_raw_trigger "instance.update" 2000 "/etc/init.d/mstpd" "reload"
 	procd_close_trigger
 
 	procd_close_instance
@@ -102,7 +102,6 @@ service_running() {
 
 reload_service() {
 	if ! running ; then
-		start
 		return
 	fi
 


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A
Run tested: N/A

--------------------------------------------------------------

Updated based on comments from @tofurky.
Link: https://github.com/openwrt/packages/pull/9347#discussion_r365567109

--------------------------------------------------------------
i've been playing with mstpd and am finding that "instance.start" never
triggers anything. looking at procd, it only appears to send a broadcast
via ubus (via `service_event()`).

the only instance.* (e.g. instance.start, instance.respawn, ...) that seems
to actually be a "trigger" (via `trigger_event()`) is instance.update.

the result is that, upon startup, the config in /etc/config/mstpd is never
applied.

as a workaround, i found that changing the instance.start to
instance.update, and then modifying reload_service like so:
```
	if ! running ; then
		return
	fi
```

seems to do the trick.

unrelated, i also found it a bit difficult to figure out what
/etc/config/mstpd should look like based solely on the init script. do you
think a sample config could be added to the package?

i could open an issue if necessary but figured this would be enough.
thanks!

--------------------------------------------------------------

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>