### PR TITLE
apache/apr/apr-util: fix some nitpicks

### DIFF
--- a/libs/apr-util/Makefile
+++ b/libs/apr-util/Makefile
@@ -126,6 +126,13 @@ endef
 $$(eval $$(call BuildPackage,libaprutil-$(subst _,-,$(1))))
 endef
 
+# PKG_CONFIG_DEPENDS trigger configure, but the compile afterward may be
+# incomplete if the build directory is not cleaned before. This is not a
+# general observation, yet it is valid for apr-util :/
+define Build/Compile
+	$(call Build/Compile/Default,clean all)
+endef
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/include/apr-1 \
 				$(1)/usr/lib/pkgconfig

--- a/libs/apr-util/Makefile
+++ b/libs/apr-util/Makefile
@@ -131,12 +131,10 @@ define Build/InstallDev
 				$(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/apu-1-config $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/apr-1/* $(1)/usr/include/apr-1
-ifneq ($(CONFIG_PACKAGE_libaprutil-crypto-openssl)$(CONFIG_PACKAGE_libaprutil-dbd-pgsql)$(CONFIG_PACKAGE_libaprutil-dbd-sqlite3)$(CONFIG_PACKAGE_libaprutil-ldap),)
 	$(INSTALL_DIR) $(1)/usr/lib/apr-util-1
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/apr-util-1/apr_*{la,a,so*} \
-					$(1)/usr/lib/apr-util-1
-endif
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libaprutil-1.{la,a,so*} \
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/apr-util-1/apr_*.{a,so} \
+			$(1)/usr/lib/apr-util-1 2>/dev/null || :
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libaprutil-1.{a,so*} \
 						$(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/apr-util-1.pc \
 					$(1)/usr/lib/pkgconfig

--- a/libs/apr/Makefile
+++ b/libs/apr/Makefile
@@ -70,7 +70,7 @@ define Build/InstallDev
 						$(1)/usr/bin
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/apr-1/* \
 					$(1)/usr/include/apr-1
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libapr-1.{la,a,so*} $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libapr-1.{a,so*} $(1)/usr/lib
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/apr-1.pc \
 						$(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/build-1/* $(1)/usr/share/build-1

--- a/net/apache/Makefile
+++ b/net/apache/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apache
 PKG_VERSION:=2.4.41
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_SOURCE_NAME:=httpd
 
 PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.bz2
@@ -282,8 +282,6 @@ define Build/InstallDev
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/apache2/* \
 					$(1)/usr/include/apache2
 	$(INSTALL_DIR) $(1)/usr/lib/apache2
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/apache2/httpd.exp \
-						$(1)/usr/lib/apache2
 	$(INSTALL_DIR) $(1)/usr/share/apache2/build
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/apache2/build/* \
 				$(1)/usr/share/apache2/build
@@ -308,8 +306,6 @@ define Package/apache/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/apache2/*.so \
 					$(1)/usr/lib/apache2
 	rm -f $(1)/usr/lib/apache2/mod_{*ldap,dav*,deflate,http2,lbmethod_*,lua,md,proxy*,proxy_html,session_crypto,ssl,suexec,xml2enc}.so
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/apache2/httpd.exp \
-						$(1)/usr/lib/apache2
 	$(INSTALL_DIR) $(1)/usr/share/apache2/{cgi-bin,htdocs}
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/apache2/cgi-bin/* \
 					$(1)/usr/share/apache2/cgi-bin


### PR DESCRIPTION
Maintainer: @heil & me
Compile tested: ath79 master
Run tested: ath79 19.07

Description:
Hi all,

This series fixes some small nitpicks. The main points are that it fixes PKG_CONFIG_DEPENDS for apr-util and a reconfigure issue that causes build failure for apache (ldap related). I believe it possible that this is the issue @tru7 ran into and mentioned in issue #10898.

Thanks!
Seb