### PR TITLE
[19.07] libxml2: fix libxslt host build

### DIFF
--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxml2
 PKG_VERSION:=2.9.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://xmlsoft.org/sources/
@@ -108,8 +108,11 @@ HOST_CONFIGURE_ARGS += \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(2)/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/xml2-config $(2)/bin/
-	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' $(2)/bin/xml2-config
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/xml2-config \
+		$(2)/bin/$(GNU_TARGET_NAME)-xml2-config
+	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' \
+		$(2)/bin/$(GNU_TARGET_NAME)-xml2-config
+	$(LN) $(GNU_TARGET_NAME)-xml2-config $(2)/bin/xml2-config
 
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libxml2 $(1)/usr/include/
@@ -126,6 +129,12 @@ define Build/InstallDev
 
 	$(INSTALL_DIR) $(2)/share/aclocal/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/aclocal/* $(2)/share/aclocal
+endef
+
+define Host/Install
+	$(call Host/Install/Default)
+	mv $(1)/bin/xml2-config $(1)/bin/$(GNU_HOST_NAME)-xml2-config
+	$(LN) $(GNU_HOST_NAME)-xml2-config $(1)/bin/xml2-config
 endef
 
 define Package/libxml2/install

--- a/libs/libxml2/Makefile
+++ b/libs/libxml2/Makefile
@@ -133,10 +133,5 @@ define Package/libxml2/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libxml2.so* $(1)/usr/lib/
 endef
 
-define Host/Install
-	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' $(HOST_BUILD_DIR)/xml2-config
-	$(call Host/Install/Default)
-endef
-
 $(eval $(call HostBuild))
 $(eval $(call BuildPackage,libxml2))


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: ath79 19.07
Run tested: ath79 master

Description:
Hi Michael,

This is a cherry-pick of two commits for libxml2 to 19.07. Currently all libxslt/host builds fail on 19.07:

```
In file included from attrvt.c:17:0:
libxslt.h:20:31: fatal error: libxml/xmlversion.h: No such file or directory
 #include <libxml/xmlversion.h>
                               ^
compilation terminated.
```

The header can't be found because xml2-config provides target includes instead of hostpkg-includes.

`OpenWrt-libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -I.. -I../libxslt -I/builder/shared-workdir/build/sdk/staging_dir/host/include -I/builder/shared-workdir/build/sdk/staging_dir/hostpkg/include -I/builder/shared-workdir/build/sdk/staging_dir/target-mips_24kc_musl/host/include -I/builder/shared-workdir/build/sdk/staging_dir/target-mips_24kc_musl/usr/include/libxml2 -O2 <snip>`

This is fixed by "revert xml2-config prefix fix".

The second commit adds the host triplet to xml2-config, because some software looks for that before it looks for libxml2-config. Examples include libxslt and asterisk.

```
checking for x86_64-pc-linux-gnu-xml2-config... no
checking for xml2-config... /builder/shared-workdir/build/sdk/staging_dir/hostpkg/bin/xml2-config
```

This is not a problem on the build bots, but if anybody uses the sdk on a host which provides, say, x86_64-pc-linux-gnu-xml2-config, then this would get preference, causing host headers to be introduced instead of the ones from the hostpkg directory.

Thanks!
Seb