### PR TITLE
[19.07] treewide: use relative include paths for python Makefiles

### DIFF
--- a/libs/libmraa/Makefile
+++ b/libs/libmraa/Makefile
@@ -26,8 +26,8 @@ PKG_USE_MIPS16:=0
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
-include $(TOPDIR)/feeds/packages/lang/python/python-package.mk
-include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
+include ../../lang/python/python-package.mk
+include ../../lang/python/python3-package.mk
 
 CMAKE_OPTIONS=-DENABLEEXAMPLES=0 \
 	-DFIRMATA=ON

--- a/libs/libupm/Makefile
+++ b/libs/libupm/Makefile
@@ -25,8 +25,8 @@ PKG_USE_MIPS16:=0
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
-include $(TOPDIR)/feeds/packages/lang/python/python-package.mk
-include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
+include ../../lang/python/python-package.mk
+include ../../lang/python/python3-package.mk
 
 UPM_MODULES:= \
 	a110x abp ad8232 adafruitms1438 adafruitss adc121c021 adis16448 ads1x15 adxl335 adxl345 \

--- a/net/freeradius3/Makefile
+++ b/net/freeradius3/Makefile
@@ -30,8 +30,8 @@ PKG_CONFIG_DEPENDS := \
 CFLAGS += $(FPIC)
 
 include $(INCLUDE_DIR)/package.mk
-include $(TOPDIR)/feeds/packages/lang/python/python-package.mk
-include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
+include ../../lang/python/python-package.mk
+include ../../lang/python/python3-package.mk
 
 define Package/freeradius3/config
   source "$(SOURCE)/Config.in"

--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -37,9 +37,9 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/kernel.mk
 include $(INCLUDE_DIR)/version.mk
-include $(TOPDIR)/feeds/packages/lang/python/python3-host.mk
-#include $(TOPDIR)/feeds/packages/lang/python/python-package.mk
-include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
+include ../../lang/python/python3-host.mk
+#include ../../lang/python/python-package.mk
+include ../../lang/python/python3-package.mk
 
 define Package/samba4/Default
   SECTION:=net


### PR DESCRIPTION
This updates the include paths for python(3)-package.mk to be relative
to the package Makefile. If not, in certain cases this will print errors
like the following one:

ERROR: please fix feeds/openwrt/net/freeradius3/Makefile
   - see logs/feeds/openwrt/net/freeradius3/dump.txt for details

In the dump.txt there is the following:

Makefile:42: /mylocalpath/feeds/packages/lang/python/python3-package.mk: No such file or directory
make[1]: *** No rule to make target '/mylocalpath/feeds/packages/lang/python/python3-package.mk'.  Stop.

The relative path is used already in 19.07 for most of the packages, and
has been updated for the packages at hand in master as well:

302f4d17e336 ("libmraa,libupm: Disable default Python package build recipe")
1bc2f4f3c621 ("treewide: Remove Python variants for non-Python packages")