### PR TITLE
seafile-server: remove GCC_LIBSSP

### DIFF
--- a/net/seafile-server/Makefile
+++ b/net/seafile-server/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=seafile-server
 PKG_VERSION:=7.1.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/haiwen/seafile-server/tar.gz/v$(PKG_VERSION)-server?
@@ -134,10 +134,6 @@ CONFIGURE_ARGS += \
 
 CONFIGURE_VARS += \
 	PYTHON="$(HOST_PYTHON3_BIN)"
-
-ifdef CONFIG_GCC_LIBSSP
-  TARGET_LDFLAGS += -lssp
-endif
 
 define Package/seafile-server/conffiles
 /etc/config/seafile-server


### PR DESCRIPTION
The variable is gone as of b933f9cf0cb254e368027cad6d5799e45b237df5

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @commodo @jefferyto 
Compile tested: i386 musl