### PR TITLE
[openwrt-19.07] python3: Use default _PYTHON_HOST_PLATFORM

### DIFF
--- a/lang/python/python3-host.mk
+++ b/lang/python/python3-host.mk
@@ -50,8 +50,7 @@ define host_python3_settings
 	LDSHARED="$(HOSTCC) -shared" \
 	CFLAGS="$(HOST_CFLAGS)" \
 	CPPFLAGS="$(HOST_CPPFLAGS) -I$(HOST_PYTHON3_INC_DIR)" \
-	LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON3_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib" \
-	_PYTHON_HOST_PLATFORM=linux2
+	LDFLAGS="$(HOST_LDFLAGS) -lpython$(PYTHON3_VERSION) -Wl$(comma)-rpath=$(STAGING_DIR_HOSTPKG)/lib"
 endef
 
 # $(1) => commands to execute before running pythons script
@@ -79,6 +78,7 @@ define Build/Compile/HostPy3PipInstall
 		--disable-pip-version-check \
 		--cache-dir "$(DL_DIR)/pip-cache" \
 		install \
+		--no-binary :all: \
 		$(1)
 endef
 

--- a/lang/python/python3-package.mk
+++ b/lang/python/python3-package.mk
@@ -20,6 +20,8 @@ PYTHON3:=python$(PYTHON3_VERSION)
 
 PYTHON3PATH:=$(PYTHON3_LIB_DIR):$(STAGING_DIR)/$(PYTHON3_PKG_DIR):$(PKG_INSTALL_DIR)/$(PYTHON3_PKG_DIR)
 
+-include $(PYTHON3_LIB_DIR)/config-$(PYTHON3_VERSION)/Makefile-vars
+
 # These configure args are needed in detection of path to Python header files
 # using autotools.
 CONFIGURE_ARGS += \
@@ -100,7 +102,7 @@ define Build/Compile/HostPy3RunTarget
 		CFLAGS="$(TARGET_CFLAGS)" \
 		CPPFLAGS="$(TARGET_CPPFLAGS) -I$(PYTHON3_INC_DIR)" \
 		LDFLAGS="$(TARGET_LDFLAGS) -lpython$(PYTHON3_VERSION)" \
-		_PYTHON_HOST_PLATFORM=linux2 \
+		_PYTHON_HOST_PLATFORM="$(_PYTHON_HOST_PLATFORM)" \
 		__PYVENV_LAUNCHER__="/usr/bin/$(PYTHON3)" \
 		$(3) \
 		, \

--- a/lang/python/python3/Makefile
+++ b/lang/python/python3/Makefile
@@ -14,7 +14,7 @@ PYTHON_VERSION:=$(PYTHON3_VERSION)
 PYTHON_VERSION_MICRO:=$(PYTHON3_VERSION_MICRO)
 
 PKG_NAME:=python3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=$(PYTHON_VERSION).$(PYTHON_VERSION_MICRO)
 
 PKG_SOURCE:=Python-$(PKG_VERSION).tar.xz
@@ -131,7 +131,6 @@ TARGET_CONFIGURE_OPTS+= \
 	READELF="$(TARGET_CROSS)readelf"
 
 MAKE_FLAGS+=\
-	CROSS_COMPILE=yes \
 	LD="$(TARGET_CC)" \
 	PGEN=pgen3
 
@@ -144,13 +143,6 @@ ENABLE_IPV6:=
 ifeq ($(CONFIG_IPV6),y)
 	ENABLE_IPV6 += --enable-ipv6
 endif
-
-PYTHON_FOR_BUILD:= \
-	_PYTHON_PROJECT_BASE=$(PKG_BUILD_DIR) \
-	_PYTHON_HOST_PLATFORM=linux2 \
-	PYTHONPATH="$(PKG_BUILD_DIR)/Lib:$(PKG_BUILD_DIR)/build/lib.linux2-$(PYTHON_VERSION)" \
-	_PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata \
-	$(HOST_PYTHON3_BIN)
 
 DISABLE_BLUETOOTH:= \
 	ac_cv_header_bluetooth_bluetooth_h=no \
@@ -165,7 +157,6 @@ CONFIGURE_ARGS+= \
 	--with-ensurepip=no \
 	--without-pymalloc \
 	$(if $(CONFIG_PYTHON3_BLUETOOTH_SUPPORT),,$(DISABLE_BLUETOOTH)) \
-	PYTHON_FOR_BUILD="$(PYTHON_FOR_BUILD)" \
 	$(ENABLE_IPV6) \
 	CONFIG_SITE="$(PKG_BUILD_DIR)/config.site" \
 	OPT="$(TARGET_CFLAGS)"
@@ -228,6 +219,10 @@ define Build/InstallDev
 		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION) \
 		$(PKG_INSTALL_DIR)/usr/lib/libpython$(PYTHON_VERSION).so* \
 		$(1)/usr/lib/
+	grep \
+		'^_PYTHON_HOST_PLATFORM=' \
+		$(PKG_INSTALL_DIR)/usr/lib/python$(PYTHON_VERSION)/config-$(PYTHON_VERSION)/Makefile > \
+		$(1)/usr/lib/python$(PYTHON_VERSION)/config-$(PYTHON_VERSION)/Makefile-vars
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/python*.pc \
 		$(1)/usr/lib/pkgconfig

--- a/lang/python/python3/patches/016-adjust-config-paths.patch
+++ b/lang/python/python3/patches/016-adjust-config-paths.patch
@@ -40,6 +40,15 @@
  # Here are a couple of targets for MacOSX again, to install a full
 --- a/configure
 +++ b/configure
+@@ -2936,7 +2936,7 @@ $as_echo_n "checking for python interpre
+ 	fi
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $interp" >&5
+ $as_echo "$interp" >&6; }
+-	PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`:)$(srcdir)/Lib _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata_$(ABIFLAGS)_$(MACHDEP)_$(MULTIARCH) '$interp
++	PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`:)$(srcdir)/Lib _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata '$interp
+     fi
+ elif test "$cross_compiling" = maybe; then
+     as_fn_error $? "Cross compiling required --host=HOST-TUPLE and --build=ARCH" "$LINENO" 5
 @@ -15291,7 +15291,7 @@ LDVERSION='$(VERSION)$(ABIFLAGS)'
  $as_echo "$LDVERSION" >&6; }
  
@@ -51,6 +60,15 @@
    LIBPL='$(prefix)'"/lib/python${VERSION}/config-${LDVERSION}-${PLATFORM_TRIPLET}"
 --- a/configure.ac
 +++ b/configure.ac
+@@ -75,7 +75,7 @@ if test "$cross_compiling" = yes; then
+ 	    AC_MSG_ERROR([python$PACKAGE_VERSION interpreter not found])
+ 	fi
+         AC_MSG_RESULT($interp)
+-	PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`:)$(srcdir)/Lib _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata_$(ABIFLAGS)_$(MACHDEP)_$(MULTIARCH) '$interp
++	PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`:)$(srcdir)/Lib _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata '$interp
+     fi
+ elif test "$cross_compiling" = maybe; then
+     AC_MSG_ERROR([Cross compiling required --host=HOST-TUPLE and --build=ARCH])
 @@ -4771,7 +4771,7 @@ AC_MSG_RESULT($LDVERSION)
  
  dnl define LIBPL after ABIFLAGS and LDVERSION is defined.


### PR DESCRIPTION
Maintainer: me, @commodo 
Compile tested: armvirt-64, 19.07.3 sdk
Run tested: armvirt-64 (qemu), 19.07.3

Description:
This lets the Python build process set `_PYTHON_HOST_PLATFORM` instead of forcing an explicit value.

Also:

* Save the target `_PYTHON_HOST_PLATFORM` value during `Build/InstallDev` for use when building target Python packages (in python3-package.mk).

* Use the (mostly) default `PYTHON_FOR_BUILD` value, instead patch configure to remove the platform triplet from the sysconfigdata file name.

* Remove the `CROSS_COMPILE=yes` make variable (there is no indication that this variable is necessary).

* Force host pip to build packages from source instead of downloading binary wheels.

  Previously, host pip can download universal (platform-independent) wheels but not platform-specific wheels, because of the custom `_PYTHON_HOST_PLATFORM` value. (Packages that do not have universal wheels would be compiled from source.)

  With a correct `_PYTHON_HOST_PLATFORM`, host pip can install platform-specific wheels as well. However, the pre-built shared object (.so) files in these wheels will have the host's platform triplet in their file names. When target Python packages are built (using the target's `_PYTHON_HOST_PLATFORM`), Python will not use these shared object files.

  By forcing host pip to build packages from source, the built shared object files will not have the platform triplet in their file names. (Host Python has been patched to remove the platform triplet from file names.) This allows these packages to be used when building target Python packages.

  (The net effect of this complete change is that platform-dependent packages will continue to be compiled from source, while platform-independent packages will now also be compiled from source.)

Fixes https://github.com/openwrt/packages/issues/12680.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>