### PR TITLE
openfortivpn: Remove pingcheck and use l3_device instead

### DIFF
--- a/net/openfortivpn/Makefile
+++ b/net/openfortivpn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openfortivpn
 PKG_VERSION:=1.14.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/adrienverge/openfortivpn/tar.gz/v$(PKG_VERSION)?

--- a/net/openfortivpn/files/openfortivpn.sh
+++ b/net/openfortivpn/files/openfortivpn.sh
@@ -36,7 +36,7 @@ proto_openfortivpn_setup() {
 
         [ -n "$iface_name" ] && {
             json_load "$(ifstatus $iface_name)"
-            json_get_var iface_device_name device
+            json_get_var iface_device_name l3_device
             json_get_var iface_device_up up
         }
 
@@ -57,16 +57,6 @@ proto_openfortivpn_setup() {
             proto_notify_error "$config" "failed to resolve server ip for $server"
             proto_setup_failed "$config"
             exit 1
-        }
-
-        [ -n $iface_name ] && {
-            ping -I $iface_device_name -c 1 -w 10 $server_ip > /dev/null 2>&1 || {
-                logger -t "openfortivpn" "$config: failed to ping $server_ip on $iface_device_name"
-                sleep 10
-                proto_notify_error  "$config" "failed to ping $server_ip on $iface_device_name"
-                proto_setup_failed "$config"
-                exit 1
-            }
         }
 
         for ip in $(resolveip -t 10 "$server"); do


### PR DESCRIPTION
Maintainer: @lucize

Description:
some server may not allow ping, therefore pingcheck shoud be optional or removed

l3_device is better considering of pppoe connections