### PR TITLE
adguardhome: initial package recipe

### DIFF
--- a/net/adguardhome/Makefile
+++ b/net/adguardhome/Makefile
@@ -1,0 +1,66 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=adguardhome
+PKG_VERSION:=0.103.3
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=v$(PKG_VERSION)
+PKG_SOURCE_URL:=https://github.com/AdguardTeam/AdGuardHome
+PKG_MIRROR_HASH:=edf00ede9d208b7f78574e267ad2617dd4d4f06548cb2e6369cc1ad702427d9a
+
+PKG_LICENSE:=GPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE.txt
+PKG_MAINTAINER:=Dobroslaw Kijowski <dobo90@gmail.com>
+
+PKG_BUILD_DEPENDS:=golang/host node/host packr/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+GO_PKG:=github.com/AdguardTeam/AdGuardHome
+GO_PKG_EXCLUDES:=dhcpd/standalone
+GO_PKG_LDFLAGS_X:=main.version=$(PKG_VERSION) main.channel=release main.goarm=$(GO_ARM)
+
+include $(INCLUDE_DIR)/package.mk
+include ../../lang/golang/golang-package.mk
+
+define Package/adguardhome
+	SECTION:=net
+	CATEGORY:=Network
+	TITLE:=Network-wide ads and trackers blocking DNS server
+	URL:=https://github.com/AdguardTeam/AdGuardHome
+	DEPENDS:=$(GO_ARCH_DEPENDS) +ca-bundle
+endef
+
+define Package/adguardhome/conffiles
+/etc/adguardhome.yaml
+endef
+
+define Package/adguardhome/description
+Free and open source, powerful network-wide ads and trackers blocking DNS server.
+endef
+
+define Build/Compile
+	( \
+		pushd $(PKG_BUILD_DIR) ; \
+		npm --prefix client ci ; \
+		npm --prefix client run build-prod ; \
+		packr -z -v -i home ; \
+		popd ; \
+		$(call GoPackage/Build/Compile) ; \
+	)
+endef
+
+define Package/adguardhome/install
+	$(call GoPackage/Package/Install/Bin,$(1))
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/adguardhome.init $(1)/etc/init.d/adguardhome
+endef
+
+$(eval $(call GoBinPackage,adguardhome))
+$(eval $(call BuildPackage,adguardhome))

--- a/net/adguardhome/files/adguardhome.init
+++ b/net/adguardhome/files/adguardhome.init
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+
+PROG=/usr/bin/AdGuardHome
+USE_PROCD=1
+
+# starts after network starts
+START=21
+# stops before networking stops
+STOP=89
+
+start_service() {
+  procd_open_instance
+  procd_set_param command "$PROG" -c /etc/adguardhome.yaml -w /tmp/adguardhome --no-check-update
+  procd_set_param stdout 1
+  procd_set_param stderr 1
+  procd_close_instance
+}


### PR DESCRIPTION
AdGuardHome is a network-wide ads and trackers blocking DNS server.
After installing it with opkg, start it like every service:
`/etc/init.d/adguardhome start`

In order to complete the installation visit http://{YOUR_ROUTERS_IP}:3000.

Then you can setup dnsmasq to forward DNS traffic to AdGuardHome:
```
uci -q delete dhcp.@dnsmasq[0].server
uci add_list dhcp.@dnsmasq[0].server=127.0.0.1#{PORT_SET_DURING_INSTALL}
uci set dhcp.@dnsmasq[0].noresolv=1
uci commit dhcp
/etc/init.d/dnsmasq restart
```

Signed-off-by: Dobroslaw Kijowski <dobo90@gmail.com>

Maintainer: me (if someone more experienced than me volunteers I will happily give this package for maintenance)  
Compile tested: OpenWrt latest master, mipsel_24kc, Xiaomi Redmi AC2100 
Run tested: OpenWrt latest master, mipsel_24kc, Xiaomi Redmi AC2100

Description:
This is my first time creating recipe for an OpenWrt package so forgive me if I've missed something. It was a little bit tricky to create it as it uses compile-time generated assets like .js files by npm and .go files by packr.
As mentioned above if someone wants to make it proper or maintain it feel free to take it.