### PR TITLE
prometheus-node-exporter-lua: add collectors for dnsmasq

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,8 +4,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2020.02.03
-PKG_RELEASE:=2
+PKG_VERSION:=2020.05.23
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
 PKG_LICENSE:=Apache-2.0
@@ -94,6 +94,12 @@ define Package/prometheus-node-exporter-lua-ltq-dsl
   DEPENDS:=prometheus-node-exporter-lua @(PACKAGE_ltq-adsl-app||PACKAGE_ltq-vdsl-app)
 endef
 
+define Package/prometheus-node-exporter-lua-dnsmasq
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (dnsmasq collector)
+  DEPENDS:=prometheus-node-exporter-lua +libubus-lua
+endef
+
 Build/Compile=
 
 define Package/prometheus-node-exporter-lua/install
@@ -164,6 +170,11 @@ define Package/prometheus-node-exporter-lua-ltq-dsl/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/ltq-dsl.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
+define Package/prometheus-node-exporter-lua-dnsmasq/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/dnsmasq.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
 $(eval $(call BuildPackage,prometheus-node-exporter-lua))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-nat_traffic))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-netstat))
@@ -175,3 +186,4 @@ $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx7))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-textfile))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-openwrt))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-ltq-dsl))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-dnsmasq))

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/dnsmasq.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/dnsmasq.lua
@@ -1,0 +1,51 @@
+local ubus = require "ubus"
+
+local function scrape_leasefile(leasefile)
+  metric_dhcp_lease = metric("dhcp_lease", "gauge")
+  local file = io.open(leasefile)
+  if not file then return end
+
+  local e
+  repeat
+    e = file:read()
+    if e then
+      local fields = space_split(e)
+      if fields[4] ~= nil then
+        local labels = {
+          dnsmasq = leasefile,
+          ip = fields[3],
+          hostname = fields[4]
+        }
+        if string.match(fields[3], "^[0-9]+%.[0-9]+%.[0-9]+%.[0-9]+$") then
+          labels['mac'] = fields[2]
+        end
+        metric_dhcp_lease(labels, fields[1])
+      end
+    end
+  until not e
+  file:close()
+end
+
+local function scrape()
+  local u = ubus.connect()
+
+  local metrics = u:call("dnsmasq", "metrics", {})
+  if not metrics then return end
+  for name, value in pairs(metrics) do
+    metric("dnsmasq_"..name, "counter", nil, value)
+  end
+
+  local values = u:call("uci", "get", {config="dhcp", type="dnsmasq"})
+  if not values then return end
+  for _, configs in pairs(values) do
+    for name, config in pairs(configs) do
+      for key, value in pairs(config) do
+        if key == "leasefile" then
+	  scrape_leasefile(value)
+        end
+      end
+    end
+  end
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
Maintainer: @champtar
Run tested: (ath79, TP-Link TL-WDR4300 v1, 19.07.3)

Description:
Collect dnsmasq metrics and dhcp leases in prometheus node exporter.

Example output:
```
# TYPE dhcp_lease gauge
dhcp_lease{mac="06:00:00:00:00",dnsmasq="cfg01411c",hostname="host0",ip="192.168.1.2"} 1590132284
dhcp_lease{mac="06:00:00:00:00:01",dnsmasq="cfg01411c",hostname="host1",ip="192.168.1.3"} 1590127663
dhcp_lease{dnsmasq="cfg01411c",hostname="ipv6",ip="fe80:abcd:ef01::2345"} 1590127663
# TYPE dnsmasq_dhcp_ack counter
dnsmasq_dhcp_ack 189
# TYPE dnsmasq_leases_pruned_6 counter
dnsmasq_leases_pruned_6 0
# TYPE dnsmasq_dhcp_decline counter
dnsmasq_dhcp_decline 0
# TYPE dnsmasq_dhcp_nak counter
dnsmasq_dhcp_nak 0
# TYPE dnsmasq_dns_cache_live_freed counter
dnsmasq_dns_cache_live_freed 0
# TYPE dnsmasq_noanswer counter
dnsmasq_noanswer 0
# TYPE dnsmasq_dns_auth_answered counter
dnsmasq_dns_auth_answered 0
# TYPE dnsmasq_leases_allocated_4 counter
dnsmasq_leases_allocated_4 13
# TYPE dnsmasq_dns_local_answered counter
dnsmasq_dns_local_answered 2487
# TYPE dnsmasq_dhcp_discover counter
dnsmasq_dhcp_discover 10
# TYPE dnsmasq_pxe counter
dnsmasq_pxe 0
# TYPE dnsmasq_leases_allocated_6 counter
dnsmasq_leases_allocated_6 2
# TYPE dnsmasq_leases_pruned_4 counter
dnsmasq_leases_pruned_4 0
# TYPE dnsmasq_dhcp_request counter
dnsmasq_dhcp_request 189
# TYPE dnsmasq_dhcp_offer counter
dnsmasq_dhcp_offer 10
# TYPE dnsmasq_dhcp_release counter
dnsmasq_dhcp_release 0
# TYPE dnsmasq_dns_queries_forwarded counter
dnsmasq_dns_queries_forwarded 4438
# TYPE dnsmasq_dhcp_inform counter
dnsmasq_dhcp_inform 0
# TYPE dnsmasq_dns_cache_inserted counter
dnsmasq_dns_cache_inserted 14267
# TYPE dnsmasq_bootp counter
dnsmasq_bootp 0
```