### PR TITLE
lxc: start() during boot()

### DIFF
--- a/utils/lxc/Makefile
+++ b/utils/lxc/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lxc
 PKG_VERSION:=4.0.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://linuxcontainers.org/downloads/lxc/

--- a/utils/lxc/files/lxc-auto.init
+++ b/utils/lxc/files/lxc-auto.init
@@ -68,4 +68,6 @@ boot() {
 	if [ ! -d /run ]; then
 		ln -s /var/run /run
 	fi
+
+	start
 }


### PR DESCRIPTION
Maintainer: @ratkaj
Compile tested: x86, master
Run tested: x86, master

Description: Broken by https://github.com/openwrt/packages/commit/9f43594e3a28deeea18cfa40acd0b1388e64f600 as this introduces boot(). And in my testing adding boot() stops start() from being called automatically.

I also noticed that when upgrading from LXC 2 to LXC 4 it seems I manually have to add the following to the image "config" file to make the image to be able to start (only tried Debian+Ubuntu)
_lxc.cgroup.devices.allow =
lxc.cgroup.devices.deny =_
or
_lxc.include = /usr/share/lxc/config/userns.conf_
(includes the same two lines)

Maybe this can be done automatically by making a patch to templates/lxc-download but I'm not sure how / or if it's a proper fix at all. I simply found out to add the two lines by googling and some trial and error.