### PR TITLE
ntpclient: fix compilation with newer kernels

### DIFF
--- a/net/ntpclient/Makefile
+++ b/net/ntpclient/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntpclient
 PKG_VERSION:=2015_365
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://doolittle.icarus.com/ntpclient

--- a/net/ntpclient/patches/200-time.patch
+++ b/net/ntpclient/patches/200-time.patch
@@ -1,0 +1,41 @@
+--- a/adjtimex.c
++++ b/adjtimex.c
+@@ -36,6 +36,7 @@
+  *  gcc -Wall -O adjtimex_1.c -o adjtimex
+  */
+ 
++#include <inttypes.h>
+ #include <stdio.h>
+ #include <sys/types.h>
+ #include <stdlib.h>
+@@ -143,8 +144,8 @@ int main(int argc, char ** argv)
+ 			"    precision:    %ld\n"
+ 			"    tolerance:    %ld\n"
+ 			"-t  tick:         %ld\n"
+-			"    time.tv_sec:  %ld\n"
+-			"    time.tv_usec: %ld\n"
++			"    time.tv_sec:  %" PRId64 "\n"
++			"    time.tv_usec: %" PRId64 "\n"
+ 			"    return value: %d (%s)\n",
+ 		txc.constant,
+ 		txc.precision, txc.tolerance, txc.tick,
+--- a/ntpclient.c
++++ b/ntpclient.c
+@@ -181,7 +181,7 @@ static void set_time(struct ntptime *new)
+ 		exit(1);
+ 	}
+ 	if (debug) {
+-		printf("set time to %lu.%.9lu\n", tv_set.tv_sec, tv_set.tv_nsec);
++		printf("set time to %" PRId64 ".%.9" PRId64 "\n", (int64_t)tv_set.tv_sec, (int64_t)tv_set.tv_nsec);
+ 	}
+ #else
+ 	/* Traditional Linux way to set the system clock
+@@ -196,7 +196,7 @@ static void set_time(struct ntptime *new)
+ 		exit(1);
+ 	}
+ 	if (debug) {
+-		printf("set time to %lu.%.6lu\n", tv_set.tv_sec, tv_set.tv_usec);
++		printf("set time to %" PRId64 ".%.6" PRId64 "\n", (int64_t)tv_set.tv_sec, (int64_t)tv_set.tv_usec);
+ 	}
+ #endif
+ }

--- a/net/ntpclient/patches/300-siocgarp.patch
+++ b/net/ntpclient/patches/300-siocgarp.patch
@@ -1,0 +1,12 @@
+--- a/ntpclient.c
++++ b/ntpclient.c
+@@ -42,6 +42,9 @@
+ #include <errno.h>
+ #ifdef PRECISION_SIOCGSTAMP
+ #include <sys/ioctl.h>
++#ifdef __GLIBC__
++#include <linux/sockios.h>
++#endif
+ #endif
+ #ifdef USE_OBSOLETE_GETTIMEOFDAY
+ #include <sys/time.h>


### PR DESCRIPTION
glibc needs an extra header included.

Also cast time values to 64-bit in preparation for 64-bit time_t for
32-bit platforms.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ath79 arc700

Fixes: https://github.com/openwrt/packages/issues/11767