### PR TITLE
prometheus-node-exporter-lua: new uci_dhcp_host module

### DIFF
--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-node-exporter-lua
-PKG_VERSION:=2020.06.26
+PKG_VERSION:=2020.07.04
 PKG_RELEASE:=1
 
 PKG_MAINTAINER:=Etienne CHAMPETIER <champetier.etienne@gmail.com>
@@ -38,6 +38,12 @@ define Package/prometheus-node-exporter-lua-nat_traffic
   $(call Package/prometheus-node-exporter-lua/Default)
   TITLE+= (nat_traffic collector)
   DEPENDS:=prometheus-node-exporter-lua
+endef
+
+define Package/prometheus-node-exporter-lua-uci_dhcp_host
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (uci_dhcp_host collector)
+  DEPENDS:=prometheus-node-exporter-lua +libuci-lua
 endef
 
 define Package/prometheus-node-exporter-lua-netstat
@@ -119,6 +125,11 @@ define Package/prometheus-node-exporter-lua-nat_traffic/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/nat_traffic.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
+define Package/prometheus-node-exporter-lua-uci_dhcp_host/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
 define Package/prometheus-node-exporter-lua-netstat/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/netstat.lua $(1)/usr/lib/lua/prometheus-collectors/
@@ -167,6 +178,7 @@ endef
 $(eval $(call BuildPackage,prometheus-node-exporter-lua))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-nat_traffic))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-netstat))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-uci_dhcp_host))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi_stations))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-hostapd_stations))

--- a/utils/prometheus-node-exporter-lua/Makefile
+++ b/utils/prometheus-node-exporter-lua/Makefile
@@ -12,6 +12,8 @@ PKG_LICENSE:=Apache-2.0
 
 include $(INCLUDE_DIR)/package.mk
 
+Build/Compile=
+
 define Package/prometheus-node-exporter-lua/Default
   SECTION:=utils
   CATEGORY:=Utilities
@@ -23,84 +25,6 @@ define Package/prometheus-node-exporter-lua
   $(call Package/prometheus-node-exporter-lua/Default)
   DEPENDS:=+luasocket +lua
 endef
-
-define Package/prometheus-node-exporter-lua/conffiles
-/etc/config/prometheus-node-exporter-lua
-endef
-
-define Package/prometheus-node-exporter-lua/description
-  Provides node metrics as Prometheus scraping endpoint.
-
-  This service is a lightweight rewrite in LUA of the offical Prometheus node_exporter.
-endef
-
-define Package/prometheus-node-exporter-lua-nat_traffic
-  $(call Package/prometheus-node-exporter-lua/Default)
-  TITLE+= (nat_traffic collector)
-  DEPENDS:=prometheus-node-exporter-lua
-endef
-
-define Package/prometheus-node-exporter-lua-uci_dhcp_host
-  $(call Package/prometheus-node-exporter-lua/Default)
-  TITLE+= (uci_dhcp_host collector)
-  DEPENDS:=prometheus-node-exporter-lua +libuci-lua
-endef
-
-define Package/prometheus-node-exporter-lua-netstat
-  $(call Package/prometheus-node-exporter-lua/Default)
-  TITLE+= (netstat collector)
-  DEPENDS:=prometheus-node-exporter-lua
-endef
-
-define Package/prometheus-node-exporter-lua-wifi
-  $(call Package/prometheus-node-exporter-lua/Default)
-  TITLE+= (wifi collector)
-  DEPENDS:=prometheus-node-exporter-lua +libiwinfo-lua +libubus-lua
-endef
-
-define Package/prometheus-node-exporter-lua-wifi_stations
-  $(call Package/prometheus-node-exporter-lua/Default)
-  TITLE+= (wifi_stations collector)
-  DEPENDS:=prometheus-node-exporter-lua +libiwinfo-lua +libubus-lua
-endef
-
-define Package/prometheus-node-exporter-lua-hostapd_stations
-  $(call Package/prometheus-node-exporter-lua/Default)
-  TITLE+= (hostapd_stations collector) - Requires a full hostapd / wpad build
-  DEPENDS:=prometheus-node-exporter-lua +hostapd-utils +lua-bit32 +libubus-lua
-endef
-
-define Package/prometheus-node-exporter-lua-bmx6
-  $(call Package/prometheus-node-exporter-lua/Default)
-  TITLE+= (bmx6 links collector)
-  DEPENDS:=prometheus-node-exporter-lua bmx6 +lua-cjson +bmx6-json
-endef
-
-define Package/prometheus-node-exporter-lua-bmx7
-  $(call Package/prometheus-node-exporter-lua/Default)
-  TITLE+= (bmx7 links collector)
-  DEPENDS:=prometheus-node-exporter-lua bmx7 +lua-cjson +bmx7-json
-endef
-
-define Package/prometheus-node-exporter-lua-textfile
-  $(call Package/prometheus-node-exporter-lua/Default)
-  TITLE+= (textfile collector)
-  DEPENDS:=prometheus-node-exporter-lua +luci-lib-nixio
-endef
-
-define Package/prometheus-node-exporter-lua-openwrt
-  $(call Package/prometheus-node-exporter-lua/Default)
-  TITLE+= (openwrt collector)
-  DEPENDS:=prometheus-node-exporter-lua +libubus-lua
-endef
-
-define Package/prometheus-node-exporter-lua-ltq-dsl
-  $(call Package/prometheus-node-exporter-lua/Default)
-  TITLE+= (lantiq dsl collector)
-  DEPENDS:=prometheus-node-exporter-lua @(PACKAGE_ltq-adsl-app||PACKAGE_ltq-vdsl-app)
-endef
-
-Build/Compile=
 
 define Package/prometheus-node-exporter-lua/install
 	$(INSTALL_DIR) $(1)/etc/config
@@ -120,34 +44,22 @@ define Package/prometheus-node-exporter-lua/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/uname.lua       $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
-define Package/prometheus-node-exporter-lua-nat_traffic/install
-	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/nat_traffic.lua $(1)/usr/lib/lua/prometheus-collectors/
+define Package/prometheus-node-exporter-lua/conffiles
+/etc/config/prometheus-node-exporter-lua
 endef
 
-define Package/prometheus-node-exporter-lua-uci_dhcp_host/install
-	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua $(1)/usr/lib/lua/prometheus-collectors/
+define Package/prometheus-node-exporter-lua/description
+  Provides node metrics as Prometheus scraping endpoint.
+
+  This service is a lightweight rewrite in LUA of the offical Prometheus node_exporter.
 endef
 
-define Package/prometheus-node-exporter-lua-netstat/install
-	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/netstat.lua $(1)/usr/lib/lua/prometheus-collectors/
-endef
+# Additional optional exporters:
 
-define Package/prometheus-node-exporter-lua-wifi/install
-	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/wifi.lua $(1)/usr/lib/lua/prometheus-collectors/
-endef
-
-define Package/prometheus-node-exporter-lua-wifi_stations/install
-	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/wifi_stations.lua $(1)/usr/lib/lua/prometheus-collectors/
-endef
-
-define Package/prometheus-node-exporter-lua-hostapd_stations/install
-	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/hostapd_stations.lua $(1)/usr/lib/lua/prometheus-collectors/
+define Package/prometheus-node-exporter-lua-bmx6
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (bmx6 links collector)
+  DEPENDS:=prometheus-node-exporter-lua bmx6 +lua-cjson +bmx6-json
 endef
 
 define Package/prometheus-node-exporter-lua-bmx6/install
@@ -155,19 +67,32 @@ define Package/prometheus-node-exporter-lua-bmx6/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/bmx6.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
+define Package/prometheus-node-exporter-lua-bmx7
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (bmx7 links collector)
+  DEPENDS:=prometheus-node-exporter-lua bmx7 +lua-cjson +bmx7-json
+endef
+
 define Package/prometheus-node-exporter-lua-bmx7/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/bmx7.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
-define Package/prometheus-node-exporter-lua-textfile/install
-	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/textfile.lua $(1)/usr/lib/lua/prometheus-collectors/
+define Package/prometheus-node-exporter-lua-hostapd_stations
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (hostapd_stations collector) - Requires a full hostapd / wpad build
+  DEPENDS:=prometheus-node-exporter-lua +hostapd-utils +lua-bit32 +libubus-lua
 endef
 
-define Package/prometheus-node-exporter-lua-openwrt/install
+define Package/prometheus-node-exporter-lua-hostapd_stations/install
 	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
-	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/openwrt.lua $(1)/usr/lib/lua/prometheus-collectors/
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/hostapd_stations.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
+define Package/prometheus-node-exporter-lua-ltq-dsl
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (lantiq dsl collector)
+  DEPENDS:=prometheus-node-exporter-lua @(PACKAGE_ltq-adsl-app||PACKAGE_ltq-vdsl-app)
 endef
 
 define Package/prometheus-node-exporter-lua-ltq-dsl/install
@@ -175,15 +100,92 @@ define Package/prometheus-node-exporter-lua-ltq-dsl/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/ltq-dsl.lua $(1)/usr/lib/lua/prometheus-collectors/
 endef
 
+define Package/prometheus-node-exporter-lua-nat_traffic
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (nat_traffic collector)
+  DEPENDS:=prometheus-node-exporter-lua
+endef
+
+define Package/prometheus-node-exporter-lua-nat_traffic/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/nat_traffic.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
+define Package/prometheus-node-exporter-lua-netstat
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (netstat collector)
+  DEPENDS:=prometheus-node-exporter-lua
+endef
+
+define Package/prometheus-node-exporter-lua-netstat/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/netstat.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
+define Package/prometheus-node-exporter-lua-openwrt
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (openwrt collector)
+  DEPENDS:=prometheus-node-exporter-lua +libubus-lua
+endef
+
+define Package/prometheus-node-exporter-lua-openwrt/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/openwrt.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
+define Package/prometheus-node-exporter-lua-textfile
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (textfile collector)
+  DEPENDS:=prometheus-node-exporter-lua +luci-lib-nixio
+endef
+
+define Package/prometheus-node-exporter-lua-textfile/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/textfile.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
+define Package/prometheus-node-exporter-lua-uci_dhcp_host
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (uci_dhcp_host collector)
+  DEPENDS:=prometheus-node-exporter-lua +libuci-lua
+endef
+
+define Package/prometheus-node-exporter-lua-uci_dhcp_host/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
+define Package/prometheus-node-exporter-lua-wifi
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (wifi collector)
+  DEPENDS:=prometheus-node-exporter-lua +libiwinfo-lua +libubus-lua
+endef
+
+define Package/prometheus-node-exporter-lua-wifi/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/wifi.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
+define Package/prometheus-node-exporter-lua-wifi_stations
+  $(call Package/prometheus-node-exporter-lua/Default)
+  TITLE+= (wifi_stations collector)
+  DEPENDS:=prometheus-node-exporter-lua +libiwinfo-lua +libubus-lua
+endef
+
+define Package/prometheus-node-exporter-lua-wifi_stations/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/prometheus-collectors
+	$(INSTALL_BIN) ./files/usr/lib/lua/prometheus-collectors/wifi_stations.lua $(1)/usr/lib/lua/prometheus-collectors/
+endef
+
 $(eval $(call BuildPackage,prometheus-node-exporter-lua))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx6))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx7))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-hostapd_stations))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-ltq-dsl))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-nat_traffic))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-netstat))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-openwrt))
+$(eval $(call BuildPackage,prometheus-node-exporter-lua-textfile))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-uci_dhcp_host))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi))
 $(eval $(call BuildPackage,prometheus-node-exporter-lua-wifi_stations))
-$(eval $(call BuildPackage,prometheus-node-exporter-lua-hostapd_stations))
-$(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx6))
-$(eval $(call BuildPackage,prometheus-node-exporter-lua-bmx7))
-$(eval $(call BuildPackage,prometheus-node-exporter-lua-textfile))
-$(eval $(call BuildPackage,prometheus-node-exporter-lua-openwrt))
-$(eval $(call BuildPackage,prometheus-node-exporter-lua-ltq-dsl))

--- a/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua
+++ b/utils/prometheus-node-exporter-lua/files/usr/lib/lua/prometheus-collectors/uci_dhcp_host.lua
@@ -1,0 +1,15 @@
+local uci=require("uci")
+
+local function scrape()
+  local curs=uci.cursor()
+  local metric_uci_host = metric("uci_dhcp_host", "gauge")
+
+  curs:foreach("dhcp", "host", function(s)
+    if s[".type"] == "host" then
+      labels = {name=s["name"], mac=string.upper(s["mac"]), dns=s["dns"], ip=s["ip"]}
+      metric_uci_host(labels, 1)
+    end
+  end)
+end
+
+return { scrape = scrape }


### PR DESCRIPTION
Extract data from configuration file /etc/config/dhcp and create labels
{name, ip, mac, dns} via uci. Those labels are useful in order to craft
complex prometheus queries as replacing the MAC address to custom name.
E.g.: wifi_station_signal_dbm * on (mac) group_left(name) uci_dhcp_host
or on (mac) label_replace(wifi_station_signal_dbm, "name", "$1", "mac",
"(.+)")

Signed-off-by: Gérondal Thibault <contact@tycale.be>

Maintainer:  @champtar
Compile tested: Marvell Armada 37x/38x/XP, Linksys WRT1900ACS (Shelby), v19.07.2
Run tested: Hit http://device:9100/metrics and it shows correctly the expected entries
```
# TYPE uci_dhcp_host gauge
uci_dhcp_host{mac="XX:XX:XX:XX:XX:XX",dns="1",name="XXXXX",ip="192.168.2.1XX"} 1
...
```

Description: Expose static leases informations to Prometheus. This module enables crafting complex queries where MAC addresses or IPs can be translated to a chosen name.
