### PR TITLE
[19.07] acme: depends on wget-ssl

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/acme
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+gnu-wget +ca-bundle +openssl-util +socat
+  DEPENDS:=+wget-ssl +ca-bundle +openssl-util +socat
   TITLE:=ACME (Letsencrypt) client
   URL:=https://acme.sh
   PKGARCH:=all

--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.20.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -29,7 +29,7 @@ define Package/wget/Default
   SUBMENU:=File Transfer
   TITLE:=Non-interactive network downloader
   URL:=https://www.gnu.org/software/wget/index.html
-  PROVIDES:=wget
+  PROVIDES:=gnu-wget
 endef
 
 define Package/wget/Default/description
@@ -46,7 +46,6 @@ $(call Package/wget/Default)
   DEPENDS+= +libopenssl +librt
   TITLE+= (with SSL support)
   VARIANT:=ssl
-  PROVIDES+=gnu-wget
   ALTERNATIVES:=300:/usr/bin/wget:/usr/bin/wget-ssl
 endef
 
@@ -59,7 +58,7 @@ define Package/wget-nossl
 $(call Package/wget/Default)
   TITLE+= (without SSL support)
   VARIANT:=nossl
-  PROVIDES+=gnu-wget
+  PROVIDES+=wget
   ALTERNATIVES:=300:/usr/bin/wget:/usr/bin/wget-nossl
 endef
 

--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.20.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -46,6 +46,7 @@ $(call Package/wget/Default)
   DEPENDS+= +libopenssl +librt
   TITLE+= (with SSL support)
   VARIANT:=ssl
+  PROVIDES+=wget-ssl
   ALTERNATIVES:=300:/usr/bin/wget:/usr/bin/wget-ssl
 endef
 


### PR DESCRIPTION
Maintainer: wget @tripolar , acme @tohojo 
Compile tested: n/a
Run tested: n/a

Description:

This backports a series of commits to make "opkg install acme" work out of the box for 19.07.

Ref: #11534