### PR TITLE
libreswan: fix compilation with musl

### DIFF
--- a/net/libreswan/Makefile
+++ b/net/libreswan/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libreswan
 PKG_VERSION:=3.29
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.libreswan.org/

--- a/net/libreswan/patches/020-limits.patch
+++ b/net/libreswan/patches/020-limits.patch
@@ -1,0 +1,20 @@
+--- a/programs/pluto/connections.c
++++ b/programs/pluto/connections.c
+@@ -34,6 +34,7 @@
+ #include <stdio.h>
+ #include <stddef.h>
+ #include <stdlib.h>
++#include <limits.h>
+ #include <unistd.h>
+ #include <netinet/in.h>
+ #include <sys/socket.h>
+--- a/programs/pluto/rcv_whack.c
++++ b/programs/pluto/rcv_whack.c
+@@ -36,6 +36,7 @@
+ #include <resolv.h>
+ #include <fcntl.h>
+ #include <unistd.h>		/* for gethostname() */
++#include <limits.h>
+ 
+ #include <libreswan.h>
+ #include "libreswan/pfkeyv2.h"


### PR DESCRIPTION
Added missing limits header. This is normally included in fortify-headers,
which I have disabled locally.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @lucize 
Compile tested: multiple