### PR TITLE
[19.07]boost: reintroduce uClibc-ng patch

### DIFF
--- a/libs/boost/Makefile
+++ b/libs/boost/Makefile
@@ -13,7 +13,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=boost
 PKG_VERSION:=1.71.0
 PKG_SOURCE_VERSION:=1_71_0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/$(PKG_NAME)/$(PKG_NAME)/$(PKG_VERSION) https://dl.bintray.com/boostorg/release/$(PKG_VERSION)/source/

--- a/libs/boost/patches/004-uclibc-math.patch
+++ b/libs/boost/patches/004-uclibc-math.patch
@@ -1,0 +1,39 @@
+--- a/boost/math/tools/roots.hpp
++++ b/boost/math/tools/roots.hpp
+@@ -796,12 +796,24 @@ Complex complex_newton(F g, Complex guess, int max_iterations=std::numeric_limit
+ // https://stackoverflow.com/questions/48979861/numerically-stable-method-for-solving-quadratic-equations/50065711
+ namespace detail
+ {
++#if defined(BOOST_GNU_STDLIB) && !defined(_GLIBCXX_USE_C99_MATH_TR1)
++inline float fma_workaround(float x, float y, float z) { return ::fmaf(x, y, z); }
++inline double fma_workaround(double x, double y, double z) { return ::fma(x, y, z); }
++#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
++inline long double fma_workaround(long double x, long double y, long double z) { return ::fmal(x, y, z); }
++#endif
++#endif
+     template<class T>
+     inline T discriminant(T const & a, T const & b, T const & c)
+     {
+         T w = 4*a*c;
++#if defined(BOOST_GNU_STDLIB) && !defined(_GLIBCXX_USE_C99_MATH_TR1)
++        T e = fma_workaround(-c, 4*a, w);
++        T f = fma_workaround(b, b, -w);
++#else
+         T e = std::fma(-c, 4*a, w);
+         T f = std::fma(b, b, -w);
++#endif
+         return f + e;
+     }
+ }
+@@ -809,7 +821,11 @@ namespace detail
+ template<class T>
+ auto quadratic_roots(T const& a, T const& b, T const& c)
+ {
++#if defined(BOOST_GNU_STDLIB) && !defined(_GLIBCXX_USE_C99_MATH_TR1)
++    using boost::math::copysign;
++#else
+     using std::copysign;
++#endif
+     using std::sqrt;
+     if constexpr (std::is_integral<T>::value)
+     {


### PR DESCRIPTION
It's all fixed upstream. Backported a combination of three patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ClaymorePT 