### PR TITLE
elektra: fully remove HostBuild

### DIFF
--- a/libs/elektra/Makefile
+++ b/libs/elektra/Makefile
@@ -427,8 +427,6 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
 endef
 
-
-$(eval $(call HostBuild))
 $(eval $(call BuildPackage,libelektra-core))
 $(eval $(call BuildPackage,elektra-kdb))
 $(eval $(call BuildPackage,libelektra-resolvers))


### PR DESCRIPTION
This is cosmetic since host-compile.mk is missing.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @haraldg 