### PR TITLE
collectd: lcdringer: apply brcm2708 target rename to bcm27xx to dependencies

### DIFF
--- a/net/lcdringer/Makefile
+++ b/net/lcdringer/Makefile
@@ -31,7 +31,7 @@ include $(INCLUDE_DIR)/nls.mk
 define Package/lcdringer
   SECTION:=network
   CATEGORY:=Network
-  DEPENDS:=+libgee +libgstreamer1 +loudmouth @TARGET_brcm2708
+  DEPENDS:=+libgee +libgstreamer1 +loudmouth @TARGET_bcm27xx
   TITLE:=lcdringer
   URL:=https://www.flyn.org/projects/lcdringer/
 endef

--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -368,7 +368,7 @@ $(eval $(call BuildPlugin,chrony,chrony status input,chrony,))
 $(eval $(call BuildPlugin,conntrack,connection tracking table size input,conntrack,))
 $(eval $(call BuildPlugin,contextswitch,context switch input,contextswitch,))
 $(eval $(call BuildPlugin,cpu,CPU input,cpu,))
-$(eval $(call BuildPlugin,cpufreq,CPU Freq input,cpufreq,@(TARGET_x86||TARGET_x86_64||TARGET_mvebu||TARGET_ipq806x||TARGET_armvirt||TARGET_ipq40xx||TARGET_brcm2708_bcm2709))) # Only enable on targets with CPUs supporting frequency scaling
+$(eval $(call BuildPlugin,cpufreq,CPU Freq input,cpufreq,@(TARGET_x86||TARGET_x86_64||TARGET_mvebu||TARGET_ipq806x||TARGET_armvirt||TARGET_ipq40xx||TARGET_bcm27xx_bcm2709))) # Only enable on targets with CPUs supporting frequency scaling
 $(eval $(call BuildPlugin,csv,CSV output,csv,))
 $(eval $(call BuildPlugin,curl,cURL input,curl,+PACKAGE_collectd-mod-curl:libcurl))
 #$(eval $(call BuildPlugin,dbi,relational database input,dbi,+PACKAGE_collectd-mod-dbi:libdbi))


### PR DESCRIPTION
Maintainer: @neheb @hnyman 

I plan to rename the brcm2708 target to bcm27xx in openwrt master [1] (already Acked by noltari) end of this week.

These two patches should fix the only two references in openwrt/packages. I've posted this already to provide a little review time here as well (though patches are trivial).

I'm not sure whether this needs a PKG_RELEASE bump, my tendency goes towards "no", so I haven't included one. Please tell me if you think otherwise.

Although I have the rights I think, I'd be happy if one of the package maintainers would merge this eventually (after the rename has been merged to trunk), so I do not mess around in someone else's place. (I'd just have to click "Merge" in GitHub if I wanted, though?)

[1] https://patchwork.ozlabs.org/patch/1235536/