### PR TITLE
[LuaJit] Add support for mips64

### DIFF
--- a/lang/luajit/Makefile
+++ b/lang/luajit/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luajit
 PKG_VERSION:=2.1.0-beta3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=LuaJIT-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://luajit.org/download
@@ -24,14 +24,13 @@ define Package/luajit
  CATEGORY:=Languages
  TITLE:=LuaJIT
  URL:=https://www.luajit.org
- DEPENDS:=@(i386||x86_64||arm||armeb||aarch64||powerpc||mips||mipsel)
+ DEPENDS:=@(i386||x86_64||arm||armeb||aarch64||powerpc||mips||mipsel||mips64)
 endef
 
 define Package/luajit/description
  LuaJIT is a Just-In-Time (JIT) compiler for the Lua programming language. *** Requires GCC Multilib on host system to build! ***
 endef
-
-ifeq ($(HOST_ARCH),x86_64)
+ifeq ($(HOST_ARCH),$(filter $(HOST_ARCH), x86_64 mips64))
   ifeq ($(CONFIG_ARCH_64BIT),)
     HOST_BITS := -m32
   endif


### PR DESCRIPTION
Maintainer: me / @\milani
Compile tested: mips64, Octeon3 Arch, r13573+1-03a0b7b7e5
Run tested: mips64, Octeon3 Arch, r13573+1-03a0b7b7e5

Description:
Add mips64 support for LuaJIT