### PR TITLE
ffmpeg: do not list AAC as patented

### DIFF
--- a/multimedia/ffmpeg/Config.in
+++ b/multimedia/ffmpeg/Config.in
@@ -144,7 +144,6 @@ comment "External Libraries"
 config FFMPEG_CUSTOM_SELECT_libfdk-aac
 	bool "Fraunhofer FDK AAC encoding library (libfdk-aac)"
 	depends on FFMPEG_CUSTOM_NONFREE
-	depends on FFMPEG_CUSTOM_PATENTED
 	depends on PACKAGE_fdk-aac
 
 config FFMPEG_CUSTOM_SELECT_libmp3lame

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=3.4.7
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/


### PR DESCRIPTION
Both libraries in the tree (fdk-aac and faad) have patented functionality
disabled when CONFIG_BUILD_PATENTED is off.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess
Compile tested: ath79

ping @diizzyy 