### PR TITLE
numpy: bump to version 1.19.0

### DIFF
--- a/lang/python/numpy/Makefile
+++ b/lang/python/numpy/Makefile
@@ -6,11 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=numpy
-PKG_VERSION:=1.18.5
-PKG_RELEASE:=2
+# Note: make sure to periodically update the Cython version in HOST_PYTHON3_PACKAGE_BUILD_DEPENDS
+PKG_VERSION:=1.19.0
+PKG_RELEASE:=1
 
 PYPI_NAME:=$(PKG_NAME)
-PKG_HASH:=34e96e9dae65c4839bd80012023aadd6ee2ccb73ce7fdf3074c62f301e63120b
+PKG_HASH:=76766cc80d6128750075378d3bb7812cf146415bd29b588616f72c943c00d598
 
 PKG_MAINTAINER:=Alexandru Ardelean <ardeleanalex@gmail.com>
 
@@ -21,7 +22,7 @@ PKG_CPE_ID:=cpe:/a:numpy:numpy
 # yes, zip... sigh
 PYPI_SOURCE_EXT:=zip
 PKG_BUILD_PARALLEL:=0
-HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:="Cython==0.29.19"
+HOST_PYTHON3_PACKAGE_BUILD_DEPENDS:="Cython==0.29.20"
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Maintainer: me
Compile tested: x86, ath79  https://github.com/openwrt/openwrt/commit/870588b6ebd8d818f65e5784bc866a8d67de0a31
Run tested: x86  https://github.com/openwrt/openwrt/commit/870588b6ebd8d818f65e5784bc866a8d67de0a31

--------------------------------------------

Bump host Cython version as well.
Add note near PKG_VERSION to remember to periodically update it.

With this version, we're also trying support for MIPS soft-float.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>