### PR TITLE
cgi-io: use O_TMPFILE for uploads and attempt to directly link target file

### DIFF
--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=17
+PKG_RELEASE:=18
 
 PKG_LICENSE:=GPL-2.0-or-later
 


### PR DESCRIPTION
Maintainer: @blogic 
Compile tested: x86/64 r12230-5715b21f80
Run tested: x86/64 r12230-5715b21f80
Description:

Create an anonymous inode in /tmp using O_TMPFILE and attempt to link the
file in place using linkat(). Only fall back to the old file copy when
linking the tempfile fails.

Avoids double memory use if both the temporary upload file and the
destination file are located in /tmp.

Ref: https://github.com/openwrt/luci/issues/3654
Signed-off-by: Jo-Philipp Wich <jo@mein.io>
