### PR TITLE
modemmanager: set interface MTU based on bearer settings

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
 PKG_VERSION:=1.12.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager

--- a/net/modemmanager/files/modemmanager.proto
+++ b/net/modemmanager/files/modemmanager.proto
@@ -204,10 +204,9 @@ modemmanager_connected_method_static_ipv4() {
 		proto_notify_error "${interface}" PREFIX_MISSING
 		return
 	}
-
 	mask=$(cdr2mask "${prefix}")
 
-	# TODO: mtu reporting in proto handler
+	[ -n "${mtu}" ] && /sbin/ip link set dev "${wwan}" mtu "${mtu}"
 
 	proto_init_update "${wwan}" 1
 	proto_set_keep 1
@@ -270,7 +269,7 @@ modemmanager_connected_method_static_ipv6() {
 		return
 	}
 
-	# TODO: mtu reporting in proto handler
+	[ -n "${mtu}" ] && /sbin/ip link set dev "${wwan}" mtu "${mtu}"
 
 	proto_init_update "${wwan}" 1
 	proto_set_keep 1


### PR DESCRIPTION
Using the same method used by other protocol handlers like uqmi.

Fixes https://github.com/openwrt/packages/issues/11383

Signed-off-by: Aleksander Morgado <aleksander@aleksander.es>

Maintainer: @nickberry17 
