### PR TITLE
keepalived: update version to 2.0.20

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
-PKG_VERSION:=2.0.19
-PKG_RELEASE:=3
+PKG_VERSION:=2.0.20
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software
-PKG_HASH:=0e2f8454765bc6a5fa26758bd9cec18aae42882843cdd24848aff0ae65ce4ca7
+PKG_HASH:=9670fbc5eb3dc113828be8b702549dc68ec9578cf83287520d935be76fc8f193
 
 PKG_CPE_ID:=cpe:/a:keepalived:keepalived
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64 and  lantiq_xrx200, OpenWrt master
Run tested: x86_64(APU3) and lantiq_xrx200

Description:
 Update to version 2.0.20
```
Keepalived v2.0.20 (02/21,2020), git commit reboot-12361-gcd33182b84

Copyright(C) 2001-2020 Alexandre Cassen, <acassen@gmail.com>

Built with kernel headers for Linux 4.19.101
Running on Linux 4.19.101 #0 SMP Fri Feb 21 08:31:00 2020

configure options: --target=x86_64-openwrt-linux --host=x86_64-openwrt-linux --build=x86_64-pc-linux-gnu --program-prefix= --program-suffix= --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --libexecdir=/usr/lib --sysconfdir=/etc --datadir=/usr/share --localstatedir=/var --mandir=/usr/man --infodir=/usr/info --disable-nls --with-init=SYSV --disable-nftables --disable-track-process --with-run-dir=/var/run --enable-sha1 --disable-libipset-dynamic build_alias=x86_64-pc-linux-gnu host_alias=x86_64-openwrt-linux target_alias=x86_64-openwrt-linux PKG_CONFIG=/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/host/bin/pkg-config PKG_CONFIG_PATH=/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/target-x86_64_musl/usr/lib/pkgconfig:/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/target-x86_64_musl/usr/share/pkgconfig PKG_CONFIG_LIBDIR=/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/target-x86_64_musl/usr/lib/pkgconfig:/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/target-x86_64_musl/usr/share/pkgconfig CC=x86_64-openwrt-linux-musl-gcc CFLAGS=-Os -pipe -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -ffile-prefix-map=/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/build_dir/target-x86_64_musl/keepalived-2.0.20=keepalived-2.0.20 -Wformat -Werror=format-security -fpic -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -I/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-4.19.101  LDFLAGS=-L/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/target-x86_64_musl/usr/lib -L/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/target-x86_64_musl/lib -L/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/toolchain-x86_64_gcc-8.3.0_musl/usr/lib -L/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/toolchain-x86_64_gcc-8.3.0_musl/lib -fpic -specs=/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/include/hardened-ld-pie.specs -znow -zrelro  CPPFLAGS=-I/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/target-x86_64_musl/usr/include -I/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/toolchain-x86_64_gcc-8.3.0_musl/usr/include -I/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/toolchain-x86_64_gcc-8.3.0_musl/include/fortify -I/home/bbworker/bbworker/owrt_master_x86_64/System6/build/openwrt/staging_dir/toolchain-x86_64_gcc-8.3.0_musl/include

Config options:  LIBIPTC LIBIPSET LVS VRRP VRRP_AUTH DISABLE_TRACK_PROCESS OLD_CHKSUM_COMPAT FIB_ROUTING

System options:  PIPE2 SIGNALFD INOTIFY_INIT1 VSYSLOG EPOLL_CREATE1 IPV4_DEVCONF IPV6_ADVANCED_API LIBNL3 RTA_ENCAP RTA_EXPIRES RTA_NEWDST RTA_PREF FRA_SUPPRESS_PREFIXLEN FRA_SUPPRESS_IFGROUP FRA_TUN_ID RTAX_CC_ALGO RTAX_QUICKACK RTEXT_FILTER_SKIP_STATS FRA_L3MDEV FRA_UID_RANGE RTAX_FASTOPEN_NO_COOKIE RTA_VIA FRA_OIFNAME FRA_PROTOCOL FRA_IP_PROTO FRA_SPORT_RANGE FRA_DPORT_RANGE RTA_TTL_PROPAGATE IFA_FLAGS IP_MULTICAST_ALL LWTUNNEL_ENCAP_MPLS LWTUNNEL_ENCAP_ILA LIBIPTC NET_LINUX_IF_H_COLLISION NETINET_LINUX_IF_ETHER_H_COLLISION LIBIPVS_NETLINK IPVS_DEST_ATTR_ADDR_FAMILY IPVS_SYNCD_ATTRIBUTES IPVS_64BIT_STATS VRRP_VMAC VRRP_IPVLAN IFLA_LINK_NETNSID SOCK_NONBLOCK SOCK_CLOEXEC O_PATH INET6_ADDR_GEN_MODE VRF SO_MARK SCHED_RESET_ON_FORK
```