### PR TITLE
bandwidthd: fix compilation with GCC10

### DIFF
--- a/utils/bandwidthd/Makefile
+++ b/utils/bandwidthd/Makefile
@@ -9,17 +9,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bandwidthd
 PKG_VERSION:=2.0.1-35
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/NethServer/bandwidthd/tar.gz/$(PKG_VERSION)?
 PKG_HASH:=75f526d9e81c5a543accbb9e197b6b582c293aa20d6cdfc8be5cef43046981c5
 
 PKG_MAINTAINER:=Jean-Michel Lacroix <lacroix@lepine-lacroix.info>
-
-PKG_LICENSE:=GPL-2.0
+PKG_LICENSE:=GPL-2.0-or-later
 
 PKG_FIXUP:=autoreconf
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/utils/bandwidthd/patches/030-gcc10.patch
+++ b/utils/bandwidthd/patches/030-gcc10.patch
@@ -1,0 +1,20 @@
+--- a/bandwidthd.h
++++ b/bandwidthd.h
+@@ -120,7 +120,7 @@ struct config
+ 	char *sensor_id;
+ 	};
+ 
+-struct SubnetData
++extern struct SubnetData
+     {
+     uint32_t ip;
+     uint32_t mask;
+@@ -139,7 +139,7 @@ struct Statistics
+ 	unsigned long long p2p;
+     };
+ 
+-struct IPData
++extern struct IPData
+     {
+     time_t timestamp;
+     uint32_t ip;	// Host byte order


### PR DESCRIPTION
Added PKG_BUILD_PARALLEL for faster compilation.

Fixed license information.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @padre-lacroix 
Compile tested: ath79