### PR TITLE
Support building freeradius3-mod-rest

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=release_3_0_20
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive
@@ -456,6 +456,16 @@ define Package/freeradius3-mod-unix/conffiles
 /etc/freeradius3/mods-enabled/unix
 endef
 
+define Package/freeradius3-mod-rest
+  $(call Package/freeradius3/Default)
+  DEPENDS:=freeradius3 +libcurl +libjson-c
+  TITLE:=Radius REST module
+endef
+
+define Package/freeradius3-mod-rest/conffiles
+/etc/freeradius3/mods-available/rest
+endef
+
 define Package/freeradius3-utils
   $(call Package/freeradius3/Default)
   DEPENDS:=+freeradius3-common
@@ -504,7 +514,6 @@ CONFIGURE_ARGS+= \
 	--without-rlm_python \
 	--without-rlm_redis \
 	--without-rlm_rediswho \
-	--without-rlm_rest \
 	--without-rlm_ruby \
 	--without-rlm_securid \
 	--without-rlm_smsotp \
@@ -629,6 +638,13 @@ ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-unix),)
 else
   CONFIGURE_ARGS+= --without-rlm_unix
 endif
+
+ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-rest),)
+  CONFIGURE_ARGS+= --with-rlm_rest
+else
+  CONFIGURE_ARGS+= --without-rlm_rest
+endif
+
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_freeradius3-mod-ldap),)
   CONFIGURE_ARGS+= --with-rlm_ldap \
@@ -778,4 +794,5 @@ $(eval $(call BuildPlugin,freeradius3-mod-sql-sqlite,rlm_sql_sqlite,))
 $(eval $(call BuildPlugin,freeradius3-mod-sqlcounter,rlm_sqlcounter,))
 $(eval $(call BuildPlugin,freeradius3-mod-sqlippool,rlm_sqlippool,))
 $(eval $(call BuildPlugin,freeradius3-mod-unix,rlm_unix,))
+$(eval $(call BuildPlugin,freeradius3-mod-rest,rlm_rest,))
 $(eval $(call BuildPackage,freeradius3-utils))


### PR DESCRIPTION
Signed-off-by: Tobias Girstmair <tobias.girstmair@tirol.gv.at>

Maintainer: @jefferyto (last touched Makefile; PKG_MAINTAINER is empty)
Compile tested: ar71xx; Mikrotik 450g; OpenWrt 19.07.2
Run tested: ar71xx; Mikrotik 450g; OpenWrt 19.07.2

Description:
We require this package at work and would like to ask the maintainers of OpenWrt to include these compile options. We suspect the reason for excluding rlm\_rest was that building it was initially rather complicated; however, this has been remedied by upstream some time ago.

Also, I have targeted this PR to master, but would like to ask for this subpackage to be built for and included in the repository of OpenWrt 19.07 as well. Should I open a second pull request for this?

Thank you in advance and please don't hesitate to ask anything.