### PR TITLE
syncthing: increase inotify limit

### DIFF
--- a/utils/syncthing/Makefile
+++ b/utils/syncthing/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=syncthing
 PKG_VERSION:=1.6.1
-PKG_RELEASE:=0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=syncthing-source-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/syncthing/syncthing/releases/download/v$(PKG_VERSION)

--- a/utils/syncthing/files/etc/sysctl.d/90-syncthing-inotify.conf
+++ b/utils/syncthing/files/etc/sysctl.d/90-syncthing-inotify.conf
@@ -1,0 +1,1 @@
+fs.inotify.max_user_watches=204800


### PR DESCRIPTION
default inotify limits at 8k are kinda low for serious usage
and the GUI shows errors like
"Failed to start filesystem watcher for folder XXXX"
increase them with this config file
as instructed by syncthing's FAQ.
https://docs.syncthing.net/users/faq.html#inotify-limits

Signed-off-by: Alberto Bursi <bobafetthotmail@gmail.com>

Maintainer: @aparcar 

I'm using this on a Helios4 NAS (a mvebu device), the PR to support it isn't merged yet
But it should not matter what I'm using, increasing inotify limits would do well for any serious (heavy) user of syncthing.