### PR TITLE
collectd: enable ubi plugin

### DIFF
--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -106,7 +106,6 @@ COLLECTD_PLUGINS_DISABLED:= \
 	tape \
 	tokyotyrant \
 	turbostat \
-	ubi \
 	uuid \
 	varnish \
 	virt \
@@ -190,6 +189,7 @@ COLLECTD_PLUGINS_SELECTED:= \
 	ted \
 	thermal \
 	threshold \
+	ubi \
 	unixsock \
 	uptime \
 	users \
@@ -453,6 +453,7 @@ $(eval $(call BuildPlugin,ted,The Energy Detective input,ted,))
 $(eval $(call BuildPlugin,tcpconns,TCP connection tracking input,tcpconns,))
 $(eval $(call BuildPlugin,thermal,system temperatures input,thermal,))
 $(eval $(call BuildPlugin,threshold,Notifications and thresholds,threshold,))
+$(eval $(call BuildPlugin,ubi,Unsorted block images,ubi,@NAND_SUPPORT))
 $(eval $(call BuildPlugin,unixsock,unix socket output,unixsock,))
 $(eval $(call BuildPlugin,uptime,uptime status input,uptime,))
 $(eval $(call BuildPlugin,users,user logged in status input,users,))

--- a/utils/collectd/Makefile
+++ b/utils/collectd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd
 PKG_VERSION:=5.11.0
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://collectd.org/files/ \

--- a/utils/collectd/files/collectd.uci
+++ b/utils/collectd/files/collectd.uci
@@ -185,6 +185,11 @@ config globals 'globals'
 #	option IgnoreSelected '0'
 #	list Device ''
 
+#config plugin 'ubi'
+#	option enable '0'
+#	list  Device 'ubi0'
+#	option IgnoreSelected '0'
+
 #config plugin 'unixsock'
 #	option enable '0'
 #	option SocketFile '/var/run/collectd/query.sock'

--- a/utils/collectd/files/usr/share/collectd/plugin/ubi.json
+++ b/utils/collectd/files/usr/share/collectd/plugin/ubi.json
@@ -1,0 +1,8 @@
+{
+	"bool": [
+		"IgnoreSelected"
+	],
+	"list": [
+		"Device"
+	]
+}

--- a/utils/collectd/patches/920-fix-ubi-data-source-type.patch
+++ b/utils/collectd/patches/920-fix-ubi-data-source-type.patch
@@ -1,0 +1,47 @@
+--- a/src/ubi.c
++++ b/src/ubi.c
+@@ -70,13 +70,13 @@ static int ubi_config(const char *key, c
+ } /* int ubi_config */
+ 
+ static void ubi_submit(const char *dev_name, const char *type,
+-                       counter_t value) {
++                       gauge_t value) {
+   value_list_t vl = VALUE_LIST_INIT;
+ 
+   if (ignorelist_match(ignorelist, dev_name) != 0)
+     return;
+ 
+-  vl.values = &(value_t){.counter = value};
++  vl.values = &(value_t){.gauge = value};
+   vl.values_len = 1;
+   sstrncpy(vl.plugin, PLUGIN_NAME, sizeof(vl.plugin));
+   sstrncpy(vl.type_instance, dev_name, sizeof(vl.type_instance));
+@@ -107,7 +107,7 @@ static int ubi_read_dev_attr(const char
+     return -1;
+   }
+ 
+-  ubi_submit(dev_name, attr, (counter_t)val);
++  ubi_submit(dev_name, attr, (gauge_t)val);
+ 
+   return 0;
+ } /* int ubi_read_dev_attr */
+--- a/src/types.db
++++ b/src/types.db
+@@ -7,7 +7,7 @@ apache_scoreboard       value:GAUGE:0:65
+ ath_nodes               value:GAUGE:0:65535
+ ath_stat                value:DERIVE:0:U
+ backends                value:GAUGE:0:65535
+-bad_peb_count           value:COUNTER:0:U
++bad_peb_count           value:GAUGE:0:U
+ bitrate                 value:GAUGE:0:4294967295
+ blocked_clients         value:GAUGE:0:U
+ bucket                  value:GAUGE:0:U
+@@ -140,7 +140,7 @@ job_stats               value:DERIVE:0:U
+ latency                 value:GAUGE:0:U
+ links                   value:GAUGE:0:U
+ load                    shortterm:GAUGE:0:5000, midterm:GAUGE:0:5000, longterm:GAUGE:0:5000
+-max_ec                  value:COUNTER:0:U
++max_ec                  value:GAUGE:0:U
+ media                   value:GAUGE:0:18446744073709551615
+ memory_bandwidth        value:DERIVE:0:U
+ md_disks                value:GAUGE:0:U


### PR DESCRIPTION
Maintainer: @hnyman
Compile tested: lantiq_xrx200, OpenWrt master
Run tested: lantiq_xrx200, OpenWrt maseter, run test

Description:
Enable ubi plugin and add plugin uci binding.
Also add a patch to fix the ubi data source type from COUNTER to GAUGE.
I have already opened a [pullrequest](https://github.com/collectd/collectd/pull/3486) to collectd.