### PR TITLE
python-more-itertools: update to version 8.4.0

### DIFF
--- a/lang/python/python-more-itertools/Makefile
+++ b/lang/python/python-more-itertools/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-more-itertools
-PKG_VERSION:=8.3.0
+PKG_VERSION:=8.4.0
 PKG_RELEASE:=1
 
 PYPI_NAME:=more-itertools
-PKG_HASH:=558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be
+PKG_HASH:=68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5
 
 PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
 PKG_LICENSE:=MIT


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master
Description:

This PR updates python-more-itertools package to version 8.4.0

[Changelog](https://github.com/more-itertools/more-itertools/blob/fc70d910cd2a8579e9b4e5fd38f8a8acf4abb2d7/docs/versions.rst#840)

Run tested with project tests

```
Ran 493 tests in 4.020s

OK (skipped=1)
```