### PR TITLE
nginx: set log level to crit for luci-static

### DIFF
--- a/net/nginx/Makefile
+++ b/net/nginx/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nginx
 PKG_VERSION:=1.17.10
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=nginx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nginx.org/download/

--- a/net/nginx/files-luci-support/luci.locations
+++ b/net/nginx/files-luci-support/luci.locations
@@ -13,4 +13,5 @@ location ~ /cgi-bin/cgi-(backup|download|upload|exec) {
 }
 
 location /luci-static {
+		error_log stderr crit;
 }


### PR DESCRIPTION
Maintainer: @Ansuel
Compile tested: x86_64, x86_64 qemu, master
Run tested: x86_64, x86_64 qemu, master, run luci-nginx

Description: Do not write errors for inexistent files to the system log (workaround for #12176).
