### PR TITLE
knxd: backport fix for usblowlever.cpp from upstream

### DIFF
--- a/net/knxd/Makefile
+++ b/net/knxd/Makefile
@@ -12,7 +12,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=knxd
 PKG_VERSION:=0.14.38
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/knxd/knxd/tar.gz/$(PKG_VERSION)?

--- a/net/knxd/patches/0110-usblowlever.patch
+++ b/net/knxd/patches/0110-usblowlever.patch
@@ -1,0 +1,10 @@
+--- a/src/libserver/usblowlevel.cpp     2020-06-03 16:41:02.128182612 +0200
++++ b/src/libserver/usblowlevel.cpp     2020-06-03 16:41:31.660704440 +0200
+@@ -155,6 +155,7 @@
+ {
+   t->setAuxName("usbL");
+   send_timeout = cfg->value("send-timeout", 1000);
++  loop = nullptr;
+   read_trigger.set<USBLowLevelDriver,&USBLowLevelDriver::read_trigger_cb>(this);
+   write_trigger.set<USBLowLevelDriver,&USBLowLevelDriver::write_trigger_cb>(this);
+   read_trigger.start();


### PR DESCRIPTION
Signed-off-by: Othmar Truniger <github@truniger.ch>

Maintainer: me
Compile tested: mpc85xx, tl-wdr4900-v1, trunk
Compile tested: ath79, tplink_archer-c7-v4, trunk
Compile tested: ramips, mt7620a, trunk
Run tested: ath79, tp-link Archer C7 v4, trunk

Description:
backport fix for usblowlevel.cpp from upstream to avoid segfaulting on certain platforms while waiting for a new upstream release

