### PR TITLE
micrond: show stdout and stderr in log

### DIFF
--- a/utils/micrond/Makefile
+++ b/utils/micrond/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=micrond
 PKG_VERSION:=1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=BSD-2-clause
 
 include $(INCLUDE_DIR)/package.mk

--- a/utils/micrond/files/etc/init.d/micrond
+++ b/utils/micrond/files/etc/init.d/micrond
@@ -9,5 +9,7 @@ start_service() {
 	procd_open_instance
 	procd_set_param command /usr/sbin/micrond "$CRONDIR"
 	procd_set_param respawn
+	procd_set_param stdout 1
+	procd_set_param stderr 1
 	procd_close_instance
 }


### PR DESCRIPTION
So far, all output created by scripts run with micrond has been
discarded. Since there is no reason for that and it also does not
match the expected behavior, this enables both stdout and stderr
output for the service.

If not desired, a user can still use >/dev/null or similar in his/her
micrond jobs to disable output easily and similar to what it would be
on other systems.

Maintainer: @NeoRaider 