### PR TITLE
softethervpn: disable PIC

### DIFF
--- a/net/softethervpn/Makefile
+++ b/net/softethervpn/Makefile
@@ -12,21 +12,22 @@ PKG_NAME:=softethervpn
 PKG_VERSION:=4.29-9680
 PKG_VERREL:=rtm
 PKG_VERDATE:=2019.02.28
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=softether-src-v$(PKG_VERSION)-$(PKG_VERREL).tar.gz
 PKG_SOURCE_URL:=http://www.softether-download.com/files/softether/v$(PKG_VERSION)-$(PKG_VERREL)-$(PKG_VERDATE)-tree/Source_Code/
 PKG_HASH:=e6035fa7d9aaf59bdb342cd7ab5ecfdff89811a875f62a3230208cdc8a4e26e4
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/v$(PKG_VERSION)
-HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)/v$(PKG_VERSION)
-
-PKG_LICENSE:=GPL-2.0
+PKG_MAINTAINER:=Federico Di Marco <fededim@gmail.com>
+PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/v$(PKG_VERSION)
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)/v$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=softethervpn/host
 HOST_BUILD_DEPENDS:=readline/host libiconv/host
 
+PKG_ASLR_PIE:=0
 HAMCORE_SE2:=$(STAGING_DIR_HOST)/share/softethervpn/hamcore.se2
 
 include $(INCLUDE_DIR)/nls.mk
@@ -89,7 +90,6 @@ define Package/softethervpn/default
   SUBMENU:=VPN
   TITLE:=Free Cross-platform Multi-protocol VPN server and client
   URL:=http://www.softether.org/
-  MAINTAINER:=Federico Di Marco <fededim@gmail.com>
 endef
 
 define Package/softethervpn/description


### PR DESCRIPTION
Compilation is broken on AArch64.

Reordered some things for consistency between packages.

Fixed license information.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @fededim 

Fixes: https://github.com/openwrt/packages/issues/11153