### PR TITLE
tiff: switch to CMake

### DIFF
--- a/libs/tiff/Makefile
+++ b/libs/tiff/Makefile
@@ -9,31 +9,27 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tiff
 PKG_VERSION:=4.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.osgeo.org/libtiff
 PKG_HASH:=5d29f32517dadb6dbcd1255ea5bbc93a2b54b94fbf83653b4d65c7d6775b8634
 
-PKG_FIXUP:=autoreconf
-PKG_REMOVE_FILES:=autogen.sh aclocal.m4
-
-PKG_LICENSE:=BSD
+PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
+PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=COPYRIGHT
 PKG_CPE_ID:=cpe:/a:libtiff:libtiff
 
 PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
-
 PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_libtiffxx
 
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/tiff/Default
   TITLE:=TIFF
   URL:=http://simplesystems.org/libtiff/
-  MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 endef
 
 define Package/libtiff
@@ -42,6 +38,7 @@ $(call Package/tiff/Default)
   CATEGORY:=Libraries
   TITLE+= library
   DEPENDS:=+zlib +libjpeg
+  ABI_VERSION:=5
 endef
 
 define Package/libtiffxx
@@ -61,44 +58,42 @@ $(call Package/tiff/Default)
   DEPENDS:=+libtiff
 endef
 
-CONFIGURE_ARGS += \
-	$(if $(CONFIG_PACKAGE_libtiffxx),--enable-cxx,--disable-cxx) \
-	--disable-lzma \
-	--enable-ccitt \
-	--enable-packbits \
-	--enable-lzw \
-	--enable-thunder \
-	--enable-next \
-	--enable-logluv \
-	--enable-mdi \
-	--enable-zlib \
-	--enable-jpeg \
-	--disable-old-jpeg \
-	--disable-jbig \
-	--disable-webp \
-	--disable-zstd \
-	--without-x
+CMAKE_OPTIONS += \
+	-Dld-version-script=OFF \
+	-Dccitt=ON \
+	-Dpackbits=ON \
+	-Dlzw=ON \
+	-Dthunder=ON \
+	-Dnext=ON \
+	-Dlogluv=ON \
+	-Dmdi=ON \
+	-Dzlib=ON \
+	-Dpixarlog=ON \
+	-Djpeg=ON \
+	-Dold-jpeg=OFF \
+	-Djbig=OFF \
+	-Dlzma=OFF \
+	-Dzstd=OFF \
+	-Dwebp=OFF \
+	-Djpeg12=OFF \
+	-Dcxx=O$(if $(CONFIG_PACKAGE_libtiffxx),N,FF)
 
-define Build/InstallDev/hxx
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/*.hxx $(1)/usr/include/
-endef
+TARGET_CFLAGS += $(TARGET_CPPFLAGS)
 
 define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/{lib,include} $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib* $(1)/usr/lib/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc $(1)/usr/lib/pkgconfig/
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
-	$(if $(CONFIG_PACKAGE_libtiffxx), $(call Build/InstallDev/hxx,$(1)))
+	$(call Build/InstallDev/cmake,$(1))
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libtiff-4.pc
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/libtiff-4.pc
 endef
 
 define Package/libtiff/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtiff.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtiff.so.$(ABI_VERSION)* $(1)/usr/lib
 endef
 
 define Package/libtiffxx/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtiffxx.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtiffxx.so.$(ABI_VERSION)* $(1)/usr/lib/
 endef
 
 define Package/tiff-utils/install


### PR DESCRIPTION
Allows removing autotools hacks. Also simplified InstallDev section.

Added ABI_VERSION parameter for proper rebuilds. Also used in the
pkgconfig path fixup.

Small cleanups for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jslachta 
Compile tested: ath79