### PR TITLE
tdb: bump to 1.4.3

### DIFF
--- a/libs/tdb/Makefile
+++ b/libs/tdb/Makefile
@@ -8,14 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tdb
-PKG_VERSION:=1.3.16
-PKG_RELEASE:=2
+PKG_VERSION:=1.4.3
+PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.samba.org/ftp/tdb/
-PKG_HASH:=6a3fc2616567f23993984ada3cea97d953a27669ffd1bfbbe961f26e0cf96cc5
+PKG_HASH:=c8058393dfa15f47e11ebd2f1d132693f0b3b3b8bf22d0201bfb305026f88a1b
 
+PKG_BUILD_DEPENDS:=python3/host
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -29,7 +30,6 @@ define Package/tdb
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Trivial Database
-  DEPNEDS:=+libattr
   URL:=http://sourceforge.net/projects/tdb/
   MAINTAINER:=Dmitry V. Zimin <pfzim@mail.ru>
 endef
@@ -48,12 +48,9 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
 endef
 
-CONFIGURE_ARGS = \
-	--target=$(GNU_TARGET_NAME) \
-	--build=$(GNU_HOST_NAME) \
+CONFIGURE_ARGS:= \
 	--cross-compile \
 	--cross-answers="$(PKG_BUILD_DIR)/cache.txt" \
-	--program-prefix="" \
 	--prefix=$(CONFIGURE_PREFIX) \
 	--exec-prefix=$(CONFIGURE_PREFIX) \
 	--bindir=$(CONFIGURE_PREFIX)/bin \
@@ -64,9 +61,6 @@ CONFIGURE_ARGS = \
 	--localstatedir=/var \
 	--mandir=$(CONFIGURE_PREFIX)/man \
 	--infodir=$(CONFIGURE_PREFIX)/info \
-	$(DISABLE_IPV6)
-
-CONFIGURE_ARGS += \
 	--disable-python \
 	--disable-rpath \
 	--disable-rpath-install \

--- a/libs/tdb/patches/100-Remove_libbsd_dependency_check.patch
+++ b/libs/tdb/patches/100-Remove_libbsd_dependency_check.patch
@@ -1,13 +1,16 @@
-diff --git a/lib/replace/wscript b/lib/replace/wscript
-index fd00a42..337d559 100644
 --- a/lib/replace/wscript
 +++ b/lib/replace/wscript
-@@ -340,22 +340,13 @@ def configure(conf):
+@@ -416,22 +416,13 @@
  
      conf.CHECK_FUNCS('prctl dirname basename')
  
 -    strlcpy_in_bsd = False
--
++    # Not checking for libbsd
++    conf.CHECK_FUNCS('strlcpy strlcat')
++    conf.CHECK_FUNCS('getpeereid')
++    conf.CHECK_FUNCS_IN('setproctitle', 'setproctitle', headers='setproctitle.h')
++    conf.CHECK_FUNCS('setproctitle_init')
+ 
 -    # libbsd on some platforms provides strlcpy and strlcat
 -    if not conf.CHECK_FUNCS('strlcpy strlcat'):
 -        if conf.CHECK_FUNCS_IN('strlcpy strlcat', 'bsd', headers='bsd/string.h',
@@ -22,17 +25,11 @@ index fd00a42..337d559 100644
 -
 -    if not conf.CHECK_FUNCS('closefrom'):
 -        conf.CHECK_FUNCS_IN('closefrom', 'bsd', headers='bsd/unistd.h')
-+    # Not checking for libbsd
-+    conf.CHECK_FUNCS('strlcpy strlcat')
-+    conf.CHECK_FUNCS('getpeereid')
-+    conf.CHECK_FUNCS_IN('setproctitle', 'setproctitle', headers='setproctitle.h')
-+    conf.CHECK_FUNCS('setproctitle_init')
-+
 +    conf.CHECK_FUNCS('closefrom')
  
      conf.CHECK_CODE('''
                  struct ucred cred;
-@@ -698,9 +689,6 @@ def configure(conf):
+@@ -808,9 +799,6 @@
  
      # look for a method of finding the list of network interfaces
      for method in ['HAVE_IFACE_GETIFADDRS', 'HAVE_IFACE_AIX', 'HAVE_IFACE_IFCONF', 'HAVE_IFACE_IFREQ']:
@@ -42,8 +39,8 @@ index fd00a42..337d559 100644
          if conf.CHECK_CODE('''
                             #define %s 1
                             #define NO_CONFIG_H 1
-@@ -713,7 +701,7 @@ def configure(conf):
-                            #include "test/getifaddrs.c"
+@@ -823,7 +811,7 @@
+                            #include "tests/getifaddrs.c"
                             ''' % method,
                             method,
 -                           lib='nsl socket' + bsd_for_strlcpy,
@@ -51,11 +48,11 @@ index fd00a42..337d559 100644
                             addmain=False,
                             execute=True):
              break
-@@ -761,7 +749,6 @@ def build(bld):
+@@ -871,7 +859,6 @@
                  break
  
      extra_libs = ''
 -    if bld.CONFIG_SET('HAVE_LIBBSD'): extra_libs += ' bsd'
+     if bld.CONFIG_SET('HAVE_LIBRT'): extra_libs += ' rt'
+     if bld.CONFIG_SET('REPLACE_REQUIRES_LIBSOCKET_LIBNSL'): extra_libs += ' socket nsl'
  
-     bld.SAMBA_SUBSYSTEM('LIBREPLACE_HOSTCC',
-         REPLACE_HOSTCC_SOURCE,


### PR DESCRIPTION
Maintainer: @pfzim, @cotequeiroz, @neheb.
Compile tested: Clean Debian 10 host, Entware repo.
Run tested: Entware, mipsel feed

Description: version bumb prior to Python3 transition, continue of https://github.com/openwrt/packages/pull/11495
