### PR TITLE
knxd: bump to upstream version 0.14.38

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -11,12 +11,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
-PKG_VERSION:=0.14.37
+PKG_VERSION:=0.14.38
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=c3fc5777c39e40afb3dfffd74907954c8951d05134d04d44d1acf3362db6ca59
+PKG_HASH:=bb0343154ee1d0d91b1b342f04ee163739e906ac530b7490b5aec516bb485d59
 
 PKG_MAINTAINER:=Othmar Truniger <github@truniger.ch>
 PKG_LICENSE:=GPL-2.0-or-later

--- a/net/knxd/patches/0100-version.patch
+++ b/net/knxd/patches/0100-version.patch
@@ -5,4 +5,4 @@
 
 -test -d .git || exit
 -git describe --tags
-+echo -n "0.14.37"
++echo -n "0.14.38"


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

Maintainer: me
Compile tested: mpc85xx, tl-wdr4900-v1, trunk
Compile tested: ath79, tplink_archer-c7-v4, trunk
Compile tested: ramips, mt7620a, trunk
Run tested: ath79, tp-link Archer C7 v4, trunk

Description:
new upstream release 0.14.38

