### PR TITLE
libevhtp: Fix dependencies not selected when building static library

### DIFF
--- a/libs/libevhtp/Makefile
+++ b/libs/libevhtp/Makefile
@@ -12,7 +12,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libevhtp
 PKG_VERSION:=1.2.18
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 # This package is building a static library, used by seafile-server
 # Every time the built library changes (metadata changes are exempt),
 # seafile-server needs a release bump to ensure the update is used.
@@ -21,11 +21,14 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/criticalstack/libevhtp/tar.gz/$(PKG_VERSION)?
 PKG_HASH:=316ede0d672be3ae6fe489d4ac1c8c53a1db7d4fe05edaff3c7c853933e02795
 
-PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
+PKG_BUILD_DEPENDS:=libevent2 oniguruma
 CMAKE_INSTALL:=1
+
+PKG_CONFIG_DEPENDS:=LIBEVHTP_BUILD_DEPENDS
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -35,13 +38,24 @@ define Package/libevhtp
     CATEGORY:=Libraries
     TITLE:=A more flexible replacement for libevent's httpd API
     URL:=https://github.com/criticalstack/libevhtp
-    DEPENDS:=+libevent2 +libevent2-openssl +libevent2-pthreads +oniguruma
 endef
 
 define Package/libevhtp/description
    Libevhtp was created as a replacement API for Libevent's current HTTP API.
    The reality of libevent's http interface is that it was created as a JIT server,
    meaning the developer never thought of it being used for creating a full-fledged HTTP service.
+endef
+
+define Package/libevhtp/config
+config LIBEVHTP_BUILD_DEPENDS
+	bool
+	default PACKAGE_libevhtp
+
+config LIBEVHTP_BUILD_SELECT
+	tristate
+	default m if LIBEVHTP_BUILD_DEPENDS
+	select PACKAGE_libevent2-openssl
+	select PACKAGE_libevent2-pthreads
 endef
 
 define Build/InstallDev

--- a/net/seafile-server/Makefile
+++ b/net/seafile-server/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-server
 PKG_VERSION:=7.1.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/haiwen/seafile-server/tar.gz/v$(PKG_VERSION)-server?
@@ -20,7 +20,7 @@ PKG_LICENSE:=AGPL-3.0-only
 PKG_LICENSE_FILES:=LICENSE.txt
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)-server
-PKG_BUILD_DEPENDS:=vala/host libevent2 libevent2-openssl libevent2-pthreads libevhtp
+PKG_BUILD_DEPENDS:=vala/host libevhtp
 
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1
@@ -52,7 +52,6 @@ define Package/seafile-server
     +libarchive \
     +libevent2 \
     +libevent2-openssl \
-    +libevent2-pthreads \
     +libmariadb \
     +libopenssl \
     +libpthread \
@@ -76,6 +75,10 @@ define Package/seafile-server/description
   protection and teamwork.
 endef
 
+define Package/seafile-server/config
+  select LIBEVHTP_BUILD_DEPENDS
+endef
+
 define Package/seafile-server-fuse
   SECTION:=net
   CATEGORY:=Network
@@ -87,7 +90,6 @@ define Package/seafile-server-fuse
     +jansson \
     +libevent2 \
     +libevent2-openssl \
-    +libevent2-pthreads \
     +libfuse \
     +libmariadb \
     +libopenssl \


### PR DESCRIPTION
Maintainer: me (for seafile-server), @commodo, @cotequeiroz 
Compile tested: armvirt-64/x86-generic, 2020-04-28 snapshot sdk
Run tested: none

Description:
When libevhtp is added to a package's `PKG_BUILD_DEPENDS` (i.e. for seafile-server), libevhtp's target package dependencies are not automatically selected, in particular libevent2-openssl and
libevent2-pthreads.

Moreover, if libevent-openssl and libevent2-pthreads are not selected, OpenSSL and thread support are disabled when compiling libevent2, which in turn causes a compile error when building libevhtp.

This adds a config option, `LIBEVHTP_BUILD_DEPENDS`, that will select libevent2-openssl and libevent2-pthreads (via `LIBEVHTP_BUILD_SELECT`) when it is selected.

Other build dependencies are moved to `PKG_BUILD_DEPENDS`.

This also updates seafile-server to remove the (indirect) dependencies added in 13d843fec1cd3281cc469fc74de302c1f793b723 and instead select `LIBEVHTP_BUILD_DEPENDS`.

This also updates the maintainer's email address and adds myself as another maintainer.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>