### PR TITLE
haveged: move init script from 13 to 01

### DIFF
--- a/utils/haveged/Makefile
+++ b/utils/haveged/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haveged
 PKG_VERSION:=1.9.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/jirka-h/haveged/tar.gz/v$(PKG_VERSION)?

--- a/utils/haveged/files/haveged.init
+++ b/utils/haveged/files/haveged.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-START=13
+START=01
 USE_PROCD=1
 
 HAVEGED_THRESHOLD=1024


### PR DESCRIPTION
Maintainer: @hnyman 
Compile tested: Simple change so not compiling
Run tested: Turris Omnia (OpenWrt 19.07)

Description:
This is intended as a match with standard urngd. They serve the same purpose
and urngd starts as first with 00. Starting haveged later can create
issues if you replace urngd with it. The example problem is if
uci-defaults script decides to generate certificate. Haveged can supply
entropy but it is started later and to mitigate this urngd would still
have to be installed. This means that haveget can't serve as replacement
without moving it to match start order of urngd.
