### PR TITLE
ddns-scripts: cloudflare.com-v4: Fix success check

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.8
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=17
+PKG_RELEASE:=18
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=

--- a/net/ddns-scripts/files/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/update_cloudflare_com_v4.sh
@@ -85,7 +85,7 @@ cloudflare_transfer() {
 	done
 
 	# check for error
-	grep -q '"success":true' $DATFILE || {
+	grep -q '"success": \?true' $DATFILE || {
 		write_log 4 "CloudFlare reported an error:"
 		write_log 7 "$(cat $DATFILE)"		# report error
 		return 1	# HTTP-Fehler


### PR DESCRIPTION
Maintainer: none
Compile tested: n/a
Run tested: Gargoyle 1.13.x (OpenWrt 19.07 base) ipq806x R7800

Description:
JSON response now has spaces between parameters. Accept this new format and the old one.

Please backport as needed.