### PR TITLE
miniupnpd: default to IGDv1

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.1.20200510
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://miniupnp.tuxfamily.org/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/net/miniupnpd/files/upnpd.config
+++ b/net/miniupnpd/files/upnpd.config
@@ -11,7 +11,7 @@ config upnpd config
 	option internal_iface	lan
 	option port		5000
 	option upnp_lease_file	/var/run/miniupnpd.leases
-	option igdv1		0
+	option igdv1		1
 
 config perm_rule
 	option action		allow


### PR DESCRIPTION
It seems even modern stuff doesn't support v2 correctly. The miniupnp
suite does but other stacks seem to lack support. Default to v1 to
avoid the headache.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: nobody
Compile tested: N/A

Fixes: https://github.com/openwrt/packages/issues/12641

ping @diizzyy 