### PR TITLE
django: bump to version 1.11.29

### DIFF
--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
-PKG_VERSION:=1.11.27
+PKG_VERSION:=1.11.29
 PKG_RELEASE:=1
 
 PKG_SOURCE:=Django-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/D/Django
-PKG_HASH:=20111383869ad1b11400c94b0c19d4ab12975316cd058eabd17452e0546169b8
+PKG_HASH:=4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c
 PKG_BUILD_DIR=$(BUILD_DIR)/Django-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A
Run tested: N/A

-------------------------------------------------------

Includes several CVE fixes.
- CVE-2020-7471 in 1.11.28
- CVE-2020-9402 in 1.11.29

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>