### PR TITLE
xtables-addons: iptgeoip requires wget-ssl and zcat

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -138,7 +138,7 @@ define Package/iptgeoip
   # syntax of dependencies permits...
   DEPENDS:=iptables +iptables-mod-geoip \
 		+perl +perlbase-getopt +perlbase-io +perl-text-csv_xs \
-		+!BUSYBOX_CONFIG_WGET:wget +!BUSYBOX_CONFIG_GZIP:gzip +!BUSYBOX_CONFIG_UNZIP:unzip
+		+!BUSYBOX_CONFIG_FEATURE_WGET_HTTPS:wget +!BUSYBOX_CONFIG_ZCAT:gzip
 endef
 
 define Package/iptgeoip/install


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: Compile tested: x86_64, generic, HEAD (5f5d812)
Run tested: installed on test router (APU2), then ran xt_geoip_dl and xt_geoip_build. Ran fine.

Description:

xt_geoip_dl doesn't work with Busybox unzip, which doesn't support stream mode.