### PR TITLE
[19.07] ksmbd: update to 3.1.3, ksmbd-tools: update to 3.2.1, add smb1 support, add avahi support package

### DIFF
--- a/kernel/ksmbd/Makefile
+++ b/kernel/ksmbd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd
-PKG_VERSION:=3.1.1
+PKG_VERSION:=3.1.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/cifsd-team/$(PKG_NAME)/archive/$(PKG_VERSION)/
-PKG_HASH:=5cf00902b77206a56f20b8ec499aea061292a15003bbdd8194fcb2299fb2343e
+PKG_SOURCE_URL:=https://github.com/cifsd-team/cifsd/archive/$(PKG_VERSION)/
+PKG_HASH:=c3c4531d3806117218d23e0552edfe883f978a00b7293180dd2919694102fcb9
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -15,10 +15,13 @@ PKG_LICENSE_FILES:=COPYING
 include $(INCLUDE_DIR)/kernel.mk
 include $(INCLUDE_DIR)/package.mk
 
+TAR_OPTIONS+= --strip-components 1
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
+
 define KernelPackage/fs-ksmbd
 	SUBMENU:=Filesystems
 	TITLE:=SMB kernel server support
-	URL:=https://github.com/cifsd-team/ksmbd
+	URL:=https://github.com/cifsd-team/cifsd
 	FILES:=$(PKG_BUILD_DIR)/ksmbd.ko
 	DEPENDS:= \
 		+kmod-nls-base \
@@ -37,13 +40,28 @@ define KernelPackage/fs-ksmbd
 endef
 
 define KernelPackage/fs-ksmbd/description
-  Ksmbd is an In-kernel SMB2/3 fileserver.
+  Ksmbd is an In-kernel SMBv(1)2/3 fileserver.
   It's an implementation of the SMB protocol in kernel space for sharing files and IPC services over network.
 endef
+
+define KernelPackage/fs-ksmbd/config
+config KSMBD_SMB_INSECURE_SERVER
+	bool "Support for insecure SMB1/CIFS and SMB2.0 protocols"
+	depends on PACKAGE_kmod-fs-ksmbd
+	help
+		This enables deprecated insecure protocols dialects: SMB1/CIFS and SMB2.0.
+	default y
+endef
+
+ifeq ($(CONFIG_KSMBD_SMB_INSECURE_SERVER),y)
+PKG_EXTRA_KCONFIG:=CONFIG_SMB_INSECURE_SERVER=y
+EXTRA_CFLAGS += -DCONFIG_SMB_INSECURE_SERVER=1
+endif
 
 define Build/Compile
 	$(KERNEL_MAKE) SUBDIRS="$(PKG_BUILD_DIR)" \
 	EXTRA_CFLAGS="$(EXTRA_CFLAGS)" \
+	$(PKG_EXTRA_KCONFIG) \
 	CONFIG_SMB_SERVER=m \
 	modules
 endef

--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -1,33 +1,36 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
-PKG_VERSION:=3.1.0
+PKG_VERSION:=3.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/cifsd-team/$(PKG_NAME)/archive/$(PKG_VERSION)/
-PKG_HASH:=7a01b327028cb52824a394dc2c4e706d15145b823fd0ff399c359f7a4c991c4a
+PKG_SOURCE_URL:=https://github.com/cifsd-team/cifsd-tools/archive/$(PKG_VERSION)/
+PKG_HASH:=acb4d97cbb0b22ad42ed1536bdd2c28af2a3c698664c058da59a644d5e6df599
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
 PKG_FIXUP:=autoreconf
+PKG_REMOVE_FILES:=autogen.sh
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_REMOVE_FILES:=autogen.sh
 
 PKG_BUILD_DEPENDS:=glib2
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 
+TAR_OPTIONS+= --strip-components 1
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
+
 define Package/ksmbd-tools/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Filesystem
   TITLE:=Kernel SMB
-  URL:=https://github.com/cifsd-team/ksmbd-tools
+  URL:=https://github.com/cifsd-team/cifsd-tools
   DEPENDS:= $(ICONV_DEPENDS) $(INTL_DEPENDS)
 endef
 
@@ -43,7 +46,7 @@ define Package/ksmbd-server
 endef
 
 define Package/ksmbd-server/description
-  installs: usmbd
+  installs: ksmbd.mountd
 
   This provides the basic fileserver service and is the minimum needed to serve 'guest only' file shares or use a existing user database file ksmbdpwd.db.
 endef
@@ -58,7 +61,7 @@ define Package/ksmbd-utils
 endef
 
 define Package/ksmbd-utils/description
-  installs: smbuseradd (smbshareadd)
+  installs: ksmbd.adduser (ksmbd.addshare)
 
   Tool needed to create the ksmbdpwd.db, to manage per user share passwords.
   NOTE: Not needed for 'guest only' shares.
@@ -66,11 +69,24 @@ endef
 
 define Package/ksmbd-utils/config
 	config KSMBD_UTILS_SHAREADD
-		bool "Add smbshareadd util"
+		bool "Add ksmbd.addshare util"
 		depends on PACKAGE_ksmbd-utils
 		help
-			Add the smbshareadd tool, to directly manipulate the /etc/ksmbd/smb.conf.
+			Add the ksmbd.addshare tool, to directly manipulate the /etc/ksmbd/smb.conf.
 		default n
+endef
+
+define Package/ksmbd-avahi-service
+  $(call Package/ksmbd-tools/Default)
+  TITLE+= (Avahi service)
+  DEPENDS:= +avahi-daemon
+endef
+
+define Package/ksmbd-avahi-service/description
+  installs: smb.service
+
+  This package contains the service definition for announcing the
+  Ksmbd (smb/445) Daemon service via mDNS/DNS-SD.
 endef
 
 CONFIGURE_ARGS += \
@@ -84,7 +100,7 @@ TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed -liconv $(if $(INTL_FULL),-lintl
 
 define Package/ksmbd-server/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/usmbd $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ksmbd.mountd $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/ksmbd $(1)/etc/init.d
 	$(INSTALL_CONF) ./files/ksmbd.config $(1)/etc/config/ksmbd
 	$(INSTALL_DATA) ./files/smb.conf.template $(1)/etc/ksmbd/
@@ -96,10 +112,15 @@ endef
 
 define Package/ksmbd-utils/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/smbuseradd $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ksmbd.adduser $(1)/usr/sbin/
 ifeq ($(CONFIG_KSMBD_UTILS_SHAREADD),y)
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/smbshareadd $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/ksmbd.addshare $(1)/usr/sbin/
 endif
+endef
+
+define Package/ksmbd-avahi-service/install
+	$(INSTALL_DIR) $(1)/etc/avahi/services
+	$(INSTALL_DATA) ./files/smb.service $(1)/etc/avahi/services/
 endef
 
 define Package/ksmbd-server/conffiles
@@ -109,5 +130,10 @@ define Package/ksmbd-server/conffiles
 /etc/ksmbd/ksmbdpwd.db
 endef
 
+define Package/ksmbd-avahi-service/conffiles
+/etc/avahi/services/smb.service
+endef
+
 $(eval $(call BuildPackage,ksmbd-server))
 $(eval $(call BuildPackage,ksmbd-utils))
+$(eval $(call BuildPackage,ksmbd-avahi-service))

--- a/net/ksmbd-tools/files/ksmbd.init
+++ b/net/ksmbd-tools/files/ksmbd.init
@@ -27,14 +27,25 @@ smb_header()
 	local hostname
 	hostname="$(cat /proc/sys/kernel/hostname)"
 
-	config_get workgroup		$1 workgroup	"WORKGROUP"
-	config_get description		$1 description	"Ksmbd on OpenWrt"
+	config_get workgroup $1 workgroup "WORKGROUP"
+	config_get description $1 description "Ksmbd on OpenWrt"
+	config_get_bool ALLOW_LEGACY_PROTOCOLS $1 allow_legacy_protocols 0
 
 	sed -e "s#|NAME|#$hostname#g" \
 	    -e "s#|WORKGROUP|#$workgroup#g" \
 	    -e "s#|DESCRIPTION|#$description#g" \
 	    -e "s#|INTERFACES|#$interfaces#g" \
 	    /etc/ksmbd/smb.conf.template > /var/etc/ksmbd/smb.conf
+		
+	{
+		printf "\n######### Dynamic written config options #########\n"
+
+		if [ "$ALLOW_LEGACY_PROTOCOLS" -eq 1 ]; then
+			logger -p daemon.info -t 'ksmbd' "Legacy Protocols allowed, don't use this option for secure environments!"
+			printf "\tserver min protocol = NT1\n"
+			printf "\tserver signing = disabled\n"
+		fi
+	} >> /var/etc/ksmbd/smb.conf
 
 	[ -e /etc/ksmbd/smb.conf ] || ln -nsf /var/etc/ksmbd/smb.conf /etc/ksmbd/smb.conf
 
@@ -168,7 +179,7 @@ start_service()
 	logger -p daemon.notice -t 'ksmbd' "Starting Ksmbd userspace service."
 	procd_open_instance
 	procd_add_mdns "smb" "tcp" "445"
-	procd_set_param command /usr/sbin/usmbd --n
+	procd_set_param command /usr/sbin/ksmbd.mountd --n
 	procd_set_param file /etc/ksmbd/smb.conf
 	procd_set_param limits nofile=16384
 	procd_close_instance
@@ -177,7 +188,7 @@ start_service()
 stop_service()
 {
 	logger -p daemon.notice -t 'ksmbd' "Stopping Ksmbd userspace service."
-	killall usmbd > /dev/null 2>&1
+	killall ksmbd.mountd > /dev/null 2>&1
 	
 	[ -e /sys/module/ksmbd ] && rmmod ksmbd > /dev/null 2>&1
 	# kill server if we cant rmmod
@@ -188,7 +199,7 @@ stop_service()
 	if [ -e /sys/module/ksmbd ]; then
 		logger -p daemon.error -t 'ksmbd' "module still loaded after kill_server?"
 	fi
-	[ -f /tmp/usmbd.lock ] && rm /tmp/usmbd.lock
+	[ -f /tmp/ksmbd.lock ] && rm /tmp/ksmbd.lock
 }
 
 # reload_service() {

--- a/net/ksmbd-tools/files/smb.service
+++ b/net/ksmbd-tools/files/smb.service
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">%h</name>
+  <service>
+    <type>_smb._tcp</type>
+    <port>445</port>
+  </service>
+</service-group>


### PR DESCRIPTION
Maintainer: me
Compile tested: mips (19.07-master)
Run tested: mips/lantiq (19.07-master)

Description:
* ksmbd: update to 3.1.3
* ksmbd-tools: update to 3.2.1
* add new package build option "KSMBD_SMB_INSECURE_SERVER"
* enable smb1 support to kmod by default
* add new UCI option "allow_legacy_protocols" to section [globals]
* add avahi support package "ksmbd-avahi-service"

```
* ksmbd: release 3.1.3 version
* ksmbd: lock SMB2_QUERY_INFO_HE request with read lock
* ksmbd: fix potential racy between query_dir and ksmbd_vfs_empty_dir
* ksmbd: fix racy issue between deleting file and checking empty directory
* ksmbd: don't register interface which are member of bridge
* ksmbd: SO_REUSEADDR is no property of tcp_setsockopt
* ksmbd: release 3.1.2 version
* ksmbd: fix read caching buffer size as max_read_size
* ksmbd: fix the infinite loop of handling FSCTL_QUERY_ALLOCATED_RANGES
* ksmbd: use compounding for smb2 flush
* ksmbd: downgrade error message to debug in get_file_all_info
* ksmbd: rename usmbd to ksmbd.mountd in trvis-ci
* ksmbd: release 3.1.1 version
* ksmbd: does not work if ipv6 module is not loaded or compiled in
* ksmbd: capsule ifdef CONFIG_SMB_INSECURE_SERVER with smb1 codes
* ksmbd: capsule ifdef CONFIG_SMB_INSECURE_SERVER with smb1 codes
* ksmbd: update README file

* ksmbd-tools: release 3.2.1 version
* ksmbd-tools: revert "remove glib2.0 dependancy" patch
* ksmbd-tools: release 3.2.0 version
* ksmbd-tools: update how to restart ksmbd in README file
* Revert "ksmbd-tools: disable tbuf and rbuf caching by default"
* ksmbd-tools: disable tbuf and rbuf caching by default
* ksmbd-tools: replace usmbd prefix with ksmbd prefix
* ksmbd-tools: update README file
* ksmbd-tools: fix warning ignoring return value of 'fread'
* ksmbd-tools: downgrade unsupported command print to debug
* ksmbd-tools: remove GLIB_LIBS in Makefiles
* ksmbd-tools: rename usmbd, smbuseradd, smbshareadd to ksmbd.mountd, ksmbd.adduser and ksmbd.addshare
* ksmbd-tools: fix null pointer dereference in _list_remove
* ksmbd-tools: fix the sanity check fails depending on the password length
* ksmbd-tools: fix build error(not found glib.h)
* ksmbd-tools: remove glib-2.0 dependancy
* ksmbd-tools: update README to add libglib2.0-dev for Ubuntu preprequisite packages
```