### PR TITLE
syslog-ng: restore service "reload" to actually working

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.26.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later

--- a/admin/syslog-ng/files/syslog-ng.init
+++ b/admin/syslog-ng/files/syslog-ng.init
@@ -11,3 +11,7 @@ start_service() {
 	procd_set_param command /usr/sbin/syslog-ng --foreground
 	procd_close_instance
 }
+
+reload_service() {
+	/usr/sbin/syslog-ng-ctl reload
+}


### PR DESCRIPTION
Maintainer: @BKPepe 
Compile tested: x86_64, generic, master HEAD
Run tested: same

Rebuilt and installed `syslog-ng` ipk.  The ran `/etc/init.d/syslog-ng reload`, and grepped `syslog-ng` out of `/var/log/messages`:

```
May  5 15:24:44 OpenWrt syslog-ng[15163]: syslog-ng shutting down; version='3.26.1'
May  5 15:24:45 OpenWrt syslog-ng[15332]: syslog-ng starting up; version='3.26.1'
May  5 15:26:37 OpenWrt syslog-ng[15332]: Configuration reload request received, reloading configuration;
May  5 15:26:37 OpenWrt syslog-ng[15332]: Configuration reload finished;
```

Note that the `postinst` script is broken, but that's a different issue:

```
root@OpenWrt:~# opkg install --force-reinstall /tmp/syslog-ng_3.26.1-2_x86_64.ip
k 
Removing package syslog-ng from root...
Installing syslog-ng (3.26.1-2) to root...
Configuring syslog-ng.
Command failed: Not found
root@OpenWrt:~# 
```

Description:
