### PR TITLE
dawn: add decentralized wifi controller

### DIFF
--- a/net/dawn/Makefile
+++ b/net/dawn/Makefile
@@ -1,0 +1,46 @@
+#
+# This software is licensed under the Public Domain.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dawn
+PKG_SOURCE_DATE:=2020-03-23
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/berlin-open-wireless-lab/DAWN.git
+PKG_SOURCE_VERSION:=f03f55ff92153337972cb9b2d1856b9a364df073
+PKG_MIRROR_HASH:=065ae3c9d04881f68da775f86c4def8cf8e19abce12bac9ac3b4145a66e33e56
+
+PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/dawn
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Decentralized wifi controller
+  URL:=https://github.com/berlin-open-wireless-lab/DAWN.git
+  DEPENDS:=$(DRV_DEPENDS) +libubus +libubox +libblobmsg-json +libuci +libgcrypt +libiwinfo +umdns
+endef
+
+define Package/dawn/description
+  This package implements a decentralized wireless daemon.
+endef
+
+define Package/dawn/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/dawn $(1)/usr/sbin/dawn
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/dawn.init $(1)/etc/init.d/dawn
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/dawn.config $(1)/etc/config/dawn
+endef
+
+$(eval $(call BuildPackage,dawn))

--- a/net/dawn/files/dawn.config
+++ b/net/dawn/files/dawn.config
@@ -1,0 +1,55 @@
+config network
+    option broadcast_ip         '10.0.0.255'
+    option broadcast_port       '1025'
+    option tcp_port             '1026'
+    option network_option       '2' # 0 udp broadcast, 1 mutlicast, 2 tcp
+    option shared_key           'Niiiiiiiiiiiiiik'
+    option iv                   'Niiiiiiiiiiiiiik'
+    option use_symm_enc         '1'
+    option collision_domain     '-1'     # enter here aps which are in the same collision domain
+    option bandwidth            '-1'     # enter network bandwidth
+
+config ordering
+    option sort_order           'cbfs'
+
+config hostapd
+    option hostapd_dir          '/var/run/hostapd'
+
+config times
+    option update_client        '10'
+    option denied_req_threshold '30'
+    option remove_client        '15'
+    option remove_probe         '30'
+    option remove_ap            '460'
+    option update_hostapd       '10'
+    option update_tcp_con       '10'
+    option update_chan_util     '5'
+
+config metric
+    option ap_weight            '0'
+    option ht_support           '0'
+    option vht_support          '0'
+    option no_ht_support        '0'
+    option no_vht_support       '0'
+    option rssi                 '10'
+    option low_rssi             '-500'
+    option freq                 '100' # some kind of band-steering
+    option chan_util            '0'
+    option max_chan_util        '-500'
+    option rssi_val             '-60'
+    option low_rssi_val         '-80'
+    option chan_util_val        '140'
+    option max_chan_util_val    '170'
+    option min_probe_count      '0'
+    option bandwith_threshold   '6'
+    option use_station_count    '1'
+    option max_station_diff     '1'
+    option eval_probe_req       '0'
+    option eval_auth_req        '0'     # no real reasoncode...
+    option eval_assoc_req       '0'     # just deny assocs...
+    option kicking              '0'
+    option deny_auth_reason     '1'     # unspecified
+    option deny_assoc_reason    '17'    # assoc rejected can't handle new station
+    option use_driver_recog     '1'
+    option min_number_to_kick   '3'
+    option chan_util_avg_period '3'

--- a/net/dawn/files/dawn.init
+++ b/net/dawn/files/dawn.init
@@ -1,0 +1,46 @@
+#!/bin/sh /etc/rc.common
+ 
+USE_PROCD=1
+
+START=50
+STOP=50
+
+PROG=/usr/sbin/dawn
+NAME=dawn
+
+reload_service()
+{
+	if service_running; then
+		ubus call dawn reload_config
+	else
+		start
+	fi
+}
+
+service_triggers()
+{
+	procd_add_reload_trigger "dawn"
+}
+
+start_service()
+{
+	local _tcp_buffer
+	config_load dawn
+	load_tcp_port() {
+		config_get _tcp_buffer "$1" tcp_port
+	}
+	config_foreach load_tcp_port network
+	
+	touch /tmp/dawn_mac_list
+
+	echo "Starting Service..."
+	procd_open_instance
+	procd_set_param command $PROG
+	procd_set_param stdout 0 # here it is possible to remove the debug output...
+	procd_set_param stderr 1
+	procd_add_mdns "dawn" "tcp" "${_tcp_buffer}"
+	procd_close_instance
+  	echo "Dawn instance started!"
+  	echo "UMDNS with port ${_tcp_buffer}"
+}
+


### PR DESCRIPTION
Dawn is a decentralized WiFi controller.
Just install dawn and the APs will find each other via umdns.
They periodically exchange information about connected clients, wireless
statistics and other needed information. With that, the daemon load
balances clients between different APs through association control.

Further, the daemon exposes through ubus the hearing map and the
complete wireless network overview. The hearing map is the list of all
probe requests seen from a client from all APs that are running the
controller.

Hearing map:

    ubus call dawn get_hearing_map

Network overview:

    ubus call dawn get_network

Dawn has a graphical user interface called luci-app-dawn. With that, the
load balancing and other useful settings can be controlled.

Next steps:
- [ ] Neighborreports
- [ ] BSS Trasnsition

Adding the controller to official openwrt package tree was wished in 
https://github.com/berlin-open-wireless-lab/DAWN/issues/53

If I should maintain the controller here, I would like commit priviliges. ;)