### PR TITLE
[19.07] Revert "ksmbd: update to 3.2.0, ksmbd-tools: update to 3.2.6"

### DIFF
--- a/kernel/ksmbd/Makefile
+++ b/kernel/ksmbd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd
-PKG_VERSION:=3.2.0
+PKG_VERSION:=3.1.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/cifsd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=063474f48f9481ff4a5acf978bd9b31fae39ccecfb232df4aac8c247a2a28b04
+PKG_SOURCE_URL:=https://github.com/cifsd-team/cifsd/archive/$(PKG_VERSION)/
+PKG_HASH:=c3c4531d3806117218d23e0552edfe883f978a00b7293180dd2919694102fcb9
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -59,7 +59,7 @@ EXTRA_CFLAGS += -DCONFIG_SMB_INSECURE_SERVER=1
 endif
 
 define Build/Compile
-	$(KERNEL_MAKE) M="$(PKG_BUILD_DIR)" \
+	$(KERNEL_MAKE) SUBDIRS="$(PKG_BUILD_DIR)" \
 	EXTRA_CFLAGS="$(EXTRA_CFLAGS)" \
 	$(PKG_EXTRA_KCONFIG) \
 	CONFIG_SMB_SERVER=m \

--- a/kernel/ksmbd/patches/01-keep_kmod_metadata.patch
+++ b/kernel/ksmbd/patches/01-keep_kmod_metadata.patch
@@ -1,5 +1,5 @@
---- a/glob.h
-+++ b/glob.h
+--- a/glob.h	2019-12-08
++++ b/glob.h	2019-12-08
 @@ -7,6 +7,8 @@
  #ifndef __KSMBD_GLOB_H
  #define __KSMBD_GLOB_H
@@ -8,4 +8,3 @@
 +
  #include <linux/ctype.h>
  #include <linux/version.h>
- 

--- a/net/ksmbd-tools/Makefile
+++ b/net/ksmbd-tools/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd-tools
-PKG_VERSION:=3.2.6
+PKG_VERSION:=3.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/ksmbd-tools/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=595029adb899fd8b4c49bea75bce4e3c3466811ef7089b2a55960174e720d919
+PKG_SOURCE_URL:=https://github.com/cifsd-team/cifsd-tools/archive/$(PKG_VERSION)/
+PKG_HASH:=acb4d97cbb0b22ad42ed1536bdd2c28af2a3c698664c058da59a644d5e6df599
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: me

Description:
This reverts commit d88405ba84d397a1ccecee5077bba25d33c4c21e.

As seen in  Andy2244/openwrt-extra#25 and Andy2244/openwrt-extra#24 i did break a default install workflow, since the kmod from the base image is incompatible with the 19.07 packages feed userspace tools now.

PS: I think we maybe need a special kmod-branch where such PR can be committed to and than only merged back to the main 19.07 on base image updates? 
Otherwise i have no clue how i can send updates to the stable branch anymore?