### PR TITLE
cgroupfs-mount: add systemd cgroup for compatibility with lxc containers

### DIFF
--- a/utils/cgroupfs-mount/patches/10-make-systemd-cgroup-for-lxc.patch
+++ b/utils/cgroupfs-mount/patches/10-make-systemd-cgroup-for-lxc.patch
@@ -1,0 +1,12 @@
+--- ./cgroupfs-mount-orig	2017-03-08 23:06:44.000000000 +0100
++++ ./cgroupfs-mount	2019-12-05 00:18:13.535165193 +0100
+@@ -41,6 +41,9 @@ for sys in $(awk '!/^#/ { if ($4 == 1) p
+ 	fi
+ done
+ 
++mkdir -p /sys/fs/cgroup/systemd
++mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,none,name=systemd cgroup /sys/fs/cgroup/systemd
++
+ # example /proc/cgroups:
+ #  #subsys_name	hierarchy	num_cgroups	enabled
+ #  cpuset	2	3	1


### PR DESCRIPTION
Maintainer: Gerard  Ryan <G.M0N3Y.2503@gmail.com>
Compile tested: master x86-64
Run tested: master x86-64

Description:
OpenWRT does not use systemd so at the moment it does not create a systemd cgroup. However this is needed by containers which use systemd when run for example under lxc. This patch lets you use such containers.