### PR TITLE
openssh: allow multiple config files

### DIFF
--- a/net/openssh/files/sshd.init
+++ b/net/openssh/files/sshd.init
@@ -6,39 +6,51 @@ STOP=50
 
 USE_PROCD=1
 PROG=/usr/sbin/sshd
+CONF=/etc/ssh/sshd_config
+
+get_clients() {
+	local clientid
+	clientid=$(pgrep -P "$1" | xargs)
+	for clientid in $clientid
+	do
+		echo "$clientid"
+		get_clients "$clientid"
+	done
+}
 
 start_service() {
-	for type in rsa ecdsa ed25519
+	for keys in $(awk '/^HostKey / { print "$2" }' $CONF)
 	do
 		# check for keys
-		key=/etc/ssh/ssh_host_${type}_key
-		[ ! -f $key ] && {
+		type=$(echo "$keys" | grep -o 'rsa\|ecdsa\|ed25519')
+		[ -f "$keys" ] || {
 			# generate missing keys
 			[ -x /usr/bin/ssh-keygen ] && {
-				/usr/bin/ssh-keygen -N '' -t $type -f $key 2>&- >&-
+				/usr/bin/ssh-keygen -N '' -t "$type" -f "$keys" 2>&- >&-
 			}
 		}
 	done
 	mkdir -m 0700 -p /var/empty
 
-	local lport=$(awk '/^Port / { print $2; exit }' /etc/ssh/sshd_config)
+	local lport=$(awk '/^Port / { print $2; exit }' $CONF)
 	[ -z "$lport" ] && lport=22
 
 	procd_open_instance
 	procd_add_mdns "ssh" "tcp" "$lport"
-	procd_set_param command $PROG -D
+	procd_set_param pidfile /var/run/sshd-$lport.pid
+	procd_set_param command $PROG -D -f $CONF
 	procd_close_instance
 }
 
 shutdown() {
 	local pid
+	pid=$(pgrep -a -f "$PROG" | grep "$CONF" | awk '{print $1}')
 
 	stop
 
-	# kill active clients
-	for pid in $(pidof sshd)
+	# kill only our active clients
+	for pid in $(get_clients "$pid" | awk '{arr[i++]=$0} END {while (i>0) print arr[--i] }')
 	do
-		[ "$pid" == "$$" ] && continue
-		[ -e "/proc/$pid/stat" ] && kill $pid
+		[ -e "/proc/$pid/stat" ] && kill "$pid"
 	done
 }


### PR DESCRIPTION
The default openssh init file only permits a single sshd instance.
However it is common to implement multiple servers with different
configuration files.
This allows us to define the configuration file sshd uses, permitting
multiple sshd instances.

Signed-off-by: Peter Geis <pgwipeout@gmail.com>

Maintainer: me / @\<tripolar> (find it by checking history of the package Makefile)
Compile tested: (aarch64 armvirt OpenWrt 19.07.1)
Run tested: (aarch64 armvirt OpenWrt 19.07.1)

Description:
Permit multiple sshd instances by defining the config file used.