### PR TITLE
collectd: disable dpdk_telemetry module

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -43,6 +43,7 @@ COLLECTD_PLUGINS_DISABLED:= \
 	dcpmm \
 	dpdkevents \
 	dpdkstat \
+	dpdk_telemetry \
 	drbd \
 	fhcount \
 	genericjmx \


### PR DESCRIPTION
Maintainer: me 

Buildbot complains about the new 5.11.0 for dpdk_telemetry plugin, so let's disable it explicitly.

This time use a PR to force circleci testing (unlike I did for the original version bump)
