### PR TITLE
[openwrt-19.07] python3-maxminddb: Fix build when using newer setuptools

### DIFF
--- a/lang/python/python3-maxminddb/Makefile
+++ b/lang/python/python3-maxminddb/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=maxminddb
 PKG_VERSION:=1.4.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/m/maxminddb/

--- a/lang/python/python3-maxminddb/patches/001-Stop-using-deprecated-Feature-from-setuptools.patch
+++ b/lang/python/python3-maxminddb/patches/001-Stop-using-deprecated-Feature-from-setuptools.patch
@@ -1,0 +1,33 @@
+Adapted from 3aac426[1] to account for a difference in formatting.
+
+[1]: https://github.com/maxmind/MaxMind-DB-Reader-python/commit/3aac426e354f91814f6fd0829baee137b0bb093f
+
+--- a/setup.py
++++ b/setup.py
+@@ -9,7 +9,7 @@ from distutils.command.build_ext import
+ from distutils.errors import (CCompilerError, DistutilsExecError,
+                               DistutilsPlatformError)
+ 
+-from setuptools import setup, Extension, Feature
++from setuptools import setup, Extension
+ 
+ cmdclass = {}
+ PYPY = hasattr(sys, 'pypy_version_info')
+@@ -107,16 +107,7 @@ def find_packages(location):
+ def run_setup(with_cext):
+     kwargs = {}
+     if with_cext:
+-        if Feature:
+-            kwargs['features'] = {
+-                'extension':
+-                Feature(
+-                    "optional C implementation",
+-                    standard=True,
+-                    ext_modules=ext_module)
+-            }
+-        else:
+-            kwargs['ext_modules'] = ext_module
++        kwargs['ext_modules'] = ext_module
+ 
+     setup(
+         name='maxminddb',


### PR DESCRIPTION
Maintainer: @ja-pa 
Compile tested: armvirt-64, 19.07.3 sdk (combined with #12755)
Run tested: none

Description:
This package fails to build with newer setuptools, because setuptools removed the (deprecated) Features feature in [v46.0.0][1].

This adapts a [commit][2] to remove the use of this feature. (Changes to code formatting prevent the original commit/patch to be used.)

[1]: https://github.com/pypa/setuptools/blob/aff64ae89e00e25fb3868bf528a14c18e7af0cf4/CHANGES.rst#v4600
[2]: https://github.com/maxmind/MaxMind-DB-Reader-python/commit/3aac426e354f91814f6fd0829baee137b0bb093f

Signed-off-by: Jeffery To <jeffery.to@gmail.com>