### PR TITLE
ddns-scripts: fix error: /usr/lib/ddns/dynamic_dns_updater.sh: eval: line 1: syntax…

### DIFF
--- a/net/ddns-scripts/files/dynamic_dns_functions.sh
+++ b/net/ddns-scripts/files/dynamic_dns_functions.sh
@@ -280,7 +280,7 @@ write_log() {
 	fi
 	[ -n "$LUCI_HELPER" ] && return	# nothing else todo when running LuCI helper script
 	[ $__LEVEL -eq 7 ] && return	# no syslog for debug messages
-	__CMD=$(echo -e "$__CMD" | tr -d '\n' | tr '\t' '     ')        # remove \n \t chars
+	__CMD=$(echo -e "$__CMD" | tr -d '\n' | tr '\t' '     ' | tr '\(' '\\\(' | tr '\)' '\\\)' )  # remove \n \t chars and '(' or ')'
 	[ $__EXIT  -eq 1 ] && {
 		eval "$__CMD"	# force syslog before exit
 		exit 1


### PR DESCRIPTION
… error: unexpected "("

fix error: /usr/lib/ddns/dynamic_dns_updater.sh: eval: line 1: syntax error: unexpected "("
