### PR TITLE
dovecot: update to version 2.3.10.1 (security fix)

### DIFF
--- a/mail/dovecot/Makefile
+++ b/mail/dovecot/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dovecot
-PKG_VERSION:=2.3.10
+PKG_VERSION:=2.3.10.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dovecot.org/releases/2.3
-PKG_HASH:=473184723d854a4d1dbd99c11a7b9f65156ca5fe6ecf85d9a44b5127e6f871c5
+PKG_HASH:=6642e62f23b1b23cfac235007ca6e21cb67460cca834689fad450724456eb10c
 
 PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 PKG_LICENSE:=LGPL-2.1-only MIT BSD-3-Clause


### PR DESCRIPTION

maintainer: @lucize 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master



Description:
This PR updates dovecot to version 2.3.10.1, it is a security update that fixes 3 security issues related to DoS.

[Security issues descriptions](https://dovecot.org/pipermail/dovecot-news/2020-May/000438.html)

Fixes:
CVE-2020-10957
CVE-2020-10958
CVE-2020-10967

This should be also cherry-picked to 19.07


