### PR TITLE
Updated Energized source URLs

### DIFF
--- a/net/adblock/files/adblock.sources
+++ b/net/adblock/files/adblock.sources
@@ -49,28 +49,28 @@
 		"descurl": "https://www.dshield.org"
 	},
 	"energized_blugo": {
-		"url": "https://raw.githubusercontent.com/EnergizedProtection/block/master/bluGo/formats/domains.txt",
+		"url": "https://block.energized.pro/bluGo/formats/domains.txt",
 		"rule": "/^([[:alnum:]_-]+\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"size": "XL",
 		"focus": "compilation",
 		"descurl": "https://github.com/EnergizedProtection/block"
 	},
 	"energized_blu": {
-		"url": "https://raw.githubusercontent.com/EnergizedProtection/block/master/blu/formats/domains.txt",
+		"url": "https://block.energized.pro/blu/formats/domains.txt",
 		"rule": "/^([[:alnum:]_-]+\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"size": "XL",
 		"focus": "compilation",
 		"descurl": "https://github.com/EnergizedProtection/block"
 	},
 	"energized_porn": {
-		"url": "https://raw.githubusercontent.com/EnergizedProtection/block/master/porn/formats/domains.txt",
+		"url": "https://block.energized.pro/porn/formats/domains.txt",
 		"rule": "/^([[:alnum:]_-]+\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"size": "XXL",
 		"focus": "compilation+porn",
 		"descurl": "https://github.com/EnergizedProtection/block"
 	},
 	"energized_unified": {
-		"url": "https://raw.githubusercontent.com/EnergizedProtection/block/master/unified/formats/domains.txt",
+		"url": "https://block.energized.pro/unified/formats/domains.txt",
 		"rule": "/^([[:alnum:]_-]+\\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}",
 		"size": "XXL",
 		"focus": "compilation",


### PR DESCRIPTION
The previous URLs 404. Copied directly from: https://github.com/EnergizedProtection/block

**Compile tested:** Not compiled
**Run tested:** Not tested

**Description:**
The previous URLs returned this error in the Adblock logs:
```
download of 'energized_blu' failed, url: https://raw.githubusercontent.com/EnergizedProtection/block/master/blu/formats/domains.txt, rule: /^([[:alnum:]_-]+\.)+[[:alpha:]]+([[:space:]]|$)/{print tolower($1)}, categories: -, rc: 8, log: Downloading 'https://raw.githubusercontent.com/EnergizedProtection/block/master/blu/formats/domains.txt' Connecting to 151.101.48.133:443 HTTP error 404
```
When going to https://github.com/EnergizedProtection/block I noticed the block list txt URLs have changed. I updated them in the sources file, but haven't compiled or tested these changes.

Anyone willing to help test this would be greatly appreciated. Thanks.
