### PR TITLE
netatalk: fix compilation with GCC10

### DIFF
--- a/net/netatalk/Makefile
+++ b/net/netatalk/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netatalk
 PKG_VERSION:=3.1.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/netatalk

--- a/net/netatalk/patches/010-gcc10.patch
+++ b/net/netatalk/patches/010-gcc10.patch
@@ -1,0 +1,22 @@
+From 32df6e155ccfc83216321925273c3e75e631ebe6 Mon Sep 17 00:00:00 2001
+From: Andrew Bauer <zonexpertconsulting@outlook.com>
+Date: Wed, 22 Jan 2020 09:59:47 -0600
+Subject: [PATCH] fix ftbs multiple def of invalid_dircache_entries
+
+---
+ etc/afpd/directory.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/etc/afpd/directory.h b/etc/afpd/directory.h
+index eb89c606..81bfa9cb 100644
+--- a/etc/afpd/directory.h
++++ b/etc/afpd/directory.h
+@@ -91,7 +91,7 @@ struct maccess {
+ #define	AR_UWRITE	(1<<2)
+ #define	AR_UOWN		(1<<7)
+ 
+-q_t *invalid_dircache_entries;
++extern q_t *invalid_dircache_entries;
+ 
+ typedef int (*dir_loop)(struct dirent *, char *, void *);
+ 


### PR DESCRIPTION
Upstream patch: https://github.com/Netatalk/Netatalk/pull/125

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @BKPepe @diizzyy 
Compile tested: ath79
