### PR TITLE
docker-compose: update to version 1.26.1

### DIFF
--- a/lang/python/python-certifi/Makefile
+++ b/lang/python/python-certifi/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-certifi
-PKG_VERSION:=2020.4.5.1
+PKG_VERSION:=2020.6.20
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
@@ -14,7 +14,7 @@ PKG_LICENSE:=MPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 
 PYPI_NAME:=certifi
-PKG_HASH:=51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519
+PKG_HASH:=5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk

--- a/lang/python/python-docker/Makefile
+++ b/lang/python/python-docker/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-docker
-PKG_VERSION:=4.2.1
-PKG_RELEASE:=2
+PKG_VERSION:=4.2.2
+PKG_RELEASE:=1
 
 PYPI_NAME:=docker
-PKG_HASH:=380a20d38fbfaa872e96ee4d0d23ad9beb0f9ed57ff1c30653cbeb0c9c0964f2
+PKG_HASH:=26eebadce7e298f55b76a88c4f8802476c5eaddbdbe38dbc6cce8781c47c9b54
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0

--- a/lang/python/python-urllib3/Makefile
+++ b/lang/python/python-urllib3/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=python-urllib3
-PKG_VERSION:=1.25.7
-PKG_RELEASE:=2
+PKG_VERSION:=1.25.9
+PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Josef Schlehofer <pepe.schlehofer@gmail.com>
 PKG_LICENSE:=MIT
@@ -17,7 +17,7 @@ PKG_LICENSE_FILES:=LICENSE.txt
 PKG_CPE_ID:=cpe:/a:urllib3_project:urllib3
 
 PYPI_NAME:=urllib3
-PKG_HASH:=f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745
+PKG_HASH:=3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527
 
 include ../pypi.mk
 include $(INCLUDE_DIR)/package.mk

--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=docker-compose
-PKG_VERSION:=1.26.0
-PKG_RELEASE:=3
+PKG_VERSION:=1.26.2
+PKG_RELEASE:=1
 
 PYPI_NAME:=docker-compose
-PKG_HASH:=7e836102d139aca667d6af53f0f4d942c9459ec24d6dd4f0203d74359b0fd311
+PKG_HASH:=576b0f81d1a1325941b3ce3436efd51f28b9ecd85b10dd6daa7d51793e187b30
 
 PKG_MAINTAINER:=Javier Marcet <javier@marcet.info>
 PKG_LICENSE:=Apache-2.0
@@ -37,7 +37,6 @@ define Package/docker-compose
       +python3-openssl \
       +python3-pkg-resources \
       +python3-requests \
-      +python3-six \
       +python3-texttable \
       +python3-websocket-client \
       +python3-yaml


### PR DESCRIPTION
Maintainer: me
Compile tested: master x86-64
Run tested: master x86-64

Description:
Bump docker-compose to 1.26.1 and python-docker to 4.2.2