### PR TITLE
python-crypto: fix time.clock in python-crypto

### DIFF
--- a/lang/python/python-crypto/patches/990-fix-clock-in-time-error
+++ b/lang/python/python-crypto/patches/990-fix-clock-in-time-error
@@ -1,0 +1,13 @@
+--- a/lib/Crypto/Random/_UserFriendlyRNG.py
++++ b/lib/Crypto/Random/_UserFriendlyRNG.py
+@@ -73,8 +73,8 @@ class _EntropyCollector(object):
+         t = time.time()
+         self._time_es.feed(struct.pack("@I", int(2**30 * (t - floor(t)))))
+ 
+-        # Add the fractional part of time.clock()
+-        t = time.clock()
++        # Add the fractional part of time.perf_counter()
++        t = time.perf_counter()
+         self._clock_es.feed(struct.pack("@I", int(2**30 * (t - floor(t)))))
+ 
+ 


### PR DESCRIPTION
This fixes the following python3 error:

  File "/__init__.py", line 41, in get_random_bytes
  File "/_UserFriendlyRNG.py", line 228, in get_random_bytes
  File "/_UserFriendlyRNG.py", line 178, in read
  File "/_UserFriendlyRNG.py", line 129, in read
  File "/_UserFriendlyRNG.py", line 77, in collect
AttributeError: module 'time' has no attribute 'clock'

Signed-off-by: Michael Braun <michael-dev@fami-braun.de>

This has been cherry-picked from a private branch based on 02640f014719a994e2e538b2cb6376a189cd39de. This is running on P1020WLAN (powerpc).


