### PR TITLE
frr: quote 'comment' parameter in Config.in

### DIFF
--- a/net/frr/Config.in
+++ b/net/frr/Config.in
@@ -13,6 +13,6 @@ choice
                 bool "internal SSL support"
 endchoice
 
-comment Packages
+comment "Packages"
 
 endif


### PR DESCRIPTION
Maintainer: @lucize 
Compile tested: mvebu, openwrt master - menuconfig checked - no change detected
Run tested: N/A - no change in generated package

Description:
Newer versions of the kconfig generator require quotes.  Prepare the
package for an eventual update.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>