### PR TITLE
nss: revert -flto change

### DIFF
--- a/libs/nss/Makefile
+++ b/libs/nss/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nss
 PKG_VERSION:=3.52
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -62,7 +62,6 @@ ifeq ($(CONFIG_CPU_TYPE),"xscale")
 TARGET_CFLAGS+= -mfloat-abi=softfp
 endif
 
-TARGET_CFLAGS += -D_GNU_SOURCE -flto
 export NATIVE_CC=$(HOSTCC)
 export NATIVE_FLAGS=$(HOST_CFLAGS)
 


### PR DESCRIPTION
it seems that it can lead to segfault in libfreebl3.so

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Maintainer: me 
Tested x86