### PR TITLE
squeezelite: remove WMA support

### DIFF
--- a/sound/squeezelite/Makefile
+++ b/sound/squeezelite/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squeezelite
 PKG_VERSION:=1.9.6-1210
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/ralph-irving/squeezelite
@@ -50,6 +50,7 @@ define Package/squeezelite/config/default
 
 	config SQUEEZELITE_WMA
 	    bool "WMA/ALAC decode support"
+	    depends on BUILD_PATENTED
 	    help
 		Include WMA and ALAC decoding using ffmpeg
 	    default n


### PR DESCRIPTION
WMA uses ffmpeg, which has patented functionality.

WMA is also an old format.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: ath79