### PR TITLE
miniupnpd: make hotplug work again

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.1.20191006
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/miniupnpd/files/miniupnpd.hotplug
+++ b/net/miniupnpd/files/miniupnpd.hotplug
@@ -1,15 +1,15 @@
-#!/bin/sh /etc/rc.common
-
-enabled miniupnpd || exit 0
+/etc/init.d/miniupnpd enabled || exit 0
 
 # If miniupnpd is not running:
-# - check on _any_ event (even updates may contribute to network_find_wan*)
+# - check on _any_ event (event updates may contribute to network_find_wan*)
 
 # If miniupnpd _is_ running:
 # - check only on ifup (otherwise lease updates etc would cause
 #   miniupnpd state loss)
 
-[ "$ACTION" != "ifup" ] && service_running miniupnpd && exit 0
+. /lib/functions/procd.sh
+
+[ "$ACTION" != "ifup" ] && procd_running "miniupnpd" "*" && exit 0
 
 tmpconf="/var/etc/miniupnpd.conf"
 extiface=$(uci get upnpd.config.external_iface)
@@ -20,7 +20,7 @@ extzone=$(uci get upnpd.config.external_zone)
 [ -z "$extiface" ] && {
   # manual external zone (if dynamically find interfaces
   # belonging to it) overrides network_find_wan*
-  [ -n "$extzone" ] && ifname=$(fw3 -q zone "$extzone" | head -1)
+  [ -n "$extzone"  ] && ifname=$(fw3 -q zone "$extzone" | head -1)
   [ -z "$extiface" ] && network_find_wan extiface
   [ -z "$extiface" ] && network_find_wan6 extiface
 }


### PR DESCRIPTION
hotplug scripts are sourced not exec'd so #!/bin/sh /etc/rc.common
doesn't pull in the functions defined in /etc/rc.common thus since
'enabled' isn't defined the following sequence always fails:

enabled miniupnpd || exit 0

Unfortunately sourcing /etc/rc.common doesn't appear to work so come up
with some alternatives.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
