### PR TITLE
boinc: new package for distributed computing/data acquisition

### DIFF
--- a/net/boinc/Makefile
+++ b/net/boinc/Makefile
@@ -1,0 +1,82 @@
+# Copyright 2020 by Christian Dreihsig and Steffen Möller
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=boinc
+PKG_VERSION:=7.16.5
+PKG_VERSION_SHORT:=$(shell echo $(PKG_VERSION)| cut -f1,2 -d.)
+PKG_RELEASE:=1
+
+PKG_SOURCE_DATE:=2020-02-25
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/BOINC/boinc/tar.gz/client_release/$(PKG_VERSION_SHORT)/$(PKG_VERSION)?
+PKG_HASH:=33db60991b253e717c6124cce4750ae7729eaab4e54ec718b9e37f87012d668a
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-client_release-$(PKG_VERSION_SHORT)-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Christian Dreihsig <christian.dreihsig@t-online.de>, Steffen Moeller <moeller@debian.org>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:boinc_project:boinc
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=0
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/target.mk
+
+define Package/boinc
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=BOINC client
+  DEPENDS:=+curl +bzip2 +libstdcpp +libopenssl +zlib
+  USERID:=boinc:boinc
+  URL:=https://github.com/BOINC/boinc/
+endef
+
+define Package/boinc/description
+  The Berkeley Open Infrastructure for Network Computing (BOINC) is a
+  software platform for distributed computing: several initiatives of
+  various scientific disciplines all compete for the idle time of
+  desktop computers. The developers' web site at the University of
+  Berkeley serves as a common portal to the otherwise independently run
+  projects.
+ 
+  This package provides the BOINC core client program that is
+  required to participate in any project that uses BOINC to control what
+  projects to join and to determine constraints for the computation
+  like the percentage of CPU time. OpenWrt does not
+  provide the graphical BOINC Manager, but you can connect to this
+  machine from the BOINC Manager of your desktop computer.
+endef
+
+CONFIGURE_ARGS += \
+	--disable-server --disable-manager --enable-client --enable-libraries \
+	--disable-boinczip --enable-install-headers --enable-dynamic-client-linkage \
+	--with-boinc-platform=$(REAL_GNU_TARGET_NAME) \
+	--with-boinc-alt-platform=$(ARCH)-$(BOARD)-$(DEVICE_TYPE)-openwrt-$(TARGET_SUFFIX)
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/boinc
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/boinc/* $(1)/usr/include/boinc/
+	$(CP) $(PKG_BUILD_DIR)/*.h $(1)/usr/include/boinc/ # project_specific_defines.h, config.h, version.h, svn_version.h
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.a $(1)/usr/lib/
+endef
+
+define Package/boinc/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.{la,so}* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/boinc-client.init $(1)/etc/init.d/boinc-client
+	$(INSTALL_DIR) $(1)/opt/boinc
+	$(CP) ./files/global_prefs_override.xml $(1)/opt/boinc/global_prefs_override.xml
+	$(CP) ./files/remote_hosts.cfg $(1)/opt/boinc/remote_hosts.cfg
+endef
+
+$(eval $(call BuildPackage,boinc))

--- a/net/boinc/files/boinc-client.init
+++ b/net/boinc/files/boinc-client.init
@@ -1,0 +1,44 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+BOINCEXE_NAME=boinc_client
+BOINCDIR=/opt/boinc/
+BOINCUSR=boinc
+BOINCEXE_OPTS="--check_all_logins --redirectio --dir $BOINCDIR"
+PID_FILE="var/run/$BOINCEXE_NAME.pid"
+
+start_service() {
+   # First Check that BOINCDIR exists...
+   if ! [ -d "$BOINCDIR" ]; then
+      if ! mkdir -p $BOINCDIR 2>/dev/null ; then
+         echo "ERROR: $BOINCDIR doesn't exist and couldn't be created"
+         return 1
+      fi
+   fi
+
+   # ... and that it is accessible by boinc
+   BOINCDIR_OWNER="$(ls -ld $BOINCDIR | awk '{print $3}')"
+   if [ "$BOINCUSR" != "$BOINCDIR_OWNER" ] ; then
+      chown -R $BOINCUSR:$BOINCUSR $BOINCDIR
+      BOINCDIR_OWNER="$(ls -ld $BOINCDIR | awk '{print $3}')"
+
+      if [ "$BOINCUSR" != "$BOINCDIR_OWNER" ] ; then
+         echo "User boinc can't access $BOINC_DIR"
+         return 3
+      fi
+   fi
+
+   # now use procd to start boinc
+   procd_open_instance $BOINCEXE_NAME
+
+   procd_set_param command $BOINCEXE_NAME
+   procd_append_param command $BOINCEXE_OPTS
+   procd_set_param user $BOINCUSR
+   procd_set_param limits core="unlimited"
+   procd_set_param stdout 1
+   procd_set_param stderr 1
+   procd_set_param pidfile $PID_FILE
+
+   procd_close_instance
+}

--- a/net/boinc/files/global_prefs_override.xml
+++ b/net/boinc/files/global_prefs_override.xml
@@ -1,0 +1,4 @@
+<global_preferences>
+   <max_ncpus_pct>50.000000</max_ncpus_pct>
+   <disk_interval>21600.000000</disk_interval>
+<global_preferences>

--- a/net/boinc/files/remote_hosts.cfg
+++ b/net/boinc/files/remote_hosts.cfg
@@ -1,0 +1,8 @@
+# This file contains a list of hostnames or IP addresses (one per line)
+# of remote hosts, that are allowed to connect and to control the local
+# BOINC core client via GUI RPCs.
+# Lines beginning with a # or a ; are treated like comments and will be
+# ignored.
+#
+#host.example.com
+#192.168.0.180


### PR DESCRIPTION
Signed-off-by: Christian Dreihsig <christian.dreihsig@t-online.de>

Maintainer: @VolunteerComputingHelp (@n30dg @smoe)
Compile tested:  x86, x86_64, OpenWrt master
Run tested: x86_64; arm/mvebu

Description:
"The 'Berkeley Open Infrastructure for Network Computing' (https://boinc.berkeley.edu, https://github.com/BOINC/boinc) is an established infrastructure for volunteer distributed computing. Besides computation, some projects use sensors for radioactivity or movement to integrate geographically distributed insights. BOINC, combined with the enormous span of computational power of OpenWrt-supported devices, their small energy footprint, vicinity to hardware and their typical 24/7 operation may help to further the development of distributed volunteer computing towards the edge. We have one established BOINC project as a start with whom we are evaluating the rate of adoption of OpenWrt as a basis for BOINC with more to come.

We are a team of two for the OpenWrt packaging of BOINC, extending the effort one of us has invested in the packaging of BOINC for Debian. Other than for Debian, there will be only the command line interface for OpenWrt. To help registering with projects, we will develop an interface with Luci. This will likely also help to direct users to projects that are feasible to run on the respective platform."
