### PR TITLE
knot: disable libcap-ng

### DIFF
--- a/net/knot/Makefile
+++ b/net/knot/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knot
 PKG_VERSION:=2.9.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://secure.nic.cz/files/knot-dns/
@@ -149,6 +149,7 @@ export KNOT_VERSION_FORMAT=release
 
 CONFIGURE_ARGS += 			\
 	--enable-recvmmsg=no		\
+	--enable-cap-ng=no            	\
 	--disable-fastparser		\
 	--without-libidn		\
 	--with-rundir=/var/run/knot	\

--- a/net/knot/patches/03-configure-allow-to-manually-disable-POSIX-capabiliti.patch
+++ b/net/knot/patches/03-configure-allow-to-manually-disable-POSIX-capabiliti.patch
@@ -1,0 +1,39 @@
+From 442633ae37f8a4e1164a2db3ad6b55bc738ba0b2 Mon Sep 17 00:00:00 2001
+From: Daniel Salzman <daniel.salzman@nic.cz>
+Date: Fri, 22 May 2020 12:50:29 +0200
+Subject: [PATCH] configure: allow to manually disable POSIX capabilities
+
+---
+ configure.ac | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 47772799e..a08ca8532 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -554,7 +554,13 @@ AS_IF([test "$enable_utilities" = "yes"], [
+   ])
+ ]) # Knot DNS utilities dependencies
+ 
++AC_ARG_ENABLE([cap-ng],
++    AS_HELP_STRING([--enable-cap-ng=auto|no], [enable POSIX capabilities [default=auto]]),
++    [enable_cap_ng="$enableval"], [enable_cap_ng=auto])
++
+ AS_IF([test "$enable_daemon" = "yes"], [
++
++AS_IF([test "$enable_cap_ng" != "no"],[
+   PKG_CHECK_MODULES([cap_ng], [cap-ng], [enable_cap_ng=yes], [
+     enable_cap_ng=no
+     AC_CHECK_HEADER([cap-ng.h], [
+@@ -570,7 +576,7 @@ AS_IF([test "$enable_daemon" = "yes"], [
+ ], [
+   enable_cap_ng=no
+   cap_ng_LIBS=
+-])
++])])
+ 
+ AS_IF([test "$enable_cap_ng" = yes],
+   [AC_DEFINE([ENABLE_CAP_NG], [1], [POSIX capabilities available])]
+-- 
+2.17.1
+


### PR DESCRIPTION
Maintainer: @salzmdan (cc: @Payne-X6)
Compile tested: Turris MOX, cortexa53, OpenWrt master + Turris Omnia, cortexa9 (both mvebu)
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
Recently, there was added libcap-ng (https://github.com/openwrt/packages/pull/12180) to OpenWrt packages feed, which is optional for Knot DNS. 

Because of it, build system detected it and wanted to enable POSIX 1003.1e capabilities.
```
Package knot is missing dependencies for the following libraries:
libcap-ng.so.0
```

This can restrict root (by default it runs under root) permissions and
might harm and as there isn't systemd on OpenWrt it can interfere.

There is an added patch, which introduced an option to disable libcap-ng.
This will be part of the next release.

I rather increased PKG_RELEASE even it is not necessary just to be sure. It was not used before and now it is disabled.