### PR TITLE
ariang: update to 1.1.6

### DIFF
--- a/net/ariang/Makefile
+++ b/net/ariang/Makefile
@@ -1,17 +1,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ariang
-PKG_VERSION:=1.1.4
-PKG_RELEASE:=2
+PKG_VERSION:=1.1.6
+PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=https://codeload.github.com/mayswind/AriaNg-DailyBuild/tar.gz/$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=0a591564ffb863d5ce55694d26ad63934d364b9408119c191a2f8276f286f2b6
+PKG_SOURCE_URL:=https://codeload.github.com/mayswind/AriaNg-DailyBuild/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=ac5a55f1549c5458dab4422ddf420055909e11d6e5ec8db0f13e52241f6c2917
 PKG_BUILD_DIR:=$(BUILD_DIR)/AriaNg-DailyBuild-$(PKG_VERSION)
 
+PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
-PKG_MAINTAINER:=Ansuel Smith <ansuelsmth@gmail.com>
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Small adjustments for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @Ansuel 
Compile tested: ath79