### PR TITLE
avahi: remove lssp_nonshared flag

### DIFF
--- a/libs/avahi/Makefile
+++ b/libs/avahi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=avahi
 PKG_VERSION:=0.8
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lathiat/avahi/releases/download/v$(PKG_VERSION) \
@@ -251,7 +251,6 @@ $(call Package/avahi/Default/description)
 endef
 
 TARGET_CFLAGS += $(FPIC) -DGETTEXT_PACKAGE
-TARGET_LDFLAGS += $(if $(CONFIG_GCC_LIBSSP),-lssp_nonshared)
 
 CONFIGURE_ARGS += \
 	--enable-shared \


### PR DESCRIPTION
Does not seem to be needed as of b933f9cf0cb254e368027cad6d5799e45b237df5

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: i386 musl