### PR TITLE
sqm-scripts: fix hash and simplify Makefile slightly

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (C) 2014 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
@@ -10,15 +10,14 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sqm-scripts
 PKG_SOURCE_VERSION:=ab763cba8b1516b3afa99760e0ca884f8b8d93b8
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=3
-PKG_LICENSE:=GPLv2
+PKG_RELEASE:=4
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_RELEASE).tar.xz
-PKG_MIRROR_HASH:=6e8ce29ba398c14fe679ea95fe03c785d7b5357d515b988360b4cc8be68b7e59
-PKG_SOURCE_URL:=https://github.com/tohojo/sqm-scripts.git
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_RELEASE)
-PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)-$(PKG_RELEASE)
+PKG_SOURCE_URL:=https://github.com/tohojo/sqm-scripts
+PKG_MIRROR_HASH:=43f59dd4c74c5f1634498c18e370c5185110be1084597df37773cecf306e3a24
+
+PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
+PKG_LICENSE:=GPL-2.0-only
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -29,7 +28,6 @@ define Package/sqm-scripts
 	+iptables-mod-ipopt +iptables-mod-conntrack-extra
   TITLE:=SQM Scripts (QoS)
   PKGARCH:=all
-  MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 endef
 
 define Package/sqm-scripts/description
@@ -49,7 +47,6 @@ define Package/luci-app-sqm
   SECTION:=luci
   CATEGORY:=LuCI
   TITLE:=SQM Scripts - LuCI interface
-  MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
   PKGARCH:=all
   DEPENDS:=+luci-compat +sqm-scripts
   SUBMENU:=3. Applications


### PR DESCRIPTION
The previous commit required the hash to be updated.

Removed a bunch of redundant variables.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tohojo 
Compile tested: malta
