### PR TITLE
knxd: bump to version 0.14.31

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -11,12 +11,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
-PKG_VERSION:=0.14.29
-PKG_RELEASE:=4
+PKG_VERSION:=0.14.31
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=4513328dd5ecfc17955e6884e938d652dbd33b82797893ae9ad768a247a0f63e
+PKG_HASH:=3bc21f1db9a72d4e6ad817f60e70af8421ede1529a57a2c12b70304e51a79d02
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -47,6 +47,8 @@ endef
 
 CONFIGURE_ARGS+= \
 	--disable-systemd
+
+TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-lm)
 
 define Package/knxd/install
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

Maintainer: me
Compile tested: mpc85xx, tl-wdr4900-v1, trunk
Compile tested: ath79, wndr3700, trunk
Run tested: ath79, wndr3700, trunk

Description:
bump to new upstream version 0.14.31
