### PR TITLE
netifyd: fix compilation with libcxx

### DIFF
--- a/net/netifyd/Makefile
+++ b/net/netifyd/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifyd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Darryl Sokoloski <darryl@egloo.ca>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/netifyd/patches/010-bind.patch
+++ b/net/netifyd/patches/010-bind.patch
@@ -1,0 +1,11 @@
+--- a/src/nd-netlink.cpp
++++ b/src/nd-netlink.cpp
+@@ -144,7 +144,7 @@ ndNetlink::ndNetlink(const nd_ifaces &ifaces)
+         throw ndNetlinkException(strerror(rc));
+     }
+ 
+-    if (bind(nd,
++    if (::bind(nd,
+         (struct sockaddr *)&sa, sizeof(struct sockaddr_nl)) < 0) {
+         rc = errno;
+         nd_printf("Error binding netlink socket: %s\n", strerror(rc));


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dsokoloski 
Compile tested: ath79

This is already upstream, before anyone asks.