### PR TITLE
docker-ce: add uci support

### DIFF
--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -124,9 +124,6 @@ define Package/docker-ce/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/dockerd.init $(1)/etc/init.d/dockerd
 
-	$(INSTALL_DIR) $(1)/etc/docker
-	$(INSTALL_CONF) ./files/daemon.json $(1)/etc/docker/
-
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/etc/config/dockerd $(1)/etc/config/dockerd
 

--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -49,6 +49,10 @@ define Package/docker-ce
   MENU:=1
 endef
 
+define Package/docker-ce/conffiles
+/etc/config/dockerd
+endef
+
 define Package/docker-ce/description
   Docker Engine is used by millions enables containerized applications
   to run anywhere consistently on any infrastructure.
@@ -122,6 +126,9 @@ define Package/docker-ce/install
 
 	$(INSTALL_DIR) $(1)/etc/docker
 	$(INSTALL_CONF) ./files/daemon.json $(1)/etc/docker/
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/etc/config/dockerd $(1)/etc/config/dockerd
 
 	# Must be after systcl 11-br-netfilter.conf from kmod-br-netfilter
 	$(INSTALL_DIR) $(1)/etc/sysctl.d

--- a/utils/docker-ce/Makefile
+++ b/utils/docker-ce/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-ce
 PKG_VERSION:=19.03.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=components/cli/LICENSE components/engine/LICENSE
 

--- a/utils/docker-ce/files/daemon.json
+++ b/utils/docker-ce/files/daemon.json
@@ -1,4 +1,0 @@
-{
-    "data-root": "/opt/docker/",
-    "log-level": "warn"
-}

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -58,3 +58,36 @@ start_service() {
 	procd_set_param limits nofile="${nofile} ${nofile}"
 	procd_close_instance
 }
+
+ip4tables_remove_nat() {
+	iptables -t nat -D OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
+	iptables -t nat -D PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
+
+	iptables -t nat -F DOCKER
+	iptables -t nat -X DOCKER
+}
+
+ip4tables_remove_filter() {
+	iptables -t filter -D FORWARD -j DOCKER-USER
+	iptables -t filter -D FORWARD -j DOCKER-ISOLATION-STAGE-1
+	iptables -t filter -D FORWARD -o docker0 -j DOCKER
+
+	iptables -t filter -F DOCKER
+	iptables -t filter -F DOCKER-ISOLATION-STAGE-1
+	iptables -t filter -F DOCKER-ISOLATION-STAGE-2
+	iptables -t filter -F DOCKER-USER
+
+	iptables -t filter -X DOCKER
+	iptables -t filter -X DOCKER-ISOLATION-STAGE-1
+	iptables -t filter -X DOCKER-ISOLATION-STAGE-2
+	iptables -t filter -X DOCKER-USER
+}
+
+ip4tables_remove() {
+	ip4tables_remove_nat
+	ip4tables_remove_filter
+}
+
+stop_service() {
+	ip4tables_remove
+}

--- a/utils/docker-ce/files/dockerd.init
+++ b/utils/docker-ce/files/dockerd.init
@@ -3,12 +3,58 @@
 USE_PROCD=1
 START=25
 
+DOCKERD_CONF="/tmp/dockerd/daemon.json"
+
+json_add_array_string() {
+	json_add_string "" "$1"
+}
+
+process_config() {
+	local alt_config_file data_root log_level
+
+	rm -f "$DOCKERD_CONF"
+
+	[ -f /etc/config/dockerd ] || {
+		# Use the daemon default configuration
+		DOCKERD_CONF=""
+		return 0
+	}
+
+	config_load 'dockerd'
+
+	config_get alt_config_file globals alt_config_file
+	[ -n "$alt_config_file" ] && [ -f "$alt_config_file" ] && {
+		ln -s "$alt_config_file" "$DOCKERD_CONF"
+		return 0
+	}
+
+	config_get data_root globals data_root "/opt/docker/"
+	config_get log_level globals log_level "warn"
+
+	. /usr/share/libubox/jshn.sh
+	json_init
+	json_add_string "data-root" "$data_root"
+	json_add_string "log-level" "$log_level"
+	json_add_array "registry-mirrors"
+	config_list_foreach globals registry_mirror json_add_array_string
+	json_close_array
+
+	mkdir -p /tmp/dockerd
+	json_dump > "$DOCKERD_CONF"
+}
+
 start_service() {
 	local nofile=$(cat /proc/sys/fs/nr_open)
 
+	process_config
+
 	procd_open_instance
 	procd_set_param stderr 1
-	procd_set_param command /usr/bin/dockerd
+	if [ -z "$DOCKERD_CONF" ]; then
+		procd_set_param command /usr/bin/dockerd
+	else
+		procd_set_param command /usr/bin/dockerd --config-file="$DOCKERD_CONF"
+	fi
 	procd_set_param limits nofile="${nofile} ${nofile}"
 	procd_close_instance
 }

--- a/utils/docker-ce/files/etc/config/dockerd
+++ b/utils/docker-ce/files/etc/config/dockerd
@@ -1,0 +1,7 @@
+
+config globals 'globals'
+#	option alt_config_file "/etc/docker/daemon.json"
+	option data_root "/opt/docker/"
+	option log_level "warn"
+#	list registry_mirror "https://<my-docker-mirror-host>"
+#	list registry_mirror "https://hub.docker.com"


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503 
Compile tested: only script changes
Run tested: x86_64, APU3, OpenWrt master

Description:
Recently we also have the application [luci-app-dockerman](https://github.com/openwrt/luci/tree/master/applications/luci-app-dockerman) in the LuCI. In this app we have also an service which reads the configuration from[ /etc/docker/daemon.json](https://github.com/openwrt/packages/blob/master/utils/docker-ce/files/daemon.json) and compares this against his own uci configuration in [/etc/config/dockerman](https://github.com/openwrt/luci/blob/master/applications/luci-app-dockerman/root/etc/config/dockerman). To reconcile configuration differences a [script](https://github.com/openwrt/luci/blob/master/applications/luci-app-dockerman/root/usr/share/dockerman/dockerd-config.lua) is used, so that everything works again.
To simplify things I think it is better to move the uci into the docker-ce package. So that we have a clear responsibility.

@lisaac To get everything working again we have to make some changes to the luci-app-dockerman as well.

Since docker's configuration options are very large, I don't think we can display all configuration options here. But I guess it doesn't hurt that we can configure at least a few things.