### PR TITLE
ddns-scripts_cloudflare.com-v4: Improved successful response parsing

### DIFF
--- a/net/ddns-scripts/files/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/update_cloudflare_com_v4.sh
@@ -85,7 +85,7 @@ cloudflare_transfer() {
 	done
 
 	# check for error
-	grep -q '"success":true' $DATFILE || {
+	grep -q '"success": *true' $DATFILE || {
 		write_log 4 "CloudFlare reported an error:"
 		write_log 7 "$(cat $DATFILE)"		# report error
 		return 1	# HTTP-Fehler


### PR DESCRIPTION
This PR handles Cloudflare responses that might also include leading space(s) in the `success` value.

Maintainer: @dibdot 
Compile tested: 
```
root@OpenWrt:~# cat /etc/openwrt_release
DISTRIB_ID='OpenWrt'
DISTRIB_RELEASE='19.07.2'
DISTRIB_REVISION='r10947-65030d81f3'
DISTRIB_TARGET='ipq806x/generic'
DISTRIB_ARCH='arm_cortex-a15_neon-vfpv4'
DISTRIB_DESCRIPTION='OpenWrt 19.07.2 r10947-65030d81f3'
DISTRIB_TAINTS=''
```
```
root@OpenWrt:~# opkg list-installed | grep ddns
ddns-scripts - 2.7.8-12
ddns-scripts_cloudflare.com-v4 - 2.7.8-12
luci-app-ddns - 2.4.9-7
```

Run tested: See above.

Description:

I've recently noticed in my ddns logs that the JSON responses returned by Cloudflare does not always follow the pattern `"success":true`. Some requests would return `"success": true` (notice the extra space after the `:`)  

For example, the request to get the `dns_records` returns:

```
 103813       : #> /usr/bin/curl -RsS -o /var/run/ddns/myddns_ipv4.dat --stderr /var/run/ddns/myddns_ipv4.err --noproxy '*' --header 'X-Auth-Email: <redacted>'  --header 'X-Auth-Key: ***PW***'  --header 'Content-Type: application/json'  --request GET 'https://api.cloudflare.com/client/v4/zones/<redacted>/dns_records?name=<redacted>&type=A'
 103814  WARN : CloudFlare reported an error:
 103814       : {
  "result": [
    {
      "id": "<redacted>",
      "zone_id": "<redacted>",
      "zone_name": "<redacted>",
      "name": "<redacted>",
      "type": "A",
      "content": "<redacted>",
      "proxiable": true,
      "proxied": true,
      "ttl": 1,
      "locked": false,
      "meta": {
        "auto_added": false,
        "managed_by_apps": false,
        "managed_by_argo_tunnel": false,
        "source": "primary"
      },
      "created_on": "2020-04-12T17:59:04.573862Z",
      "modified_on": "2020-04-12T17:59:04.573862Z"
    }
  ],
  "success": true,
  "errors": [],
  "messages": [],
  "result_info": {
    "page": 1,
    "per_page": 20,
    "count": 1,
    "total_count": 1,
    "total_pages": 1
  }
}
```

Despite the response being successful, the script fails to parse the extra space in `"success": true,` and quits.

This script should handle cases with and without extra spaces in the `success` value.