### PR TITLE
transmission: add init file STOP directive

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=2.94
-PKG_RELEASE:=15
+PKG_RELEASE:=16
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -2,6 +2,7 @@
 # Copyright (C) 2010-2015 OpenWrt.org
 
 START=99
+STOP=10
 USE_PROCD=1
 PROG="/usr/bin/transmission-daemon"
 


### PR DESCRIPTION
Signed-off-by: Francesco G <francg@idi.ntnu.no>

Maintainer: @dangowrt @neheb 

Description:
Transmission should stop early on system shutdown to avoid critical services being _pulled_ out from below when still active.
For example filesystems can be unmounted before transmission is stopped, exposing to corrupted data (happened to me).

A similar strategy (start late, stop early) is already used by other packages like mysql/mariadb:

https://github.com/openwrt/packages/blob/2d16c6fc57cc890ece010eb538461b79189df5a8/utils/mariadb/files/mysqld.init#L1-L5
