### PR TITLE
apache: tighten log dir + suEXEC

### DIFF
--- a/net/apache/Makefile
+++ b/net/apache/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apache
 PKG_VERSION:=2.4.43
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE_NAME:=httpd
 
 PKG_SOURCE:=$(PKG_SOURCE_NAME)-$(PKG_VERSION).tar.bz2
@@ -246,12 +246,9 @@ endif
 ifneq ($(CONFIG_PACKAGE_apache-mod-suexec)$(CONFIG_PACKAGE_apache-suexec),)
 CONFIGURE_ARGS+= \
 	--enable-suexec \
-	--with-suexec-bin=/usr/sbin/suexec \
+	--with-suexec-bin=/usr/lib/apache2/suexec_dir/suexec \
 	--with-suexec-caller=apache \
-	--with-suexec-docroot=/var/www \
-	--with-suexec-logfile=/var/log/apache2/suexec.log \
-	--with-suexec-uidmin=99 \
-	--with-suexec-gidmin=99
+	--with-suexec-logfile=/var/log/apache2/suexec.log
 else
 CONFIGURE_ARGS+= \
 	--disable-suexec
@@ -331,8 +328,9 @@ define Package/apache-icons/install
 endef
 
 define Package/apache-suexec/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/suexec $(1)/usr/sbin
+	$(INSTALL_DIR) -m0750 $(1)/usr/lib/apache2/suexec_dir
+	$(INSTALL_SUID) $(PKG_INSTALL_DIR)/usr/sbin/suexec \
+			$(1)/usr/lib/apache2/suexec_dir
 endef
 
 define Package/apache-utils/install
@@ -340,6 +338,22 @@ define Package/apache-utils/install
 	$(INSTALL_BIN) \
 		$(PKG_INSTALL_DIR)/usr/sbin/{checkgid,envvars*,htcacheclean,rotatelogs} \
 									$(1)/usr/sbin
+endef
+
+# Directory "suexec_dir" is installed with '-m0750' above and contains
+# SUID binary "suexec". Below post-install script changes the group of
+# "suexec_dir" to apache, so user apache can access the folder (and the
+# SUID binary). The script only changes the group if the directory is
+# currently owned by "root:root".
+define Package/apache-suexec/postinst
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+  dir="/usr/lib/apache2/suexec_dir"
+  if ! [ -L "$$dir" ] && [ -d "$$dir" ] && [ -O "$$dir" ] && [ -G "$$dir" ]; then
+    chown :apache "$$dir"
+  fi
+fi
+exit 0
 endef
 
 define Package/apache/Module

--- a/net/apache/files/apache2.init
+++ b/net/apache/files/apache2.init
@@ -11,7 +11,8 @@ restart() {
 }
 
 start() {
-	mkdir -p /var/log/apache2 /var/run/apache2
+	mkdir -p -m 0750 /var/log/apache2
+	mkdir -p /var/run/apache2
 	apachectl -k start
 }
 


### PR DESCRIPTION
Maintainer: @heil & me
Compile tested: ath79 master
Run tested: ath79 19.07, checked that logging works fine, checked suexec binary is installed properly, ran suexec, also tried running as other users than apache (failed -> OK), checked suexec log.

Description:
Hi all,

The log dir change is straight-forward. The suexec changes are a bit more involved. My reasoning for them is in the commit message. Feedback welcome :)

Kind regards,
Seb