### PR TITLE
python-wcwidth: update to version 0.1.8

### DIFF
--- a/lang/python/python-wcwidth/Makefile
+++ b/lang/python/python-wcwidth/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 CZ.NIC z.s.p.o. (http://www.nic.cz/)
+# Copyright (C) 2019-2020 CZ.NIC z.s.p.o. (http://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,11 +9,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-wcwidth
-PKG_VERSION:=0.1.7
+PKG_VERSION:=0.1.8
 PKG_RELEASE:=1
 
 PYPI_NAME:=wcwidth
-PKG_HASH:=3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e
+PKG_HASH:=f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run testd: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates python-wcwidth to version 0.1.8.. (Update with Unicode Specification 12.0.0.)

Runtested with 
```
from wcwidth import wcswidth
text = u'コンニチハ'
text_len = wcswidth(text)
print(u' ' * (80 - text_len) + text)
```
