### PR TITLE
numpy: add new package

### DIFF
--- a/lang/python/numpy/Makefile
+++ b/lang/python/numpy/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2019 Jakub Piotr Cłapa <jpc@loee.pl>
+# Copyright (C) 2020 Alexandru Ardelean <ardeleanalex@gmail.com>
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=numpy
+PKG_VERSION:=1.18.5
+PKG_RELEASE:=1
+
+PYPI_NAME:=$(PKG_NAME)
+PKG_HASH:=34e96e9dae65c4839bd80012023aadd6ee2ccb73ce7fdf3074c62f301e63120b
+
+PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE.txt
+PKG_CPE_ID:=cpe:/a:numpy:numpy
+
+# yes, zip... sigh
+PYPI_SOURCE_EXT:=zip
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS="Cython==0.29.19"
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-numpy
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=The fundamental package for scientific computing with Python
+  URL:=https://www.numpy.org/
+  DEPENDS:=@!SOFT_FLOAT +INSTALL_GFORTRAN:libgfortran +python3
+endef
+
+define Package/python3-numpy/description
+NumPy is the fundamental package for array computing with Python.
+
+By default, this package is built without some modules.
+For some modules to be available, the INSTALL_GFORTRAN symbol needs
+to be enabled in the OpenWrt core/toolchain.
+endef
+
+$(eval $(call Py3Package,python3-numpy))
+$(eval $(call BuildPackage,python3-numpy))
+$(eval $(call BuildPackage,python3-numpy-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: x86 https://github.com/openwrt/openwrt/commit/712e00877d69a6ec5a694c0773c764abab455b6c   ar71xx (also)
Run tested: x86 https://github.com/openwrt/openwrt/commit/712e00877d69a6ec5a694c0773c764abab455b6c

----------------------------------------------------------

Essentially, this is a re-spin from
  https://github.com/openwrt/packages/pull/9797/

But a really trimmed down version.
Only the Py3 variant is added now, which makes the Makefile really small
now.

Cython is needed on the host, to cythonize some files.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>