### PR TITLE
knxd: bump to version 0.14.37

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -11,12 +11,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
-PKG_VERSION:=0.14.35
+PKG_VERSION:=0.14.37
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=697bc68b64a27f0be478d8c861498533d18f0aef067cf95e9dc5e7c0653f1044
+PKG_HASH:=c3fc5777c39e40afb3dfffd74907954c8951d05134d04d44d1acf3362db6ca59
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/knxd/patches/0100-version.patch
+++ b/net/knxd/patches/0100-version.patch
@@ -1,12 +1,8 @@
 --- a/tools/version.sh  2020-04-08 19:39:40.349461034 +0200
-+++ b/tools/version.sh  2020-04-08 19:40:26.354277094 +0200
-@@ -1,8 +1,2 @@
++++ b/tools/version.sh  2020-05-13 13:40:26.354277094 +0200
+@@ -1,4 +1,3 @@
  #!/bin/sh
--sed -ne '1s/.*(\(.*\)).*/\1/' -e '1s/-1$//' -e '1p' debian/changelog | tr -d "\n"
+
 -test -d .git || exit
--git=$(git rev-parse --short HEAD)
--lgit=$(git rev-parse --short $(git rev-list -1 HEAD debian/changelog) )
--if test "$git" != "$lgit" ; then
--	echo -n ":$git"
--fi
-+echo -n "0.14.35"
+-git describe --tags
++echo -n "0.14.37"


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

Maintainer: me
Compile tested: mpc85xx, tl-wdr4900-v1, trunk
Compile tested: ath79, tplink_archer-c7-v4, trunk
Compile tested: ramips, mt7620a, trunk
Run tested: ath79, tp-link Archer C7 v4, trunk

Description:
new upstream release 0.14.37

