### PR TITLE
prometheus-node-exporter-lua: add thermal_zone collector

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -94,6 +94,12 @@ define Package/prometheus-node-exporter-lua-ltq-dsl
   DEPENDS:=prometheus-node-exporter-lua @(PACKAGE_ltq-adsl-app||PACKAGE_ltq-vdsl-app)
 endef
 
+define Package/prometheus-node-exporter-lua-thermal_zone
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (thermal_zone collector)
+  DEPENDS:=prometheus-node-exporter-lua +luci-lib-nixio
+endef
+
 Build/Compile=
 
 define Package/prometheus-node-exporter-lua/install
@@ -164,6 +170,11 @@ define Package/prometheus-node-exporter-lua-ltq-dsl/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/ltq-dsl.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
+define Package/prometheus-node-exporter-lua-thermal_zone/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/thermal_zone.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
 $(eval $(call BuildPackage,prometheus-node-exporter-lua))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-nat_traffic))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-netstat))
@@ -175,3 +186,4 @@ $(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx7))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-textfile))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-openwrt))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-ltq-dsl))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-thermal_zone))

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/thermal_zone.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/thermal_zone.lua
@@ -1,0 +1,20 @@
+
+local fs = require "nixio.fs"
+
+local function scrape()
+  for dir in fs.glob("/sys/class/thermal/thermal_zone*/") do
+    local typ = get_contents(dir .. "type")
+    -- local policy = get_contents(dir .. "policy")
+    local temp = get_contents(dir .. "temp")
+    if type and temp then
+       local labels = {}
+       labels.type = string.sub(typ, 0, -2)
+       labels.zone = string.gsub(dir, ".*/thermal_zone(%d+)/", "%1")
+       temp = tonumber(temp) / 1000
+       output("# HELP node_thermal_zone_temp Zone temperature in Celsius")
+       metric("node_thermal_zone_temp", "gauge", labels, temp)
+    end
+  end
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
This adds the `thermal_zone` collector. It returns the thermal_zone information
like the (golang) prometheus node_exporter in the latest version, example from
a Linksys WRT 1900ACS running OpenWRT 19.07.02:

    # HELP node_thermal_zone_temp Zone temperature in Celsius
    # TYPE node_thermal_zone_temp gauge
    node_thermal_zone_temp{zone="0",type="armada_thermal"} 79.879
    node_scrape_collector_duration_seconds{collector="thermal_zone"} 0.00016188621520996
    node_scrape_collector_success{collector="thermal_zone"} 1

Note that this does currently not include support for the
`/sys/class/thermal/cooling_device*`

Signed-off-by: Hanno Hecker <vetinari@ankh-morp.org>

Maintainer: @champtar 
Compile tested: ath79, TP-Link Archer C7 v5, 19.07.03
Run tested: mvebu, Linksys WRT1900ACS, 19.07.02 ... starting and checking output for no errors and correct output

Description:
see above :)