### PR TITLE
[19.07] gerbera: add taglib support

### DIFF
--- a/libs/libupnp/Makefile
+++ b/libs/libupnp/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libupnp
 PKG_VERSION:=1.8.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/pupnp
@@ -48,10 +48,27 @@ define Package/libupnp-sample/description
 TVcontrolpoint & tvdevice sample applications run inside /etc/upnp-tvdevice/
 endef
 
-TARGET_CFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -flto
-TARGET_LDFLAGS += -flto
+CONFIGURE_ARGS += \
+	--enable-client \
+	--enable-device \
+	--enable-gena \
+	--enable-reuseaddr \
+	--enable-gena \
+	--enable-webserver \
+	--enable-ssdp \
+	--enable-soap \
+	--enable-tools \
+	--enable-blocking_tcp_connections \
+	--enable-samples \
+	--disable-debug \
+	--disable-optssdp \
+	--disable-unspecified_server \
+	--disable-open_ssl \
+	--disable-scriptsupport \
+	--disable-postwrite
 
-CONFIGURE_VARS += ac_cv_lib_compat_ftime=no
+TARGET_CFLAGS += -flto
+TARGET_LDFLAGS += -flto
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include

--- a/libs/taglib/Makefile
+++ b/libs/taglib/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=taglib
 PKG_VERSION:=1.11.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/taglib/taglib/releases/download/v$(PKG_VERSION)
@@ -49,6 +49,9 @@ TARGET_CXXFLAGS += -flto
 
 define Build/InstallDev
 	$(call Build/InstallDev/cmake,$(1))
+	$(SED) '/^prefix=\|^exec_prefix=/s|/usr|$(STAGING_DIR)/usr|' $(1)/usr/bin/taglib-config
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/bin/taglib-config
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/bin/taglib-config
 	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/taglib.pc
 	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/taglib.pc
 endef

--- a/libs/taglib/Makefile
+++ b/libs/taglib/Makefile
@@ -1,0 +1,56 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=taglib
+PKG_VERSION:=1.11.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/taglib/taglib/releases/download/v$(PKG_VERSION)
+PKG_HASH:=b6d1a5a610aae6ff39d93de5efd0fdc787aa9e9dc1e7026fa4c961b26563526b
+
+PKG_MAINTAINER:=
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=COPYING.LGPL
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/taglib
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=taglib
+  URL:=https://github.com/taglib/taglib
+  DEPENDS:=+libstdcpp
+  BUILDONLY:=1
+endef
+
+define Package/taglib/description
+  TagLib is a library for reading and editing the metadata of several
+  popular audio formats. Currently it supports both ID3v1 and ID3v2 for
+  MP3 files, Ogg Vorbis comments and ID3 tags in FLAC, MPC, Speex, WavPack,
+  TrueAudio, WAV, AIFF, MP4, APE, DSF, DFF, and ASF files.
+endef
+
+CMAKE_OPTIONS += \
+	-DHAVE_BOOST_BYTESWAP=OFF \
+	-DBUILD_TESTS=OFF \
+	-DBUILD_EXAMPLES=OFF \
+	-DBUILD_BINDINGS=OFF \
+	-DNO_ITUNES_HACKS=ON
+
+TARGET_CXXFLAGS += -flto
+
+define Build/InstallDev
+	$(call Build/InstallDev/cmake,$(1))
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/taglib.pc
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/taglib.pc
+endef
+
+$(eval $(call BuildPackage,taglib))

--- a/libs/taglib/Makefile
+++ b/libs/taglib/Makefile
@@ -6,16 +6,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=taglib
-PKG_VERSION:=1.11.1
-PKG_RELEASE:=2
+PKG_VERSION:=1.12-beta-1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/taglib/taglib/releases/download/v$(PKG_VERSION)
-PKG_HASH:=b6d1a5a610aae6ff39d93de5efd0fdc787aa9e9dc1e7026fa4c961b26563526b
+PKG_SOURCE_URL:=https://codeload.github.com/taglib/taglib/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=d2a44be7ca8b7682b218affc9910dcfb027481f402f7c30bd2996392b2429ae4
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING.LGPL
+PKG_CPE_ID:=cpe:/a:taglib:taglib
 
 PKG_BUILD_PARALLEL:=1
 
@@ -39,7 +40,6 @@ define Package/taglib/description
 endef
 
 CMAKE_OPTIONS += \
-	-DHAVE_BOOST_BYTESWAP=OFF \
 	-DBUILD_TESTS=OFF \
 	-DBUILD_EXAMPLES=OFF \
 	-DBUILD_BINDINGS=OFF \
@@ -50,8 +50,6 @@ TARGET_CXXFLAGS += -flto
 define Build/InstallDev
 	$(call Build/InstallDev/cmake,$(1))
 	$(SED) '/^prefix=\|^exec_prefix=/s|/usr|$(STAGING_DIR)/usr|' $(1)/usr/bin/taglib-config
-	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/bin/taglib-config
-	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/bin/taglib-config
 	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/taglib.pc
 	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/taglib.pc
 endef

--- a/multimedia/gerbera/Makefile
+++ b/multimedia/gerbera/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gerbera
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/gerbera/gerbera/tar.gz/v$(PKG_VERSION)?
@@ -19,6 +19,7 @@ PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE.md
 
+PKG_BUILD_DEPENDS:=taglib
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -50,7 +51,7 @@ CMAKE_OPTIONS += \
 	-DWITH_CURL=0 \
 	-DWITH_INOTIFY=1 \
 	-DWITH_JS=0 \
-	-DWITH_TAGLIB=0 \
+	-DWITH_TAGLIB=1 \
 	-DWITH_AVCODEC=0 \
 	-DWITH_FFMPEGTHUMBNAILER=0 \
 	-DWITH_EXIF=1 \

--- a/multimedia/gerbera/files/gerbera.config
+++ b/multimedia/gerbera/files/gerbera.config
@@ -1,3 +1,6 @@
 config gerbera config
 	option enabled	'0'
+	option debug	'0'
+	option user	'gerbera'
+	option group	'gerbera'
 	option home	'/tmp/gerbera'

--- a/multimedia/gerbera/files/gerbera.init
+++ b/multimedia/gerbera/files/gerbera.init
@@ -7,32 +7,42 @@ PROG=/usr/bin/gerbera
 
 start_service() {
 	local enabled
+	local debug
+	local user
+	local group
 	local home
 
 	config_load 'gerbera'
 	config_get_bool enabled config 'enabled' '0'
+	config_get_bool debug config 'debug' '0'
 
 	[ "$enabled" -eq 0 ] && {
 		echo "Gerbera not enabled. Please enable in /etc/config/gerbera"
 		return 1
 	}
 
+	config_get user config 'user' 'gerbera'
+	config_get group config 'group' 'gerbera'
 	config_get home config 'home' '/tmp/gerbera'
 
 	[ -d "$home" ] || {
 		mkdir -p "$home"
-		chown gerbera:gerbera "$home"
+		chown "$user":"$group" "$home"
 
 		gerbera -m "$home" -f '' --create-config > "$home/config.xml" 2> /dev/null
+		chown "$user":"$group" "$home/config.xml"
+		chmod 600 "$home/config.xml"
+
 		echo "Created default gerbera config at $home/config.xml"
 		echo "Please edit to your liking and restart."
 		return 2
 	}
 
 	procd_open_instance
-	procd_set_param user gerbera
-	procd_set_param group gerbera
+	procd_set_param user "$user"
+	procd_set_param group "$group"
 	procd_set_param command "$PROG" -c "$home/config.xml"
+	procd_set_param stdout "$debug"
 	procd_set_param stderr 1
 	procd_close_instance
 }


### PR DESCRIPTION
I also backported a libupnp change. Gerbera suggests enabling reuseaddr in libupnp.

I tried backporting libmatroska. Got linking errors.

I also tried to patch Gerbera 1.5.0 to work with GCC7. It's a lot more annoying that I thought. experimental/filesystem are not quite the same. The former lacks some features that the latter has.

Maintainer: nobody
Compile tested: aarch64

ping @BKPepe