### PR TITLE
expat: fix compilation with doc2man

### DIFF
--- a/libs/expat/Makefile
+++ b/libs/expat/Makefile
@@ -36,7 +36,7 @@ define Package/libexpat/description
  A fast, non-validating, stream-oriented XML parsing library.
 endef
 
-CMAKE_OPTIONS += \
+OPTIONS += \
 	-DDOCBOOK_TO_MAN=OFF \
 	-DEXPAT_BUILD_TOOLS=OFF \
 	-DEXPAT_BUILD_EXAMPLES=OFF \
@@ -47,6 +47,9 @@ CMAKE_OPTIONS += \
 	-DEXPAT_DTD=OFF \
 	-DEXPAT_NS=OFF \
 	-DEXPAT_DEV_URANDOM=OFF
+
+CMAKE_OPTIONS += $(OPTIONS)
+CMAKE_HOST_OPTIONS += $(OPTIONS)
 
 define Package/libexpat/install
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
Even though doc2man is explicitly disabled, it is only for the target.
Split out the options to a separate variable.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @thess 
Compile tested: Fedora 32
