### PR TITLE
mwan3: ipv6 improvements

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.5
+PKG_VERSION:=2.8.6
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -353,9 +353,10 @@ mwan3_set_general_iptables()
 					-j RETURN
 				# do not mangle outgoing echo request
 				$IPT6 -A mwan3_hook \
-				      -m set --match-set mwan3_source_v6 src \
-				      -p ipv6-icmp -m icmp6 --icmpv6-type 128 \
-				      -j RETURN
+					-m set --match-set mwan3_source_v6 src \
+					-p ipv6-icmp \
+					-m icmp6 --icmpv6-type 128 \
+					-j RETURN
 
 			fi
 			$IPT -A mwan3_hook \
@@ -880,8 +881,8 @@ mwan3_set_sticky_iptables()
 
 mwan3_set_user_iptables_rule()
 {
-	local ipset family proto policy src_ip src_port sticky dest_ip
-	local dest_port use_policy timeout rule policy IPT
+	local ipset family proto policy src_ip src_port src_iface src_dev
+	local sticky dest_ip dest_port use_policy timeout rule policy IPT
 	local global_logging rule_logging loglevel
 
 	rule="$1"

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -74,7 +74,7 @@ mwan3_rtmon_ipv6()
 	local ret=1
 	local tbl=""
 	mkdir -p /tmp/mwan3rtmon
-	($IP6 route list table main  | grep -v "^default\|^::/0\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.main
+	($IP6 route list table main  | grep -v "^default\|^::/0\|^fe80::/64\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.main
 	while uci get mwan3.@interface[$idx] >/dev/null 2>&1 ; do
 		idx=$((idx+1))
 		tid=$idx

--- a/net/mwan3/files/lib/mwan3/mwan3.sh
+++ b/net/mwan3/files/lib/mwan3/mwan3.sh
@@ -39,14 +39,16 @@ mwan3_rtmon_ipv4()
 	local tid=1
 	local idx=0
 	local ret=1
+	local tbl=""
 	mkdir -p /tmp/mwan3rtmon
 	($IP4 route list table main  | grep -v "^default\|linkdown" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv4.main
 	while uci get mwan3.@interface[$idx] >/dev/null 2>&1 ; do
 		idx=$((idx+1))
 		tid=$idx
 		[ "$(uci get mwan3.@interface[$((idx-1))].family)" = "ipv4" ] && {
-			if $IP4 route list table $tid | grep -q ^default; then
-				($IP4 route list table $tid  | grep -v "^default\|linkdown" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv4.$tid
+			tbl=$($IP4 route list table $tid)
+			if echo "$tbl" | grep -q ^default; then
+				(echo "$tbl"  | grep -v "^default\|linkdown" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv4.$tid
 				cat /tmp/mwan3rtmon/ipv4.$tid | grep -v -x -F -f /tmp/mwan3rtmon/ipv4.main | while read line; do
 					$IP4 route del table $tid $line
 				done
@@ -70,14 +72,16 @@ mwan3_rtmon_ipv6()
 	local tid=1
 	local idx=0
 	local ret=1
+	local tbl=""
 	mkdir -p /tmp/mwan3rtmon
 	($IP6 route list table main  | grep -v "^default\|^::/0\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.main
 	while uci get mwan3.@interface[$idx] >/dev/null 2>&1 ; do
 		idx=$((idx+1))
 		tid=$idx
 		[ "$(uci get mwan3.@interface[$((idx-1))].family)" = "ipv6" ] && {
-			if $IP6 route list table $tid | grep -q "^default\|^::/0"; then
-				($IP6 route list table $tid  | grep -v "^default\|^::/0\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.$tid
+			tbl=$($IP6 route list table $tid)
+			if echo "$tbl" | grep -q "^default\|^::/0"; then
+				(echo "$tbl"  | grep -v "^default\|^::/0\|^unreachable" | sort -n; echo empty fixup) >/tmp/mwan3rtmon/ipv6.$tid
 				cat /tmp/mwan3rtmon/ipv6.$tid | grep -v -x -F -f /tmp/mwan3rtmon/ipv6.main | while read line; do
 					$IP6 route del table $tid $line
 				done

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -6,6 +6,7 @@
 LOG="logger -t $(basename "$0")[$$] -p"
 INTERFACE=""
 DEVICE=""
+PING="/bin/ping"
 
 IFDOWN_EVENT=0
 
@@ -109,7 +110,10 @@ main() {
 	local sleep_time=0
 	local turn=0
 	local result
+	local ping_protocol=4
 	local ping_result
+	local ping_result_raw
+	local ping_status
 	local loss=0
 	local latency=0
 
@@ -137,15 +141,19 @@ main() {
 						# so get the IP address of the interface and use that instead
 						if echo $track_ip | grep -q ':'; then
 							ADDR=$(ip -6 addr ls dev "$DEVICE" | sed -ne '/\/128/d' -e 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p')
+							ping_protocol=6
 						fi
 						if [ $check_quality -eq 0 ]; then
-							ping -I ${ADDR:-$DEVICE} -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null
+							$PING -$ping_protocol -I ${ADDR:-$DEVICE} -c $count -W $timeout -s $size -t $max_ttl -q $track_ip &> /dev/null
 							result=$?
 						else
-							ping_result="$(ping -I ${ADDR:-$DEVICE} -c $count -W $timeout -s $size -t $max_ttl -q $track_ip | tail -2)"
+							ping_result_raw="$($PING -$ping_protocol -I ${ADDR:-$DEVICE} -c $count -W $timeout -s $size -t $max_ttl -q $track_ip 2>/dev/null)"
+							ping_status=$?
+							ping_result=$(echo "$ping_result_raw" | tail -n2)
 							loss="$(echo "$ping_result" | grep "packet loss" |  cut -d "," -f3 | awk '{print $1}' | sed -e 's/%//')"
-							if [ "$loss" -eq 100 ]; then
+							if [ "$ping_status" -ne 0 ] || [ "$loss" -eq 100 ]; then
 								latency=999999
+								loss=100
 							else
 								latency="$(echo "$ping_result" | grep -E 'rtt|round-trip' | cut -d "=" -f2 | cut -d "/" -f2 | cut -d "." -f1)"
 							fi

--- a/net/mwan3/files/usr/sbin/mwan3track
+++ b/net/mwan3/files/usr/sbin/mwan3track
@@ -140,7 +140,8 @@ main() {
 						# https://bugs.openwrt.org/index.php?do=details&task_id=2897
 						# so get the IP address of the interface and use that instead
 						if echo $track_ip | grep -q ':'; then
-							ADDR=$(ip -6 addr ls dev "$DEVICE" | sed -ne '/\/128/d' -e 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p')
+						        ADDR=$(ip -6 addr ls dev "$DEVICE" | sed -ne '/\/128/d' -e 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p' | head -n1)
+							[ -z "$ADDR" ] && ADDR=$(ip -6 addr ls dev "$DEVICE" | sed -ne 's/ *inet6 \([^ \/]*\).* scope global.*/\1/p')
 							ping_protocol=6
 						fi
 						if [ $check_quality -eq 0 ]; then


### PR DESCRIPTION
- Support iputils ping by using `ping6' command
- Don't add link-local routes to tables
- Reduce calls to get routing table by half
- Handle failed ping when quality monitoring

Maintainer: @feckert 
Compile tested: No compile
Run tested: OpenWrt 19.07.2 r10947-65030d81f3 

Description:

- IPV6 pinging was broken using iputils-ping, since it will need an explicit call to ping6 when pinging an ipv6 address.
- ping can also return a non-zero exit code for various reasons, which broke the quality monitoring code. We check for this now and specify max latency
- mwan3 was trying to add all of the ipv6 link local addresses into the various routing tables, which failed with the error "RTNETLINK answers: File exists."
- save the output of `ip list route ...` so we don't need to call it as often