### PR TITLE
fwknop: init script improvements

### DIFF
--- a/net/fwknop/Makefile
+++ b/net/fwknop/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fwknop
 PKG_VERSION:=2.6.10
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.cipherdyne.org/fwknop/download

--- a/net/fwknop/files/fwknopd.init
+++ b/net/fwknop/files/fwknopd.init
@@ -8,28 +8,29 @@
 USE_PROCD=1
 START=95
 
-. /lib/functions/network.sh
+. "${IPKG_INSTROOT}/lib/functions/network.sh"
 
 FWKNOPD_BIN=/usr/sbin/fwknopd
+FWKNOPD_CFGDIR=/var/etc/fwknop
 
 start_service()
 {
 	generate_configuration
 
-	if [ -n "$DEPEND_IFNAME" ] ; then
+	if [ -n "${DEPEND_IFNAME}" ] ; then
 		# We know the interface, so we can start
 		procd_open_instance
-		procd_set_param command "$FWKNOPD_BIN" --foreground --syslog-enable
+		procd_set_param command "${FWKNOPD_BIN}" --foreground --syslog-enable
 		procd_set_param respawn
-		if [ $UCI_ENABLED -eq 1 ]; then
-			procd_append_param command -c /var/etc/fwknopd.conf
-			procd_append_param command -a /var/etc/access.conf
+		if [ "${UCI_ENABLED}" -eq 1 ]; then
+			procd_append_param command -c "${FWKNOPD_CFGDIR}/fwknopd.conf"
+			procd_append_param command -a "${FWKNOPD_CFGDIR}/access.conf"
 		fi
-		procd_append_param command -i "$DEPEND_IFNAME"
-		procd_set_param netdev "$DEPEND_IFNAME"
+		procd_append_param command -i "${DEPEND_IFNAME}"
+		procd_set_param netdev "${DEPEND_IFNAME}"
 		procd_close_instance
 	else
-		logger -p daemon.info -t "fwknopd[----]" "Postponing start-up of fwknopd, network $NETWORK is not up"
+		logger -p daemon.info -t "fwknopd[$$]" "Postponing start-up of fwknopd, network ${NETWORK} is not up"
 	fi
 }
 
@@ -37,21 +38,21 @@ service_triggers()
 {
 	procd_add_reload_trigger "fwknopd"
 
-	if [ -n "$NETWORK" ] ; then
-		logger -p daemon.info -t "fwknopd[----]" "Listening for changes on network $NETWORK"
-		procd_add_reload_interface_trigger "$NETWORK"
+	if [ -n "${NETWORK}" ] ; then
+		logger -p daemon.info -t "fwknopd[$$]" "Listening for changes on network ${NETWORK}"
+		procd_add_reload_interface_trigger "${NETWORK}"
 	fi
 }
 
 get_bool()
 {
-	local _tmp="$1"
-	case "$_tmp" in
+	local _tmp="${1}"
+	case "${_tmp}" in
 		1|on|true|yes|enabled) _tmp=1;;
 		0|off|false|no|disabled) _tmp=0;;
-		*) _tmp="$2";;
+		*) _tmp="${2}";;
 	esac
-	echo -n "$_tmp"
+	echo -n "${_tmp}"
 }
 
 generate_configuration()
@@ -66,72 +67,65 @@ generate_configuration()
 	local DEFAULT_UCI_NETWORK=wan
 	local DEFAULT_FWKNOPD_IFNAME=
 
-	network_get_device DEFAULT_FWKNOPD_IFNAME $DEFAULT_UCI_NETWORK
+	network_get_device DEFAULT_FWKNOPD_IFNAME "${DEFAULT_UCI_NETWORK}"
 
 	config_cb() {
-		local type="$1"
-		local name="$2"
-		if [ "$type" = "global" ]; then
+		local type="${1}"
+		local name="${2}"
+		if [ "${type}" = "global" ]; then
 			option_cb() {
-				local option="$1"
-				local value="$2"
-				if [ "$option" = "uci_enabled" ] && [ "$(get_bool "$value" 0)" -eq 1 ] ; then
-					> /var/etc/fwknopd.conf
-					> /var/etc/access.conf
-					chmod 600 /var/etc/fwknopd.conf
-					chmod 600 /var/etc/access.conf
+				local option="${1}"
+				local value="${2}"
+				if [ "${option}" = "uci_enabled" ] && [ "$(get_bool "${value}" 0)" -eq 1 ] ; then
+					mkdir -p "${FWKNOPD_CFGDIR}"
+					> "${FWKNOPD_CFGDIR}/fwknopd.conf"
+					> "${FWKNOPD_CFGDIR}/access.conf"
+					chmod 600 "${FWKNOPD_CFGDIR}/fwknopd.conf"
+					chmod 600 "${FWKNOPD_CFGDIR}/access.conf"
 					UCI_ENABLED=1
-
-					# Forced defaults
-
-					# Do not let fwknopd to shut-down when interface goes down,
-					# control it from the start-up script instead:
-					# https://bugs.openwrt.org/index.php?do=details&task_id=1481
-					echo "EXIT_AT_INTF_DOWN n" >> /var/etc/fwknopd.conf
 				fi
 			}
-		elif [ "$type" = "network" ]; then
+		elif [ "${type}" = "network" ]; then
 			option_cb() {
-				local option="$1"
-				local value="$2"
-				if [ $UCI_ENABLED -eq 1 ] && [ $option = "network" ]; then
-					NETWORK="$value"
+				local option="${1}"
+				local value="${2}"
+				if [ "${UCI_ENABLED}" -eq 1 ] && [ "${option}" = "network" ]; then
+					NETWORK="${value}"
 				fi
 			}
-		elif [ "$type" = "config" ]; then
+		elif [ "${type}" = "config" ]; then
 			option_cb() {
-				local option="$1"
-				local value="$2"
-				if [ $UCI_ENABLED -eq 1 ] && [ $option = "PCAP_INTF" ]; then
-					PCAP_INTF="$value"
-					echo "$option $value" >> /var/etc/fwknopd.conf  #writing each option to fwknopd.conf
-				elif [ $UCI_ENABLED -eq 1 ] && [ $option = "EXIT_AT_INTF_DOWN" ]; then
-					logger -p daemon.warn -t "fwknopd[----]" "Ignoring EXIT_AT_INTF_DOWN option, forced to N (no) to work reliably with procd"
-				elif [ $UCI_ENABLED -eq 1 ]; then
-					echo "$option $value" >> /var/etc/fwknopd.conf  #writing each option to fwknopd.conf
+				local option="${1}"
+				local value="${2}"
+				if [ "${UCI_ENABLED}" -eq 1 ]; then
+					if [ "${option}" = "PCAP_INTF" ]; then
+						PCAP_INTF="${value}"
+					fi
+					echo "${option} ${value}" >> "${FWKNOPD_CFGDIR}/fwknopd.conf"  #writing each option to fwknopd.conf
 				fi
 			}
-		elif [ "$type" = "access" ]; then
+		elif [ "${type}" = "access" ]; then
 			if [ -f /tmp/access.conf.tmp ] ; then
-				cat /tmp/access.conf.tmp >> /var/etc/access.conf
+				cat /tmp/access.conf.tmp >> "${FWKNOPD_CFGDIR}/access.conf"
 				rm /tmp/access.conf.tmp
 			fi
 			option_cb() {
-				local option="$1"
-				local value="$2"
-				if [ $UCI_ENABLED -eq 1 ] && [ $option = "SOURCE" ]; then
-					echo "$option $value" >> /var/etc/access.conf  #writing each option to access.conf
-				fi
-				if [ $UCI_ENABLED -eq 1 ] && [ $option != "SOURCE" ]; then
-					echo "$option $value" >> /tmp/access.conf.tmp  #writing each option to access.conf
+				local option="${1}"
+				local value="${2}"
+				if [ "${UCI_ENABLED}" -eq 1 ]; then
+					if [ "${option}" = "SOURCE" ]; then
+						echo "${option} ${value}" >> "${FWKNOPD_CFGDIR}/access.conf"  #writing each option to access.conf
+					else
+						echo "${option} ${value}" >> /tmp/access.conf.tmp  #writing each option to access.conf
+					fi
 				fi
 			}
 		else
 			reset_cb
-			if [ -z "$type" ]; then
+			if [ -z "${type}" ]; then
 				# Finalize reading
 				if [ -f /tmp/access.conf.tmp ] ; then
-					cat /tmp/access.conf.tmp >> /var/etc/access.conf
+					cat /tmp/access.conf.tmp >> "${FWKNOPD_CFGDIR}/access.conf"
 					rm /tmp/access.conf.tmp
 				fi
 			fi
@@ -142,40 +136,40 @@ generate_configuration()
 		config_load fwknopd
 	fi
 
-	if [ $UCI_ENABLED -eq 0 ]; then
-		if [ -f $USER_CONFIG_PATH ] ; then
+	if [ "${UCI_ENABLED}" -eq 0 ]; then
+		if [ -f "${USER_CONFIG_PATH}" ] ; then
 			# Scan user configuration for PCAP_INTF settings and fallback to fwknopd's default
-			DEPEND_IFNAME="$( sed -ne '/^\s*PCAP_INTF\s\+/ { s/^\s*PCAP_INTF\s\+//; s/\s\+$//; p; q; }' $USER_CONFIG_PATH )"
-			if [ -n "$DEPEND_IFNAME" ]; then
-				logger -p daemon.debug -t "fwknopd[----]" "Found fwknopd.conf configuration, using PCAP_INTF interface $DEPEND_IFNAME"
+			DEPEND_IFNAME="$( sed -ne '/^\s*PCAP_INTF\s\+/ { s/^\s*PCAP_INTF\s\+//; s/\s\+$//; p; q; }' ${USER_CONFIG_PATH} )"
+			if [ -n "${DEPEND_IFNAME}" ]; then
+				logger -p daemon.debug -t "fwknopd[$$]" "Found fwknopd.conf configuration, using PCAP_INTF interface ${DEPEND_IFNAME}"
 			else
-				logger -p daemon.info -t "fwknopd[----]" "No PCAP_INTF interface specified in fwknopd.conf, fwknopd's default $DEFAULT_FWKNOPD_IFNAME will be used"
-				DEPEND_IFNAME="$DEFAULT_FWKNOPD_IFNAME"
+				logger -p daemon.info -t "fwknopd[$$]" "No PCAP_INTF interface specified in fwknopd.conf, fwknopd's default ${DEFAULT_FWKNOPD_IFNAME} will be used"
+				DEPEND_IFNAME="${DEFAULT_FWKNOPD_IFNAME}"
 			fi
 		else
-			logger -p daemon.error -t "fwknopd[----]" "No $USER_CONFIG_PATH found, not starting"
+			logger -p daemon.error -t "fwknopd[$$]" "No ${USER_CONFIG_PATH} found, not starting"
 			exit 1
 		fi
-	elif [ $UCI_ENABLED -eq 1 ]; then
-		if [ -n "$NETWORK" ] && [ -n "$PCAP_INTF" ]; then
-			logger -p daemon.warn -t "fwknopd[----]" "Specified both network and PCAP_INTF. Ignoring PCAP_INTF"
-		elif [ -z "$NETWORK" ] && [ -z "$PCAP_INTF" ]; then
+	elif [ "${UCI_ENABLED}" -eq 1 ]; then
+		if [ -n "${NETWORK}" ] && [ -n "${PCAP_INTF}" ]; then
+			logger -p daemon.warn -t "fwknopd[$$]" "Specified both network and PCAP_INTF. Ignoring PCAP_INTF"
+		elif [ -z "${NETWORK}" ] && [ -z "${PCAP_INTF}" ]; then
 			# Fallback - compatibility with old script, which used wan interface by default
-			logger -p daemon.info -t "fwknopd[----]" "Neither network, nor PCAP_INTF interface specified, trying network $DEFAULT_UCI_NETWORK"
-			NETWORK="$DEFAULT_UCI_NETWORK"
+			logger -p daemon.info -t "fwknopd[$$]" "Neither network, nor PCAP_INTF interface specified, trying network ${DEFAULT_UCI_NETWORK}"
+			NETWORK="${DEFAULT_UCI_NETWORK}"
 		fi
 
 		# Resolve network if possible
-		if [ -n "$NETWORK" ]; then
-			network_get_device DEPEND_IFNAME "$NETWORK"
-			if [ -n "$DEPEND_IFNAME" ]; then
-				logger -p daemon.debug -t "fwknopd[----]" "Resolved network $NETWORK as interface $DEPEND_IFNAME"
+		if [ -n "${NETWORK}" ]; then
+			network_get_device DEPEND_IFNAME "${NETWORK}"
+			if [ -n "${DEPEND_IFNAME}" ]; then
+				logger -p daemon.debug -t "fwknopd[$$]" "Resolved network ${NETWORK} as interface ${DEPEND_IFNAME}"
 			else
-				logger -p daemon.warn -t "fwknopd[----]" "Cannot find interface for network $NETWORK, probably the network is not up"
+				logger -p daemon.warn -t "fwknopd[$$]" "Cannot find interface for network ${NETWORK}, probably the network is not up"
 			fi
-		elif [ -n "$PCAP_INTF" ]; then
-			DEPEND_IFNAME="$PCAP_INTF"
-			logger -p daemon.debug -t "fwknopd[----]" "Using configured PCAP_INTF interface $DEPEND_IFNAME"
+		elif [ -n "${PCAP_INTF}" ]; then
+			DEPEND_IFNAME="${PCAP_INTF}"
+			logger -p daemon.debug -t "fwknopd[$$]" "Using configured PCAP_INTF interface ${DEPEND_IFNAME}"
 		fi
 	fi
 }


### PR DESCRIPTION
Maintainer: @jp-bennett
Run tested: ath79, gl-ar150, 19.07.1
With uci config, user config is not really useable with my network configuration.
start/stop/wan hotplug tests.

Description:
* Log with pid instead of placeholder.
* Make sure directory for config files generated from uci config exists.
* Remove forced defaults.
* Simplify compares.

Additional info:

network_get_device introduced in previous commit doesn't return anything on my system.

/var/etc doesn't exist on my system, so its better to make sure it gets created.

I don't see why keeping fwknopd alive with forced settings when its not fwknopd default when interface goes down is good, no reliability problems witnessed without those. If it is nicer to see graceful shutdown in logs, maybe proper setting in default uci config would be better?

Imagebuilder package removes in test system:
-ppp -ppp-mod-pppoe -dnsmasq -odhcpd-ipv6only -wpad-basic
