### PR TITLE
ddns-scritps: Added tunnelbroker.net

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.8
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=

--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -164,6 +164,8 @@
 
 "thatip.com"		"http://update.dnsmax.com/update/?username=[USERNAME]&password=[PASSWORD]&resellerid=2&clientname=openwrt&clientversion=8.09&protocolversion=2.0&updatehostname=[DOMAIN]&ip=[IP]"
 
+"tunnelbroker.net"      "http://[USERNAME]:[PASSWORD]@ipv4.tunnelbroker.net/nic/update?hostname=[DOMAIN]&myip=[IP]"     "good|nochg"
+
 "twodns.de"		"http://[USERNAME]:[PASSWORD]@update.twodns.de/update?hostname=[DOMAIN]&ip=[IP]"
 
 "udmedia.de"		"http://[USERNAME]:[PASSWORD]@www.udmedia.de/nic/update?myip=[IP]"


### PR DESCRIPTION
Running and live on:
DISTRIB_RELEASE='18.06.5'
DISTRIB_REVISION='r7897-9d401013fc'
DISTRIB_TARGET='ipq806x/generic'
DISTRIB_ARCH='arm_cortex-a15_neon-vfpv4'

Description:
Hurricane Electric provides a free IPv6inIPv4 tunnel through tunnelbroker.net. The update URL, provided by Hurricane Electric, is https://[USERNAME]:[PASSWORD]@ipv4.tunnelbroker.net/nic/update?hostname=[DOMAIN]&myip=[IP] and it gets the response good or nochg

Signed-off-by: Euler Alves <23159753+oilervoss@users.noreply.github.com>

