### PR TITLE
mariadb: follow up on CVE-2020-7221

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
 PKG_VERSION:=10.4.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := \
@@ -559,7 +559,8 @@ endef
 define Package/mariadb-server-plugin-auth-pam/postinst
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-  chown mariadb /usr/lib/mariadb/plugin/auth_pam_tool_dir > /dev/null 2>&1
+  chown root:mariadb /usr/lib/mariadb/plugin/auth_pam_tool_dir > /dev/null 2>&1
+  chmod 0750 /usr/lib/mariadb/plugin/auth_pam_tool_dir > /dev/null 2>&1
 fi
 exit 0
 endef


### PR DESCRIPTION
Today CVE-2020-7221 was publicly discussed on oss-sec [1]. MariaDB
upstream had not mentioned this CVE in their last release notes. The CVE
is related to auth-pam and the possibility of a local mariadb to root
user exploit in the mysql_install_db script.

Upstream has made amendments to the script, but according to the oss-sec
posts the folder permissions were not updated as they should have been.

In OpenWrt the script mysql_install_db is actually patched to never run
the commands in question. This has been this way since MariaDB 10.4 was
made available.

Still, the directory permissions set by the postinstall script are too
lax. To quote the discoverer of the issue, Matthias Gerstner from Suse,
they exhibit "the dangerous situation of a setuid-root binary residing
in a directory owned by an unprivileged user".

This commit fixes this by changing the permissions to the following:

root:mariadb  0750 /usr/lib/mariadb/plugin/auth_pam_tool_dir

This way the setuid-root binary is only available to root and the
mariadb user, while at the same time the mariadb user has no ownership
of the directory.

[1] https://seclists.org/oss-sec/2020/q1/55

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: master ath79
Run tested: ath79 19.07

Description:
Hi all,

CVE fixup for mariadb.

Kind regards,
Seb
