### PR TITLE
openssh: update to 8.2p1

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -8,14 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
-PKG_VERSION:=8.1p1
+PKG_VERSION:=8.2p1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
-		https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/ \
-		https://anorien.csc.warwick.ac.uk/pub/OpenBSD/OpenSSH/portable/
-PKG_HASH:=02f5dbef3835d0753556f973cd57b4c19b6b1f6cd24c03445e23ac77ca1b93ff
+		https://ftp.spline.de/pub/OpenBSD/OpenSSH/portable/
+PKG_HASH:=43925151e6cf6cee1450190c0e9af4dc36b41c12737619edff8bcebdff64e671
 
 PKG_LICENSE:=BSD ISC
 PKG_LICENSE_FILES:=LICENCE


### PR DESCRIPTION
Signed-off-by: Sibren Vasse <github@sibrenvasse.nl>

Maintainer: @tripolar
Compile tested: tp-link archer c7 v2 / ath79 / master
Run tested: tp-link archer c7 v2 / ath79 / master

- Server running and accepting connections
- Client connecting to servers

Description:
Version bump to 8.2p1. Removal of inactive mirror.