### PR TITLE
sane-backends: use "tristate" instead of "prompt"

### DIFF
--- a/utils/sane-backends/Makefile
+++ b/utils/sane-backends/Makefile
@@ -55,7 +55,7 @@ define Package/sane-backends/config
 
     config PACKAGE_sane-backends-all
       depends on PACKAGE_sane-backends
-      prompt "Include all SANE backends (sane-backends-all)"
+      tristate "Include all SANE backends (sane-backends-all)"
 
     comment "Backends"
 
@@ -65,7 +65,7 @@ $(foreach backend,$(SANE_BACKENDS), \
       $(call Package/sane-$(backend))
     )\
     config PACKAGE_sane-$(backend)
-      prompt "$(TITLE)"
+      tristate "$(TITLE)"
      $(foreach config_dep,\
        $(filter @%,
          $(foreach v, $(DEPENDS), $(if $(findstring :,$v),,$v))


### PR DESCRIPTION

Maintainer: @luizluca 
Compile tested: mvebu, openwrt master
Run tested: N/A - no change in final package

Description:
Remove "prompt" command, dropped in kconfig-v5.6, from
Package/sane-backends/config, replacing it with "tristate".  This does
not affect the generated package.

Sorry, I forgot to send this PR earlier.  I've just sent a patch to the ML to update the config to v5.6, so this needs to be changed.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
