### PR TITLE
nfdump: fix compilation with musl-fts

### DIFF
--- a/net/nfdump/Makefile
+++ b/net/nfdump/Makefile
@@ -7,39 +7,40 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nfdump
 PKG_VERSION:=1.6.18
-PKG_RELEASE:=1
-
-PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
-
-PKG_LICENSE:=BSD-3-Clause
-PKG_LICENSE_FILES:=COPYING
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/phaag/nfdump/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=5d6046bf7faa34713b004c6cf8b3d30027c761c5ac22a3195d49388342e8147e
 
+PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=COPYING
+
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
-PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/nls.mk
 
 define Package/nfdump
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:= +libbz2
+  DEPENDS:= +libbz2 +USE_MUSL:musl-fts
   TITLE:= nfdump
   URL:=https://github.com/phaag/nfdump/
 endef
 
 define Package/nfdump/description
-	NetFlow collecting and processing tools
+  NetFlow collecting and processing tools
 endef
 
 define Package/nfdump/conffiles
 /etc/config/nfcapd
 endef
+
+TARGET_CFLAGS += -flto
+TARGET_LDFLAGS += -Wl,--as-needed $(if $(CONFIG_USE_MUSL),-lfts)
 
 define Package/nfdump/install
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
This either uses it, or falls back on its own implementation.

Removed nls.mk. It's not needed/used.

Added size reduction FLAGS.

Cleaned up for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @flyn-org 
Compile tested: ath79