### PR TITLE
python-more-itertools: update to version 8.3.0

### DIFF
--- a/lang/python/python-more-itertools/Makefile
+++ b/lang/python/python-more-itertools/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-more-itertools
-PKG_VERSION:=8.2.0
-PKG_RELEASE:=2
+PKG_VERSION:=8.3.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=more-itertools
-PKG_HASH:=b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507
+PKG_HASH:=558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR update python-more-itertools to version 8.3.0 with new  zip_equal function

[Changelog](https://github.com/more-itertools/more-itertools/blob/master/docs/versions.rst#830)

Run test
```
python3 -m unittest discover
.....................................s.............................................................................................................................................................................................
----------------------------------------------------------------------
Ran 494 tests in 3.644s

OK (skipped=1)
```