### PR TITLE
dnsdist: fix compilation with libcxx 10

### DIFF
--- a/net/dnsdist/Makefile
+++ b/net/dnsdist/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsdist
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://downloads.powerdns.com/releases/

--- a/net/dnsdist/patches/010-libcxx.patch
+++ b/net/dnsdist/patches/010-libcxx.patch
@@ -1,0 +1,41 @@
+From 405bdec807a7b530173ebf018843c4552dfa20c9 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Sat, 6 Jun 2020 11:33:55 -0700
+Subject: [PATCH] use std::string_view when available
+
+There's a standard C++ macro to check for its existence.
+
+libstdc++ from GCC makes it available under C++17 and up. libcxx from
+LLVM makes it available everywhere.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ ext/lmdb-safe/lmdb-safe.hh | 7 +++----
+ pdns/dnsdistdist/views.hh  | 7 +++----
+ 2 files changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/ext/lmdb-safe/lmdb-safe.hh b/ext/lmdb-safe/lmdb-safe.hh
+index 056a6cd823..16d150fa7d 100644
+--- a/ext/lmdb-safe/lmdb-safe.hh
++++ b/ext/lmdb-safe/lmdb-safe.hh
+@@ -10,8 +10,9 @@
+ #include <string.h>
+ #include <mutex>
+ 
+-// apple compiler somehow has string_view even in c++11!
+-#if __cplusplus < 201703L && !defined(__APPLE__)
++#ifdef __cpp_lib_string_view
++using std::string_view;
++#else
+ #include <boost/version.hpp>
+ #if BOOST_VERSION >= 106100
+ #include <boost/utility/string_view.hpp>
+@@ -20,8 +21,6 @@ using boost::string_view;
+ #include <boost/utility/string_ref.hpp>
+ using string_view = boost::string_ref;
+ #endif
+-#else // C++17
+-using std::string_view;
+ #endif
+ 
+ 

--- a/net/dnsdist/patches/020-std.patch
+++ b/net/dnsdist/patches/020-std.patch
@@ -1,0 +1,25 @@
+From 6910a23b67f64bd71ffb26c1888fb9d8b99acfa6 Mon Sep 17 00:00:00 2001
+From: Peter van Dijk <peter.van.dijk@powerdns.com>
+Date: Mon, 9 Mar 2020 19:10:00 +0100
+Subject: [PATCH] auth lmdb: avoid blanket std import; fixes #8872
+
+---
+ ext/lmdb-safe/lmdb-safe.cc | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/ext/lmdb-safe/lmdb-safe.cc b/ext/lmdb-safe/lmdb-safe.cc
+index f4874261f6..c29d291473 100644
+--- a/ext/lmdb-safe/lmdb-safe.cc
++++ b/ext/lmdb-safe/lmdb-safe.cc
+@@ -6,7 +6,10 @@
+ #include <string.h>
+ #include <map>
+ 
+-using namespace std;
++using std::string;
++using std::runtime_error;
++using std::tuple;
++using std::weak_ptr;
+ 
+ static string MDBError(int rc)
+ {


### PR DESCRIPTION
string_view is available with both boost and std.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @James-TR 
Compile tested: ath79