### PR TITLE
libhttp-parser: update to v2.9.4

### DIFF
--- a/libs/libhttp-parser/Makefile
+++ b/libs/libhttp-parser/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libhttp-parser
-PKG_VERSION:=2.9.3
+PKG_VERSION:=2.9.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/nodejs/http-parser/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=8fa0ab8770fd8425a9b431fdbf91623c4d7a9cdb842b9339289bd2b0b01b0d3d
+PKG_HASH:=467b9e30fd0979ee301065e70f637d525c28193449e1b13fbcb1b1fab3ad224f
 PKG_BUILD_DIR:=$(BUILD_DIR)/http-parser-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Ramanathan Sivagurunathan <ramzthecoder@gmail.com>, Hirokazu MORIKAWA <morikw2@gmail.com>

--- a/libs/libhttp-parser/patches/000-fix_darwin_error.patch
+++ b/libs/libhttp-parser/patches/000-fix_darwin_error.patch
@@ -3,7 +3,7 @@
 @@ -25,11 +25,7 @@
  SOMAJOR = 2
  SOMINOR = 9
- SOREV   = 3
+ SOREV   = 4
 -ifeq (darwin,$(PLATFORM))
 -SOEXT ?= dylib
 -SONAME ?= $(SOLIBNAME).$(SOMAJOR).$(SOMINOR).$(SOEXT)


### PR DESCRIPTION
Maintainer: @ageekymonk, me
 Compile tested: head r12792-b74386a, x86_64 
Run tested: x86_64 (VirtualBox)

Description: 
update to v2.9.4

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
