### PR TITLE
 [openwrt-19.07] haproxy: Update HAProxy to v2.0.14

### DIFF
--- a/net/haproxy/Makefile
+++ b/net/haproxy/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=haproxy
-PKG_VERSION:=2.0.13
+PKG_VERSION:=2.0.14
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.haproxy.org/download/2.0/src
-PKG_HASH:=21f932ae18131ad58cb2f9d7cf2338349b6ccf3f5c33382624bbf1d3760b9be1
+PKG_HASH:=552a708b8b6efd0f241f5d9fd7ad4168d37ce17cdb6dcb6239c2e519f0a63c75
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \

--- a/net/haproxy/get-latest-patches.sh
+++ b/net/haproxy/get-latest-patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CLONEURL=https://git.haproxy.org/git/haproxy-2.0.git
-BASE_TAG=v2.0.13
+BASE_TAG=v2.0.14
 TMP_REPODIR=tmprepo
 PATCHESDIR=patches
 

--- a/net/haproxy/patches/000-BUG-MINOR-protocol_buffer-Wrong-maximum-shifting.patch
+++ b/net/haproxy/patches/000-BUG-MINOR-protocol_buffer-Wrong-maximum-shifting.patch
@@ -1,0 +1,58 @@
+commit 41bf8a4314953769a11b0c09cbac8cc194e3923a
+Author: Frédéric Lécaille <flecaille@haproxy.com>
+Date:   Thu Apr 2 14:24:31 2020 +0200
+
+    BUG/MINOR: protocol_buffer: Wrong maximum shifting.
+    
+    This patch fixes a bad stop condition when decoding a protocol buffer variable integer
+    whose maximum lenghts are 10, shifting a uint64_t value by more than 63.
+    
+    Thank you to Ilya for having reported this issue.
+    
+    Must be backported to 2.1 and 2.0.
+    
+    (cherry picked from commit 876ed55d9b8d0c298b6cac1003ec365a19bf7aad)
+    Signed-off-by: Willy Tarreau <w@1wt.eu>
+    (cherry picked from commit c7a203a6c75e4efff5f3d5d675d925f11b47dba1)
+    Signed-off-by: Willy Tarreau <w@1wt.eu>
+
+diff --git a/include/proto/protocol_buffers.h b/include/proto/protocol_buffers.h
+index 69f0bdf8..0426d83d 100644
+--- a/include/proto/protocol_buffers.h
++++ b/include/proto/protocol_buffers.h
+@@ -158,7 +158,7 @@ protobuf_varint(uint64_t *val, unsigned char *pos, size_t len)
+ 
+ 		shift += 7;
+ 		/* The maximum length in bytes of a 64-bit encoded value is 10. */
+-		if (shift > 70)
++		if (shift > 63)
+ 			return 0;
+ 	}
+ 
+@@ -194,7 +194,7 @@ protobuf_decode_varint(uint64_t *val, unsigned char **pos, size_t *len)
+ 
+ 		shift += 7;
+ 		/* The maximum length in bytes of a 64-bit encoded value is 10. */
+-		if (shift > 70)
++		if (shift > 63)
+ 			return 0;
+ 	}
+ 
+@@ -227,7 +227,7 @@ protobuf_skip_varint(unsigned char **pos, size_t *len, size_t vlen)
+ 
+ 		shift += 7;
+ 		/* The maximum length in bytes of a 64-bit encoded value is 10. */
+-		if (shift > 70)
++		if (shift > 63)
+ 			return 0;
+ 	}
+ 
+@@ -263,7 +263,7 @@ protobuf_varint_getlen(unsigned char *pos, size_t len)
+ 
+ 		shift += 7;
+ 		/* The maximum length in bytes of a 64-bit encoded value is 10. */
+-		if (shift > 70)
++		if (shift > 63)
+ 			return -1;
+ 	}
+ 

--- a/net/haproxy/patches/001-OPENWRT-add-uclibc-support.patch
+++ b/net/haproxy/patches/001-OPENWRT-add-uclibc-support.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -334,6 +334,15 @@ ifeq ($(TARGET),linux-glibc)
+@@ -337,6 +337,15 @@ ifeq ($(TARGET),linux-glibc)
      USE_ACCEPT4 USE_LINUX_SPLICE USE_PRCTL USE_THREAD_DUMP USE_GETADDRINFO)
  endif
  


### PR DESCRIPTION
Maintainer: Thomas Heil <heil@terminal-consulting.de>, Christian Lachner <gladiac@gmail.com>
Compile tested: mips, ipq806x, x86
Run tested: ipq806x (r7800)

Description: Update HAProxy to v2.0.14
- Update haproxy download URL and hash
- Add new patches (see https://www.haproxy.org/bugs/bugs-2.0.14.html)
- This fixes CVE-2020-11100 (http://git.haproxy.org/?p=haproxy-2.0.git;a=commit;h=b9cac598021e2b0d4ae2cfecf9825a3469328093)