### PR TITLE
apache: apr update + configure vars

### DIFF
--- a/libs/apr-util/Makefile
+++ b/libs/apr-util/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apr-util
 PKG_VERSION:=1.6.1
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@APACHE/apr/
@@ -106,7 +106,13 @@ endif
 
 CONFIGURE_VARS += \
 	ac_cv_path_ODBC_CONFIG= \
+	apu_cv_weak_symbols=yes \
 	APR_BUILD_DIR="$(STAGING_DIR)/usr/share/build-1"
+
+ifeq ($(CONFIG_USE_GLIBC)$(CONFIG_USE_MUSL),y)
+CONFIGURE_VARS += \
+	apu_cv_explicit_bzero=yes
+endif
 
 define Package/libaprutil/install/driver
 	$(INSTALL_DIR) $(1)/usr/lib/apr-util-1
@@ -135,10 +141,9 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/include/apr-1 \
-				$(1)/usr/lib/pkgconfig
+		$(1)/usr/lib/apr-util-1 $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/apu-1-config $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/apr-1/* $(1)/usr/include/apr-1
-	$(INSTALL_DIR) $(1)/usr/lib/apr-util-1
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/apr-util-1/apr_*.{a,so} \
 			$(1)/usr/lib/apr-util-1 2>/dev/null || :
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libaprutil-1.{a,so*} \

--- a/libs/apr/Makefile
+++ b/libs/apr/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apr
-PKG_VERSION:=1.6.5
-PKG_RELEASE:=5
+PKG_VERSION:=1.7.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@APACHE/apr/
-PKG_HASH:=a67ca9fcf9c4ff59bce7f428a323c8b5e18667fdea7b0ebad47d194371b0a105
+PKG_HASH:=e2e148f0b2e99b8e5c6caa09f6d4fb4dd3e83f744aa72a952f94f5a14436f7ea
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
 		Sebastian Kemper <sebastian_ml@gmx.net>

--- a/libs/apr/Makefile
+++ b/libs/apr/Makefile
@@ -44,11 +44,18 @@ CONFIGURE_ARGS += \
 	$(call autoconf_bool,CONFIG_IPV6,ipv6)
 
 # XXX: ac_cv_sizeof_struct_iovec=1 is just to trick configure
+# XXX: don't set apr_cv_use_lfs64=yes, see
+#      https://www.openwall.com/lists/musl/2020/02/03/18
+# XXX: the atomic builtins used require 8-byte intrinsics, which are available
+#      on all 64-bit architectures and some arm as well as x86 32-bit platforms
 CONFIGURE_VARS += \
+	ap_cv_atomic_builtins=$(if $(CONFIG_ARCH_64BIT),yes,no) \
 	ac_cv_file__dev_zero=yes \
 	ac_cv_func_pthread_mutexattr_setpshared=yes \
 	ac_cv_func_sem_open=yes \
 	ac_cv_func_setpgrp_void=yes \
+	ac_cv_mmap__dev_zero=yes \
+	ac_cv_negative_eai=yes \
 	ac_cv_o_nonblock_inherited=no \
 	ac_cv_sizeof_struct_iovec=1 \
 	ac_cv_struct_rlimit=yes \
@@ -56,12 +63,18 @@ CONFIGURE_VARS += \
 	apr_cv_dup3=yes \
 	apr_cv_epoll=yes \
 	apr_cv_epoll_create1=yes \
+	apr_cv_gai_addrconfig=yes \
 	apr_cv_mutex_recursive=yes \
 	apr_cv_mutex_robust_shared=yes \
 	apr_cv_process_shared_works=yes \
+	apr_cv_pthreads_lib=-lpthread \
 	apr_cv_sock_cloexec=yes \
-	apr_cv_tcp_nodelay_with_cork=yes \
-	apr_cv_use_lfs64=yes
+	apr_cv_tcp_nodelay_with_cork=yes
+
+ifeq ($(call qstrip,$(CONFIG_LIBC)),musl)
+CONFIGURE_VARS += \
+	ac_cv_strerror_r_rc_int=yes
+endif
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/include/apr-1 \

--- a/libs/apr/patches/001-cross-compile.patch
+++ b/libs/apr/patches/001-cross-compile.patch
@@ -40,7 +40,7 @@ Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
  
  # get substituted into some targets
  APR_MAJOR_VERSION=@APR_MAJOR_VERSION@
-@@ -137,8 +139,13 @@ tools/gen_test_char.lo: tools/gen_test_c
+@@ -136,8 +138,13 @@ tools/gen_test_char.lo: tools/gen_test_c
  	$(APR_MKDIR) tools
  	$(LT_COMPILE)
  

--- a/libs/apr/patches/002-sys-param-h.patch
+++ b/libs/apr/patches/002-sys-param-h.patch
@@ -7,7 +7,7 @@ Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
 
 --- a/configure.in
 +++ b/configure.in
-@@ -1593,6 +1593,7 @@ AC_SUBST(stdlibh)
+@@ -1596,6 +1596,7 @@ AC_SUBST(stdlibh)
  AC_SUBST(stringh)
  AC_SUBST(stringsh)
  AC_SUBST(sys_ioctlh)
@@ -17,15 +17,15 @@ Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
  AC_SUBST(sys_socketh)
 --- a/include/apr.h.in
 +++ b/include/apr.h.in
-@@ -94,6 +94,7 @@
- #define APR_HAVE_STRING_H        @stringh@
+@@ -95,6 +95,7 @@
  #define APR_HAVE_STRINGS_H       @stringsh@
+ #define APR_HAVE_INTTYPES_H      @inttypesh@
  #define APR_HAVE_SYS_IOCTL_H     @sys_ioctlh@
 +#define APR_HAVE_SYS_PARAM_H     @sys_paramh@
  #define APR_HAVE_SYS_SENDFILE_H  @sys_sendfileh@
  #define APR_HAVE_SYS_SIGNAL_H    @sys_signalh@
  #define APR_HAVE_SYS_SOCKET_H    @sys_socketh@
-@@ -201,6 +202,9 @@
+@@ -218,6 +219,9 @@
  #ifdef __cplusplus
  extern "C" {
  #endif

--- a/libs/apr/patches/301-apr-fix-off_t-size-doesn-t-match-in-glibc-when-cross.patch
+++ b/libs/apr/patches/301-apr-fix-off_t-size-doesn-t-match-in-glibc-when-cross.patch
@@ -35,7 +35,7 @@ Upstream-Status: Pending
 
 --- a/configure.in
 +++ b/configure.in
-@@ -1785,7 +1785,7 @@ else
+@@ -1809,7 +1809,7 @@ else
      socklen_t_value="int"
  fi
  
@@ -44,25 +44,25 @@ Upstream-Status: Pending
  
  if test "$ac_cv_sizeof_pid_t" = "$ac_cv_sizeof_short"; then
      pid_t_fmt='#define APR_PID_T_FMT "hd"'
-@@ -1854,7 +1854,7 @@ APR_CHECK_TYPES_COMPATIBLE(ssize_t, long
- APR_CHECK_TYPES_COMPATIBLE(size_t, unsigned int, [size_t_fmt="u"])
- APR_CHECK_TYPES_COMPATIBLE(size_t, unsigned long, [size_t_fmt="lu"])
+@@ -1881,7 +1881,7 @@ APR_CHECK_TYPES_FMT_COMPATIBLE(size_t, u
+ APR_CHECK_TYPES_FMT_COMPATIBLE(size_t, unsigned int, u, [size_t_fmt="u"])
+ ])
  
 -APR_CHECK_SIZEOF_EXTENDED([#include <sys/types.h>], ssize_t, 8)
 +AC_CHECK_SIZEOF(ssize_t)
  
+ dnl the else cases below should no longer occur;
  AC_MSG_CHECKING([which format to use for apr_ssize_t])
- if test -n "$ssize_t_fmt"; then
-@@ -1871,7 +1871,7 @@ fi
+@@ -1899,7 +1899,7 @@ fi
  
  ssize_t_fmt="#define APR_SSIZE_T_FMT \"$ssize_t_fmt\""
  
 -APR_CHECK_SIZEOF_EXTENDED([#include <stddef.h>], size_t, 8)
 +AC_CHECK_SIZEOF(size_t)
  
+ # else cases below should no longer occur;
  AC_MSG_CHECKING([which format to use for apr_size_t])
- if test -n "$size_t_fmt"; then
-@@ -1888,7 +1888,7 @@ fi
+@@ -1917,7 +1917,7 @@ fi
  
  size_t_fmt="#define APR_SIZE_T_FMT \"$size_t_fmt\""
  

--- a/libs/apr/patches/302-add-cache-for-strerror_r.patch
+++ b/libs/apr/patches/302-add-cache-for-strerror_r.patch
@@ -1,0 +1,30 @@
+--- a/build/apr_common.m4
++++ b/build/apr_common.m4
+@@ -526,8 +526,9 @@ dnl  string.
+ dnl
+ dnl
+ AC_DEFUN([APR_CHECK_STRERROR_R_RC], [
+-AC_MSG_CHECKING(for type of return code from strerror_r)
+-AC_TRY_RUN([
++AC_CACHE_CHECK([whether return code from strerror_r has type int],
++[ac_cv_strerror_r_rc_int],
++[AC_TRY_RUN([
+ #include <errno.h>
+ #include <string.h>
+ #include <stdio.h>
+@@ -543,14 +544,10 @@ main()
+ }], [
+     ac_cv_strerror_r_rc_int=yes ], [
+     ac_cv_strerror_r_rc_int=no ], [
+-    ac_cv_strerror_r_rc_int=no ] )
++    ac_cv_strerror_r_rc_int=no ] ) ] )
+ if test "x$ac_cv_strerror_r_rc_int" = xyes; then
+   AC_DEFINE(STRERROR_R_RC_INT, 1, [Define if strerror returns int])
+-  msg="int"
+-else
+-  msg="pointer"
+ fi
+-AC_MSG_RESULT([$msg])
+ ] )
+ 
+ dnl

--- a/libs/apr/patches/303-add-cache-for-mmap-zero.patch
+++ b/libs/apr/patches/303-add-cache-for-mmap-zero.patch
@@ -1,0 +1,25 @@
+--- a/configure.in
++++ b/configure.in
+@@ -1191,8 +1191,9 @@ AC_CHECK_FILE(/dev/zero)
+ # Not all systems can mmap /dev/zero (such as HP-UX).  Check for that.
+ if test "$ac_cv_func_mmap" = "yes" &&
+    test "$ac_cv_file__dev_zero" = "yes"; then
+-    AC_MSG_CHECKING(for mmap that can map /dev/zero)
+-    AC_TRY_RUN([
++    AC_CACHE_CHECK([for mmap that can map /dev/zero],
++    [ac_cv_mmap__dev_zero],
++    [AC_TRY_RUN([
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
+@@ -1215,9 +1216,7 @@ if test "$ac_cv_func_mmap" = "yes" &&
+             return 3;
+         }
+         return 0;
+-    }], [], [ac_cv_file__dev_zero=no], [ac_cv_file__dev_zero=no])
+-
+-    AC_MSG_RESULT($ac_cv_file__dev_zero)
++    }], [], [ac_cv_file__dev_zero=no], [ac_cv_file__dev_zero=no])])
+ fi
+ 
+ # Now we determine which one is our anonymous shmem preference.

--- a/net/apache/Makefile
+++ b/net/apache/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apache
 PKG_VERSION:=2.4.41
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_SOURCE_NAME:=httpd
 
 PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.bz2
@@ -268,6 +268,7 @@ CONFIGURE_ARGS+= \
 endif
 
 CONFIGURE_VARS += \
+	ac_cv_gettid=yes \
 	ap_cv_void_ptr_lt_long=no
 
 define Build/Prepare


### PR DESCRIPTION
Maintainer: @heil & me
Compile tested: ath79 master, 19.07.1 x86, bcm2711 master
Run tested: ath79 19.07 with apache as well as subversion-client

Description:
Hi all,

These commits I've been working on in the past few days. apr gets updated to 1.7.0 (it's not a new release, upstream released it in April 2019 already IIRC). And configure variables are added here and there to let the configure scripts know what's supported and what not.

I'm pretty content with the state of apache as such. If the commits are accepted and once the packages are built I'll ask Othmar for another test run on his equipment. Then I'll try to get the commits squashed and backported  to 19.07.

Kind regards,
Seb