### PR TITLE
mariadb: move some binaries

### DIFF
--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mariadb
 PKG_VERSION:=10.4.13
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL := \
@@ -116,13 +116,15 @@ plugin-wsrep_info               := PLUGIN_WSREP_INFO
 
 MARIADB_CLIENT := \
 	mysql \
-	mysql_upgrade \
 	mysqlcheck
 
 MARIADB_CLIENT_EXTRA := \
+	msql2mysql \
 	mysql_find_rows \
+	mysql_plugin \
 	mysql_waitpid \
 	mysqlaccess \
+	mysqlbinlog \
 	mysqldump \
 	mysqlimport \
 	mysqlshow \
@@ -133,6 +135,7 @@ MARIADB_SERVER := \
 	innochecksum \
 	my_print_defaults \
 	mysql_install_db \
+	mysql_upgrade \
 	mysqladmin \
 	mysqld \
 	mysqld_safe
@@ -144,18 +147,15 @@ MARIADB_SERVER_EXTRA := \
 	aria_pack \
 	aria_read_log \
 	mariabackup \
-	msql2mysql \
 	myisam_ftdump \
 	myisamchk \
 	myisamlog \
 	myisampack \
 	mysql_convert_table_format \
 	mysql_fix_extensions \
-	mysql_plugin \
 	mysql_secure_installation \
 	mysql_setpermission \
 	mysql_tzinfo_to_sql \
-	mysqlbinlog \
 	mysqld_multi \
 	mysqld_safe_helper \
 	mysqldumpslow \


### PR DESCRIPTION
Even though I think that mysql_upgrade is a client package (it depends
on the mysql client and it's in the "client" directory in the source
tree, for instance), upstream laid it out differently. Since upstream
commit ec586f5 mysql_upgrade is to be considered a part of the server,
because the COMPONENT argument in the MYSQL_ADD_EXECUTABLE macro is set
to "Server".

That means that mysql_upgrade is only installed when the server is. So
we need to move it back to the server package, otherwise we will have a
build failure when mariadb-client is selected while mariadb-server is
not. This particular build failure was recently a topic on
openwrt-devel.

Some more binaries are moved, following the layout visible in
"man/CMakeLists.txt", to make sure we follow upstream's vision with
regards to how the binaries are packaged.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me
Compile tested: ath79 master
Run tested: no, just a packaging change, no code change.

Description:
Hi all,

Somebody fw'ed me a mail from openwrt-devel regarding a build fail. Here's the PR for it.

Thanks!

Kind regards,
Seb