### PR TITLE
grilo: update to 0.3.12

### DIFF
--- a/multimedia/grilo/Makefile
+++ b/multimedia/grilo/Makefile
@@ -6,21 +6,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grilo
-PKG_VERSION:=0.3.10
+PKG_VERSION:=0.3.12
 PKG_RELEASE:=1
-
-PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
-
-PKG_LICENSE:=LGPLv2.1
-PKG_LICENSE_FILES:=COPYING
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/grilo/0.3/
-PKG_HASH:=7e44b2e74c31ed24eb97e43265a9e41effe8660287b02295111805c7bda7f1e8
+PKG_HASH:=dbfbd6082103288592af97568180b9cc81a336a274ed5160412f87675ec11a71
 
-PKG_BUILD_PARALLEL:=1
+PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=COPYING
+
 PKG_INSTALL:=1
-PKG_BUILD_DEPENDS:=meson/host vala/host
+PKG_BUILD_DEPENDS:=vala/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -40,11 +38,12 @@ define Package/grilo/decription
 endef
 
 MESON_ARGS += \
+	-Denable-grl-net=true \
 	-Denable-grl-pls=false \
 	-Denable-gtk-doc=false \
 	-Denable-introspection=false \
 	-Denable-test-ui=false \
-	-Denable-vala=false \
+	-Denable-vala=false
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/
@@ -59,13 +58,13 @@ define Build/InstallDev
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc \
 		$(1)/usr/lib/pkgconfig/
-	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/share/vala-`$(STAGING_DIR_HOSTPKG)/bin/valac --api-version`/vapi/
+	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/share/vala-$($(STAGING_DIR_HOSTPKG)/bin/valac --api-version)/vapi/
 	# Note: this are compiled elsewhere because grilo refuses to
 	# generate VAPI files unless gobject-introspection exists;
 	# OpenWrt does not yet have a gobject-introspection package.
 	$(INSTALL_DATA) \
 		./files/*.vapi \
-		$(STAGING_DIR_HOSTPKG)/share/vala-`$(STAGING_DIR_HOSTPKG)/bin/valac --api-version`/vapi
+		$(STAGING_DIR_HOSTPKG)/share/vala-$($(STAGING_DIR_HOSTPKG)/bin/valac --api-version)/vapi
 endef
 
 define Package/grilo/install


### PR DESCRIPTION
Fixed license information.

Removed meson/host build dependency. That's included with libsoup and
eventually, glib2.

Added explicit Denable-grl-net.

Replaced `` with more flexible $().

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @flyn-org 
Compile tested: ath79