### PR TITLE
stubby: fix wrong permissions for stubby.yml

### DIFF
--- a/net/stubby/files/stubby.init
+++ b/net/stubby/files/stubby.init
@@ -227,6 +227,8 @@ start_service() {
         mv "$config_file_tmp" "$stubby_config"
     fi
 
+    chmod 0644 "$stubby_config"
+
     config_get command_line_arguments "global" command_line_arguments ""
 
     config_get log_level "global" log_level ""


### PR DESCRIPTION
Signed-off-by: Jonathan Liu <net147@gmail.com>

Maintainer: @jonathanunderwood
Compile tested: x86/64 19.07.1
Run tested: x86/64 19.07.1

Description:
Starting stubby can result in stubby.yml being created owned by root:root with 0600 permission and result in the error "Could not parse config file "/var/etc/stubby/stubby.yml": Permission denied" in System Log.