### PR TITLE
uwsgi: Use pypi.mk to download source tarball

### DIFF
--- a/net/uwsgi/Makefile
+++ b/net/uwsgi/Makefile
@@ -4,10 +4,8 @@ PKG_NAME:=uwsgi
 PKG_VERSION:=2.0.18
 PKG_RELEASE:=2
 
-PKG_SOURCE:=uwsgi-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL=https://files.pythonhosted.org/packages/source/u/uwsgi/
+PYPI_NAME:=$(PKG_NAME)
 PKG_HASH:=4972ac538800fb2d421027f49b4a1869b66048839507ccf0aa2fda792d99f583
-PKG_BUILD_DIR:=$(BUILD_DIR)/uwsgi-$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=python3/host
 PYTHON3_PKG_BUILD:=0
 
@@ -15,6 +13,7 @@ PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>
 
+include ../../lang/python/pypi.mk
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/python/python3-package.mk
 #for LINUX_UNAME_VERSION:


### PR DESCRIPTION
Maintainer: @Ansuel 
Compile tested: armvirt-64, 2020-04-28
Run tested: none

Description:
This also removes `PKG_BUILD_DIR`, which does not need to be explicitly set.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>