### PR TITLE
ddns-scripts: Add digitalocean as DDNS provider

### DIFF
--- a/net/ddns-scripts/Makefile
+++ b/net/ddns-scripts/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ddns-scripts
 PKG_VERSION:=2.7.8
 # Release == build
 # increase on changes of services files or tld_names.dat
-PKG_RELEASE:=19
+PKG_RELEASE:=20
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=
@@ -81,6 +81,26 @@ define Package/ddns-scripts_godaddy.com-v1
 endef
 define Package/ddns-scripts_godaddy.com-v1/description
     Dynamic DNS Client scripts extension for GoDaddy.com (require/install cURL)
+endef
+
+###### *************************************************************************
+define Package/ddns-scripts_digitalocean.com-v2
+    $(call Package/ddns-scripts/Default)
+    TITLE:=digitalocean.com (require cURL)
+    DEPENDS:=ddns-scripts +curl
+endef
+define Package/ddns-scripts_digitalocean.com-v2/description
+    Dynamic DNS Client scripts extension for digitalocean.com (require/install cURL)
+endef
+define Package/ddns-scripts_digitalocean.com-v2/config
+    help
+	The script directly updates a DNS record using the DO API. It requires
+	"option dns_server" to be set to the server to be used by nsupdate.
+	"option domain" the dns domain to update the record for (eg. A-record: home.<example.com>)
+	"option username" the dns record name to update (eg. A-record: <home>.example.com)
+	"option param_opt" the id of the dns record to update (check using chrome inspector in the DO dns tab)
+	"option password" the api token generated in the DO panel
+
 endef
 
 ###### *************************************************************************
@@ -332,6 +352,47 @@ define Package/ddns-scripts_godaddy.com-v1/prerm
 endef
 
 ###### *************************************************************************
+define Package/ddns-scripts_digitalocean.com-v2/preinst
+	#!/bin/sh
+	# if NOT run buildroot then stop service
+	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop >/dev/null 2>&1
+	exit 0	# suppress errors
+endef
+define Package/ddns-scripts_digitalocean.com-v2/install
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/ddns.defaults $(1)/etc/uci-defaults/ddns_digtalocean.com-v2
+	$(INSTALL_DIR) $(1)/usr/lib/ddns
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/update_digitalocean_com_v2.sh $(1)/usr/lib/ddns
+endef
+define Package/ddns-scripts_digitalocean.com-v2/postinst
+	#!/bin/sh
+	# remove old services file entries
+	/bin/sed -i '/digitalocean\.com-v2/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
+	/bin/sed -i '/digitalocean\.com-v2/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+	# and create new
+	printf "%s\\t%s\\n" '"digitalocean.com-v2"' '"update_digitalocean_com_v2.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services
+	printf "%s\\t%s\\n" '"digitalocean.com-v2"' '"update_digitalocean_com_v2.sh"' >> $${IPKG_INSTROOT}/etc/ddns/services_ipv6
+	# on real system restart service if enabled
+	[ -z "$${IPKG_INSTROOT}" ] && {
+		[ -x /etc/uci-defaults/ddns_digitalocean.com-v2 ] && \
+			/etc/uci-defaults/ddns_digitalocean.com-v2 && \
+				rm -f /etc/uci-defaults/ddns_digitalocean.com-v2 >/dev/null 2>&1
+		/etc/init.d/ddns enabled \
+			&& /etc/init.d/ddns start >/dev/null 2>&1
+	}
+	exit 0	# suppress errors
+endef
+define Package/ddns-scripts_digitalocean.com-v2/prerm
+	#!/bin/sh
+	# if NOT run buildroot then stop service
+	[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/ddns stop				>/dev/null 2>&1
+	# remove services file entries
+	/bin/sed -i '/digitalocean\.com-v2/d' $${IPKG_INSTROOT}/etc/ddns/services		>/dev/null 2>&1
+	/bin/sed -i '/digitalocean\.com-v2/d' $${IPKG_INSTROOT}/etc/ddns/services_ipv6	>/dev/null 2>&1
+	exit 0	# suppress errors
+endef
+
+###### *************************************************************************
 define Package/ddns-scripts_no-ip_com/preinst
 	#!/bin/sh
 	# if NOT run buildroot then stop service
@@ -497,6 +558,7 @@ $(eval $(call BuildPackage,ddns-scripts))
 $(eval $(call BuildPackage,ddns-scripts_cloudflare.com-v4))
 $(eval $(call BuildPackage,ddns-scripts_freedns_42_pl))
 $(eval $(call BuildPackage,ddns-scripts_godaddy.com-v1))
+$(eval $(call BuildPackage,ddns-scripts_digitalocean.com-v2))
 $(eval $(call BuildPackage,ddns-scripts_no-ip_com))
 $(eval $(call BuildPackage,ddns-scripts_nsupdate))
 $(eval $(call BuildPackage,ddns-scripts_route53-v1))

--- a/net/ddns-scripts/files/update_digitalocean_com_v2.sh
+++ b/net/ddns-scripts/files/update_digitalocean_com_v2.sh
@@ -1,0 +1,51 @@
+# Script for sending user defined updates using DO API
+# 2015 Artem Yakimenko <code at temik dot me>
+#
+# activated inside /etc/config/ddns by setting
+#
+# option update_script '/usr/lib/ddns/update_do.sh'
+#
+# the script is parsed (not executed) inside send_update() function
+# of /usr/lib/ddns/dynamic_dns_functions.sh
+# so you can use all available functions and global variables inside this script
+# already defined in dynamic_dns_updater.sh and dynamic_dns_functions.sh
+#
+# It make sence to define the update url ONLY inside this script
+# because it's anyway unique to the update script
+# otherwise it should work with the default scripts
+#
+# Options are passed from /etc/config/ddns:
+
+# Username - the record name DO Zone
+# Password - API Token
+# Domain - the domain managed by DO
+# Parm_opt - The Record ID in the DO API structure
+
+local __URL="https://api.digitalocean.com/v2/domains/[DOMAIN]/records/[RECORD_ID]"
+local __HEADER="Authorization: Bearer [PASSWORD]"
+local __HEADER_CONTENT="Content-Type: application/json"
+local __BODY='{"name":"[NAME]","data": "[IP]"}'
+# inside url we need username and password
+
+[ -z "$domain" ] && write_log 14 "Service section not configured correctly! Missing 'domain'"
+[ -z "$username" ] && write_log 14 "Service section not configured correctly! Missing 'Zone name in Username'"
+[ -z "$password" ] && write_log 14 "Service section not configured correctly! Missing 'password'"
+[ -z "$param_opt" ] && write_log 14 "Service section not configured correctly! Missing 'Zone ID in Optional Parameter'"
+
+# do replaces in URL, header and body:
+__URL=$(echo $__URL | sed -e "s#\[RECORD_ID\]#$param_opt#g"  \
+                               -e "s#\[DOMAIN\]#$domain#g")
+__HEADER=$(echo $__HEADER| sed -e "s#\[PASSWORD\]#$password#g")
+__HEADER_CONTENT=$(echo $__HEADER_CONTENT)
+__BODY=$(echo $__BODY | sed -e "s#\[NAME\]#$username#g" -e "s#\[IP\]#$__IP#g")
+
+#Send PUT request
+
+curl -X PUT -H "$__HEADER_CONTENT" -H "$__HEADER" -d "$__BODY" "$__URL"
+
+write_log 7 "DDNS Provider answered:\n$(cat $DATFILE)"
+
+# analyse provider answers
+# If IP is contained in the returned datastructure - API call was sucessful
+grep -E "$__IP" $DATFILE >/dev/null 2>&1
+return $?      # "0" if IP has been changed or no change is needed


### PR DESCRIPTION
Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: lantiq wr8870 4.19 (openwrt 19.07 master)
Run tested: tested on lantiq with luci, ip updated correctly

Description: This PR adds support for updating DNS records on the digital ocean api. The job was done by adding a new script that does the curl call with the configured paramters  Documentation is in the Makefile (as for the other ddns providers).
