### PR TITLE
tor: update to version 0.4.2.7 (security fix)

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
-PKG_VERSION:=0.4.2.6
-PKG_RELEASE:=3
+PKG_VERSION:=0.4.2.7
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
 	https://archive.torproject.org/tor-package-archive
-PKG_HASH:=0500102433849bbe3231c590973d126c2d2d6b3943b4b9f9962bdb108436e6c4
+PKG_HASH:=06a1d835ddf382f6bca40a62e8fb40b71b2f73d56f0d53523c8bd5caf9b3026d
 PKG_MAINTAINER:=Hauke Mehrtens <hauke@hauke-m.de> \
 		Peter Wagner <tripolar@gmx.at>
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION


Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates Tor to version 0.4.2.7 which also fixes a security issue CVE-2020-10592

[Changelog](https://blog.torproject.org/new-releases-03510-0419-0427)

Run tested with torsocks.
