### PR TITLE
fish: update to 3.1.2

### DIFF
--- a/utils/fish/Makefile
+++ b/utils/fish/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fish
-PKG_VERSION:=3.1.0
+PKG_VERSION:=3.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/fish-shell/fish-shell/releases/download/$(PKG_VERSION)
-PKG_HASH:=e5db1e6839685c56f172e1000c138e290add4aa521f187df4cd79d4eab294368
+PKG_HASH:=d5b927203b5ca95da16f514969e2a91a537b2f75bec9b21a584c4cd1c7aa74ed
 
 PKG_MAINTAINER:=Curtis Jiang <jqqqqqqqqqq@gmail.com>, Hao Dong <halbertdong@gmail.com>
 PKG_LICENSE:=GPL-2.0-only
@@ -42,6 +42,8 @@ endef
 define Package/fish/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fish $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fish_indent $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fish_key_reader $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/usr/share/fish
 	$(CP) $(PKG_INSTALL_DIR)/usr/share/fish/* $(1)/usr/share/fish/
 	rm -rf $(1)/usr/share/fish/groff


### PR DESCRIPTION
Signed-off-by: Curtis Jiang jqqqqqqqqqq@gmail.com

Maintainer: me / @jqqqqqqqqqq , @haodong (find it by checking history of the package Makefile)
Compile tested: x86-64
Run tested: x86-64, 19.07.2

Description:

Update fish to 3.1.2
Add 2 missing binaries
