### PR TITLE
libupnp: do not use usleep

### DIFF
--- a/libs/libupnp/Makefile
+++ b/libs/libupnp/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libupnp
 PKG_VERSION:=1.8.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/pupnp

--- a/libs/libupnp/patches/010-Do-not-use-usleep-when-using-newer-POSIX-C-source.patch
+++ b/libs/libupnp/patches/010-Do-not-use-usleep-when-using-newer-POSIX-C-source.patch
@@ -1,0 +1,60 @@
+From a346a4d0d732fdca306283c18b404679bbf40427 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Fri, 3 Apr 2020 17:51:45 -0700
+Subject: [PATCH] Do not use usleep when using newer POSIX C source.
+
+usleep is deprecated and is optionally unavailable with uClibc-ng.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+(cherry picked from commit c91d82a7b74df3a08de2f94a1ec2a75a7803b6bd)
+---
+ upnp/inc/ithread.h                      | 10 +++++++++-
+ upnp/src/genlib/miniserver/miniserver.c |  4 ++--
+ 2 files changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/upnp/inc/ithread.h b/upnp/inc/ithread.h
+index 38aad3f..cc76440 100644
+--- a/upnp/inc/ithread.h
++++ b/upnp/inc/ithread.h
+@@ -928,7 +928,15 @@ static UPNP_INLINE int ithread_cleanup_thread(void) {
+ #ifdef _WIN32
+ 	#define imillisleep Sleep
+ #else
+-	#define imillisleep(x) usleep(1000*x)
++#if _POSIX_C_SOURCE < 200809L
++	#define imillisleep(x) usleep(1000 * x)
++#else
++	#define imillisleep(x) \
++		do { \
++			const struct timespec req = {0, x * 1000 * 1000}; \
++			nanosleep(&req, NULL); \
++		} while(0)
++#endif
+ #endif
+ 
+ 
+diff --git a/upnp/src/genlib/miniserver/miniserver.c b/upnp/src/genlib/miniserver/miniserver.c
+index 9251d5b..31babd0 100644
+--- a/upnp/src/genlib/miniserver/miniserver.c
++++ b/upnp/src/genlib/miniserver/miniserver.c
+@@ -905,7 +905,7 @@ int StartMiniServer(
+ 	count = 0;
+ 	while (gMServState != (MiniServerState)MSERV_RUNNING && count < max_count) {
+ 		/* 0.05s */
+-		usleep(50u * 1000u);
++		imillisleep(50);
+ 		count++;
+ 	}
+ 	if (count >= max_count) {
+@@ -960,7 +960,7 @@ int StopMiniServer()
+ 		ssdpAddr.sin_port = htons(miniStopSockPort);
+ 		sendto(sock, buf, bufLen, 0,
+ 			(struct sockaddr *)&ssdpAddr, socklen);
+-		usleep(1000u);
++		imillisleep(1);
+ 		if (gMServState == (MiniServerState)MSERV_IDLE) {
+ 			break;
+ 		}
+-- 
+2.25.1
+


### PR DESCRIPTION
Deprecated and optionally unavailable under uClibc-ng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ath79

Upstream backport: https://github.com/pupnp/pupnp/pull/164