### PR TITLE
docker-ce: fix docker info warning

### DIFF
--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-ce
 PKG_VERSION:=19.03.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=components/cli/LICENSE components/engine/LICENSE
 
@@ -113,6 +113,11 @@ define Package/docker-ce/install
 
 	$(INSTALL_DIR) $(1)/etc/docker
 	$(INSTALL_CONF) ./files/daemon.json $(1)/etc/docker/
+
+	# Must be after systcl 11-br-netfilter.conf from kmod-br-netfilter
+	$(INSTALL_DIR) $(1)/etc/sysctl.d
+	$(INSTALL_DATA) ./files/etc/sysctl.d/sysctl-br-netfilter-ip.conf \
+		$(1)/etc/sysctl.d/12-br-netfilter-ip.conf
 endef
 
 $(eval $(call BuildPackage,docker-ce))

--- a/utils/docker-ce/files/etc/sysctl.d/sysctl-br-netfilter-ip.conf
+++ b/utils/docker-ce/files/etc/sysctl.d/sysctl-br-netfilter-ip.conf
@@ -1,0 +1,7 @@
+# Do not edit, changes to this file will be lost on upgrades
+# /etc/sysctl.conf can be used to customize sysctl settings
+
+# enable bridge firewalling for docker
+net.bridge.bridge-nf-call-ip6tables=1
+net.bridge.bridge-nf-call-iptables=1
+


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503

Compile tested: not needed only script change
Run tested:
x86_64, APU3, openwrt master

Description:

If we execute `docker info` we get the following warning:

```
WARNING: bridge-nf-call-iptables is disabled
WARNING: bridge-nf-call-ip6tables is disabled
```

To fix this enable this in sysctl if docker is installed.
