### PR TITLE
adblock: update 4.0.5-6

### DIFF
--- a/multimedia/ffmpeg/Makefile
+++ b/multimedia/ffmpeg/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffmpeg
-PKG_VERSION:=4.2.2
-PKG_RELEASE:=4
+PKG_VERSION:=4.2.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://ffmpeg.org/releases/
-PKG_HASH:=cb754255ab0ee2ea5f66f8850e1bd6ad5cac1cd855d0a2f4990fb8c668b0d29c
+PKG_HASH:=9df6c90aed1337634c1fb026fb01c154c29c82a64ea71291ff2da9aacb9aad31
 PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>, \
 		Ian Leonard <antonlacon@gmail.com>
 

--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=4.0.5
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/README.md
+++ b/net/adblock/files/README.md
@@ -169,8 +169,8 @@ Available commands:
 | adb_backup        | 1, enabled                         | set to 0 to disable the backup function                                                        |
 | adb_backupdir     | /tmp                               | path for adblock backups                                                                       |
 | adb_tmpbase       | /tmp                               | path for all adblock related runtime operations, e.g. downloading, sorting, merging etc.       |
-| adb_safesearch    | 0, disabled                        | set to 1 to enforce SafeSearch for google, bing, duckduckgo, yandex, youtube and pixabay       |
-| adb_safesearchmod | 0, disabled                        | set to 1 to enable moderate SafeSearch filters for youtube                                     |
+| adb_safesearch    | 0, disabled                        | set to 1 to enforce SafeSearch for Google, Bing, DuckDuckGo, Yandex, YouTube and Pixabay       |
+| adb_safesearchmod | disabled                           | set to restrictive or moderate to enable SafeSearch filters for YouTube                                     |
 | adb_mail          | 0, disabled                        | set to 1 to enable notification E-Mails in case of a processing errors                         |
 | adb_mailreceiver  | -, not set                         | receiver address for adblock notification E-Mails                                              |
 | adb_mailsender    | no-reply@adblock                   | sender address for adblock notification E-Mails                                                |

--- a/net/adblock/files/adblock.sh
+++ b/net/adblock/files/adblock.sh
@@ -20,7 +20,7 @@ adb_dnsfilereset=0
 adb_dnsflush=0
 adb_dnstimeout=20
 adb_safesearch=0
-adb_safesearchmod=0
+adb_safesearchmod="disabled"
 adb_report=0
 adb_trigger=""
 adb_triggerdelay=0
@@ -766,16 +766,19 @@ f_list()
 					out_rc="${?}"
 				;;
 				"youtube")
-					if [ "${adb_safesearchmod}" -eq 0 ]
+					if [ "${adb_safesearchmod}" != "disabled" ]
 					then
-						safe_ips="216.239.38.120 2001:4860:4802:32::78"
-						safe_cname="restrict.youtube.com"
-					else
-						safe_ips="216.239.38.119 2001:4860:4802:32::77"
-						safe_cname="restrictmoderate.youtube.com"
+						if [ "${adb_safesearchmod}" == "restrictive" ]
+						then
+							safe_ips="216.239.38.120 2001:4860:4802:32::78"
+							safe_cname="restrict.youtube.com"
+						else # if [ "${adb_safesearchmod}" == "moderate" ]
+							safe_ips="216.239.38.119 2001:4860:4802:32::77"
+							safe_cname="restrictmoderate.youtube.com"
+						fi
+						safe_domains="www.youtube.com m.youtube.com youtubei.googleapis.com youtube.googleapis.com www.youtube-nocookie.com"
+						printf "%s\n" ${safe_domains} > "${adb_tmpdir}/tmp.raw.safesearch.${src_name}"
 					fi
-					safe_domains="www.youtube.com m.youtube.com youtubei.googleapis.com youtube.googleapis.com www.youtube-nocookie.com"
-					printf "%s\n" ${safe_domains} > "${adb_tmpdir}/tmp.raw.safesearch.${src_name}"
 					out_rc="${?}"
 				;;
 			esac


### PR DESCRIPTION
New options under YouTube SafeSearch: restrictive, moderate or disabled. This allows for better YouTube filter control, as for some even moderate filtering is too intrusive, e.g. with music. This will allow to disable completely YouTube filtering and keeping SafeSearch enabled for the other search engines.

Signed-off-by: Alberto Martínez Álvarez <amteza@gmail.com>

Maintainer: Dirk Brenken <dev@brenken.org> @dibdot    @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (aarch64, RPi4, OpenWrt master)
Run tested: (aarch64, RPi4, OpenWrt master, tested all options on interface)
