### PR TITLE
bind: update to version 9.16.3

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.2
+PKG_VERSION:=9.16.3
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=d9e5b77cfca5ccad97f19cddc87128758ec15c16e6585000c6b2f84fc225993f
+PKG_HASH:=27ac6513de5f8d0db34b9f241da53baa15a14b2ad21338d0cde0826eaf564f7e
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: N/A, yet.

Description:
- Update to version [9.16.3](https://downloads.isc.org/isc/bind9/9.16.3/RELEASE-NOTES-bind-9.16.3.html)

This mitigates vulnerability [NXNSAttack](http://www.nxnsattack.com/)
[CVE-2020-8616](https://kb.isc.org/docs/cve-2020-8616)
CVE-2020-8617


