### PR TITLE
bwping: add new package

### DIFF
--- a/net/bwping/Makefile
+++ b/net/bwping/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2020 Oleg Derevenetz <oleg.derevenetz@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bwping
+PKG_VERSION:=1.16
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@SF/bwping
+PKG_HASH:=c0a0c61f779d7b497bfc264103614d013002e74502a868d678e8b569a3017687
+
+PKG_MAINTAINER:=Oleg Derevenetz <oleg.derevenetz@gmail.com>
+PKG_LICENSE:=BSD-2-Clause
+PKG_LICENSE_FILES:=COPYING
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/bwping
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Tool to measure bandwidth and RTT between two hosts using ICMP
+  URL:=https://bwping.sourceforge.io/
+endef
+
+define Package/bwping/description
+  BWPing is a tool to measure bandwidth and response times between two
+  hosts using Internet Control Message Protocol (ICMP) echo request/echo
+  reply mechanism. It does not require any special software on the remote
+  host. The only requirement is the ability to respond on ICMP echo request
+  messages. BWPing supports both IPv4 and IPv6 networks.
+endef
+
+define Package/bwping/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/$(PKG_NAME) $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,bwping))


### PR DESCRIPTION
Maintainer: me
Compile tested: MIPS 74K, ASUS RT-N16, snapshot from master branch
Run tested: MIPS 74K, ASUS RT-N16, snapshot from master branch

Description:
BWPing is a tool to measure bandwidth and response times between two
hosts using Internet Control Message Protocol (ICMP) echo request/echo
reply mechanism. It does not require any special software on the remote
host. The only requirement is the ability to respond on ICMP echo request
messages. BWPing supports both IPv4 and IPv6 networks.

Signed-off-by: Oleg Derevenetz <oleg-derevenetz@yandex.ru>
