### PR TITLE
xinetd: start service in foreground for procd

### DIFF
--- a/net/xinetd/Makefile
+++ b/net/xinetd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xinetd
 PKG_VERSION:=2.3.15
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/xinetd-org/xinetd/archive

--- a/net/xinetd/Makefile
+++ b/net/xinetd/Makefile
@@ -14,6 +14,8 @@ PKG_RELEASE:=6
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/xinetd-org/xinetd/archive
 PKG_HASH:=bf4e060411c75605e4dcbdf2ac57c6bd9e1904470a2f91e01ba31b50a80a5be3
+
+PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 PKG_LICENSE:=xinetd
 PKG_LICENSE_FILES:=COPYRIGHT
 PKG_CPE_ID:=cpe:/a:xinetd:xinetd
@@ -27,7 +29,6 @@ define Package/xinetd
   CATEGORY:=Network
   TITLE:=A powerful and secure super-server
   URL:=https://github.com/xinetd-org
-  PKG_MAINTAINER:=Jonathan McCrohan <jmccrohan@gmail.com>
 endef
 
 define Package/xinetd/description

--- a/net/xinetd/files/xinetd.init
+++ b/net/xinetd/files/xinetd.init
@@ -109,7 +109,7 @@ start_service() {
 	generate_config
 
 	procd_open_instance
-	procd_set_param command $PROG -f $GENERATED_CONF_FILE -pidfile $PIDFILE
+	procd_set_param command $PROG -dontfork -f $GENERATED_CONF_FILE -pidfile $PIDFILE
 	procd_set_param respawn
 	procd_close_instance
 }


### PR DESCRIPTION
Maintainer: @neheb the origin maintainer @jmccrohan is not active anymore so please have a look. If it is OK from your side I would also register as maintainer, because I use this package in my own setup.

Compile tested: only script change
Run tested: x86_64, APU3, OpenWRT master, latest master

Description:
Since we use now procd for xinetd, we have to start the service with the
option `-dontfork` to make procd happy.

