### PR TITLE
yggdrasil: bump to 0.3.14

### DIFF
--- a/net/yggdrasil/Makefile
+++ b/net/yggdrasil/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yggdrasil
-PKG_VERSION:=0.3.13
+PKG_VERSION:=0.3.14
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=ba2149024152c4df65e68722e7d4d1050fec71907904a7bdf9757159d94cd83d
+PKG_HASH:=e8579a04bf289434e7b8caaf621e2c0b853e83cc06f136c4f9e4bfc667df5a27
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-go-$(PKG_VERSION)
 
 PKG_MAINTAINER:=William Fleurant <meshnet@protonmail.com>


### PR DESCRIPTION
Signed-off-by: George Iv <zhoreeq@users.noreply.github.com>

Maintainer: @wfleurant 
Compile tested: arm, Raspberry Pi 3B, openwrt trunk
Run tested: arm, Raspberry Pi 3B, openwrt trunk

Description:
bump version