### PR TITLE
openssh-server: deprecate the ecdsa HostKey

### DIFF
--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
 PKG_VERSION:=8.2p1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
@@ -227,7 +227,7 @@ define Package/openssh-server/install
 	$(INSTALL_DIR) $(1)/etc/ssh
 	chmod 0700 $(1)/etc/ssh
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/etc/ssh/sshd_config $(1)/etc/ssh/
-	sed -r -i 's,^#(HostKey /etc/ssh/ssh_host_(rsa|ecdsa|ed25519)_key)$$$$,\1,' $(1)/etc/ssh/sshd_config
+	sed -r -i 's,^#(HostKey /etc/ssh/ssh_host_(rsa|ed25519)_key)$$$$,\1,' $(1)/etc/ssh/sshd_config
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/sshd.init $(1)/etc/init.d/sshd
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: x86_64, generic, master HEAD
Run tested: same

Generated `openssh-server` package and installed it (no pam).  Had to:

```
root@OpenWrt:~# mv -f /etc/ssh/sshd_config-opkg /etc/ssh/sshd_config
root@OpenWrt:~# /etc/init.d/sshd restart
```

Logged into server.

Confirmed in logs that there's no error message.

```
root@OpenWrt:~# tail /var/log/messages | grep sshd
root@OpenWrt:~# 
```
