### PR TITLE
libshout: don't use usleep

### DIFF
--- a/libs/libshout/Makefile
+++ b/libs/libshout/Makefile
@@ -7,14 +7,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libshout
 PKG_VERSION:=2.4.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.us.xiph.org/releases/libshout/
 PKG_HASH:=0d8af55d1141bf90710bcd41a768c9cc5adb251502a0af1dd22c8da215d40dfe
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
-PKG_LICENSE:=LGPL-2.0-or-later
+PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:libshout:libshout
 

--- a/libs/libshout/patches/130-usleep.patch
+++ b/libs/libshout/patches/130-usleep.patch
@@ -1,0 +1,14 @@
+--- a/examples/nonblocking.c
++++ b/examples/nonblocking.c
+@@ -70,8 +70,10 @@ int main()
+     if (ret == SHOUTERR_BUSY)
+         printf("Connection pending...\n");
+ 
++    const struct timespec req = {0, 10 * 1000 * 1000};
++    struct timespec rem;
+     while (ret == SHOUTERR_BUSY) {
+-        usleep(10000);
++        nanosleep(&req, &rem);
+         ret = shout_get_connected(shout);
+     }
+ 


### PR DESCRIPTION
usleep is deprecated and optionally unavailable with uClibc-ng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess
Compile tested: arc700