### PR TITLE
[19.07] gerbera: add taglib support

### DIFF
--- a/libs/libupnp/Makefile
+++ b/libs/libupnp/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libupnp
 PKG_VERSION:=1.8.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/pupnp
@@ -48,10 +48,27 @@ define Package/libupnp-sample/description
 TVcontrolpoint & tvdevice sample applications run inside /etc/upnp-tvdevice/
 endef
 
-TARGET_CFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -flto
-TARGET_LDFLAGS += -flto
+CONFIGURE_ARGS += \
+	--enable-client \
+	--enable-device \
+	--enable-gena \
+	--enable-reuseaddr \
+	--enable-gena \
+	--enable-webserver \
+	--enable-ssdp \
+	--enable-soap \
+	--enable-tools \
+	--enable-blocking_tcp_connections \
+	--enable-samples \
+	--disable-debug \
+	--disable-optssdp \
+	--disable-unspecified_server \
+	--disable-open_ssl \
+	--disable-scriptsupport \
+	--disable-postwrite
 
-CONFIGURE_VARS += ac_cv_lib_compat_ftime=no
+TARGET_CFLAGS += -flto
+TARGET_LDFLAGS += -flto
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include

--- a/libs/taglib/Makefile
+++ b/libs/taglib/Makefile
@@ -1,0 +1,56 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=taglib
+PKG_VERSION:=1.11.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/taglib/taglib/releases/download/v$(PKG_VERSION)
+PKG_HASH:=b6d1a5a610aae6ff39d93de5efd0fdc787aa9e9dc1e7026fa4c961b26563526b
+
+PKG_MAINTAINER:=
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=COPYING.LGPL
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/taglib
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=taglib
+  URL:=https://github.com/taglib/taglib
+  DEPENDS:=+libstdcpp
+  BUILDONLY:=1
+endef
+
+define Package/taglib/description
+  TagLib is a library for reading and editing the metadata of several
+  popular audio formats. Currently it supports both ID3v1 and ID3v2 for
+  MP3 files, Ogg Vorbis comments and ID3 tags in FLAC, MPC, Speex, WavPack,
+  TrueAudio, WAV, AIFF, MP4, APE, DSF, DFF, and ASF files.
+endef
+
+CMAKE_OPTIONS += \
+	-DHAVE_BOOST_BYTESWAP=OFF \
+	-DBUILD_TESTS=OFF \
+	-DBUILD_EXAMPLES=OFF \
+	-DBUILD_BINDINGS=OFF \
+	-DNO_ITUNES_HACKS=ON
+
+TARGET_CXXFLAGS += -flto
+
+define Build/InstallDev
+	$(call Build/InstallDev/cmake,$(1))
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/taglib.pc
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/taglib.pc
+endef
+
+$(eval $(call BuildPackage,taglib))

--- a/multimedia/gerbera/Makefile
+++ b/multimedia/gerbera/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gerbera
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/gerbera/gerbera/tar.gz/v$(PKG_VERSION)?
@@ -19,6 +19,7 @@ PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE.md
 
+PKG_BUILD_DEPENDS:=taglib
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -50,7 +51,7 @@ CMAKE_OPTIONS += \
 	-DWITH_CURL=0 \
 	-DWITH_INOTIFY=1 \
 	-DWITH_JS=0 \
-	-DWITH_TAGLIB=0 \
+	-DWITH_TAGLIB=1 \
 	-DWITH_AVCODEC=0 \
 	-DWITH_FFMPEGTHUMBNAILER=0 \
 	-DWITH_EXIF=1 \


### PR DESCRIPTION
I also backported a libupnp change. Gerbera suggests enabling reuseaddr in libupnp.

I tried backporting libmatroska. Got linking errors.

I also tried to patch Gerbera 1.5.0 to work with GCC7. It's a lot more annoying that I thought. experimental/filesystem are not quite the same. The former lacks some features that the latter has.

Maintainer: nobody
Compile tested: aarch64

ping @BKPepe 