### PR TITLE
transmission: add access to web interface files to procd jail

### DIFF
--- a/net/transmission/Makefile
+++ b/net/transmission/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=transmission
 PKG_VERSION:=3.00
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GITHUB/transmission/transmission-releases/master

--- a/net/transmission/files/transmission.init
+++ b/net/transmission/files/transmission.init
@@ -160,6 +160,7 @@ transmission() {
 	procd_add_jail_mount_rw "$config_dir/blocklists"
 	procd_add_jail_mount_rw "$config_dir/stats.json"
 	procd_add_jail_mount_rw "$download_dir"
+	[ -d "$web_home" ] && procd_add_jail_mount_rw "$web_home"
 	procd_close_instance
 }
 


### PR DESCRIPTION
Maintainer: Rosen Penev <rosenp@gmail.com>
Compile tested: N/A
Run tested: tested on TurrisOS 5.0.1 (I dont have any device with pure opwnwrt)

Description:
Currently transmission process does not have access to the web interface files so web interface is broken, this fix mounts web interface files to the procd jail.