### PR TITLE
pingcheck: Update and add script directories

### DIFF
--- a/net/pingcheck/Makefile
+++ b/net/pingcheck/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pingcheck
-PKG_VERSION:=2019-10-08
-PKG_RELEASE:=2
+PKG_VERSION:=2020-02-12
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MIRROR_HASH:=0bf82809ce36106825d1a757c4624efcbab1829c1a9bf9e1e055e75ebf83403d
+PKG_MIRROR_HASH:=3890cd39add7e523ab7418faf6a7ae1a1f71d2739982e6e09aa33cc6defac8be
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_URL:=https://github.com/br101/pingcheck
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=7223f1b10697735d34f297ca2520495337666df6
+PKG_SOURCE_VERSION:=520718f9377eab49888a3e38ece59f9ad94d978e
 
 PKG_MAINTAINER:=Bruno Randolf <br1@einfach.org>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -53,6 +53,11 @@ define Package/pingcheck/install
 	$(INSTALL_BIN) ./pingcheck.init $(1)/etc/init.d/pingcheck
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/pingcheck.config $(1)/etc/config/pingcheck
+	$(INSTALL_DIR) $(1)/etc/pingcheck/online.d/
+	$(INSTALL_DIR) $(1)/etc/pingcheck/offline.d/
+	$(INSTALL_DIR) $(1)/etc/pingcheck/panic.d/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/example-script.sh $(1)/etc/pingcheck/online.d/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/example-script.sh $(1)/etc/pingcheck/offline.d/
 endef
 
 $(eval $(call BuildPackage,pingcheck))


### PR DESCRIPTION
- Update to version with longer interface names.

- Add /etc/pingcheck/(on|off)line.d/ directories with an example
  script. Closes #11263

Signed-off-by: Bruno Randolf <br1@einfach.org>

Maintainer: me
Compile tested: ar71xx, master
Run tested: ar71xx, master
