### PR TITLE
cgroupfs-mount: Updated with git version

### DIFF
--- a/utils/cgroupfs-mount/Makefile
+++ b/utils/cgroupfs-mount/Makefile
@@ -1,12 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cgroupfs-mount
-PKG_VERSION:=1.4
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/tianon/cgroupfs-mount/tar.gz/${PKG_VERSION}?
-PKG_HASH:=d6c8aff7af59c7d0082ee3018c97f73b0421e81a49bb28ad9f66a36da5cd6ec7
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/tianon/$(PKG_NAME)
+PKG_SOURCE_VERSION:=0549428171605eae3097a3e21bf7664845eac9e8
+PKG_SOURCE_DATE:=2020-06-26
+PKG_MIRROR_HASH:=ca217ffff5aa938149d2d8adfe15d800903d2fec180acb2400c36d62905988ea
 
 PKG_MAINTAINER:=Gerard Ryan <G.M0N3Y.2503@gmail.com>
 


### PR DESCRIPTION
Maintainer: @G-M0N3Y-2503
Compile tested: x86_x64, Hyper-V, OpenWrt Master
Run tested: x86_x64, Hyper-V, OpenWrt Master

Description:
People seem to be dependent on this specific version so we switched to git versioning.

I tested to ensure that the following is no longer present when starting a container:
```
[   99.156810] cgroup: runc (21352) created nested cgroup for controller "memory" which has incomplete hierarchy support. Nested cgroups may change behavior in the future.
[   99.157978] cgroup: "memory" requires setting use_hierarchy to 1 on the root
```

Makes https://github.com/openwrt/packages/pull/12458 redundant.