### PR TITLE
[18.06] unbound: update to version 1.10.1

### DIFF
--- a/net/unbound/Makefile
+++ b/net/unbound/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=unbound
-PKG_VERSION:=1.10.0
+PKG_VERSION:=1.10.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://nlnetlabs.nl/downloads/unbound
-PKG_HASH:=152f486578242fe5c36e89995d0440b78d64c05123990aae16246b7f776ce955
+PKG_HASH:=b73677c21a71cf92f15cc8cfe76a3d875e40f65b6150081c39620b286582d536
 
 PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: @EricLuehrsen 
Compile tested: Turris 1.1, powerpc_8540, OpenWrt 18.06
Run tested: N/A

Description:
Fixes:
CVE-2020-12662
CVE-2020-12663
