### PR TITLE
prosody: /etc/prosody owner fix

### DIFF
--- a/net/prosody/Makefile
+++ b/net/prosody/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prosody
 PKG_VERSION:=0.11.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://prosody.im/downloads/source

--- a/net/prosody/files/prosody.init
+++ b/net/prosody/files/prosody.init
@@ -23,7 +23,8 @@ start_service() {
 	}
 
 	[ -d /var/log/prosody ] && {
-		chown -R prosody:prosody /etc/prosody
+		chown -R root:prosody /etc/prosody
+		chown -R prosody:prosody /etc/prosody/data
 	}
 
 	[ -f /sbin/paxctl ] && {


### PR DESCRIPTION
Signed-off-by: Sergio E. Nemirowski <sergio@outerface.net>

Description: configuration must not be service writable, it's a security issue.