### PR TITLE
Fixed broken script due to CloudFlare's API change

### DIFF
--- a/net/ddns-scripts/files/update_cloudflare_com_v4.sh
+++ b/net/ddns-scripts/files/update_cloudflare_com_v4.sh
@@ -85,7 +85,7 @@ cloudflare_transfer() {
 	done
 
 	# check for error
-	grep -q '"success":true' $DATFILE || {
+	grep -q -E '"success":\s?true' $DATFILE || {
 		write_log 4 "CloudFlare reported an error:"
 		write_log 7 "$(cat $DATFILE)"		# report error
 		return 1	# HTTP-Fehler
@@ -143,7 +143,7 @@ __ZONEID=$(grep -o '"id":"[^"]*' $DATFILE | grep -o '[^"]*$' | head -1)
 __RUNPROG="$__PRGBASE --request GET '$__URLBASE/zones/$__ZONEID/dns_records?name=$__HOST&type=$__TYPE'"
 cloudflare_transfer || return 1
 # extract record id
-__RECID=$(grep -o '"id":"[^"]*' $DATFILE | grep -o '[^"]*$' | head -1)
+__RECID=$(grep -o '"id": "[^"]*' $DATFILE | grep -o '[^"]*$' | head -1)
 [ -z "$__RECID" ] && {
 	write_log 4 "Could not detect 'record id' for host.domain.tld: '$__HOST'"
 	return 127


### PR DESCRIPTION
Maintainer: @chris5560 
Compile tested: N/A 
Run tested: ARMv7 Processor rev 2 (v7l), Linksys WRT1900AC, OpenWrt 19.07.2 r10947-65030d81f3, Tested for my DDNS update

Description:
The response from endpoint `https://api.cloudflare.com/client/v4/zones/******/dns_records?name=example.com&type=A` is now a prettified JSON, instead of minimized JSON.

This breaks the script when detecting success and parsing record ID.

Sample API response: 
```
{
  "result": [
    {
      "id": "******",
      "zone_id": "******",
      "zone_name": "example.com",
      "name": "example.com",
      "type": "A",
      "content": "123.123.123.123",
      "proxiable": true,
      "proxied": false,
      "ttl": 120,
      "locked": false,
      "meta": {
        "auto_added": false,
        "managed_by_apps": false,
        "managed_by_argo_tunnel": false,
        "source": "primary"
      },
      "created_on": "2020-05-07T16:55:32.075101Z",
      "modified_on": "2020-05-07T16:55:32.075101Z"
    }
  ],
  "success": true,
  "errors": [],
  "messages": [],
  "result_info": {
    "page": 1,
    "per_page": 20,
    "count": 1,
    "total_count": 1,
    "total_pages": 1
  }
}
```