### PR TITLE
python-more-itertools: update to version 8.2.0

### DIFF
--- a/lang/python/python-more-itertools/Makefile
+++ b/lang/python/python-more-itertools/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-more-itertools
-PKG_VERSION:=8.1.0
+PKG_VERSION:=8.2.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=more-itertools
-PKG_HASH:=c468adec578380b6281a114cb8a5db34eb1116277da92d7c46f904f0b52d3288
+PKG_HASH:=b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt maser

Description:
Update to version 5.2.0 [Changelog](https://raw.githubusercontent.com/erikrose/more-itertools/0861bed72ddd4c8ebcfa3a932b7689e272c43478/docs/versions.rst)

Runtested with project test (Ran 483 tests (skipped=1))

