### PR TITLE
treewide: add and fix conffiles

### DIFF
--- a/admin/ipmitool/Makefile
+++ b/admin/ipmitool/Makefile
@@ -39,9 +39,6 @@ define Package/ipmitool/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/ipmitool $(1)/usr/sbin/
 endef
 
-define Package/ipmitool/conffiles
-endef
-
 CONFIGURE_ARGS += \
 	--enable-intf-lan \
 	--enable-intf-lanplus \

--- a/net/addrwatch/Makefile
+++ b/net/addrwatch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=addrwatch
 PKG_VERSION:=1.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/fln/addrwatch/releases/download/v$(PKG_VERSION)
@@ -41,7 +41,7 @@ define Package/addrwatch/description
 endef
 
 define Package/addrwatch/conffiles
-	/etc/config/addrwatch
+/etc/config/addrwatch
 endef
 
 define Package/addrwatch/install

--- a/net/i2pd/Makefile
+++ b/net/i2pd/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=i2pd
 PKG_VERSION:=2.30.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_BUILD_PARALLEL:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -40,10 +40,10 @@ define Package/i2pd/description
 endef
 
 define Package/i2pd/conffiles
-	/etc/config/i2pd
-	/etc/i2pd/i2pd.conf
-	/etc/i2pd/tunnels.conf
-	/etc/i2pd/tunnels.d/*
+/etc/config/i2pd
+/etc/i2pd/i2pd.conf
+/etc/i2pd/tunnels.conf
+/etc/i2pd/tunnels.d/
 endef
 
 TARGET_LDFLAGS+=-latomic

--- a/net/noddos/Makefile
+++ b/net/noddos/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 # Name and release number of this package
 PKG_NAME:=noddos
 PKG_VERSION:=0.5.5
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/noddos/noddos/releases/download/v$(PKG_VERSION)/
@@ -39,7 +39,7 @@ Noddos discovers what devices you have in your network and tailors the firewall 
 endef
 
 define Package/noddos/conffiles
-	/etc/config/noddos
+/etc/config/noddos
 endef
 
 define Package/noddos/install

--- a/net/openssh/Makefile
+++ b/net/openssh/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssh
 PKG_VERSION:=8.3p1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/ \
@@ -94,8 +94,10 @@ endef
 
 define Package/openssh-server/conffiles
 /etc/ssh/sshd_config
-/etc/ssh/ssh_host_*_key
-/etc/ssh/ssh_host_*_key.pub
+/etc/ssh/ssh_host_ed25519_key
+/etc/ssh/ssh_host_ed25519_key.pub
+/etc/ssh/ssh_host_rsa_key
+/etc/ssh/ssh_host_rsa_key.pub
 endef
 
 define Package/openssh-server-pam

--- a/net/restic-rest-server/Makefile
+++ b/net/restic-rest-server/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=restic-rest-server
 PKG_VERSION:=0.9.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/rest-server-$(PKG_VERSION)
 PKG_SOURCE:=rest-server-$(PKG_VERSION).tar.gz
@@ -31,6 +31,10 @@ define Package/restic-rest-server
   DEPENDS:=$(GO_ARCH_DEPENDS)
   SECTION:=net
   CATEGORY:=Network
+endef
+
+define Package/restic-rest-server/conffiles
+/etc/config/restic-rest-server
 endef
 
 define Package/restic-rest-server/description

--- a/net/shorewall-core/Makefile
+++ b/net/shorewall-core/Makefile
@@ -14,7 +14,7 @@ PKG_BUGFIX_MAJOR_VERSION:=5
 PKG_BUGFIX_MINOR_VERSION:=.2
 PKG_VERSION:=$(PKG_MAJOR_MINOR_VERSION).$(PKG_BUGFIX_MAJOR_VERSION)$(PKG_BUGFIX_MINOR_VERSION)
 PKG_DIRECTORY:=$(PKG_MAJOR_MINOR_VERSION).$(PKG_BUGFIX_MAJOR_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://shorewall.org/pub/shorewall/$(PKG_MAJOR_MINOR_VERSION)/shorewall-$(PKG_DIRECTORY)/ \
 	http://slovakia.shorewall.net/pub/shorewall/$(PKG_MAJOR_MINOR_VERSION)/shorewall-$(PKG_DIRECTORY)/ \
@@ -44,7 +44,7 @@ define Package/shorewall-core/description
 endef
 
 define Package/shorewall-core/conffiles
-	/usr/share/shorewall/shorewallrc
+/usr/share/shorewall/shorewallrc
 endef
 
 CONFIGURE_ARGS += \

--- a/net/softethervpn/Makefile
+++ b/net/softethervpn/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=softethervpn
 PKG_VERSION:=4.29-9680
 PKG_VERREL:=rtm
 PKG_VERDATE:=2019.02.28
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=softether-src-v$(PKG_VERSION)-$(PKG_VERREL).tar.gz
 PKG_SOURCE_URL:=http://www.softether-download.com/files/softether/v$(PKG_VERSION)-$(PKG_VERREL)-$(PKG_VERDATE)-tree/Source_Code/
@@ -131,19 +131,19 @@ Package/softethervpn-bridge/description = $(Package/softethervpn/description)
 Package/softethervpn-client/description = $(Package/softethervpn/description)
 
 define Package/softethervpn-base/conffiles
-  /usr/libexec/softethervpn/lang.config
+/usr/libexec/softethervpn/lang.config
 endef
 
 define Package/softethervpn-server/conffiles
-  /usr/libexec/softethervpn/vpn_server.config
+/usr/libexec/softethervpn/vpn_server.config
 endef
 
 define Package/softethervpn-client/conffiles
-  /usr/libexec/softethervpn/vpn_client.config
+/usr/libexec/softethervpn/vpn_client.config
 endef
 
 define Package/softethervpn-bridge/conffiles
-  /usr/libexec/softethervpn/vpn_bridge.config
+/usr/libexec/softethervpn/vpn_bridge.config
 endef
 
 define Package/softethervpn-base/install

--- a/net/squid/Makefile
+++ b/net/squid/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squid
 PKG_VERSION:=4.6
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://www3.us.squid-cache.org/Versions/v4/ \
@@ -58,8 +58,8 @@ define Package/squid/config
 endef
 
 define Package/squid/conffiles
-  /etc/config/squid
-  /etc/squid/squid.conf
+/etc/config/squid
+/etc/squid/squid.conf
 endef
 
 define Package/squid-mod-cachemgr

--- a/utils/device-observatory/Makefile
+++ b/utils/device-observatory/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=device-observatory
 PKG_VERSION:=1.2.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_URL:=https://codeload.github.com/mwarning/device-observatory/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -20,6 +20,10 @@ define Package/device-observatory
 	MAINTAINER:=Moritz Warning <moritzwarning@web.de>
 	URL:=https://github.com/mwarning/device-observatory/
 	DEPENDS:=+iw +libpcap +libmicrohttpd
+endef
+
+define Package/device-observatory/conffiles
+/etc/config/device-observatory
 endef
 
 define Package/device-observatory/description

--- a/utils/prometheus-statsd-exporter/Makefile
+++ b/utils/prometheus-statsd-exporter/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=prometheus-statsd-exporter
 PKG_VERSION:=0.15.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=statsd_exporter-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/prometheus/statsd_exporter/tar.gz/v${PKG_VERSION}?
@@ -42,6 +42,7 @@ define Package/prometheus-statsd-exporter/install
 endef
 
 define Package/prometheus-statsd-exporter/conffiles
+/etc/config/prometheus-statsd-exporter
 /etc/prometheus-statsd-exporter.yml
 endef
 

--- a/utils/sane-backends/Makefile
+++ b/utils/sane-backends/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sane-backends
 PKG_VERSION:=1.0.30
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://gitlab.com/sane-project/backends/uploads/c3dd60c9e054b5dee1e7b01a7edc98b0
@@ -290,7 +290,7 @@ This package contains the SANE backend for $(2).
   endef
 
   define Package/sane-$(1)/conffiles
-	/etc/sane.d/$(1).conf
+/etc/sane.d/$(1).conf
   endef
 
   $$(eval $$(call BuildPackage,sane-$(1)))


### PR DESCRIPTION
Maintainer: 
Compile tested: only package openssh, i2pd and sane-backends tested. (ath79/nand, mips_24kc, latest snapshot)
Run tested: only package openssh, i2pd and sane-backends tested.(ath79/nand, mips_24kc, latest snapshot)

**Description:**

The original configuration of package openssh-server which depends the files in dir `/etc/ssh` of host machine is incorrect and varies on different machines. Maybe the source code of [openwrt/include/package-ipkg.mk](https://github.com/openwrt/openwrt/blob/4c8eb4ad9eea29707b377c987b6f3be927d8e741/include/package-ipkg.mk#L238-L249) needs a patch to support wildcard conffiles.
```bash
wget -qO- https://downloads.openwrt.org/snapshots/packages/mips_24kc/packages/openssh-server_8.3p1-1_mips_24kc.ipk | \
    tar -zxOf- ./data.tar.gz | tar -zxOf- ./lib/upgrade/keep.d/openssh-server
/etc/ssh/ssh_host_dsa_key
/etc/ssh/ssh_host_ecdsa_key
/etc/ssh/ssh_host_rsa_key
/etc/ssh/ssh_host_dsa_key.pub
/etc/ssh/ssh_host_ecdsa_key.pub
/etc/ssh/ssh_host_rsa_key.pub
```
There's neither conffiles nor keepd generated for other packages.

