### PR TITLE
mocp: disable ffmpeg

### DIFF
--- a/sound/mocp/Makefile
+++ b/sound/mocp/Makefile
@@ -9,19 +9,18 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=moc
 PKG_VERSION:=2.5.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://ftp.daper.net/pub/soft/moc/stable/
 PKG_HASH:=f3a68115602a4788b7cfa9bbe9397a9d5e24c68cb61a57695d1c2c3ecf49db08
 
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
-
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
-PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
@@ -29,33 +28,43 @@ include $(INCLUDE_DIR)/nls.mk
 define Package/moc
   SECTION:=sound
   CATEGORY:=Sound
-  DEPENDS:=+libcurl $(ICONV_DEPENDS) +alsa-lib +libid3tag +libsamplerate +libncursesw +libffmpeg +libltdl +libmagic +libdb47
+  DEPENDS:=+libcurl $(ICONV_DEPENDS) +alsa-lib +libid3tag +libsamplerate +libmad +libfaad2 +libflac +libvorbis +libncursesw +libltdl +libmagic +libdb47
   TITLE:=Music On Console
-  URL:=http://moc.daper.net/
+  URL:=https://moc.daper.net/
 endef
 
 define Package/moc/description
 	MOC (music on console) is a console audio player for LINUX/UNIX designed to be powerful and easy to use.
 endef
 
-TARGET_CFLAGS+=-D_GNU_SOURCE
-
 TARGET_CPPFLAGS+=-P
 
-CONFIGURE_ARGS+= \
+CONFIGURE_ARGS += \
 		--enable-shared \
 		--disable-static \
 		--disable-debug \
-		--without-speex \
-		--without-aac \
-		--without-flac \
-		--without-mp3 \
-		--without-musepack \
 		--without-rcc \
+		--without-oss \
+		--without-sndio \
+		--with-alsa \
+		--without-jack \
+		--with-magic \
+		--without-ncurses \
+		--with-ncursesw \
+		--with-samplerate \
+		--with-aac \
+		--without-ffmpeg \
+		--with-flac \
+		--without-modplug \
+		--with-mp3 \
+		--without-musepack \
+		--without-sidplay2 \
 		--without-sndfile \
-		--without-vorbis \
+		--without-speex \
+		--without-timidity \
+		--with-vorbis \
 		--without-wavpack \
-		$(if $(CONFIG_PACKAGE_libncursesw),--with-ncursesw --without-ncurses,--with-ncurses --without-ncursesw) \
+		--with-curl \
 		--with-bdb-dir="$(STAGING_DIR)/usr"
 
 define Package/moc/install


### PR DESCRIPTION
The recent update to ffmpeg broke this.

Instead, use the relevant libraries separately.

Added AAC support. AAC is very common and was recently fixed to be
compatible with BUILD_PATENTED.

Explicitly pass all configure arguments, to avoid future breakage.

Remove autoreconf. autotools files are not being patched.

Add PKG_BUILD_PARALLEL for speed.

Other minor cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: arc700