### PR TITLE
measurement-kit: update to version 0.10.11

### DIFF
--- a/libs/measurement-kit/Makefile
+++ b/libs/measurement-kit/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=measurement-kit
-PKG_VERSION:=0.10.9
-PKG_RELEASE:=2
+PKG_VERSION:=0.10.11
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/measurement-kit/measurement-kit/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8ac160fe1f318983b6784d78f612b657ddeed73ddc6371aaa299326196a381e5
+PKG_HASH:=f9dbf5f721516fd709c13ac5011737b3622076299e3c899a1f70861901ec1b40
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-2-Clause


### PR DESCRIPTION
Maintainer: me 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates measurement-kit to version 0.10.11

This version fixes problems with libmaxminddb

