### PR TITLE
ddns-scripts: Fixes issue #11282

### DIFF
--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -282,11 +282,11 @@ write_log() {
 	[ $__LEVEL -eq 7 ] && return	# no syslog for debug messages
 	__CMD=$(echo -e "$__CMD" | tr -d '\n' | tr '\t' '     ')        # remove \n \t chars
 	[ $__EXIT  -eq 1 ] && {
-		eval "$__CMD"	# force syslog before exit
+		eval '$__CMD'	# force syslog before exit
 		exit 1
 	}
 	[ $use_syslog -eq 0 ] && return
-	[ $((use_syslog + __LEVEL)) -le 7 ] && eval "$__CMD"
+	[ $((use_syslog + __LEVEL)) -le 7 ] && eval '$__CMD'
 
 	return
 }


### PR DESCRIPTION
this patch was provided by PaulFertser on the #openwrt IRC.

Maintainer: [No maintainer?](https://github.com/openwrt/packages/blob/master/net/ddns-scripts/Makefile#L18)
Environment: OpenWrt 19.08, Linksys WRT1900ACv1
Run tested: OpenWrt 19.08, Linksys WRT1900ACv1, with no `hostip` installed and running the script via both luci and `sh -x /usr/lib/ddns/dynamic_dns_updater.sh -v 0 -S myddns -- start`

Description:
Fixes the bug in #11282.
`< PaulFertser> Red_M: probably the bug was introduced by e2f73cbd58`