### PR TITLE
Jinja2: update to version 2.11.2

### DIFF
--- a/lang/python/Jinja2/Makefile
+++ b/lang/python/Jinja2/Makefile
@@ -5,11 +5,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Jinja2
-PKG_VERSION:=2.10.3
-PKG_RELEASE:=2
+PKG_VERSION:=2.11.2
+PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de
+PKG_HASH:=89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_LICENSE:=BSD-3-Clause
@@ -25,7 +25,7 @@ define Package/python3-jinja2
   CATEGORY:=Languages
   SUBMENU:=Python
   TITLE:=Jinja2
-  URL:=http://jinja.pocoo.org/
+  URL:=https://palletsprojects.com/p/jinja/
   DEPENDS:=+python3-light +python3-markupsafe
 endef
 


### PR DESCRIPTION
Maintainer: @dangowrt 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master

Description:
- Update to version [2.11.2](https://jinja.palletsprojects.com/en/2.11.x/changelog/#version-2-11-2)
- Update project website

