### PR TITLE
debootstrap: update to 1.0.118

### DIFF
--- a/admin/debootstrap/Makefile
+++ b/admin/debootstrap/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=debootstrap
-PKG_VERSION:=1.0.116
+PKG_VERSION:=1.0.118
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-udeb_$(PKG_VERSION)_all.udeb
 PKG_SOURCE_URL:=http://ftp.debian.org/debian/pool/main/d/debootstrap
-PKG_HASH:=2325cbad6fac19cec7db34cff8fc06f9d9781862621b6e91f10549cf7c7c66af
+PKG_HASH:=fad9b7968676c1f4a680e2b07c2b2859f5513ea94425ad3247189eb81bdb51a6
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=Unique

--- a/admin/debootstrap/files/pkgdetails.c
+++ b/admin/debootstrap/files/pkgdetails.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/admin/debootstrap/patches/010-no-nvswitch.patch
+++ b/admin/debootstrap/patches/010-no-nvswitch.patch
@@ -1,0 +1,10 @@
+--- a/usr/share/debootstrap/functions
++++ b/usr/share/debootstrap/functions
+@@ -77,7 +77,6 @@ progress_next () {
+ }
+ 
+ wgetprogress () {
+-	[ ! "$VERBOSE" ] && NVSWITCH="-nv"
+ 	local ret=0
+ 	if [ "$USE_DEBIANINSTALLER_INTERACTION" ] && [ "$PROGRESS_NEXT" ]; then
+ 		# The exit status of a pipeline is that of the last command in


### PR DESCRIPTION
Added _GNU_SOURCE define to fix compilation warning.

Added gnu-wget dependency as uclient-fetch is not enough.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: malta-glibc

Fixes: https://github.com/openwrt/packages/issues/11161