### PR TITLE
avahi: remove these pkgconfig workarounds

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avahi
 PKG_VERSION:=0.8
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lathiat/avahi/releases/download/v$(PKG_VERSION) \
@@ -321,15 +321,6 @@ endif
 endif
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/* $(1)/usr/lib/pkgconfig/
-	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/avahi-core.pc
-ifeq ($(BUILD_VARIANT),dbus)
-ifneq ($(CONFIG_PACKAGE_libavahi-client),)
-	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/avahi-client.pc
-endif
-ifneq ($(CONFIG_PACKAGE_libavahi-compat-libdnssd),)
-	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/avahi-compat-libdns_sd.pc
-endif
-endif
 endef
 
 define Package/libavahi/install

--- a/libs/avahi/patches/010-pkgconfig.patch
+++ b/libs/avahi/patches/010-pkgconfig.patch
@@ -1,0 +1,206 @@
+From 229b216d274977967790e6e2cfe13dd38effa2cf Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Mon, 16 Sep 2019 18:04:58 -0700
+Subject: [PATCH] pkgconfig: Match the first three parameters
+
+For consistency between projects. Might also fix several cross compilation
+cases.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ avahi-client.pc.in           | 4 ++--
+ avahi-compat-howl.pc.in      | 4 ++--
+ avahi-compat-libdns_sd.pc.in | 4 ++--
+ avahi-core.pc.in             | 4 ++--
+ avahi-glib.pc.in             | 4 ++--
+ avahi-gobject.pc.in          | 4 ++--
+ avahi-libevent.pc.in         | 4 ++--
+ avahi-qt3.pc.in              | 4 ++--
+ avahi-qt4.pc.in              | 4 ++--
+ avahi-qt5.pc.in              | 4 ++--
+ avahi-sharp.pc.in            | 2 +-
+ avahi-ui-gtk3.pc.in          | 4 ++--
+ avahi-ui-sharp.pc.in         | 2 +-
+ avahi-ui.pc.in               | 4 ++--
+ 14 files changed, 26 insertions(+), 26 deletions(-)
+
+diff --git a/avahi-client.pc.in b/avahi-client.pc.in
+index 65ee8d84..1e1bd249 100644
+--- a/avahi-client.pc.in
++++ b/avahi-client.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+-exec_prefix=${prefix}
+-libdir=@libdir@
++exec_prefix=@prefix@
++libdir=${exec_prefix}/lib
+ includedir=${prefix}/include
+ 
+ Name: avahi-client
+diff --git a/avahi-compat-howl.pc.in b/avahi-compat-howl.pc.in
+index b3cd02a7..1bb42c6b 100644
+--- a/avahi-compat-howl.pc.in
++++ b/avahi-compat-howl.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+-exec_prefix=${prefix}
+-libdir=@libdir@
++exec_prefix=@prefix@
++libdir=${exec_prefix}/lib
+ includedir=${prefix}/include/avahi-compat-howl/
+ 
+ Name: avahi-compat-howl
+diff --git a/avahi-compat-libdns_sd.pc.in b/avahi-compat-libdns_sd.pc.in
+index d6196325..d4778a17 100644
+--- a/avahi-compat-libdns_sd.pc.in
++++ b/avahi-compat-libdns_sd.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+-exec_prefix=${prefix}
+-libdir=@libdir@
++exec_prefix=@prefix@
++libdir=${exec_prefix}/lib
+ includedir=${prefix}/include/avahi-compat-libdns_sd/
+ 
+ Name: avahi-compat-libdns_sd
+diff --git a/avahi-core.pc.in b/avahi-core.pc.in
+index 52491b41..73412d45 100644
+--- a/avahi-core.pc.in
++++ b/avahi-core.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+-exec_prefix=${prefix}
+-libdir=@libdir@
++exec_prefix=@prefix@
++libdir=${exec_prefix}/lib
+ includedir=${prefix}/include
+ 
+ Name: avahi-core
+diff --git a/avahi-glib.pc.in b/avahi-glib.pc.in
+index f163e899..3d0ff9fc 100644
+--- a/avahi-glib.pc.in
++++ b/avahi-glib.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+-exec_prefix=${prefix}
+-libdir=@libdir@
++exec_prefix=@prefix@
++libdir=${exec_prefix}/lib
+ includedir=${prefix}/include
+ 
+ Name: avahi-glib
+diff --git a/avahi-gobject.pc.in b/avahi-gobject.pc.in
+index bf382003..88146744 100644
+--- a/avahi-gobject.pc.in
++++ b/avahi-gobject.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+-exec_prefix=${prefix}
+-libdir=@libdir@
++exec_prefix=@prefix@
++libdir=${exec_prefix}/lib
+ includedir=${prefix}/include
+ 
+ Name: avahi-gobject
+diff --git a/avahi-libevent.pc.in b/avahi-libevent.pc.in
+index a1dca01b..59b35e8e 100644
+--- a/avahi-libevent.pc.in
++++ b/avahi-libevent.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+-exec_prefix=${prefix}
+-libdir=@libdir@
++exec_prefix=@prefix@
++libdir=${exec_prefix}/lib
+ includedir=${prefix}/include
+ 
+ Name: avahi-libevent
+diff --git a/avahi-qt3.pc.in b/avahi-qt3.pc.in
+index c18f0809..d4fb4b88 100644
+--- a/avahi-qt3.pc.in
++++ b/avahi-qt3.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+-exec_prefix=${prefix}
+-libdir=@libdir@
++exec_prefix=@prefix@
++libdir=${exec_prefix}/lib
+ includedir=${prefix}/include
+ 
+ Name: avahi-qt3
+diff --git a/avahi-qt4.pc.in b/avahi-qt4.pc.in
+index f62f7171..aefc135a 100644
+--- a/avahi-qt4.pc.in
++++ b/avahi-qt4.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+-exec_prefix=${prefix}
+-libdir=@libdir@
++exec_prefix=@prefix@
++libdir=${exec_prefix}/lib
+ includedir=${prefix}/include
+ 
+ Name: avahi-qt4
+diff --git a/avahi-qt5.pc.in b/avahi-qt5.pc.in
+index 71548baf..fffe192a 100644
+--- a/avahi-qt5.pc.in
++++ b/avahi-qt5.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+-exec_prefix=${prefix}
+-libdir=@libdir@
++exec_prefix=@prefix@
++libdir=${exec_prefix}/lib
+ includedir=${prefix}/include
+ 
+ Name: avahi-qt5
+diff --git a/avahi-sharp.pc.in b/avahi-sharp.pc.in
+index 3cc78b60..4d4c15df 100644
+--- a/avahi-sharp.pc.in
++++ b/avahi-sharp.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+ exec_prefix=@prefix@
+-libdir=@libdir@
++libdir=${exec_prefix}/lib
+ 
+ Name: avahi-sharp
+ Description: Mono bindings for the Avahi mDNS/DNS-SD stack
+diff --git a/avahi-ui-gtk3.pc.in b/avahi-ui-gtk3.pc.in
+index 27c4322d..56159481 100644
+--- a/avahi-ui-gtk3.pc.in
++++ b/avahi-ui-gtk3.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+-exec_prefix=${prefix}
+-libdir=@libdir@
++exec_prefix=@prefix@
++libdir=${exec_prefix}/lib
+ includedir=${prefix}/include
+ 
+ Name: avahi-ui
+diff --git a/avahi-ui-sharp.pc.in b/avahi-ui-sharp.pc.in
+index cdc35e0d..d448b241 100644
+--- a/avahi-ui-sharp.pc.in
++++ b/avahi-ui-sharp.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+ exec_prefix=@prefix@
+-libdir=@libdir@
++libdir=${exec_prefix}/lib
+ 
+ Name: avahi-ui-sharp
+ Description: Mono bindings for the Avahi mDNS/DNS-SD stack
+diff --git a/avahi-ui.pc.in b/avahi-ui.pc.in
+index 9edeea96..0dab729a 100644
+--- a/avahi-ui.pc.in
++++ b/avahi-ui.pc.in
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+-exec_prefix=${prefix}
+-libdir=@libdir@
++exec_prefix=@prefix@
++libdir=${exec_prefix}/lib
+ includedir=${prefix}/include
+ 
+ Name: avahi-ui


### PR DESCRIPTION
Backported the upstream patch instead. Less error prone.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ath79