### PR TITLE
django-postoffice: bump to version 3.4.1

### DIFF
--- a/lang/python/django-postoffice/Makefile
+++ b/lang/python/django-postoffice/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=django-postoffice
-PKG_VERSION:=3.2.1
-PKG_RELEASE:=2
+PKG_VERSION:=3.4.1
+PKG_RELEASE:=1
 
 PYPI_NAME:=django-post-office
 PYPI_SOURCE_NAME:=django-post_office
-PKG_HASH:=e32427822f647719575094f790ca949ef9f9827ec0e8378cb021f01f3834b2a4
+PKG_HASH:=f45aadb08c4c2e7d6fa558c2f17a6b70dc81e10241b7d0ffe25524a15e67d763
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: https://github.com/openwrt/openwrt/commit/4a61a88f9006f70444e00699f76551c75f73c14e x86
Run tested: https://github.com/openwrt/openwrt/commit/4a61a88f9006f70444e00699f76551c75f73c14e x86

----------------------------------

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>