### PR TITLE
syncthing: enable/disable via config, lower priority, cleanup

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
 PKG_VERSION:=1.3.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)

--- a/utils/syncthing/files/etc/config/syncthing
+++ b/utils/syncthing/files/etc/config/syncthing
@@ -1,3 +1,7 @@
+
 config syncthing 'syncthing'
-    option gui_address 'http://127.0.0.1:8384'
-    option home '/etc/syncthing/'
+	option enabled '0'
+
+	option gui_address 'http://127.0.0.1:8384'
+	option home '/etc/syncthing/'
+

--- a/utils/syncthing/files/etc/init.d/syncthing
+++ b/utils/syncthing/files/etc/init.d/syncthing
@@ -1,14 +1,24 @@
 #!/bin/sh /etc/rc.common
 
-START=99
+START=90
+STOP=10
+
+USE_PROCD=1
+NICEPRIO=19
 
 PROG=/usr/bin/syncthing
 
 start_service() {
     [ -d /var/syncthing/ ] || mkdir /var/syncthing/
 
-    local gui_address home
+    local gui_address home enabled
     config_load "syncthing"
+
+    # The first version had the service enabled by default,
+    #   so preserving the old behaviour
+    config_get_bool enabled syncthing enabled 1
+    [ "$enabled" -gt 0 ] || return 0
+
     config_get gui_address syncthing gui_address "http://127.0.0.1:8384"
     config_get home syncthing home "/etc/syncthing/"
 
@@ -17,5 +27,6 @@ start_service() {
     procd_append_param command -gui-address="$gui_address"
     procd_append_param command -home="$home"
     procd_set_param respawn
+    procd_set_param nice "$NICEPRIO"
     procd_close_instance
 }


### PR DESCRIPTION
Maintainer: @aparcar 
Compile-tested on: ipq806x, ipq40xx
Runtime-tested on: ipq806x, ipq40xx

It is safer to not enable such a service by default.

This is an additional service, so running it the
same priority as dnsmasq, etc does not make sense.

Added USE_PROCD=1

"done" starts at "START=95", so this should start earlier

Added STOP=10 to stop syncthing early

Compile-tested on: ipq806x, ipq40xx
Runtime-tested on: ipq806x, ipq40xx

Signed-off-by: Marc Benoit <marcb62185@gmail.com>