### PR TITLE
libv4l: update to 1.16.8

### DIFF
--- a/libs/libv4l/Makefile
+++ b/libs/libv4l/Makefile
@@ -6,22 +6,21 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v4l-utils
-PKG_VERSION:=1.16.6
-PKG_RELEASE:=3
+PKG_VERSION:=1.16.8
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.linuxtv.org/downloads/v4l-utils
-PKG_HASH:=f9dac1878e3d5636eab7f56bb209fdfc66b94ee8a2aae54dcb4282fe63a678ae
+PKG_HASH:=84346bf200bd30efb8a80a65ded1b81d39ae7e0ff2272e98f478b4eee8f40d13
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
-PKG_LICENSE:=GPL-2.0 LGPL-2.1
-PKG_LICENSE_FILES:=COPYING COPYING.libv4l
 
 PKG_USE_MIPS16:=0
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
-PKG_BUILD_DEPENDS:=argp-standalone
+PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
 
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
@@ -53,6 +52,8 @@ define Package/libv4l
   CATEGORY:=Libraries
   TITLE+= wrapper libraries
   DEPENDS := +libpthread +librt $(ICONV_DEPENDS)
+  LICENSE:=LGPL-2.1-or-later
+  LICENSE_FILES:=COPYING.libv4l
 endef
 
 define Package/libv4l/description
@@ -64,7 +65,9 @@ define Package/v4l-utils
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE+= utilities
-  DEPENDS := +libv4l $(CXX_DEPENDS) $(ICONV_DEPENDS) $(INTL_DEPENDS)
+  DEPENDS:= +libv4l $(CXX_DEPENDS) $(ICONV_DEPENDS) $(INTL_DEPENDS)
+  LICENSE:=GPL-2.0-or-later
+  LICENSE_FILES:=COPYING
 endef
 
 define Package/v4l-utils/description
@@ -73,7 +76,10 @@ define Package/v4l-utils/description
 endef
 
 TARGET_CFLAGS += -flto
-TARGET_LDFLAGS += -largp -Wl,--gc-sections
+TARGET_CXXFLAGS += -std=c++11
+TARGET_LDFLAGS += \
+	$(if $(CONFIG_LIBC_USE_GLIBC),,-largp) \
+	-Wl,--gc-sections,--as-needed
 
 CONFIGURE_ARGS+= \
 	--disable-bpf \
@@ -81,7 +87,7 @@ CONFIGURE_ARGS+= \
 	--disable-libdvbv5 \
 	--disable-qv4l2 \
 	--disable-qvidcap \
-	--without-jpeg \
+	--without-jpeg
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
Fixed license information.

Update argp dependency to be for non glibc.

Added PKG_BUILD_PARALLEL for faster compilation.

Added --as-needed linker flag for slightly smaller size.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ath79