### PR TITLE
[openwrt-19.07] libuv: update to 1.34.2

### DIFF
--- a/libs/libuv/Makefile
+++ b/libs/libuv/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libuv
-PKG_VERSION:=1.32.0
+PKG_VERSION:=1.34.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://dist.libuv.org/dist/v$(PKG_VERSION)/
-PKG_HASH:=203927683d53d1b82eee766c8ffecfa8ed0e392679c15d5ad3a23504eda0ed1f
+PKG_HASH:=65d93b4504ef5f3ec784c0c186f4ba8abd1031292c7f15dda8111d7e319adf46
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr>


### PR DESCRIPTION
Maintainer: @ratkaj 
Compile tested: openwrt-19.07 r10951-1713707, mipsel 
Run tested: mipsel (qemu)

Description:
update to 1.34.2
node, luv, libwebsockets, ttyd, netdata will build successfully.

https://github.com/openwrt/packages/pull/11320#issuecomment-594032207

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
