### PR TITLE
tor: remove libssp hack

### DIFF
--- a/net/tor/Makefile
+++ b/net/tor/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tor
 PKG_VERSION:=0.4.3.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://dist.torproject.org/ \
@@ -103,17 +103,11 @@ CONFIGURE_ARGS += \
 	--disable-lzma \
 	--disable-zstd \
 	--with-tor-user=tor \
-	--with-tor-group=tor
+	--with-tor-group=tor \
+	--with-pic
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
 TARGET_LDFLAGS += -Wl,--gc-sections -flto
-
-ifneq ($(CONFIG_SSP_SUPPORT),y)
-	CONFIGURE_ARGS += \
-		--disable-gcc-hardening
-else
-	EXTRA_CFLAGS += $(FPIC)
-endif
 
 CONFIGURE_VARS += \
 	CROSS_COMPILE="yes"


### PR DESCRIPTION
Does not seem to be needed anymore.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @tripolar 
Compile tested: i386 musl

As of https://github.com/openwrt/openwrt/commit/b933f9cf0cb254e368027cad6d5799e45b237df5