### PR TITLE
libmraa: disable swig

### DIFF
--- a/libs/libmraa/Makefile
+++ b/libs/libmraa/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmraa
 PKG_VERSION:=2.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/eclipse/mraa/tar.gz/v$(PKG_VERSION)?
@@ -30,7 +30,8 @@ include $(INCLUDE_DIR)/cmake.mk
 include ../../lang/python/python3-package.mk
 
 CMAKE_OPTIONS=-DENABLEEXAMPLES=0 \
-	-DFIRMATA=ON
+	-DFIRMATA=ON \
+	-DBUILDSWIG=OFF
 
 TARGET_CFLAGS+=-I$(STAGING_DIR)/usr/include/node
 
@@ -77,7 +78,7 @@ endef
 define Package/libmraa-python3
   $(call Package/libmraa/Default)
   TITLE:=Eclipse MRAA lowlevel IO Python3 library
-  DEPENDS:=+libmraa +python3-light
+  DEPENDS:=+libmraa +python3-light @BROKEN
 endef
 
 define Package/libmraa-python3/description


### PR DESCRIPTION
swig as used in libmraa is not compatible with node 12.

This is causing build failures on all platforms.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nxhack 