### PR TITLE
[openwrt-19.07] haproxy: Update HAProxy to v2.0.13

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=2.0.12
+PKG_VERSION:=2.0.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/2.0/src
-PKG_HASH:=7fcf5adb21cd78c4161902f9fcc8d7fc97e1562319a992cbda884436ca9602fd
+PKG_HASH:=21f932ae18131ad58cb2f9d7cf2338349b6ccf3f5c33382624bbf1d3760b9be1
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \

--- a/net/haproxy/get-latest-patches.sh
+++ b/net/haproxy/get-latest-patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CLONEURL=https://git.haproxy.org/git/haproxy-2.0.git
-BASE_TAG=v2.0.12
+BASE_TAG=v2.0.13
 TMP_REPODIR=tmprepo
 PATCHESDIR=patches
 

--- a/net/haproxy/patches/000-OPENWRT-add-uclibc-support.patch
+++ b/net/haproxy/patches/000-OPENWRT-add-uclibc-support.patch
@@ -1,7 +1,7 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -326,6 +326,15 @@ ifeq ($(TARGET),linux-glibc)
-     USE_GETADDRINFO)
+@@ -334,6 +334,15 @@ ifeq ($(TARGET),linux-glibc)
+     USE_ACCEPT4 USE_LINUX_SPLICE USE_PRCTL USE_THREAD_DUMP USE_GETADDRINFO)
  endif
  
 +# For linux >= 2.6.28 and uclibc


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com>
Compile tested: mips, ipq806x, x86
Run tested: ipq806x (r7800)

Description: Update HAProxy to v2.0.13
- Update haproxy download URL and hash