### PR TITLE
libtins: add patch to fix CH_SWITCH_TIMING value

### DIFF
--- a/libs/libtins/Makefile
+++ b/libs/libtins/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtins
 PKG_VERSION:=4.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mfontanini/libtins/tar.gz/v$(PKG_VERSION)?

--- a/libs/libtins/patches/110-fix_ch_switch_timing_value.patch
+++ b/libs/libtins/patches/110-fix_ch_switch_timing_value.patch
@@ -1,0 +1,11 @@
+--- a/include/tins/dot11/dot11_base.h
++++ b/include/tins/dot11/dot11_base.h
+@@ -182,7 +182,7 @@ public:
+         DMS_RESP,
+         LINK_ID,
+         WAKEUP_SCHEDULE,
+-        CH_SWITCH_TIMING,
++        CH_SWITCH_TIMING = 104,
+         PTI_CONTROL,
+         TPU_BUFFER_STATUS,
+         INTERWORKING,


### PR DESCRIPTION
Signed-off-by: Ilya Tsybulsky <ilya.tsybulsky@gmail.com>

Maintainer: me / @StevenHessing 
Compile tested: (ramips/mt76x8-glibc, TL-MR3020v3.20, OpenWrt master)

Description:
CH_SWITCH_TIMING enumerator's in `include/tins/dot11/dot11_base.h` value is implicitly set to `103` (actually reserved) instead of correct `104`:
https://github.com/mfontanini/libtins/blob/28663b0e933733051bddcc21b2a6e5e5b74c39f9/include/tins/dot11/dot11_base.h#L185

There's an issue reported and a pull request made but not merged for now: mfontanini/libtins#388
