### PR TITLE
Uppercase NB_PARM and WG_PARM

### DIFF
--- a/net/wsdd2/files/wsdd2.init
+++ b/net/wsdd2/files/wsdd2.init
@@ -5,7 +5,7 @@ USE_PROCD=1
 
 SMB_CONF=""
 BIND_IF_PARM=""
-NB_PARM="$(cat /proc/sys/kernel/hostname)"
+NB_PARM="$(cat /proc/sys/kernel/hostname | awk '{print toupper($0)}')"
 WG_PARM="WORKGROUP"
 BI_PARM=""
 
@@ -31,11 +31,11 @@ start_service() {
 	}
 
 	local nb_name
-	nb_name="$(grep -i 'netbios name' $SMB_CONF | awk -F'=' '{print $2}' | tr -d ' \n')"
+	nb_name="$(echo $(grep -i 'netbios name' $SMB_CONF | awk -F'=' '{print $2}' | tr -d ' \n') | awk '{print toupper($0)}')"
 	[ -n "$nb_name" ] && NB_PARM="$nb_name"
 
 	local wg_name
-	wg_name="$(grep -i 'workgroup' $SMB_CONF | awk -F'=' '{print $2}' | tr -d ' \n')"
+	wg_name="$(echo $(grep -i 'workgroup' $SMB_CONF | awk -F'=' '{print $2}' | tr -d ' \n') | awk '{print toupper($0)}')"
 	[ -n "$wg_name" ] && WG_PARM="$wg_name"
 
 	# resolve lan interface (BUG: No multi-interface binds atm)


### PR DESCRIPTION
Added a forced conversion to uppercase for the NetBIOS Host and Workgroup names

Maintainer: @Andy2244 et. al.
Run tested: (mips_24kc | Qualcomm Atheros QCA956X ver 1 rev 0, TP-Link Archer C7 v5, OpenWrt 19.07.03, field-test on home br-lan iface)

_Description:_
I forced NETBIOS stuff to uppercase. This looks (works?) better in Windows.

_Improvement:_
Maybe it'd be better to also check the value of "mdns name" in smb.conf and skip forcing uppercase iff "mdns name = mdns" has been asserted (the Samba default as of this writing is "mdns name = netbios" i.e. ). See [smb.conf(5)](https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html#MDNS)

A simple fix, I think, but let me know what you think!

BTW thank you all for this package! I wish I knew about it hours/days ago! This is just my way of showing thanks to the real maintainers here.