### PR TITLE
wifidog-ng: Update to 2.0.2

### DIFF
--- a/net/wifidog-ng/Makefile
+++ b/net/wifidog-ng/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifidog-ng
-PKG_VERSION:=2.0.1
+PKG_VERSION:=2.0.2
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)
@@ -16,7 +16,7 @@ PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_MAINTAINER:=Jianhui Zhao <jianhuizhao329@gmail.com>
+PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/wifidog-ng/src/config.h
+++ b/net/wifidog-ng/src/config.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 jianhui zhao <jianhuizhao329@gmail.com>
+ *  Copyright (C) 2017 jianhui zhao <zhaojh329@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as

--- a/net/wifidog-ng/src/utils.h
+++ b/net/wifidog-ng/src/utils.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017 jianhui zhao <jianhuizhao329@gmail.com>
+ *  Copyright (C) 2017 jianhui zhao <zhaojh329@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License version 2 as


### PR DESCRIPTION
Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>

Maintainer: me
Compile tested: (mipsel,miwifi-mini, master)
Run tested: (mipsel,miwifi-mini, master)

Description: Compatible with Linux kernel 5.3 and above
