### PR TITLE
crelay: update to 0.14

### DIFF
--- a/utils/crelay/Makefile
+++ b/utils/crelay/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=crelay
-PKG_VERSION:=0.13
+PKG_VERSION:=0.14
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ondrej1024/crelay/tar.gz/V$(PKG_VERSION)?
-PKG_HASH:=d9919fe91e8641352f0b4705a37acc7ba4b3c4286ca78a629968f16f343cfdc4
+PKG_HASH:=8e406ae8560d8a42b7dd7cf20193e6dce714747f71809e124deadddf78572590
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
@@ -44,11 +44,7 @@ define Package/crelay/description
       - HID API compatible relay card
 endef
 
-define Build/Configure
-endef
-
 TARGET_CFLAGS+= \
-	-D_GNU_SOURCE \
 	-I$(STAGING_DIR)/usr/include/libftdi1 \
 	-I$(STAGING_DIR)/usr/include/hidapi
 


### PR DESCRIPTION
Fix license information.

Small cleanup.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ath79