### PR TITLE
less: add ALTERNATIVES

### DIFF
--- a/utils/less/Makefile
+++ b/utils/less/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=less
 PKG_VERSION:=530
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.greenwoodsoftware.com/less
@@ -30,6 +30,7 @@ define Package/less/Default
   CATEGORY:=Utilities
   TITLE:=Pager program similar to more
   URL:=http://www.greenwoodsoftware.com/less/
+  ALTERNATIVES:=200:/bin/less:/usr/bin/less
 endef
 
 define Package/less/Default/description
@@ -69,20 +70,8 @@ ifeq ($(BUILD_VARIANT),wide)
 endif
 
 define Package/less/install
-	$(INSTALL_DIR) $(1)/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/less $(1)/bin/less
-endef
-
-define Package/less/postinst
-#!/bin/sh
-[ -L "$${IPKG_INSTROOT}/usr/bin/less" ] && rm -f "$${IPKG_INSTROOT}/usr/bin/less"
-exit 0
-endef
-
-define Package/less/postrm
-#!/bin/sh
-/bin/busybox less -h 2>&1 | grep -q BusyBox && ln -sf ../../bin/busybox /usr/bin/less
-exit 0
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/less $(1)/usr/bin/less
 endef
 
 Package/less-wide/install = $(Package/less/install)


### PR DESCRIPTION
Maintainer: @Zokormazo
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master + 19.07
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07

Description:

This package can not be installed if you have installed less from
busybox.

Collected errors:
```
 * check_data_file_clashes: Package less wants to install file /bin/less
        But that file is already provided by package  * busybox
 * opkg_install_cmd: Cannot install package less.
```

To avoid this error, I moved it from /bin/less to /usr/bin/less. If you install it now, it changes symlink from busybox to /usr/bin/less.

Before:
```
root@turris:~# ll /bin/less
lrwxrwxrwx    1 root     root             7 Apr 21 21:05 /bin/less -> busybox*
```

After:
```
root@turris:~# opkg install less_530-1_arm_cortex-a9_vfpv3.ipk 
Installing less (530-1) to root...
Configuring less.
root@turris:~# ll /bin/less
lrwxrwxrwx    1 root     root            13 Apr 21 21:28 /bin/less -> /usr/bin/less*
```

When you remove it, it changes symlink back to busybox.

```
root@turris:~# opkg remove less
Removing package less from root...
root@turris:~# ll /bin/less
lrwxrwxrwx    1 root     root            12 Apr 21 21:33 /bin/less -> /bin/busybox*
```

That's why postint and postrm scripts are no longer needed.


