### PR TITLE
openzwave: avoid /usr/include in libopenzwave.pc

### DIFF
--- a/utils/openzwave/Makefile
+++ b/utils/openzwave/Makefile
@@ -90,6 +90,7 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libopenzwave.* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libopenzwave.pc $(1)/usr/lib/pkgconfig/
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libopenzwave.pc
 endef
 
 $(eval $(call BuildPackage,libopenzwave))


### PR DESCRIPTION
Maintainer: in the process of changing to @dwmw2 
Compile tested: mveby, wrt3200acm, openwrt master
Run tested: Not needed

Description:
This adds a line in Build/InstallDev to change a hardcoded
'/usr/include' definition in the staging_dir libopenzwave.pc file to use
${prefix}/include instead.  Otherwise dependent packages may fail to
find them.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
At least libupm fails to build:
```
[ 35%] Building CXX object src/ozw/CMakeFiles/ozw.dir/ozw.cxx.o
/home/openwrt/build_dir/target-arm_cortex-a9+neon_musl_eabi/upm-2.0.0/src/ozw/ozw.cxx:31:10: fatal error: platform/Log.h: No such file or directory
 #include "platform/Log.h"
          ^~~~~~~~~~~~~~~~
compilation terminated.
make[6]: *** [src/ozw/CMakeFiles/ozw.dir/build.make:80: src/ozw/CMakeFiles/ozw.dir/ozw.cxx.o] Error 1
```
This does not affect the generated package, so no revision bump, and not run-tested.