### PR TITLE
telldus-core: fix compilation with libcxx 10

### DIFF
--- a/utils/telldus-core/Makefile
+++ b/utils/telldus-core/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=telldus-core
 PKG_VERSION:=2.1.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download.telldus.com/TellStick/Software/telldus-core/
@@ -42,7 +42,7 @@ define Package/telldus-core/conffiles
 /etc/tellstick.conf
 endef
 
-CMAKE_OPTIONS+=\
+CMAKE_OPTIONS += \
 	-DBUILD_LIBTELLDUS-CORE=1 \
 	-DBUILD_TDTOOL=1 \
 	-DGENERATE_MAN=0 \

--- a/utils/telldus-core/patches/940-cxx11.patch
+++ b/utils/telldus-core/patches/940-cxx11.patch
@@ -1,0 +1,29 @@
+--- a/common/Event.h
++++ b/common/Event.h
+@@ -9,7 +9,7 @@
+ 
+ 
+ #ifndef _WINDOWS
+-	#include <tr1/memory>
++	#include <memory>
+ 	typedef void* EVENT_T;
+ #else
+ 	#include <windows.h>
+@@ -32,7 +32,7 @@ namespace TelldusCore {
+ 		virtual bool isValid() const;
+ 	};
+ 
+-	typedef std::tr1::shared_ptr<EventData> EventDataRef;
++	typedef std::shared_ptr<EventData> EventDataRef;
+ 
+ 	class EventBase {
+ 	public:
+@@ -74,7 +74,7 @@ namespace TelldusCore {
+ 		friend class EventHandler;
+ 	};
+ 
+-	typedef std::tr1::shared_ptr<Event> EventRef;
++	typedef std::shared_ptr<Event> EventRef;
+ }
+ 
+ #endif  // TELLDUS_CORE_COMMON_EVENT_H_

--- a/utils/telldus-core/patches/950-pthread.patch
+++ b/utils/telldus-core/patches/950-pthread.patch
@@ -1,0 +1,21 @@
+--- a/common/Thread.cpp
++++ b/common/Thread.cpp
+@@ -16,6 +16,8 @@
+ #endif
+ #include "common/EventHandler.h"
+ 
++#include <pthread.h>
++
+ namespace TelldusCore {
+ 
+ class ThreadPrivate {
+--- a/service/Timer.cpp
++++ b/service/Timer.cpp
+@@ -7,6 +7,7 @@
+ #include "service/Timer.h"
+ #ifdef _WINDOWS
+ #else
++#include <pthread.h>
+ #include <sys/time.h>
+ #include <errno.h>
+ #endif

--- a/utils/telldus-core/patches/960-time.patch
+++ b/utils/telldus-core/patches/960-time.patch
@@ -1,0 +1,20 @@
+--- a/service/DeviceManager.h
++++ b/service/DeviceManager.h
+@@ -7,6 +7,7 @@
+ #ifndef TELLDUS_CORE_SERVICE_DEVICEMANAGER_H_
+ #define TELLDUS_CORE_SERVICE_DEVICEMANAGER_H_
+ 
++#include <ctime>
+ #include <set>
+ #include <string>
+ #include "service/Device.h"
+--- a/service/Sensor.h
++++ b/service/Sensor.h
+@@ -7,6 +7,7 @@
+ #ifndef TELLDUS_CORE_SERVICE_SENSOR_H_
+ #define TELLDUS_CORE_SERVICE_SENSOR_H_
+ 
++#include <ctime>
+ #include <string>
+ #include "common/Mutex.h"
+ 


### PR DESCRIPTION
Missing headers and wrong namespace.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @PeterFromSweden 
Compile tested: ath79