### PR TITLE
knxd: bump to version 0.14.35

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -11,12 +11,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
-PKG_VERSION:=0.14.31
+PKG_VERSION:=0.14.35
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=3bc21f1db9a72d4e6ad817f60e70af8421ede1529a57a2c12b70304e51a79d02
+PKG_HASH:=697bc68b64a27f0be478d8c861498533d18f0aef067cf95e9dc5e7c0653f1044
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/knxd/patches/0099-openwrt.patch
+++ b/net/knxd/patches/0099-openwrt.patch
@@ -1,8 +1,9 @@
 --- a/src/client/Makefile.am 2017-01-25 20:17:14.000000000 +0100
 +++ b/src/client/Makefile.am 2017-01-25 20:18:50.639995000 +0100
 @@ -4,5 +4,5 @@
- BUILDJAVA =
+ BUILDJAVA = 
  endif
-
+ 
 -SUBDIRS=def c $(BUILDJAVA) php perl cs python pascal ruby lua go .
 +SUBDIRS=def c $(BUILDJAVA) php perl cs .
+ 

--- a/net/knxd/patches/0100-version.patch
+++ b/net/knxd/patches/0100-version.patch
@@ -1,0 +1,12 @@
+--- a/tools/version.sh  2020-04-08 19:39:40.349461034 +0200
++++ b/tools/version.sh  2020-04-08 19:40:26.354277094 +0200
+@@ -1,8 +1,2 @@
+ #!/bin/sh
+-sed -ne '1s/.*(\(.*\)).*/\1/' -e '1s/-1$//' -e '1p' debian/changelog | tr -d "\n"
+-test -d .git || exit
+-git=$(git rev-parse --short HEAD)
+-lgit=$(git rev-parse --short $(git rev-list -1 HEAD debian/changelog) )
+-if test "$git" != "$lgit" ; then
+-	echo -n ":$git"
+-fi
++echo -n "0.14.35"


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

Maintainer: me
Compile tested: mpc85xx, tl-wdr4900-v1, trunk
Compile tested: ath79, tplink_archer-c7-v4, trunk
Compile tested: ramips, mt7620a, trunk
Run tested: ath79, tp-link Archer C7 v4, trunk

Description:
new upstream release 0.14.35 with new patch

