### PR TITLE
mwan3: Ping IPv6 hosts using address not interface

### DIFF
--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -132,11 +132,14 @@ main() {
 			if [ $host_up_count -lt $reliability ]; then
 				case "$track_method" in
 					ping)
+                                                if echo $track_ip | grep -q ':'; then
+                                                        ADDR=$(ip -6 addr ls dev "$DEVICE" | sed -ne 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p')
+                                                fi
 						if [ $check_quality -eq 0 ]; then
-							ping -I $DEVICE -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null
+							ping -I ${ADDR:-$DEVICE} -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null
 							result=$?
 						else
-							ping_result="$(ping -I $DEVICE -c $count -W $timeout -s $size -t $max_ttl -q $track_ip | tail -2)"
+							ping_result="$(ping -I ${ADDR:-$DEVICE} -c $count -W $timeout -s $size -t $max_ttl -q $track_ip | tail -2)"
 							loss="$(echo "$ping_result" | grep "packet loss" |  cut -d "," -f3 | awk '{print $1}' | sed -e 's/%//')"
 							if [ "$loss" -eq 100 ]; then
 								latency=999999


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: N/A - not compiled code
Run tested: WNDR4300 on 19.7.02

Description:
Pinging IPv6 hosts using an interface as a source specifier seems
troublesome.

Use the desired source interface's IP address instead.

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>