### PR TITLE
softflowd: fix compilation with newer musl

### DIFF
--- a/net/softflowd/Makefile
+++ b/net/softflowd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=softflowd
 PKG_VERSION:=1.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/irino/softflowd/tar.gz/softflowd-$(PKG_VERSION)?

--- a/net/softflowd/patches/020-uid.patch
+++ b/net/softflowd/patches/020-uid.patch
@@ -1,0 +1,11 @@
+--- a/common.h
++++ b/common.h
+@@ -179,7 +179,7 @@ struct ip6_ext {
+ 
+ /* following lines are copy from unistd.h in Linux for avoidance warnings in compilation */
+ #if defined(HAVE_SETRESGID) && !defined(_GNU_SOURCE)
+-extern int setresgid (__uid_t __ruid, __uid_t __euid, __uid_t __suid);
++extern int setresgid (uid_t __ruid, uid_t __euid, uid_t __suid);
+ #endif
+ #if defined(HAVE_SETRESUID) && !defined(_GNU_SOURCE)
+ extern int setresuid (__uid_t __ruid, __uid_t __euid, __uid_t __suid);


### PR DESCRIPTION
__uid_t is a glibc extension. Switch to standard uid_t.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @rvandegrift 
Compile tested: ath79