### PR TITLE
ttyd: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/utils/ttyd/Makefile
+++ b/utils/ttyd/Makefile
@@ -9,18 +9,18 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ttyd
 PKG_VERSION:=1.5.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/tsl0922/ttyd/tar.gz/$(PKG_VERSION)?
 PKG_HASH:=b5b62ec2ce08add0173e6d1dfdd879e55f02f9490043e89f389981a62e87d376
 
+PKG_MAINTAINER:=Shuanglei Tao <tsl0922@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Shuanglei Tao <tsl0922@gmail.com>
 
+PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=vim/host
-CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk

--- a/utils/ttyd/patches/200-openssl.patch
+++ b/utils/ttyd/patches/200-openssl.patch
@@ -1,0 +1,9 @@
+--- a/src/http.c
++++ b/src/http.c
+@@ -1,5 +1,6 @@
+ #include <string.h>
+ #include <libwebsockets.h>
++#include <openssl/ssl.h>
+ 
+ #include "server.h"
+ #include "html.h"


### PR DESCRIPTION
Removed CMAKE_INSTALL as there's no need for InstallDev.

Added PKG_BUILD_PARALLEL for faster compilation.

Small cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tsl0922 
Compile tested: multiple