### PR TITLE
[openwrt-19.07] python,python3: Fix host build tool names recorded in target files

### DIFF
--- a/lang/python/python/Makefile
+++ b/lang/python/python/Makefile
@@ -12,7 +12,7 @@ include ../python-version.mk
 
 PKG_NAME:=python
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.python.org/ftp/python/$(PKG_VERSION)
@@ -289,6 +289,8 @@ define PyPackage/python-base/install
 	$(LN) python$(PYTHON_VERSION) $(1)/usr/bin/python
 	$(LN) python$(PYTHON_VERSION) $(1)/usr/bin/python2
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON_VERSION).so* $(1)/usr/lib/
+	$(SED) 's|$(TARGET_AR)|ar|g;s|$(TARGET_RANLIB)|ranlib|g;s|$(TARGET_CC)|gcc|g;s|$(TARGET_CXX)|g++|g' \
+		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/_sysconfigdata.py
 endef
 
 PyPackage/python-light/install:=:

--- a/lang/python/python/files/python-package-dev.mk
+++ b/lang/python/python/files/python-package-dev.mk
@@ -15,6 +15,8 @@ define PyPackage/python-dev/install
 	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/python*config $(1)/usr/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/config/libpython$(PYTHON_VERSION).a $(1)/usr/lib
+	$(SED) 's|$(TARGET_AR)|ar|g;s|$(TARGET_RANLIB)|ranlib|g;s|$(TARGET_CC)|gcc|g;s|$(TARGET_CXX)|g++|g' \
+		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/config/Makefile
 endef
 
 $(eval $(call PyBasePackage,python-dev, \

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -14,7 +14,7 @@ PYTHON_VERSION:=$(PYTHON3_VERSION)
 PYTHON_VERSION_MICRO:=$(PYTHON3_VERSION_MICRO)
 
 PKG_NAME:=python3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -126,6 +126,9 @@ define Package/python3/description
   This package contains the (almost) full Python install.
   It's python3-light + all other packages.
 endef
+
+TARGET_CONFIGURE_OPTS+= \
+	READELF="$(TARGET_CROSS)readelf"
 
 MAKE_FLAGS+=\
 	CROSS_COMPILE=yes \
@@ -284,6 +287,9 @@ define Py3Package/python3-base/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(LN) python$(PYTHON_VERSION) $(1)/usr/bin/python3
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON_VERSION).so* $(1)/usr/lib/
+  # This depends on being called before filespec is processed
+	$(SED) 's|$(TARGET_AR)|ar|g;s|$(TARGET_CROSS)readelf|readelf|g;s|$(TARGET_CC)|gcc|g;s|$(TARGET_CXX)|g++|g' \
+		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON3_VERSION)/_sysconfigdata.py
 endef
 
 Py3Package/python3-light/install:=:

--- a/lang/python/python3/files/python3-package-dev.mk
+++ b/lang/python/python3/files/python3-package-dev.mk
@@ -16,6 +16,9 @@ define Py3Package/python3-dev/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/python$(PYTHON3_VERSION)-config $(1)/usr/bin
 	$(LN) python$(PYTHON3_VERSION)-config $(1)/usr/bin/python3-config
 	$(LN) python$(PYTHON_VERSION)/config-$(PYTHON_VERSION)/libpython$(PYTHON3_VERSION).a $(1)/usr/lib/
+  # This depends on being called before filespec is processed
+	$(SED) 's|$(TARGET_AR)|ar|g;s|$(TARGET_CROSS)readelf|readelf|g;s|$(TARGET_CC)|gcc|g;s|$(TARGET_CXX)|g++|g' \
+		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON3_VERSION)/config-$(PYTHON3_VERSION)/Makefile
 endef
 
 $(eval $(call Py3BasePackage,python3-dev, \


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 19.07.2 sdk
Run tested: armvirt-64 (qemu), 19.07.2

Description:
(Backport of #11970)

Python will record the values of `CC`, `CXX`, `AR`, and `RANLIB`/`READELF` (and other configure options) used during compilation. pip will use these programs when asked to compile extension modules on the target device.

* If ccache is used during build, `CC` and `CXX` will be `ccache_cc` and `ccache_cxx`, respectively, which are not available on-device (#11912).

* If an external toolchain is used during build, the values of these variables will contain the external toolchain prefix, which may not be available on target.

* If the normal toolchain is used during build, `AR` and `RANLIB`/`READELF` will contain the toolchain prefix, but the names of ar and ranlib/readelf on-device do not contain the prefix; they are named `ar` and `ranlib`/`readelf`.

This changes the values of these variables in Python's files to match the names available on-device, and without any toolchain prefix.