### PR TITLE
sslh: add capabilities support

### DIFF
--- a/net/sslh/Makefile
+++ b/net/sslh/Makefile
@@ -26,7 +26,7 @@ define Package/sslh
   CATEGORY:=Network
   SUBMENU:=Routing and Redirection
   TITLE:=SSL/SSH multiplexer
-  DEPENDS:=+libconfig +USE_UCLIBC:libpcre +USE_MUSL:libpcre
+  DEPENDS:=+libconfig +libcap +USE_UCLIBC:libpcre +USE_MUSL:libpcre
   URL:=https://rutschle.net/tech/sslh/README.html
 endef
 
@@ -36,6 +36,7 @@ define Package/sslh/conffiles
 endef
 
 MAKE_FLAGS += \
+  USELIBCAP=1 \
   $(if $(CONFIG_USE_GLIBC),USELIBPCRE=,USELIBPCRE=1)
 
 define Package/sslh/install


### PR DESCRIPTION
Compile with `USELIBCAP=1` to make use of POSIX capabilities. This will save the required capabilities needed for transparent proxying for unprivileged processes.

Signed-off-by: Gabor Seljan <sgabe@users.noreply.github.com>

Maintainer: @jmccrohan
Compile tested: MT7621, RB750Gr3, v19.07.3
Run tested: MT7621, RB750Gr3, v19.07.0

Description:
Capabilities are supported since v1.16 of sslh using the `USELIBCAP` compiler flag. This PR adds the `libcap` package as a dependency and enables the `USELIBCAP` flag. Capabilities support is especially needed for transparent proxying while running sslh as the unprivileged `nobody` user.