### PR TITLE
prosody: update to 0.11.5

### DIFF
--- a/net/prosody/Makefile
+++ b/net/prosody/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prosody
-PKG_VERSION:=0.11.3
-PKG_RELEASE:=2
+PKG_VERSION:=0.11.5
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://prosody.im/downloads/source
-PKG_HASH:=cfdabd6f42a9fc5db300221967c518c26bd4b6e62def721c1626894d6325bf87
+PKG_HASH:=55f8bd65d5d2af61cc739bd6164e4207011e0d2d260cde583071c90d8d85408b
 
 PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=MIT/X11


### PR DESCRIPTION
Signed-off-by: Vieno Hakkerinen <vieno@hakkerinen.eu>

Maintainer: Thomas Heil <heil@terminal-consulting.de>
Compile tested: ramips-mt7621
Run tested: VoCore2 (ramips-mt7621) running my jabber server

Description: Update prosody to 0.11.5
https://blog.prosody.im/prosody-0.11.5-released/
https://blog.prosody.im/prosody-0.11.4-released/
