### PR TITLE
hwinfo: disable compile with uclibc

### DIFF
--- a/utils/hwinfo/Makefile
+++ b/utils/hwinfo/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hwinfo
 PKG_VERSION:=21.70
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/openSUSE/hwinfo/tar.gz/$(PKG_VERSION)?
@@ -65,7 +65,7 @@ define Package/hwinfo
   CATEGORY:=Utilities
   TITLE:=probe the hardware present in the system
   URL:=https://github.com/openSUSE/hwinfo
-  DEPENDS:= +libuuid
+  DEPENDS:= +libuuid @!USE_UCLIBC
 endef
 
 define Package/hwinfo/description


### PR DESCRIPTION
this package fails to compile with uclibc,
disable it if the uclibc toolchain is selected

Signed-off-by: Alberto Bursi <bobafetthotmai@gmail.com>

Maintainer: me 
Compile/run tested: kirkwood and ARC (in the make menuconfig of the ARC device it is not visible nor selectable)
