### PR TITLE
prometheus-node-exporter-lua: Change node_time_seconds type to "gauge"

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
 PKG_VERSION:=2020.02.03
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/time.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/time.lua
@@ -1,6 +1,6 @@
 local function scrape()
   -- current time
-  metric("node_time_seconds", "counter", nil, os.time())
+  metric("node_time_seconds", "gauge", nil, os.time())
 end
 
 return { scrape = scrape }


### PR DESCRIPTION
Maintainer: @champtar
Compile tested: no
Run tested: ar71xx, EnGenius ESR900, OpenWrt 18.06.8 r7989-82fbd85747

Description:

The official node_exporter reports node_time_seconds as a gauge, but prometheus-node-exporter-lua reports it as a counter. To be consistent with the official implementation, and because "gauge" is more correct than "counter" for this metric (system time can decrease, but the [Prometheus documentation](https://prometheus.io/docs/concepts/metric_types/#counter) states, "A counter is a cumulative metric that represents a single monotonically increasing counter whose value can only increase or be reset to zero on restart."), change the type for node_time_seconds to "gauge".

Apologies for not compile testing this, but I don't have a system set up for building packages yet, and since this is only a change from one arbitrary string to another, I run-tested by simply making the same change to the corresponding file on my ESR900's filesystem and restarting the service.