### PR TITLE
syncthing: configuration cleanup & hardening

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)
@@ -32,6 +32,7 @@ define Package/syncthing
   DEPENDS:=$(GO_ARCH_DEPENDS)
   SECTION:=utils
   CATEGORY:=Utilities
+  USERID:=syncthing:syncthing
 endef
 
 GO_PKG_LDFLAGS_X:=\

--- a/utils/syncthing/files/etc/config/syncthing
+++ b/utils/syncthing/files/etc/config/syncthing
@@ -3,5 +3,24 @@ config syncthing 'syncthing'
 	option enabled '0'
 
 	option gui_address 'http://127.0.0.1:8384'
-	option home '/etc/syncthing/'
+
+	# Use internal flash for evaluation purpouses. Use external storage
+	#   for production.
+	# This filesystem must either support ownership/attributes or
+	#   be readable/writable by the user specified in
+	#   'option user'.
+	# Consult syslog if things go wrong.
+	option home '/etc/syncthing'
+
+	# Changes to "niceness"/macprocs are not picked up by "reload_config"
+	#   nor by "restart": the service has to be stopped/started
+	#   for those to take effect
+	option nice '19'
+
+	# 0 to match the number of CPUs (default)
+	# >0 to explicitly specify concurrency
+	option macprocs '0'
+
+	# Running as 'root' is possible, but not recommended
+	option user 'syncthing'
 

--- a/utils/syncthing/files/etc/init.d/syncthing
+++ b/utils/syncthing/files/etc/init.d/syncthing
@@ -4,29 +4,66 @@ START=90
 STOP=10
 
 USE_PROCD=1
-NICEPRIO=19
 
 PROG=/usr/bin/syncthing
 
+service_triggers()
+{
+  procd_add_reload_trigger "syncthing"
+}
+
 start_service() {
-    [ -d /var/syncthing/ ] || mkdir /var/syncthing/
+  local gui_address home enabled nice macprocs user
+  config_load "syncthing"
 
-    local gui_address home enabled
-    config_load "syncthing"
+  # Some of the default values below might not match the defaults
+  #   in /etc/config/syncthing: the reason is to remain backwards
+  #   compatible with the older versions of this service as it
+  #   evolves.
 
-    # The first version had the service enabled by default,
-    #   so preserving the old behaviour
-    config_get_bool enabled syncthing enabled 1
-    [ "$enabled" -gt 0 ] || return 0
+  config_get_bool enabled syncthing enabled 1
+  [ "$enabled" -gt 0 ] || return 0
 
-    config_get gui_address syncthing gui_address "http://127.0.0.1:8384"
-    config_get home syncthing home "/etc/syncthing/"
+  config_get user syncthing user 'root'
+  config_get gui_address syncthing gui_address "http://127.0.0.1:8384"
+  config_get home syncthing home "/etc/syncthing"
 
-    procd_open_instance
-    procd_set_param command "$PROG"
-    procd_append_param command -gui-address="$gui_address"
-    procd_append_param command -home="$home"
-    procd_set_param respawn
-    procd_set_param nice "$NICEPRIO"
-    procd_close_instance
+  # For backwards compatibility
+  IDX_DB=$(readlink -n "$home"/index-v0.14.0.db)
+  if [ ! -z "$IDX_DB" ]; then
+    [ -d "$IDX_DB" ] || mkdir -p "$IDX_DB"
+
+    # A separate step to handle an upgrade use case
+    [ -d "$IDX_DB" ] && chown -R $user:$user "$IDX_DB"
+  fi
+
+  [ -d "$home" ] || mkdir -p "$home"
+  # A separate step to handle an upgrade use case
+  [ -d "$home" ] && chown -R $user:$user "$home"
+
+  # Changes to "niceness"/macprocs are not picked up by "reload_config"
+  #   nor by "restart": the service has to be stopped/started
+  #   for it to take effect
+  config_get nice syncthing nice "0"
+
+  config_get macprocs syncthing macprocs 0
+  if [ $macprocs -le 0 ]; then
+    # Default to the number of cores in this case
+    macprocs=$(grep -c ^processor /proc/cpuinfo)
+  fi
+
+  procd_open_instance
+  procd_set_param command "$PROG"
+  procd_set_param file /etc/config/syncthing
+  procd_set_param env GOMAXPROCS="$macprocs" STNOUPGRADE=1
+  procd_append_param command -gui-address="$gui_address"
+  procd_append_param command -home="$home"
+  procd_append_param command -no-browser
+  procd_set_param nice "$nice"
+  procd_set_param term_timeout 15
+  procd_set_param user "$user"
+  procd_set_param respawn
+  procd_set_param stdout 1
+  procd_set_param stderr 1
+  procd_close_instance
 }

--- a/utils/syncthing/files/etc/syncthing/index-v0.14.0.db
+++ b/utils/syncthing/files/etc/syncthing/index-v0.14.0.db
@@ -1,1 +1,0 @@
-/var/syncthing/


### PR DESCRIPTION
Maintainer: @aparcar
Compile tested: ipq40xx, ipq806x, x86/64
Run tested: ipq40xx, ipq806x, x86/64

Description:

Run the service under an unprivileged
user account

The following parameters are now configurable
niceness
max concurrency (defaults to number of CPUs)
user

Added flags "-no-browser"
Disabled in-place upgrades (disabled in the
build already)

Redirected stderr/stdout to syslog

Added support for "reload_config"

Increased "term_timeout" to 15s to give it
plenty of time to shut down gracefully

Properly handled non-existing directories

Removed a softlink that assumes a specific naming
convention in syncthing

Added a comment that using external storage is a
recommend configration