### PR TITLE
procps-ng: remove unnecessary PKG_BUILD_DEPENDS

### DIFF
--- a/utils/procps-ng/Makefile
+++ b/utils/procps-ng/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=procps-ng
 PKG_VERSION:=3.3.15
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/procps-ng
@@ -22,7 +22,6 @@ PKG_LICENSE_FILES:=COPYING COPYING.LIB
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
-PKG_BUILD_DEPENDS:=gettext libiconv
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
The package Makefile contains an unnecessary PKG_BUILD_DEPENDS
line that builds gettext and libiconv even in cases where the
build has gettext-full and libiconv-full selected.

This behaviour can and does mask errors in other package Makefiles
that are dependent on libiconv-full if it is compiled before
these packages by causing libiconv-stub to be created and put in
the staging tree and potentially linked against by these
dependent packages when they omit to specify an appropriate
PKG_BUILD_DEPENDS line.

procps-ng does not require gettext or libiconv to be built in
order to compile correctly.

Fixes issue #11973 

Signed-off-by: Ian Cooper <iancooper@hotmail.com>

Compilation tested on:  x86_64_glibc with full NLS, libiconv-full 
and libint-full; mips24_musl in default configuration without NLS 
and malta/mipsel_24kc_musl with both full NLS and without. 

Runtime functionality tested on x86_64_glibc.

This line was originally added back in 2016 in [commit aafbee](https://github.com/openwrt/packages/commit/aafbeea12b10e98b9ea9a05c996730988a938cf5#diff-37db63196fd9d4cad61f606748108fa9) due 
to an error compiing on malta. It seems that the problem that 
originally caused the addition of this PKG_BUILD_DEPENDS line no 
longer exists and that it can be safely removed.

Given that this line would cause libiconv-stub to be built and 
potentially erroneously linked by other buggy Makefiles (such as 
was the case with irqbalance), it strikes me that it would be 
sensible to fix it so that it does not hide these buggy Makefiles 
in the future.

There is of course the risk that other, un-tested platforms may 
still require the PKG_BUILD_DEPENDS line, but I think it unlikely
since the reported platform that was giving the error was malta 
and I've tested it against malta.
