### PR TITLE
admin/netdata: Update to 1.22.1

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.20.0
+PKG_VERSION:=1.22.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
@@ -18,7 +18,7 @@ PKG_CPE_ID:=cpe:/a:my-netdata:netdata
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netdata/netdata/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c739e0fa8d6d7f433c0c7c8016b763e8f70519d67f0b5e7eca9ee5318f210d90
+PKG_HASH:=6efd785eab82f98892b4b4017cadfa4ce1688985915499bc75f2f888765a3446
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
@@ -60,7 +60,8 @@ CONFIGURE_ARGS += \
 	--disable-plugin-cups \
 	--disable-plugin-xenstat \
 	--disable-backend-prometheus-remote-write \
-	--enable-jsonc
+	--disable-unit-tests \
+	--disable-cloud
 
 define Package/netdata/conffiles
 /etc/netdata/
@@ -75,9 +76,6 @@ define Package/netdata/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/netdata $(1)/usr/lib
 	$(CP) $(1)/usr/lib/netdata/conf.d/fping.conf $(1)/etc
 	$(CP) $(1)/usr/lib/netdata/conf.d/health_alarm_notify.conf $(1)/etc
-	rm -rf $(1)/usr/lib/netdata/python.d/python_modules/pyyaml2
-	rm -rf $(1)/usr/lib/netdata/python.d/python_modules/pyyaml3
-	rm -rf $(1)/usr/lib/netdata/python.d/python_modules/urllib3
 	$(CP) $(1)/usr/lib/netdata/plugins.d/tc-qos-helper.sh $(1)/etc
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/netdata $(1)/usr/sbin
@@ -90,6 +88,7 @@ define Package/netdata/install
 	rm $(1)/usr/share/netdata/web/images/*.png
 	rm $(1)/usr/share/netdata/web/images/*.gif
 	rm $(1)/usr/share/netdata/web/images/*.ico
+	rm -rf $(1)/usr/share/netdata/web/old
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/netdata.init $(1)/etc/init.d/netdata
 endef

--- a/admin/netdata/patches/002-extra-patch-web_gui_index.html.patch
+++ b/admin/netdata/patches/002-extra-patch-web_gui_index.html.patch
@@ -1,0 +1,28 @@
+--- a/web/gui/index.html
++++ b/web/gui/index.html
+@@ -90,7 +90,9 @@
+             </div>
+             <nav class="collapse navbar-collapse navbar-right" role="navigation">
+                 <ul class="nav navbar-nav">
++                    <!--
+                     <li title="Nodes view" data-toggle="tooltip" data-placement="bottom"><a onclick="openAuthenticatedUrl('console.html');" class="btn" target="_blank"><i class="fas fa-tv"></i>&nbsp;<span class="hidden-sm hidden-md">Nodes<sup class="beta"> beta</sup></span></a></li>
++                    -->
+                     <li id="alarmsButton"  title="check the health monitoring alarms and their log" data-toggle="tooltip" data-placement="bottom"><a href="#" class="btn" data-toggle="modal" data-target="#alarmsModal"><i class="fas fa-bell"></i>&nbsp;<span class="hidden-sm hidden-md">Alarms&nbsp;</span><span id="alarms_count_badge" class="badge"></span></a></li>
+                     <li title="change dashboard settings" data-toggle="tooltip" data-placement="bottom"><a href="#" class="btn" data-toggle="modal" data-target="#optionsModal"><i class="fas fa-cog"></i>&nbsp;<span class="hidden-sm hidden-md">Settings</span></a></li>
+                     <li title="check for netdata updates<br/>you should keep your netdata updated" data-toggle="tooltip" data-placement="bottom" class="hidden-sm" id="updateButton"><a href="#" class="btn" data-toggle="modal" data-target="#updateModal"><i class="fas fa-cloud-download-alt"></i> <span class="hidden-sm hidden-md">Update </span><span id="update_badge" class="badge"></span></a></li>
+@@ -110,6 +112,7 @@
+         <div id="navbar-highlight-content" class="navbar-highlight-content"></div>
+     </div>
+ 
++<!--
+     <div id="sign-in-banner" style="display: none">
+         <div class="container">
+             Like what you see? 
+@@ -120,6 +123,7 @@
+             </div>
+         </div>
+     </div>
++-->
+     
+     <div id="masthead" style="display: none;">
+         <div class="container">

--- a/admin/netdata/patches/003-extra-patch-web_gui_main.js.patch
+++ b/admin/netdata/patches/003-extra-patch-web_gui_main.js.patch
@@ -1,0 +1,15 @@
+--- a/web/gui/main.js
++++ b/web/gui/main.js
+@@ -745,11 +745,7 @@ function renderMyNetdataMenu(machinesArr
+     if (!isSignedIn()) {
+         if (!NETDATA.registry.isRegistryEnabled()) {
+             html += (
+-                `<div class="info-item" style="white-space: nowrap">
+-                    <span>Please <a href="#" onclick="signInDidClick(event); return false">sign in to netdata.cloud</a> to view your nodes!</span>
+-                    <div></div>
+-                </div>
+-                <hr />`
++                ``
+             );
+         }
+     }

--- a/admin/netdata/patches/004-patch-collectors_python.d.plugin_Makefile.am.patch
+++ b/admin/netdata/patches/004-patch-collectors_python.d.plugin_Makefile.am.patch
@@ -1,0 +1,112 @@
+--- a/collectors/python.d.plugin/Makefile.am
++++ b/collectors/python.d.plugin/Makefile.am
+@@ -142,109 +142,3 @@ dist_third_party_DATA = \
+     python_modules/third_party/boinc_client.py \
+     python_modules/third_party/monotonic.py \
+     $(NULL)
+-
+-pythonyaml2dir=$(pythonmodulesdir)/pyyaml2
+-dist_pythonyaml2_DATA = \
+-    python_modules/pyyaml2/__init__.py \
+-    python_modules/pyyaml2/composer.py \
+-    python_modules/pyyaml2/constructor.py \
+-    python_modules/pyyaml2/cyaml.py \
+-    python_modules/pyyaml2/dumper.py \
+-    python_modules/pyyaml2/emitter.py \
+-    python_modules/pyyaml2/error.py \
+-    python_modules/pyyaml2/events.py \
+-    python_modules/pyyaml2/loader.py \
+-    python_modules/pyyaml2/nodes.py \
+-    python_modules/pyyaml2/parser.py \
+-    python_modules/pyyaml2/reader.py \
+-    python_modules/pyyaml2/representer.py \
+-    python_modules/pyyaml2/resolver.py \
+-    python_modules/pyyaml2/scanner.py \
+-    python_modules/pyyaml2/serializer.py \
+-    python_modules/pyyaml2/tokens.py \
+-    $(NULL)
+-
+-pythonyaml3dir=$(pythonmodulesdir)/pyyaml3
+-dist_pythonyaml3_DATA = \
+-    python_modules/pyyaml3/__init__.py \
+-    python_modules/pyyaml3/composer.py \
+-    python_modules/pyyaml3/constructor.py \
+-    python_modules/pyyaml3/cyaml.py \
+-    python_modules/pyyaml3/dumper.py \
+-    python_modules/pyyaml3/emitter.py \
+-    python_modules/pyyaml3/error.py \
+-    python_modules/pyyaml3/events.py \
+-    python_modules/pyyaml3/loader.py \
+-    python_modules/pyyaml3/nodes.py \
+-    python_modules/pyyaml3/parser.py \
+-    python_modules/pyyaml3/reader.py \
+-    python_modules/pyyaml3/representer.py \
+-    python_modules/pyyaml3/resolver.py \
+-    python_modules/pyyaml3/scanner.py \
+-    python_modules/pyyaml3/serializer.py \
+-    python_modules/pyyaml3/tokens.py \
+-    $(NULL)
+-
+-python_urllib3dir=$(pythonmodulesdir)/urllib3
+-dist_python_urllib3_DATA = \
+-    python_modules/urllib3/__init__.py \
+-    python_modules/urllib3/_collections.py \
+-    python_modules/urllib3/connection.py \
+-    python_modules/urllib3/connectionpool.py \
+-    python_modules/urllib3/exceptions.py \
+-    python_modules/urllib3/fields.py \
+-    python_modules/urllib3/filepost.py \
+-    python_modules/urllib3/response.py \
+-    python_modules/urllib3/poolmanager.py \
+-    python_modules/urllib3/request.py \
+-    $(NULL)
+-
+-python_urllib3_utildir=$(python_urllib3dir)/util
+-dist_python_urllib3_util_DATA = \
+-    python_modules/urllib3/util/__init__.py \
+-    python_modules/urllib3/util/connection.py \
+-    python_modules/urllib3/util/request.py \
+-    python_modules/urllib3/util/response.py \
+-    python_modules/urllib3/util/retry.py \
+-    python_modules/urllib3/util/selectors.py \
+-    python_modules/urllib3/util/ssl_.py \
+-    python_modules/urllib3/util/timeout.py \
+-    python_modules/urllib3/util/url.py \
+-    python_modules/urllib3/util/wait.py \
+-    $(NULL)
+-
+-python_urllib3_packagesdir=$(python_urllib3dir)/packages
+-dist_python_urllib3_packages_DATA = \
+-    python_modules/urllib3/packages/__init__.py \
+-    python_modules/urllib3/packages/ordered_dict.py \
+-    python_modules/urllib3/packages/six.py \
+-    $(NULL)
+-
+-python_urllib3_backportsdir=$(python_urllib3_packagesdir)/backports
+-dist_python_urllib3_backports_DATA = \
+-    python_modules/urllib3/packages/backports/__init__.py \
+-    python_modules/urllib3/packages/backports/makefile.py \
+-    $(NULL)
+-
+-python_urllib3_ssl_match_hostnamedir=$(python_urllib3_packagesdir)/ssl_match_hostname
+-dist_python_urllib3_ssl_match_hostname_DATA = \
+-    python_modules/urllib3/packages/ssl_match_hostname/__init__.py \
+-    python_modules/urllib3/packages/ssl_match_hostname/_implementation.py \
+-    $(NULL)
+-
+-python_urllib3_contribdir=$(python_urllib3dir)/contrib
+-dist_python_urllib3_contrib_DATA = \
+-    python_modules/urllib3/contrib/__init__.py \
+-    python_modules/urllib3/contrib/appengine.py \
+-    python_modules/urllib3/contrib/ntlmpool.py \
+-    python_modules/urllib3/contrib/pyopenssl.py \
+-    python_modules/urllib3/contrib/securetransport.py \
+-    python_modules/urllib3/contrib/socks.py \
+-    $(NULL)
+-
+-python_urllib3_securetransportdir=$(python_urllib3_contribdir)/_securetransport
+-dist_python_urllib3_securetransport_DATA = \
+-    python_modules/urllib3/contrib/_securetransport/__init__.py \
+-    python_modules/urllib3/contrib/_securetransport/bindings.py \
+-    python_modules/urllib3/contrib/_securetransport/low_level.py \
+-    $(NULL)

--- a/admin/netdata/patches/005-patch-collectors_python.d.plugin_python__modules_bases_loaders.py.patch
+++ b/admin/netdata/patches/005-patch-collectors_python.d.plugin_python__modules_bases_loaders.py.patch
@@ -1,0 +1,14 @@
+--- a/collectors/python.d.plugin/python_modules/bases/loaders.py
++++ b/collectors/python.d.plugin/python_modules/bases/loaders.py
+@@ -10,9 +10,9 @@ PY_VERSION = version_info[:2]
+ 
+ try:
+     if PY_VERSION > (3, 1):
+-        from pyyaml3 import SafeLoader as YamlSafeLoader
++        from yaml import SafeLoader as YamlSafeLoader
+     else:
+-        from pyyaml2 import SafeLoader as YamlSafeLoader
++        from yaml import SafeLoader as YamlSafeLoader
+ except ImportError:
+     from yaml import SafeLoader as YamlSafeLoader
+ 

--- a/admin/netdata/patches/006-patch-web_gui_index.html.patch
+++ b/admin/netdata/patches/006-patch-web_gui_index.html.patch
@@ -1,0 +1,17 @@
+--- a/web/gui/index.html
++++ b/web/gui/index.html
+@@ -95,10 +95,14 @@
+                     -->
+                     <li id="alarmsButton"  title="check the health monitoring alarms and their log" data-toggle="tooltip" data-placement="bottom"><a href="#" class="btn" data-toggle="modal" data-target="#alarmsModal"><i class="fas fa-bell"></i>&nbsp;<span class="hidden-sm hidden-md">Alarms&nbsp;</span><span id="alarms_count_badge" class="badge"></span></a></li>
+                     <li title="change dashboard settings" data-toggle="tooltip" data-placement="bottom"><a href="#" class="btn" data-toggle="modal" data-target="#optionsModal"><i class="fas fa-cog"></i>&nbsp;<span class="hidden-sm hidden-md">Settings</span></a></li>
++                    <!--
+                     <li title="check for netdata updates<br/>you should keep your netdata updated" data-toggle="tooltip" data-placement="bottom" class="hidden-sm" id="updateButton"><a href="#" class="btn" data-toggle="modal" data-target="#updateModal"><i class="fas fa-cloud-download-alt"></i> <span class="hidden-sm hidden-md">Update </span><span id="update_badge" class="badge"></span></a></li>
++                    -->
++                    <!--
+                     <li title="the netdata wiki home at github<br/>remember to <b>give netdata a <i class=&quot;fas fa-star&quot;></i></b> !" data-toggle="tooltip" data-placement="bottom" class="hidden-xs hidden-sm hidden-md"><a href="https://github.com/netdata/netdata" class="btn" target="_blank"><i class="fab fa-github"></i></a></li>
+                     <li title="follow netdata on twitter" data-toggle="tooltip" data-placement="bottom" class="hidden-xs hidden-sm hidden-md"><a href="https://twitter.com/linuxnetdata" class="btn" target="_blank"><i class="fab fa-twitter"></i></a></li>
+                     <li title="like netdata on facebook" data-toggle="tooltip" data-placement="bottom" class="hidden-xs hidden-sm hidden-md"><a href="https://www.facebook.com/linuxnetdata/" class="btn" target="_blank"><i class="fab fa-facebook"></i></a></li>
++                    -->
+                     <li title="import / load a netdata snapshot" data-toggle="tooltip" data-placement="bottom" id="loadButton"><a href="#" class="btn" data-toggle="modal" data-target="#loadSnapshotModal"><i class="fas fa-download"></i>&nbsp;<span class="hidden-sm hidden-md hidden-lg">Import</span></a></li>
+                     <li title="export / save a netdata snapshot" data-toggle="tooltip" data-placement="bottom" id="saveButton"><a href="#" class="btn" data-toggle="modal" data-target="#saveSnapshotModal"><i class="fas fa-upload"></i>&nbsp;<span class="hidden-sm hidden-md hidden-lg">Export</span></a></li>
+                     <li title="print this dashboard to PDF" data-toggle="tooltip" data-placement="bottom" id="printButton"><a href="#" class="btn" data-toggle="modal" data-target="#printPreflightModal"><i class="fas fa-print"></i>&nbsp;<span class="hidden-sm hidden-md hidden-lg">Print</span></a></li>


### PR DESCRIPTION
Maintainer: myself and @BKPepe 
Compile tested: ipq40xx, Linksys EA6350v3, OpenWrt master
Run tested: ipq40xx, Linksys EA6350v3, OpenWrt master

Description:
Update netdata to 1.22.1
Disable cloud functionality
Shoehorn patches from FreeBSD's ports repo
Remove cloud notifications and netdata's self-update feature
json-c is no longer optional

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>