### PR TITLE
cryptsetup: update to 2.3.0

### DIFF
--- a/utils/cryptsetup/Makefile
+++ b/utils/cryptsetup/Makefile
@@ -8,16 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cryptsetup
-PKG_VERSION:=2.2.2
+PKG_VERSION:=2.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@KERNEL/linux/utils/cryptsetup/v2.2
-PKG_HASH:=2af0ec9551ab9c870074cae9d3f68d82cab004f4095fa89db0e4413713424a46
+PKG_SOURCE_URL:=@KERNEL/linux/utils/cryptsetup/v2.3
+PKG_HASH:=395690de99509428354d3cd15cf023bed01487e6f1565b2181e013dc847bbc85
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=GPL-2.0-or-later LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING COPYING.LGPL
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -42,13 +45,14 @@ CONFIGURE_ARGS += \
 	--disable-veritysetup \
 	--disable-udev \
 	--with-default-luks-format=LUKS2 \
+	--with-luks2-lock-path=/var/run/cryptsetup \
 	--with-crypto_backend=kernel
 
 define Package/cryptsetup/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(CP) $(PKG_BUILD_DIR)/.libs/cryptsetup $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/cryptsetup $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_BUILD_DIR)/.libs/libcryptsetup.so* $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcryptsetup.so* $(1)/usr/lib
 endef
 
 $(eval $(call BuildPackage,cryptsetup))


### PR DESCRIPTION
Use PKG_INSTALL for consistency between packages.

Add PKG_BUILD_PARALLEL for faster compilation.

Fix wrong locking path. First discovered here:
https://forum.openwrt.org/t/cannot-setup-dm-crypt/56836

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: ath79