### PR TITLE
sqm-scripts: Switch sch_cake dependency to new virtual package

### DIFF
--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sqm-scripts
 PKG_SOURCE_VERSION:=ab763cba8b1516b3afa99760e0ca884f8b8d93b8
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/tohojo/sqm-scripts
@@ -26,7 +26,7 @@ define Package/sqm-scripts
   CATEGORY:=Base system
   DEPENDS:=+tc +kmod-sched-core +kmod-ifb +iptables \
 	+iptables-mod-ipopt +iptables-mod-conntrack-extra \
-	+!LINUX_4_14:kmod-sched-cake +LINUX_4_14:kmod-sched-cake-oot
+	+kmod-sched-cake-virtual
   TITLE:=SQM Scripts (QoS)
   PKGARCH:=all
 endef


### PR DESCRIPTION
As reported in https://github.com/openwrt/packages/issues/12072, the
imagebuilder fails due to a dependency resolution error when the userspace
packages are built using a target that has a different kernel version than
that which is being run. To resolve this, move the sqm-scripts dependency
to a new virtual package, which hopefully should be consistent with the
actual kernel module being built.



This PR depends on the openwrt core patch:
https://patchwork.ozlabs.org/project/openwrt/patch/mailman.10417.1588795819.2542.openwrt-devel@lists.openwrt.org/