### PR TITLE
npupnp updates

### DIFF
--- a/libs/libnpupnp/Makefile
+++ b/libs/libnpupnp/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnpupnp
-PKG_VERSION:=2.2.1
+PKG_VERSION:=4.0.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.lesbonscomptes.com/upmpdcli/downloads
-PKG_HASH:=da67d4c258d139d476af6b800926cd9cd09ba17d9e9fcfaebe3fb98241b32790
+PKG_HASH:=160ab9b0fa8886013811573cb28cffe0b205eadb318e9627c09b297dee1cbc23
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/libs/libupnpp/Makefile
+++ b/libs/libupnpp/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libupnpp
-PKG_VERSION:=0.18.0
+PKG_VERSION:=0.19.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.lesbonscomptes.com/upmpdcli/downloads
-PKG_HASH:=c9659cd36ce70c43e9889a6c3a5eeb28e4f799580727826a6c7aef9bef6b6937
+PKG_HASH:=412b38bdd07441588c11bb1d64af7d112f439a46512d53c907f9b54a6666ff58
 
 PKG_MAINTAINER:=Petko Bordjukov <bordjukov@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later

--- a/sound/upmpdcli/Makefile
+++ b/sound/upmpdcli/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=upmpdcli
-PKG_VERSION:=1.4.7
-PKG_RELEASE:=2
+PKG_VERSION:=1.4.9
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.lesbonscomptes.com/upmpdcli/downloads
-PKG_HASH:=55dec356c98e16f00b1e547f9f4a1c03756317102e91982f93eca8cc4eda115e
+PKG_HASH:=ace5a3166891109d2a874f21306986857ee2620230a77751ed6209f7b5cc9c58
 
 PKG_MAINTAINER:=Petko Bordjukov <bordjukov@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Maintainer: @ignisf 
Compile tested: ath79

I tried to convert the first to a static library. Unfortunately, it gives linking errors and complains that compilation with -fPIC is needed. Sounds bogus since all libraries are compiled with -fPIC anyway.

ping @medoc92

edit: sorry the second. libnpupnp.