### PR TITLE
wget: make the ssl variant provides wget-ssl 

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme
 PKG_VERSION:=2.8.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/Neilpang/acme.sh/tar.gz/$(PKG_VERSION)?
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/acme
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+gnu-wget +ca-bundle +openssl-util +socat
+  DEPENDS:=+wget-ssl +ca-bundle +openssl-util +socat
   TITLE:=ACME (Letsencrypt) client
   URL:=https://acme.sh
   PKGARCH:=all

--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.20.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -46,6 +46,7 @@ $(call Package/wget/Default)
   DEPENDS+= +libopenssl +librt
   TITLE+= (with SSL support)
   VARIANT:=ssl
+  PROVIDES+=wget-ssl
   ALTERNATIVES:=300:/usr/bin/wget:/usr/bin/wget-ssl
 endef
 


### PR DESCRIPTION
Maintainer: wget @tripolar , acme @tohojo
Compile tested: n/a
Run tested: n/a

Description:


wget: make the ssl variant provides wget-ssl

This is to address the need for specifying dependency on a wget
implementation with ssl support.

Now we have a game of names for opkg

 1. uclient-fetch: minimal version by openwrt project
 2. wget-nossl: gnu wget w/o ssl support
 3. wget-ssl: for the moment since this commit, gnu wget w/ ssl support
 4. wget: uclient-fetch, wget-nossl, or wget-ssl
 5. gnu-wget: wget-nossl or wget-ssl

By the time we provide some dummy package like uclient-fetch-ssl and
make it also provide wget-ssl, I guess by then we will also need
gnu-wget-ssl...

Ref: https://github.com/openwrt/packages/issues/11534
Ref: https://github.com/openwrt/packages/pull/9941
Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
