### PR TITLE
coreutils: fix #11389 build failure

### DIFF
--- a/utils/coreutils/patches/002-strtod-fix-clash-with-strtold.patch
+++ b/utils/coreutils/patches/002-strtod-fix-clash-with-strtold.patch
@@ -1,0 +1,41 @@
+From 0562b040fa17f1722ba2b3096067b45d0582ca53 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <address@hidden>
+Date: Mon, 11 Mar 2019 16:40:29 -0700
+Subject: [PATCH] strtod: fix clash with strtold
+
+Problem reported for RHEL 5 by Jesse Caldwell (Bug#34817).
+* lib/strtod.c (compute_minus_zero, minus_zero):
+Simplify by remving the macro / external variable,
+and having just a function.  User changed.  This avoids
+the need for an external variable that might clash.
+--- a/lib/strtod.c
++++ b/lib/strtod.c
+@@ -294,16 +294,15 @@ parse_number (const char *nptr,
+    ICC 10.0 has a bug when optimizing the expression -zero.
+    The expression -MIN * MIN does not work when cross-compiling
+    to PowerPC on Mac OS X 10.5.  */
+-#if defined __hpux || defined __sgi || defined __ICC
+ static DOUBLE
+-compute_minus_zero (void)
++minus_zero (void)
+ {
++#if defined __hpux || defined __sgi || defined __ICC
+   return -MIN * MIN;
+-}
+-# define minus_zero compute_minus_zero ()
+ #else
+-DOUBLE minus_zero = -0.0;
++  return -0.0;
+ #endif
++}
+ 
+ /* Convert NPTR to a DOUBLE.  If ENDPTR is not NULL, a pointer to the
+    character after the last one used in the number is put in *ENDPTR.  */
+@@ -479,6 +478,6 @@ STRTOD (const char *nptr, char **endptr)
+   /* Special case -0.0, since at least ICC miscompiles negation.  We
+      can't use copysign(), as that drags in -lm on some platforms.  */
+   if (!num && negative)
+-    return minus_zero;
++    return minus_zero ();
+   return negative ? -num : num;
+ }


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: ipq40xx
Run tested: ipq40xx

Description:
Fix compilation error due to multiple definition
```
x86_64-openwrt-linux-musl/bin/ld: lib/libcoreutils.a(strtold.o):(.data+0x0): multiple definition of `minus_zero'; lib/libcoreutils.a(strtod.o):(.data+0x0): first defined here
collect2: error: ld returned 1 exit status
```