### PR TITLE
smartdns: update to 1.2020.30

### DIFF
--- a/net/smartdns/Makefile
+++ b/net/smartdns/Makefile
@@ -1,18 +1,18 @@
 #
-# Copyright (c) 2018-2019 Nick Peng (pymumu@gmail.com)
+# Copyright (c) 2018-2020 Nick Peng (pymumu@gmail.com)
 # This is free software, licensed under the GNU General Public License v3.
 #
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=smartdns
-PKG_VERSION:=1.2020.28
+PKG_VERSION:=1.2020.30
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://www.github.com/pymumu/smartdns.git
-PKG_SOURCE_VERSION:=2322a9dbd03de284acca388119f00a9bc7d9bec2
-PKG_MIRROR_HASH:=1698c0fc16fd67b72f1a588aad06427afd919541356e445ab75c26f5ce296e86
+PKG_SOURCE_VERSION:=a6fe329105c7275d4683d17e95ab9d9f93a9c863
+PKG_MIRROR_HASH:=d5affc45a533e38ee04f3ce47b441aecf316cb9cb68ff410eede67090ec0fcc7
 
 PKG_MAINTAINER:=Nick Peng <pymumu@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -35,7 +35,7 @@ endef
 
 define Package/smartdns/description
 SmartDNS is a local DNS server which accepts DNS query requests from local network clients,
-get DNS query results from multiple upstream DNS servers concurrently, and returns the fastest IP to clients.
+gets DNS query results from multiple upstream DNS servers concurrently, and returns the fastest IP to clients.
 Unlike dnsmasq's all-servers, smartdns returns the fastest IP. 
 endef
 


### PR DESCRIPTION
Signed-off-by: Nick Peng <pymumu@gmail.com>

Maintainer: @pymumu
Compile tested: ar71xx

Description:
Update to release 1.2020.30.
Fix some issue.
Add Server-expired feature.

