### PR TITLE
libqmi: enable selection of message collections

### DIFF
--- a/libs/libqmi/Config.in
+++ b/libs/libqmi/Config.in
@@ -1,0 +1,21 @@
+menu "Configuration"
+depends on PACKAGE_libqmi
+
+	config LIBQMI_COLLECTIONS_MINIMAL
+		bool "Build with minimal message collection support"
+		default n
+		help
+		  the bare minimum messages required to control connectivity
+
+	config LIBQMI_COLLECTIONS_BASIC
+		bool "Build with basic message collection support"
+		default y
+		help
+		  all messages and indications that ModemManager requires
+
+	config LIBQMI_COLLECTIONS_FULL
+		bool "Build with full message collection support"
+		default n
+		help
+		  all supported messages and indications
+endmenu

--- a/libs/libqmi/Makefile
+++ b/libs/libqmi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libqmi
 PKG_VERSION:=1.26.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://www.freedesktop.org/software/libqmi
@@ -22,6 +22,10 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
+
+define Package/libqmi/config
+  source "$(SOURCE)/Config.in"
+endef
 
 define Package/libqmi
   SECTION:=libs
@@ -63,6 +67,18 @@ CONFIGURE_ARGS += \
 	--enable-more-warnings=yes \
 	--without-udev \
 	--without-udev-base-dir
+
+ifdef CONFIG_LIBQMI_COLLECTIONS_MINIMAL
+  CONFIGURE_ARGS += --enable-collection=minimal
+endif
+
+ifdef CONFIG_LIBQMI_COLLECTIONS_BASIC
+  CONFIGURE_ARGS += --enable-collection=basic
+endif
+
+ifdef CONFIG_LIBQMI_COLLECTIONS_FULL
+  CONFIGURE_ARGS += --enable-collection=full
+endif
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
Maintainer: me 
Compile tested: ath79 Telco T1 master
Run tested: ath79 Telco T1 master, checked basic functions

Description:
* Added new message collections support, so that users can select which messages to include in the built library during configure with the `--enable-collection` option. Three predefined sets are given:
   * `minimal`: the bare minimum messages required to control connectivity.
   * `basic`: all messages and indications that ModemManager requires. (selected here by default)
   * `full`: all supported messages and indications.

More information: https://lists.freedesktop.org/archives/libqmi-devel/2020-June/003341.html