### PR TITLE
sslh: use tls option instead of deprecated ssl

### DIFF
--- a/net/sslh/files/sslh.config
+++ b/net/sslh/files/sslh.config
@@ -10,9 +10,9 @@ config 'sslh' 'default'
 	# ssh defaults to 'localhost:22'
 	# --ssh <sshhost>:<sshport>
 	option 'ssh' ''
-	# ssl defaults to 'localhost:443'
-	# --ssl <sslhost>:<sslport>
-	option 'ssl' ''
+	# tls defaults to 'localhost:443'
+	# --tls <tlshost>:<tlsport>
+	option 'tls' ''
 	# openvpn defaults to 'localhost:1194'
 	# --openvpn <openvpnhost>:<openvpnport>
 	option 'openvpn' ''

--- a/net/sslh/files/sslh.init
+++ b/net/sslh/files/sslh.init
@@ -22,9 +22,9 @@ start_instance() {
 	# B) ssh parameter
 	config_get val "${section}" ssh
 	[ -n "${val}" ] && append args "--ssh ${val}"
-	# C) ssl parameter
-	config_get val "${section}" ssl
-	[ -n "${val}" ] && append args "--ssl ${val}"
+	# C) tls parameter
+	config_get val "${section}" tls
+	[ -n "${val}" ] && append args "--tls ${val}"
 	# D) openvpn parameter
 	config_get val "${section}" openvpn
 	 [ -n "${val}" ] && append args "--openvpn ${val}"


### PR DESCRIPTION
Upstream will drop support for the `ssl` option in the next future version.

Signed-off-by: Gabor Seljan <sgabe@users.noreply.github.com>

Maintainer: @jmccrohan
Compile tested: MT7621, RB750Gr3, v19.07.3
Run tested: MT7621, RB750Gr3, v19.07.0

Description:
The `ssl` option is deprecated and the legacy support will be removed in sslh v1.21. This PR replaces the old `ssl` option with the new `tls` option that should be used instead.