### PR TITLE
smcroute: Keep config file /etc/smcroute.conf on sysupgrade

### DIFF
--- a/net/smcroute/Makefile
+++ b/net/smcroute/Makefile
@@ -35,7 +35,7 @@ define Package/smcroute/description
 endef
 
 define Package/smcroute/conffiles
-	/etc/smcroute.conf
+/etc/smcroute.conf
 endef
 
 CONFIGURE_ARGS += \


### PR DESCRIPTION
This time implemented the proper way

Signed-off-by: Tobias Waldvogel <tobias.waldvogel@gmail.com>

Maintainer: Moritz Warning <moritzwarning@web.de>
Compile tested: Atheros AR7xxx/AR9xxx / TP-LINK Archer C7 v2 / r13013+9
Run tested: Atheros AR7xxx/AR9xxx / TP-LINK Archer C7 v2 / r13013+9

Description: smcroute: keep config file /etc/smcroute.conf on sysupgrade
