### PR TITLE
Backport acme fixes from #11968 to 19.07

### DIFF
--- a/net/acme/Makefile
+++ b/net/acme/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=acme
 PKG_VERSION:=2.8.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/Neilpang/acme.sh/tar.gz/$(PKG_VERSION)?

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -183,6 +183,7 @@ issue_cert()
     local update_uhttpd
     local update_nginx
     local keylength
+    local keylength_ecc=0
     local domains
     local main_domain
     local moved_staging=0
@@ -215,6 +216,7 @@ issue_cert()
 
     if echo $keylength | grep -q "^ec-"; then
         domain_dir="$STATE_DIR/${main_domain}_ecc"
+        keylength_ecc=1
     else
         domain_dir="$STATE_DIR/${main_domain}"
     fi
@@ -234,6 +236,7 @@ issue_cert()
             moved_staging=1
         else
             log "Found previous cert config. Issuing renew."
+            [ "$keylength_ecc" -eq "1" ] && acme_args="$acme_args --ecc"
             run_acme --home "$STATE_DIR" --renew -d "$main_domain" $acme_args && ret=0 || ret=1
             post_checks
             return $ret

--- a/net/acme/files/run.sh
+++ b/net/acme/files/run.sh
@@ -32,17 +32,17 @@ check_cron()
 
 log()
 {
-    logger -t acme -s -p daemon.info "$@"
+    logger -t acme -s -p daemon.info -- "$@"
 }
 
 err()
 {
-    logger -t acme -s -p daemon.err "$@"
+    logger -t acme -s -p daemon.err -- "$@"
 }
 
 debug()
 {
-    [ "$DEBUG" -eq "1" ] && logger -t acme -s -p daemon.debug "$@"
+    [ "$DEBUG" -eq "1" ] && logger -t acme -s -p daemon.debug -- "$@"
 }
 
 get_listeners() {


### PR DESCRIPTION
Maintainer: @tohojo 
Run tested: OpenWrt 19.07.3 on Linksys WRT3200ACM

Description: Backport @yangfl’s acme fixes from #11968 to 19.07. My EC certificates were failing to renew without these.