### PR TITLE
update netdata to 1.22.1

### DIFF
--- a/admin/netdata/Makefile
+++ b/admin/netdata/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netdata
-PKG_VERSION:=1.20.0
+PKG_VERSION:=1.22.1
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>, Daniel Engberg <daniel.engberg.lists@pyret.net>
@@ -18,7 +18,7 @@ PKG_CPE_ID:=cpe:/a:my-netdata:netdata
 
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/netdata/netdata/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=c739e0fa8d6d7f433c0c7c8016b763e8f70519d67f0b5e7eca9ee5318f210d90
+PKG_HASH:=6efd785eab82f98892b4b4017cadfa4ce1688985915499bc75f2f888765a3446
 
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Hi,
first step is to bump this makefile to version 1.22.1

next is to get the agent and the agent-register script compiled and running as well... then We can watch our router status on nextdata.cloud.
You may help? :)
Thanks!

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: on debian10 machine cross compield for armv7 (as entware)
Run tested: on an armv7 mipsel asus rt-ac88u

Description:
bumping to 1.22.1 

Looks like it needs some further rework to get the netw cloud integration working. I will try things out. maybe you guys will try, too? :)