### PR TITLE
boinc: new upstream version, adjustments

### DIFF
--- a/net/boinc/Makefile
+++ b/net/boinc/Makefile
@@ -6,14 +6,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=boinc
-PKG_VERSION:=7.16.5
+PKG_VERSION:=7.16.6
 PKG_VERSION_SHORT:=$(shell echo $(PKG_VERSION)| cut -f1,2 -d.)
 PKG_RELEASE:=1
 
 PKG_SOURCE_DATE:=2020-02-25
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/BOINC/boinc/tar.gz/client_release/$(PKG_VERSION_SHORT)/$(PKG_VERSION)?
-PKG_HASH:=33db60991b253e717c6124cce4750ae7729eaab4e54ec718b9e37f87012d668a
+PKG_HASH:=caa567da8d3eb50859efe2eeba1c23c7b27d3b0f15b548136e75302713b25303
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-client_release-$(PKG_VERSION_SHORT)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Christian Dreihsig <christian.dreihsig@t-online.de>, Steffen Moeller <moeller@debian.org>
@@ -75,8 +75,9 @@ define Package/boinc/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/boinc-client.init $(1)/etc/init.d/boinc-client
 	$(INSTALL_DIR) $(1)/opt/boinc
-	$(CP) ./files/global_prefs_override.xml $(1)/opt/boinc/global_prefs_override.xml
-	$(CP) ./files/remote_hosts.cfg $(1)/opt/boinc/remote_hosts.cfg
+	$(INSTALL_DIR) $(1)/usr/share/boinc
+	$(CP) ./files/global_prefs_override.xml $(1)/usr/share/boinc/global_prefs_override.xml
+	$(CP) ./files/remote_hosts.cfg $(1)/usr/share/boinc/remote_hosts.cfg
 endef
 
 $(eval $(call BuildPackage,boinc))

--- a/net/boinc/files/boinc-client.init
+++ b/net/boinc/files/boinc-client.init
@@ -1,15 +1,17 @@
 #!/bin/sh /etc/rc.common
 
+START=99
 USE_PROCD=1
 
 BOINCEXE_NAME=boinc_client
 BOINCDIR=/opt/boinc/
+PRESETDIR=/usr/share/boinc
 BOINCUSR=boinc
 BOINCEXE_OPTS="--check_all_logins --redirectio --dir $BOINCDIR"
-PID_FILE="var/run/$BOINCEXE_NAME.pid"
+PID_FILE="/var/run/$BOINCEXE_NAME.pid"
 
 start_service() {
-   # First Check that BOINCDIR exists...
+   # First check that BOINCDIR exists
    if ! [ -d "$BOINCDIR" ]; then
       if ! mkdir -p $BOINCDIR 2>/dev/null ; then
          echo "ERROR: $BOINCDIR doesn't exist and couldn't be created"
@@ -17,7 +19,14 @@ start_service() {
       fi
    fi
 
-   # ... and that it is accessible by boinc
+   # adjust some presettings if necessary
+   for f in global_prefs_override.xml remote_hosts.cfg; do
+      if ! [ -f $BOINCDIR/$f ]; then
+         cp $PRESETDIR/$f $BOINCDIR
+      fi
+   done
+
+   # and ensure it is accessible by boinc
    BOINCDIR_OWNER="$(ls -ld $BOINCDIR | awk '{print $3}')"
    if [ "$BOINCUSR" != "$BOINCDIR_OWNER" ] ; then
       chown -R $BOINCUSR:$BOINCUSR $BOINCDIR

--- a/net/boinc/patches/002-hosttypeRespected
+++ b/net/boinc/patches/002-hosttypeRespected
@@ -1,0 +1,51 @@
+Index: boinc-client_release-7.16-7.16.6/client/cs_platforms.cpp
+===================================================================
+--- boinc-client_release-7.16-7.16.6.orig/client/cs_platforms.cpp
++++ boinc-client_release-7.16-7.16.6/client/cs_platforms.cpp
+@@ -76,6 +76,21 @@ void CLIENT_STATE::add_platform(const ch
+ //
+ void CLIENT_STATE::detect_platforms() {
+ 
++// if specified - use it
++#ifdef HOSTTYPE
++    add_platform(HOSTTYPE);
++#endif
++
++// if specified - use it
++#ifdef HOSTTYPEALT
++    add_platform(HOSTTYPEALT);
++#endif
++
++// if both the hosttype and its alternative are specified,
++// there is no need to look further and one should go directly
++// to the inspection of the cc_config.xml data
++#if !defined(HOSTTYPE) || !defined(HOSTTYPEALT)
++
+ #if defined(_WIN32) && !defined(__CYGWIN32__)
+ #if defined(_WIN64) && defined(_M_X64)
+     add_platform("windows_x86_64");
+@@ -206,15 +221,6 @@ void CLIENT_STATE::detect_platforms() {
+         add_platform("i686-pc-linux-gnu");
+     }
+ 
+-    if (!(support64 || support32)) {
+-        // Something went wrong. Assume HOSTTYPE and HOSTTYPEALT
+-        // are correct
+-        add_platform(HOSTTYPE);
+-#ifdef HOSTTYPEALT
+-        add_platform(HOSTTYPEALT);
+-#endif
+-    }
+-
+ #elif defined(sun)
+     // Check if we can run 64-bit binaries...
+     // this assumes there isn't a 64-bit only solaris.  (Every 64-bit solaris can run 32 bit binaries)
+@@ -290,6 +296,8 @@ void CLIENT_STATE::detect_platforms() {
+ #endif
+ 
+ #endif
++
++#endif
+ 
+     if (cc_config.no_alt_platform) {
+         PLATFORM p = platforms[0];


### PR DESCRIPTION
Maintainer: @N30dG @smoe 
Compile tested: x86_64
Run tested: x86_64, arm

Description:
 * new upstream version 7.16.6
 * fixing platform identifier for openwrt x86
   (boinc issue https://github.com/BOINC/boinc/issues/3595)
 * protected configuration from update

Signed-off-by: Christian Dreihsig <christian.dreihsig@t-online.de>
