### PR TITLE
python-pyparsing: update to version 2.4.7

### DIFF
--- a/lang/python/python-pyparsing/Makefile
+++ b/lang/python/python-pyparsing/Makefile
@@ -9,11 +9,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyparsing
-PKG_VERSION:=2.4.6
+PKG_VERSION:=2.4.7
 PKG_RELEASE:=1
 
 PYPI_NAME:=pyparsing
-PKG_HASH:=4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f
+PKG_HASH:=c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia(TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates python-pyparsing to version 2.4.7 It contains backported fixes from 3.0.0 version
[Changelog](https://github.com/pyparsing/pyparsing/blob/master/CHANGES#L207)

Runtested with project tests
```
Ran 674 tests in 125.652s
```
