### PR TITLE
keepalived: fix building with disable libipvs dynamic

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.0.20
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/patches/0001-Fix-building-with-disable-libipvs-dynamic.patch
+++ b/net/keepalived/patches/0001-Fix-building-with-disable-libipvs-dynamic.patch
@@ -1,0 +1,53 @@
+From 42c020aab6e51d09f22a2e4a33ce6fd73009e2dc Mon Sep 17 00:00:00 2001
+From: Quentin Armitage <quentin@armitage.org.uk>
+Date: Wed, 4 Mar 2020 12:21:43 +0000
+Subject: [PATCH] Fix building with --disable-libipvs-dynamic
+
+Issue #1516 reported by the OpenWRT project identified that
+keepalived_modprobe() was not defined if --disable-libipvs-dynamic
+was specified.
+
+Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>
+---
+ lib/utils.c | 4 ++--
+ lib/utils.h | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/lib/utils.c b/lib/utils.c
+index 009da0ce..7f16f444 100644
+--- a/lib/utils.c
++++ b/lib/utils.c
+@@ -34,7 +34,7 @@
+ #include <stdint.h>
+ #include <errno.h>
+ #include <sys/prctl.h>
+-#if defined _WITH_LVS_ || defined _LIBIPSET_DYNAMIC_
++#if defined _WITH_LVS_ || defined _HAVE_LIBIPSET_
+ #include <sys/wait.h>
+ #endif
+ #ifdef _WITH_PERF_
+@@ -1097,7 +1097,7 @@ memcmp_constant_time(const void *s1, const void *s2, size_t n)
+  * Utility functions coming from Wensong code
+  */
+ 
+-#if defined _WITH_LVS_ || defined _LIBIPSET_DYNAMIC_
++#if defined _WITH_LVS_ || defined _HAVE_LIBIPSET_
+ static char*
+ get_modprobe(void)
+ {
+diff --git a/lib/utils.h b/lib/utils.h
+index 66d64d9f..22325023 100644
+--- a/lib/utils.h
++++ b/lib/utils.h
+@@ -263,7 +263,7 @@ extern int open_pipe(int [2]);
+ #endif
+ extern int memcmp_constant_time(const void *, const void *, size_t);
+ 
+-#if defined _WITH_LVS_ || defined _LIBIPSET_DYNAMIC_
++#if defined _WITH_LVS_ || defined _HAVE_LIBIPSET_
+ extern bool keepalived_modprobe(const char *);
+ #endif
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, APU3, OpenWrt master
Run tested: no

Description:
This pr should fix build issue #10642. Change was backported from staging commit 
https://github.com/pqarmitage/keepalived/commit/42c020aab6e51