### PR TITLE
sshtunnel: correct access of config file

### DIFF
--- a/net/sshtunnel/Makefile
+++ b/net/sshtunnel/Makefile
@@ -40,7 +40,7 @@ define Package/sshtunnel/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/sshtunnel.init $(1)/etc/init.d/sshtunnel
 	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_DATA) ./files/uci_sshtunnel $(1)/etc/config/sshtunnel
+	$(INSTALL_CONF) ./files/uci_sshtunnel $(1)/etc/config/sshtunnel
 endef
 
 $(eval $(call BuildPackage,sshtunnel))


### PR DESCRIPTION
Maintainer: Nuno Goncalves <nunojpg@gmail.com>
Compile tested: OpenWrt 19.07.2 mips
Run tested: OpenWrt 19.07.2 Atheros

Description:

With this change the `/etc/config/sshtunnel` file has the correct access security. It's a sensible file.
