### PR TITLE
libssh: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/libs/libssh/Makefile
+++ b/libs/libssh/Makefile
@@ -7,22 +7,21 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_LICENSE:=LGPL-2.1-or-later BSD-2-Clause
-PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
-
 PKG_NAME:=libssh
 PKG_VERSION:=0.9.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.libssh.org/files/0.9/
 PKG_HASH:=2c8b5f894dced58b3d629f16f3afa6562c20b4bdc894639163cf657833688f0c
 
+PKG_MAINTAINER:=Mislav Novakovic <mislav.novakovic@sartura.hr>
+PKG_LICENSE:=LGPL-2.1-or-later BSD-2-Clause
+PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:libssh:libssh
 
 CMAKE_INSTALL:=1
 CMAKE_BINARY_SUBDIR:=build
-
 PKG_BUILD_PARALLEL:=1
 PKG_USE_MIPS16:=0
 
@@ -59,24 +58,8 @@ CMAKE_OPTIONS = \
 	-UWITH_STACK_PROTECTOR \
 	-DWITH_STACK_PROTECTOR=0 \
 	-UWITH_STACK_PROTECTOR_STRONG \
-	-DWITH_STACK_PROTECTOR_STRONG=0
-
-ifeq ($(CONFIG_BIG_ENDIAN),y)
-CMAKE_OPTIONS += -DHAVE_WORDS_BIGENDIAN=1
-else
-CMAKE_OPTIONS += -DHAVE_WORDS_BIGENDIAN=0
-endif
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include/libssh/
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/libssh/* $(1)/usr/include/libssh/
-
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libssh* $(1)/usr/lib/
-
-	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/* $(1)/usr/lib/pkgconfig/
-endef
+	-DWITH_STACK_PROTECTOR_STRONG=0 \
+	-DHAVE_WORDS_BIGENDIAN=$(if $(CONFIG_BIG_ENDIAN),1,0)
 
 define Package/libssh/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/libssh/patches/0001-libcrypto-compat-add-extra-functions.patch
+++ b/libs/libssh/patches/0001-libcrypto-compat-add-extra-functions.patch
@@ -1,0 +1,73 @@
+From ce7de0261f0c1f1640da5673dd24939a37e33bd9 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Thu, 23 Jan 2020 18:53:06 -0800
+Subject: [PATCH 1/2] libcrypto-compat: add extra functions
+
+Changed the define to compare OPENSSL_API_COMPAT instead of version as
+OpenSSL can be compiled in different ways. One is to disable all
+deprecated APIs.
+
+Added extra functions. The next commit will switch to them.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ src/libcrypto-compat.c | 14 ++++++++++++++
+ src/libcrypto-compat.h |  8 +++++++-
+ 2 files changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/src/libcrypto-compat.c b/src/libcrypto-compat.c
+index 048d1781..3604763f 100644
+--- a/src/libcrypto-compat.c
++++ b/src/libcrypto-compat.c
+@@ -280,6 +280,11 @@ void EVP_MD_CTX_free(EVP_MD_CTX *ctx)
+     OPENSSL_free(ctx);
+ }
+ 
++int EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *ctx)
++{
++	EVP_CIPHER_CTX_init(ctx);
++}
++
+ HMAC_CTX *HMAC_CTX_new(void)
+ {
+     HMAC_CTX *ctx = OPENSSL_zalloc(sizeof(HMAC_CTX));
+@@ -394,3 +399,12 @@ int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key)
+     }
+     return 1;
+ }
++
++const char *OpenSSL_version(int type)
++{
++    return SSLeay_version(type);
++}
++unsigned long OpenSSL_version_num(void)
++{
++    return SSLeay();
++}
+diff --git a/src/libcrypto-compat.h b/src/libcrypto-compat.h
+index bda0473e..44e14801 100644
+--- a/src/libcrypto-compat.h
++++ b/src/libcrypto-compat.h
+@@ -34,6 +34,8 @@ int EVP_MD_CTX_reset(EVP_MD_CTX *ctx);
+ EVP_MD_CTX *EVP_MD_CTX_new(void);
+ void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
+ 
++int EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *ctx);
++
+ HMAC_CTX *HMAC_CTX_new(void);
+ int HMAC_CTX_reset(HMAC_CTX *ctx);
+ void HMAC_CTX_free(HMAC_CTX *ctx);
+@@ -44,6 +46,10 @@ int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g);
+ void DH_get0_key(const DH *dh,
+                  const BIGNUM **pub_key, const BIGNUM **priv_key);
+ int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key);
++
++const char *OpenSSL_version(int type);
++unsigned long OpenSSL_version_num(void);
++
+ #endif /* OPENSSL_VERSION_NUMBER */
+ 
+ #endif /* LIBCRYPTO_COMPAT_H */
+-- 
+2.24.1
+

--- a/libs/libssh/patches/0002-libcrypto-remove-deprecated-API-usage.patch
+++ b/libs/libssh/patches/0002-libcrypto-remove-deprecated-API-usage.patch
@@ -1,0 +1,63 @@
+From 73f0e186964126c9e2bfba43488f543ace54746b Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Thu, 23 Jan 2020 18:54:51 -0800
+Subject: [PATCH 2/2] libcrypto: remove deprecated API usage
+
+EVP_CIPHER_CTX_init was replaced with _reset.
+
+Removed EVP_CIPHER_CTX_cleanup. The successive _free call handles that.
+
+Removed old SSLeay function usage.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ src/libcrypto.c | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/src/libcrypto.c b/src/libcrypto.c
+index b3792264..7ce7d93a 100644
+--- a/src/libcrypto.c
++++ b/src/libcrypto.c
+@@ -541,7 +541,7 @@ static int evp_cipher_set_encrypt_key(struct ssh_cipher_struct *cipher,
+     int rc;
+ 
+     evp_cipher_init(cipher);
+-    EVP_CIPHER_CTX_init(cipher->ctx);
++    EVP_CIPHER_CTX_reset(cipher->ctx);
+ 
+     rc = EVP_EncryptInit_ex(cipher->ctx, cipher->cipher, NULL, key, IV);
+     if (rc != 1){
+@@ -574,7 +574,7 @@ static int evp_cipher_set_decrypt_key(struct ssh_cipher_struct *cipher,
+     int rc;
+ 
+     evp_cipher_init(cipher);
+-    EVP_CIPHER_CTX_init(cipher->ctx);
++    EVP_CIPHER_CTX_reset(cipher->ctx);
+ 
+     rc = EVP_DecryptInit_ex(cipher->ctx, cipher->cipher, NULL, key, IV);
+     if (rc != 1){
+@@ -657,7 +657,6 @@ static void evp_cipher_decrypt(struct ssh_cipher_struct *cipher,
+ 
+ static void evp_cipher_cleanup(struct ssh_cipher_struct *cipher) {
+     if (cipher->ctx != NULL) {
+-        EVP_CIPHER_CTX_cleanup(cipher->ctx);
+         EVP_CIPHER_CTX_free(cipher->ctx);
+     }
+ }
+@@ -1481,11 +1480,11 @@ int ssh_crypto_init(void)
+     if (libcrypto_initialized) {
+         return SSH_OK;
+     }
+-    if (SSLeay() != OPENSSL_VERSION_NUMBER){
++    if (OpenSSL_version_num() != OPENSSL_VERSION_NUMBER){
+         SSH_LOG(SSH_LOG_WARNING, "libssh compiled with %s "
+             "headers, currently running with %s.",
+             OPENSSL_VERSION_TEXT,
+-            SSLeay_version(SSLeay())
++            OpenSSL_version(OpenSSL_version_num())
+         );
+     }
+ #ifdef CAN_DISABLE_AESNI
+-- 
+2.24.1
+


### PR DESCRIPTION
Cleaned up Makefile.

Fixed license information.

Simplified big endian condition.

Removed InstallDev section. CMAKE_INSTALL handles it.

Removed no mips16. It doesn't seem like it's needed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mislavn
Compile tested: ath79