### PR TITLE
smcroute: Keep config /etc/smcroute.conf on sysupgrade

### DIFF
--- a/net/smcroute/Makefile
+++ b/net/smcroute/Makefile
@@ -49,6 +49,8 @@ define Package/smcroute/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/smcroutectl $(1)/usr/bin/
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/smcroute.conf $(1)/etc
 	$(INSTALL_BIN) ./files/smcroute.init $(1)/etc/init.d/smcroute
+	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
+	echo >$(1)/lib/upgrade/keep.d/smcroute /etc/smcroute.conf
 endef
 
 $(eval $(call BuildPackage,smcroute))


### PR DESCRIPTION
Signed-off-by: Tobias Waldvogel <tobias.waldvogel@gmail.com>

Maintainer: Moritz Warning <moritzwarning@web.de>
Compile tested: Atheros AR7xxx/AR9xxx / TP-LINK Archer C7 v2 / r13013-5f126c541a
Run tested: Atheros AR7xxx/AR9xxx / TP-LINK Archer C7 v2 / r13013-5f126c541a

Description: Keep configuration file /etc/smcroute.conf on sysupgrade
