### PR TITLE
overture: update to 1.6.1

### DIFF
--- a/net/overture/Makefile
+++ b/net/overture/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=overture
-PKG_VERSION:=1.6
+PKG_VERSION:=1.6.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/shawn1m/overture/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=a7a568cc65f2a1714f036c555b95d3be27234b98ae951cb748198fecce1bb1e4
+PKG_HASH:=916ddbc4e8ee3cd008e281ba768c1502ad7b3ad71073f5e587b187e371eedd2b
 
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 PKG_LICENSE:=MIT
@@ -18,6 +18,7 @@ PKG_USE_MIPS16:=0
 
 GO_PKG:=github.com/shawn1m/overture
 GO_PKG_BUILD_PKG:=$(GO_PKG)/main
+GO_PKG_LDFLAGS_X:=main.version=$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../../lang/golang/golang-package.mk
@@ -35,16 +36,21 @@ define Package/overture/description
   Overture is a DNS server/forwarder/dispatcher written in Go.
 endef
 
+define Package/overture/conffiles
+/etc/overture/
+endef
+
 define Package/overture/install
 	$(call GoPackage/Package/Install/Bin,$(PKG_INSTALL_DIR))
 
-	$(INSTALL_DIR) $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/main $(1)/usr/bin/$(PKG_NAME)
-	$(INSTALL_DIR) $(1)/etc/$(PKG_NAME)/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/config.sample.json $(1)/etc/$(PKG_NAME)/config.json
-	$(INSTALL_DATA) ./files/*_sample $(1)/etc/$(PKG_NAME)/
-	$(INSTALL_DIR) $(1)/etc/init.d/
-	$(INSTALL_BIN) ./files/$(PKG_NAME).init $(1)/etc/init.d/$(PKG_NAME)
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/main $(1)/usr/bin/overture
+	$(INSTALL_DIR) $(1)/etc/overture
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/config.sample.json $(1)/etc/overture/config.json
+	$(SED) 's@"\.\(/[^"]\{1,\}_sample\)"@"/etc/overture\1"@g;s/":53"/"127.0.0.3:53"/' $(1)/etc/overture/config.json
+	$(INSTALL_DATA) ./files/*_sample $(1)/etc/overture
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/overture.init $(1)/etc/init.d/overture
 endef
 
 $(eval $(call GoBinPackage,overture))


### PR DESCRIPTION
Maintainer: @ysc3839 
Compile tested: Linux 5.6.14-1.el7.elrepo.x86_64 GNU/Linux, ath79/nand, r13578-b7a8a54542
Run tested: (ath79/nand, r13578-b7a8a54542, tests done)
