### PR TITLE
python3: hide -src package until main pkg selected

### DIFF
--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -56,6 +56,10 @@ define Py3Package
     (Contains the Python3 sources for this package).
   endef
 
+  define Package/$(1)-src/config
+    depends on PACKAGE_$(1)
+  endef
+
   # Add default PyPackage filespec none defined
   ifndef Py3Package/$(1)/filespec
     define Py3Package/$(1)/filespec


### PR DESCRIPTION
Maintainer:  @commodo @jefferyto 
Compile tested: tested with `make menuconfig`
Run tested: N/A

Description:
This adds a `Package/<pkg>-src/config` definition with a `depends on <pkg>` line, which will hide `<pkg>-src` unless `<pkg>` is selected.  This makes the long list of python packages a bit shorter, and also indents the `src` package:
```
<M> python3-base................................ Python 3.8 interpreter
< >   python3-base-src................. Python 3.8 interpreter (sources)
```
Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>