### PR TITLE
acpid: fix init script

### DIFF
--- a/utils/acpid/Makefile
+++ b/utils/acpid/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acpid
 PKG_VERSION:=2.0.32
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/acpid2

--- a/utils/acpid/files/acpid.init
+++ b/utils/acpid/files/acpid.init
@@ -1,4 +1,4 @@
-#!/bin/ash /etc/rc.common
+#!/bin/sh /etc/rc.common
 # Copyright (C) 2009-2010 OpenWrt.org
 
 START=99
@@ -14,6 +14,6 @@ start_service() {
 	procd_set_param pidfile "/var/run/acpid.pid"
 }
 
-reload_service()\ {
+reload_service() {
 	procd_send_signal "acpid"
 }


### PR DESCRIPTION
init script would error:
````
procd: /etc/rc.d/S99acpid: /etc/rc.common: /etc/rc.d/S99acpid: line 18: procd_send_signal: not found
procd: /etc/rc.d/S99acpid: /etc/rc.common: /etc/rc.d/S99acpid: line 19: syntax error: unexpected "}"
````
Signed-off-by: Rob Mosher <nyt-openwrt@countercultured.net>

Maintainer:  @neheb, @heil  
Run tested: (x86_64, boots properly, no errors)
````
root@rooter:~# logread | grep -i acpid | cut -d' ' -f7-
acpid: starting up with netlink and the input layer
acpid: 1 rule loaded
acpid: waiting for events: event logging is off
procd: Not starting instance acpid::data, command not set
````
