### PR TITLE
zerotier: fix compilation with newer musl

### DIFF
--- a/net/zerotier/Makefile
+++ b/net/zerotier/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zerotier
 PKG_VERSION:=1.4.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/zerotier/ZeroTierOne/tar.gz/$(PKG_VERSION)?

--- a/net/zerotier/patches/020-musl.patch
+++ b/net/zerotier/patches/020-musl.patch
@@ -1,0 +1,25 @@
+--- a/osdep/OSUtils.hpp
++++ b/osdep/OSUtils.hpp
+@@ -37,9 +37,6 @@
+ #include <sys/time.h>
+ #include <sys/stat.h>
+ #include <arpa/inet.h>
+-#ifdef __LINUX__
+-#include <sys/syscall.h>
+-#endif
+ #endif
+ 
+ #ifndef OMIT_JSON_SUPPORT
+@@ -211,11 +208,8 @@ public:
+ 		return (int64_t)( ((tmp.QuadPart - 116444736000000000LL) / 10000L) + st.wMilliseconds );
+ #else
+ 		struct timeval tv;
+-#ifdef __LINUX__
+-		syscall(SYS_gettimeofday,&tv,0); /* fix for musl libc broken gettimeofday bug */
+-#else
+ 		gettimeofday(&tv,(struct timezone *)0);
+-#endif
++
+ 		return ( (1000LL * (int64_t)tv.tv_sec) + (int64_t)(tv.tv_usec / 1000) );
+ #endif
+ 	};


### PR DESCRIPTION
musl 1.2.0 gets rid of this syscall. Just call the function directly. It's
easier.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mwarning 
Compile tested: ath79