### PR TITLE
port-mirroring: fix compilation under newer musl

### DIFF
--- a/net/port-mirroring/Makefile
+++ b/net/port-mirroring/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=port-mirroring
 PKG_VERSION:=1.4.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mmaraya/port-mirroring/tar.gz/v$(PKG_VERSION)?

--- a/net/port-mirroring/patches/020-time.patch
+++ b/net/port-mirroring/patches/020-time.patch
@@ -1,0 +1,20 @@
+--- a/src/main.c
++++ b/src/main.c
+@@ -252,7 +252,7 @@ void packet_handler_ex(const struct pcap_pkthdr* header, const u_char* pkt_data,
+         if (handle == NULL || pcap_sendpacket(handle, pkt_data, header->len) != 0)
+         {
+             //error detected
+-            long nowTime;
++            time_t nowTime;
+             time(&nowTime);
+             if (nowTime - cfg.init_time > ERRTIMEOUT && header->len < 1500)
+             {
+@@ -282,7 +282,7 @@ void packet_handler_ex(const struct pcap_pkthdr* header, const u_char* pkt_data,
+             if (handle == NULL || pcap_sendpacket(handle, buf, header->len) != 0)
+             {
+                 //error detected
+-                long nowTime;
++                time_t nowTime;
+                 time(&nowTime);
+                 if (nowTime - cfg.init_time > ERRTIMEOUT && header->len < 1500)
+                 {


### PR DESCRIPTION
time_t is 64-bit under 32-bit OSes with version 1.2.0. Fixes wrong pointer
error.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mmaraya 
Compile tested: ath79