### PR TITLE
squid: fix 'localhet' typo in squid.conf

### DIFF
--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
 PKG_VERSION:=4.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www3.us.squid-cache.org/Versions/v4/ \

--- a/net/squid/files/squid.conf
+++ b/net/squid/files/squid.conf
@@ -8,7 +8,7 @@
 acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
 acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
 acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
-acl localhet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
 acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
 acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
 acl localnet src fc00::/7       	# RFC 4193 local private network range


### PR DESCRIPTION
Signed-off-by: Jonathan Elchison <JElchison@Gmail.com>

Maintainer: @ratkaj 
Compile tested: N/A (`squid.conf` is a text configuration file)
Run tested: mips, TP-LINK Archer C7 AC1750, OpenWrt v19.07.1

Description:
Fixed typo `s/localhet/localnet/` in squid.conf.  Present since https://github.com/openwrt/packages/commit/90f4b935bde21432b5763a5b03e356a9cdc124ee in 2018.  You can follow the slow proliferation around the web using this Google search:  https://www.google.com/search?q=squid+%22localhet%22