### PR TITLE
neon: add back sed scripts for neon-config

### DIFF
--- a/libs/neon/Makefile
+++ b/libs/neon/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=neon
 PKG_VERSION:=0.31.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://notroj.github.io/neon
@@ -65,6 +65,8 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libneon.{a,so*} $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/neon.pc $(1)/usr/lib/pkgconfig/
+	$(SED) 's,-I$$$${includedir}/,-I$(STAGING_DIR)/usr/include/,g' $(1)/usr/bin/neon-config
+	$(SED) 's,-L$$$${libdir},,g' $(1)/usr/bin/neon-config
 endef
 
 define Package/libneon/install


### PR DESCRIPTION
Commit 3a67097 removed the sed scripts that ran on neon-config. Now
there is build failure for Asterisk because a host include directory is
added to the build:

mips_24kc_musl/usr/lib/libintl-stub/include    -I/store/buildbot/slave/shared-workdir/build/sdk/staging_dir/target-mips_24kc_musl/usr/include/libxml2  -Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations       -fPIC -DAST_MODULE=\"res_calendar_exchange\" -DAST_MODULE_SELF_SYM=__internal_res_calendar_exchange_self  -I/usr/include/neon -I/store/buildbot/slave/shared-workdir/build/sdk/staging_dir/target-mips_24kc_musl/usr/include -pthread -I/store/buildbot/slave/shared-workdir/build/sdk/staging_dir/target-mips_24kc_musl/usr/include
res_calendar_exchange.c:34:10: fatal error: ne_session.h: No such file or directory
 #include <ne_session.h>
          ^~~~~~~~~~~~~~
compilation terminated.

This commit adds back the sed scripts.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @fededim
Compile tested: ath79 master
Run tested: N/A

Description:
Fix neon-config.