### PR TITLE
ifstat: make dependency on libnetsnmp conditional

### DIFF
--- a/net/ifstat/Config.in
+++ b/net/ifstat/Config.in
@@ -1,0 +1,4 @@
+        config IFSTAT_SNMP
+                depends on PACKAGE_ifstat
+                bool "Build with support for SNMP"
+                default y

--- a/net/ifstat/Makefile
+++ b/net/ifstat/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ifstat
 PKG_VERSION:=1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://gael.roualland.free.fr/ifstat/
@@ -26,7 +26,7 @@ define Package/ifstat
   CATEGORY:=Network
   TITLE:=InterFace STATistics Monitoring
   URL:=http://gael.roualland.free.fr/ifstat/
-  DEPENDS:=+libnetsnmp
+  DEPENDS:=+IFSTAT_SNMP:libnetsnmp
 endef
 
 define Package/ifstat/description
@@ -35,6 +35,12 @@ define Package/ifstat/description
 	interfaces by polling the kernel counters, or remote hosts
 	interfaces using SNMP.
 endef
+
+define Package/ifstat/config
+	source "$(SOURCE)/Config.in"
+endef
+
+CONFIGURE_ARGS += --with$(if $(CONFIG_IFSTAT_SNMP),,out)-snmp
 
 define Package/ifstat/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
The upstream package supports it with a configure switch.
Defaulting to 'with SNMP support' as it was before.

Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>

Maintainer: unknown
Compile tested with IFSTAT_SNMP set and unset and ELF-checked the resulting ifstat binary