### PR TITLE
libreswan: fix compilation with Linux 4.14

### DIFF
--- a/net/libreswan/Makefile
+++ b/net/libreswan/Makefile
@@ -81,6 +81,10 @@ MAKE_FLAGS+= \
     FINALRUNDIR="/var/run/pluto" \
     ARCH="$(LINUX_KARCH)" \
 
+ifdef CONFIG_LINUX_4_14
+	MAKE_FLAGS+= USE_XFRM_INTERFACE_IFLA_HEADER=true
+endif
+
 define Build/Prepare
 	$(call Build/Prepare/Default)
 	$(SED) 's,include $$$$(top_srcdir)/mk/manpages.mk,,g' \


### PR DESCRIPTION
Maintainer: @lucize 
Compile tested: ramips, mipsel_74kc, openwrt master
Run tested: none

Description:
According to a comment in programs/pluto/kernel_xfrm_interface.c:177:

* IFLA_XFRM_IF_ID was added to mainline kernel 4.19 linux/if_link.h
  with older kernel headers 'make USE_XFRM_INTERFACE_IFLA_HEADER=true'

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
Bots are failing:
https://downloads.openwrt.org/snapshots/faillogs/mipsel_24kc/packages/libreswan/compile.txt
```
mipsel-openwrt-linux-musl-gcc -Os -pipe -mno-branch-likely -mips32r2 -mtune=24kc -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float -mips16 -minterlink-mips16 -ffile-prefix-map=/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31=libreswan-3.31 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro  -I/builder/shared-workdir/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include -I/builder/shared-workdir/build/sdk/staging_dir/toolchain-mipsel_24kc_gcc-8.4.0_musl/usr/include -I/builder/shared-workdir/build/sdk/staging_dir/toolchain-mipsel_24kc_gcc-8.4.0_musl/include/fortify -I/builder/shared-workdir/build/sdk/staging_dir/toolchain-mipsel_24kc_gcc-8.4.0_musl/include  -I /builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/programs/pluto/linux-copy -DGLIBC_KERN_FLIP_HEADERS -DTimeZoneOffset=timezone -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -Dlinux -DHAVE_UDPFROMTO=1 -DHAVE_IP_PKTINFO=1 -std=gnu99 -g  -Wall -Wextra -Wformat -Wformat-nonliteral -Wformat-security -Wundef -Wmissing-declarations -Wredundant-decls -Wnested-externs -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-all -fno-strict-aliasing -fPIE -DPIE -DNETKEY_SUPPORT -DUSE_XFRM_INTERFACE -DUSE_DNSSEC -DDEFAULT_DNSSEC_ROOTKEY_FILE=\""/var/lib/unbound/root.key"\" -DUSE_3DES -DUSE_AES -DUSE_CAMELLIA -DUSE_CHACHA -DUSE_DH31 -DUSE_MD5 -DUSE_SERPENT -DUSE_SHA1 -DUSE_SHA2 -DUSE_TWOFISH -DUSE_PRF_AES_XCBC -DDEFAULT_RUNDIR=\"/var/run/pluto\" -DFIPSPRODUCTCHECK=\"/etc/system-fips\" -DIPSEC_CONF=\"/etc/ipsec.conf\" -DIPSEC_CONFDDIR=\"/etc/ipsec.d\" -DIPSEC_NSSDIR=\"/etc/ipsec.d\" -DIPSEC_CONFDIR=\"/etc\" -DIPSEC_EXECDIR=\"/usr/libexec/ipsec\" -DIPSEC_SBINDIR=\"/usr/sbin\" -DIPSEC_VARDIR=\"/var\" -DPOLICYGROUPSDIR=\"/etc/ipsec.d/policies\" -DIPSEC_SECRETS_FILE=\"/etc/ipsec.secrets\" -DFORCE_PR_ASSERT -DUSE_FORK=1 -DUSE_VFORK=0 -DUSE_DAEMON=0 -DUSE_PTHREAD_SETSCHEDPRIO=1 -DGCC_LINT -DALLOW_MICROSOFT_BAD_PROPOSAL   -I/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/include -I/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/lib/libcrypto -I/builder/shared-workdir/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include/nss -I/builder/shared-workdir/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include/nspr  -DNSS_IPSEC_PROFILE         -pthread -DTimeZoneOffset=timezone -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -Dlinux -DHAVE_UDPFROMTO=1 -DHAVE_IP_PKTINFO=1 -std=gnu99 -g  -Wall -Wextra -Wformat -Wformat-nonliteral -Wformat-security -Wundef -Wmissing-declarations -Wredundant-decls -Wnested-externs -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-all -fno-strict-aliasing -fPIE -DPIE -DNETKEY_SUPPORT -DUSE_XFRM_INTERFACE -DUSE_DNSSEC -DDEFAULT_DNSSEC_ROOTKEY_FILE=\""/var/lib/unbound/root.key"\" -DUSE_3DES -DUSE_AES -DUSE_CAMELLIA -DUSE_CHACHA -DUSE_DH31 -DUSE_MD5 -DUSE_SERPENT -DUSE_SHA1 -DUSE_SHA2 -DUSE_TWOFISH -DUSE_PRF_AES_XCBC -DDEFAULT_RUNDIR=\"/var/run/pluto\" -DFIPSPRODUCTCHECK=\"/etc/system-fips\" -DIPSEC_CONF=\"/etc/ipsec.conf\" -DIPSEC_CONFDDIR=\"/etc/ipsec.d\" -DIPSEC_NSSDIR=\"/etc/ipsec.d\" -DIPSEC_CONFDIR=\"/etc\" -DIPSEC_EXECDIR=\"/usr/libexec/ipsec\" -DIPSEC_SBINDIR=\"/usr/sbin\" -DIPSEC_VARDIR=\"/var\" -DPOLICYGROUPSDIR=\"/etc/ipsec.d/policies\" -DIPSEC_SECRETS_FILE=\"/etc/ipsec.secrets\" -DFORCE_PR_ASSERT -DUSE_FORK=1 -DUSE_VFORK=0 -DUSE_DAEMON=0 -DUSE_PTHREAD_SETSCHEDPRIO=1 -DGCC_LINT -DALLOW_MICROSOFT_BAD_PROPOSAL  -I../../include -I/builder/shared-workdir/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include/nss -I/builder/shared-workdir/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include/nspr  -DNSS_IPSEC_PROFILE  -I /builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/programs/pluto/linux-copy -DGLIBC_KERN_FLIP_HEADERS -DTimeZoneOffset=timezone -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -Dlinux -DHAVE_UDPFROMTO=1 -DHAVE_IP_PKTINFO=1 -std=gnu99 -g  -Wall -Wextra -Wformat -Wformat-nonliteral -Wformat-security -Wundef -Wmissing-declarations -Wredundant-decls -Wnested-externs -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-all -fno-strict-aliasing -fPIE -DPIE -DNETKEY_SUPPORT -DUSE_XFRM_INTERFACE -DUSE_DNSSEC -DDEFAULT_DNSSEC_ROOTKEY_FILE=\""/var/lib/unbound/root.key"\" -DUSE_3DES -DUSE_AES -DUSE_CAMELLIA -DUSE_CHACHA -DUSE_DH31 -DUSE_MD5 -DUSE_SERPENT -DUSE_SHA1 -DUSE_SHA2 -DUSE_TWOFISH -DUSE_PRF_AES_XCBC -DDEFAULT_RUNDIR=\"/var/run/pluto\" -DFIPSPRODUCTCHECK=\"/etc/system-fips\" -DIPSEC_CONF=\"/etc/ipsec.conf\" -DIPSEC_CONFDDIR=\"/etc/ipsec.d\" -DIPSEC_NSSDIR=\"/etc/ipsec.d\" -DIPSEC_CONFDIR=\"/etc\" -DIPSEC_EXECDIR=\"/usr/libexec/ipsec\" -DIPSEC_SBINDIR=\"/usr/sbin\" -DIPSEC_VARDIR=\"/var\" -DPOLICYGROUPSDIR=\"/etc/ipsec.d/policies\" -DIPSEC_SECRETS_FILE=\"/etc/ipsec.secrets\" -DFORCE_PR_ASSERT -DUSE_FORK=1 -DUSE_VFORK=0 -DUSE_DAEMON=0 -DUSE_PTHREAD_SETSCHEDPRIO=1 -DGCC_LINT -DALLOW_MICROSOFT_BAD_PROPOSAL   -I/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/include -I/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/lib/libcrypto -I/builder/shared-workdir/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include/nss -I/builder/shared-workdir/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include/nspr  -DNSS_IPSEC_PROFILE         -pthread -DTimeZoneOffset=timezone -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -Dlinux -DHAVE_UDPFROMTO=1 -DHAVE_IP_PKTINFO=1 -std=gnu99 -g  -Wall -Wextra -Wformat -Wformat-nonliteral -Wformat-security -Wundef -Wmissing-declarations -Wredundant-decls -Wnested-externs -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-all -fno-strict-aliasing -fPIE -DPIE -DNETKEY_SUPPORT -DUSE_XFRM_INTERFACE -DUSE_DNSSEC -DDEFAULT_DNSSEC_ROOTKEY_FILE=\""/var/lib/unbound/root.key"\" -DUSE_3DES -DUSE_AES -DUSE_CAMELLIA -DUSE_CHACHA -DUSE_DH31 -DUSE_MD5 -DUSE_SERPENT -DUSE_SHA1 -DUSE_SHA2 -DUSE_TWOFISH -DUSE_PRF_AES_XCBC -DDEFAULT_RUNDIR=\"/var/run/pluto\" -DFIPSPRODUCTCHECK=\"/etc/system-fips\" -DIPSEC_CONF=\"/etc/ipsec.conf\" -DIPSEC_CONFDDIR=\"/etc/ipsec.d\" -DIPSEC_NSSDIR=\"/etc/ipsec.d\" -DIPSEC_CONFDIR=\"/etc\" -DIPSEC_EXECDIR=\"/usr/libexec/ipsec\" -DIPSEC_SBINDIR=\"/usr/sbin\" -DIPSEC_VARDIR=\"/var\" -DPOLICYGROUPSDIR=\"/etc/ipsec.d/policies\" -DIPSEC_SECRETS_FILE=\"/etc/ipsec.secrets\" -DFORCE_PR_ASSERT -DUSE_FORK=1 -DUSE_VFORK=0 -DUSE_DAEMON=0 -DUSE_PTHREAD_SETSCHEDPRIO=1 -DGCC_LINT -DALLOW_MICROSOFT_BAD_PROPOSAL  -I../../include -I/builder/shared-workdir/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include/nss -I/builder/shared-workdir/build/sdk/staging_dir/target-mipsel_24kc_musl/usr/include/nspr  -DNSS_IPSEC_PROFILE  \
	-MF ../../OBJ.linux./programs/pluto/kernel_xfrm_interface.d \
	-MP -MMD -MT kernel_xfrm_interface.o \
	-o ../../OBJ.linux./programs/pluto/kernel_xfrm_interface.o \
	-c /builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/programs/pluto/kernel_xfrm_interface.c
```
```
/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/programs/pluto/kernel_xfrm_interface.c: In function 'link_add_nl_msg':
/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/programs/pluto/kernel_xfrm_interface.c:180:30: error: 'IFLA_XFRM_IF_ID' undeclared (first use in this function); did you mean 'IPSEC1_XFRM_IF_ID'?
  nl_addattr32(&req->n, 1024, IFLA_XFRM_IF_ID, if_id);
                              ^~~~~~~~~~~~~~~
                              IPSEC1_XFRM_IF_ID
/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/programs/pluto/kernel_xfrm_interface.c:180:30: note: each undeclared identifier is reported only once for each function it appears in
/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/programs/pluto/kernel_xfrm_interface.c:186:32: error: 'IFLA_XFRM_LINK' undeclared (first use in this function); did you mean 'IFLA_VXLAN_LINK'?
    nl_addattr32(&req->n, 1024, IFLA_XFRM_LINK, dev_link_id);
                                ^~~~~~~~~~~~~~
                                IFLA_VXLAN_LINK
/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/programs/pluto/kernel_xfrm_interface.c: In function 'parse_xfrm_linkinfo_data':
/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/programs/pluto/kernel_xfrm_interface.c:309:34: error: 'IFLA_XFRM_LINK' undeclared (first use in this function); did you mean 'IFLA_VXLAN_LINK'?
   if (nested_attrib->rta_type == IFLA_XFRM_LINK) {
                                  ^~~~~~~~~~~~~~
                                  IFLA_VXLAN_LINK
/builder/shared-workdir/build/sdk/build_dir/target-mipsel_24kc_musl/libreswan-3.31/programs/pluto/kernel_xfrm_interface.c:313:34: error: 'IFLA_XFRM_IF_ID' undeclared (first use in this function); did you mean 'IPSEC1_XFRM_IF_ID'?
   if (nested_attrib->rta_type == IFLA_XFRM_IF_ID) {
                                  ^~~~~~~~~~~~~~~
                                  IPSEC1_XFRM_IF_ID
../../mk/depend.mk:34: recipe for target 'kernel_xfrm_interface.o' failed
make[7]: *** [kernel_xfrm_interface.o] Error 1
```
This should not cause a package change: 
 - if kernel >= 4.19, this will not affect compilation;
 - if kernel = 4.14, it would not compile before the change, and will compile from now on.
So I did not increase `PKG_REVISION`.