### PR TITLE
syncthing: bump to 1.4.0

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
-PKG_VERSION:=1.3.4
-PKG_RELEASE:=3
+PKG_VERSION:=1.4.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
-PKG_HASH:=e40227f67b4317419900353be3f49f381ed36e41044df5d168b850f6b183ae08
+PKG_HASH:=0c45955445752dac43d56bc321fae2140b5b05ad6d41a574ed37813607493edd
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86/64
Run tested: x86/64

Description:
Release information:
https://github.com/syncthing/syncthing/releases/tag/v1.4.0

syncthing v1.4.0 "Fermium Flea" (go1.14 linux-amd64) openwrt@openwrt 2020-03-23 21:31:05 UTC

Signed-off-by: Paul Spooren <mail@aparcar.org>