### PR TITLE
libv4l: fix compilation with newer musl

### DIFF
--- a/libs/libv4l/Makefile
+++ b/libs/libv4l/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v4l-utils
 PKG_VERSION:=1.16.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.linuxtv.org/downloads/v4l-utils

--- a/libs/libv4l/patches/040-musl.patch
+++ b/libs/libv4l/patches/040-musl.patch
@@ -1,0 +1,11 @@
+--- a/utils/keytable/keytable.c
++++ b/utils/keytable/keytable.c
+@@ -1686,7 +1686,7 @@ static void test_event(struct rc_device *rc_dev, int fd)
+ 
+ 		for (i = 0; i < rd / sizeof(struct input_event); i++) {
+ 			printf(_("%ld.%06ld: event type %s(0x%02x)"),
+-				ev[i].time.tv_sec, ev[i].time.tv_usec,
++				ev[i].input_event_sec, ev[i].input_event_usec,
+ 				get_event_name(events_type, ev[i].type), ev[i].type);
+ 
+ 			switch (ev[i].type) {


### PR DESCRIPTION
This is using the input_event struct directly, instead of using the proper
defines.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ath79