### PR TITLE
python-markdown: update to version 3.2.1

### DIFF
--- a/lang/python/python-markdown/Makefile
+++ b/lang/python/python-markdown/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+# Copyright (C) 2019-2O20 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-markdown
-PKG_VERSION:=3.1.1
+PKG_VERSION:=3.2.1
 PKG_RELEASE:=1
 
 PYPI_NAME:=Markdown
-PKG_HASH:=2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a
+PKG_HASH:=90fee683eeabe1a92e149f7ba74e5ccdc81cd397bd6c516d93a8da0ef90b6902
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

For example as an proof of run tested:
```
root@turris:~# echo "Some **Markdown** text." | python3 -m markdown > output.html
root@turris:~# cat output.html 
<p>Some <strong>Markdown</strong> text.</p>
```

Description:
- Update to version [3.2](https://python-markdown.github.io/change_log/release-3.2/) and [3.2.1](https://python-markdown.github.io/change_log/)
