### PR TITLE
Fix ttyd link error on 19.07 using glibc:/lib/libdl.so.2: error addin…

### DIFF
--- a/utils/ttyd/Makefile
+++ b/utils/ttyd/Makefile
@@ -41,7 +41,7 @@ define Package/ttyd/conffiles
 /etc/config/ttyd
 endef
 
-TARGET_LDFLAGS += -ldl
+TARGET_LDFLAGS += $(if $(CONFIG_USE_GLIBC),-ldl)
 
 define Package/ttyd/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/utils/ttyd/Makefile
+++ b/utils/ttyd/Makefile
@@ -41,6 +41,8 @@ define Package/ttyd/conffiles
 /etc/config/ttyd
 endef
 
+TARGET_LDFLAGS += -ldl
+
 define Package/ttyd/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ttyd $(1)/usr/bin/


### PR DESCRIPTION
…g symbols: DSO missing from command line

Signed-off-by: Qin Guang <topeqin@gmail.com>

Maintainer: tsl0922@gmail.com
Compile tested: (arm bcm53xx and bcm2708, OpenWrt 19.07 master)
Run tested: (arm, bcm53xx, OpenWrt 19.07, tests done)

Description:
ttyd meet libdl.so.2: error adding symbols: DSO missing from command line
When compile bcm53xx ARM target no matter using openwrt default toolchain with glibc not musl or broadcom external toolchain both meet below link DSO error.
...... 
[ 16%] Building C object CMakeFiles/ttyd.dir/src/server.c.o
[ 33%] Building C object CMakeFiles/ttyd.dir/src/http.c.o
[ 50%] Building C object CMakeFiles/ttyd.dir/src/protocol.c.o
[ 66%] Building C object CMakeFiles/ttyd.dir/src/terminal.c.o
[ 83%] Building C object CMakeFiles/ttyd.dir/src/utils.c.o
[100%] Linking C executable ttyd
/home/eq936498/vanilla/openwrt/staging_dir/toolchain-arm_cortex-a9_gcc-8.4.0_glibc_eabi/lib/gcc/arm-openwrt-linux-gnueabi/8.4.0/../../../../arm-openwrt-linux-gnueabi/bin/ld: /home/eq936498/vanilla/openwrt/staging_dir/target-arm_cortex-a9_glibc_eabi/usr/lib/libwebsockets.a(unix-plugins.c.       o): undefined reference to symbol 'dlopen@@GLIBC_2.4'
/home/eq936498/vanilla/openwrt/staging_dir/toolchain-arm_cortex-a9_gcc-8.4.0_glibc_eabi/lib/gcc/arm-openwrt-linux-gnueabi/8.4.0/../../../../arm-openwrt-linux-gnueabi/bin/ld: /home/eq936498/vanilla/openwrt/staging_dir/toolchain-arm_cortex-a9_gcc-8.4.0_glibc_eabi/arm-openwrt-linux-gnueabi/bin/../../../toolchain-arm_cortex-a9_gcc-8.4.0_glibc_eabi/lib/libdl.so.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
CMakeFiles/ttyd.dir/build.make:170: recipe for target 'ttyd' failed
make[6]: *** [ttyd] Error 1
make[6]: Leaving directory '/home/eq936498/vanilla/openwrt/build_dir/target-arm_cortex-a9_glibc_eabi/ttyd-1.6.0'
CMakeFiles/Makefile2:92: recipe for target 'CMakeFiles/ttyd.dir/all' failed
make[5]: *** [CMakeFiles/ttyd.dir/all] Error 2
make[5]: Leaving directory '/home/eq936498/vanilla/openwrt/build_dir/target-arm_cortex-a9_glibc_eabi/ttyd-1.6.0'
Makefile:146: recipe for target 'all' failed
make[4]: *** [all] Error 2
make[4]: Leaving directory '/home/eq936498/vanilla/openwrt/build_dir/target-arm_cortex-a9_glibc_eabi/ttyd-1.6.0'
Makefile:53: recipe for target '/home/eq936498/vanilla/openwrt/build_dir/target-arm_cortex-a9_glibc_eabi/ttyd-1.6.0/.built' failed
make[3]: *** [/home/eq936498/vanilla/openwrt/build_dir/target-arm_cortex-a9_glibc_eabi/ttyd-1.6.0/.built] Error 2
make[3]: Leaving directory '/home/eq936498/vanilla/openwrt/feeds/packages/utils/ttyd'
time: package/feeds/packages/ttyd/compile#1.89#0.29#5.97
package/Makefile:111: recipe for target 'package/feeds/packages/ttyd/compile' failed
make[2]: *** [package/feeds/packages/ttyd/compile] Error 2
make[2]: Leaving directory '/home/eq936498/vanilla/openwrt'
package/Makefile:107: recipe for target '/home/eq936498/vanilla/openwrt/staging_dir/target-arm_cortex-a9_glibc_eabi/stamp/.package_compile' fail       ed
make[1]: *** [/home/eq936498/vanilla/openwrt/staging_dir/target-arm_cortex-a9_glibc_eabi/stamp/.package_compile] Error 2
make[1]: Leaving directory '/home/eq936498/vanilla/openwrt'
/home/eq936498/vanilla/openwrt/include/toplevel.mk:218: recipe for target 'world' failed
make: *** [world] Error 2