### PR TITLE
bind: use json-c instead of jsoncpp

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.14.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -125,6 +125,7 @@ endef
 
 export BUILD_CC="$(TARGET_CC)"
 
+TARGET_CFLAGS += -DHAVE_JSON_C -UHAVE_JSON
 TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 CONFIGURE_ARGS += \


### PR DESCRIPTION
The configure script prefers the latter whereas the code prefers the
latter. Hack around it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmeyerhans 
Compile tested: ath79

Replaces: https://github.com/openwrt/packages/pull/11595