### PR TITLE
libvpx: update to version 1.8.2

### DIFF
--- a/libs/libvpx/Makefile
+++ b/libs/libvpx/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libvpx
-PKG_VERSION:=1.8.1
+PKG_VERSION:=1.8.2
 PKG_RELEASE:=1
 
 PKG_REV:=v$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_REV).tar.gz
-PKG_MIRROR_HASH:=6703842a870727b621a82efe5b2ff6f5553d41f7b0905dd4fde1f8bdf062d6ea
+PKG_MIRROR_HASH:=51e871a928fe98f14fd08285cb9b64c0d540b36b630ee7d47bc464e909366db7
 PKG_SOURCE_URL:=https://chromium.googlesource.com/webm/libvpx
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_REV)
@@ -22,7 +22,6 @@ PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_CPE_ID:=cpe:/a:john_koleszar:libvpx
 
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
-
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
@@ -36,7 +35,7 @@ define Package/libvpx
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=libvpx
-  URL:=http://www.webmproject.org/
+  URL:=https://www.webmproject.org/
   DEPENDS:=+libpthread
   ABI_VERSION:=$(PKG_ABI_VERSION)
 endef

--- a/libs/libvpx/Makefile
+++ b/libs/libvpx/Makefile
@@ -12,18 +12,17 @@ PKG_NAME:=libvpx
 PKG_VERSION:=1.8.2
 PKG_RELEASE:=1
 
-PKG_REV:=v$(PKG_VERSION)
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_REV).tar.gz
-PKG_MIRROR_HASH:=51e871a928fe98f14fd08285cb9b64c0d540b36b630ee7d47bc464e909366db7
-PKG_SOURCE_URL:=https://chromium.googlesource.com/webm/libvpx
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=$(PKG_REV)
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_CPE_ID:=cpe:/a:john_koleszar:libvpx
+PKG_SOURCE_URL:=https://chromium.googlesource.com/webm/libvpx
+PKG_MIRROR_HASH:=51e871a928fe98f14fd08285cb9b64c0d540b36b630ee7d47bc464e909366db7
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz
 
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:john_koleszar:libvpx
+PKG_BUILD_PARALLEL:=1
 
 PKG_ABI_VERSION:=$(subst $(space),.,$(wordlist 1, 2, $(subst .,$(space),$(PKG_VERSION))))
 


### PR DESCRIPTION
Maintainer: @luizluca 
Compile tested: Turris 1.1, powerpc_8540, OpenWrt master

Description:
- Update to version [1.8.2](https://chromium.googlesource.com/webm/libvpx/+/refs/tags/v1.8.2)
- Change URL to use HTTPS instead of HTTP
- Remove empty row between maintainer and license