### PR TITLE
freeradius3: Fix to init script.

### DIFF
--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeradius3
 PKG_VERSION:=release_3_0_21
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/FreeRADIUS/freeradius-server/archive

--- a/net/freeradius3/files/radiusd.init
+++ b/net/freeradius3/files/radiusd.init
@@ -17,6 +17,7 @@ start_service()
 	mkdir -p /var/log
 	mkdir -p /var/run
 	mkdir -p /var/db/radacct
+	mkdir -p /tmp/radiusd
 
 	procd_open_instance
 	procd_set_param command $PROG -s


### PR DESCRIPTION
To use eap tls, 'tmpdir' must be created before server starts.
This 'tmpdir' is used to store and verify client certificate,
and therefore radiusd do 'chmod go-rwx'.

If 'tmpdir' does NOT exists, server failed to start and default
'tmpdir' is '/tmp/radiusd'. So init script MUST create default
'tmpdir' like other directories.

Signed-off-by: Eiji MATSUMOTO <toudaiman@gmail.com>