### PR TITLE
python-pyparsing: update to version 2.4.6

### DIFF
--- a/lang/python/python-pyparsing/Makefile
+++ b/lang/python/python-pyparsing/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 CZ.NIC z.s.p.o. (http://www.nic.cz/)
+# Copyright (C) 2019-2020 CZ.NIC z.s.p.o. (http://www.nic.cz/)
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,11 +9,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyparsing
-PKG_VERSION:=2.4.2
+PKG_VERSION:=2.4.6
 PKG_RELEASE:=1
 
 PYPI_NAME:=pyparsing
-PKG_HASH:=6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80
+PKG_HASH:=4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
Update to version 2.4.6 [Changelog](https://github.com/pyparsing/pyparsing/releases/tag/pyparsing_2.4.6)

Run tested with project test ( Ran 10 tests) 
