### PR TITLE
Update python_init_once.patch

### DIFF
--- a/libs/newt/patches/python_init_once.patch
+++ b/libs/newt/patches/python_init_once.patch
@@ -14,7 +14,7 @@ Last-Updated: 2014-06-11
      suspend.cb = NULL;
      suspend.data = NULL;
      
-     newtInit();
+
 +    if (init_newt) { 
 +	newtInit();
 +	init_newt = 0;


### PR DESCRIPTION
Remove the initial call to newtInit, since we need to check to see if it was called.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
