### PR TITLE
mwan3: improvements

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.6
+PKG_VERSION:=2.8.7
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/etc/init.d/mwan3
+++ b/net/mwan3/files/etc/init.d/mwan3
@@ -1,20 +1,28 @@
 #!/bin/sh /etc/rc.common
 
 START=19
-
-reload() {
-	/usr/sbin/mwan3 restart
-}
+USE_PROCD=1
 
 boot() {
 	. /lib/config/uci.sh
 	uci_toggle_state mwan3 globals enabled "1"
+	mwan3_boot=1
+	rc_procd start_service
 }
 
-start() {
+reload_service() {
+	/usr/sbin/mwan3 restart
+}
+
+start_service() {
+	[ -n "${mwan3_boot}" ] && return 0
 	/usr/sbin/mwan3 start
 }
 
-stop() {
+stop_service() {
 	/usr/sbin/mwan3 stop
+}
+
+service_triggers() {
+	procd_add_reload_trigger 'mwan3'
 }

--- a/net/mwan3/files/usr/libexec/rpcd/mwan3
+++ b/net/mwan3/files/usr/libexec/rpcd/mwan3
@@ -77,7 +77,7 @@ get_mwan3_status() {
 	local online=0
 	local offline=0
 	local up="0"
-	local enabled pid device time_p time_n time_u time_d
+	local enabled pid device time_p time_n time_u time_d status
 
 	network_get_device device $1
 
@@ -111,6 +111,12 @@ get_mwan3_status() {
 		network_get_uptime uptime "$iface"
 		network_is_up "$iface" && up="1"
 
+		if [ -f "$MWAN3TRACK_STATUS_DIR/${iface}/STATUS" ]; then
+			status="$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/STATUS")"
+		else
+			status="unknown"
+		fi
+
 		json_add_object "${iface}"
 		json_add_int age "$age"
 		json_add_int online "${online}"
@@ -119,7 +125,7 @@ get_mwan3_status() {
 		json_add_int "score" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/SCORE")"
 		json_add_int "lost" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/LOST")"
 		json_add_int "turn" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/TURN")"
-		json_add_string "status" "$(cat "$MWAN3TRACK_STATUS_DIR/${iface}/STATUS")"
+		json_add_string "status" "${status}"
 		json_add_boolean "enabled" "${enabled}"
 		json_add_boolean "running" "${running}"
 		json_add_boolean "up" "${up}"


### PR DESCRIPTION
Maintainer: me 
Compile tested: not needed only script change
Run tested: x86_64 and lantiq_xrx200, APU3, OpenWrt master

Description:

- Use procd to handle service reload on uci config change
- Set ubus output for **status** info to unknown if this information is not available