### PR TITLE
mtdev: update to 1.1.6

### DIFF
--- a/libs/mtdev/Makefile
+++ b/libs/mtdev/Makefile
@@ -8,19 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mtdev
-PKG_VERSION:=1.1.5
+PKG_VERSION:=1.1.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://bitmath.org/code/mtdev/
-PKG_HASH:=6677d5708a7948840de734d8b4675d5980d4561171c5a8e89e54adf7a13eba7f
+PKG_HASH:=15d7b28da8ac71d8bc8c9287c2045fd174267bc740bec10cfda332dc1204e0e0
 
+PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 
-PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Fixes input_event usage.

Removed autoreconf as we're not modifying any files.

Added PKG_BUILD_PARALLEL for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: ath79
