### PR TITLE
openconnect: Allow to set `usergroup` option

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
 PKG_VERSION:=8.05
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.infradead.org/pub/openconnect/

--- a/net/openconnect/README
+++ b/net/openconnect/README
@@ -12,6 +12,8 @@ config interface 'MYVPN'
 	option serverhash 'AE7FF6A0426F0A0CD0A02EB9EC3C5066FAEB0B25'
 	option defaultroute '0'
 	option authgroup 'DEFAULT'
+	# usergroup option, if required by some servers
+	# option usergroup 'USERGROUP'
 
 	# For second factor auth:
 

--- a/net/openconnect/files/openconnect.sh
+++ b/net/openconnect/files/openconnect.sh
@@ -19,6 +19,7 @@ proto_openconnect_init_config() {
 	proto_config_add_string "username"
 	proto_config_add_string "serverhash"
 	proto_config_add_string "authgroup"
+	proto_config_add_string "usergroup"
 	proto_config_add_string "password"
 	proto_config_add_string "password2"
 	proto_config_add_string "token_mode"
@@ -38,7 +39,7 @@ proto_openconnect_add_form_entry() {
 proto_openconnect_setup() {
 	local config="$1"
 
-	json_get_vars server port interface username serverhash authgroup password password2 token_mode token_secret token_script os csd_wrapper mtu juniper form_entry
+	json_get_vars server port interface username serverhash authgroup usergroup password password2 token_mode token_secret token_script os csd_wrapper mtu juniper form_entry
 
 	grep -q tun /proc/modules || insmod tun
 	ifname="vpn-$config"
@@ -77,6 +78,7 @@ proto_openconnect_setup() {
 		append_args --no-system-trust
 	}
 	[ -n "$authgroup" ] && append_args --authgroup "$authgroup"
+	[ -n "$usergroup" ] && append_args --usergroup "$usergroup"
 	[ -n "$username" ] && append_args -u "$username"
 	[ -n "$password" ] || [ "$token_mode" = "script" ] && {
 		umask 077


### PR DESCRIPTION
Maintainer: @nmav (find it by checking history of the package Makefile)
Compile tested: GL-MT300N-V2 OpenWrt 19.07.2 r10947-65030d81f3 
Run tested: GL-MT300N-V2 OpenWrt 19.07.2 r10947-65030d81f3 

Description:
Just adding the extra option `-g|--usergroup <group>` (required by the VPN server I'm currently using)
