### PR TITLE
gunicorn: bump to version 20.0.4

### DIFF
--- a/lang/python/gunicorn/Makefile
+++ b/lang/python/gunicorn/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gunicorn
-PKG_VERSION:=19.9.0
-PKG_RELEASE=2
+PKG_VERSION:=20.0.4
+PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=fa2662097c66f920f53f70621c6c58ca4a3c4d3434205e608e121b5b3b71f4f3
+PKG_HASH:=1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
@@ -32,6 +32,7 @@ endef
 
 define Package/python3-gunicorn
 $(call Package/gunicorn/Default)
+  TITLE:=WSGI HTTP Server for UNIX (library)
   DEPENDS:=+python3
   VARIANT:=python3
 endef
@@ -50,7 +51,7 @@ endef
 
 define Package/gunicorn3
 $(call Package/gunicorn/Default)
-  DEPENDS:=+python3 +python3-pkg-resources +python3-gunicorn
+  DEPENDS:=+python3 +python3-setuptools +python3-gunicorn
 endef
 
 define Package/gunicorn3/description
@@ -64,9 +65,7 @@ define Package/gunicorn3/install
 	$(INSTALL_BIN) \
 		$(PKG_INSTALL_DIR)/usr/bin/gunicorn \
 		$(1)/usr/bin/gunicorn3
-	$(INSTALL_BIN) \
-		$(PKG_INSTALL_DIR)/usr/bin/gunicorn_paster \
-		$(1)/usr/bin/gunicorn3_paster
+	$(LN) gunicorn3 $(1)/usr/bin/gunicorn
 	$(call Py3Shebang,$(1)/usr/bin/*)
 endef
 


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/02f07c640159ed1ef0698f3a4198cf5363680edd
Run tested: x86 https://github.com/openwrt/openwrt/commit/02f07c640159ed1ef0698f3a4198cf5363680edd

-------------------------------

This change bumps gunicorn to version 20.0.4.
It also installs the binary for gunicorn without any suffix, via symlink.
And remove gunicorn_paster; that was removed from the package and moved
into the gunicorn library.
Also, now we need to use the full python3-setuptools package for the
gunicorn executable, as it won't start without it.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>