### PR TITLE
miredo: Initial version 1.2.6

### DIFF
--- a/ipv6/miredo/Makefile
+++ b/ipv6/miredo/Makefile
@@ -7,7 +7,7 @@ PKG_RELEASE:=1
 PKG_SOURCE:=miredo-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.remlab.net/files/miredo/
 PKG_HASH:=fa26d2f4a405415833669e2e2e22677b225d8f83600844645d5683535ea43149
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
 PKG_CONFIG_DEPENDS := \
@@ -28,8 +28,6 @@ CONFIGURE_ARGS+= \
 		--without-libintl-prefix
 
 TARGET_CFLAGS+= $(FPIC) \
-		-std=gnu99 \
-		-O3 \
 		-ffunction-sections \
 		-fdata-sections \
 		-Wno-format-security
@@ -41,7 +39,6 @@ define Package/miredo
 	CATEGORY:=Network
 	TITLE:=Teredo IPv6 tunneling utility
 	URL:=https://www.remlab.net/miredo/
-	VERSION:=$(PKG_VERSION)
 	DEPENDS:=@IPV6 +libpthread +librt +kmod-tun
 endef
 

--- a/ipv6/miredo/Makefile
+++ b/ipv6/miredo/Makefile
@@ -1,0 +1,70 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=miredo
+PKG_VERSION:=1.2.6
+PKG_RELEASE:=1
+
+PKG_SOURCE:=miredo-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://www.remlab.net/files/miredo/
+PKG_HASH:=fa26d2f4a405415833669e2e2e22677b225d8f83600844645d5683535ea43149
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_CONFIG_DEPENDS := \
+	CONFIG_IPV6 \
+	CONFIG_TUN
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+PKG_MAINTAINER:=
+
+include $(INCLUDE_DIR)/package.mk
+
+CONFIGURE_ARGS+= \
+		--enable-shared \
+		--enable-static \
+		--disable-binreloc \
+		--with-pic \
+		--without-libiconv-prefix \
+		--without-libintl-prefix
+
+TARGET_CFLAGS+= $(FPIC) \
+		-std=gnu99 \
+		-O3 \
+		-ffunction-sections \
+		-fdata-sections \
+		-Wno-format-security
+
+TARGET_LDFLAGS += -Wl,--gc-sections
+
+define Package/miredo
+	SECTION:=net
+	CATEGORY:=Network
+	TITLE:=Teredo IPv6 tunneling utility
+	URL:=https://www.remlab.net/miredo/
+	VERSION:=$(PKG_VERSION)
+	DEPENDS:=@IPV6 +libpthread +librt +kmod-tun
+endef
+
+define Package/miredo/description
+ Miredo is an open-source Teredo IPv6 tunneling software, for Linux and the BSD
+ operating systems. It includes functional implementations of all components of
+ the Teredo specification (client, relay and server). It is meant to provide
+ IPv6 connectivity even from behind NAT devices.
+endef
+
+define Package/miredo/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/miredo $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/miredo-checkconf $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/lib/miredo
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/miredo/miredo-privproc $(1)/usr/lib/miredo
+	$(INSTALL_DIR) $(1)/etc/miredo
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/miredo/miredo.conf $(1)/etc/miredo
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/etc/miredo/client-hook $(1)/etc/miredo
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/miredo.init $(1)/etc/init.d/miredo
+endef
+
+$(eval $(call BuildPackage,miredo))

--- a/ipv6/miredo/Makefile
+++ b/ipv6/miredo/Makefile
@@ -7,15 +7,17 @@ PKG_RELEASE:=1
 PKG_SOURCE:=miredo-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.remlab.net/files/miredo/
 PKG_HASH:=fa26d2f4a405415833669e2e2e22677b225d8f83600844645d5683535ea43149
-PKG_LICENSE:=GPL-2.0-or-later
-PKG_LICENSE_FILES:=COPYING
 
-PKG_CONFIG_DEPENDS := \
+PKG_CONFIG_DEPENDS:= \
 	CONFIG_IPV6 \
 	CONFIG_TUN
 PKG_BUILD_PARALLEL:=1
+PKG_CHECK_FORMAT_SECURITY:=0
 PKG_INSTALL:=1
+
 PKG_MAINTAINER:=
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -29,8 +31,7 @@ CONFIGURE_ARGS+= \
 
 TARGET_CFLAGS+= $(FPIC) \
 		-ffunction-sections \
-		-fdata-sections \
-		-Wno-format-security
+		-fdata-sections
 
 TARGET_LDFLAGS += -Wl,--gc-sections
 

--- a/ipv6/miredo/Makefile
+++ b/ipv6/miredo/Makefile
@@ -21,20 +21,6 @@ PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
 
-CONFIGURE_ARGS+= \
-		--enable-shared \
-		--enable-static \
-		--disable-binreloc \
-		--with-pic \
-		--without-libiconv-prefix \
-		--without-libintl-prefix
-
-TARGET_CFLAGS+= $(FPIC) \
-		-ffunction-sections \
-		-fdata-sections
-
-TARGET_LDFLAGS += -Wl,--gc-sections
-
 define Package/miredo
 	SECTION:=net
 	CATEGORY:=Network
@@ -49,6 +35,24 @@ define Package/miredo/description
  the Teredo specification (client, relay and server). It is meant to provide
  IPv6 connectivity even from behind NAT devices.
 endef
+
+CONFIGURE_ARGS+= \
+	--enable-shared \
+	--enable-static \
+	--disable-binreloc \
+	--with-pic \
+	--without-libiconv-prefix \
+	--without-libintl-prefix
+
+CONFIGURE_VARS += \
+	ac_cv_header_sys_capability_h=no
+
+TARGET_CFLAGS+= \
+	$(FPIC) \
+	-ffunction-sections \
+	-fdata-sections
+
+TARGET_LDFLAGS += -Wl,--gc-sections
 
 define Package/miredo/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/ipv6/miredo/files/miredo.init
+++ b/ipv6/miredo/files/miredo.init
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=20
+
+PROG=/usr/sbin/miredo
+CONFFILE=/etc/miredo/miredo.conf
+
+start_service() {
+  procd_open_instance
+  procd_set_param command $PROG -f -c $CONFFILE
+  procd_set_param respawn
+  procd_set_param file $CONFFILE
+  procd_set_param stdout 1 # forward stdout of the command to logd
+  procd_set_param stderr 1 # same for stderr
+  procd_close_instance
+}

--- a/ipv6/miredo/files/miredo.init
+++ b/ipv6/miredo/files/miredo.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 
 USE_PROCD=1
-START=20
+START=41
 
 PROG=/usr/sbin/miredo
 CONFFILE=/etc/miredo/miredo.conf

--- a/ipv6/miredo/patches/001-fix-musl-pthread-non-portable.patch
+++ b/ipv6/miredo/patches/001-fix-musl-pthread-non-portable.patch
@@ -1,0 +1,24 @@
+--- a/libteredo/debug.h	2009-02-28 23:17:14.000000000 +0300
++++ b/libteredo/debug.h	2019-04-07 01:46:48.235087395 +0300
+@@ -43,8 +43,10 @@
+ #  ifdef __linux__
+ #   include <errno.h>
+ #   include <assert.h>
+-#   undef PTHREAD_MUTEX_INITIALIZER
+-#   define PTHREAD_MUTEX_INITIALIZER PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP
++#   if defined(PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP)
++#     undef PTHREAD_MUTEX_INITIALIZER
++#     define PTHREAD_MUTEX_INITIALIZER PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP
++#   endif
+ 
+ static inline int
+ d_pthread_mutex_init (pthread_mutex_t *mutex, pthread_mutexattr_t *pattr)
+@@ -57,7 +59,7 @@
+ 		pthread_mutexattr_init (&attr);
+ 	}
+ 
+-	pthread_mutexattr_settype (pattr, PTHREAD_MUTEX_ERRORCHECK_NP);
++	pthread_mutexattr_settype (pattr, PTHREAD_MUTEX_ERRORCHECK);
+ 	int res = pthread_mutex_init (mutex, pattr);
+ 
+ 	if (pattr == &attr)

--- a/ipv6/miredo/patches/002-fix-redefinition-ethadr.patch
+++ b/ipv6/miredo/patches/002-fix-redefinition-ethadr.patch
@@ -1,0 +1,21 @@
+--- a/libtun6/tun6.c	2012-09-12 17:03:59.000000000 +0400
++++ b/libtun6/tun6.c	2019-04-07 02:21:07.439952535 +0300
+@@ -53,7 +53,7 @@
+ const char os_driver[] = "Linux";
+ # define USE_LINUX 1
+ 
+-# include <linux/if_tun.h> // TUNSETIFF - Linux tunnel driver
++# include <linux/if_tun.h> // TUNSETIFF - Linux tunnel driver, ETH_P_IPV6
+ /*
+  * <linux/ipv6.h> conflicts with <netinet/in.h> and <arpa/inet.h>,
+  * so we've got to declare this structure by hand.
+@@ -65,7 +65,7 @@
+ };
+ 
+ # include <net/route.h> // struct in6_rtmsg
+-# include <netinet/if_ether.h> // ETH_P_IPV6
++//# include <netinet/if_ether.h> // ETH_P_IPV6
+ 
+ typedef struct
+ {
+

--- a/ipv6/miredo/patches/003-fix-warnings-portable-defined.patch
+++ b/ipv6/miredo/patches/003-fix-warnings-portable-defined.patch
@@ -1,0 +1,47 @@
+--- a/include/gettext.h	2012-09-12 16:57:52.000000000 +0400
++++ b/include/gettext.h	2019-04-07 01:11:52.492519796 +0300
+@@ -182,7 +182,7 @@
+   (((__GNUC__ >= 3 || __GNUG__ >= 2) && !defined(__STRICT_ANSI__)) \
+    /* || __STDC_VERSION__ >= 199901L */ )
+ 
+-#if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
++#if !defined(_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS)
+ #include <stdlib.h>
+ #endif
+ 
+@@ -206,7 +206,7 @@
+   size_t msgctxt_len = strlen (msgctxt) + 1;
+   size_t msgid_len = strlen (msgid) + 1;
+   const char *translation;
+-#if _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
++#if defined(_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS)
+   char msg_ctxt_id[msgctxt_len + msgid_len];
+ #else
+   char buf[1024];
+@@ -221,7 +221,7 @@
+       msg_ctxt_id[msgctxt_len - 1] = '\004';
+       memcpy (msg_ctxt_id + msgctxt_len, msgid, msgid_len);
+       translation = dcgettext (domain, msg_ctxt_id, category);
+-#if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
++#if !defined(_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS)
+       if (msg_ctxt_id != buf)
+         free (msg_ctxt_id);
+ #endif
+@@ -252,7 +252,7 @@
+   size_t msgctxt_len = strlen (msgctxt) + 1;
+   size_t msgid_len = strlen (msgid) + 1;
+   const char *translation;
+-#if _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
++#if defined(_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS)
+   char msg_ctxt_id[msgctxt_len + msgid_len];
+ #else
+   char buf[1024];
+@@ -267,7 +267,7 @@
+       msg_ctxt_id[msgctxt_len - 1] = '\004';
+       memcpy (msg_ctxt_id + msgctxt_len, msgid, msgid_len);
+       translation = dcngettext (domain, msg_ctxt_id, msgid_plural, n, category);
+-#if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
++#if !defined(_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS)
+       if (msg_ctxt_id != buf)
+         free (msg_ctxt_id);
+ #endif


### PR DESCRIPTION
Teredo IPv6 tunneling utility

First PR with miredo: https://github.com/openwrt/packages/pull/4201

Compile and Run tested: x86 (on QEMU) and ramips (D-Link DIR-300-B1), OpenWrt version: latest master.
Tests done: IPv6 address accepted. Ping successful through the NAT to target openwrt.

Description:
Miredo is an open-source Teredo IPv6 tunneling software, for Linux and the BSD operating systems. It includes functional implementations of all components of the Teredo specification (client, relay and server). It is meant to provide IPv6 connectivity even from behind NAT devices.

Signed-off-by: Nikita Vostokov <yawosk@yandex.com>