### PR TITLE
cgi-io: fix compilation against uClibc

### DIFF
--- a/net/cgi-io/Makefile
+++ b/net/cgi-io/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgi-io
-PKG_RELEASE:=18
+PKG_RELEASE:=19
 
 PKG_LICENSE:=GPL-2.0-or-later
 

--- a/net/cgi-io/src/main.c
+++ b/net/cgi-io/src/main.c
@@ -37,6 +37,10 @@
 
 #include "multipart_parser.h"
 
+#ifndef O_TMPFILE
+#define O_TMPFILE	(020000000 | O_DIRECTORY)
+#endif
+
 #define READ_BLOCK 4096
 #define POST_LIMIT 131072
 


### PR DESCRIPTION
Signed-off-by: Jo-Philipp Wich <jo@mein.io>

Maintainer: @blogic 
Description:

uClibc does not declare `O_TMPFILE`, leading to the following build error:

    /builder/shared-workdir/build/sdk/build_dir/target-arc_archs_uClibc/cgi-io/main.c:536:28: error: 'O_TMPFILE' undeclared (first use in this function); did you mean 'EMFILE'?
       st.tempfd = open("/tmp", O_TMPFILE | O_RDWR, S_IRUSR | S_IWUSR);
                                ^~~~~~~~~
                                EMFILE