### PR TITLE
mini_snmpd: Add sysDescr option

### DIFF
--- a/net/mini_snmpd/files/mini_snmpd.config
+++ b/net/mini_snmpd/files/mini_snmpd.config
@@ -7,6 +7,7 @@ config mini_snmpd 'default'
 	option debug 0
 	# Turn on community authentication (snmp agent must use community name)
 	option auth 0
+	option sysDescr 'OpenWRT'
 	option community 'public'
 	option contact 'OpenWRT router <openwrt@openwrt.org>'
 	option location 'Undisclosed'

--- a/net/mini_snmpd/files/mini_snmpd.init
+++ b/net/mini_snmpd/files/mini_snmpd.init
@@ -34,6 +34,7 @@ mini_snmpd_validation="enabled:bool:0 \
 		ipv6:bool:0 \
 		debug:bool:0 \
 		auth:bool:1 \
+		sysDescr:maxlength(255) \
 		community:rangelength(1,32):public \
 		contact:maxlength(255) \
 		location:maxlength(255) \
@@ -216,6 +217,7 @@ start_instance() {
 	append_arg "-P" $tcp_port
 	append_arg "-V" "$vendor_oid"
 	append_arg "-t" $mib_timeout
+	append_arg "-D" "$sysDescr"
 
 	[ "$ipv6" = 1 ] && procd_append_param command "-6"
 	[ "$debug" = 1 ] && procd_append_param command "-v"


### PR DESCRIPTION


Maintainer: Marcin Jurkowski 
Compile tested: no need, i think
Run tested: it runs for me on `19.07.2 r10947-65030d81f3 / LuCI openwrt-19.07 branch git-20.081.60866-4778aa6` and `mini_snmpd v1.4-rc1`

Description:
Some monitoring tools will run into errors whe sysDescr field is empty. This was the case for cacti1.2.8 that i'm using to monitor my network. Ideally the sysDescr field would contain some information from the overview page of luci, e.g. the Model and Firmware and Kernel-Version fields, but i'm a stranger to openWRT so i'm unable to do that.

What i did do is enable us to set the sysDescr field as a config option to mini_snmpd and populate it with the default value "OpenWRT"