### PR TITLE
knot: update to version 2.9.3

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
-PKG_VERSION:=2.9.2
+PKG_VERSION:=2.9.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
-PKG_HASH:=298cdf33aa7589b50df7e5833694b24cd2de8b6d17cee7e1673873fe576db6ee
+PKG_HASH:=f2adf137d70955a4a20df90c5409e10be8e1127204a98b27d626ac090531a07e
 
 PKG_MAINTAINER:=Daniel Salzman <daniel.salzman@nic.cz>
 PKG_LICENSE:=GPL-3.0 LGPL-2.0 0BSD BSD-3-Clause OLDAP-2.8


### PR DESCRIPTION
Signed-off-by: Jan Hak jan.hak@nic.cz

Maintainer: Daniel Salzman / @salzmdan
Compile tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.0-dev
Run tested: ARM Cortex-A9 vfpv3, Turris Omnia, TurrisOS 5.0-dev, all tests successful (1 skipped)