### PR TITLE
redis: update to version 6.0.1

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=5.0.9
+PKG_VERSION:=6.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=53d0ae164cd33536c3d4b720ae9a128ea6166ebf04ff1add3b85f1242090cb85
+PKG_HASH:=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause
@@ -23,6 +23,8 @@ MAKE_FLAGS+= \
 	PREFIX="$(PKG_INSTALL_DIR)/usr" \
 	ARCH=""
 
+TARGET_LDFLAGS += -latomic
+
 define Package/redis/Default
   SUBMENU:=Database
   SECTION:=libs
@@ -33,12 +35,13 @@ endef
 define Package/redis-server
 $(call  Package/redis/Default)
   TITLE:=Redis server
-  DEPENDS:=+libpthread
+  DEPENDS:=+libpthread +libatomic
 endef
 
 define Package/redis-cli
 $(call  Package/redis/Default)
   TITLE:=Redis cli
+  DEPENDS+=+libatomic
 endef
 
 define Package/redis-utils


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates Redis to version 6.0.1 .  Version 6.0.x contains a lot of enhancements see http://antirez.com/news/132

Upgrade urgency is HIGH
[Full change log](https://raw.githubusercontent.com/antirez/redis/6.0/00-RELEASENOTES)

Update


