### PR TITLE
libgd: fix pkgconfig file

### DIFF
--- a/libs/libgd/Makefile
+++ b/libs/libgd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libgd
 PKG_VERSION:=2.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/gd-$(PKG_VERSION)/
@@ -20,7 +20,6 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:libgd:libgd
 
-CMAKE_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -109,6 +108,12 @@ else
 endif
 
 endif
+
+define Build/InstallDev
+	$(call Build/InstallDev/cmake,$(1))
+	$(SED) 's,/usr/lib,$(STAGING_DIR)/usr/lib,g' $(1)/usr/lib/pkgconfig/gdlib.pc
+	$(SED) 's,/usr/include,$(STAGING_DIR)/include,g' $(1)/usr/lib/pkgconfig/gdlib.pc
+endef
 
 define Package/libgd/install
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
The wrong paths are specified, causing failures with depending packages
that use pkgconfig.

Removed CMAKE_INSTALL as a result. No point when InstallDev is explicit.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jow- 
Compile tested: ath779

ping @hnyman 