### PR TITLE
python-packages: Clean up Makefiles

### DIFF
--- a/lang/python/Flask/Makefile
+++ b/lang/python/Flask/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Flask
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52
@@ -30,7 +30,6 @@ define Package/python3-flask
            +python3-itsdangerous +python3-jinja2 +python3 +python3-logging \
            +python3-markupsafe +python3-multiprocessing +python3-setuptools \
            +python3-werkzeug
-  VARIANT:=python3
 endef
 
 define Package/python3-flask/description

--- a/lang/python/Jinja2/Makefile
+++ b/lang/python/Jinja2/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Jinja2
 PKG_VERSION:=2.10.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de
@@ -27,7 +27,6 @@ define Package/python3-jinja2
   TITLE:=Jinja2
   URL:=http://jinja.pocoo.org/
   DEPENDS:=+python3-light +python3-markupsafe
-  VARIANT:=python3
 endef
 
 define Package/python3-jinja2/description

--- a/lang/python/MarkupSafe/Makefile
+++ b/lang/python/MarkupSafe/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=MarkupSafe
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b
@@ -26,7 +26,6 @@ define Package/python3-markupsafe
   TITLE:=MarkupSafe
   URL:=https://palletsprojects.com/p/markupsafe/
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-markupsafe/description

--- a/lang/python/Werkzeug/Makefile
+++ b/lang/python/Werkzeug/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Werkzeug
 PKG_VERSION:=0.16.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=7280924747b5733b246fe23972186c6b348f9ae29724135a6dfc1e53cea433e7
@@ -26,7 +26,6 @@ define Package/python3-werkzeug
   TITLE:=Werkzeug
   URL:=https://palletsprojects.com/p/werkzeug/
   DEPENDS:=+python3-light +python3-email
-  VARIANT:=python3
 endef
 
 define Package/python3-werkzeug/description

--- a/lang/python/bcrypt/Makefile
+++ b/lang/python/bcrypt/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcrypt
 PKG_VERSION:=3.1.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=0b0069c752ec14172c5f78208f1863d7ad6755a6fae6fe76ec2c80d13be41e42
@@ -22,27 +22,20 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/bcrypt/Default
+define Package/python3-bcrypt
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Modern password hashing
   URL:=https://github.com/pyca/bcrypt/
-endef
-
-define Package/python3-bcrypt
-$(call Package/bcrypt/Default)
   DEPENDS:= \
-	+PACKAGE_python3-bcrypt:python3 \
-	+PACKAGE_python3-bcrypt:python3-cffi \
-	+PACKAGE_python3-bcrypt:python3-six
-  VARIANT:=python3
+	+python3 \
+	+python3-cffi \
+	+python3-six
 endef
 
 define Package/python3-bcrypt/description
   Good password hashing for your software and your servers.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-bcrypt))

--- a/lang/python/click-log/Makefile
+++ b/lang/python/click-log/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=click-log
 PKG_VERSION:=0.3.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 
 PKG_SOURCE_URL:=https://codeload.github.com/click-contrib/click-log/tar.gz/$(PKG_VERSION)?
@@ -24,7 +24,6 @@ define Package/python3-click-log
   URL:=http://github.com/mitsuhiko/click
   TITLE:=python3-click-log
   DEPENDS:=+python3-click
-  VARIANT:=python3
 endef
 
 define Package/python3-click-log/description

--- a/lang/python/click/Makefile
+++ b/lang/python/click/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=click
 PKG_VERSION:=7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PYPI_SOURCE_NAME:=Click
@@ -27,7 +27,6 @@ define Package/python3-click
   TITLE:=Click
   URL:=https://palletsprojects.com/p/click/
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-click/description

--- a/lang/python/django-appconf/Makefile
+++ b/lang/python/django-appconf/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-appconf
 PKG_VERSION:=1.0.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=35f13ca4d567f132b960e2cd4c832c2d03cb6543452d34e29b7ba10371ba80e3
@@ -22,27 +22,20 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/django-appconf/Default
+define Package/python3-django-appconf
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Helper class for handling config defaults
   URL:=https://django-appconf.readthedocs.io
-endef
-
-define Package/python3-django-appconf
-$(call Package/django-appconf/Default)
   DEPENDS:= \
-	+PACKAGE_python3-django-appconf:python3 \
-	+PACKAGE_python3-django-appconf:python3-django1 \
-	+PACKAGE_python3-django-appconf:python3-six
-  VARIANT:=python3
+	+python3 \
+	+python3-django1 \
+	+python3-six
 endef
 
 define Package/python3-django-appconf/description
   A helper class for handling configuration defaults of packaged apps gracefully
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-django-appconf))

--- a/lang/python/django-compressor/Makefile
+++ b/lang/python/django-compressor/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-compressor
 PKG_VERSION:=2.2
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PYPI_NAME:=$(PKG_NAME)
 PYPI_SOURCE_NAME:=django_compressor
@@ -23,22 +23,17 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/django-compressor/Default
+define Package/python3-django-compressor
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Compress CSS/JS into single cached files
   URL:=https://django-compressor.readthedocs.io
-endef
-
-define Package/python3-django-compressor
-$(call Package/django-compressor/Default)
   DEPENDS:= \
-	+PACKAGE_python3-django-compressor:python3 \
-	+PACKAGE_python3-django-compressor:python3-django1 \
-	+PACKAGE_python3-django-compressor:python3-django-appconf \
-	+PACKAGE_python3-django-compressor:python3-rcssmin
-  VARIANT:=python3
+	+python3 \
+	+python3-django1 \
+	+python3-django-appconf \
+	+python3-rcssmin
 endef
 
 define Package/python3-django-compressor/description
@@ -46,8 +41,6 @@ define Package/python3-django-compressor/description
   Note that the JavaScript filter is not being installed as a dependency.
   You'll need to build the rjsmin module (it is not par of the openwrt standard
   feeds) to use JavaScript functionality.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-django-compressor))

--- a/lang/python/django-formtools/Makefile
+++ b/lang/python/django-formtools/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-formtools
 PKG_VERSION:=2.1
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=7703793f1675aa6e871f9fed147e8563816d7a5b9affdc5e3459899596217f7c
@@ -20,27 +20,20 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/django-formtools/Default
+define Package/python3-django-formtools
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=High-level abstractions for Django forms
   URL:=https://django-formtools.readthedocs.io
-endef
-
-define Package/python3-django-formtools
-$(call Package/django-formtools/Default)
   DEPENDS:= \
-	+PACKAGE_python3-django-formtools:python3 \
-	+PACKAGE_python3-django-formtools:python3-django1
-  VARIANT:=python3
+	+python3 \
+	+python3-django1
 endef
 
 define Package/python3-django-formtools/description
   Django "formtools" is a set of high-level abstractions for Django forms.
   Currently for form previews and multi-step forms.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-django-formtools))

--- a/lang/python/django-jsonfield/Makefile
+++ b/lang/python/django-jsonfield/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-jsonfield
 PKG_VERSION:=2.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=jsonfield
 PKG_HASH:=ed7c5e1829e9453e24a8bebef1e702ffe402e6def6b326f0e0b88764c59a6dc7
@@ -22,28 +22,21 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/django-jsonfield/Default
+define Package/python3-django-jsonfield
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=A reusable Django field to store validated JSON in models
   URL:=https://github.com/rpkilby/jsonfield
-endef
-
-define Package/python3-django-jsonfield
-$(call Package/django-jsonfield/Default)
   DEPENDS:= \
-	+PACKAGE_python3-django-jsonfield:python3 \
-	+PACKAGE_python3-django-jsonfield:python3-django1 \
-	+PACKAGE_python3-django-jsonfield:python3-six
-  VARIANT:=python3
+	+python3 \
+	+python3-django1 \
+	+python3-six
 endef
 
 define Package/python3-django-jsonfield/description
   jsonfield is a reusable model field that allows you to store validated
   JSON, automatically handling serialization to and from the database.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-django-jsonfield))

--- a/lang/python/django-picklefield/Makefile
+++ b/lang/python/django-picklefield/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-picklefield
 PKG_VERSION:=2.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=67a5e156343e3b032cac2f65565f0faa81635a99c7da74b0f07a0f5db467b646
@@ -25,26 +25,19 @@ include ../python3-package.mk
 PYTHON3_PKG_SETUP_VARS:= \
   PKG_VERSION="$(PKG_VERSION)"
 
-define Package/django-picklefield/Default
+define Package/python3-django-picklefield
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Pickled object field for Django
   URL:=https://github.com/gintas/django-picklefield/
-endef
-
-define Package/python3-django-picklefield
-$(call Package/django-picklefield/Default)
   DEPENDS:= \
-	+PACKAGE_python3-django-picklefield:python3 \
-	+PACKAGE_python3-django-picklefield:python3-django1
-  VARIANT:=python3
+	+python3 \
+	+python3-django1
 endef
 
 define Package/python3-django-picklefield/description
   Pickled object field for Django
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-django-picklefield))

--- a/lang/python/django-postoffice/Makefile
+++ b/lang/python/django-postoffice/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-postoffice
 PKG_VERSION:=3.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=django-post-office
 PYPI_SOURCE_NAME:=django-post_office
@@ -23,28 +23,21 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/django-postoffice/Default
+define Package/python3-django-postoffice
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=A Django app to monitor and send mail asynchronously
   URL:=https://github.com/ui/django-post_office
-endef
-
-define Package/python3-django-postoffice
-$(call Package/django-postoffice/Default)
   DEPENDS:= \
-	+PACKAGE_python3-django-postoffice:python3 \
-	+PACKAGE_python3-django-postoffice:python3-django1 \
-	+PACKAGE_python3-django-postoffice:python3-django-jsonfield
-  VARIANT:=python3
+	+python3 \
+	+python3-django1 \
+	+python3-django-jsonfield
 endef
 
 define Package/python3-django-postoffice/description
   A Django app to monitor and send mail asynchronously, complete with template
   support
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-django-postoffice))

--- a/lang/python/django-ranged-response/Makefile
+++ b/lang/python/django-ranged-response/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-ranged-response
 PKG_VERSION:=0.2.0
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=f71fff352a37316b9bead717fc76e4ddd6c9b99c4680cdf4783b9755af1cf985
@@ -20,26 +20,19 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/django-ranged-response/Default
+define Package/python3-django-ranged-response
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Add Content-Range: to FileResponse
   URL:=https://github.com/i3thuan5/django-ranged-response
-endef
-
-define Package/python3-django-ranged-response
-$(call Package/django-ranged-response/Default)
   DEPENDS:= \
-	+PACKAGE_python3-django-ranged-response:python3 \
-	+PACKAGE_python3-django-ranged-response:python3-django1
-  VARIANT:=python3
+	+python3 \
+	+python3-django1
 endef
 
 define Package/python3-django-ranged-response/description
   Modified Django FileResponse that adds Content-Range headers.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-django-ranged-response))

--- a/lang/python/django-restframework/Makefile
+++ b/lang/python/django-restframework/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-restframework
 PKG_VERSION:=3.11.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=djangorestframework
 PKG_HASH:=e782087823c47a26826ee5b6fa0c542968219263fb3976ec3c31edab23a4001f
@@ -29,13 +29,10 @@ define Package/python3-django-restframework
   TITLE:=Web APIs for Django, made easy.
   URL:=https://www.django-rest-framework.org
   DEPENDS:=+python3 +django
-  VARIANT:=python3
 endef
 
 define Package/python3-django-restframework/description
   Web APIs for Django, made easy.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-django-restframework))

--- a/lang/python/django-restframework39/Makefile
+++ b/lang/python/django-restframework39/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-restframework39
 PKG_VERSION:=3.9.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=djangorestframework
 PKG_HASH:=c12869cfd83c33d579b17b3cb28a2ae7322a53c3ce85580c2a2ebe4e3f56c4fb
@@ -22,27 +22,20 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/django-restframework39/Default
+define Package/python3-django-restframework39
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Web APIs for Django, made easy.
   URL:=https://www.django-rest-framework.org
-endef
-
-define Package/python3-django-restframework39
-$(call Package/django-restframework39/Default)
   DEPENDS:= \
-	+PACKAGE_python3-django-restframework39:python3 \
-	+PACKAGE_python3-django-restframework39:python3-django1
+	+python3 \
+	+python3-django1
   CONFLICTS:=python3-django-restframework
-  VARIANT:=python3
 endef
 
 define Package/python3-django-restframework39/description
   Web APIs for Django, made easy. (3.9 series)
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-django-restframework39))

--- a/lang/python/django-simple-captcha/Makefile
+++ b/lang/python/django-simple-captcha/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-simple-captcha
 PKG_VERSION:=0.5.12
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/mbi/django-simple-captcha/tar.gz/v$(PKG_VERSION)?
@@ -19,37 +19,26 @@ PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
-define Package/django-simple-captcha/Default
+define Package/python3-django-simple-captcha
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Simple Django captcha application
   URL:=https://github.com/mbi/django-simple-captcha
-endef
-
-define Package/python3-django-simple-captcha
-$(call Package/django-simple-captcha/Default)
   DEPENDS:= \
-	+PACKAGE_python3-django-simple-captcha:python3 \
-	+PACKAGE_python3-django-simple-captcha:python3-six \
-	+PACKAGE_python3-django-simple-captcha:python3-django1 \
-	+PACKAGE_python3-django-simple-captcha:python3-pillow \
-	+PACKAGE_python3-django-simple-captcha:python3-django-ranged-response
-  VARIANT:=python3
+	+python3 \
+	+python3-six \
+	+python3-django1 \
+	+python3-pillow \
+	+python3-django-ranged-response
 endef
 
 define Package/python3-django-simple-captcha/description
   Django Simple Captcha is an extremely simple, yet highly customizable Django
   application to add captcha images to any Django form.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-django-simple-captcha))

--- a/lang/python/django-statici18n/Makefile
+++ b/lang/python/django-statici18n/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-statici18n
 PKG_VERSION:=1.9.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=913dd056c1abcbe129b1db806cb4cfb821c4077d7e857d6eb29043ea64f4d1d0
@@ -22,28 +22,21 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/django-statici18n/Default
+define Package/python3-django-statici18n
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Helper for generating JavaScript catalog to static files
   URL:=https://django-statici18n.readthedocs.io
-endef
-
-define Package/python3-django-statici18n
-$(call Package/django-statici18n/Default)
   DEPENDS:= \
-	+PACKAGE_python3-django-statici18n:python3 \
-	+PACKAGE_python3-django-statici18n:python3-django1 \
-	+PACKAGE_python3-django-statici18n:python3-django-appconf \
-	+PACKAGE_python3-django-statici18n:python3-six
-  VARIANT:=python3
+	+python3 \
+	+python3-django1 \
+	+python3-django-appconf \
+	+python3-six
 endef
 
 define Package/python3-django-statici18n/description
   A Django app that provides helper for generating JavaScript catalog to static files.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-django-statici18n))

--- a/lang/python/django-webpack-loader/Makefile
+++ b/lang/python/django-webpack-loader/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-webpack-loader
 PKG_VERSION:=0.6.0
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=60bab6b9a037a5346fad12d2a70a6bc046afb33154cf75ed640b93d3ebd5f520
@@ -20,26 +20,19 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/django-webpack-loader/Default
+define Package/python3-django-webpack-loader
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Transparently use webpack in django
   URL:=https://github.com/owais/django-webpack-loader
-endef
-
-define Package/python3-django-webpack-loader
-$(call Package/django-webpack-loader/Default)
   DEPENDS:= \
-	+PACKAGE_python3-django-webpack-loader:python3 \
-	+PACKAGE_python3-django-webpack-loader:python3-django1
-  VARIANT:=python3
+	+python3 \
+	+python3-django1
 endef
 
 define Package/python3-django-webpack-loader/description
   Use webpack to generate your static bundles without django’s staticfiles or opaque wrappers.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-django-webpack-loader))

--- a/lang/python/django/Makefile
+++ b/lang/python/django/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django
 PKG_VERSION:=3.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=Django
 PKG_HASH:=d4666c2edefa38c5ede0ec1655424c56dc47ceb04b6d8d62a7eac09db89545c1
@@ -32,12 +32,10 @@ define Package/python3-django
   DEPENDS:= +python3 +python3-pytz +python3-sqlparse +python3-asgiref
   CONFLICTS:=python3-django1 python-django1-common
   PROVIDES:=django
-  VARIANT:=python3
 endef
 
 define Package/python3-django/description
-    The web framework for perfectionists with deadlines (LTS 2.2 series).
-    Python3 only.
+    The web framework for perfectionists with deadlines.
 endef
 
 define Py3Package/python3-django/install

--- a/lang/python/django1/Makefile
+++ b/lang/python/django1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django1
 PKG_VERSION:=1.11.29
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=Django
 PKG_HASH:=4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c
@@ -34,17 +34,14 @@ endef
 define Package/python3-django1
 $(call Package/django1/Default)
   DEPENDS:= \
-	+PACKAGE_python3-django1:python3 \
-	+PACKAGE_python3-django1:python3-pytz \
-	+PACKAGE_python3-django1:python-django1-common
-  VARIANT:=python3
+	+python3 \
+	+python3-pytz \
+	+python-django1-common
   PROVIDES:=django
 endef
 
 define Package/python3-django1/description
   The web framework for perfectionists with deadlines (LTS 1.11 series).
-.
-(Variant for Python3)
 endef
 
 define Package/python-django1-common

--- a/lang/python/gunicorn/Makefile
+++ b/lang/python/gunicorn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gunicorn
 PKG_VERSION:=20.0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626
@@ -34,13 +34,10 @@ define Package/python3-gunicorn
 $(call Package/gunicorn/Default)
   TITLE:=WSGI HTTP Server for UNIX (library)
   DEPENDS:=+python3
-  VARIANT:=python3
 endef
 
 define Package/python3-gunicorn/description
     WSGI HTTP Server for UNIX (libraries)
-.
-(Variant for Python3)
 endef
 
 # Make sure that the binaries are not installed with the libraries
@@ -56,8 +53,6 @@ endef
 
 define Package/gunicorn3/description
     WSGI HTTP Server for UNIX (daemon)
-.
-(Variant for Python3)
 endef
 
 define Package/gunicorn3/install

--- a/lang/python/itsdangerous/Makefile
+++ b/lang/python/itsdangerous/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=itsdangerous
 PKG_VERSION:=1.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19
@@ -26,7 +26,6 @@ define Package/python3-itsdangerous
   TITLE:=ItsDangerous
   URL:=https://palletsprojects.com/p/itsdangerous/
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-itsdangerous/description

--- a/lang/python/openpyxl/Makefile
+++ b/lang/python/openpyxl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-openpyxl
 PKG_VERSION:=3.0.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
@@ -29,13 +29,10 @@ define Package/python3-openpyxl
   TITLE:=A Python library to read/write Excel 2010 xlsx/xlsm files
   URL:=https://openpyxl.readthedocs.org/
   DEPENDS:=+python3 +python3-defusedxml +python3-et_xmlfile +python3-jdcal
-  VARIANT:=python3
 endef
 
 define Package/python3-openpyxl/description
   A Python library to read/write Excel 2010 xlsx/xlsm files
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-openpyxl))

--- a/lang/python/passlib/Makefile
+++ b/lang/python/passlib/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=passlib
 PKG_VERSION:=1.7.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=BSD-3-Clause
 
 PYPI_NAME:=$(PKG_NAME)
@@ -16,18 +16,13 @@ include $(INCLUDE_DIR)/package.mk
 
 include ../python3-package.mk
 
-define Package/passlib/Default
+define Package/python3-passlib
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Comprehensive password hashing framework
   URL:=https://bitbucket.org/ecollins/passlib
-endef
-
-define Package/python3-passlib
-$(call Package/passlib/Default)
-  DEPENDS:=+PACKAGE_python3-passlib:python3 +PACKAGE_python3-passlib:python3-dateutil
-  VARIANT:=python3
+  DEPENDS:=+python3 +python3-dateutil
 endef
 
 define Package/python3-passlib/description
@@ -37,8 +32,6 @@ as well as a framework for managing existing password hashes. It’s
 designed to be useful for a wide range of tasks, from verifying a hash
 found in /etc/shadow, to providing full-strength password hashing for
 multi-user applications.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-passlib))

--- a/lang/python/pillow/Makefile
+++ b/lang/python/pillow/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pillow
 PKG_VERSION:=7.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=Pillow
 PKG_HASH:=0f89ddc77cf421b8cd34ae852309501458942bf370831b4a9b406156b599a14e
@@ -22,25 +22,17 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-pillow/Default
+define Package/python3-pillow
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=The friendly PIL fork
   URL:=https://python-pillow.org/
-  DEPENDS:=+libfreetype +libjpeg +libtiff +zlib
-endef
-
-define Package/python3-pillow
-$(call Package/python-pillow/Default)
-  DEPENDS+=+python3
-  VARIANT:=python3
+  DEPENDS:=+libfreetype +libjpeg +libtiff +zlib +python3
 endef
 
 define Package/python3-pillow/description
   The friendly PIL fork
-.
-(Variant for Python3)
 endef
 
 PYTHON3_PKG_SETUP_GLOBAL_ARGS += build_ext \

--- a/lang/python/pyjwt/Makefile
+++ b/lang/python/pyjwt/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pyjwt
 PKG_VERSION:=1.7.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=MIT
@@ -20,24 +20,17 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-pyjwt/Default
+define Package/python3-pyjwt
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=JSON Web Token implementation in Python
   URL:=http://github.com/jpadilla/pyjwt
-endef
-
-define Package/python3-pyjwt
-  $(call Package/python-pyjwt/Default)
-  DEPENDS:=+PACKAGE_python3-pyjwt:python3
-  VARIANT:=python3
+  DEPENDS:=+python3
 endef
 
 define Package/python3-pyjwt/description
   A Python implementation of RFC 7519.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-pyjwt))

--- a/lang/python/pymysql/Makefile
+++ b/lang/python/pymysql/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pymysql
 PKG_VERSION:=0.9.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=PyMySQL
 PKG_HASH:=d8c059dcd81dedb85a9f034d5e22dcb4442c0b201908bede99e306d65ea7c8e7
@@ -31,7 +31,6 @@ define Package/python3-pymysql
   TITLE:=Pure Python MySQL Client
   URL:=https://pymysql.readthedocs.io/
   DEPENDS:=+python3 +PYTHON3_PYMYSQL_SHA_PASSWORD_SUPPORT:python3-cryptography
-  VARIANT:=python3
 endef
 
 define Package/python3-pymysql/config

--- a/lang/python/pyodbc/Makefile
+++ b/lang/python/pyodbc/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pyodbc
 PKG_VERSION:=4.0.26
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=e52700b5d24a846483b5ab80acd9153f8e593999c9184ffea11596288fb33de3
@@ -22,19 +22,13 @@ include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-pyodbc/Default
+define Package/python3-pyodbc
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  URL:=https://github.com/mkleehammer/pyodbc
-  DEPENDS:=+unixodbc $(CXX_DEPENDS)
-endef
-
-define Package/python3-pyodbc
-$(call Package/python-pyodbc/Default)
   TITLE:=python3-pyodbc
-  DEPENDS+=+PACKAGE_python3-pyodbc:python3-light
-  VARIANT:=python3
+  URL:=https://github.com/mkleehammer/pyodbc
+  DEPENDS:=+unixodbc +python3-light $(CXX_DEPENDS)
 endef
 
 define Package/python3-pyodbc/description
@@ -42,8 +36,6 @@ DB API Module for ODBC
 
 A Python DB API 2 module for ODBC. This project provides an up-to-date,
 convenient interface to ODBC using native data types like datetime and decimal.
-
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-pyodbc))

--- a/lang/python/python-aiohttp-cors/Makefile
+++ b/lang/python/python-aiohttp-cors/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aiohttp-cors
 PKG_VERSION:=0.7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=aiohttp_cors
 PYPI_SOURCE_NAME:=aiohttp-cors
@@ -32,7 +32,6 @@ define Package/python3-aiohttp-cors
   DEPENDS:= \
 	+python3-aiohttp \
 	+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-aiohttp-cors/description

--- a/lang/python/python-aiohttp/Makefile
+++ b/lang/python/python-aiohttp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=aiohttp
 PKG_VERSION:=3.6.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=fc55b1fec0e4cc1134ffb09ea3970783ee2906dc5dfd7cd16917913f2cfed65b
@@ -40,7 +40,6 @@ define Package/python3-aiohttp
 	+python3-codecs \
 	+python3-cgi \
 	+python3-openssl
-  VARIANT:=python3
 endef
 
 define Package/python3-aiohttp/description

--- a/lang/python/python-appdirs/Makefile
+++ b/lang/python/python-appdirs/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-appdirs
 PKG_VERSION:=1.4.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 
 PYPI_NAME:=appdirs
@@ -24,7 +24,6 @@ define Package/python3-appdirs
   URL:=https://github.com/ActiveState/appdirs
   TITLE:=python3-appdirs
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python-appdirs/description

--- a/lang/python/python-asn1crypto/Makefile
+++ b/lang/python/python-asn1crypto/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-asn1crypto
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=asn1crypto
 PKG_HASH:=5a215cb8dc12f892244e3a113fe05397ee23c5c4ca7a69cd6e69811755efc42d
@@ -29,7 +29,6 @@ define Package/python3-asn1crypto
   URL:=https://github.com/wbond/asn1crypto
   TITLE:=Fast pure Python lib for ASN1 structures
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-asn1crypto/description

--- a/lang/python/python-astral/Makefile
+++ b/lang/python/python-astral/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-astral
 PKG_VERSION:=1.10.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=astral
 PKG_HASH:=d2a67243c4503131c856cafb1b1276de52a86e5b8a1d507b7e08bee51cb67bf1
@@ -22,26 +22,19 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-astral/Default
+define Package/python3-astral
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Calculations for the position of the sun and moon
   URL:=https://github.com/sffjunkie/astral
-endef
-
-define Package/python3-astral
-$(call Package/python-astral/Default)
   DEPENDS+= \
-      +PACKAGE_python3-astral:python3-light \
-      +PACKAGE_python3-astral:python3-pytz
-  VARIANT:=python3
+      +python3-light \
+      +python3-pytz
 endef
 
 define Package/python3-astral/description
 Astral is a python module for calculating the times of various aspects of the sun and moon.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-astral))

--- a/lang/python/python-async-timeout/Makefile
+++ b/lang/python/python-async-timeout/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=async-timeout
 PKG_VERSION:=3.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=async_timeout
 PYPI_SOURCE_NAME:=async-timeout
@@ -32,7 +32,6 @@ define Package/python3-async-timeout
   DEPENDS:= \
   +python3-light \
   +python3-asyncio
-  VARIANT:=python3
 endef
 
 define Package/python3-async-timeout/description

--- a/lang/python/python-atomicwrites/Makefile
+++ b/lang/python/python-atomicwrites/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-atomicwrites
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=atomicwrites
 PKG_HASH:=75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6
@@ -29,7 +29,6 @@ define Package/python3-atomicwrites
   TITLE:=Atomic file writes
   URL:=https://github.com/untitaker/python-atomicwrites
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-atomicwrites/description

--- a/lang/python/python-attrs/Makefile
+++ b/lang/python/python-attrs/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-attrs
 PKG_VERSION:=19.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=attrs
 PKG_HASH:=f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72
@@ -22,26 +22,19 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-attrs/Default
+define Package/python3-attrs
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Classes Without Boilerplate
   URL:=https://www.attrs.org/
-endef
-
-define Package/python3-attrs
-$(call Package/python-attrs/Default)
-  DEPENDS:=+PACKAGE_python3-attrs:python3-light
-  VARIANT:=python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-attrs/description
 attrs is an MIT-licensed Python package with class decorators that ease
 the chores of implementing the most common attribute-related object
 protocols.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-attrs))

--- a/lang/python/python-automat/Makefile
+++ b/lang/python/python-automat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-automat
 PKG_VERSION:=20.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=Automat
 PKG_HASH:=7979803c74610e11ef0c0d68a2942b152df52da55336e0c9d58daf1831cbdf33
@@ -25,29 +25,22 @@ include ../python3-package.mk
 PYTHON3_PKG_SETUP_VARS:= \
   PKG_VERSION="$(PKG_VERSION)"
 
-define Package/python-automat/Default
+define Package/python3-automat
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Concise, idiomatic finite-state automata
   URL:=https://github.com/glyph/Automat
-endef
-
-define Package/python3-automat
-$(call Package/python-automat/Default)
   DEPENDS:= \
-      +PACKAGE_python3-automat:python3-light \
-      +PACKAGE_python3-automat:python3-attrs \
-      +PACKAGE_python3-automat:python3-six
-  VARIANT:=python3
+      +python3-light \
+      +python3-attrs \
+      +python3-six
 endef
 
 define Package/python3-automat/description
 Automat is a library for concise, idiomatic Python expression of
 finite-state automata (particularly deterministic finite-state
 transducers).
-.
-(Variant for Python3)
 endef
 
 define Py3Package/python3-automat/filespec

--- a/lang/python/python-awscli/Makefile
+++ b/lang/python/python-awscli/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=awscli
 PKG_VERSION:=1.16.75
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=8d96ec0de325ea8271cc6aa95b7392bbf548ec4aabd3ffbcdc0619b64edd4a45
@@ -14,31 +14,24 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-awscli/Default
+define Package/python3-awscli
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=awscli
   URL:=https://github.com/aws/aws-cli
-endef
-
-define Package/python3-awscli
-$(call Package/python-awscli/Default)
-  DEPENDS:=+PACKAGE_python3-awscli:python3 \
-	+PACKAGE_python3-awscli:python3-yaml \
-	+PACKAGE_python3-awscli:python3-pyasn1 \
-	+PACKAGE_python3-awscli:python3-botocore \
-	+PACKAGE_python3-awscli:python3-rsa \
-	+PACKAGE_python3-awscli:python3-colorama \
-	+PACKAGE_python3-awscli:python3-docutils \
-	+PACKAGE_python3-awscli:python3-s3transfer
-  VARIANT:=python3
+  DEPENDS:=+python3 \
+	+python3-yaml \
+	+python3-pyasn1 \
+	+python3-botocore \
+	+python3-rsa \
+	+python3-colorama \
+	+python3-docutils \
+	+python3-s3transfer
 endef
 
 define Package/python3-awscli/description
 This package provides a unified command line interface to Amazon Web Services.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-awscli))

--- a/lang/python/python-boto3/Makefile
+++ b/lang/python/python-boto3/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=boto3
 PKG_VERSION:=1.9.135
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=5e5805992e873e5687b5ef3b4c56c386ccb4df1c3364f8b8601d289e2f275be1
@@ -25,7 +25,6 @@ define Package/python3-boto3
 	+python3-jmespath \
 	+python3-botocore \
 	+python3-s3transfer
-  VARIANT:=python3
 endef
 
 define Package/python3-boto3/description

--- a/lang/python/python-botocore/Makefile
+++ b/lang/python/python-botocore/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=botocore
 PKG_VERSION:=1.12.66
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=25c39ecc71356287cf79d66981ec77deca374e28043b19b2f818d48aa34272a1
@@ -14,30 +14,23 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-botocore/Default
+define Package/python3-botocore
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=botocore
   URL:=https://github.com/boto/botocore
-endef
-
-define Package/python3-botocore
-$(call Package/python-botocore/Default)
-  DEPENDS:=+PACKAGE_python3-botocore:python3 \
-	+PACKAGE_python3-botocore:python3-urllib3 \
-	+PACKAGE_python3-botocore:python3-docutils \
-	+PACKAGE_python3-botocore:python3-dateutil \
-	+PACKAGE_python3-botocore:python3-jmespath \
-	+PACKAGE_python3-botocore:python3-requests
-  VARIANT:=python3
+  DEPENDS:=+python3 \
+	+python3-urllib3 \
+	+python3-docutils \
+	+python3-dateutil \
+	+python3-jmespath \
+	+python3-requests
 endef
 
 define Package/python3-botocore/description
 A low-level interface to a growing number of Amazon Web Services.
 The botocore package is the foundation for the AWS CLI as well as boto3.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-botocore))

--- a/lang/python/python-cachelib/Makefile
+++ b/lang/python/python-cachelib/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cachelib
 PKG_VERSION:=0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=cachelib
 PKG_HASH:=8b889b509d372095357b8705966e1282d40835c4126d7c2b07fd414514d8ae8d
@@ -26,7 +26,6 @@ define Package/python3-cachelib
   TITLE:=cachelib
   URL:=https://github.com/pallets/cachelib
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-cachelib/description

--- a/lang/python/python-cachetools/Makefile
+++ b/lang/python/python-cachetools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cachetools
 PKG_VERSION:=3.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=cachetools
 PKG_HASH:=8ea2d3ce97850f31e4a08b0e2b5e6c34997d7216a9d2c98e0f3978630d4da69a
@@ -29,7 +29,6 @@ define Package/python3-cachetools
   TITLE:=Extensible memoizing collections and decorators
   URL:=https://github.com/tkem/cachetools
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-cachetools/description

--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
 PKG_VERSION:=2019.11.28
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=MPL-2.0
@@ -20,25 +20,18 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-certifi/Default
+define Package/python3-certifi
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Python package for Mozilla's CA Bundle
   URL:=http://certifi.io/
-endef
-
-define Package/python3-certifi
-  $(call Package/python-certifi/Default)
-  DEPENDS:=+PACKAGE_python3-certifi:python3-light
-  VARIANT:=python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-certifi/description
   Certifi is a carefully curated collection of Root Certificates for validating the
   trustworthiness of SSL certificates while verifying the identity of TLS hosts.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-certifi))

--- a/lang/python/python-cffi/Makefile
+++ b/lang/python/python-cffi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cffi
 PKG_VERSION:=1.14.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=cffi
 PKG_HASH:=2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6
@@ -22,27 +22,20 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-cffi/Default
+define Package/python3-cffi
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=C Foreign Function Interface
   URL:=https://cffi.readthedocs.org/
-  DEPENDS:=+libffi
-endef
-
-define Package/python3-cffi
-$(call Package/python-cffi/Default)
-  DEPENDS+= \
-      +PACKAGE_python3-cffi:python3-light \
-      +PACKAGE_python3-cffi:python3-pycparser
-  VARIANT:=python3
+  DEPENDS:= \
+      +libffi \
+      +python3-light \
+      +python3-pycparser
 endef
 
 define Package/python3-cffi/description
 Foreign Function Interface for Python calling C code.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-cffi))

--- a/lang/python/python-chardet/Makefile
+++ b/lang/python/python-chardet/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-chardet
 PKG_VERSION:=3.0.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=LGPL-2.1
 
 PYPI_NAME:=chardet
@@ -19,25 +19,18 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-chardet/Default
+define Package/python3-chardet
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
   URL:=https://github.com/chardet/chardet
-endef
-
-define Package/python3-chardet
-$(call Package/python-chardet/Default)
-  TITLE:=Universal encoding detector for Python3
-  DEPENDS:=+PACKAGE_python3-chardet:python3-light
-  VARIANT:=python3
+  TITLE:=Universal encoding detector
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-chardet/description
   Universal encoding detector for Python 2 and 3
-.
-(Variant for Python3)
 endef
 
 define Py3Package/python3-chardet/install

--- a/lang/python/python-colorama/Makefile
+++ b/lang/python/python-colorama/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=colorama
 PKG_VERSION:=0.4.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d
@@ -14,25 +14,18 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-colorama/Default
+define Package/python3-colorama
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=colorama
   URL:=https://github.com/tartley/colorama
-endef
-
-define Package/python3-colorama
-$(call Package/python-colorama/Default)
-  DEPENDS:=+PACKAGE_python3-colorama:python3
-  VARIANT:=python3
+  DEPENDS:=+python3
 endef
 
 define Package/python3-colorama/description
 Makes ANSI escape character sequences
 (for producing colored terminal text and cursor positioning) work under MS Windows.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-colorama))

--- a/lang/python/python-constantly/Makefile
+++ b/lang/python/python-constantly/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-constantly
 PKG_VERSION:=15.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=constantly
 PKG_HASH:=586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35
@@ -22,26 +22,19 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-constantly/Default
+define Package/python3-constantly
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Symbolic constants in Python
   URL:=https://github.com/twisted/constantly
-endef
-
-define Package/python3-constantly
-$(call Package/python-constantly/Default)
-  DEPENDS:=+PACKAGE_python3-constantly:python3-light
-  VARIANT:=python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-constantly/description
 A library that provides symbolic constant support. It includes
 collections and constants with text, numeric, and bit flag values.
 Originally twisted.python.constants from the Twisted project.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-constantly))

--- a/lang/python/python-contextlib2/Makefile
+++ b/lang/python/python-contextlib2/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-contextlib2
 PKG_VERSION:=0.5.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 
 PYPI_NAME:=contextlib2
@@ -23,7 +23,6 @@ define Package/python3-contextlib2
   URL:=http://contextlib2.readthedocs.org
   TITLE:=python3-contextlib2
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python-contextlib2/description

--- a/lang/python/python-crypto/Makefile
+++ b/lang/python/python-crypto/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-crypto
 PKG_VERSION:=2.6.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PYPI_NAME:=pycrypto
 PKG_HASH:=f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c
@@ -27,26 +27,18 @@ PYTHON3_PKG_SETUP_ARGS:=
 PYTHON3_PKG_SETUP_VARS:= \
   CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)"
 
-define Package/python-crypto/Default
+define Package/python3-crypto
   SECTION:=lang-python
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Python Cryptography Toolkit
   URL:=https://www.dlitz.net/software/pycrypto/
-  DEPENDS:=+libgmp
-endef
-
-define Package/python3-crypto
-$(call Package/python-crypto/Default)
-  DEPENDS+=+PACKAGE_python3-crypto:python3
-  VARIANT:=python3
+  DEPENDS:=+libgmp +python3
 endef
 
 define Package/python3-crypto/description
 A collection of both secure hash functions (such as MD5 and SHA),
 and various encryption algorithms (AES, DES, IDEA, RSA, ElGamal, etc.).
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-crypto))

--- a/lang/python/python-cryptodome/Makefile
+++ b/lang/python/python-cryptodome/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptodome
 PKG_VERSION:=3.9.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pycryptodome
 PKG_HASH:=f1add21b6d179179b3c177c33d18a2186a09cc0d3af41ff5ed3f377360b869f2
@@ -24,27 +24,19 @@ PYTHON3_PKG_SETUP_ARGS:=
 PYTHON3_PKG_SETUP_VARS:= \
   CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)"
 
-define Package/python-cryptodome/Default
+define Package/python3-cryptodome
   SECTION:=lang-python
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=A self-contained cryptographic library for Python
   URL:=https://www.pycryptodome.org/
-  DEPENDS:=+libgmp
-endef
-
-define Package/python3-cryptodome
-$(call Package/python-cryptodome/Default)
-  DEPENDS+=+PACKAGE_python3-cryptodome:python3
-  VARIANT:=python3
+  DEPENDS:=+libgmp +python3
   CONFLICTS:=python3-crypto
 endef
 
 define Package/python3-cryptodome/description
 PyCryptodome is a self-contained Python package of low-level
 cryptographic primitives.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-cryptodome))

--- a/lang/python/python-cryptodomex/Makefile
+++ b/lang/python/python-cryptodomex/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptodomex
 PKG_VERSION:=3.9.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pycryptodomex
 PKG_HASH:=50163324834edd0c9ce3e4512ded3e221c969086e10fdd5d3fdcaadac5e24a78
@@ -23,26 +23,18 @@ PYTHON3_PKG_SETUP_ARGS:=
 PYTHON3_PKG_SETUP_VARS:= \
   CONFIG_BIG_ENDIAN="$(CONFIG_BIG_ENDIAN)"
 
-define Package/python-cryptodomex/Default
+define Package/python3-cryptodomex
   SECTION:=lang-python
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=A self-contained cryptographic library for Python
   URL:=https://www.pycryptodome.org/
-  DEPENDS:=+libgmp
-endef
-
-define Package/python3-cryptodomex
-$(call Package/python-cryptodomex/Default)
-  DEPENDS+=+PACKAGE_python3-cryptodomex:python3
-  VARIANT:=python3
+  DEPENDS:=+libgmp +python3
 endef
 
 define Package/python3-cryptodomex/description
 PyCryptodome is a self-contained Python package of low-level
 cryptographic primitives.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-cryptodomex))

--- a/lang/python/python-cryptography/Makefile
+++ b/lang/python/python-cryptography/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cryptography
 PKG_VERSION:=2.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=cryptography
 PKG_HASH:=0cacd3ef5c604b8e5f59bf2582c076c98a37fe206b31430d0cd08138aff0986e
@@ -26,30 +26,23 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-cryptography/Default
+define Package/python3-cryptography
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Cryptographic recipes and primitives
   URL:=https://github.com/pyca/cryptography
-  DEPENDS:=+libopenssl
-endef
-
-define Package/python3-cryptography
-$(call Package/python-cryptography/Default)
-  DEPENDS+= \
-      +PACKAGE_python3-cryptography:python3 \
-      +PACKAGE_python3-cryptography:python3-cffi \
-      +PACKAGE_python3-cryptography:python3-six
-  VARIANT:=python3
+  DEPENDS:= \
+      +libopenssl \
+      +python3 \
+      +python3-cffi \
+      +python3-six
 endef
 
 define Package/python3-cryptography/description
 cryptography is a package which provides cryptographic recipes and
 primitives to Python developers.  Our goal is for it to be your "cryptographic
 standard library". It supports Python 2.6-2.7, Python 3.3+, and PyPy 2.6+.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-cryptography))

--- a/lang/python/python-curl/Makefile
+++ b/lang/python/python-curl/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pycurl
 PKG_VERSION:=7.43.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=ec7dd291545842295b7b56c12c90ffad2976cc7070c98d7b1517b7b6cd5994b3
@@ -19,25 +19,17 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-curl/Default
+define Package/python3-curl
   CATEGORY:=Languages
   SECTION:=lang
   SUBMENU:=Python
   TITLE:=Python module interface to the cURL library
   URL:=http://pycurl.io/
-  DEPENDS:=+libcurl
-endef
-
-define Package/python3-curl
-$(call Package/python-curl/Default)
-  DEPENDS+=+PACKAGE_python3-curl:python3
-  VARIANT:=python3
+  DEPENDS:=+libcurl +python3
 endef
 
 define Package/python3-curl/description
 PycURL is a Python interface to libcurl, the multiprotocol file transfer library.
-.
-(Variant for Python3)
 endef
 
 PYTHON3_PKG_SETUP_ARGS:=

--- a/lang/python/python-dateutil/Makefile
+++ b/lang/python/python-dateutil/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dateutil
 PKG_VERSION:=2.8.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=BSD-2-Clause
 
 PYPI_NAME:=$(PKG_NAME)
@@ -21,24 +21,17 @@ include $(INCLUDE_DIR)/package.mk
 
 include ../python3-package.mk
 
-define Package/python-dateutil/Default
+define Package/python3-dateutil
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Extensions to the standard Python datetime module
   URL:=https://dateutil.readthedocs.org/
-endef
-
-define Package/python3-dateutil
-$(call Package/python-dateutil/Default)
-  DEPENDS:=+PACKAGE_python3-dateutil:python3 +PACKAGE_python3-dateutil:python3-six
-  VARIANT:=python3
+  DEPENDS:=+python3 +python3-six
 endef
 
 define Package/python3-dateutil/description
   Extensions to the standard Python datetime module
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-dateutil))

--- a/lang/python/python-decorator/Makefile
+++ b/lang/python/python-decorator/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-decorator
 PKG_VERSION:=4.3.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 PKG_CPE_ID:=cpe:/a:python:decorator
 
@@ -25,7 +25,6 @@ define Package/python3-decorator
   URL:=https://github.com/micheles/decorator
   TITLE:=python3-decodator
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 $(eval $(call Py3Package,python3-decorator))

--- a/lang/python/python-defusedxml/Makefile
+++ b/lang/python/python-defusedxml/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-defusedxml
 PKG_VERSION:=0.6.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=Python-2.0
@@ -20,27 +20,20 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-defusedxml/Default
+define Package/python3-defusedxml
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=XML bomb protection for Python
   URL:=https://github.com/tiran/defusedxml
-endef
-
-define Package/python3-defusedxml
-  $(call Package/python-defusedxml/Default)
   DEPENDS:= \
-	+PACKAGE_python3-defusedxml:python3-light \
-	+PACKAGE_python3-defusedxml:python3-xml
-  VARIANT:=python3
+	+python3-light \
+	+python3-xml
 endef
 
 define Package/python3-defusedxml/description
   The defusedxml package contains several Python-only workarounds and fixes for
   denial of service and other vulnerabilities in Python’s XML libraries.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-defusedxml))

--- a/lang/python/python-dns/Makefile
+++ b/lang/python/python-dns/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dns
 PKG_VERSION:=1.16.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=dnspython-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.dnspython.org/kits/1.16.0/
@@ -20,31 +20,22 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_CPE_ID:=cpe:/a:debian:python-dns
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-dnspython-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/dnspython-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-PKG_UNPACK:=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
-
-define Package/python-dns/Default
+define Package/python3-dns
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=dnspython
   URL:=http://www.dnspython.org/
-endef
-
-define Package/python3-dns
-$(call Package/python-dns/Default)
-  DEPENDS:=+PACKAGE_python3-dns:python3
-  VARIANT:=python3
+  DEPENDS:=+python3
 endef
 
 define Package/python3-dns/description
  dnspython is a DNS toolkit for Python. It supports almost all record types. It can be used for queries, zone transfers, and dynamic updates. It supports TSIG authenticated messages and EDNS0.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-dns))

--- a/lang/python/python-docutils/Makefile
+++ b/lang/python/python-docutils/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docutils
 PKG_VERSION:=0.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274
@@ -14,26 +14,19 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-docutils/Default
+define Package/python3-docutils
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=docutils
   URL:=http://docutils.sourceforge.net
-endef
-
-define Package/python3-docutils
-$(call Package/python-docutils/Default)
-  DEPENDS:=+PACKAGE_python3-docutils:python3
-  VARIANT:=python3
+  DEPENDS:=+python3
 endef
 
 define Package/python3-docutils/description
 Docutils is a modular system for processing documentation into useful formats,
 such as HTML, XML, and LaTeX. For input Docutils supports reStructuredText,
 an easy-to-read, what-you-see-is-what-you-get plaintext markup syntax.
-.
-(Variant for Python3)
 endef
 
 PYTHON3_PKG_SETUP_ARGS:=

--- a/lang/python/python-et_xmlfile/Makefile
+++ b/lang/python/python-et_xmlfile/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-et_xmlfile
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=MIT
@@ -19,28 +19,21 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-et_xmlfile/Default
+define Package/python3-et_xmlfile
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Low memory library for creating large XML files.
   URL:=https://bitbucket.org/openpyxl/et_xmlfile
-endef
-
-define Package/python3-et_xmlfile
-$(call Package/python-et_xmlfile/Default)
   DEPENDS:= \
 	+python3-light \
 	+python3-lxml
-  VARIANT:=python3
 endef
 
 define Package/python3-et_xmlfile/description
   An implementation of lxml.xmlfile for the standard library.
   It is based upon the xmlfile module from lxml with the aim of
   allowing code to be developed that will work with both libraries.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-et_xmlfile))

--- a/lang/python/python-evdev/Makefile
+++ b/lang/python/python-evdev/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=python-evdev
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_MAINTAINER:=Paulo Costa <me@paulo.costa.nom.br>, Alexandru Ardelean <ardeleanalex@gmail.com>
@@ -22,26 +22,19 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-evdev/Default
+define Package/python3-evdev
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  URL:=https://github.com/gvalkov/python-evdev
-endef
-
-define Package/python3-evdev
-$(call Package/python-evdev/Default)
   TITLE:=python3-evdev
+  URL:=https://github.com/gvalkov/python-evdev
   DEPENDS:= \
-      +PACKAGE_python3-evdev:python3-light \
-      +PACKAGE_python3-evdev:python3-ctypes
-  VARIANT:=python3
+      +python3-light \
+      +python3-ctypes
 endef
 
 define Package/python3-evdev/description
 	Bindings to the Linux input handling subsystem
-.
-(Variant for Python3)
 endef
 
 LINUX_EVDEV_HEADERS="$(LINUX_DIR)/include/uapi/linux/input.h:$(LINUX_DIR)/include/uapi/linux/input-event-codes.h"

--- a/lang/python/python-flask-login/Makefile
+++ b/lang/python/python-flask-login/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-flask-login
 PKG_VERSION:=0.5.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=Flask-Login
 PKG_HASH:=6d33aef15b5bcead780acc339464aae8a6e28f13c90d8b1cf9de8b549d1c0b4b
@@ -30,7 +30,6 @@ define Package/python3-flask-login
   TITLE:=User session management plugin for Flask
   URL:=https://github.com/maxcountryman/flask-login
   DEPENDS:=+python3-light +python3-flask
-  VARIANT:=python3
 endef
 
 define Package/python3-flask-login/description

--- a/lang/python/python-gmpy2/Makefile
+++ b/lang/python/python-gmpy2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-gmpy2
 PKG_VERSION:=2.0.8
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PYPI_NAME:=gmpy2
 PYPI_SOURCE_EXT:=zip
@@ -25,19 +25,13 @@ include ../python3-package.mk
 
 PYTHON3_PKG_SETUP_ARGS:=--nompfr
 
-define Package/python-gmpy2/Default
+define Package/python3-gmpy2
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=GMP/MPIR, MPFR, and MPC interface
   URL:=https://github.com/aleaxit/gmpy
-  DEPENDS:=+libgmp
-endef
-
-define Package/python3-gmpy2
-$(call Package/python-gmpy2/Default)
-  DEPENDS+=+PACKAGE_python3-gmpy2:python3-light
-  VARIANT:=python3
+  DEPENDS:=+libgmp +python3-light
 endef
 
 define Package/python3-gmpy2/description
@@ -48,8 +42,6 @@ MPFR (correctly rounded real floating-point arithmetic) and MPC (correctly
 rounded complex floating-point arithmetic) libraries. gmpy2 also updates the
 API and naming conventions to be more consistent and support the additional
 functionality.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-gmpy2))

--- a/lang/python/python-gnupg/Makefile
+++ b/lang/python/python-gnupg/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-gnupg
 PKG_VERSION:=0.4.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=45daf020b370bda13a1429c859fcdff0b766c0576844211446f9266cae97fb0e
@@ -20,19 +20,13 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-gnupg/Default
+define Package/python3-gnupg
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  URL:=https://gnupg.readthedocs.io/en/latest/
-  DEPENDS:=+gnupg
-endef
-
-define Package/python3-gnupg
-$(call Package/python-gnupg/Default)
   TITLE:=python3-gnupg
-  DEPENDS+=+PACKAGE_python3-gnupg:python3-light
-  VARIANT:=python3
+  URL:=https://gnupg.readthedocs.io/en/latest/
+  DEPENDS:=+gnupg +python3-light
 endef
 
 define Package/python3-gnupg/description
@@ -45,8 +39,6 @@ and sanitised, and therefore this module should be safe to use in
 networked applications requiring direct user input. It is intended for
 use on Windows, MacOS X, BSD, or Linux, with Python 2.6, Python 2.7,
 Python 3.3, Python 3.4, or PyPy.
-
-(Variant for Python3)
 endef
 
 define Py3Build/Compile

--- a/lang/python/python-hyperlink/Makefile
+++ b/lang/python/python-hyperlink/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-hyperlink
 PKG_VERSION:=19.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=hyperlink
 PKG_HASH:=4288e34705da077fada1111a24a0aa08bb1e76699c9ce49876af722441845654
@@ -22,28 +22,21 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-hyperlink/Default
+define Package/python3-hyperlink
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Pure-Python immutable URLs
   URL:=https://github.com/python-hyper/hyperlink
-endef
-
-define Package/python3-hyperlink
-$(call Package/python-hyperlink/Default)
   DEPENDS:= \
-      +PACKAGE_python3-hyperlink:python3-light \
-      +PACKAGE_python3-hyperlink:python3-idna
-  VARIANT:=python3
+      +python3-light \
+      +python3-idna
 endef
 
 define Package/python3-hyperlink/description
 Hyperlink provides a pure-Python implementation of immutable URLs. Based
 on RFC 3986 and 3987, the Hyperlink URL makes working with both URIs and
 IRIs easy.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-hyperlink))

--- a/lang/python/python-idna/Makefile
+++ b/lang/python/python-idna/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-idna
 PKG_VERSION:=2.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=idna
 PKG_HASH:=7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb
@@ -22,20 +22,15 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-idna/Default
+define Package/python3-idna
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=IDNA library
   URL:=https://github.com/kjd/idna
-endef
-
-define Package/python3-idna
-$(call Package/python-idna/Default)
   DEPENDS:= \
-      +PACKAGE_python3-idna:python3-light \
-      +PACKAGE_python3-idna:python3-codecs
-  VARIANT:=python3
+      +python3-light \
+      +python3-codecs
 endef
 
 define Package/python3-idna/description
@@ -43,8 +38,6 @@ A library to support the Internationalised Domain Names in Applications
 (IDNA) protocol as specified in RFC 5891. This version of the protocol
 is often referred to as "IDNA2008" and can produce different results
 from the earlier standard from 2003.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-idna))

--- a/lang/python/python-ifaddr/Makefile
+++ b/lang/python/python-ifaddr/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-ifaddr
 PKG_VERSION:=0.1.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=ifaddr
 PKG_HASH:=c19c64882a7ad51a394451dabcbbed72e98b5625ec1e79789924d5ea3e3ecb93
@@ -31,7 +31,6 @@ define Package/python3-ifaddr
   DEPENDS:= \
 	+python3-light \
 	+python3-ctypes
-  VARIANT:=python3
 endef
 
 define Package/python3-ifaddr/description

--- a/lang/python/python-incremental/Makefile
+++ b/lang/python/python-incremental/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-incremental
 PKG_VERSION:=17.5.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=incremental
 PKG_HASH:=7b751696aaf36eebfab537e458929e194460051ccad279c72b755a167eebd4b3
@@ -22,24 +22,17 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-incremental/Default
+define Package/python3-incremental
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Versions your Python projects
   URL:=https://github.com/twisted/incremental
-endef
-
-define Package/python3-incremental
-$(call Package/python-incremental/Default)
-  DEPENDS:=+PACKAGE_python3-incremental:python3-light
-  VARIANT:=python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-incremental/description
 Incremental is a small library that versions your Python projects.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-incremental))

--- a/lang/python/python-influxdb/Makefile
+++ b/lang/python/python-influxdb/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-influxdb
 PKG_VERSION:=5.2.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 
 PYPI_NAME:=influxdb
@@ -24,7 +24,6 @@ define Package/python3-influxdb
   URL:=https://github.com/influxdb/influxdb-python
   TITLE:=python3-influxdb
   DEPENDS:=+python3-requests +python3-pytz +python3-six +python3-dateutil
-  VARIANT:=python3
 endef
 
 define Package/python3-influxdb/description

--- a/lang/python/python-intelhex/Makefile
+++ b/lang/python/python-intelhex/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-intelhex
 PKG_VERSION:=2.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=IntelHex
 PYPI_SOURCE_NAME:=intelhex
@@ -27,7 +27,6 @@ define Package/python3-intelhex
   TITLE:=python3-intelhex
   URL:=https://github.com/bialix/intelhex
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-intelhex/description

--- a/lang/python/python-jdcal/Makefile
+++ b/lang/python/python-jdcal/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-jdcal
 PKG_VERSION:=1.4.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=BSD-2-Clause
@@ -20,24 +20,17 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-jdcal/Default
+define Package/python3-jdcal
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Julian dates from proleptic Gregorian and Julian calendars
   URL:=https://github.com/phn/jdcal
-endef
-
-define Package/python3-jdcal
-$(call Package/python-jdcal/Default)
-  DEPENDS:= +PACKAGE_python3-jdcal:python3-light
-  VARIANT:=python3
+  DEPENDS:= +python3-light
 endef
 
 define Package/python3-jdcal/description
   This module contains functions for converting between Julian dates and calendar dates.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-jdcal))

--- a/lang/python/python-jmespath/Makefile
+++ b/lang/python/python-jmespath/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=jmespath
 PKG_VERSION:=0.9.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64
@@ -14,25 +14,18 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-jmespath/Default
+define Package/python3-jmespath
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=jmespath
   URL:=https://github.com/jmespath/jmespath.py
-endef
-
-define Package/python3-jmespath
-$(call Package/python-jmespath/Default)
-  DEPENDS:=+PACKAGE_python3-jmespath:python3
-  VARIANT:=python3
+  DEPENDS:=+python3
 endef
 
 define Package/python3-jmespath/description
   JMESPath (pronounced “james path”) allows you to declaratively specify how to extract
   elements from a JSON document.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-jmespath))

--- a/lang/python/python-jsonpath-ng/Makefile
+++ b/lang/python/python-jsonpath-ng/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-jsonpath-ng
 PKG_VERSION:=1.4.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 
 PYPI_NAME:=jsonpath-ng
@@ -23,7 +23,6 @@ define Package/python3-jsonpath-ng
   URL:=https://github.com/h2non/jsonpath-ng
   TITLE:=python3-jsonpath-ng
   DEPENDS:=+python3-ply +python3-six +python3-decorator
-  VARIANT:=python3
 endef
 
 $(eval $(call Py3Package,python3-jsonpath-ng))

--- a/lang/python/python-libmodbus/Makefile
+++ b/lang/python/python-libmodbus/Makefile
@@ -3,7 +3,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=python-libmodbus
 PKG_VERSION:=0.5.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
@@ -15,26 +15,19 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-libmodbus/Default
+define Package/python3-libmodbus
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  URL:=https://pypi.org/project/pylibmodbus
-endef
-
-define Package/python3-libmodbus
-$(call Package/python-libmodbus/Default)
   TITLE:=pylibmodbus
+  URL:=https://pypi.org/project/pylibmodbus
   DEPENDS:=+libmodbus \
-     +PACKAGE_python3-libmodbus:python3-light \
-     +PACKAGE_python3-libmodbus:python3-cffi
-  VARIANT:=python3
+     +python3-light \
+     +python3-cffi
 endef
 
 define Package/python3-libmodbus/description
 	Python Interface for libmodbus written with CFFI.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-libmodbus))

--- a/lang/python/python-lxml/Makefile
+++ b/lang/python/python-lxml/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-lxml
 PKG_VERSION:=4.4.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=lxml
 PKG_HASH:=eff69ddbf3ad86375c344339371168640951c302450c5d3e9936e98d6459db06
@@ -23,26 +23,18 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-lxml/Default
+define Package/python3-lxml
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  URL:=https://lxml.de
-  DEPENDS:=+libxml2 +libxslt +libexslt
-endef
-
-define Package/python3-lxml
-$(call Package/python-lxml/Default)
   TITLE:=python3-lxml
-  DEPENDS+=+PACKAGE_python3-lxml:python3-light
-  VARIANT:=python3
+  URL:=https://lxml.de
+  DEPENDS:=+libxml2 +libxslt +libexslt +python3-light
 endef
 
 define Package/python3-lxml/description
 The lxml XML toolkit is a Pythonic binding
 for the C libraries libxml2 and libxslt.
-.
-(Variant for Python3)
 endef
 
 TARGET_LDFLAGS += -lxml2 -lxslt -lexslt

--- a/lang/python/python-markdown/Makefile
+++ b/lang/python/python-markdown/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-markdown
 PKG_VERSION:=3.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=Markdown
 PKG_HASH:=90fee683eeabe1a92e149f7ba74e5ccdc81cd397bd6c516d93a8da0ef90b6902
@@ -32,7 +32,6 @@ define Package/python3-markdown
 	+python3-light \
 	+python3-setuptools \
 	+python3-logging
-  VARIANT:=python3
 endef
 
 define Package/python3-markdown/description

--- a/lang/python/python-more-itertools/Makefile
+++ b/lang/python/python-more-itertools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-more-itertools
 PKG_VERSION:=8.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=more-itertools
 PKG_HASH:=b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507
@@ -29,7 +29,6 @@ define Package/python3-more-itertools
   TITLE:=More routines for operating on iterables, beyond itertools
   URL:=https://github.com/erikrose/more-itertools
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-more-itertools/description

--- a/lang/python/python-multidict/Makefile
+++ b/lang/python/python-multidict/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=multidict
 PKG_VERSION:=4.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=024b8129695a952ebd93373e45b5d341dbb87c17ce49637b34000093f243dd4f
@@ -31,7 +31,6 @@ define Package/python3-multidict
   DEPENDS:= \
       +python3-light \
       +python3-attrs
-  VARIANT:=python3
 endef
 
 define Package/python3-multidict/description

--- a/lang/python/python-mysqlclient/Makefile
+++ b/lang/python/python-mysqlclient/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-mysqlclient
 PKG_VERSION:=1.4.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0
 
 PYPI_NAME:=mysqlclient
@@ -22,25 +22,18 @@ include ../python3-package.mk
 # python-mysqlclient needs iconv
 include $(INCLUDE_DIR)/nls.mk
 
-define Package/python-mysqlclient/Default
+define Package/python3-mysqlclient
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
+  TITLE:=MySQL database adapter
   URL:=https://mysqlclient.readthedocs.io/
-endef
-
-define Package/python3-mysqlclient
-  $(call Package/python-mysqlclient/Default)
-  TITLE:=MySQL database adapter for Python3
-  DEPENDS:=+PACKAGE_python3-mysqlclient:python3 +libmysqlclient
-  VARIANT:=python3
+  DEPENDS:=+python3 +libmysqlclient
 endef
 
 define Package/python3-mysqlclient/description
  MySQLdb is an thread-compatible interface to the popular MySQL database
  server that provides the Python database API.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-mysqlclient))

--- a/lang/python/python-netdisco/Makefile
+++ b/lang/python/python-netdisco/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-netdisco
 PKG_VERSION:=2.6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=netdisco
 PKG_HASH:=2b3aca14a1807712a053f11fd80dc251dd821ee4899aefece515287981817762
@@ -32,7 +32,6 @@ define Package/python3-netdisco
 	  +python3-light \
 	  +python3-requests \
 	  +python3-zeroconf
-  VARIANT:=python3
 endef
 
 define Package/python3-netdisco/description

--- a/lang/python/python-oauthlib/Makefile
+++ b/lang/python/python-oauthlib/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-oauthlib
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -20,25 +20,18 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-oauthlib/Default
+define Package/python3-oauthlib
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=OAuth request-signing logic for Python
   URL:=https://github.com/oauthlib/oauthlib
-endef
-
-define Package/python3-oauthlib
-  $(call Package/python-oauthlib/Default)
-  DEPENDS:=+PACKAGE_python3-oauthlib:python3-light
-  VARIANT:=python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-oauthlib/description
   A generic, spec-compliant, thorough implementation of the OAuth request-signing
   logic for Python
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-oauthlib))

--- a/lang/python/python-packaging/Makefile
+++ b/lang/python/python-packaging/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-packaging
 PKG_VERSION:=20.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=packaging
 PKG_HASH:=3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3
@@ -28,7 +28,6 @@ define Package/python3-packaging
   TITLE:=Core utilities for Python packages
   URL:=https://github.com/pypa/packaging
   DEPENDS:=+python3-light +python3-pyparsing +python3-six +python3-logging +python3-distutils
-  VARIANT:=python3
 endef
 
 define Package/python3-packaging/description

--- a/lang/python/python-paho-mqtt/Makefile
+++ b/lang/python/python-paho-mqtt/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-paho-mqtt
 PKG_VERSION:=1.5.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=EPL-1.0 Eclipse Distribution License v1.0
@@ -26,7 +26,6 @@ define Package/python3-paho-mqtt
   TITLE:=python3-paho-mqtt
   URL:=http://eclipse.org/paho
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-paho-mqtt/description

--- a/lang/python/python-parsley/Makefile
+++ b/lang/python/python-parsley/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-parsley
 PKG_VERSION:=1.3
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PYPI_NAME:=Parsley
 PKG_HASH:=9444278d47161d5f2be76a767809a3cbe6db4db822f46a4fd7481d4057208d41
@@ -24,24 +24,17 @@ include ../python3-package.mk
 
 PYTHON3_PKG_SETUP_ARGS:=
 
-define Package/python-parsley/Default
+define Package/python3-parsley
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Parsing and pattern matching
   URL:=http://launchpad.net/parsley
-endef
-
-define Package/python3-parsley
-$(call Package/python-parsley/Default)
-  DEPENDS:=+PACKAGE_python3-parsley:python3-light
-  VARIANT:=python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-parsley/description
 Parsing and pattern matching made easy.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-parsley))

--- a/lang/python/python-pluggy/Makefile
+++ b/lang/python/python-pluggy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pluggy
 PKG_VERSION:=0.13.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pluggy
 PKG_HASH:=15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0
@@ -31,7 +31,6 @@ define Package/python3-pluggy
   TITLE:=Plugin and hook calling mechanisms for Python
   URL:=https://github.com/pytest-dev/pluggy
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-pluggy/description

--- a/lang/python/python-ply/Makefile
+++ b/lang/python/python-ply/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-ply
 PKG_VERSION:=3.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=ply
 PKG_HASH:=00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3
@@ -22,25 +22,18 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-ply/Default
+define Package/python3-ply
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=lex and yacc for Python
   URL:=http://www.dabeaz.com/ply/
-endef
-
-define Package/python3-ply
-$(call Package/python-ply/Default)
-  DEPENDS:=+PACKAGE_python3-ply:python3-light
-  VARIANT:=python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-ply/description
 PLY is a 100% Python implementation of the common parsing tools lex
 and yacc.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-ply))

--- a/lang/python/python-py/Makefile
+++ b/lang/python/python-py/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-py
 PKG_VERSION:=1.8.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=py
 PKG_HASH:=5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa
@@ -31,7 +31,6 @@ define Package/python3-py
   TITLE:=py
   URL:=https://github.com/pytest-dev/py
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-py/description

--- a/lang/python/python-pyasn1-modules/Makefile
+++ b/lang/python/python-pyasn1-modules/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyasn1-modules
 PKG_VERSION:=0.2.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pyasn1-modules
 PKG_HASH:=905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e
@@ -22,27 +22,20 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-pyasn1-modules/Default
+define Package/python3-pyasn1-modules
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Collection of ASN.1 modules
   URL:=https://github.com/etingof/pyasn1-modules
-endef
-
-define Package/python3-pyasn1-modules
-$(call Package/python-pyasn1-modules/Default)
   DEPENDS:= \
-      +PACKAGE_python3-pyasn1-modules:python3-light \
-      +PACKAGE_python3-pyasn1-modules:python3-pyasn1
-  VARIANT:=python3
+      +python3-light \
+      +python3-pyasn1
 endef
 
 define Package/python3-pyasn1-modules/description
 This is a small but growing collection of ASN.1 data structures
 expressed in Python terms using pyasn1 data model.
-.
-(Variant for Python3).
 endef
 
 $(eval $(call Py3Package,python3-pyasn1-modules))

--- a/lang/python/python-pyasn1/Makefile
+++ b/lang/python/python-pyasn1/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyasn1
 PKG_VERSION:=0.4.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pyasn1
 PKG_HASH:=aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba
@@ -22,18 +22,13 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-pyasn1/Default
+define Package/python3-pyasn1
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=ASN.1 library for Python
   URL:=https://github.com/etingof/pyasn1
-endef
-
-define Package/python3-pyasn1
-$(call Package/python-pyasn1/Default)
-  DEPENDS:=+PACKAGE_python3-pyasn1:python3-light
-  VARIANT:=python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-pyasn1/description
@@ -41,8 +36,6 @@ This is an implementation of ASN.1 types and codecs in Python programming
 language. It has been first written to support particular protocol (SNMP)
 but then generalized to be suitable for a wide range of protocols
 based on ASN.1 specification.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-pyasn1))

--- a/lang/python/python-pycparser/Makefile
+++ b/lang/python/python-pycparser/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pycparser
 PKG_VERSION:=2.20
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pycparser
 PKG_HASH:=2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0
@@ -24,28 +24,21 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-pycparser/Default
+define Package/python3-pycparser
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=C parser in Python
   URL:=https://github.com/eliben/pycparser
-endef
-
-define Package/python3-pycparser
-$(call Package/python-pycparser/Default)
   DEPENDS:= \
-      +PACKAGE_python3-pycparser:python3-light \
-      +PACKAGE_python3-pycparser:python3-ply
-  VARIANT:=python3
+      +python3-light \
+      +python3-ply
 endef
 
 define Package/python3-pycparser/description
 pycparser is a parser for the C language, written in pure Python. It is a
 module designed to be easily integrated into applications that need to parse
 C source code.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-pycparser))

--- a/lang/python/python-pyopenssl/Makefile
+++ b/lang/python/python-pyopenssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyopenssl
 PKG_VERSION:=19.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pyOpenSSL
 PKG_HASH:=9a24494b2602aaf402be5c9e30a0b82d4a5c67528fe8fb475e3f3bc00dd69507
@@ -23,27 +23,20 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-pyopenssl/Default
+define Package/python3-pyopenssl
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=OpenSSL wrapper
   URL:=https://pyopenssl.org/
-endef
-
-define Package/python3-pyopenssl
-$(call Package/python-pyopenssl/Default)
   DEPENDS:= \
-      +PACKAGE_python3-pyopenssl:python3-light \
-      +PACKAGE_python3-pyopenssl:python3-cryptography \
-      +PACKAGE_python3-pyopenssl:python3-six
-  VARIANT:=python3
+      +python3-light \
+      +python3-cryptography \
+      +python3-six
 endef
 
 define Package/python3-pyopenssl/description
 Python wrapper module around the OpenSSL library
-.
-(Variant for Python3).
 endef
 
 $(eval $(call Py3Package,python3-pyopenssl))

--- a/lang/python/python-pyotp/Makefile
+++ b/lang/python/python-pyotp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pyotp
 PKG_VERSION:=2.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=fc537e8acd985c5cbf51e11b7d53c42276fee017a73aec7c07380695671ca1a1
@@ -29,7 +29,6 @@ define Package/python3-pyotp
   TITLE:=Python One-Time Password Library
   URL:=https://github.com/pyauth/pyotp
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-pyotp/description

--- a/lang/python/python-pyparsing/Makefile
+++ b/lang/python/python-pyparsing/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyparsing
 PKG_VERSION:=2.4.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pyparsing
 PKG_HASH:=c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1
@@ -30,7 +30,6 @@ define Package/python3-pyparsing
   TITLE:=Library for constructing grammar directly in python
   URL:=https://github.com/pyparsing/pyparsing/
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-pyparsing/description

--- a/lang/python/python-pyrsistent/Makefile
+++ b/lang/python/python-pyrsistent/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyrsistent
 PKG_VERSION:=0.15.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pyrsistent
 PKG_HASH:=34b47fa169d6006b32e99d4b3c4031f155e6e68ebcc107d6454852e8e0ee6533
@@ -29,7 +29,6 @@ define Package/python3-pyrsistent
   TITLE:=Persistent/Functional/Immutable data structures
   URL:=https://github.com/tobgu/pyrsistent
   DEPENDS:=+python3-light +python3-six
-  VARIANT:=python3
 endef
 
 define Package/python3-pyrsistent/description

--- a/lang/python/python-pyserial/Makefile
+++ b/lang/python/python-pyserial/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pyserial
 PKG_VERSION:=3.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pyserial
 PKG_HASH:=6e2d401fdee0eab996cf734e67773a0143b932772ca8b42451440cfed942c627
@@ -21,18 +21,13 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-pyserial/Default
+define Package/python3-pyserial
   SECTION:=lang-python
   CATEGORY:=Languages
   SUBMENU:=Python
-  URL:=https://github.com/pyserial/pyserial
-endef
-
-define Package/python3-pyserial
-$(call Package/python-pyserial/Default)
   TITLE:=python3-pyserial
-  DEPENDS:=+PACKAGE_python3-pyserial:python3-light
-  VARIANT:=python3
+  URL:=https://github.com/pyserial/pyserial
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-pyserial/description
@@ -40,8 +35,6 @@ This module encapsulates the access for the serial port. It provides backends
 for Python running on Windows, OSX, Linux, BSD (possibly any POSIX compliant
 system) and IronPython. The module named "serial" automatically selects the
 appropriate backend.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-pyserial))

--- a/lang/python/python-pytest/Makefile
+++ b/lang/python/python-pytest/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pytest
 PKG_VERSION:=5.4.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pytest
 PKG_HASH:=84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970
@@ -41,8 +41,6 @@ define Package/python3-pytest
 	+python3-decimal \
 	+python3-logging \
 	+python3-urllib
-
-  VARIANT:=python3
 endef
 
 define Package/python3-pytest/description

--- a/lang/python/python-pytz/Makefile
+++ b/lang/python/python-pytz/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pytz
 PKG_VERSION:=2019.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pytz
 PKG_HASH:=b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be
@@ -22,24 +22,17 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-pytz/Default
+define Package/python3-pytz
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
+  TITLE:=World timezone definitions, modern and historical
   URL:=https://pythonhosted.org/pytz/
-endef
-
-define Package/python3-pytz
-$(call Package/python-pytz/Default)
-  TITLE:=World timezone definitions, modern and historical for Python3
-  DEPENDS:=+PACKAGE_python3-pytz:python3-light
-  VARIANT:=python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-pytz/description
   World timezone definitions, modern and historical
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-pytz))

--- a/lang/python/python-qrcode/Makefile
+++ b/lang/python/python-qrcode/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-qrcode
 PKG_VERSION:=6.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=qrcode
 PKG_HASH:=505253854f607f2abf4d16092c61d4e9d511a3b4392e60bff957a68592b04369
@@ -20,28 +20,21 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-qrcode/Default
+define Package/python3-qrcode
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=QR Code image generator
   URL:=https://github.com/lincolnloop/python-qrcode
-endef
-
-define Package/python3-qrcode
-$(call Package/python-qrcode/Default)
   DEPENDS:= \
-	+PACKAGE_python3-qrcode:python3 \
-	+PACKAGE_python3-qrcode:python3-setuptools \
-	+PACKAGE_python3-qrcode:python3-six \
-	+PACKAGE_python3-qrcode:python3-pillow
-  VARIANT:=python3
+	+python3 \
+	+python3-setuptools \
+	+python3-six \
+	+python3-pillow
 endef
 
 define Package/python3-qrcode/description
   Pure python QR Code generator
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-qrcode))

--- a/lang/python/python-rcssmin/Makefile
+++ b/lang/python/python-rcssmin/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-rcssmin
 PKG_VERSION:=1.0.6
-PKG_RELEASE=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Eneas U de Queiroz <cote2004-github@yahoo.com>
 PKG_LICENSE:=Apache-2.0
@@ -20,19 +20,14 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-rcssmin/Default
+define Package/python3-rcssmin
     SUBMENU:=Python
     SECTION:=lang
     CATEGORY:=Languages
     TITLE:=Fast CSS minifier for Python
     URL:=http://opensource.perlig.de/rcssmin/
-endef
-
-define Package/python3-rcssmin
-    $(call Package/python-rcssmin/Default)
     DEPENDS:= \
-	+PACKAGE_python3-rcssmin:python3-light
-    VARIANT:=python3
+	+python3-light
 endef
 
 define Package/python3-rcssmin/description
@@ -41,8 +36,6 @@ define Package/python3-rcssmin/description
     RCSSmin does syntactical compression only (removing spaces, comments and possibly
     semicolons). It does not provide semantic compression (like removing empty blocks,
     collapsing redundant properties etc).
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-rcssmin))

--- a/lang/python/python-requests-oauthlib/Makefile
+++ b/lang/python/python-requests-oauthlib/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-requests-oauthlib
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=ISC
@@ -20,28 +20,21 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-requests-oauthlib/Default
+define Package/python3-requests-oauthlib
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=OAuthlib auth for Requests
   URL:=https://github.com/requests/requests-oauthlib
-endef
-
-define Package/python3-requests-oauthlib
-  $(call Package/python-requests-oauthlib/Default)
   DEPENDS:= \
-	+PACKAGE_python3-requests-oauthlib:python3 \
-	+PACKAGE_python3-requests-oauthlib:python3-oauthlib \
-	+PACKAGE_python3-requests-oauthlib:python3-requests
-  VARIANT:=python3
+	+python3 \
+	+python3-oauthlib \
+	+python3-requests
 endef
 
 define Package/python3-requests-oauthlib/description
   This python package provides first-class OAuth library support
   for Requests.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-requests-oauthlib))

--- a/lang/python/python-requests/Makefile
+++ b/lang/python/python-requests/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-requests
 PKG_VERSION:=2.23.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>, Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -23,29 +23,22 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-requests/Default
+define Package/python3-requests
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=HTTP library for Python
   URL:=https://2.python-requests.org/
-endef
-
-define Package/python3-requests
-$(call Package/python-requests/Default)
   DEPENDS:= \
-	  +PACKAGE_python3-requests:python3-light  \
-	  +PACKAGE_python3-requests:python3-chardet  \
-	  +PACKAGE_python3-requests:python3-idna  \
-	  +PACKAGE_python3-requests:python3-urllib3  \
-	  +PACKAGE_python3-requests:python3-certifi
-  VARIANT:=python3
+	  +python3-light  \
+	  +python3-chardet  \
+	  +python3-idna  \
+	  +python3-urllib3  \
+	  +python3-certifi
 endef
 
 define Package/python3-requests/description
   Requests is the only Non-GMO HTTP library for Python, safe for human consumption
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-requests))

--- a/lang/python/python-rsa/Makefile
+++ b/lang/python/python-rsa/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rsa
 PKG_VERSION:=4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487
@@ -14,26 +14,19 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-rsa/Default
+define Package/python3-rsa
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=rsa
   URL:=https://stuvel.eu/rsa
-endef
-
-define Package/python3-rsa
-$(call Package/python-rsa/Default)
-  DEPENDS:=+PACKAGE_python3-rsa:python3 +PACKAGE_python3-rsa:python3-pyasn1
-  VARIANT:=python3
+  DEPENDS:=+python3 +python3-pyasn1
 endef
 
 define Package/python3-rsa/description
   Is a pure-Python RSA implementation. It supports encryption and decryption,
   signing and verifying signatures, and key generation according to PKCS#1 version 1.5.
   It can be used as a Python library as well as on the commandline. 
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-rsa))

--- a/lang/python/python-s3transfer/Makefile
+++ b/lang/python/python-s3transfer/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=s3transfer
 PKG_VERSION:=0.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=f23d5cb7d862b104401d9021fc82e5fa0e0cf57b7660a1331425aab0c691d021
@@ -14,26 +14,19 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-s3transfer/Default
+define Package/python3-s3transfer
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=s3transfer
   URL:=https://github.com/boto/s3transfer
-endef
-
-define Package/python3-s3transfer
-$(call Package/python-s3transfer/Default)
   DEPENDS:= \
-	+PACKAGE_python3-s3transfer:python3 \
-	+PACKAGE_python3-s3transfer:python3-botocore
-  VARIANT:=python3
+	+python3 \
+	+python3-botocore
 endef
 
 define Package/python3-s3transfer/description
 S3transfer is a Python library for managing Amazon S3 transfers.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-s3transfer))

--- a/lang/python/python-schedule/Makefile
+++ b/lang/python/python-schedule/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-schedule
 PKG_VERSION:=0.6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=schedule
 PKG_HASH:=f9fb5181283de4db6e701d476dd01b6a3dd81c38462a54991ddbb9d26db857c9
@@ -29,7 +29,6 @@ define Package/python3-schedule
   TITLE:=Job scheduling for humans
   URL:=https://github.com/dbader/schedule
   DEPENDS:=+python3-light +python3-logging
-  VARIANT:=python3
 endef
 
 define Package/python3-schedule/description

--- a/lang/python/python-schema/Makefile
+++ b/lang/python/python-schema/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-schema
 PKG_VERSION:=0.7.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Karel Kočí <cynerd@email.cz>
 
 PKG_SOURCE_URL:=https://codeload.github.com/keleshev/schema/tar.gz/v$(PKG_VERSION)?
@@ -24,7 +24,6 @@ define Package/python3-schema
   URL:=https://github.com/keleshev/schema
   TITLE:=python3-schema
   DEPENDS:=+python3-light +python3-contextlib2
-  VARIANT:=python3
 endef
 
 define Package/python3-schema/description

--- a/lang/python/python-sentry-sdk/Makefile
+++ b/lang/python/python-sentry-sdk/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-sentry-sdk
 PKG_VERSION:=0.13.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=sentry-sdk
 PKG_HASH:=c6b919623e488134a728f16326c6f0bcdab7e3f59e7f4c472a90eea4d6d8fe82
@@ -33,7 +33,6 @@ define Package/python3-sentry-sdk
 	+python3-light \
 	+python3-logging \
 	+python3-urllib3
-  VARIANT:=python3
 endef
 
 define Package/python3-sentry-sdk/description

--- a/lang/python/python-service-identity/Makefile
+++ b/lang/python/python-service-identity/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-service-identity
 PKG_VERSION:=18.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=service_identity
 PKG_HASH:=0858a54aabc5b459d1aafa8a518ed2081a285087f349fe3e55197989232e2e2d
@@ -22,30 +22,23 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-service-identity/Default
+define Package/python3-service-identity
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Service identity verification
   URL:=https://service-identity.readthedocs.io/
-endef
-
-define Package/python3-service-identity
-$(call Package/python-service-identity/Default)
   DEPENDS:= \
-      +PACKAGE_python3-service-identity:python3-light \
-      +PACKAGE_python3-service-identity:python3-attrs \
-      +PACKAGE_python3-service-identity:python3-cryptography \
-      +PACKAGE_python3-service-identity:python3-pyasn1 \
-      +PACKAGE_python3-service-identity:python3-pyasn1-modules
-  VARIANT:=python3
+      +python3-light \
+      +python3-attrs \
+      +python3-cryptography \
+      +python3-pyasn1 \
+      +python3-pyasn1-modules
 endef
 
 define Package/python3-service-identity/description
 service_identity aspires to give you all the tools you need for
 verifying whether a certificate is valid for the intended purposes.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-service-identity))

--- a/lang/python/python-simplejson/Makefile
+++ b/lang/python/python-simplejson/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-simplejson
 PKG_VERSION:=3.17.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=MIT
 PKG_CPE_ID:=cpe:/a:simplejson_project:simplejson
 
@@ -20,25 +20,18 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-simplejson/Default
+define Package/python3-simplejson
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+  TITLE:=Simple, fast, extensible JSON encoder/decoder
   URL:=https://simplejson.readthedocs.org/
-endef
-
-define Package/python3-simplejson
-$(call Package/python-simplejson/Default)
-  TITLE:=Simple, fast, extensible JSON encoder/decoder for Python3
-  DEPENDS:=+PACKAGE_python3-simplejson:python3-light +PACKAGE_python3-simplejson:python3-decimal
-  VARIANT:=python3
+  DEPENDS:=+python3-light +python3-decimal
 endef
 
 define Package/python3-simplejson/description
   Simple, fast, extensible JSON encoder/decoder for Python
-.
-(Variant for Python3)
 endef
 
 define Py3Package/python3-simplejson/filespec

--- a/lang/python/python-six/Makefile
+++ b/lang/python/python-six/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-six
 PKG_VERSION:=1.14.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=six
 PKG_HASH:=236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a
@@ -25,18 +25,13 @@ include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-six/Default
+define Package/python3-six
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Python 2 and 3 compatibility library
   URL:=https://github.com/benjaminp/six
-endef
-
-define Package/python3-six
-$(call Package/python-six/Default)
-  DEPENDS:=+PACKAGE_python3-six:python3-light
-  VARIANT:=python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-six/description
@@ -44,8 +39,6 @@ Six is a Python 2 and 3 compatibility library.  It provides utility functions
 for smoothing over the differences between the Python versions with the goal of
 writing Python code that is compatible on both Python versions.  See the
 documentation for more information on what is provided.
-.
-(Variant for Python3)
 endef
 
 define Host/Compile

--- a/lang/python/python-slugify/Makefile
+++ b/lang/python/python-slugify/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-slugify
 PKG_VERSION:=4.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=a8fc3433821140e8f409a9831d13ae5deccd0b033d4744d94b31fea141bdd84c
@@ -33,7 +33,6 @@ define Package/python3-slugify
     +python3-codecs \
     +python3-setuptools \
     +python3-text-unidecode
-  VARIANT:=python3
 endef
 
 define Package/python3-slugify/description

--- a/lang/python/python-sqlalchemy/Makefile
+++ b/lang/python/python-sqlalchemy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-sqlalchemy
 PKG_VERSION:=1.3.13
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=SQLAlchemy
 PKG_HASH:=64a7b71846db6423807e96820993fa12a03b89127d278290ca25c0b11ed7b4fb
@@ -34,7 +34,6 @@ define Package/python3-sqlalchemy
 	+python3-urllib \
 	+python3-decimal \
 	+python3-logging
-  VARIANT:=python3
 endef
 
 define Package/python3-sqlalchemy/description

--- a/lang/python/python-stem/Makefile
+++ b/lang/python/python-stem/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-stem
 PKG_VERSION:=1.8.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=stem
 PKG_HASH:=a0b48ea6224e95f22aa34c0bc3415f0eb4667ddeae3dfb5e32a6920c185568c2
@@ -24,7 +24,6 @@ define Package/python3-stem
   TITLE:=A controller library for Tor
   URL:=https://stem.torproject.org/
   DEPENDS:=+python3
-  VARIANT:=python3
 endef
 
 define Package/python3-stem/description

--- a/lang/python/python-twisted/Makefile
+++ b/lang/python/python-twisted/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-twisted
 PKG_VERSION:=20.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=Twisted
 PYPI_SOURCE_EXT:=tar.bz2
@@ -26,34 +26,27 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-twisted/Default
+define Package/python3-twisted
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Asynchronous networking framework
   URL:=https://twistedmatrix.com/
-endef
-
-define Package/python3-twisted
-$(call Package/python-twisted/Default)
   DEPENDS:= \
-      +PACKAGE_python3-twisted:python3-light \
-      +PACKAGE_python3-twisted:python3-attrs \
-      +PACKAGE_python3-twisted:python3-automat \
-      +PACKAGE_python3-twisted:python3-constantly \
-      +PACKAGE_python3-twisted:python3-incremental \
-      +PACKAGE_python3-twisted:python3-hyperlink \
-      +PACKAGE_python3-twisted:python3-setuptools \
-      +PACKAGE_python3-twisted:python3-zope-interface
-  VARIANT:=python3
+      +python3-light \
+      +python3-attrs \
+      +python3-automat \
+      +python3-constantly \
+      +python3-incremental \
+      +python3-hyperlink \
+      +python3-setuptools \
+      +python3-zope-interface
 endef
 
 define Package/python3-twisted/description
 Twisted is a networking engine written in Python, supporting numerous
 protocols. It contains a web server, numerous chat clients, chat servers,
 mail servers, and more.
-.
-(Variant for Python3)
 endef
 
 define Py3Package/python3-twisted/filespec

--- a/lang/python/python-urllib3/Makefile
+++ b/lang/python/python-urllib3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-urllib3
 PKG_VERSION:=1.25.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
@@ -23,24 +23,17 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-urllib3/Default
+define Package/python3-urllib3
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   TITLE:=Sanity-friendly HTTP client
   URL:=https://urllib3.readthedocs.io/
-endef
-
-define Package/python3-urllib3
-$(call Package/python-urllib3/Default)
-  DEPENDS:=+PACKAGE_python3-urllib3:python3
-  VARIANT:=python3
+  DEPENDS:=+python3
 endef
 
 define Package/python3-urllib3/description
   HTTP library with thread-safe connection pooling, file post, and more.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-urllib3))

--- a/lang/python/python-voluptuous-serialize/Makefile
+++ b/lang/python/python-voluptuous-serialize/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=voluptuous-serialize
 PKG_VERSION:=2.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=740cd00ce2ecf0f3345d550163fdd2f20de2e0a60c3c678450e68314c2f592f5
@@ -31,7 +31,6 @@ define Package/python3-voluptuous-serialize
   DEPENDS:= \
 	+python3-light \
 	+python3-voluptuous
-  VARIANT:=python3
 endef
 
 define Package/python3-voluptuous-serialize/description

--- a/lang/python/python-voluptuous/Makefile
+++ b/lang/python/python-voluptuous/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-voluptuous
 PKG_VERSION:=0.11.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=voluptuous
 PKG_HASH:=2abc341dbc740c5e2302c7f9b8e2e243194fb4772585b991931cb5b22e9bf456
@@ -22,25 +22,18 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-voluptuous/Default
+define Package/python3-voluptuous
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Data validation library
   URL:=https://github.com/alecthomas/voluptuous
-endef
-
-define Package/python3-voluptuous
-$(call Package/python-voluptuous/Default)
   DEPENDS:= \
-      +PACKAGE_python3-voluptuous:python3-light
-  VARIANT:=python3
+      +python3-light
 endef
 
 define Package/python3-voluptuous/description
 It is primarily intended for validating data coming into Python as JSON, YAML, etc.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-voluptuous))

--- a/lang/python/python-wcwidth/Makefile
+++ b/lang/python/python-wcwidth/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-wcwidth
 PKG_VERSION:=0.1.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=wcwidth
 PKG_HASH:=ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1
@@ -30,7 +30,6 @@ define Package/python3-wcwidth
   TITLE:=Terminal width calculation library
   URL:=https://github.com/jquast/wcwidth
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-wcwidth/description

--- a/lang/python/python-yaml/Makefile
+++ b/lang/python/python-yaml/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-yaml
 PKG_VERSION:=5.3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=PyYAML
 PKG_HASH:=b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d
@@ -23,25 +23,17 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-yaml/Default
+define Package/python3-yaml
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=YAML parser and emitter for Python
   URL:=https://github.com/yaml/pyyaml
-  DEPENDS:=+libyaml
-endef
-
-define Package/python3-yaml
-$(call Package/python-yaml/Default)
-  DEPENDS+=+PACKAGE_python3-yaml:python3-light
-  VARIANT:=python3
+  DEPENDS:=+libyaml +python3-light
 endef
 
 define Package/python3-yaml/description
   PyYAML is a YAML parser and emitter for the Python programming language.
-.
-(Variant for Python3)
 endef
 
 PYTHON3_PKG_SETUP_GLOBAL_ARGS:=--with-libyaml

--- a/lang/python/python-yarl/Makefile
+++ b/lang/python/python-yarl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yarl
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=024ecdc12bc02b321bc66b41327f930d1c2c543fa9a561b39861da9388ba7aa9
@@ -33,7 +33,6 @@ define Package/python3-yarl
   +python3-multidict \
   +python3-urllib \
   +python3-idna
-  VARIANT:=python3
 endef
 
 define Package/python3-yarl/description

--- a/lang/python/python-zeroconf/Makefile
+++ b/lang/python/python-zeroconf/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-zeroconf
 PKG_VERSION:=0.24.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=zeroconf
 PKG_HASH:=f66d38f16026097572939ab78b1f46a97f556bca415491eb0fd094d0b5827dfe
@@ -32,7 +32,6 @@ define Package/python3-zeroconf
 	  +python3-light \
 	  +python3-logging \
 	  +python3-ifaddr
-  VARIANT:=python3
 endef
 
 define Package/python3-zeroconf/description

--- a/lang/python/python-zipp/Makefile
+++ b/lang/python/python-zipp/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-zipp
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=zipp
 PKG_HASH:=c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96
@@ -22,7 +22,6 @@ define Package/python3-zipp
   TITLE:=Zipfile object wrapper
   URL:=https://github.com/jaraco/zipp
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:="setuptools_scm[toml] >= 3.4.1"

--- a/lang/python/python-zope-interface/Makefile
+++ b/lang/python/python-zope-interface/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-zope-interface
 PKG_VERSION:=5.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=zope.interface
 PKG_HASH:=67267aa6764f488833f92d9d6889239af92bd80b4c99cc76e7f847f660e660fa
@@ -22,18 +22,13 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-zope-interface/Default
+define Package/python3-zope-interface
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Interfaces for Python
   URL:=https://github.com/zopefoundation/zope.interface
-endef
-
-define Package/python3-zope-interface
-$(call Package/python-zope-interface/Default)
-  DEPENDS:=+PACKAGE_python3-zope-interface:python3-light
-  VARIANT:=python3
+  DEPENDS:=+python3-light
 endef
 
 define Package/python3-zope-interface/description
@@ -41,8 +36,6 @@ This package provides an implementation of "object interfaces" for
 Python. Interfaces are a mechanism for labeling objects as conforming to
 a given API or contract. So, this package can be considered as
 implementation of the Design By Contract methodology support in Python.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-zope-interface))

--- a/lang/python/python3-asgiref/Makefile
+++ b/lang/python/python3-asgiref/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asgiref
 PKG_VERSION:=3.2.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=asgiref
 PKG_HASH:=8036f90603c54e93521e5777b2b9a39ba1bad05773fcf2d208f0299d1df58ce5
@@ -22,7 +22,6 @@ define Package/python3-asgiref
   TITLE:=Standard for Python asynchronous web apps and servers.
   URL:=https://asgi.readthedocs.io/en/latest/
   DEPENDS:=+python3-light +python3-logging +python3-asyncio
-  VARIANT:=python3
 endef
 
 define Package/python3-asgiref/description

--- a/lang/python/python3-bottle/Makefile
+++ b/lang/python/python3-bottle/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-bottle
 PKG_VERSION:=0.12.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=bottle
 PKG_HASH:=e9eaa412a60cc3d42ceb42f58d15864d9ed1b92e9d630b8130c871c5bb16107c
@@ -30,7 +30,6 @@ define Package/python3-bottle
 	TITLE:=Fast and simple WSGI-framework for small web-applications
 	URL:=https://bottlepy.org
 	DEPENDS:=+python3
-	VARIANT:=python3
 endef
 
 define Package/python3-bottle/description

--- a/lang/python/python3-django-cors-headers/Makefile
+++ b/lang/python/python3-django-cors-headers/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-cors-headers
 PKG_VERSION:=3.2.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=django-cors-headers
 PKG_HASH:=a5960addecc04527ab26617e51b8ed42f0adab4594b24bb0f3c33e2bd3857c3f
@@ -22,7 +22,6 @@ define Package/python3-django-cors-headers
   TITLE:=Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS).
   URL:=https://github.com/ottoyiu/django-cors-headers
   DEPENDS:=+django +python3-urllib +python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-django-cors-headers/description

--- a/lang/python/python3-django-etesync-journal/Makefile
+++ b/lang/python/python3-django-etesync-journal/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-etesync-journal
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=django-etesync-journal
 PKG_HASH:=1b481f592217186482be9faee686f0c132790db4177deb1f5152b73e99ac6338
@@ -22,7 +22,6 @@ define Package/python3-django-etesync-journal
   TITLE:=The server side implementation of the EteSync protocol.
   URL:=https://www.etesync.com/
   DEPENDS:=+django +python3-django-restframework +python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-django-etesync-journal/description

--- a/lang/python/python3-drf-nested-routers/Makefile
+++ b/lang/python/python3-drf-nested-routers/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=drf-nested-routers
 PKG_VERSION:=0.91
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=drf-nested-routers
 PKG_HASH:=46e5c3abc15c782cafafd7d75028e8f9121bbc6228e3599bbb48a3daa4585034
@@ -22,7 +22,6 @@ define Package/python3-drf-nested-routers
   TITLE:=Nested resources for the Django Rest Framework
   URL:=https://github.com/alanjds/drf-nested-routers
   DEPENDS:=+python3-django-restframework +django +python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-drf-nested-routers/description

--- a/lang/python/python3-maxminddb/Makefile
+++ b/lang/python/python3-maxminddb/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=maxminddb
 PKG_VERSION:=1.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=d0ce131d901eb11669996b49a59f410efd3da2c6dbe2c0094fe2fef8d85b6336
@@ -30,7 +30,6 @@ define Package/python3-maxminddb
   TITLE:=Reader for the MaxMind DB format
   URL:=https://dev.maxmind.com/
   DEPENDS:=+python3-light +libmaxminddb
-  VARIANT:=python3
 endef
 
 define Package/python3-maxminddb/description

--- a/lang/python/python3-netifaces/Makefile
+++ b/lang/python/python3-netifaces/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-netifaces
 PKG_VERSION:=0.10.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=netifaces
 PKG_HASH:=2dee9ffdd16292878336a58d04a20f0ffe95555465fee7c9bd23b3490ef2abf3
@@ -29,7 +29,6 @@ define Package/python3-netifaces
   TITLE:=Portable network interface information
   URL:=https://github.com/al45tair/netifaces
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-netifaces/description

--- a/lang/python/python3-pyroute2/Makefile
+++ b/lang/python/python3-pyroute2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-pyroute2
 PKG_VERSION:=0.5.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=pyroute2
 PKG_HASH:=963fce07da2841456d39e3b932b071f6de28d23dadfae014022d67a752916f98
@@ -35,7 +35,6 @@ define Package/python3-pyroute2
 	  +python3-multiprocessing \
 	  +python3-sqlite3 \
 	  +python3-ctypes
-  VARIANT:=python3
 endef
 
 define Package/python3-pyroute2/description

--- a/lang/python/python3-speedtest-cli/Makefile
+++ b/lang/python/python3-speedtest-cli/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-speedtest-cli
 PKG_VERSION:=2.1.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=speedtest-cli
 PKG_HASH:=cf1d386222f94c324e3125ba9a0d187e46d4a13dca08c023bdb9a23096be2e54
@@ -23,7 +23,6 @@ define Package/python3-speedtest-cli
   URL:=https://github.com/sivel/speedtest-cli
   DEPENDS:=+python3-light +python3-pkg-resources +python3-xml +python3-email \
 	  +python3-urllib +python3-codecs +python3-openssl
-  VARIANT:=python3
 endef
 
 define Package/python3-speedtest-cli/description

--- a/lang/python/python3-sqlparse/Makefile
+++ b/lang/python/python3-sqlparse/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sqlparse
 PKG_VERSION:=0.3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=sqlparse
 PKG_HASH:=e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548
@@ -22,7 +22,6 @@ define Package/python3-sqlparse
   TITLE:=Non-validating SQL parser module.
   URL:=https://github.com/andialbrecht/sqlparse
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-sqlparse/description

--- a/lang/python/python3-unidecode/Makefile
+++ b/lang/python/python3-unidecode/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python3-unidecode
 PKG_VERSION:=1.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=Unidecode
 PKG_HASH:=2b6aab710c2a1647e928e36d69c21e76b453cd455f4e2621000e54b2a9b8cce8
@@ -29,7 +29,6 @@ define Package/python3-unidecode
   TITLE:=ASCII transliterations of Unicode text
   URL:=https://github.com/avian2/unidecode
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python-unidecode/description

--- a/lang/python/ruamel-yaml/Makefile
+++ b/lang/python/ruamel-yaml/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ruamel-yaml
 PKG_VERSION:=0.15.100
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=ruamel.yaml
 PKG_HASH:=8e42f3067a59e819935a2926e247170ed93c8f0b2ab64526f888e026854db2e4
@@ -22,25 +22,18 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/ruamel-yaml/Default
+define Package/python3-ruamel-yaml
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=YAML 1.2 loader/dumper package for Python
   URL:=https://bitbucket.org/ruamel/yaml
-endef
-
-define Package/python3-ruamel-yaml
-$(call Package/ruamel-yaml/Default)
   DEPENDS:= \
-      +PACKAGE_python3-ruamel-yaml:python3-light
-  VARIANT:=python3
+      +python3-light
 endef
 
 define Package/python3-ruamel-yaml/description
 ruamel-yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-ruamel-yaml))

--- a/lang/python/text-unidecode/Makefile
+++ b/lang/python/text-unidecode/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-text-unidecode
 PKG_VERSION:=1.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=text-unidecode
 PKG_HASH:=bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93
@@ -22,25 +22,18 @@ include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
 
-define Package/python-text-unidecode/Default
+define Package/python3-text-unidecode
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=The most basic Text::Unidecode port
   URL:=https://github.com/kmike/text-unidecode/
-endef
-
-define Package/python3-text-unidecode
-$(call Package/python-text-unidecode/Default)
   DEPENDS:= \
-      +PACKAGE_python3-text-unidecode:python3-light
-  VARIANT:=python3
+      +python3-light
 endef
 
 define Package/python3-text-unidecode/description
 text-unidecode is the most basic port of the Text::Unidecode Perl library.
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-text-unidecode))

--- a/lang/python/vobject/Makefile
+++ b/lang/python/vobject/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vobject
 PKG_VERSION:=0.9.6.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 
 PYPI_NAME:=$(PKG_NAME)
@@ -16,25 +16,18 @@ include $(INCLUDE_DIR)/package.mk
 
 include ../python3-package.mk
 
-define Package/python-vobject/Default
+define Package/python3-vobject
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
   MAINTAINER:=Daniel Dickinson <cshored@thecshore.com>
   TITLE:=VObject
   URL:=http://eventable.github.io/vobject/
-endef
-
-define Package/python3-vobject
-$(call Package/python-vobject/Default)
-  DEPENDS:=+PACKAGE_python3-vobject:python3 +PACKAGE_python3-vobject:python3-dateutil
-  VARIANT:=python3
+  DEPENDS:=+python3 +python3-dateutil
 endef
 
 define Package/python3-vobject/description
   vCard and vCalendar support for Python
-.
-(Variant for Python3)
 endef
 
 $(eval $(call Py3Package,python3-vobject))

--- a/lang/python/xmltodict/Makefile
+++ b/lang/python/xmltodict/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-xmltodict
 PKG_VERSION:=0.12.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=xmltodict
 PKG_HASH:=50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21
@@ -32,7 +32,6 @@ define Package/python3-xmltodict
 	+python3-light \
 	+python3-xml \
 	+python3-urllib
-  VARIANT:=python3
 endef
 
 define Package/python3-xmltodict/description


### PR DESCRIPTION
Maintainer: many (let's ping @commodo for now)
Compile tested: armvirt-64, 2020-04-19 snapshot sdk
Run tested: none

Description:
This removes:

* Python 3 variants (`VARIANT:=python3`)

* "for Python3" from package titles

* Package selection condition from package dependencies, e.g. `+PACKAGE_python3-six:python3-light` replaced with `+python3-light`

* "Default" package information sections, e.g. `Package/python-six/Default` removed and package details merged into `Package/python3-six`

* "(Variant for Python3)" from package descriptions

Signed-off-by: Jeffery To <jeffery.to@gmail.com>