### PR TITLE
[OpenConnect] Update to version 8.10 to address CVE-2020-12823

### DIFF
--- a/net/openconnect/Makefile
+++ b/net/openconnect/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openconnect
-PKG_VERSION:=8.09
+PKG_VERSION:=8.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://ftp.infradead.org/pub/openconnect/
-PKG_HASH:=f39802be4c3a099b211ee4cc3318b3a9a195075deab0b4c1c5880c69340ce9a6
+PKG_HASH:=30e64c6eca4be47bbf1d61f53dc003c6621213738d4ea7a35e5cf1ac2de9bab1
 
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING.LGPL


### PR DESCRIPTION
Information found at:
https://nvd.nist.gov/vuln/detail/CVE-2020-12823

Signed-off-by: Donald Hoskins <grommish@gmail.com>

Maintainer: me / @nmav 
Compile tested: MIPS64, Octeon3, OpenWrt r13573+1-03a0b7b7e5
Run tested: MIPS64, Octeon3, OpenWrt r13573+1-03a0b7b7e5, compiled without incident

Description:
