### PR TITLE
Revert gperf: remove

### DIFF
--- a/libs/gperf/Makefile
+++ b/libs/gperf/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2006-2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gperf
+PKG_VERSION:=3.1
+PKG_RELEASE:=1
+PKG_HASH:=588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@GNU/gperf
+PKG_HOST_ONLY=1
+
+PKG_MAINTAINER:=Espen Jürgensen <espenjurgensen+openwrt@gmail.com>
+PKG_LICENSE:=GPL-3.0
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gperf
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=GNU gperf
+  BUILDONLY:=1
+  URL:=http://www.gnu.org/software/gperf
+endef
+
+define Package/gperf/description
+ GNU gperf is a perfect hash function generator. For a given list of strings, it
+ produces a hash function and hash table, in form of C or C++ code, for looking 
+ up a value depending on the input string. The hash function is perfect, which 
+ means that the hash table has no collisions, and the hash table lookup needs a
+ single string comparison only.
+endef
+
+define Host/Install
+	$(MAKE) -C $(HOST_BUILD_DIR) install
+endef
+
+$(eval $(call HostBuild))
+$(eval $(call BuildPackage,gperf))

--- a/libs/gperf/patches/100-include_own_first.patch
+++ b/libs/gperf/patches/100-include_own_first.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/Makefile.in b/lib/Makefile.in
+index 29bbf92..cf2bf3c 100644
+--- a/lib/Makefile.in
++++ b/lib/Makefile.in
+@@ -61,7 +61,7 @@ SHELL = /bin/sh
+ VPATH = $(srcdir)
+ 
+ OBJECTS  = getopt.$(OBJEXT) getopt1.$(OBJEXT) getline.$(OBJEXT) hash.$(OBJEXT)
+-CPPFLAGS = @CPPFLAGS@ -I$(srcdir)
++CPPFLAGS = -I$(srcdir) @CPPFLAGS@
+ 
+ TARGETLIB = libgp.a
+ 
+diff --git a/src/Makefile.in b/src/Makefile.in
+index 6866ffd..bd4df14 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -64,7 +64,7 @@ VPATH = $(srcdir)
+ OBJECTS  = version.$(OBJEXT) positions.$(OBJEXT) options.$(OBJEXT) keyword.$(OBJEXT) keyword-list.$(OBJEXT) \
+            input.$(OBJEXT) bool-array.$(OBJEXT) hash-table.$(OBJEXT) search.$(OBJEXT) output.$(OBJEXT) main.$(OBJEXT)
+ LIBS     = ../lib/libgp.a @GPERF_LIBM@
+-CPPFLAGS = @CPPFLAGS@ -I. -I$(srcdir)/../lib
++CPPFLAGS = -I. -I$(srcdir)/../lib @CPPFLAGS@
+ 
+ TARGETPROG = gperf$(EXEEXT)
+ 


### PR DESCRIPTION
gperf is a basic tool used when building packages. It's not available on
all hosts, in which case having a host package like this one is
required. For instance the CircleCI environment does not contain gperf,
in which case building of software requiring gperf fails.

This commit reverts the gperf removal.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @ejurgensen 
Compile tested: x86_64 host
Run tested: x86_64 host

Description:

Hello all,

Hope the gperf tool can be added back. I would like to add rtpengine to telephony and it requires gperf during build. I think having gperf available on any build host is a good thing in general. Plus it doesn't have much of a maintenance impact.

Thanks!
Seb