### PR TITLE
bcm27xx-eeprom: add package for updating RPi bootloader

### DIFF
--- a/utils/bcm27xx-eeprom/Makefile
+++ b/utils/bcm27xx-eeprom/Makefile
@@ -1,0 +1,58 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bcm27xx-eeprom
+PKG_VERSION:=a9ca308223c1d0426b9ab320696b95954078c3b4
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/raspberrypi/rpi-eeprom/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=072dbbd4b53c2c0b5764ff628f63cc8d679a99cfe84d8f50acea06922084515e
+
+PKG_LICENSE:=BSD-3-Clause Custom
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+TAR_OPTIONS:=--strip-components 1 $(TAR_OPTIONS)
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
+
+define Package/bcm27xx-eeprom
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=bcm27xx-userland +blkid +pciutils +python3-light
+  TITLE:=BCM27xx EEPROM tools
+endef
+
+define Package/bcm27xx-eeprom/description
+  BCM27xx EEPROM tools.
+endef
+
+define Build/Compile
+	true
+endef
+
+define Package/bcm27xx-eeprom/conffiles
+/etc/bcm27xx-eeprom.conf
+endef
+
+define Package/bcm27xx-eeprom/install
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/rpi-eeprom-update-default $(1)/etc/bcm27xx-eeprom.conf
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/rpi-eeprom-config $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/rpi-eeprom-update $(1)/usr/bin
+
+	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader
+	$(CP) $(PKG_BUILD_DIR)/firmware/release-notes.md $(1)/lib/firmware/raspberrypi/bootloader
+
+	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader/critical
+	$(CP) $(PKG_BUILD_DIR)/firmware/critical/ $(1)/lib/firmware/raspberrypi/bootloader/
+
+	$(INSTALL_DIR) $(1)/lib/firmware/raspberrypi/bootloader/stable
+	$(CP) $(PKG_BUILD_DIR)/firmware/stable/ $(1)/lib/firmware/raspberrypi/bootloader/
+endef
+
+$(eval $(call BuildPackage,bcm27xx-eeprom))

--- a/utils/bcm27xx-eeprom/patches/0001-rpi-eeprom-update-OpenWrt-defaults.patch
+++ b/utils/bcm27xx-eeprom/patches/0001-rpi-eeprom-update-OpenWrt-defaults.patch
@@ -1,0 +1,48 @@
+From da37f7b051fe6833e25e78184cc9217dd4379187 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Mon, 23 Mar 2020 10:10:55 +0100
+Subject: [PATCH] rpi-eeprom-update: OpenWrt defaults
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ rpi-eeprom-update         | 6 +++---
+ rpi-eeprom-update-default | 5 +++--
+ 2 files changed, 6 insertions(+), 5 deletions(-)
+
+--- a/rpi-eeprom-update
++++ b/rpi-eeprom-update
+@@ -24,14 +24,14 @@ else
+ fi
+ 
+ # May be used to select beta or stable releases instead of the default critical updates.
+-FIRMWARE_RELEASE_STATUS=${FIRMWARE_RELEASE_STATUS:-critical}
++FIRMWARE_RELEASE_STATUS=${FIRMWARE_RELEASE_STATUS:-stable}
+ FIRMWARE_IMAGE_DIR=${FIRMWARE_IMAGE_DIR:-${FIRMWARE_ROOT}/${FIRMWARE_RELEASE_STATUS}}
+-FIRMWARE_BACKUP_DIR=${FIRMWARE_BACKUP_DIR:-/var/lib/raspberrypi/bootloader/backup}
++FIRMWARE_BACKUP_DIR=${FIRMWARE_BACKUP_DIR:-${FIRMWARE_ROOT}/backup}
+ ENABLE_VL805_UPDATES=${ENABLE_VL805_UPDATES:-1}
+ USE_FLASHROM=${USE_FLASHROM:-0}
+ RECOVERY_BIN=${RECOVERY_BIN:-${FIRMWARE_ROOT}/${FIRMWARE_RELEASE_STATUS}/recovery.bin}
+ BOOTFS=${BOOTFS:-/boot}
+-VCMAILBOX=${VCMAILBOX:-/opt/vc/bin/vcmailbox}
++VCMAILBOX=${VCMAILBOX:-/usr/bin/vcmailbox}
+ 
+ EXIT_SUCCESS=0
+ EXIT_UPDATE_REQUIRED=1
+--- a/rpi-eeprom-update-default
++++ b/rpi-eeprom-update-default
+@@ -1,8 +1,9 @@
+ 
+ FIRMWARE_ROOT=/lib/firmware/raspberrypi/bootloader
+-FIRMWARE_RELEASE_STATUS="critical"
++FIRMWARE_RELEASE_STATUS="stable"
+ FIRMWARE_IMAGE_DIR="${FIRMWARE_ROOT}/${FIRMWARE_RELEASE_STATUS}"
+-FIRMWARE_BACKUP_DIR="/var/lib/raspberrypi/bootloader/backup"
++FIRMWARE_BACKUP_DIR="${FIRMWARE_ROOT}/backup"
+ BOOTFS=/boot
+ USE_FLASHROM=0
+ EEPROM_CONFIG_HOOK=
++VCMAILBOX=/usr/bin/vcmailbox

--- a/utils/bcm27xx-eeprom/patches/0002-rpi-eeprom-config-switch-to-Python-3.patch
+++ b/utils/bcm27xx-eeprom/patches/0002-rpi-eeprom-config-switch-to-Python-3.patch
@@ -1,0 +1,21 @@
+From 869a29ec65a0985670a259f4820df4fafc22c971 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Wed, 25 Mar 2020 10:14:34 +0100
+Subject: [PATCH] rpi-eeprom-config: switch to Python 3
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ rpi-eeprom-config | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/rpi-eeprom-config
++++ b/rpi-eeprom-config
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python3
+ 
+ # rpi-eeprom-config
+ # Utility for reading and writing the configuration file in the

--- a/utils/bcm27xx-eeprom/patches/0003-rpi-eeprom-update-change-default-include-path.patch
+++ b/utils/bcm27xx-eeprom/patches/0003-rpi-eeprom-update-change-default-include-path.patch
@@ -1,0 +1,44 @@
+From 6674d49dea0104031b3f54df4c7a356dc4307bb2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Wed, 25 Mar 2020 20:58:35 +0100
+Subject: [PATCH] rpi-eeprom-update: change default include path
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ rpi-eeprom-update | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+--- a/rpi-eeprom-update
++++ b/rpi-eeprom-update
+@@ -6,8 +6,8 @@ set -e
+ 
+ script_dir=$(cd "$(dirname "$0")" && pwd)
+ 
+-if [ -f /etc/default/rpi-eeprom-update ]; then
+-   . /etc/default/rpi-eeprom-update
++if [ -f /etc/bcm27xx-eeprom.conf ]; then
++   . /etc/bcm27xx-eeprom.conf
+ fi
+ 
+ LOCAL_MODE=0
+@@ -323,7 +323,7 @@ The system should then boot normally.
+ 
+ If /boot does not correspond to the boot partition on the sd-card and this
+ is not a NOOBS system then the mount point for BOOTFS should be defined
+-in /etc/default/rpi-eeprom-update by defining the BOOTFS variable.
++in /etc/bcm27xx-eeprom.conf by defining the BOOTFS variable.
+ 
+ A backup of the current EEPROM config file is written to ${FIRMWARE_BACKUP_DIR}
+ before applying the update.
+@@ -345,7 +345,7 @@ Options:
+    -u Install the specified VL805 (USB EEPROM) image file.
+ 
+ Environment:
+-Environment variables should be defined in /etc/default/rpi-eeprom-update
++Environment variables should be defined in /etc/bcm27xx-eeprom.conf
+ 
+ EEPROM_CONFIG_HOOK
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: bcm27xx/bcm2711 Raspberry Pi 4B
Run tested: bcm27xx/bcm2711 Raspberry Pi 4B
Description: add new package for updating Raspberry Pi 4B bootloader.