### PR TITLE
libwebp: fix compilation under ARM without NEON

### DIFF
--- a/libs/libwebp/Makefile
+++ b/libs/libwebp/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libwebp
 PKG_VERSION:=1.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://storage.googleapis.com/downloads.webmproject.org/releases/webp
@@ -40,6 +40,12 @@ CMAKE_OPTIONS += \
 	-DWEBP_BUILD_WEBPINFO=OFF \
 	-DWEBP_BUILD_WEBPMUX=OFF \
 	-DWEBP_BUILD_EXTRAS=OFF
+
+ifneq ($(findstring arm,$(CONFIG_ARCH)),)
+ifeq ($(findstring neon,$(CONFIG_CPU_TYPE)),)
+CMAKE_OPTIONS += -DWEBP_ENABLE_SIMD=OFF
+endif
+endif
 
 TARGET_CFLAGS += -flto
 


### PR DESCRIPTION
The CMake logic seems broken. Luckily it's easy to work around.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: mvebu

Fixes: https://github.com/openwrt/packages/issues/12189