### PR TITLE
Mwan3: interface status detection fixes

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
 PKG_VERSION:=2.8.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0
 

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -141,7 +141,7 @@ main() {
 						# https://bugs.openwrt.org/index.php?do=details&task_id=2897
 						# so get the IP address of the interface and use that instead
 						if echo $track_ip | grep -q ':'; then
-							ADDR=$(ip -6 addr ls dev "$DEVICE" scope global | sed -ne '/\/128/d' -e 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p')
+							ADDR=$(ip -6 addr ls dev "$DEVICE" scope global | sed -ne '/\/128/d' -e 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p' | head -n 1)
 						fi
 						if [ $check_quality -eq 0 ]; then
 							ping -I ${ADDR:-$DEVICE} -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -141,7 +141,7 @@ main() {
 						# https://bugs.openwrt.org/index.php?do=details&task_id=2897
 						# so get the IP address of the interface and use that instead
 						if echo $track_ip | grep -q ':'; then
-							ADDR=$(ip -6 addr ls dev "$DEVICE" | sed -ne '/\/128/d' -e 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p')
+							ADDR=$(ip -6 addr ls dev "$DEVICE" scope global | sed -ne '/\/128/d' -e 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p')
 						fi
 						if [ $check_quality -eq 0 ]; then
 							ping -I ${ADDR:-$DEVICE} -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -61,7 +61,7 @@ main() {
 	local recovery_interval down up size
 	local keep_failure_interval check_quality failure_latency
 	local recovery_latency failure_loss recovery_loss
-	local max_ttl httping_ssl
+	local max_ttl httping_ssl gateway_mac
 
 	[ -z "$5" ] && echo "Error: should not be started manually" && exit 0
 
@@ -101,6 +101,7 @@ main() {
 	config_get recovery_latency $1 recovery_latency 500
 	config_get failure_loss $1 failure_loss 40
 	config_get recovery_loss $1 recovery_loss 10
+	config_get gateway_mac $1 gateway_mac ""
 
 	local score=$(($down+$up))
 	local track_ips=$(echo $* | cut -d ' ' -f 5-99)
@@ -130,6 +131,10 @@ main() {
 
 		for track_ip in $track_ips; do
 			if [ $host_up_count -lt $reliability ]; then
+				# There is no default gateway configured so, add an ARP entry to forward this ping to the gateway.
+				if [ -n "$gateway_mac" ]; then
+					ip neigh replace to $track_ip lladdr $gateway_mac dev $DEVICE nud reachable
+				fi
 				case "$track_method" in
 					ping)
 						# pinging IPv6 hosts with an interface is troublesome


### PR DESCRIPTION
Maintainer: @feckert 
Compile tested: master, ramips_mt7621_DEVICE_xiaomi_mir3g
Run tested:  master, ramips_mt7621_DEVICE_xiaomi_mir3g

Description:

This fixes multiple problems I ran into when using mwan3 to automatically fall back to UMTS when my DSL connection is down. I only used the fallback mode, not the load balancing mode.

-----------------------
**mwan3: Allow to specify a gateway MAC address**

When the WAN interface is not using NAT, but normal routing "ping -I
<wan> 8.8.8.8" does not work, when the default route is currently not
going over this WAN link. The system will try to send an ARP request to
the wan network for 8.8.8.8 and receives no answer, because 8.8.8.8 is
not in the same segment, but has to be routed. It should send this
request directly to the default gateway in the network, but the system
default route is pointing to the other WAN network link.

With this change it is possible to define the WAN gateway mac address,
mwan3 will add an ARP entry which makes the kernel forward the ping send
to 8.8.8.8 to the default gateway of this WAN network, like this would
be the default route.

Without this change mwan3 is not able to detect that my routed WAN, not
NAT, link is up again after it was down.

When gateway_mac is not specified the behavior should not change.
For NAT links this is not needed.

This feature need the normal iproute2 and does not work with busybox ip.

---------------

**mwan3: Only use one IPv6 address as source**

An interface can have multiple IPv6 addresses, for example one unique
and a random one. Having multiple global IPv6 addresses is very common.

This command would return all global IPv6 addresses and add then to the
source of the ping command. This fails because it only allows one IPv6
address as source. To make it easier just use the first one.

Without this change the ping test fails when the interface has multiple
IP addresses and the interface is marked as offline.

---------------

**mwan3: Only use global IPv6 addresses for IPv6 ping source**

The ip command allows to filter for the global IPv6 address already, use
that in addition for the filter later done with the sed command.