### PR TITLE
quote: disable a bunch of options

### DIFF
--- a/utils/quota/Makefile
+++ b/utils/quota/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=quota
 PKG_VERSION:=4.05
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/linuxquota
@@ -25,7 +25,6 @@ include $(INCLUDE_DIR)/package.mk
 define Package/quota
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libnl-genl +libtirpc +libwrap
   TITLE:= quota
   URL:=https://sourceforge.net/projects/linuxquota/
 endef
@@ -35,7 +34,13 @@ define Package/quota/description
 endef
 
 CONFIGURE_ARGS += \
-	--disable-ext2direct
+	--disable-bsd-behaviour \
+	--disable-ext2direct \
+	--disable-ldapmail \
+	--disable-libwrap \
+	--disable-netlink \
+	--disable-rpath \
+	--disable-rpc
 
 define Package/quota/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
libwrap is fairly useless. It's also legacy and should not be used/

dbus is a big dependency. It's fairly useless in the OpenWrt context.

I don't know how useful netlink is.

Disabling BSD behavior results in a slightly smaller size.

Disable LDAP. No size difference but I have a feeling it pulls in
another dependency...

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @flyn-org 
Compile tested: ath79