### PR TITLE
strongswan: fix local_identifier when not set and add mark option

### DIFF
--- a/net/strongswan/files/ipsec.init
+++ b/net/strongswan/files/ipsec.init
@@ -135,6 +135,7 @@ config_conn() {
 	local ikelifetime
 	local lifetime
 	local margintime
+	local mark
 	local keyingtries
 	local dpdaction
 	local dpddelay
@@ -155,6 +156,7 @@ config_conn() {
 	config_get ikelifetime              "$1"           ikelifetime "3h"
 	config_get lifetime                 "$1"           lifetime "1h"
 	config_get margintime               "$1"           margintime "9m"
+	config_get mark                     "$1"           mark ""
 	config_get keyingtries              "$1"           keyingtries "3"
 	config_get dpdaction                "$1"           dpdaction "none"
 	config_get dpddelay                 "$1"           dpddelay "30s"
@@ -173,6 +175,8 @@ config_conn() {
 
 	[ -n "$local_firewall" ] && ipsec_xappend "  leftfirewall=$local_firewall"
 	[ -n "$remote_firewall" ] && ipsec_xappend "  rightfirewall=$remote_firewall"
+
+	[ -n "$mark" ] && ipsec_xappend "  mark=$mark"
 
 	ipsec_xappend "  ikelifetime=$ikelifetime"
 	ipsec_xappend "  lifetime=$lifetime"

--- a/net/strongswan/files/ipsec.init
+++ b/net/strongswan/files/ipsec.init
@@ -244,7 +244,7 @@ config_remote() {
 		local ipdest
 
 		[ "$remote_gateway" = "%any" ] && ipdest="1.1.1.1" || ipdest="$remote_gateway"
-		local_gateway=`ip route get $ipdest | awk -F"src" '/src/{gsub(/ /,"");print $2}'`
+		local_gateway="$(ip -j route get "$ipdest" | jsonfilter -e '@[0].gateway')"
 	}
 
 	[ -n "$local_identifier" ] && secret_xappend -n "$local_identifier " || secret_xappend -n "$local_gateway "


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: master
Run tested: x86/64 (but on 19.07.2)

Description:
The first patch fixes a bug when local_identifier is not set. 
Since 19.07, 'ip route get' has an 'uid 0' after the src address.
This was appended to local ip address as in '192.168.1.1uid0'

The second one allows 'mark=nnn' to be defined
Sets an XFRM mark on the inbound policy and outbound IPsec SA and policy.
This is useful for VTI interfaces and other special policies.

I noticed that /etc/init.d/ipsec adds "include /var/ipsec/..." to these files:
* /etc/ipsec.conf
* /etc/ipsec.secrets
* /etc/strongswan.conf

Wouldn't it be better to have those include already in package files instead of including them from /etc/init.d/ipsec? It would avoid touching a file that generates a conflict (-opkg) on update. Also, it would allow a user to simply remove the include if needed.

And https://openwrt.org/docs/guide-user/services/vpn/ipsec/strongswan/basic does need an update.