### PR TITLE
simple-adblock: bugfix: start downloads on cold boot/fresh install

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.8.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=GPL-3.0-or-later
 

--- a/net/simple-adblock/files/simple-adblock.conf
+++ b/net/simple-adblock/files/simple-adblock.conf
@@ -74,10 +74,6 @@ config simple-adblock 'config'
 # blocklist too big for most routers
 #	list blacklist_hosts_url 'https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts'
 
-# File size: 1.7M
-# blocklist too big for most routers
-#	list blacklist_hosts_url 'https://hosts-file.net/ad_servers.txt'
-
 # File size: 3.1M
 # blocklist too big for most routers
 #	list blacklist_hosts_url 'https://hostsfile.mine.nu/Hosts'

--- a/net/simple-adblock/files/simple-adblock.init
+++ b/net/simple-adblock/files/simple-adblock.init
@@ -922,6 +922,8 @@ start_service() {
 	if [ "$action" = 'on_boot' ] || [ "$1" = 'on_boot' ]; then
 		if cacheOps 'testGzip' || cacheOps 'test'; then
 			action='restore'
+		else
+			action='download'
 		fi
 	elif [ "$action" = 'download' ] || [ "$1" = 'download' ] || [ -n "$error" ]; then
 		action='download'


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, WRT3200ACM, 19.07.2
Run tested: sunxi, zero Pi, 19.07.1, cold boot start

Description:
Rushed the previous fix which resulted in not properly starting on cold boot/fresh install. This patch fixes that. Also, minor update to the default config file.

Signed-off-by: Stan Grishin <stangri@melmac.net>
