### PR TITLE
measurement-kit: Add static build dependencies

### DIFF
--- a/libs/measurement-kit/Makefile
+++ b/libs/measurement-kit/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=measurement-kit
 PKG_VERSION:=0.10.11
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/measurement-kit/measurement-kit/tar.gz/v$(PKG_VERSION)?
@@ -21,7 +21,10 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
+PKG_BUILD_DEPENDS:=curl libevent2 libmaxminddb openssl
 PKG_BUILD_PARALLEL:=1
+
+PKG_CONFIG_DEPENDS:=MEASUREMENT_KIT_BUILD_DEPENDS
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -30,11 +33,23 @@ define Package/measurement-kit
   CATEGORY:=Libraries
   TITLE:=library for open network measurement
   URL:=https://measurement-kit.github.io/
-  DEPENDS:=+libstdcpp +libcurl +libevent2-pthreads +libevent2-extra +libevent2-openssl +libevent2-core +libmaxminddb +ca-bundle
+  DEPENDS:=+libstdcpp +libcurl +libevent2-pthreads +libevent2-extra +libevent2-openssl +libevent2-core +libmaxminddb +libopenssl +ca-bundle
 endef
 
 define Package/measurement-kit/description
  Measurement Kit is a C++14 library that implements open network measurement methodologies (performance, censorship, etc.)
+endef
+
+define Package/measurement-kit/config
+config MEASUREMENT_KIT_BUILD_DEPENDS
+	bool
+	default PACKAGE_measurement-kit
+
+config MEASUREMENT_KIT_BUILD_SELECT
+	tristate
+	default m if MEASUREMENT_KIT_BUILD_DEPENDS
+	select PACKAGE_libevent2-openssl
+	select PACKAGE_libevent2-pthreads
 endef
 
 CONFIGURE_ARGS+= --with-ca-bundle=/etc/ssl/cert.pem


### PR DESCRIPTION
Maintainer: @ja-pa 
Compile tested: armvirt-64, 2020-05-17 snapshot sdk
Run tested: none

Description:
When measurement-kit is a build dependency (in `PKG_BUILD_DEPENDS`) of another package, this package's build dependencies (in `DEPENDS`) may not be selected and so may not be built.

(This package does not produce a shared library; the `measurement-kit` target package contains a program that is statically linked to the measurement-kit library. Other packages may include `measurement-kit` in their `PKG_BUILD_DEPENDS` to link to the static library but not include `measurement-kit` as a run-time dependency.)

This adds `PKG_BUILD_DEPENDS` to this package to ensure that its dependencies are built in this case.

This also adds `MEASUREMENT_KIT_BUILD_DEPENDS` that dependant packages should select to ensure that this package's dependencies are correctly built. (`libevent2-openssl` and `libevent2-pthreads` need to be selected for the necessary functionality to be enabled when compiling libevent2.)

This also adds `openssl` as an explicit dependency; it appears to be used directly by this package.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>