### PR TITLE
collectd: sqm_collectd improve interface name filter

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.11.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \

--- a/utils/collectd/files/exec-scripts/sqm_collectd.sh
+++ b/utils/collectd/files/exec-scripts/sqm_collectd.sh
@@ -9,7 +9,7 @@ handle_cake() {
 	local ifc ifr tin i
 
 	ifc="$1"
-	ifr="${ifc//./_}"
+	ifr="${ifc//[!0-9A-Za-z]/_}"
 
 	# Overall
 	json_get_vars bytes packets drops backlog qlen


### PR DESCRIPTION
Increase the range of characters that get substituted by '_' so the
shell doesn't complain about illegal variable names.

Primarily done to catch '.' and '-' but who knows what funnies will
appear in i/f names.

It's a shame that busybox ash doesn't understand :punct: or indeed
:alnum:

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
