### PR TITLE
netsniff-ng: new package

### DIFF
--- a/net/netsniff-ng/Makefile
+++ b/net/netsniff-ng/Makefile
@@ -1,0 +1,69 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=netsniff-ng
+PKG_VERSION:=0.6.7
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/netsniff-ng/netsniff-ng/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=030b0554206b43c5883e48a63575fb65d7835e275333372f55f7d615d419da05
+
+PKG_MAINTAINER:=Toni Uhlig <matzeton@googlemail.com>
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+PKG_USE_MIPS16:=0
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/netsniff-ng
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libpthread +libpcap +libncurses +zlib +liburcu +libsodium +libnetfilter-conntrack
+  TITLE:=netsniff-ng
+  URL:=https://github.com/netsniff-ng/netsniff-ng
+endef
+
+define Package/netsniff-ng/description
+	netsniff-ng is a free, performant Linux network analyzer and
+	networking toolkit. If you will, the Swiss army knife for network
+	packets.
+endef
+
+define Build/Configure
+	( cd $(PKG_BUILD_DIR); \
+	  CC="$(TARGET_CC)" \
+	  LD="$(TARGET_LD)" \
+	  CFLAGS="$(TARGET_CFLAGS)" \
+	  LDFLAGS="$(TARGET_LDFLAGS)" \
+	  CROSS_COMPILE="$(REAL_GNU_TARGET_NAME)-" \
+	  ./configure --prefix=/usr --disable-geoip --disable-libnl )
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) Q= \
+	  CC="$(TARGET_CC)" \
+	  LD="$(TARGET_LD)" \
+	  CFLAGS="$(TARGET_CFLAGS)" \
+	  LDFLAGS="$(TARGET_LDFLAGS)" \
+	  CROSS_COMPILE="$(REAL_GNU_TARGET_NAME)-"
+endef
+
+define Package/netsniff-ng/install
+	$(INSTALL_DIR) $(1)/etc/netsniff-ng
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_BUILD_DIR)/ether.conf $(1)/etc/netsniff-ng
+	$(CP) $(PKG_BUILD_DIR)/tcp.conf $(1)/etc/netsniff-ng
+	$(CP) $(PKG_BUILD_DIR)/udp.conf $(1)/etc/netsniff-ng
+	$(CP) $(PKG_BUILD_DIR)/oui.conf $(1)/etc/netsniff-ng
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/netsniff-ng/netsniff-ng $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/trafgen/trafgen $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/astraceroute/astraceroute $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/flowtop/flowtop $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ifpps/ifpps $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bpfc/bpfc $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/curvetun/curvetun $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,netsniff-ng))

--- a/net/netsniff-ng/patches/0001-configure-script-honors-C-LD-FLAGS.patch
+++ b/net/netsniff-ng/patches/0001-configure-script-honors-C-LD-FLAGS.patch
@@ -1,0 +1,154 @@
+From 9da66f0925818ddb12127bfcb46acf79e354cabc Mon Sep 17 00:00:00 2001
+From: Toni Uhlig <matzeton@googlemail.com>
+Date: Mon, 18 May 2020 11:36:56 +0200
+Subject: [PATCH] configure script honors (C|LD)FLAGS
+
+Signed-off-by: Toni Uhlig <matzeton@googlemail.com>
+---
+ configure | 32 ++++++++++++++++----------------
+ 1 file changed, 16 insertions(+), 16 deletions(-)
+
+diff --git a/configure b/configure
+index 510826a..ceda000 100755
+--- a/configure
++++ b/configure
+@@ -221,8 +221,8 @@ EOF
+ 		NACL_LIB="nacl"
+ 	fi
+ 
+-	LDFLAGS="-L $NACL_LIB_DIR"
+-	CFLAGS="-I $NACL_INC_DIR"
++	LDFLAGS="$LDFLAGS -L $NACL_LIB_DIR"
++	CFLAGS="$CFLAGS -I $NACL_INC_DIR"
+ 
+ 	$CC $CFLAGS $LDFLAGS -o $TMPDIR/nacltest $TMPDIR/nacltest.c >> config.log 2>&1
+ 	if [ ! -x $TMPDIR/nacltest ] ; then
+@@ -268,7 +268,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC \
++	$CC $CFLAGS $LDFLAGS \
+ 		$($PKG_CONFIG --cflags libnl-3.0 2>> config.log) \
+ 		$($PKG_CONFIG --cflags libnl-genl-3.0 2>> config.log) \
+ 		-o $TMPDIR/libnltest \
+@@ -315,7 +315,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC \
++	$CC $CFLAGS $LDFLAGS \
+ 		$($PKG_CONFIG --cflags libnl-route-3.0 2>> config.log) \
+ 		-o $TMPDIR/libnlroutetest \
+ 		$TMPDIR/libnlroutetest.c \
+@@ -350,7 +350,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC -o $TMPDIR/tpacketv3test $TMPDIR/tpacketv3test.c >> config.log 2>&1
++	$CC $CFLAGS $LDFLAGS -o $TMPDIR/tpacketv3test $TMPDIR/tpacketv3test.c >> config.log 2>&1
+ 	if [ ! -x $TMPDIR/tpacketv3test ] ; then
+ 		echo "[NO]"
+ 		MISSING_DEFS=1
+@@ -383,7 +383,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC -o $TMPDIR/tpacketv2test $TMPDIR/tpacketv2test.c >> config.log 2>&1
++	$CC $CFLAGS $LDFLAGS -o $TMPDIR/tpacketv2test $TMPDIR/tpacketv2test.c >> config.log 2>&1
+ 	if [ ! -x $TMPDIR/tpacketv2test ] ; then
+ 		echo "[NO]"
+ 		MISSING_DEFS=1
+@@ -410,7 +410,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC -o $TMPDIR/fopencookietest $TMPDIR/fopencookietest.c >> config.log 2>&1
++	$CC $CFLAGS $LDFLAGS -o $TMPDIR/fopencookietest $TMPDIR/fopencookietest.c >> config.log 2>&1
+ 	if [ ! -x $TMPDIR/fopencookietest ] ; then
+ 		echo "[NO]"
+ 		MISSING_DEFS=1
+@@ -433,7 +433,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC \
++	$CC $CFLAGS $LDFLAGS \
+ 		$($PKG_CONFIG --cflags ncurses 2>> config.log) \
+ 		-o $TMPDIR/ncursestest $TMPDIR/ncursestest.c \
+ 		$($PKG_CONFIG --libs ncurses 2>> config.log \
+@@ -476,7 +476,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC -o $TMPDIR/geoiptest $TMPDIR/geoiptest.c -lGeoIP >> config.log 2>&1
++	$CC $CFLAGS $LDFLAGS -o $TMPDIR/geoiptest $TMPDIR/geoiptest.c -lGeoIP >> config.log 2>&1
+ 	if [ ! -x $TMPDIR/geoiptest ] ; then
+ 		echo "[NO]"
+ 		MISSING_DEFS=1
+@@ -503,7 +503,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC \
++	$CC $CFLAGS $LDFLAGS \
+ 		$($PKG_CONFIG --cflags libnetfilter_conntrack 2>> config.log) \
+ 		-o $TMPDIR/nfcttest \
+ 		$TMPDIR/nfcttest.c \
+@@ -536,7 +536,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC -o $TMPDIR/ztest $TMPDIR/ztest.c -lz >> config.log 2>&1
++	$CC $CFLAGS $LDFLAGS -o $TMPDIR/ztest $TMPDIR/ztest.c -lz >> config.log 2>&1
+ 	if [ ! -x $TMPDIR/ztest ] ; then
+ 		echo "[NO]"
+ 		echo "CONFIG_LIBZ=0" >> Config
+@@ -564,7 +564,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC -o $TMPDIR/urcutest $TMPDIR/urcutest.c -lurcu >> config.log 2>&1
++	$CC $CFLAGS $LDFLAGS -o $TMPDIR/urcutest $TMPDIR/urcutest.c -lurcu >> config.log 2>&1
+ 	if [ ! -x $TMPDIR/urcutest ] ; then
+ 		echo "[NO]"
+ 		MISSING_DEFS=1
+@@ -588,7 +588,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC -o $TMPDIR/pcaptest $TMPDIR/pcaptest.c -lpcap >> config.log 2>&1
++	$CC $CFLAGS $LDFLAGS -o $TMPDIR/pcaptest $TMPDIR/pcaptest.c -lpcap >> config.log 2>&1
+ 	if [ ! -x $TMPDIR/pcaptest ] ; then
+ 		echo "[NO]"
+ 		echo "CONFIG_LIBPCAP=0" >> Config
+@@ -638,7 +638,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC -o $TMPDIR/hwtstest $TMPDIR/hwtstest.c >> config.log 2>&1
++	$CC $CFLAGS $LDFLAGS -o $TMPDIR/hwtstest $TMPDIR/hwtstest.c >> config.log 2>&1
+ 	if [ ! -x $TMPDIR/hwtstest ] ; then
+ 		echo "[NO]"
+ 		echo "CONFIG_HWTSTAMP=0" >> Config
+@@ -663,7 +663,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC -o $TMPDIR/clitest $TMPDIR/clitest.c -lcli >> config.log 2>&1
++	$CC $CFLAGS $LDFLAGS -o $TMPDIR/clitest $TMPDIR/clitest.c -lcli >> config.log 2>&1
+ 	if [ ! -x $TMPDIR/clitest ] ; then
+ 		echo "[NO]"
+ 		MISSING_DEFS=1
+@@ -687,7 +687,7 @@ int main(void)
+ }
+ EOF
+ 
+-	$CC -o $TMPDIR/nettest $TMPDIR/nettest.c -lnet >> config.log 2>&1
++	$CC $CFLAGS $LDFLAGS -o $TMPDIR/nettest $TMPDIR/nettest.c -lnet >> config.log 2>&1
+ 	if [ ! -x $TMPDIR/nettest ] ; then
+ 		echo "[NO]"
+ 		MISSING_DEFS=1
+-- 
+2.20.1
+

--- a/net/netsniff-ng/patches/0002-fix-ncurses-check-during-configure.patch
+++ b/net/netsniff-ng/patches/0002-fix-ncurses-check-during-configure.patch
@@ -1,0 +1,30 @@
+From 505dde6ac50689ec2ba50a1f0087eb8a9ff1f419 Mon Sep 17 00:00:00 2001
+From: Toni Uhlig <matzeton@googlemail.com>
+Date: Mon, 18 May 2020 20:12:17 +0200
+Subject: [PATCH] fix ncurses check during configure
+
+Signed-off-by: Toni Uhlig <matzeton@googlemail.com>
+---
+ configure | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/configure b/configure
+index ceda000..f843d64 100755
+--- a/configure
++++ b/configure
+@@ -434,11 +434,8 @@ int main(void)
+ EOF
+ 
+ 	$CC $CFLAGS $LDFLAGS \
+-		$($PKG_CONFIG --cflags ncurses 2>> config.log) \
+ 		-o $TMPDIR/ncursestest $TMPDIR/ncursestest.c \
+-		$($PKG_CONFIG --libs ncurses 2>> config.log \
+-	          || echo '-lncurses' ) \
+-			>> config.log 2>&1
++		-lncurses 2>> config.log
+ 	if [ ! -x $TMPDIR/ncursestest ] ; then
+ 		echo "[NO]"
+ 		MISSING_DEFS=1
+-- 
+2.20.1
+

--- a/net/netsniff-ng/patches/0003-removed-flowtop-pkg-config-usage-for-ncurses.patch
+++ b/net/netsniff-ng/patches/0003-removed-flowtop-pkg-config-usage-for-ncurses.patch
@@ -1,0 +1,36 @@
+From 0f1653c82a06567ccb151e17f1fe3ff3c3b465f3 Mon Sep 17 00:00:00 2001
+From: Toni Uhlig <matzeton@googlemail.com>
+Date: Mon, 18 May 2020 20:27:32 +0200
+Subject: [PATCH] removed flowtop pkg-config usage for ncurses
+
+Signed-off-by: Toni Uhlig <matzeton@googlemail.com>
+---
+ flowtop/Makefile | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/flowtop/Makefile b/flowtop/Makefile
+index e001ce8..aeee049 100644
+--- a/flowtop/Makefile
++++ b/flowtop/Makefile
+@@ -1,7 +1,6 @@
+ flowtop-libs =	-lurcu \
+ 		$(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --libs libnetfilter_conntrack 2> /dev/null ) \
+-		$(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --libs ncurses 2> /dev/null \
+-			|| echo '-lncurses') \
++		-lncurses \
+ 		$(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --libs tinfo 2> /dev/null ) \
+ 		-lpthread
+ 
+@@ -30,8 +29,7 @@ flowtop-objs +=	geoip.o \
+ 		ioops.o
+ endif
+ 
+-flowtop-eflags = $(shell $(PKG_CONFIG) --cflags ncurses) \
+-                 $(shell $(PKG_CONFIG) --cflags libnetfilter_conntrack)
++flowtop-eflags = $(shell $(PKG_CONFIG) --cflags libnetfilter_conntrack)
+ 
+ flowtop-confs =	tcp.conf \
+ 		udp.conf \
+-- 
+2.20.1
+


### PR DESCRIPTION
Signed-off-by: Toni Uhlig <matzeton@googlemail.com>

Maintainer: me
Compile tested: x86_64, debian-stable, OpenWrt SNAPSHOT r13247+9-631c437a91
Run tested: mvebu, linksys3200ac, OpenWrt SNAPSHOT r13247+9-631c437a91

Description:
netsniff-ng contains several interesting networking tools especially flowtop and netsniff-ng.
However, the self-written configure and Makefile is somehow broken, so some additional patchwork was necessary.