### PR TITLE
protobuf: link against libm under glibc

### DIFF
--- a/libs/protobuf/Makefile
+++ b/libs/protobuf/Makefile
@@ -81,7 +81,7 @@ CMAKE_OPTIONS += \
 	-Dprotobuf_WITH_ZLIB=ON \
 	-DBUILD_SHARED_LIBS=ON
 
-TARGET_LDFLAGS += -latomic
+TARGET_LDFLAGS += -latomic $(if $(CONFIG_USE_GLIBC),-lm)
 
 define Build/InstallDev
 	$(call Build/InstallDev/cmake,$(1))


### PR DESCRIPTION
Fixes compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @kenkeys 
Compile tested: malta-glibc
