### PR TITLE
btrfs-progs: fix check for btrfs in btrfs scan

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
 PKG_VERSION:=5.4.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs

--- a/utils/btrfs-progs/files/btrfs-scan.init
+++ b/utils/btrfs-progs/files/btrfs-scan.init
@@ -1,7 +1,9 @@
 #!/bin/sh
 
 preinit_btrfs_scan() {
-	grep -vq btrfs /proc/filesystems || btrfs device scan
+	if grep -q btrfs /proc/filesystems; then
+		 btrfs device scan
+	fi
 }
 
 boot_hook_add preinit_main preinit_btrfs_scan


### PR DESCRIPTION

Maintainer: me
Compile tested: just script update
Run tested: Turris Omnia 19.07 (just  minimal change so no big testing)

Description:
The previous implementation always succeeded so no scan was performed.
This now fixes that and it correctly scans for BTRFS  devices if BTRFS
support is in kernel.
