### PR TITLE
netifyd: support uci parameters

### DIFF
--- a/net/netifyd/Makefile
+++ b/net/netifyd/Makefile
@@ -45,6 +45,10 @@ endef
 
 define Package/netifyd/conffiles
 /etc/netifyd.conf
+/etc/config/netifyd
+/etc/netify.d/agent.uuid
+/etc/netify.d/serial.uuid
+/etc/netify.d/site.uuid
 endef
 
 TARGET_CFLAGS+=-ffunction-sections -fdata-sections -Wno-psabi
@@ -85,6 +89,8 @@ endef
 define Package/netifyd/install
 	$(INSTALL_DIR) $(1)/etc
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/deploy/netifyd.conf $(1)/etc
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/netifyd.config $(1)/etc/config/netifyd
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/netifyd.init $(1)/etc/init.d/netifyd
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/net/netifyd/files/netifyd.config
+++ b/net/netifyd/files/netifyd.config
@@ -1,0 +1,5 @@
+config netifyd
+	option enabled 1
+	option autoconfig 1
+#	option internal_if 'eth0'
+#	option external_if 'eth1'

--- a/net/netifyd/files/netifyd.init
+++ b/net/netifyd/files/netifyd.init
@@ -9,20 +9,38 @@ STOP=50
 
 USE_PROCD=1
 PROG=/usr/sbin/netifyd
-NETIFYD_AUTODETECT=yes
+
+start_netifyd() {
+	local instance enabled autoconfig internal_if external_if
+
+	instance="$1"
+
+	config_get_bool enabled "$instance" enabled 0
+	[ "$enabled" -eq 0 ] && return 0
+
+	[ ! -d /var/run/netifyd ] && mkdir -p /var/run/netifyd
+
+	config_get_bool autoconfig "$instance" autoconfig 1
+
+	if [ "$autoconfig" -gt 0 ] ; then
+		source /usr/share/netifyd/functions.sh
+		load_modules
+		NETIFYD_AUTODETECT=yes
+		NETIFYD_OPTS=$(auto_detect_options)
+	else
+		config_get internal_if "$instance" internal_if "eth0"
+		config_get external_if "$instance" external_if "eth1"
+		NETIFYD_OPTS="-E $external_if -I $internal_if"
+	fi
+
+	procd_open_instance
+	procd_set_param command $PROG -R $NETIFYD_OPTS
+	procd_set_param file /etc/netifyd.conf
+	procd_set_param respawn
+	procd_close_instance
+}
 
 start_service() {
-    mkdir -p /etc/netify.d
-    mkdir -p /var/run/netifyd
-
-    source /usr/share/netifyd/functions.sh
-    NETIFYD_OPTS=$(auto_detect_options)
-
-    load_modules
-
-    procd_open_instance
-    procd_set_param command $PROG -R $NETIFYD_OPTS
-    procd_set_param file /etc/netifyd.conf
-    procd_set_param respawn
-    procd_close_instance
+	config_load netifyd
+	config_foreach start_netifyd netifyd
 }


### PR DESCRIPTION
Maintainer: Darryl Sokoloski / @dsokoloski
Compile tested: arm_cortex-a15_neon-vfpv4, TP-Link Archer C2600, master
Run tested: TP-Link Archer C2600

Integrate with uci to support 'enabled/disabled' startup option and
override netify's default auto network selection.

config netifyd
       option enabled 0
       option autoconfig 1

autoconfig: Use netify's in-built interface selection
else use 'internal/external_if' definitions.

Also persist important agent config across sysupgrade
agent.uuid, serial.uuid, site.uuid

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>