### PR TITLE
sed: disable acl

### DIFF
--- a/utils/sed/Makefile
+++ b/utils/sed/Makefile
@@ -46,6 +46,8 @@ define Package/sed/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin
 endef
 
+CONFIGURE_ARGS+= --disable-acl
+
 define Package/sed/postinst
 #!/bin/sh
 [ -L "$${IPKG_INSTROOT}/bin/sed" ] && rm -f "$${IPKG_INSTROOT}/bin/sed"


### PR DESCRIPTION
If libacl is built, gnu sed finds it during configuration and enables support
linking in libacl. This results in build failures due to the missing dependency.
Consequently, use CONFIGURE_ARGS to disable acl support.

Reported-by: Rosen Penev <rosenp@gmail.com>
Signed-off-by: Russell Senior <russell@personaltelco.net>

Maintainer: me / @RussellSenior
Compile tested: arch: ath79; model: Buffalo WZR-HP-AG300H/WZR-600DHP, OpenWrt version: reboot-12498-g2a18840cc7

