### PR TITLE
bind: update to 9.16.4

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.3
+PKG_VERSION:=9.16.4
 PKG_RELEASE:=2
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=27ac6513de5f8d0db34b9f241da53baa15a14b2ad21338d0cde0826eaf564f7e
+PKG_HASH:=7522088d3daac8bcabaae37998178e09139ef5ccae6631cb1d8a625b770f370a
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Signed-off-by: Tiago Gaspar <tiagogaspar8@gmail.com>

Maintainer: Noah Meyerhans <frodo@morgul.net>
Compile tested: x86 Latest Openwrt trunk
Run tested: ARM WRT3200ACM on the latest Openwrt trunk

Description:
Update bind to the latest version.