### PR TITLE
irqbalance: fix compilation for USE_GLIBC and BUILD_NLS cases

### DIFF
--- a/utils/irqbalance/Makefile
+++ b/utils/irqbalance/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=irqbalance
 PKG_VERSION:=1.6.0
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_PROTO:=git
@@ -23,15 +23,16 @@ PKG_REMOVE_FILES:=autogen.sh
 
 PKG_BUILD_PARALLEL:=1
 
-# -liconv due to glib2, to be revisited later
 include $(INCLUDE_DIR)/nls.mk
 
 include $(INCLUDE_DIR)/package.mk
 
+PKG_BUILD_DEPENDS += glib2
+
 define Package/irqbalance
-  PKG_BUILD_DEPENDS:=glib2
   SECTION:=utils
   CATEGORY:=Utilities
+  DEPENDS:=$(ICONV_DEPENDS) $(INTL_DEPENDS)
   TITLE:=IRQ usage balancing for multi-core systems
   URL:=https://github.com/Irqbalance/irqbalance
 endef
@@ -49,9 +50,19 @@ CONFIGURE_ARGS+= \
 	--without-irqbalance-ui \
 	--enable-static=glib2
 
+GLIB2_LIBS="$(STAGING_DIR)/usr/lib/libglib-2.0.a"
+
+ifeq ($(CONFIG_BUILD_NLS),y)
+	GLIB2_LIBS += $(INTL_LDFLAGS) -lintl
+endif
+
+ifeq ($(CONFIG_USE_GLIBC),y)
+	GLIB2_LIBS += -lpthread
+endif
+
 CONFIGURE_VARS += \
-	GLIB2_LIBS="$(STAGING_DIR)/usr/lib/libglib-2.0.a \
-		$(STAGING_DIR)/usr/lib/libiconv-stub/lib/libiconv.a"
+	GLIB2_LIBS="$(GLIB2_LIBS) \
+		$(ICONV_LDFLAGS) -liconv"
 
 define Package/irqbalance/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
The package Makefile was not taking into consideration that the build
may be using BUILD_NLS with libintl-full and libiconv-full and was
trying to link the wrong versions of these libraries in this case.

The necessary flags are added by nls.mk to TARGET_LDFLAGS and can be
passed to irqbalance's configure script for setting the GLIB2_LIBS
variable instead of the explicit static link to the libiconv stub.

The PKG_BUILD_DEPENDS line should be modified so as to add to and not
override the definition set by nls.mk, which will ensure the right
version of libiconv and libintl is built beforehand.

A DEPENDS:= line should be added to the package definition using the
variables defined in nls.mk, which will add the appropriate version
of libintl and libiconv (vanilla or -full versions)

If USE_GLIBC is true, then libpthread needs to be explicitly passed
to the configure script in the GLIB2_LIBS variable for linking.

Maintainer: Hannu Nyman <hannu.nyman@iki.fi>
Compile tested: (x86_64, master and openwrt-19.07)
Run tested: (x86_64, openwrt 19.07, functional)

Fixes issue #11969