### PR TITLE
kismet: fix compilation with libcxx 10

### DIFF
--- a/net/kismet/Makefile
+++ b/net/kismet/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kismet
 PKG_VERSION:=2016-07-R1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_LICENSE:=LGPLv2.1
 PKG_CPE_ID:=cpe:/a:kismet:kismet

--- a/net/kismet/patches/030-libcxx.patch
+++ b/net/kismet/patches/030-libcxx.patch
@@ -1,3 +1,14 @@
+--- a/ipc_remote.cc
++++ b/ipc_remote.cc
+@@ -914,7 +914,7 @@ int RootIPCRemote::OpenFDPassSock() {
+ 			return -1;
+ 		}
+ 
+-		if (bind(ipc_fd_fd, (const struct sockaddr *) &unixsock, sizeof(unixsock))) {
++		if (::bind(ipc_fd_fd, (const struct sockaddr *) &unixsock, sizeof(unixsock))) {
+ 			close(ipc_fd_fd);
+ 			_MSG("Failed to bind socket to pass file descriptors: " + 
+ 				 string(strerror(errno)), MSGFLAG_ERROR);
 --- a/packetsource_wext.cc
 +++ b/packetsource_wext.cc
 @@ -405,7 +405,7 @@ void PacketSource_Wext::OpenWpaSupplicant() {


### PR DESCRIPTION
Seems a bind call is missing.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @padre-lacroix 
Compile tested: ath79