### PR TITLE
golang: Update to 1.14.3

### DIFF
--- a/lang/golang/golang/Makefile
+++ b/lang/golang/golang/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 GO_VERSION_MAJOR_MINOR:=1.14
-GO_VERSION_PATCH:=2
+GO_VERSION_PATCH:=3
 
 PKG_NAME:=golang
 PKG_VERSION:=$(GO_VERSION_MAJOR_MINOR)$(if $(GO_VERSION_PATCH),.$(GO_VERSION_PATCH))
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 
 GO_SOURCE_URLS:=https://dl.google.com/go/ \
                 https://mirrors.ustc.edu.cn/golang/ \
@@ -20,7 +20,7 @@ GO_SOURCE_URLS:=https://dl.google.com/go/ \
 
 PKG_SOURCE:=go$(PKG_VERSION).src.tar.gz
 PKG_SOURCE_URL:=$(GO_SOURCE_URLS)
-PKG_HASH:=98de84e69726a66da7b4e58eac41b99cbe274d7e8906eeb8a5b7eb0aadee7f7c
+PKG_HASH:=93023778d4d1797b7bc6a53e86c3a9b150c923953225f8a48a2d5fabc971af56
 
 PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
@@ -330,10 +330,8 @@ define Build/Compile
 		PATH=$(HOST_GO_ROOT)/openwrt:$$$$PATH \
 	)
 
-  ifneq ($(PKG_GO_ZBOOTSTRAP_MODS),)
 	$(SED) '$(PKG_GO_ZBOOTSTRAP_MODS)' \
 		$(PKG_BUILD_DIR)/src/cmd/internal/objabi/zbootstrap.go
-  endif
 
 	@echo "Building target Go second stage"
 


### PR DESCRIPTION
Maintainer: me
Compile tested: armvirt-32, 2020-05-13 snapshot sdk
Run tested: none

Description:
This also removes a (useless) test for `PKG_GO_ZBOOTSTRAP_MODS` (it is always non-empty).

Signed-off-by: Jeffery To <jeffery.to@gmail.com>