### PR TITLE
treewide: Update ARM NEON/VFP detection

### DIFF
--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpng
 PKG_VERSION:=1.6.37
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/libpng
@@ -40,7 +40,7 @@ TARGET_CFLAGS += $(FPIC)
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
-	$(if $(findstring neon,$(CONFIG_TARGET_OPTIMIZATION)),--enable-hardware-optimizations=yes --enable-arm-neon=yes)
+	$(if $(findstring neon,$(CONFIG_CPU_TYPE)),--enable-hardware-optimizations=yes --enable-arm-neon=yes)
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/libs/opus/Makefile
+++ b/libs/opus/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opus
 PKG_VERSION:=1.3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://archive.mozilla.org/pub/opus
@@ -47,7 +47,7 @@ ifeq ($(CONFIG_SOFT_FLOAT),y)
 		--enable-fixed-point
 endif
 
-ifneq ($(findstring neon,$(CONFIG_TARGET_OPTIMIZATION)),)
+ifneq ($(findstring neon,$(CONFIG_CPU_TYPE)),)
 	CONFIGURE_ARGS+= \
 		--enable-fixed-point
 endif

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=4.2.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
@@ -424,12 +424,12 @@ endif
 ifneq ($(findstring arm,$(CONFIG_ARCH)),)
 	FFMPEG_CONFIGURE+= --enable-lto
 
-	ifneq ($(findstring vfp,$(CONFIG_TARGET_OPTIMIZATION)),)
+	ifneq ($(findstring vfp,$(CONFIG_CPU_TYPE)),)
 		FFMPEG_CONFIGURE+= --enable-vfp
 	else
 		FFMPEG_CONFIGURE+= --disable-vfp
 	endif
-	ifneq ($(findstring neon,$(CONFIG_TARGET_OPTIMIZATION)),)
+	ifneq ($(findstring neon,$(CONFIG_CPU_TYPE)),)
 		FFMPEG_CONFIGURE+= \
 			--enable-neon \
 			--enable-vfp

--- a/sound/mpg123/Makefile
+++ b/sound/mpg123/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpg123
 PKG_VERSION:=1.25.13
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/mpg123
@@ -67,14 +67,12 @@ ifeq ($(CONFIG_SOFT_FLOAT),y)
 	CONFIGURE_ARGS+= \
 		--with-cpu=generic_nofpu \
 		--enable-int-quality=yes
+else ifneq ($(findstring neon,$(CONFIG_CPU_TYPE)),)
+	CONFIGURE_ARGS+= \
+		--with-cpu=arm_fpu
 else
 	CONFIGURE_ARGS+= \
 		--with-cpu=generic_fpu
-endif
-
-ifneq ($(findstring neon,$(CONFIG_TARGET_OPTIMIZATION)),)
-        CONFIGURE_ARGS+= \
-                --with-cpu=arm_fpu
 endif
 
 define Build/InstallDev

--- a/sound/pulseaudio/Makefile
+++ b/sound/pulseaudio/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pulseaudio
 PKG_VERSION:=13.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://freedesktop.org/software/pulseaudio/releases
@@ -148,7 +148,7 @@ TARGET_LDFLAGS += -Wl,--gc-sections -liconv
 define Build/Prepare
 	$(call Build/Prepare/Default)
 ifneq ($(findstring arm,$(CONFIG_ARCH)),)
-ifeq ($(findstring neon,$(CONFIG_TARGET_OPTIMIZATION)),)
+ifeq ($(findstring neon,$(CONFIG_CPU_TYPE)),)
 	$(SED) '/remap_neon\.c/d' $(PKG_BUILD_DIR)/src/pulsecore/meson.build
 endif
 endif


### PR DESCRIPTION
Maintainer: @jow- (libpng), @thess & @antonlacon (opus & ffmpeg), @wigyori (mpg123), @tripolar (pulseaudio)
Compile tested: mvebu-cortexa9/armvirt-32, 2020-05-10 snapshot sdk
Run tested: none

Description:
With openwrt/openwrt@8dcc1087602e2dd606e4f6e81a06aee62cfd4f4c, the ARM FPU compiler options are no longer part of `CONFIG_TARGET_OPTIMIZATION`.

This updates various packages that look for NEON/VFP support to search `CONFIG_CPU_TYPE` instead.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>