### PR TITLE
postgresql: fix compilation with GCC4

### DIFF
--- a/libs/postgresql/Makefile
+++ b/libs/postgresql/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=postgresql
 PKG_VERSION:=12.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=PostgreSQL
 PKG_CPE_ID:=cpe:/a:postgresql:postgresql
@@ -155,6 +155,8 @@ CONFIGURE_ARGS += \
 			--with-zlib="yes" \
 			--enable-depend \
 			$(if $(CONFIG_arc),--disable-spinlocks)
+
+HOST_CFLAGS += -std=gnu99
 
 # Need a native zic and pg_config for build
 define Host/Compile


### PR DESCRIPTION
The minimum version of GCC according to prereq-build.mk is 4.8 which
defaults to gnu89. This breaks the host build when the host GCC is less
than 5, which defaults to gnu99. Add a simple CFLAG to fix.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @dangowrt 
Compile tested: CentOS7

Fixes: https://github.com/openwrt/packages/pull/12012