### PR TITLE
pdns-recursor: fix compilation with boost 1.73

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
 PKG_VERSION:=4.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/

--- a/net/pdns-recursor/patches/300-boost-173.patch
+++ b/net/pdns-recursor/patches/300-boost-173.patch
@@ -1,0 +1,21 @@
+--- a/webserver.cc
++++ b/webserver.cc
+@@ -36,6 +36,8 @@
+ #include "uuid-utils.hh"
+ #include <yahttp/router.hpp>
+ 
++using namespace boost::placeholders;
++
+ json11::Json HttpRequest::json()
+ {
+   string err;
+--- a/ws-recursor.cc
++++ b/ws-recursor.cc
+@@ -45,6 +45,7 @@
+ 
+ extern thread_local FDMultiplexer* t_fdm;
+ 
++using namespace boost::placeholders;
+ using json11::Json;
+ 
+ void productServerStatisticsFetch(map<string,string>& out)


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @James-TR 
Compile tested: ath79