### PR TITLE
ncdu: update to 1.15

### DIFF
--- a/utils/ncdu/Makefile
+++ b/utils/ncdu/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ncdu
-PKG_VERSION:=1.14.2
+PKG_VERSION:=1.15
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dev.yorhel.nl/download
-PKG_HASH:=947a7f5c1d0cd4e338e72b4f5bc5e2873651442cec3cb012e04ad2c37152c6b1
+PKG_HASH:=4a593dc5cceb2492a9669f5f5d69d0e517de457a11036788ea4591f33c5297fb
 
-PKG_MAINTAINER:=Charles Lehner <celehner1@gmail.com>
+PKG_MAINTAINER:=Charles E. Lehner <cel@celehner.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
 


### PR DESCRIPTION
Maintainer: me
Compile tested: openwrt-sdk-19.07.3-ar71xx-generic_gcc-7.5.0_musl.Linux-x86_64
Run tested: ar71xx-ath79 generic mips_24kc TP-Link TL-WDR3500 OpenWrt 19.07.3. Works.

<https://dev.yorhel.nl/ncdu/changes>:
> 1.15 - 2020-05-30 - ncdu-1.15.tar.gz
> - (Linux) Add --exclude-kernfs option to exclude pseudo filesystems (Christian Göttsche)
> - ~~(MacOS) Exclude firmlinks by default (Saagar Jha)~~
> - ~~(MacOS) Add --follow-firmlinks option to follow firmlinks (Saagar Jha)~~
> - Fix bug in calculating the apparent size of directories containing hardlinks
> - Fix integer overflow with directories containing >2GiB worth of file names
> - Fix yet another possible 100% CPU bug when losing terminal
