### PR TITLE
strongswan: quote 'comment' parameter in Config.in

### DIFF
--- a/net/strongswan/Config.in
+++ b/net/strongswan/Config.in
@@ -1,6 +1,6 @@
 
 if PACKAGE_strongswan
-comment Configuration
+comment "Configuration"
 
 # --with-routing-table
 config STRONGSWAN_ROUTING_TABLE
@@ -14,6 +14,6 @@ config STRONGSWAN_ROUTING_TABLE_PRIO
 	prompt "Set the IPsec routing table priority"
 	default "220"
 
-comment Packages
+comment "Packages"
 
 endif


### PR DESCRIPTION
Maintainer: @stintel 
Compile tested: openwrt master, mvebu, checked menuconfig as well - this intruduces no change
Run tested: not needed - no change in package

Description:
Newer versions of the kconfig generator require quotes.  Prepare the package for an eventual update.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>