### PR TITLE
libv4l: fix compilation under kernel 4.14

### DIFF
--- a/libs/libv4l/Makefile
+++ b/libs/libv4l/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v4l-utils
 PKG_VERSION:=1.16.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.linuxtv.org/downloads/v4l-utils

--- a/libs/libv4l/patches/050-4.14.patch
+++ b/libs/libv4l/patches/050-4.14.patch
@@ -1,0 +1,13 @@
+--- a/utils/keytable/keytable.c
++++ b/utils/keytable/keytable.c
+@@ -61,6 +61,10 @@ struct input_keymap_entry_v2 {
+ 	u_int8_t  scancode[32];
+ };
+ 
++#ifndef input_event_sec
++#define input_event_sec time.tv_sec
++#define input_event_usec time.tv_usec
++#endif
+ 
+ #define IR_PROTOCOLS_USER_DIR IR_KEYTABLE_USER_DIR "/protocols"
+ #define IR_PROTOCOLS_SYSTEM_DIR IR_KEYTABLE_SYSTEM_DIR "/protocols"


### PR DESCRIPTION
The last patch used a macro unavailable with older kernel headers.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: arc700

Fixes: https://downloads.openwrt.org/snapshots/faillogs/arc_arc700/packages/libv4l/compile.txt