### PR TITLE
(u)acme: add support for user-provided setup and cleanup scripts

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme
 PKG_VERSION:=2.8.5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/Neilpang/acme.sh/tar.gz/$(PKG_VERSION)?

--- a/net/acme/files/acme.config
+++ b/net/acme/files/acme.config
@@ -11,4 +11,6 @@ config cert 'example'
        option update_nginx 1
        option webroot ""
        option dns ""
+       # option user_setup "path-to-custom-setup.script"
+       # option user_cleanup "path-to-custom-cleanup.script"
        list domains example.org

--- a/net/uacme/Makefile
+++ b/net/uacme/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uacme
 PKG_VERSION:=1.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ndilieto/uacme/tar.gz/upstream/$(PKG_VERSION)?

--- a/net/uacme/files/acme.config
+++ b/net/uacme/files/acme.config
@@ -11,4 +11,6 @@ config cert 'example'
        option update_nginx 1
        option update_haproxy 1
        option webroot "/www/.well-known/acme-challenge"
+       # option user_setup "path-to-custom-setup.script"
+       # option user_cleanup "path-to-custom-cleanup.script"
        list domains example.org


### PR DESCRIPTION
Maintainer: @tohojo @lucize 
Run tested: lantiq/xrx200, Openwrt 19.07.2. Tested by updating acme certificates using custom setup & cleanup scripts to configure firewall and web-server

Description:
Add possibility for user to provide setup and cleanup scripts which take
precedence over the built-in behavior of acme and uacme.

This helps users with more complex use-cases to utilize (u)acme to update
certificates without adding complexity to the provided run.sh scripts.

Signed-off-by: Antti Seppälä <a.seppala@gmail.com>