### PR TITLE
tiff: declare ABI_VERSION in libtiffxx as well

### DIFF
--- a/libs/tiff/Makefile
+++ b/libs/tiff/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tiff
 PKG_VERSION:=4.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://download.osgeo.org/libtiff
@@ -47,6 +47,7 @@ $(call Package/tiff/Default)
   CATEGORY:=Libraries
   TITLE+= library(c++ bindings)
   DEPENDS:=+libtiff $(CXX_DEPENDS)
+  ABI_VERSION:=5
 endef
 
 define Package/tiff-utils


### PR DESCRIPTION
ABI_VERSION is used in Package/libtiffxx/install but not defined, so we
don't get SONAME treatment for libtiffxx. This commit adds the missing
ABI_VERSION.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @jslachta 
Compile tested: ath79 master
Run tested: no runtime-change

Description:
Hi Jiri,

This adds a missing var.

Kind regards,
Seb