### PR TITLE
[19.07] mariadb: use default umask for rundir

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
 PKG_VERSION:=10.2.32
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := \

--- a/utils/mariadb/files/mysqld.init
+++ b/utils/mariadb/files/mysqld.init
@@ -110,26 +110,30 @@ start_service() {
 	  -v group="$group" \
 	  -v a="$datadir" \
 	  -v b="$logdir" \
-	  -v c="$rundir" \
-	  -v d="$tmpdir" \
+	  -v c="$tmpdir" \
 	  '
 	    BEGIN {
 	      dir[0]=a
 	      dir[1]=b
 	      dir[2]=c
-	      dir[3]=d
 	      for (x in dir) {
 	        if (system("test ! -e \"" dir[x] "\"" )) {
 	          delete dir[x]
 	        }
 	      }
 	      for (x in dir) {
-	        system("mkdir -p \"" dir[x] "\"" )
-	        system("chmod 750 \"" dir[x] "\"" )
+	        system("mkdir -p -m 0750 \"" dir[x] "\"" )
 	        system("chown \"" user "\":\"" group "\" \"" dir[x] "\"" )
 	      }
 	    }
 	  '
+
+	if ! [ -e "$rundir" ]; then
+		# $rundir needs to be accessible for
+		# clients
+		mkdir -p "$rundir"
+		[ -d "$rundir" ] && chown "$user":"$group" "$rundir"
+	fi
 
 	if [ ! -f "$datadir/mysql/tables_priv.MYD" ]; then
 		local args="--force"


### PR DESCRIPTION
rundir needs to be accessible for clients, hence o= is not the proper
permission for rundir. This commit breaks out rundir from the awk script
and sets it up with default umask.

This also removes chmod call and instead tells mkdir to create the
directories with the proper permissions directly.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: 19.07 ath79
Run tested: 19.07 ath79

Description:
Hi all,

This fixes rundir permission issue. Clients (other than user mariadb/root) are not able to connect with the permissions in place.

Kind regards,
Seb