### PR TITLE
[19.07] stubby: remove libbsd dependency and fix compilation with deprecated OpenSSL APIs

### DIFF
--- a/libs/getdns/Makefile
+++ b/libs/getdns/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=getdns
 PKG_VERSION:=1.6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
@@ -64,7 +64,7 @@ CMAKE_OPTIONS += -DUSE_LIBIDN2=$(if $(CONFIG_GETDNS_ENABLE_IDN_LIBIDN2),ON,OFF)
 # present, otherwise it will use builtin code for these functions. In order to
 # force the use of the built in code and remove the libbsd dependency disable
 # the test for libbsd.
-CMAKE_OPTIONS += -DCMAKE_DISABLE_FIND_PACKAGE_BSD=ON
+CMAKE_OPTIONS += -DBSD_LIBRARY=OFF
 
 define Package/getdns/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/getdns/patches/010-openssl-deprecated.patch
+++ b/libs/getdns/patches/010-openssl-deprecated.patch
@@ -1,0 +1,13 @@
+--- a/src/tls/val_secalgo.c
++++ b/src/tls/val_secalgo.c
+@@ -72,6 +72,10 @@
+ #include <openssl/engine.h>
+ #endif
+ 
++#ifdef USE_DSA
++#include <openssl/dsa.h>
++#endif
++
+ /** fake DSA support for unit tests */
+ int fake_dsa = 0;
+ /** fake SHA1 support for unit tests */


### PR DESCRIPTION
Maintainer: me
Compile tested: x86
Run tested: x86

Description: remove libbsd dependency and fix compilation with deprecated OpenSSL APIs

This merges recent changes committed to master by @neheb to fix build breakages.