### PR TITLE
canutils: switch to CMake

### DIFF
--- a/utils/canutils/Makefile
+++ b/utils/canutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=canutils
 PKG_VERSION:=2020.02.04
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/linux-can/can-utils/tar.gz/v$(PKG_VERSION)?
@@ -18,12 +18,12 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/can-utils-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Anton Glukhov <anton.a.glukhov@gmail.com>
 PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
-PKG_FIXUP:=autoreconf
-PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/canutils/Default
   SECTION:=utils
@@ -41,6 +41,7 @@ define GenPlugin
   define Package/$(addprefix canutils-,$(1))
     $(call Package/canutils/Default)
     TITLE:=Utility $(1) from the CAN utilities
+    DEPENDS:=canutils
   endef
 
    define Package/$(addprefix canutils-,$(1))/description


### PR DESCRIPTION
Allows simplifying the Makefile. Faster compilation as well.

Revert b70cb0ef5ed196247bd4bcce3cb84167420eeb4d

That commit was misleading and ended up bloating the Utilities section.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @toxxin 
Compile tested: ath79