### PR TITLE
[18.06] mariadb: security bump to 10.1.44

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
-PKG_VERSION:=10.1.41
-PKG_RELEASE:=2
+PKG_VERSION:=10.1.44
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := \
@@ -18,7 +18,7 @@ PKG_SOURCE_URL := \
 	https://ftp.yz.yamagata-u.ac.jp/pub/dbms/mariadb/$(PKG_NAME)-$(PKG_VERSION)/source \
 	https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
 
-PKG_HASH:=2b47c3afdae81eab2b9c29ba6a10328acb8d07166e8112744f6d704cc70100f2
+PKG_HASH:=21f203d361ee8c6e0f5050f3d0c06f3c5a2b87ac28f39e9503b851084a335039
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING

--- a/utils/mariadb/patches/140-mips-connect-unaligned.patch
+++ b/utils/mariadb/patches/140-mips-connect-unaligned.patch
@@ -103,7 +103,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
  /***********************************************************************/
 --- a/storage/connect/valblk.cpp
 +++ b/storage/connect/valblk.cpp
-@@ -266,14 +266,14 @@ bool TYPBLK<TYPE>::Init(PGLOBAL g, bool
+@@ -268,14 +268,14 @@ bool TYPBLK<TYPE>::Init(PGLOBAL g, bool
  template <class TYPE>
  char *TYPBLK<TYPE>::GetCharString(char *p, int n)
    {
@@ -120,7 +120,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
    return p;
    } // end of GetCharString
  
-@@ -289,7 +289,7 @@ void TYPBLK<TYPE>::SetValue(PVAL valp, i
+@@ -291,7 +291,7 @@ void TYPBLK<TYPE>::SetValue(PVAL valp, i
    ChkTyp(valp);
  
    if (!(b = valp->IsNull()))
@@ -129,7 +129,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
    else
      Reset(n);
  
-@@ -351,9 +351,9 @@ void TYPBLK<TYPE>::SetValue(PCSZ p, int
+@@ -353,9 +353,9 @@ void TYPBLK<TYPE>::SetValue(PCSZ p, int
    ulonglong val = CharToNumber(p, strlen(p), maxval, Unsigned, &minus); 
      
    if (minus && val < maxval)
@@ -141,7 +141,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
  
    SetNull(n, false);
    } // end of SetValue
-@@ -396,7 +396,7 @@ void TYPBLK<double>::SetValue(PCSZ p, in
+@@ -398,7 +398,7 @@ void TYPBLK<double>::SetValue(PCSZ p, in
  		throw Type;
  	} // endif Check
  
@@ -150,7 +150,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
    SetNull(n, false);
    } // end of SetValue
  
-@@ -428,7 +428,7 @@ void TYPBLK<TYPE>::SetValue(PVBLK pv, in
+@@ -430,7 +430,7 @@ void TYPBLK<TYPE>::SetValue(PVBLK pv, in
    ChkTyp(pv);
  
    if (!(b = pv->IsNull(n2) && Nullable))
@@ -159,7 +159,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
    else
      Reset(n1);
  
-@@ -479,10 +479,10 @@ void TYPBLK<TYPE>::SetMin(PVAL valp, int
+@@ -481,10 +481,10 @@ void TYPBLK<TYPE>::SetMin(PVAL valp, int
    {
    CheckParms(valp, n)
    TYPE  tval = GetTypedValue(valp);
@@ -172,7 +172,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
  
    } // end of SetMin
  
-@@ -494,10 +494,10 @@ void TYPBLK<TYPE>::SetMax(PVAL valp, int
+@@ -496,10 +496,10 @@ void TYPBLK<TYPE>::SetMax(PVAL valp, int
    {
    CheckParms(valp, n)
    TYPE  tval = GetTypedValue(valp);
@@ -185,7 +185,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
  
    } // end of SetMax
  
-@@ -511,8 +511,7 @@ void TYPBLK<TYPE>::SetValues(PVBLK pv, i
+@@ -513,8 +513,7 @@ void TYPBLK<TYPE>::SetValues(PVBLK pv, i
    CheckType(pv)
    TYPE *lp = ((TYPBLK*)pv)->Typp;
  
@@ -195,7 +195,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
  
    } // end of SetValues
  #endif // 0
-@@ -523,7 +522,7 @@ void TYPBLK<TYPE>::SetValues(PVBLK pv, i
+@@ -525,7 +524,7 @@ void TYPBLK<TYPE>::SetValues(PVBLK pv, i
  template <class TYPE>
  void TYPBLK<TYPE>::Move(int i, int j)
    {
@@ -204,7 +204,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
    MoveNull(i, j);
    } // end of Move
  
-@@ -537,7 +536,7 @@ int TYPBLK<TYPE>::CompVal(PVAL vp, int n
+@@ -539,7 +538,7 @@ int TYPBLK<TYPE>::CompVal(PVAL vp, int n
    ChkIndx(n);
    ChkTyp(vp);
  #endif   // _DEBUG
@@ -213,7 +213,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
    TYPE vlv = GetTypedValue(vp);
  
    return (vlv > mlv) ? 1 : (vlv < mlv) ? (-1) : 0;
-@@ -549,8 +548,8 @@ int TYPBLK<TYPE>::CompVal(PVAL vp, int n
+@@ -551,8 +550,8 @@ int TYPBLK<TYPE>::CompVal(PVAL vp, int n
  template <class TYPE>
  int TYPBLK<TYPE>::CompVal(int i1, int i2)
    {
@@ -224,7 +224,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
  
    return (lv1 > lv2) ? 1 : (lv1 < lv2) ? (-1) : 0;
    } // end of CompVal
-@@ -587,7 +586,7 @@ int TYPBLK<TYPE>::Find(PVAL vp)
+@@ -589,7 +588,7 @@ int TYPBLK<TYPE>::Find(PVAL vp)
    TYPE n = GetTypedValue(vp);
  
    for (i = 0; i < Nval; i++)
@@ -233,7 +233,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
        break;
  
    return (i < Nval) ? i : (-1);
-@@ -603,7 +602,7 @@ int TYPBLK<TYPE>::GetMaxLength(void)
+@@ -605,7 +604,7 @@ int TYPBLK<TYPE>::GetMaxLength(void)
    int i, n, m;
  
    for (i = n = 0; i < Nval; i++) {
@@ -242,7 +242,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
      n = MY_MAX(n, m);
      } // endfor i
  
-@@ -1333,7 +1332,7 @@ char *DATBLK::GetCharString(char *p, int
+@@ -1335,7 +1334,7 @@ char *DATBLK::GetCharString(char *p, int
    char *vp;
  
    if (Dvalp) {
@@ -251,7 +251,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
      vp = Dvalp->GetCharString(p);
    } else
      vp = TYPBLK<int>::GetCharString(p, n);
-@@ -1349,7 +1348,7 @@ void DATBLK::SetValue(PCSZ p, int n)
+@@ -1351,7 +1350,7 @@ void DATBLK::SetValue(PCSZ p, int n)
    if (Dvalp) {
      // Decode the string according to format
      Dvalp->SetValue_psz(p);

--- a/utils/mariadb/patches/170-ppc-remove-glibc-dep.patch
+++ b/utils/mariadb/patches/170-ppc-remove-glibc-dep.patch
@@ -27,17 +27,16 @@ directly was the first solution adopted in MariaDB [2].
 
 --- a/storage/xtradb/include/ut0ut.h
 +++ b/storage/xtradb/include/ut0ut.h
-@@ -84,8 +84,7 @@ private:
-    independent way by using YieldProcessor. */
+@@ -85,7 +85,7 @@ private:
  #  define UT_RELAX_CPU() YieldProcessor()
- # elif defined(__powerpc__)
--#include <sys/platform/ppc.h>
+ # elif defined(__powerpc__) && defined __GLIBC__
+ #include <sys/platform/ppc.h>
 -#  define UT_RELAX_CPU() __ppc_get_timebase()
 +#  define UT_RELAX_CPU() __builtin_ppc_get_timebase()
  # else
  #  define UT_RELAX_CPU() ((void)0) /* avoid warning for an empty statement */
  # endif
-@@ -99,9 +98,8 @@ private:
+@@ -99,9 +99,8 @@ private:
  #endif
  
  # if defined(HAVE_HMT_PRIORITY_INSTRUCTION)


### PR DESCRIPTION
Addresses CVE-2020-2574. Patches refreshed.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: ar71xx 18.06
Run tested: nope, don't have hardware running 18.06 around anymore. Anyway, should be OK.

Description:
Minor version bump to address CVE.

Thanks!
Seb