### PR TITLE
syslog-ng: remove network source config from the default setting

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.27.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -25,9 +25,15 @@ source src {
 	unix-dgram("/dev/log");
 };
 
-source net {
-	network(ip("::1") port(514) transport(udp) ip-protocol(6));
-};
+# uncomment this section if you want network support with IPv4 and IPv6
+#source net {
+#	network(ip("::1") port(514) transport(udp) ip-protocol(6));
+#};
+
+# uncomment this section if you want network support with IPv4 only
+#source net {
+#	network(ip("127.0.0.1") port(514) transport(udp) ip-protocol(4));
+#};
 
 source s_network {
 	default-network-drivers(
@@ -52,7 +58,8 @@ destination messages {
 
 log {
 	source(src);
-	source(net);
+	# uncomment this line if you enabled network support
+	#source(net);
         source(kernel);
 	destination(messages);
 


### PR DESCRIPTION
maintainer: @BKPepe 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR disables network source config in the default setting.

The reason for this change is, that users can have a different setting
(like disabled IPv6 etc) in which case this will result in syslog
crash. It makes more sense to set this config by user when it's really
needed and don't set it as default.

