### PR TITLE
check: bump 0.15.0

### DIFF
--- a/libs/check/Makefile
+++ b/libs/check/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=check
-PKG_VERSION:=0.14.0
+PKG_VERSION:=0.15.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/libcheck/check/releases/download/$(PKG_VERSION)
-PKG_HASH:=bd0f0ca1be65b70238b32f8e9fe5d36dc2fbf7a759b7edf28e75323a7d74f30b
+PKG_HASH:=aea2e3c68fa6e1e92378e744b1c0db350ccda4b6bd0d19530d0ae185b3d1ac60
 
 PKG_MAINTAINER:=Eduardo Abinader <eduardoabinader@gmail.com>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Compiled and run in x86_64.

Changes:
        -Define CK_ATTRIBUTE_FORMAT for GCC >= 2.95.3, to make use of ‘gnu_printf’ format attribute
        -Refactor tests to fix signed - unsigned conversions
        -Refactor some Check internals to use proper interger types

Maintainer: me 
Compile tested: x86_64
Run tested:  x86_64