### PR TITLE
libtasn1: fix host build under old GCC

### DIFF
--- a/libs/libtasn1/Makefile
+++ b/libs/libtasn1/Makefile
@@ -39,6 +39,7 @@ define Package/libtasn1/description
  Distinguish Encoding Rules (DER) manipulation.
 endef
 
+HOST_CFLAGS += -std=gnu99
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections
 


### PR DESCRIPTION
prereq-build.mk says that GCC 4.8 and above is supported. GCC 4.8
defaults to std=gnu89, breaking the build. GCC5 defaults to gnu99.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nmav 
Compile tested: CentOS7