### PR TITLE
[19.07] hcxtools: update to latest versions

### DIFF
--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hcxdumptool
-PKG_VERSION:=6.0.0
+PKG_VERSION:=6.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxdumptool/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=97e0372c5a39d8d09b486e294406ca26a1bb05870cfa2ee37f555095aefec91a
+PKG_HASH:=32bc07b692f5682792dcfd1d5dcae749e5fed4a65a2a05d815ed59adc9b64b02
 
 PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 PKG_LICENSE:=MIT

--- a/net/hcxdumptool/Makefile
+++ b/net/hcxdumptool/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hcxdumptool
-PKG_VERSION:=5.2.2
+PKG_VERSION:=6.0.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxdumptool/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=b091171fe5e6f926ace3997219dfc5a84ce6d1f2080d3320d456f88282019057
+PKG_HASH:=97e0372c5a39d8d09b486e294406ca26a1bb05870cfa2ee37f555095aefec91a
 
 PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 PKG_LICENSE:=MIT

--- a/net/hcxtools/Makefile
+++ b/net/hcxtools/Makefile
@@ -66,5 +66,4 @@ define Package/hcxtools-custom/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancow2hcxpmk	$(1)/sbin/
 endef
 
-$(eval $(call BuildPackage,hcxtools-custom))
 $(eval $(call BuildPackage,hcxtools))

--- a/net/hcxtools/Makefile
+++ b/net/hcxtools/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hcxtools
-PKG_VERSION:=5.2.2
+PKG_VERSION:=5.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerbea/hcxtools/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=a2dd9559e1cc541f07f7a4c2451c295896355a94cfc970dc5cdceb40e605ee7e
+PKG_HASH:=bc3465eb3b97c4db849af41ae3fa7c812d4683eb9e493f090ac82e922ba8a36d
 
 PKG_MAINTAINER:=Andreas Nilsen <adde88@gmail.com>
 PKG_LICENSE:=MIT

--- a/net/hcxtools/Makefile
+++ b/net/hcxtools/Makefile
@@ -41,26 +41,30 @@ define Build/Compile
 		CFLAGS="$(TARGET_CFLAGS)"
 endef
 
-define Package/hcxtools/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanwkp2hcx	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanpmk2hcx	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcxmnc	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcx2essid	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanjohn2hcx	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpcaptool	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcx2john	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpsktool	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancow2hcxpmk	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcxinfo	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhash2cap	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhashcattool	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhashhcx	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhc2hcx	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxwltool	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/whoismac	$(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/usr/sbin/
+define Package/hcxtools-custom/install
+	$(INSTALL_DIR) $(1)/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpcapngtool	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhashtool	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpsktool	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxwltool	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancap2wpasec	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/whoismac	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpmkidtool	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcx2john	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxpcaptool	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhashcattool	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxmactool	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxessidtool	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/hcxhash2cap	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhc2hcx	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanwkp2hcx	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcxinfo	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcx2ssid	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanhcxcat	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanpmk2hcx	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlanjohn2hcx	$(1)/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/wlancow2hcxpmk	$(1)/sbin/
 endef
 
+$(eval $(call BuildPackage,hcxtools-custom))
 $(eval $(call BuildPackage,hcxtools))


### PR DESCRIPTION
Maintainer: @adde88  
Compile tested: ar71xx, WIFI PINEAPPLE NANO/TETRA, OpenWRT 19.07
Run tested: ar71xx, WIFI PINEAPPLE NANO/TETRA, OpenWRT 19.07. All tools have been tested, and works.


Description:
Update to latest versions.