### PR TITLE
vim: Do not make autowrite default

### DIFF
--- a/utils/vim/files/vimrc
+++ b/utils/vim/files/vimrc
@@ -1,7 +1,7 @@
 set showcmd			" show (partial) command in status line
 set showmatch		" show matching brackets
 set incsearch		" incremental search
-set autowrite		" automatically save before commands like :next and :make
+"set autowrite		" automatically save before commands like :next and :make
 set nocompatible	" use vim defaults instead of 100% vi compatibility
 set backspace=indent,eol,start	" more powerful backspacing
 set autoindent		" always set autoindenting on

--- a/utils/vim/files/vimrc.full
+++ b/utils/vim/files/vimrc.full
@@ -1,7 +1,7 @@
 set showcmd			" show (partial) command in status line
 set showmatch			" show matching brackets
 set incsearch			" incremental search
-set autowrite			" automatically save before commands like :next and :make
+"set autowrite			" automatically save before commands like :next and :make
 set nocompatible		" use Vim defaults instead of 100% vi compatibility
 set backspace=indent,eol,start	" more powerful backspacing
 set autoindent			" always set autoindenting on


### PR DESCRIPTION
Making autowrite the default is dangerous. Moving around multiple files
or sending vim to the background will make vim silently write all open
files. While this can be a great developer feature it's likely a very bad
idea for a sysadmin editing critical config files.

Maintainer: Marko Ratkaj <marko.ratkaj@sartura.hr>
Compile tested: N/A - Config file
Run tested: VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Jul 21 2018 08:08:45)