### PR TITLE
RFC/T miniupnpd: improve hotplug & interface handling

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.1.20191006
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/miniupnpd/files/miniupnpd.hotplug
+++ b/net/miniupnpd/files/miniupnpd.hotplug
@@ -12,18 +12,35 @@
 [ "$ACTION" != "ifup" ] && procd_running "miniupnpd" "*" && exit 0
 
 tmpconf="/var/etc/miniupnpd.conf"
-extiface=$(uci get upnpd.config.external_iface)
-extzone=$(uci get upnpd.config.external_zone)
+external_iface=$(uci get upnpd.config.external_iface)
+external_iface6=$(uci get upnpd.config.external_iface6)
+external_zone=$(uci get upnpd.config.external_zone)
 
 . /lib/functions/network.sh
 
-[ -z "$extiface" ] && {
-  # manual external zone (if dynamically find interfaces
-  # belonging to it) overrides network_find_wan*
-  [ -n "$extzone"  ] && ifname=$(fw3 -q zone "$extzone" | head -1)
-  [ -z "$extiface" ] && network_find_wan extiface
-  [ -z "$extiface" ] && network_find_wan6 extiface
-}
+if [ -n "$external_iface" ] ; then
+	network_get_device ifname "$external_iface"
+else
+	if [ -n "$external_zone" ] ; then
+		ifname=$(fw3 -q zone "$external_zone" 2>/dev/null | head -1)
+	else
+		network_find_wan external_iface && \
+			network_get_device ifname "$external_iface"
+	fi
+fi
+if [ -n "$external_iface6" ] ; then
+	network_get_device ifname6 "$external_iface6"
+else
+	if [ -n "$external_zone" ] ; then
+		ifname6=$(fw3 -q zone "$external_zone" 2>/dev/null | head -1)
+	else
+		network_find_wan6 external_iface6 && \
+			network_get_device ifname6 "$external_iface6"
+	fi
+fi
 
-[ -z "$ifname" ] && network_get_device ifname "$extiface"
-grep -q "ext_ifname=$ifname" "$tmpconf" || /etc/init.d/miniupnpd restart
+[ "$DEVICE" != "$ifname" ] && [ "$DEVICE" != "$ifname6" ] && exit 0
+
+grep -q "^ext_ifname=$ifname" "$tmpconf" && grep -q "^ext_ifname6=$ifname6" "$tmpconf" && exit 0
+
+/etc/init.d/miniupnpd restart

--- a/net/miniupnpd/files/miniupnpd.init
+++ b/net/miniupnpd/files/miniupnpd.init
@@ -67,6 +67,7 @@ upnpd() {
 	[ "$enabled" -eq 0 ] && return 1
 
 	config_get external_iface config external_iface
+	config_get external_iface6 config external_iface6
 	config_get external_zone config external_zone
 	config_get external_ip config external_ip
 	config_get internal_iface config internal_iface
@@ -91,17 +92,26 @@ upnpd() {
 
 	. /lib/functions/network.sh
 
-	# manual external interface overrides everything
-	[ -z "$external_iface" ] && {
-		# manual external zone (if dynamically find interfaces
-		# belonging to it) overrides network_find_wan*
-		[ -n "$external_zone" ] && ifname=$(fw3 -q zone "$external_zone" | head -1)
-		[ -z "$external_iface" ] && network_find_wan external_iface
-		[ -z "$external_iface6" ] && network_find_wan6 external_iface6
-	}
-
-	[ -z "$ifname" ] && network_get_device ifname "$external_iface"
-	[ -z "$ifname6" ] && network_get_device ifname6 "$external_iface6"
+	if [ -n "$external_iface" ] ; then
+		network_get_device ifname "$external_iface"
+	else
+		if [ -n "$external_zone" ] ; then
+			ifname=$(fw3 -q zone "$external_zone" 2>/dev/null | head -1)
+		else
+			network_find_wan external_iface && \
+				network_get_device ifname "$external_iface"
+		fi
+	fi
+	if [ -n "$external_iface6" ] ; then
+		network_get_device ifname6 "$external_iface6"
+	else
+		if [ -n "$external_zone" ] ; then
+			ifname6=$(fw3 -q zone "$external_zone" 2>/dev/null | head -1)
+		else
+			network_find_wan6 external_iface6 && \
+				network_get_device ifname6 "$external_iface6"
+		fi
+	fi
 
 	if [ -n "$config_file" ]; then
 		conf="$config_file"


### PR DESCRIPTION
The existing interface selection/detection code was convoluted and
incomprehensible at best.  The uci config file suggested it understood
an external ipv6 interface but in reality the init script took no
notice.  Re-work it so it is at least comprehendible and takes notice of
ipv6 interface details if specified.

Update the hotplug script to use the same interface selection/detection
code as the init script and take note of ipv6 interface selection, only
restarting miniupnpd on interface up events and only if that interface
isn't already known (for that ip class) by miniupnpd.

For me this has solved numerous 'flaky' startup problems, especially
with regards to ipv6.

It needs more real world testing.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
