### PR TITLE
irqbalance: support reload_config & start later

### DIFF
--- a/utils/irqbalance/Makefile
+++ b/utils/irqbalance/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=irqbalance
 PKG_VERSION:=1.6.0
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_PROTO:=git

--- a/utils/irqbalance/files/irqbalance.init
+++ b/utils/irqbalance/files/irqbalance.init
@@ -1,7 +1,14 @@
 #!/bin/sh /etc/rc.common
 
-START=11
+START=90
+STOP=10
+
 USE_PROCD=1
+
+service_triggers()
+{
+	procd_add_reload_trigger "irqbalance"
+}
 
 start_service() {
 	local enabled
@@ -25,4 +32,3 @@ start_service() {
 	procd_set_param respawn
 	procd_close_instance
 }
-


### PR DESCRIPTION
Maintainer: @hnyman 
Compile tested: ipq806x
Run tested: ipq806x

Description:

Added support for reload_config

This service does not need to start so early (even
before the netwrok is up). Start it after
the device is mostly up and operational.

Signed-off-by: Marc Benoit <marcb62185@gmail.com>
