### PR TITLE
[18.06] simple-adblock: remove obsolete dshield.org links from config

### DIFF
--- a/net/simple-adblock/Makefile
+++ b/net/simple-adblock/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-adblock
 PKG_VERSION:=1.8.3
-PKG_RELEASE:=9
+PKG_RELEASE:=11
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
 PKG_LICENSE:=GPL-3.0-or-later
 
@@ -16,12 +16,14 @@ define Package/simple-adblock
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=Simple AdBlock Service
+	DEPENDS:=+jshn +jsonfilter
 	PKGARCH:=all
 endef
 
 define Package/simple-adblock/description
-This service provides DNSMASQ or Unbound based ad blocking.
-Please see the project's README on GitHub for further information.
+Simple adblock script to block ad or abuse/malware domains with DNSMASQ or Unbound.
+Script supports local/remote list of domains and hosts-files for both black- and white-listing.
+Please see https://github.com/openwrt/packages/blob/master/net/simple-adblock/files/README.md for more information.
 
 endef
 

--- a/net/simple-adblock/files/simple-adblock.conf
+++ b/net/simple-adblock/files/simple-adblock.conf
@@ -17,9 +17,6 @@ config simple-adblock 'config'
 # File size: 4.0K
 	list blacklist_domains_url 'https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt'
 
-# File size: 4.0K
-#	list blacklist_domains_url 'https://www.dshield.org/feeds/suspiciousdomains_High.txt'
-
 # File size: 12.0K
 	list blacklist_domains_url 'https://ssl.bblck.me/blacklists/domain-list.txt'
 

--- a/net/simple-adblock/files/simple-adblock.conf.update
+++ b/net/simple-adblock/files/simple-adblock.conf.update
@@ -2,3 +2,4 @@ s|dbl.oisd.nl|hosts.oisd.nl|g
 s|raw.githubusercontent.com/StevenBlack/hosts/|cdn.jsdelivr.net/gh/StevenBlack/hosts@|g
 s|raw.githubusercontent.com/hoshsadiq/adblock-nocoin-list/|cdn.jsdelivr.net/gh/hoshsadiq/adblock-nocoin-list@|g
 s|raw.githubusercontent.com/jawz101/MobileAdTrackers/|cdn.jsdelivr.net/gh/jawz101/MobileAdTrackers@|g
+/dshield.org/d


### PR DESCRIPTION
Maintainer: me
Compile tested: mvebu, WRT3200ACM, 19.07.3
Run tested: mvebu, WRT3200ACM, 18.06.8, verify updated config

Description:
* The dshield.org no longer offers block-lists for downloads, this update removes dshield.org entries from users' config files. This fixes the error being reported by simple-adblock and the luci app on failed download/processing of a blocklist.
* Minor updates to Makefile to improve description and dependencies.

Signed-off-by: Stan Grishin <stangri@melmac.net>
