### PR TITLE
[openwrt-19.07] python-pyasn1-modules: Update to 0.2.8

### DIFF
--- a/lang/python/python-pyasn1-modules/Makefile
+++ b/lang/python/python-pyasn1-modules/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyasn1-modules
-PKG_VERSION:=0.2.7
+PKG_VERSION:=0.2.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=pyasn1-modules-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/p/pyasn1-modules
-PKG_HASH:=0c35a52e00b672f832e5846826f1fb7507907f7d52fba6faa9e3c4cbe874fe4b
+PKG_HASH:=905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE.txt


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: none (cherry-picked from #11025)
Run tested: none

Description:
Signed-off-by: Jeffery To <jeffery.to@gmail.com>
(cherry picked from commit a6f1e7689b806e3a2baf1446cb8cb547cbc03797)