### PR TITLE
golang: Improve build isolation from user environment

### DIFF
--- a/lang/golang/golang-package.mk
+++ b/lang/golang/golang-package.mk
@@ -114,7 +114,6 @@ GO_PKG_WORK_DIR:=$(PKG_BUILD_DIR)/$(GO_PKG_WORK_DIR_NAME)
 
 GO_PKG_BUILD_DIR:=$(GO_PKG_WORK_DIR)/build
 GO_PKG_CACHE_DIR:=$(GO_PKG_WORK_DIR)/cache
-GO_PKG_TMP_DIR:=$(GO_PKG_WORK_DIR)/tmp
 
 GO_PKG_BUILD_BIN_DIR:=$(GO_PKG_BUILD_DIR)/bin$(if $(GO_HOST_TARGET_DIFFERENT),/$(GO_OS_ARCH))
 
@@ -189,8 +188,7 @@ GoPackage/has_binaries=$(call GoPackage/is_dir_not_empty,$(GO_PKG_BUILD_BIN_DIR)
 define GoPackage/Build/Configure
 	( \
 		cd $(PKG_BUILD_DIR) ; \
-		mkdir -p $(GO_PKG_BUILD_DIR)/bin $(GO_PKG_BUILD_DIR)/src \
-			$(GO_PKG_CACHE_DIR) $(GO_PKG_TMP_DIR) ; \
+		mkdir -p $(GO_PKG_BUILD_DIR)/bin $(GO_PKG_BUILD_DIR)/src $(GO_PKG_CACHE_DIR) ; \
 		\
 		files=$$$$($(FIND) ./ \
 			-type d -a \( -path './.git' -o -path './$(GO_PKG_WORK_DIR_NAME)' \) -prune -o \
@@ -268,7 +266,7 @@ define GoPackage/Build/Compile
 		cd $(GO_PKG_BUILD_DIR) ; \
 		export GOPATH=$(GO_PKG_BUILD_DIR) \
 			GOCACHE=$(GO_PKG_CACHE_DIR) \
-			GOTMPDIR=$(GO_PKG_TMP_DIR) \
+			GOENV=off \
 			GOROOT_FINAL=$(GO_TARGET_ROOT) \
 			CC=$(TARGET_CC) \
 			CXX=$(TARGET_CXX) \

--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -10,7 +10,7 @@ include ../golang-version.mk
 
 PKG_NAME:=golang
 PKG_VERSION:=$(GO_VERSION_MAJOR_MINOR)$(if $(GO_VERSION_PATCH),.$(GO_VERSION_PATCH))
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 GO_SOURCE_URLS:=https://dl.google.com/go/ \
                 https://mirrors.ustc.edu.cn/golang/ \
@@ -33,10 +33,12 @@ PKG_USE_MIPS16:=0
 PKG_GO_WORK_DIR:=$(PKG_BUILD_DIR)/.go_work
 PKG_GO_HOST_CACHE_DIR:=$(PKG_GO_WORK_DIR)/host_cache
 PKG_GO_TARGET_CACHE_DIR:=$(PKG_GO_WORK_DIR)/target_cache
-PKG_GO_TMP_DIR:=$(PKG_GO_WORK_DIR)/tmp
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/go-$(PKG_VERSION)
 HOST_BUILD_PARALLEL:=1
+
+HOST_GO_WORK_DIR:=$(HOST_BUILD_DIR)/.go_work
+HOST_GO_CACHE_DIR:=$(HOST_GO_WORK_DIR)/cache
 
 HOST_GO_PREFIX:=$(STAGING_DIR_HOSTPKG)
 HOST_GO_VERSION_ID:=cross
@@ -68,6 +70,8 @@ BOOTSTRAP_SOURCE_URL:=$(GO_SOURCE_URLS)
 BOOTSTRAP_HASH:=f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52
 
 BOOTSTRAP_BUILD_DIR:=$(HOST_BUILD_DIR)/.go_bootstrap
+BOOTSTRAP_WORK_DIR:=$(BOOTSTRAP_BUILD_DIR)/.go_work
+BOOTSTRAP_CACHE_DIR:=$(BOOTSTRAP_WORK_DIR)/cache
 
 BOOTSTRAP_GO_VALID_OS_ARCH:= \
   darwin_386     darwin_amd64 \
@@ -189,13 +193,19 @@ define Host/Compile
 	$(call GoCompiler/Bootstrap/CheckHost,$(BOOTSTRAP_GO_VALID_OS_ARCH))
 	$(call GoCompiler/Host/CheckHost,$(HOST_GO_VALID_OS_ARCH))
 
+	mkdir -p \
+		$(BOOTSTRAP_CACHE_DIR) \
+		$(HOST_GO_CACHE_DIR)
+
 	$(call GoCompiler/Bootstrap/Make, \
+		GOCACHE=$(BOOTSTRAP_CACHE_DIR) \
 		CC=$(HOSTCC_NOCACHE) \
 		CXX=$(HOSTCXX_NOCACHE) \
 	)
 
 	$(call GoCompiler/Host/Make, \
 		GOROOT_BOOTSTRAP=$(BOOTSTRAP_BUILD_DIR) \
+		GOCACHE=$(HOST_GO_CACHE_DIR) \
 		CC=$(HOSTCC_NOCACHE) \
 		CXX=$(HOSTCXX_NOCACHE) \
 	)
@@ -206,6 +216,8 @@ define Host/Compile
 	( \
 		cd $(HOST_BUILD_DIR)/bin ; \
 		$(CP) go go-nopie ; \
+		GOCACHE=$(HOST_GO_CACHE_DIR) \
+		GOENV=off \
 		CC=$(HOSTCC_NOCACHE) \
 		CXX=$(HOSTCXX_NOCACHE) \
 		./go-nopie install -a -buildmode=pie std cmd ; \
@@ -246,15 +258,13 @@ endef
 define Build/Compile
 	mkdir -p \
 		$(PKG_GO_HOST_CACHE_DIR) \
-		$(PKG_GO_TARGET_CACHE_DIR) \
-		$(PKG_GO_TMP_DIR)
+		$(PKG_GO_TARGET_CACHE_DIR)
 
 	@echo "Building target Go first stage"
 
 	$(call GoCompiler/Package/Make, \
 		GOROOT_BOOTSTRAP=$(HOST_GO_ROOT) \
 		GOCACHE=$(PKG_GO_HOST_CACHE_DIR) \
-		GOTMPDIR=$(PKG_GO_TMP_DIR) \
 		GO_GCC_HELPER_CC="$(HOSTCC)" \
 		GO_GCC_HELPER_CXX="$(HOSTCXX)" \
 		GO_GCC_HELPER_PATH=$$$$PATH \
@@ -271,7 +281,7 @@ define Build/Compile
 		$(CP) go go-host ; \
 		GOROOT_FINAL=$(GO_TARGET_ROOT) \
 		GOCACHE=$(PKG_GO_TARGET_CACHE_DIR) \
-		GOTMPDIR=$(PKG_GO_TMP_DIR) \
+		GOENV=off \
 		GO_GCC_HELPER_CC="$(TARGET_CC)" \
 		GO_GCC_HELPER_CXX="$(TARGET_CXX)" \
 		GO_GCC_HELPER_PATH=$$$$PATH \


### PR DESCRIPTION
Maintainer: me
Compile tested: armvirt-64, 2020-02-03 snapshot sdk
Run tested: N/A

Description:
* Set `GOENV=off` when building Go compiler and packages, to ignore user's environment configuration file
* Set `GOCACHE` when building host Go
* Unset `GOTMPDIR`, to use the buildroot temp directory instead of temp directories in `build_dir`

Signed-off-by: Jeffery To <jeffery.to@gmail.com>