### PR TITLE
shadow: don't compile bcrypt for unsupported platforms

### DIFF
--- a/utils/shadow/Makefile
+++ b/utils/shadow/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shadow
 PKG_VERSION:=4.8.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/shadow-maint/shadow/releases/download/$(PKG_VERSION)
@@ -41,7 +41,7 @@ CONFIGURE_ARGS += \
 	--without-attr \
 	--without-tcb \
 	--without-nscd \
-	--with-bcrypt
+	--with$(if $(CONFIG_MUSL_DISABLE_CRYPT_SIZE_HACK),,out)-bcrypt
 
 CONFIGURE_VARS += \
 	ac_cv_func_ruserok=no


### PR DESCRIPTION
If musl has no bcrypt:

passwd: failed to crypt password with salt '$2a$13$w8EJ0Yfz5bGsG4U/0m7bk/': Function not implemented
The password for root is unchanged.

glibc output as it has no bcrypt:

passwd: failed to crypt password with salt '$2a$13$xbpmAYmq6Q/rZN5jOlNxJZ': Invalid argument
The password for root is unchanged.

--without-bcrypt output:

Invalid ENCRYPT_METHOD value: 'BCRYPT'.
Defaulting to DES.
passwd: password changed.

The solution was tested on glibc despite using a musl specific variable
Still works.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: malta musl/glibc mips-be

Fixes: https://github.com/openwrt/packages/issues/12490

The proper fix to these hacks is to introduce https://github.com/besser82/libxcrypt

ping @Cynerd @BKPepe 