### PR TITLE
mini_snmpd: Allow specifying raw netdev names

### DIFF
--- a/net/mini_snmpd/files/mini_snmpd.config
+++ b/net/mini_snmpd/files/mini_snmpd.config
@@ -21,6 +21,6 @@ config mini_snmpd 'default'
 	list disks '/tmp'
 	# enable basic network statistics on specified interface
 	# 4 interfaces maximum per instance, as named in /etc/config/network and luci
-	# not physical device names
+	# OR physical device names
 	list interfaces 'lan'
 	list interfaces 'wan'

--- a/net/mini_snmpd/files/mini_snmpd.init
+++ b/net/mini_snmpd/files/mini_snmpd.init
@@ -76,6 +76,10 @@ append_interface() {
 	[ -z $netdev_count ] && netdev_count=0
 	# for the purposes of snmp monitoring it doesn't need to be up, it just needs to exist in /proc/net/dev
 	network_get_device netdev "$name"
+	# Also accept raw device names.
+	if [ -z "$netdev" ] && grep -qF "$name" /proc/net/dev ]; then
+		netdev="$name"
+	fi
 	if [ -n "$netdev" ] && grep -qF "$netdev" /proc/net/dev ]; then
 		[ $netdev_count -ge 8 ] && {
 			_err "$cfg: too many network interfaces configured, ignoring $name"


### PR DESCRIPTION
Maintainer: Marcin Jurkowski <marcin1j@gmail.com>
Compile tested: no
Run tested: mips_24kc, TP-LINK TL-WR703N v1, 17.01.7, tested running the daemon with these changes

Description:
There are many cases where you want to specify a network interface name directly, instead of an UCI name. For example, I have a LAN bridge where I want to monitor the traffic of each interface separately. This change allows to specify either kind of name.