### PR TITLE
redis: update to version 5.0.8 (security fix)

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=5.0.7
+PKG_VERSION:=5.0.8
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=61db74eabf6801f057fd24b590232f2f337d422280fd19486eca03be87d3a82b
+PKG_HASH:=f3c7eac42f433326a8d981b50dba0169fdfaf46abb23fcda2f933a7552ee4ed7
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates redis to version 5.0.8.  Update urgency is set to HIGH because it fixes a few potential security issues.

Fix potential memory leak of rioWriteBulkStreamID(),  
Fix potential memory leak of clusterLoadConfig() etc
See changelog https://raw.githubusercontent.com/antirez/redis/5.0/00-RELEASENOTES

Runtested with redis-cli and redis-benchmark
