### PR TITLE
xtables-addons: update to 3.9, fix build on kernel 5.4

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
-PKG_VERSION:=3.7
-PKG_RELEASE:=2
-PKG_HASH:=045ee3fcfe5d6edb95483cf49e2446ff8cab4bb79411018b18354138b70c5eb5
+PKG_VERSION:=3.9
+PKG_RELEASE:=1
+PKG_HASH:=064dd68937d98e6cfcbdf51ef459310d9810c17ab31b21285bc7a76cdcef7c49
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/xtables-addons

--- a/net/xtables-addons/patches/002-restore-support-for-Linux-4.14.patch
+++ b/net/xtables-addons/patches/002-restore-support-for-Linux-4.14.patch
@@ -6,21 +6,17 @@ This reverts commit bf63a25a64c9223435c26e6543ba749834b47752.
  extensions/pknock/xt_pknock.c | 16 ++++++++++++++++
  3 files changed, 19 insertions(+), 3 deletions(-)
 
-diff --git a/configure.ac b/configure.ac
-index 7631f6b..0d3aa72 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -61,7 +61,7 @@ if test -n "$kbuilddir"; then
  			echo "WARNING: That kernel version is not officially supported yet. Continue at own luck.";
  		elif test "$kmajor" -eq 5 -a "$kminor" -ge 0; then
  			:
--		elif test "$kmajor" -eq 4 -a "$kminor" -ge 18; then
+-		elif test "$kmajor" -eq 4 -a "$kminor" -ge 15; then
 +		elif test "$kmajor" -eq 4 -a "$kminor" -ge 14; then
  			:
  		else
  			echo "WARNING: That kernel version is not officially supported.";
-diff --git a/extensions/compat_xtables.h b/extensions/compat_xtables.h
-index d08354a..faf5dd8 100644
 --- a/extensions/compat_xtables.h
 +++ b/extensions/compat_xtables.h
 @@ -8,8 +8,8 @@
@@ -34,11 +30,9 @@ index d08354a..faf5dd8 100644
  #endif
  
  #if defined(CONFIG_NF_CONNTRACK) || defined(CONFIG_NF_CONNTRACK_MODULE)
-diff --git a/extensions/pknock/xt_pknock.c b/extensions/pknock/xt_pknock.c
-index c76901a..7be0345 100644
 --- a/extensions/pknock/xt_pknock.c
 +++ b/extensions/pknock/xt_pknock.c
-@@ -357,10 +357,18 @@ has_logged_during_this_minute(const struct peer *peer)
+@@ -356,10 +356,18 @@ has_logged_during_this_minute(const stru
   *
   * @r: rule
   */
@@ -57,7 +51,7 @@ index c76901a..7be0345 100644
  	struct peer *peer;
  	struct list_head *pos, *n;
  
-@@ -467,7 +475,15 @@ add_rule(struct xt_pknock_mtinfo *info)
+@@ -466,7 +474,15 @@ add_rule(struct xt_pknock_mtinfo *info)
  	rule->peer_head      = alloc_hashtable(peer_hashsize);
  	if (rule->peer_head == NULL)
  		goto out;
@@ -73,6 +67,3 @@ index c76901a..7be0345 100644
  	rule->status_proc = proc_create_data(info->rule_name, 0, pde,
  	                    &pknock_proc_ops, rule);
  	if (rule->status_proc == NULL)
--- 
-2.21.0
-

--- a/net/xtables-addons/patches/100-add-rtsp-conntrack.patch
+++ b/net/xtables-addons/patches/100-add-rtsp-conntrack.patch
@@ -7,7 +7,7 @@
 +obj-m += nf_conntrack_rtsp.o
 --- /dev/null
 +++ b/extensions/rtsp/netfilter_helpers.h
-@@ -0,0 +1,133 @@
+@@ -0,0 +1,144 @@
 +/*
 + * Helpers for netfiler modules.  This file provides implementations for basic
 + * functions such as strncasecmp(), etc.
@@ -23,6 +23,8 @@
 +
 +/* Only include these functions for kernel code. */
 +#ifdef __KERNEL__
++
++#include <net/netfilter/nf_conntrack_expect.h>
 +
 +#include <linux/ctype.h>
 +#define iseol(c) ( (c) == '\r' || (c) == '\n' )
@@ -138,6 +140,15 @@
 +}
 +#endif /* NF_NEED_NEXTLINE */
 +
++static inline int rtsp_nf_ct_expect_related(struct nf_conntrack_expect *expect)
++{
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
++	return nf_ct_expect_related(expect, 0);
++#else
++	return nf_ct_expect_related(expect);
++#endif
++}
++
 +#endif /* __KERNEL__ */
 +
 +#endif /* _NETFILTER_HELPERS_H */
@@ -235,7 +246,7 @@
 +#endif /* _NETFILTER_MIME_H */
 --- /dev/null
 +++ b/extensions/rtsp/nf_conntrack_rtsp.c
-@@ -0,0 +1,761 @@
+@@ -0,0 +1,756 @@
 +/*
 + * RTSP extension for IP connection tracking
 + * (C) 2003 by Tom Marshall <tmarshall at real.com>
@@ -288,7 +299,6 @@
 +#include <net/tcp.h>
 +
 +#include <net/netfilter/nf_conntrack.h>
-+#include <net/netfilter/nf_conntrack_expect.h>
 +#include <net/netfilter/nf_conntrack_helper.h>
 +#include <net/netfilter/nf_conntrack_zones.h>
 +#include "nf_conntrack_rtsp.h"
@@ -316,7 +326,7 @@
 +MODULE_PARM_DESC(ports, "port numbers of RTSP servers");
 +module_param(max_outstanding, int, 0400);
 +MODULE_PARM_DESC(max_outstanding, "max number of outstanding SETUP requests per RTSP session");
-+module_param(setup_timeout, int, 0400);
++module_param(setup_timeout, uint, 0400);
 +MODULE_PARM_DESC(setup_timeout, "timeout on for unestablished data channels");
 +
 +static char *rtsp_buffer;
@@ -704,8 +714,8 @@
 +					  &expinfo, rtp_exp, rtcp_exp);
 +#endif
 +		else {
-+			if (nf_ct_expect_related(rtp_exp) == 0) {
-+				if (rtcp_exp && nf_ct_expect_related(rtcp_exp) != 0) {
++			if (rtsp_nf_ct_expect_related(rtp_exp) == 0) {
++				if (rtcp_exp && rtsp_nf_ct_expect_related(rtcp_exp) != 0) {
 +					nf_ct_unexpect_related(rtp_exp);
 +					pr_info("nf_conntrack_expect_related failed for rtcp\n");
 +					ret = NF_DROP;
@@ -942,10 +952,6 @@
 +		printk("nf_conntrack_rtsp: max_outstanding must be a positive integer\n");
 +		return -EBUSY;
 +	}
-+	if (setup_timeout < 0) {
-+		printk("nf_conntrack_rtsp: setup_timeout must be a positive integer\n");
-+		return -EBUSY;
-+	}
 +
 +	rtsp_exp_policy.max_expected = max_outstanding;
 +	rtsp_exp_policy.timeout = setup_timeout;
@@ -1076,7 +1082,7 @@
 +#endif /* _IP_CONNTRACK_RTSP_H */
 --- /dev/null
 +++ b/extensions/rtsp/nf_nat_rtsp.c
-@@ -0,0 +1,636 @@
+@@ -0,0 +1,635 @@
 +/*
 + * RTSP extension for TCP NAT alteration
 + * (C) 2003 by Tom Marshall <tmarshall at real.com>
@@ -1125,7 +1131,6 @@
 +#endif
 +#include <net/netfilter/nf_nat_helper.h>
 +#include "nf_conntrack_rtsp.h"
-+#include <net/netfilter/nf_conntrack_expect.h>
 +
 +#include <linux/inet.h>
 +#include <linux/ctype.h>
@@ -1281,7 +1286,7 @@
 +	case pb_single:
 +		for (loport = prtspexp->loport; loport != 0; loport++) { /* XXX: improper wrap? */
 +			rtp_t->dst.u.udp.port = htons(loport);
-+			if (nf_ct_expect_related(rtp_exp) == 0) {
++			if (rtsp_nf_ct_expect_related(rtp_exp) == 0) {
 +				pr_debug("using port %hu\n", loport);
 +				break;
 +			}
@@ -1294,12 +1299,12 @@
 +	case pb_range:
 +		for (loport = prtspexp->loport; loport != 0; loport += 2) { /* XXX: improper wrap? */
 +			rtp_t->dst.u.udp.port = htons(loport);
-+			if (nf_ct_expect_related(rtp_exp) != 0) {
++			if (rtsp_nf_ct_expect_related(rtp_exp) != 0) {
 +				continue;
 +			}
 +			hiport = loport + 1;
 +			rtcp_exp->tuple.dst.u.udp.port = htons(hiport);
-+			if (nf_ct_expect_related(rtcp_exp) != 0) {
++			if (rtsp_nf_ct_expect_related(rtcp_exp) != 0) {
 +				nf_ct_unexpect_related(rtp_exp);
 +				continue;
 +			}
@@ -1322,14 +1327,14 @@
 +	case pb_discon:
 +		for (loport = prtspexp->loport; loport != 0; loport++) { /* XXX: improper wrap? */
 +			rtp_t->dst.u.udp.port = htons(loport);
-+			if (nf_ct_expect_related(rtp_exp) == 0) {
++			if (rtsp_nf_ct_expect_related(rtp_exp) == 0) {
 +				pr_debug("using port %hu (1 of 2)\n", loport);
 +				break;
 +			}
 +		}
 +		for (hiport = prtspexp->hiport; hiport != 0; hiport++) { /* XXX: improper wrap? */
 +			rtp_t->dst.u.udp.port = htons(hiport);
-+			if (nf_ct_expect_related(rtp_exp) == 0) {
++			if (rtsp_nf_ct_expect_related(rtp_exp) == 0) {
 +				pr_debug("using port %hu (2 of 2)\n", hiport);
 +				break;
 +			}

--- a/net/xtables-addons/patches/201-fix-lua-packetscript.patch
+++ b/net/xtables-addons/patches/201-fix-lua-packetscript.patch
@@ -22,6 +22,15 @@
  {
  	uint32_t  verdict;
  	lua_packet_segment *p;
+@@ -79,7 +79,7 @@ lua_tg(struct sk_buff *pskb, const struc
+ 
+ 	L = lua_envs[info->state_id]->L;
+ 
+-	if (!skb_make_writable(pskb, pskb->len))
++	if (skb_ensure_writable(pskb, pskb->len))
+ 		return NF_DROP;
+ 
+ 	/* call the function provided by --function parameter or the default 'process_packet' defined in Lua */
 @@ -88,11 +88,11 @@ lua_tg(struct sk_buff *pskb, const struc
  	/* push the lua_packet_segment as a parameter */
  	p = (lua_packet_segment *)lua_newuserdata(L, sizeof(lua_packet_segment));


### PR DESCRIPTION
Maintainer: @jow-
Compile tested: ramips
Run tested: ramips

Description:
Update xtables-addons to 3.9
Fix packetscript and rtsp build on kernel 5.4