### PR TITLE
seafile-server: Update to 7.1.4

### DIFF
--- a/lang/python/django-jsonfield2/Makefile
+++ b/lang/python/django-jsonfield2/Makefile
@@ -1,0 +1,49 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+# Please do not update: 3.0.3 is the last version compatible with Django 1.11
+PKG_NAME:=django-jsonfield2
+PKG_VERSION:=3.0.3
+PKG_RELEASE:=1
+
+# Source for 3.0.3 is not available from PyPI
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/rpkilby/jsonfield2/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=4b79ac28738671fe27cadbd537d50130c35a286207d31d8320c7b48b6cda36ca
+
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/jsonfield2-$(PKG_VERSION)
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-django-jsonfield2
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=A reusable Django field to store validated JSON in models
+  URL:=https://github.com/rpkilby/jsonfield2
+  DEPENDS:=+python3-light +python3-decimal +django
+  CONFLICTS:=python3-django-jsonfield
+endef
+
+define Package/python3-django-jsonfield2/description
+  A modern fork of django-jsonfield, compatible with the latest versions
+  of Django.
+
+  jsonfield2 is a reusable model field that allows you to store
+  validated JSON, automatically handling serialization to and from the
+  database.
+endef
+
+$(eval $(call Py3Package,python3-django-jsonfield2))
+$(eval $(call BuildPackage,python3-django-jsonfield2))
+$(eval $(call BuildPackage,python3-django-jsonfield2-src))

--- a/lang/python/django-postoffice/Makefile
+++ b/lang/python/django-postoffice/Makefile
@@ -7,13 +7,14 @@
 
 include $(TOPDIR)/rules.mk
 
+# Please do not update: 3.3.0 is the last version compatible with Django 1.11
 PKG_NAME:=django-postoffice
-PKG_VERSION:=3.2.1
-PKG_RELEASE:=2
+PKG_VERSION:=3.3.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=django-post-office
 PYPI_SOURCE_NAME:=django-post_office
-PKG_HASH:=e32427822f647719575094f790ca949ef9f9827ec0e8378cb021f01f3834b2a4
+PKG_HASH:=b06514da601c22e955bd93a4ac6dd6b2218c571ca67c193e62bd1f22cec7536f
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 PKG_LICENSE:=MIT
@@ -32,7 +33,7 @@ define Package/python3-django-postoffice
   DEPENDS:= \
 	+python3 \
 	+python3-django1 \
-	+python3-django-jsonfield
+	+python3-django-jsonfield2
 endef
 
 define Package/python3-django-postoffice/description

--- a/net/seafile-ccnet/Makefile
+++ b/net/seafile-ccnet/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-ccnet
-PKG_VERSION:=7.1.3
-PKG_RELEASE:=2
+PKG_VERSION:=7.1.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/haiwen/ccnet-server/tar.gz/v$(PKG_VERSION)-server?
-PKG_HASH:=148d9b1af9218943de310f3f2e29e542e7279dbfba307a1cdd894bf8b7faf2e8
+PKG_HASH:=b46508a686e7fe8eb9e1515e5384c7d9aca25cf596ef4b8383646e587f1032eb
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=AGPL-3.0-only

--- a/net/seafile-seahub/Makefile
+++ b/net/seafile-seahub/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-seahub
-PKG_VERSION:=7.1.3
-PKG_RELEASE:=2
+PKG_VERSION:=7.1.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/haiwen/seahub/tar.gz/v$(PKG_VERSION)-server?
-PKG_HASH:=a2cf1ad1ff357b06c112f3f80e2e4a2ef109813496c96afc309449f6915e8797
+PKG_HASH:=921ef4373311c06c1192975a294d7d38c12ac34381a7df19542391fc1d810baf
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/net/seafile-seahub/patches/030-uci-conf.patch
+++ b/net/seafile-seahub/patches/030-uci-conf.patch
@@ -9,7 +9,7 @@
              os.path.join(PROJECT_ROOT, 'seahub/templates'),
          ],
          'APP_DIRS': True,
-@@ -630,7 +630,7 @@ CAPTCHA_IMAGE_SIZE = (90, 42)
+@@ -633,7 +633,7 @@ CAPTCHA_IMAGE_SIZE = (90, 42)
  ENABLE_THUMBNAIL = True
  
  # Absolute filesystem path to the directory that will hold thumbnail files.
@@ -18,7 +18,7 @@
  if os.path.exists(SEAHUB_DATA_ROOT):
      THUMBNAIL_ROOT = os.path.join(SEAHUB_DATA_ROOT, 'thumbnail')
  else:
-@@ -793,7 +793,7 @@ except ImportError:
+@@ -829,7 +829,7 @@ except ImportError:
      pass
  else:
      # In server release, sqlite3 db file is <topdir>/seahub.db

--- a/net/seafile-server/Makefile
+++ b/net/seafile-server/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-server
-PKG_VERSION:=7.1.3
-PKG_RELEASE:=4
+PKG_VERSION:=7.1.4
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/haiwen/seafile-server/tar.gz/v$(PKG_VERSION)-server?
-PKG_HASH:=79f7722a34c304adb78462194e64d6a610bd5ee40def37f4e4cdf5befed44fcd
+PKG_HASH:=cc5aaf76044f907758a75a43e321fef499482d7b57d9e61d0297a4bba66dcce4
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>, Jeffery To <jeffery.to@gmail.com>
 PKG_LICENSE:=AGPL-3.0-only

--- a/net/seafile-server/patches/060-timestamps-as-int64.patch
+++ b/net/seafile-server/patches/060-timestamps-as-int64.patch
@@ -1,23 +1,5 @@
 --- a/lib/repo.vala
 +++ b/lib/repo.vala
-@@ -34,7 +34,7 @@ public class Repo : Object {
-     // data format version
-     public int version { get; set; }
- 
--    public int    last_modify { get; set; }
-+    public int64  last_modify { get; set; }
-     public int64  size { get; set; }
-     public int64  file_count { get; set; }
-     public string last_modifier { get; set; }
-@@ -46,7 +46,7 @@ public class Repo : Object {
-     public string repo_id { get; set; }
-     public string repo_name { get; set; }
-     public string repo_desc { get; set; }
--    public int last_modified { get; set; }
-+    public int64 last_modified { get; set; }
- 
-     // Section 2: Encryption related
-     // Members in this section should be set for every Repo object
 @@ -70,7 +70,7 @@ public class Repo : Object {
          get { return _relay_id; }
          set { _relay_id = value; }


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 2020-05-17 snapshot sdk
Run tested: armvirt-64 (qemu), 2020-05-17 snapshot

Description:
This also updates django-postoffice to 3.3.0 and adds a new package (django-jsonfield2).

The dependency situation with django-post-office and jsonfield is a little troublesome (jsonfield2 has been merged back into jsonfield, and newer versions of django-post-office depend on the new jsonfield again); if/when seafile-server moves beyond Django 1.11, we can update django-postoffice and django-jsonfield to their newest versions, change the dependency back and remove django-jsonfield2.