### PR TITLE
python3: Fix host build tool names recorded in target files

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include ../python3-version.mk
 
 PKG_NAME:=python3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_VERSION:=$(PYTHON3_VERSION).$(PYTHON3_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -124,6 +124,9 @@ define Package/python3/description
   This package contains the (almost) full Python install.
   It's python3-light + all other packages.
 endef
+
+TARGET_CONFIGURE_OPTS+= \
+	READELF="$(TARGET_CROSS)readelf"
 
 MAKE_FLAGS+=\
 	CROSS_COMPILE=yes \
@@ -282,6 +285,9 @@ define Py3Package/python3-base/install
 	$(LN) python$(PYTHON3_VERSION) $(1)/usr/bin/python3
 	$(LN) python$(PYTHON3_VERSION) $(1)/usr/bin/python
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON3_VERSION).so* $(1)/usr/lib/
+  # This depends on being called before filespec is processed
+	$(SED) 's|$(TARGET_AR)|ar|g;s|$(TARGET_CROSS)readelf|readelf|g;s|$(TARGET_CC)|gcc|g;s|$(TARGET_CXX)|g++|g' \
+		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON3_VERSION)/_sysconfigdata.py
 endef
 
 Py3Package/python3-light/install:=:

--- a/lang/python/python3/files/python3-package-dev.mk
+++ b/lang/python/python3/files/python3-package-dev.mk
@@ -16,6 +16,9 @@ define Py3Package/python3-dev/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/python$(PYTHON3_VERSION)-config $(1)/usr/bin
 	$(LN) python$(PYTHON3_VERSION)-config $(1)/usr/bin/python3-config
 	$(LN) python$(PYTHON3_VERSION)/config-$(PYTHON3_VERSION)/libpython$(PYTHON3_VERSION).a $(1)/usr/lib/
+  # This depends on being called before filespec is processed
+	$(SED) 's|$(TARGET_AR)|ar|g;s|$(TARGET_CROSS)readelf|readelf|g;s|$(TARGET_CC)|gcc|g;s|$(TARGET_CXX)|g++|g' \
+		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON3_VERSION)/config-$(PYTHON3_VERSION)/Makefile
 endef
 
 $(eval $(call Py3BasePackage,python3-dev, \


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2020-04-19 snapshot sdk
Run tested: armvirt-64 (qemu), 2020-04-19 snapshot

Description:
Python will record the values of `CC`, `CXX`, `AR`, and `READELF` (and other configure options) used during compilation. pip will use these programs when asked to compile extension modules on the target device.

* If ccache is used during build, `CC` and `CXX` will be `ccache_cc` and `ccache_cxx`, respectively, which are not available on-device (#11912).

* If an external toolchain is used during build, the values of these variables will contain the external toolchain prefix, which may not be available on target.

* If the normal toolchain is used during build, `AR` and `READELF` will contain the toolchain prefix, but the names of ar and readelf on-device do not contain the prefix; they are named `ar` and `readelf`.

This changes the values of these variables in Python's files to match the names available on-device, and without any toolchain prefix.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>