### PR TITLE
minidlna: restore service triggers

### DIFF
--- a/multimedia/minidlna/Makefile
+++ b/multimedia/minidlna/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=minidlna
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.code.sf.net/p/minidlna/git

--- a/multimedia/minidlna/files/minidlna.init
+++ b/multimedia/minidlna/files/minidlna.init
@@ -83,7 +83,7 @@ start_service() {
 	[ "$enabled" -gt 0 ] || return 1
 
 	config_get val "config" uuid
-	[ "$val" = '' ] && uci set minidlna.config.uuid="$(cat /proc/sys/kernel/random/uuid)" && uci commit
+	[ "$val" = '' ] && uci set minidlna.config.uuid="$(cat /proc/sys/kernel/random/uuid)" && uci commit minidlna
 
 	minidlna_create_config config || return 1
 
@@ -102,4 +102,8 @@ start_service() {
 	procd_set_param stderr 1
 	procd_set_param respawn
 	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger "minidlna"
 }


### PR DESCRIPTION
Maintainer: none specifically but @bobafetthotmail and @neheb changed the affected code
Compile tested: OpenWrt master r12230-5715b21f80, x86/64
Run tested: OpenWrt master r12230-5715b21f80, x86/64

Description:

Restore service triggers which got wrongly removed in commit
733aae9584ef92c327b9008142602a7e69cfec3b ("fix issues").

Without triggers, changing settings from LuCI or calling reload_config
from the cli won't have any effect.

Also adjust the uci commit call to only commit the minidlna configuration
when setting a UUID, to avoid committing unrelated user changes in other
config files.

Ref: https://github.com/openwrt/luci/issues/4194
Fixes: 733aae958 ("minidlna: fix issues")
Fixes: 37367bdc8 ("minidlna: create UUID in config if it is empty")
Signed-off-by: Jo-Philipp Wich <jo@mein.io>