### PR TITLE
mwan3: Fix mwan3 start not doing anything

### DIFF
--- a/net/mwan3/Makefile
+++ b/net/mwan3/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwan3
-PKG_VERSION:=2.8.7
+PKG_VERSION:=2.8.8
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=GPL-2.0

--- a/net/mwan3/files/usr/sbin/mwan3
+++ b/net/mwan3/files/usr/sbin/mwan3
@@ -129,6 +129,7 @@ start()
 
 	uci_toggle_state mwan3 globals enabled "1"
 
+	config_load mwan3
 	config_foreach ifup interface
 }
 


### PR DESCRIPTION
Maintainer: @feckert
Compile tested: armv7l, Turris Omnia, Turris OS 5.0.2 (based on OpenWrt 19.07.3 I believe; note that this is a minimal script-only change)
Run tested: armv7l, Turris Omnia, Turris OS 5.0.2 (based on OpenWrt 19.07.3 I believe), mwan3 start/stop/restart, switch wan link from A->B

Description:
Due to a missing config load function call, mwan3 start runs ifup for an empty
list of interfaces, thus not calling ifup at all.

This PR introduces the missing config_load call.