### PR TITLE
postgresql: fix C99 loop initialization error

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
 PKG_VERSION:=12.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
 PKG_CPE_ID:=cpe:/a:postgresql:postgresql
@@ -122,6 +122,8 @@ PGSQL_CONFIG_VARS+= \
 		pgac_cv_type_locale_t=no
 endif
 
+HOST_CFLAGS+=-std=gnu99
+TARGET_CFLAGS+=-std=gnu99
 TARGET_CONFIGURE_OPTS+=$(PGSQL_CONFIG_VARS)
 
 HOST_CONFIGURE_ARGS += \


### PR DESCRIPTION
The source contains for loop initial declarations which require
a -std=gnu99 compile-time option to compile correctly

Signed-off-by: Ian Cooper <iancooper@hotmail.com>

Tested on x86_64_glibc and mips_24kc_musl

Fixes #12011 
