### PR TITLE
pdns-recursor: update to 4.2.2

### DIFF
--- a/net/pdns-recursor/Makefile
+++ b/net/pdns-recursor/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns-recursor
-PKG_VERSION:=4.2.1
-PKG_RELEASE:=2
+PKG_VERSION:=4.2.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=8d8c3235cc5281f0fc51946129f22758778f4c50bfda095d5856feb4c756891f
+PKG_HASH:=9502de8ab7dde3fe5ecb3dea0f6dd8f9c96ca5e09b06f3d58d2f123abf6f7204
 
 PKG_MAINTAINER:=James Taylor <james@jtaylor.id.au>
 PKG_LICENCE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: Ubuntu - musl-libc toolchain, OpenWRT SNAPSHOT
Run tested: Linksys WRT1900ACS - OpenWRT Snapshot

Description:
Updates pdns-recursor to latest release in the 4.2 series.

Includes backported fixes for CVE-2020-10995, CVE-2020-12244 and
CVE-2020-10030, plus avoid a crash when loading an invalid RPZ.

Full change log for this release is available at:
https://doc.powerdns.com/recursor/changelog/4.2.html#change-4.2.2

Signed-off-by: James Taylor <james@jtaylor.id.au>
