### PR TITLE
[19.07] bind: update to version 9.14.12 (security fix)

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.14.8
+PKG_VERSION:=9.14.12
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=e545aa75ced6695a9bf4b591606ef00260fb3c055c2865b299cfe0fe6eeea076
+PKG_HASH:=9c4de493bf7dfaa68b0273135369601d474175ab504ab572ffbb42a6db6ef4c8
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: Turris 1.1, p2020, OpenWrt 19.07
Run tested: Turris 1.1, p2020, OpenWrt 19.07

Description:
This mitigates vulnerability [NXNSAttack](http://www.nxnsattack.com/)
[CVE-2020-8616](https://kb.isc.org/docs/cve-2020-8616)
CVE-2020-8617
