### PR TITLE
yggdrasil: bump to 0.3.13

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
-PKG_VERSION:=0.3.12
+PKG_VERSION:=0.3.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c82ba4020276f85f53ecd8ccb08db4c79ac0a1a23c1011140ca8585721ae9008
+PKG_HASH:=ba2149024152c4df65e68722e7d4d1050fec71907904a7bdf9757159d94cd83d
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-go-$(PKG_VERSION)
 
 PKG_MAINTAINER:=William Fleurant <meshnet@protonmail.com>

--- a/net/yggdrasil/files/yggdrasil.defaults
+++ b/net/yggdrasil/files/yggdrasil.defaults
@@ -11,11 +11,10 @@ first_boot_genConfig()
 
   json_load "$boardcfg"
   json_get_var kernel     kernel
-  json_get_var hostname   hostname
   json_get_var system     system
   json_get_var model      model
   json_get_var board_name board_name
-  nodeinfo='{"kernel": "'$kernel'", "hostname":"'$hostname'", "system": "'$system'", "model": "'$model'", "board_name": "'$board_name'"}'
+  nodeinfo='{"kernel": "'$kernel'", "hostname":"'OpenWrt'", "system": "'$system'", "model": "'$model'", "board_name": "'$board_name'"}'
 
   uci set yggdrasil.yggdrasil.IfName="ygg0"
   uci set yggdrasil.yggdrasil.NodeInfo="$nodeinfo"

--- a/net/yggdrasil/files/ygguci
+++ b/net/yggdrasil/files/ygguci
@@ -12,7 +12,7 @@ UCI = {}
 function UCI.defaults()
 	return { 
 		AdminListen = "unix:///var/run/yggdrasil.sock", IfName = "ygg0", 
-		NodeInfoPrivacy = false, IfTAPMode = false,
+		NodeInfoPrivacy = false,
 		LinkLocalTCPPort = 0, IfMTU = 65535,
 
 		Peers = { }, Listen = { }, MulticastInterfaces = { }, AllowedEncryptionPublicKeys = { },
@@ -55,7 +55,7 @@ function UCI.get()
 	obj.AdminListen = config.AdminListen or obj.AdminListen
 	obj.IfName = config.IfName or obj.IfName
 	obj.NodeInfo = dkjson.decode(config.NodeInfo) or obj.NodeInfo
-	for _, v in pairs({ "NodeInfoPrivacy", "IfTAPMode" }) do
+	for _, v in pairs({ "NodeInfoPrivacy" }) do
 		if config[v] ~= nil then obj[v] = to_bool(config[v]) end
 	end
 	for _, v in pairs({ "LinkLocalTCPPort", "IfMTU" }) do
@@ -145,7 +145,6 @@ function UCI.set(obj)
 	cursor:set("yggdrasil", "yggdrasil", "IfName", obj.IfName) 
 	cursor:set("yggdrasil", "yggdrasil", "NodeInfoPrivacy", to_int(obj.NodeInfoPrivacy)) 
 	cursor:set("yggdrasil", "yggdrasil", "NodeInfo", dkjson.encode(obj.NodeInfo)) 
-	cursor:set("yggdrasil", "yggdrasil", "IfTAPMode", to_int(obj.IfTAPMode)) 
 	cursor:set("yggdrasil", "yggdrasil", "LinkLocalTCPPort", obj.LinkLocalTCPPort)
 	cursor:set("yggdrasil", "yggdrasil", "IfMTU", obj.IfMTU)
 


### PR DESCRIPTION
Maintainer: @wfleurant
Compile tested: x86_64 apu2 from trunk, against luci-app-yggdrasil (v12 and v13)
Description: https://github.com/yggdrasil-network/yggdrasil-go/releases/tag/v0.3.13

- NodeInfo:  'hostname' is now hard coded to 'OpenWrt'
- UCI: Removed Tap support (support dropped in v0.3.13)