### PR TITLE
sane-backends: update to 1.0.30

### DIFF
--- a/utils/sane-backends/Makefile
+++ b/utils/sane-backends/Makefile
@@ -9,11 +9,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sane-backends
-PKG_VERSION:=1.0.29
+PKG_VERSION:=1.0.30
 PKG_RELEASE:=1
+
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://gitlab.com/sane-project/backends/uploads/54f858b20a364fc35d820df935a86478
-PKG_HASH:=aa027b4e5f59849cd41b8c26d54584cf31fffd986049019be6ad4140e11ea8ed
+PKG_SOURCE_URL:=https://gitlab.com/sane-project/backends/uploads/c3dd60c9e054b5dee1e7b01a7edc98b0
+PKG_HASH:=3f5d96a9c47f6124a46bb577c776bbc4896dd17b9203d8bfbc7fe8cbbcf279a3
+
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=GPL-2.0 GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING LICENSE
@@ -171,7 +173,7 @@ $(call Package/sane-backends/Default/description)
 This package contains the SANE frontends.
 endef
 
-CONFIGURE_ARGS+= \
+CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
 	--disable-preload \
@@ -181,8 +183,8 @@ CONFIGURE_ARGS+= \
 	--without-usb-record-replay \
 
 # ./configure does not even try to detect mmap if crosscompiling
-CONFIGURE_VARS+= \
-    ac_cv_func_mmap_fixed_mapped="yes" \
+CONFIGURE_VARS += \
+    ac_cv_func_mmap_fixed_mapped="yes"
 
 define Build/Configure
 	mkdir -p $(PKG_BUILD_DIR)/backend/.libs


### PR DESCRIPTION
Minor cleanups.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @luizluca 
Compile tested: ath79