### PR TITLE
libpng: fix compilation with ccache

### DIFF
--- a/libs/libpng/Makefile
+++ b/libs/libpng/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpng
 PKG_VERSION:=1.6.37
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@SF/libpng

--- a/libs/libpng/patches/200-ccache.patch
+++ b/libs/libpng/patches/200-ccache.patch
@@ -1,0 +1,19 @@
+--- a/scripts/genout.cmake.in
++++ b/scripts/genout.cmake.in
+@@ -14,6 +14,7 @@ set(BINDIR "@CMAKE_CURRENT_BINARY_DIR@")
+ 
+ set(AWK "@AWK@")
+ set(CMAKE_C_COMPILER "@CMAKE_C_COMPILER@")
++set(CMAKE_C_COMPILER_ARG1 "@CMAKE_C_COMPILER_ARG1@")
+ set(CMAKE_C_FLAGS @CMAKE_C_FLAGS@)
+ set(INCDIR "@CMAKE_CURRENT_BINARY_DIR@")
+ set(PNG_PREFIX "@PNG_PREFIX@")
+@@ -58,7 +59,7 @@ if ("${INPUTEXT}" STREQUAL ".c" AND "${OUTPUTEXT}" STREQUAL ".out")
+     set(PNG_PREFIX_DEF "-DPNG_PREFIX=${PNG_PREFIX}")
+   endif()
+ 
+-  execute_process(COMMAND "${CMAKE_C_COMPILER}" "-E"
++  execute_process(COMMAND "${CMAKE_C_COMPILER}" ${CMAKE_C_COMPILER_ARG1} "-E"
+                           ${CMAKE_C_FLAGS}
+                           ${PLATFORM_C_FLAGS}
+                           "-I${SRCDIR}"


### PR DESCRIPTION
It seems an extra CMake variable is needed for one of the scripts.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jow- 
Compile tested: ath79

Fixes: https://github.com/openwrt/packages/issues/12725