### PR TITLE
syslog-ng: including user settings after system settings

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.26.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -6,7 +6,6 @@
 
 @version: 3.26
 @include "scl.conf"
-@include "/etc/syslog-ng.d/" # Put any customization files in this directory
 
 options {
 	chain_hostnames(no); # Enable or disable the chained hostname format.
@@ -60,3 +59,9 @@ log {
 	# uncomment this line to open port 514 to receive messages
 	#source(s_network);
 };
+
+#
+# Finally, include any user settings last so that s/he can override or
+# supplement all "canned" settings inherited from the distribution.
+#
+@include "/etc/syslog-ng.d/" # Put any customization files in this directory


### PR DESCRIPTION
Maintainer: @BKPepe 
Compile tested: x86_64, generic, HEAD (54d6cb34e6)
Run tested: ditto

Copied over config file, stopped and restarted `syslog-ng` service.  Had `/etc/syslog-ng.d/custom.conf` file containing:

```
options {
	use_fqdn(yes);
};
```

and confirmed that the logging overrode the system defaults:

```
May  1 11:28:48 OpenWrt.redfish-solutions.com syslog-ng[13319]: syslog-ng starting up; version='3.26.1'
```
Description:

Restore the ability to override the system defaults for logging settings.
