### PR TITLE
libzdb: fix headers path

### DIFF
--- a/libs/libzdb/Makefile
+++ b/libs/libzdb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libzdb
 PKG_VERSION:=3.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.tildeslash.com/libzdb/dist/
@@ -69,20 +69,20 @@ endef
 
 define Host/Install
 	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/bin
-	$(INSTALL_BIN) $(HOST_BUILD_DIR)/tools/bin/filterh $(STAGING_DIR_HOSTPKG)/bin/
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/tools/bin/filterh $(STAGING_DIR_HOSTPKG)/bin
 endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/zdb
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/zdb/* $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libzdb* $(1)/usr/lib/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/zdb/* $(1)/usr/include/zdb
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libzdb* $(1)/usr/lib
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/zdb.pc $(1)/usr/lib/pkgconfig
 endef
 
 define Package/libzdb/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libzdb.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libzdb.so* $(1)/usr/lib
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
Maintainer: @neheb, @commodo, @kissg1988.
Compile tested: Clean Debian 10 host, Entware repo ([commit](https://github.com/Entware/entware-packages/commit/0c88eaad50d8a730c713292ef88bd185dae2dea8)).
Run tested: Entware, mipsel feed

Description: fixes regression introduced [here](https://github.com/openwrt/packages/commit/496ee7f91bcd00a64254a707f90fdd6252c2e690#diff-c4213bc7821578f1750e9b7173e0f012R77): package places `$(STAGING_DIR)/usr/include/Threads.h` instead of `$(STAGING_DIR)/usr/include/zdb/Threads.h`, causing compilation fail for `monit` package:
```
libtool: compile:  mipsel-openwrt-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I./src -I/Entware/staging_dir/target-mipsel_mips32r2_glibc-2.27/opt/include -I/Entware/staging_dir/toolchain-mipsel_mips32r2_gcc-8.3.0_glibc-2.27/include -I./src -I./src/exceptions -I./src/io -I./src/net -I./src/statistics -I./src/util -I./src/thread -I/Entware/staging_dir/target-mipsel_mips32r2_glibc-2.27/opt/include -I/Entware/staging_dir/toolchain-mipsel_mips32r2_gcc-8.3.0_glibc-2.27/include -Wno-address -Wno-pointer-sign -O2 -pipe -mno-branch-likely -mips32r2 -mtune=mips32r2 -fno-caller-saves -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float -D _REENTRANT -Wall -Wunused -Wno-unused-label -funsigned-char -D_GNU_SOURCE -std=c99 -c src/exceptions/Exception.c  -fPIC -DPIC -o src/exceptions/.libs/Exception.o
src/exceptions/Exception.c: In function 'init_once':
src/exceptions/Exception.c:75:64: error: macro "ThreadData_create" requires 2 arguments, but only 1 given
 static void init_once(void) { ThreadData_create(Exception_Stack); }
                                                                ^
src/exceptions/Exception.c:75:31: error: 'ThreadData_create' undeclared (first use in this function); did you mean 'pthread_key_create'?
 static void init_once(void) { ThreadData_create(Exception_Stack); }
                               ^~~~~~~~~~~~~~~~~
                               pthread_key_create
src/exceptions/Exception.c:75:31: note: each undeclared identifier is reported only once for each function it appears in
make[6]: *** [Makefile:532: src/exceptions/Exception.lo] Error 1
```