### PR TITLE
freeradius3: Fix proxy.conf file conflict and enable the rlm_python and rlm_python3 modules

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -345,7 +345,6 @@ define Package/freeradius3-mod-realm
 endef
 
 define Package/freeradius3-mod-realm/conffiles
-/etc/freeradius3/proxy.conf
 /etc/freeradius3/mods-available/realm
 /etc/freeradius3/mods-enabled/realm
 endef

--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=release_3_0_20
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive
@@ -27,7 +27,11 @@ PKG_CONFIG_DEPENDS := \
   FREERADIUS3_OPENSSL \
   FREERADIUS3_NOSSL
 
+CFLAGS += $(FPIC)
+
 include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/feeds/packages/lang/python/python-package.mk
+include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
 
 define Package/freeradius3/config
   source "$(SOURCE)/Config.in"
@@ -338,6 +342,26 @@ define Package/freeradius3-mod-preprocess/conffiles
 /etc/freeradius3/mods-enabled/preprocess
 endef
 
+define Package/freeradius3-mod-python
+  $(call Package/freeradius3/Default)
+  DEPENDS:=freeradius3 +python
+  TITLE:=Python module
+endef
+
+define Package/freeradius3-mod-python/conffiles
+/etc/freeradius3/mods-available/python
+endef
+
+define Package/freeradius3-mod-python3
+  $(call Package/freeradius3/Default)
+  DEPENDS:=freeradius3 +python3
+  TITLE:=Python3 module
+endef
+
+define Package/freeradius3-mod-python3/conffiles
+/etc/freeradius3/mods-available/python3
+endef
+
 define Package/freeradius3-mod-realm
   $(call Package/freeradius3/Default)
   DEPENDS:=freeradius3
@@ -488,7 +512,6 @@ CONFIGURE_ARGS+= \
 	--without-rlm_opendirectory \
 	--without-rlm_pam \
 	--without-rlm_perl \
-	--without-rlm_python \
 	--without-rlm_redis \
 	--without-rlm_rediswho \
 	--without-rlm_rest \
@@ -552,6 +575,32 @@ ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-eap-pwd),)
   CONFIGURE_LIBS+= -lcrypto -lssl
 else
   CONFIGURE_ARGS+= --without-rlm_eap_pwd
+endif
+
+ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-python),)
+  CFLAGS+= -fPIC
+  CONFIGURE_ARGS+= \
+		--with-rlm_python \
+		--with-rlm-python-include-dir="$(PYTHON_INC_DIR)" \
+		--with-rlm-python-lib-dir="$(PYTHON_LIB_DIR)"
+  CONFIGURE_VARS+= \
+		OPENWRTTARGET_PY_PREFIX="$(PYTHON_DIR)" \
+		OPENWRTTARGET_PY_SYS_VERSION="$(PYTHON_VERSION)"
+else
+  CONFIGURE_ARGS+= --without-rlm_python
+endif
+
+ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-python3),)
+  CFLAGS+= -fPIC
+  CONFIGURE_ARGS+= \
+		--with-modules="rlm_python3" \
+		--with-rlm-python3-include-dir="$(PYTHON3_INC_DIR)" \
+		--with-rlm-python3-lib-dir="$(PYTHON3_LIB_DIR)"
+  CONFIGURE_VARS+= \
+		OPENWRTTARGET_PY3_PREFIX="$(PYTHON3_DIR)" \
+		OPENWRTTARGET_PY3_SYS_VERSION="$(PYTHON3_VERSION)"
+else
+  CONFIGURE_ARGS+= --without-rlm_python3
 endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-sql),)
@@ -740,6 +789,10 @@ $(eval $(call BuildPlugin,freeradius3-mod-mschap,rlm_mschap,))
 $(eval $(call BuildPlugin,freeradius3-mod-pap,rlm_pap,))
 $(eval $(call BuildPlugin,freeradius3-mod-passwd,rlm_passwd,))
 $(eval $(call BuildPlugin,freeradius3-mod-preprocess,rlm_preprocess,))
+$(eval $(call PyPackage,freeradius3-mod-python))
+$(eval $(call BuildPlugin,freeradius3-mod-python,rlm_python,))
+$(eval $(call Py3Package,freeradius3-mod-python3))
+$(eval $(call BuildPlugin,freeradius3-mod-python3,rlm_python3,))
 $(eval $(call BuildPlugin,freeradius3-mod-radutmp,rlm_radutmp,))
 $(eval $(call BuildPlugin,freeradius3-mod-realm,rlm_realm,))
 $(eval $(call BuildPlugin,freeradius3-mod-sql,rlm_sql,))

--- a/net/freeradius3/patches/004-fix-target-python-header-detection.patch
+++ b/net/freeradius3/patches/004-fix-target-python-header-detection.patch
@@ -1,0 +1,80 @@
+--- a/src/modules/rlm_python/configure
++++ b/src/modules/rlm_python/configure
+@@ -2928,15 +2928,15 @@ fi
+ 
+ 
+ 	if test x$fail = x; then
+-		PY_PREFIX=`${PYTHON_BIN} -c 'import sys ; print(sys.prefix)'`
++		PY_PREFIX="$OPENWRTTARGET_PY_PREFIX"
+ 		{ $as_echo "$as_me:${as_lineno-$LINENO}: Python sys.prefix \"${PY_PREFIX}\"" >&5
+ $as_echo "$as_me: Python sys.prefix \"${PY_PREFIX}\"" >&6;}
+ 
+-		PY_EXEC_PREFIX=`${PYTHON_BIN} -c 'import sys ; print(sys.exec_prefix)'`
++		PY_EXEC_PREFIX="$OPENWRTTARGET_PY_PREFIX"
+ 		{ $as_echo "$as_me:${as_lineno-$LINENO}: Python sys.exec_prefix \"${PY_EXEC_PREFIX}\"" >&5
+ $as_echo "$as_me: Python sys.exec_prefix \"${PY_EXEC_PREFIX}\"" >&6;}
+ 
+-		PY_SYS_VERSION=`${PYTHON_BIN} -c 'import sys ; print(sys.version[0:3])'`
++		PY_SYS_VERSION="$OPENWRTTARGET_PY_SYS_VERSION"
+ 		{ $as_echo "$as_me:${as_lineno-$LINENO}: Python sys.version \"${PY_SYS_VERSION}\"" >&5
+ $as_echo "$as_me: Python sys.version \"${PY_SYS_VERSION}\"" >&6;}
+ 
+--- a/src/modules/rlm_python/configure.ac
++++ b/src/modules/rlm_python/configure.ac
+@@ -65,13 +65,13 @@ if test x$with_[]modname != xno; then
+ 	)
+ 
+ 	if test x$fail = x; then
+-		PY_PREFIX=`${PYTHON_BIN} -c 'import sys ; print(sys.prefix)'`
++		PY_PREFIX="$OPENWRTTARGET_PY_PREFIX"
+ 		AC_MSG_NOTICE([Python sys.prefix \"${PY_PREFIX}\"])
+ 
+-		PY_EXEC_PREFIX=`${PYTHON_BIN} -c 'import sys ; print(sys.exec_prefix)'`
++		PY_EXEC_PREFIX="$OPENWRTTARGET_PY_PREFIX"
+ 		AC_MSG_NOTICE([Python sys.exec_prefix \"${PY_EXEC_PREFIX}\"])
+ 
+-		PY_SYS_VERSION=`${PYTHON_BIN} -c 'import sys ; print(sys.version[[0:3]])'`
++		PY_SYS_VERSION="$OPENWRTTARGET_PY_SYS_VERSION"
+ 		AC_MSG_NOTICE([Python sys.version \"${PY_SYS_VERSION}\"])
+ 
+ 		if test "x$PY_LIB_DIR" = "x"; then
+--- a/src/modules/rlm_python3/configure
++++ b/src/modules/rlm_python3/configure
+@@ -2928,15 +2928,15 @@ fi
+ 
+ 
+ 	if test x$fail = x; then
+-		PY_PREFIX=`${PYTHON3_BIN} -c 'import sys ; print(sys.prefix)'`
++		PY_PREFIX="$OPENWRTTARGET_PY3_PREFIX"
+ 		{ $as_echo "$as_me:${as_lineno-$LINENO}: Python sys.prefix \"${PY_PREFIX}\"" >&5
+ $as_echo "$as_me: Python sys.prefix \"${PY_PREFIX}\"" >&6;}
+ 
+-		PY_EXEC_PREFIX=`${PYTHON3_BIN} -c 'import sys ; print(sys.exec_prefix)'`
++		PY_EXEC_PREFIX="$OPENWRTTARGET_PY3_PREFIX"
+ 		{ $as_echo "$as_me:${as_lineno-$LINENO}: Python sys.exec_prefix \"${PY_EXEC_PREFIX}\"" >&5
+ $as_echo "$as_me: Python sys.exec_prefix \"${PY_EXEC_PREFIX}\"" >&6;}
+ 
+-		PY_SYS_VERSION=`${PYTHON3_BIN} -c 'import sys ; print(sys.version[0:3])'`
++		PY_SYS_VERSION="$OPENWRTTARGET_PY3_SYS_VERSION"
+ 		{ $as_echo "$as_me:${as_lineno-$LINENO}: Python sys.version \"${PY_SYS_VERSION}\"" >&5
+ $as_echo "$as_me: Python sys.version \"${PY_SYS_VERSION}\"" >&6;}
+ 
+--- a/src/modules/rlm_python3/configure.ac
++++ b/src/modules/rlm_python3/configure.ac
+@@ -65,13 +65,13 @@ if test x$with_[]modname != xno; then
+ 	)
+ 
+ 	if test x$fail = x; then
+-		PY_PREFIX=`${PYTHON3_BIN} -c 'import sys ; print(sys.prefix)'`
++		PY_PREFIX="$OPENWRTTARGET_PY3_PREFIX"
+ 		AC_MSG_NOTICE([Python sys.prefix \"${PY_PREFIX}\"])
+ 
+-		PY_EXEC_PREFIX=`${PYTHON3_BIN} -c 'import sys ; print(sys.exec_prefix)'`
++		PY_EXEC_PREFIX="$OPENWRTTARGET_PY3_PREFIX"
+ 		AC_MSG_NOTICE([Python sys.exec_prefix \"${PY_EXEC_PREFIX}\"])
+ 
+-		PY_SYS_VERSION=`${PYTHON3_BIN} -c 'import sys ; print(sys.version[[0:3]])'`
++		PY_SYS_VERSION="$OPENWRTTARGET_PY3_SYS_VERSION"
+ 		AC_MSG_NOTICE([Python sys.version \"${PY_SYS_VERSION}\"])
+ 
+ 		if test "x$PY_LIB_DIR" = "x"; then


### PR DESCRIPTION
Maintainer: no maintainer at this time
Compile tested: ARM, Linksys EA3500, master
Run tested: No

Description:
- Fix proxy.conf file conflict. This closes #11169.
- Enable the rlm_python and rlm_python3 modules. This closes #9572.