### PR TITLE
mwan3: Don't use /128 address for ping source

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.4
-PKG_RELEASE:=2
+PKG_VERSION:=2.8.5
+PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -136,7 +136,7 @@ main() {
 						# https://bugs.openwrt.org/index.php?do=details&task_id=2897
 						# so get the IP address of the interface and use that instead
 						if echo $track_ip | grep -q ':'; then
-							ADDR=$(ip -6 addr ls dev "$DEVICE" | sed -ne 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p')
+							ADDR=$(ip -6 addr ls dev "$DEVICE" | sed -ne '/\/128/d' -e 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p')
 						fi
 						if [ $check_quality -eq 0 ]; then
 							ping -I ${ADDR:-$DEVICE} -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: WNDR4300 19.07.2
Run tested: WNDR4300 19.07.2
Verified that ping tests now work.

Description:
An interface can have both a /64 and a /128 from a provider.

In such a case, use the address from the /64 to do the ping check, not
the /128.

Fixes: 12009
Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>