### PR TITLE
opusfile: bump 0.12

### DIFF
--- a/libs/opusfile/Makefile
+++ b/libs/opusfile/Makefile
@@ -6,13 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opusfile
-PKG_VERSION:=0.11
+PKG_VERSION:=0.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://downloads.xiph.org/releases/opus/
-PKG_HASH:=74ce9b6cf4da103133e7b5c95df810ceb7195471e1162ed57af415fabf5603bf
-
+PKG_HASH:=118d8601c12dd6a44f52423e68ca9083cc9f2bfe72da7a8c1acb22a80ae3550b
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Eduardo Abinader <eduardoabinader@gmail.com>


### PR DESCRIPTION
Changes since the v0.11 release:

    Fix stack overflow buffering out-of-sequence streams.
    Fix possible divide-by-zero.
    Fix issues with seeking in the win32 backend.
    Fix an issue where the seek algorithm could be confused by stream data changing between reads.
    Clean up compiler and scan-build warnings.
    Avoid use of the deprecated ftime() function which has Y2038 problems.
    Remove undefined behaviour memcpy(NULL) in op_read_native().
    Visual Studio project files updated for libogg 1.3.4 library name change.
    Various build systems updates.
    Various integration and testing environment improvements.

Signed-off-by: Eduardo Abinader <eduardoabinader@gmail.com>

Maintainer: me 
Compile tested: x86_64
Run tested: x86_64