### PR TITLE
zoneinfo: Updated to the latest release

### DIFF
--- a/utils/zoneinfo/Makefile
+++ b/utils/zoneinfo/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zoneinfo
-PKG_VERSION:=2019c
+PKG_VERSION:=2020a
 PKG_RELEASE:=1
 
 #As i couldn't find real license used "Public Domain"
@@ -19,14 +19,14 @@ PKG_LICENSE:=Public Domain
 PKG_SOURCE:=tzdata$(PKG_VERSION).tar.gz
 PKG_SOURCE_CODE:=tzcode$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.iana.org/time-zones/repository/releases
-PKG_HASH:=79c7806dab09072308da0e3d22c37d3b245015a591891ea147d3b133b60ffc7c
+PKG_HASH:=547161eca24d344e0b5f96aff6a76b454da295dc14ed4ca50c2355043fb899a2
 
 include $(INCLUDE_DIR)/package.mk
 
 define Download/tzcode
    FILE=$(PKG_SOURCE_CODE)
    URL=$(PKG_SOURCE_URL)
-   HASH:=f6ebd3668e02d5ed223d3b7b1947561bf2d2da2f4bd1db61efefd9e06c167ed4
+   HASH:=7d2af7120ee03df71fbca24031ccaf42404752e639196fe93c79a41b38a6d669
 endef
 
 $(eval $(call Download,tzcode))


### PR DESCRIPTION
Maintainer: me
Compile tested: TI OMAP3/4/AM33xx, default, OpenWRT/LEDE master
Run tested: n/a

Description:

  Briefly:

    Morocco springs forward on 2020-05-31, not 2020-05-24.
    Canada's Yukon advanced to -07 year-round on 2020-03-08.
    America/Nuuk renamed from America/Godthab.
    zic now supports expiration dates for leap second lists.

  Changes to future timestamps

    Morocco's second spring-forward transition in 2020 will be May 31,
    not May 24 as predicted earlier.  (Thanks to Semlali Naoufal.)
    Adjust future-year predictions to use the first Sunday after the
    day after Ramadan, not the first Sunday after Ramadan.

    Canada's Yukon, represented by America/Whitehorse and
    America/Dawson, advanced to -07 year-round, beginning with its
    spring-forward transition on 2020-03-08, and will not fall back on
    2020-11-01.  Although a government press release calls this
    "permanent Pacific Daylight Saving Time", we prefer MST for
    consistency with nearby Dawson Creek, Creston, and Fort Nelson.
    (Thanks to Tim Parenti.)

  Changes to past timestamps

    Shanghai observed DST in 1919.  (Thanks to Phake Nick.)

  Changes to timezone identifiers

    To reflect current usage in English better, America/Godthab has
    been renamed to America/Nuuk.  A backwards-compatibility link
    remains for the old name.

  Changes to code

    localtime.c no longer mishandles timestamps after the last
    transition in a TZif file with leap seconds and with daylight
    saving time transitions projected into the indefinite future.
    For example, with TZ='America/Los_Angeles' with leap seconds,
    zdump formerly reported a DST transition on 2038-03-14
    from 01:59:32.999... to 02:59:33 instead of the correct transition
    from 01:59:59.999... to 03:00:00.

    zic -L now supports an Expires line in the leapseconds file, and
    truncates the TZif output accordingly.  This propagates leap
    second expiration information into the TZif file, and avoids the
    abovementioned localtime.c bug as well as similar bugs present in
    many client implementations.  If no Expires line is present, zic
    -L instead truncates the TZif output based on the #expires comment
    present in leapseconds files distributed by tzdb 2018f and later;
    however, this usage is obsolescent.  For now, the distributed
    leapseconds file has an Expires line that is commented out, so
    that the file can be fed to older versions of zic which ignore the
    commented-out line.  Future tzdb distributions are planned to
    contain a leapseconds file with an Expires line.

    The configuration macros HAVE_TZNAME and USG_COMPAT should now be
    set to 1 if the system library supports the feature, and 2 if not.
    As before, these macros are nonzero if tzcode should support the
    feature, zero otherwise.

    The configuration macro ALTZONE now has the same values with the
    same meaning as HAVE_TZNAME and USG_COMPAT.

    The code's defense against CRLF in leap-seconds.list is now
    portable to POSIX awk.  (Problem reported by Deborah Goldsmith.)

    Although the undocumented tzsetwall function is not changed in
    this release, it is now deprecated in preparation for removal in
    future releases.  Due to POSIX requirements, tzsetwall has not
    worked for some time.  Any code that uses it should instead use
    tzalloc(NULL) or, if portability trumps thread-safety, should
    unset the TZ environment variable.

  Changes to commentary

    The Îles-de-la-Madeleine and the Listuguj reserve are noted as
    following America/Halifax, and comments about Yukon's "south" and
    "north" have been corrected to say "east" and "west".  (Thanks to
    Jeffery Nichols.)
