### PR TITLE
spice: add nls.mk

### DIFF
--- a/libs/spice/Makefile
+++ b/libs/spice/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spice
 PKG_VERSION:=0.14.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.spice-space.org/download/releases/spice-server
 PKG_HASH:=551d4be4a07667cf0543f3c895beb6da8a93ef5a9829f2ae47817be5e616a114
@@ -22,6 +22,7 @@ PKG_FIXUP:=autoreconf
 PKG_BUILD_DEPENDS+=spice-protocol
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/libspice-server
   SECTION:=libs


### PR DESCRIPTION
Otherwise a linking error occurs. This is because of the glib2 dependency.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @yousong 
Compile tested: arc700

This package should probably be migrated to meson.