### PR TITLE
nft-qos: swap dependency order

### DIFF
--- a/net/nft-qos/Makefile
+++ b/net/nft-qos/Makefile
@@ -21,7 +21,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/nft-qos
   SECTION:=utils
   CATEGORY:=Base system
-  DEPENDS:=+nftables +kmod-nft-netdev +kmod-nft-bridge
+  DEPENDS:=+kmod-nft-netdev +kmod-nft-bridge +nftables
   TITLE:=QoS scripts over nftables
   PKGARCH:=all
 endef


### PR DESCRIPTION
In preparation for generating nftables-no/json variants, swap dependency
order to prevent following recursive dependency warnings:

tmp/.config-package.in:73879:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:73879:	symbol PACKAGE_luci-app-nft-qos depends on PACKAGE_luci-app-nft-qos
tmp/.config-package.in:854:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:854:	symbol PACKAGE_nft-qos depends on PACKAGE_nft-qos

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
