### PR TITLE
radicale2: Clean up Makefile

### DIFF
--- a/net/radicale2/Makefile
+++ b/net/radicale2/Makefile
@@ -5,9 +5,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=radicale2
 PKG_VERSION:=2.1.11
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
-PKG_LICENSE:=GPL-3.0
+PKG_LICENSE:=GPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:radicale:radicale
 
@@ -22,7 +22,7 @@ define Package/radicale2/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Web Servers/Proxies
-  URL:=http://radicale.org/
+  URL:=https://radicale.org/
   TITLE:=Radicale 2.x CalDAV/CardDAV server
 endef
 
@@ -70,25 +70,9 @@ define Package/radicale2/conffiles
 /etc/radicale2/logging
 endef
 
-define Package/radicale2/preinst
-	#!/bin/sh
-	[ -n "$${IPKG_INSTROOT}" ] && exit 0	# if run within buildroot exit
-
-	# stop service if PKG_UPGRADE
-	[ "$${PKG_UPGRADE}" = "1" ] && /etc/init.d/radicale2 stop >/dev/null 2>&1
-
-	exit 0	# suppress errors from stop command
-endef
-
-define Py3Package/radicale2/filespec
-  +|$(PYTHON3_PKG_DIR)
-  +|/usr/bin/radicale2|0755
-endef
-
 define Py3Package/radicale2/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/radicale $(PKG_INSTALL_DIR)/usr/bin/radicale2
-	$(SED) 's,^#!.*python.*,#!/usr/bin/python$(PYTHON3_VERSION),' $(PKG_INSTALL_DIR)/usr/bin/radicale2
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/radicale $(1)/usr/bin/radicale2
 	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/init.d
 	$(INSTALL_CONF) ./files/radicale2.config $(1)/etc/config/radicale2
 	$(INSTALL_BIN) ./files/radicale2.init $(1)/etc/init.d/radicale2


### PR DESCRIPTION
Maintainer: none
Compile tested: armvirt-64, 2020-04-28 snapshot sdk
Run tested: none

Description:
* Remove preinst, the default prerm script will stop the service
* Use default Python package filespec and shebang fix

Signed-off-by: Jeffery To <jeffery.to@gmail.com>