### PR TITLE
ddns-scripts: Remove afraid.org-v2-token.

### DIFF
--- a/net/ddns-scripts/files/services
+++ b/net/ddns-scripts/files/services
@@ -46,7 +46,7 @@
 "afraid.org-basicauth"	"https://[USERNAME]:[PASSWORD]@freedns.afraid.org/nic/update?hostname=[DOMAIN]&myip=[IP]"
 "afraid.org-keyauth"	"https://freedns.afraid.org/dynamic/update.php?[PASSWORD]&address=[IP]"
 "afraid.org-v2-basic"	"https://[USERNAME]:[PASSWORD]@sync.afraid.org/u/?h=[DOMAIN]&ip=[IP]"
-"afraid.org-v2-token"	"https://sync.afraid.org/u/[PASSWORD]/?address=[IP]"
+# remove.bad uri getting 404. "afraid.org-v2-token"	"https://sync.afraid.org/u/[PASSWORD]/?address=[IP]"
 
 "all-inkl.com"		"http://[USERNAME]:[PASSWORD]@dyndns.kasserver.com/?myip=[IP]"
 


### PR DESCRIPTION
ddns-scripts: Remove afraid.org-v2-token. Wrong uri format, resulting in 404.
signed-off-by:  You Xiaojie / 尤晓杰 <yxj790222@163.com>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
