### PR TITLE
neon: update to 0.31.1

### DIFF
--- a/libs/neon/Makefile
+++ b/libs/neon/Makefile
@@ -8,16 +8,20 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=neon
-PKG_VERSION:=0.30.2
-PKG_RELEASE:=4
+PKG_VERSION:=0.31.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://web.archive.org/web/20170923042221/http://webdav.org:80/neon/
-PKG_HASH:=db0bd8cdec329b48f53a6f00199c92d5ba40b0f015b153718d1b15d3d967fbca
+PKG_SOURCE_URL:=https://notroj.github.io/neon
+PKG_HASH:=c9dfcee723050df37ce18ba449d7707b78e7ab8230f3a4c59d9112e17dc2718d
 
+PKG_MAINTAINER:=Federico Di Marco <fededim@gmail.com>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=src/COPYING.LIB
 PKG_CPE_ID:=cpe:/a:webdav:neon
 
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -25,9 +29,8 @@ define Package/libneon
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=HTTP and WebDAV client library
-  URL:=http://www.webdav.org/neon/
+  URL:=https://notroj.github.io/neon/
   DEPENDS:=+libopenssl +libexpat +zlib
-  MAINTAINER:=Federico Di Marco <fededim@gmail.com>
 endef
 
 define Package/libneon/description
@@ -44,10 +47,6 @@ define Package/libneon/description
   - WebDAV metadata support; wrappers for PROPFIND and PROPPATCH to simplify property manipulation.
 endef
 
-
-TARGET_CFLAGS += $(FPIC)
-TARGET_CPPFLAGS += -D_GNU_SOURCE
-
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
@@ -56,9 +55,6 @@ CONFIGURE_ARGS += \
 	--without-egd \
 	--without-gssapi \
 	--without-libproxy
-
-CONFIGURE_VARS += \
-	LDFLAGS="$$$$LDFLAGS -lcrypto -lssl"
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/bin
@@ -69,8 +65,6 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libneon.{a,so*} $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/neon.pc $(1)/usr/lib/pkgconfig/
-	$(SED) 's,-I$$$${includedir}/,-I$(STAGING_DIR)/usr/include/,g' $(1)/usr/bin/neon-config
-	$(SED) 's,-L$$$${libdir},,g' $(1)/usr/bin/neon-config
 endef
 
 define Package/libneon/install

--- a/libs/neon/patches/010-openssl-deprecated.patch
+++ b/libs/neon/patches/010-openssl-deprecated.patch
@@ -1,17 +1,6 @@
 --- a/src/ne_openssl.c
 +++ b/src/ne_openssl.c
-@@ -35,6 +35,10 @@
- #include <openssl/x509v3.h>
- #include <openssl/rand.h>
- #include <openssl/opensslv.h>
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L
-+#define X509_get0_notBefore X509_get_notBefore
-+#define X509_get0_notAfter X509_get_notAfter
-+#endif
- 
- #ifdef NE_HAVE_TS_SSL
- #include <stdlib.h> /* for abort() */
-@@ -226,10 +230,10 @@ void ne_ssl_cert_validity_time(const ne_ssl_certificate *cert,
+@@ -230,10 +230,10 @@ void ne_ssl_cert_validity_time(const ne_ssl_certificate *cert,
                                 time_t *from, time_t *until)
  {
      if (from) {
@@ -24,14 +13,3 @@
      }
  }
  
---- a/src/ne_socket.c
-+++ b/src/ne_socket.c
-@@ -27,7 +27,7 @@
- #include "config.h"
- 
- #include <sys/types.h>
--#ifdef HAVE_SYS_UIO_h
-+#ifdef HAVE_SYS_UIO_H
- #include <sys/uio.h> /* writev(2) */
- #endif
- #ifdef HAVE_SYS_TIME_H


### PR DESCRIPTION
Upstream changed.

Add license information.

Add PKG_BUILD_PARALLEL for faster compilation.

Remove several outdated options.

Refreshed OpenSSL patch.

Other small cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @fededim 
Compile tested: ath79