### PR TITLE
avahi: fix reliance on config symbol SSP_SUPPORT

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avahi
 PKG_VERSION:=0.8
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lathiat/avahi/releases/download/v$(PKG_VERSION) \
@@ -251,7 +251,7 @@ $(call Package/avahi/Default/description)
 endef
 
 TARGET_CFLAGS += $(FPIC) -DGETTEXT_PACKAGE
-TARGET_LDFLAGS += $(if $(CONFIG_SSP_SUPPORT),-lssp_nonshared)
+TARGET_LDFLAGS += $(if $(CONFIG_GCC_LIBSSP),-lssp_nonshared)
 
 CONFIGURE_ARGS += \
 	--enable-shared \


### PR DESCRIPTION
The config symbol SSP_SUPPORT is ambiguous and means different
things to different packages: either "toolchain is compiled
with ssp support" or "toolchain uses gcc libssp". The use of the
symbol should be deprecated and the appropriate symbol used
instead.

Signed-off-by: Ian Cooper <iancooper@hotmail.com>

Maintainer: @thess 
Compile tested: mips musl, x86_64 glibc, arc ucLibc with stack protection on and off in all cases
Run tested: x86_64 glibc

Musl uses libssp_nonshared.a, which is automatically linked and does not need to be explicitly specified. If using SSP with glibc or uClibc, they currently use gcc's libssp, which has a similarly named static variant of libssp.

```
 config SSP_SUPPORT
        default y if USE_MUSL || GCC_LIBSSP
        bool
```

However, if we were to switch to using the native ssp implementations of glibc and uClibc, then this will cause an attempted link of a non-existent libssp_nonshared.a. See [here](https://patchwork.ozlabs.org/project/openwrt/patch/KU1PR01MB2022BE75254218CF30E1C9B7ADB00@KU1PR01MB2022.apcprd01.prod.exchangelabs.com/)

This patch switches to using the right symbol needed to base a link decision on and thus will be ignored if gcc's libssp is not being used. It preserves current behaviour intact.

cc @neheb 
