### PR TITLE
sqm-scripts: luci-app-sqm: init ucitrack with uci-defaults

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sqm-scripts
 PKG_SOURCE_VERSION:=ab763cba8b1516b3afa99760e0ca884f8b8d93b8
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/tohojo/sqm-scripts
@@ -57,18 +57,9 @@ define Package/luci-app-sqm/description
 endef
 
 define Package/luci-app-sqm/install
-	make -C $(PKG_BUILD_DIR) DESTDIR=$(1) PLATFORM=openwrt install-luci
-endef
-
-define Package/luci-app-sqm/postinst
-#!/bin/sh
-which uci > /dev/null || exit 0
-uci -q get ucitrack.@sqm[0] > /dev/null || {
-  uci add ucitrack sqm > /dev/null
-  uci set ucitrack.@sqm[0].init=sqm
-  uci add_list ucitrack.@firewall[0].affects=sqm
-  uci commit
-}
+	$(MAKE) -C $(PKG_BUILD_DIR) DESTDIR=$(1) PLATFORM=openwrt install-luci
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/luci-app-sqm.defaults $(1)/etc/uci-defaults
 endef
 
 define Package/luci-app-sqm/postrm

--- a/net/sqm-scripts/files/luci-app-sqm.defaults
+++ b/net/sqm-scripts/files/luci-app-sqm.defaults
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+uci -q get ucitrack.@sqm[0] >/dev/null || {
+	uci add ucitrack sqm > /dev/null
+	uci set ucitrack.@sqm[0].init=sqm
+	uci add_list ucitrack.@firewall[0].affects=sqm
+	uci commit
+}


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: x86_64, master
Run tested: x86_64, master, check /e/c/ucitrack

Description:

To avoid build failure when luci-app-sqm is selected as builtin where
the ipk will be installed on build machine

While at it, switch to using $(MAKE) instead of plain "make"

Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
