### PR TITLE
transmission: add a disabled notification

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=3.00
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -41,7 +41,11 @@ transmission() {
 
 	local enabled
 	config_get_bool enabled "$cfg" enabled 0
-	[ "$enabled" -gt 0 ] || return 1
+	[ "$enabled" -gt 0 ] || {
+		echo "Transmission not enabled. Please enable in /etc/config/transmission"
+		logger -t "transmission" -p "daemon.info" "Transmission not enabled. Please enable in /etc/config/transmission"
+		return 1
+	}
 
 	local config_dir
 	config_get config_dir "$cfg" 'config_dir' '/var/etc/transmission'


### PR DESCRIPTION
Helps to see that transmission must be enabled.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: me

Fixes: https://github.com/openwrt/packages/issues/12317

ping @BKPepe 