### PR TITLE
acme: Update acme.sh URL, add support for challenge & domain alises.

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme
 PKG_VERSION:=2.8.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/Neilpang/acme.sh/tar.gz/$(PKG_VERSION)?
+PKG_SOURCE_URL:=https://github.com/acmesh-official/acme.sh/archive/$(PKG_VERSION).tar.gz
 PKG_HASH:=fd36cb749466296ded521ceacda3fc841ec76be620900d1116e0492d171c1d9f
 PKG_BUILD_DIR:=$(BUILD_DIR)/acme.sh-$(PKG_VERSION)
 

--- a/net/acme/files/acme.config
+++ b/net/acme/files/acme.config
@@ -3,14 +3,31 @@ config acme
        option account_email 'email@example.org'
        option debug 0
 
+config cert 'example_wildcard'
+       option enabled 0
+       option use_staging 1
+       option keylength 2048
+       option update_uhttpd 1
+       option update_nginx 1
+       list domains example.org
+       list domains sub.example.org
+       list domains *.sub.example.org
+       # option user_setup "path-to-custom-setup.script"
+       # option user_cleanup "path-to-custom-cleanup.script"
+       option dns "dns_freedns"
+       list credentials 'FREEDNS_User="ssladmin@example.org"'
+       list credentials 'FREEDNS_Password="1234"'
+       option calias "example.com"
+       option dalias "dalias.example.com"
+
 config cert 'example'
        option enabled 0
        option use_staging 1
        option keylength 2048
        option update_uhttpd 1
        option update_nginx 1
+       list domains example.org
+       list domains sub.example.org
        option webroot ""
-       option dns ""
        # option user_setup "path-to-custom-setup.script"
        # option user_cleanup "path-to-custom-cleanup.script"
-       list domains example.org

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -205,6 +205,8 @@ issue_cert()
     config_get_bool use_staging "$section" use_staging
     config_get_bool update_uhttpd "$section" update_uhttpd
     config_get_bool update_nginx "$section" update_nginx
+    config_get calias "$section" calias
+    config_get dalias "$section" dalias
     config_get domains "$section" domains
     config_get keylength "$section" keylength
     config_get webroot "$section" webroot
@@ -268,6 +270,16 @@ issue_cert()
     if [ -n "$dns" ]; then
         log "Using dns mode"
         acme_args="$acme_args --dns $dns"
+        if [ -n "$dalias" ]; then
+            log "Using domain alias for dns mode"
+            acme_args="$acme_args --domain-alias $dalias"
+            if [ -n "$calias" ]; then
+                err "Both domain and challenge aliases are defined. Ignoring the challenge alias."
+            fi
+        elif [ -n "$calias" ]; then
+            log "Using challenge alias for dns mode"
+            acme_args="$acme_args --challenge-alias $calias"
+        fi
     elif [ -z "$webroot" ]; then
         log "Using standalone mode"
         acme_args="$acme_args --standalone --listen-v6"


### PR DESCRIPTION
Signed-off-by: Will O'Neill <0100wrxb@gmail.com>

Maintainer: @tohojo 
Compile tested: Snapshot, default target (for makefile download of new URL)
Run tested: ramips_mt7621_DEVICE_ubnt_edgerouter-x (for shell scritp run)

Description:
1) The acme.sh project has moved on github to [acmesh-official](https://github.com/acmesh-official/acme.sh)
2) I have added some simple logic in the script to support challenge and domain aliases. These related functions allow using CNAME records from the main domain to point to a different domain where the script can modify text records.

I am preparing an associated LUCI commit for the lua file.