### PR TITLE
[19.07] https-dns-proxy: support for dnsmasq noresolv option

### DIFF
--- a/net/https-dns-proxy/Makefile
+++ b/net/https-dns-proxy/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=https-dns-proxy
 PKG_VERSION:=2019-12-03
-PKG_RELEASE=3
+PKG_RELEASE=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/aarond10/https_dns_proxy

--- a/net/https-dns-proxy/files/README.md
+++ b/net/https-dns-proxy/files/README.md
@@ -57,7 +57,7 @@ config https-dns-proxy
   option listen_addr '127.0.0.1'
   option listen_port '5054'
   option user 'nobody'
-  option group 'nogroup'```
+  option group 'nogroup'
 ```
 
 The ```update_dnsmasq_config``` option can be set to dash (set to ```'-'``` to not change ```DNSMASQ``` server settings on start/stop), can be set to ```'*'``` to affect all ```DNSMASQ``` instance server settings or have a space-separated list of ```DNSMASQ``` instances to affect (like ```'0 4 5'```). If this option is omitted, the default setting is ```'*'```.
@@ -87,7 +87,8 @@ The https-dns-proxy instance settings are:
 |user|String|nobody|Local user to run instance under.|
 |group|String|nogroup|Local group to run instance under.|
 |use_http1|Boolean|0|If set to 1, use HTTP/1 on installations with broken/outdated ```curl``` package. Included for posterity reasons, you will most likely not ever need it on OpenWrt.|
-|verbosity|Integer||Use setting between 1 to 4 to control the logging verbosity level.|String
+|verbosity|Integer|0|logging verbosity level. fatal = 0, error = 1, warning = 2, info = 3, debug = 4|
+|use_ipv6_resolvers_only|Boolean|0|If set to 1, Forces IPv6 DNS resolvers instead of IPv4|
 
 ## Thanks
 

--- a/net/https-dns-proxy/files/https-dns-proxy.init
+++ b/net/https-dns-proxy/files/https-dns-proxy.init
@@ -33,16 +33,6 @@ append_parm() {
 	xappend "$switch $_loctmp"
 }
 
-append_match() {
-	local section="$1"
-	local option="$2"
-	local value="$3"
-	local match="$4"
-	local _loctmp
-	config_get_bool _loctmp "$section" "$option"
-	[ "$_loctmp" = "$match" ] && xappend "$value"
-}
-
 start_instance() {
 	local cfg="$1" param listen_addr listen_port i
 
@@ -56,25 +46,35 @@ start_instance() {
 	append_parm "$cfg" 'proxy_server' '-t'
 	append_parm "$cfg" 'logfile' '-l'
 	append_bool "$cfg" 'use_http1' '-x'
-	append_match "$cfg" 'verbosity' '-v' '1'
-	append_match "$cfg" 'verbosity' '-vv' '2'
-	append_match "$cfg" 'verbosity' '-vvv' '3'
-	append_match "$cfg" 'verbosity' '-vvvv' '4'
+	config_get_bool ipv6_resolvers_only "$cfg" 'use_ipv6_resolvers_only' '0'
+	config_get verbosity "$cfg" 'verbosity' "0"
+
+# shellcheck disable=SC2086,SC2154
+	for i in $(seq 1 $verbosity); do
+		xappend "-v"
+	done
+# shellcheck disable=SC2154
+	if [ "$ipv6_resolvers_only" = 0 ]; then
+		xappend "-4"
+	fi
 
 	procd_open_instance
 # shellcheck disable=SC2086
-	procd_set_param command ${PROG} -4 ${param}
+	procd_set_param command ${PROG} ${param}
+	procd_set_param stderr 1
+	procd_set_param stdout 1
 	procd_set_param respawn
 	procd_close_instance
 
 	config_get listen_addr "$cfg" 'listen_addr' '127.0.0.1'
 	config_get listen_port "$cfg" 'listen_port' "$p"
+
 	if [ "$dnsmasqConfig" = "*" ]; then
 		config_load 'dhcp'
-		config_foreach dnsmasq_add_doh_server 'dnsmasq' "${listen_addr}#${listen_port}"
+		config_foreach dnsmasq_add_doh_server 'dnsmasq' "${listen_addr}" "${listen_port}"
 	elif [ -n "$dnsmasqConfig" ]; then
 		for i in $dnsmasqConfig; do
-			dnsmasq_add_doh_server "@dnsmasq[${i}]" "${listen_addr}#${listen_port}"
+			dnsmasq_add_doh_server "@dnsmasq[${i}]" "${listen_addr}" "${listen_port}"
 		done
 	fi
 	p="$((p+1))"
@@ -112,32 +112,56 @@ service_triggers() {
 }
 
 dnsmasq_add_doh_server() {
-	local cfg="$1" value="$2"
-	uci -q del_list dhcp."$cfg".server="$value"
-	uci -q add_list dhcp."$cfg".server="$value"
+	local cfg="$1" address="$2" port="$3"
+	case $address in
+		0.0.0.0|::ffff:0.0.0.0) address='127.0.0.1';;
+		::) address='::1';;
+	esac
+	uci -q del_list "dhcp.${cfg}.server=${address}#${port}"
+	uci -q add_list "dhcp.${cfg}.server=${address}#${port}"
 }
 
 dnsmasq_create_server_backup() {
 	local cfg="$1"
 	local i
-	uci -q get "dhcp.$cfg.doh_backup_server" >/dev/null && return 0
-	for i in $(uci -q get "dhcp.$cfg.server"); do
-		uci -q add_list dhcp."$cfg".doh_backup_server="$i"
-		if [ "$i" = "${i//127.0.0.1}" ] && [ "$i" = "$(echo "$i" | tr -d /)" ]; then
-			uci -q del_list dhcp."$cfg".server="$i"
+	uci -q get "dhcp.${cfg}" >/dev/null || return 0
+	if ! uci -q get "dhcp.${cfg}.doh_backup_noresolv" >/dev/null; then
+		if [ -z "$(uci -q get "dhcp.${cfg}.noresolv")" ]; then
+			uci -q set "dhcp.${cfg}.noresolv=1"
+			uci -q set "dhcp.${cfg}.doh_backup_noresolv=-1"
+		elif [ "$(uci -q get "dhcp.${cfg}.noresolv")" != "1" ]; then
+			uci -q set "dhcp.${cfg}.noresolv=1"
+			uci -q set "dhcp.${cfg}.doh_backup_noresolv=0"
 		fi
-	done
+	fi
+	if ! uci -q get "dhcp.${cfg}.doh_backup_server" >/dev/null; then
+		for i in $(uci -q get "dhcp.${cfg}.server"); do
+			uci -q add_list "dhcp.${cfg}.doh_backup_server=$i"
+			if [ "$i" = "${i//127.0.0.1}" ] && [ "$i" = "$(echo "$i" | tr -d /)" ]; then
+				uci -q del_list "dhcp.${cfg}.server=$i"
+			fi
+		done
+	fi
 }
 
 dnsmasq_restore_server_backup() {
 	local cfg="$1"
 	local i
-	if uci -q get "dhcp.$cfg.doh_backup_server" >/dev/null; then
-		uci -q del "dhcp.$cfg.server"
-		for i in $(uci -q get "dhcp.$cfg.doh_backup_server"); do
-			uci -q add_list dhcp."$cfg".server="$i"
+	uci -q get "dhcp.${cfg}" >/dev/null || return 0
+	if uci -q get "dhcp.${cfg}.doh_backup_noresolv" >/dev/null; then
+		if [ "$(uci -q get "dhcp.${cfg}.doh_backup_noresolv")" = "0" ]; then
+			uci -q set "dhcp.${cfg}.noresolv=0"
+		else 
+			uci -q del "dhcp.${cfg}.noresolv"
+		fi
+		uci -q del "dhcp.${cfg}.doh_backup_noresolv"
+	fi
+	if uci -q get "dhcp.${cfg}.doh_backup_server" >/dev/null; then
+		uci -q del "dhcp.${cfg}.server"
+		for i in $(uci -q get "dhcp.${cfg}.doh_backup_server"); do
+			uci -q add_list "dhcp.${cfg}.server=$i"
 		done
-	uci -q del "dhcp.$cfg.doh_backup_server"
+	uci -q del "dhcp.${cfg}.doh_backup_server"
 	fi
 }
 


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, WRT3200ACM, 19.07.2
Run tested: mvebu, WRT3200ACM, 19.07.2, start/stop and verify affected setting

Description: This patch introduces support for changing the dnsmasq's `noresolv` option on start, as well as (if needed) backing up previously used setting on start and (if exists) restoring the previously used setting on stop.

Signed-off-by: Stan Grishin <stangri@melmac.net>
