### PR TITLE
jupp: update to 3.1.39

### DIFF
--- a/utils/jupp/Makefile
+++ b/utils/jupp/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=jupp
-PKG_VERSION:=3.1.38
+PKG_VERSION:=3.1.39
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-1.0
 PKG_LICENSE_FILES:=COPYING
@@ -17,7 +17,7 @@ PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_libncurses
 PKG_SOURCE:=joe-$(basename ${PKG_VERSION})jupp$(subst .,,$(suffix ${PKG_VERSION})).tgz
 PKG_SOURCE_URL:=http://www.mirbsd.org/MirOS/dist/jupp/ \
 		http://pub.allbsd.org/MirOS/dist/jupp/
-PKG_HASH:=c5cbe3f97683f6e513f611a60531feefb9b877f8cea4c6e9087b48631f69ed40
+PKG_HASH:=0d5d5b3c8e3db7b64410779fd4ccf962174ebac0c7e717674c780edf44d2fe91
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Maintainer: @mirabilos 
Compile & Run tested: ramips, mipsel_74kc, openwrt master & mvebu, wrt3200acm

Description:
Among other changes, this fixes compilation with mips16, working around a gcc bug.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
Bots are failing: https://downloads.openwrt.org/snapshots/faillogs/mipsel_74kc/packages/jupp/compile.txt:
```
{standard input}: Assembler messages:
{standard input}:542: Error: branch to a symbol in another ISA mode
Makefile:490: recipe for target 'bw.o' failed
make[5]: *** [bw.o] Error 1
make[5]: Leaving directory '/store/buildbot/slave/shared-workdir/build/sdk/build_dir/target-mipsel_74kc_musl/jupp'
Makefile:306: recipe for target 'all' failed
```