### PR TITLE
python-pytest: update to version 6.0.1

### DIFF
--- a/lang/python/python-iniconfig/Makefile
+++ b/lang/python/python-iniconfig/Makefile
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-iniconfig
+PKG_VERSION:=1.0.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=iniconfig
+PKG_HASH:=e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_PARALLEL:=0
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:=setuptools-scm
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-iniconfig
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Simple config-ini parser
+  URL:=https://github.com/RonnyPfannschmidt/iniconfig
+  DEPENDS:= +python3-light
+endef
+
+define Package/python3-iniconfig/description
+  iniconfig is a small and simple INI-file parser module.
+endef
+
+$(eval $(call Py3Package,python3-iniconfig))
+$(eval $(call BuildPackage,python3-iniconfig))
+$(eval $(call BuildPackage,python3-iniconfig-src))

--- a/lang/python/python-py/Makefile
+++ b/lang/python/python-py/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-py
-PKG_VERSION:=1.8.1
-PKG_RELEASE:=3
+PKG_VERSION:=1.9.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=py
-PKG_HASH:=5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa
+PKG_HASH:=9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT
@@ -31,7 +31,7 @@ define Package/python3-py
   CATEGORY:=Languages
   TITLE:=py
   URL:=https://github.com/pytest-dev/py
-  DEPENDS:=+python3-light
+  DEPENDS:=+python3-light +python3-xml +python3-urllib
 endef
 
 define Package/python3-py/description

--- a/lang/python/python-pytest/Makefile
+++ b/lang/python/python-pytest/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-pytest
-PKG_VERSION:=5.4.2
-PKG_RELEASE:=2
+PKG_VERSION:=6.0.1
+PKG_RELEASE:=1
 
 PYPI_NAME:=pytest
-PKG_HASH:=eb2b5e935f6a019317e455b6da83dd8650ac9ffd2ee73a7b657a30873d67a698
+PKG_HASH:=85228d75db9f45e06e57ef9bf4429267f81ac7c0d742cc9ed63d09886a9fe6f4
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT
@@ -32,16 +32,14 @@ define Package/python3-pytest
   TITLE:=Python testing framework
   URL:=https://docs.pytest.org/en/latest/
   DEPENDS:= \
-	+python3-light \
+	+python3 \
 	+python3-more-itertools \
 	+python3-py \
 	+python3-attrs \
 	+python3-pluggy \
 	+python3-packaging \
-	+python3-wcwidth \
-	+python3-decimal \
-	+python3-logging \
-	+python3-urllib
+	+python3-toml \
+	+python3-iniconfig
 endef
 
 define Package/python3-pytest/description

--- a/lang/python/python-toml/Makefile
+++ b/lang/python/python-toml/Makefile
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2020 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=python-toml
+PKG_VERSION:=0.10.1
+PKG_RELEASE:=1
+
+PYPI_NAME:=toml
+PKG_HASH:=926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include ../pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include ../python3-package.mk
+
+define Package/python3-toml
+  SUBMENU:=Python
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=A Python library for parsing and creating TOML
+  URL:=https://github.com/uiri/toml
+  DEPENDS:= +python3-light +python3-decimal
+endef
+
+define Package/python3-toml/description
+  Python Library for Tom's Obvious, Minimal Language
+endef
+
+$(eval $(call Py3Package,python3-toml))
+$(eval $(call BuildPackage,python3-toml))
+$(eval $(call BuildPackage,python3-toml-src))


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates pytest to version 6.0.1

It also adds **python-toml**, **python-iniconfig** packages which are required by 6.0.x version and updates **python-py** package.

Run tested by running test set:
```
platform linux -- Python 3.8.3, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /ccc/pytest, configfile: pyproject.toml, testpaths: testing
plugins: xdist-1.34.0
collected 2727 items / 2 errors / 2725 selected                                                                                                                                                            
```


