### PR TITLE
nginx: fix endianness issue with http2

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.17.7
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
@@ -360,6 +360,8 @@ ifeq ($(CONFIG_NGINX_LUA),y)
   CONFIGURE_VARS += LUA_INC=$(STAGING_DIR)/usr/include \
 					LUA_LIB=$(STAGING_DIR)/usr/lib
 endif
+
+CONFIGURE_VARS += CONFIG_BIG_ENDIAN=$(CONFIG_BIG_ENDIAN)
 
 CONFIGURE_ARGS += \
 			--crossbuild=Linux::$(ARCH) \

--- a/net/nginx/patches/104-endianness_fix.patch
+++ b/net/nginx/patches/104-endianness_fix.patch
@@ -1,0 +1,21 @@
+diff --git a/auto/endianness b/auto/endianness
+index 1b552b6b..2b6f9ea4 100644
+--- a/auto/endianness
++++ b/auto/endianness
+@@ -12,6 +12,16 @@ checking for system byte ordering
+ 
+ END
+ 
++if [ "${CONFIG_BIG_ENDIAN}" != "y" ]; then
++    echo " little endian"
++    have=NGX_HAVE_LITTLE_ENDIAN . auto/have
++else
++    echo " big endian"
++fi
++
++return
++
++
+ 
+ cat << END > $NGX_AUTOTEST.c
+ 


### PR DESCRIPTION
Maintainer: @Ansuel @heil 
Compile tested: x86_64, qemu, master snapshot
Run tested: x86_64, qemu, master snapshot, serve ariang-nginx

Description: Patch the `auto/endianess` file to use `CONFIG_BIG_ENDIAN` from the Makefile. This fixes the issue #8988.

<strike>**TODO:** Test for big endian system.</strike> (tested in qemu with malta-be)