### PR TITLE
apache/mariadb/sqlite: remove myself as maintainer

### DIFF
--- a/libs/apr-util/Makefile
+++ b/libs/apr-util/Makefile
@@ -14,8 +14,7 @@ PKG_RELEASE:=6
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@APACHE/apr/
 PKG_HASH:=d3e12f7b6ad12687572a3a39475545a072608f4ba03a6ce8a3778f607dd0035b
-PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
-		Sebastian Kemper <sebastian_ml@gmx.net>
+PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE

--- a/libs/apr/Makefile
+++ b/libs/apr/Makefile
@@ -15,8 +15,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@APACHE/apr/
 PKG_HASH:=e2e148f0b2e99b8e5c6caa09f6d4fb4dd3e83f744aa72a952f94f5a14436f7ea
 
-PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
-		Sebastian Kemper <sebastian_ml@gmx.net>
+PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE

--- a/libs/libmariadb/Makefile
+++ b/libs/libmariadb/Makefile
@@ -19,7 +19,7 @@ PKG_SOURCE_URL := \
 	https://downloads.mariadb.org/interstitial/connector-c-$(PKG_VERSION)
 
 PKG_HASH:=431434d3926f4bcce2e5c97240609983f60d7ff50df5a72083934759bb863f7b
-PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
+PKG_MAINTAINER:=
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING.LIB
 

--- a/libs/sqlite3/Makefile
+++ b/libs/sqlite3/Makefile
@@ -18,6 +18,8 @@ PKG_SOURCE_URL:=https://www.sqlite.org/2020/
 PKG_LICENSE:=PUBLICDOMAIN
 PKG_LICENSE_FILES:=
 
+PKG_MAINTAINER:=
+
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-autoconf-$(PKG_VERSION)
 
 PKG_BUILD_PARALLEL:=1
@@ -45,7 +47,6 @@ define Package/sqlite3/Default
   SUBMENU:=Database
   TITLE:=SQLite (v3.x) database engine
   URL:=http://www.sqlite.org/
-  MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 endef
 
 define Package/sqlite3/Default/description

--- a/net/apache/Makefile
+++ b/net/apache/Makefile
@@ -18,8 +18,7 @@ PKG_HASH:=a497652ab3fc81318cdc2a203090a999150d86461acff97c1065dc910fe10f43
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_NAME)-$(PKG_VERSION)
 
-PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>, \
-		Sebastian Kemper <sebastian_ml@gmx.net>
+PKG_MAINTAINER:=Thomas Heil <heil@terminal-consulting.de>
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 

--- a/utils/mariadb-common/Makefile
+++ b/utils/mariadb-common/Makefile
@@ -11,7 +11,7 @@ PKG_NAME:=mariadb-common
 PKG_VERSION:=1.0
 PKG_RELEASE:=2
 
-PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
+PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0
 
 CONF_DIR:=/etc/mysql

--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -19,7 +19,7 @@ PKG_SOURCE_URL := \
 	https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
 
 PKG_HASH:=45bbbb12d1de8febd9edf630e940c23cf14efd60570c743b268069516a5d91df
-PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
+PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING THIRDPARTY
 


### PR DESCRIPTION
Maintainer: me
Compile tested: N/A
Run tested: N/A

Description:
Hi all,

I have less time these days for package maintenance. The time I do have I'd like to focus on my favorite repo; telephony :)

So here I drop maintainer-ship of

apr
apr-util
apache
libmariadb
mariab
mariadb-common
sqlite3

I do would like to keep maintaining json-glib, so it is not part of this list. Nothing depends on it except one package in telephony as of now, if I'm not mistaken. So I'll keep taking care of it.

Thanks!
Seb