### PR TITLE
treewide: Enable VFP/NEON optimizations for aarch64

### DIFF
--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpng
 PKG_VERSION:=1.6.37
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/libpng
@@ -40,7 +40,8 @@ TARGET_CFLAGS += $(FPIC)
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
-	$(if $(findstring neon,$(CONFIG_CPU_TYPE)),--enable-hardware-optimizations=yes --enable-arm-neon=yes)
+	$(if $(findstring neon,$(CONFIG_CPU_TYPE))$(findstring aarch64,$(CONFIG_ARCH)), \
+		--enable-hardware-optimizations=yes --enable-arm-neon=yes)
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/libs/opus/Makefile
+++ b/libs/opus/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opus
 PKG_VERSION:=1.3.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://archive.mozilla.org/pub/opus
@@ -47,7 +47,7 @@ ifeq ($(CONFIG_SOFT_FLOAT),y)
 		--enable-fixed-point
 endif
 
-ifneq ($(findstring neon,$(CONFIG_CPU_TYPE)),)
+ifneq ($(findstring neon,$(CONFIG_CPU_TYPE))$(findstring aarch64,$(CONFIG_ARCH)),)
 	CONFIGURE_ARGS+= \
 		--enable-fixed-point
 endif

--- a/libs/speexdsp/Makefile
+++ b/libs/speexdsp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=speexdsp
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.us.xiph.org/releases/speex/
@@ -60,7 +60,6 @@ CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
 	--disable-examples \
-	$(if $(CONFIG_aarch64),--disable-neon) \
 	$(if $(CONFIG_SOFT_FLOAT),--enable-fixed-point --disable-float-api)
 
 $(eval $(call BuildPackage,libspeexdsp))

--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=4.2.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
@@ -411,7 +411,7 @@ FFMPEG_CONFIGURE+= \
 	--disable-fast-unaligned \
 	--disable-runtime-cpudetect
 
-else ifneq ($(findstring arm,$(CONFIG_ARCH)),)
+else ifneq ($(findstring arm,$(CONFIG_ARCH))$(findstring aarch64,$(CONFIG_ARCH)),)
 FFMPEG_CONFIGURE+= \
 	--disable-runtime-cpudetect
 # XXX: GitHub issue 3320 ppc cpu with fpu but no altivec (WNDR4700)
@@ -436,6 +436,13 @@ ifneq ($(findstring arm,$(CONFIG_ARCH)),)
 	else
 		FFMPEG_CONFIGURE+= --disable-neon
 	endif
+endif
+
+ifneq ($(findstring aarch64,$(CONFIG_ARCH)),)
+	FFMPEG_CONFIGURE+= \
+		--enable-lto \
+		--enable-neon \
+		--enable-vfp
 endif
 
 ifeq ($(ARCH),x86_64)

--- a/sound/mpg123/Makefile
+++ b/sound/mpg123/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mpg123
 PKG_VERSION:=1.25.13
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/mpg123
@@ -70,6 +70,9 @@ ifeq ($(CONFIG_SOFT_FLOAT),y)
 else ifneq ($(findstring neon,$(CONFIG_CPU_TYPE)),)
 	CONFIGURE_ARGS+= \
 		--with-cpu=arm_fpu
+else ifneq ($(findstring aarch64,$(CONFIG_ARCH)),)
+	CONFIGURE_ARGS+= \
+		--with-cpu=aarch64
 else
 	CONFIGURE_ARGS+= \
 		--with-cpu=generic_fpu


### PR DESCRIPTION
Maintainer:  @jow- (libpng), @thess & @antonlacon (opus & ffmpeg), @wigyori (mpg123), @tripolar (speexdsp)
Compile tested: armvirt-32/armvirt-64/malta-be/mvebu-cortexa9/sunxi-cortexa53, 2020-05-10 snapshot (sunxi-cortexa53: 2020-05-11 snapshot) sdk
Run tested: none

Description:
For speexdsp, support for NEON on aarch64 was [added][1] in 1.2.0.

[1]: https://github.com/xiph/speexdsp/pull/8

Signed-off-by: Jeffery To <jeffery.to@gmail.com>