### PR TITLE
ntpd: update to version 4.2.8p15 (security fix)

### DIFF
--- a/net/ntpd/Makefile
+++ b/net/ntpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ntp
-PKG_VERSION:=4.2.8p13
-PKG_RELEASE:=4
+PKG_VERSION:=4.2.8p15
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/
-PKG_HASH:=288772cecfcd9a53694ffab108d1825a31ba77f3a8466b0401baeca3bc232a38
+PKG_HASH:=f65840deab68614d5d7ceb2d0bb9304ff70dcdedd09abb79754a87536b849c19
 
 PKG_LICENSE:=Unique
 PKG_LICENSE_FILES:=COPYRIGHT html/copyright.html


### PR DESCRIPTION
Maintainer: @tripolar 
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TOS5), OpenWrt master

Description:
This PR updates ntpd to version 4.2.8p15. It fixes multiple security issues. https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ChangeLog-stable

Fixes:
CVE-2020-11868
CVE-2018-8956
CVE-2020-13817
CVE-2020-1502


Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>

