### PR TITLE
clamav: update to version 0.102.3 (security fix)

### DIFF
--- a/net/clamav/Makefile
+++ b/net/clamav/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=clamav
-PKG_VERSION:=0.102.2
-PKG_RELEASE:=2
+PKG_VERSION:=0.102.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.clamav.net/downloads/production/
-PKG_HASH:=89fcdcc0eba329ca84d270df09d2bb89ae55f5024b0c3bddb817512fb2c907d3
+PKG_HASH:=ed3050c4569989ee7ab54c7b87246b41ed808259632849be0706467442dc0693
 
 PKG_MAINTAINER:=Marko Ratkaj <marko.ratkaj@sartura.hr> \
 		Lucian Cristian <lucian.cristian@gmail.com>


### PR DESCRIPTION
Maintainer: @lucize 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates ClamAV to version 0.102.3 which fixes two security issues.

[Full Changelog](https://blog.clamav.net/2020/05/clamav-01023-security-patch-released.html)

Fixes:
[CVE-2020-3341](https://nvd.nist.gov/vuln/detail/CVE-2020-3341)
[CVE-2020-3327](https://nvd.nist.gov/vuln/detail/CVE-2020-3327)

