### PR TITLE
unbound: expose interface-auto to UCI

### DIFF
--- a/net/unbound/files/README.md
+++ b/net/unbound/files/README.md
@@ -259,6 +259,10 @@ config unbound
     Boolean. If enabled version.server, version.bind, id.server, and
     hostname.bind queries are refused.
 
+  option interface_auto '0'
+    Boolean. If enabled DNS replies will have the same source address as
+    the request was sent to.
+
   option listen_port '53'
     Port. Incoming. Where Unbound will listen for queries.
 

--- a/net/unbound/files/unbound.sh
+++ b/net/unbound/files/unbound.sh
@@ -36,6 +36,7 @@ UB_B_NTP_BOOT=1
 UB_B_QUERY_MIN=0
 UB_B_QRY_MINST=0
 UB_B_AUTH_ROOT=0
+UB_B_IF_AUTO=0
 
 UB_D_CONTROL=0
 UB_D_DOMAIN_TYPE=static
@@ -720,6 +721,11 @@ unbound_conf() {
   esac
 
 
+  if [ "$UB_B_IF_AUTO" -gt 0 ] ; then
+    echo "  interface-automatic: yes" >> $UB_CORE_CONF
+  fi
+
+
   case "$UB_D_RESOURCE" in
     # Tiny - Unbound's recommended cheap hardware config
     tiny)   rt_mem=1  ; rt_conn=2  ; rt_buff=1 ;;
@@ -1208,6 +1214,7 @@ unbound_uci() {
   config_get_bool UB_B_LOCL_BLCK  "$cfg" rebind_localhost 0
   config_get_bool UB_B_DNSSEC     "$cfg" validator 0
   config_get_bool UB_B_NTP_BOOT   "$cfg" validator_ntp 1
+  config_get_bool UB_B_IF_AUTO    "$cfg" interface_auto 0
 
   config_get UB_IP_DNS64    "$cfg" dns64_prefix "64:ff9b::/96"
 

--- a/net/unbound/files/unbound.uci
+++ b/net/unbound/files/unbound.uci
@@ -28,6 +28,7 @@ config unbound
 	option validator '0'
 	option validator_ntp '1'
 	option verbosity '1'
+	option interface_auto '0'
 	list trigger_interface 'lan'
 	list trigger_interface 'wan'
 	#list domain_insecure 'ntp.example.com'


### PR DESCRIPTION
Maintainer: @EricLuehrsen 
Compile tested: ipq40xx / AVM 4040
Run tested: ipq40xx / AVM 4040

Description:

This exposes the interface-auto option to UCI.

By default, interface-auto is disabled.
This leads to the DNS reply possibly originating from
a different address then the request was sent to.

Devices with a packet filter might not receive the reply in this case.

Enabling interface-auto ensures the reply is sent with the
source-address the request was sent to.

Signed-off-by: David Bauer <mail@david-bauer.net>