### PR TITLE
python-certifi: bump to 2020.4.5.1, update email

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -6,15 +6,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
-PKG_VERSION:=2019.11.28
-PKG_RELEASE:=2
+PKG_VERSION:=2020.4.5.1
+PKG_RELEASE:=1
 
-PKG_MAINTAINER:=Eneas U de Queiroz <cote2004-github@yahoo.com>
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PYPI_NAME:=certifi
-PKG_HASH:=25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f
+PKG_HASH:=51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, wrt3200acm, openwrt master
Run tested: to be done

Description:
Besides the version bump, maintainer e-mail address was updated.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
I plan to run-test this as soon as I have the time.  Nonetheless, it is a straightforward version bump, so anyone feel free to merge this.