### PR TITLE
foolsm: change mail dependency

### DIFF
--- a/net/foolsm/Makefile
+++ b/net/foolsm/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=foolsm
 PKG_VERSION:=1.0.13
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://lsm.foobar.fi/download
@@ -26,7 +26,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/foolsm
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+ssmtp
+  DEPENDS:=+msmtp
   TITLE:=A link state monitor
   URL:=http://lsm.foobar.fi/
 endef

--- a/net/foolsm/files/foolsm_script
+++ b/net/foolsm/files/foolsm_script
@@ -22,7 +22,7 @@ CONS_WAIT=${11}
 CONS_MISS=${12}
 AVG_RTT=${13}
 
-cat <<EOM | ssmtp ${WARN_EMAIL}
+cat <<EOM | msmtp ${WARN_EMAIL}
 Subject: "LSM: ${NAME} ${STATE}, DEV ${DEVICE}"
 
 Hi,


### PR DESCRIPTION
Maintainer: -
Compile tested: -
Run tested: -

Description:
* changed mail dependency from orphaned 'ssmtp' to 'msmtp'

Signed-off-by: Dirk Brenken <dev@brenken.org>

