### PR TITLE
[19.07] bind: update to version 9.16.x

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.2
+PKG_VERSION:=9.16.3
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=d9e5b77cfca5ccad97f19cddc87128758ec15c16e6585000c6b2f84fc225993f
+PKG_HASH:=27ac6513de5f8d0db34b9f241da53baa15a14b2ad21338d0cde0826eaf564f7e
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
 PKG_VERSION:=9.16.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -83,6 +83,7 @@ define Package/bind-tools
 	DEPENDS:= \
 	+bind-check \
 	+bind-dig \
+	+bind-nslookup \
 	+bind-dnssec \
 	+bind-host \
 	+bind-rndc
@@ -111,6 +112,13 @@ endef
 define Package/bind-dig
   $(call Package/bind/Default)
   TITLE+= DNS excavation tool
+endef
+
+define Package/bind-nslookup
+  $(call Package/bind/Default)
+  TITLE+= nslookup utility
+  ALTERNATIVES:= \
+	  200:/usr/bin/nslookup:/usr/libexec/nslookup-bind
 endef
 
 export BUILD_CC="$(TARGET_CC)"
@@ -234,6 +242,11 @@ define Package/bind-dig/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/dig $(1)/usr/bin/
 endef
 
+define Package/bind-nslookup/install
+	$(INSTALL_DIR) $(1)/usr/libexec
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nslookup $(1)/usr/libexec/nslookup-bind
+endef
+
 $(eval $(call BuildPackage,bind-libs))
 $(eval $(call BuildPackage,bind-server))
 $(eval $(call BuildPackage,bind-server-filter-aaaa))
@@ -244,3 +257,4 @@ $(eval $(call BuildPackage,bind-check))
 $(eval $(call BuildPackage,bind-dnssec))
 $(eval $(call BuildPackage,bind-host))
 $(eval $(call BuildPackage,bind-dig))
+$(eval $(call BuildPackage,bind-nslookup))

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.16.1
+PKG_VERSION:=9.16.2
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=a913d7e78135b9123d233215b58102fa0f18130fb1e158465a1c2b6f3bd75e91
+PKG_HASH:=d9e5b77cfca5ccad97f19cddc87128758ec15c16e6585000c6b2f84fc225993f
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4

--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2006-2012 OpenWrt.org
-#               2014-2017 Noah Meyerhans <frodo@morgul.net>
+#               2014-2020 Noah Meyerhans <frodo@morgul.net>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.14.12
+PKG_VERSION:=9.16.1
 PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
@@ -18,11 +18,11 @@ PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:isc:bind
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=9c4de493bf7dfaa68b0273135369601d474175ab504ab572ffbb42a6db6ef4c8
+PKG_HASH:=a913d7e78135b9123d233215b58102fa0f18130fb1e158465a1c2b6f3bd75e91
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4
@@ -35,12 +35,7 @@ PKG_CONFIG_DEPENDS := \
 	CONFIG_BIND_LIBJSON \
 	CONFIG_BIND_LIBXML2
 
-ifdef CONFIG_BIND_LIBXML2
-  PKG_BUILD_DEPENDS += libxml2
-endif
-ifdef CONFIG_BIND_LIBJSON
-  PKG_BUILD_DEPENDS += libjson-c
-endif
+PKG_BUILD_DEPENDS += BIND_LIBXML2:libxml2 BIND_LIBJSON:libjson-c
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -56,15 +51,10 @@ endef
 define Package/bind-libs
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libopenssl +zlib +libpthread +libatomic
+  DEPENDS:=+libopenssl +zlib +libpthread +libatomic +libuv \
+	+BIND_LIBXML2:libxml2 +BIND_LIBJSON:libjson-c
   TITLE:=bind shared libraries
   URL:=https://www.isc.org/software/bind
-ifdef CONFIG_BIND_LIBJSON
-  DEPENDS+= +libjson-c
-endif
-ifdef CONFIG_BIND_LIBXML2
-  DEPENDS+= +libxml2
-endif
 endef
 
 define Package/bind-server
@@ -78,7 +68,7 @@ endef
 
 define Package/bind-server-filter-aaaa
   $(call Package/bind-server)
-  DEPENDS:=+bind-server
+  DEPENDS:=bind-server
   TITLE+= filter AAAA plugin
 endef
 
@@ -139,19 +129,20 @@ CONFIGURE_ARGS += \
 	--sysconfdir=/etc/bind
 
 ifdef CONFIG_BIND_LIBJSON
+	TARGET_CFLAGS += -DHAVE_JSON_C -UHAVE_JSON
 	CONFIGURE_ARGS += \
-		--with-libjson="$(STAGING_DIR)/usr"
+		--with-json-c=yes
 else
 	CONFIGURE_ARGS += \
-		--without-libjson
+		--with-json-c=no
 endif
 
 ifdef CONFIG_BIND_LIBXML2
 	CONFIGURE_ARGS += \
-		--with-libxml2="$(STAGING_DIR)/usr"
+		--with-libxml2=yes
 else
 	CONFIGURE_ARGS += \
-		--without-libxml2
+		--with-libxml2=no
 endif
 
 CONFIGURE_VARS += \


### PR DESCRIPTION
Maintainer: @nmeyerhans 
Compile tested: Turris 1.1, powerpc_8540, OpenWrt 19.07.3
Run tested: Turris 1.1, powerpc_8540, OpenWrt 19.07.3

Description:

In OpenWrt 19.07, there's a version of bind 9.14, which is not supported anymore. It reached End of Life since May 2020.
It means that there are not going to be any security updates and as this is a DNS resolver, we should be using versions, which are supported. There was a possibility to use 9.11, but it would be a downgrade from 9.14. Let's use 9.16, which is used in OpenWrt master branch. I cherry-picked commits from OpenWrt master branch, compile it and run tested it on 19.07.

This perhaps should solve issue which was reported on Turris forum:
https://forum.turris.cz/t/bind-server-hangs-after-some-time-1-day-avg/13286?u=pepe