### PR TITLE
sslh: add transparent proxy support

### DIFF
--- a/net/sslh/Makefile
+++ b/net/sslh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sslh
 PKG_VERSION:=v1.20
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://rutschle.net/tech/sslh/

--- a/net/sslh/Makefile
+++ b/net/sslh/Makefile
@@ -26,7 +26,7 @@ define Package/sslh
   CATEGORY:=Network
   SUBMENU:=Routing and Redirection
   TITLE:=SSL/SSH multiplexer
-  DEPENDS:=+libconfig +USE_UCLIBC:libpcre +USE_MUSL:libpcre
+  DEPENDS:=+libconfig +libcap +USE_UCLIBC:libpcre +USE_MUSL:libpcre
   URL:=https://rutschle.net/tech/sslh/README.html
 endef
 
@@ -36,6 +36,7 @@ define Package/sslh/conffiles
 endef
 
 MAKE_FLAGS += \
+  USELIBCAP=1 \
   $(if $(CONFIG_USE_GLIBC),USELIBPCRE=,USELIBPCRE=1)
 
 define Package/sslh/install

--- a/net/sslh/files/sslh.config
+++ b/net/sslh/files/sslh.config
@@ -10,6 +10,9 @@ config 'sslh' 'default'
 	# ssh defaults to 'localhost:22'
 	# --ssh <sshhost>:<sshport>
 	option 'ssh' ''
+	# http defaults to 'localhost:80'
+	# --http <httphost>:<httpport>
+	option 'http' ''
 	# ssl defaults to 'localhost:443'
 	# --ssl <sslhost>:<sslport>
 	option 'ssl' ''

--- a/net/sslh/files/sslh.config
+++ b/net/sslh/files/sslh.config
@@ -13,9 +13,9 @@ config 'sslh' 'default'
 	# http defaults to 'localhost:80'
 	# --http <httphost>:<httpport>
 	option 'http' ''
-	# ssl defaults to 'localhost:443'
-	# --ssl <sslhost>:<sslport>
-	option 'ssl' ''
+	# tls defaults to 'localhost:443'
+	# --tls <tlshost>:<tlsport>
+	option 'tls' ''
 	# openvpn defaults to 'localhost:1194'
 	# --openvpn <openvpnhost>:<openvpnport>
 	option 'openvpn' ''

--- a/net/sslh/files/sslh.config
+++ b/net/sslh/files/sslh.config
@@ -28,5 +28,8 @@ config 'sslh' 'default'
 	# verbose defaults to off
 	# -v
 	option 'verbose' '0'
+	# transparent defaults to false
+	# --transparent
+	option 'transparent' '0'
 	# use external config file
 	# option configfile '/etc/sslh.conf'

--- a/net/sslh/files/sslh.init
+++ b/net/sslh/files/sslh.init
@@ -22,9 +22,9 @@ start_instance() {
 	# B) ssh parameter
 	config_get val "${section}" ssh
 	[ -n "${val}" ] && append args "--ssh ${val}"
-	# C) ssl parameter
-	config_get val "${section}" ssl
-	[ -n "${val}" ] && append args "--ssl ${val}"
+	# C) tls parameter
+	config_get val "${section}" tls
+	[ -n "${val}" ] && append args "--tls ${val}"
 	# D) openvpn parameter
 	config_get val "${section}" openvpn
 	 [ -n "${val}" ] && append args "--openvpn ${val}"

--- a/net/sslh/files/sslh.init
+++ b/net/sslh/files/sslh.init
@@ -47,6 +47,9 @@ start_instance() {
 	# J) http parameter
     config_get val "${section}" http
     [ -n "${val}" ] && append args "--http ${val}"
+	# K) transparent parameter
+	config_get_bool val "${section}" transparent 0
+	[ "${val}" -ne 0 ] && append args "--transparent"
 
 	# Defaults were removed for --user and --pidfile options
 	# in sslh 1.11; Define them here instead.


### PR DESCRIPTION
Compile with `USELIBCAP=1` to make use of POSIX capabilities. This will save the required capabilities needed for transparent proxying for unprivileged processes. Furthermore, upstream will drop support for the `ssl` option in the next future version, hence we should use `tls` instead.

Signed-off-by: Gabor Seljan <sgabe@users.noreply.github.com>

Maintainer: @jmccrohan
Compile tested: MT7621, RB750Gr3, v19.07.3
Run tested: MT7621, RB750Gr3, v19.07.0

Description:
- Transparent proxying is supported with the `--transparent` option added in v1.15 of sslh. This PR updates the init script and the configuration file to support transparent proxying.
- Capabilities are supported since v1.16 of sslh using the `USELIBCAP` compiler flag. This PR adds the `libcap` package as a dependency and enables the `USELIBCAP` flag. Capabilities support is especially needed for transparent proxying while running sslh as the unprivileged nobody user.
- The `ssl` option is deprecated and the legacy support will be removed in sslh v1.21. This PR replaces the old `ssl` option with the new `tls` option that should be used instead.