### PR TITLE
pdns: update to 4.2.2

### DIFF
--- a/net/pdns/Makefile
+++ b/net/pdns/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pdns
-PKG_VERSION:=4.2.1
-PKG_RELEASE:=3
+PKG_VERSION:=4.2.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/
-PKG_HASH:=f65019986b8fcbb1c6fffebcded04b2b397b84395830f4c63e8d119bcfa1aa28
+PKG_HASH:=3a1b524b9cecd1a38fdc2e71082d9f52471d22735113a890016ff48baee16b15
 
 PKG_MAINTAINER:=James Taylor <james@jtaylor.id.au>
 PKG_LICENCE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: Ubuntu - musl-libc toolchain, OpenWRT SNAPSHOT
Run tested: Linksys WRT1900ACS - OpenWRT Snapshot

Description:
Updates pdns to latest release in the 4.2 series.

Full change log for this release is available at:
https://doc.powerdns.com/authoritative/changelog/4.2.html#change-4.2.2

Signed-off-by: James Taylor james@jtaylor.id.au