### PR TITLE
taglib: fix taglib-config paths

### DIFF
--- a/libs/taglib/Makefile
+++ b/libs/taglib/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=taglib
 PKG_VERSION:=1.11.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/taglib/taglib/releases/download/v$(PKG_VERSION)
@@ -49,6 +49,9 @@ TARGET_CXXFLAGS += -flto
 
 define Build/InstallDev
 	$(call Build/InstallDev/cmake,$(1))
+	$(SED) '/^prefix=\|^exec_prefix=/s|/usr|$(STAGING_DIR)/usr|' $(1)/usr/bin/taglib-config
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/bin/taglib-config
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/bin/taglib-config
 	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/taglib.pc
 	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/taglib.pc
 endef


### PR DESCRIPTION
It seems gerbera uses this instead of pkgconfig.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ath79