### PR TITLE
redis: update to version 6.0.4

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=6.0.1
+PKG_VERSION:=6.0.4
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
+PKG_HASH:=3337005a1e0c3aa293c87c313467ea8ac11984921fab08807998ba765c9943de
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates redis to version 6.0.4. Update is marked as CRITICAL. It fixes a bug in chained replication. Users of version 6.0.x should upgrade. 

[Full Changelog](https://raw.githubusercontent.com/antirez/redis/6.0/00-RELEASENOTES)

Run tested with a Redis benchmark.