### PR TITLE
gerbera: set config file to 600 permissions

### DIFF
--- a/multimedia/gerbera/Makefile
+++ b/multimedia/gerbera/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gerbera
 PKG_VERSION:=1.5.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/gerbera/gerbera/tar.gz/v$(PKG_VERSION)?
@@ -41,7 +41,6 @@ endef
 
 define Package/gerbera/conffiles
 /etc/config/gerbera
-/etc/gerbera/config.xml
 endef
 
 CMAKE_OPTIONS += \

--- a/multimedia/gerbera/files/gerbera.config
+++ b/multimedia/gerbera/files/gerbera.config
@@ -1,4 +1,6 @@
 config gerbera config
 	option enabled	'0'
 	option debug	'0'
+	option user	'gerbera'
+	option group	'gerbera'
 	option home	'/tmp/gerbera'

--- a/multimedia/gerbera/files/gerbera.init
+++ b/multimedia/gerbera/files/gerbera.init
@@ -8,6 +8,8 @@ PROG=/usr/bin/gerbera
 start_service() {
 	local enabled
 	local debug
+	local user
+	local group
 	local home
 
 	config_load 'gerbera'
@@ -19,21 +21,26 @@ start_service() {
 		return 1
 	}
 
+	config_get user config 'user' 'gerbera'
+	config_get group config 'group' 'gerbera'
 	config_get home config 'home' '/tmp/gerbera'
 
 	[ -d "$home" ] || {
 		mkdir -p "$home"
-		chown gerbera:gerbera "$home"
+		chown "$user":"$group" "$home"
 
 		gerbera -m "$home" -f '' --create-config > "$home/config.xml" 2> /dev/null
+		chown "$user":"$group" "$home/config.xml"
+		chmod 600 "$home/config.xml"
+
 		echo "Created default gerbera config at $home/config.xml"
 		echo "Please edit to your liking and restart."
 		return 2
 	}
 
 	procd_open_instance
-	procd_set_param user gerbera
-	procd_set_param group gerbera
+	procd_set_param user "$user"
+	procd_set_param group "$group"
 	procd_set_param command "$PROG" -c "$home/config.xml"
 	procd_set_param stdout "$debug"
 	procd_set_param stderr 1


### PR DESCRIPTION
Only gerbera needs to read the file.

Added config file to conffiles to fix opkg update support.

Added several extra options to the UCI config. Manual editing is still required.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: N/A

It's fairly difficult to get this to option parity with minidlna.

I don't know of a way using sh to insert XML that is not present. It needs to be inserted in the proper location.