### PR TITLE
liburing: new package: liburing v0.6

### DIFF
--- a/libs/liburing/Makefile
+++ b/libs/liburing/Makefile
@@ -33,9 +33,7 @@ endef
 
 CONFIGURE_ARGS:=--prefix=$(CONFIGURE_PREFIX) --cc=${TARGET_CC}
 
-ifeq ($(CONFIG_USE_MUSL),y)
-	TARGET_CFLAGS+=-Dloff_t=off_t
-endif
+TARGET_CFLAGS += $(if $(CONFIG_USE_MUSL),-Dloff_t=off_t)
 
 define Build/Compile
 	$(MAKE) $(PKG_BUILD_DIR) \

--- a/libs/liburing/Makefile
+++ b/libs/liburing/Makefile
@@ -20,7 +20,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/liburing
   SECTION:=libs
   CATEGORY:=Libraries
-  TITLE:=liburing
+  TITLE:=io_uring library
   URL:=https://git.kernel.dk/cgit/liburing
 endef
 
@@ -35,10 +35,6 @@ CONFIGURE_ARGS:=--prefix=$(CONFIGURE_PREFIX) --cc=${TARGET_CC}
 
 ifeq ($(CONFIG_USE_MUSL),y)
 	TARGET_CFLAGS+=-Dloff_t=off_t
-endif
-
-ifeq ($(CONFIG_USE_UCLIBC),y)
-	TARGET_CFLAGS+=-fno-stack-protector
 endif
 
 define Build/Compile

--- a/libs/liburing/Makefile
+++ b/libs/liburing/Makefile
@@ -1,0 +1,65 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=liburing
+PKG_VERSION:=0.6
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://git.kernel.dk/cgit/liburing/snapshot
+PKG_HASH:=44c99b9f148a885d882acd7aa63658141675eae251298cbf79bb9a4ab307ef9c
+
+PKG_MAINTAINER:=Christian Lachner <gladiac@gmail.com>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYING
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/liburing
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=liburing
+  URL:=https://git.kernel.dk/cgit/liburing
+endef
+
+define Package/liburing/description
+  liburing provides helpers to setup and teardown io_uring instances,
+  and also a simplified interface for applications that don't need
+  (or want) to deal with the full kernel side implementation.
+  For more info on io_uring, please see: https://kernel.dk/io_uring.pdf
+endef
+
+CONFIGURE_ARGS:=--prefix=$(CONFIGURE_PREFIX) --cc=${TARGET_CC}
+
+ifeq ($(CONFIG_USE_MUSL),y)
+	TARGET_CFLAGS+=-Dloff_t=off_t
+endif
+
+ifeq ($(CONFIG_USE_UCLIBC),y)
+	TARGET_CFLAGS+=-fno-stack-protector
+endif
+
+define Build/Compile
+	$(MAKE) $(PKG_BUILD_DIR) \
+		DSTROOT="$(PKG_INSTALL_DIR)"
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.{so*,a} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/liburing.pc $(1)/usr/lib/pkgconfig/
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/liburing.pc
+	$(SED) 's,/usr/lib,$$$${prefix}/lib,g' $(1)/usr/lib/pkgconfig/liburing.pc
+endef
+
+define Package/liburing/install
+	$(INSTALL_DIR) $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liburing.so $(PKG_INSTALL_DIR)/usr/lib/liburing.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,liburing))

--- a/libs/liburing/patches/000-OPENWRT-add-int64_t-detection.patch
+++ b/libs/liburing/patches/000-OPENWRT-add-int64_t-detection.patch
@@ -1,0 +1,11 @@
+--- ./configure
++++ ./configure
+@@ -301,6 +301,8 @@
+ fi
+ if test "$__kernel_timespec" != "yes"; then
+ cat >> $compat_h << EOF
++#include <inttypes.h>
++
+ struct __kernel_timespec {
+ 	int64_t		tv_sec;
+ 	long long	tv_nsec;


### PR DESCRIPTION
Maintainer: Christian Lachner <gladiac@gmail.com>
Compile tested: mipsel, mips74k, ipq806x, x86, arc700

Description: New package: liburing v0.6
This is the liburing library. liburing provides helpers to setup and
teardown io_uring instances, and also a simplified interface for
applications that don't need (or want) to deal with the full kernel
side implementation.

This package was made primarily to support a [new VFS module](https://wiki.samba.org/index.php/Samba_4.12_Features_added/changed#.27io_uring.27_vfs_module) for the samba4 package and has been run-tested by @Andy2244 who is a maintainer for samba4 in openwrt.

This PR does the following:
- Add initial Makefile
- Add patch to fix inttypes.h inclusion when __kernel_timespec is unavailable