### PR TITLE
xfsprogs: fix compilation with uClibc-ng

### DIFF
--- a/utils/xfsprogs/Makefile
+++ b/utils/xfsprogs/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xfsprogs
 PKG_VERSION:=5.5.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/fs/xfs/xfsprogs

--- a/utils/xfsprogs/patches/140-mman.patch
+++ b/utils/xfsprogs/patches/140-mman.patch
@@ -1,11 +1,15 @@
 --- a/io/mmap.c
 +++ b/io/mmap.c
-@@ -11,6 +11,10 @@
+@@ -11,6 +11,14 @@
  #include "init.h"
  #include "io.h"
  
 +#ifndef MAP_SYNC
 +#define MAP_SYNC 0
++#endif
++
++#ifndef MAP_SHARED_VALIDATE
++#define MAP_SHARED_VALIDATE 0x03
 +#endif
 +
  static cmdinfo_t mmap_cmd;


### PR DESCRIPTION
MAP_SHARED_VALIDATE is completely missing.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: arc700