### PR TITLE
lxc: use -minterlink-mips16 only with USE_MIPS16

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -142,7 +142,9 @@ CONFIGURE_ARGS += \
 	--enable-capabilities \
 	--disable-examples
 
-TARGET_CFLAGS += -minterlink-mips16
+ifdef CONFIG_USE_MIPS16
+  TARGET_CFLAGS += -minterlink-mips16
+endif
 TARGET_LDFLAGS += -lgcc_eh
 
 define Build/InstallDev


### PR DESCRIPTION
Maintainer: @ratkaj 
Compile tested: mipsel_74kc, ASUS RT-N56U, openwrt master
Run tested: none

Description:
The flag is either not supported or not needed unless there's mixed
mips/mips16 code.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
Not bumping PKG_RELEASE, since it does not change the package (mips still builds the same, and everyone else is currently failing).