### PR TITLE
fping: add new config option to install SUID root

### DIFF
--- a/net/fping/Makefile
+++ b/net/fping/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fping
 PKG_VERSION:=4.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://fping.org/dist/
@@ -46,7 +46,7 @@ CONFIGURE_ARGS+= \
 
 define Package/fping/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/fping $(1)/usr/bin/
+	$(INSTALL_SUID) $(PKG_INSTALL_DIR)/usr/sbin/fping $(1)/usr/bin/
 endef
 
 $(eval $(call BuildPackage,fping))


### PR DESCRIPTION
fping requires either root or CAP_NET_PING to work, otherwise it is
useless.  Add a config option to install it setuid root, thus unbreaking
it for non-root usage.

fping knows to drop root priviledges after it parses the command line
and creates the ping socket.  You actually get a lot less code running
as root when you make it setuid root and run it from an unprivileged
user.

Note: the new config option is disabled by default to preserve the
status-quo, in order to ease the merging of this patch.

Signed-off-by: Henrique de Moraes Holschuh <henrique@nic.br>

Maintainer: @nikil 
Compile tested: ar71xx openwrt-18.06, openwrt-19.07, master
Run tested: TP-Link TL-WR842v2, TP-Link Archer C7v4

Description:
Adds config option (default: disabled) that installs fping setuid root.