### PR TITLE
gerbera: fix compilation with libcxx 10

### DIFF
--- a/multimedia/gerbera/Makefile
+++ b/multimedia/gerbera/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gerbera
 PKG_VERSION:=1.5.0
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/gerbera/gerbera/tar.gz/v$(PKG_VERSION)?

--- a/multimedia/gerbera/patches/020-pid.patch
+++ b/multimedia/gerbera/patches/020-pid.patch
@@ -1,0 +1,22 @@
+--- a/src/util/process.h
++++ b/src/util/process.h
+@@ -35,6 +35,8 @@
+ #include <memory>
+ #include <string>
+ 
++#include <unistd.h>
++
+ // forward declaration
+ class Config;
+ 
+--- a/src/util/process_executor.h
++++ b/src/util/process_executor.h
+@@ -35,6 +35,8 @@
+ #include <string>
+ #include <vector>
+ 
++#include <unistd.h>
++
+ #include "executor.h"
+ 
+ class ProcessExecutor : public Executor {


### PR DESCRIPTION
Missing header for pid_t.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ath79