### PR TITLE
boinc: FTBFS: avoiding unexpected dependencies

### DIFF
--- a/net/boinc/patches/001-avoidExtraDependencies
+++ b/net/boinc/patches/001-avoidExtraDependencies
@@ -1,0 +1,15 @@
+Index: boinc-client_release-7.16-7.16.5/configure.ac
+===================================================================
+--- boinc-client_release-7.16-7.16.5.orig/configure.ac
++++ boinc-client_release-7.16-7.16.5/configure.ac
+@@ -506,8 +506,10 @@ SAH_CHECK_LIB([dl], [dlopen],
+     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
+ SAH_CHECK_LIB([nsl], [gethostbyname],
+     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
++if test "${enable_manager}" = yes ; then
+ SAH_CHECK_LIB([freetype], [fopen],
+     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
++fi
+ SAH_CHECK_LIB([socket], [bind],
+     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
+ SAH_CHECK_LIB([z], [gzopen],


### PR DESCRIPTION
Maintainer: Christian Dreihsig <christian.dreihsig@t-online.de>
                   Steffen Moeller <moeller@debian.org>
Compile tested: X86, 64, SNAPSHOT
Run tested: X86, 64, SNAPSHOT
Description:
packages/net/boinc was just recently merged and failed to build from source as boinc's configure script in its wisdom found the fonttype library installed on the build machine and prepped for adding it as something to link against without having that library declared as a dependency.

This pull request is a reaction to the helpful comment by @hnyman in
https://github.com/openwrt/packages/pull/11768#issuecomment-610513948
Many thanks!
The errant inclusion of the freetype library is now excluded
by an embracing "if" statement. It seems to have worked on my end and I hope for another opportunity to see this executed on the OpenWrt builders - @aparcar and @BKPepe have reviewed this package before.

The patch is presented to BOINC upstream at
https://github.com/BOINC/boinc/pull/3578

Sign-off-by: Steffen Moeller <moeller@debian.org>