### PR TITLE
syncthing: fixup version detection

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
 PKG_VERSION:=1.3.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
@@ -35,10 +35,11 @@ define Package/syncthing
 endef
 
 GO_PKG_LDFLAGS_X:=\
-	main.Version=v$(PKG_VERSION) \
-	main.BuildUser=openwrt \
-	main.BuildHost=openwrt \
-	main.BuildStamp=$(SOURCE_DATE_EPOCH)
+	github.com/syncthing/syncthing/lib/build.Version=v$(PKG_VERSION) \
+	github.com/syncthing/syncthing/lib/build.Stamp=$(SOURCE_DATE_EPOCH) \
+	github.com/syncthing/syncthing/lib/build.User=openwrt \
+	github.com/syncthing/syncthing/lib/build.Host=openwrt \
+	github.com/syncthing/syncthing/lib/build.Program=syncthing
 
 define Build/Compile
   $(call GoPackage/Build/Compile,-tags noupgrade)


### PR DESCRIPTION
Maintainer: me
Compile tested: x86/64
Run tested: x86/64

Description:
Since upstream commit dc92994 the LDFLAGS used for settings the version
(and build host and user) changed resulting in "unknown" versions in
syncthing.

Correct version detection is important for syncthing to assure
compatibility with other running instances. The "unknown" version fails
to communicate and sync with correctly compiled instances.

This patch updates the syncthing Makefile to inject the correct
variables and thereby fixes the version detection in syncthing.

Signed-off-by: Paul Spooren <mail@aparcar.org>
