### PR TITLE
spoofer: remove host build + cleanups

### DIFF
--- a/net/spoofer/Makefile
+++ b/net/spoofer/Makefile
@@ -19,12 +19,11 @@ PKG_MAINTAINER:=Ken Keys <spoofer-info@caida.org>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_USE_MIPS16:=0
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=protobuf/host
 
-include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
-
-$(eval $(call HostBuild))
 
 define Package/spoofer
   SECTION:=net
@@ -54,19 +53,15 @@ CONFIGURE_ARGS += \
 CONFIGURE_VARS += \
 	PROTOC=$(STAGING_DIR_HOSTPKG)/bin/protoc
 
-EXTRA_CXXFLAGS += -std=gnu++14
-
-SPOOFER_SRC=$(PKG_BUILD_DIR)
-
 define Package/spoofer/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/prober/spoofer-prober $(1)/usr/bin
-	$(INSTALL_BIN) $(SPOOFER_SRC)/openwrt-files/spoofer $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin//spoofer-prober $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwrt-files/spoofer $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/etc/init.d
-	$(INSTALL_BIN) $(SPOOFER_SRC)/openwrt-files/initscript $(1)/etc/init.d/spoofer
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwrt-files/initscript $(1)/etc/init.d/spoofer
 	$(INSTALL_DIR) $(1)/usr/share/spoofer
-	$(INSTALL_DATA) $(SPOOFER_SRC)/gd_bundle.crt $(1)/usr/share/spoofer
-	$(INSTALL_DATA) $(SPOOFER_SRC)/openwrt-files/spoofer-lib.sh $(1)/usr/share/spoofer
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/gd_bundle.crt $(1)/usr/share/spoofer
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/openwrt-files/spoofer-lib.sh $(1)/usr/share/spoofer
 endef
 
 $(eval $(call BuildPackage,spoofer))


### PR DESCRIPTION
The host build is not used by anything.

Added PKG_INSTALL for consistency between packages.

Added PKG_BUILD_PARALLEL for faster compilation.

Added missing protobuf/host build dependency. This was previously
specified as a host dependency, which is wrong.

Removed pointless std parameter.  It's only useful for old G++ versions.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @kenkeys 
Compile tested: ath79

ping @robcore