### PR TITLE
miniupnpd: suppress grep and uci errors

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.1.20191006
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/miniupnpd/files/miniupnpd.hotplug
+++ b/net/miniupnpd/files/miniupnpd.hotplug
@@ -12,9 +12,9 @@
 [ "$ACTION" != "ifup" ] && procd_running "miniupnpd" "*" && exit 0
 
 tmpconf="/var/etc/miniupnpd.conf"
-external_iface=$(uci get upnpd.config.external_iface)
-external_iface6=$(uci get upnpd.config.external_iface6)
-external_zone=$(uci get upnpd.config.external_zone)
+external_iface=$(uci -q get upnpd.config.external_iface)
+external_iface6=$(uci -q get upnpd.config.external_iface6)
+external_zone=$(uci -q get upnpd.config.external_zone)
 
 . /lib/functions/network.sh
 
@@ -41,6 +41,6 @@ fi
 
 [ "$DEVICE" != "$ifname" ] && [ "$DEVICE" != "$ifname6" ] && exit 0
 
-grep -q "^ext_ifname=$ifname" "$tmpconf" && grep -q "^ext_ifname6=$ifname6" "$tmpconf" && exit 0
+grep -qs "^ext_ifname=$ifname" "$tmpconf" && grep -qs "^ext_ifname6=$ifname6" "$tmpconf" && exit 0
 
 /etc/init.d/miniupnpd restart


### PR DESCRIPTION
Maintainer: @ldir-EDB0
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:

If `miniupnpd` is installed but disabled or not running, the hotplug script will query `uci` for keys that don't exist and `grep` a temporary config file that doesn't exist, resulting in the following errors:

```
uci: Entry not found
grep: /var/etc/miniupnd.conf: No such file or directory
```

These would arise when an interface is brought up or down, and are more confusing than helpful, especially when `miniupnpd` is disabled.

Suppress these errors.