### PR TITLE
node: update to v12.16.1

### DIFF
--- a/lang/node/Makefile
+++ b/lang/node/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=node
-PKG_VERSION:=v12.15.0
+PKG_VERSION:=v12.16.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://nodejs.org/dist/$(PKG_VERSION)
-PKG_HASH:=d2fb4fa80ccf321570552b0a6e6b5f2aedeb281a8450207b057cf54c54d5a81b
+PKG_HASH:=0a95845ba02c46102b5671d0c5732460073f2d397488337e18d1fc30146d412d
 
 PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>, Adrian Panella <ianchi74@outlook.com>
 PKG_LICENSE:=MIT

--- a/lang/node/patches/003-path.patch
+++ b/lang/node/patches/003-path.patch
@@ -1,6 +1,6 @@
 --- a/lib/internal/modules/cjs/loader.js
 +++ b/lib/internal/modules/cjs/loader.js
-@@ -1095,7 +1095,8 @@
+@@ -1260,7 +1260,8 @@
      path.resolve(process.execPath, '..') :
      path.resolve(process.execPath, '..', '..');
  

--- a/lang/node/patches/004-musl_support.patch
+++ b/lang/node/patches/004-musl_support.patch
@@ -22,7 +22,7 @@ diff -urN a/deps/v8/src/base/platform/condition-variable.cc b/deps/v8/src/base/p
 diff -urN a/deps/v8/src/base/platform/platform-posix.cc b/deps/v8/src/base/platform/platform-posix.cc
 --- a/deps/v8/src/base/platform/platform-posix.cc	2019-09-05 00:36:23.000000000 +0900
 +++ b/deps/v8/src/base/platform/platform-posix.cc	2019-09-12 15:10:01.063792083 +0900
-@@ -773,7 +773,7 @@
+@@ -772,7 +772,7 @@
  #if V8_OS_MACOSX
      // Default on Mac OS X is 512kB -- bump up to 1MB
      stack_size = 1 * 1024 * 1024;

--- a/lang/node/patches/006-mips64_support.patch
+++ b/lang/node/patches/006-mips64_support.patch
@@ -9,7 +9,7 @@
                'ppc64', 'x32','x64', 'x86', 'x86_64', 's390x')
  valid_arm_float_abi = ('soft', 'softfp', 'hard')
  valid_arm_fpu = ('vfp', 'vfpv3', 'vfpv3-d16', 'neon')
-@@ -883,6 +883,9 @@
+@@ -896,6 +896,9 @@
    if rtn == 'mipsel' and '_LP64' in k:
      rtn = 'mips64el'
  
@@ -19,7 +19,7 @@
    return rtn
  
  
-@@ -981,7 +984,7 @@
+@@ -1001,7 +1004,7 @@
  
    if target_arch == 'arm':
      configure_arm(o)

--- a/lang/node/patches/999-delete_unnecessary_libraries_for_host_execute.patch
+++ b/lang/node/patches/999-delete_unnecessary_libraries_for_host_execute.patch
@@ -34,7 +34,7 @@
          '<@(icu_src_genccode)',
 --- a/tools/v8_gypfiles/v8.gyp	2019-06-27 19:12:20.000000000 +0900
 +++ b/tools/v8_gypfiles/v8.gyp	2019-07-01 14:40:48.292020880 +0900
-@@ -1258,6 +1258,7 @@
+@@ -1265,6 +1265,7 @@
      {
        'target_name': 'bytecode_builtins_list_generator',
        'type': 'executable',
@@ -42,7 +42,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1281,6 +1282,8 @@
+@@ -1288,6 +1289,8 @@
      {
        'target_name': 'mksnapshot',
        'type': 'executable',
@@ -51,7 +51,7 @@
        'dependencies': [
          'v8_base_without_compiler',
          'v8_compiler_for_mksnapshot',
-@@ -1303,6 +1306,7 @@
+@@ -1310,6 +1313,7 @@
      {
        'target_name': 'torque',
        'type': 'executable',
@@ -59,7 +59,7 @@
        'dependencies': [
          'torque_base',
          # "build/win:default_exe_manifest",
-@@ -1341,6 +1345,7 @@
+@@ -1348,6 +1352,7 @@
      {
        'target_name': 'torque-language-server',
        'type': 'executable',
@@ -67,7 +67,7 @@
        'conditions': [
          ['want_separate_host_toolset', {
            'toolsets': ['host'],
-@@ -1368,6 +1373,8 @@
+@@ -1375,6 +1380,8 @@
      {
        'target_name': 'gen-regexp-special-case',
        'type': 'executable',

--- a/lang/node/patches/999-fix_missing_llhttp_depends.patch
+++ b/lang/node/patches/999-fix_missing_llhttp_depends.patch
@@ -1,7 +1,7 @@
 diff -urN a/node.gypi b/node.gypi
 --- a/node.gypi	2019-09-05 00:36:25.000000000 +0900
 +++ b/node.gypi	2019-09-13 09:57:54.073191914 +0900
-@@ -142,6 +142,10 @@
+@@ -149,6 +149,10 @@
          'deps/http_parser/http_parser.gyp:http_parser',
          'deps/llhttp/llhttp.gyp:llhttp'
        ],

--- a/lang/node/patches/999-v8_this_build_method_will_be_deprecated.patch
+++ b/lang/node/patches/999-v8_this_build_method_will_be_deprecated.patch
@@ -1,7 +1,7 @@
 diff -urN a/configure.py b/configure.py
 --- a/configure.py	2019-09-05 00:36:21.000000000 +0900
 +++ b/configure.py	2019-09-27 11:49:55.445800884 +0900
-@@ -1202,6 +1202,25 @@
+@@ -1223,6 +1223,25 @@
      options.build_v8_with_gn = FetchDeps(v8_path)
    o['variables']['build_v8_with_gn'] = b(options.build_v8_with_gn)
  
@@ -18,16 +18,16 @@ diff -urN a/configure.py b/configure.py
 +    o['variables']['v8_enable_embedded_builtins'] = 0
 +  elif target_arch == 'x64':
 +    if options.with_intl in (None, 'none'):
-+      o['variables']['v8_enable_embedded_builtins'] = 0
++      o['variables']['v8_enable_embedded_builtins'] = 1
 +  elif target_arch == 'ia32':
 +    if options.with_intl in (None, 'none'):
-+      o['variables']['v8_enable_embedded_builtins'] = 1
++      o['variables']['v8_use_snapshot'] = 'false'
 +    else:
 +      o['variables']['v8_enable_embedded_builtins'] = 0
  
  def configure_openssl(o):
    variables = o['variables']
-@@ -1632,6 +1651,7 @@
+@@ -1654,6 +1673,7 @@
  configure_intl(output)
  configure_static(output)
  configure_inspector(output)


### PR DESCRIPTION
Maintainer: @blogic @ianchi
Compile tested: head r12317-a1dd773, mips mips64 mipsel mips64el arm aarch64 x86_64 i386
Run tested: mips mips64 mipsel mips64el arm aarch64 x86_64 i386

Description:
update to v12.16.1
Add some new APIs
V8 was updated to 7.8.279.23. This includes performance improvements to object
destructuring, RegExp match failures and WebAssembly startup time.

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
