### PR TITLE
redis: update to version 6.0.5

### DIFF
--- a/libs/redis/Makefile
+++ b/libs/redis/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=redis
-PKG_VERSION:=6.0.4
+PKG_VERSION:=6.0.5
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://download.redis.io/releases/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=3337005a1e0c3aa293c87c313467ea8ac11984921fab08807998ba765c9943de
+PKG_HASH:=42cf86a114d2a451b898fcda96acd4d01062a7dbaaad2801d9164a36f898f596
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates redis to version 6.0.5 It's a bugfix release.
Update urgency is MODERATE

 [Changelog](https://raw.githubusercontent.com/antirez/redis/6.0/00-RELEASENOTES)
