### PR TITLE
[RFC] nginx-util: use uci for server configuraton

### DIFF
--- a/net/nginx-util/Makefile
+++ b/net/nginx-util/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx-util
-PKG_VERSION:=1.4
+PKG_VERSION:=1.5
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Peter Stadler <peter.stadler@student.uibk.ac.at>
 
@@ -17,7 +17,7 @@ define Package/nginx-util/default
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
   TITLE:=Nginx configurator
-  DEPENDS:=+libstdcpp +libubus +libubox +libpthread
+  DEPENDS:=+libstdcpp +libuci +libubus +libubox +libpthread
 endef
 
 
@@ -70,23 +70,77 @@ Package/nginx-ssl-util-nopcre/description = \
   It uses the standard regex library of C++.
 
 
+define Package/nginx-util/install/default
+	$(INSTALL_DIR) $(1)/etc/nginx/conf.d/
+
+	$(INSTALL_CONF) ./files/uci.conf.template $(1)/etc/nginx/
+	$(LN) /var/lib/nginx/uci.conf $(1)/etc/nginx/uci.conf
+
+	$(INSTALL_CONF) ./files/restrict_locally $(1)/etc/nginx/
+endef
+
+
 define Package/nginx-util/install
+	$(call Package/nginx-util/install/default, $(1))
+
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) ./files/config-nginx $(1)/etc/config/nginx
+
+ifneq ($(CONFIG_IPV6),y) # without directives using `::`:
+	$(SED) "/::/d" $(1)/etc/nginx/restrict_locally
+	$(SED) "/::/d" $(1)/etc/config/nginx
+endif
+
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nginx-util $(1)/usr/bin/nginx-util
 endef
 
 
+define Package/nginx-ssl-util/install/default
+	$(call Package/nginx-util/install/default, $(1))
+
+	$(INSTALL_DIR) $(1)/etc/config/
+	$(INSTALL_CONF) ./files/config-nginx-ssl $(1)/etc/config/nginx
+
+ifneq ($(CONFIG_IPV6),y) # without directives using `::`:
+	$(SED) "/::/d" $(1)/etc/nginx/restrict_locally
+	$(SED) "/::/d" $(1)/etc/config/nginx
+endif
+endef
+
+
 define Package/nginx-ssl-util/install
+	$(call Package/nginx-ssl-util/install/default, $(1))
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nginx-ssl-util $(1)/usr/bin/nginx-util
 endef
 
 
 define Package/nginx-ssl-util-nopcre/install
+	$(call Package/nginx-ssl-util/install/default, $(1))
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nginx-ssl-util-nopcre \
 		$(1)/usr/bin/nginx-util
 endef
+
+
+define Package/nginx-ssl-util/prerm
+#!/bin/sh
+
+[ -z "$${IPKG_INSTROOT}" ] && exit 0
+[ "$${PKG_UPGRADE}" = "1" ] && exit 0
+
+eval "$$(/usr/bin/nginx-util get_env)"
+
+[ "$$(/sbin/uci get "nginx.$${LAN_NAME}.$${MANAGE_SSL}" 2>/dev/null)" = \
+	"self-signed" ] &&
+rm -f "$${CONF_DIR}$${LAN_NAME}.crt" "$${CONF_DIR}$${LAN_NAME}.key"
+
+exit 0
+endef
+
+
+Package/nginx-ssl-util-nopcre/prerm = $(Package/nginx-ssl-util/prerm)
 
 
 $(eval $(call BuildPackage,nginx-util))

--- a/net/nginx-util/files/README.sh
+++ b/net/nginx-util/files/README.sh
@@ -1,0 +1,447 @@
+#!/bin/sh
+# This is a template copy it by: ./README.sh | xclip -selection c
+# to https://openwrt.org/docs/guide-user/services/webserver/nginx#configuration
+
+NGINX_UTIL="/usr/bin/nginx-util"
+
+EXAMPLE_COM="example.com"
+
+MSG="
+/* Created by the following bash script that includes the source of some files:
+ * https://github.com/openwrt/packages/net/nginx-util/files/README.sh
+ */"
+
+eval $("${NGINX_UTIL}" get_env)
+
+code() {
+    local file
+    [ $# -gt 1 ] && file="$2" || file="$(basename "$1")"
+    printf "<file nginx %s>\n%s</file>" "$1" "$(cat "${file}")";
+}
+
+ifConfEcho() {
+    sed -nE "s/^\s*$1=\s*(\S*)\s*\\\\$/\n$2 \"\1\";/p" ../../nginx/Makefile;
+}
+
+cat <<EOF
+
+
+
+
+
+===== Configuration =====${MSG}
+
+
+
+The official Documentation contains a
+[[https://docs.nginx.com/nginx/admin-guide/|Admin Guide]].
+Here we will look at some often used configuration parts and how we handle them
+at OpenWrt.
+At different places there are references to the official
+[[https://docs.nginx.com/nginx/technical-specs/|Technical Specs]]
+for further reading.
+
+**tl;dr:** When starting Nginx by ''/etc/init.d/nginx'', it creates its main
+configuration dynamically based on a minimal template and the
+[[docs:guide-user:base-system:uci|🡒UCI]] configuration.
+
+The UCI ''/etc/config/nginx'' contains initially:
+| ''config server '${LAN_NAME}''' | \
+Default server for the LAN, which includes all ''${CONF_DIR}*.locations''. |
+| ''config server '_redirect2ssl''' | \
+Redirects inexistent URLs to HTTPS (installed only for Nginx with SSL). |
+
+It enables also the ''${CONF_DIR}'' directory for further configuration:
+| ''${CONF_DIR}\$NAME.conf'' | \
+Is included in the main configuration. \
+It is prioritized over a UCI ''config server '\$NAME' ''. |
+| ''${CONF_DIR}\$NAME.locations'' | \
+Is include in the ''${LAN_NAME}'' server and can be re-used for others, too. |
+| ''$(dirname "${CONF_DIR}")/restrict_locally'' | \
+Is include in the ''${LAN_NAME}'' server and allows only accesses from LAN. |
+
+Setup configuration (for a server ''\$NAME''):
+| ''$(basename ${NGINX_UTIL}) [${ADD_SSL_FCT}|del_ssl] \$NAME''  | \
+Add/remove a self-signed certificate and corresponding directives. |
+| ''uci set nginx.\$NAME.access_log='logd openwrt''' | \
+Writes accesses to Openwrt’s \
+[[docs:guide-user:base-system:log.essentials|🡒logd]]. |
+| ''uci set nginx.\$NAME.error_log='logd' '' | \
+Writes errors to Openwrt’s \
+[[docs:guide-user:base-system:log.essentials|🡒logd]]. |
+| ''uci [set|add_list] nginx.\$NAME.key='value' '' | \
+Becomes a ''key value;'' directive if the //key// does not start with //uci_//. |
+| ''uci set nginx.\$NAME=[disable|server]'' |\
+Disable/enable inclusion in the dynamic conf.|
+| ''uci set nginx.global.uci_enable=false'' | \
+Use a custom ''${NGINX_CONF}'' rather than a dynamic conf. |
+
+
+
+==== Basic ====${MSG}
+
+
+We modify the configuration by changing servers saved in the UCI configuration
+at ''/etc/config/nginx'' and/or by creating different configuration files in the
+''${CONF_DIR}'' directory.
+These files use the file extensions ''.locations'' and ''.conf'' (plus ''.crt''
+and ''.key'' for Nginx with SSL).((
+We can disable a single configuration file by giving it another extension, e.g.,
+by adding ''.disabled''.))
+For the new configuration to take effect, we must reload it by:
+
+<code bash>service nginx reload</code>
+
+For OpenWrt we use a special initial configuration, which is explained in the
+section [[#openwrt_s_defaults|🡓OpenWrt’s Defaults]].
+So, we can make a site available at a specific URL in the **LAN** by creating a
+''.locations'' file in the directory ''${CONF_DIR}''.
+Such a file consists just of some
+[[https://nginx.org/en/docs/http/ngx_http_core_module.html#location|
+location blocks]].
+Under the latter link, you can find also the official documentation for all
+available directives of the HTTP core of Nginx.
+Look for //location// in the Context list.
+
+The following example provides a simple template, see at the end for
+different [[#locations_for_apps|🡓Locations for Apps]]((look for
+[[https://github.com/search?utf8=%E2%9C%93&q=repo%3Aopenwrt%2Fpackages
++extension%3Alocations&type=Code&ref=advsearch&l=&l=|
+other packages using a .locations file]], too.)):
+
+<code nginx ${CONF_DIR}example.locations>
+location /ex/am/ple {
+	access_log off; # default: not logging accesses.
+	# access_log /proc/self/fd/1 openwrt; # use logd (init forwards stdout).
+	# error_log stderr; # default: logging to logd (init forwards stderr).
+	error_log /dev/null; # disable error logging after config file is read.
+	# (state path of a file for access_log/error_log to the file instead.)
+	index index.html;
+}
+# location /eg/static { … }
+</code>
+
+All location blocks in all ''.locations'' files must use different URLs,
+since they are all included in the ''${LAN_NAME}'' server that is part of the
+[[#openwrt_s_defaults|🡓OpenWrt’s Defaults]].((
+We reserve the ''location /'' for making LuCI available under the root URL,
+e.g. [[http://192.168.1.1/|192.168.1.1/]].
+All other sites shouldn’t use the root ''location /'' without suffix.))
+We should use the root URL for other sites than LuCI only on **other** domain
+names, e.g. we could make a site available at //www.example.com///.
+In order to do that, we create [[#new_server_parts|🡓New Server Parts]] for all
+domain names.
+For Nginx with SSL we can also activate SSL thereby, see
+[[#ssl_server_parts|🡓SSL Server Parts]].
+We use such server parts also for publishing sites to the internet (WAN)
+instead of making them available just locally (in the LAN).
+
+Via ''${CONF_DIR}*.conf'' files we can add directives to the //http// part of
+the configuration.
+If you would change the configuration ''$(basename "${UCI_CONF}").template''
+instead, it is not updated to new package's versions anymore.
+Although it is not recommended, you can also disable the whole UCI config and
+create your own ''${NGINX_CONF}''; then invoke:
+
+<code bash>uci set nginx.global.uci_enable=false</code>
+
+
+
+==== New Server Parts ====${MSG}
+
+
+For making the router reachable from the WAN at a registered domain name,
+it is not enough to give the name server the internet IP address of the router
+(maybe updated automatically by a
+[[docs:guide-user:services:ddns:client|🡒DDNS Client]]).
+We also need to set up virtual hosting for this domain name by creating an
+appropriate server section in ''/etc/config/nginx''
+(or in a ''${CONF_DIR}*.conf'' file, which cannot be changed using UCI).
+All such parts are included in the main configuration of OpenWrt
+([[#openwrt_s_defaults|🡓OpenWrt’s Defaults]]).
+
+In the server part, we state the domain as
+[[https://nginx.org/en/docs/http/ngx_http_core_module.html#server_name|
+server_name]].
+The link points to the same document as for the location blocks in the
+[[#basic|🡑Basic Configuration]]: the official documentation for all available
+directives of the HTTP core of Nginx.
+This time look for //server// in the Context list, too.
+The server part should also contain similar location blocks as
+++before.|
+We can re-include a ''.locations'' file that is included in the server part for
+the LAN by default.
+Then the site is reachable under the same path at both domains, e.g., by
+http://192.168.1.1/ex/am/ple as well as by http://example.com/ex/am/ple.
+++
+
+The [[#openwrt_s_defaults|🡓OpenWrt’s Defaults]] has a
+''config server '${LAN_NAME}' '' containing a server part that listens on all
+addresses, acts as //default_server// and allows connections from LAN only
+(by including the file ''restrict_locally'' with //allow/deny// directives, cf.
+the official documentation on
+[[https://nginx.org/en/docs/http/ngx_http_access_module.html|limiting access]]).
+For making another domain name accessible to all addresses, the corresponding
+server part should listen on port //80// and contain the FQDN as //server_name//,
+cf. the official documentation on
+[[https://nginx.org/en/docs/http/request_processing.html|request_processing]].
+
+We can add directives to a server in the UCI configuration by invoking
+''uci [set|add_list] nginx.${EXAMPLE_COM//./_}.key=value''.
+If the //key// is not starting with //uci_//, it becomes a ''key value;''
+++directive.|
+Although the UCI config does not support nesting like Nginx, we can add a whole
+block as //value//.
+++
+
+We cannot use dots in a //key// name other than in the //value//.
+In the following example we replace the dot in //${EXAMPLE_COM}// by an
+underscore for the UCI name of the server, but not for Nginx's //server_name//:
+
+<code bash>
+uci add nginx server &&
+uci rename nginx.@server[-1]=${EXAMPLE_COM//./_} &&
+uci add_list nginx.${EXAMPLE_COM//./_}.listen='80' &&
+uci add_list nginx.${EXAMPLE_COM//./_}.listen='[::]:80' &&
+uci set nginx.${EXAMPLE_COM//./_}.server_name='${EXAMPLE_COM}' &&
+uci add_list nginx.${EXAMPLE_COM//./_}.include=\
+'$(basename ${CONF_DIR})/${EXAMPLE_COM}.locations'
+# uci add_list nginx.${EXAMPLE_COM//./_}.location='/ { … }' \
+# root location for this server.
+</code>
+
+We can disable respective re-enable this server again by:
+
+<code bash>
+uci set nginx.${EXAMPLE_COM//./_}=disable # respective: \
+uci set nginx.${EXAMPLE_COM//./_}=server
+</code>
+
+These changes are made in the RAM (and can be used until a reboot), we can save
+them permanently by:
+
+<code bash>uci commit nginx</code>
+
+For creating a similar ''${CONF_DIR}${EXAMPLE_COM}.conf'', we can adopt the
+following:
+
+<code nginx ${CONF_DIR}${EXAMPLE_COM}.conf>
+server {
+	listen 80;
+	listen [::]:80;
+	server_name ${EXAMPLE_COM};
+	include '$(basename ${CONF_DIR})/${EXAMPLE_COM}.locations';
+	# location / { … } # root location for this server.
+}
+</code>
+
+
+
+==== SSL Server Parts ====${MSG}
+
+
+We can enable HTTPS for a domain if Nginx is installed with SSL support.
+We need a SSL certificate as well as its key and add them by the directives
+//ssl_certificate// respective //ssl_certificate_key// to the server part of the
+domain.
+The rest of the configuration is similar as for general
+[[#new_server_parts|🡑New Server Parts]].
+We only have to adjust the listen directives by adding the //ssl// parameter and
+changing the port from //80// to //443//.
+See the official documentation for
+[[https://nginx.org/en/docs/http/configuring_https_servers.html|
+configuring HTTPS servers]], too.
+
+The official documentation of the SSL module contains an
+[[https://nginx.org/en/docs/http/ngx_http_ssl_module.html#example|
+example]] with some optimizations.
+We can extend an existing UCI server section similarly, e.g., for the above
+''config server '${EXAMPLE_COM//./_}' '' we invoke:
+
+<code bash>
+# Instead of 'del_list' the listen* entries, we could use '443 ssl' beforehand.
+uci del_list nginx.${EXAMPLE_COM//./_}.listen='80' &&
+uci del_list nginx.${EXAMPLE_COM//./_}.listen='[::]:80' &&
+uci add_list nginx.${EXAMPLE_COM//./_}.listen='443 ssl' &&
+uci add_list nginx.${EXAMPLE_COM//./_}.listen='[::]:443 ssl' &&
+uci set nginx.${EXAMPLE_COM//./_}.ssl_certificate=\
+'${CONF_DIR}${EXAMPLE_COM}.crt' &&
+uci set nginx.${EXAMPLE_COM//./_}.ssl_certificate_key=\
+'${CONF_DIR}${EXAMPLE_COM}.key' &&
+uci set nginx.${EXAMPLE_COM//./_}.ssl_session_cache=\
+'${SSL_SESSION_CACHE_ARG}' &&
+uci set nginx.${EXAMPLE_COM//./_}.ssl_session_timeout=\
+'${SSL_SESSION_TIMEOUT_ARG}' &&
+uci commit nginx
+</code>
+
+For making the server in ''${CONF_DIR}${EXAMPLE_COM}.conf'' available
+via SSL, we can make similar changes there.
+
+The following command creates a **self-signed** SSL certificate and changes the
+corresponding configuration:
+
+<code bash>$(basename "${NGINX_UTIL}") ${ADD_SSL_FCT} ${EXAMPLE_COM//./_}</code>
+
+  - If a ''$(basename "${CONF_DIR}")/${EXAMPLE_COM//./_}.conf'' file exists, it\
+    adds //ssl_*// directives and changes the listen directives for the server.\
+    Else it does that for the UCI server like in the example above.
+  - Then, it checks if there is a certificate with key for the given name\
+    that is valid for at least 13 months or tries to create a self-signed one.
+  - When cron is activated, it installs a cron job for renewing the self-signed\
+    certificate every year if needed, too. We can activate cron by: \
+    <code bash>service cron enable && service cron start</code>
+
+This can be undone by invoking:
+
+<code bash>$(basename "${NGINX_UTIL}") del_ssl ${EXAMPLE_COM//./_}</code>
+
+For creating a certificate and its key signed by Let’s Encrypt we can use
+[[https://github.com/ndilieto/uacme|uacme]] or
+[[https://github.com/Neilpang/acme.sh|acme.sh]], which are installed by:
+
+<code bash>
+opkg update && opkg install uacme #or: acme #and for LuCI: luci-app-acme
+</code>
+
+[[#openwrt_s_defaults|🡓OpenWrt’s Defaults]] include a UCI server for the LAN:
+''config server '${LAN_NAME}' ''. It has //ssl_*// directives prepared for a
+self-signed SSL certificate((Let’s Encrypt (and other CAs) cannot sign
+certificates of a **local** server.))
+that is created on the first start of Nginx.
+Furthermore, there is also a UCI server named ''_redirect2ssl'' that redirects
+all HTTP requests for inexistent URLs to HTTPS.
+
+
+
+==== OpenWrt’s Defaults ====${MSG}
+
+
+Since Nginx is compiled with these presets, we can pretend that the main
+configuration will always contain the following directives
+(though we can overwrite them):
+
+<code nginx>$(ifConfEcho --pid-path pid)\
+$(ifConfEcho --lock-path lock_file)\
+$(ifConfEcho --error-log-path error_log)\
+$(false && ifConfEcho --http-log-path access_log)\
+$(ifConfEcho --http-proxy-temp-path proxy_temp_path)\
+$(ifConfEcho --http-client-body-temp-path client_body_temp_path)\
+$(ifConfEcho --http-fastcgi-temp-path fastcgi_temp_path)\
+</code>
+
+When starting or reloading the Nginx service, the ''/etc/init.d/nginx'' script
+sets also the following directives
+(so we cannot change them in the used configuration file):
+
+<code nginx>
+daemon off; # procd expects services to run in the foreground
+</code>
+
+Then, it creates the main configuration ''$(basename "${UCI_CONF}")''
+dynamically from the template:
+
+$(code "${UCI_CONF}.template")
+
+So, the access log is turned off by default and we can look at the error log
+by ''logread'', as Nginx’s init script forwards stderr and stdout to the
+[[docs:guide-user:base-system:log.essentials|🡒runtime log]].
+We can set the //error_log// and //access_log// to files, where the log
+messages are forwarded to instead (after the configuration is read).
+And for redirecting the access log of a //server// or //location// to the logd,
+too, we insert the following directive in the corresponding block:
+
+<code nginx>	access_log /proc/self/fd/1 openwrt;</code>
+
+If we setup a server through UCI, we can use the options //error_log// and/or
+//access_log// with the path
+++'logd'.|
+When initializing the Nginx service, this special path is replaced by //stderr//
+respective ///proc/self/fd/1// (which are forwarded to the runtime log).
+++
+
+For creating the configuration from the template shown above, the init.d script
+replaces the comment ''#UCI_HTTP_CONFIG'' by all UCI servers.
+For each server section in the the UCI configuration, it basically copies all
+options into a Nginx //server { … }// part, in detail:
+  * Options starting with ''uci_'' are skipped. Currently there is only\
+  the ''option ${MANAGE_SSL}=…'' in ++usage.| It is set to\
+  //'self-signed'// when invoking ''$(basename ${NGINX_UTIL}) $ADD_SSL_FCT …''.\
+  Then the corresponding certificate is re-newed if it is about to expire.\
+  All those certificates are checked on the initialization of the Nginx service\
+  and if Cron is available, it is deployed for checking them annually, too.++
+  * All other lists or options of the form ''key='value' '' are written\
+  one-to-one as ''key value;'' directives to the configuration file.\
+  Just the path //logd// has a special meaning for the logging directives\
+  (described in the previous paragraph).
+
+The init.d script of Nginx uses the //$(basename ${NGINX_UTIL})// for creating
+the configuration file
+++in RAM.|
+The main configuration ''${UCI_CONF}'' is a symbolic link to this place
+(it is a dead link if the Nginx service is not running).
+++
+
+We could use a custom configuration created at ''${NGINX_CONF}'' instead of the
+dynamic configuration, too.((
+For using a custom configuration at ''${NGINX_CONF}'', we execute
+<code bash>uci set nginx.global.uci_enable='false' </code>
+Then the rest of the UCI config is ignored and init.d will not create the main
+configuration dynamically from the template anymore.
+For Nginx with SSL invoking
+''$(basename ${NGINX_UTIL}) [add_ssl|del_ssl] \$FQDN''
+will still try to change a server in ''$(basename "${CONF_DIR}")/\$FQDN.conf''
+(this is less reliable than for a UCI config as it uses regular expressions, not
+a complete parser for the Nginx configuration).))
+This is not encouraged since you cannot setup servers using UCI anymore.
+Rather, we can put custom configuration parts to ''.conf'' files in the
+''${CONF_DIR}'' directory.
+The main configuration pulls in all ''$(basename "${CONF_DIR}")/*.conf'' files
+into the //http {…}// block behind the created UCI servers.
+
+The initial UCI config is enabled and contains a server section for the LAN:
+
+$(code "/etc/config/nginx" "config-nginx")
+
+The LAN server pulls in all ''.locations'' files from the directory
+''${CONF_DIR}''.
+We can install the location parts of different sites there (see
+[[#basic|🡑Basic Configuration]]) and re-include them into other servers.
+This is needed especially for making them available to the WAN
+([[#new_server_parts|🡑New Server Parts]]).
+The LAN server becomes the //default_server// for all addresses on port //80//
+and restricts the access to local addresses by including:
+$(code "$(dirname "${CONF_DIR}")/restrict_locally")
+
+
+=== Additional Defaults for OpenWrt if Nginx is installed with SSL support ===
+
+When Nginx is installed with SSL support, the //default_server// for the LAN
+listens on port //443// instead (but still on all addresses restricted locally).
+Additionally there is a server section that redirects requests for an inexistent
+''server_name'' from HTTP to HTTPS. It acts as //default_server// if there is
+++no other|; it uses an invalid name for that, more in the official
+documentation on
+[[https://nginx.org/en/docs/http/request_processing.html|request_processing]]
+++:
+
+$(code "/etc/config/nginx" "config-nginx-ssl")
+
+When starting or reloading the Nginx service, the init.d looks which UCI servers
+have set ''option ${MANAGE_SSL} 'self-signed' '', e.g., the LAN server.
+For all those servers it checks if there is a certificate that is still valid
+for 13 months or (re-)creates a self-signed one.
+If there is any such server, it installs also a cron job that checks the
+corresponding certificates once a year.
+The option ''${MANAGE_SSL}'' is set to //'self-signed'// respectively removed
+from a UCI server named ''${EXAMPLE_COM//./_}'' by the following
+(see [[#ssl_server_parts|🡑SSL Server Parts]], too):
+
+<code bash>
+$(basename ${NGINX_UTIL}) ${ADD_SSL_FCT} ${EXAMPLE_COM//./_} \
+# respectively: \
+$(basename ${NGINX_UTIL}) del_ssl ${EXAMPLE_COM//./_}
+</code>
+
+
+EOF

--- a/net/nginx-util/files/config-nginx
+++ b/net/nginx-util/files/config-nginx
@@ -1,0 +1,11 @@
+
+config main global
+	option uci_enable 'true'
+
+config server '_lan'
+	list listen '80 default_server'
+	list listen '[::]:80 default_server'
+	option server_name '_lan'
+	list include 'restrict_locally'
+	list include 'conf.d/*.locations'
+	option access_log 'off; # logd openwrt'

--- a/net/nginx-util/files/config-nginx-ssl
+++ b/net/nginx-util/files/config-nginx-ssl
@@ -1,0 +1,22 @@
+
+config main global
+	option uci_enable 'true'
+
+config server '_lan'
+	list listen '443 ssl default_server'
+	list listen '[::]:443 ssl default_server'
+	option server_name '_lan'
+	list include 'restrict_locally'
+	list include 'conf.d/*.locations'
+	option uci_manage_ssl 'self-signed'
+	option ssl_certificate '/etc/nginx/conf.d/_lan.crt'
+	option ssl_certificate_key '/etc/nginx/conf.d/_lan.key'
+	option ssl_session_cache 'shared:SSL:32k'
+	option ssl_session_timeout '64m'
+	option access_log 'off; # logd openwrt'
+
+config server '_redirect2ssl'
+	list listen '80'
+	list listen '[::]:80'
+	option server_name '_redirect2ssl'
+	option return '302 https://$host$request_uri'

--- a/net/nginx-util/files/restrict_locally
+++ b/net/nginx-util/files/restrict_locally
@@ -1,0 +1,10 @@
+	allow ::1;
+	allow fc00::/7;
+	allow fec0::/10;
+	allow fe80::/10;
+	allow 127.0.0.0/8;
+	allow 10.0.0.0/8;
+	allow 172.16.0.0/12;
+	allow 192.168.0.0/16;
+	allow 169.254.0.0/16;
+	deny all; 

--- a/net/nginx-util/files/uci.conf.template
+++ b/net/nginx-util/files/uci.conf.template
@@ -1,0 +1,32 @@
+# Consider using UCI or creating files in /etc/nginx/conf.d/ for configuration.
+# Parsing UCI configuration is skipped if uci set nginx.global.uci_enable=false
+# For details see: https://openwrt.org/docs/guide-user/services/webserver/nginx
+
+worker_processes auto;
+
+user root;
+
+events {}
+
+http {
+	access_log off;
+	log_format openwrt
+		'$request_method $scheme://$host$request_uri => $status'
+		' (${body_bytes_sent}B in ${request_time}s) <- $http_referer';
+
+	include mime.types;
+	default_type application/octet-stream;
+	sendfile on;
+
+	client_max_body_size 128M;
+	large_client_header_buffers 2 1k;
+
+	gzip on;
+	gzip_vary on;
+	gzip_proxied any;
+
+	root /www;
+
+	#UCI_HTTP_CONFIG
+	include conf.d/*.conf;
+}

--- a/net/nginx-util/src/CMakeLists.txt
+++ b/net/nginx-util/src/CMakeLists.txt
@@ -10,6 +10,13 @@ ADD_DEFINITIONS(-Wno-unused-parameter -Wmissing-declarations -Wshadow)
 
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 
+FIND_PATH(uci_include_dir uci.h)
+FIND_LIBRARY(uci NAMES uci)
+INCLUDE_DIRECTORIES(${uci_include_dir})
+
+FIND_PATH(ubox_include_dir libubox/blobmsg.h)
+FIND_LIBRARY(ubox NAMES ubox)
+INCLUDE_DIRECTORIES(${ubox_include_dir})
 
 IF(UBUS)
 
@@ -19,22 +26,18 @@ FIND_PATH(ubus_include_dir libubus.h)
 FIND_LIBRARY(ubus NAMES ubus)
 INCLUDE_DIRECTORIES(${ubus_include_dir})
 
-FIND_PATH(ubox_include_dir libubox/blobmsg.h)
-FIND_LIBRARY(ubox NAMES ubox)
-INCLUDE_DIRECTORIES(${ubox_include_dir})
-
 ADD_EXECUTABLE(nginx-util nginx-util.cpp)
 TARGET_COMPILE_DEFINITIONS(nginx-util PUBLIC -DNO_SSL)
-TARGET_LINK_LIBRARIES(nginx-util ${ubox} ${ubus} pthread)
+TARGET_LINK_LIBRARIES(nginx-util ${uci} ${ubox} ${ubus} pthread)
 INSTALL(TARGETS nginx-util RUNTIME DESTINATION bin)
 
 ADD_EXECUTABLE(nginx-ssl-util nginx-util.cpp)
-TARGET_LINK_LIBRARIES(nginx-ssl-util ${ubox} ${ubus} pthread ssl crypto pcre)
+TARGET_LINK_LIBRARIES(nginx-ssl-util ${uci} ${ubox} ${ubus} pthread ssl crypto pcre)
 INSTALL(TARGETS nginx-ssl-util RUNTIME DESTINATION bin)
 
 ADD_EXECUTABLE(nginx-ssl-util-nopcre nginx-util.cpp)
 TARGET_COMPILE_DEFINITIONS(nginx-ssl-util-nopcre PUBLIC -DNO_PCRE)
-TARGET_LINK_LIBRARIES(nginx-ssl-util-nopcre ${ubox} ${ubus} pthread ssl crypto)
+TARGET_LINK_LIBRARIES(nginx-ssl-util-nopcre ${uci} ${ubox} ${ubus} pthread ssl crypto)
 INSTALL(TARGETS nginx-ssl-util-nopcre RUNTIME DESTINATION bin)
 
 ELSE()
@@ -44,6 +47,8 @@ ADD_COMPILE_DEFINITIONS(VERSION=0)
 CONFIGURE_FILE(test-px5g.sh test-px5g.sh COPYONLY)
 CONFIGURE_FILE(test-nginx-util.sh test-nginx-util.sh COPYONLY)
 CONFIGURE_FILE(test-nginx-util-root.sh test-nginx-util-root.sh COPYONLY)
+CONFIGURE_FILE(../files/config-nginx-ssl config-nginx-ssl COPYONLY)
+CONFIGURE_FILE(../files/uci.conf.template uci.conf.template COPYONLY)
 
 ADD_EXECUTABLE(px5g px5g.cpp)
 TARGET_LINK_LIBRARIES(px5g ssl crypto)
@@ -51,12 +56,12 @@ INSTALL(TARGETS px5g RUNTIME DESTINATION bin)
 
 ADD_EXECUTABLE(nginx-ssl-util-noubus nginx-util.cpp)
 TARGET_COMPILE_DEFINITIONS(nginx-ssl-util-noubus PUBLIC -DNO_UBUS)
-TARGET_LINK_LIBRARIES(nginx-ssl-util-noubus pthread ssl crypto pcre)
+TARGET_LINK_LIBRARIES(nginx-ssl-util-noubus ${uci} ${ubox} pthread ssl crypto pcre)
 INSTALL(TARGETS nginx-ssl-util-noubus RUNTIME DESTINATION bin)
 
 ADD_EXECUTABLE(nginx-ssl-util-nopcre-noubus nginx-util.cpp)
 TARGET_COMPILE_DEFINITIONS(nginx-ssl-util-nopcre-noubus PUBLIC -DNO_PCRE -DNO_UBUS)
-TARGET_LINK_LIBRARIES(nginx-ssl-util-nopcre-noubus pthread ssl crypto)
+TARGET_LINK_LIBRARIES(nginx-ssl-util-nopcre-noubus ${uci} ${ubox} pthread ssl crypto)
 INSTALL(TARGETS nginx-ssl-util-nopcre-noubus RUNTIME DESTINATION bin)
 
 ENDIF()

--- a/net/nginx-util/src/nginx-util.cpp
+++ b/net/nginx-util/src/nginx-util.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <numeric>
 
 #include "nginx-util.hpp"
 
@@ -7,105 +8,256 @@
 #endif
 
 
-void create_lan_listen()
-{
-    std::string listen = "# This file is re-created if Nginx starts or"
-                    " a LAN address changes.\n";
-    std::string listen_default = listen;
-    std::string ssl_listen = listen;
-    std::string ssl_listen_default = listen;
+static auto constexpr file_comment_auto_created = std::string_view
+    {"# This file is re-created when Nginx starts.\n"};
 
-    auto add_listen = [&listen, &listen_default
-#ifndef NO_SSL
-                       ,&ssl_listen, &ssl_listen_default
+
+// TODO(pst) replace it with blobmsg_get_string if upstream takes const:
+#ifndef NO_UBUS
+static inline auto _pst_get_string(const blob_attr *attr) -> char *
+{ return static_cast<char *>(blobmsg_data(attr)); }
 #endif
-                      ]
-        (const std::string &pre, const std::string &ip, const std::string &suf)
-        -> void
-    {
-        if (ip.empty()) { return; }
-        const std::string val = pre + ip + suf;
-        listen += "\tlisten " + val + ":80;\n";
-        listen_default += "\tlisten " + val + ":80 default_server;\n";
-#ifndef NO_SSL
-        ssl_listen += "\tlisten " + val + ":443 ssl;\n";
-        ssl_listen_default += "\tlisten " + val + ":443 ssl default_server;\n";
-#endif
-    };
+
+
+void create_lan_listen() // create empty files for compatibility:
+{ 
+    //TODO: replace by dummies after transitioning nginx config to UCI:
+    std::vector<std::string> ips;
 
 #ifndef NO_UBUS
     try {
         auto loopback_status=ubus::call("network.interface.loopback", "status");
 
-        for (auto ip : loopback_status.filter("ipv4-address", "", "address")) {
-            add_listen("",  static_cast<const char *>(blobmsg_data(ip)), "");
-        }
+        for (auto ip : loopback_status.filter("ipv4-address", "", "address"))
+        { ips.emplace_back(_pst_get_string(ip)); }
 
-        for (auto ip : loopback_status.filter("ipv6-address", "", "address")) {
-            add_listen("[", static_cast<const char *>(blobmsg_data(ip)), "]");
-        }
+        for (auto ip : loopback_status.filter("ipv6-address", "", "address"))
+        { ips.emplace_back(std::string{"["} + _pst_get_string(ip) + "]"); }
+
     } catch (const std::runtime_error &) { /* do nothing about it */ }
 
     try {
         auto lan_status = ubus::call("network.interface.lan", "status");
 
-        for (auto ip : lan_status.filter("ipv4-address", "", "address")) {
-            add_listen("",  static_cast<const char *>(blobmsg_data(ip)), "");
-        }
+        for (auto ip : lan_status.filter("ipv4-address", "", "address"))
+        { ips.emplace_back(_pst_get_string(ip)); }
 
-        for (auto ip : lan_status.filter("ipv6-address", "", "address")) {
-            add_listen("[", static_cast<const char *>(blobmsg_data(ip)), "]");
-        }
+        for (auto ip : lan_status.filter("ipv6-address", "", "address"))
+        { ips.emplace_back(std::string{"["} + _pst_get_string(ip) + "]"); }
 
-        for (auto ip : lan_status.filter("ipv6-prefix-assignment", "", 
+        for (auto ip : lan_status.filter("ipv6-prefix-assignment", "",
             "local-address", "address"))
-        {
-            add_listen("[", static_cast<const char *>(blobmsg_data(ip)), "]");
-        }
+        { ips.emplace_back(std::string{"["} + _pst_get_string(ip) + "]"); }
+
     } catch (const std::runtime_error &) { /* do nothing about it */ }
 #else
-    add_listen("", "127.0.0.1", "");
+    ips.emplace_back("127.0.0.1");
 #endif
 
+    std::string listen = std::string{file_comment_auto_created};
+    std::string listen_default = std::string{file_comment_auto_created};
+    for (const auto & ip : ips) {
+        listen += "\tlisten " + ip + ":80;\n";
+        listen_default += "\tlisten " + ip + ":80 default_server;\n";
+    }
     write_file(LAN_LISTEN, listen);
     write_file(LAN_LISTEN_DEFAULT, listen_default);
+
 #ifndef NO_SSL
+    std::string ssl_listen = std::string{file_comment_auto_created};
+    std::string ssl_listen_default = std::string{file_comment_auto_created};
+    for (const auto & ip : ips) {
+        ssl_listen += "\tlisten " + ip + ":443 ssl;\n";
+        ssl_listen_default += "\tlisten " + ip + ":443 ssl default_server;\n";
+    }
     write_file(LAN_SSL_LISTEN, ssl_listen);
     write_file(LAN_SSL_LISTEN_DEFAULT, ssl_listen_default);
 #endif
 }
 
 
+inline auto change_if_starts_with(const std::string_view & subject,
+                                   const std::string_view & prefix,
+                                   const std::string_view & substitute,
+                                   const std::string_view & seperator=" \t\n;")
+    -> std::string
+{
+    auto view = subject;
+    view = view.substr(view.find_first_not_of(seperator));
+    if (view.rfind(prefix, 0)==0) {
+        if (view.size()==prefix.size()) { return std::string{substitute}; }
+        view = view.substr(prefix.size());
+        if (seperator.find(view[0])!=std::string::npos) {
+            auto ret = std::string{substitute};
+            ret += view;
+            return ret;
+        }
+    }
+    return std::string{subject};
+}
+
+
+inline auto create_server_conf(const uci::section & sec,
+                               const std::string & indent="") -> std::string
+{
+        auto secname = sec.name();
+
+        auto legacypath = std::string{CONF_DIR} + secname + ".conf";
+        if (access(legacypath.c_str(), R_OK)==0) {
+
+            auto message = std::string{"skipped UCI server 'nginx."} + secname;
+            message += "' as it could conflict with: " + legacypath + "\n";
+
+            //TODO(pst) std::cerr<<"create_server_conf notice: "<<message;
+
+            return indent + "# " + message;
+        } //else:
+
+        auto conf = indent + "server { #see uci show 'nginx." + secname + "'\n";
+
+        for (auto opt : sec) {
+
+            for (auto itm : opt) {
+
+                if (opt.name().rfind("uci_", 0)==0) { continue; }
+                //else: standard opt.name()
+
+                auto val = itm.name();
+
+                if (opt.name()=="error_log")
+                { val = change_if_starts_with(val, "logd", "/proc/self/fd/1"); }
+
+                else if (opt.name()=="access_log")
+                { val = change_if_starts_with(val, "logd", "stderr"); }
+
+                conf += indent + "\t" + opt.name() + " " + itm.name() + ";\n";
+            }
+        }
+
+        conf += indent + "}\n";
+
+        return conf;
+}
+
+
+void init_uci(const uci::package & pkg)
+{
+    auto conf = std::string{file_comment_auto_created};
+    auto suffix = std::string{};
+    auto indent = std::string{};
+
+    {
+        const auto tmpl = read_file(std::string{UCI_CONF}+".template");
+
+        const auto uci_http_config = std::string_view{"#UCI_HTTP_CONFIG\n"};
+
+        /* regex needs PCRE or std::regex (only used in SSL version):
+         * #ifndef NO_SSL
+         * rgx::smatch match;
+         * auto rgx_http_config = rgx::regex{R"(^(\s*)"+uci_http_config+")"};
+         * if (rgx::regex_search(tmpl, match, rgx_http_config)) {
+         *      auto pos = tmpl.begin() + match.position(0);
+         *      conf.append(tmpl.begin(), pos);
+         *      indent = match.str(1);
+         *      suffix.assign(pos+match.length(0), tmpl.end());
+         * }
+         * #else
+         */
+        auto pos = tmpl.find(uci_http_config);
+        if (pos != std::string::npos) {
+            const auto index = tmpl.find_last_not_of(" \t", pos-1);
+            const auto before = tmpl.begin() + index + 1;
+            conf.append(tmpl.begin(), before);
+            const auto middle = tmpl.begin() + pos;
+            indent.assign(before, middle);
+            const auto after = middle + uci_http_config.length();
+            suffix.assign(after, tmpl.end());
+        }
+        /*#endif*/
+        else {
+            write_file(VAR_UCI_CONF, tmpl);
+            return;
+        }
+    }
+
+    for (auto sec : pkg) {
+        if (sec.type()==std::string_view{"server"}) {
+            conf += create_server_conf(sec, indent) + "\n";
+        }
+    }
+
+    conf += suffix;
+    write_file(VAR_UCI_CONF, conf);
+}
+
+
+auto is_enabled(const uci::package & pkg) -> bool {
+    for (auto sec : pkg) {
+        if (sec.type()!=std::string_view{"main"}) { continue; }
+        if (sec.name()!=std::string_view{"global"}) { continue; }
+        for (auto opt : sec) {
+            if (opt.name()!="uci_enable") { continue; }
+            for (auto itm : opt) {
+                if (itm) { return true; }
+            }
+        }
+    }
+    return false;
+}
+
+
+/*
+ * ___________main_thread________________|______________thread_1________________
+ *  create_lan_listen() or do nothing    | config = uci::package("nginx")
+ *  if config_enabled (set in thread_1): | config_enabled = is_enabled(config)
+ *  then init_uci(config)                | check_ssl(config, config_enabled)
+ */
 void init_lan()
 {
     std::exception_ptr ex;
+    std::unique_ptr<uci::package> config;
+    bool config_enabled = false;
+    std::mutex configuring;
 
+    configuring.lock();
+    auto thrd = std::thread([&config, &config_enabled, &configuring, &ex]{
+        try {
+            config = std::make_unique<uci::package>("nginx");
+            config_enabled = is_enabled(*config);
+            configuring.unlock();
 #ifndef NO_SSL
-    auto thrd = std::thread([]{ //&ex
-        try { add_ssl_if_needed(std::string{LAN_NAME}); }
-        catch (...) {
-            std::cerr<<"init_lan notice: no server named "<<LAN_NAME<<std::endl;
-            // not: ex = std::current_exception();
+            check_ssl(*config, config_enabled);
+#endif
+        } catch (...) {
+            std::cerr<<"init_lan error: checking UCI file /etc/config/nginx\n";
+            ex = std::current_exception();
         }
     });
-#endif
 
     try { create_lan_listen(); }
     catch (...) {
-        std::cerr<<"init_lan error: cannot create LAN listen files"<<std::endl;
+        std::cerr<<"init_lan error: cannot create listen files of local IPs.\n";
         ex = std::current_exception();
     }
 
-#ifndef NO_SSL
-    thrd.join();
-#endif
+    configuring.lock();
+    if (config_enabled) {
+        try { init_uci(*config); }
+        catch (...) {
+            std::cerr<<"init_lan error: cannot create "<<VAR_UCI_CONF<<" from ";
+            std::cerr<<UCI_CONF<<".template using UCI file /etc/config/nginx\n";
+            ex = std::current_exception();
+        }
+    }
 
+    thrd.join();
     if (ex) { std::rethrow_exception(ex); }
 }
 
 
 void get_env()
 {
+    std::cout<<"UCI_CONF="<<"'"<<UCI_CONF<<"'"<<std::endl;
     std::cout<<"NGINX_CONF="<<"'"<<NGINX_CONF<<"'"<<std::endl;
     std::cout<<"CONF_DIR="<<"'"<<CONF_DIR<<"'"<<std::endl;
     std::cout<<"LAN_NAME="<<"'"<<LAN_NAME<<"'"<<std::endl;
@@ -116,6 +268,7 @@ void get_env()
         "'"<<std::endl;
     std::cout<<"SSL_SESSION_TIMEOUT_ARG="<<"'"<<SSL_SESSION_TIMEOUT_ARG<<"'\n";
     std::cout<<"ADD_SSL_FCT="<<"'"<<ADD_SSL_FCT<<"'"<<std::endl;
+    std::cout<<"MANAGE_SSL="<<"'"<<MANAGE_SSL<<"'"<<std::endl;
 #endif
 }
 
@@ -129,14 +282,15 @@ auto main(int argc, char * argv[]) -> int
         std::array<std::string_view, 2>{"init_lan", ""},
         std::array<std::string_view, 2>{"get_env", ""},
 #ifndef NO_SSL
-        std::array<std::string_view, 2>{ADD_SSL_FCT, " server_name" },
-        std::array<std::string_view, 2>{"del_ssl", " server_name" },
+        std::array<std::string_view, 2>{ADD_SSL_FCT, "server_name" },
+        std::array<std::string_view, 2>{"del_ssl", "server_name" },
+        std::array<std::string_view, 2>{"check_ssl", "" },
 #endif
     };
 
     try {
 
-        if (argc==2 && args[1]==cmds[0][0]) { init_lan(); }
+        if (argc==2 && args[1]==cmds[0][0]) {init_lan();}
 
         else if (argc==2 && args[1]==cmds[1][0]) { get_env(); }
 
@@ -147,8 +301,21 @@ auto main(int argc, char * argv[]) -> int
         else if (argc==3 && args[1]==cmds[3][0])
         { del_ssl(std::string{args[2]}); }
 
-        else if (argc==2 && args[1]==cmds[3][0])
-        { del_ssl(std::string{LAN_NAME}); }
+        else if (argc==2 && args[1]==cmds[3][0]) //TODO(pst) deprecate
+        {
+            try {
+                auto name = std::string{LAN_NAME};
+                if (del_ssl_legacy(name)) {
+                    auto crtpath = std::string{CONF_DIR} + name + ".crt";
+                    remove(crtpath.c_str());
+                    auto keypath = std::string{CONF_DIR} + name + ".key";
+                    remove(keypath.c_str());
+                }
+            } catch (...) { /* do nothing. */ }
+        }
+
+        else if (argc==2 && args[1]==cmds[4][0])
+        { check_ssl(uci::package{"nginx"}); }
 #endif
 
         else {
@@ -156,25 +323,28 @@ auto main(int argc, char * argv[]) -> int
 #ifdef VERSION
             std::cerr<<"version "<<VERSION<<" ";
 #endif
-            std::cerr<<"with ";
+            std::cerr<<"with libuci, ";
 #ifndef NO_UBUS
-            std::cerr<<"ubus, ";
+            std::cerr<<"libubus, ";
 #endif
 #ifndef NO_SSL
             std::cerr<<"libopenssl, ";
-#ifdef NO_PCRE
-            std::cerr<<"std::regex, ";
-#else
+#ifndef NO_PCRE
             std::cerr<<"PCRE, ";
 #endif
 #endif
             std::cerr<<"pthread and libstdcpp)."<<std::endl;
 
-            auto usage = std::string{"usage: "} + *argv + " [";
-            for (auto cmd : cmds) {
-                usage += std::string{cmd[0]};
-                usage += std::string{cmd[1]} + "|";
-            }
+            auto usage =std::accumulate(
+                cmds.begin(),
+                cmds.end(),
+                std::string{"usage: "} + *argv + " [",
+                [](const auto & use, const auto &cmd)
+                {
+                    return use + std::string{cmd[0]} +
+                        (cmd[1].empty() ? "" : " ") + std::string{cmd[1]} + "|";
+                }
+            );
             usage[usage.size()-1] = ']';
             std::cerr<<usage<<std::endl;
 
@@ -185,9 +355,14 @@ auto main(int argc, char * argv[]) -> int
 
     }
 
-    catch (const std::exception & e) { std::cerr<<e.what()<<std::endl; }
+    catch (const std::exception & e) {
+        std::cerr<<" * "<<*argv<<" "<<e.what()<<"\n";
+    }
 
-    catch (...) { perror("main error"); }
+    catch (...) {
+        std::cerr<<" * * "<<*argv;
+        perror(" main error");
+    }
 
     return 1;
 

--- a/net/nginx-util/src/nginx-util.hpp
+++ b/net/nginx-util/src/nginx-util.hpp
@@ -17,8 +17,13 @@
 #include "ubus-cxx.hpp"
 #endif
 
+#include "uci-cxx.hpp"
 
 static constexpr auto NGINX_UTIL = std::string_view{"/usr/bin/nginx-util"};
+
+static constexpr auto VAR_UCI_CONF =std::string_view{"/var/lib/nginx/uci.conf"};
+
+static constexpr auto UCI_CONF = std::string_view{"/etc/nginx/uci.conf"};
 
 static constexpr auto NGINX_CONF = std::string_view{"/etc/nginx/nginx.conf"};
 
@@ -26,9 +31,11 @@ static constexpr auto CONF_DIR = std::string_view{"/etc/nginx/conf.d/"};
 
 static constexpr auto LAN_NAME = std::string_view{"_lan"};
 
+static auto constexpr MANAGE_SSL = std::string_view{"uci_manage_ssl"};
+
 static constexpr auto LAN_LISTEN =std::string_view{"/var/lib/nginx/lan.listen"};
 
-static constexpr auto LAN_LISTEN_DEFAULT =
+static constexpr auto LAN_LISTEN_DEFAULT = //TODO(pst) deprecate
     std::string_view{"/var/lib/nginx/lan.listen.default"};
 
 
@@ -48,6 +55,12 @@ auto call(const std::string & program, S... args) -> pid_t;
 
 
 void create_lan_listen();
+
+
+void init_uci(const uci::package & pkg);
+
+
+auto is_enabled(const uci::package & pkg) -> bool;
 
 
 void init_lan();

--- a/net/nginx-util/src/px5g.cpp
+++ b/net/nginx-util/src/px5g.cpp
@@ -1,6 +1,7 @@
 #include "px5g-openssl.hpp"
 #include <array>
 #include <iostream>
+#include <numeric>
 #include <string>
 #include <string_view>
 #include <unistd.h>
@@ -422,10 +423,13 @@ auto main(int argc, const char ** argv) -> int
 
     catch (const std::exception & e)  {
 
-        auto usage = std::string{"usage: \n"}  ;
-        for (auto cmd : cmds) {
-            usage += std::string{4, ' '} + *argv +" "+ cmd[0] + cmd[1] +"\n";
-        }
+        auto usage = std::accumulate(
+            cmds.begin(),
+            cmds.end(),
+            std::string{"usage: \n"},
+            [=](const auto &use, const auto &cmd)
+            { return use+ std::string{4, ' '} + *argv +" "+cmd[0]+cmd[1]+"\n"; }
+        );
 
         std::cerr<<usage<<std::flush;
 

--- a/net/nginx-util/src/regex-pcre.hpp
+++ b/net/nginx-util/src/regex-pcre.hpp
@@ -105,12 +105,15 @@ public:
     inline auto operator=(regex &&) -> regex & = delete;
 
 
-    explicit regex(const std::string & str)
-    : re{ pcre_compile2(str.c_str(), 0, &errcode, &errptr, &erroffset,nullptr) }
+    explicit regex(const std::string & str) : regex(str.c_str()) {}
+
+
+    explicit regex(const char * const str)
+    : re{ pcre_compile2(str, 0, &errcode, &errptr, &erroffset,nullptr) }
     {
         if (re==nullptr) {
             std::string what = std::string("regex error: ") + errptr + '\n';
-            what += "    '" + str + "'\n";
+            what += "    '" + std::string{str} + "'\n";
             what += "     " + std::string(erroffset, ' ') + '^';
 
             throw regex_error(errcode_pcre2regex.at(errcode), what.c_str());

--- a/net/nginx-util/src/test-nginx-util-root.sh
+++ b/net/nginx-util/src/test-nginx-util-root.sh
@@ -4,6 +4,57 @@ PRINT_PASSED=2
 
 NGINX_UTIL="/usr/bin/nginx-util"
 
+ORIG=".original-test-nginx-util-root"
+
+mkdir -p /tmp/.uci/
+
+uci commit nginx || { printf "Error invoking: uci commit\n Exit."; exit 2; }
+
+
+pst_exit() {
+    printf "\nExit: Recovering original settings ... "
+
+    uci revert nginx
+
+    cd "/etc/config/" && rm "nginx" && mv "nginx.${ORIG}" "nginx" ||
+    printf "\n%s: not moved %s to %s\n" "/etc/config/" "nginx${ORIG}" "nginx"
+
+    cd "/etc/crontabs/" && rm "root" && mv "root${ORIG}" "root" ||
+    printf "\n%s: not moved %s to %s\n" "/etc/crontabs/" "root${ORIG}" "root"
+
+    cd "$(dirname "${CONF_DIR}")" && rm -r "${CONF_DIR}" &&
+    mv "$(basename "${CONF_DIR}")${ORIG}" "$(basename "${CONF_DIR}")" ||
+    printf "\n%s: not moved %s to %s\n" "$(dirname "${CONF_DIR}")" \
+        "$(basename "${CONF_DIR}")${ORIG}" "$(basename "${CONF_DIR}")"
+
+    printf "done.\n"
+
+    exit "$1"
+}
+
+
+mkdir -p "/etc/config/" && touch "/etc/config/nginx"
+
+cd "/etc/config/" && [ ! -e "nginx${ORIG}" ] && cp "nginx" "nginx.${ORIG}" || {
+    printf "\n%s: not copied %s to %s\n" "/etc/config/" "nginx" "nginx${ORIG}"
+    pst_exit 3
+}
+
+uci set nginx.global.uci_enable=1
+
+
+mkdir -p "/etc/crontabs/" && touch "/etc/crontabs/root"
+
+cd "/etc/crontabs/" && [ ! -e "root${ORIG}" ] && mv "root" "root${ORIG}" || {
+    printf "\n%s: not moved %s to %s\n" "/etc/crontabs/" "root${ORIG}" "root"
+    pst_exit 4
+}
+
+touch "/etc/crontabs/root"
+
+
+# ----------------------------------------------------------------------------
+
 __esc_newlines() {
     echo "${1}" | sed -E 's/$/\\n/' | tr -d '\n' | sed -E 's/\\n$/\n/'
 }
@@ -33,6 +84,36 @@ _echo_sed() {
     echo "" | sed -E "c${1}"
 }
 
+
+fileauto="# This file is re-created when Nginx starts."
+
+setpoint_init_lan() {
+#     local r
+#     r='/^\s*listen\s+([^1]|1[^2]|12[^7]).*:(80|443)\s+(\S*\s+)*default_server/d'
+#     sed -i -E "${r}" "$(readlink "${UCI_CONF}")" >/dev/null
+
+    echo "${fileauto}"
+
+    sed -n -E '/^\s*#UCI_HTTP_CONFIG\s*$/q;p' "${UCI_CONF}.template"
+
+    local rhs="\t}\n\n\tserver { #see uci show 'nginx.\1'"
+    uci -n export nginx \
+    | sed -E -e "s/'//g" \
+        -e '/^\s*package\s+nginx\s*$/d' \
+        -e '/^\s*config\s+main\s/d' \
+        -e "s/^\s*config\s+server\s+(.*)$/$rhs/g" \
+        -e 's/^\s*list\s/\t\t/g' \
+        -e 's/^\s*option\s/\t\t/g' \
+        -e 's/^\s*uci_listen_locally\s+/\t\tlisten 127.0.0.1:/g' \
+        -e '/^\s*uci_/d' \
+        -e '/^$/d' -e "s/[^'\n]$/&;/g" \
+    | sed "1,2d"
+    printf "\t}\n\n"
+
+    sed -E '1,/^\s*#UCI_HTTP_CONFIG\s*$/ d' "${UCI_CONF}.template"
+}
+
+
 setpoint_add_ssl() {
     local indent="\n$1"
     local name="$2"
@@ -40,13 +121,19 @@ setpoint_add_ssl() {
     [ "${name}" = "${LAN_NAME}" ] && default=".default"
     local prefix="${CONF_DIR}${name}"
 
-    local CONF="$(grep -vE "$(_regex "${NGX_INCLUDE}" \
-        "${LAN_LISTEN}${default}")" "${prefix}.sans" 2>/dev/null)"
     local ADDS=""
-    echo "${CONF}" \
-        | grep -qE "$(_regex "${NGX_INCLUDE}" "${LAN_SSL_LISTEN}${default}")" \
-    || ADDS="${ADDS}${indent}$(_sed_rhs "${NGX_INCLUDE}" \
-        "${LAN_SSL_LISTEN}${default}")"
+    local CONF
+    CONF="$(sed -E \
+        -e "s/$(_regex "${NGX_INCLUDE}" "${LAN_LISTEN}${default}")/$1$(\
+                _sed_rhs "${NGX_INCLUDE}" "${LAN_SSL_LISTEN}${default}")/g" \
+        -e "s/^(\s*listen\s+)([^:]*:|\[[^]]*\]:)?80(\s|$|;)/\1\2443 ssl\3/g" \
+            "${prefix}.sans" 2>/dev/null)"
+#     CONF="$(grep -vE "$(_regex "${NGX_INCLUDE}" "${LAN_LISTEN}${default}")" \
+#             "${prefix}.sans" 2>/dev/null)"
+#     echo "${CONF}" \
+#         | grep -qE "$(_regex "${NGX_INCLUDE}" "${LAN_SSL_LISTEN}${default}")" \
+#     || ADDS="${ADDS}${indent}$(_sed_rhs "${NGX_INCLUDE}" \
+#         "${LAN_SSL_LISTEN}${default}")"
     echo "${CONF}" | grep -qE "$(_regex "${NGX_SSL_CRT}" "${prefix}")" \
     || ADDS="${ADDS}${indent}$(_sed_rhs "${NGX_SSL_CRT}" "${prefix}")"
     echo "${CONF}" | grep -qE "$(_regex "${NGX_SSL_KEY}" "${prefix}")" \
@@ -90,14 +177,19 @@ test() {
         && printf "%-72s%-1s\n" "$1" "2>/dev/null >/dev/null (-> $2?) passed."
     else
         printf "%-72s%-1s\n" "$1" "2>/dev/null >/dev/null (-> $2?) failed!!!"
-        [ "${PRINT_PASSED}" -gt 1 ] && exit 1
+        [ "${PRINT_PASSED}" -gt 0 ] && printf "\n### Snip:\n" && eval "$1"
+        [ "${PRINT_PASSED}" -gt 0 ] && printf "### Snap.\n"
+        [ "${PRINT_PASSED}" -gt 1 ] && pst_exit 1
     fi
 }
 
 
+
 [ "$PRINT_PASSED" -gt 0 ] && printf "\nTesting %s get_env ...\n" "${NGINX_UTIL}"
 
+
 eval $("${NGINX_UTIL}" get_env)
+test '[ -n "${UCI_CONF}" ]' 0
 test '[ -n "${NGINX_CONF}" ]' 0
 test '[ -n "${CONF_DIR}" ]' 0
 test '[ -n "${LAN_NAME}" ]' 0
@@ -106,13 +198,26 @@ test '[ -n "${LAN_SSL_LISTEN}" ]' 0
 test '[ -n "${SSL_SESSION_CACHE_ARG}" ]' 0
 test '[ -n "${SSL_SESSION_TIMEOUT_ARG}" ]' 0
 test '[ -n "${ADD_SSL_FCT}" ]' 0
+test '[ -n "${MANAGE_SSL}" ]' 0
+
+mkdir -p "$(dirname "${LAN_LISTEN}")"
+
+mkdir -p "${CONF_DIR}"
+
+cd "$(dirname "${CONF_DIR}")" && [ ! -e "$(basename "${CONF_DIR}")${ORIG}" ] &&
+mv "$(basename "${CONF_DIR}")" "$(basename "${CONF_DIR}")${ORIG}" ||
+{
+    printf "\n%s: not moved %s to %s\n" "$(dirname "${CONF_DIR}")" \
+        "$(basename "${CONF_DIR}")" "$(basename "${CONF_DIR}")${ORIG}"
+    pst_exit 3
+}
 
 
 [ "$PRINT_PASSED" -gt 0 ] && printf "\nPrepare files in %s ...\n" "${CONF_DIR}"
 
 mkdir -p "${CONF_DIR}"
 
-cd "${CONF_DIR}" || exit 2
+cd "${CONF_DIR}" || pst_exit 2
 
 NGX_INCLUDE="include '\$';"
 NGX_SERVER_NAME="server_name * '\$' *;"
@@ -140,6 +245,24 @@ server {
 EOF
 CONFS="${CONFS} minimal:0"
 
+cat > listens.sans <<EOF
+server {
+    listen 80;
+    listen 81;
+    listen hostname:80;
+    listen hostname:81;
+    listen [::]:80;
+    listen [::]:81;
+    listen 1.3:80;
+#    listen 1.3:80;
+    listen 1.3:81;
+    listen [1::3]:80;
+    listen [1::3]:81;
+    server_name listens;
+}
+EOF
+CONFS="${CONFS} listens:0"
+
 cat > normal.sans <<EOF
 server {
     include '${LAN_LISTEN}';
@@ -163,6 +286,9 @@ CONFS="${CONFS} more_server:0"
 cat > more_names.sans <<EOF
 server {
     include '${LAN_LISTEN}';
+    include '${LAN_LISTEN}';
+    include '${LAN_LISTEN}';
+    not include '${LAN_LISTEN}';
     server_name example.com more_names example.org;
 }
 EOF
@@ -203,16 +329,9 @@ EOF
 CONFS="${CONFS} tab:0"
 
 
-[ "$PRINT_PASSED" -gt 0 ] && printf "\nTesting %s init_lan ...\n" "${NGINX_UTIL}"
-
-mkdir -p "$(dirname "${LAN_LISTEN}")"
-
-cp "${LAN_NAME}.sans" "${LAN_NAME}.conf"
-
-test '"${NGINX_UTIL}" init_lan' 0
-
 
 [ "$PRINT_PASSED" -gt 0 ] && printf "\nSetup files in %s ...\n" "${CONF_DIR}"
+
 
 for conf in ${CONFS}
 do test 'setpoint_add_ssl "    " '"${conf%:*}" "${conf#*:}"
@@ -221,26 +340,197 @@ done
 test 'setpoint_add_ssl "\t" tab' 0 # fixes wrong indentation.
 
 
+
+[ "$PRINT_PASSED" -gt 0 ] && printf "\nTesting Cron ... \n"
+
+
+echo -n "prefix" >"/etc/crontabs/root"
+test '"${NGINX_UTIL}" add_ssl _lan' 0
+echo "postfix" >>"/etc/crontabs/root"
+test_setpoint "/etc/crontabs/root" "prefix
+3 3 12 12 * ${NGINX_UTIL} 'check_ssl'
+postfix"
+
+test '"${NGINX_UTIL}" del_ssl _lan' 0
+test_setpoint "/etc/crontabs/root" "prefix
+3 3 12 12 * ${NGINX_UTIL} 'check_ssl'
+postfix"
+
+test '"${NGINX_UTIL}" check_ssl' 0
+test_setpoint "/etc/crontabs/root" "prefix
+postfix"
+
+test '"${NGINX_UTIL}" add_ssl _lan' 0
+test_setpoint "/etc/crontabs/root" "prefix
+postfix
+3 3 12 12 * ${NGINX_UTIL} 'check_ssl'"
+
+rm -f "/etc/crontabs/root"
+
+
+[ "$PRINT_PASSED" -gt 0 ] && printf '\n\t-"-\t(legacy) ... \n'
+
+echo -n "prefix" >"/etc/crontabs/root"
+cp "minimal.sans" "minimal.conf"
+
+test '"${NGINX_UTIL}" add_ssl minimal' 0
+echo "postfix" >>"/etc/crontabs/root"
+test_setpoint "/etc/crontabs/root" "prefix
+3 3 12 12 * ${NGINX_UTIL} 'add_ssl' 'minimal'
+postfix"
+
+test '"${NGINX_UTIL}" del_ssl minimal' 0
+test_setpoint "/etc/crontabs/root" "prefix
+postfix"
+
+rm -f "/etc/crontabs/root"
+
+
+
+[ "$PRINT_PASSED" -gt 0 ] && printf "\nTesting %s init_lan ...\n" "${NGINX_UTIL}"
+
+
+rm -f "${LAN_NAME}.conf" "_redirect2ssl.conf" "${UCI_ADDED}.conf"
+rm -f "$(readlink "${UCI_CONF}")"
+
+test '"${NGINX_UTIL}" init_lan' 0
+test_setpoint "${UCI_CONF}" "$(setpoint_init_lan)"
+test_setpoint "/etc/crontabs/root" "3 3 12 12 * ${NGINX_UTIL} 'check_ssl'"
+
+
+[ "$PRINT_PASSED" -gt 0 ] && printf '\n\t-"-\twith temporary UCI config ... \n'
+
+UCI_ADDED="$(uci add nginx server)" &&
+uci set nginx.@server[-1].server_name='temp' &&
+uci add_list nginx.@server[-1].listen='81 default_server' &&
+uci add_list nginx.@server[-1].listen='80' &&
+echo "UCI: nginx.${UCI_ADDED} added."
+
+rm -f "${LAN_NAME}.conf" "_redirect2ssl.conf" "${UCI_ADDED}.conf"
+rm -f "$(readlink "${UCI_CONF}")"
+
+test '"${NGINX_UTIL}" init_lan' 0
+test_setpoint "${UCI_CONF}" "$(setpoint_init_lan)"
+test_setpoint "/etc/crontabs/root" "3 3 12 12 * ${NGINX_UTIL} 'check_ssl'"
+
+
+[ "$PRINT_PASSED" -gt 0 ] && printf '\n\t-"-\t(legacy) ... \n'
+
+cp "${LAN_NAME}.sans" "${LAN_NAME}.conf"
+touch "_redirect2ssl.conf" "${UCI_ADDED}.conf"
+rm -f "$(readlink "${UCI_CONF}")"
+test '"${NGINX_UTIL}" init_lan' 0
+
+skipped() {
+    printf "\t# skipped UCI server 'nginx.%s'" "$1"
+    printf " as it could conflict with: %s%s.conf\n\n" "${CONF_DIR}" "$1"
+}
+rhs="$(skipped "$LAN_NAME" && skipped _redirect2ssl && skipped "${UCI_ADDED}")"
+sed -E -e "s/^\t#UCI_HTTP_CONFIG$/$(__esc_sed_rhs "$rhs")\n/" \
+    -e 's/\\n/\n/g' -e "1i${fileauto}" "${UCI_CONF}.template" >"uci.setpoint"
+
+test_setpoint "${UCI_CONF}" "$(cat "uci.setpoint")"
+test_setpoint "/etc/crontabs/root" ""
+
+
+
 [ "$PRINT_PASSED" -gt 0 ] && printf "\nTesting %s add_ssl ...\n" "${NGINX_UTIL}"
 
-cp different_name.sans different_name.with
 
 test '[ "${ADD_SSL_FCT}" = "add_ssl" ] ' 0
 
+rm -f "${LAN_NAME}.conf" "_redirect2ssl.conf" "${UCI_ADDED}.conf"
+rm -f "$(readlink "${UCI_CONF}")"
+test 'uci set nginx._lan.uci_manage_ssl="self-signed"' 0
+"${NGINX_UTIL}" del_ssl "${LAN_NAME}" 2>/dev/null
+test '"${NGINX_UTIL}" add_ssl '"${LAN_NAME}" 0
+test_setpoint "/etc/crontabs/root" "3 3 12 12 * ${NGINX_UTIL} 'check_ssl'"
+test '"${NGINX_UTIL}" add_ssl '"${LAN_NAME}" 0
+test_setpoint "/etc/crontabs/root" "3 3 12 12 * ${NGINX_UTIL} 'check_ssl'"
+test '"${NGINX_UTIL}" add_ssl '"${UCI_ADDED}" 0
+test_setpoint "/etc/crontabs/root" "3 3 12 12 * ${NGINX_UTIL} 'check_ssl'"
+test '"${NGINX_UTIL}" add_ssl inexistent' 1
+test_setpoint "/etc/crontabs/root" "3 3 12 12 * ${NGINX_UTIL} 'check_ssl'"
+test '"${NGINX_UTIL}" init_lan' 0
+test_setpoint "${UCI_CONF}" "$(setpoint_init_lan)"
+test_setpoint "/etc/crontabs/root" "3 3 12 12 * ${NGINX_UTIL} 'check_ssl'"
+
+
+[ "$PRINT_PASSED" -gt 0 ] && printf '\n\t-"-\t(legacy) ... \n'
+
+cp different_name.sans different_name.with
+
+cp "/etc/crontabs/root" "cron.setpoint"
 for conf in ${CONFS}; do
     name="${conf%:*}"
+    [ "${name}" = "different_name" ] ||
+    echo "3 3 12 12 * ${NGINX_UTIL} 'add_ssl' '${name}'" >>"cron.setpoint"
     cp "${name}.sans" "${name}.conf"
     test '"${NGINX_UTIL}" add_ssl '"${name}" "${conf#*:}"
     test_setpoint "${name}.conf" "$(cat "${name}.with")"
+    test_setpoint "/etc/crontabs/root" "$(cat "cron.setpoint")"
 done
+
+
 
 [ "$PRINT_PASSED" -gt 0 ] && printf "\nTesting %s del_ssl ...\n" "${NGINX_UTIL}"
 
-sed -i "/server {/a\\    include '${LAN_LISTEN}';" minimal.sans
+
+sed -E -e 's/443 ssl/80/' -e '/[^2]ssl/d' "/etc/config/nginx" >"config.setpoint"
+
+cp "/etc/crontabs/root" "cron.setpoint"
+rm -f "${LAN_NAME}.conf" "_redirect2ssl.conf" "${UCI_ADDED}.conf"
+test '"${NGINX_UTIL}" del_ssl '"${LAN_NAME}" 0
+test_setpoint "/etc/crontabs/root" "$(cat "cron.setpoint")"
+test '"${NGINX_UTIL}" del_ssl '"${LAN_NAME}" 1
+test_setpoint "/etc/crontabs/root" "$(cat "cron.setpoint")"
+test '"${NGINX_UTIL}" del_ssl '"${UCI_ADDED}" 0
+test_setpoint "/etc/crontabs/root" "$(cat "cron.setpoint")"
+test '"${NGINX_UTIL}" del_ssl inexistent' 1
+test_setpoint "/etc/crontabs/root" "$(cat "cron.setpoint")"
+
+test_setpoint "/etc/config/nginx" "$(cat "config.setpoint")"
+
+rm -f "$(readlink "${UCI_CONF}")"
+sed -E "/$(__esc_regex "'check_ssl'")/d" "/etc/crontabs/root" >"cron.setpoint"
+test '"${NGINX_UTIL}" init_lan' 0
+test_setpoint "${UCI_CONF}" "$(setpoint_init_lan)"
+test_setpoint "/etc/crontabs/root" "$(cat "cron.setpoint")"
+
+
+[ "$PRINT_PASSED" -gt 0 ] && printf '\n\t-"-\t(legacy) ... \n'
 
 for conf in ${CONFS}; do
     name="${conf%:*}"
+    sed -E "/$(__esc_regex "'${name}'")/d" "/etc/crontabs/root" >"cron.setpoint"
     cp "${name}.with" "${name}.conf"
     test '"${NGINX_UTIL}" del_ssl '"${name}" "${conf#*:}"
     test_setpoint "${name}.conf" "$(cat "${name}.sans")"
+    test_setpoint "/etc/crontabs/root" "$(cat "cron.setpoint")"
 done
+test_setpoint "/etc/crontabs/root" ""
+
+
+[ "$PRINT_PASSED" -gt 0 ] && printf "\nTesting without UCI ... \n"
+
+rm -f "$(readlink "${UCI_CONF}")"
+
+test 'uci set nginx.global.uci_enable=0' 0
+
+test '"${NGINX_UTIL}" init_lan' 0
+
+test '[ -e "$(readlink '"${UCI_CONF}"')" ]' 1
+
+cp "${LAN_NAME}.sans" "${LAN_NAME}.conf"
+test '"${NGINX_UTIL}" add_ssl '"${LAN_NAME}" 0
+test '"${NGINX_UTIL}" add_ssl '"${LAN_NAME}" 0
+test '"${NGINX_UTIL}" del_ssl '"${LAN_NAME}" 0
+test '"${NGINX_UTIL}" del_ssl '"${LAN_NAME}" 0
+
+test 'rm "${LAN_NAME}.conf"' 0
+test '"${NGINX_UTIL}" add_ssl '"${LAN_NAME}" 1
+test '"${NGINX_UTIL}" del_ssl '"${LAN_NAME}" 1
+
+
+
+pst_exit 0

--- a/net/nginx-util/src/test-nginx-util.sh
+++ b/net/nginx-util/src/test-nginx-util.sh
@@ -14,8 +14,17 @@ TMPROOT="$(mktemp -d "/tmp/test-nginx-util-XXXXXX")"
 
 ln -s /bin "${TMPROOT}/bin"
 
-mkdir -p "${TMPROOT}/usr/bin/"
+mkdir -p "${TMPROOT}/etc/crontabs/"
 
+mkdir -p "${TMPROOT}/etc/config/"
+cp "./config-nginx-ssl" "${TMPROOT}/etc/config/nginx"
+
+mkdir -p "${TMPROOT}/etc/nginx/"
+cp "./uci.conf.template" "${TMPROOT}/etc/nginx/uci.conf.template"
+ln -s "${TMPROOT}/var/lib/nginx/uci.conf" "${TMPROOT}/etc/nginx/uci.conf"
+
+mkdir -p "${TMPROOT}/usr/bin/"
+cp "/usr/local/bin/uci" "${TMPROOT}/usr/bin/"
 cp "./test-nginx-util-root.sh" "${TMPROOT}/usr/bin/"
 
 

--- a/net/nginx-util/src/uci-cxx.cpp
+++ b/net/nginx-util/src/uci-cxx.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "uci-cxx.hpp"
+
+
+auto main() -> int {
+
+    uci::element p = uci::package{"nginx"};
+    std::cout<<"package "<<p.name()<<"\n\n";
+    for (auto s : p) {
+        std::cout<<"config "<<s.type()<<" '"<<s.name()<<"'\n";
+        for (auto o : s) {
+            for (auto i : o) {
+                std::cout<<"\t"<<o.type()<<" "<<o.name()<<" '"<<i.name()<<"'\n";
+            }
+        }
+        std::cout<<"\n";
+    }
+
+}

--- a/net/nginx-util/src/uci-cxx.hpp
+++ b/net/nginx-util/src/uci-cxx.hpp
@@ -1,0 +1,510 @@
+#ifndef _UCI_CXX_HPP
+#define _UCI_CXX_HPP
+
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <uci.h>
+
+
+namespace uci {
+
+
+
+template<class T>
+class iterator { // like uci_foreach_element_safe.
+
+private:
+
+    const uci_ptr & _ptr;
+
+    uci_element * _it = nullptr;
+
+    uci_element * _next = nullptr;
+
+    // wrapper for clang-tidy
+    inline auto _list_to_element(const uci_list * cur) -> uci_element * {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-cstyle-cast)
+        return list_to_element(cur); // macro casting container=pointer-offset.
+    }
+
+
+public:
+
+    inline explicit iterator(const uci_ptr & ptr, const uci_list * cur)
+    : _ptr{ptr}, _it{_list_to_element(cur)}
+    { _next = _list_to_element(_it->list.next); }
+
+
+    inline iterator(iterator &&) noexcept = default;
+
+
+    inline iterator(const iterator &) = delete;
+
+
+    inline auto operator=(const iterator &) -> iterator & = delete;
+
+
+    inline auto operator=(iterator &&) -> iterator & = delete;
+
+
+    auto operator*() -> T { return T{_ptr, _it}; }
+
+
+    inline auto operator!=(const iterator & rhs) -> bool
+    { return (&_it->list != &rhs._it->list); }
+
+
+    inline auto operator++() -> iterator &
+    {
+        _it = _next;
+        _next = _list_to_element(_next->list.next);
+        return *this;
+    }
+
+
+    inline ~iterator() = default;
+
+};
+
+
+
+class locked_context {
+
+private:
+
+    static std::mutex inuse;
+
+
+public:
+
+    inline locked_context() { inuse.lock(); }
+
+    inline locked_context(locked_context &&) noexcept = default;
+
+    inline locked_context(const locked_context &) = delete;
+
+    inline auto operator=(const locked_context &) -> locked_context & = delete;
+
+    inline auto operator=(locked_context &&) -> locked_context & = delete;
+
+
+    //NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    inline auto get() -> uci_context * // is member to enforce inuse
+    {
+        static auto free_ctx = [](uci_context * ctx) { uci_free_context(ctx); };
+        static std::unique_ptr<uci_context, decltype(free_ctx)>
+            lazy_ctx{uci_alloc_context(), free_ctx};
+
+        if (!lazy_ctx) { // it could be available on a later call:
+            lazy_ctx.reset(uci_alloc_context());
+            if (!lazy_ctx) {
+                throw std::runtime_error("uci error: cannot allocate context");
+            }
+        }
+
+        return lazy_ctx.get();
+    }
+
+
+    inline ~locked_context() { inuse.unlock(); }
+
+};
+
+
+
+template<class T>
+class element {
+
+private:
+
+    uci_list * _begin = nullptr;
+
+    uci_list * _end = nullptr;
+
+    uci_ptr _ptr{};
+
+
+protected:
+
+    [[nodiscard]] inline auto ptr() -> uci_ptr & { return _ptr; }
+
+
+    [[nodiscard]] inline auto ptr() const -> const uci_ptr & { return _ptr; }
+
+
+    void init_begin_end(uci_list * begin, uci_list * end)
+    {
+        _begin = begin;
+        _end = end;
+    }
+
+
+    inline explicit element(const uci_ptr & pre, uci_element * last)
+    : _ptr{pre} { _ptr.last = last; }
+
+
+    inline explicit element() = default;
+
+
+public:
+
+    inline element(element &&) noexcept = default;
+
+
+    inline element(const element &) = delete;
+
+
+    inline auto operator=(const element &) -> element & = delete;
+
+
+    inline auto operator=(element &&) -> element & = delete;
+
+
+    auto operator[](std::string_view key) const -> T;
+
+
+    [[nodiscard]] inline auto name() const -> std::string
+    { return _ptr.last->name; }
+
+
+    void rename(const char * value) const;
+
+
+    void commit() const;
+
+
+    [[nodiscard]] inline auto begin() const -> iterator<T>
+    { return iterator<T>{_ptr, _begin}; }
+
+
+    [[nodiscard]] inline auto end() const -> iterator<T>
+    { return iterator<T>{_ptr, _end}; }
+
+
+    inline ~element() = default;
+
+};
+
+
+class section;
+
+class option;
+
+class item;
+
+
+
+class package : public element<section> {
+
+public:
+
+    inline package(const uci_ptr & pre, uci_element * last) : element{pre, last}
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-cstyle-cast)
+        ptr().p = uci_to_package(ptr().last); // macro casting pointer-offset.
+        ptr().package = ptr().last->name;
+
+        auto end = &ptr().p->sections;
+        auto begin = end->next;
+        init_begin_end(begin, end);
+    }
+
+
+    explicit package(const char * name);
+
+
+    auto set(const char * key, const char * type) const -> section;
+
+};
+
+
+
+class section : public element<option> {
+
+public:
+
+    inline section(const uci_ptr & pre, uci_element * last) : element{pre, last}
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-cstyle-cast)
+        ptr().s = uci_to_section(ptr().last); // macro casting pointer-offset.
+        ptr().section = ptr().last->name;
+
+        auto end = &ptr().s->options;
+        auto begin = end->next;
+        init_begin_end(begin, end);
+    }
+
+
+    auto set(const char * key, const char * value) const -> option;
+
+
+    void del();
+
+
+    [[nodiscard]] inline auto anonymous() const -> bool
+    { return ptr().s->anonymous; }
+
+
+    [[nodiscard]] inline auto type() const -> std::string
+    { return ptr().s->type; }
+
+};
+
+
+
+class option : public element<item> {
+
+public:
+
+    inline option(const uci_ptr & pre, uci_element * last) : element{pre, last}
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-cstyle-cast)
+        ptr().o = uci_to_option(ptr().last); // macro casting pointer-offset.
+        ptr().option = ptr().last->name;
+
+        if (ptr().o->type==UCI_TYPE_LIST) { // use union ptr().o->v as list:
+            //NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+            auto end = &ptr().o->v.list;
+            auto begin = end->next;
+            init_begin_end(begin, end);
+        } else {
+            auto begin = &ptr().last->list;
+            auto end = begin->next;
+            init_begin_end(begin, end);
+        }
+    }
+
+
+    void del();
+
+
+    [[nodiscard]] inline auto type() const -> std::string
+    { return (ptr().o->type==UCI_TYPE_LIST ? "list" : "option"); }
+
+};
+
+
+
+class item : public element<item> {
+
+public:
+
+    inline item(const uci_ptr & pre, uci_element * last) : element{pre, last}
+    { ptr().value = ptr().last->name; }
+
+
+    [[nodiscard]] inline auto type() const -> std::string
+    { return (ptr().o->type==UCI_TYPE_LIST ? "list" : "option"); }
+
+
+    [[nodiscard]] inline auto name() const -> std::string
+    {
+        return ( ptr().last->type==UCI_TYPE_ITEM ? ptr().last->name :
+                 //else: use union ptr().o->v as string:
+                 //NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+                 ptr().o->v.string );
+    }
+
+
+    inline explicit operator bool() const
+    {
+        const auto x = std::string_view{name()};
+
+        if (x=="0" || x=="off" || x=="false" || x=="no" || x=="disabled")
+        { return false; }
+
+        if (x=="1" || x=="on" || x=="true" || x=="yes" || x=="enabled")
+        { return true; }
+
+        auto errmsg = std::string{"uci_error: item is not bool "} + name();
+        throw std::runtime_error(errmsg);
+    }
+
+
+    void rename(const char * value) const;
+
+};
+
+
+
+// ------------------------- implementation: ----------------------------------
+
+
+std::mutex locked_context::inuse{};
+
+
+inline auto uci_error(uci_context * ctx, const char * prefix=nullptr)
+    -> std::runtime_error
+{
+    char * errmsg = nullptr;
+    uci_get_errorstr(ctx, &errmsg, prefix);
+
+    std::unique_ptr<char, decltype(&std::free)> auto_free{errmsg, std::free};
+    return std::runtime_error{errmsg};
+}
+
+
+template<class T>
+auto element<T>::operator[](std::string_view key) const -> T
+{
+    for (auto elmt : *this) { if (elmt.name()==key) { return elmt; } }
+
+    auto errmsg = std::string{"uci error: cannot find "}.append(key);
+    throw uci_error(locked_context{}.get(), errmsg.c_str());
+}
+
+
+template<class T>
+void element<T>::rename(const char * value) const
+{
+    if (value==name()) { return; }
+
+    auto ctx = locked_context{};
+    auto tmp_ptr = uci_ptr{_ptr};
+    tmp_ptr.value = value;
+    if (uci_rename(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot rename "}.append(name());
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+template<class T>
+void element<T>::commit() const
+{
+    auto ctx = locked_context{};
+    // TODO(pst) use when possible:
+    // if (uci_commit(ctx.get(), &_ptr.p, true) != 0) {
+    //    auto errmsg = std::string{"uci error: cannot commit "} + _ptr.package;
+    //    throw uci_error(ctx.get(), errmsg.c_str());
+    // }
+    auto err = uci_save(ctx.get(), _ptr.p);
+    if (err==0) {
+        uci_context * tmp_ctx = uci_alloc_context();
+        err = tmp_ctx==nullptr;
+        uci_package * tmp_pkg = nullptr;
+        if (err==0) { err = uci_load(tmp_ctx, _ptr.package, &tmp_pkg); }
+        if (err==0) { err = uci_commit(tmp_ctx, &tmp_pkg, false); }
+        if (err==0) { err = uci_unload(tmp_ctx, tmp_pkg); }
+        if (tmp_ctx!=nullptr) { uci_free_context(tmp_ctx); }
+    }
+
+    if (err != 0) {
+        auto errmsg = std::string{"uci error: cannot commit "} + _ptr.package;
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+package::package(const char * name)
+{
+    auto ctx = locked_context{};
+
+    auto pkg = uci_lookup_package(ctx.get(), name);
+    if (pkg==nullptr) {
+        if (uci_load(ctx.get(), name, &pkg) != 0) {
+            auto errmsg = std::string{"uci error: cannot load package "} + name;
+            throw uci_error(ctx.get(), errmsg.c_str());
+        }
+    }
+
+    ptr().package = name;
+    ptr().p = pkg;
+    ptr().last = &pkg->e;
+
+    auto end = &ptr().p->sections;
+    auto begin = end->next;
+    init_begin_end(begin, end);
+}
+
+
+auto package::set(const char * key, const char * type) const -> section
+{
+    auto ctx = locked_context{};
+
+    auto tmp_ptr = uci_ptr{ptr()};
+    tmp_ptr.section = key;
+    tmp_ptr.value = type;
+    if (uci_set(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot set section "} + type
+            + "'" + key + "' in package " + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+
+    return section{ptr(), tmp_ptr.last};
+}
+
+
+auto section::set(const char * key, const char * value) const -> option
+{
+    auto ctx = locked_context{};
+
+    auto tmp_ptr = uci_ptr{ptr()};
+    tmp_ptr.option = key;
+    tmp_ptr.value = value;
+    if (uci_set(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot set option "} + key
+            + "'" + value + "' in package " + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+
+    return option{ptr(), tmp_ptr.last};
+}
+
+
+void section::del()
+{
+    auto ctx = locked_context{};
+    if (uci_delete(ctx.get(), &ptr()) != 0) {
+        auto errmsg = std::string{"uci error: cannot delete section "} + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+void option::del()
+{
+    auto ctx = locked_context{};
+    if (uci_delete(ctx.get(), &ptr()) != 0) {
+        auto errmsg = std::string{"uci error: cannot delete option "} + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+void item::rename(const char * value) const
+{
+    if (value==name()) { return; }
+
+    auto ctx = locked_context{};
+    auto tmp_ptr = uci_ptr{ptr()};
+
+    if (tmp_ptr.last->type!=UCI_TYPE_ITEM) {
+        tmp_ptr.value = value;
+        if (uci_set(ctx.get(), &tmp_ptr) != 0) {
+            auto errmsg = std::string{"uci error: cannot rename item "}+name();
+            throw uci_error(ctx.get(), errmsg.c_str());
+        }
+        return;
+    } //else:
+
+    tmp_ptr.value = tmp_ptr.last->name;
+    if (uci_del_list(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot rename (del) "} + name();
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+
+    tmp_ptr.value = value;
+    if (uci_add_list(ctx.get(), &tmp_ptr) != 0) {
+        auto errmsg = std::string{"uci error: cannot rename (add) "} + value;
+        throw uci_error(ctx.get(), errmsg.c_str());
+    }
+}
+
+
+} // namespace uci
+
+#endif


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, x86_64 qemu, master
Run tested: x86_64, x86_64 qemu, master, running test-nginx-ssl-util-root.sh

**tl;dr:** The functions `{add,del}_ssl` modify a server section of the UCI config if there is no `.conf` file with the same name in `/etc/nginx/conf.d/`.

Then `init_lan` creates `/var/lib/nginx/uci.conf` files by copying the `/etc/nginx/uci.conf.template` and standard options from the UCI config; additionally the special path `logd` can be used in `{access,error}_log`.

The init does not change the configuration beside re-creating self-signed certificates when needed. This is also the only purpose of the new `check_ssl`, which is installed as yearly cron job.

**Initialization:**

Invoking `nginx-util init_lan` parses the UCI configuration for package `nginx`. It creates a server part in `/var/lib/nginx/uci.conf` for every `section server '$name'` by copying all UCI options but the following:

* `option uci_manage_ssl` is skipped. It is set to 'self-signed' by `nginx-util add_ssl $name`, removed by `nginx-util del_ssl $name` and used by `nginx-util check_ssl` (see below).

* `logd` as path in `error_log` or `access_log` writes them to STDERR respective STDOUT, which are fowarded by Nginx's init to the log daemon. Specifically:
`option error_log 'logd'` becomes `error_log stderr;` and
`option access_log 'logd openwrt'` becomes `access_log /proc/self/fd/1 openwrt;`

* Other `[option|list] key 'value'` entries just become `key value;` directives.

The init calls internally also `check_ssl` for rebuilding self-signed SSL certificates if needed (see below). And it still sets up `/var/lib/nginx/lan{,_ssl}.listen` files as it is doing in the current version (so they stay available).

**Defaults:**

The package installs the file `/etc/nginx/restrict_locally` containing allow/deny directives for restricting the access to LAN addresses by including it into a server part. This file is included by the default server that listens on all IPs (instead of only the local IPs as it did before, other servers do not need to listen on the local IPs explicitly anymore). The default server is contained (together with a server that redirects inexistent URLs to https in the SSL version) in the UCI configuration file `/etc/config/nginx`. Furthermore, the packages installs a `/etc/nginx/uci.conf.template` containing the current setup and a marker, which will be replaced by the created UCI servers when calling `init_lan`.

**Other:**

If there is a file named `/etc/nginx/conf.d/$name.conf` the functions `init_lan`, `add_ssl $name` and `del_ssl $name` will use that file instead of a UCI server section with the same $name (as it is doing in the current version).

Else if there is only a UCI `section server $name`:
* `nginx-util add_ssl $name` will add to it:
`option uci_manage_ssl 'self-signed'`
`option ssl_certificate '/etc/nginx/conf.d/$name.crt'`
`option ssl_certificate_key '/etc/nginx/conf.d/$name.key'`
`option ssl_session_cache 'shared:SSL:32k'`
`option ssl_session_timeout '64m'`
If these options are already present, they will stay the same; just the first option `uci_manage_ssl` will always be changed to 'self-signed'. The command also changes all `listen` list items to use port 443 and ssl instead of port 80 (without ssl). If they stated another port than 80 before, they are kept the same. Furthermore, it creates a self-signed SSL certificate if necessary, i.e., if there is no *valid* certificate and key at the locations given by the options `ssl_certificate` and `ssl_certificate_key`.

* `nginx-util del_ssl $name` checks if `uci_manage_ssl` is set 'self-signed' in the corresponding UCI section. Only then it removes all of the above options regardless of the value looking just at the key name. Then, it also changes all `listen` list items to use port 80 (without ssl) instead of port 443 with ssl. If stating another port than 443, they are kept the same. Furthermore, it removes the SSL certificate and key that were indicated by `ssl_certificate{,_key}`.

* `nginx-util check_ssl` looks through all server sections of the UCI config for `uci_manage_ssl 'self-signed'`. On every hit it checks if the SSL certificate-key-pair indicated by the options `ssl_certificate{,_key}` is expired. Then it re-creates a self-signed certificate. If there exists at least one `section server` with `uci_manage_ssl 'self-signed'`, it will try to install itself as cron job. If there are no such sections, it removes that cron job if possible.



### Plan


This change prepares Nginx for using UCI. So, the decisions here will influence Nginx's behavior. 


**Configuration:**

I (still) think it is the best to give a standard configuration with a default server that uses a self-signed certificate (if SSL is enabled) <strike>and listens locally</strike> but listens on all IPs restricting the access locally. <strike>(This implies that other servers must also listen explicitly on local IPs to be reachable from LAN.)</strike>

I do not see a possibility to achieve this without adding some configuration, which could interfere with existing custom configuration. To make it more smoothly, it would not use the new `_lan` default server from the `/etc/config/nginx` UCI configuration if the file `/etc/nginx/conf.d/_lan.conf` is still there (it will only be removed in a future change if it was not modified).

This is done in the UCI configuration `/etc/config/nginx`. There are two versions of this file depending on whether Nginx is installed with or without SSL support, which could also be installed by the nginx package.

Although, we could make the default server optional package(s), this would be different to all previous versions (there was always a default server, although there were differences if LuCI using Nginx was installed or not). Then other packages (e.g. `luci-nginx`, `luci-ssl-nginx`, `ariang` or `etesync-server`) could depend on the new package(s), and the default server is only installed then.

IMHO we should *not* separate the default server in other package(s): This would only postpone problems of interference with previous configurations to the point when such a package is installed (and then it becomes more difficult to spot). And since this would be a bigger change, I would only do it if a maintainer of Nginx (@Ansuel and @heil) want it.


**Main Functions:**

The main purpose of this tool is to unify the workload of `/etc/init.d/nginx` with the functionality of `px5g` by the commands:
* `init_lan` sets up the configuration for Nginx (faster than doing all in a shell script `/etc/init.d/nginx` that calls this function)
* `add_ssl name' creates a self-signed certificates (like `px5g` but linked against `libopenssl`) setting up corresponding SSL directives in Nginx's config, too.
* `del_ssl name` undoes that.

Additionally there is a yearly cron job (if needed and cron is available) using the function:
* `check_ssl` re-creates self-signed certificates if they would expire (in the next 13 months).

This is how to interact with server $name:
* delete it from config: `uci delete nginx.$name`
* add self-signed SSL: `nginx-util add_ssl $name`
* disable re-creation of self-signed certificate: `uci delete nginx.$name.uci_manage_ssl` or better:
* remove self-signed SSL: `nginx-util del_ssl $name`
* reload (all) config: `service nginx reload`


**Proposed Timeline:**

1. Discuss these changes (until 11th of March draft PR)
2. Change and test these tools (until 22nd of March make PR)
3. Adopt the [wiki documentation](https://openwrt.org/docs/guide-user/services/webserver/nginx#configuration) (until end of March)
4. Change Nginx to setup the default server via UCI (using `/etc/nginx/uci.conf` if it is a symlink to `/var/lib/nginx/uci.conf` and removing `/etc/nginx/conf.d/_lan.conf` and `/etc/nginx/conf.d/_redirect2ssl.conf` for the SSL version until 1st of April make PR)

Maybe, I will look into making some Nginx options available through LuCI afterwards.



### Questions


There are some things, I am not sure how to do:
* Should it use other directory/file names, e.g. `/var/etc/nginx/...` for dynamic configurations?
* <strike>Should we install the UCI config with this package or with Nginx?</strike> (Here) <strike> Should we use `/etc/config/nginx-util` instead of `/etc/config/nginx` in the first case?</strike> (No)
* <strike>How should we handle a `stream { … }` part in the Nginx configuration? Currently you have to edit the main `/etc/nginx/nginx.conf` file, which will not get updated if it was modified.</strike> (Setup manually.)



### To be changed (updated according to discussion)


**Dynamically create the main configuration file and symlink `/etc/nginx/uci.conf` to it.**

Prepared and edited above description: I changed it to include a `/etc/nginx/uci.conf.template` and to create `/var/lib/nginx/uci.conf` from it via `nginx-util init_lan` using servers of the UCI config in `/etc/config/nginx`.

I would suggest to install the symlink by the Nginx package when adopting it to the new version of nginx-util.


**In the testscripts use /bin/sh and shellcheck them.**

Done.

**Use allow/deny instead of listen locally**

Done and edited the above description: there will be no `uci_listen_locally` …
