### PR TITLE
jool: update to v4.1.0

### DIFF
--- a/net/jool/Makefile
+++ b/net/jool/Makefile
@@ -8,12 +8,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=jool
-PKG_VERSION:=4.0.8
+PKG_VERSION:=4.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/NICMx/Jool/releases/download/v$(PKG_VERSION)
-PKG_HASH:=73dd65a14feedc8bd0f650d3316bca346474c8420d60b48ca95bd1ca8846f1d4
+PKG_HASH:=7acdb1cd96b5f856fc75a9ee97758bb4dfb4cd7af4af26f88d512b5ac71f01a0
 
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Maintainer: me
Compile tested: ipq40xx-generic
Run tested: ipq40xx-generic

Description:

Update Jool to v4.1.0

```
Improvements since 4.0.8:
- Implement `lowest-ipv6-mtu`
- Implement shallow translation of ICMP extensions. (RFC 7915 pp. 13, 22)
- Add support for kernel 5.7.
- Patch userspace compilation error triggered when different
   versions of Jool's libraries are already installed in the system.
- #326: Patch userspace-kernel communication on newer kernels.
   (This bug was introduced in Jool 4.0.8.)
- Add support for kernel 5.6.
```