### PR TITLE
snort: bump to 2.9.15.1

### DIFF
--- a/net/snort/Makefile
+++ b/net/snort/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=snort
-PKG_VERSION:=2.9.15
+PKG_VERSION:=2.9.15.1
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPL-2.0
@@ -16,9 +16,9 @@ PKG_MAINTAINER:=W. Michael Petullo <mike@flyn.org>
 PKG_CPE_ID:=cpe:/a:snort:snort
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://www.snort.org/downloads/snort/ \
+PKG_SOURCE_URL:=https://www.snort.org/downloads/archive/snort/ \
 	@SF/$(PKG_NAME)
-PKG_HASH:=bfb437746446ef72a03c501db13cd6da5edd2b41f55c80c437ba288be6da7dba
+PKG_HASH:=2cccfc1d1a706586cd47ae9f085a7d5e4e36390b8e9c28cd2020b4b5b587f6c3
 
 PKG_BUILD_DEPENDS:=libtirpc
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/$(PKG_NAME)-$(PKG_VERSION)


### PR DESCRIPTION
Fix compilation error with x86_64 glibc

Fix changed download location on snort.org

Signed-off-by: Ian Cooper <iancooper@hotmail.com>

Maintainer: @flyn-org 
Compile tested: x86_64_glibc, mips_24kc_musl
Run tested: x86_64_glibc, 19.07.2 

I've been running this version for several weeks already, so I'm confident it's stable and no issues. The codebase is almost identical to 2.9.15 except for changes to support glibc 2.30, which is the reason snort compilation is failing with glibc, since master was bumped to glibc 2.31 a short while back. Snort changelog below

```
2019-12-15 Hariharan Chandrashekar <harchand@cisco.com>
snort 2.9.15.1

	* src/file-process/file_ss.c :
	  Fixed the right order of precedence. Thanks to David Binderman for reporting this.

	* src/dynamic-preprocessors/ssl_common/ssl_config.c :
	  Fixed snort core seen during ssl re-configuration.

	* src/fpdetect.c,
	  src/log_text.c, src/profiler.h :
	  Fixed compiler warnings.

	* src/file-process/file_segment_process.c :
	  Fixed file access issues on files from SMB share.

	* configure.in,
	  src/reload.c, src/side-channel/sidechannel.c,
	  src/snort.c, src/target-based/sftarget_reader.c, src/util.h :
	  Added support for glibc version 2.30.
```

Fixes issue #12020 
Fixes issue #12024 

Waiting for comment from @flyn-org before marking ready for review
