### PR TITLE
nmap: fix compilation with libcxx 10

### DIFF
--- a/net/nmap/Makefile
+++ b/net/nmap/Makefile
@@ -14,7 +14,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nmap
 PKG_VERSION:=7.80
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Nuno Goncalves <nunojpg@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/net/nmap/patches/030-libcxx.patch
+++ b/net/nmap/patches/030-libcxx.patch
@@ -1,0 +1,20 @@
+--- a/nmap_error.cc
++++ b/nmap_error.cc
+@@ -134,6 +134,7 @@
+ #include "NmapOps.h"
+ #include "xml.h"
+ 
++#include <ctime>
+ #include <errno.h>
+ #if TIME_WITH_SYS_TIME
+ # include <sys/time.h>
+--- a/nping/EchoServer.cc
++++ b/nping/EchoServer.cc
+@@ -137,6 +137,7 @@
+ #include "NpingOps.h"
+ #include "ProbeMode.h"
+ #include <signal.h>
++#include <ctime>
+ 
+ extern NpingOps o;
+ extern EchoServer es;


### PR DESCRIPTION
Seems nmap's time header logic is broken.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @nunojpg 
Compile tested: ath79