### PR TITLE
Docker compose (2 of 3)

### DIFF
--- a/lang/python/python-docker/Makefile
+++ b/lang/python/python-docker/Makefile
@@ -1,0 +1,41 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-docker
+PKG_VERSION:=4.2.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=docker
+PKG_HASH:=380a20d38fbfaa872e96ee4d0d23ad9beb0f9ed57ff1c30653cbeb0c9c0964f2
+
+PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+PYTHON3_PKG_SETUP_ARGS:=
+
+define Package/python3-docker
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=A Python library for the Docker Engine API
+  URL:=https://github.com/docker/docker-py
+  DEPENDS:=\
+	  +python3-light +python3-distutils +python3-logging \
+	  +python3-openssl +python3-paramiko +python3-six +python3-requests \
+	  +python3-websocket-client
+  VARIANT:=python3
+endef
+
+define Package/python3-docker/description
+  A Python library for the Docker Engine API. It lets you do anything the
+  docker command does, but from within Python apps – run containers manage
+  containers, manage Swarms, etc.
+endef
+
+$(eval $(call Py3Package,python3-docker))
+$(eval $(call BuildPackage,python3-docker))
+$(eval $(call BuildPackage,python3-docker-src))

--- a/lang/python/python-paramiko/Makefile
+++ b/lang/python/python-paramiko/Makefile
@@ -1,0 +1,40 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-paramiko
+PKG_VERSION:=2.7.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=paramiko
+PKG_HASH:=920492895db8013f6cc0179293147f830b8c7b21fdfc839b6bad760c27459d9f
+
+PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+PYTHON3_PKG_SETUP_ARGS:=
+
+define Package/python3-paramiko
+  SECTION:=lang
+  CATEGORY:=Languages
+  SUBMENU:=Python
+  TITLE:=SSH2 protocol library
+  URL:=https://github.com/paramiko/paramiko/
+  DEPENDS:=+python3-light +python3-logging +python3-bcrypt \
+	  +python3-cryptography +python3-openssl +python3-pynacl
+  VARIANT:=python3
+endef
+
+define Package/python3-paramiko/description
+  Paramiko is a Python (2.7, 3.4+) implementation of the SSHv2 protocol,
+  providing both client and server functionality. While it leverages a Python
+  C extension for low level cryptography (Cryptography), Paramiko itself is a
+  pure Python interface around SSH networking concepts.
+endef
+
+$(eval $(call Py3Package,python3-paramiko))
+$(eval $(call BuildPackage,python3-paramiko))
+$(eval $(call BuildPackage,python3-paramiko-src))

--- a/lang/python/python-pynacl/Makefile
+++ b/lang/python/python-pynacl/Makefile
@@ -1,0 +1,40 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pynacl
+PKG_VERSION:=1.4.0
+PKG_RELEASE:=1
+
+PYPI_NAME:=PyNaCl
+PKG_HASH:=54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505
+
+PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=libffi/host
+
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:="cffi>=1.4.1"
+
+PYTHON3_PKG_SETUP_VARS:= SODIUM_INSTALL=system
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pynacl
+  CATEGORY:=Languages
+  SECTION:=lang
+  SUBMENU:=Python
+  TITLE:=Python binding to the libsodium library
+  URL:=https://github.com/pyca/pynacl/
+  DEPENDS:=+libsodium +python3-light +python3-cffi +python3-six
+  VARIANT:=python3
+endef
+
+define Package/python3-pynacl/description
+  PyNaCl is a Python binding to libsodium, which is a fork of the Networking and Cryptography library.
+endef
+
+$(eval $(call Py3Package,python3-pynacl))
+$(eval $(call BuildPackage,python3-pynacl))
+$(eval $(call BuildPackage,python3-pynacl-src))


### PR DESCRIPTION
Maintainer: Javier Marcet <javier@marcet.info>
Compile tested: x86-64 master
Run tested: x86-64 master

Description: second set of packages required by docker-compose, python3-docker is required directly by docker-compose, python3-docker depends on python3-paramiko, and paramiko depends on python3-pynacl.

This comes from splitting #11155
