### PR TITLE
Authentication protocol setup in ModemManager

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.12.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager

--- a/net/modemmanager/README.md
+++ b/net/modemmanager/README.md
@@ -4,19 +4,33 @@
 
 Cellular modem control and connectivity
 
-Optional libraries libmbim and libqmi are available.  Optional mbim-utils and qmi-utils are available.
-Your modem may require additional kernel modules.
+Optional libraries libmbim and libqmi are available.
+Your modem may require additional kernel modules and/or the usb-modeswitch
+package.
 
 ## Usage
 
-# Once installed, you can configure the 2G/3G/4G modem connections directly in
-   /etc/config/network as in the following example:
+Once installed, you can configure the 2G/3G/4G modem connections directly in
+/etc/config/network as in the following example:
 
     config interface 'broadband'
-        option device   '/sys/devices/platform/soc/20980000.usb/usb1/1-1/1-1.2/1-1.2.1'
-        option proto    'modemmanager'
-        option apn      'ac.vodafone.es'
-        option username 'vodafone'
-        option password 'vodafone'
-        option pincode  '7423'
-        option lowpower '1'
+        option device      '/sys/devices/platform/soc/20980000.usb/usb1/1-1/1-1.2/1-1.2.1'
+        option proto       'modemmanager'
+        option apn         'ac.vodafone.es'
+        option allowedauth 'pap chap'
+        option username    'vodafone'
+        option password    'vodafone'
+        option pincode     '7423'
+        option iptype      'ipv4'
+        option lowpower    '1'
+
+Only 'device' and 'proto' are mandatory options, the remaining ones are all
+optional.
+
+The 'allowedauth' option allows limiting the list of authentication protocols.
+It is given as a space-separated list of values, including any of the
+following: 'pap', 'chap', 'mschap', 'mschapv2' or 'eap'. It will default to
+allowing all protocols.
+
+The 'iptype' option supports any of these values: 'ipv4', 'ipv6' or 'ipv4v6'.
+It will default to 'ipv4' if not given.

--- a/net/modemmanager/files/modemmanager.proto
+++ b/net/modemmanager/files/modemmanager.proto
@@ -116,6 +116,35 @@ modemmanager_connected_method_ppp_ipv4() {
 	local ttyname="$2"
 	local username="$3"
 	local password="$4"
+	local allowedauth="$5"
+
+	# all auth types are allowed unless a user given list is given
+	local authopts
+	local pap=1
+	local chap=1
+	local mschap=1
+	local mschapv2=1
+	local eap=1
+
+	[ -n "$allowedauth" ] && {
+		pap=0 chap=0 mschap=0 mschapv2=0 eap=0
+		for auth in $allowedauth; do
+			case $auth in
+				"pap") pap=1 ;;
+				"chap") chap=1 ;;
+				"mschap") mschap=1 ;;
+				"mschapv2") mschapv2=1 ;;
+				"eap") eap=1 ;;
+				*) ;;
+			esac
+		done
+	}
+
+	[ $pap -eq 1 ] || append authopts "refuse-pap"
+	[ $chap -eq 1 ] || append authopts "refuse-chap"
+	[ $mschap -eq 1 ] || append authopts "refuse-mschap"
+	[ $mschapv2 -eq 1 ] || append authopts "refuse-mschap-v2"
+	[ $eap -eq 1 ] || append authopts "refuse-eap"
 
 	proto_run_command "${interface}" /usr/sbin/pppd \
 		"${ttyname}" \
@@ -126,6 +155,7 @@ modemmanager_connected_method_ppp_ipv4() {
 		nopcomp \
 		novj \
 		noauth \
+		$authopts \
 		${username:+ user $username} \
 		${password:+ password $password} \
 		lcp-echo-failure 5 \
@@ -308,6 +338,7 @@ proto_modemmanager_init_config() {
 	no_device=1
 	proto_config_add_string	 device
 	proto_config_add_string	 apn
+	proto_config_add_string	 'allowedauth:list(string)'
 	proto_config_add_string	 username
 	proto_config_add_string	 password
 	proto_config_add_string	 pincode
@@ -320,14 +351,14 @@ proto_modemmanager_setup() {
 	local interface="$1"
 
 	local modempath modemstatus bearercount bearerpath connectargs bearerstatus beareriface
-	local bearermethod_ipv4 bearermethod_ipv6
+	local bearermethod_ipv4 bearermethod_ipv6 auth cliauth
 	local operatorname operatorid registration accesstech signalquality
 
-	local device apn username password pincode iptype metric
+	local device apn allowedauth username password pincode iptype metric
 
 	local address prefix gateway mtu dns1 dns2
 
-	json_get_vars device apn username password pincode iptype metric
+	json_get_vars device apn allowedauth username password pincode iptype metric
 
 	# validate sysfs path given in config
 	[ -n "${device}" ] || {
@@ -356,9 +387,14 @@ proto_modemmanager_setup() {
 	# always cleanup before attempting a new connection, just in case
 	modemmanager_cleanup_connection "${modemstatus}"
 
+	# if allowedauth list given, build option string
+	for auth in $allowedauth; do
+		cliauth="${cliauth}${cliauth:+|}$auth"
+	done
+
 	# setup connect args; APN mandatory (even if it may be empty)
 	echo "starting connection with apn '${apn}'..."
-	connectargs="apn=${apn}${iptype:+,ip-type=${iptype}}${username:+,user=${username}}${password:+,password=${password}}${pincode:+,pin=${pincode}}"
+	connectargs="apn=${apn}${iptype:+,ip-type=${iptype}}${cliauth:+,allowed-auth=${cliauth}}${username:+,user=${username}}${password:+,password=${password}}${pincode:+,pin=${pincode}}"
 	mmcli --modem="${device}" --timeout 120 --simple-connect="${connectargs}" || {
 		proto_notify_error "${interface}" CONNECT_FAILED
 		proto_block_restart "${interface}"
@@ -412,7 +448,7 @@ proto_modemmanager_setup() {
 			modemmanager_connected_method_static_ipv4 "${interface}" "${beareriface}" "${address}" "${prefix}" "${gateway}" "${mtu}" "${dns1}" "${dns2}" "${metric}"
 			;;
 		"ppp")
-			modemmanager_connected_method_ppp_ipv4 "${interface}" "${beareriface}" "${username}" "${password}"
+			modemmanager_connected_method_ppp_ipv4 "${interface}" "${beareriface}" "${username}" "${password}" "${allowedauth}"
 			;;
 		*)
 			proto_notify_error "${interface}" UNKNOWN_METHOD


### PR DESCRIPTION
Maintainer: @nickberry17 
Description:
Improve the ModemManager protocol handler to allow specifying which are the authentication protocols to be used. This is required in some operators that only support specific protocols (e.g. "chap" or "pap"). The new option allows giving a list of protocols as a space-separated list of values.
