### PR TITLE
perl-www-curl: curl 7.69.0 compatibility

### DIFF
--- a/lang/perl-www-curl/Makefile
+++ b/lang/perl-www-curl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-www-curl
 PKG_VERSION:=4.17
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_URL:=http://www.cpan.org/authors/id/S/SZ/SZBALINT/
 PKG_SOURCE:=WWW-Curl-$(PKG_VERSION).tar.gz

--- a/lang/perl-www-curl/patches/220-curl_7.69_compat.patch
+++ b/lang/perl-www-curl/patches/220-curl_7.69_compat.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.PL
++++ b/Makefile.PL
+@@ -127,7 +127,7 @@
+     close H;
+ 
+     for my $e (sort @syms) {
+-       if($e =~ /(OBSOLETE|^CURL_EXTERN|^CURL_STRICTER\z|_LAST\z|_LASTENTRY\z)/) {
++       if($e =~ /(OBSOLETE|^CURL_EXTERN|CURLOPT\z|^CURL_STRICTER\z|_LAST\z|_LASTENTRY\z|WIN32)/) {
+           next;
+        }
+        my ($group) = $e =~ m/^([^_]+_)/;


### PR DESCRIPTION
Maintainer: @Naoir, @jow-, @neheb.
Compile tested: Clean Debian 10 host, Entware repo.
Run tested: Entware, mipsel feed

Description: [fixes build](https://downloads.openwrt.org/snapshots/faillogs/aarch64_cortex-a53/packages/perl-www-curl/) with new curl, [taken](https://github.com/Entware/entware-packages/commit/ee62eafd1c344970d343d60bcbac1e2caf800b9c) from Entware. Similar to https://github.com/openwrt/packages/pull/10096.