### PR TITLE
kmod: fix ALTERNATIVES

### DIFF
--- a/utils/kmod/Makefile
+++ b/utils/kmod/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kmod
 PKG_VERSION:=20
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/kernel/kmod/
@@ -32,6 +32,12 @@ define Package/kmod/Default
   TITLE:=Linux kernel module handling
   URL:=https://www.kernel.org/pub/linux/utils/kernel/kmod/
   DEPENDS:=+zlib
+endef
+
+
+define Package/kmod
+$(call Package/kmod/Default)
+  TITLE+= (tools)
   ALTERNATIVES:=\
     200:/sbin/depmod:/sbin/kmod \
     200:/sbin/insmod:/sbin/kmod \
@@ -39,12 +45,6 @@ define Package/kmod/Default
     200:/sbin/modinfo:/sbin/kmod \
     200:/sbin/modprobe:/sbin/kmod \
     200:/sbin/rmmod:/sbin/kmod
-endef
-
-
-define Package/kmod
-$(call Package/kmod/Default)
-  TITLE+= (tools)
 endef
 
 define Package/kmod/description


### PR DESCRIPTION
ALTERNATIVES shall be defined in the package where /sbin/kmod resides --
otherwise kmod tools will break if we install only the library as these
tools will be linked to a nonexistent executable.

Signed-off-by: Kuan-Yi Li <kyli@abysm.org>

Maintainer: @jdub
Compile tested: aarch64, Raspberry Pi 4 Model B Rev 1.1, OpenWrt SNAPSHOT r13548-8f3b176e86, pciutils installed
Run tested: as above

Description: An example is when we install `pciutils`, while it installs `libkmod` as dependency, it does not install `kmod`, thus there will be no `/sbin/kmod` to link to. And kmod tools break in this case before this fix is applied.
