### PR TITLE
python-packages: Remove variants

### DIFF
--- a/lang/python/python-cached-property/Makefile
+++ b/lang/python/python-cached-property/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-cached-property
 PKG_VERSION:=1.5.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=cached-property
 PKG_HASH:=9217a59f14a5682da7c4b8829deadbfc194ac22e9908ccf7c8820234e80a1504
@@ -24,7 +24,6 @@ define Package/python3-cached-property
   TITLE:=A decorator for caching properties in classes
   URL:=https://github.com/pydanny/cached-property
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-cached-property/description

--- a/lang/python/python-distro/Makefile
+++ b/lang/python/python-distro/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-distro
 PKG_VERSION:=1.5.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=distro
 PKG_HASH:=0e58756ae38fbd8fc3020d54badb8eae17c5b9dcbed388b17bb55b8a5928df92
@@ -22,7 +22,6 @@ define Package/python3-distro
   TITLE:=Distro - an OS platform information API
   URL:=https://github.com/nir0s/distro
   DEPENDS:=+python3-light +python3-logging
-  VARIANT:=python3
 endef
 
 define Package/python3-distro/description

--- a/lang/python/python-docker/Makefile
+++ b/lang/python/python-docker/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-docker
 PKG_VERSION:=4.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=docker
 PKG_HASH:=380a20d38fbfaa872e96ee4d0d23ad9beb0f9ed57ff1c30653cbeb0c9c0964f2
@@ -27,7 +27,6 @@ define Package/python3-docker
 	  +python3-light +python3-distutils +python3-logging \
 	  +python3-openssl +python3-paramiko +python3-six +python3-requests \
 	  +python3-websocket-client
-  VARIANT:=python3
 endef
 
 define Package/python3-docker/description

--- a/lang/python/python-dockerpty/Makefile
+++ b/lang/python/python-dockerpty/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dockerpty
 PKG_VERSION:=0.4.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=dockerpty
 PKG_HASH:=69a9d69d573a0daa31bcd1c0774eeed5c15c295fe719c61aca550ed1393156ce
@@ -24,7 +24,6 @@ define Package/python3-dockerpty
   TITLE:=Python library to use the pseudo-tty of a docker container
   URL:=https://github.com/d11wtq/dockerpty
   DEPENDS:=+python3-light +python3-openssl +python3-six
-  VARIANT:=python3
 endef
 
 define Package/python3-dockerpty/description

--- a/lang/python/python-docopt/Makefile
+++ b/lang/python/python-docopt/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-docopt
 PKG_VERSION:=0.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=docopt
 PKG_HASH:=49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491
@@ -24,7 +24,6 @@ define Package/python3-docopt
   TITLE:=Pythonic argument parser, that will make you smile
   URL:=http://docopt.org/
   DEPENDS:=+python3-light
-  VARIANT:=python3
 endef
 
 define Package/python3-docopt/description

--- a/lang/python/python-dotenv/Makefile
+++ b/lang/python/python-dotenv/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-dotenv
 PKG_VERSION:=0.13.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=python-dotenv
 PKG_HASH:=3b9909bc96b0edc6b01586e1eed05e71174ef4e04c71da5786370cebea53ad74
@@ -22,7 +22,6 @@ define Package/python3-dotenv
   TITLE:=Add .env support to your django/flask apps in development and deployments
   URL:=http://github.com/theskumar/python-dotenv
   DEPENDS:=+python3-light +python3-logging
-  VARIANT:=python3
 endef
 
 define Package/python3-dotenv/description

--- a/lang/python/python-jsonschema/Makefile
+++ b/lang/python/python-jsonschema/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-jsonschema
 PKG_VERSION:=3.2.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=jsonschema
 PKG_HASH:=c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a
@@ -25,7 +25,6 @@ define Package/python3-jsonschema
   URL:=https://github.com/Julian/jsonschema
   DEPENDS:=+python3-light +python3-attrs +python3-urllib \
 	  +python3-six +python3-pyrsistent +python3-setuptools
-  VARIANT:=python3
 endef
 
 define Package/python3-jsonschema/description

--- a/lang/python/python-paramiko/Makefile
+++ b/lang/python/python-paramiko/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-paramiko
 PKG_VERSION:=2.7.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=paramiko
 PKG_HASH:=920492895db8013f6cc0179293147f830b8c7b21fdfc839b6bad760c27459d9f
@@ -25,7 +25,6 @@ define Package/python3-paramiko
   URL:=https://github.com/paramiko/paramiko/
   DEPENDS:=+python3-light +python3-logging +python3-bcrypt \
 	  +python3-cryptography +python3-openssl +python3-pynacl
-  VARIANT:=python3
 endef
 
 define Package/python3-paramiko/description

--- a/lang/python/python-pynacl/Makefile
+++ b/lang/python/python-pynacl/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pynacl
 PKG_VERSION:=1.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=PyNaCl
 PKG_HASH:=54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505
@@ -28,7 +28,6 @@ define Package/python3-pynacl
   TITLE:=Python binding to the libsodium library
   URL:=https://github.com/pyca/pynacl/
   DEPENDS:=+libsodium +python3-light +python3-cffi +python3-six
-  VARIANT:=python3
 endef
 
 define Package/python3-pynacl/description

--- a/lang/python/python-texttable/Makefile
+++ b/lang/python/python-texttable/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-texttable
 PKG_VERSION:=1.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=texttable
 PKG_HASH:=eff3703781fbc7750125f50e10f001195174f13825a92a45e9403037d539b4f4
@@ -22,7 +22,6 @@ define Package/python3-texttable
   TITLE:=Module for creating simple ASCII tables
   URL:=https://github.com/foutaise/texttable/
   DEPENDS:=+python3-light +python3-codecs
-  VARIANT:=python3
 endef
 
 define Package/python3-texttable/description

--- a/lang/python/python-websocket-client/Makefile
+++ b/lang/python/python-websocket-client/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-websocket-client
 PKG_VERSION:=0.57.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PYPI_NAME:=websocket_client
 PKG_HASH:=d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010
@@ -22,7 +22,6 @@ define Package/python3-websocket-client
   TITLE:=WebSocket client for Python. hybi13 is supported
   URL:=https://github.com/websocket-client/websocket-client
   DEPENDS:=+python3-light +python3-logging +python3-openssl +python3-six
-  VARIANT:=python3
 endef
 
 define Package/python3-websocket-client/description

--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-compose
 PKG_VERSION:=1.26.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=docker-compose
 PKG_HASH:=7e836102d139aca667d6af53f0f4d942c9459ec24d6dd4f0203d74359b0fd311
@@ -41,7 +41,6 @@ define Package/docker-compose
       +python3-texttable \
       +python3-websocket-client \
       +python3-yaml
-  VARIANT:=python3
 endef
 
 define Package/docker-compose/description


### PR DESCRIPTION
Maintainer: @jmarcet 
Compile tested: armvirt-64, 2020-06-08 snapshot sdk
Run tested: none

Description:
These packages were in the PR stage when the cleanup occurred and so still had `VARIANT:=python3`.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>