### PR TITLE
faad2: update to 2.9.1

### DIFF
--- a/libs/faad2/Makefile
+++ b/libs/faad2/Makefile
@@ -6,17 +6,22 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=faad2
-PKG_VERSION:=2.8.8
-PKG_RELEASE:=2
+PKG_VERSION:=2.9.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/faac/faad2-src/$(PKG_NAME)-2.8.0
-PKG_HASH:=985c3fadb9789d2815e50f4ff714511c79c2710ac27a4aaaf5c0c2662141426d
+PKG_SOURCE_URL:=https://codeload.github.com/knik0/faad2/tar.gz/2_9_1?
+PKG_HASH:=7fa33cff76abdda5a220ca5de0b2e05a77354f3b97f735193c2940224898aa9a
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-2_9_1
+
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
-PKG_CPE_ID:=cpe:/a:audiocoding:faad2
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:audiocoding:freeware_advanced_audio_decoder_2
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -57,13 +62,14 @@ $(call Package/faad2/Default/description)
   This package contains the library.
 endef
 
-TARGET_CFLAGS += $(FPIC)
-CONFIGURE_ARGS+= --without-xmms
+TARGET_CFLAGS += \
+	$(if $(CONFIG_BUILD_PATENTED),,-DLC_ONLY_DECODER) \
+	$(if $(CONFIG_SOFT_FLOAT),-DFIXED_POINT)
 
-ifeq ($(CONFIG_SOFT_FLOAT),y)
-	TARGET_CFLAGS+= -DFIXED_POINT
-	CONFIGURE_ARGS+= -nfp
-endif
+CONFIGURE_ARGS += \
+	--without-drm \
+	--without-mpeg4ip \
+	--without-xmms
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include

--- a/libs/faad2/patches/010-lc-decoder.patch
+++ b/libs/faad2/patches/010-lc-decoder.patch
@@ -1,0 +1,48 @@
+From 8552fd53aaf5059ed769a0564330816beacaca98 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 10 Mar 2020 17:38:29 -0700
+Subject: [PATCH] fix compilation with LC_ONLY_DECODER
+
+881b5e263f25a8a8b714e83407fc2c9dab407e40 broke compilation by always
+defining DRN and DRM_PS. Fix this and place the define where it belongs.
+---
+ libfaad/Makefile.am | 2 +-
+ libfaad/common.h    | 7 +++++--
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/libfaad/Makefile.am b/libfaad/Makefile.am
+index 8ed57ae..7d9c71f 100644
+--- a/libfaad/Makefile.am
++++ b/libfaad/Makefile.am
+@@ -32,5 +32,5 @@ libfaad_la_SOURCES = bits.c cfft.c decoder.c drc.c \
+ 
+ libfaad_drm_la_LDFLAGS = ${libfaad_la_LDFLAGS}
+ libfaad_drm_la_LIBADD = ${libfaad_la_LIBADD}
+-libfaad_drm_la_CFLAGS = ${libfaad_la_CFLAGS} -DDRM -DDRM_PS
++libfaad_drm_la_CFLAGS = ${libfaad_la_CFLAGS} -DDRM_SUPPORT
+ libfaad_drm_la_SOURCES = ${libfaad_la_SOURCES}
+diff --git a/libfaad/common.h b/libfaad/common.h
+index 8b78807..76722e4 100644
+--- a/libfaad/common.h
++++ b/libfaad/common.h
+@@ -91,8 +91,10 @@ extern "C" {
+ /* Allow decoding of LD profile AAC */
+ #define LD_DEC
+ /* Allow decoding of Digital Radio Mondiale (DRM) */
+-//#define DRM
+-//#define DRM_PS
++#ifdef DRM_SUPPORT
++#define DRM
++#define DRM_PS
++#endif
+ 
+ /* LD can't do without LTP */
+ #ifdef LD_DEC
+@@ -115,6 +117,7 @@ extern "C" {
+   #undef MAIN_DEC
+   #undef SSR_DEC
+   #undef DRM
++  #undef DRM_PS
+   #undef ALLOW_SMALL_FRAMELENGTH
+   #undef ERROR_RESILIENCE
+ #endif

--- a/libs/faad2/patches/020-bits.patch
+++ b/libs/faad2/patches/020-bits.patch
@@ -1,0 +1,35 @@
+From 4ae9873a80ea47858d20f1d590aaf816c3aebb20 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 10 Mar 2020 20:13:57 -0700
+Subject: [PATCH] fix compilation without SBR/PS_DEC
+
+The bits.h include needs to be in mp4.h as it uses the bitfield struct.
+---
+ libfaad/mp4.c | 1 -
+ libfaad/mp4.h | 1 +
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libfaad/mp4.c b/libfaad/mp4.c
+index 9f0198a..dbcff83 100644
+--- a/libfaad/mp4.c
++++ b/libfaad/mp4.c
+@@ -33,7 +33,6 @@
+ 
+ #include <stdlib.h>
+ 
+-#include "bits.h"
+ #include "mp4.h"
+ #include "syntax.h"
+ 
+diff --git a/libfaad/mp4.h b/libfaad/mp4.h
+index 5a94be4..d99a3e3 100644
+--- a/libfaad/mp4.h
++++ b/libfaad/mp4.h
+@@ -35,6 +35,7 @@
+ extern "C" {
+ #endif
+ 
++#include "bits.h"
+ #include "neaacdec.h"
+ 
+ int8_t AudioSpecificConfig2(uint8_t *pBuffer,

--- a/libs/faad2/patches/030-sbr-ps-dec.patch
+++ b/libs/faad2/patches/030-sbr-ps-dec.patch
@@ -1,0 +1,20 @@
+--- a/libfaad/common.h
++++ b/libfaad/common.h
+@@ -120,8 +120,7 @@ extern "C" {
+   #undef DRM_PS
+   #undef ALLOW_SMALL_FRAMELENGTH
+   #undef ERROR_RESILIENCE
+-#endif
+-
++#else
+ #define SBR_DEC
+ //#define SBR_LOW_POWER
+ #define PS_DEC
+@@ -129,6 +128,7 @@ extern "C" {
+ #ifdef SBR_LOW_POWER
+ #undef PS_DEC
+ #endif
++#endif
+ 
+ /* FIXED POINT: No MAIN decoding */
+ #ifdef FIXED_POINT


### PR DESCRIPTION
It seems upstream abandoned sourceforge.

Add license information.

Fix CVE tag. It seems the mass CVE patch placed many wrong CVEs.

Add PKG_BUILD_PARALLEL for faster compilation.

Do not build patented functionality when BUILD_PATENTED is missing.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ath79