### PR TITLE
mini_snmpd: Add sysDescr option.

### DIFF
--- a/net/mini_snmpd/Makefile
+++ b/net/mini_snmpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mini_snmpd
 PKG_VERSION:=1.4-rc1
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_MAINTAINER:=Marcin Jurkowski <marcin1j@gmail.com>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING

--- a/net/mini_snmpd/files/mini_snmpd.config
+++ b/net/mini_snmpd/files/mini_snmpd.config
@@ -8,6 +8,7 @@ config mini_snmpd 'default'
 	# Turn on community authentication (snmp agent must use community name)
 	option auth 0
 	option community 'public'
+	option description 'OpenWRT'
 	option contact 'OpenWRT router <openwrt@openwrt.org>'
 	option location 'Undisclosed'
 	# to listen on all interfaces you need to set option listen_interface ''

--- a/net/mini_snmpd/files/mini_snmpd.init
+++ b/net/mini_snmpd/files/mini_snmpd.init
@@ -36,6 +36,7 @@ mini_snmpd_validation="enabled:bool:0 \
 		auth:bool:1 \
 		community:rangelength(1,32):public \
 		contact:maxlength(255) \
+		description:maxlength(255) \
 		location:maxlength(255) \
 		listen_interface:uciname \
 		udp_port:port \
@@ -212,6 +213,7 @@ start_instance() {
 	append_arg "-c" "$community"
 	append_arg "-L" "$location"
 	append_arg "-C" "$contact"
+	append_arg "-D" "$description"
 	append_arg "-p" $udp_port
 	append_arg "-P" $tcp_port
 	append_arg "-V" "$vendor_oid"


### PR DESCRIPTION
retrying since i messed up with #11663.

Some monitoring tools will run into errors when sysDescr field is empty. This was the case for cacti 1.2.8 that i'm using to monitor my network. Ideally the sysDescr field would contain some information from the overview of luci, e.g. the Model, Firmware and Kernel-Version fields, but i am stranger to OpenWRT, so I'm unable to do that.

Signed-off-by: Robert von Könemann <lordtaifleh@gmail.com>

Maintainer: @marcin1j
Run tested: OpenWRT 19.07

