### PR TITLE
mariadb/libmariadb: Take over as a maintainer

### DIFF
--- a/libs/libmariadb/Makefile
+++ b/libs/libmariadb/Makefile
@@ -19,7 +19,7 @@ PKG_SOURCE_URL := \
 	https://downloads.mariadb.org/interstitial/connector-c-$(PKG_VERSION)
 
 PKG_HASH:=431434d3926f4bcce2e5c97240609983f60d7ff50df5a72083934759bb863f7b
-PKG_MAINTAINER:=
+PKG_MAINTAINER:=Michal Hrusecky <Michal@Hrusecky.net>
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING.LIB
 

--- a/utils/mariadb/Makefile
+++ b/utils/mariadb/Makefile
@@ -19,7 +19,7 @@ PKG_SOURCE_URL := \
 	https://downloads.mariadb.org/interstitial/$(PKG_NAME)-$(PKG_VERSION)/source
 
 PKG_HASH:=45bbbb12d1de8febd9edf630e940c23cf14efd60570c743b268069516a5d91df
-PKG_MAINTAINER:=
+PKG_MAINTAINER:=Michal Hrusecky <Michal@Hrusecky.net>
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING THIRDPARTY
 


### PR DESCRIPTION
Maintainer: me
Compile tested: NA
Run tested: NA

Description:
We use it in Turris OS anyway as dependency of Nextcloud, so I can as well maintain it.