### PR TITLE
bind: add nslookup alternative to busybox nslookup

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.16.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -83,6 +83,7 @@ define Package/bind-tools
 	DEPENDS:= \
 	+bind-check \
 	+bind-dig \
+	+bind-nslookup \
 	+bind-dnssec \
 	+bind-host \
 	+bind-rndc
@@ -111,6 +112,13 @@ endef
 define Package/bind-dig
   $(call Package/bind/Default)
   TITLE+= DNS excavation tool
+endef
+
+define Package/bind-nslookup
+  $(call Package/bind/Default)
+  TITLE+= nslookup utility
+  ALTERNATIVES:= \
+	  200:/usr/bin/nslookup:/usr/libexec/nslookup-bind
 endef
 
 export BUILD_CC="$(TARGET_CC)"
@@ -234,6 +242,11 @@ define Package/bind-dig/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/dig $(1)/usr/bin/
 endef
 
+define Package/bind-nslookup/install
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nslookup $(1)/usr/libexec/nslookup-bind
+endef
+
 $(eval $(call BuildPackage,bind-libs))
 $(eval $(call BuildPackage,bind-server))
 $(eval $(call BuildPackage,bind-server-filter-aaaa))
@@ -244,3 +257,4 @@ $(eval $(call BuildPackage,bind-check))
 $(eval $(call BuildPackage,bind-dnssec))
 $(eval $(call BuildPackage,bind-host))
 $(eval $(call BuildPackage,bind-dig))
+$(eval $(call BuildPackage,bind-nslookup))


### PR DESCRIPTION
Add the bind9 nslookup utility as an alternative to busybox nslookup

Signed-off-by: Ian Cooper <iancooper@hotmail.com>

Maintainer: @nmeyerhans 
Compile tested:  x86_64 glibc, mips24k_c uClibc, mips24k_c musl
Run tested: x86_64 glibc master/trunk

Busybox nslookup is broken. Offer an alternative that isn't broken.

Where a host does not have an ipv6 address record, busybox's nslookup returns an error

```
root@openwrt:/# nslookup www.google.com
Server:		192.168.1.1
Address:	192.168.1.1#53

Name:      www.google.com
Address 1: 216.58.210.36
Address 2: 2a00:1450:4009:800::2004

root@openwrt:/# nslookup whatsmyipaddress.com
Server:		192.168.2.1
Address:	192.168.2.1#53

Name:      whatsmyipaddress.com
Address 1: 35.186.238.101
*** Can't find whatsmyipaddress.com: No answer
````

@neheb 