### PR TITLE
squashfs-tools: fix compilation with GCC10

### DIFF
--- a/utils/squashfs-tools/Makefile
+++ b/utils/squashfs-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squashfs-tools
 PKG_VERSION:=4.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING

--- a/utils/squashfs-tools/patches/010-gcc10.patch
+++ b/utils/squashfs-tools/patches/010-gcc10.patch
@@ -1,0 +1,43 @@
+From fe2f5da4b0f8994169c53e84b7cb8a0feefc97b5 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyfox@gentoo.org>
+Date: Sun, 26 Jan 2020 18:35:13 +0000
+Subject: [PATCH] squashfs-tools: fix build failure against gcc-10
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+On gcc-10 (and gcc-9 -fno-common) build fails as:
+
+```
+cc ... -o mksquashfs
+ld: read_fs.o:(.bss+0x0):
+  multiple definition of `fwriter_buffer'; mksquashfs.o:(.bss+0x400c90): first defined here
+ld: read_fs.o:(.bss+0x8):
+  multiple definition of `bwriter_buffer'; mksquashfs.o:(.bss+0x400c98): first defined here
+```
+
+gcc-10 will change the default from -fcommon to fno-common:
+https://gcc.gnu.org/PR85678.
+
+The error also happens if CFLAGS=-fno-common passed explicitly.
+
+Reported-by: Toralf Förster
+Bug: https://bugs.gentoo.org/706456
+Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>
+---
+ squashfs-tools/mksquashfs.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/squashfs-tools/mksquashfs.h b/squashfs-tools/mksquashfs.h
+index 1beefef7..b6503063 100644
+--- a/squashfs-tools/mksquashfs.h
++++ b/squashfs-tools/mksquashfs.h
+@@ -143,7 +143,7 @@ struct append_file {
+ #endif
+ 
+ extern struct cache *reader_buffer, *fragment_buffer, *reserve_cache;
+-struct cache *bwriter_buffer, *fwriter_buffer;
++extern struct cache *bwriter_buffer, *fwriter_buffer;
+ extern struct queue *to_reader, *to_deflate, *to_writer, *from_writer,
+ 	*to_frag, *locked_fragment, *to_process_frag;
+ extern struct append_file **file_mapping;


### PR DESCRIPTION
Upstream backport.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @commodo 
Compile tested: ath79