### PR TITLE
libffi: fix build failure on powerpc platforms

### DIFF
--- a/libs/libffi/Makefile
+++ b/libs/libffi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libffi
 PKG_VERSION:=3.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://sourceware.org/pub/libffi/

--- a/libs/libffi/patches/200-ppc.patch
+++ b/libs/libffi/patches/200-ppc.patch
@@ -1,0 +1,36 @@
+From 01a75ed76ea7e57f1b7a5c183e2b1e890e6aa0fd Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyfox@gentoo.org>
+Date: Thu, 28 Nov 2019 12:42:41 +0000
+Subject: [PATCH] powerpc: fix build failure on power7 and older (#532)
+
+Build failure looks as:
+```
+libtool: compile:  powerpc-unknown-linux-gnu-gcc \
+    -O2 -mcpu=powerpc -mtune=powerpc -pipe ... -c src/powerpc/ffi.c ...
+In file included from src/powerpc/ffi.c:33:
+src/powerpc/ffi_powerpc.h:65:9: error: '__int128' is not supported on this target
+   65 | typedef __int128 float128;
+      |         ^~~~~~~~
+```
+
+The fix avoids using __int128 in favour of aligned char[16].
+
+Closes: https://github.com/libffi/libffi/issues/531
+Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>
+---
+ src/powerpc/ffi_powerpc.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/powerpc/ffi_powerpc.h b/src/powerpc/ffi_powerpc.h
+index 5ee2a709..8e2f2f0e 100644
+--- a/src/powerpc/ffi_powerpc.h
++++ b/src/powerpc/ffi_powerpc.h
+@@ -62,7 +62,7 @@ typedef _Float128 float128;
+ #elif defined(__FLOAT128__)
+ typedef __float128 float128;
+ #else
+-typedef __int128 float128;
++typedef char float128[16] __attribute__((aligned(16)));
+ #endif
+ 
+ void FFI_HIDDEN ffi_closure_SYSV (void);


### PR DESCRIPTION
This is an upstream backport.

Currently on the buildbots, having libffi unavailable leads to long
range build failures.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar
Compile tested: powerpc_8540