### PR TITLE
[18.06] msmtp: update to version 1.8.7

### DIFF
--- a/mail/msmtp/Makefile
+++ b/mail/msmtp/Makefile
@@ -9,16 +9,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=msmtp
-PKG_VERSION:=1.6.6
+PKG_VERSION:=1.8.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@SF/msmtp
-PKG_HASH:=da15db1f62bd0201fce5310adb89c86188be91cd745b7cb3b62b81a501e7fb5e
+PKG_SOURCE_URL:=https://marlam.de/msmtp/releases
+PKG_HASH:=9a53bcdc244ec5b1a806934ecc7746d9d09db581f587bedf597e9da2f48c51f1
 
-PKG_LICENSE:=GPL-3.0+
-PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Nicolas Thill <nico@openwrt.org>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:marlam:msmt
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -33,7 +34,7 @@ define Package/msmtp/Default
   CATEGORY:=Mail
   DEPENDS:=$(INTL_DEPENDS)
   TITLE:=Simple sendmail SMTP forwarding
-  URL:=http://msmtp.sourceforge.net/
+  URL:=https://marlam.de/msmtp/
 endef
 
 define Package/msmtp/Default/description
@@ -46,7 +47,7 @@ endef
 
 define Package/msmtp
 $(call Package/msmtp/Default)
-  DEPENDS+= +libopenssl +ca-bundle
+  DEPENDS+= +libgnutls +ca-bundle
   TITLE+= (with SSL support)
   VARIANT:=ssl
 endef
@@ -110,12 +111,12 @@ MAKE_FLAGS :=
 
 ifeq ($(BUILD_VARIANT),ssl)
 	CONFIGURE_ARGS += \
-		--with-tls=openssl
+		--with-tls=gnutls
 endif
 
 ifeq ($(BUILD_VARIANT),nossl)
 	CONFIGURE_ARGS += \
-		--with-tls=no
+		--without-tls
 endif
 
 define Package/msmtp/install


### PR DESCRIPTION
Maintainer: @nicolas-thill  and in the master @neheb was using it.
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 18.06

Description:
- It brings oauthbearer support
- It switches from OpenSSL to GnuTLS, which is fully compatible and
  brings more parameters

Makefile changes:
- Fix SPDX License Identifier
- Add PKG_CPE_ID
- The Project does not use sourceforce anymore.
- Uses GnuTLS instead of OpenSSL, which was discouraged

https://marlam.de/msmtp/news/openssl-discouraged/

Proof of run test:
```
root@omnia:~# msmtp --version
msmtp version 1.6.6
Platform: arm-openwrt-linux-gnu
TLS/SSL library: OpenSSL
Authentication library: built-in
Supported authentication methods:
plain external cram-md5 login 
IDN support: disabled
NLS: enabled, LOCALEDIR is /usr/share/locale
Keyring support: none
System configuration file name: /etc/msmtprc
User configuration file name: /root/.msmtprc

Copyright (C) 2016 Martin Lambers and others.
This is free software.  You may redistribute copies of it under the terms of
the GNU General Public License <http://www.gnu.org/licenses/gpl.html>.
There is NO WARRANTY, to the extent permitted by law.
root@omnia:~# opkg install msmtp_1.8.7-1_arm_cortex-a9_vfpv3.ipk 
Upgrading msmtp on root from 1.6.6-1.36 to 1.8.7-1...
Configuring msmtp.
root@omnia:~# msmtp --version
msmtp version 1.8.7
Platform: arm-openwrt-linux-gnu
TLS/SSL library: GnuTLS
Authentication library: built-in
Supported authentication methods:
plain external cram-md5 login oauthbearer 
IDN support: disabled
NLS: enabled, LOCALEDIR is /usr/share/locale
Keyring support: none
System configuration file name: /etc/msmtprc
User configuration file name: /root/.msmtprc

Copyright (C) 2019 Martin Lambers and others.
This is free software.  You may redistribute copies of it under the terms of
the GNU General Public License <http://www.gnu.org/licenses/gpl.html>.
There is NO WARRANTY, to the extent permitted by law.
root@omnia:~# 
```

Sending e-mails to gmail works.

Fixes #11547