### PR TITLE
wifidog-ng: remove incorrect PKG_BUILD_DIR override

### DIFF
--- a/net/wifidog-ng/Makefile
+++ b/net/wifidog-ng/Makefile
@@ -11,13 +11,12 @@ PKG_NAME:=wifidog-ng
 PKG_VERSION:=2.0.2
 PKG_RELEASE:=1
 
-PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)
-
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_MAINTAINER:=Jianhui Zhao <zhaojh329@gmail.com>
 
+include $(INCLUDE_DIR)/kernel.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/wifidog-ng/default
@@ -76,8 +75,6 @@ Package/wifidog-ng-nossl/install = $(Package/wifidog-ng/default/install)
 Package/wifidog-ng-openssl/install = $(Package/wifidog-ng/default/install)
 Package/wifidog-ng-wolfssl/install = $(Package/wifidog-ng/default/install)
 Package/wifidog-ng-mbedtls/install = $(Package/wifidog-ng/default/install)
-
-include $(INCLUDE_DIR)/kernel.mk
 
 define KernelPackage/wifidog-ng
   SUBMENU:=Other modules


### PR DESCRIPTION
Maintainer: @zhaojh329 
Compile tested: x86-64
Run tested: -

Description:

As wifidog-ng builds a kernel module, it must use a PKG_BUILD_DIR in
KERNEL_BUILD_DIR instead of BUILD_DIR, otherwise old build artifacts may
be incorrectly reused when switching between different targets of same
architecture without a full clean.

Instead of fixing up the override, just remove it and instead move the
kernel.mk include above package.mk, so PKG_BUILD_DIR is set up correctly
by default.

Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>

I will also apply this to openwrt-19.07 after review.