### PR TITLE
xtables-addons: include xt_geoip_fetch utility

### DIFF
--- a/net/xtables-addons/Makefile
+++ b/net/xtables-addons/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=xtables-addons
 PKG_VERSION:=3.13
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_HASH:=893c0c4ea09759cda1ab7e68f1281d125e59270f7b59e446204ce686c6a76d65
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -144,6 +144,9 @@ define Package/iptgeoip/install
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/xtables-addons/xt_geoip_{build,dl} \
 		$(1)/usr/lib/xtables-addons/
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/bin/xt_geoip_fetch \
+		$(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/usr/share/xt_geoip
 endef
 


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: x86_64, generic, HEAD (`54d6cb34e6`)
Run tested: x86_64, generic, installed onto pkg onto running production router, ran `/usr/lib/xtables-addons/xt_geoip_fetch -4 -D /usr/share/xt_geoip WF` and validated output.

Description:

The `xt_geoip_fetch` utility dumps the country database (ipv4 or ipv6) as sorted non-overlapping, consecutive lines of CIDRs, suitable for machine post-processing.
