### PR TITLE
pdns: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/pdns/Makefile
+++ b/net/pdns/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns
 PKG_VERSION:=4.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/

--- a/net/pdns/patches/200-openssl-deprecated.patch
+++ b/net/pdns/patches/200-openssl-deprecated.patch
@@ -1,0 +1,20 @@
+--- a/pdns/opensslsigners.cc
++++ b/pdns/opensslsigners.cc
+@@ -29,6 +29,7 @@
+ #if defined(HAVE_LIBCRYPTO_ED25519) || defined(HAVE_LIBCRYPTO_ED448)
+ #include <openssl/evp.h>
+ #endif
++#include <openssl/bn.h>
+ #include <openssl/sha.h>
+ #include <openssl/rand.h>
+ #include <openssl/rsa.h>
+--- a/pdns/pkcs11signers.cc
++++ b/pdns/pkcs11signers.cc
+@@ -15,6 +15,7 @@
+ #include "pdns/lock.hh"
+ 
+ #ifdef HAVE_LIBCRYPTO_ECDSA
++#include <openssl/bn.h>
+ #include <openssl/ec.h>
+ #endif
+ 


### PR DESCRIPTION
The bn.h header is missing.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @James-TR 
Compile tested: ath79