### PR TITLE
yubico-pam: fix compilation with fixed ykpers

### DIFF
--- a/libs/yubico-pam/Makefile
+++ b/libs/yubico-pam/Makefile
@@ -2,17 +2,19 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yubico-pam
 PKG_VERSION:=2.26
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=pam_yubico-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://developers.yubico.com/yubico-pam/Releases
 PKG_HASH:=2de96495963fefd72b98243952ca5d5ec513e702c596e54bc667ef6b5e252966
+PKG_BUILD_DIR:=$(BUILD_DIR)/pam_yubico-$(PKG_VERSION)
+
 PKG_MAINTAINER:=Stuart B. Wilkins <stuwilkins@mac.com>
-PKG_BUILD_DEPENDS:=ykclient ykpers libyubikey libpam curl
 PKG_LICENSE_FILES:=COPYING
 PKG_LICENSE:=BSD-2-Clause
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/pam_yubico-$(PKG_VERSION)
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -25,27 +27,18 @@ define Package/yubico-pam
 endef
 
 define Package/yubico-pam/description
-	The Yubico PAM module provides an easy way to integrate the YubiKey 
+	The Yubico PAM module provides an easy way to integrate the YubiKey
 	into your existing user authentication infrastructure.
 endef
-	
-CONFIGURE_VARS += 	YKPERS_CFLAGS=-I$(STAGING_DIR)/usr/include \
-			YKPERS_LIBS=-L$(STAGING_DIR)/usr/lib \
-			LDFLAGS="-Wl,-rpath-link,$(STAGING_DIR)/usr/lib \
-				  -L$(STAGING_DIR)/usr/lib"
 
-CONFIGURE_ARGS += --without-ldap \
-        	  --enable-shared \
-        	  --disable-static \
-
-define Build/Compile
-    $(call Build/Compile/Default, \
-	LDFLAGS="-L$(STAGING_DIR)/usr/lib -lykpers-1")
-endef
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--disable-static \
+	--without-ldap
 
 define Package/yubico-pam/install
-	$(INSTALL_DIR) $(1)/lib/security
-	$(CP) $(PKG_BUILD_DIR)/.libs/pam_yubico.so* $(1)/lib/security
+	$(INSTALL_DIR) $(1)/usr/lib/security
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/security/pam_yubico.so $(1)/usr/lib/security
 endef
 
-$(eval $(call BuildPackage,yubico-pam,+ykclient,+ykpers,+libyubikey))
+$(eval $(call BuildPackage,yubico-pam))


### PR DESCRIPTION
Massively cleaned up the Makefile for simplicity.

Added PKG_INSTALL and PKG_BUILD_PARALLEL for consistency between packages.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @stuwilkins 
Compile tested: ath79