### PR TITLE
miniupnpd: fix sh syntax error

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.1.20191006
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -78,6 +78,7 @@ upnpd() {
 	config_get serial_number config serial_number
 	config_get model_number config model_number
 	config_get uuid config uuid
+	config_get use_stun config use_stun 0
 	config_get stun_host config stun_host
 	config_get stun_port config stun_port
 	config_get notify_interval config notify_interval


### PR DESCRIPTION
Add "use_stun" default to prevent sh: out of range error introduced by
c61614a84

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
