### PR TITLE
keepalived: config generation improvments

### DIFF
--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -216,6 +216,10 @@ define Package/keepalived/install
 	$(INSTALL_CONF) $(PKG_INSTALL_DIR)/etc/keepalived/keepalived.conf \
 		$(1)/etc/keepalived/
 
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/etc/uci-defaults/keepalived \
+		$(1)/etc/uci-defaults/keepalived
+
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/keepalived.init \
 		$(1)/etc/init.d/keepalived

--- a/net/keepalived/Makefile
+++ b/net/keepalived/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=keepalived
 PKG_VERSION:=2.0.20
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.keepalived.org/software

--- a/net/keepalived/files/etc/uci-defaults/keepalived
+++ b/net/keepalived/files/etc/uci-defaults/keepalived
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Check if old config section is still in use
+uci show keepalived.@global_defs[-1] 1>/dev/null 2>/dev/null
+if [ "$?" -eq "0" ]; then
+	uci -q rename keepalived.@global_defs[-1]=globals
+	uci -q commit keepalived
+	sed -i "s|^config global_defs 'globals'$|config globals 'globals'|" \
+		/etc/config/keepalived
+fi
+
+exit 0

--- a/net/keepalived/files/keepalived.init
+++ b/net/keepalived/files/keepalived.init
@@ -98,6 +98,9 @@ print_notify() {
 globals() {
 	local notification_email
 
+	printf '%bscript_user root\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
+	printf '%benabled_script_security\n' "${INDENT_1}" >> "$KEEPALIVED_CONF"
+
 	config_get notification_email "$1" notification_email
 	print_list_indent notification_email
 

--- a/net/keepalived/files/keepalived.init
+++ b/net/keepalived/files/keepalived.init
@@ -95,11 +95,8 @@ print_notify() {
 	done
 }
 
-global_defs() {
+globals() {
 	local linkbeat_use_polling notification_email
-
-	config_get alt_config_file "$1" alt_config_file
-	[ -z "$alt_config_file" ] || return 0
 
 	config_get_bool linkbeat_use_polling "$1" linkbeat_use_polling 0
 	[ "$linkbeat_use_polling" -gt 0 ] && printf 'linkbeat_use_polling\n\n' >> "$KEEPALIVED_CONF"
@@ -494,10 +491,7 @@ process_config() {
 
 	[ -f /etc/config/keepalived ] || return 0
 	config_load 'keepalived'
-
-	config_section_open "global_defs"
-	config_foreach_wrapper global_defs
-	config_section_close
+	config_get alt_config_file globals alt_config_file
 
 	# If "alt_config_file" specified, use that instead
 	[ -n "$alt_config_file" ] && [ -f "$alt_config_file" ] && {
@@ -506,6 +500,10 @@ process_config() {
 		ln -s "$alt_config_file" "$KEEPALIVED_CONF"
 		return 0
 	}
+
+	config_section_open "global_defs"
+	config_foreach_wrapper globals
+	config_section_close
 
 	config_section_open "static_ipaddress"
 	config_foreach_wrapper static_ipaddress

--- a/net/keepalived/files/keepalived.init
+++ b/net/keepalived/files/keepalived.init
@@ -96,10 +96,7 @@ print_notify() {
 }
 
 globals() {
-	local linkbeat_use_polling notification_email
-
-	config_get_bool linkbeat_use_polling "$1" linkbeat_use_polling 0
-	[ "$linkbeat_use_polling" -gt 0 ] && printf 'linkbeat_use_polling\n\n' >> "$KEEPALIVED_CONF"
+	local notification_email
 
 	config_get notification_email "$1" notification_email
 	print_list_indent notification_email
@@ -481,7 +478,7 @@ virtual_server() {
 }
 
 process_config() {
-	local alt_config_file
+	local alt_config_file linkbeat_use_polling
 
 	rm -f "$KEEPALIVED_CONF"
 
@@ -500,6 +497,9 @@ process_config() {
 		ln -s "$alt_config_file" "$KEEPALIVED_CONF"
 		return 0
 	}
+
+	config_get_bool linkbeat_use_polling globals linkbeat_use_polling 0
+	[ "$linkbeat_use_polling" -gt 0 ] && printf 'linkbeat_use_polling\n\n' >> "$KEEPALIVED_CONF"
 
 	config_section_open "global_defs"
 	config_foreach_wrapper globals


### PR DESCRIPTION
Maintainer: me
Compile tested: no needed only script changes
Run tested: x86_64 and lantiq_xrx200, APU3, openwrt master

Description:

- keepalived: add script security param to fix warning
- keepalived: move linkbeat_use_polling section into main section
- keepalived: move alt_config_file check into process_config
- keepalived: add upgrade script for globals section