### PR TITLE
mpd changes

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpd
-PKG_VERSION:=0.21.16
+PKG_VERSION:=0.21.19
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://www.musicpd.org/download/mpd/0.21/
-PKG_HASH:=30cf1bddf7d7388487276745ad3515f134e07f0c57f9f97cb2b5d3befd4a4d92
+PKG_SOURCE_URL:=https://www.musicpd.org/download/mpd/0.21/
+PKG_HASH:=d3275e11d85637adde250cadf3b4f5aec2144228f0d8085767493fc46c55b2f9
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -31,7 +31,7 @@ define Package/mpd/Default
   SECTION:=sound
   CATEGORY:=Sound
   TITLE:=Music Player Daemon
-  URL:=http://www.musicpd.org/
+  URL:=https://www.musicpd.org/
   DEPENDS:= +zlib +libcurl +libpthread +libmpdclient +libstdcpp $(ICONV_DEPENDS) \
 	    +AUDIO_SUPPORT:alsa-lib +boost +libexpat +libflac
 endef

--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -33,7 +33,7 @@ define Package/mpd/Default
   TITLE:=Music Player Daemon
   URL:=https://www.musicpd.org/
   DEPENDS:= +zlib +libcurl +libpthread +libmpdclient +libstdcpp $(ICONV_DEPENDS) \
-	    +AUDIO_SUPPORT:alsa-lib +boost +libexpat +libflac
+	    +AUDIO_SUPPORT:alsa-lib +boost +libexpat +libflac +USE_UCLIBC:icu
 endef
 
 define Package/mpd/Default/description
@@ -158,8 +158,8 @@ MESON_ARGS += \
 	-Dsolaris_output=disabled \
 	-Ddbus=disabled \
 	-Dexpat=enabled \
-	-Dicu=disabled \
-	-Diconv=enabled \
+	-Dicu=$(if $(CONFIG_USE_UCLIBC),enabled,disabled) \
+	-Diconv=$(if $(CONFIG_USE_UCLIBC),disabled,enabled) \
 	-Dpcre=disabled \
 	-Dsqlite=disabled \
 	-Dzlib=enabled \

--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -64,7 +64,7 @@ endef
 define Package/mpd-mini
 $(call Package/mpd/Default)
   TITLE+= (mini)
-  DEPENDS+= +libmpg123 +libvorbisidec
+  DEPENDS+= +libmad +libvorbisidec
   PROVIDES:=mpd
   VARIANT:=mini
 endef
@@ -132,7 +132,7 @@ MESON_ARGS += \
 	-Dflac=enabled \
 	-Dfluidsynth=disabled \
 	-Dgme=disabled \
-	-Dmad=disabled \
+	-Dmpg123=disabled \
 	-Dmikmod=disabled \
 	-Dmodplug=disabled \
 	-Dmpcdec=disabled \
@@ -174,7 +174,7 @@ ifeq ($(BUILD_VARIANT),full)
 	-Dsoundcloud=enabled \
 	-Did3tag=enabled \
 	-Dffmpeg=enabled \
-	-Dmpg123=disabled \
+	-Dmad=disabled \
 	-Dtremor=disabled \
 	-Dvorbis=enabled \
 	-Dfifo=true \
@@ -194,7 +194,7 @@ ifeq ($(BUILD_VARIANT),mini)
 	-Dsoundcloud=disabled \
 	-Did3tag=disabled \
 	-Dffmpeg=disabled \
-	-Dmpg123=enabled \
+	-Dmad=enabled \
 	-Dtremor=enabled \
 	-Dvorbis=disabled \
 	-Dfifo=false \

--- a/sound/mpd/patches/010-treewide-use-boost-lround-when-std-round-is-unavaila.patch
+++ b/sound/mpd/patches/010-treewide-use-boost-lround-when-std-round-is-unavaila.patch
@@ -1,0 +1,196 @@
+From bffc5cde6d71556f143500a12c53c1835deebe07 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sun, 2 Feb 2020 21:21:57 -0800
+Subject: [PATCH 1/3] treewide: use boost::lround when std::round is
+ unavailable
+
+This is the case with uClibc-ng currently.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ src/Stats.cxx                             |  4 +--
+ src/command/PlayerCommands.cxx            |  5 ++-
+ src/decoder/plugins/FaadDecoderPlugin.cxx |  3 +-
+ src/mixer/plugins/WinmmMixerPlugin.cxx    |  2 +-
+ src/output/plugins/HaikuOutputPlugin.cxx  |  3 +-
+ src/pcm/Mix.cxx                           |  5 ++-
+ src/player/CrossFade.cxx                  |  5 ++-
+ src/util/Math.hxx                         | 41 +++++++++++++++++++++++
+ 8 files changed, 52 insertions(+), 16 deletions(-)
+ create mode 100644 src/util/Math.hxx
+
+--- a/src/Stats.cxx
++++ b/src/Stats.cxx
+@@ -29,9 +29,9 @@
+ #include "system/Clock.hxx"
+ #include "Log.hxx"
+ #include "time/ChronoUtil.hxx"
++#include "util/Math.hxx"
+ 
+ #include <chrono>
+-#include <cmath>
+ 
+ #ifndef _WIN32
+ /**
+@@ -121,7 +121,7 @@ stats_print(Response &r, const Partition &partition)
+ #else
+ 		 (unsigned)std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - start_time).count(),
+ #endif
+-		 std::lround(partition.pc.GetTotalPlayTime().count()));
++		 lround(partition.pc.GetTotalPlayTime().count()));
+ 
+ #ifdef ENABLE_DATABASE
+ 	const Database *db = partition.instance.GetDatabase();
+--- a/src/command/PlayerCommands.cxx
++++ b/src/command/PlayerCommands.cxx
+@@ -34,13 +34,12 @@
+ #include "util/StringBuffer.hxx"
+ #include "util/ScopeExit.hxx"
+ #include "util/Exception.hxx"
++#include "util/Math.hxx"
+ 
+ #ifdef ENABLE_DATABASE
+ #include "db/update/Service.hxx"
+ #endif
+ 
+-#include <cmath>
+-
+ #define COMMAND_STATUS_STATE            "state"
+ #define COMMAND_STATUS_REPEAT           "repeat"
+ #define COMMAND_STATUS_SINGLE           "single"
+@@ -154,7 +153,7 @@ handle_status(Client &client, gcc_unused Request args, Response &r)
+ 
+ 	if (pc.GetCrossFade() > FloatDuration::zero())
+ 		r.Format(COMMAND_STATUS_CROSSFADE ": %lu\n",
+-			 std::lround(pc.GetCrossFade().count()));
++			 lround(pc.GetCrossFade().count()));
+ 
+ 	if (pc.GetMixRampDelay() > FloatDuration::zero())
+ 		r.Format(COMMAND_STATUS_MIXRAMPDELAY ": %f\n",
+--- a/src/mixer/plugins/WinmmMixerPlugin.cxx
++++ b/src/mixer/plugins/WinmmMixerPlugin.cxx
+@@ -20,13 +20,13 @@
+ #include "mixer/MixerInternal.hxx"
+ #include "output/OutputAPI.hxx"
+ #include "output/plugins/WinmmOutputPlugin.hxx"
++#include "util/Math.hxx"
+ 
+ #include <mmsystem.h>
+ 
+ #include <stdexcept>
+ 
+ #include <assert.h>
+-#include <math.h>
+ #include <windows.h>
+ 
+ class WinmmMixer final : public Mixer {
+--- a/src/output/plugins/HaikuOutputPlugin.cxx
++++ b/src/output/plugins/HaikuOutputPlugin.cxx
+@@ -22,6 +22,7 @@
+ #include "../OutputAPI.hxx"
+ #include "mixer/MixerList.hxx"
+ #include "util/Domain.hxx"
++#include "util/Math.hxx"
+ #include "system/Error.hxx"
+ #include "Log.hxx"
+ 
+@@ -37,8 +38,6 @@
+ #include <StringList.h>
+ #include <SoundPlayer.h>
+ 
+-#include <cmath>
+-
+ #include <string.h>
+ 
+ #define UTF8_PLAY "\xE2\x96\xB6"
+--- a/src/pcm/PcmMix.cxx
++++ b/src/pcm/PcmMix.cxx
+@@ -22,11 +22,10 @@
+ #include "Clamp.hxx"
+ #include "Traits.hxx"
+ #include "util/Clamp.hxx"
++#include "util/Math.hxx"
+ 
+ #include "PcmDither.cxx" // including the .cxx file to get inlined templates
+ 
+-#include <cmath>
+-
+ #include <assert.h>
+ 
+ template<SampleFormat F, class Traits=SampleTraits<F>>
+@@ -225,7 +224,7 @@ pcm_mix(PcmDither &dither, void *buffer1, const void *buffer2, size_t size,
+ 	s = sin(M_PI_2 * portion1);
+ 	s *= s;
+ 
+-	int vol1 = std::lround(s * PCM_VOLUME_1S);
++	int vol1 = lround(s * PCM_VOLUME_1S);
+ 	vol1 = Clamp<int>(vol1, 0, PCM_VOLUME_1S);
+ 
+ 	return pcm_add_vol(dither, buffer1, buffer2, size,
+--- a/src/player/CrossFade.cxx
++++ b/src/player/CrossFade.cxx
+@@ -23,10 +23,9 @@
+ #include "AudioFormat.hxx"
+ #include "util/NumberParser.hxx"
+ #include "util/Domain.hxx"
++#include "util/Math.hxx"
+ #include "Log.hxx"
+ 
+-#include <cmath>
+-
+ #include <assert.h>
+ 
+ static constexpr Domain cross_fade_domain("cross_fade");
+@@ -112,7 +111,7 @@ CrossFadeSettings::Calculate(SignedSongTime total_time,
+ 
+ 	if (mixramp_delay <= FloatDuration::zero() ||
+ 	    !mixramp_start || !mixramp_prev_end) {
+-		chunks = std::lround(duration / chunk_duration);
++		chunks = lround(duration / chunk_duration);
+ 	} else {
+ 		/* Calculate mixramp overlap. */
+ 		const auto mixramp_overlap_current =
+--- /dev/null
++++ b/src/util/Math.hxx
+@@ -0,0 +1,41 @@
++/*
++ * Copyright (C) 2020 Rosen Penev <rosenp@gmail.com>
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *
++ * - Redistributions of source code must retain the above copyright
++ * notice, this list of conditions and the following disclaimer.
++ *
++ * - Redistributions in binary form must reproduce the above copyright
++ * notice, this list of conditions and the following disclaimer in the
++ * documentation and/or other materials provided with the
++ * distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
++ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
++ * FOUNDATION OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
++ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
++ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
++ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
++ * OF THE POSSIBILITY OF SUCH DAMAGE.
++ */
++
++#ifndef MATH_HXX
++#define MATH_HXX
++
++#ifdef __UCLIBC__
++#include <boost/math/special_functions/round.hpp>
++using boost::math::lround;
++#else
++#include <cmath>
++using std::lround;
++#endif
++
++#endif

--- a/sound/mpd/patches/020-volume_mapping-get-rid-of-exp10-workaround.patch
+++ b/sound/mpd/patches/020-volume_mapping-get-rid-of-exp10-workaround.patch
@@ -1,0 +1,52 @@
+From b8ed7496963aafdb6ec3415c4efd1ff98a7e8a1d Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Mon, 3 Feb 2020 15:26:50 -0800
+Subject: [PATCH 2/3] volume_mapping: get rid of exp10 workaround
+
+pow(10,x) is an alternative that works just as well.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ src/mixer/plugins/volume_mapping.c | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/src/mixer/plugins/volume_mapping.c b/src/mixer/plugins/volume_mapping.c
+index 61a7138af..beecce640 100644
+--- a/src/mixer/plugins/volume_mapping.c
++++ b/src/mixer/plugins/volume_mapping.c
+@@ -34,11 +34,6 @@
+ #include <stdbool.h>
+ #include "volume_mapping.h"
+ 
+-#ifdef __UCLIBC__
+-/* 10^x = 10^(log e^x) = (e^x)^log10 = e^(x * log 10) */
+-#define exp10(x) (exp((x) * log(10)))
+-#endif /* __UCLIBC__ */
+-
+ #define MAX_LINEAR_DB_SCALE	24
+ 
+ static inline bool use_linear_dB_scale(long dBmin, long dBmax)
+@@ -111,9 +106,9 @@ static double get_normalized_volume(snd_mixer_elem_t *elem,
+ 	if (use_linear_dB_scale(min, max))
+ 		return (value - min) / (double)(max - min);
+ 
+-	normalized = exp10((value - max) / 6000.0);
++	normalized = pow(10, (value - max) / 6000.0);
+ 	if (min != SND_CTL_TLV_DB_GAIN_MUTE) {
+-		min_norm = exp10((min - max) / 6000.0);
++		min_norm = pow(10, (min - max) / 6000.0);
+ 		normalized = (normalized - min_norm) / (1 - min_norm);
+ 	}
+ 
+@@ -159,7 +154,7 @@ static int set_normalized_volume(snd_mixer_elem_t *elem,
+ 	}
+ 
+ 	if (min != SND_CTL_TLV_DB_GAIN_MUTE) {
+-		min_norm = exp10((min - max) / 6000.0);
++		min_norm = pow(10, (min - max) / 6000.0);
+ 		volume = volume * (1 - min_norm) + min_norm;
+ 	}
+ 	value = lrint_dir(6000.0 * log10(volume), dir) + max;
+-- 
+2.24.1
+

--- a/sound/mpd/patches/030-treewide-get-rid-of-C-math-function-usage.patch
+++ b/sound/mpd/patches/030-treewide-get-rid-of-C-math-function-usage.patch
@@ -1,0 +1,146 @@
+From 506b806e253af7cc37e269b79cc3e099d02cf81a Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Mon, 3 Feb 2020 15:50:46 -0800
+Subject: [PATCH 3/3] treewide: get rid of C math function usage
+
+Boost does not seem to offer an overload for lrint.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ src/ReplayGainGlobal.cxx                    | 2 +-
+ src/ReplayGainInfo.cxx                      | 3 +--
+ src/decoder/Bridge.cxx                      | 5 +++--
+ src/decoder/plugins/MpcdecDecoderPlugin.cxx | 3 +--
+ src/mixer/plugins/AlsaMixerPlugin.cxx       | 3 +--
+ src/mixer/plugins/SoftwareMixerPlugin.cxx   | 5 +++--
+ src/util/Math.hxx                           | 6 ++++++
+ 7 files changed, 16 insertions(+), 11 deletions(-)
+
+--- a/src/ReplayGainGlobal.cxx
++++ b/src/ReplayGainGlobal.cxx
+@@ -22,10 +22,10 @@
+ #include "config/Param.hxx"
+ #include "config/Data.hxx"
+ #include "util/RuntimeError.hxx"
++#include "util/Math.hxx"
+ 
+ #include <assert.h>
+ #include <stdlib.h>
+-#include <math.h>
+ 
+ static float
+ ParsePreamp(const char *s)
+--- a/src/ReplayGainInfo.cxx
++++ b/src/ReplayGainInfo.cxx
+@@ -19,8 +19,7 @@
+ 
+ #include "ReplayGainInfo.hxx"
+ #include "ReplayGainConfig.hxx"
+-
+-#include <math.h>
++#include "util/Math.hxx"
+ 
+ float
+ ReplayGainTuple::CalculateScale(const ReplayGainConfig &config) const noexcept
+--- a/src/decoder/Bridge.cxx
++++ b/src/decoder/Bridge.cxx
+@@ -33,9 +33,10 @@
+ #include "util/ConstBuffer.hxx"
+ #include "util/StringBuffer.hxx"
+ 
++#include <cmath>
++
+ #include <assert.h>
+ #include <string.h>
+-#include <math.h>
+ 
+ DecoderBridge::~DecoderBridge()
+ {
+@@ -591,7 +592,7 @@ DecoderBridge::SubmitReplayGain(const ReplayGainInfo *new_replay_gain_info)
+ 			const auto &tuple = new_replay_gain_info->Get(rgm);
+ 			const auto scale =
+ 				tuple.CalculateScale(dc.replay_gain_config);
+-			dc.replay_gain_db = 20.0 * log10f(scale);
++			dc.replay_gain_db = 20.0 * std::log10(scale);
+ 		}
+ 
+ 		replay_gain_info = *new_replay_gain_info;
+--- a/src/decoder/plugins/MpcdecDecoderPlugin.cxx
++++ b/src/decoder/plugins/MpcdecDecoderPlugin.cxx
+@@ -26,6 +26,7 @@
+ #include "util/Domain.hxx"
+ #include "util/Macros.hxx"
+ #include "util/Clamp.hxx"
++#include "util/Math.hxx"
+ #include "util/ScopeExit.hxx"
+ #include "Log.hxx"
+ 
+@@ -33,8 +34,6 @@
+ 
+ #include <exception>
+ 
+-#include <math.h>
+-
+ struct mpc_decoder_data {
+ 	InputStream &is;
+ 	DecoderClient *client;
+--- a/src/mixer/plugins/AlsaMixerPlugin.cxx
++++ b/src/mixer/plugins/AlsaMixerPlugin.cxx
+@@ -26,6 +26,7 @@
+ #include "event/Call.hxx"
+ #include "util/ASCII.hxx"
+ #include "util/Domain.hxx"
++#include "util/Math.hxx"
+ #include "util/RuntimeError.hxx"
+ #include "Log.hxx"
+ 
+@@ -35,8 +36,6 @@ extern "C" {
+ 
+ #include <alsa/asoundlib.h>
+ 
+-#include <math.h>
+-
+ #define VOLUME_MIXER_ALSA_DEFAULT		"default"
+ #define VOLUME_MIXER_ALSA_CONTROL_DEFAULT	"PCM"
+ static constexpr unsigned VOLUME_MIXER_ALSA_INDEX_DEFAULT = 0;
+--- a/src/mixer/plugins/SoftwareMixerPlugin.cxx
++++ b/src/mixer/plugins/SoftwareMixerPlugin.cxx
+@@ -22,8 +22,9 @@
+ #include "filter/plugins/VolumeFilterPlugin.hxx"
+ #include "pcm/Volume.hxx"
+ 
++#include <cmath>
++
+ #include <assert.h>
+-#include <math.h>
+ 
+ class SoftwareMixer final : public Mixer {
+ 	Filter *filter = nullptr;
+@@ -73,7 +74,7 @@ PercentVolumeToSoftwareVolume(unsigned volume) noexcept
+ 	if (volume >= 100)
+ 		return PCM_VOLUME_1;
+ 	else if (volume > 0)
+-		return pcm_float_to_volume((exp(volume / 25.0) - 1) /
++		return pcm_float_to_volume((std::exp(volume / 25.0) - 1) /
+ 					   (54.5981500331F - 1));
+ 	else
+ 		return 0;
+--- a/src/util/Math.hxx
++++ b/src/util/Math.hxx
+@@ -31,10 +31,16 @@
+ #define MATH_HXX
+ 
+ #ifdef __UCLIBC__
++#include <boost/math/special_functions/pow.hpp>
+ #include <boost/math/special_functions/round.hpp>
++using boost::math::iround;
++using boost::math::pow;
+ using boost::math::lround;
++#define lrint iround
+ #else
+ #include <cmath>
++using std::pow;
++using std::lrint;
+ using std::lround;
+ #endif
+ 


### PR DESCRIPTION
Maintainer: @thess 
Compile tested: malta arc770d

The first one is related to https://downloads.openwrt.org/snapshots/faillogs/arc_archs/packages/mpd/mini/compile.txt

Fixes compilation there. ping @dhewg . Since the conversion to meson, does ICONV_FULL even work properly?

The second relates to this thread: https://forum.openwrt.org/t/mp3-streams-in-mpd-mini/35763/32

Several people are reporting problems with mpd-mini not being able to decode mp3 streams. Because upstream is not merging my patch that fixes mpd-full for legacy x86, mpd-full is unavailable as a solution.

This should be done anyway as libmad is smaller and does not use floating point, making it ideal for softfloat equipment.