### PR TITLE
oniguruma: add patch to fix NULL pointer exception

### DIFF
--- a/libs/oniguruma/Makefile
+++ b/libs/oniguruma/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=oniguruma
 PKG_VERSION:=6.9.5_rev1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=onig-v$(subst _,-,$(PKG_VERSION)).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/kkos/oniguruma/tar.gz/v$(PKG_VERSION)?

--- a/libs/oniguruma/patches/0002-i_free_callout_name_entry.patch
+++ b/libs/oniguruma/patches/0002-i_free_callout_name_entry.patch
@@ -1,0 +1,13 @@
+--- a/src/regparse.c	2020-04-26 09:20:56.000000000 +0200
++++ b/src/regparse.c	2020-06-14 21:22:18.396966276 +0200
+@@ -1294,7 +1294,9 @@
+ i_free_callout_name_entry(st_callout_name_key* key, CalloutNameEntry* e,
+                           void* arg ARG_UNUSED)
+ {
+-  xfree(e->name);
++  if (IS_NOT_NULL(e)) {
++    xfree(e->name);
++  }
+   /*xfree(key->s); */ /* is same as e->name */
+   xfree(key);
+   xfree(e);


### PR DESCRIPTION
Maintainer: @cotequeiroz
Compile tested: mxs
Run tested: mxs

Description:
I propose to carry this patch until a new upstream
release includes it. For forther references see:

https://github.com/openwrt/packages/issues/12403
and
https://github.com/kkos/oniguruma/pull/196

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
