### PR TITLE
libqmi: bump libqmi version

### DIFF
--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.24.4
-PKG_RELEASE:=2
+PKG_VERSION:=1.24.6
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
-PKG_HASH:=0316badec92ff32f51fe6278e6046968d2272a26608995deedd8e4afb563918a
+PKG_HASH:=1325257bc16de7b2b443fa689826c993474bdbd6e78c7a1e60e527269b44d8c9
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 


### PR DESCRIPTION
Signed-off-by: Nicholas Smith <nicholas.smith@telcoantennas.com.au>

Maintainer: me 
Compile tested: ath79/TEL-T1
Run tested: ath79/TEL-T1, ran basic functions

Description: Update libqmi to 1.24.6
