### PR TITLE
[18.06] acme: depends on wget-ssl

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/acme
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+gnu-wget +ca-bundle +openssl-util +socat
+  DEPENDS:=+wget-ssl +ca-bundle +openssl-util +socat
   TITLE:=ACME (Letsencrypt) client
   URL:=https://acme.sh
   PKGARCH:=all

--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.19.5
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -46,6 +46,7 @@ $(call Package/wget/Default)
   DEPENDS+= +libopenssl +librt
   TITLE+= (with SSL support)
   VARIANT:=ssl
+  PROVIDES+=wget-ssl
 endef
 
 define Package/wget/description

--- a/net/wget/Makefile
+++ b/net/wget/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wget
 PKG_VERSION:=1.19.5
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -28,8 +28,8 @@ define Package/wget/Default
   DEPENDS:=+libpcre +zlib
   SUBMENU:=File Transfer
   TITLE:=Non-interactive network downloader
-  URL:=http://www.gnu.org/software/wget/index.html
-  PROVIDES:=wget
+  URL:=https://www.gnu.org/software/wget/index.html
+  PROVIDES:=gnu-wget
 endef
 
 define Package/wget/Default/description
@@ -46,7 +46,6 @@ $(call Package/wget/Default)
   DEPENDS+= +libopenssl +librt
   TITLE+= (with SSL support)
   VARIANT:=ssl
-  PROVIDES+=gnu-wget
 endef
 
 define Package/wget/description
@@ -58,7 +57,7 @@ define Package/wget-nossl
 $(call Package/wget/Default)
   TITLE+= (without SSL support)
   VARIANT:=nossl
-  PROVIDES+=gnu-wget
+  PROVIDES+=wget
 endef
 
 define Package/wget-nossl/description


### PR DESCRIPTION
Maintainer: wget @tripolar , acme @tohojo 
Compile tested: n/a
Run tested: n/a

Description:

This backports a series of commits to make "opkg install acme" work out of the box for 18.06, fixing #11534.  It's 19.07 counterpart is at #11882