### PR TITLE
syslog-ng: detect disabled IPv6 on loopback and fallback to IPv4

### DIFF
--- a/admin/syslog-ng/Makefile
+++ b/admin/syslog-ng/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syslog-ng
 PKG_VERSION:=3.27.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Josef Schlehofer <josef.schlehofer@nic.cz>
 PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
@@ -87,6 +87,9 @@ define Package/syslog-ng/install
 
 	$(INSTALL_DIR) $(1)/sbin
 	$(INSTALL_BIN) ./files/logread $(1)/sbin
+
+	$(INSTALL_DIR) $(1)/usr/share/syslog-ng/include/
+	$(CP) -r ./files/scl $(1)/usr/share/syslog-ng/include/
 endef
 
 define Package/syslog-ng/postinst

--- a/admin/syslog-ng/files/scl/network_localhost/detect.sh
+++ b/admin/syslog-ng/files/scl/network_localhost/detect.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ "$(sysctl net.ipv6.conf.lo.disable_ipv6 | cut -d' ' -f 3)" = "0" ]; then
+	echo 'network(ip("::1") port(514) transport(udp) ip-protocol(6) )'
+else
+	echo 'network(ip("127.0.0.1") port(514) transport(udp) ip-protocol(4) )'
+fi

--- a/admin/syslog-ng/files/scl/network_localhost/plugin.conf
+++ b/admin/syslog-ng/files/scl/network_localhost/plugin.conf
@@ -1,0 +1,1 @@
+@module confgen context(source) name(network_localhost) exec("`scl-root`/network_localhost/detect.sh")

--- a/admin/syslog-ng/files/syslog-ng.conf
+++ b/admin/syslog-ng/files/syslog-ng.conf
@@ -26,7 +26,7 @@ source src {
 };
 
 source net {
-	network(ip("::1") port(514) transport(udp) ip-protocol(6));
+	network_localhost();
 };
 
 source s_network {


### PR DESCRIPTION
Maintainer: @BKPepe 
Compile tested: 
Run tested: Turris Omnia (OpenWrt 19.07)

Description:
Binding in default to IPv6 is preferable but it can be disabled in
kernel and that prevents syslog-ng to start. This setup should not be
that common but syslog is very important service and should survive
that.

This introduces new plugin defining source generator
`network_localhost`. This is used instead of original network source.
