### PR TITLE
fwknop: fix compilation with GCC10

### DIFF
--- a/net/fwknop/Makefile
+++ b/net/fwknop/Makefile
@@ -9,15 +9,19 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fwknop
 PKG_VERSION:=2.6.10
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.cipherdyne.org/fwknop/download
 PKG_HASH:=f6c09bec97ed8e474a98ae14f9f53e1bcdda33393f20667b6af3fb6bb894ca77
+
 PKG_MAINTAINER:=Jonathan Bennett <JBennett@incomsystems.biz>
 PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:cipherdyne:fwknop
+
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -90,16 +94,10 @@ define Package/libfko/description
 endef
 
 
-ifneq ($(CONFIG_FWKNOPD_GPG),y)
-	CONFIGURE_ARGS += --without-gpgme 
-endif
-
-ifeq ($(CONFIG_FWKNOPD_NFQ_CAPTURE),y)
- 	CONFIGURE_ARGS += --enable-nfq-capture 
-endif
-
 CONFIGURE_ARGS += \
-	--with-iptables=/usr/sbin/iptables
+	--$(if $(CONFIG_FWKNOPD_NFQ_CAPTURE),en,dis)able-nfq-capture \
+	--with$(if $(CONFIG_FWKNOPD_GPG),,out)-gpgme \
+	--with-iptables=/usr/sbin/iptables \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include

--- a/net/fwknop/patches/010-gcc10.patch
+++ b/net/fwknop/patches/010-gcc10.patch
@@ -1,0 +1,11 @@
+--- a/client/log_msg.h
++++ b/client/log_msg.h
+@@ -29,7 +29,7 @@
+ #ifndef LOG_MSG_H
+ #define LOG_MSG_H
+ 
+-enum
++static enum
+ {
+     LOG_FIRST_VERBOSITY = 0,
+     LOG_VERBOSITY_ERROR = 0,    /*!< Constant to define a ERROR message */


### PR DESCRIPTION
Added PKG_LICENSE_FILES.

Added PKG_BUILD_PARALLEL for faster compilation.

Simplified configure arguments.

Small cleanups for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jp-bennett 
Compile tested: ath79