### PR TITLE
vobject: Remove maintainer

### DIFF
--- a/lang/python/vobject/Makefile
+++ b/lang/python/vobject/Makefile
@@ -20,7 +20,6 @@ define Package/python3-vobject
   SUBMENU:=Python
   SECTION:=lang
   CATEGORY:=Languages
-  MAINTAINER:=Daniel Dickinson <cshored@thecshore.com>
   TITLE:=VObject
   URL:=http://eventable.github.io/vobject/
   DEPENDS:=+python3 +python3-dateutil


### PR DESCRIPTION
Maintainer: @cshoredaniel 
Compile tested: N/A
Run tested: N/A

Description:
The previous maintainer has removed himself from his other packages (#11612). This package appears to have been omitted by mistake.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>