### PR TITLE
wsdd2: fix infinite loop when BI_PARM is never set

### DIFF
--- a/net/wsdd2/Makefile
+++ b/net/wsdd2/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wsdd2
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/Andy2244/wsdd2.git

--- a/net/wsdd2/files/wsdd2.init
+++ b/net/wsdd2/files/wsdd2.init
@@ -68,7 +68,7 @@ start_service() {
 	[ -n "$ifname" ] && procd_append_param command -i "$ifname"
 	procd_append_param command -N "$NB_PARM"
 	procd_append_param command -G "$WG_PARM"
-	[ "x${BI_PARM}" != "x" ] && procd_append_param command -b "$BI_PARM"
+	[ "x${BI_PARM}" = "x" ] || procd_append_param command -b "$BI_PARM"
 	procd_set_param respawn
 	procd_set_param file "$SMB_CONF"
 	procd_close_instance

--- a/net/wsdd2/files/wsdd2.init
+++ b/net/wsdd2/files/wsdd2.init
@@ -68,7 +68,7 @@ start_service() {
 	[ -n "$ifname" ] && procd_append_param command -i "$ifname"
 	procd_append_param command -N "$NB_PARM"
 	procd_append_param command -G "$WG_PARM"
-	procd_append_param command -b "$BI_PARM"
+	[ "x${BI_PARM}" != "x" ] && procd_append_param command -b "$BI_PARM"
 	procd_set_param respawn
 	procd_set_param file "$SMB_CONF"
 	procd_close_instance


### PR DESCRIPTION
Maintainer:  @Andy2244 
Compile tested: x86_64
Run tested: x86_64

Description:
if BI_PARM is never set, it's `""` and causes infinite loop (before my PR sent upstream) or error out (after my PR sent upstream). Append `-b` option only if it's valid.

PS: should bump the source code revision and release code, this PR doesn't update anything, thus not bump the release code.