### PR TITLE
python-pytest: add new package

### DIFF
--- a/lang/python/python-pytest/Makefile
+++ b/lang/python/python-pytest/Makefile
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-pytest
+PKG_VERSION:=5.4.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=pytest
+PKG_HASH:=84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=setuptools-scm
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-pytest
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Python testing framework
+  URL:=https://docs.pytest.org/en/latest/
+  DEPENDS:= \
+	+python3-light \
+	+python3-more-itertools \
+	+python3-py \
+	+python3-attrs \
+	+python3-pluggy \
+	+python3-packaging \
+	+python3-wcwidth \
+	+python3-decimal \
+	+python3-logging \
+	+python3-urllib
+
+  VARIANT:=python3
+endef
+
+define Package/python3-pytest/description
+  The pytest framework makes it easy to write small tests, yet scales to support
+  complex functional testing for applications and libraries.
+endef
+
+$(eval $(call Py3Package,python3-pytest))
+$(eval $(call BuildPackage,python3-pytest))
+$(eval $(call BuildPackage,python3-pytest-src))


### PR DESCRIPTION
Maintainer: me 
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
This PR adds pytest package. It's related to https://github.com/openwrt/packages/pull/8562, because all packages were separated into special PRs.

It could be merged after https://github.com/openwrt/packages/pull/10449 and ~~https://github.com/openwrt/packages/pull/11664~~
