### PR TITLE
uacme: remove cron entry on package removal

### DIFF
--- a/net/uacme/Makefile
+++ b/net/uacme/Makefile
@@ -91,4 +91,9 @@ define Package/uacme/install
 	$(INSTALL_BIN) ./files/acme.init $(1)/etc/init.d/acme
 endef
 
+define Package/uacme/prerm
+#!/bin/sh
+sed -i '/\/etc\/init\.d\/acme start/d' /etc/crontabs/root
+endef
+
 $(eval $(call BuildPackage,uacme))


### PR DESCRIPTION
Previously, the cron config was not removed on uninstall. This change fixes
that.

Signed-off-by: Wren Turkal <wt@penguintechs.org>

Maintainer: @pesintta 
Compile tested: Turris Omnia
Run tested: None

Description:
The same diff was applied to the acme package as well. I jut noticed that this package had the same issue.