### PR TITLE
ffmpeg: fix compilation with glibc

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
 PKG_VERSION:=4.2.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/

--- a/multimedia/ffmpeg/patches/050-glibc.patch
+++ b/multimedia/ffmpeg/patches/050-glibc.patch
@@ -1,0 +1,10 @@
+--- a/libavcodec/wmv2dsp.c
++++ b/libavcodec/wmv2dsp.c
+@@ -263,6 +263,6 @@ av_cold void ff_wmv2dsp_init(WMV2DSPContext *c)
+     c->put_mspel_pixels_tab[6] = put_mspel8_mc22_c;
+     c->put_mspel_pixels_tab[7] = put_mspel8_mc32_c;
+
+-    if (ARCH_MIPS)
++    if (ARCH_MIPS64)
+         ff_wmv2dsp_init_mips(c);
+ }


### PR DESCRIPTION
No idea why.

Patch submitted upstream:
https://patchwork.ffmpeg.org/project/ffmpeg/patch/20200503090023.29418-1-rosenp@gmail.com/

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @antonlacon @thess 
Compile tested: ipq806x-glibc

Fixes: https://github.com/openwrt/packages/issues/12156