### PR TITLE
ffmpeg: disable x86 asm for old CPU types

### DIFF
--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -1,3 +1,11 @@
+config FFMPEG_X86ASM
+	bool "Compile x86 ASM"
+	depends on (x86_64 || (i386 && !(TARGET_x86_geode || TARGET_x86_legacy)))
+	help
+		This compiles ffmpeg with x86 assembly optimizations. This option is needed as NASM is
+		totally broken with CPU_TYPE=pentium.
+	default y
+
 if PACKAGE_libffmpeg-custom
 
 comment "Build Licensing"

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=3.4.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
@@ -482,12 +482,10 @@ ifeq ($(ARCH),x86_64)
 	FFMPEG_CONFIGURE+= --enable-lto
 endif
 
-ifneq ($(CONFIG_TARGET_x86),)
-ifeq ($(CONFIG_NASM),y)
+ifeq ($(CONFIG_FFMPEG_X86ASM),y)
   FFMPEG_CONFIGURE += --enable-x86asm
 else
   FFMPEG_CONFIGURE += --disable-x86asm
-endif
 endif
 
 ifeq ($(BUILD_VARIANT),full)


### PR DESCRIPTION
This is a workaround for NASM being totally broken.

I have two patches, one for master and another for 19.07 that upstream is
not merging.

https://patchwork.ozlabs.org/patch/1221696/
https://patchwork.ozlabs.org/patch/1221697/

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess @antonlacon 

ping @diizzyy 

https://downloads.openwrt.org/snapshots/faillogs/i386_pentium/packages/ffmpeg/full/compile.txt
https://downloads.openwrt.org/releases/faillogs-19.07/i386_pentium/packages/ffmpeg/full/compile.txt

I plan on backporting if there are no objections.