### PR TITLE
evtest: fix compilation with newer musl

### DIFF
--- a/utils/evtest/Makefile
+++ b/utils/evtest/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=evtest
 PKG_VERSION:=1.34
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://cgit.freedesktop.org/evtest/snapshot

--- a/utils/evtest/patches/020-Fix-build-on-32bit-arches-with-64bit-time_t.patch
+++ b/utils/evtest/patches/020-Fix-build-on-32bit-arches-with-64bit-time_t.patch
@@ -1,0 +1,43 @@
+From 648f5c1a9e07843e185782d207bc1bcbe6586f6e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 30 Nov 2019 11:58:58 -0800
+Subject: [PATCH] Fix build on 32bit arches with 64bit time_t
+
+time element is deprecated on new input_event structure in kernel's
+input.h [1]
+
+[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=152194fe9c3f
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ evtest.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/evtest.c b/evtest.c
+index be5e42c..d00437f 100644
+--- a/evtest.c
++++ b/evtest.c
+@@ -62,6 +62,11 @@
+ #include <unistd.h>
+ #include <limits.h> /* PATH_MAX */
+ 
++#ifndef input_event_sec
++#define input_event_sec time.tv_sec
++#define input_event_usec time.tv_usec
++#endif
++
+ #define BITS_PER_LONG (sizeof(long) * 8)
+ #define NBITS(x) ((((x)-1)/BITS_PER_LONG)+1)
+ #define OFF(x)  ((x)%BITS_PER_LONG)
+@@ -1141,7 +1146,7 @@ static int print_events(int fd)
+ 			type = ev[i].type;
+ 			code = ev[i].code;
+ 
+-			printf("Event: time %ld.%06ld, ", ev[i].time.tv_sec, ev[i].time.tv_usec);
++			printf("Event: time %ld.%06ld, ", ev[i].input_event_sec, ev[i].input_event_usec);
+ 
+ 			if (type == EV_SYN) {
+ 				if (code == SYN_MT_REPORT)
+-- 
+2.25.1
+


### PR DESCRIPTION
Backported from master.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @psidhu 
Compile tested: ath79