### PR TITLE
https-dns-proxy: support for dnsmasq noresolv option

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2019-12-03
-PKG_RELEASE=4
+PKG_RELEASE=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -46,14 +46,13 @@ start_instance() {
 	append_parm "$cfg" 'proxy_server' '-t'
 	append_parm "$cfg" 'logfile' '-l'
 	append_bool "$cfg" 'use_http1' '-x'
-
+	config_get_bool ipv6_resolvers_only "$cfg" 'use_ipv6_resolvers_only' '0'
 	config_get verbosity "$cfg" 'verbosity' "0"
+
 # shellcheck disable=SC2086,SC2154
 	for i in $(seq 1 $verbosity); do
 		xappend "-v"
 	done
-
-	config_get_bool ipv6_resolvers_only "$cfg" 'use_ipv6_resolvers_only' '0'
 # shellcheck disable=SC2154
 	if [ "$ipv6_resolvers_only" = 0 ]; then
 		xappend "-4"
@@ -114,42 +113,55 @@ service_triggers() {
 
 dnsmasq_add_doh_server() {
 	local cfg="$1" address="$2" port="$3"
-
-	# Don't add the any address to dnsmasq
 	case $address in
-		0.0.0.0|::ffff:0.0.0.0)
-			address='127.0.0.1'
-			;;
-		::)
-			address='::1'
-			;;
+		0.0.0.0|::ffff:0.0.0.0) address='127.0.0.1';;
+		::) address='::1';;
 	esac
-
-	uci -q del_list "dhcp.$cfg.server=${address}#${port}"
-	uci -q add_list "dhcp.$cfg.server=${address}#${port}"
+	uci -q del_list "dhcp.${cfg}.server=${address}#${port}"
+	uci -q add_list "dhcp.${cfg}.server=${address}#${port}"
 }
 
 dnsmasq_create_server_backup() {
 	local cfg="$1"
 	local i
-	uci -q get "dhcp.$cfg.doh_backup_server" >/dev/null && return 0
-	for i in $(uci -q get "dhcp.$cfg.server"); do
-		uci -q add_list dhcp."$cfg".doh_backup_server="$i"
-		if [ "$i" = "${i//127.0.0.1}" ] && [ "$i" = "$(echo "$i" | tr -d /)" ]; then
-			uci -q del_list "dhcp.$cfg.server=$i"
+	uci -q get "dhcp.${cfg}" >/dev/null || return 0
+	if ! uci -q get "dhcp.${cfg}.doh_backup_noresolv" >/dev/null; then
+		if [ -z "$(uci -q get "dhcp.${cfg}.noresolv")" ]; then
+			uci -q set "dhcp.${cfg}.noresolv=1"
+			uci -q set "dhcp.${cfg}.doh_backup_noresolv=-1"
+		elif [ "$(uci -q get "dhcp.${cfg}.noresolv")" != "1" ]; then
+			uci -q set "dhcp.${cfg}.noresolv=1"
+			uci -q set "dhcp.${cfg}.doh_backup_noresolv=0"
 		fi
-	done
+	fi
+	if ! uci -q get "dhcp.${cfg}.doh_backup_server" >/dev/null; then
+		for i in $(uci -q get "dhcp.${cfg}.server"); do
+			uci -q add_list "dhcp.${cfg}.doh_backup_server=$i"
+			if [ "$i" = "${i//127.0.0.1}" ] && [ "$i" = "$(echo "$i" | tr -d /)" ]; then
+				uci -q del_list "dhcp.${cfg}.server=$i"
+			fi
+		done
+	fi
 }
 
 dnsmasq_restore_server_backup() {
 	local cfg="$1"
 	local i
-	if uci -q get "dhcp.$cfg.doh_backup_server" >/dev/null; then
-		uci -q del "dhcp.$cfg.server"
-		for i in $(uci -q get "dhcp.$cfg.doh_backup_server"); do
-			uci -q add_list "dhcp.$cfg.server=$i"
+	uci -q get "dhcp.${cfg}" >/dev/null || return 0
+	if uci -q get "dhcp.${cfg}.doh_backup_noresolv" >/dev/null; then
+		if [ "$(uci -q get "dhcp.${cfg}.doh_backup_noresolv")" = "0" ]; then
+			uci -q set "dhcp.${cfg}.noresolv=0"
+		else 
+			uci -q del "dhcp.${cfg}.noresolv"
+		fi
+		uci -q del "dhcp.${cfg}.doh_backup_noresolv"
+	fi
+	if uci -q get "dhcp.${cfg}.doh_backup_server" >/dev/null; then
+		uci -q del "dhcp.${cfg}.server"
+		for i in $(uci -q get "dhcp.${cfg}.doh_backup_server"); do
+			uci -q add_list "dhcp.${cfg}.server=$i"
 		done
-	uci -q del "dhcp.$cfg.doh_backup_server"
+	uci -q del "dhcp.${cfg}.doh_backup_server"
 	fi
 }
 


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, WRT3200ACM, 19.07.2
Run tested: mvebu, WRT3200ACM, 19.07.2, start/stop and verify affected setting

Description: This patch introduces support for changing the dnsmasq's `noresolv` option on start, as well as (if needed) backing up previously used setting on start and (if exists) restoring the previously used setting on stop.

Signed-off-by: Stan Grishin <stangri@melmac.net>
