### PR TITLE
phantap: update to latest commit

### DIFF
--- a/net/phantap/Makefile
+++ b/net/phantap/Makefile
@@ -11,9 +11,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/nccgroup/phantap
-PKG_MIRROR_HASH:=a8bbcdeb3520384ad7a7ff26324143dfd2e1baaf04e32396501dbfc78819287c
-PKG_SOURCE_DATE:=2019.09.18
-PKG_SOURCE_VERSION:=7cc6017ee445885a99d52e556406c07093aa2bb1
+PKG_MIRROR_HASH:=01723a955e975b877f35924d3b5bfa53251f8928abe4657de0ed4c4943d9510c
+PKG_SOURCE_DATE:=2020.02.09
+PKG_SOURCE_VERSION:=fb3be84b4f4e081c35b7d0caa977bc659c02f8f1
 
 PKG_MAINTAINER:=Diana Dragusin <diana.dragusin@nccgroup.com>, \
     Etienne Champetier <champetier.etienne@gmail.com>
@@ -34,7 +34,7 @@ define Package/phantap
   $(call Package/phantap/Default)
   TITLE:=PhanTap
   PKGARCH:=all
-  DEPENDS:=+ebtables +libpcap +ip-full +kmod-br-netfilter +kmod-ebtables-ipv4
+  DEPENDS:=+ebtables +libpcap +libnl-tiny +ip-full +kmod-br-netfilter +kmod-ebtables-ipv4
 endef
 
 define Package/phantap/conffiles
@@ -56,6 +56,7 @@ define Package/phantap/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/etc/hotplug.d/net/00-phantap $(1)/etc/hotplug.d/net/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/init.d/phantap $(1)/etc/init.d/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/init.d/phantap-early $(1)/etc/init.d/
 	$(INSTALL_DIR) $(1)/etc/sysctl.d
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/etc/sysctl.d/12-phantap.conf $(1)/etc/sysctl.d/
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
Maintainer: me
Compile & run tested: ath79 / gl-ar750s

fb3be84 Split out ebtables anti-leak rules in phantap-early, improve logs
e3fbe61 phantap-learn: use libnl instead of ip executable
b2c2514 phantap/Readme: Warn about OpenWrt failsafe leak
394d3b7 Readme: Update to add blogpost link and detection via Internet traffic