### PR TITLE
re2: update to 2020-04-01

### DIFF
--- a/libs/libre2/Makefile
+++ b/libs/libre2/Makefile
@@ -1,64 +1,48 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=re2
-PKG_VERSION:=2019-06-01
-PKG_RELEASE:=2
+PKG_VERSION:=2020-04-01
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/google/re2/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=02b7d73126bd18e9fbfe5d6375a8bb13fadaf8e99e48cbb062e4500fc18e8e2e
+PKG_HASH:=98794bc5416326817498384a9c43cbb5a406bab8da9f84f83c39ecad43ed5cea
 
+PKG_MAINTAINER:=
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
+CMAKE_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-PKG_BUILD_PARALLEL:=1
-HOST_BUILD_PARALLEL:=1
-CMAKE_OPTIONS:= \
-	-DBUILD_SHARED_LIBS=$(if $(CONFIG_RE2_SHARED),ON,OFF)
-CMAKE_INSTALL:=1
-
 define Package/re2
-	SECTION:=libs
-	CATEGORY:=Libraries
-	DEPENDS:=+libstdcpp
-	TITLE:=RE2 is a fast, safe, thread-friendly alternative to backtracking regular expression engines like those used in PCRE, Perl, and Python. It is a C++ library.
-	URL:=https://github.com/google/re2
-	MAINTAINER:=Amol Bhave <ambhave@fb.com>
-endef
-
-define Package/re2/config
-	choice
-		prompt "Compile RE2 library."
-			default RE2_SHARED
-			help
-				Choose which version to compile.
-				-> Shared:
-					- Only Shared lib will be compiled.
-				-> Static:
-					- Only Static lib will be compiled.
-
-		config RE2_SHARED
-			bool "Shared"
-
-		config RE2_STATIC
-			bool "Static"
-	endchoice
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+libstdcpp
+  TITLE:=RE2 - C++ regular expression library
+  URL:=https://github.com/google/re2
+  ABI_VERSION:=6
 endef
 
 define Package/re2/description
-	RE2 is a fast, safe, thread-friendly alternative to backtracking regular
-	expression engines like those used in PCRE, Perl, and Python.
-	It is a C++ library.
+  RE2 is a fast, safe, thread-friendly alternative to backtracking regular
+  expression engines like those used in PCRE, Perl, and Python.
+  It is a C++ library.
 endef
+
+CMAKE_OPTIONS += \
+	-DBUILD_SHARED_LIBS=ON
+
+TARGET_LDFLAGS += \
+	$(if $(CONFIG_USE_GLIBC),-lm) \
+	-Wl,--as-needed,--gc-sections
 
 define Package/re2/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libre2.so* $(1)/usr/lib/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libre2.so $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,re2))
-$(eval $(call HostBuild))

--- a/libs/libre2/patches/010-cxx17.patch
+++ b/libs/libre2/patches/010-cxx17.patch
@@ -1,0 +1,23 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -38,9 +38,9 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+   add_compile_options(/utf-8)
+ elseif(CYGWIN OR MINGW)
+   # See https://stackoverflow.com/questions/38139631 for details.
+-  add_compile_options(-std=gnu++11)
++  add_compile_options(-std=gnu++17)
+ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+-  add_compile_options(-std=c++11)
++  add_compile_options(-std=c++17)
+ endif()
+ 
+ if(WIN32)
+--- a/re2.pc
++++ b/re2.pc
+@@ -6,5 +6,5 @@ libdir=@libdir@
+ Name: re2
+ Description: RE2 is a fast, safe, thread-friendly regular expression engine.
+ Version: 0.0.0
+-Cflags: -std=c++11 -pthread -I${includedir}
++Cflags: -std=c++17 -pthread -I${includedir}
+ Libs: -pthread -L${libdir} -lre2


### PR DESCRIPTION
Massive cleanup of Makefile.

Remove inactive maintainer.

Remove completely unused host build.

Shorten title so that it shows under menuconfig.

Remove pointless static/shared choice.

Add C++17 patch as libcxx seems to need it with this package.

Add ABI_VERSION.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ath79