### PR TITLE
uacme: update to 1.2.1

### DIFF
--- a/net/uacme/Makefile
+++ b/net/uacme/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uacme
-PKG_VERSION:=1.0.22
+PKG_VERSION:=1.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ndilieto/uacme/tar.gz/upstream/$(PKG_VERSION)?
-PKG_HASH:=08070779232c9711a227189ee2d3cb55042f6be2ea0aa59525cb7b554c4688b0
+PKG_HASH:=ccd6001e96ec2eb22a1d557bf8dcc4152a567782afc9a1e017a93d7de3b49833
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -64,6 +64,7 @@ TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 CONFIGURE_ARGS+= \
 	--disable-maintainer-mode \
 	--disable-docs \
+	--without-ualpn \
 	$(if $(CONFIG_LIBCURL_GNUTLS),--with-gnutls --without-mbedtls --without-openssl,) \
 	$(if $(CONFIG_LIBCURL_MBEDTLS),--without-gnutls --with-mbedtls --without-openssl,) \
 	$(if $(CONFIG_LIBCURL_OPENSSL),--without-gnutls --without-mbedtls --with-openssl,) \


### PR DESCRIPTION
Maintainer: @lucize 
Compile tested: lantiq-xrx200, OpenWrt-19.07.2
Run tested: lantiq-xrx200, OpenWrt-19.07.2, Tested package installation and certificate renewal.

Description:
Update to latest release.

Do not compile optional ualpn binary.

Signed-off-by: Antti Seppälä <a.seppala@gmail.com>