### PR TITLE
[19.07] samba4: update to 4.11.11

### DIFF
--- a/net/samba4/Makefile
+++ b/net/samba4/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=samba
-PKG_VERSION:=4.11.9
+PKG_VERSION:=4.11.11
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -13,7 +13,7 @@ PKG_SOURCE_URL:= \
 		http://www.nic.funet.fi/index/samba/pub/samba/stable/ \
 		http://samba.mirror.bit.nl/samba/ftp/stable/ \
 		https://download.samba.org/pub/samba/stable/
-PKG_HASH:=ad8cef354cf3f3a8835b04c896906b839270bee763d941db52af037ab5ec8dcc
+PKG_HASH:=457f08a2956534269c784b95cff840250165f1e98f8db725bf64e2fca707ff60
 
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 PKG_LICENSE:=GPL-3.0-only
@@ -60,7 +60,7 @@ endef
 define Package/samba4-libs
   $(call Package/samba4/Default)
   TITLE+= libs
-  DEPENDS:= +libtirpc +libreadline +libpopt +libcap +zlib +libgnutls +libtasn1 +libuuid +libopenssl +USE_GLIBC:libpthread \
+  DEPENDS:= +libtirpc +libreadline +libpopt +libcap +zlib +libgnutls +libtasn1 +libuuid +libopenssl +libpthread \
 	+PACKAGE_libpam:libpam \
 	+SAMBA4_SERVER_VFS:attr \
 	+SAMBA4_SERVER_VFSX:libaio \
@@ -126,13 +126,15 @@ define Package/samba4-utils/description
   Utilities collection
 endef
 
-TARGET_CFLAGS += $(FPIC) -ffunction-sections -fdata-sections -I$(STAGING_DIR)/usr/include/tirpc
+TARGET_CFLAGS += $(FPIC) -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 # dont mess with sambas private rpath!
 RSTRIP:=:
 
 CONFIGURE_VARS += \
-	CPP="$(TARGET_CROSS)cpp"
+	CPP="$(TARGET_CROSS)cpp" \
+	XSLTPROC=false \
+	WAF_NO_PREFORK=1
 
 CONFIGURE_CMD = ./buildtools/bin/waf
 HOST_CONFIGURE_CMD = ./buildtools/bin/waf
@@ -212,7 +214,6 @@ HOST_CONFIGURE_ARGS += \
 HOST_CONFIGURE_ARGS += --disable-avahi --without-quotas --without-acl-support --without-winbind \
 	--without-ad-dc --without-json --without-libarchive --disable-python --nopyc --nopyo \
 	--without-dnsupdate --without-ads --without-ldap --without-ldb-lmdb
-HOST_CONFIGURE_VARS += python_LDFLAGS="" python_LIBDIR=""
 
 # Optional AES-NI support - https://lists.samba.org/archive/samba-technical/2017-September/122738.html
 # Support for Nettle wasn't comitted
@@ -240,22 +241,17 @@ else
 	CONFIGURE_ARGS += --disable-avahi
 endif
 
-# NOTE: We need host python-bin, but target python-config here!
-CONFIGURE_VARS += python_LDFLAGS="" python_LIBDIR=""
 ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
 	CONFIGURE_ARGS += --without-winbind --without-ldb-lmdb --with-acl-support
-	CONFIGURE_VARS += \
-		PYTHON="$(HOST_PYTHON3_BIN)" \
-		PYTHON_CONFIG="$(STAGING_DIR)/host/bin/$(PYTHON3)-config"
 else
 	CONFIGURE_ARGS += --without-winbind --without-ads --without-ldap --without-ldb-lmdb --without-ad-dc \
 		--without-json --without-libarchive --disable-python --nopyc --nopyo --without-dnsupdate --without-acl-support
 endif
 
 SAMBA4_PDB_MODULES :=pdb_smbpasswd,pdb_tdbsam,
-SAMBA4_AUTH_MODULES :=auth_builtin,auth_sam,auth_unix,auth_script,
+SAMBA4_AUTH_MODULES :=auth_builtin,auth_sam,auth_unix,
 SAMBA4_VFS_MODULES :=vfs_default,
-SAMBA4_VFS_MODULES_SHARED :=
+SAMBA4_VFS_MODULES_SHARED :=auth_script,
 ifeq ($(CONFIG_SAMBA4_SERVER_VFS),y)
 	SAMBA4_VFS_MODULES_SHARED :=$(SAMBA4_VFS_MODULES_SHARED)vfs_fruit,vfs_shadow_copy2,vfs_recycle,vfs_fake_perms,vfs_readonly,vfs_cap,vfs_offline,vfs_crossrename,vfs_catia,vfs_streams_xattr,vfs_xattr_tdb,vfs_default_quota,
 ifeq ($(CONFIG_PACKAGE_kmod-fs-btrfs),y)
@@ -305,10 +301,23 @@ CONFIGURE_ARGS += --private-libraries=$(SYSTEM_BUNDLED_LIBS)
 export COMPILE_ET=$(STAGING_DIR_HOSTPKG)/bin/compile_et_samba
 export ASN1_COMPILE=$(STAGING_DIR_HOSTPKG)/bin/asn1_compile_samba
 
+# make sure we use the hostpkg build toolset
+HOST_CONFIGURE_VARS+= \
+	PATH="$(STAGING_DIR_HOSTPKG)/bin:$(STAGING_DIR_HOSTPKG)/usr/bin:$(PATH)"
+CONFIGURE_VARS += \
+	PATH="$(STAGING_DIR_HOSTPKG)/bin:$(STAGING_DIR_HOSTPKG)/usr/bin:$(PATH)"
+
+# we need hostpkg bin and target config	
+ifeq ($(CONFIG_SAMBA4_SERVER_AD_DC),y)
+	CONFIGURE_VARS += \
+		PYTHON_CONFIG="$(STAGING_DIR)/host/bin/$(PYTHON3)-config"
+endif
+
 # we dont need GnuTLS for the host helpers
 define Host/Prepare
 	$(call Host/Prepare/Default)
 	$(SED) 's,mandatory=True,mandatory=False,g' $(HOST_BUILD_DIR)/wscript_configure_system_gnutls
+	$(SED) 's,gnutls_version =.*,gnutls_version = gnutls_min_required_version,g' $(HOST_BUILD_DIR)/wscript_configure_system_gnutls
 endef
 define Host/Compile
 	(cd $(HOST_BUILD_DIR); \

--- a/net/samba4/files/samba.config
+++ b/net/samba4/files/samba.config
@@ -1,4 +1,24 @@
+
 config samba
-	option 'workgroup'		'WORKGROUP'
-	option 'description'	'Samba on OpenWrt'
-	option 'charset' 		'UTF-8'
+	option workgroup 'WORKGROUP'
+	option charset 'UTF-8'
+	option description 'Samba on OpenWRT'
+	#option enable_extra_tuning '0'
+
+## example share
+#config sambashare
+	#option guest_only 'yes'
+	#option create_mask '0666'
+	#option dir_mask '0777'
+	#option force_root '1'
+	#option name 'share'
+	#option inherit_owner 'yes'
+	#option guest_ok 'yes'
+	#option read_only 'no'
+	#option path '/mnt/tmp'
+
+## reduce process priority via nice
+#config procd 'extra'
+	#option samba_nice '3'
+## on mvebu platform we need negative values!
+	#option samba_nice '-10'

--- a/net/samba4/files/samba.init
+++ b/net/samba4/files/samba.init
@@ -37,6 +37,7 @@ smb_header() {
 	config_get_bool DISABLE_WINBIND $1 disable_winbind 0
 	config_get_bool DISABLE_ASYNC_IO $1 disable_async_io 0
 	config_get_bool ALLOW_LEGACY_PROTOCOLS $1 allow_legacy_protocols 0
+	config_get_bool ENABLE_EXTRA_TUNING $1 enable_extra_tuning 0
 
 	mkdir -p /var/etc
 	sed -e "s#|NAME|#$hostname#g" \
@@ -48,6 +49,21 @@ smb_header() {
 
 	{
 		printf "\n######### Dynamic written config options #########\n"
+
+		# extra tuning options by community feedback (kinda try&error)
+		if [ "$ENABLE_EXTRA_TUNING" -eq 1 ]; then
+			local socket_opt
+			socket_opt="$(grep -i 'socket options' /etc/samba/smb.conf.template | awk -F'=' '{print $2}' | tr -d '\n')"
+			[ -n "$socket_opt" ] && printf "\tsocket options =%s SO_KEEPALIVE\n" "$socket_opt" # add keepalive, maybe larger buffer? SO_RCVBUF=65536 SO_SNDBUF=65536
+
+			printf "\tmax xmit = 131072\n" # increase smb1 transmit size
+			printf "\tmin receivefile size = 131072\n" # allows zero-copy writes via fs
+			printf "\tfake oplocks = Yes\n" # may corrupt files for simultanous writes to the same files by multiple clients, but might also see big speed boost
+			printf "\tuse sendfile = Yes\n" # enable sendfile, not sure whats with the 2019 bug https://bugzilla.samba.org/show_bug.cgi?id=14095
+			# Removed in 4.12.x in favor of VFS io_uring ; this is per file, so may increase memory useage on many simultanous oplocked files!
+			printf "\twrite cache size = 262144\n" # adds a write cache buffer per file for oplocked files, flushes if size is exhausted
+		fi
+
 		if [ "$DISABLE_NETBIOS" -eq 1 ] || [ ! -x /usr/sbin/nmbd ]; then
 			printf "\tdisable netbios = yes\n"
 			# note: samba opens port 139 even if netbios is disabled via option above, so adjust listening ports
@@ -157,12 +173,14 @@ smb_add_share() {
 
 init_config() {
 	# Create samba dirs
-	[ -d /var/lib/samba ] || mkdir -p /var/lib/samba
-	[ -d /var/cache/samba ] || mkdir -p /var/cache/samba
+	[ -d /var/lib/samba ] || mkdir -m 755 -p /var/lib/samba
+	[ -d /var/cache/samba ] || mkdir -m 755 -p /var/cache/samba
+	[ -d /var/lock ] || mkdir -m 755 -p /var/lock
 	[ -d /var/run/samba ] || mkdir -p /var/run/samba
 	[ -d /var/log/samba ] || mkdir -p /var/log/samba
-	[ -d /var/lock ] || mkdir -p /var/lock
 	chmod 0755 /var/lock
+	chmod 0755 /var/lib/samba
+	chmod 0755 /var/cache/samba
 
 	config_load samba4
 	config_foreach smb_header samba

--- a/net/samba4/files/smb.conf.template
+++ b/net/samba4/files/smb.conf.template
@@ -40,7 +40,7 @@
 	## Set location of smbpasswd ('smbd -b' will show default compiled location)
 	#smb passwd file = /etc/samba/smbpasswd 
 
-	## LAN/WAN options (IPTOS_LOWDELAY TCP_NODELAY) WAN (IPTOS_THROUGHPUT)
+	## LAN (IPTOS_LOWDELAY TCP_NODELAY) WAN (IPTOS_THROUGHPUT) WiFi (SO_KEEPALIVE) try&error for buffer sizes (SO_RCVBUF=65536 SO_SNDBUF=65536)
 	socket options = IPTOS_LOWDELAY TCP_NODELAY
 
 	## If this integer parameter is set to a non-zero value, Samba will read from files asynchronously when the request size is bigger than this value.
@@ -56,7 +56,7 @@
 	#aio write behind = /*.tmp/
 
 	## lower CPU useage if supported and aio is disabled (aio read size = 0 ; aio write size = 0)
-	## currently broken (NOTE: see https://bugzilla.samba.org/show_bug.cgi?id=14095 )
+	## is this still broken? issue is from 2019 (NOTE: see https://bugzilla.samba.org/show_bug.cgi?id=14095 )
 	## (no, yes)
 	#use sendfile = yes
 

--- a/net/samba4/patches/011-samba-4-11-fix-musl_missing__nss_buflen_passwd.patch
+++ b/net/samba4/patches/011-samba-4-11-fix-musl_missing__nss_buflen_passwd.patch
@@ -1,0 +1,12 @@
+--- a/lib/util/util_paths.c	2020-07-03
++++ b/lib/util/util_paths.c	2020-07-03
+@@ -26,6 +26,9 @@
+ #include "dynconfig/dynconfig.h"
+ #include "lib/util/util_paths.h"
+ #include "system/passwd.h"
++#if !defined(__GLIBC__) 
++	#define NSS_BUFLEN_PASSWD 1024
++#endif
+ 
+ /**
+  * @brief Returns an absolute path to a file in the Samba modules directory.


### PR DESCRIPTION
Maintainer: me
Compile tested: arm (19.07)
Run tested: arm/qemu (19.07)

Description:
* update to 4.11.11
* fixes CVE-2020-10730, CVE-2020-10745, CVE-2020-10760, CVE-2020-14303
* add fix-musl_missing__nss_buflen_passwd.patch
* remove fixed tirpc include
* add extra CONFIGURE_VARS (XSLTPROC=false, WAF_NO_PREFORK=1)
* fix python3 host paths, ensure we use build hostpkg tools
* add new UCI option "enable_extra_tuning"
* update template
* add config examples for options
* fix some access warnings on samba /var dirs