### PR TITLE
libhttp-parser: update to v2.9.3

### DIFF
--- a/libs/libhttp-parser/Makefile
+++ b/libs/libhttp-parser/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libhttp-parser
-PKG_VERSION:=2.9.2
-PKG_RELEASE:=2
+PKG_VERSION:=2.9.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/nodejs/http-parser/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=5199500e352584852c95c13423edc5f0cb329297c81dd69c3c8f52a75496da08
+PKG_HASH:=8fa0ab8770fd8425a9b431fdbf91623c4d7a9cdb842b9339289bd2b0b01b0d3d
 PKG_BUILD_DIR:=$(BUILD_DIR)/http-parser-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Ramanathan Sivagurunathan <ramzthecoder@gmail.com>, Hirokazu MORIKAWA <morikw2@gmail.com>

--- a/libs/libhttp-parser/patches/000-fix_darwin_error.patch
+++ b/libs/libhttp-parser/patches/000-fix_darwin_error.patch
@@ -3,7 +3,7 @@
 @@ -25,11 +25,7 @@
  SOMAJOR = 2
  SOMINOR = 9
- SOREV   = 2
+ SOREV   = 3
 -ifeq (darwin,$(PLATFORM))
 -SOEXT ?= dylib
 -SONAME ?= $(SOLIBNAME).$(SOMAJOR).$(SOMINOR).$(SOEXT)
@@ -36,8 +36,8 @@
 +	$(INSTALL) -d $(DESTDIR)$(LIBDIR)
 +	$(INSTALL)    http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
 +	$(INSTALL)    $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
- 	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
- 	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
+ 	ln -sf $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+ 	ln -sf $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
  
  install-strip: library
 -	$(INSTALL) -D  http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
@@ -46,6 +46,6 @@
 +	$(INSTALL) -d $(DESTDIR)$(LIBDIR)
 +	$(INSTALL)    http_parser.h $(DESTDIR)$(INCLUDEDIR)/http_parser.h
 +	$(INSTALL) -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
- 	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
- 	ln -s $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
+ 	ln -sf $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+ 	ln -sf $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SOLIBNAME).$(SOEXT)
  


### PR DESCRIPTION
Maintainer: @ageekymonk, me
 Compile tested: head rr12190-71de48b, aarch64
Run tested: aarch64 (qemu)

Description:
Support multi-coding Transfer-Encoding
CVE-2019-15605: HTTP request smuggling using malformed Transfer-Encoding header.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
