### PR TITLE
python3-package.mk: fix typo PYTHON3_PKG_SETUP_GLOABL_ARGS -> PYTHON3_PKG_SETUP_GLOBAL_ARGS

### DIFF
--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -126,7 +126,7 @@ define Build/Compile/Py3Mod
 endef
 
 PYTHON3_PKG_SETUP_DIR ?=
-PYTHON3_PKG_SETUP_GLOABL_ARGS ?=
+PYTHON3_PKG_SETUP_GLOBAL_ARGS ?=
 PYTHON3_PKG_SETUP_ARGS ?= --single-version-externally-managed
 PYTHON3_PKG_SETUP_VARS ?=
 


### PR DESCRIPTION
Maintainer: me, @jefferyto 
Compile tested: n/a
Run tested: n/a

-------------------------------------------

This fixes a typo with the default PYTHON3_PKG_SETUP_GLOBAL_ARGS.
Since in make context non-defined variables are empty anyway, this doesn't
produce any issues. The fix is more semantic in nature.

Fixes https://github.com/openwrt/packages/issues/11790

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>