### PR TITLE
json-glib: new package

### DIFF
--- a/libs/json-glib/Makefile
+++ b/libs/json-glib/Makefile
@@ -1,0 +1,83 @@
+#
+# Copyright (C) 2020 Sebastian Kemper <sebastian_ml@gmx.net>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=json-glib
+PKG_VERSION:=1.4.4
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=@GNOME/json-glib/1.4
+PKG_HASH:=720c5f4379513dc11fd97dc75336eb0c0d3338c53128044d9fabec4374f4bc47
+
+PKG_INSTALL:=1
+
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
+
+PKG_BUILD_DEPENDS:=glib2/host meson/host
+
+OPENWRT_VERBOSE:=c
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+include ../../devel/meson/meson.mk
+
+define Package/json-glib
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=JSON GLib Library
+  URL:=https://wiki.gnome.org/Projects/JsonGlib
+  DEPENDS:=+glib2
+endef
+
+define Package/json-glib/description
+JSON-GLib is a library providing serialization and deserialization
+support for the JavaScript Object Notation (JSON) format described by
+RFC 4627.
+endef
+
+MESON_ARGS += \
+	-Ddocs=false \
+	-Dintrospection=false \
+	-Dman=false
+
+# Disable installed-tests; this also indirectly removes
+# build_aux/gen-installed-test.py calls (copied from Gentoo)
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(SED) 's/install: true/install: false/g' \
+		$(PKG_BUILD_DIR)/json-glib/tests/meson.build
+	$(SED) '/install_data/d' \
+		$(PKG_BUILD_DIR)/json-glib/tests/meson.build
+	$(SED) '/error=format=2/d' $(PKG_BUILD_DIR)/meson.build
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/json-glib-1.0/json-glib
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)/usr/include/json-glib-1.0/json-glib/*.h \
+				$(1)/usr/include/json-glib-1.0/json-glib
+	
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libjson-glib-1.0.so* \
+						$(1)/usr/lib
+	
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/json-glib-1.0.pc \
+					$(1)/usr/lib/pkgconfig
+endef
+
+define Package/json-glib/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libjson-glib-1.0.so.* \
+						$(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,json-glib))


### PR DESCRIPTION
From upstream description:

JSON-GLib is a library providing serialization and deserialization
support for the JavaScript Object Notation (JSON) format described by
RFC 4627.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: arc770, ath79, x86_64 (all master)
Run tested: ath79 19.07 using rtpengine (uses this library)

Description:

Hi all,

I'm hoping to get this into packages. I want to add rtpengine to telephony repo. This is the one dependency that is missing. json-glib is not a telephony package, hence I'd rather it gets added to packages. I would maintain it.

I checked if introducing this lib could cause build fails for any other packages. I looked at Gentoo's packages that depend on json-glib and checked which of these are in OpenWrt. The only two I found were zerotier and grilo-plugins (maintainer @flyn-org). But in zerotier I actually cannot find any mention of json-glib, so I'm wondering if that might be a mistake in Gentoo. And in grilo-plugins the parts that can use json-glib (lua and some other part I now forget) are not packaged in OpenWrt.

I compiled both full zerotier and grilo-plugins with json-glib in staging and there was no issue. So to the best of my knowledge there wouldn't be any failure introduced. But in the unexpected case that there is build failure I would fix it.

Thanks!

Best regards,
Seb