### PR TITLE
samba4: add new UCI option "enable_extra_tuning"

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
 PKG_VERSION:=4.12.3
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \

--- a/net/samba4/files/samba.config
+++ b/net/samba4/files/samba.config
@@ -1,4 +1,24 @@
+
 config samba
-	option 'workgroup'		'WORKGROUP'
-	option 'description'	'Samba on OpenWrt'
-	option 'charset' 		'UTF-8'
+	option workgroup 'WORKGROUP'
+	option charset 'UTF-8'
+	option description 'Samba on OpenWRT'
+	#option enable_extra_tuning '0'
+
+## example share
+#config sambashare
+	#option guest_only 'yes'
+	#option create_mask '0666'
+	#option dir_mask '0777'
+	#option force_root '1'
+	#option name 'share'
+	#option inherit_owner 'yes'
+	#option guest_ok 'yes'
+	#option read_only 'no'
+	#option path '/mnt/tmp'
+
+## reduce process priority via nice
+#config procd 'extra'
+	#option samba_nice '3'
+## on mvebu platform we need negative values!
+	#option samba_nice '-10'

--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -37,6 +37,7 @@ smb_header() {
 	config_get_bool DISABLE_WINBIND $1 disable_winbind 0
 	config_get_bool DISABLE_ASYNC_IO $1 disable_async_io 0
 	config_get_bool ALLOW_LEGACY_PROTOCOLS $1 allow_legacy_protocols 0
+	config_get_bool ENABLE_EXTRA_TUNING $1 enable_extra_tuning 0
 
 	mkdir -p /var/etc
 	sed -e "s#|NAME|#$hostname#g" \
@@ -48,6 +49,21 @@ smb_header() {
 
 	{
 		printf "\n######### Dynamic written config options #########\n"
+
+		# extra tuning options by community feedback (kinda try&error)
+		if [ "$ENABLE_EXTRA_TUNING" -eq 1 ]; then
+			local socket_opt
+			socket_opt="$(grep -i 'socket options' /etc/samba/smb.conf.template | awk -F'=' '{print $2}' | tr -d '\n')"
+			[ -n "$socket_opt" ] && printf "\tsocket options =%s SO_KEEPALIVE\n" "$socket_opt" # add keepalive, maybe larger buffer? SO_RCVBUF=65536 SO_SNDBUF=65536
+
+			printf "\tmax xmit = 131072\n" # increase smb1 transmit size
+			printf "\tmin receivefile size = 131072\n" # allows zero-copy writes via fs
+			printf "\tfake oplocks = Yes\n" # may corrupt files for simultanous writes to the same files by multiple clients, but might also see big speed boost
+			printf "\tuse sendfile = Yes\n" # enable sendfile, not sure whats with the 2019 bug https://bugzilla.samba.org/show_bug.cgi?id=14095
+			# Removed in 4.12.x in favor of VFS io_uring ; this is per file, so may increase memory useage on many simultanous oplocked files!
+			printf "\twrite cache size = 262144\n" # adds a write cache buffer per file for oplocked files, flushes if size is exhausted
+		fi
+
 		if [ "$DISABLE_NETBIOS" -eq 1 ] || [ ! -x /usr/sbin/nmbd ]; then
 			printf "\tdisable netbios = yes\n"
 			# note: samba opens port 139 even if netbios is disabled via option above, so adjust listening ports
@@ -157,12 +173,14 @@ smb_add_share() {
 
 init_config() {
 	# Create samba dirs
-	[ -d /var/lib/samba ] || mkdir -p /var/lib/samba
-	[ -d /var/cache/samba ] || mkdir -p /var/cache/samba
+	[ -d /var/lib/samba ] || mkdir -m 755 -p /var/lib/samba
+	[ -d /var/cache/samba ] || mkdir -m 755 -p /var/cache/samba
+	[ -d /var/lock ] || mkdir -m 755 -p /var/lock
 	[ -d /var/run/samba ] || mkdir -p /var/run/samba
 	[ -d /var/log/samba ] || mkdir -p /var/log/samba
-	[ -d /var/lock ] || mkdir -p /var/lock
 	chmod 0755 /var/lock
+	chmod 0755 /var/lib/samba
+	chmod 0755 /var/cache/samba
 
 	config_load samba4
 	config_foreach smb_header samba

--- a/net/samba4/files/smb.conf.template
+++ b/net/samba4/files/smb.conf.template
@@ -40,7 +40,7 @@
 	## Set location of smbpasswd ('smbd -b' will show default compiled location)
 	#smb passwd file = /etc/samba/smbpasswd 
 
-	## LAN/WAN options (IPTOS_LOWDELAY TCP_NODELAY) WAN (IPTOS_THROUGHPUT)
+	## LAN (IPTOS_LOWDELAY TCP_NODELAY) WAN (IPTOS_THROUGHPUT) WiFi (SO_KEEPALIVE) try&error for buffer sizes (SO_RCVBUF=65536 SO_SNDBUF=65536)
 	socket options = IPTOS_LOWDELAY TCP_NODELAY
 
 	## If this integer parameter is set to a non-zero value, Samba will read from files asynchronously when the request size is bigger than this value.
@@ -56,7 +56,7 @@
 	#aio write behind = /*.tmp/
 
 	## lower CPU useage if supported and aio is disabled (aio read size = 0 ; aio write size = 0)
-	## currently broken (NOTE: see https://bugzilla.samba.org/show_bug.cgi?id=14095 )
+	## is this still broken? issue is from 2019 (NOTE: see https://bugzilla.samba.org/show_bug.cgi?id=14095 )
 	## (no, yes)
 	#use sendfile = yes
 


### PR DESCRIPTION
Maintainer: me
Compile tested: arm (master)
Run tested: arm/mvebu (master)

Description:
* add new UCI option "enable_extra_tuning"
* update template
* add config examples for options
* fix some access warnings on samba /var dirs

PS: The new UCI option is a attempt to have an easy to "try" option, if you suffer from really bad samba4 speeds. The included options are based on community feedback.