### PR TITLE
zerotier: fix compilation with libcxx

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
 PKG_VERSION:=1.4.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?

--- a/net/zerotier/patches/010-mangix.patch
+++ b/net/zerotier/patches/010-mangix.patch
@@ -1,0 +1,10 @@
+--- a/osdep/LinuxNetLink.hpp
++++ b/osdep/LinuxNetLink.hpp
+@@ -18,6 +18,7 @@
+ 
+ #ifdef __LINUX__
+ 
++#include <cerrno>
+ #include <vector>
+ 
+ #include <sys/socket.h>


### PR DESCRIPTION
Missing header.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mwarning 
Compile tested: multiple

https://github.com/zerotier/ZeroTierOne/pull/1110