### PR TITLE
afalg_engine: Update to 1.2.0-beta.1

### DIFF
--- a/libs/afalg_engine/Config.in
+++ b/libs/afalg_engine/Config.in
@@ -1,0 +1,43 @@
+if PACKAGE_libopenssl-afalg_sync
+    comment "Build Options"
+
+    config AFALG_DIGESTS
+	bool "Build support for digest acceleration"
+	help
+	    Digests are fast in software, and accessing AF_ALG adds latency, so
+	    you'll need a large request (16KB) just to match software speed.
+	    This increases memory usage, and has problems when process fork
+	    with open digest contexts (openssh will not work because of it).
+
+    config AFALG_FALLBACK
+	bool "Enable software fallback feature"
+	default y
+	help
+	    Use software to fulfill small requests.  Using AF_ALG adds latency,
+	    which makes it slow to perform small requests.  Enabling this
+	    option overcomes this problem, at the cost of increased memory
+	    and CPU usage.  This is a new, experimental feature; if you
+	    encounter any problem, this is the first option to disable.
+	    The fallback will fail if you enable this engine alongside
+	    devcrypto, so you'll not be able to install both at the same
+	    time if this option is enabled.
+
+    config AFALG_UPDATE_CTR_IV
+	bool "Don't rely on kernel to update CTR IV"
+	default y
+	help
+	    Don't count on the kernel driver to update the CTR-mode counter
+	    (IV).  At least one driver does not update the IV as a workaround
+	    for DMA issues.  With this option turned on, the engine will keep
+	    track of the counter, and the IV will be sent with every update.
+	    If fallback is enabled, then the counter needs to be updated by
+	    the engine anyway, and sent with the request everytime there's a
+	    switch from software to hardware, so this won't bring much gain in
+	    that case.
+
+    config AFALG_ZERO_COPY
+	bool "Use Zero-Copy Mode"
+	help
+	    Uses a Zero-Copy interface.  Even though it is supposed to improve
+	    performance, actual measurements indicate otherwise.
+endif

--- a/libs/afalg_engine/Makefile
+++ b/libs/afalg_engine/Makefile
@@ -7,17 +7,21 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=afalg_engine
-PKG_VERSION:=1.1.0
+PKG_VERSION:=1.2.0-beta.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/cotequeiroz/afalg_engine/archive/v$(PKG_VERSION)
-PKG_HASH:=0c0304558e9450752656522a8f9036130f4e745c4818f02f92cb8d6c99357ed6
+PKG_HASH:=6f0da98a3c12eaf50331ac7cd81f7b8800abf54b96fd73bd3e37cc50fd3d2ba8
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
-PKG_CONFIG_DEPENDS:= CONFIG_AFALG_ZERO_COPY
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_AFALG_DIGESTS \
+	CONFIG_AFALG_FALLBACK \
+	CONFIG_AFALG_UPDATE_CTR_IV \
+	CONFIG_AFALG_ZERO_COPY
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -33,7 +37,8 @@ define Package/libopenssl-afalg_sync
     URL:=https://github.com/cotequeiroz/afalg_engine
     DEPENDS:=libopenssl @OPENSSL_ENGINE @!OPENSSL_ENGINE_BUILTIN_AFALG \
 	     +libopenssl-conf +kmod-crypto-user
-    CONFLICTS:=libopenssl-afalg
+    CONFLICTS:=libopenssl-afalg $(if $(CONFIG_AFALG_FALLBACK),libopenssl-devcrypto)
+    MENU:=1
 endef
 
 define Package/libopenssl-afalg_sync/description
@@ -41,21 +46,20 @@ define Package/libopenssl-afalg_sync/description
     engine, but using the AF_ALG interface instead of /dev/crypto
 
     It is different than the AF_ALG engine that ships with OpenSSL:
+     - it is faster
      - it uses sync calls, instead of async
      - it suports more algorithms
 endef
 
 define Package/libopenssl-afalg_sync/config
-    config AFALG_ZERO_COPY
-        depends on PACKAGE_libopenssl-afalg_sync
-	bool "Use Zero-Copy Mode"
-	help
-	    Uses a Zero-Copy interface.  Even though it is supposed to improve
-	    performance, actual measurements indicate otherwise.
+    source "$(SOURCE)/Config.in"
 endef
 
 CMAKE_OPTIONS += \
 	-DOPENSSL_ENGINES_DIR=/usr/lib/$(ENGINES_DIR) \
+	-DDIGESTS=$(if $(CONFIG_AFALG_DIGESTS),ON,OFF) \
+	-DFALLBACK=$(if $(CONFIG_AFALG_FALLBACK),ON,OFF) \
+	-DUPDATE_CTR_IV=$(if $(CONFIG_AFALG_UPDATE_CTR_IV),ON,OFF) \
 	-DUSE_ZERO_COPY=$(if $(CONFIG_AFALG_ZERO_COPY),ON,OFF)
 
 define Package/libopenssl-afalg_sync/install


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, WRT3200ACM, openwrt master
Run tested: mvebu, WRT3200ACM, openwrt master -- tested with the openssl util with all build variants; running in production with default options
ipq40xx, Asus RT-AC58U, limited testing using the openssl util

Description:
This is a beta release that introduces a software fallback mechanism
that greatly speeds up smaller requests by fulfilling them in software,
avoiding the latency of switching to kernel-mode for small jobs.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
Here's a comparison of running the old engine, without an engine, using openssl default software-only implementation, and the new engine, using  WRT3200ACM.  There's a small cost to pay in terms of overhead for setting things up, explicit in the 16-bytes blocks case, but it is still 23 times faster:
```
$openssl speed -elapsed -evp AES-256-CBC
type           16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
afalg-v1.1.0   1232.86k     4851.14k    17397.67k    48835.24k    91714.90k    97479.34k
software-only 37255.54k    42867.84k    45405.70k    46087.17k    46295.72k    46301.18k
afalg-v1.2.0  28900.50k    39968.58k    44547.84k    47765.16k    90431.49k    96665.60k
```
Here's a run using an Asus RT-AC58.  Notice the drop going from 16-bytes to 64-bytes in v1.1.0.  I used an patched version of the qcrypto driver that passes 16-bytes requests to the kernel software implementation--I'm still debugging the qce ctr implementation.  So it shows that even staying within the kernel, the use of hardware for such small blocks is not optimal.  It also shows that in this particular case, a tweak in the fallback threshold to > 1024 would speed things up.  When setting the default thresholds, I leaned towards more use of hardware in close cases, to free up the CPU, but you can override the defaults by setting a cipher list, and adding a colon and the fallback threshold after the cipher name (`CIPHERS=AES-128-CTR, AES-128-CBC, AES-256-CTR:1040, AES-256-CBC`):
```
$openssl speed -elapsed -evp AES-256-CTR
type           16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
afalg-v1.1.0   1421.58k      696.73k     2643.54k     9679.19k    42612.05k    55263.23k
software-only 13126.33k    17004.78k    18358.44k    20051.63k    20605.61k    20638.38k
afalg-v1.2.0   7055.20k    11265.54k    12957.78k     8784.55k    39930.54k    53340.84k
```