### PR TITLE
forked-daapd: fix compilation with newer musl

### DIFF
--- a/sound/forked-daapd/Makefile
+++ b/sound/forked-daapd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=forked-daapd
 PKG_VERSION:=27.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ejurgensen/$(PKG_NAME)/releases/download/$(PKG_VERSION)/

--- a/sound/forked-daapd/patches/010-errno.patch
+++ b/sound/forked-daapd/patches/010-errno.patch
@@ -1,0 +1,10 @@
+--- a/src/websocket.c
++++ b/src/websocket.c
+@@ -25,6 +25,7 @@
+ #ifdef HAVE_PTHREAD_NP_H
+ # include <pthread_np.h>
+ #endif
++#include <errno.h>
+ #include <stdbool.h>
+ #include <stdio.h>
+ #include <string.h>


### PR DESCRIPTION
Needed for errno definition.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @ejurgensen 
Compile tested: ath79