### PR TITLE
dovecot: update to version 2.3.9.3 (security fix)

### DIFF
--- a/mail/dovecot/Makefile
+++ b/mail/dovecot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot
-PKG_VERSION:=2.3.9
-PKG_RELEASE:=2
+PKG_VERSION:=2.3.9.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dovecot.org/releases/2.3
-PKG_HASH:=df2c53e5a0463c5c52af682fb11c17eb7f79115d95a861a63cd09329fd7daa9f
+PKG_HASH:=f89fb69423fc5bdc05955c8fc0607eab9e33511f9a643b721763db6156c49651
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=LGPL-2.1-only MIT BSD-3-Clause


### PR DESCRIPTION

Maintainer: @lucize 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates dovecot to version 2.3.9.3 to fix [CVE-2020-7046](https://nvd.nist.gov/vuln/detail/CVE-2020-7046) and [CVE-2020-7957](https://nvd.nist.gov/vuln/detail/CVE-2020-7957)

This should be also cherrypicked to 19.07 and 18.06

