### PR TITLE
scapy: Use Python packaging, PyPI download

### DIFF
--- a/net/scapy/Makefile
+++ b/net/scapy/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=scapy
 PKG_VERSION:=2.4.3
-PKG_RELEASE:=1
-PKG_LICENSE:=GPL-2.0
+PKG_RELEASE:=2
+PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/secdev/scapy/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6cacd9ebe2beeb06b10ff57bff3632222755e9d62f1b38e71b02edab6e71d776
+PYPI_NAME:=$(PKG_NAME)
+PKG_HASH:=e2f8d11f6a941c14a789ae8b236b27bd634681f1b29b5e893861e284d234f6b0
 
+include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
 
@@ -36,19 +36,6 @@ define Package/scapy/description
   requests and replies, and much more.
 endef
 
-define Build/Compile
-	$(call Python3/ModSetup,., \
-		install --prefix="/usr" --root="$(PKG_INSTALL_DIR)", \
-	)
-endef
-
-define Package/scapy/install
-	$(INSTALL_DIR) $(1)$(PYTHON3_PKG_DIR)
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) \
-		$(PKG_INSTALL_DIR)$(PYTHON3_PKG_DIR)/* \
-		$(1)$(PYTHON3_PKG_DIR)/
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin
-endef
-
+$(eval $(call Py3Package,scapy))
 $(eval $(call BuildPackage,scapy))
+$(eval $(call BuildPackage,scapy-src))


### PR DESCRIPTION
Maintainer: @flyn-org 
Compile tested: armvirt-64, 2020-04-28 snapshot sdk
Run tested: none

Description:
This updates the package to use the default Python package build recipe, adds a src package, and changes to download from PyPI (using pypi.mk).

Signed-off-by: Jeffery To <jeffery.to@gmail.com>