### PR TITLE
getdns: update to version 1.6.0

### DIFF
--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -5,8 +5,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=getdns
-PKG_VERSION:=1.5.2
-PKG_RELEASE:=2
+PKG_VERSION:=1.6.0
+PKG_RELEASE:=1
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -14,17 +14,17 @@ PKG_MAINTAINER:=Jonathan Underwood <jonathan.underwood@gmail.com>
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://getdnsapi.net/dist/
-PKG_HASH:=1826a6a221ea9e9301f2c1f5d25f6f5588e841f08b967645bf50c53b970694c0
+PKG_HASH:=40e5737471a3902ba8304b0fd63aa7c95802f66ebbc6eae53c487c8e8a380f4a
 
-PKG_FIXUP:=autoreconf
-
-PKG_INSTALL:=1
+CMAKE_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_GETDNS_ENABLE_STUB_ONLY \
 	CONFIG_GETDNS_ENABLE_IDN_LIBIDN2
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/getdns/Default
 	TITLE:=getdns
@@ -49,26 +49,20 @@ define Package/getdns/config
 	source "$(SOURCE)/Config.in"
 endef
 
-CONFIGURE_ARGS += \
-		$(if $(CONFIG_GETDNS_ENABLE_STUB_ONLY), --enable-stub-only, ) \
-		--without-libidn \
-		$(if $(CONFIG_GETDNS_ENABLE_IDN_LIBIDN2), , --without-libidn2 ) \
-		--with-ssl="$(STAGING_DIR)/usr" \
+# CMAKE options for GetDNS are described in this document:
+# https://getdnsapi.net/quick-start/cmake-quick-start/
+CMAKE_OPTIONS += -DBUILD_LIBEV=OFF
+CMAKE_OPTIONS += -DBUILD_LIBEVENT2=OFF
+CMAKE_OPTIONS += -DBUILD_LIBUV=OFF
 
-# This will make 'configure' think that our libbsd.so is missing the
-# functions inet_pton, inet_ntop, strlcpy and use the builtin. This
-# removes the libbsd dependency
-CONFIGURE_VARS += LIBBSD_LIBS=-lc
+CMAKE_OPTIONS += -DENABLE_STUB_ONLY=$(if $(CONFIG_GETDNS_ENABLE_STUB_ONLY),ON,OFF)
+CMAKE_OPTIONS += -DUSE_LIBIDN2=$(if $(CONFIG_GETDNS_ENABLE_IDN_LIBIDN2),ON,OFF)
 
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)/usr/include/getdns/
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/getdns/getdns*.h $(1)/usr/include/getdns/
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgetdns*.{a,so*} $(1)/usr/lib/
-	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/getdns*.pc $(1)/usr/lib/pkgconfig/
-endef
-
+# getdns will use libbsd for the functions inet_pton, inet_ntop, strlcpy if
+# present, otherwise it will use builtin code for these functions. In order to
+# force the use of the built in code and remove the libbsd dependency disable
+# the test for libbsd.
+CMAKE_OPTIONS += -DCMAKE_DISABLE_FIND_PACKAGE_BSD=ON
 
 define Package/getdns/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/getdns/patches/getdns-1.6.0-fix-crosscompile.patch
+++ b/libs/getdns/patches/getdns-1.6.0-fix-crosscompile.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt	2020-07-01 00:06:07.784792469 +0100
++++ b/CMakeLists.txt	2020-07-01 00:07:09.232511018 +0100
+@@ -520,7 +520,7 @@
+   res = strptime(\"20070207111842\", \"%Y%m%d%H%M%S\", &tm);\n
+   if (!res) return 1; return 0; }")
+ 
+-if (HAVE_STRPTIME)
++if (HAVE_STRPTIME AND NOT CMAKE_CROSSCOMPILING)
+   check_c_source_runs("${STRPTIME_TEST_SOURCE}" STRPTIME_WORKS)
+ endif ()
+ 


### PR DESCRIPTION
Signed-off-by: Jonathan G. Underwood <jonathan.underwood@gmail.com>

Maintainer: me 
Compile tested: x86
Run tested: x86

Description: update to version 1.6.0

Moving to this new version required changing build system to CMake.
