### PR TITLE
mariadb: bump to 10.4.12 (CVE fix)

### DIFF
--- a/libs/libmariadb/Makefile
+++ b/libs/libmariadb/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmariadb
-PKG_VERSION:=3.1.5
+PKG_VERSION:=3.1.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=mariadb-connector-c-$(PKG_VERSION)-src.tar.gz
@@ -18,7 +18,7 @@ PKG_SOURCE_URL := \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/connector-c-$(PKG_VERSION) \
 	https://downloads.mariadb.org/interstitial/connector-c-$(PKG_VERSION)
 
-PKG_HASH:=a9de5fedd1a7805c86e23be49b9ceb79a86b090ad560d51495d7ba5952a9d9d5
+PKG_HASH:=64f7bc8f5df3200ba6e3080f68ee4942382a33e8371baea8ca4b9242746df59a
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING.LIB

--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
-PKG_VERSION:=10.4.10
+PKG_VERSION:=10.4.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -18,7 +18,7 @@ PKG_SOURCE_URL := \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/$(PKG_NAME)-$(PKG_VERSION)/source \
 	https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
 
-PKG_HASH:=cd50fddf86c2a47405737e342f78ebd40d5716f0fb32b976245de713bed01421
+PKG_HASH:=fef1e1d38aa253dd8a51006bd15aad184912fce31c446bb69434fcde735aa208
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING THIRDPARTY

--- a/utils/mariadb/patches/130-c11_atomics.patch
+++ b/utils/mariadb/patches/130-c11_atomics.patch
@@ -38,7 +38,7 @@ Date:   Fri Dec 21 19:14:04 2018 +0200
    SET(HAVE_valgrind 1)
 --- a/mysys/CMakeLists.txt
 +++ b/mysys/CMakeLists.txt
-@@ -72,6 +72,10 @@ TARGET_LINK_LIBRARIES(mysys dbug strings
+@@ -79,6 +79,10 @@ TARGET_LINK_LIBRARIES(mysys dbug strings
   ${LIBNSL} ${LIBM} ${LIBRT} ${LIBDL} ${LIBSOCKET} ${LIBEXECINFO} ${CRC32_LIBRARY})
  DTRACE_INSTRUMENT(mysys)
  

--- a/utils/mariadb/patches/180-relax-mysql_install-db-wrt-pam-tool.patch
+++ b/utils/mariadb/patches/180-relax-mysql_install-db-wrt-pam-tool.patch
@@ -24,8 +24,8 @@
 +# we can revisit.
 +if test -n ""
  then
-   chown $user "$pamtooldir/auth_pam_tool_dir" && \
-   chmod 0700 "$pamtooldir/auth_pam_tool_dir"
+   if test -z "$srcdir" -a "$in_rpm" -eq 0
+   then
 @@ -499,6 +509,10 @@ then
          echo
      fi


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79 master
Run tested: 19.07 ath79

Description:
Hi all,

Minor version bump to address CVE-2020-2574. Patches refreshed.

Kind regards,
Seb