### PR TITLE
dnsdist: fix default SSL lib spelling

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -32,7 +32,7 @@ menu "Configuration"
 	comment "SSL Support"
 	choice
 		prompt "Selected SSL library"
-		default DNSDIST_OPENSSSL
+		default DNSDIST_OPENSSL
 
 		config DNSDIST_OPENSSL
 			bool "OpenSSL"


### PR DESCRIPTION
Maintainer: @James-TR 
Compile tested: mvebu, openwrt master
Run tested: N/A, no change in package files

Description:
This is cosmetic only, since openssl is the first one being defined, but
it avoids a warning in scripts/config, after upgrading to kconfig-v5.6:
`tmp/.config-package.in:102839:warning: choice default symbol 'DNSDIST_OPENSSSL' is not contained in the choice`

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

