### PR TITLE
ddns-scripts: Use API for "mythic-beasts.com"

### DIFF
--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -130,7 +130,7 @@
 
 "myonlineportal.net"	"http://[USERNAME]:[PASSWORD]@myonlineportal.net/updateddns?hostname=[DOMAIN]&ip=[IP]"	"good|nochg"
 
-"mythic-beasts.com"	"http://dnsapi4.mythic-beasts.com/?domain=[USERNAME]&password=[PASSWORD]&command=REPLACE%20[DOMAIN]%2060%20A%20DYNAMIC_IP&origin=."
+"mythic-beasts.com"	"http://[USERNAME]:[PASSWORD]@ipv4.api.mythic-beasts.com/beta/dns/dynamic/[DOMAIN]"
 
 "namecheap.com"		"http://dynamicdns.park-your-domain.com/update?host=[USERNAME]&domain=[DOMAIN]&password=[PASSWORD]&ip=[IP]"
 


### PR DESCRIPTION
mythic-beasts.com scripts didn't work, which caused by its newest api token. You can generate a token from this url (https://www.mythic-beasts.com/customer/api-users), and it will work

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
