### PR TITLE
klish: update to 2.2.0

### DIFF
--- a/utils/klish/Makefile
+++ b/utils/klish/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=klish
-PKG_VERSION:=2.1.4
-PKG_RELEASE:=2
+PKG_VERSION:=2.2.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://libcode.org/attachments/download/70/
-PKG_HASH:=a89dd1027dce713407b6d68e836c8fdead56406dcfc650da84da8e0b92c9b2e5
+PKG_SOURCE_URL:=http://libcode.org/attachments/download/77/
+PKG_HASH:=a069ef06bb485e15b2ff27b856e46cd76fee1eac7e0f62a8d8ac0ad413694614
 
 PKG_MAINTAINER:=Takashi Umeno <umeno.takashi@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @t-umeno 
Compile tested: ath79