### PR TITLE
grilo-plugins: backport patches from grilo-plugins master to support libdmapshare's 4.0 API

### DIFF
--- a/multimedia/grilo-plugins/Makefile
+++ b/multimedia/grilo-plugins/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grilo-plugins
-PKG_VERSION:=0.3.10
+PKG_VERSION:=0.3.11
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
@@ -15,7 +15,7 @@ PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/grilo-plugins/0.3/
-PKG_HASH:=803b360fdb6d5fde1e647bdc40c16de3031b1a95b347b48b65fe4fc27a548d4a
+PKG_HASH:=dde2e605b1994341c6bf012493e056b406b08571834dea3b3c671d5b8b1dcd73
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -89,8 +89,7 @@ endef
 $(eval $(call BuildPackage,grilo-plugins))
 
 $(eval $(call BuildPlugin,dleyna,DLNA sharing,dleyna,,30))
-# This is currently disabled because it won't work with libdmapsharing-4.0.so
-#$(eval $(call BuildPlugin,dmap,DAAP and DPAP sharing,daap dpap,libdmapsharing,30))
+$(eval $(call BuildPlugin,dmap,DAAP and DPAP sharing,daap dpap,libdmapsharing,30))
 $(eval $(call BuildPlugin,gravatar,Gravatar provider,gravatar,,30))
 $(eval $(call BuildPlugin,jamendo,Jamendo sharing,jamendo,,30))
 $(eval $(call BuildPlugin,magnatune,Magnatune sharing,magnatune,,30))

--- a/multimedia/grilo-plugins/patches/010-backport-fix-whitespace.patch
+++ b/multimedia/grilo-plugins/patches/010-backport-fix-whitespace.patch
@@ -1,0 +1,1250 @@
+diff --git a/src/dmap/grl-common.c b/src/dmap/grl-common.c
+index fa92df9..6a1da5e 100644
+--- a/src/dmap/grl-common.c
++++ b/src/dmap/grl-common.c
+@@ -39,7 +39,7 @@ gchar *
+ grl_dmap_build_url (DMAPMdnsBrowserService *service)
+ {
+   return g_strdup_printf ("%s://%s:%u",
+-                          service->service_name,
+-                          service->host,
+-                          service->port);
++                           service->service_name,
++                           service->host,
++                           service->port);
+ }
+diff --git a/src/dmap/grl-daap-db.c b/src/dmap/grl-daap-db.c
+index 6621094..c931d91 100644
+--- a/src/dmap/grl-daap-db.c
++++ b/src/dmap/grl-daap-db.c
+@@ -112,8 +112,8 @@ grl_daap_db_lookup_by_id (const DMAPDb *db, guint id)
+ 
+ static void
+ grl_daap_db_foreach (const DMAPDb *db,
+-                        GHFunc func,
+-                        gpointer data)
++                     GHFunc func,
++                     gpointer data)
+ {
+   g_error ("Not implemented");
+ }
+@@ -135,7 +135,7 @@ set_insert (GHashTable *category, const char *category_name, char *set_name, Grl
+   id = g_strdup_printf ("%s-%s", category_name, set_name);
+ 
+   container = grl_media_container_new ();
+-  grl_media_set_id    (container, id);
++  grl_media_set_id (container, id);
+   grl_media_set_title (container, set_name);
+ 
+   set = g_hash_table_lookup (category, container);
+@@ -173,26 +173,16 @@ grl_daap_db_add (DMAPDb *_db, DMAPRecord *_record)
+   GrlMedia *media;
+ 
+   g_object_get (record,
+-               "songalbum",
+-               &album,
+-               "songartist",
+-               &artist,
+-               "bitrate",
+-               &bitrate,
+-               "duration",
+-               &duration,
+-               "songgenre",
+-               &genre,
+-               "title",
+-               &title,
+-               "track",
+-               &track,
+-               "disc",
+-               &disc,
+-               "location",
+-               &url,
+-               "has-video",
+-               &has_video,
++               "songalbum", &album,
++               "songartist", &artist,
++               "bitrate", &bitrate,
++               "duration", &duration,
++               "songgenre", &genre,
++               "title", &title,
++               "track", &track,
++               "disc", &disc,
++               "location", &url,
++               "has-video", &has_video,
+                 NULL);
+ 
+   id_s = g_strdup_printf ("%u", nextid);
+@@ -203,8 +193,8 @@ grl_daap_db_add (DMAPDb *_db, DMAPRecord *_record)
+     media = grl_media_audio_new ();
+   }
+ 
+-  grl_media_set_id           (media, id_s);
+-  grl_media_set_duration     (media, duration);
++  grl_media_set_id (media, id_s);
++  grl_media_set_duration (media, duration);
+ 
+   if (title) {
+     grl_media_set_title (media, title);
+@@ -217,7 +207,7 @@ grl_daap_db_add (DMAPDb *_db, DMAPRecord *_record)
+   }
+ 
+   if (has_video == FALSE) {
+-    grl_media_set_bitrate      (media, bitrate);
++    grl_media_set_bitrate (media, bitrate);
+     grl_media_set_track_number (media, track);
+ 
+     if (disc != 0) {
+@@ -249,7 +239,7 @@ grl_daap_db_add (DMAPDb *_db, DMAPRecord *_record)
+ static gboolean
+ same_media (GrlMedia *a, GrlMedia *b)
+ {
+-  return (strcmp (grl_media_get_id (a), grl_media_get_id (b)) == 0);
++  return strcmp (grl_media_get_id (a), grl_media_get_id (b)) == 0;
+ }
+ 
+ void
+@@ -334,7 +324,7 @@ grl_daap_db_search (GrlDAAPDb *db,
+   results = g_hash_table_new (g_str_hash, g_str_equal);
+ 
+   /* For albums and artists... */
+-  for (i = 0; i < G_N_ELEMENTS(hash_tables); i++) {
++  for (i = 0; i < G_N_ELEMENTS (hash_tables); i++) {
+     g_hash_table_iter_init (&iter1, hash_tables[i]);
+     /* For each album or artist in above... */
+     for (j = 0; g_hash_table_iter_next (&iter1, &key1, &val1); j++) {
+@@ -396,10 +386,10 @@ grl_daap_db_init (GrlDAAPDb *db)
+   db->priv->albums_container  = grl_media_container_new ();
+   db->priv->artists_container = grl_media_container_new ();
+ 
+-  grl_media_set_id    (GRL_MEDIA (db->priv->albums_container), ALBUMS_ID);
++  grl_media_set_id (GRL_MEDIA (db->priv->albums_container), ALBUMS_ID);
+   grl_media_set_title (GRL_MEDIA (db->priv->albums_container), ALBUMS_NAME);
+ 
+-  grl_media_set_id    (GRL_MEDIA (db->priv->artists_container), ARTISTS_ID);
++  grl_media_set_id (GRL_MEDIA (db->priv->artists_container), ARTISTS_ID);
+   grl_media_set_title (GRL_MEDIA (db->priv->artists_container), ARTISTS_NAME);
+ 
+   db->priv->root    = g_hash_table_new_full (container_hash, container_equal, g_object_unref, (GDestroyNotify) g_hash_table_destroy);
+@@ -426,9 +416,9 @@ grl_daap_db_finalize (GObject *object)
+ 
+ static void
+ grl_daap_db_set_property (GObject *object,
+-                             guint prop_id,
+-                             const GValue *value,
+-                             GParamSpec *pspec)
++                          guint prop_id,
++                          const GValue *value,
++                          GParamSpec *pspec)
+ {
+   switch (prop_id) {
+   default:
+@@ -439,9 +429,9 @@ grl_daap_db_set_property (GObject *object,
+ 
+ static void
+ grl_daap_db_get_property (GObject *object,
+-                             guint prop_id,
+-                             GValue *value,
+-                             GParamSpec *pspec)
++                          guint prop_id,
++                          GValue *value,
++                          GParamSpec *pspec)
+ {
+   switch (prop_id) {
+   default:
+diff --git a/src/dmap/grl-daap-db.h b/src/dmap/grl-daap-db.h
+index f52a9b5..2548c50 100644
+--- a/src/dmap/grl-daap-db.h
++++ b/src/dmap/grl-daap-db.h
+@@ -26,34 +26,34 @@
+ 
+ G_BEGIN_DECLS
+ 
+-#define TYPE_GRL_DAAP_DB                     \
+-  (grl_daap_db_get_type ())
+-
+-#define GRL_DAAP_DB(o)                             \
+-  (G_TYPE_CHECK_INSTANCE_CAST ((o),                   \
+-                               TYPE_GRL_DAAP_DB,   \
+-                               GrlDAAPDb))
+-
+-#define GRL_DAAP_DB_CLASS(k)                 \
+-  (G_TYPE_CHECK_CLASS_CAST((k),                 \
+-                           TYPE_GRL_DAAP_DB, \
+-                           GrlDAAPDbClass))
+-#define IS_GRL_DAAP_DB(o)                          \
+-  (G_TYPE_CHECK_INSTANCE_TYPE((o),                    \
+-                              TYPE_GRL_DAAP_DB))
+-#define IS_GRL_DAAP_DB_CLASS(k)                       \
+-  (G_TYPE_CHECK_CLASS_TYPE((k),                          \
+-                           TYPE_GRL_DAAP_DB_CLASS))
+-
+-#define GRL_DAAP_DB_GET_CLASS(o)                \
+-  (G_TYPE_INSTANCE_GET_CLASS((o),                  \
+-                             TYPE_GRL_DAAP_DB,  \
+-                             GrlDAAPDbClass))
++#define TYPE_GRL_DAAP_DB (grl_daap_db_get_type ())
++
++#define GRL_DAAP_DB(o)                                                         \
++  (G_TYPE_CHECK_INSTANCE_CAST ((o),                                            \
++                                TYPE_GRL_DAAP_DB,                              \
++                                GrlDAAPDb))
+ 
+-#define GRL_DAAP_DB_GET_PRIVATE(o)                 \
+-  (G_TYPE_INSTANCE_GET_PRIVATE((o),                   \
+-                               TYPE_GRL_DAAP_DB,   \
+-                               GrlDAAPDbPrivate))
++#define GRL_DAAP_DB_CLASS(k)                                                   \
++  (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
++                             TYPE_GRL_DAAP_DB,                                 \
++                             GrlDAAPDbClass))
++#define IS_GRL_DAAP_DB(o)                                                      \
++  (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
++                                TYPE_GRL_DAAP_DB))
++
++#define IS_GRL_DAAP_DB_CLASS(k)                                                \
++  (G_TYPE_CHECK_CLASS_TYPE ((k),                                               \
++                             TYPE_GRL_DAAP_DB_CLASS))
++
++#define GRL_DAAP_DB_GET_CLASS(o)                                               \
++  (G_TYPE_INSTANCE_GET_CLASS ((o),                                             \
++                               TYPE_GRL_DAAP_DB,                               \
++                               GrlDAAPDbClass))
++
++#define GRL_DAAP_DB_GET_PRIVATE(o)                                             \
++  (G_TYPE_INSTANCE_GET_PRIVATE ((o),                                           \
++                                 TYPE_GRL_DAAP_DB,                             \
++                                 GrlDAAPDbPrivate))
+ 
+ typedef struct GrlDAAPDbPrivate GrlDAAPDbPrivate;
+ 
+diff --git a/src/dmap/grl-daap-record-factory.c b/src/dmap/grl-daap-record-factory.c
+index e986394..648fd85 100644
+--- a/src/dmap/grl-daap-record-factory.c
++++ b/src/dmap/grl-daap-record-factory.c
+@@ -22,9 +22,9 @@
+ #include "grl-daap-record.h"
+ 
+ DMAPRecord *
+-grl_daap_record_factory_create  (DMAPRecordFactory *factory, gpointer user_data)
++grl_daap_record_factory_create (DMAPRecordFactory *factory, gpointer user_data)
+ {
+-	return DMAP_RECORD (grl_daap_record_new ());
++  return DMAP_RECORD (grl_daap_record_new ());
+ }
+ 
+ static void
+@@ -40,19 +40,19 @@ grl_daap_record_factory_class_init (GrlDAAPRecordFactoryClass *klass)
+ static void
+ grl_daap_record_factory_interface_init (gpointer iface, gpointer data)
+ {
+-	DMAPRecordFactoryIface *factory = iface;
++  DMAPRecordFactoryIface *factory = iface;
+ 
+-	g_assert (G_TYPE_FROM_INTERFACE (factory) == DMAP_TYPE_RECORD_FACTORY);
++  g_assert (G_TYPE_FROM_INTERFACE (factory) == DMAP_TYPE_RECORD_FACTORY);
+ 
+-	factory->create = grl_daap_record_factory_create;
++  factory->create = grl_daap_record_factory_create;
+ }
+ 
+ G_DEFINE_TYPE_WITH_CODE (GrlDAAPRecordFactory, grl_daap_record_factory, G_TYPE_OBJECT,
+-			 G_IMPLEMENT_INTERFACE (DMAP_TYPE_RECORD_FACTORY,
+-					        grl_daap_record_factory_interface_init))
++                         G_IMPLEMENT_INTERFACE (DMAP_TYPE_RECORD_FACTORY,
++                                               grl_daap_record_factory_interface_init))
+ 
+ GrlDAAPRecordFactory *
+ grl_daap_record_factory_new (void)
+ {
+-	return SIMPLE_DAAP_RECORD_FACTORY (g_object_new (TYPE_SIMPLE_DAAP_RECORD_FACTORY, NULL));
++  return SIMPLE_DAAP_RECORD_FACTORY (g_object_new (TYPE_SIMPLE_DAAP_RECORD_FACTORY, NULL));
+ }
+diff --git a/src/dmap/grl-daap-record-factory.h b/src/dmap/grl-daap-record-factory.h
+index 514713a..45aa69a 100644
+--- a/src/dmap/grl-daap-record-factory.h
++++ b/src/dmap/grl-daap-record-factory.h
+@@ -25,32 +25,31 @@
+ 
+ G_BEGIN_DECLS
+ 
+-#define TYPE_SIMPLE_DAAP_RECORD_FACTORY         \
+-  (grl_daap_record_factory_get_type ())
+-
+-#define SIMPLE_DAAP_RECORD_FACTORY(o)                          \
+-  (G_TYPE_CHECK_INSTANCE_CAST((o),                             \
+-                              TYPE_SIMPLE_DAAP_RECORD_FACTORY, \
+-                              GrlDAAPRecordFactory))
+-
+-#define SIMPLE_DAAP_RECORD_FACTORY_CLASS(k)                 \
+-  (G_TYPE_CHECK_CLASS_CAST((k),                             \
+-                           TYPE_SIMPLE_DAAP_RECORD_FACTORY, \
+-                           GrlDAAPRecordFactoryClass))
+-
+-#define IS_SIMPLE_DAAP_RECORD_FACTORY(o)                          \
+-  (G_TYPE_CHECK_INSTANCE_TYPE((o),                                \
+-                              TYPE_SIMPLE_DAAP_RECORD_FACTORY))
+-
+-#define IS_SIMPLE_DAAP_RECORD_FACTORY_CLASS(k)                       \
+-  (G_TYPE_CHECK_CLASS_TYPE((k),                                      \
+-                           TYPE_SIMPLE_DAAP_RECORD_FACTORY_CLASS))
+-
+-#define SIMPLE_DAAP_RECORD_FACTORY_GET_CLASS(o)                \
+-  (G_TYPE_INSTANCE_GET_CLASS((o),                              \
+-                             TYPE_SIMPLE_DAAP_RECORD_FACTORY,  \
++#define TYPE_SIMPLE_DAAP_RECORD_FACTORY (grl_daap_record_factory_get_type ())
++
++#define SIMPLE_DAAP_RECORD_FACTORY(o)                                          \
++  (G_TYPE_CHECK_INSTANCE_CAST ((o),                                            \
++                                TYPE_SIMPLE_DAAP_RECORD_FACTORY,               \
++                                GrlDAAPRecordFactory))
++
++#define SIMPLE_DAAP_RECORD_FACTORY_CLASS(k)                                    \
++  (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
++                             TYPE_SIMPLE_DAAP_RECORD_FACTORY,                  \
+                              GrlDAAPRecordFactoryClass))
+ 
++#define IS_SIMPLE_DAAP_RECORD_FACTORY(o)                                       \
++  (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
++                                TYPE_SIMPLE_DAAP_RECORD_FACTORY))
++
++#define IS_SIMPLE_DAAP_RECORD_FACTORY_CLASS(k)                                 \
++  (G_TYPE_CHECK_CLASS_TYPE ((k),                                               \
++                             TYPE_SIMPLE_DAAP_RECORD_FACTORY_CLASS))
++
++#define SIMPLE_DAAP_RECORD_FACTORY_GET_CLASS(o)                                \
++  (G_TYPE_INSTANCE_GET_CLASS ((o),                                             \
++                               TYPE_SIMPLE_DAAP_RECORD_FACTORY,                \
++                               GrlDAAPRecordFactoryClass))
++
+ typedef struct GrlDAAPRecordFactoryPrivate GrlDAAPRecordFactoryPrivate;
+ 
+ typedef struct {
+@@ -61,11 +60,11 @@ typedef struct {
+   GObjectClass parent;
+ } GrlDAAPRecordFactoryClass;
+ 
+-GType                    grl_daap_record_factory_get_type (void);
++GType grl_daap_record_factory_get_type (void);
+ 
+-GrlDAAPRecordFactory *grl_daap_record_factory_new      (void);
++GrlDAAPRecordFactory *grl_daap_record_factory_new (void);
+ 
+-DMAPRecord              *grl_daap_record_factory_create   (DMAPRecordFactory *factory, gpointer user_data);
++DMAPRecord *grl_daap_record_factory_create (DMAPRecordFactory *factory, gpointer user_data);
+ 
+ #endif /* __SIMPLE_DAAP_RECORD_FACTORY */
+ 
+diff --git a/src/dmap/grl-daap-record.c b/src/dmap/grl-daap-record.c
+index d1721d2..82bf2f9 100644
+--- a/src/dmap/grl-daap-record.c
++++ b/src/dmap/grl-daap-record.c
+@@ -69,9 +69,9 @@ enum {
+ 
+ static void
+ grl_daap_record_set_property (GObject *object,
+-                                 guint prop_id,
+-                                 const GValue *value,
+-                                 GParamSpec *pspec)
++                              guint prop_id,
++                              const GValue *value,
++                              GParamSpec *pspec)
+ {
+   GrlDAAPRecord *record = SIMPLE_DAAP_RECORD (object);
+ 
+@@ -86,27 +86,27 @@ grl_daap_record_set_property (GObject *object,
+     break;
+   case PROP_ALBUM:
+     g_free (record->priv->album);
+-    record->priv->album = g_value_dup_string(value);
++    record->priv->album = g_value_dup_string (value);
+     break;
+   case PROP_SORT_ALBUM:
+     g_free (record->priv->sort_album);
+-    record->priv->sort_album = g_value_dup_string(value);
++    record->priv->sort_album = g_value_dup_string (value);
+     break;
+   case PROP_ARTIST:
+     g_free (record->priv->artist);
+-    record->priv->artist = g_value_dup_string(value);
++    record->priv->artist = g_value_dup_string (value);
+     break;
+   case PROP_SORT_ARTIST:
+     g_free (record->priv->sort_artist);
+-    record->priv->sort_artist = g_value_dup_string(value);
++    record->priv->sort_artist = g_value_dup_string (value);
+     break;
+   case PROP_GENRE:
+     g_free (record->priv->genre);
+-    record->priv->genre = g_value_dup_string(value);
++    record->priv->genre = g_value_dup_string (value);
+     break;
+   case PROP_FORMAT:
+     g_free (record->priv->format);
+-    record->priv->format = g_value_dup_string(value);
++    record->priv->format = g_value_dup_string (value);
+     break;
+   case PROP_MEDIAKIND:
+     record->priv->mediakind = g_value_get_enum (value);
+@@ -142,18 +142,16 @@ grl_daap_record_set_property (GObject *object,
+     record->priv->has_video = g_value_get_boolean (value);
+     break;
+   default:
+-    G_OBJECT_WARN_INVALID_PROPERTY_ID (object,
+-                                       prop_id,
+-                                       pspec);
++    G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+     break;
+   }
+ }
+ 
+ static void
+ grl_daap_record_get_property (GObject *object,
+-                                 guint prop_id,
+-                                 GValue *value,
+-                                 GParamSpec *pspec)
++                              guint prop_id,
++                              GValue *value,
++                              GParamSpec *pspec)
+ {
+   GrlDAAPRecord *record = SIMPLE_DAAP_RECORD (object);
+ 
+@@ -216,9 +214,7 @@ grl_daap_record_get_property (GObject *object,
+     g_value_set_boolean (value, record->priv->has_video);
+     break;
+   default:
+-    G_OBJECT_WARN_INVALID_PROPERTY_ID (object,
+-                                       prop_id,
+-                                       pspec);
++    G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+     break;
+   }
+ }
+diff --git a/src/dmap/grl-daap-record.h b/src/dmap/grl-daap-record.h
+index 59558c4..7aae82d 100644
+--- a/src/dmap/grl-daap-record.h
++++ b/src/dmap/grl-daap-record.h
+@@ -25,36 +25,35 @@
+ 
+ G_BEGIN_DECLS
+ 
+-#define TYPE_SIMPLE_DAAP_RECORD                 \
+-  (grl_daap_record_get_type ())
+-
+-#define SIMPLE_DAAP_RECORD(o)                            \
+-  (G_TYPE_CHECK_INSTANCE_CAST((o),                       \
+-                              TYPE_SIMPLE_DAAP_RECORD,   \
+-                              GrlDAAPRecord))
+-
+-#define SIMPLE_DAAP_RECORD_CLASS(k)                   \
+-  (G_TYPE_CHECK_CLASS_CAST((k),                       \
+-                           TYPE_SIMPLE_DAAP_RECORD,   \
+-                           GrlDAAPRecordClass))
+-
+-#define IS_SIMPLE_DAAP_RECORD(o)                         \
+-  (G_TYPE_CHECK_INSTANCE_TYPE((o),                       \
+-                              TYPE_SIMPLE_DAAP_RECORD))
+-
+-#define IS_SIMPLE_DAAP_RECORD_CLASS(k)                      \
+-  (G_TYPE_CHECK_CLASS_TYPE((k),                             \
+-                           TYPE_SIMPLE_DAAP_RECORD_CLASS))
+-
+-#define SIMPLE_DAAP_RECORD_GET_CLASS(o)               \
+-  (G_TYPE_INSTANCE_GET_CLASS((o),                     \
+-                             TYPE_SIMPLE_DAAP_RECORD, \
++#define TYPE_SIMPLE_DAAP_RECORD (grl_daap_record_get_type ())
++
++#define SIMPLE_DAAP_RECORD(o)                                                  \
++  (G_TYPE_CHECK_INSTANCE_CAST ((o),                                            \
++                                TYPE_SIMPLE_DAAP_RECORD,                       \
++                                GrlDAAPRecord))
++
++#define SIMPLE_DAAP_RECORD_CLASS(k)                                            \
++  (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
++                             TYPE_SIMPLE_DAAP_RECORD,                          \
+                              GrlDAAPRecordClass))
+ 
+-#define SIMPLE_DAAP_RECORD_GET_PRIVATE(o)                \
+-  (G_TYPE_INSTANCE_GET_PRIVATE((o),                      \
+-                               TYPE_SIMPLE_DAAP_RECORD,  \
+-                               GrlDAAPRecordPrivate))
++#define IS_SIMPLE_DAAP_RECORD(o)                                               \
++  (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
++                                TYPE_SIMPLE_DAAP_RECORD))
++
++#define IS_SIMPLE_DAAP_RECORD_CLASS(k)                                         \
++  (G_TYPE_CHECK_CLASS_TYPE ((k),                                               \
++                             TYPE_SIMPLE_DAAP_RECORD_CLASS))
++
++#define SIMPLE_DAAP_RECORD_GET_CLASS(o)                                        \
++  (G_TYPE_INSTANCE_GET_CLASS ((o),                                             \
++                               TYPE_SIMPLE_DAAP_RECORD,                        \
++                               GrlDAAPRecordClass))
++
++#define SIMPLE_DAAP_RECORD_GET_PRIVATE(o)                                      \
++  (G_TYPE_INSTANCE_GET_PRIVATE ((o),                                           \
++                                 TYPE_SIMPLE_DAAP_RECORD,                      \
++                                 GrlDAAPRecordPrivate))
+ 
+ typedef struct GrlDAAPRecordPrivate GrlDAAPRecordPrivate;
+ 
+@@ -69,9 +68,9 @@ typedef struct {
+ 
+ GType grl_daap_record_get_type (void);
+ 
+-GrlDAAPRecord *grl_daap_record_new    (void);
+-GInputStream     *grl_daap_record_read   (DAAPRecord *record, GError **error);
+-gint              grl_daap_record_get_id (DAAPRecord *record);
++GrlDAAPRecord *grl_daap_record_new (void);
++GInputStream *grl_daap_record_read (DAAPRecord *record, GError **error);
++gint grl_daap_record_get_id (DAAPRecord *record);
+ 
+ #endif /* __SIMPLE_DAAP_RECORD */
+ 
+diff --git a/src/dmap/grl-daap.c b/src/dmap/grl-daap.c
+index 13cc7e3..f3c4115 100644
+--- a/src/dmap/grl-daap.c
++++ b/src/dmap/grl-daap.c
+@@ -42,7 +42,7 @@
+ /* --------- Logging  -------- */
+ 
+ #define GRL_LOG_DOMAIN_DEFAULT daap_log_domain
+-GRL_LOG_DOMAIN_STATIC(daap_log_domain);
++GRL_LOG_DOMAIN_STATIC (daap_log_domain);
+ 
+ /* --- Plugin information --- */
+ 
+@@ -111,19 +111,19 @@ grl_daap_plugin_init (GrlRegistry *registry,
+   sources     = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+ 
+   g_signal_connect (G_OBJECT (browser),
+-                    "service-added",
++                   "service-added",
+                     G_CALLBACK (grl_daap_service_added_cb),
+                     (gpointer) plugin);
+ 
+   g_signal_connect (G_OBJECT (browser),
+-                    "service-removed",
++                   "service-removed",
+                     G_CALLBACK (grl_daap_service_removed_cb),
+                     (gpointer) plugin);
+ 
+   if (!dmap_mdns_browser_start (browser, &error)) {
+     GRL_DEBUG ("error starting browser. code: %d message: %s",
+-               error->code,
+-               error->message);
++                error->code,
++                error->message);
+     g_error_free (error);
+ 
+     g_hash_table_unref (connections);
+@@ -138,12 +138,12 @@ grl_daap_plugin_init (GrlRegistry *registry,
+ GRL_PLUGIN_DEFINE (GRL_MAJOR,
+                    GRL_MINOR,
+                    DAAP_PLUGIN_ID,
+-                   "DAAP",
+-                   "A plugin for browsing DAAP servers",
+-                   "W. Michael Petullo",
++                  "DAAP",
++                  "A plugin for browsing DAAP servers",
++                  "W. Michael Petullo",
+                    VERSION,
+-                   "LGPL",
+-                   "http://www.flyn.org",
++                  "LGPL",
++                  "http://www.flyn.org",
+                    grl_daap_plugin_init,
+                    NULL,
+                    NULL);
+@@ -166,10 +166,10 @@ grl_daap_source_new (DMAPMdnsBrowserService *service)
+   source_id = g_strdup_printf (SOURCE_ID_TEMPLATE, service->name);
+ 
+   source = g_object_new (GRL_DAAP_SOURCE_TYPE,
+-                         "source-id",   source_id,
+-                         "source-name", service->name,
+-                         "source-desc", source_desc,
+-                         "supported-media", GRL_SUPPORTED_MEDIA_AUDIO,
++                        "source-id",   source_id,
++                        "source-name", service->name,
++                        "source-desc", source_desc,
++                        "supported-media", GRL_SUPPORTED_MEDIA_AUDIO,
+                          NULL);
+ 
+   source->priv->service = service;
+@@ -209,14 +209,14 @@ grl_daap_source_finalize (GObject *object)
+ static void
+ grl_daap_do_browse (ResultCbAndArgsAndDb *cb_and_db)
+ {
+-  grl_daap_db_browse(GRL_DAAP_DB(cb_and_db->db),
+-                     cb_and_db->cb.container,
+-                     cb_and_db->cb.source,
+-                     cb_and_db->cb.op_id,
+-                     cb_and_db->cb.skip,
+-                     cb_and_db->cb.count,
+-                     cb_and_db->cb.callback,
+-                     cb_and_db->cb.user_data);
++  grl_daap_db_browse (GRL_DAAP_DB(cb_and_db->db),
++                      cb_and_db->cb.container,
++                      cb_and_db->cb.source,
++                      cb_and_db->cb.op_id,
++                      cb_and_db->cb.skip,
++                      cb_and_db->cb.count,
++                      cb_and_db->cb.callback,
++                      cb_and_db->cb.user_data);
+ 
+   g_free (cb_and_db);
+ }
+@@ -224,13 +224,13 @@ grl_daap_do_browse (ResultCbAndArgsAndDb *cb_and_db)
+ static void
+ grl_daap_do_search (ResultCbAndArgsAndDb *cb_and_db)
+ {
+-  grl_daap_db_search(GRL_DAAP_DB(cb_and_db->db),
+-                     cb_and_db->cb.source,
+-                     cb_and_db->cb.op_id,
+-                     (GHRFunc) cb_and_db->cb.predicate,
+-                     cb_and_db->cb.predicate_data,
+-                     cb_and_db->cb.callback,
+-                     cb_and_db->cb.user_data);
++  grl_daap_db_search (GRL_DAAP_DB (cb_and_db->db),
++                      cb_and_db->cb.source,
++                      cb_and_db->cb.op_id,
++                      (GHRFunc) cb_and_db->cb.predicate,
++                      cb_and_db->cb.predicate_data,
++                      cb_and_db->cb.callback,
++                      cb_and_db->cb.user_data);
+ 
+   g_free (cb_and_db);
+ }
+diff --git a/src/dmap/grl-daap.h b/src/dmap/grl-daap.h
+index 4912b05..1119495 100644
+--- a/src/dmap/grl-daap.h
++++ b/src/dmap/grl-daap.h
+@@ -26,31 +26,30 @@
+ 
+ #include <grilo.h>
+ 
+-#define GRL_DAAP_SOURCE_TYPE                    \
+-  (grl_daap_source_get_type ())
+-
+-#define GRL_DAAP_SOURCE(obj)                          \
+-  (G_TYPE_CHECK_INSTANCE_CAST ((obj),                 \
+-                               GRL_DAAP_SOURCE_TYPE,  \
+-                               GrlDaapSource))
+-
+-#define GRL_IS_DAAP_SOURCE(obj)                       \
+-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj),                 \
+-                               GRL_DAAP_SOURCE_TYPE))
+-
+-#define GRL_DAAP_SOURCE_CLASS(klass)               \
+-  (G_TYPE_CHECK_CLASS_CAST((klass),                \
+-                           GRL_DAAP_SOURCE_TYPE,   \
+-                           GrlDaapSourceClass))
+-
+-#define GRL_IS_DAAP_SOURCE_CLASS(klass)            \
+-  (G_TYPE_CHECK_CLASS_TYPE((klass),                \
+-                           GRL_DAAP_SOURCE_TYPE))
+-
+-#define GRL_DAAP_SOURCE_GET_CLASS(obj)                \
+-  (G_TYPE_INSTANCE_GET_CLASS ((obj),                  \
+-                              GRL_DAAP_SOURCE_TYPE,   \
+-                              GrlDaapSourceClass))
++#define GRL_DAAP_SOURCE_TYPE (grl_daap_source_get_type ())
++
++#define GRL_DAAP_SOURCE(obj)                                                   \
++  (G_TYPE_CHECK_INSTANCE_CAST ((obj),                                          \
++                                GRL_DAAP_SOURCE_TYPE,                          \
++                                GrlDaapSource))
++
++#define GRL_IS_DAAP_SOURCE(obj)                                                \
++  (G_TYPE_CHECK_INSTANCE_TYPE ((obj),                                          \
++                                GRL_DAAP_SOURCE_TYPE))
++
++#define GRL_DAAP_SOURCE_CLASS(klass)                                           \
++  (G_TYPE_CHECK_CLASS_CAST ((klass),                                           \
++                             GRL_DAAP_SOURCE_TYPE,                             \
++                             GrlDaapSourceClass))
++
++#define GRL_IS_DAAP_SOURCE_CLASS(klass)                                        \
++  (G_TYPE_CHECK_CLASS_TYPE ((klass),                                           \
++                             GRL_DAAP_SOURCE_TYPE))
++
++#define GRL_DAAP_SOURCE_GET_CLASS(obj)                                         \
++  (G_TYPE_INSTANCE_GET_CLASS ((obj),                                           \
++                               GRL_DAAP_SOURCE_TYPE,                           \
++                               GrlDaapSourceClass))
+ 
+ typedef struct _GrlDaapSourcePrivate GrlDaapSourcePrivate;
+ typedef struct _GrlDaapSource  GrlDaapSource;
+diff --git a/src/dmap/grl-dpap-db.c b/src/dmap/grl-dpap-db.c
+index 1f2d5ca..02ffd3a 100644
+--- a/src/dmap/grl-dpap-db.c
++++ b/src/dmap/grl-dpap-db.c
+@@ -80,8 +80,8 @@ grl_dpap_db_lookup_by_id (const DMAPDb *db, guint id)
+ 
+ static void
+ grl_dpap_db_foreach (const DMAPDb *db,
+-                        GHFunc func,
+-                        gpointer data)
++                     GHFunc func,
++                     gpointer data)
+ {
+   g_warning ("Not implemented");
+ }
+@@ -103,7 +103,7 @@ set_insert (GHashTable *category, const char *category_name, char *set_name, Grl
+   id = g_strdup_printf ("%s-%s", category_name, set_name);
+ 
+   container = grl_media_container_new ();
+-  grl_media_set_id    (container, id);
++  grl_media_set_id (container, id);
+   grl_media_set_title (container, set_name);
+ 
+   set = g_hash_table_lookup (category, container);
+@@ -142,35 +142,24 @@ grl_dpap_db_add (DMAPDb *_db, DMAPRecord *_record)
+   GrlMedia   *media;
+ 
+   g_object_get (record,
+-               "large-filesize",
+-               &largefilesize,
+-               "creation-date",
+-               &creationdate,
+-               "rating",
+-               &rating,
+-               "filename",
+-               &filename,
+-               "aspect-ratio",
+-               &aspectratio,
+-               "pixel-height",
+-               &height,
+-               "pixel-width",
+-               &width,
+-               "format",
+-               &format,
+-               "comments",
+-               &comments,
+-               "thumbnail",
+-               &thumbnail,
+-               "location",
+-               &url,
++               "large-filesize", &largefilesize,
++               "creation-date", &creationdate,
++               "rating", &rating,
++               "filename", &filename,
++               "aspect-ratio", &aspectratio,
++               "pixel-height", &height,
++               "pixel-width", &width,
++               "format", &format,
++               "comments", &comments,
++               "thumbnail", &thumbnail,
++               "location", &url,
+                 NULL);
+ 
+   id_s = g_strdup_printf ("%u", nextid);
+ 
+   media = grl_media_image_new ();
+ 
+-  grl_media_set_id           (media, id_s);
++  grl_media_set_id (media, id_s);
+ 
+   if (filename)
+     grl_media_set_title (media, filename);
+@@ -181,7 +170,7 @@ grl_dpap_db_add (DMAPDb *_db, DMAPRecord *_record)
+     grl_media_set_url (media, url);
+   }
+ 
+-  grl_media_set_width  (media, width);
++  grl_media_set_width (media, width);
+   grl_media_set_height (media, height);
+ 
+   set_insert (db->priv->photos,  PHOTOS_ID, "Unknown",  media);
+@@ -195,7 +184,7 @@ grl_dpap_db_add (DMAPDb *_db, DMAPRecord *_record)
+ static gboolean
+ same_media (GrlMedia *a, GrlMedia *b)
+ {
+-  return (strcmp (grl_media_get_id (a), grl_media_get_id (b)) == 0);
++  return strcmp (grl_media_get_id (a), grl_media_get_id (b)) == 0;
+ }
+ 
+ void
+@@ -230,7 +219,7 @@ grl_dpap_db_browse (GrlDPAPDb *db,
+   if (hash_table == NULL) {
+     GError *error = g_error_new (GRL_CORE_ERROR,
+                                  GRL_CORE_ERROR_BROWSE_FAILED,
+-                                 "Invalid container identifier %s",
++                                "Invalid container identifier %s",
+                                  container_id);
+     func (source, op_id, NULL, 0, user_data, error);
+     goto done;
+@@ -334,7 +323,7 @@ grl_dpap_db_init (GrlDPAPDb *db)
+ 
+   db->priv->photos_container  = grl_media_container_new ();
+ 
+-  grl_media_set_id    (GRL_MEDIA (db->priv->photos_container), PHOTOS_ID);
++  grl_media_set_id (GRL_MEDIA (db->priv->photos_container), PHOTOS_ID);
+   grl_media_set_title (GRL_MEDIA (db->priv->photos_container), PHOTOS_NAME);
+ 
+   db->priv->root   = g_hash_table_new_full (container_hash, container_equal, g_object_unref, (GDestroyNotify) g_hash_table_destroy);
+diff --git a/src/dmap/grl-dpap-db.h b/src/dmap/grl-dpap-db.h
+index 4c17d1a..d3abcba 100644
+--- a/src/dmap/grl-dpap-db.h
++++ b/src/dmap/grl-dpap-db.h
+@@ -26,34 +26,33 @@
+ 
+ G_BEGIN_DECLS
+ 
+-#define TYPE_GRL_DPAP_DB                     \
+-  (grl_dpap_db_get_type ())
++#define TYPE_GRL_DPAP_DB (grl_dpap_db_get_type ())
+ 
+-#define GRL_DPAP_DB(o)                             \
+-  (G_TYPE_CHECK_INSTANCE_CAST ((o),                   \
+-                               TYPE_GRL_DPAP_DB,   \
+-                               GrlDPAPDb))
++#define GRL_DPAP_DB(o)                                                         \
++  (G_TYPE_CHECK_INSTANCE_CAST ((o),                                            \
++                                TYPE_GRL_DPAP_DB,                              \
++                                GrlDPAPDb))
+ 
+-#define GRL_DPAP_DB_CLASS(k)                 \
+-  (G_TYPE_CHECK_CLASS_CAST((k),                 \
+-                           TYPE_GRL_DPAP_DB, \
+-                           GrlDPAPDbClass))
+-#define IS_GRL_DPAP_DB(o)                          \
+-  (G_TYPE_CHECK_INSTANCE_TYPE((o),                    \
+-                              TYPE_GRL_DPAP_DB))
+-#define IS_GRL_DPAP_DB_CLASS(k)                       \
+-  (G_TYPE_CHECK_CLASS_TYPE((k),                          \
+-                           TYPE_GRL_DPAP_DB_CLASS))
+-
+-#define GRL_DPAP_DB_GET_CLASS(o)                \
+-  (G_TYPE_INSTANCE_GET_CLASS((o),                  \
+-                             TYPE_GRL_DPAP_DB,  \
++#define GRL_DPAP_DB_CLASS(k)                                                   \
++  (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
++                             TYPE_GRL_DPAP_DB,                                 \
+                              GrlDPAPDbClass))
++#define IS_GRL_DPAP_DB(o)                                                      \
++  (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
++                                TYPE_GRL_DPAP_DB))
++#define IS_GRL_DPAP_DB_CLASS(k)                                                \
++  (G_TYPE_CHECK_CLASS_TYPE ((k),                                               \
++                             TYPE_GRL_DPAP_DB_CLASS))
++
++#define GRL_DPAP_DB_GET_CLASS(o)                                               \
++  (G_TYPE_INSTANCE_GET_CLASS ((o),                                             \
++                               TYPE_GRL_DPAP_DB,                               \
++                               GrlDPAPDbClass))
+ 
+-#define GRL_DPAP_DB_GET_PRIVATE(o)                 \
+-  (G_TYPE_INSTANCE_GET_PRIVATE((o),                   \
+-                               TYPE_GRL_DPAP_DB,   \
+-                               GrlDPAPDbPrivate))
++#define GRL_DPAP_DB_GET_PRIVATE(o)                                             \
++  (G_TYPE_INSTANCE_GET_PRIVATE ((o),                                           \
++                                 TYPE_GRL_DPAP_DB,                             \
++                                 GrlDPAPDbPrivate))
+ 
+ typedef struct GrlDPAPDbPrivate GrlDPAPDbPrivate;
+ 
+diff --git a/src/dmap/grl-dpap-record-factory.c b/src/dmap/grl-dpap-record-factory.c
+index 8174338..3d0c87a 100644
+--- a/src/dmap/grl-dpap-record-factory.c
++++ b/src/dmap/grl-dpap-record-factory.c
+@@ -22,9 +22,9 @@
+ #include "grl-dpap-record.h"
+ 
+ DMAPRecord *
+-grl_dpap_record_factory_create  (DMAPRecordFactory *factory, gpointer user_data)
++grl_dpap_record_factory_create (DMAPRecordFactory *factory, gpointer user_data)
+ {
+-	return DMAP_RECORD (grl_dpap_record_new ());
++  return DMAP_RECORD (grl_dpap_record_new ());
+ }
+ 
+ static void
+@@ -40,19 +40,19 @@ grl_dpap_record_factory_class_init (GrlDPAPRecordFactoryClass *klass)
+ static void
+ grl_dpap_record_factory_interface_init (gpointer iface, gpointer data)
+ {
+-	DMAPRecordFactoryIface *factory = iface;
++  DMAPRecordFactoryIface *factory = iface;
+ 
+-	g_assert (G_TYPE_FROM_INTERFACE (factory) == DMAP_TYPE_RECORD_FACTORY);
++  g_assert (G_TYPE_FROM_INTERFACE (factory) == DMAP_TYPE_RECORD_FACTORY);
+ 
+-	factory->create = grl_dpap_record_factory_create;
++  factory->create = grl_dpap_record_factory_create;
+ }
+ 
+ G_DEFINE_TYPE_WITH_CODE (GrlDPAPRecordFactory, grl_dpap_record_factory, G_TYPE_OBJECT,
+-			 G_IMPLEMENT_INTERFACE (DMAP_TYPE_RECORD_FACTORY,
+-					        grl_dpap_record_factory_interface_init))
++                         G_IMPLEMENT_INTERFACE (DMAP_TYPE_RECORD_FACTORY,
++                                                grl_dpap_record_factory_interface_init))
+ 
+ GrlDPAPRecordFactory *
+ grl_dpap_record_factory_new (void)
+ {
+-	return SIMPLE_DPAP_RECORD_FACTORY (g_object_new (TYPE_SIMPLE_DPAP_RECORD_FACTORY, NULL));
++  return SIMPLE_DPAP_RECORD_FACTORY (g_object_new (TYPE_SIMPLE_DPAP_RECORD_FACTORY, NULL));
+ }
+diff --git a/src/dmap/grl-dpap-record-factory.h b/src/dmap/grl-dpap-record-factory.h
+index c2106b1..3f4ca54 100644
+--- a/src/dmap/grl-dpap-record-factory.h
++++ b/src/dmap/grl-dpap-record-factory.h
+@@ -25,30 +25,29 @@
+ 
+ G_BEGIN_DECLS
+ 
+-#define TYPE_SIMPLE_DPAP_RECORD_FACTORY         \
+-  (grl_dpap_record_factory_get_type ())
++#define TYPE_SIMPLE_DPAP_RECORD_FACTORY (grl_dpap_record_factory_get_type ())
+ 
+-#define SIMPLE_DPAP_RECORD_FACTORY(o)                          \
+-  (G_TYPE_CHECK_INSTANCE_CAST((o),                             \
+-                              TYPE_SIMPLE_DPAP_RECORD_FACTORY, \
+-                              GrlDPAPRecordFactory))
++#define SIMPLE_DPAP_RECORD_FACTORY(o)                                          \
++  (G_TYPE_CHECK_INSTANCE_CAST ((o),                                            \
++                                TYPE_SIMPLE_DPAP_RECORD_FACTORY,               \
++                                GrlDPAPRecordFactory))
+ 
+-#define SIMPLE_DPAP_RECORD_FACTORY_CLASS(k)                 \
+-  (G_TYPE_CHECK_CLASS_CAST((k),                             \
+-                           TYPE_SIMPLE_DPAP_RECORD_FACTORY, \
+-                           GrlDPAPRecordFactoryClass))
++#define SIMPLE_DPAP_RECORD_FACTORY_CLASS(k)                                    \
++  (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
++                             TYPE_SIMPLE_DPAP_RECORD_FACTORY,                  \
++                             GrlDPAPRecordFactoryClass))
+ 
+-#define IS_SIMPLE_DPAP_RECORD_FACTORY(o)                          \
+-  (G_TYPE_CHECK_INSTANCE_TYPE((o),                                \
++#define IS_SIMPLE_DPAP_RECORD_FACTORY(o)                                       \
++  (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
+                               TYPE_SIMPLE_DPAP_RECORD_FACTORY))
+ 
+-#define IS_SIMPLE_DPAP_RECORD_FACTORY_CLASS(k)                       \
+-  (G_TYPE_CHECK_CLASS_TYPE((k),                                      \
+-                           TYPE_SIMPLE_DPAP_RECORD_FACTORY_CLASS))
++#define IS_SIMPLE_DPAP_RECORD_FACTORY_CLASS(k)                                 \
++  (G_TYPE_CHECK_CLASS_TYPE ((k),                                               \
++                             TYPE_SIMPLE_DPAP_RECORD_FACTORY_CLASS))
+ 
+-#define SIMPLE_DPAP_RECORD_FACTORY_GET_CLASS(o)                \
+-  (G_TYPE_INSTANCE_GET_CLASS((o),                              \
+-                             TYPE_SIMPLE_DPAP_RECORD_FACTORY,  \
++#define SIMPLE_DPAP_RECORD_FACTORY_GET_CLASS(o)                                \
++  (G_TYPE_INSTANCE_GET_CLASS ((o),                                             \
++                             TYPE_SIMPLE_DPAP_RECORD_FACTORY,                  \
+                              GrlDPAPRecordFactoryClass))
+ 
+ typedef struct GrlDPAPRecordFactoryPrivate GrlDPAPRecordFactoryPrivate;
+@@ -61,11 +60,11 @@ typedef struct {
+   GObjectClass parent;
+ } GrlDPAPRecordFactoryClass;
+ 
+-GType                    grl_dpap_record_factory_get_type (void);
++GType grl_dpap_record_factory_get_type (void);
+ 
+-GrlDPAPRecordFactory *grl_dpap_record_factory_new      (void);
++GrlDPAPRecordFactory *grl_dpap_record_factory_new (void);
+ 
+-DMAPRecord              *grl_dpap_record_factory_create   (DMAPRecordFactory *factory, gpointer user_data);
++DMAPRecord *grl_dpap_record_factory_create (DMAPRecordFactory *factory, gpointer user_data);
+ 
+ #endif /* __SIMPLE_DPAP_RECORD_FACTORY */
+ 
+diff --git a/src/dmap/grl-dpap-record.c b/src/dmap/grl-dpap-record.c
+index 6281417..14eb1de 100644
+--- a/src/dmap/grl-dpap-record.c
++++ b/src/dmap/grl-dpap-record.c
+@@ -61,9 +61,9 @@ G_DEFINE_TYPE_WITH_CODE (GrlDPAPRecord, grl_dpap_record, G_TYPE_OBJECT,
+ 
+ static void
+ grl_dpap_record_set_property (GObject *object,
+-                                guint prop_id,
+-                                const GValue *value,
+-                                GParamSpec *pspec)
++                              guint prop_id,
++                              const GValue *value,
++                              GParamSpec *pspec)
+ {
+   GrlDPAPRecord *record = SIMPLE_DPAP_RECORD (object);
+ 
+@@ -116,9 +116,9 @@ grl_dpap_record_set_property (GObject *object,
+ 
+ static void
+ grl_dpap_record_get_property (GObject *object,
+-                                 guint prop_id,
+-                                 GValue *value,
+-                                 GParamSpec *pspec)
++                              guint prop_id,
++                              GValue *value,
++                              GParamSpec *pspec)
+ {
+   GrlDPAPRecord *record = SIMPLE_DPAP_RECORD (object);
+ 
+diff --git a/src/dmap/grl-dpap-record.h b/src/dmap/grl-dpap-record.h
+index 4441740..203e57e 100644
+--- a/src/dmap/grl-dpap-record.h
++++ b/src/dmap/grl-dpap-record.h
+@@ -25,36 +25,35 @@
+ 
+ G_BEGIN_DECLS
+ 
+-#define TYPE_SIMPLE_DPAP_RECORD                 \
+-  (grl_dpap_record_get_type ())
+-
+-#define SIMPLE_DPAP_RECORD(o)                            \
+-  (G_TYPE_CHECK_INSTANCE_CAST((o),                       \
+-                              TYPE_SIMPLE_DPAP_RECORD,   \
+-                              GrlDPAPRecord))
+-
+-#define SIMPLE_DPAP_RECORD_CLASS(k)                   \
+-  (G_TYPE_CHECK_CLASS_CAST((k),                       \
+-                           TYPE_SIMPLE_DPAP_RECORD,   \
+-                           GrlDPAPRecordClass))
+-
+-#define IS_SIMPLE_DPAP_RECORD(o)                         \
+-  (G_TYPE_CHECK_INSTANCE_TYPE((o),                       \
+-                              TYPE_SIMPLE_DPAP_RECORD))
+-
+-#define IS_SIMPLE_DPAP_RECORD_CLASS(k)                      \
+-  (G_TYPE_CHECK_CLASS_TYPE((k),                             \
+-                           TYPE_SIMPLE_DPAP_RECORD_CLASS))
+-
+-#define SIMPLE_DPAP_RECORD_GET_CLASS(o)               \
+-  (G_TYPE_INSTANCE_GET_CLASS((o),                     \
+-                             TYPE_SIMPLE_DPAP_RECORD, \
++#define TYPE_SIMPLE_DPAP_RECORD (grl_dpap_record_get_type ())
++
++#define SIMPLE_DPAP_RECORD(o)                                                  \
++  (G_TYPE_CHECK_INSTANCE_CAST ((o),                                            \
++                                TYPE_SIMPLE_DPAP_RECORD,                       \
++                                GrlDPAPRecord))
++
++#define SIMPLE_DPAP_RECORD_CLASS(k)                                            \
++  (G_TYPE_CHECK_CLASS_CAST ((k),                                               \
++                             TYPE_SIMPLE_DPAP_RECORD,                          \
+                              GrlDPAPRecordClass))
+ 
+-#define SIMPLE_DPAP_RECORD_GET_PRIVATE(o)                \
+-  (G_TYPE_INSTANCE_GET_PRIVATE((o),                      \
+-                               TYPE_SIMPLE_DPAP_RECORD,  \
+-                               GrlDPAPRecordPrivate))
++#define IS_SIMPLE_DPAP_RECORD(o)                                               \
++  (G_TYPE_CHECK_INSTANCE_TYPE ((o),                                            \
++                                TYPE_SIMPLE_DPAP_RECORD))
++
++#define IS_SIMPLE_DPAP_RECORD_CLASS(k)                                         \
++  (G_TYPE_CHECK_CLASS_TYPE ((k),                                               \
++                            TYPE_SIMPLE_DPAP_RECORD_CLASS))
++
++#define SIMPLE_DPAP_RECORD_GET_CLASS(o)                                        \
++  (G_TYPE_INSTANCE_GET_CLASS ((o),                                             \
++                              TYPE_SIMPLE_DPAP_RECORD,                         \
++                              GrlDPAPRecordClass))
++
++#define SIMPLE_DPAP_RECORD_GET_PRIVATE(o)                                      \
++  (G_TYPE_INSTANCE_GET_PRIVATE ((o),                                           \
++                                TYPE_SIMPLE_DPAP_RECORD,                       \
++                                GrlDPAPRecordPrivate))
+ 
+ typedef struct GrlDPAPRecordPrivate GrlDPAPRecordPrivate;
+ 
+@@ -69,9 +68,9 @@ typedef struct {
+ 
+ GType grl_dpap_record_get_type (void);
+ 
+-GrlDPAPRecord    *grl_dpap_record_new    (void);
+-GInputStream     *grl_dpap_record_read   (DPAPRecord *record, GError **error);
+-gint              grl_dpap_record_get_id (DPAPRecord *record);
++GrlDPAPRecord *grl_dpap_record_new (void);
++GInputStream *grl_dpap_record_read (DPAPRecord *record, GError **error);
++gint grl_dpap_record_get_id (DPAPRecord *record);
+ 
+ #endif /* __SIMPLE_DPAP_RECORD */
+ 
+diff --git a/src/dmap/grl-dpap.c b/src/dmap/grl-dpap.c
+index 744de80..9829ec2 100644
+--- a/src/dmap/grl-dpap.c
++++ b/src/dmap/grl-dpap.c
+@@ -42,7 +42,7 @@
+ /* --------- Logging  -------- */
+ 
+ #define GRL_LOG_DOMAIN_DEFAULT dmap_log_domain
+-GRL_LOG_DOMAIN_STATIC(dmap_log_domain);
++GRL_LOG_DOMAIN_STATIC (dmap_log_domain);
+ 
+ /* --- Plugin information --- */
+ 
+@@ -51,10 +51,10 @@ GRL_LOG_DOMAIN_STATIC(dmap_log_domain);
+ 
+ /* --- Grilo DPAP Private --- */
+ 
+-#define GRL_DPAP_SOURCE_GET_PRIVATE(object)           \
+-  (G_TYPE_INSTANCE_GET_PRIVATE((object),              \
+-                               GRL_DPAP_SOURCE_TYPE,  \
+-                               GrlDpapSourcePrivate))
++#define GRL_DPAP_SOURCE_GET_PRIVATE(object)            \
++  (G_TYPE_INSTANCE_GET_PRIVATE ((object),              \
++                                 GRL_DPAP_SOURCE_TYPE, \
++                                 GrlDpapSourcePrivate))
+ 
+ struct _GrlDpapSourcePrivate {
+   DMAPMdnsBrowserService *service;
+@@ -116,19 +116,19 @@ grl_dpap_plugin_init (GrlRegistry *registry,
+   sources     = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+ 
+   g_signal_connect (G_OBJECT (browser),
+-                    "service-added",
++                   "service-added",
+                     G_CALLBACK (grl_dpap_service_added_cb),
+                     (gpointer) plugin);
+ 
+   g_signal_connect (G_OBJECT (browser),
+-                    "service-removed",
++                   "service-removed",
+                     G_CALLBACK (grl_dpap_service_removed_cb),
+                     (gpointer) plugin);
+ 
+   if (!dmap_mdns_browser_start (browser, &error)) {
+     GRL_DEBUG ("error starting browser. code: %d message: %s",
+-               error->code,
+-               error->message);
++                error->code,
++                error->message);
+     g_error_free (error);
+ 
+     g_hash_table_unref (connections);
+@@ -143,12 +143,12 @@ grl_dpap_plugin_init (GrlRegistry *registry,
+ GRL_PLUGIN_DEFINE (GRL_MAJOR,
+                    GRL_MINOR,
+                    DPAP_PLUGIN_ID,
+-                   "DPAP",
+-                   "A plugin for browsing DPAP servers",
+-                   "W. Michael Petullo",
++                  "DPAP",
++                  "A plugin for browsing DPAP servers",
++                  "W. Michael Petullo",
+                    VERSION,
+-                   "LGPL",
+-                   "http://www.flyn.org",
++                  "LGPL",
++                  "http://www.flyn.org",
+                    grl_dpap_plugin_init,
+                    NULL,
+                    NULL);
+@@ -171,10 +171,10 @@ grl_dpap_source_new (DMAPMdnsBrowserService *service)
+   source_id = g_strdup_printf (SOURCE_ID_TEMPLATE, service->name);
+ 
+   source = g_object_new (GRL_DPAP_SOURCE_TYPE,
+-                         "source-id",   source_id,
+-                         "source-name", service->name,
+-                         "source-desc", source_desc,
+-                         "supported-media", GRL_SUPPORTED_MEDIA_IMAGE,
++                        "source-id",   source_id,
++                        "source-name", service->name,
++                        "source-desc", source_desc,
++                        "supported-media", GRL_SUPPORTED_MEDIA_IMAGE,
+                          NULL);
+ 
+   source->priv->service = service;
+@@ -214,14 +214,14 @@ grl_dpap_source_finalize (GObject *object)
+ static void
+ grl_dpap_do_browse (ResultCbAndArgsAndDb *cb_and_db)
+ {
+-  grl_dpap_db_browse(GRL_DPAP_DB(cb_and_db->db),
+-                     cb_and_db->cb.container,
+-                     cb_and_db->cb.source,
+-                     cb_and_db->cb.op_id,
+-                     cb_and_db->cb.skip,
+-                     cb_and_db->cb.count,
+-                     cb_and_db->cb.callback,
+-                     cb_and_db->cb.user_data);
++  grl_dpap_db_browse (GRL_DPAP_DB (cb_and_db->db),
++                      cb_and_db->cb.container,
++                      cb_and_db->cb.source,
++                      cb_and_db->cb.op_id,
++                      cb_and_db->cb.skip,
++                      cb_and_db->cb.count,
++                      cb_and_db->cb.callback,
++                      cb_and_db->cb.user_data);
+ 
+   g_free (cb_and_db);
+ }
+@@ -229,13 +229,13 @@ grl_dpap_do_browse (ResultCbAndArgsAndDb *cb_and_db)
+ static void
+ grl_dpap_do_search (ResultCbAndArgsAndDb *cb_and_db)
+ {
+-  grl_dpap_db_search(GRL_DPAP_DB(cb_and_db->db),
+-                     cb_and_db->cb.source,
+-                     cb_and_db->cb.op_id,
+-                     (GHRFunc) cb_and_db->cb.predicate,
+-                     cb_and_db->cb.predicate_data,
+-                     cb_and_db->cb.callback,
+-                     cb_and_db->cb.user_data);
++  grl_dpap_db_search (GRL_DPAP_DB (cb_and_db->db),
++                      cb_and_db->cb.source,
++                      cb_and_db->cb.op_id,
++                      (GHRFunc) cb_and_db->cb.predicate,
++                      cb_and_db->cb.predicate_data,
++                      cb_and_db->cb.callback,
++                      cb_and_db->cb.user_data);
+ 
+   g_free (cb_and_db);
+ }
+diff --git a/src/dmap/grl-dpap.h b/src/dmap/grl-dpap.h
+index 1f36cfc..ee596b5 100644
+--- a/src/dmap/grl-dpap.h
++++ b/src/dmap/grl-dpap.h
+@@ -26,31 +26,30 @@
+ 
+ #include <grilo.h>
+ 
+-#define GRL_DPAP_SOURCE_TYPE                    \
+-  (grl_dpap_source_get_type ())
++#define GRL_DPAP_SOURCE_TYPE (grl_dpap_source_get_type ())
+ 
+-#define GRL_DPAP_SOURCE(obj)                          \
+-  (G_TYPE_CHECK_INSTANCE_CAST ((obj),                 \
+-                               GRL_DPAP_SOURCE_TYPE,  \
+-                               GrlDpapSource))
++#define GRL_DPAP_SOURCE(obj)                                                   \
++  (G_TYPE_CHECK_INSTANCE_CAST ((obj),                                          \
++                                GRL_DPAP_SOURCE_TYPE,                          \
++                                GrlDpapSource))
+ 
+-#define GRL_IS_DPAP_SOURCE(obj)                       \
+-  (G_TYPE_CHECK_INSTANCE_TYPE ((obj),                 \
+-                               GRL_DPAP_SOURCE_TYPE))
++#define GRL_IS_DPAP_SOURCE(obj)                                                \
++  (G_TYPE_CHECK_INSTANCE_TYPE ((obj),                                          \
++                                GRL_DPAP_SOURCE_TYPE))
+ 
+-#define GRL_DPAP_SOURCE_CLASS(klass)               \
+-  (G_TYPE_CHECK_CLASS_CAST((klass),                \
+-                           GRL_DPAP_SOURCE_TYPE,   \
+-                           GrlDpapSourceClass))
++#define GRL_DPAP_SOURCE_CLASS(klass)                                           \
++  (G_TYPE_CHECK_CLASS_CAST ((klass),                                           \
++                             GRL_DPAP_SOURCE_TYPE,                             \
++                             GrlDpapSourceClass))
+ 
+-#define GRL_IS_DPAP_SOURCE_CLASS(klass)            \
+-  (G_TYPE_CHECK_CLASS_TYPE((klass),                \
+-                           GRL_DPAP_SOURCE_TYPE))
++#define GRL_IS_DPAP_SOURCE_CLASS(klass)                                        \
++  (G_TYPE_CHECK_CLASS_TYPE ((klass),                                           \
++                             GRL_DPAP_SOURCE_TYPE))
+ 
+-#define GRL_DPAP_SOURCE_GET_CLASS(obj)                \
+-  (G_TYPE_INSTANCE_GET_CLASS ((obj),                  \
+-                              GRL_DPAP_SOURCE_TYPE,   \
+-                              GrlDpapSourceClass))
++#define GRL_DPAP_SOURCE_GET_CLASS(obj)                                         \
++  (G_TYPE_INSTANCE_GET_CLASS ((obj),                                           \
++                               GRL_DPAP_SOURCE_TYPE,                           \
++                               GrlDpapSourceClass))
+ 
+ typedef struct _GrlDpapSourcePrivate GrlDpapSourcePrivate;
+ typedef struct _GrlDpapSource  GrlDpapSource;

--- a/multimedia/grilo-plugins/patches/020-backport-add-missing-calls-to-free.patch
+++ b/multimedia/grilo-plugins/patches/020-backport-add-missing-calls-to-free.patch
@@ -1,0 +1,33 @@
+diff --git a/src/dmap/grl-daap-db.c b/src/dmap/grl-daap-db.c
+index c931d91..f460113 100644
+--- a/src/dmap/grl-daap-db.c
++++ b/src/dmap/grl-daap-db.c
+@@ -232,6 +232,11 @@ grl_daap_db_add (DMAPDb *_db, DMAPRecord *_record)
+ 
+   g_free (id_s);
+   g_object_unref (media);
++  g_free(album);
++  g_free(artist);
++  g_free(genre);
++  g_free(title);
++  g_free(url);
+ 
+   return --nextid;
+ }
+diff --git a/src/dmap/grl-dpap-db.c b/src/dmap/grl-dpap-db.c
+index 02ffd3a..8be278b 100644
+--- a/src/dmap/grl-dpap-db.c
++++ b/src/dmap/grl-dpap-db.c
+@@ -177,6 +177,12 @@ grl_dpap_db_add (DMAPDb *_db, DMAPRecord *_record)
+ 
+   g_free (id_s);
+   g_object_unref (media);
++  g_free(filename);
++  g_free(aspectratio);
++  g_free(format);
++  g_free(comments);
++  g_free(url);
++  g_byte_array_unref(thumbnail);
+ 
+   return --nextid;
+ }

--- a/multimedia/grilo-plugins/patches/030-backport-libdmapsharing4.patch
+++ b/multimedia/grilo-plugins/patches/030-backport-libdmapsharing4.patch
@@ -1,0 +1,1490 @@
+diff --git a/meson.build b/meson.build
+index 33a6f40..8a590b9 100644
+--- a/meson.build
++++ b/meson.build
+@@ -62,7 +62,12 @@ gstreamer_dep = dependency('gstreamer-1.0', required: false)
+ gthread_dep = dependency('gthread-2.0', required: false)
+ json_glib_dep = dependency('json-glib-1.0', required: false)
+ libarchive_dep = dependency('libarchive', required: false)
+-libdmapsharing_dep = dependency('libdmapsharing-3.0', version: '>= 2.9.12', required: false)
++libdmapsharing4_dep = dependency('libdmapsharing-4.0', version: '>= 3.9.4', required: false)
++if libdmapsharing4_dep.found()
++    libdmapsharing_dep = libdmapsharing4_dep
++else
++    libdmapsharing_dep = dependency('libdmapsharing-3.0', version: '>= 2.9.12', required: false)
++endif
+ libgdata_dep = dependency('libgdata', version: '>= 0.9.1', required: false)
+ libmediaart_dep = dependency('libmediaart-2.0', required: false)
+ libsoup_dep = dependency('libsoup-2.4', required: false)
+diff --git a/src/dmap/grl-common.c b/src/dmap/grl-common.c
+index 6a1da5e..74a965f 100644
+--- a/src/dmap/grl-common.c
++++ b/src/dmap/grl-common.c
+@@ -33,13 +33,27 @@
+ #include <stdlib.h>
+ #include <libdmapsharing/dmap.h>
+ 
++#include "grl-dmap-compat.h"
+ #include "grl-common.h"
+ 
+ gchar *
+-grl_dmap_build_url (DMAPMdnsBrowserService *service)
++grl_dmap_build_url (DmapMdnsService *service)
+ {
+-  return g_strdup_printf ("%s://%s:%u",
+-                           service->service_name,
+-                           service->host,
+-                           service->port);
++  gchar *url = NULL;
++  gchar *service_name, *host;
++  guint port;
++
++  service_name = grl_dmap_service_get_service_name (service);
++  host         = grl_dmap_service_get_host (service);
++  port         = grl_dmap_service_get_port (service);
++
++  url = g_strdup_printf ("%s://%s:%u",
++                          service_name,
++                          host,
++                          port);
++
++  g_free (service_name);
++  g_free (host);
++
++  return url;
+ }
+diff --git a/src/dmap/grl-common.h b/src/dmap/grl-common.h
+index e9c8327..d61df63 100644
+--- a/src/dmap/grl-common.h
++++ b/src/dmap/grl-common.h
+@@ -24,9 +24,6 @@
+ #ifndef _GRL_COMMON_H_
+ #define _GRL_COMMON_H_
+ 
+-#include <grilo.h>
+-#include <libdmapsharing/dmap.h>
+-
+ typedef struct {
+   GrlSourceResultCb callback;
+   GrlSource *source;
+@@ -41,9 +38,9 @@ typedef struct {
+ 
+ typedef struct {
+   ResultCbAndArgs cb;
+-  DMAPDb *db;
++  DmapDb *db;
+ } ResultCbAndArgsAndDb;
+ 
+-gchar *grl_dmap_build_url (DMAPMdnsBrowserService *service);
++gchar *grl_dmap_build_url (DmapMdnsService *service);
+ 
+ #endif /* _GRL_COMMON_H_ */
+diff --git a/src/dmap/grl-daap-compat.h b/src/dmap/grl-daap-compat.h
+new file mode 100644
+index 0000000..da9025f
+--- /dev/null
++++ b/src/dmap/grl-daap-compat.h
+@@ -0,0 +1,76 @@
++/*
++ * Copyright (C) 2019 W. Michael Petullo
++ * Copyright (C) 2019 Igalia S.L.
++ *
++ * Contact: W. Michael Petullo <mike@flyn.org>
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public License
++ * as published by the Free Software Foundation; version 2.1 of
++ * the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful, but
++ * WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
++ * 02110-1301 USA
++ *
++ */
++
++#ifndef _GRL_DAAP_COMPAT_H_
++#define _GRL_DAAP_COMPAT_H_
++
++#include "grl-dmap-compat.h"
++
++#ifdef LIBDMAPSHARING_COMPAT
++
++DMAPRecord *grl_daap_record_factory_create (DMAPRecordFactory *factory, gpointer user_data, GError **error);
++guint grl_daap_db_add (DMAPDb *_db, DMAPRecord *_record, GError **error);
++
++/* Building against libdmapsharing 3 API. */
++
++#define dmap_av_connection_new daap_connection_new
++#define DmapAvRecord DAAPRecord
++#define DmapAvRecordInterface DAAPRecordIface
++#define DMAP_AV_RECORD DAAP_RECORD
++#define DMAP_TYPE_AV_RECORD DAAP_TYPE_RECORD
++#define IS_DMAP_AV_RECORD IS_DAAP_RECORD
++
++static inline DmapRecord *
++grl_daap_record_factory_create_compat (DmapRecordFactory *factory, gpointer user_data)
++{
++  return grl_daap_record_factory_create (factory, user_data, NULL);
++}
++
++static inline guint
++grl_daap_db_add_compat (DmapDb *_db, DmapRecord *_record)
++{
++  return grl_daap_db_add (_db, _record, NULL);
++}
++
++#else
++
++/* Building against libdmapsharing 4 API. */
++
++DmapRecord *grl_daap_record_factory_create (DmapRecordFactory *factory, gpointer user_data, GError **error);
++guint grl_daap_db_add (DmapDb *_db, DmapRecord *_record, GError **error);
++
++static inline DmapRecord *
++grl_daap_record_factory_create_compat (DmapRecordFactory *factory, gpointer user_data, GError **error)
++{
++  return grl_daap_record_factory_create (factory, user_data, error);
++}
++
++static inline guint
++grl_daap_db_add_compat (DmapDb *_db, DmapRecord *_record, GError **error)
++{
++  return grl_daap_db_add (_db, _record, error);
++}
++
++#endif
++
++#endif /* _GRL_DAAP_COMPAT_H_ */
+diff --git a/src/dmap/grl-daap-db.c b/src/dmap/grl-daap-db.c
+index f460113..315370e 100644
+--- a/src/dmap/grl-daap-db.c
++++ b/src/dmap/grl-daap-db.c
+@@ -54,8 +54,12 @@
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <glib.h>
++#include <grilo.h>
+ #include <string.h>
++#include <libdmapsharing/dmap.h>
+ 
++#include "grl-daap-compat.h"
++#include "grl-common.h"
+ #include "grl-daap-db.h"
+ 
+ #define ALBUMS_ID    "albums"
+@@ -103,23 +107,23 @@ grl_daap_db_new (void)
+   return db;
+ }
+ 
+-static DMAPRecord *
+-grl_daap_db_lookup_by_id (const DMAPDb *db, guint id)
++static DmapRecord *
++grl_daap_db_lookup_by_id (const DmapDb *db, guint id)
+ {
+   g_error ("Not implemented");
+   return NULL;
+ }
+ 
+ static void
+-grl_daap_db_foreach (const DMAPDb *db,
+-                     GHFunc func,
++grl_daap_db_foreach (const DmapDb *db,
++                     DmapIdRecordFunc func,
+                      gpointer data)
+ {
+   g_error ("Not implemented");
+ }
+ 
+ static gint64
+-grl_daap_db_count (const DMAPDb *db)
++grl_daap_db_count (const DmapDb *db)
+ {
+   g_error ("Not implemented");
+   return 0;
+@@ -150,14 +154,14 @@ set_insert (GHashTable *category, const char *category_name, char *set_name, Grl
+   g_object_unref (container);
+ }
+ 
+-static guint
+-grl_daap_db_add (DMAPDb *_db, DMAPRecord *_record)
++guint
++grl_daap_db_add (DmapDb *_db, DmapRecord *_record, GError **error)
+ {
+   g_assert (IS_GRL_DAAP_DB (_db));
+-  g_assert (IS_DAAP_RECORD (_record));
++  g_assert (IS_DMAP_AV_RECORD (_record));
+ 
+   GrlDAAPDb *db = GRL_DAAP_DB (_db);
+-  DAAPRecord *record = DAAP_RECORD (_record);
++  DmapAvRecord *record = DMAP_AV_RECORD (_record);
+ 
+   gint   duration = 0;
+   gint32  bitrate = 0,
+@@ -232,11 +236,11 @@ grl_daap_db_add (DMAPDb *_db, DMAPRecord *_record)
+ 
+   g_free (id_s);
+   g_object_unref (media);
+-  g_free(album);
+-  g_free(artist);
+-  g_free(genre);
+-  g_free(title);
+-  g_free(url);
++  g_free (album);
++  g_free (artist);
++  g_free (genre);
++  g_free (title);
++  g_free (url);
+ 
+   return --nextid;
+ }
+@@ -359,11 +363,11 @@ grl_daap_db_search (GrlDAAPDb *db,
+ static void
+ dmap_db_interface_init (gpointer iface, gpointer data)
+ {
+-  DMAPDbIface *daap_db = iface;
++  DmapDbInterface *daap_db = iface;
+ 
+   g_assert (G_TYPE_FROM_INTERFACE (daap_db) == DMAP_TYPE_DB);
+ 
+-  daap_db->add = grl_daap_db_add;
++  daap_db->add = grl_daap_db_add_compat;
+   daap_db->lookup_by_id = grl_daap_db_lookup_by_id;
+   daap_db->foreach = grl_daap_db_foreach;
+   daap_db->count = grl_daap_db_count;
+diff --git a/src/dmap/grl-daap-db.h b/src/dmap/grl-daap-db.h
+index 2548c50..1a37a3a 100644
+--- a/src/dmap/grl-daap-db.h
++++ b/src/dmap/grl-daap-db.h
+@@ -24,6 +24,8 @@
+ #include <libdmapsharing/dmap.h>
+ #include <grilo.h>
+ 
++#include "grl-daap-compat.h"
++
+ G_BEGIN_DECLS
+ 
+ #define TYPE_GRL_DAAP_DB (grl_daap_db_get_type ())
+diff --git a/src/dmap/grl-daap-record-factory.c b/src/dmap/grl-daap-record-factory.c
+index 648fd85..d0c590f 100644
+--- a/src/dmap/grl-daap-record-factory.c
++++ b/src/dmap/grl-daap-record-factory.c
+@@ -1,5 +1,5 @@
+ /*
+- * DAAPRecord factory class
++ * DmapAvRecord factory class
+  *
+  * Copyright (C) 2008 W. Michael Petullo <mike@flyn.org>
+  *
+@@ -18,11 +18,16 @@
+  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+  */
+ 
++#include <grilo.h>
++#include <libdmapsharing/dmap.h>
++
++#include "grl-daap-compat.h"
++#include "grl-common.h"
+ #include "grl-daap-record-factory.h"
+ #include "grl-daap-record.h"
+ 
+-DMAPRecord *
+-grl_daap_record_factory_create (DMAPRecordFactory *factory, gpointer user_data)
++DmapRecord *
++grl_daap_record_factory_create (DmapRecordFactory *factory, gpointer user_data, GError **error)
+ {
+   return DMAP_RECORD (grl_daap_record_new ());
+ }
+@@ -40,11 +45,11 @@ grl_daap_record_factory_class_init (GrlDAAPRecordFactoryClass *klass)
+ static void
+ grl_daap_record_factory_interface_init (gpointer iface, gpointer data)
+ {
+-  DMAPRecordFactoryIface *factory = iface;
++  DmapRecordFactoryInterface *factory = iface;
+ 
+   g_assert (G_TYPE_FROM_INTERFACE (factory) == DMAP_TYPE_RECORD_FACTORY);
+ 
+-  factory->create = grl_daap_record_factory_create;
++  factory->create = grl_daap_record_factory_create_compat;
+ }
+ 
+ G_DEFINE_TYPE_WITH_CODE (GrlDAAPRecordFactory, grl_daap_record_factory, G_TYPE_OBJECT,
+diff --git a/src/dmap/grl-daap-record-factory.h b/src/dmap/grl-daap-record-factory.h
+index 45aa69a..f114bad 100644
+--- a/src/dmap/grl-daap-record-factory.h
++++ b/src/dmap/grl-daap-record-factory.h
+@@ -23,6 +23,8 @@
+ 
+ #include <libdmapsharing/dmap.h>
+ 
++#include "grl-daap-compat.h"
++
+ G_BEGIN_DECLS
+ 
+ #define TYPE_SIMPLE_DAAP_RECORD_FACTORY (grl_daap_record_factory_get_type ())
+@@ -64,8 +66,6 @@ GType grl_daap_record_factory_get_type (void);
+ 
+ GrlDAAPRecordFactory *grl_daap_record_factory_new (void);
+ 
+-DMAPRecord *grl_daap_record_factory_create (DMAPRecordFactory *factory, gpointer user_data);
+-
+ #endif /* __SIMPLE_DAAP_RECORD_FACTORY */
+ 
+ G_END_DECLS
+diff --git a/src/dmap/grl-daap-record.c b/src/dmap/grl-daap-record.c
+index 82bf2f9..4fa0c54 100644
+--- a/src/dmap/grl-daap-record.c
++++ b/src/dmap/grl-daap-record.c
+@@ -20,6 +20,11 @@
+  *
+  */
+ 
++#include <grilo.h>
++#include <libdmapsharing/dmap.h>
++
++#include "grl-daap-compat.h"
++#include "grl-common.h"
+ #include "grl-daap-record.h"
+ 
+ struct GrlDAAPRecordPrivate {
+@@ -226,7 +231,7 @@ grl_daap_record_new (void)
+ }
+ 
+ GInputStream *
+-grl_daap_record_read (DAAPRecord *record, GError **error)
++grl_daap_record_read (DmapAvRecord *record, GError **error)
+ {
+   GFile *file;
+   GInputStream *stream;
+@@ -280,9 +285,9 @@ grl_daap_record_class_init (GrlDAAPRecordClass *klass)
+ static void
+ grl_daap_record_daap_iface_init (gpointer iface, gpointer data)
+ {
+-  DAAPRecordIface *daap_record = iface;
++  DmapAvRecordInterface *daap_record = iface;
+ 
+-  g_assert (G_TYPE_FROM_INTERFACE (daap_record) == DAAP_TYPE_RECORD);
++  g_assert (G_TYPE_FROM_INTERFACE (daap_record) == DMAP_TYPE_AV_RECORD);
+ 
+   daap_record->read = grl_daap_record_read;
+ }
+@@ -290,7 +295,7 @@ grl_daap_record_daap_iface_init (gpointer iface, gpointer data)
+ static void
+ grl_daap_record_dmap_iface_init (gpointer iface, gpointer data)
+ {
+-  DMAPRecordIface *dmap_record = iface;
++  DmapRecordInterface *dmap_record = iface;
+ 
+   g_assert (G_TYPE_FROM_INTERFACE (dmap_record) == DMAP_TYPE_RECORD);
+ }
+@@ -298,7 +303,7 @@ grl_daap_record_dmap_iface_init (gpointer iface, gpointer data)
+ 
+ G_DEFINE_TYPE_WITH_CODE (GrlDAAPRecord, grl_daap_record, G_TYPE_OBJECT,
+                          G_ADD_PRIVATE (GrlDAAPRecord)
+-                         G_IMPLEMENT_INTERFACE (DAAP_TYPE_RECORD, grl_daap_record_daap_iface_init)
++                         G_IMPLEMENT_INTERFACE (DMAP_TYPE_AV_RECORD, grl_daap_record_daap_iface_init)
+                          G_IMPLEMENT_INTERFACE (DMAP_TYPE_RECORD, grl_daap_record_dmap_iface_init))
+ 
+ static void
+diff --git a/src/dmap/grl-daap-record.h b/src/dmap/grl-daap-record.h
+index 7aae82d..42782b1 100644
+--- a/src/dmap/grl-daap-record.h
++++ b/src/dmap/grl-daap-record.h
+@@ -23,6 +23,8 @@
+ 
+ #include <libdmapsharing/dmap.h>
+ 
++#include "grl-daap-compat.h"
++
+ G_BEGIN_DECLS
+ 
+ #define TYPE_SIMPLE_DAAP_RECORD (grl_daap_record_get_type ())
+@@ -69,8 +71,8 @@ typedef struct {
+ GType grl_daap_record_get_type (void);
+ 
+ GrlDAAPRecord *grl_daap_record_new (void);
+-GInputStream *grl_daap_record_read (DAAPRecord *record, GError **error);
+-gint grl_daap_record_get_id (DAAPRecord *record);
++GInputStream *grl_daap_record_read (DmapAvRecord *record, GError **error);
++gint grl_daap_record_get_id (DmapAvRecord *record);
+ 
+ #endif /* __SIMPLE_DAAP_RECORD */
+ 
+diff --git a/src/dmap/grl-daap.c b/src/dmap/grl-daap.c
+index f3c4115..962f2b8 100644
+--- a/src/dmap/grl-daap.c
++++ b/src/dmap/grl-daap.c
+@@ -33,6 +33,7 @@
+ #include <stdlib.h>
+ #include <libdmapsharing/dmap.h>
+ 
++#include "grl-daap-compat.h"
+ #include "grl-common.h"
+ #include "grl-daap.h"
+ #include "grl-daap-db.h"
+@@ -52,12 +53,12 @@ GRL_LOG_DOMAIN_STATIC (daap_log_domain);
+ /* --- Grilo DAAP Private --- */
+ 
+ struct _GrlDaapSourcePrivate {
+-  DMAPMdnsBrowserService *service;
++  DmapMdnsService *service;
+ };
+ 
+ /* --- Data types --- */
+ 
+-static GrlDaapSource *grl_daap_source_new (DMAPMdnsBrowserService *service);
++static GrlDaapSource *grl_daap_source_new (DmapMdnsService *service);
+ 
+ static void grl_daap_source_finalize (GObject *object);
+ 
+@@ -74,16 +75,16 @@ static void grl_daap_source_search (GrlSource *source,
+                                     GrlSourceSearchSpec *ss);
+ 
+ 
+-static void grl_daap_service_added_cb (DMAPMdnsBrowser *browser,
+-                                       DMAPMdnsBrowserService *service,
++static void grl_daap_service_added_cb (DmapMdnsBrowser *browser,
++                                       DmapMdnsService *service,
+                                        GrlPlugin *plugin);
+ 
+-static void grl_daap_service_removed_cb (DMAPMdnsBrowser *browser,
++static void grl_daap_service_removed_cb (DmapMdnsBrowser *browser,
+                                          const gchar *service_name,
+                                          GrlPlugin *plugin);
+ 
+ /* ===================== Globals  ======================= */
+-static DMAPMdnsBrowser *browser;
++static DmapMdnsBrowser *browser;
+ /* Maps URIs to DBs */
+ static GHashTable *connections;
+ /* Map DAAP services to Grilo media sources */
+@@ -106,7 +107,7 @@ grl_daap_plugin_init (GrlRegistry *registry,
+   bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+ 
+-  browser     = dmap_mdns_browser_new (DMAP_MDNS_BROWSER_SERVICE_TYPE_DAAP);
++  browser     = dmap_mdns_browser_new (DMAP_MDNS_SERVICE_TYPE_DAAP);
+   connections = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+   sources     = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+ 
+@@ -153,8 +154,10 @@ GRL_PLUGIN_DEFINE (GRL_MAJOR,
+ G_DEFINE_TYPE_WITH_PRIVATE (GrlDaapSource, grl_daap_source, GRL_TYPE_SOURCE)
+ 
+ static GrlDaapSource *
+-grl_daap_source_new (DMAPMdnsBrowserService *service)
++grl_daap_source_new (DmapMdnsService *service)
+ {
++  gchar *name;
++  gchar *service_name;
+   gchar *source_desc;
+   gchar *source_id;
+ 
+@@ -162,12 +165,15 @@ grl_daap_source_new (DMAPMdnsBrowserService *service)
+ 
+   GRL_DEBUG ("grl_daap_source_new");
+ 
+-  source_desc = g_strdup_printf (SOURCE_DESC_TEMPLATE, service->name);
+-  source_id = g_strdup_printf (SOURCE_ID_TEMPLATE, service->name);
++  name = grl_dmap_service_get_name (service);
++  service_name = grl_dmap_service_get_service_name (service);
++
++  source_desc = g_strdup_printf (SOURCE_DESC_TEMPLATE, name);
++  source_id = g_strdup_printf (SOURCE_ID_TEMPLATE, name);
+ 
+   source = g_object_new (GRL_DAAP_SOURCE_TYPE,
+                         "source-id",   source_id,
+-                        "source-name", service->name,
++                        "source-name", service_name,
+                         "source-desc", source_desc,
+                         "supported-media", GRL_SUPPORTED_MEDIA_AUDIO,
+                          NULL);
+@@ -176,6 +182,8 @@ grl_daap_source_new (DMAPMdnsBrowserService *service)
+ 
+   g_free (source_desc);
+   g_free (source_id);
++  g_free (service_name);
++  g_free (name);
+ 
+   return source;
+ }
+@@ -209,7 +217,7 @@ grl_daap_source_finalize (GObject *object)
+ static void
+ grl_daap_do_browse (ResultCbAndArgsAndDb *cb_and_db)
+ {
+-  grl_daap_db_browse (GRL_DAAP_DB(cb_and_db->db),
++  grl_daap_db_browse (GRL_DAAP_DB (cb_and_db->db),
+                       cb_and_db->cb.container,
+                       cb_and_db->cb.source,
+                       cb_and_db->cb.op_id,
+@@ -236,7 +244,7 @@ grl_daap_do_search (ResultCbAndArgsAndDb *cb_and_db)
+ }
+ 
+ static void
+-browse_connected_cb (DMAPConnection       *connection,
++browse_connected_cb (DmapConnection       *connection,
+                      gboolean              result,
+                      const char           *reason,
+                      ResultCbAndArgsAndDb *cb_and_db)
+@@ -261,7 +269,7 @@ browse_connected_cb (DMAPConnection       *connection,
+ }
+ 
+ static void
+-search_connected_cb (DMAPConnection       *connection,
++search_connected_cb (DmapConnection       *connection,
+                      gboolean              result,
+                      const char           *reason,
+                      ResultCbAndArgsAndDb *cb_and_db)
+@@ -286,8 +294,8 @@ search_connected_cb (DMAPConnection       *connection,
+ }
+ 
+ static void
+-grl_daap_service_added_cb (DMAPMdnsBrowser *browser,
+-                           DMAPMdnsBrowserService *service,
++grl_daap_service_added_cb (DmapMdnsBrowser *browser,
++                           DmapMdnsService *service,
+                            GrlPlugin *plugin)
+ {
+   GrlRegistry   *registry = grl_registry_get_default ();
+@@ -301,13 +309,16 @@ grl_daap_service_added_cb (DMAPMdnsBrowser *browser,
+                                 GRL_SOURCE (source),
+                                 NULL);
+   if (source != NULL) {
+-    g_hash_table_insert (sources, g_strdup (service->name), g_object_ref (source));
++    gchar *name;
++    name = grl_dmap_service_get_name (service);
++    g_hash_table_insert (sources, g_strdup (name), g_object_ref (source));
+     g_object_remove_weak_pointer (G_OBJECT (source), (gpointer *) &source);
++    g_free (name);
+   }
+ }
+ 
+ static void
+-grl_daap_service_removed_cb (DMAPMdnsBrowser *browser,
++grl_daap_service_removed_cb (DmapMdnsBrowser *browser,
+                              const gchar *service_name,
+                              GrlPlugin *plugin)
+ {
+@@ -323,14 +334,14 @@ grl_daap_service_removed_cb (DMAPMdnsBrowser *browser,
+ }
+ 
+ static void
+-grl_daap_connect (gchar *name, gchar *host, guint port, ResultCbAndArgsAndDb *cb_and_db, DMAPConnectionCallback callback)
++grl_daap_connect (gchar *name, gchar *host, guint port, ResultCbAndArgsAndDb *cb_and_db, DmapConnectionFunc callback)
+ {
+-  DMAPRecordFactory *factory;
+-  DMAPConnection *connection;
++  DmapRecordFactory *factory;
++  DmapConnection *connection;
+ 
+   factory = DMAP_RECORD_FACTORY (grl_daap_record_factory_new ());
+-  connection = DMAP_CONNECTION (daap_connection_new (name, host, port, DMAP_DB (cb_and_db->db), factory));
+-  dmap_connection_connect (connection, (DMAPConnectionCallback) callback, cb_and_db);
++  connection = DMAP_CONNECTION (dmap_av_connection_new (name, host, port, DMAP_DB (cb_and_db->db), factory));
++  dmap_connection_start (connection, (DmapConnectionFunc) callback, cb_and_db);
+ }
+ 
+ static gboolean
+@@ -397,15 +408,25 @@ grl_daap_source_browse (GrlSource *source,
+     browse_connected_cb (NULL, TRUE, NULL, cb_and_db);
+   } else {
+     /* Connect */
++    gchar *name, *host;
++    guint port;
++
+     cb_and_db->db = DMAP_DB (grl_daap_db_new ());
+ 
+-    grl_daap_connect (dmap_source->priv->service->name,
+-                      dmap_source->priv->service->host,
+-                      dmap_source->priv->service->port,
++    name = grl_dmap_service_get_name (dmap_source->priv->service);
++    host = grl_dmap_service_get_host (dmap_source->priv->service);
++    port = grl_dmap_service_get_port (dmap_source->priv->service);
++
++    grl_daap_connect (name,
++                      host,
++                      port,
+                       cb_and_db,
+-                      (DMAPConnectionCallback) browse_connected_cb);
++                      (DmapConnectionFunc) browse_connected_cb);
+ 
+     g_hash_table_insert (connections, g_strdup (url), cb_and_db->db);
++
++    g_free (name);
++    g_free (host);
+   }
+ 
+   g_free (url);
+@@ -417,7 +438,7 @@ static void grl_daap_source_search (GrlSource *source,
+   GrlDaapSource *dmap_source = GRL_DAAP_SOURCE (source);
+ 
+   ResultCbAndArgsAndDb *cb_and_db;
+-  DMAPMdnsBrowserService *service = dmap_source->priv->service;
++  DmapMdnsService *service = dmap_source->priv->service;
+   gchar *url = grl_dmap_build_url (service);
+ 
+   cb_and_db = g_new (ResultCbAndArgsAndDb, 1);
+@@ -435,9 +456,25 @@ static void grl_daap_source_search (GrlSource *source,
+     search_connected_cb (NULL, TRUE, NULL, cb_and_db);
+   } else {
+     /* Connect */
++    gchar *name, *host;
++    guint port;
++
+     cb_and_db->db = DMAP_DB (grl_daap_db_new ());
+-    grl_daap_connect (service->name, service->host, service->port, cb_and_db, (DMAPConnectionCallback) search_connected_cb);
++
++    name = grl_dmap_service_get_name (dmap_source->priv->service);
++    host = grl_dmap_service_get_host (dmap_source->priv->service);
++    port = grl_dmap_service_get_port (dmap_source->priv->service);
++
++    grl_daap_connect (name,
++                      host,
++                      port,
++                      cb_and_db,
++                      (DmapConnectionFunc) search_connected_cb);
++
+     g_hash_table_insert (connections, g_strdup (url), cb_and_db->db);
++
++    g_free (name);
++    g_free (host);
+   }
+ 
+   g_free (url);
+diff --git a/src/dmap/grl-daap.h b/src/dmap/grl-daap.h
+index 1119495..5271435 100644
+--- a/src/dmap/grl-daap.h
++++ b/src/dmap/grl-daap.h
+@@ -26,6 +26,8 @@
+ 
+ #include <grilo.h>
+ 
++#include "grl-daap-compat.h"
++
+ #define GRL_DAAP_SOURCE_TYPE (grl_daap_source_get_type ())
+ 
+ #define GRL_DAAP_SOURCE(obj)                                                   \
+diff --git a/src/dmap/grl-dmap-compat.h b/src/dmap/grl-dmap-compat.h
+new file mode 100644
+index 0000000..cd1934f
+--- /dev/null
++++ b/src/dmap/grl-dmap-compat.h
+@@ -0,0 +1,108 @@
++/*
++ * Copyright (C) 2019 W. Michael Petullo
++ * Copyright (C) 2019 Igalia S.L.
++ *
++ * Contact: W. Michael Petullo <mike@flyn.org>
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public License
++ * as published by the Free Software Foundation; version 2.1 of
++ * the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful, but
++ * WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
++ * 02110-1301 USA
++ *
++ */
++
++#ifndef _GRL_DMAP_COMPAT_H_
++#define _GRL_DMAP_COMPAT_H_
++
++#ifdef LIBDMAPSHARING_COMPAT
++
++/* Building against libdmapsharing 3 API. */
++
++#define DmapConnection DMAPConnection
++#define DmapConnectionFunc DMAPConnectionCallback
++#define dmap_connection_start dmap_connection_connect
++#define DmapDb DMAPDb
++#define DmapDbInterface DMAPDbIface
++#define DmapIdRecordFunc GHFunc
++#define DmapMdnsBrowser DMAPMdnsBrowser
++#define DmapMdnsService DMAPMdnsBrowserService
++#define DMAP_MDNS_SERVICE_TYPE_DAAP DMAP_MDNS_BROWSER_SERVICE_TYPE_DAAP
++#define DMAP_MDNS_SERVICE_TYPE_DPAP DMAP_MDNS_BROWSER_SERVICE_TYPE_DPAP
++#define DmapRecord DMAPRecord
++#define DmapRecordFactory DMAPRecordFactory
++#define DmapRecordFactoryInterface DMAPRecordFactoryIface
++#define DmapRecordInterface DMAPRecordIface
++
++static inline gchar *
++grl_dmap_service_get_name (DmapMdnsService *service)
++{
++  return g_strdup (service->name);
++}
++
++static inline gchar *
++grl_dmap_service_get_service_name (DmapMdnsService *service)
++{
++  return g_strdup (service->service_name);
++}
++
++static inline gchar *
++grl_dmap_service_get_host (DmapMdnsService *service)
++{
++  return g_strdup (service->host);
++}
++
++static inline guint
++grl_dmap_service_get_port (DmapMdnsService *service)
++{
++  return service->port;
++}
++
++#else
++
++/* Building against libdmapsharing 4 API. */
++
++static inline gchar *
++grl_dmap_service_get_name (DmapMdnsService *service)
++{
++  gchar *name;
++  g_object_get (service, "name", &name, NULL);
++  return name;
++}
++
++static inline gchar *
++grl_dmap_service_get_service_name (DmapMdnsService *service)
++{
++  gchar *service_name;
++  g_object_get (service, "service-name", &service_name, NULL);
++  return service_name;
++}
++
++static inline gchar *
++grl_dmap_service_get_host (DmapMdnsService *service)
++{
++  gchar *host;
++  g_object_get (service, "host", &host, NULL);
++  return host;
++}
++
++static inline guint
++grl_dmap_service_get_port (DmapMdnsService *service)
++{
++  guint port;
++  g_object_get (service, "port", &port, NULL);
++  return port;
++}
++
++#endif
++
++#endif /* _GRL_DMAP_COMPAT_H_ */
+diff --git a/src/dmap/grl-dpap-compat.h b/src/dmap/grl-dpap-compat.h
+new file mode 100644
+index 0000000..b996464
+--- /dev/null
++++ b/src/dmap/grl-dpap-compat.h
+@@ -0,0 +1,116 @@
++/*
++ * Copyright (C) 2019 W. Michael Petullo
++ * Copyright (C) 2019 Igalia S.L.
++ *
++ * Contact: W. Michael Petullo <mike@flyn.org>
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public License
++ * as published by the Free Software Foundation; version 2.1 of
++ * the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful, but
++ * WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
++ * 02110-1301 USA
++ *
++ */
++
++#ifndef _GRL_DPAP_COMPAT_H_
++#define _GRL_DPAP_COMPAT_H_
++
++#include "grl-dmap-compat.h"
++
++#ifdef LIBDMAPSHARING_COMPAT
++
++DMAPRecord *grl_dpap_record_factory_create (DMAPRecordFactory *factory, gpointer user_data, GError **error);
++guint grl_dpap_db_add (DMAPDb *_db, DMAPRecord *_record, GError **error);
++
++/* Building against libdmapsharing 3 API. */
++
++#define dmap_image_connection_new dpap_connection_new
++#define DmapImageRecord DPAPRecord
++#define DmapImageRecordInterface DPAPRecordIface
++#define DMAP_IMAGE_RECORD DPAP_RECORD
++#define DMAP_TYPE_IMAGE_RECORD DPAP_TYPE_RECORD
++#define IS_DMAP_IMAGE_RECORD IS_DPAP_RECORD
++
++static inline DmapRecord *
++grl_dpap_record_factory_create_compat (DmapRecordFactory *factory, gpointer user_data)
++{
++  return grl_dpap_record_factory_create (factory, user_data, NULL);
++}
++
++static inline void
++set_thumbnail (GValue *value, GByteArray *thumbnail)
++{
++  g_value_set_pointer (value, thumbnail);
++}
++
++static inline GByteArray *
++get_thumbnail (GByteArray *thumbnail, const GValue *value)
++{
++  if (thumbnail)
++    g_byte_array_unref (thumbnail);
++  return g_byte_array_ref (g_value_get_pointer (value));
++}
++
++static inline void
++unref_thumbnail (GByteArray *thumbnail)
++{
++  g_byte_array_unref (thumbnail);
++}
++
++static inline guint
++grl_dpap_db_add_compat (DMAPDb *_db, DmapRecord *_record)
++{
++  return grl_dpap_db_add (_db, _record, NULL);
++}
++
++#else
++
++/* Building against libdmapsharing 4 API. */
++
++DmapRecord *grl_dpap_record_factory_create (DmapRecordFactory *factory, gpointer user_data, GError **error);
++guint grl_dpap_db_add (DmapDb *_db, DmapRecord *_record, GError **error);
++
++static inline void
++set_thumbnail (GValue *value, GArray *thumbnail)
++{
++  g_value_set_boxed (value, thumbnail);
++}
++
++static inline GArray *
++get_thumbnail (GArray *thumbnail, const GValue *value)
++{
++  if (thumbnail)
++    g_array_unref (thumbnail);
++  return g_value_get_boxed (value);
++}
++
++static inline void
++unref_thumbnail (GArray *thumbnail)
++{
++  g_array_unref (thumbnail);
++}
++
++static inline DmapRecord *
++grl_dpap_record_factory_create_compat (DmapRecordFactory *factory, gpointer user_data, GError **error)
++{
++  return grl_dpap_record_factory_create (factory, user_data, error);
++}
++
++static inline guint
++grl_dpap_db_add_compat (DmapDb *_db, DmapRecord *_record, GError **error)
++{
++  return grl_dpap_db_add (_db, _record, error);
++}
++
++#endif
++
++#endif /* _GRL_DPAP_COMPAT_H_ */
+diff --git a/src/dmap/grl-dpap-db.c b/src/dmap/grl-dpap-db.c
+index 8be278b..cd647ee 100644
+--- a/src/dmap/grl-dpap-db.c
++++ b/src/dmap/grl-dpap-db.c
+@@ -24,12 +24,16 @@
+ #include "config.h"
+ #endif
+ 
++#include <grilo.h>
+ #include <glib/gi18n-lib.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <glib.h>
+ #include <string.h>
++#include <libdmapsharing/dmap.h>
+ 
++#include "grl-dpap-compat.h"
++#include "grl-common.h"
+ #include "grl-dpap-db.h"
+ 
+ #define PHOTOS_ID     "photos"
+@@ -71,23 +75,23 @@ grl_dpap_db_new (void)
+   return db;
+ }
+ 
+-static DMAPRecord *
+-grl_dpap_db_lookup_by_id (const DMAPDb *db, guint id)
++static DmapRecord *
++grl_dpap_db_lookup_by_id (const DmapDb *db, guint id)
+ {
+   g_warning ("Not implemented");
+   return NULL;
+ }
+ 
+ static void
+-grl_dpap_db_foreach (const DMAPDb *db,
+-                     GHFunc func,
++grl_dpap_db_foreach (const DmapDb *db,
++                     DmapIdRecordFunc func,
+                      gpointer data)
+ {
+   g_warning ("Not implemented");
+ }
+ 
+ static gint64
+-grl_dpap_db_count (const DMAPDb *db)
++grl_dpap_db_count (const DmapDb *db)
+ {
+   g_warning ("Not implemented");
+   return 0;
+@@ -118,21 +122,21 @@ set_insert (GHashTable *category, const char *category_name, char *set_name, Grl
+   g_object_unref (container);
+ }
+ 
+-static guint
+-grl_dpap_db_add (DMAPDb *_db, DMAPRecord *_record)
++guint
++grl_dpap_db_add (DmapDb *_db, DmapRecord *_record, GError **error)
+ {
+   g_assert (IS_GRL_DPAP_DB (_db));
+-  g_assert (IS_DPAP_RECORD (_record));
++  g_assert (IS_DMAP_IMAGE_RECORD (_record));
+ 
+   GrlDPAPDb *db = GRL_DPAP_DB (_db);
+-  DPAPRecord *record = DPAP_RECORD (_record);
++  DmapImageRecord *record = DMAP_IMAGE_RECORD (_record);
+ 
+   gint        height        = 0,
+               width         = 0,
+               largefilesize = 0,
+               creationdate  = 0,
+               rating        = 0;
+-  GByteArray *thumbnail     = NULL;
++  GArray     *thumbnail     = NULL;
+   gchar      *id_s          = NULL,
+              *filename      = NULL,
+              *aspectratio   = NULL,
+@@ -177,12 +181,12 @@ grl_dpap_db_add (DMAPDb *_db, DMAPRecord *_record)
+ 
+   g_free (id_s);
+   g_object_unref (media);
+-  g_free(filename);
+-  g_free(aspectratio);
+-  g_free(format);
+-  g_free(comments);
+-  g_free(url);
+-  g_byte_array_unref(thumbnail);
++  g_free (filename);
++  g_free (aspectratio);
++  g_free (format);
++  g_free (comments);
++  g_free (url);
++  g_array_unref (thumbnail);
+ 
+   return --nextid;
+ }
+@@ -298,11 +302,11 @@ grl_dpap_db_search (GrlDPAPDb *db,
+ static void
+ dmap_db_interface_init (gpointer iface, gpointer data)
+ {
+-  DMAPDbIface *dpap_db = iface;
++  DmapDbInterface *dpap_db = iface;
+ 
+   g_assert (G_TYPE_FROM_INTERFACE (dpap_db) == DMAP_TYPE_DB);
+ 
+-  dpap_db->add = grl_dpap_db_add;
++  dpap_db->add = grl_dpap_db_add_compat;
+   dpap_db->lookup_by_id = grl_dpap_db_lookup_by_id;
+   dpap_db->foreach = grl_dpap_db_foreach;
+   dpap_db->count = grl_dpap_db_count;
+diff --git a/src/dmap/grl-dpap-db.h b/src/dmap/grl-dpap-db.h
+index d3abcba..a21ad7a 100644
+--- a/src/dmap/grl-dpap-db.h
++++ b/src/dmap/grl-dpap-db.h
+@@ -24,6 +24,8 @@
+ #include <libdmapsharing/dmap.h>
+ #include <grilo.h>
+ 
++#include "grl-dpap-compat.h"
++
+ G_BEGIN_DECLS
+ 
+ #define TYPE_GRL_DPAP_DB (grl_dpap_db_get_type ())
+diff --git a/src/dmap/grl-dpap-record-factory.c b/src/dmap/grl-dpap-record-factory.c
+index 3d0c87a..860d957 100644
+--- a/src/dmap/grl-dpap-record-factory.c
++++ b/src/dmap/grl-dpap-record-factory.c
+@@ -18,11 +18,18 @@
+  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+  */
+ 
++#include <grilo.h>
++#include <libdmapsharing/dmap.h>
++
++#include "grl-dpap-compat.h"
++#include "grl-common.h"
+ #include "grl-dpap-record-factory.h"
+ #include "grl-dpap-record.h"
+ 
+-DMAPRecord *
+-grl_dpap_record_factory_create (DMAPRecordFactory *factory, gpointer user_data)
++DmapRecord *
++grl_dpap_record_factory_create (DmapRecordFactory *factory,
++                                gpointer user_data,
++                                GError **error)
+ {
+   return DMAP_RECORD (grl_dpap_record_new ());
+ }
+@@ -40,11 +47,11 @@ grl_dpap_record_factory_class_init (GrlDPAPRecordFactoryClass *klass)
+ static void
+ grl_dpap_record_factory_interface_init (gpointer iface, gpointer data)
+ {
+-  DMAPRecordFactoryIface *factory = iface;
++  DmapRecordFactoryInterface *factory = iface;
+ 
+   g_assert (G_TYPE_FROM_INTERFACE (factory) == DMAP_TYPE_RECORD_FACTORY);
+ 
+-  factory->create = grl_dpap_record_factory_create;
++  factory->create = grl_dpap_record_factory_create_compat;
+ }
+ 
+ G_DEFINE_TYPE_WITH_CODE (GrlDPAPRecordFactory, grl_dpap_record_factory, G_TYPE_OBJECT,
+diff --git a/src/dmap/grl-dpap-record-factory.h b/src/dmap/grl-dpap-record-factory.h
+index 3f4ca54..899fd0a 100644
+--- a/src/dmap/grl-dpap-record-factory.h
++++ b/src/dmap/grl-dpap-record-factory.h
+@@ -23,6 +23,8 @@
+ 
+ #include <libdmapsharing/dmap.h>
+ 
++#include "grl-dpap-compat.h"
++
+ G_BEGIN_DECLS
+ 
+ #define TYPE_SIMPLE_DPAP_RECORD_FACTORY (grl_dpap_record_factory_get_type ())
+@@ -64,7 +66,7 @@ GType grl_dpap_record_factory_get_type (void);
+ 
+ GrlDPAPRecordFactory *grl_dpap_record_factory_new (void);
+ 
+-DMAPRecord *grl_dpap_record_factory_create (DMAPRecordFactory *factory, gpointer user_data);
++DmapRecord *grl_dpap_record_factory_create (DmapRecordFactory *factory, gpointer user_data, GError **error);
+ 
+ #endif /* __SIMPLE_DPAP_RECORD_FACTORY */
+ 
+diff --git a/src/dmap/grl-dpap-record.c b/src/dmap/grl-dpap-record.c
+index 14eb1de..0afb2b8 100644
+--- a/src/dmap/grl-dpap-record.c
++++ b/src/dmap/grl-dpap-record.c
+@@ -20,6 +20,11 @@
+  *
+  */
+ 
++#include <grilo.h>
++#include <libdmapsharing/dmap.h>
++
++#include "grl-dpap-compat.h"
++#include "grl-common.h"
+ #include "grl-dpap-record.h"
+ 
+ struct GrlDPAPRecordPrivate {
+@@ -28,7 +33,7 @@ struct GrlDPAPRecordPrivate {
+   gint creationdate;
+   gint rating;
+   char *filename;
+-  GByteArray *thumbnail;
++  void *thumbnail; /* GByteArray or GArray, depending on libdmapsharing ver. */
+   char *aspectratio;
+   gint height;
+   gint width;
+@@ -56,7 +61,7 @@ static void grl_dpap_record_dpap_iface_init (gpointer iface, gpointer data);
+ 
+ G_DEFINE_TYPE_WITH_CODE (GrlDPAPRecord, grl_dpap_record, G_TYPE_OBJECT,
+                          G_ADD_PRIVATE (GrlDPAPRecord)
+-                         G_IMPLEMENT_INTERFACE (DPAP_TYPE_RECORD, grl_dpap_record_dpap_iface_init)
++                         G_IMPLEMENT_INTERFACE (DMAP_TYPE_IMAGE_RECORD, grl_dpap_record_dpap_iface_init)
+                          G_IMPLEMENT_INTERFACE (DMAP_TYPE_RECORD, grl_dpap_record_dmap_iface_init))
+ 
+ static void
+@@ -104,9 +109,7 @@ grl_dpap_record_set_property (GObject *object,
+     record->priv->comments = g_value_dup_string (value);
+     break;
+   case PROP_THUMBNAIL:
+-    if (record->priv->thumbnail)
+-      g_byte_array_unref (record->priv->thumbnail);
+-    record->priv->thumbnail = g_byte_array_ref (g_value_get_pointer (value));
++    record->priv->thumbnail = get_thumbnail (record->priv->thumbnail, value);
+     break;
+   default:
+     G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+@@ -154,7 +157,7 @@ grl_dpap_record_get_property (GObject *object,
+     g_value_set_static_string (value, record->priv->comments);
+     break;
+   case PROP_THUMBNAIL:
+-    g_value_set_pointer (value, record->priv->thumbnail);
++    set_thumbnail (value, record->priv->thumbnail);
+     break;
+   default:
+     G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+@@ -169,7 +172,7 @@ grl_dpap_record_new (void)
+ }
+ 
+ GInputStream *
+-grl_dpap_record_read (DPAPRecord *record, GError **error)
++grl_dpap_record_read (DmapImageRecord *record, GError **error)
+ {
+   GFile *file;
+   GInputStream *stream;
+@@ -215,9 +218,9 @@ grl_dpap_record_class_init (GrlDPAPRecordClass *klass)
+ static void
+ grl_dpap_record_dpap_iface_init (gpointer iface, gpointer data)
+ {
+-  DPAPRecordIface *dpap_record = iface;
++  DmapImageRecordInterface *dpap_record = iface;
+ 
+-  g_assert (G_TYPE_FROM_INTERFACE (dpap_record) == DPAP_TYPE_RECORD);
++  g_assert (G_TYPE_FROM_INTERFACE (dpap_record) == DMAP_TYPE_IMAGE_RECORD);
+ 
+   dpap_record->read = grl_dpap_record_read;
+ }
+@@ -225,7 +228,7 @@ grl_dpap_record_dpap_iface_init (gpointer iface, gpointer data)
+ static void
+ grl_dpap_record_dmap_iface_init (gpointer iface, gpointer data)
+ {
+-  DMAPRecordIface *dmap_record = iface;
++  DmapRecordInterface *dmap_record = iface;
+ 
+   g_assert (G_TYPE_FROM_INTERFACE (dmap_record) == DMAP_TYPE_RECORD);
+ }
+@@ -242,7 +245,7 @@ grl_dpap_record_finalize (GObject *object)
+   g_free (record->priv->comments);
+ 
+   if (record->priv->thumbnail)
+-    g_byte_array_unref (record->priv->thumbnail);
++    unref_thumbnail (record->priv->thumbnail);
+ 
+   G_OBJECT_CLASS (grl_dpap_record_parent_class)->finalize (object);
+ }
+diff --git a/src/dmap/grl-dpap-record.h b/src/dmap/grl-dpap-record.h
+index 203e57e..77eece0 100644
+--- a/src/dmap/grl-dpap-record.h
++++ b/src/dmap/grl-dpap-record.h
+@@ -23,6 +23,8 @@
+ 
+ #include <libdmapsharing/dmap.h>
+ 
++#include "grl-dpap-compat.h"
++
+ G_BEGIN_DECLS
+ 
+ #define TYPE_SIMPLE_DPAP_RECORD (grl_dpap_record_get_type ())
+@@ -69,8 +71,8 @@ typedef struct {
+ GType grl_dpap_record_get_type (void);
+ 
+ GrlDPAPRecord *grl_dpap_record_new (void);
+-GInputStream *grl_dpap_record_read (DPAPRecord *record, GError **error);
+-gint grl_dpap_record_get_id (DPAPRecord *record);
++GInputStream *grl_dpap_record_read (DmapImageRecord *record, GError **error);
++gint grl_dpap_record_get_id (DmapImageRecord *record);
+ 
+ #endif /* __SIMPLE_DPAP_RECORD */
+ 
+diff --git a/src/dmap/grl-dpap.c b/src/dmap/grl-dpap.c
+index 9829ec2..6339654 100644
+--- a/src/dmap/grl-dpap.c
++++ b/src/dmap/grl-dpap.c
+@@ -33,6 +33,7 @@
+ #include <stdlib.h>
+ #include <libdmapsharing/dmap.h>
+ 
++#include "grl-dpap-compat.h"
+ #include "grl-common.h"
+ #include "grl-dpap.h"
+ #include "grl-dpap-db.h"
+@@ -57,12 +58,12 @@ GRL_LOG_DOMAIN_STATIC (dmap_log_domain);
+                                  GrlDpapSourcePrivate))
+ 
+ struct _GrlDpapSourcePrivate {
+-  DMAPMdnsBrowserService *service;
++  DmapMdnsService *service;
+ };
+ 
+ /* --- Data types --- */
+ 
+-static GrlDpapSource *grl_dpap_source_new (DMAPMdnsBrowserService *service);
++static GrlDpapSource *grl_dpap_source_new (DmapMdnsService *service);
+ 
+ static void grl_dpap_source_finalize (GObject *object);
+ 
+@@ -79,16 +80,16 @@ static void grl_dpap_source_search (GrlSource *source,
+                                     GrlSourceSearchSpec *ss);
+ 
+ 
+-static void grl_dpap_service_added_cb (DMAPMdnsBrowser *browser,
+-                                       DMAPMdnsBrowserService *service,
++static void grl_dpap_service_added_cb (DmapMdnsBrowser *browser,
++                                       DmapMdnsService *service,
+                                        GrlPlugin *plugin);
+ 
+-static void grl_dpap_service_removed_cb (DMAPMdnsBrowser *browser,
++static void grl_dpap_service_removed_cb (DmapMdnsBrowser *browser,
+                                          const gchar *service_name,
+                                          GrlPlugin *plugin);
+ 
+ /* ===================== Globals  ======================= */
+-static DMAPMdnsBrowser *browser;
++static DmapMdnsBrowser *browser;
+ /* Maps URIs to DBs */
+ static GHashTable *connections;
+ /* Map DPAP services to Grilo media sources */
+@@ -111,7 +112,7 @@ grl_dpap_plugin_init (GrlRegistry *registry,
+   bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+ 
+-  browser     = dmap_mdns_browser_new (DMAP_MDNS_BROWSER_SERVICE_TYPE_DPAP);
++  browser     = dmap_mdns_browser_new (DMAP_MDNS_SERVICE_TYPE_DPAP);
+   connections = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+   sources     = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
+ 
+@@ -158,8 +159,10 @@ GRL_PLUGIN_DEFINE (GRL_MAJOR,
+ G_DEFINE_TYPE_WITH_PRIVATE (GrlDpapSource, grl_dpap_source, GRL_TYPE_SOURCE)
+ 
+ static GrlDpapSource *
+-grl_dpap_source_new (DMAPMdnsBrowserService *service)
++grl_dpap_source_new (DmapMdnsService *service)
+ {
++  gchar *name;
++  gchar *service_name;
+   gchar *source_desc;
+   gchar *source_id;
+ 
+@@ -167,12 +170,14 @@ grl_dpap_source_new (DMAPMdnsBrowserService *service)
+ 
+   GRL_DEBUG ("grl_dpap_source_new");
+ 
+-  source_desc = g_strdup_printf (SOURCE_DESC_TEMPLATE, service->name);
+-  source_id = g_strdup_printf (SOURCE_ID_TEMPLATE, service->name);
++  name = grl_dmap_service_get_name (service);
++  service_name = grl_dmap_service_get_service_name (service);
++  source_desc = g_strdup_printf (SOURCE_DESC_TEMPLATE, name);
++  source_id = g_strdup_printf (SOURCE_ID_TEMPLATE, name);
+ 
+   source = g_object_new (GRL_DPAP_SOURCE_TYPE,
+                         "source-id",   source_id,
+-                        "source-name", service->name,
++                        "source-name", service_name,
+                         "source-desc", source_desc,
+                         "supported-media", GRL_SUPPORTED_MEDIA_IMAGE,
+                          NULL);
+@@ -181,6 +186,8 @@ grl_dpap_source_new (DMAPMdnsBrowserService *service)
+ 
+   g_free (source_desc);
+   g_free (source_id);
++  g_free (service_name);
++  g_free (name);
+ 
+   return source;
+ }
+@@ -241,7 +248,7 @@ grl_dpap_do_search (ResultCbAndArgsAndDb *cb_and_db)
+ }
+ 
+ static void
+-browse_connected_cb (DMAPConnection       *connection,
++browse_connected_cb (DmapConnection       *connection,
+                      gboolean              result,
+                      const char           *reason,
+                      ResultCbAndArgsAndDb *cb_and_db)
+@@ -266,7 +273,7 @@ browse_connected_cb (DMAPConnection       *connection,
+ }
+ 
+ static void
+-search_connected_cb (DMAPConnection       *connection,
++search_connected_cb (DmapConnection       *connection,
+                      gboolean              result,
+                      const char           *reason,
+                      ResultCbAndArgsAndDb *cb_and_db)
+@@ -291,8 +298,8 @@ search_connected_cb (DMAPConnection       *connection,
+ }
+ 
+ static void
+-grl_dpap_service_added_cb (DMAPMdnsBrowser *browser,
+-                           DMAPMdnsBrowserService *service,
++grl_dpap_service_added_cb (DmapMdnsBrowser *browser,
++                           DmapMdnsService *service,
+                            GrlPlugin *plugin)
+ {
+   GrlRegistry   *registry = grl_registry_get_default ();
+@@ -306,13 +313,16 @@ grl_dpap_service_added_cb (DMAPMdnsBrowser *browser,
+                                 GRL_SOURCE (source),
+                                 NULL);
+   if (source != NULL) {
+-    g_hash_table_insert (sources, g_strdup (service->name), g_object_ref (source));
++    gchar *name;
++    name = grl_dmap_service_get_name (service);
++    g_hash_table_insert (sources, g_strdup (name), g_object_ref (source));
+     g_object_remove_weak_pointer (G_OBJECT (source), (gpointer *) &source);
++    g_free (name);
+   }
+ }
+ 
+ static void
+-grl_dpap_service_removed_cb (DMAPMdnsBrowser *browser,
++grl_dpap_service_removed_cb (DmapMdnsBrowser *browser,
+                              const gchar *service_name,
+                              GrlPlugin *plugin)
+ {
+@@ -328,14 +338,14 @@ grl_dpap_service_removed_cb (DMAPMdnsBrowser *browser,
+ }
+ 
+ static void
+-grl_dpap_connect (gchar *name, gchar *host, guint port, ResultCbAndArgsAndDb *cb_and_db, DMAPConnectionCallback callback)
++grl_dpap_connect (gchar *name, gchar *host, guint port, ResultCbAndArgsAndDb *cb_and_db, DmapConnectionFunc callback)
+ {
+-  DMAPRecordFactory *factory;
+-  DMAPConnection *connection;
++  DmapRecordFactory *factory;
++  DmapConnection *connection;
+ 
+   factory = DMAP_RECORD_FACTORY (grl_dpap_record_factory_new ());
+-  connection = DMAP_CONNECTION (dpap_connection_new (name, host, port, DMAP_DB (cb_and_db->db), factory));
+-  dmap_connection_connect (connection, (DMAPConnectionCallback) callback, cb_and_db);
++  connection = DMAP_CONNECTION (dmap_image_connection_new (name, host, port, DMAP_DB (cb_and_db->db), factory));
++  dmap_connection_start (connection, (DmapConnectionFunc) callback, cb_and_db);
+ }
+ 
+ static gboolean
+@@ -396,15 +406,25 @@ grl_dpap_source_browse (GrlSource *source,
+     browse_connected_cb (NULL, TRUE, NULL, cb_and_db);
+   } else {
+     /* Connect */
++    gchar *name, *host;
++    guint port;
++
+     cb_and_db->db = DMAP_DB (grl_dpap_db_new ());
+ 
+-    grl_dpap_connect (dmap_source->priv->service->name,
+-                      dmap_source->priv->service->host,
+-                      dmap_source->priv->service->port,
++    name = grl_dmap_service_get_name (dmap_source->priv->service);
++    host = grl_dmap_service_get_host (dmap_source->priv->service);
++    port = grl_dmap_service_get_port (dmap_source->priv->service);
++
++    grl_dpap_connect (name,
++                      host,
++                      port,
+                       cb_and_db,
+-                      (DMAPConnectionCallback) browse_connected_cb);
++                      (DmapConnectionFunc) browse_connected_cb);
+ 
+     g_hash_table_insert (connections, g_strdup (url), cb_and_db->db);
++
++    g_free (name);
++    g_free (host);
+   }
+ 
+   g_free (url);
+@@ -416,7 +436,7 @@ static void grl_dpap_source_search (GrlSource *source,
+   GrlDpapSource *dmap_source = GRL_DPAP_SOURCE (source);
+ 
+   ResultCbAndArgsAndDb *cb_and_db;
+-  DMAPMdnsBrowserService *service = dmap_source->priv->service;
++  DmapMdnsService *service = dmap_source->priv->service;
+   gchar *url = grl_dmap_build_url (service);
+ 
+   cb_and_db = g_new (ResultCbAndArgsAndDb, 1);
+@@ -434,9 +454,25 @@ static void grl_dpap_source_search (GrlSource *source,
+     search_connected_cb (NULL, TRUE, NULL, cb_and_db);
+   } else {
+     /* Connect */
++    gchar *name, *host;
++    guint port;
++
+     cb_and_db->db = DMAP_DB (grl_dpap_db_new ());
+-    grl_dpap_connect (service->name, service->host, service->port, cb_and_db, (DMAPConnectionCallback) search_connected_cb);
++
++    name = grl_dmap_service_get_name (dmap_source->priv->service);
++    host = grl_dmap_service_get_host (dmap_source->priv->service);
++    port = grl_dmap_service_get_port (dmap_source->priv->service);
++
++    grl_dpap_connect (name, 
++                      host,
++                      port,
++                      cb_and_db,
++                      (DmapConnectionFunc) search_connected_cb);
++
+     g_hash_table_insert (connections, g_strdup (url), cb_and_db->db);
++
++    g_free (name);
++    g_free (host);
+   }
+ 
+   g_free (url);
+diff --git a/src/dmap/grl-dpap.h b/src/dmap/grl-dpap.h
+index ee596b5..30cd61e 100644
+--- a/src/dmap/grl-dpap.h
++++ b/src/dmap/grl-dpap.h
+@@ -26,6 +26,8 @@
+ 
+ #include <grilo.h>
+ 
++#include "grl-dpap-compat.h"
++
+ #define GRL_DPAP_SOURCE_TYPE (grl_dpap_source_get_type ())
+ 
+ #define GRL_DPAP_SOURCE(obj)                                                   \
+diff --git a/src/dmap/meson.build b/src/dmap/meson.build
+index 2907a80..817ff5d 100644
+--- a/src/dmap/meson.build
++++ b/src/dmap/meson.build
+@@ -31,6 +31,15 @@ dpap_sources = [
+     'grl-dpap.h',
+ ]
+ 
++args = [
++    '-DG_LOG_DOMAIN="GrlDmap"',
++    '-DHAVE_CONFIG_H',
++]
++
++if not libdmapsharing4_dep.found()
++    args += '-DLIBDMAPSHARING_COMPAT'
++endif
++
+ configure_file(output: 'config.h',
+     configuration: cdata)
+ 
+@@ -39,17 +48,11 @@ shared_library('grldaap',
+     install: true,
+     install_dir: pluginsdir,
+     dependencies: must_deps + plugins[dmap_idx][REQ_DEPS] + plugins[dmap_idx][OPT_DEPS],
+-    c_args: [
+-        '-DG_LOG_DOMAIN="GrlDmap"',
+-        '-DHAVE_CONFIG_H',
+-    ])
++    c_args: args)
+ 
+ shared_library('grldpap',
+     sources: dpap_sources,
+     install: true,
+     install_dir: pluginsdir,
+     dependencies: must_deps + plugins[dmap_idx][REQ_DEPS] + plugins[dmap_idx][OPT_DEPS],
+-    c_args: [
+-        '-DG_LOG_DOMAIN="GrlDmap"',
+-        '-DHAVE_CONFIG_H',
+-    ])
++    c_args: args)


### PR DESCRIPTION
grilo-plugins: backport patches from grilo-plugins master to support libdmapshare's 4.0 API

Signed-off-by: W. Michael Petullo <mike@flyn.org>

Maintainer: me
Compile tested: x86_64, master

Description:
