### PR TITLE
mpd: link against libm under glibc

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -97,7 +97,10 @@ define Package/mpd-avahi-service/conffiles
 /etc/avahi/services/mpd.service
 endef
 
-EXTRA_LDFLAGS += $(if $(ICONV_FULL),-liconv,-Wl,--whole-archive -liconv -Wl,--no-whole-archive) -Wl,-rpath-link=$(STAGING_DIR)/usr/lib/pulseaudio
+TARGET_LDFLAGS += \
+	$(if $(ICONV_FULL),-liconv,-Wl,--whole-archive -liconv -Wl,--no-whole-archive) \
+	$(if $(CONFIG_USE_GLIBC),-lpthread) \
+	-Wl,-rpath-link=$(STAGING_DIR)/usr/lib/pulseaudio
 
 MESON_ARGS += \
 	-Ddocumentation=false \


### PR DESCRIPTION
Fixes compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: malta-glibc
