### PR TITLE
oniguruma: bump to 6.9.5_rev1, switch to cmake

### DIFF
--- a/libs/oniguruma/Makefile
+++ b/libs/oniguruma/Makefile
@@ -5,12 +5,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oniguruma
-PKG_VERSION:=6.9.4
+PKG_VERSION:=6.9.5_rev1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=onig-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=onig-v$(subst _,-,$(PKG_VERSION)).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/kkos/oniguruma/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=aea68e5843b627f5fe6d3d6b598845b7f3622910e0568408e7cc2fa6b3690b87
+PKG_HASH:=e0c2212102fa4146c43b6c4f2f7727a84fd055cc2109c293d64298cef0c372b5
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
 PKG_LICENSE:=BSD-2-Clause
@@ -21,6 +21,10 @@ PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+CMAKE_INSTALL:=1
+CMAKE_OPTIONS += -DENABLE_POSIX_API:BOOL=ON
 
 define Package/oniguruma
     SECTION:=libs
@@ -41,13 +45,6 @@ endef
 define Package/oniguruma/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/libonig.so.$(ABI_VERSION) $(1)/usr/lib/
-endef
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/{include,lib}
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
-	$(SED) 's,/usr,$(STAGING_DIR)/usr,g' $(1)/usr/lib/pkgconfig/oniguruma.pc
 endef
 
 $(eval $(call BuildPackage,oniguruma))

--- a/libs/oniguruma/patches/0001-Add-SOVERSION-info-to-library-when-using-cmake.patch
+++ b/libs/oniguruma/patches/0001-Add-SOVERSION-info-to-library-when-using-cmake.patch
@@ -1,0 +1,35 @@
+From afb2a1587a828bf7cd7ddd87b2e2609a9bb7fab0 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cotequeiroz@gmail.com>
+Date: Wed, 6 May 2020 08:59:54 -0300
+Subject: [PATCH] Add SOVERSION info to library when using cmake
+
+Currently the SOVERSION is different when building with cmake than the
+value used by autotools.
+This adds the version information from autotools to cmake.
+
+Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 29a1417..1c8a090 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -67,6 +67,19 @@ target_include_directories(onig PUBLIC
+ target_compile_definitions(onig PUBLIC
+   $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:ONIG_STATIC>)
+ 
++if(BUILD_SHARED_LIBS)
++  # Parse SOVERSION information from LTVERSION in configure.ac
++  file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/configure.ac" LTVERSION REGEX "^LTVERSION *= *\"?[0-9]+:[0-9]+:[0-9]+\"?")
++  string(REGEX REPLACE "^LTVERSION *= *\"?([0-9]+:[0-9]+:[0-9]+)\"?.*$" "\\1" LTVERSION "${LTVERSION}")
++  string(REGEX REPLACE "^([0-9]+):([0-9]+):([0-9]+)" "\\1" LTCURRENT ${LTVERSION})
++  string(REGEX REPLACE "^([0-9]+):([0-9]+):([0-9]+)" "\\2" LTREVISION ${LTVERSION})
++  string(REGEX REPLACE "^([0-9]+):([0-9]+):([0-9]+)" "\\3" LTAGE ${LTVERSION})
++  math(EXPR ONIG_SOVERSION "${LTCURRENT} - ${LTAGE}")
++  set_target_properties(onig PROPERTIES
++      SOVERSION "${ONIG_SOVERSION}"
++      VERSION "${ONIG_SOVERSION}.${LTAGE}.${LTREVISION}")
++endif()
++
+ if(MSVC)
+   target_compile_options(onig PRIVATE
+ 	#/W4


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, wrt3200acm, openwrt master
Run tested: plan to test this with seafile as soon as able, using the wrt3200acm above

Description:
Besides the version bump, this backports a patch so that cmake uses the
same so version information as the current autotools, allowing the
switch over to cmake.

6.9.5_rev1 Changelog:

- Look-behind bug: if the look-behind contains a branch with a character
  length of 0 and an anchor is included in the branch, the whole
  look-behind is ignored
- POSIX API disabled by default -- enabled in openwrt, as at least
  libevhtp needs it
- Update Unicode version 13.0.0
- NEW: Code point sequence notation \x{HHHH HHHH ...}, \o{OOOO OOOO ...}
- NEW API: retry limit in search functions
- NEW API: maximum nesting level of subexp call
- Fixed behavior of isolated options in Perl and Java syntaxes.
  /...(?i).../

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

@neheb You wanted to use cmake from the start, now I finally took the time to update it.  The patch was merged upstream.