### PR TITLE
btrfs-progs: update to version 5.6

### DIFF
--- a/utils/btrfs-progs/Makefile
+++ b/utils/btrfs-progs/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=btrfs-progs
-PKG_VERSION:=5.4.1
-PKG_RELEASE:=3
+PKG_VERSION:=5.6
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/kdave/btrfs-progs
-PKG_HASH:=f3e07fb248d608bdad5b63973513211de5daba47aaecfa44d29a836f6e7a9d69
+PKG_HASH:=a1321c77521dfa6cac41d0d030358e9c74bcf650afd6a9c1c7d531e6cd112f6b
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Karel Kočí <karel.koci@nic.cz>


### PR DESCRIPTION
Maintainer: @Cynerd 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master + 19.07
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07.

Description:

- Update to version [5.6](https://btrfs.wiki.kernel.org/index.php/Changelog#btrfs-progs_v5.6_.28Apr_2020.29).

Changelog:
```
inspect logical-resolve: support LOGICAL_INO_V2 as new option '-o', helps advanced dedupe tools
inspect: user larger buffer (64K) for results
subvol delete: support deletion by id (requires kernel 5.7+)

libbtrfsutil:
support subvolume deletion by id
bump version to 1.2
library symbols are now versioned

dump-tree: new option --hide-names, replace any names (file, directory, subvolume, xattr) in the output with stubs
convert: warn if the filesystem is not mountable on the machine

fixes:
restore: proper mirror iteration on decompression error
restore: make symlink messages less noisy
check: handle holes at the begining or end of file
fix xxhash output on big endian machines
receive: fix lookup of subvolume by uuid in case it was already received before

other:
new and updated tests
add missing binaries in exported testsuite
docs updates
remove obsolete files
move files to more appropriate directories
fixes reported by valgrind
many typos fixed
```