### PR TITLE
nlbwmon: add hotplug script to reload after interface ifup

### DIFF
--- a/net/nlbwmon/Makefile
+++ b/net/nlbwmon/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nlbwmon
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/jow-/nlbwmon.git
@@ -25,7 +25,7 @@ define Package/nlbwmon
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=+libubox +libnl-tiny +zlib +kmod-nf-conntrack-netlink
-  TITLE:=LEDE Traffic Usage Monitor
+  TITLE:=OpenWrt Traffic Usage Monitor
 endef
 
 define Package/nlbwmon/install
@@ -38,6 +38,8 @@ define Package/nlbwmon/install
 	$(INSTALL_BIN) ./files/nlbwmon.init $(1)/etc/init.d/nlbwmon
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/nlbwmon.config $(1)/etc/config/nlbwmon
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
+	$(INSTALL_BIN) ./files/nlbwmon.hotplug $(1)/etc/hotplug.d/iface/30-nlbwmon
 endef
 
 define Package/nlbwmon/conffiles

--- a/net/nlbwmon/files/nlbwmon.hotplug
+++ b/net/nlbwmon/files/nlbwmon.hotplug
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+[ -n "$DEVICE" ] || exit 0
+
+[ "$ACTION" = ifup ] && /etc/init.d/nlbwmon enabled && {
+	/etc/init.d/nlbwmon reload
+	logger -t nlbwmon "Reloading nlbwmon due to $ACTION of $INTERFACE ($DEVICE)"
+}
+


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: ipq806x/R7800, master and 19.07
Run tested: ipq806x/R7800, master and 19.07

Description:
Add a hotplug script to reload nlbwmon's config after interface ifup actions.

That should improve the detection of the IPv6 LAN address that can get enabled a bit later in the boot process. Before this patch nlbwmon ignored my native IPv6 address maybe 50% of the times on boot. I assume that nlbwmon starts before the wan6 has had time to receive an upstream address and pass that to LAN interface.

I am not sure if this is the optimal way, or if the script needs additional checks (like e.g. nlbwmon uci enabled), but this seems to work for me.

Evidence from system log: wan6 comes online about one minute after lan. nlbwmon reloads after that.
```
 OpenWrt SNAPSHOT, r13628-870588b6eb
 -----------------------------------------------------
root@router1:~# logread | grep -C 1 nlbw
Thu Jun 25 19:34:03 2020 user.info adblock-4.0.6[1221]: blocklist with overall 0 blocked domains loaded successfully (Netgear Nighthawk X4S R7800, OpenWrt SNAPSHOT r13628-870588b6eb)
Thu Jun 25 19:34:03 2020 user.notice nlbwmon: Reloading nlbwmon due to ifup of lan (br-lan)
Thu Jun 25 19:34:03 2020 daemon.err collectd[2867]: rrdtool plugin: rrd_update_r failed: /tmp/rrd/router1/thermal-thermal_zone8/temperature.rrd: opening '/tmp/rrd/router1/thermal-thermal_zone8/temperature.rrd': No such file or directory
--
Thu Jun 25 19:34:04 2020 daemon.info hostapd: wlan1: STA 7c:46:85:53:89:44 WPA: pairwise key handshake completed (RSN)
Thu Jun 25 19:34:04 2020 user.notice nlbwmon: Reloading nlbwmon due to ifup of loopback (lo)
Thu Jun 25 19:34:04 2020 daemon.info dnsmasq-dhcp[2347]: DHCPDISCOVER(br-lan) 7c:46:85:53:89:44
--
Thu Jun 25 19:34:57 2020 user.notice ntpd: Stratum change, stratum=3 interval=32 offset=-0.002470
Thu Jun 25 19:34:57 2020 user.notice nlbwmon: Reloading nlbwmon due to ifup of wan (eth0.2)
Thu Jun 25 19:34:57 2020 user.notice odhcpd: *** ODHCPD triggers DNSMASQ reload ***
--
Thu Jun 25 19:34:59 2020 user.notice firewall: Reloading firewall due to ifup of wan6 (eth0.2)
Thu Jun 25 19:35:00 2020 user.notice nlbwmon: Reloading nlbwmon due to ifup of wan6 (eth0.2)
Thu Jun 25 19:35:00 2020 user.notice ddns-scripts[5487]: myddns_ipv6: PID '5487' started at 2020-06-25 19:35
```

Note: the same patch also works in 19.07, so it should be backported there.