### PR TITLE
python3: Fix on-device extension module compilation with ccache enabled

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include ../python3-version.mk
 
 PKG_NAME:=python3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_VERSION:=$(PYTHON3_VERSION).$(PYTHON3_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -282,6 +282,11 @@ define Py3Package/python3-base/install
 	$(LN) python$(PYTHON3_VERSION) $(1)/usr/bin/python3
 	$(LN) python$(PYTHON3_VERSION) $(1)/usr/bin/python
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON3_VERSION).so* $(1)/usr/lib/
+  # This depends on being called before filespec is processed
+  ifneq ($(CONFIG_CCACHE),)
+	$(SED) 's|$(TARGET_CC)|$(TARGET_CC_NOCACHE)|g;s|$(TARGET_CXX)|$(TARGET_CXX_NOCACHE)|g' \
+		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON3_VERSION)/_sysconfigdata.py
+  endif
 endef
 
 Py3Package/python3-light/install:=:

--- a/lang/python/python3/files/python3-package-dev.mk
+++ b/lang/python/python3/files/python3-package-dev.mk
@@ -16,6 +16,11 @@ define Py3Package/python3-dev/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/python$(PYTHON3_VERSION)-config $(1)/usr/bin
 	$(LN) python$(PYTHON3_VERSION)-config $(1)/usr/bin/python3-config
 	$(LN) python$(PYTHON3_VERSION)/config-$(PYTHON3_VERSION)/libpython$(PYTHON3_VERSION).a $(1)/usr/lib/
+  # This depends on being called before filespec is processed
+  ifneq ($(CONFIG_CCACHE),)
+	$(SED) 's|$(TARGET_CC)|$(TARGET_CC_NOCACHE)|g;s|$(TARGET_CXX)|$(TARGET_CXX_NOCACHE)|g' \
+		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON3_VERSION)/config-$(PYTHON3_VERSION)/Makefile
+  endif
 endef
 
 $(eval $(call Py3BasePackage,python3-dev, \


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2020-04-19 snapshot sdk
Run tested: armvirt-64 (qemu), 2020-04-19 snapshot

Description:
When ccache is enabled (`CONFIG_CCACHE`), `$(TARGET_CC)` and `$(TARGET_CXX)` are set to `ccache_cc` and `ccache_cxx`, respectively. This leads to Python recording these names in its files and attempting to use these programs when compiling extension modules on the target.

This modifies Python's files to replace `$(TARGET_CC)` and `$(TARGET_CXX)` with `$(TARGET_CC_NOCACHE)` and `$(TARGET_CXX_NOCACHE)`, respectively.

This addresses one of the issues raised in #11912.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>

