### PR TITLE
make: update to 4.3

### DIFF
--- a/devel/make/Makefile
+++ b/devel/make/Makefile
@@ -8,17 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=make
-PKG_VERSION:=4.2.1
-PKG_RELEASE:=4
+PKG_VERSION:=4.3
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@GNU/make
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=d6e262bf3601b42d2b1e4ef8310029e1dcf20083c5446b4b7aa67081fdffc589
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_HASH:=e05fdde47c5f7ca45cb697e973894ff4f5d79e13b750ed57d7b66d8defc78e19
+
 PKG_MAINTAINER:=Heinrich Schuchardt <xypron.glpk@gmx.de>
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_CPE_ID:=cpe:/a:gnu:make
 
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -43,7 +45,7 @@ CONFIGURE_VARS += ac_cv_lib_elf_elf_begin=no
 # provide gnumake.h at build time for other packages
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_BUILD_DIR)/gnumake.h $(1)/usr/include/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/gnumake.h $(1)/usr/include/
 endef
 
 $(eval $(call BuildPackage,make))


### PR DESCRIPTION
Switch to gz tarball. bz2 one went away.

Add PKG_BUILD_PARALLEL for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @xypron 
Compile tested: ath79