### PR TITLE
python-lxml: Update to 4.5.0

### DIFF
--- a/lang/python/python-lxml/Makefile
+++ b/lang/python/python-lxml/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-lxml
-PKG_VERSION:=4.4.2
-PKG_RELEASE:=2
+PKG_VERSION:=4.5.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=lxml
-PKG_HASH:=eff69ddbf3ad86375c344339371168640951c302450c5d3e9936e98d6459db06
+PKG_HASH:=8620ce80f50d023d414183bf90cc2576c2837b88e00bea3f33ad2630133bbb60
 
-PKG_LICENSE:=BSD
-PKG_LICENSE_FILES:=LICENSES.txt
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE.txt LICENSES.txt
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_CPE_ID:=cpe:/a:lxml:lxml
 
@@ -27,30 +27,30 @@ define Package/python3-lxml
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
-  TITLE:=python3-lxml
+  TITLE:=Pythonic XML processing library
   URL:=https://lxml.de
   DEPENDS:=+libxml2 +libxslt +libexslt +python3-light
 endef
 
 define Package/python3-lxml/description
-The lxml XML toolkit is a Pythonic binding
-for the C libraries libxml2 and libxslt.
+  lxml is a Pythonic, mature binding for the libxml2 and libxslt
+  libraries. It provides safe and convenient access to these libraries
+  using the ElementTree API.
+
+  It extends the ElementTree API significantly to offer support for
+  XPath, RelaxNG, XML Schema, XSLT, C14N and much more.
 endef
 
 TARGET_LDFLAGS += -lxml2 -lxslt -lexslt
 
-define Py3Build/Compile
-	$(call Python3/ModSetup,, \
-		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)" \
-		--static \
-		--single-version-externally-managed \
-		, \
-		INCLUDE="$(STAGING_DIR)/usr/include/ $(STAGING_DIR)/usr/include/libxml2" \
-		LIBRARY="$(STAGING_DIR)/usr/lib $(STAGING_DIR)/lib" \
-		CFLAGS="$(TARGET_CFLAGS)" \
-		LDFLAGS="$(TARGET_LDFLAGS)" \
-	)
-endef
+PYTHON3_PKG_SETUP_ARGS += \
+	--static
+
+PYTHON3_PKG_SETUP_VARS += \
+	INCLUDE="$(STAGING_DIR)/usr/include/ $(STAGING_DIR)/usr/include/libxml2" \
+	LIBRARY="$(STAGING_DIR)/usr/lib $(STAGING_DIR)/lib" \
+	CFLAGS="$(TARGET_CFLAGS)" \
+	LDFLAGS="$(TARGET_LDFLAGS)"
 
 $(eval $(call Py3Package,python3-lxml))
 $(eval $(call BuildPackage,python3-lxml))


### PR DESCRIPTION
Maintainer: @commodo 
Compile tested: armvirt-64, 2020-04-19 snapshot sdk
Run tested: none

Description:
This also updates the package's metadata (title, description, license) and changes the package to use the default Python package build recipe.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>