### PR TITLE
add libexecinfo package

### DIFF
--- a/libs/libexecinfo/Makefile
+++ b/libs/libexecinfo/Makefile
@@ -1,0 +1,81 @@
+#
+# Copyright (C) 2006-2013 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libexecinfo
+PKG_VERSION:=1.1
+PKG_RELEASE:=3
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=http://distcache.freebsd.org/local-distfiles/itetcu
+PKG_HASH:=c9a21913e7fdac8ef6b33250b167aa1fc0a7b8a175145e26913a4c19d8a59b1f
+
+PKG_LICENSE:=BSD
+PKG_LICENSE_FILES:=README
+
+PKG_MAINTAINER:=Robert Nemeti <nrobert13@gmail.com>
+
+PKG_INSTALL:=2
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libexecinfo
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Library implementing glibc's backtrace
+  URL:=https://www.freshports.org/devel/libexecinfo
+endef
+
+define Package/libexecinfo-dev
+  SECTION:=devel
+  CATEGORY:=Development
+  SUBMENU:=Libraries
+  DEPENDS:=libexecinfo
+  TITLE:=Development files for the libexecinfo library
+endef
+
+define Package/libexecinfo/description
+ libexecinfo is a quick-n-dirty BSD licensed clone of the GNU libc backtrace facility
+ This package includes the shared library.
+endef
+
+define Package/libexecinfo-dev/description
+ libexecinfo is a quick-n-dirty BSD licensed clone of the GNU libc backtrace facility
+ This package includes the development support files.
+endef
+
+TARGET_CFLAGS += -fno-omit-frame-pointer
+
+define Build/Install
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_BUILD_DIR)/execinfo.h $(1)/usr/include/
+	$(CP) $(PKG_BUILD_DIR)/stacktraverse.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/libexecinfo.{a,so*} $(1)/usr/lib/
+	$(LN) libexecinfo.so.1 $(1)/usr/lib/libexecinfo.so
+endef
+
+define Package/libexecinfo/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/libexecinfo.so.1 $(1)/usr/lib/
+	$(LN) libexecinfo.so.1 $(1)/usr/lib/libexecinfo.so
+endef
+
+define Package/libexecinfo-dev/install
+	$(INSTALL_DIR) $(1)/usr/include
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/execinfo.h $(1)/usr/include/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/stacktraverse.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)//libexecinfo.a $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libexecinfo))
+$(eval $(call BuildPackage,libexecinfo-dev))

--- a/libs/libexecinfo/patches/10-execinfo.patch
+++ b/libs/libexecinfo/patches/10-execinfo.patch
@@ -1,0 +1,64 @@
+--- libexecinfo/execinfo.c.orig
++++ libexecinfo/execinfo.c
+@@ -69,7 +69,8 @@
+ char **
+ backtrace_symbols(void *const *buffer, int size)
+ {
+-    int i, clen, alen, offset;
++    size_t clen, alen;
++    int i, offset;
+     char **rval;
+     char *cp;
+     Dl_info info;
+@@ -78,7 +79,6 @@
+     rval = malloc(clen);
+     if (rval == NULL)
+         return NULL;
+-    (char **)cp = &(rval[size]);
+     for (i = 0; i < size; i++) {
+         if (dladdr(buffer[i], &info) != 0) {
+             if (info.dli_sname == NULL)
+@@ -92,14 +92,14 @@
+                    2 +                      /* " <" */
+                    strlen(info.dli_sname) + /* "function" */
+                    1 +                      /* "+" */
+-                   D10(offset) +            /* "offset */
++                   10 +                     /* "offset */
+                    5 +                      /* "> at " */
+                    strlen(info.dli_fname) + /* "filename" */
+                    1;                       /* "\0" */
+             rval = realloc_safe(rval, clen + alen);
+             if (rval == NULL)
+                 return NULL;
+-            snprintf(cp, alen, "%p <%s+%d> at %s",
++            snprintf((char *) rval + clen, alen, "%p <%s+%d> at %s",
+               buffer[i], info.dli_sname, offset, info.dli_fname);
+         } else {
+             alen = 2 +                      /* "0x" */
+@@ -108,12 +108,15 @@
+             rval = realloc_safe(rval, clen + alen);
+             if (rval == NULL)
+                 return NULL;
+-            snprintf(cp, alen, "%p", buffer[i]);
++            snprintf((char *) rval + clen, alen, "%p", buffer[i]);
+         }
+-        rval[i] = cp;
+-        cp += alen;
++        rval[i] = (char *) clen;
++        clen += alen;
+     }
+ 
++    for (i = 0; i < size; i++)
++        rval[i] += (long) rval;
++
+     return rval;
+ }
+ 
+@@ -155,6 +158,6 @@
+                 return;
+             snprintf(buf, len, "%p\n", buffer[i]);
+         }
+-        write(fd, buf, len - 1);
++        write(fd, buf, strlen(buf));
+     }
+ }

--- a/libs/libexecinfo/patches/20-define-gnu-source.patch
+++ b/libs/libexecinfo/patches/20-define-gnu-source.patch
@@ -1,0 +1,24 @@
+--- libexecinfo/execinfo.c.orig
++++ libexecinfo/execinfo.c
+@@ -26,6 +26,7 @@
+  * $Id: execinfo.c,v 1.3 2004/07/19 05:21:09 sobomax Exp $
+  */
+ 
++#define _GNU_SOURCE
+ #include <sys/types.h>
+ #include <sys/uio.h>
+ #include <dlfcn.h>
+--- libexecinfo/stacktraverse.c.orig
++++ libexecinfo/stacktraverse.c
+@@ -1,3 +1,4 @@
++#define _GNU_SOURCE
+ #include <stddef.h>
+ 
+ #include "stacktraverse.h"
+--- libexecinfo/test.c.orig
++++ libexecinfo/test.c
+@@ -1,3 +1,4 @@
++#define _GNU_SOURCE
+ #include <stdio.h>
+ #include <stdlib.h>
+ 

--- a/libs/libexecinfo/patches/30-linux-makefile.patch
+++ b/libs/libexecinfo/patches/30-linux-makefile.patch
@@ -1,0 +1,44 @@
+--- libexecinfo/Makefile.orig
++++ libexecinfo/Makefile
+@@ -23,24 +23,25 @@
+ # SUCH DAMAGE.
+ #
+ # $Id: Makefile,v 1.3 2004/07/19 05:19:55 sobomax Exp $
++#
++# Linux Makefile by Matt Smith <mcs@darkregion.net>, 2011/01/04
+ 
+-LIB=	execinfo
++CC=cc
++AR=ar
++EXECINFO_CFLAGS=$(CFLAGS) -O2 -pipe -fno-strict-aliasing -std=gnu99 -fstack-protector -c
++EXECINFO_LDFLAGS=$(LDFLAGS)
+ 
+-SRCS=	stacktraverse.c stacktraverse.h execinfo.c execinfo.h
++all: static dynamic
+ 
+-INCS=	execinfo.h
++static:
++	$(CC) $(EXECINFO_CFLAGS) $(EXECINFO_LDFLAGS) stacktraverse.c
++	$(CC) $(EXECINFO_CFLAGS) $(EXECINFO_LDFLAGS) execinfo.c
++	$(AR) rcs libexecinfo.a stacktraverse.o execinfo.o
+ 
+-SHLIB_MAJOR=	1
+-SHLIB_MINOR=	0
++dynamic:
++	$(CC) -fpic -DPIC $(EXECINFO_CFLAGS) $(EXECINFO_LDFLAGS) stacktraverse.c -o stacktraverse.So
++	$(CC) -fpic -DPIC $(EXECINFO_CFLAGS) $(EXECINFO_LDFLAGS) execinfo.c -o execinfo.So
++	$(CC) -shared -Wl,-soname,libexecinfo.so.1 -o libexecinfo.so.1 stacktraverse.So execinfo.So
+ 
+-NOPROFILE=	yes
+-
+-DPADD=		${LIBM}
+-LDADD=		-lm
+-
+-#WARNS?=	4
+-
+-#stacktraverse.c: gen.py
+-#	./gen.py > stacktraverse.c
+-
+-.include <bsd.lib.mk>
++clean:
++	rm -rf *.o *.So *.a *.so


### PR DESCRIPTION
in order to be able to build projects using backtrace with musl, as musl doesn't implement backtrace capability, unlike glibc.

Maintainer: me 
Compile tested: (put here arch, model, OpenWrt version)
mvebu, WRT1900ACS, v19.072
Run tested: (put here arch, model, OpenWrt version, tests done)
https://github.com/nrobert13/packages.git
Description:
