### PR TITLE
modemmanager: remove unnecessary autoreconf 

### DIFF
--- a/net/modemmanager/Makefile
+++ b/net/modemmanager/Makefile
@@ -20,7 +20,6 @@ PKG_MAINTAINER:=Nicholas Smith <nicholas.smith@telcoantennas.com.au>
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 
-PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=glib2/host libxslt/host
@@ -76,10 +75,6 @@ define Build/Prepare
 	( cd "$(PKG_BUILD_DIR)"; \
 		printf "all:\ninstall:\n" >po/Makefile.in.in; \
 	)
-	$(SED) 's|^\(GLIB_MKENUMS\)=.*|\1=$(STAGING_DIR_HOSTPKG)/bin/glib-mkenums|' \
-		$(PKG_BUILD_DIR)/configure.ac
-	$(SED) 's|^\(GDBUS_CODEGEN\)=.*|\1=$(STAGING_DIR_HOSTPKG)/bin/gdbus-codegen|' \
-		$(PKG_BUILD_DIR)/configure.ac
 endef
 
 define Build/InstallDev


### PR DESCRIPTION

Signed-off-by: Nicholas Smith <nicholas.smith@telcoantennas.com.au>

Maintainer: me 
Compile tested: ath79, Telco T1, master
Run tested: ath79, Telco T1, master, checked basic functions
Description:
Autoreconf is unnecessary and is actually causing build errors on some systems for MM 1.14 and above.  Also, the correct glib-mkenums and gdbus-codegen are already being found correctly by the regular build system, so the setting the directory in Build/Prepare are not required.

More information: https://lists.freedesktop.org/archives/modemmanager-devel/2020-July/008005.html