### PR TITLE
syslog-ng: update to version 3.27.1

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
-PKG_VERSION:=3.26.1
-PKG_RELEASE:=2
+PKG_VERSION:=3.27.1
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
@@ -11,7 +11,7 @@ PKG_CPE_ID:=cpe:/a:balabit:syslog-ng
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syslog-ng/syslog-ng/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
-PKG_HASH:=90214223864df252cea80dbb35c88a2464edcbbb2c9fbc6f6f6c13ee60cb62cd
+PKG_HASH:=c54c633c97f7fd8dd68261cfd784a76211e6e52965178e3aa4d0e32b899d61b3
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -48,7 +48,7 @@ define Build/Configure
 endef
 
 CONFIGURE_ARGS +=  \
-	--disable-snmp-dest \
+	--disable-afsnmp \
 	$(call autoconf_bool,CONFIG_IPV6,ipv6) \
 	--disable-tcp-wrapper \
 	--disable-spoof-source \


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master + OpenWrt 19.07
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master + OpenWrt 19.07.

Description:
- Update to version [3.27.1](https://github.com/syslog-ng/syslog-ng/releases/tag/syslog-ng-3.27.1)
- snmp-dest was moved to afsnmp