### PR TITLE
[19.07] php7: update to version 7.2.30

### DIFF
--- a/lang/php7/Makefile
+++ b/lang/php7/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=php
-PKG_VERSION:=7.2.28
+PKG_VERSION:=7.2.30
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
@@ -17,7 +17,7 @@ PKG_CPE_ID:=cpe:/a:php:php
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www.php.net/distributions/
-PKG_HASH:=afe1863301da572dee2e0bad8014813bcced162f980ddc8ec8e41fd72263eb2d
+PKG_HASH:=aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3
 
 PKG_FIXUP:=libtool autoreconf
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Maintainer: @mhei 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt  19.07
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07

_Description:_

**Update to version 7.2.30**
Fixes:
[CVE-2020-7066](https://nvd.nist.gov/vuln/detail/CVE-2020-7066)
[CVE-2020-7064](https://nvd.nist.gov/vuln/detail/CVE-2020-7064)
