### PR TITLE
ksmbd: update to 3.2.2

### DIFF
--- a/kernel/ksmbd/Makefile
+++ b/kernel/ksmbd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ksmbd
-PKG_VERSION:=3.2.0
+PKG_VERSION:=3.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/cifsd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=063474f48f9481ff4a5acf978bd9b31fae39ccecfb232df4aac8c247a2a28b04
+PKG_HASH:=16ad304c09d5f04ddbe99d21ca9df8a9a6d8e35b21ff0e205f212f8c545b979b
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: me
Compile tested: arm (master)
Run tested: arm/mvebu (master)

Description:
* update to 3.2.2

ksmbd changelog:
* fix kernel oops when using signing and pysmb (SMB1) as client.
* fix signing bugs.
* fix encryption bugs.
* fix build error on linux-5.8-rc1
* fix bugs with read-only=yes
* fix potential stuck issue due to cache buffers exhaustion