### PR TITLE
treewide: alternatives instead of postinst, {pre,post}rm

### DIFF
--- a/utils/grep/Makefile
+++ b/utils/grep/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=grep
 PKG_VERSION:=3.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/grep
@@ -31,6 +31,10 @@ define Package/grep
   TITLE:=grep search utility - full version
   DEPENDS:=+libpcre
   URL:=https://www.gnu.org/software/grep/
+  ALTERNATIVES:=\
+    300:/bin/egrep:/usr/libexec/egrep-gnu \
+    300:/bin/fgrep:/usr/libexec/fgrep-gnu \
+    300:/bin/grep:/usr/libexec/grep-gnu
 endef
 
 define Package/grep/description
@@ -40,20 +44,10 @@ prints the matching lines.
 endef
 
 define Package/grep/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin
-endef
-
-define Package/grep/postinst
-#!/bin/sh
-[ -L "$${IPKG_INSTROOT}/bin/grep" ] && rm -f "$${IPKG_INSTROOT}/bin/grep"
-exit 0
-endef
-
-define Package/grep/prerm
-$${IPKG_INSTROOT}/bin/busybox grep -h 2>&1 | grep -q BusyBox && \
-ln -sf busybox $${IPKG_INSTROOT}/bin/grep
-exit 0
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/egrep $(1)/usr/libexec/egrep-gnu
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/fgrep $(1)/usr/libexec/fgrep-gnu
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/grep $(1)/usr/libexec/grep-gnu
 endef
 
 $(eval $(call BuildPackage,grep))

--- a/utils/gzip/Makefile
+++ b/utils/gzip/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gzip
 PKG_VERSION:=1.10
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/gzip
@@ -29,6 +29,10 @@ define Package/gzip
   TITLE:=gzip (GNU zip) is a compression utility.
   URL:=https://www.gnu.org/software/gzip/
   MAINTAINER:=Christian Beier <dontmind@freeshell.org>
+  ALTERNATIVES:=\
+    300:/bin/gunzip:/usr/libexec/gunzip-gnu \
+    300:/bin/gzip:/usr/libexec/gzip-gnu \
+    300:/bin/zcat:/usr/libexec/zcat-gnu
 endef
 
 define Package/gzip/description
@@ -42,25 +46,10 @@ CONFIGURE_VARS += \
 
 define Package/gzip/install
 	$(SED) 's,/bin/bash,/bin/sh,g' $(PKG_INSTALL_DIR)/usr/bin/{gunzip,zcat}
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/{gunzip,gzip,zcat} $(1)/usr/bin/
-endef
-
-define Package/gzip/postinst
-#!/bin/sh
-for app in gunzip gzip zcat; do
-  ln -sf ../usr/bin/$$app $${IPKG_INSTROOT}/bin/$$app
-done
-endef
-
-define Package/gzip/postrm
-#!/bin/sh
-for app in gunzip gzip zcat; do
-  ln -sf busybox $${IPKG_INSTROOT}/bin/$$app
-  $${IPKG_INSTROOT}/bin/$$app 2>&1 | grep 'applet not found' > /dev/null 2>&1 && rm $${IPKG_INSTROOT}/bin/$$app
-done
-exit 0
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gunzip $(1)/usr/libexec/gunzip-gnu
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gzip $(1)/usr/libexec/gzip-gnu
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/zcat $(1)/usr/libexec/zcat-gnu
 endef
 
 $(eval $(call BuildPackage,gzip))
-

--- a/utils/sed/Makefile
+++ b/utils/sed/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sed
 PKG_VERSION:=4.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/sed
@@ -31,6 +31,7 @@ define Package/sed
   TITLE:=sed stream editor utility - full version
   DEPENDS:=+libpcre
   URL:=https://www.gnu.org/software/sed/
+  ALTERNATIVES:=300:/bin/sed:/usr/libexec/sed-gnu
 endef
 
 define Package/sed/description
@@ -42,22 +43,10 @@ occurrences of a string within a file.
 endef
 
 define Package/sed/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/sed $(1)/usr/libexec/sed-gnu
 endef
 
 CONFIGURE_ARGS+= --disable-acl
-
-define Package/sed/postinst
-#!/bin/sh
-[ -L "$${IPKG_INSTROOT}/bin/sed" ] && rm -f "$${IPKG_INSTROOT}/bin/sed"
-exit 0
-endef
-
-define Package/sed/prerm
-$${IPKG_INSTROOT}/bin/busybox sed -h 2>&1 | grep -q BusyBox && \
-ln -sf busybox $${IPKG_INSTROOT}/bin/sed
-exit 0
-endef
 
 $(eval $(call BuildPackage,sed))

--- a/utils/tar/Makefile
+++ b/utils/tar/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tar
 PKG_VERSION:=1.32
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
+PKG_SOURCE_URL:=@GNU/tar
 PKG_HASH:=d0d3ae07f103323be809bc3eac0dcc386d52c5262499fe05511ac4788af1fdd8
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
@@ -33,6 +33,7 @@ define Package/tar
   TITLE:=GNU tar
   URL:=https://www.gnu.org/software/tar/
   MENU:=1
+  ALTERNATIVES:=300:/bin/tar:/usr/libexec/tar-gnu
 endef
 
 define Package/tar/config
@@ -73,22 +74,6 @@ define Package/tar/description
 	single archive in tar format.
 endef
 
-define Package/tar/postinst
-#!/bin/sh
-if [ -e $${IPKG_INSTROOT}/bin/tar ]; then
-  rm -r $${IPKG_INSTROOT}/bin/tar;
-fi
-ln -sf /usr/bin/tar $${IPKG_INSTROOT}/bin/tar
-endef
-
-define Package/tar/postrm
-#!/bin/sh
-rm $${IPKG_INSTROOT}/bin/tar
-ln -s busybox $${IPKG_INSTROOT}/bin/tar
-$${IPKG_INSTROOT}/bin/tar 2>&1 | grep 'applet not found' > /dev/null 2>&1 && rm $${IPKG_INSTROOT}/bin/tar
-exit 0
-endef
-
 CONFIGURE_ARGS += \
 	$(if $(CONFIG_PACKAGE_TAR_POSIX_ACL),--with,--without)-posix-acls \
 	$(if $(CONFIG_PACKAGE_TAR_XATTR),--with,--without)-xattrs \
@@ -108,8 +93,8 @@ MAKE_FLAGS += \
 	LDFLAGS="$(TARGET_LDLAGS)"
 
 define Package/tar/install
-	$(INSTALL_DIR) $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/$(PKG_NAME) $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/tar $(1)/usr/libexec/tar-gnu
 endef
 
 $(eval $(call BuildPackage,tar))


### PR DESCRIPTION
Maintainer: @RussellSenior, @neheb 
Compile tested: ath79/nand, mpc85xx/p2020, latest master
Run tested: ath79/nand, tests done

Description:
Make it work fine to upgrade package gzip.