### PR TITLE
python3-asgiref: add package to fix django

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
 PKG_VERSION:=3.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=Django
 PKG_HASH:=8c3575f81e11390893860d97e1e0154c47512f180ea55bd84ce8fa69ba8051ca
@@ -34,7 +34,7 @@ endef
 
 define Package/python3-django
 $(call Package/django/Default)
-  DEPENDS:= +python3 +python3-pytz +python3-sqlparse
+  DEPENDS:= +python3 +python3-pytz +python3-sqlparse +python3-asgiref
   VARIANT:=python3
 endef
 

--- a/lang/python/python3-asgiref/Makefile
+++ b/lang/python/python3-asgiref/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=asgiref
+PKG_VERSION:=3.2.3
+PKG_RELEASE:=1
+
+PYPI_NAME:=asgiref
+PKG_HASH:=7e06d934a7718bf3975acbf87780ba678957b87c7adc056f13b6215d610695a0
+
+PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-asgiref
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Standard for Python asynchronous web apps and servers.
+  URL:=https://asgi.readthedocs.io/en/latest/
+  DEPENDS:=+python3-light +python3-logging +python3-asyncio
+  VARIANT:=python3
+endef
+
+define Package/python3-asgiref/description
+  ASGI is a standard for Python asynchronous web apps and servers to communicate
+  with each other, and positioned as an asynchronous successor to WSGI.
+endef
+
+$(eval $(call Py3Package,python3-asgiref))
+$(eval $(call BuildPackage,python3-asgiref))
+$(eval $(call BuildPackage,python3-asgiref-src))


### PR DESCRIPTION
Maintainer: me / @commodo Alexandru Ardelean <ardeleanalex@gmail.com>
Compile tested: MIPS 74K, Asus RT-N16, master snapshot
Run tested: MIPS 74K, Asus RT-N16, master snapshot, run etesync with it

Description: Django 3 has this package as dependency.