### PR TITLE
modemmanager: update ModemManager and dependencies

### DIFF
--- a/libs/libmbim/Makefile
+++ b/libs/libmbim/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmbim
-PKG_VERSION:=1.22.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.24.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libmbim
-PKG_HASH:=5c0778eb1cd12c3604523134e55183f5147b0cae71150e875b583768f7aa1f38
+PKG_HASH:=3d495cec3becfd02731ceac67a5ad7e0f1b328395137024d7cb91d31f00e1196
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
-PKG_VERSION:=1.24.14
+PKG_VERSION:=1.26.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
-PKG_HASH:=208fe3e94dabe1d8117d1023d841737b6fe92aaff21ef8f35bbed15417ee507f
+PKG_HASH:=7f0429e0ae58792e21512d09ca2412537840ea42696762795af1284a65fd6e40
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 

--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=modemmanager
-PKG_VERSION:=1.12.10
-PKG_RELEASE:=2
+PKG_VERSION:=1.14.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=ModemManager-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/ModemManager
-PKG_HASH:=b2b3058bbb72adf98b24707fdbebe58e590644a38145e30d574f685f154bf8aa
+PKG_HASH:=8976e2f890380d35144d4d9146bc225d926ae72c9b48d7e50c1dd9674d2bd079
 PKG_BUILD_DIR:=$(BUILD_DIR)/ModemManager-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>


### PR DESCRIPTION
Maintainer: me
Compile tested: ath79 Telco T1 master
Run tested: ath79 Telco T1 master, basic functions tested and confirmed working

Description:
Feature update and new stable release series for ModemManager. Requires updated libmbim and libqmi dependencies
Full release notes: https://lists.freedesktop.org/archives/modemmanager-devel/2020-June/007954.html