### PR TITLE
bind: update to version (security fix)

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.1
+PKG_VERSION:=9.16.2
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=a913d7e78135b9123d233215b58102fa0f18130fb1e158465a1c2b6f3bd75e91
+PKG_HASH:=d9e5b77cfca5ccad97f19cddc87128758ec15c16e6585000c6b2f84fc225993f
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates BIND to the last stable version which fixes ineffective DNS rebinding protection in the case that BIND is used as a forwarding DNS server. [Changelog](https://downloads.isc.org/isc/bind9/9.16.2/RELEASE-NOTES-bind-9.16.2.html)

