### PR TITLE
Netopeer2: fix compilation with GCC10

### DIFF
--- a/net/Netopeer2/Makefile
+++ b/net/Netopeer2/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=Netopeer2
 PKG_VERSION:=1.1.27
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/CESNET/Netopeer2/tar.gz/v$(PKG_VERSION)?

--- a/net/Netopeer2/patches/001-openss_1.1_support.patch
+++ b/net/Netopeer2/patches/001-openss_1.1_support.patch
@@ -1,6 +1,6 @@
 --- a/cli/commands.c	2020-05-08 16:29:28.284509842 +0300
 +++ b/cli/commands.c	2020-05-08 16:29:38.856397844 +0300
-@@ -1725,7 +1725,7 @@
+@@ -1727,7 +1727,7 @@
      BIO_printf(bio_out, "\n");
  
      BIO_printf(bio_out, "Valid until: ");

--- a/net/Netopeer2/patches/010-gcc10.patch
+++ b/net/Netopeer2/patches/010-gcc10.patch
@@ -1,0 +1,22 @@
+--- a/cli/commands.h
++++ b/cli/commands.h
+@@ -17,7 +17,7 @@
+ 
+ #include "cli_version.h"
+ 
+-char some_msg[4096];
++static char some_msg[4096];
+ #define INSTRUCTION(format,args...) {snprintf(some_msg,4095,format,##args);printf("\n  %s",some_msg);}
+ #define ERROR(function,format,args...) {snprintf(some_msg,4095,format,##args);fprintf(stderr,"%s: %s\n",function,some_msg);}
+ 
+--- a/src/log.h
++++ b/src/log.h
+@@ -36,7 +36,7 @@ extern uint8_t np2_sr_verbose_level;
+ /**
+  * @brief netopeer2 flag whether to print messages to stderr (only if not daemon).
+  */
+-uint8_t np2_stderr_log;
++extern uint8_t np2_stderr_log;
+ 
+ /**
+  * @brief internal printing function, follows the levels from libnetconf2


### PR DESCRIPTION
Refreshed openssl patch.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @mislavn
Compile tested: ath79