### PR TITLE
Improvements for Travis (use different target and update Ubuntu image)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ git:
   quiet: true
 
 language: c
+os: linux
 dist: focal
-sudo: false
 cache:
   directories:
     - $HOME/sdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ git:
   quiet: true
 
 language: c
-dist: bionic
+dist: focal
 sudo: false
 cache:
   directories:

--- a/.travis_do.sh
+++ b/.travis_do.sh
@@ -5,8 +5,8 @@
 set -e
 
 SDK_HOME="$HOME/sdk"
-SDK_PATH=https://downloads.openwrt.org/snapshots/targets/ar71xx/generic/
-SDK=-sdk-ar71xx-generic_
+SDK_PATH=https://downloads.openwrt.org/snapshots/targets/mpc85xx/p2020/
+SDK=-sdk-mpc85xx-p2020_
 PACKAGES_DIR="$PWD"
 
 echo_red()   { printf "\033[1;31m$*\033[m\n"; }


### PR DESCRIPTION
Maintainers: @champtar , @lynxis , @yousong 

Description:
Target ar71xx is deprecated and removed in the master branch and makes SDK
not available anymore. Travis fails because of that.
It was superseded by target ath79. These devices have 4 MB flash and/or 32 MB RAM.

Build log: https://travis-ci.org/github/BKPepe/packages/builds/699273897?utm_medium=notification&utm_source=email

However, ath79 is being used by CircleCI if you have it configured for
your repository and if you are contributing to this repository. It
is not good to have two CI for the same target. Let's use mvebu.

Tested with youtube-dl package: https://travis-ci.org/github/BKPepe/packages/builds/699295449