### PR TITLE
uwsgi-cgi: re-add dummy package fixing upgrade

### DIFF
--- a/net/uwsgi-cgi/Makefile
+++ b/net/uwsgi-cgi/Makefile
@@ -1,0 +1,46 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=uwsgi-cgi
+PKG_VERSION:=2.0.18
+PKG_RELEASE:=4
+
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/uwsgi-cgi
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
+  TITLE:=The uWSGI server
+  URL:=https://projects.unbit.it/uwsgi
+  DEPENDS:=+uwsgi +uwsgi-cgi-plugin
+endef
+
+define Package/uwsgi-cgi-luci-support
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Web Servers/Proxies
+  TITLE:=Support files for LuCI on Nginx
+  DEPENDS:=+uwsgi-cgi-plugin +uwsgi-syslog-plugin
+endef
+
+define Build/Compile
+endef
+
+define Package/uwsgi-cgi/description
+	The uWSGI project build with cgi profile
+endef
+
+define Package/uwsgi-cgi/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+endef
+
+define Package/uwsgi-cgi-luci-support/install
+	$(INSTALL_DIR) $(1)/etc/uwsgi/vassals
+endef
+
+$(eval $(call BuildPackage,uwsgi-cgi))
+$(eval $(call BuildPackage,uwsgi-cgi-luci-support))


### PR DESCRIPTION
Maintainer: @Ansuel 
Compile tested: x86_64, qemu, master snapshot
Run tested: x86_64, qemu, master snapshot, upgrade uwsgi-cgi

Description: This package has a higher PKG_RELEASE number as before. The old package was removed in favor of the modular build of uwsgi. Now just add DEPENDS on the new modular package. So the upgrade should work more smoothly avoiding problems as seen in #10134 (2 issue).
