### PR TITLE
[19.07]meson: use python3

### DIFF
--- a/devel/meson/Makefile
+++ b/devel/meson/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=meson
 PKG_VERSION:=0.54.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=meson
 PKG_HASH:=dde5726d778112acbd4a67bb3633ab2ee75d33d1e879a6283a7b4a44c3363c27
@@ -11,7 +11,7 @@ PKG_MAINTAINER:=Andre Heider <a.heider@gmail.com>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=COPYING
 
-HOST_BUILD_DEPENDS:=ninja/host
+HOST_BUILD_DEPENDS:=ninja/host python3/host
 
 include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/host-build.mk

--- a/devel/meson/meson.mk
+++ b/devel/meson/meson.mk
@@ -37,7 +37,7 @@ MESON_VARS:=
 MESON_ARGS:=
 
 define Meson
-	$(2) $(STAGING_DIR_HOST)/bin/$(PYTHON) $(MESON_DIR)/meson.py $(1)
+	$(2) $(HOST_PYTHON3_BIN) $(MESON_DIR)/meson.py $(1)
 endef
 
 define Meson/CreateNativeFile


### PR DESCRIPTION
meson supports python 3.5.3 and up only.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dhewg 
Compile tested: ath79

ping @jefferyto @BKPepe 