### PR TITLE
c-ares: switch to CMake

### DIFF
--- a/libs/c-ares/Makefile
+++ b/libs/c-ares/Makefile
@@ -10,21 +10,21 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=c-ares
 PKG_VERSION:=1.16.1
-PKG_RELEASE:=1
-PKG_LICENSE:=MIT
-PKG_CPE_ID:=cpe:/a:c-ares_project:c-ares
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://c-ares.haxx.se/download
 PKG_HASH:=d08312d0ecc3bd48eee0a4cc0d2137c9f194e0a28de2028928c0f6cae85f86ce
 
-PKG_FIXUP:=autoreconf
-PKG_INSTALL:=1
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE.md
+PKG_CPE_ID:=cpe:/a:c-ares_project:c-ares
+
+CMAKE_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
-
-TARGET_CPPFLAGS += $(filter -D%,$(TARGET_CFLAGS))
-TARGET_CFLAGS := $(filter-out -D%,$(TARGET_CFLAGS))
+include $(INCLUDE_DIR)/cmake.mk
 
 define Package/libcares
   SECTION:=libs
@@ -42,14 +42,16 @@ Netware, Android and many more operating systems.
 
 endef
 
+CMAKE_OPTIONS += \
+	-DCARES_STATIC=OFF \
+	-DCARES_SHARED=ON \
+	-DCARES_STATIC_PIC=ON \
+	-DCARES_BUILD_TESTS=OFF \
+	-DCARES_BUILD_TOOLS=OFF
+
 define Package/libcares/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so.* $(1)/usr/lib/
-endef
-
-define Build/InstallDev
-	$(INSTALL_DIR) $(1)
-	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcares.so.* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libcares))


### PR DESCRIPTION
Allows simplifying the Makefile. Also allows faster compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @karlp 
Compile tested: ath79