### PR TITLE
Revert "perl: fix compilation on x86_64 with glibc and ssp"

### DIFF
--- a/lang/perl/Makefile
+++ b/lang/perl/Makefile
@@ -11,7 +11,7 @@ include perlver.mk
 
 PKG_NAME:=perl
 PKG_VERSION:=$(PERL_VERSION)
-PKG_RELEASE:=5
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=\
 		https://cpan.metacpan.org/src/5.0 \
@@ -99,7 +99,7 @@ define Build/Configure
 	                                -Dowrt:gccversion=$(CONFIG_GCC_VERSION) \
 	                                -Dowrt:target_cross='$(TARGET_CROSS)' \
 	                                -Dowrt:cflags='$(TARGET_CFLAGS_PERL) $(TARGET_CPPFLAGS_PERL)' \
-	                                -Dowrt:ldflags='$(TARGET_LDFLAGS) $(if $(CONFIG_GCC_LIBSSP),-lssp)' \
+	                                -Dowrt:ldflags='$(TARGET_LDFLAGS)' \
 	                                -Dowrt:libc=$(subst uClibc,uclibc,$(CONFIG_LIBC)) \
 	                                -Dowrt:ipv6=$(if $($(CONFIG_IPV6)),define,undef) \
 	                                -Dowrt:threads=$(if $(CONFIG_PERL_THREADS),yes,no) \


### PR DESCRIPTION
This reverts commit 3d5ba0f094709c1ca98a39d1f080aa414c40d530.

As of b933f9cf0cb254e368027cad6d5799e45b237df5 , this is not needed.

Maintainer: @pprindeville 
Compile tested: i386 musl