### PR TITLE
fdk-aac: don't build two versions

### DIFF
--- a/sound/fdk-aac/Makefile
+++ b/sound/fdk-aac/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fdk-aac
 PKG_VERSION:=2.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mstorsjo/fdk-aac/tar.gz/v$(PKG_VERSION)?
@@ -23,9 +23,26 @@ PKG_BUILD_PARALLEL:=1
 
 PKG_CONFIG_DEPENDS:= CONFIG_FDK-AAC_OPTIMIZE_SPEED
 
-ifeq ($(BUILD_VARIANT),free)
+ifeq ($(CONFIG_BUILD_PATENTED),y)
 PATCH_DIR:=./patches-free
 endif
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/fdk-aac
+  SECTION:=sound
+  CATEGORY:=Sound
+  TITLE:=Fraunhofer FDK AAC Codec Library
+  URL:=https://sourceforge.net/projects/opencore-amr/
+endef
+
+define Package/fdk-aac/config
+  source "$(SOURCE)/Config.in"
+endef
+
+define Package/fdk-aac/description
+  Port of the Fraunhofer FDK AAC Codec Library for Android
+endef
 
 ifeq ($(CONFIG_FDK-AAC_OPTIMIZE_SPEED),y)
 	TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS))
@@ -34,52 +51,6 @@ ifeq ($(CONFIG_FDK-AAC_OPTIMIZE_SPEED),y)
 	TARGET_CXXFLAGS += $(TARGET_CXXFLAGS) -O2 -flto
 	TARGET_LDFLAGS += $(TARGET_LDFLAGS) -flto
 endif
-
-include $(INCLUDE_DIR)/package.mk
-
-define Package/fdk-aac/Default
-  SECTION:=sound
-  CATEGORY:=Sound
-  TITLE:=Fraunhofer FDK AAC Codec Library
-  URL:=https://sourceforge.net/projects/opencore-amr/
-endef
-
-define Package/fdk-aac/Default/description
-  Port of the Fraunhofer FDK AAC Codec Library for Android
-endef
-
-define Package/fdk-aac/Default/config
-  source "$(SOURCE)/Config.in"
-endef
-
-define Package/fdk-aac
-  $(call Package/fdk-aac/Default)
-  DEPENDS:=@BUILD_PATENTED
-  VARIANT:=nonfree
-endef
-
-define Package/fdk-aac/description
-  $(call Package/fdk-aac/Default/description)
-  This is the full patent encumbered version.
-endef
-
-define Package/fdk-aac/config
-  $(call Package/fdk-aac/Default/config)
-endef
-
-define Package/fdk-aac-free
-  $(call Package/fdk-aac/Default)
-  VARIANT:=free
-endef
-
-define Package/fdk-aac-free/description
-  $(call Package/fdk-aac/Default/description)
-  This is the free version that only supports LC-AAC.
-endef
-
-define Package/fdk-aac-free/config
-  $(call Package/fdk-aac/Default/config)
-endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
@@ -95,10 +66,4 @@ define Package/fdk-aac/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfdk-aac.so* $(1)/usr/lib/
 endef
 
-define Package/fdk-aac-free/install
-	$(INSTALL_DIR) $(1)/usr/lib/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libfdk-aac.so* $(1)/usr/lib/
-endef
-
 $(eval $(call BuildPackage,fdk-aac))
-$(eval $(call BuildPackage,fdk-aac-free))


### PR DESCRIPTION
Instead, chose which to build based on CONFIG_BUILD_PATENTED. This is
more flexible and causes fewer problems when compiling.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 