### PR TITLE
ariang: use new configuration of Nginx

### DIFF
--- a/net/ariang/Makefile
+++ b/net/ariang/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ariang
 PKG_VERSION:=1.1.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://codeload.github.com/mayswind/AriaNg-DailyBuild/tar.gz/$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/ariang/files/80_ariang-nginx-support
+++ b/net/ariang/files/80_ariang-nginx-support
@@ -1,17 +1,5 @@
 #!/bin/sh
 
-
-if [ -f "/etc/nginx/nginx.conf" ] && [ -f "/etc/nginx/conf.d/ariang.locations" ];
-then
-	if [ "$( grep 'server_name  localhost;' < /etc/nginx/nginx.conf)" ] && 
-	[ ! "$( grep 'include conf.d/ariang.locations;' < /etc/nginx/nginx.conf)" ]; then
-		sed -i '/server_name  localhost;/\
-			a\\tinclude conf.d/ariang.locations;' /etc/nginx/nginx.conf
-		if [ -f /var/run/nginx.pid ]; then
-			/etc/init.d/nginx restart
-		fi
-	fi
-fi
+[ -x /etc/init.d/nginx ] && /etc/init.d/nginx running && /etc/init.d/nginx reload
 
 exit 0
-


### PR DESCRIPTION
Maintainer: @Ansuel
Compile tested: MIPS 74K, Asus RT-N16, master snapshot
Run tested: MIPS 74K, Asus RT-N16, master snapshot, open http://192.168.1.1/ariang/

Description: Remove the superfluous parts of the uci-defaults file, which does nothing anymore. The new configuration for Nginx enables the `/etc/nginx/conf.d/ariang.locations` by default for the LAN.
