### PR TITLE
mactelnet : Secure access to mactelnet config file

### DIFF
--- a/net/mac-telnet/Makefile
+++ b/net/mac-telnet/Makefile
@@ -63,6 +63,7 @@ define Package/mac-telnet-server/install-extra
 	$(INSTALL_BIN) ./files/mactelnet.init $$(1)/etc/init.d/mactelnet
 	$(INSTALL_DIR) $$(1)/etc/config
 	$(INSTALL_DATA) ./files/mactelnet.config $$(1)/etc/config/mactelnet
+	chmod 0600 /etc/config/mactelnet
 endef
 
 


### PR DESCRIPTION
Maintainer: Jo-Philipp Wich <jo@mein.io>
Compile tested: OpenWrt 19.07.2 mips
Run tested: OpenWrt 19.07.2 Atheros

Description:

When installing the package, set the root only access to the mactelnet config file. This file includes clean passwords!

