### PR TITLE
libplist: add missing pkgconfig files in libplist 2.2

### DIFF
--- a/libs/libplist/Makefile
+++ b/libs/libplist/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libplist
 PKG_VERSION:=2.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.libimobiledevice.org/downloads
@@ -92,7 +92,10 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libplist-2.0*.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libplist*.pc $(1)/usr/lib/pkgconfig/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libplist++-2.0.pc $(1)/usr/lib/pkgconfig/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libplist-2.0.pc $(1)/usr/lib/pkgconfig/
+	$(LN) libplist++-2.0.pc $(1)/usr/lib/pkgconfig/libplist++.pc
+	$(LN) libplist-2.0.pc $(1)/usr/lib/pkgconfig/libplist.pc
 endef
 
 define Package/libplist/install


### PR DESCRIPTION
Maintainer: @neheb 
Compile tested: ar7xxx, trunk
Run tested: no

Description:
Commit d082258c3eb6305dd11429f4d41e42ac2d91234f broke builds where the configure script uses pkgconfig to search for "libplist", since version 2.2 of libplist doesn't ship a "libplist.pc", only a "libplist-2.0.pc". 

This fix is the same as Debian uses, see:
https://github.com/libimobiledevice/libplist/commit/137716df3f197a7184c1fba88fcb30480dafd6e0#commitcomment-40099153

I have also submitted an issue to libplist suggesting that they going forward also ship libplist.pc.

Closes #12571.

Signed-off-by: Espen Jürgensen <espenjurgensen+openwrt@gmail.com>