### PR TITLE
[restic-rest-server] command params fix names

### DIFF
--- a/net/restic-rest-server/files/etc/config/restic-rest-server
+++ b/net/restic-rest-server/files/etc/config/restic-rest-server
@@ -1,13 +1,13 @@
 config rest-server
 	option enabled '0'
 	option path '/mnt/backup'			# data directory (default "/tmp/restic")
-	#option append-only '1'				# enable append only mode
+	#option append_only '1'				# enable append only mode
 	#option cpuprofile '/mnt/backup/cpuprofile'	# write CPU profile to file
 	#option debug '1'				# output debug messages
 	#option listen ':8000'				# listen address (default ":8000")
 	#option log '/mnt/backup/http.log'		# log HTTP requests in the combined log format
-	#option private-repos '1'			# users can only access their private repo
+	#option private_repos '1'			# users can only access their private repo
 	#option prometheus '1'				# enable Prometheus metrics
 	#option tls '1'					# turn on TLS support
-	#option tls-cert '/mnt/backup/public_key'	# TLS certificate path
-	#option tls-key '/mnt/backup/private_key'	# TLS key path
+	#option tls_cert '/mnt/backup/public_key'	# TLS certificate path
+	#option tls_key '/mnt/backup/private_key'	# TLS key path


### PR DESCRIPTION
for-loops in /etc/init.d/restic-rest-server [line18](https://github.com/openwrt/packages/blob/38be46a7ae496cf9f01dd2fd6fee74bc9f1b2673/net/restic-rest-server/files/etc/init.d/restic-rest-server#L18) and [line22](https://github.com/openwrt/packages/blob/38be46a7ae496cf9f01dd2fd6fee74bc9f1b2673/net/restic-rest-server/files/etc/init.d/restic-rest-server#L22) uses underlines, not dashes