### PR TITLE
postgresql: fix pkg-config file

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
 PKG_VERSION:=12.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
 PKG_CPE_ID:=cpe:/a:postgresql:postgresql

--- a/libs/postgresql/patches/001-configure_fixes.patch
+++ b/libs/postgresql/patches/001-configure_fixes.patch
@@ -1,8 +1,6 @@
-diff --git a/configure.in b/configure.in
-index 9082c5b..2c04edc 100644
 --- a/configure.in
 +++ b/configure.in
-@@ -2283,36 +2283,6 @@ if test "$with_python" = yes; then
+@@ -2285,36 +2285,6 @@ if test "$with_python" = yes; then
    CPPFLAGS=$ac_save_CPPFLAGS
  fi
  

--- a/libs/postgresql/patches/200-ranlib.patch
+++ b/libs/postgresql/patches/200-ranlib.patch
@@ -1,10 +1,10 @@
 --- a/src/port/Makefile
 +++ b/src/port/Makefile
-@@ -53,6 +53,7 @@ uninstall:
+@@ -63,6 +63,7 @@ uninstall:
  libpgport.a: $(OBJS)
  	rm -f $@
  	$(AR) $(AROPT) $@ $^
 +	$(RANLIB) libpgport.a
  
- # thread.o needs PTHREAD_CFLAGS (but thread_srv.o does not)
+ # thread.o and thread_shlib.o need PTHREAD_CFLAGS (but thread_srv.o does not)
  thread.o: CFLAGS+=$(PTHREAD_CFLAGS)

--- a/libs/postgresql/patches/300-fix-pc-file.patch
+++ b/libs/postgresql/patches/300-fix-pc-file.patch
@@ -1,0 +1,33 @@
+--- a/src/Makefile.shlib
++++ b/src/Makefile.shlib
+@@ -396,14 +396,27 @@ endif # PORTNAME == cygwin || PORTNAME =
+ 
+ 
+ %.pc: $(MAKEFILE_LIST)
+-	echo 'Name: lib$(NAME)' >$@
++	echo 'prefix=$(prefix)' >$@
++	echo 'exec_prefix=$(exec_prefix)' >>$@
++ifeq ($(patsubst $(prefix)/%,,$(includedir)),)
++	echo 'includedir=$${prefix}/$(patsubst $(prefix)/%,%,$(includedir))' >>$@
++else
++	echo 'includedir=$(includedir)' >>$@
++endif
++ifeq ($(patsubst $(exec_prefix)/%,,$(libdir)),)
++	echo 'libdir=$${exec_prefix}/$(patsubst $(exec_prefix)/%,%,$(libdir))' >>$@
++else
++	echo 'libdir=$(libdir)' >>$@
++endif
++	echo >>$@
++	echo 'Name: lib$(NAME)' >>$@
+ 	echo 'Description: PostgreSQL lib$(NAME) library' >>$@
+ 	echo 'Url: http://www.postgresql.org/' >>$@
+ 	echo 'Version: $(VERSION)' >>$@
+ 	echo 'Requires: ' >>$@
+ 	echo 'Requires.private: $(PKG_CONFIG_REQUIRES_PRIVATE)' >>$@
+-	echo 'Cflags: -I$(includedir)' >>$@
+-	echo 'Libs: -L$(libdir) -l$(NAME)' >>$@
++	echo 'Cflags: -I$${includedir}' >>$@
++	echo 'Libs: -L$${libdir} -l$(NAME)' >>$@
+ # Record -L flags that the user might have passed in to the PostgreSQL
+ # build to locate third-party libraries (e.g., ldap, ssl).  Filter out
+ # those that point inside the build or source tree.  Use sort to

--- a/libs/postgresql/patches/900-pg_ctl-setuid.patch
+++ b/libs/postgresql/patches/900-pg_ctl-setuid.patch
@@ -1,14 +1,14 @@
 --- a/src/bin/pg_ctl/pg_ctl.c
 +++ b/src/bin/pg_ctl/pg_ctl.c
-@@ -88,6 +88,7 @@ static char *event_source = NULL;
- static char *register_servicename = "PostgreSQL";		/* FIXME: + version ID? */
+@@ -93,6 +93,7 @@ static char *event_source = NULL;
+ static char *register_servicename = "PostgreSQL";	/* FIXME: + version ID? */
  static char *register_username = NULL;
  static char *register_password = NULL;
 +static char *username = "";
  static char *argv0 = NULL;
  static bool allow_core_files = false;
  static time_t start_time;
-@@ -1930,6 +1931,9 @@ do_help(void)
+@@ -2047,6 +2048,9 @@ do_help(void)
  #endif
  	printf(_("  -s, --silent           only print errors, no informational messages\n"));
  	printf(_("  -t, --timeout=SECS     seconds to wait when using -w option\n"));
@@ -16,17 +16,17 @@
 +	printf(_("  -U, --username=NAME    user name of account PostgreSQL server is running as\n"));
 +#endif
  	printf(_("  -V, --version          output version information, then exit\n"));
- 	printf(_("  -w                     wait until operation completes\n"));
- 	printf(_("  -W                     do not wait until operation completes\n"));
-@@ -2126,6 +2130,7 @@ main(int argc, char **argv)
- 		{"pgdata", required_argument, NULL, 'D'},
+ 	printf(_("  -w, --wait             wait until operation completes (default)\n"));
+ 	printf(_("  -W, --no-wait          do not wait until operation completes\n"));
+@@ -2259,6 +2263,7 @@ main(int argc, char **argv)
+ 		{"options", required_argument, NULL, 'o'},
  		{"silent", no_argument, NULL, 's'},
  		{"timeout", required_argument, NULL, 't'},
 +		{"username", required_argument, NULL, 'U'},
  		{"core-files", no_argument, NULL, 'c'},
- 		{NULL, 0, NULL, 0}
- 	};
-@@ -2166,20 +2171,6 @@ main(int argc, char **argv)
+ 		{"wait", no_argument, NULL, 'w'},
+ 		{"no-wait", no_argument, NULL, 'W'},
+@@ -2299,20 +2304,6 @@ main(int argc, char **argv)
  		}
  	}
  
@@ -47,7 +47,7 @@
  
  	env_wait = getenv("PGCTLTIMEOUT");
  	if (env_wait != NULL)
-@@ -2265,11 +2256,15 @@ main(int argc, char **argv)
+@@ -2399,11 +2390,15 @@ main(int argc, char **argv)
  					wait_seconds_arg = true;
  					break;
  				case 'U':
@@ -63,7 +63,7 @@
  					break;
  				case 'w':
  					do_wait = true;
-@@ -2351,6 +2346,41 @@ main(int argc, char **argv)
+@@ -2485,6 +2480,41 @@ main(int argc, char **argv)
  		exit(1);
  	}
  


### PR DESCRIPTION
Currently the pc file has includedir hard coded to "/usr/include" and
libdir to "/usr/lib". This commit changes this so they can be controlled
via the "prefix" variable.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @dangowrt 
Compile tested: ath79 master
Run tested: N/A, no run-time change

Description:
Hi all,

This fixes the pkg-config file. I think this is currently causing some build failures on the bots (freeswitch, gnunet, kamailio, probably more). I think with the previous pkg-config package in OpenWrt this wasn't an issue (didn't lead to build failures), but with the current one it seems to be. Didn't check into the new pkg-config, though, so I might be wrong. But the postgresql pc file should be fixed anyway.

Refreshed the other patches while doing this.

Kind regards,
Seb