### PR TITLE
pingcheck: Update and add script directories

### DIFF
--- a/net/pingcheck/Makefile
+++ b/net/pingcheck/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pingcheck
-PKG_VERSION:=2017-10-02
-PKG_RELEASE:=2
+PKG_VERSION:=2020-02-12
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_MIRROR_HASH:=8c8d1743b8972ade6c75027346fc652f7a1c0f17e2f9bd2e65aad20013d9870e
+PKG_MIRROR_HASH:=3890cd39add7e523ab7418faf6a7ae1a1f71d2739982e6e09aa33cc6defac8be
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_URL:=https://github.com/br101/pingcheck
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=12e65e2f3fd2a17db785d28756df43ccade29b1b
+PKG_SOURCE_VERSION:=520718f9377eab49888a3e38ece59f9ad94d978e
 
 PKG_MAINTAINER:=Bruno Randolf <br1@einfach.org>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -53,6 +53,11 @@ define Package/pingcheck/install
 	$(INSTALL_BIN) ./pingcheck.init $(1)/etc/init.d/pingcheck
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/pingcheck.config $(1)/etc/config/pingcheck
+	$(INSTALL_DIR) $(1)/etc/pingcheck/online.d/
+	$(INSTALL_DIR) $(1)/etc/pingcheck/offline.d/
+	$(INSTALL_DIR) $(1)/etc/pingcheck/panic.d/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/example-script.sh $(1)/etc/pingcheck/online.d/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/example-script.sh $(1)/etc/pingcheck/offline.d/
 endef
 
 $(eval $(call BuildPackage,pingcheck))


### PR DESCRIPTION
- Update to version with longer interface names.

- Add /etc/pingcheck/(on|off)line.d/ directories with an example
  script. Closes #11263

Signed-off-by: Bruno Randolf <br1@einfach.org>

Maintainer: me
Compile tested: ar71xx, Rambutan, OpenWrt 19.07.2, master
Run tested:  ar71xx, Rambutan, OpenWrt 19.07.2, master

Description:

Cherry picked from master
