### PR TITLE
Lxml bump 4 5 1

### DIFF
--- a/lang/python/python-lxml/Makefile
+++ b/lang/python/python-lxml/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-lxml
-PKG_VERSION:=4.4.2
-PKG_RELEASE:=3
+PKG_VERSION:=4.5.1
+PKG_RELEASE:=1
 
 PYPI_NAME:=lxml
-PKG_HASH:=eff69ddbf3ad86375c344339371168640951c302450c5d3e9936e98d6459db06
+PKG_HASH:=27ee0faf8077c7c1a589573b1450743011117f1aa1a91d5ae776bbc5ca6070f2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSES.txt
@@ -40,17 +40,6 @@ define Package/python3-lxml/description
   It extends the ElementTree API significantly to offer support for
   XPath, RelaxNG, XML Schema, XSLT, C14N and much more.
 endef
-
-TARGET_LDFLAGS += -lxml2 -lxslt -lexslt
-
-PYTHON3_PKG_SETUP_ARGS += \
-	--static
-
-PYTHON3_PKG_SETUP_VARS += \
-	INCLUDE="$(STAGING_DIR)/usr/include/ $(STAGING_DIR)/usr/include/libxml2" \
-	LIBRARY="$(STAGING_DIR)/usr/lib $(STAGING_DIR)/lib" \
-	CFLAGS="$(TARGET_CFLAGS)" \
-	LDFLAGS="$(TARGET_LDFLAGS)"
 
 $(eval $(call Py3Package,python3-lxml))
 $(eval $(call BuildPackage,python3-lxml))

--- a/libs/libxslt/Makefile
+++ b/libs/libxslt/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxslt
 PKG_VERSION:=1.1.34
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
@@ -73,7 +73,6 @@ CONFIGURE_ARGS += \
 	--without-debug \
 	--without-mem-debug \
 	--without-debugger \
-	--without-profiler \
 	--without-plugins
 
 HOST_CONFIGURE_ARGS += \


### PR DESCRIPTION
Maintainer: me, @jslachta 
Compile tested: https://github.com/openwrt/openwrt/commit/4661b053908f2a955a70fcb8a691736a90ce6308 x86
Run tested: https://github.com/openwrt/openwrt/commit/4661b053908f2a955a70fcb8a691736a90ce6308  x86

--------------------------------------------

Took a while to get this running.
It turns out, the fix is mostly in libxslt.
lxml uses the xsltGetProfileInformation() function, which is disabled from libxslt via --without-profiler.
This causes a runtime error, since it cannot find the symbol. 

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>