### PR TITLE
[19.07] stubby: fix handling of tls_port config option

### DIFF
--- a/net/stubby/Makefile
+++ b/net/stubby/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=stubby
 PKG_VERSION:=0.2.6
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/getdnsapi/$(PKG_NAME)

--- a/net/stubby/files/stubby.init
+++ b/net/stubby/files/stubby.init
@@ -162,7 +162,7 @@ generate_config()
         config_get tls_auth_name "$config" tls_auth_name
         echo "    tls_auth_name: \"$tls_auth_name\""
 
-        config_get tls_auth_port "$config" tls_port ""
+        config_get tls_port "$config" tls_port ""
         if [ -n "$tls_port" ]; then
             echo "    tls_port: $tls_port"
         fi


### PR DESCRIPTION
Signed-off-by: Jonathan G. Underwood <jonathan.underwood@gmail.com>

Maintainer: me
Compile tested: x86
Run tested: x86

Description: This fixes a bug with how the `tls_port` UCI config option was being handled
