### PR TITLE
transmission: init script check syscall list for seccomp

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=3.00
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -63,6 +63,7 @@ transmission() {
 	config_get nice "$cfg" nice 0
 	local web_home
 	config_get web_home "$cfg" 'web_home'
+	local seccomp_path
 
 	local MEM
 	MEM=$(sed -ne 's!^MemTotal:[[:space:]]*\([0-9]*\) kB$!\1!p' /proc/meminfo)
@@ -133,7 +134,11 @@ transmission() {
 	procd_set_param nice "$nice"
 	procd_set_param stderr 1
 	procd_set_param respawn
-	procd_set_param seccomp "/etc/seccomp/transmission-daemon.json"
+
+	seccomp_path="/etc/seccomp/transmission-daemon.json"
+	if [ -f "$seccomp_path" ]; then
+		procd_set_param seccomp "$seccomp_path"
+	fi
 
 	if [ -z "$USE" ]; then
 		procd_set_param limits core="0 0"


### PR DESCRIPTION
maintainer: @neheb 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR adds check for seccomp json file in int script. The reason for this is, that without it transmission will crash.  This could happen for example in case your transmission package was compiled on SDK with disabled seccomp but your system is running with seccomp enabled.  In that case, the package will not contain JSON file. see https://github.com/openwrt/openwrt/blob/master/include/package-seccomp.mk#L11 and https://github.com/openwrt/packages/blob/master/net/transmission/Makefile#L154
