### PR TITLE
sslh: Add http probe support

### DIFF
--- a/net/sslh/Makefile
+++ b/net/sslh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sslh
 PKG_VERSION:=v1.20
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://rutschle.net/tech/sslh/

--- a/net/sslh/files/sslh.init
+++ b/net/sslh/files/sslh.init
@@ -44,6 +44,9 @@ start_instance() {
 	 # I) sslh config file (cmd line args override file settings)
 	config_get val "${section}" configfile
 	[ -n "${val}" ] && append args "-F${val}"
+	# J) http parameter
+    config_get val "${section}" http
+    [ -n "${val}" ] && append args "--http ${val}"
 
 	# Defaults were removed for --user and --pidfile options
 	# in sslh 1.11; Define them here instead.


### PR DESCRIPTION
Signed-off-by: Warren Ng <looklookson@gmail.com>

Maintainer: @jmccrohan
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
sslh support http probe since v1.11 (https://github.com/yrutschle/sslh/blob/master/ChangeLog). However, the sslh script still haven't updated to include the http parameter. This pull request is for adding back the http parameter
