### PR TITLE
linknx: convert to procd

### DIFF
--- a/net/linknx/Makefile
+++ b/net/linknx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linknx
 PKG_VERSION:=0.0.1.37
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-${PKG_VERSION}.tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/linknx/linknx/tar.gz/$(PKG_VERSION)?
@@ -41,9 +41,6 @@ CONFIGURE_ARGS+= \
 	--with-lua \
 	--with-libcurl \
 	--without-mysql
-
-EXTRA_LDFLAGS+= \
-	-fno-builtin
 
 define Package/linknx/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/net/linknx/files/linknx.config
+++ b/net/linknx/files/linknx.config
@@ -1,8 +1,3 @@
-config daemon args
-        # daemon is started as 'linknx --config=$conf $options'
-        # use 'linknx --help' to get all possible options'
-        #
-        # typical example
+config args
         option conf '/etc/linknx.xml'
-        option options '-w --daemon=/tmp/linknx/linknx.log --pid-file=/var/run/linknx.pid'
 

--- a/net/linknx/files/linknx.init
+++ b/net/linknx/files/linknx.init
@@ -3,21 +3,25 @@
 
 START=98
 STOP=10
+USE_PROCD=1
 NAME=linknx
 PROG=/usr/bin/$NAME
 
 . /lib/functions.sh
 
-start() {
-        local conf options
+start_service() {
+        local conf
         config_load "$NAME"
         config_get conf args conf '/etc/linknx.xml'
-        config_get options args options ''
-        test -f $conf || cp -p /etc/linknx.xml.dist $conf
+        [ -f "$conf" ] || cp -p /etc/linknx.xml.dist "$conf"
         mkdir -p /tmp/$NAME/persist
-        service_start $PROG --config=$conf $options
-}
 
-stop() {
-        service_stop $PROG
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_append_param command --config="$conf" -w
+	procd_set_param file "$conf"
+	procd_set_param pidfile /var/run/linknx.pid
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
 }


### PR DESCRIPTION
Removed options UCI parameter. It's not terribly useful. Most of the
parameters can be replaced with procd functionality. procd also demands
processes to run in the foreground.

Removed -fno-builtin. It seems to be a legacy option.

Ran init script through shellcheck.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tru7 
Compile tested: malta-glibc
Run tested: malta-glibc