### PR TITLE
mwan3: backport master branch fixes to openwrt-19.07

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.2
+PKG_VERSION:=2.8.3
 PKG_RELEASE:=2
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.3
+PKG_VERSION:=2.8.4
 PKG_RELEASE:=2
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.8.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
-PKG_LICENSE:=GPLv2
+PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.1
+PKG_VERSION:=2.8.2
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPLv2

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -1004,7 +1004,7 @@ mwan3_set_user_iptables_rule()
 			case $proto in
 				tcp|udp)
 				[ "$global_logging" = "1" ] && [ "$rule_logging" = "1" ] && {
-					$IPT -A mwan3_rules \
+					$IPT4 -A mwan3_rules \
 						-p $proto \
 						-s $src_ip \
 						-d $dest_ip $ipset \

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -61,7 +61,7 @@ main() {
 	local recovery_interval down up size
 	local keep_failure_interval check_quality failure_latency
 	local recovery_latency failure_loss recovery_loss
-	local max_ttl
+	local max_ttl httping_ssl
 
 	[ -z "$5" ] && echo "Error: should not be started manually" && exit 0
 
@@ -75,6 +75,7 @@ main() {
 
 	config_load mwan3
 	config_get track_method $1 track_method ping
+	config_get_bool httping_ssl $1 httping_ssl 0
 	validate_track_method $track_method $SRC_IP || {
 		track_method=ping
 		if validate_track_method $track_method; then
@@ -149,7 +150,11 @@ main() {
 						result=$?
 					;;
 					httping)
-						httping -y $SRC_IP -c $count -t $timeout -q $track_ip &> /dev/null
+						if [ "$httping_ssl" -eq 1 ]; then
+							httping -y $SRC_IP -c $count -t $timeout -q "https://$track_ip" &> /dev/null
+						else
+							httping -y $SRC_IP -c $count -t $timeout -q "http://$track_ip" &> /dev/null
+						fi
 						result=$?
 					;;
 					nping-tcp)

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -132,11 +132,17 @@ main() {
 			if [ $host_up_count -lt $reliability ]; then
 				case "$track_method" in
 					ping)
+						# pinging IPv6 hosts with an interface is troublesome
+						# https://bugs.openwrt.org/index.php?do=details&task_id=2897
+						# so get the IP address of the interface and use that instead				   
+						if echo $track_ip | grep -q ':'; then
+￼							ADDR=$(ip -6 addr ls dev "$DEVICE" | sed -ne 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p')
+						fi
 						if [ $check_quality -eq 0 ]; then
-							ping -I $DEVICE -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null
+							ping -I ${ADDR:-$DEVICE} -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null
 							result=$?
 						else
-							ping_result="$(ping -I $DEVICE -c $count -W $timeout -s $size -t $max_ttl -q $track_ip | tail -2)"
+							ping_result="$(ping -I ${ADDR:-$DEVICE} -c $count -W $timeout -s $size -t $max_ttl -q $track_ip | tail -2)"
 							loss="$(echo "$ping_result" | grep "packet loss" |  cut -d "," -f3 | awk '{print $1}' | sed -e 's/%//')"
 							if [ "$loss" -eq 100 ]; then
 								latency=999999

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -134,9 +134,9 @@ main() {
 					ping)
 						# pinging IPv6 hosts with an interface is troublesome
 						# https://bugs.openwrt.org/index.php?do=details&task_id=2897
-						# so get the IP address of the interface and use that instead				   
+						# so get the IP address of the interface and use that instead
 						if echo $track_ip | grep -q ':'; then
-￼							ADDR=$(ip -6 addr ls dev "$DEVICE" | sed -ne 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p')
+							ADDR=$(ip -6 addr ls dev "$DEVICE" | sed -ne 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p')
 						fi
 						if [ $check_quality -eq 0 ]; then
 							ping -I ${ADDR:-$DEVICE} -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null


### PR DESCRIPTION
Maintainer: me
Compile tested: not needed only scripts
Run tested: x86_64 and lantiq_xrx200, APU3, openwrt-19.07

Description:

The following commits fixes some issue with mwan3.
With this change we are event with the master branch

- mwan3: fix whitespace issue
- mwan3: Ping IPv6 hosts using address not interface
- mwan3: change license to SPDX compatible identifier
- mwan3: update version to 2.8.2
- mwan3: add httping_ssl option
- mwan3: fix variable naming