### PR TITLE
miniupnpd: update to 2.1.20200510

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -8,16 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
-PKG_VERSION:=2.1.20191006
-PKG_RELEASE:=6
+PKG_VERSION:=2.1.20200510
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=218fad7af31f3c22fb4c9db28a55a2a8b5067d41f5b38f52008a057a00d2206d
+PKG_HASH:=821e708f369cc1fb851506441fbc3a1f4a1b5a8bf8e84a9e71758a32f5127e8b
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:miniupnp_project:miniupnpd
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/version.mk
@@ -40,16 +43,15 @@ define Build/Prepare
 	echo "$(VERSION_NUMBER)" | tr '() ' '_' >$(PKG_BUILD_DIR)/os.openwrt
 endef
 
+CONFIGURE_ARGS = \
+	$(if $(CONFIG_IPV6),--ipv6) \
+	--igd2 \
+	--leasefile \
+	--portinuse \
+	--firewall=iptables
+
 TARGET_CFLAGS += $(FPIC) -flto
 TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
-
-MAKE_FLAGS += \
-	TARGET_OPENWRT=1 TEST=0 LIBS="" \
-	CC="$(TARGET_CC) -DIPTABLES_143 -lip4tc -luuid \
-		$(if $(CONFIG_IPV6),-lip6tc)" \
-	CONFIG_OPTIONS="--portinuse --leasefile --igd2 \
-		$(if $(CONFIG_IPV6),--ipv6)" \
-	-f Makefile.linux miniupnpd
 
 define Package/miniupnpd/install
 	$(INSTALL_DIR) $(1)/usr/sbin
@@ -59,7 +61,7 @@ define Package/miniupnpd/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_DIR) $(1)/usr/share/miniupnpd
 
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/miniupnpd $(1)/usr/sbin/miniupnpd
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/miniupnpd $(1)/usr/sbin/miniupnpd
 	$(INSTALL_BIN) ./files/miniupnpd.init $(1)/etc/init.d/miniupnpd
 	$(INSTALL_CONF) ./files/upnpd.config $(1)/etc/config/upnpd
 	$(INSTALL_DATA) ./files/miniupnpd.hotplug $(1)/etc/hotplug.d/iface/50-miniupnpd


### PR DESCRIPTION
Use the newly introduced configure script.

Use PKG_INSTALL for consistency between packages.

Use PKG_BUILD_PARALLEL for faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: ath79
