### PR TITLE
[19.07] vpnbypass: bugfix: remove non-ASCII from system log; update README

### DIFF
--- a/net/vpnbypass/Makefile
+++ b/net/vpnbypass/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vpnbypass
 PKG_VERSION:=1.3.1
-PKG_RELEASE:=4
+PKG_RELEASE:=7
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 
@@ -14,9 +14,8 @@ include $(INCLUDE_DIR)/package.mk
 define Package/vpnbypass
 	SECTION:=net
 	CATEGORY:=Network
-	DEPENDS:=+ipset +iptables
-	CONFLICTS:=vpn-policy-routing
 	TITLE:=VPN Bypass Service
+	DEPENDS:=+ipset +iptables
 	PKGARCH:=all
 endef
 
@@ -59,16 +58,6 @@ define Package/vpnbypass/postinst
 	# check if we are on real system
 	if [ -z "$${IPKG_INSTROOT}" ]; then
 		/etc/init.d/vpnbypass enable
-
-		while uci -q del ucitrack.@vpnbypass[-1]; do :; done
-
-		uci -q batch <<-EOF >/dev/null
-			add ucitrack vpnbypass
-			set ucitrack.@vpnbypass[0].init='vpnbypass'
-			del_list ucitrack.@firewall[0].affects='vpnbypass'
-			add_list ucitrack.@firewall[0].affects='vpnbypass'
-			commit ucitrack
-	EOF
 	fi
 	exit 0
 endef
@@ -77,8 +66,6 @@ define Package/vpnbypass/prerm
 	#!/bin/sh
 	# check if we are on real system
 	if [ -z "$${IPKG_INSTROOT}" ]; then
-		while uci -q delete ucitrack.@vpnbypass[-1]; do :; done
-		uci -q del_list ucitrack.@firewall[0].affects='vpnbypass'
 		echo "Stopping service and removing rc.d symlink for vpnbypass"
 		/etc/init.d/vpnbypass stop || true
 		/etc/init.d/vpnbypass disable || true

--- a/net/vpnbypass/files/README.md
+++ b/net/vpnbypass/files/README.md
@@ -1,15 +1,15 @@
 # VPN Bypass
 
-A simple PROCD-based ```vpnbypass``` service for OpenWrt/LEDE Project. Useful if your router accesses internet thru VPN client/tunnel, but you want specific traffic (ports, IP ranges, domains or local IP ranges) to be routed outside of this tunnel.
+A simple [procd](https://openwrt.org/docs/techref/procd)-based ```vpnbypass``` service for OpenWrt/LEDE Project. This is useful if your router accesses Internet through a VPN client/tunnel, but you want specific traffic (ports, IP ranges, domains or local IP ranges) to be routed outside of this tunnel.
 
 ## Features
 
-- Allows to define local ports so that traffic to them is routed outside of the VPN tunnel (by default routes Plex Media Server traffic (port 32400) outside of the VPN tunnel).
-- Allows to define IPs/subnets in local network so that their traffic is routed outside of the VPN tunnel (by default routes traffic from 192.168.1.81-192.168.1.87 outside of the VPN tunnel).
-- Allows to define remote IPs/ranges that they are accessed outside of the VPN tunnel (by default routes LogmeIn Hamachi traffic (25.0.0.0/8) outside of the VPN tunnel).
-- Allows to define list of domain names which are accessed outside of the VPN tunnel (useful for Netflix, Hulu, etc).
-- Doesn't stay in memory -- creates the iptables rules which are automatically updated on WAN up/down.
-- Has a companion package (luci-app-vpnbypass) so everything can be configured with Web UI.
+- Define local ports so traffic to them is routed outside of the VPN tunnel (by default it routes Plex Media Server traffic (port 32400) outside of the VPN tunnel).
+- Define IPs/subnets in local networks so their traffic is routed outside the VPN tunnel (by default it routes traffic from 192.168.1.81-192.168.1.87 outside the VPN tunnel).
+- Define remote IP ranges that are accessed outside the VPN tunnel (by default, LogmeIn Hamachi traffic (25.0.0.0/8) is routed outside the VPN tunnel).
+- Creates list of domain names which should be accessed outside the VPN tunnel (useful for Netflix, Hulu, etc).
+- Does not reside in RAM -- creates `iptables` rules which are automatically updated on WAN up/down events.
+- A companion package (`luci-app-vpnbypass`) is provided so all features may be configured from the Web UI.
 - Proudly made in Canada, using locally-sourced electrons.
 
 ## Screenshot (luci-app-vpnbypass)
@@ -18,9 +18,9 @@ A simple PROCD-based ```vpnbypass``` service for OpenWrt/LEDE Project. Useful if
 
 ## Requirements
 
-This service requires following packages to be installed on your router: ```ipset``` and ```iptables```. Additionally, if you want to use Domain Bypass feature, you need to install ```dnsmasq-full``` (```dnsmasq-full``` requires you uninstall ```dnsmasq``` first).
+This service requires the following packages to be installed on your router: ```ipset``` and ```iptables```. Additionally, if you want to use the Domain Bypass feature, you need to install ```dnsmasq-full``` (```dnsmasq-full``` requires you uninstall ```dnsmasq``` first).
 
-To fully satisfy the requirements for both IP/Port VPN Bypass and Domain Bypass features connect to your router via ssh and run the following commands:
+To fully satisfy the requirements for both IP/Port VPN Bypass and Domain Bypass features connect via ssh to your router and run the following commands:
 
 ```sh
 opkg update; opkg remove dnsmasq; opkg install ipset iptables dnsmasq-full
@@ -46,11 +46,11 @@ Navigate to System->Software page on your router and then perform the following 
 3. In the "Download and install package:" field type ```vpnbypass luci-app-vpnbypass```
 4. Click "OK" to install ```vpnbypass``` and ```luci-app-vpnbypass```
 
-If you get an ```Unknown package 'vpnbypass'``` error, your router is not set up with the access to repository containing these packages and you need to add custom repository to your router first.
+If you get an ```Unknown package 'vpnbypass'``` error, your router is not set up with the access to a repository containing these packages and you need to add the custom repository to your router first.
 
 #### From console/ssh
 --->
-Please make sure that the [requirements](#requirements) are satisfied and install ```vpnbypass``` and ```luci-app-vpnbypass``` from Web UI or connect to your router via ssh and run the following commands:
+Please ensure that the [requirements](#requirements) are satisfied and install ```vpnbypass``` and ```luci-app-vpnbypass``` from the Web UI or connect to your router via ssh and run the following commands:
 
 ```sh
 opkg update
@@ -61,7 +61,7 @@ If these packages are not found in the official feed/repo for your version of Op
 
 ## Default Settings
 
-Default configuration has service disabled (use Web UI to enable/start service or run ```uci set vpnbypass.config.enabled=1; uci commit vpnbypass;```) and routes Plex Media Server traffic (port 32400) outside of the VPN tunnel, routes LogmeIn Hamachi traffic (25.0.0.0/8) outside of the VPN tunnel and also routes internet traffic from local IPs 192.168.1.81-192.168.1.87 outside of the VPN tunnel. You can safely delete these example rules if they do not apply to you.
+The default configuration ships with the service disabled, use the Web UI to enable/start the service or run ```uci set vpnbypass.config.enabled=1; uci commit vpnbypass;```. It routes Plex Media Server traffic (port 32400) and LogmeIn Hamachi traffic (25.0.0.0/8) outside of the VPN tunnel. Internet traffic from local IPs `192.168.1.81-192.168.1.87` is also routed outside the VPN tunnel. You can safely delete these example rules if they do not apply to you.
 
 ## Documentation / Discussion
 
@@ -69,7 +69,7 @@ Please head to [OpenWrt Forum](https://forum.openwrt.org/t/vpn-bypass-split-tunn
 
 ### Bypass Domains Format/Syntax
 
-Domain lists should be in following format/syntax: ```/domain1.com/domain2.com/vpnbypass```. Please don't forget the leading ```/``` and trailing ```/vpnbypass```. There's no validation if you enter something incorrectly -- it just won't work. Please see [Notes/Known Issues](#notesknown-issues) if you want to edit this setting manually, without Web UI.
+Domain lists should be in the following format/syntax: ```/domain1.com/domain2.com/vpnbypass```. Please do not forget the leading ```/``` and trailing ```/vpnbypass```. There is no validation if you enter something incorrectly -- it simply will not work. Please see [Notes/Known Issues](#notesknown-issues) if you wish to edit this setting manually, without using the Web UI.
 
 ## What's New
 
@@ -79,11 +79,11 @@ Domain lists should be in following format/syntax: ```/domain1.com/domain2.com/v
 - Table ID, IPSET name and FW_MARK as well as FW_MASK can be defined in config file.
 - Uses iptables, not ip rules for handling local IPs/ranges.
 - More reliable creation/destruction of VPNBYPASS iptables chain.
-- Updated Web UI enables/start and stops service.
+- Updated Web UI enables, starts and stops the service.
 
 ## Notes/Known Issues
 
-1. Domains to be accessed outside of VPN tunnel are handled by dnsmasq and thus are not defined in ```/etc/config/vpnpass```, but rather in ```/etc/config/dhcp```. To add/delete/edit domains you can use VPN Bypass Web UI or you can edit ```/etc/config/dhcp``` manually or run following commands:
+1. Domains to be accessed outside of VPN tunnel are handled by dnsmasq and thus are not defined in ```/etc/config/vpnpass```, but rather in ```/etc/config/dhcp```. To add/delete/edit domains you can use VPN Bypass Web UI or you can edit ```/etc/config/dhcp``` manually or run the following commands:
 
 ```sh
 uci add_list dhcp.@dnsmasq[-1].ipset='/github.com/plex.tv/google.com/vpnbypass'
@@ -92,4 +92,4 @@ uci commit dhcp
 /etc/init.d/dnsmasq restart
 ```
 
-This feature requires ```dnsmasq-full``` to work. See [Requirements](#requirements) paragraph for more details.
+This feature requires ```dnsmasq-full``` to work. See the [Requirements](#requirements) section for more details.

--- a/net/vpnbypass/files/vpnbypass.init
+++ b/net/vpnbypass/files/vpnbypass.init
@@ -1,5 +1,7 @@
 #!/bin/sh /etc/rc.common
-PKG_VERSION=
+# Copyright 2017-2020 Stan Grishin (stangri@melmac.net)
+# shellcheck disable=SC2039,SC1091,SC2086
+PKG_VERSION='dev-test'
 
 export START=94
 export USE_PROCD=1
@@ -12,25 +14,28 @@ readonly __PASS__='\033[0;33m[-]\033[0m'
 readonly _ERROR_='\033[0;31mERROR\033[0m'
 
 export serviceEnabled verbosity=2 TID='200' IPSET='vpnbypass' FW_MARK='0x010000' FW_MASK='0xff0000' wan_if4 wan_gw
+readonly packageName='vpnbypass'
+readonly serviceName="$packageName $PKG_VERSION"
+readonly sharedMemoryOutput="/dev/shm/$packageName-output"
 
 output() {
 # Can take a single parameter (text) to be output at any verbosity
 # Or target verbosity level and text to be output at specifc verbosity
+	local msg memmsg logmsg
 	if [ $# -ne 1 ]; then
-		if [ ! $((verbosity & $1)) -gt 0 ]; then return 0; else shift; fi
+		if [ $((verbosity & $1)) -gt 0 ] || [ "$verbosity" = "$1" ]; then shift; else return 0; fi
 	fi
-	[ -t 1 ] && echo -e -n "$1"
-	local msg=$(echo -n "${1/$serviceName /service }" | sed 's|\\033\[[0-9]\?;\?[0-9]\?[0-9]\?m||g');
-	if [ "$(echo -e -n "$msg" | wc -l)" -gt 0 ]; then
-		logger -t "${packageName:-service} [$$]" "$(echo -e -n "${logmsg}${msg}")"
-		logmsg=''
+	[ -t 1 ] && printf "%b" "$1"
+	msg="${1//$serviceName /service }";
+	if [ "$(printf "%b" "$msg" | wc -l)" -gt 0 ]; then
+		[ -s "$sharedMemoryOutput" ] && memmsg="$(cat "$sharedMemoryOutput")"
+		logmsg="$(printf "%b" "${memmsg}${msg}" | sed 's/\x1b\[[0-9;]*m//g')"
+		logger -t "${packageName:-service} [$$]" "$(printf "%b" "$logmsg")"
+		rm -f "$sharedMemoryOutput"
 	else
-		logmsg="${logmsg}${msg}"
+		printf "%b" "$msg" >> "$sharedMemoryOutput"
 	fi
 }
-readonly packageName='vpnbypass'
-readonly serviceName="$packageName $PKG_VERSION"
-
 load_package_config() {
 	config_load "$packageName"
 	config_get_bool serviceEnabled 'config' 'enabled' 1
@@ -60,23 +65,22 @@ is_ovpn() { local dev; dev=$(uci -q get network."$1".ifname); if [ "${dev:0:3}" 
 is_wan() { if [ -n "$wan_if4" ] && [ "$1" = "$wan_if4" ]; then return 0; else return 1; fi; }
 is_supported_interface() { if is_wan "$1" || is_ovpn "$1"; then return 0; else return 1; fi; }
 
-# shellcheck disable=SC2086
 ipt() {
-  local d; 
-  d="${*//-A/-D}"; [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
-  d="${*//-I/-D}"; [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
-  d="${*//-N/-F}"; [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
-  d="${*//-N/-X}"; [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
+	local d; 
+	d="${*//-A/-D}"; [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
+	d="${*//-I/-D}"; [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
+	d="${*//-N/-F}"; [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
+	d="${*//-N/-X}"; [ "$d" != "$*" ] && iptables $d >/dev/null 2>&1
 	d="$*"; iptables $d >/dev/null 2>&1 || output "\\n$__ERROR__: iptables $d\\n"
 }
 
 start_service() {
-  local ll lports rports routes ranges
-  is_enabled || return 1
-  config_get lports   'config' 'localport'
-  config_get rports   'config' 'remoteport'
-  config_get routes   'config' 'remotesubnet'
-  config_get ranges   'config' 'localsubnet'
+	local ll lports rports routes ranges
+	is_enabled || return 1
+	config_get lports   'config' 'localport'
+	config_get rports   'config' 'remoteport'
+	config_get routes   'config' 'remotesubnet'
+	config_get ranges   'config' 'localsubnet'
 
 	procd_open_instance "main"
 	procd_set_param command /bin/true
@@ -85,8 +89,8 @@ start_service() {
 	procd_close_instance
 
 	ipt -t mangle -D PREROUTING -m mark --mark 0x00/${FW_MASK} -g VPNBYPASS >/dev/null 2>&1
-	ipt -t mangle -N VPNBYPASS; ipt -t mangle -A PREROUTING -m mark --mark 0x00/${FW_MASK} -g VPNBYPASS;
-	ipt -t mangle -A VPNBYPASS -m set --match-set $IPSET dst -j MARK --set-mark ${FW_MARK}/${FW_MASK}
+	{ ipt -t mangle -N VPNBYPASS; ipt -t mangle -A PREROUTING -m mark --mark 0x00/${FW_MASK} -g VPNBYPASS; } >/dev/null 2>&1
+	ipt -t mangle -A VPNBYPASS -m set --match-set $IPSET dst -j MARK --set-mark ${FW_MARK}/${FW_MASK} >/dev/null 2>&1
 	ip rule del fwmark "$FW_MARK" table "$TID" >/dev/null 2>&1; 
 	ipset -q flush "$IPSET"; ipset -q destroy "$IPSET";
 	ip route flush table "$TID"; ip route flush cache;
@@ -102,12 +106,12 @@ start_service() {
 }
 
 stop_service() {
-  load_package_config
+	load_package_config
 	ip rule del fwmark "$FW_MARK" table "$TID" >/dev/null 2>&1; 
 	ipset -q flush "$IPSET"; ipset -q destroy "$IPSET";
 	ip route flush table "$TID"; ip route flush cache;
-	ipt -t mangle -D PREROUTING -m mark --mark 0x00/${FW_MASK} -g VPNBYPASS
-	ipt -t mangle -F VPNBYPASS; ipt -t mangle -X VPNBYPASS;
+	ipt -t mangle -D PREROUTING -m mark --mark 0x00/${FW_MASK} -g VPNBYPASS >/dev/null 2>&1
+	{ ipt -t mangle -F VPNBYPASS; ipt -t mangle -X VPNBYPASS; } >/dev/null 2>&1
 	output "$serviceName stopped\\n"
 }
 
@@ -115,8 +119,7 @@ service_triggers_load_interface() { is_supported_interface "$1" && ifaces="${ifa
 service_triggers() {
 		local ifaces n
 		config_load network; config_foreach service_triggers_load_interface 'interface';
-		procd_add_reload_trigger 'firewall'
-		procd_add_reload_trigger 'openvpn'
+		procd_add_reload_trigger 'firewall' 'openvpn' 'vpnbypass'
 		procd_open_trigger
 			for n in $ifaces; do procd_add_reload_interface_trigger "$n"; procd_add_interface_trigger "interface.*" "$n" /etc/init.d/vpnbypass reload; done;
 			output "$serviceName monitoring interfaces: $ifaces $_OK_\\n"


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, WRT3200ACM, 19.07.2
Run tested: sunxi/H3, zeroPi, 19.07.1, start/stop, verify iptables 

Description:
This contains following 3 fixes:
1. Remove non-ASCII characters from system log
2. Update README
3. Suppress some useless iptables output from CLI on service start/stop

Signed-off-by: Stan Grishin <stangri@melmac.net>