### PR TITLE
[19.07] wsdd2: fix typos

### DIFF
--- a/net/wsdd2/Makefile
+++ b/net/wsdd2/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wsdd2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Andy2244/wsdd2.git

--- a/net/wsdd2/files/wsdd2.init
+++ b/net/wsdd2/files/wsdd2.init
@@ -45,7 +45,7 @@ start_service() {
 	if [ -n "$wg_name" ]; then
 		WG_PARM="-G $wg_name"
 	else
-		NB_PARM="-G WORKGROUP"
+		WG_PARM="-G WORKGROUP"
 	fi
 
 	# resolve lan interface (BUG: No multi-interface binds atm)
@@ -82,5 +82,5 @@ start_service() {
 
 service_triggers() {
 	PROCD_RELOAD_DELAY=1000
-	procd_add_reload_trigger "dhcp" "system" "samba" "samba4" "smbd"
+	procd_add_reload_trigger "dhcp" "system" "samba" "samba4" "ksmbd"
 }


### PR DESCRIPTION
Maintainer: me
Compile tested: arm (master-19.07)
Run tested:

Description:
* fix #11194, typos (WG_PARM, reload_trigger)
