### PR TITLE
acme: update to v2.8.5

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme
-PKG_VERSION:=2.8.3
-PKG_RELEASE:=4
+PKG_VERSION:=2.8.5
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/Neilpang/acme.sh/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=bdec71377a764919ac277e26d71ef7e24087f7f05171921888b70de6ab6e2cbc
+PKG_HASH:=45d964de8970096dae06aaa45dba2d9d09a41c0a43355191ee627eb00ba5db45
 PKG_BUILD_DIR:=$(BUILD_DIR)/acme.sh-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: PPC, WD MyBook Live, 19.07.1
Run tested: PPC, WD MyBook Live, 19.07.1. Renewed certificates successfully.

Description:
The currently packaged version has issues renewing the certificates (see https://github.com/acmesh-official/acme.sh/issues/2533). The 2.8.5 version solves this issue.