### PR TITLE
darkstat: correct incompatbility with sshd

### DIFF
--- a/net/darkstat/Makefile
+++ b/net/darkstat/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=darkstat
 PKG_VERSION:=3.0.719
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_MAINTAINER:=Jean-Michel Lacroix <lacroix@lepine-lacroix.info>
 

--- a/net/darkstat/files/darkstat.init
+++ b/net/darkstat/files/darkstat.init
@@ -6,7 +6,7 @@ USE_PROCD=1
 START=60
 
 APP=darkstat
-RUN_D=/var/empty
+RUN_D=/var/darkstat
 PID_F=$RUN_D/$APP.pid
 CONFIGNAME=darkstat
 USER=nobody
@@ -30,7 +30,6 @@ export_bool () {
 
 set_config_string(){
 	mkdir -p $RUN_D
-	chown $USER:$GROUP $RUN_D
 	. /lib/functions/network.sh
 	config_load $CONFIGNAME
 	config_foreach build_config_string darkstat


### PR DESCRIPTION
The init file of darkstat is creating the pid in /var/empty and
setting the owner of the directory to darkstat which is incompatible
with sshd as sshd requires /var/empty to be owned by root and not
group or world-writable.  See issue #12420.

This corrects the problem by creating another directory: /var/darkstat
instead without setting the owner, which is not actually required.
Compile tested: not applicable as the changes do not involve
compilation.
Tested on my home router running darkstat.

Signed-off-by: Jean-Michel Lacroix <lacroix@lepine-lacroix.info>

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
