### PR TITLE
kismet: fix compilation with libcxx

### DIFF
--- a/net/kismet/Makefile
+++ b/net/kismet/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kismet
 PKG_VERSION:=2016-07-R1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=LGPLv2.1
 PKG_CPE_ID:=cpe:/a:kismet:kismet

--- a/net/kismet/patches/030-libcxx.patch
+++ b/net/kismet/patches/030-libcxx.patch
@@ -1,0 +1,53 @@
+--- a/packetsource_wext.cc
++++ b/packetsource_wext.cc
+@@ -405,7 +405,7 @@ void PacketSource_Wext::OpenWpaSupplicant() {
+ 		wpa_local.sun_family = AF_UNIX;
+ 		snprintf(wpa_local.sun_path, sizeof(wpa_local.sun_path), 
+ 				 "%s", wpa_local_path.c_str());
+-		if (bind(wpa_sock, (struct sockaddr *) &wpa_local, sizeof(wpa_local)) < 0) {
++		if (::bind(wpa_sock, (struct sockaddr *) &wpa_local, sizeof(wpa_local)) < 0) {
+ 			_MSG("Source '" + parent + "' failed to bind local socket for "
+ 				 "wpa_supplicant, disabling scan_wpa: " + string(strerror(errno)),
+ 				 MSGFLAG_PRINTERROR);
+--- a/tcpclient.cc
++++ b/tcpclient.cc
+@@ -75,7 +75,7 @@ int TcpClient::Connect(const char *in_remotehost, short int in_port,
+     local_sock.sin_addr.s_addr = htonl(INADDR_ANY);
+     local_sock.sin_port = htons(0);
+ 
+-    if (bind(cli_fd, (struct sockaddr *) &local_sock, sizeof(local_sock)) < 0) {
++    if (::bind(cli_fd, (struct sockaddr *) &local_sock, sizeof(local_sock)) < 0) {
+         snprintf(errstr, 1024, "TCP client bind() failed: %s", strerror(errno));
+         globalreg->messagebus->InjectMessage(errstr, MSGFLAG_ERROR);
+ 		close(cli_fd);
+@@ -170,7 +170,7 @@ int TcpClient::ConnectSync(const char *in_remotehost, short int in_port,
+     local_sock.sin_addr.s_addr = htonl(INADDR_ANY);
+     local_sock.sin_port = htons(0);
+ 
+-    if (bind(cli_fd, (struct sockaddr *) &local_sock, sizeof(local_sock)) < 0) {
++    if (::bind(cli_fd, (struct sockaddr *) &local_sock, sizeof(local_sock)) < 0) {
+         snprintf(errstr, 1024, "TCP client bind() failed: %s", strerror(errno));
+         globalreg->messagebus->InjectMessage(errstr, MSGFLAG_ERROR);
+ 		close(cli_fd);
+--- a/tcpserver.cc
++++ b/tcpserver.cc
+@@ -84,7 +84,7 @@ int TcpServer::EnableServer() {
+     }
+ 
+     // Bind the socket
+-    if (bind(serv_fd, (struct sockaddr *) &serv_sock, sizeof(serv_sock)) < 0) {
++    if (::bind(serv_fd, (struct sockaddr *) &serv_sock, sizeof(serv_sock)) < 0) {
+         snprintf(errstr, STATUS_MAX, "TCP server bind() failed: %s",
+                  strerror(errno));
+         globalreg->messagebus->InjectMessage(errstr, MSGFLAG_ERROR);
+--- a/unixdomainserver.cc
++++ b/unixdomainserver.cc
+@@ -64,7 +64,7 @@ int UnixDomainServer::EnableServer() {
+     }
+ 
+     // Bind the socket
+-    if (bind(serv_fd, (struct sockaddr *) &serv_sock, sizeof(serv_sock)) < 0) {
++    if (::bind(serv_fd, (struct sockaddr *) &serv_sock, sizeof(serv_sock)) < 0) {
+         _MSG("Unix domain server bind() failed: " + string(strerror(errno)),
+              MSGFLAG_ERROR);
+         return -1;


### PR DESCRIPTION
std::bind is not the same as bind().

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @padre-lacroix 
Compile tested: ath79