### PR TITLE
measurement-kit: Fix compilation with uClibc-ng

### DIFF
--- a/libs/measurement-kit/Makefile
+++ b/libs/measurement-kit/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=measurement-kit
 PKG_VERSION:=0.10.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/measurement-kit/measurement-kit/tar.gz/v$(PKG_VERSION)?
@@ -38,6 +38,8 @@ define Package/measurement-kit/description
 endef
 
 CONFIGURE_ARGS+= --with-ca-bundle=/etc/ssl/cert.pem
+
+TARGET_CFLAGS += $(if $(CONFIG_USE_UCLIBC),-DCATCH_CONFIG_GLOBAL_NEXTAFTER)
 
 define Build/Configure
 	( cd $(PKG_BUILD_DIR); ./autogen.sh )


### PR DESCRIPTION
The define in the codebase is wrong. Fixed in the Makefile.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ja-pa 
Compile tested: arc770d

https://downloads.openwrt.org/snapshots/faillogs/arc_archs/packages/measurement-kit/compile.txt