### PR TITLE
perl: fix build failure in GCC10

### DIFF
--- a/lang/perl/patches/999-fix-build-failure-against-gcc-10.patch
+++ b/lang/perl/patches/999-fix-build-failure-against-gcc-10.patch
@@ -1,0 +1,103 @@
+From 6bd6308fcea3541e505651bf8e8127a4a03d22cd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20P=C3=ADsa=C5=99?= <ppisar@redhat.com>
+Date: Tue, 12 Nov 2019 09:19:18 +0100
+Subject: [PATCH] Adapt Configure to GCC version 10
+
+I got a notice from Jeff Law <law@redhat.com>:
+
+    Your particular package fails its testsuite. This was ultimately
+    tracked down to a Configure problem. The perl configure script treated
+    gcc-10 as gcc-1 and turned on -fpcc-struct-return. This is an ABI
+    changing flag and caused Perl to not be able to interact properly with
+    the dbm libraries on the system leading to a segfault.
+
+His proposed patch corrected only this one instance of the version
+mismatch. Reading the Configure script revealed more issues. This
+patch fixes all of them I found.
+
+---
+ Configure | 14 +++++++-------
+ cflags.SH |  2 +-
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/Configure b/Configure
+index fad1c9f2b1..706c0b64ed 100755
+--- a/Configure
++++ b/Configure
+@@ -4701,7 +4701,7 @@ else
+ fi
+ $rm -f try try.*
+ case "$gccversion" in
+-1*) cpp=`./loc gcc-cpp $cpp $pth` ;;
++1.*) cpp=`./loc gcc-cpp $cpp $pth` ;;
+ esac
+ case "$gccversion" in
+ '') gccosandvers='' ;;
+@@ -4741,7 +4741,7 @@ esac
+ # gcc 3.* complain about adding -Idirectories that they already know about,
+ # so we will take those off from locincpth.
+ case "$gccversion" in
+-3*)
++3.*)
+     echo "main(){}">try.c
+     for incdir in $locincpth; do
+        warn=`$cc $ccflags -I$incdir -c try.c 2>&1 | \
+@@ -5467,13 +5467,13 @@ fi
+ case "$hint" in
+ default|recommended)
+ 	case "$gccversion" in
+-	1*) dflt="$dflt -fpcc-struct-return" ;;
++	1.*) dflt="$dflt -fpcc-struct-return" ;;
+ 	esac
+ 	case "$optimize:$DEBUGGING" in
+ 	*-g*:old) dflt="$dflt -DDEBUGGING";;
+ 	esac
+ 	case "$gccversion" in
+-	2*) if $test -d /etc/conf/kconfig.d &&
++	2.*) if $test -d /etc/conf/kconfig.d &&
+ 			$contains _POSIX_VERSION $usrinc/sys/unistd.h >/dev/null 2>&1
+ 		then
+ 			# Interactive Systems (ISC) POSIX mode.
+@@ -5482,7 +5482,7 @@ default|recommended)
+ 		;;
+ 	esac
+ 	case "$gccversion" in
+-	1*) ;;
++	1.*) ;;
+ 	2.[0-8]*) ;;
+ 	?*)	set strict-aliasing -fno-strict-aliasing
+ 		eval $checkccflag
+@@ -5600,7 +5600,7 @@ case "$cppflags" in
+     ;;
+ esac
+ case "$gccversion" in
+-1*) cppflags="$cppflags -D__GNUC__"
++1.*) cppflags="$cppflags -D__GNUC__"
+ esac
+ case "$mips_type" in
+ '');;
+@@ -23103,7 +23103,7 @@ fi
+ 
+ : add -D_FORTIFY_SOURCE if feasible and not already there
+ case "$gccversion" in
+-[4567].*)	case "$optimize$ccflags" in
++[456789].*|[1-9][0-9]*)	case "$optimize$ccflags" in
+ 	*-O*)	case "$ccflags$cppsymbols" in
+ 		*_FORTIFY_SOURCE=*) # Don't add it again.
+ 			echo "You seem to have -D_FORTIFY_SOURCE already, not adding it." >&4
+diff --git a/cflags.SH b/cflags.SH
+index e60742fed1..f1bcd6c38e 100755
+--- a/cflags.SH
++++ b/cflags.SH
+@@ -156,7 +156,7 @@ esac
+ 
+ case "$gccversion" in
+ '') ;;
+-[12]*) ;; # gcc versions 1 (gasp!) and 2 are not good for this.
++[12].*) ;; # gcc versions 1 (gasp!) and 2 are not good for this.
+ Intel*) ;; # # Is that you, Intel C++?
+ #
+ # NOTE 1: the -std=c89 without -pedantic is a bit pointless.
+-- 
+2.17.1
+


### PR DESCRIPTION
The perl Configure file was matching GCC 10 against "1*" and treating it
as GCC 1, causing ABI breakage and segfaults.

Cherry-pick the upstream patch which fixes it to check against (e.g)
"1.*" instead, which will make it work for hundreds more GCC versions
to come.

https://github.com/Perl/perl5/commit/6bd6308fcea3541

Signed-off-by: Ken Wong <xinxijishuwyq@gmail.com>

Maintainer: @pprindeville @Naoir 
Compile tested: Asus RT-AC85P, OpenWRT master
Run tested: x

This supersedes #12178 in which we're being cruel to a potential contributor by asking them to "fix" their commit message without telling them how. If they knew what we were asking for, they might have done it in the first place.

@xinxijishuwyq here's what I think you were being asked for:
 • Make it clearer that the patch is cherry-picked from upstream, and provide the reference
 • Use the precise patch that was merged upstream (there are a couple of minor differences)
 • Include an explanation of the problem in the OpenWRT commit message.

Thanks for your contribution to OpenWRT!
