### PR TITLE
python3-openssl: Add dependency on ca-certs

### DIFF
--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 include ../python3-version.mk
 
 PKG_NAME:=python3
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_VERSION:=$(PYTHON3_VERSION).$(PYTHON3_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz

--- a/lang/python/python3/files/python3-package-openssl.mk
+++ b/lang/python/python3/files/python3-package-openssl.mk
@@ -8,7 +8,7 @@
 define Package/python3-openssl
 $(call Package/python3/Default)
   TITLE:=Python $(PYTHON3_VERSION) SSL module
-  DEPENDS:=+python3-light +libopenssl
+  DEPENDS:=+python3-light +libopenssl +ca-certs
 endef
 
 $(eval $(call Py3BasePackage,python3-openssl, \


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2020-05-17 snapshot sdk
Run tested: none

Description:
The ssl module assumes OpenSSL can load the default trust anchors (root CA certificates).

From https://github.com/openwrt/packages/issues/12209

Signed-off-by: Jeffery To <jeffery.to@gmail.com>