### PR TITLE
pixman: update to 0.40.0

### DIFF
--- a/libs/pixman/Makefile
+++ b/libs/pixman/Makefile
@@ -8,19 +8,23 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pixman
-PKG_VERSION:=0.38.4
+PKG_VERSION:=0.40.0
 PKG_RELEASE:=1
+
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=da66d6fd6e40aee70f7bd02e4f8f76fc3f006ec879d346bae6a723025cfbdde7
 PKG_SOURCE_URL:=https://www.cairographics.org/releases
+PKG_HASH:=6d200dec3740d9ec4ec8d1180e25779c00bc749f94278c8b9021f5534db223fc
+
+PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
+
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
-PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
+PKG_BUILD_DEPENDS:=meson/host
 
 include $(INCLUDE_DIR)/package.mk
-
+include ../../devel/meson/meson.mk
 
 define Package/pixman
   SECTION:=libs


### PR DESCRIPTION
Add some spacing and minor adjustments for consistency between packages

Switched to using meson for compilation. meson compiles faster.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @yousong 
Compile tested: ath79