### PR TITLE
nginx: bump version and fix bug 

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
-PKG_VERSION:=1.17.8
+PKG_VERSION:=1.17.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/
-PKG_HASH:=97d23ecf6d5150b30e284b40e8a6f7e3bb5be6b601e373a4d013768d5a25965b
+PKG_HASH:=7dd65d405c753c41b7fdab9415cfb4bdbaf093ec6d9f7432072d52cb7bcbb689
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de> \
 				Ansuel Smith <ansuelsmth@gmail.com>

--- a/net/nginx/files/nginx.conf
+++ b/net/nginx/files/nginx.conf
@@ -15,7 +15,7 @@ http {
 	default_type application/octet-stream;
 	sendfile on;
 
-	client_max_body_size 17M;
+	client_max_body_size 128M;
 	large_client_header_buffers 2 1k;
 
 	gzip on;


### PR DESCRIPTION
This fix #11610 by increasing max client body size
in nginx conf.
Bump nginx to latest version.

@hnyman 

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>