### PR TITLE
stubby: fix init script

### DIFF
--- a/net/stubby/Makefile
+++ b/net/stubby/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stubby
 PKG_VERSION:=0.2.6
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/getdnsapi/$(PKG_NAME)

--- a/net/stubby/files/stubby.init
+++ b/net/stubby/files/stubby.init
@@ -20,7 +20,6 @@ boot()
 
 generate_config()
 {
-    local config_file="$1"
     local round_robin
     local tls_authentication
     local tls_query_padding_blocksize
@@ -205,7 +204,7 @@ generate_config()
     }
 
     config_foreach handle_resolver resolver
-} > "$config_file"
+} > "$config_file_tmp"
 
 start_service() {
     local config_file_tmp
@@ -223,10 +222,11 @@ start_service() {
         cp "$stubby_manual_config" "$stubby_config"
     else
         config_file_tmp="$stubby_config.$$"
-        generate_config "$config_file_tmp"
+        generate_config
         mv "$config_file_tmp" "$stubby_config"
     fi
-    chmod 0644 "$stubby_config"
+    chown stubby:stubby "$stubby_config"
+    chmod 0400 "$stubby_config"
 
     config_get command_line_arguments "global" command_line_arguments ""
 


### PR DESCRIPTION
The configuration file was not being generated.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jonathanunderwood 
Compile tested: malta-glibc
Run tested: malta-glibc