### PR TITLE
libs: libzdb: bump to version 3.2.1

### DIFF
--- a/libs/libzdb/Makefile
+++ b/libs/libzdb/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libzdb
-PKG_VERSION:=3.2
+PKG_VERSION:=3.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.tildeslash.com/libzdb/dist/
-PKG_HASH:=005ddf4b29c6db622e16303298c2f914dfd82590111cea7cfd09b4acf46cf4f2
+PKG_HASH:=b9a7b59a0a9f53dc87ce1b5a919f21b8cd6448c04a9157bccef1e3c1dffd3ff1
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -22,6 +22,7 @@ PKG_LICENSE_FILES:=COPYING
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=libzdb/host
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk

--- a/libs/libzdb/patches/010-do-not-run-test-progs.patch
+++ b/libs/libzdb/patches/010-do-not-run-test-progs.patch
@@ -1,0 +1,19 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -454,16 +454,6 @@ if test $ondarwin -eq 1; then
+ else
+     stdc="gnu"
+ fi
+-AC_RUN_IFELSE(
+-[AC_LANG_PROGRAM([], [dnl
+-        #ifdef __STDC_VERSION__
+-        #if __STDC_VERSION__ >= 201112L
+-        return 0;
+-        #endif
+-        #endif
+-        return 1;
+-        ])], [CFLAGS="$CFLAGS -std=${stdc}11"], [CFLAGS="$CFLAGS -std=${stdc}99"])
+-AC_CHECK_HEADERS([stdint.h stdbool.h], [], [AC_MSG_ERROR([toolchain does not have C99 headers])])
+ 
+ # ---------------------------------------------------------------------------
+ # Outputs

--- a/libs/libzdb/patches/010-missing-header.patch
+++ b/libs/libzdb/patches/010-missing-header.patch
@@ -1,7 +1,0 @@
---- a/test/zdbpp.cpp
-+++ b/test/zdbpp.cpp
-@@ -1,3 +1,4 @@
-+#include <cassert>
- #include <iostream>
- #include <string>
- #include <map>

--- a/libs/libzdb/patches/020-filterh-use-host-built-version.patch
+++ b/libs/libzdb/patches/020-filterh-use-host-built-version.patch
@@ -1,11 +1,11 @@
---- a/Makefile.in
-+++ b/Makefile.in
-@@ -476,7 +476,7 @@ DIST_SUBDIRS = . test
- EXTRA_DIST = README AUTHORS CHANGES COPYING bootstrap doc test src tools config
- LIBRARY_NAME = zdb
- RE2CFLAGS = -b
--FILTERH = ./tools/bin/filterh
-+FILTERH = $(STAGING_DIR_HOSTPKG)/bin/filterh
- AM_CPPFLAGS = $(CPPFLAGS) $(DBCPPFLAGS) -Isrc -Isrc/util -Isrc/net \
- 	-Isrc/db -Isrc/db/oracle -Isrc/exceptions
- pkgconfigdir = $(libdir)/pkgconfig
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -12,7 +12,7 @@ LIBRARY_NAME    = zdb
+ 
+ RE2C		= @RE2C@
+ RE2CFLAGS       = -b
+-FILTERH         = ./tools/bin/filterh
++FILTERH         = $(STAGING_DIR_HOSTPKG)/bin/filterh
+ 
+ AM_CPPFLAGS     = $(CPPFLAGS) $(DBCPPFLAGS)
+ AM_CPPFLAGS     += -Isrc -Isrc/util -Isrc/net -Isrc/db -Isrc/db/oracle -Isrc/exceptions


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/openwrt/openwrt/commit/04a87fedda522895766d7de6f3aeb03c6b3dc3b4  x86
Run tested: https://github.com/openwrt/openwrt/commit/04a87fedda522895766d7de6f3aeb03c6b3dc3b4  x86

--------------------------------------------------------

Patches require a bit of rework:
- dropped 010-missing-header.patch
- add 010-do-not-run-test-progs.patch
- re-updated 020-filterh-use-host-built-version.patch
  - Makefile.in gets regenerated from PKG_FIXUP:=autoreconf
- added PKG_FIXUP:=autoreconf ; it's easier to patch automake stuff that
  big configure scripts

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>