### PR TITLE
svox: fix compilation with newer musl

### DIFF
--- a/sound/svox/Makefile
+++ b/sound/svox/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=svox
 PKG_VERSION:=1.0+git20130326
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
 PKG_SOURCE_URL:=http://ftp.debian.org/debian/pool/non-free/s/svox

--- a/sound/svox/patches/0003-pico2wave-Convert-text-to-.wav-using-svox-text-to-sp.patch
+++ b/sound/svox/patches/0003-pico2wave-Convert-text-to-.wav-using-svox-text-to-sp.patch
@@ -41,7 +41,7 @@ new file mode 100644
 index 0000000..0c035a7
 --- /dev/null
 +++ b/pico/bin/pico2wave.c
-@@ -0,0 +1,341 @@
+@@ -0,0 +1,342 @@
 +/* pico2wave.c
 +
 + * Copyright (C) 2009 Mathieu Parent <math.parent@gmail.com>
@@ -65,6 +65,7 @@ index 0000000..0c035a7
 +
 +#include <popt.h>
 +#include <stdio.h>
++#include <stdint.h>
 +#include <stdlib.h>
 +#include <string.h>
 +


### PR DESCRIPTION
Otherwise int8_t is undeclared.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dmrlsn 
Compile tested: ath79