### PR TITLE
cgroupfs-mount: enable use_hierarchy on the root cgroup

### DIFF
--- a/utils/cgroupfs-mount/files/cgroupfs-mount.init
+++ b/utils/cgroupfs-mount/files/cgroupfs-mount.init
@@ -9,4 +9,5 @@ boot() {
 	fi
 
 	cgroupfs-mount
+	echo 1 > /sys/fs/cgroup/memory/memory.use_hierarchy
 }


### PR DESCRIPTION
Maintainer: Gerard Ryan G.M0N3Y.2503@gmail.com
Compile tested: master x86-64
Run tested: master x86-64

Description:
When using docker I could see on my dmesg:

```
[   99.156810] cgroup: runc (21352) created nested cgroup for controller "memory" which has incomplete hierarchy support. Nested cgroups may change behavior in the future.
[   99.157978] cgroup: "memory" requires setting use_hierarchy to 1 on the root
```

OpenWRT mounts the root sysfs cgroup in /etc/init.d/cgroupfs-mount, which has this comment:
```
# Procd mounts non-hierarchical cgroupfs so unmount first before cgroupfs-mount
```
So the intention, if I understand correctly, is already to have hierarchical cgroups. Anyhow, the cgroup memory controller needs it.

Writing `1` to `/sys/fs/cgroup/memory/memory.use_hierarchy` right after the mount, fixes the problem.