### PR TITLE
perl: fix compilation on x86_64 with glibc and ssp

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \
@@ -99,7 +99,7 @@ define Build/Configure
 	                                -Dowrt:gccversion=$(CONFIG_GCC_VERSION) \
 	                                -Dowrt:target_cross='$(TARGET_CROSS)' \
 	                                -Dowrt:cflags='$(TARGET_CFLAGS_PERL) $(TARGET_CPPFLAGS_PERL)' \
-	                                -Dowrt:ldflags='$(TARGET_LDFLAGS)' \
+	                                -Dowrt:ldflags='$(TARGET_LDFLAGS) $(if $(CONFIG_GCC_LIBSSP),-lssp)' \
 	                                -Dowrt:libc=$(subst uClibc,uclibc,$(CONFIG_LIBC)) \
 	                                -Dowrt:ipv6=$(if $($(CONFIG_IPV6)),define,undef) \
 	                                -Dowrt:threads=$(if $(CONFIG_PERL_THREADS),yes,no) \


### PR DESCRIPTION
perl fails to compile on x86_64 with glibc and stack smashing
protection enabled due to libssp not being specified in the
ldflags.

Signed-off-by: Ian Cooper <iancooper@hotmail.com>

Compilation tested on x86_64_glibc and mips24_musl to ensure 
both cases compile correctly

This fixes issue #12004 