### PR TITLE
libsoup: update to 2.70.0

### DIFF
--- a/libs/libsoup/Makefile
+++ b/libs/libsoup/Makefile
@@ -6,13 +6,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsoup
-PKG_VERSION:=2.68.2
-PKG_RELEASE:=2
+PKG_VERSION:=2.70.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@GNOME/$(PKG_NAME)/2.68
-PKG_HASH:=51ad3001a946fe3bcf29b692dc9ffe05cdf702ea6ca0ee8c3099a99a2f4e3933
+PKG_SOURCE_URL:=@GNOME/$(PKG_NAME)/2.70
+PKG_HASH:=54b020f74aefa438918d8e53cff62e2b1e59efe2de53e06b19a4b07b1f4d5342
 
+PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:gnome:libsoup
@@ -29,20 +30,20 @@ define Package/libsoup
   CATEGORY:=Libraries
   TITLE:=libsoup
   URL:=https://wiki.gnome.org/Projects/libsoup
-  MAINTAINER:=W. Michael Petullo <mike@flyn.org>
   DEPENDS:=+glib2 +libxml2 +libgnutls +libsqlite3 +libpsl $(ICONV_DEPENDS) $(INTL_DEPENDS)
 endef
 
 MESON_ARGS += \
-	-Dtests=false \
-	-Dinstalled_tests=false \
-	-Dgtk_doc=false \
-	-Dintrospection=disabled \
-	-Dtls_check=false \
-	-Dvapi=disabled \
-	-Dgnome=false \
 	-Dgssapi=disabled \
 	-Dntlm=disabled \
+	-Dbrotli=disabled \
+	-Dtls_check=false \
+	-Dgnome=false \
+	-Dintrospection=disabled \
+	-Dvapi=disabled \
+	-Dgtk_doc=false \
+	-Dtests=false \
+	-Dinstalled_tests=false
 
 define package/libsoup/decription
 Libsoup is an HTTP library implementation in C


### PR DESCRIPTION
Moved maintainer above for consistency between packages.

Reordered MESON_ARGS based on order of meson_options.txt.

Disabled Brotli.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @flyn-org 
Compile tested: ath79