### PR TITLE
samba4: update to 4.11.6, add new UCI option

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,17 +2,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.11.4
-PKG_RELEASE:=2
+PKG_VERSION:=4.11.6
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://ftp.heanet.ie/mirrors/ftp.samba.org/stable/ \
+PKG_SOURCE_URL:= \
 		https://ftp.gwdg.de/pub/samba/stable/ \
+		https://ftp.heanet.ie/mirrors/ftp.samba.org/stable/ \
 		https://ftp.riken.jp/net/samba/samba/stable/ \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=b95471ba450757109dce65acfe75dafc719c5cc5d464fc65ee442433a461db24
+PKG_HASH:=91438f4d7b71f673421435fa7f26b03b613f214139636ce50af35bc2ff09ef38
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only

--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -27,15 +27,16 @@ smb_header() {
 	local hostname
 	hostname="$(cat /proc/sys/kernel/hostname)"
 
-	config_get workgroup		$1 workgroup	"WORKGROUP"
-	config_get description		$1 description	"Samba on OpenWrt"
-	config_get charset		$1 charset	"UTF-8"
+	config_get workgroup $1 workgroup "WORKGROUP"
+	config_get description $1 description "Samba on OpenWrt"
+	config_get charset $1 charset "UTF-8"
 
-	config_get_bool MACOS		$1 macos		0
-	config_get_bool DISABLE_NETBIOS	$1 disable_netbios	0
-	config_get_bool DISABLE_AD_DC	$1 disable_ad_dc	0
-	config_get_bool DISABLE_WINBIND	$1 disable_winbind	0
-	config_get_bool DISABLE_ASYNC_IO $1 disable_async_io	0
+	config_get_bool MACOS $1 macos 0
+	config_get_bool DISABLE_NETBIOS $1 disable_netbios 0
+	config_get_bool DISABLE_AD_DC $1 disable_ad_dc 0
+	config_get_bool DISABLE_WINBIND $1 disable_winbind 0
+	config_get_bool DISABLE_ASYNC_IO $1 disable_async_io 0
+	config_get_bool ALLOW_LEGACY_PROTOCOLS $1 allow_legacy_protocols 0
 
 	mkdir -p /var/etc
 	sed -e "s#|NAME|#$hostname#g" \
@@ -50,12 +51,19 @@ smb_header() {
 		if [ "$DISABLE_NETBIOS" -eq 1 ] || [ ! -x /usr/sbin/nmbd ]; then
 			printf "\tdisable netbios = yes\n"
 		fi
-		
+
 		if [ "$DISABLE_ASYNC_IO" -eq 1 ]; then
 			printf "\taio read size = 0\n"
 			printf "\taio write size = 0\n"
 			# sendfile bug: https://bugzilla.samba.org/show_bug.cgi?id=14095
 			printf "\tuse sendfile = no\n"
+		fi
+
+		if [ "$ALLOW_LEGACY_PROTOCOLS" -eq 1 ]; then
+			logger -p daemon.info -t 'samba4-server' "Legacy Protocols allowed, don't use this option for secure environments!"
+			printf "\tserver min protocol = NT1\n"
+			printf "\tlanman auth = yes\n"
+			printf "\tntlm auth = ntlmv1-permitted\n"
 		fi
 	} >> /var/etc/smb.conf
 


### PR DESCRIPTION
Maintainer: me
Compile tested: arm (master)
Run tested: arm/mvebu (master)

Description:
* update to 4.11.6
* add new UCI option "allow_legacy_protocols" to section [samba]

Related PR:
openwrt/luci#3619